### PR TITLE
docs(qc): documenter écart 4-types classification (hub vs feuille) — #5661

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -14,7 +14,9 @@ Supports de cours pour l'apprentissage du trading algorithmique avec QuantConnec
 | **(c)** standalone research | 6 | Local yfinance/sklearn training |
 | **(d)** pedagogical placeholder | 33 | Course material with embedded QCAlgorithm strings |
 
-> Récapitulatif : 18+2+6+33 = 59 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **55** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md) pour la classification détaillée.
+**Récapitulatif** : 18+2+6+33 = 59 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **55** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md) pour la classification détaillée.
+
+> **Note — écarts de classification 4-types (hub vs feuille)** : la classification ci-dessus (a/b/c/d) classe les notebooks Python du dossier par **modalité d'exécution** (quantbook QC Cloud, research companion, standalone local, placeholder pédagogique). Le dossier [`projects/`](../projects/) — catalogué dans [`projects/README.md`](../projects/README.md) et référencé depuis le hub [`QuantConnect/README.md`](../README.md) — utilise un 4-types **distinct** par **robustesse** (Robuste / Historique / Exploratoire / ML-DL-RL). Les deux classifications ont des **périmètres disjoints** : ce dossier = supports de cours (notebooks pédagogiques), `projects/` = stratégies déployables (code backtest). Toute lecture transversale doit garder cette distinction à l'esprit : un notebook (c) « standalone research » n'est pas pour autant une stratégie de production, et inversement un projet « Robuste » n'a pas forcément de notebook pédagogique ici. Alignement non forcé volontairement (cf. note tracker `#5661`).
 
 Full classification: [docs/archive/qc-strategies-status.md](../../../docs/archive/qc-strategies-status.md)
 


### PR DESCRIPTION
## Résumé

Per note tracker #5661 (item `QuantConnect/Python/README.md`) : « documenter l'écart plutôt que forcer l'alignement ».

Fix §E surgical — 1 paragraphe de clarification post-l.19 explicitant que le 4-types (a/b/c/d) classe par **modalité d'exécution** (supports de cours) tandis que le hub `QuantConnect/README.md` l.212 utilise un 4-types **distinct** par **robustesse** (Robuste/Historique/Exploratoire/ML-DL-RL) couvrant les projets `projects/`.

Périmètres disjoints documentés : notebooks pédagogiques vs stratégies déployables. Alignement non forcé volontairement.

## Audit fichier-ENTIER §E (C267-L1)

Reconciliation disk ↔ table ↔ prose vérifiée firsthand sur `MyIA.AI.Notebooks/QuantConnect/Python/` :

| Métrique | Disque | README | Verdict |
|----------|--------|--------|---------|
| Total `.ipynb` | 55 (53 main + 2 research/) | 55 (l.17) | aligné |
| 4-types (a) quantbook QC Cloud | 18 | 18 (l.12) | aligné |
| 4-types (b) research companion | 2 | 2 (l.13) | aligné |
| 4-types (c) standalone research | 6 | 6 (l.14) | aligné |
| 4-types (d) pedagogical placeholder | 33 | 33 (l.15) | aligné |
| Total entrées 4-types | 18+2+6+33 = 59 | 59 (l.17) | aligné |
| Hub 4-types (Robuste/Hist/Explor/ML-DL-RL) | absent Python | absent Python | aligné (hub l.212 pointe projects/) |

**Écart documenté** : deux 4-types à **périmètres disjoints** (notebooks pédagogiques vs stratégies déployables). Issue #5661 explicite : « documenter l'écart plutôt que forcer l'alignement, cf hub note ».

## CATALOG-STATUS marker

**Absent** dans `MyIA.AI.Notebooks/QuantConnect/Python/README.md` (vérifié `grep -n "CATALOG-STATUS"`). R1 byte-identity triviale OK — pas de marqueur à préserver.

## Scope (R3 atomicité)

- 1 file / +2/-0 lines
- < 50L groupement E-règle OK
- 1 sujet = 1 PR = 1 item #5661

## Tests

Aucun code modifié, aucun notebook touché. Pas de Papermill à relancer.

Refs #5661