### PR TITLE
fix(genai-video): reorder .env-loader break-check before remount in 03-1-Multi-Model (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "cell-setup",
    "metadata": {
     "execution": {
@@ -160,16 +160,7 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
-      "Helpers GenAI importes\n",
-      "Comparaison Multi-Modeles de Generation Video\n",
-      "Date : 2026-05-12 11:56:50\n",
-      "Mode : interactive\n",
-      "Modeles a tester : ['hunyuan', 'ltx', 'wan']\n",
-      "Prompt : a cat walking gracefully through a garden, soft sunlight, ci...\n",
-      "Frames : 16, Steps : 25, CFG : 6.0\n"
-     ]
+     "text": ".env charge depuis: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\nHelpers GenAI importes\nComparaison Multi-Modeles de Generation Video\nDate : 2026-07-09 22:03:40\nMode : interactive\nModeles a tester : ['hunyuan', 'ltx', 'wan']\nPrompt : a cat walking gracefully through a garden, soft sunlight, ci...\nFrames : 16, Steps : 25, CFG : 6.0\n"
     }
    ],
    "source": [
@@ -205,9 +196,9 @@
     "        print(f\".env charge depuis: {env_path}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "\n",
     "# Definir GENAI_ROOT a partir de current_path (apres la boucle de recherche)\n",
     "GENAI_ROOT = current_path if current_path.name == \"GenAI\" else current_path / \"GenAI\"\n",


### PR DESCRIPTION
EPIC #3801 axis-2 .env-loader rollout — 8e notebook (Video family). Cf #5814/#5824/#5825 Video, #5819 Texte, #5821/#5822/#5823 Image.

## Bug
Identique : remount avant break-check GenAI → depuis cwd=03-Orchestration, break à GenAI sans tester GenAI/.env.

## Subtilité (G.1)
GENAI_ROOT est calculé APRÈS la loop (`current_path if name=='GenAI' else parent/GenAI`). Les deux loops (buggy/fixed) aboutissent à current_path=GenAI → GENAI_ROOT inchangé. Seul le **test du .env** était faux (break sans tester GenAI/.env). Preuve empirique :
```
BUGGY from 03-Orchestration: WARNING .env non trouve
FIXED from 03-Orchestration: loaded from GenAI
```

## Fix
Swap 2-lignes (break-check avant remount), +3/−12.

## Re-exec EN CONTEXTE (pattern c.64)
Cell 4 entrelacée (params cell 1). Mini [cell1 + cell4] depuis cwd=03-Orchestration. ec 4→2, 0 error. Contrast observable pre/post : `WARNING .env non trouve` → `.env charge depuis GenAI/.env`.

## Verdict SOTA
- Cell 4 (deps + .env-loader + setup) : **SOTA-OK** (CPU re-exec en contexte).
- Cells génération vidéo : hors scope, outputs préservés. **RECOVERABLE-MACHINE** (GPU multi-modèles).

Stop & Repair respecté, aucun secret, CATALOG-STATUS inchangé, scope atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>