### PR TITLE
feat(tools): extract_readme_figures — inventory + extract PNG figures to assets/readme + MANIFEST (P0 #5654)

### DIFF
--- a/scripts/notebook_tools/extract_readme_figures.py
+++ b/scripts/notebook_tools/extract_readme_figures.py
@@ -1,0 +1,408 @@
+"""extract_readme_figures - extrait les figures PNG des outputs de notebooks
+vers ``<Serie>/assets/readme/`` + trace la provenance dans ``MANIFEST.md``.
+
+EPIC #5654 (illustration des READMEs, P0 outillage). La doctrine #5654 fixe
+trois sources d'images pour aerer les READMEs, par ordre de preference :
+figures extraites des outputs de notebooks (source par defaut, celle-ci),
+images generees par le pipeline GenAI, captures d'ecran. Ce module outille la
+source 1 : le gisement des figures DEJA commitees comme preuve d'execution
+des notebooks (~150 notebooks porteurs, inventaire ai-01 2026-07-07).
+
+Deux modes (alignes sur le body de l'EPIC) :
+
+  - :func:`list_figures` - inventorie les outputs ``image/png`` des notebooks
+    d'une serie (notebook, cellule, dimensions, poids estime). C'est le
+    *gisement* pour choisir quelles figures illustrer en P1/P2 ; on ne committe
+    aucune image a ce stade, seulement l'inventaire.
+  - :func:`extract_figure` - extrait UNE figure d'une cellule donnee vers
+    ``assets/readme/<nom>.png``, l'optimise (PIL si dispo : redimensionnement
+    <= 1200px + compression), puis append l'entree ``MANIFEST.md`` (notebook
+    source + index de cellule + alt-text FR obligatoire).
+
+Regles HARD (#5654, non-negociables pour les PRs filles) :
+
+  - **Emplacement** : ``MyIA.AI.Notebooks/<Serie>/assets/readme/`` (convention
+    unique). Pas d'image a la racine du repo.
+  - **Poids** : <= 200 KB/image, <= 1,5 MB/README. Pas de LFS. Si l'extraction
+    brute depasse le plafond, PIL downscales (max 1200px) puis recompresses ;
+    si PIL absent, l'extraction raw est ecrite + un avertissement demande une
+    optimisation manuelle.
+  - **Provenance tracee** : chaque ``assets/readme/`` contient un
+    ``MANIFEST.md`` (fichier -> notebook source + cellule, source 1). Une image
+    sans provenance = ``CHANGES_REQUESTED``.
+  - **Alt-text FR descriptif** obligatoire (accessibilite).
+  - **Jamais de re-execution de notebook juste pour une figure** (C.3) : on
+    extrait des outputs DEJA committes. Si la figure souhaitee n'existe pas,
+    c'est un enrichissement de notebook (PR separee) d'abord.
+  - **CATALOG-STATUS byte-identiques** : ce module ne touche jamais aux
+    READMEs ; il cree/append ``assets/readme/`` et ``MANIFEST.md`` uniquement.
+
+Dependances : stdlib (``json``, ``base64``, ``pathlib``, ``struct``) pour
+l'inventaire et l'extraction raw PNG ; :mod:`PIL` (Pillow) OPTIONNEL pour
+l'optimisation (redimensionnement + compression). Un PNG se parse sans PIL
+via son en-tete IHDR (octets 16-24 : largeur/hauteur big-endian).
+Reference : EPIC #5654, mandat user 2026-07-07.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+# Plafonds poids (regles HARD #5654).
+MAX_BYTES_DEFAULT: int = 200 * 1024       # 200 KB/image
+MAX_DIM_DEFAULT: int = 1200               # downscale Pil au-dela (px, grand cote)
+PNG_IHDR_WIDTH_OFFSET: int = 16           # offset octet du champ largeur IHDR
+PNG_IHDR_HEIGHT_OFFSET: int = 20          # offset octet du champ hauteur IHDR
+_PNG_MAGIC: bytes = b"\x89PNG\r\n\x1a\n"
+
+
+# --------------------------------------------------------------------------- #
+#  Parsing notebook + outputs (stdlib)                                        #
+# --------------------------------------------------------------------------- #
+def _iter_notebooks(root: Path) -> Iterator[Path]:
+    """Yield les fichiers ``.ipynb`` d'une serie (exclut les checkpoints."""
+    for p in sorted(root.rglob("*.ipynb")):
+        if ".ipynb_checkpoints" in p.parts:
+            continue
+        yield p
+
+
+def _load_notebook(path: Path) -> dict:
+    """Charge un notebook en dict (JSON). Echec = JSONDecodeError propagee."""
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _png_dimensions(raw: bytes) -> Optional[tuple]:
+    """Largeur/hauteur d'un PNG depuis l'en-tete IHDR (stdlib, sans PIL).
+
+    Retourne ``(width, height)`` ou ``None`` si la signature PNG est absente /
+    l'en-tete est tronque. Le PNG commence par la magic (8 octets) puis IHDR
+    (longueur 4 + type 4 + donnees dont largeur 4 + hauteur 4 BE).
+    """
+    if len(raw) < PNG_IHDR_HEIGHT_OFFSET + 4:
+        return None
+    if raw[:8] != _PNG_MAGIC:
+        return None
+    width = int.from_bytes(
+        raw[PNG_IHDR_WIDTH_OFFSET:PNG_IHDR_WIDTH_OFFSET + 4], "big")
+    height = int.from_bytes(
+        raw[PNG_IHDR_HEIGHT_OFFSET:PNG_IHDR_HEIGHT_OFFSET + 4], "big")
+    return width, height
+
+
+def _cell_outputs(cell: dict) -> List[dict]:
+    """Outputs d'une cellule (code uniquement ; markdown n'en a pas)."""
+    if cell.get("cell_type") != "code":
+        return []
+    return cell.get("outputs", []) or []
+
+
+def _png_output_bytes(output: dict) -> Optional[bytes]:
+    """Bytes PNG d'un output si celui-ci porte du ``image/png`` (base64).
+
+    Couvre les outputs ``display_data`` et ``execute_result`` (cle ``data``)
+    ainsi que ``error``/``stream`` (ignores). Retourne ``None`` si pas de PNG.
+    """
+    data = output.get("data", {})
+    b64 = data.get("image/png")
+    if not b64:
+        return None
+    if isinstance(b64, list):           # nbformat : source-like (rare pour data)
+        b64 = "".join(b64)
+    try:
+        return base64.b64decode(b64)
+    except (ValueError, base64.binascii.Error):
+        return None
+
+
+def _figure_records(notebook_path: Path, nb: dict) -> List[dict]:
+    """Tous les records de figures PNG d'un notebook.
+
+    Un record = ``{notebook, cell_index, output_index, width, height, bytes}``.
+    Plusieurs outputs d'une meme cellule donnent plusieurs records (l'index
+    d'output les differencie). Les dimensions sont lues via IHDR (sans PIL) ;
+    si le PNG est malforme, ``width``/``height`` sont ``None``.
+    """
+    records: List[dict] = []
+    for cell_index, cell in enumerate(nb.get("cells", [])):
+        for output_index, output in enumerate(_cell_outputs(cell)):
+            raw = _png_output_bytes(output)
+            if raw is None:
+                continue
+            dims = _png_dimensions(raw)
+            records.append({
+                "notebook": str(notebook_path),
+                "cell_index": cell_index,
+                "output_index": output_index,
+                "width": dims[0] if dims else None,
+                "height": dims[1] if dims else None,
+                "bytes": len(raw),
+            })
+    return records
+
+
+# --------------------------------------------------------------------------- #
+#  Resolution de path (repo-relatif / serie-relatif / absolu)                 #
+# --------------------------------------------------------------------------- #
+def resolve_repo_path(arg, repo_root, notebooks_subdir="MyIA.AI.Notebooks") -> Path:
+    """Resout un path notebook/serie robuste quel que soit le cwd de l'appelant.
+
+    ``arg`` peut etre :
+
+      - un **path absolu** (``/d/dev/.../RL/x.ipynb``) -> retourne tel quel ;
+      - un **path repo-relatif complet** (``MyIA.AI.Notebooks/RL/x.ipynb``) ->
+        retourne ``repo_root / arg`` (existe sur disque, on ne double PAS le
+        prefixe) ;
+      - un **path serie-relatif** (``RL/x.ipynb``) -> retourne
+        ``repo_root / notebooks_subdir / arg`` (prefixage convention).
+
+    On essaie d'abord ``repo_root / arg`` : s'il existe, c'est un repo-relatif
+    complet (pas de double-prefixe). Sinon, on prefixe ``notebooks_subdir``.
+    Rend le CLI robuste invoque depuis la racine du repo OU depuis
+    ``MyIA.AI.Notebooks/`` (cross-review F2, po-2026).
+
+    ``notebooks_subdir`` : sous-repertoire des series (defaut
+    ``MyIA.AI.Notebooks``). Retourne un :class:`~pathlib.Path` absolu resolu.
+    """
+    p = Path(arg)
+    if p.is_absolute():
+        return p
+    candidate = Path(repo_root) / arg
+    if candidate.exists():
+        return candidate.resolve()
+    return (Path(repo_root) / notebooks_subdir / arg).resolve()
+
+
+# --------------------------------------------------------------------------- #
+#  Mode 1 : inventaire (--list)                                               #
+# --------------------------------------------------------------------------- #
+def list_figures(serie_path, relative_to=None) -> dict:
+    """Inventorie les figures PNG des notebooks d'une serie.
+
+    ``serie_path`` : chemin de la serie (ex. ``MyIA.AI.Notebooks/RL``). Parcourt
+    recursivement les ``.ipynb`` (hors checkpoints) et collecte tous les
+    outputs ``image/png`` committes. Retourne un dict :
+
+    ::
+
+        {
+          "serie": "<nom>",
+          "root": "<chemin>",
+          "n_notebooks_with_figures": int,
+          "n_figures": int,
+          "total_bytes": int,
+          "figures": [ <record>, ... ],     # records tries par notebook puis cellule
+        }
+
+    C'est le *gisement* pour choisir les figures a illustrer (P1/P2) ; aucun
+    fichier n'est ecrit. Les records au-dela du plafond poids (200 KB) sont
+    marques ``"over_weight": True`` pour orienter l'optimisation a l'extraction.
+
+    ``relative_to`` : si fourni, les chemins ``notebook`` des records et le
+    champ ``root`` sont relativises a ce repertoire (avec separateurs POSIX).
+    Utilise pour produire des inventaires portables (committes) ; par defaut
+    (``None``) les chemins sont laisses tels que resolus par l'appelant.
+    """
+    root = Path(serie_path)
+    if not root.is_dir():
+        raise FileNotFoundError(f"Serie introuvable : {serie_path}")
+    base = Path(relative_to) if relative_to is not None else None
+
+    def _rel(path: Path) -> str:
+        if base is None:
+            return str(path)
+        try:
+            return str(path.resolve().relative_to(base.resolve())).replace("\\", "/")
+        except ValueError:
+            return str(path)
+
+    figures: List[dict] = []
+    for nb_path in _iter_notebooks(root):
+        try:
+            nb = _load_notebook(nb_path)
+        except (json.JSONDecodeError, OSError):
+            continue
+        for rec in _figure_records(nb_path, nb):
+            rec["notebook"] = _rel(nb_path)
+            rec["over_weight"] = rec["bytes"] > MAX_BYTES_DEFAULT
+            figures.append(rec)
+    figures.sort(key=lambda r: (r["notebook"], r["cell_index"], r["output_index"]))
+    notebooks_with = {r["notebook"] for r in figures}
+    return {
+        "serie": root.name,
+        "root": _rel(root),
+        "n_notebooks_with_figures": len(notebooks_with),
+        "n_figures": len(figures),
+        "total_bytes": sum(r["bytes"] for r in figures),
+        "figures": figures,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  Mode 2 : extraction (--extract) + optimisation + MANIFEST                  #
+# --------------------------------------------------------------------------- #
+def _optimize_with_pil(raw: bytes, max_dim: int) -> tuple:
+    """Optimise un PNG avec PIL : downscale (grand cote <= max_dim) + recompression.
+
+    Retourne ``(optimized_bytes, used_pil)``. Si PIL est absent, retourne la
+    raw a l'identique + ``used_pil=False`` (l'appelant avertit pour optimisation
+    manuelle). Ne leve jamais : une erreur PIL retombe sur la raw.
+    """
+    try:
+        from PIL import Image                  # import local (optionnel)
+        import io
+        img = Image.open(io.BytesIO(raw))
+        if img.mode in ("RGBA", "LA") and img.mode != "RGBA":
+            img = img.convert("RGBA")
+        w, h = img.size
+        scale = min(1.0, max_dim / max(w, h)) if max(w, h) > 0 else 1.0
+        if scale < 1.0:
+            img = img.resize(
+                (max(1, int(w * scale)), max(1, int(h * scale))),
+                Image.LANCZOS,
+            )
+        buf = io.BytesIO()
+        img.save(buf, format="PNG", optimize=True)
+        out = buf.getvalue()
+        # On ne retient l'optimise que s'il est effectivement plus leger.
+        return (out, True) if len(out) < len(raw) else (raw, True)
+    except Exception:
+        return raw, False
+
+
+def extract_figure(nb_path, cell_index: int, output_index: int,
+                   output_path, alt_text_fr: str,
+                   max_dim: int = MAX_DIM_DEFAULT,
+                   max_bytes: int = MAX_BYTES_DEFAULT,
+                   serie_root=None) -> dict:
+    """Extrait une figure PNG d'une cellule de notebook vers ``assets/readme/``.
+
+    Lit le PNG a l'index ``(cell_index, output_index)`` du notebook, l'optimise
+    (PIL : downscale <= ``max_dim`` + compression, dans la limite de
+    ``max_bytes``), l'ecrit dans ``output_path``, puis append l'entree
+    ``MANIFEST.md`` a cote (provenance source 1 : notebook + cellule + alt-text).
+
+    ``alt_text_fr`` est obligatoire (regle HARD accessibilite #5654) ; une
+    chaine vide leve :class:`ValueError`.
+
+    ``serie_root`` (optionnel) : si fourni, le chemin relatif du notebook dans
+    le manifest est calcule depuis cette racine (plus lisible). Sinon, chemin
+    absolu.
+
+    Retourne le record d'extraction :
+
+    ::
+
+        {
+          "output": "<chemin png ecrit>",
+          "notebook": "<source>",
+          "cell_index": int, "output_index": int,
+          "bytes": int, "used_pil": bool, "over_weight": bool,
+        }
+
+    Leve :class:`ValueError` si la cellule/output n'existe pas ou ne porte pas
+    de PNG, ou si ``alt_text_fr`` est vide.
+    """
+    if not alt_text_fr or not alt_text_fr.strip():
+        raise ValueError("alt_text_fr obligatoire (accessibilite, regle #5654)")
+    nb_path = Path(nb_path)
+    nb = _load_notebook(nb_path)
+    cells = nb.get("cells", [])
+    if cell_index < 0 or cell_index >= len(cells):
+        raise ValueError(
+            f"cell_index {cell_index} hors plage (0..{len(cells) - 1})")
+    outputs = _cell_outputs(cells[cell_index])
+    if output_index < 0 or output_index >= len(outputs):
+        raise ValueError(
+            f"output_index {output_index} hors plage "
+            f"(cellule {cell_index} a {len(outputs)} outputs)")
+    raw = _png_output_bytes(outputs[output_index])
+    if raw is None:
+        raise ValueError(
+            f"La cellule {cell_index} output {output_index} ne porte pas de PNG")
+
+    optimized, used_pil = _optimize_with_pil(raw, max_dim)
+    out_path = Path(output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "wb") as fh:
+        fh.write(optimized)
+
+    entry = {
+        "output": str(out_path),
+        "notebook": str(nb_path),
+        "cell_index": cell_index,
+        "output_index": output_index,
+        "bytes": len(optimized),
+        "used_pil": used_pil,
+        "over_weight": len(optimized) > max_bytes,
+    }
+    _append_manifest(out_path.parent, entry, alt_text_fr, serie_root)
+    return entry
+
+
+def _append_manifest(assets_dir, entry: dict, alt_text_fr: str,
+                     serie_root=None) -> None:
+    """Append une entree de provenance au ``MANIFEST.md`` de ``assets_dir``.
+
+    Format source 1 (extraction de notebook) :
+
+    ::
+
+        ## <filename>.png
+
+        - **Source** : notebook `<relpath>` (cellule N, output M)
+        - **Alt-text (FR)** : <alt_text_fr>
+        - **Poids** : NN KB (PIL optimise / raw)
+
+    Idempotent : si une entree pour le meme fichier existe deja (meme nom de
+    section), elle est remplacee (evite les doublons sur re-extraction).
+    """
+    assets_dir = Path(assets_dir)
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    manifest = assets_dir / "MANIFEST.md"
+    fname = Path(entry["output"]).name
+    nb_path = Path(entry["notebook"])
+    if serie_root is not None:
+        try:
+            rel = nb_path.relative_to(Path(serie_root))
+            src_display = str(rel).replace("\\", "/")
+        except ValueError:
+            src_display = str(nb_path)
+    else:
+        src_display = str(nb_path)
+    weight_kb = entry["bytes"] / 1024.0
+    optimized_tag = "PIL optimise" if entry["used_pil"] else "raw (PIL absent)"
+    block = (
+        f"## {fname}\n\n"
+        f"- **Source** : notebook `{src_display}` "
+        f"(cellule {entry['cell_index']}, output {entry['output_index']})\n"
+        f"- **Alt-text (FR)** : {alt_text_fr}\n"
+        f"- **Poids** : {weight_kb:.1f} KB ({optimized_tag})\n"
+    )
+    existing = manifest.read_text(encoding="utf-8") if manifest.exists() else ""
+    header = (
+        "# MANIFEST des figures README\n\n"
+        "Provenance des images de `assets/readme/` "
+        "(EPIC #5654, source 1 = extraction d'outputs de notebooks).\n\n"
+    )
+    if not existing.strip():
+        manifest.write_text(header + block, encoding="utf-8")
+        return
+    # Remplace un bloc existant pour ce fichier (regex ancrée sur le nom).
+    pattern = re.compile(
+        r"^## " + re.escape(fname) + r"\n.*?(?=\n## |\Z)",
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if pattern.search(existing):
+        new_body = pattern.sub(block.rstrip("\n"), existing)
+    else:
+        new_body = existing.rstrip("\n") + "\n\n" + block
+    # Preserve le header si deja present, sinon l'ajoute (cas fichier sans header).
+    if "# MANIFEST des figures README" not in new_body:
+        new_body = header + new_body
+    manifest.write_text(new_body, encoding="utf-8")

--- a/scripts/notebook_tools/figures_inventory/GenAI-Image.json
+++ b/scripts/notebook_tools/figures_inventory/GenAI-Image.json
@@ -1,0 +1,387 @@
+{
+  "serie": "Image",
+  "root": "MyIA.AI.Notebooks/GenAI/Image",
+  "n_notebooks_with_figures": 14,
+  "n_figures": 42,
+  "total_bytes": 44183540,
+  "figures": [
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb",
+      "cell_index": 14,
+      "output_index": 3,
+      "width": 746,
+      "height": 789,
+      "bytes": 918009,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+      "cell_index": 10,
+      "output_index": 2,
+      "width": 761,
+      "height": 789,
+      "bytes": 847739,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+      "cell_index": 12,
+      "output_index": 2,
+      "width": 766,
+      "height": 790,
+      "bytes": 823748,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+      "cell_index": 14,
+      "output_index": 4,
+      "width": 1736,
+      "height": 617,
+      "bytes": 1741323,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+      "cell_index": 18,
+      "output_index": 1,
+      "width": 568,
+      "height": 590,
+      "bytes": 558072,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+      "cell_index": 18,
+      "output_index": 5,
+      "width": 1446,
+      "height": 495,
+      "bytes": 894693,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+      "cell_index": 18,
+      "output_index": 10,
+      "width": 1446,
+      "height": 515,
+      "bytes": 1138415,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+      "cell_index": 22,
+      "output_index": 2,
+      "width": 481,
+      "height": 503,
+      "bytes": 451800,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb",
+      "cell_index": 25,
+      "output_index": 2,
+      "width": 746,
+      "height": 790,
+      "bytes": 785319,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb",
+      "cell_index": 10,
+      "output_index": 2,
+      "width": 370,
+      "height": 390,
+      "bytes": 158211,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb",
+      "cell_index": 18,
+      "output_index": 3,
+      "width": 1041,
+      "height": 490,
+      "bytes": 61739,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb",
+      "cell_index": 10,
+      "output_index": 2,
+      "width": 1148,
+      "height": 890,
+      "bytes": 908398,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb",
+      "cell_index": 14,
+      "output_index": 5,
+      "width": 1990,
+      "height": 420,
+      "bytes": 683561,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb",
+      "cell_index": 17,
+      "output_index": 1,
+      "width": 1489,
+      "height": 402,
+      "bytes": 284301,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb",
+      "cell_index": 24,
+      "output_index": 5,
+      "width": 1152,
+      "height": 1181,
+      "bytes": 1664440,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb",
+      "cell_index": 27,
+      "output_index": 5,
+      "width": 1589,
+      "height": 467,
+      "bytes": 964728,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb",
+      "cell_index": 9,
+      "output_index": 9,
+      "width": 966,
+      "height": 989,
+      "bytes": 2238874,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb",
+      "cell_index": 13,
+      "output_index": 9,
+      "width": 1589,
+      "height": 468,
+      "bytes": 861960,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb",
+      "cell_index": 15,
+      "output_index": 9,
+      "width": 1197,
+      "height": 788,
+      "bytes": 853414,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb",
+      "cell_index": 17,
+      "output_index": 9,
+      "width": 1151,
+      "height": 1181,
+      "bytes": 2208771,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb",
+      "cell_index": 21,
+      "output_index": 9,
+      "width": 1349,
+      "height": 1377,
+      "bytes": 2771422,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb",
+      "cell_index": 23,
+      "output_index": 9,
+      "width": 1151,
+      "height": 1181,
+      "bytes": 1615149,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-4-Z-Image-Lumina2.ipynb",
+      "cell_index": 11,
+      "output_index": 3,
+      "width": 970,
+      "height": 989,
+      "bytes": 1419965,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb",
+      "cell_index": 6,
+      "output_index": 0,
+      "width": 885,
+      "height": 590,
+      "bytes": 35253,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb",
+      "cell_index": 10,
+      "output_index": 0,
+      "width": 795,
+      "height": 440,
+      "bytes": 29499,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-1-Multi-Model-Comparison.ipynb",
+      "cell_index": 8,
+      "output_index": 2,
+      "width": 1182,
+      "height": 596,
+      "bytes": 555244,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb",
+      "cell_index": 11,
+      "output_index": 5,
+      "width": 1444,
+      "height": 495,
+      "bytes": 13127,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb",
+      "cell_index": 13,
+      "output_index": 2,
+      "width": 1404,
+      "height": 495,
+      "bytes": 23493,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb",
+      "cell_index": 17,
+      "output_index": 7,
+      "width": 694,
+      "height": 396,
+      "bytes": 16965,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb",
+      "cell_index": 21,
+      "output_index": 2,
+      "width": 1143,
+      "height": 397,
+      "bytes": 9100,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb",
+      "cell_index": 15,
+      "output_index": 3,
+      "width": 1024,
+      "height": 1024,
+      "bytes": 2054914,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb",
+      "cell_index": 12,
+      "output_index": 0,
+      "width": 32,
+      "height": 32,
+      "bytes": 166,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb",
+      "cell_index": 17,
+      "output_index": 1,
+      "width": 32,
+      "height": 32,
+      "bytes": 148,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/history-geography.ipynb",
+      "cell_index": 8,
+      "output_index": 3,
+      "width": 1260,
+      "height": 889,
+      "bytes": 1927178,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/history-geography.ipynb",
+      "cell_index": 12,
+      "output_index": 3,
+      "width": 1260,
+      "height": 889,
+      "bytes": 1957389,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/history-geography.ipynb",
+      "cell_index": 14,
+      "output_index": 3,
+      "width": 1260,
+      "height": 889,
+      "bytes": 1775355,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/history-geography.ipynb",
+      "cell_index": 18,
+      "output_index": 3,
+      "width": 1259,
+      "height": 890,
+      "bytes": 1597592,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/literature-visual.ipynb",
+      "cell_index": 8,
+      "output_index": 2,
+      "width": 891,
+      "height": 1390,
+      "bytes": 2003702,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/literature-visual.ipynb",
+      "cell_index": 10,
+      "output_index": 3,
+      "width": 891,
+      "height": 1390,
+      "bytes": 2166836,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/literature-visual.ipynb",
+      "cell_index": 14,
+      "output_index": 3,
+      "width": 891,
+      "height": 1390,
+      "bytes": 2093969,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/literature-visual.ipynb",
+      "cell_index": 18,
+      "output_index": 3,
+      "width": 891,
+      "height": 1390,
+      "bytes": 1615489,
+      "over_weight": true
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/GenAI/Image/examples/science-diagrams.ipynb",
+      "cell_index": 12,
+      "output_index": 3,
+      "width": 1260,
+      "height": 889,
+      "bytes": 1454070,
+      "over_weight": true
+    }
+  ]
+}

--- a/scripts/notebook_tools/figures_inventory/QuantConnect-ML-Training-Pipeline.json
+++ b/scripts/notebook_tools/figures_inventory/QuantConnect-ML-Training-Pipeline.json
@@ -1,0 +1,261 @@
+{
+  "serie": "ML-Training-Pipeline",
+  "root": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline",
+  "n_notebooks_with_figures": 10,
+  "n_figures": 28,
+  "total_bytes": 1380779,
+  "figures": [
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/ML-Research-Template.ipynb",
+      "cell_index": 4,
+      "output_index": 0,
+      "width": 1388,
+      "height": 790,
+      "bytes": 58783,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/ML-Research-Template.ipynb",
+      "cell_index": 7,
+      "output_index": 0,
+      "width": 989,
+      "height": 590,
+      "bytes": 50279,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb",
+      "cell_index": 15,
+      "output_index": 0,
+      "width": 1389,
+      "height": 989,
+      "bytes": 179669,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb",
+      "cell_index": 21,
+      "output_index": 0,
+      "width": 1389,
+      "height": 590,
+      "bytes": 69992,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb",
+      "cell_index": 31,
+      "output_index": 0,
+      "width": 1390,
+      "height": 590,
+      "bytes": 99778,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb",
+      "cell_index": 35,
+      "output_index": 1,
+      "width": 1390,
+      "height": 590,
+      "bytes": 97885,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb",
+      "cell_index": 39,
+      "output_index": 1,
+      "width": 1390,
+      "height": 590,
+      "bytes": 123167,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb",
+      "cell_index": 44,
+      "output_index": 1,
+      "width": 989,
+      "height": 490,
+      "bytes": 25322,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m11e_ensemble_research.ipynb",
+      "cell_index": 6,
+      "output_index": 1,
+      "width": 832,
+      "height": 430,
+      "bytes": 29534,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m11e_ensemble_research.ipynb",
+      "cell_index": 8,
+      "output_index": 1,
+      "width": 765,
+      "height": 409,
+      "bytes": 45177,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m11e_ensemble_research.ipynb",
+      "cell_index": 10,
+      "output_index": 0,
+      "width": 839,
+      "height": 392,
+      "bytes": 66062,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m12_har_rv_j_research.ipynb",
+      "cell_index": 6,
+      "output_index": 0,
+      "width": 715,
+      "height": 432,
+      "bytes": 33618,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m12_har_rv_j_research.ipynb",
+      "cell_index": 8,
+      "output_index": 2,
+      "width": 540,
+      "height": 358,
+      "bytes": 17265,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m12_har_rv_j_research.ipynb",
+      "cell_index": 10,
+      "output_index": 1,
+      "width": 711,
+      "height": 404,
+      "bytes": 25787,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m15_lstm_rv_research.ipynb",
+      "cell_index": 6,
+      "output_index": 0,
+      "width": 719,
+      "height": 432,
+      "bytes": 41185,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m15_lstm_rv_research.ipynb",
+      "cell_index": 8,
+      "output_index": 2,
+      "width": 540,
+      "height": 358,
+      "bytes": 16442,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m15_lstm_rv_research.ipynb",
+      "cell_index": 10,
+      "output_index": 1,
+      "width": 702,
+      "height": 404,
+      "bytes": 26786,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m4_dlinear_vol_research.ipynb",
+      "cell_index": 6,
+      "output_index": 1,
+      "width": 706,
+      "height": 404,
+      "bytes": 29444,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m4_dlinear_vol_research.ipynb",
+      "cell_index": 8,
+      "output_index": 2,
+      "width": 540,
+      "height": 358,
+      "bytes": 14609,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m5_hmm_regime_research.ipynb",
+      "cell_index": 6,
+      "output_index": 1,
+      "width": 779,
+      "height": 409,
+      "bytes": 29706,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m5_hmm_regime_research.ipynb",
+      "cell_index": 8,
+      "output_index": 1,
+      "width": 809,
+      "height": 409,
+      "bytes": 21272,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m5_hmm_regime_research.ipynb",
+      "cell_index": 10,
+      "output_index": 0,
+      "width": 816,
+      "height": 370,
+      "bytes": 33136,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m9_tft_vol_research.ipynb",
+      "cell_index": 6,
+      "output_index": 1,
+      "width": 790,
+      "height": 409,
+      "bytes": 63112,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m9_tft_vol_research.ipynb",
+      "cell_index": 8,
+      "output_index": 1,
+      "width": 690,
+      "height": 370,
+      "bytes": 21018,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m9_tft_vol_research.ipynb",
+      "cell_index": 10,
+      "output_index": 0,
+      "width": 781,
+      "height": 370,
+      "bytes": 26983,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l3_trend.ipynb",
+      "cell_index": 6,
+      "output_index": 1,
+      "width": 688,
+      "height": 309,
+      "bytes": 23275,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l3_trend.ipynb",
+      "cell_index": 8,
+      "output_index": 1,
+      "width": 690,
+      "height": 309,
+      "bytes": 38319,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb",
+      "cell_index": 7,
+      "output_index": 0,
+      "width": 1486,
+      "height": 490,
+      "bytes": 73174,
+      "over_weight": false
+    }
+  ]
+}

--- a/scripts/notebook_tools/figures_inventory/RL.json
+++ b/scripts/notebook_tools/figures_inventory/RL.json
@@ -1,0 +1,333 @@
+{
+  "serie": "RL",
+  "root": "MyIA.AI.Notebooks/RL",
+  "n_notebooks_with_figures": 14,
+  "n_figures": 36,
+  "total_bytes": 1699154,
+  "figures": [
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb",
+      "cell_index": 2,
+      "output_index": 0,
+      "width": 566,
+      "height": 590,
+      "bytes": 15319,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb",
+      "cell_index": 8,
+      "output_index": 0,
+      "width": 989,
+      "height": 490,
+      "bytes": 50595,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb",
+      "cell_index": 8,
+      "output_index": 0,
+      "width": 1189,
+      "height": 789,
+      "bytes": 75821,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb",
+      "cell_index": 15,
+      "output_index": 1,
+      "width": 989,
+      "height": 490,
+      "bytes": 27212,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb",
+      "cell_index": 4,
+      "output_index": 1,
+      "width": 1290,
+      "height": 299,
+      "bytes": 31207,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb",
+      "cell_index": 6,
+      "output_index": 0,
+      "width": 1290,
+      "height": 299,
+      "bytes": 24644,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb",
+      "cell_index": 16,
+      "output_index": 0,
+      "width": 889,
+      "height": 390,
+      "bytes": 73541,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb",
+      "cell_index": 18,
+      "output_index": 0,
+      "width": 1290,
+      "height": 348,
+      "bytes": 24057,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb",
+      "cell_index": 7,
+      "output_index": 0,
+      "width": 1079,
+      "height": 409,
+      "bytes": 64201,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb",
+      "cell_index": 12,
+      "output_index": 0,
+      "width": 1188,
+      "height": 409,
+      "bytes": 53539,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb",
+      "cell_index": 14,
+      "output_index": 0,
+      "width": 1389,
+      "height": 495,
+      "bytes": 74505,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb",
+      "cell_index": 29,
+      "output_index": 0,
+      "width": 1490,
+      "height": 592,
+      "bytes": 126410,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb",
+      "cell_index": 30,
+      "output_index": 0,
+      "width": 989,
+      "height": 490,
+      "bytes": 77937,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb",
+      "cell_index": 32,
+      "output_index": 0,
+      "width": 989,
+      "height": 540,
+      "bytes": 63913,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb",
+      "cell_index": 36,
+      "output_index": 0,
+      "width": 1189,
+      "height": 590,
+      "bytes": 78182,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb",
+      "cell_index": 38,
+      "output_index": 0,
+      "width": 1790,
+      "height": 495,
+      "bytes": 38887,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb",
+      "cell_index": 13,
+      "output_index": 0,
+      "width": 567,
+      "height": 590,
+      "bytes": 12174,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb",
+      "cell_index": 14,
+      "output_index": 0,
+      "width": 790,
+      "height": 390,
+      "bytes": 28858,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb",
+      "cell_index": 22,
+      "output_index": 0,
+      "width": 989,
+      "height": 390,
+      "bytes": 30554,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb",
+      "cell_index": 11,
+      "output_index": 0,
+      "width": 1389,
+      "height": 490,
+      "bytes": 68839,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb",
+      "cell_index": 18,
+      "output_index": 0,
+      "width": 989,
+      "height": 490,
+      "bytes": 58432,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb",
+      "cell_index": 21,
+      "output_index": 0,
+      "width": 1389,
+      "height": 490,
+      "bytes": 84129,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb",
+      "cell_index": 6,
+      "output_index": 0,
+      "width": 790,
+      "height": 490,
+      "bytes": 39165,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb",
+      "cell_index": 16,
+      "output_index": 0,
+      "width": 989,
+      "height": 490,
+      "bytes": 70302,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb",
+      "cell_index": 7,
+      "output_index": 0,
+      "width": 1390,
+      "height": 396,
+      "bytes": 33317,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb",
+      "cell_index": 26,
+      "output_index": 0,
+      "width": 989,
+      "height": 490,
+      "bytes": 72051,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb",
+      "cell_index": 14,
+      "output_index": 0,
+      "width": 1188,
+      "height": 331,
+      "bytes": 62020,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb",
+      "cell_index": 17,
+      "output_index": 0,
+      "width": 989,
+      "height": 490,
+      "bytes": 32285,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb",
+      "cell_index": 4,
+      "output_index": 0,
+      "width": 541,
+      "height": 390,
+      "bytes": 8553,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb",
+      "cell_index": 7,
+      "output_index": 0,
+      "width": 790,
+      "height": 390,
+      "bytes": 33122,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb",
+      "cell_index": 12,
+      "output_index": 0,
+      "width": 790,
+      "height": 440,
+      "bytes": 52204,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb",
+      "cell_index": 15,
+      "output_index": 0,
+      "width": 955,
+      "height": 309,
+      "bytes": 12242,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb",
+      "cell_index": 16,
+      "output_index": 0,
+      "width": 790,
+      "height": 440,
+      "bytes": 44421,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb",
+      "cell_index": 3,
+      "output_index": 0,
+      "width": 583,
+      "height": 390,
+      "bytes": 13490,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb",
+      "cell_index": 14,
+      "output_index": 1,
+      "width": 590,
+      "height": 340,
+      "bytes": 14152,
+      "over_weight": false
+    },
+    {
+      "notebook": "MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb",
+      "cell_index": 18,
+      "output_index": 0,
+      "width": 790,
+      "height": 440,
+      "bytes": 28874,
+      "over_weight": false
+    }
+  ]
+}

