### PR TITLE
docs(harness): refresh coordinate + continue to current cluster doctrine

### DIFF
--- a/.claude/commands/continue.md
+++ b/.claude/commands/continue.md
@@ -1,112 +1,47 @@
-# Continue - Resume Work
+# Continue - Cycle worker
 
-Resume work from GitHub issues OR local memory — reads context, checks state, picks next task, starts working.
+Reprendre le travail sur cette lane : lire les directives coordinateur, choisir la prochaine tache, livrer une PR, reporter. C'est le prompt du cron worker (30 min staggered). **Un worker ne lance JAMAIS `/coordinate`** (lecon #1502) : pas de merge, pas de `gh auth switch`, pas de close d'issue d'autrui.
 
 ## Workflow
 
-### Phase 1 : Charger le contexte (30s)
+### Phase 1 : Contexte (30s)
 
 1. Lire `MEMORY.md` (auto-memory) pour l'etat des sessions precedentes
+2. `git checkout main && git pull --ff-only` — repartir d'un main courant (les branches feature se rebasent frais, cf [catalog-pr-hygiene](../rules/catalog-pr-hygiene.md))
+3. `git status` — si l'arbre partage est sale (WIP d'une autre session), travailler en **worktree isole** : `git worktree add ../CoursIA-<sujet> -b feature/<sujet> origin/main`. Ne jamais stasher/toucher le WIP d'autrui.
 
-2. **Option A - GitHub issues** (si applicable):
+### Phase 1.5 : Tour RooSync (obligatoire, AVANT de travailler)
 
-   - `git status` et `git log --oneline -5` pour l'etat du depot
-   - `gh issue list --state open` pour les issues ouvertes
+1. **Inbox DM en PREMIER** : `roosync_messages(action:"inbox", status:"unread")` — le DM est le canal de decision du coordinateur, il survit a la condensation du dashboard.
+2. **Dashboard workspace** : `roosync_dashboard(action:"read", type:"workspace", section:"all")` — chercher les `[DISPATCH→inbox]` et les steers de MA lane (`machine:workspace`). Si la machine a une lane CoursIA-2, lire aussi ce dashboard pour cette lane.
+3. **Filtrage workspace** : traiter UNIQUEMENT les messages adresses a cette lane ou cette machine ; ignorer les autres workspaces.
+4. Missions coordinateur (ai-01) HIGH/URGENT = priorite sur les taches locales. Accuser reception (reply DM ou dashboard).
 
