### PR TITLE
docs(sw): fix SemanticWeb README stats drift — table 18→22, sidetracks b 4→6 (See #3975)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -20,9 +20,9 @@ Chiffres lus directement depuis le marqueur `CATALOG-STATUS` byte-identique (l. 
 | Sous-catégorie | Notebooks | Statut | Paradigmes / stacks dominants |
 |----------------|-----------|--------|-------------------------------|
 | Fondations RDF/OWL (.NET C# avec dotNetRDF, SW-1 à SW-7) | 7 | PRODUCTION=7, BETA=0 | Triplet RDF, graphe nommé, SPARQL, RDFS, OWL (HermiT), raisonneur DL |
-| Standards modernes (Python rdflib/pySHACL/owlready2, SW-8 à SW-13 + SW-12 GraphRAG) | 7 | PRODUCTION=7, BETA=0 | SHACL Advanced, JSON-LD 1.1, RDF-Star, KG + kglab, GraphRAG (Microsoft anti-hallucination), comparaisons raisonneurs |
-| Sidetracks Python miroirs (SW-2b/4b/5b/7b) | 4 | PRODUCTION=4, BETA=0 | Équivalent Python des notebooks .NET — rdflib + owlready2 |
-| **Total** | **18** | **PRODUCTION=18, BETA=0** | Double stack .NET C# (dotNetRDF) / Python (rdflib, pySHACL, owlready2, kglab) — 100% production |
+| Standards modernes (Python rdflib/pySHACL/owlready2, SW-8 à SW-13 + GraphRAG + twins C# SW-8/9/10) | 9 | PRODUCTION=9, BETA=0 | SHACL Advanced, JSON-LD 1.1, RDF-Star, KG + kglab, GraphRAG (Microsoft anti-hallucination), comparaisons raisonneurs |
+| Sidetracks Python miroirs (SW-2b/3b/4b/5b/6b/7b) | 6 | PRODUCTION=6, BETA=0 | Équivalent Python des notebooks .NET — rdflib + owlready2 |
+| **Total** | **22** | **PRODUCTION=22, BETA=0** | Double stack .NET C# (dotNetRDF) / Python (rdflib, pySHACL, owlready2, kglab) — 100% production |
 
 **Conformité C.1 — stubs d'exercice sans erreur volontaire** : les templates `student/` portent les stubs conformes (`pass` / `return None` / `print("Exercice à compléter")` / `result = None  # TODO étudiant`) — **jamais** `raise NotImplementedError`, `assert False` ou `1/0`. Dépendances Python : `rdflib`, `pySHACL`, `owlready2`, `kglib`, `SPARQLWrapper` (cf `requirements.txt` racine). Dépendances .NET : `dotNetRDF` + .NET 9.0 + .NET Interactive. La double stack .NET/Python reflète le mandat EPIC #3975 : un même raisonnement rendu par deux runtimes (ici, dotNetRDF côté C# typé, rdflib côté Python expressif), la parité devenant un objet d'étude en soi.
 
@@ -68,7 +68,7 @@ flowchart BT
     KG --> GRAG["<b>GraphRAG</b><br/>ancrer les LLMs"]
 ```
 
-La série propose délibérément deux stacks : **.NET C#** (SW-1 à SW-7) pour les fondations avec dotNetRDF (typed, performant, intégré à l'écosystème CoursIA), et **Python** (SW-8 à SW-13) pour les standards modernes et l'IA. Les sidetracks Python (SW-2b, 4b, 5b, 7b) offrent un miroir des notebooks C# en Python.
+La série propose délibérément deux stacks : **.NET C#** (SW-1 à SW-7) pour les fondations avec dotNetRDF (typed, performant, intégré à l'écosystème CoursIA), et **Python** (SW-8 à SW-13) pour les standards modernes et l'IA. Les sidetracks Python (SW-2b, 3b, 4b, 5b, 6b, 7b) offrent un miroir des notebooks C# en Python.
 
 ## Concepts clés
 


### PR DESCRIPTION
## docs(sw): fix SemanticWeb README stats drift — table prose réconciliée disque↔catalogue

**§E whole-file audit** de `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md` (614 lignes). La table de statistiques prose (L22-25) avait **sévèrement dérivé** du disque et du catalogue — drift post-rollout (pattern L286-2 : sweep massif = déclencheur docs fix-up, ici marathon #4956 SW-3b/SW-6b/SW-9-CSharp/SW-10-CSharp ajoutés sans réconcilier la table).

### Constat firsthand (audit fichier entier §E)

3 chiffres contradictoires pour la même série avant cette PR :

| Source | Count | Note |
|--------|-------|------|
| **Disque firsthand** (`git ls-files 'SW-*.ipynb'`) | **23** | 11 CSharp + 6 Python main + 6 b-sidetracks (2b,3b,4b,5b,6b,7b) |
| **CATALOG-STATUS L9** (catalogue généré, byte-identique) | **22** | cron `ef70ad591` 07:03 UTC, **pré-#5638** (SW-13-Reasoners-CSharp mergé 14:38 UTC) |
| **Table prose L22-25** (avant cette PR) | **18** | drift ancien — n'a jamais été réconciliée post-marathon |

Le catalogue (22) est en retard d'un cycle de cron (1 notebook mergé post-cron) — **fonctionnement normal**, s'auto-corrigera au prochain cron (22→23).

### Corrections (alignées sur catalogue = source canonique per L7)

| Ligne | Avant | Après | Raison |
|-------|-------|-------|--------|
| L23 Standards modernes | `\| 7 \| PRODUCTION=7` | `\| 9 \| PRODUCTION=9` | 6 Python SW-8..13 + 3 twins C# SW-8/9/10 (pré-#5638) = 9 |
| L24 Sidetracks b | `(SW-2b/4b/5b/7b) \| 4` | `(SW-2b/3b/4b/5b/6b/7b) \| 6` | 3b (#5601) + 6b omis du listing |
| L25 Total | `**18** \| **PRODUCTION=18**` | `**22** \| **PRODUCTION=22**` | aligné CATALOG-STATUS L9 |
| L71 listing b prose | `SW-2b, 4b, 5b, 7b` | `SW-2b, 3b, 4b, 5b, 6b, 7b` | listing complet |

Sous-décomposition : 7 (Fondations SW-1..7 C#) + 9 (Standards modernes) + 6 (b) = **22** ✓ aligné CATALOG-STATUS.

### catalog-pr-hygiene R1 respectée

- **CATALOG-STATUS marker L5-9 byte-identique à origin/main** (vérifié `diff` explicite — le marqueur n'est PAS régénéré sur cette branche, seul le cron le met à jour).
- Branche créée fraîche depuis `origin/main` (30d482222) — base FRESH (R2 ✓).
- Atomique : 1 fichier, 4 lignes changées (+4/−4), 1 domaine (SymbolicAI SemanticWeb docs), 1 feature (stats drift fix) — sous tous seuils G.4.

### Audit fichier entier §E (proof)

- `ls` count par sous-dossier : `git ls-files 'MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/*.ipynb'` = 23 SW-* + 1 `RDF.Net-Legacy/` (archive isolée, hors schéma SW-N).
- Réconciliation disque (23) ↔ CATALOG-STATUS (22, retard cron) ↔ table prose (18, drift) ↔ frontmatter (22, = CATALOG-STATUS).
- Aucun autre compteur chiffré dérivé dans le README (L106 requirements comment = listing illustratif non-exhaustif, laissé tel quel).
- FR-first respecté (déjà FR, pas de bascule de langue).

See #3975 (README ascendant feuilles — SymbolicAI non-Lean), #4956 (marathon .NET⇄Python twins), #5081 (renum narrative — SemanticWeb partition po-2024 complete, #5669).
