### PR TITLE
fix(ci): force core.quotePath=false in Quarto render generator (site deploy ~2 days down)

### DIFF
--- a/scripts/regen_quarto_render.py
+++ b/scripts/regen_quarto_render.py
@@ -59,8 +59,14 @@ EXCLUDE_MARKERS = (
 def git_tracked_readmes() -> list[str]:
     """Return repo-relative POSIX paths of every git-tracked README.md,
     excluding vendored and archived subtrees."""
+    # `-c core.quotePath=false`: without it, git quotes non-ASCII paths
+    # (accents/spaces) as "\303\251..." AND wraps them in double-quotes under
+    # CI's default core.quotePath=true. The emitter below wraps again -> doubled
+    # quotes ("" ... "") -> broken YAML in _quarto.yml (CI Quarto Pages Deploy
+    # failure since 2026-07-05). Forcing false yields raw UTF-8 paths, so the
+    # single wrap below stays valid YAML on every machine (CI or local).
     out = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "ls-files", "*README.md"],
+        ["git", "-C", str(REPO_ROOT), "-c", "core.quotePath=false", "ls-files", "*README.md"],
         capture_output=True, text=True, check=True,
     )
     paths = []


### PR DESCRIPTION
## Problem

The **Quarto Pages Deploy** workflow (`quarto-pages-deploy.yml`, push:main only) has been **failing since 2026-07-05T15:38** — last green deploy right before commit `c5714ed49` (#5452, which expanded the render list to 382 READMEs). The user noticed the ~2-day site outage.

Failure at `quarto render`:
```
YAMLException: bad indentation of a sequence entry (_quarto.yml, 19:9)
```

## Root cause — environment drift in the render-list generator

`_quarto.yml`'s `project.render` list is regenerated as a CI **pre-render step** by `scripts/regen_quarto_render.py`, which runs `git ls-files *README.md`.

- Under CI's **default `core.quotePath=true`**, git returns non-ASCII paths (accents / spaces) **pre-wrapped in double-quotes and octal-escaped**: `"MyIA.AI.Notebooks/GenAI/Vibe-Coding/.../Conf\303\251rence Tech 2025/README.md"`.
- The emitter then wraps **again** (`f'    - "{p}"'`) -> `""...\303\251...""` -> **doubled quotes** -> broken YAML.
- On a dev machine with `core.quotePath=false`, paths come out as raw UTF-8, the single wrap is valid, and the committed `_quarto.yml` is clean — which is why the file on `main` looks fine while CI regenerates a broken one. **Classic works-on-my-machine drift.**

Empirically verified this window: **10** README paths get quoted under `quotePath=true`; raw UTF-8 under `quotePath=false`.

## Fix

Force `-c core.quotePath=false` in the generator's `git ls-files` subprocess, so paths are raw UTF-8 regardless of the ambient git config. The single YAML wrap then stays valid on **every** machine (CI or local).

## Verification

Simulated CI locally (`git config core.quotePath true`) then ran the fixed generator:
- `grep -c '""' _quarto.yml` -> **0** (no doubled-quotes)
- `python -c "import yaml; yaml.safe_load(open('_quarto.yml'))"` -> **OK, 389 render entries**
- `git diff --numstat _quarto.yml` -> **empty** (regenerated file is byte-identical to origin/main)

So this PR is **script-only** (`_quarto.yml` unchanged). The Quarto Pages Deploy job only runs on push:main, so the real confirmation is the **post-merge deploy run**, which I will watch.

See #4211 (Axe C -- Quarto Pages site deploy)