### PR TITLE
docs(genai-image): rewrite 6 figure captions to match image content (#5780)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/examples/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/README.md
@@ -50,20 +50,20 @@ Exemples concrets d'utilisation des notebooks GenAI Image dans différents domai
 
 ## Galerie
 
-Sorties réelles des notebooks d'exemple, couvrant les trois domaines éducatifs : [history-geography](history-geography.ipynb) (cartes et reconstitutions historiques), [literature-visual](literature-visual.ipynb) (illustrations de textes littéraires) et [science-diagrams](science-diagrams.ipynb) (schémas et diagrammes scientifiques).
+Sorties réelles des notebooks d'exemple (générées par gpt-image-1), couvrant les trois domaines éducatifs : [history-geography](history-geography.ipynb) (carte de l'Empire romain, reconstruction du Colisée, timeline de la Révolution française), [literature-visual](literature-visual.ipynb) (barricade des Misérables, character sheet de Jean Valjean) et [science-diagrams](science-diagrams.ipynb) (coupe de cellule animale).
 
 <table>
 <tr>
-<td align="center"><img src="assets/readme/imgex-hist1.webp" alt="Reconstitution historique générée par GenAI" width="400"/><br/><sub>Histoire-Géographie — reconstitution de scène (<a href="history-geography.ipynb">notebook</a>)</sub></td>
-<td align="center"><img src="assets/readme/imgex-hist2.webp" alt="Carte historique générée par GenAI" width="400"/><br/><sub>Histoire-Géographie — carte et annotations (<a href="history-geography.ipynb">notebook</a>)</sub></td>
+<td align="center"><img src="assets/readme/imgex-hist1.webp" alt="Carte de l'Empire romain à son apogée en 117 ap. J.-C. générée par gpt-image-1" width="400"/><br/><sub><b>Empire romain (117 ap. J.-C.)</b> (<a href="history-geography.ipynb">history-geography</a>) — carte pédagogique de l'expansion romaine à son apogée, générée par gpt-image-1 en format paysage (usages : cours d'Histoire 6ᵉ, comparaison avec l'Europe actuelle)</sub></td>
+<td align="center"><img src="assets/readme/imgex-hist2.webp" alt="Reconstruction photoréaliste du Colisée de Rome au Ier siècle, amphithéâtre complet avec velarium et foule en toges" width="400"/><br/><sub><b>Colisée de Rome (Iᵉʳ siècle)</b> (<a href="history-geography.ipynb">history-geography</a>) — reconstruction photoréaliste de l'amphithéâtre complet (marbre/travertin d'origine, velarium, foule en toges), montrant le bâtiment dans son état d'origine</sub></td>
 </tr>
 <tr>
-<td align="center"><img src="assets/readme/imgex-hist3.webp" alt="Vestige ou site historique généré par GenAI" width="400"/><br/><sub>Histoire-Géographie — vestige archéologique (<a href="history-geography.ipynb">notebook</a>)</sub></td>
-<td align="center"><img src="assets/readme/imgex-lit1.webp" alt="Illustration d'un passage littéraire générée par GenAI" width="400"/><br/><sub>Littérature — illustration de texte (<a href="literature-visual.ipynb">notebook</a>)</sub></td>
+<td align="center"><img src="assets/readme/imgex-hist3.webp" alt="Frise chronologique illustrée de la Révolution française 1789-1799 avec événements (Bastille, République, Terreur)" width="400"/><br/><sub><b>Révolution française (1789-1799)</b> (<a href="history-geography.ipynb">history-geography</a>) — frise chronologique horizontale illustrée (prise de la Bastille 1789, Première République 1792, Terreur 1793, coup de Napoléon 1799), barre bleu-blanc-rouge, style poster éducatif</sub></td>
+<td align="center"><img src="assets/readme/imgex-lit1.webp" alt="Illustration de la scène de la barricade des Misérables de Victor Hugo, scène du XIXe siècle" width="400"/><br/><sub><b>Les Misérables — la barricade</b> (<a href="literature-visual.ipynb">literature-visual</a>) — illustration de la scène de barricade (XIXᵉ siècle, romantisme), format portrait (usages : cours de français 4ᵉ/3ᵉ, thématique révolution et justice sociale)</sub></td>
 </tr>
 <tr>
