### PR TITLE
fix(lean): correct stale root name in grothendieck_lean + erc20_lean manifests (batch 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lake-manifest.json
@@ -111,7 +111,7 @@
       "configFile": "lakefile.toml"
     }
   ],
-  "name": "conway",
+  "name": "grothendieck",
   "lakeDir": ".lake",
   "fixedToolchain": false
 }

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lake-manifest.json
@@ -91,6 +91,6 @@
    "inputRev": "v4.31.0-rc1",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "knot_lean",
+ "name": "erc20_lean",
  "lakeDir": ".lake",
  "fixedToolchain": false}


### PR DESCRIPTION
## Summary

**Batch 2** of the stale-manifest-root-name cleanup (batch 1 = PR #5758, 6 lakes). A broader scan found **2 more lakes** with the same templating artifact: the lakefile declares the correct package name, but the manifest root `"name"` field carries a stale value copied from a sibling template at lake creation.

| Lake | lakefile package | manifest `name` before | after |
|------|-----------------|------------------------|-------|
| `SymbolicAI/Lean/grothendieck_lean` | `«grothendieck»` | `conway` | `grothendieck` |
| `SymbolicAI/SmartContracts/erc20_lean` | `«erc20_lean»` | `knot_lean` | `erc20_lean` |

## Why a separate PR (not extending #5758)

#5758 (batch 1, 6 lakes) is already pushed + reviewed (po-2023 c.17 gold-review) + coordinating a cross-lane duplicate (#5759 closed-as-dup by po-2024). Rebasing/force-pushing it now would invalidate that review thread and the coordination note. Same defect, same fix, same concern — but a clean separate PR keeps #5758's review trail intact. Atomic (one subject: stale manifest root names).

## Why surgical edit, not `lake update`

Both lakes are among the **19 junctioned lakes** sharing the rc1-`d568c8c09630` Mathlib checkout (`scripts/lean/setup_shared_mathlib.ps1`). Per the documented caveat: **`lake update` in a junctioned project mutates the SHARED Mathlib checkout for all group members** — forbidden. The manifest root `"name"` field is pure metadata (not build-critical — proven both ways), idempotent with what `lake update` would produce. Two indent schemes handled: grothendieck 2-space, erc20 1-space.

## Verification

- **2 files changed, 1 line each** (+2/−2); all other content byte-identical.
- Manifest root `name` now == lakefile `package «...»` for both (Python `re` match, verified).
- **0 stale values** (`conway`/`knot_lean`) remaining as root names.
- **Mathlib rev `d568c8c09630` unchanged** in both (dependency block untouched — only the root `name` line edited).
- **LF preserved** (no CRLF); JSON validated post-edit.

## Scope

Pure metadata hygiene, single concern, atomic. No Lean source, no proofs, no lakefiles, no notebooks touched.

Related: #5758 (batch 1), #4365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
