### PR TITLE
feat(symbolic-learning): SL-10-ActiveAutomataLearning-Csharp -- twin C# de L* d'Angluin (Prong B from-scratch)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -185,6 +185,7 @@ Note : dans SL-7, le premier exercice de la numérotation interne est un exemple
 | 8 | [SL-8 - ILP Moderne et Knowledge Graphs](SL-8-KnowledgeGraphs-ILP.ipynb) | rdflib, AMIE rule mining, complétion KG, ASP avec clingo | 55 min |
 | 9 | [SL-9 - LLMs et Apprentissage Symbolique](SL-9-LLM-SymbolicLearning.ipynb) | Prompting, extraction de règles, vérification symbolique (Gemini 3.5 Flash optionnel) | 50 min |
 | 10 | [SL-10 - Apprentissage Actif d'Automates](SL-10-ActiveAutomataLearning.ipynb) | L* d'Angluin, table d'observation, requêtes MQ/EQ, Myhill-Nerode | 60 min |
+| 10 (C#) | [SL-10 - L* Angluin (Twin C#)](SL-10-ActiveAutomataLearning-Csharp.ipynb) | **Jumeau C#** — DFA, ObservationTable (S/E/T), requêtes MQ/EQ, conjecture DFA, contre-exemple (Angluin/Maler-Pnueli), oracle bruité + L* borné, forward sum-product + agrégation d'evidence from-scratch (See #4956) | 60 min |
 | 11 | [SL-11 - Capstone Neuro-Symbolique](SL-11-Capstone-NeuroSymbolic.ipynb) | Pipeline 6 étages : extraction LLM, oracle, KG, mining, inférence avec provenance, QA | 90 min |
 | 12 | [SL-12 - Réseaux de Portes Logiques Différentiables](SL-12-DifferentiableLogicGateNetworks.ipynb) | difflogic (Petersen NeurIPS 2022) : portes logiques apprises par descente de gradient, discrétisation en circuit booléen, inférence ultra-rapide | 45 min |
 
@@ -303,6 +304,8 @@ Note : dans SL-7, le premier exercice de la numérotation interne est un exemple
 | Contre-exemples | Traitement, raffinement, convergence vers le DFA minimal |
 | Oracle échantillonné | Équivalence approchée par tirage, lien PAC |
 | Théorie | Myhill-Nerode, minimalité, bornes sur le nombre de requêtes |
+
+> **Parité .NET** : [SL-10-ActiveAutomataLearning-Csharp.ipynb](SL-10-ActiveAutomataLearning-Csharp.ipynb) est le jumeau C# (.NET Interactive) — L\* d'Angluin implémenté from-scratch (DFA, ObservationTable S/E/T, requêtes d'appartenance et d'équivalence, conjecture, contre-exemples Angluin/Maler-Pnueli, oracle d'équivalence échantillonné PAC, oracle bruité + L\* borné, algorithme forward sum-product et agrégation d'evidence), BCL .NET 9 seule (0 NuGet). Marathon parité .NET ⇄ Python (#4956).
 
 ### SL-11-Capstone-NeuroSymbolic.ipynb
 
@@ -445,6 +448,7 @@ SymbolicLearning/
 ├── SL-8-KnowledgeGraphs-ILP.ipynb           # rdflib, AMIE rule mining
 ├── SL-9-LLM-SymbolicLearning.ipynb          # LLMs + vérification symbolique (Gemini 3.5 Flash optionnel)
 ├── SL-10-ActiveAutomataLearning.ipynb        # L* d'Angluin, apprentissage actif d'automates
+├── SL-10-ActiveAutomataLearning-Csharp.ipynb # Jumeau C# (.NET Interactive) — L* d'Angluin (DFA/ObservationTable/MQ-EQ/forward) from-scratch, parité #4956
 ├── SL-11-Capstone-NeuroSymbolic.ipynb       # Capstone : pipeline neuro-symbolique 6 étages
 ├── .env.example                             # Modèle de configuration LLM (OpenRouter)
 ├── requirements.txt                         # Dépendances optionnelles

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
@@ -1,0 +1,7739 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1074edf7",
+   "metadata": {},
+   "source": [
+    "# SL-10 --- Apprentissage Actif d'Automates (L* d'Angluin) --- twin C# .NET\n",
+    "\n",
+    "**Navigation** : [Index](./README.md) | [twin Python](SL-10-ActiveAutomataLearning.ipynb) | [<< SL-9](SL-9-LLM-SymbolicLearning.ipynb) | [SL-11 >>](SL-11-Capstone-NeuroSymbolic.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. Distinguer apprentissage **passif** (exemples imposes, SL-1) et **actif** (l'apprenant pose des questions)\n",
+    "2. Formaliser le modele **MAT** (Minimally Adequate Teacher) : requetes d'appartenance et d'equivalence\n",
+    "3. Implementer la **table d'observation** d'Angluin (fermeture, consistance)\n",
+    "4. Derouler l'algorithme **L*** complet et apprendre un DFA inconnu\n",
+    "5. Relier la garantie de **minimalite** au theoreme de Myhill-Nerode\n",
+    "6. Mesurer ce qui se passe quand l'oracle d'equivalence devient **approximatif** (echantillonnage, PAC)\n",
+    "\n",
+    "### Prerequis\n",
+    "- SL-1 (espaces d'hypotheses, apprentissage passif)\n",
+    "- Notions d'automates finis deterministes (rappel complet en section 1)\n",
+    "- Twin C# .NET 9 (BCL seule, 0 NuGet) -- Prong B from-scratch (cf #4956, #3801)\n",
+    "\n",
+    "### Duree estimee : 60 minutes\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0219832f",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Du passif a l'actif : le modele MAT\n",
+    "\n",
+    "Tous les algorithmes de la serie jusqu'ici sont **passifs** : l'apprenant recoit un\n",
+    "jeu d'exemples qu'il n'a pas choisi (les 12 restaurants de SL-1, les triples du KG\n",
+    "de SL-8) et doit s'en contenter. Or certains concepts sont *exponentiellement* plus\n",
+    "faciles a apprendre si l'apprenant peut **poser des questions**.\n",
+    "\n",
+    "Dana Angluin (1987) formalise cela avec le **MAT** (*Minimally Adequate Teacher*),\n",
+    "un professeur qui repond a exactement deux types de requetes :\n",
+    "\n",
+    "| Requete | Question | Reponse |\n",
+    "|---------|----------|---------|\n",
+    "| **Appartenance** (MQ) | « le mot $w$ est-il dans le langage cible $L$ ? » | Oui / Non |\n",
+    "| **Equivalence** (EQ) | « mon hypothese $H$ est-elle exactement $L$ ? » | Oui, ou un **contre-exemple** $w \\in H \\triangle L$ |\n",
+    "\n",
+    "La cible est ici un **langage regulier** : un ensemble de mots reconnu par un\n",
+    "**automate fini deterministe** (DFA). C'est un objet pleinement symbolique --- etats,\n",
+    "transitions, etats acceptants --- et le theoreme central d'Angluin est remarquable :\n",
+    "\n",
+    "> **Theoreme (Angluin 1987).** L* apprend le DFA minimal de tout langage regulier\n",
+    "> avec un nombre de requetes **polynomial** en le nombre d'etats $n$ du DFA minimal\n",
+    "> et la longueur $m$ du plus long contre-exemple.\n",
+    "\n",
+    "A titre de comparaison, apprendre un DFA *passivement* (trouver le plus petit DFA\n",
+    "consistant avec un echantillon donne) est **NP-difficile** (Gold 1978). Le droit de\n",
+    "poser des questions change la classe de complexite du probleme.\n",
+    "\n",
+    "Commencons par la cible : un DFA jouet que L* devra decouvrir *sans jamais regarder\n",
+    "sa structure*, uniquement en l'interrogeant.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c10e0b0d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:54.289423Z",
+     "iopub.status.busy": "2026-07-07T07:52:54.283645Z",
+     "iopub.status.idle": "2026-07-07T07:52:56.083658Z",
+     "shell.execute_reply": "2026-07-07T07:52:56.079424Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '58580.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cible : Dfa(4 etats, 1 acceptants)  (structure invisible pour l'apprenant)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     mot | nb_a | nb_b | dans L ?\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     eps |    0 |    0 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       a |    1 |    0 | non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       b |    0 |    1 | non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      ab |    1 |    1 | non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    aabb |    2 |    2 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    abab |    2 |    2 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     aab |    2 |    1 | non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    bbaa |    2 |    2 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    abba |    2 |    2 | OUI\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Un DFA = (etats, alphabet, transitions, etat initial, etats acceptants)\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "using System.Text;\n",
+    "\n",
+    "public class Dfa\n",
+    "{\n",
+    "    public HashSet<string> States { get; set; }\n",
+    "    public List<char> Alphabet { get; set; }\n",
+    "    public Dictionary<(string, char), string> Delta { get; set; }\n",
+    "    public string Start { get; set; }\n",
+    "    public HashSet<string> Accepting { get; set; }\n",
+    "    public Dfa(IEnumerable<string> states, IEnumerable<char> alphabet,\n",
+    "               IEnumerable<((string, char), string)> delta, string start, IEnumerable<string> accepting)\n",
+    "    {\n",
+    "        States = states.ToHashSet();\n",
+    "        Alphabet = alphabet.ToList();\n",
+    "        Delta = new Dictionary<(string, char), string>();\n",
+    "        foreach (var (k, v) in delta) Delta[k] = v;\n",
+    "        Start = start;\n",
+    "        Accepting = accepting.ToHashSet();\n",
+    "    }\n",
+    "    public bool Accepts(string word)\n",
+    "    {\n",
+    "        var q = Start;\n",
+    "        foreach (var ch in word) q = Delta[(q, ch)];\n",
+    "        return Accepting.Contains(q);\n",
+    "    }\n",
+    "    public int StateCount => States.Count;\n",
+    "    public override string ToString() => $\"Dfa({States.Count} etats, {Accepting.Count} acceptants)\";\n",
+    "}\n",
+    "\n",
+    "// Langage cible (cache pour L*) : mots sur {a, b} avec un nombre PAIR de 'a'\n",
+    "// ET un nombre PAIR de 'b'. Etat = (parite des a, parite des b) -> 4 etats.\n",
+    "List<char> ALPHABET = new List<char> { 'a', 'b' };\n",
+    "string[] _states = { \"ee\", \"eo\", \"oe\", \"oo\" };  // (pair/impair a, pair/impair b)\n",
+    "var _delta = new List<((string, char), string)>();\n",
+    "foreach (var s in _states)\n",
+    "{\n",
+    "    char pa = s[0], pb = s[1];\n",
+    "    _delta.Add(((s, 'a'), (pa == 'e' ? \"o\" : \"e\") + pb.ToString()));\n",
+    "    _delta.Add(((s, 'b'), pa.ToString() + (pb == 'e' ? \"o\" : \"e\")));\n",
+    "}\n",
+    "Dfa TARGET = new Dfa(_states, ALPHABET, _delta, \"ee\", new[] { \"ee\" });\n",
+    "\n",
+    "// L'apprenant n'aura acces qu'a cette fonction (la requete d'appartenance) :\n",
+    "bool MembershipQuery(string word) => TARGET.Accepts(word);\n",
+    "\n",
+    "// Verification rapide sur quelques mots\n",
+    "Console.WriteLine($\"Cible : {TARGET}  (structure invisible pour l'apprenant)\");\n",
+    "Console.WriteLine($\"{\"mot\",8} | nb_a | nb_b | dans L ?\");\n",
+    "Console.WriteLine(new string('-', 36));\n",
+    "foreach (var w in new[] { \"\", \"a\", \"b\", \"ab\", \"aabb\", \"abab\", \"aab\", \"bbaa\", \"abba\" })\n",
+    "{\n",
+    "    int na = w.Count(c => c == 'a'), nb = w.Count(c => c == 'b');\n",
+    "    Console.WriteLine($\"{(w == \"\" ? \"eps\" : w),8} | {na,4} | {nb,4} | {(MembershipQuery(w) ? \"OUI\" : \"non\")}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d81c7c9",
+   "metadata": {},
+   "source": [
+    "### Pourquoi ce langage ?\n",
+    "\n",
+    "Le mot vide est accepte (0 est pair), `ab` est rejete (1 'a', 1 'b'), `aabb` et\n",
+    "`abab` sont acceptes. Le DFA minimal a exactement **4 etats** --- le produit des\n",
+    "deux parites --- et aucune conjonction d'attributs a la SL-1 ne peut le representer :\n",
+    "l'appartenance depend d'un *compteur modulaire*, pas de la presence ou l'absence\n",
+    "d'un motif. C'est un concept hors de portee des espaces d'hypotheses de SL-1, et\n",
+    "parfaitement dans celui de L*.\n",
+    "\n",
+    "L'apprenant ne voit que `membership_query` : une boite noire mot -> booleen.\n",
+    "Tout l'enjeu est de reconstruire la structure (etats, transitions) a partir de\n",
+    "reponses oui/non bien choisies.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afd974af",
+   "metadata": {},
+   "source": [
+    "### Schema : le DFA cible (invisible pour l'apprenant)\n",
+    "\n",
+    "Le langage cible -- *nombre pair de `a` **et** pair de `b`* -- est reconnu par le DFA\n",
+    "minimal a **4 etats**, un par couple (parite des `a`, parite des `b`). C'est cette\n",
+    "structure (etats + transitions) que L* doit reconstruire a partir des seules reponses\n",
+    "oui/non de l'oracle ; elle lui est **cachee**. La voici :\n",
+    "\n",
+    "```mermaid\n",
+    "stateDiagram-v2\n",
+    "    direction LR\n",
+    "    [*] --> ee\n",
+    "    ee --> oe : a\n",
+    "    ee --> eo : b\n",
+    "    oe --> ee : a\n",
+    "    oe --> oo : b\n",
+    "    eo --> oo : a\n",
+    "    eo --> ee : b\n",
+    "    oo --> eo : a\n",
+    "    oo --> oe : b\n",
+    "    ee : ee (pair a, pair b)\n",
+    "    oe : oe (impair a, pair b)\n",
+    "    eo : eo (pair a, impair b)\n",
+    "    oo : oo (impair a, impair b)\n",
+    "    classDef accept fill:#d1e7dd,stroke:#0f5132,stroke-width:3px,color:#0a3622\n",
+    "    class ee accept\n",
+    "```\n",
+    "\n",
+    "> **Lecture.** L'etat initial `ee` (pair, pair) est aussi le **seul etat acceptant**\n",
+    "> (en vert) : un mot est dans le langage si, en le lisant lettre par lettre, on revient\n",
+    "> en `ee`. Chaque `a` bascule la parite des `a` (colonne gauche/droite), chaque `b`\n",
+    "> bascule celle des `b` -- d'ou la symetrie en damier. Aucune conjonction d'attributs a\n",
+    "> la SL-1 ne capture ce **compteur modulaire** : c'est precisement ce qui place ce\n",
+    "> concept hors de portee de l'apprentissage passif et dans celui de L*.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "908b2d73",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. La table d'observation\n",
+    "\n",
+    "L* organise ses requetes d'appartenance dans une **table d'observation** $(S, E, T)$ :\n",
+    "\n",
+    "- $S$ : un ensemble de **prefixes d'acces** (chaque $s \\in S$ est un chemin candidat\n",
+    "  vers un etat du DFA) ;\n",
+    "- $E$ : un ensemble de **suffixes distinguants** (des « experiences » qui separent\n",
+    "  les etats) ;\n",
+    "- $T(s \\cdot e) \\in \\{0, 1\\}$ : la reponse de l'oracle a la requete $s \\cdot e \\in L$ ?\n",
+    "\n",
+    "La **ligne** d'un prefixe $s$ est le vecteur $row(s) = (T(s \\cdot e))_{e \\in E}$.\n",
+    "L'intuition centrale : *deux prefixes qui ont la meme ligne menent (provisoirement)\n",
+    "au meme etat*. C'est une approximation finie de la congruence de Myhill-Nerode :\n",
+    "$u \\equiv_L v \\iff \\forall w,\\; uw \\in L \\Leftrightarrow vw \\in L$ --- ici on ne\n",
+    "teste pas *tous* les suffixes $w$, seulement ceux de $E$.\n",
+    "\n",
+    "Pour pouvoir construire un DFA a partir de la table, deux proprietes sont requises :\n",
+    "\n",
+    "| Propriete | Definition | Si violee... |\n",
+    "|-----------|------------|--------------|\n",
+    "| **Fermeture** | $\\forall s \\in S, a \\in \\Sigma$, $row(s a)$ est la ligne d'un element de $S$ | la transition $row(s) \\xrightarrow{a} {?}$ sort de la table : **promouvoir** $sa$ dans $S$ |\n",
+    "| **Consistance** | $row(s_1) = row(s_2) \\Rightarrow \\forall a, row(s_1 a) = row(s_2 a)$ | deux etats fusionnes a tort : **ajouter** le suffixe $a e$ qui les separe a $E$ |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9e076da6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:56.085149Z",
+     "iopub.status.busy": "2026-07-07T07:52:56.084927Z",
+     "iopub.status.idle": "2026-07-07T07:52:56.269658Z",
+     "shell.execute_reply": "2026-07-07T07:52:56.269387Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table initiale (haut : S ; bas : les successeurs S.A) :\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |  eps\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "eps    |    1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a      |    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b      |    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Requetes MQ posees : 3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fermee ? NON : row(a) absente de S\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "public class ObservationTable\n",
+    "{\n",
+    "    public List<char> A { get; set; }\n",
+    "    public Func<string, bool> Mq { get; set; }\n",
+    "    public List<string> S { get; set; } = new List<string> { \"\" };\n",
+    "    public List<string> E { get; set; } = new List<string> { \"\" };\n",
+    "    public Dictionary<string, bool> T { get; set; } = new Dictionary<string, bool>();\n",
+    "    public int NMq { get; set; } = 0;\n",
+    "\n",
+    "    public ObservationTable(IEnumerable<char> alphabet, Func<string, bool> mq)\n",
+    "    {\n",
+    "        A = alphabet.ToList();\n",
+    "        Mq = mq;\n",
+    "        Fill();\n",
+    "    }\n",
+    "\n",
+    "    public bool Ask(string w)\n",
+    "    {\n",
+    "        if (!T.ContainsKey(w)) { T[w] = Mq(w); NMq++; }\n",
+    "        return T[w];\n",
+    "    }\n",
+    "\n",
+    "    public void Fill()\n",
+    "    {\n",
+    "        foreach (var s in S.Concat(S.SelectMany(s => A.Select(a => s + a))))\n",
+    "            foreach (var e in E) Ask(s + e);\n",
+    "    }\n",
+    "\n",
+    "    // Ligne d'un prefixe = signature textuelle sur les colonnes E (comparable/hashable).\n",
+    "    public string Row(string s) => string.Join(\"\", E.Select(e => Ask(s + e) ? \"1\" : \"0\"));\n",
+    "\n",
+    "    public string FindUnclosed()\n",
+    "    {\n",
+    "        var rowsS = S.Select(s => Row(s)).ToHashSet();\n",
+    "        foreach (var s in S)\n",
+    "            foreach (var a in A)\n",
+    "                if (!rowsS.Contains(Row(s + a))) return s + a;\n",
+    "        return null;\n",
+    "    }\n",
+    "\n",
+    "    public string FindInconsistency()\n",
+    "    {\n",
+    "        for (int i = 0; i < S.Count; i++)\n",
+    "            for (int j = i + 1; j < S.Count; j++)\n",
+    "            {\n",
+    "                if (Row(S[i]) != Row(S[j])) continue;\n",
+    "                foreach (var a in A)\n",
+    "                    foreach (var e in E)\n",
+    "                        if (Ask(S[i] + a + e) != Ask(S[j] + a + e)) return a + e;\n",
+    "            }\n",
+    "        return null;\n",
+    "    }\n",
+    "\n",
+    "    public void Show()\n",
+    "    {\n",
+    "        string eps = \"eps\";\n",
+    "        var cols = E.Select(e => e == \"\" ? eps : e).ToList();\n",
+    "        int w = Math.Max(6, S.Max(s => s.Length) + 2);\n",
+    "        string Lab(string s) => (s == \"\" ? eps : s).PadRight(w);\n",
+    "        string RowStr(string s) => string.Join(\" \", Row(s).Select(v => (v == '1' ? \"1\" : \"0\").PadLeft(4)));\n",
+    "        Console.WriteLine(new string(' ', w) + \" | \" + string.Join(\" \", cols.Select(c => c.PadLeft(4))));\n",
+    "        Console.WriteLine(new string('-', w + 3 + 5 * cols.Count));\n",
+    "        foreach (var s in S) Console.WriteLine(Lab(s) + \" | \" + RowStr(s));\n",
+    "        Console.WriteLine(new string('-', w + 3 + 5 * cols.Count));\n",
+    "        var inS = S.ToHashSet();\n",
+    "        foreach (var s in S)\n",
+    "            foreach (var a in A)\n",
+    "            {\n",
+    "                var sa = s + a;\n",
+    "                if (inS.Contains(sa)) continue;\n",
+    "                Console.WriteLine(Lab(sa) + \" | \" + RowStr(sa));\n",
+    "            }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Table initiale : S = {epsilon}, E = {epsilon}\n",
+    "var table = new ObservationTable(ALPHABET, MembershipQuery);\n",
+    "Console.WriteLine(\"Table initiale (haut : S ; bas : les successeurs S.A) :\\n\");\n",
+    "table.Show();\n",
+    "var sa0 = table.FindUnclosed();\n",
+    "Console.WriteLine($\"\\nRequetes MQ posees : {table.NMq}\");\n",
+    "Console.WriteLine($\"Fermee ? {(sa0 == null ? \"oui\" : \"NON : row(\" + sa0 + \") absente de S\")}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "271575fc",
+   "metadata": {},
+   "source": [
+    "### Lecture de la table initiale\n",
+    "\n",
+    "La ligne de $\\varepsilon$ vaut $(1)$ (le mot vide est dans $L$), mais celles de\n",
+    "`a` et `b` valent $(0)$ : la table n'est **pas fermee** --- l'automate conjecture\n",
+    "aurait une transition vers un etat qui n'existe pas encore. Le remede est mecanique :\n",
+    "promouvoir le prefixe fautif dans $S$, ce qui *cree* l'etat manquant, puis re-remplir\n",
+    "la table. L'algorithme L* n'est rien d'autre que la repetition disciplinee de ce\n",
+    "geste, plus le traitement des contre-exemples.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a710b59",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. L'algorithme L*\n",
+    "\n",
+    "```text\n",
+    "L*(alphabet, MQ, EQ):\n",
+    "    initialiser la table (S = E = {epsilon})\n",
+    "    repeter:\n",
+    "        tant que la table n'est pas fermee ou pas consistante:\n",
+    "            non fermee      -> promouvoir le prefixe s.a fautif dans S\n",
+    "            non consistante -> ajouter le suffixe a.e separateur a E\n",
+    "        H <- DFA conjecture a partir des lignes de la table\n",
+    "        si EQ(H) repond OUI : retourner H\n",
+    "        sinon (contre-exemple c) : ajouter TOUS les prefixes de c a S\n",
+    "```\n",
+    "\n",
+    "La **conjecture** se lit directement dans la table : les etats sont les lignes\n",
+    "distinctes de $S$, l'etat initial est $row(\\varepsilon)$, un etat est acceptant si\n",
+    "sa premiere colonne ($e = \\varepsilon$) vaut 1, et la transition par $a$ envoie\n",
+    "$row(s)$ sur $row(sa)$ --- la fermeture garantit que cette ligne existe, la\n",
+    "consistance qu'elle ne depend pas du representant $s$ choisi.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e4407dce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:56.271016Z",
+     "iopub.status.busy": "2026-07-07T07:52:56.270804Z",
+     "iopub.status.idle": "2026-07-07T07:52:56.388995Z",
+     "shell.execute_reply": "2026-07-07T07:52:56.388802Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L* implemente : ObservationTable + conjecture + boucle de raffinement.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "Dfa Conjecture(ObservationTable table)\n",
+    "{\n",
+    "    var reps = new Dictionary<string, string>();  // ligne (signature) -> prefixe representant\n",
+    "    foreach (var s in table.S)\n",
+    "        if (!reps.ContainsKey(table.Row(s))) reps[table.Row(s)] = s;\n",
+    "    var delta = new List<((string, char), string)>();\n",
+    "    foreach (var kv in reps)\n",
+    "    {\n",
+    "        var sig = kv.Key; var s = kv.Value;\n",
+    "        foreach (var a in table.A) delta.Add(((sig, a), table.Row(s + a)));\n",
+    "    }\n",
+    "    string start = table.Row(\"\");\n",
+    "    var accepting = reps.Keys.Where(sig => sig[0] == '1').ToList();\n",
+    "    return new Dfa(reps.Keys, table.A, delta, start, accepting);\n",
+    "}\n",
+    "\n",
+    "string FindCounterexample(Dfa hyp, Dfa target, IEnumerable<char> alphabet)\n",
+    "{\n",
+    "    var alph = alphabet.ToList();\n",
+    "    var start = (hyp.Start, target.Start);\n",
+    "    var seen = new HashSet<(string, string)>() { start };\n",
+    "    var queue = new Queue<(string w, string qh, string qt)>();\n",
+    "    queue.Enqueue((\"\", hyp.Start, target.Start));\n",
+    "    while (queue.Count > 0)\n",
+    "    {\n",
+    "        var (w, qh, qt) = queue.Dequeue();\n",
+    "        if (hyp.Accepting.Contains(qh) != target.Accepting.Contains(qt)) return w;\n",
+    "        foreach (var a in alph)\n",
+    "        {\n",
+    "            var nxt = (hyp.Delta[(qh, a)], target.Delta[(qt, a)]);\n",
+    "            if (seen.Add(nxt)) queue.Enqueue((w + a, nxt.Item1, nxt.Item2));\n",
+    "        }\n",
+    "    }\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "(Dfa hyp, ObservationTable table, int nEq) Lstar(IEnumerable<char> alphabet, Func<string, bool> mq,\n",
+    "                                                  Func<Dfa, string> eq, bool verbose = true)\n",
+    "{\n",
+    "    var tbl = new ObservationTable(alphabet, mq);\n",
+    "    int nEq = 0, round_ = 0;\n",
+    "    while (true)\n",
+    "    {\n",
+    "        // 1. Stabiliser la table\n",
+    "        while (true)\n",
+    "        {\n",
+    "            var sa = tbl.FindUnclosed();\n",
+    "            if (sa != null) { tbl.S.Add(sa); tbl.Fill(); if (verbose) Console.WriteLine($\"  table non fermee -> S += {sa}\"); continue; }\n",
+    "            var ae = tbl.FindInconsistency();\n",
+    "            if (ae != null) { tbl.E.Add(ae); tbl.Fill(); if (verbose) Console.WriteLine($\"  table non consistante -> E += {ae}\"); continue; }\n",
+    "            break;\n",
+    "        }\n",
+    "        // 2. Conjecturer et interroger le professeur\n",
+    "        var hyp = Conjecture(tbl);\n",
+    "        nEq++; round_++;\n",
+    "        var cex = eq(hyp);\n",
+    "        if (verbose) Console.WriteLine($\"Conjecture {round_} : {hyp.StateCount} etats -> {(cex == null ? \"ACCEPTEE\" : \"contre-exemple \" + cex)}\");\n",
+    "        if (cex == null) return (hyp, tbl, nEq);\n",
+    "        // 3. Integrer le contre-exemple (tous ses prefixes dans S, Angluin 1987)\n",
+    "        for (int i = 1; i <= cex.Length; i++)\n",
+    "            if (!tbl.S.Contains(cex[..i])) tbl.S.Add(cex[..i]);\n",
+    "        tbl.Fill();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"L* implemente : ObservationTable + conjecture + boucle de raffinement.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e879b52",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Execution complete sur le langage cible\n",
+    "\n",
+    "Lancons L* contre la boite noire. L'oracle d'equivalence est ici *exact* (BFS sur\n",
+    "l'automate produit) : un luxe possible seulement parce que nous connaissons la cible\n",
+    "--- la section 6 le remplacera par ce qu'on a vraiment en pratique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6544dcb7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:56.390109Z",
+     "iopub.status.busy": "2026-07-07T07:52:56.389918Z",
+     "iopub.status.idle": "2026-07-07T07:52:56.535880Z",
+     "shell.execute_reply": "2026-07-07T07:52:56.535125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  table non fermee -> S += a\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conjecture 1 : 2 etats -> contre-exemple ba\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  table non consistante -> E += a\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  table non consistante -> E += b\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conjecture 2 : 4 etats -> ACCEPTEE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "DFA appris : Dfa(4 etats, 1 acceptants)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requetes d'appartenance : 19\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requetes d'equivalence  : 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Table finale (S = 4 prefixes, E = { '', 'a', 'b' } ) :\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |  eps    a    b\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "eps    |    1    0    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a      |    0    1    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b      |    0    0    1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ba     |    0    0    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "aa     |    1    0    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ab     |    0    0    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bb     |    1    0    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "baa    |    0    0    1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bab    |    0    1    0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Verification exhaustive : 2047/2047 mots (longueur <= 10) identiques\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "var (learned, finalTable, nEqRun) = Lstar(ALPHABET, MembershipQuery,\n",
+    "    h => FindCounterexample(h, TARGET, ALPHABET));\n",
+    "\n",
+    "Console.WriteLine($\"\\nDFA appris : {learned}\");\n",
+    "Console.WriteLine($\"Requetes d'appartenance : {finalTable.NMq}\");\n",
+    "Console.WriteLine($\"Requetes d'equivalence  : {nEqRun}\");\n",
+    "string eList = string.Join(\", \", finalTable.E.Select(e => \"'\" + e + \"'\"));\n",
+    "Console.WriteLine($\"\\nTable finale (S = {finalTable.S.Count} prefixes, E = {{ {eList} }} ) :\\n\");\n",
+    "finalTable.Show();\n",
+    "\n",
+    "// Verification independante exhaustive jusqu'a la longueur 10\n",
+    "IEnumerable<string> AllWords(List<char> alphabet, int maxLen)\n",
+    "{\n",
+    "    yield return \"\";\n",
+    "    var frontier = new List<string> { \"\" };\n",
+    "    for (int _ = 0; _ < maxLen; _++)\n",
+    "    {\n",
+    "        var next = new List<string>();\n",
+    "        foreach (var w in frontier) foreach (var a in alphabet) next.Add(w + a);\n",
+    "        frontier = next;\n",
+    "        foreach (var w in frontier) yield return w;\n",
+    "    }\n",
+    "}\n",
+    "var allW = AllWords(ALPHABET, 10).ToList();\n",
+    "int mismatch = allW.Count(w => learned.Accepts(w) != TARGET.Accepts(w));\n",
+    "Console.WriteLine($\"\\nVerification exhaustive : {allW.Count - mismatch}/{allW.Count} mots (longueur <= 10) identiques\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea739970",
+   "metadata": {},
+   "source": [
+    "### Interpretation : que s'est-il passe ?\n",
+    "\n",
+    "1. **La premiere conjecture est minuscule et fausse.** Avec $S = E = \\{\\varepsilon\\}$\n",
+    "   stabilises, la table ne distingue que « accepte / rejette » : 2 etats. Le\n",
+    "   professeur repond par un contre-exemple court.\n",
+    "\n",
+    "2. **Le contre-exemple force la croissance.** Ses prefixes entrent dans $S$, la\n",
+    "   consistance casse, des suffixes distinguants entrent dans $E$ --- chaque rejet\n",
+    "   d'une conjecture ajoute *au moins un etat* a la suivante. Comme le DFA minimal a\n",
+    "   4 etats, il y a au plus 4 conjectures : la terminaison est garantie, pas\n",
+    "   seulement esperee.\n",
+    "\n",
+    "3. **Le cout total est modeste** : quelques dizaines de MQ et une poignee d'EQ pour\n",
+    "   identifier exactement un langage infini. Comparez avec SL-1 : 12 exemples\n",
+    "   *imposes* n'avaient pas suffi a stabiliser une simple conjonction. Le choix actif\n",
+    "   des questions est la source de l'efficacite --- chaque requete de la table sert a\n",
+    "   trancher une distinction precise entre deux etats candidats.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7453720a",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Garanties : minimalite et complexite polynomiale\n",
+    "\n",
+    "Le theoreme de **Myhill-Nerode** (1958) donne la borne inferieure structurelle : le\n",
+    "nombre d'etats du DFA minimal de $L$ est exactement le nombre de classes de la congruence $u \\equiv_L v \\iff \\forall w,\\; uw \\in L \\Leftrightarrow vw \\in L$.\n",
+    "\n",
+    "> **Origine.** L'exposition canonique du theoreme de Myhill-Nerode et de son role pour la minimalite des automates se trouve dans Hopcroft, J. E., Motwani, R. & Ullman, J. D., *Introduction to Automata Theory, Languages, and Computation* (3e ed., Pearson/Addison-Wesley). Le theoreme (Myhill 1958, Nerode 1958) caracterise un langage regulier par sa congruence syntactique : deux prefixes sont equivalents s'ils ne peuvent etre distingues par aucun suffixe.\n",
+    "\n",
+    "L* s'y adosse directement :\n",
+    "\n",
+    "- chaque paire de lignes **distinctes** de la table est un *certificat* de\n",
+    "  non-equivalence (un suffixe de $E$ separe les deux prefixes), donc la conjecture\n",
+    "  n'a jamais *plus* d'etats que le DFA minimal ;\n",
+    "- l'oracle d'equivalence fournit des contre-exemples tant qu'elle en a *moins* ;\n",
+    "- l'algorithme s'arrete donc precisement sur le DFA minimal --- il ne peut pas\n",
+    "  retourner autre chose.\n",
+    "\n",
+    "Cote complexite : $O(n)$ requetes d'equivalence et $O(|\\Sigma| \\cdot m \\cdot n^2)$\n",
+    "requetes d'appartenance, ou $n$ est le nombre d'etats du minimal et $m$ la longueur\n",
+    "du plus long contre-exemple. Verifions empiriquement la croissance sur la famille\n",
+    "$L_k$ = « le nombre de 'a' est divisible par $k$ » (DFA minimal a $k$ etats) :\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fc77f50e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:56.538343Z",
+     "iopub.status.busy": "2026-07-07T07:52:56.537928Z",
+     "iopub.status.idle": "2026-07-07T07:52:56.630954Z",
+     "shell.execute_reply": "2026-07-07T07:52:56.630789Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classes de Myhill-Nerode empiriques (prefixes <= 4, suffixes <= 4) : 4\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  classe de      eps : 11 prefixes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  classe de      'a' : 5 prefixes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  classe de      'b' : 5 prefixes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  classe de     'ab' : 10 prefixes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  k | etats appris | MQ | EQ\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2 |            2 |    5 |  1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3 |            3 |   14 |  2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4 |            4 |   23 |  2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  5 |            5 |   34 |  2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  6 |            6 |   47 |  2\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Verification empirique 1 : les classes de Myhill-Nerode du langage cible\n",
+    "Dictionary<string, List<string>> NerodeClasses(Func<string, bool> mq, List<char> alphabet, int maxPrefix = 4, int maxSuffix = 4)\n",
+    "{\n",
+    "    var suffixes = AllWords(alphabet, maxSuffix).ToList();\n",
+    "    var sig = new Dictionary<string, List<string>>();\n",
+    "    foreach (var u in AllWords(alphabet, maxPrefix))\n",
+    "    {\n",
+    "        var key = string.Join(\"\", suffixes.Select(w => mq(u + w) ? \"1\" : \"0\"));\n",
+    "        if (!sig.ContainsKey(key)) sig[key] = new List<string>();\n",
+    "        sig[key].Add(u);\n",
+    "    }\n",
+    "    return sig;\n",
+    "}\n",
+    "\n",
+    "var classes = NerodeClasses(MembershipQuery, ALPHABET);\n",
+    "Console.WriteLine($\"Classes de Myhill-Nerode empiriques (prefixes <= 4, suffixes <= 4) : {classes.Count}\");\n",
+    "foreach (var kv in classes)\n",
+    "    Console.WriteLine($\"  classe de {(kv.Value[0] == \"\" ? \"eps\" : (\"'\" + kv.Value[0] + \"'\")),8} : {kv.Value.Count} prefixes\");\n",
+    "\n",
+    "// Verification empirique 2 : croissance du cout en fonction de k\n",
+    "Console.WriteLine($\"\\n{\"k\",3} | etats appris | MQ | EQ\");\n",
+    "Console.WriteLine(new string('-', 34));\n",
+    "for (int k = 2; k <= 6; k++)\n",
+    "{\n",
+    "    bool MqK(string word) => word.Count(c => c == 'a') % k == 0;\n",
+    "    var dkStates = Enumerable.Range(0, k).Select(i => i.ToString()).ToList();\n",
+    "    var dkDelta = new List<((string, char), string)>();\n",
+    "    foreach (var q in dkStates) { dkDelta.Add(((q, 'a'), ((int.Parse(q) + 1) % k).ToString())); dkDelta.Add(((q, 'b'), q)); }\n",
+    "    var dk = new Dfa(dkStates, ALPHABET, dkDelta, \"0\", new[] { \"0\" });\n",
+    "    var (h, tbl, neq) = Lstar(ALPHABET, MqK, h2 => FindCounterexample(h2, dk, ALPHABET), verbose: false);\n",
+    "    Console.WriteLine($\"{k,3} | {h.StateCount,12} | {tbl.NMq,4} | {neq,2}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3859f6c",
+   "metadata": {},
+   "source": [
+    "### Interpretation\n",
+    "\n",
+    "Les classes empiriques de Myhill-Nerode sont bien au nombre de **4** --- et L* a\n",
+    "appris un DFA a 4 etats : la garantie de minimalite n'est pas un a-cote theorique,\n",
+    "c'est le mecanisme meme de l'algorithme. Sur la famille $L_k$, le nombre d'etats\n",
+    "appris suit exactement $k$ et le nombre de requetes croit polynomialement, tres\n",
+    "loin de l'explosion exponentielle qu'exigerait l'enumeration des DFA candidats.\n",
+    "\n",
+    "A noter : c'est un des rares algorithmes de la serie a venir avec une garantie\n",
+    "*exacte* (identification du concept, pas approximation). Le prix est le professeur :\n",
+    "sans oracle d'equivalence fiable, la garantie s'evapore --- voyons precisement\n",
+    "comment.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb7a7f14",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. L'oracle d'equivalence en pratique\n",
+    "\n",
+    "Dans le monde reel (retro-ingenierie d'un protocole, test d'un composant boite\n",
+    "noire), personne ne sait repondre exactement a « ton hypothese est-elle correcte ? ».\n",
+    "On *approxime* l'EQ par echantillonnage : tirer $N$ mots au hasard, comparer\n",
+    "l'hypothese et le systeme, renvoyer le premier desaccord. S'il n'y en a aucun,\n",
+    "declarer l'hypothese correcte... en croisant les doigts.\n",
+    "\n",
+    "C'est exactement le cadre **PAC** (SL-3) : le DFA retourne est *probablement\n",
+    "approximativement correct* --- mais plus *exactement* correct. Et la nuance n'est\n",
+    "pas academique : elle depend entierement de la **densite des desaccords** entre une\n",
+    "hypothese fausse et la cible. Mesurons-la sur deux langages aux profils opposes :\n",
+    "le langage des parites (ou une hypothese fausse se trompe sur environ un mot sur\n",
+    "quatre) et un langage-aiguille, « les mots contenant le facteur `aabbaabb` », ou\n",
+    "les mots discriminants sont rares.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a64892b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:56.632336Z",
+     "iopub.status.busy": "2026-07-07T07:52:56.632143Z",
+     "iopub.status.idle": "2026-07-07T07:52:56.760917Z",
+     "shell.execute_reply": "2026-07-07T07:52:56.760514Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Langage parites (desaccords DENSES) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " N essais | etats | DFA exact ?\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        1 |     2 | NON\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       10 |     4 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      100 |     4 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1000 |     4 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Langage contient 'aabbaabb' (desaccords RARES) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " N essais | etats | DFA exact ?\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        1 |     1 | NON\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       10 |     1 | NON\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      100 |     9 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1000 |     9 | OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Globalization;\n",
+    "// Oracle d'equivalence approximatif : N mots aleatoires, premier desaccord.\n",
+    "Func<Dfa, string> MakeSamplingEq(Func<string, bool> mq, List<char> alphabet, int nSamples, int maxLen = 20, int seed = 0)\n",
+    "{\n",
+    "    var rng = new Random(seed);\n",
+    "    string Eq(Dfa hyp)\n",
+    "    {\n",
+    "        for (int _ = 0; _ < nSamples; _++)\n",
+    "        {\n",
+    "            int len = rng.Next(0, maxLen + 1);\n",
+    "            var sb = new StringBuilder();\n",
+    "            for (int i = 0; i < len; i++) sb.Append(alphabet[rng.Next(alphabet.Count)]);\n",
+    "            var w = sb.ToString();\n",
+    "            if (hyp.Accepts(w) != mq(w)) return w;\n",
+    "        }\n",
+    "        return null;\n",
+    "    }\n",
+    "    return Eq;\n",
+    "}\n",
+    "\n",
+    "// Le langage-aiguille : mots contenant le facteur \"aabbaabb\".\n",
+    "// Son DFA minimal est l'automate de Knuth-Morris-Pratt du motif : 9 etats.\n",
+    "Dfa FactorDfa(string pattern, List<char> alphabet)\n",
+    "{\n",
+    "    int n = pattern.Length;\n",
+    "    var delta = new List<((string, char), string)>();\n",
+    "    for (int q = 0; q <= n; q++)\n",
+    "        foreach (var ch in alphabet)\n",
+    "        {\n",
+    "            string target;\n",
+    "            if (q == n) target = n.ToString();               // motif deja vu : etat absorbant\n",
+    "            else if (pattern[q] == ch) target = (q + 1).ToString();\n",
+    "            else\n",
+    "            {\n",
+    "                var s = pattern[..q] + ch;                   // repli KMP : plus long prefixe du motif encore suffixe\n",
+    "                int best = 0;\n",
+    "                for (int kk = s.Length; kk >= 0; kk--)\n",
+    "                    if (kk <= s.Length && s.EndsWith(pattern[..kk])) { best = kk; break; }\n",
+    "                target = best.ToString();\n",
+    "            }\n",
+    "            delta.Add(((q.ToString(), ch), target));\n",
+    "        }\n",
+    "    var states = Enumerable.Range(0, n + 1).Select(i => i.ToString());\n",
+    "    return new Dfa(states, alphabet, delta, \"0\", new[] { n.ToString() });\n",
+    "}\n",
+    "\n",
+    "Dfa NEEDLE = FactorDfa(\"aabbaabb\", ALPHABET);\n",
+    "\n",
+    "foreach (var (name, mq, tgt) in new (string, Func<string, bool>, Dfa)[]\n",
+    "{\n",
+    "    (\"parites (desaccords DENSES)\", MembershipQuery, TARGET),\n",
+    "    (\"contient 'aabbaabb' (desaccords RARES)\", NEEDLE.Accepts, NEEDLE),\n",
+    "})\n",
+    "{\n",
+    "    Console.WriteLine($\"Langage {name} :\");\n",
+    "    Console.WriteLine($\"{\"N essais\",9} | etats | DFA exact ?\");\n",
+    "    foreach (var nSamples in new[] { 1, 10, 100, 1000 })\n",
+    "    {\n",
+    "        var (h, _t, _e) = Lstar(ALPHABET, mq, MakeSamplingEq(mq, ALPHABET, nSamples, seed: 7), verbose: false);\n",
+    "        bool exact = FindCounterexample(h, tgt, ALPHABET) == null;\n",
+    "        Console.WriteLine($\"{nSamples,9} | {h.StateCount,5} | {(exact ? \"OUI\" : \"NON\")}\");\n",
+    "    }\n",
+    "    Console.WriteLine();\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1048106",
+   "metadata": {},
+   "source": [
+    "### Interpretation : tout depend de la densite des desaccords\n",
+    "\n",
+    "Sur les **parites**, un seul mot aleatoire par appel suffit deja : une hypothese\n",
+    "fausse y est en desaccord avec la cible sur environ un mot sur quatre, le premier\n",
+    "tirage venu fait office de contre-exemple. La garantie *semble* intacte --- mais\n",
+    "c'est une propriete du langage, pas de l'algorithme.\n",
+    "\n",
+    "Sur le **langage-aiguille**, un mot aleatoire de longueur $\\le 20$ ne contient le\n",
+    "facteur qu'avec une probabilite de quelques pourcents. A $N = 1$ ou $10$ essais,\n",
+    "l'EQ approximatif ne voit jamais de desaccord et accepte la *toute premiere*\n",
+    "conjecture : un DFA a **un etat qui rejette tout**. Le resultat est grossierement\n",
+    "faux et *rien dans l'execution ne le signale* --- c'est le sens exact du PAC :\n",
+    "correct avec probabilite $1 - \\delta$ *sur la distribution d'echantillonnage*,\n",
+    "rien de plus. A $N = 100$, le contre-exemple finit par sortir, et un seul suffit :\n",
+    "ses prefixes injectent dans la table tout le materiel necessaire, et L* deroule\n",
+    "les 9 etats sans aide supplementaire.\n",
+    "\n",
+    "C'est la meme lecon que SL-9, vue de l'autre cote : la-bas, un generateur faillible\n",
+    "(le LLM) etait discipline par un oracle exact ; ici, un apprenant exact est\n",
+    "fragilise par un oracle faillible. Dans un pipeline neuro-symbolique, *identifier\n",
+    "qui joue le role de l'oracle et ce qu'il garantit vraiment* est la premiere\n",
+    "question d'architecture.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2eb3b6ee",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7. Posterite : le *model learning*\n",
+    "\n",
+    "L* n'est pas reste un resultat theorique. Sous le nom de **model learning**\n",
+    "(Vaandrager, CACM 2017), ses descendants directs apprennent des machines a etats\n",
+    "de systemes reels, en branchant les MQ sur le systeme lui-meme :\n",
+    "\n",
+    "- **Retro-ingenierie de protocoles** : les implementations de TLS, TCP, SSH ou des\n",
+    "  cartes bancaires ont ete apprises comme des machines de Mealy ; plusieurs\n",
+    "  violations de specification et failles ont ete trouvees en *lisant le DFA appris*\n",
+    "  (etats parasites, transitions interdites presentes).\n",
+    "- **[LearnLib](https://learnlib.de/)** (open source, Java) industrialise L* et ses\n",
+    "  variantes modernes (TTT, Rivest-Schapire, ADT), avec des EQ approximatifs\n",
+    "  intelligents (W-method, echantillonnage dirige).\n",
+    "- **Verification** : le DFA appris sert d'interface formelle d'un composant boite\n",
+    "  noire, sur laquelle un model checker peut ensuite prouver des proprietes\n",
+    "  (assume-guarantee reasoning).\n",
+    "\n",
+    "Et la boucle se referme avec les LLM : des travaux recents utilisent un LLM comme\n",
+    "*professeur approximatif* (repondre aux MQ sur un format textuel, proposer des\n",
+    "contre-exemples) et L* comme *apprenant exact* qui en extrait un automate verifiable\n",
+    "--- la division generateur faillible / verificateur symbolique de SL-9, devenue\n",
+    "protocole d'apprentissage.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9398165e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 8. Exercices\n",
+    "\n",
+    "### Tableau recapitulatif\n",
+    "\n",
+    "| Concept | Definition | Implementation |\n",
+    "|---------|------------|----------------|\n",
+    "| Requete MQ / EQ | $w \\in L$ ? / $H = L$ ? | `membership_query`, `find_counterexample` |\n",
+    "| Table d'observation | $(S, E, T)$, lignes = etats candidats | `ObservationTable` |\n",
+    "| Fermeture | $row(sa)$ presente dans $S$ | `find_unclosed()` |\n",
+    "| Consistance | lignes egales -> successeurs egaux | `find_inconsistency()` |\n",
+    "| Conjecture | DFA des lignes distinctes | `conjecture()` |\n",
+    "| EQ approximatif | echantillonnage, garantie PAC | `make_sampling_eq()` |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4af4e53f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:56.763536Z",
+     "iopub.status.busy": "2026-07-07T07:52:56.763087Z",
+     "iopub.status.idle": "2026-07-07T07:52:56.843449Z",
+     "shell.execute_reply": "2026-07-07T07:52:56.843298Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DFA appris : Dfa(4 etats, 1 acceptants)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Conjectures (equivalences) : 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  |S| = 16, |E| = 3, MQ posees = 67\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prediction theorique : 4 etats (rien vu / 'a' vu / 'ab' vu / 'abb' vu).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-> observe : 4 etats (confirme)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       mot | DFA | vrai | OK ?\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     (eps) |   0 |    0 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         a |   0 |    0 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        ab |   0 |    0 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       abb |   1 |    1 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      abbb |   1 |    1 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      babb |   1 |    1 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     aaabb |   1 |    1 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      abab |   0 |    0 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    abbabb |   1 |    1 | OK\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     bbabb |   1 |    1 | OK\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple guide 1 : Apprendre le langage \"contient 'abb' comme facteur\"\n",
+    "// Etape 1 : requete d'appartenance -- une ligne suffit (\"abb\" in word)\n",
+    "bool MqAbb(string word) => word.Contains(\"abb\");\n",
+    "\n",
+    "// Etape 2 : lancer L* avec un oracle d'equivalence par echantillonnage\n",
+    "var (learnedAbb, finalTableAbb, nEqAbb) = Lstar(ALPHABET, MqAbb,\n",
+    "    MakeSamplingEq(MqAbb, ALPHABET, 2000), verbose: false);\n",
+    "\n",
+    "Console.WriteLine($\"DFA appris : {learnedAbb}\");\n",
+    "Console.WriteLine($\"  Conjectures (equivalences) : {nEqAbb}\");\n",
+    "Console.WriteLine($\"  |S| = {finalTableAbb.S.Count}, |E| = {finalTableAbb.E.Count}, MQ posees = {finalTableAbb.NMq}\");\n",
+    "\n",
+    "// Etape 3 : interpretation des etats (prediction theorique : 4 etats)\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Prediction theorique : 4 etats (rien vu / 'a' vu / 'ab' vu / 'abb' vu).\");\n",
+    "Console.WriteLine($\"-> observe : {learnedAbb.StateCount} etats \"\n",
+    "    + (learnedAbb.StateCount == 4 ? \"(confirme)\" : \"(a commenter)\"));\n",
+    "\n",
+    "// Etape 4 : verification sur 10 mots\n",
+    "var testWords = new[] { \"\", \"a\", \"ab\", \"abb\", \"abbb\", \"babb\", \"aaabb\", \"abab\", \"abbabb\", \"bbabb\" };\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"{\"mot\",10} | DFA | vrai | OK ?\");\n",
+    "Console.WriteLine(new string('-', 34));\n",
+    "foreach (var w in testWords)\n",
+    "{\n",
+    "    bool pred = learnedAbb.Accepts(w), vrai = w.Contains(\"abb\");\n",
+    "    Console.WriteLine($\"{(w == \"\" ? \"(eps)\" : w),10} | {(pred ? 1 : 0),3} | {(vrai ? 1 : 0),4} | {(pred == vrai ? \"OK\" : \"ECHEC\")}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e4abd18",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 (variation) : Apprendre un autre langage-facteur\n",
+    "\n",
+    "Reprenez la methode de l'exemple guide pour apprendre par L* le langage des mots (sur {a, b}) qui contiennent la sous-chaine **\"ba\"** (au lieu de \"abb\"). Combien d'etats le DFA minimal comporte-t-il, et pourquoi ?\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Ecrire `mq_ba(word)` : appartenance au langage \"contient 'ba' comme facteur\"\n",
+    "2. Lancer L* avec `make_sampling_eq(mq_ba, ALPHABET, 2000)`\n",
+    "3. Donner le nombre d'etats du DFA appris et expliquer chacun (prediction theorique : 3 etats)\n",
+    "4. Verifier sur 8 mots de votre choix\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "72bdd513",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:56.844614Z",
+     "iopub.status.busy": "2026-07-07T07:52:56.844427Z",
+     "iopub.status.idle": "2026-07-07T07:52:56.900333Z",
+     "shell.execute_reply": "2026-07-07T07:52:56.900008Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : apprenez le langage 'contient ba' par L*\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 1 : ecrivez MqBa(word) avec .Contains(\"ba\")\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 2 : lancez Lstar(ALPHABET, MqBa, MakeSamplingEq(..., 2000))\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 3 : donnez le nombre d'etats et expliquez chacun\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 4 : verifiez sur 8 mots\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 (variation) : apprendre le langage \"contient 'ba' comme facteur\"\n",
+    "// TODO etudiant : reprenez l'exemple guide ci-dessus avec le motif \"ba\".\n",
+    "Console.WriteLine(\"Exercice a completer : apprenez le langage 'contient ba' par L*\");\n",
+    "Console.WriteLine(\"Etape 1 : ecrivez MqBa(word) avec .Contains(\\\"ba\\\")\");\n",
+    "Console.WriteLine(\"Etape 2 : lancez Lstar(ALPHABET, MqBa, MakeSamplingEq(..., 2000))\");\n",
+    "Console.WriteLine(\"Etape 3 : donnez le nombre d'etats et expliquez chacun\");\n",
+    "Console.WriteLine(\"Etape 4 : verifiez sur 8 mots\");\n",
+    "// Indice : le motif \"ba\" est plus court que \"abb\" -> moins d'etats \"amorce\".\n",
+    "// Etape 1 : bool MqBa(string word) => word.Contains(\"ba\");   // TODO etudiant\n",
+    "// Etape 2 : var (learnedBa, _, _) = Lstar(ALPHABET, MqBa, MakeSamplingEq(MqBa, ALPHABET, 2000), verbose: false);\n",
+    "// Etape 3 : Console.WriteLine($\"DFA appris : {learnedBa} ...\");   // prediction : 3 etats\n",
+    "// Etape 4 : boucle de verification sur 8 mots\n",
+    "Dfa learnedBa = null;  // TODO etudiant : le DFA appris (a remplir)\n",
+    "Console.WriteLine($\"Resultat : {(learnedBa == null ? \"(a completer)\" : learnedBa.ToString())}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd20a706",
+   "metadata": {},
+   "source": [
+    "L'exercice suivant quantifie ce que la section 6 a montre qualitativement : la\n",
+    "fiabilite de l'oracle d'equivalence par echantillonnage est une variable aleatoire,\n",
+    "qui se mesure en repetant l'experience.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cc11ba64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:56.901573Z",
+     "iopub.status.busy": "2026-07-07T07:52:56.901372Z",
+     "iopub.status.idle": "2026-07-07T07:52:57.100145Z",
+     "shell.execute_reply": "2026-07-07T07:52:57.099940Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fiabilite de l'oracle d'equivalence par echantillonnage (20 graines)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " n_samples |  NEEDLE (desaccords rares) |  TARGET parites (denses)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         1 |                       0 % |                    25 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        10 |                       5 % |                   100 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        50 |                      55 % |                   100 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       100 |                      80 % |                   100 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       500 |                     100 % |                   100 %\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lecture : le seuil de fiabilite (n_samples au-dela duquel le taux tend\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vers 100%) depend fortement du langage. NEEDLE a des desaccords RARES --\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "il faut beaucoup d'echantillons pour tomber sur un mot revelateur. TARGET\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(parite) a des desaccords DENSES -- donc peu d'echantillons suffisent.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple guide 2 : Fiabilite de l'oracle d'equivalence approximatif\n",
+    "// Etape 1 : taux de reussite sur n_seeds graines\n",
+    "double TauxFiabilite(Func<string, bool> mq, Dfa target, int nSamples, int nSeeds = 20)\n",
+    "{\n",
+    "    int corrects = 0;\n",
+    "    for (int seed = 0; seed < nSeeds; seed++)\n",
+    "    {\n",
+    "        var eq = MakeSamplingEq(mq, ALPHABET, nSamples, seed: seed);\n",
+    "        var (h, _t, _e) = Lstar(ALPHABET, mq, eq, verbose: false);\n",
+    "        if (FindCounterexample(h, target, ALPHABET) == null) corrects++;\n",
+    "    }\n",
+    "    return (double)corrects / nSeeds;\n",
+    "}\n",
+    "\n",
+    "// Etape 2 : tableau n_samples -> taux de reussite (20 runs), NEEDLE vs TARGET\n",
+    "Console.WriteLine(\"Fiabilite de l'oracle d'equivalence par echantillonnage (20 graines)\");\n",
+    "Console.WriteLine(new string('=', 64));\n",
+    "Console.WriteLine($\"{\"n_samples\",10} | {\"NEEDLE (desaccords rares)\",26} | {\"TARGET parites (denses)\",24}\");\n",
+    "Console.WriteLine(new string('-', 64));\n",
+    "foreach (var nSamples in new[] { 1, 10, 50, 100, 500 })\n",
+    "{\n",
+    "    double tNeedle = TauxFiabilite(NEEDLE.Accepts, NEEDLE, nSamples);\n",
+    "    double tTarget = TauxFiabilite(MembershipQuery, TARGET, nSamples);\n",
+    "    Console.WriteLine($\"{nSamples,10} | {tNeedle.ToString(\"P0\", CultureInfo.InvariantCulture),25} | {tTarget.ToString(\"P0\", CultureInfo.InvariantCulture),23}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Lecture : le seuil de fiabilite (n_samples au-dela duquel le taux tend\");\n",
+    "Console.WriteLine(\"vers 100%) depend fortement du langage. NEEDLE a des desaccords RARES --\");\n",
+    "Console.WriteLine(\"il faut beaucoup d'echantillons pour tomber sur un mot revelateur. TARGET\");\n",
+    "Console.WriteLine(\"(parite) a des desaccords DENSES -- donc peu d'echantillons suffisent.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2377b97",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 (variation) : Fiabilite vs longueur des mots echantillonnes\n",
+    "\n",
+    "Pour NEEDLE, le contre-exemple revelateur est un mot LONG (il faut un mot contenant \"aabbaabb\"). L'oracle echantillonne des mots de longueur `<= max_len` : que se passe-t-il si `max_len < 8` (aucun mot genere ne peut contenir le motif) ? Mesurez le taux de fiabilite pour `max_len` dans `[5, 8, 12, 20]`, a `n_samples` fixe.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Reutiliser `taux_fiabilite` en variant `max_len` (parametre de `make_sampling_eq`) avec `n_samples=200` fixe, sur NEEDLE\n",
+    "2. Tableau `max_len` -> taux de reussite (20 graines)\n",
+    "3. Pourquoi `max_len < len(motif)` annule-t-il la fiabilite meme avec beaucoup d'echantillons ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f8119638",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:57.101686Z",
+     "iopub.status.busy": "2026-07-07T07:52:57.101479Z",
+     "iopub.status.idle": "2026-07-07T07:52:57.176652Z",
+     "shell.execute_reply": "2026-07-07T07:52:57.176337Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : fiabilite vs longueur des mots echantillonnes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 1 : reutilisez TauxFiabilite en variant max_len (n_samples=200 fixe)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 2 : affichez le tableau max_len -> taux sur NEEDLE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 3 : expliquez pourquoi max_len < 8 annule la fiabilite\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 (variation) : fiabilite vs longueur des mots echantillonnes\n",
+    "// TODO etudiant : pour NEEDLE, la fiabilite depend de max_len (longueur max des mots tires).\n",
+    "Console.WriteLine(\"Exercice a completer : fiabilite vs longueur des mots echantillonnes\");\n",
+    "Console.WriteLine(\"Etape 1 : reutilisez TauxFiabilite en variant max_len (n_samples=200 fixe)\");\n",
+    "Console.WriteLine(\"Etape 2 : affichez le tableau max_len -> taux sur NEEDLE\");\n",
+    "Console.WriteLine(\"Etape 3 : expliquez pourquoi max_len < 8 annule la fiabilite\");\n",
+    "// Indice : si aucun mot genere ne peut contenir le motif 'aabbaabb',\n",
+    "// l'oracle ne trouvera JAMAIS de contre-exemple, meme avec n_samples infini.\n",
+    "// Etape 1 : double TauxFiabiliteMaxLen(int maxLen, int nSamples = 200, int nSeeds = 20) { ... }\n",
+    "//   (variation de TauxFiabilite passant maxLen a MakeSamplingEq)\n",
+    "// Etape 2 : foreach (var ml in new[] { 5, 8, 12, 20 }) Console.WriteLine($\"  max_len={ml} : {TauxFiabiliteMaxLen(ml):P0}\");\n",
+    "Dictionary<int, double> resultat2 = null;  // TODO etudiant : dict {max_len: taux}\n",
+    "Console.WriteLine($\"Resultat : {(resultat2 == null ? \"(a completer)\" : string.Join(\", \", resultat2.Select(kv => kv.Key + \":\" + kv.Value.ToString(\"P0\"))))}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d742e0e2",
+   "metadata": {},
+   "source": [
+    "L'exercice suivant touche au coeur algorithmique : la maniere d'integrer le\n",
+    "contre-exemple. Angluin ajoute tous ses **prefixes** a $S$ ; la variante de\n",
+    "Maler-Pnueli ajoute tous ses **suffixes** a $E$ --- meme garantie, couts differents.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "88e80a27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:57.178245Z",
+     "iopub.status.busy": "2026-07-07T07:52:57.178053Z",
+     "iopub.status.idle": "2026-07-07T07:52:57.299782Z",
+     "shell.execute_reply": "2026-07-07T07:52:57.299558Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison Angluin (prefixes -> S) vs Maler-Pnueli (suffixes -> E)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Langage                | Variante      |  |S| |  |E| | |S|x|E| |    MQ |  EQ\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TARGET (parites)       | Angluin       |    4 |    3 |      12 |    19 |   2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TARGET (parites)       | Maler-Pnueli  |    4 |    3 |      12 |    19 |   2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L_5 (longueur % 5)     | Angluin       |    6 |    4 |      24 |    34 |   2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L_5 (longueur % 5)     | Maler-Pnueli  |    5 |    6 |      30 |    41 |   2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lecture : les deux variantes echangent |S| contre |E|. Angluin ajoute des\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PREFIXES a S ; Maler-Pnueli ajoute des SUFFIXES a E. La compacite globale\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n'avantage aucune des deux variantes en general.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple guide 3 : Variante de traitement du contre-exemple (suffixes vs prefixes)\n",
+    "// L* variante Maler-Pnueli : integre le contre-exemple par ses SUFFIXES (ajoutes a E).\n",
+    "(Dfa hyp, ObservationTable table, int nEq) LstarSuffixes(IEnumerable<char> alphabet, Func<string, bool> mq,\n",
+    "                                                          Func<Dfa, string> eq, bool verbose = false)\n",
+    "{\n",
+    "    var tbl = new ObservationTable(alphabet, mq);\n",
+    "    int nEq = 0;\n",
+    "    while (true)\n",
+    "    {\n",
+    "        while (true)\n",
+    "        {\n",
+    "            var sa = tbl.FindUnclosed();\n",
+    "            if (sa != null) { tbl.S.Add(sa); tbl.Fill(); continue; }\n",
+    "            var ae = tbl.FindInconsistency();\n",
+    "            if (ae != null) { tbl.E.Add(ae); tbl.Fill(); continue; }\n",
+    "            break;\n",
+    "        }\n",
+    "        var hyp = Conjecture(tbl);\n",
+    "        nEq++;\n",
+    "        var cex = eq(hyp);\n",
+    "        if (cex == null) return (hyp, tbl, nEq);\n",
+    "        // 3. Maler-Pnueli : ajouter les SUFFIXES cex[i:] du contre-exemple a E\n",
+    "        for (int i = 0; i < cex.Length; i++)\n",
+    "        {\n",
+    "            var suf = cex[i..];\n",
+    "            if (!tbl.E.Contains(suf)) tbl.E.Add(suf);\n",
+    "        }\n",
+    "        tbl.Fill();\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Deuxieme langage de comparaison : L_5 = mots de longueur divisible par 5.\n",
+    "var l5Delta = new List<((string, char), string)>();\n",
+    "for (int q = 0; q < 5; q++) foreach (var a in ALPHABET) l5Delta.Add(((q.ToString(), a), ((q + 1) % 5).ToString()));\n",
+    "Dfa L5 = new Dfa(Enumerable.Range(0, 5).Select(i => i.ToString()), ALPHABET, l5Delta, \"0\", new[] { \"0\" });\n",
+    "\n",
+    "// Etape 2 : comparaison prefixes (Angluin) vs suffixes (Maler-Pnueli)\n",
+    "Console.WriteLine(\"Comparaison Angluin (prefixes -> S) vs Maler-Pnueli (suffixes -> E)\");\n",
+    "Console.WriteLine(new string('=', 70));\n",
+    "Console.WriteLine($\"{\"Langage\",-22} | {\"Variante\",-13} | {\"|S|\",4} | {\"|E|\",4} | {\"|S|x|E|\",7} | {\"MQ\",5} | {\"EQ\",3}\");\n",
+    "Console.WriteLine(new string('-', 70));\n",
+    "var langages = new (string nom, Func<string, bool> mq, Dfa tgt)[]\n",
+    "{\n",
+    "    (\"TARGET (parites)\", MembershipQuery, TARGET),\n",
+    "    (\"L_5 (longueur % 5)\", L5.Accepts, L5),\n",
+    "};\n",
+    "foreach (var (nom, mq, tgt) in langages)\n",
+    "{\n",
+    "    Func<Dfa, string> eq = h => FindCounterexample(h, tgt, ALPHABET);\n",
+    "    foreach (var (variante, runner) in new (string, Func<IEnumerable<char>, Func<string, bool>, Func<Dfa, string>, bool, (Dfa, ObservationTable, int)>)[]\n",
+    "    {\n",
+    "        (\"Angluin\", (a, m, e, v) => Lstar(a, m, e, v)),\n",
+    "        (\"Maler-Pnueli\", (a, m, e, v) => LstarSuffixes(a, m, e, v)),\n",
+    "    })\n",
+    "    {\n",
+    "        var (h, tbl, nEq) = runner(ALPHABET, mq, eq, false);\n",
+    "        int taille = tbl.S.Count * tbl.E.Count;\n",
+    "        Console.WriteLine($\"{nom,-22} | {variante,-13} | {tbl.S.Count,4} | {tbl.E.Count,4} | {taille,7} | {tbl.NMq,5} | {nEq,3}\");\n",
+    "    }\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Lecture : les deux variantes echangent |S| contre |E|. Angluin ajoute des\");\n",
+    "Console.WriteLine(\"PREFIXES a S ; Maler-Pnueli ajoute des SUFFIXES a E. La compacite globale\");\n",
+    "Console.WriteLine(\"n'avantage aucune des deux variantes en general.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97779ae6",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 (variation) : Variante Rivest-Schapire (un seul suffixe, par dichotomie)\n",
+    "\n",
+    "Angluin ajoute **tous** les prefixes, Maler-Pnueli **tous** les suffixes. La variante de Rivest-Schapire (1993) est plus parcimonieuse : par **recherche dichotomique** sur le contre-exemple, elle identifie **un seul** suffixe distinguant et l'ajoute a `E`. Implementez cette recherche.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Soit un contre-exemple `c` ou l'hypothese et la cible differentent : trouvez par dichotomie un indice `i` tel que le suffixe `c[i:]` separe la ligne d'acces correspondante de celle de la cible\n",
+    "2. Ajoutez ce **seul** suffixe `c[i:]` a `E` (pas tous les suffixes)\n",
+    "3. Comparez le nombre total de MQ avec la variante Maler-Pnueli (tous les suffixes) sur `TARGET` : Rivest ajoute-t-il moins de colonnes ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6fcf565b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:57.301274Z",
+     "iopub.status.busy": "2026-07-07T07:52:57.301084Z",
+     "iopub.status.idle": "2026-07-07T07:52:57.345383Z",
+     "shell.execute_reply": "2026-07-07T07:52:57.345231Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : variante Rivest-Schapire (un seul suffixe par dichotomie)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 1 : ecrivez SuffixeDistinguantRivest(table, cex) (recherche dichotomique)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 2 : ecrivez LstarRivest (copie de LstarSuffixes, ajout d'un seul suffixe)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 3 : comparez n_mq et |E| avec Maler-Pnueli sur TARGET\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 3 (variation) : variante Rivest-Schapire (un seul suffixe par dichotomie)\n",
+    "// TODO etudiant : au lieu d'ajouter TOUS les suffixes du contre-exemple a E,\n",
+    "// n'en ajouter qu'UN, trouve par recherche dichotomique.\n",
+    "Console.WriteLine(\"Exercice a completer : variante Rivest-Schapire (un seul suffixe par dichotomie)\");\n",
+    "Console.WriteLine(\"Etape 1 : ecrivez SuffixeDistinguantRivest(table, cex) (recherche dichotomique)\");\n",
+    "Console.WriteLine(\"Etape 2 : ecrivez LstarRivest (copie de LstarSuffixes, ajout d'un seul suffixe)\");\n",
+    "Console.WriteLine(\"Etape 3 : comparez n_mq et |E| avec Maler-Pnueli sur TARGET\");\n",
+    "// Indice : la dichotomie exploite le fait que si la ligne d'acces hypothese != cible\n",
+    "// mais coincide a un certain decalage, il existe un point de bascule i ; cex[i:] est\n",
+    "// le suffixe cherche. O(log|cex|) ajout au lieu de |cex|.\n",
+    "// Etape 1 : string SuffixeDistinguantRivest(ObservationTable table, string cex) { ... }\n",
+    "// Etape 2 : (Dfa, ObservationTable, int) LstarRivest(...) { ... }   (copie LstarSuffixes)\n",
+    "// Etape 3 : comparer n_mq et |E| avec Maler-Pnueli sur TARGET\n",
+    "Dfa learnedRivest = null;  // TODO etudiant : le DFA appris par LstarRivest\n",
+    "Console.WriteLine($\"Resultat : {(learnedRivest == null ? \"(a completer)\" : learnedRivest.ToString())}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e241fc91",
+   "metadata": {},
+   "source": [
+    "Dernier exercice : la robustesse. Tous les algorithmes de la serie rencontrent\n",
+    "tot ou tard cette question, et la reponse de L* est singuliere.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "4df712b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:57.346491Z",
+     "iopub.status.busy": "2026-07-07T07:52:57.346325Z",
+     "iopub.status.idle": "2026-07-07T07:52:57.540905Z",
+     "shell.execute_reply": "2026-07-07T07:52:57.540703Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Oracle d'appartenance bruite : comportement de L* (cible TARGET = 4 etats)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "p=0.05 :  8 etats | max_rounds |  2 EQ | ecart (contre-ex abb)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "p=0.01 :  4 etats | max_rounds |  3 EQ | EXACT vs TARGET\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "p=0.20 : 40 etats | max_rounds |  3 EQ | ecart (contre-ex aaaa)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lecture : le resultat n'est PAS monotone en p -- il depend de QUELS mots\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "l'oracle ment. Un apprenant EXACT comme L* n'a AUCUNE degradation gracieuse\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "face au bruit : un seul mensonge memorise dans T cree un etat fantome permanent.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exemple guide 4 : Oracle d'appartenance bruite\n",
+    "// Oracle qui MENT avec probabilite p, de facon DETERMINISTE par mot (memoire par mot).\n",
+    "Func<string, bool> MakeNoisyMq(Func<string, bool> trueMq, double p = 0.05, int seed = 0)\n",
+    "{\n",
+    "    var rng = new Random(seed);\n",
+    "    var cache = new Dictionary<string, bool>();\n",
+    "    bool Noisy(string word)\n",
+    "    {\n",
+    "        if (!cache.ContainsKey(word))\n",
+    "        {\n",
+    "            bool truth = trueMq(word);\n",
+    "            bool lie = rng.NextDouble() < p;\n",
+    "            cache[word] = lie ? !truth : truth;\n",
+    "        }\n",
+    "        return cache[word];\n",
+    "    }\n",
+    "    return Noisy;\n",
+    "}\n",
+    "\n",
+    "// L* borne : evite la boucle infinie si mq est inconsistant (oracle bruite).\n",
+    "(Dfa hyp, ObservationTable table, int nEq, bool stable) LstarBounded(IEnumerable<char> alphabet, Func<string, bool> mq,\n",
+    "                                                                     Func<Dfa, string> eq, int maxRounds = 8, int maxSteps = 60)\n",
+    "{\n",
+    "    var tbl = new ObservationTable(alphabet, mq);\n",
+    "    int nEq = 0;\n",
+    "    Dfa hyp = null;\n",
+    "    for (int round = 1; round <= maxRounds; round++)\n",
+    "    {\n",
+    "        int steps = 0;\n",
+    "        while (true)\n",
+    "        {\n",
+    "            var sa = tbl.FindUnclosed();\n",
+    "            if (sa != null) { tbl.S.Add(sa); tbl.Fill(); }\n",
+    "            else\n",
+    "            {\n",
+    "                var ae = tbl.FindInconsistency();\n",
+    "                if (ae != null) { tbl.E.Add(ae); tbl.Fill(); }\n",
+    "                else break;\n",
+    "            }\n",
+    "            steps++;\n",
+    "            if (steps > maxSteps) break;\n",
+    "        }\n",
+    "        if (tbl.FindUnclosed() != null || tbl.FindInconsistency() != null)\n",
+    "            return (hyp, tbl, nEq, false);   // non-stabilise\n",
+    "        hyp = Conjecture(tbl);\n",
+    "        nEq++;\n",
+    "        var cex = eq(hyp);\n",
+    "        if (cex == null) return (hyp, tbl, nEq, true);\n",
+    "        for (int i = 1; i <= cex.Length; i++)\n",
+    "            if (!tbl.S.Contains(cex[..i])) tbl.S.Add(cex[..i]);\n",
+    "        tbl.Fill();\n",
+    "    }\n",
+    "    return (hyp, tbl, nEq, false);\n",
+    "}\n",
+    "\n",
+    "// Etape 2 : L* borne sous oracle bruite, pour p = 0.05, 0.01, 0.20\n",
+    "Console.WriteLine(\"Oracle d'appartenance bruite : comportement de L* (cible TARGET = 4 etats)\");\n",
+    "Console.WriteLine(new string('=', 66));\n",
+    "foreach (var p in new[] { 0.05, 0.01, 0.20 })\n",
+    "{\n",
+    "    var noisy = MakeNoisyMq(MembershipQuery, p, seed: 0);\n",
+    "    var eqNoisy = MakeSamplingEq(noisy, ALPHABET, 300, seed: 1);\n",
+    "    var (hyp, _tbl, nEq, stable) = LstarBounded(ALPHABET, noisy, eqNoisy, maxRounds: 8);\n",
+    "    if (hyp == null) { Console.WriteLine($\"p={p.ToString(\"F2\", CultureInfo.InvariantCulture),4} : NON-STABILISE apres {nEq} conjectures\"); continue; }\n",
+    "    var cexReal = FindCounterexample(hyp, TARGET, ALPHABET);\n",
+    "    bool exact = cexReal == null;\n",
+    "    string statut = stable ? \"stable\" : \"max_rounds\";\n",
+    "    string verdict = exact ? \"EXACT vs TARGET\" : \"ecart (contre-ex \" + cexReal + \")\";\n",
+    "    Console.WriteLine($\"p={p.ToString(\"F2\", CultureInfo.InvariantCulture),4} : {hyp.StateCount,2} etats | {statut,10} | {nEq,2} EQ | {verdict}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Lecture : le resultat n'est PAS monotone en p -- il depend de QUELS mots\");\n",
+    "Console.WriteLine(\"l'oracle ment. Un apprenant EXACT comme L* n'a AUCUNE degradation gracieuse\");\n",
+    "Console.WriteLine(\"face au bruit : un seul mensonge memorise dans T cree un etat fantome permanent.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54d65cbf",
+   "metadata": {},
+   "source": [
+    "### Exercice 4 (variation) : Robustesse par vote majoritaire\n",
+    "\n",
+    "Le bruit de l'oracle d'appartenance casse l'hypothese d'exactitude de L*. La parade classique : pour chaque mot, poser la requete `K` fois a l'oracle bruite et garder la **reponse majoritaire** (le vrai verdict ressort des que `K` est grand devant le taux de mensonges). Implementez ce `robust_mq` et montrez qu'il permet a L* de retrouver le DFA exact.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Ecrire `make_robust_mq(noisy_mq, K)` : pour chaque mot, echantillonne `K` reponses bruitees et renvoie la majorite (memoire par mot, comme le bruite)\n",
+    "2. Lancer `lstar_bounded` avec `robust_mq` (K=21) sur un oracle bruite a p=0.05\n",
+    "3. Le DFA appris est-il exact vs `TARGET` ? Quel `K` minimal suffit pour p=0.05 ? pour p=0.20 ?\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c7ebae7b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:57.542288Z",
+     "iopub.status.busy": "2026-07-07T07:52:57.542083Z",
+     "iopub.status.idle": "2026-07-07T07:52:57.585341Z",
+     "shell.execute_reply": "2026-07-07T07:52:57.585150Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : robustesse par vote majoritaire\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 1 : ecrivez MakeRobustMq(noisyMq, K) (vote majoritaire par mot)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 2 : lancez LstarBounded avec robustMq (K=21) sur un bruite p=0.05\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etape 3 : le DFA est-il exact vs TARGET ? K minimal pour p=0.05 ? p=0.20 ?\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat : (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 4 (variation) : robustesse par vote majoritaire\n",
+    "// TODO etudiant : diluez le bruit en posant K fois chaque requete et en gardant la majorite.\n",
+    "Console.WriteLine(\"Exercice a completer : robustesse par vote majoritaire\");\n",
+    "Console.WriteLine(\"Etape 1 : ecrivez MakeRobustMq(noisyMq, K) (vote majoritaire par mot)\");\n",
+    "Console.WriteLine(\"Etape 2 : lancez LstarBounded avec robustMq (K=21) sur un bruite p=0.05\");\n",
+    "Console.WriteLine(\"Etape 3 : le DFA est-il exact vs TARGET ? K minimal pour p=0.05 ? p=0.20 ?\");\n",
+    "// Indice : le vote majoritaire marche seulement si chaque appel bruite est INDEPENDANT.\n",
+    "// Il faut un oracle bruite NON memoise pour que K tirages soient independants.\n",
+    "// Etape 1 : Func<string,bool> MakeRobustMq(Func<string,bool> noisy, int K) { ... }\n",
+    "// Etape 2 : var robust = MakeRobustMq(noisy, 21); var (h,_,_,_) = LstarBounded(ALPHABET, robust, eqR, maxRounds:15);\n",
+    "// Etape 3 : exact vs TARGET ; K minimal\n",
+    "Dfa learnedRobust = null;  // TODO etudiant : le DFA robuste appris\n",
+    "Console.WriteLine($\"Resultat : {(learnedRobust == null ? \"(a completer)\" : learnedRobust.ToString())}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4fca3db",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 9. Pont vers Infer.NET : du DFA exact a la reconnaissance probabiliste de motifs\n",
+    "\n",
+    "Les sections 6 et 7 ont etabli le talon d'Achille de L* : il est *exact* et donc\n",
+    "*fragile*. L'exemple guide 4 (oracle d'appartenance bruite) l'a montre nettement\n",
+    "-- un seul mensonge memorise dans la table T cree un etat fantome permanent --\n",
+    "et concluait par une promesse :\n",
+    "\n",
+    "> un apprenant EXACT comme L* n'a aucune degradation gracieuse face au bruit, la\n",
+    "> ou un classifieur statistique se degrade *smoothment* (loi des grands nombres).\n",
+    "\n",
+    "Cette section construit ce classifieur statistique, et montre qu'il est le\n",
+    "pendant probabiliste exact de l'automate appris par L*. C'est le pont vers la\n",
+    "**programmation probabiliste sur sequences** d'Infer.NET (serie `Probas/Infer`).\n",
+    "\n",
+    "### Le changement de modele\n",
+    "\n",
+    "| | Automate exact (L*) | Chaine probabiliste (Infer.NET) |\n",
+    "|---|---|---|\n",
+    "| Objet | DFA deterministe | automate *pondere* / HMM |\n",
+    "| Verdict | `accepte` / `rejette` (binaire) | `P(accepte)` (probabilite calibree) |\n",
+    "| Bruit | aucun modele -- un mensonge = une verite | modele de canal explicite (`epsilon`) |\n",
+    "| Inference | parcours d'etat | algorithme *forward* (somme-produit) |\n",
+    "\n",
+    "Au lieu d'un oracle qui *ment* sur l'appartenance (section 6), on adopte le\n",
+    "cadre naturel de la reconnaissance de motifs : un **canal d'observation bruite**\n",
+    "sur les symboles eux-memes (pensez OCR, parole, capteurs). Le mot vrai `w` passe\n",
+    "dans un canal qui retourne chaque symbole correct avec probabilite `1 - epsilon`\n",
+    "et le corrompt avec probabilite `epsilon`. On observe `w` *abime* et l'on cherche\n",
+    "`P(w vrai appartient au langage | observation)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "6495c484",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:57.586713Z",
+     "iopub.status.busy": "2026-07-07T07:52:57.586503Z",
+     "iopub.status.idle": "2026-07-07T07:52:57.697818Z",
+     "shell.execute_reply": "2026-07-07T07:52:57.697629Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Coherence epsilon=0 : le forward redonne le verdict exact du DFA. OK\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mot vrai w = 'aabb'  (appartient a L ? True)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epsilon | P(accepte | obs) | lecture\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   0.00 |            1.000 | certain\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   0.05 |            0.828 | penche accepte\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   0.10 |            0.705 | penche accepte\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   0.20 |            0.565 | penche accepte\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   0.35 |            0.504 | penche accepte\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Reconnaissance probabiliste : l'algorithme forward sur les etats du DFA.\n",
+    "// alpha_t[q] = masse des prefixes vrais finissant dans l'etat q, sachant o_1..o_t.\n",
+    "double ForwardAcceptProb(Dfa dfa, string observed, double epsilon)\n",
+    "{\n",
+    "    var A = dfa.Alphabet;\n",
+    "    int m = A.Count;\n",
+    "    double pFlip = m > 1 ? epsilon / (m - 1) : 0.0;   // masse repartie sur les mauvais symboles\n",
+    "    var alpha = dfa.States.ToDictionary(q => q, q => q == dfa.Start ? 1.0 : 0.0);\n",
+    "    foreach (var o in observed)\n",
+    "    {\n",
+    "        var nxt = dfa.States.ToDictionary(q => q, q => 0.0);\n",
+    "        foreach (var (q, mass) in alpha)\n",
+    "        {\n",
+    "            if (mass == 0.0) continue;\n",
+    "            foreach (var s in A)\n",
+    "            {\n",
+    "                double lik = s == o ? 1.0 - epsilon : pFlip;   // P(observer o | vrai s)\n",
+    "                nxt[dfa.Delta[(q, s)]] += mass * (1.0 / m) * lik;\n",
+    "            }\n",
+    "        }\n",
+    "        double Z = alphaSum(nxt);\n",
+    "        foreach (var q in dfa.States) nxt[q] = Z > 0 ? nxt[q] / Z : 0.0;\n",
+    "        alpha = nxt;\n",
+    "    }\n",
+    "    double Ztot = alphaSum(alpha);\n",
+    "    return Ztot > 0 ? dfa.Accepting.Sum(q => alpha[q]) / Ztot : 0.0;\n",
+    "}\n",
+    "double alphaSum(Dictionary<string, double> d) => d.Values.Sum();\n",
+    "\n",
+    "// Garde-fou : a epsilon = 0, le canal est parfait -> le forward redonne le verdict exact.\n",
+    "foreach (var w in new[] { \"\", \"a\", \"ab\", \"aabb\", \"abab\", \"aab\", \"bbaa\", \"abba\" })\n",
+    "{\n",
+    "    double p0 = ForwardAcceptProb(TARGET, w, 0.0);\n",
+    "    bool mq = MembershipQuery(w);\n",
+    "    if ((p0 > 0.5) != mq || Math.Abs(p0 - (mq ? 1.0 : 0.0)) > 1e-9)\n",
+    "        Console.WriteLine($\"ECHEC coherence epsilon=0 sur {w}\");\n",
+    "}\n",
+    "Console.WriteLine(\"Coherence epsilon=0 : le forward redonne le verdict exact du DFA. OK\\n\");\n",
+    "\n",
+    "string trueW = \"aabb\";\n",
+    "Console.WriteLine($\"Mot vrai w = '{trueW}'  (appartient a L ? {MembershipQuery(trueW)})\");\n",
+    "Console.WriteLine($\"{\"epsilon\",7} | {\"P(accepte | obs)\",16} | lecture\");\n",
+    "Console.WriteLine(new string('-', 52));\n",
+    "foreach (var eps in new[] { 0.0, 0.05, 0.10, 0.20, 0.35 })\n",
+    "{\n",
+    "    double p = ForwardAcceptProb(TARGET, trueW, eps);\n",
+    "    string note = p > 0.95 ? \"certain\" : (p > 0.5 ? \"penche accepte\" : \"doute\");\n",
+    "    Console.WriteLine($\"{eps.ToString(\"F2\", CultureInfo.InvariantCulture),7} | {p.ToString(\"F3\", CultureInfo.InvariantCulture),16} | {note}\");\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "267d40d8",
+   "metadata": {},
+   "source": [
+    "### Lecture : une probabilite calibree, pas un meilleur verdict\n",
+    "\n",
+    "A partir d'**une seule** observation, la decision a seuil 0.5 du recognizer\n",
+    "probabiliste coincide avec le parcours dur du DFA sur l'observation : pour\n",
+    "`epsilon < 0.5`, le symbole le plus probable reste celui observe. Ce que le\n",
+    "modele probabiliste apporte d'emblee n'est donc pas une meilleure *exactitude*\n",
+    "sur un coup, mais une **confiance calibree** : `P(accepte)` glisse *doucement*\n",
+    "vers 0.5 quand le bruit monte -- jamais le basculement catastrophique de L*, qui\n",
+    "construisait un automate faux. La degradation est gracieuse.\n",
+    "\n",
+    "Le vrai gain d'exactitude vient quand on dispose de **plusieurs** observations\n",
+    "bruitees du meme mot (plusieurs lectures OCR, plusieurs trames audio). C'est la\n",
+    "version probabiliste -- et correcte -- du vote majoritaire de l'exercice 4.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "52072e9a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:57.699208Z",
+     "iopub.status.busy": "2026-07-07T07:52:57.699011Z",
+     "iopub.status.idle": "2026-07-07T07:52:59.121647Z",
+     "shell.execute_reply": "2026-07-07T07:52:59.003602Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recuperation par agregation de k observations (n=3000 mots) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " k obs | dur (1 obs) | forward (k obs)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     1 |       0.784 | eps=.20 0.784  eps=.30 0.788\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     3 |       0.782 | eps=.20 0.827  eps=.30 0.795\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     5 |       0.774 | eps=.20 0.866  eps=.30 0.793\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     9 |       0.782 | eps=.20 0.944  eps=.30 0.832\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    15 |       0.806 | eps=.20 0.985  eps=.30 0.882\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    25 |       0.795 | eps=.20 0.998  eps=.30 0.954\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recuperation par evidence (ASCII) : exactitude vs nombre d'observations k\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exact 1.00 +\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "O"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "O"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "O"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "O"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "O"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       |"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exact 0.70 +----------------------------------------------  k -> 25\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "O = forward eps=0.20 ; X = forward eps=0.30 ; - = plafond DFA dur (1 obs).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Agregation de preuves : k observations independantes du meme mot vrai.\n",
+    "double ForwardAcceptProbMulti(Dfa dfa, List<string> observations, double epsilon)\n",
+    "{\n",
+    "    var A = dfa.Alphabet;\n",
+    "    int m = A.Count;\n",
+    "    double pFlip = m > 1 ? epsilon / (m - 1) : 0.0;\n",
+    "    int T = observations[0].Length;\n",
+    "    var alpha = dfa.States.ToDictionary(q => q, q => q == dfa.Start ? 1.0 : 0.0);\n",
+    "    for (int i = 0; i < T; i++)\n",
+    "    {\n",
+    "        var column = observations.Select(o => o[i]).ToList();\n",
+    "        var nxt = dfa.States.ToDictionary(q => q, q => 0.0);\n",
+    "        foreach (var (q, mass) in alpha)\n",
+    "        {\n",
+    "            if (mass == 0.0) continue;\n",
+    "            foreach (var s in A)\n",
+    "            {\n",
+    "                double lik = 1.0;\n",
+    "                foreach (var oI in column) lik *= s == oI ? 1.0 - epsilon : pFlip;\n",
+    "                nxt[dfa.Delta[(q, s)]] += mass * (1.0 / m) * lik;\n",
+    "            }\n",
+    "        }\n",
+    "        double Z = nxt.Values.Sum(); if (Z == 0) Z = 1.0;\n",
+    "        foreach (var q in dfa.States) nxt[q] /= Z;\n",
+    "        alpha = nxt;\n",
+    "    }\n",
+    "    double Ztot = alpha.Values.Sum();\n",
+    "    return Ztot > 0 ? dfa.Accepting.Sum(q => alpha[q]) / Ztot : 0.0;\n",
+    "}\n",
+    "\n",
+    "string Corrupt(string word, double eps, Random rng)\n",
+    "{\n",
+    "    var sb = new StringBuilder();\n",
+    "    foreach (var c in word) sb.Append(rng.NextDouble() >= eps ? c : (c == 'a' ? 'b' : 'a'));\n",
+    "    return sb.ToString();\n",
+    "}\n",
+    "\n",
+    "(double hard1, double probK) BatchAccuracy(double eps, int k, int nWords = 3000, int seed = 7)\n",
+    "{\n",
+    "    var rng = new Random(seed);\n",
+    "    int hard1 = 0, probK = 0;\n",
+    "    for (int _ = 0; _ < nWords; _++)\n",
+    "    {\n",
+    "        int len = rng.Next(0, 13);\n",
+    "        var sb = new StringBuilder();\n",
+    "        for (int i = 0; i < len; i++) sb.Append(ALPHABET[rng.Next(ALPHABET.Count)]);\n",
+    "        var w = sb.ToString();\n",
+    "        bool y = MembershipQuery(w);\n",
+    "        var obs = new List<string>();\n",
+    "        for (int j = 0; j < k; j++) obs.Add(Corrupt(w, eps, rng));\n",
+    "        if (TARGET.Accepts(obs[0]) == y) hard1++;\n",
+    "        if ((ForwardAcceptProbMulti(TARGET, obs, eps) > 0.5) == y) probK++;\n",
+    "    }\n",
+    "    return ((double)hard1 / nWords, (double)probK / nWords);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Recuperation par agregation de k observations (n=3000 mots) :\");\n",
+    "Console.WriteLine($\"{\"k obs\",6} | {\"dur (1 obs)\",11} | {\"forward (k obs)\",15}\");\n",
+    "Console.WriteLine(new string('-', 40));\n",
+    "var ks = new[] { 1, 3, 5, 9, 15, 25 };\n",
+    "var curve20 = new List<double>(); var curve30 = new List<double>(); double hardRef = 0;\n",
+    "foreach (var k in ks)\n",
+    "{\n",
+    "    var (h20, p20) = BatchAccuracy(0.20, k);\n",
+    "    var (_h30, p30) = BatchAccuracy(0.30, k);\n",
+    "    curve20.Add(p20); curve30.Add(p30); hardRef = h20;\n",
+    "    Console.WriteLine($\"{k,6} | {h20.ToString(\"F3\", CultureInfo.InvariantCulture),11} | eps=.20 {p20.ToString(\"F3\", CultureInfo.InvariantCulture)}  eps=.30 {p30.ToString(\"F3\", CultureInfo.InvariantCulture)}\");\n",
+    "}\n",
+    "\n",
+    "// Visualisation ASCII : exactitude vs k (forward eps=.20 / eps=.30 + plafond DFA dur).\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Recuperation par evidence (ASCII) : exactitude vs nombre d'observations k\");\n",
+    "int W = 46, H = 14;\n",
+    "char[,] g = new char[H, W];\n",
+    "for (int y = 0; y < H; y++) for (int x = 0; x < W; x++) g[y, x] = ' ';\n",
+    "Action<List<double>, char> Plot = (curve, mark) =>\n",
+    "{\n",
+    "    for (int i = 0; i < curve.Count; i++)\n",
+    "    {\n",
+    "        int x = (int)Math.Round((double)i / (curve.Count - 1) * (W - 1));\n",
+    "        int y = (int)Math.Round((1.0 - curve[i]) * (H - 1) / 0.3);  // plage 0.70-1.00\n",
+    "        if (y >= 0 && y < H) g[y, x] = mark;\n",
+    "    }\n",
+    "};\n",
+    "Plot(curve20, 'O'); Plot(curve30, 'X');\n",
+    "int yRef = (int)Math.Round((1.0 - hardRef) * (H - 1) / 0.3);\n",
+    "if (yRef >= 0 && yRef < H) for (int x = 0; x < W; x++) if (g[yRef, x] == ' ') g[yRef, x] = '-';\n",
+    "Console.WriteLine($\"exact {1.0.ToString(\"F2\", CultureInfo.InvariantCulture)} +\");\n",
+    "for (int y = 0; y < H; y++) { Console.Write(\"       |\"); for (int x = 0; x < W; x++) Console.Write(g[y, x]); Console.WriteLine(); }\n",
+    "Console.WriteLine($\"exact {0.7.ToString(\"F2\", CultureInfo.InvariantCulture)} +{new string('-', W)}  k -> {ks.Last()}\");\n",
+    "Console.WriteLine(\"O = forward eps=0.20 ; X = forward eps=0.30 ; - = plafond DFA dur (1 obs).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f60d94a5",
+   "metadata": {},
+   "source": [
+    "### Le pont : Infer.NET fait exactement cela, automatiquement\n",
+    "\n",
+    "Trois faits reunis ferment la boucle :\n",
+    "\n",
+    "1. **L'algorithme forward est du passage de messages.** La recursion\n",
+    "   `alpha_t[q'] = somme ...` est l'algorithme *somme-produit* sur le graphe de\n",
+    "   facteurs en chaine `etat_0 -- etat_1 -- ... -- etat_T`. C'est le meme moteur\n",
+    "   qui calcule les marginales d'un HMM.\n",
+    "\n",
+    "2. **Infer.NET (Microsoft Research) automatise ce passage de messages.** On y\n",
+    "   *declare* le modele generatif -- un mot vrai tire d'un prior, un canal qui le\n",
+    "   bruite, des observations -- et le moteur infere la posterieure. Surtout,\n",
+    "   Infer.NET sait raisonner directement sur des **distributions de sequences**\n",
+    "   (`StringDistribution`), c'est-a-dire des **automates ponderes** : la version\n",
+    "   probabiliste *native* du DFA que L* apprend.\n",
+    "\n",
+    "3. **C'est la synthese neuro-symbolique de la serie.** L* fournit la *structure*\n",
+    "   exacte (l'automate minimal, garanti) ; Infer.NET l'enveloppe d'une *inference*\n",
+    "   statistique robuste au bruit. Structure symbolique + inference probabiliste :\n",
+    "   ni l'exactitude fragile seule, ni le tout-statistique opaque.\n",
+    "\n",
+    "### Ou continuer dans le depot\n",
+    "\n",
+    "| Notebook | Ce qu'il apporte au pont |\n",
+    "|----------|--------------------------|\n",
+    "| [`Probas/Infer/Infer-11-Sequences`](../../Probas/Infer/Infer-11-Sequences.ipynb) | distributions sur sequences = automates ponderes (le coeur du pont) |\n",
+    "| [`Probas/Infer-101`](../../Probas/Infer-101.ipynb) | prise en main d'Infer.NET (programmation probabiliste .NET) |\n",
+    "| [`Probas/Infer/Infer-3-Factor-Graphs`](../../Probas/Infer/Infer-3-Factor-Graphs.ipynb) | graphes de facteurs + passage de messages = le forward generalise |\n",
+    "| [`HMM Gaussian Alpha`](../../QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb) | le meme HMM gaussien, cote Python (hmmlearn) |\n",
+    "\n",
+    "### Pour aller plus loin (exercice du pont)\n",
+    "\n",
+    "Le canal ci-dessus est *symetrique* (meme `epsilon` dans les deux sens). Beaucoup\n",
+    "de capteurs reels sont *asymetriques* : confondre `a` en `b` est plus frequent\n",
+    "que l'inverse. Reprenez `forward_accept_prob` avec une matrice de confusion\n",
+    "`P(observe | vrai)` quelconque (2x2, lignes sommant a 1) au lieu du scalaire\n",
+    "`epsilon`, puis verifiez que la coherence canal-parfait (matrice identite =\n",
+    "verdict exact) tient toujours. Indice : seule la ligne `lik = ...` change.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "ea12aa8d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T07:52:59.123886Z",
+     "iopub.status.busy": "2026-07-07T07:52:59.123503Z",
+     "iopub.status.idle": "2026-07-07T07:52:59.176847Z",
+     "shell.execute_reply": "2026-07-07T07:52:59.176643Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice du pont : generalisez ForwardAcceptProb a une matrice de confusion.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice du pont : canal d'observation ASYMETRIQUE (matrice de confusion).\n",
+    "// confusion[(vrai, observe)] = P(observer 'observe' | vrai symbole 'vrai').\n",
+    "double ForwardAcceptProbConfusion(Dfa dfa, string observed, Dictionary<(char, char), double> confusion)\n",
+    "{\n",
+    "    // Indice : recopier ForwardAcceptProb et remplacer la ligne\n",
+    "    //   lik = (1 - epsilon) if s == o else p_flip\n",
+    "    // par\n",
+    "    //   lik = confusion[(s, o)]\n",
+    "    // TODO etudiant : implementer la passe forward avec la matrice de confusion.\n",
+    "    Console.WriteLine(\"Exercice du pont a completer : forward avec matrice de confusion.\");\n",
+    "    return 0.0;  // TODO etudiant : remplacer par la probabilite calculee\n",
+    "}\n",
+    "\n",
+    "// Verification attendue une fois implemente (canal parfait = identite -> verdict exact) :\n",
+    "// var identite = new Dictionary<(char,char),double>();\n",
+    "// foreach (var x in ALPHABET) foreach (var y in ALPHABET) identite[(x,y)] = x == y ? 1.0 : 0.0;\n",
+    "// foreach (var w in new[] { \"aabb\", \"aab\", \"abba\" }) {\n",
+    "//     double p = ForwardAcceptProbConfusion(TARGET, w, identite);\n",
+    "//     if ((p > 0.5) != MembershipQuery(w)) Console.WriteLine($\"ECHEC canal identite sur {w}\");\n",
+    "// }\n",
+    "Console.WriteLine(\"Exercice du pont : generalisez ForwardAcceptProb a une matrice de confusion.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd1249a2",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 10. Conclusion\n",
+    "\n",
+    "### Recapitulatif\n",
+    "\n",
+    "1. **Le modele MAT** (Angluin 1987) donne a l'apprenant le droit de poser des\n",
+    "   questions : appartenance (MQ) et equivalence (EQ). Ce droit change la classe de\n",
+    "   complexite du probleme --- l'inference passive du plus petit DFA consistant est\n",
+    "   NP-difficile, l'inference active est polynomiale.\n",
+    "\n",
+    "2. **La table d'observation** $(S, E, T)$ approxime la congruence de Myhill-Nerode\n",
+    "   avec un ensemble fini de suffixes distinguants. Fermeture et consistance sont\n",
+    "   les deux conditions pour qu'elle definisse un DFA.\n",
+    "\n",
+    "3. **L*** alterne stabilisation de la table, conjecture, et integration du\n",
+    "   contre-exemple. Chaque conjecture rejetee gagne au moins un etat : terminaison\n",
+    "   et minimalite sont garanties, en au plus $n$ equivalences.\n",
+    "\n",
+    "4. **L'oracle d'equivalence exact n'existe pas en pratique** : on echantillonne, et\n",
+    "   la garantie exacte devient garantie PAC. La fiabilite du resultat est plafonnee\n",
+    "   par celle du professeur.\n",
+    "\n",
+    "5. **Le model learning** industrialise tout cela (LearnLib, machines de Mealy,\n",
+    "   protocoles reels) --- et la variante moderne « LLM comme professeur, L* comme\n",
+    "   apprenant » re-applique la division du travail de SL-9.\n",
+    "\n",
+    "### Position dans la serie\n",
+    "\n",
+    "| Methode | Type | L'apprenant... | Garantie |\n",
+    "|---------|------|----------------|----------|\n",
+    "| Version Space (SL-1) | passif, symbolique | subit les exemples | convergence si realisable |\n",
+    "| FOIL (SL-4) | passif, relationnel | subit les exemples | heuristique (gain) |\n",
+    "| LTN (SL-7) | passif, neuro-symbolique | subit les exemples | satisfaction approchee |\n",
+    "| **L* (SL-10)** | **actif, symbolique** | **choisit ses questions** | **identification exacte, DFA minimal** |\n",
+    "\n",
+    "### Connexions\n",
+    "\n",
+    "| Direction | Sujet | Lien |\n",
+    "|-----------|-------|------|\n",
+    "| Prerequis | Espaces d'hypotheses, PAC | [SL-1](SL-1-LogicalLearning.ipynb), [SL-3](SL-3-RelevanceLearning.ipynb) |\n",
+    "| Suite | Resolution inverse, Progol | [SL-5](SL-5-InverseResolution.ipynb) |\n",
+    "| Capstone | LLM professeur / oracle symbolique | [SL-11](SL-11-Capstone-NeuroSymbolic.ipynb) |\n",
+    "| Pont probabiliste | Reconnaissance de sequences sous bruit | [Infer.NET](../../Probas/Infer-101.ipynb), [Infer-11-Sequences](../../Probas/Infer/Infer-11-Sequences.ipynb) |\n",
+    "| Automates & verification | Model checking | Serie SymbolicAI |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "617c6c79",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Defi presentation\n",
+    "\n",
+    "Modalite du cours : chaque groupe choisit **un exercice** de la serie, le prepare,\n",
+    "et le presente en seance. Resoudre l'exercice est le minimum ; ce qui distingue une\n",
+    "presentation qui maitrise le sujet, c'est la **question-twist** associee ci-dessous.\n",
+    "Elle fait partie integrante de la presentation attendue.\n",
+    "\n",
+    "| Exercice | Question-twist a traiter en plus |\n",
+    "|----------|----------------------------------|\n",
+    "| **Ex. 1 (langage 'abb')** | Verifiez que le DFA appris est *minimal* en exhibant, pour chaque paire d'etats, un suffixe qui les distingue (certificat de Myhill-Nerode). Pourquoi L* est-il structurellement incapable de retourner un DFA non minimal ? |\n",
+    "| **Ex. 2 (fiabilite de l'EQ)** | Reliez votre taux de reussite empirique a la borne PAC : combien d'echantillons la theorie exige-t-elle pour $\\varepsilon = 0.01, \\delta = 0.05$ ? Construisez une distribution de tirage qui fait echouer l'echantillonnage quel que soit $N$ raisonnable. |\n",
+    "| **Ex. 3 (prefixes vs suffixes)** | Exhibez le pire cas : une famille de langages ou les contre-exemples sont longs et ou la variante prefixes fait exploser $\\vert S\\vert $. La variante de Rivest-Schapire n'ajoute qu'UN suffixe trouve par dichotomie sur le contre-exemple : quel est son cout en MQ et pourquoi est-ce le bon compromis ? |\n",
+    "| **Ex. 4 (oracle bruite)** | Peut-on reparer L* par vote majoritaire (poser chaque MQ 2k+1 fois) ? Calculez le surcout en requetes et la probabilite residuelle d'erreur ; comparez avec la degradation *graduelle* d'un classifieur statistique sous le meme bruit. Que conclure sur le contrat exactitude-contre-robustesse du symbolique ? |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d8fda2e",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Ressources\n",
+    "\n",
+    "- D. Angluin, *Learning Regular Sets from Queries and Counterexamples*, Information and Computation 75(2), 1987\n",
+    "- M. Kearns & U. Vazirani, *An Introduction to Computational Learning Theory*, ch. 8 (MIT Press, 1994)\n",
+    "- F. Vaandrager, *Model Learning*, Communications of the ACM 60(2), 2017\n",
+    "- R. Rivest & R. Schapire, *Inference of Finite Automata Using Homing Sequences*, Information and Computation 103(2), 1993\n",
+    "- [LearnLib](https://learnlib.de/) --- bibliotheque de reference du model learning\n",
+    "- E. M. Gold, *Complexity of Automaton Identification from Given Data*, Information and Control 37, 1978\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Retour** : [Index SymbolicLearning](./README.md) | [<< SL-9](SL-9-LLM-SymbolicLearning.ipynb) | [SL-11 >>](SL-11-Capstone-NeuroSymbolic.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Ce que fait cette PR

Établit la parité .NET sur le notebook SL-10 de la série SymbolicLearning : **twin C#**
de `SL-10-ActiveAutomataLearning.ipynb` — l'algorithme **L\* d'Angluin** (apprentissage
actif d'automates finis) implémenté **from-scratch** en C# .NET 9 (BCL seule, **0 NuGet** —
Prong B du marathon parité #4956). Suite des twins SL-2/SL-3/SL-4/SL-5-Csharp déjà livrés.

## Contenu (17 cells code + 28 md, EXEC_PROVED 17/17)

1. **DFA + cible** : classe `Dfa` (états/alphabet/transitions/start/accepting, `Accepts`) ;
   langage cible = parité (nombre **pair** de `a` **ET** pair de `b`, 4 états), `MembershipQuery`
2. **Table d'observation** : `ObservationTable` (S/E/T, cache MQ, `Fill`, `Row` signature,
   `FindUnclosed`, `FindInconsistency`, `Show` ASCII) — fermeture et cohérence
3. **Conjecture + contre-exemple** : DFA construit depuis les lignes distinctes de S ;
   `FindCounterexample` par **BFS produit** des deux automates (plus court mot discriminant)
4. **L\*** : boucle de raffinement complète (stabiliser → conjecturer → EQ → intégrer les
   **préfixes** du contre-exemple dans S, Angluin 1987). Converge en 2 conjectures (4 états)
5. **Vérification exhaustive** : 2047/2047 mots (longueur ≤ 10) identiques au TARGET
6. **Myhill-Nerode empirique** + coût vs k (langage `L_k` divisible par k, croissance du #MQ)
7. **Oracle d'équivalence échantillonné (PAC)** + `FactorDfa` **KMP** du motif « aabbaabb »
   (9 états) : contraste désaccords **denses** (parité) vs **rares** (aiguille)
8. **Exemple guide 1** : « contient abb » — 4 états prédits (théorie) → 4 observés (confirmé)
9. **Exemple guide 2** : taux de fiabilité de l'oracle échantillonné (NEEDLE vs TARGET, 20 graines)
10. **Exemple guide 3** : variante **Maler-Pnueli** (suffixes → E) comparée à Angluin (préfixes → S)
11. **Exemple guide 4** : oracle d'appartenance **bruité** + `LstarBounded` (p = 0.05 / 0.01 / 0.20)
12. **Forward sum-product** : passe avant sur les états du DFA, canal symétrique, renormalisation
    anti-underflow ; garde-fou ε=0 redonne le verdict exact
13. **Agrégation d'évidence** : k observations indépendantes → courbe de récupération
    **0.78 → 0.998** (ε=0.20), **viz ASCII** autonome (pas de matplotlib)
14. **4 exercices C.1** (stubs `TODO etudiant` : contient-ba, fiabilité vs max_len,
    Rivest-Schapire dichotomie, vote majoritaire robuste)
15. **1 exercice du pont** : forward avec matrice de **confusion asymétrique** (pont vers Infer.NET)

## Vérification EXEC_PROVED

| Critère | Résultat |
|---------|----------|
| execution_count | 1..17 contigus OK |
| errors | 0 OK |
| path-leaks | 0 OK |
| emoji | 0 OK |
| warning/erreur CS | 0 OK |
| throw/assert/NotImplemented | 0 OK |
| exercices (TODO etudiant) | 5 OK (4 variations + 1 pont) |
| mermaid stateDiagram préservé | OK |
| lien parité twin Python | OK |
| CATALOG byte-identique | OK (R1) |
| .gitattributes `eol=lf` | OK (0 CR) |

## Valeur ajoutée du twin (parité .NET)

Le twin Python est en **Python pur** (aucune dépendance). Ce twin C# montre l'implémentation
from-scratch des mêmes algorithmes en **C# .NET 9 (BCL seule, 0 NuGet)** : `Dfa`, `ObservationTable`,
`Conjecture`, BFS produit pour le contre-exemple, les variantes Angluin/Maler-Pnueli, l'oracle
bruité borné, et l'algorithme **forward sum-product** avec agrégation d'évidence (le pont vers
Infer.NET reste conceptuel, comme dans le twin Python). La visualisation matplotlib est remplacée
par un rendu **ASCII autonome**. Les deux démontrent les **mêmes techniques** (MAT, requêtes
MQ/EQ, Myhill-Nerode, PAC, robustesse au bruit, agrégation probabiliste).

## Diffs

- nouveau notebook C# (45 cells) + README `+4 lignes` (ligne table `10 (C#)`, arbre fichiers,
  bloc Parité .NET dans la section détaillée SL-10 — convention alignée sur SL-2/SL-5-Csharp)
- CATALOG byte-identique (règle catalog-pr-hygiene R1)
- EOF : trailing newline LF, 0 CR (vérifié via `git cat-file blob | tr -cd '\r' | wc -c`)

See #4956

Généré avec Claude Code
