### PR TITLE
docs(symbolicai): fix README intro drift — SMT family omitted from prose (§E, #4959)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -11,15 +11,16 @@ maturity: PRODUCTION=165, BETA=31, ALPHA=1
 
 L'intelligence artificielle n'est pas qu'apprentissage automatique et réseaux de neurones. Une grande partie de l'IA classique repose sur le **raisonnement symbolique** : représenter la connaissance sous forme de propositions, de règles et de structures logiques, puis dériver mécaniquement de nouvelles conclusions. C'est cette tradition — des systèmes experts des années 80 aux assistants de preuve modernes comme Lean 4 — que cette série explore en profondeur.
 
-Vous y découvrirez sept domaines complémentaires. Le **Web Sémantique** (RDF, SPARQL, OWL) montre comment structurer les connaissances du web pour les rendre exploitables par les machines. La **vérification formelle** avec Lean 4 vous apprend à écrire des preuves mathématiques vérifiées par un ordinateur. L'**argumentation computationnelle** (TweetyProject) modélise le débat et la délibération. La **planification automatique** résout des problèmes concrets de logistique et d'ordonnancement. Les **smart contracts** relient la cryptographie et la logique formelle aux blockchains. L'**analyse argumentative** avec les LLMs jette un pont entre l'IA symbolique et l'IA neuronale. Et l'**apprentissage symbolique** (AIMA ch. 19) montre comment un agent apprend à partir de connaissances existantes plutôt que de données brutes, jusqu'aux pipelines neuro-symboliques couplés aux LLMs. Chaque sous-série est autonome, mais ensemble elles dessinent une vision cohérente de l'IA symbolique moderne.
+Vous y découvrirez huit domaines complémentaires. Le **Web Sémantique** (RDF, SPARQL, OWL) montre comment structurer les connaissances du web pour les rendre exploitables par les machines. La **vérification formelle** avec Lean 4 vous apprend à écrire des preuves mathématiques vérifiées par un ordinateur. L'**argumentation computationnelle** (TweetyProject) modélise le débat et la délibération. La **résolution SMT** (Z3, satisfiability modulo theories) automatise la décision sous contraintes — cryptarithmes, planification, vérification de propriétés. La **planification automatique** résout des problèmes concrets de logistique et d'ordonnancement. Les **smart contracts** relient la cryptographie et la logique formelle aux blockchains. L'**analyse argumentative** avec les LLMs jette un pont entre l'IA symbolique et l'IA neuronale. Et l'**apprentissage symbolique** (AIMA ch. 19) montre comment un agent apprend à partir de connaissances existantes plutôt que de données brutes, jusqu'aux pipelines neuro-symboliques couplés aux LLMs. Chaque sous-série est autonome, mais ensemble elles dessinent une vision cohérente de l'IA symbolique moderne.
 
-**Carte de la famille** — les sept sous-séries et leurs ponts (formalismes fondamentaux → applications → ponts neuro-symboliques) :
+**Carte de la famille** — les huit sous-séries et leurs ponts (formalismes fondamentaux → applications → ponts neuro-symboliques) :
 
 ```mermaid
 flowchart TD
     TW["Tweety<br/>Argumentation + logiques<br/>(Dung, ASPIC+, AGM, Pearl)"]
     SW["SemanticWeb<br/>Connaissance du web<br/>(RDF, SPARQL, OWL, SHACL)"]
     LEAN["Lean<br/>Preuve formelle<br/>(Mathlib4, types dependants)"]
+    SMT["SMT / Z3<br/>Décision sous contraintes<br/>(SAT modulo theories, optimisation)"]
     PL["Planners<br/>Planification<br/>(PDDL, Fast-Downward, CP-SAT)"]
     SC["SmartContracts<br/>Blockchain + crypto<br/>(Solidity, DeFi, ZK)"]
     AA["Argument Analysis<br/>Pont LLM (sophismes, SK)"]
@@ -28,6 +29,8 @@ flowchart TD
     TW -->|"generalise en representation"| SW
     TW -.->|"companion natif (Tweety-5b)"| LEAN
     LEAN -.->|"companion (planners_lean)"| PL
+    SMT -.->|"meme solveur Z3"| PL
+    LEAN -->|"verification de proprietes"| SMT
     TW --> AA
     SW -->|"GraphRAG / linked data"| AA
     AA --> SL
@@ -36,7 +39,7 @@ flowchart TD
     classDef app fill:#e6f4ea,stroke:#188038
     classDef bridge fill:#fef7e0,stroke:#f9ab00
     class TW,SW,LEAN found
-    class PL,SC app
+    class SMT,PL,SC app
     class AA,SL bridge
 ```
 
@@ -699,7 +702,7 @@ Légende : ● couverture large ; ◐ couverture partielle / companion ; — abs
 
 ### Ce que cette série dessine
 
-Les sept domaines ci-dessus ne sont pas sept sujets indépendants : ils forment un **pipeline complet du raisonnement symbolique**, du représentationnel au certifié. L'architecture implicite du parcours :
+Les huit domaines ci-dessus ne sont pas huit sujets indépendants : ils forment un **pipeline complet du raisonnement symbolique**, du représentationnel au certifié. L'architecture implicite du parcours :
 
 - **Représenter** la connaissance (Tweety : logiques formelles ; SemanticWeb : RDF/OWL/SHACL pour le web de données).
 - **Raisonner** dessus (Tweety : argumentation, révision de croyances ; SMT/Z3 : décision automatique par contraintes).


### PR DESCRIPTION
## Summary

Fix §E drift on the SymbolicAI hub README (P0 central hub, see #4959). The intro paragraph said **« sept domaines complémentaires »** but only enumerated **7** — omitting **SMT/Z3 entirely**, even though SMT is the **3rd-largest family** (29 notebooks per CATALOG-STATUS breakdown). The mermaid family map and the conclusion had the same omission.

SMT was well-documented deeper in the file (sections l.363-430, 563-694, pipeline summary l.708) — this was purely an **intro-level §E drift**: the prose's family roster didn't match the (correct) CATALOG marker and disk.

## Audit fichier-entier (§E rule)

Reconciled **prose ↔ CATALOG-STATUS ↔ disk**:

| Family | CATALOG-STATUS | Disk (origin/main) | In intro prose? |
|--------|---------------|--------------------|------------------|
| Tweety | 32 | 32 | ✓ |
| SMT | 29 | 29 | ✗ (omitted — **fixed**) |
| Lean | 28 | 28 | ✓ |
| SmartContracts | 27 | 27 | ✓ |
| Planners | 23 | 23 | ✓ |
| SemanticWeb | 22 | 22 | ✓ |
| Argument_Analysis | 18 | 18 | ✓ |
| SymbolicLearning | 17 | 17 | ✓ |

→ **8 families**, intro said 7. CATALOG-STATUS marker is **byte-identical** to main (0 churn — catalog-pr-hygiene respected: not regenerated on branch).

## Changes (3 surgical prose edits)

1. **Intro paragraph (l.14)**: « sept » → « huit », added SMT sentence: *« La résolution SMT (Z3, satisfiability modulo theories) automatise la décision sous contraintes — cryptarithmes, planification, vérification de propriétés. »*
2. **Mermaid map (l.18-41)**: added  node + 2 edges ( same Z3 solver,  property verification), classed as .
3. **Conclusion (l.705)**: « Les sept domaines... sept sujets » → « Les huit domaines... huit sujets ».

## Residual drift — honestly documented (deferred)

The **« Parcours d'apprentissage » Phases 1-4 (l.45-69)** have **no dedicated SMT phase** — only Tweety/SemanticWeb/Lean/Planners+SmartContracts/ArgumentAnalysis/SymbolicLearning get a phase. Adding a SMT phase needs a **pedagogical placement decision** (Phase 3.5 between Lean-preuve and Planners-applications, or merged into Phase 4) — scope larger than an intro §E fix, deferred to a separate PR. The pipeline summary (l.707-712) already correctly includes SMT (*« Raisonner dessus (... SMT/Z3 : décision automatique par contraintes) »*).

See #4959 (intermediate READMEs P0). See #3973 (ascending method).

## Validation

-  (two-dot, not three-dot) = exactly 3 surgical hunks, CATALOG-STATUS untouched.
- French-first prose (readme-french-first rule), no emojis, no catalog regen.

Co-Authored-By: Claude-Code <noreply@anthropic.com>