### PR TITLE
fix(genai): reorder .env-loader break-check before remount in 01-5-Qwen-Image-Edit (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "244bd967",
    "metadata": {
     "execution": {
@@ -162,20 +162,12 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Toutes les dependances sont disponibles\n"
-     ]
+     "text": "Toutes les dependances sont disponibles\n"
     },
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
-      "Configuration chargee\n",
-      "API: http://127.0.0.1:8188 (LOCAL_MODE=True)\n",
-      "Client ID: cca71846-ab52-4a71-bf9c-cc82b8f9a299\n",
-      "Token: configuré\n"
-     ]
+     "text": ".env charge depuis: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\nConfiguration chargee\nAPI: http://127.0.0.1:8188 (LOCAL_MODE=True)\nClient ID: 2a455690-7c04-438b-9ced-499d323663cb\nToken: configuré\n"
     }
    ],
    "source": [
@@ -256,9 +248,9 @@
     "        print(f\".env charge depuis: {env_path}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
     "\n",


### PR DESCRIPTION
EPIC #3801 axis-2 SOTA .env-loader rollout — 4e notebook (cf exemplar #5814 Video-03-2, #5819 Texte-10/11, #5821 01-4-Forge).

## Bug
Identique à #5821/#5819/#5814 : dans la boucle parent-search du .env-loader, le remount `current_path = current_path.parent` était placé AVANT le break-check GenAI. Depuis cwd=`GenAI/Image/01-Foundation` (cwd Jupyter normal), l'itération 1 remonte vers GenAI/Image puis GenAI, break, donc **GenAI/.env n'est jamais testé**.

## Preuve observable du bug (output pre-fix, ec=2, préservé sur main)
Cell 3 imprimait :
```
WARNING: .env non trouve, utilisation variables environnement
Configuration chargee
API: http://127.0.0.1:8188 (LOCAL_MODE=True)
```
Le WARNING alors que `GenAI/.env` existe = preuve directe que le loop buggy ratait GenAI/.env.

## Fix
Swap 2-lignes (break-check avant remount), edit byte-identical surgical. +4/-12.

## Re-exec (cwd=GenAI/Image/01-Foundation/)
Cell 3 re-exécutée CPU, ec 2->1, **0 error**. Output régénéré honnêtement :
```
.env charge depuis: D:\...\GenAI\.env
Configuration chargee
API: http://127.0.0.1:8188 (LOCAL_MODE=True)
Token: configure
```
`.env charge depuis GenAI/.env` = **fix prouvé**. Config COMFYUI chargée depuis .env (port 8188 = service Qwen-Image po-2023).

## Verdict SOTA (EPIC #3801 axis-2)
- **Cell 3 (deps + .env-loader + config)** : **SOTA-OK** — re-exécutée CPU, fix prouvé.
- **Cells de génération image (subsequent)** : hors scope, outputs préservés. Full re-exec = **RECOVERABLE-MACHINE** (Qwen-Image/ComfyUI GPU).

## Hygiène
- **Stop & Repair respecté** : re-exec honnête, aucun hand-edit d'output.
- **Aucun secret** dans le diff : Token affiche seulement `configure`, Client ID = uuid session.
- **CATALOG-STATUS** inchangé (HARD 1). Scope = 1 notebook atomique (HARD 3).

Part of #3801 axis-2 SOTA rollout.

Co-Authored-By: Claude-Code <noreply@anthropic.com>