### PR TITLE
docs(ml): link ML-6-ONNX-Python twin in ML.Net README table (See #5661)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -43,7 +43,7 @@ Le parcours va du premier pipeline (ML-1) jusqu'à une application complète : p
 | # | Notebook | Contenu | Jumeau Python (scikit-learn / statsmodels) | Durée |
 |---|----------|---------|------------------------------------------|-------|
 | 5 | [ML-5-TimeSeries](ML-5-TimeSeries.ipynb) | **Time Series Forecasting** avec ForecastBySsa (SSA) | [ML-5-Python](ML-5-TimeSeries-Python.ipynb) — STL + SARIMA | 45-60 min |
-| 6 | [ML-6-ONNX](ML-6-ONNX.ipynb) | **ONNX Integration** : modèles Python/PyTorch dans .NET | — (pont inter-langage, par nature .NET-centrique) | 45-60 min |
+| 6 | [ML-6-ONNX](ML-6-ONNX.ipynb) | **ONNX Integration** : modèles Python/PyTorch dans .NET | [ML-6-Python](ML-6-ONNX-Python.ipynb) — skl2onnx + onnxruntime (export côté Python du pont inter-langage) | 45-60 min |
 | 7 | [ML-7-Recommendation](ML-7-Recommendation.ipynb) | **Recommandation** : Matrix Factorization, collaborative filtering | [ML-7-Python](ML-7-Recommendation-Python.ipynb) — NMF | 45-60 min |
 | 8 | [ML-8-Clustering](ML-8-Clustering.ipynb) | **Clustering non-supervisé** : K-Means, segmentation RFM, méthode du coude | [ML-8-Python](ML-8-Clustering-Python.ipynb) — KMeans scikit-learn + méthode du coude | 45-60 min |
 | 9 | [ML-9-Anomaly-Detection](ML-9-Anomaly-Detection.ipynb) | **Détection d'anomalies** : Randomized PCA, AUC, seuil de décision | [ML-9-Python](ML-9-Anomaly-Detection-Python.ipynb) — PCA + erreur de reconstruction | 45-60 min |


### PR DESCRIPTION
## #5661 — ML/ML.Net/README.md : colonne jumeau Python de ML-6 (lien manquant)

**Item de #5661** (drifts feuilles, rollout #3973). See #5661, See #3973. Item = ma famille (#3974 ML ; jumeau ML-6-ONNX-Python livré commit `b895ef92a`).

### Drift corrigé (§E, audit fichier entier)

La ligne ML-6 du tableau indiquait « — (pont inter-langage, par nature .NET-centrique) » dans la colonne *Jumeau Python*. Cette rationale éditoriale était **stale** : le jumeau Python **existe et est substantif**.

| Colonne | Avant (stale) | Après (grounded) |
|---------|---------------|------------------|
| Jumeau Python (ML-6) | — (pont inter-langage, par nature .NET-centrique) | **[ML-6-Python](ML-6-ONNX-Python.ipynb) — skl2onnx + onnxruntime** (export côté Python du pont inter-langage) |

**Vérification G.1 firsthand** que le jumeau est substantif (pas un stub) :
```
ML-6-ONNX-Python.ipynb : 28 cells, 10 code, 10/10 outputs (C.2-conforme, exécuté)
first cell : « # ML-6 (Python) : Intégration de modèles ONNX (skl2onnx + onnxruntime) »
provenance : commit b895ef92a feat(ml): ML-6 Python (skl2onnx + onnxruntime) parity twin
taille : 29583 bytes
```

La rationale « pont inter-langage » est **préservée** dans la nouvelle description (« export côté Python du pont inter-langage ») : le jumeau Python montre le versant export (skl2onnx) du pont ONNX que ML.NET consomme côté import.

### Cohérence parité (vérifié firsthand, corrige une note mémoire stale)

`git ls-tree origin/main MyIA.AI.Notebooks/ML/ML.Net/` : les **9 notebooks ML-1 à ML-9 ont TOUS un jumeau `-Python.ipynb`** sur origin/main (ML-1-Introduction-Python, ML-2-Data&Features-Python, ML-3-Entrainement-Python, ML-4-Evaluation-Python, ML-5-TimeSeries-Python, ML-6-ONNX-Python, ML-7-Recommendation-Python, ML-8-Clustering-Python, ML-9-Anomaly-Detection-Python). Soit **9/9**. Une note de campagne disait « ML-2/3/4 SKIP, parité 9/10 » — stale : ces 3 jumeaux ont été livrés depuis. Cette PR aligne le README (ML-6 était la dernière ligne de tableau à ne pas référencer son jumeau).

### §E cohérence fichier entier

Audit des 16 autres références ML-6/ONNX du fichier (lignes 12, 16, 27, 73, 90, 118, 119, 175, 284, 293, 302, 355, 389, 399, 405, 409) : **aucune** ne clame l'absence de jumeau ML-6 — toutes discutent l'intégration ONNX .NET. La seule exclusion était la cellule de tableau (ligne 46), désormais corrigée.

### Conformité

- **§E pr-review-discipline** : audit fichier entier (415+ lignes).
- **catalog-pr-hygiene HARD 3** : 1 fichier, 1 ligne, 1 sujet (R3 atomique).
- **readme-french-first** : prose FR préservée.
- **MD047** : trailing newline préservé (`ends_nl=True`).
- **CRLF** : LF-only (Python-authoritative `crlf=0`, `lonely_cr=0`).
- **check-links** : lien `ML-6-ONNX-Python.ipynb` résout (fichier présent même dir, 29583 bytes).

### Validation

```
git diff --stat : 1 file changed, 1 insertion(+), 1 deletion(-)
endswith(b'\n') : True   # MD047 préservé
crlf count : 0           # LF-only
link ML-6-ONNX-Python.ipynb : resolves (29583 bytes)
parité ML-*-Python : 9/9 sur origin/main (firsthand)
```

Worktree isolé `d:/dev/coursia-mlnet-ml6-5661` depuis `origin/main` `915ae5b53` (FRESH, base = merge-base).

— myia-po-2025:CoursIA (item #5661, famille ML)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
