### PR TITLE
fix(notebooks): demote Indice hints H1->blockquote in 4 C# twins (EPIC #3966)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
@@ -1110,7 +1110,7 @@
     "\n",
     "Étant donné un jeu, lister ses **6 voisins** (3 swaps × 2 joueurs) et classifier chacun (nom de famille + nombre de Nash).\n",
     "\n",
-    "# Indice : itérer sur les 3 paires de swaps, appliquer `ApplyRowSwap` et `ApplyColSwap`, puis `FindPureNash` sur chaque voisin.\n"
+    "> **Indice :** itérer sur les 3 paires de swaps, appliquer `ApplyRowSwap` et `ApplyColSwap`, puis `FindPureNash` sur chaque voisin.\n"
    ]
   },
   {
@@ -1177,7 +1177,7 @@
     "\n",
     "Combien des 576 jeux n'ont **aucun** Nash pur ? Lesquels sont « proches » de Matching Pennies (distance ≤ 2) ?\n",
     "\n",
-    "# Indice : filtrer `allGames` par `FindPureNash(g).Count == 0`, puis `SwapDistance` vs Matching Pennies.\n"
+    "> **Indice :** filtrer `allGames` par `FindPureNash(g).Count == 0`, puis `SwapDistance` vs Matching Pennies.\n"
    ]
   },
   {
@@ -1243,7 +1243,7 @@
     "\n",
     "Deux jeux sont **stratégiquement équivalents** si l'échange Ligne↔Colonne (transposée) donne le même jeu. Compter les classes d'équivalence des 576 jeux sous cette relation.\n",
     "\n",
-    "# Indice : pour chaque jeu, calculer sa transposée (échanger rôles + transposer matrices), regrouper par `HashSet` de représentants canoniques.\n"
+    "> **Indice :** pour chaque jeu, calculer sa transposée (échanger rôles + transposer matrices), regrouper par `HashSet` de représentants canoniques.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb
@@ -1235,7 +1235,7 @@
     "\n",
     "L'**exploitabilité** mesure la vulnérabilité : l'écart entre le pire et le meilleur gain obtenu contre une galerie d'adversaires. Une stratégie robuste a une faible exploitabilité.\n",
     "\n",
-    "# Indice : pour chaque adversaire, calculer le gain via `PlayMatch`, identifier min/max, exploitabilité = max − min.\n"
+    "> **Indice :** pour chaque adversaire, calculer le gain via `PlayMatch`, identifier min/max, exploitabilité = max − min.\n"
    ]
   },
   {
@@ -1303,7 +1303,7 @@
     "\n",
     "**GenerousTitForTat** = TitForTat avec pardon : après une défection adverse, elle coopère avec probabilité $p$ (au lieu de punir systématiquement). Implémenter GTFT et montrer qu'elle résiste mieux au bruit.\n",
     "\n",
-    "# Indice : sous-classe de `Strategy`, `Choose()` imite TFT mais après une défection adverse, tire `Random.NextDouble() < p`.\n"
+    "> **Indice :** sous-classe de `Strategy`, `Choose()` imite TFT mais après une défection adverse, tire `Random.NextDouble() < p`.\n"
    ]
   },
   {
@@ -1372,7 +1372,7 @@
     "\n",
     "Une stratégie $S$ **envahit** une population résidente $R$ si, introduite à faible fréquence $\\varepsilon$, sa fitness contre la population (majoritairement $R$) est supérieure à celle de $R$. Tester si TitForTat envahit AlwaysDefect (et inversement).\n",
     "\n",
-    "# Indice : fitness de $S$ rare = $M[S, R]$ (gain contre $R$ quasi seul) ; fitness de $R$ = $M[R, R]$. Envahit ssi $M[S,R] > M[R,R]$.\n"
+    "> **Indice :** fitness de $S$ rare = $M[S, R]$ (gain contre $R$ quasi seul) ; fitness de $R$ = $M[R, R]$. Envahit ssi $M[S,R] > M[R,R]$.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17b-VRP-Logistics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-17b-VRP-Logistics-Csharp.ipynb
@@ -1550,7 +1550,7 @@
     "\n",
     "**Objectif** : implémenter `ClarkeWright(instance)` retournant une `VRPSolution` faisable.\n",
     "\n",
-    "# Indice : calculer la liste triée des savings décroissants, puis fusionner en respectant la capacité et la contrainte « un client n'appartient qu'à une tournée ».\n"
+    "> **Indice :** calculer la liste triée des savings décroissants, puis fusionner en respectant la capacité et la contrainte « un client n'appartient qu'à une tournée ».\n"
    ]
   },
   {
@@ -1623,7 +1623,7 @@
     "\n",
     "**Objectif** : ajouter l'opérateur OR-opt au voisinage du recuit simulé et mesurer l'impact sur la qualité finale.\n",
     "\n",
-    "# Indice : dans `SimulatedAnnealing`, ajouter un 3e type de mouvement (extraire segment length 1-3, réinsérer à une position aléatoire faisable).\n"
+    "> **Indice :** dans `SimulatedAnnealing`, ajouter un 3e type de mouvement (extraire segment length 1-3, réinsérer à une position aléatoire faisable).\n"
    ]
   },
   {
@@ -1692,7 +1692,7 @@
     "\n",
     "**Objectif** : étendre `VRPInstance` en `VRPTWInstance` et valider les fenêtres dans `IsValid()`.\n",
     "\n",
-    "# Indice : calculer le temps d'arrivée à chaque client (somme cumulée des distances + service), vérifier $e_i \\le t_i \\le l_i$.\n"
+    "> **Indice :** calculer le temps d'arrivée à chaque client (somme cumulée des distances + service), vérifier $e_i \\le t_i \\le l_i$.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb
@@ -1810,7 +1810,7 @@
     "\n",
     "L'**échec par négation** (Negation As Failure) : `not p(X)` est vrai si `p(X)` ne peut pas être prouvé. Étendre `EvaluateLiteral` pour gérer les littéraux niés dans le corps via NAF.\n",
     "\n",
-    "# Indice : un littéral nié `~lit` est vrai si la version positive `lit` n'est PAS dans le background (déjà géré), mais pour un littéral contenant des variables liées, vérifier qu'aucune instanciation ne le satisfait.\n"
+    "> **Indice :** un littéral nié `~lit` est vrai si la version positive `lit` n'est PAS dans le background (déjà géré), mais pour un littéral contenant des variables liées, vérifier qu'aucune instanciation ne le satisfait.\n"
    ]
   },
   {
@@ -1877,7 +1877,7 @@
     "\n",
     "FOIL utilise $p \\cdot \\log_2(\\frac{p}{p+n})$ comme gain. Une variante classique est le **gain d'information de Shannon** : $\\text{Gain} = H(parent) - \\frac{N_{child}}{N_{parent}} H(child)$ où $H(S) = -\\frac{p}{p+n}\\log_2\\frac{p}{p+n} - \\frac{n}{p+n}\\log_2\\frac{n}{p+n}$. L'implémenter et comparer les littéraux choisis.\n",
     "\n",
-    "# Indice : attention aux cas limites (p=0 ou n=0 → H=0 par convention). Comparer le littéral sélectionné à chaque profondeur avec FOIL classique.\n"
+    "> **Indice :** attention aux cas limites (p=0 ou n=0 → H=0 par convention). Comparer le littéral sélectionné à chaque profondeur avec FOIL classique.\n"
    ]
   },
   {
@@ -1943,7 +1943,7 @@
     "\n",
     "Sur le mini-KG, apprendre la règle **transitive** `livesIn(X, Z) :- livesIn(X, Y), locatedIn(Y, Z)` par FOIL (sans l'écrire à la main). Définir `positives` = tous les `(X, Z)` inférés, `negatives` = contre-exemples, `background` = le KG, et lancer `FoilStepByStep`.\n",
     "\n",
-    "# Indice : convertir le KG en background `(predicat, args[2])`, définir les positifs comme les paires `(X, Z)` où il existe une chaîne `livesIn-locatedIn`, les négatifs comme des paires au hasard non connectées.\n"
+    "> **Indice :** convertir le KG en background `(predicat, args[2])`, définir les positifs comme les paires `(X, Z)` où il existe une chaîne `livesIn-locatedIn`, les négatifs comme des paires au hasard non connectées.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixe une pathologie de rendu visuel signalée par le user dans l'EPIC #3966 : des hints d'exercice `# Indice :` étaient rendus en **H1** (police la plus grande), apparaissant plus gros que les titres d'exercice `### Exercice` (H3) — inversion pédagogique.

> Verbatim user (#3966) : « dans pas mal de Notebooks, les titres sont difficilement visibles, et les indices donnés aux exercices apparaissent comme les éléments de police la plus grande alors que ça devrait être l'inverse. »

## Notebooks affectés (12 cells, pattern uniforme single-line `# Indice :`)

| Notebook | Cells |
|----------|-------|
| GameTheory-3-Topology2x2-Csharp.ipynb | 21, 23, 25 |
| GameTheory-6-EvolutionTrust-Csharp.ipynb | 3 cells |
| App-17b-VRP-Logistics-Csharp.ipynb | 23, 25, 27 |
| SL-4-InductiveLogicProgramming-Csharp.ipynb | 17, 19, 21 |

## Fix

`# Indice : <texte>` → `> **Indice :** <texte>` (blockquote + gras).

L'indice est désormais visuellement distinct (blockquote) et en police normale, sous le titre d'exercice. Le contenu pédagogique est inchangé (classification par contenu préservée : reste un hint d'exercice, pas une solution — cf exercise-example-labeling).

**Avant** :
```markdown
### Exercice 1 — Négation par échec (NAF)
...
# Indice : un littéral nié `~lit` est vrai si...
```
**Après** :
```markdown
### Exercice 1 — Négation par échec (NAF)
...
> **Indice :** un littéral nié `~lit` est vrai si...
```

## Vérification

- `scripts/notebook_tools/scan_md_hierarchy.py` → **0/4 notebooks flaggés** après fix.
- Les nombres de l'EPIC #3966 (515 HINT-AS-HEADING fleet-wide) sont stale : campagnes antérieures ont nettoyé la plupart des familles. Re-scan actuel : GenAI 0/144, Sudoku 0/36, SymbolicAI non-Lean 1/77. Cette PR adresse les 4 notebooks résiduels flaggés.

## Conformité

- **Markdown-only edit (C.2 exception)** : 0 cellule code touchée, `outputs` et `execution_count` byte-identiques. Diff chirurgical (±14 lignes sur 4 fichiers).
- 0 CRLF (LF-only), CATALOG byte-identique à `main`.
- Pas de re-exécution requise (markdown-only).

See #3966. Part of #3801 (axe-2 SOTA, non-touché).

🤖 Generated with [Claude Code](https://claude.com/claude-code)