### PR TITLE
feat(sudoku): Sudoku-13 Exercice 3 — palindrome recursif (?&rec) (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
@@ -84,10 +84,10 @@
    "id": "739ddb62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.552438Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.552248Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.571003Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.570575Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.780591Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.780591Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.791486Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.791486Z"
     },
     "papermill": {
      "duration": 0.022668,
@@ -194,10 +194,10 @@
    "id": "38b99e2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.584864Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.584452Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.588790Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.588392Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.791486Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.791486Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.796412Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.796412Z"
     },
     "papermill": {
      "duration": 0.00811,
@@ -273,10 +273,10 @@
    "id": "c4eff3f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.597020Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.596768Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.599690Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.599249Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.796412Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.796412Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.800280Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.800280Z"
     },
     "papermill": {
      "duration": 0.005872,
@@ -332,10 +332,10 @@
    "id": "7581d1df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.608349Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.608186Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.674624Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.674161Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.800280Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.800280Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.855621Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.855621Z"
     },
     "papermill": {
      "duration": 0.06938,
@@ -351,7 +351,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Resolution Z3 : sat en 41.1 ms\n",
+      "Resolution Z3 : sat en 34.7 ms\n",
       "Grille solution :\n",
       "  5 3 4 6 7 8 9 1 2\n",
       "  6 7 2 1 9 5 3 4 8\n",
@@ -441,10 +441,10 @@
    "id": "c87338d8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.684117Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.683917Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.687250Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.686897Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.855621Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.855621Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.860311Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.860311Z"
     },
     "papermill": {
      "duration": 0.006713,
@@ -499,10 +499,10 @@
    "id": "2742fd4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.697135Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.696769Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.704787Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.704378Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.860311Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.860311Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.868414Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.868414Z"
     },
     "papermill": {
      "duration": 0.011257,
@@ -577,10 +577,10 @@
    "id": "8cd6348c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.714425Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.714188Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.726089Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.725644Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.868414Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.868414Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.881101Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.881101Z"
     },
     "papermill": {
      "duration": 0.01544,
@@ -642,6 +642,58 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c328a301",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — palindromes sur {a, b} par récursion `(?&rec)`\n",
+    "\n",
+    "Le module `regex` reconnaît les langages non-réguliers via la **récursion nommée**\n",
+    "`(?&rec)` (illustrée ci-dessus sur $a^n b^n$). Un palindrome est un mot qui se lit\n",
+    "identiquement dans les deux sens ; le langage des palindromes sur $\\{a, b\\}$ est\n",
+    "**non-régulier** mais **algébrique** (context-free), donc exprimable par `(?&rec)`.\n",
+    "\n",
+    "**Objectif** : compléter le motif `palindrome_ab` pour qu'il reconnaisse exactement les\n",
+    "palindromes sur $\\{a, b\\}$ — par ex. `\"abba\"`, `\"aba\"`, `\"aa\"`, `\"a\"`, `\"\"` sont des\n",
+    "palindromes ; `\"ab\"`, `\"aab\"`, `\"ba\"` n'en sont pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c328a302",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-08T04:29:51.881101Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.881101Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.885624Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.885624Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice à compléter : palindrome sur {a,b} via (?&rec).\n",
+      "  attendus vrais : 'abba', 'aba', 'aa', 'a', '' ; faux : 'ab', 'aab', 'ba'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : palindrome sur {a, b} par récursion nommée (?&rec)\n",
+    "# TODO étudiant : remplacer le motif ci-dessous par un vrai palindrome récursif.\n",
+    "# Indice : grammaire  S -> aSa | bSb | a | b | epsilon   (epsilon = cas vide).\n",
+    "# Etape 1 : écrire chaque alternative comme branche de (?P<rec> ... ).\n",
+    "# Etape 2 : rendre la récursion optionnelle pour les cas de base (a, b, chaîne vide).\n",
+    "# Etape 3 : ancrer ^...$ puis vérifier sur les témoins ci-dessous.\n",
+    "palindrome_ab = r\"^[ab]*$\"  # TODO étudiant : motif récursif palindrome (à remplacer)\n",
+    "pal_re = regex.compile(palindrome_ab)\n",
+    "print(\"Exercice à compléter : palindrome sur {a,b} via (?&rec).\")\n",
+    "print(\"  attendus vrais : 'abba', 'aba', 'aa', 'a', '' ; faux : 'ab', 'aab', 'ba'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8a2f13f6",
    "metadata": {
     "papermill": {
@@ -661,14 +713,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "91fc7d83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.735643Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.735460Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.763199Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.762683Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.885624Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.885624Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.916648Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.916087Z"
     },
     "papermill": {
      "duration": 0.03112,
@@ -684,8 +736,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtracking recursif : resolu en 22.4 ms\n",
-      "Z3 (barreau 3)         : resolu en 41.1 ms\n",
+      "Backtracking recursif : resolu en 23.4 ms\n",
+      "Z3 (barreau 3)         : resolu en 34.7 ms\n",
       "Les deux solveurs donnent la meme grille : True\n"
      ]
     }
@@ -747,14 +799,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c9bb7c1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:00:11.773678Z",
-     "iopub.status.busy": "2026-07-06T07:00:11.773489Z",
-     "iopub.status.idle": "2026-07-06T07:00:11.777595Z",
-     "shell.execute_reply": "2026-07-06T07:00:11.777184Z"
+     "iopub.execute_input": "2026-07-08T04:29:51.917671Z",
+     "iopub.status.busy": "2026-07-08T04:29:51.917671Z",
+     "iopub.status.idle": "2026-07-08T04:29:51.921621Z",
+     "shell.execute_reply": "2026-07-08T04:29:51.921108Z"
     },
     "papermill": {
      "duration": 0.007447,
@@ -853,7 +905,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
feat(sudoku): Sudoku-13-SymbolicAutomata-Python — Exercice 3 palindrome recursif (EPIC #2161)

Ajoute un 3e exercice au twin Python Sudoku-13 pour atteindre la convention >= 3
exercices pedagogiques par notebook (EPIC #2161). Le notebook n'avait que 2 exercices
(lookahead intersection, Sudoku-X diagonales) + 4 exemples guides (PCRE monstre,
Z3 resolution, Z3 string theory, backtracking recursif).

### Exercice 3 — palindromes sur {a, b} par recursion nommee `(?&rec)`

Place apres la demo cell 16 (recursion `(?&rec)` du module `regex` sur a^n b^n),
suivant le pattern pedagogique deja etabli : exemple guide -> exercice qui l'etend
(comme Exo 1 etend le lookahead Python, Exo 2 etend la resolution Z3).

L'exercice demande a l'etudiant d'ecrire un motif recursif reconnaissant les
palindromes sur {a, b} — langage non-regulier mais algebrique (context-free),
donc exprimable par `(?&rec)`. Grammaire cible : S -> aSa | bSb | a | b | epsilon.

Stub C.1-conforme (regle user 2026-04-26) :
- AUCUN `raise NotImplementedError` / `assert False` / `1/0`
- `# TODO etudiant` + `# Indice` (grammaire) + `# Etape 1/2/3` (demarche)
- Default `r"^[ab]*$"` qui compile et s'execute (l'etudiant doit le remplacer par le
  vrai motif recursif palindrome)
- `print("Exercice a completer ...")` avec temoins attendus (vrais/faux)
- Le notebook s'execute de bout en bout meme exercice non complete (convention C.1)

### Validation reelle (regle C.2 + H.1)
- Re-execution COMPLETE du notebook via `jupyter nbconvert --execute --inplace --kernel python3`
  (Python 3.11, deps `regex` 2026.2.28 + `z3` 4.16.0 presentes, regle F satisfaite)
- 24 cellules (22 + 2 nouvelles), 10 cellules code TOUTES avec `execution_count` entier
- Cellule Exercice 3 : `execution_count: 8` + output stream (les 2 lignes print)
- C.1 verify : 0 `raise NotImplementedError` / 0 `assert False` / 0 `1/0`
- 0 CRLF (nbconvert Windows en introduit 925 -> strip `replace(b"\r\n", b"\n")`, regle L268)
- 0 source supprime (anti-regression §D verifie : 22 cellules source de main toutes
  presentes, +2 ajoutees ; les -42 du line-diff = purement papermill metadata timestamp
  churn a la re-execution, acceptable C.2)

### Classification par contenu (exercise-example-labeling)
- Cell 8 (Exercice 1 lookahead) = EXERCICE stub, garde
- Cell 10 (resoudre_sudoku_z3) = EXEMPLE solution complete, garde (NE PAS stubber)
- Cell 12 (Exercice 2 Sudoku-X) = EXERCICE stub, garde
- Cells 14/16/18 (Z3 SM string, (?&rec) demo, backtracking) = EXEMPLES, gardes
- Cells 17/18 (nouvel Exercice 3) = EXERCICE stub + markdown context/objectif/indices

Aucun exemple resolu stubbe, aucun exercice resolu, aucun relabel find-replace
(anti-gaming detecteur, regle exercise-example-labeling).

See #2161

Co-Authored-By: Claude <noreply@anthropic.com>
