### PR TITLE
fix(lean): correct stale astar_lean root name in 6 unrelated lake-manifest.json

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "minimax_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "learning_theory_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "kelly_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "sudoku_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "planning_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "argumentation_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}


### PR DESCRIPTION
## Summary

Fix a stale top-level `"name": "astar_lean"` field in **6 unrelated lake-manifest.json** files — a copy-paste artifact from when these lakes were scaffolded off the `astar_lean` template. Each lakefile declares the correct package name; the manifest root field was the only stale entry.

| Lake | Was | Now |
|------|-----|-----|
| GameTheory/minimax_lean | `astar_lean` | `minimax_lean` |
| ML/learning_theory_lean | `astar_lean` | `learning_theory_lean` |
| QuantConnect/kelly_lean | `astar_lean` | `kelly_lean` |
| Sudoku/sudoku_lean | `astar_lean` | `sudoku_lean` |
| SymbolicAI/Planners/planning_lean | `astar_lean` | `planning_lean` |
| SymbolicAI/Tweety/argumentation_lean | `astar_lean` | `argumentation_lean` |

## Origin

Surfaced firsthand during the `astar_lean -> search_lean` rename (PR #5757, #4365): the rename made these stale `astar_lean` references in unrelated lakes even more confusing (a lake name that no longer exists anywhere). Flagged out-of-scope in #5757's body; this PR is the dedicated cleanup.

## Why surgical edit, not `lake update`

All 6 are among the **19 junctioned lakes** sharing the rc1-`d568c8c09630` Mathlib checkout (`scripts/lean/setup_shared_mathlib.ps1`). Per the documented caveat: **`lake update` in a junctioned project would mutate the SHARED Mathlib checkout for all group members** — forbidden. The manifest root `"name"` field is pure metadata (the project's own name cached from the lakefile), **not build-critical** (proven both ways: these 6 lakes build fine with the wrong name; `search_lean` builds with the correct one). A surgical 1-line-per-file edit makes the field match the canonical lakefile package name — idempotent with what `lake update` would produce — without touching the junction or shared cache.

## Verification

- **6 files changed, 1 line each** (+6/-6); all other manifest content byte-identical.
- Manifest root `name` now == lakefile `package «...»` for all 6 (Python `re` match, verified).
- **0 `astar_lean`** remaining across the 6 manifests.
- **LF preserved** (no CRLF introduced); trailing newline preserved.
- **Mathlib rev `d568c8c09630` unchanged** in all 6 (dependency block untouched — only the root `name` line edited).

## Scope

Pure metadata hygiene, single concern (stale root names), atomic. No Lean source, no proofs, no lakefiles, no notebooks touched.

Related: #4365, #5757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