-<td align="center"><img src="assets/readme/imgex-lit2.webp" alt="Couverture ou visuel narratif littéraire généré par GenAI" width="400"/><br/><sub>Littérature — visuel narratif (<a href="literature-visual.ipynb">notebook</a>)</sub></td>
-<td align="center"><img src="assets/readme/imgex-sci.webp" alt="Diagramme scientifique généré par GenAI" width="400"/><br/><sub>Sciences — diagramme technique (<a href="science-diagrams.ipynb">notebook</a>)</sub></td>
+<td align="center"><img src="assets/readme/imgex-lit2.webp" alt="Character design sheet de Jean Valjean : portrait central, profil, études d'expressions, progression d'âge" width="400"/><br/><sub><b>Jean Valjean (Les Misérables) — character sheet</b> (<a href="literature-visual.ipynb">literature-visual</a>) — feuille de design de personnage : portrait central (homme d'une cinquantaine d'années), profil, études d'expressions et progression d'âge (jeune forçat → maire → vieillard)</sub></td>
+<td align="center"><img src="assets/readme/imgex-sci.webp" alt="Diagramme pédagogique en coupe d'une cellule animale : membrane, noyau, mitochondries, réticulum endoplasmique" width="400"/><br/><sub><b>Coupe de cellule animale</b> (<a href="science-diagrams.ipynb">science-diagrams</a>) — schéma pédagogique en coupe : membrane cellulaire, noyau (enveloppe + chromatine), mitochondries, réticulum endoplasmique (usages : biologie cellulaire niveau lycée, identification des organites)</sub></td>
 </tr>
 </table>
 

