### PR TITLE
feat(conway-lean): N2 hashlife honnêteté — re-sign p5_large_n_jump + refresh docstrings (#3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2805,25 +2805,33 @@ both hypotheses `(hwf : (padCenter2 c).wf = true)` and
 from `c.wf = true` and `1 ≤ c.level`. The "wf composition lift residual"
 dispatched 2026-06-15 09:59Z is now structurally closed on both axes.
 
-**Residual obstacle chain.**
+**Residual obstacle chain (4 `sorry` total: L2471, L2536, L2853, L2862).**
 
-  `p5_large_n_jump`            (L1646, currently `: True` placeholder)
-    └→ `hashlifeResult_central_correct`  (L1412 — P4 entry point)
-         └→ inductive `succ k` arm of P4 — five `sorry`s:
-              ├ `p4_double_nine_shape`   (L1344, P4.1: 9-cell tiling shape)
-              ├ `p4_wave1_ih`            (L1354, P4.2: first IH wave)
-              ├ `p4_wave2_ih`            (L1364, P4.3: second IH wave)
-              ├ `p4_half_steps_compose`  (L1375, P4.4: `step_light_cone` chained)
-              └ `p4_succ_membership`     (L1393, glue: pointwise biconditional)
+  `p5_large_n_jump`            (L2852, re-signed to real target — proof body `sorry` at L2853)
+    └→ `hashlifeResult_central_correct`  (L2555 — P4 entry point)
+         └→ inductive `succ k` arm of P4 — residual `sorry`s:
+              · `p4_half_steps_compose`  (L2470, P4.4 placeholder `True` — see note)
+              · wave-glue residual       (L2536, succ-arm composition)
+            (the shape/IH sub-lemmas `p4_double_nine_shape` L1744, `p4_wave1_ih_step`
+            L2108, `p4_wave2_ih_step` L2146 carry no `sorry` in the current file)
 
 The P4 inductive step is **research-level, multi-cycle**. The base case `k = 0`
-of P4 is already fully proven (`hashlifeResult_central_correct_base`, L1259,
+of P4 is already fully proven (`hashlifeResult_central_correct_base`, L1648,
 shape lemmas + `2^16` `native_decide`).
+
+**Note on `p4_half_steps_compose` (L2470, P4.4).** The pure evolve half-step
+composition is already closed (`evolve_add` L2353, `evolve_half_step` L2370), so
+re-signing this placeholder to a raw-evolve statement would be vacuously provable
+(gaming the sorry count). The genuine P4.4 content — the hashlife wave
+decomposition on the centered window — is the wave-glue residual at L2536. So
+`p4_half_steps_compose` is, as stated, redundant: its honest treatment is either
+deletion (sorry 4→3) or a re-statement tied to the hashlife wave structure
+(coordinator call). Left as `True` placeholder pending that call.
 
 **Independently provable sub-claim (sorry-free additive grain, P4-free).**
 
-The proof plan (L1588-1591) states "the jump expands the bounding box by at
-most `2^(k-2)`, within the padding margin", so the claim
+The proof plan states "the jump expands the bounding box by at most `2^(k-2)`,
+within the padding margin", so the claim
 
   `BoxAssezGrand g n → n ≥ jumpSize ... → BoxAssezGrand (jumpResult g) (n - jumpSize ...)`
 
@@ -2832,14 +2840,14 @@ It does **not** depend on `hashlifeResult_central_correct` and can be discharged
 via decidable evaluation + `Nat` arithmetic. This is a natural next sorry-free
 additive grain on the P5.2 frame, queueable behind the P4 verrou unlock.
 
-**Placeholder defect.** `p5_large_n_jump : True` (L1646) is vacuously typed —
-the real target is something like
+**Re-signed target (N2, 2026-07-09).** `p5_large_n_jump` (L2852) now carries the
+real conclusion
 
   `(h : BoxAssezGrand g n) (hbig : n ≥ jumpSize (gridToMacroCellWithOffset g).2.level) →`
   `  evolveHashlifeFast n g = evolve n g`
 
-When the P4 verrou unlocks, both the signature AND the proof body need to be
-filled in. Until then the obstacle remains structural-on-P4, not local-on-P5. -/
+with the proof body still `sorry` (L2853) pending the P4 unlock. The obstacle
+remains structural-on-P4, not local-on-P5. -/
 
 /-- **P5.2** (compositional, blocked on P4): when `n ≥ 2^(k-2)`,
     `evolveHashlifeFast n g` makes one Hashlife jump of `2^(k-2)` generations
@@ -2849,7 +2857,9 @@ filled in. Until then the obstacle remains structural-on-P4, not local-on-P5. -/
     cells into the live region, and `box_assez_grand` is preserved through the
     recursion. Difficulty: P5.2 (research-level; **blocked until P4
     inductive step proven**). -/
-theorem p5_large_n_jump (n : Nat) (g : Grid) (h : BoxAssezGrand g n) : True := by
+theorem p5_large_n_jump (n : Nat) (g : Grid) (h : BoxAssezGrand g n)
+    (hbig : n ≥ jumpSize (gridToMacroCellWithOffset g).2.level) :
+    evolveHashlifeFast n g = evolve n g := by
   sorry
 
 /-- **P5.3** (glue): the full induction on `n`, with a case split on


### PR DESCRIPTION
## Ce que fait cette PR

Tranche **N2 « honnêteté »** du balisage #3846 (hashlife, ai-01 P0 dispatch « ce cycle ») — **partielle : 1/2 placeholders `True` re-signés + docstrings**, le 2ᵉ placeholder (`p4_half_steps_compose`) est **flaggé pour décision coordinateur** (voir §« Finding »).

1. **Re-signature `p5_large_n_jump`** (L2852) : placeholder `: True` (vacuously typed) → vraie cible P5.2 :
   ```lean
   theorem p5_large_n_jump (n : Nat) (g : Grid) (h : BoxAssezGrand g n)
       (hbig : n ≥ jumpSize (gridToMacroCellWithOffset g).2.level) :
       evolveHashlifeFast n g = evolve n g := by
     sorry
   ```
   Le binder `hbig` et la conclusion miroirent exactement le `by_cases` de `p5_inductive_step` (`n < jumpSize (gridToMacroCellWithOffset g).2.level`) — donc la signature typecheck (mêmes symboles en scope). Corps de preuve `sorry` (P4 verrouillé). **Consumer-safe** : `p5_large_n_jump` n'a **aucun call-site en corps de preuve** (le bras large de `p5_inductive_step` est `· sorry`, ne l'invoque pas) — vérifié firsthand via grep.

2. **Refresh docstring périmée** (L2808-2842) : « five sorrys » → **4 réels** (L2471/L2536/L2863/L2872) ; vieux numéros de ligne L1646/L1412/L1259/L1344-1393 → courants (L2852/L2555/L1648/L1744/L2108/L2146/L2470) ; documente le finding `p4_half_steps_compose` (voir § Finding).

## Finding firsthand — `p4_half_steps_compose` (L2470) est redondant (POUR DÉCISION ai-01)

Le balisage N2 demandait de re-signer **les 2** placeholders `True`. Je n'en re-signature qu'**un** (`p5_large_n_jump`, ci-dessus). Le 2ᵉ, `p4_half_steps_compose` (P4.4), s'avère **redondant** après investigation firsthand :

- La **composition pure evolve half-step est déjà close** : `evolve_add` (L2353) + `evolve_half_step` (L2370) sont prouvés dans le fichier. Re-signer `p4_half_steps_compose` comme une composition `evolve` brute → **trivialement prouvable** (gaming du sorry count, anti-honnêteté G.2).
- Le **vrai contenu P4.4** — la décomposition des ondes hashlife (`hashlifeResultAux` wave1∘wave2) sur la fenêtre centrée — est le **résidu de wave-glue au L2536** (contenu S2-S4 absorbé). Re-signer `p4_half_steps_compose` en ça → **duplique L2536**.
- Donc le traitement honnête de `p4_half_steps_compose` est : **(a) suppression (sorry 4→3)** OU **(b) re-statement lié à la structure d'onde hashlife** (research-level, typecheck-itération nécessaire). Les deux options **brisent la contrainte « sorry 4→4 »** du dispatch N2 — d'où la remontée à ai-01 plutôt que deviner.

**Je laisse `p4_half_steps_compose` comme placeholder `True` (L2470)** en attendant la décision d'ai-01 (suppression 4→3 vs énoncé wave-structure). C'est documenté dans la docstring refresh.

## Acceptance §B (pr-review-discipline Lean)

| Critère §B | Preuve |
|------------|--------|
| `grep -c sorry` avant/après | **4 → 4** (L2471/L2536/L2863/L2872), pattern standalone-tactic `^\s*sorry\s*$\|:= by sorry\|:= sorry\b\|exact sorry\|^\s*· sorry`, `.lake/` exclu. **Pas de régression.** |
| Lake build SUCCESS | Pas de build local ce cycle : `conway_lean` mathlib = symlink vers le shared cache **corrompu** (c.356, origin pointer → CoursIA repo au lieu de mathlib, tree `d568c8c0` absent). **CI dédiée `lean-conway.yml` typecheck sur push = preuve autoritaire** (règle durable ai-01 c.357 : « Do NOT block Lean merges on local build failure when the PR carries a green Lean CI job »). Le check CI post-push est la preuve. |
| Proof integrity | Aucun axiome touché (corps de preuve = `sorry`,inchangé). 0 nouveau `sorry`. 0 nouveau placeholder `True` (le seul restant, `p4_half_steps_compose` L2470, est préexistant et flaggé). |
| `sorry-baseline: "7"` (lean-conway.yml) | C'est un **plancher de régression** (count ≤ baseline passe), pas égalité stricte. 4 ≤ 7 → CI verte. Le baseline 7 est **stale** (3 sorries fermés via gates P4 sans bump du baseline) — nettoyage infra = PR séparée, **pas bundled ici**. |

## Vérifications

- sorry count 4→4 (grep ci-dessus, firsthand).
- 1 seul placeholder `True` restant (L2470 `p4_half_steps_compose`, préexistant + flaggé).
- LF-clean (0 octet CR dans le blob staged, c.282).
- `p5_large_n_jump` re-signature consumer-safe (grep call-sites : 0 en corps de preuve).
- Pas de régression §D : c'est un **renforcement** (`True` → vrai énoncé), pas un remplacement de preuve par `sorry`.

## Scope

`See #3846` — **tranche partielle N2** (1/2 placeholders + docstrings). La décision sur `p4_half_steps_compose` (suppression 4→3 vs re-statement wave) est remontée à ai-01. Pas `Closes` (epic multi-grain N2→N1→N5∥N3).

Co-authored-by: Claude-Code <noreply@anthropic.com>
