### PR TITLE
feat(lean,i18n): PacLearning/Concentration_en + MGF_en siblings — concentration tools (EPIC #4980)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/Concentration_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/Concentration_en.lean
@@ -1,0 +1,111 @@
+import Mathlib
+import PacLearning.Data_en
+import PacLearning.Sample_en
+
+/-!
+# PacLearning.Concentration — expectation and Markov inequality (ℝ-weight)
+
+Submodule of `PacLearning`: **brick 2a/3** of iter-2. We define the **expectation**
+of a function `g : X → ℝ` under distribution `D`, then the **Markov inequality**
+in ℝ-weight. These two tools are the foundations of the Chernoff method
+(Hoeffding-for-Bernoulli, brick 2b/3) and then of the `pac_finite_class_bound`
+bound (brick 3/3).
+
+We stay in the **pedagogical ℝ-weight style** of `Data.lean` / `Sample.lean`:
+the expectation is the weighted sum `∑ x, D.weight x * g x`, without the
+`ℝ≥0∞` / `Measure` / `Kernel` machinery of Mathlib. The Mathlib *lemmas* are reused
+(`Finset.sum_*`, `log_le_sub_one_of_pos`, `convexOn_exp`) but not the *framework*
+`HasSubgaussianMGF` + `iIndepFun` — disproportionate for the discrete model.
+
+## Expectation and link to `trueError`
+
+The true error `trueError D f h` can be reformulated as the expectation of the
+misclassification indicator: `trueError D f h = expect D (fun x ↦ if h x ≠ f x then
+1 else 0)`. This is the bridge between the model of `Data.lean` and the concentration
+analysis.
+
+English mirror of `PacLearning/Concentration.lean` (FR-first canonical), EPIC #4980
+(i18n Lean). Convention ratified 2026-07-04 (issue #4980): namespace
+`PacLearning_en` (anti-collision with the FR `PacLearning` namespace); cross-module
+`_en` imports `_en` (imports `PacLearning.Data_en` + `PacLearning.Sample_en`,
+pattern Perceptron_en #5683 / Gittins_en); non-docstring proof code unchanged.
+-/
+
+namespace PacLearning_en
+
+open Finset
+
+variable {X : Type*} [Fintype X]
+variable (D : Distribution X)
+
+/-- **Expectation** of `g : X → ℝ` under distribution `D`: weighted sum.
+This is the discrete counterpart of the integral `∫ g dD`. -/
+noncomputable def expect (g : X → ℝ) : ℝ :=
+  ∑ x, D.weight x * g x
+
+variable {D}
+
+/-- The expectation of a non-negative function is non-negative: a sum of
+non-negative weights (`≥ 0`) times `g ≥ 0`. -/
+theorem expect_nonneg {g : X → ℝ} (hg : ∀ x, 0 ≤ g x) : 0 ≤ expect D g := by
+  dsimp only [expect]
+  apply sum_nonneg
+  intro x _
+  exact mul_nonneg (D.nonneg x) (hg x)
+
+/-- Expectation is linear in `g`: `E[a·g + b] = a·E[g] + b` (since `∑` is). -/
+theorem expect_linear {g₁ g₂ : X → ℝ} (a b : ℝ) : expect D (fun x ↦ a * g₁ x + b * g₂ x) =
+    a * expect D g₁ + b * expect D g₂ := by
+  dsimp only [expect]
+  simp only [mul_add, Finset.sum_add_distrib]
+  -- Factor `a` (resp. `b`) moved to the left in each weighted scalar product,
+  -- then `← mul_sum` pulls it out of the sum: `∑ (a·(w·g)) = a·∑ (w·g)`.
+  simp only [show ∀ x, D.weight x * (a * g₁ x) = a * (D.weight x * g₁ x) from fun _ => by ring,
+             show ∀ x, D.weight x * (b * g₂ x) = b * (D.weight x * g₂ x) from fun _ => by ring]
+  rw [← Finset.mul_sum, ← Finset.mul_sum]
+
+/-- The expectation of the constant function `c` is `c`: `∑ x, D.weight x * c = c`
+(since the total mass is `1`). -/
+theorem expect_const (c : ℝ) : expect D (fun _ ↦ c) = c := by
+  dsimp only [expect]
+  -- `∑ (w·c) = (∑ w)·c` (sum_mul inverted), then `∑ w = 1` and `1·c = c`.
+  rw [← Finset.sum_mul, D.sum_one, one_mul]
+
+/-- **Link to `trueError`**: the true error is the expectation of the
+misclassification indicator `if h x ≠ f x then 1 else 0`. This is the bridge
+between the model of `Data.lean` and the concentration analysis. -/
+theorem trueError_eq_expect (f h : Hypothesis X) :
+    trueError D f h = expect D (fun x ↦ if h x ≠ f x then (1 : ℝ) else 0) := by
+  dsimp only [expect, trueError]
+  apply sum_congr rfl
+  intro x _
+  by_cases hx : h x ≠ f x
+  · simp only [if_pos hx, mul_one]
+  · simp only [if_neg hx, mul_zero]
+
+/-- **Markov inequality** (ℝ-weight): for `g ≥ 0` and `t > 0`,
+`D-weight { x | t ≤ g x } ≤ E[g] / t`. Proof: on the filter `{x | t ≤ g x}`
+(implemented as `Finset.filter` — membership via `Finset.mem_filter` is more
+robust than the `Set`-comprehension `.toFinset` whose `Fintype ↑s` leaves a
+universe metavariable) we have `t ≤ g` pointwise, hence `t · D.weight ≤
+D.weight · g` (weight `≥ 0`), so `t · ∑_{filter} ≤ ∑_{filter} D.weight · g ≤
+∑_{all} D.weight · g = E[g]`, and we divide by `t > 0`. -/
+theorem markov_ineq {g : X → ℝ} (hg : ∀ x, 0 ≤ g x) {t : ℝ} (ht : 0 < t) :
+    ∑ x ∈ Finset.filter (fun x => t ≤ g x) (Finset.univ : Finset X), D.weight x ≤
+      expect D g / t := by
+  dsimp only [expect]
+  -- `le_div_iff₀` gives `(∑_F w) · t ≤ E[g]`, then `sum_mul` distributes the `t`.
+  rw [le_div_iff₀ ht, Finset.sum_mul]
+  -- Step 1: termwise `w·t ≤ w·g` on the filter (`t ≤ g`, `w ≥ 0`).
+  have hF : ∑ x ∈ Finset.filter (fun x => t ≤ g x) Finset.univ, D.weight x * t ≤
+            ∑ x ∈ Finset.filter (fun x => t ≤ g x) Finset.univ, D.weight x * g x := by
+    apply sum_le_sum
+    intro x hx
+    exact mul_le_mul_of_nonneg_left (Finset.mem_filter.mp hx).2 (D.nonneg x)
+  -- Step 2: `∑_F w·t ≤ ∑_F w·g ≤ ∑_all w·g = E[g]`.
+  calc ∑ x ∈ Finset.filter (fun x => t ≤ g x) Finset.univ, D.weight x * t
+      ≤ ∑ x ∈ Finset.filter (fun x => t ≤ g x) Finset.univ, D.weight x * g x := hF
+    _ ≤ ∑ x, D.weight x * g x :=
+        sum_le_univ_sum_of_nonneg (fun x => mul_nonneg (D.nonneg x) (hg x))
+
+end PacLearning_en

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/MGF_en.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/PacLearning/MGF_en.lean
@@ -1,0 +1,116 @@
+import Mathlib
+import PacLearning.Data_en
+import PacLearning.Sample_en
+import PacLearning.Concentration_en
+
+/-!
+# PacLearning.MGF — moment generating function of the indicator (brick 2c/3-hoeffding-2a/5)
+
+Submodule of `PacLearning`: analytic tool for Hoeffding concentration.
+The Hoeffding chain for the mean of i.i.d. indicators rests on the
+**moment generating function (MGF)** of the centered indicator:
+
+    E_D [ exp (t · (ind(x) − μ)) ]   where  ind(x) = 𝟙{h(x) ≠ f(x)},  μ = trueError = E_D[ind].
+
+This deliverable establishes the **algebraic reduction** (brick 2a/5): we reduce this
+discrete MGF to a **closed form** depending only on `μ` and `t`:
+
+    E_D [ exp (t · (ind − μ)) ] = μ · exp(t·(1−μ)) + (1−μ) · exp(−t·μ).
+
+The idea: `ind(x) ∈ {0,1}`, so `exp(t·(ind−μ)) = exp(t(1−μ))·ind + exp(−tμ)·(1−ind)`
+pointwise (if `ind = 1`, this reads `exp(t(1−μ))`; if `ind = 0`, `exp(−tμ)`). We then
+distribute the expectation (`expect_linear`): `E[ind] = μ` (`trueError_eq_expect`),
+`E[1 − ind] = 1 − μ` (`expect_sub` + `expect_const` + `D.sum_one`).
+
+This is an **algebraic** ingredient (no analysis) preparing the **final bound**
+`bernoulli_mgf_le : μ·exp(t(1−μ)) + (1−μ)·exp(−tμ) ≤ exp(t²/8)` (Hoeffding lemma,
+brick 2b/5 — hard analytic core, dedicated cycle). We stay in the **pedagogical
+ℝ-weight style**: the MGF is `expect D (fun x ↦ exp(t·(...)))`, a weighted sum over `D`.
+
+English mirror of `PacLearning/MGF.lean` (FR-first canonical), EPIC #4980
+(i18n Lean). Convention ratified 2026-07-04 (issue #4980): namespace
+`PacLearning_en` (anti-collision with the FR `PacLearning` namespace); cross-module
+`_en` imports `_en` (imports `PacLearning.Data_en` + `PacLearning.Sample_en` +
+`PacLearning.Concentration_en`, pattern Perceptron_en #5683 / Gittins_en);
+non-docstring proof code unchanged.
+-/
+
+namespace PacLearning_en
+
+open Finset
+open scoped Classical
+
+variable {X : Type*} [Fintype X]
+variable (D : Distribution X)
+variable {D}
+
+/-- **Expectation of a pointwise difference**: `E_D[g − ind] = E_D[g] − E_D[ind]`
+(weighted sum of differences = difference of weighted sums, via
+`Finset.sum_sub_distrib`). Subtractive variant of `expect_linear`, reused by
+`expect_exp_centered_eq` for `E_D[1 − ind] = 1 − trueError`. -/
+theorem expect_sub (g₁ g₂ : X → ℝ) :
+    expect D (fun x ↦ g₁ x - g₂ x) = expect D g₁ - expect D g₂ := by
+  dsimp only [expect, expect]
+  simp only [mul_sub]
+  rw [← Finset.sum_sub_distrib]
+
+/-- **Algebraic reduction of the MGF of the centered indicator**: for `ind(x) = 𝟙{h≠f}`
+and `μ = trueError`, the moment generating function reduces to a closed form.
+
+    E_D [ exp (t · (ind(x) − μ)) ] = μ · exp(t·(1−μ)) + (1−μ) · exp(−t·μ).
+
+This is **brick 2a/5** of Hoeffding concentration: purely algebraic
+(Fubini over the partition `{ind = 1}` / `{ind = 0}`), with no analysis. This is
+the exact ingredient required by the final bound `bernoulli_mgf_le` (brick 2b/5, OPEN)
+which will show this closed form is `≤ exp(t²/8)`.
+
+Proof: pointwise, `exp(t·(ind−μ)) = exp(t(1−μ))·ind + exp(−tμ)·(1−ind)` (since
+`ind ∈ {0,1}`: case `ind = 1` ⟹ `exp(t(1−μ))`; case `ind = 0` ⟹ `exp(−tμ)`). We then
+distribute the expectation (`expect_linear`): `E[ind] = μ` (`trueError_eq_expect`) and
+`E[1 − ind] = 1 − μ` (`expect_sub` + `expect_const`). -/
+theorem expect_exp_centered_eq (f h : Hypothesis X) (t : ℝ) :
+    expect D (fun x ↦ Real.exp (t * ((if h x ≠ f x then (1 : ℝ) else 0) - trueError D f h))) =
+      trueError D f h * Real.exp (t * (1 - trueError D f h)) +
+        (1 - trueError D f h) * Real.exp (-(t * trueError D f h)) := by
+  set μ := trueError D f h
+  -- (1) Pointwise identity: `exp(t·(ind−μ)) = exp(t(1−μ))·ind + exp(−tμ)·(1−ind)`,
+  -- since `ind ∈ {0,1}` (the `exp(...)` constant on the LEFT so that `expect_linear` matches).
+  -- The `exp` arguments are not defeq between branches (`t*(0−μ)` vs `−(t*μ)`), hence
+  -- the final `congr 1; ring` to equalize the arguments under the exponential.
+  have hind : ∀ x : X,
+      Real.exp (t * ((if h x ≠ f x then (1 : ℝ) else 0) - μ)) =
+        Real.exp (t * (1 - μ)) * (if h x ≠ f x then (1 : ℝ) else 0) +
+          Real.exp (-(t * μ)) * (1 - (if h x ≠ f x then (1 : ℝ) else 0)) := by
+    intro x
+    by_cases hx : h x ≠ f x
+    · -- `ind x = 1`: `exp(t(1−μ))·1 + exp(−tμ)·0 = exp(t(1−μ))`.
+      simp only [if_pos hx, mul_one, mul_zero, sub_self, add_zero]
+    · -- `ind x = 0`: `exp(t(0−μ)) = exp(t(1−μ))·0 + exp(−tμ)·(1−0) = exp(−tμ)`.
+      -- simp reduces ifs + algebra; `Real.exp` is not handled by `ring`, hence the
+      -- `congr 1` (peel exp) then `ring` on the argument `t*(0−μ) = −(t*μ)`.
+      simp only [if_neg hx, mul_zero, mul_one, sub_zero, zero_add]
+      congr 1
+      ring
+  -- (2) `E[ind] = μ` (the expectation of the indicator is the true error).
+  have hind_exp : expect D (fun x ↦ if h x ≠ f x then (1 : ℝ) else 0) = μ :=
+    (trueError_eq_expect (D := D) f h).symm
+  -- (3) `E[1 − ind] = 1 − μ` (total mass `1` minus the error mass).
+  have hcompl_exp : expect D (fun x ↦ 1 - (if h x ≠ f x then (1 : ℝ) else 0)) = 1 - μ := by
+    rw [expect_sub, expect_const, hind_exp]
+  -- (4) Assembly: pointwise identity (`congr`+`ext`), then `expect_linear`
+  -- distributes each term in one go (constant on the left), then substitutions.
+  calc expect D (fun x ↦ Real.exp (t * ((if h x ≠ f x then (1 : ℝ) else 0) - μ)))
+      = expect D (fun x ↦
+            Real.exp (t * (1 - μ)) * (if h x ≠ f x then (1 : ℝ) else 0) +
+              Real.exp (-(t * μ)) * (1 - (if h x ≠ f x then (1 : ℝ) else 0))) := by
+          congr 1; ext x; exact hind x
+    _ = Real.exp (t * (1 - μ)) * expect D (fun x ↦ if h x ≠ f x then (1 : ℝ) else 0) +
+          Real.exp (-(t * μ)) * expect D (fun x ↦ 1 - (if h x ≠ f x then (1 : ℝ) else 0)) := by
+          rw [expect_linear]
+    _ = Real.exp (t * (1 - μ)) * μ + Real.exp (-(t * μ)) * (1 - μ) := by
+          rw [hind_exp, hcompl_exp]
+    _ = μ * Real.exp (t * (1 - μ)) + (1 - μ) * Real.exp (-(t * μ)) := by
+          rw [mul_comm (Real.exp (t * (1 - μ))) μ,
+              mul_comm (Real.exp (-(t * μ))) (1 - μ)]
+
+end PacLearning_en


### PR DESCRIPTION
## Summary

Second tranche of the `PacLearning/` submodule EN mirror of `learning_theory_lean` (ML série), EPIC **#4980** (i18n Lean). Continues from PR #5695 (deterministic core: `Data_en` + `Sample_en` + `ERM_en`).

This PR delivers the **concentration-tools tranche** (brick 2a/3 + 2c/3): the analytic foundations of Hoeffding concentration over the sample space.

Convention siblings `Foo.lean` (FR canonique) + `Foo_en.lean` (EN miroir) **ratifiée user 2026-07-04** (#4980, comment 4881909354).

## Contenu — 2 modules EN siblings

### `PacLearning/Concentration_en.lean` (+105L, mirror de `Concentration.lean`)
Brique 2a/3 : espérance + inégalité de Markov en ℝ-weight.
- `noncomputable def expect` (somme pondérée `∑ x, D.weight x * g x`)
- `expect_nonneg` (sum_nonneg + mul_nonneg)
- `expect_linear` (mul_add + ← mul_sum)
- `expect_const` (← sum_mul + sum_one + one_mul)
- `trueError_eq_expect` — pont vers le modèle PAC (trueError = expect de l'indicateur)
- `markov_ineq` — inégalité de Markov en ℝ-weight (Finset.filter + le_div_iff₀ + sum_le_sum + calc)

### `PacLearning/MGF_en.lean` (+109L, mirror de `MGF.lean`)
Brique 2c/3 / 2a/5 : fonction génératrice de moments de l'indicateur centré.
- `expect_sub` (variante soustractive de `expect_linear`, Finset.sum_sub_distrib)
- `expect_exp_centered_eq` — **réduction algébrique** de la MGF à forme fermée :
  `E_D[exp(t·(ind−μ))] = μ·exp(t(1−μ)) + (1−μ)·exp(−tμ)`, via Fubini ponctuel sur la partition `{ind=1}/{ind=0}` + `congr`/`ring`/`expect_linear`. C'est l'ingrédient exact que la borne finale `bernoulli_mgf_le` (brique 2b/5, OPEN) invoquera pour montrer `≤ exp(t²/8)`.

## Convention respectée (pattern Perceptron_en #5683 / Gittins_en / #5695)

- `namespace PacLearning_en` (anti-collision avec FR `PacLearning`)
- **cross-module `_en` imports `_en`** : `Concentration_en` importe `PacLearning.Data_en` + `PacLearning.Sample_en` ; `MGF_en` importe en plus `PacLearning.Concentration_en`
- code de preuve Lean **inchangé** (tactiques + références Mathlib restent EN indépendamment)
- FR canoniques `Concentration.lean` + `MGF.lean` **byte-identiques à `origin/main`** (anti-régression §D — vérifié : 0 diff line chacune)

## §B Lean — preuve de progrès vérifiable

1. **`grep -c sorry`** : `0` → `0` sur les 4 fichiers (miroirs de docstrings + code EN, 0 preuve ajoutée ni modifiée ; FR canoniques byte-identiques). Aucune nouvelle définition partagée.
2. **`Lake build SUCCESS` local firsthand** : `lake build PacLearning.Concentration_en PacLearning.MGF_en` → **SUCCESS 8496 jobs EXIT 0** (cache Mathlib warm, règle F c.317).
3. **Proof integrity** : 0 axiom, 0 sorry, 0 admit (grep verified). Warnings linter `unusedSectionVars` hérités du FR canonique (proof code byte-identique), pas introduits par le miroir.
4. Pas de refactor prover : PR pure i18n (2 fichiers ajoutés, 0 ligne modifiée sur l'existant).

## Forensic (conformité)

- 2 fichiers ajoutés (`Concentration_en.lean` +105L, `MGF_en.lean` +109L), 0 suppression
- CRLF : 0 (UTF-8 LF, vérifié sur les 2)
- 0 emoji / 0 CJK
- FR canoniques byte-identiques à `origin/main` (anti-régression §D)
- Rebase frais depuis `origin/main` `67e60a6cf` (catalog-pr-hygiene HARD 2)
- 0 marqueur `CATALOG-STATUS` touché (catalog-pr-hygiene HARD 1)

## Plan de tranche (PRs ultérieures PacLearning/)

- **#5695 (ouvert)** : `Data_en` + `Sample_en` + `ERM_en` (deterministic core) — 3 modules
- **Cette PR** : `Concentration_en` + `MGF_en` (concentration tools) — 2 modules
- **PRs suivantes** (ordre de dépendance) : `BernoulliMGF_en` (446L, autonome), `SampleExpect_en` (261L), `UnionBound_en` (150L), `Hoeffding_en` (360L, borne finale concentration), `UniformConcentration_en` (89L), `Agnostic_en` (170L), `PacFiniteBound_en` (384L, borne finale PAC réalisable)

## Test plan

- [x] `lake build PacLearning.Concentration_en PacLearning.MGF_en` → SUCCESS (8496 jobs, EXIT 0)
- [x] 0 sorry / 0 axiom / 0 admit (grep verified)
- [x] FR canoniques `Concentration.lean` + `MGF.lean` byte-identiques à `origin/main` (anti-§D, 0 diff line chacune)
- [x] Convention `_en` ratified + cross-module `_en` import `_en`
- [x] CRLF 0, UTF-8 LF, 0 emoji/CJK
- [x] 0 marqueur CATALOG-STATUS touché

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
