### PR TITLE
docs(qc): add qc-strategies-status.md landing (tranche 1) (#1621)

### DIFF
--- a/docs/qc/qc-strategies-status.md
+++ b/docs/qc/qc-strategies-status.md
@@ -1,0 +1,91 @@
+# Statut des stratégies QuantConnect — source de vérité
+
+> **Issue parente** : [#1621 EPIC Consolidation QC/Trading](https://github.com/jsboige/CoursIA/issues/1621) (mandat user 2026-05-27).
+> **Partition** : `po-2024:CoursIA` (QC). **Tranche 1** (livrable incrémental — l'EPIC demande explicitement « un sujet par PR, ne pas tout faire d'un coup »).
+
+Ce document est le **point d'entrée unique** pour un visiteur qui découvre les 112 stratégies sous `MyIA.AI.Notebooks/QuantConnect/projects/`. Il cartographie les stratégies, leur type, leur source de données, et — là où l'évidence existe — leur statut (alive / superseded / needs-improvement / à confirmer).
+
+## Méthodologie (honnête)
+
+Les statuts ci-dessous sont **exclusivement dérivés d'évidence firsthand** :
+
+- **Backtests documentés** dans la mémoire du cluster (baselines vérifiées cross-seed).
+- **Figures de recherche** couvertes par la campagne EPIC [#5654](https://github.com/jsboige/CoursIA/issues/5654) (2026-07-08, 11 stratégies QC illustrées).
+
+Les stratégies **sans backtest récent dédié** sont marquées **« À confirmer »** plutôt que de recevoir un statut fabriqué. Un backtest par stratégie (via QC Cloud, MCP `qc-mcp`) reste l'acceptance finale — voir [#1027](https://github.com/jsboige/CoursIA/issues/1027) pour la gate paper-trading/backtest.
+
+## Les 4 types de notebooks (acceptance EPIC)
+
+Le matériel QC mélange 4 types de notebooks qu'un visiteur doit distinguer :
+
+| Type | Description | Localisation |
+|------|-------------|--------------|
+| **(a) Quantbook QC Cloud** | Notebook officiel utilisant `QuantBook()`, exécuté via QC Cloud (MCP `qc-mcp` / Playwright en fallback). Non exécutable localement. | `projects/*/research.ipynb`, `Python/QC-Py-*` |
+| **(b) Research notebook lié** | Notebook de recherche compagnon d'un quantbook/stratégie `projects/`. | `projects/*/research_*.ipynb` |
+| **(c) Standalone research** | Recherche indépendante, données locales (yfinance, pandas, sklearn). Aucun QC Cloud requis. | `research/research_*.ipynb` (18 notebooks) |
+| **(d) Placeholder pédagogique** | Notebook de cours avec stubs `# TODO étudiant`. | `Python/QC-Py-*` (cours) |
+
+**Note** : `projects/Research-Executor/` est un **harness d'exécution** (`main.py` + `runner.ipynb` + MockQB), pas une stratégie ni une zone de recherche — README explicite : « Type: Utility (research execution harness, not a trading strategy) ».
+
+## Stratégies vérifiées (statut firsthand)
+
+| Stratégie | Type | Classe d'actifs | Statut | Évidence |
+|-----------|------|-----------------|--------|----------|
+| `LongShortHarvest-QC` | Composite pairs | Multi-actifs | **Alive — BEATS** | Baseline cluster 98.7% (backtest vérifié) ; figure #5740 |
+| `Framework_Composite_FamaFrenchAllWeather` | Composite | Multi-actifs | **Alive — BEATS** | 87.5% OOS (backtest vérifié) |
+| `DynamicVIXSpyRegime-QC` | Régime VIX | US Equity | **Alive** | 69.4% (backtest vérifié) |
+| `AllWeather` | Multi-asset risk-parity | Actions/Bonds/Or/Commodities | **Alive** | Figure #5743 |
+| `EMA-Cross-Index` | Trend EMA | US Equity (SPY) | **Alive** | Figure #5746 |
+| `EMA-Cross-Crypto` | Trend EMA | Crypto (BTC) | **Alive** | Figure #5750 |
+| `ML-RandomForest` | ML supervisé (RF) | US large-cap | **Alive** | Figure #5747 |
+| `ML-XGBoost` | ML supervisé (XGBoost) | US large-cap | **Alive** | Figure #5749 |
+| `ForexCarry` | FX carry/momentum | G10 FX | **Alive** | Figure #5748 |
+| `RiskParity` / `Cloud-RiskParity-Composite` | Inverse-vol risk-parity | Multi-actifs | **Needs-improvement** (plafond structurel) | Sharpe 0.399 (contre-exemple pédagogique) ; figure #5753 |
+| `DualMomentum` | Momentum dual-asset | Multi-actifs | **Superseded** | Échec TLT 2022 → remplacé par `DualMomentumNoTLT` |
+| `DualMomentumNoTLT` | Momentum (sans TLT) | Multi-actifs | **Alive** (remplacement) | Figure #5754 |
+
+## Régimes de performance (connaissance cluster firsthand)
+
+Backtests cross-stratégies 2022–2024 (stress test) — un visiteur peut anticiper le comportement d'une stratégie selon sa classe :
+
+| Régime | Comportement typique |
+|--------|----------------------|
+| Value / Factor / Trend classique | **Effondrement** (−62% à −85%) |
+| Structured ML / Composites | **Tien** (−2% à −14%) |
+| High-Turnover US Equity | **Near-immune** (0% à −2%) |
+| Low-Turnover Multi-Asset / Crypto | **Vulnérable** (−30% à −43%) |
+
+## Inventaire à compléter (tranches suivantes)
+
+Les stratégies ci-dessus sont la **tranche 1 vérifiée**. Les ~100 stratégies restantes sont listées ci-dessous par catégorie (dénombrement fiable via `git ls-tree`) ; leur statut individuel reste **à confirmer par un backtest dédié** (scope séparé, gated QC Cloud).
+
+| Catégorie | Dénombrement | Exemples |
+|-----------|--------------|----------|
+| `ML-*` (ML supervisé / DL) | 19 | `ML-Classification`, `ML-DeepLearning`, `ML-SVM`, `ML-FinBERT-Sentiment`, `ML-Temporal-CNN`, `ML-HeadShoulders-CNN`, `ML-LLM-Summarization` |
+| `CSharp-*` (algorithmes C# de référence) | 3 | `CSharp-BTC-EMA-Cross`, `CSharp-BTC-MACD-ADX`, `CSharp-CTG-Momentum` |
+| `Cloud-*` (composites QC Cloud) | 4 | `Cloud-MeanReversion-Sectors`, `Cloud-RiskParity-Composite`, `Cloud-SectorRotation-Momentum`, `Cloud-VolTargeting` |
+| `Vol-*` (ex-ESGF, dégénéricisées) | 2 | Stratégies renommées post-cours ESGF (mandat #1621) |
+| RL (RL/PPO/DQN) | 4 | `RL-DQN-Trading`, `RL-Options-Hedging`, `RL-Portfolio`, `Reinforcement-Learning-Trading` |
+| DL (LSTM/Transformer/Mamba/TFT) | 9 | `DL-LSTM`, `LSTM-Forecasting`, `Crypto-LSTM-Prediction`, `Chronos-Foundation-Forecasting`, `Mamba-Crypto-Ranking`, `TFT-Crypto-Ranking`, `Ensemble-DLinear-TFT` |
+| Options | 5 | `Option-Wheel`, `Dynamic-Options-Wheel`, `Options-VGT`, `OptionsIncome`, `RL-Options-Hedging` |
+| Trend / Momentum | 12 | `Trend-Following`, `MomentumStrategy`, `SectorMomentum`, `LeveragedETFMomentum-QC`, `Multi-Layer-EMA`, `VolTarget-Momentum` |
+| Mean Reversion / Pairs / StatArb | 7 | `MeanReversion`, `PairsTrading`, `ETF-Pairs`, `PCA-StatArbitrage`, `TrendFilteredMeanReversion` |
+| Composites (`Framework_Composite_*` / `composite-*`) | 7 | `Framework_Composite_EMATrend`, `Framework_Composite_MomentumRegime`, `Framework_Composite_TrendWeather`, `composite-c1-multiasset`, `composite-c2-equityfactor` |
+| Vol / Régime / Risk | 8 | `Vol-GARCH-Target`, `VIX-TermStructure`, `RegimeSwitching`, `Markov-Regime-Detection`, `Adaptive-Conformal-Risk`, `InverseVolatility-Rank` |
+| Autres | variable | `BTC-ML`, `GraphSAGE-MultiAsset-Ranking`, `HAR-RV-J-Kelly`, `PuppiesOfTheDow-QC`, `TermStructureCommodities-QC`, `TurnOfMonth`, `TradingCosts-Optimization`, … |
+
+**Liste exhaustive** : `git ls-tree -d --name-only origin/main MyIA.AI.Notebooks/QuantConnect/projects/` (112 entrées, `_docs` exclu).
+
+## Travaux connexes
+
+- **Checkpoints ML** : `ML-Training-Pipeline/` (444 MB `.pt`, 137 modèles) — migration Git LFS + purge des obsolètes = gated user (mandat 2026-05-27). Non livré.
+- **Papertrading** : `Python/QC-Py-40-PaperTrading-Binance.ipynb`, `Python/QC-Py-41-PaperTrading-IBKR.ipynb` — statut à confirmer (gate [#1027](https://github.com/jsboige/CoursIA/issues/1027)).
+- **Notebooks cours** : `Python/QC-Py-01..35` + `Cloud-01..07` + companion `Python/research/` (QC-Py-19/22) — cohérents, audit prod-ready à part.
+
+## Voir aussi
+
+- [docs/qc/quantconnect.md](quantconnect.md) — structure complète QC, MCP Docker, livre de référence
+- [docs/qc/qc-comparative-backtests.md](qc-comparative-backtests.md) — backtests comparatifs
+- [#1621](https://github.com/jsboige/CoursIA/issues/1621) — EPIC Consolidation QC/Trading
+- [#5654](https://github.com/jsboige/CoursIA/issues/5654) — EPIC Illustration READMEs (figures)
+- [#1027](https://github.com/jsboige/CoursIA/issues/1027) — paper-trading / backtest gate

--- a/docs/qc/qc-strategies-status.md
+++ b/docs/qc/qc-strategies-status.md
@@ -3,7 +3,7 @@
 > **Issue parente** : [#1621 EPIC Consolidation QC/Trading](https://github.com/jsboige/CoursIA/issues/1621) (mandat user 2026-05-27).
 > **Partition** : `po-2024:CoursIA` (QC). **Tranche 1** (livrable incrémental — l'EPIC demande explicitement « un sujet par PR, ne pas tout faire d'un coup »).
 
-Ce document est le **point d'entrée unique** pour un visiteur qui découvre les 112 stratégies sous `MyIA.AI.Notebooks/QuantConnect/projects/`. Il cartographie les stratégies, leur type, leur source de données, et — là où l'évidence existe — leur statut (alive / superseded / needs-improvement / à confirmer).
+Ce document est le **point d'entrée unique** pour un visiteur qui découvre les 111 stratégies sous `MyIA.AI.Notebooks/QuantConnect/projects/` (112 entrées brutes, dont `_docs/` qui n'est pas une stratégie). Il cartographie les stratégies, leur type, leur source de données, et — là où l'évidence existe — leur statut (alive / superseded / needs-improvement / à confirmer).
 
 ## Méthodologie (honnête)
 
@@ -74,7 +74,7 @@ Les stratégies ci-dessus sont la **tranche 1 vérifiée**. Les ~100 stratégies
 | Vol / Régime / Risk | 8 | `Vol-GARCH-Target`, `VIX-TermStructure`, `RegimeSwitching`, `Markov-Regime-Detection`, `Adaptive-Conformal-Risk`, `InverseVolatility-Rank` |
 | Autres | variable | `BTC-ML`, `GraphSAGE-MultiAsset-Ranking`, `HAR-RV-J-Kelly`, `PuppiesOfTheDow-QC`, `TermStructureCommodities-QC`, `TurnOfMonth`, `TradingCosts-Optimization`, … |
 
-**Liste exhaustive** : `git ls-tree -d --name-only origin/main MyIA.AI.Notebooks/QuantConnect/projects/` (112 entrées, `_docs` exclu).
+**Liste exhaustive** : `git ls-tree -d --name-only origin/main MyIA.AI.Notebooks/QuantConnect/projects/` (112 entrées brutes, dont `_docs/` — soit **111 stratégies** ; `Research-Executor` est un harness d'exécution, pas une stratégie, cf. note ci-dessus).
 
 ## Travaux connexes
 


### PR DESCRIPTION
## Summary

Creates `docs/qc/qc-strategies-status.md` — the **single source of truth** for the 112 strategies under `QuantConnect/projects/`. Delivers the EPIC #1621 acceptance item (« catalogué dans `docs/qc-strategies-status.md` ou successor »).

**Tranche 1** (incremental — the EPIC asks « un sujet par PR, ne pas tout faire d'un coup »). This follows my firsthand Phase-5 re-audit ([comment `4917797687`](https://github.com/jsboige/CoursIA/issues/1621#issuecomment-4917797687)) which found PR-A already delivered, PR-B framing inexact (3 `research/` zones are structurally distinct, not duplicates), PR-C gated user, and **PR-D = genuine gap** (this doc).

## What the doc contains

- **Methodology (honest)** — statuses derived *exclusively* from firsthand evidence (cluster backtest baselines + figures campaign #5654). Strategies without a recent dedicated backtest are marked **« À confirmer »** rather than receiving a fabricated status. Dedicated backtest per strategy via QC Cloud remains the final acceptance (gate #1027).
- **The 4 notebook types** (a quantbook QC Cloud / b research-linked / c standalone / d placeholder) from EPIC acceptance, with the `Research-Executor` harness distinction clarified firsthand (it's a utility, not a strategy nor a research zone).
- **Verified-subset table** (12 strategies with firsthand status):
  | Statut | Stratégies |
  |--------|-----------|
  | Alive — BEATS | LongShortHarvest (98.7%), FamaFrenchAllWeather (87.5% OOS) |
  | Alive | DynamicVIX (69.4%), AllWeather, EMA-Cross-Index/Crypto, ML-RF/XGBoost, ForexCarry, DualMomentumNoTLT |
  | Needs-improvement | RiskParity (Sharpe 0.399 structural ceiling) |
  | Superseded | DualMomentum (→ DualMomentumNoTLT, TLT 2022 failure) |
- **Performance regimes** (cluster firsthand cross-strategy stress test 2022–2024).
- **Inventory-by-category** for the ~100 remaining (count + examples), full list via `git ls-tree` (no fabricated per-strategy status).

## Honesty (G.9)

**No fabricated statuses.** README metadata across the 112 projects is heterogeneous (3 formats observed: table / `**Asset class:**` / title-with-ID + prose), so a mechanical 112-status derivation would be unreliable. Tranche 1 delivers the **landing + verified subset + explicit TODO** for the rest — a visitor is no longer lost (all 112 enumerated + categorized, verified ones flagged), without misleading anyone with guessed statuses.

## Validation

- **Docs-only** (prose markdown). No notebooks re-touched (N/A lake/papermill — pure docs). C.2 N/A.
- **No catalog/markers touched** (this is `docs/qc/` prose, not `COURSE_CATALOG.generated.*` nor `CATALOG-STATUS` markers — catalog-pr-hygiene R1 satisfied).
- **French-first** (readme-french-first rule — new doc).
- **Atomic**: 1 new file, 91 lines, one subject (status catalog tranche 1).
- `See #1621` (partial contribution to the EPIC — does not close it; backtests + papertrading #1027 + LFS checkpoints remain gated).

## Coordination note

Posted as the reasonable-default interpretation of my [c.337 greenlight question](https://github.com/jsboige/CoursIA/issues/1621#issuecomment-4917797687) (the doc's existence is a user-mandated EPIC acceptance item, not an ai-01 design decision). If ai-01/user prefers prioritizing papertrading #1027 or a different structure, this tranche-1 doc still stands as a useful landing and is easy to extend.

Co-Authored-By: Claude <noreply@anthropic.com>