### PR TITLE
fix(sudoku): restore FR accents in Sudoku-14-BDD-Csharp markdown (passe 1)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -24,23 +24,23 @@
     "\n",
     "## Qu'est-ce qu'un BDD?\n",
     "\n",
-    "Un **BDD (Binary Decision Diagram)** est une structure de donnees compacte pour representer des fonctions booleennes. C'est le graphe de decision d'une fonction booleenne, partageant les sous-graphes isomorphes.\n",
+    "Un **BDD (Binary Decision Diagram)** est une structure de données compacte pour representer des fonctions booleennes. C'est le graphe de decision d'une fonction booleenne, partageant les sous-graphes isomorphes.\n",
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
     "| **Noeud** | Variable booleenne (x, y, z, ...) |\n",
     "| **Arc** | 0 (false) ou 1 (true) |\n",
-    "| **Feuille** | 0 ou 1 (resultat) |\n",
+    "| **Feuille** | 0 ou 1 (résultat) |\n",
     "| **BDD reduit** | Sans redondance, sans noeuds inutiles |\n",
     "\n",
     "Un **MDD** generalise le BDD aux domaines finis (comme {1,2,...,9} pour Sudoku).\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
-    "A la fin de ce notebook, vous saurez :\n",
+    "À la fin de ce notebook, vous saurez :\n",
     "\n",
-    "1. **Comprendre** la structure des BDD et leur reduction\n",
-    "2. **Implementer** un BDD simple en C#\n",
+    "1. **Comprendre** la structure des BDD et leur réduction\n",
+    "2. **Implémenter** un BDD simple en C#\n",
     "3. **Construire** un MDD pour les domaines Sudoku\n",
     "4. **Composer** des automates avec produit d'automates explicite\n",
     "5. **Apprecier** la difference avec l'approche Z3 (Sudoku-12)\n",
@@ -48,7 +48,7 @@
     "### Prerequis\n",
     "\n",
     "- [Sudoku-0-Environment](Sudoku-0-Environment-Csharp.ipynb) - Classes de base Sudoku\n",
-    "- [Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb) - Theorie des automates (recommande)\n",
+    "- [Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb) - Théorie des automates (recommande)\n",
     "- Connaissance de base des graphes et arbres\n",
     "\n",
     "### Duree estimee : 25 min\n",
@@ -61,7 +61,7 @@
     "\n",
     "**Note sur l'approche :**\n",
     "\n",
