### PR TITLE
docs(qc): fix stale notebook count in Python README — 53→55 (See #3976)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -9,12 +9,12 @@ Supports de cours pour l'apprentissage du trading algorithmique avec QuantConnec
 
 | Type | Count | Description |
 |------|-------|-------------|
-| **(a)** quantbook QC Cloud | 16 | QuantBook research or cloud-deploy descriptors (inclut Cloud-06-PCA-StatArb, Cloud-07-TemporalCNN ajoutés 2026-05) |
+| **(a)** quantbook QC Cloud | 18 | QuantBook research or cloud-deploy descriptors (inclut Cloud-06-PCA-StatArb, Cloud-07-TemporalCNN ajoutés 2026-05, Cloud-08-ValueFactor-ZScore, Cloud-09-OptionWheel ajoutés 2026-06) |
 | **(b)** research companion | 2 | QuantBook research paired with a course notebook |
 | **(c)** standalone research | 6 | Local yfinance/sklearn training |
 | **(d)** pedagogical placeholder | 33 | Course material with embedded QCAlgorithm strings |
 
-> Récapitulatif : 16+2+6+33 = 57 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **53** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md) pour la classification détaillée.
+> Récapitulatif : 18+2+6+33 = 59 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **55** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md) pour la classification détaillée.
 
 Full classification: [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md)
 


### PR DESCRIPTION
## Summary

Fix stale `.ipynb` count in `QuantConnect/Python/README.md` footnote — prose said **53**, disk truth is **55** (2 notebooks added since last update, never reflected in the prose count). Part of #3976 (QC READMEs feuilles, owner po-2024). See #3973.

## §E whole-file audit (pr-review-discipline §E)

**Disk truth (G.1 firsthand)** : `git ls-tree -r --name-only origin/main -- .../QuantConnect/Python/ | grep '\.ipynb$' | wc -l` = **55**.

**Drift root cause** : 2 notebooks added since the 2026-05-28 prose update (both already listed in the classification table AND the per-notebook status table — only the prose *count* footnote was stale) :
- `QC-Py-Cloud-08-ValueFactor-ZScore.ipynb`
- `QC-Py-Cloud-09-OptionWheel.ipynb`

(`git log --diff-filter=A --since=2026-05-28 origin/main -- .../QuantConnect/Python/` confirms both are additions.)

**Fix (2 lines)** :
1. Category (a) count `16 → 18` (+ Cloud-08/09, both "doc cloud" = category a per status table) + parenthetical updated.
2. Footnote : `16+2+6+33 = 57 → 18+2+6+33 = 59`, and `**53** → **55**`.

**Internal consistency** : 59 entries − 4 double-counts = 55 unique files ✓ (was 57 − 4 = 53). The 4-notebook double-count relationship is preserved.

**Whole-file check** : the rest of the README (intro, 4-Type table, per-notebook status table with Cloud-08/09 already present, audit notes) is current — no other stale count found. The CATALOG-STATUS block lives in the parent `QuantConnect/README.md` (not this file) and is cron-owned, untouched.

## Conformity

- **catalog-pr-hygiene R1** : no CATALOG-STATUS in this file; parent catalog byte-identical (not touched).
- **catalog-pr-hygiene R2** : fresh branch from `origin/main` (`9ed71df17`).
- **catalog-pr-hygiene R3** : atomic — 1 file, 2 lines, 1 feature (count fix), 1 domaine (QC docs).
- **catalog-pr-hygiene R4** : `See #3976` (partial contribution to EPIC #3973, not closing).
- **readme-french-first** : prose is already FR, edit preserves FR.
- **L268 anti-CRLF** : verified 0 CRLF, LF-only (UTF-8 no BOM).
- **§A composite** : +2/−2 net, 1 file — far below split threshold.

## Notes

CATALOG-STATUS in parent `QuantConnect/README.md` still says `Python=53` — left untouched (cron-owned, will auto-converge within 24h via `catalog-cron.yml`). Editing it on a branch would violate R1.

Co-Authored-By: Claude <noreply@anthropic.com>
