### PR TITLE
fix(notebook-tools): count_exercises detect Lean -- line comments

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -118,6 +118,17 @@ STUB_PATTERNS = [
     re.compile(r"//\s*TODO", re.IGNORECASE),
     re.compile(r"#\s*Indice", re.IGNORECASE),
     re.compile(r"//\s*Indice", re.IGNORECASE),
+    # Lean 4 / Haskell line comments use ``--``. A scaffolded Lean exercise
+    # (``-- Exercice N`` + ``-- TODO etudiant`` + partial skeleton) is a student
+    # stub, not a solution: without the ``--`` form it escaped both STUB_PATTERNS
+    # and the ``<= 1 effective code-line`` rule (Lean comment lines were counted
+    # as code lines), so Lean notebooks were silently under-counted (e.g.
+    # GameTheory/SocialChoice/02-Lean-SocialChoice-Formal cells 32-34, each
+    # ``-- EXERCICE N`` + ``-- TODO etudiant`` + formalisation skeleton; and
+    # GameTheory-2b/4b/15b-Lean ``-- Exercice N`` stubs). Analogous to the C#
+    # ``//`` blind-spot fixed in #5179, now closed for the Lean family.
+    re.compile(r"--\s*TODO", re.IGNORECASE),
+    re.compile(r"--\s*Indice", re.IGNORECASE),
     # `$?` accepts both regular (`"..."`) and interpolated (`$"..."`) strings:
     # `Console.WriteLine($"Exercice 2 a completer ...")` is the idiomatic C#
     # interpolated form and was not matched by the quote-only variant.
@@ -200,6 +211,11 @@ def _is_stub_code(source: str) -> bool:
         if ln.strip()
         and not ln.strip().startswith("#")
         and not ln.strip().startswith("//")
+        # Lean 4 / Haskell line comments start with ``--``; without this they
+        # were counted as effective code lines, so a Lean stub cell full of
+        # ``--`` scaffold comments read as multi-line "code" and escaped the
+        # ``<= 1 effective code-line`` rule.
+        and not ln.strip().startswith("--")
     ]
     code_lines = [
         ln for ln in lines
@@ -213,19 +229,23 @@ def _code_cell_mentions_exercise(source: str) -> bool:
     """A code cell whose comments name an exercise.
 
     Language-agnostic comment detection: a full-line comment is one whose
-    stripped form starts with ``#`` (Python / F# / Lean) OR ``//`` (C# /
-    .NET Interactive). Inline trailing comments (``code // Exercice``) are
-    intentionally NOT matched -- a stub marker is a full-line comment, not a
-    reference buried after executable code.
+    stripped form starts with ``#`` (Python / F#) OR ``//`` (C# /
+    .NET Interactive) OR ``--`` (Lean 4 / Haskell). Inline trailing comments
+    (``code // Exercice``) are intentionally NOT matched -- a stub marker is a
+    full-line comment, not a reference buried after executable code.
 
     Historically this only matched ``#``, which made every C# notebook blind
     to ``// Exercice N`` stubs (the .NET family uses ``//``). Agents then
     re-discovered the undercount ad-hoc, notebook by notebook (Probas/Infer,
     ML.Net). Matching ``//`` here closes that blind-spot at the source.
+    Matching ``--`` closes the analogous Lean blind-spot (GameTheory-Lean
+    ``-- Exercice N`` stubs were invisible to the canonical tool).
     """
     comments = [
         ln for ln in source.split("\n")
-        if ln.strip().startswith("#") or ln.strip().startswith("//")
+        if ln.strip().startswith("#")
+        or ln.strip().startswith("//")
+        or ln.strip().startswith("--")
     ]
     blob = "\n".join(comments)
     return bool(EXERCISE_WORD_RE.search(blob) or EXERCISE_WORD_EN_RE.search(blob))

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -434,6 +434,109 @@ class TestCodeCellOnlyExercise:
 
 
 # ---------------------------------------------------------------------------
+# Lean (``--`` line comment) detection -- mirrors the C# ``//`` tests above.
+# ---------------------------------------------------------------------------
+
+class TestLeanDoubleDashCommentExercise:
+    def test_lean_double_dash_comment_exercise_is_counted(self, tmp_path):
+        """Lean 4 / Haskell line comments use ``--`` (not ``#`` or ``//``).
+        A stub code cell whose ``-- Exercice ...`` comment names an exercise
+        with NO preceding markdown header must be counted -- historically the
+        canonical tool was blind to the entire Lean family (GameTheory-Lean
+        ``-- Exercice N`` stubs), re-discovered ad-hoc notebook by notebook.
+        """
+        nb = _write_nb(
+            tmp_path / "lean.ipynb",
+            [
+                _md("# Titre Lean"),
+                # Lean code-cell-only exercise, no markdown header above:
+                _code(
+                    "-- Exercice : Shapley value for n = 3\n"
+                    "-- TODO etudiant : calculer phi_i\n"
+                    "sorry\n"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            "Lean -- Exercice stub (no markdown header) must count"
+        )
+        assert result.exercises[0].detected_by == "code_cell_comment"
+
+    def test_lean_scaffolded_exercise_todo_with_code_is_counted(
+        self, tmp_path
+    ):
+        """A scaffolded Lean exercise -- ``-- Exercice N`` + ``-- TODO etudiant``
+        ABOVE a partial formalisation skeleton (multiple lines, each a ``--``
+        comment) -- is a student stub, NOT a solution. The ``-- TODO`` marker
+        must classify it as a stub; without the ``--`` comment-stripping the
+        ``<= 1 effective code-line`` rule counted every ``--`` comment line as
+        code and the cell escaped stub classification.
+
+        Regression for ``SocialChoice/02-Lean-SocialChoice-Formal`` cells
+        32-34 (Pareto / Condorcet / median): each ``-- EXERCICE N`` +
+        ``-- TODO etudiant`` + formalisation skeleton was silently
+        under-counted, so the notebook read as 1 exercise instead of its
+        real 4 (markdown header + 3 code stubs).
+        """
+        nb = _write_nb(
+            tmp_path / "lean_scaffold.ipynb",
+            [
+                _md("# Theorie du choix social"),
+                _md("## Exercice 1 : Pareto"),
+                _code(
+                    "-- Exercice 1 : verifier le respect de Pareto\n"
+                    "-- Soit 2 individus et 3 alternatives.\n"
+                    "-- TODO etudiant : prouver le resultat\n"
+                    "--   etape 1 : appliquer la definition\n"
+                    "theorem pareto_respected : True := by trivial\n"
+                ),
+                _md("## Exercice 2 : Condorcet"),
+                _code(
+                    "-- Exercice 2 : cycle de Condorcet\n"
+                    "-- 3 electeurs, 3 alternatives.\n"
+                    "-- TODO etudiant : calculer les marges\n"
+                    "theorem condorcet_cycle : True := by trivial\n"
+                ),
+                _md("## Exercice 3 : electeur median"),
+                _code(
+                    "-- Exercice 3 : preferences unimodales\n"
+                    "-- TODO etudiant : verifier le vainqueur\n"
+                    "theorem median_winner : True := by trivial\n"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            "3 scaffolded Lean -- Exercice stubs must each count"
+        )
+
+    def test_lean_solution_code_cell_is_not_an_exercise(self, tmp_path):
+        """A Lean code cell whose ``-- Exercice`` comment sits ABOVE a COMPLETE
+        proof (not a stub) is an example, not an exercise -- not counted,
+        mirroring ``test_solution_code_cell_is_not_an_exercise`` for the
+        Python form.
+        """
+        solution = (
+            "-- Exercice 1 : preuve complete\n"
+            "-- Demonstration du theoreme.\n"
+            "theorem foo (n : Nat) : n + 0 = n := by\n"
+            "  rw [Nat.add_zero]\n"
+        )
+        nb = _write_nb(
+            tmp_path / "lean_sol.ipynb",
+            [
+                _md("# Titre Lean"),
+                _code(solution),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 0, (
+            "Lean -- Exercice above a complete proof is an example, not counted"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Stub classification
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Contexte

Le compteur d'exercices canonique était **aveugle au commentaire ligne Lean 4 / Haskell (`--`)** — le dernier angle mort majeur de syntaxe de commentaire après le fix C# `//` (#5179) et le fix `display()` (#5767). ai-01 l'a flaggé comme grain tooling borné disponible (sweep c.356), et je l'ai touché firsthand c.355 (3 notebooks Lean sous-dénombrés).

## Bug — 2 fonctions ignoraient `--`

| Fonction | Avant | Conséquence |
|----------|-------|-------------|
| `_code_cell_mentions_exercise` | matchait seulement commentaires `#`/`//` pleine ligne | une cellule `-- Exercice N` n'était jamais reconnue comme nommant un exercice |
| `_is_stub_code` STUB_PATTERNS | `#\s*TODO` + `//\s*TODO`, **pas** `--\s*TODO` | un stub Lean `-- TODO etudiant` échappait à la détection stub |
| `_is_stub_code` filtre code-lines | stripait seulement lignes `#`/`//` | chaque ligne `--` de scaffolding comptait comme ligne de code → la règle `<= 1 effective code-line` échouait |

**Conséquence** : les notebooks Lean avec exercices en code-cell-only (sans header markdown au-dessus) étaient silencieusement sous-dénombrés. **Firsthand po-2024 c.355** : `SocialChoice/02-Lean-SocialChoice-Formal` cells 32-34 (`-- EXERCICE N` + `-- TODO etudiant` + squelette de formalisation) lues comme 1 exercice au lieu de 4. **119 cellules Lean-comment stub/exercise** existent dans le repo (série GameTheory-Lean).

## Fix

- STUB_PATTERNS : ajout `--\s*TODO` + `--\s*Indice`.
- `_is_stub_code` filtre : strip aussi les lignes `--`.
- `_code_cell_mentions_exercise` : match aussi les commentaires pleine ligne `--`.

## Vérification firsthand

| Preuve | Résultat |
|--------|----------|
| `SocialChoice/02-Lean-SocialChoice-Formal` | 1 → **3** (FP résolu, maintenant conforming) ✅ |
| `Lean-18-Search-AStar-Optimality` | 3 → **4** (un stub genuin de plus vu) ✅ |
| **Diff per-notebook avant/après (repo entier)** | **SEULEMENT 2 notebooks changés, LES DEUX Lean** — ZERO notebook non-Lean affecté (pas de false-positive Python/SQL du stripping `--`) ✅ |
| Full-repo aggregate | total 2748→2751, conforming 731→**732**, sub-threshold 184→**183** (aucune régression conforming→sub-threshold) ✅ |
| Suite de tests | **35 passed** (32 existants + 3 nouveaux tests Lean miroir du précédent C# : code-cell-only compté, scaffolded-avec-TODO compté, solution-complète non comptée) ✅ |

## Hygiène

- **Atomique** (R3) : 1 outil + ses tests, 1 sujet (angle mort commentaire Lean).
- **Catalogue R1** : non touché. **No notebook touched** (tooling only).
- **Variété R6** : famille Python/tooling (distincte Lean c.354/c.355).
- `py_compile` OK sur les 2 fichiers.

Analogue au fix C# `//` (#5179) + `display()` (#5767) ; ferme la famille Lean à la source pour que les agents arrêtent de re-découvrir le sous-dénombrement ad-hoc.

See #2161 (convention 3-exercices, le scanner qui supporte cette convention). Flagged by ai-01 sweep c.356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)