### PR TITLE
fix(genai-video): reorder .env-loader break-check before remount in 02-3-Wan (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "2d24084b",
    "metadata": {
     "execution": {
@@ -278,30 +278,7 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
-      "\n",
-      "==================================================\n",
-      "MODE : API ComfyUI\n",
-      "==================================================\n",
-      "\n",
-      "[API] Verification de l'API ComfyUI-Video...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[WARN] ComfyUI-Video non accessible: Exception: HTTP 401 Error calling https://comfyui-video.myia.io/system_stats: Unauthorized\n",
-      "Body: {\"error\": \"Aut\n",
-      "\n",
-      "💡 Pour démarrer ComfyUI-Video :\n",
-      "   docker-compose -f docker-configurations/services/comfyui-video/docker-compose.yml up -d\n",
-      "\n",
-      "==================================================\n",
-      "Generation activee : False\n",
-      "==================================================\n"
-     ]
+     "text": ".env charge depuis: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n\n==================================================\nMODE : API ComfyUI\n==================================================\n\n[API] Verification de l'API ComfyUI-Video...\n[WARN] ComfyUI-Video non accessible: Exception: HTTP 401 Error calling https://comfyui-video.myia.io/system_stats: Unauthorized\nBody: {\"error\": \"Aut\n\n💡 Pour démarrer ComfyUI-Video :\n   docker-compose -f docker-configurations/services/comfyui-video/docker-compose.yml up -d\n\n==================================================\nGeneration activee : False\n==================================================\n"
     }
    ],
    "source": [
@@ -320,9 +297,9 @@
     "        print(f\".env charge depuis: {env_path}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",


### PR DESCRIPTION
## Fix
Same `.env`-loader bug as the rest of the #3801 axis-2 rollout: the parent-search loop remounted (`current_path = current_path.parent`) **before** the GenAI break-check, so from `cwd=GenAI/Video/02-Advanced/`, `GenAI/.env` was never tested.

2-line swap (break-check **before** remount), byte-identical surgical edit — same fix as #5814 (03-2 exemplar), #5819 (Texte), #5821/#5822/#5823/#5828/#5829 (Image), #5824/#5825/#5826/#5827 (Video).

## Correction of an earlier abstention (G.9)
An earlier cycle abstained on this notebook citing "two `GENAI_ROOT` walks entangled". Firsthand re-examination proves that was a **misread**:
- **Cell 4** walk = `while GENAI_ROOT.name != 'GenAI'...` = **CORRECT** (check-name-in-condition, not the buggy for-loop). Independent and idempotent.
- **Cell 6** walk = the buggy `for`-loop (remount-before-check). This is the only bug.
- `use_api = True` (cell 1) ⇒ cell 6 takes the **API ComfyUI branch**: `get_system_stats()` HTTP probe wrapped in `try/except` ⇒ graceful `[WARN] 401`, no crash, **no GPU**. CPU-safe re-exec.

The earlier `NameError: Path` blocker was simply a missing cell 4 in the re-exec context (`from pathlib import Path` lives in cell 4). Fix: context = 3 cells `[1 params + 4 imports + 6 loader]`.

## Re-exec proof (in context, cwd=`02-Advanced`)
Mini-notebook `[cell 1 + cell 4 + cell 6]`, `nbconvert --execute`, rc=0, ec 4→3, 0 error.

Observable contrast:
```
PRE  (buggy, ec=4 on main): WARNING: .env non trouve, utilisation variables environnement
POST (fixed, ec=3):         .env charge depuis: D:\...\GenAI\.env
```
Content faithful: 633 chars old (2 stream objs) → 635 chars new (1 consolidated). **Only line 1 changed** (`.env`-load status); the rest (MODE header / API verification / 401-WARN / docker hint / `Generation activee: False`) is byte-identical.

The persistent 401 (`ComfyUI-Video Unauthorized`) is **RECOVERABLE-MACHINE** — graceful `try/except`, `run_generation=False`, no crash. Orthogonal to the `.env`-loader fix (token auth on the tunnel service).

## Verdict SOTA (EPIC #3801 axis-2)
- **Cell 6** (deps + `.env`-loader + API probe): **SOTA-OK** — re-executed CPU in context, fix proven.
- **Video-generation cells** (subsequent): out of scope, outputs preserved. Full re-exec = **RECOVERABLE-MACHINE** (ComfyUI-Video multi-model GPU generation, RTX 3090).

Stop & Repair respected (re-exec honest, no hand-edit). No secrets in diff (token travels in Bearer header, never printed; `myia.io` URL = public tunnel). CATALOG-STATUS untouched. Scope = 1 notebook atomic.

Part of #3801 axis-2 SOTA rollout. **Video family now truly complete (6/6)**: #5814 03-2 · #5824 02-2 · #5825 02-5 · #5826 03-1 · #5827 02-4 · this.

See #3801