### PR TITLE
fix(notebook-tools): count_exercises detect Lean -- comment exercise stubs

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -108,16 +108,19 @@ STUB_PATTERNS = [
     re.compile(r'print\(["\']Exercice[s]? a completer', re.IGNORECASE),
     re.compile(r"^\s*pass\s*$", re.MULTILINE),
     re.compile(r"\breturn\s+None\b"),
-    # TODO / Indice markers. Python/F#/Lean use `#`, C# / .NET Interactive
-    # use `//`. A scaffolded C# exercise (class skeleton + `// TODO etudiant`
-    # + multiple code lines) is a student stub, not a solution: without the
-    # `//` form it escaped the `<= 1 effective code-line` rule and was
-    # silently under-counted (e.g. Search-11-Metaheuristics-Csharp cells
-    # 24-26, each `// Exercice N` + `// TODO etudiant` + partial skeleton).
+    # TODO / Indice markers. Python/F# use `#`, C# / .NET Interactive use
+    # `//`, Lean 4 uses `--`. A scaffolded exercise (skeleton + `<comment> TODO
+    # etudiant` + multiple code lines) is a student stub, not a solution:
+    # without the comment form it escaped the `<= 1 effective code-line` rule
+    # and was silently under-counted (e.g. Search-11-Metaheuristics-Csharp
+    # cells 24-26 `// Exercice N` + `// TODO etudiant` + partial skeleton;
+    # GameTheory Lean series `-- Exercice N :` + `-- TODO etudiant` + prose).
     re.compile(r"#\s*TODO", re.IGNORECASE),
     re.compile(r"//\s*TODO", re.IGNORECASE),
+    re.compile(r"--\s*TODO", re.IGNORECASE),
     re.compile(r"#\s*Indice", re.IGNORECASE),
     re.compile(r"//\s*Indice", re.IGNORECASE),
+    re.compile(r"--\s*Indice", re.IGNORECASE),
     # `$?` accepts both regular (`"..."`) and interpolated (`$"..."`) strings:
     # `Console.WriteLine($"Exercice 2 a completer ...")` is the idiomatic C#
     # interpolated form and was not matched by the quote-only variant.
@@ -200,6 +203,7 @@ def _is_stub_code(source: str) -> bool:
         if ln.strip()
         and not ln.strip().startswith("#")
         and not ln.strip().startswith("//")
+        and not ln.strip().startswith("--")
     ]
     code_lines = [
         ln for ln in lines
@@ -213,19 +217,24 @@ def _code_cell_mentions_exercise(source: str) -> bool:
     """A code cell whose comments name an exercise.
 
     Language-agnostic comment detection: a full-line comment is one whose
-    stripped form starts with ``#`` (Python / F# / Lean) OR ``//`` (C# /
-    .NET Interactive). Inline trailing comments (``code // Exercice``) are
-    intentionally NOT matched -- a stub marker is a full-line comment, not a
-    reference buried after executable code.
+    stripped form starts with ``#`` (Python / F#), ``//`` (C# / .NET
+    Interactive), OR ``--`` (Lean 4). Inline trailing comments
+    (``code // Exercice``) are intentionally NOT matched -- a stub marker is
+    a full-line comment, not a reference buried after executable code.
 
     Historically this only matched ``#``, which made every C# notebook blind
     to ``// Exercice N`` stubs (the .NET family uses ``//``). Agents then
     re-discovered the undercount ad-hoc, notebook by notebook (Probas/Infer,
-    ML.Net). Matching ``//`` here closes that blind-spot at the source.
+    ML.Net). Matching ``//`` here closes that blind-spot at the source, and
+    matching ``--`` does the same for Lean notebooks whose exercise stubs live
+    in ``-- Exercice N : ...`` comments (e.g. GameTheory/02-Lean-SocialChoice
+    ``-- EXERCICE 4/5/6``, GameTheory-2b/4b/8b/15b-Lean series).
     """
     comments = [
         ln for ln in source.split("\n")
-        if ln.strip().startswith("#") or ln.strip().startswith("//")
+        if ln.strip().startswith("#")
+        or ln.strip().startswith("//")
+        or ln.strip().startswith("--")
     ]
     blob = "\n".join(comments)
     return bool(EXERCISE_WORD_RE.search(blob) or EXERCISE_WORD_EN_RE.search(blob))

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -307,6 +307,39 @@ class TestCodeCellOnlyExercise:
         )
         assert result.exercises[0].detected_by == "code_cell_comment"
 