-3. **Option B - Memoires locales** (si pas d'issue GitHub):
+### Phase 2 : Choisir la tache
 
-   - Lire `.claude/memory/*.md` pour les taches en cours
-   - Identifier les fichiers memoire pertinents (ex: `issue-XX-*.md`)
+**P0 — Missions coordinateur** : DM HIGH/URGENT, puis steers dashboard de ma lane.
 
-### Phase 1.5 : Tour de coordination RooSync (obligatoire)
+**P1 — Travail en cours** : tache `[CLAIMED]` par cette lane non terminee, deep-queue de la lane si posee sur le dashboard.
 
-**TOUJOURS executer avant de commencer le travail**, pour detecter les nouvelles missions du coordinateur.
+**P2 — Pool global (auto-alimentation, JAMAIS d'idle)** : `gh issue list --state open` **en entier, cross-lane** — la lane est une etiquette de reporting, pas une frontiere de travail. Prendre n'importe quelle issue techniquement executable (autre famille, autre langage : rien n'est "le turf d'un autre"), poser `[CLAIMED] <#N> — <machine:workspace> <ts>` sur le dashboard AVANT de commencer, livrer. Regles completes : [proactive-coordination.md](../rules/proactive-coordination.md) (>=1 PR/wakeup = PLANCHER, variete R6, "rien a faire" avec >0 issues ouvertes = echec de methode).
 
-1. **Lire l'inbox RooSync** : `roosync_read` mode=inbox, status=unread
-2. **Lire le dashboard workspace** : `roosync_dashboard` action=read, type=workspace
-3. **Verifier le heartbeat** cluster : `roosync_inventory` type=heartbeat
+### Phase 3 : Travailler et livrer
 
-**Filtrage workspace OBLIGATOIRE** :
-- Traiter UNIQUEMENT les messages adressés à ce workspace (CoursIA) ou à cette machine
-- IGNORER les messages adressés à d'autres workspaces (roo-extensions, etc.) — ce n'est pas votre travail
-- Si un message est marqué pour un autre workspace, le marquer lu sans action
+- Une PR = un sujet ([catalog-pr-hygiene](../rules/catalog-pr-hygiene.md) : catalogue byte-identique a main, `Closes #N` seulement si l'issue est entierement resolue, sinon `See #N`).
+- Notebooks : C.1 (pas d'erreur volontaire), C.2 (commit AVEC outputs, re-exec des cellules modifiees), H.3 (pre-commit) — cf [notebook-conventions.md](../rules/notebook-conventions.md).
+- Vrai outil SOTA, jamais workaround degrade ([sota-not-workaround.md](../rules/sota-not-workaround.md)) ; env casse = reparer, pas contourner (regle F).
+- Skills/sous-agents specialises quand ils existent : [docs/reference/subagents-reference.md](../../docs/reference/subagents-reference.md).
 
-**Si des missions ou messages HIGH/URGENT existent** (pour CE workspace uniquement) :
-- Lire le message complet avec `roosync_read` mode=message
-- Les missions du coordinateur (ai-01) ont priorite sur les taches locales
-- Repondre accusant reception sur le dashboard
+### Phase 4 : Avant de terminer (obligatoire)
 
-**Presenter le statut coordination dans le resume** :
-```text
-## Coordination RooSync
-- Messages non-lus: {N} (URGENT: {N}, HIGH: {N})
-- Missions actives: {liste}
-- Prochaine action coordinateur: {description ou "aucune"}
-```
-
-### Phase 2 : Identifier la prochaine tache (30s)
-
-**Priorite 0 - Missions coordinateur** (si messages RooSync HIGH/URGENT):
-1. Missions URGENT du coordinateur ai-01
-2. Missions HIGH du coordinateur ai-01
-3. Taches demandees via dashboard workspace
-
-**Priorite 1 - GitHub** (si issues existent):
-
-1. **Issue en cours** : Si une issue a un commentaire recent "IN_PROGRESS"
-2. **BROKEN strategies** : Issues label `priority-high`
-3. **NEEDS_IMPROVEMENT** : Issues label `priority-medium`
-4. **Documentation/Infrastructure** : Quand le code est traite
-
-**Priorite 2 - Memoires Locales** (si pas d'issue GitHub):
-
-1. Chercher `.claude/memory/*.md` avec des taches en cours
-2. Identifier la tache `in_progress` ou la plus ancienne `pending`
-3. Lire le fichier memoire pour le contexte complet
-
-### Phase 3 : Presenter et commencer
-
-Afficher un resume concis :
-
-```text
-## Session Resume
-- Mode: {COORDINATION / GITHUB / LOCAL_MEMORY}
-- Source: {Mission RooSync / Issue #XX / Fichier memoire}
-- Dernier commit: {hash} {message}
-- Prochaine tache: {description}
-- Etat: {in_progress / pending / completed}
-```
-
-Puis commencer a travailler :
-
-**Si Mission coordinateur** :
-- Executer les instructions du message RooSync
-- Reporter les resultats sur le dashboard workspace
-- Repondre au coordinateur via RooSync a la fin
-
-**Si GitHub issue** :
-
-- QuantConnect strategy : `/qc-iterative-improve #{XX}`
-- README/Documentation : Lire et rediger
-- Infrastructure : Mettre a jour fichiers skill/agent
-
-**Si Memoire locale** :
-- Restaurer la todo list depuis le memoire
-- Continuer depuis la tache `in_progress` ou `pending`
-- Executer les commandes specifiees dans le memoire
-
-### Phase 4 : Avant de terminer
-
-1. **Coordination** : Mettre a jour le dashboard workspace avec le progres
-2. **GitHub** : Commenter/fermer l'issue
-3. **Local** : Mettre a jour le fichier memoire avec le progres
-4. Mettre a jour `MEMORY.md` avec les lecons apprises
-5. Si --commit demande : commit les changements
+1. **Commit + PR AVANT le rapport** — jamais de [DONE] sur un travail non commite.
+2. `[DONE]` lane-specific sur le dashboard workspace (resume : livrable, PR#, residuel). Une PR livree ne clot pas la session : re-piocher si la fenetre le permet.
+3. Bloqueur necessitant une action user : tag `[ASK USER]` separe du [DONE], repete a CHAQUE fin de session ([user-blocker-signaling](../rules/user-blocker-signaling.md)).
+4. Repondre au DM coordinateur si une mission a ete traitee.
+5. MAJ `MEMORY.md` si lecon durable (les PR#/SHA ephemeres vont au dashboard, pas en memoire).
 
 ## Notes
 
-- Cette commande est **sans parametre** : elle choisit automatiquement la tache suivante
-- **Phase 1.5 obligatoire** : toujours verifier RooSync avant de commencer
-- L'etat persiste via : RooSync dashboard + issues GitHub + MEMORY.md + .claude/memory/*.md
-- Pour forcer une tache specifique, utiliser le skill approprie directement
-- Utiliser pour reprendre apres saturation de contexte ou nouveau demarrage
+- Commande **sans parametre** : elle choisit automatiquement la tache suivante.
+- Etat persistant : dashboards RooSync + issues GitHub + MEMORY.md.
+- Jamais d'etat terminal-idle ("rien a faire", "await dispatch", "lane exhausted") : le pool global est toujours ouvert.

--- a/.claude/skills/coordinate/SKILL.md
+++ b/.claude/skills/coordinate/SKILL.md
@@ -1,145 +1,65 @@
 ---
 name: coordinate
-description: Resume multi-agent coordination session. Reads memory, RooSync inbox, GitHub issues, and produces a situational briefing with recommended actions. Arguments: [--dispatch] [--focus <topic>] [--reply-all]
+description: Cycle de coordination ai-01 (coordinateur UNIQUEMENT — jamais sur un worker). Lit memoire + dashboards + inbox + GitHub, merge les PRs pretes, tranche les design-gates, dispatche des grains par lane, reporte. Arguments: [--dispatch] [--focus <topic>]
 ---
 
-# Skill: Coordinate - Multi-Agent Coordination Hub
+# Skill: Coordinate - Cycle coordinateur ai-01
 
-Resume or start a coordination session across all agents working on the CoursIA repository.
+Cycle de coordination du cluster CoursIA. **Reserve au coordinateur ai-01** : un worker ne lance JAMAIS `/coordinate` (lecon #1502 phantom-merger — le cron worker execute `/continue`). Un worker ne merge pas et ne fait pas de `gh auth switch`.
 
 **Target**: `$ARGUMENTS`
 
 ## Arguments
 
-- (no args): Full situational briefing (memory + RooSync + issues)
-- `--dispatch`: After briefing, propose and send task assignments to idle agents via RooSync
-- `--focus <topic>`: Focus on a specific area: `qc`, `slides`, `smartcontracts`, `sudoku`, `genai`, `epita`
-- `--reply-all`: Read all unread RooSync messages and draft replies
+- (sans args) : cycle complet (briefing + merges + steers + reporting)
+- `--dispatch` : forcer une passe de dispatch explicite vers les lanes idle
+- `--focus <topic>` : concentrer le cycle sur un sujet (texte libre : lean, genai, qc, renum, ...)
 
 ## Process
 
-### Phase 1 - Load Context from Memory
+### Phase 1 - Contexte memoire
 
-Read the following memory files to restore full situational awareness:
+1. `~/.claude/projects/d--CoursIA/memory/MEMORY.md` — index + quick reference
+2. `~/.claude/projects/d--CoursIA/memory/coordinator-durable-state.md` — axes directeurs, bloqueurs user, watches, calendrier
+3. Au besoin : [docs/reference/cluster-agents.md](../../../docs/reference/cluster-agents.md) (machines, lanes, GPU), [docs/reference/teaching-context.md](../../../docs/reference/teaching-context.md) (calendrier ecoles)
 
-1. `~/.claude/projects/d--CoursIA/memory/MEMORY.md` - Index + quick reference
-2. `~/.claude/projects/d--CoursIA/memory/agent_map.md` - Agent statuses + RooSync IDs
-3. `~/.claude/projects/d--CoursIA/memory/teaching_schedule_2026.md` - Deadlines + priorities
-4. `~/.claude/projects/d--CoursIA/memory/jared_qc_partnership.md` - QC sponsorship context (if --focus qc)
+### Phase 2 - Etat live
 
-### Phase 2 - Gather Live State
+0. **Rester courant** : `git checkout main && git pull --ff-only` + `git submodule update --init` — le coordinateur travaille sur un main LOCAL a jour, jamais en grepant un working-tree stale ni en pilotant via `origin/*`.
+1. **Dashboards (canal PRINCIPAL) — lire LES DEUX, independamment** : `roosync_dashboard(action:"read", type:"workspace", section:"all")` pour `workspace-CoursIA` **et** pour `workspace-CoursIA-2`. Deux lanes co-egales ; **aucune n'est "le dashboard du coordinateur"**. Une `lane` = machine x workspace : chaque machine avec une lane CoursIA-2 a AUSSI une lane CoursIA. Lire chacun separement pour ne rater aucun ASK/blocker.
+2. **Inbox DM** : `roosync_messages(action:"inbox", status:"unread")` — les reponses/escalades workers arrivent la.
+3. **GitHub** : `gh pr list --state open` (a merger) + `gh issue list --state open --limit 30` (pool).
+4. **Cron** : `CronList` — si le job coordinateur a disparu (session-only), re-armer `CronCreate("13 0-23/4 * * *", "/coordinate", recurring)`. Cadence unique, PAS de 2e cron ni ScheduleWakeup en plus.
 
-0. **Dashboards (PRIMARY channel) — read BOTH, independently**: `roosync_dashboard(action:"read", type:"workspace", section:"all")` for `workspace-CoursIA` **and** for `workspace-CoursIA-2`. These are two co-equal lanes; **neither is "the coordinator's dashboard"**. Each carries its own worker lanes (a `lane` = machine × workspace: every machine with a CoursIA-2 lane also has a CoursIA lane). Read each separately so ASKs/blockers on one lane are not missed.
-1. **RooSync inbox**: `roosync_read(mode: "inbox", status: "unread")` - Check for new messages from agents
-2. **GitHub issues**: `gh issue list --state open --limit 30 --json number,title,labels` - Current open issues
-3. **Git status**: `git log --oneline -5` - Recent commits on main
-4. **PRs**: `gh pr list --state open` - Any pending PRs to review
+### Phase 3 - Passe de merge (avant tout dispatch)
 
-### Phase 3 - Produce Situational Briefing
+Pour chaque PR ouverte, dans l'ordre d'anciennete :
 
-Output a structured briefing:
+1. Lire body + comments + reviews + diff ([regle HARD](~/.claude/CLAUDE.md) "Read Body Before Any Action").
+2. Verifier l'etat A L'INSTANT-T : `gh pr view N --json state,mergedAt,mergeStateStatus` (jamais depuis le dashboard ou le cycle N-1 — lecon phantom-steer #5563).
+3. Gates : H.4 (notebooks : checkout + Papermill local OU log dans le body), catalogue byte-identique a main (`gh pr view N --json files` — lecon stale-catalog), scope reel = titre, criteres [pr-review-discipline](../../rules/pr-review-discipline.md).
+4. Merge : compte `jsboige` (defaut, seul compte avec MergePullRequest), `--squash` par defaut, `--merge` (preserve-SHA) pour la base d'un stack, **JAMAIS `--delete-branch`**.
 
-```markdown
-# Coordination Briefing - [DATE]
+### Phase 4 - Steers et design-gates
 
-## Deadlines
-- [Next 3 deadlines with countdown]
+Regles completes : [coordinator-discipline.md](../../rules/coordinator-discipline.md) (R3 lanes independantes, R4 jamais sanctionner l'idle, R5 steer qui ATTEINT/VRAI/DECIDE).
 
-## Agent Status
-| Agent | Status | Last Activity | Pending Questions |
-|-------|--------|---------------|-------------------|
+1. **Trancher les design-gates en attente** dans le cycle — ne pas deferer une option deja investiguee.
+2. **Grounder chaque grain firsthand** (`gh issue view N` / `gh pr view N`) AVANT de dispatcher — jamais depuis un status condense.
+3. **Double canal obligatoire** : DM `roosync_messages(action:"send", to:"<machine>:<workspace>", subject:"...", body:"...", priority:"HIGH|MEDIUM")` (le worker lit l'inbox en premier, le DM survit a la condensation) **+** pointeur `[DISPATCH→inbox]` sur le dashboard de la lane (sonnette persistante).
+4. Une lane sans grain = echec coordinateur : deep-queue, fallback perenne par famille, ou pool global — jamais un statut terminal-idle.
 
-## Unread Messages
-- [Summary of unread RooSync messages, if any]
+### Phase 5 - Fin de cycle (obligatoire)
 
-## Open Issues (relevant)
-- [Top issues by priority, filtered by --focus if provided]
+1. **Commit + PR AVANT le rapport** — ne jamais annoncer un travail non commite.
+2. `[DONE]` lane-specific sur **les deux** dashboards (jamais un miroir copie-colle).
+3. **Bloqueurs user** : re-poke explicite dans vscode a CHAQUE fin de session tant que l'action user n'est pas faite ([user-blocker-signaling](../../rules/user-blocker-signaling.md)).
+4. MAJ `coordinator-durable-state.md` si l'etat durable a change (PR#/SHA ephemeres → dashboard, pas la memoire).
 
-## Recommended Actions
-1. [Prioritized list of what to do next]
-```
+## Regles importantes
 
-### Phase 4 - Dispatch (if --dispatch)
-
-For each idle agent with a clear next task:
-
-1. Compose a directive message with:
-   - Clear task description
-   - Issue number reference
-   - Expected deliverables (branch name, PR)
-   - Quality criteria
-2. Send via `roosync_send` to the agent's RooSync ID
-3. Log the dispatch in the briefing output
-
-### Phase 5 - Reply All (if --reply-all)
-
-For each unread message:
-1. Read full message content
-2. Draft appropriate reply (answer questions, acknowledge status, assign next task)
-3. Present replies to user for approval before sending
-4. Mark messages as read after processing
-
-## RooSync Communication Patterns
-
-### Sending directives
-```
-roosync_send(
-  to: "<machine>:<workspace>",
-  subject: "[DIRECTIVE] <short description>",
-  body: "## Mission\n...\n## Deliverables\n...\n## Quality Criteria\n...",
-  priority: "MEDIUM",
-  tags: ["directive", "<topic>"]
-)
-```
-
-### Acknowledging status reports
-```
-roosync_send(
-  action: "reply",
-  message_id: "<original-msg-id>",
-  body: "Recu. [feedback/next steps]",
-  priority: "MEDIUM"
-)
-```
-
-## Focus Areas
-
-### qc (QuantConnect)
-- Agent: po-2024
-- Issues: #106-113, #81
-- Context: Partner course deadline fin mars, Sprint 1 done, Sprint 2 pending
-- Memory: jared_qc_partnership.md, qc_strategies_catalog.md
-
-### slides
-- Agent: po-2025
-- Deadline: 24 mars CM ECE
-- Context: PPTX migration, Marp attempt failed previously
-
-### smartcontracts
-- Agents: po-2023:CoursIA, po-2026
-- Issues: #119, #129
-- Deadline: 20 mai EPITA
-- Context: Plan complet existe (26 notebooks, execution reelle)
-
-### sudoku / search
-- Agents: po-2023:CoursIA, po-2026
-- Deadline: mi-avril EPITA
-- Context: Search/CSP done (PR #127), Sudoku a reviser
-
-### genai
-- Agent: po-2023:GenAI_Series
-- Issues: #49, #60, #78, #79, #80, #84
-- Context: 14/20 SemanticKernel OK, 6 echecs diagnostiques
-
-### epita
-- Issues: #55 (IA Symbolique), Search/Sudoku
-- Deadlines: mi-avril (contraintes), 20 mai (symbolique)
-- Context: Tweety/Planners/SC enrichis, Lean-9/SW-13 done
-
-## Important Rules
-
-- **Never force push** - See CLAUDE.md rules
-- **Coordination via RooSync only** - No coordination files in git
-- **Two workspace dashboards, coordinated independently** - `workspace-CoursIA` and `workspace-CoursIA-2` are co-equal lanes; a `lane` = machine × workspace. Every machine with a CoursIA-2 lane ALSO has a CoursIA lane (e.g. po-2026:CoursIA = Lean Conway/Knot vs po-2026:CoursIA-2 = Grothendieck; po-2024:CoursIA = QC vs po-2024:CoursIA-2 = MGS/.NET; po-2025:CoursIA = Python/ML vs po-2025:CoursIA-2 = .NET/Argumentum). READ and POST a lane-specific coordination on EACH dashboard every cycle — never mirror-broadcast identical content, never treat one as "mine vs the workers'".
-- **Issues + PRs** - Each task = issue, each delivery = PR with review
-- **Prioritize by deadline** - QC/slides > SmartContracts > Sudoku > GenAI
+- **Jamais de force push** — cf [git-workflow.md](../../rules/git-workflow.md)
+- **Coordination via RooSync uniquement** — aucun fichier de coordination/rapport dans git
+- **Deux dashboards workspace, coordonnes independamment** — `workspace-CoursIA` et `workspace-CoursIA-2` sont co-egaux ; lire et poster un contenu lane-specific sur CHACUN a chaque cycle, jamais de broadcast miroir, jamais "le mien vs celui des workers".
+- **Issues + PRs** — chaque tache = issue, chaque livraison = PR avec review
+- **Priorites courantes** : vivre dans `coordinator-durable-state.md` (memoire) + dashboards — pas dans ce fichier (harness-hygiene : le skill decrit le processus, pas l'etat).


### PR DESCRIPTION
## Summary

Refresh des deux fichiers harnais nommés par le user (mandat 2026-07-09) : `.claude/skills/coordinate/SKILL.md` et `.claude/commands/continue.md` décrivaient des dispositifs retirés.

**Supprimé (obsolète)** :
- Outils `roosync_read` / `roosync_send` → `roosync_messages` (inbox/send/reply)
- Fichiers mémoire fantômes (`agent_map.md`, `teaching_schedule_2026.md`, `jared_qc_partnership.md`) → `MEMORY.md` + `coordinator-durable-state.md`
- Focus Areas avec deadlines mars/mai 2026 et issues #55/#106-113/#119/#129 (fermées depuis des mois) → l'état vit en mémoire + dashboards (harness-hygiene), pas dans le skill
- Priorités worker ère-QC (« BROKEN strategies », `/qc-iterative-improve`) → pool global `gh issue list` cross-lane + protocole `[CLAIMED]`

**Ajouté (gaps réels, doctrine actuelle par POINTEURS vers `.claude/rules/`)** :
- `/coordinate` = coordinateur UNIQUEMENT, cron worker = `/continue` (leçon #1502 phantom-merger)
- Passe de merge : état à l'instant-T (`--json state,mergedAt`), gates H.4/catalogue, `--squash` défaut / `--merge` stack-base, jamais `--delete-branch`, compte jsboige
- Steers double-canal : DM `roosync_messages` + pointeur `[DISPATCH→inbox]` dashboard
- Worktree isolé sur arbre sale ; commit+PR AVANT `[DONE]` ; `[ASK USER]` re-poke

**Conservé** : la règle deux-dashboards co-égaux (déjà à jour), le filtrage workspace, la structure par phases.

## Vérifications
- No-pendulum : suppression d'abord, ajouts limités aux gaps non couverts par les rules auto-loaded (les détails restent dans `.claude/rules/*`, le skill pointe)
- Docs-only, 0 notebook, catalogue intouché (diff = 2 fichiers `.claude/`)
- `76 insertions(+), 221 deletions(-)` — le harnais raccourcit

Reste du refresh harnais (hors scope, signalé au user) : `~/.claude/CLAUDE.md` global (cadence 2h supersédée par 30 min) vit dans roo-extensions, à corriger là-bas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
