### PR TITLE
fix(genai): reorder .env-loader break-check before remount in 04-1-Educational (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "62a0d5b9",
    "metadata": {
     "execution": {
@@ -162,20 +162,12 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Toutes les dependances sont disponibles\n"
-     ]
+     "text": "Toutes les dependances sont disponibles\n"
     },
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      ".env charge depuis: .env\n",
-      "✅ Helpers GenAI importés\n",
-      "🎓 Educational Content Generation - GenAI\n",
-      "📅 2026-06-23 21:51:23\n",
-      "📚 Matière: biology | Niveau: high_school | Sujet: photosynthesis\n"
-     ]
+     "text": ".env charge depuis: .env\n✅ Helpers GenAI importés\n🎓 Educational Content Generation - GenAI\n📅 2026-07-09 21:47:41\n📚 Matière: biology | Niveau: high_school | Sujet: photosynthesis\n"
     }
    ],
    "source": [
@@ -267,9 +259,9 @@
     "        print(f\".env charge depuis: {env_path.name}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
     "# GENAI_ROOT pointe vers le dossier GenAI (current_path du while loop)\n",


### PR DESCRIPTION
EPIC #3801 axis-2 SOTA .env-loader rollout — 5e notebook (cf #5814 Video-03-2, #5819 Texte-10/11, #5821 01-4-Forge, #5822 01-5-Qwen).

## Bug
Identique aux 4 PRs soeurs : le remount `current_path = current_path.parent` était AVANT le break-check GenAI → depuis le cwd Jupyter réaliste (04-Applications), le loop break à GenAI sans jamais tester GenAI/.env.

## Preuve (nuance G.1 — le pre-fix output masque le bug)
Le pre-fix output committed dit `.env charge depuis: .env` (succès), MAIS il a été généré depuis **cwd=GenAI** où le bug est masqué (iter 0 trouve GenAI/.env directement). Depuis le cwd réaliste 04-Applications, preuve empirique du bug :

```
BUGGY from 04-Applications: WARNING .env non trouve (breaks at GenAI sans checker GenAI/.env)
FIXED from 04-Applications: LOADED (atteint GenAI/.env à l'iter 2)
```

## Fix
Swap 2-lignes (break-check avant remount), edit byte-identical surgical. +4/−12.

## Re-exec EN CONTEXTE (pattern c.64)
Cell 4 est entrelacée : vars `subject_area`/`education_level`/`topic` de cell 1 + imports `AsyncOpenAI`/helpers + header educational. Re-exec isolée = NameError. Mini-notebook `[cell 1 config + cell 4 loader]` exécuté depuis cwd=04-Applications (réaliste). ec 3→2, **0 error**. Output régénéré honnêtement :
```
Toutes les dependances sont disponibles
.env charge depuis: .env
✅ Helpers GenAI importés
🎓 Educational Content Generation - GenAI
📅 2026-07-09 21:47:41   (timestamp runtime légitime)
📚 Matière: biology | Niveau: high_school | Sujet: photosynthesis
```
Le print loader utilise `{env_path.name}` ('.env') → texte identique pre/post. Fix prouvé par : trace control-flow + test empirique ci-dessus + `current_path=GenAI` après loop (HELPERS_PATH=GenAI/shared/helpers résolu).

## Verdict SOTA (EPIC #3801 axis-2)
- **Cell 4 (deps + .env-loader + imports + setup)** : **SOTA-OK** — re-exécutée CPU en contexte, fix prouvé.
- **Cells de génération image (subsequent)** : hors scope, outputs préservés. Full re-exec = **RECOVERABLE-MACHINE** (OpenAI/ComfyUI GPU).

## Hygiène
- **Stop & Repair respecté** : re-exec honnête, aucun hand-edit d'output.
- **Aucun secret** : config educational seule (biology/high_school/photosynthesis).
- **CATALOG-STATUS** inchangé. Scope = 1 notebook atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>