### PR TITLE
feat(gametheory): SC-04-CSharp tranche 2 - Sen theorem + Arrow-vs-Sen benchmark

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
@@ -35,10 +35,10 @@
    "id": "caae5054",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:09:10.674174Z",
-     "iopub.status.busy": "2026-07-07T20:09:10.663849Z",
-     "iopub.status.idle": "2026-07-07T20:09:12.762107Z",
-     "shell.execute_reply": "2026-07-07T20:09:12.756587Z"
+     "iopub.execute_input": "2026-07-07T23:04:42.640896Z",
+     "iopub.status.busy": "2026-07-07T23:04:42.630655Z",
+     "iopub.status.idle": "2026-07-07T23:04:44.857653Z",
+     "shell.execute_reply": "2026-07-07T23:04:44.852696Z"
     }
    },
    "outputs": [
@@ -97,7 +97,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '1903172.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '1953784.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -220,10 +220,10 @@
    "id": "3b4fa15e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:09:12.764986Z",
-     "iopub.status.busy": "2026-07-07T20:09:12.764646Z",
-     "iopub.status.idle": "2026-07-07T20:09:13.145593Z",
-     "shell.execute_reply": "2026-07-07T20:09:13.145253Z"
+     "iopub.execute_input": "2026-07-07T23:04:44.860491Z",
+     "iopub.status.busy": "2026-07-07T23:04:44.860218Z",
+     "iopub.status.idle": "2026-07-07T23:04:45.325193Z",
+     "shell.execute_reply": "2026-07-07T23:04:45.324668Z"
     }
    },
    "outputs": [],
@@ -354,10 +354,10 @@
    "id": "3129f116",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:09:13.147360Z",
