### PR TITLE
feat(lean): durable native lean4-wsl Mathlib import via fork (jsboige/lean4_jupyter) (#4394)

### DIFF
--- a/docs/reference/wsl-kernels-detail.md
+++ b/docs/reference/wsl-kernels-detail.md
@@ -88,17 +88,17 @@ Le wrapper Python v6 `~/.lean4-kernel-wrapper.py` (source dans le dépôt : `MyI
 - `#check Sensitivity.f_squared` → `(f n) ((f n) v) = ↑n • v`
 - `#print axioms Sensitivity.huang_degree_theorem` → **depends on axioms: [propext, Classical.choice, Quot.sound]** (0 sorry, pas de `sorryAx`)
 
-**Prérequis** : (1) le wrapper v6 (`find_lake_root` chdir vers le lakefile ancêtre) pour que le kernel hérite le cwd du lake, (2) un repl binaire matchant la toolchain du lake (`~/.elan/bin/repl` est stable-locked ; rc1/rc2 lakes ont besoin d'un repl matché), (3) le patch `lean4_jupyter/repl.py` `launch()`. Le script `scripts/lean/setup_native_lean4_import.py` automatise le patch (idempotent + backup) + le build de repl par toolchain (`build-repl v4.30.0-rc2` / `v4.31.0-rc1`).
+**Prérequis** : (1) le wrapper v6 (`find_lake_root` chdir vers le lakefile ancêtre) pour que le kernel hérite le cwd du lake, (2) un repl binaire matchant la toolchain du lake (`~/.elan/bin/repl` est stable-locked ; rc1/rc2 lakes ont besoin d'un repl matché), (3) le fork `jsboige/lean4_jupyter@v0.0.1-native-import` qui intègre le patch `lean4_jupyter/repl.py` `launch()` (direct-launch REPL + `LEAN_PATH`). Le script `scripts/lean/setup_native_lean4_import.py` automatise l'install du fork + le build de repl par toolchain (`build-repl v4.30.0-rc2` / `v4.31.0-rc1`).
 
 **Setup** :
 
 ```powershell
+python scripts/lean/setup_native_lean4_import.py install      # install fork jsboige/lean4_jupyter@v0.0.1-native-import (durable — remplace patch)
 python scripts/lean/setup_native_lean4_import.py status        # état patch + repl toolchains
 python scripts/lean/setup_native_lean4_import.py build-repl v4.30.0-rc2   # build+install repl matché (~2 min)
-python scripts/lean/setup_native_lean4_import.py patch         # patch repl.py (idempotent)
 ```
 
-**Note durabilité (gate ai-01/user)** : le patch modifie le package pip `lean4_jupyter` (perdu au prochain `pip install`). Solution durable = fork lean4_jupyter ou PR upstream. Le script rend le patch reproductible (idempotent, backup `.bak.native`), mais c'est un débloqueur local, pas une solution upstream.
+**Note durabilité — RÉSOLU (fork `jsboige/lean4_jupyter@v0.0.1-native-import`, #4394)** : le fork intègre le patch direct-launch directement dans `lean4_jupyter/repl.py`, donc il **survit à un `pip install`/reinstall propre** (le gap de durabilité antérieur est fermé). Le sous-script `install` fait `pip install --force-reinstall --no-deps git+https://github.com/jsboige/lean4_jupyter.git@v0.0.1-native-import` dans le venv `~/.lean4-venv`. Le sous-script `patch` (in-place, idempotent + backup `.bak.native`) reste disponible comme **fallback offline** (machine sans accès GitHub), mais n'est plus le chemin canonique. Source unique du patch : les constantes `REPL_PY_ORIGINAL` / `REPL_PY_PATCH` du setup script, reflétées dans le fork — `status` détecte le patch par le marqueur `_find_lake_root` quelle que soit la voie d'install.
 
 ### Diagnostic manuel (commandes)
 

--- a/scripts/lean/setup_native_lean4_import.py
+++ b/scripts/lean/setup_native_lean4_import.py
@@ -25,7 +25,8 @@ stable-locked; rc1/rc2 lakes need a matched REPL — see ``build-repl``).
 USAGE
 -----
     python scripts/lean/setup_native_lean4_import.py status        # what's patched/installed
-    python scripts/lean/setup_native_lean4_import.py patch         # patch repl.py (idempotent, backup)
+    python scripts/lean/setup_native_lean4_import.py install       # install durable fork (replaces in-place patch)
+    python scripts/lean/setup_native_lean4_import.py patch         # [legacy] patch repl.py in-place (offline fallback)
     python scripts/lean/setup_native_lean4_import.py build-repl v4.30.0-rc2
     python scripts/lean/setup_native_lean4_import.py --check
 
@@ -47,6 +48,13 @@ REPL_TOOLCHAIN_TAGS = {
     "v4.30.0-rc2": "repl-4.30.0-rc2",
     "v4.31.0-rc1": "repl-4.31.0-rc1",
 }
+# Durable fork of utensil/lean4_jupyter baking the direct-launch patch directly into
+# repl.py (survives a clean ``pip install``/reinstall, closing the durability gap of the
+# in-place ``patch``). The fork repl.py is the single runtime source of the patch; the
+# ``REPL_PY_PATCH`` constant below mirrors it verbatim for the legacy offline fallback.
+# See issue #4394.
+FORK_URL = "git+https://github.com/jsboige/lean4_jupyter.git"
+FORK_TAG = "v0.0.1-native-import"
 # Marker present in repl.py once patched (idempotency check).
 PATCH_MARKER = "_find_lake_root"
 
@@ -142,6 +150,30 @@ def _find_repl_py():
     return path or None
 
 
+def cmd_install():
+    """Install the durable fork ``jsboige/lean4_jupyter@v0.0.1-native-import`` into the
+    WSL lean4 venv. The fork bakes the direct-launch patch into ``lean4_jupyter/repl.py``
+    itself, so native Mathlib-lake import survives a clean reinstall — this replaces the
+    in-place ``patch`` (which was lost on every ``pip install``)."""
+    spec = f"{FORK_URL}@{FORK_TAG}"
+    # --force-reinstall: the patched fork must replace any prior upstream lean4_jupyter.
+    # --no-deps: pexpect etc. are already satisfied in ~/.lean4-venv; avoid dependency churn.
+    cmd = f"~/.lean4-venv/bin/pip install --force-reinstall --no-deps {spec}"
+    print(f"installing durable fork {spec} ...")
+    r = _wsl(cmd, timeout=300)
+    print((r.stdout or r.stderr or "").strip()[-1200:])
+    rp = _find_repl_py()
+    if not rp:
+        print("ERROR: lean4_jupyter/repl.py not found after install", file=sys.stderr)
+        return 1
+    chk = _wsl(f"grep -q '{PATCH_MARKER}' {rp} && echo PATCHED || echo UNPATCHED", timeout=20)
+    state = chk.stdout.strip()
+    print("post-install patch state:", state)
+    rc = _wsl(f"/home/*/.lean4-venv/bin/python3 -m py_compile {rp} && echo OK", timeout=30)
+    print("py_compile:", (rc.stdout or rc.stderr or "").strip())
+    return 0 if state == "PATCHED" else 1
+
+
 def cmd_status():
     rp = _find_repl_py()
     print("== native lean4-wsl Mathlib import — status ==")
@@ -228,13 +260,15 @@ def cmd_build_repl(tag):
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    ap.add_argument("command", nargs="?", choices=["status", "patch", "build-repl"],
+    ap.add_argument("command", nargs="?", choices=["install", "status", "patch", "build-repl"],
                     default="status")
     ap.add_argument("tag", nargs="?", help="toolchain tag for build-repl (e.g. v4.30.0-rc2)")
     ap.add_argument("--check", action="store_true", help="alias for status")
     args = ap.parse_args()
     if args.check or args.command == "status":
         return cmd_status()
+    if args.command == "install":
+        return cmd_install()
     if args.command == "patch":
         return cmd_patch()
     if args.command == "build-repl":


### PR DESCRIPTION
## What

Durable native lean4-wsl Mathlib import via a maintained fork of `lean4_jupyter`, closing the durability gap of #4390 (the in-place `repl.py` patch was lost on every `pip install`/reinstall).

Closes the durability acceptance of #4394: *Native `import <MathlibLake>` works in `lean4-wsl` after a clean `pip install` of the kernel, **without** running `setup_native_lean4_import.py`.*

## External artifact (already live)

- **Fork**: `jsboige/lean4_jupyter@v0.0.1-native-import` (fork of `utensil/lean4_jupyter`, MIT).
- `lean4_jupyter/repl.py` patched with the direct-launch `Lean4ReplWrapper.launch()` (REPL binary direct + `LEAN_PATH` from the ancestor lake, fallback `lake env repl` for Mathlib-free stub lakes).
- **Byte-identical** to `REPL_PY_PATCH` in the setup script (single source of truth). Upstream `repl.py:50-53` matched `REPL_PY_ORIGINAL` verbatim → clean apply.
- Tag `v0.0.1-native-import` pinned so `pip` resolves a stable ref. Upstream PR deferred (maintainer dormant since 2024-11; fork-first is more reliable).

## Changes (this PR — 2 files, atomic)

| File | Change |
|------|--------|
| `scripts/lean/setup_native_lean4_import.py` | New `install` subcommand: `pip install --force-reinstall --no-deps git+https://github.com/jsboige/lean4_jupyter.git@v0.0.1-native-import` into `~/.lean4-venv`, verifies `_find_lake_root` marker + `py_compile` post-install. `patch` kept as **legacy offline fallback** (marked `[legacy]`). `status`/`build-repl` unchanged (status detects the marker regardless of install path). |
| `docs/reference/wsl-kernels-detail.md` | `install` replaces `patch` as the canonical setup step. "Note durabilité" flipped from *(gate ai-01/user)* → **RÉSOLU (fork #4394)**. |

## Verification (firsthand)

```
$ python scripts/lean/setup_native_lean4_import.py install
... Successfully installed lean4_jupyter-0.0.3.dev0
post-install patch state: PATCHED
py_compile: OK

$ python scripts/lean/setup_native_lean4_import.py status
repl.py: /home/jesse/.lean4-venv/lib/python3.12/site-packages/lean4_jupyter/repl.py
patch state: PATCHED                          # marker present from the fork alone, no in-place patch run
matched REPL binaries:
  repl-4.30.0-rc2: present
  repl-4.31.0-rc1: present
```

→ After a clean `pip install` of the fork (no `patch` run), the installed `repl.py` carries the direct-launch marker. **The durability gap is closed.**

Runtime native import (`import <MathlibLake>` + `#check`) was proven firsthand in **c.127** on `sensitivity_lean` (`import Sensitivity` + `#check huang_degree_theorem` real signature + `#print axioms` = `[propext, Classical.choice, Quot.sound]`, 0 sorry). The fork delivers the **byte-identical** patch, so runtime behavior is unchanged — only durability is added. A fresh end-to-end import probe with the fork can be run on request as a re-confirmation of c.127.

## Safety / scope

- Fresh-contribution PR (not catalog); one subject (durable native import), 2 files, +39/-5.
- `pip install --force-reinstall --no-deps`: `--no-deps` avoids dependency churn (pexpect etc. already satisfied); `--force-reinstall` guarantees the fork replaces any prior upstream install.
- No kernel-wrapper (`lean4-kernel-wrapper.py` v6) or `build-repl` change.

See #4394
