### PR TITLE
docs(qc): fix Vol-* README cloud-id drift + cross-contamination (See #1621)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/README.md
@@ -2,7 +2,7 @@
 
 **Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**Cloud project ID :** Voir `config.json` (local-id : 818573377)
+**Cloud project ID :** `33248352` (voir `config.json`, local-id : `209093652`)
 
 ## Description
 
@@ -16,7 +16,7 @@ lean backtest --algorithm Vol-Ensemble-Conservative/main.py
 ```
 
 ### QC Cloud
-Ouvrir le projet cloud (local-id : 818573377), compiler et lancer un backtest.
+Ouvrir le projet cloud (project-id : `33248352`), compiler et lancer un backtest.
 
 ## Métriques de backtest
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/README.md
@@ -2,7 +2,7 @@
 
 **Classe d'actifs :** Multi-actifs (Actions, Obligations, Matières premières)
 
-**Cloud project ID :** Voir `config.json` (local-id : 209093652)
+**Cloud project ID :** `33245149` (voir `config.json`, local-id : `818573377`)
 
 ## Description
 
@@ -16,7 +16,7 @@ lean backtest --algorithm Vol-GARCH-Target/main.py
 ```
 
 ### QC Cloud
-Ouvrir le projet cloud (local-id : 209093652), compiler et lancer un backtest.
+Ouvrir le projet cloud (project-id : `33245149`), compiler et lancer un backtest.
 
 ## Métriques de backtest
 


### PR DESCRIPTION
## Summary

Fix two Vol-* project READMEs that cited **wrong project IDs** — a cross-contamination from the ESGF degenericization rename (#1629). Part of QC consolidation #1621 (Phase 5 navigability). `See #1621`.

## G.1 firsthand — the cross-contamination bug

Both Vol-* READMEs pointed to the **other** project's local-id, and neither cited the real cloud project-id:

| README | Cited (wrong) | Real local-id | Real cloud-id |
|--------|---------------|---------------|---------------|
| `Vol-GARCH-Target/README.md` | local-id `209093652` | `818573377` | **`33245149`** |
| `Vol-Ensemble-Conservative/README.md` | local-id `818573377` | `209093652` | **`33248352`** |

Cross-checked via `qc-mcp-lite list_projects` (G.1, not from memory/dashboard) :
- `Vol-GARCH-Target` → projectId `33245149`
- `Vol-Ensemble-Conservative` → projectId `33248352`

So `Vol-GARCH-Target/README.md` was sending visitors to the **Vol-Ensemble** project (and vice-versa). The degenericization #1629 renamed `projects/ESGF-*` → `projects/Vol-*` but the README IDs were left pointing at stale/foreign IDs — the projects were later recreated fresh on QC Cloud (new project-ids) and the READMEs never resynced.

## Fix (2 READMEs, +4/-4)

Each README now shows the **real cloud project-id** (so a visitor can actually open the right project on QC Cloud) AND the correct **local-id** (matching its own `config.json`).

```
**Cloud project ID :** `33245149` (voir `config.json`, local-id : `818573377`)   # GARCH
**Cloud project ID :** `33248352` (voir `config.json`, local-id : `209093652`)   # Ensemble
```

## Scope discipline

- **`config.json` left untouched** — the `local-id` there drives LEAN CLI's local↔cloud linkage; rewriting it risks de-linking the local project. README-only fix = safe.
- **Verdict phantom (0-orders / cash interest) NOT addressed here** — a separate concern. Both Vol-* backtests report `totalOrders: 0` with CAGR ~6% (2018-2025) = cash interest phantom, not real edge (cf `qc-1027-phase2-phantom-baseline-0-orders` memory pattern). The `Vol-Ensemble` README currently claims "CAGR 6.14 % implique des trades réels" and was "Promue Tier 4 → 2 (Historique)" on that basis — this is a **false verdict** worth a dedicated fix (runtime diagnostic of the 0-orders + tier downgrade). Tracked separately to keep this PR atomic.

## Conformity

- **catalog-pr-hygiene R1** : no CATALOG-STATUS touched (project READMEs have none).
- **catalog-pr-hygiene R2** : fresh branch from `origin/main`.
- **catalog-pr-hygiene R3** : atomic — 2 files, 1 feature (cross-contamination + cloud-id drift), 1 domaine (Vol-* projects docs).
- **catalog-pr-hygiene R4** : `See #1621` (partial contribution to EPIC, not closing).
- **readme-french-first** : prose FR preserved.
- **L268 anti-CRLF** : verified 0 CRLF, LF-only (UTF-8 no BOM).
- **§A composite** : +4/-4 net, 2 files — far below split threshold.
- **H.4 / no backtest needed** : docs-only ID fix, no notebook re-execution.

Co-Authored-By: Claude <noreply@anthropic.com>
