### PR TITLE
docs(gt): fix SocialChoice README drift — list C# twins SC-01/SC-03 (#5661)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md
@@ -18,11 +18,15 @@ Cette sous-série du parcours [GameTheory](../README.md) explore ces résultats 
 | # | Notebook | Titre | Durée | Status |
 |---|----------|-------|-------|--------|
 | SC-01 | [01-Arrow-Impossibility-Theorem](01-Arrow-Impossibility-Theorem.ipynb) | Théorème d'Arrow : Preuve Formelle et Simulation | 45 min | COMPLET |
+| SC-01 (C#) | [01-Arrow-Impossibility-Theorem-Csharp](01-Arrow-Impossibility-Theorem-Csharp.ipynb) | **Jumeau C#** — parité .NET du SC-01 (théorème d'Arrow) implémenté from-scratch en C# (.NET Interactive) (See #4956) | 45 min | PARITÉ |
 | SC-02 | [02-Lean-SocialChoice-Formal](02-Lean-SocialChoice-Formal.ipynb) | Choix Social Formel en Lean 4 (Arrow, Sen, Électeur Médian, Tour Peters) | 80 min | COMPLET |
 | SC-03 | [03-Voting-Methods](03-Voting-Methods.ipynb) | Méthodes de Vote et Paradoxes (Condorcet, Borda, Copeland, Downs) | 35 min | COMPLET |
+| SC-03 (C#) | [03-Voting-Methods-Csharp](03-Voting-Methods-Csharp.ipynb) | **Jumeau C#** — parité .NET du SC-03 (méthodes de vote) implémenté from-scratch en C# (.NET Interactive) (See #4956) | 35 min | PARITÉ |
 | SC-04 | [04-Computational-Aggregation-SAT-Z3](04-Computational-Aggregation-SAT-Z3.ipynb) | Agrégation Computationnelle : SAT et Z3 | 45 min | COMPLET |
 
 **Durée totale** : ~3h25
+
+> **Parité .NET** : les notebooks [01-Arrow-Impossibility-Theorem-Csharp.ipynb](01-Arrow-Impossibility-Theorem-Csharp.ipynb) (jumeau du SC-01) et [03-Voting-Methods-Csharp.ipynb](03-Voting-Methods-Csharp.ipynb) (jumeau du SC-03) sont les miroirs C# (.NET Interactive) des originaux Python — mêmes algorithmes implémentés from-scratch en C#. Marathon parité .NET ⇄ Python (#4956). Ils ne sont pas comptés dans le `pedagogical_count` (ce sont des miroirs de parité, pas des notebooks pédagogiques distincts).
 
 ## Parcours d'apprentissage
 


### PR DESCRIPTION
## Summary

Fix du drift `GameTheory/SocialChoice/README.md` (item #5661) : la table Notebooks listait **4 notebooks** mais ignorait les **2 jumeaux C#** (`01-Arrow-Impossibility-Theorem-Csharp.ipynb`, `03-Voting-Methods-Csharp.ipynb`) présents sur disque (6 `.ipynb` au total). Un étudiant parcourant le README voyait 4 entrées alors que `ls` en montrait 6.

## §E whole-file audit (pr-review-discipline §E obligatoire)

Reconciliation disque ↔ table ↔ prose ↔ CATALOG-STATUS :

| Source | Compte | Détail |
|--------|--------|--------|
| **Disque** (`git ls-tree`) | **6 `.ipynb`** | 01-Arrow, 01-Arrow-**Csharp**, 02-Lean, 03-Voting, 03-Voting-**Csharp**, 04-SAT-Z3 |
| **Table README (avant)** | 4 | SC-01, SC-02, SC-03, SC-04 (manquait les 2 jumeaux C#) |
| **Table README (après)** | 6 | + SC-01 (C#), SC-03 (C#) statut PARITÉ |
| **Prose** (« quatre notebooks », « sous quatre angles ») | 4 | **Correct** = 4 originaux pédagogiques (inchangée) |
| **CATALOG-STATUS** `pedagogical_count` | 4 | **Correct + byte-identique à main** (jumeaux = miroirs parité, pas pédagogiques) |

## Changement (4 insertions, 0 deletion, 1 fichier)

Pattern **marathon #4956** (même convention que SL-3/4/6/10 twins et hub GameTheory ligne 40 « SC-01 (Arrow) et SC-03 (Voting) en binômes Python ⇄ C# ») :

1. **+2 rows table Notebooks** : `SC-01 (C#)` et `SC-03 (C#)`, statut `PARITÉ`, lien `-Csharp.ipynb`, `**Jumeau C#** — parité .NET ... (See #4956)`.
2. **+1 callout « Parité .NET »** sous « Durée totale » : explique les miroirs C# et documente explicitement pourquoi `pedagogical_count` reste 4 (miroirs ≠ notebooks pédagogiques distincts) — anti-confusion pour les futurs auditeurs §E.

## Pourquoi `pedagogical_count: 4` reste correct

Les jumeaux C# sont des **miroirs de parité** (marathon .NET ⇄ Python #4956), pas des notebooks pédagogiques distincts — convention ratifiée (cf SL-8-KnowledgeGraphs-ILP-Csharp #5678, SL-6 #5652, etc. : le compteur pédagogique Python est inchangé à l'ajout d'un twin C#). Le marqueur `CATALOG-STATUS` est donc **byte-identique à main** (catalog-pr-hygiene HARD 1).

## Vérifications

- [x] CATALOG-STATUS byte-identique à `origin/main` (`diff` vide sur le bloc marqueur)
- [x] Liens C# résolvent (les 2 `-Csharp.ipynb` existent sur disque, vérifié `test -f`)
- [x] 0 emoji / 0 CJK dans le diff (FR prose, readme-french-first)
- [x] Rebase frais depuis `origin/main` `30d482222` (catalog-pr-hygiene HARD 2)
- [x] Prose « quatre notebooks »/« quatre angles » inchangée (correcte : 4 angles pédagogiques)
- [x] Convention naming/hyperliens cohérente avec les autres twins C# du dépôt

See #5661, See #3973, See #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)