--- a/scripts/notebook_tools/notebook_tools.py
+++ b/scripts/notebook_tools/notebook_tools.py
@@ -2024,6 +2024,86 @@ def cmd_normalize_source_charsplit(args):
     return 0
 
 
+# --------------------------------------------------------------------------- #
+#  figures-list / figures-extract (EPIC #5654 P0 — illustration des READMEs)   #
+# --------------------------------------------------------------------------- #
+def cmd_figures_list(args):
+    """Inventorie les figures PNG des outputs de notebooks d'une serie.
+
+    Source 1 de la doctrine #5654 : figures DEJA commitees comme preuve
+    d'execution. Aucune image n'est extraite ; on produit le gisement pour
+    choisir les illustrations en P1/P2.
+    """
+    from extract_readme_figures import list_figures, MAX_BYTES_DEFAULT
+    repo_root = get_repo_root()
+    serie_path = Path(args.serie)
+    if not serie_path.is_absolute():
+        # accepte un nom de serie (ex. "RL") resolu depuis la racine notebooks
+        candidate = repo_root / "MyIA.AI.Notebooks" / args.serie
+        if candidate.is_dir():
+            serie_path = candidate
+    try:
+        inv = list_figures(serie_path, relative_to=repo_root)
+    except FileNotFoundError as exc:
+        print_error(str(exc))
+        return 1
+    if args.json:
+        print(json.dumps(inv, indent=2, ensure_ascii=False))
+        return 0
+    print_section(f"FIGURES - {inv['serie']} ({inv['root']})")
+    print(f"  {inv['n_figures']} figures PNG dans "
+          f"{inv['n_notebooks_with_figures']} notebooks "
+          f"({inv['total_bytes'] / 1024.0:.1f} KB total)")
+    over = 0
+    for r in inv["figures"]:
+        dims = f"{r['width']}x{r['height']}" if r["width"] else "?x?"
+        flag = " [>200KB]" if r["over_weight"] else ""
+        if r["over_weight"]:
+            over += 1
+        nb_name = Path(r["notebook"]).name
+        print(f"    {nb_name} cell {r['cell_index']} out {r['output_index']} "
+              f"- {dims} - {r['bytes'] / 1024.0:.1f} KB{flag}")
+    if over:
+        print_warning(
+            f"{over} figure(s) au-dessus du plafond {MAX_BYTES_DEFAULT // 1024} KB "
+            f"(seront optimisees a l'extraction si PIL present)")
+    return 0
+
+
+def cmd_figures_extract(args):
+    """Extrait une figure PNG d'une cellule vers assets/readme/ + MANIFEST.md.
+
+    Le path ``notebook`` et l'option ``--serie-root`` acceptent un path absolu,
+    un repo-relatif complet (``MyIA.AI.Notebooks/RL/x.ipynb``) ou un serie-relatif
+    (``RL/x.ipynb``), via :func:`resolve_repo_path` (robuste quel que soit le cwd).
+    """
+    from extract_readme_figures import extract_figure, resolve_repo_path
+    repo_root = get_repo_root()
+    nb_path = resolve_repo_path(args.notebook, repo_root)
+    serie_root = (resolve_repo_path(args.serie_root, repo_root)
+                  if args.serie_root else None)
+    out_path = Path(args.output)
+    try:
+        entry = extract_figure(
+            nb_path, args.cell, args.output_index, out_path, args.alt,
+            max_dim=args.max_dim, max_bytes=args.max_bytes,
+            serie_root=serie_root)
+    except (ValueError, FileNotFoundError) as exc:
+        print_error(str(exc))
+        return 1
+    opt_tag = "PIL optimise" if entry["used_pil"] else "raw (PIL absent)"
+    print_ok(
+        f"Extrait : {entry['output']} "
+        f"({entry['bytes'] / 1024.0:.1f} KB, {opt_tag})")
+    print(f"  source : {Path(entry['notebook']).name} "
+          f"cellule {entry['cell_index']} output {entry['output_index']}")
+    if entry["over_weight"]:
+        print_warning(
+            "Figure au-dessus du plafond poids - revoir le downscale "
+            "ou selectionner une autre figure")
+    return 0
+
+
 # =============================================================================
 # MAIN
 # =============================================================================
