### PR TITLE
feat(lean): sudoku_lean root EN aggregator (Sudoku_en.lean) (#4980)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku_en.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/Sudoku_en.lean
@@ -1,0 +1,56 @@
+import Sudoku.Basic
+import Sudoku.Propagation
+import Sudoku.ExactCover
+
+/-!
+# Sudoku — soundness of propagation + exact-cover reduction (Lean 4)
+
+Formalization of the **soundness of the propagation rules** of a Sudoku (naked
+single, hidden single) and of the **Sudoku ⇔ exact cover reduction** (Knuth), the
+formal foundation of the solvers taught in the `Sudoku` series (backtracking,
+OR-Tools, .NET). See issue #4055 (Lean roadmap #4038).
+
+## Contents
+- `Sudoku.Basic`: abstract constraint structure — `Scopes` (all-distinct scopes),
+  `Solution`, `IsSolution`, `AllDistinctOn`, `IsPeer`, `PresentIn`. The
+  abstraction captures any "all-distinct-scopes" CSP (the 9×9 is an instance, not
+  a special case).
+- `Sudoku.Propagation`: the **keystone** `peer_excludes_value` (an assigned cell
+  excludes its value from its peers) and the two soundness theorems
+  `naked_single_sound` + `hidden_single_sound`, 0 `sorry`.
+- `Sudoku.ExactCover`: the Sudoku ⇔ exact cover reduction (Knuth, 4-family encoding
+  → 2 in the abstract framework). The capstone theorem `sudoku_iff_exact_cover`
+  proves the **complete equivalence**: `solution_imp_exact_cover` (forward
+  direction, via `toSelection` and the full-house lemma `full_house_present`) +
+  `exact_cover_imp_solution` (reverse direction, via the inverse construction
+  `fromSelection`), 0 `sorry`.
+
+## Status
+- Proved without `sorry`: (1) the soundness of the naked/hidden single rules
+  (keystone `peer_excludes_value`, propagation removes no valid solution); (2) the
+  **complete equivalence** Sudoku ⇔ exact cover — `(∃ σ, IsSolution scopes σ) ↔
+  (∃ sel, IsExactCover sel scopes)` under the "full house" hypothesis (satisfied by
+  the 9×9 where each scope has 9 cells for 9 values), in two steps: forward
+  `solution_imp_exact_cover` + reverse `exact_cover_imp_solution`.
+- Axioms: the standard Lean 4 kernel trio (`propext`, `Classical.choice`,
+  `Quot.sound`) — `Classical.choice` is used for the non-constructive construction
+  `fromSelection` (extracting a witness per cell from the `∃!` of cover). No ad-hoc
+  axioms.
+- Out of scope: the "17 minimum clues" result (massive computation, not
+  formalizable).
+
+## Cross-reference
+- `Sudoku` series (C#/.NET + Python): the backtracking/OR-Tools/Infer.NET solvers
+  whose propagation step this lake formally grounds.
+- #2978 (Sudoku as a symbolic regex): the Lean angle there = `finiteness-derivatives`
+  (recognizer termination), **no overlap** with the propagation/exact-cover
+  formalized here (coordination verified).
+-/
+
+/-!
+English mirror of `Sudoku.lean` (FR-first canonical), EPIC #4980 (i18n Lean).
+Convention ratified 2026-07-04 (issue #4980): distinct FR + EN sibling files in the
+same lake; this is a pure landing doc module (imports + module docstring, no
+declarations) so no namespace suffix is needed (mirrors the FR root structure
+exactly). Submodule EN siblings live under `Sudoku/*_en.lean` (#5538).
+-/


### PR DESCRIPTION
## Summary

English mirror of the FR-first **root landing module** of `sudoku_lean`, completing the i18n arc (#4980) for this lake. The `Sudoku/*` submodules already had EN siblings (#5538 MERGED — Basic_en, Propagation_en, ExactCover_en); only the **root aggregator** `Sudoku.lean` lacked an `_en` mirror.

- `Sudoku_en.lean` — EN translation of the ~48-line FR module docstring (soundness of naked/hidden single propagation, Sudoku ⇔ exact-cover reduction / Knuth, status, axiom note, cross-references).

Convention ratified 2026-07-04 (#4980, comment-4881909354): distinct FR + EN sibling files in the same lake. This is a **pure landing doc module** (imports + module docstring, no declarations), mirroring the FR root structure exactly — no namespace suffix needed.

## Firsthand verification (G.1)

| Check | Result |
|-------|--------|
| Structural parity (imports) | same 3 imports as FR `Sudoku.lean` ✓ |
| Both pure doc modules | zero `namespace`/`def`/`theorem`/`abbrev` declarations (FR + EN) ✓ |
| CRLF / encoding | LF-only, trailing newline ✓ |
| CATALOG byte-identical to main | ✓ (no catalog files touched) |
| Scope | 1 file, +56, single subject (atomic) |

## Build-target note

`Sudoku_en.lean` is a **standalone landing doc module** — not in `lean_lib` globs (`.submodules Sudoku` reaches the submodules `Sudoku.*`, not the root). Neither FR `Sudoku.lean` nor EN `Sudoku_en.lean` is a `lake build` target. This is **by design and consistent** with the FR root (same as the learning_theory_lean pattern proven in #5764). No `lakefile.lean` change needed.

## Note on local elaboration (transparent, G.9)

`lake env lean Sudoku_en.lean` could **not** run locally because the **shared mathlib cache is corrupted**: `.mathlib-cache/leanprover_lean4_v4.31.0-rc1-d568c8c0/mathlib` git `origin` points to `https://github.com/jsboige/CoursIA` (the CoursIA repo, not mathlib) and the `d568c8c0` tree object is absent. This affects **BOTH** FR `Sudoku.lean` and EN identically (same `mathlib: URL has changed; unable to read tree` error) — so it is an environment defect, not a file defect.

**CI fresh clone is the verification source** (the same pure-doc-module pattern was proven CI-green on learning_theory_lean in #5764 — `Lean CI` PASS 1m55s). Reported separately to ai-01 as an infra finding (shared cache affects all 19 junctioned lakes).

## Anti-regression (§D)

Pure addition (+56, 0 deletions). No existing FR file modified. EN mirror only translates the docstring.

## Related

See #4980 (partial — completes the i18n arc for this lake; the EPIC spans all Lean lakes). Companion to #5764 (learning_theory_lean root EN aggregators, same pattern).