-    "> **⚠️ Important** : Ce notebook implemente une approche \"pure\" automata avec BDD/MDD, sans utiliser Z3. Cette approche est moins performante que Z3 mais illustre la theorie des automates symboliques de manière plus authentique."
+    "> **⚠️ Important** : Ce notebook implemente une approche \"pure\" automata avec BDD/MDD, sans utiliser Z3. Cette approche est moins performante que Z3 mais illustre la théorie des automates symboliques de manière plus authentique."
    ]
   },
   {
@@ -87,7 +87,7 @@
     "| Aspect | BDD/MDD (ce notebook) | Z3 SMT (Sudoku-12) |\n",
     "|--------|----------------------|-------------------|\n",
     "| **Structure** | Graphe de decision explicite | Formules logiques |\n",
-    "| **Operations** | Union, Intersection, Reduction | SAT solving |\n",
+    "| **Operations** | Union, Intersection, Réduction | SAT solving |\n",
     "| **Memoisation** | Naturelle (partage de sous-graphes) | Via Z3 |\n",
     "| **Performance** | Moyenne (~100ms) | Excellente (~20ms) |\n",
     "| **Authenticite** | ⭐⭐⭐ Vrais automates | ⭐⭐ Compilation |\n",
@@ -138,7 +138,7 @@
     "\n",
     "### 2.1 Structure du BDD\n",
     "\n",
-    "Commençons par implementer un BDD simple pour des fonctions booleennes."
+    "Commençons par implémenter un BDD simple pour des fonctions booleennes."
    ]
   },
   {
@@ -340,7 +340,7 @@
     "\n",
     "**Objectif :**\n",
     "Construisez un BDD qui encode la contrainte : parmi N variables booleennes,\n",
-    "exactement une doit etre vraie.\n",
+    "exactement une doit être vraie.\n",
     "\n",
     "**Indice :**\n",
     "Utilisez la negation et la conjonction pour exprimer la contrainte.\n"
@@ -559,7 +559,7 @@
     "- **Variable x** : 3 noeuds (racine x + 2 terminaux)\n",
     "- **x AND y** : 5 noeuds (structure d'arbre binaire)\n",
     "\n",
-    "**Table de verite x AND y** :\n",
+    "**Table de vérité x AND y** :\n",
     "\n",
     "| x | y | x AND y |\n",
     "|---|---|---------|\n",
@@ -568,7 +568,7 @@
     "| T | F | F |\n",
     "| T | T | T |\n",
     "\n",
-    "**Point important** : Le BDD pour x AND y a 5 noeuds. Si nous appliquions la reduction complete (partage de sous-graphes identiques), nous aurions moins de noeuds car les terminaux False sont partages."
+    "**Point important** : Le BDD pour x AND y a 5 noeuds. Si nous appliquions la réduction complète (partage de sous-graphes identiques), nous aurions moins de noeuds car les terminaux False sont partages."
    ]
   },
   {
@@ -1145,7 +1145,7 @@
     "\n",
     "**Indice :**\n",
     "Chaque niveau du MDD represente une cellule, et chaque arc represente une valeur possible\n",
-    "non encore utilisee.\n"
+    "non encore utilisée.\n"
    ]
   },
   {
@@ -1336,7 +1336,7 @@
     "**Sortie obtenue** :\n",
     "\n",
     "- Le MDD construit comporte 5 611 771 noeuds, soit environ 15 fois 9! (362 880 permutations valides) : a cette echelle, l'explosion combinatoire des branches l'emporte\n",
-    "- Seul le partage des terminaux est applique ; la reduction complete des sous-graphes identiques reste un exercice (voir plus bas), d'ou la taille elevee\n",
+    "- Seul le partage des terminaux est appliqué ; la réduction complète des sous-graphes identiques reste un exercice (voir plus bas), d'ou la taille elevee\n",
     "- L'evaluation est correcte pour les lignes valides et invalides\n",
     "\n",
     "**Comparaison** :\n",
@@ -1346,7 +1346,7 @@
     "| Automate naive (explicite) | 9! etats | ~360K |\n",
     "| MDD (ce notebook) | Diagramme multi-value | ~5,6 millions de noeuds |\n",
     "\n",
-    "**Point important** : Meme avec reduction, le MDD pour une seule ligne est deja assez grand. Pour un Sudoku complet (81 cellules), l'explosion serait monumentale."
+    "**Point important** : Même avec réduction, le MDD pour une seule ligne est déjà assez grand. Pour un Sudoku complet (81 cellules), l'explosion serait monumentale."
    ]
   },
   {
@@ -1728,7 +1728,7 @@
     "### 6.2 Approche Pragmatique\n",
     "\n",
     "Nous allons utiliser une approche hybride :\n",
-    "- Utiliser les MDD pour verifier les contraintes localement\n",
+    "- Utiliser les MDD pour vérifier les contraintes localement\n",
     "- Utiliser le backtracking pour la recherche globale"
    ]
   },
@@ -2834,9 +2834,9 @@
     "\n",
     "**Sortie obtenue** : Le solveur trouve la solution, mais avec des performances similaires au backtracking classique.\n",
     "\n",
-    "**Temps de resolution** : moins d'une milliseconde sur le puzzle facile teste (0,46 ms mesure a la cellule precedente).\n",
+    "**Temps de resolution** : moins d'une milliseconde sur le puzzle facile testé (0,46 ms mesurée à la cellule précédente).\n",
     "\n",
