### PR TITLE
fix(genai-video): reorder .env-loader break-check before remount in 02-5-LTX2 (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "ltx2-03",
    "metadata": {
     "execution": {
@@ -189,15 +189,7 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      ".env charge depuis: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n",
-      "Helpers GenAI importes\n",
-      "LTX-2 - Generation Audiovisuelle Conjointe\n",
-      "Date : 2026-06-16 23:04:45\n",
-      "Mode : interactive\n",
-      "Modele : Lightricks/LTX-2.3 (ltx-2.3-22b-dev.safetensors)\n",
-      "Quantization : fp8-cast | Frames : 97, Steps : 30, CFG : 3.0\n"
-     ]
+     "text": ".env charge depuis: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\nHelpers GenAI importes\nLTX-2 - Generation Audiovisuelle Conjointe\nDate : 2026-07-09 21:59:50\nMode : interactive\nModele : Lightricks/LTX-2.3 (ltx-2.3-22b-dev.safetensors)\nQuantization : fp8-cast | Frames : 97, Steps : 30, CFG : 3.0\n"
     }
    ],
    "source": [
@@ -232,9 +224,9 @@
     "        env_loaded = True\n",
     "        GENAI_ROOT = current_path\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
     "    GENAI_ROOT = GENAI_ROOT.parent\n",


### PR DESCRIPTION
EPIC #3801 axis-2 SOTA .env-loader rollout — 7e notebook (Video family). Cf #5814 Video-03-2, #5824 Video-02-2, #5819 Texte, #5821/#5822/#5823 Image.

## Bug
Identique : remount `current_path = current_path.parent` AVANT le break-check GenAI → depuis cwd=02-Advanced, le loop break à GenAI sans tester GenAI/.env, et `GENAI_ROOT` est mis à `GenAI/Video` (erroné).

## Preuve (nuance G.1 — pre-fix output masque le bug)
Le pre-fix output committed dit `.env charge depuis ...GenAI\.env` (succès), MAIS généré depuis **cwd=GenAI** où le bug est masqué (iter 0). Depuis le cwd réaliste 02-Advanced :
```
BUGGY from 02-Advanced: WARNING .env non trouve (GENAI_ROOT=GenAI/Video, wrong)
FIXED from 02-Advanced: LOADED (GENAI_ROOT=GenAI, correct)
```

## Fix
Swap 2-lignes (break-check avant remount), edit byte-identical surgical. +3/−11.

## Re-exec EN CONTEXTE (pattern c.64)
Cell 4 entrelacée (params papermill de cell 2). Mini-notebook `[cell 2 params + cell 4 loader]` exécuté depuis cwd=02-Advanced. ec 3→2, **0 error** :
```
.env charge depuis: D:\dev\CoursIA\MyIA.AI.Notebooks\GenAI\.env
Helpers GenAI importes
LTX-2 - Generation Audiovisuelle Conjointe
Date : 2026-07-09 21:59:50
Mode : interactive
Modele : Lightricks/LTX-2.3 (ltx-2.3-22b-dev.safetensors)
Quantization : fp8-cast | Frames : 97, Steps : 30, CFG : 3.0
```

## Verdict SOTA (EPIC #3801 axis-2)
- **Cell 4 (deps + .env-loader + imports + setup)** : **SOTA-OK** — re-exécutée CPU en contexte, fix prouvé.
- **Cells génération vidéo (subsequent)** : hors scope, outputs préservés. Full re-exec = **RECOVERABLE-MACHINE** (LTX-2 GPU 22B fp8, RTX 3090).

## Hygiène
- **Stop & Repair respecté** : re-exec honnête, aucun hand-edit.
- **Aucun secret**, **CATALOG-STATUS** inchangé, scope = 1 notebook atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>