### PR TITLE
fix(genai-audio): reorder .env-loader break-check before remount in 02-7-Song-Generation (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb
@@ -283,7 +283,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n",
+      ".env charge depuis: D:\\dev\\wt-audio-3801\\MyIA.AI.Notebooks\\GenAI\\.env\n",
       "Token HuggingFace non disponible (modeles publics uniquement)\n"
      ]
     }
@@ -302,9 +302,9 @@
     "        print(f\".env charge depuis: {env_path}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
     "\n",


### PR DESCRIPTION
## Fix

Same `.env`-loader bug as the rest of the #3801 axis-2 rollout: the parent-search loop remounted (`current_path = current_path.parent`) **before** the GenAI break-check, so from `cwd=GenAI/Audio/02-Advanced/`, `GenAI/.env` was never tested → emits `WARNING: .env non trouve`.

2-line swap (break-check **before** remount), byte-identical surgical edit — same fix as Chatterbox (#5833), XTTS (#5835), MusicGen (#5836), MIDI (#5837), Demucs (#5831), Image (#5821/#5822/#5823/#5828/#5829), Video (#5814/#5824/#5825/#5826/#5827/#5830), Texte (#5819).

## Re-exec proof (in context, cwd=`Audio/02-Advanced`)

Mini-notebook `[params + setup + loader]`, `nbconvert --execute` kernel `conda-torch` (miniconda3-base, dotenv+torch available), rc=0, ec 4 kept, 0 error.

**CPU-safe**: setup cell imports `torch`/etc and does a device query (no compute/model-load, electrical mandate respected). Loader cell = `.env` parent-search only.

Observable contrast (**bug actually fired on main** — WARN, not latent):
```
PRE  (buggy, on main): WARNING: .env non trouve, utilisation variables environnement
POST (fixed):          .env charge depuis: D:\dev\wt-audio-3801\...\GenAI\.env
```
WARN→SUCCESS is the proof of fix. The output path delta is category-A env/cwd (worktree checkout path), benign, no secret — same handling as #5821/#5831/#5833. (The pre-existing `Token HuggingFace non disponible` status line is unchanged — not a secret, states the token is absent.)

## Verdict SOTA (EPIC #3801 axis-2)

- **Loader cell** (`.env`-loader, 18L): **SOTA-OK** — re-executed CPU in context, fix proven (WARN→SUCCESS).
- **Generation cells** (song generation model load, lyrics+vocal synthesis): out of scope, outputs preserved. Full re-exec = **RECOVERABLE-MACHINE** (song generation model, GPU, HF download).

Stop & Repair respected (re-exec honest, no hand-edit). No secrets in diff. CATALOG-STATUS untouched (single-file, +2/−2). Scope = 1 notebook atomic.

## Coordination

Audio family 8/9 assigned to po-2025 (po-2023 took 02-4-Demucs = #5831). Preexisting C.2 cosmetic flags (params cells ec-set-no-outputs) are NOT introduced here — preexisting on `origin/main`, benign.
