### PR TITLE
feat(conway-lean): N2-bis hashlife — suppress redundant p4_half_steps_compose (sorry 4->3) (#3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1754,16 +1754,16 @@ DEMOS = {
     62: {
         "name": "HASHLIFE_P4_SUCC_MEMBERSHIP",
         "file": str(CONWAY_HASHLIFE_FILE) if CONWAY_HASHLIFE_FILE else "",
-        "line": 2536,
+        "line": 2527,
         "sorry_type": "sorry_replacement",
         "theorem_name": "p4_succ_membership",
         "theorem": "p4_succ_membership",
         "imports": CONWAY_HASHLIFE_IMPORTS,
         "description": (
             "BG-prover target (hashlife nibble plan #3846, N3): residual sorry in\n"
-            "noncomputable def p4_succ_membership (declared L2498 of\n"
+            "noncomputable def p4_succ_membership (declared L2490 of\n"
             "HashlifeCorrectness.lean). The whnf wall is already traversed at\n"
-            "L2520-2531 (node16_level_ne_two -> rw [if_neg hne2] ->\n"
+            "L2519-2530 (node16_level_ne_two -> rw [if_neg hne2] ->\n"
             "rw [mem_toGrid_node]); what remains is the offset-matching assembly:\n"
             "prove each `out_*.toGrid (off_*, off_*)` membership via\n"
             "centralCorrect_mem (gate G2, merged #4812) plus the induction\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1716,7 +1716,7 @@ independent, difficulty-ranked prover target (grignotable one-per-session).
 | `p4_double_nine_shape`     | P4.1 (structural) | The 9 sub-cells `n_i` tile `c` and each has level `k+1` + is wf |
 | `p4_wave1_ih`              | P4.2 (IH application) | Each `r_i = hashlifeResultAux (k+1) n_i` matches `evolve 2^(k-1)` on the `n_i` window (by IH at level `k`) |
 | `p4_wave2_ih`              | P4.3 (IH application) | Each `out_* = hashlifeResultAux (k+1) q_*` matches `evolve 2^(k-1)` on the `q_*` window (by IH at level `k`) |
-| `p4_half_steps_compose`    | P4.4 (compositional, hardest) | Wave1 ∘ Wave2 = `2^k` generations via `step_light_cone` (P2, proven) — the boundary of each sub-cell does not leak because the live region stays inside the centered window |
+| ~~`p4_half_steps_compose`~~ | P4.4 (compositional) — **SUBSUMED** | The pure `evolve` half-step composition is `evolve_add` (L2353) + `evolve_half_step` (L2370), both proven sorry-free; the wave-assembly obligation is carried by the residual `sorry` of `p4_succ_membership`. The standalone `: True` placeholder theorem was deleted (N2-bis) as a vacuous dup of an already-closed obligation |
 
 Once all four are proven, `p4_succ_membership` glues them. The ordering
 P4.1 → P4.2 → P4.3 → P4.4 reflects dependency: P4.2/P4.3 need P4.1's shape
@@ -1799,7 +1799,7 @@ private theorem node16_level (nw_nw nw_ne nw_sw nw_se ne_nw ne_ne ne_sw ne_se
     opaque binders + one level hypothesis), the `hashlifeResultAux_succ_node`
     if-condition `(node16).level == 2` is false for `k ≥ 1` (the node level is
     `k + 2 ≥ 3`). Proven standalone because stating/rewriting `(node16).level`
-    INLINE inside `p4_succ_membership`'s rich context (post `_h1`/`_h2`/`_h3`/`_h4`
+    INLINE inside `p4_succ_membership`'s rich context (post `_h1`/`_h2`/`_h3`
     obtain of 16 gc's) whnf-diverges (the c.142 pathology). Applying this helper
     there keeps the level term inferred, never re-elaborated — the opaque-binder
     pattern of c.139/c.143. -/
@@ -2339,10 +2339,13 @@ of milestones with clear interfaces (the same methodology that isolated
   `centralCorrect q_j (k-1)` facts from P4.3 (`p4_wave2_ih`) to conclude the
   pointwise membership agreement that `p4_succ_membership` needs.
 
-Until S3–S4 are closed, `p4_half_steps_compose` remains the `True` placeholder
-(it is consumed by `p4_succ_membership` only structurally); S1 (composition)
-and S2 (no-leak) are now closed, so the remaining open surface is the
-sub-cell-coverage + assembly argument (S3, S4). -/
+S1 (composition) and S2 (no-leak) are closed; the remaining open surface is
+the sub-cell-coverage + assembly argument (S3, S4), carried by the residual
+`sorry` of `p4_succ_membership`. The standalone `p4_half_steps_compose`
+theorem (former `: True` placeholder) was deleted in N2-bis: its pure-evolve
+content is exactly `evolve_add` + `evolve_half_step` (both proven), and its
+wave-assembly content is exactly the S3/S4 residual, so it duplicated an
+already-closed obligation — a vacuous placeholder (G.2). -/
 
 /-- **S1** (CLOSED): `evolve (a + b) g = evolve a (evolve b g)`.
 
@@ -2457,23 +2460,12 @@ private theorem window_cone_in_domain (k : Nat) (p q : Int × Int)
   refine ⟨?_, ?_, ?_, ?_⟩
   all_goals linarith
 
-/-- **P4.4** (compositional, hardest): the two half-steps compose — wave 1
-    (advancing `2^(k-1)` generations) followed by wave 2 (another `2^(k-1)`)
-    equals `evolve (2^k)` on the centered window, because the boundary of
-    each sub-cell does not leak into the live region (light-cone lemma P2,
-    `step_light_cone`, proven above). Difficulty: P4.4 (research-level).
-
-    **Balisage (c.145)**: decomposed into S1 (CLOSED, `evolve_add`) + S2/S3/S4
-    sub-sorries — see the section docstring above. Until S2–S4 close, this
-    remains the `True` placeholder consumed structurally by `p4_succ_membership`. -/
-theorem p4_half_steps_compose
-    (c : MacroCell) (k : Nat) (hwf : c.wf = true) (hk : c.level = k + 2) : True := by
-  sorry
-
 /-- **P4 entry point**: the pointwise membership biconditional for the
     inductive step. Glues `p4_double_nine_shape` (P4.1), `p4_wave1_ih`
-    (P4.2), `p4_wave2_ih` (P4.3), and `p4_half_steps_compose` (P4.4). Once
-    the four sub-lemmas are proven, this function produces the
+    (P4.2), and `p4_wave2_ih` (P4.3). The P4.4 half-step composition is
+    subsumed by the closed lemmas `evolve_add` (L2353) + `evolve_half_step`
+    (L2370) and the wave-assembly residual carried in this proof body's own
+    `sorry`. Once the residual closes, this function produces the
     `∀ p, p ∈ ... ↔ p ∈ ...` hypothesis that `p4_ext_bridge` consumes.
 
     **Pointwise-proof balisage (c.147)** — the residual `sorry` after `intro p`
@@ -2504,7 +2496,6 @@ noncomputable def p4_succ_membership
   have _h1 := p4_double_nine_shape c k hwf hk
   have _h2 := p4_wave1_ih c k hwf hk hk1 ih
   have _h3 := p4_wave2_ih c k hwf hk hk1 ih
-  have _h4 := p4_half_steps_compose c k hwf hk
   intro p
   -- LHS assembly (c.156). The 3 G3 gates (hcnode, hashlifeResultAux_succ_node,
   -- if_neg) now compose through the whnf wall, exposing the `node out_*`
@@ -2805,28 +2796,29 @@ both hypotheses `(hwf : (padCenter2 c).wf = true)` and
 from `c.wf = true` and `1 ≤ c.level`. The "wf composition lift residual"
 dispatched 2026-06-15 09:59Z is now structurally closed on both axes.
 
-**Residual obstacle chain (4 `sorry` total: L2471, L2536, L2853, L2862).**
+**Residual obstacle chain (3 `sorry` total: L2527, L2855, L2864).**
 
-  `p5_large_n_jump`            (L2852, re-signed to real target — proof body `sorry` at L2853)
-    └→ `hashlifeResult_central_correct`  (L2555 — P4 entry point)
-         └→ inductive `succ k` arm of P4 — residual `sorry`s:
-              · `p4_half_steps_compose`  (L2470, P4.4 placeholder `True` — see note)
-              · wave-glue residual       (L2536, succ-arm composition)
+  `p5_large_n_jump`            (L2852, re-signed to real target — proof body `sorry` at L2855)
+    └→ `hashlifeResult_central_correct`  (L2546 — P4 entry point)
+         └→ inductive `succ k` arm of P4 — 1 residual `sorry`:
+              · wave-glue residual       (L2527, succ-arm composition + assembly)
             (the shape/IH sub-lemmas `p4_double_nine_shape` L1744, `p4_wave1_ih_step`
-            L2108, `p4_wave2_ih_step` L2146 carry no `sorry` in the current file)
+            L2108, `p4_wave2_ih_step` L2146 carry no `sorry`; the P4.4 half-step
+            composition is closed via `evolve_add`/`evolve_half_step` — see note)
 
 The P4 inductive step is **research-level, multi-cycle**. The base case `k = 0`
 of P4 is already fully proven (`hashlifeResult_central_correct_base`, L1648,
 shape lemmas + `2^16` `native_decide`).
 
-**Note on `p4_half_steps_compose` (L2470, P4.4).** The pure evolve half-step
-composition is already closed (`evolve_add` L2353, `evolve_half_step` L2370), so
-re-signing this placeholder to a raw-evolve statement would be vacuously provable
-(gaming the sorry count). The genuine P4.4 content — the hashlife wave
-decomposition on the centered window — is the wave-glue residual at L2536. So
-`p4_half_steps_compose` is, as stated, redundant: its honest treatment is either
-deletion (sorry 4→3) or a re-statement tied to the hashlife wave structure
-(coordinator call). Left as `True` placeholder pending that call.
+**Note on P4.4 (SUPPRESSED in N2-bis, 2026-07-09).** The standalone
+`p4_half_steps_compose` theorem was a `: True` placeholder. Its pure-evolve
+half-step content is exactly `evolve_add` (L2353) + `evolve_half_step` (L2370),
+both already proven sorry-free; its wave-assembly content is exactly the
+wave-glue residual (L2527). Re-signing it would either duplicate L2527 or be
+vacuously provable (gaming the sorry count, G.2), so the coordinator greenlit
+its **deletion** (sorry 4→3) together with its unused `have _h4` consumer in
+`p4_succ_membership`. P4.4 is now carried by `evolve_add`/`evolve_half_step`
+(closed) + the L2527 residual.
 
 **Independently provable sub-claim (sorry-free additive grain, P4-free).**
 
@@ -2846,7 +2838,7 @@ real conclusion
   `(h : BoxAssezGrand g n) (hbig : n ≥ jumpSize (gridToMacroCellWithOffset g).2.level) →`
   `  evolveHashlifeFast n g = evolve n g`
 
-with the proof body still `sorry` (L2853) pending the P4 unlock. The obstacle
+with the proof body still `sorry` (L2855) pending the P4 unlock. The obstacle
 remains structural-on-P4, not local-on-P5. -/
 
 /-- **P5.2** (compositional, blocked on P4): when `n ≥ 2^(k-2)`,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.en.md
@@ -5,7 +5,7 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 ## Status
 
 - **Toolchain**: v4.31.0-rc1
-- **Sorry count**: 4 (all in `HashlifeCorrectness.lean` — P4 double-nine inductive step [2] + P5 large-n jump [2], Epic #2162). Three P4 sub-lemmas are now proven sorry-free (see § "Game of Life" below)
+- **Sorry count**: 3 (all in `HashlifeCorrectness.lean` — P4 double-nine wave-glue residual `p4_succ_membership` [1] + P5 large-n jump [2], Epic #2162). Three P4 sub-lemmas are now proven sorry-free (see § "Game of Life" below). The P4.4 `p4_half_steps_compose` placeholder was deleted: its pure-evolve composition is already closed (`evolve_add` + `evolve_half_step`), its wave-glue content carried by the `p4_succ_membership` residual
 - **Build**: `lake build Conway` -- SUCCESS (3352 jobs)
 - **Dependencies**: Mathlib4
 
@@ -38,7 +38,7 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 | `Conway/Life/Computation.lean` | 0 | Hashlife cross-validation (6 + 6 fast), eater1 still-life (1), glider composition (5) |
 | `Conway/Life/HashlifeMemo.lean` | 0 | Memoized Hashlife for community pillar witnesses (OTCA 35K, UnitCell 4096, Gemini 33M) |
 | `Conway/Life/Pillars.lean` | 0 | Community-witness theorem scaffolding (4 pillars) |
-| `Conway/Life/HashlifeCorrectness.lean` | 4 | Bounded correctness `hashlife_correct`; P4/P5 prover targets (Epic #1453, #2162) |
+| `Conway/Life/HashlifeCorrectness.lean` | 3 | Bounded correctness `hashlife_correct`; P4/P5 prover targets (Epic #1453, #2162) |
 
 ### Phase 3 — Free Will Theorem (Epic #1651, COMPLETE)
 
@@ -79,17 +79,20 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 - **Memoized Hashlife**: Community pillar witnesses (OTCA 35K gen, UnitCell 4096 gen, Gemini 33M gen)
 - **HashlifeCorrectness**: bounded correctness `hashlife_correct`, decomposed P1-P5
   - **P1-P3 proven** (base case `k=0` via `2^16 native_decide`, PR #2810)
-  - **P4 inductive step** (2 sorry): decomposed by #2975 scaffolding into five sub-lemmas.
+  - **P4 inductive step** (1 residual sorry): decomposed by #2975 scaffolding into sub-lemmas.
     Three are now **proven sorry-free** with real statements — `p4_double_nine_shape`
     (structural existence of the nine quadrants of a double-nine cell), `p4_wave1_ih` and
     `p4_wave2_ih` (propagation of `centralCorrect` via the induction hypothesis over the two
-    waves). Remaining: `p4_half_steps_compose` (`: True` placeholder, light-cone double-nine
-    half-step composition) + glue `p4_succ_membership` (the real pointwise biconditional after
-    `intro p`). Research-level double-nine light-cone composition, whnf-hard — reserved for a
-    dedicated multi-cycle effort. The sub-lemmas' real statements live in their docstrings —
-    restate + prove, do not eliminate as `True`.
+    waves). The P4.4 `p4_half_steps_compose` placeholder (`: True`) was **deleted** (N2-bis):
+    its pure-evolve half-step composition is exactly the closed `evolve_add` + `evolve_half_step`,
+    and its wave-assembly content is carried by the **1 residual sorry** of glue
+    `p4_succ_membership` (the real pointwise biconditional after `intro p`). Research-level
+    double-nine light-cone composition, whnf-hard — reserved for a dedicated multi-cycle effort.
+    The sub-lemmas' real statements live in their docstrings — restate + prove, do not eliminate
+    as `True`.
   - **P5 large-n** (2 sorry): `p5_small_n_fallback` **PROVEN** (PR #2984); `p5_large_n_jump`
-    (P5.2, `: True` placeholder, blocked on P4) + `p5_inductive_step` large-n branch (P5.3
+    (P5.2, re-signed to its real target `evolveHashlifeFast n g = evolve n g`, body `sorry`,
+    blocked on P4) + `p5_inductive_step` large-n branch (P5.3
     glue) remain. Base `n=0` proven (`hashlife_correct_base_zero` #2898,
     `evolveHashlifeFastAux_zero_n` #2901).
 
@@ -121,7 +124,7 @@ Ce workspace formalise en Lean 4 trois facettes de l'oeuvre de John Conway, des 
 
 ### État honnête du verrou HashlifeCorrectness
 
-Le théorème central `hashlife_correct` (borné par l'hypothèse de padding `BoxAssezGrand`) n'est **pas encore prouvé en pleine généralité** : il reste **4 `sorry`** dans `HashlifeCorrectness.lean`. Le socle est solide — cas de base `k=0` prouvé (`2^16 native_decide`), cas de base `n=0` prouvé, P1/P2/P3 (padding, light-cone, locality) prouvés, `p5_small_n_fallback` prouvé, et trois des cinq sous-lemmes P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`) désormais prouvés sorry-free — mais le pas inductif P4 (double-nine decomposition, 2 sorry résiduels : `p4_half_steps_compose` + colle `p4_succ_membership`) et le grand-n P5 (2 sorry, bloqué sur P4) sont **research-level**. Ce sont les cibles du BG-prover (`agent_tests/prover/`), pas des grains bornés : la composition light-cone multi-vagues résiste à l'automatisation tactique courante. Les scaffolds P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_half_steps_compose`, `p4_succ_membership`) énoncent précisément chaque sous-but dans leurs docstrings.
+Le théorème central `hashlife_correct` (borné par l'hypothèse de padding `BoxAssezGrand`) n'est **pas encore prouvé en pleine généralité** : il reste **3 `sorry`** dans `HashlifeCorrectness.lean`. Le socle est solide — cas de base `k=0` prouvé (`2^16 native_decide`), cas de base `n=0` prouvé, P1/P2/P3 (padding, light-cone, locality) prouvés, `p5_small_n_fallback` prouvé, et trois des sous-lemmes P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`) désormais prouvés sorry-free — mais le pas inductif P4 (double-nine decomposition, 1 sorry résiduel : colle `p4_succ_membership` — le placeholder `p4_half_steps_compose` a été supprimé, sa composition pure-evolve étant close via `evolve_add`+`evolve_half_step`) et le grand-n P5 (2 sorry, bloqué sur P4) sont **research-level**. Ce sont les cibles du BG-prover (`agent_tests/prover/`), pas des grains bornés : la composition light-cone multi-vagues résiste à l'automatisation tactique courante. Les scaffolds P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_succ_membership`) énoncent précisément chaque sous-but dans leurs docstrings.
 
 ### Leçons méthodologiques
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -19,7 +19,7 @@ flowchart LR
 ## Statut
 
 - **Toolchain** : v4.31.0-rc1
-- **Compte de sorry** : 4 (tous dans `HashlifeCorrectness.lean` — assemblage offset-matching P4 `p4_half_steps_compose` [2] + grand-n P5 [2], Epic #2162). Plusieurs sous-lemmes P4 et ingrédients additifs sont prouvés sorry-free (voir § « Jeu de la Vie » ci-dessous)
+- **Compte de sorry** : 3 (tous dans `HashlifeCorrectness.lean` — assemblage wave-glue P4 `p4_succ_membership` [1] + grand-n P5 [2], Epic #2162). Plusieurs sous-lemmes P4 et ingrédients additifs sont prouvés sorry-free (voir § « Jeu de la Vie » ci-dessous). Le placeholder `p4_half_steps_compose` (P4.4) a été supprimé : sa composition pure-evolve est déjà close (`evolve_add` + `evolve_half_step`), son contenu wave-glue porté par le résiduel `p4_succ_membership`
 - **Build** : `lake build Conway` — SUCCESS
 - **Dépendances** : Mathlib4
 
@@ -53,7 +53,7 @@ flowchart LR
 | `Conway/Life/Computation.lean` | 0 | Cross-validation Hashlife (6 + 6 fast), still-life eater1 (1), composition de planeurs (5) |
 | `Conway/Life/HashlifeMemo.lean` | 0 | Hashlife mémoïsé pour témoins des piliers communautaires (OTCA 35K, UnitCell 4096, Gemini 33M) |
 | `Conway/Life/Pillars.lean` | 0 | Scaffolding du théorème community-witness (4 piliers) |
-| `Conway/Life/HashlifeCorrectness.lean` | 4 | Correction bornée `hashlife_correct` ; cibles P4/P5 du prouveur (Epic #1453, #2162) |
+| `Conway/Life/HashlifeCorrectness.lean` | 3 | Correction bornée `hashlife_correct` ; cibles P4/P5 du prouveur (Epic #1453, #2162) |
 
 ### Phase 3 — Free Will Theorem (Epic #1651, COMPLETE)
 
@@ -94,22 +94,24 @@ flowchart LR
 - **Hashlife mémoïsé** : témoins des piliers communautaires (OTCA 35K gen, UnitCell 4096 gen, Gemini 33M gen)
 - **HashlifeCorrectness** : correction bornée `hashlife_correct`, décomposée en P1-P5
   - **P1-P3 prouvés** (cas de base `k=0` via `2^16 native_decide`, PR #2810)
-  - **Pas inductif P4** (2 sorry) : le scaffolding #2975 décompose le pas inductif en
+  - **Pas inductif P4** (1 sorry résiduel) : le scaffolding #2975 décompose le pas inductif en
     sous-lemmes. Sont **prouvés sorry-free** — `p4_double_nine_shape` (existence
     structurelle des neuf quadrants d'une cellule double-nine), `p4_wave1_ih` et
     `p4_wave2_ih` (propagation du `centralCorrect` par l'hypothèse d'induction sur les
     deux vagues), `p4_ext_bridge`, ainsi que les ingrédients additifs clos cycles 145-160 :
     `evolve_add` (S1), `window_cone_in_domain` (S2), `evolve_half_step` (demi-pas `2^k`,
     #4555), `centralCorrect_mem_shift` (gate G2 offset-généralisé, #4812) et
-    `evolve_cone_agree` (gate de composition de localité radius-doubling, #4892). Restent
-    les **2 sorry** de `p4_half_steps_compose` — le cœur d'assemblage offset-matching G3
-    (« p4_succ_membership ») : caractériser l'appartenance des super-cellules `q_*` aux
-    quatre offsets de quadrant via `centralCorrect_mem` (G2) + le pontage
+    `evolve_cone_agree` (gate de composition de localité radius-doubling, #4892). Le
+    placeholder P4.4 `p4_half_steps_compose` (`: True`) a été **supprimé** (N2-bis) : sa
+    composition pure-evolve est exactement `evolve_add` + `evolve_half_step` (clos), son
+    contenu wave-glue étant porté par le **1 sorry résiduel** de `p4_succ_membership` — le
+    cœur d'assemblage offset-matching G3 : caractériser l'appartenance des super-cellules
+    `q_*` aux quatre offsets de quadrant via `centralCorrect_mem` (G2) + le pontage
     `evolve_half_step`/`step_light_cone` (G3). Composition light-cone double-nine whnf-dure
     de niveau recherche — cible du BG-prover multi-cycle.
   - **Grand-n P5** (2 sorry) : `p5_small_n_fallback` **PROUVÉ** (PR #2984) ;
     `evolve_dead_of_cone_dead` (contrapositive P5.2, #4574) **prouvé sorry-free** ;
-    `p5_large_n_jump` (P5.2, placeholder `: True`, bloqué sur P4) + branche grand-n de
+    `p5_large_n_jump` (P5.2, re-signé en sa vraie cible `evolveHashlifeFast n g = evolve n g`, corps `sorry`, bloqué sur P4) + branche grand-n de
     `p5_inductive_step` (colle P5.3) restent. Cas de base `n=0` prouvé
     (`hashlife_correct_base_zero` #2898, `evolveHashlifeFastAux_zero_n` #2901).
 
@@ -141,7 +143,7 @@ Ce workspace formalise en Lean 4 trois facettes de l'oeuvre de John Conway, des 
 
 ### État honnête du verrou HashlifeCorrectness
 
-Le théorème central `hashlife_correct` (borné par l'hypothèse de padding `BoxAssezGrand`) n'est **pas encore prouvé en pleine généralité** : il reste **4 `sorry`** dans `HashlifeCorrectness.lean`. Le socle est solide — cas de base `k=0` prouvé (`2^16 native_decide`), cas de base `n=0` prouvé, P1/P2/P3 (padding, light-cone, locality) prouvés, `p5_small_n_fallback` prouvé, les sous-lemmes P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_ext_bridge`) prouvés sorry-free, ainsi que les ingrédients additifs clos cycles 145-160 (`evolve_add`, `window_cone_in_domain`, `evolve_half_step`, `centralCorrect_mem_shift`, `evolve_cone_agree`) et la contrapositive P5.2 (`evolve_dead_of_cone_dead`) — mais le pas inductif P4 (assemblage offset-matching G3, 2 sorry résiduels dans `p4_half_steps_compose`) et le grand-n P5 (2 sorry, bloqué sur P4) sont **research-level**. Ce sont les cibles du BG-prover (`agent_tests/prover/`), pas des grains bornés : la composition light-cone multi-vagues résiste à l'automatisation tactique courante. Les scaffolds P4 énoncent précisément chaque sous-but dans leurs docstrings.
+Le théorème central `hashlife_correct` (borné par l'hypothèse de padding `BoxAssezGrand`) n'est **pas encore prouvé en pleine généralité** : il reste **3 `sorry`** dans `HashlifeCorrectness.lean`. Le socle est solide — cas de base `k=0` prouvé (`2^16 native_decide`), cas de base `n=0` prouvé, P1/P2/P3 (padding, light-cone, locality) prouvés, `p5_small_n_fallback` prouvé, les sous-lemmes P4 (`p4_double_nine_shape`, `p4_wave1_ih`, `p4_wave2_ih`, `p4_ext_bridge`) prouvés sorry-free, ainsi que les ingrédients additifs clos cycles 145-160 (`evolve_add`, `window_cone_in_domain`, `evolve_half_step`, `centralCorrect_mem_shift`, `evolve_cone_agree`) et la contrapositive P5.2 (`evolve_dead_of_cone_dead`) — mais le pas inductif P4 (assemblage offset-matching G3, 1 sorry résiduel dans `p4_succ_membership` — le placeholder `p4_half_steps_compose` a été supprimé, sa composition pure-evolve étant déjà close via `evolve_add`+`evolve_half_step`) et le grand-n P5 (2 sorry, bloqué sur P4) sont **research-level**. Ce sont les cibles du BG-prover (`agent_tests/prover/`), pas des grains bornés : la composition light-cone multi-vagues résiste à l'automatisation tactique courante. Les scaffolds P4 énoncent précisément chaque sous-but dans leurs docstrings.
 
 *La pyramide de correction `hashlife_correct` : le socle prouvé (cas de base, P1-P3,
 `p5_small_n_fallback`) porte le théorème ; au sommet, le verrou research-level P4
@@ -155,7 +157,7 @@ flowchart TD
     P2["P2 — Light-cone<br/>step_light_cone  <b>✓</b>"]
     P3["P3 — Localité<br/>aliveNext_local · step_local  <b>✓</b>"]
     P5S["P5 petit-n<br/>p5_small_n_fallback  <b>✓</b> (#2984)"]
-    P4["P4 — Pas inductif double-nine  <b>⚠ research-level</b><br/>2 sorry · p4_half_steps_compose (assemblage offset-matching G3)<br/><i>sous-lemmes + ingrédients additifs prouvés (shape, wave1, wave2, ext_bridge, evolve_cone_agree, centralCorrect_mem_shift, evolve_half_step) ; reste le cœur G3 whnf-dur</i>"]
+    P4["P4 — Pas inductif double-nine  <b>⚠ research-level</b><br/>1 sorry · p4_succ_membership (assemblage offset-matching G3)<br/><i>sous-lemmes + ingrédients additifs prouvés (shape, wave1, wave2, ext_bridge, evolve_cone_agree, centralCorrect_mem_shift, evolve_half_step) ; p4_half_steps_compose supprimé (subsumé evolve_add/evolve_half_step) ; reste le cœur G3 whnf-dur</i>"]
     P5["P5 — Grand-n jump  <b>⚠ bloqué sur P4</b><br/>2 sorry · p5_large_n_jump · p5_inductive_step<br/><i>p5_small_n_fallback + evolve_dead_of_cone_dead prouvés</i>"]
     GOAL["hashlife_correct  <b>non prouvé en pleine généralité</b>"]
 


### PR DESCRIPTION
## Ce que fait cette PR

Tranche **N2-bis** du balisage #3846 (hashlife) — **suppression du placeholder redondant `p4_half_steps_compose` (sorry 4→3)**. Suite directe de #5793 (N2, MERGÉ 41fb3cc23) suite à la décision (a) SUPPRESSION greenlitée par ai-01 (DM 2026-07-09) après cross-check G.1 des deux côtés.

### 1. Suppression (HashlifeCorrectness.lean)
- **Théorème `p4_half_steps_compose`** (L2469-2471 sur #5793) supprimé : `theorem ... : True := by sorry` — placeholder **vacant** (zéro contenu de preuve).
- **Consommateur `have _h4 := p4_half_steps_compose c k hwf hk`** dans `p4_succ_membership` supprimé : `have` `_h4` type `True`, jeté structuralement (aucun usage ultérieur en corps de preuve — vérifié firsthand).

### 2. Anti-régression §D — justification écrite (pourquoi la suppression est safe)
| Critère | Preuve firsthand |
|---------|------------------|
| Contenu du placeholder | `: True := by sorry` — **vacant**, aucune preuve |
| Composition evolve pure half-step | **Déjà close** : `evolve_add` (L2353) + `evolve_half_step` (L2370), sorry-free |
| Contenu wave-assembly | **Porté** par le sorry résiduel de `p4_succ_membership` (L2527) — donc le placeholder **dupliquait** une obligation déjà tracée |
| Re-signature alternative | Soit duplique L2527, soit trivialement prouvable (gaming sorry count G.2) → (b) re-statement REJETÉ par ai-01 |

→ Deletion = traitement honnête. Pas une preuve remplacée par `sorry` (règle §D respectée).

### 3. Refresh références (scope ai-01 N2-bis)
- **HashlifeCorrectness.lean docstrings** (6 blocs) : P4.4 table row → SUBSUMED, node16 context `_h1/_h2/_h3` (sans `_h4`), section close S1-S4, docstring entrée `p4_succ_membership`, obstacle-chain + Note + Re-signed block → « p4_half_steps_compose SUPPRESSED, P4.4 porté par evolve_add/evolve_half_step (clos) + résiduel L2527 ».
- **conway_lean/README.md** : sorry 4→3 (statut + table + prose P4 + paragraphe lock honnête + nœud mermaid P4).
- **conway_lean/README.en.md** : sorry 4→3 (statut + table + prose P4 + paragraphe lock).
- **agent_tests/prover/config.py** : `DEMOS[62]` (HASHLIFE_P4_SUCC_MEMBERSHIP) `"line": 2536→2527` (le résiduel a remonté de 9 lignes après la suppression du théorème) + declared-line L2498→L2490.

## Acceptance §B (Lean PR)

| Critère | Preuve |
|---------|--------|
| `grep -c sorry` avant/après | **4 → 3** (pattern standalone-tactic `^\s*sorry\s*$\|:= by sorry\|:= sorry\b\|exact sorry\|^\s*· sorry`, `.lake/` exclu). Sorries : L2527 (p4_succ_membership résiduel), L2855 (p5_large_n_jump), L2864 (p5_inductive_step). |
| Lake build SUCCESS | CI dédiée `lean-conway.yml` typecheck sur push = preuve autoritaire (c.357 ; build local bloqué shared cache c.356). |
| Proof integrity | 0 axiome touché. 0 nouveau `sorry`. **0 placeholder `True`** (le seul restant sur main était `p4_half_steps_compose`, supprimé ici). |
| `sorry-baseline: "7"` | Plancher de régression (3 ≤ 7 → vert). |
| Anti-régression §D | Suppression documentée (table ci-dessus), pas un `sorry`-replacement. |

## Vérifications
- sorry **3** (grep firsthand), 0 `: True` placeholder.
- Consumer-safe : `_h4` était un `have ... : True` jeté (0 usage en corps).
- LF-clean : 0 octet CR sur les 4 fichiers staged (c.282).
- Branche rebasée sur main frais `41fb3cc23` (inclut #5793 + #5792).

## Scope
`See #3846` — tranche N2-bis. Reste : N1 `boxAssezGrand_jump_preserved` (sorry-free additif) + N3 wave-glue résiduel L2527 (BG-prover, multi-cycle).

Co-authored-by: Claude-Code <noreply@anthropic.com>
