### PR TITLE
docs(ml): fix ML/README.md Track A notebook count drift — 13→19 real structure (#3974)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -35,7 +35,7 @@ Avoir ces trois angles permet de comprendre que le ML n'est pas lié à un langa
 
 ## Parcours d'apprentissage
 
-### Track A : ML.NET (.NET/C#, 13 notebooks C# ⇄ Python + TP, ~7h)
+### Track A : ML.NET (.NET/C#, 9 notebooks C# ML-1 à ML-9 et leurs 9 jumeaux Python + 1 TP capstone, ~7h)
 
 Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML). Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Les notebooks 8-9 ouvrent sur l'apprentissage non-supervisé : clustering K-Means (segmentation RFM, méthode du coude) puis détection d'anomalies par Randomized PCA (maintenance prédictive, choix du seuil de décision). Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
 


### PR DESCRIPTION
## #3974 ML family — fix Track A notebook count drift (13 → real structure 19) sur ML/README.md

**See #3973, #3974** (Part of EPIC README ascendant — livraison partielle famille ML, PR distincte de #5648/IIT). Owner #3974 = po-2025:CoursIA (mon turf — ML/ dans mon partition Python). **Variété** (directive ai-01 14:41Z « pas de mono-thème ») : pivot ICT→ML après #5648.

### Périmètre (atomique, 1 fichier)

`MyIA.AI.Notebooks/ML/README.md` : 1 ligne modifiée (header Track A). Aucun notebook touché, aucun catalogue régénéré.

### Le drift corrigé (G.1 firsthand)

Le header Track A disait « **13 notebooks C# ⇄ Python + TP** » — count **stale**. Vérification firsthand `git ls-tree -r --name-only origin/main -- MyIA.AI.Notebooks/ML/ML.Net/` :

| Notebook | Type |
|---|---|
| ML-1-Introduction + ML-1-Introduction-Python | C# + jumeau |
| ML-2-Data&Features + ...-Python | C# + jumeau |
| ML-3-Entrainement + ...-Python | C# + jumeau |
| ML-4-Evaluation + ...-Python | C# + jumeau |
| ML-5-TimeSeries + ...-Python | C# + jumeau |
| ML-6-ONNX + ...-Python | C# + jumeau |
| ML-7-Recommendation + ...-Python | C# + jumeau |
| ML-8-Clustering + ...-Python | C# + jumeau |
| ML-9-Anomaly-Detection + ...-Python | C# + jumeau |
| TP-prevision-ventes | TP capstone |

**Total = 19** (9 C# + 9 jumeaux Python + 1 TP), ce que le bloc `<!-- CATALOG-STATUS -->` (pedagogical_count: 19 sur la feuille ML.Net/README.md, breakdown ML.Net=19) dit déjà correctement. Le header prose dérivait.

Le fix remplace le compte en dur « 13 » par la **structure réelle** (« 9 notebooks C# ML-1 à ML-9 et leurs 9 jumeaux Python + 1 TP capstone ») — aligné sur CATALOG, et formulation structurelle minimisant le drift futur (#3974 driver « Pas de compte en dur dérivant »).

### Conformité

- **catalog-pr-hygiene HARD 1** : bloc `<!-- CATALOG-STATUS -->` (lignes 3-8) **byte-identique** (vérifié `diff` avant/après). Aucune régénération catalogue sur la branche.
- **readme-french-first** : prose FR conservée.
- **0 CRLF** (vérifié `git diff | grep -c $'\r'` = 0).
- **Scope .md pur** : C.1/C.2 N/A. R3 atomique (1 fichier, 1 ligne).

### Vérifications G.1 croisées

- ML.Net/README.md (feuille) : son CATALOG `pedagogical_count: 19` est **correct**, sa prose ne mentionne pas « 13 » → drift **confiné au root ML/README.md** uniquement (scope propre).
- Track B count (27 notebooks Python, 8 scikit-learn 02-ML-Cours) vérifié firsthand = **correct** (27 DataScienceWithAgents, 8 dans 02-ML-Cours). Pas touché.
- Compte total ML/ (46) = CATALOG pedagogical_count ✓.

### Validation

```
git diff -- MyIA.AI.Notebooks/ML/README.md    # 1 ligne modifiée
CATALOG-STATUS byte-identity: IDENTICAL
CRLF count: 0
```

Papermill N/A (documentation markdown pure).

— myia-po-2025:CoursIA (owner #3974 famille ML, variété vs #5648 ICT)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
