### PR TITLE
fix(notebook-tools): count_exercises detect .NET Interactive display() stub markers (#2161)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -121,7 +121,12 @@ STUB_PATTERNS = [
     # `$?` accepts both regular (`"..."`) and interpolated (`$"..."`) strings:
     # `Console.WriteLine($"Exercice 2 a completer ...")` is the idiomatic C#
     # interpolated form and was not matched by the quote-only variant.
-    re.compile(r'Console\.WriteLine\(\$?["\']Exercice', re.IGNORECASE),
+    # `display(...)` (not `Console.WriteLine`) is the .NET Interactive idiom for
+    # stub markers: `Console.WriteLine` is SWALLOWED in headless papermill, so
+    # authors use `display("Exercice ... a completer")` instead. Without the
+    # `display` form, such stubs were under-counted (e.g. GameTheory-5 cell Ex2,
+    # `display("Exercice 2 a completer ...")` with no `// TODO`/`// Indice`).
+    re.compile(r'(?:Console\.WriteLine|display)\(\$?["\']Exercice', re.IGNORECASE),
     re.compile(r"^\s*result\s*=\s*None\b", re.MULTILINE | re.IGNORECASE),
     re.compile(r"^\s*raise\s+NotImplementedError", re.MULTILINE),
     re.compile(r"^\s*assert\s+False\b", re.MULTILINE),

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -364,6 +364,32 @@ class TestCodeCellOnlyExercise:
             'C# interpolated Console.WriteLine($"Exercice ...") must count'
         )
 
+    def test_csharp_display_fn_exercice_is_counted(self, tmp_path):
+        """``display("Exercice ...")`` (the .NET Interactive ``display`` helper,
+        not ``Console.WriteLine``) is a stub marker. Authors use ``display(...)``
+        because ``Console.WriteLine`` is swallowed in headless papermill. A stub
+        cell that carries ``display("Exercice ... a completer")`` but neither
+        ``// TODO`` nor ``// Indice`` must still be counted.
+
+        Regression for ``GameTheory-5-ZeroSum-Minimax-Csharp`` Ex2, whose stub
+        marker ``display("Exercice 2 a completer ...")`` was silently
+        under-counted (notebook read as 2 exercises instead of its real 3).
+        """
+        nb = _write_nb(
+            tmp_path / "display.ipynb",
+            [
+                _md("# Titre C#"),
+                _code(
+                    "// Exercice 2 : verifier le theoreme minimax.\n"
+                    'display("Exercice 2 a completer : matrice 3x3 -> SolveMatrixGame");\n'
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            "display(\"Exercice ...\") stub (no // TODO / // Indice) must count"
+        )
+
     def test_inline_csharp_comment_after_code_is_not_a_stub_marker(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary

Widens `count_exercises` to detect `.NET Interactive` **`display("Exercice ...")` stub markers** — the follow-up blind-spot I root-caused firsthand on PR #5760 (c.23). **Greenlit by ai-01** ([RooSync `msg-20260708T223940`](https://...)) as a small owner-lane PR. `See #2161`.

## Root cause

`Console.WriteLine` is **swallowed in headless papermill**, so `.NET Interactive` authors correctly use the `display(...)` helper for stub markers instead. PR #5760's pattern matched only `Console.WriteLine`, so a stub cell carrying `display("Exercice ... a completer")` — but **no `// TODO` and no `// Indice`** — was silently under-counted.

**Canonical case**: `GameTheory-5-ZeroSum-Minimax-Csharp.ipynb` Ex2 — `display("Exercice 2 a completer ...")`, no `// TODO`/`// Indice` → counted 0; the notebook read as **2 exercises instead of its real 3**.

## Fix

`scripts/notebook_tools/count_exercises.py` — STUB_PATTERNS, widen the `Console.WriteLine` line:

```python
re.compile(r'(?:Console\.WriteLine|display)\(\$?["\']Exercice', re.IGNORECASE),
```

## Acceptance (all verified firsthand)

| # | Criterion | Result |
|---|-----------|--------|
| 1 | GT-5 count 2→3 | **3 (Conforming)** ✓ |
| 2 | tests 31→32 green | **32 passed** ✓ |
| 3 | 0 regression (full notebook-tools suite) | **2013 passed** ✓ |
| 4 | FP-safe (prod `display()` outside exercise cells doesn't inflate) | verified via `_code_cell_mentions_exercise` AND-gate ✓ |

## FP safety

`_is_stub_code` is gated by `_code_cell_mentions_exercise` (line 334, AND-logic). A production `display("result: 42")` call (no "Exercice" mention) → not counted. Verified:

```
prod display(no exo)     : counted=0   ← FP-safe
GT-5 Ex2 shape           : counted=1   ← fixed
Console.WriteLine (ex1)  : counted=1   ← no regression
interpolated $" (ex2)    : counted=1   ← no regression
```

## Scope

Atomic: `scripts/notebook_tools/count_exercises.py` (+7) + `scripts/notebook_tools/tests/test_count_exercises.py` (+26, 1 new test `test_csharp_display_fn_exercice_is_counted`). 2 files, no notebook/doc changes. Base fresh from `origin/main` (`03102123f`).

Composes with #5760 (which fixed the `// TODO` + interpolated-`Console.WriteLine` paths); this PR closes the `display()` path that #5760 didn't reach. `See #2161` (not closing — tooling improvement, not a strategy resolution).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
