### PR TITLE
docs(search-apps): README Applications parity — App-18b twin row + count resync (post-#5632)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -1,8 +1,8 @@
 # Search - Applications
 
-C'est ici que la série Search se confronte au réel. Les 37 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents. À cela s'ajoutent les **jumeaux C#** (App-1b, App-2b, App-3b, App-4b, App-5b, App-6-Csharp, App-7b, App-9b, App-10b, App-11b, App-12b, App-13b, App-14-CSharp, App-15b, App-16-CSharp, App-17b, App-19-CSharp, App-20b) qui déroulent les mêmes algorithmes *from-scratch* en .NET, en complément des versions Python qui invoquent des solveurs industriels.
+C'est ici que la série Search se confronte au réel. Les 40 notebooks d'application, pour la plupart adaptés de projets étudiants, prennent les algorithmes des Parties 1 et 2 et les mettent face à des problèmes qui ne se laissent pas faire : planifier les gardes d'un service hospitalier, ordonnancer un atelier, construire un calendrier sportif équitable, router une flotte de véhicules. Trois catégories les organisent — **Search pur** (jeux combinatoires), **CSP** (satisfaction de contraintes) et **Hybride** (métaheuristiques et algorithmes génétiques) — et la plupart sont autonomes, avec des pointeurs vers les prérequis pertinents. À cela s'ajoutent les **jumeaux C#** (App-1b, App-2b, App-3b, App-4b, App-5b, App-6-Csharp, App-7b, App-9b, App-10b, App-11b, App-12b, App-13b, App-14-CSharp, App-15b, App-16-CSharp, App-17b, App-18b, App-19-CSharp, App-20b) qui déroulent les mêmes algorithmes *from-scratch* en .NET, en complément des versions Python qui invoquent des solveurs industriels.
 
-Sous-série de **37 notebooks** | **~19h00** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`) ; .NET 9 (`dotnet-interactive`) pour les jumeaux C#
+Sous-série de **40 notebooks** | **~19h00** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`) ; .NET 9 (`dotnet-interactive`) pour les jumeaux C#
 
 ## Pourquoi cette sous-série
 
@@ -31,8 +31,8 @@ Un algorithme compris sur un exemple jouet n'est pas encore un algorithme maîtr
 ```text
 Applications/
 ├── Search/     # Applications purement Search (4 notebooks : 2 Python + 2 twins C#)
-├── CSP/        # Applications CSP (24 notebooks : 13 Python + 11 twins C#)
-└── Hybrid/     # Metaheuristiques / GA (9 notebooks : 5 Python + 4 twins C#)
+├── CSP/        # Applications CSP (26 notebooks : 13 Python + 13 twins C#)
+└── Hybrid/     # Metaheuristiques / GA (10 notebooks : 5 Python + 5 twins C#)
 ```
 
 ```mermaid
@@ -42,7 +42,7 @@ flowchart LR
     P4["<b>Partie 4 — Métaheuristiques</b><br/>SA, GA, ACO, recuit"]
     S["<b>Applications Search</b> (2)<br/>ConnectFour : Minimax,<br/>MCTS, DQN-RL"]
     C["<b>Applications CSP</b> (13)<br/>N-Queens, GraphColoring,<br/>Nurse/JobShop, Minesweeper,<br/>Wordle, Picross, WFC,<br/>Sudoku..."]
-    H["<b>Applications Hybrides</b> (8)<br/>EdgeDetection, Portfolio,<br/>TSP, VRP, Hyperparameter"]
+    H["<b>Applications Hybrides</b> (5)<br/>EdgeDetection, Portfolio,<br/>TSP, VRP, Hyperparameter"]
     P1 --> S
     P2 --> C
     P4 --> H
@@ -112,6 +112,7 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 | 6 | [App-17-VRP-Logistics](Hybrid/App-17-VRP-Logistics.ipynb) | ~60 min | Vehicle Routing : SA, GA, ACO, CP-SAT | Projet étudiant |
 | 6b | [App-17b-VRP-Logistics-CSharp](Hybrid/App-17b-VRP-Logistics-Csharp.ipynb) | ~50 min | Twin C# : Nearest-Neighbor, cheapest-insertion, 2-opt, recuit simulé (métaheuristiques from-scratch) | Jumeau .NET |
 | 7 | [App-18-HyperparameterTuning](Hybrid/App-18-HyperparameterTuning.ipynb) | ~40 min | Optimisation ML : Bayésienne, GA, PSO, Optuna | Nouveau |
+| 7b | [App-18b-HyperparameterTuning-CSharp](Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb) | ~40 min | **Jumeau C#** — Grid/Random Search + Bayesian Optimization from-scratch (Gaussian Process RBF + Expected Improvement via Abramowitz-Stegun) + GA + PSO, objectif = k-NN CV 5-fold, parité #4956 | Jumeau .NET |
 
 ---
 
@@ -163,6 +164,7 @@ Quand l'espace est trop vaste ou l'objectif trop irrégulier pour les méthodes 
 | App-17 VRP-Logistics | Search-4, Search-5, CSP-3 | ortools |
 | App-17b VRP-Logistics (C#) | Search-4 (LocalSearch), Search-5 (SA) | dotnet-interactive |
 | App-18 HyperparameterTuning | Search-4, Search-5 | optuna, scikit-learn |
+| App-18b HyperparameterTuning (C#) | Search-4, Search-5 | dotnet-interactive |
 
 ---
 


### PR DESCRIPTION
## Summary

§E whole-file audit of `Search/Applications/README.md` after App-18b twin C# merged (#5632). Reconciles prose counts ↔ structure tree ↔ mermaid ↔ tables ↔ disk.

## Changes

| Location | Before | After |
|----------|--------|-------|
| Intro total | 37 notebooks | **40** |
| Intro twin list | (…App-17b, App-19-CSharp, App-20b) | + **App-18b** |
| Line 5 total | 37 | **40** |
| Structure tree CSP | 24 (13 Py + 11 C#) | **26 (13 Py + 13 C#)** |
| Structure tree Hybrid | 9 (5 Py + 4 C#) | **10 (5 Py + 5 C#)** |
| Mermaid node H | (8) | **(5)** (Python-count parity with S/C) |
| Hybrid table | (no App-18b) | + **App-18b twin row** (Bayesian Opt from-scratch GP+EI, k-NN CV 5-fold, #4956) |
| Prérequis Hybrid | (no App-18b) | + **App-18b row** (Search-4/5, dotnet-interactive — pure BCL, 0 NuGet, 0 Z3) |

## Disk verification (post-rebase origin/main)

```
Search/:  4 notebooks (2 Python + 2 C#)
CSP/:    26 notebooks (13 Python + 13 C#)
Hybrid/: 10 notebooks (5 Python + 5 C#)
Total:   40
```

## Conformité

- §E readme-french-first : FR preserved (no EN added).
- §E.2 audit-fichier-entier : prose ↔ structure ↔ mermaid ↔ tables ↔ disk réconciliés.
- catalog-pr-hygiene R1 : **0 CATALOG-STATUS markers** in this README (catalog = cron/CI, untouched).
- 0 CRLF, 0 emoji, +7/-5 surgical single-file.

## Scope (R3 atomic)

§E resync of THIS file only. Pre-existing **CSP-table** drifts (rows `App-8-MiniZinc-Csharp` + `App-16-Crossword-CSP-Csharp` missing from the CSP notebook table) are a **separate axis** — signaled on dashboard, not folded here (one-file-one-subject for the §E pass).

See #4956, #3973, #4959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
