### PR TITLE
docs(owui): fix Open-WebUI README module count 5->6 + v0.10 theme (See #5661)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/README.md
@@ -32,7 +32,7 @@ garantit la qualité*.
 | Parcours | Angle | Format | État |
 |----------|-------|--------|------|
 | **[Tour de la plateforme](00-Tour-Plateforme/README.md)** | « À quoi sert Open WebUI et comment l'utilise-t-on ? » | Markdown pédagogique + captures d'écran annotées | 🟡 Narratif disponible — captures live à venir (Epic #4433) |
-| **[Série QA Playwright-OWUI](Playwright-OWUI/README.md)** | « Comment teste-t-on une plateforme GenAI de bout en bout ? » | Notebooks + specs Playwright (5 modules) | ✅ Disponible |
+| **[Série QA Playwright-OWUI](Playwright-OWUI/README.md)** | « Comment teste-t-on une plateforme GenAI de bout en bout ? » | Notebooks + specs Playwright (6 modules) | ✅ Disponible |
 
 ### [Tour de la plateforme](00-Tour-Plateforme/README.md)
 
@@ -48,9 +48,10 @@ des champs sensibles) une fois le tenant de démonstration en ligne — voir
 
 ### Série QA Playwright-OWUI
 
-Une série de 5 modules qui apprend à écrire des tests end-to-end sur Open WebUI
+Une série de 6 modules qui apprend à écrire des tests end-to-end sur Open WebUI
 avec Playwright : découverte et sélecteurs, navigation & authentification, chat
-& streaming, RAG / outils MCP / canaux, puis isolation multi-tenant et CI/CD.
+& streaming, RAG / outils MCP / canaux, isolation multi-tenant et CI/CD,
+puis les nouveautés v0.10 (mémoire, dossiers d'équipe, raisonnement streamé).
 
 ➡️ **[Ouvrir la série Playwright-OWUI](Playwright-OWUI/README.md)**
 


### PR DESCRIPTION
## Scope

Correction d'un **count drift §E** dans `GenAI/Open-WebUI/README.md` (feuille #5661, ma famille GenAI #3974).

## Drift (audit §E)

Le README racine Open-WebUI annoncait « **5 modules** » pour la série QA Playwright-OWUI :
- Ligne 35 (table des parcours) : `Notebooks + specs Playwright (5 modules)`
- Ligne 51 (prose) : `Une série de 5 modules qui apprend à écrire des tests end-to-end...`

mais **Playwright-OWUI compte désormais 6 modules** sur `origin/main` :

```bash
$ git ls-tree -d origin/main MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/
01-decouverte
02-navigation-authentification
03-chat-streaming
04-rag-tools-avances
05-multi-tenant-ci
06-nouveautes-v0.10    # <- 6e module (nouvelles fonctionnalités v0.10.2)
```

Le module 06 « Les nouveautés v0.10 » (mémoire, dossiers d'équipe, raisonnement streamé) est documenté ligne 112 du README Playwright-OWUI (passage fleet à Open WebUI v0.10.2 le 1er juillet 2026).

## Correctif (audit fichier ENTIER §E, pas seulement le count)

3 changements pour rester cohérent §E :

1. **Ligne 35** (table) : « (5 modules) » → « (6 modules) ».
2. **Ligne 51** (prose) : « Une série de 5 modules » → « 6 modules ».
3. **Ligne 53** (énumération des thèmes) : ajout du 6e thème « puis les nouveautés v0.10 (mémoire, dossiers d'équipe, raisonnement streamé) ».

Le point 3 est **obligatoire pour §E** : sans lui, le count « 6 modules » contredirait l'énumération de 5 thèmes (nouveau drift au lieu d'une correction).

## Conformité

- **Aucun marqueur CATALOG-STATUS** dans ce README (feuille sans catalog).
- **COURSE_CATALOG.generated.json byte-identique** main/branch (`cc3ae1acd3542a189deebac078b4875d`).
- **CRLF = 0**, **MD047** trailing newline préservé.
- **README racine clean shared tree** : WIP po-2023 (refonte #4433) = module 06 + fichiers Playwright-OWUI, **pas** ce README racine. Pas de collision.
- **Atomique** : 1 fichier, 1 sujet. Base FRESH `30d482222`.

See #5661, #3974, #4433.

Co-Authored-By: Claude-Code <noreply@anthropic.com>