### PR TITLE
fix(lean): correct stale root name in 6 lake-manifest.json (astar_lean templating)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "minimax_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "learning_theory_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "kelly_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "sudoku_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/planning_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "planning_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/argumentation_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "astar_lean",
+ "name": "argumentation_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}


### PR DESCRIPTION
## Summary

6 unrelated Lean lakes inherited a stale root `"name": "astar_lean"` in their `lake-manifest.json` from templating at lake creation, while their `lakefile.lean` declares its own package. This corrects each manifest `name` field to match its lakefile package declaration.

**This is generated lock-file metadata only — no `.lean` source, no proof code, no dependency revs touched.** Pre-existing anomaly (not introduced by #5757), flagged independently by **po-2026** (c.349) and **po-2023** (c.17) during the #5757 (astar→search rename) cross-review.

## Changes (6 files, +6/−6 = 1 line each)

| Lake | lakefile package decl | manifest name before | manifest name after |
|------|----------------------|----------------------|---------------------|
| `Sudoku/sudoku_lean` | `«sudoku_lean»` | `astar_lean` | `sudoku_lean` |
| `QuantConnect/kelly_lean` | `«kelly_lean»` | `astar_lean` | `kelly_lean` |
| `ML/learning_theory_lean` | `«learning_theory_lean»` | `astar_lean` | `learning_theory_lean` |
| `GameTheory/minimax_lean` | `«minimax_lean»` | `astar_lean` | `minimax_lean` |
| `SymbolicAI/Planners/planning_lean` | `«planning_lean»` | `astar_lean` | `planning_lean` |
| `SymbolicAI/Tweety/argumentation_lean` | `«argumentation_lean»` | `astar_lean` | `argumentation_lean` |

The `astar_lean` lake itself (`Search/astar_lean/`) is **correctly** named (its lakefile declares `package astar_lean`) — it is NOT touched here. Only the 6 unrelated lakes were stale.

## Verification (firsthand)

1. **Lakefile = source of truth**: each of the 6 lakefiles declares its own distinct package name (grep `^package` firsthand) — confirmed above.
2. **Manifest convergence**: `social_choice_lean` (a known-correct lake) has `manifest name == lakefile pkg decl` (`social_choice` ← `«social_choice»`). So `lake update` produces `manifest name = lakefile decl`. My hand-edit converges with that canonical output.
3. **Stale occurrence isolated**: each manifest had **exactly 1** occurrence of `astar_lean` (the root name field) — confirmed via `grep -c`. So the targeted edit is surgical.
4. **Post-edit validation**: all 6 manifests are valid JSON (`json.load` succeeds) and `manifest name == lakefile decl` for each.
5. **Diff isolated**: `git diff` shows ONLY the `name` field changed per file (1 line), nothing else. All dependency revs (mathlib `d568c8c0…`, etc.) byte-identical.
6. **Collision guard**: 0 open PRs touch any of these 6 manifests (no overlap with #5757's 29 files).

## Approach — hand-edit, not `lake update` (honest rationale)

Chose to hand-edit the `name` field only rather than running `lake update`:

1. The `name` field is **generated metadata** = lakefile package decl → hand-edit converges with `lake update` output (point 2 above).
2. `lake update` (no args) **bumps dependencies to HEAD** (e.g. mathlib → latest) = unwanted scope creep + warm-cache invalidation. This PR's intent is a 1-field metadata correction, not a dependency bump.
3. Avoids the known **~3h cold-recompile risk** on po-2024 (MEMORY `po2024-lean-via-wsl-elan-not-wdac` c.330: lake 5.0.0 olean path mismatch `lib/lean/Mathlib` vs `lib/Mathlib`). `lake update` does not itself build, but the broader lake tooling churn on this repo makes the minimal hand-edit the safer choice.

## Lean §B (pr-review-discipline) — applicability

This PR does **not** touch `.lean` source or `agent_tests/prover/`, so the §B Lean-PR proof-progress criteria (sorry count, lake build SUCCESS, proof integrity) are **N/A by scope**:

- `grep -c sorry`: N/A — no `.lean` files changed (lake-manifest.json only).
- `Lake build`: N/A — no compiled artifact affected; the `name` field is manifest metadata, not elaborated. (The 6 lakes build fine *despite* the wrong name today; correcting it cannot break the build.)
- Proof integrity (axiom check): N/A — no proofs touched.

If the reviewer prefers canonical regeneration, `lake update` per lake on a machine with a warm Mathlib cache would produce the same `name` value (convergence proven via social_choice_lean) — but with the dep-bump/cold-recompile tradeoffs above.

## Hygiene

- **One subject**: 6 files, single anomaly (templating staleness), 6 lines.
- **Atomic**: single commit `6bf454ea1`.
- **Catalog R1**: no `COURSE_CATALOG` / `CATALOG-STATUS` touched.
- **No proof regression**: 0 `.lean` files modified.

See #4365 (astar→search rename epic; this cleanup supports manifest coherence post-rename). Does not close #4365.
