### PR TITLE
docs(dswa): fix DataScienceWithAgents README count drift 25->27 (See #5661)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -24,7 +24,7 @@ La formation couvre deux stacks complémentaires :
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 25 (7 LangChain + 10 ADK + 2 fondations Python + 6 fondations ML) |
+| Notebooks | 27 (7 LangChain + 10 ADK + 2 fondations Python + 8 fondations ML) |
 | Kernel | Python 3.11+ |
 | Durée totale | ~7 jours |
 


### PR DESCRIPTION
## Scope

Correction d'un **count drift** dans la table recap de `ML/DataScienceWithAgents/README.md` (feuille #5661, ma famille #3974).

## Drift (audit $E)

La ligne 27 (table des statistiques) annoncait :

```
| Notebooks | 25 (7 LangChain + 10 ADK + 2 fondations Python + 6 fondations ML) |
```

mais **l'arbre de structure du README lui-meme** (ligne 40) disait deja :

```
02-ML-Cours/  # Fondations ML canoniques (8 notebooks)
```

et la prose pedagogique (ligne 71) detaille **8** fondations ML (workflow, descente de gradient, regression lineaire/logistique, arbres et ensembles, biais-variance/CV/ROC, clustering/ACP, SVM a noyau/k-NN, **theorie PAC/dimension VC**).

**Incoherence interne §E** : la table contredisait le reste du meme README. Les notebooks 2.7-Modeles-Non-Parametriques et 2.8-Theorie-PAC ont ete ajoutes sans mettre a jour le compteur de la table.

## Verification disque (G.1)

```bash
$ git ls-tree -r origin/main MyIA.AI.Notebooks/ML/DataScienceWithAgents/ | grep -c '\.ipynb$'
27
# decomposition : 2 fondations Python + 8 ML (02-ML-Cours) + 7 LangChain + 10 ADK = 27
```

## Correctif (atomique, 1 ligne)

```diff
-| Notebooks | 25 (7 LangChain + 10 ADK + 2 fondations Python + 6 fondations ML) |
+| Notebooks | 27 (7 LangChain + 10 ADK + 2 fondations Python + 8 fondations ML) |
```

## Conformite

- **CATALOG byte-identique** : md5 identique main/branch (`cc3ae1acd3542a189deebac078b4875d`).
- **CRLF = 0** (LF-only, verifie Python-authoritative).
- **MD047** : trailing newline preserve.
- **Atomique** : 1 ligne, 1 fichier, ma famille ML. Base FRESH `30d482222`.

See #5661 (feuille README ascendante), #3974 (famille GenAI+Python+ML).

Co-Authored-By: Claude-Code <noreply@anthropic.com>