--- a/MyIA.AI.Notebooks/GenAI/Image/examples/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/assets/readme/MANIFEST.md
@@ -4,11 +4,11 @@ Provenance de chaque figure (convention d'indexation **all-cells** du module `ex
 
 | Figure | Fichier | Dimensions | Poids | Source (notebook · cellule · output) | Source native |
 |--------|---------|------------|-------|--------------------------------------|---------------|
-| Histoire-Géo — fig. 1 | `imgex-hist1.webp` | 1200×846 | 89 Ko | `history-geography.ipynb` · cellule 8 · output 3 | 1260×889, 1882 Ko |
-| Histoire-Géo — fig. 2 | `imgex-hist2.webp` | 1200×846 | 122 Ko | `history-geography.ipynb` · cellule 12 · output 3 | 1260×889, 1911 Ko |
-| Histoire-Géo — fig. 3 | `imgex-hist3.webp` | 1200×848 | 64 Ko | `history-geography.ipynb` · cellule 18 · output 3 | 1259×890, 1560 Ko |
-| Littérature — fig. 1 | `imgex-lit1.webp` | 769×1200 | 65 Ko | `literature-visual.ipynb` · cellule 8 · output 2 | 891×1390, 1957 Ko |
-| Littérature — fig. 2 | `imgex-lit2.webp` | 769×1200 | 62 Ko | `literature-visual.ipynb` · cellule 10 · output 3 | 891×1390, 2116 Ko |
-| Sciences — diagramme | `imgex-sci.webp` | 1200×846 | 86 Ko | `science-diagrams.ipynb` · cellule 12 · output 3 | 1260×889, 1420 Ko |
+| Empire romain (117 ap. J.-C.) — carte d'expansion | `imgex-hist1.webp` | 1200×846 | 89 Ko | `history-geography.ipynb` · cellule 8 · output 3 | 1260×889, 1882 Ko |
+| Colisée de Rome (Iᵉʳ siècle) — reconstruction photoréaliste | `imgex-hist2.webp` | 1200×846 | 122 Ko | `history-geography.ipynb` · cellule 12 · output 3 | 1260×889, 1911 Ko |
+| Révolution française (1789-1799) — frise chronologique illustrée | `imgex-hist3.webp` | 1200×848 | 64 Ko | `history-geography.ipynb` · cellule 18 · output 3 | 1259×890, 1560 Ko |
+| Les Misérables — la barricade (scène XIXᵉ) | `imgex-lit1.webp` | 769×1200 | 65 Ko | `literature-visual.ipynb` · cellule 8 · output 2 | 891×1390, 1957 Ko |
+| Jean Valjean (Les Misérables) — character sheet (portrait + âges) | `imgex-lit2.webp` | 769×1200 | 62 Ko | `literature-visual.ipynb` · cellule 10 · output 3 | 891×1390, 2116 Ko |
+| Cellule animale en coupe — schéma des organites | `imgex-sci.webp` | 1200×846 | 86 Ko | `science-diagrams.ipynb` · cellule 12 · output 3 | 1260×889, 1420 Ko |
 
 **Total** : 6 figures, 501 Ko. **Politique** (#5654) : ≤200 Ko/fichier, downscale ≤1200 px max. Ces sorties sont des images GenAI photographiques denses (sources 1,4–2,1 Mo) : WebP q82 à 1200 px comprime d'un facteur 15–30 sans perte visuelle pédagogique (recommandation WebP P2 « gain net »). Chaque figure couvre un domaine éducatif distinct (histoire-géographie, littérature, sciences).


### PR DESCRIPTION
## Ce que fait cette PR

Répond au mandat **#5780** sur le README **GenAI/Image/examples** (tranche #5654) : les 6 légendes décrivaient la *catégorie de domaine éducatif*, pas *ce que l'image générée montre* — **6/6 génériques ou factuellement fausses** (vérifié firsthand par lecture des 6 cellules génératrices + leurs stream outputs, G.1).

1. **Fidélité des légendes** : 6 légendes README (alt + `<sub>`) + 6 cellules caption MANIFEST réécrites pour décrire le contenu réel de chaque image GenAI (scène/structure/diagramme spécifique, pas la catégorie).
2. **Intro réécrite** : énumère désormais ce que chaque notebook produit (carte Empire romain + Colisée + timeline Révolution + barricade Misérables + Valjean sheet + cellule animale).
3. **Layout préservé** : grille HTML `<table>` inchangée (convention figure-grid des siblings mergés).

## Preuve G.1 — ce que chaque image montre VRAIMENT (cellule génératrice + stream lue firsthand)

| Figure | Cellule | Ce que l'image montre (réel) | Ancienne légende (trompeuse) |
|--------|---------|-------------------------------|------------------------------|
| `imgex-hist1` | history c8·out3 | **Carte Empire romain (117 ap. J.-C.)** | « reconstitution de scène » (générique) |
| `imgex-hist2` | history c12·out3 | **Reconstruction photoréaliste Colisée (Iᵉʳ siècle)** amphithéâtre complet + velarium + foule toges | « carte et annotations » (**faux** : pas une carte) |
| `imgex-hist3` | history c18·out3 | **Frise chronologique Révolution française (1789-1799)** Bastille/République/Terreur/Napoléon | « vestige archéologique » (**faux** : une timeline) |
| `imgex-lit1` | literature c8·out2 | **Barricade des Misérables** scène XIXᵉ romantisme | « illustration de texte » (générique) |
| `imgex-lit2` | literature c10·out3 | **Character sheet Jean Valjean** portrait + profil + études expressions + progression d'âge | « visuel narratif » (générique) |
| `imgex-sci` | science c12·out3 | **Cellule animale en coupe** membrane/noyau/mitochondries/réticulum | « diagramme technique » (générique) |

## Audit fichier-entier §E (preuve dans le body)

- **Disque** : `assets/readme/` = 6 `.webp` + MANIFEST (cohérent). 6/6 résolus sur disque.
- **CATALOG-STATUS** : ce README **n'a pas de marqueur** (0 occurrence) — pas de concern catalogue (examples/ = sous-répertoire pédagogique sans entry de série). Byte-identique trivial.
- **Prose / counts** : cette PR ne touche AUCUN compteur, AUCUNE table de structure, AUCUNE liste de notebooks. Diff = 6 légendes + 1 intro + 6 captions MANIFEST (+13/−13 symétrique = rewrite pur).
- MD033 (inline HTML `<table>`/`<img>`/`<sub>`/`<b>`/`<a>`) : **convention figure-grid pré-existante** des siblings mergés, non-required (markdownlint).

## Distinction SOTA

Contrairement à Video/03-Orchestration (deferred c.381 — outputs fallbacks synthétiques = deficit #3801), les 6 figures examples/ sont de **vraies sorties gpt-image-1** (streams « ✅ Généré en 41-56s », prompts révisés DALL-E). C'est un grain caption-fidelity pur #5780, pas un deficit SOTA — aucune re-exec GPU requise.

## Vérification

- 6 figures : résolues sur disque (`ls assets/readme/*.webp` = 6).
- 0 légende-générique/fausse restante.
- README + MANIFEST : UTF-8, **LF-clean** (0 octet CR).
- Branch fraîche depuis `main` (41fb3cc23), un seul sujet (figures Image-examples).

## Scope

`See #5780` — **tranche partielle** (GenAI/Image-examples). Tranches déjà livrées : SymbolicLearning (#5786 MERGED), ML.Net (#5787), ICT (#5791), GenAI/Texte (#5795), SemanticWeb (#5796), SocialChoice (#5797). Restantes : GenAI/Video-03 (deferred SOTA), GenAI/Image-01-Foundation, GenAI/Image-02-Advanced, GenAI/Image-03-Orchestration — chacune sa G.1 per-figure.

Co-authored-by: Claude-Code <noreply@anthropic.com>
