### PR TITLE
fix(lean): align decision_theory_lean lakefile mathlib pin rc2 -> rc1 (#4364 §D)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/lakefile.lean
@@ -5,7 +5,7 @@ package decision_theory_lean where
   leanOptions := #[⟨`autoImplicit, false⟩, ⟨`pp.unicode.fun, true⟩]
 
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git" @ "v4.30.0-rc2"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.31.0-rc1"
 
 -- Convention i18n EPIC #4980 (ratifiée user 04/07, finding 2 ai-01) :
 -- `globs` (et non `roots`) pour que `lake build` auto-découvre les siblings


### PR DESCRIPTION
## Ce que fait cette PR

Répare le **résiduel de drift rc2→rc1** sur `decision_theory_lean` identifié par l'audit fleet Lean §D (greenlit ai-01, en attente exécution po-2026).

PR #4827 avait convergé ce lake vers rc1 mais **n'a touché que `lean-toolchain` + `lake-manifest.json`** — le pin source dans `lakefile.lean:8` est resté `@ "v4.30.0-rc2"`. Drift 3-voies : toolchain rc1 / manifest rc1 / pin source lakefile rc2.

**Fix 1-ligne** : `lakefile.lean:8` `@ "v4.30.0-rc2"` → `@ "v4.31.0-rc1"`.

## Preuve G.1 (firsthand, AVANT edit)

| Artefact | Valeur | Source |
|----------|--------|--------|
| `lean-toolchain` | `v4.31.0-rc1` | `cat lean-toolchain` |
| `lake-manifest.json` mathlib rev | `d568c8c0...` | `lake build` log "checking out revision d568c8c0" |
| tag `v4.31.0-rc1` résout vers | `d568c8c0...` | `git -C .lake/packages/mathlib rev-parse v4.31.0-rc1` |
| `lakefile.lean:8` (avant) | `@ "v4.30.0-rc2"` | `grep` (seule occurrence) |

→ Écrire `@ "v4.31.0-rc1"` aligne le pin source **exactement** sur le rev que le manifest pinne déjà (`d568c8c0`). **Pas de downgrade, pas de regen manifest.**

## Pourquoi c'est un vrai bug (pas cosmétique)

Sur le prochain `lake update`, lake consulte le `require` du lakefile. Avec le pin rc2 stale, il tenterait de checkout `v4.30.0-rc2` → **downgrade du manifest** loin du rc1 auquel la fleet a convergé (#4363 cluster `rc1-d568c8c0`, 19/19 lakes). Le build fonctionne aujourd'hui (manifest déjà rc1), mais le drift se manifeste à l'update.

## Vérification post-edit

`lake build Gittins` (local, lake.exe natif) : résout mathlib vers `d568c8c0` (**cohérent**, pas de version-mismatch) + compile Batteries/Qq/Aesop sans erreur. Phase de résolution + early-compile prouvées ; typecheck complet délégué à CI dédiée.

## Scope & sécurité

- **1 ligne**, fichier `lakefile.lean` seulement. **0 preuve `.lean` touchée** (sorry count inchangé = 4 INTRINSIC Gittins → CI baseline 4 standalone-tactic respecté).
- **Lake non-junctionné** (`.lake/packages/mathlib` = vrai clone, `LinkType` vide) → pas de risque shared-checkout (cf [anti-pattern junction `lake update`]).
- **CI dédiée** `lean-decision-theory.yml` typecheck ce path.
- N'aligne PAS le style sur les peers (conway/social_choice float sans pin) — rester scope-bounded au greenlit « 1-line rc2→rc1 » ; retirer le pin ferait flotter vers un mathlib plus récent et risquerait casser les preuves Gittins INTRINSIC (anti-régression §D).

## Scope

`See #4364` (epic convergence rc1 — tranche decision_theory_lean, résiduel §D de #4827). Partiel : ne close pas l'epic.

Co-authored-by: Claude-Code <noreply@anthropic.com>
