### PR TITLE
fix(genai-video): reorder .env-loader break-check before remount in 02-2-LTX (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "cell-2",
    "metadata": {
     "execution": {
@@ -161,13 +161,7 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
-      "LTX-Video - Generation Video Rapide et Legere\n",
-      "Date : 2026-05-13 08:03:32\n",
-      "Mode : interactive\n",
-      "Frames : 16, Steps : 20, CFG : 7.5\n"
-     ]
+     "text": ".env charge depuis: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\nHelpers GenAI importes\nLTX-Video - Generation Video Rapide et Legere\nDate : 2026-07-09 21:52:03\nMode : interactive\nFrames : 16, Steps : 20, CFG : 7.5\n"
     }
    ],
    "source": [
@@ -204,9 +198,9 @@
     "        env_loaded = True\n",
     "        GENAI_ROOT = current_path  # GenAI root trouve\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
     "    GENAI_ROOT = GENAI_ROOT.parent\n",


### PR DESCRIPTION
EPIC #3801 axis-2 SOTA .env-loader rollout — 6e notebook, **Video family** (rotation sous-famille R6). Cf exemplar #5814 Video-03-2, #5819 Texte, #5821/#5822/#5823 Image.

## Bug
Identique : remount `current_path = current_path.parent` AVANT le break-check GenAI → depuis cwd=02-Advanced, le loop break à GenAI sans tester GenAI/.env.

## Preuve observable (contrast pre/post, ec=3→2)
```
PRE : WARNING: .env non trouve, utilisation variables environnement
POST: .env charge depuis: D:\...\GenAI\.env
```
Le pre-fix output a été généré depuis un cwd où le bug se manifeste (02-Advanced). Fix visible car le print utilise `{env_path}` (chemin complet).

## Fix
Swap 2-lignes (break-check avant remount), edit byte-identical surgical. +3/−9.

## Re-exec EN CONTEXTE (pattern c.64)
Cell 4 entrelacée : params papermill (`debug_level`, `notebook_mode`, `num_frames`, `num_inference_steps`, `guidance_scale`) de cell 1. Mini-notebook `[cell 1 params + cell 4 loader]` exécuté depuis cwd=02-Advanced (réaliste). ec 3→2, **0 error** :
```
.env charge depuis: D:\dev\CoursIA\MyIA.AI.Notebooks\GenAI\.env
Helpers GenAI importes
LTX-Video - Generation Video Rapide et Legere
Date : 2026-07-09 21:52:03   (timestamp runtime légitime)
Mode : interactive
Frames : 16, Steps : 20, CFG : 7.5
```

## Verdict SOTA (EPIC #3801 axis-2)
- **Cell 4 (deps + .env-loader + imports + setup)** : **SOTA-OK** — re-exécutée CPU en contexte, fix prouvé.
- **Cells génération vidéo (subsequent)** : hors scope, outputs préservés. Full re-exec = **RECOVERABLE-MACHINE** (LTX-Video GPU, RTX 3090).

## Hygiène
- **Stop & Repair respecté** : re-exec honnête, aucun hand-edit.
- **Aucun secret**, **CATALOG-STATUS** inchangé, scope = 1 notebook atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>