### PR TITLE
fix(sc04-csharp): cell-order backwards numbering 7→6 (Epic #3240, scan_cell_ordering HIGH)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
@@ -1856,20 +1856,7 @@
    "cell_type": "markdown",
    "id": "a84aabff",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## 6. Exercices\n",
-    "\n",
-    "### Exercice 1 : Purs litteraux\n",
-    "Un literal est **pur** s'il n'apparait qu'avec un signe dans toute la CNF. La regle des **litteraux purs** (pure literal elimination) l'assigne pour satisfaire toutes ses clauses. Ajoutez cette regle au solveur DPLL (avant le branchement) et mesurez l'acceleration sur l'encodage d'Arrow.\n",
-    "\n",
-    "### Exercice 2 : Theoreme de Sen\n",
-    "Le theoreme de Sen (1970) est une autre impossibilite (Pareto + liberalisme minimal). Portez le `SenSATEncoder` du notebook Python et verifiez UNSAT avec DPLL.\n",
-    "\n",
-    "### Exercice 3 : Passage a l'echelle\n",
-    "Chronometrez DPLL sur 3, puis 4 alternatives. A partir de combien d'alternatives DPLL devient-il impraticable ? Comparez avec les temps Glucose3 rapportes dans le notebook Python."
-   ]
+   "source": "---\n\n## 8. Exercices\n\n### Exercice 1 : Purs litteraux\nUn literal est **pur** s'il n'apparait qu'avec un signe dans toute la CNF. La regle des **litteraux purs** (pure literal elimination) l'assigne pour satisfaire toutes ses clauses. Ajoutez cette regle au solveur DPLL (avant le branchement) et mesurez l'acceleration sur l'encodage d'Arrow.\n\n### Exercice 2 : Theoreme de Sen\nLe theoreme de Sen (1970) est une autre impossibilite (Pareto + liberalisme minimal). Portez le `SenSATEncoder` du notebook Python et verifiez UNSAT avec DPLL.\n\n### Exercice 3 : Passage a l'echelle\nChronometrez DPLL sur 3, puis 4 alternatives. A partir de combien d'alternatives DPLL devient-il impraticable ? Comparez avec les temps Glucose3 rapportes dans le notebook Python."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Fixe un **HIGH cell-order finding** détecté par `scan_cell_ordering.py` (Epic **#3240**) sur `SC-04-Csharp` :

```
MyIA.AI.Notebooks\GameTheory\SocialChoice\04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
  [HIGH] cell#30  SECTION_ORDER  section 6 appears after 7 (numbering goes backwards under parent <root>)
         > ## 6. Exercices
```

### G.1 ground-truth firsthand (le signal n'est pas un verdict — vérifié avant correction)

Trace complète des en-têtes numérotés du notebook :

```
cell[1]  ## 0. Configuration
cell[3]  ## 1. Rappels : Logique Propositionnelle et SAT
cell[11] ## 2. Encodage SAT du theoreme d'Arrow
cell[14] ## 3. Verification UNSAT
cell[17] ## 4. Cas special : 2 alternatives
cell[19] ## 5. Verdict SOTA (EPIC #3801)
cell[20] ## 5. Theoreme de Sen
cell[23] ## 6. Benchmark structurel : Arrow vs Sen
cell[26] ## 7. Theoreme d'Arrow par SMT : Z3
cell[30] ## 6. Exercices     ← backwards (7 -> 6) + duplicate "6"
```

**Cause racine** : PR #5699 (tranche 3 Z3) a inséré `## 7. Theoreme d'Arrow par SMT` (cell 26) **après** `## 6. Benchmark` (cell 23), mais le `## 6. Exercices` préexistant (cell 30) est resté en dessous → numérotation 7→6 backwards + 2 sections "6".

### Fix

Renommer cell[30] `## 6. Exercices` → `## 8. Exercices`. L'arc devient monotone : `0(Config)→1(Rappels)→2(Arrow)→3(Verification)→4(2 alt)→5(Verdict)→5(Sen)→6(Benchmark)→7(SMT Z3)→8(Exercices)→Conclusion`. Plus aucun backward step.

## Validation post-fix

```
scan_cell_ordering.py <nb> --severity HIGH  ->  1 clean, 0 finding(s)   (was 1 HIGH)
JSON valid, 33 cells (inchangées), 12 code cells toutes execution_count non-null
```

## Conformité règles

- **C.2 (markdown exception)** : édit markdown-only (cell 30 était déjà markdown, seul le titre `## 6.`→`## 8.` change). **Aucune cellule code touchée** → pas de re-exécution requise (exception markdown C.2). Vérifié : `git diff` isole le changement à la cellule `a84aabff`, 0 output/execution_count churn sur les cellules code.
- **catalog-pr-hygiene R1** : `CATALOG-STATUS` byte-identique, aucun fichier catalogue touché.
- **anti-regression §D** : aucun contenu pédagogique supprimé — juste un numéro de section corrigé (6→8). La prose des exercices 1/2/3 est intégralement préservée.
- **NotebookEdit** : la source cellule passe d'array de lignes à string (comportement standard de l'API, JSON valide).

## Scope hors-this-PR (signaled, not fixed)

Il y a **deux** `## 5.` (cell 19 « Verdict SOTA » + cell 20 « Sen ») — un autre duplicate-numbering introduit à travers #5699 + #5685 + #5677 (tranches successives). Le corriger impliquerait de renuméroter du contenu authored by d'autres PRs (changement structurel au-delà du scope de ce fix backwards-7→6). **Laisssé pour un passage numbering-consistency dédié** par le mainteneur SC-04 — signalé ici pour traçabilité.

## Diff

```
.../04-Computational-Aggregation-SAT-Z3-Csharp.ipynb | 17 ++-------------
1 file changed, 2 insertions(+), 15 deletions(-)
```

(−15 = source array collapsée en string par NotebookEdit + 1 char `## 6.`→`## 8.`; markdown-only, 0 code/output churn.)

See #3240 (cell-ordering Epic, tooling `scan_cell_ordering.py`).
See #4956 (SC-04-Csharp twin, marathon .NET ⇄ Python).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
