### PR TITLE
test(ict): workspace guard tests — anti-copy emergence_gain + numpy-only + defensive validation (See #5635)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_workspace.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_workspace.py
@@ -410,3 +410,89 @@ def test_event_triggered_battery_short_window_handled_gracefully():
     out = ws.event_triggered_battery(states, [0], window=1, rng=rng, n_shuffles=3)
     assert out["n_events"] == 1
     # le per-event est marque court (ec_gain=0 convention) -- pas de crash
+
+
+# --------------------------------------------------------------------------- #
+# Gardes anti-regression (portes de #5640 sur directive ai-01 + numpy-only)
+# --------------------------------------------------------------------------- #
+def test_emergence_gain_is_not_redefined_in_workspace():
+    """``ict.workspace`` n'expose pas ``emergence_gain`` localement.
+
+    Garde-fou anti-regression : si un futur dev copie ``emergence_gain`` dans
+    ``workspace.py`` (au lieu de l'importer depuis :mod:`ict.synthesis`), ce
+    test echoue immediatement. C'est l'acceptance #5635 (reutilisation VERBATIM
+    par import, pas par copie). Porte depuis #5640 (session miroir) sur
+    directive ai-01 (msg-20260707T135024-m2ohdn).
+    """
+    assert not hasattr(ws, "emergence_gain"), (
+        "ict.workspace definit emergence_gain localement -- INTERDIT "
+        "(acceptance #5635). Importer depuis ict.synthesis plutot que redefinir."
+    )
+    # Reciproque : synthesis.emergence_gain reste la source canonique.
+    from ict import synthesis
+    assert hasattr(synthesis, "emergence_gain")
+    assert callable(synthesis.emergence_gain)
+
+
+def test_workspace_module_is_numpy_only():
+    """Garde numpy-only : ``ict.workspace`` ne doit JAMAIS importer torch/scipy/transformers.
+
+    Invariant HARD #5635 (architecture) : torch confine au pipeline d'extraction
+    #5101, ``workspace.py`` = numpy-only. Ce test casse si quelqu'un ajoute un
+    import interdit au top-level. On extrait les lignes d'import reelles (pas
+    les mentions dans les docstrings) pour eviter les faux positifs.
+    """
+    import inspect
+    import ict.workspace as wmod
+    src = inspect.getsource(wmod)
+    top_imports = [ln.strip() for ln in src.splitlines()
+                   if ln.strip().startswith(("import ", "from "))]
+    joined = " ".join(top_imports)
+    for banned in ("torch", "scipy", "transformers", "tensorflow", "sklearn"):
+        assert banned not in joined, (
+            f"import {banned} interdit dans ict.workspace (numpy-only, #5635): {joined}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Validation defensive (couvre les ValueError existantes des primitives)
+# --------------------------------------------------------------------------- #
+def test_concentration_series_rejects_non_2d():
+    """acts 1-D ou 3-D leve ValueError (la signature documente (T, K))."""
+    with pytest.raises(ValueError, match="2-D"):
+        ws.concentration_series(np.zeros(10), metric="gini")
+    with pytest.raises(ValueError, match="2-D"):
+        ws.concentration_series(np.zeros((10, 4, 3)), metric="gini")
+
+
+def test_concentration_series_rejects_unknown_metric():
+    """metric inconnu leve ValueError explicite (pas de comportement silencieux)."""
+    acts = np.ones((10, 4))
+    with pytest.raises(ValueError, match="metric inconnu"):
+        ws.concentration_series(acts, metric="bogus")
+
+
+def test_lagged_influence_rejects_non_2d_and_bad_lag():
+    """Validation defensive de la forme et du retard max."""
+    with pytest.raises(ValueError, match="2-D"):
+        ws.lagged_influence(np.zeros(10), max_lag=3)
+    acts = np.ones((10, 4))
+    with pytest.raises(ValueError, match="max_lag >= 1"):
+        ws.lagged_influence(acts, max_lag=0)
+
+
+def test_workspace_candidates_rejects_bad_top_fraction():
+    """top_fraction hors ]0, 1] leve ValueError."""
+    fanout = np.array([5.0, 3.0, 1.0])
+    with pytest.raises(ValueError, match="top_fraction"):
+        ws.workspace_candidates(fanout, top_fraction=0.0)
+    with pytest.raises(ValueError, match="top_fraction"):
+        ws.workspace_candidates(fanout, top_fraction=1.5)
+
+
+def test_event_triggered_battery_rejects_bad_window():
+    """window < 1 leve ValueError (demi-largeur doit etre positive)."""
+    states = list(range(20))
+    rng = np.random.default_rng(0)
+    with pytest.raises(ValueError, match="window >= 1"):
+        ws.event_triggered_battery(states, [5], window=0, rng=rng, n_shuffles=2)


### PR DESCRIPTION
## #5635 — workspace guard tests (garde anti-copie + numpy-only + validation défensive)

**Suite de la PR #5641** (MERGED canonique `3a3f060695`). Action explicite ai-01 (msg-20260707T135024-m2ohdn, post-arbitrage duplication #5640/#5641) : porter le garde-fou anti-copie `test_emergence_gain_is_not_redefined_in_workspace` depuis #5640 (session miroir fermée avec crédit) dans `tests/test_workspace.py`, + considérer la validation défensive. Livrable partiel `See #5635` (le notebook ICT-24 reste côté ai-01, gated #5101).

### Périmètre (atomique, 1 fichier)

- `tests/test_workspace.py` **+86 lignes** (insertions pures, 0 suppression) — 7 nouveaux tests à la fin du fichier. Ne touche ni `workspace.py`, ni `synthesis.py`, ni notebooks.

### Les 7 nouveaux tests

**Gardes anti-régression** (ports de #5640, indépendants de l'API) :

1. `test_emergence_gain_is_not_redefined_in_workspace` — **action explicite ai-01**. Vérifie `not hasattr(ws, "emergence_gain")` : si un futur dev copie `emergence_gain` dans workspace.py (au lieu de l'importer depuis `synthesis`), le test échoue immédiatement. **G.1 self-validé** : une copie simulée (`workspace.emergence_gain = lambda...`) fait bien échouer le garde (vérifié hors-test).
2. `test_workspace_module_is_numpy_only` — garde l'invariant HARD #5635 (numpy-only). Extrait les vrais imports top-level (pas les mentions dans les docstrings — évite les faux positifs) et rejette `torch`/`scipy`/`transformers`/`tensorflow`/`sklearn`.

**Validation défensive** (couvre les `ValueError` existantes des primitives — protection contre suppression accidentelle future, adapté à MON API 2-D contrairement à l'API 3-D de #5640) :

3. `test_concentration_series_rejects_non_2d` — acts 1-D/3-D → `ValueError("2-D")`
4. `test_concentration_series_rejects_unknown_metric` — metric inconnu → `ValueError("metric inconnu")`
5. `test_lagged_influence_rejects_non_2d_and_bad_lag` — forme + `max_lag >= 1`
6. `test_workspace_candidates_rejects_bad_top_fraction` — `top_fraction` hors `]0, 1]`
7. `test_event_triggered_battery_rejects_bad_window` — `window < 1`

### Validation

```
python -m pytest tests/test_workspace.py -q
27 passed in 3.49s   # 20 (existants #5641) + 7 nouveaux

python -m pytest tests/test_workspace.py tests/test_synthesis.py tests/test_feature_dynamics.py -q
53 passed in 1.99s   # pas de régression
```

Papermill N/A : test Python pur (aucun notebook modifié).

### Note d'adaptation API

Le test `test_emergence_gain_is_not_redefined_in_workspace` est **indépendant de l'API** (vérifie juste l'absence d'attribut local) → porté quasi-tel quel depuis #5640. La validation défensive a été **adaptée** : mon API est 2-D `(T, K)` (alignée sur `feature_dynamics.py`), pas 3-D `(T, N, F)` comme #5640. Les guards testent donc mes `ValueError` réelles (rejet non-2D, pas non-3D). Aucune fonctionnalité copiée — seule l'idée du garde-fou.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
