### PR TITLE
docs(gametheory): fix SocialChoice README §E drift — C# twins counted in pedagogical_count (#5661)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/README.md
@@ -27,7 +27,7 @@ Cette sous-série du parcours [GameTheory](../README.md) explore ces résultats 
 
 **Durée totale** : ~3h25
 
-> **Parité .NET** : les notebooks [01-Arrow-Impossibility-Theorem-Csharp.ipynb](01-Arrow-Impossibility-Theorem-Csharp.ipynb) (jumeau du SC-01), [03-Voting-Methods-Csharp.ipynb](03-Voting-Methods-Csharp.ipynb) (jumeau du SC-03) et [04-Computational-Aggregation-SAT-Z3-Csharp.ipynb](04-Computational-Aggregation-SAT-Z3-Csharp.ipynb) (jumeau du SC-04) sont les miroirs C# (.NET Interactive) des originaux Python — mêmes algorithmes implémentés from-scratch en C#. Marathon parité .NET ⇄ Python (#4956). Ils ne sont pas comptés dans le `pedagogical_count` (ce sont des miroirs de parité, pas des notebooks pédagogiques distincts).
+> **Parité .NET** : les notebooks [01-Arrow-Impossibility-Theorem-Csharp.ipynb](01-Arrow-Impossibility-Theorem-Csharp.ipynb) (jumeau du SC-01), [03-Voting-Methods-Csharp.ipynb](03-Voting-Methods-Csharp.ipynb) (jumeau du SC-03) et [04-Computational-Aggregation-SAT-Z3-Csharp.ipynb](04-Computational-Aggregation-SAT-Z3-Csharp.ipynb) (jumeau du SC-04) sont les miroirs C# (.NET Interactive) des originaux Python — mêmes algorithmes implémentés from-scratch en C#. Marathon parité .NET ⇄ Python (#4956). Ces trois jumeaux C# sont comptés dans le `pedagogical_count` de la sous-série (7 notebooks au total, tous formats confondus) mais arborent le statut `PARITÉ` dans le tableau ci-dessus pour les distinguer des quatre notebooks Python d'origine dont ils sont les retranscriptions .NET.
 
 ## Parcours d'apprentissage
 


### PR DESCRIPTION
## Scope

Corrige le drift §E résiduel du README `GameTheory/SocialChoice/` identifié dans le tracker #5661 (passe ascendante hubs). La note « Parité .NET » affirmait que les 3 jumeaux C# (SC-01/03/04-Csharp) **ne sont pas comptés dans le `pedagogical_count`** — c'est factuellement faux.

## §E whole-file audit (4 sources reconciliées firsthand)

| Source | Compte SocialChoice |
|--------|---------------------|
| **Disque** (`git ls-tree -r --name-only HEAD`) | 7 `.ipynb` (4 Python COMPLET + 3 C# PARITÉ) |
| **Catalogue** (`COURSE_CATALOG.generated.json`) | 7 entrées |
| **Marker CATALOG-STATUS** | `pedagogical_count: 7`, `maturity: PRODUCTION=4, BETA=2, ALPHA=1` |
| **Table README** | 7 lignes (4 COMPLET + 3 PARITÉ) |

**4/4 sources alignées à 7.** Le seul drift résiduel = la prose de la note Parité qui claimait l'exclusion. Vérification de la sémantique du générateur de catalogue (`scripts/notebook_tools/generate_catalog.py`) :

```python
EXCLUDE_PEDAGOGICAL = {"research", "archive", "_output", "output", "partner-course", "examples"}
```

Les jumeaux `-Csharp` ne matchent **aucun** pattern d'exclusion → ils **SONT** comptés dans `pedagogical_count` (comme le confirme le marker à 7, cohérent avec la méthodologie SmartContracts=27 qui compte aussi les twins).

## Correctif

La note Parité est reformulée pour refléter la réalité : les 3 jumeaux C# **sont** comptés (7 notebooks au total, tous formats confondus), et distingués par leur statut `PARITÉ` dans le tableau. Le framing « quatre angles / quatre notebooks » de l'intro/parcours/conclusion (qui décrit l'arc pédagogique des 4 originaux Python, pas le compte de fichiers) est **laissé inchangé** — il est correct.

## Contexte #5661

Le bullet SocialChoice de #5661 était partiellement adressé : #5682 a ajouté les lignes SC-01/03-Csharp au tableau, #5688 a ajouté SC-04-Csharp. Mais la **prose** de la note Parité (qui contredisait le marker) n'avait pas été corrigée — c'est ce résiduel que cette PR clot. Contribution partielle au tracker 14-bullets #5661 → `See #5661` (pas `Closes`).

## Hygiène

- Scope atomique : 1 fichier, `+1/-1`, chirurgical
- `CATALOG-STATUS` marker **byte-identique** à `main` (regex extraction, `main == branch: True`) — catalog-pr-hygiene HARD 1 respecté
- 0 CRLF (raw byte check Python : `CR count = 0` main et branch — LF pur)
- readme-french-first : prose FR conservée

See #5661
