### PR TITLE
feat(gametheory): GameTheory-1-Setup Exercice 3 - Battle of the Sexes (3 NE) (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -2550,6 +2550,67 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex3-bos-0",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Bataille des Sexes (Battle of the Sexes)\n",
+    "\n",
+    "Deux partenaires (Alice et Bob) veulent passer la soiree ensemble mais preferent des activites differentes : Alice prefere l'Opera, Bob prefere le Football. Tous deux preferent cependant etre ensemble que separes.\n",
+    "\n",
+    "Matrice des gains (Alice = Ligne, Bob = Colonne) :\n",
+    "\n",
+    "|              | Opera (Bob) | Football (Bob) |\n",
+    "|--------------|-------------|----------------|\n",
+    "| **Opera (Alice)**    | (3, 2) | (1, 1) |\n",
+    "| **Football (Alice)** | (0, 0) | (2, 3) |\n",
+    "\n",
+    "Ce jeu se distingue du Stag Hunt et du Chicken Game : il admet **trois** equilibres de Nash (deux en strategies pures, un en strategies mixtes). C'est l'exemple canonique de *jeu de coordination* avec conflit de preferences.\n",
+    "\n",
+    "> **Question** : Combien d'equilibres de Nash ce jeu admet-il ? Identifiez les deux equilibres purs, puis l'equilibre mixte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "ex3-bos-1",
+   "metadata": {},
+   "execution_count": 21,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer : Battle of the Sexes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Bataille des Sexes (Battle of the Sexes)\n",
+    "# Ce jeu admet 3 equilibres de Nash : 2 purs + 1 mixte.\n",
+    "\n",
+    "# Exercice: Definir les matrices de gains A_bos et B_bos (np.array)\n",
+    "# A_bos[i,j] = gain d'Alice, B_bos[i,j] = gain de Bob\n",
+    "# Indice: Alice en lignes [Opera, Football], Bob en colonnes [Opera, Football]\n",
+    "#   (Opera, Opera)       -> Alice 3, Bob 2\n",
+    "#   (Opera, Football)    -> Alice 1, Bob 1\n",
+    "#   (Football, Opera)    -> Alice 0, Bob 0\n",
+    "#   (Football, Football) -> Alice 2, Bob 3\n",
+    "\n",
+    "\n",
+    "# Exercice: Creer le jeu bimatriciel avec nash.Game(A_bos, B_bos)\n",
+    "\n",
+    "\n",
+    "# Exercice: Trouver et afficher TOUS les equilibres de Nash via support_enumeration()\n",
+    "# Indice: il doit y en avoir 3 (deux purs, un mixte).\n",
+    "\n",
+    "\n",
+    "# Question: Identifiez l'equilibre en strategies mixtes.\n",
+    "# Indice: dans l'equilibre mixte, chaque joueur randomise entre Opera et Football\n",
+    "# avec une probabilite strictement comprise entre 0 et 1.\n",
+    "print(\"Exercice a completer : Battle of the Sexes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ff4001f0",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Add a **3rd exercise stub (Battle of the Sexes)** to `GameTheory-1-Setup.ipynb` so it meets the **≥3 exercises per notebook** convention (EPIC #2161, mandate user 2026-06-02).

The notebook previously had 2 exercise stubs (Stag Hunt c57, Chicken Game c62). This PR adds **Exercice 3: Battle of the Sexes** — a 2×2 coordination game with **three Nash equilibria** (2 pure + 1 mixed), extending the single-NE analysis of the first two exercises.

## Pedagogical rationale

| Exercise | Game | Nash equilibria | Concept exercised |
|----------|------|-----------------|-------------------|
| 1 (Stag Hunt) | coordination | 2 pure | pure-strategy NE, payoff-dominance |
| 2 (Chicken) | anti-coordination | 2 pure + 1 mixed | non-zero-sum, swerve vs deviate |
| **3 (BoS, this PR)** | **coordination w/ conflict** | **2 pure + 1 mixed** | **multiple equilibria + identification of the mixed one** |

BoS is the canonical *coordination game with preference conflict* and forces students to confront **equilibrium selection** (3 NE) and identify the mixed-strategy equilibrium via `support_enumeration` — a step up from the single/dual-NE cases. Thematically coherent with §7 "Autres jeux classiques".

## Stub design (rule C.1)

C.1-clean — matches the existing stub style exactly:
- Comments: `# Exercice:` instructions + `# Indice:` hints (preserved per `exercise-example-labeling.md`)
- Only executable line: `print("Exercice a completer : Battle of the Sexes")`
- **No** `raise NotImplementedError` / `assert False` / `1/0`
- Classification by content = **STUB** (no solution leaked; notebook runs end-to-end)

## Execution + validation (H.1-H.5)

- **Re-exec**: nbconvert `--execute --inplace` via `python3` kernel (Python 3.13, full stack: numpy/nashpy/matplotlib/networkx/scipy/pyspiel all present). **0 errors** across all 68 cells. New cell `execution_count=21`, genuine stream output.
- **Surgical diff (C.3)**: pre-existing cells + outputs byte-preserved from `origin/main`. Diff = **61 insertions, 0 deletions** — pure additive, no timestamp/install-status/PNG churn. The new cell's output is its literal `print()` stdout (independently captured, not fabricated — Stop & Repair compliant).
- **Canonical validator PASS**: `validate_pr_notebooks.py` → 1/1 passed (21 code cells).
- **C.1 sweep**: 0 forbidden patterns across all cells.
- **3-exos convention**: now 3 stubs (cells 57, 62, 64) ✓.

## Why this notebook / why now

- Cold: 0 open PRs touch `GameTheory-1-Setup.ipynb` (collision-checked).
- Python3 kernel, light deps, re-executable locally per rule F.
- GameTheory-1-Setup is the **root-series intro** — a natural priority for the ≥3-exercises rollout.

See #2161