### PR TITLE
fix(genai-video): reorder .env-loader break-check before remount in 02-4-SVD (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-4-SVD-Image-to-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-4-SVD-Image-to-Video.ipynb
@@ -134,15 +134,7 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
-      "Helpers GenAI importes\n",
-      "SVD - Stable Video Diffusion (Image-to-Video)\n",
-      "Date : 2026-05-23 17:15:51\n",
-      "Mode : interactive\n",
-      "Frames : 25, Steps : 25\n",
-      "Motion bucket : 127, Noise aug : 0.02\n"
-     ]
+     "text": ".env charge depuis: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\nHelpers GenAI importes\nSVD - Stable Video Diffusion (Image-to-Video)\nDate : 2026-07-09 22:06:27\nMode : interactive\nFrames : 25, Steps : 25\nMotion bucket : 127, Noise aug : 0.02\n"
     }
    ],
    "source": [
@@ -178,9 +170,9 @@
     "        print(f\".env charge depuis: {env_path}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "\n",
     "# Definir GENAI_ROOT a partir de current_path (apres la boucle de recherche)\n",
     "GENAI_ROOT = current_path if current_path.name == \"GenAI\" else current_path / \"GenAI\"\n",


### PR DESCRIPTION
EPIC #3801 axis-2 .env-loader — 9e notebook. **Video family COMPLETE** (6/6: #5814 03-2, #5824 02-2, #5825 02-5, #5826 03-1, this 02-4). Cf #5819 Texte, #5821/#5822/#5823 Image.

## Bug + Fix
Identique (remount avant break-check). Swap 2-lignes, +2/−10. Même logique GENAI_ROOT post-loop que #5826 (inchangée par le swap — seul le test .env était fautif).

## Re-exec EN CONTEXTE (c.64)
Cell 3 entrelacée (params cell 1). Mini [cell1+cell3] depuis cwd=02-Advanced. ec 4→2, 0 error. Contrast observable : `WARNING .env non trouve` → `.env charge depuis GenAI/.env`. Header SVD (Frames 25, Steps 25, motion bucket/noise) représentatif.

## Verdict SOTA
- Cell 3 (loader/setup) : **SOTA-OK** (CPU re-exec en contexte).
- Cells génération SVD : hors scope, outputs préservés. **RECOVERABLE-MACHINE** (SVD GPU).

Stop & Repair, 0 secret, CATALOG inchangé, atomique. Co-Authored-By: Claude-Code <noreply@anthropic.com>