### PR TITLE
feat(gametheory): GameTheory-15c-CooperativeGames-Csharp — twin C# jeux cooperatifs (marathon #4956)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
@@ -1,0 +1,1721 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0a161c01",
+   "metadata": {},
+   "source": [
+    "# GameTheory 15c - Jeux Cooperatifs (C# / .NET)\n",
+    "\n",
+    "**Navigation** : [<< 15-CooperativeGames (track principal)](GameTheory-15-CooperativeGames.ipynb) | [Index](README.md)\n",
+    "\n",
+    "**Autres side tracks** : [15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) | [15c-Python-CooperativeGames](GameTheory-15c-CooperativeGames-Python.ipynb)\n",
+    "\n",
+    "**Kernel** : .NET (C#) -- marathon #4956, parite .NET ⇄ Python (twin de `GameTheory-15c-CooperativeGames-Python.ipynb`).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Ce notebook est le **twin C#** du notebook `15c-Python` : il illustre les memes concepts de\n",
+    "theorie des jeux cooperatifs (valeur de Shapley, Core, indice de Banzhaf, jeux de vote ponderes)\n",
+    "implementes **from-scratch en C# .NET 9 (BCL seule, 0 NuGet)**. La parite .NET ⇄ Python est\n",
+    "l'objet d'etude : deux runtimes, memes valeurs exactes.\n",
+    "\n",
+    "### Objectifs d'apprentissage\n",
+    "\n",
+    "1. Calculer la **valeur de Shapley** d'un jeu cooperatif et l'illustrer sur le jeu de gants (Glove Game)\n",
+    "2. Verifier qu'un jeu de **majorite** peut avoir un **Core vide**\n",
+    "3. Comparer **Shapley vs Banzhaf** sur un jeu de vote pondere (Mini-ONU)\n",
+    "4. Tester la **convexite** d'un jeu (condition pour que Shapley soit dans le Core)\n",
+    "\n",
+    "> **Note SOTA (EPIC #3801)** : il n'existe pas de solveur NuGet canonique pour la theorie des jeux\n",
+    "> cooperatifs. La valeur de Shapley et l'indice de Banzhaf sont des **algorithmes deterministes**\n",
+    "> (enumerateurs de permutations / coalitions) -- le from-scratch C# est l'implementation fidele du\n",
+    "> SOTA algorithmique, parallele au twin Python qui l'implemente aussi lui-meme (numpy/stdlib).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ac7a1ce4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:47.930240Z",
+     "iopub.status.busy": "2026-07-07T09:07:47.923076Z",
+     "iopub.status.idle": "2026-07-07T09:07:49.598714Z",
+     "shell.execute_reply": "2026-07-07T09:07:49.594455Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:95e3:e85b:50a2:c5eb:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://2a01:e0a:9d4:f320:ad48:df3a:b26f:8f6c:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1737752.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Twin C# .NET des jeux cooperatifs (marathon #4956, parite avec 15c-Python)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Implementation from-scratch BCL .NET 9 (0 NuGet).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Linq;\n",
+    "\n",
+    "Console.WriteLine(\"Twin C# .NET des jeux cooperatifs (marathon #4956, parite avec 15c-Python)\");\n",
+    "Console.WriteLine(\"Implementation from-scratch BCL .NET 9 (0 NuGet).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad9ac4c5",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Valeur de Shapley - Rappels\n",
+    "\n",
+    "La valeur de Shapley est la contribution marginale moyenne d'un joueur sur toutes les permutations\n",
+    "de l'ordre d'arrivee :\n",
+    "\n",
+    "$$\\phi_i(v) = \\sum_{S \\subseteq N \\setminus \\{i\\}} \\frac{|S|!(n-|S|-1)!}{n!} [v(S \\cup \\{i\\}) - v(S)]$$\n",
+    "\n",
+    "Implementation equivalente (et exacte) : enumerer **toutes les permutations** de $N$, et pour chaque\n",
+    "permutation, additionner la contribution marginale de $i$ quand il rejoint la coalition de ses\n",
+    "predecesseurs. On divise ensuite par $n!$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cda0d942",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:49.600052Z",
+     "iopub.status.busy": "2026-07-07T09:07:49.599866Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.038320Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.038118Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonction ShapleyValueExact definie.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Fonction caracteristique : v(S) -> double. S est un ISet<int>.\n",
+    "using GameFunc = System.Func<System.Collections.Generic.ISet<int>, double>;\n",
+    "\n",
+    "// Toutes les permutations de {0..n-1} (algorithme de Heap).\n",
+    "static IEnumerable<int[]> Permutations(int n)\n",
+    "{\n",
+    "    var a = Enumerable.Range(0, n).ToArray();\n",
+    "    var c = new int[n];\n",
+    "    yield return (int[])a.Clone();\n",
+    "    int i = 0;\n",
+    "    while (i < n)\n",
+    "    {\n",
+    "        if (c[i] < i)\n",
+    "        {\n",
+    "            if (i % 2 == 0) (a[0], a[i]) = (a[i], a[0]);\n",
+    "            else (a[c[i]], a[i]) = (a[i], a[c[i]]);\n",
+    "            yield return (int[])a.Clone();\n",
+    "            c[i]++;\n",
+    "            i = 0;\n",
+    "        }\n",
+    "        else { c[i] = 0; i++; }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Valeur de Shapley exacte (permutations). Retourne le vecteur phi de taille n.\n",
+    "static double[] ShapleyValueExact(GameFunc v, int n)\n",
+    "{\n",
+    "    var phi = new double[n];\n",
+    "    long count = 0;\n",
+    "    foreach (var perm in Permutations(n))\n",
+    "    {\n",
+    "        var coalition = new HashSet<int>();\n",
+    "        foreach (var i in perm)\n",
+    "        {\n",
+    "            var with = new HashSet<int>(coalition) { i };\n",
+    "            double marginal = v(with) - v(coalition);\n",
+    "            phi[i] += marginal;\n",
+    "            coalition.Add(i);\n",
+    "        }\n",
+    "        count++;\n",
+    "    }\n",
+    "    for (int k = 0; k < n; k++) phi[k] /= count;\n",
+    "    return phi;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Fonction ShapleyValueExact definie.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f758401",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. Jeu de Gants (Glove Game)\n",
+    "\n",
+    "**Exercice du notebook 15b Lean** : trois joueurs L1, L2 ont chacun un gant gauche, R1 a un gant\n",
+    "droit. Une paire de gants vaut 1. La fonction caracteristique compte le nombre de paires completes,\n",
+    "limite par le gant droit (ressource rare)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "66fd674c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.039524Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.039356Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.314691Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.314278Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JEU DE GANTS\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Joueurs : L1=0, L2=1 (gants gauches), R1=2 (gant droit)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonction caracteristique :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({L1}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({L2}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({R1}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({L1, L2}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({L1, R1}) = 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({L2, R1}) = 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({L1, L2, R1}) = 1\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Jeu de gants : joueurs 0,1 = gants gauches, joueur 2 = gant droit.\n",
+    "static GameFunc GloveGame() => S =>\n",
+    "{\n",
+    "    int left = S.Count(i => i == 0 || i == 1);\n",
+    "    int right = S.Count(i => i == 2);\n",
+    "    return Math.Min(left, right);\n",
+    "};\n",
+    "\n",
+    "var glove = GloveGame();\n",
+    "var labels = new Dictionary<int,string> { [0]=\"L1\", [1]=\"L2\", [2]=\"R1\" };\n",
+    "\n",
+    "Console.WriteLine(\"JEU DE GANTS\");\n",
+    "Console.WriteLine(new string('=', 40));\n",
+    "Console.WriteLine(\"Joueurs : L1=0, L2=1 (gants gauches), R1=2 (gant droit)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Fonction caracteristique :\");\n",
+    "\n",
+    "// Toutes les coalitions de {0,1,2}, triees par taille puis lex.\n",
+    "static List<List<int>> AllCoalitions(int n)\n",
+    "{\n",
+    "    var res = new List<List<int>>();\n",
+    "    for (int mask = 0; mask < (1 << n); mask++)\n",
+    "    {\n",
+    "        var c = new List<int>();\n",
+    "        for (int i = 0; i < n; i++) if ((mask & (1 << i)) != 0) c.Add(i);\n",
+    "        res.Add(c);\n",
+    "    }\n",
+    "    res.Sort((a, b) => a.Count != b.Count ? a.Count.CompareTo(b.Count) : string.Join(\",\", a).CompareTo(string.Join(\",\", b)));\n",
+    "    return res;\n",
+    "}\n",
+    "\n",
+    "foreach (var S in AllCoalitions(3))\n",
+    "{\n",
+    "    var set = new HashSet<int>(S);\n",
+    "    string str = S.Count == 0 ? \"{}\" : \"{\" + string.Join(\", \", S.Select(i => labels[i])) + \"}\";\n",
+    "    Console.WriteLine($\"  v({str}) = {glove(set)}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4214c63",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Fonction caracteristique du jeu de gants\n",
+    "\n",
+    "La fonction caracteristique encode la **structure de complementarite** du jeu :\n",
+    "\n",
+    "| Type de coalition | Valeur | Raison |\n",
+    "|-------------------|--------|--------|\n",
+    "| Vide ou singletons | 0 | Aucune paire possible |\n",
+    "| {L1, L2} (deux gauches) | 0 | Pas de gant droit pour completer |\n",
+    "| {L1, R1} ou {L2, R1} | 1 | Une paire complete |\n",
+    "| {L1, L2, R1} | 1 | Une seule paire possible (1 gant droit) |\n",
+    "\n",
+    "> **Point cle** : le gant droit est la **ressource limitante**. Cette asymetrie aura un impact\n",
+    "> majeur sur les valeurs de Shapley : R1 capturera l'essentiel de la valeur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5f6a88cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.316242Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.316005Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.425596Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.425377Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VALEURS DE SHAPLEY :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  L1 (gant gauche): 0,1667 = 1/6\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  L2 (gant gauche): 0,1667 = 1/6\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  R1 (gant droit): 0,6667 = 4/6\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total : 1,0000 (= v(N) = 1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Interpretation :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - R1 (gant droit) a une valeur de 4/6 = 2/3 car il possede la ressource rare\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - L1 et L2 se partagent 2/6 = 1/3 car ils sont en competition\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Calcul de Shapley pour le jeu de gants\n",
+    "var shapleyGlove = ShapleyValueExact(glove, 3);\n",
+    "\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"VALEURS DE SHAPLEY :\");\n",
+    "var gloveLabels = new[] { \"L1 (gant gauche)\", \"L2 (gant gauche)\", \"R1 (gant droit)\" };\n",
+    "for (int i = 0; i < 3; i++)\n",
+    "{\n",
+    "    // valeur * 6 pour exprimer en sixiemes (denominateur commun n! = 6)\n",
+    "    Console.WriteLine($\"  {gloveLabels[i]}: {shapleyGlove[i]:F4} = {(int)Math.Round(shapleyGlove[i]*6)}/6\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Total : {shapleyGlove.Sum():F4} (= v(N) = 1)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Interpretation :\");\n",
+    "Console.WriteLine(\"  - R1 (gant droit) a une valeur de 4/6 = 2/3 car il possede la ressource rare\");\n",
+    "Console.WriteLine(\"  - L1 et L2 se partagent 2/6 = 1/3 car ils sont en competition\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3e3af70",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Valeur de la rarete\n",
+    "\n",
+    "| Joueur | Ressource | Shapley | Explication |\n",
+    "|--------|-----------|---------|-------------|\n",
+    "| L1, L2 | Gant gauche (abondant) | 1/6 chacun | Competition entre detenteurs de la meme ressource |\n",
+    "| R1 | Gant droit (rare) | 4/6 | Monopole sur la ressource complementaire |\n",
+    "\n",
+    "> **Lecon economique** : la valeur d'une ressource ne depend pas seulement de son utilite\n",
+    "> intrinseque, mais de sa **rarete relative** par rapport aux ressources complementaires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "11e976f1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.427027Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.426818Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.552566Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.552327Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Valeurs de Shapley (jeu de gants) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  L1 (gant gauche)     0,1667 |######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  L2 (gant gauche)     0,1667 |######\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  R1 (gant droit)      0,6667 |#########################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Partage egal 1/3     0,3333 |------------\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Visualisation ASCII des valeurs de Shapley (jeu de gants)\n",
+    "Console.WriteLine(\"Valeurs de Shapley (jeu de gants) :\");\n",
+    "Console.WriteLine();\n",
+    "double maxBar = 0.8;\n",
+    "foreach (var (lab, val) in gloveLabels.Zip(shapleyGlove))\n",
+    "{\n",
+    "    int width = (int)Math.Round(val / maxBar * 30);\n",
+    "    string bar = new string('#', width);\n",
+    "    string marker = Math.Abs(val - 1.0/3) < 1e-9 ? \"  <-- partage egal (1/3)\" : \"\";\n",
+    "    Console.WriteLine($\"  {lab,-20} {val:F4} |{bar}{marker}\");\n",
+    "}\n",
+    "double third = 1.0 / 3;\n",
+    "int twidth = (int)Math.Round(third / maxBar * 30);\n",
+    "string egalLbl = \"Partage egal 1/3\";\n",
+    "Console.WriteLine($\"  {egalLbl,-20} {third:F4} |{new string('-', twidth)}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a85c633",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Jeu de gants etendu a 4 joueurs\n",
+    "\n",
+    "**Objectif** : etendre le jeu de gants a 4 joueurs (L1, L2 gauches ; R1, R2 droits).\n",
+    "Definir `GloveGame4`, calculer les valeurs de Shapley, interpreter comment le marche 2-vs-2\n",
+    "repartit la valeur (ressource equilibree vs rare).\n",
+    "\n",
+    "- **Indice :** joueurs 0,1 = gauches, 2,3 = droits. v(S) = min(gauches, droites).\n",
+    "- **Etape 1 :** definir `GloveGame4`.\n",
+    "- **Etape 2 :** calculer `ShapleyValueExact(GloveGame4, 4)`.\n",
+    "- **Etape 3 :** comparer avec le resultat a 3 joueurs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4f224d14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.554237Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.553964Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.643776Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.643505Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : valeurs de Shapley du jeu de gants a 4 joueurs.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 1 (stub C.1) : jeu de gants etendu a 4 joueurs.\n",
+    "static double[] ExerciceGloveGame4()\n",
+    "{\n",
+    "    // TODO etudiant : retourner ShapleyValueExact(GloveGame4(), 4)\n",
+    "    // ou GloveGame4(S) = min(count gauche parmi {0,1}, count droit parmi {2,3}).\n",
+    "    return new double[0];  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "var shapleyGlove4 = ExerciceGloveGame4();\n",
+    "var labels4 = new[] { \"L1\", \"L2\", \"R1\", \"R2\" };\n",
+    "if (shapleyGlove4.Length == 4)\n",
+    "{\n",
+    "    foreach (var (lab, val) in labels4.Zip(shapleyGlove4))\n",
+    "        Console.WriteLine($\"  {lab}: {val:F4}\");\n",
+    "    Console.WriteLine($\"Total: {shapleyGlove4.Sum():F4}\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice 1 a completer : valeurs de Shapley du jeu de gants a 4 joueurs.\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec842a36",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Core Vide : Jeu de Majorite\n",
+    "\n",
+    "On montre que le jeu de majorite simple a 3 joueurs a un **Core vide** : aucune allocation\n",
+    "efficace n'est stable (toute proposition est bloquee par une coalition de 2 joueurs)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cc766041",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.645651Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.645290Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.742339Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.741868Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JEU DE MAJORITE SIMPLE A 3 JOUEURS\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonction caracteristique :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({1}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({2}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({3}) = 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({1, 2}) = 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({1, 3}) = 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({2, 3}) = 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  v({1, 2, 3}) = 1\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Jeu de majorite simple a 3 joueurs : v(S) = 1 si |S| >= 2, 0 sinon.\n",
+    "static GameFunc MajorityGame3() => S => S.Count >= 2 ? 1.0 : 0.0;\n",
+    "\n",
+    "var maj3 = MajorityGame3();\n",
+    "Console.WriteLine(\"JEU DE MAJORITE SIMPLE A 3 JOUEURS\");\n",
+    "Console.WriteLine(new string('=', 50));\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Fonction caracteristique :\");\n",
+    "foreach (var S in AllCoalitions(3))\n",
+    "{\n",
+    "    var set = new HashSet<int>(S);\n",
+    "    string str = S.Count == 0 ? \"{}\" : \"{\" + string.Join(\", \", S.Select(i => (i+1).ToString())) + \"}\";\n",
+    "    Console.WriteLine($\"  v({str}) = {(int)maj3(set)}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "713448d7",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Structure du jeu de majorite\n",
+    "\n",
+    "La fonction caracteristique revele une **symetrie parfaite** entre les joueurs :\n",
+    "\n",
+    "- **Coalitions perdantes** (v=0) : singletons uniquement\n",
+    "- **Coalitions gagnantes** (v=1) : toute paire ou plus\n",
+    "\n",
+    "Cette structure est celle d'un **jeu simple symetrique** : tous les joueurs sont interchangeables.\n",
+    "On s'attend donc a des valeurs de Shapley egales (1/3 chacune) -- mais cette allocation **n'est pas\n",
+    "stable** (pas dans le Core)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3b3013b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.744114Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.743844Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.822914Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.822599Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PREUVE QUE LE CORE EST VIDE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Pour qu'une allocation (x1, x2, x3) soit dans le Core :\n",
+      "\n",
+      "1. Efficacite : x1 + x2 + x3 = v(N) = 1\n",
+      "\n",
+      "2. Stabilite (aucune coalition ne peut bloquer) :\n",
+      "   x1 + x2 >= v({1,2}) = 1\n",
+      "   x1 + x3 >= v({1,3}) = 1\n",
+      "   x2 + x3 >= v({2,3}) = 1\n",
+      "\n",
+      "En additionnant les trois contraintes de stabilite :\n",
+      "   2(x1 + x2 + x3) >= 3\n",
+      "   2 * 1 >= 3   (par efficacite x1+x2+x3=1)\n",
+      "   2 >= 3       CONTRADICTION!\n",
+      "\n",
+      "=> Le Core est VIDE.\n",
+      "\n",
+      "Intuition : chaque coalition de 2 joueurs peut bloquer et demander au moins 1,\n",
+      "mais il n'y a que 1 a partager entre les 3 joueurs.\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Preuve que le Core est vide (3 joueurs, majorite simple).\n",
+    "Console.WriteLine(\"PREUVE QUE LE CORE EST VIDE\");\n",
+    "Console.WriteLine(new string('=', 50));\n",
+    "Console.WriteLine(@\"\n",
+    "Pour qu'une allocation (x1, x2, x3) soit dans le Core :\n",
+    "\n",
+    "1. Efficacite : x1 + x2 + x3 = v(N) = 1\n",
+    "\n",
+    "2. Stabilite (aucune coalition ne peut bloquer) :\n",
+    "   x1 + x2 >= v({1,2}) = 1\n",
+    "   x1 + x3 >= v({1,3}) = 1\n",
+    "   x2 + x3 >= v({2,3}) = 1\n",
+    "\n",
+    "En additionnant les trois contraintes de stabilite :\n",
+    "   2(x1 + x2 + x3) >= 3\n",
+    "   2 * 1 >= 3   (par efficacite x1+x2+x3=1)\n",
+    "   2 >= 3       CONTRADICTION!\n",
+    "\n",
+    "=> Le Core est VIDE.\n",
+    "\n",
+    "Intuition : chaque coalition de 2 joueurs peut bloquer et demander au moins 1,\n",
+    "mais il n'y a que 1 a partager entre les 3 joueurs.\n",
+    "\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cabb21d",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Preuve du Core vide\n",
+    "\n",
+    "La preuve utilise la technique classique de **sommation des contraintes** :\n",
+    "\n",
+    "1. Chaque paire exige au moins 1 (elle forme une coalition gagnante).\n",
+    "2. En additionnant les 3 contraintes de paires, chaque joueur apparait 2 fois.\n",
+    "3. On obtient `2 * total >= 3`, soit `2 >= 3` -- contradiction.\n",
+    "\n",
+    "> **Consequence** : dans un jeu de majorite simple, aucun partage ne satisfait toutes les\n",
+    "> coalitions. Shapley donne une allocation \"juste\" (1/3, 1/3, 1/3) mais elle n'est pas stable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "68fdb78c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.824771Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.824460Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.880951Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.880685Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VALEURS DE SHAPLEY :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Joueur 1: 0,3333 = 1/3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Joueur 2: 0,3333 = 1/3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Joueur 3: 0,3333 = 1/3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note : Shapley donne une allocation 'juste' (1/3, 1/3, 1/3)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mais cette allocation n'est PAS stable (pas dans le Core).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification : chaque coalition de 2 peut bloquer\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  x1 + x2 = 0,6667 < 1 = v({1,2})\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Shapley du jeu de majorite (tous egaux par symetrie).\n",
+    "var shapleyMajority = ShapleyValueExact(maj3, 3);\n",
+    "\n",
+    "Console.WriteLine(\"VALEURS DE SHAPLEY :\");\n",
+    "for (int i = 0; i < 3; i++)\n",
+    "    Console.WriteLine($\"  Joueur {i+1}: {shapleyMajority[i]:F4} = 1/3\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Note : Shapley donne une allocation 'juste' (1/3, 1/3, 1/3)\");\n",
+    "Console.WriteLine(\"mais cette allocation n'est PAS stable (pas dans le Core).\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Verification : chaque coalition de 2 peut bloquer\");\n",
+    "Console.WriteLine($\"  x1 + x2 = {shapleyMajority[0] + shapleyMajority[1]:F4} < 1 = v({{1,2}})\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a32be861",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Jeux de Vote Ponderes et indice de Banzhaf\n",
+    "\n",
+    "Un jeu de vote pondere $[q; w_1, \\dots, w_n]$ ou une coalition gagne si $\\sum_{i \\in S} w_i \\geq q$.\n",
+    "L'**indice de Banzhaf** mesure le pouvoir d'un joueur comme le nombre de coalitions ou il est\n",
+    "**critique** (S gagne, S \\ {i} perd), normalise par la somme des pouvoirs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3a57b641",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.882647Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.882370Z",
+     "iopub.status.idle": "2026-07-07T09:07:50.982175Z",
+     "shell.execute_reply": "2026-07-07T09:07:50.981923Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonctions WeightedVotingGame + BanzhafIndex definies.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Jeu de vote pondere : [quota; w1..wn]. v(S) = 1 si sum des poids >= quota.\n",
+    "static GameFunc WeightedVotingGame(int[] weights, int quota) => S =>\n",
+    "    S.Sum(i => weights[i]) >= quota ? 1.0 : 0.0;\n",
+    "\n",
+    "// Indice de Banzhaf normalise : compte les coalitions gagnantes ou chaque joueur est critique.\n",
+    "static double[] BanzhafIndex(GameFunc v, int n)\n",
+    "{\n",
+    "    var critical = new double[n];\n",
+    "    double total = 0;\n",
+    "    foreach (var S in AllCoalitions(n))\n",
+    "    {\n",
+    "        var set = new HashSet<int>(S);\n",
+    "        if (v(set) != 1.0) continue;          // coalition gagnante uniquement\n",
+    "        foreach (var i in S)\n",
+    "        {\n",
+    "            var without = new HashSet<int>(set); without.Remove(i);\n",
+    "            if (v(without) != 1.0)            // i est critique : S\\{i} perd\n",
+    "            {\n",
+    "                critical[i] += 1;\n",
+    "                total += 1;\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "    if (total == 0) return critical;\n",
+    "    for (int k = 0; k < n; k++) critical[k] /= total;\n",
+    "    return critical;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Fonctions WeightedVotingGame + BanzhafIndex definies.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a65ca67",
+   "metadata": {},
+   "source": [
+    "### Mini-ONU : un jeu de vote pondere\n",
+    "\n",
+    "**Mini-ONU** $[9; 7, 7, 1, 1, 1]$ : deux membres permanents (P1, P2, poids 7 chacun) et trois\n",
+    "membres non-permanents (N1, N2, N3, poids 1). Une motion passe si le poids total atteint 9.\n",
+    "On compare **Shapley vs Banzhaf** -- revelateur de l'ecart entre poids nominal et pouvoir reel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "4656b260",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:50.983800Z",
+     "iopub.status.busy": "2026-07-07T09:07:50.983587Z",
+     "iopub.status.idle": "2026-07-07T09:07:51.103559Z",
+     "shell.execute_reply": "2026-07-07T09:07:51.103315Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JEU DE VOTE PONDERE : Mini-ONU\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[9; 7, 7, 1, 1, 1]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P1, P2 = permanents (poids 7), N1, N2, N3 = non-permanents (poids 1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison Shapley vs Banzhaf :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Joueur    Poids     Shapley     Banzhaf     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P1        7         0,3000      0,2857      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P2        7         0,3000      0,2857      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N1        1         0,1333      0,1429      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N2        1         0,1333      0,1429      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N3        1         0,1333      0,1429      \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Somme Shapley = 1,0000, Somme Banzhaf = 1,0000\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Mini-ONU : [9; 7, 7, 1, 1, 1]\n",
+    "int[] wUN = { 7, 7, 1, 1, 1 };\n",
+    "int quotaUN = 9;\n",
+    "var un = WeightedVotingGame(wUN, quotaUN);\n",
+    "var shapleyUN = ShapleyValueExact(un, 5);\n",
+    "var banzhafUN = BanzhafIndex(un, 5);\n",
+    "var labelsUN = new[] { \"P1\", \"P2\", \"N1\", \"N2\", \"N3\" };\n",
+    "\n",
+    "Console.WriteLine(\"JEU DE VOTE PONDERE : Mini-ONU\");\n",
+    "Console.WriteLine(new string('=', 48));\n",
+    "Console.WriteLine($\"[{quotaUN}; {string.Join(\", \", wUN)}]\");\n",
+    "Console.WriteLine(\"P1, P2 = permanents (poids 7), N1, N2, N3 = non-permanents (poids 1)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Comparaison Shapley vs Banzhaf :\");\n",
+    "Console.WriteLine($\"{\"Joueur\",-10}{\"Poids\",-10}{\"Shapley\",-12}{\"Banzhaf\",-12}\");\n",
+    "Console.WriteLine(new string('-', 44));\n",
+    "for (int i = 0; i < 5; i++)\n",
+    "    Console.WriteLine($\"{labelsUN[i],-10}{wUN[i],-10}{shapleyUN[i],-12:F4}{banzhafUN[i],-12:F4}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Somme Shapley = {shapleyUN.Sum():F4}, Somme Banzhaf = {banzhafUN.Sum():F4}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "260a2c28",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Indices de pouvoir\n",
+    "\n",
+    "| Joueur | Poids nominal | Pouvoir Shapley | Ratio pouvoir/poids |\n",
+    "|--------|---------------|-----------------|---------------------|\n",
+    "| P1, P2 | 7 (41%) | 0.30 (30%) | 0.73 |\n",
+    "| N1-N3 | 1 (6%) | 0.13 (13%) | 2.17 |\n",
+    "\n",
+    "**Paradoxe classique** : les non-permanents ont **plus de pouvoir relatif** que leur poids.\n",
+    "Avec 6% du poids, ils captent 13% du pouvoir. Inversement, les permanents (41% du poids) n'ont\n",
+    "que 30% du pouvoir. Le poids nominal ment sur le pouvoir reel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "453fcf55",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:51.105154Z",
+     "iopub.status.busy": "2026-07-07T09:07:51.104906Z",
+     "iopub.status.idle": "2026-07-07T09:07:51.201424Z",
+     "shell.execute_reply": "2026-07-07T09:07:51.201187Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison Shapley vs Banzhaf (Mini-ONU) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P1 (poids 7)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Shapley 0,3000 |##############################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Banzhaf 0,2857 |+++++++++++++++++++++++++++++\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  P2 (poids 7)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Shapley 0,3000 |##############################\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Banzhaf 0,2857 |+++++++++++++++++++++++++++++\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  N1 (poids 1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Shapley 0,1333 |#############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Banzhaf 0,1429 |++++++++++++++\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  N2 (poids 1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Shapley 0,1333 |#############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Banzhaf 0,1429 |++++++++++++++\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  N3 (poids 1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Shapley 0,1333 |#############\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Banzhaf 0,1429 |++++++++++++++\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note : le pouvoir reel (Shapley/Banzhaf) peut differer du poids nominal.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Visualisation ASCII comparative Shapley vs Banzhaf (Mini-ONU).\n",
+    "Console.WriteLine(\"Comparaison Shapley vs Banzhaf (Mini-ONU) :\");\n",
+    "Console.WriteLine();\n",
+    "double maxPow = Math.Max(shapleyUN.Max(), banzhafUN.Max());\n",
+    "foreach (var (lab, sh, ba) in labelsUN.Zip(shapleyUN, banzhafUN))\n",
+    "{\n",
+    "    int wS = (int)Math.Round(sh / maxPow * 30);\n",
+    "    int wB = (int)Math.Round(ba / maxPow * 30);\n",
+    "    Console.WriteLine($\"  {lab} (poids {wUN[Array.IndexOf(labelsUN, lab)]})\");\n",
+    "    Console.WriteLine($\"    Shapley {sh:F4} |{new string('#', wS)}\");\n",
+    "    Console.WriteLine($\"    Banzhaf {ba:F4} |{new string('+', wB)}\");\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Note : le pouvoir reel (Shapley/Banzhaf) peut differer du poids nominal.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8afd8af8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Jeux Convexes : Shapley dans le Core\n",
+    "\n",
+    "Un jeu est **convexe** (supermodulaire) si les contributions marginales sont croissantes :\n",
+    "pour tous S, T : `v(S) + v(T) <= v(S u T) + v(S n T)`.\n",
+    "**Theoreme** : pour un jeu convexe, la valeur de Shapley est **dans le Core** (stable)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0d4e906f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:51.203041Z",
+     "iopub.status.busy": "2026-07-07T09:07:51.202815Z",
+     "iopub.status.idle": "2026-07-07T09:07:51.263529Z",
+     "shell.execute_reply": "2026-07-07T09:07:51.263305Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TEST DE CONVEXITE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu de gants convexe ?     False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu de majorite convexe ?  False\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu d'unanimite convexe ?  True\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Test de convexite : pour tous S, T : v(S)+v(T) <= v(S u T)+v(S n T).\n",
+    "static bool IsConvex(GameFunc v, int n)\n",
+    "{\n",
+    "    foreach (var Ss in AllCoalitions(n))\n",
+    "    {\n",
+    "        var S = new HashSet<int>(Ss);\n",
+    "        foreach (var Tt in AllCoalitions(n))\n",
+    "        {\n",
+    "            var T = new HashSet<int>(Tt);\n",
+    "            var u = new HashSet<int>(S); u.UnionWith(T);\n",
+    "            var inter = new HashSet<int>(S); inter.IntersectWith(T);\n",
+    "            double lhs = v(S) + v(T);\n",
+    "            double rhs = v(u) + v(inter);\n",
+    "            if (lhs > rhs + 1e-10) return false;\n",
+    "        }\n",
+    "    }\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "// Jeu d'unanimite u_{1,2} : v(S) = 1 si S contient {1,2}, 0 sinon.\n",
+    "static GameFunc UnanimityGame12() => S => (S.Contains(0) && S.Contains(1)) ? 1.0 : 0.0;\n",
+    "\n",
+    "Console.WriteLine(\"TEST DE CONVEXITE\");\n",
+    "Console.WriteLine(new string('=', 40));\n",
+    "Console.WriteLine($\"Jeu de gants convexe ?     {IsConvex(glove, 3)}\");\n",
+    "Console.WriteLine($\"Jeu de majorite convexe ?  {IsConvex(maj3, 3)}\");\n",
+    "Console.WriteLine($\"Jeu d'unanimite convexe ?  {IsConvex(UnanimityGame12(), 3)}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a95e483",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Tests de convexite\n",
+    "\n",
+    "- **Glove game** : NON convexe (les contributions marginales ne sont pas croissantes -- un deuxieme\n",
+    "  gant gauche n'apporte rien une fois une paire formee).\n",
+    "- **Majorite** : NON convexe (structure symetrique non supermodulaire).\n",
+    "- **Unanimite** `{1,2}` : convexe. Le theoreme s'applique : sa valeur de Shapley est dans le Core.\n",
+    "\n",
+    "> **Lecon** : la convexite est la condition cle qui reconcilie **equite** (Shapley) et **stabilite**\n",
+    "> (Core). Hors convexite, comme dans le jeu de majorite, Shapley est equitable mais instable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd039b69",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Jeu de vote pondere personnalise\n",
+    "\n",
+    "**Objectif** : definir un jeu de vote pondere de votre choix (ex : conseil municipal $[6; 4,3,2,1]$),\n",
+    "calculer Shapley et Banzhaf, identifier les joueurs dont le pouvoir depasse le poids.\n",
+    "\n",
+    "- **Indice :** `WeightedVotingGame(new[]{4,3,2,1}, 6)`.\n",
+    "- **Etape 1 :** calculer `ShapleyValueExact` et `BanzhafIndex`.\n",
+    "- **Etape 2 :** comparer ratio pouvoir/poids de chaque joueur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "bfacbfe2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:51.265191Z",
+     "iopub.status.busy": "2026-07-07T09:07:51.264956Z",
+     "iopub.status.idle": "2026-07-07T09:07:51.312798Z",
+     "shell.execute_reply": "2026-07-07T09:07:51.312586Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : Shapley et Banzhaf d'un jeu de vote pondere.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 (stub C.1) : analyse d'un jeu de vote pondere personnalise.\n",
+    "static (double[] shapley, double[] banzhaf) ExerciceWeightedVoting()\n",
+    "{\n",
+    "    // TODO etudiant : choisir un jeu [q; w...], retourner (ShapleyValueExact, BanzhafIndex).\n",
+    "    return (new double[0], new double[0]);  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "var (sh2, bz2) = ExerciceWeightedVoting();\n",
+    "if (sh2.Length > 0)\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice 2 : pouvoir par joueur (Shapley / Banzhaf).\");\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    Console.WriteLine(\"Exercice 2 a completer : Shapley et Banzhaf d'un jeu de vote pondere.\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70d4119b",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Verification du Core pour un jeu convexe\n",
+    "\n",
+    "**Objectif** : pour le jeu d'unanimite `{1,2}` a 3 joueurs (convexe), verifier que la valeur de\n",
+    "Shapley est bien dans le Core en testant toutes les contraintes de stabilite.\n",
+    "\n",
+    "- **Indice :** `UnanimityGame12()` ; une allocation (x1,x2,x3) est dans le Core si elle est efficace\n",
+    "  (`x1+x2+x3 = v(N)`) et stable (`xS >= v(S)` pour toute coalition S).\n",
+    "- **Etape 1 :** calculer `ShapleyValueExact(UnanimityGame12(), 3)`.\n",
+    "- **Etape 2 :** verifier que chaque contrainte de coalition est satisfaite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ecb31a9b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T09:07:51.314275Z",
+     "iopub.status.busy": "2026-07-07T09:07:51.314041Z",
+     "iopub.status.idle": "2026-07-07T09:07:51.389923Z",
+     "shell.execute_reply": "2026-07-07T09:07:51.389400Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : verifier l'appartenance de Shapley au Core.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 (stub C.1) : verifier que Shapley d'un jeu convexe est dans le Core.\n",
+    "static bool ExerciceShapleyInCore()\n",
+    "{\n",
+    "    // TODO etudiant : calculer Shapley de UnanimityGame12(), verifier toutes les contraintes du Core.\n",
+    "    return false;  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "bool inCore = ExerciceShapleyInCore();\n",
+    "Console.WriteLine(inCore\n",
+    "    ? \"Exercice 3 : Shapley du jeu d'unanimite EST dans le Core (convexe).\"\n",
+    "    : \"Exercice 3 a completer : verifier l'appartenance de Shapley au Core.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51478c5c",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "Ce twin C# a confirme, valeur pour valeur, les memes resultats que le notebook Python :\n",
+    "\n",
+    "- **Shapley (glove)** : (1/6, 1/6, 4/6) -- la ressource rare (R1) capture l'essentiel.\n",
+    "- **Core vide** : le jeu de majorite 3-joueurs n'admet aucun partage stable (contradiction 2 >= 3).\n",
+    "- **Shapley (majorite)** : (1/3, 1/3, 1/3) -- equitable mais instable.\n",
+    "- **Mini-ONU** : ecart poids/pouvoir revelé (Shapley vs Banzhaf proches ici).\n",
+    "- **Convexite** : seule l'unanimite est convexe (Shapley alors dans le Core).\n",
+    "\n",
+    "> **Parite .NET ⇄ Python (marathon #4956)** : tous les ancres deterministes (valeurs de Shapley,\n",
+    "> fonction caracteristique, convexite) sont concordants au bit pres entre le twin C# (BCL .NET 9,\n",
+    "> 0 NuGet) et le twin Python (numpy/stdlib). Les deux runtimes implementent fidelement les memes\n",
+    "> algorithmes exacts (permutations pour Shapley, enumeration de coalitions pour Banzhaf).\n",
+    "\n",
+    "Voir aussi : [15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb) (track principal),\n",
+    "[15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) (preuves formelles Lean).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -165,6 +165,7 @@ flowchart TD
 | 15 (C#) | [GameTheory-15-CooperativeGames-Csharp](GameTheory-15-CooperativeGames-Csharp.ipynb) | .NET (C#) | Twin C# du 15 : Shapley (permutations), Banzhaf (swing), core, convexité, airport game from-scratch (See #4956) | 65 min |
 | 15b | [GameTheory-15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb) | Lean 4 | Axiomes Shapley formels, Core | 55 min |
 | 15c | [GameTheory-15c-CooperativeGames-Python](GameTheory-15c-CooperativeGames-Python.ipynb) | Python | Exemples avancés (Glove Game, politique) | 40 min |
+| 15c (C#) | [GameTheory-15c-CooperativeGames-Csharp](GameTheory-15c-CooperativeGames-Csharp.ipynb) | .NET (C#) | Twin C# du 15c : Shapley (permutations), Banzhaf (swing), Core vide (majorité 3-joueurs), Mini-ONU, convexité from-scratch (See #4956) | 40 min |
 | 16 | [GameTheory-16-MechanismDesign](GameTheory-16-MechanismDesign.ipynb) | Python | Principe de révélation, VCG, matching | 65 min |
 | 16 (C#) | [GameTheory-16-MechanismDesign-Csharp](GameTheory-16-MechanismDesign-Csharp.ipynb) | .NET (C#) | Twin C# du 16 : **enchères Vickrey 1er/2nd prix + VCG (règle de Clarke) + Gale-Shapley (stable matching) + double auction** from-scratch, BCL .NET 9 (See #4956) | 50 min |
 | SC-01 | [SocialChoice/01-Arrow-Impossibility-Theorem](SocialChoice/01-Arrow-Impossibility-Theorem.ipynb) | Python | Arrow : preuve formelle vs simulation | 45 min |
@@ -563,6 +564,7 @@ GameTheory/
 ├── GameTheory-7-ExtensiveForm-Csharp.ipynb                      # Twin C# arbre de jeu + infosets from-scratch (marathon #4956, Prong B)
 ├── GameTheory-14-DifferentialGames-Csharp.ipynb                 # Twin C# jeux différentiels : RK4 + Riccati from-scratch, pursuit-evasion (marathon #4956, Prong B)
 ├── GameTheory-15-CooperativeGames-Csharp.ipynb                  # Twin C# Shapley + Banzhaf + core + convexité + airport game from-scratch (marathon #4956)
+├── GameTheory-15c-CooperativeGames-Csharp.ipynb                 # Twin C# du 15c : Shapley (permutations) + Banzhaf + Core vide (majorité) + Mini-ONU + convexité from-scratch (marathon #4956, Prong B)
 ├── GameTheory-10-ForwardInduction-SPE-Csharp.ipynb              # Twin C# SPE/backward-induction + trembling-hand + forward induction + burn money (marathon #4956)
 ├── SocialChoice/                                                   # Sous-série Choix Social
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb


### PR DESCRIPTION
## Summary

Twin C# (.NET 9, BCL seule, **0 NuGet**) de [`GameTheory-15c-CooperativeGames-Python.ipynb`](MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb) — marathon **#4956** (parité .NET ⇄ Python). Implémente **from-scratch** les concepts de jeux coopératifs avancés : valeur de Shapley, indice de Banzhaf, Core, jeux de vote pondérés, convexité.

See #4956 (contribution partielle à l'Epic parité — l'Epic reste ouvert).

## Algorithme (Prong B from-scratch, SOTA-OK)

Aucun solveur NuGet canonique n'existe pour la théorie des jeux coopératifs. La valeur de Shapley et l'indice de Banzhaf sont des **algorithmes déterministes** : ce twin les implémente fidelement en C# (permutations via Heap pour Shapley, énumération de coalitions pour Banzhaf), en miroir exact du twin Python qui les implémente aussi lui-même (numpy/stdlib). **Verdict SOTA : SOTA-OK** (les vrais algorithmes sont implémentés et exécutés — pas de workaround dégradé).

**Prong B (non-trivialité)** : le notebook pose des problèmes riches qui exercent les algorithmes — Shapley sur le jeu de gants (asymétrie ressource rare), Core vide (preuve par contradiction 2≥3), comparaison Shapley/Banzhaf sur Mini-ONU (écart poids/pouvoir).

## Ancres déterministes — concordance bit-par-bit avec le twin Python

| Ancre | Résultat C# | Python 15c | Concordance |
|-------|-------------|------------|-------------|
| Shapley glove (L1, L2, R1) | 1/6, 1/6, 4/6 | 1/6, 1/6, 4/6 | EXACT |
| Shapley majorité (3 joueurs) | 1/3, 1/3, 1/3 | 1/3, 1/3, 1/3 | EXACT |
| Core vide (majorité 3-j) | contradiction 2≥3 | contradiction 2≥3 | EXACT |
| Mini-ONU P1/P2 Shapley | 0.3000 | 0.30 | EXACT |
| Mini-ONU P1/P2 Banzhaf | 0.2857 | 0.2857 | EXACT |
| Mini-ONU N1-N3 Shapley | 0.1333 | 0.1333 | EXACT |
| Mini-ONU N1-N3 Banzhaf | 0.1429 | 0.1429 | EXACT |
| Convexité glove / majorité / unanimity | False / False / True | False / False / True | EXACT |

> Note : le séparateur décimal virgule (`0,3000`) dans les sorties C# est le rendu de la culture .NET française sur la machine worker — artifact de locale, pas une différence mathématique. Sortie réelle non hand-editée (Stop & Repair respecté).

## Preuve d'exécution (§D, EXEC_PROVED H.1)

```
jupyter nbconvert --to notebook --execute --inplace \
  --ExecutePreprocessor.kernel_name=.net-csharp \
  MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
→ [NbConvertApp] Writing 53069 bytes  (SUCCESS, 0 erreur)
```

**Forensic JSON** : `code=15 ec_none=0 errors=0 C.1=0 leaks=0`, `ec=[1..15]` (toutes les cellules exécutées, 0 erreur, 0 pattern banni C.1, 0 fuite de chemin machine).

Vérification C.1 (grep patterns interdits) : `0` occurrence de `raise NotImplementedError` / `assert False` / `1/0` / `throw null`.

## Périmètre

- **Nouveau notebook** : `GameTheory-15c-CooperativeGames-Csharp.ipynb` (32 cells : 15 code + 17 markdown, 3 exercices C.1 stubs)
- **README** : `GameTheory/README.md` +1 ligne table de navigation (rang « 15c (C#) ») +1 ligne arbre de structure. Audit fichier-entier fait (§E) : « statut maturité » et « apport pédagogique » ne listent pas les twins C# (cohérent avec 13/14/15/16-Csharp) — pas de modification de ces tables. Marqueur `CATALOG-STATUS` byte-identique à `main` (0 churn catalogue).

## Contenu pédagogique

1. **Valeur de Shapley** (rappels + permutations de Heap)
2. **Jeu de gants** (glove game) — ressource rare, Shapley (1/6, 1/6, 4/6)
3. **Core vide** (jeu de majorité 3-joueurs, preuve par sommation des contraintes)
4. **Jeux de vote pondérés + indice de Banzhaf** — Mini-ONU [9;7,7,1,1,1], écart poids/pouvoir
5. **Convexité** (supermodularité, condition Shapley ∈ Core)
6. **3 exercices** : gants 4-joueurs, vote pondéré personnalisé, vérification Core pour jeu convexe

Co-Authored-By: Claude-Code <noreply@anthropic.com>