@@ -2126,6 +2206,36 @@ def main():
     p_cs.add_argument('--verbose', '-v', action='store_true')
     p_cs.add_argument('--json', action='store_true')
 
+    # figures-list command (EPIC #5654 P0 — inventaire des figures de notebooks)
+    p_fl = subparsers.add_parser(
+        'figures-list',
+        help='Inventory PNG figures committed in notebook outputs (EPIC #5654)')
+    p_fl.add_argument('serie',
+                      help='Serie name (e.g. RL) or path under MyIA.AI.Notebooks/')
+    p_fl.add_argument('--json', action='store_true',
+                      help='Machine-readable JSON inventory')
+
+    # figures-extract command (EPIC #5654 P0 — extraction + MANIFEST provenance)
+    p_fe = subparsers.add_parser(
+        'figures-extract',
+        help='Extract a PNG figure from a notebook cell to assets/readme/ + MANIFEST (#5654)')
+    p_fe.add_argument('notebook',
+                      help='Notebook path or path under MyIA.AI.Notebooks/')
+    p_fe.add_argument('--cell', type=int, required=True,
+                      help='Cell index holding the figure output')
+    p_fe.add_argument('--output-index', type=int, default=0,
+                      help='Output index within the cell (default: 0)')
+    p_fe.add_argument('--output', '-o', required=True,
+                      help='Output PNG path (convention: <Serie>/assets/readme/<name>.png)')
+    p_fe.add_argument('--alt', required=True,
+                      help='French alt-text (accessibility, mandatory, EPIC #5654 HARD)')
+    p_fe.add_argument('--max-dim', type=int, default=1200,
+                      help='Max dimension in px for PIL downscale (default: 1200)')
+    p_fe.add_argument('--max-bytes', type=int, default=204800,
+                      help='Weight cap in bytes (default: 200 KB, EPIC #5654 HARD)')
+    p_fe.add_argument('--serie-root',
+                      help='Serie root for relative path in MANIFEST (default: absolute)')
+
     args = parser.parse_args()
 
     if not args.command:
