### PR TITLE
fix(lean): setup_lean4_all.py WSL distro UTF-16 + Windows path translation

### DIFF
--- a/scripts/lean/setup_lean4_all.py
+++ b/scripts/lean/setup_lean4_all.py
@@ -30,17 +30,59 @@ LEAN_SCRIPTS = REPO_ROOT / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean" / "script
 
 WSL_DISTRO = "Ubuntu"
 
+# Regex + helper mirror scripts/notebook_tools/wsl_papermill.py:win_to_wsl_path
+# (kept local to avoid a cross-directory import; identical logic, #2871 part 2).
+import re as _re
+_WIN_DRIVE_RE = _re.compile(r"^([A-Za-z]:)[\\/](.*)$")
+
+
+def _win_to_wsl_path(win_path: str) -> str:
+    """Convert a Windows path (``C:\\dev\\repo``) to its WSL mount form
+    (``/mnt/c/dev/repo``). WSL ``bash`` strips backslashes from args, so passing
+    a raw Windows path to ``wsl -- bash <winpath>`` yields ``C:devrepo`` ->
+    file-not-found (incident po-2024 c.355 lean4-wsl setup, exit 127). A path
+    without a drive prefix is returned unchanged.
+    """
+    m = _WIN_DRIVE_RE.match(win_path)
+    if not m:
+        return win_path
+    drive = m.group(1)[0].lower()
+    rest = m.group(2).replace("\\", "/")
+    return f"/mnt/{drive}/{rest}"
+
 
 def _detect_wsl_distro():
-    """Detect default WSL distro, fallback to 'Ubuntu'."""
+    """Detect default WSL distro, fallback to 'Ubuntu'.
+
+    `wsl -l -q` emits UTF-16LE on Windows (null byte between every ASCII char),
+    so reading it with ``text=True`` yields e.g. ``'U\\x00b\\x00u\\x00n\\x00t\\x00u'``
+    -- a string with embedded nulls. Passing that to ``subprocess.run(["wsl",
+    "-d", distro, ...])`` crashes ``CreateProcess`` with ``ValueError: embedded
+    null character`` (incident po-2024 c.355 lean4-wsl setup). Decode bytes
+    robustly instead: try UTF-16LE first (WSL's actual output), strip the nulls
+    as a belt-and-suspenders fallback, then split on newlines.
+    """
     try:
         result = subprocess.run(
-            ["wsl", "-l", "-q"], capture_output=True, text=True, timeout=10,
+            ["wsl", "-l", "-q"], capture_output=True, timeout=10,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            lines = [l.strip() for l in result.stdout.splitlines() if l.strip()]
-            if lines:
-                return lines[0]
+        if result.returncode != 0:
+            return "Ubuntu"
+        # WSL -l -q is UTF-16LE with BOM on recent Windows; decode defensively.
+        raw = result.stdout
+        text = None
+        if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):
+            text = raw.decode("utf-16", errors="ignore")
+        elif b"\x00" in raw:
+            # UTF-16LE without BOM: every other byte is 0x00 for ASCII distro names.
+            text = raw.decode("utf-16-le", errors="ignore")
+        else:
+            text = raw.decode("utf-8", errors="ignore")
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        if lines:
+            # Final guard: reject any name with a stray null (corrupt decode).
+            name = lines[0]
+            return name if "\x00" not in name else "Ubuntu"
     except Exception:
         pass
     return "Ubuntu"
@@ -55,9 +97,10 @@ def step_wsl_install():
     if not script.exists():
         print(f"ERROR: {script} not found")
         return False
-    print(f"Running: wsl -d {WSL_DISTRO} -- bash {script}")
+    wsl_script = _win_to_wsl_path(str(script))
+    print(f"Running: wsl -d {WSL_DISTRO} -- bash {wsl_script}")
     result = subprocess.run(
-        ["wsl", "-d", WSL_DISTRO, "--", "bash", str(script)],
+        ["wsl", "-d", WSL_DISTRO, "--", "bash", wsl_script],
         cwd=str(REPO_ROOT),
     )
     if result.returncode != 0:


### PR DESCRIPTION
## Contexte

Le script d'installation canonique du kernel `lean4-wsl` ([scripts/lean/setup_lean4_all.py](scripts/lean/setup_lean4_all.py)) ne pouvait pas s'exécuter sur une machine Windows + WSL par défaut, bloquant l'enregistrement du kernel (Règle F : réparer, pas contourner). Trouvé firsthand po-2024 c.355 en installant le kernel pour débloquer la ré-exécution des notebooks Lean (#5772 outputs figés, travail Lean fleet-wide).

## Bug 1 — `_detect_wsl_distro` : crash `embedded null character`

`wsl -l -q` émet en **UTF-16LE** sur Windows (un octet `0x00` entre chaque caractère ASCII : `b'U\x00b\x00u\x00n\x00t\x00u\x00'`, vérifié firsthand). Lu avec `text=True`, on obtient `'U\x00b\x00u\x00n\x00t\x00u'`, et passer ce nom de distro à `subprocess.run(["wsl", "-d", distro, ...])` fait planter `CreateProcess` : **`ValueError: embedded null character`**.

**Fix** : décodage bytes défensif (BOM-aware UTF-16, fallback UTF-16LE, UTF-8 en dernier), rejet final de tout null résiduel → fallback `"Ubuntu"`.

## Bug 2 — backslash-stripping du path Windows (exit 127)

`step_wsl_install` passait `str(script)` (ex. `C:\dev\CoursIA\...\setup_wsl_lean4.sh`) à `wsl -- bash <path>`. WSL bash **strippe les backslashes** → `C:devCoursIA...` → file-not-found (**exit 127**). C'est le gotcha WSL documenté ([.claude/rules/wsl-kernels.md](.claude/rules/wsl-kernels.md)).

**Fix** : ajout de `_win_to_wsl_path` (miroir de [wsl_papermill.py:win_to_wsl_path](scripts/notebook_tools/wsl_papermill.py#L58), #2871 part 2) traduisant `C:\...` → `/mnt/c/...`, passage du path POSIX à bash.

## Vérification end-to-end firsthand (po-2024)

| État | Résultat |
|------|----------|
| **Avant** | `ValueError: embedded null character` (bug 1), puis exit 127 `C:devCoursIA...: No such file or directory` (bug 2) |
| **Après — Step 1** (WSL install) | `INSTALLATION TERMINEE / lean4_jupyter OK` ✅ |
| **Après — Step 2** (register) | `OK: Kernel registration complete` ✅ |
| **Après — check-wrapper** | `OK: kernel.json (lean4-wsl): wrapper Python v5 correct` (no #1618 regression) ✅ |
| **Kernel enregistré** | `lean4-wsl` visible dans `jupyter kernelspec list` ✅ |

`py_compile` OK. Pas de changement de comportement pour paths non-Windows / déjà-POSIX (regex retourne le path inchangé sans préfixe de drive).

## Hygiène

- **Atomique** (R3) : 1 script, 1 sujet (2 bugs corrélés du même installer).
- **Catalogue R1** : non touché. **No notebook touched** (infra script only).
- **Variété R6** : famille infra/scripts (distincte Probas/Lean-docs c.354).

Co-Authored-By: Claude-Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)