### PR TITLE
feat(probas): DecPyMC-5 lift exo 3+4 (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb
@@ -1794,12 +1794,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Extension : Strategie sequentielle\n",
-    "\n",
-    "Et si on pouvait faire le **Test 1 d'abord**, puis decider du **Test 2** en fonction\n",
-    "du resultat ? C'est une strategie sequentielle d'acquisition d'information.\n",
-    "\n",
-    "**Exercice** : Completez le calcul de la strategie optimale sequentielle."
+    "## 9. Extension : Strategie sequentielle\n\nEt si on pouvait faire le **Test 1 d'abord**, puis decider du **Test 2** en fonction\ndu resultat ? C'est une strategie sequentielle d'acquisition d'information.\n\n### Exercice 3 : EVSI d'une strategie sequentielle (Test1 -> Test2)\n\nCalculez l'**EVSI** (Expected Value of Sample Information) d'une strategie en deux\netapes : on effectue le Test 1 (cout `cout_t1`), puis **conditionnellement au resultat\npositif** on effectue le Test 2 (cout `cout_t2`). Comparez cette strategie sequentielle\na la strategie \"Test 2 directement\" et a la strategie \"ne pas tester\".\n\n**Objectif** : Completez la fonction `strategie_sequentielle` ci-dessous pour calculer\nl'utilite esperee de la strategie sequentielle optimale.\n\n**Indices** :\n- Si Test 1 est negatif : pas de Test 2, decision = action optimale sans information\n- Si Test 1 est positif : le posterior apres Test 1 devient le prior du Test 2\n- L'EVSI = EU(strategie sequentielle optimale) - EU(ne pas tester)\n- Verifiez que la strategie sequentielle >= Test 2 seul (propriete de monotonie de l'information)"
    ]
   },
   {
@@ -2884,6 +2879,36 @@
     "Le modele `Beta(3,7) -> Bernoulli` de la section precedente est **conjugue** : la loi a posteriori de `p_theta` admet une forme analytique fermee (une Beta mise a jour). Pire, comme aucune observation n'est fournie a la vraisemblance (`pm.Bernoulli` sans `observed=`), l'echantillonneur NUTS **se contente de reproduire le prior** -- les diagnostics R-hat ~ 1.000 et ESS ~ 8000 sont alors triviaux, car il n'y a ni apprentissage ni geometrie difficile. Autrement dit, sur ce cas **degenere**, `pm.sample` est strictement equivalent a `np.random.beta(3, 7)`.\n",
     "\n",
     "Pour que le MCMC apporte une valeur distinctive (Prong-B), il faut un probleme ou **aucune solution analytique n'existe** : c'est le cas des lors qu'on evalue la Valeur de l'Information sur un **portefeuille de plusieurs sites** aux rendements heterogenes, en modelisant cette heterogeneite par un **modele hierarchique**. Le *partial pooling* (chaque site emprunte de l'information aux autres) induit une posterior jointe non-conjuguee que seul un echantillonneur MCMC peut explorer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex4_pymc_partial_pooling",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : Valeur de l'Information sur un portefeuille hierarchique\n",
+    "\n",
+    "On considere maintenant un **portefeuille de N sites petroliers** avec une structure\n",
+    "hierarchique : la probabilite de trouver du petrole sur chaque site suit un prior\n",
+    "commun `p_i ~ Beta(alpha, beta)` avec hyperpriors sur `alpha` et `beta`.\n",
+    "\n",
+    "**Objectif** : Completez le calcul de la **Valeur de l'Information au niveau du\n",
+    "portefeuille** en propageant l'incertitude hierarchique via MCMC (PyMC).\n",
+    "\n",
+    "**Questions** :\n",
+    "1. Pourquoi le **partial pooling** (modele hierarchique) est-il preferable au\n",
+    "   pooling complet ou au no-pooling pour estimer les `p_i` ?\n",
+    "2. Tracez la distribution de l'EVPI portfolio : `EVPI_portfolio = sum_i EVPI(p_i)`\n",
+    "   sur les posteriors MCMC. Quelle est la **valeur de l'information partagee**\n",
+    "   entre sites (shrinkage) ?\n",
+    "3. Comparez l'EVPI portfolio avec l'EVPI moyen d'un site individuel. Le ratio\n",
+    "   est-il proche de N (additivite) ou superieur (synergie informationnelle) ?\n",
+    "\n",
+    "**Indice** : Utilisez la parametrisation **non-centree**\n",
+    "`p_i = sigmoid(mu + sigma * eta_i)` avec `eta_i ~ N(0, 1)` pour eviter les\n",
+    "problemes de funnel dans le posterior MCMC."
    ]
   },
   {


### PR DESCRIPTION
## Scope

Single notebook lift to satisfy \#2161 (>= 3 exos per substantive notebook).

**Notebook**: `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb` (77 cells, 29 code cells)

**Before** : 2 exos formels (cells 9 + 17) + 1 stub code cell with bare "Exercice :" inline label (no markdown heading, non-conformant).

**After** : 4 exos formels (cell 9, 17, 46, 68).

### Changes

| Cell | Change | Type |
|------|--------|------|
| **46** | Remplace "**Exercice** :" inline par "### Exercice 3 : EVSI d'une strategie sequentielle (Test1 -> Test2)" + objectif + 4 indices | markdown edit |
| **68 (NEW)** | Insere "### Exercice 4 : Valeur de l'Information sur un portefeuille hierarchique" + 3 questions + parametrisations non-centrees | markdown insert |

### Pedagogical lift

- **Exo 3** (cell 46) : EVSI sequentiel = Strategie Test1 -> si Test1+, Test2. Suit directement l'exemple guide cell 47-48. Indice explicite sur la propriete de **monotonie de l'information** (sequentiel >= Test2 seul).
- **Exo 4** (cell 68) : EVPI portefeuille hierarchique = partie distinctive PyMC (Prong B). 3 questions pedagogiques : (1) partial pooling vs no-pooling, (2) shrinkage informationnel, (3) ratio EVPI_portfolio / EVPI_moyen (synergie vs additivite). Indice sur la parametrisation **non-centree** pour eviter le funnel geometry MCMC.

### Conformite

| Regle | Statut |
|-------|--------|
| **#2161 >= 3 exos** | 4 exos formels ✓ (lift 2 -> 4) |
| **C.2 outputs preserves** | 29/29 code cells retain execution_count + outputs (pure markdown edits = no re-exec required) |
| **C.1 stubs** | 4 stubs existants = conforme (TODO etudiant, Exercice a completer, pas de raise NotImplementedError) |
| **C.3 scope strict** | 1 notebook modifie (source change uniquement dans cell 46 + new cell 68) |
| **#3240 cell-ordering** | `scan_cell_ordering.py --severity HIGH` = **0 finding** |
| **§A composite split** | 1 fichier / 1 feature / +31/-6 = single subject, sous seuils |
| **catalog-pr-hygiene R1** | Pas de catalogue touche |
| **readme-french-first** | Pas de README touche |
| **L268 + MD047** | trailing newline OK |
| **#2161 owner-lane** | Probas partition = owner-lane po-2024 ✓ |

### Verification

```bash
python scripts/notebook_tools/scan_cell_ordering.py     "MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-5-Value-Information.ipynb"     --severity HIGH
# Scanned 1 notebook(s): 1 clean, 0 finding(s).
```

### Lien Epic

- Issue #2161 : Convention 3 exercices par notebook pedagogique (mandat user 2026-06-02)
- Family : Probas/DecisionTheory/PyMC (5ᵉᵐᵉ notebook DecisionTheory, 2ᵉ tranche DecPyMC exo lift)
- Owner-lane : po-2024 partition CPU/.NET

🤖 Generated with [Claude Code](https://claude.com/claude-code)