### PR TITLE
fix(genai): reorder .env-loader break-check before remount in 04-3-Production (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb
@@ -274,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "5a00a0c5",
    "metadata": {
     "execution": {
@@ -296,20 +296,12 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Toutes les dependances sont disponibles\n"
-     ]
+     "text": "Toutes les dependances sont disponibles\n"
     },
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      ".env charge depuis: .env\n",
-      "🏭 Production Integration - GenAI\n",
-      "📅 2026-06-25 00:43:29\n",
-      "🎯 Mode: batch_processing | Batch: 10 | Concurrent: 3\n",
-      "💰 Budget: $50.0 | Quality: 0.7\n"
-     ]
+     "text": ".env charge depuis: .env\n🏭 Production Integration - GenAI\n📅 2026-07-09 22:16:37\n🎯 Mode: batch_processing | Batch: 10 | Concurrent: 3\n💰 Budget: $50.0 | Quality: 0.7\n"
     }
    ],
    "source": [
@@ -419,9 +411,9 @@
     "        print(f\".env charge depuis: {env_path.name}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
     "# GENAI_ROOT pointe vers le dossier GenAI (current_path du while loop)\n",


### PR DESCRIPTION
EPIC #3801 axis-2 .env-loader — 11e notebook. **Image family COMPLETE** (5/5 mine: #5821 01-4, #5822 01-5, #5823 04-1, #5828 04-2, this). Cf #5824-27 Video, #5819 Texte.

## Bug + Fix
Identique (remount avant break-check). Swap 2-lignes, cell 6 entrelacée (params cell 3). Pre-fix output masqué par cwd=GenAI → preuve empirique :
```
BUGGY from 04-Applications: WARNING .env non trouve | FIXED: LOADED
```

## Re-exec EN CONTEXTE (c.64)
Mini [cell3 params + cell6 loader] depuis cwd=04-Applications. ec 4→2, 0 error. Header production (batch/concurrent/budget/quality) représentatif.

## Verdict SOTA
Cell 6 (loader/setup) **SOTA-OK** (CPU re-exec en contexte). Generation cells **RECOVERABLE-MACHINE** (GPU). Stop & Repair, 0 secret, CATALOG inchangé, atomique.

**Peer-validated** : po-2026 c.396 drain-verification confirme po-2023/po-2025 sont les bons exécuteurs #3801.

Co-Authored-By: Claude-Code <noreply@anthropic.com>