### PR TITLE
feat(search): App-8-MiniZinc-Csharp twin .NET (marathon #4956)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
@@ -1,0 +1,1718 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "94cce746",
+   "metadata": {},
+   "source": [
+    "# App-8 : Modelisation declarative par contraintes (twin C# .NET)\n",
+    "\n",
+    "> **Twin C# .NET de `App-8-MiniZinc.ipynb`** (marathon parite #4956). Kernel `.net-csharp`. Ce notebook utilise **Google.OrTools CP-SAT** (Prong A, EPIC #3801) -- le vrai moteur industriel de programmation par contraintes, accessible en .NET via NuGet. MiniZinc etant un langage de modelisation independant sans binding .NET officiel, ce twin exprime les memes modeles declaratifs via OR-Tools CP-SAT, qui partage le paradigme : **declarer les contraintes, laisser le solveur chercher**. Les graphiques matplotlib du twin Python sont remplaces par un rendu ASCII autonome.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Comprendre** le paradigme declaratif (CP) face a l'imperatif (backtracking)\n",
+    "2. **Modeliser** en OR-Tools CP-SAT : variables, domaines, contraintes lineaires et globales\n",
+    "3. **Resolver** problemes classiques (equations, monnaie, N-Reines, emploi du temps, Sudoku)\n",
+    "4. **Comparer** la concision CP-SAT vs MiniZinc (du twin Python)\n",
+    "5. **Optimiser** : minimiser un objectif (monnaie, makespan, distance)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "31951426",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:04.522703Z",
+     "iopub.status.busy": "2026-07-07T10:00:04.518060Z",
+     "iopub.status.idle": "2026-07-07T10:00:08.983069Z",
+     "shell.execute_reply": "2026-07-07T10:00:08.976612Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '55600.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.15.6755</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Environnement charge.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  .NET 10.0.9\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Google.OrTools CP-SAT importe (vrai moteur industriel, Prong A #3801)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// App-8 : Modelisation declarative par contraintes -- twin C# de App-8-MiniZinc\n",
+    "// Prong A (#3801) : Google.OrTools CP-SAT, le vrai moteur industriel de programmation\n",
+    "// par contraintes. MiniZinc est un LANGAGE de modelisation independant (multi-solveur)\n",
+    "// sans binding .NET officiel ; ce twin exprime donc les memes modeles declaratifs via\n",
+    "// OR-Tools CP-SAT, qui partage le MEME paradigme (declarer les contraintes, laisser le\n",
+    "// solveur chercher). Le twin Python (App-8-MiniZinc.ipynb) utilise MiniZinc + OR-Tools.\n",
+    "#r \"nuget: Google.OrTools\"\n",
+    "\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Diagnostics;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "using Google.OrTools.Sat;\n",
+    "\n",
+    "// Culture invariante : separateur decimal \".\" (parite de sortie avec le twin Python,\n",
+    "// independant du locale FR de la machine hote). Les 3 setters sont necessaires car\n",
+    "// .NET Interactive evalue les cellules sur des threads du pool distincts.\n",
+    "CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;\n",
+    "CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;\n",
+    "CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;\n",
+    "\n",
+    "Console.WriteLine(\"Environnement charge.\");\n",
+    "Console.WriteLine(\"  .NET \" + Environment.Version);\n",
+    "Console.WriteLine(\"  Google.OrTools CP-SAT importe (vrai moteur industriel, Prong A #3801)\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b5194aaf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:08.985930Z",
+     "iopub.status.busy": "2026-07-07T10:00:08.985507Z",
+     "iopub.status.idle": "2026-07-07T10:00:09.319247Z",
+     "shell.execute_reply": "2026-07-07T10:00:09.319049Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonctions utilitaires definies.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Utilitaire d'affichage d'un modele declare (numerotation des lignes), comme\n",
+    "// display_model() du twin Python. Permet de montrer la syntaxe MiniZinc cote-a-cote\n",
+    "// avec le code CP-SAT C# executable correspondant.\n",
+    "static void DisplayModel(string modelStr, string title = \"Modele MiniZinc\")\n",
+    "{\n",
+    "    string bar = new string('=', 60);\n",
+    "    Console.WriteLine(\"\\n\" + bar + \"\\n  \" + title + \"\\n\" + bar);\n",
+    "    var lines = modelStr.Trim().Split('\\n');\n",
+    "    for (int i = 0; i < lines.Length; i++)\n",
+    "        Console.WriteLine($\"  {i + 1,2} | {lines[i]}\");\n",
+    "    Console.WriteLine(bar + \"\\n\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Fonctions utilitaires definies.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05c19703",
+   "metadata": {},
+   "source": [
+    "## 1. Introduction : pourquoi la programmation par contraintes ?\n",
+    "\n",
+    "La **programmation par contraintes (CP)** renverse le paradigme imperatif : au lieu decrire *comment* resoudre (algorithme pas-a-pas), on decrit *quoi* resoudre (les contraintes que la solution doit satisfaire), et un **solveur** cherche. MiniZinc est un langage dedie (concis, multi-solveur) ; OR-Tools CP-SAT est un moteur industriel accessible via une API .NET. Ce twin utilise CP-SAT ; le twin Python montre MiniZinc cote-a-cote.\n",
+    "\n",
+    "### Architecture\n",
+    "\n",
+    "```\n",
+    "Modele (variables + contraintes)  -->  Solveur CP-SAT  -->  Solution\n",
+    "   (ce qu'on veut)                      (le moteur)        (ce qu'on obtient)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "05487dc2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:09.320557Z",
+     "iopub.status.busy": "2026-07-07T10:00:09.320324Z",
+     "iopub.status.idle": "2026-07-07T10:00:09.534879Z",
+     "shell.execute_reply": "2026-07-07T10:00:09.534566Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "============================================================\n",
+      "  Systeme d'equations (syntaxe MiniZinc)\n",
+      "============================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   1 | var 1..10: x;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2 | var 1..10: y;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   3 | constraint x + y = 10;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   4 | constraint x * y = 21;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   5 | solve satisfy;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution CP-SAT : x = 7, y = 3  (status: Optimal)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verification : x + y = 10, x * y = 21\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 2 : Premier modele -- systeme d'equations ===\n",
+    "// x + y = 10 ET x * y = 21 (x, y dans 1..10). Solution : x = 7, y = 3 (ou x = 3, y = 7).\n",
+    "//\n",
+    "// Equivalent MiniZinc (modele declare puis resolu par le twin Python) :\n",
+    "//   var 1..10: x;  var 1..10: y;\n",
+    "//   constraint x + y = 10;  constraint x * y = 21;\n",
+    "//   solve satisfy;\n",
+    "\n",
+    "string mznEquations = @\"\n",
+    "var 1..10: x;\n",
+    "var 1..10: y;\n",
+    "constraint x + y = 10;\n",
+    "constraint x * y = 21;\n",
+    "solve satisfy;\";\n",
+    "DisplayModel(mznEquations, \"Systeme d'equations (syntaxe MiniZinc)\");\n",
+    "\n",
+    "// Execution CP-SAT C# (Prong A : vrai moteur).\n",
+    "var model = new CpModel();\n",
+    "var x = model.NewIntVar(1, 10, \"x\");\n",
+    "var y = model.NewIntVar(1, 10, \"y\");\n",
+    "model.Add(x + y == 10);\n",
+    "var produit = model.NewIntVar(1, 100, \"produit\");\n",
+    "model.AddMultiplicationEquality(produit, new[] { x, y });\n",
+    "model.Add(produit == 21);\n",
+    "\n",
+    "var solver = new CpSolver();\n",
+    "var status = solver.Solve(model);\n",
+    "Console.WriteLine($\"Solution CP-SAT : x = {solver.Value(x)}, y = {solver.Value(y)}  (status: {status})\");\n",
+    "Console.WriteLine($\"Verification : x + y = {solver.Value(x) + solver.Value(y)}, x * y = {solver.Value(x) * solver.Value(y)}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59264935",
+   "metadata": {},
+   "source": [
+    "## 2. Syntaxe de base : premier modele\n",
+    "\n",
+    "On commence par un **systeme d'equations** simple. MiniZinc (twin Python) l'exprime en 5 lignes ; CP-SAT C# ajoute la creation explicite des variables et le produit via `AddMultiplicationEquality`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "54d9a8d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:09.536598Z",
+     "iopub.status.busy": "2026-07-07T10:00:09.536374Z",
+     "iopub.status.idle": "2026-07-07T10:00:09.656257Z",
+     "shell.execute_reply": "2026-07-07T10:00:09.656050Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "============================================================\n",
+      "  Probleme de monnaie (optimisation, syntaxe MiniZinc)\n",
+      "============================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   1 | var 0..99: p1; var 0..19: p5; var 0..9: p10; var 0..3: p25;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2 | constraint p1 + 5*p5 + 10*p10 + 25*p25 = 99;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   3 | var int: total = p1 + p5 + p10 + p25;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   4 | solve minimize total;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution optimale CP-SAT :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3x25c + 2x10c + 0x5c + 4x1c\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Total = 9 pieces (minimum prouve par le solveur)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 2 (suite) : Optimisation -- probleme de monnaie ===\n",
+    "// Rendre 99 centimes avec le MINIMUM de pieces (1c, 5c, 10c, 25c).\n",
+    "// Solution optimale : 3x25c + 2x10c + 0x5c + 4x1c = 9 pieces.\n",
+    "//\n",
+    "// Equivalent MiniZinc : solve minimize total;  -->  CP-SAT : model.Minimize(total)\n",
+    "\n",
+    "string mznCoins = @\"\n",
+    "var 0..99: p1; var 0..19: p5; var 0..9: p10; var 0..3: p25;\n",
+    "constraint p1 + 5*p5 + 10*p10 + 25*p25 = 99;\n",
+    "var int: total = p1 + p5 + p10 + p25;\n",
+    "solve minimize total;\";\n",
+    "DisplayModel(mznCoins, \"Probleme de monnaie (optimisation, syntaxe MiniZinc)\");\n",
+    "\n",
+    "var mCoins = new CpModel();\n",
+    "var p1 = mCoins.NewIntVar(0, 99, \"p1\");\n",
+    "var p5 = mCoins.NewIntVar(0, 19, \"p5\");\n",
+    "var p10 = mCoins.NewIntVar(0, 9, \"p10\");\n",
+    "var p25 = mCoins.NewIntVar(0, 3, \"p25\");\n",
+    "mCoins.Add(p1 + 5 * p5 + 10 * p10 + 25 * p25 == 99);\n",
+    "var totalCoins = mCoins.NewIntVar(0, 200, \"total\");\n",
+    "mCoins.Add(totalCoins == p1 + p5 + p10 + p25);\n",
+    "mCoins.Minimize(totalCoins);   // <-- objectif : minimiser le nombre de pieces\n",
+    "\n",
+    "var sCoins = new CpSolver();\n",
+    "sCoins.Solve(mCoins);\n",
+    "Console.WriteLine(\"Solution optimale CP-SAT :\");\n",
+    "Console.WriteLine($\"  {sCoins.Value(p25)}x25c + {sCoins.Value(p10)}x10c + {sCoins.Value(p5)}x5c + {sCoins.Value(p1)}x1c\");\n",
+    "Console.WriteLine($\"  Total = {sCoins.ObjectiveValue} pieces (minimum prouve par le solveur)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92e37664",
+   "metadata": {},
+   "source": [
+    "### Optimisation : probleme de monnaie\n",
+    "\n",
+    "On passe de `solve satisfy` (trouver UNE solution) a `solve minimize` (trouver la MEILLEURE). En CP-SAT : `model.Minimize(objectif)`. Le solveur prouve l'optimalite (aucune solution a moins de pieces n'existe)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "de6d8ffa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:09.657768Z",
+     "iopub.status.busy": "2026-07-07T10:00:09.657553Z",
+     "iopub.status.idle": "2026-07-07T10:00:09.715457Z",
+     "shell.execute_reply": "2026-07-07T10:00:09.714647Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "============================================================\n",
+      "  N-Reines (syntaxe MiniZinc, ~5 lignes)\n",
+      "============================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   1 | include \"globals.mzn\";\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   2 | int: n = 8;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   3 | array[1..n] of var 1..n: q;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   4 | constraint alldifferent(q);                        % pas meme ligne\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   5 | constraint alldifferent([q[i] + i | i in 1..n]);   % pas meme diagonale montante\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   6 | constraint alldifferent([q[i] - i | i in 1..n]);   % pas meme diagonale descendante\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   7 | solve satisfy;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison de concision : MiniZinc ~5 lignes vs CP-SAT ~12 lignes (ratio ~2.4x).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 3 : Contraintes globales -- N-Reines ===\n",
+    "// MiniZinc exprime N-Reines en ~5 lignes grace a la contrainte globale alldifferent.\n",
+    "// On presente la concision MiniZinc, puis l'equivalent CP-SAT C# executable.\n",
+    "\n",
+    "string mznNQueens = @\"\n",
+    "include \"\"globals.mzn\"\";\n",
+    "int: n = 8;\n",
+    "array[1..n] of var 1..n: q;\n",
+    "constraint alldifferent(q);                        % pas meme ligne\n",
+    "constraint alldifferent([q[i] + i | i in 1..n]);   % pas meme diagonale montante\n",
+    "constraint alldifferent([q[i] - i | i in 1..n]);   % pas meme diagonale descendante\n",
+    "solve satisfy;\";\n",
+    "DisplayModel(mznNQueens, \"N-Reines (syntaxe MiniZinc, ~5 lignes)\");\n",
+    "Console.WriteLine(\"Comparaison de concision : MiniZinc ~5 lignes vs CP-SAT ~12 lignes (ratio ~2.4x).\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "81096937",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:09.717414Z",
+     "iopub.status.busy": "2026-07-07T10:00:09.717056Z",
+     "iopub.status.idle": "2026-07-07T10:00:09.935433Z",
+     "shell.execute_reply": "2026-07-07T10:00:09.935225Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CP-SAT solution 8-reines : [7, 3, 0, 2, 5, 1, 6, 4]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CP-SAT temps             : 20.41 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Echiquier (Q = reine, . = vide) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . Q . . . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . . . Q . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . Q . . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . Q . . . . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . . . . . Q \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . . Q . . . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . . . . . Q . \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Q . . . . . . . \r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// N-Reines en CP-SAT C# (executable). q[i] = ligne de la reine en colonne i (0-indexe).\n",
+    "static (int[] solution, double ms) SolveNQueensCpsat(int n)\n",
+    "{\n",
+    "    var m = new CpModel();\n",
+    "    var q = new IntVar[n];\n",
+    "    for (int i = 0; i < n; i++) q[i] = m.NewIntVar(0, n - 1, $\"q{i}\");\n",
+    "    m.AddAllDifferent(q);   // pas deux reines sur la meme ligne\n",
+    "    // Diagonales : q[i]+i et q[i]-i toutes differentes\n",
+    "    var d1 = new IntVar[n]; var d2 = new IntVar[n];\n",
+    "    for (int i = 0; i < n; i++)\n",
+    "    {\n",
+    "        d1[i] = m.NewIntVar(0, 2 * n, $\"d1{i}\");\n",
+    "        d2[i] = m.NewIntVar(-n, n, $\"d2{i}\");\n",
+    "        m.Add(d1[i] == q[i] + i);\n",
+    "        m.Add(d2[i] == q[i] - i);\n",
+    "    }\n",
+    "    m.AddAllDifferent(d1);\n",
+    "    m.AddAllDifferent(d2);\n",
+    "    var s = new CpSolver();\n",
+    "    var sw = Stopwatch.StartNew();\n",
+    "    var status = s.Solve(m);\n",
+    "    sw.Stop();\n",
+    "    if (status == CpSolverStatus.Optimal || status == CpSolverStatus.Feasible)\n",
+    "    {\n",
+    "        var sol = new int[n];\n",
+    "        for (int i = 0; i < n; i++) sol[i] = (int)s.Value(q[i]);\n",
+    "        return (sol, sw.Elapsed.TotalMilliseconds);\n",
+    "    }\n",
+    "    return (null, sw.Elapsed.TotalMilliseconds);\n",
+    "}\n",
+    "\n",
+    "var (sol8, ms8) = SolveNQueensCpsat(8);\n",
+    "Console.WriteLine($\"CP-SAT solution 8-reines : [{string.Join(\", \", sol8)}]\");\n",
+    "Console.WriteLine($\"CP-SAT temps             : {ms8:F2} ms\");\n",
+    "Console.WriteLine(\"Echiquier (Q = reine, . = vide) :\");\n",
+    "for (int row = 0; row < 8; row++)\n",
+    "{\n",
+    "    var line = \"\";\n",
+    "    for (int col = 0; col < 8; col++)\n",
+    "        line += (sol8[col] == row ? \"Q \" : \". \");\n",
+    "    Console.WriteLine(\"  \" + line);\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed1f7883",
+   "metadata": {},
+   "source": [
+    "## 3. Contraintes globales\n",
+    "\n",
+    "Les contraintes **globales** (alldifferent, cumulative, circuit) capturent des structures recurrentes. `alldifferent` est la plus utile : elle exprime en une ligne ce qui demanderait O(n^2) contraintes binaires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "fc818cb1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:09.936926Z",
+     "iopub.status.busy": "2026-07-07T10:00:09.936722Z",
+     "iopub.status.idle": "2026-07-07T10:00:10.108534Z",
+     "shell.execute_reply": "2026-07-07T10:00:10.108036Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Emploi du temps -- status: Optimal\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cours 1 -> creneau 1, salle 1 (prof=1, 30 eleves)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cours 2 -> creneau 4, salle 3 (prof=1, 25 eleves)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cours 3 -> creneau 3, salle 2 (prof=2, 40 eleves)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cours 4 -> creneau 4, salle 2 (prof=2, 20 eleves)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cours 5 -> creneau 2, salle 1 (prof=3, 35 eleves)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Cours 6 -> creneau 4, salle 1 (prof=3, 15 eleves)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 4 : Emploi du temps (timetabling) ===\n",
+    "// 6 cours, 5 creneaux, 3 salles, 3 enseignants. Contraintes C1/C2/C3.\n",
+    "// C1 : un enseignant ne donne pas 2 cours au meme creneau.\n",
+    "// C2 : une salle n'accueille qu'un cours par creneau (slot[i]!=slot[j] OU room[i]!=room[j]).\n",
+    "// C3 : la salle est assez grande pour les effectifs.\n",
+    "//\n",
+    "// C2 est une DISJONCTION (OU) -- en CP-SAT on la modelise avec des booleens et OnlyEnforceIf.\n",
+    "\n",
+    "int nCourses = 6, nSlots = 5, nRooms = 3;\n",
+    "int[] teacher = { 1, 1, 2, 2, 3, 3 };\n",
+    "int[] students = { 30, 25, 40, 20, 35, 15 };\n",
+    "int[] roomCap = { 35, 45, 25 };\n",
+    "\n",
+    "var mTt = new CpModel();\n",
+    "var slot = new IntVar[nCourses];\n",
+    "var room = new IntVar[nCourses];\n",
+    "for (int i = 0; i < nCourses; i++)\n",
+    "{\n",
+    "    slot[i] = mTt.NewIntVar(0, nSlots - 1, $\"slot{i}\");\n",
+    "    room[i] = mTt.NewIntVar(0, nRooms - 1, $\"room{i}\");\n",
+    "}\n",
+    "\n",
+    "// C1 : enseignant ne donne pas 2 cours au meme creneau\n",
+    "for (int i = 0; i < nCourses; i++)\n",
+    "    for (int j = i + 1; j < nCourses; j++)\n",
+    "        if (teacher[i] == teacher[j])\n",
+    "            mTt.Add(slot[i] != slot[j]);\n",
+    "\n",
+    "// C2 : une salle, un cours par creneau (disjonction reifiee)\n",
+    "for (int i = 0; i < nCourses; i++)\n",
+    "    for (int j = i + 1; j < nCourses; j++)\n",
+    "    {\n",
+    "        var bSlot = mTt.NewBoolVar($\"sameSlot{i}_{j}\");\n",
+    "        var bRoom = mTt.NewBoolVar($\"sameRoom{i}_{j}\");\n",
+    "        mTt.Add(slot[i] == slot[j]).OnlyEnforceIf(bSlot);\n",
+    "        mTt.Add(slot[i] != slot[j]).OnlyEnforceIf(bSlot.Not());\n",
+    "        mTt.Add(room[i] == room[j]).OnlyEnforceIf(bRoom);\n",
+    "        mTt.Add(room[i] != room[j]).OnlyEnforceIf(bRoom.Not());\n",
+    "        mTt.AddBoolOr(new[] { bSlot.Not(), bRoom.Not() });   // NON(meme slot ET meme room)\n",
+    "    }\n",
+    "\n",
+    "// C3 : capacite de la salle suffisante\n",
+    "for (int i = 0; i < nCourses; i++)\n",
+    "    for (int r = 0; r < nRooms; r++)\n",
+    "        if (students[i] > roomCap[r])\n",
+    "            mTt.Add(room[i] != r);\n",
+    "\n",
+    "var sTt = new CpSolver();\n",
+    "var stTt = sTt.Solve(mTt);\n",
+    "Console.WriteLine($\"Emploi du temps -- status: {stTt}\");\n",
+    "for (int i = 0; i < nCourses; i++)\n",
+    "    Console.WriteLine($\"  Cours {i + 1} -> creneau {sTt.Value(slot[i]) + 1}, salle {sTt.Value(room[i]) + 1} (prof={teacher[i]}, {students[i]} eleves)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "365ce6d6",
+   "metadata": {},
+   "source": [
+    "### N-Reines en CP-SAT C#\n",
+    "\n",
+    "Le solveur trouve une solution en quelques millisecondes. La concision est moindre qu'en MiniZinc (~12 vs ~5 lignes) car CP-SAT exige la creation explicite des variables de diagonale intermediaires."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bb87de86",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:10.111181Z",
+     "iopub.status.busy": "2026-07-07T10:00:10.110730Z",
+     "iopub.status.idle": "2026-07-07T10:00:10.368269Z",
+     "shell.execute_reply": "2026-07-07T10:00:10.367802Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grille initiale (0 = vide) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . 3 .\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3 . . 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . 3 . .\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  . . 2 .\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Solution CP-SAT :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  4 2 3 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3 1 4 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2 3 1 4\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1 4 2 3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Voir la serie Sudoku pour des solveurs CSP complets -> ../../Sudoku/README.md\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 5 : Sudoku 4x4 pilote depuis le code ===\n",
+    "// Le twin Python pilote MiniZinc depuis Python (model + data .dzn).\n",
+    "// En CP-SAT C#, le modele et les donnees vivent dans le meme code : on fixe les\n",
+    "// cases initiales par des contraintes d'egalite, puis alldifferent sur lignes/colonnes/blocs.\n",
+    "\n",
+    "int[,] initSudoku = { { 0, 0, 3, 0 }, { 3, 0, 0, 2 }, { 0, 3, 0, 0 }, { 0, 0, 2, 0 } };\n",
+    "Console.WriteLine(\"Grille initiale (0 = vide) :\");\n",
+    "for (int i = 0; i < 4; i++)\n",
+    "    Console.WriteLine(\"  \" + string.Join(\" \", Enumerable.Range(0, 4).Select(j => initSudoku[i, j] > 0 ? initSudoku[i, j].ToString() : \".\")));\n",
+    "\n",
+    "var mSk = new CpModel();\n",
+    "var g = new IntVar[4, 4];\n",
+    "for (int i = 0; i < 4; i++)\n",
+    "    for (int j = 0; j < 4; j++)\n",
+    "    {\n",
+    "        g[i, j] = mSk.NewIntVar(1, 4, $\"g{i}{j}\");\n",
+    "        if (initSudoku[i, j] > 0) mSk.Add(g[i, j] == initSudoku[i, j]);\n",
+    "    }\n",
+    "for (int i = 0; i < 4; i++)\n",
+    "{\n",
+    "    mSk.AddAllDifferent(new[] { g[i, 0], g[i, 1], g[i, 2], g[i, 3] });   // ligne i\n",
+    "    mSk.AddAllDifferent(new[] { g[0, i], g[1, i], g[2, i], g[3, i] });   // colonne i\n",
+    "}\n",
+    "for (int br = 0; br < 2; br++)   // blocs 2x2\n",
+    "    for (int bc = 0; bc < 2; bc++)\n",
+    "        mSk.AddAllDifferent(new[] { g[br * 2, bc * 2], g[br * 2, bc * 2 + 1], g[br * 2 + 1, bc * 2], g[br * 2 + 1, bc * 2 + 1] });\n",
+    "\n",
+    "var sSk = new CpSolver();\n",
+    "sSk.Solve(mSk);\n",
+    "Console.WriteLine(\"\\nSolution CP-SAT :\");\n",
+    "for (int i = 0; i < 4; i++)\n",
+    "    Console.WriteLine(\"  \" + string.Join(\" \", Enumerable.Range(0, 4).Select(j => sSk.Value(g[i, j]).ToString())));\n",
+    "Console.WriteLine(\"\\nVoir la serie Sudoku pour des solveurs CSP complets -> ../../Sudoku/README.md\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e42ecc73",
+   "metadata": {},
+   "source": [
+    "## 4. Emploi du temps (timetabling)\n",
+    "\n",
+    "Un probleme reel : assigner creneaux et salles a 6 cours sans conflit (enseignant, salle, capacite). La contrainte C2 est une **disjonction** (OU) -- modelisee en CP-SAT avec des booleens et `OnlyEnforceIf` / `AddBoolOr`. C'est l'apport pedagogique cles : la logique disjonctive se traduit en variables booleennes de reification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f52f1650",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:10.370212Z",
+     "iopub.status.busy": "2026-07-07T10:00:10.369924Z",
+     "iopub.status.idle": "2026-07-07T10:00:10.486543Z",
+     "shell.execute_reply": "2026-07-07T10:00:10.486300Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Backtracking pur :     0.43 ms  -> solution trouvee: True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CP-SAT declaratif:    20.11 ms  -> solution trouvee: True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "12-Reines : les deux approches trouvent une solution valide.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 6 : Comparaison imperatif vs declaratif ===\n",
+    "// N-Reines resolu de 2 facons : (1) backtracking pur (imperatif), (2) CP-SAT (declaratif).\n",
+    "// (MiniZinc, 3e approche du twin Python, est remplace par CP-SAT ici -- meme paradigme declaratif.)\n",
+    "\n",
+    "static int[] SolveNQueensBacktrack(int n)\n",
+    "{\n",
+    "    int[] queens = new int[n];\n",
+    "    bool IsSafe(int col, int row)\n",
+    "    {\n",
+    "        for (int c = 0; c < col; c++)\n",
+    "            if (queens[c] == row || Math.Abs(c - col) == Math.Abs(queens[c] - row)) return false;\n",
+    "        return true;\n",
+    "    }\n",
+    "    bool Solve(int col)\n",
+    "    {\n",
+    "        if (col == n) return true;\n",
+    "        for (int row = 0; row < n; row++)\n",
+    "            if (IsSafe(col, row)) { queens[col] = row; if (Solve(col + 1)) return true; }\n",
+    "        return false;\n",
+    "    }\n",
+    "    return Solve(0) ? queens : null;\n",
+    "}\n",
+    "\n",
+    "int nBench = 12;\n",
+    "var swBt = Stopwatch.StartNew();\n",
+    "var solBt = SolveNQueensBacktrack(nBench);\n",
+    "swBt.Stop();\n",
+    "Console.WriteLine($\"Backtracking pur : {swBt.Elapsed.TotalMilliseconds,8:F2} ms  -> solution trouvee: {solBt != null}\");\n",
+    "\n",
+    "var (solCpsat12, msCpsat12) = SolveNQueensCpsat(nBench);\n",
+    "Console.WriteLine($\"CP-SAT declaratif: {msCpsat12,8:F2} ms  -> solution trouvee: {solCpsat12 != null}\");\n",
+    "Console.WriteLine($\"\\n{nBench}-Reines : les deux approches trouvent une solution valide.\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3fecd579",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:10.488729Z",
+     "iopub.status.busy": "2026-07-07T10:00:10.488332Z",
+     "iopub.status.idle": "2026-07-07T10:00:10.635181Z",
+     "shell.execute_reply": "2026-07-07T10:00:10.634827Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison des paradigmes de resolution\n",
+      "======================================================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Critere                        Python pur         CP-SAT             MiniZinc          \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lignes de code (N-Reines)      ~20 lignes         ~12 lignes         ~5 lignes         \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lisibilite mathematique        Faible             Moyenne            Haute             \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flexibilite du solveur         Aucune (ad-hoc)    CP-SAT uniquement  Multi-solveur     \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Integration Python/.NET        Totale             Excellente (API native) Via package/CLI   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Separation modele/donnees      Non                Non (code)         Oui (.mzn + .dzn) \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Performance brute              Lente              Tres rapide        Depend du solveur \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cas d'usage ideal              Prototypage        Production         Modelisation, recherche\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================================\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Tableau comparatif des 3 paradigmes (Python pur / CP-SAT / MiniZinc).\n",
+    "// Repris du twin Python, avec la colonne MiniZinc (high-level, multi-solveur).\n",
+    "var rows = new[]\n",
+    "{\n",
+    "    new { Crit = \"Lignes de code (N-Reines)\", Py = \"~20 lignes\", Cp = \"~12 lignes\", Mz = \"~5 lignes\" },\n",
+    "    new { Crit = \"Lisibilite mathematique\", Py = \"Faible\", Cp = \"Moyenne\", Mz = \"Haute\" },\n",
+    "    new { Crit = \"Flexibilite du solveur\", Py = \"Aucune (ad-hoc)\", Cp = \"CP-SAT uniquement\", Mz = \"Multi-solveur\" },\n",
+    "    new { Crit = \"Integration Python/.NET\", Py = \"Totale\", Cp = \"Excellente (API native)\", Mz = \"Via package/CLI\" },\n",
+    "    new { Crit = \"Separation modele/donnees\", Py = \"Non\", Cp = \"Non (code)\", Mz = \"Oui (.mzn + .dzn)\" },\n",
+    "    new { Crit = \"Performance brute\", Py = \"Lente\", Cp = \"Tres rapide\", Mz = \"Depend du solveur\" },\n",
+    "    new { Crit = \"Cas d'usage ideal\", Py = \"Prototypage\", Cp = \"Production\", Mz = \"Modelisation, recherche\" },\n",
+    "};\n",
+    "string sep = new string('-', 86);\n",
+    "Console.WriteLine(\"Comparaison des paradigmes de resolution\\n\" + new string('=', 86));\n",
+    "Console.WriteLine($\"{\"Critere\",-30} {\"Python pur\",-18} {\"CP-SAT\",-18} {\"MiniZinc\",-18}\");\n",
+    "Console.WriteLine(sep);\n",
+    "foreach (var r in rows)\n",
+    "    Console.WriteLine($\"{r.Crit,-30} {r.Py,-18} {r.Cp,-18} {r.Mz,-18}\");\n",
+    "Console.WriteLine(new string('=', 86));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cccf684",
+   "metadata": {},
+   "source": [
+    "## 5. Sudoku 4x4\n",
+    "\n",
+    "Le twin Python pilote MiniZinc depuis Python (modele + donnees `.dzn`). En CP-SAT C#, le modele et les donnees vivent dans le meme code : on fixe les cases initiales par `Add(var == valeur)`, puis `AddAllDifferent` sur lignes, colonnes et blocs 2x2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c5217853",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:10.636792Z",
+     "iopub.status.busy": "2026-07-07T10:00:10.636581Z",
+     "iopub.status.idle": "2026-07-07T10:00:10.705536Z",
+     "shell.execute_reply": "2026-07-07T10:00:10.705668Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Concision du modele (lignes de code estimees)\n",
+      "--------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "N-Reines:\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Python pur ####################                                           20\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CP-SAT     ############                                                   12\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MiniZinc   #####                                                          5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Emploi du temps:\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Python pur ############################################################   60\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CP-SAT     #############################################                  45\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MiniZinc   #########################                                      25\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Sudoku:\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Python pur ##################################################             50\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CP-SAT     ###################################                            35\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MiniZinc   ####################                                           20\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Evaluation multi-criteres (score 1-5)\n",
+      "--------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Concision:\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Python pur ##   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CP-SAT     ###  \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MiniZinc   #####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Lisibilite:\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Python pur ##   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CP-SAT     ###  \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MiniZinc   #####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Portabilite:\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Python pur #    \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CP-SAT     ##   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MiniZinc   #####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Integr. .NET:\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Python pur #####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CP-SAT     #####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MiniZinc   ###  \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Performance:\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Python pur ##   \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CP-SAT     #####\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  MiniZinc   #### \r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Visualisation ASCII (remplace matplotlib) : concision et score multi-criteres.\n",
+    "static string Bar(int filled, int maxBars, char c = '#')\n",
+    "    => new string(c, filled) + new string(' ', maxBars - filled);\n",
+    "\n",
+    "Console.WriteLine(\"Concision du modele (lignes de code estimees)\\n\" + new string('-', 50));\n",
+    "var problems = new[] { \"N-Reines\", \"Emploi du temps\", \"Sudoku\" };\n",
+    "var linesPy = new[] { 20, 60, 50 };\n",
+    "var linesCp = new[] { 12, 45, 35 };\n",
+    "var linesMz = new[] { 5, 25, 20 };\n",
+    "int maxL = 60;\n",
+    "for (int i = 0; i < 3; i++)\n",
+    "{\n",
+    "    Console.WriteLine($\"\\n{problems[i]}:\");\n",
+    "    Console.WriteLine($\"  Python pur {Bar(linesPy[i], maxL),-62} {linesPy[i]}\");\n",
+    "    Console.WriteLine($\"  CP-SAT     {Bar(linesCp[i], maxL),-62} {linesCp[i]}\");\n",
+    "    Console.WriteLine($\"  MiniZinc   {Bar(linesMz[i], maxL),-62} {linesMz[i]}\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"\\n\\nEvaluation multi-criteres (score 1-5)\\n\" + new string('-', 50));\n",
+    "var criteria = new[] { \"Concision\", \"Lisibilite\", \"Portabilite\", \"Integr. .NET\", \"Performance\" };\n",
+    "var scPy = new[] { 2, 2, 1, 5, 2 };\n",
+    "var scCp = new[] { 3, 3, 2, 5, 5 };\n",
+    "var scMz = new[] { 5, 5, 5, 3, 4 };\n",
+    "for (int i = 0; i < 5; i++)\n",
+    "{\n",
+    "    Console.WriteLine($\"\\n{criteria[i]}:\");\n",
+    "    Console.WriteLine($\"  Python pur {Bar(scPy[i], 5)}\");\n",
+    "    Console.WriteLine($\"  CP-SAT     {Bar(scCp[i], 5)}\");\n",
+    "    Console.WriteLine($\"  MiniZinc   {Bar(scMz[i], 5)}\");\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f289c86",
+   "metadata": {},
+   "source": [
+    "## 6. Comparaison : imperatif vs declaratif\n",
+    "\n",
+    "On resout N-Reines des deux facons pour comparer. Le backtracking pur (imperatif) est plus lent et moins declaratif ; CP-SAT (declaratif) delegue au solveur. La troisieme approche du twin Python (MiniZinc) est omise ici (pas de binding .NET) -- CP-SAT la represente dans le paradigme declaratif.\n",
+    "\n",
+    "### Tableau comparatif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "684a4095",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:10.707507Z",
+     "iopub.status.busy": "2026-07-07T10:00:10.707291Z",
+     "iopub.status.idle": "2026-07-07T10:00:10.782403Z",
+     "shell.execute_reply": "2026-07-07T10:00:10.782178Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : carre magique 3x3 en CP-SAT\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 7 : Exercices (stubs C.1 -- a completer par l'etudiant) ===\n",
+    "// Exercice 1 : Carre magique 3x3. Les entiers 1..9 tous differents, chaque ligne/colonne/\n",
+    "// diagonale sommant a magic_sum = n*(n*n+1)/2 = 15 pour n=3. modele CP-SAT a completer.\n",
+    "static int[][] MagicSquareCpsat()   // TODO etudiant\n",
+    "{\n",
+    "    // Indice : 9 IntVar(1,9), AddAllDifferent sur les 9, puis Add(==15) sur chaque ligne,\n",
+    "    // colonne et les 2 diagonales. Retourner la grille 3x3 resolue, ou null.\n",
+    "    // Etape 1 : creer le modele et les 9 variables.\n",
+    "    // Etape 2 : ajouter AddAllDifferent et les contraintes de somme (magic_sum = 15).\n",
+    "    // Etape 3 : resoudre et extraire la grille.\n",
+    "    Console.WriteLine(\"Exercice a completer : carre magique 3x3 en CP-SAT\");\n",
+    "    return null;\n",
+    "}\n",
+    "MagicSquareCpsat();\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8c0cffd2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:10.784508Z",
+     "iopub.status.busy": "2026-07-07T10:00:10.784001Z",
+     "iopub.status.idle": "2026-07-07T10:00:10.841797Z",
+     "shell.execute_reply": "2026-07-07T10:00:10.841276Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : coloration de graphe en CP-SAT\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Coloration de graphe. Graphe A-B-C, A-D, B-E, C-F, D-E, E-F.\n",
+    "// Minimiser le nombre de couleurs (chromatique). modele CP-SAT a completer.\n",
+    "static int[] GraphColoringCpsat()   // TODO etudiant\n",
+    "{\n",
+    "    // Indice : 6 IntVar(0, maxColors-1) pour les sommets A..F. Pour chaque arete (u,v),\n",
+    "    // Add(color[u] != color[v]). Minimiser le nombre de couleurs distinctes (variable objectif).\n",
+    "    // Etape 1 : modeliser les contraintes d'aretes (voisins de couleur differente).\n",
+    "    // Etape 2 : chercher le minimum de couleurs (essayer k=1, 2, 3... jusqu'a faisabilite).\n",
+    "    Console.WriteLine(\"Exercice a completer : coloration de graphe en CP-SAT\");\n",
+    "    return null;\n",
+    "}\n",
+    "GraphColoringCpsat();\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "a96a4857",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:00:10.844378Z",
+     "iopub.status.busy": "2026-07-07T10:00:10.843978Z",
+     "iopub.status.idle": "2026-07-07T10:00:10.914323Z",
+     "shell.execute_reply": "2026-07-07T10:00:10.913918Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : VRP simplifie en CP-SAT\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Recapitulatif ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OR-Tools CP-SAT est le moteur declaratif CP de reference en .NET (Prong A #3801).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Il exprime les memes modeles que MiniZinc (alldifferent, sommes, optimisation)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "avec une API imperative. MiniZinc reste superieur pour la concision et le\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "multi-solveur (Gecode, Chuffed, CBC...). Les deux partagent le paradigme :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "declarer les contraintes, laisser le solveur chercher -- l'oppose du backtracking.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : VRP simplifie (6 noeuds, 1 depot). Minimiser la distance totale\n",
+    "// d'une tournee passant par tous les clients. modele CP-SAT a completer.\n",
+    "static int[] VrpCpsat()   // TODO etudiant\n",
+    "{\n",
+    "    // Indice : variables next[i] = successeur du noeud i. AddAllDifferent(next) pour une\n",
+    "    // permutation, contrainte de circuit (cycle hamiltonien), minimiser sum dist[i,next[i]].\n",
+    "    // Etape 1 : fixer les variables next et la permutation.\n",
+    "    // Etape 2 : ajouter l'elimination de sous-tours (ou utiliser AddCircuit si disponible).\n",
+    "    // Etape 3 : minimiser la distance totale.\n",
+    "    Console.WriteLine(\"Exercice a completer : VRP simplifie en CP-SAT\");\n",
+    "    return null;\n",
+    "}\n",
+    "VrpCpsat();\n",
+    "\n",
+    "Console.WriteLine(\"\\n=== Recapitulatif ===\");\n",
+    "Console.WriteLine(\"OR-Tools CP-SAT est le moteur declaratif CP de reference en .NET (Prong A #3801).\");\n",
+    "Console.WriteLine(\"Il exprime les memes modeles que MiniZinc (alldifferent, sommes, optimisation)\");\n",
+    "Console.WriteLine(\"avec une API imperative. MiniZinc reste superieur pour la concision et le\");\n",
+    "Console.WriteLine(\"multi-solveur (Gecode, Chuffed, CBC...). Les deux partagent le paradigme :\");\n",
+    "Console.WriteLine(\"declarer les contraintes, laisser le solveur chercher -- l'oppose du backtracking.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cee591e",
+   "metadata": {},
+   "source": [
+    "### Visualisation ASCII (concision et score multi-criteres)\n",
+    "\n",
+    "Les graphiques matplotlib du twin Python sont remplaces par des barres ASCII autonomes. Deux axes : concision (lignes de code) et evaluation multi-criteres (score 1-5)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Twin C# .NET 9 de [`App-8-MiniZinc.ipynb`](MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb) — marathon parité **#4956**.

**Prong A EPIC #3801** : [Google.OrTools CP-SAT](https://developers.google.com/optimization) (vrai moteur industriel de programmation par contraintes), même paradigme déclaratif que MiniZinc (*déclarer les contraintes, laisser le solveur chercher*). MiniZinc n'ayant pas de binding .NET officiel, CP-SAT exprime les mêmes modèles déclaratifs via une API native NuGet. Les graphiques matplotlib du twin Python sont remplacés par un rendu ASCII autonome.

## Modèles exécutés (EXEC_PROVED 14/14, kernel `.net-csharp`)

| # | Modèle | Sortie CP-SAT | Parité Python |
|---|--------|---------------|---------------|
| 1 | Équations (x+y=10, xy=21) | x=7, y=3 (Optimal) | x=7, y=3 ✓ |
| 2 | Monnaie (minimiser pièces, 99c) | 9 pièces (Optimal prouvé) | 9 ✓ |
| 3 | N-Reines 8 | `[7,3,0,2,5,1,6,4]` valide | solution différente (voir note) |
| 4 | Timetabling (6 cours, C1/C2/C3) | Optimal (disjonction réifiée) | feasible ✓ |
| 5 | Sudoku 4x4 | grille résolue (alldifferent) | ✓ |
| 6 | Comparaison imperatif vs déclaratif (n=12) | backtracking + CP-SAT | — |

**Note honnête cross-solveur (N-Reines)** : CP-SAT retourne `[7,3,0,2,5,1,6,4]`, le twin Python (MiniZinc/OR-Tools) retourne `[4,7,3,0,6,1,5,2]`. Les DEUX sont des solutions 8-Reines valides (N-Reines admet de multiples solutions) — il n'y a pas de parité byte possible entre solveurs pour un CSP à solutions multiples. Vérifié : les 8 reines sont sur lignes/diagonales distinctes.

## Exercices (3, règle C.1)

Stubs `// TODO etudiant` (sans `raise`/`NotImplemented`) — le notebook s'exécute end-to-end :
1. **Carré magique 3x3** (somme = 15)
2. **Coloration de graphe** (6 sommets, minimiser couleurs)
3. **VRP simplifié** (6 nœuds, minimiser distance)

## SOTA / scope honest (EPIC #3801)

**Verdict : SOTA-OK** sur les modèles déclaratifs core (alldifferent, sommes linéaires, optimisation `Minimize`, disjonction réifiée `OnlyEnforceIf`/`AddBoolOr`). Les globals `cumulative` (scheduling) et `circuit` (TSP) d'OR-Tools .NET ont des signatures version-spécifiques (`AddCumulative`/`AddCircuit` CS1501 sur cette version) ; ces deux modèles sont donc présentés via leur syntaxe MiniZinc (display) et **non exécutés en CP-SAT** ici — documenté honnêtement dans le notebook. Les modèles déclaratifs principaux du twin Python sont pleinement démontrés.

## Validation

- `jupyter nbconvert --execute --inplace --kernel .net-csharp` : **SUCCESS**, 55476 bytes
- `execution_count != null` : **14/14** (forensic EXEC_PROVED)
- 0 erreur, 0 path-leak, 0 emoji
- CRLF→LF post-exécution (`.gitattributes *.ipynb text eol=lf`)
- 3 setters culture invariante (séparateur décimal `.` — parité sortie Python, `.NET Interactive` évalue les cellules sur des threads du pool distincts)
- CATALOG byte-identical (R1) — nouvelle entrée, inscription §E reportée au catalog-drift CI

## Scope

1 fichier, 1718 insertions (notebook only). L'inscription dans les tables §E faites-main (`Search/README.md` ligne 270, `Applications/README.md` ligne 87) est différée au catalog-drift (per `catalog-pr-hygiene` R1 : nouvelle entrée pas inscrite à la main dans une PR de contenu).

See #4956, #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)