### PR TITLE
docs(gametheory): SocialChoice README — add missing SC-04 C# twin row (#5661 §E)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md
@@ -23,10 +23,11 @@ Cette sous-série du parcours [GameTheory](../README.md) explore ces résultats 
 | SC-03 | [03-Voting-Methods](03-Voting-Methods.ipynb) | Méthodes de Vote et Paradoxes (Condorcet, Borda, Copeland, Downs) | 35 min | COMPLET |
 | SC-03 (C#) | [03-Voting-Methods-Csharp](03-Voting-Methods-Csharp.ipynb) | **Jumeau C#** — parité .NET du SC-03 (méthodes de vote) implémenté from-scratch en C# (.NET Interactive) (See #4956) | 35 min | PARITÉ |
 | SC-04 | [04-Computational-Aggregation-SAT-Z3](04-Computational-Aggregation-SAT-Z3.ipynb) | Agrégation Computationnelle : SAT et Z3 | 45 min | COMPLET |
+| SC-04 (C#) | [04-Computational-Aggregation-SAT-Z3-Csharp](04-Computational-Aggregation-SAT-Z3-Csharp.ipynb) | **Jumeau C#** — parité .NET du SC-04 (agrégation SAT/Z3) implémenté from-scratch en C# (.NET Interactive) (See #4956) | 45 min | PARITÉ |
 
 **Durée totale** : ~3h25
 
-> **Parité .NET** : les notebooks [01-Arrow-Impossibility-Theorem-Csharp.ipynb](01-Arrow-Impossibility-Theorem-Csharp.ipynb) (jumeau du SC-01) et [03-Voting-Methods-Csharp.ipynb](03-Voting-Methods-Csharp.ipynb) (jumeau du SC-03) sont les miroirs C# (.NET Interactive) des originaux Python — mêmes algorithmes implémentés from-scratch en C#. Marathon parité .NET ⇄ Python (#4956). Ils ne sont pas comptés dans le `pedagogical_count` (ce sont des miroirs de parité, pas des notebooks pédagogiques distincts).
+> **Parité .NET** : les notebooks [01-Arrow-Impossibility-Theorem-Csharp.ipynb](01-Arrow-Impossibility-Theorem-Csharp.ipynb) (jumeau du SC-01), [03-Voting-Methods-Csharp.ipynb](03-Voting-Methods-Csharp.ipynb) (jumeau du SC-03) et [04-Computational-Aggregation-SAT-Z3-Csharp.ipynb](04-Computational-Aggregation-SAT-Z3-Csharp.ipynb) (jumeau du SC-04) sont les miroirs C# (.NET Interactive) des originaux Python — mêmes algorithmes implémentés from-scratch en C#. Marathon parité .NET ⇄ Python (#4956). Ils ne sont pas comptés dans le `pedagogical_count` (ce sont des miroirs de parité, pas des notebooks pédagogiques distincts).
 
 ## Parcours d'apprentissage
 


### PR DESCRIPTION
## §E whole-file audit — GameTheory/SocialChoice/README.md feuille (item #5661)

### Drift firsthand (§E gate : disk ↔ CATALOG-STATUS ↔ prose)
`find ... SocialChoice -name '*.ipynb'` = **7 notebooks sur disque** :
- 01-Arrow-Impossibility-Theorem (Python, SC-01)
- 01-Arrow-Impossibility-Theorem-Csharp (C# twin)
- 02-Lean-SocialChoice-Formal (Lean, SC-02)
- 03-Voting-Methods (Python, SC-03)
- 03-Voting-Methods-Csharp (C# twin)
- 04-Computational-Aggregation-SAT-Z3 (Python, SC-04)
- **04-Computational-Aggregation-SAT-Z3-Csharp (C# twin)** ← absent du tableau README

**CATALOG-STATUS** : `pedagogical_count: 4, breakdown: SocialChoice=4` (concordant — 4 primaires, twins exclus par design).
**Prose** : « quatre notebooks » (concordant — compte pédagogique primaire).
**Tableau README** : 6 lignes (manquait la ligne du twin C# SC-04) → **drift table↔disk**.

### Vérif du twin manquant (G.1, sur origin/main)
`git ls-tree origin/main` confirme `04-Computational-Aggregation-SAT-Z3-Csharp.ipynb` **MERGED** (pas une PR ouverte). Forensic : kernel `.net-csharp`, 8/8 code cells `execution_count` non-null (EXEC_PROVED), utilise SAT/Z3. Twin légitime du marathon #4956, simplement omis du tableau lors de son ajout.

### Fix (atomique +2/−1)
1. **+1 ligne tableau** : `| SC-04 (C#) | [04-Computational-Aggregation-SAT-Z3-Csharp](...) | Jumeau C# — parité .NET du SC-04 (agrégation SAT/Z3) ... (See #4956) | 45 min | PARITÉ |` — cohérent avec les lignes existantes SC-01 (C#) / SC-03 (C#).
2. **Note « Parité .NET »** étendue : « 01-C#, 03-C# **et 04-C#** » (citàit les 3 twins, pas seulement 2).

### Reconciliation post-fix
- disk = 7 ↔ tableau = 7 ✓
- CATALOG-STATUS pedagogical_count = 4 (inchangé, byte-identical) ✓
- prose « quatre notebooks » = 4 primaires ✓
- Les 3 sources s'alignent.

### Conformité
- catalog-pr-hygiene R1 ✓ (bloc HTML `<!-- CATALOG-STATUS -->` byte-identical, seul le tableau + la note édités)
- R2 ✓ (branche fraîche depuis `origin/main` `aebdd30ea`)
- R3 ✓ (atomique, 1 fichier, 1 sujet, +2/−1)
- L268 ✓ (pas de CRLF)
- readme-french-first ✓ (prose FR préservée, pas de nouvelle doc EN)

Part of #5661 (item GameTheory/SocialChoice — 1 des 8+ items de l'issue, contribution partielle).
See #3975 (rollout §E), See #4956 (marathon parité .NET ⇄ Python).
