### PR TITLE
docs(sm): SmartContracts feuille §E — reconcile Statistiques table (disk/catalog/prose) (#5661)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -603,13 +603,13 @@ maturity: PRODUCTION=27
 
 | Sous-série | Notebooks | Maturité | Contenu clé |
 |------------|-----------|----------|-------------|
-| **00-Foundations** | 4 | PRODUCTION=4, BETA=0 | Cryptographie primitive (hachage, Merkle, signatures, PoW), cypherpunks (Diffie-Hellman, Schnorr, ECDSA), gouvernance distribuée, histoire BTC/ETH |
-| **01-Solidity-Foundation** | 5 | PRODUCTION=5, BETA=0 | Solidity types/contrôles/Storage, héritage, ERC-20/ERC-721/ERC-1155, Foundry/Anvil local, déploiement et tests unitaires |
+| **00-Foundations** | 3 | PRODUCTION=3, BETA=0 | Cryptographie primitive (hachage, Merkle, signatures, PoW), cypherpunks (Diffie-Hellman, Schnorr, ECDSA), gouvernance distribuée, histoire BTC/ETH |
+| **01-Solidity-Foundation** | 4 | PRODUCTION=4, BETA=0 | Solidity types/contrôles/Storage, héritage, ERC-20/ERC-721/ERC-1155, Foundry/Anvil local, déploiement et tests unitaires |
 | **02-Solidity-Advanced** | 5 | PRODUCTION=5, BETA=0 | DeFi (DEX/AMM, lending, oracles), gouvernance DAO (ERC-20 snapshot, Governor Timelock), NFT avancé (royalties, ERC-2981), staking, LLM-assisted contracts |
 | **03-Foundry-Testing** | 3 | PRODUCTION=3, BETA=0 | Fuzzing Foundry (invariant testing, Echidna), tests intégration cross-contrats, **SC-14 vérification formelle (Certora + SMTChecker)** |
-| **04-Privacy-Cryptography** | 4 | PRODUCTION=4, BETA=0 | Zero-Knowledge Proofs (zk-SNARKs Groth16, Plonk, Halo2), chiffrement homomorphe (Paillier, BFV/BGV), vote E2E vérifiable (ElectionGuard, MACI) |
-| **05-Alternative-Chains** | 3 | PRODUCTION=3, BETA=0 | Vyper (alternative EVM), XRP Ledger (modèle UTXO différent), Bitcoin Script (limites intentionnelles), Move (Aptos/Sui resource-oriented), Solana (BPF parallèle) |
-| **06-Real-World** | 3 | PRODUCTION=3, BETA=0 | Cross-chain bridges (atomic swap, IBC, LayerZero), déploiement testnet/mainnet (Goerli/Sepolia), **SC-26 Final Project capstone** |
+| **04-Privacy-Cryptography** | 3 | PRODUCTION=3, BETA=0 | Zero-Knowledge Proofs (zk-SNARKs Groth16, Plonk, Halo2), chiffrement homomorphe (Paillier, BFV/BGV), vote E2E vérifiable (ElectionGuard, MACI) |
+| **05-Alternative-Chains** | 5 | PRODUCTION=5, BETA=0 | Vyper (alternative EVM), XRP Ledger (modèle UTXO différent), Bitcoin Script (limites intentionnelles), Move (Aptos/Sui resource-oriented), Solana (BPF parallèle) |
+| **06-Real-World** | 4 | PRODUCTION=4, BETA=0 | Cross-chain bridges (atomic swap, IBC, LayerZero), déploiement testnet/mainnet (Goerli/Sepolia), **SC-26 Final Project capstone** |
 | **Total** | **27** | **PRODUCTION=27** | Python 3.9+ (web3.py), Solidity ^0.8.x, Foundry stable (forge/anvil/cast), kernel Python 3 (exécution) |
 
 **Note explicite maturité 100% PRODUCTION** : la série SmartContracts est l'une des séries les plus matures du dépôt. Les 27 notebooks sont validés pour exécution locale (Foundry toolchain installée, Anvil local sur port 8545) et déploiement testnet (Goerli/Sepolia via Infura/Alchemy). Le seul prérequis non-Python est Foundry (`curl -L https://foundry.paradigm.xyz | bash` puis `foundryup`) qui installe `forge`/`anvil`/`cast`/`chisel` — toolchain SOTA-OK pour le développement Solidity professionnel.


### PR DESCRIPTION
## Summary

Whole-file **§E audit** (pr-review-discipline §E : reconciliation disque ↔ `CATALOG-STATUS` ↔ prose) du `SmartContracts/README.md` — l'item `SmartContracts/README.md : arbre de structure et table des notebooks incohérents entre eux (sous-dossiers manquants dans l'arbre)` du tracker #5661.

**Correction** : la table **Statistiques catalogue** (l.604-613) portait **5 lignes sur 7 avec des comptes faux**, écrits à la main, en désaccord avec le reste du **même** fichier.

### Réconciliation disque ↔ catalogue ↔ prose (les trois doivent s'aligner)

| Sous-série | table avant | disque / catalogue / arbre / Parties | corrigé |
|------------|-------------|---------------------------------------|---------|
| 00-Foundations | 4 | 3 | **3** |
| 01-Solidity-Foundation | 5 | 4 | **4** |
| 02-Solidity-Advanced | 5 | 5 | 5 |
| 03-Foundry-Testing | 3 | 3 | 3 |
| 04-Privacy-Cryptography | 4 | 3 | **3** |
| 05-Alternative-Chains | 3 | 5 | **5** |
| 06-Real-World | 3 | 4 | **4** |
| **Total** | **27** | **27** | **27** |

Le total faisait 27 avant et après (cohérent avec le marqueur `pedagogical_count: 27`), mais le breakdown par ligne était faux sur 5 lignes. L'**arbre de structure** (l.128-134) et les **7 tables « Partie N »** (l.186-256) étaient **déjà corrects** (3/4/5/3/3/5/4) — seule la table Statistiques avait dérivé.

## Vérification firsthand (G.1)

```
git ls-files MyIA.AI.Notebooks/SymbolicAI/SmartContracts/*.ipynb   -> 27 notebooks
COURSE_CATALOG.generated.json                                      -> 27 entries
  by sous-série (Counter): 00=3, 01=4, 02=5, 03=3, 04=3, 05=5, 06=4
README structure tree (l.128-134)                                  -> 3/4/5/3/3/5/4 ✓
README Partie tables (l.186-256)                                   -> 3/4/5/3/3/5/4 ✓
README Statistiques table (l.604-613) before                       -> 4/5/5/3/4/3/3 ✗ (this PR)
README Statistiques table (l.604-613) after                        -> 3/4/5/3/3/5/4 ✓
```

## Conformité règles

- **§E pr-review-discipline** : audit fichier **entier** (pas seulement la ligne) — vérifié les 4 sources de vérité du fichier (disque, catalogue, arbre de structure, tables Partie). Les 7 tables Partie + l'arbre étaient déjà corrects → seule la table Statistiques dérivait.
- **catalog-pr-hygiene R1** : marqueur `CATALOG-STATUS` (l.5-10) **byte-identique à main**. `git diff --name-only | grep catalog` = vide. Aucun fichier catalogue touché.
- **readme-french-first** : prose conservée en français (pas de nouvelle prose, juste des comptes corrigés).
- **G.9 / #5661 first item (SemanticWeb) NON touché** : sa drift du tracker (prose 18 vs disque 23) était un **état transitionnel mid-marathon** — le marathon #4956 (jumeaux C#⇄Python) a depuis ajouté SW-3b/6b/8/9/10/11/13-CSharp, amenant le catalogue à **25** et la table README est **déjà réconciliée à 25** par une session concurrente. L'éditer maintenant = collision L283. Vérifié `git log` README SemanticWeb : commits récents #5671/#5638/755961/#5601/#5602/#5595 (marathon actif). → laissé tel quel.

## Scope

```
 MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
```

1 fichier, 5 cellules de compte corrigées (+5/−5). Pas de churn metadata (`.md`, pas de notebook).

See #5661 (contribution **partielle** : item SmartContracts fixé ; item SemanticWeb déjà résolu par le marathon #4956 — détaillé ci-dessus).
See #4959, See #3973 (rollout parent READMEs feuilles).
