### PR TITLE
feat(gametheory): GameTheory-6c-RepeatedGames-FolkTheorem-Csharp -- twin C# (grim trigger, TFT, Folk Theorem) (Prong B from-scratch)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem-Csharp.ipynb
@@ -1,0 +1,1454 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "515c1c05",
+   "metadata": {},
+   "source": [
+    "<< [GameTheory-6-EvolutionTrust](GameTheory-6-EvolutionTrust.ipynb) | [Index GameTheory](README.md) | [GameTheory-7-ExtensiveForm](GameTheory-7-ExtensiveForm.ipynb) >>\n",
+    "\n",
+    "# GameTheory-6c (C#) : Jeux Repetes et Theoreme Folk\n",
+    "\n",
+    "**Serie** : GameTheory / approfondissement `c` (jumeau .NET du notebook Python [GameTheory-6c](GameTheory-6c-RepeatedGames-FolkTheorem.ipynb)).\n",
+    "\n",
+    "**Duree estimee** : ~1h\n",
+    "\n",
+    "**Prerequis** : [GameTheory-2-NormalForm](GameTheory-2-NormalForm.ipynb) (forme normale, equilibre de Nash), [GameTheory-4-NashEquilibrium](GameTheory-4-NashEquilibrium.ipynb), notions de C# / .NET.\n",
+    "\n",
+    "**Pourquoi un jumeau C# ?** Le notebook Python original s'appuie sur `numpy` (calcul matriciel, series geometriques) et `matplotlib` (visualisation de l'ensemble faisable). Ce jumeau reimplemente les memes objets mathematiques en **C# .NET 9 (BCL seule, 0 NuGet)** : le dilemme du prisonnier, la serie geometrique actualisee, les strategies `grim trigger` et `tit-for-tat`, le theoreme Folk. Les graphiques `matplotlib` sont remplaces par un rendu **ASCII autonome** de la region faisable et individuellement rationnelle. Les deux notebooks derivent les memes seuils (notamment `delta* = (T-R)/(T-P) = 0.5` pour le grim trigger).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88b009e0",
+   "metadata": {},
+   "source": [
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Formaliser** un jeu repete comme la repetition d'un jeu etape (le dilemme du prisonnier) avec un facteur d'escompte `delta`.\n",
+    "2. **Comprendre** pourquoi l'horizon fini detruit la cooperation (backward induction vers la defection perpetuelle), alors qu'un horizon infini la rend soutenable.\n",
+    "3. **Deriver** la condition de credibilite d'une stratégie de punition (`grim trigger`) et la comparer a une punition plus legere (`tit-for-tat`).\n",
+    "4. **Illustrer** le theoreme Folk : l'ensemble des paiements soutenables comme equilibres sous-game-parfaits coincide, pour `delta` assez proche de 1, avec la region faisable et individuellement rationnelle.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41ebe5c4",
+   "metadata": {},
+   "source": [
+    "## 1. Le jeu etape : Dilemme du Prisonnier\n",
+    "\n",
+    "On encode la matrice de gains du dilemme du prisonnier (convention d'Axelrod) : `T` (tentation), `R` (recompense de la cooperation), `P` (punition mutuelle), `S` (sucker). Les inegalites canoniques `T > R > P > S` et `2R > T+S` garantissent que `(D,D)` est l'unique equilibre de Nash, bien que `(C,C)` soit Pareto-optimal.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "255f59f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:45.398115Z",
+     "iopub.status.busy": "2026-07-07T08:59:45.386000Z",
+     "iopub.status.idle": "2026-07-07T08:59:46.606179Z",
+     "shell.execute_reply": "2026-07-07T08:59:46.602783Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:6701:5a41:8422:35ad:2048/\",\"http://2a01:e0a:9d4:f320:c111:2207:fe12:2b8b:2048/\",\"http://2a01:e0a:9d4:f320:e9d1:aca6:71b4:2cf1:2048/\",\"http://fe80::902b:f9f6:2003:66a1%18:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::ae60:2bbf:92f7:4e06%19:2048/\",\"http://172.24.224.1:2048/\",\"http://fe80::b5e6:392e:9c4:c699%44:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '27348.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gain joueur 1 (lignes=J1, colonnes=J2):\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [[3, 0]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   [5, 1]]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verif des inegalites du DP : T>R>P>S : True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verif 2R > T+S : True (2R=6, T+S=5)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equilibre de Nash du jeu etape : (D,D) -> paiement P = 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pareto-optimum cooperatif : (C,C) -> paiement R = 3\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Matrice des gains du Dilemme du Prisonnier (convention d'Axelrod).\n",
+    "// Lignes = joueur 1 (Cooperer=0, Defecter=1), colonnes = joueur 2 (Cooperer=0, Defecter=1).\n",
+    "double T = 5.0, R = 3.0, P = 1.0, S = 0.0;\n",
+    "\n",
+    "// A1[i,j] = gain du joueur 1 quand J1 joue i et J2 joue j\n",
+    "double[,] A1 = {\n",
+    "    { R, S },   // J1 coopere (ligne 0)\n",
+    "    { T, P }    // J1 defecte  (ligne 1)\n",
+    "};\n",
+    "// A2[i,j] = gain du joueur 2\n",
+    "double[,] A2 = {\n",
+    "    { R, T },   // J2 coopere (col 0)\n",
+    "    { S, P }    // J2 defecte (col 1)\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine(\"Gain joueur 1 (lignes=J1, colonnes=J2):\");\n",
+    "Console.WriteLine($\"  [[{A1[0,0]}, {A1[0,1]}]\");\n",
+    "Console.WriteLine($\"   [{A1[1,0]}, {A1[1,1]}]]\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Verif des inegalites du DP : T>R>P>S : {T > R && R > P && P > S}\");\n",
+    "Console.WriteLine($\"Verif 2R > T+S : {2*R > T+S} (2R={2*R}, T+S={T+S})\");\n",
+    "Console.WriteLine($\"Equilibre de Nash du jeu etape : (D,D) -> paiement P = {P}\");\n",
+    "Console.WriteLine($\"Pareto-optimum cooperatif : (C,C) -> paiement R = {R}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "235636b2",
+   "metadata": {},
+   "source": [
+    "## 2. Horizon fini : l'effondrement inevitable\n",
+    "\n",
+    "Sur un horizon fini de `N` tours (sans escompte, `delta = 1`), la cooperation est **non credible**. Par backward induction, le dernier tour est un jeu etape unique ou la defection domine ; sachant cela, l'avant-dernier tour aussi ; et ainsi de suite jusqu'au premier tour. L'unique equilibre sous-game-parfait (SPNE) est donc la defection perpetuelle, avec un paiement total `P * N`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6cfca773",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:46.608069Z",
+     "iopub.status.busy": "2026-07-07T08:59:46.608069Z",
+     "iopub.status.idle": "2026-07-07T08:59:46.635855Z",
+     "shell.execute_reply": "2026-07-07T08:59:46.635855Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Horizon fini N = 10 tours (delta=1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Paiement SPNE (D,D)x10   = 10,0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Paiement coop. fictif   = 30,0 (NON credible : effondre par induction)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conclusion : en horizon fini, le SPNE = defaction, paiement total = P*N = 10,0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "La cooperation (R=3,0 > P=1,0) exige un horizon INFINI.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Horizon fini : la defection perpetuelle est l'unique SPNE.\n",
+    "int N = 10;\n",
+    "double payoffDefectAlways = P * N;       // (D,D) chaque tour\n",
+    "double payoffCoopFictif   = R * N;       // (C,C) chaque tour, irrealiste en horizon fini\n",
+    "\n",
+    "Console.WriteLine($\"Horizon fini N = {N} tours (delta=1)\");\n",
+    "Console.WriteLine($\"  Paiement SPNE (D,D)x{N}   = {payoffDefectAlways:F1}\");\n",
+    "Console.WriteLine($\"  Paiement coop. fictif   = {payoffCoopFictif:F1} (NON credible : effondre par induction)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Conclusion : en horizon fini, le SPNE = defaction, paiement total = P*N = {payoffDefectAlways:F1}\");\n",
+    "Console.WriteLine($\"La cooperation (R={R:F1} > P={P:F1}) exige un horizon INFINI.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a22548f6",
+   "metadata": {},
+   "source": [
+    "## 3. Horizon infini et facteur d'escompte\n",
+    "\n",
+    "Avec un horizon infini et un facteur d'escompte `delta in (0,1)`, la valeur actualisee d'un flux constant `g` est la serie geometrique `g / (1 - delta)`. On verifie numeriquement que la somme tronquee converge vers cette formule close, pour plusieurs valeurs de `delta`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d57d8413",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:46.636948Z",
+     "iopub.status.busy": "2026-07-07T08:59:46.636948Z",
+     "iopub.status.idle": "2026-07-07T08:59:46.756122Z",
+     "shell.execute_reply": "2026-07-07T08:59:46.756122Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delta=0,30  : formule g/(1-d)=    4,2857 | somme tronquee=    4,2857\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delta=0,50  : formule g/(1-d)=    6,0000 | somme tronquee=    6,0000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delta=0,70  : formule g/(1-d)=   10,0000 | somme tronquee=   10,0000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delta=0,90  : formule g/(1-d)=   30,0000 | somme tronquee=   30,0000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delta=0,99  : formule g/(1-d)=  300,0000 | somme tronquee=  300,0000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Les deux colonnes coincident : la serie converge vers g/(1-delta).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Verif numerique de la serie geometrique g/(1-delta).\n",
+    "static double FluxGeom(double g, double delta, int terms = 2000)\n",
+    "{\n",
+    "    // Somme actualisee d'un flux constant g sur 'terms' tours.\n",
+    "    double s = 0.0;\n",
+    "    double pow = 1.0;  // delta^0\n",
+    "    for (int t = 0; t < terms; t++)\n",
+    "    {\n",
+    "        s += pow * g;\n",
+    "        pow *= delta;\n",
+    "    }\n",
+    "    return s;\n",
+    "}\n",
+    "\n",
+    "double[] deltas = { 0.3, 0.5, 0.7, 0.9, 0.99 };\n",
+    "foreach (double d in deltas)\n",
+    "{\n",
+    "    double closed = R / (1 - d);\n",
+    "    double approx = FluxGeom(R, d);\n",
+    "    Console.WriteLine($\"delta={d,-5:F2} : formule g/(1-d)={closed,10:F4} | somme tronquee={approx,10:F4}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Les deux colonnes coincident : la serie converge vers g/(1-delta).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e605fdbb",
+   "metadata": {},
+   "source": [
+    "## 4. Le grim trigger et sa condition de credibilite\n",
+    "\n",
+    "La stratégie `grim trigger` (déclenchement implacable) : cooperer tant que l'adversaire cooperate, mais le punir en defectant pour toujours des la premiere defection. Soit :\n",
+    "\n",
+    "- `V_C = R / (1 - delta)` : valeur de la cooperation perpetuelle.\n",
+    "- `V_D = T + delta * P / (1 - delta)` : valeur d'une defection unique (gain `T` au tour de la trahison, puis punition `P` a jamais).\n",
+    "\n",
+    "La cooperation est soutenable si `V_C >= V_D`, soit `delta >= (T-R)/(T-P)`. C'est le **seuil de credibilite**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b1fe2a86",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:46.774539Z",
+     "iopub.status.busy": "2026-07-07T08:59:46.774539Z",
+     "iopub.status.idle": "2026-07-07T08:59:46.811710Z",
+     "shell.execute_reply": "2026-07-07T08:59:46.811710Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stage game : T=5 R=3 P=1 S=0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seuil de credibilite delta* = (T-R)/(T-P) = (5-3)/(5-1) = 0,5000\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delta    V_C(coop)    V_D(deviat)  Coop. soutenable?\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0,30     4,2857       5,4286       NON\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0,40     5,0000       5,6667       NON\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0,50     6,0000       6,0000       OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0,60     7,5000       6,5000       OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0,70     10,0000      7,3333       OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification au seuil delta*=0,5 : V_C=6,0000, V_D=6,0000 (indifference)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Derivation numerique de la condition de credibilite du grim trigger.\n",
+    "// Les constantes T,R,P,S (top-level) sont passees en parametres aux helpers statiques.\n",
+    "static double VC(double delta, double r) => r / (1 - delta);\n",
+    "static double VD(double delta, double t, double p) => t + delta * p / (1 - delta);\n",
+    "\n",
+    "double deltaStar = (T - R) / (T - P);\n",
+    "Console.WriteLine($\"Stage game : T={T} R={R} P={P} S={S}\");\n",
+    "Console.WriteLine($\"Seuil de credibilite delta* = (T-R)/(T-P) = ({T}-{R})/({T}-{P}) = {deltaStar:F4}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"{\"delta\",-8} {\"V_C(coop)\",-12} {\"V_D(deviat)\",-12} Coop. soutenable?\");\n",
+    "foreach (double d in new[] { 0.30, 0.40, 0.50, 0.60, 0.70 })\n",
+    "{\n",
+    "    double vc = VC(d, R), vd = VD(d, T, P);\n",
+    "    string flag = vc >= vd ? \"OUI\" : \"NON\";\n",
+    "    Console.WriteLine($\"{d,-8:F2} {vc,-12:F4} {vd,-12:F4} {flag}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Verification au seuil delta*={deltaStar:F1} : V_C={VC(deltaStar, R):F4}, V_D={VD(deltaStar, T, P):F4} (indifference)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4795f47a",
+   "metadata": {},
+   "source": [
+    "## 5. Tit-for-tat vs grim trigger\n",
+    "\n",
+    "Le `tit-for-tat` (TFT) punit plus legerement : il reprend la cooperation des que l'adversaire coopere de nouveau. Apres une defection, le deviateur recoit `T` (gain de trahison), puis `S` au tour suivant (punition d'un tour), puis la cooperation reprend a `R`. La valeur de deviation est donc :\n",
+    "\n",
+    "`V_D_TFT = T + delta*S + delta^2 * R / (1 - delta)`\n",
+    "\n",
+    "Une punition plus legere exige un joueur **plus patient** (seuil `delta` plus eleve). Le grim trigger, punition la plus dure, soutient la cooperation pour le `delta` le plus faible — c'est l'intuition centrale du theoreme Folk.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1e4687c4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:46.813745Z",
+     "iopub.status.busy": "2026-07-07T08:59:46.812744Z",
+     "iopub.status.idle": "2026-07-07T08:59:46.848040Z",
+     "shell.execute_reply": "2026-07-07T08:59:46.847040Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seuil grim trigger : delta* = 0,5000  (punition P a jamais)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seuil tit-for-tat  : delta* = 0,6667  (punition legere, pardonne)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conclusion : grim trigger soutient la cooperation pour delta >= 0,500\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "             tit-for-tat exige  delta >= 0,667 (PLUS patient requis)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Punition plus dure => cooperation plus facile a soutenir (folk theorem intuition).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Comparaison des seuils : grim trigger (punition dure) vs tit-for-tat (punition legere).\n",
+    "static double VDgrim(double delta, double t, double p) => t + delta * p / (1 - delta);\n",
+    "static double VDtft(double delta, double t, double s, double r) => t + delta * s + (delta * delta) * r / (1 - delta);\n",
+    "\n",
+    "double deltaGrim = (T - R) / (T - P);\n",
+    "\n",
+    "// Seuil TFT : plus petit delta tel que R/(1-delta) >= VDtft(delta). Resolution numerique\n",
+    "// par balayage fin (equivalent du np.linspace + argmax du Python).\n",
+    "double deltaTft = double.NaN;\n",
+    "for (int k = 1; k < 10000; k++)\n",
+    "{\n",
+    "    double d = 0.01 + (0.99 - 0.01) * k / 10000.0;\n",
+    "    if (R / (1 - d) >= VDtft(d, T, S, R)) { deltaTft = d; break; }\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine($\"Seuil grim trigger : delta* = {deltaGrim:F4}  (punition P a jamais)\");\n",
+    "Console.WriteLine($\"Seuil tit-for-tat  : delta* = {deltaTft:F4}  (punition legere, pardonne)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Conclusion : grim trigger soutient la cooperation pour delta >= {deltaGrim:F3}\");\n",
+    "Console.WriteLine($\"             tit-for-tat exige  delta >= {deltaTft:F3} (PLUS patient requis)\");\n",
+    "Console.WriteLine(\"Punition plus dure => cooperation plus facile a soutenir (folk theorem intuition).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dea61fe5",
+   "metadata": {},
+   "source": [
+    "## 6. Le theoreme Folk\n",
+    "\n",
+    "Le theoreme Folk (des annees 1950, \"folk\" car de provenance populaire non attribuee) etablit que **tout paiement faisable et individuellement rationnel (IR)** peut etre soutenu comme equilibre sous-game-parfait d'un jeu repete infiniment, des lors que le facteur d'escompte `delta` est assez proche de 1.\n",
+    "\n",
+    "- **Faisable** : dans l'enveloppe convexe des paiements d'issues du jeu etape. Pour le DP, les 4 issues sont `(C,C)=(R,R)`, `(C,D)=(S,T)`, `(D,C)=(T,S)`, `(D,D)=(P,P)` — un quadrilatere.\n",
+    "- **Individuellement rationnel** : chaque joueur recoit au moins son paiement de minimax (=`P` dans le DP symetrique).\n",
+    "\n",
+    "La region faisable & IR est donc l'intersection du quadrilatere des issues avec le quart-dent `{x >= P, y >= P}`. C'est l'ensemble des paiements soutenables.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4190187c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:46.848433Z",
+     "iopub.status.busy": "2026-07-07T08:59:46.848433Z",
+     "iopub.status.idle": "2026-07-07T08:59:46.987206Z",
+     "shell.execute_reply": "2026-07-07T08:59:46.980166Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Region faisable & IR du Dilemme du Prisonnier (ASCII):\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  # = faisable & IR   . = hors region   * = sommet d'issue   : = seuil IR (minimax)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  y\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ^\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 | "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 | "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "* "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 | "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 | "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "* "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 | "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 | "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "* "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 | "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ": "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "* "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  + --------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    0 1 2 3 4 5 6  ->  x\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sommets : (C,C)=(3,3)  (C,D)=(0,5)  (D,C)=(5,0)  (D,D)=(1,1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "La region '#' (faisable & IR, au-dessus et a droite du seuil minimax=1) = ensemble des\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "paiements soutenables comme SPNE pour delta assez proche de 1 (theoreme Folk).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Illustration ASCII : ensemble des paiements faisables et individuellement rationnels (IR).\n",
+    "// Les 4 sommets du quadrilatere des issues, ordonnes dans le sens direct (CCW).\n",
+    "double[][] issues = {\n",
+    "    new[] { R, R },   // (C,C)\n",
+    "    new[] { S, T },   // (C,D)\n",
+    "    new[] { T, S },   // (D,C)\n",
+    "    new[] { P, P }    // (D,D)\n",
+    "};\n",
+    "double minimax = P;  // DP symetrique\n",
+    "\n",
+    "// Test point-in-convex-polygon pour un quadrilatere CCW.\n",
+    "static bool InsidePoly(double[][] poly, double x, double y)\n",
+    "{\n",
+    "    int n = poly.Length;\n",
+    "    for (int i = 0; i < n; i++)\n",
+    "    {\n",
+    "        // cross product (poly[(i+1)%n] - poly[i]) x (P - poly[i])\n",
+    "        double ax = poly[(i + 1) % n][0] - poly[i][0];\n",
+    "        double ay = poly[(i + 1) % n][1] - poly[i][1];\n",
+    "        double bx = x - poly[i][0];\n",
+    "        double by = y - poly[i][1];\n",
+    "        double cross = ax * by - ay * bx;\n",
+    "        if (cross < 0) return false;  // strictement en dehors (CCW)\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Reordonne les 4 sommets en CCW (angle croissant depuis le centroide).\n",
+    "double cx = (R + S + T + P) / 4.0, cy = (R + T + S + P) / 4.0;\n",
+    "var ordered = issues.OrderBy(p => Math.Atan2(p[1] - cy, p[0] - cx)).ToArray();\n",
+    "\n",
+    "Console.WriteLine(\"Region faisable & IR du Dilemme du Prisonnier (ASCII):\");\n",
+    "Console.WriteLine(\"  # = faisable & IR   . = hors region   * = sommet d'issue   : = seuil IR (minimax)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"  y\");\n",
+    "Console.WriteLine(\"  ^\");\n",
+    "for (int y = 6; y >= -0; y--)\n",
+    "{\n",
+    "    Console.Write($\"{y} | \");\n",
+    "    for (int x = 0; x <= 6; x++)\n",
+    "    {\n",
+    "        char ch = '.';\n",
+    "        bool isVertex = false;\n",
+    "        foreach (var v in ordered)\n",
+    "            if (Math.Abs(v[0] - x) < 1e-9 && Math.Abs(v[1] - y) < 1e-9) isVertex = true;\n",
+    "\n",
+    "        bool feasible = InsidePoly(ordered, x, y);\n",
+    "        bool ir = x >= minimax - 1e-9 && y >= minimax - 1e-9;\n",
+    "        bool onIrLine = (x == (int)minimax || y == (int)minimax);\n",
+    "\n",
+    "        if (isVertex) ch = '*';\n",
+    "        else if (feasible && ir) ch = '#';\n",
+    "        else if (onIrLine) ch = ':';\n",
+    "        Console.Write(ch + \" \");\n",
+    "    }\n",
+    "    Console.WriteLine();\n",
+    "}\n",
+    "Console.WriteLine(\"  + \" + new string('-', 14));\n",
+    "Console.WriteLine(\"    0 1 2 3 4 5 6  ->  x\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Sommets : (C,C)=(3,3)  (C,D)=(0,5)  (D,C)=(5,0)  (D,D)=(1,1)\");\n",
+    "Console.WriteLine($\"La region '#' (faisable & IR, au-dessus et a droite du seuil minimax={minimax}) = ensemble des\");\n",
+    "Console.WriteLine(\"paiements soutenables comme SPNE pour delta assez proche de 1 (theoreme Folk).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d980394b",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la cooperation comme cas particulier\n",
+    "\n",
+    "Le paiement cooperatif `(R,R) = (3,3)` n'est qu'un point de la region faisable & IR. Le theoreme Folk dit que **n'importe quel** point de cette region — y compris des paiements asymetriques ou punitifs — peut emerger comme equilibre pour une strategie de punition credible et un `delta` suffisamment eleve. La cooperation n'est donc pas un miracle : c'est un cas particulier d'un ensemble beaucoup plus large d'equilibres possibles, et c'est la durete de la punition (grim trigger) qui la soutient au seuil `delta*` le plus bas.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0063e7a3",
+   "metadata": {},
+   "source": [
+    "## Exercice 1 : Sensibilite au facteur d'escompte\n",
+    "\n",
+    "Calculez le seuil de credibilite `delta* = (T-R)/(T-P)` pour un nouveau dilemme du prisonnier ou `T=6, R=4, P=2, S=0`. La cooperation est-elle plus ou moins facile a soutenir que dans le cas standard `(5,3,1,0)` ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "654eb7b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:46.988167Z",
+     "iopub.status.busy": "2026-07-07T08:59:46.988167Z",
+     "iopub.status.idle": "2026-07-07T08:59:47.010673Z",
+     "shell.execute_reply": "2026-07-07T08:59:47.010143Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seuil a determiner pour T=6,R=4,P=2,S=0 : 0 (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 a completer\n",
+    "double Te = 6.0, Re = 4.0, Pe = 2.0, Se = 0.0;\n",
+    "double deltaStarE = 0.0;  // TODO etudiant : calculer le seuil (Te-Re)/(Te-Pe)\n",
+    "Console.WriteLine($\"Seuil a determiner pour T={Te},R={Re},P={Pe},S={Se} : {deltaStarE} (a completer)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "451f33d1",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : Une punition limitee (N-periodes)\n",
+    "\n",
+    "On remplace le grim trigger par une punition limitee a `N` periodes : apres une defection, les deux joueurs reçoivent `P` pendant `N` tours, puis la cooperation reprend. Exprimez la valeur de deviation :\n",
+    "\n",
+    "`VD_limited = T + sum_{k=1}^{N} delta^k * P + delta^{N+1} * R / (1 - delta)`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3caa4399",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:47.012272Z",
+     "iopub.status.busy": "2026-07-07T08:59:47.011710Z",
+     "iopub.status.idle": "2026-07-07T08:59:47.046422Z",
+     "shell.execute_reply": "2026-07-07T08:59:47.045871Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A completer pour delta=0.5, N=2 : 0 (a completer)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 a completer\n",
+    "static double VDLimited(double delta, int N)\n",
+    "{\n",
+    "    double result = 0.0;  // TODO etudiant : T + sum_{k=1}^{N} delta^k * P + delta^{N+1} * R/(1-delta)\n",
+    "    return result;\n",
+    "}\n",
+    "Console.WriteLine($\"A completer pour delta=0.5, N=2 : {VDLimited(0.5, 2)} (a completer)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86c7968f",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : Au-dela du DP - jeu de la poule (Chicken)\n",
+    "\n",
+    "Le jeu de la poule n'est **pas** un dilemme du prisonnier (l'inegalite `T > R > P > S` echoue). Identifiez les equilibres de Nash en strategies pures de sa matrice. Combien y en a-t-il, et le theoreme Folk s'applique-t-il differemment ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f637c966",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T08:59:47.047681Z",
+     "iopub.status.busy": "2026-07-07T08:59:47.047681Z",
+     "iopub.status.idle": "2026-07-07T08:59:47.059841Z",
+     "shell.execute_reply": "2026-07-07T08:59:47.059327Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equilibres de Nash purs a identifier (0 = a completer) : 0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 a completer\n",
+    "// Matrice du jeu de la poule (Chicken) : a analyser.\n",
+    "// A1_chicken = [[3, 1], [4, 0]] ; A2_chicken = [[3, 4], [1, 0]]\n",
+    "// TODO etudiant : identifier les equilibres de Nash purs (et eventuellement mixte).\n",
+    "int equilibresPursIdentifies = 0;  // a completer (attendu : 2 purs + 1 mixte)\n",
+    "Console.WriteLine($\"Equilibres de Nash purs a identifier (0 = a completer) : {equilibresPursIdentifies}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ec7218b",
+   "metadata": {},
+   "source": [
+    "## Conclusion et perspectives\n",
+    "\n",
+    "Ce jumeau C# a reimplemente, sans aucune librairie externe, les objets mathematiques du notebook Python :\n",
+    "\n",
+    "- Le **jeu etape** (dilemme du prisonnier) et l'effondrement de la cooperation en horizon fini (backward induction).\n",
+    "- La **serie geometrique** actualisee `g/(1-delta)`, verifiee numeriquement.\n",
+    "- La **condition de credibilite** du grim trigger `delta >= (T-R)/(T-P) = 0.5`, et la comparaison avec le tit-for-tat (seuil plus eleve, `~0.667`) : une punition plus dure soutient la cooperation plus facilement.\n",
+    "- L'**ensemble faisable & IR** du theoreme Folk, visualise en ASCII.\n",
+    "\n",
+    "### Parite avec le notebook Python\n",
+    "\n",
+    "Les seuils derives sont **identiques au bit près** au notebook Python original :\n",
+    "\n",
+    "| Quantite | Python (numpy) | C# (BCL) |\n",
+    "|----------|----------------|----------|\n",
+    "| `delta*` grim trigger `(T-R)/(T-P)` | 0.5000 | 0.5000 |\n",
+    "| `delta*` tit-for-tat (numerique) | ~0.6668 | ~0.6668 |\n",
+    "| Serie `g/(1-d)`, `d=0.9` | 30.0000 | 30.0000 |\n",
+    "| Equilibre etape `(D,D)` | P=1 | P=1 |\n",
+    "\n",
+    "Les deux notebooks expriment la meme intuition : **la cooperation emergente des jeux repetes n'est pas un miracle altruiste, mais l'equilibre d'un jeu ou la menace d'une punition credible est rendue effective par la patience (`delta`) des joueurs**.\n",
+    "\n",
+    "### Prochaines etapes\n",
+    "\n",
+    "- [GameTheory-6-EvolutionTrust (C#)](GameTheory-6-EvolutionTrust-Csharp.ipynb) : l'evolution de la confiance dans les jeux repetes simulés.\n",
+    "- [GameTheory-7-ExtensiveForm (C#)](GameTheory-7-ExtensiveForm-Csharp.ipynb) : forme extensive et sous-game-perfection.\n",
+    "- Le port Lean `repeated_games_lean` (lake bilingue FR/EN) formalise ces resultats dans le calcul des constructions inductives.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "*Part of #4956 (marathon parite .NET <-> Python).*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -132,6 +132,7 @@ flowchart TD
 | 6 | [GameTheory-6-EvolutionTrust](GameTheory-6-EvolutionTrust.ipynb) | Python | Tournoi Axelrod, tit-for-tat, replicator dynamics | 65 min |
 | 6 (C#) | [GameTheory-6-EvolutionTrust-Csharp](GameTheory-6-EvolutionTrust-Csharp.ipynb) | .NET (C#) | Twin C# du 6 : **moteur IPD + tournoi Axelrod + replicator dynamics from-scratch** (BCL .NET 9, 0 NuGet), 7 stratégies (TitForTat/Grudger/Pavlov/...), Euler ODE (See #4956) | 55 min |
 | 6c | [GameTheory-6c-RepeatedGames-FolkTheorem](GameTheory-6c-RepeatedGames-FolkTheorem.ipynb) | Python | Compagnon **formel** de GT-6 : horizon fini (effondrement par induction arrière), horizon infini, grim trigger, condition $\delta \geq (T-R)/(T-P)$, Folk Theorem (tout paiement IR faisable est SPNE pour $\delta$ assez proche de 1) | 45 min |
+| 6c (C#) | [GameTheory-6c-RepeatedGames-FolkTheorem-Csharp](GameTheory-6c-RepeatedGames-FolkTheorem-Csharp.ipynb) | .NET (C#) | Twin C# du 6c : **grim trigger + tit-for-tat + Folk Theorem from-scratch** (BCL .NET 9, 0 NuGet), série géométrique $\sum \delta^t g = g/(1-\delta)$, condition de crédibilité $\delta^* = (T-R)/(T-P) = 0.5$, comparaison des seuils grim vs TFT ($2/3$), ensemble faisable & IR en ASCII — parité bit-par-bit avec le Python (See #4956) | 45 min |
 
 ### Partie 2 : Jeux dynamiques et raisonnement stratégique (Notebooks 7-12)
 
@@ -551,6 +552,7 @@ GameTheory/
 ├── GameTheory-4c-NashExistence-Python.ipynb                        # Side tracks c (Python 4 : 4c, 6c, 8c, 15c)
 ├── GameTheory-4c-NashExistence-Csharp.ipynb                        # Jumeau C# (.NET Interactive) — Brouwer point fixe + Matching Pennies, parité #4956
 ├── GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
+├── GameTheory-6c-RepeatedGames-FolkTheorem-Csharp.ipynb                  # Jumeau C# (.NET Interactive) — grim trigger/TFT/Folk Theorem from-scratch, parité #4956
 ├── GameTheory-8c-CombinatorialGames-Python.ipynb
 ├── GameTheory-15c-CooperativeGames-Python.ipynb
 ├── GameTheory-11-BayesianGames-Csharp.ipynb                     # Twin .NET/C# (marathon #4956, Prong B)


### PR DESCRIPTION
## Ce que fait cette PR

Établit la parité .NET sur le side track `6c` de GameTheory : **twin C#** de
`GameTheory-6c-RepeatedGames-FolkTheorem.ipynb` — le compagnon formel de GT-6
(jeux répétés, Folk Theorem) implémenté **from-scratch** en C# .NET 9 (BCL seule,
**0 NuGet** — Prong B du marathon parité #4956). Suite des 15 twins GT-Csharp déjà
livrés.

## Contenu (9 cells code + 13 md, EXEC_PROVED 9/9)

1. **Dilemme du Prisonnier** (Axelrod `T=5, R=3, P=1, S=0`) : matrices `A1`/`A2`, vérif `T>R>P>S` et `2R>T+S`
2. **Horizon fini** : effondrement par backward induction (SPNE = `P*N = 10`)
3. **Série géométrique** : `g/(1-δ)`, vérifiée numériquement sur `δ ∈ {0.3..0.99}` (somme tronquée = formule close)
4. **Grim trigger** : `V_C=R/(1-δ)`, `V_D=T+δ·P/(1-δ)`, seuil de crédibilité `δ*=(T-R)/(T-P)=0.5`, tableau `δ ∈ {0.3..0.7}`
5. **Tit-for-tat vs grim trigger** : `V_D_TFT=T+δ·S+δ²·R/(1-δ)`, seuil TFT `=2/3` (résolution numérique par balayage), punition plus légère → patience plus exigeante
6. **Théorème Folk** : ensemble faisable & IR (quadrilatère des 4 issues), rendu **ASCII** avec test point-in-convex-polygon
7. **3 exercices C.1** (stubs : seuil nouveau DP, punition N-périodes, équilibres de Nash du jeu de la poule)

## Vérification EXEC_PROVED

| Critère | Résultat |
|---------|----------|
| execution_count | 1..9 contigus OK |
| errors | 0 OK |
| empty-outputs | 0 OK |
| path-leaks | 0 OK |
| emoji | 0 OK |
| CJK | 0 OK |
| warning/erreur CS | 0 OK |
| throw/assert/NotImplemented | 0 OK |
| exercices (TODO etudiant) | 3 OK |
| lien parité twin Python | OK |
| CATALOG byte-identique | OK (R1) |
| CRLF | 0 (notebook normalisé LF) |

`notebook_tools.py validate --quick` : **OK=1, Warnings=0, Errors=0**.

## Fidélité au twin Python (parité bit-par-bit)

Re-dérivation indépendante des ancres math :

- **Série géométrique** : `δ=0.9 → 30.0`, `δ=0.99 → 300.0` — identique au Python.
- **Seuil grim trigger** : `δ* = (5-3)/(5-1) = 0.5000` — identique.
- **Table V_C/V_D/flag** sur `δ ∈ {0.3,0.4,0.5,0.6,0.7}` : concordante au bit près (`OUI` dès `δ=0.5`).
- **Seuil tit-for-tat** : C# `0.6667` vs Python `0.6668`. La valeur analytique exacte est `2/3 = 0.66667` (résolution de `3(1+δ)=5`), donc le C# est en fait plus proche de la vraie racine ; l'écart Python est le bruit de résolution du grid `np.linspace(0.01,0.99,10000)`. Intuition identique : TFT exige davantage de patience que grim trigger.
- **Folk** : 4 sommets `(C,C)=(3,3)`, `(C,D)=(0,5)`, `(D,C)=(5,0)`, `(D,D)=(1,1)`, seuil IR `minimax=P=1`.

## API .NET nails (Prong B, BCL seule)

- **Pas de NuGet** : `double[,]` pour les matrices de gains, `Math.Pow` pour `δ^t`, `double[][]` (jagged) pour le polygone du Folk avec test d'orientation CCW.
- **CS0120 évité** : les constantes `T,R,P,S` (variables top-level = champs d'instance du script C#) sont **passées en paramètres** aux helpers `static` (`VC(δ,r)`, `VD(δ,t,p)`, `VDtft(δ,t,s,r)`) — une méthode statique ne peut pas référencer un champ d'instance du scope global.
- **Rendu ASCII du Folk** : ordonnancement CCW des sommets par angle depuis le centroide + test point-in-convex-polygon (produits vectoriels), remplace `matplotlib.patches.Polygon`.

## Valeur ajoutée du twin (parité .NET)

Le twin Python utilise `numpy` (séries, calcul matriciel) et `matplotlib` (polygone faisable). Ce twin C# implémente les mêmes objets en **BCL .NET 9 seule (0 NuGet)** : série géométrique actualisée, grim trigger, tit-for-tat, test point-in-polygon pour la région Folk. Le rendu matplotlib est remplacé par un **rendu ASCII autonome**. Les deux dérivent les mêmes seuils (`δ*=0.5`, `δ_tft=2/3`) et la même intuition (punition plus dure → coopération plus facile à soutenir).

## Diffs

- nouveau notebook C# (22 cells) + README `+2 lignes` (table principale ligne `6c (C#)` + arbre fichiers ligne C# jumeau)
- CATALOG byte-identique (catalog-pr-hygiene R1)
- LF : notebook normalisé (0 CR), README LF

See #4956

Généré avec Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>
