### PR TITLE
fix(genai): reorder .env-loader break-check before remount in 04-2-Creative (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-2-Creative-Workflows.ipynb
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "7408faf5",
    "metadata": {
     "execution": {
@@ -172,20 +172,12 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Toutes les dependances sont disponibles\n"
-     ]
+     "text": "Toutes les dependances sont disponibles\n"
     },
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      ".env charge depuis: .env\n",
-      "Helpers GenAI importés\n",
-      "Creative Workflows - GenAI\n",
-      "2026-06-24 22:45:30\n",
-      "Workflow: concept_to_image | Style: modern | Audience: students\n"
-     ]
+     "text": ".env charge depuis: .env\nHelpers GenAI importés\nCreative Workflows - GenAI\n2026-07-09 22:11:39\nWorkflow: concept_to_image | Style: modern | Audience: students\n"
     }
    ],
    "source": [
@@ -286,9 +278,9 @@
     "        print(f\".env charge depuis: {env_path.name}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
     "# GENAI_ROOT pointe vers le dossier GenAI (current_path du while loop)\n",


### PR DESCRIPTION
EPIC #3801 axis-2 .env-loader — 10e notebook (Image family). Cf #5821/22/23 Image, #5824-27 Video, #5819 Texte.

## Bug + Fix
Identique (remount avant break-check). Swap 2-lignes +4/−12. Cell 4 entrelacée (params cell 1).

## Preuve (cwd-masking G.1)
Pre-fix output dit `.env charge depuis: .env` (succès) MAIS généré depuis cwd=GenAI (bug masqué). Depuis cwd réaliste 04-Applications :
```
BUGGY: WARNING .env non trouve | FIXED: LOADED
```

## Re-exec EN CONTEXTE (c.64)
Mini [cell1 params + cell4 loader] depuis cwd=04-Applications. ec 3→2, 0 error.

## Verdict SOTA
Cell 4 (loader/setup) **SOTA-OK** (CPU re-exec en contexte). Generation cells **RECOVERABLE-MACHINE** (GPU). Stop & Repair, 0 secret, CATALOG inchangé, atomique.

Co-Authored-By: Claude-Code <noreply@anthropic.com>