### PR TITLE
feat(lean,i18n): learning_theory_lean Perceptron/ EN siblings — full submodule (Data + Perceptron + Convergence + Tightness, EPIC #4980)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Convergence_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Convergence_en.lean
@@ -1,0 +1,138 @@
+import Mathlib
+import Perceptron.Perceptron_en
+
+/-!
+# Perceptron convergence theorem (Novikoff, 1962) — bound `(R/γ)²`
+
+> **Theorem (Novikoff).** Let a valid perceptron run on data linearly separable by a
+> unit vector `u` with margin `γ > 0`, the points being of norm `≤ R`. Then the number
+> of updates (mistakes) `n` satisfies `n ≤ (R/γ)²`.
+
+The proof, **elementary geometric and entirely 0-sorry**, rests on two growth
+inequalities of the weight vector `wₖ` combined via Cauchy–Schwarz:
+
+- **Lemma A — alignment** (`align_growth`) : `⟪wₖ, u⟫ ≥ k·γ`.
+  Each mistake adds `yₖ · xₖ` to `w`, and the margin hypothesis guarantees
+  `yₖ · ⟪u, xₖ⟫ ≥ γ`, so the alignment onto the separator grows by at least `γ`.
+- **Lemma B — norm** (`norm_bound`) : `‖wₖ‖² ≤ k·R²`.
+  Each mistake adds at most `R²` to `‖w‖²` (via the expansion
+  `‖a + b‖² = ‖a‖² + 2⟪a,b⟫ + ‖b‖²`), the cross term being `≤ 0` because the update
+  is a mistake (`yₖ · ⟪wₖ, xₖ⟫ ≤ 0`).
+- **Conclusion** : Cauchy–Schwarz `⟪wₙ, u⟫ ≤ ‖wₙ‖·‖u‖ = ‖wₙ‖` (with `‖u‖ = 1`)
+  yields `n·γ ≤ ‖wₙ‖`, hence `(n·γ)² ≤ ‖wₙ‖² ≤ n·R²`, i.e. `n·γ² ≤ R²`.
+
+Reference : A. B. J. Novikoff, *On convergence proofs for perceptrons*, Symposium
+on the Mathematical Theory of Automata (1962).
+
+English mirror of `Perceptron/Convergence.lean` (FR-first canonical), EPIC #4980
+(i18n Lean). Convention ratified 2026-07-04 (issue #4980): distinct FR + EN sibling
+files in the same lake, both compile; namespace `Perceptron_en` (anti-collision
+with the FR `Perceptron` namespace); non-docstring proof code unchanged.
+-/
+
+open scoped InnerProductSpace
+
+namespace Perceptron_en
+
+variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+open PerceptronRun
+
+/-- **Lemma A — alignment growth** : after `k ≤ n` updates,
+`⟪wₖ, u⟫ ≥ k·γ` (each mistake aligns `w` onto `u` by at least the margin `γ`). -/
+theorem PerceptronRun.align_growth (run : PerceptronRun V) :
+    ∀ k ≤ run.n,
+      (k : ℝ) * run.γ ≤ ⟪perceptronWeights run.pts run.lbl k, run.u⟫_ℝ := by
+  intro k
+  induction k with
+  | zero =>
+    intro _
+    rw [perceptronWeights_zero, inner_zero_left, Nat.cast_zero]
+    linarith
+  | succ k ih =>
+    intro hk
+    have hkn : k < run.n := Nat.lt_of_succ_le hk
+    have hstep : run.γ ≤ run.lbl k * ⟪run.u, run.pts k⟫_ℝ := run.hMargin k hkn
+    have hih : (k : ℝ) * run.γ ≤ ⟪perceptronWeights run.pts run.lbl k, run.u⟫_ℝ :=
+      ih (Nat.le_of_succ_le hk)
+    rw [perceptronWeights_succ run.pts run.lbl k, inner_add_left,
+        real_inner_smul_left, real_inner_comm run.u (run.pts k), Nat.cast_add_one]
+    linarith
+
+/-- **Lemma B — norm growth** : after `k ≤ n` updates,
+`‖wₖ‖² ≤ k·R²` (each mistake adds at most `R²` to `‖w‖²`). -/
+theorem PerceptronRun.norm_bound (run : PerceptronRun V) :
+    ∀ k ≤ run.n,
+      ‖perceptronWeights run.pts run.lbl k‖ ^ 2 ≤ (k : ℝ) * run.R ^ 2 := by
+  intro k
+  induction k with
+  | zero =>
+    intro _
+    rw [perceptronWeights_zero, norm_zero]
+    -- But `0 ≤ ↑0 * run.R²` : product of non-negatives (`↑0 ≥ 0`, `run.R² ≥ 0`).
+    nlinarith [sq_nonneg run.R]
+  | succ k ih =>
+    intro hk
+    have hkn : k < run.n := Nat.lt_of_succ_le hk
+    have hih : ‖perceptronWeights run.pts run.lbl k‖ ^ 2 ≤ (k : ℝ) * run.R ^ 2 :=
+      ih (Nat.le_of_succ_le hk)
+    -- Decomposition of the squared norm of a sum.
+    have hCross : ⟪perceptronWeights run.pts run.lbl k, run.lbl k • run.pts k⟫_ℝ ≤ 0 := by
+      rw [real_inner_smul_right]
+      exact run.hMistake k hkn
+    have hLbl2 : run.lbl k ^ 2 = 1 := run.hLbl k hkn
+    have hRad : ‖run.pts k‖ ≤ run.R := run.hRad k hkn
+    have hRad2 : ‖run.pts k‖ ^ 2 ≤ run.R ^ 2 :=
+      (sq_le_sq₀ (norm_nonneg _) run.hR).mpr hRad
+    have hSc2 : ‖run.lbl k • run.pts k‖ ^ 2 ≤ run.R ^ 2 := by
+      have hexp : ‖run.lbl k • run.pts k‖ ^ 2 = run.lbl k ^ 2 * ‖run.pts k‖ ^ 2 := by
+        rw [norm_smul, mul_pow, Real.norm_eq_abs, sq_abs]
+      rw [hexp, hLbl2, one_mul]
+      exact hRad2
+    rw [perceptronWeights_succ run.pts run.lbl k, norm_add_sq_eq]
+    -- Linarith does not see `↑(k+1)·R²` as `↑k·R² + R²` (product of atoms):
+    -- we provide the expanded equality as a hypothesis.
+    have hRHS : (k + 1 : ℝ) * run.R ^ 2 = (k : ℝ) * run.R ^ 2 + run.R ^ 2 := by ring
+    simp only [Nat.cast_add_one]
+    linarith
+
+/-- **Perceptron convergence theorem (Novikoff, 1962)** : the number of updates `n`
+of a valid run on data of radius `R` separated with margin `γ` satisfies the bound
+`n · γ² ≤ R²`, i.e. `n ≤ (R/γ)²`. -/
+theorem PerceptronRun.novikoff_mistake_bound (run : PerceptronRun V) :
+    (run.n : ℝ) * run.γ ^ 2 ≤ run.R ^ 2 := by
+  -- Lemma A at `k = n`.
+  have hAlign : (run.n : ℝ) * run.γ ≤
+      ⟪perceptronWeights run.pts run.lbl run.n, run.u⟫_ℝ :=
+    run.align_growth run.n (Nat.le_refl run.n)
+  -- Lemma B at `k = n`.
+  have hNorm : ‖perceptronWeights run.pts run.lbl run.n‖ ^ 2 ≤ (run.n : ℝ) * run.R ^ 2 :=
+    run.norm_bound run.n (Nat.le_refl run.n)
+  -- Cauchy–Schwarz : ⟪wₙ, u⟫ ≤ ‖wₙ‖·‖u‖ = ‖wₙ‖.
+  have hCS : ⟪perceptronWeights run.pts run.lbl run.n, run.u⟫_ℝ ≤
+      ‖perceptronWeights run.pts run.lbl run.n‖ := by
+    have hle := real_inner_le_norm (perceptronWeights run.pts run.lbl run.n) run.u
+    rw [run.hUnit] at hle
+    linarith
+  -- n·γ ≤ ‖wₙ‖, then (n·γ)² ≤ ‖wₙ‖² ≤ n·R².
+  have hNG : (run.n : ℝ) * run.γ ≤ ‖perceptronWeights run.pts run.lbl run.n‖ :=
+    le_trans hAlign hCS
+  have hNG2 : ((run.n : ℝ) * run.γ) ^ 2 ≤ ‖perceptronWeights run.pts run.lbl run.n‖ ^ 2 :=
+    (sq_le_sq₀ (mul_nonneg (Nat.cast_nonneg _) (le_of_lt run.hγ)) (norm_nonneg _)).mpr hNG
+  have hKey : ((run.n : ℝ) * run.γ) ^ 2 ≤ (run.n : ℝ) * run.R ^ 2 :=
+    le_trans hNG2 hNorm
+  -- Conclusion : (n·γ)² ≤ n·R²  ⟹  n·γ² ≤ R²  (case n = 0 trivial ; n ≥ 1 simplify by n).
+  rcases Nat.eq_zero_or_pos run.n with hz | hpos
+  · -- n = 0 : 0·γ² ≤ R² trivial.
+    rw [hz, Nat.cast_zero, zero_mul]
+    exact sq_nonneg run.R
+  · -- n > 0 : simplify by n (strictly positive).
+    have hnpos : (0 : ℝ) < run.n := Nat.cast_pos.mpr hpos
+    have hkey' : (run.n : ℝ) * ((run.n : ℝ) * run.γ ^ 2) ≤ (run.n : ℝ) * run.R ^ 2 := by
+      have hexp : ((run.n : ℝ) * run.γ) ^ 2 = (run.n : ℝ) ^ 2 * run.γ ^ 2 := by
+        rw [mul_pow]
+      rw [hexp, pow_two, mul_assoc] at hKey
+      exact hKey
+    exact (mul_le_mul_iff_of_pos_left hnpos).mp hkey'
+
+end Perceptron_en

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Data_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Data_en.lean
@@ -1,0 +1,51 @@
+import Mathlib
+
+/-!
+# Perceptron data — real inner product space, points, labels
+
+The Novikoff theorem (1962) is proved in an **abstract real inner product space** `V`
+(the `(R/γ)²` bound is independent of the dimension). This file gathers the elementary
+geometric facts about the norm and the inner product needed for the proof, in
+particular the expansion `‖a + b‖² = ‖a‖² + 2·⟪a, b⟫ + ‖b‖²` which is the core of
+Lemma B (growth of the weight vector's norm).
+
+The data itself (sequence of points `xₖ`, labels `yₖ ∈ {±1}`, unit separator `u` of
+margin `γ`, radius `R`) is modeled in `Perceptron.lean` by the `PerceptronRun`
+structure.
+
+English mirror of `Perceptron/Data.lean` (FR-first canonical), EPIC #4980
+(i18n Lean). Convention ratified 2026-07-04 (issue #4980): distinct FR + EN sibling
+files in the same lake, both compile; namespace `Perceptron_en` (anti-collision with
+the FR `Perceptron` namespace); non-docstring proof code unchanged (Lean tactic names
+and Mathlib references stay in English regardless).
+-/
+
+open scoped InnerProductSpace
+
+namespace Perceptron_en
+
+variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- `‖x‖² = ⟪x, x⟫_ℝ` — the square of the norm coincides with the self-inner product. -/
+theorem norm_sq_eq_inner_self (x : V) : ‖x‖ ^ 2 = ⟪x, x⟫_ℝ :=
+  (real_inner_self_eq_norm_sq x).symm
+
+/-- Expansion of the squared norm of a sum:
+`‖a + b‖² = ‖a‖² + 2·⟪a, b⟫ + ‖b‖²`. Central identity of Novikoff's Lemma B. -/
+theorem norm_add_sq_eq (a b : V) :
+    ‖a + b‖ ^ 2 = ‖a‖ ^ 2 + 2 * ⟪a, b⟫_ℝ + ‖b‖ ^ 2 := by
+  rw [norm_sq_eq_inner_self (a + b), real_inner_add_add_self,
+      ← norm_sq_eq_inner_self a, ← norm_sq_eq_inner_self b]
+
+/-- A **label** is a real scalar whose square is `1` (i.e. `±1`). -/
+abbrev IsLabel (y : ℝ) : Prop :=
+  y ^ 2 = 1
+
+/-- A labeled point: a vector `x ∈ V` together with its label `y ∈ {±1}`. -/
+structure LabeledPoint where
+  /-- The vector (point in the space). -/
+  x : V
+  /-- The label (`±1`). -/
+  y : ℝ
+
+end Perceptron_en

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Perceptron_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Perceptron_en.lean
@@ -1,0 +1,87 @@
+import Mathlib
+import Perceptron.Data_en
+
+/-!
+# The perceptron and its execution — weight vector and valid runs
+
+The perceptron update rule: upon a classification mistake on `(xₖ, yₖ)`, the weight
+vector evolves by
+```
+w_{k+1} = wₖ + yₖ · xₖ        (w₀ = 0)
+```
+The sequence `perceptronWeights` encodes this evolution. A **valid run**
+(`PerceptronRun`) records that we consider `n` consecutive updates, each being a
+**mistake** (`yₖ · ⟨wₖ, xₖ⟩ ≤ 0`), on data of radius `R` separated by a unit vector
+`u` with margin `γ`.
+
+These two invariants (mistake + margin) are exactly what makes Novikoff's proof
+work: the mistake caps the growth of `‖w‖`, the margin guarantees that of `⟨w, u⟩`.
+
+English mirror of `Perceptron/Perceptron.lean` (FR-first canonical), EPIC #4980
+(i18n Lean). Convention ratified 2026-07-04 (issue #4980): distinct FR + EN sibling
+files in the same lake, both compile; namespace `Perceptron_en` (anti-collision
+with the FR `Perceptron` namespace); non-docstring proof code unchanged.
+-/
+
+open scoped InnerProductSpace
+
+namespace Perceptron_en
+
+variable {V : Type*} [SeminormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- The sequence of perceptron weight vectors after `k` updates:
+`w₀ = 0`, `w_{k+1} = wₖ + yₖ · xₖ`. -/
+def perceptronWeights (pts : ℕ → V) (lbl : ℕ → ℝ) : ℕ → V
+  | 0 => 0
+  | k + 1 => perceptronWeights pts lbl k + lbl k • pts k
+
+@[simp]
+theorem perceptronWeights_zero (pts : ℕ → V) (lbl : ℕ → ℝ) :
+    perceptronWeights pts lbl 0 = 0 :=
+  rfl
+
+theorem perceptronWeights_succ (pts : ℕ → V) (lbl : ℕ → ℝ) (k : ℕ) :
+    perceptronWeights pts lbl (k + 1) =
+      perceptronWeights pts lbl k + lbl k • pts k :=
+  rfl
+
+/-- A **valid perceptron run** on linearly separable data: `n` consecutive updates,
+each being a mistake, on points of radius `R` separated by the unit vector `u` with
+margin `γ`. -/
+structure PerceptronRun (V : Type*) [SeminormedAddCommGroup V] [InnerProductSpace ℝ V] where
+  /-- Number of updates (mistakes) considered. -/
+  n : ℕ
+  /-- The points `xₖ` (relevant for `k < n`). -/
+  pts : ℕ → V
+  /-- The labels `yₖ` (of square `1`, i.e. `±1`). -/
+  lbl : ℕ → ℝ
+  /-- Unit separator of margin `γ`. -/
+  u : V
+  /-- Data radius (`R ≥ 0`, `‖xₖ‖ ≤ R`). -/
+  R : ℝ
+  /-- Separation margin (`γ > 0`). -/
+  γ : ℝ
+  /-- The radius is non-negative. -/
+  hR : 0 ≤ R
+  /-- The margin is strictly positive. -/
+  hγ : 0 < γ
+  /-- The separator is unit. -/
+  hUnit : ‖u‖ = 1
+  /-- Each label is `±1`. -/
+  hLbl : ∀ k < n, lbl k ^ 2 = 1
+  /-- Each point has norm `≤ R`. -/
+  hRad : ∀ k < n, ‖pts k‖ ≤ R
+  /-- **Margin**: `γ ≤ yₖ · ⟨u, xₖ⟩` (the separator classifies correctly with margin). -/
+  hMargin : ∀ k < n, γ ≤ lbl k * ⟪u, pts k⟫_ℝ
+  /-- **Mistake**: `yₖ · ⟨wₖ, xₖ⟩ ≤ 0` (the k-th update is indeed a mistake). -/
+  hMistake : ∀ k < n, lbl k * ⟪perceptronWeights pts lbl k, pts k⟫_ℝ ≤ 0
+
+namespace PerceptronRun
+
+/-- The weight vector before the `k`-th update. -/
+abbrev w (run : PerceptronRun V) (k : ℕ) : V :=
+  perceptronWeights run.pts run.lbl k
+
+end PerceptronRun
+
+end Perceptron_en

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Tightness_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/Perceptron/Tightness_en.lean
@@ -1,0 +1,161 @@
+import Mathlib
+import Perceptron.Perceptron_en
+import Perceptron.Convergence_en
+
+/-!
+# Saturation of the Novikoff bound — a tight witness (sharpness)
+
+> **Result.** The Novikoff bound `n · γ² ≤ R²` (i.e. `n ≤ (R/γ)²` updates) is
+> **optimal** : we exhibit a valid perceptron run, on `ℂ` seen as a real
+> 2-dimensional inner product space, which **saturates** the bound —
+> `n · γ² = R²` exactly. A universal constant strictly smaller than `1` in front of
+> `(R/γ)²` therefore cannot upper-bound the number of mistakes over all separable
+> runs.
+
+**Geometric witness.** Two points `x₀ = 1 + I`, `x₁ = 1 − I` (half-lines at ±45°),
+both of label `+1`, separated by the unit vector `u = 1` with margin `γ = 1`, each
+of norm `‖xₖ‖ = √2` (so `R = √2`). The first update makes `w₁ = x₀ = 1 + I` ; at
+the second step, `⟪w₁, x₁⟫ = ⟨1 + I, 1 − I⟩ = 0` (the two half-lines are
+orthogonal) : `x₁` lies exactly on the decision boundary of `w₁`, so the update is
+a mistake. We then get `n · γ² = 2 · 1 = 2 = (√2)² = R²` : **equality** — the bound
+is met, hence sharp.
+
+The space `ℂ` carries the instance `InnerProductSpace ℝ ℂ` ; the real inner product
+unfolds as `⟪w, z⟫_ℝ = (z · conj w).re` (`Complex.inner` +
+`Complex.starRingEnd_apply`), i.e. `w.re · z.re + w.im · z.im`, and the norms as
+`‖z‖² = Complex.normSq z = z.re² + z.im²` (`Complex.normSq_eq_norm_sq`,
+`Complex.normSq_apply`).
+
+This module is **entirely sorry-free** : it is a concrete *sharpness* result
+(equality attained), distinct from the universal bound theorem
+`novikoff_mistake_bound` (inequality) proved in `Convergence.lean`.
+
+English mirror of `Perceptron/Tightness.lean` (FR-first canonical), EPIC #4980
+(i18n Lean). Convention ratified 2026-07-04 (issue #4980): distinct FR + EN sibling
+files in the same lake, both compile; namespace `Perceptron_en` (anti-collision
+with the FR `Perceptron` namespace); non-docstring proof code unchanged.
+-/
+
+open scoped InnerProductSpace
+
+open Complex
+
+namespace Perceptron_en
+
+/-- Real inner product on `ℂ` unfolded into coordinates : `⟪w, z⟫ = w.re·z.re +
+w.im·z.im` (utility lemma for the concrete computations of the witness). -/
+theorem complex_inner_re (w z : ℂ) : ⟪w, z⟫_ℝ = w.re * z.re + w.im * z.im := by
+  rw [Complex.inner, Complex.mul_re, Complex.conj_re, Complex.conj_im]
+  ring
+
+/-- The witness points `xₖ` : `x₀ = 1 + I`, `xₖ = 1 − I` for `k ≥ 1`
+(two half-lines at ±45° of the complex plane). -/
+def witnessPts : ℕ → ℂ
+  | 0 => 1 + I
+  | _ + 1 => 1 - I
+
+/-- The witness labels : all `+1`. -/
+def witnessLbl : ℕ → ℝ := fun _ => 1
+
+/-- `‖xₖ‖² = 2` for every `k` (the two half-lines have the same norm `√2`). -/
+theorem witnessPts_norm_sq (k : ℕ) : ‖witnessPts k‖ ^ 2 = 2 := by
+  rcases k with rfl | k
+  · rw [show ‖witnessPts 0‖ ^ 2 = Complex.normSq (witnessPts 0) from
+          (Complex.normSq_eq_norm_sq _).symm,
+        Complex.normSq_apply, witnessPts]
+    norm_num [Complex.add_re, Complex.add_im, I_re, I_im]
+  · rw [show ‖witnessPts (k + 1)‖ ^ 2 = Complex.normSq (witnessPts (k + 1)) from
+          (Complex.normSq_eq_norm_sq _).symm,
+        Complex.normSq_apply, witnessPts]
+    norm_num [Complex.sub_re, Complex.sub_im, I_re, I_im]
+
+/-- The margin `⟪u, xₖ⟫ = ⟨1, xₖ⟩ = 1` for every `k` (equal to `γ`). -/
+theorem witness_margin_inner (k : ℕ) : ⟪(1 : ℂ), witnessPts k⟫_ℝ = 1 := by
+  rw [complex_inner_re]
+  rcases k with rfl | k
+  · rw [witnessPts]
+    norm_num [Complex.add_re, Complex.add_im, I_re, I_im]
+  · rw [witnessPts]
+    norm_num [Complex.sub_re, Complex.sub_im, I_re, I_im]
+
+/-- The "mistake" inner product `⟪1 + I, 1 − I⟫ = 0` (orthogonality of the two
+half-lines) — core of the second update. -/
+theorem witness_cross_inner : ⟪(1 + I : ℂ), 1 - I⟫_ℝ = 0 := by
+  rw [complex_inner_re]
+  norm_num [Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im, I_re, I_im]
+
+/-- After the first update, `w₁ = x₀ = 1 + I`. -/
+theorem witness_w1 : perceptronWeights witnessPts witnessLbl 1 = 1 + I := by
+  rw [perceptronWeights_succ, perceptronWeights_zero, zero_add]
+  show witnessLbl 0 • witnessPts 0 = 1 + I
+  rw [show witnessLbl 0 = 1 from rfl, show witnessPts 0 = (1 + I : ℂ) from rfl]
+  exact one_smul _ _
+
+theorem witness_lbl : ∀ k < (2 : ℕ), witnessLbl k ^ 2 = 1 := by
+  intro k _
+  rw [show witnessLbl k = 1 from rfl]
+  norm_num
+
+theorem witness_rad : ∀ k < (2 : ℕ), ‖witnessPts k‖ ≤ Real.sqrt 2 := by
+  intro k _
+  have h := witnessPts_norm_sq k
+  have hnn : 0 ≤ ‖witnessPts k‖ := norm_nonneg _
+  calc ‖witnessPts k‖
+      = Real.sqrt (‖witnessPts k‖ ^ 2) := (Real.sqrt_sq hnn).symm
+    _ = Real.sqrt 2 := by rw [h]
+    _ ≤ Real.sqrt 2 := le_refl _
+
+theorem witness_margin : ∀ k < (2 : ℕ),
+    (1 : ℝ) ≤ witnessLbl k * ⟪(1 : ℂ), witnessPts k⟫_ℝ := by
+  intro k _
+  rw [show witnessLbl k = 1 from rfl, one_mul]
+  linarith [witness_margin_inner k]
+
+theorem witness_mistake : ∀ k < (2 : ℕ),
+    witnessLbl k * ⟪perceptronWeights witnessPts witnessLbl k, witnessPts k⟫_ℝ ≤ 0 := by
+  intro k _
+  have h01 : k = 0 ∨ k = 1 := by omega
+  rcases h01 with rfl | rfl
+  · rw [perceptronWeights_zero, inner_zero_left, show witnessLbl 0 = 1 from rfl]
+    norm_num
+  · rw [witness_w1, show witnessLbl 1 = 1 from rfl, one_mul,
+        show witnessPts 1 = (1 - I : ℂ) from rfl]
+    linarith [witness_cross_inner]
+
+/-- The saturating run : `n = 2` points of `ℂ`, separated by `u = 1` with margin
+`γ = 1`, of radius `R = √2`, reaching `n · γ² = R²`. -/
+noncomputable def tightnessRun : PerceptronRun ℂ :=
+  { n := 2,
+    pts := witnessPts,
+    lbl := witnessLbl,
+    u := 1,
+    R := Real.sqrt 2,
+    γ := 1,
+    hR := Real.sqrt_nonneg _,
+    hγ := one_pos,
+    hUnit := norm_one,
+    hLbl := witness_lbl,
+    hRad := witness_rad,
+    hMargin := witness_margin,
+    hMistake := witness_mistake }
+
+/-- The witness reaches the bound **with equality** : `n · γ² = R²`. -/
+theorem tightnessRun_saturates :
+    (tightnessRun.n : ℝ) * tightnessRun.γ ^ 2 = tightnessRun.R ^ 2 := by
+  have hn : tightnessRun.n = 2 := rfl
+  have hγ : tightnessRun.γ = 1 := rfl
+  have hR : tightnessRun.R = Real.sqrt 2 := rfl
+  rw [hn, hγ, hR]
+  rw [show (Real.sqrt 2 : ℝ) ^ 2 = 2 from Real.sq_sqrt (by norm_num)]
+  norm_num
+
+/-- **The Novikoff bound is sharp.** There exists a valid run (on `ℂ`) which
+reaches it with equality `n · γ² = R²`. Since `novikoff_mistake_bound` gives the
+universal inequality `n · γ² ≤ R²` and equality is reached by `tightnessRun`, no
+bound of the form `n · γ² ≤ c · R²` with `c < 1` is universally valid : the
+constant `1` (in front of `(R/γ)²`) is optimal. -/
+theorem novikoff_bound_is_sharp :
+    ∃ run : PerceptronRun ℂ, (run.n : ℝ) * run.γ ^ 2 = run.R ^ 2 :=
+  ⟨tightnessRun, tightnessRun_saturates⟩
+
+end Perceptron_en


### PR DESCRIPTION
## Summary

First English `_en.lean` siblings for `learning_theory_lean` (série ML) — the **sole substantive Lean lake repo-wide (18 modules) without any EN mirror**, identifié dans l'inventaire i18n exhaustif repo-wide (comment 4909613250 sur #4980). EPIC #4980 (i18n Lean).

Créé 2026-06-25 (`5ff1eeee5`), **postérieur à la passe i18n du 2026-07-05** (`f5ff4b4ee`) qui a traduit les autres lakes FR-first (astar/sudoku/kelly) — jamais rattrapé. Convention siblings `Foo.lean` (FR canonique) + `Foo_en.lean` (EN miroir) **ratifiée user 2026-07-04** (#4980, comment 4881909354).

Cette PR livre **le sous-module `Perceptron/` complet** (4 modules sur 4) : `Data_en.lean` + `Perceptron_en.lean` + `Convergence_en.lean` (théorème de Novikoff) + `Tightness_en.lean` (saturation de la borne). Le sous-module suivant `PacLearning/*` (12 modules) viendra en PRs ultérieures.

## Contenu — 4 modules EN siblings (sous-module Perceptron/ complet)

### `Perceptron/Data_en.lean` (+51L, mirror de `Data.lean` 46L)
- `import Mathlib` (self-contained)
- `namespace Perceptron_en`
- `norm_sq_eq_inner_self`, `norm_add_sq_eq`, `abbrev IsLabel`, `structure LabeledPoint` — docstrings FR→EN, **même preuve**

### `Perceptron/Perceptron_en.lean` (+87L, mirror de `Perceptron.lean` 83L)
- `import Mathlib` + `import Perceptron.Data_en` (**convention cross-module `_en` import `_en`**, cf `decision_theory_lean/Gittins/GittinsTheorem_en.lean`)
- `namespace Perceptron_en`
- `def perceptronWeights`, `@[simp] theorem perceptronWeights_zero`, `theorem perceptronWeights_succ` — code identique (`rfl`)
- `structure PerceptronRun` (n, pts, lbl, u, R, γ + invariants `hR`/`hγ`/`hUnit`/`hLbl`/`hRad`/`hMargin`/`hMistake`) — docstrings FR→EN
- namespace imbriqué `PerceptronRun` avec `abbrev w`

### `Perceptron/Convergence_en.lean` (+138L, mirror de `Convergence.lean` 134L)
- `import Mathlib` + `import Perceptron.Perceptron_en` (cross-module `_en` import `_en`)
- `namespace Perceptron_en` + `open PerceptronRun`
- **Théorème de Novikoff (1962)** : borne `(R/γ)²` sur le nombre d'erreurs
- 3 théorèmes : `PerceptronRun.align_growth` (Lemme A, induction + linarith), `PerceptronRun.norm_bound` (Lemme B, induction + nlinarith), `PerceptronRun.novikoff_mistake_bound` (Cauchy–Schwarz + algèbre, rcases n=0/n>0)
- **Preuve réelle** (tactiques induction/linarith/nlinarith/rcases/ring, PAS juste `rfl`) — docstrings + commentaires FR→EN, **code de preuve inchangé**

### `Perceptron/Tightness_en.lean` (+161L, mirror de `Tightness.lean` 157L) — NOUVEAU commit 4 (final)
- `import Mathlib` + `import Perceptron.Perceptron_en` + `import Perceptron.Convergence_en`
- `namespace Perceptron_en` + `open Complex`
- **Saturation (sharpness) de la borne de Novikoff** : témoin sur `ℂ` qui atteint `n·γ² = R²` avec égalité → la constante `1` devant `(R/γ)²` est optimale
- Témoin géométrique : `x₀ = 1+I`, `x₁ = 1−I` (demi-droites ±45° orthogonales), `u = 1`, `γ = 1`, `R = √2`, `n = 2`
- `complex_inner_re`, `witnessPts`, `witnessLbl` (utilitaire + définitions témoin), 8 lemmes de témoin (`witnessPts_norm_sq` rcases+norm_num, `witness_margin_inner`, `witness_cross_inner` orthogonauté, `witness_w1`, `witness_lbl`, `witness_rad` calc, `witness_margin`, `witness_mistake`), `tightnessRun` (noncomputable PerceptronRun ℂ), `tightnessRun_saturates` (égalité), `novikoff_bound_is_sharp` (existential)
- **Preuve réelle** (rcases/norm_num/calc/linarith/rfl, PAS juste rfl) — docstrings FR→EN, **code de preuve inchangé**

## Convention respectée (pattern sudoku_lean/Basic_en.lean + Gittins_en)

- `namespace Perceptron_en` (anti-collision avec FR `Perceptron`)
- `_en` import `_en` (pas le FR) pour cohérence cross-module
- code de preuve Lean **inchangé** (tactiques + références Mathlib restent EN indépendamment)
- FR canoniques `Perceptron/{Data,Perceptron,Convergence,Tightness}.lean` **byte-identiques à `origin/main`** (non touchés, anti-régression §D — vérifié per-file : 0 diff lines chacune)

## §B Lean — preuve de progrès vérifiable

1. **`grep -c sorry`** : `0` → `0` (miroirs de docstrings, 0 preuve ajoutée ni modifiée ; FR canoniques byte-identiques).
2. **`Lake build SUCCESS` local firsthand** :
   - `lake build Perceptron.Data_en` → **SUCCESS 8493 jobs EXIT 0**
   - `lake build Perceptron.Perceptron_en` → **SUCCESS 8494 jobs EXIT 0**
   - `lake build Perceptron.Convergence_en` → **SUCCESS 8495 jobs EXIT 0**
   - `lake build Perceptron.Tightness_en` → **SUCCESS 8496 jobs EXIT 0**
3. **Proof integrity** : 0 axiom, 0 sorry, 0 admit (sur les 4 fichiers).
4. **CI `Lean CI (learning_theory_lean)` PASS** sur les 3 premiers commits — fresh clone compile le lake incluant les siblings (commit 4 re-running).
5. Pas de refactor prover : PR pure i18n (4 fichiers ajoutés, 0 ligne modifiée sur l'existant).

## Règle F — repair stale Mathlib cache (c.261) contourné en local

Le blocker fleet-wide « Cache Mathlib rc1 STALE c.261 » (`d568c8c0` force-pushed → checkout git local corrompu) est **contournable en local** : `rm -rf .lake/packages/mathlib lake-manifest.json && lake update mathlib` re-clone propre depuis le tag `v4.31.0-rc1` (existe bien sur remote) + décompresse 8473 fichiers du cache Azure CI. Build-verif local **réalisable, PAS USER-HAND bloquant**. Leçon durable propagée.

## Forensic (conformité)

- 4 fichiers ajoutés (`Data_en` +51, `Perceptron_en` +87, `Convergence_en` +138, `Tightness_en` +161), 0 suppression
- CRLF : 0 (UTF-8 LF, vérifié sur les 4)
- 0 emoji / 0 CJK
- FR canoniques byte-identiques à `origin/main` (anti-régression §D, vérifié per-file)
- Rebase frais depuis `origin/main` `aebdd30ea` (catalog-pr-hygiene HARD 2)
- `globs := #[.submodules \`Perceptron]` inclut les 4 `_en` dans le build (compilent)

## Plan de tranche (PRs ultérieures)

- **Cette PR** : sous-module Perceptron/ EN complet (Data + Perceptron + Convergence/Novikoff + Tightness/saturation) — 4 modules
- **PRs suivantes** : `PacLearning/*` (12 modules, plus large, multi-PR)

## Test plan

- [x] `lake build Perceptron.Data_en` → SUCCESS (8493 jobs, EXIT 0)
- [x] `lake build Perceptron.Perceptron_en` → SUCCESS (8494 jobs, EXIT 0)
- [x] `lake build Perceptron.Convergence_en` → SUCCESS (8495 jobs, EXIT 0)
- [x] `lake build Perceptron.Tightness_en` → SUCCESS (8496 jobs, EXIT 0)
- [x] CI `Lean CI (learning_theory_lean)` PASS (fresh clone, commits 1-3)
- [x] 0 sorry / 0 axiom / 0 admit (FR proofs inchangées)
- [x] FR canoniques byte-identiques à `origin/main` (anti-§D, per-file vérifié)
- [x] Convention `_en` ratified + cross-module `_en` import `_en` (pattern Gittins_en)
- [x] CRLF 0, UTF-8 LF, 0 emoji/CJK

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
