### PR TITLE
chore(lean): track finiteness_lean lake-manifest.json (consistency with 8 sibling lakes)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lake-manifest.json
@@ -1,0 +1,6 @@
+{"version": "1.2.0",
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "finiteness",
+ "lakeDir": ".lake",
+ "fixedToolchain": false}


### PR DESCRIPTION
## What

Track `finiteness_lean/lake-manifest.json` in git. It is currently untracked (shows as `??` in every `git status`), while 8 sibling Lean lakes commit theirs — including **2 zero-dependency lakes** (`lean_game_defs`, `lean_game_defs_ext`). finiteness_lean is the lone outlier.

## Why

Consistency with the repo-wide convention. The manifest is generated by `lake build`; committing it (a) removes recurring `git status` noise, (b) aligns with the 8 tracked lakes. For a zero-dep lake the manifest pins no upstream rev, but precedent (`lean_game_defs`, `lean_game_defs_ext`, both zero-dep and tracked) establishes that the convention is to track regardless of dependency count.

## Firsthand verification (G.1)

The manifest is well-formed and non-stale:
- `"name": "finiteness"` matches `package «finiteness»` in `lakefile.lean` (not a stale rename artifact, cf the c.350/c.352 junction-manifest lessons — though those apply to **junctioned** lakes; finiteness_lean is **standalone**, empty `.lake`, no shared-cache symlink).
- `"packages": []` matches the lakefile's declared autonomy ("autonome, sans dépendance Mathlib").
- `"fixedToolchain": false` is **consistent** with `decision_theory_lean` and `lean_game_defs` (both also carry a `lean-toolchain` file pinning `v4.31.0-rc1` — the toolchain is pinned there, the manifest field stays false).
- LF-only + trailing newline, compliant with `.gitattributes` (`lake-manifest.json text eol=lf`).

## Safety

- 1 file, +6/-0, single subject (manifest tracking consistency).
- No CI workflow regenerates `lake-manifest.json` (grep confirmed) → no churn.
- Standalone lake (not junctioned) → no shared-checkout race (unlike the c.352 junction-manifest surgical-edit caveat, which does **not** apply here).
- Deterministic for a 0-dep lake (`lake build` regenerates it identically) → trivially reversible if wrong.

No issue reference (pure repo-hygiene consistency cleanup; not tied to an epic).