### PR TITLE
fix(docs): Playwright-OWUI CATALOG-STATUS series key (was pedagogical_count: 0)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Open-WebUI/Playwright-OWUI/README.md
@@ -1,10 +1,10 @@
 # Playwright-OWUI - Tests E2E pédagogiques pour Open WebUI
 
 <!-- CATALOG-STATUS
-series: GenAI-Playwright-OWUI
-pedagogical_count: 0
-breakdown: 
-maturity: 
+series: GenAI-Open-WebUI
+pedagogical_count: 7
+breakdown: Open-WebUI=7
+maturity: PRODUCTION=6, BETA=1
 -->
 
 [← Documentation GenAI](../../README.md) | [↑ Open-WebUI](../README.md) | [→ Vibe-Coding](../../Vibe-Coding/README.md)


### PR DESCRIPTION
## Root cause

The `CATALOG-STATUS` marker in `Playwright-OWUI/README.md` declared `series: GenAI-Playwright-OWUI`, but the catalog classifies the 7 notebooks under `GenAI/Open-WebUI/Playwright-OWUI/` as `serie=GenAI, sous_serie=Open-WebUI`.

`generate_catalog.py` derives `sous_serie` from `parts[1]` only (2-level model, `analyze_notebook` L549-550) — the 3rd-level `Playwright-OWUI` dir is never captured. So `_filter_by_series` (in `expand_catalog_markers.py`) tried exact match `GenAI-Playwright-OWUI` (0), then fallback `parent=GenAI / child=Playwright-OWUI` → still 0 (real `sous_serie` is `Open-WebUI`). Result: the marker rendered `pedagogical_count: 0` with **empty** breakdown/maturity — the series looked empty/uncataloged despite holding 7 notebooks.

Found while triaging #5661 ("marqueur CATALOG-STATUS vide — vérifier pourquoi le cron ne le remplit pas"). Answer: the cron **was** filling it — with the wrong `series:` key, so the filter matched 0 entries.

## Fix

Align the marker `series:` key with the catalog's actual 2-level classification: `GenAI-Playwright-OWUI` → `GenAI-Open-WebUI` (matches the sibling convention `GenAI-Texte`). Derived fields regenerated via the **canonical script** `scripts/notebook_tools/expand_catalog_markers.py --file …` (not hand-edited — respects catalog-pr-hygiene HARD 1; the CI `catalog-drift.yml` does the same on PR branches).

Before / after:
```
-series: GenAI-Playwright-OWUI
-pedagogical_count: 0
-breakdown:
-maturity:
+series: GenAI-Open-WebUI
+pedagogical_count: 7
+breakdown: Open-WebUI=7
+maturity: PRODUCTION=6, BETA=1
```

## Verification (firsthand)

- **Root cause**: `git show origin/main:COURSE_CATALOG.generated.json` → 7 entries with `serie=GenAI, sous_serie=Open-WebUI`; `generate_catalog.py` L549-550 confirms `sous_serie = parts[1] if len(parts) > 2` (2-level only).
- **Scope isolation**: `expand_catalog_markers.py --file` reported "Updated CATALOG-STATUS block for GenAI-Open-WebUI" — `git diff --stat` shows **only** this README (4 insertions / 4 deletions, the 4 marker value lines). 0 other READMEs churned.
- **Test suite**: `pytest scripts/notebook_tools/tests/test_expand_catalog_markers.py` → **71 passed**, 0 regression.
- **§E fichier-entier audit** (per pr-review-discipline §E):
  - Module structure tree (6 modules `01-..`–`06-..`) matches disk exactly.
  - Per-module `spec.ts` `test(` counts match README claims precisely: 4 / 8 / 7 / 7 / 8 / 7.
  - "6 modules" prose accurate vs disk.

## Note on the catalog 2-level model

`generate_catalog.py` uses a deliberate 2-level `serie`/`sous_serie` model (parts[0]/parts[1]). Playwright-OWUI is the only GenAI sub-series with a 3-level nesting that this flattens. The marker fix (Option A) is the minimal correct change. A systemic catalog-model change to recognize 3-level sous_serie (Option B) is out of scope — it would reclassify every series and is a design change, not a bug fix. Flagged here for the record.

See #5661, Part of #3973.
