### PR TITLE
fix(notebook-tools): count_exercises detect C# // TODO stubs (scaffolded exercises under-counted)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -108,9 +108,20 @@ STUB_PATTERNS = [
     re.compile(r'print\(["\']Exercice[s]? a completer', re.IGNORECASE),
     re.compile(r"^\s*pass\s*$", re.MULTILINE),
     re.compile(r"\breturn\s+None\b"),
+    # TODO / Indice markers. Python/F#/Lean use `#`, C# / .NET Interactive
+    # use `//`. A scaffolded C# exercise (class skeleton + `// TODO etudiant`
+    # + multiple code lines) is a student stub, not a solution: without the
+    # `//` form it escaped the `<= 1 effective code-line` rule and was
+    # silently under-counted (e.g. Search-11-Metaheuristics-Csharp cells
+    # 24-26, each `// Exercice N` + `// TODO etudiant` + partial skeleton).
     re.compile(r"#\s*TODO", re.IGNORECASE),
+    re.compile(r"//\s*TODO", re.IGNORECASE),
     re.compile(r"#\s*Indice", re.IGNORECASE),
-    re.compile(r'Console\.WriteLine\(["\']Exercice', re.IGNORECASE),
+    re.compile(r"//\s*Indice", re.IGNORECASE),
+    # `$?` accepts both regular (`"..."`) and interpolated (`$"..."`) strings:
+    # `Console.WriteLine($"Exercice 2 a completer ...")` is the idiomatic C#
+    # interpolated form and was not matched by the quote-only variant.
+    re.compile(r'Console\.WriteLine\(\$?["\']Exercice', re.IGNORECASE),
     re.compile(r"^\s*result\s*=\s*None\b", re.MULTILINE | re.IGNORECASE),
     re.compile(r"^\s*raise\s+NotImplementedError", re.MULTILINE),
     re.compile(r"^\s*assert\s+False\b", re.MULTILINE),

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -307,6 +307,63 @@ class TestCodeCellOnlyExercise:
         )
         assert result.exercises[0].detected_by == "code_cell_comment"
 
