### PR TITLE
docs(casestudies): remove decorative emojis from Diagnostic-Medical subject headers

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/subject.md
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/subject.md
@@ -12,7 +12,7 @@ points: "20"
 # CC1 - IA Exploratoire et Symbolique
 ## Système de Diagnostic Médical Multi-Contraintes pour le Diabète de Type 2
 
-### 🎯 Objectifs Pédagogiques
+### Objectifs Pédagogiques
 
 Ce devoir vise à évaluer votre maîtrise des concepts fondamentaux de l'intelligence artificielle exploratoire et symbolique à travers une application concrète dans le domaine biomédical. Vous développerez un système de diagnostic intelligent qui combine trois approches complémentaires :
 
@@ -24,7 +24,7 @@ Ce devoir vise à évaluer votre maîtrise des concepts fondamentaux de l'intell
 - Application biomédicale (diabète type 2)
 - Documentation technique et communication
 
-### 📋 Contexte du Problème
+### Contexte du Problème
 
 Le diabète de type 2 représente un défi de santé publique majeur, nécessitant une approche de diagnostic personnalisée qui combine :
 - **Analyse multi-dimensionnelle** : Glycémie, HbA1c, symptômes, antécédents
@@ -36,7 +36,7 @@ Votre système doit intégrer trois approches algorithmiques complémentaires :
 2. **Optimisation Génétique** : Algorithme évolutionnaire pour personnaliser les seuils diagnostiques
 3. **Validation par Contraintes** : Solveur Z3 pour valider les protocoles thérapeutiques
 
-### 📊 Données du Problème
+### Données du Problème
 
 #### Structure Patient
 ```python
@@ -94,7 +94,7 @@ protocoles_diabete_type2 = {
 }
 ```
 
-### 🎯 Objectifs à Réaliser
+### Objectifs à Réaliser
 
 #### Partie 1 : Agent de Diagnostic Basique (6 points)
 Implémenter un système de diagnostic qui évalue les patients selon les règles cliniques standards :
@@ -120,7 +120,7 @@ Intégrer un solveur de contraintes pour valider les protocoles thérapeutiques 
 2. **Solveur Z3** : Utilisation de Z3 pour la résolution efficace
 3. **Validation** : Vérification des protocoles selon les contraintes
 
-### 📋 Exemples de Données
+### Exemples de Données
 
 #### Cas de Test 1 : Situation Simple
 ```python
@@ -150,7 +150,7 @@ patients_complexes = [
 ]
 ```
 
-### 🛠️ Environnement Technique
+### Environnement Technique
 
 #### Langages et Librairies
 - **Python 3.8+** requis
@@ -167,7 +167,7 @@ patients_complexes = [
 - **Mémoire utilisée** : <200MB pour 1000 patients
 - **Portabilité** : Code compatible Windows/Linux/macOS
 
-### 📊 Barème d'Évaluation
+### Barème d'Évaluation
 
 | Critère | Points | Détails d'Évaluation |
 |----------|---------|-------------------|
@@ -214,7 +214,7 @@ patients_complexes = [
 - Analyse absente ou erronée
 - Documentation manquante
 
-### 📚 Références
+### Références
 
 #### Théorie
 - **Russell & Norvig**, *Artificial Intelligence: A Modern Approach*, Chapitres 1, 3, 4, 6
@@ -232,7 +232,7 @@ patients_complexes = [
 - **WHO Diabetes Guidelines** : Standards internationaux pour le diagnostic
 - **Medical Constraint Systems** : Littérature sur les applications CSP en santé
 
-### 📝 Livrables Attendus
+### Livrables Attendus
 
 1. **CC1-Diagnostic-Medical.ipynb** : Notebook template à compléter par les étudiants
 2. **data/patients.csv** : Données de test pour valider les implémentations
@@ -242,13 +242,13 @@ patients_complexes = [
    - Justification des choix algorithmiques
    - Mesures et graphiques
 
-### ⏰ Calendrier
+### Calendrier
 
 - **Date de remise** : 21 jours après la publication du sujet
 - **Pénalité de retard** : -1 point par jour de retard
 - **Format de remise** : Archive ZIP avec tous les livrables
 
-### 🚀 Extensions Possibles
+### Extensions Possibles
 
 #### Pour Étudiants Avancés
 - **Apprentissage Automatique** : Optimisation des heuristiques par machine learning


### PR DESCRIPTION
## What

Removes 11 decorative emoji prefixes from section headers in `CaseStudies/Diagnostic-Medical/subject.md` (the CC1 assignment statement). Headers were `### 🎯 Objectifs Pédagogiques`, `### 📋 Contexte du Problème`, `### 📊 Données`, `### 🛠️ Environnement Technique`, etc.; they become plain `### Objectifs Pédagogiques`, … Header text and all surrounding content are byte-identical.

## Why

Violation of the repo code-style rule **"No emojis in code, variable names, or generated files"** ([code-style.md §E](../../blob/main/.claude/rules/code-style.md)). Flagged in #5661 item 13 ("emojis résiduels dans la prose").

Alignment evidence (firsthand, `origin/main`):
- Sibling `CaseStudies/Oncology-Planning/README.md` — **0 emojis**.
- `Diagnostic-Medical/README.md` itself — already emoji-free (only a typographic `→` arrow, kept).
- Only `subject.md` carried the 11 decorative headers — now aligned.

## §E note (size)

This is a 22-line docs-only change on a single non-README assignment file. [pr-review-discipline.md §E](../../blob/main/.claude/rules/pr-review-discipline.md) prefers grouping for docs PRs < 50 lines. I verified firsthand that **every other item in #5661 is drained** (see the verification comment I'm posting on the issue), so there is no legitimate grouping target — this is the single remaining real defect in the tracker. Standalone is the honest path; grouping for grouping's sake would mean bundling already-fixed or cron-owned items.

## Verification (firsthand)

- `git diff --stat`: `1 file changed, 11 insertions(+), 11 deletions(-)` — exactly the 11 headers, nothing else.
- CRLF regression check: `0` `\r\n` (UTF-8 no-BOM, LF preserved).
- Trailing-newline parity: `origin/main` ends without `\n` (`*Version finale : 2.0.0*`); my version is byte-identical at EOF — **no MD047 regression** (pre-existing, out of scope).
- No content change: only the `### <emoji> ` prefix is stripped; header titles, code blocks, tables, barème all intact.

See #5661

Co-Authored-By: Claude <noreply@anthropic.com>
