### PR TITLE
feat(lean): decision_theory_lean Coherence root EN aggregator (Coherence_en.lean)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence_en.lean
@@ -1,0 +1,51 @@
+import Coherence.Basic
+import Coherence.DutchBook
+import Coherence.Probability
+
+/-!
+# Decision Theory — Dutch Book / coherence (de Finetti)
+
+Formalization of de Finetti's coherence theorem (finite case): the conceptual
+foundation of probabilities. **Incoherent** betting prices (violating
+inclusion–exclusion) expose the agent to a **Dutch Book** — a book of bets at
+sure loss. Coherence therefore *forces* the probability axioms.
+
+## Contents
+- `Coherence.Basic`: events (`Event`), price functions (`Price`), indicators, and
+  the inclusion–exclusion identity (`ind_inclusion_exclusion`) — the keystone.
+- `Coherence.DutchBook`: the constructive direction "incoherence ⟹ Dutch Book"
+  (`non_additive_implies_dutch_book`, explicit witness, 0 `sorry`) and its
+  contrapositive "coherence ⟹ additivity" (`coherent_on_implies_additive`).
+- `Coherence.Probability`: the **single-book characterization** of de Finetti
+  (`single_coherent_iff_prob_bounds`) — a price function `q` is coherent in the
+  single-ticket sense (no single-ticket Dutch Book) **iff** it satisfies the
+  probability bounds `0 ≤ q A ≤ 1`, `q ∅ = 0`, `q univ = 1`. Each violated axiom
+  admits an explicit single-ticket Dutch Book (`single_dutch_book_of_neg/high/pos_empty/univ_lt`),
+  0 `sorry`.
+
+## Status
+- Proved without `sorry`: the constructive direction (inclusion–exclusion
+  violation ⟹ Dutch Book with explicit stakes `(1,1,−1,−1)` or the converse),
+  coherence ⟹ additivity on two events, and the **complete single-book
+  characterization** (`single_coherent_iff_prob_bounds`, 0 `sorry`, axioms
+  `[propext, Classical.choice, Quot.sound]`).
+- Open (next milestone): the full `coherent_iff_probability` (arbitrary-size
+  books, via the measure reconstruction `q A = Σ_{ω ∈ A} q {ω}` then the
+  expectation argument, or hyperplane separation / LP duality in finite
+  dimension). The single-book version delivered here is its tractable core (Lean
+  feasibility "MEDIUM", cf #4050).
+
+## Cross-references
+- `Utility` (same lake): von Neumann–Morgenstern expected-utility representation —
+  the other foundation of decision theory under risk.
+- Infer-14 (Infer.NET): Bayesian expected utility under the posterior.
+- PyMC-1 (PyMC): expected-utility estimation by posterior sampling.
+-/
+
+/-!
+English mirror of `Coherence.lean` (FR-first canonical), EPIC #4980 (i18n Lean).
+Convention ratified 2026-07-04 (issue #4980): distinct FR + EN sibling files in the
+same lake; this is a pure landing doc module (imports + module docstring, no
+declarations) so no namespace suffix is needed (mirrors the FR root structure
+exactly). Submodule EN siblings live under `Coherence/*_en.lean`.
+-/


### PR DESCRIPTION
## What

English mirror of the FR-first root landing module `Coherence.lean` of `decision_theory_lean`, completing the i18n arc (#4980) for the **Coherence sublibrary**. The `Coherence/*` submodules already had EN siblings (`Basic_en`, `DutchBook_en`, `Probability_en`, merged in #5565); only the root aggregator lacked one.

## Why

EPIC #4980 (i18n Lean): distinct FR + EN sibling files in the same lake, convention ratified 2026-07-04. A FR student reads the proofs in FR, an English reader in EN. The `Coherence.lean` FR root carried a ~43-line module docstring (de Finetti coherence theorem, Dutch Book / inclusion-exclusion, single-book characterization, status, cross-references to Utility/Infer-14/PyMC-1) that had no EN twin.

## How — pure landing doc module (same pattern as #5764, #5765)

`Coherence_en.lean` = imports + module docstring (EN translation), **zero declarations**. It mirrors the FR root structure exactly:
- Same 3 imports (`Coherence.Basic`, `Coherence.DutchBook`, `Coherence.Probability`).
- Pure doc module → **no namespace suffix** needed (no declarations to disambiguate; the FR root has no namespace either).
- **Not in `lean_lib` globs**: the `decision_theory_lean` lake uses `globs := #[.submodules Utility, .submodules Coherence, .submodules Gittins]`, which reaches `Coherence.*` (the submodules), not the bare root `Coherence`. So neither the FR root `Coherence.lean` nor this EN root is a `lake build` target — both are standalone landing docs (orphan-trap avoided, consistent with FR). **No `lakefile.lean` change.**

Precedent: #5764 (learning_theory_lean roots) and #5765 (sudoku_lean root), both MERGED, same standalone-landing-doc pattern.

## Structural parity (verified firsthand)

| | FR `Coherence.lean` | EN `Coherence_en.lean` |
|---|---|---|
| imports | 3 (Basic/DutchBook/Probability) | 3 (identical) |
| declarations | none (pure doc) | none (pure doc) |
| namespace | none | none |
| line endings | LF-only, trailing newline | LF-only, trailing newline |

§D anti-regression: clean — pure addition (+51, 0 deletions), no source/preof touched, no `sorry` involved.

## Note on local elaboration

`lake env lean Coherence_en.lean` cannot run locally: the shared mathlib cache (`.mathlib-cache/leanprover_lean4_v4.31.0-rc1-d568c8c0/mathlib`) is **corrupted** — its git `origin` points to `https://github.com/jsboige/CoursIA` (the CoursIA repo, NOT mathlib) and HEAD = CoursIA main, so the mathlib tree `d568c8c0` is absent (`git cat-file -t` fails). This is a **fleet-wide environment defect** affecting all 19 junctioned lakes identically (FR and EN fail the same way) — not a file defect.

Per ai-01 decision (RooSync msg-20260708T223707, durable rule):

> Do NOT block Lean i18n merges on local build failure when the PR carries a green Lean CI job. The green CI Lean job IS the authoritative compile proof; local cache is irrelevant to the merge gate.

The same pure-doc-module pattern was proven CI-green on #5764 (`Lean CI learning_theory_lean` PASS 1m55s) and #5765 (`Lean CI sudoku_lean` PASS). Shared-cache repair is tracked as an autonomous non-blocking infra grain (greenlit by ai-01, no-rush).

## Verification checklist

- [x] Structural parity FR ↔ EN (imports, declarations, namespace, line endings)
- [x] Pure addition, §D anti-regression clean (+51, 0 deletions)
- [x] CATALOG byte-identical to main (no churn)
- [x] Same pattern as #5764 / #5765 (MERGED)
- [ ] `Lean CI decision_theory_lean` green (canonical gate per ai-01 rule; expected green like #5764/#5765)

See #4980 (partial — completes the Coherence sublibrary root; the EPIC spans all Lean lakes).