+    def test_csharp_scaffolded_exercise_todo_with_code_is_counted(
+        self, tmp_path
+    ):
+        """A scaffolded C# exercise -- ``// Exercice N`` + ``// TODO etudiant``
+        ABOVE a partial class skeleton (multiple code lines) -- is a student
+        stub, NOT a solution. The ``// TODO`` line-comment marker must classify
+        it as a stub even though it has more than one effective code line (the
+        ``<= 1 effective code-line`` rule alone misses it).
+
+        Regression for ``Search-11-Metaheuristics-Csharp`` cells 24-26 (ABC /
+        inertia-schedule / Schwefel): each ``// Exercice N`` + ``// TODO etudiant``
+        + partial skeleton was silently under-counted, so the notebook read as
+        1 exercise instead of its real 3.
+        """
+        nb = _write_nb(
+            tmp_path / "scaffold.ipynb",
+            [
+                _md("# Titre C#"),
+                _code(
+                    "// Exercice 1 : Artificial Bee Colony (ABC).\n"
+                    "// TODO etudiant : implementez ABC (phases employe/onlooker/scout)\n"
+                    "public class ABC\n"
+                    "{\n"
+                    "    public double[] Best;\n"
+                    "    public double BestFitness = double.MaxValue;\n"
+                    "}\n"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            "Scaffolded C# exercise (// TODO + multi-line skeleton) must count"
+        )
+        assert result.exercises[0].detected_by == "code_cell_comment"
+
+    def test_csharp_interpolated_console_writeline_exercice_is_counted(
+        self, tmp_path
+    ):
+        """``Console.WriteLine($"Exercice ...")`` (C# interpolated string) is a
+        stub marker. The ``$?`` in the pattern accepts the optional interpolation
+        sigil -- the quote-only variant missed ``$"Exercice"`` (idiomatic C#).
+        """
+        nb = _write_nb(
+            tmp_path / "interp.ipynb",
+            [
+                _md("# Titre"),
+                _code(
+                    "// Exercice 2 : comparer schedules d'inertie.\n"
+                    'Console.WriteLine($"Exercice 2 a completer : fitness");\n'
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            'C# interpolated Console.WriteLine($"Exercice ...") must count'
+        )
+
     def test_inline_csharp_comment_after_code_is_not_a_stub_marker(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary

`count_exercises.py` under-counted **scaffolded C# exercise stubs**: `STUB_PATTERNS` matched Python `# TODO` but not C# `// TODO` (nor `# Indice` / `// Indice`). A scaffolded C# exercise — `// Exercice N` + `// TODO etudiant` above a partial class skeleton with multiple code lines — escaped both the TODO marker and the `<=1 effective code-line` rule, so it was silently classified as a **solution** and not counted.

## Canonical case (firsthand)

`Search-11-Metaheuristics-Csharp.ipynb` cells 24-26 — each is a genuine C.1-compliant student stub:

```csharp
// Exercice 1 : Artificial Bee Colony (ABC).
// TODO etudiant : implementez ABC (employe/onlooker/scout phases)
public class ABC
{
    public double[] Best;
    public double BestFitness = double.MaxValue;
}
```

3 real stubs (ABC / inertia-schedule / Schwefel), each with `execution_count` + outputs. But the tool reported **1** (only the markdown `## 10. Exercices` header counted) → flagged sub-threshold on `#2161`.

## Why the existing C# test didn't catch it

`test_csharp_double_slash_comment_exercise_is_counted` (added #5179) passes — but its cell contains a bare `pass`, so `_is_stub_code` matches via the `^\s*pass\s*$` pattern, **not** via `// TODO`. The `// TODO` detection path itself was untested.

## Fix

`scripts/notebook_tools/count_exercises.py` — `STUB_PATTERNS`:

```python
re.compile(r"#\s*TODO", re.IGNORECASE),
re.compile(r"//\s*TODO", re.IGNORECASE),      # NEW — C# / .NET line comment
re.compile(r"#\s*Indice", re.IGNORECASE),
re.compile(r"//\s*Indice", re.IGNORECASE),    # NEW
re.compile(r'Console\.WriteLine\(\$?["\']Exercice', re.IGNORECASE),  # $? accepts interpolated $"..."
```

**FP risk is minimal.** `_is_stub_code` only affects cells that already `_code_cell_mentions_exercise`. So a `// TODO` only reclassifies exercise-mentioning cells — and a `// TODO` in a cell that names an exercise is a student stub by definition (the student has work to do). A `// TODO` in a non-exercise cell changes nothing (mention-check gates first).

## Verification (firsthand)

| Check | Before | After |
|-------|--------|-------|
| `Search-11-Metaheuristics-Csharp` | 1 exercise (sub-threshold) | **3 exercises (conforming)** ✓ |
| Test suite | 29 passed | **31 passed** (+2 regression tests), 0 regressions |
| Repo-wide total exercises (915 notebooks) | 2713 | **2741** (+28 correctly detected) |
| Repo-wide conforming | 716 | **728** (+12) |
| Repo-wide sub-threshold | 199 | **187** (−12 no longer falsely flagged) |

New regression tests (`tests/test_count_exercises.py`):
1. `test_csharp_scaffolded_exercise_todo_with_code_is_counted` — `// Exercice 1` + `// TODO etudiant` + multi-line class skeleton must count (the exact Search-11 pattern).
2. `test_csharp_interpolated_console_writeline_exercice_is_counted` — `Console.WriteLine($"Exercice 2 a completer")` (interpolated) must count.

## How I found it (honest)

Investigating `#2161` sub-threshold notebooks in my lane (.NET / Search / CSP). The crude ad-hoc regex scanner I started with under-counted (markdown-header-only); the **canonical** `count_exercises.py` also under-counted (1 for Search-11). Direct-reading the cells firsthand revealed 3 genuine stubs → the tool had a residual `// TODO` blind-spot after #5179. Fixing the tool (not the notebook — the notebook is already correct) is the right move: prevents the whole cluster from re-discovering this and "fixing" already-conforming notebooks by stripping scaffolding (anti-régression risk).

## Hygiene

- **One subject**: tooling fix for C# stub detection + 2 regression tests. 2 files, +69/−1.
- **Atomic**: single commit `7c3f6ff3f`.
- **No notebook touched**: this is a detector fix, not a content change — the notebooks were already correct.
- **Tests**: 31/31 pass.

See #2161 (three-exercises-per-notebook convention). Does not close #2161.
