### PR TITLE
fix(genai-audio): reorder .env-loader break-check before remount in 02-1-Chatterbox (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb
@@ -318,7 +318,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".env charge depuis: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+      ".env charge depuis: D:\\dev\\wt-audio-3801\\MyIA.AI.Notebooks\\GenAI\\.env\n"
      ]
     }
    ],
@@ -336,9 +336,9 @@
     "        print(f\".env charge depuis: {env_path}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")"
    ]


### PR DESCRIPTION
## Fix

Same `.env`-loader bug as the rest of the #3801 axis-2 rollout: the parent-search loop remounted (`current_path = current_path.parent`) **before** the GenAI break-check, so from `cwd=GenAI/Audio/02-Advanced/`, `GenAI/.env` was never tested.

2-line swap (break-check **before** remount), byte-identical surgical edit — same fix as Demucs (#5831), Image (#5821/#5822/#5823/#5828/#5829), Video (#5814/#5824/#5825/#5826/#5827/#5830), Texte (#5819).

## Re-exec proof (in context, cwd=`Audio/02-Advanced`)

Mini-notebook `[params + setup + loader]`, `nbconvert --execute` kernel `conda-torch` (miniconda3-base, dotenv+torch+soundfile available), rc=0, ec 4 kept, 0 error.

**CPU-safe**: setup cell imports `torch`+`soundfile` and does `torch.cuda.is_available()` (device query, no compute/model-load, electrical mandate respected). Loader cell = `.env` parent-search only.

Observable contrast (this notebook had cwd-favorable SUCCESS masking the buggy source — now genuinely reproducible):
```
PRE  (buggy, on main): .env charge depuis: D:\Dev\CoursIA\...\GenAI\.env   # only because cwd was already GenAI-rooted
POST (fixed):          .env charge depuis: D:\dev\wt-audio-3801\...\GenAI\.env   # reproducible from any deep cwd
```
The output path delta (`D:\Dev\CoursIA` → `D:\dev\wt-audio-3801`) is category-A env/cwd (worktree checkout path), benign, no secret — same handling as #5821/#5831.

## Verdict SOTA (EPIC #3801 axis-2)

- **Loader cell** (`.env`-loader, 18L): **SOTA-OK** — re-executed CPU in context, fix proven (now reaches `GenAI/.env` from deep cwd).
- **Generation cells** (Chatterbox model load, TTS, emotions, voice conditioning): out of scope, outputs preserved. Full re-exec = **RECOVERABLE-MACHINE** (Chatterbox `~300M` model, GPU, HF download).

Stop & Repair respected (re-exec honest, no hand-edit). No secrets in diff. CATALOG-STATUS untouched (single-file, +2/−2). Scope = 1 notebook atomic.

## Coordination

Audio family 8/9 assigned to po-2025 (po-2023 took 02-4-Demucs = #5831). `[CLAIMED]` DM exchanged (msg `msg-20260709T204323-3zbw98`). Preexisting C.2 cosmetic flags (params cells #1/#2 ec-set-no-outputs, exercise-def cell #13) are NOT introduced here — preexisting on `origin/main`, benign (Papermill params / function defs produce no stdout).
