### PR TITLE
enrich(gametheory): GT-4c Nash exercises supplementaires 2+3 code stubs (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
@@ -106,147 +106,31 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
-       "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:3c97:6970:5b83:ff68:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '49652.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": "\r\n<div>\r\n    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n    </div>\r\n    <script type='text/javascript'>\r\nasync function probeAddresses(probingAddresses) {\r\n    function timeout(ms, promise) {\r\n        return new Promise(function (resolve, reject) {\r\n            setTimeout(function () {\r\n                reject(new Error('timeout'))\r\n            }, ms)\r\n            promise.then(resolve, reject)\r\n        })\r\n    }\r\n\r\n    if (Array.isArray(probingAddresses)) {\r\n        for (let i = 0; i < probingAddresses.length; i++) {\r\n\r\n            let rootUrl = probingAddresses[i];\r\n\r\n            if (!rootUrl.endsWith('/')) {\r\n                rootUrl = `${rootUrl}/`;\r\n            }\r\n\r\n            try {\r\n                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n                    method: 'POST',\r\n                    cache: 'no-cache',\r\n                    mode: 'cors',\r\n                    timeout: 1000,\r\n                    headers: {\r\n                        'Content-Type': 'text/plain'\r\n                    },\r\n                    body: probingAddresses[i]\r\n                }));\r\n\r\n                if (response.status == 200) {\r\n                    return rootUrl;\r\n                }\r\n            }\r\n            catch (e) { }\r\n        }\r\n    }\r\n}\r\n\r\nfunction loadDotnetInteractiveApi() {\r\n    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2048/\",\"http://172.29.0.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:e0fb:b2fb:5f8f:6805:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::781:37f3:97d5:ccae%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n        .then((root) => {\r\n        // use probing to find host url and api resources\r\n        // load interactive helpers and language services\r\n        let dotnetInteractiveRequire = require.config({\r\n        context: '230116.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n                paths:\r\n            {\r\n                'dotnet-interactive': `${root}resources`\r\n                }\r\n        }) || require;\r\n\r\n            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n\r\n            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n                let paths = {};\r\n                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n                \r\n                let internalRequire = require.config({\r\n                    context: extensionCacheBuster,\r\n                    paths: paths,\r\n                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n                    }) || require;\r\n\r\n                return internalRequire\r\n            };\r\n        \r\n            dotnetInteractiveRequire([\r\n                    'dotnet-interactive/dotnet-interactive'\r\n                ],\r\n                function (dotnet) {\r\n                    dotnet.init(window);\r\n                },\r\n                function (error) {\r\n                    console.log(error);\r\n                }\r\n            );\r\n        })\r\n        .catch(error => {console.log(error);});\r\n    }\r\n\r\n// ensure `require` is available globally\r\nif ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n    let require_script = document.createElement('script');\r\n    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n    require_script.setAttribute('type', 'text/javascript');\r\n    \r\n    \r\n    require_script.onload = function() {\r\n        loadDotnetInteractiveApi();\r\n    };\r\n\r\n    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n}\r\nelse {\r\n    loadDotnetInteractiveApi();\r\n}\r\n\r\n    </script>\r\n</div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Point fixe trouve   : 1,0000000000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Point fixe trouve   : 1,0000000000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Verification f(x*)  : 1,0000000000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Verification f(x*)  : 1,0000000000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Iterations          : 6\r\n"
-     ]
+     "name": "stdout",
+     "text": "Iterations          : 6\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "|f(x*) - x*|        : 1,11E-015\r\n"
-     ]
+     "name": "stdout",
+     "text": "|f(x*) - x*|        : 1,11E-015\r\n"
     }
    ],
    "source": [
@@ -317,34 +201,24 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Point fixe 2D : [0,5000, 0,5000]\r\n"
-     ]
+     "name": "stdout",
+     "text": "Point fixe 2D : [0,5000, 0,5000]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Somme         : 1,000000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Somme         : 1,000000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Iterations    : 106\r\n"
-     ]
+     "name": "stdout",
+     "text": "Iterations    : 106\r\n"
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(14,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
+     "text": "\r\n(14,44): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n\r\n"
     }
    ],
    "source": [
@@ -435,67 +309,49 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "==================================================\r\n"
-     ]
+     "name": "stdout",
+     "text": "==================================================\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "MATCHING PENNIES - Point fixe\r\n"
-     ]
+     "name": "stdout",
+     "text": "MATCHING PENNIES - Point fixe\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "==================================================\r\n"
-     ]
+     "name": "stdout",
+     "text": "==================================================\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Strategie initiale     : [0,5000, 0,5000]\r\n"
-     ]
+     "name": "stdout",
+     "text": "Strategie initiale     : [0,5000, 0,5000]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Gain espere J1 (U1)    : 0,0000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Gain espere J1 (U1)    : 0,0000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Gain espere J2 (U2)    : 0,0000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Gain espere J2 (U2)    : 0,0000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "BR perturbee J1        : [0,5000, 0,5000]\r\n"
-     ]
+     "name": "stdout",
+     "text": "BR perturbee J1        : [0,5000, 0,5000]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Est un point fixe ?    : True\r\n"
-     ]
+     "name": "stdout",
+     "text": "Est un point fixe ?    : True\r\n"
     }
    ],
    "source": [
@@ -582,74 +438,54 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Convergence vers Nash (0.5, 0.5) depuis 3 departs :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Convergence vers Nash (0.5, 0.5) depuis 3 departs :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Depart         | Apres 5 it     | Apres 20 it    | Apres 50 it   \r\n"
-     ]
+     "name": "stdout",
+     "text": "Depart         | Apres 5 it     | Apres 20 it    | Apres 50 it   \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "------------------------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "------------------------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[0,9000, 0,1000] | [0,6507, 0,3493] | [0,5531, 0,4469] | [0,5233, 0,4767]\r\n"
-     ]
+     "name": "stdout",
+     "text": "[0,9000, 0,1000] | [0,6507, 0,3493] | [0,5531, 0,4469] | [0,5233, 0,4767]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[0,1000, 0,9000] | [0,3493, 0,6507] | [0,4469, 0,5531] | [0,4767, 0,5233]\r\n"
-     ]
+     "name": "stdout",
+     "text": "[0,1000, 0,9000] | [0,3493, 0,6507] | [0,4469, 0,5531] | [0,4767, 0,5233]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[0,7000, 0,3000] | [0,6098, 0,3902] | [0,5470, 0,4530] | [0,5220, 0,4780]\r\n"
-     ]
+     "name": "stdout",
+     "text": "[0,7000, 0,3000] | [0,6098, 0,3902] | [0,5470, 0,4530] | [0,5220, 0,4780]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      ">>> Tous les points de depart convergent vers (0.5, 0.5) = equilibre de Nash.\r\n"
-     ]
+     "name": "stdout",
+     "text": ">>> Tous les points de depart convergent vers (0.5, 0.5) = equilibre de Nash.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      ">>> C'est l'illustration numerique du theoreme de Brouwer :\r\n"
-     ]
+     "name": "stdout",
+     "text": ">>> C'est l'illustration numerique du theoreme de Brouwer :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      ">>> la dynamique continue BR a un point fixe sur le simplexe.\r\n"
-     ]
+     "name": "stdout",
+     "text": ">>> la dynamique continue BR a un point fixe sur le simplexe.\r\n"
     }
    ],
    "source": [
@@ -727,2960 +563,2114 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Depart [0,9000, 0,1000] -> Nash (0.5, 0.5)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Depart [0,9000, 0,1000] -> Nash (0.5, 0.5)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  P(Tails)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  P(Tails)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  1,0 "
-     ]
+     "name": "stdout",
+     "text": "  1,0 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,9 "
-     ]
+     "name": "stdout",
+     "text": "  0,9 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,8 "
-     ]
+     "name": "stdout",
+     "text": "  0,8 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,6 "
-     ]
+     "name": "stdout",
+     "text": "  0,6 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,5 "
-     ]
+     "name": "stdout",
+     "text": "  0,5 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "N"
-     ]
+     "name": "stdout",
+     "text": "N"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,4 "
-     ]
+     "name": "stdout",
+     "text": "  0,4 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,2 "
-     ]
+     "name": "stdout",
+     "text": "  0,2 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,1 "
-     ]
+     "name": "stdout",
+     "text": "  0,1 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "D"
-     ]
+     "name": "stdout",
+     "text": "D"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,0 "
-     ]
+     "name": "stdout",
+     "text": "  0,0 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    0.0          1.0  P(Heads)\r\n"
-     ]
+     "name": "stdout",
+     "text": "    0.0          1.0  P(Heads)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    D=depart  #=trajectoire  N=Nash(0.5,0.5)\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "    D=depart  #=trajectoire  N=Nash(0.5,0.5)\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Depart [0,1000, 0,9000] -> Nash (0.5, 0.5)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Depart [0,1000, 0,9000] -> Nash (0.5, 0.5)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  P(Tails)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  P(Tails)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  1,0 "
-     ]
+     "name": "stdout",
+     "text": "  1,0 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,9 "
-     ]
+     "name": "stdout",
+     "text": "  0,9 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "D"
-     ]
+     "name": "stdout",
+     "text": "D"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,8 "
-     ]
+     "name": "stdout",
+     "text": "  0,8 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,6 "
-     ]
+     "name": "stdout",
+     "text": "  0,6 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,5 "
-     ]
+     "name": "stdout",
+     "text": "  0,5 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#"
-     ]
+     "name": "stdout",
+     "text": "#"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "N"
-     ]
+     "name": "stdout",
+     "text": "N"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,4 "
-     ]
+     "name": "stdout",
+     "text": "  0,4 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,2 "
-     ]
+     "name": "stdout",
+     "text": "  0,2 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,1 "
-     ]
+     "name": "stdout",
+     "text": "  0,1 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0,0 "
-     ]
+     "name": "stdout",
+     "text": "  0,0 "
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "."
-     ]
+     "name": "stdout",
+     "text": "."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    0.0          1.0  P(Heads)\r\n"
-     ]
+     "name": "stdout",
+     "text": "    0.0          1.0  P(Heads)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    D=depart  #=trajectoire  N=Nash(0.5,0.5)\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "    D=depart  #=trajectoire  N=Nash(0.5,0.5)\n\r\n"
     }
    ],
    "source": [
@@ -3773,11 +2763,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice Chicken a completer (voir indice ci-dessus).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice Chicken a completer (voir indice ci-dessus).\r\n"
     }
    ],
    "source": [
@@ -3813,11 +2801,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 2 (Battle of the Sexes) à compléter : itérez NashDynamicsStep depuis 3 départs.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 2 (Battle of the Sexes) à compléter : itérez NashDynamicsStep depuis 3 départs.\r\n"
     }
    ],
    "source": [
@@ -3859,11 +2845,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 3 (Dilemme du prisonnier) à compléter : vérifiez la convergence vers le NE pur (0, 1).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 3 (Dilemme du prisonnier) à compléter : vérifiez la convergence vers le NE pur (0, 1).\r\n"
     }
    ],
    "source": [
@@ -3879,6 +2863,76 @@
     "//      (Indice : anti-coordination vs dominance stricte.)\n",
     "// TODO étudiant\n",
     "Console.WriteLine(\"Exercice 3 (Dilemme du prisonnier) à compléter : vérifiez la convergence vers le NE pur (0, 1).\");\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "// EXERCICE 2 (supplementaire) : dynamique de meilleure reponse ALTERNEE.\n",
+    "// Au lieu de moyenner BR1 et BR2 simultanement (NashDynamicsStep), alternez-les :\n",
+    "// J1 joue sa BR courante, puis J2 repond a la BR de J1, puis J1 repond a J2, etc.\n",
+    "// Question : la convergence vers (0.5, 0.5) differe-t-elle de la dynamique simutanee ?\n",
+    "// Pourquoi la simultaneite (moyenne des BR) est-elle plus proche de la preuve de Nash\n",
+    "// (qui invoque Brouwer sur f = moyenne des BR) que l'alternance ?\n",
+    "// Indice : PerturbedBR(sigma, U, epsilon=0.1) calcule la BR d'UN joueur (cellule 6).\n",
+    "//          L'alternance = J1 fixe sigma1, J2 repond via PerturbedBR(sigma, U2),\n",
+    "//          puis on recombine (sigma1, sigma2_repondu) -- une etape = 2 sous-etapes.\n",
+    "//          Comparer le nombre d'iterations pour atteindre |sigma - (0.5,0.5)| < 0.01.\n",
+    "\n",
+    "// TODO etudiant : iterer une dynamique alternee (J1 puis J2) depuis (0.9, 0.1)\n",
+    "//                 et comparer la vitesse de convergence a NashDynamicsStep.\n",
+    "double[] NashDynamicsStepAlternate(double[] sigma, double[,] u1, double[,] u2, double epsilon = 0.2) {\n",
+    "    // Etape 1 : J1 joue sa BR courante (PerturbedBR sur u1).\n",
+    "    // Etape 2 : J2 repond a la BR de J1 (PerturbedBR sur u2, avec le sigma mis a jour).\n",
+    "    // Etape 3 : recombinez (sigma1_new, sigma2_new) et projetez sur le simplexe.\n",
+    "    return (double[])sigma.Clone();  // TODO etudiant : remplacer par la dynamique alternee\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 2 a completer : dynamique alternee vs simultanee.\");\n"
+   ],
+   "metadata": {},
+   "execution_count": 9,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 2 a completer : dynamique alternee vs simultanee.\r\n"
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "// EXERCICE 3 (supplementaire) : verificateur d'hypotheses de Brouwer.\n",
+    "// Brouwer exige pour f : Delta -> Delta : (a) continue, (b) Delta convexe compact,\n",
+    "// (c) f(Delta) subset Delta. Implementez un verificateur qui teste ces 3 proprietes\n",
+    "// sur une fonction donnee, puis testez sur PerturbedBR (qui les satisfait) et sur\n",
+    "// une fonction discontinue (qui les viole).\n",
+    "// Indice : Delta = simplexe 2D {(p, 1-p) : p in [0,1]}.\n",
+    "//   (a) continuite : discretisez [0,1] en N pas, verifiez |f(p1)-f(p2)| petit quand\n",
+    "//       |p1-p2| petit (test Lipschitz numerique).\n",
+    "//   (b) Delta convexe compact : toujours vrai pour le simplexe (fait Mathlib/theorique).\n",
+    "//   (c) f(Delta) subset Delta : verifiez ProjectSimplex(f(p)) ~ f(p) sur la grille.\n",
+    "//   Discontinu test : f(p) = p < 0.5 ? (1,0) : (0,1) -- saut, viole (a).\n",
+    "\n",
+    "// TODO etudiant : implementez VerifierBrouwer(f, N) renvoyant (continue, stable_simplexe).\n",
+    "(bool continuous, bool stableSimplex) VerifierBrouwer(Func<double[], double[]> f, int N = 50) {\n",
+    "    // Etape 1 : discretisez p in [0,1] en N pas, sigma = (p, 1-p).\n",
+    "    // Etape 2 : continuite -> max |f(p1)-f(p2)| / |p1-p2| borne (test Lipschitz).\n",
+    "    // Etape 3 : stableSimplexe -> ProjectSimplex(f(sigma)) ~ f(sigma) pour tout p.\n",
+    "    return (false, false);  // TODO etudiant\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 3 a completer : verificateur d'hypothese de Brouwer.\");\n"
+   ],
+   "metadata": {},
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice 3 a completer : verificateur d'hypothese de Brouwer.\r\n"
+    }
    ]
   },
   {


### PR DESCRIPTION
## Summary

`GameTheory-4c-NashExistence-Csharp.ipynb` had **3 main exercises** (cells 12/14/16, all with stubs) but its `## Exercices supplémentaires` section (cell 17 Bilan) **described two more exercises with NO companion code stub** — a genuine exercise-content gap ([#2161](https://github.com/jsboige/CoursIA/issues/2161)), same pattern as SL-2 (PR #5762) and SL-5 (PR #5763): a *described* exercise should have a stub.

## What was wrong (firsthand)

```
cell 17 (markdown): ## Bilan ... ## Exercices supplémentaires
                     ### Exercice 2 : dynamique de meilleure réponse alternée   ← described, NO code stub ✗
                     ### Exercice 3 : vérificateur d'hypothèses de Brouwer      ← described, NO code stub ✗
```

The two exercises were prose only — no code cell for the student to fill.

## Fix

Inserted 2 C.1-compliant code stub cells (now cells 17-18, before Bilan which shifted to 19), reusing the existing `PerturbedBR` / `NashDynamicsStep` / `ProjectSimplex` signatures from cells 6/8 and following the existing Exercice 1 stub pattern (`// EXERCICE N` + `// TODO etudiant` + `// Indice` + skeleton + `Console.WriteLine("Exercice ... à compléter")`):

- **Ex 2 supp — `NashDynamicsStepAlternate(sigma, u1, u2, epsilon)`**: J1 plays its current BR, then J2 responds to J1's BR (alternating instead of simultaneous averaging). Question: does convergence to (0.5, 0.5) differ, and why is simultaneity closer to Nash's original Brouwer proof?
- **Ex 3 supp — `VerifierBrouwer(f, N)`**: test the 3 Brouwer hypotheses (continuity via numeric Lipschitz, convex-compact simplex, `f(Δ) ⊆ Δ`) on `PerturbedBR` (satisfies) and a discontinuous function (violates).

No `raise NotImplementedError` / `assert False` / `1/0` (rule C.1).

## Validation (firsthand)

| Check | Result |
|-------|--------|
| **Re-execution** (.NET Interactive, `dotnet_executor` module, `.net-csharp` kernel) | **10/10 code cells, 0 errors**, `execution_count` 1-10 sequential |
| **Outputs** | REAL .NET stream outputs (not hand-edited — Stop & Repair rule 6). Ex 2 stub prints `Exercice 2 a completer : dynamique alternee vs simultanee.`; Ex 3 prints `Exercice 3 a completer : verificateur d'hypothese de Brouwer.` |
| **C.1** | 0 `NotImplementedError` / `assert False` / `1/0` (verified by direct read of cells 17-18) |
| **Semantic source-diff** | ONLY cells 17-18 added (Ex 2 + Ex 3 supp), Bilan shifted 17→19 (byte-identical); **all other cell sources byte-identical** (0 mismatches) |
| **Original cell 10** (ASCII viz, 422 outputs) | Preserved (re-execution did not wipe) |
| **Line endings** | LF-normalized per `.gitattributes` (`*.ipynb eol=lf`) + trailing newline |

## Note on diff size

The diff is +978/−1924 lines, but the **source** change is only the 2 added cells (verified by semantic source-diff, 0 source mismatches on original cells). The large line-count is dominated by **papermill metadata timestamp churn** (`duration`/`end_time`/`start_time` regenerated on every cell by re-execution) + the LF normalization (CRLF→LF across the file) — benign, required by C.2 (re-execution).

## Honest note on the detector

The canonical `count_exercises.py` may under-count C# stubs whose marker line format isn't `// Exercice N :` (this notebook's Ex1 uses `// Cellule 10 — Exercice 1`). The notebook **content** is correct regardless (2 described exercises now have companion stubs).

## Hygiene

- **One subject**: 2 exercise stubs in 1 notebook, single commit.
- **Atomic**: commit `0f4484d1a`.
- **No catalog touched**, no `.lean` touched, no anti-régression (pure additive exercise content).

See #2161 (three-exercises-per-notebook), See #4956 (.NET/Python parity). Does not close #2161.