-     "iopub.status.busy": "2026-07-07T20:09:13.147097Z",
-     "iopub.status.idle": "2026-07-07T20:09:13.541097Z",
-     "shell.execute_reply": "2026-07-07T20:09:13.540816Z"
+     "iopub.execute_input": "2026-07-07T23:04:45.326934Z",
+     "iopub.status.busy": "2026-07-07T23:04:45.326692Z",
+     "iopub.status.idle": "2026-07-07T23:04:45.812464Z",
+     "shell.execute_reply": "2026-07-07T23:04:45.812142Z"
     }
    },
    "outputs": [
@@ -475,10 +475,10 @@
    "id": "480f83bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:09:13.543083Z",
-     "iopub.status.busy": "2026-07-07T20:09:13.542814Z",
-     "iopub.status.idle": "2026-07-07T20:09:13.649142Z",
-     "shell.execute_reply": "2026-07-07T20:09:13.648791Z"
+     "iopub.execute_input": "2026-07-07T23:04:45.814485Z",
+     "iopub.status.busy": "2026-07-07T23:04:45.814211Z",
+     "iopub.status.idle": "2026-07-07T23:04:45.910710Z",
+     "shell.execute_reply": "2026-07-07T23:04:45.910414Z"
     }
    },
    "outputs": [
@@ -541,10 +541,10 @@
    "id": "1f687b50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:09:13.669337Z",
-     "iopub.status.busy": "2026-07-07T20:09:13.650615Z",
-     "iopub.status.idle": "2026-07-07T20:09:13.988906Z",
-     "shell.execute_reply": "2026-07-07T20:09:13.988712Z"
+     "iopub.execute_input": "2026-07-07T23:04:45.943594Z",
+     "iopub.status.busy": "2026-07-07T23:04:45.912462Z",
+     "iopub.status.idle": "2026-07-07T23:04:46.347325Z",
+     "shell.execute_reply": "2026-07-07T23:04:46.347002Z"
     }
    },
    "outputs": [
@@ -773,10 +773,10 @@
    "id": "074f0fcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:09:13.991177Z",
-     "iopub.status.busy": "2026-07-07T20:09:13.990899Z",
-     "iopub.status.idle": "2026-07-07T20:09:14.091581Z",
-     "shell.execute_reply": "2026-07-07T20:09:14.091288Z"
+     "iopub.execute_input": "2026-07-07T23:04:46.349330Z",
+     "iopub.status.busy": "2026-07-07T23:04:46.349082Z",
+     "iopub.status.idle": "2026-07-07T23:04:46.442078Z",
+     "shell.execute_reply": "2026-07-07T23:04:46.441818Z"
     }
    },
    "outputs": [
@@ -916,10 +916,10 @@
    "id": "3e23fc63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:09:14.093862Z",
-     "iopub.status.busy": "2026-07-07T20:09:14.093448Z",
-     "iopub.status.idle": "2026-07-07T20:09:14.177705Z",
-     "shell.execute_reply": "2026-07-07T20:09:14.177457Z"
+     "iopub.execute_input": "2026-07-07T23:04:46.443814Z",
+     "iopub.status.busy": "2026-07-07T23:04:46.443532Z",
+     "iopub.status.idle": "2026-07-07T23:04:46.509311Z",
+     "shell.execute_reply": "2026-07-07T23:04:46.508952Z"
     }
    },
    "outputs": [
@@ -1103,6 +1103,380 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sen-tranche2-0",
+   "metadata": {},
+   "source": [
+    "## 5. Theoreme de Sen : un autre angle d'impossibilite\n",
+    "\n",
+    "Le theoreme de Sen (1970) propose une impossibilite **differente** de celle d'Arrow, basee sur le conflit entre **liberte individuelle minimale** et **efficacite collective**. La ou Arrow exige IIA + non-dictature, Sen remplace ces deux axiomes par une seule contrainte de **liberte minimale** : chaque individu decide seul d'au moins une paire d'alternatives.\n",
+    "\n",
+    "L'encodage SAT est donc plus parcimonieux (transitivite + Pareto + liberte), et UNSAT prouve que ces trois conditions sont deja incompatibles -- un resultat **plus fort** qu'Arrow car il ne requiert pas l'axiome IIA (souvent critique comme trop restrictif)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "sen-tranche2-1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:04:46.510886Z",
+     "iopub.status.busy": "2026-07-07T23:04:46.510693Z",
+     "iopub.status.idle": "2026-07-07T23:04:46.692269Z",
+     "shell.execute_reply": "2026-07-07T23:04:46.692108Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ENCODAGE DU THEOREME DE SEN (3 alt, 2 voters)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Variables       : 216\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Clauses         : 558\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Pairs de liberte: voter0->(A,C), voter1->(B,C)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultat DPLL    : UNSAT (Sen verifie) en 0.1 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Liberte minimale + Pareto + transitivite = IMPOSSIBLE (theoreme de Sen)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Encodeur SAT du theoreme de Sen (port C# de SenSATEncoder Python) ===\n",
+    "// Genere les clauses CNF pour : totalite, asymetrie, transitivite, Pareto, liberte minimale.\n",
+    "// Reutilise Permutations/Combinations definis au-dessus (cell Arrow).\n",
+    "\n",
+    "public class SenSATEncoder\n",
+    "{\n",
+    "    public List<string> Alternatives { get; }\n",
+    "    public int NAlt => Alternatives.Count;\n",
+    "    public int NVoters { get; }\n",
+    "    public List<List<List<string>>> Profiles { get; }\n",
+    "    public List<(int voter, string x, string y)> LibertyPairs { get; }\n",
+    "\n",
+    "    private readonly Dictionary<(int,string,string), int> _varMap = new();\n",
+    "    private int _varCounter = 0;\n",
+    "\n",
+    "    public SenSATEncoder(List<string> alternatives, int nVoters, List<(int,string,string)> libertyPairs = null)\n",
+    "    {\n",
+    "        Alternatives = alternatives;\n",
+    "        NVoters = nVoters;\n",
+    "        // Paires de liberte par defaut : chaque voter decide d'une paire (round-robin)\n",
+    "        if (libertyPairs == null)\n",
+    "        {\n",
+    "            LibertyPairs = new List<(int,string,string)>();\n",
+    "            var allPairs = Combinations(alternatives, 2);\n",
+    "            for (int v = 0; v < nVoters; v++)\n",
+    "            {\n",
+    "                var pair = allPairs[v % allPairs.Count];\n",
+    "                LibertyPairs.Add((v, pair[0], pair[1]));\n",
+    "            }\n",
+    "        }\n",
+    "        else LibertyPairs = libertyPairs;\n",
+    "\n",
+    "        var allOrders = Permutations(alternatives, NAlt).Select(p => p.ToList()).ToList();\n",
+    "        Profiles = new List<List<List<string>>>();\n",
+    "        void Build(int depth, List<List<string>> cur)\n",
+    "        {\n",
+    "            if (depth == nVoters) { Profiles.Add(cur.Select(o => o.ToList()).ToList()); return; }\n",
+    "            foreach (var order in allOrders) { cur.Add(order); Build(depth + 1, cur); cur.RemoveAt(cur.Count - 1); }\n",
+    "        }\n",
+    "        Build(0, new List<List<string>>());\n",
+    "        for (int pi = 0; pi < Profiles.Count; pi++)\n",
+    "            foreach (var (x, y) in from a in Alternatives from b in Alternatives where a != b select (a, b))\n",
+    "                _varMap[(pi, x, y)] = ++_varCounter;\n",
+    "    }\n",
+    "\n",
+    "    public int GetVar(int pi, string x, string y) => _varMap[(pi, x, y)];\n",
+    "\n",
+    "    public List<List<int>> EncodeCompleteness()\n",
+    "    {\n",
+    "        var clauses = new List<List<int>>();\n",
+    "        for (int pi = 0; pi < Profiles.Count; pi++)\n",
+    "            foreach (var pair in Combinations(Alternatives, 2))\n",
+    "                clauses.Add(new(){ GetVar(pi, pair[0], pair[1]), GetVar(pi, pair[1], pair[0]) });\n",
+    "        return clauses;\n",
+    "    }\n",
+    "\n",
+    "    public List<List<int>> EncodeAsymmetry()\n",
+    "    {\n",
+    "        var clauses = new List<List<int>>();\n",
+    "        for (int pi = 0; pi < Profiles.Count; pi++)\n",
+    "            foreach (var pair in Combinations(Alternatives, 2))\n",
+    "                clauses.Add(new(){ -GetVar(pi, pair[0], pair[1]), -GetVar(pi, pair[1], pair[0]) });\n",
+    "        return clauses;\n",
+    "    }\n",
+    "\n",
+    "    public List<List<int>> EncodeTransitivity()\n",
+    "    {\n",
+    "        var clauses = new List<List<int>>();\n",
+    "        for (int pi = 0; pi < Profiles.Count; pi++)\n",
+    "            foreach (var t in Permutations(Alternatives, 3).Select(p => p.ToList()))\n",
+    "                clauses.Add(new(){ -GetVar(pi, t[0], t[1]), -GetVar(pi, t[1], t[2]), GetVar(pi, t[0], t[2]) });\n",
+    "        return clauses;\n",
+    "    }\n",
+    "\n",
+    "    public List<List<int>> EncodePareto()\n",
+    "    {\n",
+    "        var clauses = new List<List<int>>();\n",
+    "        for (int pi = 0; pi < Profiles.Count; pi++)\n",
+    "        {\n",
+    "            var profile = Profiles[pi];\n",
+    "            foreach (var (x, y) in from a in Alternatives from b in Alternatives where a != b select (a, b))\n",
+    "                if (profile.All(v => v.IndexOf(x) < v.IndexOf(y)))\n",
+    "                    clauses.Add(new(){ GetVar(pi, x, y) });\n",
+    "        }\n",
+    "        return clauses;\n",
+    "    }\n",
+    "\n",
+    "    public List<List<int>> EncodeLiberty()\n",
+    "    {\n",
+    "        // Liberte minimale : pour chaque paire assignee a un voter, son choix est contraignant\n",
+    "        var clauses = new List<List<int>>();\n",
+    "        foreach (var (voter, x, y) in LibertyPairs)\n",
+    "            for (int pi = 0; pi < Profiles.Count; pi++)\n",
+    "            {\n",
+    "                if (Profiles[pi][voter].IndexOf(x) < Profiles[pi][voter].IndexOf(y))\n",
+    "                    clauses.Add(new(){ GetVar(pi, x, y) });\n",
+    "                else\n",
+    "                    clauses.Add(new(){ GetVar(pi, y, x) });\n",
+    "            }\n",
+    "        return clauses;\n",
+    "    }\n",
+    "\n",
+    "    public List<List<int>> EncodeAll()\n",
+    "    {\n",
+    "        var all = new List<List<int>>();\n",
+    "        all.AddRange(EncodeCompleteness());\n",
+    "        all.AddRange(EncodeAsymmetry());\n",
+    "        all.AddRange(EncodeTransitivity());\n",
+    "        all.AddRange(EncodePareto());\n",
+    "        all.AddRange(EncodeLiberty());\n",
+    "        return all;\n",
+    "    }\n",
+    "\n",
+    "    public int NVariables => _varCounter;\n",
+    "}\n",
+    "\n",
+    "// Encodage de Sen : 3 alternatives, 2 votants\n",
+    "// Liberte : voter 0 decide (A,C), voter 1 decide (B,C)\n",
+    "var liberty = new List<(int,string,string)>{ (0,\"A\",\"C\"), (1,\"B\",\"C\") };\n",
+    "var senEnc = new SenSATEncoder(new List<string>{\"A\",\"B\",\"C\"}, 2, liberty);\n",
+    "var senClauses = senEnc.EncodeAll();\n",
+    "\n",
+    "Console.WriteLine(\"ENCODAGE DU THEOREME DE SEN (3 alt, 2 voters)\");\n",
+    "Console.WriteLine($\"  Variables       : {senEnc.NVariables}\");\n",
+    "Console.WriteLine($\"  Clauses         : {senClauses.Count}\");\n",
+    "Console.WriteLine($\"  Pairs de liberte: voter0->(A,C), voter1->(B,C)\");\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "var senWatch = System.Diagnostics.Stopwatch.StartNew();\n",
+    "var (senSat, senModel) = DpllSolver.Solve(senClauses, senEnc.NVariables);\n",
+    "senWatch.Stop();\n",
+    "Console.WriteLine($\"Resultat DPLL    : {(senSat ? \"SAT\" : \"UNSAT (Sen verifie)\")} en {senWatch.Elapsed.TotalMilliseconds:F1} ms\");\n",
+    "if (!senSat)\n",
+    "    Console.WriteLine(\"=> Liberte minimale + Pareto + transitivite = IMPOSSIBLE (theoreme de Sen)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sen-tranche2-2",
+   "metadata": {},
+   "source": [
+    "**Interpretation du theoreme de Sen.** L'encodage produit **moins de clauses** que celui d'Arrow (transitivite + Pareto + liberte remplacent IIA + non-dictature qui sont quadratiques en profils). Le resultat UNSAT confirme le theoreme : on ne peut pas avoir simultanement le respect des droits individuels minimaux, l'efficacite collective (Pareto) et la coherence du classement social (transitivite).\n",
+    "\n",
+    "> **Pourquoi Sen est \"plus fort\" qu'Arrow.** Le theoreme de Sen ne requiert **pas** l'axiome IIA (Independance of Irrelevant Alternatives), souvent critique comme trop restrictif. Le conflit entre liberte et coherence collective est donc **plus fondamental** que le conflit entre coherence et non-dictature mis en lumiere par Arrow. Donner des droits individuels meme minimaux mene a l'incoherence collective."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sen-tranche2-3",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Benchmark structurel : Arrow vs Sen\n",
+    "\n",
+    "La ou le notebook Python compare plusieurs solveurs CDCL (Glucose3, MiniSat22, CaDiCaL), le twin C# dispose d'un seul solveur (DPLL from-scratch, Prong B #3801). Le benchmark pertinent ici est **structurel** : comparer la taille de l'encodage Arrow vs Sen sur la meme instance (3 alternatives, 2 votants) pour comprendre pourquoi Sen est computationnellement plus parcimonieux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "sen-tranche2-4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:04:46.693728Z",
+     "iopub.status.busy": "2026-07-07T23:04:46.693513Z",
+     "iopub.status.idle": "2026-07-07T23:04:46.812241Z",
+     "shell.execute_reply": "2026-07-07T23:04:46.812051Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BENCHMARK STRUCTUREL : ARROW vs SEN (3 alt, 2 voters)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==========================================================\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    Theoreme    Profils     Vars    Clauses            Verdict   DPLL(ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       Arrow         36      216       2226      UNSAT (Arrow)        0.8\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         Sen         36      216        558        UNSAT (Sen)        0.1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ratio clauses Arrow/Sen : 4.0x\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Sen remplace IIA (quadratique en profils) + non-dictature par une seule\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   contrainte de liberte lineaire => encodage beaucoup plus compact.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Benchmark structurel Arrow vs Sen (3 alt, 2 voters) ===\n",
+    "Console.WriteLine(\"BENCHMARK STRUCTUREL : ARROW vs SEN (3 alt, 2 voters)\");\n",
+    "Console.WriteLine(\"=\".PadRight(58, '='));\n",
+    "Console.WriteLine();\n",
+    "\n",
+    "// Arrow\n",
+    "var arrEnc = new ArrowSATEncoder(new List<string>{\"A\",\"B\",\"C\"}, 2);\n",
+    "var arrClauses = arrEnc.EncodeAll();\n",
+    "var arrStats = arrEnc.Stats();\n",
+    "var arrWatch = System.Diagnostics.Stopwatch.StartNew();\n",
+    "var (arrSat, _) = DpllSolver.Solve(arrClauses, arrStats[\"variables\"]);\n",
+    "arrWatch.Stop();\n",
+    "\n",
+    "// Sen\n",
+    "var senBenc = new SenSATEncoder(new List<string>{\"A\",\"B\",\"C\"}, 2, liberty);\n",
+    "var senBclauses = senBenc.EncodeAll();\n",
+    "var senBwatch = System.Diagnostics.Stopwatch.StartNew();\n",
+    "var (senBsat, _) = DpllSolver.Solve(senBclauses, senBenc.NVariables);\n",
+    "senBwatch.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"{\"Theoreme\",12} {\"Profils\",10} {\"Vars\",8} {\"Clauses\",10} {\"Verdict\",18} {\"DPLL(ms)\",10}\");\n",
+    "Console.WriteLine(\"-\".PadRight(58, '-'));\n",
+    "Console.WriteLine($\"{\"Arrow\",12} {arrStats[\"profiles\"],10} {arrStats[\"variables\"],8} {arrClauses.Count,10} {(arrSat?\"SAT\":\"UNSAT (Arrow)\"),18} {arrWatch.Elapsed.TotalMilliseconds,10:F1}\");\n",
+    "Console.WriteLine($\"{\"Sen\",12} {arrStats[\"profiles\"],10} {senBenc.NVariables,8} {senBclauses.Count,10} {(senBsat?\"SAT\":\"UNSAT (Sen)\"),18} {senBwatch.Elapsed.TotalMilliseconds,10:F1}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"Ratio clauses Arrow/Sen : {(double)arrClauses.Count/senBclauses.Count:F1}x\");\n",
+    "Console.WriteLine(\"=> Sen remplace IIA (quadratique en profils) + non-dictature par une seule\");\n",
+    "Console.WriteLine(\"   contrainte de liberte lineaire => encodage beaucoup plus compact.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sen-tranche2-5",
+   "metadata": {},
+   "source": [
+    "**Analyse du benchmark structurel.**\n",
+    "\n",
+    "| Aspect | Arrow | Sen |\n",
+    "|--------|-------|-----|\n",
+    "| Axiomes | totalite + asymetrie + transitivite + Pareto + **IIA + non-dictature** | totalite + asymetrie + transitivite + Pareto + **liberte minimale** |\n",
+    "| Source de la complexite | IIA est **quadratique** en nombre de profils (compare toutes paires de profils) | liberte est **lineaire** (une clause par paire assignee par profil) |\n",
+    "| Verdict | UNSAT | UNSAT |\n",
+    "\n",
+    "L'encodage de Sen est typiquement **3-4x plus compact** en clauses que celui d'Arrow sur la meme instance, car l'axiome IIA -- qui compare chaque paire de profils partageant le meme ordre sur une paire d'alternatives -- genere un nombre de clauses quadratique en le nombre de profils. La liberte minimale, elle, n'ajoute qu'une clause unitaire par paire de liberte par profil.\n",
+    "\n",
+    "> **Limite du DPLL from-scratch (Prong B #3801, verdict honnete).** Sans apprentissage de clauses (clause-learning CDCL), DPLL explore un arbre de branchement exponentiel. Sur ces instances modestes (216 variables), le UNSAT est trouve en temps raisonnable, mais le passage a l'echelle (4+ alternatives ou 3+ votants) devient prohibitif. Les solveurs CDCL industriels (Glucose, CaDiCaL) gerent ces tailles grace a l'apprentissage de clauses et aux heuristiques VSIDS. La couverture SMT via Microsoft.Z3 (NuGet) est l'extension naturelle pour les instances plus larges (cf. Python original Partie 2)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a84aabff",
    "metadata": {},
    "source": [
@@ -1122,14 +1496,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "7d0146e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T20:09:14.179706Z",
-     "iopub.status.busy": "2026-07-07T20:09:14.179453Z",
-     "iopub.status.idle": "2026-07-07T20:09:14.269136Z",
-     "shell.execute_reply": "2026-07-07T20:09:14.268446Z"
+     "iopub.execute_input": "2026-07-07T23:04:46.813560Z",
+     "iopub.status.busy": "2026-07-07T23:04:46.813373Z",
+     "iopub.status.idle": "2026-07-07T23:04:46.858353Z",
+     "shell.execute_reply": "2026-07-07T23:04:46.858126Z"
     }
    },
    "outputs": [],


### PR DESCRIPTION
## SC-04-CSharp tranche 2 — Sen theorem encoder + Arrow-vs-Sen benchmark

Suite de #5677 (tranche 1 : DPLL solver + Arrow UNSAT). Étend le twin C# du notebook Python [`04-Computational-Aggregation-SAT-Z3.ipynb`](../blob/main/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb) avec deux sections supplémentaires (marathon #4956, contribution partielle).

### Section 5 — Théorème de Sen
`SenSATEncoder` (port C# from-scratch, BCL .NET 9, **0 NuGet**, Prong B #3801) encode : totalité + asymétrie + transitivité + Pareto + **liberté minimale**. L'axiome de liberté remplace IIA + non-dictature (chaque votant décide seul d'une paire d'alternatives).

- **Résultat** : 216 variables / **558 clauses** → **UNSAT en 0.1 ms** (théorème de Sen vérifié).
- **Bit-faithful Python** : 558 clauses identiques au `SenSATEncoder` Python (cell 23).
- Interprétation : Sen est « plus fort » qu'Arrow car ne requiert pas IIA.

### Section 6 — Benchmark structurel Arrow vs Sen
Le twin C# dispose d'un seul solveur (DPLL from-scratch), pas des 3 solveurs CDCL du Python (Glucose3/MiniSat22/CaDiCaL). Le benchmark pertinent est donc **structurel** : comparer la taille des encodages sur la même instance (3 alt, 2 voters).

| Théorème | Profils | Vars | Clauses | Verdict | DPLL (ms) |
|----------|---------|------|---------|---------|-----------|
| Arrow | 36 | 216 | 2226 | UNSAT | 0.8 |
| Sen | 36 | 216 | 558 | UNSAT | 0.1 |

**Ratio Arrow/Sen : 4.0x.** Sen est 4x plus compact car la contrainte de liberté est **linéaire** (une clause unitaire par paire assignée par profil) alors que IIA est **quadratique** en nombre de profils (compare toutes paires de profils).

### Verdict honnête Prong B (#3801)
DPLL from-scratch sans apprentissage de clauses (clause-learning CDCL). Sur ces instances modestes (216 variables), l'UNSAT est trouvé en <1 ms, mais le passage à l'échelle (4+ alternatives, 3+ votants) devient prohibitif. Les solveurs CDCL industriels gèrent ces tailles grâce à l'apprentissage de clauses + heuristiques VSIDS. **Tranche 3 future** : couverture SMT via Microsoft.Z3 (NuGet) pour les instances plus larges (cf. Python original Partie 2).

### Forensic H.5 — EXEC_PROVED
Kernel `.net-csharp` local (règle F, nbconvert `--execute --inplace`). **10 code cells, ec=1-10 contigus, 0 erreur, 0 pattern C.1-forbidden** (`raise`/`throw`/`assert`/`1/0`), 0 emoji, 0 path-leak, **CRLF=0** (L268 #5005 normalisé), trailing newline préservé. **Tranche 1 préservée** : Arrow UNSAT (216v/2226c) et cas 2-alt UNSAT (8v/14c) intacts après re-exécution complète.

### Math-Verification firsthand (concordance Python)
- Sen 3 alt / 2 voters : **558 clauses** (= Python cell 23) → UNSAT ✓
- Arrow 3 alt / 2 voters : 2226 clauses (= Python) → UNSAT ✓
- Ratio Arrow/Sen clauses : **4.0x** (cohérent avec IIA quadratique vs liberté linéaire)

See #4956 (marathon parité .NET ⇄ Python, contribution partielle SC-04 tranche 2).

Co-Authored-By: Claude <noreply@anthropic.com>
