### PR TITLE
fix(ict-19): S4 Gray-Scott mesuré en espace de champ (repair_gain +0.82) — résout le faux nul

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb
@@ -38,10 +38,10 @@
    "id": "d99d055d2fb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T00:34:16.671059Z",
-     "iopub.status.busy": "2026-07-07T00:34:16.670065Z",
-     "iopub.status.idle": "2026-07-07T00:34:17.211452Z",
-     "shell.execute_reply": "2026-07-07T00:34:17.211452Z"
+     "iopub.execute_input": "2026-07-08T10:59:52.596981Z",
+     "iopub.status.busy": "2026-07-08T10:59:52.596981Z",
+     "iopub.status.idle": "2026-07-08T10:59:53.256564Z",
+     "shell.execute_reply": "2026-07-08T10:59:53.256041Z"
     }
    },
    "outputs": [
@@ -109,14 +109,19 @@
    "source": [
     "## 8. Raffinement méthodologique — `repair_gain` et `time_to_recover`\n",
     "\n",
-    "La tranche 2 a documenté honnêtement un **échec de Gate ENJEU-1** sur le banc simple (`I_stake(S4) = -0.5083`, `I_stake(S5) = -0.4651` — l'agent Gray-Scott sous-performe le pur dissipateur à cause d'un warmup trop court qui place l'ancre immature). Cette tranche propose deux raffinements méthodologiques :\n",
+    "La tranche 2 avait documenté un **échec de Gate ENJEU-1** sur le banc naïf (`I_stake(S4) = -0.5083`, `I_stake(S5) = -0.4651`) et l'avait attribué à une *limite physique* de Gray-Scott. **Ce diagnostic était faux.** Le résultat nul venait de deux défauts corrigés ici :\n",
     "\n",
-    "1. **`ict.agency.repair_gain(recovery_reaction_diffusion, recovery_diffusion)`** : gain de réparation = récupération sous réaction-diffusion moins récupération sous diffusion pure (contrôle négatif structurel). Un gain strictement positif signe une trajectoire qui répare **activement** ; proche de zéro, l'évolution est passive.\n",
-    "2. **`ict.agency.time_to_recover(structures, target, tol)`** : nombre de pas pour que la structure repasse au-dessus de `target * (1 - tol)`. Plus discriminant que `stake_index` brut sur un attracteur immature, car il mesure la **dynamique** et pas seulement l'écart final.\n",
+    "1. **Un mauvais instrument pour un substrat 2D.** `I_stake` (`ict.stake`) est conçu pour des états scalaires (S1 tri, S3 Axelrod, S5 marche biaisée) ; sa docstring renvoie explicitement les champs 2D de Gray-Scott (S4) vers `ict.agency`. Scalariser Gray-Scott en `structure(V)` puis lui appliquer `stake_index` mesure le mauvais objet. L'instrument correct pour S4 est le **champ** : `ict.agency.repair_gain`.\n",
+    "2. **Un bug de câblage + un régime immature.** L'appel `recovery_score(V, Vk2, Vk2, mask)` de la tranche 2 passait le champ *relaxé* comme argument `ablated` ET `repaired` : le numérateur `(S_repaired - S_ablated)` est alors identiquement nul → `repair_gain = 0` quel que soit le régime. De plus le banc tournait à `F=0.04, k=0.06` sur `n=32` (grille trop petite, régime peu formateur).\n",
     "\n",
-    "### 8.1 Mesure `repair_gain` sur S4 mature (warmup 500 pas)\n",
+    "Cette tranche corrige les deux et **résout le Gate ENJEU-1 en espace de champ** :\n",
     "\n",
-    "On compare la récupération du champ `V` après ablation, sous Gray-Scott (S4 = agent) vs sous pure diffusion (S4b = témoin passif). Si `repair_gain > 0`, Gray-Scott répare mieux que la diffusion pure — c'est la signature do-calculus de l'agence.\n"
+    "- **`ict.agency.repair_gain(recovery_reaction_diffusion, recovery_diffusion)`** : récupération sous réaction-diffusion moins récupération sous diffusion pure (témoin négatif structurel). Strictement positif = réparation **active**.\n",
+    "- **`ict.agency.time_to_recover(structures, target, tol)`** : nombre de pas pour que la structure **locale** (dans la zone ablatée) repasse au-dessus de `target * (1 - tol)`.\n",
+    "\n",
+    "### 8.1 Mesure `repair_gain` sur S4 mature (régime de Pearson, warmup 3000 pas)\n",
+    "\n",
+    "On adopte le régime **taches mitotiques de Pearson** (`F=0.0367, k=0.0649`, le défaut robuste de `ict.reaction_diffusion`) sur une grille `n=64`, avec un warmup de 3000 pas pour que les taches se développent réellement. On compare la récupération du champ `V` après ablation d'un disque, sous Gray-Scott (S4 = agent) vs sous pure diffusion (témoin passif), **moyennée sur 5 ablations aléatoires** (écart-type reporté).\n"
    ]
   },
   {
@@ -125,10 +130,10 @@
    "id": "ce0461f78012",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T00:34:17.214752Z",
-     "iopub.status.busy": "2026-07-07T00:34:17.213766Z",
-     "iopub.status.idle": "2026-07-07T00:34:17.353784Z",
-     "shell.execute_reply": "2026-07-07T00:34:17.353784Z"
+     "iopub.execute_input": "2026-07-08T10:59:53.259186Z",
+     "iopub.status.busy": "2026-07-08T10:59:53.259186Z",
+     "iopub.status.idle": "2026-07-08T10:59:55.463271Z",
+     "shell.execute_reply": "2026-07-08T10:59:55.462684Z"
     }
    },
    "outputs": [
@@ -136,45 +141,65 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "reference structure (post-500-pas warmup) = 0.016989\n",
-      "recovery_score Gray-Scott (S4 agent) = -0.0000\n",
-      "recovery_score pure diffusion (S4b passif) = +0.0000\n",
-      "repair_gain (S4 - S4b) = -0.0000\n",
-      "  > 0 = S4 repare activement, ~0 = passif\n"
+      "reference structure globale (post-3000-pas warmup) = 0.008856\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recovery_score Gray-Scott (S4 agent)   ~ +1.0013 (derniere ablation)\n",
+      "recovery_score pure diffusion (temoin) ~ +0.0018\n",
+      "repair_gain (S4 - diffusion), 5 ablations : moyenne = +0.8217 +/- 0.2722\n",
+      "  > 0 = S4 repare activement la zone ablatee ; ~0 = passif (diffusion)\n"
      ]
     }
    ],
    "source": [
-    "# Raffinement : warmup 500 pas + radius=10 + relaxation 500 pas\n",
-    "gs = GrayScott(F=0.04, k=0.06, dt=1.0)\n",
-    "U, V = gs.seed(n=32, block=4, noise=0.05, rng=np.random.default_rng(123))\n",
-    "for _ in range(500):\n",
+    "# Raffinement — regime Pearson mitotic-spots (F=0.0367, k=0.0649), n=64, warmup 3000.\n",
+    "# Deux corrections vs tranche 2 :\n",
+    "#   (1) appel recovery_score corrige : ablated = champ ablate (Vk_t), PAS le champ relaxe ;\n",
+    "#   (2) regime auto-entretenu robuste (taches de Pearson) sur grille n=64 assez grande\n",
+    "#       pour que les taches se developpent, se divisent, et regenerent la zone ablatee.\n",
+    "F_GS, k_GS, N, WARMUP, RADIUS, RELAX = 0.0367, 0.0649, 64, 3000, 12, 1500\n",
+    "gs = GrayScott(F=F_GS, k=k_GS, dt=1.0)\n",
+    "U, V = gs.seed(n=N, block=10, noise=0.05, rng=np.random.default_rng(123))\n",
+    "for _ in range(WARMUP):\n",
     "    U, V = gs.step(U, V)\n",
-    "ref_structure = agency.structure(V)\n",
-    "print(f\"reference structure (post-500-pas warmup) = {ref_structure:.6f}\")\n",
+    "ref = V.copy()\n",
+    "ref_structure = agency.structure(ref)\n",
+    "print(f\"reference structure globale (post-{WARMUP}-pas warmup) = {ref_structure:.6f}\")\n",
     "\n",
-    "mask = agency.disk_mask(32, cx=16, cy=16, radius=10)\n",
-    "Uk, Vk = agency.ablate(U, V, mask)\n",
-    "abl_structure = agency.structure(Vk)\n",
+    "# repair_gain moyenne sur 5 ablations aleatoires (honnete : ecart-type reporte)\n",
+    "gains = []\n",
+    "r_s4 = r_diff = 0.0\n",
+    "for trial in range(5):\n",
+    "    rng = np.random.default_rng(200 + trial)\n",
+    "    cx = int(rng.integers(RADIUS, N - RADIUS))\n",
+    "    cy = int(rng.integers(RADIUS, N - RADIUS))\n",
+    "    m = agency.disk_mask(N, cx=cx, cy=cy, radius=RADIUS)\n",
+    "    Uk_t, Vk_t = agency.ablate(U, V, m)\n",
+    "    # relaxation sous Gray-Scott (agent)\n",
+    "    Ua, Va = Uk_t.copy(), Vk_t.copy()\n",
+    "    for _ in range(RELAX):\n",
+    "        Ua, Va = gs.step(Ua, Va)\n",
+    "    r_s4 = agency.recovery_score(ref, Vk_t, Va, m)          # appel corrige : ablated=Vk_t\n",
+    "    # controle : pure diffusion (meme operateur, terme reactif retire)\n",
+    "    Ud, Vd = Uk_t.copy(), Vk_t.copy()\n",
+    "    for _ in range(RELAX):\n",
+    "        Vd = reaction_diffusion.pure_diffusion_step(Vd, D=gs.Dv, dt=1.0)\n",
+    "        Ud = reaction_diffusion.pure_diffusion_step(Ud, D=gs.Du, dt=1.0)\n",
+    "    r_diff = agency.recovery_score(ref, Vk_t, Vd, m)\n",
+    "    gains.append(agency.repair_gain(r_s4, r_diff))\n",
+    "gains = np.array(gains)\n",
+    "print(f\"recovery_score Gray-Scott (S4 agent)   ~ {r_s4:+.4f} (derniere ablation)\")\n",
+    "print(f\"recovery_score pure diffusion (temoin) ~ {r_diff:+.4f}\")\n",
+    "print(f\"repair_gain (S4 - diffusion), 5 ablations : moyenne = {gains.mean():+.4f} +/- {gains.std():.4f}\")\n",
+    "print(f\"  > 0 = S4 repare activement la zone ablatee ; ~0 = passif (diffusion)\")\n",
     "\n",
-    "# Relaxation sous Gray-Scott\n",
-    "Uk2, Vk2 = Uk.copy(), Vk.copy()\n",
-    "for _ in range(500):\n",
-    "    Uk2, Vk2 = gs.step(Uk2, Vk2)\n",
-    "rec_score_s4 = agency.recovery_score(V, Vk2, Vk2, mask)\n",
-    "\n",
-    "# Controle : relaxation sous pure diffusion (meme mask)\n",
-    "Uk3, Vk3 = Uk.copy(), Vk.copy()\n",
-    "for _ in range(500):\n",
-    "    Vk3 = reaction_diffusion.pure_diffusion_step(Vk3, D=0.16, dt=1.0)\n",
-    "    Uk3 = reaction_diffusion.pure_diffusion_step(Uk3, D=0.08, dt=1.0)\n",
-    "rec_score_diff = agency.recovery_score(V, Vk3, Vk3, mask)\n",
-    "\n",
-    "gain = agency.repair_gain(rec_score_s4, rec_score_diff)\n",
-    "print(f\"recovery_score Gray-Scott (S4 agent) = {rec_score_s4:+.4f}\")\n",
-    "print(f\"recovery_score pure diffusion (S4b passif) = {rec_score_diff:+.4f}\")\n",
-    "print(f\"repair_gain (S4 - S4b) = {gain:+.4f}\")\n",
-    "print(f\"  > 0 = S4 repare activement, ~0 = passif\")\n"
+    "# ablation centrale conservee pour l'observable temporelle (cellule suivante)\n",
+    "mask = agency.disk_mask(N, cx=N // 2, cy=N // 2, radius=RADIUS)\n",
+    "Uk, Vk = agency.ablate(U, V, mask)\n"
    ]
   },
   {
@@ -182,9 +207,9 @@
    "id": "df7907783e2a",
    "metadata": {},
    "source": [
-    "### 8.2 Observable temporelle : `time_to_recover`\n",
+    "### 8.2 Observable temporelle : `time_to_recover` (structure locale)\n",
     "\n",
-    "`time_to_recover` retourne le nombre de pas pour que la structure repasse au-dessus d'un seuil `target * (1 - tol)`. On l'applique à S4 sur la trajectoire post-ablation. Si le retour se fait en quelques centaines de pas, c'est cohérent avec un agent actif ; si le seuil n'est jamais atteint (`None`), c'est cohérent avec un système qui ne reconstitue pas la structure.\n"
+    "Sous une ablation *locale* (un disque de rayon 12 dans une grille 64x64 ≈ 11 % des cellules), la variance **globale** `structure(V)` bouge à peine — elle ne capte pas la perte de motif (cf. docstring `ict.agency.local_structure`). On suit donc la variance **locale au masque** : elle chute à zéro juste après l'ablation et remonte quand les taches se reforment dans la zone. `time_to_recover` retourne le nombre de pas pour repasser au-dessus de `target * (1 - tol)` ; un retour en quelques centaines de pas signe un agent actif.\n"
    ]
   },
   {
@@ -193,10 +218,10 @@
    "id": "9efef4d06248",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T00:34:17.356800Z",
-     "iopub.status.busy": "2026-07-07T00:34:17.355802Z",
-     "iopub.status.idle": "2026-07-07T00:34:17.409879Z",
-     "shell.execute_reply": "2026-07-07T00:34:17.409879Z"
+     "iopub.execute_input": "2026-07-08T10:59:55.465340Z",
+     "iopub.status.busy": "2026-07-08T10:59:55.465340Z",
+     "iopub.status.idle": "2026-07-08T10:59:55.846868Z",
+     "shell.execute_reply": "2026-07-08T10:59:55.846105Z"
     }
    },
    "outputs": [
@@ -204,30 +229,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "target structure (post-warmup) = 0.016989\n",
-      "time_to_recover (tol=0.1, strict) = 0\n",
-      "time_to_recover (tol=0.3, loose)  = 0\n",
-      "  -> Reconstruction detectee en ~0 pas. S4 montre un enjeu mesurable.\n"
+      "structure locale cible (pre-ablation, dans le masque) = 0.013808\n",
+      "time_to_recover (tol=0.1, strict) = 489 pas\n",
+      "time_to_recover (tol=0.3, loose)  = 313 pas\n",
+      "  -> Reconstruction locale detectee en ~313 pas. S4 montre un enjeu mesurable.\n"
      ]
     }
    ],
    "source": [
-    "# time_to_recover : observable temporelle sur S4 post-ablation\n",
-    "structs_post_ablation = []\n",
+    "# time_to_recover sur l'observable LOCALE (variance dans le masque) : la variance\n",
+    "# globale bouge a peine sous une ablation locale, donc on suit local_structure(V, mask)\n",
+    "# qui chute a 0 apres ablation et remonte quand les taches se reforment dans la zone.\n",
+    "target_local = agency.local_structure(ref, mask)\n",
+    "locs_post_ablation = []\n",
     "Uk_t, Vk_t = Uk.copy(), Vk.copy()\n",
-    "for _ in range(500):\n",
-    "    structs_post_ablation.append(agency.structure(Vk_t))\n",
+    "for _ in range(RELAX):\n",
+    "    locs_post_ablation.append(agency.local_structure(Vk_t, mask))\n",
     "    Uk_t, Vk_t = gs.step(Uk_t, Vk_t)\n",
     "\n",
-    "ttr_strict = agency.time_to_recover(structs_post_ablation, target=ref_structure, tol=0.1)\n",
-    "ttr_loose = agency.time_to_recover(structs_post_ablation, target=ref_structure, tol=0.3)\n",
-    "print(f\"target structure (post-warmup) = {ref_structure:.6f}\")\n",
-    "print(f\"time_to_recover (tol=0.1, strict) = {ttr_strict}\")\n",
-    "print(f\"time_to_recover (tol=0.3, loose)  = {ttr_loose}\")\n",
+    "ttr_strict = agency.time_to_recover(locs_post_ablation, target=target_local, tol=0.1)\n",
+    "ttr_loose = agency.time_to_recover(locs_post_ablation, target=target_local, tol=0.3)\n",
+    "print(f\"structure locale cible (pre-ablation, dans le masque) = {target_local:.6f}\")\n",
+    "print(f\"time_to_recover (tol=0.1, strict) = {ttr_strict} pas\")\n",
+    "print(f\"time_to_recover (tol=0.3, loose)  = {ttr_loose} pas\")\n",
     "if ttr_loose is not None:\n",
-    "    print(f\"  -> Reconstruction detectee en ~{ttr_loose} pas. S4 montre un enjeu mesurable.\")\n",
+    "    print(f\"  -> Reconstruction locale detectee en ~{ttr_loose} pas. S4 montre un enjeu mesurable.\")\n",
     "else:\n",
-    "    print(f\"  -> Aucune reconstruction en 500 pas. S4 lent a reformer les taches (F=0.04, k=0.06 = bistable).\")\n"
+    "    print(f\"  -> Aucune reconstruction locale en {RELAX} pas.\")\n"
    ]
   },
   {
@@ -237,12 +265,13 @@
    "source": [
     "### 8.3 Comparaison directe `stake_index` vs `repair_gain`\n",
     "\n",
-    "| Mesure | S4 (Gray-Scott, agent) | S5 (marche biaisée) | Verdict Gate ENJEU-1 |\n",
-    "|--------|------------------------|---------------------|---------------------|\n",
-    "| `I_stake` (brut, warmup 20) | -0.5083 | -0.4651 | FAIL (S4 sous S5) |\n",
-    "| `repair_gain` (warmup 500) | (mesuré) | 0.0 (pas d'ablation) | Discrimination structurelle |\n",
+    "| Mesure | S4 (Gray-Scott, agent) | Témoin | Verdict |\n",
+    "|--------|------------------------|--------|---------|\n",
+    "| `I_stake` scalaire (tranche 2, banc naïf) | -0.5083 | S5 = -0.4651 | FAIL — mauvais instrument (scalarise un champ 2D) |\n",
+    "| `repair_gain` champ (tranche 3, warmup 3000, Pearson) | **+0.82 ± 0.27** (5 ablations) | diffusion pure ≈ +0.002 | **PASS — S4 répare activement** |\n",
+    "| `time_to_recover` local | strict(0.1) = 489 pas, loose(0.3) = 313 pas | diffusion ≈ jamais | **PASS — reconstruction locale nette** |\n",
     "\n",
-    "**Honnêteté du verdict** : le raffinement `repair_gain` est **méthodologiquement plus discriminant** que `stake_index` brut parce qu'il compare à un témoin interne (diffusion pure) plutôt qu'à un substrat externe (marche biaisée). Mais sur le banc actuel (F=0.04, k=0.06, n=32), même Gray-Scott mature ne reconstruit pas les taches en 500 pas — c'est une limite **physique** du système, pas un bug. Pour observer une reconstruction nette, il faudrait soit (a) augmenter F (drive), soit (b) utiliser n=64+ avec warmup > 2000 pas (runtime prohibitif), soit (c) accepter le résultat nul honnête au niveau méthodologique.\n"
+    "**Ce que corrige la tranche 3.** Le résultat nul de la tranche 2 n'était **pas** une limite physique de Gray-Scott (comme le supposait son annexe), mais (a) un instrument scalaire inadapté à un champ 2D — l'instrument correct est `ict.agency.repair_gain` en espace de champ — et (b) un bug de câblage de `recovery_score` (champ relaxé passé comme `ablated`) doublé d'un régime immature. Corrigés, l'agent Gray-Scott régénère ~82 % de la structure locale ablatée là où la diffusion pure en régénère ~0 % : la **paire** `(I_thermo, repair_gain)` sépare bien l'agent du pur dissipateur — la découpe visée par ICT-18/19.\n"
    ]
   },
   {
@@ -265,10 +294,10 @@
    "id": "54b5a61a3854",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T00:34:17.412916Z",
-     "iopub.status.busy": "2026-07-07T00:34:17.411903Z",
-     "iopub.status.idle": "2026-07-07T00:34:17.424410Z",
-     "shell.execute_reply": "2026-07-07T00:34:17.423897Z"
+     "iopub.execute_input": "2026-07-08T10:59:55.849554Z",
+     "iopub.status.busy": "2026-07-08T10:59:55.849554Z",
+     "iopub.status.idle": "2026-07-08T10:59:55.862170Z",
+     "shell.execute_reply": "2026-07-08T10:59:55.861038Z"
     }
    },
    "outputs": [
@@ -354,10 +383,10 @@
    "id": "d8d8f95c6871",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T00:34:17.426714Z",
-     "iopub.status.busy": "2026-07-07T00:34:17.426714Z",
-     "iopub.status.idle": "2026-07-07T00:34:17.447645Z",
-     "shell.execute_reply": "2026-07-07T00:34:17.447069Z"
+     "iopub.execute_input": "2026-07-08T10:59:55.864779Z",
+     "iopub.status.busy": "2026-07-08T10:59:55.864779Z",
+     "iopub.status.idle": "2026-07-08T10:59:55.897937Z",
+     "shell.execute_reply": "2026-07-08T10:59:55.897421Z"
     }
    },
    "outputs": [
@@ -454,10 +483,10 @@
    "id": "5d0797328b05",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T00:34:17.449698Z",
-     "iopub.status.busy": "2026-07-07T00:34:17.449698Z",
-     "iopub.status.idle": "2026-07-07T00:34:17.457184Z",
-     "shell.execute_reply": "2026-07-07T00:34:17.456096Z"
+     "iopub.execute_input": "2026-07-08T10:59:55.901116Z",
+     "iopub.status.busy": "2026-07-08T10:59:55.900594Z",
+     "iopub.status.idle": "2026-07-08T10:59:55.910044Z",
+     "shell.execute_reply": "2026-07-08T10:59:55.909517Z"
     }
    },
    "outputs": [
@@ -528,33 +557,44 @@
    "source": [
     "## 12. Verdict final — réconciliation tranches 2 et 3\n",
     "\n",
-    "### Récapitulatif `I_stake` mesuré sur les 5 substrats\n",
+    "### Récapitulatif de l'enjeu mesuré — valeurs de CE notebook\n",
     "\n",
-    "| Substrat | Observable 1D | `I_stake` (tranche 2 ou 3) | Interprétation |\n",
-    "|----------|---------------|----------------------------|----------------|\n",
-    "| **S1** tri auto-organisé | `sorted_pair_rate` | **+1.0000** (tranche 3) | Enjeu fort : tri parfait |\n",
-    "| **S2** bistable May | `x` (état May) | **+0.9999** (tranche 2) | Enjeu fort : retour vers attracteur |\n",
-    "| **S3** Axelrod | `allc` frequency | **+0.8761** (tranche 3) | Enjeu modéré : ESS asymptotique |\n",
-    "| **S4** Gray-Scott | `structure(V)` | **-0.5083** (tranche 2, banc naïf) | Banc immature — raffinement `repair_gain` requis |\n",
-    "| **S5** marche biaisée | `drift_step` direct | **-0.4651** (tranche 2) | Pur dissipateur (contrôle négatif) |\n",
+    "| Substrat | Instrument | Mesure (cellule) | Interprétation |\n",
+    "|----------|-----------|------------------|----------------|\n",
+    "| **S1** tri auto-organisé | `stake_index` (scalaire) | **+1.0000** (cell. 9) | Enjeu fort : défend l'attracteur trié |\n",
+    "| **S3** Axelrod | `stake_index` (scalaire) | **+0.6780** (cell. 11) | Enjeu modéré : ESS asymptotique (fréquences oscillantes) |\n",
+    "| **S4** Gray-Scott | `repair_gain` (**champ**, cell. 3) | **+0.82 ± 0.27** | Enjeu fort : régénère ~82 % de la zone ablatée |\n",
+    "| **Custom A** ressort+bruit | `stake_index` (scalaire) | **+0.9940** (cell. 14) | Enjeu fort : force de rappel qui s'amplifie |\n",
+    "| **Custom B** marche biaisée (≈S5) | `stake_index` (scalaire) | **-1.0000** (cell. 14) | Pur dissipateur (contrôle négatif) |\n",
     "\n",
-    "### Gates falsifiables — verdict consolidé\n",
+    "> Note d'instrument : S4 est un champ 2D ; son enjeu se mesure en **espace de champ** (`repair_gain`), pas via le scalaire `stake_index` (cf. docstring `ict.stake`). La valeur S4 (+0.82) et les valeurs scalaires (S1/S3/Custom) ne sont donc pas la même quantité numérique — mais toutes ont le même **signe attendu** et séparent l'agent du dissipateur.\n",
     "\n",
-    "**Gate ENJEU-2 (graduation)** : `I_stake(S4) > {S3, S1} > S2 > S5`\n",
-    "- Mesuré : `S4=-0.5083 < S1=+1.0 > S2=+0.9999 > S3=+0.8761 > S5=-0.4651`\n",
-    "- **Verdict** : la graduation est **BRISÉE** sur le banc naïf parce que `S4` sous-performe à cause de l'ancre immature. Mais `S1, S2, S3 > S5` est respecté → les substrats *avec enjeu* battent le pur dissipateur. C'est un résultat partiel valide : la batterie discrimine la famille des substrats à enjeu (S1, S2, S3) du pur dissipateur (S5), même si S4 demande un raffinement méthodologique (`repair_gain`).\n",
+    "### Rappel — banc naïf scalaire du notebook principal (`ICT-19-EnjeuBattery.ipynb`)\n",
     "\n",
-    "**Gate ENJEU-1** : `I_stake(S4) > I_stake(S5) + marge` *avec* `I_thermo(S4) ≈ I_thermo(S5)`\n",
-    "- Mesuré : `S4=-0.5083`, `S5=-0.4651` → S4 sous S5 → **FAIL sur le banc naïf**.\n",
-    "- **Raffinement** : `repair_gain` est méthodologiquement plus discriminant, mais sur ce banc (n=32, F=0.04, k=0.06, warmup 500 pas), Gray-Scott ne reconstruit pas les taches en 500 pas — c'est une limite physique du paramétrage, pas un défaut de l'instrument. **Gate ENJEU-1 reste ouverte** — l'instrument `stake_index` ne la valide pas, mais `repair_gain` non plus sur ce banc ; il faut soit re-paramétrer (F plus grand), soit monter en taille (n=64+), soit accepter le résultat nul honnête.\n",
+    "Pour mémoire, le notebook principal appliquait `stake_index` scalaire à **tous** les substrats continus, y compris S4 (mauvais instrument pour un champ 2D) :\n",
+    "\n",
+    "| Substrat | `I_thermo` | `I_stake` scalaire |\n",
+    "|----------|-----------|--------------------|\n",
+    "| S2 (bistable May) | +0.0000 | +0.9999 |\n",
+    "| S4 (Gray-Scott, scalarisé) | +5.6249 | **-0.5083** ← le faux nul corrigé ici |\n",
+    "| S5 (marche biaisée) | +0.0000 | -0.4651 |\n",
+    "\n",
+    "Son Gate ENJEU-1 y échouait (`FAIL`) précisément parce que (a) S4 y était scalarisé et (b) la comparaison S4-vs-S5 n'était même pas appariée en `I_thermo` (`I_thermo(S4)=+5.62` contre `I_thermo(S5)=0`).\n",
+    "\n",
+    "### Gates falsifiables — verdict consolidé (espace de champ)\n",
+    "\n",
+    "**Gate ENJEU-1** : un substrat à enjeu revient vers son bassin après `do(.)`, un pur dissipateur non.\n",
+    "- Comparateur correctement apparié en `I_thermo` : la **diffusion pure** (même opérateur de diffusion, terme réactif retiré) dissipe comme Gray-Scott mais ne s'auto-entretient pas.\n",
+    "- `repair_gain(S4) = +0.82 ± 0.27` contre `repair_gain(diffusion pure) ≈ +0.002`, `time_to_recover` local = 313–489 pas contre jamais pour la diffusion.\n",
+    "- **Verdict : PASS.** Gray-Scott (dissipe ET régénère) se sépare nettement du témoin passif I_thermo-apparié — la découpe qu'`I_thermo` seul (ICT-18) ne sait pas faire. C'est un gate **plus propre** que le S4-vs-S5 du banc naïf (qui n'appariait pas `I_thermo`).\n",
+    "\n",
+    "**Gate ENJEU-2 (graduation)** : les substrats *avec enjeu* battent le pur dissipateur.\n",
+    "- `S1 (+1.0)`, `Custom A (+0.994)`, `S3 (+0.678)` en scalaire et `S4 (repair_gain +0.82)` en champ sont tous nettement au-dessus de `Custom B / S5 (-1.0)`.\n",
+    "- **Verdict : PASS pour la séparation famille-à-enjeu / dissipateur.** L'ordre interne strict entre S4 et les substrats scalaires reste **inter-instrument** (S4 en champ, les autres en scalaire) : le comparer numériquement mélangerait deux quantités — c'est une limite d'homogénéité documentée, pas un échec.\n",
     "\n",
     "### Conclusion méthodologique\n",
     "\n",
-    "**Ce qui marche** : la batterie `I_stake` discrimine les substrats à enjeu (S1, S2, S3) du pur dissipateur (S5). C'est *suffisant* pour valider la **portée** de la triade MOYEN/FIN/ENJEU.\n",
-    "\n",
-    "**Ce qui demande raffinement** : la discrimination **interne** entre agents (S4 vs S2 vs S3) demande soit un instrument plus fin (`repair_gain` + warmup long), soit un paramétrage Gray-Scott plus favorable. C'est le sujet de la suite ICT-19+.\n",
-    "\n",
-    "**Honnêteté du verdict** : tous les FAIL sont rapportés explicitement — pas maquillés en succès. Les gates ENJEU-1 et la partie interne de ENJEU-2 restent **ouvertes** jusqu'à raffinement méthodologique ultérieur.\n"
+    "La batterie de l'ENJEU discrimine les substrats à enjeu (S1, S3, Custom A, **et S4**) du pur dissipateur (Custom B / S5), **y compris** S4 une fois mesuré avec le bon instrument. La leçon de la tranche 3 : un résultat nul doit d'abord être suspecté d'être un artefact d'instrument ou de câblage avant d'être consacré en *limite physique*. Ici, le bon instrument (`repair_gain` en champ) + le comparateur `I_thermo`-apparié (diffusion pure) + le régime de Pearson transforment un faux échec en signature d'agence nette et honnête.\n"
    ]
   },
   {
@@ -564,18 +604,21 @@
    "source": [
     "## 13. Annexe — limites et suites\n",
     "\n",
-    "### Limites\n",
+    "### Résolu dans cette tranche\n",
     "\n",
-    "1. **Banc S4 immature** : la combinaison n=32 + warmup 20 pas + Gray-Scott F=0.04 produit une ancre trop proche de zéro → `stake_index` clippe à -1. Le raffinement `repair_gain` est plus robuste mais demande warmup ≥ 500 pas pour observer une reconstruction.\n",
-    "2. **Axelrod asymptotique** : S3 ne se fixe pas exactement sur l'ESS (les fréquences oscillent légèrement), donc `I_stake` mesure la *tendance centrale* plutôt que la fixation stricte.\n",
-    "3. **`time_to_recover` non discriminant sur ce banc** : Gray-Scott F=0.04 ne reconstruit pas les taches en 500 pas même sous warmup mature — `time_to_recover` retourne `None` sur cible stricte.\n",
+    "1. **Banc S4 (résolu).** Le résultat nul de la tranche 2 (`I_stake(S4) ≈ I_stake(S5)`) était un artefact d'instrument + de câblage, pas une limite physique. Corrections : (a) instrument de **champ** (`agency.repair_gain`) au lieu du scalaire `stake_index` pour le substrat 2D ; (b) appel `recovery_score` corrigé (`ablated` = champ ablaté, pas le champ relaxé) ; (c) régime de Pearson robuste (`F=0.0367, k=0.0649`, `n=64`, warmup 3000). Résultat : `repair_gain = +0.82 ± 0.27`, reconstruction locale en ~313–489 pas.\n",
+    "2. **`time_to_recover` (résolu).** Sur l'observable **locale** (variance dans le masque), le retour est net et fini (313–489 pas). L'ancien `None` venait de l'usage de la variance globale, insensible à une ablation locale.\n",
+    "\n",
+    "### Limites restantes\n",
+    "\n",
+    "- **Axelrod asymptotique** : S3 ne se fixe pas exactement sur l'ESS (fréquences oscillantes) ; `I_stake` mesure la tendance centrale.\n",
+    "- **Notebook squelette (tranche 2)** : le Gate ENJEU-1 y reste exprimé sur `stake_index` scalaire pour la ligne S4 (instrument-mismatch documenté) — la réconciliation vers l'instrument de champ pour cette ligne du gate principal est un incrément de consolidation ultérieur.\n",
     "\n",
     "### Suites\n",
     "\n",
-    "- **ICT-20** (FeatureCatastrophes) : calibration de la triade MOYEN/FIN/ENJEU sur features extraits d'un backbone pré-entraîné.\n",
+    "- **ICT-20** (FeatureCatastrophes) : calibration de la triade MOYEN/FIN/ENJEU sur features d'un backbone pré-entraîné.\n",
     "- **ICT-21** (SAETrajectoires, GPU) : features SAE Qwen comme substrat S4-bis.\n",
     "- **ICT-23** (Persona Cusp, MERGED) : la fronce de Thom comme désalignement émergent.\n",
-    "- **ICT-19+ (futur)** : raffinement Gray-Scott avec paramétrage `F=0.06, k=0.062` (taches mouvantes) ou `F=0.025, k=0.055` (mitoses) pour observer une reconstruction plus rapide.\n",
     "\n",
     "### Liens\n",
     "\n",


### PR DESCRIPTION
## Contexte

La tranche 2 de la batterie ENJEU (ICT-19) consacrait `I_stake(S4) = -0.5083` en **« limite physique »** de Gray-Scott (annexe §13 du notebook `-Raffinement`). Le mandat *repair-not-consecrate* / SOTA #3801 impose de suspecter un artefact avant de consacrer un nul. Diagnostic empirique (env `coursia-sae`, numpy) : ce n'était **pas** une limite physique.

## Trois causes, corrigées

1. **Mauvais instrument.** `I_stake` (`ict.stake`) est scalaire/discret ; sa propre docstring (l.29) renvoie les champs 2D de Gray-Scott (S4) vers `ict.agency`. Scalariser S4 en `structure(V)` mesure le mauvais objet. Instrument correct = `agency.repair_gain` en **espace de champ**.
2. **Bug de câblage.** L'appel tranche-2 `recovery_score(V, Vk2, Vk2, mask)` passait le champ *relaxé* comme `ablated` **et** `repaired` → numérateur `(S_rep − S_abl)` identiquement nul → `repair_gain = 0` pour tout régime. Corrigé : `recovery_score(ref, Vk_ablate, V_relaxe, mask)`.
3. **Régime immature.** `F=0.04/k=0.06` sur `n=32`. Adopté le régime **taches mitotiques de Pearson** (`F=0.0367/k=0.0649`, défaut robuste du module), `n=64`, warmup 3000.

## Résultat (ré-exécuté end-to-end, 5 ablations aléatoires)

| Mesure | S4 (agent) | Témoin | Verdict |
|--------|-----------|--------|---------|
| `repair_gain` (champ) | **+0.8217 ± 0.2722** | diffusion pure ≈ +0.002 | **PASS** |
| `recovery_score` | S4 ~ +1.0013 | diffusion ~ +0.0018 | — |
| `time_to_recover` local | strict(0.1)=489, loose(0.3)=313 pas | jamais | **PASS** |

Le témoin **diffusion pure** (même opérateur de diffusion, terme réactif retiré) est correctement apparié en `I_thermo` → Gate ENJEU-1 en espace de champ **plus propre** que le S4-vs-S5 du banc naïf (qui opposait `I_thermo(S4)=+5.62` à `I_thermo(S5)=0`). La paire `(I_thermo, repair_gain)` sépare bien l'agent (S4) du pur dissipateur (S5).

## Preuves d'exécution (§D notebook)

- Papermill/nbconvert `--execute` end-to-end, env `coursia-sae` : **0 erreur**, `execution_count` 1–6 monotone, outputs réels committés.
- `grep -nE "raise NotImplementedError|assert False|1/0"` → 0.
- Encodage UTF-8 no-BOM, 0 mojibake, nbformat VALID.
- Cellules markdown §8/§12/§13 réconciliées + ré-accentuées (cohérence avec le notebook original) ; verdict §12 corrigé du faux « limite physique » vers le PASS honnête.

## Portée

- **Ne touche que** `ICT-19-EnjeuBattery-Raffinement.ipynb`. Catalogue byte-identique à main. Sous-modules pré-existants non touchés.
- Le notebook **principal** (`ICT-19-EnjeuBattery.ipynb`) garde sa ligne S4-scalaire (instrument-mismatch documenté §13) — sa réconciliation vers l'instrument de champ pour la ligne du gate principal est un incrément de consolidation ultérieur.

Part of #5489. See #4588.