+    def test_lean_double_dash_comment_exercise_is_counted(self, tmp_path):
+        """Lean 4 uses ``--`` for line comments (not ``#``). A stub code cell
+        whose ``-- Exercice ...`` comment names an exercise with NO preceding
+        markdown header must be counted -- historically the canonical tool was
+        blind to Lean ``--`` stubs (it only matched ``#`` and ``//``), so agents
+        re-discovered the undercount ad-hoc.
+
+        Regression for ``GameTheory/SocialChoice/02-Lean-SocialChoice-Formal``
+        (``-- EXERCICE 4/5/6`` in cells 32-34) and the GameTheory-2b/4b/8b/15b-Lean
+        series (``-- Exercice N :`` stubs): each was silently under-counted, so
+        these notebooks read as sub-threshold despite carrying real exercises.
+        """
+        nb = _write_nb(
+            tmp_path / "lean.ipynb",
+            [
+                _md("# Titre Lean"),
+                # Lean code-cell-only exercise, no markdown header above.
+                # Uppercase EXERCICE exercises the case-insensitive word regex.
+                # The `-- TODO etudiant` marker mirrors the `// TODO etudiant`
+                # idiom the real GameTheory Lean series uses (e.g. SocialChoice/02
+                # cells 32-34).
+                _code(
+                    "-- EXERCICE : verifier le cycle de Condorcet\n"
+                    "-- TODO etudiant : construire un profil cyclique\n"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            "Lean -- Exercice stub (no markdown header) must count"
+        )
+        assert result.exercises[0].detected_by == "code_cell_comment"
+
     def test_csharp_scaffolded_exercise_todo_with_code_is_counted(
         self, tmp_path
     ):


### PR DESCRIPTION
## What

Close the Lean 4 (`--` comment) blind-spot in `count_exercises.py`. Exercise stubs written as `-- Exercice N : ...` + `-- TODO etudiant` were silently under-counted, the residual false-positive surface ai-01 flagged as an available bounded tooling grain (and the root cause behind po-2024 c.355 + po-2026 c.364 scanner-FP reports).

## Root cause (firsthand — three touch-points all missing Lean `--`)

| Site | Before | After |
|------|--------|-------|
| `_code_cell_mentions_exercise` comment detection | `#` + `//` only | + `--` |
| `STUB_PATTERNS` (TODO/Indice markers) | `//\s*TODO`, `//\s*Indice` | + `--\s*TODO`, `--\s*Indice` |
| `_is_stub_code` code-line filter (comment exclusion) | `#` + `//` | + `--` |

Note: ai-01's steer framed the gap as "colon-form C# + Lean uppercase". Firsthand, the colon-form `// Exercice N :` (C#) was ALREADY caught (Sudoku-4 reports 4 exercises) and uppercase is handled by the case-insensitive word regex. The **real** residual gap is the Lean `--` comment prefix (the docstring even mis-stated "Lean" under `#` — Lean uses `--`). The fix mirrors the existing `//` (C#) treatment for `--` (Lean) at all three sites.

## Firsthand verification

- **`SocialChoice/02-Lean-SocialChoice-Formal.ipynb`**: **1 → 3 exercises** (now conforming ≥3; the `-- EXERCICE 4/5/6` stubs in cells 32-34 are counted).
- **GameTheory-2b/4b/8b/15b-Lean + SocialChoice/02**: all now report **3** (conforming) — previously under-counted by the `--` gap.
- **2014 notebook-tools tests pass, 0 regression**; new `test_lean_double_dash_comment_exercise_is_counted` covers the Lean `--` path (mirrors the C# `//` regression test from a prior fix).

## Safety

- Bounded tooling fix, 2 files (+54/-12), single subject.
- No notebook content touched.
- No over-match: the AND-gate (`_code_cell_mentions_exercise AND _is_stub_code`) still applies — a Lean code cell that merely *mentions* an exercise but is real working code is not counted.
- `--` as a comment prefix is Lean-specific; in code cells it does not collide with Python/JS `--` (Python has no `--`; JS `--i` would not start a stripped line).

## Why it matters even though Lean notebooks are convention-exempt

Lean notebooks are exempt from the ≥3 target (three-exercises-per-notebook convention: "Notebook purement Lean ... 0-2 OK"). But the tool's **COUNT** must still be correct — a false sub-threshold flag on an exempt notebook misleads workers into dispatching a non-existent gap (exactly the FP po-2024 and I hit). Correct counting prevents the re-dispatch loop.

See #2161 (exercise-count convention).