### PR TITLE
docs(gt): fix repeated_games_lean README lake phantom knot -> social_choice_lean_peters (See #5661)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.en.md
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.en.md
@@ -1,7 +1,7 @@
 # Repeated Games — Lean (formal companion of GT-6c)
 
 > **Formal companion** of the pedagogical notebook [GameTheory-6c](../GameTheory-6c-RepeatedGames-FolkTheorem.ipynb) (`Repeated Games` — Iterated prisoner's dilemma).
-> This companion fills the gap in the GameTheory series (which has 7 Lean lakes: `conway_cgt`, `cooperative_games`, `knot`, `minimax`, `repeated_games`, `social_choice`, `stable_marriage`).
+> This companion fills the gap in the GameTheory series (which has 7 Lean lakes: `conway_cgt`, `cooperative_games`, `minimax`, `repeated_games`, `social_choice`, `social_choice_lean_peters`, `stable_marriage`).
 
 ## Headline theorem
 

--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md
@@ -1,7 +1,7 @@
 # Repeated Games — Lean (compagnon formel GT-6c)
 
 > **Compagnon formel** du notebook pédagogique [GameTheory-6c](../GameTheory-6c-RepeatedGames-FolkTheorem.ipynb) (`Jeux répétés` — Dilemme du prisonnier itéré).
-> Série GameTheory regroupe 7 lakes (`conway_cgt`, `cooperative_games`, `knot`, `minimax`, `repeated_games`, `social_choice`, `stable_marriage`).
+> Série GameTheory regroupe 7 lakes (`conway_cgt`, `cooperative_games`, `minimax`, `repeated_games`, `social_choice`, `social_choice_lean_peters`, `stable_marriage`).
 > Aucun autre ne couvrait les jeux répétés — ce companion comble le manque avec le théorème-phare de la **stratégie grim-trigger**.
 
 ## Théorème-phare


### PR DESCRIPTION
## Scope

Correction d'un **lake phantom** dans `GameTheory/repeated_games_lean/README.md` + `README.en.md` (feuille #5661, R5.4 cross-lane).

## Drift (audit §E firsthand G.1)

Les README FR et EN (ligne 4 chacun) listaient les 7 lakes GameTheory en citant **`knot`** — un lake **fantôme** :

```bash
$ git ls-tree -r origin/main --name-only | grep -iE 'GameTheory.*knot'
(empty)   # ← knot n'existe PAS dans GameTheory

$ git ls-tree -r origin/main --name-only | grep -iE 'knot.*lakefile'
MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/lakefile.lean   # ← knot vit dans SymbolicAI/Lean (EPIC #2874)
```

**Copier-coller évident** : `knot` est un lake de la série Knot Theory (SymbolicAI/Lean), pas GameTheory. Les 6 autres lakes cités existent bien :

```bash
$ git ls-tree -r origin/main --name-only | grep 'GameTheory/.*lakefile\.lean'
conway_cgt_lean/        ✓
cooperative_games_lean/ ✓
minimax_lean/           ✓
repeated_games_lean/    ✓
social_choice_lean/     ✓
social_choice_lean_peters/  ← 7e lakefile RÉEL, omis de la liste
stable_marriage_lean/   ✓
# = 7 lakefile.lean physiques sous GameTheory/
```

Le 7e lakefile réel présent sur disque est **`social_choice_lean_peters/`** (projet Lake reference DominikPeters/SocialChoiceLean, documenté comme « adjacent » dans le README social_choice_lean L161) — il était **omis** de la liste.

## Correctif (audit fichier entier §E, cohérence FR/EN)

Remplacer `knot` → `social_choice_lean_peters` dans la liste, dans les **deux** READMEs (FR + EN) pour cohérence §E :

```diff
-> ... 7 lakes (`conway_cgt`, `cooperative_games`, `knot`, `minimax`, `repeated_games`, `social_choice`, `stable_marriage`).
+> ... 7 lakes (`conway_cgt`, `cooperative_games`, `minimax`, `repeated_games`, `social_choice`, `social_choice_lean_peters`, `stable_marriage`).
```

Le count **« 7 lakes » reste exact** (7 lakefile.lean physiques sur disque), ordre alphabétique préservé. Vérifié par assertion Python : 7 lakes, knot absent, peters présent, dans les 2 langues.

## Note §E (transparence pour le turf Lean)

`social_choice_lean_peters` est un projet Lake **reference externe** (importe DominikPeters/SocialChoiceLean en dépendance, décrit comme « adjacent/séparé » per README social_choice_lean L54/L161). Si un reviewer (turf Lean / po-2026) considère qu'il ne devrait pas compter comme lake de série, le count descendrait à **6**. Mais :
- Le retrait du fantôme `knot` est **indiscutable** (knot vit dans SymbolicAI/Lean).
- Le count « 7 » correspond aux **7 lakefile.lean physiques** sur disque (vérification mécanique).
- Le fix est minimal (1 mot/fichier) et préserve le count.

## Conformité

- **Aucun marqueur CATALOG-STATUS** dans ces feuilles (READMEs de lake Lean, pas catalogués).
- **COURSE_CATALOG.generated.json byte-identique** main/branch (`cc3ae1acd3542a189deebac078b4875d`).
- **CRLF = 0** (LF-only, Python-authoritative), **MD047** trailing newline préservé.
- **Cohérence FR/EN §E** : les deux READMEs corrigés à l'identique.
- **README clean shared tree** (porcelain vide). Pas de collision (po-2026 = marathon .NET saturated, ce README est docs pas du code .NET, item non-claimé).
- **Atomique** : 2 fichiers (FR+EN), 1 sujet (lake phantom). Base FRESH `30d482222`.
- **readme-french-first** : prose FR préservée, `README.en.md` EN préservé (règle 2 : ne jamais supprimer l'original).

See #5661 (feuille README ascendante), #3975 (famille SymbolicAI+GameTheory+Sudoku+CaseStudies).

Co-Authored-By: Claude-Code <noreply@anthropic.com>