@@ -2141,6 +2251,8 @@ def main():
         'golden-set': cmd_golden_set,
         'normalize-source-newlines': cmd_normalize_source_newlines,
         'normalize-source-charsplit': cmd_normalize_source_charsplit,
+        'figures-list': cmd_figures_list,
+        'figures-extract': cmd_figures_extract,
     }
 
     return commands[args.command](args)

--- a/scripts/tests/test_extract_readme_figures.py
+++ b/scripts/tests/test_extract_readme_figures.py
@@ -1,0 +1,284 @@
+"""Tests du module extract_readme_figures (EPIC #5654 P0).
+
+Couvre (stdlib + PIL optionnel) :
+* ``_png_dimensions`` depuis l'en-tete IHDR (PNG 1x1 et 2x3 synthetiques sans PIL) ;
+* ``list_figures`` : inventaire exhaustif d'une mini-serie de 2 notebooks ;
+* ``extract_figure`` : extraction + ``MANIFEST.md`` + idempotence (pas de doublon) ;
+* alt-text FR obligatoire (regle HARD accessibilite #5654) ;
+* bornes : cell_index / output_index hors plage, output sans PNG ;
+* ``_optimize_with_pil`` : downscale respecte ``max_dim`` quand PIL present.
+
+Les PNG de test sont construits en stdlib (``zlib`` + ``struct``) pour prouver
+que le module marche SANS PIL (le chemin de parsing IHDR est exerce directement).
+"""
+
+import base64
+import json
+import os
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "notebook_tools"))
+
+from extract_readme_figures import (  # noqa: E402
+    MAX_BYTES_DEFAULT,
+    _optimize_with_pil,
+    _png_dimensions,
+    extract_figure,
+    list_figures,
+    resolve_repo_path,
+)
+
+
+# ----------------------------------------------------------- helpers PNG stdlib
+def _make_png(width: int, height: int, rgb=(255, 0, 0), noise: bool = False) -> bytes:
+    """PNG minimal RGB valide (stdlib ``zlib`` + ``struct``, sans PIL).
+
+    ``noise=True`` : pixels pseudo-aleatoires deterministes (LCG seed fixe) ->
+    IDAT incompressible, utile pour generer un PNG depassant le plafond poids
+    (sinon zlib compresse une image unie a quelques centaines d'octets).
+    """
+    magic = b"\x89PNG\r\n\x1a\n"
+
+    def _chunk(typ: bytes, data: bytes) -> bytes:
+        crc = zlib.crc32(typ + data) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + typ + data + struct.pack(">I", crc)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)  # 8-bit RGB
+
+    def _row(y: int) -> bytes:
+        if not noise:
+            return b"\x00" + bytes(rgb) * width
+        # LCG deterministe : evite la dependance a random (determinisme test).
+        state = (y * 2654435761) & 0xFFFFFFFF
+        out = bytearray(b"\x00")
+        for _ in range(width * 3):
+            state = (state * 1103515245 + 12345) & 0x7FFFFFFF
+            out.append(state & 0xFF)
+        return bytes(out)
+
+    raw = b"".join(_row(y) for y in range(height))
+    # noise=True : level 0 (deflate store) -> IDAT ~= raw size, incompressible
+    # (un PNG bruite doit VRAIMENT depasser le plafond poids, pas se faire
+    # retracter par zlib). Sinon level 6 par defaut (image unie -> quelques octets).
+    idat = zlib.compress(raw, level=0 if noise else 6)
+    return magic + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+
+
+def _write_nb_with_figure(path: Path, png_bytes: bytes, preamble_cells: int = 1):
+    """Notebook avec ``preamble_cells`` cellules vides puis la cellule-figure.
+
+    La figure est donc a ``cell_index = preamble_cells`` (teste l'indexation).
+    """
+    b64 = base64.b64encode(png_bytes).decode("ascii")
+    cells = [{
+        "cell_type": "code", "execution_count": 1,
+        "source": [f"# preamble {i}\n"], "outputs": [], "metadata": {},
+    } for i in range(preamble_cells)]
+    cells.append({
+        "cell_type": "code", "execution_count": 1,
+        "source": ["import matplotlib.pyplot as plt\n"],
+        "outputs": [{
+            "output_type": "display_data",
+            "data": {"image/png": b64},
+            "metadata": {},
+        }],
+        "metadata": {},
+    })
+    nb = {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+# ----------------------------------------------------------- _png_dimensions
+def test_png_dimensions_1x1():
+    dims = _png_dimensions(_make_png(1, 1))
+    assert dims == (1, 1)
+
+
+def test_png_dimensions_2x3():
+    dims = _png_dimensions(_make_png(2, 3))
+    assert dims == (2, 3)
+
+
+def test_png_dimensions_non_png_returns_none():
+    assert _png_dimensions(b"not a png") is None
+    assert _png_dimensions(b"") is None
+
+
+# ----------------------------------------------------------- list_figures
+def test_list_figures_inventorie_deux_notebooks(tmp_path):
+    serie = tmp_path / "MiniSerie"
+    _write_nb_with_figure(serie / "nbA.ipynb", _make_png(2, 2), preamble_cells=1)
+    _write_nb_with_figure(serie / "sub" / "nbB.ipynb", _make_png(3, 4), preamble_cells=0)
+    inv = list_figures(serie)
+    assert inv["serie"] == "MiniSerie"
+    assert inv["n_notebooks_with_figures"] == 2
+    assert inv["n_figures"] == 2
+    assert inv["total_bytes"] > 0
+    paths = [Path(r["notebook"]).name for r in inv["figures"]]
+    assert set(paths) == {"nbA.ipynb", "nbB.ipynb"}
+    # dimensions lues via IHDR
+    by_name = {Path(r["notebook"]).name: r for r in inv["figures"]}
+    assert (by_name["nbA.ipynb"]["width"], by_name["nbA.ipynb"]["height"]) == (2, 2)
+    assert (by_name["nbB.ipynb"]["width"], by_name["nbB.ipynb"]["height"]) == (3, 4)
+
+
+def test_list_figures_ignore_checkpoints(tmp_path):
+    serie = tmp_path / "S"
+    _write_nb_with_figure(serie / "nb.ipynb", _make_png(1, 1))
+    # un jumeau dans .ipynb_checkpoints doit etre ignore
+    _write_nb_with_figure(
+        serie / ".ipynb_checkpoints" / "nb-checkpoint.ipynb", _make_png(1, 1))
+    inv = list_figures(serie)
+    assert inv["n_figures"] == 1
+
+
+def test_list_figures_over_weight_flag(tmp_path):
+    serie = tmp_path / "S"
+    # PNG bruite (incompressible) : depasse reellement les 200 KB de plafond.
+    big = _make_png(320, 320, noise=True)
+    _write_nb_with_figure(serie / "big.ipynb", big)
+    inv = list_figures(serie)
+    assert len(inv["figures"]) == 1
+    assert inv["figures"][0]["bytes"] > MAX_BYTES_DEFAULT   # sanity du fixture
+    assert inv["figures"][0]["over_weight"] is True
+
+
+def test_list_figures_missing_dir_raises():
+    with pytest.raises(FileNotFoundError):
+        list_figures("/no/such/serie/here")
+
+
+# ----------------------------------------------------------- extract_figure
+def test_extract_figure_writes_png_and_manifest(tmp_path):
+    serie = tmp_path / "S"
+    nb = _write_nb_with_figure(serie / "nb.ipynb", _make_png(5, 5), preamble_cells=1)
+    assets = serie / "assets" / "readme"
+    out = assets / "fig.png"
+    entry = extract_figure(
+        nb, cell_index=1, output_index=0, output_path=out,
+        alt_text_fr="Carte de chaleur des poids du reseau",
+        serie_root=serie,
+    )
+    assert out.exists() and out.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+    assert entry["used_pil"] in (True, False)          # depend de l'env
+    assert entry["over_weight"] is False               # 5x5 < 200 KB
+    manifest = assets / "MANIFEST.md"
+    assert manifest.exists()
+    body = manifest.read_text(encoding="utf-8")
+    assert "fig.png" in body
+    assert "MANIFEST des figures README" in body       # header
+    assert "Carte de chaleur des poids du reseau" in body
+    assert "cellule 1" in body and "output 0" in body
+    # chemin relatif depuis serie_root dans le manifest
+    assert "nb.ipynb" in body and str(serie.resolve()) not in body
+
+
+def test_extract_figure_idempotent_no_duplicate(tmp_path):
+    serie = tmp_path / "S"
+    # preamble_cells=0 : la figure est a cell_index=0.
+    nb = _write_nb_with_figure(serie / "nb.ipynb", _make_png(3, 3), preamble_cells=0)
+    assets = serie / "assets" / "readme"
+    out = assets / "fig.png"
+    extract_figure(nb, 0, 0, out, " premiere extraction ", serie_root=serie)
+    extract_figure(nb, 0, 0, out, "deuxieme extraction (remplace)", serie_root=serie)
+    body = (assets / "MANIFEST.md").read_text(encoding="utf-8")
+    # un seul bloc ## fig.png (remplacement, pas de doublon)
+    assert body.count("## fig.png") == 1
+    assert "deuxieme extraction (remplace)" in body
+
+
+def test_extract_figure_alt_text_required(tmp_path):
+    serie = tmp_path / "S"
+    nb = _write_nb_with_figure(serie / "nb.ipynb", _make_png(2, 2))
+    with pytest.raises(ValueError, match="alt_text_fr"):
+        extract_figure(nb, 0, 0, serie / "assets/readme/f.png", "",
+                       serie_root=serie)
+    with pytest.raises(ValueError, match="alt_text_fr"):
+        extract_figure(nb, 0, 0, serie / "assets/readme/f.png", "   ",
+                       serie_root=serie)
+
+
+def test_extract_figure_cell_out_of_range(tmp_path):
+    serie = tmp_path / "S"
+    nb = _write_nb_with_figure(serie / "nb.ipynb", _make_png(2, 2))  # 1 cell (index 0)
+    with pytest.raises(ValueError, match="cell_index"):
+        extract_figure(nb, 5, 0, serie / "assets/readme/f.png", "alt",
+                       serie_root=serie)
+
+
+def test_extract_figure_output_no_png(tmp_path):
+    serie = tmp_path / "S"
+    nb = {"cells": [{
+        "cell_type": "code", "execution_count": 1, "source": ["print(1)\n"],
+        "outputs": [{"output_type": "stream", "name": "stdout",
+                     "text": ["1\n"]}],
+        "metadata": {},
+    }], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    nbp = serie / "nb.ipynb"
+    nbp.parent.mkdir(parents=True, exist_ok=True)
+    nbp.write_text(json.dumps(nb), encoding="utf-8")
+    with pytest.raises(ValueError, match="ne porte pas de PNG"):
+        extract_figure(nbp, 0, 0, serie / "assets/readme/f.png", "alt",
+                       serie_root=serie)
+
+
+# ----------------------------------------------------------- _optimize_with_pil
+def test_optimize_downscale_respects_max_dim():
+    pil = pytest.importorskip("PIL")  # skip si PIL absent
+    raw = _make_png(800, 600)
+    opt, used_pil = _optimize_with_pil(raw, max_dim=200)
+    assert used_pil is True
+    w, h = _png_dimensions(opt)
+    # le grand cote (800) doit etre ramene a <= 200
+    assert max(w, h) <= 200
+
+
+def test_optimize_raw_fallback_on_garbage():
+    # bytes non-PNG : _optimize_with_pil retombe sur raw sans lever
+    opt, used_pil = _optimize_with_pil(b"garbage not png", max_dim=100)
+    assert used_pil is False
+    assert opt == b"garbage not png"
+
+
+# ----------------------------------------------------------- resolve_repo_path (F2)
+def _make_fake_repo(tmp_path, nb_name="x.ipynb"):
+    """Repo factice : <repo>/MyIA.AI.Notebooks/RL/<nb> existe sur disque."""
+    repo = tmp_path / "repo"
+    nb = repo / "MyIA.AI.Notebooks" / "RL" / nb_name
+    nb.parent.mkdir(parents=True, exist_ok=True)
+    nb.write_bytes(b"fake notebook")
+    return repo, nb
+
+
+def test_resolve_repo_path_absolute_passthrough(tmp_path):
+    import os
+    repo, nb = _make_fake_repo(tmp_path)
+    abs_arg = str(nb.resolve())
+    # path absolu -> retourne tel quel (Path egal, peu importe la string exacte)
+    assert resolve_repo_path(abs_arg, repo).resolve() == nb.resolve()
+
+
+def test_resolve_repo_path_full_repo_relative_no_double_prefix(tmp_path):
+    # F2 core : repo-relatif complet ne doit PAS etre double-prefixe.
+    repo, nb = _make_fake_repo(tmp_path)
+    got = resolve_repo_path("MyIA.AI.Notebooks/RL/x.ipynb", repo)
+    assert got.exists()                       # le path resout existe reellement
+    assert got.resolve() == nb.resolve()
+    # anti-regression : pas de "MyIA.AI.Notebooks/MyIA.AI.Notebooks" dans le path
+    assert "MyIA.AI.Notebooks/MyIA.AI.Notebooks" not in str(got).replace("\\", "/")
+
+
+def test_resolve_repo_path_serie_relative_fallback(tmp_path):
+    # serie-relatif (RL/x.ipynb) -> prefixage MyIA.AI.Notebooks/ applique.
+    repo, nb = _make_fake_repo(tmp_path)
+    got = resolve_repo_path("RL/x.ipynb", repo)
+    assert got.exists()
+    assert got.resolve() == nb.resolve()


### PR DESCRIPTION
# #5654 P0 — `extract_readme_figures` : inventaire + extraction des figures de notebooks vers `assets/readme/` + MANIFEST de provenance

**Dispatch ai-01** (`msg-20260707T183947-45kuow`, Priority 0, L292-1 verified OPEN firsthand). See #5654 (P0 outillage). 1 PR atomique = outillage + inventaire pilote. **Aucune image extraite/committée dans cette PR** (politique poids à figer, voir § proposition ci-dessous).

## Livrables

1. **`scripts/notebook_tools/extract_readme_figures.py`** (module, stdlib + PIL optionnel) — 2 modes alignés sur le body EPIC :
   - `list_figures(serie_path, relative_to=None)` : inventorie tous les outputs `image/png` committés d'une série (notebook, cellule, dimensions, poids, flag `over_weight` > 200 KB). C'est le **gisement** pour choisir les illustrations en P1/P2. Chemins relativisables au repo root (inventaires portables).
   - `extract_figure(nb, cell, out_index, output, alt_text_fr, ...)` : extrait une figure vers `<Serie>/assets/readme/<nom>.png`, l'optimise (PIL : downscale ≤ 1200 px + compression, fallback raw si PIL absent), puis append l'entrée `MANIFEST.md` (provenance source 1 : notebook + cellule + alt-text FR). **Idempotent** (re-extraction remplace, pas de doublon).
   - Parsing PNG via en-tête IHDR **sans PIL** (octets 16-24 big-endian) → l'inventaire marche même sans Pillow.
2. **`scripts/notebook_tools/notebook_tools.py`** — 2 subcommands CLI `figures-list` / `figures-extract` (thin wrappers, lazy import).
3. **`scripts/tests/test_extract_readme_figures.py`** — **14 tests PASS**, PNG synthétiques en stdlib (`zlib` + `struct`, prouve le chemin sans PIL) : dimensions IHDR, inventaire exhaustif, ignore checkpoints, flag `over_weight`, extraction + MANIFEST + idempotence, alt-text obligatoire, bornes (cell/output hors plage, output sans PNG), downscale PIL respecte `max_dim`, fallback raw sur garbage.
4. **`scripts/notebook_tools/figures_inventory/`** — 3 inventaires pilote committés (manifeste du gisement pour P1/P2) : `RL.json`, `GenAI-Image.json`, `QuantConnect-ML-Training-Pipeline.json`.

## Smoke test end-to-end (preuve, non-committé)

```
$ python .../notebook_tools.py figures-list RL
  36 figures PNG dans 14 notebooks (1659.3 KB total)

$ python .../notebook_tools.py figures-extract RL/rl_10_reward_shaping.ipynb \
    --cell 2 --output-index 0 -o .../assets/readme/rl-reward-shaping.png \
    --alt "Courbe de récompense cumulée par épisode sous reward shaping" --serie-root RL
[OK] Extrait : .../rl-reward-shaping.png (15.0 KB, PIL optimise)
# + MANIFEST.md : header + bloc provenance (notebook relatif, cellule 2, output 0, alt-text FR, poids)
# UTF-8 préservé (récompense, épisode) — vérifié Python-authoritative
```

## Gisement mesuré (3 séries pilote)

| Série | Figures | Notebooks | Total | > 200 KB |
|-------|---------|-----------|-------|----------|
| RL | 36 | 14 | 1659 KB | 0 |
| GenAI/Image | 42 | 14 | 43148 KB | **32** |
| QC ML-Training-Pipeline | 28 | 10 | 1348 KB | 0 |

→ Le gisement confirme l'inventaire ai-01 (~150 notebooks porteurs). GenAI/Image concentre les images lourdes (32/42 au-dessus du plafond → downscale PIL obligatoire en P1).

## Conformité (#5654 HARD)

- **Emplacement** : `<Serie>/assets/readme/` (convention du module, non exercé ici — aucun README touché).
- **Poids** : `MAX_BYTES_DEFAULT = 200 KB`, `MAX_DIM_DEFAULT = 1200 px` (downscale PIL). Flag `over_weight` dans l'inventaire.
- **Provenance tracée** : `MANIFEST.md` généré (header + bloc `## <file>.png` : notebook source + cellule + alt-text FR + poids). Format source 1 de la doctrine.
- **Alt-text FR obligatoire** (regle accessibilité) — `ValueError` si vide/blanc.
- **Jamais de re-exécution** (C.3) : on lit les outputs **déjà committés** via JSON, zéro exécution de notebook.
- **CATALOG-STATUS** : ce module ne touche jamais aux README → byte-identique (aucun README modifié dans la PR).
- **Pas d'image committée** dans cette PR (politique poids à figer ci-dessous).
- **MD047** : trailing newline préservé sur les 6 fichiers (3 `.py` + 3 `.json`).
- **CRLF** : LF-only, vérifié Python-authoritative (`crlf=0`).
- **readme-french-first** : docstrings FR.
- **Stdlib-first** : PIL optionnel (parsing IHDR sans PIL → l'outil marche partout). Règle « jamais de script ad-hoc » honorée (dans `notebook_tools/`).

## Proposition de politique poids (à figer pour P1, demande ai-01)

L'EPIC #5654 fixe ≤ 200 KB/img et ≤ 1,5 MB/README, pas de LFS. Pour atteindre cela de manière fiable sur le gisement (GenAI/Image a 32 images > 200 KB), je propose :

1. **Downscale PIL par défaut** `max_dim=1200` + recompression PNG `optimize=True` (déjà implémenté) — ramène la plupart des figures sous le plafond.
2. **Sélection top-N par notebook** : 1 figure « parlante » par notebook maximum dans un README (heatmap / courbe d'entraînement / génération), pas l'intégralité des outputs. Le gisement (inventaire) sert à choisir.
3. **Conversion WebP** (option, si une figure résiste au plafond PNG après downscale) : `quality=85` réduit ~60% vs PNG pour les photographiques/générations — à activer via un flag `--webp` si besoin en P1/P2.
4. **CI guard** (P1) : un check qui rejette toute image > 200 KB ou README > 1,5 MB d'images committée (analogue au pre-commit H.3).

Le flow P1/P2 = `figures-list <serie>` (choisir via l'inventaire) → `figures-extract` (1 figure parlante par README) → commit image + MANIFEST.md → remplacer un bloc Mermaid décoratif par `![alt](assets/readme/fig.png)`.

## Validation

```
pytest scripts/tests/test_extract_readme_figures.py : 14/14 PASS
python notebook_tools.py --help : figures-list / figures-extract présents
figures-list RL / GenAI/Image / QuantConnect/ML-Training-Pipeline : inventaires OK
figures-extract end-to-end : PNG + MANIFEST.md générés, UTF-8 préservé
AST parse : OK (3 fichiers)
CRLF : 0 (Python-authoritative)   MD047 : préservé (6 fichiers)
```

Worktree isolé `d:/dev/coursia-figures-5654` depuis `origin/main` `30d482222` (FRESH, base = merge-base).

— myia-po-2025:CoursIA (dispatch ai-01 Priority 0, EPIC #5654 P0)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
