### PR TITLE
feat(gametheory): SocialChoice-03-Voting-Methods-Csharp twin (marathon #4956)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods-Csharp.ipynb
@@ -1,0 +1,1763 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a2d8a3c",
+   "metadata": {},
+   "source": [
+    "# SocialChoice 03 : Methodes de Vote et Paradoxes (twin C# .NET)\n",
+    "\n",
+    "> **Twin C# .NET de `GameTheory/SocialChoice/03-Voting-Methods.ipynb`** (marathon parite #4956). Kernel `.net-csharp`. Ce notebook compagnon du **notebook 02 (Lean, preuves formelles)** fournit les **implementations C# from-scratch** des methodes de vote (Prong B, EPIC #3801). Le twin Python utilise numpy/matplotlib/networkx ; les visualisations sont remplacees par un rendu ASCII autonome.\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. **Modeliser** un profil de preferences collectives (classements individuels)\n",
+    "2. **Implementer** les regles de vote : Pluralite, Borda, Copeland, Condorcet, IRV\n",
+    "3. **Illustrer** les paradoxes : cycle de Condorcet, divergence des regles, theoreme de Sen\n",
+    "4. **Simuler** empiriquement les violations de IIA (theoreme d'Arrow)\n",
+    "5. **Comprendre** le theoreme de l'electeur median (preferences unimodales)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6a751efd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:32:59.384900Z",
+     "iopub.status.busy": "2026-07-07T10:32:59.378779Z",
+     "iopub.status.idle": "2026-07-07T10:33:01.100665Z",
+     "shell.execute_reply": "2026-07-07T10:33:01.094165Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '44716.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Configuration OK : SocialChoice 03 - Methodes de Vote (twin C# .NET 9)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// SocialChoice 03 : Methodes de Vote et Paradoxes -- twin C# de 03-Voting-Methods\n",
+    "// Prong B (#3801) : implementations from-scratch des regles de vote (Pluralite, Borda,\n",
+    "// Copeland, Condorcet, IRV). Le twin Python (03-Voting-Methods.ipynb) est le compagnon\n",
+    "// du notebook 02 (Lean, preuves formelles) ; ce twin execute les memes algorithmes en C#.\n",
+    "using System;\n",
+    "using System.Collections.Generic;\n",
+    "using System.Globalization;\n",
+    "using System.Linq;\n",
+    "\n",
+    "// Culture invariante : separateur decimal \".\" (parite de sortie avec le twin Python).\n",
+    "// Les 3 setters sont necessaires : .NET Interactive evalue les cellules sur des threads\n",
+    "// du pool distincts (CurrentCulture seul ne persiste pas cross-cell).\n",
+    "CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;\n",
+    "CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;\n",
+    "CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;\n",
+    "\n",
+    "Console.WriteLine(\"Configuration OK : SocialChoice 03 - Methodes de Vote (twin C# .NET 9)\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d2c96612",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:01.102393Z",
+     "iopub.status.busy": "2026-07-07T10:33:01.102162Z",
+     "iopub.status.idle": "2026-07-07T10:33:01.587711Z",
+     "shell.execute_reply": "2026-07-07T10:33:01.587471Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PROFIL DE CONDORCET\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 1: A > B > C\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 2: B > C > A\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 3: C > A > B\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Pareto(A, B) ici ? A (A bat B en duel)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 1 : Profil de preferences ===\n",
+    "// Un profil = liste des classements (du meilleur au pire) de chaque votant.\n",
+    "// Equivalent C# de la classe Profile du twin Python / de la structure Lean Profile (SC-02).\n",
+    "\n",
+    "static class Vote\n",
+    "{\n",
+    "    // Le votant i prefere-t-il x a y ? (x et y sont des indices d'alternatives)\n",
+    "    public static bool Prefers(List<List<string>> profile, int voter, string x, string y)\n",
+    "        => profile[voter].IndexOf(x) < profile[voter].IndexOf(y);\n",
+    "\n",
+    "    // Majorite des votants prefere-t-elle x a y ?\n",
+    "    public static bool MajorityPrefers(List<List<string>> profile, string x, string y)\n",
+    "    {\n",
+    "        int xCount = profile.Count(p => p.IndexOf(x) < p.IndexOf(y));\n",
+    "        return xCount > profile.Count / 2.0;\n",
+    "    }\n",
+    "\n",
+    "    // Resultat du duel majoritaire entre x et y : x, y, ou null (egalite)\n",
+    "    public static string PairwiseMajority(List<List<string>> profile, string x, string y)\n",
+    "    {\n",
+    "        int xWins = profile.Count(p => p.IndexOf(x) < p.IndexOf(y));\n",
+    "        int yWins = profile.Count - xWins;\n",
+    "        if (xWins > yWins) return x;\n",
+    "        if (yWins > xWins) return y;\n",
+    "        return null;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Profil de Condorcet (3 votants, cycle A>B>C / B>C>A / C>A>B)\n",
+    "var condorcetProfile = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"B\", \"C\" },\n",
+    "    new() { \"B\", \"C\", \"A\" },\n",
+    "    new() { \"C\", \"A\", \"B\" },\n",
+    "};\n",
+    "\n",
+    "static void PrintProfile(string title, List<List<string>> profile)\n",
+    "{\n",
+    "    Console.WriteLine(title);\n",
+    "    Console.WriteLine(new string('=', 40));\n",
+    "    for (int i = 0; i < profile.Count; i++)\n",
+    "        Console.WriteLine($\"  Votant {i + 1}: {string.Join(\" > \", profile[i])}\");\n",
+    "}\n",
+    "\n",
+    "PrintProfile(\"PROFIL DE CONDORCET\", condorcetProfile);\n",
+    "Console.WriteLine($\"\\nPareto(A, B) ici ? {Vote.PairwiseMajority(condorcetProfile, \"A\", \"B\")} (A bat B en duel)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67d03be7",
+   "metadata": {},
+   "source": [
+    "## 1. Profil de preferences et paradoxe de Condorcet\n",
+    "\n",
+    "Un **profil** decrit les classements (du meilleur au pire) de chaque votant. La structure `Profile` est l'equivalent C# de la structure Lean du notebook SC-02. Le **paradoxe de Condorcet** : avec 3 alternatives et des preferences cycliques, les duels majoritaires forment un cycle (A bat B, B bat C, C bat A) -- aucun gagnant n'emerge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8b5992cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:01.589494Z",
+     "iopub.status.busy": "2026-07-07T10:33:01.589230Z",
+     "iopub.status.idle": "2026-07-07T10:33:01.666983Z",
+     "shell.execute_reply": "2026-07-07T10:33:01.666353Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultats pairwise :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  A vs B: A\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  A vs C: C\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  B vs C: B\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=> CYCLE : A bat B, B bat C, C bat A ! (chacun 2-1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Graphe oriente des duels (cycle) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    A\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   ^ \\\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   |  v\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   C <- B\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   A > B, B > C, C > A  (cycle de longueur 3)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 1 (suite) : Paradoxe de Condorcet et cycles ===\n",
+    "// On calcule tous les duels pairwise. S'il y a un cycle (A bat B, B bat C, C bat A),\n",
+    "// aucun gagnant de Condorcet n'existe.\n",
+    "\n",
+    "static void CheckCondorcetCycle(List<List<string>> profile, List<string> alternatives)\n",
+    "{\n",
+    "    Console.WriteLine(\"Resultats pairwise :\");\n",
+    "    for (int i = 0; i < alternatives.Count; i++)\n",
+    "        for (int j = i + 1; j < alternatives.Count; j++)\n",
+    "        {\n",
+    "            string x = alternatives[i], y = alternatives[j];\n",
+    "            string winner = Vote.PairwiseMajority(profile, x, y);\n",
+    "            Console.WriteLine($\"  {x} vs {y}: {(winner ?? \"egalite\")}\");\n",
+    "        }\n",
+    "}\n",
+    "\n",
+    "CheckCondorcetCycle(condorcetProfile, new List<string> { \"A\", \"B\", \"C\" });\n",
+    "Console.WriteLine(\"\\n=> CYCLE : A bat B, B bat C, C bat A ! (chacun 2-1)\");\n",
+    "\n",
+    "// Visualisation ASCII du cycle (remplace networkx du twin Python)\n",
+    "Console.WriteLine(\"\\nGraphe oriente des duels (cycle) :\");\n",
+    "Console.WriteLine(\"    A\");\n",
+    "Console.WriteLine(\"   ^ \\\\\");\n",
+    "Console.WriteLine(\"   |  v\");\n",
+    "Console.WriteLine(\"   C <- B\");\n",
+    "Console.WriteLine(\"   A > B, B > C, C > A  (cycle de longueur 3)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eacd9101",
+   "metadata": {},
+   "source": [
+    "### Cycle de Condorcet\n",
+    "\n",
+    "On enumere tous les duels pairwise. Le cycle ( chacun 2-1) montre qu'aucun candidat ne bat tous les autres : il n'y a **pas de gagnant de Condorcet**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "569633a9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:01.669443Z",
+     "iopub.status.busy": "2026-07-07T10:33:01.669186Z",
+     "iopub.status.idle": "2026-07-07T10:33:01.769520Z",
+     "shell.execute_reply": "2026-07-07T10:33:01.768987Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Profil cyclique   : gagnant = AUCUN (cycle)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Profil a gagnant  : gagnant = A\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 2 : Gagnant de Condorcet (version generale) ===\n",
+    "// Un candidat est gagnant de Condorcet s'il bat tous les autres en duel.\n",
+    "// Retourne null s'il y a un cycle (aucun gagnant).\n",
+    "\n",
+    "static string CondorcetWinner(List<List<string>> profile, List<string> alternatives)\n",
+    "{\n",
+    "    foreach (var candidate in alternatives)\n",
+    "    {\n",
+    "        bool beatsAll = true;\n",
+    "        foreach (var other in alternatives)\n",
+    "        {\n",
+    "            if (other == candidate) continue;\n",
+    "            if (Vote.PairwiseMajority(profile, candidate, other) != candidate)\n",
+    "            {\n",
+    "                beatsAll = false;\n",
+    "                break;\n",
+    "            }\n",
+    "        }\n",
+    "        if (beatsAll) return candidate;\n",
+    "    }\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "// Profil cyclique : aucun gagnant\n",
+    "Console.WriteLine($\"Profil cyclique   : gagnant = {CondorcetWinner(condorcetProfile, new() { \"A\", \"B\", \"C\" }) ?? \"AUCUN (cycle)\"}\");\n",
+    "\n",
+    "// Profil avec un gagnant de Condorcet (A)\n",
+    "var profileWithWinner = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"B\", \"C\" },\n",
+    "    new() { \"A\", \"C\", \"B\" },\n",
+    "    new() { \"B\", \"A\", \"C\" },\n",
+    "    new() { \"C\", \"A\", \"B\" },\n",
+    "    new() { \"A\", \"B\", \"C\" },\n",
+    "};\n",
+    "Console.WriteLine($\"Profil a gagnant  : gagnant = {CondorcetWinner(profileWithWinner, new() { \"A\", \"B\", \"C\" })}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b9c8f00",
+   "metadata": {},
+   "source": [
+    "## 2. Gagnant de Condorcet\n",
+    "\n",
+    "Un candidat est **gagnant de Condorcet** s'il bat tous les autres en duel majoritaire. Sur un profil cyclique, il n'existe pas (retour null). Sur un profil favorable, un candidat (A) emerge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3640aa01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:01.771377Z",
+     "iopub.status.busy": "2026-07-07T10:33:01.771112Z",
+     "iopub.status.idle": "2026-07-07T10:33:01.956305Z",
+     "shell.execute_reply": "2026-07-07T10:33:01.955855Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "COMPARAISON DES REGLES (profil de Condorcet)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Pluralite: A > B > C\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Borda    : A > B > C  (A=B=C=3, ex aequo)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Copeland : A > B > C  (A=B=C=0, ex aequo)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Scores Borda : A=3, B=3, C=3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Scores Copeland : A=0, B=0, C=0\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 3 : Regles de vote positionnelles ===\n",
+    "// Pluralite, Borda, Copeland. Trois regles, trois facon d'agreger les preferences.\n",
+    "\n",
+    "static List<string> PluralityRule(List<List<string>> profile, List<string> alternatives)\n",
+    "{\n",
+    "    // 1 point par premier choix\n",
+    "    var scores = alternatives.ToDictionary(a => a, a => profile.Count(p => p[0] == a));\n",
+    "    return scores.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key).Select(kv => kv.Key).ToList();\n",
+    "}\n",
+    "\n",
+    "static Dictionary<string, int> BordaScores(List<List<string>> profile, List<string> alternatives)\n",
+    "{\n",
+    "    // n-1 points pour le 1er, 0 pour le dernier\n",
+    "    int n = profile[0].Count;\n",
+    "    var scores = alternatives.ToDictionary(a => a, a => 0);\n",
+    "    foreach (var pref in profile)\n",
+    "        for (int rank = 0; rank < pref.Count; rank++)\n",
+    "            scores[pref[rank]] += (n - 1 - rank);\n",
+    "    return scores;\n",
+    "}\n",
+    "\n",
+    "static List<string> BordaRule(List<List<string>> profile, List<string> alternatives)\n",
+    "{\n",
+    "    var scores = BordaScores(profile, alternatives);\n",
+    "    return scores.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key).Select(kv => kv.Key).ToList();\n",
+    "}\n",
+    "\n",
+    "static Dictionary<string, int> CopelandScores(List<List<string>> profile, List<string> alternatives)\n",
+    "{\n",
+    "    // score = victoires - defaites (pairwise)\n",
+    "    var scores = alternatives.ToDictionary(a => a, a => 0);\n",
+    "    for (int i = 0; i < alternatives.Count; i++)\n",
+    "        for (int j = i + 1; j < alternatives.Count; j++)\n",
+    "        {\n",
+    "            string x = alternatives[i], y = alternatives[j];\n",
+    "            string w = Vote.PairwiseMajority(profile, x, y);\n",
+    "            if (w == x) { scores[x]++; scores[y]--; }\n",
+    "            else if (w == y) { scores[y]++; scores[x]--; }\n",
+    "        }\n",
+    "    return scores;\n",
+    "}\n",
+    "\n",
+    "static List<string> CopelandRule(List<List<string>> profile, List<string> alternatives)\n",
+    "{\n",
+    "    var scores = CopelandScores(profile, alternatives);\n",
+    "    return scores.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key).Select(kv => kv.Key).ToList();\n",
+    "}\n",
+    "\n",
+    "var alts3 = new List<string> { \"A\", \"B\", \"C\" };\n",
+    "Console.WriteLine(\"COMPARAISON DES REGLES (profil de Condorcet)\");\n",
+    "Console.WriteLine(new string('=', 44));\n",
+    "Console.WriteLine($\"  Pluralite: {string.Join(\" > \", PluralityRule(condorcetProfile, alts3))}\");\n",
+    "Console.WriteLine($\"  Borda    : {string.Join(\" > \", BordaRule(condorcetProfile, alts3))}  (A=B=C=3, ex aequo)\");\n",
+    "Console.WriteLine($\"  Copeland : {string.Join(\" > \", CopelandRule(condorcetProfile, alts3))}  (A=B=C=0, ex aequo)\");\n",
+    "Console.WriteLine(\"\\n  Scores Borda : \" + string.Join(\", \",\n",
+    "    BordaScores(condorcetProfile, alts3).Select(kv => $\"{kv.Key}={kv.Value}\")));\n",
+    "Console.WriteLine(\"  Scores Copeland : \" + string.Join(\", \",\n",
+    "    CopelandScores(condorcetProfile, alts3).Select(kv => $\"{kv.Key}={kv.Value}\")));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "740d1a98",
+   "metadata": {},
+   "source": [
+    "## 3. Regles de vote positionnelles\n",
+    "\n",
+    "Trois regles, trois logiques d'agregation :\n",
+    "- **Pluralite** : 1 point par premier choix\n",
+    "- **Borda** : n-1 points pour le 1er, ... , 0 pour le dernier\n",
+    "- **Copeland** : +1 par victoire pairwise, -1 par defaite\n",
+    "\n",
+    "Sur le profil de Condorcet (cycle parfait), les trois regles donnent des ex aequo (symetrie totale)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "897b5d74",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:01.958306Z",
+     "iopub.status.busy": "2026-07-07T10:33:01.957877Z",
+     "iopub.status.idle": "2026-07-07T10:33:02.064227Z",
+     "shell.execute_reply": "2026-07-07T10:33:02.063913Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PROFIL AVEC RESULTATS DIVERGENTS\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 1: A > B > C\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 2: A > B > C\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 3: B > C > A\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 4: C > B > A\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 5: C > B > A\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Pluralite: A > C > B  (A=2, C=2, B=1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Borda    : B > C > A  (A=4, B=6, C=5)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Copeland : B > C > A  (A=-2, B=2, C=0)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=> Meme profil, resultats differents selon la regle ! (B gagne selon Borda et Copeland, ex aequo A=C en pluralite)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 4 : Profil a resultats divergents ===\n",
+    "// Un meme profil ou Pluralite, Borda et Copeland donnent des gagnants differents.\n",
+    "\n",
+    "var divergentProfile = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"B\", \"C\" },\n",
+    "    new() { \"A\", \"B\", \"C\" },\n",
+    "    new() { \"B\", \"C\", \"A\" },\n",
+    "    new() { \"C\", \"B\", \"A\" },\n",
+    "    new() { \"C\", \"B\", \"A\" },\n",
+    "};\n",
+    "PrintProfile(\"PROFIL AVEC RESULTATS DIVERGENTS\", divergentProfile);\n",
+    "\n",
+    "var bordaDiv = BordaScores(divergentProfile, alts3);\n",
+    "var copelandDiv = CopelandScores(divergentProfile, alts3);\n",
+    "Console.WriteLine($\"\\n  Pluralite: {string.Join(\" > \", PluralityRule(divergentProfile, alts3))}  (A=2, C=2, B=1)\");\n",
+    "Console.WriteLine($\"  Borda    : {string.Join(\" > \", BordaRule(divergentProfile, alts3))}  ({string.Join(\", \", bordaDiv.Select(kv => $\"{kv.Key}={kv.Value}\"))})\");\n",
+    "Console.WriteLine($\"  Copeland : {string.Join(\" > \", CopelandRule(divergentProfile, alts3))}  ({string.Join(\", \", copelandDiv.Select(kv => $\"{kv.Key}={kv.Value}\"))})\");\n",
+    "Console.WriteLine(\"\\n=> Meme profil, resultats differents selon la regle ! (B gagne selon Borda et Copeland, ex aequo A=C en pluralite)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "703e70c5",
+   "metadata": {},
+   "source": [
+    "## 4. Divergence des regles\n",
+    "\n",
+    "Sur un profil ou les preferences sont **asymetriques**, les trois regles donnent des gagnants differents. C'est l'illustration concrete qu'aucune regle n'est \"naturelle\" -- le choix de la regle determine le vainqueur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "24108203",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:02.066168Z",
+     "iopub.status.busy": "2026-07-07T10:33:02.065927Z",
+     "iopub.status.idle": "2026-07-07T10:33:02.156958Z",
+     "shell.execute_reply": "2026-07-07T10:33:02.156665Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L'EXEMPLE DE LADY CHATTERLEY (Theoreme de Sen)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Alternatives : np = personne ne lit, pr = Prude lit, lr = Lewd lit\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Preferences Prude : np > pr > lr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Preferences Lewd  : pr > lr > np\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Principe de liberte minimale ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Prude decide entre pr et np  => socialement np > pr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Lewd decide entre lr et np   => socialement lr > np\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Par transitivite ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  lr > np et np > pr  =>  lr > pr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Principe de Pareto (unanimite) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Prude prefere pr > lr ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Lewd  prefere pr > lr ? True\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => Pareto(pr, lr) = True  => socialement pr > lr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** CONTRADICTION ***\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Liberte + Transitivite => lr > pr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Pareto                 => pr > lr\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => Liberte minimale et Pareto sont INCOMPATIBLES (Sen 1970)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 5 : Theoreme de Sen (1970) -- Liberte vs Pareto ===\n",
+    "// L'exemple de Lady Chatterley : conflit entre liberte individuelle et efficacite Pareto.\n",
+    "// Deterministe (argument logique, pas de calcul aleatoire).\n",
+    "\n",
+    "// np = personne ne lit, pr = Prude lit, lr = Lewd lit\n",
+    "var prudePref = new List<string> { \"np\", \"pr\", \"lr\" };   // Prude : np > pr > lr\n",
+    "var lewdPref  = new List<string> { \"pr\", \"lr\", \"np\" };   // Lewd  : pr > lr > np\n",
+    "var senProfile = new List<List<string>> { prudePref, lewdPref };\n",
+    "\n",
+    "Console.WriteLine(\"L'EXEMPLE DE LADY CHATTERLEY (Theoreme de Sen)\");\n",
+    "Console.WriteLine(new string('=', 50));\n",
+    "Console.WriteLine(\"  Alternatives : np = personne ne lit, pr = Prude lit, lr = Lewd lit\");\n",
+    "Console.WriteLine($\"  Preferences Prude : {string.Join(\" > \", prudePref)}\");\n",
+    "Console.WriteLine($\"  Preferences Lewd  : {string.Join(\" > \", lewdPref)}\");\n",
+    "\n",
+    "Console.WriteLine(\"\\n--- Principe de liberte minimale ---\");\n",
+    "Console.WriteLine(\"  Prude decide entre pr et np  => socialement np > pr\");\n",
+    "Console.WriteLine(\"  Lewd decide entre lr et np   => socialement lr > np\");\n",
+    "Console.WriteLine(\"\\n--- Par transitivite ---\");\n",
+    "Console.WriteLine(\"  lr > np et np > pr  =>  lr > pr\");\n",
+    "Console.WriteLine(\"\\n--- Principe de Pareto (unanimite) ---\");\n",
+    "bool paretoPrLr = Vote.Prefers(senProfile, 0, \"pr\", \"lr\") && Vote.Prefers(senProfile, 1, \"pr\", \"lr\");\n",
+    "Console.WriteLine($\"  Prude prefere pr > lr ? {Vote.Prefers(senProfile, 0, \"pr\", \"lr\")}\");\n",
+    "Console.WriteLine($\"  Lewd  prefere pr > lr ? {Vote.Prefers(senProfile, 1, \"pr\", \"lr\")}\");\n",
+    "Console.WriteLine($\"  => Pareto(pr, lr) = {paretoPrLr}  => socialement pr > lr\");\n",
+    "Console.WriteLine(\"\\n*** CONTRADICTION ***\");\n",
+    "Console.WriteLine(\"  Liberte + Transitivite => lr > pr\");\n",
+    "Console.WriteLine(\"  Pareto                 => pr > lr\");\n",
+    "Console.WriteLine(\"  => Liberte minimale et Pareto sont INCOMPATIBLES (Sen 1970)\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23a968ee",
+   "metadata": {},
+   "source": [
+    "## 5. Theoreme de Sen (1970) : Liberte vs Pareto\n",
+    "\n",
+    "L'exemple de Lady Chatterley : le **principe de liberte minimale** (chacun decide sur sa sphere privee) combine a la **transitivite** et au **principe de Pareto** mene a une contradiction. Sen prouve ainsi que liberte et Pareto sont incompatibles. Deterministe (argument logique)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "37559e2f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:02.158939Z",
+     "iopub.status.busy": "2026-07-07T10:33:02.158685Z",
+     "iopub.status.idle": "2026-07-07T10:33:02.350608Z",
+     "shell.execute_reply": "2026-07-07T10:33:02.350431Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEMONSTRATION DETERMINISTE : Borda viole IIA\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Preferences individuelles A-vs-B IDENTIQUES dans les deux profils :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Profil 1 : 3 votants A>B, 2 votants B>A\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Profil 2 : 3 votants A>B, 2 votants B>A  (identique)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Profil 1 (C en derniere position) : Borda A=6, B=7, C=2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    => Borda : B au-dessus de A (B=7 > A=6)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Profil 2 (C au milieu)            : Borda A=8, B=4, C=3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    => Borda : A au-dessus de B (A=8 > B=4)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  *** VIOLATION DE IIA ***\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Les preferences A-vs-B sont identiques, yet Borda inverse son classement A/B\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  quand C (irrelevant) passe de la derniere a la position mediane.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => Borda ne satisfait pas IIA (theoreme d'Arrow, 1951).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 6 : Theoreme d'Arrow -- demonstration deterministe d'une violation de IIA ===\n",
+    "// IIA (Independance of Irrelevant Alternatives) : le classement social entre A et B ne\n",
+    "// doit dependre QUE des preferences individuelles entre A et B (pas de la position de C).\n",
+    "// On construit DEUX profils ou chaque electeur a la MEME preference A-vs-B, mais ou le\n",
+    "// classement Borda de A vs B s'INVERSE -> Borda viole IIA. Demo deterministe (parite exacte\n",
+    "// avec le raisonnement ; le twin Python utilise une simulation stochastique equivalente).\n",
+    "\n",
+    "// Profil 1 : 3 electeurs A>B>C, 2 electeurs B>C>A  (A>B pour 3, B>A pour 2)\n",
+    "var iiaProfil1 = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"B\", \"C\" }, new() { \"A\", \"B\", \"C\" }, new() { \"A\", \"B\", \"C\" },\n",
+    "    new() { \"B\", \"C\", \"A\" }, new() { \"B\", \"C\", \"A\" },\n",
+    "};\n",
+    "// Profil 2 : 3 electeurs A>C>B, 2 electeurs B>A>C  (A>B pour 3, B>A pour 2 -- IDENTIQUE)\n",
+    "var iiaProfil2 = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"C\", \"B\" }, new() { \"A\", \"C\", \"B\" }, new() { \"A\", \"C\", \"B\" },\n",
+    "    new() { \"B\", \"A\", \"C\" }, new() { \"B\", \"A\", \"C\" },\n",
+    "};\n",
+    "\n",
+    "Console.WriteLine(\"DEMONSTRATION DETERMINISTE : Borda viole IIA\");\n",
+    "Console.WriteLine(new string('=', 50));\n",
+    "Console.WriteLine(\"  Preferences individuelles A-vs-B IDENTIQUES dans les deux profils :\");\n",
+    "Console.WriteLine(\"    Profil 1 : 3 votants A>B, 2 votants B>A\");\n",
+    "Console.WriteLine(\"    Profil 2 : 3 votants A>B, 2 votants B>A  (identique)\");\n",
+    "\n",
+    "var b1 = BordaScores(iiaProfil1, alts3);\n",
+    "var b2 = BordaScores(iiaProfil2, alts3);\n",
+    "Console.WriteLine($\"\\n  Profil 1 (C en derniere position) : Borda A={b1[\"A\"]}, B={b1[\"B\"]}, C={b1[\"C\"]}\");\n",
+    "string winner1 = b1[\"A\"] > b1[\"B\"] ? \"A\" : (b1[\"B\"] > b1[\"A\"] ? \"B\" : \"ex aequo\");\n",
+    "Console.WriteLine($\"    => Borda : {(b1[\"A\"] >= b1[\"B\"] ? \"A\" : \"B\")} au-dessus de {(b1[\"A\"] >= b1[\"B\"] ? \"B\" : \"A\")} (B={b1[\"B\"]} > A={b1[\"A\"]})\");\n",
+    "Console.WriteLine($\"  Profil 2 (C au milieu)            : Borda A={b2[\"A\"]}, B={b2[\"B\"]}, C={b2[\"C\"]}\");\n",
+    "Console.WriteLine($\"    => Borda : {(b2[\"A\"] >= b2[\"B\"] ? \"A\" : \"B\")} au-dessus de {(b2[\"A\"] >= b2[\"B\"] ? \"B\" : \"A\")} (A={b2[\"A\"]} > B={b2[\"B\"]})\");\n",
+    "Console.WriteLine(\"\\n  *** VIOLATION DE IIA ***\");\n",
+    "Console.WriteLine(\"  Les preferences A-vs-B sont identiques, yet Borda inverse son classement A/B\");\n",
+    "Console.WriteLine(\"  quand C (irrelevant) passe de la derniere a la position mediane.\");\n",
+    "Console.WriteLine(\"  => Borda ne satisfait pas IIA (theoreme d'Arrow, 1951).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9d4afb1",
+   "metadata": {},
+   "source": [
+    "## 6. Theoreme d'Arrow : demonstration d'une violation de IIA\n",
+    "\n",
+    "Le **theoreme d'Arrow (1951)** : aucune regle d'agregation (avec >= 3 alternatives) ne satisfait simultanement Universalite, Pareto, IIA et Non-dictature. On le demontre ici de facon **deterministe** (parite exacte) : deux profils ou chaque electeur a la meme preference A-vs-B, mais ou le classement Borda de A vs B s'inverse quand l'alternative irrelevant C est deplacee. Le twin Python utilise une simulation stochastique (random.shuffle) qui arrive a la meme conclusion ; ce twin C# prefere une demo deterministe reproductible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b2bd2172",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:02.352005Z",
+     "iopub.status.busy": "2026-07-07T10:33:02.351832Z",
+     "iopub.status.idle": "2026-07-07T10:33:02.479804Z",
+     "shell.execute_reply": "2026-07-07T10:33:02.479630Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "THEOREME DE L'ELECTEUR MEDIAN\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Alternatives : [0, 2, 4, 6, 8, 10]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Pics des electeurs : [1, 3, 4, 5, 7, 8, 9]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Preferences generees (unimodales) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Electeur 1 (pic=1): [0, 2, 4, 6, 8, 10]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Electeur 2 (pic=3): [2, 4, 0, 6, 8, 10]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Electeur 3 (pic=4): [4, 2, 6, 0, 8, 10]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Electeur 4 (pic=5): [4, 6, 2, 8, 0, 10]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Electeur 5 (pic=7): [6, 8, 4, 10, 2, 0]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Electeur 6 (pic=8): [8, 6, 10, 4, 2, 0]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Electeur 7 (pic=9): [8, 10, 6, 4, 2, 0]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Pic median : 5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Gagnant de Condorcet (single-peaked) : 4\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => Avec des preferences unimodales, PAS de cycle de Condorcet.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 7 : Theoreme de l'electeur median (Black, Duncan) ===\n",
+    "// Avec des preferences unimodales (single-peaked), le gagnant de Condorcet existe\n",
+    "// toujours et correspond au pic de l'electeur median. Deterministe.\n",
+    "\n",
+    "static List<int> SinglePeakedPreference(int peak, List<int> alternatives)\n",
+    "    => alternatives.OrderBy(a => Math.Abs(a - peak)).ToList();\n",
+    "\n",
+    "static int FindMedianVoter(List<int> peaks)\n",
+    "{\n",
+    "    var sorted = peaks.OrderBy(p => p).ToList();\n",
+    "    return sorted[sorted.Count / 2];\n",
+    "}\n",
+    "\n",
+    "var alternativesSp = new List<int> { 0, 2, 4, 6, 8, 10 };\n",
+    "var voterPeaks = new List<int> { 1, 3, 4, 5, 7, 8, 9 };   // 7 electeurs\n",
+    "\n",
+    "Console.WriteLine(\"THEOREME DE L'ELECTEUR MEDIAN\");\n",
+    "Console.WriteLine(new string('=', 40));\n",
+    "Console.WriteLine($\"  Alternatives : [{string.Join(\", \", alternativesSp)}]\");\n",
+    "Console.WriteLine($\"  Pics des electeurs : [{string.Join(\", \", voterPeaks)}]\");\n",
+    "Console.WriteLine(\"\\n  Preferences generees (unimodales) :\");\n",
+    "var profileSp = voterPeaks.Select(p => SinglePeakedPreference(p, alternativesSp)).ToList();\n",
+    "for (int i = 0; i < voterPeaks.Count; i++)\n",
+    "    Console.WriteLine($\"    Electeur {i + 1} (pic={voterPeaks[i]}): [{string.Join(\", \", profileSp[i])}]\");\n",
+    "\n",
+    "int medianPeak = FindMedianVoter(voterPeaks);\n",
+    "Console.WriteLine($\"\\n  Pic median : {medianPeak}\");\n",
+    "// Gagnant de Condorcet = alternative la plus proche du pic median\n",
+    "int winnerSp = alternativesSp.OrderBy(a => Math.Abs(a - medianPeak)).First();\n",
+    "Console.WriteLine($\"  Gagnant de Condorcet (single-peaked) : {winnerSp}\");\n",
+    "Console.WriteLine(\"  => Avec des preferences unimodales, PAS de cycle de Condorcet.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "443b1f86",
+   "metadata": {},
+   "source": [
+    "## 7. Theoreme de l'electeur median (Black)\n",
+    "\n",
+    "Avec des **preferences unimodales** (single-peaked), le gagnant de Condorcet existe toujours et correspond au pic de l'electeur median. Le cycle de Condorcet disparait. Deterministe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "eb7ad32f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:02.481276Z",
+     "iopub.status.busy": "2026-07-07T10:33:02.480986Z",
+     "iopub.status.idle": "2026-07-07T10:33:02.675388Z",
+     "shell.execute_reply": "2026-07-07T10:33:02.674898Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MODELE DE DOWNS : convergence vers le centre (2 partis)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Median des electeurs : 5.0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Parti de gauche : 2.0 -> 5.0  (converge vers le median)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Parti de droite  : 8.0 -> 5.0  (converge vers le median)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Trajectoire (G=gauche, D=droite, |=median) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    t= 0: G=2.0   D=8.0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    t= 4: G=3.2   D=6.8\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    t= 8: G=4.4   D=5.6\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    t=12: G=5.0   D=5.0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    t=16: G=5.0   D=5.0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    t=20: G=5.0   D=5.0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  => Les deux partis convergent vers la position mediane (5.0).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 8 : Convergence vers le centre (modele de Downs) ===\n",
+    "// ATTENTION (parite) : le twin Python tire des electeurs via np.random.normal(5,2,100)\n",
+    "// avec seed 42 (Mersenne Twister). System.Random en C# (seed 42) produit une distribution\n",
+    "// differente. On simule donc la convergence avec une grille DETERMINISTE d'electeurs\n",
+    "// (7 pics fixes, meme principe) pour obtenir une parite exacte sur la trajectoire.\n",
+    "// Le RESULTAT pedagogique (les deux partis convergent vers le median) est preserve.\n",
+    "\n",
+    "static (List<double> histL, List<double> histR, double median) SimulateTwoParty(\n",
+    "    List<int> peaks, int nRounds)\n",
+    "{\n",
+    "    double partyL = 2.0, partyR = 8.0;\n",
+    "    var histL = new List<double> { partyL };\n",
+    "    var histR = new List<double> { partyR };\n",
+    "    double median = peaks.OrderBy(p => p).ToList()[peaks.Count / 2];\n",
+    "    for (int r = 0; r < nRounds; r++)\n",
+    "    {\n",
+    "        if (partyL < median) partyL = Math.Min(partyL + 0.3, median);\n",
+    "        if (partyR > median) partyR = Math.Max(partyR - 0.3, median);\n",
+    "        histL.Add(partyL);\n",
+    "        histR.Add(partyR);\n",
+    "    }\n",
+    "    return (histL, histR, median);\n",
+    "}\n",
+    "\n",
+    "// Pics deterministes (grille) -- evite le tirage aleatoire cross-langage\n",
+    "var peaksDet = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9 };\n",
+    "var (histL, histR, medianD) = SimulateTwoParty(peaksDet, nRounds: 20);\n",
+    "\n",
+    "Console.WriteLine(\"MODELE DE DOWNS : convergence vers le centre (2 partis)\");\n",
+    "Console.WriteLine(new string('=', 54));\n",
+    "Console.WriteLine($\"  Median des electeurs : {medianD:F1}\");\n",
+    "Console.WriteLine($\"  Parti de gauche : {histL[0]:F1} -> {histL[^1]:F1}  (converge vers le median)\");\n",
+    "Console.WriteLine($\"  Parti de droite  : {histR[0]:F1} -> {histR[^1]:F1}  (converge vers le median)\");\n",
+    "// Visualisation ASCII de la convergence\n",
+    "Console.WriteLine(\"\\n  Trajectoire (G=gauche, D=droite, |=median) :\");\n",
+    "for (int t = 0; t < histL.Count; t += 4)\n",
+    "    Console.WriteLine($\"    t={t,2}: G={histL[t]:F1}   D={histR[t]:F1}\");\n",
+    "Console.WriteLine($\"\\n  => Les deux partis convergent vers la position mediane ({medianD:F1}).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a560d375",
+   "metadata": {},
+   "source": [
+    "## 8. Modele de Downs : convergence vers le centre\n",
+    "\n",
+    "Deux partis en competition ajustent leur position pour maximiser leurs votes ; ils convergent tous deux vers la position mediane (theoreme de l'electeur median applique a la competition partisane).\n",
+    "\n",
+    "> **Note de parite** : le twin Python tire 100 electeurs via `np.random.normal(5,2)` (seed 42). Pour une parite exacte de la trajectoire, ce twin C# utilise une **grille deterministe** de pics. Le resultat (convergence vers le median) est identique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a540dcaf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:02.677974Z",
+     "iopub.status.busy": "2026-07-07T10:33:02.677466Z",
+     "iopub.status.idle": "2026-07-07T10:33:02.736862Z",
+     "shell.execute_reply": "2026-07-07T10:33:02.736575Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AVEC 2 ALTERNATIVES : LA MAJORITE FONCTIONNE\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Exemple (3 electeurs)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 1: A > B\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 2: A > B\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Votant 3: B > A\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  Resultat majoritaire : A gagne (2 contre 1)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  => Pas de cycle possible avec 2 alternatives (relation complete et antisymetrique).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     Le theoreme d'Arrow (dictateur ou violation d'une autre propriete) requiert >= 3 alternatives.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 9 : Avec 2 alternatives, la majorite fonctionne ===\n",
+    "// Le theoreme d'Arrow requiert |A| >= 3. Avec 2 alternatives, pas de cycle possible.\n",
+    "\n",
+    "Console.WriteLine(\"AVEC 2 ALTERNATIVES : LA MAJORITE FONCTIONNE\");\n",
+    "Console.WriteLine(new string('=', 50));\n",
+    "var profile2alt = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"B\" },\n",
+    "    new() { \"A\", \"B\" },\n",
+    "    new() { \"B\", \"A\" },\n",
+    "};\n",
+    "PrintProfile(\"  Exemple (3 electeurs)\", profile2alt);\n",
+    "string winner2 = Vote.PairwiseMajority(profile2alt, \"A\", \"B\");\n",
+    "Console.WriteLine($\"\\n  Resultat majoritaire : {winner2} gagne (2 contre 1)\");\n",
+    "Console.WriteLine(\"  => Pas de cycle possible avec 2 alternatives (relation complete et antisymetrique).\");\n",
+    "Console.WriteLine(\"     Le theoreme d'Arrow (dictateur ou violation d'une autre propriete) requiert >= 3 alternatives.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d728cd15",
+   "metadata": {},
+   "source": [
+    "## 9. Avec 2 alternatives, la majorite fonctionne\n",
+    "\n",
+    "Le theoreme d'Arrow requiert **|A| >= 3**. Avec 2 alternatives, le vote majoritaire satisfait Pareto, IIA et Non-dictature : pas de cycle possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "4181c3f9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:02.738616Z",
+     "iopub.status.busy": "2026-07-07T10:33:02.738398Z",
+     "iopub.status.idle": "2026-07-07T10:33:02.849965Z",
+     "shell.execute_reply": "2026-07-07T10:33:02.849752Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : gagnant de Condorcet sur un profil a 4 candidats\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Section 10 : Exercices (stubs C.1 -- a completer par l'etudiant) ===\n",
+    "// Exercice 1 : Gagnant de Condorcet et cycles. Profil a 4 candidats.\n",
+    "static string TrouverGagnantCondorcet(List<List<string>> profil, List<string> candidats)   // TODO etudiant\n",
+    "{\n",
+    "    // Indice : pour chaque candidat, verifier s'il bat tous les autres en duel pairwise\n",
+    "    // (reutiliser CondorcetWinner ci-dessus, ou le reimplementer).\n",
+    "    // Etape 1 : parcourir chaque candidat.\n",
+    "    // Etape 2 : pour chacun, verifier tous les duels.\n",
+    "    // Etape 3 : retourner le gagnant, ou null s'il y a un cycle.\n",
+    "    Console.WriteLine(\"Exercice a completer : gagnant de Condorcet sur un profil a 4 candidats\");\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "var profil1 = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"B\", \"D\", \"C\" },\n",
+    "    new() { \"B\", \"C\", \"A\", \"D\" },\n",
+    "    new() { \"C\", \"D\", \"A\", \"B\" },\n",
+    "    new() { \"D\", \"A\", \"B\", \"C\" },\n",
+    "    new() { \"A\", \"C\", \"D\", \"B\" },\n",
+    "};\n",
+    "TrouverGagnantCondorcet(profil1, new() { \"A\", \"B\", \"C\", \"D\" });\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b1af6b08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:02.851249Z",
+     "iopub.status.busy": "2026-07-07T10:33:02.851053Z",
+     "iopub.status.idle": "2026-07-07T10:33:02.932360Z",
+     "shell.execute_reply": "2026-07-07T10:33:02.932147Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : vote par elimination successive (IRV)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 2 : Vote par elimination successive (IRV / instant-runoff).\n",
+    "static List<string> InstantRunoffVoting(List<List<string>> profil, List<string> candidats)   // TODO etudiant\n",
+    "{\n",
+    "    // Indice : a chaque tour, compter les premiers choix. Si un candidat a la majorite\n",
+    "    // absolue (> 50%), c'est le gagnant. Sinon, eliminer le candidat avec le moins de\n",
+    "    // premiers choix et recommencer.\n",
+    "    // Etape 1 : boucle sur les tours (tant qu'aucun majorite absolue).\n",
+    "    // Etape 2 : compter les premiers choix parmi les candidats restants.\n",
+    "    // Etape 3 : eliminer le dernier et continuer.\n",
+    "    Console.WriteLine(\"Exercice a completer : vote par elimination successive (IRV)\");\n",
+    "    return candidats;\n",
+    "}\n",
+    "\n",
+    "var profilA = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"X\", \"Y\", \"Z\" }, new() { \"X\", \"Y\", \"Z\" }, new() { \"X\", \"Y\", \"Z\" }, new() { \"X\", \"Y\", \"Z\" },\n",
+    "    new() { \"Y\", \"Z\", \"X\" }, new() { \"Y\", \"Z\", \"X\" }, new() { \"Y\", \"Z\", \"X\" },\n",
+    "    new() { \"Z\", \"Y\", \"X\" }, new() { \"Z\", \"Y\", \"X\" },\n",
+    "};\n",
+    "InstantRunoffVoting(profilA, new() { \"X\", \"Y\", \"Z\" });\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1c558934",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T10:33:02.934080Z",
+     "iopub.status.busy": "2026-07-07T10:33:02.933872Z",
+     "iopub.status.idle": "2026-07-07T10:33:03.007584Z",
+     "shell.execute_reply": "2026-07-07T10:33:03.007348Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : verification IIA pour Borda\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Recapitulatif ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aucune regle d'agregation (avec >= 3 alternatives) ne satisfait simultanement\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Universalite, Pareto, IIA et Non-dictature (theoreme d'Arrow, 1951).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Les methodes positionnelles (Pluralite, Borda) et pairwise (Copeland, Condorcet)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "offrent des compromis differents. Les preuves formelles vivent dans le notebook\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lean SC-02 ; ce twin C# execute les algorithmes from-scratch (Prong B).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice 3 : Theoreme d'Arrow -- verifier IIA pour Borda sur deux profils.\n",
+    "static bool VerifierIiaBorda(List<List<string>> profil1, List<List<string>> profil2,\n",
+    "    List<string> candidats, string x, string y)   // TODO etudiant\n",
+    "{\n",
+    "    // Indice : IIA dit que le classement SOCIAL entre x et y ne doit dependre que des\n",
+    "    // preferences individuelles entre x et y. Si profil1 et profil2 ont les memes preferences\n",
+    "    // x-vs-y pour tous les electeurs mais un classement social x/y different, IIA est violee.\n",
+    "    // Etape 1 : verifier que les preferences x-vs-y sont identiques entre profil1 et profil2.\n",
+    "    // Etape 2 : calculer le classement Borda de chacun.\n",
+    "    // Etape 3 : comparer la position relative de x et y ; retourner true si IIA respectee.\n",
+    "    Console.WriteLine(\"Exercice a completer : verification IIA pour Borda\");\n",
+    "    return true;\n",
+    "}\n",
+    "\n",
+    "var profilIia1 = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"B\", \"C\" }, new() { \"B\", \"A\", \"C\" }, new() { \"A\", \"C\", \"B\" },\n",
+    "};\n",
+    "var profilIia2 = new List<List<string>>\n",
+    "{\n",
+    "    new() { \"A\", \"B\", \"C\" }, new() { \"B\", \"A\", \"C\" }, new() { \"C\", \"A\", \"B\" },\n",
+    "};\n",
+    "VerifierIiaBorda(profilIia1, profilIia2, new() { \"A\", \"B\", \"C\" }, \"A\", \"B\");\n",
+    "\n",
+    "Console.WriteLine(\"\\n=== Recapitulatif ===\");\n",
+    "Console.WriteLine(\"Aucune regle d'agregation (avec >= 3 alternatives) ne satisfait simultanement\");\n",
+    "Console.WriteLine(\"Universalite, Pareto, IIA et Non-dictature (theoreme d'Arrow, 1951).\");\n",
+    "Console.WriteLine(\"Les methodes positionnelles (Pluralite, Borda) et pairwise (Copeland, Condorcet)\");\n",
+    "Console.WriteLine(\"offrent des compromis differents. Les preuves formelles vivent dans le notebook\");\n",
+    "Console.WriteLine(\"Lean SC-02 ; ce twin C# execute les algorithmes from-scratch (Prong B).\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b234cb00",
+   "metadata": {},
+   "source": [
+    "## 10. Exercices\n",
+    "\n",
+    "Trois exercices en C# (stubs `TODO etudiant`, regle C.1 -- aucune erreur volontaire, le notebook s'execute de bout en bout)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Twin C# .NET 9 de [`GameTheory/SocialChoice/03-Voting-Methods.ipynb`](MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb) — marathon parité **#4956**.

**Prong B EPIC #3801** : implémentations **from-scratch** des règles de vote (Plurality, Borda, Copeland, Condorcet, IRV). Compagnon exécutable du notebook 02 (Lean, preuves formelles). Rotation R6 : Sudoku (c.94) → Search/CSP (c.95) → **SocialChoice** (c.96, genre = théorie du vote, distinct de CSP). Les visualisations matplotlib/networkx du twin Python sont remplacées par un rendu ASCII autonome.

## Ancres déterministes (EXEC_PROVED 14/14, kernel `.net-csharp`)

| Section | Modèle | Sortie C# | Vérification |
|---|---|---|---|
| 1 | Paradoxe de Condorcet | cycle A>B, B>C, C>A (chacun 2-1) | aucun gagnant ✓ |
| 2 | Gagnant de Condorcet | cyclique=AUCUN, favorable=A | ✓ |
| 3 | Plurality/Borda/Copeland (profil Condorcet) | tous ex aequo (A=B=C=3 Borda, 0 Copeland) | symétrie ✓ |
| 4 | Profil divergent | Plurality A>C>B, Borda **B=6>C=5>A=4**, Copeland **B=2>C=0>A=-2** | divergence ✓ |
| 5 | Théorème de Sen (Lady Chatterley) | contradiction liberté+transitivité vs Pareto | logique déterministe ✓ |
| 6 | Théorème d'Arrow (IIA) | **flip Borda** Profil1 B=7>A=6, Profil2 A=8>B=4 | violation IIA ✓ |
| 7 | Électeur médian (Black) | pics [1,3,4,5,7,8,9] → médiane 5 | single-peaked ✓ |
| 8 | Modèle de Downs | convergence G et D → médiane (grille déterministe) | ✓ |
| 9 | 2 alternatives | A bat B 2-1, pas de cycle | Arrow requiert ≥3 ✓ |

## Choix de conception : déterminisme vs stochasticité

Le twin Python utilise deux cellules **stochastiques** (simulation IIA via `random.shuffle`, modèle de Downs via `np.random.normal(seed=42)`). Pour ce twin C# :
- **Théorème d'Arrow** : remplace la simulation stochastique (qui donnait un résultat incohérent — 0/100 violations Borda sur le profil de référence, contredisant le message pédagogique) par une **démo déterministe à 2 profils** construits pour exhiber une vraie violation IIA de Borda (préférences A-vs-B identiques, mais Borda flippe quand C est déplacé). Parité exacte du raisonnement, pédagogie correcte, aucun RNG.
- **Modèle de Downs** : utilise une **grille déterministe** de 9 pics au lieu du tirage aléatoire, pour une trajectoire parity-exacte (le résultat — convergence vers le médian — est identique).

C'est la même leçon qu'en c.94 (recuit simulé) : un algorithme stochastique n'a pas de parité byte cross-langage (`System.Random` ≠ Mersenne Twister) ; on préfère ici une version déterministe qui préserve exactement le sens pédagogique.

## Exercices (3, règle C.1)

Stubs `// TODO etudiant` (sans `raise`/`NotImplemented`) — le notebook s'exécute end-to-end :
1. **Gagnant de Condorcet** sur un profil à 4 candidats (détection de cycle)
2. **Vote par élimination successive (IRV)**
3. **Vérification de IIA pour Borda** sur deux profils

## Validation

- `jupyter nbconvert --execute --inplace --kernel .net-csharp` : **SUCCESS**, 59886 bytes
- `execution_count != null` : **14/14** (forensic EXEC_PROVED)
- 0 erreur, 0 path-leak, 0 emoji
- CRLF→LF post-exécution (`.gitattributes *.ipynb text eol=lf`)
- 3 setters culture invariante (séparateur décimal `.` — parité sortie Python)
- CATALOG byte-identical (R1) — nouvelle entrée, inscription §E reportée au catalog-drift CI

## Scope

1 fichier, 1763 insertions (notebook only). L'inscription dans la table §E faite-main (`GameTheory/README.md`) est différée au catalog-drift (per `catalog-pr-hygiene` R1).

See #4956, #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)