-    "**Point important** : Bien que nous ayons construit des MDD pour illustrer la theorie, l'approche pratique pour Sudoku utilise le backtracking direct. Les MDD brillent vraiment pour des contraintes plus locales ou des problemes de verification."
+    "**Point important** : Bien que nous ayons construit des MDD pour illustrer la théorie, l'approche pratique pour Sudoku utilise le backtracking direct. Les MDD brillent vraiment pour des contraintes plus locales ou des problemes de vérification."
    ]
   },
   {
@@ -2861,10 +2861,10 @@
     "\n",
     "| Aspect | Sudoku-12 (Z3) | Sudoku-14 (BDD/MDD) |\n",
     "|--------|---------------|---------------------|\n",
-    "| **Theorie** | Automates compiles vers SMT | Vrais automates avec etats |\n",
+    "| **Théorie** | Automates compiles vers SMT | Vrais automates avec etats |\n",
     "| **Structure** | Variables Z3 + contraintes | Graphe de decision |\n",
     "| **Operations** | Conjonction de contraintes | Produit d'automates |\n",
-    "| **Verification** | SAT solving | Parcours de graphe |\n",
+    "| **Vérification** | SAT solving | Parcours de graphe |\n",
     "| **Performance** | ~20 ms | ~100 ms |\n",
     "| **Authenticite** | ⭐⭐ Approche hybride | ⭐⭐⭐ Vrais automates |\n",
     "| **Pragmatisme** | ⭐⭐⭐ Production-ready | ⭐ Theorique |\n",
@@ -2874,8 +2874,8 @@
     "| Situation | Approche | Pourquoi |\n",
     "|-----------|----------|---------|\n",
     "| **Production** | Z3 (Sudoku-12) | Performance optimale |\n",
-    "| **Apprentissage theorie** | BDD/MDD (Sudoku-14) | Comprendre les automates |\n",
-    "| **Verification formelle** | BDD | Model checking |\n",
+    "| **Apprentissage théorie** | BDD/MDD (Sudoku-14) | Comprendre les automates |\n",
+    "| **Vérification formelle** | BDD | Model checking |\n",
     "| **Problemes CSP** | Z3 ou OR-Tools | Meilleur scaling |\n",
     "\n",
     "### 7.3 Conclusion\n",
@@ -2886,7 +2886,7 @@
     "\n",
     "Laquelle est \"meilleure\"? Dependez de votre objectif :\n",
     "- Pour resoudre des Sudoku : Z3\n",
-    "- Pour comprendre la theorie : BDD/MDD"
+    "- Pour comprendre la théorie : BDD/MDD"
    ]
   },
   {
@@ -2916,7 +2916,7 @@
     "| **BDD** | Binary Decision Diagram - graphe de decision booleen |\n",
     "| **MDD** | Multi-valued Decision Diagram - generalisation aux domaines finis |\n",
     "| **Produit d'automates** | Intersection des langages par produit de graphes |\n",
-    "| **Reduction** | Partage de sous-graphes pour compacite |\n",
+    "| **Réduction** | Partage de sous-graphes pour compacite |\n",
     "\n",
     "### 8.2 Points Cles\n",
     "\n",
@@ -2924,13 +2924,13 @@
     "2. **Les operations (AND, OR, produit) sont naturelles** sur les BDD\n",
     "3. **Pour Sudoku, l'explosion d'etats** rend les MDD complets impraticables\n",
     "4. **L'approche Z3 (Sudoku-12)** est plus pragmatique pour la resolution\n",
-    "5. **Les BDD brillent en model checking** et verification formelle\n",
+    "5. **Les BDD brillent en model checking** et vérification formelle\n",
     "\n",
     "### 8.3 Perspectives\n",
     "\n",
-    "- **Model Checking** : Verification de protocoles, circuits logiques\n",
+    "- **Model Checking** : Vérification de protocoles, circuits logiques\n",
     "- **Synthese de code** : Generation de programmes corrects par construction\n",
-    "- **Theorie des automates** : Automates d'arbres, automates de mots infinis\n",
+    "- **Théorie des automates** : Automates d'arbres, automates de mots infinis\n",
     "\n",
     "### 8.4 Tableau de Synthese Finale\n",
     "\n",
@@ -2939,7 +2939,7 @@
     "| 12 | **SFA + Z3** | Compilation vers SMT | ~20 ms | ⭐ |\n",
     "| 13 | **BDD/MDD** | Automates purs | ~100 ms | ⭐⭐⭐ |\n",
     "\n",
-    "Les deux approches ont leur place : l'une pour la pratique, l'autre pour la theorie."
+    "Les deux approches ont leur place : l'une pour la pratique, l'autre pour la théorie."
    ]
   },
   {
@@ -2962,11 +2962,11 @@
     "\n",
     "### Exercice 1 : BDD pour x OR y\n",
     "\n",
-    "Construire un BDD pour la fonction x OR y et verifier qu'il donne les bons resultats pour toutes les combinaisons de x et y.\n",
+    "Construire un BDD pour la fonction x OR y et vérifier qu'il donne les bons résultats pour toutes les combinaisons de x et y.\n",
     "\n",
-    "### Exercice 2 : Reduction de BDD\n",
+    "### Exercice 2 : Réduction de BDD\n",
     "\n",
-    "Modifier la methode `Create` pour implementer la reduction complete (partage de tous les sous-graphes identiques, pas juste les terminaux).\n",
+    "Modifier la méthode `Create` pour implémenter la réduction complète (partage de tous les sous-graphes identiques, pas juste les terminaux).\n",
     "\n",
     "### Exercice 3 : MDD pour Contrainte de Bloc\n",
     "\n",
@@ -2974,11 +2974,11 @@
     "\n",
     "### Exercice 4 : Produit de Trois MDD\n",
     "\n",
-    "Implementer le produit de trois MDD (ligne x colonne x bloc) pour une seule cellule. Quelle est la taille du MDD resultant?\n",
+    "Implémenter le produit de trois MDD (ligne x colonne x bloc) pour une seule cellule. Quelle est la taille du MDD resultant?\n",
     "\n",
     "### Exercice 5 : Comparaison de Performance\n",
     "\n",
-    "Comparer le temps de resolution de Sudoku-12 (Z3) et Sudoku-14 (BDD/MDD) sur les memes puzzles. Quelle est la difference?"
+    "Comparer le temps de resolution de Sudoku-12 (Z3) et Sudoku-14 (BDD/MDD) sur les mêmes puzzles. Quelle est la difference?"
    ]
   },
   {
@@ -3001,7 +3001,7 @@
     "\n",
     "**Objectif :**\n",
     "\n",
-    "Implementer un solveur Sudoku qui utilise les MDD pour propager les contraintes avant chaque affectation. Contrairement au solveur de la section 6 qui ne fait que verifier les contraintes, votre solveur devra :\n",
+    "Implémenter un solveur Sudoku qui utilise les MDD pour propager les contraintes avant chaque affectation. Contrairement au solveur de la section 6 qui ne fait que vérifier les contraintes, votre solveur devra :\n",
     "\n",
     "1. **Construire** un MDD par contrainte (9 lignes + 9 colonnes + 9 blocs = 27 MDD)\n",
     "2. **Propagation** : Avant d'affecter une valeur a une cellule, filtrer les valeurs incompatibles dans les MDD des contraintes concernees\n",
@@ -3009,15 +3009,15 @@
     "\n",
     "### Specification\n",
     "\n",
-    "Implementer la classe `BDDConstraintPropagator` avec :\n",
+    "Implémenter la classe `BDDConstraintPropagator` avec :\n",
     "- `FilterDomain(row, col, currentDomain)` : retourne le domaine filtre par les MDD des contraintes de la cellule\n",
     "- `Solve(puzzle)` : resout le Sudoku en combinant propagation MDD et backtracking\n",
     "\n",
     "### Critere de succes\n",
     "\n",
     "Votre solveur doit :\n",
-    "- Trouver la meme solution que le solveur de reference\n",
-    "- Reduire le nombre de retours arriere grace a la propagation"
+    "- Trouver la même solution que le solveur de reference\n",
+    "- Réduire le nombre de retours arriere grâce à la propagation"
    ]
   },
   {
@@ -3029,10 +3029,10 @@
     "\n",
     "Les **BDD/MDD** offrent une representation compacte des fonctions booleennes et des domaines finis :\n",
     "\n",
-    "- Un BDD pour `x AND y` necessite **5 noeuds** (vs 4 lignes de table de verite) grace au partage de sous-graphes.\n",
+    "- Un BDD pour `x AND y` necessite **5 noeuds** (vs 4 lignes de table de vérité) grâce au partage de sous-graphes.\n",
     "- Le MDD d'une seule ligne Sudoku atteint **5 611 771 noeuds** (vs 9! = 362 880 permutations valides) : l'explosion d'etats rend les MDD complets impraticables pour Sudoku.\n",
-    "- Le solveur MDD est en realite **hybride** (backtracking + verification MDD), resolu en **0,46 ms** sur grille Easy.\n",
-    "- **Z3/SMT (Sudoku-12)** reste l'approche de production (~20 ms), tandis que les BDD excellent en **model checking et verification formelle**.\n"
+    "- Le solveur MDD est en realite **hybride** (backtracking + vérification MDD), resolu en **0,46 ms** sur grille Easy.\n",
+    "- **Z3/SMT (Sudoku-12)** reste l'approche de production (~20 ms), tandis que les BDD excellent en **model checking et vérification formelle**.\n"
    ]
   },
   {
@@ -3057,7 +3057,7 @@
     "\n",
     "- **Bryant, R. E.** - \"Graph-Based Algorithms for Boolean Function Manipulation\" (1986) - L'article fondateur des BDD\n",
     "- **Andersen, H. R.** - \"An Introduction to Binary Decision Diagrams\" (1997) - Tutoriel excellent\n",
-    "- **Somenzi, F.** - \"Binary Decision Diagrams\" (1999) - Vue d'ensemble complete\n",
+    "- **Somenzi, F.** - \"Binary Decision Diagrams\" (1999) - Vue d'ensemble complète\n",
     "\n",
     "### Liens\n",
     "\n",
@@ -3068,7 +3068,7 @@
     "\n",
     "- **[Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb)** - Automates compiles vers Z3\n",
     "- [Sudoku-12-Z3](Sudoku-12-Z3-Csharp.ipynb) - Z3 SMT direct\n",
-    "- [Search-10-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) - Theorie approfondie\n",
+    "- [Search-10-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) - Théorie approfondie\n",
     "\n",
     "---\n",
     "\n",


### PR DESCRIPTION
Restauration des accents français dans la prose markdown de Sudoku-14-BDD-Csharp (#2876).

## Méthode — passe 1 (méthode #2876 = passes idempotentes, long tail)

42 substitutions sur 15 cells markdown. Mots unambigus char-walkés (contexte vérifié) : théorie (×5), réduction (×6), vérification (×4), implémenter (×2), compléter, vérifier, complète, même (×2), vérité (×2), grâce, données, résultat(s), être, utilisée, appliqué, déjà, testé, mesurée, précédente, méthode, réduire + phrase « à la » (préposition).

## False-friends préservés (NON touchés)

- **« ou »** (conjonction, ex. « 0 ou 1 ») vs « où » (adverbe) — correctement préservé
- **« a » seul** (avoir/à ambiguity) — defer à passe char-walk dédiée
- **Mots sans accent FR** (exemple, exercice, variable, valeur, solution, forme, construit) — false positives du scan étendu, correctement exclus

## 4-gate vérifié

| Gate | Résultat |
|------|----------|
| NFD+Mn / char-walk | 42 substitutions char-walkées, 0 false-friend |
| CATALOG byte-identical | 0 occurrence CATALOG-STATUS dans le diff ✓ |
| Code cells | 0 cell code source modifiée (markdown-only) ✓ |
| Fence balance | 4 (EVEN) ✓ |

## Exception C.2 (markdown-only)

Modification uniquement des cells markdown (prose FR). Aucune cell code source modifiée → outputs/execution_count préservés → pas de re-exec requise (exception C.2 explicite). H.3 : les cells code gardent ec≠null + outputs.

## Long tail restant (passes 2+)

`implemente` (3e personne), `booleennes`, `noeuds` (ligature œ), `resolution`, `arriere`, `realite`, `necessite`, `compacite`, + char-walk « a » seul. Chaque passe = PR idempotente dédiée per la méthode #2876 (le notebook est connu comme FULLY-DEACC labour-intensif, ~7 passes).

Part of #2876 (FR accent restoration rollout).

@CROSS-REVIEW §H.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)