### PR TITLE
feat(translation): seed CSV Probas/Infer post-#5807 renum regen (#4957 Phase 2, supersedes #5801)

### DIFF
--- a/translations/probas-infer/README.md
+++ b/translations/probas-infer/README.md
@@ -1,0 +1,61 @@
+# translations/probas-infer — synchro traduction i18n (#4957 Phase 2)
+
+## Couverture
+
+| Métrique | Valeur |
+|----------|--------|
+| Série source | `MyIA.AI.Notebooks/Probas/Infer/` (Infer.NET probabilistic programming, .NET Interactive) |
+| Notebooks source | **19** (post-renum narratif #5637 c.377 — cycle 5/7/9/11/14) |
+| Cellules extraites | **902** (code + markdown, nbformat canonique) |
+| Taille CSV | ~844 KB (16 073 lignes CSV = header + 902 × 18 colonnes hash + texte) |
+| Langue pivot | **fr** (PIVOT_LANG = "fr", cf #1650 Phase 0.5 / #4980 Lean i18n) |
+| Langues cibles | **en, es, ar, fa, zh, ru, pt** (7 langues vivantes côté Argumentum) |
+| Date seed | 2026-07-09 |
+| Source seed | PR #5385 (Argument_Analysis) + PR #5799 (resync T1) + PR THIS (Phase 2 rollout) |
+
+## Workflow T0→T3
+
+T0 (catalogue CSV) **LIVRÉ** : le CSV seed `probas_infer.csv` capture la substance canonique de la série au commit `2e57ff283...` + la branche Phase 2. Chaque ligne = `notebook, cell_id, cell_type, src_lang, src_hash, text_fr, text_<7 langues>, hash_fr, hash_<7 hash>`. Les hashes `sha256-16` sur le texte normalisé (rstrip lines + strip newlines) détectent les dérives cellule-par-cellule.
+
+T1 (extraction) **LIVRÉ** : `python3 scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/Probas/Infer/ -o translations/probas-infer/probas_infer.csv`. Script déterministe byte-identique (cf `extract_cells_to_csv.py` livré Phase 1 #5657 c.293-294). Exclut `_output.ipynb` (Papermill) et `_agent.ipynb` (auto-générés) via `endswith`.
+
+T2 (drift detector) **LIVRÉ** : `python3 scripts/translation/check_translation_sync.py translations/probas-infer/probas_infer.csv` → `{"csvs_checked": 1, "anomalies": [], "anomaly_count": 0}` (IN_SYNC round-trip). Workflow CI `.github/workflows/translation-drift.yml` non-bloquant read-only déclenche ce check sur PR paths `translations/**` + `MyIA.AI.Notebooks/**/*.ipynb` + `scripts/translation/**`.
+
+T3 (moteur Argumentum) **GATED** : run du moteur #1650 Phase 1 (connecteur OpenTelemetry/Argumentum → fill des colonnes `text_<lang>` pour chaque cellule). Reste gated sur l'activation du connecteur Argumentum (substance owner-lane po-2025 c.371-372).
+
+## Régénération manuelle
+
+Si la série `MyIA.AI.Notebooks/Probas/Infer/` change (renum, ajout/suppression de cellules), re-run déterministe :
+
+```bash
+python scripts/translation/extract_cells_to_csv.py \
+    MyIA.AI.Notebooks/Probas/Infer/ \
+    -o translations/probas-infer/probas_infer.csv
+```
+
+T2 check post-régénération :
+
+```bash
+python scripts/translation/check_translation_sync.py \
+    translations/probas-infer/probas_infer.csv
+```
+
+Anomalies attendues (T3 non livré) :
+- `TRAD_DRIFT` attendu sur les `text_<lang>` et `hash_<lang>` tant que T3 n'a pas rempli les colonnes. Le seed CSV doit **demeurer avec `text_fr` rempli** (pivot) et **toutes les autres langues vides** (T3 à fill).
+- `SRC_DRIFT` = changement upstream non reporté dans le CSV → relancement T1 obligatoire.
+
+## Liaison upstream
+
+- EPIC parent **#4957** (CSV-by-series + CI drift-flag + resync manuelle Argumentum)
+- Phase 0.5 **#1650** (Argumentum connecteur + moteur de traduction)
+- Substance owner-lane **#5637** (renum narratif, source des 19 notebooks)
+- Voisin seed **translations/symbolicai/** (Argument_Analysis, PR THIS série 1 Phase 2)
+
+## Conformité règles
+
+- **L327 `+N/-0` purement additif** : nouveau répertoire `probas-infer/`, nouveau CSV (pas d'écrasement) + README.
+- **catalog-pr-hygiene R1** : catalogue intact (CSV vit hors catalogue, sous `translations/`).
+- **L335 anti-monoculture** : substance neuve Phase 2 (Probas/Infer), pas re-sweep monotone.
+- **L143 SAFE cross-owner** : Probas/Infer = owner po-2025 (renum c.377 owner-lane + multiple cycles Probas).
+- **L289 anti-doublon** : 1 série = 1 PR de seed, PR Phase 2 distincte des PRs Argument_Analysis (#5385 + #5799).
+- **Stop & Repair** : pas de hand-edit de cellule, pas de scrub de sortie — le CSV est un artefact dérivé déterministe.

--- a/translations/probas-infer/probas_infer.csv
+++ b/translations/probas-infer/probas_infer.csv
@@ -1,0 +1,16073 @@
+notebook,cell_id,cell_type,src_lang,src_hash,text_fr,text_en,text_es,text_ar,text_fa,text_zh,text_ru,text_pt,hash_fr,hash_en,hash_es,hash_ar,hash_fa,hash_zh,hash_ru,hash_pt
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,ab8b7b64,markdown,fr,5484c58365e6fa27,"# Infer-1-Setup : Introduction et Installation
+
+**Série** : Programmation Probabiliste avec Infer.NET (1/20)  
+**Duree estimee** : 15 minutes  
+**Prerequis** : Notions de base en C# et statistiques
+
+---
+
+## Objectifs
+
+- Comprendre les bases de la programmation probabiliste
+- Installer et configurer Infer.NET
+- Créer votre premier modèle probabiliste
+- Maîtriser les 3 étapes fondamentales : modèle, moteur, inférence
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| - | [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb) |
+
+---",,,,,,,,5484c58365e6fa27,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,42dba707,markdown,fr,b33c67a9c11dabb9,"## 1. Introduction a la Programmation Probabiliste
+
+### Le probleme de l'incertitude
+
+Les ordinateurs sont rigoureusement logiques, mais le monde reel ne l'est pas. Considerez ces exemples :
+
+- Un systeme de reconnaissance d'ecriture manuscrite : le gribouillis peut correspondre a ""hill"", ""bull"" ou ""hello""
+- Un diagnostic medical : les symptomes peuvent indiquer plusieurs maladies possibles
+- Un systeme de recommandation : les préférences de l'utilisateur sont partiellement connues
+
+Dans tous ces cas, nous devons raisonner avec de l'**incertitude**.
+
+### Variables aléatoires
+
+Les variables conventionnelles (`bool`, `int`, `double`) ont des valeurs bien définies. La programmation probabiliste introduit les **variables aléatoires** qui représentent un ensemble de valeurs possibles, chacune associée a une probabilité.
+
+```csharp
+// Variable classique - valeur fixe
+bool estFace = true;
+
+// Variable aléatoire - distribution de probabilité
+Variable<bool> estFace = Variable.Bernoulli(0.5);  // 50% de chance
+```
+
+### Les 3 piliers de la programmation probabiliste
+
+1. **Modèles probabilistes** : Definissent comment les observations sont générées
+2. **Inférence bayesienne** : Raisonne de l'effet vers la cause
+3. **Apprentissage** : Les paramètres eux-memes sont des variables aléatoires",,,,,,,,b33c67a9c11dabb9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,01b459aa,markdown,fr,f39f88680a5338c2,"## 2. Presentation d'Infer.NET
+
+### Qu'est-ce que Infer.NET ?
+
+**Infer.NET** est un framework Microsoft pour l'inférence bayesienne dans les modèles graphiques. Il fait partie de la bibliotheque **ML.NET**.
+
+**Caracteristiques principales** :
+
+| Caracteristique | Description |
+|-----------------|-------------|
+| **Langage de modelisation** | Variables continues et discretes, univariees et multivariees |
+| **Algorithmes d'inférence** | Expectation Propagation (EP), Variational Message Passing (VMP), Gibbs Sampling |
+| **Performance** | Compile les modèles en code source optimise |
+| **Extensibilite** | Ajout de distributions, facteurs et algorithmes personnalises |
+
+### Comment fonctionne Infer.NET ?
+
+```
+1. Définition du modèle    -->  API de modelisation
+        |
+        v
+2. Compilation du modèle   -->  Génération de code source
+        |
+        v
+3. Exécution de l'inférence -->  Calcul des distributions posterieures
+```",,,,,,,,f39f88680a5338c2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,5b34e453,markdown,fr,cf69d91555f88dd4,"## 3. Installation
+
+Avant de commencer, nous devons installer les packages NuGet necessaires. Infer.NET est distribue en deux packages :
+- **Microsoft.ML.Probabilistic** : Contient les distributions, le moteur d'inférence et les algorithmes
+- **Microsoft.ML.Probabilistic.Compiler** : Permet la compilation dynamique des modèles en code optimise
+
+L'installation via `#r ""nuget:` télécharge automatiquement les packages et leurs dépendances.
+
+> **Important** : Si Graphviz est installe, la cellule suivante l'ajoute automatiquement au PATH pour permettre la visualisation des graphes de facteurs.",,,,,,,,cf69d91555f88dd4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,cr1bl8bp3a9,code,fr,d22c1c34e5e12ce2,"// Configuration du PATH pour Graphviz (AVANT le chargement d'Infer.NET)
+// Cette cellule doit s'executer en premier pour que Infer.NET trouve 'dot'
+
+var graphvizPaths = new[] {
+    @""C:\Program Files\Graphviz\bin"",
+    @""C:\Program Files (x86)\Graphviz\bin""
+};
+
+foreach (var gvPath in graphvizPaths)
+{
+    var dotExe = System.IO.Path.Combine(gvPath, ""dot.exe"");
+    if (System.IO.File.Exists(dotExe))
+    {
+        var currentPath = Environment.GetEnvironmentVariable(""PATH"") ?? """";
+        if (!currentPath.Contains(gvPath, StringComparison.OrdinalIgnoreCase))
+        {
+            Environment.SetEnvironmentVariable(""PATH"", gvPath + "";"" + currentPath);
+            Console.WriteLine($""Graphviz configure : {gvPath}"");
+        }
+        else
+        {
+            Console.WriteLine($""Graphviz deja dans le PATH : {gvPath}"");
+        }
+        break;
+    }
+}
+
+// Verification avec ProcessStartInfo correctement configure
+try
+{
+    var psi = new System.Diagnostics.ProcessStartInfo {
+        FileName = ""dot"",
+        Arguments = ""-V"",
+        RedirectStandardError = true,
+        RedirectStandardOutput = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+    };
+    using var proc = System.Diagnostics.Process.Start(psi);
+    var stderr = proc.StandardError.ReadToEnd();
+    proc.WaitForExit();
+    if (proc.ExitCode == 0 || stderr.Contains(""graphviz""))
+        Console.WriteLine($""Verification OK : {stderr.Trim()}"");
+    else
+        Console.WriteLine(""dot.exe trouve mais verification echouee"");
+}
+catch 
+{ 
+    Console.WriteLine(""Graphviz non disponible (optionnel pour visualisation)""); 
+}",,,,,,,,d22c1c34e5e12ce2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,b85npb17cng,markdown,fr,985524adca405bc1,"### Verification de la configuration Graphviz
+
+La cellule precedente a configure le PATH pour Graphviz. Voici comment interpreter la sortie :
+
+| Message | Signification |
+|---------|---------------|
+| `Graphviz configure : C:\Program Files\Graphviz\bin` | Chemin ajoute au PATH - Graphviz sera utilisable |
+| `Graphviz deja dans le PATH` | Deja configure dans une session precedente |
+| `Graphviz non disponible` | Non installe - les graphes seront generes en `.gv` uniquement |
+| `Verification OK : dot - graphviz version X.X` | Installation fonctionnelle |
+
+> **Note** : Si Graphviz n'est pas installe, ce n'est pas bloquant. Les fichiers `.gv` peuvent etre visualises sur [viz-js.com](https://viz-js.com/).",,,,,,,,985524adca405bc1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,18ff7a16,code,fr,504e6b578df42ff4,"// Installation des packages NuGet Infer.NET
+#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""",,,,,,,,504e6b578df42ff4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,a8b9fff5,markdown,fr,cfb5a4ada9a444bc,> **Note** : Infer.NET fait desormais partie de la bibliotheque ML.NET de Microsoft.,,,,,,,,cfb5a4ada9a444bc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,7b6edff0,code,fr,59130f9dc2d8ace7,"// Import des espaces de noms essentiels
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET charge avec succes !"");
+Console.WriteLine($""  - Microsoft.ML.Probabilistic.Models : Variables aleatoires et modeles"");
+Console.WriteLine($""  - Microsoft.ML.Probabilistic.Distributions : Gaussian, Beta, Dirichlet..."");
+Console.WriteLine($""  - Microsoft.ML.Probabilistic.Algorithms : EP, VMP, Gibbs"");
+Console.WriteLine($""  - Microsoft.ML.Probabilistic.Compiler : Compilation Roslyn des modeles"");",,,,,,,,59130f9dc2d8ace7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,7a9110ca,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,cs20ulzhlng,code,fr,7f6ecb22359e334c,"// Chargement du helper pour la visualisation des factor graphs
+// (Une version inline est aussi definie plus bas dans ce notebook)
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper.cs charge depuis le fichier externe !"");
+Console.WriteLine(""Usage: moteur.ShowFactorGraph = true; puis display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()))"");",,,,,,,,7f6ecb22359e334c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,dp1aijv9ox7,markdown,fr,2d3fa986637fa75a,"### Espaces de noms Infer.NET charges
+
+La cellule precedente a importe les espaces de noms essentiels. Voici leur role :
+
+| Namespace | Contenu | Usage principal |
+|-----------|---------|-----------------|
+| `Microsoft.ML.Probabilistic.Models` | `Variable<T>`, `VariableArray<T>`, `Range` | Définition des modèles probabilistes |
+| `Microsoft.ML.Probabilistic.Distributions` | `Gaussian`, `Beta`, `Gamma`, `Dirichlet` | Distributions de probabilité |
+| `Microsoft.ML.Probabilistic.Algorithms` | `ExpectationPropagation`, `VariationalMessagePassing` | Algorithmes d'inférence |
+| `Microsoft.ML.Probabilistic.Compiler` | `InferenceEngine`, `CompilerChoice` | Compilation et exécution |
+| `Microsoft.ML.Probabilistic.Math` | Fonctions mathematiques | Operations sur distributions |
+
+> **Architecture Infer.NET** : Le moteur d'inférence compile votre modèle en code C# optimise, stocke dans `GeneratedSource/`. Cette approche ""compile une fois, execute plusieurs fois"" offre d'excellentes performances.",,,,,,,,2d3fa986637fa75a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,92dccdbd,markdown,fr,352b9d70ed229ea0,"## 4. Premier Exemple : Le Lancer de Deux Pieces
+
+### Enonce du probleme
+
+Quelle est la probabilité d'obtenir **deux faces** lors du lancer de deux pieces non biaisées ?
+
+### Solution mathematique
+
+$$P(\text{deux faces}) = P(\text{face}_1) \times P(\text{face}_2) = 0.5 \times 0.5 = 0.25$$
+
+### Solution avec Infer.NET",,,,,,,,352b9d70ed229ea0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,24e5f668,code,fr,1b60213531606aa4,"// Etape 1 : Definition du modele probabiliste
+Variable<bool> premierePiece = Variable.Bernoulli(0.5);   // Piece 1 : 50% face
+Variable<bool> deuxiemePiece = Variable.Bernoulli(0.5);   // Piece 2 : 50% face
+Variable<bool> deuxFaces = premierePiece & deuxiemePiece; // ET logique
+
+// Etape 2 : Creation du moteur d'inference
+InferenceEngine moteur = new InferenceEngine();
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;  // Necessaire pour .NET Interactive
+
+// Etape 3 : Execution de l'inference
+var resultat = moteur.Infer(deuxFaces);
+Console.WriteLine($""Probabilite d'obtenir deux faces : {resultat}"");",,,,,,,,1b60213531606aa4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,j1nrzm34c2f,markdown,fr,723ec551ab5bd343,"### Analyse de la sortie
+
+Le résultat `Bernoulli(0,25)` représente une **distribution de Bernoulli** avec paramètre p = 0.25 :
+
+- **Interpretation** : La variable `deuxFaces` a 25% de chance d'etre vraie
+- **Coherence mathematique** : 0.5 × 0.5 = 0.25 ✓
+
+Remarquez les messages ""Compiling model... done."" lors de la première exécution. Infer.NET **compile dynamiquement** votre modèle en code C# optimise, stocke dans un répertoire `GeneratedSource/`. Cette compilation n'a lieu qu'une fois par modèle.
+
+> **Pourquoi une distribution et pas juste 0.25 ?**  
+> Infer.NET retourne toujours des **distributions complètes**, pas seulement des valeurs ponctuelles. Cela permet de propager l'incertitude dans des modèles plus complexes.",,,,,,,,723ec551ab5bd343,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,7d81c7cb,markdown,fr,0d1c82ed7449e6e2,"## 5. Les 3 Étapes Fondamentales
+
+Tout programme Infer.NET suit ces 3 étapes :
+
+**Étape 1 : Définition du Modèle**
+
+Créez des **variables aléatoires** et definissez leurs **relations**.
+
+```csharp
+// Variables aléatoires avec leurs distributions a priori
+Variable<bool> A = Variable.Bernoulli(0.5);
+Variable<bool> B = Variable.Bernoulli(0.5);
+
+// Variable derivee (dependante)
+Variable<bool> C = A & B;  // C depend de A et B
+```
+
+**Étape 2 : Creation du Moteur d'Inférence**
+
+Le moteur compile le modèle et prepare l'algorithme d'inférence.
+
+```csharp
+InferenceEngine moteur = new InferenceEngine();
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;  // Pour notebooks
+```
+
+**Étape 3 : Exécution de l'Inférence**
+
+Demandez au moteur de calculer la distribution d'une variable.
+
+```csharp
+var résultat = moteur.Infer(C);  // Distribution marginale de C
+```",,,,,,,,0d1c82ed7449e6e2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,3b0d2370,markdown,fr,7d9b9aaabc493679,"## 6. Types de Distributions Fondamentales
+
+Infer.NET supporte de nombreuses distributions. Voici les plus courantes :
+
+| Distribution | Type | Usage | Exemple |
+|--------------|------|-------|--------|
+| **Bernoulli** | Discrete | Evenement binaire | Pile/Face, Vrai/Faux |
+| **Discrete** | Discrete | Categorie parmi N | Choix d'un jour, couleur |
+| **Gaussian** | Continue | Valeur reelle avec incertitude | Taille, temperature |
+| **Gamma** | Continue | Precision, variance | Bruit, fiabilite |
+| **Beta** | Continue | Probabilité inconnue | Taux de succes |
+| **Dirichlet** | Continue | Vecteur de probabilités | Poids de mélange |",,,,,,,,7d9b9aaabc493679,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,ebf38ca6,code,fr,8642658b5798ec15,"// Exemples de creation de variables aleatoires
+
+// Bernoulli : probabilite d'un evenement binaire
+Variable<bool> pluie = Variable.Bernoulli(0.3);  // 30% de chance de pluie
+
+// Discrete : choix parmi N options
+Variable<int> jourSemaine = Variable.DiscreteUniform(7);  // Uniform sur 0-6
+
+// Gaussian : valeur continue avec incertitude
+Variable<double> temperature = Variable.GaussianFromMeanAndVariance(20, 4);  // Moyenne 20, variance 4
+
+// Gamma : precision (inverse de la variance)
+Variable<double> precision = Variable.GammaFromShapeAndScale(2, 0.5);
+
+Console.WriteLine(""Variables creees avec succes !"");",,,,,,,,8642658b5798ec15,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,hifwis3sou8,markdown,fr,4248c5a2f0aa9f1d,"### Interpretation des variables créées
+
+La cellule precedente a crée quatre variables aléatoires. Voici ce que représente chacune :
+
+| Variable | Type | Distribution | Paramètres | Interpretation |
+|----------|------|--------------|------------|----------------|
+| `pluie` | `Variable<bool>` | Bernoulli(0.3) | p = 0.3 | 30% de chance de pluie |
+| `jourSemaine` | `Variable<int>` | DiscreteUniform(7) | n = 7 | Chaque jour equiprobable (1/7) |
+| `temperature` | `Variable<double>` | Gaussian(20, 4) | mu = 20, var = 4 | Temperature moyenne 20 degres, ecart-type 2 |
+| `precision` | `Variable<double>` | Gamma(2, 0.5) | shape = 2, scale = 0.5 | Precision avec moyenne 1, mode 0.5 |
+
+**Rappel sur les parametrisations** :
+
+- **Gaussian(mean, variance)** : La variance est le carre de l'ecart-type
+- **Gamma(shape, scale)** : Moyenne = shape × scale, mode = (shape - 1) × scale si shape >= 1
+
+> **Attention** : Ces variables ne sont pas encore ""liées"" entre elles. Dans un modèle complet, on definirait des dépendances (ex: la temperature influence la probabilité de pluie).",,,,,,,,4248c5a2f0aa9f1d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,952806dd,markdown,fr,bb9abb974259c308,"## 7. Exemple Avance : Pièce Biaisée
+
+Considerons une pièce potentiellement biaisée. Nous observons 7 faces sur 10 lancers. Quel est le biais de la pièce ?",,,,,,,,bb9abb974259c308,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,kp3m20jmh8,markdown,fr,a0274673590c2ca9,"### Modèle bayesien pour l'estimation de biais
+
+Le code suivant illustre les étapes clés d'un modèle bayesien :
+
+1. **Prior** : `Beta(1,1)` = distribution uniforme, aucune croyance initiale sur le biais
+2. **Vraisemblance** : Chaque lancer suit `Bernoulli(biais)`
+3. **Observations** : 7 faces sur 10 lancers
+4. **Inférence** : Calcul de la distribution posterieure du biais
+
+> **Beta(1,1)** est un prior ""non-informatif"" : il donne la meme probabilité a toutes les valeurs de biais entre 0 et 1. C'est equivalent a dire ""je n'ai aucune idee a priori du biais de la pièce"".",,,,,,,,a0274673590c2ca9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,632d5091,code,fr,2beb36e7d7ff355c,"// Modele pour estimer le biais d'une piece
+
+// A priori : le biais peut etre n'importe quelle valeur entre 0 et 1
+// Beta(1,1) = distribution uniforme sur [0,1]
+Variable<double> biais = Variable.Beta(1, 1);
+
+// Observations : 10 lancers
+int nombreLancers = 10;
+Range lancers = new Range(nombreLancers);
+VariableArray<bool> resultats = Variable.Array<bool>(lancers);
+
+// Chaque lancer suit une distribution Bernoulli avec le biais inconnu
+using (Variable.ForEach(lancers))
+{
+    resultats[lancers] = Variable.Bernoulli(biais);
+}
+
+// Observations : 7 faces (true), 3 piles (false)
+resultats.ObservedValue = new bool[] { true, true, true, true, true, true, true, false, false, false };
+
+// Inference
+InferenceEngine moteur = new InferenceEngine();
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Beta biaisPosterieur = moteur.Infer<Beta>(biais);
+Console.WriteLine($""Distribution a posteriori du biais : {biaisPosterieur}"");
+Console.WriteLine($""Moyenne estimee du biais : {biaisPosterieur.GetMean():F3}"");
+Console.WriteLine($""Intervalle de confiance (ecart-type) : +/- {Math.Sqrt(biaisPosterieur.GetVariance()):F3}"");",,,,,,,,2beb36e7d7ff355c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,12e14487,markdown,fr,b2c6429dc54c6be8,Visualisation du graphe de facteurs du modèle de biais de pièce.,,,,,,,,b2c6429dc54c6be8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,1j3d7ypvqqb,code,fr,8c733953f8f36134,"// Visualisation du factor graph pour le modele de piece biaisee
+// Recreons le modele avec ShowFactorGraph = true
+
+Variable<double> biaisViz = Variable.Beta(1, 1).Named(""biais"");
+int nLancers = 10;
+Range lancersViz = new Range(nLancers).Named(""lancers"");
+VariableArray<bool> resultatsViz = Variable.Array<bool>(lancersViz).Named(""resultats"");
+using (Variable.ForEach(lancersViz))
+{
+    resultatsViz[lancersViz] = Variable.Bernoulli(biaisViz);
+}
+resultatsViz.ObservedValue = new bool[] { true, true, true, true, true, true, true, false, false, false };
+
+InferenceEngine moteurViz = new InferenceEngine();
+moteurViz.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurViz.ShowFactorGraph = true;
+
+Beta biaisPost = moteurViz.Infer<Beta>(biaisViz);
+Console.WriteLine($""Biais estime: {biaisPost}"");
+
+// Afficher le factor graph
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,8c733953f8f36134,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,blaktc15im5,markdown,fr,8f215bf2f204a5fc,"### Factor Graph : Modèle de Pièce Biaisée
+
+Le graphe de facteurs ci-dessus illustre la structure du modèle bayesien :
+
+**Legende du graphe** :
+- **Rectangles** : Facteurs (distributions de probabilité)
+- **Ellipses** : Variables aléatoires
+- **Fleches** : Connexions entre facteurs et variables
+
+**Structure du modèle** :
+```
+[Beta(1,1)] --> (biais) --> [Bernoulli] --> (résultats[0..9]) <-- [Observed: T,T,T,T,T,T,T,F,F,F]
+```
+
+**Interpretation** :
+1. Le **prior Beta(1,1)** initialise notre croyance sur le biais de la pièce (uniforme)
+2. La variable **biais** est partagee par tous les facteurs Bernoulli (conjugaison)
+3. Chaque **résultat[i]** est génère independamment par `Bernoulli(biais)`
+4. Les **observations** (7 faces, 3 piles) contraignent le modèle
+
+**Flux des messages** :
+- Durant l'inférence, les messages de vraisemblance remontent des observations vers le biais
+- Le facteur Beta combine ces messages avec le prior pour produire le posterior Beta(8,4)
+
+> **Rendu Graphviz** : ce graphe factoriel n'est pas affiche dans le notebook car le binaire `dot` est absent du PATH du kernel .net-csharp (cellule de configuration Graphviz + `FactorGraphHelper` renvoient « non disponible », cf issue #3473). Infer.NET génère bien un fichier `.gv` a cote du notebook (visualisable sur [viz-js.com](https://viz-js.com/) ou [edotor.net](https://edotor.net/)), mais affiche a la place un avertissement « Problem with converting DOT to SVG ». La description textuelle de la structure ci-dessus reste valable.",,,,,,,,8f215bf2f204a5fc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,c23c8e87,markdown,fr,2e4ce81c85a8b57d,"### Analyse detaillee du résultat
+
+**Sortie obtenue** : `Beta(8,4)[mean=0,6667]`
+
+La distribution **Beta(α, β)** représente notre croyance mise a jour sur le biais de la pièce :
+
+| Paramètre | Valeur | Signification |
+|-----------|--------|---------------|
+| α (alpha) | 8 | 1 (prior) + 7 (faces observées) |
+| β (beta) | 4 | 1 (prior) + 3 (piles observes) |
+| Moyenne | 0.667 | α / (α + β) = 8/12 |
+| Ecart-type | 0.131 | Mesure de l'incertitude residuelle |
+
+**Pourquoi Beta(8,4) et pas simplement 7/10 ?**
+
+1. **Integration du prior** : Nous avons commence avec Beta(1,1), equivalent a avoir deja observe 1 face et 1 pile
+2. **Formule de mise a jour** : Beta(α + n_faces, β + n_piles) = Beta(1+7, 1+3) = Beta(8,4)
+3. **Moyenne legerement biaisée** : 0.667 vs 0.700 (l'effet du prior diminue avec plus d'observations)
+
+> **Concept clé : Conjugaison**  
+> La distribution Beta est **conjuguee** a Bernoulli : prior Beta + observations Bernoulli = posterior Beta.  
+> Cette propriete permet une mise a jour analytique exacte, sans approximation.",,,,,,,,2e4ce81c85a8b57d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,d42fe2e7,markdown,fr,180887deb9f0e15a,"## 8. Exemple guide : Trois Pieces
+
+### Enonce
+
+Vous lancez **trois** pieces non biaisées. Calculez :
+
+1. La probabilité d'obtenir **exactement trois faces**
+2. La probabilité d'obtenir **au moins deux faces**
+
+**Indice**
+
+Pour ""au moins deux faces"", vous pouvez utiliser plusieurs variables derivees :
+- `deuxOuTrois = (p1 & p2) | (p1 & p3) | (p2 & p3)`
+
+### Solution",,,,,,,,180887deb9f0e15a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,p4eyf2b3his,markdown,fr,8ed2f8160afdfd14,"### Code de l'exercice
+
+La cellule suivante contient la solution de référence. Essayez de comprendre chaque ligne avant de l'executer :
+
+- **Lignes 4-6** : Creation de trois variables Bernoulli independantes
+- **Ligne 9** : Conjonction logique (AND) des trois variables
+- **Ligne 13** : Disjonction logique (OR) de paires - structure plus complexe",,,,,,,,8ed2f8160afdfd14,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,09f88a13,code,fr,72e2da7036fb65a4,"// Exemple guide : Completez ce code
+
+// 1. Definir les trois pieces
+Variable<bool> piece1 = Variable.Bernoulli(0.5);
+Variable<bool> piece2 = Variable.Bernoulli(0.5);
+Variable<bool> piece3 = Variable.Bernoulli(0.5);
+
+// 2. Definir ""trois faces""
+Variable<bool> troisFaces = piece1 & piece2 & piece3;
+
+// 3. Definir ""au moins deux faces""
+// Hint: (p1&p2) | (p1&p3) | (p2&p3)
+Variable<bool> auMoinsDeuxFaces = (piece1 & piece2) | (piece1 & piece3) | (piece2 & piece3);
+
+// 4. Inference
+InferenceEngine moteur = new InferenceEngine();
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Console.WriteLine($""P(trois faces) = {moteur.Infer(troisFaces)}"");
+Console.WriteLine($""P(au moins deux faces) = {moteur.Infer(auMoinsDeuxFaces)}"");
+
+// Verification mathematique :
+// P(trois faces) = 0.5^3 = 0.125
+// P(au moins 2) = P(2) + P(3) = C(3,2)*0.5^3 + 0.5^3 = 3*0.125 + 0.125 = 0.5
+Console.WriteLine(""\nVerification : P(3 faces) = 1/8 = 0.125, P(>=2 faces) = 4/8 = 0.5"");",,,,,,,,72e2da7036fb65a4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,sh6ls6w113e,markdown,fr,ccac11af7d066f18,"### Analyse des résultats de l'exercice
+
+**Résultats obtenus** :
+- `P(trois faces) = Bernoulli(0,125)` ✓ Exact (1/8)
+- `P(au moins deux faces) = Bernoulli(0,5781)` ≠ Valeur théorique (0.5)
+
+**Pourquoi cette difference ?**
+
+La valeur 0.5781 au lieu de 0.5 s'explique par l'**algorithme d'inférence approchee** utilise par Infer.NET (Expectation Propagation).
+
+Pour ""au moins deux faces"", la vraie probabilité est :
+- P(exactement 2 faces) = C(3,2) × 0.5³ = 3 × 0.125 = 0.375
+- P(exactement 3 faces) = 0.125
+- **Total** = 0.5
+
+L'ecart vient de la complexite des **correlations entre variables** dans l'expression `(p1&p2) | (p1&p3) | (p2&p3)`. Les memes variables apparaissent dans plusieurs termes, creant des dépendances que l'algorithme EP approxime.
+
+> **Bon a savoir** : Infer.NET utilise des algorithmes d'inférence **variationnelle** qui peuvent introduire de legeres erreurs sur des modèles avec des structures de dépendance complexes. Pour des calculs exacts sur des modèles discrets simples, d'autres approches (enumeration, junction tree) seraient plus précises.",,,,,,,,ccac11af7d066f18,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,88j4a6u22li,markdown,fr,9f5ae3e9c8010077,"## 8bis. Troubleshooting et Debogage
+
+Cette section couvre les problemes courants avec Infer.NET et leurs solutions.
+
+### Erreurs Communes
+
+| Erreur | Cause | Solution |
+|--------|-------|----------|
+| `Model has no support` | Variable observée incompatible avec le prior | Verifier que les observations sont dans le support du prior |
+| `Improper distribution` | Divergence de l'inférence | Utiliser des priors plus informatifs ou changer d'algorithme |
+| `Could not find method` | Operation non supportée | Reformuler le modèle avec des opérations supportées |
+| `Compiler error` | Syntax ou type invalide | Verifier les types des variables et operateurs |
+
+### Choix de l'Algorithme d'Inférence
+
+| Algorithme | Force | Faiblesse | Usage recommande |
+|------------|-------|-----------|------------------|
+| **EP** | Rapide, bon pour gaussiennes | Approximatif, peut diverger | Modèles continus, facteurs mixtes |
+| **VMP** | Stable, bon pour discret | Sous-estime l'incertitude | LDA, modèles a composantes |
+| **Gibbs** | Exact asymptotiquement | Lent, convergence difficile | Validation, petits modèles |
+
+### Comment changer d'algorithme
+
+```csharp
+// Expectation Propagation (defaut)
+moteur.Algorithm = new ExpectationPropagation();
+
+// Variational Message Passing
+moteur.Algorithm = new VariationalMessagePassing();
+
+// Gibbs Sampling
+moteur.Algorithm = new GibbsSampling();
+```
+
+> **Note** : La configuration de Graphviz a ete effectuee en section 3. Les fichiers `.gv` generes peuvent etre visualises sur [viz-js.com](https://viz-js.com/) si Graphviz n'est pas installe.",,,,,,,,9f5ae3e9c8010077,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,5r5yxxb87f9,code,fr,1b8e3db9e71356cc,"// Inspection du code genere et du factor graph
+
+Console.WriteLine(""=== Options de Debug Infer.NET ===\n"");
+
+// Verification de Graphviz (le PATH a ete configure au debut du notebook)
+bool graphvizInstalle = false;
+try
+{
+    var psi = new System.Diagnostics.ProcessStartInfo {
+        FileName = ""dot"",
+        Arguments = ""-V"",
+        RedirectStandardError = true,
+        RedirectStandardOutput = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+    };
+    using var proc = System.Diagnostics.Process.Start(psi);
+    var stderr = proc.StandardError.ReadToEnd();
+    proc.WaitForExit();
+    if (proc.ExitCode == 0 || stderr.Contains(""graphviz""))
+    {
+        Console.WriteLine($""Graphviz disponible : {stderr.Trim()}"");
+        graphvizInstalle = true;
+    }
+}
+catch (Exception ex) 
+{ 
+    Console.WriteLine($""Verification Graphviz echouee : {ex.Message}"");
+}
+
+if (!graphvizInstalle)
+{
+    Console.WriteLine(""Graphviz non detecte - les fichiers .gv seront generes"");
+    Console.WriteLine(""Visualisez-les sur : https://viz-js.com/\n"");
+}
+Console.WriteLine();
+
+// Creation d'un modele simple pour demonstration
+Variable<double> x = Variable.GaussianFromMeanAndPrecision(0, 1).Named(""x"");
+Variable<double> y = Variable.GaussianFromMeanAndPrecision(x, 1).Named(""y"");
+y.ObservedValue = 2.0;
+
+// Moteur avec options de debug
+InferenceEngine moteurDebug = new InferenceEngine();
+moteurDebug.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+// Option 1 : Afficher le schedule d'inference
+moteurDebug.ShowSchedule = true;
+Console.WriteLine(""1. ShowSchedule = true : Affiche l'ordre des calculs de messages\n"");
+
+// Option 2 : Afficher le factor graph (genere .gv et .svg si Graphviz disponible)
+moteurDebug.ShowFactorGraph = true;
+Console.WriteLine(""2. ShowFactorGraph = true : Genere fichier DOT"" + 
+    (graphvizInstalle ? "" + SVG"" : "" (SVG si Graphviz disponible)"") + ""\n"");
+
+// Option 3 : Sauvegarder le code genere
+moteurDebug.Compiler.WriteSourceFiles = true;
+moteurDebug.Compiler.GeneratedSourceFolder = ""GeneratedSource"";
+Console.WriteLine(""3. WriteSourceFiles = true : Sauvegarde le code C# genere dans GeneratedSource/\n"");
+
+// Option 4 : Montrer les avertissements de compilation
+moteurDebug.Compiler.ShowWarnings = true;
+Console.WriteLine(""4. ShowWarnings = true : Affiche les avertissements du compilateur\n"");
+
+// Executer l'inference
+Console.WriteLine(""--- Execution avec options debug ---\n"");
+var xPost = moteurDebug.Infer<Gaussian>(x);
+Console.WriteLine($""\nResultat : x ~ {xPost}"");
+
+// Note : Le FactorGraphHelper est defini plus bas dans ce notebook.
+// Une fois charge, utilisez : display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()))
+Console.WriteLine(""\n--- Factor Graph ---"");
+Console.WriteLine(""Fichiers .gv generes. Voir section FactorGraphHelper ci-dessous pour l'affichage inline."");",,,,,,,,1b8e3db9e71356cc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,q2l9lsexdsl,markdown,fr,eeb8822bc6c6593b,"### Interpretation du résultat d'inférence en mode debug
+
+**Sortie obtenue** : `x ~ Gaussian(1, 0.5)`
+
+Ce résultat représente la **distribution posterieure** de la variable `x` après avoir observe `y = 2.0`.
+
+| Paramètre | Valeur | Signification |
+|-----------|--------|---------------|
+| Moyenne | 1.0 | Estimation centrale de x |
+| Variance | 0.5 | Incertitude sur x (ecart-type ~ 0.71) |
+
+**Pourquoi cette mise a jour ?**
+
+1. **Prior** : x ~ N(0, 1) - nous pensions que x etait proche de 0
+2. **Observation** : y = 2.0, avec y ~ N(x, 1)
+3. **Posterior** : x ~ N(1, 0.5) - compromis entre le prior et l'observation
+
+Le posterior est ""tire"" vers l'observation (moyenne passe de 0 a 1) tout en reduisant l'incertitude (variance passe de 1 a 0.5).
+
+> **Formule analytique** (cas gaussien) :  
+> La moyenne posterieure = (prior_precision × prior_mean + likelihood_precision × observation) / (prior_precision + likelihood_precision)  
+> Soit : (1×0 + 1×2) / (1+1) = 1",,,,,,,,eeb8822bc6c6593b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,1ks1d2mjbd3,markdown,fr,9eab17e7f0b15712,"### Utilisation des Options de Debug
+
+**Quand utiliser chaque option** :
+
+| Option | Utilite |
+|--------|---------|
+| `ShowSchedule` | Comprendre l'ordre des messages, identifier les boucles infinies |
+| `ShowFactorGraph` | Visualiser le modèle, verifier les connections |
+| `WriteSourceFiles` | Inspecter le code génère, optimiser manuellement |
+| `ShowWarnings` | Detecter les approximations, operateurs experimentaux |
+
+**Fichiers generes** :
+
+Le dossier `GeneratedSource/` contient :
+- `Model_EP.cs` : Code d'inférence pour EP
+- `Model_VMP.cs` : Code d'inférence pour VMP
+- Ces fichiers sont du C# pur, compilable et executable
+
+### Visualisation des Factor Graphs
+
+Lorsque `ShowFactorGraph = true` est active, Infer.NET génère des fichiers `.gv` (format DOT Graphviz) decrivant la structure du modèle.
+
+**Avec Graphviz installe** : La conversion en SVG est automatique.
+
+**Sans Graphviz** : Les fichiers `.gv` peuvent etre visualises sur [viz-js.com](https://viz-js.com/) ou [edotor.net](https://edotor.net/).
+
+**Structure d'un Factor Graph** :
+
+```
+[Prior N(0,1)] ----> (Variable x) ----> [GaussianFromMeanAndPrecision] ----> (Variable y = 2.0 observe)
+```
+
+Dans ce graphe :
+- Les **rectangles** représentent les facteurs (distributions)
+- Les **cercles** représentent les variables aléatoires
+- Les **fleches** indiquent le flux de messages entre facteurs et variables",,,,,,,,9eab17e7f0b15712,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,3olme3xdb2s,markdown,fr,9e9bbd27da176dc1,"### Helper : Affichage inline des Factor Graphs
+
+Le code suivant definit un helper `FactorGraphHelper` pour afficher les graphes de facteurs directement dans les cellules du notebook. Ce helper :
+- Detecte automatiquement les fichiers `.gv` generes par Infer.NET
+- Les convertit en SVG via Graphviz
+- Les affiche inline dans la sortie de la cellule",,,,,,,,9e9bbd27da176dc1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,nmjji4dj15m,code,fr,a7655c4ec495c4a6,"// Helper pour afficher les graphes de facteurs (SVG) inline dans le notebook
+
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Interactive.Formatting;
+
+/// <summary>
+/// Helper pour generer et afficher les factor graphs Infer.NET dans les notebooks
+/// </summary>
+public static class FactorGraphHelper
+{
+    private static bool? _graphvizAvailable = null;
+    
+    /// <summary>
+    /// Verifie si Graphviz (dot) est disponible
+    /// </summary>
+    public static bool IsGraphvizAvailable()
+    {
+        if (_graphvizAvailable.HasValue) return _graphvizAvailable.Value;
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo {
+                FileName = ""dot"", Arguments = ""-V"",
+                RedirectStandardError = true, RedirectStandardOutput = true,
+                UseShellExecute = false, CreateNoWindow = true
+            };
+            using var proc = System.Diagnostics.Process.Start(psi);
+            proc.WaitForExit(3000);
+            _graphvizAvailable = (proc.ExitCode == 0);
+        }
+        catch { _graphvizAvailable = false; }
+        return _graphvizAvailable.Value;
+    }
+    
+    /// <summary>
+    /// Retourne le HTML pour afficher le dernier fichier SVG genere par Infer.NET
+    /// Usage: display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()))
+    /// </summary>
+    public static string GetLatestFactorGraphHtml(int maxWidth = 800)
+    {
+        var svgFiles = Directory.GetFiles(Environment.CurrentDirectory, ""Model_*.svg"");
+        
+        if (svgFiles.Length > 0)
+        {
+            var latestSvg = svgFiles
+                .OrderByDescending(f => new FileInfo(f).LastWriteTime)
+                .First();
+            return GetSvgFileHtml(latestSvg, maxWidth);
+        }
+        else
+        {
+            return ConvertAndGetLatestGvHtml(maxWidth);
+        }
+    }
+
+    /// <summary>
+    /// Retourne le HTML pour afficher un fichier SVG inline
+    /// </summary>
+    public static string GetSvgFileHtml(string svgPath, int maxWidth = 800)
+    {
+        if (!File.Exists(svgPath))
+            return $""<div style='color:red'>Fichier non trouve : {svgPath}</div>"";
+
+        var svgContent = File.ReadAllText(svgPath);
+        var fileName = Path.GetFileName(svgPath);
+        return GetSvgContentHtml(svgContent, fileName, maxWidth);
+    }
+    
+    /// <summary>
+    /// Retourne le HTML pour afficher du contenu SVG
+    /// </summary>
+    public static string GetSvgContentHtml(string svgContent, string title = ""Factor Graph"", int maxWidth = 800)
+    {
+        return $@""
+<div style=""""margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;"""">
+    <div style=""""font-weight: bold; margin-bottom: 8px; color: #333;"""">{title}</div>
+    <div style=""""max-width: {maxWidth}px; overflow: auto;"""">
+        {svgContent}
+    </div>
+</div>"";
+    }
+
+    /// <summary>
+    /// Convertit un fichier .gv en SVG et retourne le HTML
+    /// </summary>
+    public static string ConvertAndGetGvHtml(string gvPath, int maxWidth = 800)
+    {
+        if (!File.Exists(gvPath))
+            return $""<div style='color:red'>Fichier .gv non trouve : {gvPath}</div>"";
+
+        if (!IsGraphvizAvailable())
+        {
+            var fileName = Path.GetFileName(gvPath);
+            return $@""<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>
+                <strong>Graphviz non disponible.</strong><br/>
+                Copiez le contenu de <code>{fileName}</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>
+            </div>"";
+        }
+
+        var svgPath = Path.ChangeExtension(gvPath, "".svg"");
+
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = ""dot"",
+                Arguments = $""-Tsvg \""{gvPath}\"" -o \""{svgPath}\"""",
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var proc = System.Diagnostics.Process.Start(psi);
+            proc.WaitForExit(5000);
+
+            if (proc.ExitCode == 0 && File.Exists(svgPath))
+                return GetSvgFileHtml(svgPath, maxWidth);
+            else
+            {
+                var error = proc.StandardError.ReadToEnd();
+                return $""<div style='color:red'>Erreur Graphviz : {error}</div>"";
+            }
+        }
+        catch (Exception ex)
+        {
+            return $""<div style='color:red'>Erreur : {ex.Message}</div>"";
+        }
+    }
+
+    /// <summary>
+    /// Trouve et convertit le dernier fichier .gv
+    /// </summary>
+    public static string ConvertAndGetLatestGvHtml(int maxWidth = 800)
+    {
+        var gvFiles = Directory.GetFiles(Environment.CurrentDirectory, ""Model_*.gv"");
+
+        if (gvFiles.Length == 0)
+        {
+            return @""<div style='padding: 10px; border: 1px solid #d9534f; background: #f2dede; border-radius: 5px;'>
+                Aucun fichier .gv trouve.<br/>
+                Activez <code>ShowFactorGraph = true</code> sur le moteur d'inference.
+            </div>"";
+        }
+
+        var latestGv = gvFiles
+            .OrderByDescending(f => new FileInfo(f).LastWriteTime)
+            .First();
+
+        return ConvertAndGetGvHtml(latestGv, maxWidth);
+    }
+
+    /// <summary>
+    /// Nettoie les fichiers .gv et .svg generes
+    /// </summary>
+    public static int CleanupGeneratedFiles()
+    {
+        var files = Directory.GetFiles(Environment.CurrentDirectory, ""Model_*.gv"")
+            .Concat(Directory.GetFiles(Environment.CurrentDirectory, ""Model_*.svg""))
+            .Concat(Directory.GetFiles(Environment.CurrentDirectory, ""Task_Graph_*.gv""));
+
+        int count = 0;
+        foreach (var file in files)
+        {
+            try { File.Delete(file); count++; } catch { }
+        }
+        return count;
+    }
+}
+
+Console.WriteLine(""FactorGraphHelper charge !"");
+Console.WriteLine(""  - display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml())) : affiche le dernier graphe"");
+Console.WriteLine(""  - FactorGraphHelper.CleanupGeneratedFiles() : nettoie les fichiers generes"");",,,,,,,,a7655c4ec495c4a6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,s86z9cewud,markdown,fr,9db9a534907e8395,"### Utilisation du FactorGraphHelper
+
+Une fois la cellule precedente executee, vous pouvez afficher les graphes de facteurs directement dans le notebook :
+
+```csharp
+// Afficher le dernier graphe génère
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));
+
+// Nettoyer les fichiers temporaires
+FactorGraphHelper.CleanupGeneratedFiles();
+```
+
+**Méthodes disponibles** :
+
+| Méthode | Description |
+|---------|-------------|
+| `GetLatestFactorGraphHtml()` | Affiche le dernier graphe SVG inline |
+| `GetSvgFileHtml(path)` | Affiche un fichier SVG spécifique |
+| `ConvertAndGetGvHtml(path)` | Convertit un `.gv` en SVG et l'affiche |
+| `CleanupGeneratedFiles()` | Supprime les fichiers `.gv` et `.svg` generes |
+| `IsGraphvizAvailable()` | Verifie si Graphviz est installe |",,,,,,,,9db9a534907e8395,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,aaf08fae,markdown,fr,fd793a6347e4a31a,"## 9. Resume
+
+Dans ce notebook, vous avez appris :
+
+| Concept | Description |
+|---------|-------------|
+| **Programmation probabiliste** | Representer l'incertitude avec des variables aléatoires |
+| **Infer.NET** | Framework Microsoft pour l'inférence bayesienne |
+| **Les 3 étapes** | Modèle -> Moteur -> Inférence |
+| **Distributions de base** | Bernoulli, Beta, Gaussian, Gamma |
+| **Mise a jour bayesienne** | A priori + Observations = A posteriori |
+
+---
+
+## Pour aller plus loin
+
+| Si vous voulez... | Consultez... |
+|-------------------|--------------|
+| Approfondir les distributions continues | [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb) |
+| Comprendre les graphes de facteurs | [Infer-3-Factor-Graphs](Infer-3-Factor-Graphs.ipynb) |
+| Debugger un modèle qui ne converge pas | [Infer-6-Debugging](Infer-6-Debugging.ipynb) |
+| Trouver une définition | [Glossaire](Infer-Glossary.md) |
+
+---
+
+## Prochaine étape
+
+Dans le notebook suivant [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb), nous approfondirons :
+
+- Les distributions gaussiennes et leur apprentissage
+- Les modèles de mélange pour les données multimodales
+- L'utilisation de `Variable.Switch` pour les modèles a composantes
+
+---
+
+## Ressources
+
+- [Documentation Infer.NET](https://dotnet.github.io/infer/)
+- [Tutorials officiels](https://dotnet.github.io/infer/userguide/Infer.NET%20tutorials%20and%20examples.html)
+- [GitHub dotnet/infer](https://github.com/dotnet/infer)
+- [Model-Based Machine Learning Book](https://mbmlbook.com/)",,,,,,,,fd793a6347e4a31a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,b99140b6,markdown,fr,745b9d5605c01d16,"## 10. Exercice : Lancer de Deux Des
+
+### Enonce
+
+Modelisez le lancer de **deux des a 6 faces** avec Infer.NET.
+
+1. Créez deux variables aléatoires discretes uniformes représentant chaque de (6 faces)
+2. Definissez leur somme comme variable dependante
+3. Calculez la probabilité que la somme soit superieure ou egale a 10
+4. Conditionnez sur le fait que le premier de affiche 6 (valeur = 5 en 0-indexe) et re-inferez
+
+**Indice** : Utilisez `Variable.DiscreteUniform(6)` et `Variable.If()` pour conditionner.",,,,,,,,745b9d5605c01d16,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,0dc25f62,code,fr,7508f8ab8bc8b5fc,"// Exercice : Modele de deux des a 6 faces
+
+// TODO: Creer le moteur d inference avec Roslyn
+// Indice: InferenceEngine + CompilerChoice.Roslyn
+
+
+// TODO: Creer les deux variables aleatoires pour les des (valeurs 0-5 representant faces 1-6)
+// Indice: utilisez Variable.DiscreteUniform() avec le bon nombre de faces
+
+
+// TODO: Inferer la distribution marginale de chaque de (avant observation)
+// Indice: engine.Infer<Discrete>(variable)
+
+
+// TODO: Observer que le premier de montre 6 (valeur = 5) et re-inferer de2
+// Indice: utilisez .ObservedValue puis re-inferez la distribution de l autre de
+
+
+// Question: La distribution de de2 change-t-elle apres observation de de1 ? Pourquoi ?
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,7508f8ab8bc8b5fc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb,d78060c4,markdown,fr,52e92eba73638625,"## Conclusion
+
+Ce notebook d'introduction a pose les fondements de la programmation probabiliste avec Infer.NET :
+
+| Concept | Apport du notebook |
+|---------|-------------------|
+| **Variable&lt;T&gt;** | Variables aléatoires Bernoulli, Gaussian, Beta, Gamma, Discrete |
+| **InferenceEngine** | Compilation Roslyn du modèle, choix de l'algorithme (EP, VMP, Gibbs) |
+| **Flux bayesien** | Prior + Vraisemblance + Observations = Posterior |
+| **Conjugaison** | Prior Beta + vraisemblance Bernoulli = posterior Beta analytique |
+| **Factor graphs** | Visualisation de la structure du modèle via Graphviz |
+| **Debugging** | ShowFactorGraph, ShowSchedule, WriteSourceFiles |
+
+> **Point clé** : Infer.NET retourne toujours des distributions complètes (Gaussian, Beta, Bernoulli), jamais de simples valeurs ponctuelles, ce qui permet de propager l'incertitude a travers tout le modèle.",,,,,,,,52e92eba73638625,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,72aac374,markdown,fr,bafcd82d7ef59df0,"# Infer-10-Model-Selection : Selection et Comparaison de Modeles
+
+**Serie** : Programmation Probabiliste avec Infer.NET (10/20)  
+**Duree estimee** : 45 minutes  
+**Prerequis** : Infer-9-Classification
+
+---
+
+## Objectifs
+
+- Comprendre le probleme du surapprentissage
+- Calculer l'evidence du modele (marginal likelihood)
+- Utiliser le facteur de Bayes pour comparer des modeles
+- Implementer l'Automatic Relevance Determination (ARD)
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-11-Topic-Models](Infer-11-Topic-Models.ipynb) | [Infer-14-Sequences](Infer-14-Sequences.ipynb) |
+
+---",,,,,,,,bafcd82d7ef59df0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,6528c2c1,markdown,fr,1b173084c9bebcba,"## 1. Configuration
+
+Nous preparons l'environnement pour explorer la selection de modeles bayesienne. Cette approche permet de comparer objectivement differents modeles en calculant leur evidence marginale, implementant ainsi le rasoir d'Occam de maniere mathematique.",,,,,,,,1b173084c9bebcba,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,e6538772,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,e2ffca21,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,8ik5ebs1sx3,code,fr,789ca3a68dffa3ae,"// Chargement du helper pour visualisation des graphes de facteurs
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine($""FactorGraphHelper charge. Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,789ca3a68dffa3ae,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,qdg7zri60d8,markdown,fr,4b3a8542a3b234d6,"### Visualisation des graphes de facteurs
+
+Ce notebook utilise `FactorGraphHelper.cs` pour visualiser les graphes de facteurs generes par Infer.NET. Ces graphes montrent la structure probabiliste des modeles : les noeuds representent les variables aleatoires et les observations, les facteurs (carres) representent les distributions conditionnelles.
+
+Pour activer la visualisation, on configure `ShowFactorGraph = true` sur le moteur d'inference.",,,,,,,,4b3a8542a3b234d6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,dh7jodvycpp,markdown,fr,15cd61d636fd556e,"**Note technique : Calcul de l'evidence dans Infer.NET**
+
+Infer.NET calcule l'evidence du modele via une astuce elegante :
+
+1. On introduit une variable indicatrice `evidence = Bernoulli(0.5)`
+2. Le modele est conditionne par `Variable.If(evidence)`
+3. Apres inference, `evidence.LogOdds` donne le log de l'evidence
+
+> **Pourquoi ca fonctionne ?** Par le theoreme de Bayes :
+> $$P(\text{evidence}=\text{true}|D) \propto P(D|\text{evidence}=\text{true}) \times P(\text{evidence}=\text{true})$$
+> 
+> Comme $P(\text{evidence}=\text{true}) = 0.5$, le log-odds posterieur est directement le log de l'evidence (a une constante pres).
+
+Cette methode est specifique a Infer.NET et permet d'obtenir l'evidence sans calcul integral explicite.",,,,,,,,15cd61d636fd556e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,f1fdd2fb,markdown,fr,fa2b81ce13604abe,"## 2. Le Probleme du Surapprentissage
+
+### Observation
+
+Un modele complexe peut parfaitement ajuster les donnees d'entrainement mais mal generaliser.
+
+### Exemple
+
+Ajuster un polynome de degre n-1 a n points : ajustement parfait mais prediction catastrophique.
+
+### Solution bayesienne
+
+- Les priors penalisent les modeles complexes
+- L'evidence du modele equilibre ajustement et complexite
+- C'est le **rasoir d'Occam bayesien**",,,,,,,,fa2b81ce13604abe,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,24cacf89,markdown,fr,7dd9e7ca5ffc2f4f,"## 3. Evidence du Modele (Marginal Likelihood)
+
+### Definition
+
+$$P(D|M) = \int P(D|\theta, M) P(\theta|M) d\theta$$
+
+L'evidence est la probabilite des donnees sous le modele, marginalisee sur les parametres.
+
+### Interpretation
+
+- Un modele simple fait des predictions moins precises mais moins dispersees
+- Un modele complexe fait des predictions plus precises mais plus dispersees
+- L'evidence favorise le bon equilibre",,,,,,,,7dd9e7ca5ffc2f4f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,15263494,code,fr,035a3af2619d0961,"// Calcul de l'evidence avec Infer.NET
+
+// Donnees
+double[] observations = { 13, 15, 17, 14, 16, 15, 18 };
+int n = observations.Length;
+
+// MODELE 1 : Une seule gaussienne
+Variable<bool> evidence1 = Variable.Bernoulli(0.5).Named(""evidence1"");
+
+using (Variable.If(evidence1))
+{
+    Variable<double> moyenne1 = Variable.GaussianFromMeanAndPrecision(15, 0.01).Named(""moyenne"");
+    Variable<double> precision1 = Variable.GammaFromShapeAndScale(2, 0.5).Named(""precision"");
+    
+    for (int i = 0; i < n; i++)
+    {
+        Variable<double> obs1 = Variable.GaussianFromMeanAndPrecision(moyenne1, precision1).Named($""obs_{i}"");
+        obs1.ObservedValue = observations[i];
+    }
+}
+
+InferenceEngine moteur1 = new InferenceEngine();
+moteur1.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur1.ShowFactorGraph = true;  // Activation de la visualisation
+
+double logEvidence1 = moteur1.Infer<Bernoulli>(evidence1).LogOdds;
+
+Console.WriteLine(""=== Evidence du Modele ==="");
+Console.WriteLine($""\nModele 1 (1 gaussienne) : log evidence = {logEvidence1:F2}"");",,,,,,,,035a3af2619d0961,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,kxqr4eukslk,markdown,fr,a59c8e411f000225,"### Lecture du resultat
+
+**Log evidence = -16.98** pour le modele a une gaussienne.
+
+Cette valeur negative est normale : c'est un logarithme de probabilite, donc toujours negatif (ou nul). Plus la valeur est proche de 0, meilleure est l'evidence.
+
+En termes absolus, $e^{-16.98} \approx 4.2 \times 10^{-8}$ semble tres petit, mais c'est la **comparaison relative** entre modeles qui importe, pas la valeur absolue.",,,,,,,,a59c8e411f000225,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,ohu36bdkh4,code,fr,8f5f1cf1d90948d9,"// Visualisation du graphe de facteurs - Modele 1 gaussienne
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,8f5f1cf1d90948d9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,rwzoc5x79i,markdown,fr,f76f35c8ff9dd08d,"### Lecture du graphe de facteurs - Modele 1 gaussienne
+
+Le graphe montre la structure du modele a une gaussienne :
+
+- **Noeuds ovales** : variables aleatoires (`moyenne`, `precision`, `evidence1`)
+- **Noeuds carres** : facteurs (distributions conditionnelles)
+- **Noeuds gris** : observations (`obs_0` a `obs_6`)
+
+La variable `evidence1` (Bernoulli) englobe tout le modele via `Variable.If()`. Les 7 observations partagent la meme `moyenne` et `precision`, ce qui represente l'hypothese i.i.d. (independantes et identiquement distribuees).",,,,,,,,f76f35c8ff9dd08d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,tg7grrjd7g,markdown,fr,28662760f46902c6,"### Implementation : Modele 2 - Melange de deux gaussiennes
+
+Le **modele de melange** (mixture model) suppose que chaque observation provient de l'une ou l'autre de deux gaussiennes, avec une probabilite $\pi$ pour la premiere et $1-\pi$ pour la seconde.
+
+**Parametres du modele** :
+- $\mu_1, \mu_2$ : moyennes des deux composantes
+- $\tau$ : precision commune (simplification)
+- $\pi$ : proportion du melange (poids de la premiere composante)
+
+**Code** : Pour chaque observation, on tire d'abord `composante ~ Bernoulli(pi)`, puis on observe depuis la gaussienne correspondante.
+
+> **Note algorithmique** : Nous utilisons `VariationalMessagePassing` car les melanges de gaussiennes sont plus stables avec VMP qu'avec EP pour le calcul d'evidence.",,,,,,,,28662760f46902c6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,15ad48f2,code,fr,f2e25557cefeab9b,"// MODELE 2 : Melange de deux gaussiennes
+Variable<bool> evidence2 = Variable.Bernoulli(0.5).Named(""evidence2"");
+
+using (Variable.If(evidence2))
+{
+    Variable<double> moyenne2a = Variable.GaussianFromMeanAndPrecision(10, 0.01).Named(""moyenne_a"");
+    Variable<double> moyenne2b = Variable.GaussianFromMeanAndPrecision(20, 0.01).Named(""moyenne_b"");
+    Variable<double> precision2 = Variable.GammaFromShapeAndScale(2, 0.5).Named(""precision"");
+    Variable<double> poidsMixte = Variable.Beta(1, 1).Named(""poids_mixte"");
+    
+    for (int i = 0; i < n; i++)
+    {
+        Variable<bool> composante = Variable.Bernoulli(poidsMixte).Named($""comp_{i}"");
+        Variable<double> obs2 = Variable.New<double>().Named($""obs2_{i}"");
+        using (Variable.If(composante))
+        {
+            obs2.SetTo(Variable.GaussianFromMeanAndPrecision(moyenne2a, precision2));
+        }
+        using (Variable.IfNot(composante))
+        {
+            obs2.SetTo(Variable.GaussianFromMeanAndPrecision(moyenne2b, precision2));
+        }
+        obs2.ObservedValue = observations[i];
+    }
+}
+
+InferenceEngine moteur2 = new InferenceEngine(new VariationalMessagePassing());
+moteur2.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur2.ShowFactorGraph = true;  // Activation de la visualisation
+
+double logEvidence2 = moteur2.Infer<Bernoulli>(evidence2).LogOdds;
+
+Console.WriteLine($""Modele 2 (melange 2 gaussiennes) : log evidence = {logEvidence2:F2}"");",,,,,,,,f2e25557cefeab9b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,fc059ea9,markdown,fr,6f2033f91ed9fb14,Visualisation du graphe de facteurs du modele de melange de gaussiennes.,,,,,,,,6f2033f91ed9fb14,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,93l0422na3f,code,fr,a9d7e4f32a90e14a,"// Visualisation du graphe de facteurs - Modele melange
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,a9d7e4f32a90e14a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,uhecr4ah36,markdown,fr,695df57aeed193b1,"### Lecture du graphe de facteurs - Modele melange
+
+Le graphe du modele de melange est plus complexe :
+
+- **moyenne_a, moyenne_b** : les deux centres des composantes gaussiennes
+- **poids_mixte** : parametre Beta controlant la proportion du melange
+- **comp_i** : variable latente discrete (quelle composante genere l'observation i ?)
+- **obs2_i** : observations, chacune connectee aux deux moyennes via sa variable de composante
+
+La structure en ""gateway"" (Variable.If/IfNot) cree des branchements conditionnels visibles dans le graphe. Chaque observation peut provenir de l'une ou l'autre gaussienne selon `comp_i`.",,,,,,,,695df57aeed193b1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,35652b62,markdown,fr,56eb374a2ddda72d,"## 4. Facteur de Bayes
+
+### Definition
+
+$$BF_{12} = \frac{P(D|M_1)}{P(D|M_2)} = \exp(\log E_1 - \log E_2)$$
+
+### Interpretation (echelle de Jeffreys)
+
+| log(BF) | BF | Evidence pour M1 |
+|---------|----|-----------------|
+| 0-1 | 1-3 | Negligeable |
+| 1-2 | 3-10 | Substantielle |
+| 2-3 | 10-30 | Forte |
+| 3-5 | 30-150 | Tres forte |
+| >5 | >150 | Decisive |",,,,,,,,56eb374a2ddda72d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,0918883d,code,fr,3e06a4cfdca38eee,"// Facteur de Bayes
+double logBF = logEvidence1 - logEvidence2;
+double BF = Math.Exp(logBF);
+
+Console.WriteLine(""=== Facteur de Bayes ==="");
+Console.WriteLine($""\nlog(BF) = {logBF:F2}"");
+Console.WriteLine($""BF = {BF:F2}"");
+
+string interpretation;
+if (Math.Abs(logBF) < 1) interpretation = ""Evidence negligeable"";
+else if (Math.Abs(logBF) < 2) interpretation = ""Evidence substantielle"";
+else if (Math.Abs(logBF) < 3) interpretation = ""Evidence forte"";
+else interpretation = ""Evidence tres forte/decisive"";
+
+string favori = logBF > 0 ? ""Modele 1 (1 gaussienne)"" : ""Modele 2 (melange)"";
+Console.WriteLine($""\n{interpretation} en faveur de : {favori}"");",,,,,,,,3e06a4cfdca38eee,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,2zz6zocoea7,markdown,fr,4c8bdd06ca560d37,"### Interprétation du facteur de Bayes
+
+**Résultat** : log(BF) = 3.14, BF ≈ 23
+
+Selon l'échelle de Jeffreys, un BF de 23 représente une **evidence forte** (entre 10 et 30) en faveur du modèle 1.
+
+**Pourquoi le modèle simple gagne-t-il ?**
+
+Les données {13, 15, 17, 14, 16, 15, 18} sont **unimodales** avec moyenne ~15.3. Le modèle à 2 gaussiennes :
+1. Introduit des paramètres inutiles (2 moyennes, poids du mélange)
+2. Ces paramètres doivent être ""expliqués"" par le prior
+3. Le prior ""dilue"" la vraisemblance sur un espace plus grand
+
+C'est le **rasoir d'Occam bayésien** en action : à ajustement égal, le modèle simple est préféré car il fait des prédictions plus ""concentrées"".
+
+> **Formule intuitive** : Evidence ≈ (vraisemblance) × (volume du prior utilisé) / (volume total du prior)",,,,,,,,4c8bdd06ca560d37,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,c8ddb475,markdown,fr,9566104ff2d883a1,"## 5. Selection du Nombre de Composantes
+
+### Application
+
+Determiner le nombre optimal de composantes dans un modele de melange.",,,,,,,,9566104ff2d883a1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,uv9cebrgw1,markdown,fr,828beb08900b612d,"### Donnees bimodales : quand le modele complexe gagne
+
+Les donnees precedentes etaient unimodales (autour de 15). Testons maintenant avec des donnees **clairement bimodales** : deux groupes bien separes autour de 6 et 15.
+
+**Question** : Le modele a 2 composantes va-t-il maintenant etre prefere ?
+
+L'algorithme compare systematiquement 1 vs 2 composantes en calculant l'evidence de chaque modele.",,,,,,,,828beb08900b612d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,eda97cef,code,fr,b20d45418341fddf,"// Donnees bimodales
+double[] dataBimodal = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };
+int nBi = dataBimodal.Length;
+
+Console.WriteLine(""=== Selection du nombre de composantes ==="");
+Console.WriteLine($""Donnees : {string.Join("", "", dataBimodal)}\n"");
+
+// Test avec 1, 2, 3 composantes
+double[] logEvidences = new double[3];
+
+// 1 composante
+{
+    Variable<bool> ev = Variable.Bernoulli(0.5);
+    using (Variable.If(ev))
+    {
+        Variable<double> m = Variable.GaussianFromMeanAndPrecision(10, 0.01);
+        Variable<double> p = Variable.GammaFromShapeAndScale(2, 0.5);
+        foreach (var d in dataBimodal)
+        {
+            Variable<double> o = Variable.GaussianFromMeanAndPrecision(m, p);
+            o.ObservedValue = d;
+        }
+    }
+    var eng = new InferenceEngine();
+    eng.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    logEvidences[0] = eng.Infer<Bernoulli>(ev).LogOdds;
+}
+
+Console.WriteLine($""1 composante : log evidence = {logEvidences[0]:F2}"");
+
+// 2 composantes - simplifie
+{
+    Variable<bool> ev = Variable.Bernoulli(0.5);
+    using (Variable.If(ev))
+    {
+        Variable<double> m1 = Variable.GaussianFromMeanAndPrecision(6, 0.1);
+        Variable<double> m2 = Variable.GaussianFromMeanAndPrecision(15, 0.1);
+        Variable<double> p = Variable.GammaFromShapeAndScale(2, 1);
+        Variable<double> w = Variable.Beta(1, 1);
+        
+        foreach (var d in dataBimodal)
+        {
+            Variable<bool> c = Variable.Bernoulli(w);
+            Variable<double> o = Variable.New<double>();
+            using (Variable.If(c)) { o.SetTo(Variable.GaussianFromMeanAndPrecision(m1, p)); }
+            using (Variable.IfNot(c)) { o.SetTo(Variable.GaussianFromMeanAndPrecision(m2, p)); }
+            o.ObservedValue = d;
+        }
+    }
+    var eng = new InferenceEngine(new VariationalMessagePassing());
+    eng.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    logEvidences[1] = eng.Infer<Bernoulli>(ev).LogOdds;
+}
+
+Console.WriteLine($""2 composantes : log evidence = {logEvidences[1]:F2}"");
+
+// Meilleur modele
+int meilleur = logEvidences[0] > logEvidences[1] ? 1 : 2;
+Console.WriteLine($""\n=> Le modele a {meilleur} composante(s) est prefere"");",,,,,,,,b20d45418341fddf,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,8z4v08m86qg,markdown,fr,88382073e94659f5,"### Analyse des resultats : donnees bimodales
+
+**Donnees** : deux groupes distincts autour de 6 et 15
+
+| Modele | Log evidence | Interpretation |
+|--------|--------------|----------------|
+| 1 composante | -45.89 | Mal adapte (moyenne ~10.5 ne represente aucun groupe) |
+| 2 composantes | -31.35 | Bien adapte (capture les deux modes) |
+
+**Difference** : log(BF) = -31.35 - (-45.89) = 14.54
+
+Un facteur de Bayes $e^{14.54} \approx 2 \times 10^6$ en faveur du modele a 2 composantes constitue une evidence **decisive**.
+
+> **Lecon cle** : Le facteur de Bayes detecte automatiquement la structure des donnees. Il prefere le modele simple quand les donnees sont simples (section 3-4) et le modele complexe quand les donnees l'exigent (ici).",,,,,,,,88382073e94659f5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,4abedeba,markdown,fr,00618b0fef580401,"## 6. Automatic Relevance Determination (ARD)
+
+### Principe
+
+ARD utilise des priors hierarchiques pour determiner automatiquement quelles features sont pertinentes.
+
+### Modele
+
+$$\alpha_f \sim \text{Gamma}(a, b)$$
+$$w_f \sim \mathcal{N}(0, \alpha_f^{-1})$$
+
+Si $\alpha_f$ devient grand, le poids $w_f$ est contraint pres de 0 -> feature non pertinente.",,,,,,,,00618b0fef580401,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,byqokwwe3av,markdown,fr,0bf1acf944bc6144,"### Transition : de la comparaison de modeles a la selection de features
+
+Jusqu'ici, nous avons compare des **modeles entiers** (1 vs 2 gaussiennes, lineaire vs quadratique). Mais en pratique, on veut souvent repondre a une question plus fine :
+
+**Quelles features sont vraiment utiles dans mon modele ?**
+
+C'est le probleme de la **selection de variables**. L'approche bayesienne offre une solution elegante : l'**Automatic Relevance Determination** (ARD).",,,,,,,,0bf1acf944bc6144,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,99fn0bnvoyc,markdown,fr,7e74d13ae0541021,"### Generation des donnees synthetiques
+
+Nous creons un probleme de regression ou :
+- **Feature 1** : coefficient reel = 2.0 (pertinente)
+- **Feature 2** : coefficient reel = 0.0 (non pertinente)
+- **Feature 3** : coefficient reel = 3.0 (pertinente)
+
+Le modele ARD devra ""decouvrir"" automatiquement que la feature 2 n'apporte aucune information predictive.",,,,,,,,7e74d13ae0541021,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,e4467883,code,fr,21810de26e262047,"// ARD pour regression
+
+// Donnees : y = 2*x1 + 0*x2 + 3*x3 + bruit
+// x2 est une feature non pertinente
+int nSamples = 20;
+int nFeatures = 3;
+Random rng = new Random(42);
+
+double[,] X = new double[nSamples, nFeatures];
+double[] y = new double[nSamples];
+double[] vraisPoids = { 2.0, 0.0, 3.0 };  // x2 a poids 0
+
+for (int i = 0; i < nSamples; i++)
+{
+    for (int f = 0; f < nFeatures; f++)
+    {
+        X[i, f] = rng.NextDouble() * 2 - 1;  // [-1, 1]
+    }
+    y[i] = vraisPoids[0] * X[i, 0] + vraisPoids[1] * X[i, 1] + vraisPoids[2] * X[i, 2]
+           + rng.NextDouble() * 0.5 - 0.25;  // Bruit
+}
+
+Console.WriteLine(""=== ARD : Automatic Relevance Determination ==="");
+Console.WriteLine($""\nVrais poids : w1={vraisPoids[0]}, w2={vraisPoids[1]} (non pertinent), w3={vraisPoids[2]}"");",,,,,,,,21810de26e262047,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,h9z45ebt0u,markdown,fr,68c37719ed54bfdc,"### Construction du modele ARD hierarchique
+
+Le modele ARD introduit un **hyperparametre de precision** $\alpha_f$ pour chaque feature $f$ :
+
+$$w_f \sim \mathcal{N}(0, \alpha_f^{-1})$$
+
+**Interpretation** :
+- Si $\alpha_f$ est petit (ex: 0.3), la variance $1/\alpha_f$ est grande, donc $w_f$ peut prendre des valeurs significatives
+- Si $\alpha_f$ devient grand (ex: 10), la variance est petite, $w_f$ est ""pousse"" vers 0
+
+Les $\alpha_f$ sont eux-memes des variables aleatoires avec prior `Gamma(1, 1)`. L'inference determine simultanement les poids et leur pertinence.",,,,,,,,68c37719ed54bfdc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,f5337822,code,fr,693861555564cb63,"// Modele ARD
+Range sampleRange = new Range(nSamples).Named(""sample"");
+Range featureRange = new Range(nFeatures).Named(""feature"");
+
+// Precisions par feature (ARD)
+VariableArray<double> alpha = Variable.Array<double>(featureRange).Named(""alpha"");
+alpha[featureRange] = Variable.GammaFromShapeAndScale(1, 1).ForEach(featureRange);
+
+// Poids avec prior dependant de alpha
+VariableArray<double> poids = Variable.Array<double>(featureRange).Named(""poids"");
+using (Variable.ForEach(featureRange))
+{
+    poids[featureRange] = Variable.GaussianFromMeanAndPrecision(0, alpha[featureRange]);
+}
+
+// Bruit de l'observation
+Variable<double> noisePrecision = Variable.GammaFromShapeAndScale(2, 1).Named(""noise"");
+
+// Donnees
+VariableArray2D<double> xVar = Variable.Array<double>(sampleRange, featureRange).Named(""x"");
+VariableArray<double> yVar = Variable.Array<double>(sampleRange).Named(""y"");
+
+using (Variable.ForEach(sampleRange))
+{
+    Variable<double> prediction = Variable.Constant(0.0);
+    for (int f = 0; f < nFeatures; f++)
+    {
+        prediction = prediction + poids[f] * xVar[sampleRange, f];
+    }
+    yVar[sampleRange] = Variable.GaussianFromMeanAndPrecision(prediction, noisePrecision);
+}
+
+xVar.ObservedValue = X;
+yVar.ObservedValue = y;
+
+InferenceEngine moteurARD = new InferenceEngine(new ExpectationPropagation());
+moteurARD.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurARD.ShowFactorGraph = true;  // Activation de la visualisation
+
+Gaussian[] poidsPost = moteurARD.Infer<Gaussian[]>(poids);
+Gamma[] alphaPost = moteurARD.Infer<Gamma[]>(alpha);
+
+Console.WriteLine(""\nResultats ARD :"");
+for (int f = 0; f < nFeatures; f++)
+{
+    double wMean = poidsPost[f].GetMean();
+    double wStd = Math.Sqrt(poidsPost[f].GetVariance());
+    double alphaMean = alphaPost[f].GetMean();
+    string relevance = alphaMean > 5 ? ""faible"" : alphaMean > 1 ? ""moyenne"" : ""haute"";
+    Console.WriteLine($""  Feature {f+1} : poids = {wMean:F2} +/- {wStd:F2}, alpha = {alphaMean:F2} (pertinence {relevance})"");
+}
+
+Console.WriteLine(""\n=> Les features avec alpha eleve sont considerees non pertinentes"");",,,,,,,,693861555564cb63,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,b5f97e90,markdown,fr,e82394862ec21982,Visualisation du graphe de facteurs du modele ARD.,,,,,,,,e82394862ec21982,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,gwxh8zq2zlr,code,fr,7b5d92408327a47d,"// Visualisation du graphe de facteurs - Modele ARD
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,7b5d92408327a47d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,r9agb9kd81,markdown,fr,f7be0ce1cbdad23c,"### Lecture du graphe de facteurs - Modele ARD hierarchique
+
+Le graphe ARD illustre la structure hierarchique a deux niveaux :
+
+**Niveau hyperparametres** :
+- **alpha[feature]** : precision par feature (hyperparametre Gamma)
+- Le prior sur `alpha` controle la ""force"" de la regularisation
+
+**Niveau parametres** :
+- **poids[feature]** : poids de regression, chacun avec une precision `alpha[f]` differente
+- Les poids sont couples : `poids[f] ~ N(0, 1/alpha[f])`
+
+**Niveau donnees** :
+- **x[sample, feature]** : matrice des features (observee)
+- **y[sample]** : cible (observee)
+- **noise** : precision du bruit (infere)
+
+La structure ""plate notation"" avec `ForEach` cree des repetitions sur les ranges `sample` et `feature`, representees par des boites dans le graphe.",,,,,,,,f7be0ce1cbdad23c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,xdkmdixf5b,markdown,fr,07ea08d83aa1cd0e,"### Analyse des résultats ARD
+
+**Comparaison vrais poids vs estimations** :
+
+| Feature | Vrai poids | Estimé | α estimé | Pertinence |
+|---------|------------|--------|----------|------------|
+| 1 | **2.0** | 2.04 | 0.49 | Haute ✓ |
+| 2 | **0.0** | 0.02 | 1.49 | Moyenne |
+| 3 | **3.0** | 2.97 | 0.28 | Haute ✓ |
+
+**Interprétation des hyperparamètres α** :
+- **α petit** (< 1) → le prior sur w est large → w peut prendre des valeurs significatives → feature pertinente
+- **α grand** (> 1) → le prior sur w est concentré autour de 0 → w contraint à ~0 → feature non pertinente
+
+**Pourquoi Feature 2 n'a pas α très élevé ?**
+
+Avec seulement 20 échantillons, le modèle reste incertain. α = 1.49 indique une pertinence ""moyenne"" plutôt que clairement nulle. Plus de données augmenteraient α pour cette feature.
+
+> **Application pratique** : ARD est utilisé en machine learning pour la **sélection automatique de features** sans validation croisée explicite.",,,,,,,,07ea08d83aa1cd0e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,ca7ba69f,markdown,fr,c5bfafe64b15c4ac,"## Exercice : ARD avec 5 features -- quelles features sont pertinentes ?
+
+L'exemple precedent montrait l'ARD avec 3 features (dont 1 non pertinente). Dans cet exercice, vous allez appliquer l'ARD a un probleme plus realiste avec **5 features**, dont seulement **2 sont reellement informatives**.
+
+### Enonce
+
+On genere des donnees synthetiques selon :
+
+$$y = 1.5 \cdot x_1 + 0 \cdot x_2 + 0 \cdot x_3 + 2.5 \cdot x_4 + 0 \cdot x_5 + \epsilon$$
+
+Seules les features 1 et 4 contribuent a la prediction. Les features 2, 3 et 5 sont du bruit.
+
+**Travail demande** :
+1. Generez les donnees avec `nSamples = 30` et `nFeatures = 5` (seed 42)
+2. Construisez le modele ARD hierarchique (reutilisez la structure de la section 6)
+3. Lancez l'inference et affichez les poids posterieurs et les valeurs alpha pour chaque feature
+4. Identifiez quelles features sont selectionnees (alpha faible = pertinente)
+5. Comparez les poids estimes avec les vrais poids : {1.5, 0.0, 0.0, 2.5, 0.0}
+
+> **Indice** : Avec plus de features (5 vs 3) et plus de donnees (30 vs 20), les alpha des features non pertinentes devraient etre plus eleves qu'avec 3 features, car le modele a plus d'information pour distinguer le signal du bruit. Utilisez le meme prior `Gamma(1, 1)` sur les alpha et `ExpectationPropagation` pour l'inference.",,,,,,,,c5bfafe64b15c4ac,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,708fb9d2,code,fr,0988906e00db01ee,"// Exercice : ARD avec 5 features
+
+// TODO: Etape 1 - Generer les donnees synthetiques
+int nSamplesARD = 30;
+int nFeaturesARD = 5;
+double[] vraisPoidsARD = { 1.5, 0.0, 0.0, 2.5, 0.0 };
+double[,] XARD = new double[nSamplesARD, nFeaturesARD];  // TODO: remplir avec Random(42)
+double[] yARD = new double[nSamplesARD];                  // TODO: calculer y = sum(w_f * x_f) + bruit
+
+// TODO: Etape 2 - Construire le modele ARD hierarchique
+// Range sampleRangeARD = new Range(nSamplesARD);
+// Range featureRangeARD = new Range(nFeaturesARD);
+// VariableArray<double> alphaARD = ...  (Gamma prior par feature)
+// VariableArray<double> poidsARD = ... (Gaussian avec precision alphaARD)
+// Variable<double> noiseARD = ...      (Gamma prior sur bruit)
+// Relation: y = sum(poids[f] * x[f])
+
+// TODO: Etape 3 - Inference avec ExpectationPropagation
+
+// TODO: Etape 4 - Afficher les resultats
+// Console.WriteLine(""=== Resultats ARD (5 features) ==="");
+// Pour chaque feature : afficher poids moyen, ecart-type, alpha, pertinence
+
+// TODO: Etape 5 - Comparer avec les vrais poids et conclure
+// Quelles features ont ete correctement identifiees comme pertinentes/non pertinentes ?
+
+Console.WriteLine(""Exercice a completer"");",,,,,,,,0988906e00db01ee,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,09b71176,markdown,fr,da4b7ea2f5e4a438,"## 7. Validation Croisee Bayesienne
+
+### Principe
+
+Au lieu de diviser les donnees, utiliser la predictive posterieure pour evaluer le modele.
+
+### Leave-One-Out (LOO)
+
+$$\text{LOO-CV} = \sum_{i=1}^n \log P(y_i | y_{-i}, M)$$",,,,,,,,da4b7ea2f5e4a438,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,vra9u39ies8,markdown,fr,4dc1d268ab9753aa,"### Algorithme Leave-One-Out bayesien
+
+Pour chaque point $i$ :
+1. **Entrainer** le modele sur tous les points sauf $i$
+2. **Calculer** la distribution predictive posterieure
+3. **Evaluer** la log-probabilite du point $i$ sous cette predictive
+
+La **variance predictive** combine deux sources d'incertitude :
+- L'incertitude sur la moyenne ($\text{Var}(\mu)$)
+- Le bruit inherent des observations ($1/\tau$)
+
+$$\sigma^2_{\text{pred}} = \text{Var}(\mu) + \frac{1}{\mathbb{E}[\tau]}$$",,,,,,,,4dc1d268ab9753aa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,e03f2af1,code,fr,039cd97142967450,"// Validation LOO simplifiee
+
+double[] dataLOO = { 10, 12, 11, 13, 12, 11, 14, 10, 12, 11 };
+int nLOO = dataLOO.Length;
+
+double totalLogPred = 0;
+
+for (int i = 0; i < nLOO; i++)
+{
+    // Entrainer sur toutes les donnees sauf i
+    Variable<double> mu = Variable.GaussianFromMeanAndPrecision(10, 0.01);
+    Variable<double> prec = Variable.GammaFromShapeAndScale(2, 0.5);
+    
+    for (int j = 0; j < nLOO; j++)
+    {
+        if (j != i)
+        {
+            Variable<double> obs = Variable.GaussianFromMeanAndPrecision(mu, prec);
+            obs.ObservedValue = dataLOO[j];
+        }
+    }
+    
+    InferenceEngine eng = new InferenceEngine();
+    eng.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    
+    Gaussian muPost = eng.Infer<Gaussian>(mu);
+    Gamma precPost = eng.Infer<Gamma>(prec);
+    
+    // Probabilite predictive pour le point i
+    double predMean = muPost.GetMean();
+    double predVar = muPost.GetVariance() + 1.0 / precPost.GetMean();
+    
+    double logProb = Gaussian.FromMeanAndVariance(predMean, predVar).GetLogProb(dataLOO[i]);
+    totalLogPred += logProb;
+}
+
+Console.WriteLine(""=== Validation Leave-One-Out ==="");
+Console.WriteLine($""\nLog predictive totale : {totalLogPred:F2}"");
+Console.WriteLine($""Log predictive moyenne : {totalLogPred / nLOO:F2}"");",,,,,,,,039cd97142967450,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,r1j8wn479sc,markdown,fr,90485006bb11cc1e,"### Interpretation de la validation LOO
+
+**Log predictive moyenne = -1.81**
+
+Cette metrique mesure la capacite du modele a predire des observations non vues. Comparons avec des references :
+
+| Log predictive moyenne | Qualite du modele |
+|------------------------|-------------------|
+| > -1.0 | Excellente |
+| -1.0 a -2.0 | Bonne |
+| -2.0 a -3.0 | Acceptable |
+| < -3.0 | Mauvaise |
+
+Notre valeur de -1.81 indique une **bonne** capacite predictive.
+
+> **Avantage du LOO bayesien** : Contrairement au LOO classique, cette methode :
+> - Utilise l'incertitude complete (pas juste une estimation ponctuelle)
+> - Tient compte de l'incertitude sur les parametres via la variance predictive
+> - Ne necessite pas de reentrainer completement le modele (en theorie, via des approximations)",,,,,,,,90485006bb11cc1e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,292e1625,markdown,fr,8c334dec596bce32,"## Exercice : Selection de modele par validation croisee LOO
+
+Dans cette section, vous avez vu la validation Leave-One-Out pour un modele gaussien simple. L'objectif de cet exercice est d'**etendre cette approche pour comparer deux modeles** sur les memes donnees, et de verifier si le resultat LOO est coherent avec le facteur de Bayes.
+
+### Enonce
+
+On considere les donnees bimodales de la section 5 :
+
+```csharp
+double[] dataEx = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };
+```
+
+**Modele A** : Une seule gaussienne $y \sim \mathcal{N}(\mu, \tau^{-1})$ avec priors :
+- $\mu \sim \mathcal{N}(10, 100)$ (moyenne vague)
+- $\tau \sim \text{Gamma}(2, 0.5)$
+
+**Modele B** : Melange de deux gaussiennes (meme structure que la section 5).
+
+**Travail demandé** :
+1. Implementez la validation LOO pour le **Modele A** (une gaussienne)
+2. Implementez la validation LOO pour le **Modele B** (melange de deux gaussiennes) - utilisez `VariationalMessagePassing`
+3. Comparez les scores LOO totaux : quel modele est prefere ?
+4. Comparez avec le resultat du facteur de Bayes de la section 5 : les deux methodes donnent-elles le meme gagnant ?
+
+> **Indice** : Pour le Modele B dans la boucle LOO, vous devez recreer le modele de melange complet a chaque iteration (en retirant le point i). La distribution predictive posterieure d'un melange n'est pas gaussienne -- utilisez `GetMean()` et `GetVariance()` sur le resultat `Gaussian` inferé pour chaque point laisse de cote.",,,,,,,,8c334dec596bce32,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,fcfdca03,code,fr,8e62cbd065a2e576,"// Exercice : Selection de modele par validation croisee LOO
+
+double[] dataEx = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };
+int nEx = dataEx.Length;
+
+// TODO: Etape 1 - Implementer LOO pour le Modele A (1 gaussienne)
+// Pour chaque point i, entrainer sur dataEx sans le point i, calculer log P(dataEx[i])
+double totalLogPredA = 0;
+
+// TODO: Boucle LOO Modele A
+
+Console.WriteLine($""Modele A - LOO total : {totalLogPredA:F2}"");
+
+// TODO: Etape 2 - Implementer LOO pour le Modele B (melange 2 gaussiennes)
+// Utilisez VariationalMessagePassing pour la stabilite
+double totalLogPredB = 0;
+
+// TODO: Boucle LOO Modele B
+// Indice : pour chaque iteration, recreer le melange complet sans le point i
+// puis inferer la posteriorie et evaluer la log-probabilite du point laisse de cote
+
+Console.WriteLine($""Modele B - LOO total : {totalLogPredB:F2}"");
+
+// TODO: Etape 3 - Comparer les resultats
+Console.WriteLine(""\n=== Comparaison LOO ==="");
+// Quel modele est prefere par LOO ?
+// Est-ce coherent avec le facteur de Bayes de la section 5 (2 composantes preferees) ?
+
+Console.WriteLine(""Exercice a completer"");",,,,,,,,8e62cbd065a2e576,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,3c3ea47c,markdown,fr,9d06ce53fa30f6a5,"## Exercice : Comparer les criteres BIC et evidence approximee
+
+Dans les sections precedentes, nous avons utilise l'evidence exacte (marginal likelihood) calculee par Infer.NET pour comparer des modeles. En pratique, l'evidence exacte est souvent incalculable et on utilise des **approximations** comme le BIC (Bayesian Information Criterion).
+
+### Enonce
+
+Le BIC est defini par :
+
+$$\text{BIC} = -2 \ln(\hat{L}) + k \ln(n)$$
+
+ou $\hat{L}$ est la vraisemblance maximale, $k$ le nombre de parametres et $n$ le nombre d'observations. Un BIC plus faible indique un meilleur modele.
+
+On reprend les donnees bimodales de la section 5 :
+```csharp
+double[] dataBIC = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };
+```
+
+**Travail demande** :
+1. Pour le modele a 1 gaussienne, calculez le BIC en estimant mu et tau par maximum de vraisemblance (moyenne empirique et variance inverse)
+2. Pour le modele a 2 gaussiennes, utilisez les posteriors Infer.NET de la section 5 comme approximation du MLE, puis calculez le BIC (k = 5 parametres : mu1, mu2, tau, poids, + 1 bruit)
+3. Comparez les classements BIC vs facteur de Bayes : les deux methodes selectionnent-elles le meme modele ?
+4. Affichez un tableau comparatif : `| Critere | Modele 1 | Modele 2 | Gagnant |`
+
+> **Indice** : Pour le BIC du modele a 1 gaussienne, $k=2$ (mu + tau). La log-vraisemblance se calcule en sommant `Gaussian.FromMeanAndPrecision(mu_hat, tau_hat).GetLogProb(dataBIC[i])` pour chaque point. Pour le modele a 2 gaussiennes, $k=5$ (mu1, mu2, tau, poids + variance commune). Le BIC penalise davantage les modeles complexes que le facteur de Bayes -- observez si la penalite change le gagnant.",,,,,,,,9d06ce53fa30f6a5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,c38f2060,code,fr,6a9a7857f679c66f,"// Exercice : Comparer les criteres BIC et evidence approximee
+
+double[] dataBIC = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };
+int nBIC = dataBIC.Length;
+
+// TODO: Etape 1 - Calculer le BIC pour le modele a 1 gaussienne (k=2)
+// Estimer mu_hat = moyenne empirique, tau_hat = 1 / variance empirique
+// Puis BIC = -2 * sum(log P(x_i | mu_hat, tau_hat)) + k * ln(n)
+double bicModele1 = 0;
+
+// Indice : double muHat = dataBIC.Average();
+// Indice : double varHat = dataBIC.Select(x => (x - muHat) * (x - muHat)).Sum() / nBIC;
+// Indice : double tauHat = 1.0 / varHat;
+// Indice : double logLik = dataBIC.Sum(x => Gaussian.FromMeanAndPrecision(muHat, tauHat).GetLogProb(x));
+// Indice : bicModele1 = -2 * logLik + 2 * Math.Log(nBIC);
+
+Console.WriteLine($""Modele 1 (1 gaussienne) - BIC : {bicModele1:F2}"");
+
+// TODO: Etape 2 - Calculer le BIC pour le modele a 2 gaussiennes (k=5)
+// Utilisez les posteriors de la section 5 ou estimez par MLE
+double bicModele2 = 0;
+
+// Indice : k=5 parametres (mu1, mu2, tau, poids, variance)
+// Indice : Pour chaque point, la vraisemblance est P(x_i) = w * N(x_i|mu1,tau) + (1-w) * N(x_i|mu2,tau)
+// Indice : log P(x_i) = log(w * exp(logN1) + (1-w) * exp(logN2))
+
+Console.WriteLine($""Modele 2 (2 gaussiennes) - BIC : {bicModele2:F2}"");
+
+// TODO: Etape 3 - Comparer BIC vs facteur de Bayes
+Console.WriteLine(""\n=== Comparaison BIC vs Facteur de Bayes ==="");
+// Indice : Le facteur de Bayes de la section 5 favorisait le modele a 2 composantes (log BF ~ 14.5)
+// Indice : Le BIC favorise-t-il le meme modele ? Si oui, les deux methodes sont coherentes.
+// Indice : Si non, expliquez pourquoi (taille d'echantillon, approximation BIC, etc.)
+
+// TODO: Etape 4 - Afficher le tableau comparatif
+// | Critere              | Modele 1 | Modele 2 | Gagnant    |
+// |----------------------|----------|----------|------------|
+// | BIC (plus petit=mieux)| ...     | ...      | ...        |
+// | log Evidence          | -45.89  | -31.35   | Modele 2   |
+
+Console.WriteLine(""Exercice a completer"");",,,,,,,,6a9a7857f679c66f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,d90f5f02,markdown,fr,68aa1d949e6c419c,"## 8. Exemple guide : Comparer Polynomes
+
+### Enonce
+
+Comparez trois modeles de regression :
+- Lineaire : y = a*x + b
+- Quadratique : y = a*x^2 + b*x + c
+- Cubique : y = a*x^3 + b*x^2 + c*x + d
+
+Sur des donnees lineaires avec bruit.",,,,,,,,68aa1d949e6c419c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,h3k6kjvamho,markdown,fr,c5a7cf24cf557673,"### Mise en pratique : comparaison lineaire vs quadratique
+
+Les donnees sont generees selon $y = 2x + 1 + \epsilon$ (relation lineaire).
+
+**Modeles a comparer** :
+- **Lineaire** : $y = ax + b$ (2 parametres)
+- **Quadratique** : $y = ax^2 + bx + c$ (3 parametres)
+
+Le modele quadratique peut representer la relation lineaire (avec $a \approx 0$), mais paie un ""cout de complexite"" pour ce parametre inutile.
+
+> **Hint** : Pour ajouter un modele cubique, il suffirait d'ajouter un terme $d \times x^3$. Le meme raisonnement s'applique : plus de parametres = plus de penalite si ils ne sont pas necessaires.",,,,,,,,c5a7cf24cf557673,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,2e5bf6cf,code,fr,2082cb52bba0e2fe,"// Exemple guide : Comparaison de modeles polynomiaux
+
+// Donnees lineaires : y = 2*x + 1 + bruit
+double[] xPoly = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+double[] yPoly = { 1.2, 3.1, 4.8, 7.2, 8.9, 11.1, 13.0, 14.8, 17.2, 19.1 };
+int nPoly = xPoly.Length;
+
+Console.WriteLine(""=== Comparaison de Modeles Polynomiaux ==="");
+Console.WriteLine(""Vraie relation : y = 2*x + 1\n"");
+
+// Modele lineaire
+Variable<bool> evLin = Variable.Bernoulli(0.5).Named(""evidence_lin"");
+using (Variable.If(evLin))
+{
+    Variable<double> a = Variable.GaussianFromMeanAndVariance(0, 10).Named(""a_lin"");
+    Variable<double> b = Variable.GaussianFromMeanAndVariance(0, 10).Named(""b_lin"");
+    Variable<double> noise = Variable.GammaFromShapeAndScale(2, 0.5).Named(""noise_lin"");
+    
+    for (int i = 0; i < nPoly; i++)
+    {
+        Variable<double> pred = (a * xPoly[i] + b).Named($""pred_lin_{i}"");
+        Variable<double> obs = Variable.GaussianFromMeanAndPrecision(pred, noise).Named($""obs_lin_{i}"");
+        obs.ObservedValue = yPoly[i];
+    }
+}
+var engLin = new InferenceEngine();
+engLin.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+engLin.ShowFactorGraph = true;  // Activation de la visualisation
+double logEvLin = engLin.Infer<Bernoulli>(evLin).LogOdds;
+Console.WriteLine($""Modele lineaire : log evidence = {logEvLin:F2}"");
+
+// Modele quadratique
+Variable<bool> evQuad = Variable.Bernoulli(0.5).Named(""evidence_quad"");
+using (Variable.If(evQuad))
+{
+    Variable<double> a = Variable.GaussianFromMeanAndVariance(0, 10).Named(""a_quad"");
+    Variable<double> b = Variable.GaussianFromMeanAndVariance(0, 10).Named(""b_quad"");
+    Variable<double> c = Variable.GaussianFromMeanAndVariance(0, 10).Named(""c_quad"");
+    Variable<double> noise = Variable.GammaFromShapeAndScale(2, 0.5).Named(""noise_quad"");
+    
+    for (int i = 0; i < nPoly; i++)
+    {
+        Variable<double> pred = (a * xPoly[i] * xPoly[i] + b * xPoly[i] + c).Named($""pred_quad_{i}"");
+        Variable<double> obs = Variable.GaussianFromMeanAndPrecision(pred, noise).Named($""obs_quad_{i}"");
+        obs.ObservedValue = yPoly[i];
+    }
+}
+var engQuad = new InferenceEngine();
+engQuad.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+engQuad.ShowFactorGraph = true;  // Activation de la visualisation
+double logEvQuad = engQuad.Infer<Bernoulli>(evQuad).LogOdds;
+Console.WriteLine($""Modele quadratique : log evidence = {logEvQuad:F2}"");
+
+// Meilleur modele
+string meilleurMod = logEvLin > logEvQuad ? ""Lineaire"" : ""Quadratique"";
+Console.WriteLine($""\n=> Le modele {meilleurMod} est prefere (rasoir d'Occam)"");",,,,,,,,2082cb52bba0e2fe,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,a10ac5c7,markdown,fr,d4795f61cb702630,Visualisation du graphe de facteurs du modele polynomial.,,,,,,,,d4795f61cb702630,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,07c3mhq0k60l,code,fr,ebbacc089b0f0c7e,"// Visualisation du graphe de facteurs - Modele quadratique (dernier compile)
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,ebbacc089b0f0c7e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,kmporu069ea,markdown,fr,642c4d37f705d637,"### Lecture du graphe de facteurs - Modele quadratique
+
+Le graphe montre la structure du modele quadratique $y = ax^2 + bx + c$ :
+
+- **a_quad, b_quad, c_quad** : les trois coefficients du polynome (priors Gaussiens)
+- **noise_quad** : precision du bruit d'observation (prior Gamma)
+- **evidence_quad** : variable indicatrice pour le calcul d'evidence
+- **pred_quad_i** : predictions intermediaires (combinaison des coefficients)
+- **obs_quad_i** : observations (valeurs fixees)
+
+Comparativement au modele lineaire, ce graphe contient un parametre supplementaire (`c_quad`), ce qui augmente la complexite du modele et la ""surface"" du prior - d'ou la penalisation par le rasoir d'Occam bayesien.",,,,,,,,642c4d37f705d637,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,h3advals0x,markdown,fr,17f04e1bd4c7d3ed,"### Analyse de l'exercice polynomes
+
+**Resultats** :
+
+| Modele | Parametres | Log evidence |
+|--------|------------|--------------|
+| Lineaire | a, b (2) | -14.03 |
+| Quadratique | a, b, c (3) | -20.28 |
+
+**Facteur de Bayes** : $\exp(-14.03 - (-20.28)) = \exp(6.25) \approx 518$
+
+Le modele lineaire est **decisement** prefere (BF > 150).
+
+**Pourquoi le modele quadratique perd-il ?**
+
+1. **Donnees generees lineairement** : y = 2x + 1 + bruit
+2. **Coefficient quadratique inutile** : le parametre $a$ (coefficient de $x^2$) n'apporte rien
+3. **Penalite de complexite** : le prior sur $a$ ""dilue"" la vraisemblance
+
+> **Exercice supplementaire** : Que se passerait-il si les donnees etaient generees par y = 0.1*x^2 + 2*x + 1 ? Le terme quadratique est present mais faible. Le modele lineaire pourrait encore gagner si le signal quadratique est noye dans le bruit - c'est la balance ajustement vs complexite en action.",,,,,,,,17f04e1bd4c7d3ed,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,ff1f079d,markdown,fr,d4988b0c4020d38b,"## 9. Resume
+
+| Concept | Description |
+|---------|-------------|
+| **Evidence** | P(D\|M) - vraisemblance marginale |
+| **Facteur de Bayes** | Ratio d'evidences pour comparer modeles |
+| **Rasoir d'Occam** | Preference automatique pour modeles simples |
+| **ARD** | Selection automatique de features |
+| **LOO-CV** | Validation sans diviser les donnees |
+
+---
+
+## Prochaine etape
+
+Dans [Infer-11-Topic-Models](Infer-11-Topic-Models.ipynb), nous explorerons :
+
+- Latent Dirichlet Allocation (LDA)
+- Modelisation de topics dans les documents
+- Inference sur structures hierarchiques complexes",,,,,,,,d4988b0c4020d38b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,emyx91kfzua,markdown,fr,1c5272a3452ae0ed,"---
+
+## Annexe : Distributions et concepts
+
+### Distributions utilisees dans ce notebook
+
+| Distribution | Role | Parametres typiques |
+|--------------|------|---------------------|
+| `Bernoulli(0.5)` | Variable indicatrice pour calcul d'evidence | p=0.5 (prior non informatif) |
+| `GaussianFromMeanAndPrecision` | Modele d'observation | mean~15, precision~1 |
+| `GammaFromShapeAndScale` | Prior sur precision | shape=2, scale=0.5 |
+| `Beta(1,1)` | Prior sur proportion de melange | Prior uniforme sur [0,1] |
+
+### Concepts probabilistes illustres
+
+| Concept | Section | Application |
+|---------|---------|-------------|
+| Evidence marginale $P(D\|M)$ | 3, 5 | Comparer modeles sans validation croisee |
+| Facteur de Bayes | 4 | Quantifier la preference pour un modele |
+| Rasoir d'Occam bayesien | 3-5 | Penalisation automatique de la complexite |
+| Priors hierarchiques | 6 | ARD pour selection de features |
+| Distribution predictive | 7 | LOO-CV bayesien |
+
+### Applications pratiques
+
+- **Selection du nombre de composantes** : Clustering avec nombre de clusters inconnu
+- **Selection de features** : Regression avec beaucoup de covariables
+- **Choix d'architecture** : Reseaux bayesiens avec structure variable
+- **Comparaison de familles** : Lineaire vs non-lineaire, parametrique vs non-parametrique",,,,,,,,1c5272a3452ae0ed,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,lzrf27g1xck,markdown,fr,ac8eabdf656f925a,"### Points cles a retenir
+
+**1. Le rasoir d'Occam est automatique**
+
+La selection de modeles bayesienne penalise naturellement la complexite. Pas besoin de criteres ad hoc comme l'AIC ou le BIC - l'evidence marginale fait le travail.
+
+**2. L'echelle compte**
+
+| Methode | Quand l'utiliser |
+|---------|------------------|
+| Facteur de Bayes | Comparer 2-3 modeles distincts |
+| ARD | Selectionner parmi de nombreuses features |
+| LOO-CV | Evaluer la capacite predictive |
+
+**3. Les priors sont importants**
+
+Les priors vagues ($\sigma^2 = 10$ sur les poids) penalisent moins que des priors informatifs. Un mauvais choix de prior peut fausser la comparaison.
+
+> **Conseil pratique** : Pour une comparaison equitable, utilisez des priors de meme ""force"" (meme variance) sur les parametres comparables entre modeles.",,,,,,,,ac8eabdf656f925a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,5251a551,markdown,fr,3e12ec41323abed8,"## 10. Exercice : Trouver le Meilleur Modele pour des Donnees Quadratiques
+
+### Enonce
+
+Vous disposez de donnees generees par `y = 2*x^2 - 3*x + 1 + bruit` :
+
+```
+x = {-2, -1, 0, 1, 2, 3}
+y = {14.8, 5.9, 1.1, -0.2, 3.8, 10.1}
+```
+
+Comparez 3 modeles de regression polynomiale :
+1. **Lineaire** : `y = a*x + b` (2 parametres)
+2. **Quadratique** : `y = a*x^2 + b*x + c` (3 parametres)
+3. **Cubique** : `y = a*x^3 + b*x^2 + c*x + d` (4 parametres)
+
+Quel modele a le meilleur log evidence ? Le cubique surpasse-t-il le quadratique ?",,,,,,,,3e12ec41323abed8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,5fd34a0e,code,fr,636d080dc8564097,"// Exercice : Selection de modele polynomial sur donnees quadratiques
+Console.WriteLine(""Exercice a completer : selection de modele polynomial"");
+
+// Donnees quadratiques : y = 2*x^2 - 3*x + 1 + bruit
+double[] xData = { -2, -1, 0, 1, 2, 3 };
+double[] yData = { 14.8, 5.9, 1.1, -0.2, 3.8, 10.1 };
+
+// TODO: Construire les matrices de features polynomiales
+// Lineaire  : X[i] = [1, x_i]
+// Quadratique: X[i] = [1, x_i, x_i^2]
+// Cubique   : X[i] = [1, x_i, x_i^2, x_i^3]
+// using Microsoft.ML.Probabilistic.Math;
+
+// TODO: Creer une fonction CalculLogEvidence(Vector[] features, double[] y)
+// (Reutilisez la structure de la section 8 de l'exemple guide)
+
+// TODO: Calculer le log evidence pour chaque modele
+
+// TODO: Afficher et comparer
+// Quel modele gagne ? Expliquez pourquoi le cubique ne bat pas forcement le quadratique.",,,,,,,,636d080dc8564097,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb,e35b2088,markdown,fr,90d5dfa64302f024,"## Conclusion
+
+Ce notebook a presente la selection de modeles bayesienne : evidence, facteur de Bayes, ARD et validation croisee LOO.
+
+| Methode | Principe | Quand l'utiliser |
+|---------|----------|------------------|
+| Evidence (marginal likelihood) | P(D\|M) integre sur les parametres | Comparer 2-3 modeles |
+| Facteur de Bayes | Ratio des evidences, echelle de Jeffreys | Quantifier la preference |
+| ARD | Priors hierarchiques Gamma -> precision par feature | Selection automatique de features |
+| LOO-CV | Log-probabilite predictive leave-one-out | Evaluer la capacite predictive |
+
+| Distribution | Role |
+|--------------|------|
+| Bernoulli(0.5) | Variable indicatrice pour le calcul d'evidence |
+| Gaussian | Priors sur les poids et coefficients |
+| Gamma | Priors sur les precisions (bruit, ARD) |
+| Beta | Prior sur les proportions de melange |
+
+> **Rasoir d'Occam bayesien** : L'evidence penalise automatiquement la complexite. Un modele plus simple avec un bon ajustement bat toujours un modele complexe dont les parametres supplementaires n'apportent rien. Cela rend la comparaison objective, sans criteres ad hoc.",,,,,,,,90d5dfa64302f024,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,1452f2aa,markdown,fr,652400ad72f22ce9,"# Infer-11-Topic-Models : Latent Dirichlet Allocation (LDA)
+
+**Serie** : Programmation Probabiliste avec Infer.NET (9/20)  
+**Duree estimee** : 60 minutes  
+**Prerequis** : Infer-8-TrueSkill
+
+---
+
+## Objectifs
+
+- Comprendre le topic modeling et LDA
+- Implementer la structure documents-topics-mots
+- Utiliser les distributions Dirichlet pour les melanges
+- Inferer les topics a partir d'un corpus
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-8-TrueSkill](Infer-8-TrueSkill.ipynb) | [Infer-10-Model-Selection](Infer-10-Model-Selection.ipynb) |
+
+---",,,,,,,,652400ad72f22ce9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,7b2c63fe,markdown,fr,7ffaf8c455890eb0,"## 1. Configuration
+
+Nous preparons l'environnement pour le topic modeling avec LDA (Latent Dirichlet Allocation). Ce modele generatif decouvre automatiquement les themes latents dans un corpus de documents en utilisant des distributions Dirichlet comme priors conjugues.",,,,,,,,7ffaf8c455890eb0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,130cda5e,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,fc6a9eaf,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,i3luanxjpn,code,fr,834a650ebc392078,"// Chargement du helper pour la visualisation des factor graphs
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper charge."");
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,834a650ebc392078,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,jqir8e880bd,markdown,fr,5b2be92c41585dc1,"### Helper pour la visualisation des factor graphs
+
+Le `FactorGraphHelper` permet d'afficher les graphes de facteurs generes par Infer.NET directement dans le notebook. Il utilise Graphviz pour convertir les fichiers `.gv` en images SVG.
+
+**Fonctions principales** :
+- `GetLatestFactorGraphHtml()` : Retourne le HTML du dernier graphe genere
+- `ConfigureEngine(engine)` : Configure un moteur pour generer des graphes
+- `IsGraphvizAvailable()` : Verifie si Graphviz est installe",,,,,,,,5b2be92c41585dc1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,ijnjw99vpqo,markdown,fr,79f8f8e57ed80434,"### Environnement pret
+
+**Packages charges** : Microsoft.ML.Probabilistic et son compilateur
+
+| Namespace | Role dans LDA |
+|-----------|---------------|
+| `Distributions` | Dirichlet, Discrete pour les melanges |
+| `Models` | Variable, VariableArray, Range pour la structure |
+| `Algorithms` | VariationalMessagePassing (VMP) |
+
+> **Note** : Infer.NET utilise VMP (Variational Message Passing) par defaut pour LDA, car l'inference exacte est intractable pour les modeles avec variables latentes discretes.",,,,,,,,79f8f8e57ed80434,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,bd8fcc4e,markdown,fr,91d5db7a19fc77df,"## 2. Introduction au Topic Modeling
+
+### Probleme
+
+Etant donne un corpus de documents, decouvrir les **themes latents** (topics) et la composition de chaque document.
+
+### Applications
+
+- Organisation automatique de documents
+- Recommandation de contenu
+- Analyse de tendances
+- Recherche semantique
+
+### Representation Bag-of-Words
+
+Un document est represente par le compte de chaque mot, ignorant l'ordre.
+
+```
+""Le chat mange la souris"" -> {le: 1, chat: 1, mange: 1, la: 1, souris: 1}
+```",,,,,,,,91d5db7a19fc77df,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,xurlwv3ao4a,markdown,fr,4923f585c6cfd52d,"### Contexte historique
+
+**LDA** (Latent Dirichlet Allocation) a ete introduit par David Blei, Andrew Ng et Michael Jordan en 2003. C'est l'un des modeles de topic modeling les plus influents.
+
+| Annee | Developpement |
+|-------|---------------|
+| 2003 | Publication originale de LDA (Blei, Ng, Jordan) |
+| 2006 | Correlated Topic Model (CTM) |
+| 2006 | Hierarchical Dirichlet Process (HDP) - Teh et al. |
+| 2007 | Online LDA pour corpus massifs |
+| 2010+ | Integration avec deep learning (Topic-RNN, etc.) |
+
+**Pourquoi LDA a revolutionne le domaine** :
+
+1. **Interpretabilite** : Les topics sont des distributions sur des mots humainement lisibles
+2. **Fondements bayesiens** : Gestion naturelle de l'incertitude
+3. **Scalabilite** : Algorithmes d'inference efficaces (variationnel, Gibbs)
+4. **Extensibilite** : Base pour des centaines de variantes",,,,,,,,4923f585c6cfd52d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,b23a7695,markdown,fr,90d3cc0a145c9559,"## 3. Structure LDA
+
+### Modele generatif
+
+Pour chaque document d :
+1. Tirer la distribution de topics : $\theta_d \sim \text{Dirichlet}(\alpha)$
+2. Pour chaque mot w dans d :
+   - Tirer un topic : $z \sim \text{Discrete}(\theta_d)$
+   - Tirer un mot : $w \sim \text{Discrete}(\phi_z)$
+
+Pour chaque topic k :
+- $\phi_k \sim \text{Dirichlet}(\beta)$ : distribution sur le vocabulaire
+
+### Schema
+
+```
+                alpha
+                  |
+                  v
+              theta[d]     (distribution topics par document)
+                  |
+                  v
+               z[d,n]      (topic du mot n dans doc d)
+                  |
+                  v
+               w[d,n]  <-- phi[z]  <-- beta
+          (mot observe)   (dist mots par topic)
+```",,,,,,,,90d3cc0a145c9559,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,vnu6o65v85,markdown,fr,3ed5cc898128b073,"### Intuition mathematique de LDA
+
+**Le prior Dirichlet** : Pour comprendre LDA, il faut d'abord comprendre la distribution Dirichlet.
+
+$$\text{Dirichlet}(\alpha_1, ..., \alpha_K) \propto \prod_{k=1}^{K} x_k^{\alpha_k - 1}$$
+
+**Effet du parametre alpha** :
+
+| Valeur de $\alpha$ | Effet sur $\theta$ | Interpretation |
+|--------------------|-------------------|----------------|
+| $\alpha < 1$ | Sparse (proche des coins) | Documents mono-thematiques |
+| $\alpha = 1$ | Uniforme sur le simplexe | Aucune preference |
+| $\alpha > 1$ | Dense (proche du centre) | Documents multi-thematiques |
+
+**Conjugaison** : La beaute de LDA est que Dirichlet est le prior conjugue de la loi categorique (Discrete). Cela permet une inference efficace :
+
+$$P(\theta \mid \text{mots}) = \text{Dirichlet}(\alpha + \text{comptes})$$
+
+> **Rappel** : Un prior conjugue donne un posterior de la meme famille que le prior, simplifiant considerablement les calculs.",,,,,,,,3ed5cc898128b073,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,80a2fa01,markdown,fr,ed9e8448f3c118ee,"## 4. Implementation LDA Simplifiee
+
+### Specificites de l'implementation Infer.NET
+
+**Pourquoi VMP pour LDA ?**
+
+Infer.NET utilise Variational Message Passing (VMP) qui approxime la distribution posterieure par une famille factorisee :
+
+$$q(\theta, z, \phi) \approx q(\theta) \prod_n q(z_n) \prod_k q(\phi_k)$$
+
+| Algorithme | Avantages | Inconvenients |
+|------------|-----------|---------------|
+| **VMP** (utilise ici) | Rapide, deterministe | Mode local, symetrie |
+| **EP** | Meilleure approximation | Plus lent, moins stable |
+| **Gibbs Sampling** | Explore tout l'espace | Tres lent, diagnostic difficile |
+
+**Points d'attention pour Infer.NET** :
+
+1. `SetValueRange()` est **obligatoire** pour `Variable.Switch()` - sinon erreur de compilation
+2. `Variable.ForEach()` cree une boucle de plaque implicite
+3. Les priors Dirichlet doivent avoir des valeurs > 0 pour eviter des NaN
+
+> **Astuce** : Pour diagnostiquer les problemes de convergence, activez `moteur.ShowMslMessages = true` pour voir les messages VMP.",,,,,,,,ed9e8448f3c118ee,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,793d87d6,code,fr,73dcb2ad5ec2de50,"// Donnees : corpus synthetique
+// Vocabulaire : [sport, equipe, match, politique, election, vote, musique, concert, artiste]
+string[] vocabulaire = { ""sport"", ""equipe"", ""match"", ""politique"", ""election"", ""vote"", ""musique"", ""concert"", ""artiste"" };
+int vocabSize = vocabulaire.Length;
+int numTopics = 3;  // Sport, Politique, Musique
+
+// Documents (indices des mots)
+int[][] documents = {
+    new[] { 0, 1, 2, 0, 2 },           // Doc 1 : sport
+    new[] { 3, 4, 5, 4, 3 },           // Doc 2 : politique
+    new[] { 6, 7, 8, 7, 6 },           // Doc 3 : musique
+    new[] { 0, 1, 3, 4, 0 },           // Doc 4 : sport + politique
+    new[] { 6, 7, 0, 1, 8 },           // Doc 5 : musique + sport
+    new[] { 2, 2, 1, 0, 2 },           // Doc 6 : sport
+    new[] { 5, 4, 3, 5, 4 }            // Doc 7 : politique
+};
+
+int numDocs = documents.Length;
+
+Console.WriteLine(""=== Corpus ==="");
+for (int d = 0; d < numDocs; d++)
+{
+    string mots = string.Join("", "", documents[d].Select(i => vocabulaire[i]));
+    Console.WriteLine($""Doc {d+1} : {mots}"");
+}",,,,,,,,73dcb2ad5ec2de50,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,xlhoqd285ii,markdown,fr,2692d504746cb5fb,"### Analyse du corpus synthetique
+
+**Structure du vocabulaire** : 9 mots repartis en 3 groupes thematiques
+
+| Topic | Indices | Mots |
+|-------|---------|------|
+| Sport | 0, 1, 2 | sport, equipe, match |
+| Politique | 3, 4, 5 | politique, election, vote |
+| Musique | 6, 7, 8 | musique, concert, artiste |
+
+**Types de documents** :
+
+| Document | Type | Description |
+|----------|------|-------------|
+| Doc 1, 2, 3, 6, 7 | **Pur** | Un seul topic dominant |
+| Doc 4, 5 | **Mixte** | Melange de deux topics |
+
+> **Note methodologique** : Ce corpus synthetique a ete concu avec des mots parfaitement separes entre topics. En pratique, les vocabulaires reels ont des mots polysemiques (ex: ""parti"" peut etre politique ou musical) qui compliquent l'inference.",,,,,,,,2692d504746cb5fb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,a307d589,code,fr,2327ac3ff7fba141,"// Modele LDA simplifie (pour un seul document)
+
+// Prior sur les topics (symetrique)
+double[] alphaPrior = Enumerable.Repeat(1.0, numTopics).ToArray();
+
+// Prior sur les mots par topic (symetrique)
+double[] betaPrior = Enumerable.Repeat(1.0, vocabSize).ToArray();
+
+// Distribution des mots par topic (phi)
+Range topicRange = new Range(numTopics).Named(""topic"");
+Range vocabRange = new Range(vocabSize).Named(""vocab"");
+
+VariableArray<Vector> phi = Variable.Array<Vector>(topicRange).Named(""phi"");
+phi[topicRange] = Variable.Dirichlet(betaPrior).ForEach(topicRange);
+
+Console.WriteLine(""Variables LDA definies."");
+Console.WriteLine($""  Nombre de topics : {numTopics}"");
+Console.WriteLine($""  Taille vocabulaire : {vocabSize}"");",,,,,,,,2327ac3ff7fba141,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,csoow5q2v7,markdown,fr,c8e91fc8a38c899d,"### Structure du modele LDA dans Infer.NET
+
+**Variables definies** :
+
+| Variable | Type | Role |
+|----------|------|------|
+| `phi[k]` | `Vector` (Dirichlet) | Distribution des mots pour le topic k |
+| `topicRange` | `Range(3)` | Indexation des 3 topics |
+| `vocabRange` | `Range(9)` | Indexation des 9 mots du vocabulaire |
+
+**Prior Dirichlet symetrique** :
+
+Le prior `betaPrior = [1, 1, 1, 1, 1, 1, 1, 1, 1]` est un Dirichlet(1,...,1) qui correspond a une distribution **uniforme** sur le simplexe. Cela signifie que chaque mot a la meme probabilite a priori pour chaque topic.
+
+$$\phi_k \sim \text{Dirichlet}(\beta) \quad \text{avec} \quad \beta = (1, 1, ..., 1)$$
+
+> **Attention** : Ce prior symetrique pose un probleme d'identifiabilite que nous verrons dans la cellule suivante.",,,,,,,,c8e91fc8a38c899d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,c2f4c3c1,code,fr,1df19fb83aca5784,"// Inference pour un document
+int docIndex = 0;  // Premier document (sport)
+int[] docWords = documents[docIndex];
+int numWordsInDoc = docWords.Length;
+
+// Distribution de topics pour ce document
+Variable<Vector> theta = Variable.Dirichlet(alphaPrior).Named(""theta"");
+
+Range wordRange = new Range(numWordsInDoc).Named(""word"");
+VariableArray<int> wordObs = Variable.Array<int>(wordRange).Named(""wordObs"");
+VariableArray<int> topicAssign = Variable.Array<int>(wordRange).Named(""topicAssign"");
+
+// IMPORTANT: SetValueRange est necessaire pour utiliser Variable.Switch()
+topicAssign.SetValueRange(topicRange);
+
+using (Variable.ForEach(wordRange))
+{
+    topicAssign[wordRange] = Variable.Discrete(theta);
+    using (Variable.Switch(topicAssign[wordRange]))
+    {
+        wordObs[wordRange] = Variable.Discrete(phi[topicAssign[wordRange]]);
+    }
+}
+
+wordObs.ObservedValue = docWords;
+
+InferenceEngine moteurLDA = new InferenceEngine(new VariationalMessagePassing());
+moteurLDA.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurLDA.ShowFactorGraph = true;  // Activer la generation du factor graph
+
+Dirichlet thetaPost = moteurLDA.Infer<Dirichlet>(theta);
+
+Console.WriteLine($""\n=== Inference pour Doc {docIndex + 1} ==="");
+Console.WriteLine($""Mots : {string.Join("", "", docWords.Select(i => vocabulaire[i]))}\n"");
+Console.WriteLine($""Distribution de topics (theta) :"");
+Vector thetaMean = thetaPost.GetMean();
+for (int k = 0; k < numTopics; k++)
+{
+    Console.WriteLine($""  Topic {k+1} : {thetaMean[k]:F3}"");
+}",,,,,,,,1df19fb83aca5784,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,6svtmfrylba,markdown,fr,b58c19c71611c639,"### Analyse des résultats LDA (Document 1) - Problème de Symétrie
+
+**Résultats observés** : Distribution uniforme (0.333 par topic)
+
+| Observation | Explication |
+|-------------|-------------|
+| **Topics équiprobables** | Le modèle converge vers un **mode local symétrique** |
+| **Cause principale** | Les distributions $\phi$ (mots par topic) ont des priors **symétriques** |
+| **Prior Dirichlet(1,...,1)** | N'encode aucune préférence entre topics |
+
+**Pourquoi ce résultat ? Le problème de symétrie dans LDA**
+
+C'est un problème classique de LDA avec VMP (Variational Message Passing) :
+
+1. **Symétrie initiale** : Tous les topics sont interchangeables au départ
+2. **Mode local** : VMP converge vers le point-selle symétrique où tous les topics sont identiques
+3. **Brisure de symétrie nécessaire** : Il faut ""guider"" l'inférence vers des solutions distinctes
+
+**Solutions possibles** :
+- Priors asymétriques sur $\phi$ (le plus efficace)
+- Initialisation aléatoire des paramètres
+- Gibbs Sampling au lieu de VMP (explore mieux l'espace)
+
+**Note technique** : VMP converge en 50 itérations mais vers une solution dégénérée - ce n'est pas un bug, c'est une propriété mathématique des méthodes variationnelles face à des modèles symétriques.",,,,,,,,b58c19c71611c639,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,999fcj0uf1g,code,fr,cd855e20ae8c098a,"// Visualisation du factor graph LDA
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,cd855e20ae8c098a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,gsr4n9ovnlr,markdown,fr,ecd036b15be449ee,"### Interpretation du factor graph LDA
+
+Le graphe de facteurs ci-dessus represente la structure du modele LDA pour un seul document.
+
+**Composants du graphe** :
+
+| Noeud | Type | Role dans LDA |
+|-------|------|---------------|
+| `theta` | Variable latente | Distribution de topics du document (Dirichlet) |
+| `phi` | Parametre | Distribution des mots par topic (tableau de Dirichlet) |
+| `topicAssign` | Variable latente | Assignation de topic pour chaque mot (Discrete) |
+| `wordObs` | Observation | Mots observes dans le document |
+
+**Structure hierarchique** :
+
+```
+theta (Dirichlet prior)
+   |
+   v
+topicAssign[word] (Discrete)  <-- choix du topic pour chaque mot
+   |
+   v
+wordObs[word] (Discrete)  <-- mot genere selon phi[topic]
+   ^
+   |
+phi[topic] (Dirichlet prior)
+```
+
+**Messages VMP** : Les aretes representent les messages variationnels echanges entre facteurs. VMP itere jusqu'a convergence des parametres de l'approximation $q(\theta, z)$.",,,,,,,,ecd036b15be449ee,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,o57n219kxqb,markdown,fr,91b65d8cfb76badb,"## 4bis. Solution : LDA avec Priors Asymétriques
+
+Pour briser la symétrie, nous utilisons des **priors Dirichlet asymétriques** sur $\phi$ (distribution des mots par topic). L'idée est d'encoder notre connaissance a priori que certains mots sont plus probables pour certains topics.
+
+### Stratégie de brisure de symétrie
+
+```
+Topic Sport :     beta = [10, 10, 10, 1, 1, 1, 1, 1, 1]  → favorise mots 0-2
+Topic Politique : beta = [1, 1, 1, 10, 10, 10, 1, 1, 1]  → favorise mots 3-5
+Topic Musique :   beta = [1, 1, 1, 1, 1, 1, 10, 10, 10]  → favorise mots 6-8
+```
+
+Ces priors ne sont pas arbitraires : ils encodent une **hypothèse structurelle** sur le vocabulaire. En pratique, on peut :
+- Utiliser des embeddings de mots pour initialiser
+- Faire une première passe de clustering
+- Encoder des connaissances du domaine",,,,,,,,91b65d8cfb76badb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,3guhtb200iz,markdown,fr,dcd33d71bb124ea4,"### Execution : Definition des priors asymetriques
+
+Le code suivant definit la matrice de priors asymetriques. Observez comment chaque topic recoit un prior qui favorise un groupe de mots specifique :",,,,,,,,dcd33d71bb124ea4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,52jbbkuqdnp,code,fr,8bc1f819752a9aad,"// LDA avec priors asymétriques pour briser la symétrie
+
+// Priors asymétriques sur phi (mots par topic)
+// Chaque topic a une ""affinité"" pour un groupe de mots
+double[][] betaAsym = new double[][] {
+    // Topic 0 (Sport) : favorise mots 0, 1, 2
+    new double[] { 10, 10, 10, 1, 1, 1, 1, 1, 1 },
+    // Topic 1 (Politique) : favorise mots 3, 4, 5
+    new double[] { 1, 1, 1, 10, 10, 10, 1, 1, 1 },
+    // Topic 2 (Musique) : favorise mots 6, 7, 8
+    new double[] { 1, 1, 1, 1, 1, 1, 10, 10, 10 }
+};
+
+// Redefinition du modele avec priors asymetriques
+Range topicRangeAsym = new Range(numTopics).Named(""topicAsym"");
+Range vocabRangeAsym = new Range(vocabSize).Named(""vocabAsym"");
+
+VariableArray<Vector> phiAsym = Variable.Array<Vector>(topicRangeAsym).Named(""phiAsym"");
+
+// Assigner des priors differents a chaque topic
+for (int k = 0; k < numTopics; k++)
+{
+    phiAsym[k] = Variable.Dirichlet(betaAsym[k]);
+}
+
+Console.WriteLine(""=== LDA avec Priors Asymétriques ==="");
+Console.WriteLine(""\nPriors sur phi (log-echelle relative) :"");
+for (int k = 0; k < numTopics; k++)
+{
+    var topMots = betaAsym[k]
+        .Select((b, i) => (mot: vocabulaire[i], beta: b))
+        .Where(x => x.beta > 1)
+        .ToList();
+    Console.WriteLine($""  Topic {k} : {string.Join("", "", topMots.Select(x => x.mot))} (beta=10)"");}
+Console.WriteLine();",,,,,,,,8bc1f819752a9aad,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,57ted49ipac,markdown,fr,c0d0d8939f7aff1e,"### Execution : Inference LDA sur plusieurs documents
+
+Maintenant que les priors asymetriques sont definis, nous allons tester l'inference sur 5 documents : 3 documents ""purs"" (un seul topic) et 2 documents ""mixtes"" (melange de topics).
+
+**Documents testes** :
+
+| Document | Contenu attendu | Type |
+|----------|-----------------|------|
+| Doc 1 | Sport | Pur |
+| Doc 2 | Politique | Pur |
+| Doc 3 | Musique | Pur |
+| Doc 4 | Sport + Politique | Mixte |
+| Doc 5 | Musique + Sport | Mixte |",,,,,,,,c0d0d8939f7aff1e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,r4m4ks1spuf,code,fr,ef3a746c5a49431f,"// Inference LDA avec priors asymetriques sur plusieurs documents
+
+Console.WriteLine(""=== Inference LDA Corrigee ===\n"");
+
+// On teste sur les 3 premiers documents (1 par topic)
+int[] testDocs = { 0, 1, 2, 3, 4 };  // Sport, Politique, Musique, Sport+Politique, Musique+Sport
+
+foreach (int docIdx in testDocs)
+{
+    int[] dWords = documents[docIdx];
+    int nWords = dWords.Length;
+    
+    // Nouveau modele pour ce document
+    Variable<Vector> thetaDoc = Variable.Dirichlet(alphaPrior).Named($""theta_{docIdx}"");
+    
+    Range wRange = new Range(nWords).Named($""word_{docIdx}"");
+    VariableArray<int> wordsDoc = Variable.Array<int>(wRange).Named($""words_{docIdx}"");
+    VariableArray<int> topicsDoc = Variable.Array<int>(wRange).Named($""topics_{docIdx}"");
+    
+    topicsDoc.SetValueRange(topicRangeAsym);
+    
+    using (Variable.ForEach(wRange))
+    {
+        topicsDoc[wRange] = Variable.Discrete(thetaDoc);
+        using (Variable.Switch(topicsDoc[wRange]))
+        {
+            wordsDoc[wRange] = Variable.Discrete(phiAsym[topicsDoc[wRange]]);
+        }
+    }
+    
+    wordsDoc.ObservedValue = dWords;
+    
+    // Inference
+    InferenceEngine moteurLDAAsym = new InferenceEngine(new VariationalMessagePassing());
+    moteurLDAAsym.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    moteurLDAAsym.ShowFactorGraph = true;  // Activer la generation du factor graph
+    moteurLDAAsym.ShowProgress = false;
+    
+    Dirichlet thetaPostAsym = moteurLDAAsym.Infer<Dirichlet>(thetaDoc);
+    Vector thetaMeanAsym = thetaPostAsym.GetMean();
+    
+    // Affichage
+    string motsStr = string.Join("", "", dWords.Select(i => vocabulaire[i]));
+    Console.WriteLine($""Doc {docIdx + 1} : {motsStr}"");
+    Console.WriteLine($""  Theta : Sport={thetaMeanAsym[0]:F3}, Politique={thetaMeanAsym[1]:F3}, Musique={thetaMeanAsym[2]:F3}"");
+    
+    // Topic dominant
+    int topicDom = thetaMeanAsym[0] > thetaMeanAsym[1] && thetaMeanAsym[0] > thetaMeanAsym[2] ? 0 :
+                   thetaMeanAsym[1] > thetaMeanAsym[2] ? 1 : 2;
+    string[] topicLabels = { ""Sport"", ""Politique"", ""Musique"" };
+    Console.WriteLine($""  Topic dominant : {topicLabels[topicDom]} ({thetaMeanAsym[topicDom]:P0})"");
+    Console.WriteLine();
+}",,,,,,,,ef3a746c5a49431f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,8k7gcy3r1fv,markdown,fr,f1044c1208ff35af,"### Analyse : Résultats avec Priors Asymétriques
+
+**Amélioration observée** : Les topics sont maintenant correctement identifiés !
+
+| Document | Mots | Topic attendu | Résultat |
+|----------|------|---------------|----------|
+| Doc 1 | sport, equipe, match | Sport | Sport ~74% |
+| Doc 2 | politique, election, vote | Politique | Politique ~74% |
+| Doc 3 | musique, concert, artiste | Musique | Musique ~74% |
+| Doc 4 | sport + politique | Mixte | Sport ~55%, Politique ~40% |
+| Doc 5 | musique + sport | Mixte | Musique ~55%, Sport ~40% |
+
+**Pourquoi ça fonctionne maintenant ?**
+
+1. **Brisure de symétrie** : Les priors asymétriques créent des ""bassins d'attraction"" distincts
+2. **Vraisemblance dirigée** : Un mot ""sport"" a 10× plus de chances sous Topic 0
+3. **Inférence correcte** : VMP converge vers le mode correspondant aux données
+
+**Comparaison avant/après** :
+
+| Aspect | Prior symétrique | Prior asymétrique |
+|--------|------------------|-------------------|
+| Theta Doc 1 | (0.33, 0.33, 0.33) | (~0.74, ~0.13, ~0.13) |
+| Mode | Symétrique (dégénéré) | Correct |
+| Utilité | Aucune | Classification fonctionnelle |
+
+**Note** : Cette approche est ""semi-supervisée"" car les priors encodent une connaissance préalable. Un LDA purement non-supervisé nécessiterait des techniques plus avancées (initialisation aléatoire multiple, collapsed Gibbs sampling).",,,,,,,,f1044c1208ff35af,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,gu30fyfyiap,code,fr,3f5b6a6e1c07e75d,"// Visualisation du factor graph LDA avec priors asymetriques
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,3f5b6a6e1c07e75d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,vrkrzb9mpw,markdown,fr,30b0780d06e94e49,"### Interpretation du factor graph LDA avec priors asymetriques
+
+Le graphe ci-dessus montre la structure du modele LDA avec **priors asymetriques** sur les distributions de mots par topic.
+
+**Difference cle avec le modele precedent** :
+
+| Aspect | Prior symetrique | Prior asymetrique |
+|--------|------------------|-------------------|
+| **phi[k]** | Dirichlet(1,...,1) identique | Dirichlet(betaAsym[k]) different par topic |
+| **Brisure de symetrie** | Non | Oui |
+| **Convergence VMP** | Mode degenere | Mode informatif |
+
+**Structure du graphe** :
+
+Les noeuds `phiAsym[k]` ont maintenant des **priors differents** pour chaque topic k :
+- Topic 0 (Sport) : prior fort sur mots 0-2
+- Topic 1 (Politique) : prior fort sur mots 3-5  
+- Topic 2 (Musique) : prior fort sur mots 6-8
+
+**Impact sur l'inference** :
+
+L'asymetrie des priors cree des ""bassins d'attraction"" distincts dans l'espace des parametres, permettant a VMP de converger vers des solutions interpretables plutot que vers le point-selle symetrique.
+
+> **Note technique** : Le graphe genere correspond au dernier document traite dans la boucle. La structure est identique pour tous les documents, seules les observations (`wordsDoc`) changent.",,,,,,,,30b0780d06e94e49,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,65b0019f,markdown,fr,b2c44349b73b72d2,"## 5. LDA sur Corpus Complet
+
+### Approche simplifiee : comptage par categorie
+
+Avant d'utiliser l'inference probabiliste complete, nous pouvons obtenir une premiere approximation des compositions de topics par **comptage direct des mots** appartenant a chaque categorie thematique.
+
+Cette approche exploite la structure connue du vocabulaire :
+- Indices 0-2 : mots de **Sport**
+- Indices 3-5 : mots de **Politique**
+- Indices 6-8 : mots de **Musique**
+
+> **Limitation** : Cette methode ne capture pas l'incertitude ni les correlations entre mots. L'inference probabiliste est necessaire pour des corpus reels ou le vocabulaire n'est pas parfaitement partitionne.",,,,,,,,b2c44349b73b72d2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,106c17ea,code,fr,402490bff61587ef,"// Inference simplifiee document par document
+
+Console.WriteLine(""=== LDA sur corpus complet ==="");
+Console.WriteLine();
+
+// Distribution des mots par topic (initialisation supervisee pour demo)
+// Topic 0 : Sport (mots 0, 1, 2)
+// Topic 1 : Politique (mots 3, 4, 5)
+// Topic 2 : Musique (mots 6, 7, 8)
+
+for (int d = 0; d < numDocs; d++)
+{
+    int[] dWords = documents[d];
+    int nWords = dWords.Length;
+    
+    // Comptage simple des mots par categorie
+    int countSport = dWords.Count(w => w <= 2);
+    int countPolitique = dWords.Count(w => w >= 3 && w <= 5);
+    int countMusique = dWords.Count(w => w >= 6);
+    double total = countSport + countPolitique + countMusique + 0.001;
+    
+    Console.WriteLine($""Doc {d+1} : Sport={countSport/total:F2}, Politique={countPolitique/total:F2}, Musique={countMusique/total:F2}"");
+}
+
+Console.WriteLine(""\n(Proportions basees sur les mots observes)"");",,,,,,,,402490bff61587ef,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,6p8toq74n8h,markdown,fr,cdfb983a06707804,"### Analyse des compositions de topics
+
+**Résultats** : Classification correcte basée sur le comptage de mots
+
+| Document | Topics détectés | Observation |
+|----------|-----------------|-------------|
+| Doc 1, 6 | Sport = 100% | Documents thématiques purs |
+| Doc 2, 7 | Politique = 100% | Documents thématiques purs |
+| Doc 3 | Musique = 100% | Document thématique pur |
+| Doc 4 | Sport 60% / Politique 40% | Mélange détecté |
+| Doc 5 | Musique 60% / Sport 40% | Mélange détecté |
+
+**Observations clés** :
+
+1. **Documents purs** : La séparation parfaite du vocabulaire en 3 groupes disjoints (indices 0-2, 3-5, 6-8) permet une classification triviale
+
+2. **Documents mixtes** : Les proportions reflètent directement le comptage (Doc 4 : 3 mots sport, 2 mots politique → 60/40)
+
+3. **Limitation** : Cette approche de comptage ne capture pas les **co-occurrences** ni les **corrélations sémantiques** entre mots
+
+**En pratique** : Un vrai LDA avec inférence jointe découvrirait automatiquement la structure des topics sans connaître a priori les groupes de mots.",,,,,,,,cdfb983a06707804,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,1dc820f4,markdown,fr,2c0afe41102e39bc,"## 6. Visualisation des Topics
+
+### Visualisation de la matrice phi
+
+Pour comprendre ce que chaque topic a ""appris"", nous visualisons la distribution $\phi_k$ des mots pour chaque topic. Les **mots les plus probables** definissent l'interpretation semantique du topic.
+
+En pratique, on affiche les **top-N mots** par topic pour faciliter l'interpretation humaine.",,,,,,,,2c0afe41102e39bc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,0e5bd4a3,code,fr,963a7023ddaaa7ba,"// Distribution phi (mots par topic) - simulee
+
+double[,] phiSimule = {
+    // Topic Sport
+    { 0.30, 0.30, 0.30, 0.02, 0.02, 0.02, 0.02, 0.01, 0.01 },
+    // Topic Politique
+    { 0.02, 0.02, 0.02, 0.30, 0.30, 0.30, 0.02, 0.01, 0.01 },
+    // Topic Musique
+    { 0.02, 0.01, 0.01, 0.02, 0.02, 0.02, 0.30, 0.30, 0.30 }
+};
+
+string[] topicNames = { ""Sport"", ""Politique"", ""Musique"" };
+
+Console.WriteLine(""=== Distribution Mots par Topic (phi) ==="");
+Console.WriteLine();
+
+for (int k = 0; k < numTopics; k++)
+{
+    Console.WriteLine($""Topic {k+1} ({topicNames[k]}) :"");
+    
+    // Top mots
+    var topMots = Enumerable.Range(0, vocabSize)
+        .Select(v => (mot: vocabulaire[v], prob: phiSimule[k, v]))
+        .OrderByDescending(x => x.prob)
+        .Take(3);
+    
+    foreach (var (mot, prob) in topMots)
+    {
+        Console.WriteLine($""  {mot,-12} : {prob:F2}"");
+    }
+    Console.WriteLine();
+}",,,,,,,,963a7023ddaaa7ba,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,cc8aichxbkn,markdown,fr,5ccab0f76313cb75,"### Interpretation de la matrice phi
+
+**Structure de la distribution mots/topics** :
+
+La matrice $\phi$ de dimension $(K \times V) = (3 \times 9)$ encode la probabilite de chaque mot sachant le topic.
+
+$$\phi_{k,v} = P(\text{mot} = v \mid \text{topic} = k)$$
+
+**Proprietes observees** :
+
+| Propriete | Valeur | Interpretation |
+|-----------|--------|----------------|
+| **Prob. mots dominants** | 0.30 | Forte association mot-topic |
+| **Prob. mots hors-topic** | 0.01-0.02 | Faible bruit de fond |
+| **Somme par topic** | 1.0 | Distribution normalisee |
+| **Entropie par topic** | Faible | Topics bien separes |
+
+**Visualisation mentale** :
+
+```
+           sport equipe match polit elect vote  musiq conc  artis
+Topic 0:   ████  ████   ████  ░     ░     ░     ░     ░     ░
+Topic 1:   ░     ░      ░     ████  ████  ████  ░     ░     ░
+Topic 2:   ░     ░      ░     ░     ░     ░     ████  ████  ████
+```
+
+> **Note** : En pratique, les distributions phi sont apprises par inference et montrent souvent des chevauchements plus subtils entre topics.",,,,,,,,5ccab0f76313cb75,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,ac34753e,markdown,fr,a0056bc9cb73d313,"## 7. Prediction sur Nouveaux Documents
+
+### Inference sur un nouveau document
+
+L'objectif de LDA n'est pas seulement d'analyser le corpus d'entrainement, mais aussi de **predire** la composition thematique de nouveaux documents jamais vus.
+
+**Methode** : Pour un nouveau document, on calcule la vraisemblance de chaque topic en utilisant les distributions $\phi$ apprises, puis on normalise pour obtenir des probabilites.
+
+$$P(\text{topic} = k \mid \text{document}) \propto \prod_{w \in \text{doc}} \phi_{k,w}$$
+
+**Document test** : Un melange de mots ""sport"" et ""musique"" pour voir comment le modele gere les documents multi-thematiques.",,,,,,,,a0056bc9cb73d313,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,85050b23,code,fr,95e768c4d25fc765,"// Prediction de topics pour un nouveau document
+
+int[] nouveauDoc = { 0, 1, 6, 7, 0 };  // Sport + Musique
+Console.WriteLine(""=== Prediction Nouveau Document ==="");
+Console.WriteLine($""Mots : {string.Join("", "", nouveauDoc.Select(i => vocabulaire[i]))}"");
+
+// Calcul des vraisemblances par topic
+double[] logLik = new double[numTopics];
+
+for (int k = 0; k < numTopics; k++)
+{
+    logLik[k] = 0;
+    foreach (int w in nouveauDoc)
+    {
+        logLik[k] += Math.Log(phiSimule[k, w] + 1e-10);
+    }
+}
+
+// Normalisation (softmax)
+double maxLogLik = logLik.Max();
+double[] lik = logLik.Select(ll => Math.Exp(ll - maxLogLik)).ToArray();
+double sumLik = lik.Sum();
+double[] topicProbs = lik.Select(l => l / sumLik).ToArray();
+
+Console.WriteLine(""\nProbabilites de topics :"");
+for (int k = 0; k < numTopics; k++)
+{
+    Console.WriteLine($""  {topicNames[k],-12} : {topicProbs[k]:F3}"");
+}",,,,,,,,95e768c4d25fc765,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,ddchdll6qyc,markdown,fr,c4c64a6cefd2f4f3,"### Analyse de la prédiction
+
+**Document testé** : ""sport, equipe, musique, concert, sport"" (2 mots musique, 3 mots sport)
+
+**Résultat** : Sport = 93.7%, Musique = 6.2%, Politique ≈ 0%
+
+| Aspect | Observation |
+|--------|-------------|
+| **Dominance Sport** | 3 mots sur 5 = 60%, mais probabilité 93.7% |
+| **Sous-estimation Musique** | 2 mots sur 5 = 40%, mais probabilité 6.2% |
+| **Politique éliminée** | Aucun mot du topic → probabilité ~0 |
+
+**Explication de l'asymétrie** :
+
+Le calcul utilise la **vraisemblance** (produit des probabilités) :
+- Sport : $0.30^3 \times 0.02^2 = 1.08 \times 10^{-5}$
+- Musique : $0.02^3 \times 0.30^2 = 7.2 \times 10^{-7}$
+- Ratio : Sport est ~15× plus probable que Musique
+
+**Effet de la vraisemblance** : Le modèle pénalise fortement les mots ""hors topic"" (prob=0.02), ce qui amplifie la différence entre topics.
+
+**Note** : C'est un comportement attendu des modèles génératifs - la vraisemblance capture plus que de simples proportions.",,,,,,,,c4c64a6cefd2f4f3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,c03e2ce8,markdown,fr,b75f74a412bae30c,"## 8. Extensions de LDA
+
+### Variantes
+
+| Modele | Description |
+|--------|-------------|
+| **HDP** (Hierarchical Dirichlet Process) | Nombre de topics appris automatiquement |
+| **Correlated Topic Model** | Correlations entre topics |
+| **Dynamic Topic Model** | Evolution des topics dans le temps |
+| **Supervised LDA** | Avec labels de documents |",,,,,,,,b75f74a412bae30c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,fjhhqs4af88,markdown,fr,eb04097a175d25d9,"### Comparaison des extensions de LDA
+
+| Extension | Avantage principal | Complexite | Cas d'usage |
+|-----------|-------------------|------------|-------------|
+| **LDA standard** | Simple, bien compris | $O(NKV)$ | Corpus statiques |
+| **HDP** | Pas de K a specifier | $O(NK^2V)$ | Exploration non-supervisee |
+| **CTM** | Topics correles | $O(NK^2 + NKV)$ | Documents structurees |
+| **DTM** | Evolution temporelle | $O(TNK^2V)$ | Flux de documents |
+| **sLDA** | Prediction supervisee | $O(NKV + NK)$ | Classification |
+
+**Formules des extensions** :
+
+- **HDP** : $G_0 \sim \text{DP}(\gamma, H)$, $G_j \sim \text{DP}(\alpha, G_0)$ (processus de Dirichlet hierarchique)
+- **CTM** : $\eta_d \sim \mathcal{N}(\mu, \Sigma)$, $\theta_d = \text{softmax}(\eta_d)$ (normale multivariee pour correlations)
+- **DTM** : $\beta_{t,k} \sim \mathcal{N}(\beta_{t-1,k}, \sigma^2 I)$ (evolution gaussienne des topics)
+
+> **Conseil pratique** : Commencez toujours par LDA standard. N'utilisez les extensions que si les donnees montrent clairement des correlations temporelles ou entre topics.",,,,,,,,eb04097a175d25d9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,d7c637b6,markdown,fr,dd142fdb3155c45a,"## 9. Exemple guide : Analyser un Corpus
+
+### Enonce
+
+Etendez le vocabulaire et ajoutez des documents pour creer un corpus plus realiste avec 4 topics.",,,,,,,,dd142fdb3155c45a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,oxub8w4irxl,markdown,fr,36340c836077f854,"### Objectifs de l'exercice
+
+L'extension a 4 topics permet d'explorer :
+
+1. **Scalabilite** : Comment le modele se comporte avec plus de topics
+2. **Chevauchements** : Comment gerer les documents multi-thematiques
+3. **Equilibre** : Importance d'avoir des topics de taille comparable
+
+**Parametres a ajuster** :
+
+| Parametre | Valeur suggeree | Impact |
+|-----------|-----------------|--------|
+| $\alpha$ (prior theta) | 0.1-1.0 | Sparsity des documents |
+| $\beta$ (prior phi) | 0.01-0.1 | Sparsity des topics |
+| Nombre de topics K | 3-10 | Granularite thematique |
+| Iterations VMP | 50-200 | Convergence |
+
+> **Defi supplementaire** : Essayez d'ajouter des mots ambigus partages entre topics (ex: ""competition"" pour Sport et Tech) et observez comment le modele les attribue.",,,,,,,,36340c836077f854,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,2ocnn07hu2o,markdown,fr,26f6a42e147e721a,"### Implementation de l'exercice
+
+Le code suivant cree un corpus etendu avec 4 topics et 16 mots de vocabulaire. La classification est effectuee par comptage simple des indices de mots.",,,,,,,,26f6a42e147e721a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,486b86a1,code,fr,f2a5b370e5350000,"// Exemple guide : Corpus etendu
+
+string[] vocabEtendu = {
+    // Sport (0-3)
+    ""football"", ""basketball"", ""tennis"", ""competition"",
+    // Tech (4-7)
+    ""ordinateur"", ""logiciel"", ""internet"", ""application"",
+    // Cuisine (8-11)
+    ""recette"", ""ingredient"", ""cuisson"", ""gastronomie"",
+    // Voyage (12-15)
+    ""hotel"", ""avion"", ""destination"", ""tourisme""
+};
+
+int[][] docsEtendus = {
+    new[] { 0, 1, 2, 3, 0 },     // Sport
+    new[] { 4, 5, 6, 7, 5 },     // Tech
+    new[] { 8, 9, 10, 11, 9 },   // Cuisine
+    new[] { 12, 13, 14, 15, 13 },// Voyage
+    new[] { 0, 4, 5, 1, 6 },     // Sport + Tech
+    new[] { 8, 12, 13, 10, 14 }, // Cuisine + Voyage
+    new[] { 2, 3, 0, 1, 2 },     // Sport
+    new[] { 6, 7, 4, 5, 7 }      // Tech
+};
+
+Console.WriteLine(""=== Corpus Etendu (4 topics) ==="");
+
+for (int d = 0; d < docsEtendus.Length; d++)
+{
+    // Classification simple basee sur les indices de mots
+    int sport = docsEtendus[d].Count(w => w <= 3);
+    int tech = docsEtendus[d].Count(w => w >= 4 && w <= 7);
+    int cuisine = docsEtendus[d].Count(w => w >= 8 && w <= 11);
+    int voyage = docsEtendus[d].Count(w => w >= 12);
+    
+    string dominant;
+    int max = new[] { sport, tech, cuisine, voyage }.Max();
+    if (sport == max) dominant = ""Sport"";
+    else if (tech == max) dominant = ""Tech"";
+    else if (cuisine == max) dominant = ""Cuisine"";
+    else dominant = ""Voyage"";
+    
+    string mots = string.Join("", "", docsEtendus[d].Select(i => vocabEtendu[i]));
+    Console.WriteLine($""Doc {d+1} [{dominant,-8}] : {mots}"");
+}",,,,,,,,f2a5b370e5350000,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,x4ns56qo67,markdown,fr,39b6026f72906c2e,"### Analyse du corpus étendu
+
+**Structure** : 4 topics (Sport, Tech, Cuisine, Voyage) × 4 mots chacun
+
+| Document | Topic dominant | Composition |
+|----------|----------------|-------------|
+| Doc 1, 7 | Sport | Documents purs |
+| Doc 2, 8 | Tech | Documents purs |
+| Doc 3 | Cuisine | Document pur |
+| Doc 4 | Voyage | Document pur |
+| Doc 5 | Tech (3) > Sport (2) | Mélange tech-sport |
+| Doc 6 | Voyage (3) > Cuisine (2) | Mélange voyage-cuisine |
+
+**Observations** :
+
+1. **Scalabilité** : Le passage de 3 à 4 topics reste gérable avec le comptage simple
+
+2. **Mélanges asymétriques** : Doc 5 et Doc 6 montrent des documents multi-thématiques
+
+3. **Vocabulaire disjoint** : La structure en blocs de 4 mots consécutifs simplifie l'identification
+
+**Exercice proposé** : Ajouter des mots partagés entre topics (ex: ""compétition"" pour Sport et Tech) pour observer comment le modèle gère l'ambiguïté lexicale.",,,,,,,,39b6026f72906c2e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,1cbe72e5,markdown,fr,a0747a5ac8e84ecc,"## 10. Resume
+
+| Concept | Description |
+|---------|-------------|
+| **LDA** | Modele generatif pour documents |
+| **Topic** | Distribution sur le vocabulaire |
+| **Theta** | Distribution de topics par document |
+| **Phi** | Distribution de mots par topic |
+| **Dirichlet** | Prior conjugue pour distributions categoriques |
+
+---
+
+## Pour aller plus loin
+
+| Si vous voulez... | Consultez... |
+|-------------------|--------------|
+| Comprendre les priors Dirichlet | [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb) |
+| Debugger un probleme de convergence | [Infer-6-Debugging](Infer-6-Debugging.ipynb) |
+| Comparer VMP et EP | [Infer-6-Debugging](Infer-6-Debugging.ipynb) Section 4 |
+| Trouver une definition | [Glossaire](Infer-Glossary.md) |
+
+---
+
+## Prochaine etape
+
+Dans [Infer-10-Model-Selection](Infer-10-Model-Selection.ipynb), nous explorerons :
+
+- La selection et comparaison de modeles
+- L'evidence bayesienne (marginal likelihood)
+- Le facteur de Bayes",,,,,,,,a0747a5ac8e84ecc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,yidp380kmlf,markdown,fr,274d598e34b67067,"### Points cles a retenir
+
+**Ce que nous avons appris** :
+
+1. **LDA est un modele generatif** : Il decrit comment les documents sont ""generes"" a partir de topics latents
+
+2. **Probleme de symetrie** : Avec des priors uniformes, VMP converge vers des solutions degenerees - les priors asymetriques ou l'initialisation aleatoire sont necessaires
+
+3. **Dirichlet est central** : Prior conjugue pour les melanges de distributions categoriques
+
+4. **Trade-off interpretation/scalabilite** : Le comptage simple fonctionne sur des corpus synthetiques, mais l'inference probabiliste capture les incertitudes
+
+**Erreurs courantes a eviter** :
+
+| Erreur | Consequence | Solution |
+|--------|-------------|----------|
+| Prior symetrique | Mode degenere | Priors asymetriques ou init. aleatoire |
+| K trop grand | Overfitting, topics non-interpretatifs | Validation croisee ou HDP |
+| K trop petit | Topics melanges | Augmenter K ou utiliser hierarchie |
+| Ignorer la preprocessing | Mots frequents dominent | Stop-words, TF-IDF |
+
+**Applications pratiques** :
+
+- **Recherche d'information** : Indexation semantique de documents
+- **Recommandation** : ""Utilisateurs qui aiment ce topic aiment aussi...""
+- **Analyse de sentiments** : Topics combines avec polarite
+- **Bioinformatique** : Decouverte de motifs dans les sequences",,,,,,,,274d598e34b67067,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,8e836a16,markdown,fr,c68101aaf8a95fd4,"## 11. Exercice : Decouvrir les Topics d'un Corpus Francais
+
+### Enonce
+
+Analysez un corpus de 9 documents repartis sur 3 themes : **Cuisine**, **Voyage**, **Science**.
+
+Vocabulaire (15 mots, indices 0-14) :
+- Cuisine (0-4) : ""recette"", ""cuisson"", ""saveur"", ""ingredient"", ""plat""
+- Voyage (5-9) : ""destination"", ""hotel"", ""vol"", ""decouverte"", ""carte""
+- Science (10-14) : ""experience"", ""donnee"", ""analyse"", ""resultat"", ""hypothese""
+
+Documents (indices des mots) : 3 Cuisine + 3 Voyage + 3 Science.
+
+1. Entrainer LDA avec K=3 topics
+2. Verifier que chaque topic correspond a un theme
+3. Afficher les 3 mots les plus probables par topic",,,,,,,,c68101aaf8a95fd4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,39a2f788,code,fr,60e58185aca52867,"// Exercice : LDA 3 topics sur corpus francais
+string[] vocab = {
+    ""recette"", ""cuisson"", ""saveur"", ""ingredient"", ""plat"",       // 0-4: Cuisine
+    ""destination"", ""hotel"", ""vol"", ""decouverte"", ""carte"",       // 5-9: Voyage
+    ""experience"", ""donnee"", ""analyse"", ""resultat"", ""hypothese""  // 10-14: Science
+};
+int V = vocab.Length;  // 15 mots
+int K = 3;             // 3 topics attendus
+
+// Documents (chaque sous-tableau = indices des mots du document)
+int[][] docs = {
+    new[] {0, 1, 2, 0, 2, 3},      // Doc 0: Cuisine
+    new[] {0, 2, 3, 3, 4},         // Doc 1: Cuisine
+    new[] {1, 3, 4, 1, 0},         // Doc 2: Cuisine
+    new[] {5, 6, 7, 5, 8},         // Doc 3: Voyage
+    new[] {5, 7, 8, 9, 5, 6},      // Doc 4: Voyage
+    new[] {6, 8, 9, 6, 7},         // Doc 5: Voyage
+    new[] {10, 11, 12, 11, 13},    // Doc 6: Science
+    new[] {11, 12, 13, 14, 11},    // Doc 7: Science
+    new[] {10, 12, 14, 13, 10}     // Doc 8: Science
+};
+
+// TODO: Creer le modele LDA avec K=3 topics
+// (Reutilisez la structure LDA de l'exemple guide : phi, theta, z, w)
+
+// TODO: Entrainer et inferer les distributions topic-par-mot (phi)
+// Chaque topic devrait concentrer son poids sur 5 mots d'un theme
+
+// TODO: Afficher les 3 mots les plus probables pour chaque topic
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,60e58185aca52867,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,b7941386,markdown,fr,7edfa0905cdfe6eb,"## 12. Exercice : Detecter l'Emergence d'un Nouveau Topic
+
+### Enonce
+
+Vous disposez d'un corpus de **12 documents** couvrant 3 themes connus (Sport, Politique, Musique) et un **nouveau theme emergent** (Economie) que vous ne connaissez pas a priori.
+
+**Objectif** : Determinez le nombre optimal de topics K et identifiez le theme emergent.
+
+### Donnees
+
+Un vocabulaire de 15 mots et 12 documents dont certains contiennent des mots d'un nouveau theme inconnu.
+
+### Taches
+
+1. Entrainez LDA avec K=3 topics. Qu'observez-vous dans les distributions phi ?
+2. Entrainez LDA avec K=4 topics. Le nouveau topic est-il identifie ?
+3. Comparez les distributions theta pour un document contenant le theme emergent avec K=3 vs K=4.
+
+**Indice**
+
+Avec K=3, les mots du theme emergent seront ""absorbes"" par les topics existants, creant des distributions phi brouillees. Avec K=4, un topic dedie devrait apparaitre avec des mots clairs.
+
+### Etapes suggerees
+
+1. Definir le vocabulaire et les 12 documents
+2. Creer le modele LDA avec K=3, observer les distributions phi
+3. Creer le modele LDA avec K=4, comparer
+4. Afficher les top-mots de chaque topic pour les deux valeurs de K",,,,,,,,7edfa0905cdfe6eb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,908106ac,code,fr,7b219bb33729134e,"// Exercice : Detecter un theme emergent avec LDA
+// Vocabulaire elargi (15 mots, 4 themes caches)
+string[] vocabEx = {
+    ""sport"", ""equipe"", ""match"",           // 0-2: Sport
+    ""politique"", ""election"", ""vote"",      // 3-5: Politique
+    ""musique"", ""concert"", ""artiste"",      // 6-8: Musique
+    ""marche"", ""investissement"", ""action""  // 9-11: Economie (theme emergent)
+};
+
+// 12 documents dont certains melangent Economie avec d'autres themes
+int[][] docsEx = {
+    new[] { 0, 1, 2, 0, 2 },             // Sport
+    new[] { 3, 4, 5, 4, 3 },             // Politique
+    new[] { 6, 7, 8, 7, 6 },             // Musique
+    new[] { 9, 10, 11, 9, 10 },          // Economie pur
+    new[] { 0, 1, 9, 10, 0 },            // Sport + Economie
+    new[] { 6, 7, 9, 11, 8 },            // Musique + Economie
+    new[] { 3, 4, 5, 3, 4 },             // Politique
+    new[] { 0, 2, 1, 2, 0 },             // Sport
+    new[] { 9, 11, 10, 9, 11 },          // Economie pur
+    new[] { 6, 8, 7, 6, 8 },             // Musique
+    new[] { 3, 5, 9, 10, 4 },            // Politique + Economie
+    new[] { 0, 1, 2, 1, 0 }              // Sport
+};
+
+// TODO: Etape 1 - Entrainer LDA avec K=3 topics sur ce corpus
+// Observer: les mots d'economie seront-ils absorbes par quel(s) topic(s) ?
+
+// TODO: Etape 2 - Entrainer LDA avec K=4 topics
+// Observer: un topic dedie a l'economie devrait emerger
+
+// TODO: Etape 3 - Comparer les distributions theta pour les documents mixtes
+// (ex: doc 4 = Sport+Economie) entre K=3 et K=4
+
+Console.WriteLine(""Exercice a completer : detection de theme emergent"");",,,,,,,,7b219bb33729134e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,0f07eda3,markdown,fr,d28c39496521569e,"### 11bis. Exercice : Evaluation de la Coherence des Topics
+
+Comment savoir si les topics appris par LDA sont de ""bonne qualite"" ? La mesure de **coherence UMass** evalue si les mots les plus probables d'un topic apparaissent frequemment ensemble dans les documents.
+
+**Principe** : Pour chaque paire de mots $(w_i, w_j)$ parmi les top-N mots d'un topic, on calcule :
+
+$$C_{\text{UMass}}(w_i, w_j) = \log \frac{D(w_i, w_j) + 1}{D(w_j)}$$
+
+ou $D(w_i, w_j)$ est le nombre de documents contenant les deux mots, et $D(w_j)$ le nombre de documents contenant $w_j$.
+
+**Objectif** : Calculer la coherence UMass pour 3 topics estimes et identifier celui qui est le moins coherent.
+
+**Donnees fournies** :
+- 3 topics estimes (distributions phi simulees sur 9 mots)
+- Topic A : principalement Sport (bruite)
+- Topic B : principalement Politique
+- Topic C : melange Musique + Sport (topic mal isole)
+
+**Etapes** :
+
+1. **Top-mots** -- Pour chaque topic, extraire les 3 mots les plus probables et les afficher.
+2. **Coherence UMass** -- Pour chaque topic, calculer la coherence sur les paires de top-mots. Un topic coherent aura une coherence positive ; un topic melange aura une coherence plus faible.
+3. **Diagnostic** -- Identifier le topic le moins coherent et expliquer pourquoi (presence de mots de themes differents dans le meme topic).
+
+**Indices** :
+- `# Indice` : Pour compter les co-occurrences $D(w_i, w_j)$, parcourez les documents et verifiez si les deux indices de mots sont presents dans le meme document.
+- `# Indice` : La coherence UMass est plus elevee quand les mots co-occurrent souvent. Le Topic C devrait avoir une coherence plus faible car ses top-mots viennent de deux themes differents.
+- `# Indice` : Utilisez `Enumerable.Range(0, Vcoh).OrderByDescending(i => phiEstimated[k][i]).Take(topN)` pour extraire les top-mots.",,,,,,,,d28c39496521569e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,4a80aa15,code,fr,1026481e0207081b,"// Exercice : Evaluation de la coherence des topics
+// On dispose de 3 topics estimes par LDA sur un corpus de 12 documents
+// Chaque topic est represente par sa distribution phi sur 12 mots
+
+string[] vocabCoherence = {
+    ""ballon"", ""terrain"", ""match"",       // 0-2: Sport
+    ""parlement"", ""lois"", ""debat"",       // 3-5: Politique
+    ""guitare"", ""scene"", ""melodie""       // 6-8: Musique
+};
+int Vcoh = vocabCoherence.Length;
+
+// Topics estimes (distributions phi simulees)
+double[][] phiEstimated = {
+    // Topic A : principalement Sport (mais un peu bruite)
+    new double[] { 0.30, 0.28, 0.25, 0.03, 0.02, 0.02, 0.03, 0.04, 0.03 },
+    // Topic B : principalement Politique
+    new double[] { 0.03, 0.02, 0.03, 0.29, 0.30, 0.28, 0.01, 0.02, 0.02 },
+    // Topic C : melange Musique + Sport (topic mal isole)
+    new double[] { 0.15, 0.12, 0.10, 0.03, 0.02, 0.02, 0.20, 0.18, 0.18 }
+};
+
+// TODO: Etape 1 - Pour chaque topic, afficher les 3 mots les plus probables
+// Indice : trier les indices par probabilite decroissante avec OrderByDescending
+
+// TODO: Etape 2 - Calculer la coherence UMass pour chaque topic
+// Pour chaque paire de mots parmi les top-5, calculer :
+//   C(i,j) = log( (D(w_i, w_j) + 1) / D(w_j) )
+// ou D(w_i, w_j) = nombre de documents contenant les deux mots
+// et D(w_j) = nombre de documents contenant w_j
+// La coherence d'un topic = moyenne des C(i,j) sur toutes les paires
+
+// Donnees : 12 documents (indices de mots)
+int[][] docsCoherence = {
+    new[] { 0, 1, 2 },           // Sport
+    new[] { 0, 2, 0 },           // Sport
+    new[] { 1, 2, 0, 1 },        // Sport
+    new[] { 3, 4, 5 },           // Politique
+    new[] { 3, 5, 4, 3 },        // Politique
+    new[] { 4, 5, 3 },           // Politique
+    new[] { 6, 7, 8 },           // Musique
+    new[] { 6, 8, 7, 6 },        // Musique
+    new[] { 7, 8, 6 },           // Musique
+    new[] { 0, 1, 6, 7 },        // Sport + Musique (melange)
+    new[] { 2, 0, 6, 8, 1 },     // Sport + Musique (melange)
+    new[] { 3, 4, 0, 6 }         // Politique + Sport + Musique
+};
+
+// TODO: Etape 3 - Identifier le topic le moins coherent et proposer une explication
+// Indice : Topic C a des mots de deux themes differents -> coherence plus faible
+
+Console.WriteLine(""Exercice a completer : evaluation de coherence des topics"");",,,,,,,,1026481e0207081b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,fdabb688,markdown,fr,be1ed41510d1c9f4,"### 11ter. Exercice 3 : Determiner le Nombre Optimal de Topics
+
+Le choix du nombre de topics K est un hyperparametre central de LDA. Un K trop petit fusionne des themes distincts ; un K trop grand cree des topics redondants ou non-interpretables.
+
+**Objectif** : Pour un corpus couvrant un nombre inconnu de themes, tester plusieurs valeurs de K (de 2 a 6) et selectionner celle qui produit les topics les plus coherents en utilisant la metrique de coherence UMass vue precedemment.
+
+**Donnees fournies** :
+- Un corpus de 15 documents couvrant 4 themes caches (Sport, Politique, Musique, Economie)
+- Un vocabulaire de 16 mots
+
+**Etapes** :
+
+1. **Grille de K** -- Pour chaque K dans {2, 3, 4, 5, 6}, entrainer un modele LDA (comptage simple ou inference) et extraire les 3 top-mots de chaque topic.
+2. **Coherence par K** -- Calculer la coherence UMass moyenne de tous les topics pour chaque valeur de K.
+3. **Selection** -- Identifier le K optimal (celui qui maximise la coherence moyenne) et verifier visuellement que les top-mots sont coherents.
+
+**Indices** :
+- `# Indice` : Pour chaque K, les topics sont obtenus en regroupant les mots du vocabulaire en K clusters. Avec le comptage simple, chaque document est classifie selon son theme dominant, puis les mots de chaque cluster forment un topic.
+- `# Indice` : La coherence devrait augmenter jusqu'au vrai nombre de topics (K=4), puis stagner ou diminuer quand K depasse la vraie valeur.
+- `# Indice` : Reutilisez la formule UMass de l'Exercice 2 : `C(i,j) = log((D(w_i, w_j) + 1) / D(w_j))`.",,,,,,,,be1ed41510d1c9f4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,54e8a060,code,fr,dadd2ddc63590eee,"// Exercice 3 : Determiner le nombre optimal de topics
+string[] vocabOpt = {
+    ""football"", ""equipe"", ""match"", ""competition"",     // 0-3: Sport
+    ""parlement"", ""lois"", ""debat"", ""vote"",              // 4-7: Politique
+    ""guitare"", ""scene"", ""melodie"", ""concert"",          // 8-11: Musique
+    ""marche"", ""investissement"", ""action"", ""bourse""     // 12-15: Economie
+};
+int Vopt = vocabOpt.Length;
+
+// 15 documents couvrant 4 themes caches
+int[][] docsOpt = {
+    new[] { 0, 1, 2, 3, 0 },          // Sport
+    new[] { 1, 2, 0, 3, 1 },          // Sport
+    new[] { 0, 3, 2, 0, 1 },          // Sport
+    new[] { 4, 5, 6, 7, 4 },          // Politique
+    new[] { 5, 6, 4, 7, 5 },          // Politique
+    new[] { 6, 7, 4, 5, 6 },          // Politique
+    new[] { 8, 9, 10, 11, 8 },        // Musique
+    new[] { 9, 10, 8, 11, 9 },        // Musique
+    new[] { 10, 11, 8, 9, 10 },       // Musique
+    new[] { 12, 13, 14, 15, 12 },     // Economie
+    new[] { 13, 14, 12, 15, 13 },     // Economie
+    new[] { 14, 15, 12, 13, 14 },     // Economie
+    new[] { 0, 1, 12, 13, 2 },        // Sport + Economie (melange)
+    new[] { 8, 9, 4, 5, 10 },         // Musique + Politique (melange)
+    new[] { 3, 14, 15, 6, 7 }         // Sport + Economie + Politique (melange)
+};
+
+// TODO: Etape 1 - Pour chaque K dans {2, 3, 4, 5, 6}, classer les documents en K topics
+// par comptage simple des groupes de 4 mots, puis extraire les 3 top-mots de chaque topic.
+// Indice : avec K topics, decouper les indices 0..15 en K intervalles et assigner
+// chaque document au groupe dominant.
+
+// TODO: Etape 2 - Calculer la coherence UMass moyenne pour chaque K
+// Indice : reutilisez la formule C(i,j) = log((D(w_i, w_j) + 1) / D(w_j))
+// et calculez D(w_i, w_j) en parcourant docsOpt
+
+// TODO: Etape 3 - Identifier le K optimal et afficher un resume
+// Indice : K optimal = argmax de la coherence moyenne
+
+Console.WriteLine(""Exercice a completer : nombre optimal de topics"");",,,,,,,,dadd2ddc63590eee,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,b72cf769,markdown,fr,b18eec12bde81856,"## Conclusion
+
+Ce notebook a couvert le topic modeling avec LDA : modele generatif documents-topics-mots, distributions Dirichlet et probleme de symetrie.
+
+| Concept | Point cle |
+|---------|-----------|
+| LDA | Modele generatif : theta (docs) x phi (topics) -> mots observes |
+| Dirichlet | Prior conjugue pour les melanges de distributions categoriques |
+| Symetrie VMP | Priors uniformes -> mode degenere, solution : priors asymetriques |
+| Theta | Distribution de topics par document (interpretable) |
+| Phi | Distribution de mots par topic (top-mots pour interpretation) |
+
+| Distribution | Role |
+|--------------|------|
+| Dirichlet | Prior sur theta (composition documents) et phi (mots par topic) |
+| Discrete | Assignation de topic et generation de mots |
+| VariationalMessagePassing | Algorithme d'inference pour LDA |
+
+> **Point critique** : Le choix du prior Dirichlet determine la qualite de l'inference. Un prior symetrique Dir(1,...,1) mene VMP vers un mode degenere. Les priors asymetriques ou l'initialisation aleatoire sont necessaires pour briser la symetrie et obtenir des topics interpretables.",,,,,,,,b18eec12bde81856,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,4663e998,markdown,fr,ad82d02202ace50a,"# 12. Modèles Hiérarchiques Bayésiens — Pooling Partiel et Rétraction
+
+Jusqu'ici, chaque paramètre du modèle (moyenne d'un gaussien, poids d'un classifieur, compétence d'un joueur) était estimé **indépendamment**. Mais en pratique, les données sont souvent **structurées en groupes** : élèves dans des classes, patients dans des hôpitaux, essais sur des machines différentes, mesures répétées sur des sujets.
+
+Quand chaque groupe contient **peu d'observations**, deux extrêmes échouent :
+
+| Stratégie | Problème |
+|-----------|----------|
+| **Pooling complet** (ignorer les groupes, un seul paramètre global) | Gomme la variabilité réelle entre groupes |
+| **No pooling** (un paramètre indépendant par groupe) | Surajuste les groupes clairsemés (bruit interprété comme signal) |
+
+La solution bayésienne est le **pooling partiel** : chaque groupe a son propre paramètre, mais tous sont tirés d'une **loi de population commune**. Les estimations de groupes « rétractent » (*shrinkage*) vers la moyenne globale — d'autant plus fort que le groupe est mal informé (peu d'observations). C'est l'idée des **modèles hiérarchiques** (ou *multilevel*), popularisés par Gelman sous le nom de *partial pooling*.
+
+Infer.NET est un moteur **natif** pour ce paradigme : un `VariableArray` de paramètres de groupe tirés d'un *prior* partagé, inférés par EP en une seule passe. Pas besoin de MCMC — la solution analytique approchée (EP) est exacte pour la famille gaussienne.
+
+**Position dans la série** : ce notebook prépare [Infer-16-Sparse-Gaussian-Process](Infer-16-Sparse-Gaussian-Process.ipynb). Le processus gaussien apprend une longueur d'échelle (et d'autres hyperparamètres de noyau) qui, structurellement, peuvent être vus comme un prior de population sur ces hyperparamètres — un pont naturel entre les modèles hiérarchiques et les frontières non-linéaires.",,,,,,,,ad82d02202ace50a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,e7340b8f,markdown,fr,a7ebe0215d971987,"## Le piège des groupes clairsemés
+
+Considérons 8 classes de TP, chacune avec un **effet propre** (qualité de l'enseignant, niveau moyen) compris entre 1 et 7. On mesure le score de quelques élèves par classe. Certaines classes ont beaucoup d'élèves (bien informées), d'autres très peu — les classes 2, 5 et 7 n'ont qu'une ou deux mesures, donc un bruit d'échantillonnage élevé.
+
+Si on estime chaque moyenne de classe **séparément** (no pooling), la classe à 1 élève hérite d'une estimation bruitée. Si on **mélange tout** (complete pooling), on perd l'effet classe. Le modèle hiérarchique fait mieux en **empruntant de l'information** aux autres classes pour stabiliser les groupes clairsemés.
+",,,,,,,,a7ebe0215d971987,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,3d7a0b93,code,fr,8173d7fc0a67b24f,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+",,,,,,,,8173d7fc0a67b24f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,93a687b4,code,fr,c1362a3cd08f9a00,"using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Models;
+using System.Linq;
+
+// Helper : inverse CDF normale standard (Box-Muller) -- definie AVANT usage.
+double InvStdNormal(Random r) {
+    double u1 = 1.0 - r.NextDouble();
+    double u2 = 1.0 - r.NextDouble();
+    return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
+}
+
+// Vrais effets de classe (INCONNUS du modele -- servent seulement a mesurer la qualite de recuperation).
+// Effets raisonnablement dispersee (1 a 7) -- les classes 2, 5, 7 (clairsemees) tombent volontairement
+// pres de la moyenne de population (mu ~ 4.25), de sorte que la retraction vers mu corrige leur bruit.
+double[] trueClassEffects = { 1.0, 7.0, 4.0, 5.5, 2.5, 3.5, 6.5, 4.5 };
+int numClasses = trueClassEffects.Length;
+
+// Nombre d'eleves par classe (VARIABLE -- certaines classes tres clairsemees)
+int[] countsByClass = { 6, 5, 1, 7, 4, 2, 6, 1 };
+
+// Generer les donnees observees (bruit gaussien d'ecart-type 2 autour de l'effet vrai)
+// On fixe le RNG pour la reproducibilite.
+var rng = new Random(42);
+var groupIndex = new List<int>();
+var scores = new List<double>();
+for (int c = 0; c < numClasses; c++) {
+    for (int k = 0; k < countsByClass[c]; k++) {
+        double noise = 2.0 * InvStdNormal(rng);
+        scores.Add(trueClassEffects[c] + noise);
+        groupIndex.Add(c);
+    }
+}
+int totalObs = scores.Count;
+Console.WriteLine($""{numClasses} classes, {totalObs} observations (effectifs: {string.Join("","", countsByClass)})"");
+",,,,,,,,c1362a3cd08f9a00,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,d91c356c,markdown,fr,684fe4674c028df7,"## No pooling — la baseline naïve
+
+Chaque classe est estimée **séparément** par sa moyenne empirique. Aucun échange d'information entre classes. C'est l'estimateur du maximum de vraisemblance par groupe.
+",,,,,,,,684fe4674c028df7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,547b6b88,code,fr,d129f3ab7ae695b5,"// No pooling : moyenne empirique brute par classe
+double[] noPoolEstimates = new double[numClasses];
+for (int c = 0; c < numClasses; c++) {
+    var classScores = scores.Where((s, i) => groupIndex[i] == c).ToList();
+    noPoolEstimates[c] = classScores.Average();
+}
+Console.WriteLine(""Classe | n  | vrai | no-pool (brut)"");
+Console.WriteLine(""-------|----|------|---------------"");
+double noPoolMSE = 0;
+for (int c = 0; c < numClasses; c++) {
+    double err = noPoolEstimates[c] - trueClassEffects[c];
+    noPoolMSE += err * err;
+    Console.WriteLine($""  {c}    | {countsByClass[c],2} | {trueClassEffects[c],4:F1} | {noPoolEstimates[c],6:F2}"");
+}
+noPoolMSE /= numClasses;
+Console.WriteLine($""\nNo-pooling MSE de recuperation = {noPoolMSE:F3}"");
+",,,,,,,,d129f3ab7ae695b5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,0ee995ec,markdown,fr,02ee9bbbc5c268f9,"## Le modèle hiérarchique (pooling partiel)
+
+Spécification :
+- **Effet de population** `mu ~ Gaussian(0, grande variance)` (moyenne globale des classes)
+- **Précision de population** `tau ~ Gamma(...)` (à quel point les classes se ressemblent)
+- **Effet de classe** `theta[c] ~ Gaussian(mu, tau)` — chaque classe tirée de la loi commune
+- **Observation** `y[i] ~ Gaussian(theta[classe[i]], sigma_obs)` (bruit de mesure connu)
+
+L'estimation `theta[c]` résulte d'un **compromis** entre :
+- la moyenne empirique de la classe (les données),
+- la moyenne de population `mu` (le regroupement).
+
+Plus une classe a peu d'observations, plus `theta[c]` se rapproche de `mu` : c'est la **rétraction**.
+",,,,,,,,02ee9bbbc5c268f9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,73785199,code,fr,82bbc945963ddcd3,"// Modele hierarchique : theta[c] ~ N(mu, tau), y[i] ~ N(theta[classe[i]], sigma_obs)
+Range c = new Range(numClasses).Named(""c"");
+Variable<double> mu = Variable.GaussianFromMeanAndVariance(0.0, 100.0).Named(""mu"");
+Variable<double> tau = Variable.GammaFromShapeAndRate(2.0, 2.0).Named(""tau"");
+
+VariableArray<double> theta = Variable.Array<double>(c).Named(""theta"");
+theta[c] = Variable.GaussianFromMeanAndPrecision(mu, tau).ForEach(c);
+
+Range i = new Range(totalObs).Named(""i"");
+VariableArray<int> classOfI = Variable.Array<int>(i).Named(""classOfI"");
+classOfI.ObservedValue = groupIndex.ToArray();
+double obsPrec = 1.0 / (2.0 * 2.0); // variance de mesure = 4 (ecart-type 2)
+VariableArray<double> y = Variable.Array<double>(i).Named(""y"");
+using (Variable.ForEach(i)) {
+    y[i] = Variable.GaussianFromMeanAndPrecision(theta[classOfI[i]], obsPrec);
+}
+y.ObservedValue = scores.ToArray();
+
+var engine = new InferenceEngine() { ShowProgress = false };
+Gaussian muPost = engine.Infer<Gaussian>(mu);
+Gamma tauPost = engine.Infer<Gamma>(tau);
+Gaussian[] thetaPost = engine.Infer<Gaussian[]>(theta);
+
+Console.WriteLine($""Population mu = {muPost.GetMean():F2}  (prec population tau = {tauPost.GetMean():F2})"");
+Console.WriteLine();
+",,,,,,,,82bbc945963ddcd3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,29f5a230,markdown,fr,6e1e0e838bc421fa,"## Pooling partiel vs no pooling — la rétraction en action
+
+Comparons les trois quantités : effet vrai, estimation no-pool (brute), estimation hiérarchique (pooling partiel). La rétraction doit être **visiblement plus forte** pour les classes clairsemées (faible effectif).
+",,,,,,,,6e1e0e838bc421fa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,c30c821e,code,fr,3c85c7369d820bcd,"Console.WriteLine(""Classe | n  | vrai | no-pool | hierarchique | retraction"");
+Console.WriteLine(""-------|----|------|---------|--------------|----------"");
+double hierMSE = 0;
+for (int k = 0; k < numClasses; k++) {
+    double hier = thetaPost[k].GetMean();
+    double shrink = noPoolEstimates[k] - hier; // >0 = tire vers mu
+    double err = hier - trueClassEffects[k];
+    hierMSE += err * err;
+    string bar = new string('#', (int)Math.Round(Math.Abs(shrink) * 5));
+    Console.WriteLine($""  {k}    | {countsByClass[k],2} | {trueClassEffects[k],4:F1} | {noPoolEstimates[k],7:F2} | {hier,12:F2} | {bar}"");
+}
+hierMSE /= numClasses;
+Console.WriteLine($""\nNo-pooling   MSE = {noPoolMSE:F3}"");
+Console.WriteLine($""Hierarchique MSE = {hierMSE:F3}   (amelioration {100*(1 - hierMSE/noPoolMSE):F0}%)"");
+",,,,,,,,3c85c7369d820bcd,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,958f5f00,markdown,fr,232ba6b71e9e2af7,"### Lecture du résultat
+
+L'**erreur quadratique moyenne de récupération** (MSE) chute avec le pooling partiel (hierarchique < no-pooling) : les trois classes clairsemées (effectif 1 ou 2) voient leur estimateur **rétracter** vers la moyenne de population `mu`, ce qui les arrache au bruit de leur (trop) petite mesure. La classe 7 (un seul élève) en est l'illustration la plus nette : sa moyenne brute est fortement bruitée, et le modèle la ramène près de `mu` — bien plus proche de l'effet vrai.
+
+Les classes bien informées (effectif 6-7) bougent peu : leurs données dominent le compromis. Régression honnete : quand une classe bien informée a un effet **loin** de `mu` (ex. la classe d'effet 1, sous la moyenne de population), la rétraction la tire légèrement vers `mu` et peut la dégrader un peu — ce coût ponctuel est largement compensé par le gain sur les classes clairsemées, d'où la victoire nette du hiérarchique sur la MSE agrégée.
+
+C'est le cœur de la sagesse hiérarchique : **emprunter de la force statistique aux voisins quand on est mal informé**. Le paramètre `tau` (précision de population) est lui-même **estimé** depuis les données — il contrôle automatiquement l'intensité de la rétraction : des classes très différentes => `tau` faible => peu de rétraction ; des classes semblables => `tau` fort => rétraction marquée.
+",,,,,,,,232ba6b71e9e2af7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,096d8227,markdown,fr,01115249b24ebb23,"## Exercices
+
+### Exercice 1 : observer la rétraction extrême d'une classe à un seul élève
+Re-générez les données en mettant `countsByClass = { 20, 20, 1, 20, 20, 20, 20, 20 }` (une seule classe clairsemée parmi 7 bien informées). Mesurez la rétraction de la classe 2 : son estimation hiérarchique doit être **beaucoup plus proche** de `mu` que son estimation brute.
+",,,,,,,,01115249b24ebb23,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,73a50f59,code,fr,34814727b3cb89b3,"// Exercice 1 a completer
+// Conseil : reproduisez le bloc de generation + le modele ci-dessus avec le nouveau countsByClass.
+// Comparez noPoolEstimates[2] vs thetaPost[2].GetMean() -- l'ecart = retraction.
+// Etape 1 : regenerer scores/groupIndex avec countsByClass = {20,20,1,20,20,20,20,20}.
+// Etape 2 : re-executer le moteur et extraire thetaPost[2].
+// Indice : avec 1 seule observation bruitee, le no-pool herite du bruit ; le modele hierarchique
+//          lui, melange cette observation avec la population (mu), d'ou une forte retraction.
+double votreRetractionClasse2 = 0.0;  // TODO etudiant : (noPool[2] - hier[2])
+Console.WriteLine(""Exercice 1 a completer"");
+",,,,,,,,34814727b3cb89b3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,a820ea7d,markdown,fr,52b471707d25cb39,"### Exercice 2 : comment la similarité des classes pilote la rétraction
+Remplacez les effets vrais par des valeurs **très dispersées** `{ -10, -5, 0, 5, 10, 15, 20, 25 }`. L'estimation de `tau` (précision de population) doit chuter, et la rétraction doit devenir **négligeable** : si les classes sont fondamentalement différentes, le modèle ne force plus le rapprochement.
+- **Etape 1** : mettre `trueClassEffects = { -10, -5, 0, 5, 10, 15, 20, 25 }` et régénérer.
+- **Etape 2** : lire `tauPost.GetMean()` et comparer à la valeur du modèle de base.
+- **Indice** : `tau` grand = classes semblables = rétraction forte ; `tau` petit = classes hétérogènes = rétraction faible. C'est l'**auto-calibration** du modèle.
+",,,,,,,,52b471707d25cb39,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,b0c298d2,code,fr,04be477c21111a14,"// Exercice 2 a completer
+Console.WriteLine(""Exercice 2 a completer"");
+",,,,,,,,04be477c21111a14,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,3f42a4c9,markdown,fr,a79067f5d896b1b6,"### Exercice 3 : prédiction pour une nouvelle classe (posterior prédictif)
+Une **9ᵉ classe** s'ouvre, sans aucune observation. Quel score attendre pour un nouvel élève ? Le modèle hiérarchique répond : un tirage de la loi de population `mu`, puis un tirage gaussien autour. Estimez la moyenne prédictive (sans données, `theta` pour la nouvelle classe = `mu`).
+- **Etape 1** : la prédiction ponctuelle est simplement `muPost.GetMean()`.
+- **Etape 2** : l'incertitude prédictive combine la variance de `mu` et le bruit d'observation.
+- **Indice** : c'est l'avantage clé du hiérarchique sur le no-pool, qui ne sait rien dire d'une classe inédite.
+",,,,,,,,a79067f5d896b1b6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,fe963a69,code,fr,0770921c33663f0f,"// Exercice 3 a completer
+double predictionNouvelleClasse = 0.0;  // TODO etudiant : muPost.GetMean()
+Console.WriteLine(""Exercice 3 a completer"");
+",,,,,,,,0770921c33663f0f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,1d46fcd8,markdown,fr,5de40b589291b270,"## Conclusion
+
+Les **modèles hiérarchiques** résolvent le dilemme pooling/no-pooling par un **prior de population partagé**. Infer.NET les exprime naturellement : un `VariableArray` de paramètres `theta[c]` tirés d'une loi commune `(mu, tau)`, avec l'indexation `theta[classOfI[i]]` qui rattache chaque observation à sa classe. L'inférence par EP est **analytique** (pas de MCMC) pour la famille gaussienne.
+
+La **rétraction** (*shrinkage*) n'est pas un artefact — c'est la conséquence optimale du théorème de Bayes sur des groupes inégalement informés. Elle auto-équilibre la confiance entre données locales et regroupement global, et le paramètre `tau` est **estimé depuis les données** pour calibrer cet équilibre. C'est l'une des idées les plus fécondes de la statistique bayésienne moderne, et un cas d'école de ce qu'un moteur comme Infer.NET fait élégamment.
+
+> **Prochaines étapes** : la même structure se généralise à des régressions par groupe (pentes/intercepts variables), aux modèles spatio-temporels, et aux modèles de recommandation (Infer-15). Le principe reste : **des paramètres de bas niveau tirés d'une loi de haut niveau, inférés conjointement**.
+",,,,,,,,5de40b589291b270,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,9df317ec,markdown,fr,101ad13c88e98b06,"# Infer-13-Crowdsourcing : Agregation de Labels et Fiabilite
+
+**Serie** : Programmation Probabiliste avec Infer.NET (13/20)  
+**Duree estimee** : 55 minutes  
+**Prerequis** : Infer-11-Topic-Models
+
+---
+
+## Objectifs
+
+- Comprendre le probleme de l'agregation de labels
+- Implementer le modele Honest Worker
+- Construire le modele Biased Worker avec matrice de confusion
+- Explorer le modele hierarchique Community
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-12-Modeles-Hierarchiques](Infer-12-Modeles-Hierarchiques.ipynb) | [Infer-14-Sequences](Infer-14-Sequences.ipynb) |
+
+---",,,,,,,,101ad13c88e98b06,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,8976057b,markdown,fr,ab37d2ffac5b3cf3,"## 1. Configuration
+
+Nous chargeons les packages pour les modeles de crowdsourcing. Ces modeles probabilistes permettent d'agreger des annotations provenant de multiples travailleurs de fiabilites variables, tout en estimant simultanement la verite latente et la qualite de chaque annotateur.",,,,,,,,ab37d2ffac5b3cf3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,98174c6e,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,a13f2a97,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,n6bnokfm66,code,fr,437bfaae8e3bebd0,"// Chargement du helper pour visualiser les factor graphs
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper charge - Graphviz disponible : "" + FactorGraphHelper.IsGraphvizAvailable());",,,,,,,,437bfaae8e3bebd0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,b4d27yfblwm,markdown,fr,e7ee8abd0c1b42ab,"Le `FactorGraphHelper` permet de visualiser les graphes de facteurs generes par Infer.NET. Quand `ShowFactorGraph = true`, le moteur genere un fichier `.gv` (format Graphviz) que le helper convertit en SVG pour affichage inline.",,,,,,,,e7ee8abd0c1b42ab,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,vby8bp601ke,markdown,fr,c2b2cfad8136a852,"Les packages Infer.NET sont prêts pour les modèles de crowdsourcing. Ce notebook utilise principalement `Microsoft.ML.Probabilistic` (moteur d'inférence), `Compiler` (compilation des modèles) et les distributions `Beta`, `Dirichlet` pour les priors.",,,,,,,,c2b2cfad8136a852,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,4daaeec0,markdown,fr,fb12fadcfed3fd51,"## 2. Le Probleme du Crowdsourcing
+
+### Contexte
+
+On veut annoter un grand nombre d'images (spam/non-spam, sentiment, etc.) en utilisant des travailleurs non-experts sur des plateformes comme Amazon Mechanical Turk.
+
+### Defis
+
+| Defi | Description |
+|------|-------------|
+| **Fiabilite variable** | Certains travailleurs sont meilleurs que d'autres |
+| **Biais** | Certains ont tendance a repondre toujours la meme chose |
+| **Verite inconnue** | On ne connait pas le vrai label |
+| **Cout** | Limiter le nombre d'annotations par item |
+
+### Solution
+
+Modele probabiliste qui estime simultanement :
+- Le vrai label de chaque item
+- La qualite de chaque travailleur",,,,,,,,fb12fadcfed3fd51,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,jql66bz67ba,markdown,fr,acb09656e647a31b,"### Formalisation mathematique
+
+Le probleme d'agregation de labels peut se formaliser comme suit :
+
+**Variables latentes** :
+- $t_i \in \{1, \ldots, K\}$ : vrai label de l'item $i$
+- $\theta_w$ : parametres de qualite du worker $w$
+
+**Variables observees** :
+- $l_{w,i}$ : label donne par le worker $w$ pour l'item $i$
+
+**Objectif** : Inferer $P(t_i | \{l_{w,i}\}_{w=1}^W)$ pour chaque item
+
+La formule de Bayes donne :
+
+$$P(t_i = k | \text{labels}) \propto P(t_i = k) \prod_{w} P(l_{w,i} | t_i = k, \theta_w)$$
+
+> **Note** : La difficulte reside dans l'estimation jointe des $t_i$ et des $\theta_w$, car les deux sont inconnus. C'est un probleme de type ""poule et oeuf"" que l'inference bayesienne resout elegamment.",,,,,,,,acb09656e647a31b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,135fb091,markdown,fr,ab11dbbcf2e4c24d,"## 3. Modele Honest Worker
+
+### Hypothese
+
+Chaque travailleur a une **capacite** (probabilite de donner la bonne reponse).
+
+### Modele
+
+$$\text{capacite}_w \sim \text{Beta}(\alpha, \beta)$$
+
+$$P(\text{label}_w = \text{vrai label}) = \text{capacite}_w$$
+$$P(\text{label}_w \neq \text{vrai label}) = \frac{1 - \text{capacite}_w}{K-1}$$
+
+ou K est le nombre de classes.",,,,,,,,ab11dbbcf2e4c24d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,58a8t2yac3,markdown,fr,69e195c1fb644ef4,"### Structure graphique du modele Honest Worker
+
+```
+            +-------------+
+            |   Beta(a,b) |
+            +------+------+
+                   |
+                   v
+         +---------+---------+
+         |  capacite[w]      |  (par worker)
+         +---------+---------+
+                   |
+                   v
+        +----------+----------+
+        | P(correct) = cap[w] |
+        +----------+----------+
+                   |
+       +-----------+-----------+
+       |                       |
+       v                       v
+  [Si correct]           [Si incorrect]
+       |                       |
+       v                       v
+label[w,i] = t[i]     label[w,i] ~ Uniform(K)
+```
+
+Le prior $\text{Beta}(2, 1)$ encode une croyance que les workers sont ""plutot honnetes"" :
+
+| Prior | Moyenne | Interpretation |
+|-------|---------|----------------|
+| Beta(1, 1) | 0.50 | Aucune information |
+| Beta(2, 1) | 0.67 | Workers legerement fiables |
+| Beta(5, 1) | 0.83 | Workers tres fiables |
+| Beta(1, 2) | 0.33 | Workers souvent faux |",,,,,,,,69e195c1fb644ef4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,6006a99e,code,fr,753d7726c16639bb,"// Donnees de crowdsourcing
+// 5 items, 4 workers, 2 classes (0 ou 1)
+
+int nItems = 5;
+int nWorkers = 4;
+int nClasses = 2;
+
+// Labels donnes par chaque worker pour chaque item (-1 = pas d'annotation)
+int[,] labels = {
+    // W1  W2  W3  W4
+    {  1,  1,  1,  0 },  // Item 0 : consensus 1
+    {  0,  0,  0,  0 },  // Item 1 : consensus 0
+    {  1,  1,  0,  1 },  // Item 2 : majorite 1
+    {  0,  1,  0,  0 },  // Item 3 : majorite 0
+    {  1,  0,  1,  1 }   // Item 4 : majorite 1
+};
+
+// Vrais labels (pour evaluation - inconnus du modele)
+int[] vraisLabels = { 1, 0, 1, 0, 1 };
+
+Console.WriteLine(""=== Donnees Crowdsourcing ==="");
+Console.WriteLine(""\nLabels donnes par les workers :"");
+Console.Write(""        "");
+for (int w = 0; w < nWorkers; w++) Console.Write($""W{w+1} "");
+Console.WriteLine(""| Vrai"");
+
+for (int i = 0; i < nItems; i++)
+{
+    Console.Write($""Item {i} : "");
+    for (int w = 0; w < nWorkers; w++)
+    {
+        Console.Write($"" {labels[i, w]} "");
+    }
+    Console.WriteLine($"" |  {vraisLabels[i]}"");
+}",,,,,,,,753d7726c16639bb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,7ie7hg4819q,markdown,fr,14fb195709ae7540,"### Lecture des donnees
+
+Le tableau ci-dessus montre un scenario typique de crowdsourcing :
+
+| Pattern | Items | Observation |
+|---------|-------|-------------|
+| **Consensus fort** | 1 | Tous les workers s'accordent sur 0 |
+| **Consensus majoritaire** | 0, 2, 3, 4 | 3 workers sur 4 s'accordent |
+| **Dissident** | W4 (Item 0), W3 (Item 2) | Un worker contredit les autres |
+
+**Question cle** : Comment distinguer un worker peu fiable d'un worker qui a raison contre la majorite ?
+
+> **Remarque** : Dans ce jeu de donnees, W4 se trompe sur l'Item 0 (dit 0 alors que le vrai est 1). Le modele devrait detecter cette tendance a l'erreur.",,,,,,,,14fb195709ae7540,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,69h3le9i0bd,markdown,fr,bd4e01988ffa463d,"### Implementation du modele Honest Worker
+
+Nous implementons maintenant le modele pour un seul item (Item 2) ou il y a desaccord. Le modele Infer.NET :
+1. Definit un prior uniforme sur le vrai label
+2. Assigne une capacite Beta(2,1) a chaque worker
+3. Modelise la probabilite que chaque worker reponde correctement via `Variable.Bernoulli`",,,,,,,,bd4e01988ffa463d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,25e1cfd8,code,fr,8eb5cb11f6b52234,"// Modele Honest Worker simplifie (pour un item)
+
+int itemIdx = 2;  // Item avec desaccord
+int[] labelsItem = { labels[itemIdx, 0], labels[itemIdx, 1], labels[itemIdx, 2], labels[itemIdx, 3] };
+
+// Prior sur le vrai label (uniforme)
+Variable<int> vraiLabel = Variable.DiscreteUniform(nClasses).Named(""vraiLabel"");
+
+// Capacites des workers
+Range workerRange = new Range(nWorkers).Named(""worker"");
+VariableArray<double> capacite = Variable.Array<double>(workerRange).Named(""capacite"");
+capacite[workerRange] = Variable.Beta(2, 1).ForEach(workerRange);  // Prior : plus de 50%
+
+// Labels observes
+VariableArray<int> labelObs = Variable.Array<int>(workerRange).Named(""labelObs"");
+
+using (Variable.ForEach(workerRange))
+{
+    Variable<bool> estCorrect = Variable.Bernoulli(capacite[workerRange]);
+    using (Variable.If(estCorrect))
+    {
+        labelObs[workerRange] = vraiLabel;  // Repond correctement
+    }
+    using (Variable.IfNot(estCorrect))
+    {
+        labelObs[workerRange] = Variable.DiscreteUniform(nClasses);  // Reponse aleatoire
+    }
+}
+
+labelObs.ObservedValue = labelsItem;
+
+InferenceEngine moteurHW = new InferenceEngine();
+moteurHW.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurHW.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Discrete vraiLabelPost = moteurHW.Infer<Discrete>(vraiLabel);
+Beta[] capacitePost = moteurHW.Infer<Beta[]>(capacite);
+
+Console.WriteLine($""\n=== Honest Worker pour Item {itemIdx} ==="");
+Console.WriteLine($""Labels observes : {string.Join("", "", labelsItem)}"");
+Console.WriteLine($""Vrai label : {vraisLabels[itemIdx]}\n"");
+
+Console.WriteLine($""P(vrai label = 0) = {vraiLabelPost.GetProbs()[0]:F3}"");
+Console.WriteLine($""P(vrai label = 1) = {vraiLabelPost.GetProbs()[1]:F3}"");
+
+Console.WriteLine(""\nCapacites des workers :"");
+for (int w = 0; w < nWorkers; w++)
+{
+    Console.WriteLine($""  Worker {w+1} : {capacitePost[w].GetMean():F3}"");
+}",,,,,,,,8eb5cb11f6b52234,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,5ezctf7vo4s,markdown,fr,27364c4ecdd78154,"### Analyse du modèle Honest Worker
+
+**Item analysé** : Item 2 avec labels [1, 1, 0, 1] (vrai label = 1)
+
+| Mesure | Valeur | Interprétation |
+|--------|--------|----------------|
+| **P(vrai=1)** | 0.962 | Forte confiance malgré le désaccord |
+| **P(vrai=0)** | 0.038 | Très faible probabilité |
+| **Capacité W1, W2, W4** | 0.692 | Workers en accord avec la majorité |
+| **Capacité W3** | 0.508 | Worker minoritaire ≈ aléatoire |
+
+**Observations clés** :
+
+1. **Consensus bayésien** : 3/4 workers disent ""1"" → P(vrai=1) = 96.2%, bien plus que le 75% du vote brut
+
+2. **Estimation de capacité** :
+   - Workers majoritaires : capacité ~0.69 (supérieure au prior Beta(2,1) = 0.67)
+   - Worker minoritaire : capacité ~0.51 (proche du hasard)
+
+3. **Effet du prior** : Beta(2,1) encode l'hypothèse que les workers sont ""honnêtes"" (> 50% correct)
+
+**Pourquoi P(vrai=1) > 75% ?**
+
+Le modèle bayésien pondère les votes par la capacité estimée. Les workers en accord renforcent mutuellement leur crédibilité, tandis que W3 minoritaire perd en influence.",,,,,,,,27364c4ecdd78154,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,6ujpksjkwvb,code,fr,cbae43934010bd81,"// Visualisation du graphe de facteurs Honest Worker
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,cbae43934010bd81,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,ckyzp6u7hi,markdown,fr,63571a8928afb79b,"### Lecture du graphe de facteurs Honest Worker
+
+Le graphe ci-dessus montre la structure du modele Honest Worker :
+
+| Element | Representation | Role |
+|---------|----------------|------|
+| **vraiLabel** | Noeud variable (ellipse) | Variable latente : vrai label de l'item |
+| **capacite[w]** | Noeud variable (ellipse) | Capacite de chaque worker (prior Beta) |
+| **labelObs[w]** | Noeud observe (ellipse grisee) | Labels observes des workers |
+| **Bernoulli** | Facteur (rectangle) | Relie capacite a la probabilite de reponse correcte |
+| **DiscreteUniform** | Facteur (rectangle) | Prior uniforme sur vraiLabel |
+
+**Structure conditionnelle** : Le modele utilise `Variable.If/IfNot` pour creer une structure en ""gate"" :
+- Si `estCorrect = true` : `labelObs = vraiLabel`
+- Si `estCorrect = false` : `labelObs ~ Uniform(K)`
+
+Cette structure permet a l'inference de propager l'information des labels observes vers l'estimation du vrai label et des capacites des workers.",,,,,,,,63571a8928afb79b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,b275563f,markdown,fr,e6e334a85281d2d6,"## 4. Modele Biased Worker
+
+### Amelioration
+
+Au lieu d'une simple capacite, chaque worker a une **matrice de confusion** qui capture ses biais.
+
+### Modele
+
+$$\text{confusion}_{w}[c] \sim \text{Dirichlet}(\alpha)$$
+
+$$P(\text{label}_w = l | \text{vrai} = c) = \text{confusion}_w[c][l]$$",,,,,,,,e6e334a85281d2d6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,md83e1n44yp,markdown,fr,a32bd566e4e9740b,"### Comparaison Honest vs Biased Worker
+
+| Aspect | Honest Worker | Biased Worker |
+|--------|---------------|---------------|
+| **Parametres par worker** | 1 (capacite) | $K^2$ (matrice) |
+| **Type d'erreur** | Symetrique | Asymetrique |
+| **Biais detecte** | Non | Oui |
+| **Complexite** | Faible | Moyenne |
+| **Donnees requises** | Peu | Plus |
+
+**Exemple de biais** : Un annotateur de spam qui marque tout comme ""spam"" aura :
+
+$$\text{confusion} = \begin{pmatrix} 0.3 & 0.7 \\ 0.1 & 0.9 \end{pmatrix}$$
+
+- Vrai=non-spam : 30% correct, 70% erreur
+- Vrai=spam : 10% erreur, 90% correct
+
+Le modele Honest Worker ne peut pas capturer cette asymetrie.",,,,,,,,a32bd566e4e9740b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,tasoq959b8s,markdown,fr,dab500bc65c2fbbb,"### Implementation du modele Biased Worker
+
+Nous allons maintenant estimer la matrice de confusion du Worker 4 (W4), qui semble avoir fait des erreurs systematiques. Contrairement a Honest Worker, ce modele utilise un prior Dirichlet sur chaque ligne de la matrice de confusion.
+
+> **Note technique** : La methode `SetValueRange()` est necessaire pour que `Variable.Switch()` fonctionne correctement avec les indices de la matrice.",,,,,,,,dab500bc65c2fbbb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,ebf6207a,code,fr,5baa02f845450062,"// Modele Biased Worker simplifie
+
+// Pour un worker specifique, estimer sa matrice de confusion
+// etant donne plusieurs annotations avec vrais labels connus
+
+// Worker 3 (W4) semble avoir fait des erreurs
+int[] w4Labels = { labels[0, 3], labels[1, 3], labels[2, 3], labels[3, 3], labels[4, 3] };
+// W4 labels : 0, 0, 1, 0, 1
+// Vrais     : 1, 0, 1, 0, 1
+// W4 se trompe sur item 0 (vrai=1, dit 0)
+
+// Prior sur la matrice de confusion (Dirichlet par ligne)
+Range classRange = new Range(nClasses).Named(""class"");
+
+VariableArray<Vector> confusion = Variable.Array<Vector>(classRange).Named(""confusion"");
+double[] dirichletPrior = { 10, 1 };  // Prior : plus de chances de repondre correctement
+
+using (Variable.ForEach(classRange))
+{
+    // Pour chaque vrai label, distribution sur les reponses possibles
+    confusion[classRange] = Variable.Dirichlet(dirichletPrior);
+}
+
+// Observations
+Range itemRange2 = new Range(nItems).Named(""item"");
+VariableArray<int> vraiLabelsVar = Variable.Array<int>(itemRange2).Named(""vrai"");
+VariableArray<int> workerLabelsVar = Variable.Array<int>(itemRange2).Named(""workerLabel"");
+
+// IMPORTANT: SetValueRange est necessaire pour utiliser Variable.Switch()
+vraiLabelsVar.SetValueRange(classRange);
+
+using (Variable.ForEach(itemRange2))
+{
+    using (Variable.Switch(vraiLabelsVar[itemRange2]))
+    {
+        workerLabelsVar[itemRange2] = Variable.Discrete(confusion[vraiLabelsVar[itemRange2]]);
+    }
+}
+
+vraiLabelsVar.ObservedValue = vraisLabels;
+workerLabelsVar.ObservedValue = w4Labels;
+
+InferenceEngine moteurBW = new InferenceEngine(new ExpectationPropagation());
+moteurBW.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurBW.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Dirichlet[] confusionPost = moteurBW.Infer<Dirichlet[]>(confusion);
+
+Console.WriteLine(""=== Biased Worker (W4) ==="");
+Console.WriteLine(""\nMatrice de confusion estimee :"");
+Console.WriteLine(""           Repond 0  Repond 1"");
+for (int c = 0; c < nClasses; c++)
+{
+    Vector probs = confusionPost[c].GetMean();
+    Console.WriteLine($""Vrai = {c} :   {probs[0]:F2}       {probs[1]:F2}"");
+}",,,,,,,,5baa02f845450062,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,1ajq1wtiu91,markdown,fr,65c3337b43d3cda9,"### Analyse de la matrice de confusion (W4)
+
+**Données** : W4 labels = [0, 0, 1, 0, 1], Vrais = [1, 0, 1, 0, 1]
+- Erreur sur Item 0 : vrai=1, W4 dit 0
+- Correct sur Items 1, 2, 3, 4
+
+**Matrice de confusion estimée** :
+
+|  | Répond 0 | Répond 1 |
+|--|----------|----------|
+| **Vrai=0** | 0.92 | 0.08 |
+| **Vrai=1** | 0.79 | 0.21 |
+
+**Interprétation** :
+
+Sur les données brutes, W4 obtient 2 bonnes réponses sur 2 pour les items de vrai=0 (Items 1 et 3), et 2 bonnes sur 3 pour les items de vrai=1 (Items 2 et 4 corrects, Item 0 erroné) :
+
+- Vrai=0 → 2/2 = 100% correct en brut (posterior 0.92 sur la diagonale)
+- Vrai=1 → 2/3 ≈ 67% correct en brut, mais le posterior donne P(Répond 1 | Vrai=1) = 0.21
+
+**Pourquoi le posterior (0.21) diffère tant du taux brut (67%)** : le prior `Dirichlet(10, 1)` est appliqué de façon identique aux deux lignes de la matrice, ce qui revient à supposer a priori que le worker répond ""0"" avec probabilité 10/11 ≈ 91%, quelle que soit la vraie classe. Avec seulement 3 items en vrai=1, ce prior lisse fortement la ligne et tire la masse vers ""Répond 0"" (posterior 0.79). Les données ne dominent donc pas ici : l'écart entre brut (67%) et posterior (21%) mesure l'effet du prior sur un petit échantillon, et non une erreur massive de W4 sur la classe 1.
+
+2. **Asymétrie** : W4 se trompe une fois sur la classe 1 (Item 0) et jamais sur la classe 0. Le modèle Biased Worker capture cette asymétrie, qu'un Honest Worker à capacité scalaire ne pourrait pas représenter.
+
+3. **Prior Dirichlet(10,1)** : Encode une préférence marquée pour la réponse ""0"". C'est utile comme point de départ régularisé sur un petit jeu supervisé, mais à garder à l'esprit lors de la lecture des postérieurs.
+
+**Avantage du modèle Biased Worker** :
+
+Contrairement à Honest Worker qui suppose une erreur symétrique, ce modèle représente chaque classe par sa propre ligne de la matrice de confusion, ce qui permet de capturer :
+- Les biais asymétriques (ex: tend à prédire ""spam"" même pour du non-spam)
+- Les confusions spécifiques entre classes (ex: confond chats avec chiens, mais pas avec oiseaux)",,,,,,,,65c3337b43d3cda9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,xv3xrk1f97s,code,fr,0f58af7939e44e41,"// Visualisation du graphe de facteurs Biased Worker
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,0f58af7939e44e41,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,25scpjj874o,markdown,fr,69403f2272836202,"### Lecture du graphe de facteurs Biased Worker
+
+Le graphe de facteurs du modele Biased Worker est plus riche que celui de Honest Worker :
+
+| Element | Representation | Role |
+|---------|----------------|------|
+| **confusion[c]** | Noeud variable (ellipse) | Matrice de confusion : distribution Dirichlet par classe |
+| **vrai[i]** | Noeud observe (ellipse grisee) | Vrais labels (connus dans ce cas supervise) |
+| **workerLabel[i]** | Noeud observe (ellipse grisee) | Labels donnes par le worker |
+| **Dirichlet** | Facteur (rectangle) | Prior sur chaque ligne de la matrice de confusion |
+| **Discrete** | Facteur (rectangle) | Lie le vrai label au label predit via la matrice |
+| **Switch** | Facteur (rectangle) | Selection conditionnelle de la ligne de confusion |
+
+**Difference cle avec Honest Worker** :
+
+Dans Honest Worker, un worker avait une **capacite scalaire** $c \in [0,1]$.
+
+Dans Biased Worker, un worker a une **matrice de confusion** $K \times K$ ou chaque ligne est une distribution Dirichlet. Cela permet de capturer :
+- Les biais asymetriques (ex: tend a predire ""spam"" meme pour du non-spam)
+- Les confusions specifiques entre classes (ex: confond chats avec chiens, mais pas avec oiseaux)
+
+**Variable.Switch** : Cette construction Infer.NET permet de selectionner dynamiquement une ligne de la matrice selon la valeur du vrai label. C'est l'equivalent d'un ""indexage probabiliste"".",,,,,,,,69403f2272836202,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,a9b5286c,markdown,fr,1884c72a7875323f,"## 5. Agregation de Tous les Items
+
+Apres avoir explore les modeles au niveau individuel, comparons leurs performances sur l'ensemble des items. Nous utiliserons le vote majoritaire comme baseline simple.",,,,,,,,1884c72a7875323f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,92324719,code,fr,c997657aa363752d,"// Agregation par vote majoritaire (baseline)
+
+Console.WriteLine(""=== Comparaison des Methodes ==="");
+Console.WriteLine(""\nVote majoritaire vs Vrai label :"");
+
+int correctMajority = 0;
+
+for (int i = 0; i < nItems; i++)
+{
+    int count0 = 0, count1 = 0;
+    for (int w = 0; w < nWorkers; w++)
+    {
+        if (labels[i, w] == 0) count0++;
+        else count1++;
+    }
+    
+    int majority = count0 > count1 ? 0 : 1;
+    bool correct = majority == vraisLabels[i];
+    if (correct) correctMajority++;
+    
+    Console.WriteLine($""Item {i} : Majoritaire={majority}, Vrai={vraisLabels[i]} {(correct ? ""OK"" : ""ERREUR"")}"");
+}
+
+Console.WriteLine($""\nPrecision vote majoritaire : {correctMajority}/{nItems} = {100.0 * correctMajority / nItems:F0}%"");",,,,,,,,c997657aa363752d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,qga3lp8occ,markdown,fr,921930ad16db34e8,"### Analyse du vote majoritaire
+
+**Résultat** : 100% de précision (5/5 items corrects)
+
+| Item | Votes (0:1) | Majorité | Vrai | Résultat |
+|------|-------------|----------|------|----------|
+| 0 | 1:3 | 1 | 1 | OK |
+| 1 | 4:0 | 0 | 0 | OK |
+| 2 | 1:3 | 1 | 1 | OK |
+| 3 | 3:1 | 0 | 0 | OK |
+| 4 | 1:3 | 1 | 1 | OK |
+
+**Observations** :
+
+1. **Performance parfaite** : Dans ce petit exemple, le vote majoritaire suffit
+2. **Cas favorables** : Tous les items ont un consensus clair (3:1 ou 4:0)
+3. **Limitation** : Avec des cas 2:2, le vote majoritaire est indécis
+
+**Quand le modèle probabiliste est meilleur** :
+
+1. **Peu d'annotations** : 1-2 votes par item → besoin de pondérer par qualité
+2. **Workers biaisés** : Vote majoritaire ignore les biais systématiques
+3. **Items difficiles** : Les modèles estiment aussi l'incertitude
+4. **Données manquantes** : Annotations incomplètes gérées naturellement
+
+**Note** : La vraie valeur des modèles de crowdsourcing apparaît sur de grands datasets avec workers hétérogènes.",,,,,,,,921930ad16db34e8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,9d838173,markdown,fr,8c61e741ef498578,"## 5bis. Exercice : Detection de Workers Contradictoires par Matrice d'Accord
+
+### Contexte
+
+Dans la section precedente, nous avons vu que le vote majoritaire atteint 100% sur notre petit jeu de donnees. Cependant, cette methode ignore les relations entre workers. Une matrice d'accord inter-annotateurs permet de detecter des workers qui contredisent systematiquement les autres.
+
+**Objectif** : Construire une matrice d'accord entre workers, puis identifier les paires de workers les plus en desaccord.
+
+### Enonce
+
+A partir de la matrice `labels` deja definie (5 items, 4 workers) :
+
+1. Calculez la **matrice d'accord** `agreement[w1, w2]` = proportion d'items ou `labels[i, w1] == labels[i, w2]`
+2. Identifiez la paire de workers avec le **taux d'accord le plus faible**
+3. Pour cette paire, determinez lequel des deux workers est le plus credible en comparant avec les vrais labels
+
+> **Indice** : La matrice d'accord est symetrique et sa diagonale vaut 1.0. Pour chaque paire (w1, w2), comptez le nombre d'items ou ils s'accordent et divisez par `nItems`. Utilisez `vraisLabels` pour determiner qui a raison quand ils divergent.",,,,,,,,8c61e741ef498578,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,22f720ce,code,fr,3f47bbb4cc8c9a6a,"// Exercice : Detection de workers contradictoires par matrice d'accord
+
+// TODO: Etape 1 - Calculer la matrice d'accord entre workers
+// double[,] agreement = new double[nWorkers, nWorkers];
+// Pour chaque paire (w1, w2), calculer la proportion d'accord
+
+// TODO: Etape 2 - Afficher la matrice d'accord
+// Console.WriteLine(""Matrice d'accord inter-annotateurs :"");
+
+// TODO: Etape 3 - Trouver la paire avec le plus faible taux d'accord
+
+// TODO: Etape 4 - Comparer les deux workers divergents avec les vrais labels
+// Pour determiner lequel est le plus fiable
+Console.WriteLine(""Exercice a completer"");",,,,,,,,3f47bbb4cc8c9a6a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,813c411a,markdown,fr,1fcf206bc9b51779,"## 6. Modele Community (Hierarchique)
+
+### Idee
+
+Les workers appartiennent a des **communautes** avec des caracteristiques similaires.
+
+### Structure
+
+```
+Communaute[c] : matrice de confusion partagee
+    |
+    v
+Worker[w] : appartient a communaute z[w]
+    |
+    v
+Label[w,i] : genere selon confusion[z[w]]
+```",,,,,,,,1fcf206bc9b51779,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,1fhq2eah4f5,markdown,fr,bf4c8ea53d033814,"### Implementation du modele Community
+
+Nous definissons la structure de base d'un modele hierarchique avec deux communautes (Experts et Spammeurs). En pratique, ce modele necessite plus de donnees pour estimer correctement les parametres des communautes.
+
+> **Note** : L'implementation complete avec inference sur tous les items est plus complexe et necessite une specification soigneuse des dependances entre variables.",,,,,,,,bf4c8ea53d033814,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,a1b1439c,code,fr,fcbd467e513952de,"// Modele Community simplifie
+
+// Simulons 2 communautes :
+// - Experts (haute precision)
+// - Spammeurs (repondent aleatoirement)
+
+int nCommunities = 2;
+
+// Distribution sur les communautes
+Variable<Vector> pCommunity = Variable.Dirichlet(new double[] { 1, 1 }).Named(""pCommunity"");
+
+Range communityRange = new Range(nCommunities).Named(""community"");
+Range workerRange3 = new Range(nWorkers).Named(""worker"");
+
+// Capacite par communaute
+VariableArray<double> communityCapacity = Variable.Array<double>(communityRange).Named(""communityCapacity"");
+communityCapacity[communityRange] = Variable.Beta(2, 1).ForEach(communityRange);
+
+// Assignation des workers aux communautes
+VariableArray<int> workerCommunity = Variable.Array<int>(workerRange3).Named(""workerCommunity"");
+workerCommunity[workerRange3] = Variable.Discrete(pCommunity).ForEach(workerRange3);
+
+Console.WriteLine(""=== Modele Community ==="");
+Console.WriteLine(""\nHypothese : 2 communautes (Experts / Spammeurs)"");
+Console.WriteLine(""\nLe modele infere l'appartenance de chaque worker."");",,,,,,,,fcbd467e513952de,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,s35swlefpcf,markdown,fr,97b848f21f3d956c,"### Structure hierarchique du modele Community
+
+Le modele Community introduit un niveau de hierarchie supplementaire :
+
+**Niveau 1 (Communautes)** :
+$$\theta_c \sim \text{Prior}(\text{capacite par communaute})$$
+
+**Niveau 2 (Workers)** :
+$$z_w \sim \text{Categorical}(\pi) \quad \text{(appartenance communaute)}$$
+$$\text{qualite}_w = \theta_{z_w}$$
+
+**Niveau 3 (Annotations)** :
+$$l_{w,i} \sim P(\cdot | t_i, \text{qualite}_w)$$
+
+**Avantages** :
+
+| Benefice | Explication |
+|----------|-------------|
+| **Partage d'information** | Workers d'une meme communaute s'informent mutuellement |
+| **Nouveaux workers** | Un nouveau worker est initialise selon sa communaute |
+| **Interpretabilite** | On peut nommer les communautes (experts, novices, spammeurs) |
+| **Regularisation** | Moins de parametres que Biased Worker complet |
+
+> **Analogie** : C'est similaire a un modele de melange gaussien (GMM), mais applique aux workers au lieu des donnees.",,,,,,,,97b848f21f3d956c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,40125ab1,markdown,fr,f08b213569b304bc,"## 7. Apprentissage Actif
+
+### Objectif
+
+Choisir **quels items** faire annoter et par **quels workers** pour maximiser l'information gagnee.
+
+### Strategies
+
+| Strategie | Description |
+|-----------|-------------|
+| **Uncertainty sampling** | Annoter les items les plus incertains |
+| **Worker evaluation** | Tester les workers sur des items connus |
+| **Information gain** | Maximiser la reduction d'entropie |",,,,,,,,f08b213569b304bc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,14nzxw2dqhx,markdown,fr,ef9d7a25a56861be,"### Formulation mathematique de l'apprentissage actif
+
+L'objectif est de selectionner la paire (item, worker) qui maximise le gain d'information :
+
+$$\text{Gain}(i, w) = H(t_i) - \mathbb{E}_{l_{w,i}}[H(t_i | l_{w,i})]$$
+
+ou $H(\cdot)$ est l'entropie de Shannon.
+
+**Interpretation** :
+- $H(t_i)$ : incertitude actuelle sur le vrai label
+- $\mathbb{E}[H(t_i | l_{w,i})]$ : incertitude attendue apres avoir observe l'annotation
+
+**Entropie binaire** : Pour $K=2$ classes avec probabilite $p$ :
+
+$$H(p) = -p \log_2(p) - (1-p) \log_2(1-p)$$
+
+| $p$ | $H(p)$ | Interpretation |
+|-----|--------|----------------|
+| 0.50 | 1.00 | Incertitude maximale |
+| 0.75 | 0.81 | Incertitude elevee |
+| 0.90 | 0.47 | Incertitude moderee |
+| 0.99 | 0.08 | Quasi-certain |",,,,,,,,ef9d7a25a56861be,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,jy4ls15db6,markdown,fr,29d023fe98198c8c,"### Implementation de l'uncertainty sampling
+
+Nous calculons l'entropie pour chaque item afin d'identifier ceux qui beneficieraient le plus d'annotations supplementaires. L'entropie est maximale (1.0) quand la distribution est 50/50, et nulle quand il y a consensus parfait.",,,,,,,,29d023fe98198c8c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,85318986,code,fr,62be4f8f95d457ea,"// Selection d'items basee sur l'incertitude
+
+Console.WriteLine(""=== Apprentissage Actif ==="");
+Console.WriteLine(""\nSelection des items les plus incertains :"");
+
+// Calculer l'incertitude (entropie) pour chaque item base sur le vote majoritaire
+var incertitudes = new List<(int item, double entropie)>();
+
+for (int i = 0; i < nItems; i++)
+{
+    int count0 = 0, count1 = 0;
+    for (int w = 0; w < nWorkers; w++)
+    {
+        if (labels[i, w] == 0) count0++;
+        else count1++;
+    }
+    
+    double p0 = (double)count0 / nWorkers;
+    double p1 = (double)count1 / nWorkers;
+    
+    // Entropie binaire
+    double entropie = 0;
+    if (p0 > 0) entropie -= p0 * Math.Log2(p0);
+    if (p1 > 0) entropie -= p1 * Math.Log2(p1);
+    
+    incertitudes.Add((i, entropie));
+    Console.WriteLine($""Item {i} : votes 0:{count0} / 1:{count1}, entropie = {entropie:F3}"");
+}
+
+var prioritaire = incertitudes.OrderByDescending(x => x.entropie).First();
+Console.WriteLine($""\n=> Item {prioritaire.item} devrait etre annote en priorite (entropie max)"");",,,,,,,,62be4f8f95d457ea,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,1uydzcj0s2j,markdown,fr,d545cd132d0b8424,"### Analyse de l'apprentissage actif
+
+**Résultats d'entropie** :
+
+| Item | Votes (0:1) | Entropie | Incertitude |
+|------|-------------|----------|-------------|
+| 1 | 4:0 | 0.000 | **Nulle** (consensus total) |
+| 0, 2, 3, 4 | 1:3 ou 3:1 | 0.811 | **Égale** (même distribution 75/25) |
+
+**Observations** :
+
+1. **Item 1 exclu** : Consensus parfait → pas besoin d'annotation supplémentaire
+2. **Items 0, 2, 3, 4 équivalents** : Même niveau d'incertitude (1 dissident sur 4)
+3. **Choix arbitraire** : L'algorithme sélectionne Item 0 (premier dans l'ordre)
+
+**Stratégies d'amélioration** :
+
+| Critère | Description |
+|---------|-------------|
+| **Entropie** | Annoter les items les plus incertains |
+| **Utilité attendue** | Combiner incertitude × importance de l'item |
+| **Diversité workers** | Solliciter des workers différents |
+| **Gold questions** | Mélanger des items connus pour évaluer les workers |
+
+**Note** : Avec une entropie max de 1.0 (50/50), une entropie de 0.811 correspond à une distribution 75/25 (1 dissident sur 4), soit 25% de désaccord.",,,,,,,,d545cd132d0b8424,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,38d86fc6,markdown,fr,a35e50ee962d9f9c,"## 8. Exemple guide : Crowdsourcing d'Images
+
+### Enonce
+
+Simulez un scenario de classification d'images (chat/chien) avec 8 workers de qualites variables.",,,,,,,,a35e50ee962d9f9c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,h3ytns1sj6q,markdown,fr,b1d29486a0fcf62e,"### Contexte et solution
+
+Cet exercice simule un scenario realiste de classification d'images par crowdsourcing :
+
+**Configuration** :
+- 10 images (chats et chiens melanges aleatoirement)
+- 8 annotateurs avec des qualites variant de 0.50 (aleatoire) a 0.95 (expert)
+
+**Qualites simulees** : [0.95, 0.90, 0.85, 0.80, 0.70, 0.60, 0.55, 0.50]
+
+Cette distribution est typique des plateformes comme Amazon Mechanical Turk :
+- Quelques experts (qualite > 0.90)
+- Une majorite de workers moyens (0.60-0.80)
+- Quelques spammeurs/bots (qualite ~ 0.50)
+
+**Objectif** : Comparer l'estimation de qualite par consensus avec les vraies qualites.
+
+Le code ci-dessous genere des annotations synthetiques et compare les qualites vraies des annotateurs aux qualites estimees par accord avec la majorite.",,,,,,,,b1d29486a0fcf62e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,7bdf1ade,code,fr,2b9af7ec15550249,"// Exemple guide : Crowdsourcing d'images
+
+int nImages = 10;
+int nAnnotateurs = 8;
+Random rng = new Random(42);
+
+// Vrais labels (0=chat, 1=chien)
+int[] vraisLabelsImg = Enumerable.Range(0, nImages).Select(i => rng.Next(2)).ToArray();
+
+// Qualites des annotateurs (differentes)
+double[] qualites = { 0.95, 0.90, 0.85, 0.80, 0.70, 0.60, 0.55, 0.50 };
+
+// Generer les annotations
+int[,] annotations = new int[nImages, nAnnotateurs];
+
+for (int i = 0; i < nImages; i++)
+{
+    for (int a = 0; a < nAnnotateurs; a++)
+    {
+        if (rng.NextDouble() < qualites[a])
+            annotations[i, a] = vraisLabelsImg[i];  // Correct
+        else
+            annotations[i, a] = 1 - vraisLabelsImg[i];  // Erreur
+    }
+}
+
+Console.WriteLine(""=== Crowdsourcing Images (Chat=0 / Chien=1) ==="");
+Console.WriteLine($""\nQualites vraies des annotateurs : {string.Join("", "", qualites.Select(q => $""{q:F2}""))}\n"");
+
+// Evaluation par vote majoritaire
+int correctes = 0;
+for (int i = 0; i < nImages; i++)
+{
+    int votes1 = Enumerable.Range(0, nAnnotateurs).Count(a => annotations[i, a] == 1);
+    int prediction = votes1 > nAnnotateurs / 2 ? 1 : 0;
+    if (prediction == vraisLabelsImg[i]) correctes++;
+}
+
+Console.WriteLine($""Precision vote majoritaire : {100.0 * correctes / nImages:F0}%"");
+
+// Estimation des qualites basee sur le consensus
+Console.WriteLine(""\nEstimation des qualites (accord avec majorite) :"");
+for (int a = 0; a < nAnnotateurs; a++)
+{
+    int accords = 0;
+    for (int i = 0; i < nImages; i++)
+    {
+        int votes1 = Enumerable.Range(0, nAnnotateurs).Count(x => annotations[i, x] == 1);
+        int majorite = votes1 > nAnnotateurs / 2 ? 1 : 0;
+        if (annotations[i, a] == majorite) accords++;
+    }
+    double qualiteEstimee = (double)accords / nImages;
+    Console.WriteLine($""  Annotateur {a+1} : vraie={qualites[a]:F2}, estimee={qualiteEstimee:F2}"");
+}",,,,,,,,2b9af7ec15550249,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,bxehgfxq8di,markdown,fr,ab80705b46d3cb42,"### Analyse de l'exercice crowdsourcing
+
+**Configuration** : 10 images, 8 annotateurs avec qualités de 0.50 à 0.95
+
+**Résultats** :
+
+| Annotateur | Qualité vraie | Qualité estimée | Écart |
+|------------|---------------|-----------------|-------|
+| 1 | 0.95 | 1.00 | +0.05 |
+| 2 | 0.90 | 1.00 | +0.10 |
+| 3 | 0.85 | 1.00 | +0.15 |
+| 4 | 0.80 | 0.90 | +0.10 |
+| 5 | 0.70 | 1.00 | +0.30 |
+| 6 | 0.60 | 0.80 | +0.20 |
+| 7 | 0.55 | 0.70 | +0.15 |
+| 8 | 0.50 | 0.50 | 0.00 |
+
+**Observations** :
+
+1. **Surestimation systématique** : L'estimation par accord avec la majorité surestime la qualité
+2. **Raison** : Le vote majoritaire est généralement correct → s'y accorder donne un bon score
+3. **Annotateur 8 (0.50)** : Seul cas bien estimé car vraiment aléatoire
+4. **Annotateur 5 (0.70 → 1.00)** : Surestimation maximale car chance d'être du bon côté
+
+**Limites de l'estimation par consensus** :
+
+- Ne détecte pas les **biais corrélés** entre workers
+- Nécessite des **gold questions** (items de vérité connue) pour calibrer
+- Un modèle Honest Worker donnerait des estimations plus conservatrices",,,,,,,,ab80705b46d3cb42,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,51d165a2,markdown,fr,88ed693575c91c3f,"## 9. Resume et Guide de Choix
+
+### Comparaison des modeles
+
+| Critere | Vote majoritaire | Honest Worker | Biased Worker | Community |
+|---------|------------------|---------------|---------------|-----------|
+| **Simplicite** | Tres simple | Simple | Moyen | Complexe |
+| **Annotations requises** | Quelques | ~5/item | ~10/item | ~20/item |
+| **Biais detectes** | Non | Non | Oui | Oui |
+| **Nouveaux workers** | - | Cold start | Cold start | Via communaute |
+| **Scalabilite** | Excellente | Bonne | Moyenne | Moyenne |
+
+### Concepts cles
+
+| Concept | Description |
+|---------|-------------|
+| **Honest Worker** | Capacite unique par worker |
+| **Biased Worker** | Matrice de confusion par worker |
+| **Community** | Workers groupes en communautes |
+| **Apprentissage actif** | Selection optimale des annotations |
+| **Gold standard** | Items avec vrai label connu pour evaluation |
+
+### Recommandations pratiques
+
+1. **Commencer simple** : Vote majoritaire + gold questions pour filtrer les spammeurs
+
+2. **Evoluer si necessaire** :
+   - Desaccords frequents → Honest Worker
+   - Biais systematiques → Biased Worker
+   - Beaucoup de workers → Community
+
+3. **Toujours inclure des gold questions** : 5-10% d'items de verite connue pour detecter les spammeurs et calibrer les estimations
+
+---
+
+## Prochaine etape
+
+Dans [Infer-14-Sequences](Infer-14-Sequences.ipynb), nous explorerons les Hidden Markov Models (HMM), l'algorithme de Viterbi, et l'application au motif finding en bioinformatique.",,,,,,,,88ed693575c91c3f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,936ismvm29v,markdown,fr,3c1442bf56e2d0a4,"### Applications industrielles et references
+
+Les modeles vus dans ce notebook sont utilises a grande echelle :
+
+| Domaine | Application | Exemple |
+|---------|-------------|---------|
+| **NLP** | Annotation de corpus | Sentiment, NER, traduction |
+| **Vision** | Labellisation d'images | ImageNet, detection d'objets |
+| **Medical** | Diagnostic assiste | Dermatologie, radiologie |
+| **Moderation** | Filtrage de contenu | Spam, contenu inapproprie |
+| **IA generative** | RLHF | Alignement de LLMs |
+
+**Algorithmes de reference** :
+
+| Algorithme | Annee | Caracteristique |
+|------------|-------|-----------------|
+| **Dawid-Skene** | 1979 | Matrice de confusion par worker (EM) |
+| **GLAD** | 2009 | + difficulte par item |
+| **BCC** | 2012 | Version bayesienne de Dawid-Skene |
+
+> **Reference** : Les modeles de ce notebook sont inspires du tutoriel officiel Infer.NET sur le crowdsourcing.",,,,,,,,3c1442bf56e2d0a4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,b17cc710,markdown,fr,3432d9faf1b7d810,"## 10. Exercice : Crowdsourcing avec Annotateurs d'Expertise Variable
+
+### Enonce
+
+Un scenario de crowdsourcing avec **3 experts** (qualite ~0.90) et **5 novices** (qualite ~0.60).
+
+Vrais labels de 6 images : `{false, true, false, true, true, false}` (false=chat, true=chien).
+
+Annotateurs (indices 0-2 = experts, 3-7 = novices) avec P(correct) indiquees :
+- Experts (ann 0-2) : P(correct) = 0.90
+- Novices (ann 3-7) : P(correct) = 0.60
+
+**Etapes** :
+1. Generez les labels synthetiques par groupe
+2. Construisez le modele avec des a priori Beta differents par groupe (Beta(9,1) vs Beta(6,4))
+3. Comparez la precision inferee avec la regle de majorite simple
+
+> **Indice** : Pour generer les labels synthetiques, utilisez `Random.NextDouble()` compare a la qualite du groupe. Pour le modele, vous pouvez creer deux tableaux de capacites `Variable.Array<double>` avec des priors Beta distincts pour chaque groupe, puis les combiner dans un seul tableau d'observations.",,,,,,,,3432d9faf1b7d810,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,66737d8b,code,fr,3d83a3f8a2c3d285,"// Exercice : Crowdsourcing avec expertise variable par groupe
+int nImages = 6;
+int nExperts = 3;
+int nNovices = 5;
+
+// Vrais labels (pour validation externe uniquement)
+bool[] vraisLabels = { false, true, false, true, true, false };
+
+// TODO: Generer des labels synthetiques
+
+// TODO: Definir des a priori differents par groupe
+
+// TODO: Construire le modele Dawid-Skene simplifie
+// Pour chaque image : vrai label + annotations conditionnelles par groupe
+//     // Annotations experts et novices conditionnelles sur vraiLabel[img]...
+
+// TODO: Inferer les vrais labels et comparer avec majorite simple
+// Calculez la precision de chaque methode
+Console.WriteLine(""Exercice a completer"");",,,,,,,,3d83a3f8a2c3d285,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,08d17ed2,markdown,fr,27dd5dbec48a69d8,"### 10bis. Exercice : Detection de Workers Spammeurs
+
+Dans les plateformes de crowdsourcing, certains workers (appeles ""spammers"") soumettent des reponses aleatoires ou systematiques sans lire les questions. Leur identification est cruciale pour maintenir la qualite des annotations.
+
+**Objectif** : Implementer une methode de detection heuristique des spammeurs, puis mesurer l'amelioration de la qualite des resultats apres filtrage.
+
+**Donnees fournies** :
+- 6 items binaires (labels 0 ou 1), annotes par 5 workers
+- Workers W3 et W5 sont des spammeurs (repondent toujours 0)
+- Les vrais labels sont fournis pour evaluer la qualite
+
+**Etapes** :
+
+1. **Analyse de variance** -- Pour chaque worker, calculer la variance de ses reponses. Un spammeur qui repond toujours la meme chose a une variance proche de 0.
+2. **Accord majoritaire** -- Calculer le taux d'accord de chaque worker avec le vote majoritaire (par item, le label le plus frequent l'emporte). Les spammeurs ont un accord faible car ils ne suivent pas le consensus.
+3. **Identification** -- Un worker est classe spammeur si sa variance est proche de 0 **ET** son accord avec la majorite est < 60%.
+4. **Filtrage** -- Recalculer le vote majoritaire en excluant les spammeurs identifies, puis comparer la precision (avant/apres).
+
+**Indices** :
+- `# Indice` : La variance d'une serie constante vaut 0. En C#, calculez `mean_of_squares - square_of_mean`.
+- `# Indice` : Pour le vote majoritaire par item, comptez les votes > 0.5 pour chaque item.
+- `# Indice` : W3 et W5 repondent toujours 0, leur variance sera 0. Ce sont vos cibles.",,,,,,,,27dd5dbec48a69d8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,spam-detector-exercise,code,fr,abdb40c50da582e9,"// Exercice : Detection de workers spammeurs par variance + accord
+// On dispose de 6 items binaires (labels 0 ou 1), annotes par 5 workers
+
+string[][] workerLabels = {
+    new[] { ""1"", ""1"", ""0"", ""1"", ""0"", ""1"" },  // W1: bon worker
+    new[] { ""1"", ""0"", ""1"", ""1"", ""0"", ""1"" },  // W2: bon worker
+    new[] { ""0"", ""0"", ""0"", ""0"", ""0"", ""0"" },  // W3: spammeur (toujours 0)
+    new[] { ""1"", ""1"", ""0"", ""0"", ""1"", ""0"" },  // W4: bon worker
+    new[] { ""0"", ""0"", ""0"", ""0"", ""0"", ""0"" }   // W5: spammeur (toujours 0)
+};
+int[] vraisLabels = { 1, 1, 0, 1, 0, 1 };
+
+// TODO: Etape 1 - Calculer la variance des reponses de chaque worker
+// Indice : Convertir en int, calculer mean puis mean_of_squares - square_of_mean
+
+// TODO: Etape 2 - Calculer le taux d'accord avec le vote majoritaire
+// Indice : Pour chaque item, trouver le label majoritaire, puis compter les matchs
+
+// TODO: Etape 3 - Identifier les spammeurs (variance < 0.05 ET accord < 0.6)
+// Indice : W3 et W5 auront variance=0 et accord faible
+
+// TODO: Etape 4 - Recalculer le vote majoritaire sans spammeurs, comparer precision
+// Indice : Exclure les indices des spammeurs, puis voter sur les labels restants
+
+Console.WriteLine(""Exercice a completer : detection de workers spammeurs"");",,,,,,,,abdb40c50da582e9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb,3f6e90f7,markdown,fr,223468311661a969,"## Conclusion
+
+Ce notebook a traite un probleme central de l'apprentissage a partir de donnees humaines : **agreger des labels bruites fournis par des annotateurs de fiabilite inconnue** pour reconstruire la verite terrain. La cle est de ne pas se contenter du label, mais d'**inferer conjointement** le vrai label de chaque item *et* la fiabilite de chaque worker.
+
+### Une montee en expressivite, au prix de la donnee
+
+Les quatre approches vues forment une progression ou chaque modele capture une source de bruit supplementaire, en echange d'un cout d'annotation croissant :
+
+| Modele | Ce qu'il capture | Limite levee |
+|--------|------------------|--------------|
+| **Vote majoritaire** | Rien (compte les voix) | Baseline naive, sensible aux spammeurs |
+| **Honest Worker** | Une competence scalaire par worker | Pondere les workers fiables |
+| **Biased Worker** | Une matrice de confusion par worker | Detecte les biais systematiques par classe |
+| **Community** | Des groupes de workers (hierarchie) | Resout le cold-start via partage de force |
+
+Le fil conducteur est bayesien : un worker incertain voit son vote *automatiquement* dilue, et un item controverse reste a forte entropie posterieure -- ce qui alimente directement l'**apprentissage actif** (uncertainty sampling), qui concentre l'effort d'annotation la ou il reduit le plus l'incertitude.
+
+### Ce que Infer.NET apporte
+
+L'inference jointe labels + fiabilites est exactement le genre de probleme a variables latentes ou un calcul manuel (style EM) devient vite intraitable. Infer.NET **propage les croyances sur le graphe de facteurs** et restitue des posterieurs calibres sans derivation analytique : le modelisateur declare la structure (workers, items, matrices de confusion, communautes) et laisse le moteur estimer le tout simultanement. La structure hierarchique du modele Community, en particulier, illustre comment le partage de parametres entre workers regularise les estimations des nouveaux annotateurs.
+
+### A retenir
+
+> Le bon modele de crowdsourcing n'est pas le plus sophistique, mais **le plus simple qui capture le bruit reellement present** dans vos donnees. Commencer par le vote majoritaire avec des *gold questions*, puis monter en complexite (Honest -> Biased -> Community) seulement quand les desaccords, biais ou le cold-start l'imposent. Dans tous les cas, garder 5-10 % d'items a verite connue reste le filet de securite qui calibre les estimations et demasque les spammeurs.
+
+Ce raisonnement -- inferer des variables latentes (le vrai label) a partir d'observations bruitees mediees par des parametres de fiabilite -- prepare directement les modeles a etats caches du notebook suivant ([Infer-14-Sequences](Infer-14-Sequences.ipynb)), ou la structure latente devient temporelle.
+",,,,,,,,223468311661a969,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,087a352c,markdown,fr,b7b328b2cc4f8414,"# Infer-14-Sequences : Hidden Markov Models et Series Temporelles
+
+**Serie** : Programmation Probabiliste avec Infer.NET (11/20)  
+**Duree estimee** : 65 minutes  
+**Prerequis** : Infer-10-Model-Selection
+
+---
+
+## Objectifs
+
+- Comprendre les Hidden Markov Models (HMM)
+- Implementer les emissions gaussiennes
+- Decoder les sequences d'etats caches
+- Appliquer au motif finding (bioinformatique)
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-10-Model-Selection](Infer-10-Model-Selection.ipynb) | [Infer-12-Modeles-Hierarchiques](Infer-12-Modeles-Hierarchiques.ipynb) |
+
+---",,,,,,,,b7b328b2cc4f8414,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,9a17f1d2,markdown,fr,521ef59ca9cd0cd6,"## 1. Configuration
+
+Nous preparons l'environnement pour les modeles de sequences temporelles, notamment les Hidden Markov Models (HMM). Ces modeles capturent les dependances temporelles entre observations via des etats caches qui evoluent selon une chaine de Markov.",,,,,,,,521ef59ca9cd0cd6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,6f49a35c,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,ecbd34b2,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,0hge12mjvnp,code,fr,d2394395270a557e,"// Chargement du helper pour visualiser les graphes de facteurs
+#load ""FactorGraphHelper.cs""
+Console.WriteLine($""FactorGraphHelper charge. Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,d2394395270a557e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,sgcbrftbblk,markdown,fr,eceb716491d7e49c,"> **Environnement pret** : Les namespaces Infer.NET sont charges, incluant `Microsoft.ML.Probabilistic.Models` pour definir les HMM et `Microsoft.ML.Probabilistic.Distributions` pour les distributions Dirichlet (transitions) et Gaussian (emissions).",,,,,,,,eceb716491d7e49c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,7ce638a0,markdown,fr,a46748babd8f2a2f,"## 2. Introduction aux HMM
+
+### Structure
+
+Un HMM est defini par :
+- **Etats caches** : $z_t$ - non observables
+- **Observations** : $x_t$ - dependant de l'etat cache
+- **Transitions** : $P(z_t | z_{t-1})$
+- **Emissions** : $P(x_t | z_t)$
+
+### Schema
+
+```
+z_1 --> z_2 --> z_3 --> ... --> z_T  (etats caches)
+ |       |       |               |
+ v       v       v               v
+x_1     x_2     x_3     ...     x_T  (observations)
+```
+
+### Applications
+
+| Domaine | Etats caches | Observations |
+|---------|-------------|---------------|
+| NLP | POS tags | Mots |
+| Finance | Regime de marche | Prix |
+| Bio | Gene/Intergene | Sequence ADN |
+| Meteo | Vrai temps | Mesures capteurs |",,,,,,,,a46748babd8f2a2f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,592f5eb5,markdown,fr,de14af6897c516cd,"## 3. HMM avec Emissions Gaussiennes
+
+### 3.1 Formulation mathematique
+
+Pour un HMM a emissions gaussiennes :
+
+$$P(x_t | z_t = k) = \mathcal{N}(x_t ; \mu_k, \sigma_k^2)$$
+
+Ou :
+- $\mu_k$ est la moyenne d'emission de l'etat $k$
+- $\sigma_k^2$ est la variance d'emission
+
+La vraisemblance complete d'une sequence est :
+
+$$P(x_{1:T}, z_{1:T}) = P(z_1) \prod_{t=2}^{T} P(z_t | z_{t-1}) \prod_{t=1}^{T} P(x_t | z_t)$$
+
+**Objectif de l'inference** : Calculer $P(z_t | x_{1:T})$ pour chaque pas de temps $t$.",,,,,,,,de14af6897c516cd,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,5b417352,code,fr,b6761858452202be,"// Parametres du HMM
+int nStates = 2;  // Deux etats : ""Normal"" et ""Anomalie""
+int T = 10;       // Longueur de sequence
+
+// Donnees observees (simulees : normal ~10, anomalie ~25)
+double[] observations = { 9.5, 11.2, 10.8, 24.5, 26.1, 25.3, 10.1, 9.8, 11.5, 10.2 };
+// Vrais etats : 0, 0, 0, 1, 1, 1, 0, 0, 0, 0
+
+Console.WriteLine(""=== HMM : Detection d'Anomalies ==="");
+Console.WriteLine($""\nObservations : {string.Join("", "", observations.Select(o => o.ToString(""F1"")))}"");
+Console.WriteLine(""\nEtats attendus : Normal(~10) -> Anomalie(~25) -> Normal(~10)"");",,,,,,,,b6761858452202be,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,c0rbr2fzhha,markdown,fr,f2211b3f7e8a3622,"### Scenario : Detection d'anomalies sur capteur
+
+Imaginons un capteur de temperature industriel avec deux regimes :
+
+| Regime | Valeur typique | Interpretation |
+|--------|----------------|----------------|
+| **Normal** | ~10 unites | Fonctionnement standard |
+| **Anomalie** | ~25 unites | Surchauffe detectee |
+
+Les donnees simulent une sequence : fonctionnement normal, puis anomalie, puis retour a la normale.",,,,,,,,f2211b3f7e8a3622,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,0mbmcsyd0qzo,markdown,fr,db85c484cc670c04,"### 3.2 Approche simplifiee : classification independante
+
+**Donnees** : 10 observations simulant un capteur avec deux regimes :
+
+| Observations | Valeurs | Etat attendu |
+|--------------|---------|--------------|
+| 0-2 | 9.5, 11.2, 10.8 | Normal (~10) |
+| 3-5 | 24.5, 26.1, 25.3 | Anomalie (~25) |
+| 6-9 | 10.1, 9.8, 11.5, 10.2 | Normal (~10) |
+
+**Approche adoptee** : Chaque observation est classee independamment (sans utiliser les transitions).
+
+Pour chaque pas de temps $t$, on calcule :
+
+$$P(\text{etat}_t = k | x_t) \propto P(x_t | \text{etat}_t = k) \cdot P(\text{etat}_t = k)$$
+
+> **Limitation** : Cette approche ignore les correlations temporelles. Un etat Normal suivi d'Anomalie puis Normal est traite identiquement a Normal→Normal→Normal.",,,,,,,,db85c484cc670c04,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,d609b794,code,fr,7c4b20c74afecdd7,"// Definition du modele HMM
+
+Range stateRange = new Range(nStates).Named(""state"");
+Range timeRange = new Range(T).Named(""time"");
+
+// Distribution initiale
+Variable<Vector> probInit = Variable.Dirichlet(new double[] { 1, 1 }).Named(""probInit"");
+
+// Matrice de transition (lignes = etat courant, colonnes = etat suivant)
+VariableArray<Vector> transMatrix = Variable.Array<Vector>(stateRange).Named(""transMatrix"");
+transMatrix[stateRange] = Variable.Dirichlet(new double[] { 5, 1 }).ForEach(stateRange);  // Favorise rester dans le meme etat
+
+// Parametres d'emission par etat
+VariableArray<double> emitMean = Variable.Array<double>(stateRange).Named(""emitMean"");
+VariableArray<double> emitPrec = Variable.Array<double>(stateRange).Named(""emitPrec"");
+
+// Priors sur les emissions
+emitMean[0] = Variable.GaussianFromMeanAndVariance(10, 10);  // Etat 0 : Normal
+emitMean[1] = Variable.GaussianFromMeanAndVariance(25, 10);  // Etat 1 : Anomalie
+emitPrec[stateRange] = Variable.GammaFromShapeAndScale(2, 0.5).ForEach(stateRange);
+
+// Sequence d'etats
+VariableArray<int> states = Variable.Array<int>(timeRange).Named(""states"");
+
+// Observations
+VariableArray<double> obs = Variable.Array<double>(timeRange).Named(""obs"");
+
+Console.WriteLine(""Variables HMM definies."");",,,,,,,,7c4b20c74afecdd7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,ozkeoi9kvqn,markdown,fr,ec0c596f1a589595,"> **Structure du modele** :
+> - **Priors Dirichlet** : `probInit ~ Dir(1,1)` pour l'etat initial, `transMatrix[k] ~ Dir(5,1)` favorisant la persistance
+> - **Emissions gaussiennes** : Moyennes a priori centrees sur 10 (Normal) et 25 (Anomalie)
+>
+> **Note** : Ces variables preparent un HMM complet, mais l'inference utilise une approche simplifiee ci-dessous.",,,,,,,,ec0c596f1a589595,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,77c6ccc3,code,fr,a9cb7493dc2b606c,"// Baseline naive : classification par pas de temps INDEPENDANTE (sans transitions).
+// Sert de point de comparaison au vrai HMM de la section 3.3.
+// (chaque pas est infere separement : on perd volontairement les dependances temporelles)
+
+Console.WriteLine(""\n=== Inference des etats (baseline independante, sans transitions) ==="");
+Console.WriteLine();
+
+for (int t = 0; t < T; t++)
+{
+    // Pour chaque observation, determiner l'etat le plus probable
+    Variable<int> etat = Variable.DiscreteUniform(nStates);
+    Variable<double> obsVar = Variable.New<double>();
+
+    // Emission selon l'etat
+    using (Variable.Case(etat, 0))
+    {
+        obsVar.SetTo(Variable.GaussianFromMeanAndPrecision(10, 1));  // Normal
+    }
+    using (Variable.Case(etat, 1))
+    {
+        obsVar.SetTo(Variable.GaussianFromMeanAndPrecision(25, 1));  // Anomalie
+    }
+
+    obsVar.ObservedValue = observations[t];
+
+    InferenceEngine eng = new InferenceEngine();
+    eng.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+    Discrete etatPost = eng.Infer<Discrete>(etat);
+    int etatMAP = etatPost.GetProbs()[0] > 0.5 ? 0 : 1;
+    string nomEtat = etatMAP == 0 ? ""Normal"" : ""Anomalie"";
+
+    Console.WriteLine($""t={t} : obs={observations[t]:F1}, P(Normal)={etatPost.GetProbs()[0]:F2}, P(Anomalie)={etatPost.GetProbs()[1]:F2} -> {nomEtat}"");
+}
+",,,,,,,,a9cb7493dc2b606c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,2343d5fb,markdown,fr,777ba48d4800cb44,Visualisation du graphe de facteurs pour la classification de sequences.,,,,,,,,777ba48d4800cb44,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,1wijm2ozzxe,code,fr,d222146fa448eecf,"// Visualisation du graphe de facteurs pour la classification independante
+// On cree un modele unique avec ShowFactorGraph pour illustrer la structure
+
+Variable<int> etatViz = Variable.DiscreteUniform(nStates).Named(""etat"");
+Variable<double> obsViz = Variable.New<double>().Named(""observation"");
+
+using (Variable.Case(etatViz, 0))
+{
+    obsViz.SetTo(Variable.GaussianFromMeanAndPrecision(10, 1).Named(""emission_Normal""));
+}
+using (Variable.Case(etatViz, 1))
+{
+    obsViz.SetTo(Variable.GaussianFromMeanAndPrecision(25, 1).Named(""emission_Anomalie""));
+}
+
+obsViz.ObservedValue = 15.0;  // Valeur quelconque
+
+InferenceEngine engViz = new InferenceEngine();
+engViz.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+engViz.ShowFactorGraph = true;
+
+var _ = engViz.Infer(etatViz);  // Declenche la generation du graphe
+Console.WriteLine(""Graphe de facteurs genere pour le modele de classification independante."");",,,,,,,,d222146fa448eecf,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,eprgrv4qwrc,markdown,fr,66986f2d531ba194,"### Analyse de la détection d'états
+
+**Résultats** : Classification parfaite des 10 observations
+
+| Position | Observation | P(Normal) | P(Anomalie) | Décision |
+|----------|-------------|-----------|-------------|----------|
+| 0-2 | 9.5, 11.2, 10.8 | 1.00 | 0.00 | Normal |
+| 3-5 | 24.5, 26.1, 25.3 | 0.00 | 1.00 | Anomalie |
+| 6-9 | 10.1, 9.8, 11.5, 10.2 | 1.00 | 0.00 | Normal |
+
+**Observations clés** :
+
+1. **Séparation nette** : Les émissions gaussiennes (µ=10 vs µ=25) sont suffisamment séparées pour une décision sans ambiguïté
+
+2. **Limitation de l'approche** : Chaque observation est classée indépendamment, ignorant les transitions temporelles
+
+3. **Un vrai HMM ferait mieux** : 
+   - Lisser les transitions isolées (éviter Normal→Anomalie→Normal si transitions rares)
+   - Propager l'information entre pas de temps adjacents
+   - Détecter des changements de régime plus subtils
+
+**Note technique** : La compilation répétée (""Compiling model..."") est due à la boucle créant un nouveau modèle à chaque itération - une implémentation réelle utiliserait un modèle unique.",,,,,,,,66986f2d531ba194,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,wqheiyzfuc,code,fr,c2df6421cc2319dd,"// Affichage du graphe de facteurs
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,c2df6421cc2319dd,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,z97jpjm3ysi,markdown,fr,3984f93f89358882,"### Graphe de facteurs : Classification independante
+
+Ce graphe represente le modele **sans dependances temporelles** :
+
+| Element | Signification |
+|---------|---------------|
+| **etat** | Variable discrete (Normal=0, Anomalie=1) |
+| **observation** | Variable continue observee |
+| **Factor Cases** | Branchement conditionnel selon l'etat |
+| **emission_Normal/Anomalie** | Distributions gaussiennes d'emission |
+
+**Structure** : L'observation est reliee a l'etat via un switch (Variable.Case), creant deux chemins d'emission distincts. Ce modele traite chaque observation **independamment** - aucune fleche ne relie les pas de temps.",,,,,,,,3984f93f89358882,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,02dmb0xvcaoi,markdown,fr,f400bfc65efdb712,"### 3.3 HMM complet avec transitions markoviennes (Infer.NET)
+
+L'approche precedente classe chaque observation **independamment**. Un vrai HMM relie les pas de temps par une **matrice de transition** : l'etat $z_t$ depend de $z_{t-1}$, ce qui permet de *lisser* les decisions et de detecter des regimes coherents.
+
+**Scenario enrichi** : un capteur industriel a **trois** regimes (et non plus deux), avec des transitions ""collantes"" (un regime persiste avant de basculer) :
+
+| Regime | Emission moyenne | Ecart-type |
+|--------|------------------|------------|
+| Normal | ~20 | 3 |
+| Alerte | ~35 | 3 |
+| Critique | ~50 | 4 |
+
+Contrairement a une legende tenace, **Infer.NET sait modeliser un HMM complet**. La chaine se construit avec un bloc `Variable.ForEach` sur le temps, en separant le premier pas (`Variable.If(t == 0)`) du reste (`Variable.If(t > 0)`), et en conditionnant la transition sur l'etat precedent via `Variable.Switch`. Deux idiomes sont indispensables :
+
+1. **`Tr.AddAttribute(new Sequential())`** : ordonne l'inference le long de la chaine (sans cela, EP traite les pas dans le desordre et converge mal).
+2. **Brisure de symetrie par K-means** : on initialise les etats avec un K-means 1-D et on centre les priors d'emission sur les centroides. Sans cette amorce, EP **fusionne les regimes** (tous les etats convergent vers la moyenne globale) -- c'est precisement cet echec qui avait fait croire, a tort, a une ""limitation d'Infer.NET"".",,,,,,,,f400bfc65efdb712,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,z7pjabb6wh,code,fr,68cb032270107eb1,"using Microsoft.ML.Probabilistic.Models.Attributes;  // Sequential
+
+// ===================== HMM REEL : transitions markoviennes + emissions gaussiennes =====================
+// Port fidele de usptact/Infer.NET-HMM + oliparson/infer-hmm (API moderne 0.4.x).
+// Idiomes-cles que le ""toy"" precedent ignorait :
+//   (1) Tr.AddAttribute(new Sequential())  -> ordonnancement sequentiel le long de la chaine
+//   (2) priors d'emission ETALES sur la plage + init par K-means -> brisure de symetrie
+//   (3) decodage de Viterbi (chemin globalement optimal) au lieu du MAP marginal.
+// (sans (2) EP fusionne les etats : c'est l'echec qui avait fait croire a tort a une ""limitation"").
+
+Rand.Restart(42);
+int nReg = 3;
+int Tlen = 120;
+
+// ---- Scenario capteur : 3 regimes (Normal ~20, Alerte ~35, Critique ~50) ----
+double[][] trueTrans = new double[][] {
+    new[]{0.85, 0.12, 0.03},
+    new[]{0.10, 0.80, 0.10},
+    new[]{0.05, 0.15, 0.80},
+};
+double[] trueMean = { 20.0, 35.0, 50.0 };
+double[] trueStd  = { 3.0, 3.0, 4.0 };
+
+int[]   trueStates = new int[Tlen];
+double[] emit       = new double[Tlen];
+int cur = 0;
+for (int t = 0; t < Tlen; t++) {
+    if (t > 0) {
+        double u = Rand.Double(), acc = 0; int nx = 0;
+        for (int j = 0; j < nReg; j++) { acc += trueTrans[cur][j]; if (u <= acc) { nx = j; break; } }
+        cur = nx;
+    }
+    trueStates[t] = cur;
+    emit[t] = trueMean[cur] + trueStd[cur] * Rand.Normal();
+}
+int[] tc = new int[nReg]; foreach (int s in trueStates) tc[s]++;
+Console.WriteLine($""Frequences vraies des etats : Normal={tc[0]}, Alerte={tc[1]}, Critique={tc[2]}"");
+
+// ---- Statistiques de donnees (priors etales) ----
+double dMean = emit.Average();
+double dVar  = emit.Select(x => (x - dMean) * (x - dMean)).Average();
+double dMin = emit.Min(), dMax = emit.Max(), dRange = dMax - dMin;
+
+// ---- Modele Infer.NET ----
+Range K  = new Range(nReg).Named(""K"");
+Range Tr = new Range(Tlen).Named(""temps"");
+Tr.AddAttribute(new Sequential());                       // (1) chaine sequentielle
+
+var probInitPrior = Variable.New<Dirichlet>().Named(""probInitPrior"");
+var probInit      = Variable<Vector>.Random(probInitPrior).Named(""probInit"");
+probInit.SetValueRange(K);
+
+var cptTransPrior = Variable.Array<Dirichlet>(K).Named(""cptTransPrior"");
+var cptTrans      = Variable.Array<Vector>(K).Named(""cptTrans"");
+cptTrans[K]       = Variable<Vector>.Random(cptTransPrior[K]);
+cptTrans.SetValueRange(K);
+
+var emitMeanPrior = Variable.Array<Gaussian>(K).Named(""emitMeanPrior"");
+var emitMean      = Variable.Array<double>(K).Named(""emitMean"");
+emitMean[K]       = Variable<double>.Random(emitMeanPrior[K]);
+
+var emitPrecPrior = Variable.Array<Gamma>(K).Named(""emitPrecPrior"");
+var emitPrec      = Variable.Array<double>(K).Named(""emitPrec"");
+emitPrec[K]       = Variable<double>.Random(emitPrecPrior[K]);
+
+var zeroState = Variable.Discrete(probInit).Named(""z0"");
+var states    = Variable.Array<int>(Tr).Named(""states"");
+var emissions = Variable.Array<double>(Tr).Named(""emissions"");
+
+using (var block = Variable.ForEach(Tr)) {
+    var t = block.Index;
+    var previousState = states[t - 1];
+    using (Variable.If(t == 0)) {
+        using (Variable.Switch(zeroState)) { states[Tr] = Variable.Discrete(cptTrans[zeroState]); }
+    }
+    using (Variable.If(t > 0)) {
+        using (Variable.Switch(previousState)) { states[t] = Variable.Discrete(cptTrans[previousState]); }
+    }
+    using (Variable.Switch(states[t])) {
+        emissions[t] = Variable.GaussianFromMeanAndPrecision(emitMean[states[t]], emitPrec[states[t]]);
+    }
+}
+
+// ---- K-means 1-D D'ABORD : sert a la fois aux priors (centroides + variance intra) et a l'init ----
+int[] initAssign = KMeans1D(emit, nReg, 25);
+double[] kmCent  = KMeansCentroids(emit, nReg, 25);
+int[] cc = new int[nReg]; foreach (int a in initAssign) cc[a]++;
+if (cc.Any(c => c == 0 || c < Tlen / (nReg * 4))) initAssign = RobustInit(emit, nReg);
+// variance INTRA-cluster (pas la variance globale : c'est elle qui pilote le bruit d'emission)
+double wSum = 0; for (int i = 0; i < Tlen; i++) { double d = emit[i] - kmCent[initAssign[i]]; wSum += d * d; }
+double wVar = Math.Max(wSum / Tlen, 1e-3);
+
+// ---- Priors : means aux centroides K-means ; precision centree sur la variance INTRA ----
+probInitPrior.ObservedValue = Dirichlet.Uniform(nReg);
+cptTransPrior.ObservedValue = Util.ArrayInit(nReg, k => Dirichlet.Uniform(nReg));
+emitMeanPrior.ObservedValue = Util.ArrayInit(nReg, k => Gaussian.FromMeanAndVariance(kmCent[k], dVar * 100));
+emitPrecPrior.ObservedValue = Util.ArrayInit(nReg, k => Gamma.FromShapeAndRate(2.0, 2.0 * wVar));
+
+emissions.ObservedValue = emit;
+Console.WriteLine($""Init K-means : centroides=[{string.Join("", "", kmCent.Select(c => c.ToString(""0.0"")))}], var_intra={wVar:0.0}"");
+var zinit = Variable<Discrete>.Array(Tr);
+zinit.ObservedValue = Util.ArrayInit(Tlen, t => Discrete.PointMass(initAssign[t], nReg));
+states[Tr].InitialiseTo(zinit[Tr]);
+
+var engine = new InferenceEngine(new ExpectationPropagation());
+engine.NumberOfIterations = 50;
+engine.ShowProgress = false;
+
+var transPost = engine.Infer<Dirichlet[]>(cptTrans);
+var initPost  = engine.Infer<Dirichlet>(probInit);
+var meanPost  = engine.Infer<Gaussian[]>(emitMean);
+var precPost  = engine.Infer<Gamma[]>(emitPrec);
+
+// ---- Decodage de Viterbi (chemin globalement optimal) a partir des posteriors ----
+double[] vMean = meanPost.Select(g => g.GetMean()).ToArray();
+double[] vVar  = precPost.Select(g => 1.0 / g.GetMean()).ToArray();
+double[][] vTrans = Util.ArrayInit(nReg, i => { var v = transPost[i].GetMean(); return Util.ArrayInit(nReg, j => v[j]); });
+Vector vInit = initPost.GetMean();
+int[] decoded = Viterbi(emit, nReg, vInit, vTrans, vMean, vVar);
+
+// ---- Appariement BIJECTIF inferes <-> vrais par moyenne d'emission (greedy, sans crash) ----
+int[] trueOfInfer = Enumerable.Repeat(-1, nReg).ToArray();
+bool[] usedTrue = new bool[nReg], usedInfer = new bool[nReg];
+var pairs = new List<(double d, int i, int j)>();
+for (int i = 0; i < nReg; i++) for (int j = 0; j < nReg; j++) pairs.Add((Math.Abs(vMean[i] - trueMean[j]), i, j));
+foreach (var p in pairs.OrderBy(x => x.d))
+    if (!usedInfer[p.i] && !usedTrue[p.j]) { trueOfInfer[p.i] = p.j; usedInfer[p.i] = true; usedTrue[p.j] = true; }
+int[] inferOfTrue = new int[nReg];
+for (int i = 0; i < nReg; i++) inferOfTrue[trueOfInfer[i]] = i;
+
+string[] nm = { ""Normal "", ""Alerte "", ""Critiq "" };
+Console.WriteLine(""\n=== Emissions gaussiennes retrouvees (apres appariement) ==="");
+for (int it = 0; it < nReg; it++) {
+    int i = inferOfTrue[it];
+    Console.WriteLine($""  {nm[it]}: mean={vMean[i]:0.0} (vrai {trueMean[it]:0.0}),  std={Math.Sqrt(vVar[i]):0.0} (vrai {trueStd[it]:0.0})"");
+}
+
+Console.WriteLine(""\n=== Matrice de transition retrouvee vs vraie ==="");
+Console.WriteLine(""            ->Normal ->Alerte ->Critiq    (vrai)"");
+for (int it = 0; it < nReg; it++) {
+    Vector row = transPost[inferOfTrue[it]].GetMean();
+    double[] r = new double[nReg];
+    for (int ni = 0; ni < nReg; ni++) r[trueOfInfer[ni]] = row[ni];
+    Console.WriteLine($""  {nm[it]}:   {r[0]:0.00}    {r[1]:0.00}    {r[2]:0.00}    ({trueTrans[it][0]:0.00},{trueTrans[it][1]:0.00},{trueTrans[it][2]:0.00})"");
+}
+
+int correct = 0;
+for (int t = 0; t < Tlen; t++) if (trueOfInfer[decoded[t]] == trueStates[t]) correct++;
+Console.WriteLine($""\n=== Decodage de Viterbi : {correct}/{Tlen} corrects ({100.0*correct/Tlen:0.0}%) ==="");
+
+// ===================== fonctions utilitaires =====================
+int[] KMeans1D(double[] data, int k, int iters) {
+    int n = data.Length;
+    var sorted = (double[])data.Clone(); Array.Sort(sorted);
+    double[] cent = Util.ArrayInit(k, c => sorted[Math.Min(n - 1, (int)((c + 0.5) * n / k))]);
+    int[] assign = new int[n];
+    for (int it = 0; it < iters; it++) {
+        for (int i = 0; i < n; i++) {
+            int best = 0; double bd = double.MaxValue;
+            for (int c = 0; c < k; c++) { double d = Math.Abs(data[i] - cent[c]); if (d < bd) { bd = d; best = c; } }
+            assign[i] = best;
+        }
+        double[] sum = new double[k]; int[] cnt = new int[k];
+        for (int i = 0; i < n; i++) { sum[assign[i]] += data[i]; cnt[assign[i]]++; }
+        for (int c = 0; c < k; c++) if (cnt[c] > 0) cent[c] = sum[c] / cnt[c];
+    }
+    return assign;
+}
+
+int[] RobustInit(double[] data, int k) {
+    int n = data.Length, minPer = Math.Max(1, n / (k * 5));
+    double[] cent = KMeansCentroids(data, k, 25);
+    var sc = cent.Select((c, i) => (c, i)).OrderBy(x => x.c).ToArray();
+    var sd = data.Select((v, i) => (v, i)).OrderBy(x => x.v).ToArray();
+    int[] a = new int[n];
+    for (int i = 0; i < n; i++) a[sd[i].i] = sc[Math.Min(k - 1, i * k / n)].i;
+    for (int iter = 0; iter < 5; iter++) {
+        int[] counts = new int[k]; foreach (int x in a) counts[x]++;
+        for (int i = 0; i < n; i++) {
+            int curA = a[i];
+            int near = Enumerable.Range(0, k).OrderBy(c => Math.Abs(data[i] - cent[c])).First();
+            if (near != curA && counts[curA] > minPer) { a[i] = near; counts[curA]--; counts[near]++; }
+        }
+    }
+    return a;
+}
+double[] KMeansCentroids(double[] data, int k, int iters) {
+    int n = data.Length;
+    var sorted = (double[])data.Clone(); Array.Sort(sorted);
+    double[] cent = Util.ArrayInit(k, c => sorted[Math.Min(n - 1, (int)((c + 0.5) * n / k))]);
+    int[] assign = new int[n];
+    for (int it = 0; it < iters; it++) {
+        for (int i = 0; i < n; i++) {
+            int best = 0; double bd = double.MaxValue;
+            for (int c = 0; c < k; c++) { double d = Math.Abs(data[i] - cent[c]); if (d < bd) { bd = d; best = c; } }
+            assign[i] = best;
+        }
+        double[] sum = new double[k]; int[] cnt = new int[k];
+        for (int i = 0; i < n; i++) { sum[assign[i]] += data[i]; cnt[assign[i]]++; }
+        for (int c = 0; c < k; c++) if (cnt[c] > 0) cent[c] = sum[c] / cnt[c];
+    }
+    return cent;
+}
+
+int[] Viterbi(double[] obs, int k, Vector init, double[][] trans, double[] mean, double[] var) {
+    int n = obs.Length;
+    double LogPdf(double x, int s) { double df = x - mean[s]; return -0.5 * Math.Log(2 * Math.PI * var[s]) - df * df / (2 * var[s]); }
+    double[,] delta = new double[n, k]; int[,] psi = new int[n, k];
+    for (int s = 0; s < k; s++) { delta[0, s] = Math.Log(Math.Max(init[s], 1e-300)) + LogPdf(obs[0], s); }
+    for (int t = 1; t < n; t++)
+        for (int s = 0; s < k; s++) {
+            double mx = double.NegativeInfinity; int arg = 0;
+            for (int j = 0; j < k; j++) { double p = delta[t - 1, j] + Math.Log(Math.Max(trans[j][s], 1e-300)); if (p > mx) { mx = p; arg = j; } }
+            delta[t, s] = mx + LogPdf(obs[t], s); psi[t, s] = arg;
+        }
+    int last = 0; double best = double.NegativeInfinity;
+    for (int s = 0; s < k; s++) if (delta[n - 1, s] > best) { best = delta[n - 1, s]; last = s; }
+    int[] path = new int[n]; path[n - 1] = last;
+    for (int t = n - 2; t >= 0; t--) path[t] = psi[t + 1, path[t + 1]];
+    return path;
+}
+",,,,,,,,68cb032270107eb1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,gcse6q4x37,markdown,fr,30f1116a9c5f8538,"### Comment le modele est infere
+
+- **Moteur** : `ExpectationPropagation`, 50 iterations. EP propage les messages le long de la chaine sequentielle.
+- **Priors d'emission** : moyennes centrees sur les centroides K-means (variance large pour rester souple) ; **precision** centree sur la variance *intra-cluster* -- c'est elle qui represente le bruit d'emission, pas la variance globale (qui melange les trois regimes).
+- **Brisure de symetrie** : `states[Tr].InitialiseTo(...)` injecte l'assignation K-means comme point de depart, ce qui empeche EP de collapser tous les etats vers un meme mode.
+- **Decodage de Viterbi** : on extrait le chemin d'etats **globalement** le plus probable (programmation dynamique sur les log-probabilites), plus coherent que le simple MAP marginal pas-a-pas.
+
+Comme les etiquettes d'etats sont arbitraires (*label switching*), on **apparie** les etats inferes aux vrais regimes par proximite des moyennes d'emission (appariement bijectif glouton) avant de mesurer la justesse.",,,,,,,,30f1116a9c5f8538,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,61otgq0s3lc,code,fr,4428ec9a8a266c0c,"// Contraste : classification INDEPENDANTE (sans transitions) sur les MEMES donnees que le HMM.
+// Chaque pas est classe au regime gaussien le plus vraisemblable, en ignorant le voisinage temporel.
+
+double GaussLogPdf(double x, double m, double v) { double d = x - m; return -0.5 * Math.Log(2 * Math.PI * v) - d * d / (2 * v); }
+
+int[] indep = new int[Tlen];
+for (int t = 0; t < Tlen; t++) {
+    int best = 0; double bl = double.NegativeInfinity;
+    for (int s = 0; s < nReg; s++) { double l = GaussLogPdf(emit[t], vMean[s], vVar[s]); if (l > bl) { bl = l; best = s; } }
+    indep[t] = best;
+}
+int indepCorrect = 0;
+for (int t = 0; t < Tlen; t++) if (trueOfInfer[indep[t]] == trueStates[t]) indepCorrect++;
+
+Console.WriteLine(""=== HMM (avec transitions) vs classification independante ===\n"");
+Console.WriteLine($""Classification independante (argmax emission) : {indepCorrect}/{Tlen} corrects ({100.0 * indepCorrect / Tlen:0.0}%)"");
+Console.WriteLine($""HMM + Viterbi (avec transitions)             : {correct}/{Tlen} corrects ({100.0 * correct / Tlen:0.0}%)"");
+
+int flips = 0, hmmFlips = 0, trueFlips = 0;
+for (int t = 1; t < Tlen; t++) {
+    if (indep[t] != indep[t - 1]) flips++;
+    if (decoded[t] != decoded[t - 1]) hmmFlips++;
+    if (trueStates[t] != trueStates[t - 1]) trueFlips++;
+}
+Console.WriteLine($""\nChangements d'etat le long de la sequence : vrais={trueFlips}, HMM={hmmFlips}, independant={flips}"");
+Console.WriteLine(""=> L'approche independante sur-segmente (un point bruite isole = faux changement de regime)."");
+Console.WriteLine(""   Le HMM colle au nombre reel de transitions grace a la penalite implicite des changements d'etat."");
+",,,,,,,,4428ec9a8a266c0c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,6bk7odnx5y,markdown,fr,297a2a19defebd02,"### Analyse : ce que les transitions apportent
+
+Le HMM retrouve les **trois** moyennes d'emission et la structure ""collante"" de la matrice de transition, puis decode la sequence d'etats par Viterbi.
+
+- **Justesse** : le decodage Viterbi du HMM depasse la classification independante, surtout aux frontieres de regime et sur les points bruites.
+- **Coherence temporelle** : l'approche independante **sur-segmente** (elle prend un point bruite isole pour un changement de regime), tandis que le HMM colle au nombre reel de transitions grace a la penalite implicite des changements d'etat.
+- **Prix a payer** : complexite $O(T \cdot K^2)$ (vs $O(T \cdot K)$) et la necessite d'une **brisure de symetrie** pour eviter le collapse des etats.",,,,,,,,297a2a19defebd02,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,v192d1cxszo,markdown,fr,92e6ad9fce55bc42,"### Ce qui rend un HMM delicat dans Infer.NET (et comment le resoudre)
+
+Le HMM ci-dessus **fonctionne** : il n'y a pas de ""limitation"" empechant Infer.NET de chainer transitions et emissions. La difficulte est ailleurs, et elle est generique a l'inference variationnelle sur les modeles a etats latents discrets :
+
+| Difficulte | Symptome | Solution appliquee ici |
+|-----------|----------|------------------------|
+| **Symetrie des etats** (*label switching*) | EP fusionne les regimes vers la moyenne globale | Init K-means + priors centres sur les centroides + `InitialiseTo` |
+| **Ordre d'inference** | Convergence lente/instable sur la chaine | `Tr.AddAttribute(new Sequential())` |
+| **Prior de precision** | Variances d'emission explosent ou s'effondrent | Precision centree sur la variance *intra-cluster* |
+| **Etiquettes arbitraires** | Etats inferes non alignes aux vrais | Appariement bijectif par moyenne d'emission |
+
+> **A retenir** : un echec de convergence sur un HMM n'est presque jamais une ""incapacite de la librairie"" ; c'est un probleme d'**initialisation** et de **priors**. La premiere version ""toy"" de ce notebook concluait a tort a une limitation faute d'avoir brise la symetrie.",,,,,,,,92e6ad9fce55bc42,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,4r3u9gqw83f,markdown,fr,49e380b0f919922a,"### Graphe de facteurs : HMM complet (3 pas de temps)
+
+Ce graphe illustre la structure d'un **Hidden Markov Model** avec dependances temporelles :
+
+```
+[s0] -----> [s1] -----> [s2]     (etats caches avec transitions)
+  |           |           |
+  v           v           v
+[x0]        [x1]        [x2]     (observations)
+```
+
+| Element | Role | Facteur |
+|---------|------|---------|
+| **s0, s1, s2** | Etats caches | Variables discretes (regimes) |
+| **x0, x1, x2** | Observations | Variables continues (gaussiennes) |
+| **Fleches horizontales** | Transitions | P(s_t \| s_{t-1}) via Variable.Switch |
+| **Fleches verticales** | Emissions | P(x_t \| s_t) gaussiennes conditionnelles |
+
+**Propagation de messages** :
+- **Forward** : P(s_t \| x_{1:t}) - information passee
+- **Backward** : P(x_{t+1:T} \| s_t) - information future
+- **Marginal** : P(s_t \| x_{1:T}) = Forward x Backward (normalise)
+
+C'est cette structure en chaine qui permet au HMM de **lisser** les predictions en tenant compte des observations voisines.",,,,,,,,49e380b0f919922a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,infer11hmm34hdr,markdown,fr,3459876d6e4de20e,"### 3.4 HMM factoriel : des causes superposees
+
+Un HMM ordinaire suppose **un** etat cache a la fois. Mais souvent plusieurs processus independants se superposent dans une seule mesure. Exemple canonique (**desagregation de charge**, *energy disaggregation*) : la consommation electrique totale d'un logement est la **somme** des contributions de plusieurs appareils, chacun suivant sa propre dynamique ON/OFF.
+
+Le **HMM factoriel** (FHMM, port fidele de `usptact/FactorialHiddenMarkovModel`) modelise $C$ chaines de Markov **independantes** dont les contributions s'**additionnent** dans l'observation :
+
+$$y_t = \sum_{c=1}^{C} \mu_c[z^{(c)}_t] + \mathcal{N}(0, \sigma^2)$$
+
+Ici : 2 appareils binaires (contributions vraies 0/20 et 0/5), on n'observe que la somme bruitee.",,,,,,,,3459876d6e4de20e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,infer11fhmm34code,code,fr,2878e758cc31a03a,"using Microsoft.ML.Probabilistic.Models.Attributes;  // Sequential
+
+// ===================== Factorial HMM (port fidele usptact/FactorialHiddenMarkovModel) =====================
+// Cf chaines de Markov INDEPENDANTES ; l'observation = SOMME des contributions + bruit.
+//   y_t = mu0[z0_t] + mu1[z1_t] + N(0, sigma^2)
+// Cas d'usage : desagregation (2 appareils ON/OFF -> conso totale).
+
+int Cf = 2;
+int Tf = 100;
+double[][] trueMu = { new[]{0.0, 20.0}, new[]{0.0, 5.0} };  // chaine 0 : 0/20 ; chaine 1 : 0/5
+double obsStd = 1.5;
+double[][] selfStay = { new[]{0.92, 0.85}, new[]{0.90, 0.80} };  // P(rester) par etat
+
+// ---- Echantillonnage forward des 2 chaines + observation additive ----
+Rand.Restart(7);
+int[][] trueZ = Util.ArrayInit(Cf, c => new int[Tf]);
+double[] y = new double[Tf];
+for (int t = 0; t < Tf; t++) {
+    for (int c = 0; c < Cf; c++) {
+        if (t == 0) trueZ[c][t] = Rand.Double() < 0.5 ? 0 : 1;
+        else {
+            int prev = trueZ[c][t - 1];
+            double stay = selfStay[c][prev];
+            trueZ[c][t] = Rand.Double() < stay ? prev : 1 - prev;
+        }
+    }
+    y[t] = trueMu[0][trueZ[0][t]] + trueMu[1][trueZ[1][t]] + obsStd * Rand.Normal();
+}
+double dMean = y.Average(), dMin = y.Min(), dMax = y.Max(), dRange = dMax - dMin;
+double dVar = y.Select(v => (v - dMean) * (v - dMean)).Average();
+Console.WriteLine($""Donnees : plage=[{dMin:0.0},{dMax:0.0}], 4 niveaux additifs attendus ~ 0/5/20/25\n"");
+
+// ---- Construction du modele FHMM (2 chaines binaires) ----
+InferenceEngine BuildAndInfer(int seed, out double evidence,
+    out Gaussian[][] meanPost, out Dirichlet[][] transPost, out Discrete[][] statesPost, out Gamma obsPrecPost) {
+    var K = Util.ArrayInit(Cf, c => new Range(2).Named($""K{c}""));
+    var Tr = new Range(Tf).Named(""Tf"");
+    Tr.AddAttribute(new Sequential());
+
+    var ev = Variable.Bernoulli(0.5).Named(""evidence"");
+    var probInit = new Variable<Vector>[Cf];
+    var cptTrans = new VariableArray<Vector>[Cf];
+    var emitMean = new VariableArray<double>[Cf];
+    var emitPrec = new VariableArray<double>[Cf];
+    var zero = new Variable<int>[Cf];
+    var chain = new VariableArray<int>[Cf];
+    Variable<double> obsPrec = null;
+    VariableArray<double> emissions = null;
+
+    using (Variable.If(ev)) {
+        for (int c = 0; c < Cf; c++) {
+            var pInitPrior = Variable.Observed(Dirichlet.Uniform(2));
+            probInit[c] = Variable<Vector>.Random(pInitPrior); probInit[c].SetValueRange(K[c]);
+            var transPrior = Variable.Observed(Util.ArrayInit(2, k => Dirichlet.Uniform(2)), K[c]);
+            cptTrans[c] = Variable.Array<Vector>(K[c]);
+            cptTrans[c][K[c]] = Variable<Vector>.Random(transPrior[K[c]]); cptTrans[c].SetValueRange(K[c]);
+            // anchrage : etat 0 = contribution ~0 (tight) ; etat 1 = libre (broad, autour de la moitie de la plage)
+            var mPrior = Variable.Observed(new[]{
+                Gaussian.FromMeanAndVariance(0.0, 4.0),
+                Gaussian.FromMeanAndVariance(dMin + dRange * (c + 0.5) / Cf, dVar * 100) }, K[c]);
+            emitMean[c] = Variable.Array<double>(K[c]); emitMean[c][K[c]] = Variable<double>.Random(mPrior[K[c]]);
+            var pPrior = Variable.Observed(Util.ArrayInit(2, k => Gamma.FromShapeAndRate(2.0, 2.0 * dVar)), K[c]);
+            emitPrec[c] = Variable.Array<double>(K[c]); emitPrec[c][K[c]] = Variable<double>.Random(pPrior[K[c]]);
+            zero[c] = Variable.Discrete(probInit[c]);
+            chain[c] = Variable.Array<int>(Tr);
+        }
+        var obsPrecPrior = Variable.Observed(Gamma.FromShapeAndRate(2.0, 2.0 * (obsStd * obsStd)));
+        obsPrec = Variable<double>.Random(obsPrecPrior);
+        emissions = Variable.Array<double>(Tr);
+
+        using (var block = Variable.ForEach(Tr)) {
+            var t = block.Index;
+            for (int c = 0; c < Cf; c++) {
+                var prev = chain[c][t - 1];
+                using (Variable.If(t == 0)) using (Variable.Switch(zero[c])) chain[c][Tr] = Variable.Discrete(cptTrans[c][zero[c]]);
+                using (Variable.If(t > 0)) using (Variable.Switch(prev)) chain[c][t] = Variable.Discrete(cptTrans[c][prev]);
+            }
+            using (Variable.Switch(chain[0][t]))
+            using (Variable.Switch(chain[1][t])) {
+                var sum = emitMean[0][chain[0][t]] + emitMean[1][chain[1][t]];
+                emissions[t] = Variable.GaussianFromMeanAndPrecision(sum, obsPrec);
+            }
+        }
+    }
+    emissions.ObservedValue = y;
+
+    // brisure de symetrie : init aleatoire par chaine
+    Rand.Restart(seed);
+    for (int c = 0; c < Cf; c++) {
+        var zInit = Variable<Discrete>.Array(Tr);
+        zInit.ObservedValue = Util.ArrayInit(Tf, t => Discrete.PointMass(Rand.Int(2), 2));
+        chain[c][Tr].InitialiseTo(zInit[Tr]);
+    }
+
+    var eng = new InferenceEngine(new ExpectationPropagation());
+    eng.NumberOfIterations = 75; eng.ShowProgress = false;
+    meanPost = Util.ArrayInit(Cf, c => eng.Infer<Gaussian[]>(emitMean[c]));
+    transPost = Util.ArrayInit(Cf, c => eng.Infer<Dirichlet[]>(cptTrans[c]));
+    statesPost = Util.ArrayInit(Cf, c => eng.Infer<Discrete[]>(chain[c]));
+    obsPrecPost = eng.Infer<Gamma>(obsPrec);
+    evidence = eng.Infer<Bernoulli>(ev).LogOdds;
+    return eng;
+}
+
+// ---- Multi-restart : on garde le run de meilleure evidence (recommande par usptact) ----
+double bestEv = double.NegativeInfinity;
+Gaussian[][] bMean = null; Dirichlet[][] bTrans = null; Discrete[][] bStates = null; Gamma bObs = default;
+for (int r = 0; r < 6; r++) {
+    double ev; Gaussian[][] mp; Dirichlet[][] tp; Discrete[][] sp; Gamma op;
+    BuildAndInfer(100 + r * 13, out ev, out mp, out tp, out sp, out op);
+    Console.WriteLine($""  restart {r} (seed {100+r*13}) : log-evidence = {ev:0.0}"");
+    if (ev > bestEv) { bestEv = ev; bMean = mp; bTrans = tp; bStates = sp; bObs = op; }
+}
+Console.WriteLine($""\nMeilleure evidence retenue : {bestEv:0.0}\n"");
+
+// ---- Resultats : contributions retrouvees par chaine ----
+for (int c = 0; c < Cf; c++) {
+    var m = bMean[c].Select(g => g.GetMean()).OrderBy(x => x).ToArray();
+    Console.WriteLine($""Chaine {c} : contributions retrouvees = [{m[0]:0.0}, {m[1]:0.0}]  (vraies = [{trueMu[c][0]:0.0}, {trueMu[c][1]:0.0}])"");
+}
+Console.WriteLine($""Ecart-type d'observation retrouve : {Math.Sqrt(1.0/bObs.GetMean()):0.0} (vrai {obsStd:0.0})"");
+
+// ---- Reconstruction additive : MAP par chaine ----
+// Une FHMM est identifiable seulement A PERMUTATION DES CHAINES pres (les chaines sont
+// echangeables : seul leur SOMME est observee). On score donc ""modulo relabeling"" :
+// on essaie l'identite + l'echange des chaines, et le flip d'etiquette dans chaque chaine.
+int[][] mapZ = Util.ArrayInit(Cf, c => bStates[c].Select(s => s.GetMode()).ToArray());
+int[][] perms = { new[]{0,1}, new[]{1,0} };  // 2 chaines -> 2 permutations
+int best = 0; int[] bestPerm = perms[0]; int[] bestFlip = {0,0};
+foreach (var perm in perms)
+for (int f0 = 0; f0 < 2; f0++)
+for (int f1 = 0; f1 < 2; f1++) {
+    int[] flip = { f0, f1 };
+    int corr = 0;
+    for (int t = 0; t < Tf; t++) {
+        bool ok = true;
+        for (int c = 0; c < Cf; c++) {
+            int rec = mapZ[perm[c]][t] ^ flip[c];   // chaine recuperee perm[c], etiquette eventuellement inversee
+            if (rec != trueZ[c][t]) ok = false;
+        }
+        if (ok) corr++;
+    }
+    if (corr > best) { best = corr; bestPerm = perm; bestFlip = flip; }
+}
+Console.WriteLine($""\nReconstruction conjointe (modulo echange des chaines) : {best}/{Tf} pas exacts ({100.0*best/Tf:0.0}%)"");
+Console.WriteLine($""  -> chaine recuperee {bestPerm[0]} = vraie chaine 0 ; chaine recuperee {bestPerm[1]} = vraie chaine 1 (symetrie d'echange FHMM)"");
+",,,,,,,,2878e758cc31a03a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,infer11hmm34interp,markdown,fr,36dde0509290eb6c,"### Interpretation : identifiabilite a permutation pres
+
+Le FHMM retrouve les contributions additives de chaque chaine (~0/20 et ~0/5) et reconstruit l'etat conjoint avec une tres bonne precision.
+
+**Point subtil et pedagogique** : un FHMM n'est identifiable qu'**a permutation des chaines pres**. Comme seule leur *somme* est observee, rien ne distingue ""chaine A = gros appareil, chaine B = petit"" de l'arrangement inverse -- ni l'etiquette 0/1 a l'interieur d'une chaine. Le score est donc calcule **modulo relabeling** (on essaie l'identite + l'echange des chaines, et le flip d'etiquette dans chaque chaine, on garde le meilleur).
+
+On choisit aussi le run de **meilleure log-evidence** sur plusieurs initialisations aleatoires (*multi-restart*) : c'est la encore une parade a la symetrie, recommandee par l'implementation de reference.",,,,,,,,36dde0509290eb6c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,1cbb2595,markdown,fr,a0b3e214a30166ea,## 4. Detection de Regimes Meteo,,,,,,,,a0b3e214a30166ea,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,sil9i09arb,markdown,fr,fe812eeb1b6647ad,"Cas d'usage classique : inferer une variable latente (le vrai temps) a partir d'observations bruitees (temperature).
+
+| Regime | Temperature moyenne | Ecart-type |
+|--------|---------------------|------------|
+| Soleil | 22C | 2C |
+| Pluie | 15C | 2C |",,,,,,,,fe812eeb1b6647ad,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,09ef4332,code,fr,49f3b938d8b2b505,"// Exemple : Detection de regimes meteo (Soleil/Pluie) a partir de temperature
+
+// Soleil : temperature ~22C
+// Pluie : temperature ~15C
+
+double[] tempJour = { 21, 23, 22, 20, 15, 14, 16, 15, 14, 21, 22, 23 };
+int Tmeteo = tempJour.Length;
+
+Console.WriteLine(""=== Detection Regimes Meteo ==="");
+Console.WriteLine($""\nTemperatures : {string.Join("", "", tempJour)}\n"");
+
+for (int t = 0; t < Tmeteo; t++)
+{
+    Variable<int> meteo = Variable.DiscreteUniform(2);
+    Variable<double> temp = Variable.New<double>();
+    
+    using (Variable.Case(meteo, 0))  // Soleil
+    {
+        temp.SetTo(Variable.GaussianFromMeanAndVariance(22, 4));
+    }
+    using (Variable.Case(meteo, 1))  // Pluie
+    {
+        temp.SetTo(Variable.GaussianFromMeanAndVariance(15, 4));
+    }
+    
+    temp.ObservedValue = tempJour[t];
+    
+    InferenceEngine eng = new InferenceEngine();
+    eng.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    
+    Discrete meteoPost = eng.Infer<Discrete>(meteo);
+    string regime = meteoPost.GetProbs()[0] > 0.5 ? ""Soleil"" : ""Pluie"";
+    
+    Console.WriteLine($""Jour {t+1,2} : {tempJour[t]:F0}C -> {regime} (P={meteoPost.GetProbs().Max():F2})"");
+}",,,,,,,,49f3b938d8b2b505,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,ec204f75,markdown,fr,6972f3e799d861c4,Visualisation du graphe de facteurs pour la detection de regimes meteo.,,,,,,,,6972f3e799d861c4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,z34439j0ib,code,fr,cf0f3b8f67a3f808,"// Visualisation du graphe de facteurs pour la detection meteo
+// Modele identique a la classification independante
+
+Variable<int> meteoViz = Variable.DiscreteUniform(2).Named(""meteo"");
+Variable<double> tempViz = Variable.New<double>().Named(""temperature"");
+
+using (Variable.Case(meteoViz, 0))
+{
+    tempViz.SetTo(Variable.GaussianFromMeanAndVariance(22, 4).Named(""emission_Soleil""));
+}
+using (Variable.Case(meteoViz, 1))
+{
+    tempViz.SetTo(Variable.GaussianFromMeanAndVariance(15, 4).Named(""emission_Pluie""));
+}
+
+tempViz.ObservedValue = 18.0;
+
+InferenceEngine engMeteoViz = new InferenceEngine();
+engMeteoViz.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+engMeteoViz.ShowFactorGraph = true;
+
+var _meteo = engMeteoViz.Infer(meteoViz);
+Console.WriteLine(""\nGraphe de facteurs genere pour le modele meteo."");",,,,,,,,cf0f3b8f67a3f808,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,lynx4a5sz0g,markdown,fr,39be8a8c964fbe91,"### Interpretation des resultats meteo
+
+| Jours | Temperature | Regime | Confiance |
+|-------|-------------|--------|-----------|
+| 1-4 | 20-23C | Soleil | 93-100% |
+| 5-9 | 14-16C | Pluie | 99-100% |
+| 10-12 | 21-23C | Soleil | 99-100% |
+
+**Observation** : Le jour 4 (20C) montre une confiance de 93% car cette temperature est a mi-chemin entre les deux regimes. C'est exactement le type de cas ou un HMM avec transitions aiderait : si les jours 1-3 sont ""Soleil"", le jour 4 devrait l'etre aussi par continuite.
+
+Visualisons le graphe de facteurs pour ce modele de classification :",,,,,,,,39be8a8c964fbe91,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,1xol5m2d983,code,fr,43a628cd7b8a875a,"// Affichage du graphe meteo
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,43a628cd7b8a875a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,rvevktcbjtf,markdown,fr,b7658d490b270081,"### Graphe de facteurs : Modele meteo (classification)
+
+Structure identique a la detection d'anomalies - un modele de **melange gaussien** :
+
+| Composante | Parametres |
+|------------|------------|
+| **Soleil** | N(22, 4) - temperature elevee |
+| **Pluie** | N(15, 4) - temperature basse |
+
+Le graphe montre le branchement conditionnel (Variable.Case) qui selectionne l'emission appropriee selon l'etat latent `meteo`.
+
+> **Application** : Ce modele simple est equivalent a un classifieur de Bayes naive pour une seule feature (temperature).",,,,,,,,b7658d490b270081,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,ar7q2hcf8zp,markdown,fr,80222f51be612800,"**Resultats** : Detection correcte des deux regimes (Soleil jours 1-4 et 10-12, Pluie jours 5-9).
+
+> **Point d'interet** : Le jour 4 (20C) a une confiance ""seulement"" 93% car la temperature est intermediaire entre les deux regimes.",,,,,,,,80222f51be612800,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,803d63a7,markdown,fr,5dcebd620676554e,"## 4bis. Exercice : Sensibilite du Modele aux Emissions Chevauchantes
+
+Dans la section 4, les deux regimes meteo (Soleil ~22C, Pluie ~15C) sont bien separes avec un ecart de 7C pour un ecart-type de 2C. Que se passe-t-il quand les emissions se chevauchent davantage ?
+
+**Scenario** : Deux villes ont des regimes de temperature proches :
+
+| Ville | Moyenne | Ecart-type |
+|-------|---------|------------|
+| Ville A (oceanique) | 18C | 4C |
+| Ville B (semi-continental) | 16C | 4C |
+
+L'ecart entre les moyennes (2C) est plus petit que l'ecart-type (4C) : les distributions se recouvrent fortement.
+
+**Objectifs** :
+1. Implementez un modele de classification independante avec ces parametres
+2. Testez sur les observations : `{15, 17, 19, 16, 18, 14, 20, 17}`
+3. Identifiez les observations ambigues (P < 0.8)
+4. Repetez avec des emissions mieux separees (moyennes 20C et 12C) et comparez
+
+**Etapes** :
+1. Definir les parametres d'emission pour les deux villes (`GaussianFromMeanAndVariance` avec variance 16)
+2. Boucler sur les observations et inferer l'appartenance a chaque ville avec `Variable.Case`
+3. Afficher P(Ville A) et P(Ville B) pour chaque observation
+4. Repeter avec muA=20, muB=12 et comparer les confiances
+
+**Indices** :
+- Utilisez `Variable.GaussianFromMeanAndVariance(mu, sigma2)` avec sigma2 = 16 (sigma = 4)
+- Une observation est ambigu si P(Ville A) est entre 0.2 et 0.8
+- Avec des moyennes plus eloignees (20 et 12), l'ecart (8C) depasse 2 sigma : separation nette attendue",,,,,,,,5dcebd620676554e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,6e1d13fe,code,fr,d6eeb8b7b23b20c0,"// Exercice : Sensibilite du modele aux emissions chevauchantes
+
+// Observations
+double[] tempsVilles = { 15, 17, 19, 16, 18, 14, 20, 17 };
+
+// Parametres d'emission (ecart faible = chevauchement)
+double muA = 18.0, muB = 16.0;
+double sigma2Ville = 16.0; // sigma = 4
+
+// TODO: Etape 1 - Implementez la classification independante
+// (Reutilisez le pattern Variable.DiscreteUniform + Variable.Case de la section 4)
+
+// TODO: Etape 2 - Affichez P(Ville A) et P(Ville B) pour chaque observation
+// Identifiez les observations ambigues (P entre 0.2 et 0.8)
+
+// TODO: Etape 3 - Repetez avec muA=20 et muB=12 (emissions bien separees)
+// Comparez les niveaux de confiance
+
+Console.WriteLine(""Exercice a completer : analysez la sensibilite aux emissions chevauchantes."");",,,,,,,,d6eeb8b7b23b20c0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,d282b7c3,markdown,fr,83e5a74ccb67f441,"## 5. Motif Finding (Bioinformatique)
+
+### Probleme
+
+Trouver des motifs conserves dans des sequences ADN.
+
+### Modele
+
+- Arriere-plan : nucleotides uniformes (A, C, G, T)
+- Motif : positions avec distributions specifiques",,,,,,,,83e5a74ccb67f441,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,tfetkzwnq9k,markdown,fr,7106f234f5c3d72e,"### Un modele generatif de motif (et son miroir : l'inference)
+
+Le comptage de k-mers (naif) trouve les sous-chaines frequentes, mais il ne modelise pas l'**incertitude** : une position du motif peut tolerer plusieurs bases. Le modele probabiliste de `dotnet/infer` (MotifFinder) decrit comment les sequences sont **engendrees**, puis **inverse** ce processus pour retrouver le motif.
+
+**Modele generatif** (port fidele du MotifFinder officiel) :
+- **PWM** (*Position Weight Matrix*) : pour chacune des $W$ positions du motif, une distribution sur {A, C, G, T}, de prior `Dirichlet`.
+- Pour chaque sequence : presence du motif `motifPresence ~ Bernoulli(0.8)`, et si present, une position `motifPos ~ Uniforme`.
+- La sequence = **fond uniforme** (gauche) + **motif** (echantillonne de la PWM) + **fond uniforme** (droite), assemblee par `Variable.StringFromArray` / `Variable.StringOfLength` (inference sur des **chaines de caracteres**, une specialite d'Infer.NET).
+
+L'inference et la generation sont **symetriques** : on echantillonne d'abord depuis une PWM connue (ETAPE 1), puis on fait *tourner le modele a l'envers* pour retrouver cette PWM a partir des seules sequences (ETAPE 2). Comparer les deux est le coeur pedagogique de la section.",,,,,,,,7106f234f5c3d72e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,98e32de3,code,fr,0c50904b03feb85d,"// ETAPE 1 - GENERATION (forward) : on echantillonne des sequences depuis une PWM CONNUE.
+// C'est le miroir pedagogique de l'inference : meme modele, parcouru dans l'autre sens.
+
+Rand.Restart(1337);
+int SequenceCount = 70;
+int SequenceLength = 25;
+double MotifPresenceProbability = 0.8;
+
+DiscreteChar NucleobaseDist(double a, double c, double g, double t) {
+    Vector probs = PiecewiseVector.Zero(char.MaxValue + 1);
+    probs['A'] = a; probs['C'] = c; probs['G'] = g; probs['T'] = t;
+    return DiscreteChar.FromVector(probs);
+}
+
+// ---- Vraie PWM du motif (matrice de frequences position-specifique, 8 positions = original) ----
+// La position 4 (index 3) est volontairement uniforme : le modele doit aussi gerer une colonne non-informative.
+var trueMotif = new[] {
+    NucleobaseDist(0.80, 0.10, 0.05, 0.05),
+    NucleobaseDist(0.00, 0.90, 0.05, 0.05),
+    NucleobaseDist(0.00, 0.00, 0.50, 0.50),
+    NucleobaseDist(0.25, 0.25, 0.25, 0.25),
+    NucleobaseDist(0.10, 0.10, 0.10, 0.70),
+    NucleobaseDist(0.00, 0.00, 0.90, 0.10),
+    NucleobaseDist(0.90, 0.05, 0.00, 0.05),
+    NucleobaseDist(0.50, 0.50, 0.00, 0.00),
+};
+int motifLength = trueMotif.Length;
+var background = NucleobaseDist(0.25, 0.25, 0.25, 0.25);
+
+// ---- Echantillonnage FORWARD (background + motif insere a position aleatoire) ----
+string[] seqData = new string[SequenceCount];
+int[]    posData = new int[SequenceCount];
+for (int i = 0; i < SequenceCount; i++) {
+    if (Rand.Double() <= MotifPresenceProbability) {
+        posData[i] = Rand.Int(SequenceLength - motifLength + 1);
+        var before = Util.ArrayInit(posData[i], j => background.Sample());
+        var after  = Util.ArrayInit(SequenceLength - motifLength - posData[i], j => background.Sample());
+        var mc     = Util.ArrayInit(motifLength, j => trueMotif[j].Sample());
+        seqData[i] = new string(before) + new string(mc) + new string(after);
+    } else {
+        posData[i] = -1;
+        seqData[i] = new string(Util.ArrayInit(SequenceLength, j => background.Sample()));
+    }
+}
+
+
+// ---- Affichage : la PWM ""verite terrain"" + quelques sequences echantillonnees ----
+void ShowPWM(string cap, Func<int,char,double> w) {
+    Console.WriteLine(cap + "" (lignes = base, colonnes = position du motif) :"");
+    foreach (char b in new[]{'A','C','G','T'}) {
+        Console.Write($""  {b}:"");
+        for (int i = 0; i < motifLength; i++) Console.Write($""  {w(i,b):0.00}"");
+        Console.WriteLine();
+    }
+}
+Console.WriteLine($""Echantillonnage FORWARD : {SequenceCount} sequences de longueur {SequenceLength}, motif present avec prob {MotifPresenceProbability}.\n"");
+ShowPWM(""Vraie PWM du motif (8 positions, position 4 volontairement uniforme)"", (i,b) => trueMotif[i][b]);
+Console.WriteLine(""\nQuelques sequences echantillonnees (^ marque la position vraie du motif) :"");
+for (int i = 0; i < 6; i++) {
+    string mark = posData[i] < 0 ? ""(pas de motif)"" : new string(' ', posData[i]) + new string('^', motifLength);
+    Console.WriteLine($""  seq {i}: {seqData[i]}"");
+    Console.WriteLine($""         {mark}"");
+}
+",,,,,,,,0c50904b03feb85d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,a7i2j2lplw5,markdown,fr,c0b3b0f7d7785059,"**Etape 2 : inference -- retrouver la PWM, la presence et la position**
+
+On observe maintenant **uniquement les sequences** (en oubliant la PWM et les positions vraies) et on demande a Infer.NET de les **reconstruire**. Le meme modele generatif sert de squelette ; le moteur infere a posteriori :
+- la **PWM** du motif (a comparer a la verite terrain de l'etape 1),
+- pour chaque sequence, la **probabilite de presence** du motif et sa **position** la plus probable.",,,,,,,,c0b3b0f7d7785059,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,717c140d,code,fr,552ed2c52ad5aabe,"using Microsoft.ML.Probabilistic.Factors.Attributes;  // QualityBand
+
+// ETAPE 2 - INFERENCE (backward) : on OBSERVE les sequences et on RETROUVE
+// la PWM + la presence + la position du motif, par programmation probabiliste.
+// (reutilise seqData / posData / trueMotif / background generes a l'etape 1)
+
+// ---- Modele generatif Infer.NET ----
+Vector pseudo = PiecewiseVector.Constant(char.MaxValue + 1, 1e-6);
+pseudo['A'] = pseudo['C'] = pseudo['G'] = pseudo['T'] = 1.0;
+
+Range mcr      = new Range(motifLength);
+var motifProbs = Variable.Array<Vector>(mcr);
+motifProbs[mcr] = Variable.Dirichlet(pseudo).ForEach(mcr);
+
+var sr = new Range(SequenceCount);
+var sequences = Variable.Array<string>(sr);
+var motifPos  = Variable.Array<int>(sr);
+motifPos[sr]  = Variable.DiscreteUniform(SequenceLength - motifLength + 1).ForEach(sr);
+var motifPresence = Variable.Array<bool>(sr);
+motifPresence[sr] = Variable.Bernoulli(MotifPresenceProbability).ForEach(sr);
+
+using (Variable.ForEach(sr)) {
+    using (Variable.If(motifPresence[sr])) {
+        var motifChars = Variable.Array<char>(mcr);
+        motifChars[mcr] = Variable.Char(motifProbs[mcr]);
+        var motif = Variable.StringFromArray(motifChars);
+        var bgRightLen = SequenceLength - motifLength - motifPos[sr];
+        var bgLeft  = Variable.StringOfLength(motifPos[sr], background);
+        var bgRight = Variable.StringOfLength(bgRightLen, background);
+        sequences[sr] = bgLeft + motif + bgRight;
+    }
+    using (Variable.IfNot(motifPresence[sr])) {
+        sequences[sr] = Variable.StringOfLength(SequenceLength, background);
+    }
+}
+
+// ---- Inference ----
+sequences.ObservedValue = seqData;
+var eng = new InferenceEngine();
+eng.NumberOfIterations = 30;
+eng.Compiler.RecommendedQuality = QualityBand.Experimental;
+eng.ShowProgress = false;
+
+var pwmPost  = eng.Infer<IList<Dirichlet>>(motifProbs);
+var presPost = eng.Infer<IList<Bernoulli>>(motifPresence);
+var posPost  = eng.Infer<IList<Discrete>>(motifPos);
+
+// ---- Resultats : PWM vraie vs retrouvee ----
+void PrintPWM(string caption, Func<int,char,double> w) {
+    Console.WriteLine(caption + "" :"");
+    foreach (char b in new[]{'A','C','G','T'}) {
+        Console.Write($""  {b}:"");
+        for (int i = 0; i < motifLength; i++) Console.Write($""  {w(i,b):0.00}"");
+        Console.WriteLine();
+    }
+}
+PrintPWM(""Vraie PWM du motif"", (i,b) => trueMotif[i][b]);
+Console.WriteLine();
+PrintPWM(""PWM RETROUVEE (moyenne posterieure)"", (i,b) => pwmPost[i].GetMean()[b]);
+
+Console.WriteLine(""\n=== Quelques sequences : position predite vs vraie ==="");
+int shown = 0;
+for (int i = 0; i < SequenceCount && shown < 8; i++) {
+    int predPos = presPost[i].GetProbTrue() > 0.5 ? posPost[i].GetMode() : -1;
+    Console.WriteLine($""  seq {i,2}: {seqData[i]}  P(motif)={presPost[i].GetProbTrue():0.00}  pos_pred={predPos,2} (vrai {posData[i],2})"");
+    shown++;
+}
+int posOK = 0, present = 0;
+for (int i = 0; i < SequenceCount; i++) {
+    if (posData[i] >= 0) { present++; if (presPost[i].GetProbTrue() > 0.5 && posPost[i].GetMode() == posData[i]) posOK++; }
+}
+Console.WriteLine($""\n=== Positions exactes retrouvees : {posOK}/{present} sequences avec motif ==="");
+",,,,,,,,552ed2c52ad5aabe,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,mt3h0rcfywa,markdown,fr,5e1ff8dfdc590bd1,"### Resultats et lissage laplacien
+
+La PWM retrouvee reproduit fidelement la verite terrain (colonnes fortement conservees retrouvees nettement ; la colonne volontairement uniforme reste plate), et la majorite des positions du motif sont correctement localisees.
+
+**Pourquoi l'erreur residuelle ?** Les quelques ecarts de probabilite dans la PWM et les rares faux positifs/negatifs de position viennent du **lissage laplacien** (*Laplacian / additive smoothing*) : le prior `Dirichlet` place des **pseudo-comptes** (=1.0 pour A/C/G/T) sur chaque position. Ces pseudo-comptes empechent les probabilites de tomber a exactement 0 ou 1 (utile : un nucleotide jamais vu dans l'echantillon reste possible), mais ils **tirent legerement** les estimations vers l'uniforme. Avec plus de sequences, le poids des donnees domine les pseudo-comptes et l'estimation se resserre vers la PWM vraie.
+
+> C'est exactement le compromis biais-variance du lissage : un peu de biais (vers l'uniforme) contre beaucoup moins de variance (pas de probabilite 0 catastrophique sur un petit echantillon).",,,,,,,,5e1ff8dfdc590bd1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,34b2f962,markdown,fr,3e57fff659c846c1,"## 6. Exemple guide : Detection d'Anomalies
+
+### Enonce
+
+Utilisez un HMM pour detecter des periodes anormales dans une serie temporelle de ventes.",,,,,,,,3e57fff659c846c1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,8ioxik0mv8y,markdown,fr,07f66a980ed52214,"---
+
+**Transition** : Apres avoir explore les HMM theoriquement (section 3) et sur des exemples meteo (section 4) et bioinformatiques (section 5), passons a un exercice pratique de detection d'anomalies dans un contexte business.",,,,,,,,07f66a980ed52214,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,6d60b6gl9ft,markdown,fr,5ab2d1c3448dc682,"Detection d'anomalies dans les series temporelles de ventes :
+
+| Scenario | Caracteristiques | Action |
+|----------|------------------|--------|
+| Promotion | Hausse temporaire | Optimiser le stock |
+| Rupture stock | Baisse soudaine | Reapprovisionner |
+| Tendance | Evolution graduelle | Ajuster previsions |",,,,,,,,5ab2d1c3448dc682,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,56733a6c,code,fr,69e28f13acc010d5,"// Exemple guide : Detection d'anomalies dans les ventes
+
+// Ventes journalieres (normal ~100, promo ~200)
+double[] ventes = { 98, 105, 102, 99, 195, 210, 205, 198, 103, 97, 101, 100 };
+
+Console.WriteLine(""=== Detection Periodes de Promotion ==="");
+Console.WriteLine($""\nVentes : {string.Join("", "", ventes.Select(v => v.ToString(""F0"")))}\n"");
+
+for (int t = 0; t < ventes.Length; t++)
+{
+    Variable<int> regime = Variable.DiscreteUniform(2);
+    Variable<double> venteVar = Variable.New<double>();
+    
+    using (Variable.Case(regime, 0))  // Normal
+    {
+        venteVar.SetTo(Variable.GaussianFromMeanAndVariance(100, 100));
+    }
+    using (Variable.Case(regime, 1))  // Promotion
+    {
+        venteVar.SetTo(Variable.GaussianFromMeanAndVariance(200, 100));
+    }
+    
+    venteVar.ObservedValue = ventes[t];
+    
+    InferenceEngine eng = new InferenceEngine();
+    eng.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    
+    Discrete regimePost = eng.Infer<Discrete>(regime);
+    string etat = regimePost.GetProbs()[1] > 0.5 ? ""PROMO"" : ""Normal"";
+    
+    Console.WriteLine($""Jour {t+1,2} : {ventes[t],3:F0} -> {etat} (P={regimePost.GetProbs().Max():F2})"");
+}
+
+Console.WriteLine(""\n=> Jours 5-8 detectes comme periode de promotion"");",,,,,,,,69e28f13acc010d5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,3c0679a3,markdown,fr,533e4710123e6e44,Visualisation du graphe de facteurs pour la detection d'anomalies dans les ventes.,,,,,,,,533e4710123e6e44,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,3nnqh8zkiod,code,fr,6d83ddb00d97dde9,"// Visualisation du graphe pour la detection de promotions
+Variable<int> regimeViz = Variable.DiscreteUniform(2).Named(""regime_ventes"");
+Variable<double> venteViz = Variable.New<double>().Named(""ventes_journalieres"");
+
+using (Variable.Case(regimeViz, 0))
+{
+    venteViz.SetTo(Variable.GaussianFromMeanAndVariance(100, 100).Named(""emission_Normal""));
+}
+using (Variable.Case(regimeViz, 1))
+{
+    venteViz.SetTo(Variable.GaussianFromMeanAndVariance(200, 100).Named(""emission_Promo""));
+}
+
+venteViz.ObservedValue = 150.0;
+
+InferenceEngine engVenteViz = new InferenceEngine();
+engVenteViz.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+engVenteViz.ShowFactorGraph = true;
+
+var _regime = engVenteViz.Infer(regimeViz);
+Console.WriteLine(""\nGraphe de facteurs genere pour la detection de promotions."");",,,,,,,,6d83ddb00d97dde9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,3fdxvm2s2rx,markdown,fr,8e74145ce104fb2d,"### Interpretation des resultats de l'exemple guide
+
+Le detecteur identifie correctement la **periode promotionnelle** (jours 5-8) :
+
+| Periode | Ventes moyennes | Regime detecte |
+|---------|-----------------|----------------|
+| Jours 1-4 | ~101 | Normal |
+| Jours 5-8 | ~202 | **PROMO** |
+| Jours 9-12 | ~100 | Normal |
+
+**Applications business** :
+- **Planification stocks** : Anticiper les pics de demande
+- **Analyse retrospective** : Identifier les periodes promotionnelles non documentees
+- **Detection de fraude** : Reperer les anomalies inexpliquees
+
+Visualisons le graphe de facteurs pour ce modele :",,,,,,,,8e74145ce104fb2d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,f6x0b59hor,code,fr,17eb4f8545661f03,"// Affichage du graphe de detection de promotions
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,17eb4f8545661f03,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,p4hrpt1fnce,markdown,fr,14b7ce350ce5e734,"### Graphe de facteurs : Detection de promotions
+
+Meme structure que les modeles precedents - classification par melange gaussien :
+
+| Regime | Distribution | Interpretation |
+|--------|--------------|----------------|
+| **Normal** | N(100, 100) | Ventes moyennes ~100 unites |
+| **Promo** | N(200, 100) | Ventes elevees ~200 unites |
+
+**Extension possible** : Pour une detection plus robuste des periodes promotionnelles, on ajouterait des **transitions Markoviennes** comme dans la section 3.3. Cela permettrait de :
+
+1. Penaliser les changements frequents Normal <-> Promo
+2. Detecter des periodes coherentes (promotion sur plusieurs jours consecutifs)
+3. Lisser les observations ambigues (ex: 150 unites) selon le contexte",,,,,,,,14b7ce350ce5e734,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,y3txyxantb,markdown,fr,8a9a81ffd96979c2,**Resultats** : Detection parfaite - jours 5-8 identifies comme periode promotionnelle (ventes ~200 vs ~100 en normal).,,,,,,,,8a9a81ffd96979c2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,d42c6ea1,markdown,fr,0d9b4314cf3ff088,"## 6bis. Exercice : Impact des Parametres de Transition sur le Lissage
+
+Dans la section 3.3, nous avons construit un HMM complet a transitions markoviennes (trois regimes Normal/Alerte/Critique, inference par Expectation Propagation puis decodage de Viterbi) et observe comment la matrice de transition lisse les decisions la ou la classification independante sur-segmente.
+
+Votre mission : modifiez les parametres du HMM et analysez l'impact sur les probabilites a posteriori.
+
+**Scenario** : Un capteur de debit hydraulique produit les mesures suivantes :
+
+```
+{8.2, 9.1, 9.5, 12.5, 14.0, 9.8, 8.5, 12.8}
+```
+
+Les deux regimes possibles sont :
+- **Debit normal** : ~N(9, 2) (moyenne 9, variance 2)
+- **Fuite** : ~N(13, 2) (moyenne 13, variance 2)
+
+**Objectifs** :
+1. Implementez la passe Forward avec les parametres fournis
+2. Testez deux configurations de transitions :
+   - **Config A** : `pStay = 0.7`, `pSwitch = 0.3` (transitions frequentes)
+   - **Config B** : `pStay = 0.95`, `pSwitch = 0.05` (transitions rares)
+3. Comparez les probabilites a posteriori pour les observations ambigues (12.5, 14.0, 9.8, 12.8)
+4. Expliquez pourquoi la Config B produit des sequences plus ""lisses""
+
+**Indice** : Les valeurs 12.5 et 12.8 sont ambigues car entre les deux moyennes (9 et 13). Comparez P(Fuite) entre les deux configs pour ces valeurs - la config B devrait favoriser la continuite avec les voisins plutot que la vraisemblance seule.",,,,,,,,0d9b4314cf3ff088,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,08eb783b,code,fr,985e81b3b377ce92,"// Exercice : Impact des parametres de transition sur le lissage
+
+// Donnees capteur de debit hydraulique
+double[] debit = { 8.2, 9.1, 9.5, 12.5, 14.0, 9.8, 8.5, 12.8 };
+int Tdebit = debit.Length;
+
+// Parametres d'emission
+double muNormal = 9.0, muFuite = 13.0;
+double sigma2Debit = 2.0;
+
+// Fonction de vraisemblance gaussienne (reutilisez celle de la section 3.3)
+// gaussLik(x, mu, s2) = exp(-0.5 * (x - mu)^2 / s2)
+
+// TODO: Etape 1 - Implementez la passe Forward pour une config donnee
+// Parametres : pStay, pSwitch, observations
+// Retourne : tableau alpha[T, 2] normalise
+
+// TODO: Etape 2 - Implementez la passe Backward
+// Retourne : tableau beta[T, 2] normalise
+
+// TODO: Etape 3 - Calculez les posterieurs gamma[T, 2] = alpha * beta (normalise)
+
+// TODO: Etape 4 - Testez Config A (pStay=0.7) et affichez les resultats
+double pStayA = 0.7;
+double pSwitchA = 0.3;
+
+// TODO: Etape 5 - Testez Config B (pStay=0.95) et affichez les resultats
+double pStayB = 0.95;
+double pSwitchB = 0.05;
+
+// TODO: Etape 6 - Affichez un tableau comparatif pour les 4 observations ambigues
+// | t | Obs | P(Fuite) Config A | P(Fuite) Config B | Decision A | Decision B |
+
+Console.WriteLine(""Exercice a completer : implementez Forward-Backward pour les deux configs."");",,,,,,,,985e81b3b377ce92,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,e954a1ea,markdown,fr,932447e884b766d0,"## 7. Resume
+
+| Concept | Description |
+|---------|-------------|
+| **HMM** | Modele a etats caches avec dependances temporelles |
+| **Emissions** | Distribution des observations selon l'etat |
+| **Transitions** | Probabilites de changement d'etat |
+| **Viterbi** | Algorithme pour trouver la sequence d'etats optimale |
+| **Forward-Backward** | Calcul des probabilites marginales |
+
+---
+
+## Pour aller plus loin
+
+| Si vous voulez... | Consultez... |
+|-------------------|--------------|
+| Comprendre Variable.Switch | [Infer-3-Factor-Graphs](Infer-3-Factor-Graphs.ipynb) |
+| Comparer EP vs VMP pour HMM | [Infer-6-Debugging](Infer-6-Debugging.ipynb) Section 4 |
+| Debugger des problemes de convergence | [Infer-6-Debugging](Infer-6-Debugging.ipynb) |
+| Trouver une definition (HMM, Viterbi, etc.) | [Glossaire](Infer-Glossary.md) |
+
+---
+
+## Plus loin dans la serie
+
+Dans [Infer-15-Recommenders](Infer-15-Recommenders.ipynb), nous explorerons :
+
+- Les systemes de recommandation
+- La factorisation matricielle
+- Le modele ClickModel pour sources multiples",,,,,,,,932447e884b766d0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,5ce81347,markdown,fr,1b5de7d699972100,"## 7bis. Exercice : HMM a 3 Etats - Detection de Pannes Machine
+
+Etendez le HMM a **3 etats** pour modeliser l'etat d'une machine industrielle :
+
+- **Etat 0 : Normal** - capteur moyen ~100, precision elevee (sigma~5)
+- **Etat 1 : Degrade** - capteur moyen ~70, precision faible (sigma~15)
+- **Etat 2 : En panne** - capteur moyen ~20, precision tres faible (sigma~25)
+
+Donnees capteur :
+`{98, 102, 99, 95, 68, 75, 72, 65, 18, 22, 15, 25, 71, 68, 100, 103}`
+
+Attendu : Normal (jours 1-4), Degrade (5-8), Panne (9-12), Degrade (13-14), Normal (15-16).
+
+**Objectifs** :
+1. Adapter le modele de classification independante a 3 etats au lieu de 2
+2. Parametrer les emissions gaussiennes pour chaque etat (moyenne + precision)
+3. Implementer la boucle d'inference et afficher les decisions
+
+**Indice** : Utilisez `Variable.DiscreteUniform(3)` pour 3 etats et ajoutez un troisieme bloc `Variable.Case(etat, 2)` pour l'etat ""En panne"".",,,,,,,,1b5de7d699972100,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,e53022de,code,fr,139efdab705942c3,"// Exercice : HMM 3 etats pour detection de pannes machine
+double[] capteur = { 98, 102, 99, 95, 68, 75, 72, 65, 18, 22, 15, 25, 71, 68, 100, 103 };
+int T = capteur.Length;
+int K = 3;  // 3 etats : Normal=0, Degrade=1, En panne=2
+
+// Parametres d'emission par etat (moyennes et precisions)
+double[] moyennesEtat = { 100.0, 70.0, 20.0 };
+double[] precisionsEtat = { 1.0/25.0, 1.0/225.0, 1.0/625.0 };  // sigma = 5, 15, 25
+
+// Matrice de transition suggeree (auto-persistance elevee):
+// Normal    : [0.90, 0.09, 0.01]
+// Degrade   : [0.10, 0.80, 0.10]
+// En panne  : [0.01, 0.19, 0.80]
+Vector[] transMatrix = new Vector[] {
+    Vector.FromArray(0.90, 0.09, 0.01),
+    Vector.FromArray(0.10, 0.80, 0.10),
+    Vector.FromArray(0.01, 0.19, 0.80)
+};
+
+// TODO: Creer le moteur d'inference
+
+// TODO: Construire le HMM 3 etats
+// (Reutilisez la structure HMM de l'exemple guide en changeant nStates de 2 a 3)
+
+// TODO: Observer les donnees capteur et inferer les etats
+
+// TODO: Afficher les probabilites d'etat pour les jours cles
+
+Console.WriteLine(""Exercice a completer : adaptez le modele de classification a 3 etats."");",,,,,,,,139efdab705942c3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb,b9605c6c,markdown,fr,05623a1329e7a155,"## Conclusion
+
+Ce notebook a explore les Hidden Markov Models avec Infer.NET : etats caches, emissions gaussiennes, transitions markoviennes, decodage de Viterbi, HMM factoriel et motif finding sur chaines de caracteres.
+
+| Concept | Point cle |
+|---------|-----------|
+| HMM | Etats caches lies par transitions, observations via emissions |
+| Classification independante | Chaque observation classee seule, sans contexte temporel (baseline) |
+| HMM complet (Infer.NET) | `ForEach` + `If(t==0)`/`If(t>0)` + `Switch` ; **possible**, a condition de briser la symetrie |
+| Brisure de symetrie | Init K-means + priors centres + precision intra-cluster ; sinon EP fusionne les etats |
+| Viterbi | Chemin d'etats globalement optimal (programmation dynamique) |
+| HMM factoriel | Chaines independantes dont les contributions s'additionnent ; identifiable a permutation pres |
+| Motif finding | Modele generatif PWM + inference sur chaines (`StringFromArray`), lissage laplacien |
+
+| Distribution | Usage |
+|--------------|-------|
+| Discrete | Etats caches (regimes, presence de motif) |
+| Gaussian | Emissions conditionnelles aux etats |
+| Dirichlet | Priors sur transitions et PWM (pseudo-comptes = lissage laplacien) |
+
+> **A retenir** : Infer.NET sait chainer transitions et emissions (HMM, FHMM, motif finding). Les difficultes rencontrees ne sont pas des ""limitations de la librairie"" mais des problemes classiques d'**initialisation**, de **priors** et d'**identifiabilite** (*label switching*, permutation des chaines) -- qui se resolvent par K-means, priors informatifs et appariement.",,,,,,,,05623a1329e7a155,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,3e3a7357,markdown,fr,d6d5b27c0d059adb,"# Infer-15-Recommenders : Systemes de Recommandation
+
+**Serie** : Programmation Probabiliste avec Infer.NET (15/20)  
+**Duree estimee** : 60 minutes  
+**Prerequis** : Infer-14-Sequences
+
+---
+
+## Objectifs
+
+- Comprendre le filtrage collaboratif bayesien
+- Implementer la factorisation matricielle
+- Gerer le probleme du cold-start
+- Reconcilier des sources multiples (ClickModel)
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-5-Causal-Inference](Infer-5-Causal-Inference.ipynb) | [Infer-16-Sparse-Gaussian-Process](Infer-16-Sparse-Gaussian-Process.ipynb) |
+
+---",,,,,,,,d6d5b27c0d059adb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,111e0303,markdown,fr,268e3e80a1dd1e1b,"## 1. Configuration
+
+Nous chargeons Infer.NET pour implementer des systemes de recommandation probabilistes. Ces modeles utilisent la factorisation matricielle bayesienne pour predire les preferences des utilisateurs a partir de donnees partiellement observees, tout en gerant l'incertitude inherente aux recommandations.",,,,,,,,268e3e80a1dd1e1b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,cb4cf1f5,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,61b7d25a,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,5e1c85830652,code,fr,a059ace6b8242f0b,"// Chargement du helper de visualisation des graphes factoriels
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper charge - visualisation des graphes factoriels disponible."");",,,,,,,,a059ace6b8242f0b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,r0agasglm9l,markdown,fr,76b709e40abcc17d,"### Configuration chargee
+
+L'import des namespaces Infer.NET est reussi. Nous disposons maintenant de :
+- `Microsoft.ML.Probabilistic.Models` : Definition des modeles graphiques
+- `Microsoft.ML.Probabilistic.Distributions` : Distributions (Gaussian, Gamma, Dirichlet, etc.)
+- `Microsoft.ML.Probabilistic.Algorithms` : Algorithmes d'inference (EP, VMP)
+
+> **Note** : Les systemes de recommandation utilisent intensivement **Expectation Propagation (EP)** car les modeles de factorisation impliquent des produits de variables gaussiennes, non supportes par VMP.",,,,,,,,76b709e40abcc17d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,627137ed,markdown,fr,4b44633b1fb8bc52,"## 2. Introduction au Filtrage Collaboratif
+
+### Principe
+
+Le filtrage collaboratif predit les preferences d'un utilisateur en se basant sur les preferences d'utilisateurs similaires.
+
+### Matrice de notes
+
+```
+          Film1  Film2  Film3  Film4
+User1     5      ?      3      ?
+User2     ?      4      ?      2
+User3     4      3      5      ?
+User4     ?      ?      4      5
+```
+
+### Approches
+
+| Methode | Description | Avantage |
+|---------|-------------|----------|
+| Voisinage | k-NN sur similarite | Simple |
+| Factorisation | Decomposition U x V | Scalable |
+| Bayesien | Incertitude + priors | Robuste |",,,,,,,,4b44633b1fb8bc52,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,200af10a,markdown,fr,4983b1e45ffd4e27,"## 3. Factorisation Matricielle Bayesienne
+
+### Fondements mathematiques
+
+La factorisation matricielle decompose la matrice des notes $R$ (partiellement observee) en deux matrices de facteurs latents :
+
+$$R \approx U \times V^T$$
+
+Ou :
+- $U \in \mathbb{R}^{n_{users} \times k}$ : traits latents des utilisateurs
+- $V \in \mathbb{R}^{n_{items} \times k}$ : traits latents des items
+- $k$ : nombre de facteurs latents (hyperparametre)
+
+**Interpretation probabiliste** :
+
+$$r_{ui} \sim \mathcal{N}\left(\sum_{t=1}^{k} U_{ut} \cdot V_{it}, \sigma^2\right)$$
+
+La note $r_{ui}$ est generee par le produit scalaire des traits, plus un bruit gaussien.
+
+**Avantage bayesien** : On place des priors sur $U$ et $V$, ce qui :
+- Regularise automatiquement le modele
+- Fournit des intervalles de confiance sur les predictions
+- Gere naturellement les donnees manquantes",,,,,,,,4983b1e45ffd4e27,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,mvmlffi7lf,markdown,fr,2a03cabf741a0f4b,"### Preparation des donnees
+
+Nous definissons une matrice de notes **partiellement observee** (8 notes sur 20 possibles). Le format sparse `(user, item, note)` est standard pour les systemes de recommandation avec matrices creuses.
+
+**Parametres du modele** :
+- **nUsers** : Nombre d'utilisateurs
+- **nItems** : Nombre d'items (films, produits, etc.)
+- **nTraits** : Nombre de facteurs latents (hyperparametre critique)",,,,,,,,2a03cabf741a0f4b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,1f83e574,code,fr,4a7de00c89408b89,"// Donnees : notes observees
+int nUsers = 4;
+int nItems = 5;
+int nTraits = 2;  // Facteurs latents
+
+// Observations : (user, item, note)
+int[] userObs = { 0, 0, 1, 1, 2, 2, 3, 3 };
+int[] itemObs = { 0, 2, 1, 3, 0, 2, 2, 4 };
+double[] noteObs = { 5.0, 3.0, 4.0, 2.0, 4.0, 5.0, 4.0, 5.0 };
+int nObs = userObs.Length;
+
+Console.WriteLine(""=== Factorisation Matricielle ==="");
+Console.WriteLine($""\nUtilisateurs : {nUsers}, Items : {nItems}, Traits : {nTraits}"");
+Console.WriteLine($""Observations : {nObs} notes"");
+Console.WriteLine(""\nNotes observees :"");
+for (int i = 0; i < nObs; i++)
+{
+    Console.WriteLine($""  User {userObs[i]} -> Item {itemObs[i]} : {noteObs[i]}"");
+}",,,,,,,,4a7de00c89408b89,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,6t4pu9qx6pb,markdown,fr,4439bc322d2c510b,"### Interpretation des donnees chargees
+
+**Sortie obtenue** : 8 observations (user, item, note)
+
+| Statistique | Valeur |
+|-------------|--------|
+| Utilisateurs | 4 |
+| Items | 5 |
+| Observations | 8 (40% de la matrice) |
+| Traits latents | 2 |
+
+**Visualisation de la matrice sparse** :
+
+```
+          Item0  Item1  Item2  Item3  Item4
+User 0      5      -      3      -      -
+User 1      -      4      -      2      -
+User 2      4      -      5      -      -
+User 3      -      -      4      -      5
+```
+
+Les cases `-` sont les notes a predire. L'objectif de la factorisation est de completer cette matrice.",,,,,,,,4439bc322d2c510b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,ur0jmxpqu1i,markdown,fr,9662e2b2de9467cd,"### Definition des variables latentes
+
+Nous definissons maintenant les **matrices de traits latents** U (utilisateurs) et V (items).
+
+**Architecture du modele** :
+- `userTraits[u, t]` : Trait t de l'utilisateur u
+- `itemTraits[i, t]` : Trait t de l'item i
+- `noisePrecision` : Precision du bruit gaussien
+
+**Prior choisi** : `Gaussian(0, 1)` pour tous les traits
+- Moyenne 0 : Pas de biais a priori
+- Precision 1 : Regularisation moderee",,,,,,,,9662e2b2de9467cd,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,c6ada779,code,fr,923bb2e199f9d7e2,"// Modele de factorisation
+
+Range userRange = new Range(nUsers).Named(""user"");
+Range itemRange = new Range(nItems).Named(""item"");
+Range traitRange = new Range(nTraits).Named(""trait"");
+Range obsRange = new Range(nObs).Named(""obs"");
+
+// Traits utilisateurs : U[user, trait]
+VariableArray2D<double> userTraits = Variable.Array<double>(userRange, traitRange).Named(""userTraits"");
+userTraits[userRange, traitRange] = Variable.GaussianFromMeanAndPrecision(0, 1).ForEach(userRange, traitRange);
+
+// Traits items : V[item, trait]
+VariableArray2D<double> itemTraits = Variable.Array<double>(itemRange, traitRange).Named(""itemTraits"");
+itemTraits[itemRange, traitRange] = Variable.GaussianFromMeanAndPrecision(0, 1).ForEach(itemRange, traitRange);
+
+// Precision du bruit
+Variable<double> noisePrecision = Variable.GammaFromShapeAndScale(2, 0.5).Named(""noisePrecision"");
+
+Console.WriteLine(""Traits latents definis (U et V)."");",,,,,,,,923bb2e199f9d7e2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,er7occkq7c,markdown,fr,b631b705da49aadc,"### Structure du graphe factoriel
+
+Le modele de factorisation peut etre visualise comme un graphe factoriel :
+
+```
+Prior Gaussian(0,1)     Prior Gaussian(0,1)
+       |                       |
+       v                       v
+   U[user,trait]           V[item,trait]
+       |                       |
+       +--------> * <----------+
+                  |
+                  v
+           Sum(produits) = affinite
+                  |
+                  v
+            Gaussian(affinite, precision)
+                  |
+                  v
+              Rating observe
+```
+
+> **Note technique** : Le produit de deux variables gaussiennes (U * V) n'est pas gaussien, ce qui rend l'inference exacte impossible. Infer.NET utilise Expectation Propagation (EP) pour approximer les posterieurs.",,,,,,,,b631b705da49aadc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,sm96ir761m,markdown,fr,6f17b594cc5cfb2c,"### Lien entre traits et observations
+
+Nous connectons maintenant les observations aux variables latentes via le **modele generatif**.
+
+**Equation du modele** :
+$$r_{ui} = \sum_{t=1}^{k} U_{u,t} \cdot V_{i,t} + \epsilon, \quad \epsilon \sim \mathcal{N}(0, 1/\text{precision})$$
+
+Le code utilise :
+1. `Variable.ForEach(obsRange)` : Boucle sur chaque observation
+2. `userTraits[userIndex[obs], trait] * itemTraits[itemIndex[obs], trait]` : Produit element par element
+3. `Variable.Sum(produits)` : Produit scalaire (affinite)
+4. `GaussianFromMeanAndPrecision(affinite, noisePrecision)` : Generation de la note",,,,,,,,6f17b594cc5cfb2c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,67801ad1,code,fr,f2bc45852d0aad8b,"// Observations indexees
+VariableArray<int> userIndex = Variable.Observed(userObs, obsRange).Named(""userIndex"");
+VariableArray<int> itemIndex = Variable.Observed(itemObs, obsRange).Named(""itemIndex"");
+VariableArray<double> rating = Variable.Observed(noteObs, obsRange).Named(""rating"");
+
+// Modele de generation des notes
+using (Variable.ForEach(obsRange))
+{
+    // Produit scalaire des traits
+    VariableArray<double> produits = Variable.Array<double>(traitRange).Named(""produits"");
+    produits[traitRange] = userTraits[userIndex[obsRange], traitRange] * itemTraits[itemIndex[obsRange], traitRange];
+    
+    Variable<double> affinite = Variable.Sum(produits).Named(""affinite"");
+    
+    // Note = affinite + bruit gaussien
+    rating[obsRange] = Variable.GaussianFromMeanAndPrecision(affinite, noisePrecision);
+}
+
+Console.WriteLine(""Modele de notes defini : rating ~ Gaussian(U * V', precision)."");",,,,,,,,f2bc45852d0aad8b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,gftckt8jac7,markdown,fr,6e3c59fdb5a3760d,"### Execution de l'inference
+
+Nous executons l'inference avec **Expectation Propagation (EP)**, le seul algorithme capable de gerer les produits de variables gaussiennes.
+
+**Pourquoi EP et pas VMP ?**
+- VMP (Variational Message Passing) ne supporte pas `Variable.Product` entre deux gaussiennes
+- EP approxime ces operations par propagation de messages locaux
+
+**Sorties attendues** :
+- `userTraitsPost[u, t]` : Distribution posterieure du trait t de l'utilisateur u
+- `itemTraitsPost[i, t]` : Distribution posterieure du trait t de l'item i
+- `noisePrecPost` : Precision du bruit inferee",,,,,,,,6e3c59fdb5a3760d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,1c3da0f9,code,fr,e0568d49392d9b78,"// Inference
+InferenceEngine moteur = new InferenceEngine();
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur.Algorithm = new ExpectationPropagation();
+moteur.ShowFactorGraph = true;
+
+Console.WriteLine(""\n=== Inference ==="");
+
+var userTraitsPost = moteur.Infer<Gaussian[,]>(userTraits);
+var itemTraitsPost = moteur.Infer<Gaussian[,]>(itemTraits);
+var noisePrecPost = moteur.Infer<Gamma>(noisePrecision);
+
+Console.WriteLine($""\nPrecision du bruit : {noisePrecPost.GetMean():F2}"");
+
+Console.WriteLine(""\nTraits utilisateurs (moyenne) :"");
+for (int u = 0; u < nUsers; u++)
+{
+    Console.Write($""  User {u} : ["");
+    for (int t = 0; t < nTraits; t++)
+    {
+        Console.Write($""{userTraitsPost[u, t].GetMean():F2}"");
+        if (t < nTraits - 1) Console.Write("", "");
+    }
+    Console.WriteLine(""]"");
+}",,,,,,,,e0568d49392d9b78,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,e6b2h61zy1n,markdown,fr,a49476e62c5e3e24,"### Analyse de l'inférence de factorisation
+
+**Résultats observés** :
+
+| Paramètre | Valeur | Interprétation |
+|-----------|--------|----------------|
+| **Précision bruit** | 0.12 | Très faible → grande variance résiduelle |
+| **Traits utilisateurs** | ~0.00 | Presque nuls |
+
+**Diagnostic : Problème de convergence**
+
+Les traits utilisateurs proches de zéro indiquent un problème :
+
+1. **Identifiabilité** : Avec seulement 8 observations pour (4 users + 5 items) × 2 traits = 18 paramètres, le modèle est sous-déterminé
+
+2. **Warnings du compilateur** :
+   - ""GaussianProductOp... has quality band Experimental"" → opérations numériquement instables
+   - ""excess memory due to indexing"" → structure de données non optimale
+
+3. **Solution pratique** :
+   - Augmenter le nombre d'observations (>50 pour ce modèle)
+   - Réduire le nombre de traits latents
+   - Utiliser des priors plus informatifs
+
+**Note** : En production, Matchbox (API Infer.NET) utilise des techniques d'optimisation avancées pour éviter ces problèmes.",,,,,,,,a49476e62c5e3e24,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,6bbe575e7c97,markdown,fr,7b3a8debc409ae46,"### Visualisation du graphe factoriel - Factorisation matricielle
+
+Le graphe factoriel ci-dessous illustre la structure du modele de recommandation par factorisation matricielle :
+
+- **Variables latentes** : `userTraits[user,trait]` et `itemTraits[item,trait]` representent les preferences cachees
+- **Facteur produit scalaire** : Calcule l'affinite entre un utilisateur et un item
+- **Observations** : `rating[obs]` sont les notes observees, conditionnees par l'affinite et la precision du bruit
+- **Hyperparametre** : `noisePrecision` controle la variance des observations
+
+Ce modele suppose que les preferences sont expliquees par un petit nombre de **traits latents** (ici 2), permettant de generaliser a des paires (user, item) non observees.",,,,,,,,7b3a8debc409ae46,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,dce24b880838,code,fr,72406695547826a0,"// Affichage du graphe factoriel de la factorisation matricielle
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,72406695547826a0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,3i30sjg9a0l,markdown,fr,4d083c3ce7986d14,"## 3bis. Correction : Factorisation avec Données Suffisantes
+
+Le problème précédent vient d'un **ratio données/paramètres** insuffisant :
+- 8 observations
+- 4 users × 2 traits + 5 items × 2 traits = 18 paramètres
+- Ratio : 8/18 ≈ 0.4 (devrait être > 5 pour convergence fiable)
+
+### Règle pratique
+
+Pour une factorisation matricielle stable :
+$$\text{nb\_observations} > 5 \times (\text{nb\_users} + \text{nb\_items}) \times \text{nb\_traits}$$
+
+### Solution : Plus de données + priors ajustés",,,,,,,,4d083c3ce7986d14,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,ykur4bu57gs,markdown,fr,70f0f976792d32b0,"### Configuration amelioree
+
+Nous creons un jeu de donnees avec un **pattern clair** :
+- **Users 0, 1** : Preferent items 0, 1 (profil ""action"")
+- **Users 2, 3** : Preferent items 2, 3 (profil ""romance"")
+- **User 4** : Profil mixte
+
+Ce pattern devrait permettre au modele d'apprendre des traits latents distinctifs.",,,,,,,,70f0f976792d32b0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,9zx24xbim5,code,fr,4f006b0c45940e8d,"// Factorisation corrigee avec plus de donnees
+
+// Configuration amelioree
+int nUsers2 = 5;
+int nItems2 = 5;
+int nTraits2 = 2;  // Reduire les traits si peu de donnees
+
+// Plus d'observations (15 notes au lieu de 8)
+// Pattern : Users 0,1 aiment items 0,1 (action), Users 2,3 aiment items 2,3 (romance)
+int[] userObs2 = { 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4 };
+int[] itemObs2 = { 0, 1, 2, 0, 1, 3, 2, 3, 4, 2, 3, 4, 0, 2, 4 };
+double[] noteObs2 = { 5, 5, 2, 4, 5, 1, 2, 5, 4, 1, 4, 5, 4, 3, 3 };
+int nObs2 = userObs2.Length;
+
+Console.WriteLine(""=== Factorisation Corrigee ==="");
+Console.WriteLine($""\nParametres : {nUsers2} users, {nItems2} items, {nTraits2} traits"");
+Console.WriteLine($""Observations : {nObs2} notes"");
+Console.WriteLine($""Ratio donnees/parametres : {nObs2} / {(nUsers2 + nItems2) * nTraits2} = {(double)nObs2 / ((nUsers2 + nItems2) * nTraits2):F1}"");
+
+// Afficher la matrice de notes (partiellement observee)
+Console.WriteLine(""\nMatrice de notes :"");
+Console.WriteLine(""       Item0  Item1  Item2  Item3  Item4"");
+for (int u = 0; u < nUsers2; u++)
+{
+    Console.Write($""User{u}   "");
+    for (int i = 0; i < nItems2; i++)
+    {
+        double note = double.NaN;
+        for (int o = 0; o < nObs2; o++)
+        {
+            if (userObs2[o] == u && itemObs2[o] == i) { note = noteObs2[o]; break; }
+        }
+        Console.Write(double.IsNaN(note) ? ""  -    "" : $"" {note:F0}     "");
+    }
+    Console.WriteLine();
+}",,,,,,,,4f006b0c45940e8d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,unvld23w1oh,markdown,fr,3568594fb9394e97,"### Definition du modele corrige
+
+Les modifications cles par rapport au modele original :
+
+| Parametre | Avant | Apres | Justification |
+|-----------|-------|-------|---------------|
+| **Prior precision** | 1.0 | 0.1 | Moins de regularisation → traits non collapses |
+| **Biais global** | Non | Oui (3.0) | Capture la moyenne des notes |
+
+**Pourquoi un biais global ?**
+
+Sans biais, le modele doit expliquer la moyenne des notes (~3.5) uniquement via les produits U*V, ce qui est difficile. Le biais capture cette baseline, laissant les traits encoder les **deviations** par rapport a la moyenne.",,,,,,,,3568594fb9394e97,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,mh2456tb4z,code,fr,a60ea04e37471f20,"// Modele avec priors ajustes
+
+Range userRange2 = new Range(nUsers2).Named(""user2"");
+Range itemRange2 = new Range(nItems2).Named(""item2"");
+Range traitRange2 = new Range(nTraits2).Named(""trait2"");
+Range obsRange2 = new Range(nObs2).Named(""obs2"");
+
+// Prior plus large (precision 0.1 au lieu de 1) pour eviter l'ecrasement vers 0
+double priorPrec = 0.1;  // Precision faible = variance elevee = plus de liberte
+
+// Traits utilisateurs avec prior large
+VariableArray2D<double> userTraits2 = Variable.Array<double>(userRange2, traitRange2).Named(""userTraits2"");
+userTraits2[userRange2, traitRange2] = Variable.GaussianFromMeanAndPrecision(0, priorPrec).ForEach(userRange2, traitRange2);
+
+// Traits items avec prior large
+VariableArray2D<double> itemTraits2 = Variable.Array<double>(itemRange2, traitRange2).Named(""itemTraits2"");
+itemTraits2[itemRange2, traitRange2] = Variable.GaussianFromMeanAndPrecision(0, priorPrec).ForEach(itemRange2, traitRange2);
+
+// Biais global (moyenne des notes ~ 3)
+Variable<double> globalBias2 = Variable.GaussianFromMeanAndPrecision(3, 1).Named(""globalBias2"");
+
+// Precision du bruit
+Variable<double> noisePrecision2 = Variable.GammaFromShapeAndScale(2, 0.5).Named(""noisePrecision2"");
+
+// Observations indexees
+VariableArray<int> userIndex2 = Variable.Observed(userObs2, obsRange2).Named(""userIndex2"");
+VariableArray<int> itemIndex2 = Variable.Observed(itemObs2, obsRange2).Named(""itemIndex2"");
+VariableArray<double> rating2 = Variable.Observed(noteObs2, obsRange2).Named(""rating2"");
+
+// Modele avec biais
+using (Variable.ForEach(obsRange2))
+{
+    VariableArray<double> produits2 = Variable.Array<double>(traitRange2).Named(""produits2"");
+    produits2[traitRange2] = userTraits2[userIndex2[obsRange2], traitRange2] * itemTraits2[itemIndex2[obsRange2], traitRange2];
+    
+    Variable<double> affinite2 = globalBias2 + Variable.Sum(produits2);
+    rating2[obsRange2] = Variable.GaussianFromMeanAndPrecision(affinite2, noisePrecision2);
+}
+
+Console.WriteLine(""\nModele corrige avec :"");
+Console.WriteLine($""  - Prior precision : {priorPrec} (vs 1.0 avant)"");
+Console.WriteLine($""  - Biais global : oui"");
+Console.WriteLine($""  - Ratio donnees/params : {(double)nObs2 / ((nUsers2 + nItems2) * nTraits2):F1} (vs 0.4 avant)"");",,,,,,,,a60ea04e37471f20,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,nf6qmv9l55s,markdown,fr,a34d6dede8a22005,"### Interpretation des donnees corrigees
+
+**Sortie obtenue** : Configuration amelioree
+
+| Aspect | Ancienne config | Nouvelle config |
+|--------|-----------------|-----------------|
+| Observations | 8 | 15 |
+| Ratio donnees/params | 0.4 | 0.75 |
+| Couverture matrice | 40% | 60% |
+| Pattern semantique | Disperse | Structure claire |
+
+**Matrice de notes** :
+
+La matrice affichee montre clairement les patterns :
+- Diagonale haute-gauche (Users 0-1, Items 0-1) : notes elevees
+- Diagonale basse-droite (Users 2-3, Items 2-3) : notes elevees
+
+Cette structure est un ""ground truth"" que le modele devrait pouvoir apprendre.",,,,,,,,a34d6dede8a22005,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,jz4ci2kh7ta,markdown,fr,17a42751064817c3,"### Execution de l'inference corrigee
+
+Nous executons l'inference avec `ShowProgress = false` pour un affichage plus compact. L'algorithme EP devrait converger plus facilement avec ce modele ameliore.",,,,,,,,17a42751064817c3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,24aadgud61,code,fr,0dcd702b58d17e4d,"// Inference du modele corrige
+
+InferenceEngine moteur3 = new InferenceEngine();
+moteur3.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur3.Algorithm = new ExpectationPropagation();
+moteur3.ShowProgress = false;
+
+Console.WriteLine(""\n=== Inference Factorisation Corrigee ===\n"");
+
+var userTraitsPost2 = moteur3.Infer<Gaussian[,]>(userTraits2);
+var itemTraitsPost2 = moteur3.Infer<Gaussian[,]>(itemTraits2);
+var globalBiasPost2 = moteur3.Infer<Gaussian>(globalBias2);
+
+Console.WriteLine($""Biais global : {globalBiasPost2.GetMean():F2}"");
+
+Console.WriteLine(""\nTraits utilisateurs :"");
+for (int u = 0; u < nUsers2; u++)
+{
+    Console.Write($""  User {u} : ["");
+    for (int t = 0; t < nTraits2; t++)
+    {
+        Console.Write($""{userTraitsPost2[u, t].GetMean():F2}"");
+        if (t < nTraits2 - 1) Console.Write("", "");
+    }
+    Console.WriteLine(""]"");
+}
+
+Console.WriteLine(""\nTraits items :"");
+for (int i = 0; i < nItems2; i++)
+{
+    Console.Write($""  Item {i} : ["");
+    for (int t = 0; t < nTraits2; t++)
+    {
+        Console.Write($""{itemTraitsPost2[i, t].GetMean():F2}"");
+        if (t < nTraits2 - 1) Console.Write("", "");
+    }
+    Console.WriteLine(""]"");
+}
+moteur3.ShowFactorGraph = true;
+",,,,,,,,0dcd702b58d17e4d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,0542178806a7,markdown,fr,6b2a6a57b7edbf9a,"### Visualisation du graphe factoriel - Modele corrige
+
+Le graphe ci-dessous montre le modele de factorisation **ameliore** avec :
+
+- **Plus de donnees** : 15 observations au lieu de 8, avec un pattern clair (2 groupes d'utilisateurs)
+- **Biais global** : `globalBias2` capture la moyenne generale des notes
+- **Priors plus larges** : Precision 0.1 au lieu de 1.0 pour permettre plus de variation dans les traits
+- **Structure identique** : Toujours `U[user,trait] * V[item,trait]` pour l'affinite
+
+Le modele corrige devrait montrer des traits latents plus informatifs grace au ratio observations/parametres ameliore.",,,,,,,,6b2a6a57b7edbf9a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,01c324c1cb17,code,fr,3cc64e9f4ac92952,"// Affichage du graphe factoriel du modele corrige
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,3cc64e9f4ac92952,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,rvr5f1ahk4,markdown,fr,e5bf64bf76912f29,"### Generation des predictions
+
+Nous calculons maintenant les notes predites pour **toutes les paires** (user, item) :
+
+$$\hat{r}_{ui} = \text{biais} + \sum_{t} U_{u,t} \cdot V_{i,t}$$
+
+Les notes entre crochets `[X.X]` correspondent aux observations utilisees pour l'entrainement. Les autres sont des predictions pour des paires non observees.",,,,,,,,e5bf64bf76912f29,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,hghiozc7b0k,code,fr,5149551774096e8a,"// Predictions avec le modele corrige
+
+Console.WriteLine(""\n=== Predictions Corrigees ===\n"");
+
+// Matrice de predictions
+Console.WriteLine(""Matrice de notes predites (observees entre crochets) :"");
+Console.WriteLine(""         Item0   Item1   Item2   Item3   Item4"");
+
+double bias = globalBiasPost2.GetMean();
+
+for (int u = 0; u < nUsers2; u++)
+{
+    Console.Write($""User {u}   "");
+    for (int i = 0; i < nItems2; i++)
+    {
+        // Prediction = biais + produit scalaire
+        double pred = bias;
+        for (int t = 0; t < nTraits2; t++)
+        {
+            pred += userTraitsPost2[u, t].GetMean() * itemTraitsPost2[i, t].GetMean();
+        }
+        
+        // Verifier si observe
+        bool observe = false;
+        double noteReelle = 0;
+        for (int o = 0; o < nObs2; o++)
+        {
+            if (userObs2[o] == u && itemObs2[o] == i) 
+            { 
+                observe = true; 
+                noteReelle = noteObs2[o];
+                break; 
+            }
+        }
+        
+        if (observe)
+            Console.Write($""[{pred:F1}]   "");
+        else
+            Console.Write($"" {pred:F1}    "");
+    }
+    Console.WriteLine();
+}
+
+// Top recommandation par utilisateur
+Console.WriteLine(""\n=== Top Recommandations ==="");
+for (int u = 0; u < nUsers2; u++)
+{
+    double maxPred = double.MinValue;
+    int bestItem = -1;
+    
+    for (int i = 0; i < nItems2; i++)
+    {
+        // Ignorer si deja observe
+        bool observe = false;
+        for (int o = 0; o < nObs2; o++)
+        {
+            if (userObs2[o] == u && itemObs2[o] == i) { observe = true; break; }
+        }
+        if (observe) continue;
+        
+        double pred = bias;
+        for (int t = 0; t < nTraits2; t++)
+        {
+            pred += userTraitsPost2[u, t].GetMean() * itemTraitsPost2[i, t].GetMean();
+        }
+        
+        if (pred > maxPred) { maxPred = pred; bestItem = i; }
+    }
+    
+    Console.WriteLine($""  User {u} -> Item {bestItem} (score predit: {maxPred:F2})"");
+}",,,,,,,,5149551774096e8a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,9bmicn9ogwa,markdown,fr,1aba5ad978e4cbb7,"### Analyse : Comparaison Avant/Après Correction
+
+**Améliorations appliquées** :
+
+| Aspect | Avant | Après |
+|--------|-------|-------|
+| **Observations** | 8 | 15 |
+| **Ratio données/params** | 0.4 | 0.75 |
+| **Prior precision** | 1.0 | 0.1 |
+| **Biais global** | Non | Oui |
+
+**Résultats attendus** :
+
+Avec la correction, le modèle devrait maintenant :
+1. **Traits non-nuls** : Les utilisateurs et items ont des représentations distinctes
+2. **Prédictions variées** : Les scores prédits reflètent les patterns dans les données
+3. **Recommandations sensées** : Les utilisateurs reçoivent des items alignés avec leurs préférences
+
+**Interprétation des traits** :
+
+Si le modèle converge correctement :
+- **Trait 1** pourrait capturer : action vs romance
+- **Trait 2** pourrait capturer : préférence pour notes élevées vs basses
+
+**Recommandations cohérentes** :
+
+| Utilisateur | Pattern observé | Recommandation attendue |
+|-------------|-----------------|-------------------------|
+| User 0,1 | Aiment items 0,1 (action) | Items similaires à 0,1 |
+| User 2,3 | Aiment items 2,3 (romance) | Items similaires à 2,3 |
+| User 4 | Pattern mixte | Dépend de l'inférence |
+
+**Note** : Si les traits restent proches de 0, augmenter encore les données ou réduire à 1 trait.",,,,,,,,1aba5ad978e4cbb7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,97d9f518,markdown,fr,aa0a0b6c30d3646a,"## 4. Prediction de Notes
+
+Nous utilisons maintenant les posterieurs inferes pour predire des notes sur des paires (utilisateur, item) non observees. Cette etape permet d'evaluer la qualite du modele et d'identifier les problemes de convergence.",,,,,,,,aa0a0b6c30d3646a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,ncqavjm2nop,markdown,fr,326b8b031238d52f,"### Predictions du modele original
+
+Cette cellule utilise les posterieurs du **premier modele** (8 observations, priors serres) pour illustrer le probleme de convergence. Les predictions devraient etre proches de 0.",,,,,,,,326b8b031238d52f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,35866f47,code,fr,0ec65cf72943c3c1,"// Prediction pour des paires (user, item) non observees
+
+Console.WriteLine(""\n=== Predictions ==="");
+Console.WriteLine(""\nNotes predites pour paires non observees :"");
+
+// Calculer l'affinite predite
+for (int u = 0; u < nUsers; u++)
+{
+    Console.Write($""User {u} : "");
+    for (int i = 0; i < nItems; i++)
+    {
+        // Verifier si observe
+        bool observe = false;
+        for (int o = 0; o < nObs; o++)
+        {
+            if (userObs[o] == u && itemObs[o] == i)
+            {
+                observe = true;
+                break;
+            }
+        }
+        
+        // Calcul produit scalaire des moyennes
+        double pred = 0;
+        for (int t = 0; t < nTraits; t++)
+        {
+            pred += userTraitsPost[u, t].GetMean() * itemTraitsPost[i, t].GetMean();
+        }
+        
+        if (observe)
+            Console.Write($""[{pred:F1}] "");
+        else
+            Console.Write($"" {pred:F1}  "");
+    }
+    Console.WriteLine();
+}
+
+Console.WriteLine(""\n(Notes entre crochets = observees)"");",,,,,,,,0ec65cf72943c3c1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,5rjas07dwcj,markdown,fr,b347065bdc3824f7,"### Analyse des prédictions
+
+**Observations** : Toutes les prédictions sont ~0.0
+
+| User | Prédictions | Problème |
+|------|-------------|----------|
+| 0-3 | 0.0 partout | Traits latents nuls → produit scalaire nul |
+
+**Explication** :
+
+Le calcul $\text{rating} = \sum_t U_{u,t} \times V_{i,t}$ donne 0 car :
+- $U_{u,t} \approx 0$ pour tous les traits
+- Même avec $V_{i,t} \neq 0$, le produit reste ~0
+
+**Ce que cela illustre** :
+
+1. **Importance des données** : La factorisation nécessite suffisamment d'observations
+2. **Régularisation implicite** : Les priors Gaussian(0,1) tirent vers 0 en l'absence de signal
+3. **Diagnostic rapide** : Des prédictions uniformes signalent un modèle non appris
+
+**Dans un système réel** :
+
+| Technique | Bénéfice |
+|-----------|----------|
+| **Biais utilisateur/item** | Capture la moyenne même sans facteurs |
+| **Popularity baseline** | Recommande les items populaires par défaut |
+| **Features cold-start** | Utilise des caractéristiques explicites |",,,,,,,,b347065bdc3824f7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,ef7b08f6,markdown,fr,b544e1bfdad4de34,"## 5. Cold-Start avec Features
+
+Le probleme du **cold-start** : comment recommander pour un nouvel utilisateur ou item sans historique ?
+
+### Solution : utiliser des features
+
+- **Utilisateur** : age, genre, localisation
+- **Item** : genre, annee, realisateur",,,,,,,,b544e1bfdad4de34,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,z1vvgb32pnp,markdown,fr,f8676271c32bc209,"### Taxonomie du probleme cold-start
+
+| Type | Description | Exemple |
+|------|-------------|---------|
+| **Nouvel utilisateur** | Aucun historique de notes | Nouveau client |
+| **Nouvel item** | Item jamais note | Film sortant en salle |
+| **Nouveau systeme** | Peu de donnees globales | Startup |
+
+**Strategies de resolution** :
+
+| Strategie | Avantage | Limite |
+|-----------|----------|--------|
+| **Features explicites** | Immediat, interpretable | Necessite meta-donnees |
+| **Popularity baseline** | Simple, efficace | Pas personnalise |
+| **Exploration active** | Optimise apprentissage | Peut degrader UX |
+| **Transfer learning** | Exploite autre domaine | Complexe a mettre en place |
+
+La solution bayesienne avec features combine les avantages : prediction immediate + incertitude explicite qui diminue avec plus de donnees.",,,,,,,,f8676271c32bc209,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,d2jlbclb74q,markdown,fr,ede3a3d8fcf5b081,"### Definition des features
+
+Nous definissons des **meta-donnees** pour chaque utilisateur et item :
+
+**Features utilisateurs (2 dimensions)** :
+- Age normalise [0, 1]
+- Genre (1=homme, 0=femme)
+
+**Features items (3 dimensions)** :
+- Proportion action [0, 1]
+- Proportion romance [0, 1]
+- Annee de sortie normalisee [0, 1]
+
+Ces features permettent de predire des affinites meme sans historique de notes.",,,,,,,,ede3a3d8fcf5b081,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,e33bd394,code,fr,f0f4451b8e98961e,"// Modele avec features utilisateur
+
+Console.WriteLine(""=== Cold-Start avec Features ==="");
+
+// Features utilisateurs : age normalise, genre (0/1)
+double[,] userFeatures = {
+    { 0.2, 1.0 },  // User 0 : jeune, homme
+    { 0.8, 0.0 },  // User 1 : age, femme
+    { 0.5, 1.0 },  // User 2 : moyen, homme
+    { 0.3, 0.0 }   // User 3 : jeune, femme
+};
+
+// Features items : genre (action/romance), annee
+double[,] itemFeatures = {
+    { 1.0, 0.0, 0.9 },  // Item 0 : action, recent
+    { 0.0, 1.0, 0.5 },  // Item 1 : romance, ancien
+    { 0.5, 0.5, 0.8 },  // Item 2 : mixte, recent
+    { 0.0, 1.0, 0.3 },  // Item 3 : romance, tres ancien
+    { 1.0, 0.0, 0.7 }   // Item 4 : action, moyen
+};
+
+int nUserFeatures = 2;
+int nItemFeatures = 3;
+
+Console.WriteLine($""\nFeatures utilisateurs : {nUserFeatures} (age, genre)"");
+Console.WriteLine($""Features items : {nItemFeatures} (action, romance, annee)"");",,,,,,,,f0f4451b8e98961e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,mxz8l5y7ded,markdown,fr,8c509e10adbf5c1e,"### Poids de regression cold-start
+
+Nous definissons des **poids de regression** pour transformer les features en scores :
+
+$$\text{score}_{ui} = \text{biais} + w_{user}^T \cdot x_u + w_{item}^T \cdot x_i$$
+
+**Priors choisis** :
+- `Gaussian(0, 1)` pour les poids → regularisation L2 implicite
+- `Gaussian(3, 0.1)` pour le biais → centre sur 3 (milieu de l'echelle 1-5)
+
+> **Note** : Dans un modele hybride complet, ces poids seraient appris conjointement avec les traits latents.",,,,,,,,8c509e10adbf5c1e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,dc64fd2c,code,fr,1825a3a2fe5c7716,"// Nouveau modele avec biais bases sur features
+
+Range uFeatRange = new Range(nUserFeatures).Named(""uFeat"");
+Range iFeatRange = new Range(nItemFeatures).Named(""iFeat"");
+
+// Poids pour les features
+VariableArray<double> userWeights = Variable.Array<double>(uFeatRange).Named(""userWeights"");
+userWeights[uFeatRange] = Variable.GaussianFromMeanAndPrecision(0, 1).ForEach(uFeatRange);
+
+VariableArray<double> itemWeights = Variable.Array<double>(iFeatRange).Named(""itemWeights"");
+itemWeights[iFeatRange] = Variable.GaussianFromMeanAndPrecision(0, 1).ForEach(iFeatRange);
+
+// Biais global
+Variable<double> globalBias = Variable.GaussianFromMeanAndPrecision(3, 0.1).Named(""globalBias"");
+
+Console.WriteLine(""Poids de regression pour cold-start definis."");",,,,,,,,1825a3a2fe5c7716,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,e7weqfh0y3g,markdown,fr,be534eaa33d6dc1d,"### Modele mathematique du cold-start
+
+Le modele hybride combine factorisation et regression sur features :
+
+$$r_{ui} = \underbrace{\mu}_{\text{biais global}} + \underbrace{w_{user}^T \cdot x_u}_{\text{effet features user}} + \underbrace{w_{item}^T \cdot x_i}_{\text{effet features item}} + \underbrace{U_u \cdot V_i^T}_{\text{factorisation}}$$
+
+**Avantage** : Meme sans historique ($U_u = 0$, $V_i = 0$), les predictions restent informatives grace aux features.
+
+> **Note** : Dans la cellule suivante, nous simulons les poids appris pour illustrer le mecanisme. Un modele complet apprendrait ces poids conjointement avec la factorisation.",,,,,,,,be534eaa33d6dc1d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,21k2m4s6mvy,markdown,fr,4c7c7e64f03fd05f,"### Simulation cold-start
+
+Cette cellule **simule** une prediction cold-start avec des poids pre-definis (dans un systeme reel, ces poids seraient appris).
+
+**Nouvel utilisateur** : age=0.4 (relativement jeune), genre=1.0 (homme)
+
+Le calcul de score combine :
+1. Contribution utilisateur : $w_{user} \cdot x_{user}$
+2. Contribution item : $w_{item} \cdot x_{item}$
+3. Biais global : 3.0",,,,,,,,4c7c7e64f03fd05f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,fa58c9f7,code,fr,6b638caaed26abd4,"// Prediction cold-start simplifiee (sans factorisation complete)
+
+Console.WriteLine(""\n=== Prediction Cold-Start ==="");
+Console.WriteLine(""\nSimulation : nouvel utilisateur (age=0.4, genre=1.0)"");
+
+// Nouvel utilisateur
+double[] newUserFeat = { 0.4, 1.0 };
+
+// Modele simple : affinite = features_user dot weights + features_item dot weights
+// Utilisons les moyennes des posterieurs (simplification)
+double[] wUser = { 0.5, 0.8 };   // Appris (simule)
+double[] wItem = { 0.6, -0.3, 0.2 };  // Appris (simule)
+
+Console.WriteLine(""\nScores predits pour chaque item :"");
+for (int i = 0; i < nItems; i++)
+{
+    double userScore = 0;
+    for (int f = 0; f < nUserFeatures; f++)
+        userScore += newUserFeat[f] * wUser[f];
+    
+    double itemScore = 0;
+    for (int f = 0; f < nItemFeatures; f++)
+        itemScore += itemFeatures[i, f] * wItem[f];
+    
+    double prediction = 3.0 + userScore + itemScore;  // Biais + scores
+    Console.WriteLine($""  Item {i} : {prediction:F2}"");
+}
+
+Console.WriteLine(""\n=> Recommander items avec score le plus eleve"");",,,,,,,,6b638caaed26abd4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,275qi7deg4o,markdown,fr,21752a4132e98aef,"### Analyse de la prédiction cold-start
+
+**Nouvel utilisateur** : (age=0.4, genre=1.0) → homme, relativement jeune
+
+**Scores prédits** :
+
+| Item | Type | Score | Rang |
+|------|------|-------|------|
+| Item 0 | Action, récent | 4.78 | **1** |
+| Item 4 | Action, moyen | 4.74 | **2** |
+| Item 2 | Mixte, récent | 4.31 | 3 |
+| Item 1 | Romance, ancien | 3.80 | 4 |
+| Item 3 | Romance, très ancien | 3.76 | 5 |
+
+**Interprétation des poids** :
+
+Les poids simulés (wUser=[0.5, 0.8], wItem=[0.6, -0.3, 0.2]) encodent :
+- **Genre masculin** : bonus +0.8 → préférence action
+- **Age jeune** : bonus modéré +0.5×0.4 = +0.2
+- **Action** : bonus +0.6 pour genre action
+- **Romance** : malus -0.3 pour genre romance
+- **Récence** : léger bonus +0.2 pour films récents
+
+**Valeur du cold-start** :
+
+Même sans historique de notes, le modèle :
+1. Exploite la démographie utilisateur
+2. Utilise les caractéristiques des items
+3. Fournit des recommandations raisonnables dès le premier contact",,,,,,,,21752a4132e98aef,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,f78795c9,markdown,fr,6025b6df4958048b,"## 5bis. Exercice : Cold-Start avec un Nouvel Item
+
+Dans la section 5, nous avons predit les scores pour un **nouvel utilisateur**. Maintenant, traitez le cas dual : un **nouvel item** sans aucune note.
+
+**Scenario** : Un nouveau film arrive sur la plateforme :
+
+| Feature | Valeur | Description |
+|---------|--------|-------------|
+| Action | 0.8 | Film d'action |
+| Romance | 0.1 | Peu de romance |
+| Annee | 0.95 | Tres recent |
+
+**Objectifs** :
+1. Calculez le score predit de ce nouvel item pour chaque utilisateur existant
+2. Identifiez les utilisateurs les plus susceptibles d'apprecier ce film
+3. Comparez avec un film ""romance ancien"" (action=0.1, romance=0.9, annee=0.2)
+
+**Etapes** :
+1. Definir les features du nouvel item
+2. Calculer le score pour chaque utilisateur avec les poids simules de la section 5
+3. Afficher les recommandations par utilisateur
+4. Repeter avec un item ""romance ancien"" et comparer les ciblages
+
+**Indices** :
+- Reutilisez les memes poids simules : `wUser = {0.5, 0.8}`, `wItem = {0.6, -0.3, 0.2}`, `biais = 3.0`
+- Pour un nouvel item sans historique, seul le terme features contribue (pas de traits latents)
+- Score = biais + wUser dot featuresUser + wItem dot featuresItem",,,,,,,,6025b6df4958048b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,b857098f,code,fr,2d2918e70df52df1,"// Exercice : Cold-Start avec un nouvel item
+
+// Nouvel item : film d'action recent
+double[] newItemFeat = { 0.8, 0.1, 0.95 };
+
+// Poids simules (memes que section 5)
+double[] wUserCS = { 0.5, 0.8 };
+double[] wItemCS = { 0.6, -0.3, 0.2 };
+double biaisCS = 3.0;
+
+// Features utilisateurs (de la section 5)
+// User 0 : jeune homme, User 1 : agee femme, User 2 : moyen homme, User 3 : jeune femme
+double[,] userFeats = {
+    { 0.2, 1.0 },  // User 0 : jeune, homme
+    { 0.8, 0.0 },  // User 1 : age, femme
+    { 0.5, 1.0 },  // User 2 : moyen, homme
+    { 0.3, 0.0 }   // User 3 : jeune, femme
+};
+string[] nomsUsers = { ""User 0 (jeune homme)"", ""User 1 (agee femme)"", ""User 2 (moyen homme)"", ""User 3 (jeune femme)"" };
+
+// TODO: Etape 1 - Calculez le score predit du nouvel item pour chaque utilisateur
+// Score = biais + sum(wUserCS[f] * userFeats[u,f]) + sum(wItemCS[f] * newItemFeat[f])
+
+// TODO: Etape 2 - Affichez les scores et identifiez les meilleurs utilisateurs cibles
+
+// TODO: Etape 3 - Repetez avec un item ""romance ancien""
+double[] romanceAncienFeat = { 0.1, 0.9, 0.2 };
+
+Console.WriteLine(""Exercice a completer : prediction cold-start pour un nouvel item."");",,,,,,,,2d2918e70df52df1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,ee734922,markdown,fr,bf5ec9757ddde715,"## 6. Click Model : Sources Multiples
+
+### Probleme
+
+Comment reconcilier plusieurs sources d'information sur la qualite d'un document ?
+
+- **Jugements humains** : experts mais couteux
+- **Clics utilisateurs** : abondants mais bruites
+- **Temps de lecture** : signal implicite
+
+### Modele
+
+```
+Score latent (vrai) du document
+        |
+    +---+---+---+
+    |   |   |   |
+    v   v   v   v
+  Juge Clic Temps ...
+```",,,,,,,,bf5ec9757ddde715,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,k9xu8ed38t,markdown,fr,9a99db8a28a9b487,"### Transition : Du filtrage collaboratif au Click Model
+
+Les sections precedentes traitaient de la **prediction de preferences** : estimer la note qu'un utilisateur donnerait.
+
+Le Click Model aborde un probleme different : **fusionner des signaux heterogenes** pour estimer la qualite ""vraie"" d'un document. C'est un modele de mesure avec sources multiples, pas de recommandation directe.",,,,,,,,9a99db8a28a9b487,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,140c636a,code,fr,81acb19a4fb3582d,"// Click Model simplifie
+
+int nDocs = 6;
+
+// Observations de deux sources
+double[] jugements = { 4.5, 3.0, 4.0, 2.5, 5.0, 3.5 };  // Notes experts (1-5)
+double[] clics = { 120, 80, 95, 60, 150, 70 };          // Nombre de clics
+
+Console.WriteLine(""=== Click Model ==="");
+Console.WriteLine(""\nReconciliation jugements experts vs clics utilisateurs"");
+Console.WriteLine(""\nDonnees :"");
+for (int d = 0; d < nDocs; d++)
+{
+    Console.WriteLine($""  Doc {d} : Juge={jugements[d]:F1}, Clics={clics[d]}"");
+}",,,,,,,,81acb19a4fb3582d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,msribrget5g,markdown,fr,c961f8094d5d821d,"### Donnees multi-sources
+
+Nous disposons de **deux signaux** pour evaluer la qualite des documents :
+
+| Source | Avantage | Inconvenient |
+|--------|----------|--------------|
+| **Jugements experts** | Precis, calibres | Couteux, peu nombreux |
+| **Clics utilisateurs** | Abondants, gratuits | Bruites, biais position |
+
+L'objectif du Click Model est de **fusionner** ces sources pour obtenir une estimation optimale.",,,,,,,,c961f8094d5d821d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,2w4ooq3v3v2,markdown,fr,c908533cfa40f314,"### Definition du modele Click
+
+Le modele suppose un **score latent** (qualite vraie) qui genere les deux observations :
+
+**Variables du modele** :
+- `scoreLatent[d]` : Qualite ""vraie"" du document d
+- `precJuge` : Precision des jugements experts
+- `precClic` : Precision des clics
+- `echelleClics` : Facteur de conversion score → clics
+
+**Priors choisis** :
+- Score latent : `Gaussian(3, 0.5)` → centre sur 3 (echelle 1-5)
+- Precision juges : `Gamma(5, 1)` → elevee (experts fiables)
+- Precision clics : `Gamma(2, 0.5)` → plus faible (clics bruites)
+- Echelle clics : `Gaussian(30, 0.01)` → environ 30 clics par point de score",,,,,,,,c908533cfa40f314,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,1086530f,code,fr,cb418a08e3254a7c,"// Modele Click
+
+Range docRange = new Range(nDocs).Named(""doc"");
+
+// Score latent (vrai) de chaque document
+VariableArray<double> scoreLatent = Variable.Array<double>(docRange).Named(""scoreLatent"");
+scoreLatent[docRange] = Variable.GaussianFromMeanAndPrecision(3, 0.5).ForEach(docRange);
+
+// Precision de chaque source
+Variable<double> precJuge = Variable.GammaFromShapeAndScale(5, 1).Named(""precJuge"");    // Experts : haute precision
+Variable<double> precClic = Variable.GammaFromShapeAndScale(2, 0.5).Named(""precClic""); // Clics : basse precision
+
+// Facteur d'echelle pour les clics (clics = score * echelle + bruit)
+Variable<double> echelleClics = Variable.GaussianFromMeanAndPrecision(30, 0.01).Named(""echelleClics"");
+
+// Observations
+VariableArray<double> obsJuge = Variable.Array<double>(docRange).Named(""obsJuge"");
+VariableArray<double> obsClic = Variable.Array<double>(docRange).Named(""obsClic"");
+
+// Modele generatif
+obsJuge[docRange] = Variable.GaussianFromMeanAndPrecision(scoreLatent[docRange], precJuge);
+obsClic[docRange] = Variable.GaussianFromMeanAndPrecision(scoreLatent[docRange] * echelleClics, precClic);
+
+// Observations
+obsJuge.ObservedValue = jugements;
+obsClic.ObservedValue = clics;
+
+Console.WriteLine(""Modele Click defini avec deux sources."");",,,,,,,,cb418a08e3254a7c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,96x87un3t3g,markdown,fr,5135f999deb2facb,"### Structure probabiliste du Click Model
+
+Le modele genere les observations a partir d'un score latent unique :
+
+$$s_d \sim \mathcal{N}(\mu_{prior}, \sigma_{prior}^2)$$
+
+$$\text{Jugement}_d \sim \mathcal{N}(s_d, \sigma_{juge}^2)$$
+
+$$\text{Clics}_d \sim \mathcal{N}(s_d \times \text{echelle}, \sigma_{clic}^2)$$
+
+**Interpretation** :
+- $s_d$ : qualite ""vraie"" (latente) du document
+- $\sigma_{juge}^2$ : variance du bruit des experts
+- $\sigma_{clic}^2$ : variance du bruit des clics
+- $\text{echelle}$ : facteur de conversion score → clics
+
+> **Note** : Le facteur d'echelle est crucial car les deux sources ont des unites differentes (notes 1-5 vs clics 0-200).",,,,,,,,5135f999deb2facb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,jng5taw0ubm,markdown,fr,767bdc46021bbf4c,"### Execution de l'inference Click Model
+
+Nous inferons simultanement :
+1. Les scores latents de chaque document
+2. Les precisions de chaque source
+3. Le facteur d'echelle
+
+L'inference **pondere automatiquement** les sources selon leur precision inferee.",,,,,,,,767bdc46021bbf4c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,6bf39d46,code,fr,08cf9040ebaac09b,"// Inference
+InferenceEngine moteur2 = new InferenceEngine();
+moteur2.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur2.ShowFactorGraph = true;
+
+Console.WriteLine(""\n=== Inference Click Model ==="");
+
+var scorePost = moteur2.Infer<Gaussian[]>(scoreLatent);
+var precJugePost = moteur2.Infer<Gamma>(precJuge);
+var precClicPost = moteur2.Infer<Gamma>(precClic);
+var echellePost = moteur2.Infer<Gaussian>(echelleClics);
+
+Console.WriteLine($""\nPrecision juges : {precJugePost.GetMean():F2}"");
+Console.WriteLine($""Precision clics : {precClicPost.GetMean():F2}"");
+Console.WriteLine($""Echelle clics : {echellePost.GetMean():F2}"");
+
+Console.WriteLine(""\nScores latents inferes :"");
+for (int d = 0; d < nDocs; d++)
+{
+    double mean = scorePost[d].GetMean();
+    double std = Math.Sqrt(scorePost[d].GetVariance());
+    Console.WriteLine($""  Doc {d} : {mean:F2} +/- {std:F2}  (Juge: {jugements[d]:F1}, Clics: {clics[d]})"");
+}",,,,,,,,08cf9040ebaac09b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,v1yv6vu72ag,markdown,fr,785d8603acfd7cb7,"### Analyse du Click Model
+
+**Paramètres inférés** :
+
+| Paramètre | Valeur | Interprétation |
+|-----------|--------|----------------|
+| **Précision juges** | 4.50 | Élevée → experts fiables |
+| **Précision clics** | 0.99 | Faible → clics très bruités |
+| **Échelle clics** | 26.90 | 1 point de score ≈ 27 clics |
+
+**Qualité des sources** :
+
+La précision relative (4.50 vs 0.99) indique que le modèle fait **4.5× plus confiance** aux jugements experts qu'aux clics.
+
+**Scores latents inférés** :
+
+| Doc | Score | Incertitude | Juge | Clics/échelle |
+|-----|-------|-------------|------|---------------|
+| 4 | 5.58 | ±0.29 | 5.0 | 5.57 |
+| 0 | 4.47 | ±0.23 | 4.5 | 4.46 |
+| 2 | 3.54 | ±0.19 | 4.0 | 3.53 |
+| 1 | 2.98 | ±0.16 | 3.0 | 2.97 |
+
+**Observations** :
+
+1. **Cohérence sources** : Jugements et clics/échelle sont très proches → bonne calibration
+2. **Doc 2 ajusté** : Juge=4.0, Clics/échelle≈3.53 → score final 3.54 (score intermédiaire entre les deux sources)
+3. **Incertitude croissante** : Les documents mieux notés ont plus d'incertitude (variance proportionnelle au score)",,,,,,,,785d8603acfd7cb7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,a8ff4b7ac191,markdown,fr,32067feb2cfce44e,"### Visualisation du graphe factoriel - Click Model
+
+Le graphe factoriel du Click Model illustre la **fusion de sources multiples** :
+
+- **Variable latente centrale** : `scoreLatent[doc]` represente la qualite ""vraie"" de chaque document
+- **Source 1 - Experts** : `obsJuge[doc]` avec precision elevee (`precJuge` ~ 5)
+- **Source 2 - Clics** : `obsClic[doc]` avec precision faible (`precClic` ~ 1) et facteur d'echelle
+- **Fusion bayesienne** : Le modele pondere automatiquement les sources selon leur fiabilite
+
+Ce pattern est generalizable a N sources d'information (temps de lecture, partages, etc.).",,,,,,,,32067feb2cfce44e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,843556ef647c,code,fr,6562f273f5a485d9,"// Affichage du graphe factoriel du Click Model
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,6562f273f5a485d9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,hjpzc1z1emj,markdown,fr,acb0b5430bb7871f,"### Classement des documents
+
+Nous utilisons les scores latents inferes pour produire un **classement final** ordonne par qualite estimee.",,,,,,,,acb0b5430bb7871f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,a0acb48f,code,fr,8bc18287b0c44e56,"// Classement final
+
+Console.WriteLine(""\n=== Classement Final ==="");
+
+var classement = Enumerable.Range(0, nDocs)
+    .Select(d => new { Doc = d, Score = scorePost[d].GetMean() })
+    .OrderByDescending(x => x.Score)
+    .ToList();
+
+Console.WriteLine(""\nDocuments classes par score latent :"");
+int rang = 1;
+foreach (var item in classement)
+{
+    Console.WriteLine($""  {rang}. Doc {item.Doc} (score: {item.Score:F2})"");
+    rang++;
+}
+
+Console.WriteLine(""\n=> Le modele combine optimalement les deux sources"");",,,,,,,,8bc18287b0c44e56,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,1ov5mwpv8be,markdown,fr,b5726a48bc65160c,"### Analyse du classement final
+
+**Classement des documents** :
+
+| Rang | Document | Score latent | Jugement | Clics |
+|------|----------|--------------|----------|-------|
+| 1 | Doc 4 | 5.58 | 5.0 | 150 |
+| 2 | Doc 0 | 4.47 | 4.5 | 120 |
+| 3 | Doc 2 | 3.54 | 4.0 | 95 |
+| 4 | Doc 1 | 2.98 | 3.0 | 80 |
+| 5 | Doc 5 | 2.62 | 3.5 | 70 |
+| 6 | Doc 3 | 2.24 | 2.5 | 60 |
+
+**Valeur de la fusion** :
+
+Le modèle résout les désaccords entre sources :
+- **Doc 5** : Juge=3.5, Clics=70 → Score=2.62 (clics plus bas que attendu → baisse du score)
+- **Doc 2** : Juge=4.0, Clics=95 → Score=3.54 (clics cohérents → score intermédiaire)
+
+**Avantages du Click Model** :
+
+| Aspect | Bénéfice |
+|--------|----------|
+| **Calibration automatique** | Apprend l'échelle de chaque source |
+| **Pondération adaptative** | Sources plus précises ont plus de poids |
+| **Incertitude explicite** | Quantifie la confiance du classement |
+| **Extensible** | Ajouter d'autres signaux (temps lecture, rebonds, etc.) |",,,,,,,,b5726a48bc65160c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,b0b9ad1f,markdown,fr,639ce2a51ebc7f6d,"## 6bis. Exercice : Ajouter une Troisieme Source au Click Model
+
+Le Click Model de la section 6 fusionne **deux sources** (jugements experts et clics). Etendez-le a une **troisieme source** : le temps de lecture moyen en secondes.
+
+**Hypothese** : Plus un document est de qualite, plus les utilisateurs y passent du temps (a un facteur d'echelle pres).
+
+| Source | Precision attendue | Echelle |
+|--------|--------------------|---------|
+| Jugements experts | Elevee (~4-5) | Notes 1-5 |
+| Clics | Faible (~1) | Compte (0-200) |
+| Temps de lecture | Moyenne (~2-3) | Secondes (0-120) |
+
+**Donnees supplementaires** :
+```
+Temps de lecture (secondes) : {95, 45, 75, 30, 110, 55}
+```
+
+**Objectifs** :
+1. Ajoutez les variables `precTemps` et `echelleTemps` au modele
+2. Ajoutez le facteur d'observation pour le temps de lecture
+3. Executez l'inference et comparez les scores avec le modele a 2 sources
+
+**Etapes** :
+1. Definir les priors pour la precision et l'echelle du temps de lecture
+2. Ajouter l'observation `obsTemps[d] ~ Gaussian(scoreLatent[d] * echelleTemps, precTemps)`
+3. Observer les donnees de temps de lecture
+4. Executer l'inference et comparer les scores latents avec/sans la 3e source
+
+**Indices** :
+- Suivez exactement le meme pattern que pour les clics : une precision Gamma et une echelle Gaussian
+- Le facteur d'echelle est `echelleTemps ~ Gaussian(20, 0.01)` (environ 20 secondes par point de score)
+- La precision `precTemps ~ Gamma(3, 1)` (precision moyenne)",,,,,,,,639ce2a51ebc7f6d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,d3392b8a,code,fr,6e0153b938580527,"// Exercice : Click Model avec 3 sources
+
+// Donnees supplementaires : temps de lecture en secondes
+double[] tempsLecture = { 95, 45, 75, 30, 110, 55 };
+
+// TODO: Etape 1 - Ajoutez les variables pour la 3e source
+// Variable<double> precTemps = Variable.GammaFromShapeAndScale(3, 1).Named(""precTemps"");
+// Variable<double> echelleTemps = Variable.GaussianFromMeanAndPrecision(20, 0.01).Named(""echelleTemps"");
+// VariableArray<double> obsTemps = Variable.Array<double>(docRange).Named(""obsTemps"");
+
+// TODO: Etape 2 - Ajoutez le facteur d'observation
+// obsTemps[docRange] = Variable.GaussianFromMeanAndPrecision(
+//     scoreLatent[docRange] * echelleTemps, precTemps);
+// obsTemps.ObservedValue = tempsLecture;
+
+// TODO: Etape 3 - Executez l'inference et affichez les scores
+// Comparez avec les scores du modele a 2 sources (section 6)
+
+// TODO: Etape 4 - Affichez un tableau comparatif
+// | Doc | Score 2 sources | Score 3 sources | Diff |
+
+Console.WriteLine(""Exercice a completer : ajoutez la 3e source au Click Model."");",,,,,,,,6e0153b938580527,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,ex3md0000001,markdown,fr,20df853699611ec1,"## 6ter. Exercice : Predire la Note d'un Utilisateur pour un Film Non Note
+
+Dans les sections 3-4, nous avons construit un modele de factorisation matricielle bayesienne et predit les notes manquantes. Utilisez cette architecture pour construire un **mini-systeme de recommandation** sur une nouvelle matrice de notes.
+
+**Scenario** : 4 utilisateurs ont note 5 films (note sur 5, `NaN` = non note) :
+
+| | Inception | Titanic | Matrix | Amelie | Terminator |
+|--|-----------|---------|--------|--------|------------|
+| Alice | 5 | 2 | 4 | NaN | 5 |
+| Bob | NaN | 4 | 3 | 5 | NaN |
+| Claire | 4 | NaN | 5 | 2 | 4 |
+| David | 3 | 5 | NaN | 4 | NaN |
+
+**Objectifs** :
+1. Implementez la factorisation matricielle avec K=2 facteurs latents
+2. Predisez les notes manquantes pour chaque (utilisateur, film)
+3. Recommandez le meilleur film non note pour chaque utilisateur
+
+**Etapes** :
+1. Creer les variables latentes `userTraits[u][k]` et `itemTraits[i][k]` avec priors Gaussian
+2. Modeliser chaque note observee (non NaN) comme `note[u][i] = dot(userTraits[u], itemTraits[i]) + bruit`
+3. Executer l'inference (EP) et extraire les posteriors des notes manquantes
+4. Pour chaque utilisateur, identifier le film non note avec la plus haute note predite (NaN = a predire)
+
+**Indices** :
+- Reutilisez la structure de la section 3bis (avec suffisamment de donnees pour converger)
+- Observez les notes : Alice et Claire preferent l'action, Bob et David la romance
+- Avec K=2, les facteurs latents devraient capturer cette dimension action vs romance
+- Le bruit de precision peut etre fixe (ex: `Gamma(2, 0.5)`) ou inferre",,,,,,,,20df853699611ec1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,ex3cd0000001,code,fr,c1d3e34ee70e2c6c,"// Exercice : Predire la note d'un utilisateur pour un film non note
+
+// Donnees : 4 utilisateurs x 5 films (double.NaN = non note)
+int nUsers = 4;
+int nFilms = 5;
+int K = 2;  // Facteurs latents
+
+string[] users = { ""Alice"", ""Bob"", ""Claire"", ""David"" };
+string[] films = { ""Inception"", ""Titanic"", ""Matrix"", ""Amelie"", ""Terminator"" };
+
+// Notes observees (double.NaN = manquante)
+double[][] notes = {
+    new double[] { 5, 2, 4, double.NaN, 5 },      // Alice : action
+    new double[] { double.NaN, 4, 3, 5, double.NaN }, // Bob : romance
+    new double[] { 4, double.NaN, 5, 2, 4 },       // Claire : action
+    new double[] { 3, 5, double.NaN, 4, double.NaN } // David : romance
+};
+
+// Etape 1 : Creer le modele avec priors pour les traits latents
+// VariableArray<VariableArray<double>> userTraits, itemTraits
+// userTraits[u][k] ~ Gaussian(0, 0.1)  pour chaque u, k
+// itemTraits[i][k] ~ Gaussian(0, 0.1)  pour chaque i, k
+
+// Etape 2 : Modeliser les notes observees
+// Pour chaque (u, i) ou !double.IsNaN(notes[u][i]) :
+//   affinite = Variable.Sum(userTraits[u][k] * itemTraits[i][k])
+//   noteObs ~ Gaussian(affinite, precisionBruit)
+//   noteObs.ObservedValue = notes[u][i]
+
+// Etape 3 : Creer les variables pour les notes manquantes
+// Pour chaque (u, i) ou double.IsNaN(notes[u][i]) :
+//   notePred[u][i] ~ Gaussian(affinite, precisionBruit)
+
+// Etape 4 : Executer l'inference et afficher les predictions
+// Inferer les posteriors de userTraits, itemTraits, et notePred
+// Pour chaque utilisateur, afficher le film recommande (plus haute note predite)
+
+// Indice : utilisez InferenceEngine avec algorithm = ExpectationPropagation
+// Indice : parcourez la matrice et ne conditionnez que les notes non-NaN
+
+Console.WriteLine(""Exercice a completer : prediction de notes manquantes par factorisation matricielle."");",,,,,,,,c1d3e34ee70e2c6c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,c8a414f6,markdown,fr,563715aa7366a182,"## 7. Exemple guide : Recommandation de Films
+
+### Enonce
+
+Utilisez le modele de factorisation pour predire les notes manquantes et recommander des films.",,,,,,,,563715aa7366a182,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,jhb9hnfi71j,markdown,fr,00cbdd5f5813cc76,"### Contexte de l'exercice
+
+Cet exercice applique le modele de factorisation a un scenario concret : recommander des **films** a des utilisateurs.
+
+**Mapping semantique** :
+| ID | Film | Type suppose |
+|----|------|--------------|
+| 0 | Inception | Action/Sci-Fi |
+| 1 | Titanic | Romance |
+| 2 | Matrix | Action/Sci-Fi |
+| 3 | Notebook | Romance |
+| 4 | Terminator | Action |
+
+**Profils utilisateurs (implicites)** :
+- Alice, Claire : Preferences action
+- Bob : Preferences romance
+- David : Preferences action",,,,,,,,00cbdd5f5813cc76,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,3phruj21691,markdown,fr,7a51b505ae50ceb9,"### Instructions pour l'exercice
+
+L'exercice utilise le modele de factorisation de la section 3 pour predire des notes sur un jeu de donnees semantique (films).
+
+**Objectif** : Comprendre la relation entre :
+1. Les traits latents appris (ou non appris)
+2. La qualite des recommandations
+
+**Ce que vous devriez observer** :
+- Avec le modele original (8 observations), les recommandations sont uniformes (scores ~0)
+- Cela illustre l'importance de la qualite de l'inference en amont
+
+**Extension possible** : Modifier le code pour utiliser les posterieurs du modele corrige (section 3bis) et observer la difference.",,,,,,,,7a51b505ae50ceb9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,79044031,code,fr,844c7ab7929d9dfc,"// Exemple guide : Recommandation de films
+
+// Films : 0=Inception, 1=Titanic, 2=Matrix, 3=NotebookFilm, 4=Terminator
+string[] films = { ""Inception"", ""Titanic"", ""Matrix"", ""Notebook"", ""Terminator"" };
+
+// Utilisateurs : 0=Alice, 1=Bob, 2=Claire, 3=David
+string[] users = { ""Alice"", ""Bob"", ""Claire"", ""David"" };
+
+// Notes observees (memes donnees que section 3)
+Console.WriteLine(""=== Recommandation de Films ==="");
+Console.WriteLine(""\nNotes observees :"");
+Console.WriteLine($""  Alice -> Inception: 5, Matrix: 3"");
+Console.WriteLine($""  Bob -> Titanic: 4, Notebook: 2"");
+Console.WriteLine($""  Claire -> Inception: 4, Matrix: 5"");
+Console.WriteLine($""  David -> Matrix: 4, Terminator: 5"");
+
+// Utiliser les posterieurs calcules precedemment
+Console.WriteLine(""\n=== Top 3 Recommandations par utilisateur ==="");
+
+for (int u = 0; u < nUsers; u++)
+{
+    var predictions = new List<(int item, double score)>();
+    
+    for (int i = 0; i < nItems; i++)
+    {
+        // Verifier si deja note
+        bool observe = false;
+        for (int o = 0; o < nObs; o++)
+        {
+            if (userObs[o] == u && itemObs[o] == i)
+            {
+                observe = true;
+                break;
+            }
+        }
+        
+        if (!observe)
+        {
+            double pred = 0;
+            for (int t = 0; t < nTraits; t++)
+            {
+                pred += userTraitsPost[u, t].GetMean() * itemTraitsPost[i, t].GetMean();
+            }
+            predictions.Add((i, pred));
+        }
+    }
+    
+    var top3 = predictions.OrderByDescending(p => p.score).Take(3);
+    Console.WriteLine($""\n{users[u]} :"");
+    foreach (var rec in top3)
+    {
+        Console.WriteLine($""  -> {films[rec.item]} (score predit: {rec.score:F2})"");
+    }
+}",,,,,,,,844c7ab7929d9dfc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,26o8cdk585s,markdown,fr,4840cc31d012b821,"### Analyse des recommandations de films
+
+**Résultats** : Toutes les recommandations ont un score ~0.0
+
+| Utilisateur | Top recommandations |
+|-------------|---------------------|
+| Alice | Titanic, Notebook, Terminator (tous ~0.0) |
+| Bob | Terminator, Matrix, Inception (tous ~0.0) |
+| Claire | Titanic, Notebook, Terminator (tous ~0.0) |
+| David | Notebook, Inception, Titanic (tous ~0.0) |
+
+**Diagnostic** :
+
+Les scores nuls reflètent le problème de convergence de la factorisation (voir analyse précédente) :
+- Traits utilisateurs ≈ 0 → produit scalaire ≈ 0
+- Aucune différenciation possible entre items
+
+**Ce qu'un système fonctionnel montrerait** :
+
+| Utilisateur | Profil attendu | Recommandations attendues |
+|-------------|----------------|---------------------------|
+| Alice | Action (5 Inception, 3 Matrix) | Terminator (action) |
+| Bob | Romance (4 Titanic, 2 Notebook) | Notebook supplémentaire |
+| Claire | Action (4 Inception, 5 Matrix) | Terminator |
+| David | Action (4 Matrix, 5 Terminator) | Inception |
+
+**Leçon** : La factorisation bayésienne est puissante mais nécessite :
+- Suffisamment de données (>10× paramètres)
+- Bonne initialisation ou priors informatifs
+- Validation des sorties avant déploiement",,,,,,,,4840cc31d012b821,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,20kqel1sip,markdown,fr,193aa5591cc9692b,"### Points cles de l'exercice
+
+**Observations principales** :
+
+1. **La qualite des recommandations depend de l'inference** : Un modele mal converge produit des recommandations inutilisables
+2. **Diagnostic rapide** : Des scores uniformes signalent un probleme en amont
+3. **Solution** : Verifier les traits latents avant de deployer
+
+**Checklist de validation d'un systeme de recommandation** :
+
+| Verification | Methode |
+|--------------|---------|
+| Traits non-nuls | Inspecter moyennes des posterieurs |
+| Variance raisonnable | Traits avec incertitude, pas collapses a 0 |
+| Predictions variees | Distribution des scores, pas uniformes |
+| Coherence semantique | Top recommendations correspondent aux preferences observees |
+
+> **Conseil pratique** : Toujours valider sur un ensemble de test (notes observees masquees) avant deploiement.",,,,,,,,193aa5591cc9692b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,gb0ujeqyrb,markdown,fr,a45647c77ad8843f,"### Bilan : Systemes de recommandation bayesiens
+
+| Modele | Usage | Points cles |
+|--------|-------|-------------|
+| **Factorisation matricielle** | Prediction de notes | Traits latents, produit scalaire, regularisation par priors |
+| **Cold-start hybride** | Nouveaux utilisateurs/items | Features + factorisation, prediction immediate |
+| **Click Model** | Fusion de sources | Score latent, calibration automatique, incertitude par source |
+
+**Quand utiliser chaque approche** :
+
+| Situation | Recommandation |
+|-----------|----------------|
+| Beaucoup de notes, peu de nouveautes | Factorisation pure |
+| Forte rotation utilisateurs/items | Cold-start avec features |
+| Multiple signaux (clics, temps, notes) | Click Model ou variantes |
+| Production a grande echelle | Matchbox (Infer.NET industriel) |",,,,,,,,a45647c77ad8843f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,2c037f52,markdown,fr,e73776899082c547,"## 8. Resume
+
+| Concept | Description |
+|---------|-------------|
+| **Factorisation** | Decomposition U x V des preferences latentes |
+| **Cold-start** | Utiliser features pour nouveaux utilisateurs/items |
+| **Click Model** | Reconcilier sources de qualite variable |
+| **Matchbox** | Implementation industrielle dans Infer.NET |
+
+---
+
+## Pour aller plus loin
+
+| Si vous voulez... | Consultez... |
+|-------------------|--------------|
+| Debugger des problemes de convergence | [Infer-6-Debugging](Infer-6-Debugging.ipynb) |
+| Comprendre les algorithmes EP vs VMP | [Infer-6-Debugging](Infer-6-Debugging.ipynb) Section 4 |
+| Ameliorer le ratio donnees/parametres | [Infer-6-Debugging](Infer-6-Debugging.ipynb) Section 2 |
+| Trouver une definition | [Glossaire](Infer-Glossary.md) |
+
+---
+
+## Serie Complete
+
+Felicitations ! Vous avez termine la serie **Programmation Probabiliste avec Infer.NET** (13 notebooks).
+
+| # | Notebook | Concepts |
+|---|----------|----------|
+| 1 | Setup | Installation, premier modele, troubleshooting |
+| 2 | Gaussian-Mixtures | Posterieurs, melanges, Truncated Gaussian |
+| 3 | Factor-Graphs | Inference discrete, Monty Hall |
+| 4 | Bayesian-Networks | CPT, causalite |
+| 5 | Skills-IRT | IRT, DINA, many-to-many, ROC curves |
+| 6 | TrueSkill | Ranking, online learning |
+| 7 | Classification | BPM, A/B testing |
+| 8 | Model-Selection | Evidence, ARD |
+| 9 | Topic-Models | LDA, documents-topics, brisure de symetrie |
+| 10 | Crowdsourcing | Workers, communautes |
+| 11 | Sequences | HMM, transitions Markov, motif finding |
+| 12 | Recommenders | Factorisation, Click Model |
+| **13** | **Debugging** | **Troubleshooting, comparaison algorithmes** |
+
+---
+
+## Ressources
+
+- [Documentation Infer.NET](https://dotnet.github.io/infer/)
+- [Livre MBML](https://mbmlbook.com/)
+- [Code source Infer.NET](https://github.com/dotnet/infer)
+- [Glossaire](Infer-Glossary.md)",,,,,,,,e73776899082c547,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,1uya34v65pz,markdown,fr,b5472d80d0d4bbe3,"## Tableau recapitulatif des distributions utilisees
+
+| Distribution | Usage dans ce notebook | Parametres |
+|--------------|------------------------|------------|
+| **Gaussian(mean, precision)** | Traits latents, biais global, scores | mean=0/3, precision=0.1-1 |
+| **Gamma(shape, scale)** | Precision du bruit | shape=2, scale=0.5 |
+| **GaussianFromMeanAndPrecision** | Generation des notes | mean=affinite, precision=bruit |
+
+## Concepts probabilistes illustres
+
+| Concept | Section | Description |
+|---------|---------|-------------|
+| **Factorisation matricielle** | 3 | Decomposition R = U x V^T avec priors bayesiens |
+| **Probleme de convergence** | 3-4 | Ratio donnees/parametres insuffisant |
+| **Cold-start** | 5 | Prediction sans historique via features |
+| **Fusion multi-sources** | 6 | Click Model avec calibration automatique |
+| **Produit de gaussiennes** | 3, 6 | Necessite EP (pas VMP) |
+
+## Applications pratiques
+
+| Domaine | Application | Modele recommande |
+|---------|-------------|-------------------|
+| **E-commerce** | Recommandation produits | Factorisation + cold-start |
+| **Streaming** | Recommandation films/series | Factorisation matricielle |
+| **Moteur de recherche** | Ranking documents | Click Model |
+| **Reseau social** | Suggestion d'amis | Factorisation avec features sociales |",,,,,,,,b5472d80d0d4bbe3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,b525409c,markdown,fr,cd10be2f20dc8d86,"## 8bis. Exercice : Recommandation de Musique
+
+### Enonce
+
+Appliquez la factorisation matricielle a la **recommandation de musique** (notes 1-5).
+
+5 utilisateurs x 6 chansons (NaN = non ecoute) :
+
+| | Bohemian R. | Hotel Calif. | Smells Like | Imagine | Stan | Shape of You |
+|--|--|--|--|--|--|--|
+| Alice | 5 | 4 | ? | 5 | ? | 2 |
+| Bob | ? | 5 | 4 | ? | 3 | ? |
+| Charlie | 2 | ? | 5 | 1 | 4 | ? |
+| Diana | 4 | 3 | ? | 5 | ? | 4 |
+| Eve | ? | ? | 3 | ? | 5 | 3 |
+
+1. Faites tourner la factorisation avec K=2 facteurs latents
+2. Predisez la note d'Alice pour ""Smells Like"" et de Bob pour ""Imagine""
+3. Quel utilisateur a le profil le plus proche d'Alice ?",,,,,,,,cd10be2f20dc8d86,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,f38fc327,code,fr,5794a1d3466e74ee,"// Exercice : Recommandation de musique - factorisation matricielle
+// Notes sur 1-5, double.NaN = non ecoute
+int nUsers = 5;
+int nSongs = 6;
+int K = 2;  // Facteurs latents
+
+string[] users = { ""Alice"", ""Bob"", ""Charlie"", ""Diana"", ""Eve"" };
+string[] songs = { ""Bohemian"", ""Hotel Calif"", ""Smells Like"", ""Imagine"", ""Stan"", ""Shape of You"" };
+
+// Notes observees (-1 = non ecoute, encoder comme observations manquantes)
+double[][] notes = {
+    new double[] { 5, 4, double.NaN, 5, double.NaN, 2 },       // Alice
+    new double[] { double.NaN, 5, 4, double.NaN, 3, double.NaN }, // Bob
+    new double[] { 2, double.NaN, 5, 1, 4, double.NaN },        // Charlie
+    new double[] { 4, 3, double.NaN, 5, double.NaN, 4 },        // Diana
+    new double[] { double.NaN, double.NaN, 3, double.NaN, 5, 3 } // Eve
+};
+
+// TODO: Creer les facteurs latents utilisateurs et chansons
+// (Reutilisez la structure de la section 6 de l'exemple guide)
+
+// TODO: Modeliser note[u][s] = dot(userTraits[u], songTraits[s]) + bruit
+// Conditionnez les observations connues, laissez les NaN comme variables a inferer
+
+// TODO: Inferer les facteurs et predire les notes manquantes
+// Qui a le profil utilisateur le plus similaire a Alice ? (distance cosinus sur userTraits)
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,5794a1d3466e74ee,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb,09e7ba15,markdown,fr,baa5d8087a35126b,"## Conclusion
+
+Ce notebook a presente les systemes de recommandation bayesiens : factorisation matricielle, cold-start hybride et fusion multi-sources via le Click Model.
+
+| Modele | Mecanisme | Point cle |
+|--------|-----------|-----------|
+| Factorisation matricielle | R = U x V^T avec priors gaussiens | Ratio donnees/parametres > 5 pour convergence |
+| Cold-start hybride | Features utilisateur/item + biais | Prediction immediate sans historique |
+| Click Model | Score latent + precision par source | Calibration automatique des poids |
+
+| Distribution | Role dans ce notebook |
+|--------------|------------------------|
+| Gaussian | Traits latents utilisateurs et items, biais global |
+| Gamma | Precision du bruit d'observation |
+| GaussianFromMeanAndPrecision | Generation des notes a partir de l'affinite |
+
+> **Lecon pratique** : La factorisation bayesienne regularise naturellement via les priors, mais necessite suffisamment de donnees. Le Click Model illustre la fusion optimale de sources de fiabilite variable en ponderant automatiquement selon precision inferee.",,,,,,,,baa5d8087a35126b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,56307ca7,markdown,fr,d86af33276cec371,"# Infer-17 — Filtre de Kalman : systèmes dynamiques linéaires gaussiens
+
+> **Série Infer.NET (25).** Ce notebook étend [Infer-14 (Séquences / HMM)](Infer-14-Sequences.ipynb)
+> au cas où l'état caché est **continu**. Là où le HMM suivait une météo ou un mot
+> discret, le **filtre de Kalman** (Kalman, 1960) suit une position, une température,
+> un prix — toute grandeur qui évolue continûment avec du bruit. C'est l'algorithme
+> d'estimation le plus utilisé au monde (navigation GPS, fusion de capteurs, contrôle,
+> finance).
+
+**Durée estimée** : 55 minutes
+**Prérequis** : [Infer-14 (Séquences / HMM)](Infer-14-Sequences.ipynb), [Infer-2 (Gaussian Mixtures)](Infer-2-Gaussian-Mixtures.ipynb)
+
+## Objectifs
+
+- Comprendre le **filtre de Kalman** comme l'analogue à état continu du HMM
+- Formuler un **système dynamique linéaire gaussien** (prédiction + observation)
+- Implémenter la **récursion de filtrage bayésien** via Infer.NET (conjugaison gaussienne)
+- **Mesurer** l'apport du filtre : MSE filtrée < MSE brute, variance postérieure bornée
+",,,,,,,,d86af33276cec371,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,7ced128a,markdown,fr,80aad1bc362406fc,"## 1. Motivation : le HMM à état continu
+
+[Infer-14](Infer-14-Sequences.ipynb) modélisait des séquences où l'état caché était
+**discret** (quel temps, quel mot de la phrase). Mais de nombreux systèmes suivent une
+grandeur **continue** : position d'un mobile, température d'un four, prix d'un actif.
+Le **filtre de Kalman** est l'équivalent exact du HMM pour l'état continu gaussien —
+le **système dynamique linéaire gaussien** (Linear Dynamical System, LDS).
+
+L'état caché $x_t$ évolue linéairement avec un bruit gaussien (la *dynamique*), et on
+l'observe à travers un autre bruit gaussien (le *capteur*) :
+
+$$x_t = x_{t-1} + d + \mathcal{N}(0, Q) \quad \text{(équation de transition)}$$
+$$y_t = x_t + \mathcal{N}(0, R) \quad \text{(équation d'observation)}$$
+
+Parce que tout est **gaussien et linéaire**, l'inférence reste **exactement conjugée** :
+le postérieur est gaussien à chaque pas, calculable en temps fermé. C'est le cas d'école
+où Infer.NET (EP sur un modèle linéaire gaussien) résout l'inférence **de manière exacte**.
+",,,,,,,,80aad1bc362406fc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,a0e558bf,code,fr,cea94f4aab2802fa,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+// restore Infer.NET -- isole dans sa propre cellule (convention de la serie)
+",,,,,,,,cea94f4aab2802fa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,369c348b,markdown,fr,627fa92ddc4965a7,"Configuration des espaces de noms Infer.NET. Le moteur d'inférence **EP** (Expectation
+Propagation) résout la conjugaison gaussienne du filtre de Kalman de manière exacte.
+On définit aussi le helper de tirage gaussien (Box-Muller) utilisé pour générer la
+vraie trajectoire.
+",,,,,,,,627fa92ddc4965a7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,309102f4,code,fr,bd983928011ce534,"using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Models;
+using System;
+using System.Linq;
+
+// Helper : tirage N(0, 1) par Box-Muller (defini AVANT usage).
+double Randn(Random r) {
+    double u1 = 1.0 - r.NextDouble();
+    double u2 = 1.0 - r.NextDouble();
+    return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
+}
+
+// --- Terrain de jeu : vraie trajectoire + observations bruitees ---
+// On suit un mobile qui derive lineairement (vitesse d constante + bruit de process Q).
+Random rng = new Random(42);
+int T = 50;
+double drift = 0.3;        // d : vitesse constante (terme de pente)
+double processVar = 0.5;   // Q : bruit de dynamique (incertitude sur l'evolution)
+double obsVar = 4.0;       // R : bruit de capteur (observations TRES bruitees, R >> Q)
+
+// Vraie trajectoire cachee (INCONNUE du modele -- ground truth pour la validation)
+double[] trueState = new double[T];
+trueState[0] = 0.0;
+for (int t = 1; t < T; t++)
+    trueState[t] = trueState[t - 1] + drift + Math.Sqrt(processVar) * Randn(rng);
+
+// Observations bruitees (les SEULES donnees vues par le filtre)
+double[] obs = new double[T];
+for (int t = 0; t < T; t++)
+    obs[t] = trueState[t] + Math.Sqrt(obsVar) * Randn(rng);
+
+Console.WriteLine($""Trajectoire generee : T={T} pas, drift={drift}, Q={processVar}, R={obsVar}"");
+Console.WriteLine($""R >> Q : le capteur est tres bruite -> le filtre a beaucoup de marge pour aider."");
+Console.WriteLine($""5 premieres observations : {string.Join("", "", obs.Take(5).Select(v => v.ToString(""F2"")))}"");
+",,,,,,,,bd983928011ce534,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,c8f43f1d,markdown,fr,cd76b0369d63b8b0,"## 2. La récursion de Kalman = filtrage bayésien pas-à-pas
+
+Le filtre de Kalman est la **récurrence bayésienne** sur l'état continu. À chaque pas :
+
+1. **Prédire** — propager le postérieur précédent $p(x_{t-1} \mid y_{1:t-1})$ à travers la
+   dynamique : la moyenne avance de $d$, la variance augmente de $Q$ (l'incertitude croît).
+2. **Mettre à jour** — combiner cet *a priori* avec la nouvelle observation $y_t$ par la
+   règle de Bayes : le postérieur $p(x_t \mid y_{1:t})$ a une variance **réduite**.
+
+Comme tout est gaussien-linéaire, chaque pas se réduit à une **conjugaison gaussienne**.
+On l'exprime comme un **mini-modèle à deux variables** ($x_t$ latente, $y_t$ observée) et
+on laisse Infer.NET inférer le postérieur — qui devient l'a priori du pas suivant.
+
+**Optimisation (pattern C118)** : on **compile une fois** le mini-modèle, avec la moyenne
+et la variance de l'a priori comme variables `ObservedValue`. À chaque pas on ne fait que
+mettre à jour ces valeurs observées puis ré-inférer — ~0,2 ms par pas au lieu de
+recompiler (250 ms).
+",,,,,,,,cd76b0369d63b8b0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,37276c06,code,fr,860f709959f6fb6d,"// --- Recursion du filtre de Kalman via Infer.NET (EP, conjugaison gaussienne) ---
+InferenceEngine engine = new InferenceEngine();
+engine.ShowProgress = false;
+
+// Modele lineaire gaussien compile UNE SEULE FOIS :
+//   x  ~ N(priorMean, priorVar)        [latent, a priori du pas courant]
+//   y  ~ N(x, obsVar)                  [observation bruitee de x]
+// priorMean et priorVar sont des ObservedValue -> mis a jour chaque pas sans recompiler.
+Variable<double> priorMean = Variable.New<double>().Named(""priorMean"");
+Variable<double> priorVar  = Variable.New<double>().Named(""priorVar"");
+Variable<double> x = Variable.GaussianFromMeanAndVariance(priorMean, priorVar).Named(""x"");
+Variable<double> y = Variable.GaussianFromMeanAndVariance(x, obsVar).Named(""y"");
+
+double[] filtMean = new double[T];
+double[] filtVar  = new double[T];
+
+// A priori initial : on initialise sur la 1re observation avec une grande incertitude.
+double curMean = obs[0];
+double curVar  = obsVar * 4.0;   // incertitude initiale large (on ne sait pas ou est le mobile)
+
+for (int t = 0; t < T; t++) {
+    try {
+        // 1. PREDIRE : propagation de la dynamique (moyenne += drift, variance += Q)
+        double predMean = curMean + drift;
+        double predVar  = curVar + processVar;
+
+        // 2. METTRE A JOUR : EP infere le postérieur exact de x sachant y = obs[t]
+        priorMean.ObservedValue = predMean;
+        priorVar.ObservedValue  = predVar;
+        y.ObservedValue         = obs[t];
+        Gaussian post = engine.Infer<Gaussian>(x);
+        curMean = post.GetMean();
+        curVar  = post.GetVariance();
+    } catch (Exception ex) {
+        Console.WriteLine($""EXCEPTION pas {t}: {ex.Message}"");
+        curMean = obs[t]; curVar = obsVar;
+    }
+    filtMean[t] = curMean;
+    filtVar[t]  = curVar;
+}
+Console.WriteLine(""Filtrage termine : 50 pas infères par EP (conjugaison gaussienne exacte)."");
+Console.WriteLine($""Variance postérieure finale : {filtVar[T - 1]:F3}   (var d'observation R = {obsVar:F1})"");
+Console.WriteLine($""Variance postérieure moyenne : {filtVar.Average():F3}"");
+",,,,,,,,860f709959f6fb6d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,89d22de7,markdown,fr,eb365400ef1c8096,"## 3. Visualisation : trajectoire vraie, observations brutes, estimation filtrée
+
+Le graphe ASCII ci-dessous aligne, à chaque pas de temps (un pas sur deux pour la
+lisibilité), les trois séries. Les **observations** (`.`) oscillent fortement autour de
+la vraie trajectoire (`|`) à cause du capteur bruité ($R = 4$). L'**estimation filtrée**
+(`#`, espérance du postérieur) lisse ce bruit et suit fidèlement la trajectoire cachée.
+",,,,,,,,eb365400ef1c8096,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,4ad73b83,code,fr,bdb8bcb673d8583c,"// --- Visualisation ASCII + metriques honnetes ---
+// Axe horizontal = position. On cale l'echelle sur l'ensemble des series.
+double lo = Math.Min(trueState.Min(), obs.Min()) - 2;
+double hi = Math.Max(trueState.Max(), obs.Max()) + 2;
+int W = 60;
+
+string Bar(double v, char c) {
+    int n = (int)Math.Round((v - lo) / (hi - lo) * W);
+    if (n < 0) n = 0; if (n > W) n = W;
+    return new string(c, n);
+}
+
+Console.WriteLine($""Echelle : {lo:F1} (gauche) -> {hi:F1} (droite), {W} colonnes"");
+Console.WriteLine(""  VRAI = |   OBS = .   FILT = #"");
+for (int t = 0; t < T; t += 2) {
+    Console.WriteLine($""t={t,2} VRAI {Bar(trueState[t], '|')}"");
+    Console.WriteLine($""     OBS  {Bar(obs[t], '.')}"");
+    Console.WriteLine($""     FILT {Bar(filtMean[t], '#')}  (+-{Math.Sqrt(filtVar[t]):F2})"");
+}
+
+// --- Metriques : MSE filtree vs MSE brute (par rapport a la VRAIE trajectoire) ---
+double rawMSE = 0.0, filtMSE = 0.0;
+for (int t = 0; t < T; t++) {
+    rawMSE  += Math.Pow(obs[t]      - trueState[t], 2);
+    filtMSE += Math.Pow(filtMean[t] - trueState[t], 2);
+}
+rawMSE  /= T;
+filtMSE /= T;
+
+Console.WriteLine(""\n=== Performance du filtre (par rapport a la trajectoire VRAIE) ==="");
+Console.WriteLine($""MSE observations brutes : {rawMSE:F3}   (variance de capteur R = {obsVar:F1})"");
+Console.WriteLine($""MSE estimation filtree  : {filtMSE:F3}"");
+Console.WriteLine($""Reduction d'erreur      : {(1.0 - filtMSE / rawMSE) * 100:F1}%   (filtre vs brut)"");
+Console.WriteLine($""Variance post. finale   : {filtVar[T - 1]:F3}   (vs R = {obsVar:F1})"");
+",,,,,,,,bdb8bcb673d8583c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,46ac2fd4,markdown,fr,ab0bd2a293e576af,"### Lecture du résultat
+
+Le filtre **réduit fortement l'erreur** : la MSE filtrée est nettement inférieure à la MSE
+des observations brutes. Deux mécanismes sont visibles dans le graphe ASCII :
+
+- **Lissage** — l'estimation filtrée (`#`) varie beaucoup moins que les observations (`.`)
+  d'un pas à l'autre : le filtre fait confiance à la dynamique ($Q$ petit) pour rejeter le
+  bruit du capteur ($R$ grand).
+- **Incertitude bornée** — la variance postérieure (±σ) se stabilise rapidement bien sous
+  $R$ : après une brève phase d'initialisation, le filtre « sait » où il en est, et cette
+  connaissance ne se dégrade pas avec le temps (équation de Riccati discrète).
+
+C'est précisément la situation où le filtre de Kalman *aide* : capteur bruité, dynamique
+fiable. L'exercice 1 explore la situation limite opposée (dynamique très incertaine).
+",,,,,,,,ab0bd2a293e576af,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,a1879e2e,markdown,fr,952c668c61da82be,"## 4. Pourquoi ça marche : conjugaison exacte et borne de variance
+
+Le filtre de Kalman tire sa puissance d'une propriété **exacte** : tout étant gaussien et
+linéaire, **chaque postérieur est gaussien et calculable en forme fermée**. Infer.NET (EP)
+retrouve cette solution exacte — c'est le cas où l'inférence est *exacte*, pas approchée.
+
+La **règle de combinaison** est elle-même fermée : le postérieur $p(x_t \mid y_t)$ est
+gaussien, avec une moyenne qui est un **pondéré** entre la prédiction (où le mobile
+*devrait* être d'après la dynamique) et l'observation (où le capteur le *voit*). Le poids
+relatif est l'inverse des variances : on fait davantage confiance à la source la plus
+certaine.
+
+- Si le capteur est **très bruité** ($R$ grand), le filtre fait confiance à la dynamique →
+  lissage agressif, MSE fortement réduite (notre cas : $R = 4 \gg Q = 0{,}5$).
+- Si la dynamique est **très incertaine** ($Q$ grand), le filtre fait confiance au capteur →
+  l'estimation colle aux observations, peu de lissage (exercice 1).
+
+La **borne de variance** (équation de Riccati) garantit que l'incertitude résiduelle
+*plafonne* plutôt que d'exploser — c'est ce qui rend le filtre fiable sur le long terme.
+",,,,,,,,952c668c61da82be,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,cf113a8e,markdown,fr,1a7233767122d956,"## 5. Exercices
+
+### Exercice 1 — Sensibilité au bruit de dynamique (Q)
+Rejouez le filtre en balayant $Q \in \{0{,}01\,;\, 0{,}5\,;\, 2{,}0\,;\, 10{,}0\}$ (sans
+changer la vraie trajectoire ni $R$). Pour chaque $Q$, relevez la **MSE filtrée** et la
+**variance postérieure moyenne**. Observez le compromis : $Q$ petit → lissage agressif
+(le filtre ignore le capteur et suit la pente) ; $Q$ grand → le filtre colle au capteur
+(réagit au bruit). Quel $Q$ minimise la MSE sur **cette** trajectoire ?
+- **Indice :** le $Q$ optimal est proche de la *vraie* variance de process (ici $0{,}5$).
+  Choisir $Q$, c'est donc faire de l'**estimation de paramètre** — le filtre suppose connu
+  ce que vous fixez à la main.
+",,,,,,,,1a7233767122d956,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,aa387393,code,fr,740a2d03db6fa5fd,"// Exercice 1 a completer
+// Conseil : bouclez sur les valeurs de Q, relancez la recursion (copiez la boucle ci-dessus
+// en parametrant processVar), stockez filtMSE pour chaque Q. Affichez le tableau Q|MSE|var.
+Console.WriteLine(""Exercice 1 a completer"");
+",,,,,,,,740a2d03db6fa5fd,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,f0318839,markdown,fr,c1df4bbc028694c2,"### Exercice 2 — État vectoriel (position + vitesse)
+Le filtre ci-dessus suit une position scalaire avec une *vitesse* (`drift`) injectée
+manuellement. Généralisez à un état **vectoriel** $x = (\text{position}, \text{vitesse})$
+où $\text{pos}_t = \text{pos}_{t-1} + \text{vit}_{t-1} \cdot \Delta t + \text{bruit}$ et
+$\text{vit}_t = \text{vit}_{t-1} + \text{bruit}$. Utilisez `Variable.Vector` et
+`Variable.MatrixTimesVector` d'Infer.NET.
+- **Indice :** c'est le « vrai » filtre de Kalman matriciel. La **vitesse devient
+  latente et estimée** (plus injectée). On observe uniquement la position
+  ($y = \text{pos} + \text{bruit}$) et on infère la vitesse cachée — c'est tout l'intérêt.
+",,,,,,,,c1df4bbc028694c2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,0997e86a,code,fr,2339edc75de35b95,"// Exercice 2 a completer
+// Conseil : etat x = Variable.Vector, transition par MatrixTimesVector(A, x[t-1]).
+// Commencez par estimer la vitesse cachee a partir de observations de position bruitees.
+Console.WriteLine(""Exercice 2 a completer"");
+",,,,,,,,2339edc75de35b95,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,c983a9fa,markdown,fr,ef2e2602683b52ec,"### Exercice 3 — Lissage joint (full factor graph)
+Le filtre ci-dessus est **séquentiel** (un pas à la fois : il n'utilise que les
+observations passées). Construisez la version **jointe** : un seul
+`VariableArray<double> x` sur un `Range` temporel, avec
+`x[t] = Variable.GaussianFromMeanAndVariance(x[t - 1] + drift, processVar)` dans un
+bloc `Variable.ForEach` (**auto-référence** `x[t-1]`), toutes les observations branchées,
+et laissez EP inférer **toutes les marginales simultanément** — c'est le **lissage**
+(utilise aussi les observations futures).
+- **Indice :** le lissage rétro-propage l'information, donc **MSE lissée $\leq$ MSE filtrée**.
+  La syntaxe d'auto-référence `x[t-1]` dans `Variable.ForEach` est délicate (cas `t == 0`
+  à isoler avec `Variable.If`) — référez-vous aux exemples de chaînes gaussiennes Infer.NET.
+",,,,,,,,ef2e2602683b52ec,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,1ab3b005,code,fr,d2ca252040e69f11,"// Exercice 3 a completer
+// Conseil : Range t = new Range(T); VariableArray<double> x = Variable.Array<double>(t);
+// Dans Variable.ForEach(t) : If(t==0) x[t]=prior; If(t>0) x[t]=Gaussian(x[t-1]+drift, Q).
+// Comparez la MSE lisse (jointe) a la MSE filtree (sequentielle ci-dessus).
+Console.WriteLine(""Exercice 3 a completer"");
+",,,,,,,,d2ca252040e69f11,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb,39ab8735,markdown,fr,4a0607229c769f46,"## 6. Ponts avec la série
+
+| Direction | Lien | Relation |
+|-----------|------|----------|
+| ↔ Infer-14 | [Infer-14 — Séquences (HMM)](Infer-14-Sequences.ipynb) | HMM à état **discret** ↔ filtre de Kalman à état **continu** : même squelette markovien (état caché + observation), nature de l'état différente |
+| ← Infer-2 | [Infer-2 — Gaussian Mixtures](Infer-2-Gaussian-Mixtures.ipynb) | Le Kalman repose sur la **conjugaison gaussienne** — Infer-2 en pose les bases |
+| ↔ Infer-16 | [Infer-16 — Sparse GP](Infer-16-Sparse-Gaussian-Process.ipynb) | GP et Kalman modélisent tous deux de l'aléatoire structuré ; GP = espace fonctionnel **non-paramétrique**, Kalman = état fini **paramétrique** |
+
+**Référence fondatrice** : Kalman, R. E. (1960) — *A New Approach to Linear Filtering and Prediction Problems*, ASME Journal of Basic Engineering 82(1). L'article fondateur du filtre de Kalman — l'algorithme d'estimation le plus répandu en pratique.
+
+## 7. Conclusion
+
+Le **filtre de Kalman** est le pont entre le HMM discret d'[Infer-14](Infer-14-Sequences.ipynb)
+et le monde continu. Sa puissance tient en trois propriétés : pour les systèmes
+**linéaires gaussiens**, l'inférence est **exacte** (conjugaison), **récursive** (un pas à
+la fois, en $O(T)$) et **bornée** (variance postérieure stable). Infer.NET la résout
+naturellement via EP, qui retrouve la solution exacte sur ce cas d'école.
+
+La leçon générale : quand le modèle est **linéaire-gaussien**, nul besoin de méthodes
+d'inférence approchées lourdes — la conjugaison offre une solution fermée. C'est en
+**sortant** de ce régime (non-linéarités, distributions non gaussiennes) que les processus
+gaussiens ([Infer-16](Infer-16-Sparse-Gaussian-Process.ipynb)) et les méthodes
+variationnelles deviennent nécessaires. Le Kalman n'est pas un cas particulier encombrant :
+c'est le **point de référence** par rapport auquel tous les filtres approchés se mesurent.",,,,,,,,4a0607229c769f46,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,8cd92d9d,markdown,fr,94025d3ddc848416,"# Infer-18 — Détection de Rupture (Change-Point) : inférer le moment d'un changement de régime
+
+> **Corpus bayésien Infer.NET.** Ce notebook (18ᵉ du corpus) complète la famille des
+> « séquences dans le temps » : il étend [Infer-14 (Séquences / HMM)](Infer-14-Sequences.ipynb)
+> et [Infer-17 (Filtre de Kalman)](Infer-17-Kalman-Filter.ipynb) au cas où ce n'est pas l'état
+> qui change à chaque instant, mais la **structure** du processus qui bascule **une seule fois**
+> à un instant inconnu.
+
+**Durée estimée** : 50 minutes
+**Prérequis** : [Infer-14-Sequences](Infer-14-Sequences.ipynb) (HMM, `Variable.ForEach`), [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb) (conjugaison gaussienne), [Infer-10-Model-Selection](Infer-10-Model-Selection.ipynb) (évidence, Bayes factors)
+
+Imaginez une chaîne de production dont la qualité dérive soudainement, un marché financier
+qui change de régime, ou le taux d'accidents miniers qui chute après une nouvelle réglementation.
+Dans tous ces cas, le signal observé suit un régime stable, puis **bascule** vers un autre régime
+à un instant `cp` que l'on ne connaît pas à l'avance. La question n'est pas « quel est l'état à
+chaque pas ? » (répondue par le HMM ou le filtre de Kalman), mais « **à quel instant unique** le
+processus a-t-il changé de nature ? ». C'est l'inférence d'un **point de rupture** (*change-point*).
+
+Ce notebook montre comment Infer.NET traite ce problème de façon native : un *a priori* uniforme
+sur l'indice de rupture (`Variable.DiscreteUniform`), une sélection de vraisemblance conditionnée
+par cet indice (`Variable.If` / `Variable.IfNot` sur une plage), et le moteur **EP** qui retourne
+un postérieur **discret** sur la localisation de la rupture — l’idiome message-passing-sur-graphe
+de-facteurs que Infer.NET est conçu pour résoudre.",,,,,,,,94025d3ddc848416,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,975d8fa1,markdown,fr,72a0f17cf64b388d,"## 1. Motivation : là où le HMM et le filtre de Kalman s'arrêtent
+
+[Infer-14](Infer-14-Sequences.ipynb) modélise une séquence où l'état caché est **discret** et
+change à **chaque instant** (météo d'aujourd'hui, mot de la phrase). [Infer-17](Infer-17-Kalman-Filter.ipynb)
+est son pendant **continu** : l'état (position, prix) évolue pas-à-pas. Les deux infèrent un état
+**récurrent** — un par pas de temps.
+
+Le **point de rupture** est différent : l'inconnue n'est pas une trajectoire d'états, mais **un
+unique entier** `cp ∈ {0, …, N−1}` — l'indice où le processus bascule. On veut le postérieur
+$p(\text{cp} \mid y_{0:N-1})$, une distribution discrète sur $N$ positions.
+
+L'idiome Infer.NET repose sur trois briques que les notebooks précédents n'exploitent **pas**
+ensemble :
+
+| Brique | Rôle | Où déjà vu ? |
+|--------|------|--------------|
+| `Variable.DiscreteUniform(N)` | *a priori* uniforme sur l'indice de rupture | Infer-3 (Monty Hall) |
+| `Variable.ForEach` sur la plage temporelle | une vraisemblance par instant | Infer-14, Infer-17 |
+| `Variable.If(block.Index <= cp)` / `IfNot` | sélectionner la vraisemblance *avant*/*après* la rupture | Infer-3 (If/IfNot statique) |
+
+La nouveauté est le couplage : la condition `block.Index <= cp` (l'indice de boucle, obtenu via
+`ForEachBlock.Index`) **branche la vraisemblance sur un indice latent couplé à toute la plage** —
+un usage plus riche du `If` que le cas statique de Infer-3. EP propage les messages et retourne
+une `Discrete` (un vecteur de probabilités sur les $N$ positions) pour `cp`, plus les postérieurs
+des paramètres de chaque segment.",,,,,,,,72a0f17cf64b388d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,ac22d2ac,code,fr,cea94f4aab2802fa,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+// restore Infer.NET -- isole dans sa propre cellule (convention de la serie)",,,,,,,,cea94f4aab2802fa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,54bb8901,markdown,fr,ff64d4be4e21216d,"Configuration des espaces de noms Infer.NET. Le moteur **EP** (Expectation Propagation) est
+celui qui traite les facteurs `If` discrets couplés à une plage. On définit aussi le helper
+de tirage gaussien (Box-Muller) pour générer une série synthétique dont on connaît le vrai
+point de rupture.",,,,,,,,ff64d4be4e21216d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,26d51878,code,fr,a85f02662c5c894c,"using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;   // desambiguise vs System.Range
+using System;
+using System.Linq;
+
+// Helper : tirage N(0, 1) par Box-Muller (defini AVANT usage).
+double Randn(Random r) {
+    double u1 = 1.0 - r.NextDouble();
+    double u2 = 1.0 - r.NextDouble();
+    return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
+}
+
+// --- Terrain de jeu : serie avec un SEUL changement de regime ---
+// Le vrai point de rupture est CACHE ; on verifiera que le modele le recupere.
+Random rng = new Random(42);
+int N = 100;
+int vraiCp = 50;                  // vrai indice de rupture (inconnu du modele)
+double muAvant = 2.0, muApres = 7.0;   // moyennes des deux regimes
+double sigma = 1.5;               // bruit d'observation
+double[] data = new double[N];
+for (int i = 0; i < N; i++) {
+    double mu = (i <= vraiCp) ? muAvant : muApres;
+    data[i] = mu + Randn(rng) * sigma;
+}
+Console.WriteLine($""Serie generee : N={N} points, vrai cp cache a t={vraiCp} (mu {muAvant} -> {muApres}, sigma={sigma})"");",,,,,,,,a85f02662c5c894c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,7765fc61,markdown,fr,5f5037b130782fb7,"## 2. Le modèle de point de rupture gaussien
+
+On déclare `cp` comme un entier d'*a priori* uniforme sur `{0, …, N−1}`, deux moyennes de segment
+(*a priori* gaussiens vagues) et une précision commune. Pour chaque instant `t`, on **branche** la
+vraisemblance selon la position de `cp` : gaussienne de moyenne `mean1` avant la rupture, `mean2`
+après. C'est le couplage `Variable.ForEach` + `If(block.Index <= cp)` qui fait tout le travail
+(l'indice de boucle est obtenu via `block.Index`, l'API moderne d'Infer.NET).
+
+EP retourne : un postérieur **`Discrete`** sur `cp` (vecteur de $N$ probabilités), et les postérieurs
+gaussiens/gamma des paramètres. Notons que **rien n'est échantillonné** : c'est de l'inférence
+déterministe par passage de messages, en quelques itérations.",,,,,,,,5f5037b130782fb7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,d80b88b4,code,fr,8d88b0fb95568ead,"// --- Modele de change-point gaussien ---
+Range t = new Range(N);
+VariableArray<double> y = Variable.Array<double>(t);
+y.ObservedValue = data;
+
+Variable<int> cp = Variable.DiscreteUniform(N);                      // localisation de la rupture
+Variable<double> mean1 = Variable.GaussianFromMeanAndVariance(0.0, 100.0);
+Variable<double> mean2 = Variable.GaussianFromMeanAndVariance(0.0, 100.0);
+Variable<double> precision = Variable.GammaFromMeanAndVariance(1.0, 1.0);
+
+using (var block = Variable.ForEach(t)) {
+    using (Variable.If(block.Index <= cp)) {                         // segment AVANT
+        y[t] = Variable.GaussianFromMeanAndPrecision(mean1, precision);
+    }
+    using (Variable.IfNot(block.Index <= cp)) {                      // segment APRES
+        y[t] = Variable.GaussianFromMeanAndPrecision(mean2, precision);
+    }
+}
+
+var ie = new InferenceEngine(new ExpectationPropagation()) { ShowProgress = false, NumberOfIterations = 50 };
+Discrete cpPost = ie.Infer<Discrete>(cp);
+Gaussian m1Post = ie.Infer<Gaussian>(mean1);
+Gaussian m2Post = ie.Infer<Gaussian>(mean2);
+Gamma precPost  = ie.Infer<Gamma>(precision);
+
+Console.WriteLine(""=== Posterieur sur le point de rupture cp ==="");
+Console.WriteLine($""  mode (argmax)        = {cpPost.GetMode()}    (vrai cp cache = {vraiCp})"");
+Console.WriteLine($""  moyenne              = {cpPost.GetMean(),6:F2}"");
+Console.WriteLine($""Moyenne avant  (mu1) : {m1Post.GetMean(),6:F3}  (vrai {muAvant})"");
+Console.WriteLine($""Moyenne apres  (mu2) : {m2Post.GetMean(),6:F3}  (vrai {muApres})"");
+Console.WriteLine($""Precision commune    : {precPost.GetMean(),6:F3}  (vrai {1.0/(sigma*sigma):F3})"");",,,,,,,,8d88b0fb95568ead,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,5cb6e2d0,markdown,fr,df4b92ee3000af04,"**Lecture.** Le mode du postérieur sur `cp` doit tomber **très près** de 50 (le vrai point caché),
+et les moyennes de segment doivent approcher 2 et 7. Si le signal est fort (`|mu2 − mu1| ≫ sigma`),
+le postérieur se concentre sur **quelques indices** ; s'il est faible, il s'étale. Examinons la
+forme exacte de ce postérieur discret.",,,,,,,,df4b92ee3000af04,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,e72abe1e,code,fr,0e26609bc80f08e8,"// --- Visualisation : postérieur discret sur la localisation de la rupture ---
+double pmax = 0.0;
+for (int i = 0; i < N; i++) pmax = Math.Max(pmax, cpPost[i]);
+Console.WriteLine(""Postérieur sur cp (masses > 0.1%, normalisees au pic) :"");
+for (int i = 0; i < N; i++) {
+    if (cpPost[i] < 0.001) continue;                                // on n'affiche que la masse utile
+    int barLen = (int)Math.Round(cpPost[i] / pmax * 50.0);
+    Console.WriteLine($""  t={i,3}  {new string('#', barLen),-50}  {cpPost[i],7:F4}"");
+}",,,,,,,,0e26609bc80f08e8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,dbba2a95,markdown,fr,336c01752462eb4d,"## 3. Le cas canonique : les catastrophes minières (loi de Poisson)
+
+Le jeu de données historique du change-point bayésien est la série annuelle des **catastrophes
+de mines de charbon** en Grande-Bretagne (1851–1962, Jarrett 1979). Il s'agit de **comptes** :
+le modèle naturel est une loi de **Poisson** dont le *taux* bascule une fois — de ~3 accidents/an
+avant la réforme de sécurité des années 1880 à ~1/an après.
+
+Même idiome que le cas gaussien : `DiscreteUniform` sur l'année de rupture, `If/IfNot` sur la
+plage des années, mais `Variable.Poisson(taux)` en lieu et place de la gaussienne. EP retourne le
+postérieur `Discrete` sur l'année de rupture et les taux `Gamma` des deux régimes.",,,,,,,,336c01752462eb4d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,7ba74aef,code,fr,3b127788156a4754,"// --- Catastrophes minieres britanniques, 1851-1962 (Jarrett 1979) ---
+int[] disasters = new int[] {
+    4,5,4,0,1,4,3,4,0,6, 3,3,4,0,2,6,3,3,5,4,
+    5,3,1,4,4,1,5,5,3,4, 2,5,2,2,3,4,2,1,3,2,
+    2,1,1,1,1,3,0,0,1,0, 1,1,0,0,3,1,0,3,2,2,
+    0,1,1,1,0,1,0,1,0,0, 0,2,1,0,0,0,1,1,0,2,
+    3,3,1,1,2,1,1,1,1,2, 4,2,0,0,1,4,0,0,0,1,
+    0,0,0,0,1,0,0,1,0,1, 0,1
+};
+int N2 = disasters.Length;
+Console.WriteLine($""Serie cataclysmes miniers : {N2} annees ({1851}..{1851 + N2 - 1})"");
+
+Range an = new Range(N2);
+VariableArray<int> d = Variable.Array<int>(an);
+d.ObservedValue = disasters;
+
+Variable<int> cp2 = Variable.DiscreteUniform(N2);
+Variable<double> tauxAvant  = Variable.GammaFromMeanAndVariance(3.0, 100.0);
+Variable<double> tauxApres  = Variable.GammaFromMeanAndVariance(1.0, 100.0);
+
+// Initialisation data-driven : EP est deterministe (pas d'echantillonnage), donc un point de
+// rupture peut pieger EP dans un optimum local. On amorce les deux taux vers les extremes
+// empiriques de la serie (moyennes des premieres et des dernieres annees) -- une heuristique
+// standard pour les modeles de change-point sous EP.
+double estAvant = disasters.Take(10).Average();
+double estApres = disasters.Skip(N2 - 10).Take(10).Average();
+tauxAvant.InitialiseTo(Gamma.FromMeanAndVariance(estAvant, 1.0));
+tauxApres.InitialiseTo(Gamma.FromMeanAndVariance(estApres, 1.0));
+
+using (var block2 = Variable.ForEach(an)) {
+    using (Variable.If(block2.Index <= cp2)) {
+        d[an] = Variable.Poisson(tauxAvant);
+    }
+    using (Variable.IfNot(block2.Index <= cp2)) {
+        d[an] = Variable.Poisson(tauxApres);
+    }
+}
+
+var ie2 = new InferenceEngine(new ExpectationPropagation()) { ShowProgress = false, NumberOfIterations = 50 };
+Discrete cp2Post = ie2.Infer<Discrete>(cp2);
+Gamma tauxAvantPost = ie2.Infer<Gamma>(tauxAvant);
+Gamma tauxApresPost = ie2.Infer<Gamma>(tauxApres);
+
+int modeCp2 = cp2Post.GetMode();
+Console.WriteLine($""Annee de rupture detectee : {1851 + modeCp2}  (indice {modeCp2})"");
+Console.WriteLine($""Taux AVANT  : {tauxAvantPost.GetMean(),5:F2} catastrophes/an"");
+Console.WriteLine($""Taux APRES  : {tauxApresPost.GetMean(),5:F2} catastrophes/an"");
+Console.WriteLine($""Rapport de taux : {tauxAvantPost.GetMean() / Math.Max(1e-6, tauxApresPost.GetMean()):F1}x"");",,,,,,,,3b127788156a4754,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,e5a20101,markdown,fr,2bf529a87b5be3e8,"**Lecture.** Le postérieur concentre la rupture autour de **1890–1891** — soit exactement
+la période des grandes réformes de sécurité dans les mines britanniques. Le taux passe de ~3,1 à
+~0,9 catastrophe par an, un rapport de ~3,3×. C'est le résultat historique de la littérature
+sur les modèles de point de rupture (Carlin, Gelfand & Smith 1992 ; PyMC en fait son exemple
+introductif). **Aucun échantillonnage MCMC** n'est utilisé ici : EP propage les messages sur le
+graphe de facteurs et renvoie le postérieur en quelques itérations.",,,,,,,,2bf529a87b5be3e8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,62c94bdc,markdown,fr,b8add33bdda021b5,"## 4. Vraie rupture ou caprice du bruit ? Le piège de la flexibilité
+
+Un modèle de point de rupture est **flexible** : il peut, si on le laisse faire, trouver une
+« meilleure » coupure dans n'importe quelle série — y compris du pur bruit. C'est le piège du
+surajustement. Pour le mesurer, on génère une série **sans rupture** (même moyenne du début à la
+fin) et on lui applique le **même** modèle. On quantifie la concentration du postérieur sur `cp`
+par son **entropie** $H$ (en bits) : $H_{\max} = \log_2 N$ pour un postérieur plat (aucune idée sur
+la localisation), $H \to 0$ pour un postérieur piqué (localisation quasi certaine).
+
+Le résultat est instructif : une **vraie** rupture fait chuter l'entropie vers 0, mais même du
+pur bruit laisse l'entropie **nettement sous** le maximum — le modèle surajuste et « trouve » une
+coupure spurieuse. Distinguer les deux exige donc plus que la seule concentration : un **Bayes
+factor** (rapport de vraisemblance marginale) qui pénalise la flexibilité supplémentaire du modèle
+à rupture (rasoir d'Occam) — c'est l'objet d'[Infer-10](Infer-10-Model-Selection.ipynb).",,,,,,,,b8add33bdda021b5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,388b1f4b,code,fr,954d3cd5aef01bf6,"// Entropie (bits) du postérieur de cp sur la serie AVEC rupture
+double Hcp = 0.0, HmaxReel = Math.Log(N, 2);
+for (int i = 0; i < N; i++) { double p = cpPost[i]; if (p > 1e-12) Hcp -= p * Math.Log(p, 2); }
+
+// --- Controle : serie SANS rupture (moyenne constante) ---
+Random rng2 = new Random(7);
+int Nc = 100;
+double[] dataCtrl = new double[Nc];
+double muConst = 5.0;
+for (int i = 0; i < Nc; i++) dataCtrl[i] = muConst + Randn(rng2) * 1.5;
+
+Range tc = new Range(Nc);
+VariableArray<double> yc = Variable.Array<double>(tc);
+yc.ObservedValue = dataCtrl;
+Variable<int> cpC = Variable.DiscreteUniform(Nc);
+Variable<double> mc1 = Variable.GaussianFromMeanAndVariance(0.0, 100.0);
+Variable<double> mc2 = Variable.GaussianFromMeanAndVariance(0.0, 100.0);
+Variable<double> pc  = Variable.GammaFromMeanAndVariance(1.0, 1.0);
+using (var blockC = Variable.ForEach(tc)) {
+    using (Variable.If(blockC.Index <= cpC)) yc[tc] = Variable.GaussianFromMeanAndPrecision(mc1, pc);
+    using (Variable.IfNot(blockC.Index <= cpC)) yc[tc] = Variable.GaussianFromMeanAndPrecision(mc2, pc);
+}
+var ieC = new InferenceEngine(new ExpectationPropagation()) { ShowProgress = false, NumberOfIterations = 50 };
+Discrete cpCPost = ieC.Infer<Discrete>(cpC);
+
+double Hctrl = 0.0;
+for (int i = 0; i < Nc; i++) { double p = cpCPost[i]; if (p > 1e-12) Hctrl -= p * Math.Log(p, 2); }
+double HmaxCtrl = Math.Log(Nc, 2);
+
+Console.WriteLine($""Serie AVEC rupture   : H(cp) = {Hcp,6:F3} bits / {HmaxReel:F3}  =>  information = {HmaxReel - Hcp,5:F3} bits"");
+Console.WriteLine($""Controle SANS rupture : H(cp) = {Hctrl,6:F3} bits / {HmaxCtrl:F3}  =>  information = {HmaxCtrl - Hctrl,5:F3} bits"");
+Console.WriteLine();
+Console.WriteLine(""=> Vraie rupture : H -> 0 (localisation quasi certaine)."");
+Console.WriteLine(""=> Pur bruit    : H reste BAS mais non nul -- le modele SURAJUSTE une coupure spurieuse."");
+Console.WriteLine(""=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. Infer-8), pas la seule entropie."");",,,,,,,,954d3cd5aef01bf6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,d1a4682a,markdown,fr,d224e722f96c738a,"**Lecture.** La série **avec** rupture pousse l'entropie vers 0 (localisation quasi certaine),
+tandis que le **contrôle** (pur bruit) laisse une entropie faible mais non nulle (~0,7 bits) :
+le modèle, trop flexible, a « trouvé » une coupure spurieuse. C'est le piège classique des
+modèles de point de rupture.
+
+La leçon : la concentration du postérieur signale qu'une coupure est **possible**, mais seule la
+comparaison de modèles par **Bayes factor** (vraisemblance marginale) tranche entre « vraie
+rupture » et « surajustement ». Le Bayes factor pénalise la flexibilité supplémentaire du modèle
+à rupture (rasoir d'Occam) : sur la vraie série, le gain de vraisemblance compense largement la
+pénalité ; sur le bruit, non. C'est exactement le mécanisme étudié dans
+[Infer-10 (Sélection de modèles)](Infer-10-Model-Selection.ipynb).",,,,,,,,d224e722f96c738a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,9d45bf2f,markdown,fr,ebb961959a70d531,"## 5. Exercices
+
+Les trois exercices ci-dessous exploitent le même idiome `DiscreteUniform` + `If/IfNot` sur une
+plage. Ils sont laissés **à compléter** (stubbs sans erreur) — le notebook s'exécute de bout en
+bout même non rempli.",,,,,,,,ebb961959a70d531,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,ac15704c,markdown,fr,97884709920eb6ec,"### Exercice 1 — Deux points de rupture (trois régimes)
+
+Étendez le modèle à **deux** ruptures `cp1 < cp2` délimitant trois segments de moyennes
+`mu1, mu2, mu3`. Le postérieur devient joint sur `(cp1, cp2)`.
+
+**Indice :** générez une série à trois régimes, puis emboîtez les `If` — `If(t <= cp1)` pour le
+premier segment, sinon `If(t <= cp2)` pour le second, sinon le troisième.
+
+**Étape 1.** Générez `data3` avec `mu = 2` sur `[0, cp1]`, `mu = 5` sur `[cp1, cp2]`, `mu = 8`
+au-delà.
+**Étape 2.** Déclarez `cp1, cp2` (`DiscreteUniform`, avec `cp1 < cp2`), trois moyennes, et
+emboîtez les `If/IfNot`.
+**Étape 3.** Inférez `cp1Post` et `cp2Post` et vérifiez la récupération des deux positions.",,,,,,,,97884709920eb6ec,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,8bdae4b6,code,fr,8b70b357407a8f8c,"// Exercice 1 : deux points de rupture (a completer)
+// TODO etudiant : declarer cp1, cp2, mu1, mu2, mu3 et emboiter les If/IfNot sur les trois segments.
+Console.WriteLine(""Exercice 1 a completer : deux points de rupture (trois regimes)."");",,,,,,,,8b70b357407a8f8c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,d655f518,markdown,fr,e68dd6d031716d81,"### Exercice 2 — Un changement de variance (moyenne constante)
+
+Jusqu'ici la rupture portait sur la **moyenne**. Détectez une rupture de **variance** seule : la
+moyenne reste constante, mais la précision bascule de `prec1` (régime calme) à `prec2` (régime
+turbulent) à l'instant `cp`.
+
+**Indice :** la moyenne `mu` est commune aux deux segments ; seules les précisions diffèrent.
+Placez `mu` *en dehors* des `If`, et branchez la précision à l'intérieur.
+
+**Étape 1.** Générez une série de moyenne 5 constante, de variance 0.25 avant `cp` et 4.0 après.
+**Étape 2.** Adaptez le modèle (une moyenne commune, deux précisions branchées par `If/IfNot`).
+**Étape 3.** Le postérieur sur `cp` se concentre-t-il malgré l'absence de saut de moyenne ?",,,,,,,,e68dd6d031716d81,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,99527d63,code,fr,3a0f0276e08d66e7,"// Exercice 2 : changement de variance (a completer)
+// TODO etudiant : moyenne commune, deux precisions (prec1, prec2) branchees par If/IfNot.
+Console.WriteLine(""Exercice 2 a completer : detection d'un changement de variance."");",,,,,,,,3a0f0276e08d66e7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,8b80db48,markdown,fr,3c5b9a16e2d7cada,"### Exercice 3 — Robustesse au signal et à la taille
+
+Étudiez comment la **concentration** du postérieur sur `cp` dépend (a) de l'amplitude du saut
+`delta = mu2 − mu1` et (b) de la longueur `N` de la série.
+
+**Indice :** reprenez le modèle de la section 2 dans une boucle sur `delta ∈ {1, 2, 4}` et notez
+`H(cp)` à chaque fois.
+
+**Étape 1.** Pour chaque `delta`, générez une série et inférez `cpPost`.
+**Étape 2.** Calculez l'entropie `H(cp)` et l'information `Hmax − H`.
+**Étape 3.** Observez : un signal faible ou une courte série élargit le postérieur ; un signal
+fort ou une longue série le resserre. Quantifiez la transition.",,,,,,,,3c5b9a16e2d7cada,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,8fdbb0ca,code,fr,2393154e51b45c31,"// Exercice 3 : robustesse au signal et a N (a completer)
+// TODO etudiant : boucler sur delta dans {1, 2, 4}, mesurer H(cp) a chaque fois.
+Console.WriteLine(""Exercice 3 a completer : robustesse du posterieur au signal et a la taille."");",,,,,,,,2393154e51b45c31,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb,40705fce,markdown,fr,1c871c2023cd3155,"## 6. Conclusion
+
+Le **point de rupture** complète la famille des séquences temporelles du corpus :
+
+| Notebook | État caché | Inférence |
+|----------|-----------|-----------|
+| [Infer-14](Infer-14-Sequences.ipynb) (HMM) | discret, **récurrent** (un par pas) | postérieur sur la trajectoire d'états |
+| [Infer-17](Infer-17-Kalman-Filter.ipynb) (Kalman) | continu, **récurrent** | postérieur gaussien pas-à-pas |
+| **Infer-18 (change-point)** | **entier structurel unique** | postérieur `Discrete` sur la localisation |
+
+Le trait distinctif : l'inconnue est un **indice structurel** couplé à toute la plage temporelle,
+et EP retourne sa distribution discrète — un usage du `Variable.If(t.Item <= cp)` sur une plage
+que n'exploite aucun autre notebook de l'arc. C'est aussi le chaînon naturel vers
+[Infer-5 (Causal)](Infer-5-Causal-Inference.ipynb) : un point de rupture est un changement de
+**mécanisme générateur**, exactement ce que l'inférence causale cherche à détecter (rupture dans
+$p(Y \mid do(X))$), et vers la sélection de modèles ([Infer-10](Infer-10-Model-Selection.ipynb)),
+où la concentration du postérieur joue le rôle d'un Bayes factor.
+
+**Pour aller plus loin.** Plusieurs ruptures (exercice 1) ; ruptures de variance (exercice 2) ;
+nombre de ruptures inconnu (processus de Dirichlet — non natif en Infer.NET, voir le versant PyMC) ;
+ou la détection en ligne (filtering) plutôt qu'off-line.",,,,,,,,1c871c2023cd3155,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,62712df6,markdown,fr,adc2fa1fe3f1c2a6,"# Infer-19 — Analyse de survie / fiabilite bayesienne : inferer le temps jusqu'a un evenement
+
+> **Corpus bayesien Infer.NET.** Ce notebook (19e du corpus) ouvre la famille des
+> **modeles de duree** (time-to-event) : la quantite centrale n'est plus une moyenne ou un compte,
+> mais une **fonction de survie** `S(t) = P(T > t)` — probabilite qu'un composant, un patient ou
+> un client survive au-dela de l'instant `t`. Il complete la famille « sequences dans le temps »
+> ([Infer-14 HMM](Infer-14-Sequences.ipynb), [Infer-17 Kalman](Infer-17-Kalman-Filter.ipynb),
+> [Infer-18 Change-Point](Infer-18-Change-Point.ipynb)) par le cas ou l'observation n'est pas un
+> etat recurrent mais un **delai unique** avant evenement.
+
+**Plan.** (1) Pourquoi un modele dedie aux durees. (2) Le modele exponentiel (cas conjugue).
+(3) Fonction de survie predictive en forme fermee. (4) Le modele de Weibull via une astuce de
+transformee. (5) Selection de la forme `k`. (6) Trois exercices (censure, regression AFT,
+comparaison de modeles).",,,,,,,,adc2fa1fe3f1c2a6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,25f729d4,markdown,fr,6fe9b23588ede827,"## 1. Motivation : pourquoi pas une gaussienne ?
+
+Un ingenieur fiabilite observe les **durees de vie** (en heures) de `N` composants identiques
+soumis a un test. La grandeur qui l'interesse est : *« quelle probabilite qu'un composant
+fonctionne encore apres 1500 h ? »* — c'est-a-dire `S(1500) = P(T > 1500)`.
+
+Modeliser `T` par une gaussienne est inadequat pour trois raisons :
+
+1. **Le temps est positif.** Une gaussienne attribue une masse non nulle aux durees negatives.
+2. **La distribution est asymetrique a droite.** Quelques composants vivent tres longtemps
+   (longue queue), la moyenne depasse la mediane.
+3. **Ce qui importe est la queue**, pas le centre : `S(t)` dans la region ou peu de composants
+   sont encore en vie.
+
+Deux lois canoniques repondent a ces contraintes :
+
+- **Exponentielle** `T ~ Exp(lambda)` : taux de defaillance **constant** dans le temps
+  (memoire, usure nulle). Un seul parametre `lambda > 0` (le taux).
+- **Weibull** `T ~ Weibull(k, eta)` : taux de defaillance qui **varie** — `k < 1` (mortalite
+  infantile, le composant se rodit), `k = 1` (retombe sur l'exponentielle), `k > 1` (usure,
+  le risque croit avec l'age).
+
+Le defi d'inference : estimer `lambda`, ou le couple `(k, eta)`, a partir de durees observees,
+puis **propager l'incertitude** jusqu'a `S(t)` — avec un intervalle de credibilite, pas un
+chiffre unique. C'est exactement ce que le calcul bayesien via Infer.NET fournit.",,,,,,,,6fe9b23588ede827,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,6cafeb7a,code,fr,cea94f4aab2802fa,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+// restore Infer.NET -- isole dans sa propre cellule (convention de la serie)",,,,,,,,cea94f4aab2802fa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,cf8be122,markdown,fr,67677804189aad66,"Configuration des espaces de noms Infer.NET. On retrouve le moteur **EP** (Expectation
+Propagation) et les helpers. On ajoute une graine fixee pour que les durees synthetiques soient
+reproductibles (le test porte sur l'inference, pas sur le tirage).",,,,,,,,67677804189aad66,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,444c7d04,code,fr,0fa433a5e5dc3560,"using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Range = Microsoft.ML.Probabilistic.Models.Range;   // desambiguise vs System.Range
+using System;
+using System.Linq;
+
+var rand = new Random(42);
+
+// Helper : tirage uniforme et exponentiel reproductibles.
+double Uniform() => rand.NextDouble();                                   // U ~ Uniform(0,1)
+double SampleExponential(double rate) => -Math.Log(Uniform()) / rate;     // T ~ Exp(rate)
+double SampleWeibull(double shape, double scale)                         // T ~ Weibull(k, eta)
+    => scale * Math.Pow(-Math.Log(Uniform()), 1.0 / shape);
+
+Console.WriteLine(""Infer.NET charge. Helpers Uniform / SampleExponential / SampleWeibull definis."");",,,,,,,,0fa433a5e5dc3560,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,3e1ae6ae,markdown,fr,395f1362bfdfd416,"## 2. Un jeu de donnees synthetique (verite connue)
+
+On simule les durees de vie de `N = 60` composants dont le **vrai** taux de defaillance est
+`lambda_true = 1/1000` (duree moyenne caracteristique 1000 h). Connaissant la verite, on pourra
+verifier que le postieur la recouvre. On garde egalement un jeu **Weibull** avec usure
+(`k = 1.8`) pour la section 4.",,,,,,,,395f1362bfdfd416,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,1dc34615,code,fr,1b05af086c6751a3,"const int N = 60;
+const double lambdaTrue = 1.0 / 1000.0;   // duree moyenne 1000 h
+
+double[] lifetimesExp = Enumerable.Range(0, N)
+    .Select(_ => SampleExponential(lambdaTrue)).ToArray();
+
+// Second jeu : Weibull avec usure (k=1.8), meme duree caracteristique (eta=1000).
+const double kTrue = 1.8, etaTrue = 1000.0;
+double[] lifetimesWei = Enumerable.Range(0, N)
+    .Select(_ => SampleWeibull(kTrue, etaTrue)).ToArray();
+
+Console.WriteLine($""Durees Exponentiel : N={N}, moyenne observee={lifetimesExp.Average():F1} h (attendu ~1000)"");
+Console.WriteLine($""Durees Weibull      : N={N}, moyenne observee={lifetimesWei.Average():F1} h (k=1.8 -> queue plus courte)"");",,,,,,,,1b05af086c6751a3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,d1949cf8,markdown,fr,e2a320edb32c4535,"## 3. Le modele exponentiel : le cas conjugue
+
+Le modele le plus simple : `T_i ~ Exp(lambda)` pour chaque composant, avec un *a priori*
+**Gamma** sur le taux `lambda`. Le prior Gamma est **conjugue** a la vraisemblance exponentielle :
+EP renvoie donc un postieur exact, lui-meme Gamma.
+
+**Lien de conjugaison.** Si `lambda ~ Gamma(a0, b0)` (parametre forme `a0`, parametre **taux**
+`b0`, donc moyenne `a0/b0`) et `T_i ~ Exp(lambda)` pour `i = 1..N`, alors le postieur est
+`Gamma(a0 + N, b0 + somme(T_i))`. On retrouve ainsi, a la main, ce que le moteur calcule :
+chaque observation ajoute `1` a la forme et sa duree `T_i` au taux. Le prior faible
+`Gamma(0.001, 0.001)` laisse les donnees parler.",,,,,,,,e2a320edb32c4535,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,1722c159,code,fr,94f898a8ebd33168,"// Modele exponentiel conjugue sur le jeu de durees exponentielles.
+Range item = new Range(N);
+var lambda = Variable.GammaFromShapeAndRate(0.001, 0.001).Named(""lambda"");   // prior vague sur le taux
+var T = Variable.Array<double>(item).Named(""T"");
+T[item] = Variable.GammaFromShapeAndRate(1.0, lambda).ForEach(item);   // shape=1 => Exponentielle(lambda)
+T.ObservedValue = lifetimesExp;
+
+var engine = new InferenceEngine { Algorithm = new ExpectationPropagation() };
+Gamma lambdaPost = engine.Infer<Gamma>(lambda);
+
+Console.WriteLine(""=== Posterieur du taux lambda (modele exponentiel) ==="");
+Console.WriteLine($""  Forme A   = {lambdaPost.Shape:F3}"");
+Console.WriteLine($""  Taux  B   = {lambdaPost.Rate:F3}"");
+Console.WriteLine($""  Moyenne   = {lambdaPost.GetMean():F6}  (vrai lambda = {lambdaTrue:F6})"");
+Console.WriteLine($""  Ecart-type= {Math.Sqrt(lambdaPost.GetVariance()):F6}"");",,,,,,,,94f898a8ebd33168,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,7ca37573,markdown,fr,107719c40b3ed48d,"### Lecture du postérieur : la conjugaison se vérifie chiffres en main
+
+Le postérieur `Gamma(A, B)` renvoyé par EP coincide avec la formule de conjugaison :
+
+- `A = 60,001 = 0,001 + N` — la forme est l'a priori plus le nombre d'observations, **au centieme pres**.
+- `B = 75 774,77 = 0,001 + Σ T_i` — le taux est l'a priori plus la somme des durees
+  (or `Σ T_i / 60 = 1262,9 h`, exactement la moyenne observee).
+
+La moyenne postérieure `A/B = 7,92e-4` est **identique a l'estimateur du maximum de vraisemblance**
+`1 / moyenne(T_i)`, parce que le prior `Gamma(0,001 ; 0,001)` est negligible devant 60 donnees. Elle
+est legerement inferieure au vrai `lambda = 1e-3` non par biais du modele, mais parce que **cet
+echantillon** a tire une moyenne de 1262,9 h (queue haute) au lieu de 1000 : avec `N = 60`,
+l'intervalle de confiance sur la moyenne est large, et le postérieur le reflete fidelement
+(ecart-type `~1,0e-4`, soit un coefficient de variation de 13 %). C'est precisement l'interet du
+bayesien : on recupere non un chiffre, mais une **distribution** dont on propagera l'incertitude
+jusqu'a la fonction de survie.",,,,,,,,107719c40b3ed48d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,0b9b9f43,markdown,fr,b907b561fcc38c21,"## 4. Fonction de survie predictive : une forme fermee
+
+La question de l'ingenieur — *« probabilite de survivre au-dela de 1500 h »* — se traduit par
+la **survie predictive** : on moyenne la survie `exp(-lambda * t)` sur le postieur de `lambda`.
+
+**Forme fermee.** Si `lambda ~ Gamma(A, B)`, alors par transformee de Laplace :
+
+```
+S(t) = E_lambda[ exp(-lambda * t) ] = ( B / (B + t) )^A
+```
+
+Pas besoin d'echantillonner : pour chaque `t`, on branche les moments du postieur Gamma et on
+obtient `S(t)` **exactement**, avec son incertitude qui decroit quand le postieur se concentre.
+On trace `S(t)` sur `t ∈ [0, 3000]` et on le compare a la courbe empirique (Kaplan-Meier simplifiee,
+ici sans censure : fraction d'observations superieures a `t`).",,,,,,,,b907b561fcc38c21,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,3358bca7,code,fr,0c2a9e0464ea9a8a,"// Survie predictive (forme fermee) + comparaison empirique.
+double A = lambdaPost.Shape, B = lambdaPost.Rate;
+double Sbayes(double t) => Math.Pow(B / (B + t), A);
+
+// Courbe empirique : fraction de durees > t.
+double Semp(double t, double[] data) => data.Count(d => d > t) / (double)data.Length;
+
+Console.WriteLine(""=== Fonction de survie S(t) : bayesienne vs empirique ==="");
+Console.WriteLine($""{""t (h)"",8}  {""S_bayes"",8}  {""S_empir"",8}"");
+foreach (var t in new[] { 0.0, 250, 500, 1000, 1500, 2000, 3000 })
+    Console.WriteLine($""{t,8:F0}  {Sbayes(t),8:F3}  {Semp(t, lifetimesExp),8:F3}"");
+
+// Trace ASCII leger de S(t) bayesienne.
+Console.WriteLine(""\nS(t) bayesienne (modele exponentiel) :"");
+const int W = 50;
+foreach (var t in Enumerable.Range(0, W + 1).Select(j => j * 3000.0 / W))
+{
+    int bar = (int)Math.Round(Sbayes(t) * 40);
+    Console.WriteLine($""{t,6:F0}h |{new string('#', bar)}"");
+}",,,,,,,,0c2a9e0464ea9a8a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,d5f897c1,markdown,fr,149f3aaf879e6228,"### Lecture : la question de l'ingenieur a maintenant une reponse quantifiee
+
+La question *« probabilite qu'un composant survive au-dela de 1500 h »* admet la reponse
+`S(1500) ≈ 0,31` : environ un composant sur trois est encore en vie a 1500 h. Deux points :
+
+- **Accord bayesien / empirique.** Les deux courbes se suivent (ecart maximal ~0,08 a `t = 250`)
+  mais de nature differente : la bayesienne est **parametrique et lisse** (elle croit au modele
+  exponentiel et projette sa forme), l'empirique est **en escalier** (fraction brute des durees
+  superieures a `t`). Leur proximite valide que l'exponentielle decrit bien ce jeu.
+- **Forme fermee exacte.** `S(t) = (B/(B+t))^A` n'est pas une approximation Monte-Carlo : c'est
+  la transformee de Laplace du postieur Gamma, calculee en un seul coup. On peut donc donner un
+  intervalle de credibilite sur `S(t)` en tirant des `lambda` du postieur — l'incertitude sur le
+  taux se propage gratuitement jusqu'a la queue, la ou l'enjeu fiabilite se trouve.",,,,,,,,149f3aaf879e6228,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,e1789688,markdown,fr,b1aa0534fa033117,"## 5. Le modele de Weibull : une astuce de transformee
+
+L'exponentielle suppose un taux **constant** (ni rodage, ni usure). La loi de **Weibull**
+generalise : `T ~ Weibull(k, eta)` avec fonction de survie `S(t) = exp(-(t/eta)^k)`.
+
+Inferer directement la **forme** `k` par EP est delicat (la vraisemblance de Weibull n'est
+conjuguee a aucun prior usuel). Mais si l'on fixe `k`, une **transformee** ramene le probleme au
+cas conjugue :
+
+```
+U_i = T_i^k  ==>  U_i ~ Exp(rate = eta^{-k})
+```
+
+On infere donc le taux transforme `r = eta^{-k}` avec un prior Gamma (conjugue), puis on remonte
+a `eta = r^{-1/k}`. La survie predictive devient `S(t) = (B / (B + t^k))^A` (meme forme fermee,
+avec `t` remplace par `t^k`). La section suivante choisira le meilleur `k` par balayage.",,,,,,,,b1aa0534fa033117,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,d77b4a83,code,fr,932e8c444fcc580c,"// Weibull a forme k fixee : transformee U = T^k ~ Exp(r), r = eta^{-k}.
+double InferWeibullRate(double k, double[] data, out Gamma rPost)
+{
+    Range it = new Range(data.Length);
+    var r = Variable.GammaFromShapeAndRate(0.001, 0.001).Named(""r_"" + k.ToString(""F1""));
+    var U = Variable.Array<double>(it).Named(""U_"" + k.ToString(""F1""));
+    U[it] = Variable.GammaFromShapeAndRate(1.0, r).ForEach(it);   // shape=1 => Exponentielle(r)
+    U.ObservedValue = data.Select(t => Math.Pow(t, k)).ToArray();
+    var eng = new InferenceEngine { Algorithm = new ExpectationPropagation() };
+    rPost = eng.Infer<Gamma>(r);
+    return rPost.GetMean();
+}
+
+double kFixed = 1.8;   // (on retrouvera ce k par balayage a la section 6)
+double rMean = InferWeibullRate(kFixed, lifetimesWei, out Gamma rPost);
+double etaMean = Math.Pow(rMean, -1.0 / kFixed);
+
+Console.WriteLine(""=== Modele Weibull (k=1.8 fixe) sur le jeu Weibull ==="");
+Console.WriteLine($""  r = eta^-k      = {rMean:E3}"");
+Console.WriteLine($""  eta (back-out)  = {etaMean:F1} h  (vrai eta = {etaTrue:F1})"");
+Console.WriteLine($""  Survie a 1000 h = {Math.Pow(rPost.Rate/(rPost.Rate + Math.Pow(1000,kFixed)), rPost.Shape):F3}"");",,,,,,,,932e8c444fcc580c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,2589f066,markdown,fr,de743203833a250c,"### Lecture : la transformee ramene Weibull au cas conjugue
+
+L'astuce `U = T^k ~ Exp(rate = eta^{-k})` fonctionne : EP infere un postérieur Gamma sur `r` sans
+aucune fragilite (pas d'inference directe sur la forme). On remonte `eta = r^{-1/k} ≈ 1187 h`,
+a comparer au vrai `eta = 1000 h`. La surestimation vient, comme pour l'exponentiel, de
+l'echantillon : sa moyenne (1041 h) est un peu haute, et avec `k = 1,8` on a
+`moyenne = eta · Γ(1 + 1/k) ≈ eta · 0,89`, d'ou un `eta` implique par les donnees autour de 1170 h.
+
+La survie estimee `S(1000) ≈ 0,48` (contre `e^{-1} ≈ 0,37` pour le vrai `Weibull(1,8 ; 1000)`)
+reflete cette meme surestimation de `eta`. Ce n'est pas un defaut de la methode mais du bruit
+d'echantillonnage a `N = 60` ; l'apport pedagogique est ailleurs : **toute la richesse de Weibull
+(usure, rodage) est accessible sans payer le cout d'une inference EP sur la forme**, des lors que
+l'on fixe `k` (ou qu'on le choisit par balayage, section suivante).",,,,,,,,de743203833a250c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,876c6bfc,markdown,fr,450ce7f6c4f18e63,"## 6. Selection de la forme k : balayage par log-vraisemblance predictive
+
+Comment choisir `k` sans payer le cout d'une inference EP sur la forme ? On **balaye** `k` sur
+une grille et, pour chaque `k`, on calcule la **log-vraisemblance predictive** (leave-one-out
+approchee) du jeu observe : pour chaque duree `T_i`, la densite Weibull evaluee avec le postieur
+entraene sur les autres. Le `k` qui maximise cette score est le meilleur compromis biais/variance.
+
+Sur le jeu exponentiel (taux constant), `k ≈ 1` doit gagner ; sur le jeu Weibull `k = 1.8`,
+c'est `k ≈ 1.8` qui doit gagner. C'est un test de coherence interne.",,,,,,,,450ce7f6c4f18e63,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,71468adb,code,fr,32abd54a42700315,"// Balayage de k : pour chaque k, log-vraisemblance predictive (LOO approchee).
+double ShapeScore(double k, double[] data)
+{
+    // Posterieur du taux transforme r sur TOUT le jeu, densite Weibull evaluee en chaque point.
+    // (approximation LOO : le postieur est peu sensible a un seul point quand N est grand.)
+    double rMean = InferWeibullRate(k, data, out Gamma rPost);
+    double A_ = rPost.Shape, B_ = rPost.Rate;
+    // Densite de T_i sous Weibull(k, eta) avec eta = r^{-1/k}, r ~ Gamma(A,B).
+    // On evalue la log-densite marginale approchee a la moyenne post.: r_hat = A/B.
+    double rHat = A_ / B_;
+    double eta = Math.Pow(rHat, -1.0 / k);
+    double lp = 0.0;
+    foreach (var t in data)
+    {
+        double z = t / eta;
+        lp += Math.Log(k) - k * Math.Log(eta) + (k - 1) * Math.Log(t) - Math.Pow(z, k);
+    }
+    return lp;
+}
+
+Console.WriteLine(""=== Selection de la forme k (log-vraisemblance predictive) ==="");
+Console.WriteLine($""{""k"",5}  {""score Exp"",12}  {""score Weibull"",14}"");
+var ks = new[] { 0.8, 1.0, 1.2, 1.5, 1.8, 2.0, 2.5 };
+double bestExp = double.NegativeInfinity, bestWei = double.NegativeInfinity;
+double kExp = 1, kWei = 1;
+foreach (var k in ks)
+{
+    double se = ShapeScore(k, lifetimesExp);
+    double sw = ShapeScore(k, lifetimesWei);
+    Console.WriteLine($""{k,5:F1}  {se,12:F1}  {sw,14:F1}"");
+    if (se > bestExp) { bestExp = se; kExp = k; }
+    if (sw > bestWei) { bestWei = sw; kWei = k; }
+}
+Console.WriteLine($""\n  k* (jeu exponentiel) = {kExp:F1}  (attendu ~1.0)"");
+Console.WriteLine($""  k* (jeu Weibull)     = {kWei:F1}  (attendu ~1.8)"");",,,,,,,,32abd54a42700315,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,bb31ff41,markdown,fr,d7745c37470d9faf,"### Lecture : le balayage recupere la vraie forme et distingue les deux regimes
+
+Le test de coherence reussit sur les deux jeux :
+
+- **Jeu Weibull** (`k = 1,8`) : le score est **minimal en `k = 1,8`** (`-466,7`), c'est-a-dire
+  exactement la valeur vraie. Le pic est net (`k = 1,5` et `k = 2,0` sont deja moins bons).
+  La methode retrouve la signature d'usure.
+- **Jeu exponentiel** (`k = 1`) : le meilleur est `k = 1,2` (`-486,8`), mais `k = 1,0` (`-488,5`)
+  est a moins de 2 unites : **ex aequo dans le bruit d'echantillonnage**. Leger tilt vers `1,2`
+  parce que cet echantillon exponentiel n'etait pas un exponentiel parfait. On conclut donc
+  raisonnablement `k ≈ 1` (taux constant), ce qui est la bonne reponse.
+
+Cette approche par **grille** evite l'inference EP directe sur la forme (notoirement instable) au
+prix de quelques compilations de modele (7 ici, chacune instantanee). C'est le compromis
+operationnel : robustesse contre temps de calcul, dans l'esprit de la regle « realiser le moteur,
+pas le contourner ».",,,,,,,,d7745c37470d9faf,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,bf264f67,markdown,fr,0ecf83d60d8274b7,"## 7. Exercices
+
+Les trois exercices ci-dessous etendent le modele de duree. Ils sont laisses **a completer**
+(stubs sans erreur) — le notebook s'execute de bout en bout meme non rempli.",,,,,,,,0ecf83d60d8274b7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,a19660d6,markdown,fr,189e07a9d3c9f547,"### Exercice 1 — Censure a droite (donnees tronquees)
+
+En fiabilite reelle, beaucoup de composants **survivent** a la fin du test : on n'observe pas
+leur duree exacte `T_i`, seulement qu'elle depasse la duree du test `c_i`. C'est la **censure a
+droite**. La contribution de vraisemblance d'un point censure n'est pas la densite `f(c_i)` mais
+la survie `S(c_i) = exp(-lambda * c_i)`.
+
+**Indice :** separez indices observes / censures. Pour les observes, branchez `T_i ~ Exp(lambda)`
+comme en section 3. Pour les censures, ajoutez un facteur de survie : en Infer.NET on peut
+exprimer `exp(-lambda * c_i)` comme la probabilite qu'une variable latente exponentielle de taux
+`lambda` soit superieure a `c_i` (via `Variable.ConstrainPositive` sur `c_i - T_i`, ou en
+modelisant un indicateur d'evenement). Comparez le postieur obtenu avec/sans censure.",,,,,,,,189e07a9d3c9f547,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,668036ef,code,fr,4b3ddf5073cc1497,"// Exercice 1 : censure a droite (a completer)
+// TODO etudiant : repartir indices observes/censures, ajouter le facteur S(c_i) pour les censures.
+Console.WriteLine(""Exercice 1 a completer : modele exponentiel avec censure a droite."");",,,,,,,,4b3ddf5073cc1497,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,a84e4a09,markdown,fr,435a0b77025e0351,"### Exercice 2 — Regression de temps accelere (AFT)
+
+La duree depend d'une covariable (temperature, contrainte). Modele **AFT** (Accelerated Failure
+Time) : le taux devient specifique au composant, `lambda_i = lambda0 * exp(beta * x_i)` ou `x_i`
+est la covariable centree et `beta` le coefficient a inferer.
+
+**Indice :** declarez `lambda0 ~ Gamma` et `beta ~ Gaussian(0, grande)`, puis bouclez sur les
+composants avec `Variable.Exponential(lambda0 * Variable.Exp(beta * x[i]))`. Inferer `beta`
+donne l'effet de la contrainte sur la duree de vie (signe et amplitude). Attention : le produit
+dans le taux rend le postieur non conjugue — EP le traite quand meme (approximation).",,,,,,,,435a0b77025e0351,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,e2014207,code,fr,d7ac63eafbc70635,"// Exercice 2 : regression AFT (a completer)
+// TODO etudiant : lambda_i = lambda0 * exp(beta * x_i), inferer beta.
+Console.WriteLine(""Exercice 2 a completer : regression de temps accelere (AFT)."");",,,,,,,,d7ac63eafbc70635,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,c11b94eb,markdown,fr,5d286e7637a4df2d,"### Exercice 3 — Exponentiel vs Weibull : facteur de Bayes
+
+Sur un meme jeu de durees, comparer le modele exponentiel (`k = 1`) au modele Weibull (`k` libre)
+via un **facteur de Bayes** (rapport des vraisemblances marginales). Le verdict depend de la
+taille `N` et du vrai `k`.
+
+**Indice :** la section 6 calcule deja un score par `k`. Generalisez-le en vraisemblance
+marginale (intégrez sur le postieur de `r`, pas juste evaluez a la moyenne), puis formez le
+rapport `BF = p(D | Weibull) / p(D | exponentiel)`. A partir de quel `N` le Weibull `k = 1.8`
+est-il prefere de facon decisive (`log BF > 5`) ?",,,,,,,,5d286e7637a4df2d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,8f861db9,code,fr,51ef2a89a050be0f,"// Exercice 3 : facteur de Bayes exponentiel vs Weibull (a completer)
+// TODO etudiant : vraisemblance marginale par k, rapport BF, seuil en N.
+Console.WriteLine(""Exercice 3 a completer : facteur de Bayes exponentiel vs Weibull."");",,,,,,,,51ef2a89a050be0f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb,2c52015b,markdown,fr,07ee4d5edd3ecfd9,"## 8. Conclusion
+
+L'analyse de survie complete la famille des modeles temporels du corpus Infer :
+
+| Notebook | Nature du temps | Quantite inferee |
+|----------|-----------------|------------------|
+| [Infer-14](Infer-14-Sequences.ipynb) (HMM) | discret, recurrent | trajectoire d'etats caches |
+| [Infer-17](Infer-17-Kalman-Filter.ipynb) (Kalman) | continu, recurrent | etat filtre pas-a-pas |
+| [Infer-18](Infer-18-Change-Point.ipynb) (Change-Point) | continu, a rupture | instant d'un changement de regime |
+| **Infer-19 (Survie)** | **continu, duree unique** | **fonction de survie S(t)** |
+
+**A retenir.**
+
+- Le temps jusqu'a un evenement se modelise par une loi **positive asymetrique** (exponentielle,
+  Weibull), pas une gaussienne — ce qui compte est la queue, i.e. `S(t)`.
+- Le cas **exponentiel** est conjugue : prior Gamma sur le taux, postieur Gamma exact. La survie
+  predictive se ramene a une **forme fermée** `(B/(B+t))^A` (transformee de Laplace du Gamma).
+- Le cas **Weibull** se ramene a l'exponentiel par **transformee** `U = T^k` des que `k` est fixe,
+  evitant la fragilite de EP sur la forme. On choisit `k` par balayage (log-vraisemblance
+  predictive), non par inference directe.
+- La censure, la regression AFT et la selection par facteur de Bayes sont les prolongements
+  naturels (exercices).
+
+**Pour aller plus loin.** La censure a gauche/par intervalle, les modeles a risques concurrents
+(competing risks) et les modeles de fragilite partagee (frailty, analogue hierarchique de
+[Infer-12](Infer-12-Modeles-Hierarchiques.ipynb) applique a la survie) sont les extensions
+classiques au-dela de ce notebook.
+
+---
+
+### References
+
+- Gelman A. et al., *Bayesian Data Analysis* (3e ed.), chap. « Survival models ».
+- Lawless J. F., *Statistical Models and Methods for Lifetime Data* — reference pour Weibull/AFT.
+- Infer.NET documentation : `Variable.GammaFromShapeAndRate` (prior sur le taux ; shape=1 donne
+  l'exponentielle), `Variable.Weibull`.
+- Relation a la serie : [Infer-12](Infer-12-Modeles-Hierarchiques.ipynb) (modeles hierarchiques),
+  [Infer-18](Infer-18-Change-Point.ipynb) (rupture — ou le taux change brusquement).
+",,,,,,,,07ee4d5edd3ecfd9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,0b71b238,markdown,fr,603b5853efe461c8,"# Infer-2-Gaussian-Mixtures : Distributions Gaussiennes et Melanges
+
+**Série** : Programmation Probabiliste avec Infer.NET (2/20)  
+**Duree estimee** : 50 minutes  
+**Prerequis** : Infer-1-Setup
+
+---
+
+## Objectifs
+
+- Maitriser les distributions Gaussienne et Gamma
+- Comprendre la notion de priors conjugues
+- Implementer l'apprentissage de paramètres
+- Construire des modèles de melange de Gaussiennes
+- Utiliser `Variable.Switch` pour les modèles a composantes
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-1-Setup](Infer-1-Setup.ipynb) | [Infer-3-Factor-Graphs](Infer-3-Factor-Graphs.ipynb) |
+
+---",,,,,,,,603b5853efe461c8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,371477d5,markdown,fr,1785a2755d1c4363,"## 1. Configuration
+
+Comme pour chaque notebook de cette série, nous commencons par charger les packages Infer.NET et importer les espaces de noms necessaires. Cette étape standardisee garantit que tous les exemples sont reproductibles et que les distributions, algorithmes et outils de modelisation sont disponibles.",,,,,,,,1785a2755d1c4363,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,352e055d,code,fr,2870aa26008d04e7,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+#load ""FactorGraphHelper.cs""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,2870aa26008d04e7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,b3e128fc,markdown,fr,5b6685d5397d23b7,"## 2. Scenario : Le Cycliste
+
+### Contexte
+
+Vous vous rendez au travail a velo chaque jour. Votre temps de trajet varie :
+- Certains jours, le trajet est rapide (peu de trafic)
+- D'autres jours, il est plus lent (embouteillages, meteo)
+
+### Objectifs
+
+1. **Apprendre** la distribution du temps de trajet a partir d'observations
+2. **Predire** le temps de trajet de demain
+3. **Calculer** des probabilites (ex: P(trajet < 18 min))
+
+### Modelisation
+
+Nous modelerons le temps de trajet avec une distribution **Gaussienne** :
+
+$$\text{temps} \sim \mathcal{N}(\mu, \tau^{-1})$$
+
+- $\mu$ : moyenne (temps moyen de trajet)
+- $\tau$ : precision (inverse de la variance)",,,,,,,,5b6685d5397d23b7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,dfe88a85,markdown,fr,e819c6a7e90e0f77,"## 3. Distributions Conjuguees
+
+### Theorie
+
+En inference bayesienne, une distribution **a priori conjuguee** permet une mise a jour analytique simple :
+
+| Vraisemblance | Prior Conjugue | Posterieur |
+|---------------|----------------|------------|
+| Gaussian (moyenne) | Gaussian | Gaussian |
+| Gaussian (precision) | Gamma | Gamma |
+| Bernoulli | Beta | Beta |
+| Discrete | Dirichlet | Dirichlet |
+
+### Pour notre modèle cycliste
+
+- **Moyenne** : prior Gaussian vague $\mu \sim \mathcal{N}(15, 100)$
+- **Precision** : prior Gamma $\tau \sim \text{Gamma}(2, 0.5)$",,,,,,,,e819c6a7e90e0f77,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,e797a9b2,markdown,fr,80e10235938cdc16,"## 4. Modèle Simple : Une Gaussienne
+
+Nous allons maintenant construire notre premier modèle Infer.NET pour le scenario du cycliste. Ce modèle simple utilise une seule Gaussienne pour capturer la distribution des temps de trajet.",,,,,,,,80e10235938cdc16,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,3hvxpaexqiw,markdown,fr,fdce0decd7e6be7f,"### Définition des priors
+
+Le code suivant definit deux variables aleatoires avec leurs distributions **a priori** :
+
+1. **`dureeMoyenne`** : Prior Gaussien centre sur 15 minutes avec une **precision tres faible** (0.01), ce qui correspond a une variance de 100. Ce prior ""vague"" exprime notre incertitude initiale sur la vraie moyenne.
+
+2. **`bruitTrafic`** : Prior Gamma sur la **precision** (inverse de la variance). Une distribution Gamma est toujours positive, ce qui convient pour une precision. Les paramètres `shape=2, scale=0.5` donnent une esperance de 1 et permettent un large eventail de valeurs.
+
+> **Pourquoi precision plutot que variance ?** Infer.NET utilise la parametrisation en precision car elle simplifie les formules de mise a jour bayesienne pour les Gaussiennes conjuguees.",,,,,,,,fdce0decd7e6be7f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,e0276196,code,fr,d62cc19e47510710,"// Definition du modele
+// Prior sur la moyenne : Gaussian vague centree sur 15 min
+Variable<double> dureeMoyenne = Variable.GaussianFromMeanAndPrecision(15, 0.01);  // precision = 0.01 -> variance = 100
+
+// Prior sur la precision (inverse de la variance)
+Variable<double> bruitTrafic = Variable.GammaFromShapeAndScale(2, 0.5);
+Console.WriteLine(""Modele Gaussien cycliste defini."");
+",,,,,,,,d62cc19e47510710,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,as59jhqh7th,markdown,fr,9c3b65913589e079,"### Observations
+
+Nous definissons maintenant trois variables aleatoires représentant les temps de trajet observes. Chaque trajet suit une distribution Gaussienne avec la **même** moyenne et precision (paramètres partages).
+
+La méthode `ObservedValue` fixe les valeurs observées. Cela ""ancre"" le modèle aux données et permet a l'inference de mettre a jour les posterieurs en consequence.
+
+| Jour | Temps observe |
+|------|---------------|
+| Lundi | 13 min |
+| Mardi | 17 min |
+| Mercredi | 16 min |
+
+**Moyenne empirique** : (13 + 17 + 16) / 3 = 15.33 min",,,,,,,,9c3b65913589e079,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,3764dcc3,code,fr,7bc0202d9a539d4f,"// Definition des temps de trajet observes
+Variable<double> dureeLundi = Variable.GaussianFromMeanAndPrecision(dureeMoyenne, bruitTrafic);
+Variable<double> dureeMardi = Variable.GaussianFromMeanAndPrecision(dureeMoyenne, bruitTrafic);
+Variable<double> dureeMercredi = Variable.GaussianFromMeanAndPrecision(dureeMoyenne, bruitTrafic);
+
+// Observations
+dureeLundi.ObservedValue = 13;
+dureeMardi.ObservedValue = 17;
+dureeMercredi.ObservedValue = 16;
+Console.WriteLine(""Donnees observees initialisees."");
+",,,,,,,,7bc0202d9a539d4f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,evghdc4xqho,markdown,fr,0df55a9a839980ad,"### Inference des posterieurs
+
+L'étape d'inference utilise `InferenceEngine` pour calculer les distributions **a posteriori** des paramètres inconnus (`dureeMoyenne` et `bruitTrafic`) etant données les observations.
+
+**Ce que fait l'algorithme** :
+1. Combine les priors avec la vraisemblance des données
+2. Propage les messages dans le graphe de facteurs (Expectation Propagation)
+3. Itere jusqu'a convergence
+4. Retourne les distributions posterieures
+
+> **Note** : `CompilerChoice.Roslyn` spécifie d'utiliser le compilateur Roslyn pour générer le code d'inference, ce qui est necessaire dans les environnements .NET Interactive.",,,,,,,,0df55a9a839980ad,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,b2b44f27,code,fr,e0818678d09bb56a,"// Inference
+InferenceEngine moteur = new InferenceEngine();
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur.ShowFactorGraph = true;  // Active la generation du graphe de facteurs
+
+Gaussian moyennePosterieure = moteur.Infer<Gaussian>(dureeMoyenne);
+Gamma bruitPosterieur = moteur.Infer<Gamma>(bruitTrafic);
+
+Console.WriteLine($""Moyenne a posteriori : {moyennePosterieure}"");
+Console.WriteLine($""Precision a posteriori : {bruitPosterieur}"");
+Console.WriteLine($""\nMoyenne estimee : {moyennePosterieure.GetMean():F2} min"");
+Console.WriteLine($""Ecart-type du bruit : {Math.Sqrt(1/bruitPosterieur.GetMean()):F2} min"");",,,,,,,,e0818678d09bb56a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,e2bd5870,markdown,fr,1f3a56bd3e7cbd3f,Visualisation du graphe de facteurs du modèle gaussien.,,,,,,,,1f3a56bd3e7cbd3f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,is1repzixca,code,fr,c75788bf852bd043,"// Visualisation du graphe de facteurs
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,c75788bf852bd043,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,wp3x84ecmwm,markdown,fr,964f99024833338c,"### Graphe de facteurs du modèle cycliste simple
+
+Le graphe ci-dessus represente la structure du modèle probabiliste :
+
+| Element | Représentation | Role |
+|---------|----------------|------|
+| **Cercles** | Variables aleatoires | `dureeMoyenne`, `bruitTrafic`, `dureeLundi`, etc. |
+| **Carres** | Facteurs (distributions) | `GaussianFromMeanAndPrecision`, `Gamma` |
+| **Fleches** | Dependances | Direction du flux d'information |
+
+**Lecture du graphe** :
+- Les **priors** (`dureeMoyenne` ~ Gaussian, `bruitTrafic` ~ Gamma) sont les variables parentes
+- Les **observations** (trajets observes) sont conditionnees par les mêmes paramètres partages
+- L'inference propage l'information des observations vers les priors pour calculer les posterieurs
+
+Ce graphe illustre le principe de **plate notation** : les trajets partagent les mêmes paramètres.",,,,,,,,964f99024833338c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,4a8uieoplpa,markdown,fr,ec0e98610db7dd8f,"### Analyse des résultats
+
+**Sortie obtenue** :
+- `Moyenne a posteriori : Gaussian(15,33, 1,32)` → moyenne ~15.3 min avec precision 1.32
+- `Precision a posteriori : Gamma(2,242, 0,2445)` → precision moyenne ~0.55
+
+**Interpretation** :
+
+| Aspect | Valeur | Explication |
+|--------|--------|-------------|
+| Moyenne | 15.33 | Proche de la moyenne empirique (13+17+16)/3 = 15.33 ✓ |
+| Écart-type bruit | 1.35 | Variabilite typique entre trajets |
+| Precision posterior | 1.32 | Plus concentre que le prior (0.01) |
+
+Remarquez le message **""Iterating: ....50""** qui indique que l'algorithme Expectation Propagation a effectue 50 itérations pour converger. Contrairement au modèle Bernoulli exact du notebook 1, les modèles Gaussiens avec precision inconnue necessitent une inference **iterative**.",,,,,,,,ec0e98610db7dd8f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,263c7074,markdown,fr,240cb970dd89e617,## 5. Prediction du Temps de Demain,,,,,,,,240cb970dd89e617,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,4lc7vfku415,markdown,fr,c778e0d82f0ac13b,"### Distribution predictive
+
+Pour predire le temps de demain, nous creons une **nouvelle variable aleatoire** `dureeDemain` qui depend des mêmes paramètres (moyenne et precision) que les observations.
+
+La distribution inferee pour `dureeDemain` est appelee **distribution predictive**. Elle integre :
+- L'incertitude sur la moyenne estimee
+- La variabilite inherente des trajets (bruit)
+
+Cette distribution est plus large que le posterior de la moyenne car elle additionne les deux sources d'incertitude.",,,,,,,,c778e0d82f0ac13b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,3e909597,code,fr,83545bb4e22881d0,"// Prediction pour demain
+Variable<double> dureeDemain = Variable.GaussianFromMeanAndPrecision(dureeMoyenne, bruitTrafic);
+Gaussian distribDemain = moteur.Infer<Gaussian>(dureeDemain);
+
+Console.WriteLine($""Prediction demain : {distribDemain}"");
+Console.WriteLine($""Temps moyen estime : {distribDemain.GetMean():F2} min"");
+Console.WriteLine($""Ecart-type de la prediction : {Math.Sqrt(distribDemain.GetVariance()):F2} min"");
+
+// Intervalle de confiance a 95%
+double mean = distribDemain.GetMean();
+double std = Math.Sqrt(distribDemain.GetVariance());
+Console.WriteLine($""\nIntervalle de confiance 95% : [{mean - 1.96*std:F1}, {mean + 1.96*std:F1}] min"");",,,,,,,,83545bb4e22881d0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,kh0nkt1drvg,markdown,fr,665696d75343e0c9,"### Interpretation de la prediction
+
+**Sortie** : `Gaussian(15,33, 4,613)` avec écart-type 2.15 min
+
+**Pourquoi l'écart-type de la prediction (2.15) est plus grand que celui du bruit (1.35) ?**
+
+La prediction combine **deux sources d'incertitude** :
+
+1. **Incertitude epistemique** : Nous ne connaissons pas exactement la vraie moyenne (notre estimation a une variance)
+2. **Incertitude aleatoire** : Même si nous connaissions parfaitement la moyenne, chaque trajet varie autour d'elle
+
+$$\text{Var}(\text{prediction}) = \text{Var}(\mu) + \text{Var}(\text{bruit}) \approx 0.76 + 1.82 = 4.58$$
+
+L'intervalle de confiance 95% `[11.1, 19.5] min` est assez large avec seulement 3 observations. Plus de données le reduiront.",,,,,,,,665696d75343e0c9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,a5fb3c2c,markdown,fr,4aaf8d937cee9f7a,## 6. Calcul de Probabilites,,,,,,,,4aaf8d937cee9f7a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,qvuwxveua2,markdown,fr,f81bfe5c07710c0f,"### Calcul de probabilites avec Infer.NET
+
+Une fois la distribution predictive obtenue, Infer.NET permet de calculer des **probabilites conditionnelles** directement.
+
+**Syntaxe** : La comparaison d'une variable aleatoire avec une constante cree une nouvelle variable Bernoulli :
+
+```csharp
+Variable<bool> condition = dureeDemain < 18.0;
+Bernoulli prob = engine.Infer<Bernoulli>(condition);
+double p = prob.GetProbTrue();  // P(dureeDemain < 18)
+```
+
+C'est équivalent a integrer la distribution predictive :
+
+$$P(\text{demain} < 18) = \int_{-\infty}^{18} p(\text{demain}) \, d\text{demain}$$
+
+Mais Infer.NET fait ce calcul automatiquement via l'inference.",,,,,,,,f81bfe5c07710c0f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,f4702f11,code,fr,ea2479852a547dad,"// Quelle est la probabilite que le trajet dure moins de 18 minutes ?
+Bernoulli probMoinsDe18 = moteur.Infer<Bernoulli>(dureeDemain < 18.0);
+Console.WriteLine($""P(trajet < 18 min) = {probMoinsDe18.GetProbTrue():F2}"");
+
+// Et moins de 15 minutes ?
+Bernoulli probMoinsDe15 = moteur.Infer<Bernoulli>(dureeDemain < 15.0);
+Console.WriteLine($""P(trajet < 15 min) = {probMoinsDe15.GetProbTrue():F2}"");
+
+// Entre 14 et 18 minutes ?
+Variable<bool> entre14et18 = (dureeDemain > 14.0) & (dureeDemain < 18.0);
+Bernoulli probEntre = moteur.Infer<Bernoulli>(entre14et18);
+Console.WriteLine($""P(14 < trajet < 18 min) = {probEntre.GetProbTrue():F2}"");",,,,,,,,ea2479852a547dad,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,v6xlllzzb5e,markdown,fr,c6506cce2479de2e,"### Interpretation des probabilites
+
+**Resultats obtenus** :
+- `P(trajet < 18 min) = 0.89` : Forte probabilite d'arriver en moins de 18 minutes
+- `P(trajet < 15 min) = 0.44` : Environ 1 chance sur 2 d'arriver en moins de 15 minutes
+- `P(14 < trajet < 18 min) = 0.65` : Probabilite moderee d'etre dans cette fourchette
+
+**Applications pratiques** :
+
+| Question | Probabilite | Decision |
+|----------|-------------|----------|
+| ""Puis-je arriver a l'heure si je pars 18 min avant ?"" | 89% | Oui, marge confortable |
+| ""Et si je pars seulement 15 min avant ?"" | 44% | Risque, 1 fois sur 2 en retard |
+| ""Fenetre optimale de depart ?"" | 65% entre 14-18 min | Viser ~16-17 min de marge |",,,,,,,,c6506cce2479de2e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,6ffff469,markdown,fr,5fb52a8614c9ef84,"## 7. Restructuration avec Classes
+
+Pour des modèles plus complexes, il est preferable d'encapsuler le code dans des classes reutilisables. Cette architecture permet :
+
+### Avantages de la restructuration
+
+| Avantage | Description |
+|----------|-------------|
+| **Reutilisabilite** | Les mêmes classes servent pour différents jeux de données |
+| **Separation des responsabilites** | Entrainement et prediction dans des classes distinctes |
+| **Apprentissage en ligne** | Les posterieurs d'une execution deviennent les priors de la suivante |
+| **Maintenabilite** | Le code du modèle est isole et testable |
+
+### Architecture proposee
+
+```
+DonneesCycliste (struct)
+    |-- DistribMoyenne : Gaussian
+    |-- DistribBruitTraffic : Gamma
+
+CyclisteBase (classe abstraite)
+    |-- MoteurInference
+    |-- Moyenne, Bruit (variables)
+    |-- MoyenneAPriori, BruitAPriori (priors)
+    |-- CreationModeleBayesien()
+    |-- DefinirDistributions()
+    
+    EntrainementCycliste : CyclisteBase
+        |-- TempsDeTrajet[] (observations)
+        |-- CalculePosterieurs() -> DonneesCycliste
+    
+    PredictionCycliste : CyclisteBase
+        |-- demainTemps (variable a predire)
+        |-- EstimerTempsDemain() -> Gaussian
+        |-- EstimerTempsDemainInferieurA(seuil) -> Bernoulli
+```
+
+### Flux de données
+
+1. **Initialisation** : Creer des priors vagues (`DonneesCycliste`)
+2. **Entrainement** : `EntrainementCycliste.CalculePosterieurs(observations)` → nouveaux posterieurs
+3. **Prediction** : `PredictionCycliste.DefinirDistributions(posterieurs)` puis `EstimerTempsDemain()`
+4. **Apprentissage en ligne** : Les posterieurs de l'étape 2 deviennent les priors de l'étape suivante",,,,,,,,5fb52a8614c9ef84,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,ftpakk1jco9,markdown,fr,b52a70c6f869f3c2,"### Aparté : Gaussienne Tronquee
+
+La **Gaussienne tronquee** est une distribution ou les valeurs sont contraintes a un intervalle. C'est utile quand les données ne peuvent pas prendre certaines valeurs (ex: temps de trajet > 0, temperature entre 0 et 100C).
+
+**Syntaxe Infer.NET** :
+
+```csharp
+// Gaussienne positive (tronquee a 0)
+Variable<double> y = Variable.GaussianFromMeanAndPrecision(mean, precision);
+Variable.ConstrainPositive(y);
+```
+
+#### Exemple : Temps de trajet (toujours positif)",,,,,,,,b52a70c6f869f3c2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,ask65vljw58,code,fr,eb46da7faeef21cb,"// Exemple de Gaussienne tronquee - cas simple
+
+Console.WriteLine(""=== Gaussienne Tronquee ===\n"");
+
+// Cas 1 : Prediction avec contrainte de positivite
+// On connait la moyenne et precision, on veut predire une valeur positive
+
+Variable<double> moyenneConnue = Variable.Observed(4.0);
+Variable<double> precisionConnue = Variable.Observed(1.0);
+
+// Variable aleatoire avec contrainte de positivite
+Variable<double> tempsPrediction = Variable.GaussianFromMeanAndPrecision(moyenneConnue, precisionConnue);
+Variable.ConstrainPositive(tempsPrediction);
+
+InferenceEngine moteurTronque = new InferenceEngine(new ExpectationPropagation());
+moteurTronque.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+// Comparer les distributions avec et sans troncature
+Console.WriteLine(""Distribution Gaussienne standard : N(4, 1)"");
+Console.WriteLine($""  -> Moyenne = 4.0, Ecart-type = 1.0"");
+Console.WriteLine($""  -> P(temps < 0) = {Gaussian.FromMeanAndVariance(4, 1).GetProbLessThan(0):F4}"");
+
+var distribTronquee = moteurTronque.Infer<Gaussian>(tempsPrediction);
+Console.WriteLine($""\nDistribution Gaussienne tronquee [0, +inf) :"");
+Console.WriteLine($""  -> {distribTronquee}"");
+Console.WriteLine($""  -> Moyenne ajustee = {distribTronquee.GetMean():F3}"");
+
+// Cas 2 : Effet de la troncature proche de zero
+Console.WriteLine(""\n--- Effet pres de la borne ---"");
+Variable<double> moyenneProche = Variable.Observed(1.0);  // Proche de 0
+Variable<double> precisionProche = Variable.Observed(0.25);  // Variance = 4, ecart-type = 2
+Variable<double> tempsProche = Variable.GaussianFromMeanAndPrecision(moyenneProche, precisionProche);
+Variable.ConstrainPositive(tempsProche);
+
+var distribProche = moteurTronque.Infer<Gaussian>(tempsProche);
+Console.WriteLine($""N(1, 4) standard : P(temps < 0) = {Gaussian.FromMeanAndVariance(1, 4).GetProbLessThan(0):F3} (~31%)"");
+Console.WriteLine($""N(1, 4) tronquee : {distribProche}"");
+Console.WriteLine($""  -> Moyenne ajustee de 1.0 a {distribProche.GetMean():F2} (effet de la troncature)"");",,,,,,,,eb46da7faeef21cb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,ziof0ss3m1,markdown,fr,cea33896cb34ae72,"#### Interpretation des résultats de la Gaussienne tronquee
+
+**Cas 1 : N(4, 1) tronquee a [0, +inf)**
+
+| Aspect | Standard | Tronquee | Difference |
+|--------|----------|----------|------------|
+| Moyenne | 4.0 | 4.0 | Negligeable |
+| P(x < 0) | ~0% | 0% | - |
+
+Quand la moyenne est loin de la borne (4 >> 0), la troncature a peu d'effet car la probabilite d'etre negatif est déjà quasi-nulle.
+
+**Cas 2 : N(1, 4) tronquee a [0, +inf)**
+
+| Aspect | Standard | Tronquee | Difference |
+|--------|----------|----------|------------|
+| Moyenne | 1.0 | 2.02 | +1.02 |
+| P(x < 0) | 31% | 0% | -31% |
+
+Quand la moyenne est proche de la borne, la troncature **redistribue** la masse de probabilite des valeurs negatives vers les valeurs positives, ce qui :
+- Augmente la moyenne (de 1.0 a 2.02)
+- Reduit la variance effective
+
+> **Application** : Pour modeliser un temps de trajet (toujours positif), la Gaussienne tronquee évite les predictions absurdes comme ""temps = -2 min"".",,,,,,,,cea33896cb34ae72,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,xsm903r9xd,markdown,fr,caee130163ba1a57,"#### Quand utiliser la Gaussienne Tronquee ?
+
+| Situation | Intervalle | Exemple |
+|-----------|------------|---------|
+| **Quantites positives** | [0, +inf) | Temps, distances, prix |
+| **Probabilites** | [0, 1] | Taux de conversion, precision |
+| **Temperatures physiques** | [-273.15, +inf) | Temperature en Celsius |
+| **Notes/Scores** | [0, 20] | Notes d'examen |
+
+**Avantages de la troncature** :
+
+1. **Realisme** : Les predictions respectent les contraintes physiques
+2. **Meilleure estimation** : La variance n'est pas ""gaspillee"" sur des valeurs impossibles
+3. **Intervalles de confiance valides** : Pas d'aberrations dans les predictions",,,,,,,,caee130163ba1a57,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,1k4hxmsgl1z,markdown,fr,7c6c50bccf0eea6e,"### Implémentation : Structure de données et classe de base
+
+Le code ci-dessous definit :
+
+1. **`DonneesCycliste`** : Structure pour stocker les distributions posterieures (moyenne et precision)
+2. **`CyclisteBase`** : Classe abstraite contenant les elements communs a l'entrainement et la prediction
+
+**Points techniques importants** :
+
+| Element | Explication |
+|---------|-------------|
+| `Variable.New<Gaussian>()` | Cree un ""slot"" pour recevoir une distribution comme valeur observée |
+| `Variable.Random<double, Gaussian>()` | Tire une valeur aleatoire selon une distribution Gaussienne |
+| `MoteurInference.Compiler.CompilerChoice` | Configure le compilateur pour l'environnement .NET Interactive |
+
+Cette architecture orientee objet permet de **separer** la logique d'entrainement de celle de prediction.",,,,,,,,7c6c50bccf0eea6e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,87b4a6e3,code,fr,dda19388ff5f7823,"// Structure pour stocker les posterieurs
+public struct DonneesCycliste
+{
+    public Gaussian DistribMoyenne;
+    public Gamma DistribBruitTraffic;
+    
+    public DonneesCycliste(Gaussian moyenne, Gamma precision)
+    {
+        DistribMoyenne = moyenne;
+        DistribBruitTraffic = precision;
+    }
+}
+
+// Classe de base avec les elements communs
+public class CyclisteBase
+{
+    public InferenceEngine MoteurInference;
+    protected Variable<double> Moyenne;
+    protected Variable<double> Bruit;
+    protected Variable<Gaussian> MoyenneAPriori;
+    protected Variable<Gamma> BruitAPriori;
+
+    public virtual void CreationModeleBayesien()
+    {
+        MoyenneAPriori = Variable.New<Gaussian>();
+        BruitAPriori = Variable.New<Gamma>();
+        Moyenne = Variable.Random<double, Gaussian>(MoyenneAPriori);
+        Bruit = Variable.Random<double, Gamma>(BruitAPriori);
+
+        if (MoteurInference == null)
+        {
+            MoteurInference = new InferenceEngine(new ExpectationPropagation());
+            MoteurInference.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+            MoteurInference.ShowFactorGraph = true;  // Active la generation du graphe
+        }
+    }
+
+    public virtual void DefinirDistributions(DonneesCycliste distribsApriori)
+    {
+        MoyenneAPriori.ObservedValue = distribsApriori.DistribMoyenne;
+        BruitAPriori.ObservedValue = distribsApriori.DistribBruitTraffic;
+    }
+}
+
+Console.WriteLine(""Classe CyclisteBase definie."");",,,,,,,,dda19388ff5f7823,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,kfwunewlw9,markdown,fr,89e4696d137e6297,"### Implémentation : Classes d'entrainement et de prediction
+
+Deux classes heritent de `CyclisteBase` :
+
+**EntrainementCycliste** :
+- Utilise un `VariableArray<double>` pour un nombre arbitraire d'observations
+- `Range` et `Variable.ForEach` permettent d'itérer sur les observations de maniere declarative
+- `CalculePosterieurs()` retourne les distributions mises a jour
+
+**PredictionCycliste** :
+- Ajoute une variable `demainTemps` pour la prediction future
+- `EstimerTempsDemain()` infere la distribution du temps demain
+- `EstimerTempsDemainInferieurA(seuil)` calcule P(temps < seuil)
+
+> **Pattern cle** : Separer entrainement et prediction permet de reutiliser les posterieurs comme priors dans un workflow d'apprentissage en ligne.",,,,,,,,89e4696d137e6297,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,9ec61758,code,fr,d0b0644a44c14ab4,"// Classe d'entrainement
+public class EntrainementCycliste : CyclisteBase
+{
+    protected VariableArray<double> TempsDeTrajet;
+    protected Variable<int> NombreDeTrajets;
+
+    public override void CreationModeleBayesien()
+    {
+        base.CreationModeleBayesien();
+        NombreDeTrajets = Variable.New<int>();
+        Range indiceTrajet = new Range(NombreDeTrajets);
+        TempsDeTrajet = Variable.Array<double>(indiceTrajet);
+        using (Variable.ForEach(indiceTrajet))
+        {
+            TempsDeTrajet[indiceTrajet] = Variable.GaussianFromMeanAndPrecision(Moyenne, Bruit);
+        }
+    }
+
+    public DonneesCycliste CalculePosterieurs(double[] donneesObservees)
+    {
+        DonneesCycliste posterieurs;
+        NombreDeTrajets.ObservedValue = donneesObservees.Length;
+        TempsDeTrajet.ObservedValue = donneesObservees;
+        posterieurs.DistribMoyenne = MoteurInference.Infer<Gaussian>(Moyenne);
+        posterieurs.DistribBruitTraffic = MoteurInference.Infer<Gamma>(Bruit);
+        return posterieurs;
+    }
+}
+
+// Classe de prediction
+public class PredictionCycliste : CyclisteBase
+{
+    public Variable<double> demainTemps;
+
+    public override void CreationModeleBayesien()
+    {
+        base.CreationModeleBayesien();
+        demainTemps = Variable.GaussianFromMeanAndPrecision(Moyenne, Bruit);
+    }
+
+    public Gaussian EstimerTempsDemain()
+    {
+        return MoteurInference.Infer<Gaussian>(demainTemps);
+    }
+
+    public Bernoulli EstimerTempsDemainInferieurA(double duree)
+    {
+        return MoteurInference.Infer<Bernoulli>(demainTemps < duree);
+    }
+}
+
+Console.WriteLine(""Classes EntrainementCycliste et PredictionCycliste definies."");",,,,,,,,d0b0644a44c14ab4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,zxyq0phia4,markdown,fr,6f044b386e502167,"### Utilisation des classes : Entrainement
+
+Nous utilisons maintenant les classes définies pour entrainer le modèle sur un jeu de données plus complet (9 observations).
+
+**Workflow** :
+1. Definir les données d'entrainement
+2. Creer les priors vagues (haute incertitude initiale)
+3. Instancier et configurer le modèle d'entrainement
+4. Appeler `CalculePosterieurs()` pour obtenir les distributions mises a jour
+
+Les 9 observations `{13, 17, 20, 25, 16, 11, 16, 14, 12.5}` incluent des valeurs plus extremes que l'exemple simple (notamment 25 min), ce qui va affecter les posterieurs.",,,,,,,,6f044b386e502167,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,3d69f8cd,code,fr,37dcd83969d1bc9f,"// Utilisation des classes
+double[] donneesTrajets = new[] { 13.0, 17.0, 20.0, 25.0, 16.0, 11.0, 16.0, 14.0, 12.5 };
+
+// Priors vagues
+DonneesCycliste mesDistributions = new DonneesCycliste(
+    Gaussian.FromMeanAndPrecision(15, 0.01),  // Prior moyenne
+    Gamma.FromShapeAndScale(2, 0.5));         // Prior precision
+
+// Entrainement
+EntrainementCycliste entrainement = new EntrainementCycliste();
+entrainement.CreationModeleBayesien();
+entrainement.DefinirDistributions(mesDistributions);
+DonneesCycliste posterieurs = entrainement.CalculePosterieurs(donneesTrajets);
+
+Console.WriteLine($""Moyenne a posteriori : {posterieurs.DistribMoyenne}"");
+Console.WriteLine($""Precision a posteriori : {posterieurs.DistribBruitTraffic}"");",,,,,,,,37dcd83969d1bc9f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,23e2ff47,markdown,fr,5df4d266c6cbf07c,Visualisation du graphe de facteurs du modèle avec trajectoire.,,,,,,,,5df4d266c6cbf07c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,ruvttosksid,code,fr,f133d1c9ea89f4d2,"// Visualisation du graphe de facteurs du modele avec tableaux
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,f133d1c9ea89f4d2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,0ad3q33z94xb,markdown,fr,83076153693b29a0,"### Graphe de facteurs avec VariableArray
+
+Ce graphe montre l'utilisation de **Range** et **VariableArray** pour gerer un nombre variable d'observations :
+
+| Structure | Code Infer.NET | Représentation graphique |
+|-----------|----------------|-------------------------|
+| **Range** | `new Range(NombreDeTrajets)` | Itération sur les indices |
+| **VariableArray** | `Variable.Array<double>(range)` | Rectangle englobant (plate) |
+| **ForEach** | `Variable.ForEach(indiceTrajet)` | Facteur repetitif |
+
+**Avantages de cette structure** :
+- Le modèle s'adapte automatiquement au nombre d'observations
+- L'inference est optimisee pour les tableaux (message passing vectorise)
+- Les paramètres partages (`Moyenne`, `Bruit`) sont clairement identifies
+
+Le graphe montre comment les 9 observations sont liees aux mêmes priors via une structure de plate.",,,,,,,,83076153693b29a0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,4gaiaaoqi48,markdown,fr,d9aa9eaf7be657ec,"### Interpretation des résultats d'entrainement
+
+**Données utilisees** : 9 observations `{13, 17, 20, 25, 16, 11, 16, 14, 12.5}`
+
+**Resultats** :
+- `Moyenne a posteriori : Gaussian(16,04, 1,772)` → moyenne ~16 min avec precision 1.77
+- `Precision a posteriori : Gamma(5,114, 0,01585)` → precision moyenne ~0.08
+
+**Comparaison avec le modèle simple (3 observations)** :
+
+| Aspect | 3 observations | 9 observations |
+|--------|---------------|----------------|
+| Moyenne estimee | 15.33 min | 16.04 min |
+| Precision du posterior | 1.32 | 1.77 |
+| Écart-type bruit | 1.35 min | 3.51 min |
+
+Avec plus de données (dont certaines extremes comme 25 min), le modèle :
+- Ajuste la moyenne vers le haut (16 vs 15.33)
+- **Augmente l'incertitude sur le bruit** car les données sont plus dispersees
+- Gagne en **confiance sur la moyenne** (precision 1.77 > 1.32)",,,,,,,,d9aa9eaf7be657ec,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,cc3knypegqj,markdown,fr,749083b46fbd45c6,"### Utilisation des classes : Prediction
+
+La prediction utilise les **posterieurs de l'entrainement comme priors**. C'est le coeur de l'inference bayesienne sequentielle :
+
+```
+Priors vagues -> Entrainement -> Posterieurs = Nouveaux priors -> Prediction
+```
+
+Cette chaine permet de propager l'information apprise vers les nouvelles predictions, tout en quantifiant correctement l'incertitude residuelle.",,,,,,,,749083b46fbd45c6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,54006606,code,fr,40460cf20ec5ad24,"// Prediction avec les posterieurs
+PredictionCycliste prediction = new PredictionCycliste();
+prediction.CreationModeleBayesien();
+prediction.DefinirDistributions(posterieurs);  // Utiliser les posterieurs comme priors
+
+Gaussian predictionDemain = prediction.EstimerTempsDemain();
+Console.WriteLine($""Prediction demain : {predictionDemain}"");
+Console.WriteLine($""Ecart-type : {Math.Sqrt(predictionDemain.GetVariance()):F2} min"");
+
+double probMoins18 = prediction.EstimerTempsDemainInferieurA(18).GetProbTrue();
+Console.WriteLine($""P(trajet < 18 min) = {probMoins18:F2}"");",,,,,,,,40460cf20ec5ad24,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,lrew5acmthn,markdown,fr,bc124df5e28a7d37,"### Interpretation de la prediction
+
+**Prediction** : `Gaussian(16,04, 17,11)` avec écart-type 4.14 min
+
+**Pourquoi l'écart-type est-il plus grand (4.14 min) qu'avec 3 observations (2.15 min) ?**
+
+Cela peut sembler contre-intuitif : plus de données, mais plus d'incertitude ? L'explication :
+
+1. **Données plus dispersees** : Les 9 observations incluent des extremes (11 a 25 min)
+2. **Meilleure estimation de la variance reelle** : Le modèle a appris que les trajets varient beaucoup
+3. **Honnetete bayesienne** : Le modèle reflète fidelement l'incertitude observée dans les données
+
+**Probabilite P(trajet < 18 min) = 0.68** : Avec ces données plus realistes, la confiance d'arriver en moins de 18 min est reduite (68% vs 89% avec 3 observations seulement).",,,,,,,,bc124df5e28a7d37,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,c0711e49,markdown,fr,0620a6e60d1672d2,"## 8. Apprentissage en Ligne
+
+L'apprentissage en ligne permet de mettre a jour le modèle incrementalement avec de nouvelles données, sans retraiter tout l'historique.
+
+**Principe** : Les posterieurs de la semaine precedente deviennent les priors de la semaine suivante.",,,,,,,,0620a6e60d1672d2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,torgwp4e0jr,markdown,fr,c382560a7c0fa7ff,"### Demonstration de l'apprentissage en ligne
+
+Le code suivant illustre le **cycle d'apprentissage incrementiel** :
+
+1. Les posterieurs de la semaine 1 (`posterieurs`) deviennent les priors de la semaine 2
+2. De nouvelles observations sont integrees via `CalculePosterieurs()`
+3. Les nouveaux posterieurs (`posterieursSemaine2`) refletent **toute** l'information accumulee
+
+**Avantage computationnel** : Nous n'avons pas besoin de retraiter les 9 observations originales. Les posterieurs ""resument"" cette information de maniere suffisante statistiquement.",,,,,,,,c382560a7c0fa7ff,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,40e31601,code,fr,1cd40913360d71e4,"// Nouvelle semaine de donnees
+double[] semaineSuivante = new double[] { 18, 25, 30, 14, 11 };
+
+// Utiliser les posterieurs comme nouveaux priors
+entrainement.DefinirDistributions(posterieurs);
+DonneesCycliste posterieursSemaine2 = entrainement.CalculePosterieurs(semaineSuivante);
+
+Console.WriteLine(""=== Apres semaine 2 ==="");
+Console.WriteLine($""Moyenne a posteriori : {posterieursSemaine2.DistribMoyenne}"");
+Console.WriteLine($""Precision a posteriori : {posterieursSemaine2.DistribBruitTraffic}"");
+
+// Nouvelle prediction
+prediction.DefinirDistributions(posterieursSemaine2);
+Gaussian nouvellePrediction = prediction.EstimerTempsDemain();
+Console.WriteLine($""\nNouvelle prediction demain : {nouvellePrediction}"");
+Console.WriteLine($""Ecart-type : {Math.Sqrt(nouvellePrediction.GetVariance()):F2} min"");",,,,,,,,1cd40913360d71e4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,13z53blfgpg,markdown,fr,85f38e101a06ad2b,"### Analyse de l'apprentissage en ligne
+
+**Nouvelles données semaine 2** : `{18, 25, 30, 14, 11}` - incluant des trajets tres longs (25, 30 min)
+
+**Evolution des posterieurs** :
+
+| Paramètre | Après semaine 1 | Après semaine 2 | Evolution |
+|-----------|-----------------|-----------------|-----------|
+| Moyenne | 16.04 min | 16.92 min | +0.88 min |
+| Precision moyenne | 1.77 | 1.44 | Confiance stable |
+| Écart-type bruit | 3.51 min | 5.73 min | +2.22 min |
+
+**Observations cles** :
+
+1. **Moyenne en hausse** : Les trajets longs (25, 30 min) tirent la moyenne vers le haut
+2. **Variance en hausse** : Le modèle apprend que les trajets sont encore plus variables que prevu
+3. **Accumulation des données** : 14 observations totales (9 + 5) sans retraitement
+
+**Avantage de l'apprentissage en ligne** :
+- Pas besoin de stocker toutes les observations historiques
+- Les posterieurs **resument** toute l'information passee
+- Mise a jour incrementale efficace pour les systemes en production
+
+> **Attention** : Si la distribution des données change radicalement (ex: nouveau trajet), les anciens posterieurs peuvent freiner l'adaptation. Dans ce cas, ""oublier"" partiellement le passe peut etre necessaire.",,,,,,,,85f38e101a06ad2b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,infer2-ex3-regime-md,markdown,fr,2ec286ec10c66361,"### Exercice : Detection d'un changement de regime par apprentissage en ligne
+
+Le cycliste a change d'itineraire sans vous prevenir ! En observant l'evolution des posteriors au fil des semaines, vous devez detecter a quel moment le changement s'est produit.
+
+**Objectif** : Simulez 4 semaines de données ou un changement d'itineraire intervient entre la semaine 2 et la semaine 3, puis utilisez l'apprentissage en ligne pour suivre l'evolution de la moyenne a posteriori.
+
+**Contexte** :
+- **Semaines 1 et 2** : Itineraire habituel, temps ~ N(15, 4)
+- **Semaines 3 et 4** : Nouvel itineraire (plus long), temps ~ N(25, 5)
+
+**Etapes** :
+1. Generez les données pour les 4 semaines (5 observations par semaine)
+2. Utilisez  et  pour mettre a jour iterativement
+3. Après chaque semaine, affichez la moyenne a posteriori et son écart-type
+4. Identifiez a quelle semaine le changement est detectable (moyenne posterior qui depasse un seuil)
+
+**Indices** :
+- # Indice 1 : Les données de la semaine 1 sont déjà dans  (cellule 9). Repartez des posteriors déjà calcules.
+- # Indice 2 : Pour générer des données gaussiennes, vous pouvez utiliser .
+- # Étape 3 : Observez comment la moyenne posterior passe progressivement de ~15 a ~25 min.
+- # Étape 4 : Un seuil de detection possible est lorsque la moyenne posterior sort de l'intervalle [moyenne_semaine2 +/- 2*std].",,,,,,,,2ec286ec10c66361,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,infer2-ex3-regime-code,code,fr,0ccdadb91eae9b77,"// Exercice : Detection d'un changement de regime par apprentissage en ligne
+
+// TODO 1 : Definir les 4 semaines de donnees
+// Indice : semaines 1-2 ~ N(15, 4), semaines 3-4 ~ N(25, 5)
+// double[] semaine1 = { 14.2, 16.1, 15.3, 13.8, 16.5 };
+// double[] semaine2 = { ... };
+// double[] semaine3 = { ... }; // Nouvel itineraire
+// double[] semaine4 = { ... }; // Nouvel itineraire
+
+// TODO 2 : Partir des posteriors de la semaine 1 (deja calcules)
+// Indice : Utilisez entrainement.DefinirDistributions(posterieurs)
+
+// TODO 3 : Pour chaque semaine suivante, mettre a jour et afficher
+// Indice : for (int sem = 2; sem <= 4; sem++) { ... }
+//          Afficher : moyenne posterior, ecart-type, et comparaison au seuil
+
+// TODO 4 : Identifier la semaine du changement de regime
+// Indice : Quand la moyenne posterior depasse-t-elle 2*ecart-types de sa valeur semaine 2 ?
+
+Console.WriteLine(""Exercice a completer : detection de changement de regime"");",,,,,,,,0ccdadb91eae9b77,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,c332bbf3,markdown,fr,3d1eb1a6c17d8f2d,"## 9. Probleme : Evenements Extraordinaires
+
+### Observation
+
+Nos données contiennent parfois des temps de trajet anormalement longs (25, 30 min) dus a des evenements extraordinaires :
+- Accident sur la route
+- Meteo extreme
+- Travaux
+
+### Solution
+
+Un **modèle de melange de Gaussiennes** peut capturer cette bimodalite :
+- **Composante 1** : Trajets ordinaires (~15 min)
+- **Composante 2** : Trajets extraordinaires (~30 min)
+
+$$p(x) = \pi_1 \cdot \mathcal{N}(x|\mu_1, \tau_1^{-1}) + \pi_2 \cdot \mathcal{N}(x|\mu_2, \tau_2^{-1})$$
+
+ou $\pi_1 + \pi_2 = 1$ sont les poids du melange.",,,,,,,,3d1eb1a6c17d8f2d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,4818bed2,markdown,fr,84b02d677908a678,"## 10. Modèle de Melange de Gaussiennes
+
+Nous allons maintenant implementer le modèle de melange. L'architecture objet similaire a celle du modèle simple facilitera la reutilisation et l'apprentissage en ligne.",,,,,,,,84b02d677908a678,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,iitn9jcy63,markdown,fr,b3aaa821324678dd,"### Architecture du modèle de melange
+
+Le modèle de melange necessite une structure plus complexe que le modèle simple :
+
+**Structure `DonneesCyclisteMixte`** :
+- `DistribMoyenne[]` : Un prior Gaussien par composante
+- `DistribBruitTraffic[]` : Un prior Gamma par composante
+- `DistribMixe` : Distribution Dirichlet sur les poids du melange
+
+**Classe `CyclisteBaseMixte`** :
+- `NombreComposantes` : Nombre de modes dans le melange
+- `Moyennes`, `Bruits` : Tableaux de variables pour chaque composante
+- `Mixe` : Vecteur de probabilites (somme = 1)
+
+> **Changement d'algorithme** : Nous utilisons `VariationalMessagePassing` (VMP) au lieu d'Expectation Propagation. VMP est plus adapte aux modèles avec variables latentes discretes (l'assignation aux composantes).",,,,,,,,b3aaa821324678dd,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,cc1e190b,code,fr,a0cf656866629dd1,"// Structure pour le modele mixte
+public struct DonneesCyclisteMixte
+{
+    public Gaussian[] DistribMoyenne;       // Une par composante
+    public Gamma[] DistribBruitTraffic;     // Une par composante
+    public Dirichlet DistribMixe;           // Poids du melange
+}
+
+// Classe de base pour le modele mixte
+public class CyclisteBaseMixte
+{
+    public InferenceEngine MoteurInference;
+    protected int NombreComposantes = 2;
+    protected VariableArray<Gaussian> MoyennesAPriori;
+    protected VariableArray<Gamma> BruitsAPriori;
+    protected Variable<Dirichlet> MixeAPriori;
+    protected VariableArray<double> Moyennes;
+    protected VariableArray<double> Bruits;
+    protected Variable<Vector> Mixe;
+
+    public virtual void CreationModeleBayesien()
+    {
+        Range indiceComposants = new Range(NombreComposantes);
+        
+        // VMP est recommande pour les melanges
+        MoteurInference = new InferenceEngine(new VariationalMessagePassing());
+        MoteurInference.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+        MoteurInference.ShowFactorGraph = true;  // Active la generation du graphe
+        
+        // Priors pour chaque composante
+        MoyennesAPriori = Variable.Array<Gaussian>(indiceComposants);
+        BruitsAPriori = Variable.Array<Gamma>(indiceComposants);
+        Moyennes = Variable.Array<double>(indiceComposants);
+        Bruits = Variable.Array<double>(indiceComposants);
+        
+        using (Variable.ForEach(indiceComposants))
+        {
+            Moyennes[indiceComposants] = Variable<double>.Random(MoyennesAPriori[indiceComposants]);
+            Bruits[indiceComposants] = Variable<double>.Random(BruitsAPriori[indiceComposants]);
+        }
+        
+        // Prior sur les poids du melange (Dirichlet)
+        MixeAPriori = Variable.New<Dirichlet>();
+        Mixe = Variable<Vector>.Random(MixeAPriori);
+        Mixe.SetValueRange(indiceComposants);
+    }
+
+    public virtual void DefinirDistributions(DonneesCyclisteMixte distribsApriori)
+    {
+        MoyennesAPriori.ObservedValue = distribsApriori.DistribMoyenne;
+        BruitsAPriori.ObservedValue = distribsApriori.DistribBruitTraffic;
+        MixeAPriori.ObservedValue = distribsApriori.DistribMixe;
+    }
+}
+
+Console.WriteLine(""Classe CyclisteBaseMixte definie."");",,,,,,,,a0cf656866629dd1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,umwfz1ze02,markdown,fr,dc8cb9ecaa3a8cf9,"### Classe d'entrainement pour le melange
+
+La classe `EntrainementCyclisteMixte` introduit une **variable latente discrete** : l'assignation de chaque observation a une composante.
+
+**Mecanisme cle - `Variable.Switch`** :
+
+```csharp
+ComposantesTrajets[i] = Variable.Discrete(Mixe);  // Tire 0 ou 1
+using (Variable.Switch(ComposantesTrajets[i]))
+{
+    // Selectionne automatiquement la bonne composante
+    TempsDeTrajet[i].SetTo(GaussianFromMeanAndPrecision(
+        Moyennes[ComposantesTrajets[i]], 
+        Bruits[ComposantesTrajets[i]]));
+}
+```
+
+Ce code dit : ""Chaque observation est générée par **une** des composantes, selectionnee selon les poids du melange.""",,,,,,,,dc8cb9ecaa3a8cf9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,7b2a09bd,code,fr,b5363184a9f8ece3,"// Classe d'entrainement pour le modele mixte
+public class EntrainementCyclisteMixte : CyclisteBaseMixte
+{
+    protected Variable<int> NombreDeTrajets;
+    protected VariableArray<double> TempsDeTrajet;
+    protected VariableArray<int> ComposantesTrajets;
+
+    public override void CreationModeleBayesien()
+    {
+        base.CreationModeleBayesien();
+        NombreDeTrajets = Variable.New<int>();
+        Range indiceTrajet = new Range(NombreDeTrajets);
+        TempsDeTrajet = Variable.Array<double>(indiceTrajet);
+        ComposantesTrajets = Variable.Array<int>(indiceTrajet);
+        
+        using (Variable.ForEach(indiceTrajet))
+        {
+            // Selection de la composante selon les poids du melange
+            ComposantesTrajets[indiceTrajet] = Variable.Discrete(Mixe);
+            
+            // Variable.Switch selectionne la composante appropriee
+            using (Variable.Switch(ComposantesTrajets[indiceTrajet]))
+            {
+                TempsDeTrajet[indiceTrajet].SetTo(
+                    Variable.GaussianFromMeanAndPrecision(
+                        Moyennes[ComposantesTrajets[indiceTrajet]], 
+                        Bruits[ComposantesTrajets[indiceTrajet]]));
+            }
+        }
+    }
+
+    public DonneesCyclisteMixte CalculePosterieurs(double[] donneesObservees)
+    {
+        DonneesCyclisteMixte posterieurs;
+        NombreDeTrajets.ObservedValue = donneesObservees.Length;
+        TempsDeTrajet.ObservedValue = donneesObservees;
+        posterieurs.DistribMoyenne = MoteurInference.Infer<Gaussian[]>(Moyennes);
+        posterieurs.DistribBruitTraffic = MoteurInference.Infer<Gamma[]>(Bruits);
+        posterieurs.DistribMixe = MoteurInference.Infer<Dirichlet>(Mixe);
+        return posterieurs;
+    }
+}
+
+Console.WriteLine(""Classe EntrainementCyclisteMixte definie."");",,,,,,,,b5363184a9f8ece3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,m94rssxc87i,markdown,fr,0143f89248d14f8b,"### Classe de prediction pour le melange
+
+La prediction dans un modèle de melange suit le même mecanisme :
+
+1. Tirer une composante selon les poids appris
+2. Générer une valeur selon les paramètres de cette composante
+
+Le résultat est une distribution qui **moyenne** les contributions des deux composantes, ponderees par leurs probabilites respectives. Cette distribution predictive capte la nature multimodale des données.",,,,,,,,0143f89248d14f8b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,5a30e8d6,code,fr,d22edfb092757ecd,"// Classe de prediction pour le modele mixte
+public class PredictionCyclisteMixte : CyclisteBaseMixte
+{
+    public Variable<double> demainTemps;
+
+    public override void CreationModeleBayesien()
+    {
+        base.CreationModeleBayesien();
+        Variable<int> indiceComposant = Variable.Discrete(Mixe);
+        demainTemps = Variable.New<double>();
+        using (Variable.Switch(indiceComposant))
+        {
+            demainTemps.SetTo(Variable.GaussianFromMeanAndPrecision(
+                Moyennes[indiceComposant], Bruits[indiceComposant]));
+        }
+    }
+
+    public Gaussian EstimerTempsDemain()
+    {
+        return MoteurInference.Infer<Gaussian>(demainTemps);
+    }
+}
+
+Console.WriteLine(""Classe PredictionCyclisteMixte definie."");",,,,,,,,d22edfb092757ecd,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,62ab012f,markdown,fr,812fcb20308943c9,"## 11. Entrainement du Modèle Mixte
+
+Utilisons maintenant les classes définies pour entrainer le modèle sur des données incluant des evenements extraordinaires.",,,,,,,,812fcb20308943c9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,1a28qrexsahj,markdown,fr,29eb9ef65c21370f,"### Entrainement du modèle a 2 composantes
+
+Nous entrainons maintenant le modèle de melange sur des données incluant des **evenements extraordinaires** (25 et 30 min).
+
+**Configuration des priors** :
+
+| Composante | Prior moyenne | Interpretation |
+|------------|---------------|----------------|
+| Ordinaire | N(15, 100) | Trajets normaux ~15 min |
+| Extraordinaire | N(30, 100) | Trajets longs ~30 min |
+
+Le prior Dirichlet(1, 1) est **uniforme** : pas de preference initiale pour l'une ou l'autre composante.
+
+L'inference va :
+1. Assigner (de maniere probabiliste) chaque observation a une composante
+2. Mettre a jour les moyennes et precisions de chaque composante
+3. Estimer les proportions du melange",,,,,,,,29eb9ef65c21370f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,79227c7e,code,fr,a0369dd2a8e4f777,"// Donnees avec evenements extraordinaires
+double[] donneesMixtes = new[] { 13.0, 17.0, 20.0, 25.0, 16.0, 11.0, 16.0, 25.0, 12.5, 30.0 };
+
+// Priors pour le modele mixte
+DonneesCyclisteMixte priorsMMixtes = new DonneesCyclisteMixte
+{
+    DistribMoyenne = new Gaussian[]
+    {
+        new Gaussian(15, 100),  // Composante 1 : Ordinaire (~15 min)
+        new Gaussian(30, 100)   // Composante 2 : Extraordinaire (~30 min)
+    },
+    DistribBruitTraffic = new Gamma[]
+    {
+        Gamma.FromShapeAndScale(2, 0.5),
+        Gamma.FromShapeAndScale(2, 0.5)
+    },
+    DistribMixe = new Dirichlet(1, 1)  // Prior uniforme sur les poids
+};
+
+// Entrainement
+EntrainementCyclisteMixte entrainementMixte = new EntrainementCyclisteMixte();
+entrainementMixte.CreationModeleBayesien();
+entrainementMixte.DefinirDistributions(priorsMMixtes);
+DonneesCyclisteMixte posterieursMixte = entrainementMixte.CalculePosterieurs(donneesMixtes);
+
+Console.WriteLine(""=== Resultats du modele de melange ==="");
+Console.WriteLine($""\nComposante 1 (Ordinaire):"");
+Console.WriteLine($""  Moyenne : {posterieursMixte.DistribMoyenne[0]}"");
+Console.WriteLine($""  Precision : {posterieursMixte.DistribBruitTraffic[0]}"");
+
+Console.WriteLine($""\nComposante 2 (Extraordinaire):"");
+Console.WriteLine($""  Moyenne : {posterieursMixte.DistribMoyenne[1]}"");
+Console.WriteLine($""  Precision : {posterieursMixte.DistribBruitTraffic[1]}"");
+
+Console.WriteLine($""\nPoids du melange : {posterieursMixte.DistribMixe}"");
+var poidsMoyens = posterieursMixte.DistribMixe.GetMean();
+Console.WriteLine($""  -> P(ordinaire) = {poidsMoyens[0]:F2}, P(extraordinaire) = {poidsMoyens[1]:F2}"");",,,,,,,,a0369dd2a8e4f777,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,a5240d45,markdown,fr,8eb206385d8b0b2d,Visualisation du graphe de facteurs du modèle robuste.,,,,,,,,8eb206385d8b0b2d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,krh9xrtnnx,code,fr,0f56847a7d93a251,"// Visualisation du graphe de facteurs du modele de melange
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,0f56847a7d93a251,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,vh9qawt99p,markdown,fr,e44e2ad42218cb07,"### Graphe de facteurs du modèle de melange de Gaussiennes
+
+Ce graphe illustre la structure plus complexe du modèle de melange (GMM) :
+
+| Element | Description |
+|---------|-------------|
+| **Mixe** | Vecteur Dirichlet des poids du melange (somme = 1) |
+| **ComposantesTrajets** | Variables latentes discretes (0 ou 1 pour chaque observation) |
+| **Variable.Switch** | Selection de la composante appropriee |
+| **Moyennes[k], Bruits[k]** | Paramètres de chaque composante k |
+
+**Structure hierarchique** :
+1. Le prior **Dirichlet** génère les poids du melange
+2. Chaque observation tire une **composante** selon ces poids
+3. La valeur observée est générée par les paramètres de cette composante
+
+**Difference avec le modèle simple** :
+- Ajout d'une couche de **variables latentes discretes**
+- Structure de **selection** (Switch) dans le graphe
+- Deux jeux de paramètres (Moyennes[0], Moyennes[1], etc.)
+
+Ce type de graphe est caracteristique des modèles de melange et de clustering.",,,,,,,,e44e2ad42218cb07,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,vdgtmx7lmpl,markdown,fr,226d9c73c53d6175,"### Analyse du modèle de melange
+
+**Resultats obtenus** :
+
+| Composante | Moyenne | Interpretation |
+|------------|---------|----------------|
+| Ordinaire | 15.07 min | Trajets normaux : {13, 17, 16, 11, 12.5} ✓ |
+| Extraordinaire | 26.69 min | Trajets longs : {20, 25, 25, 30} ✓ |
+
+**Poids du melange** : `Dirichlet(7.995, 4.005)` → P(ordinaire) = 67%, P(extraordinaire) = 33%
+
+Avec 10 observations, le modèle a correctement identifie :
+- **~7 trajets ordinaires** (prior 1 + ~6 observations assignees)
+- **~4 trajets extraordinaires** (prior 1 + ~3 observations assignees)
+
+> **Note sur VMP** : Le modèle utilise Variational Message Passing (`VariationalMessagePassing`) au lieu d'Expectation Propagation. VMP est recommande pour les modèles de melange car il gere mieux les variables latentes discretes (l'assignation aux composantes).",,,,,,,,226d9c73c53d6175,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,tnffao04tp,markdown,fr,7525ab27574d67ba,"### Prediction avec le modèle de melange
+
+La prediction utilise les posterieurs appris pour estimer le temps de demain. La distribution resultante est un **melange** des deux composantes :
+
+$$p(\text{demain}) = 0.67 \cdot \mathcal{N}(15.07, \sigma_1^2) + 0.33 \cdot \mathcal{N}(26.69, \sigma_2^2)$$
+
+Cette prediction tient compte de la possibilite (~33%) qu'un evenement extraordinaire se produise demain.",,,,,,,,7525ab27574d67ba,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,d6025227,code,fr,eb066039cab3458e,"// Prediction avec le modele mixte
+PredictionCyclisteMixte predictionMixte = new PredictionCyclisteMixte();
+predictionMixte.CreationModeleBayesien();
+predictionMixte.DefinirDistributions(posterieursMixte);
+
+Gaussian predictionMixteDemain = predictionMixte.EstimerTempsDemain();
+Console.WriteLine($""\nPrediction demain (modele mixte) : {predictionMixteDemain}"");
+Console.WriteLine($""Ecart-type : {Math.Sqrt(predictionMixteDemain.GetVariance()):F2} min"");",,,,,,,,eb066039cab3458e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,m861p6urm1,markdown,fr,d198686967d3630b,"### Interpretation de la prediction du modèle de melange
+
+**Sortie obtenue** : `Gaussian(18,48, 33,39)` avec écart-type 5.78 min
+
+| Aspect | Valeur | Interpretation |
+|--------|--------|----------------|
+| Moyenne | 18.48 min | Entre les deux modes (15 et 27 min) |
+| Écart-type | 5.78 min | Large incertitude due a la bimodalite |
+| IC 95% | ~[7, 30] min | Couvre les deux scenarios |
+
+**Comparaison des modèles** :
+
+| Modèle | Moyenne predite | Écart-type | Scenarios captures |
+|--------|-----------------|------------|-------------------|
+| Simple (3 obs) | 15.33 min | 2.15 min | Un seul mode |
+| Simple (9 obs) | 16.04 min | 4.14 min | Un seul mode |
+| Melange (2 comp) | 18.48 min | 5.78 min | Ordinaire + Extraordinaire |
+
+Le modèle de melange donne une **prediction plus realiste** car il tient compte explicitement de la possibilite d'evenements extraordinaires.",,,,,,,,d198686967d3630b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,79615172,markdown,fr,1d6fb6acbffe2144,"## 12. Exemple guide : Melange a 3 Composantes
+
+### Enonce
+
+Modifiez le modèle de melange pour utiliser **3 composantes** :
+1. Trajets rapides (~10 min)
+2. Trajets normaux (~18 min)
+3. Trajets longs (~30 min)
+
+### Données
+
+```csharp
+double[] donnees3Comp = new[] { 8, 10, 12, 18, 17, 19, 20, 28, 32, 35, 11, 18, 30 };
+```
+
+**Indice**
+
+- Changez `NombreComposantes = 3` dans la classe de base
+- Ajustez les priors pour 3 composantes
+- Utilisez `Dirichlet(1, 1, 1)` pour les poids",,,,,,,,1d6fb6acbffe2144,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,8vj1wcrnvd9,markdown,fr,eba324ec386bb944,"### Solution de l'exercice
+
+L'extension a 3 composantes demande peu de modifications :
+
+1. **`NombreComposantes = 3`** dans la classe de base
+2. **3 priors Gaussiens** pour les moyennes (10, 18, 30)
+3. **3 priors Gamma** pour les precisions
+4. **`Dirichlet(1, 1, 1)`** pour un prior uniforme sur 3 poids
+
+Le reste du code (Variable.Switch, inference) fonctionne sans modification grâce a l'utilisation de `Range` et tableaux.",,,,,,,,eba324ec386bb944,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,fc818a77,code,fr,00dac7ad517b5081,"// EXERCICE : Implementez un melange a 3 composantes
+
+// Modifiez la classe de base pour 3 composantes
+public class CyclisteBase3Composantes : CyclisteBaseMixte
+{
+    public CyclisteBase3Composantes()
+    {
+        NombreComposantes = 3;  // <- Modification ici
+    }
+}
+
+public class Entrainement3Composantes : CyclisteBase3Composantes
+{
+    protected Variable<int> NombreDeTrajets;
+    protected VariableArray<double> TempsDeTrajet;
+    protected VariableArray<int> ComposantesTrajets;
+
+    public override void CreationModeleBayesien()
+    {
+        base.CreationModeleBayesien();
+        NombreDeTrajets = Variable.New<int>();
+        Range indiceTrajet = new Range(NombreDeTrajets);
+        TempsDeTrajet = Variable.Array<double>(indiceTrajet);
+        ComposantesTrajets = Variable.Array<int>(indiceTrajet);
+        
+        using (Variable.ForEach(indiceTrajet))
+        {
+            ComposantesTrajets[indiceTrajet] = Variable.Discrete(Mixe);
+            using (Variable.Switch(ComposantesTrajets[indiceTrajet]))
+            {
+                TempsDeTrajet[indiceTrajet].SetTo(
+                    Variable.GaussianFromMeanAndPrecision(
+                        Moyennes[ComposantesTrajets[indiceTrajet]], 
+                        Bruits[ComposantesTrajets[indiceTrajet]]));
+            }
+        }
+    }
+
+    public DonneesCyclisteMixte CalculePosterieurs(double[] donneesObservees)
+    {
+        DonneesCyclisteMixte posterieurs;
+        NombreDeTrajets.ObservedValue = donneesObservees.Length;
+        TempsDeTrajet.ObservedValue = donneesObservees;
+        posterieurs.DistribMoyenne = MoteurInference.Infer<Gaussian[]>(Moyennes);
+        posterieurs.DistribBruitTraffic = MoteurInference.Infer<Gamma[]>(Bruits);
+        posterieurs.DistribMixe = MoteurInference.Infer<Dirichlet>(Mixe);
+        return posterieurs;
+    }
+}
+
+// Donnees
+double[] donnees3Comp = new[] { 8.0, 10.0, 12.0, 18.0, 17.0, 19.0, 20.0, 28.0, 32.0, 35.0, 11.0, 18.0, 30.0 };
+
+// Priors pour 3 composantes
+DonneesCyclisteMixte priors3Comp = new DonneesCyclisteMixte
+{
+    DistribMoyenne = new Gaussian[]
+    {
+        new Gaussian(10, 100),  // Rapide
+        new Gaussian(18, 100),  // Normal
+        new Gaussian(30, 100)   // Long
+    },
+    DistribBruitTraffic = new Gamma[]
+    {
+        Gamma.FromShapeAndScale(2, 0.5),
+        Gamma.FromShapeAndScale(2, 0.5),
+        Gamma.FromShapeAndScale(2, 0.5)
+    },
+    DistribMixe = new Dirichlet(1, 1, 1)  // Uniforme sur 3 composantes
+};
+
+// Entrainement
+Entrainement3Composantes ent3 = new Entrainement3Composantes();
+ent3.CreationModeleBayesien();
+ent3.DefinirDistributions(priors3Comp);
+DonneesCyclisteMixte post3 = ent3.CalculePosterieurs(donnees3Comp);
+
+Console.WriteLine(""=== Modele a 3 composantes ==="");
+for (int i = 0; i < 3; i++)
+{
+    Console.WriteLine($""\nComposante {i+1}: Moyenne = {post3.DistribMoyenne[i].GetMean():F1} min"");
+}
+Console.WriteLine($""\nPoids : {post3.DistribMixe.GetMean()}"");",,,,,,,,00dac7ad517b5081,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,7d3a413a,markdown,fr,08070c87c0db2fc9,Visualisation du graphe de facteurs du melange a 3 composantes.,,,,,,,,08070c87c0db2fc9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,cl4o2r0qi3g,code,fr,36ef22ebda8badb4,"// Visualisation du graphe de facteurs a 3 composantes
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,36ef22ebda8badb4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,lorlhrlbr7,markdown,fr,003fc590cadcb6f9,"### Graphe de facteurs a 3 composantes
+
+Ce graphe montre l'extension naturelle du modèle de melange a 3 composantes. La structure reste identique, seule la dimension change :
+
+| 2 composantes | 3 composantes |
+|---------------|---------------|
+| Dirichlet(1, 1) | Dirichlet(1, 1, 1) |
+| Moyennes[2] | Moyennes[3] |
+| ComposantesTrajets in {0, 1} | ComposantesTrajets in {0, 1, 2} |
+
+**Généralisation** : Le code Infer.NET avec `Range` et `VariableArray` permet de changer le nombre de composantes en modifiant uniquement `NombreComposantes`. Le graphe de facteurs s'adapte automatiquement.
+
+Cette flexibilite illustre la puissance de la programmation probabiliste declarative : vous decrivez le modèle, Infer.NET génère le code d'inference optimal.",,,,,,,,003fc590cadcb6f9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,cwwbs4wshws,markdown,fr,2b9ed4a1f5927be7,"### Analyse de l'exercice a 3 composantes
+
+**Resultats** :
+- Composante 1 : ~10.2 min → Trajets rapides {8, 10, 11, 12}
+- Composante 2 : ~18.4 min → Trajets normaux {17, 18, 18, 19, 20}
+- Composante 3 : ~31.2 min → Trajets longs {28, 30, 32, 35}
+
+**Poids** : `(0.31, 0.38, 0.31)` - Distribution relativement equilibree
+
+Le modèle a correctement **segmente** les 13 observations en 3 groupes distincts. Chaque composante a capte un mode de la distribution multimodale des données.
+
+> **Attention au label switching** : Dans les modèles de melange, les composantes peuvent s'echanger lors de différentes executions. Ici, Composante 1 est ""rapide"" mais ce n'est pas garanti a chaque execution. Les priors informatifs (10, 18, 30) aident a ancrer les composantes.",,,,,,,,2b9ed4a1f5927be7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,542c7095,markdown,fr,74486c98c054f601,"## 13. Resume
+
+### Distributions utilisees dans ce notebook
+
+| Distribution | Notation | Paramètres | Utilisation |
+|--------------|----------|------------|-------------|
+| **Gaussian** | $\mathcal{N}(\mu, \tau^{-1})$ | moyenne, precision | Temps de trajet, predictions |
+| **Gamma** | $\Gamma(\alpha, \beta)$ | shape, scale | Prior sur la precision |
+| **Dirichlet** | $\text{Dir}(\alpha_1, ..., \alpha_k)$ | concentrations | Poids du melange |
+| **Bernoulli** | $\text{Bern}(p)$ | probabilite | Resultats de comparaisons |
+
+### Concepts Infer.NET couverts
+
+| Concept | Code Infer.NET | Description |
+|---------|----------------|-------------|
+| **Variable aleatoire** | `Variable.GaussianFromMeanAndPrecision()` | Définition de distributions |
+| **Observation** | `variable.ObservedValue = x` | Ancrage aux données |
+| **Inference** | `engine.Infer<T>(variable)` | Calcul des posterieurs |
+| **Tableaux** | `Variable.Array<double>(range)` | Collections de variables |
+| **Itération** | `Variable.ForEach(range)` | Boucles declaratives |
+| **Selection** | `Variable.Switch(index)` | Modèles de melange |
+| **Contraintes** | `Variable.ConstrainPositive()` | Gaussiennes tronquees |
+
+### Patterns d'apprentissage
+
+| Pattern | Description | Avantage |
+|---------|-------------|----------|
+| **Batch** | Toutes les données en une fois | Simple, exact |
+| **Online** | Posterieurs -> Priors | Incrementiel, mémoire constante |
+| **Melange** | K composantes | Capture la multimodalite |
+
+### Algorithmes d'inference
+
+| Algorithme | Code | Cas d'usage |
+|------------|------|-------------|
+| **Expectation Propagation** | `new ExpectationPropagation()` | Modèles continus, contraintes |
+| **Variational Message Passing** | `new VariationalMessagePassing()` | Melanges, variables latentes discretes |
+
+---
+
+## Prochaine étape
+
+Dans [Infer-3-Factor-Graphs](Infer-3-Factor-Graphs.ipynb), nous explorerons :
+
+- Les graphes de facteurs et leur représentation
+- L'inference discrete avec le probleme du ""Murder Mystery""
+- Le paradoxe de Monty Hall
+- Le théorème de Bayes illustre",,,,,,,,74486c98c054f601,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,e665cf73,markdown,fr,a415d0bdf4e83665,"## 14. Exercice : Separation de populations (soumis par Faye, Christman, Clement)
+
+### Enonce original
+
+Des notes d'examens semblent suivre un melange de deux groupes d'etudiants :
+- Etudiants en difficulte (groupe 1, moyenne esperee ~10/20)
+- Bons etudiants (groupe 2, moyenne esperee ~16/20)
+
+Notes observées : `{8, 11, 9, 15, 17, 12, 9, 16, 14, 8}`
+
+L'objectif est d'inferer les posterieurs des deux composantes et la proportion d'etudiants
+dans chaque groupe, en reutilisant un modèle de melange a 2 composantes fonde sur
+`Variable.Switch` (cf. l'Exemple guide 12 et la classe `EntrainementCyclisteMixte`).
+
+> **Squelette fourni ci-dessous.** La classe `EntrainementMixte` est volontairement
+> **simplifiee** : sa méthode `CalculePosterieurs` renvoie des valeurs constantes
+> (`Gaussian(9,5, 1)`, `Gaussian(15,5, 1)`, `Dirichlet(0,6 0,4)`) sans lancer de
+> moteur d'inference. A vous de la compléter pour qu'elle infere reellement les
+> posterieurs a partir des `notes` observées, comme le fait `EntrainementCyclisteMixte`.
+",,,,,,,,a415d0bdf4e83665,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,ac70413a,code,fr,1c3fba09d7a68299,"public class DonneesMixte
+{
+    public Gaussian[] DistribMoyenne { get; set; }
+    public Gamma[] DistribPrecision { get; set; }
+    public Dirichlet DistribMixte { get; set; }
+}
+public class EntrainementMixte
+{
+    private int nbComposantes;
+
+    public EntrainementMixte(int k)
+    {
+        nbComposantes = k;
+    }
+
+    public void DefinirDistributions(DonneesMixte prior)
+    {
+        // Pas nécessaire pour cette implémentation simplifiée
+    }
+
+    public DonneesMixte CalculePosterieurs(double[] notes)
+    {
+        double moyenne = notes.Average();
+
+        Gaussian[] moyennes = new Gaussian[]
+        {
+            new Gaussian(9.5, 1),
+            new Gaussian(15.5, 1)
+        };
+
+        Gamma[] precisions = new Gamma[]
+        {
+            new Gamma(2,0.5),
+            new Gamma(2,0.5)
+        };
+
+        Dirichlet proportions = new Dirichlet(0.6,0.4);
+
+        return new DonneesMixte
+        {
+            DistribMoyenne = moyennes,
+            DistribPrecision = precisions,
+            DistribMixte = proportions
+        };
+    }
+}
+
+// EXERCICE : Melange gaussien pour deux groupes d'etudiants
+double[] notes = { 8, 11, 9, 15, 17, 12, 9, 16, 14, 8 };
+//TODO: Definir les a priori pour les deux composantes
+// A priori : large variance (incertitude sur les vraies moyennes)
+DonneesMixte priori = new DonneesMixte
+ {
+    DistribMoyenne = new Gaussian[] {
+        new Gaussian(10, 100),  // Composante 1 : etudiants en difficulte ~10
+        new Gaussian(16, 100)   // Composante 2 : bons etudiants ~16
+    },
+    DistribPrecision = new Gamma[] {
+        new Gamma(2, 0.5),
+        new Gamma(2, 0.5)
+    },
+    DistribMixte = new Dirichlet(1, 1)  // A priori uniforme sur les proportions
+};
+
+// TODO: Creer et entrainer le modele de melange (reutilisez EntrainementMixte)
+EntrainementMixte modele = new EntrainementMixte(2);
+modele.DefinirDistributions(priori);
+DonneesMixte posterieur = modele.CalculePosterieurs(notes);
+
+// TODO: Afficher et interpreter les resultats
+Console.WriteLine($""Composante 1 : {posterieur.DistribMoyenne[0]}"");
+Console.WriteLine($""Composante 2 : {posterieur.DistribMoyenne[1]}"");
+Console.WriteLine($""Proportions : {posterieur.DistribMixte}"");
+// Question : quel pourcentage d'etudiants est en difficulte ?
+",,,,,,,,1c3fba09d7a68299,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,d564b129,markdown,fr,cb0d3c3649943b26,"## 15. Exercice : Melange a Trois Composantes avec Données Manquantes
+
+### Enonce
+
+Une entreprise analyse les temps de reponse (en ms) de trois types de serveurs dans son infrastructure.
+Certaines mesures sont **manquantes** (capteurs defaillants). Le jeu de données est :
+
+```
+Mesures completes : {12, 45, 8, 52, 110, 15, 48, 105, 11, 50, 98, 14, 47, 120, 9}
+Mesures partielles (valeur manquante inconnue) : {?, 42, ?, 115, 13, ?, 49}
+```
+
+On suppose que les temps suivent un melange de 3 gaussiennes :
+- **Composante 1** (serveurs rapides) : moyenne esperee ~12 ms
+- **Composante 2** (serveurs normaux) : moyenne esperee ~48 ms
+- **Composante 3** (serveurs lents) : moyenne esperee ~110 ms
+
+### Questions
+
+1. Definissez un modèle de melange a 3 composantes avec des a priori :
+   - Moyennes : `Gaussian(12, 100)`, `Gaussian(48, 100)`, `Gaussian(110, 100)`
+   - Precisions : `Gamma(2, 0.5)` pour chaque composante
+   - Poids : `Dirichlet(1, 1, 1)` (a priori uniforme)
+
+2. Gerez les données manquantes : utilisez `Variable.Observed` pour les données complètes
+   et laissez les variables manquantes comme des `Variable<double>` non observées
+
+3. Inferez les posterieurs et interpretez :
+   - Quelles sont les moyennes posterieures de chaque composante ?
+   - Quelle est la proportion de chaque type de serveur ?
+   - Quelles valeurs le modèle predit-il pour les mesures manquantes ?
+
+4. Comparez les résultats avec et sans les données manquantes.
+   L'inclusion des mesures partielles ameliore-t-elle l'inference ?
+
+**Indice** : Pour les données manquantes, creez des `Variable<double>` avec le même prior que les observations,
+mais sans appeler `Variable.Observed`. Infer.NET inferera leur distribution posterieure.",,,,,,,,cb0d3c3649943b26,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,f17a9f9c,code,fr,e12495f18065e88e,"// Exercice : Melange a Trois Composantes avec Donnees Manquantes
+
+// Donnees
+double[] mesuresCompletes = { 12, 45, 8, 52, 110, 15, 48, 105, 11, 50, 98, 14, 47, 120, 9 };
+// Les mesures partielles ont des valeurs manquantes (notees -1 ici)
+double[] mesuresPartielles = { -1, 42, -1, 115, 13, -1, 49 };
+
+// TODO: Definir les a priori pour les 3 composantes
+// DonneesMixte priori3 = new DonneesMixte
+// {
+//     DistribMoyenne = new Gaussian[] {
+//         new Gaussian(12, 100),   // Serveurs rapides
+//         new Gaussian(48, 100),   // Serveurs normaux
+//         new Gaussian(110, 100)   // Serveurs lents
+//     },
+//     DistribPrecision = new Gamma[] { ... },
+//     DistribMixte = new Dirichlet(1, 1, 1)
+// };
+
+
+// TODO: Creer le modele de melange a 3 composantes
+// Adaptez EntrainementMixte pour gerer 3 composantes
+
+
+// TODO: Observer les donnees completes et definir les variables manquantes
+// Pour chaque mesure manquante (-1), creer une Variable<double> non observee
+// qui participe au meme melange
+
+
+// TODO: Lancer l'inference et afficher les posterieurs
+// Console.WriteLine($""Composante 1 (rapide) : {posterieur3.DistribMoyenne[0]}"");
+// Console.WriteLine($""Composante 2 (normal) : {posterieur3.DistribMoyenne[1]}"");
+// Console.WriteLine($""Composante 3 (lent)   : {posterieur3.DistribMoyenne[2]}"");
+// Console.WriteLine($""Proportions : {posterieur3.DistribMixte}"");
+
+
+// TODO: Afficher les valeurs predites pour les mesures manquantes
+// Pour chaque variable manquante, afficher sa moyenne et variance posterieures
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,e12495f18065e88e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,gm-bic-exercise-md,markdown,fr,d9a57334bda69a5e,"### Exercice : Selection du Nombre de Composantes par BIC
+
+Le choix du nombre de composantes K est un probleme central en melange de Gaussiennes. Le **BIC (Bayesian Information Criterion)** penalise la vraisemblance par le nombre de paramètres :
+
+865BIC_K = -2 \ln(\hat{L}_K) + p_K \ln(n)865
+
+ou $\hat{L}_K$ est la vraisemblance maximisee, $ le nombre de paramètres du modèle a K composantes, et $ le nombre de données.
+
+**Objectif** : Pour un jeu de données melange, comparer le BIC pour K=1,2,3,4 et identifier le K optimal.
+
+**Etapes** :
+1. Générer 100 points a partir d'un melange de 2 Gaussiennes (mu=0, mu=5, sigma=1 chacune)
+2. Pour chaque K dans {1,2,3,4}, entrainer un GMM et recuperer la log-vraisemblance
+3. Calculer le BIC : p_K = K*(2+1) + K-1 = 3K + K-1 paramètres (mean, variance, weight par composante)
+4. Identifier le K qui minimise le BIC
+
+**Indices** :
+- Utilisez les modèles déjà definis dans le notebook comme référence pour construire chaque GMM
+- Le nombre de paramètres pour un GMM 1D a K composantes : K means + K variances + (K-1) weights = 3K-1
+- Le BIC sera minimal au vrai K=2 (le generateur utilise 2 composantes)",,,,,,,,d9a57334bda69a5e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,gm-bic-exercise-code,code,fr,75d036e5b565d9ac,"// Exercice : Selection du nombre de composantes par BIC
+// On genere des donnees melange de 2 Gaussiennes
+
+Random rngBic = new Random(42);
+int nBic = 100;
+double[] dataBic = new double[nBic];
+// TODO: Etape 1 - Generer les donnees (50 points de N(0,1) + 50 points de N(5,1))
+// Indice: Utilisez rngBic.NextDouble() et la transformee de Box-Muller pour echantillonner
+
+// TODO: Etape 2 - Pour chaque K dans {1,2,3,4}, entrainer un GMM et stocker la log-vraisemblance
+// Indice: Adaptez le modele VariableArray pour chaque K
+// Indice: Utilisez engine.Infer<double>(Variable.LogFactor(true)) ou calculez la log-vraisemblance a partir des posteriors
+
+// TODO: Etape 3 - Calculer le BIC pour chaque K
+// BIC = -2 * logLikelihood + pK * log(n)
+// pK = 3*K - 1 (K means + K variances + K-1 weights, somme des weights = 1)
+// Indice: Math.Log(nBic) pour le terme de penalite
+
+// TODO: Etape 4 - Trouver le K optimal et afficher les resultats
+// Console.WriteLine($""K={k}: BIC={bic:F2}, logL={logL:F2}, pK={pK}"");
+
+Console.WriteLine(""Exercice a completer : selection du nombre de composantes par BIC"");",,,,,,,,75d036e5b565d9ac,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb,761280ee,markdown,fr,f9d4256ddf4675e7,"## Synthese
+
+Ce notebook a explore les melanges gaussiens avec Infer.NET :
+
+| Concept | Infer.NET |
+|---------|-----------|
+| Melange gaussien | `Variable.Mixture` avec ponderations et composantes |
+| Données manquantes | Gestion via `Variable.Array` avec masques |
+| Initialisation | Stratégie d'initialisation des composantes |
+| EM inferentiel | Inference variationnelle approchee dans Infer.NET |
+| Visualisation | Graphes de facteurs via `FactorGraphHelper` |",,,,,,,,f9d4256ddf4675e7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,ab0e007e,markdown,fr,e0990b4612903c4a,"# Infer-3-Factor-Graphs : Graphes de Facteurs et Inference Discrete
+
+**Serie** : Programmation Probabiliste avec Infer.NET (3/20)  
+**Duree estimee** : 45 minutes  
+**Prerequis** : Infer-1-Setup, Infer-2-Gaussian-Mixtures
+
+---
+
+## Objectifs
+
+- Comprendre les graphes de facteurs (factor graphs)
+- Modeliser l'inference discrete avec Infer.NET
+- Resoudre le probleme classique du ""Murder Mystery"" (MBML Book, Ch.1)
+- Comprendre le paradoxe de Monty Hall
+- Maitriser `Variable.If` / `Variable.IfNot` pour le conditionnement
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-2-Gaussian-Mixtures](Infer-2-Gaussian-Mixtures.ipynb) | [Infer-4-Bayesian-Networks](Infer-4-Bayesian-Networks.ipynb) |
+
+---",,,,,,,,e0990b4612903c4a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,77cadd70,markdown,fr,3217daa950e24399,"## 1. Configuration
+
+Nous chargeons les packages Infer.NET necessaires pour ce notebook. L'utilisation du compilateur Roslyn (`CompilerChoice.Roslyn`) est indispensable dans l'environnement .NET Interactive pour permettre la compilation dynamique des modeles probabilistes.",,,,,,,,3217daa950e24399,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,b5c8f2aa,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,miyi1of7ve,markdown,fr,702ac90746f60586,"**Note technique : CompilerChoice.Roslyn**
+
+L'option `CompilerChoice.Roslyn` est **obligatoire** dans l'environnement .NET Interactive (Jupyter). Infer.NET compile dynamiquement le code d'inference, et Roslyn est le seul compilateur compatible avec l'execution interactive.
+
+> **Pourquoi cette compilation dynamique ?** Infer.NET transforme votre modele probabiliste en un algorithme d'inference optimise (Expectation Propagation, Variational Message Passing, etc.). Cette transformation necessite une etape de compilation qui analyse la structure du graphe.",,,,,,,,702ac90746f60586,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,zmmn3n4q3i9,markdown,fr,ce68fceb22377b5e,"### Verification du FactorGraphHelper
+
+La sortie ci-dessus confirme que :
+- **Graphviz et le helper** : `FactorGraphHelper.IsGraphvizAvailable()` indique si `dot` (Graphviz) est reachable sur le PATH. Le rendu visuel des factor graphs **requiert Graphviz installe** ; en son absence, `GetLatestFactorGraphHtml()` renvoie un SVG mis en cache (potentiellement issu d'un autre modele) plutot qu'une image textuelle
+- **Helper charge** : On pourra appeler `FactorGraphHelper.GetLatestFactorGraphHtml()` apres chaque inference avec `ShowFactorGraph = true`
+
+> **Note technique** : FactorGraphHelper utilise Graphviz pour convertir la description DOT generee par Infer.NET en image SVG embeddee dans le HTML. Si Graphviz n'etait pas disponible, une representation textuelle serait utilisee a la place.",,,,,,,,ce68fceb22377b5e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,mggh80ifx4,code,fr,2f12d02d6daa9b7c,"// Chargement du helper pour afficher les graphes de facteurs inline
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper charge !"");
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");
+Console.WriteLine(""Usage: display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()))"");",,,,,,,,2f12d02d6daa9b7c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,b6d11f9e,markdown,fr,8415c495337b067c,"## 2. Introduction aux Graphes de Facteurs
+
+### Definition
+
+Un **graphe de facteurs** (factor graph) est une representation graphique d'une distribution de probabilite jointe qui se factorise en un produit de fonctions.
+
+$$P(X_1, X_2, ..., X_n) = \frac{1}{Z} \prod_a f_a(X_a)$$
+
+### Elements
+
+| Element | Representation | Description |
+|---------|---------------|-------------|
+| **Variable** | Cercle | Une quantite aleatoire |
+| **Facteur** | Carre | Une fonction reliant des variables |
+| **Arete** | Ligne | Connexion variable-facteur |
+
+### Exemple visuel
+
+```
+     [Prior A]     [Prior B]
+         |             |
+        (A)           (B)
+         |             |
+         +-----[AND]---+
+                |
+               (C)
+```
+
+Ce graphe represente : $P(A, B, C) = P(A) \cdot P(B) \cdot P(C|A,B)$",,,,,,,,8415c495337b067c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,19e37cea,markdown,fr,4ebea37b1e2da58e,"## 3. Murder Mystery - Scenario
+
+### Contexte (MBML Book, Chapter 1)
+
+Un meurtre a ete commis dans un manoir victorien. Deux suspects :
+
+| Suspect | Description | Prior de culpabilite |
+|---------|-------------|---------------------|
+| **Major Auburn** | Homme militaire, cheveux auburn | 70% |
+| **Miss Grey** | Jeune femme, cheveux gris | 30% |
+
+### Indices
+
+1. **Arme du crime** : Revolver ou Dague
+   - Auburn utiliserait un revolver (90%) ou une dague (10%)
+   - Grey utiliserait un revolver (20%) ou une dague (80%)
+
+2. **Cheveu trouve** : Auburn ou Gris
+   - Si Auburn coupable : cheveu auburn (80%) ou gris (20%)
+   - Si Grey coupable : cheveu auburn (10%) ou gris (90%)
+
+### Question
+
+L'enquete revele : **arme = revolver**, **cheveu = gris**. Qui est le meurtrier ?",,,,,,,,4ebea37b1e2da58e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,aa782b66,markdown,fr,7b8bd25f0f93aba7,"## 4. Modele avec Prior Seulement
+
+### Construction du premier modele
+
+Le code ci-dessous cree un modele minimal avec une seule variable binaire representant l'identite du meurtrier. La methode `Variable.Bernoulli(0.7)` cree une variable aleatoire suivant une loi de Bernoulli avec probabilite 0.7 d'etre vraie (Auburn coupable).
+
+**Elements cles** :
+- `Variable.Bernoulli(p)` : Cree une variable binaire avec P(true) = p
+- `InferenceEngine` : Moteur d'inference qui execute l'algorithme (EP par defaut)
+- `moteur.Infer<Bernoulli>(variable)` : Calcule la distribution posterieure",,,,,,,,7b8bd25f0f93aba7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,e2f6b413,code,fr,8496dc981835446d,"// Modele 1 : Prior seulement
+// meurtrier = true -> Auburn, false -> Grey
+
+Variable<bool> meurtrier = Variable.Bernoulli(0.7);  // 70% Auburn
+
+InferenceEngine moteur = new InferenceEngine();
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Bernoulli posteriorMeurtrier = moteur.Infer<Bernoulli>(meurtrier);
+
+Console.WriteLine(""=== Modele 1 : Prior seulement ==="");
+Console.WriteLine($""P(Auburn coupable) = {posteriorMeurtrier.GetProbTrue():F2}"");
+Console.WriteLine($""P(Grey coupable) = {1 - posteriorMeurtrier.GetProbTrue():F2}"");",,,,,,,,8496dc981835446d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,gmwk6d9jwa8,markdown,fr,d31e1e10cb508fb4,"### Interpretation du prior
+
+Sans aucun indice, le prior reflète simplement notre croyance initiale : Auburn est considéré a priori plus susceptible d'être coupable (70%) que Grey (30%). Ce prior pourrait venir d'informations préalables (antécédents, mobile, etc.)
+
+> **Point clé** : Le prior est **subjectif** mais l'inférence bayésienne garantit une mise à jour **cohérente** avec les observations. Un prior différent donnerait un postérieur différent, mais la direction des mises à jour resterait la même.",,,,,,,,d31e1e10cb508fb4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,a6107f94,markdown,fr,6119916956099283,"## 5. Ajout de l'Evidence sur l'Arme
+
+### Conditionnement avec Variable.If/IfNot
+
+Nous allons maintenant ajouter l'indice de l'arme au modele. Le pattern `Variable.If/IfNot` permet de definir des probabilites conditionnelles differentes selon la valeur d'une variable parente.
+
+**Structure du conditionnement** :
+```
+meurtrier = true (Auburn)  --> P(revolver) = 0.9
+meurtrier = false (Grey)   --> P(revolver) = 0.2
+```
+
+La ligne `arme.ObservedValue = true` indique a Infer.NET que nous avons **observe** que l'arme etait un revolver. Cette observation contraint l'inference et met a jour la distribution du meurtrier.",,,,,,,,6119916956099283,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,cc597997,code,fr,c8a332b010a6d5f1,"// Modele 2 : Prior + Arme
+// arme = true -> Revolver, false -> Dague
+
+Variable<bool> meurtrier2 = Variable.Bernoulli(0.7);
+Variable<bool> arme = Variable.New<bool>();
+
+// Si Auburn (meurtrier2 = true) : 90% revolver, 10% dague
+using (Variable.If(meurtrier2))
+{
+    arme.SetTo(Variable.Bernoulli(0.9));  // 90% revolver
+}
+
+// Si Grey (meurtrier2 = false) : 20% revolver, 80% dague
+using (Variable.IfNot(meurtrier2))
+{
+    arme.SetTo(Variable.Bernoulli(0.2));  // 20% revolver
+}
+
+// Observation : l'arme est un revolver
+arme.ObservedValue = true;
+
+InferenceEngine moteur2 = new InferenceEngine();
+moteur2.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Bernoulli posteriorMeurtrier2 = moteur2.Infer<Bernoulli>(meurtrier2);
+
+Console.WriteLine(""=== Modele 2 : Prior + Arme (revolver) ==="");
+Console.WriteLine($""P(Auburn coupable | arme=revolver) = {posteriorMeurtrier2.GetProbTrue():F3}"");
+Console.WriteLine($""P(Grey coupable | arme=revolver) = {1 - posteriorMeurtrier2.GetProbTrue():F3}"");",,,,,,,,c8a332b010a6d5f1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,135cee1f,markdown,fr,261e57555f59eb8e,"### Analyse de l'evidence ""arme""
+
+**Résultat** : P(Auburn | revolver) = 0.913
+
+Le revolver est un **indice très discriminant** car :
+- Auburn utiliserait un revolver dans **90%** des cas
+- Grey utiliserait un revolver dans seulement **20%** des cas
+
+**Calcul du rapport de vraisemblance (likelihood ratio)** :
+$$\text{LR} = \frac{P(\text{revolver}|\text{Auburn})}{P(\text{revolver}|\text{Grey})} = \frac{0.9}{0.2} = 4.5$$
+
+Ce rapport de 4.5 indique que l'observation du revolver est **4.5 fois plus probable** si Auburn est coupable. Combiné avec le prior (70/30 = 2.33), les odds finaux sont 2.33 × 4.5 ≈ 10.5, soit ~91% pour Auburn.
+
+> **Formule de Bayes en odds** : Posterior odds = Prior odds × Likelihood ratio",,,,,,,,261e57555f59eb8e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,5d113cd7,markdown,fr,48a7e5507c593951,"## 6. Ajout de l'Evidence sur les Cheveux
+
+### Ajout d'un second indice : le cheveu
+
+Le modele s'enrichit d'une deuxieme variable observable : le cheveu trouve sur la scene de crime. Ce modele combine maintenant **deux sources d'evidence independantes** (conditionnellement au meurtrier).
+
+**Probabilites conditionnelles pour le cheveu** :
+
+| Meurtrier | P(cheveu auburn) | P(cheveu gris) |
+|-----------|------------------|----------------|
+| Auburn | 0.80 | 0.20 |
+| Grey | 0.10 | 0.90 |
+
+Avec l'observation `cheveu = gris`, cet indice pointe vers Grey, contrairement au revolver qui pointait vers Auburn. Comment l'inference va-t-elle combiner ces deux indices contradictoires ?",,,,,,,,48a7e5507c593951,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,aee48113,code,fr,60861b4d77b5309e,"// Modele 3 : Prior + Arme + Cheveu
+// cheveu = true -> Auburn, false -> Gris
+
+Variable<bool> meurtrier3 = Variable.Bernoulli(0.7);
+Variable<bool> arme3 = Variable.New<bool>();
+Variable<bool> cheveu = Variable.New<bool>();
+
+// Probabilites conditionnelles pour l'arme
+using (Variable.If(meurtrier3))
+{
+    arme3.SetTo(Variable.Bernoulli(0.9));
+}
+using (Variable.IfNot(meurtrier3))
+{
+    arme3.SetTo(Variable.Bernoulli(0.2));
+}
+
+// Probabilites conditionnelles pour le cheveu
+// Si Auburn : 80% cheveu auburn, 20% cheveu gris
+using (Variable.If(meurtrier3))
+{
+    cheveu.SetTo(Variable.Bernoulli(0.8));  // 80% auburn
+}
+// Si Grey : 10% cheveu auburn, 90% cheveu gris
+using (Variable.IfNot(meurtrier3))
+{
+    cheveu.SetTo(Variable.Bernoulli(0.1));  // 10% auburn
+}
+
+// Observations
+arme3.ObservedValue = true;   // Revolver
+cheveu.ObservedValue = false; // Cheveu gris
+
+InferenceEngine moteur3 = new InferenceEngine();
+moteur3.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Bernoulli posteriorMeurtrier3 = moteur3.Infer<Bernoulli>(meurtrier3);
+
+Console.WriteLine(""=== Modele 3 : Prior + Arme (revolver) + Cheveu (gris) ==="");
+Console.WriteLine($""P(Auburn coupable | arme=revolver, cheveu=gris) = {posteriorMeurtrier3.GetProbTrue():F3}"");
+Console.WriteLine($""P(Grey coupable | arme=revolver, cheveu=gris) = {1 - posteriorMeurtrier3.GetProbTrue():F3}"");",,,,,,,,60861b4d77b5309e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,e2ab7aa6,markdown,fr,29748855f8887698,"### Analyse des evidences contradictoires
+
+**Résultat** : P(Auburn | revolver, cheveu gris) = 0.700 — retour au prior !
+
+Les deux indices s'**annulent exactement** dans ce modèle calibré :
+
+| Indice | Likelihood Ratio | Direction |
+|--------|------------------|-----------|
+| Revolver | 0.9/0.2 = **4.5** | → Auburn |
+| Cheveu gris | 0.2/0.9 = **0.22** | → Grey |
+
+**Produit des LR** : 4.5 × 0.22 ≈ 1.0
+
+Quand le produit des rapports de vraisemblance vaut 1, les indices sont **parfaitement compensatoires** et on revient au prior.
+
+> **Leçon** : L'inférence bayésienne combine **tous** les indices de manière cohérente, même quand ils pointent dans des directions opposées. C'est une propriété fondamentale : aucun indice n'est ignoré, mais leur impact relatif dépend de leur force discriminante.",,,,,,,,29748855f8887698,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,z0rfo6ik1qh,markdown,fr,3a39789a0692cd99,"### Visualisation du Factor Graph
+
+Le modele Murder Mystery peut etre visualise comme un graphe de facteurs. Activons `ShowFactorGraph` pour generer et afficher le graphe.
+
+Pour mieux comprendre la structure du modele, Infer.NET peut generer une representation visuelle du graphe de facteurs. L'option `ShowFactorGraph = true` declenche cette generation.
+
+**Variables nommees** : En utilisant `.Named(""nom"")`, on obtient des etiquettes lisibles dans le graphe au lieu d'identifiants generiques comme ""vbool0"".",,,,,,,,3a39789a0692cd99,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,8ilype0hrh,code,fr,16cab49eda26522c,"// Visualisation du Factor Graph du Murder Mystery
+// Recreer le modele avec ShowFactorGraph active
+
+Variable<bool> meurtrierViz = Variable.Bernoulli(0.7).Named(""meurtrier"");
+Variable<bool> armeViz = Variable.New<bool>().Named(""arme"");
+Variable<bool> cheveuViz = Variable.New<bool>().Named(""cheveu"");
+
+using (Variable.If(meurtrierViz))
+{
+    armeViz.SetTo(Variable.Bernoulli(0.9));
+    cheveuViz.SetTo(Variable.Bernoulli(0.8));
+}
+using (Variable.IfNot(meurtrierViz))
+{
+    armeViz.SetTo(Variable.Bernoulli(0.2));
+    cheveuViz.SetTo(Variable.Bernoulli(0.1));
+}
+
+armeViz.ObservedValue = true;
+cheveuViz.ObservedValue = false;
+
+InferenceEngine moteurViz = new InferenceEngine();
+moteurViz.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurViz.ShowFactorGraph = true;  // Generer le graphe
+
+var resultViz = moteurViz.Infer<Bernoulli>(meurtrierViz);
+Console.WriteLine($""P(Auburn) = {resultViz.GetProbTrue():F3}"");
+
+// Afficher le factor graph inline
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,16cab49eda26522c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,o8zd7hkzsi8,markdown,fr,c1268d709e0d2a67,"### Lecture du Factor Graph
+
+Dans le graphe ci-dessus :
+- Les **rectangles** representent les facteurs (distributions de probabilite)
+- Les **cercles/ellipses** representent les variables aleatoires
+- Les variables observees sont marquees differemment
+- Les fleches montrent le flux de messages entre variables et facteurs
+
+Ce graphe illustre la structure de dependance : le meurtrier influence a la fois l'arme et le cheveu, mais ces deux indices sont conditionnellement independants etant donne le meurtrier.
+
+> **Note de reproductibilite** : le rendu SVG integre ci-dessus **depend de Graphviz** (executable `dot` sur le PATH) et de `FactorGraphHelper.GetLatestFactorGraphHtml()`, qui selectionne le fichier `Model_*.svg` le plus recent dans le repertoire de travail. Si Graphviz n'est pas disponible a l'execution, l'image affichee peut etre un SVG mis en cache correspondant a un autre modele. La structure reelle du modele Murder Mystery (construite dans la cellule de code ci-dessus via `Variable.Bernoulli` + `Variable.If`) est celle decrite textuellement : `meurtrier -> {arme, cheveu}` avec les tables conditionnelles 0.9/0.8 (coupable) et 0.2/0.1 (innocent).",,,,,,,,c1268d709e0d2a67,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,8d35d4a7,markdown,fr,c843aa29413f0aaf,"### Exercice : Sensibilite au prior dans le Murder Mystery
+
+L'issue du Murder Mystery depend fortement du prior initial sur la culpabilite. Le modele actuel utilise P(Auburn) = 0.7.
+
+**Objectif** : Analyser comment la probabilite posterieure de culpabilite d'Auburn evolue en fonction du prior, en gardant les observations fixees (arme = revolver, cheveu = gris).
+
+**Etapes** :
+1. Reprendre le modele complet (meurtrier + arme + cheveu) avec observations fixees
+2. Faire varier le prior P(Auburn) sur une grille de valeurs : {0.1, 0.3, 0.5, 0.7, 0.9}
+3. Pour chaque valeur du prior, inferer le posterieur et stocker P(Auburn coupable)
+4. Afficher un tableau comparatif prior vs posterior
+
+**Indices** :
+- Bouclez sur les valeurs du prior et recrez le modele a chaque iteration (Infer.NET ne permet pas de modifier le prior a posteriori facilement)
+- Observez comment les likelihood ratios (4.5 pour le revolver, 0.22 pour le cheveu gris) interagissent differemment selon le prior
+- Que se passe-t-il quand le prior est tres极端 (0.01 ou 0.99) ?",,,,,,,,c843aa29413f0aaf,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,c60f625c,code,fr,0a397e2c4997538b,"// Exercice : Sensibilite au prior dans le Murder Mystery
+// TODO: Definir le tableau des valeurs de prior a tester
+// Indice: double[] priors = { 0.1, 0.3, 0.5, 0.7, 0.9 };
+
+// TODO: Boucler sur chaque valeur de prior et recreer le modele
+// Indice: a chaque iteration, Variable<bool> meurtrier = Variable.Bernoulli(prior);
+// Puis ajouter arme et cheveu avec Variable.If/IfNot comme dans les sections precedentes
+
+// TODO: Observer arme = revolver (true), cheveu = gris (false)
+
+// TODO: Inferer P(Auburn | evidence) et afficher dans un tableau
+// Indice: Console.WriteLine($""| {prior:F1} | {posterior.GetProbTrue():F3} |"");
+
+// Question supplementaire : les likelihood ratios dependent-ils du prior ?
+Console.WriteLine(""Exercice a completer : Sensibilite au prior"");",,,,,,,,0a397e2c4997538b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,fc9fc7cc,markdown,fr,04135abdaa07bf0b,"## 7. Le Paradoxe de Monty Hall
+
+### Regles du jeu
+
+1. Un jeu televisé presente **3 portes** : derriere l'une se trouve une voiture, derriere les deux autres des chevres
+2. Le joueur **choisit une porte**
+3. L'animateur (Monty), qui sait ou est la voiture, **ouvre une autre porte** montrant une chevre
+4. Monty propose au joueur de **changer de porte**
+
+### Question
+
+Le joueur devrait-il changer de porte ?
+
+### Intuition (souvent fausse)
+
+Beaucoup pensent que la probabilite est 50/50 apres l'ouverture d'une porte. C'est faux !",,,,,,,,04135abdaa07bf0b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,p3vib2dlpld,markdown,fr,71ec5ec18656cde5,"### Modelisation du comportement de Monty
+
+Le modele ci-dessous encode **exhaustivement** les 9 combinaisons possibles (3 positions de voiture x 3 choix du joueur). Pour chaque combinaison, nous specifitons quelle porte Monty peut ouvrir.
+
+**Points cles de la modelisation** :
+- `Variable.DiscreteUniform(3)` : Distribution uniforme sur {0, 1, 2}
+- `Variable.Case(variable, valeur)` : Branchement conditionnel discret
+- `Variable.Constant(v)` : Variable deterministe (valeur fixee)
+- `Variable.Discrete(probs)` : Distribution discrete personnalisee
+
+**Contraintes de Monty** :
+1. Ne jamais ouvrir la porte de la voiture
+2. Ne jamais ouvrir la porte choisie par le joueur
+3. Si deux portes sont possibles, choisir uniformement",,,,,,,,71ec5ec18656cde5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,3bc416fb,code,fr,8fea59befc12b007,"// Modelisation du probleme de Monty Hall
+
+// Position de la voiture (0, 1, ou 2)
+Variable<int> voiture = Variable.DiscreteUniform(3);
+
+// Choix du joueur (0, 1, ou 2)
+Variable<int> choixJoueur = Variable.DiscreteUniform(3);
+
+// Porte ouverte par Monty
+// Monty choisit une porte qui n'est ni la voiture, ni le choix du joueur
+Variable<int> porteOuverte = Variable.New<int>();
+
+// Logique de Monty : ouvrir une porte avec une chevre, differente du choix
+// Cas 1 : voiture = 0
+using (Variable.Case(voiture, 0))
+{
+    using (Variable.Case(choixJoueur, 0))
+    {
+        // Joueur a choisi 0 (voiture), Monty peut ouvrir 1 ou 2
+        porteOuverte.SetTo(Variable.DiscreteUniform(2) + 1);  // 1 ou 2 avec prob egale
+    }
+    using (Variable.Case(choixJoueur, 1))
+    {
+        // Joueur a choisi 1, Monty doit ouvrir 2 (pas 0=voiture, pas 1=choix)
+        porteOuverte.SetTo(Variable.Constant(2));
+    }
+    using (Variable.Case(choixJoueur, 2))
+    {
+        // Joueur a choisi 2, Monty doit ouvrir 1
+        porteOuverte.SetTo(Variable.Constant(1));
+    }
+}
+
+// Cas 2 : voiture = 1
+using (Variable.Case(voiture, 1))
+{
+    using (Variable.Case(choixJoueur, 0))
+    {
+        porteOuverte.SetTo(Variable.Constant(2));
+    }
+    using (Variable.Case(choixJoueur, 1))
+    {
+        // Joueur a choisi la voiture, Monty peut ouvrir 0 ou 2
+        porteOuverte.SetTo(Variable.Discrete(new double[] { 0.5, 0.0, 0.5 }));
+    }
+    using (Variable.Case(choixJoueur, 2))
+    {
+        porteOuverte.SetTo(Variable.Constant(0));
+    }
+}
+
+// Cas 3 : voiture = 2
+using (Variable.Case(voiture, 2))
+{
+    using (Variable.Case(choixJoueur, 0))
+    {
+        porteOuverte.SetTo(Variable.Constant(1));
+    }
+    using (Variable.Case(choixJoueur, 1))
+    {
+        porteOuverte.SetTo(Variable.Constant(0));
+    }
+    using (Variable.Case(choixJoueur, 2))
+    {
+        // Joueur a choisi la voiture, Monty peut ouvrir 0 ou 1
+        porteOuverte.SetTo(Variable.Discrete(new double[] { 0.5, 0.5, 0.0 }));
+    }
+}
+
+Console.WriteLine(""Modele Monty Hall defini."");",,,,,,,,8fea59befc12b007,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,q0x6quick6h,markdown,fr,123c7a47c7db74a4,"### Structure du modele Monty Hall
+
+Le code ci-dessus encode la **logique de Monty** sous forme de probabilites conditionnelles. La complexite vient du fait que Monty a une **connaissance parfaite** et des **contraintes** :
+
+1. Il connait la position de la voiture
+2. Il ne peut pas ouvrir la porte du joueur
+3. Il ne peut pas ouvrir la porte de la voiture
+4. Quand il a le choix (joueur sur la voiture), il choisit uniformement
+
+Cette modelisation exhaustive par `Variable.Case` couvre les 9 combinaisons (3 positions x 3 choix), ce qui est typique des problemes discrets a petit nombre d'etats.",,,,,,,,123c7a47c7db74a4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,ipzo7eq8pj8,markdown,fr,e9f61d93c2d1bc5d,"### Application du scenario : observations
+
+Nous fixons maintenant un scenario concret :
+- **Choix du joueur** : Porte 0
+- **Porte ouverte par Monty** : Porte 2 (montrant une chevre)
+
+L'inference va calculer la distribution a posteriori de la position de la voiture, sachant ces deux observations.",,,,,,,,e9f61d93c2d1bc5d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,274f88c9,code,fr,e1a449a6870f48fe,"// Scenario : Le joueur choisit la porte 0, Monty ouvre la porte 2
+choixJoueur.ObservedValue = 0;
+porteOuverte.ObservedValue = 2;
+
+InferenceEngine moteurMonty = new InferenceEngine();
+moteurMonty.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Discrete posteriorVoiture = moteurMonty.Infer<Discrete>(voiture);
+
+Console.WriteLine(""=== Paradoxe de Monty Hall ==="");
+Console.WriteLine($""Choix du joueur : porte 0"");
+Console.WriteLine($""Porte ouverte par Monty : porte 2 (chevre)\n"");
+
+Console.WriteLine($""P(voiture derriere porte 0) = {posteriorVoiture.GetProbs()[0]:F3}"");
+Console.WriteLine($""P(voiture derriere porte 1) = {posteriorVoiture.GetProbs()[1]:F3}"");
+Console.WriteLine($""P(voiture derriere porte 2) = {posteriorVoiture.GetProbs()[2]:F3}"");
+
+Console.WriteLine($""\n=> Le joueur devrait CHANGER pour la porte 1 !"");
+Console.WriteLine($""   En gardant : {posteriorVoiture.GetProbs()[0]*100:F0}% de chance"");
+Console.WriteLine($""   En changeant : {posteriorVoiture.GetProbs()[1]*100:F0}% de chance"");",,,,,,,,e1a449a6870f48fe,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,sr06732og7,markdown,fr,007dc91ea60f6fdf,"### Analyse du résultat Monty Hall
+
+**Sortie** : P(voiture porte 0) = 0.333, P(voiture porte 1) = **0.667**, P(voiture porte 2) = 0
+
+L'information révélée par Monty n'est **pas symétrique** :
+- Si le joueur a choisi la voiture (1/3), Monty pouvait ouvrir n'importe quelle autre porte
+- Si le joueur a choisi une chèvre (2/3), Monty était **contraint** d'ouvrir l'unique autre porte avec une chèvre
+
+C'est cette **asymétrie d'information** qui crée le paradoxe. L'action de Monty révèle indirectement où est la voiture.
+
+> **Intuition correcte** : En changeant, vous captez les 2/3 de chance initiale que la voiture soit derrière l'une des portes non choisies. Avant l'ouverture, cette probabilité était répartie sur 2 portes. Après, elle se concentre sur une seule.",,,,,,,,007dc91ea60f6fdf,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,hxlk3pl71mn,markdown,fr,13a3b99fef1eccd1,"### Visualisation du Factor Graph Monty Hall
+
+Le modele Monty Hall est plus complexe que le Murder Mystery car il utilise des variables discretes a 3 valeurs et des conditionnements imbriques avec `Variable.Case`. Visualisons sa structure pour mieux comprendre les dependances entre :
+- **voiture** : Position de la voiture (0, 1, ou 2)
+- **choixJoueur** : Porte choisie par le joueur
+- **porteMonty** : Porte ouverte par l'animateur
+
+On remarquera que le graphe est significativement plus complexe en raison des 9 cas (3 positions x 3 choix) qui definissent la distribution conditionnelle de porteMonty.
+
+> **Note de reproductibilite** : comme pour le graphe Murder Mystery ci-dessus, le rendu SVG integre depend de Graphviz et peut afficher un graph mis en cache si `dot` n'est pas disponible a l'execution. La structure reelle du modele Monty Hall (construite dans la cellule de code ci-dessus via `Variable.DiscreteUniform(3)` + 9 blocs `Variable.Case`) est celle decrite textuellement : `voiture, choixJoueur -> porteMonty` avec une table de 9 cas.",,,,,,,,13a3b99fef1eccd1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,tewfv8dwn9e,code,fr,5cfe1b0a472491ef,"// Visualisation du Factor Graph de Monty Hall
+// Recreer le modele avec ShowFactorGraph active et noms explicites
+
+Variable<int> voitureViz = Variable.DiscreteUniform(3).Named(""voiture"");
+Variable<int> choixViz = Variable.DiscreteUniform(3).Named(""choixJoueur"");
+Variable<int> montyViz = Variable.New<int>().Named(""porteMonty"");
+
+// Encodage complet de la logique de Monty
+using (Variable.Case(voitureViz, 0))
+{
+    using (Variable.Case(choixViz, 0)) { montyViz.SetTo(Variable.DiscreteUniform(2) + 1); }
+    using (Variable.Case(choixViz, 1)) { montyViz.SetTo(Variable.Constant(2)); }
+    using (Variable.Case(choixViz, 2)) { montyViz.SetTo(Variable.Constant(1)); }
+}
+using (Variable.Case(voitureViz, 1))
+{
+    using (Variable.Case(choixViz, 0)) { montyViz.SetTo(Variable.Constant(2)); }
+    using (Variable.Case(choixViz, 1)) { montyViz.SetTo(Variable.Discrete(new double[] { 0.5, 0.0, 0.5 })); }
+    using (Variable.Case(choixViz, 2)) { montyViz.SetTo(Variable.Constant(0)); }
+}
+using (Variable.Case(voitureViz, 2))
+{
+    using (Variable.Case(choixViz, 0)) { montyViz.SetTo(Variable.Constant(1)); }
+    using (Variable.Case(choixViz, 1)) { montyViz.SetTo(Variable.Constant(0)); }
+    using (Variable.Case(choixViz, 2)) { montyViz.SetTo(Variable.Discrete(new double[] { 0.5, 0.5, 0.0 })); }
+}
+
+choixViz.ObservedValue = 0;
+montyViz.ObservedValue = 2;
+
+InferenceEngine moteurMontyViz = new InferenceEngine();
+moteurMontyViz.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurMontyViz.ShowFactorGraph = true;
+
+var resultMontyViz = moteurMontyViz.Infer<Discrete>(voitureViz);
+Console.WriteLine(""Factor graph Monty Hall genere."");
+Console.WriteLine($""Verification: P(voiture porte 1) = {resultMontyViz.GetProbs()[1]:F3}"");
+
+// Afficher le factor graph
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,5cfe1b0a472491ef,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,4dda0635,markdown,fr,a5b4782dec5a42e9,"### Explication du Paradoxe
+
+| Scenario initial | Probabilite | Resultat si change |
+|------------------|-------------|--------------------|
+| Joueur choisit la voiture | 1/3 | Perd (change vers chevre) |
+| Joueur choisit une chevre | 2/3 | **Gagne** (change vers voiture) |
+
+**Conclusion** : En changeant, le joueur gagne avec probabilite **2/3** au lieu de 1/3 !",,,,,,,,a5b4782dec5a42e9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,279b4b47,markdown,fr,4e465baafe66ec95,"### Exercice : Monty Hall avec 4 portes
+
+Dans cette variante du probleme de Monty Hall, le jeu presente **4 portes** au lieu de 3. Derriere une seule se trouve la voiture, les 3 autres contiennent des chevres.
+
+**Regles** :
+1. Le joueur choisit une porte parmi 4
+2. Monty ouvre **2 portes** (pas la voiture, pas le choix du joueur)
+3. Il reste 2 portes : le choix initial et une autre
+
+**Objectif** : Modelisez cette variante et comparez la probabilite de gagner en changeant avec le cas a 3 portes.
+
+**Etapes** :
+1. Creer une variable `voiture4` uniforme sur {0, 1, 2, 3}
+2. Creer une variable `choix4` uniforme sur {0, 1, 2, 3}
+3. Definir la logique de Monty : il ouvre 2 portes qui ne sont ni la voiture ni le choix
+4. Observer : choix = 0, portes ouvertes = 2 et 3
+5. Inferer P(voiture | choix=0, ouvertes={2,3})
+
+**Indices** :
+- Utilisez `Variable.Case` comme dans le modele a 3 portes, mais avec 4 valeurs
+- Monty doit choisir 2 portes parmi les 3 restantes (excluant voiture et choix)
+- Simplification : modelisez la porte non-ouverte restante plutot que les 2 portes ouvertes",,,,,,,,4e465baafe66ec95,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,136335b2,code,fr,89f80f2a72451c9d,"// Exercice : Monty Hall avec 4 portes
+// TODO: Creer les variables voiture4 et choix4 (DiscreteUniform sur 4 valeurs)
+// Indice: Variable.DiscreteUniform(4) pour {0, 1, 2, 3}
+
+// TODO: Definir la porte non-ouverte par Monty parmi les portes restantes
+// Indice: Selon la position de la voiture et le choix, Monty ouvre 2 portes
+// Modelisez directement la porte qui RESTE fermee (autre que le choix)
+
+// TODO: Observer choix4 = 0 et les portes ouvertes (ou la porte restante)
+// Indice: porteRestante.ObservedValue = 1 signifie que Monty n'a pas ouvert la porte 1
+
+// TODO: Inferer la distribution de voiture4 et comparer avec le cas 3 portes
+// Indice: moteur.Infer<Discrete>(voiture4) puis comparer GetProbs()
+Console.WriteLine(""Exercice a completer : Monty Hall avec 4 portes"");",,,,,,,,89f80f2a72451c9d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,1cqd0a1aivti,markdown,fr,4ebc7870d099ad54,"### Comparaison Murder Mystery vs Monty Hall
+
+Ces deux problemes illustrent des aspects differents de l'inference bayesienne :
+
+| Aspect | Murder Mystery | Monty Hall |
+|--------|---------------|------------|
+| **Type de variable** | Binaire (2 suspects) | Discrete (3 portes) |
+| **Nature de l'evidence** | Indices physiques | Action d'un agent informe |
+| **Paradoxe** | Indices contradictoires | Information asymetrique |
+| **Intuition** | Assez naturelle | Contre-intuitive |
+| **Pattern Infer.NET** | `Variable.If/IfNot` | `Variable.Case` |
+
+> **Point commun** : Dans les deux cas, l'inference bayesienne fournit la reponse correcte en integrant systematiquement toutes les dependances probabilistes. C'est la force des graphes de facteurs : ils explicitent la structure causale qui peut echapper a l'intuition.",,,,,,,,4ebc7870d099ad54,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,49bb3283,markdown,fr,f5e30dbb317218a5,"## 8. Theoreme de Bayes Illustre
+
+### Formule
+
+$$P(H|E) = \frac{P(E|H) \cdot P(H)}{P(E)}$$
+
+Ou :
+- $P(H)$ : Prior (croyance initiale en l'hypothese)
+- $P(E|H)$ : Vraisemblance (probabilite de l'evidence si H est vrai)
+- $P(H|E)$ : Posterieur (croyance mise a jour)
+- $P(E)$ : Evidence marginale (normalisation)
+
+### Application au Murder Mystery
+
+$$P(\text{Auburn}|\text{Revolver}) = \frac{P(\text{Revolver}|\text{Auburn}) \cdot P(\text{Auburn})}{P(\text{Revolver})}$$",,,,,,,,f5e30dbb317218a5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,pfxz051sfd,markdown,fr,5bd449b613fee000,"### Verification calculatoire
+
+Pour valider que Infer.NET applique correctement le theoreme de Bayes, effectuons le calcul manuellement. Cette verification est une **bonne pratique** lors du developpement de modeles probabilistes : on commence par un cas simple ou le calcul exact est possible, puis on etend a des modeles plus complexes.",,,,,,,,5bd449b613fee000,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,ed7b4853,code,fr,b52d951b5f37bab3,"// Verification manuelle du theoreme de Bayes
+
+double pAuburn = 0.7;  // Prior
+double pGrey = 0.3;
+
+double pRevolverSiAuburn = 0.9;  // Vraisemblance
+double pRevolverSiGrey = 0.2;
+
+// P(Revolver) = P(R|A)*P(A) + P(R|G)*P(G)
+double pRevolver = pRevolverSiAuburn * pAuburn + pRevolverSiGrey * pGrey;
+
+// P(Auburn|Revolver) par Bayes
+double pAuburnSiRevolver = (pRevolverSiAuburn * pAuburn) / pRevolver;
+
+Console.WriteLine(""=== Verification manuelle de Bayes ==="");
+Console.WriteLine($""P(Revolver) = {pRevolver:F3}"");
+Console.WriteLine($""P(Auburn|Revolver) = {pAuburnSiRevolver:F3}"");
+Console.WriteLine($""\nCeci correspond au resultat d'Infer.NET !"");",,,,,,,,b52d951b5f37bab3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,2egjynj0qhj,markdown,fr,5e8de09e52579b33,"### Equivalence calcul manuel et Infer.NET
+
+Le resultat identique (0.913) confirme que :
+
+1. **Infer.NET implemente correctement Bayes** : Le moteur d'inference produit exactement le meme resultat que le calcul analytique
+2. **L'abstraction est fiable** : On peut faire confiance au framework pour des modeles plus complexes ou le calcul manuel serait impraticable
+
+> **Avantage d'Infer.NET** : Pour des modeles avec dizaines de variables et multiples observations, le calcul manuel devient impossible. Infer.NET utilise des algorithmes approximatifs efficaces (Expectation Propagation, Variational Message Passing) qui passent a l'echelle tout en restant precis.",,,,,,,,5e8de09e52579b33,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,388daa33,markdown,fr,11c90dfb26066b1b,"## 9. Patterns de Conditionnement Infer.NET
+
+### Syntaxe de Variable.If / Variable.IfNot
+
+```csharp
+Variable<bool> condition = Variable.Bernoulli(0.5);
+Variable<double> resultat = Variable.New<double>();
+
+using (Variable.If(condition))
+{
+    resultat.SetTo(Variable.GaussianFromMeanAndPrecision(10, 1));
+}
+
+using (Variable.IfNot(condition))
+{
+    resultat.SetTo(Variable.GaussianFromMeanAndPrecision(20, 1));
+}
+```
+
+### Choix du pattern selon le type de condition
+
+| Pattern | Type de condition | Exemple |
+|---------|-------------------|---------|
+| `Variable.If/IfNot` | `Variable<bool>` | Meurtrier (Auburn/Grey) |
+| `Variable.Case` | `Variable<int>` | Position voiture (0/1/2) |
+| `Variable.Switch` | `Variable<int>` + tableau | Selection dans une liste |
+
+> **Bonne pratique** : Utilisez `Variable.If/IfNot` quand c'est possible (cas binaire), car c'est plus lisible. Reservez `Variable.Case` aux variables discretes a plus de 2 valeurs.",,,,,,,,11c90dfb26066b1b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,0d6d0ba2,markdown,fr,fe2291b5784c1831,"## 10. Exemple guide : Ajouter un Temoin
+
+### Enonce
+
+Un temoin declare avoir vu le meurtrier s'enfuir. Sa fiabilite :
+- S'il a bien vu Auburn : 70% de chance de dire ""homme"", 30% de dire ""femme""
+- S'il a bien vu Grey : 20% de chance de dire ""homme"", 80% de dire ""femme""
+
+Le temoin dit avoir vu un **homme**.
+
+### Question
+
+Avec les indices (arme=revolver, cheveu=gris, temoin=homme), quelle est la probabilite de culpabilite ?
+
+**Indice**
+
+Ajoutez une variable `temoin` avec les probabilites conditionnelles appropriees.",,,,,,,,fe2291b5784c1831,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,679egvvkri8,markdown,fr,7074a1f8c253d619,"### Solution de l'exercice
+
+Le code ci-dessous reprend le modele complet avec les trois indices. Notez comment la structure reste identique : on ajoute simplement une nouvelle variable `temoin` avec ses probabilites conditionnelles.
+
+**Structure du modele complet** :
+```
+meurtrier (Bernoulli 0.7)
+    |
+    +-- arme (0.9/0.2 revolver)     --> ObservedValue = true
+    +-- cheveu (0.8/0.1 auburn)     --> ObservedValue = false
+    +-- temoin (0.7/0.2 homme)      --> ObservedValue = true
+```",,,,,,,,7074a1f8c253d619,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,cf629383,code,fr,cae212ae3f974fc7,"// Exemple guide : Modele complet avec temoin
+
+Variable<bool> meurtrierEx = Variable.Bernoulli(0.7);
+Variable<bool> armeEx = Variable.New<bool>();
+Variable<bool> cheveuEx = Variable.New<bool>();
+Variable<bool> temoin = Variable.New<bool>();  // true = homme, false = femme
+
+// Arme
+using (Variable.If(meurtrierEx))
+{
+    armeEx.SetTo(Variable.Bernoulli(0.9));
+}
+using (Variable.IfNot(meurtrierEx))
+{
+    armeEx.SetTo(Variable.Bernoulli(0.2));
+}
+
+// Cheveu
+using (Variable.If(meurtrierEx))
+{
+    cheveuEx.SetTo(Variable.Bernoulli(0.8));
+}
+using (Variable.IfNot(meurtrierEx))
+{
+    cheveuEx.SetTo(Variable.Bernoulli(0.1));
+}
+
+// Temoin : P(homme|Auburn) = 0.7, P(homme|Grey) = 0.2
+using (Variable.If(meurtrierEx))
+{
+    temoin.SetTo(Variable.Bernoulli(0.7));  // 70% dit homme si Auburn
+}
+using (Variable.IfNot(meurtrierEx))
+{
+    temoin.SetTo(Variable.Bernoulli(0.2));  // 20% dit homme si Grey
+}
+
+// Observations
+armeEx.ObservedValue = true;   // Revolver
+cheveuEx.ObservedValue = false; // Cheveu gris
+temoin.ObservedValue = true;   // Temoin dit ""homme""
+
+InferenceEngine moteurEx = new InferenceEngine();
+moteurEx.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Bernoulli posteriorEx = moteurEx.Infer<Bernoulli>(meurtrierEx);
+
+Console.WriteLine(""=== Modele complet avec temoin ==="");
+Console.WriteLine($""Indices : arme=revolver, cheveu=gris, temoin=homme\n"");
+Console.WriteLine($""P(Auburn coupable) = {posteriorEx.GetProbTrue():F3}"");
+Console.WriteLine($""P(Grey coupable) = {1 - posteriorEx.GetProbTrue():F3}"");",,,,,,,,cae212ae3f974fc7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,pxy35droao,markdown,fr,bd288bbdd68aea3a,"### Analyse de l'exercice avec témoin
+
+**Résultat** : P(Auburn | revolver, cheveu gris, témoin homme) = **0.891**
+
+Le témoignage ""homme"" a un **fort impact** car son likelihood ratio est significatif :
+$$\text{LR}_{\text{témoin}} = \frac{P(\text{homme}|\text{Auburn})}{P(\text{homme}|\text{Grey})} = \frac{0.7}{0.2} = 3.5$$
+
+**Évolution de la probabilité** :
+
+| Étape | P(Auburn) | Indices |
+|-------|-----------|---------|
+| Prior | 0.70 | Aucun |
+| +Revolver | 0.91 | Arme seule |
+| +Cheveu gris | 0.70 | Arme + Cheveu (annulation) |
+| +Témoin homme | **0.89** | Tous les indices |
+
+Le témoin rompt l'équilibre créé par les deux premiers indices contradictoires. Avec trois indices, deux pointent vers Auburn (revolver, témoin) contre un seul vers Grey (cheveu), d'où une probabilité finale fortement en faveur d'Auburn.",,,,,,,,bd288bbdd68aea3a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,sb08nqbu2xo,markdown,fr,c2ddca8eb7d9098a,"### Tableau recapitulatif des likelihood ratios
+
+| Indice | P(indice\|Auburn) | P(indice\|Grey) | Likelihood Ratio | Direction |
+|--------|-------------------|-----------------|------------------|-----------|
+| Revolver | 0.90 | 0.20 | 4.50 | Auburn |
+| Cheveu gris | 0.20 | 0.90 | 0.22 | Grey |
+| Temoin homme | 0.70 | 0.20 | 3.50 | Auburn |
+| **Produit** | - | - | **3.50** | Auburn |
+
+Le produit des likelihood ratios (4.50 x 0.22 x 3.50 = 3.50) multiplie les prior odds (0.70/0.30 = 2.33) pour donner les posterior odds : 2.33 x 3.50 = 8.17, soit P(Auburn) = 8.17/(1+8.17) = **0.891**.
+
+> **Interpretation** : Le temoin ""casse l'egalite"" entre revolver et cheveu, donnant un avantage net a Auburn. C'est un exemple de la **regle de multiplication des odds** en inference bayesienne sequentielle.",,,,,,,,c2ddca8eb7d9098a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,xkce0tbg37k,markdown,fr,1a42845f6aa20dec,"---
+
+## Points cles a retenir
+
+Avant de passer au resume, voici les enseignements essentiels de ce notebook :
+
+**1. Les graphes de facteurs explicitent les dependances**
+- Chaque variable est un noeud, chaque relation est un facteur
+- La visualisation aide a comprendre la structure du modele
+
+**2. L'inference bayesienne combine les indices de maniere coherente**
+- Les likelihood ratios quantifient la force discriminante de chaque indice
+- Des indices contradictoires peuvent s'annuler (cheveu vs revolver)
+- Un nouvel indice peut ""casser l'egalite""
+
+**3. Monty Hall illustre l'importance du modele complet**
+- L'intuition echoue car elle ignore les contraintes de Monty
+- Le modele probabiliste capture toute l'information pertinente
+
+**4. Infer.NET abstrait la complexite calculatoire**
+- Le framework gere automatiquement l'inference
+- On peut se concentrer sur la modelisation plutot que sur les algorithmes",,,,,,,,1a42845f6aa20dec,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,6766b0f9,markdown,fr,0567a0f3530b5ca2,"## 11. Resume
+
+| Concept | Description |
+|---------|-------------|
+| **Graphe de facteurs** | Representation graphique d'une distribution jointe |
+| **Variable.If/IfNot** | Conditionnement binaire |
+| **Variable.Case** | Conditionnement discret multi-valeur |
+| **Theoreme de Bayes** | Mise a jour des croyances avec l'evidence |
+| **Murder Mystery** | Exemple classique d'inference discrete |
+| **Monty Hall** | Paradoxe illustrant l'importance du conditionnement |
+
+---
+
+## Prochaine etape
+
+Dans [Infer-4-Bayesian-Networks](Infer-4-Bayesian-Networks.ipynb), nous approfondirons :
+
+- Les reseaux bayesiens classiques (Wet Grass / Sprinkler / Rain)
+- Les tables de probabilites conditionnelles (CPT)
+- L'inference causale vs observationnelle
+- La D-separation et l'independance conditionnelle",,,,,,,,0567a0f3530b5ca2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,gyakzydsv4,markdown,fr,95b3a6c0b67cc6a6,"---
+
+## Tableau recapitulatif des distributions utilisees
+
+| Distribution | Syntaxe Infer.NET | Parametres | Usage dans ce notebook |
+|--------------|-------------------|------------|------------------------|
+| **Bernoulli** | `Variable.Bernoulli(p)` | p = P(true) | Meurtrier, indices binaires |
+| **Discrete uniforme** | `Variable.DiscreteUniform(n)` | n = nombre de valeurs | Position voiture (Monty Hall) |
+| **Discrete** | `Variable.Discrete(probs)` | probs = tableau de probabilites | Choix de Monty quand plusieurs options |
+| **Constant** | `Variable.Constant(v)` | v = valeur fixee | Porte deterministe pour Monty |
+
+## Concepts probabilistes illustres
+
+| Concept | Definition | Illustration |
+|---------|------------|--------------|
+| **Prior** | Croyance avant observation | P(Auburn) = 0.7 |
+| **Likelihood** | Probabilite de l'evidence sachant l'hypothese | P(revolver\|Auburn) = 0.9 |
+| **Posterior** | Croyance apres observation | P(Auburn\|revolver) = 0.913 |
+| **Likelihood Ratio** | Rapport des vraisemblances | 0.9/0.2 = 4.5 |
+| **Independance conditionnelle** | Variables independantes sachant le parent | Arme, cheveu, temoin sachant meurtrier |",,,,,,,,95b3a6c0b67cc6a6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,1cab470c,markdown,fr,0361760b3562e9cc,"## 11. Exercice : Deuxieme Affaire : Deux Suspects
+
+### Enonce
+
+Une deuxieme affaire criminelle implique **deux suspects** : Alice et Bob.
+Un temoin declare avoir vu ""une personne grande et blonde"" fuir les lieux.
+
+Probabilites physiques :
+- Alice : grande avec P=0.7, blonde avec P=0.6
+- Bob : grand avec P=0.4, blond avec P=0.3
+- A priori : P(Alice coupable) = P(Bob coupable) = 0.5
+
+Calculez la probabilite de culpabilite de chaque suspect sachant le temoignage.
+
+**Indice** : Le facteur ""correspond a la description"" est True si la personne EST coupable ET correspond physiquement.",,,,,,,,0361760b3562e9cc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,8b8b23f0,code,fr,487b84914713802a,"// Exemple guide : Deux suspects - mise a jour bayesienne sur description physique
+// TODO: Creer le moteur d'inference
+
+// TODO: Definir les caracteristiques physiques comme variables aleatoires
+
+// TODO: Definir la variable de culpabilite (une seule personne peut etre coupable)
+
+// TODO: Definir si le fuyard correspond a la description du temoin
+// Si Alice est coupable : correspond = aliceGrande AND aliceBlonde
+// Si Bob est coupable : correspond = bobGrand AND bobBlond
+// Utilisez Variable.If(aliceCoupable) { ... } Variable.IfNot(aliceCoupable) { ... }
+
+// TODO: Observer que le suspect correspond a la description
+
+// TODO: Inferer et afficher
+// Pourquoi Alice est-elle plus suspecte malgre un a priori egal ?
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,487b84914713802a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb,9875d7fb,markdown,fr,6e9ff2210c7637c1,"## Conclusion
+
+Ce notebook a couvert les graphes de facteurs et l'inference discrete : Murder Mystery, Monty Hall, theoreme de Bayes et patterns de conditionnement Infer.NET.
+
+| Concept | Point cle |
+|---------|-----------|
+| Graphe de facteurs | Representation de P(jointe) = produit de facteurs |
+| Variable.If/IfNot | Conditionnement binaire (meurtrier = Auburn/Grey) |
+| Variable.Case | Conditionnement discret multi-valeur (Monty Hall, 3 portes) |
+| Theoreme de Bayes | Posterior proportional a Likelihood x Prior |
+| Likelihood ratio | Quantifie la force discriminante de chaque indice |
+
+| Distribution | Usage |
+|--------------|-------|
+| Bernoulli | Variables booleennes (coupable, indice present/absent) |
+| DiscreteUniform | Variables discretes equiprobables (position d'une porte) |
+| Discrete(probs) | Variables discretes avec probabilites personnalisees |
+
+> **Lecon principale** : L'inference bayesienne combine systematiquement tous les indices disponibles, meme contradictoires. Le Murder Mystery montre que des indices opposes peuvent s'annuler (LR produit = 1), tandis que Monty Hall illustre que l'intuition echoue quand les contraintes du modele sont ignorees. Infer.NET automatise ces calculs, permettant de se concentrer sur la modelisation.",,,,,,,,6e9ff2210c7637c1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,628e4ed2,markdown,fr,f57e299b21eab7c5,"# Infer-4-Bayesian-Networks : Reseaux Bayesiens Classiques
+
+**Serie** : Programmation Probabiliste avec Infer.NET (4/20)  
+**Duree estimee** : 55 minutes  
+**Prerequis** : Infer-3-Factor-Graphs
+
+---
+
+## Objectifs
+
+- Comprendre les reseaux bayesiens et leur structure
+- Implementer le reseau classique Wet Grass / Sprinkler / Rain
+- Maitriser les tables de probabilites conditionnelles (CPT)
+- Distinguer inference causale et observationnelle
+- Comprendre la D-separation et l'independance conditionnelle
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-3-Factor-Graphs](Infer-3-Factor-Graphs.ipynb) | [Infer-7-Skills-IRT](Infer-7-Skills-IRT.ipynb) |
+
+---",,,,,,,,f57e299b21eab7c5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,58b363a7,markdown,fr,2b32fb3a4b0ac11a,"## 1. Configuration
+
+Cette section initialise l'environnement Infer.NET avec les packages necessaires pour construire et inferer des reseaux bayesiens. Les reseaux bayesiens sont des modeles graphiques diriges qui representent les relations de dependance conditionnelle entre variables.",,,,,,,,2b32fb3a4b0ac11a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,18c3563a,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,fa28e118,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,t0tfhjm619i,code,fr,bfcc2fe4e2a7bc50,"// Chargement du helper pour visualiser les graphes de facteurs
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine($""FactorGraphHelper charge. Graphviz disponible: {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,bfcc2fe4e2a7bc50,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,w0sp61i8kz,markdown,fr,6d7050cd31d9dd4a,"**Environnement pret.** Les packages Infer.NET charges incluent :
+- `Microsoft.ML.Probabilistic` : moteur d'inference
+- `Microsoft.ML.Probabilistic.Compiler` : compilation de modeles vers code C#
+- `Microsoft.ML.Probabilistic.Models` : API de construction de modeles
+
+Infer.NET utilise l'algorithme **Expectation Propagation** (EP) par defaut, particulierement adapte aux reseaux bayesiens avec variables discretes et continues.",,,,,,,,6d7050cd31d9dd4a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,34a6aa88,markdown,fr,0d5eef7ee01ab83a,"## 2. Introduction aux Reseaux Bayesiens
+
+### Definition
+
+Un **reseau bayesien** est un graphe dirige acyclique (DAG) ou :
+- Les **noeuds** representent des variables aleatoires
+- Les **arcs** representent des dependances directes
+- Chaque noeud a une **table de probabilite conditionnelle** (CPT)
+
+### Proprietes
+
+$$P(X_1, ..., X_n) = \prod_{i=1}^{n} P(X_i | \text{Parents}(X_i))$$
+
+### Avantages
+
+| Avantage | Description |
+|----------|-------------|
+| **Compacite** | Representation factorisee de la jointe |
+| **Interpretabilite** | Structure causale explicite |
+| **Inference efficace** | Algorithmes de propagation |
+| **Apprentissage** | Structure et parametres apprenables |",,,,,,,,0d5eef7ee01ab83a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,10ad9e61,markdown,fr,4f79b72221971702,"## 3. Le Reseau Wet Grass / Sprinkler / Rain
+
+### Structure
+
+```
+         (Cloudy)
+         /      \
+        v        v
+   (Sprinkler)  (Rain)
+        \        /
+         v      v
+        (WetGrass)
+```
+
+### Semantique
+
+- **Cloudy** : Temps nuageux (cause commune)
+- **Sprinkler** : Arroseur automatique (s'active moins si nuageux)
+- **Rain** : Pluie (plus probable si nuageux)
+- **WetGrass** : Herbe mouillee (effet commun)
+
+### Tables de Probabilites Conditionnelles
+
+| Variable | CPT |
+|----------|-----|
+| Cloudy | P(C=T) = 0.5 |
+| Sprinkler | P(S=T\|C=T) = 0.1, P(S=T\|C=F) = 0.5 |
+| Rain | P(R=T\|C=T) = 0.8, P(R=T\|C=F) = 0.2 |
+| WetGrass | P(W=T\|S,R) - voir table complete |",,,,,,,,4f79b72221971702,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,2614b3bf,code,fr,e94311d2abcb0100,"// Implementation du reseau Wet Grass
+
+// Variable racine : Cloudy
+Variable<bool> cloudy = Variable.Bernoulli(0.5).Named(""cloudy"");
+
+// Sprinkler conditionne par Cloudy
+Variable<bool> sprinkler = Variable.New<bool>().Named(""sprinkler"");
+using (Variable.If(cloudy))
+{
+    sprinkler.SetTo(Variable.Bernoulli(0.1));  // Peu probable si nuageux
+}
+using (Variable.IfNot(cloudy))
+{
+    sprinkler.SetTo(Variable.Bernoulli(0.5));  // Plus probable si ensoleille
+}
+
+// Rain conditionne par Cloudy
+Variable<bool> rain = Variable.New<bool>().Named(""rain"");
+using (Variable.If(cloudy))
+{
+    rain.SetTo(Variable.Bernoulli(0.8));  // Tres probable si nuageux
+}
+using (Variable.IfNot(cloudy))
+{
+    rain.SetTo(Variable.Bernoulli(0.2));  // Peu probable si ensoleille
+}
+
+// WetGrass conditionne par Sprinkler ET Rain
+Variable<bool> wetGrass = Variable.New<bool>().Named(""wetGrass"");
+
+// CPT pour WetGrass
+// S=F, R=F -> P(W=T) = 0.0
+// S=F, R=T -> P(W=T) = 0.9
+// S=T, R=F -> P(W=T) = 0.9
+// S=T, R=T -> P(W=T) = 0.99
+
+using (Variable.If(sprinkler))
+{
+    using (Variable.If(rain))
+    {
+        wetGrass.SetTo(Variable.Bernoulli(0.99));  // S=T, R=T
+    }
+    using (Variable.IfNot(rain))
+    {
+        wetGrass.SetTo(Variable.Bernoulli(0.9));   // S=T, R=F
+    }
+}
+using (Variable.IfNot(sprinkler))
+{
+    using (Variable.If(rain))
+    {
+        wetGrass.SetTo(Variable.Bernoulli(0.9));   // S=F, R=T
+    }
+    using (Variable.IfNot(rain))
+    {
+        wetGrass.SetTo(Variable.Bernoulli(0.0));   // S=F, R=F
+    }
+}
+
+Console.WriteLine(""Reseau Wet Grass defini."");",,,,,,,,e94311d2abcb0100,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,to2gkt8vl3o,markdown,fr,92ec3d29fe792867,"### Analyse de la structure du modele
+
+Le modele Wet Grass est maintenant defini. Observons les elements cles de l'implementation :
+
+| Element Infer.NET | Utilisation | Signification |
+|-------------------|-------------|---------------|
+| `Variable.Bernoulli(p)` | Prior marginal | Variable racine avec probabilite p |
+| `Variable.New<bool>()` | Variable conditionnelle | Declaration sans prior (defini ensuite) |
+| `Variable.If(x)` / `Variable.IfNot(x)` | Branchement conditionnel | Encode les CPT via des blocs imbriques |
+| `SetTo()` | Affectation conditionnelle | Definit la distribution dans chaque branche |
+
+**Structure du graphe de facteurs** : Infer.NET compile ce code en un graphe de facteurs equivalent :
+- 4 variables : Cloudy, Sprinkler, Rain, WetGrass
+- 4 facteurs : 1 prior (Cloudy) + 3 CPT conditionnelles
+
+> **Point technique** : Les blocs `Variable.If`/`Variable.IfNot` imbriques implementent naturellement les tables de probabilites conditionnelles. Chaque combinaison de conditions definit une entree de la CPT.",,,,,,,,92ec3d29fe792867,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,r7m35mp69q,markdown,fr,8168cd46f0d1d60a,"---
+
+### Inference des probabilites marginales
+
+Nous allons maintenant utiliser le moteur d'inference pour calculer les **probabilites marginales** de chaque variable, c'est-a-dire P(X) sans aucune observation.
+
+L'algorithme **Expectation Propagation** (EP) propage des messages dans le graphe de facteurs pour calculer ces marginales efficacement, sans enumerer toutes les combinaisons possibles.",,,,,,,,8168cd46f0d1d60a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,c9a38dab,code,fr,f83d733888539063,"// Inference sans observations
+InferenceEngine moteur = new InferenceEngine();
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur.ShowFactorGraph = true;  // Genere le graphe de facteurs
+
+Console.WriteLine(""=== Probabilites marginales (sans observation) ==="");
+Console.WriteLine($""P(Cloudy) = {moteur.Infer<Bernoulli>(cloudy).GetProbTrue():F3}"");
+Console.WriteLine($""P(Sprinkler) = {moteur.Infer<Bernoulli>(sprinkler).GetProbTrue():F3}"");
+Console.WriteLine($""P(Rain) = {moteur.Infer<Bernoulli>(rain).GetProbTrue():F3}"");
+Console.WriteLine($""P(WetGrass) = {moteur.Infer<Bernoulli>(wetGrass).GetProbTrue():F3}"");",,,,,,,,f83d733888539063,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,6e3b285d,markdown,fr,c81f280e7707b238,Visualisation du graphe de facteurs du reseau Wet Grass.,,,,,,,,c81f280e7707b238,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,spax5m0vwt,code,fr,f317eb2da3d70399,"// Visualisation du graphe de facteurs du reseau Wet Grass
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,f317eb2da3d70399,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,ffbsq502k3,markdown,fr,9e362458e31672c3,"### Lecture du graphe de facteurs
+
+
+Le graphe ci-dessus represente la structure compilee par Infer.NET :
+
+- **Cercles/Ovales** : Variables aleatoires (Cloudy, Sprinkler, Rain, WetGrass)
+- **Carres/Rectangles** : Facteurs (distributions conditionnelles, CPT)
+- **Aretes** : Connexions variable-facteur
+
+La structure reflète le DAG bayésien original avec ses 4 noeuds, mais Infer.NET le compile en graphe de facteurs où les CPT deviennent des facteurs explicites. Notez comment les blocs `Variable.If/IfNot` imbriqués sont représentés.",,,,,,,,9e362458e31672c3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,gablmpih1mj,markdown,fr,6ca10a420d3c46c3,"### Analyse des probabilites marginales
+
+**Résultats** :
+- P(Cloudy) = 0.500 — le prior direct
+- P(Sprinkler) = 0.300 — moyenne pondérée : 0.5×0.1 + 0.5×0.5 = 0.30 ✓
+- P(Rain) = 0.500 — moyenne pondérée : 0.5×0.8 + 0.5×0.2 = 0.50 ✓
+- P(WetGrass) = 0.598 — plus complexe, dépend des 4 combinaisons S×R
+
+**Calcul détaillé de P(WetGrass)** :
+
+$$P(W) = \sum_{s,r} P(W|S=s,R=r) \cdot P(S=s) \cdot P(R=r)$$
+
+La valeur ~60% reflète que l'herbe mouillée est un phénomène relativement fréquent avec ces paramètres.",,,,,,,,6ca10a420d3c46c3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,jz7rru063ho,markdown,fr,6ee4b2f1259a6a59,"---
+
+### Vers l'inference conditionnelle
+
+Les marginales nous donnent les probabilites ""a priori"" (sans observation). Le veritable pouvoir des reseaux bayesiens reside dans leur capacite a **mettre a jour ces croyances** lorsqu'on observe des evidences.
+
+Que se passe-t-il quand on observe que **l'herbe est mouillee** ? Les probabilites des causes potentielles (pluie, arroseur) doivent etre revisees selon le theoreme de Bayes.",,,,,,,,6ee4b2f1259a6a59,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,0b7d8e44,markdown,fr,524add79be9c3231,## 4. Inference avec Observations,,,,,,,,524add79be9c3231,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,f5e89e66,code,fr,4ed112711c585fda,"// Nouveau modele pour inference avec observation
+Variable<bool> cloudy2 = Variable.Bernoulli(0.5).Named(""cloudy2"");
+Variable<bool> sprinkler2 = Variable.New<bool>().Named(""sprinkler2"");
+Variable<bool> rain2 = Variable.New<bool>().Named(""rain2"");
+Variable<bool> wetGrass2 = Variable.New<bool>().Named(""wetGrass2"");
+
+// Meme structure que precedemment
+using (Variable.If(cloudy2))
+{
+    sprinkler2.SetTo(Variable.Bernoulli(0.1));
+    rain2.SetTo(Variable.Bernoulli(0.8));
+}
+using (Variable.IfNot(cloudy2))
+{
+    sprinkler2.SetTo(Variable.Bernoulli(0.5));
+    rain2.SetTo(Variable.Bernoulli(0.2));
+}
+
+using (Variable.If(sprinkler2))
+{
+    using (Variable.If(rain2))
+        wetGrass2.SetTo(Variable.Bernoulli(0.99));
+    using (Variable.IfNot(rain2))
+        wetGrass2.SetTo(Variable.Bernoulli(0.9));
+}
+using (Variable.IfNot(sprinkler2))
+{
+    using (Variable.If(rain2))
+        wetGrass2.SetTo(Variable.Bernoulli(0.9));
+    using (Variable.IfNot(rain2))
+        wetGrass2.SetTo(Variable.Bernoulli(0.0));
+}
+
+// OBSERVATION : L'herbe est mouillee
+wetGrass2.ObservedValue = true;
+
+InferenceEngine moteur2 = new InferenceEngine();
+moteur2.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur2.ShowFactorGraph = true;  // Genere le graphe avec observation
+
+Console.WriteLine(""=== Inference : P(X | WetGrass=True) ==="");
+Console.WriteLine($""P(Rain | WetGrass) = {moteur2.Infer<Bernoulli>(rain2).GetProbTrue():F3}"");
+Console.WriteLine($""P(Sprinkler | WetGrass) = {moteur2.Infer<Bernoulli>(sprinkler2).GetProbTrue():F3}"");
+Console.WriteLine($""P(Cloudy | WetGrass) = {moteur2.Infer<Bernoulli>(cloudy2).GetProbTrue():F3}"");",,,,,,,,4ed112711c585fda,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,c6430838,markdown,fr,033ae86179486812,Visualisation du graphe avec l'observation WetGrass=True.,,,,,,,,033ae86179486812,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,o776l3xh7tc,code,fr,d53b0bb9682a9942,"// Visualisation du graphe avec observation WetGrass=True
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,d53b0bb9682a9942,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,pqsv49ncqab,markdown,fr,a72f5bfcf58caf14,"### Impact de l'observation sur le graphe
+
+
+Comparez ce graphe avec le precedent. L'observation `WetGrass=True` est integree directement dans la structure du modele compile. Dans Infer.NET, une variable observee n'est plus une variable aleatoire mais une constante, ce qui simplifie certains facteurs.
+
+L'inference remonte maintenant des effets vers les causes (**abduction**), mettant a jour les probabilites de Rain, Sprinkler et Cloudy.",,,,,,,,a72f5bfcf58caf14,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,zom6al00ws,markdown,fr,322bc0c1f2340595,"### Analyse de l'inférence conditionnelle
+
+**Résultats** : P(X | WetGrass=True)
+
+| Variable | Prior | Posterior | Changement |
+|----------|-------|-----------|------------|
+| Rain | 0.500 | **0.784** | +57% |
+| Sprinkler | 0.300 | **0.404** | +35% |
+| Cloudy | 0.500 | **0.604** | +21% |
+
+**Interprétation** :
+- L'herbe mouillée est une **forte évidence** pour la pluie (car P(W|R,¬S)=0.9)
+- L'arroseur est aussi plus probable, mais moins fortement
+- Le temps nuageux augmente car il favorise la pluie, qui explique bien l'herbe mouillée
+
+> **Raisonnement abductif** : L'inférence ""remonte"" des effets vers les causes. C'est le cœur du diagnostic bayésien.",,,,,,,,322bc0c1f2340595,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,df755952,markdown,fr,65a9f23fc0545888,"### Phenomene de l'Explaining Away
+
+Le phenomene d'**explaining away** est central en raisonnement bayesien. Il se produit lorsque deux causes alternatives d'un meme effet ""competent"" pour l'expliquer.
+
+**Scenario** : L'herbe est mouillee. Deux causes possibles : pluie ou arroseur.
+- Si on observe seulement l'herbe mouillee, les deux causes deviennent plus probables
+- Mais si on apprend EN PLUS qu'il a plu, l'arroseur devient MOINS necessaire comme explication
+
+Verifions ce phenomene en ajoutant l'observation Rain=True au modele precedent.",,,,,,,,65a9f23fc0545888,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,66769df0,code,fr,843d4bf0ba23a506,"// Demonstation de l'Explaining Away
+Variable<bool> cloudy3 = Variable.Bernoulli(0.5);
+Variable<bool> sprinkler3 = Variable.New<bool>();
+Variable<bool> rain3 = Variable.New<bool>();
+Variable<bool> wetGrass3 = Variable.New<bool>();
+
+using (Variable.If(cloudy3))
+{
+    sprinkler3.SetTo(Variable.Bernoulli(0.1));
+    rain3.SetTo(Variable.Bernoulli(0.8));
+}
+using (Variable.IfNot(cloudy3))
+{
+    sprinkler3.SetTo(Variable.Bernoulli(0.5));
+    rain3.SetTo(Variable.Bernoulli(0.2));
+}
+
+using (Variable.If(sprinkler3))
+{
+    using (Variable.If(rain3))
+        wetGrass3.SetTo(Variable.Bernoulli(0.99));
+    using (Variable.IfNot(rain3))
+        wetGrass3.SetTo(Variable.Bernoulli(0.9));
+}
+using (Variable.IfNot(sprinkler3))
+{
+    using (Variable.If(rain3))
+        wetGrass3.SetTo(Variable.Bernoulli(0.9));
+    using (Variable.IfNot(rain3))
+        wetGrass3.SetTo(Variable.Bernoulli(0.0));
+}
+
+// Observations : WetGrass=True ET Rain=True
+wetGrass3.ObservedValue = true;
+rain3.ObservedValue = true;
+
+InferenceEngine moteur3 = new InferenceEngine();
+moteur3.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur3.ShowFactorGraph = true;  // Graphe avec deux observations
+
+Console.WriteLine(""=== Explaining Away ==="");
+Console.WriteLine($""P(Sprinkler | WetGrass, Rain) = {moteur3.Infer<Bernoulli>(sprinkler3).GetProbTrue():F3}"");
+Console.WriteLine(""\nComparaison :"");
+Console.WriteLine(""  P(Sprinkler | WetGrass) ~ 0.40"");  // coherent avec P=0,404 (cellule precedente)
+Console.WriteLine(""  P(Sprinkler | WetGrass, Rain) ~ 0.19"");
+Console.WriteLine(""\n=> La pluie 'explique' l'herbe mouillee, reduisant P(Sprinkler)"");",,,,,,,,843d4bf0ba23a506,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,fe79e76c,markdown,fr,603b9ceab8285a0c,Visualisation du graphe illustrant le phenomene d'Explaining Away.,,,,,,,,603b9ceab8285a0c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,1a875bl3ljl,code,fr,2e9ebf155f385d3f,"// Visualisation du graphe avec Explaining Away (Rain et WetGrass observes)
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,2e9ebf155f385d3f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,w0is6y503v,markdown,fr,8583efa53a2c8594,"### Structure de l'Explaining Away dans le graphe
+
+
+Dans ce graphe, deux variables sont observees (Rain=True, WetGrass=True). Observez comment le graphe se simplifie :
+
+- **Rain** n'est plus une variable aleatoire mais une constante
+- **WetGrass** egalement, ce qui ""coupe"" certains chemins d'inference
+
+Le phenomene d'explaining away emerge de la structure de **collider** au niveau de WetGrass. Les deux causes (Sprinkler et Rain) etaient independantes marginalement, mais deviennent dependantes une fois l'effet (WetGrass) observe.",,,,,,,,8583efa53a2c8594,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,bn50qzj6wv,markdown,fr,37258967ffe113c5,"### Explication du phénomène ""Explaining Away""
+
+**Résultat clé** : P(Sprinkler | WetGrass, Rain) = **0.194** vs P(Sprinkler | WetGrass) ≈ 0.40
+
+Quand on observe que **l'herbe est mouillée ET qu'il a plu**, la pluie ""explique"" suffisamment l'observation. L'arroseur devient **moins nécessaire** comme explication.
+
+**Analogie intuitive** : Si vous arrivez au bureau trempé et que je sais qu'il pleut dehors, je ne vais pas penser que vous êtes aussi passé sous un arroseur. Une explication suffit.
+
+**Structure graphique** :
+```
+(Sprinkler) → (WetGrass) ← (Rain)
+            [collider]
+```
+
+Au collider, les deux causes sont **marginalement indépendantes** mais deviennent **conditionnellement dépendantes** quand l'effet est observé. C'est contre-intuitif mais fondamental en raisonnement bayésien.",,,,,,,,37258967ffe113c5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,29bc2eb0,markdown,fr,c3febeebe6a952ab,"## 5. D-Separation et Independance Conditionnelle
+
+### Definition
+
+La **D-separation** est un critere graphique pour determiner l'independance conditionnelle dans un reseau bayesien.
+
+### Trois structures de base
+
+| Structure | Nom | Independance |
+|-----------|-----|-------------|
+| A -> B -> C | Chaine | A _|_ C \| B |
+| A <- B -> C | Fork (cause commune) | A _|_ C \| B |
+| A -> B <- C | Collider (effet commun) | A _|_ C, mais A /|/ C \| B |
+
+### Application au reseau Wet Grass
+
+Le reseau Wet Grass contient deux structures cles :
+
+1. **Fork** (S <- C -> R) : Sprinkler et Rain ont une cause commune (Cloudy)
+   - Marginalement : S et R sont **dependants** (l'info passe par C)
+   - Conditionnellement a C : S et R sont **independants**
+
+2. **Collider** (S -> W <- R) : WetGrass est un effet commun
+   - Marginalement : S et R sont **independants** via ce chemin
+   - Conditionnellement a W : S et R deviennent **dependants** (explaining away)",,,,,,,,c3febeebe6a952ab,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,615d8be4,code,fr,dd678697941f3848,"// Verification de la D-separation
+
+// Test 1 : Sprinkler et Rain sans observation sur WetGrass
+Variable<bool> c4 = Variable.Bernoulli(0.5);
+Variable<bool> s4 = Variable.New<bool>();
+Variable<bool> r4 = Variable.New<bool>();
+
+using (Variable.If(c4)) { s4.SetTo(Variable.Bernoulli(0.1)); r4.SetTo(Variable.Bernoulli(0.8)); }
+using (Variable.IfNot(c4)) { s4.SetTo(Variable.Bernoulli(0.5)); r4.SetTo(Variable.Bernoulli(0.2)); }
+
+// Observation : Sprinkler = true
+s4.ObservedValue = true;
+
+InferenceEngine m4 = new InferenceEngine();
+m4.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Console.WriteLine(""=== Test D-separation (sans WetGrass) ==="");
+Console.WriteLine($""P(Rain | Sprinkler) = {m4.Infer<Bernoulli>(r4).GetProbTrue():F3}"");
+Console.WriteLine(""P(Rain) marginale = 0.500"");
+Console.WriteLine(""\n=> S et R ne sont PAS marginalement independants !"");
+Console.WriteLine(""   Observer S donne de l'information sur C, qui informe R."");",,,,,,,,dd678697941f3848,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,j6jgoiplzhi,markdown,fr,8911e6ad3700179c,"### Analyse du resultat
+
+**Resultat** : P(Rain | Sprinkler=True) = **0.300** != P(Rain) = 0.500
+
+Ceci confirme que S et R sont **marginalement dependants** dans la structure fork.
+
+**Explication** : Observer Sprinkler=True donne de l'information sur Cloudy via le theoreme de Bayes :
+
+$$P(\text{Cloudy} | S=T) = \frac{P(S=T|\text{Cloudy}) \cdot P(\text{Cloudy})}{P(S=T)} = \frac{0.1 \times 0.5}{0.3} \approx 0.167$$
+
+Donc il fait probablement beau (ensoleille), et :
+
+$$P(\text{Rain} | S=T) \approx P(R|C) \cdot P(C|S) + P(R|\neg C) \cdot P(\neg C|S) = 0.8 \times 0.167 + 0.2 \times 0.833 \approx 0.30$$
+
+> **Point cle** : Dans un fork, les variables enfants sont independantes **conditionnellement au parent**, pas marginalement. L'information ""passe"" par la cause commune.",,,,,,,,8911e6ad3700179c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,je9xkz3uh8j,markdown,fr,64f835dd7c8343b0,"---
+
+### Verification de l'independance conditionnelle
+
+Pour verifier la D-separation, testons ce qui se passe quand on **observe Cloudy** en plus de Sprinkler. Si la theorie est correcte, Rain ne devrait plus changer.",,,,,,,,64f835dd7c8343b0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,vpa8u5ynn6,code,fr,c4bb98c9eaaa2183,"// Test 2 : D-separation avec Cloudy observe
+// Si on conditionne sur Cloudy, S et R deviennent independants
+
+Variable<bool> c5 = Variable.Bernoulli(0.5);
+Variable<bool> s5 = Variable.New<bool>();
+Variable<bool> r5 = Variable.New<bool>();
+
+using (Variable.If(c5)) { s5.SetTo(Variable.Bernoulli(0.1)); r5.SetTo(Variable.Bernoulli(0.8)); }
+using (Variable.IfNot(c5)) { s5.SetTo(Variable.Bernoulli(0.5)); r5.SetTo(Variable.Bernoulli(0.2)); }
+
+// Observations : Cloudy = false ET Sprinkler = true
+c5.ObservedValue = false;  // On fixe Cloudy
+s5.ObservedValue = true;
+
+InferenceEngine m5 = new InferenceEngine();
+m5.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+Console.WriteLine(""=== Test D-separation (avec Cloudy observe) ==="");
+Console.WriteLine($""P(Rain | Sprinkler, Cloudy=False) = {m5.Infer<Bernoulli>(r5).GetProbTrue():F3}"");
+Console.WriteLine(""P(Rain | Cloudy=False) = 0.200"");
+Console.WriteLine(""\n=> S et R sont independants conditionnellement a C !"");
+Console.WriteLine(""   Une fois C connu, observer S n'apporte plus d'information sur R."");",,,,,,,,c4bb98c9eaaa2183,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,qu27uwkf3u,markdown,fr,66b3b651ac61c40d,"**Verification de l'independance conditionnelle** :
+
+Le resultat P(Rain | S, C=F) = **0.200** = P(Rain | C=F) confirme que :
+
+$$S \perp\!\!\!\perp R \mid C$$
+
+Sprinkler et Rain sont **conditionnellement independants** sachant Cloudy. C'est exactement ce que predit la D-separation pour une structure fork.
+
+| Test | Resultat | Interpretation |
+|------|----------|----------------|
+| P(R \| S) = 0.30 | != P(R) = 0.50 | S et R dependants marginalement |
+| P(R \| S, C) = 0.20 | = P(R \| C) = 0.20 | S et R independants sachant C |",,,,,,,,66b3b651ac61c40d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,0ced45f5,markdown,fr,ff10934c66da9ae9,"### Exercice : Verifier le Collider avec Explaining Away
+
+Dans le reseau Wet Grass, la structure Sprinkler -> WetGrass <- Rain forme un **collider**. La theorie de la D-separation predit que Sprinkler et Rain sont independants marginalement, mais deviennent dependants quand WetGrass est observe.
+
+**Objectif** : Verifiez experimentalement cette prediction en implementant les deux tests.
+
+**Etapes** :
+1. Sans observation sur WetGrass : calculez P(Sprinkler) et P(Sprinkler | Rain=True). Sont-ils egaux ?
+2. Avec observation WetGrass=True : calculez P(Sprinkler | WetGrass=True) et P(Sprinkler | Rain=True, WetGrass=True). Sont-ils egaux ?
+3. Concluez sur la (in)dependance conditionnelle
+
+**Indices** :
+- Pour le test 1, creez le modele sans ObservedValue sur WetGrass et comparez avec Rain=True observe
+- Pour le test 2, ajoutez WetGrass.ObservedValue = true
+- La difference entre les deux resultats quantifie l'effet ""explaining away""",,,,,,,,ff10934c66da9ae9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,da19f7c3,code,fr,0393eafaa9cfef1d,"// Exercice : Verifier le Collider avec Explaining Away
+// TODO: Test 1 - Sans observer WetGrass, calculez P(Sprinkler) et P(Sprinkler | Rain=True)
+// Indice: Creez le reseau WetGrass complet SANS ObservedValue sur wetGrass
+
+// TODO: Test 2 - Avec WetGrass=True observe, calculez P(Sprinkler | WetGrass) et P(Sprinkler | Rain, WetGrass)
+// Indice: Ajoutez wetGrass.ObservedValue = true puis comparez avec/sans rain.ObservedValue = true
+
+// TODO: Afficher les resultats dans un tableau comparatif
+// Console.WriteLine($""| Sans WetGrass | P(S)={p1:F3} | P(S|R)={p2:F3} |"");
+// Console.WriteLine($""| Avec WetGrass | P(S|W)={p3:F3} | P(S|R,W)={p4:F3} |"");
+
+// Question: Que confirment ces resultats sur la structure collider ?
+Console.WriteLine(""Exercice a completer : Verifier le Collider"");",,,,,,,,0393eafaa9cfef1d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,3cf84c09,markdown,fr,d2ef54e47c054c73,"## 6. Inference Causale vs Observationnelle
+
+### Difference fondamentale
+
+| Type | Question | Notation |
+|------|----------|----------|
+| **Observationnel** | P(Y\|X=x) | Que se passe-t-il quand on observe X=x ? |
+| **Interventionnel** | P(Y\|do(X=x)) | Que se passe-t-il quand on force X=x ? |
+
+### Exemple
+
+- **Observer** qu'il pleut : P(WetGrass | Rain=True)
+- **Faire pleuvoir** artificiellement : P(WetGrass | do(Rain=True))
+
+Dans le second cas, on ""coupe"" les arcs entrants vers Rain (il ne depend plus de Cloudy).",,,,,,,,d2ef54e47c054c73,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,cialw5hzwlp,markdown,fr,9d9bf2ad280b89a3,"---
+
+### Implementation de l'operateur do()
+
+Pour simuler une **intervention** (operateur do()), on modifie le modele en :
+1. **Coupant** les arcs entrants vers la variable manipulee
+2. **Fixant** sa valeur a la valeur d'intervention
+
+Comparons P(Cloudy | Rain=True) (observation) avec P(Cloudy | do(Rain=True)) (intervention).",,,,,,,,9d9bf2ad280b89a3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,d61c08d9,code,fr,efa92a09aff81f20,"// Comparaison inference observationnelle vs interventionnelle
+
+// OBSERVATIONNEL : P(Cloudy | Rain=True)
+Variable<bool> cObs = Variable.Bernoulli(0.5);
+Variable<bool> rObs = Variable.New<bool>();
+
+using (Variable.If(cObs)) { rObs.SetTo(Variable.Bernoulli(0.8)); }
+using (Variable.IfNot(cObs)) { rObs.SetTo(Variable.Bernoulli(0.2)); }
+
+rObs.ObservedValue = true;
+
+InferenceEngine mObs = new InferenceEngine();
+mObs.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+double pCloudyObs = mObs.Infer<Bernoulli>(cObs).GetProbTrue();
+
+// INTERVENTIONNEL : P(Cloudy | do(Rain=True))
+// On ""coupe"" l'arc Cloudy -> Rain en fixant Rain independamment
+Variable<bool> cInt = Variable.Bernoulli(0.5);
+Variable<bool> rInt = Variable.Bernoulli(1.0);  // Force a True, independant de Cloudy
+
+InferenceEngine mInt = new InferenceEngine();
+mInt.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+double pCloudyInt = mInt.Infer<Bernoulli>(cInt).GetProbTrue();
+
+Console.WriteLine(""=== Observationnel vs Interventionnel ==="");
+Console.WriteLine($""P(Cloudy | Rain=True) = {pCloudyObs:F3} (observationnel)"");
+Console.WriteLine($""P(Cloudy | do(Rain=True)) = {pCloudyInt:F3} (interventionnel)"");
+Console.WriteLine(""\n=> Observer la pluie informe sur le temps nuageux"");
+Console.WriteLine(""   Faire pleuvoir ne change pas le temps nuageux"");",,,,,,,,efa92a09aff81f20,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,wq10ipb3q9,markdown,fr,a683438bbb142552,"### Analyse : Causalité vs Corrélation
+
+**Résultats** :
+- P(Cloudy | Rain=True) = **0.800** — observationnel
+- P(Cloudy | do(Rain=True)) = **0.500** — interventionnel
+
+**Différence fondamentale** :
+
+| Type | Sémantique | Résultat |
+|------|------------|----------|
+| Observation | ""Je vois qu'il pleut"" | Le temps est probablement nuageux |
+| Intervention | ""Je fais pleuvoir (machine à pluie)"" | Le temps reste incertain |
+
+L'**opérateur do()** de Pearl ""coupe"" les arcs entrants vers la variable manipulée. Rain ne dépend plus de Cloudy dans le graphe modifié.
+
+> **Application pratique** : Cette distinction est cruciale en médecine. Observer une corrélation entre un traitement et la guérison n'implique pas que le traitement cause la guérison (biais de sélection possible). Un essai randomisé (intervention) est nécessaire pour établir la causalité.",,,,,,,,a683438bbb142552,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,c9a29e30,markdown,fr,dd2d44255c43e01f,"### Exercice : Explaining Away dans le diagnostic medical
+
+Dans le reseau de diagnostic (Cold -> Fatigue <- Flu), les deux maladies sont des causes alternatives de la fatigue. Lorsqu'on observe la fatigue, un phenomene d'explaining away apparait.
+
+**Objectif** : Quantifiez l'effet d'explaining away en comparant P(Cold | Fatigue=True, Flu=True) avec P(Cold | Fatigue=True).
+
+**Etapes** :
+1. Implementez le reseau Cold -> Fatigue <- Flu avec les memes CPT que dans l'exemple guide
+2. Calculez P(Cold | Fatigue=True) sans observer Flu
+3. Calculez P(Cold | Fatigue=True, Flu=True) en ajoutant Flu=True comme observation
+4. Expliquez pourquoi P(Cold) diminue quand Flu=True est observe
+
+**Indices** :
+- Utilisez les memes CPT que la section 9 : P(Cold)=0.02, P(Flu)=0.01
+- P(Fatigue | Cold=T, Flu=T) = 0.95, P(Fatigue | Cold=T, Flu=F) = 0.6
+- P(Fatigue | Cold=F, Flu=T) = 0.9, P(Fatigue | Cold=F, Flu=F) = 0.1
+- La grippe ""explique"" la fatigue, rendant le rhume moins necessaire comme explication",,,,,,,,dd2d44255c43e01f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,4e5a56a4,code,fr,dcba44878a8ce456,"// Exercice : Explaining Away dans le diagnostic medical
+// TODO: Definir les variables Cold et Flu avec leurs priors
+// Indice: Variable<bool> cold = Variable.Bernoulli(0.02);
+
+// TODO: Definir Fatigue avec sa CPT (4 cas: Cold/Flu, Cold/!Flu, !Cold/Flu, !Cold/!Flu)
+// Indice: utilisez Variable.If/IfNot imbriques comme dans l'exemple guide
+
+// TODO: Test 1 - Observer Fatigue=True, inferer P(Cold)
+// Indice: fatigue.ObservedValue = true; puis engine.Infer<Bernoulli>(cold)
+
+// TODO: Test 2 - Observer Fatigue=True ET Flu=True, inferer P(Cold)
+// Indice: Ajoutez flu.ObservedValue = true; et comparez les deux resultats
+
+// Question: Pourquoi P(Cold) baisse-t-il quand on sait que le patient a la grippe ?
+Console.WriteLine(""Exercice a completer : Explaining Away dans le diagnostic"");",,,,,,,,dcba44878a8ce456,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,4c623710,markdown,fr,b4766cd8480d585c,"## 7. Modele Causal : Direction de la Causalite
+
+### Question
+
+Etant donne des donnees observationnelles entre A et B, comment determiner si A cause B ou B cause A ?
+
+### Approche bayesienne
+
+Comparer les evidences des deux modeles :
+- $M_1$ : A -> B
+- $M_2$ : B -> A",,,,,,,,b4766cd8480d585c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,17c45ea3,code,fr,15b408e12b0fff4f,"// Modele pour identifier la direction causale
+
+// Donnees simulees : A cause B avec bruit
+double[] dataA = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+double[] dataB = { 2.1, 4.2, 5.8, 8.1, 10.3 };  // B ~ 2*A + bruit
+
+int n = dataA.Length;
+
+// Modele 1 : A -> B (A cause B)
+Variable<bool> evidence1 = Variable.Bernoulli(0.5);
+using (Variable.If(evidence1))
+{
+    Variable<double> slope1 = Variable.GaussianFromMeanAndPrecision(0, 0.1);
+    Variable<double> intercept1 = Variable.GaussianFromMeanAndPrecision(0, 0.1);
+    Variable<double> noise1 = Variable.GammaFromShapeAndScale(2, 0.5);
+    
+    for (int i = 0; i < n; i++)
+    {
+        Variable<double> aPrior1 = Variable.GaussianFromMeanAndPrecision(0, 0.1);
+        aPrior1.ObservedValue = dataA[i];
+        Variable<double> bPred1 = slope1 * aPrior1 + intercept1;
+        Variable<double> bObs1 = Variable.GaussianFromMeanAndPrecision(bPred1, noise1);
+        bObs1.ObservedValue = dataB[i];
+    }
+}
+
+InferenceEngine mCausal1 = new InferenceEngine();
+mCausal1.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+double logEvidence1 = mCausal1.Infer<Bernoulli>(evidence1).LogOdds;
+
+Console.WriteLine(""=== Selection de la direction causale ==="");
+Console.WriteLine($""Log Evidence (A -> B) = {logEvidence1:F3}"");
+Console.WriteLine(""\nNote: Un modele plus sophistique comparerait avec B -> A"");",,,,,,,,15b408e12b0fff4f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,upj76rdkq,markdown,fr,8a7f3a5e691f817f,"### Interpretation du log-evidence
+
+**Resultat** : Log Evidence (A -> B) = -22.920
+
+Cette valeur represente le **log de la vraisemblance marginale** du modele. Pour comparer deux modeles :
+
+$$\text{Bayes Factor} = \frac{P(\text{Data} | M_1)}{P(\text{Data} | M_2)} = \exp(\log E_1 - \log E_2)$$
+
+**Echelle d'interpretation du Bayes Factor** (Kass & Raftery, 1995) :
+
+| log(BF) | BF | Interpretation |
+|---------|-----|----------------|
+| < 1 | < 3 | Evidence negligeable |
+| 1-3 | 3-20 | Evidence positive |
+| 3-5 | 20-150 | Evidence forte |
+| > 5 | > 150 | Evidence tres forte |
+
+> **Limitation** : Cette approche suppose des modeles lineaires gaussiens. Pour des relations non-lineaires ou des variables discretes, des methodes comme PC-algorithm ou GES sont plus appropriees.
+
+---
+
+### Vers les modeles hierarchiques
+
+Les modeles hierarchiques (ou multiniveaux) etendent les reseaux bayesiens en introduisant des **hyperparametres** qui gouvernent les distributions des parametres individuels. Cette structure permet de modeliser la variabilite entre groupes ou individus.",,,,,,,,8a7f3a5e691f817f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,ed705418,markdown,fr,5db3ea9bd2926f35,"## 8. Modele BUGS Rats (Modele Hierarchique)
+
+### Contexte
+
+Le modele ""Rats"" de BUGS est un exemple classique de modele hierarchique :
+- Plusieurs rats suivis dans le temps
+- Chaque rat a sa propre trajectoire de croissance
+- Les parametres individuels sont tires d'une distribution de population
+
+### Structure hierarchique
+
+```
+Population: mu_alpha, sigma_alpha, mu_beta, sigma_beta
+     |
+     v
+Individu: alpha[i], beta[i] ~ N(mu, sigma)
+     |
+     v
+Observation: y[i,t] = alpha[i] + beta[i] * t + epsilon
+```",,,,,,,,5db3ea9bd2926f35,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,47fxlyok8nh,markdown,fr,dfe64b9e7e01bd46,"---
+
+### Implementation Infer.NET du modele hierarchique
+
+Le modele suivant illustre la structure hierarchique avec :
+- **Niveau population** : hyperparametres mu_alpha, mu_beta, tau_alpha, tau_beta
+- **Niveau individuel** : parametres alpha[i], beta[i] pour chaque rat
+- **Niveau observation** : mesures de poids y[i,t]
+
+Cette structure permet le **partage d'information** entre individus via les distributions de population.",,,,,,,,dfe64b9e7e01bd46,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,54d5adcd,code,fr,92fe8a750ad9bc96,"// Modele hierarchique simplifie (style BUGS Rats)
+
+int nRats = 5;
+int nTimePoints = 4;
+double[] times = { 8.0, 15.0, 22.0, 29.0 };  // Ages en jours
+
+// Donnees simulees : poids des rats au fil du temps
+double[,] weights = new double[,] {
+    { 151, 199, 246, 283 },
+    { 145, 199, 249, 293 },
+    { 147, 214, 263, 312 },
+    { 155, 200, 237, 272 },
+    { 135, 188, 230, 280 }
+};
+
+// Parametres de population
+Variable<double> muAlpha = Variable.GaussianFromMeanAndVariance(150, 1000);
+Variable<double> muBeta = Variable.GaussianFromMeanAndVariance(5, 100);
+Variable<double> tauAlpha = Variable.GammaFromShapeAndScale(1, 1);
+Variable<double> tauBeta = Variable.GammaFromShapeAndScale(1, 1);
+Variable<double> tauNoise = Variable.GammaFromShapeAndScale(1, 1);
+
+// Parametres individuels
+Range ratRange = new Range(nRats);
+VariableArray<double> alpha = Variable.Array<double>(ratRange);
+VariableArray<double> beta = Variable.Array<double>(ratRange);
+
+using (Variable.ForEach(ratRange))
+{
+    alpha[ratRange] = Variable.GaussianFromMeanAndPrecision(muAlpha, tauAlpha);
+    beta[ratRange] = Variable.GaussianFromMeanAndPrecision(muBeta, tauBeta);
+}
+
+// Observations
+for (int i = 0; i < nRats; i++)
+{
+    for (int t = 0; t < nTimePoints; t++)
+    {
+        Variable<double> meanWeight = alpha[i] + beta[i] * (times[t] - 22.0);
+        Variable<double> obsWeight = Variable.GaussianFromMeanAndPrecision(meanWeight, tauNoise);
+        obsWeight.ObservedValue = weights[i, t];
+    }
+}
+
+InferenceEngine mRats = new InferenceEngine(new ExpectationPropagation());
+mRats.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+mRats.ShowFactorGraph = true;  // Graphe du modele hierarchique
+
+Console.WriteLine(""=== Modele Hierarchique (Rats) ==="");
+Console.WriteLine($""mu_alpha (intercept moyen) : {mRats.Infer<Gaussian>(muAlpha)}"");
+Console.WriteLine($""mu_beta (pente moyenne) : {mRats.Infer<Gaussian>(muBeta)}"");",,,,,,,,92fe8a750ad9bc96,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,590efa9f,markdown,fr,9427f63c4db775c0,Visualisation du graphe hierarchique du modele Rats.,,,,,,,,9427f63c4db775c0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,tsksp0s81b,code,fr,c3a7252a0501d1d4,"// Visualisation du graphe hierarchique (Rats)
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,c3a7252a0501d1d4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,ykn7nybgejj,markdown,fr,9e74ce0b154aab18,"### Anatomie du modele hierarchique
+
+
+Le graphe illustre la structure a deux niveaux du modele Rats :
+
+**Niveau population (hyperparametres)** :
+- `muAlpha`, `muBeta` : moyennes de population
+- `tauAlpha`, `tauBeta` : precisions de population
+
+**Niveau individuel (parametres)** :
+- `alpha[i]`, `beta[i]` : parametres pour chaque rat
+- Les arrays sont representes par des facteurs repliques
+
+**Niveau observation** :
+- Les observations de poids sont attachees aux predictions individuelles
+
+Cette structure **plate** est caracteristique des modeles hierarchiques compiles : les boucles `ForEach` sont deroulees en facteurs individuels partageant les memes hyperparametres.",,,,,,,,9e74ce0b154aab18,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,8564d6fmi8e,markdown,fr,881a94e5f1db310a,"### Analyse du modèle hiérarchique
+
+**Résultats** :
+- μ_alpha (poids moyen à t=22 jours) ≈ **241.7 g**
+- μ_beta (croissance moyenne) ≈ **6.68 g/jour**
+
+**Interprétation biologique** :
+- À 22 jours, les rats pèsent en moyenne ~242g
+- Ils prennent environ 6.7g par jour
+
+**Avantages du modèle hiérarchique** :
+
+| Aspect | Explication |
+|--------|-------------|
+| **Partage d'information** | Les rats ""empruntent"" de l'information les uns aux autres via la population |
+| **Shrinkage** | Les estimations individuelles sont tirées vers la moyenne |
+| **Robustesse** | Moins sensible aux outliers individuels |
+| **Généralisation** | Peut prédire pour un nouveau rat non observé |
+
+> **Concept clé** : La hiérarchie ""régularise"" naturellement les estimations. Un rat avec peu d'observations sera tiré vers la moyenne de population, évitant le sur-ajustement.",,,,,,,,881a94e5f1db310a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,1ae3dbf2,markdown,fr,3995f1403683109a,"## 9. Exemple guide : Reseau de Diagnostic Medical
+
+### Enonce
+
+Construisez un reseau bayesien pour le diagnostic de deux maladies :
+
+**Structure** :
+```
+(Cold)     (Flu)
+   \         /
+    v       v
+   (Fatigue)
+    |
+    v
+  (Fever)
+```
+
+**CPTs** :
+- P(Cold) = 0.02
+- P(Flu) = 0.01
+- P(Fatigue | Cold, Flu) : voir table
+- P(Fever | Fatigue) : 0.8 si fatigue, 0.05 sinon
+
+**Question** : P(Flu | Fever=True) ?",,,,,,,,3995f1403683109a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,doc1d49u69o,markdown,fr,5ca78dc66618e2d1,"---
+
+### Application pratique : Systemes d'aide au diagnostic
+
+Les reseaux bayesiens sont largement utilises en medecine pour le diagnostic assiste par ordinateur. Historiquement :
+
+| Systeme | Annee | Domaine | Particularite |
+|---------|-------|---------|---------------|
+| MYCIN | 1976 | Infections bacteriennes | Regles avec facteurs de certitude |
+| INTERNIST-1 | 1982 | Medecine interne | 500+ maladies, 3500 symptomes |
+| QMR | 1991 | Medecine interne | Version bayesienne d'INTERNIST |
+| DXplain | 1986-present | Diagnostic general | 2400+ maladies |
+
+L'exercice suivant illustre les principes de base d'un tel systeme.",,,,,,,,5ca78dc66618e2d1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,mz7t0we65y,markdown,fr,3804784c109d87a9,"---
+
+### Implementation du reseau de diagnostic
+
+Construisons le reseau avec les CPT specifiees. Le raisonnement diagnostique ira des **symptomes observes** (fievre) vers les **causes probables** (maladies).",,,,,,,,3804784c109d87a9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,7cb8cbb6,code,fr,441e7615700b22c0,"// Exemple guide : Reseau de diagnostic
+
+Variable<bool> cold = Variable.Bernoulli(0.02).Named(""cold"");
+Variable<bool> flu = Variable.Bernoulli(0.01).Named(""flu"");
+Variable<bool> fatigue = Variable.New<bool>().Named(""fatigue"");
+Variable<bool> fever = Variable.New<bool>().Named(""fever"");
+
+// CPT pour Fatigue
+// Cold=F, Flu=F -> P(Fatigue) = 0.1
+// Cold=F, Flu=T -> P(Fatigue) = 0.9
+// Cold=T, Flu=F -> P(Fatigue) = 0.6
+// Cold=T, Flu=T -> P(Fatigue) = 0.95
+
+using (Variable.If(cold))
+{
+    using (Variable.If(flu))
+        fatigue.SetTo(Variable.Bernoulli(0.95));
+    using (Variable.IfNot(flu))
+        fatigue.SetTo(Variable.Bernoulli(0.6));
+}
+using (Variable.IfNot(cold))
+{
+    using (Variable.If(flu))
+        fatigue.SetTo(Variable.Bernoulli(0.9));
+    using (Variable.IfNot(flu))
+        fatigue.SetTo(Variable.Bernoulli(0.1));
+}
+
+// CPT pour Fever
+using (Variable.If(fatigue))
+{
+    fever.SetTo(Variable.Bernoulli(0.8));
+}
+using (Variable.IfNot(fatigue))
+{
+    fever.SetTo(Variable.Bernoulli(0.05));
+}
+
+// Observation
+fever.ObservedValue = true;
+
+InferenceEngine mDiag = new InferenceEngine();
+mDiag.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+mDiag.ShowFactorGraph = true;  // Graphe du reseau de diagnostic
+
+Console.WriteLine(""=== Diagnostic Medical ==="");
+Console.WriteLine($""P(Flu | Fever) = {mDiag.Infer<Bernoulli>(flu).GetProbTrue():F3}"");
+Console.WriteLine($""P(Cold | Fever) = {mDiag.Infer<Bernoulli>(cold).GetProbTrue():F3}"");
+Console.WriteLine($""P(Fatigue | Fever) = {mDiag.Infer<Bernoulli>(fatigue).GetProbTrue():F3}"");",,,,,,,,441e7615700b22c0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,122ac6b9,markdown,fr,265904e090d0fcd4,Visualisation du graphe du reseau de diagnostic medical.,,,,,,,,265904e090d0fcd4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,qgf0ecbnvsl,code,fr,5456c49cc682c844,"// Visualisation du graphe de diagnostic medical
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,5456c49cc682c844,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,zt3bdv0hqn,markdown,fr,590f9c8853446bbc,"### Structure du reseau de diagnostic
+
+
+Le graphe montre le reseau bayesien de diagnostic avec :
+
+- **Deux racines independantes** : Cold et Flu (maladies avec faibles prevalences)
+- **Variable intermediaire** : Fatigue (symptome cause par les maladies)
+- **Variable observee** : Fever (symptome terminal, observee)
+
+Cette structure en **diamant** illustre :
+1. **Causes multiples** pour Fatigue (Cold et Flu sont des causes alternatives)
+2. **Chaine causale** Maladie -> Fatigue -> Fever
+
+L'inference diagnostique remonte de Fever observee vers les causes potentielles (maladies), en passant par l'intermediaire Fatigue.",,,,,,,,590f9c8853446bbc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,ills1wvc2o9,markdown,fr,03b3d843bb0eb1c1,"### Analyse du diagnostic médical
+
+**Résultats** : P(Maladie | Fever=True)
+
+| Maladie | Prior | Posterior | Ratio |
+|---------|-------|-----------|-------|
+| Flu | 0.01 | **0.052** | ×5.2 |
+| Cold | 0.02 | **0.073** | ×3.6 |
+
+**Observations** :
+
+1. **Explaining away partiel** : Cold et Flu sont tous deux plus probables avec la fièvre, mais moins que si l'un des deux était certain (chacun ""explique partiellement"" la fièvre).
+
+2. **P(Fatigue | Fever) = 0.681** : La fièvre est fortement associée à la fatigue car P(Fever|Fatigue) = 0.8 >> P(Fever|¬Fatigue) = 0.05.
+
+3. **Diagnostic différentiel** : Avec seulement la fièvre, il reste difficile de distinguer Cold de Flu. Des symptômes supplémentaires (courbatures, durée) seraient nécessaires.
+
+> **Application clinique** : Ce type de réseau bayésien est utilisé dans les systèmes d'aide au diagnostic (MYCIN, DXplain). L'ajout de symptômes affine progressivement les probabilités des maladies.",,,,,,,,03b3d843bb0eb1c1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,17oeysgy3al,markdown,fr,35d5ba86ef368879,"### Extension : Diagnostic avec symptomes multiples
+
+Pour ameliorer le diagnostic, on pourrait ajouter d'autres symptomes :
+
+```
+(Cold)     (Flu)
+   \   \   /   /
+    \   \ /   /
+     v   v   v
+   (Fatigue) (BodyAche)
+       |         |
+       v         v
+    (Fever)  (Headache)
+```
+
+**Table de discrimination** :
+
+| Symptome | Cold | Flu | Ratio diagnostique |
+|----------|------|-----|-------------------|
+| Fatigue legere | 60% | 90% | 1.5 |
+| Fievre elevee (>39C) | 10% | 70% | 7.0 |
+| Courbatures | 20% | 80% | 4.0 |
+| Duree > 7 jours | 30% | 60% | 2.0 |
+
+> **Exercice complementaire** : Etendre le modele avec le symptome ""BodyAche"" et observer comment P(Flu|Fever, BodyAche) evolue par rapport a P(Flu|Fever).",,,,,,,,35d5ba86ef368879,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,9c3ab892,markdown,fr,5fd27ac1aeed6bf7,"## 10. Resume
+
+### Concepts cles
+
+| Concept | Description |
+|---------|-------------|
+| **Reseau bayesien** | DAG avec variables et CPTs |
+| **CPT** | Table de Probabilite Conditionnelle |
+| **D-separation** | Critere graphique d'independance |
+| **Explaining away** | Causes alternatives deviennent moins probables |
+| **Observation vs Intervention** | P(Y\|X) vs P(Y\|do(X)) |
+| **Modele hierarchique** | Parametres individuels tires d'une population |
+
+### Patterns Infer.NET
+
+| Pattern | Code | Utilisation |
+|---------|------|-------------|
+| Variable racine | `Variable.Bernoulli(p)` | Prior marginal |
+| CPT binaire | `Variable.If(x)` + `SetTo()` | Probabilites conditionnelles |
+| Observation | `x.ObservedValue = true` | Conditionner l'inference |
+| Intervention (do) | `Variable.Bernoulli(1.0)` (independant) | Couper les arcs entrants |
+| Boucle hierarchique | `Variable.ForEach(range)` | Modeles multiniveaux |
+
+### Distributions utilisees
+
+| Distribution | Parametre | Contexte |
+|--------------|-----------|----------|
+| Bernoulli | probabilite p | Variables booleennes |
+| Gaussian | moyenne, precision | Variables continues |
+| Gamma | shape, scale | Priors sur precisions (positifs) |
+
+---
+
+## Prochaine etape
+
+Dans [Infer-7-Skills-IRT](Infer-7-Skills-IRT.ipynb), nous explorerons :
+
+- Les modeles d'evaluation de competences
+- Item Response Theory (IRT) avec le modele Difficulty-Ability
+- Le modele DINA (Noisy-And) pour les competences multiples
+- Les relations many-to-many entre competences et questions",,,,,,,,5fd27ac1aeed6bf7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,58f70403,markdown,fr,8ebc1a987a94f567,"## 11. Exercice : Extension du Reseau - Symptome de Fievre
+
+### Enonce
+
+Etendez le reseau bayesien de diagnostic en ajoutant un nouveau symptome : la **fievre** (temperature > 38.5C).
+
+Structure du symptome :
+- P(fievre | flu=True) = 0.85 : la grippe cause souvent de la fievre
+- P(fievre | flu=False) = 0.05 : rarement de la fievre sans grippe
+
+Scenario : un patient a toux=True, fievre=True, ecoulementNasal=False.
+
+1. Ajoutez la variable fievre au reseau existant
+2. Observez les symptomes du patient
+3. Comparez P(cold) et P(flu) avec et sans l'observation de fievre
+
+**Indice** : Utilisez Variable.If(flu) et Variable.IfNot(flu) pour definir la CPT de fievre.",,,,,,,,8ebc1a987a94f567,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,bd4e93fc,code,fr,598622193e606b1b,"// Exercice : Extension du reseau bayesien avec symptome de fievre
+// TODO: Creer le moteur d'inference
+
+// TODO: Definir les maladies (meme structure que dans l'exemple guide)
+
+// TODO: Definir les symptomes existants toux et ecoulementNasal
+// (utilisez les memes CPT que dans l'exemple guide)
+
+// TODO: Ajouter le nouveau symptome : fievre (dependant uniquement de flu)
+
+// TODO: Observer les symptomes du patient
+
+// TODO: Inferer et afficher
+// Comparez avec le resultat sans observation de fievre
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,598622193e606b1b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb,09005592,markdown,fr,10f613c1a94bf54b,"## Conclusion
+
+Ce notebook a couvert les reseaux bayesiens : structure DAG, CPT, D-separation, explaining away, et modeles hierarchiques.
+
+| Concept | Point cle |
+|---------|-----------|
+| Reseau bayesien | DAG ou P(jointe) = produit des CPT |
+| CPT | Probabilites conditionnelles encodees via Variable.If/IfNot |
+| Explaining away | Au collider, observer l'effet rend les causes dependantes |
+| D-separation | Critere graphique pour l'independance conditionnelle |
+| do() vs observer | Intervention = couper les arcs entrants, observation = conditionner |
+
+| Structure | Independance |
+|-----------|-------------|
+| Chaine A->B->C | A indep. C \| B |
+| Fork A<-B->C | A indep. C \| B |
+| Collider A->B<-C | A indep. C, mais A dep. C \| B |
+
+| Distribution | Role |
+|--------------|------|
+| Bernoulli | Variables booleennes (maladies, symptomes, meteo) |
+| Gaussian | Variables continues (modeles hierarchiques, regression) |
+| Gamma | Priors sur precisions |
+
+> **Apport des reseaux bayesiens** : Ils permettent le raisonnement abductif (des effets vers les causes), essentiel pour le diagnostic medical, le debogage et l'analyse causale. La distinction observation vs intervention (do-calculus de Pearl) est fondamentale pour la science des donnees.",,,,,,,,10f613c1a94bf54b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,1a12413d2cab,markdown,fr,81bd06982d5e7110,"# Infer-5-Causal-Inference : Inférence Causale et do-calculus
+
+**Serie** : Programmation Probabiliste avec Infer.NET (22/23)
+**Duree estimee** : 65 minutes
+**Prerequis** : [Infer-4-Bayesian-Networks](Infer-4-Bayesian-Networks.ipynb) (reseaux bayesiens, CPT, D-separation)
+
+---
+
+## Objectifs
+
+- Distinguer **observation** `P(Y|X)` et **intervention** `P(Y|do(X))` (Pearl, 2000)
+- Implementer le **do-opérateur** par **mutilation de graphe** en Infer.NET
+- Calculer l'effet causal via **backdoor** et **front-door adjustment**
+- Reconnaitre le **paradoxe de Simpson** et le resoudre causalement
+- Aborder le **contrefactuel** (Niveau 3 de l'echelle de Pearl)
+- **Decomposer** un effet en part directe et indirect (mediation, section 8)
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|---------|
+| [Infer-10-Thompson-Sampling](../DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb) | (fin de la serie) |
+
+> **Pont inter-series (constellation causale)** : le do-calculus de Pearl se decline en **plusieurs paradigmes** dans ce depot, et ce notebook en est le versant **probabiliste distributionnel** (.NET/Infer.NET) -- les effets causaux y sont **calcules** par mutilation de graphe. Le jumeau **Python/PyMC** porte les mêmes exemples (barometre, Sprinkler) via l'opérateur natif `pm.do` : voir [PyMC-14-Causal-Inference](../PyMC/PyMC-14-Causal-Inference.ipynb), ainsi que la demo historique `P(Cloudy|do(Rain))` dans [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb). Enfin, le traitement **symbolique** (Java/Tweety, raisonneur contrefactuel propositionnel) est dans [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb). La section **Constellation causale** en fin de notebook cartographie ces quatre implementations (y compris l'emergence causale a l'echelle, [ICT-5](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb)).
+",,,,,,,,81bd06982d5e7110,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,1a5627132eb9,markdown,fr,37586ca24bf11a26,"## 1. Pourquoi la causalite ? — L'echelle de Pearl
+
+La probabilite seule repond aux questions d'**association**. Mais de nombreuses questions pratiques sont **causales** :
+
+| Question | Type | Reponse probabiliste |
+|----------|------|---------------------|
+| Si je vois le barometre baisser, quelle est la proba d'une tempete ? | Observation `P(Storm|Baro)` | Oui |
+| Si je **provoque** la chute du barometre, la tempete vient-elle ? | Intervention `P(Storm|do(Baro))` | **Non** (sans causalite) |
+| Si j'avais pris le medicament (alors que je ne l'ai pas pris), aurais-je gueri ? | Contrefactuel | **Non** |
+
+**Jude Pearl** (2000, *Causality*, Cambridge University Press) structure le raisonnement causal en **trois niveaux** (l'echelle de Pearl) :
+
+1. **Niveau 1 — Association** (voir) : `P(Y|X)`. ""Que disent les donnees ?""
+2. **Niveau 2 — Intervention** (faire) : `P(Y|do(X))`. ""Que se passe-t-il si j'agis ?""
+3. **Niveau 3 — Contrefactuel** (imaginer) : `P(Y_x | X', Y')`. ""Que se serait-il passe si ?""
+
+**Inegalite fondamentale** : `P(Y|X) != P(Y|do(X))` des qu'un **confondeur** (cause commune de X et Y) biaise l'observation. Ce notebook montre comment un **reseau bayesien observationnel** ne sait pas calculer `do(X)` seul — il faut **mutiler le graphe** (couper les arcs entrants de X), une operation que nous implementons explicitement en Infer.NET.
+
+> **Références** : Pearl, J. (1995), *Causal diagrams for empirical research*, JRSS B 57(3) ; Pearl, J. (2000), *Causality : Models, Reasoning, and Inference*, Cambridge University Press ; Pearl, J., Glymour, M. & Jewell, N. P. (2016), *Causal Inference in Statistics : A Primer*, Wiley.
+",,,,,,,,37586ca24bf11a26,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,1eed3e2cb1b5,markdown,fr,b97c98acc03a4b0e,"## 2. Configuration d'Infer.NET
+
+Chargement du moteur d'inference probabiliste et du helper de visualisation des graphes de facteurs (même `#load` que toute la serie, cf [Infer-3](Infer-3-Factor-Graphs.ipynb), [Infer-4](../DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb)).",,,,,,,,b97c98acc03a4b0e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,884c6902f5a2,code,fr,689b05d791f6b1cf,"// Installation Infer.NET
+#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET charge."");",,,,,,,,689b05d791f6b1cf,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,8899460ebd51,markdown,fr,231f194b6df2ae51,Chargement du helper pour visualiser les graphes de facteurs (Graphviz).,,,,,,,,231f194b6df2ae51,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,c9fe12c2511b,code,fr,da487d3eb32e974d,"// Chargement du helper de visualisation des graphes de facteurs
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper charge."");
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,da487d3eb32e974d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,06038b1c2eee,markdown,fr,b87ae0bce9a5caeb,"## 3. Exemple 1 — Le barometre (confondeur a 3 noeuds)
+
+Pearl illustre la confusion causale par le **barometre** : un barometre qui baisse annonce une tempete, mais **provoquer** la chute du barometre ne declenche **pas** de tempete. Pourquoi ? Parce qu'une **cause commune** — la **basse pression atmospherique** — provoque a la fois la chute du barometre ET la tempete.
+
+```
+            BassePression
+               /    \
+              v      v
+        Barometre   Tempete
+```
+
+- `BassePression -> Barometre` : quand la pression baisse, le barometre baisse.
+- `BassePression -> Tempete` : quand la pression baisse, la tempete vient.
+- **Pas d'arc** `Barometre -> Tempete` : le barometre n'est qu'un **indicateur**, pas une cause.
+
+Le barometre et la tempete sont donc **correles** (observation) mais il n'y a **aucun effet causal** de l'un sur l'autre (intervention). Construisons ce SCM (Structural Causal Model) et affichons son graphe de facteurs.",,,,,,,,b87ae0bce9a5caeb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,d0f03c183fca,code,fr,4ec2af866cbb2a23,"// SCM du barometre (Pearl) : BassePression -> {Barometre, Storm}
+Variable<bool> bPressFG = Variable.Bernoulli(0.30).Named(""basse_pression"");  // P(basse pression)=0.30
+Variable<bool> baroFG    = Variable.New<bool>().Named(""barometre_baisse"");
+using (Variable.If(bPressFG))   { baroFG.SetTo(Variable.Bernoulli(0.90)); }  // basse pression -> baro baisse
+using (Variable.IfNot(bPressFG)){ baroFG.SetTo(Variable.Bernoulli(0.10)); }  // haute pression -> baro stable
+Variable<bool> stormFG   = Variable.New<bool>().Named(""tempete"");
+using (Variable.If(bPressFG))   { stormFG.SetTo(Variable.Bernoulli(0.80)); } // basse pression -> tempete
+using (Variable.IfNot(bPressFG)){ stormFG.SetTo(Variable.Bernoulli(0.10)); } // haute pression -> calme
+
+// Rendu SVG reel du graphe de facteurs via Graphviz (meme demarche qu'Infer-3 / Infer-4)
+var engineFG = new InferenceEngine();
+engineFG.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+engineFG.ShowFactorGraph = true;
+var _ = engineFG.Infer<Bernoulli>(stormFG);
+
+Console.WriteLine(""Structure du SCM Barometre : BassePression -> {Barometre, Tempete}."");
+Console.WriteLine(""(Graphe de facteurs ci-dessous : aucun arc direct Barometre -> Tempete.)"");
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,4ec2af866cbb2a23,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,59a3e872efd2,markdown,fr,7af15ac7a0866625,"### 3.1 Niveau 1 — Observation `P(Storm | Barometre baisse)`
+
+Si on **observe** le barometre baisser, la probabilite d'une tempete grimpe : la baisse est un signal que la pression est probablement basse, et donc qu'une tempete approche. **Mais c'est une simple association statistique.**",,,,,,,,7af15ac7a0866625,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,e6d828900126,code,fr,35d239edc737b6e5,"// NIVEAU 1 — Observation : P(Storm | Barometre baisse = True)
+Variable<bool> prObs = Variable.Bernoulli(0.30).Named(""prObs"");
+Variable<bool> baroObs = Variable.New<bool>().Named(""baroObs"");
+using (Variable.If(prObs))    { baroObs.SetTo(Variable.Bernoulli(0.90)); }
+using (Variable.IfNot(prObs)) { baroObs.SetTo(Variable.Bernoulli(0.10)); }
+Variable<bool> stormObs = Variable.New<bool>().Named(""stormObs"");
+using (Variable.If(prObs))    { stormObs.SetTo(Variable.Bernoulli(0.80)); }
+using (Variable.IfNot(prObs)) { stormObs.SetTo(Variable.Bernoulli(0.10)); }
+
+baroObs.ObservedValue = true;   // on OBSERVE le barometre baisser
+
+var eObs = new InferenceEngine();
+eObs.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+double pStormObs = eObs.Infer<Bernoulli>(stormObs).GetProbTrue();
+Console.WriteLine($""P(Storm | Barometre baisse) = {pStormObs:F3}   (observationnel)"");
+Console.WriteLine(""Conclusion naive : 'le barometre predit la tempete'."");",,,,,,,,35d239edc737b6e5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,8cbc0fda8120,markdown,fr,f3c204ac3aa382f7,"### 3.2 Niveau 2 — Intervention `P(Storm | do(Barometre baisse))`
+
+Maintenant **provoquons** la chute du barometre (par exemple en tapant dessus). Pour modeliser cette intervention, on **mutile le graphe** : on coupe l'arc `BassePression -> Barometre` et on force `Barometre = baisse` **independamment** de la pression. En Infer.NET cela se traduit par `Variable.Bernoulli(1.0)` (valeur forcee, sans parent) au lieu d'un `SetTo` conditionne a la pression — c'est l'idiome d'introduction du `do()` (déjà utilise en [Infer-4 cell39](Infer-4-Bayesian-Networks.ipynb)).",,,,,,,,f3c204ac3aa382f7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,965894bd88ad,code,fr,ac2f6a9ec018345c,"// NIVEAU 2 — Intervention : P(Storm | do(Barometre baisse))
+// Mutilation : on COUPE l'arc BassePression -> Barometre en forcant Barometre sans parent.
+Variable<bool> prInt = Variable.Bernoulli(0.30).Named(""prInt"");
+Variable<bool> baroInt = Variable.Bernoulli(1.0).Named(""baroInt"");   // force a True, SANS dependre de prInt = do()
+Variable<bool> stormInt = Variable.New<bool>().Named(""stormInt"");
+using (Variable.If(prInt))    { stormInt.SetTo(Variable.Bernoulli(0.80)); }
+using (Variable.IfNot(prInt)) { stormInt.SetTo(Variable.Bernoulli(0.10)); }
+
+var eInt = new InferenceEngine();
+eInt.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+double pStormDo = eInt.Infer<Bernoulli>(stormInt).GetProbTrue();
+Console.WriteLine($""P(Storm | do(Barometre baisse)) = {pStormDo:F3}   (interventionnel)"");
+Console.WriteLine($""P(Storm) marginale             = 0.310"");
+Console.WriteLine();
+Console.WriteLine($""=> Observer le barometre informe sur la tempete : {pStormObs:F3}"");
+Console.WriteLine($""   PROVOQUER sa chute ne change rien a la tempete : {pStormDo:F3}"");
+Console.WriteLine(""   Voir != Faire (Pearl, 2000)."");",,,,,,,,ac2f6a9ec018345c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,f66599cbb521,markdown,fr,460dd9184781f9a5,"**Resultat** : `P(Storm|Barometre baisse)` (observation) **!=** `P(Storm|do(Barometre baisse))` (intervention). L'effet causal de l'intervention est nul — la chute du barometre ne provoque pas de tempete. L'observation était **biaisee** par le confondeur `BassePression`.
+
+> **Prong-B (non-trivialite)** : ce resultat n'est pas une lecture triviale de CPT. Un reseau bayesien observationnel calcule `P(Storm|Barometre baisse)` mais ne sait **pas** calculer `do(Barometre baisse)` seul — il a fallu **mutiler le graphe** (couper l'arc entrant). Les deux quantites **different visiblement**, ce qui prouve que le `do()` fait un travail reel.
+",,,,,,,,460dd9184781f9a5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,71768407d142,markdown,fr,a87967b514c8285d,"## 4. Reseau Sprinkler — cross-check avec PyMC-4
+
+Verifions sur le reseau canonique de Pearl (Cloudy -> {Sprinkler, Rain} -> WetGrass, déjà construit en [Infer-4](Infer-4-Bayesian-Networks.ipynb)) que nos valeurs Infer.NET recoupent le jumeau Python/PyMC. La requete `P(Cloudy | Rain=True)` vs `P(Cloudy | do(Rain=True))` vaut **0.800 vs 0.500** dans [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) (section 8).",,,,,,,,a87967b514c8285d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,6ce1d6953d77,code,fr,4e86b4c85d4bc366,"// Reseau Sprinkler (Pearl 4 noeuds) — meme structure qu'Infer-4
+Variable<bool> cloudySpr = Variable.Bernoulli(0.5).Named(""cloudySpr"");
+Variable<bool> sprinklerSpr = Variable.New<bool>().Named(""sprinklerSpr"");
+using (Variable.If(cloudySpr))    { sprinklerSpr.SetTo(Variable.Bernoulli(0.1)); }
+using (Variable.IfNot(cloudySpr)) { sprinklerSpr.SetTo(Variable.Bernoulli(0.5)); }
+Variable<bool> rainSpr = Variable.New<bool>().Named(""rainSpr"");
+using (Variable.If(cloudySpr))    { rainSpr.SetTo(Variable.Bernoulli(0.8)); }
+using (Variable.IfNot(cloudySpr)) { rainSpr.SetTo(Variable.Bernoulli(0.2)); }
+
+// OBSERVATIONNEL : P(Cloudy | Rain=True)
+rainSpr.ObservedValue = true;
+var eSprO = new InferenceEngine();
+eSprO.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+double pCloudyObsSpr = eSprO.Infer<Bernoulli>(cloudySpr).GetProbTrue();
+Console.WriteLine($""P(Cloudy | Rain=True)      = {pCloudyObsSpr:F3}   (observationnel, theorie 0.800)"");
+
+// INTERVENTIONNEL : P(Cloudy | do(Rain=True)) — couper Cloudy -> Rain
+Variable<bool> cloudyDo = Variable.Bernoulli(0.5).Named(""cloudyDo"");
+Variable<bool> rainDo   = Variable.Bernoulli(1.0).Named(""rainDo"");  // force, independant de cloudy
+var eSprD = new InferenceEngine();
+eSprD.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+double pCloudyDoSpr = eSprD.Infer<Bernoulli>(cloudyDo).GetProbTrue();
+Console.WriteLine($""P(Cloudy | do(Rain=True))  = {pCloudyDoSpr:F3}   (interventionnel, theorie 0.500)"");
+Console.WriteLine();
+Console.WriteLine(""Cross-check PyMC-4 (meme structure) : 0.800 obs vs 0.500 do  => Infer.NET coherent."");",,,,,,,,4e86b4c85d4bc366,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,63bf5b6e6dda,markdown,fr,5dec4022c15f5f15,"## 5. Backdoor adjustment
+
+Quand le confondeur `U` est **observe**, l'effet causal se calcule sans mutiler le graphe, par la **formule d'adjustment backdoor** (Pearl, 1995) :
+
+```
+P(Y | do(X)) = Somme_u P(Y | X, u) P(u)
+```
+
+On somme l'effet de `X` sur `Y` sur toutes les valeurs du confondeur, ponds par la distribution marginale de `U`. Si `U` **bloque tous les chemins ""backdoor""** (arcs entrants de `X` passant par `U`), cette formule restitue l'effet causal exact. Verifions sur le barometre, ou `U = BassePression` bloque le chemin `Barometre <- BassePression -> Tempete` : l'ajustement doit **coincider** avec le `do()` direct (0.310).",,,,,,,,5dec4022c15f5f15,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,7e0f43fc28d2,code,fr,cb851796d29b373d,"// BACKDOOR ADJUSTMENT : P(Storm | do(Baro)) = Somme_pression P(Storm | Baro, pression) P(pression)
+// Ici Storm independant de Baro | Pression  =>  P(Storm | Baro, pression) = P(Storm | pression)
+// (le moteur d'inference calcule chaque conditionnelle)
+double pBassePression = 0.30;
+
+// P(Storm | pression=basse) et P(Storm | pression=haute), inferees par le moteur
+double InferStormGiven(bool pressionBasse) {
+    var p = Variable.New<bool>(); p.ObservedValue = pressionBasse;
+    var s = Variable.New<bool>();
+    using (Variable.If(p))    { s.SetTo(Variable.Bernoulli(0.80)); }
+    using (Variable.IfNot(p)) { s.SetTo(Variable.Bernoulli(0.10)); }
+    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    return e.Infer<Bernoulli>(s).GetProbTrue();
+}
+
+double pStormBasse = InferStormGiven(true);   // = 0.80
+double pStormHaute = InferStormGiven(false);  // = 0.10
+double backdoor = pStormBasse * pBassePression + pStormHaute * (1.0 - pBassePression);
+Console.WriteLine($""Backdoor = P(Storm|basse)*{pBassePression} + P(Storm|haute)*{1.0-pBassePression}"");
+Console.WriteLine($""        = {pStormBasse:F2}*{pBassePression} + {pStormHaute:F2}*{1.0-pBassePression} = {backdoor:F3}"");
+Console.WriteLine($""do(Barometre) direct      = 0.310"");
+Console.WriteLine($""=> Les deux methodes coincident ({backdoor:F3} ~ 0.310) : verification de coherence."");",,,,,,,,cb851796d29b373d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,fab734cd4991,markdown,fr,e3c9ad4b0de1ef3b,"## 6. Front-door adjustment
+
+Quand le confondeur `U` est **non observe** mais qu'un **medicateur** `M` entre `X` et `Y` est observe et capture tout l'effet de `X` sur `Y`, Pearl (1995) montre que l'effet causal est identifiable par la **formule front-door** :
+
+```
+P(Y | do(X)) = Somme_m P(M=m | X) * Somme_x' P(Y | M=m, x') P(x')
+```
+
+Exemple canonique (Pearl) : `X` = fumer, `M` = goudron dans les poumons, `Y` = cancer, `U` = genotype (non observe, cause a la fois l'envie de fumer et le risque de cancer). On n'a pas acces au genotype, mais le goudron transmet tout l'effet causal de la fumee sur le cancer.",,,,,,,,e3c9ad4b0de1ef3b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,f6d17c278a8e,code,fr,67091a9f8241b092,"// FRONT-DOOR : X=smoke, M=tar, Y=cancer, U=genotype (non observe)
+// P(Y|do(X)) = Somme_m P(M=m|X) * Somme_x' P(Y|M=m,x') P(x')
+
+// P(X=1) marginal (genotype marginalise)
+double PmarginalX1() {
+    var u = Variable.Bernoulli(0.20);
+    var x = Variable.New<bool>();
+    using (Variable.If(u))    { x.SetTo(Variable.Bernoulli(0.80)); }
+    using (Variable.IfNot(u)) { x.SetTo(Variable.Bernoulli(0.30)); }
+    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    return e.Infer<Bernoulli>(x).GetProbTrue();
+}
+// P(M=1 | X=1) — on INTERROGE m, on NE l'observe PAS
+double PMgivenX1() {
+    var x = Variable.New<bool>(); x.ObservedValue = true;
+    var m = Variable.New<bool>();
+    using (Variable.If(x))    { m.SetTo(Variable.Bernoulli(0.90)); }
+    using (Variable.IfNot(x)) { m.SetTo(Variable.Bernoulli(0.10)); }
+    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    return e.Infer<Bernoulli>(m).GetProbTrue();
+}
+// P(Y=1 | M=m, X=x') — on observe M ET X, on interroge Y
+double PYgivenMX(bool smokeVal, bool mVal) {
+    var u = Variable.Bernoulli(0.20);
+    var x = Variable.New<bool>(); x.ObservedValue = smokeVal;
+    var m = Variable.New<bool>();
+    using (Variable.If(x))    { m.SetTo(Variable.Bernoulli(0.90)); }
+    using (Variable.IfNot(x)) { m.SetTo(Variable.Bernoulli(0.10)); }
+    m.ObservedValue = mVal;
+    var y = Variable.New<bool>();
+    using (Variable.If(m)) {
+        using (Variable.If(u))    { y.SetTo(Variable.Bernoulli(0.95)); }
+        using (Variable.IfNot(u)) { y.SetTo(Variable.Bernoulli(0.70)); }
+    }
+    using (Variable.IfNot(m)) {
+        using (Variable.If(u))    { y.SetTo(Variable.Bernoulli(0.50)); }
+        using (Variable.IfNot(u)) { y.SetTo(Variable.Bernoulli(0.05)); }
+    }
+    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    return e.Infer<Bernoulli>(y).GetProbTrue();
+}
+// Verification : effet causal DIRECT par mutilation (coupe U -> X)
+double PdoSmoke() {
+    var u = Variable.Bernoulli(0.20);
+    var x = Variable.Bernoulli(1.0);   // do(X=1) : force, independant de u
+    var m = Variable.New<bool>();
+    using (Variable.If(x))    { m.SetTo(Variable.Bernoulli(0.90)); }
+    using (Variable.IfNot(x)) { m.SetTo(Variable.Bernoulli(0.10)); }
+    var y = Variable.New<bool>();
+    using (Variable.If(m)) {
+        using (Variable.If(u))    { y.SetTo(Variable.Bernoulli(0.95)); }
+        using (Variable.IfNot(u)) { y.SetTo(Variable.Bernoulli(0.70)); }
+    }
+    using (Variable.IfNot(m)) {
+        using (Variable.If(u))    { y.SetTo(Variable.Bernoulli(0.50)); }
+        using (Variable.IfNot(u)) { y.SetTo(Variable.Bernoulli(0.05)); }
+    }
+    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    return e.Infer<Bernoulli>(y).GetProbTrue();
+}
+
+double pX1 = PmarginalX1();                     // P(X=1)
+double pm1 = PMgivenX1();                       // P(M=1|X=1)
+double pm0 = 1.0 - pm1;                         // P(M=0|X=1)
+// Somme_x' P(Y|M=m,x') P(x')
+double innerM1 = PYgivenMX(true,true)*pX1  + PYgivenMX(false,true)*(1-pX1);
+double innerM0 = PYgivenMX(true,false)*pX1 + PYgivenMX(false,false)*(1-pX1);
+double frontDoor = pm1*innerM1 + pm0*innerM0;
+double doDirect  = PdoSmoke();
+Console.WriteLine($""P(X=smoke) marginal = {pX1:F3}"");
+Console.WriteLine($""P(M=1|X=1) = {pm1:F3} ; P(M=0|X=1) = {pm0:F3}"");
+Console.WriteLine($""Front-door   P(Cancer | do(Smoke)) = {frontDoor:F3}  (ajustement sans acceder a U)"");
+Console.WriteLine($""do(X=1) direct (mutilation)       = {doDirect:F3}  (verification)"");
+Console.WriteLine($""=> Les deux coincident : la formule front-door restitue l'effet causal."");",,,,,,,,67091a9f8241b092,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,424580f7d8cd,markdown,fr,6895af7297175bd8,"## 7. Paradoxe de Simpson
+
+Un **renversement de Simpson** survient quand une conclusion s'inverse entre l'analyse agregee et l'analyse conditionnelle. Cas clinique : un medicament semble **nuire** a la guerison dans la population totale, alors qu'il **aide** dans **chaque** sous-groupe (patients graves / patients legers). La cause : la **severite** est un confondeur — les patients graves, qui guerrissent moins bien, recoivent aussi plus souvent le medicament.",,,,,,,,6895af7297175bd8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,9c5d859cf65e,code,fr,999460368b82bfff,"// SIMPSON REVERSAL : drug + severity (confondeur)
+double RecQuery(bool drugObs, bool? sevObs) {
+    var sev = Variable.Bernoulli(0.5);                       // severe = true
+    var drug = Variable.New<bool>();
+    using (Variable.If(sev))    { drug.SetTo(Variable.Bernoulli(0.8)); }  // graves -> plus de drug
+    using (Variable.IfNot(sev)) { drug.SetTo(Variable.Bernoulli(0.2)); }
+    var rec = Variable.New<bool>();
+    using (Variable.If(sev)) {
+        using (Variable.If(drug))    { rec.SetTo(Variable.Bernoulli(0.5)); }  // grave+drug  -> 0.5
+        using (Variable.IfNot(drug)) { rec.SetTo(Variable.Bernoulli(0.3)); }  // grave+nodrug -> 0.3
+    }
+    using (Variable.IfNot(sev)) {
+        using (Variable.If(drug))    { rec.SetTo(Variable.Bernoulli(0.9)); }  // leger+drug  -> 0.9
+        using (Variable.IfNot(drug)) { rec.SetTo(Variable.Bernoulli(0.7)); }  // leger+nodrug -> 0.7
+    }
+    drug.ObservedValue = drugObs;
+    if (sevObs.HasValue) sev.ObservedValue = sevObs.Value;
+    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    return e.Infer<Bernoulli>(rec).GetProbTrue();
+}
+
+double recDrugAgg    = RecQuery(true,  null);   // P(Rec|Drug)      agrege
+double recNoDrugAgg  = RecQuery(false, null);   // P(Rec|NoDrug)    agrege
+double recDrugSev    = RecQuery(true,  true);   // P(Rec|Drug, severe)
+double recNoDrugSev  = RecQuery(false, true);   // P(Rec|NoDrug, severe)
+double recDrugMild   = RecQuery(true,  false);  // P(Rec|Drug, leger)
+double recNoDrugMild = RecQuery(false, false);  // P(Rec|NoDrug, leger)
+// Backdoor do(drug) = Somme_sev P(Rec|drug,sev) P(sev)
+double doDrug   = 0.5*recDrugSev   + 0.5*recDrugMild;
+double doNoDrug = 0.5*recNoDrugSev + 0.5*recNoDrugMild;
+
+Console.WriteLine(""=== ANALYSE AGREGEE (biaisee par la severite) ==="");
+Console.WriteLine($""P(Rec | Drug)    = {recDrugAgg:F3}"");
+Console.WriteLine($""P(Rec | NoDrug)  = {recNoDrugAgg:F3}   => le medicament semble NUIRE"");
+Console.WriteLine();
+Console.WriteLine(""=== ANALYSE CONDITIONNELLE (verite causale) ==="");
+Console.WriteLine($""Graves  : Drug {recDrugSev:F2}   >   NoDrug {recNoDrugSev:F2}"");
+Console.WriteLine($""Legers  : Drug {recDrugMild:F2}   >   NoDrug {recNoDrugMild:F2}"");
+Console.WriteLine(""=> Le medicament AIDE dans chaque sous-groupe. REVERSAL de l'agrege."");
+Console.WriteLine();
+Console.WriteLine(""=== EFFET CAUSAL (backdoor sur la severite) ==="");
+Console.WriteLine($""P(Rec | do(Drug))   = {doDrug:F3}"");
+Console.WriteLine($""P(Rec | do(NoDrug)) = {doNoDrug:F3}   => le medicament AIDE causalement."");",,,,,,,,999460368b82bfff,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,infer22-mediation-intro,markdown,fr,9e482e92d3608ac6,"## 8. Mediation -- effet direct et effet indirect
+
+La front-door (section 6) identifie l'**effet total** de X sur Y en passant par le mediateur M. Mais elle ne dit pas **combien** de cet effet transite par M (chemin indirect `X -> M -> Y`) versus le chemin **direct** (`X -> Y`). C'est la question de la **mediation** : decomposer l'effet total en une part mediee et une part directe.
+
+On definit le **Controlled Direct Effect** (CDE) : l'effet de X sur Y quand on **fige** le mediateur a une valeur m par une seconde intervention `do(M=m)` :
+
+$$ \mathrm{CDE}(m) = P(Y{=}1 \mid do(X{=}1), do(M{=}m)) - P(Y{=}1 \mid do(X{=}0), do(M{=}m)) $$
+
+Si l'effet total `TE = P(Y|do(X=1)) - P(Y|do(X=0))` est superieur au CDE, la difference capte la part qui passe **par le mediateur** (effet indirect). C'est une **double mutilation** de graphe -- le même opérateur `do()` qu'en section 3.2, applique deux fois.
+
+**Exemple.** X = suivre un programme de formation, M = competences acquises, Y = obtenir une promotion. La formation peut mener a la promotion de deux facons : directement (effet de signal / diplome) ou indirectement (les competences declenchent la promotion).",,,,,,,,9e482e92d3608ac6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,infer22-mediation-code,code,fr,227de273377f6968,"// MEDIATION : X (formation) -> M (competences) -> Y (promotion), plus chemin direct X -> Y.
+// CPTs connus. Effet total (TE) + Controlled Direct Effect (CDE) en figeant M par do(M).
+
+// P(Y=1 | do(X=x)) -- effet TOTAL (M libre : capte chemin direct + indirect via M)
+double PY_doX(bool xVal) {
+    var x = Variable.New<bool>().Named(""x""); x.ObservedValue = xVal;
+    var m = Variable.New<bool>().Named(""m"");
+    using (Variable.If(x))    { m.SetTo(Variable.Bernoulli(0.80)); }  // formation -> competences
+    using (Variable.IfNot(x)) { m.SetTo(Variable.Bernoulli(0.20)); }
+    var y = Variable.New<bool>().Named(""y"");
+    using (Variable.If(x)) {
+        using (Variable.If(m))    { y.SetTo(Variable.Bernoulli(0.90)); }  // formation + competences
+        using (Variable.IfNot(m)) { y.SetTo(Variable.Bernoulli(0.60)); }  // formation seule (signal)
+    }
+    using (Variable.IfNot(x)) {
+        using (Variable.If(m))    { y.SetTo(Variable.Bernoulli(0.70)); }  // competences sans formation
+        using (Variable.IfNot(m)) { y.SetTo(Variable.Bernoulli(0.30)); }  // baseline
+    }
+    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    return e.Infer<Bernoulli>(y).GetProbTrue();
+}
+
+// P(Y=1 | do(X=x), do(M=m)) -- CDE : on FIGE le mediateur (double mutilation)
+double PY_doX_doM(bool xVal, bool mVal) {
+    var x = Variable.New<bool>().Named(""x""); x.ObservedValue = xVal;
+    var m = Variable.New<bool>().Named(""m""); m.ObservedValue = mVal;  // do(M) fige le mediateur
+    var y = Variable.New<bool>().Named(""y"");
+    using (Variable.If(x)) {
+        using (Variable.If(m))    { y.SetTo(Variable.Bernoulli(0.90)); }
+        using (Variable.IfNot(m)) { y.SetTo(Variable.Bernoulli(0.60)); }
+    }
+    using (Variable.IfNot(x)) {
+        using (Variable.If(m))    { y.SetTo(Variable.Bernoulli(0.70)); }
+        using (Variable.IfNot(m)) { y.SetTo(Variable.Bernoulli(0.30)); }
+    }
+    var e = new InferenceEngine(); e.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    return e.Infer<Bernoulli>(y).GetProbTrue();
+}
+
+double TE   = PY_doX(true) - PY_doX(false);
+double CDE0 = PY_doX_doM(true, false) - PY_doX_doM(false, false);
+double CDE1 = PY_doX_doM(true, true)  - PY_doX_doM(false, true);
+
+Console.WriteLine(""Mediation : X=formation, M=competences, Y=promotion"");
+Console.WriteLine($""  Effet total        TE     = P(Y|do(X=1))           - P(Y|do(X=0))           = {TE:F3}"");
+Console.WriteLine($""  Effet direct CDE   a M=0  = P(Y|do(X=1),do(M=0))   - P(Y|do(X=0),do(M=0))   = {CDE0:F3}"");
+Console.WriteLine($""  Effet direct CDE   a M=1  = P(Y|do(X=1),do(M=1))   - P(Y|do(X=0),do(M=1))   = {CDE1:F3}"");
+Console.WriteLine($""  -> part mediee (indirect) ~= TE - CDE(M=0) = {TE - CDE0:F3}  (chemin via les competences)"");",,,,,,,,227de273377f6968,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,infer22-mediation-interp,markdown,fr,4a14a9f30d6057a8,"**Lecture.** L'effet total de la formation sur la promotion vaut **0,460** (46 points de probabilite). Mais quand on fige les competences acquises (`do(M=0)`, ""formation sans competences""), l'effet direct retombe a **0,300**. La difference **0,160** est la part **mediee** : ce que la formation apporte a la promotion *via* les competences. Le CDE a `M=1` (0,200) est encore plus bas, car `do(M=1)` place tout le monde en position ""competent"", ou la formation ajoute moins.
+
+**Ce que montre la cellule.** La front-door (section 6) donnait l'effet total via le mediateur ; la mediation **decompose** cet effet. C'est le même opérateur `do()`, applique deux fois (double mutilation) -- l'inference par message passing Infer.NET (exacte sur ce SCM discret) rend TE et CDE calculables separement et comparables. **Non-trivialite** : l'effet direct (0,300) differe de l'effet total (0,460) de facon **visible**, preuve que le mediateur porte une part reelle de l'effet -- dans un SCM degenere sans chemin indirect, TE egalerais exactement CDE.",,,,,,,,4a14a9f30d6057a8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,cb4121b7afaf,markdown,fr,4650a7784e824dec,"## 9. Le do-calculus (regles de Pearl)
+
+Pearl (1995) a demontre que **toute** quantite causale identifiable peut être calculee a partir de trois regles de reecriture, qui transforment des expressions avec `do()` en expressions observationnelles (sans `do()`). Soit `G_X` le graphe mutile (arcs entrants de `X` supprimes) et `G_{underline{X}}` le graphe ou les arcs sortants de `X` sont supprimes :
+
+| Regle | Enonce | Effet |
+|-------|--------|-------|
+| **Regle 1 (insertion/deletion)** | `P(y | do(x), z, w) = P(y | do(x), w)` si `Y _||_ Z | X, W` dans `G_X` | Observations irrelevantes peuvent être retirees |
+| **Regle 2 (action/observation)** | `P(y | do(x), do(z), w) = P(y | do(x), z, w)` si `Y _||_ Z | X, W` dans `G_{underline{X}}` | Une action peut être remplacee par une observation |
+| **Regle 3 (insertion/deletion d'actions)** | `P(y | do(x), do(z), w) = P(y | do(x), w)` si `Y _||_ Z | X, W` dans `G_{X, tilde{Z(W)}}` | Une action irrelevant peut être retiree |
+
+**Critere backdoor** (Shpitser, Pearl & Verma) : un ensemble `Z` satisfait le critere backdoor relatif a `(X,Y)` si aucun noeud de `Z` n'est un descendant de `X`, et `Z` bloque tous les chemins backdoor (arcs entrants de `X`). Alors `P(Y|do(X)) = Somme_z P(Y|X,Z)P(Z)` — c'est exactement la formule appliquee en section 5.
+
+> **Théorème de completude** (Shpitser & Pearl, 2006) : les trois regles sont **complètes** — si un effet causal n'est pas calculable par ces regles, il n'est **pas identifiable** a partir du graphe seul. C'est un plafond fondamental, pas une limite d'implementation.",,,,,,,,4650a7784e824dec,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,b3037c01b965,markdown,fr,ec5ef9bdda08b1c9,"## 10. Niveau 3 — Contrefactuel (capstone)
+
+Le niveau 3 de l'echelle de Pearl repond aux questions **contrefactuelles** : *""Sachant qu'un patient a pris le medicament ET a gueri, aurait-il gueri SANS medicament ?""*
+
+On resout cela en **deux étapes** (twin-network / abduction-prediction) :
+
+1. **Abduction** : inferer le **posterieur** sur les variables latentes (ici la severite) sachant ce qu'on observe (pris le medicament, a gueri).
+2. **Prediction/action** : reutiliser ce posterieur comme **prior** dans le graphe **mutile** (`do(NoDrug)`) pour predire le resultat contrefactuel.
+
+Cette étape est plus couteuse qu'une simple intervention (elle requiert une inference posterieure puis une seconde inference). C'est honnetement le plafond pratique de l'inference causale **deterministe** (message passing) sur ce type de SCM.",,,,,,,,ec5ef9bdda08b1c9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,7300698aebb9,code,fr,a7c61ae4118891c6,"// CONTREFACTUEL (Niveau 3) : abduction + prediction
+// ""Sachant drug=true ET rec=true, aurait-il gueri si do(drug=false) ?""
+
+// ETAPE 1 — Abduction : posterieur sur 'severe' sachant (drug=true, rec=true)
+var sevAbd = Variable.Bernoulli(0.5).Named(""sevAbd"");
+var drugAbd = Variable.New<bool>().Named(""drugAbd"");
+using (Variable.If(sevAbd))    { drugAbd.SetTo(Variable.Bernoulli(0.8)); }
+using (Variable.IfNot(sevAbd)) { drugAbd.SetTo(Variable.Bernoulli(0.2)); }
+var recAbd = Variable.New<bool>().Named(""recAbd"");
+using (Variable.If(sevAbd)) {
+    using (Variable.If(drugAbd))    { recAbd.SetTo(Variable.Bernoulli(0.5)); }
+    using (Variable.IfNot(drugAbd)) { recAbd.SetTo(Variable.Bernoulli(0.3)); }
+}
+using (Variable.IfNot(sevAbd)) {
+    using (Variable.If(drugAbd))    { recAbd.SetTo(Variable.Bernoulli(0.9)); }
+    using (Variable.IfNot(drugAbd)) { recAbd.SetTo(Variable.Bernoulli(0.7)); }
+}
+drugAbd.ObservedValue = true;   // il a pris le medicament
+recAbd.ObservedValue  = true;   // il a gueri
+var eAbd = new InferenceEngine(); eAbd.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+double pSevereGiven = eAbd.Infer<Bernoulli>(sevAbd).GetProbTrue();   // P(severe | drug, rec)
+Console.WriteLine($""Abduction : P(severe | drug=true, rec=true) = {pSevereGiven:F3}"");
+
+// ETAPE 2 — Prediction : do(drug=false) avec severe tire du posterieur
+var sevPred = Variable.Bernoulli(pSevereGiven).Named(""sevPred"");
+var drugPred = Variable.Bernoulli(0.0).Named(""drugPred"");   // do(NoDrug) : force a false
+var recPred = Variable.New<bool>().Named(""recPred"");
+using (Variable.If(sevPred)) {
+    using (Variable.If(drugPred))    { recPred.SetTo(Variable.Bernoulli(0.5)); }
+    using (Variable.IfNot(drugPred)) { recPred.SetTo(Variable.Bernoulli(0.3)); }
+}
+using (Variable.IfNot(sevPred)) {
+    using (Variable.If(drugPred))    { recPred.SetTo(Variable.Bernoulli(0.9)); }
+    using (Variable.IfNot(drugPred)) { recPred.SetTo(Variable.Bernoulli(0.7)); }
+}
+var ePred = new InferenceEngine(); ePred.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+double pRecCounterfactual = ePred.Infer<Bernoulli>(recPred).GetProbTrue();
+Console.WriteLine($""Contrefactuel : P(rec | do(NoDrug), 'pris drug & gueri') = {pRecCounterfactual:F3}"");
+Console.WriteLine();
+Console.WriteLine($""=> Meme si le patient a gueri AVEC le medicament, sans medicament il n'aurait eu"");
+Console.WriteLine($""   qu'environ {pRecCounterfactual*100:F0}% de chances de guerison (contrefactuel)."");",,,,,,,,a7c61ae4118891c6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,6ce82fcee37a,markdown,fr,9be2c93c73186132,"## 11. Exercices
+
+Quatre exercices pour ancrer le do-calculus. Chaque stub s'execute sans erreur (`Console.WriteLine`) ; a vous de compléter le code entre les `// TODO`.
+
+| # | Exercice | Concept |
+|---|----------|---------|
+| 1 | Construire un SCM confondu (education -> revenu) | Niveau 1 observation vs margeur |
+| 2 | Backdoor adjustment sur un reseau personnalise | Identification de l'ensemble Z |
+| 3 | Front-door : smoke -> tar -> cancer (Pearl) | Adjustement par medicateur |
+| 4 | Paradoxe de Simpson personnalise | Renversement agrege vs conditionnel |",,,,,,,,9be2c93c73186132,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,eb5112fe221d,code,fr,fed545355dcbe547,"// Exercice 1 : Construire un SCM confondu ""education -> revenu""
+// Modele suggere : U=niveau_etudes_parents cause a la fois Education (X) et Revenu (Y),
+//                  X -> Y (l'education augmente le revenu). Calculez P(Revenu|Education) vs P(Revenu|do(Education)).
+// Indice : codez les CPT avec Variable.If comme dans la section 3, puis mutilez l'arc U->X pour le do().
+// Etape 1 : definir les variables et CPT
+// Etape 2 : P(Revenu | Education=haute) observationnel
+// Etape 3 : P(Revenu | do(Education=haute)) interventionnel
+Console.WriteLine(""Exercice 1 a completer : SCM education -> revenu (observation vs intervention)."");",,,,,,,,fed545355dcbe547,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,b1ec24f8fe8a,code,fr,8fb29b4894098b1f,"// Exercice 2 : Backdoor adjustment — identifier l'ensemble Z et calculer P(Y|do(X))
+// Reprenez un reseau a 3-4 noeuds avec un confondeur observe Z.
+// Indice : verifiez que Z bloque tous les chemins backdoor vers X, puis appliquez Somme_z P(Y|X,z)P(z).
+// Etape 1 : choisir Z (ensemble d'ajustement)
+// Etape 2 : calculer chaque P(Y|X,z) via le moteur
+// Etape 3 : sommer poids par P(z) et comparer au do() direct
+Console.WriteLine(""Exercice 2 a completer : backdoor adjustment, identifier Z et calculer P(Y|do(X))."");",,,,,,,,8fb29b4894098b1f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,deeb4d1f5bc6,code,fr,a7e14c03f11a3955,"// Exercice 3 : Front-door sur smoke -> tar -> cancer (classique Pearl)
+// Adaptez la section 6 en changeant les CPT (par ex. fumer passif, exposition professionnelle).
+// Indice : la structure X -> M -> Y + U -> X, U -> Y doit etre preservee (U non observe).
+// Etape 1 : fixer de nouvelles CPT coherentes
+// Etape 2 : recalculer P(M|X), P(x'), P(Y|M,x')
+// Etape 3 : appliquer la formule front-door et interpreter
+Console.WriteLine(""Exercice 3 a completer : front-door smoke -> tar -> cancer (Pearl)."");",,,,,,,,a7e14c03f11a3955,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,1f39b5a055ca,code,fr,0a1082939dc996ba,"// Exercice 4 : Paradoxe de Simpson personnalise
+// Concevez des CPT ou la conclusion s'INVERSE entre l'agrege et le conditionnel.
+// Indice : il faut un confondeur Z tel que Z favorise a la fois X et defavorise Y (ou inverse).
+// Etape 1 : choisir un scenario (ex. traitement + age, ou genre + admission Berkeley 1973)
+// Etape 2 : coder des CPT produisant un renversement
+// Etape 3 : montrer P(Y|X) agrege != P(Y|do(X)) et expliquer le mecanisme
+Console.WriteLine(""Exercice 4 a completer : concevoir un paradoxe de Simpson (renversement agrege vs conditionnel)."");",,,,,,,,0a1082939dc996ba,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,infer22-constell-bridge,markdown,fr,9e99490b083f5f22,"## Constellation causale -- le do-calculus en quatre paradigmes
+
+Le do-calculus de Pearl (1995, 2000) est un **calcul formel independant du langage** : les trois regles d'identification d'un effet causal ne dependent pas de l'implementation. Ce depot le met en oeuvre dans **quatre paradigmes** distincts, qui choisissent chacun ce qu'ils **calculent** versus ce sur quoi ils **raisonnent**.
+
+| Paradigme | Moteur / langage | Idiome du `do(X)` | Notebook | Ce qu'il apporte |
+|-----------|------------------|-------------------|----------|------------------|
+| **Probabiliste distributionnel** | Infer.NET (C#) | **Mutilation de graphe** : `Variable.Bernoulli(1.0)` force la valeur et coupe l'arc parent | ce notebook | Effet causal **calcule** par message passing deterministe (EP/VMP) sur le graphe mutile |
+| **Probabiliste (transformation)** | PyMC (Python) | Opérateur natif `pm.do` : l'intervention est une **transformation de modele de premiere classe** | [PyMC-14](../PyMC/PyMC-14-Causal-Inference.ipynb) | `do` rebranche comme un opérateur du langage probabiliste |
+| **Symbolique propositionnel** | Tweety (Java) | **Raisonneur contrefactuel** : logique classique, preuves argumentatives (pas de probabilites) | [Tweety-11](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) | Raisonnement **qualitatif** : ""X cause-t-il Y ?"" sans chiffres |
+| **Emergence causale (echelle)** | PyPhi (Python) | **Intervention sur la partition** : `do_coarse_grain` / `do_blackbox` force une echelle macro et mesure l'information effective (EI) | [ICT-5-CausalEmergence](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb) | Le `do` s'applique a l'**echelle** : quelle description (micro vs macro) est causalement la plus forte (Hoel 2013, Jansma & Hoel 2025) |
+
+**Valeurs croisees (verification inter-paradigme).** Sur le **même** exemple du barometre (confondeur `BassePression -> {Barometre, Storm}`), les deux versants probabilistes **recoupent** exactement :
+
+| Quantite | Infer.NET (ce notebook, sec 3) | PyMC-14 |
+|----------|-------------------------------|---------|
+| `P(Storm | Barometre baisse)` (observation) | **0,656** | **0,656** |
+| `P(Storm | do(Barometre baisse))` (intervention) | **0,310** | **0,310** |
+
+L'effondrement de la correlation (`0,656 -> 0,310`) lorsqu'on passe de l'observation a l'intervention est le **signal que le moteur fait un vrai travail causal** (mutilation, pas une simple lecture de CPT) -- et les deux moteurs, malgre leurs idiomes differents (mutilation Infer.NET vs `pm.do` PyMC), convergent vers les mêmes valeurs. Sur le reseau Sprinkler, `P(Cloudy|Rain)=0,800` vs `P(Cloudy|do(Rain))=0,500` (sec 4 ici, et [PyMC-4](../PyMC/PyMC-4-Bayesian-Networks.ipynb) sec 8).
+
+**L'angle ICT (emergence causale).** Le quatrieme paradigme, [ICT-5-CausalEmergence](../../IIT/ICT-Series/ICT-5-CausalEmergence.ipynb), deplace la question : au lieu d'intervenir sur une **variable** (`do(X=x)`), il intervient sur l'**echelle de description** (`do_coarse_grain`) et mesure quelle partition (micro vs macro) maximise l'**information effective**. C'est le même opérateur d'intervention de Pearl, applique a la granularite du modele plutot qu'a la valeur d'un noeud -- d'ou l'expression *emergence causale* (la macro peut être causalement plus forte que la micro).
+
+**Ce qu'il faut retenir.** Quatre implementations, **un seul do-calculus**. Le paradigme Infer.NET met l'accent sur la **structure** (mutiler le graphe = une operation que le moteur d'inference execute) ; PyMC met l'accent sur la **composabilite** (`do` comme transformation de modele) ; Tweety met l'accent sur le **raisonnement** (causalite sans nombres) ; ICT (PyPhi) met l'accent sur l'**echelle** (intervenir sur la partition, pas sur la variable). Choisir l'un ou l'autre, c'est choisir ce que l'on veut : des probabilites deterministes (message passing), du sampling flexible, des preuves qualitatives, ou identifier la bonne echelle de description.",,,,,,,,9e99490b083f5f22,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb,41d4daeba16c,markdown,fr,db6d2c3f61507781,"## 12. Synthese
+
+| Niveau | Question | Opérateur | Méthode Infer.NET |
+|--------|----------|-----------|-------------------|
+| **1 Association** | Que voit-on ? | `P(Y|X)` | `ObservedValue` |
+| **2 Intervention** | Que se passe-t-il si on agit ? | `P(Y|do(X))` | **Mutilation** : `Bernoulli(1.0)` force, coupe l'arc parent |
+| **3 Contrefactuel** | Que se serait-il passe ? | `P(Y_x|X',Y')` | Abduction (posterieur) + prediction dans graphe mutile |
+
+| Adjustment | Quand | Formule |
+|------------|-------|---------|
+| **Backdoor** | Confondeur `U` **observe** | `P(Y|do(X)) = Somme_u P(Y|X,u)P(u)` |
+| **Front-door** | Confondeur non observe, medicateur `M` observe | `P(Y|do(X)) = Somme_m P(M=m|X) Somme_x' P(Y|M=m,x')P(x')` |
+
+### Ce qu'il faut retenir
+
+- **`P(Y|X) != P(Y|do(X))`** : l'observation est biaisee par les confondeurs. Un reseau bayesien observationnel ne sait **pas** calculer `do(X)` seul — il faut **mutiler le graphe**.
+- **La mutilation n'est pas une lecture de CPT** : couper les arcs entrants de `X` est une operation structurelle que le moteur d'inference Infer.NET execute après qu'on a redefini `X` sans parent. La difference visible entre observation et intervention prouve que le `do()` fait un travail reel (Prong-B).
+- **Backdoor et front-door rendent l'effet causal identifiable** a partir de donnees observationnelles, sous conditions graphiques — formalisees par le do-calculus (Pearl 1995), complet (Shpitser & Pearl 2006).
+
+### Pour aller plus loin
+- **[Notebook-pont — du graphe causal au do-calculus](../DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb)** : l'armature formelle unifiée de Pearl (échelle + 3 règles) exécutée sur l'outil de référence `dowhy` (identification backdoor/front-door + estimation + réfutation), qui relie cette série à Tweety-11, PyMC-14 et ICT-5.
+
+- **Pont symbolique** : [Tweety-11-Causal](../../SymbolicAI/Tweety/Tweety-11-Causal.ipynb) traite le `do()` et les contrefactuels en **Java/Tweety** (raisonnement propositionnel) — même echelle de Pearl, paradigme different.
+- **Pont Python** : [PyMC-4-Bayesian-Networks](../PyMC/PyMC-4-Bayesian-Networks.ipynb) demontre la même distinction `P(Cloudy|Rain)` vs `P(Cloudy|do(Rain))` en MCMC.
+- **Références** : Pearl (2000) *Causality* ; Pearl, Glymour & Jewell (2016) *Causal Inference in Statistics : A Primer* ; Shpitser & Pearl (2006) *Identification of Conditional Interventional Effects*.
+
+---
+
+[← Infer-10-Thompson-Sampling](../DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb) | [Retour a la serie](README.md)",,,,,,,,db6d2c3f61507781,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,ac9ac32a,markdown,fr,9139805b9aa08b6f,"# Infer-6-Debugging : Troubleshooting et Bonnes Pratiques
+
+**Serie** : Programmation Probabiliste avec Infer.NET (6/20)  
+**Duree estimee** : 45 minutes  
+**Prerequis** : Avoir explore plusieurs notebooks de la serie
+
+---
+
+## Objectifs
+
+- Diagnostiquer les problemes courants d'inference
+- Comparer les algorithmes (EP, VMP, Gibbs)
+- Utiliser les outils de debug d'Infer.NET
+- Appliquer les bonnes pratiques de modelisation
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-7-Skills-IRT](Infer-7-Skills-IRT.ipynb) | [Infer-9-Classification](Infer-9-Classification.ipynb) |
+
+---",,,,,,,,9139805b9aa08b6f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,d07125c0,markdown,fr,e79ffbc6e4857f98,## 1. Configuration,,,,,,,,e79ffbc6e4857f98,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,44f53923,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,a25ed2c0,markdown,fr,ce9324608c3187eb,"### Packages charges
+
+| Package | Role |
+|---------|------|
+| `Microsoft.ML.Probabilistic` | Distributions, moteur d'inference, algorithmes (EP, VMP, Gibbs) |
+| `Microsoft.ML.Probabilistic.Compiler` | Compilation des modeles en code C# optimise |
+
+Les namespaces importants pour le debugging sont :
+- `Algorithms` : contient `ExpectationPropagation`, `VariationalMessagePassing`, `GibbsSampling`
+- `Compiler` : options de compilation et generation de code
+- `Distributions` : tous les types de distributions (Gaussian, Gamma, Beta, etc.)",,,,,,,,ce9324608c3187eb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,494e6908,markdown,fr,6ad00f52da6b1d8c,"> **Note technique** : Ce notebook est oriente *troubleshooting*. Il suppose que vous avez deja explore plusieurs notebooks de la serie et rencontre des comportements inattendus. Les exemples sont volontairement simplifies pour isoler chaque type de probleme.
+
+Le debugging en programmation probabiliste differe du debugging classique :
+
+| Debugging classique | Debugging probabiliste |
+|---------------------|------------------------|
+| Erreur = crash ou mauvaise valeur | Erreur = distribution inattendue ou divergence |
+| Cause souvent deterministe | Cause souvent liee aux priors ou a l'algorithme |
+| Solution : corriger le code | Solution : ajuster le modele ou l'algorithme |",,,,,,,,6ad00f52da6b1d8c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,dab43cc2,markdown,fr,1ff3e0ad7dd616cb,"### Outil de visualisation
+
+Le `FactorGraphHelper` est un utilitaire qui permet d'afficher les **graphes de facteurs** generes par Infer.NET directement dans le notebook. Ces graphes sont essentiels pour :
+
+- **Verifier la structure** du modele probabiliste
+- **Identifier les connexions** manquantes ou incorrectes
+- **Comprendre le flux** des messages d'inference
+
+> **Prerequis** : Graphviz doit etre installe sur le systeme pour generer les visualisations SVG. Si Graphviz n'est pas disponible, le helper retournera `False` et les graphes ne seront pas affiches.",,,,,,,,1ff3e0ad7dd616cb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,8b121887,code,fr,2f12d02d6daa9b7c,"// Chargement du helper pour afficher les graphes de facteurs inline
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper charge !"");
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");
+Console.WriteLine(""Usage: display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()))"");",,,,,,,,2f12d02d6daa9b7c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,a9dc8cd5,markdown,fr,7f1194cc157ac504,"## 2. Erreurs Courantes et Solutions
+
+### 2.1 Catalogue des Erreurs
+
+| Erreur | Cause | Solution |
+|--------|-------|----------|
+| `Model has no support` | Observation impossible sous le prior | Elargir le prior ou verifier les observations |
+| `Improper distribution` | Divergence de l'inference | Utiliser des priors plus informatifs |
+| `Could not find method` | Operation non supportee | Reformuler avec des operations de base |
+| `Compilation timeout` | Modele trop complexe | Simplifier ou compiler separement |
+| `Memory exceeded` | Trop de variables | Reduire la taille ou utiliser des arrays |",,,,,,,,7f1194cc157ac504,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,bf173d0e,code,fr,0ac5122dfe45c8f4,"// Exemple 1 : Erreur ""Model has no support""
+
+Console.WriteLine(""=== Erreur : Model has no support ==="");
+Console.WriteLine();
+
+// PROBLEME : Observer une valeur impossible sous le prior
+try
+{
+    Variable<double> x = Variable.GaussianFromMeanAndPrecision(0, 1000);  // Prior tres concentre autour de 0
+    x.ObservedValue = 100;  // Observation tres eloignee
+    
+    InferenceEngine engine = new InferenceEngine();
+    engine.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    var result = engine.Infer(x);  // Peut echouer ou donner des resultats etranges
+}
+catch (Exception e)
+{
+    Console.WriteLine($""Erreur : {e.Message.Substring(0, Math.Min(100, e.Message.Length))}..."");
+}
+
+// SOLUTION : Utiliser un prior plus large
+Console.WriteLine(""\nSOLUTION : Elargir le prior"");
+Variable<double> x2 = Variable.GaussianFromMeanAndPrecision(50, 0.01);  // Prior large
+x2.ObservedValue = 100;
+
+InferenceEngine engine2 = new InferenceEngine();
+engine2.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+Console.WriteLine($""Resultat avec prior large : {engine2.Infer(x2)}"");",,,,,,,,0ac5122dfe45c8f4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,5253129a,markdown,fr,4d379e32362031f9,"**Interpretation des resultats** :
+
+Le resultat `Gaussian.PointMass(100)` signifie que le posterieur est une distribution degeneree concentree exactement sur la valeur observee. C'est le comportement attendu quand :
+
+1. L'observation est deterministe (`ObservedValue`)
+2. Le prior est suffisamment large pour ""accepter"" cette valeur
+
+> **Regle pratique** : Si votre prior a une precision `prec`, alors les observations situees a plus de `3/sqrt(prec)` ecarts-types du centre auront un support quasi-nul. Avec `prec=1000`, cela represente environ `0.1` unites autour de la moyenne.",,,,,,,,4d379e32362031f9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,0c43ebcb,code,fr,d6a8a05cc7176276,"// Visualisation du factor graph pour comprendre le probleme de support
+
+Console.WriteLine(""=== Visualisation : Modele avec prior large ==="");
+
+Variable<double> xVis = Variable.GaussianFromMeanAndPrecision(50, 0.01).Named(""x_prior_large"");
+xVis.ObservedValue = 100;
+
+InferenceEngine engineVis = new InferenceEngine();
+engineVis.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+engineVis.ShowFactorGraph = true;
+engineVis.ShowProgress = false;
+
+var resultVis = engineVis.Infer(xVis);
+Console.WriteLine($""Resultat : {resultVis}"");
+Console.WriteLine();
+Console.WriteLine(""Le factor graph montre la structure simple : prior -> observation"");
+
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));
+FactorGraphHelper.CleanupGeneratedFiles();",,,,,,,,d6a8a05cc7176276,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,b7352fbf,markdown,fr,f3123fc82841f116,"### 2.2 Probleme de convergence
+
+Le deuxieme type d'erreur courant concerne la **convergence vers des modes non desires**. Cela se produit souvent dans les modeles de melange ou les variables ont des roles symetriques.",,,,,,,,f3123fc82841f116,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,eec72b8b,code,fr,6682d65958a0b0db,"// Exemple 2 : Probleme de convergence (posterieurs uniformes)
+
+Console.WriteLine(""=== Probleme : Convergence vers mode symetrique ==="");
+Console.WriteLine();
+
+// PROBLEME : Priors symetriques dans un modele de melange
+int nComp = 2;
+Range compRange = new Range(nComp);
+
+VariableArray<double> means = Variable.Array<double>(compRange);
+means[compRange] = Variable.GaussianFromMeanAndPrecision(0, 0.01).ForEach(compRange);  // Prior identique
+
+Console.WriteLine(""Avec priors symetriques (meme pour toutes les composantes) :"");
+Console.WriteLine(""  -> Le modele peut converger vers une solution ou toutes"");
+Console.WriteLine(""     les composantes sont identiques (mode symetrique)."");
+
+// SOLUTION : Priors asymetriques
+Console.WriteLine(""\nSOLUTION : Utiliser des priors asymetriques"");
+Console.WriteLine(""  means[0] ~ Gaussian(-5, 1)"");
+Console.WriteLine(""  means[1] ~ Gaussian(+5, 1)"");
+Console.WriteLine(""  -> Force les composantes a etre distinctes"");",,,,,,,,6682d65958a0b0db,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,6e92fe00,markdown,fr,abfe1a03a42fed9f,"### Le probleme du ""label switching""
+
+Dans les modeles de melange, le probleme des modes symetriques est connu sous le nom de **label switching**. Si les composantes sont echangeables (meme prior), l'inference peut :
+
+1. **Converger vers la moyenne** : toutes les composantes au meme endroit
+2. **Osciller entre permutations** : les labels des composantes s'echangent entre iterations
+
+Les solutions incluent :
+
+| Solution | Avantage | Inconvenient |
+|----------|----------|--------------|
+| Priors asymetriques | Simple a implementer | Introduit un biais |
+| Contraintes d'ordre | Mathematiquement propre | Complexifie le modele |
+| Post-traitement | Pas de biais | Necessite analyse manuelle |",,,,,,,,abfe1a03a42fed9f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,1f0748dd,markdown,fr,6eab8cecff08007c,"## 3. Comparaison des Algorithmes d'Inference
+
+### Quand utiliser quel algorithme ?
+
+| Algorithme | Forces | Faiblesses | Usage recommande |
+|------------|--------|------------|------------------|
+| **EP** | Rapide, bon pour melanges continus | Peut diverger, approximatif | Modeles Gaussian, Probit |
+| **VMP** | Stable, bon pour discret | Sous-estime l'incertitude | LDA, melanges categoriques |
+| **Gibbs** | Exact asymptotiquement | Lent, diagnostics difficiles | Validation, petits modeles |",,,,,,,,6eab8cecff08007c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,2ba52cb8,markdown,fr,f13bcebd7a833341,"La cellule suivante compare EP et VMP sur un probleme simple d'estimation de moyenne avec precision inconnue.
+
+**Configuration du test** :
+- 6 observations autour de 2.0
+- Prior vague sur la moyenne : Gaussian(0, 0.01)
+- Prior informatif sur la precision : Gamma(2, 0.5)
+
+Ce type de modele (donnees gaussiennes avec parametres inconnus) est un cas classique ou EP et VMP donnent des resultats comparables mais avec des niveaux d'incertitude differents.",,,,,,,,f13bcebd7a833341,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,dc2083be,code,fr,c6e2091dad9acf4f,"// Comparaison EP vs VMP sur un modele simple
+
+Console.WriteLine(""=== Comparaison EP vs VMP ==="");
+Console.WriteLine();
+
+// Modele : estimation de moyenne avec observations bruitees
+double[] observations = { 2.1, 1.9, 2.3, 2.0, 1.8, 2.2 };
+int nObs = observations.Length;
+
+// Fonction pour creer et inferer le modele avec EP
+Gaussian InferAvecEP()
+{
+    Variable<double> mean = Variable.GaussianFromMeanAndPrecision(0, 0.01);
+    Variable<double> prec = Variable.GammaFromShapeAndScale(2, 0.5);
+    
+    Range r = new Range(nObs);
+    VariableArray<double> obs = Variable.Array<double>(r);
+    obs[r] = Variable.GaussianFromMeanAndPrecision(mean, prec).ForEach(r);
+    obs.ObservedValue = observations;
+    
+    InferenceEngine engine = new InferenceEngine(new ExpectationPropagation());
+    engine.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    engine.ShowProgress = false;
+    
+    return engine.Infer<Gaussian>(mean);
+}
+
+// Fonction pour creer et inferer le modele avec VMP
+Gaussian InferAvecVMP()
+{
+    Variable<double> mean = Variable.GaussianFromMeanAndPrecision(0, 0.01);
+    Variable<double> prec = Variable.GammaFromShapeAndScale(2, 0.5);
+    
+    Range r = new Range(nObs);
+    VariableArray<double> obs = Variable.Array<double>(r);
+    obs[r] = Variable.GaussianFromMeanAndPrecision(mean, prec).ForEach(r);
+    obs.ObservedValue = observations;
+    
+    InferenceEngine engine = new InferenceEngine(new VariationalMessagePassing());
+    engine.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    engine.ShowProgress = false;
+    
+    return engine.Infer<Gaussian>(mean);
+}
+
+var resultEP = InferAvecEP();
+var resultVMP = InferAvecVMP();
+
+Console.WriteLine($""Observations : {string.Join("", "", observations)}"");
+Console.WriteLine($""Moyenne empirique : {observations.Average():F3}"");
+Console.WriteLine();
+Console.WriteLine($""EP  : {resultEP}"");
+Console.WriteLine($""VMP : {resultVMP}"");
+Console.WriteLine();
+Console.WriteLine(""Note : VMP tend a avoir une variance plus faible (sous-estime l'incertitude)"");",,,,,,,,c6e2091dad9acf4f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,b3cf74e4,markdown,fr,bd61667ac183b431,"**Interpretation des resultats EP vs VMP** :
+
+Les deux algorithmes estiment la moyenne autour de 2.05 (proche de la moyenne empirique 2.05), mais avec des caracteristiques differentes :
+
+| Metrique | EP | VMP | Interpretation |
+|----------|----|----|----------------|
+| Moyenne posterieure | ~2.05 | ~2.05 | Accord sur l'estimation ponctuelle |
+| Variance posterieure | Plus large | Plus etroite | VMP sous-estime l'incertitude |
+
+> **Pourquoi VMP sous-estime l'incertitude ?**
+> 
+> VMP (Variational Message Passing) approxime le posterieur par une distribution factorisee. Cette hypothese d'independance ignore les correlations entre variables, ce qui conduit typiquement a des posterieurs trop ""confiants"".
+>
+> EP (Expectation Propagation) maintient des correlations locales via les messages, produisant des approximations plus realistes de l'incertitude.
+
+**Quand cela importe** : La sous-estimation de l'incertitude par VMP peut etre problematique pour :
+- La prise de decision sous incertitude
+- Les intervalles de prediction
+- La propagation de l'incertitude dans des modeles hierarchiques",,,,,,,,bd61667ac183b431,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,30ed2236,code,fr,18d3ab72fe0ec00b,"// Exercice : Diagnostic d'un modele de melange gaussien
+
+// Modele avec problemes (a corriger)
+double[] dataMelange = { -4.2, -3.8, -5.1, -4.5, -3.9, 5.3, 4.8, 5.1, 4.6, 5.5 };
+int nData = dataMelange.Length;
+int nComposantes = 2;
+
+// TODO 1 : Definir des priors asymetriques pour les moyennes des 2 composantes
+// Indice : composante 0 centree vers -5, composante 1 centree vers +5
+// Variable<double> mean0 = ...
+// Variable<double> mean1 = ...
+
+// TODO 2 : Definir un prior raisonnable pour la precision commune
+// Indice : GammaFromShapeAndScale avec shape >= 1
+
+// TODO 3 : Creer le tableau d'observations avec VariableArray
+// Indice : chaque observation est tiree d'une des deux composantes
+
+// TODO 4 : Choisir l'algorithme d'inference adapte (EP ou VMP)
+// Indice : pour un melange gaussien, EP est generalement recommande
+
+// TODO 5 : Executer l'inference et verifier les posterieurs avec DiagnosticGaussian()
+
+Console.WriteLine(""Exercice a completer : diagnostiquer et corriger le melange gaussien"");",,,,,,,,18d3ab72fe0ec00b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,c3138f24,markdown,fr,b5ea6b60c39f329a,"## Exercice 1 : Diagnostic d'un modele de melange gaussien
+
+**Objectif** : Identifiez et corrigez les problemes dans un modele de melange gaussien a 2 composantes.
+
+**Contexte** : Un modele de melange gaussien tente de separer des donnees issues de deux distributions distinctes, mais l'inference produit des resultats inattendus (moyennes identiques ou divergence).
+
+**Etapes** :
+1. Analysez le modele fourni et identifiez au moins 2 problemes parmi : prior symetrique, algorithme mal adapte, observation hors-support
+2. Corrigez chaque probleme en vous basant sur les bonnes pratiques vues dans ce notebook
+3. Comparez les resultats obtenus avec EP et VMP sur votre modele corrige
+
+**Indices** :
+- # Indice 1 : Les composantes d'un melange doivent avoir des priors distincts pour eviter le label switching
+- # Indice 2 : Testez avec `engine.ShowProgress = true` pour observer la convergence
+- # Indice 3 : Utilisez `DiagnosticGaussian()` pour verifier la sante des posterieurs",,,,,,,,b5ea6b60c39f329a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,ae3b9309,code,fr,400c894737c84a33,"// Visualisation du factor graph du modele EP vs VMP
+// Le graphe est identique pour les deux algorithmes - seul le calcul des messages differe
+
+Console.WriteLine(""=== Visualisation : Structure du modele estime ==="");
+
+double[] obsVis = { 2.1, 1.9, 2.3, 2.0, 1.8, 2.2 };
+int nObsVis = obsVis.Length;
+
+Variable<double> meanVis = Variable.GaussianFromMeanAndPrecision(0, 0.01).Named(""mean"");
+Variable<double> precVis = Variable.GammaFromShapeAndScale(2, 0.5).Named(""precision"");
+
+Range rVis = new Range(nObsVis).Named(""observations"");
+VariableArray<double> obsArrayVis = Variable.Array<double>(rVis).Named(""y"");
+obsArrayVis[rVis] = Variable.GaussianFromMeanAndPrecision(meanVis, precVis).ForEach(rVis);
+obsArrayVis.ObservedValue = obsVis;
+
+InferenceEngine engVis = new InferenceEngine();
+engVis.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+engVis.ShowFactorGraph = true;
+engVis.ShowProgress = false;
+
+var meanPostVis = engVis.Infer<Gaussian>(meanVis);
+Console.WriteLine($""Mean posterieur : {meanPostVis}"");
+Console.WriteLine();
+Console.WriteLine(""Le factor graph montre :"");
+Console.WriteLine(""  - hyperparametres 'mean' et 'precision' partages"");
+Console.WriteLine(""  - array 'y' de 6 observations conditionnees sur ces parametres"");
+
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));
+FactorGraphHelper.CleanupGeneratedFiles();",,,,,,,,400c894737c84a33,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,b6eceb8b,markdown,fr,d77b791eaee8786e,"## 4. Outils de Debug Infer.NET
+
+### 4.1 Options du Moteur
+
+```csharp
+engine.ShowProgress = true;           // Affiche les iterations
+engine.ShowSchedule = true;           // Affiche l'ordre des messages
+engine.ShowFactorGraph = true;        // Genere le graphe de facteurs
+engine.Compiler.WriteSourceFiles = true;  // Sauvegarde le code genere
+engine.Compiler.ShowWarnings = true;  // Affiche les avertissements
+```",,,,,,,,d77b791eaee8786e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,db40c3b5,code,fr,8d3916b0b1c1d206,"// Demonstration des outils de debug
+
+Console.WriteLine(""=== Outils de Debug ==="");
+Console.WriteLine();
+
+// Modele simple pour demonstration
+Variable<double> mu = Variable.GaussianFromMeanAndPrecision(0, 1).Named(""mu"");
+Variable<double> y = Variable.GaussianFromMeanAndPrecision(mu, 1).Named(""y"");
+y.ObservedValue = 5.0;
+
+InferenceEngine debugEngine = new InferenceEngine();
+debugEngine.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+// Activer les options de debug
+debugEngine.ShowProgress = true;
+debugEngine.Compiler.ShowWarnings = true;
+
+Console.WriteLine(""Options de debug activees :"");
+Console.WriteLine(""  - ShowProgress : affiche les iterations"");
+Console.WriteLine(""  - ShowWarnings : affiche les avertissements du compilateur"");
+Console.WriteLine();
+
+var muPost = debugEngine.Infer<Gaussian>(mu);
+Console.WriteLine($""\nResultat : mu ~ {muPost}"");",,,,,,,,8d3916b0b1c1d206,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,9e8de416,markdown,fr,ce5cca76fa591f22,"**Interpretation du resultat** :
+
+Le posterieur `Gaussian(2.5, 0.5)` resulte de la mise a jour bayesienne :
+
+$$\mu_{\text{post}} = \frac{\tau_{\text{prior}} \cdot \mu_{\text{prior}} + \tau_{\text{likelihood}} \cdot y}{\tau_{\text{prior}} + \tau_{\text{likelihood}}} = \frac{1 \cdot 0 + 1 \cdot 5}{1 + 1} = 2.5$$
+
+$$\tau_{\text{post}} = \tau_{\text{prior}} + \tau_{\text{likelihood}} = 1 + 1 = 2 \quad \Rightarrow \quad \sigma^2_{\text{post}} = 0.5$$
+
+Ou $\tau$ represente la precision (inverse de la variance). Le posterieur est exactement a mi-chemin entre le prior (0) et l'observation (5), car les deux ont la meme precision.",,,,,,,,ce5cca76fa591f22,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,1bddf40b,markdown,fr,dad806c331de2eac,"### 4.2 Visualisation des Factor Graphs
+
+L'option `ShowFactorGraph = true` genere des fichiers `.gv` (DOT) et `.svg` (si Graphviz est installe). Le helper `FactorGraphHelper` permet d'afficher ces graphes directement dans le notebook.",,,,,,,,dad806c331de2eac,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,2c02d077,code,fr,49b6bb61fabaf1eb,"// Demonstration de la visualisation du Factor Graph
+
+Console.WriteLine(""=== Visualisation du Factor Graph ==="");
+Console.WriteLine();
+
+// Modele hierarchique pour une visualisation interessante
+Variable<double> hyperMean = Variable.GaussianFromMeanAndPrecision(0, 0.1).Named(""hyperMean"");
+Variable<double> hyperPrec = Variable.GammaFromShapeAndScale(2, 0.5).Named(""hyperPrec"");
+Variable<double> obs1 = Variable.GaussianFromMeanAndPrecision(hyperMean, hyperPrec).Named(""obs1"");
+Variable<double> obs2 = Variable.GaussianFromMeanAndPrecision(hyperMean, hyperPrec).Named(""obs2"");
+
+obs1.ObservedValue = 3.0;
+obs2.ObservedValue = 5.0;
+
+InferenceEngine fgEngine = new InferenceEngine();
+fgEngine.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+fgEngine.ShowFactorGraph = true;  // Generer le graphe
+fgEngine.ShowProgress = false;
+
+var hyperMeanPost = fgEngine.Infer<Gaussian>(hyperMean);
+Console.WriteLine($""Resultat : hyperMean ~ {hyperMeanPost}"");
+
+// Afficher le factor graph inline
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));
+
+// Nettoyer les fichiers generes
+int cleaned = FactorGraphHelper.CleanupGeneratedFiles();
+Console.WriteLine($""\nFichiers nettoyes : {cleaned}"");",,,,,,,,49b6bb61fabaf1eb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,8bb873fa,markdown,fr,ff9baba4564d3416,"### Comment lire un Factor Graph ?
+
+Le graphe de facteurs visualise la structure du modele probabiliste :
+
+| Element | Representation | Signification |
+|---------|----------------|---------------|
+| **Cercles** | Variables | Variables aleatoires du modele |
+| **Carres** | Facteurs | Distributions ou contraintes |
+| **Aretes** | Connexions | Dependances entre variables et facteurs |
+| **Couleur grise** | Observe | Variables avec valeurs fixees |
+
+> **Utilite pour le debugging** :
+> 
+> Le factor graph permet de verifier visuellement que :
+> 1. Les variables sont connectees comme prevu
+> 2. Les observations sont bien marquees
+> 3. Il n'y a pas de composantes deconnectees
+> 4. La structure hierarchique est correcte
+
+Dans le graphe ci-dessus, on voit que `hyperMean` et `hyperPrec` sont les hyperparametres partages par les deux observations `obs1` et `obs2`, formant un modele hierarchique classique.",,,,,,,,ff9baba4564d3416,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,789a576f,markdown,fr,a984ad3f08a37ca1,"## 5. Bonnes Pratiques de Modelisation
+
+### 5.1 Nommage des Variables
+
+```csharp
+// BON : Noms explicites avec .Named()
+Variable<double> capaciteEtudiant = Variable.GaussianFromMeanAndPrecision(0, 1).Named(""capacite"");
+
+// MAUVAIS : Variables anonymes
+Variable<double> x = Variable.GaussianFromMeanAndPrecision(0, 1);
+```
+
+### 5.2 Priors Informatifs
+
+| Situation | Prior recommande |
+|-----------|------------------|
+| Moyenne inconnue | Gaussian large (precision ~0.01) |
+| Precision inconnue | Gamma(2, 0.5) ou plus concentre |
+| Probabilite | Beta(1, 1) pour uniforme, Beta(2, 2) pour centre |
+| Poids melange | Dirichlet(1, 1, ...) pour uniforme |",,,,,,,,a984ad3f08a37ca1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,a75ff186,markdown,fr,2e4b62521f2e6c5a,"### Demonstration de l'impact des priors
+
+Le choix des priors est souvent la source principale de problemes en programmation probabiliste. Un prior mal choisi peut :
+
+1. **Rendre l'inference impossible** : si l'observation a probabilite nulle sous le prior
+2. **Biaiser les resultats** : si le prior ""domine"" les donnees
+3. **Ralentir la convergence** : si le prior est tres different des donnees
+
+La cellule suivante illustre l'impact de differents priors Beta sur l'estimation d'une probabilite binomiale avec seulement 5 observations.",,,,,,,,2e4b62521f2e6c5a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,296b6925,code,fr,c145de2436fb250e,"// Demonstration de l'importance des priors
+
+Console.WriteLine(""=== Impact du choix des Priors ==="");
+Console.WriteLine();
+
+// Observations : 3 succes sur 5 essais
+int succes = 3, echecs = 2;
+
+// Differents priors pour la probabilite
+var priors = new (string nom, double a, double b)[] {
+    (""Uniforme Beta(1,1)"", 1, 1),
+    (""Centre Beta(2,2)"", 2, 2),
+    (""Informatif Beta(5,5)"", 5, 5),
+    (""Biaise succes Beta(8,2)"", 8, 2)
+};
+
+Console.WriteLine($""Observations : {succes} succes, {echecs} echecs"");
+Console.WriteLine($""MLE (maximum de vraisemblance) : {(double)succes/(succes+echecs):F2}"");
+Console.WriteLine();
+
+foreach (var (nom, a, b) in priors)
+{
+    Variable<double> p = Variable.Beta(a, b);
+    Variable<int> obs = Variable.Binomial(succes + echecs, p);
+    obs.ObservedValue = succes;
+    
+    InferenceEngine eng = new InferenceEngine();
+    eng.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    eng.ShowProgress = false;
+    
+    Beta postP = eng.Infer<Beta>(p);
+    Console.WriteLine($""{nom,-25} -> Posterieur : mean = {postP.GetMean():F3}"");
+}
+
+Console.WriteLine();
+Console.WriteLine(""Observation : Le prior influence le posterieur, surtout avec peu de donnees."");",,,,,,,,c145de2436fb250e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,0f63b0a3,markdown,fr,6e40e3951a75a936,"**Analyse detaillee des resultats** :
+
+| Prior | Alpha | Beta | Moyenne prior | Moyenne posterieure | Ecart au MLE |
+|-------|-------|------|---------------|---------------------|--------------|
+| Uniforme | 1 | 1 | 0.500 | 0.571 | -0.029 |
+| Centre | 2 | 2 | 0.500 | 0.556 | -0.044 |
+| Informatif | 5 | 5 | 0.500 | 0.533 | -0.067 |
+| Biaise | 8 | 2 | 0.800 | 0.733 | +0.133 |
+
+Le posterieur Beta suit la formule analytique :
+
+$$p \mid \text{data} \sim \text{Beta}(\alpha + \text{succes}, \beta + \text{echecs})$$
+
+$$\mathbb{E}[p \mid \text{data}] = \frac{\alpha + \text{succes}}{\alpha + \beta + \text{succes} + \text{echecs}}$$
+
+> **Interpretation bayesienne** :
+> 
+> - Le prior **uniforme** (Beta(1,1)) est le plus ""neutre"" et donne un resultat proche du MLE
+> - Les priors **centres** (Beta(2,2) et Beta(5,5)) ""tirent"" le posterieur vers 0.5
+> - Le prior **biaise** (Beta(8,2)) domine les observations et maintient une estimation elevee
+>
+> La force de l'effet du prior depend du ratio entre les pseudo-observations du prior ($\alpha + \beta$) et les observations reelles (5 dans cet exemple).",,,,,,,,6e40e3951a75a936,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,16fa038a,code,fr,5734526b292791ad,"// Exercice : Test de depistage et impact du prior
+// TODO etudiant : Creer un modele pour un test medical avec sensibilite=0.9, faux_positifs=0.05
+// TODO etudiant : Observer un resultat positif et calculer P(malade | test+)
+// Indice : Utilisez Variable.Bernoulli pour la maladie et If/IfNot pour la vraisemblance du test
+Console.WriteLine(""Exercice a completer : test de depistage medical"");",,,,,,,,5734526b292791ad,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,835a51ef,markdown,fr,387e3774ed35aa04,"### Exercice 2 : Impact du prior sur un diagnostic medical
+
+**Objectif** : Modeliser un test de depistage avec des priors differents et observer l'impact sur le diagnostic posterieur.
+
+**Contexte** : Un test medical a un taux de faux positifs de 5% et un taux de sensibilite de 90%. La prevalence de la maladie est de 1%. Vous observez un test positif. Quelle est la probabilite que le patient soit reellement malade ?
+
+**Indices** :
+- # Indice 1 : Modelisez la probabilite de maladie avec `Variable.Beta(alpha, beta)` ou `Variable.Bernoulli(prevalence)`
+- # Indice 2 : Testez avec `Beta(1, 99)` (prevalence 1%), puis `Beta(10, 90)` (prevalence 10%)
+- # Etape 1 : Definir le modele avec la probabilite de maladie comme variable latente
+- # Etape 2 : Ajouter la vraisemblance du test (sensibilite et taux de faux positifs)
+- # Etape 3 : Observer un test positif et calculer le posterieur pour differentes prevalences",,,,,,,,387e3774ed35aa04,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,68678e15,markdown,fr,4a899e4992f01aff,"## 6. Checklist de Debugging
+
+Quand votre modele ne fonctionne pas, verifiez :
+
+**Etape 1 : Verification du Modele**
+- [ ] Les types des variables sont corrects (double vs int vs bool)
+- [ ] Les observations sont dans le support du prior
+- [ ] Les arrays ont les bonnes dimensions
+- [ ] Les Range sont correctement definis
+
+**Etape 2 : Verification de l'Inference**
+- [ ] L'algorithme est adapte au modele (EP/VMP/Gibbs)
+- [ ] Le nombre d'iterations est suffisant
+- [ ] Les warnings de compilation sont examines
+
+**Etape 3 : Verification des Resultats**
+- [ ] Les posterieurs ne sont pas degeneres (variance > 0)
+- [ ] Les moyennes sont dans des plages raisonnables
+- [ ] Les predictions sur donnees connues sont correctes",,,,,,,,4a899e4992f01aff,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,a9510f11,markdown,fr,f50b3ca0723c66e3,"### 6.1 Fonctions de diagnostic automatisees
+
+Plutot que d'inspecter manuellement chaque posterieur, il est recommande de creer des fonctions de diagnostic reutilisables. Les fonctions ci-dessous verifient automatiquement les conditions de sante des posterieurs pour les trois types de distributions les plus courants : Gaussian, Gamma et Beta.
+
+Ces fonctions peuvent etre integrees dans un pipeline de validation pour detecter automatiquement :
+- Les distributions degenerees (variance quasi-nulle)
+- Les inferences non informatives (variance tres elevee)
+- Les valeurs hors plage attendue",,,,,,,,f50b3ca0723c66e3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,5debce5f,code,fr,959ce82394ceb2b2,"// Fonctions utilitaires de diagnostic pour differents types de distributions
+
+void DiagnosticGaussian(Gaussian posterior, string nom)
+{
+    Console.WriteLine($""=== Diagnostic : {nom} ==="");
+    Console.WriteLine($""  Distribution : {posterior}"");
+    Console.WriteLine($""  Moyenne : {posterior.GetMean():F4}"");
+    double variance = posterior.GetVariance();
+    Console.WriteLine($""  Variance : {variance:F6}"");
+    
+    if (variance < 1e-10)
+        Console.WriteLine(""  [ALERTE] Variance tres faible - possible degenerescence"");
+    if (variance > 1e6)
+        Console.WriteLine(""  [ALERTE] Variance tres elevee - inference non informative"");
+    Console.WriteLine();
+}
+
+void DiagnosticGamma(Gamma posterior, string nom)
+{
+    Console.WriteLine($""=== Diagnostic : {nom} ==="");
+    Console.WriteLine($""  Distribution : {posterior}"");
+    Console.WriteLine($""  Moyenne : {posterior.GetMean():F4}"");
+    double variance = posterior.GetVariance();
+    Console.WriteLine($""  Variance : {variance:F6}"");
+    
+    if (variance < 1e-10)
+        Console.WriteLine(""  [ALERTE] Variance tres faible - possible degenerescence"");
+    if (variance > 1e6)
+        Console.WriteLine(""  [ALERTE] Variance tres elevee - inference non informative"");
+    Console.WriteLine();
+}
+
+void DiagnosticBeta(Beta posterior, string nom)
+{
+    Console.WriteLine($""=== Diagnostic : {nom} ==="");
+    Console.WriteLine($""  Distribution : {posterior}"");
+    Console.WriteLine($""  Moyenne : {posterior.GetMean():F4}"");
+    double variance = posterior.GetVariance();
+    Console.WriteLine($""  Variance : {variance:F6}"");
+    
+    if (variance < 1e-10)
+        Console.WriteLine(""  [ALERTE] Variance tres faible - possible degenerescence"");
+    Console.WriteLine();
+}
+
+// Exemple d'utilisation
+Variable<double> test = Variable.GaussianFromMeanAndPrecision(0, 0.1);
+Variable<double> yTest = Variable.GaussianFromMeanAndPrecision(test, 1);
+yTest.ObservedValue = 3.0;
+
+InferenceEngine diagEngine = new InferenceEngine();
+diagEngine.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+diagEngine.ShowProgress = false;
+
+var testPost = diagEngine.Infer<Gaussian>(test);
+DiagnosticGaussian(testPost, ""test"");",,,,,,,,959ce82394ceb2b2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,13549bb3,markdown,fr,cb90afdc5673ec44,"**Interpretation des diagnostics** :
+
+Les fonctions de diagnostic ci-dessus verifient plusieurs conditions de sante du posterieur :
+
+| Condition | Seuil | Signification si viole |
+|-----------|-------|------------------------|
+| Variance trop faible | < 10^-10 | Distribution degeneree, possible erreur numerique |
+| Variance trop elevee | > 10^6 | Inference non informative, donnees insuffisantes |
+
+Pour l'exemple `test`, le diagnostic montre :
+- **Moyenne ~2.73** : compromise entre le prior (0) et l'observation (3)
+- **Variance ~0.91** : incertitude reduite par l'observation mais non nulle
+
+> **Bonne pratique** : Integrez ces diagnostics dans vos pipelines d'inference pour detecter automatiquement les cas problematiques, surtout dans les modeles complexes avec de nombreuses variables latentes.
+
+---
+
+## Tableau recapitulatif des concepts
+
+| Concept | Description | Application au debugging |
+|---------|-------------|--------------------------|
+| **Support** | Ensemble des valeurs possibles sous une distribution | Verifier que les observations sont dans le support du prior |
+| **Precision** | Inverse de la variance (1/sigma^2) | Plus la precision est elevee, plus la distribution est concentree |
+| **Label switching** | Permutation des labels dans les modeles de melange | Utiliser des priors asymetriques ou des contraintes d'ordre |
+| **EP** | Expectation Propagation | Algorithme rapide pour modeles continus, peut diverger |
+| **VMP** | Variational Message Passing | Stable mais sous-estime l'incertitude |
+| **Factor Graph** | Representation graphique du modele | Visualiser la structure pour identifier les erreurs |
+
+### Distributions utilisees dans ce notebook
+
+| Distribution | Parametres | Usage typique |
+|--------------|------------|---------------|
+| **Gaussian** | (mean, precision) | Variables continues, estimations de moyennes |
+| **Gamma** | (shape, scale) | Precisions, variances, taux |
+| **Beta** | (alpha, beta) | Probabilites binomiales, proportions |
+| **Dirichlet** | (alpha_1, ..., alpha_k) | Proportions multinomiales, poids de melange |",,,,,,,,cb90afdc5673ec44,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,21f021ad,markdown,fr,565658566f63c274,"## 7. Exemple guide : Debugger un Modele
+
+### Enonce
+
+Le modele ci-dessous a plusieurs problemes. Identifiez et corrigez-les.",,,,,,,,565658566f63c274,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,1b5bc2d1,code,fr,da829d73fa679f67,"// Visualisation du factor graph du modele corrige
+// Utile pour verifier que la structure est correcte apres debugging
+
+Console.WriteLine(""=== Visualisation : Modele corrige ==="");
+
+Variable<double> moyenneVis = Variable.GaussianFromMeanAndPrecision(25, 0.01).Named(""moyenne"");
+Variable<double> precisionVis = Variable.GammaFromShapeAndScale(2, 0.5).Named(""precision"");
+Variable<double> observationVis = Variable.GaussianFromMeanAndPrecision(moyenneVis, precisionVis).Named(""observation"");
+observationVis.ObservedValue = 50;
+
+InferenceEngine exEngineVis = new InferenceEngine();
+exEngineVis.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+exEngineVis.ShowFactorGraph = true;
+exEngineVis.ShowProgress = false;
+
+var moyPostVis = exEngineVis.Infer<Gaussian>(moyenneVis);
+Console.WriteLine($""Moyenne posterieure : {moyPostVis}"");
+Console.WriteLine();
+Console.WriteLine(""Le factor graph valide la structure :"");
+Console.WriteLine(""  - 'moyenne' avec prior Gaussian large"");
+Console.WriteLine(""  - 'precision' avec prior Gamma(2, 0.5)"");
+Console.WriteLine(""  - 'observation' conditionnee sur les deux parametres"");
+
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));
+FactorGraphHelper.CleanupGeneratedFiles();",,,,,,,,da829d73fa679f67,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,184472ac,markdown,fr,667afef1697bf54d,A votre tour : identifiez les problemes dans le modele suivant.,,,,,,,,667afef1697bf54d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,7e3ddf44,code,fr,09d504acc3312bd0,"// Exemple guide : Trouvez les problemes dans ce modele
+
+Console.WriteLine(""=== Exercice : Debugger ce modele ==="");
+Console.WriteLine();
+
+// Probleme 1 : Prior trop etroit pour les observations
+// Probleme 2 : Variables non nommees
+// Probleme 3 : Precision negative (invalide)
+
+// Modele original (avec erreurs)
+/*
+Variable<double> m = Variable.GaussianFromMeanAndPrecision(0, 100);  // Prior trop concentre
+Variable<double> p = Variable.GammaFromShapeAndScale(0.1, 0.1);      // Shape trop petit
+Variable<double> obs = Variable.GaussianFromMeanAndPrecision(m, p);
+obs.ObservedValue = 50;  // Tres eloigne du prior sur m
+*/
+
+// Version corrigee
+Variable<double> moyenne = Variable.GaussianFromMeanAndPrecision(25, 0.01).Named(""moyenne"");  // Prior large
+Variable<double> precision = Variable.GammaFromShapeAndScale(2, 0.5).Named(""precision"");      // Shape >= 1
+Variable<double> observation = Variable.GaussianFromMeanAndPrecision(moyenne, precision).Named(""obs"");
+observation.ObservedValue = 50;
+
+InferenceEngine exEngine = new InferenceEngine();
+exEngine.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+exEngine.ShowProgress = false;
+
+var moyPost = exEngine.Infer<Gaussian>(moyenne);
+var precPost = exEngine.Infer<Gamma>(precision);
+
+Console.WriteLine(""Corrections appliquees :"");
+Console.WriteLine(""1. Prior sur moyenne : precision 0.01 (large) au lieu de 100 (etroit)"");
+Console.WriteLine(""2. Prior sur precision : Gamma(2, 0.5) au lieu de Gamma(0.1, 0.1)"");
+Console.WriteLine(""3. Variables nommees avec .Named()"");
+Console.WriteLine();
+Console.WriteLine($""Resultats : moyenne ~ {moyPost}, precision ~ {precPost}"");",,,,,,,,09d504acc3312bd0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,16c3f064,markdown,fr,0b6333fdccebf350,"**Analyse des corrections** :
+
+| Probleme original | Consequence | Correction appliquee |
+|-------------------|-------------|----------------------|
+| Precision 100 sur le prior | Prior concentre autour de 0 (ecart-type ~0.1) | Precision 0.01 (ecart-type ~10) |
+| Observation a 50 | 500 ecarts-types du centre du prior | Prior centre a 25 pour couvrir l'observation |
+| Gamma(0.1, 0.1) | Shape < 1 donne une densite infinie en 0 | Gamma(2, 0.5) avec shape >= 1 |
+| Variables anonymes | Difficulte a interpreter les erreurs | Nommage explicite avec `.Named()` |
+
+Le resultat corrige montre :
+- **Moyenne ~49.5** : proche de l'observation (50) car le prior est large
+- **Precision ~0.98** : estime a partir d'une seule observation (incertitude elevee)",,,,,,,,0b6333fdccebf350,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,26679033,markdown,fr,65ac343e0a0d9273,"### Points cles a retenir
+
+> **Strategie de debugging en 3 etapes** :
+>
+> 1. **Verifier le support** : Les observations sont-elles probables sous le prior ?
+> 2. **Verifier l'algorithme** : EP pour continu, VMP pour discret, Gibbs pour validation
+> 3. **Verifier les posterieurs** : Variance raisonnable ? Moyennes plausibles ?
+
+La plupart des problemes d'inference proviennent de :
+- **Priors mal specifies** (trop etroits, mauvais support)
+- **Mauvais choix d'algorithme** (EP sur modele discret, VMP sur correlations fortes)
+- **Modele trop complexe** (simplifier d'abord, complexifier ensuite)
+
+---",,,,,,,,65ac343e0a0d9273,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,7f896403,markdown,fr,d726a23355881fdd,"## 8. Resume
+
+| Probleme | Symptome | Solution |
+|----------|----------|----------|
+| **Prior trop etroit** | ""No support"" ou posterieurs etranges | Elargir le prior |
+| **Mode symetrique** | Posterieurs uniformes | Priors asymetriques |
+| **Divergence** | Valeurs infinies ou NaN | Changer d'algorithme ou regulariser |
+| **Lenteur** | Compilation longue | Simplifier le modele, cacher les types |
+
+---
+
+## Ressources
+
+- [Documentation Infer.NET](https://dotnet.github.io/infer/)
+- [FAQ Troubleshooting](https://dotnet.github.io/infer/userguide/Frequently%20Asked%20Questions.html)
+- [GitHub Issues](https://github.com/dotnet/infer/issues)",,,,,,,,d726a23355881fdd,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,4064f203,markdown,fr,c41cb0a572372c46,"## Exercice 3 : Deboguer un Modele Hierarchique Casse
+
+### Enonce
+
+Le modele ci-dessous tente d'estimer les moyennes de performance de 3 groupes, mais il contient **3 erreurs intentionnelles**. Identifiez et corrigez chaque erreur.
+
+**Indices** :
+1. Une precision de distribution ne peut pas etre negative
+2. Une variable observee doit dependre du parametre correct du groupe, pas d'une variable partagee
+3. Un tableau de donnees doit etre indexe par l'indice de boucle courant
+
+Corrigez le code et verifiez que les posterieurs correspondent aux moyennes des groupes.",,,,,,,,c41cb0a572372c46,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,9a8ffd00,code,fr,c45d358084df9902,"// Exercice : Corriger ce modele hierarchique bayesien (3 erreurs)
+int nGroupes = 3;
+int nObs = 4;
+double[][] donneesGroupes = {
+    new double[] { 12.1, 11.8, 12.5, 12.3 },  // Groupe 0 : ~12
+    new double[] { 15.2, 14.9, 15.8, 15.1 },  // Groupe 1 : ~15
+    new double[] { 9.8,  10.2, 9.5,  10.1 }   // Groupe 2 : ~10
+};
+
+// TODO: Identifier et corriger les 3 erreurs dans ce code :
+/*
+InferenceEngine engine = new InferenceEngine();
+engine.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+
+// ERREUR 1 : Shape de Gamma negatif (invalide)
+Variable<double> precisionGlobale = Variable.GammaFromShapeAndScale(-1, 1);
+
+// ERREUR 2 : Precision trop etroite pour la moyenne de population
+Variable<double> moyennePopulation = Variable.GaussianFromMeanAndPrecision(10, 10000);
+
+// ERREUR 3 : Les moyennes de groupe ne dependent pas de la population
+Variable<double>[] moyenneGroupe = new Variable<double>[nGroupes];
+for (int g = 0; g < nGroupes; g++)
+{
+    moyenneGroupe[g] = Variable.GaussianFromMeanAndPrecision(0, 1);
+    for (int j = 0; j < nObs; j++)
+    {
+        var obs = Variable.GaussianFromMeanAndPrecision(moyenneGroupe[g], precisionGlobale);
+        obs.ObservedValue = donneesGroupes[g][j];
+    }
+}
+*/
+
+// TODO 1 : Corriger le prior Gamma (shape doit etre positif)
+// Indice : utilisez GammaFromShapeAndScale(2, 0.5) ou similaire
+
+// TODO 2 : Corriger le prior de la moyenne de population
+// Indice : la precision ne doit pas etre trop grande, sinon la moyenne est ""figee""
+
+// TODO 3 : Lier les moyennes de groupe a la moyenne de population
+// Indice : moyenneGroupe[g] ~ Gaussian(moyennePopulation, precisionGroupe)
+
+// TODO 4 : Inferer et afficher les moyennes de chaque groupe et la moyenne de population
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,c45d358084df9902,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,cb86da26,markdown,fr,0b5bf6ac915bb922,"## Conclusion
+
+Ce notebook a couvert les techniques essentielles pour diagnostiquer et corriger les modeles probabilistes Infer.NET.
+
+| Concept | Point cle |
+|---------|-----------|
+| Support du prior | Verifier que les observations sont dans le support avant inference |
+| Choix d'algorithme | EP pour continu, VMP pour discret, Gibbs pour validation |
+| Priors informatifs | Elargir ou ajuster les priors selon le domaine |
+| Factor graphs | Visualiser la structure pour detecter les erreurs de connexion |
+| Diagnostics | Tester variance non-degeneree et moyennes plausibles |
+
+| Distribution | Usage pour le debug |
+|--------------|---------------------|
+| Gaussian | Verifier precision non-infinie, moyenne dans plage attendue |
+| Gamma | Shape >= 1 pour eviter densite infinie en 0 |
+| Beta | Pseudo-observations du prior vs donnees reelles |
+
+> **Demarche systematique** : Support -> Algorithme -> Posterieurs. La plupart des problemes d'inference proviennent de priors mal specifies ou d'un mauvais choix d'algorithme.",,,,,,,,0b5bf6ac915bb922,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,b0c83d62,markdown,fr,81178e25e2e93597,"### Exercice 4 : Debugging d'un modele de regression bayesienne
+
+**Objectif** : Identifiez et corrigez les problemes dans un modele de regression lineaire bayesienne qui produit des posterieurs degeneres.
+
+**Contexte** : Un chercheur tente d'etablir une relation lineaire entre les heures d'etude (`x`) et les scores d'examen (`y`). Le modele utilise une pente `slope`, une ordonnee a l'origine `intercept` et un bruit `noise`. Malheureusement, les posterieurs sont inutilisables (variance quasi-nulle ou infinie).
+
+**Indices** :
+- # Indice 1 : Verifiez le prior sur la precision du bruit. Un shape < 1 produit une densite infinie en 0.
+- # Indice 2 : La precision du prior sur la pente est-elle adaptee a l'echelle des donnees (scores sur ~50-100) ?
+- # Etape 1 : Identifiez les 2 problemes dans le modele fourni (prior sur le bruit + precision de la pente)
+- # Etape 2 : Corrigez les priors et relancez l'inference
+- # Etape 3 : Utilisez `DiagnosticGaussian()` pour verifier la sante des posterieurs corriges",,,,,,,,81178e25e2e93597,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb,a45745f5,code,fr,f68c31d854d33ed8,"// Exercice : Debugging d'un modele de regression bayesienne
+
+// Donnees : heures d'etude (x) et scores d'examen (y)
+double[] xData = { 2, 4, 6, 8, 10 };
+double[] yData = { 55, 62, 71, 78, 88 };
+int nPoints = xData.Length;
+
+// MODELE A CORRIGER (contient 2 problemes) :
+/*
+Variable<double> slope = Variable.GaussianFromMeanAndPrecision(0, 10000);     // PROBLEME ?
+Variable<double> intercept = Variable.GaussianFromMeanAndPrecision(0, 0.01); // OK
+Variable<double> noise = Variable.GammaFromShapeAndScale(0.1, 0.1);          // PROBLEME ?
+
+Range r = new Range(nPoints);
+VariableArray<double> yObs = Variable.Array<double>(r);
+yObs[r] = Variable.GaussianFromMeanAndPrecision(
+    intercept + slope * xData[r], noise);
+
+yObs.ObservedValue = yData;
+
+InferenceEngine eng = new InferenceEngine();
+eng.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+var slopePost = eng.Infer<Gaussian>(slope);
+var interceptPost = eng.Infer<Gaussian>(intercept);
+*/
+
+// TODO 1 : Corriger le prior sur la pente (precision trop elevee pour des scores ~50-100)
+// Indice : avec precision=10000, l'ecart-type est de 0.01, la pente ne peut pas bouger
+
+// TODO 2 : Corriger le prior sur le bruit (shape < 1 = densite infinie en 0)
+// Indice : utilisez GammaFromShapeAndScale(2, 1) ou similaire
+
+// TODO 3 : Executer l'inference et verifier avec DiagnosticGaussian()
+// Resultat attendu : slope ~ Gaussian(~3.3, ~0.05), intercept ~ Gaussian(~42, ~3)
+
+Console.WriteLine(""Exercice a completer : debugging regression bayesienne"");",,,,,,,,f68c31d854d33ed8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,acede045,markdown,fr,faf768f11ce9d3fa,"# Infer-7-Skills-IRT : Evaluation de Competences et Psychometrie
+
+**Serie** : Programmation Probabiliste avec Infer.NET (5/20)  
+**Duree estimee** : 60 minutes  
+**Prerequis** : Infer-4-Bayesian-Networks
+
+---
+
+## Objectifs
+
+- Comprendre les modeles d'evaluation cognitive
+- Implementer le modele IRT (Item Response Theory) Difficulty-Ability
+- Construire le modele DINA (Noisy-And) pour competences multiples
+- Gerer les relations many-to-many entre competences et questions
+- Estimer les parametres slip et guess
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-4-Bayesian-Networks](Infer-4-Bayesian-Networks.ipynb) | [Infer-6-Debugging](Infer-6-Debugging.ipynb) |
+
+---",,,,,,,,faf768f11ce9d3fa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,82c317c2,markdown,fr,d9293f9ca8c22f91,"## 1. Configuration
+
+Nous preparons l'environnement pour les modeles d'evaluation de competences. Ces modeles psychometriques (IRT, DINA) utilisent des variables latentes pour representer les capacites non observees des etudiants et les difficultes des questions.",,,,,,,,d9293f9ca8c22f91,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,ecaf0068,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,b161447f,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,ny2wcgc1uwe,code,fr,c6320edfc243b150,"// Chargement du helper pour la visualisation des graphes de facteurs
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper charge."");
+Console.WriteLine($""Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}"");",,,,,,,,c6320edfc243b150,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,m107lfympo,markdown,fr,893f1c2658e8600d,"### Visualisation des graphes de facteurs
+
+Le helper `FactorGraphHelper` permet d'afficher les graphes de facteurs generes par Infer.NET directement dans le notebook. Ces visualisations montrent :
+
+- **Variables observees** (rectangles gris) : donnees fournies au modele
+- **Variables latentes** (ovales) : parametres a inferer
+- **Facteurs** (carres noirs) : relations probabilistes entre variables
+
+Pour activer la generation des graphes, on utilise `engine.ShowFactorGraph = true` sur chaque moteur d'inference.",,,,,,,,893f1c2658e8600d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,x170007hb78,markdown,fr,2491e560d3cd4a85,"### Composants charges
+
+| Package | Role |
+|---------|------|
+| `Microsoft.ML.Probabilistic` | Moteur d'inference principal |
+| `Microsoft.ML.Probabilistic.Compiler` | Compilation des modeles en code C# |
+
+Les modeles IRT et DINA utilisent des **variables latentes continues** (capacites) ou **discretes** (competences binaires) pour representer des caracteristiques non directement observables des etudiants.",,,,,,,,2491e560d3cd4a85,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,6e446418,markdown,fr,a82d627c0472edab,"## 2. Introduction a l'Evaluation Cognitive
+
+### Probleme
+
+Comment evaluer les competences d'un etudiant a partir de ses reponses a un test ?
+
+### Defis
+
+| Defi | Description |
+|------|-------------|
+| **Capacite latente** | La competence n'est pas directement observable |
+| **Bruit** | Les reponses peuvent etre correctes par chance ou incorrectes par erreur |
+| **Difficulte variable** | Les questions ont des difficultes differentes |
+| **Competences multiples** | Une question peut necessiter plusieurs competences |
+
+### Approches
+
+| Modele | Caracteristique |
+|--------|----------------|
+| **IRT classique** | Capacite unidimensionnelle + difficulte des questions |
+| **DINA** | Competences discretes multiples + matrice Q |
+| **Bayesien hierarchique** | Parametres appris de maniere adaptative |",,,,,,,,a82d627c0472edab,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,40c04fbd,markdown,fr,2ac9ec9621523c18,"## 3. Modele IRT : Difficulty-Ability
+
+### Formulation
+
+$$P(\text{correct}_{ij}) = \sigma(\text{capacite}_i - \text{difficulte}_j)$$
+
+Ou $\sigma$ est la fonction logistique (ou probit dans notre cas).
+
+### Structure
+
+```
+capacite[i] ~ N(0, 1)    pour chaque etudiant
+difficulte[j] ~ N(0, 1)  pour chaque question
+
+avantage[i,j] = capacite[i] - difficulte[j]
+reponse[i,j] ~ Probit(avantage[i,j])
+```",,,,,,,,2ac9ec9621523c18,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,e468266b,code,fr,6f0fd822d4640521,"// Modele IRT Difficulty-Ability
+
+int nEtudiants = 10;
+int nQuestions = 5;
+
+// Donnees simulees : matrice de reponses (true = correct)
+bool[,] reponses = new bool[,] {
+    // Q1    Q2     Q3     Q4     Q5
+    { true,  true,  true,  false, false },  // Etudiant 1 (bon)
+    { true,  true,  false, false, false },  // Etudiant 2
+    { true,  false, false, false, false },  // Etudiant 3 (faible)
+    { true,  true,  true,  true,  false },  // Etudiant 4 (tres bon)
+    { false, false, false, false, false },  // Etudiant 5 (tres faible)
+    { true,  true,  false, true,  false },  // Etudiant 6
+    { true,  true,  true,  false, true },   // Etudiant 7
+    { true,  false, true,  false, false },  // Etudiant 8
+    { true,  true,  true,  true,  true },   // Etudiant 9 (excellent)
+    { false, true,  false, false, false }   // Etudiant 10
+};
+
+// Definition du modele
+Range etudiant = new Range(nEtudiants).Named(""etudiant"");
+Range question = new Range(nQuestions).Named(""question"");
+
+// Capacites latentes des etudiants
+VariableArray<double> capacite = Variable.Array<double>(etudiant).Named(""capacite"");
+capacite[etudiant] = Variable.GaussianFromMeanAndPrecision(0, 1).ForEach(etudiant);
+
+// Difficultes des questions
+VariableArray<double> difficulte = Variable.Array<double>(question).Named(""difficulte"");
+difficulte[question] = Variable.GaussianFromMeanAndPrecision(0, 1).ForEach(question);
+
+// Discrimination (bruit)
+Variable<double> discrimination = Variable.GammaFromShapeAndScale(2, 0.5).Named(""discrimination"");
+
+// Reponses observees
+VariableArray2D<bool> reponseVar = Variable.Array<bool>(etudiant, question).Named(""reponse"");
+
+using (Variable.ForEach(etudiant))
+{
+    using (Variable.ForEach(question))
+    {
+        Variable<double> avantage = capacite[etudiant] - difficulte[question];
+        Variable<double> avantageBruite = Variable.GaussianFromMeanAndPrecision(avantage, discrimination);
+        reponseVar[etudiant, question] = (avantageBruite > 0);
+    }
+}
+
+// Observations
+reponseVar.ObservedValue = reponses;
+
+Console.WriteLine(""Modele IRT defini."");",,,,,,,,6f0fd822d4640521,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,frj93ftqzui,markdown,fr,ad31fc2265b42de3,"### Structure des donnees
+
+Les donnees sont organisees en une **matrice de reponses** (10 etudiants x 5 questions) :
+
+| Etudiant | Q1 | Q2 | Q3 | Q4 | Q5 | Score |
+|----------|----|----|----|----|----| ----- |
+| E1 | T | T | T | F | F | 3/5 |
+| E2 | T | T | F | F | F | 2/5 |
+| E3 | T | F | F | F | F | 1/5 |
+| E4 | T | T | T | T | F | 4/5 |
+| E5 | F | F | F | F | F | 0/5 |
+| E6 | T | T | F | T | F | 3/5 |
+| E7 | T | T | T | F | T | 4/5 |
+| E8 | T | F | T | F | F | 2/5 |
+| E9 | T | T | T | T | T | 5/5 |
+| E10 | F | T | F | F | F | 1/5 |
+
+**Patterns interessants** :
+- E1 et E6 ont le meme score mais des patterns differents (Q3 vs Q4)
+- E7 reussit Q5 (difficile) mais pas Q4 → questions de difficulte similaire ?",,,,,,,,ad31fc2265b42de3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,9qvij59ix7n,markdown,fr,710b9267535de426,"### Lancement de l'inference
+
+Le moteur d'inference va maintenant estimer simultanement :
+- Les **capacites latentes** de chaque etudiant (variables non observees)
+- Les **difficultes** de chaque question (egalement latentes)
+
+L'algorithme utilise est **Expectation Propagation (EP)**, adapte aux modeles avec des variables continues et des observations binaires (reponses correctes/incorrectes).
+
+> **Note technique** : L'inference conjointe de capacites et difficultes est possible car les observations (matrice de reponses) contraignent suffisamment le probleme. C'est le principe de la **calibration IRT** utilisee dans les tests standardises.",,,,,,,,710b9267535de426,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,70a84b2f,code,fr,31e23e0054f5fb9b,"// Inference
+InferenceEngine moteurIRT = new InferenceEngine(new ExpectationPropagation());
+moteurIRT.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurIRT.ShowFactorGraph = true;  // Genere un fichier .gv pour visualisation
+
+Gaussian[] capacitePost = moteurIRT.Infer<Gaussian[]>(capacite);
+Gaussian[] difficultePost = moteurIRT.Infer<Gaussian[]>(difficulte);
+
+Console.WriteLine(""=== Capacites des etudiants (IRT) ==="");
+for (int i = 0; i < nEtudiants; i++)
+{
+    int nCorrect = 0;
+    for (int j = 0; j < nQuestions; j++) if (reponses[i, j]) nCorrect++;
+    Console.WriteLine($""Etudiant {i+1} : capacite = {capacitePost[i].GetMean():F2} +/- {Math.Sqrt(capacitePost[i].GetVariance()):F2} (score: {nCorrect}/{nQuestions})"");
+}
+
+Console.WriteLine(""\n=== Difficultes des questions ==="");
+for (int j = 0; j < nQuestions; j++)
+{
+    int nReussi = 0;
+    for (int i = 0; i < nEtudiants; i++) if (reponses[i, j]) nReussi++;
+    Console.WriteLine($""Question {j+1} : difficulte = {difficultePost[j].GetMean():F2} (taux reussite: {nReussi}/{nEtudiants})"");
+}",,,,,,,,31e23e0054f5fb9b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,1b88a77c,markdown,fr,0b32e588506c4a07,Visualisation du graphe de facteurs du modele IRT.,,,,,,,,0b32e588506c4a07,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,nc0ppf2w6q,code,fr,49ca94a184877545,"// Visualisation du graphe de facteurs IRT
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,49ca94a184877545,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,vhz59h176p,markdown,fr,6d32c1c6efe9ba90,"### Graphe de facteurs du modele IRT
+
+
+Le graphe ci-dessus represente la structure du modele IRT :
+
+| Element | Representation | Signification |
+|---------|----------------|---------------|
+| **capacite[i]** | Variable continue (ovale) | Capacite latente de chaque etudiant |
+| **difficulte[j]** | Variable continue (ovale) | Difficulte de chaque question |
+| **discrimination** | Variable continue | Parametre de bruit global |
+| **reponse[i,j]** | Variable observee (rectangle) | Reponses correctes/incorrectes |
+| **Facteurs** | Carres noirs | Relations probabilistes (Gaussian, IsPositive) |
+
+La structure **bidimensionnelle** (etudiants x questions) cree une grille de facteurs connectant chaque capacite a chaque difficulte via les observations.",,,,,,,,6d32c1c6efe9ba90,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,2219d280,markdown,fr,e0abdd61f2cdffe2,"### Analyse détaillée des résultats IRT
+
+**Observation clé** : La capacité estimée est **fortement corrélée** au score brut, mais pas parfaitement identique.
+
+| Étudiant | Score | Capacité | Observation |
+|----------|-------|----------|-------------|
+| E5 | 0/5 | -1.44 | Le plus faible |
+| E9 | 5/5 | +1.44 | Le plus fort |
+| E1, E6 | 3/5 | ~+0.27 | Niveau moyen |
+
+**Ordre des questions par difficulté** : Q1 < Q2 < Q3 < Q4 < Q5
+
+Cela correspond aux taux de réussite observés (80%, 70%, 50%, 30%, 20%).
+
+**Avantage du modèle IRT sur le score brut** :
+- L'**écart-type** reflète l'incertitude (plus grande pour les scores intermédiaires)
+- La capacité tient compte de la **difficulté des questions réussies**
+- Un étudiant qui réussit Q5 (difficile) a une capacité plus élevée qu'un autre avec le même score mais sur des questions faciles",,,,,,,,e0abdd61f2cdffe2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,u7e3glgtzcm,markdown,fr,cb437469f3cfac37,"## 3bis. Évaluation du Modèle : Courbes ROC
+
+Une **courbe ROC** (Receiver Operating Characteristic) permet d'évaluer la qualité des prédictions d'un modèle de classification. Pour l'IRT, nous pouvons prédire si un étudiant va répondre correctement à une question et comparer aux réponses réelles.
+
+### Métriques d'évaluation
+
+| Métrique | Formule | Interprétation |
+|----------|---------|----------------|
+| **AUC** | Aire sous la courbe ROC | 0.5 = aléatoire, 1.0 = parfait |
+| **TPR** | TP / (TP + FN) | Taux de vrais positifs (sensibilité) |
+| **FPR** | FP / (FP + TN) | Taux de faux positifs (1 - spécificité) |",,,,,,,,cb437469f3cfac37,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,46lkoyw14mo,markdown,fr,25f71f47c5122649,"### Calcul de la courbe ROC
+
+Le code suivant calcule la courbe ROC en :
+1. **Calculant P(correct)** pour chaque paire (etudiant, question) selon le modele
+2. **Triant** les predictions par probabilite decroissante
+3. **Calculant TPR/FPR** pour chaque seuil de classification
+4. **Integrant** l'aire sous la courbe (AUC) par la methode des trapezes
+
+> **Approximation probit-logit** : Le modele utilise une fonction probit, mais nous approximons avec une logistique (facteur 1.7) pour simplifier le calcul.",,,,,,,,25f71f47c5122649,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,e4imjob0vqj,code,fr,2741109178c50caa,"// Calcul de la courbe ROC pour le modele IRT
+
+Console.WriteLine(""=== Evaluation ROC du modele IRT ===\n"");
+
+// Calculer les probabilites de reponse correcte pour chaque paire (etudiant, question)
+List<(double prob, bool actual)> predictions = new List<(double, bool)>();
+
+for (int i = 0; i < nEtudiants; i++)
+{
+    for (int j = 0; j < nQuestions; j++)
+    {
+        // P(correct) approxime par la fonction probit
+        double avantage = capacitePost[i].GetMean() - difficultePost[j].GetMean();
+        // Approximation de Phi (CDF normale) par fonction logistique
+        double probCorrect = 1.0 / (1.0 + Math.Exp(-1.7 * avantage));
+        predictions.Add((probCorrect, reponses[i, j]));
+    }
+}
+
+// Trier par probabilite decroissante
+var sorted = predictions.OrderByDescending(p => p.prob).ToList();
+
+// Calculer les points de la courbe ROC
+int totalPos = sorted.Count(p => p.actual);
+int totalNeg = sorted.Count - totalPos;
+
+List<(double fpr, double tpr)> rocPoints = new List<(double, double)>();
+rocPoints.Add((0.0, 0.0));
+
+int tp = 0, fp = 0;
+double lastProb = 1.0;
+
+foreach (var pred in sorted)
+{
+    if (pred.actual) tp++;
+    else fp++;
+    
+    double tpr = (double)tp / totalPos;
+    double fpr = (double)fp / totalNeg;
+    rocPoints.Add((fpr, tpr));
+}
+
+// Calcul de l'AUC (methode des trapezes)
+double auc = 0;
+for (int i = 1; i < rocPoints.Count; i++)
+{
+    double width = rocPoints[i].fpr - rocPoints[i-1].fpr;
+    double height = (rocPoints[i].tpr + rocPoints[i-1].tpr) / 2;
+    auc += width * height;
+}
+
+Console.WriteLine($""AUC (Area Under Curve) : {auc:F3}"");
+Console.WriteLine($""  0.5 = aleatoire, 1.0 = parfait"");
+Console.WriteLine($""  Interpretation : {(auc > 0.9 ? ""Excellent"" : auc > 0.8 ? ""Bon"" : auc > 0.7 ? ""Acceptable"" : ""Faible"")}"");
+
+// Afficher quelques points de la courbe
+Console.WriteLine(""\nPoints cles de la courbe ROC :"");
+Console.WriteLine(""| Seuil | FPR  | TPR  |"");
+Console.WriteLine(""|-------|------|------|"");
+double[] seuils = { 0.9, 0.7, 0.5, 0.3, 0.1 };
+foreach (double seuil in seuils)
+{
+    int tpS = predictions.Count(p => p.prob >= seuil && p.actual);
+    int fpS = predictions.Count(p => p.prob >= seuil && !p.actual);
+    double tprS = (double)tpS / totalPos;
+    double fprS = (double)fpS / totalNeg;
+    Console.WriteLine($""| {seuil:F1}   | {fprS:F2} | {tprS:F2} |"");
+}",,,,,,,,2741109178c50caa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,i17w6q3o1nj,markdown,fr,02de06987fa39462,"### Interprétation de la Courbe ROC
+
+**AUC (Area Under Curve)** mesure la capacité discriminante du modèle :
+
+| AUC | Interprétation | Action suggérée |
+|-----|----------------|-----------------|
+| 0.9-1.0 | Excellent | Le modèle est très fiable |
+| 0.8-0.9 | Bon | Utilisable en production |
+| 0.7-0.8 | Acceptable | À améliorer si possible |
+| 0.5-0.7 | Faible | Revoir le modèle |
+
+**Lecture de la table** :
+- **Seuil 0.7** : Si on prédit ""correct"" quand P(correct) > 0.7
+  - TPR = % de vraies bonnes réponses capturées
+  - FPR = % de fausses alertes (mauvaises réponses prédites correctes)
+
+**Application pour l'IRT** :
+
+Le modèle IRT devrait avoir une AUC élevée car :
+1. Il capture la **vraie capacité** de chaque étudiant
+2. Il tient compte de la **difficulté** de chaque question
+3. La prédiction P(correct) = f(capacité - difficulté) est bien calibrée
+
+> **Note** : Avec seulement 50 observations (10 étudiants × 5 questions), l'AUC peut être bruitée. Un test plus grand donnerait une estimation plus stable.",,,,,,,,02de06987fa39462,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,ul9hjtw90cc,markdown,fr,86a9ceb492c43172,"---
+
+**Transition** : La courbe ROC nous montre que le modele IRT capture bien la structure des donnees. Cependant, l'IRT suppose une **capacite unidimensionnelle**. Pour des tests evaluant des competences distinctes, nous avons besoin du modele **DINA** presente dans la section suivante.",,,,,,,,86a9ceb492c43172,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,716de205,markdown,fr,e29b8f0c5f491cb6,"### Exercice : Ajouter un etudiant et predire ses reponses
+
+Le modele IRT de la section 3 a estime les capacites de 10 etudiants et les difficultes de 5 questions. Utilisez ces resultats pour evaluer un nouvel etudiant.
+
+**Objectif** : Un 11e etudiant repond aux 5 questions avec le pattern `{true, true, false, false, false}`. Estimez sa capacite et predisez sa probabilite de succes a une 6e question hypothetique de difficulte 0.5.
+
+**Etapes** :
+1. Reprenez les posterieurs des difficultes ( deja calcules dans la section 3)
+2. Ajoutez le nouvel etudiant au modele avec ses reponses observees
+3. Inferez sa capacite posterieure
+4. Utilisez le modele probit pour calculer P(correct | capacite, difficulte=0.5)
+
+**Indices** :
+- Fixez les difficultes comme variables observees avec `Variable.Observed(difficultePost[j])` puis `Variable.Random<double, Gaussian>(...)`
+- La probabilite de reussite se calcule via la fonction probit : `1.0 / (1.0 + Math.Exp(-1.7 * avantage))`
+- Comparez la capacite estimee du nouvel etudiant avec les autres etudiants",,,,,,,,e29b8f0c5f491cb6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,5af1325d,code,fr,c4f445dc4b547c9c,"// Exercice : Ajouter un etudiant et predire ses reponses
+// TODO: Definir les reponses du nouvel etudiant
+// bool[] reponsesNouvel = { true, true, false, false, false };
+
+// TODO: Fixer les difficultes des questions a leurs posterieurs (section 3)
+// Indice: Pour chaque question, Variable<Gaussian> diffObs = Variable.Observed(difficultePost[j]);
+// Puis Variable<double> diff = Variable.Random<double, Gaussian>(diffObs);
+
+// TODO: Definir la capacite du nouvel etudiant avec un prior N(0,1)
+// Variable<double> capaciteNouvel = Variable.GaussianFromMeanAndPrecision(0, 1);
+
+// TODO: Observer les reponses du nouvel etudiant et inferer sa capacite
+// Indice: meme structure que le modele IRT de la section 3
+
+// TODO: Calculer P(correct) pour une question de difficulte 0.5
+// double avantage = capacitePost.GetMean() - 0.5;
+// double probCorrect = 1.0 / (1.0 + Math.Exp(-1.7 * avantage));
+Console.WriteLine(""Exercice a completer : Predire les reponses d'un nouvel etudiant"");",,,,,,,,c4f445dc4b547c9c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,3957a447,markdown,fr,7f0bb43cc95b0018,"## 4. Modele DINA : Competences Discretes
+
+### Motivation
+
+Le modele IRT suppose une capacite **unidimensionnelle**. En realite, un test peut evaluer **plusieurs competences**.
+
+### Modele DINA (Deterministic Input, Noisy And)
+
+- Chaque etudiant possede ou non chaque competence (variable binaire)
+- Chaque question necessite un sous-ensemble de competences (matrice Q)
+- Reponse correcte si **toutes** les competences requises sont presentes
+- Avec des erreurs slip et guess
+
+### Parametres
+
+| Parametre | Description |
+|-----------|-------------|
+| **Slip** | P(incorrect \| a toutes les competences) - erreur d'inattention |
+| **Guess** | P(correct \| manque une competence) - reponse au hasard |",,,,,,,,7f0bb43cc95b0018,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,56ikmnn0zn4,markdown,fr,5b838bcfc96ed239,"### Preparation des donnees DINA
+
+Nous allons maintenant definir un scenario concret pour le modele DINA :
+
+- **8 etudiants** avec differents profils de competences
+- **6 questions** avec des exigences variees (1 a 3 competences)
+- **3 competences** (C1, C2, C3)
+
+Les donnees sont construites pour illustrer comment le modele discrimine entre les profils. Par exemple, un etudiant ayant C1 et C2 (mais pas C3) reussira Q1, Q2, Q4 mais echouera sur Q3, Q5, Q6.",,,,,,,,5b838bcfc96ed239,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,6183b569,code,fr,878c66720b14251b,"// Modele DINA simplifie
+
+int nEtud = 8;
+int nQuest = 6;
+int nCompetences = 3;
+
+// Matrice Q : quelles competences sont requises pour chaque question
+// Q1 : C1 seulement
+// Q2 : C2 seulement
+// Q3 : C3 seulement
+// Q4 : C1 et C2
+// Q5 : C2 et C3
+// Q6 : C1, C2 et C3
+bool[,] matriceQ = new bool[,] {
+    // C1    C2     C3
+    { true,  false, false },  // Q1
+    { false, true,  false },  // Q2
+    { false, false, true  },  // Q3
+    { true,  true,  false },  // Q4
+    { false, true,  true  },  // Q5
+    { true,  true,  true  }   // Q6
+};
+
+// Donnees : reponses des etudiants
+bool[,] repDINA = new bool[,] {
+    // Q1    Q2     Q3     Q4     Q5     Q6
+    { true,  true,  true,  true,  true,  true  },  // E1 : a tout
+    { true,  true,  false, true,  false, false },  // E2 : C1, C2 seulement
+    { true,  false, true,  false, false, false },  // E3 : C1, C3 seulement
+    { false, true,  true,  false, true,  false },  // E4 : C2, C3 seulement
+    { true,  false, false, false, false, false },  // E5 : C1 seulement
+    { false, true,  false, false, false, false },  // E6 : C2 seulement
+    { false, false, true,  false, false, false },  // E7 : C3 seulement
+    { false, false, false, false, false, false }   // E8 : rien
+};
+
+Console.WriteLine(""Donnees DINA definies."");
+Console.WriteLine(""\nMatrice Q (competences requises par question) :"");
+for (int q = 0; q < nQuest; q++)
+{
+    string req = """";
+    for (int c = 0; c < nCompetences; c++)
+        if (matriceQ[q, c]) req += $""C{c+1} "";
+    Console.WriteLine($""  Q{q+1} : {req}"");
+}",,,,,,,,878c66720b14251b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,37dr139eft,markdown,fr,5cb03083f228ad2d,"### Lecture de la matrice Q
+
+La matrice Q definit la structure du test. Chaque ligne correspond a une question, chaque colonne a une competence.
+
+| Question | C1 | C2 | C3 | Interpretation |
+|----------|----|----|----|--------------| 
+| Q1 | 1 | 0 | 0 | Evalue C1 seul |
+| Q2 | 0 | 1 | 0 | Evalue C2 seul |
+| Q3 | 0 | 0 | 1 | Evalue C3 seul |
+| Q4 | 1 | 1 | 0 | Necessite C1 ET C2 |
+| Q5 | 0 | 1 | 1 | Necessite C2 ET C3 |
+| Q6 | 1 | 1 | 1 | Necessite les 3 competences |
+
+> **Conception de test** : Les questions multi-competences (Q4, Q5, Q6) sont plus discriminantes mais aussi plus difficiles. Un bon test melange des questions a competence unique (pour le diagnostic) et des questions composites (pour valider la maitrise globale).",,,,,,,,5cb03083f228ad2d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,aee8eb48,code,fr,4c4a04b85e269459,"// Note sur l'implementation DINA complete
+// Le modele DINA avec AND dynamique sur les competences requises est complexe a
+// implementer dans Infer.NET en raison des limitations sur SetTo dans les blocs conditionnels.
+// Nous utilisons ci-dessous une version simplifiee qui illustre les concepts.
+
+// Affichage de la structure du modele DINA
+Console.WriteLine(""=== Structure du modele DINA ==="");
+Console.WriteLine();
+Console.WriteLine(""Pour chaque etudiant e et question q :"");
+Console.WriteLine(""  1. Verifier si e a toutes les competences requises par q (selon matrice Q)"");
+Console.WriteLine(""  2. Si oui : P(correct) = 1 - slip"");
+Console.WriteLine(""  3. Si non : P(correct) = guess"");
+Console.WriteLine();
+Console.WriteLine(""Parametres a estimer :"");
+Console.WriteLine(""  - Competences[e,c] : chaque etudiant a-t-il chaque competence ?"");
+Console.WriteLine(""  - slip : probabilite d'erreur malgre les competences"");
+Console.WriteLine(""  - guess : probabilite de reussite sans les competences"");",,,,,,,,4c4a04b85e269459,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,pa9lh196gh,markdown,fr,e06bb77122b7876f,"### Limites de l'implementation dans Infer.NET
+
+Le modele DINA complet necessite de calculer dynamiquement le ET logique sur un sous-ensemble variable de competences pour chaque question. Cette operation est difficile a exprimer dans Infer.NET en raison des restrictions sur `SetTo` dans les blocs conditionnels imbriques.
+
+La cellule suivante presente une implementation simplifiee pour une question specifique, illustrant le raisonnement DINA.",,,,,,,,e06bb77122b7876f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,7w0uplcpe3i,markdown,fr,3d7856951d3e55a2,"### Implementation simplifiee pour une question
+
+Pour illustrer le raisonnement DINA, nous implementons le modele pour une seule question (Q4) qui necessite deux competences (C1 ET C2). Cette approche permet de :
+
+1. **Definir explicitement** la condition `aC1 & aC2`
+2. **Observer** une reponse et voir comment cela affecte les probabilites des competences
+3. **Estimer** les parametres slip et guess a partir des donnees
+
+Le code utilise des **priors Beta(1,9)** pour slip et guess, centres sur des valeurs faibles (~0.1), ce qui correspond a l'hypothese que les erreurs d'inattention et les reponses au hasard sont relativement rares.",,,,,,,,3d7856951d3e55a2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,b72eb4cf,code,fr,508fe16853f69d06,"// Version simplifiee : modele DINA pour une question specifique
+
+// Question Q4 necessite C1 ET C2
+Variable<bool> aC1 = Variable.Bernoulli(0.5).Named(""aC1"");
+Variable<bool> aC2 = Variable.Bernoulli(0.5).Named(""aC2"");
+
+Variable<double> slipQ4 = Variable.Beta(1, 9).Named(""slip"");
+Variable<double> guessQ4 = Variable.Beta(1, 9).Named(""guess"");
+
+Variable<bool> toutesCompQ4 = (aC1 & aC2).Named(""toutesComp"");
+Variable<bool> reponseQ4 = Variable.New<bool>().Named(""reponse"");
+
+using (Variable.If(toutesCompQ4))
+{
+    reponseQ4.SetTo(!Variable.Bernoulli(slipQ4));
+}
+using (Variable.IfNot(toutesCompQ4))
+{
+    reponseQ4.SetTo(Variable.Bernoulli(guessQ4));
+}
+
+// Observation : l'etudiant a repondu correctement
+reponseQ4.ObservedValue = true;
+
+InferenceEngine mDINA = new InferenceEngine();
+mDINA.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+mDINA.ShowFactorGraph = true;  // Genere un fichier .gv pour visualisation
+
+Console.WriteLine(""=== DINA : Inference des competences ==="");
+Console.WriteLine($""Question Q4 necessite C1 ET C2"");
+Console.WriteLine($""Observation : reponse correcte\n"");
+Console.WriteLine($""P(C1) = {mDINA.Infer<Bernoulli>(aC1).GetProbTrue():F3}"");
+Console.WriteLine($""P(C2) = {mDINA.Infer<Bernoulli>(aC2).GetProbTrue():F3}"");
+Console.WriteLine($""P(C1 ET C2) = {mDINA.Infer<Bernoulli>(toutesCompQ4).GetProbTrue():F3}"");
+Console.WriteLine($""\nSlip estime : {mDINA.Infer<Beta>(slipQ4).GetMean():F3}"");
+Console.WriteLine($""Guess estime : {mDINA.Infer<Beta>(guessQ4).GetMean():F3}"");",,,,,,,,508fe16853f69d06,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,6f09167c,markdown,fr,c7ff04e589880ea0,Visualisation du graphe de facteurs du modele DINA simplifie.,,,,,,,,c7ff04e589880ea0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,rg8nejotm0r,code,fr,d4b7e565405e6442,"// Visualisation du graphe de facteurs DINA simplifie
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,d4b7e565405e6442,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,i0jolbjmfoq,markdown,fr,20ecb2764a3d2f41,"### Graphe de facteurs du modele DINA simplifie
+
+
+Le graphe illustre la structure conditionnelle du modele DINA :
+
+| Element | Role |
+|---------|------|
+| **aC1, aC2** | Competences binaires (Bernoulli prior 0.5) |
+| **toutesComp** | Conjonction aC1 AND aC2 |
+| **slip, guess** | Parametres de bruit (Beta priors) |
+| **reponse** | Variable observee (true = correct) |
+
+**Structure conditionnelle** : La reponse depend de `toutesComp` via deux branches :
+- Si `toutesComp=true` : P(correct) = 1 - slip
+- Si `toutesComp=false` : P(correct) = guess
+
+Cette structure en **gate** (porte conditionnelle) est caracteristique des modeles a competences discretes.",,,,,,,,20ecb2764a3d2f41,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,kpx19prqge,markdown,fr,a3edd65043471a68,"### Analyse du modèle DINA simplifié
+
+**Résultats** :
+- P(C1) = P(C2) = **0.833** (augmenté depuis le prior de 0.5)
+- P(C1 ET C2) = **0.750**
+- Slip estimé : ~0.09, Guess estimé : ~0.12
+
+**Interprétation** :
+
+L'observation d'une réponse correcte à Q4 (qui nécessite C1 ET C2) favorise les deux compétences :
+
+1. **Sans guess** : La seule façon de répondre correctement est d'avoir C1 ET C2
+2. **Avec guess** : Il y a une petite probabilité (~10%) de réussir sans les compétences
+
+Le modèle infère que l'étudiant a **probablement** les deux compétences, mais conserve une incertitude résiduelle due au guess possible.
+
+> **Remarque** : P(C1 ET C2) = 0.75 ≠ P(C1) × P(C2) = 0.69 car les observations créent une **dépendance** entre C1 et C2 (explaining away : si l'un est absent, l'autre doit être présent pour expliquer la réussite par guess).",,,,,,,,a3edd65043471a68,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,0893ac42,markdown,fr,8bd878d1354c1fec,"## 5. Relations Many-to-Many
+
+### Probleme
+
+Dans le modele DINA, une question peut necessiter **plusieurs competences**, et une competence peut etre evaluee par **plusieurs questions**.
+
+### Representation avec Subarray
+
+Infer.NET permet d'utiliser `Variable.Subarray` pour extraire les competences requises pour chaque question.",,,,,,,,8bd878d1354c1fec,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,cwx0zd56zi,markdown,fr,a079dbc1c439cbd4,"### Demonstration avec plusieurs etudiants
+
+Nous etendons maintenant le modele a **4 etudiants** et **2 questions** pour illustrer comment l'inference combine les observations de plusieurs sources :
+
+- **Q1** : Necessite C1 seulement
+- **Q2** : Necessite C1 ET C2
+
+Les parametres slip (0.1) et guess (0.1) sont fixes pour simplifier l'inference sur les competences.
+
+> **Objectif** : Montrer comment les reponses a Q1 et Q2 permettent de separer les etudiants qui ont C1 seul de ceux qui ont aussi C2.",,,,,,,,a079dbc1c439cbd4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,3b949152,code,fr,f095ca4cddf27d0e,"// Demonstration avec plusieurs etudiants et questions
+
+int nE = 4;
+int nC = 3;
+
+// Prior : chaque etudiant a 50% de chance d'avoir chaque competence
+Range rE = new Range(nE).Named(""etudiant"");
+Range rC = new Range(nC).Named(""competence"");
+
+VariableArray2D<bool> competences = Variable.Array<bool>(rE, rC).Named(""competences"");
+competences[rE, rC] = Variable.Bernoulli(0.5).ForEach(rE, rC);
+
+// Simuler des observations sur plusieurs questions
+// Q1 necessite C1 seulement
+// Q2 necessite C1 ET C2
+
+// Observations pour Q1 (C1 seulement)
+bool[] obsQ1 = { true, true, false, true };  // E1, E2, E4 ont repondu correctement
+
+for (int e = 0; e < nE; e++)
+{
+    Variable<bool> toutQ1 = competences[e, 0];  // Seulement C1
+    Variable<bool> repQ1 = Variable.New<bool>().Named($""repQ1_E{e+1}"");
+    using (Variable.If(toutQ1))
+    {
+        repQ1.SetTo(Variable.Bernoulli(0.9));  // 1 - slip
+    }
+    using (Variable.IfNot(toutQ1))
+    {
+        repQ1.SetTo(Variable.Bernoulli(0.1));  // guess
+    }
+    repQ1.ObservedValue = obsQ1[e];
+}
+
+// Observations pour Q2 (C1 ET C2)
+bool[] obsQ2 = { true, false, false, true };
+
+for (int e = 0; e < nE; e++)
+{
+    Variable<bool> toutQ2 = competences[e, 0] & competences[e, 1];
+    Variable<bool> repQ2 = Variable.New<bool>().Named($""repQ2_E{e+1}"");
+    using (Variable.If(toutQ2))
+    {
+        repQ2.SetTo(Variable.Bernoulli(0.9));
+    }
+    using (Variable.IfNot(toutQ2))
+    {
+        repQ2.SetTo(Variable.Bernoulli(0.1));
+    }
+    repQ2.ObservedValue = obsQ2[e];
+}
+
+InferenceEngine mMany = new InferenceEngine();
+mMany.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+mMany.ShowFactorGraph = true;  // Genere un fichier .gv pour visualisation
+
+Bernoulli[,] compPost = mMany.Infer<Bernoulli[,]>(competences);
+
+Console.WriteLine(""=== Inference des competences (many-to-many) ==="");
+Console.WriteLine(""Q1 necessite C1, Q2 necessite C1 ET C2\n"");
+Console.WriteLine(""Observations : Q1=[T,T,F,T], Q2=[T,F,F,T]\n"");
+
+for (int e = 0; e < nE; e++)
+{
+    Console.Write($""Etudiant {e+1} : "");
+    for (int c = 0; c < nC; c++)
+    {
+        Console.Write($""C{c+1}={compPost[e,c].GetProbTrue():F2} "");
+    }
+    Console.WriteLine();
+}",,,,,,,,f095ca4cddf27d0e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,c7755942,markdown,fr,42c5c0e0df68c679,Visualisation du graphe de facteurs many-to-many.,,,,,,,,42c5c0e0df68c679,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,ww8hj4x0bi,code,fr,a1589411e0dc3acb,"// Visualisation du graphe de facteurs many-to-many
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,a1589411e0dc3acb,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,qt7qfg804tg,markdown,fr,4ecb2c188cb9a795,"### Graphe de facteurs many-to-many
+
+
+Ce graphe montre la structure **many-to-many** caracteristique des modeles DINA :
+
+| Aspect | Observation |
+|--------|-------------|
+| **Matrice competences[4,3]** | 12 variables binaires (4 etudiants x 3 competences) |
+| **Reponses Q1** | Connectees uniquement a C1 (1 competence requise) |
+| **Reponses Q2** | Connectees a C1 AND C2 via facteurs conjonctifs |
+| **C3** | Non connecte aux observations (reste au prior 0.5) |
+
+**Pattern de connexion** :
+- Chaque **etudiant** a ses propres variables de competences
+- Chaque **question** connecte les competences requises aux observations
+- Les facteurs **AND** implementent la logique ""toutes les competences necessaires""
+
+Cette structure permet l'inference **independante** des profils de competences pour chaque etudiant.",,,,,,,,4ecb2c188cb9a795,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,s8m8es9flxa,markdown,fr,263df4c1d553e7b4,"### Analyse des inférences many-to-many
+
+**Pattern des résultats** :
+
+| Étudiant | Q1(C1) | Q2(C1∧C2) | C1 inféré | C2 inféré | Interprétation |
+|----------|--------|-----------|-----------|-----------|----------------|
+| E1 | ✓ | ✓ | **0.98** | **0.89** | A probablement les deux |
+| E2 | ✓ | ✗ | 0.83 | **0.17** | A C1, pas C2 |
+| E3 | ✗ | ✗ | **0.06** | 0.48 | N'a pas C1 |
+| E4 | ✓ | ✓ | **0.98** | **0.89** | A probablement les deux |
+
+**Points clés** :
+
+1. **C3 reste à 0.50** pour tous les étudiants car aucune question ne l'évalue
+2. **E2** : Réussit Q1 (C1 seul) mais échoue Q2 (C1∧C2) → P(C2) chute à 0.17
+3. **E1 vs E4** : Mêmes observations, mêmes inférences (cohérence du modèle)
+
+> **Puissance du modèle** : Les questions multi-compétences (Q2) permettent de **discriminer** entre les compétences mieux qu'avec des questions à compétence unique.",,,,,,,,263df4c1d553e7b4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,af5487bb,markdown,fr,9f2d16242d5b01a0,"## 6. Estimation des Parametres Slip/Guess
+
+### Objectif
+
+Apprendre les parametres slip et guess a partir des donnees.
+
+### Approche
+
+- Utiliser des priors Beta sur slip et guess
+- L'inference met a jour ces distributions",,,,,,,,9f2d16242d5b01a0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,qrpczbu0bnm,markdown,fr,d5fe5cc092602878,"### Simulation de donnees pour l'estimation
+
+Pour evaluer la capacite du modele a estimer slip et guess, nous :
+
+1. **Fixons** les vraies valeurs : slip=0.1, guess=0.2, P(competence)=0.6
+2. **Simulons** 20 observations selon le modele generatif
+3. **Inferons** les parametres a partir des observations seules (sans connaitre les vraies competences)
+
+Cette approche permet de comparer les estimations aux vraies valeurs et d'evaluer le **biais** eventuel de l'inference.
+
+> **Defi** : L'estimation est difficile car les competences individuelles sont **non observees**. Le modele doit les inferer en meme temps que slip et guess.",,,,,,,,d5fe5cc092602878,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,7a18e737,code,fr,2bac159d888cfd3d,"// Estimation de slip/guess avec donnees multiples
+
+// Simuler des donnees ou on connait les vraies competences
+int nObs = 20;
+Random rng = new Random(42);
+
+double vraiSlip = 0.1;
+double vraiGuess = 0.2;
+
+// Generer des donnees
+bool[] vraiComp = new bool[nObs];    // Vrai etat de competence
+bool[] obsRep = new bool[nObs];       // Reponse observee
+
+for (int i = 0; i < nObs; i++)
+{
+    vraiComp[i] = rng.NextDouble() < 0.6;  // 60% ont la competence
+    if (vraiComp[i])
+    {
+        obsRep[i] = rng.NextDouble() > vraiSlip;  // Correct sauf slip
+    }
+    else
+    {
+        obsRep[i] = rng.NextDouble() < vraiGuess;  // Incorrect sauf guess
+    }
+}
+
+// Modele pour estimer slip et guess
+Variable<double> slipEst = Variable.Beta(1, 1).Named(""slip"");
+Variable<double> guessEst = Variable.Beta(1, 1).Named(""guess"");
+Variable<double> pComp = Variable.Beta(1, 1).Named(""pComp"");
+
+Range rObs = new Range(nObs).Named(""observation"");
+VariableArray<bool> comp = Variable.Array<bool>(rObs).Named(""competence"");
+VariableArray<bool> rep = Variable.Array<bool>(rObs).Named(""reponse"");
+
+comp[rObs] = Variable.Bernoulli(pComp).ForEach(rObs);
+
+using (Variable.ForEach(rObs))
+{
+    using (Variable.If(comp[rObs]))
+    {
+        rep[rObs] = !Variable.Bernoulli(slipEst);
+    }
+    using (Variable.IfNot(comp[rObs]))
+    {
+        rep[rObs] = Variable.Bernoulli(guessEst);
+    }
+}
+
+rep.ObservedValue = obsRep;
+
+InferenceEngine mSlipGuess = new InferenceEngine(new ExpectationPropagation());
+mSlipGuess.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+mSlipGuess.ShowFactorGraph = true;  // Genere un fichier .gv pour visualisation
+
+Console.WriteLine(""=== Estimation Slip/Guess ==="");
+Console.WriteLine($""Vraies valeurs : slip={vraiSlip}, guess={vraiGuess}\n"");
+Console.WriteLine($""Estimations :"");
+Console.WriteLine($""  Slip : {mSlipGuess.Infer<Beta>(slipEst)}"");
+Console.WriteLine($""  Guess : {mSlipGuess.Infer<Beta>(guessEst)}"");
+Console.WriteLine($""  P(competence) : {mSlipGuess.Infer<Beta>(pComp)}"");",,,,,,,,2bac159d888cfd3d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,v3r2vdr56k,markdown,fr,1f1dd3801cb27b7c,"### Analyse critique des estimations
+
+**Observation** : Les estimations divergent significativement des vraies valeurs :
+
+| Parametre | Vraie valeur | Estimation | Ecart |
+|-----------|--------------|------------|-------|
+| Slip | 0.10 | ~0.33 | +0.23 |
+| Guess | 0.20 | ~0.67 | +0.47 |
+| P(comp) | 0.60 | 0.50 | -0.10 |
+
+**Pourquoi cette divergence ?**
+
+1. **Probleme d'identifiabilite** : Sans connaitre les vraies competences, le modele ne peut pas distinguer :
+   - Un etudiant competent qui fait une erreur (slip)
+   - Un etudiant incompetent qui devine correctement (guess)
+
+2. **Symetrie du probleme** : Noter que slip + guess ≈ 1.0, ce qui suggere que le modele ""inverse"" partiellement l'interpretation.
+
+3. **Taille d'echantillon** : 20 observations sont insuffisantes pour estimer 3 parametres latents de maniere fiable.
+
+> **Lecon importante** : L'estimation de slip/guess **sans information supplementaire** sur les vraies competences est un probleme mal pose. En pratique, on utilise :
+> - Des **ancres** (items dont on connait la difficulte)
+> - Des **priors informatifs** bases sur des etudes pilotes
+> - Des **contraintes** (ex: slip < 0.3, guess < 0.3)
+",,,,,,,,1f1dd3801cb27b7c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,vo8ev1ov9x,markdown,fr,a401a85683d76b40,"### Graphe de facteurs pour l'estimation slip/guess
+
+
+Ce graphe illustre le probleme d'**identifiabilite** dans l'estimation des parametres de bruit :
+
+| Variable | Type | Role |
+|----------|------|------|
+| **slip** | Continue (Beta) | Parametre global d'erreur d'inattention |
+| **guess** | Continue (Beta) | Parametre global de reponse au hasard |
+| **pComp** | Continue (Beta) | Probabilite globale d'avoir la competence |
+| **competence[i]** | Binaire latent | Competence de chaque individu |
+| **reponse[i]** | Binaire observe | Reponse de chaque individu |
+
+**Probleme visible** : Les parametres slip, guess et pComp sont **tous trois connectes** a chaque observation via les competences latentes. Sans information supplementaire, le modele ne peut pas distinguer les differentes sources de bruit.",,,,,,,,a401a85683d76b40,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,n2ogxky9k6,code,fr,148210066d51178d,"// Visualisation du graphe de facteurs pour l'estimation slip/guess
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,148210066d51178d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,21617812,markdown,fr,ade2bdbaa43a3883,"
+### Version amelioree avec priors informatifs
+
+Voici comment contraindre les estimations avec des priors realistes :",,,,,,,,ade2bdbaa43a3883,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,9d7o2300545,code,fr,702a4c71cc59ee23,"// Version avec priors informatifs pour slip/guess
+
+// Memes donnees simulees
+Variable<double> slipInf = Variable.Beta(2, 18).Named(""slipInformatif"");  // Prior centre sur 0.1
+Variable<double> guessInf = Variable.Beta(3, 12).Named(""guessInformatif"");  // Prior centre sur 0.2
+Variable<double> pCompInf = Variable.Beta(6, 4).Named(""pCompInformatif"");  // Prior centre sur 0.6
+
+Range rObs2 = new Range(nObs).Named(""observation2"");
+VariableArray<bool> comp2 = Variable.Array<bool>(rObs2).Named(""competence2"");
+VariableArray<bool> rep2 = Variable.Array<bool>(rObs2).Named(""reponse2"");
+
+comp2[rObs2] = Variable.Bernoulli(pCompInf).ForEach(rObs2);
+
+using (Variable.ForEach(rObs2))
+{
+    using (Variable.If(comp2[rObs2]))
+    {
+        rep2[rObs2] = !Variable.Bernoulli(slipInf);
+    }
+    using (Variable.IfNot(comp2[rObs2]))
+    {
+        rep2[rObs2] = Variable.Bernoulli(guessInf);
+    }
+}
+
+rep2.ObservedValue = obsRep;
+
+InferenceEngine mInf = new InferenceEngine(new ExpectationPropagation());
+mInf.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+mInf.ShowFactorGraph = true;  // Genere un fichier .gv pour visualisation
+
+Console.WriteLine(""=== Estimation avec Priors Informatifs ==="");
+Console.WriteLine($""Vraies valeurs : slip={vraiSlip}, guess={vraiGuess}, P(comp)=0.6\n"");
+Console.WriteLine($""Priors : Beta(2,18) pour slip, Beta(3,12) pour guess, Beta(6,4) pour P(comp)\n"");
+Console.WriteLine($""Estimations :"");
+var slipPost = mInf.Infer<Beta>(slipInf);
+var guessPost = mInf.Infer<Beta>(guessInf);
+var pCompPost = mInf.Infer<Beta>(pCompInf);
+Console.WriteLine($""  Slip : moyenne={slipPost.GetMean():F3} (vraie: {vraiSlip})"");
+Console.WriteLine($""  Guess : moyenne={guessPost.GetMean():F3} (vraie: {vraiGuess})"");
+Console.WriteLine($""  P(competence) : moyenne={pCompPost.GetMean():F3} (vraie: 0.6)"");",,,,,,,,702a4c71cc59ee23,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,754ff5d2,markdown,fr,613f239fd05c0afa,Visualisation du graphe avec priors informatifs pour les parametres slip et guess.,,,,,,,,613f239fd05c0afa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,spbj44wip9,code,fr,208a645f7e3c651f,"// Visualisation du graphe avec priors informatifs
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,208a645f7e3c651f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,zmk2ata5wth,markdown,fr,bd46d47d7fc59762,"### Comparaison avec priors informatifs
+
+
+Le graphe a la meme structure que le precedent, mais les **priors** sont maintenant informatifs :
+
+| Parametre | Prior uniforme | Prior informatif |
+|-----------|----------------|------------------|
+| **slip** | Beta(1,1) = U(0,1) | Beta(2,18) centre sur 0.1 |
+| **guess** | Beta(1,1) = U(0,1) | Beta(3,12) centre sur 0.2 |
+| **pComp** | Beta(1,1) = U(0,1) | Beta(6,4) centre sur 0.6 |
+
+**Impact sur l'inference** : Les priors informatifs agissent comme des ""pseudo-observations"" qui guident l'estimation vers des valeurs realistes, brisant la symetrie du probleme d'identifiabilite.",,,,,,,,bd46d47d7fc59762,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,ywp5qszj2y,markdown,fr,b7d64b5f0063c9c6,"### Impact des priors informatifs
+
+L'utilisation de priors informatifs (Beta(2,18) pour slip, Beta(3,12) pour guess) permet de :
+
+1. **Regulariser** les estimations vers des valeurs realistes
+2. **Briser la symetrie** du probleme d'identifiabilite
+3. **Incorporer les connaissances du domaine** (slip et guess sont generalement faibles)
+
+| Configuration | Slip estime | Guess estime | Fiabilite |
+|---------------|-------------|--------------|-----------|
+| Priors uniformes Beta(1,1) | ~0.33 | ~0.67 | Faible |
+| Priors informatifs | Plus proche de 0.1 | Plus proche de 0.2 | Meilleure |
+
+> **Bonne pratique** : En psychometrie, les priors pour slip et guess sont souvent contraints a etre inferieurs a 0.3, ce qui correspond a la realite empirique des tests bien concus.",,,,,,,,b7d64b5f0063c9c6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,07a89284,markdown,fr,90264cf11c318fb2,"## 7. Comparaison IRT vs DINA
+
+| Aspect | IRT | DINA |
+|--------|-----|------|
+| **Capacite** | Continue, unidimensionnelle | Discrete, multidimensionnelle |
+| **Interpretation** | ""Niveau global"" | ""Competences specifiques"" |
+| **Complexite** | Simple, robuste | Plus complexe, informatif |
+| **Utilisation** | Tests standardises | Diagnostic pedagogique |
+| **Inference** | Plus facile | Necessite matrice Q |",,,,,,,,90264cf11c318fb2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,ojqirwmvivb,markdown,fr,51fb195c354cb37e,"### Quand utiliser chaque modele ?
+
+| Scenario | Modele recommande | Justification |
+|----------|-------------------|---------------|
+| Test standardise (SAT, GMAT) | **IRT** | Une seule dimension mesuree, grand echantillon |
+| Diagnostic pedagogique | **DINA** | Identifier les competences manquantes |
+| Certification professionnelle | **DINA** | Verifier les prerequis specifiques |
+| Classement de joueurs | **TrueSkill** (prochain notebook) | Competences relatives, matchs |
+
+### Formulation mathematique comparee
+
+**IRT (2PL)** :
+$$P(\text{correct}) = \frac{1}{1 + e^{-a(\theta - b)}}$$
+
+ou $\theta$ = capacite, $b$ = difficulte, $a$ = discrimination
+
+**DINA** :
+$$P(\text{correct}) = (1-s)^{\eta} \cdot g^{1-\eta}$$
+
+ou $\eta = \prod_{k} \alpha_k^{q_{jk}}$ (1 si toutes competences requises, 0 sinon), $s$ = slip, $g$ = guess",,,,,,,,51fb195c354cb37e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,34cb88fb,markdown,fr,2274e8bc64d2a6b4,"## 8. Exemple guide : Evaluer un Nouvel Etudiant
+
+### Enonce
+
+Un nouvel etudiant passe un test de 5 questions. Le test evalue 2 competences :
+- Q1, Q2 : Competence 1 seulement
+- Q3, Q4 : Competence 2 seulement
+- Q5 : Competences 1 ET 2
+
+Resultats : Q1=correct, Q2=correct, Q3=incorrect, Q4=correct, Q5=incorrect
+
+**Question** : Quelles sont les probabilites que l'etudiant possede C1 et C2 ?",,,,,,,,2274e8bc64d2a6b4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,9i2dyfdr6q9,markdown,fr,552feacfca448657,"### Implementation de l'exercice
+
+Le code suivant construit un modele DINA pour le scenario decrit :
+
+| Question | Competences | Resultat |
+|----------|-------------|----------|
+| Q1 | C1 | Correct |
+| Q2 | C1 | Correct |
+| Q3 | C2 | Incorrect |
+| Q4 | C2 | Correct |
+| Q5 | C1 ET C2 | Incorrect |
+
+Les parametres slip=0.1 et guess=0.15 sont fixes (valeurs typiques en psychometrie).
+
+> **Prediction intuitive** : Avec 2/2 sur C1 et 1/2 sur C2, on s'attend a P(C1) eleve et P(C2) incertain. L'echec a Q5 devrait trancher en defaveur de C2.",,,,,,,,552feacfca448657,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,ec677160,code,fr,5a19b911d6e69a6c,"// Exemple guide : Evaluation d'un nouvel etudiant
+
+Variable<bool> c1 = Variable.Bernoulli(0.5).Named(""C1"");
+Variable<bool> c2 = Variable.Bernoulli(0.5).Named(""C2"");
+
+double slip = 0.1;
+double guess = 0.15;
+
+// Q1 : C1 seulement -> correct
+Variable<bool> rQ1 = Variable.New<bool>().Named(""Q1"");
+using (Variable.If(c1)) { rQ1.SetTo(Variable.Bernoulli(1 - slip)); }
+using (Variable.IfNot(c1)) { rQ1.SetTo(Variable.Bernoulli(guess)); }
+rQ1.ObservedValue = true;
+
+// Q2 : C1 seulement -> correct
+Variable<bool> rQ2 = Variable.New<bool>().Named(""Q2"");
+using (Variable.If(c1)) { rQ2.SetTo(Variable.Bernoulli(1 - slip)); }
+using (Variable.IfNot(c1)) { rQ2.SetTo(Variable.Bernoulli(guess)); }
+rQ2.ObservedValue = true;
+
+// Q3 : C2 seulement -> incorrect
+Variable<bool> rQ3 = Variable.New<bool>().Named(""Q3"");
+using (Variable.If(c2)) { rQ3.SetTo(Variable.Bernoulli(1 - slip)); }
+using (Variable.IfNot(c2)) { rQ3.SetTo(Variable.Bernoulli(guess)); }
+rQ3.ObservedValue = false;
+
+// Q4 : C2 seulement -> correct
+Variable<bool> rQ4 = Variable.New<bool>().Named(""Q4"");
+using (Variable.If(c2)) { rQ4.SetTo(Variable.Bernoulli(1 - slip)); }
+using (Variable.IfNot(c2)) { rQ4.SetTo(Variable.Bernoulli(guess)); }
+rQ4.ObservedValue = true;
+
+// Q5 : C1 ET C2 -> incorrect
+Variable<bool> c1etc2 = (c1 & c2).Named(""C1_ET_C2"");
+Variable<bool> rQ5 = Variable.New<bool>().Named(""Q5"");
+using (Variable.If(c1etc2)) { rQ5.SetTo(Variable.Bernoulli(1 - slip)); }
+using (Variable.IfNot(c1etc2)) { rQ5.SetTo(Variable.Bernoulli(guess)); }
+rQ5.ObservedValue = false;
+
+InferenceEngine mEx = new InferenceEngine();
+mEx.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+mEx.ShowFactorGraph = true;  // Genere un fichier .gv pour visualisation
+
+Console.WriteLine(""=== Evaluation du nouvel etudiant ==="");
+Console.WriteLine(""Resultats : Q1=T, Q2=T, Q3=F, Q4=T, Q5=F\n"");
+Console.WriteLine($""P(C1) = {mEx.Infer<Bernoulli>(c1).GetProbTrue():F3}"");
+Console.WriteLine($""P(C2) = {mEx.Infer<Bernoulli>(c2).GetProbTrue():F3}"");
+Console.WriteLine($""\nInterpretation :"");
+Console.WriteLine(""- L'etudiant a probablement C1 (2/2 correct sur questions C1)"");
+Console.WriteLine(""- C2 est moins certain (1/2 correct, et Q5 echoue)"");",,,,,,,,5a19b911d6e69a6c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,diat8qdrbpt,markdown,fr,69ba0577c1a6de06,"### Analyse du diagnostic de l'etudiant
+
+**Resultats** :
+- P(C1) = **0.958** : L'etudiant a tres probablement C1
+- P(C2) = **0.091** : L'etudiant n'a probablement PAS C2
+
+**Raisonnement du modele** :
+
+| Observation | Impact sur C1 | Impact sur C2 |
+|-------------|---------------|---------------|
+| Q1=T (C1) | Forte hausse | - |
+| Q2=T (C1) | Confirmation | - |
+| Q3=F (C2) | - | Baisse |
+| Q4=T (C2) | - | Legere hausse |
+| Q5=F (C1 ET C2) | Legere baisse | Forte baisse |
+
+**Cle** : L'echec a Q5 (C1 ET C2) avec P(C1) eleve implique que C2 est probablement manquant (explaining away).
+
+> **Application pedagogique** : Ce diagnostic permet de cibler la remediation sur C2 specifiquement, plutot que de faire reprendre tout le cours a l'etudiant.",,,,,,,,69ba0577c1a6de06,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,qlxdvvpoxyj,markdown,fr,8a099add09f5186a,"### Graphe de facteurs de l'exercice diagnostic
+
+
+Ce graphe montre le **modele DINA complet** pour l'evaluation de l'etudiant :
+
+| Question | Variables connectees | Observation |
+|----------|---------------------|-------------|
+| Q1, Q2 | C1 uniquement | true, true |
+| Q3, Q4 | C2 uniquement | false, true |
+| Q5 | C1 AND C2 | false |
+
+**Propagation des messages** :
+
+1. Q1=T et Q2=T → **forte evidence** pour C1 (deux confirmations)
+2. Q3=F et Q4=T → **evidence ambigue** pour C2 (une erreur, une reussite)
+3. Q5=F avec C1 probable → **evidence contre C2** (explaining away)
+
+Le graphe visualise pourquoi P(C1)=0.96 >> P(C2)=0.09 : les messages provenant de Q5 ""expliquent"" l'echec par l'absence de C2 plutot que de C1.",,,,,,,,8a099add09f5186a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,qrvzgbgjpk,code,fr,3dd6ab79839f2ba6,"// Visualisation du graphe de facteurs de l'exercice
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,3dd6ab79839f2ba6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,p8ydm8z0cti,markdown,fr,a62611d5336e05d8,"### Exemple guide supplementaire : Conception d'un test diagnostic
+
+Imaginez que vous devez concevoir un test pour evaluer 3 competences en programmation :
+- **C1** : Syntaxe de base (variables, boucles)
+- **C2** : Structures de donnees (tableaux, listes)
+- **C3** : Algorithmes (tri, recherche)
+
+**Questions** :
+
+1. Combien de questions minimum faut-il pour diagnostiquer chaque competence de maniere fiable ?
+
+2. Proposez une matrice Q pour 6 questions qui permette de distinguer les 8 profils possibles d'etudiants (2^3 combinaisons de competences).
+
+3. Si un etudiant echoue uniquement sur les questions necessitant C3, quelle remediation proposeriez-vous ?
+
+> **Indice** : Pour distinguer tous les profils, il faut au moins une question testant chaque competence isolement (Q1-C1, Q2-C2, Q3-C3) et des questions composites pour valider les interactions.",,,,,,,,a62611d5336e05d8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,f670c385,markdown,fr,03ace20b74d512a3,"## 9. Resume
+
+| Concept | Description |
+|---------|-------------|
+| **IRT** | Modele capacite-difficulte pour tests unidimensionnels |
+| **DINA** | Modele a competences discretes multiples |
+| **Matrice Q** | Definition des competences requises par question |
+| **Slip** | Erreur d'inattention (correct -> incorrect) |
+| **Guess** | Reponse au hasard (incorrect -> correct) |
+| **Many-to-many** | Questions multiples, competences multiples |
+
+---
+
+## Prochaine etape
+
+Dans [Infer-6-Debugging](Infer-6-Debugging.ipynb), nous explorerons :
+
+- Le diagnostic des problemes de convergence
+- La comparaison des algorithmes (EP, VMP, Gibbs)
+- Les outils de debug d'Infer.NET
+- Les bonnes pratiques de modelisation",,,,,,,,03ace20b74d512a3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,h7zoj7d20kv,markdown,fr,c2511fbafd5303f0,"### Points cles a retenir
+
+1. **IRT** : Ideal pour les tests standardises avec une dimension principale (intelligence, aptitude verbale)
+
+2. **DINA** : Plus adapte au diagnostic pedagogique car il identifie les competences specifiques manquantes
+
+3. **Slip et Guess** : Ces parametres de bruit sont difficiles a estimer sans priors informatifs ou donnees abondantes
+
+4. **Matrice Q** : La conception du test (quelles competences pour chaque question) est cruciale pour le diagnostic
+
+5. **Inference bayesienne** : Permet de quantifier l'incertitude sur les estimations et d'integrer les connaissances prealables
+
+> **Perspective** : Ces modeles sont utilises en production par des plateformes educatives (Duolingo, Khan Academy) pour personnaliser les parcours d'apprentissage.",,,,,,,,c2511fbafd5303f0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,37ww41xdon2,code,fr,55d66a7f03f14ed1,"// Nettoyage des fichiers generes (optionnel)
+int cleaned = FactorGraphHelper.CleanupGeneratedFiles();
+Console.WriteLine($""Fichiers .gv et .svg nettoyes : {cleaned}"");",,,,,,,,55d66a7f03f14ed1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,d6c96c7e,markdown,fr,ecfc1aa1981e7ed6,"## 10. Exercice : Comparer Deux Classes
+
+### Enonce
+
+Comparez les competences entre deux classes d'etudiants (classe A et classe B) sur le meme test de 5 questions.
+- Q1, Q2, Q4 testent la competence C1 ; Q3, Q5 testent C2 ; Q4 teste les deux
+
+**Reponses classe A** : `{true, true, false, true, false}`
+**Reponses classe B** : `{false, false, true, false, true}`
+
+1. Estimez P(maitrise C1) et P(maitrise C2) pour chaque classe
+2. Quelle classe est plus forte en C1 ? En C2 ?
+
+**Indice** : Appliquez le modele DINA deux fois (une fois par classe) avec les memes a priori.",,,,,,,,ecfc1aa1981e7ed6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,fe2a415e,code,fr,a97997a90419b3d0,"// Exercice : Comparaison de competences entre deux classes
+bool[] reponsesA = { true, true, false, true, false };
+bool[] reponsesB = { false, false, true, false, true };
+
+// Structure du test : Q1-C1, Q2-C1, Q3-C2, Q4-C1+C2, Q5-C2
+// Slip rate (P(reponse fausse si maitrise) = 0.1
+// Guess rate (P(reponse correcte si non-maitrise) = 0.25
+
+// TODO: Pour CHAQUE classe, definir les variables de competences C1 et C2
+
+// --- Classe A ---
+
+// TODO: Modeliser les reponses aux 5 questions pour la classe A
+// Q1 (teste C1 seulement) : P(Q1=T | c1A) = 1-slip = 0.9, P(Q1=T | !c1A) = guess = 0.25
+
+// TODO: Observer les reponses de la classe A et inferer les competences
+
+// --- Classe B (meme structure, reponses differentes) ---
+
+// TODO: Comparer et interpreter
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,a97997a90419b3d0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,44d03a9a,markdown,fr,c0f8c281315ae9be,"## 11. Exercice : Concevoir un Test Diagnostic Optimal
+
+### Enonce
+
+Vous devez concevoir un **test diagnostic** pour evaluer 4 competences en programmation Python :
+
+- **C1** : Variables et types
+- **C2** : Boucles et iterations
+- **C3** : Fonctions et portee
+- **C4** : Structures de donnees (listes, dictionnaires)
+
+**Objectif** : Proposez une matrice Q (questions x competences) et un ensemble de questions qui permette de diagnostiquer efficacement chaque profil d'etudiant.
+
+### Taches
+
+1. **Conception** : Proposez une matrice Q pour 6-8 questions. Justifiez vos choix (pourquoi cette combinaison de competences par question ?).
+2. **Simulation** : Simulez les reponses de 5 etudiants avec des profils differents (ex: un bon en tout, un faible en boucles, un expert fonctions mais debutant structures).
+3. **Inference** : Utilisez le modele DINA pour inferer les competences de chaque etudiant et verifier que le diagnostic est coherent.
+
+**Indice**
+
+- Chaque competence doit etre testee par **au moins 2 questions** (une seule et une composite)
+- Les questions composites sont plus discriminantes mais augmentent l'ambiguite
+- Verifiez que votre matrice Q permet de distinguer les profils (ex: l'etudiant qui a C1+C2 mais pas C3+C4)
+
+### Etapes suggerees
+
+1. Definir la matrice Q et les questions
+2. Choisir des valeurs realistes pour slip (0.1) et guess (0.15)
+3. Simuler les reponses pour 5 profils differents
+4. Construire le modele DINA et inferer les competences
+5. Comparer les diagnostics aux vrais profils",,,,,,,,c0f8c281315ae9be,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,d90576d0,code,fr,2c4a035481513d5e,"// Exercice : Concevoir un test diagnostic pour 4 competences Python
+
+// TODO: Definir la matrice Q (6-8 questions x 4 competences)
+// Indice : chaque competence doit etre testee par au moins 2 questions
+// bool[,] matriceQ = new bool[,] { ... };
+
+// TODO: Definir 5 profils d'etudiants avec des competences differentes
+// bool[,] profils = new bool[,] { ... };
+
+// TODO: Simuler les reponses avec slip=0.1, guess=0.15
+// bool[,] reponsesSimulees = ... ;
+
+// TODO: Construire le modele DINA pour chaque etudiant
+// et inferer les competences
+
+// TODO: Comparer les competences inferiees aux vrais profils
+// Afficher un tableau : Etudiant | Vrai profil | Profil inferre | Accord ?
+
+Console.WriteLine(""Exercice a completer : test diagnostic optimal"");",,,,,,,,2c4a035481513d5e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,b15384df,markdown,fr,76a6c3aca98cdf31,"### Exercice : Analyser la fiabilite discriminante des items
+
+Le modele IRT de la section 3 a estime les capacites de 10 etudiants et les difficultes de 5 questions. Cependant, toutes les questions n'apportent pas la meme quantite d'information. La **fonction d'information d'un item** mesure la precision avec laquelle une question distingue les etudiants selon leur capacite.
+
+**Objectif** : Calculez l'indice de discrimination de chaque question et identifiez laquelle est la plus (et la moins) informative pour le diagnostic.
+
+**Etapes** :
+1. Pour chaque question, calculez la correlation point-biserial entre la reponse observee et la capacite estimee des etudiants
+2. Calculez la fonction d'information I(theta) = discrimination^2 * P(correct) * (1 - P(correct)) pour chaque question a theta = capacite moyenne
+3. Affichez un classement des questions du plus informatif au moins informatif
+
+**Indices** :
+- La correlation point-biserial se calcule comme : r_pb = (M_correct - M_incorrect) / sigma * sqrt(p * q) ou M_correct = moyenne des capacites des etudiants ayant repondu correctement
+- La variable `capacitePost` (tableau de Gaussian) et `difficultePost` sont disponibles depuis la section 3
+- La discrimination a ete estimee dans le modele IRT : `moteurIRT.Infer<Gamma>(discrimination)`
+- Un item est bon discriminateur si |r_pb| > 0.3 ; il est faible si |r_pb| < 0.15",,,,,,,,76a6c3aca98cdf31,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,5b18e940,code,fr,2e88d74b5e94a3a5,"// Exercice : Analyser la fiabilite discriminante des items
+
+// TODO: Recuperer la discrimination estimee dans la section 3
+// var discriminationPost = moteurIRT.Infer<Gamma>(discrimination);
+// double discriminationMean = discriminationPost.GetMean();
+
+// TODO: Pour chaque question, calculer la correlation point-biserial
+// Etape 1 : Extraire les capacites moyennes des etudiants
+// double[] capacites = capacitePost.Select(c => c.GetMean()).ToArray();
+// Etape 2 : Calculer l'ecart-type global des capacites
+// Etape 3 : Pour chaque question j, separer les etudiants en deux groupes (correct/incorrect)
+//           et calculer r_pb = (M_correct - M_incorrect) / sigma * sqrt(p * q)
+
+// TODO: Calculer la fonction d'information I(theta) pour chaque question
+// a theta = moyenne des capacites
+// double thetaMoyen = capacites.Average();
+// Pour chaque question j : I(theta) = discrimination^2 * P(correct) * (1 - P(correct))
+
+// TODO: Afficher le classement des questions par informativite decroissante
+// Console.WriteLine(""Question | r_pb | I(theta) | Qualite"");
+// Indice: |r_pb| > 0.3 = bon, 0.15 < |r_pb| < 0.3 = acceptable, |r_pb| < 0.15 = faible
+
+var result = ""Exercice a completer"";
+Console.WriteLine(result);",,,,,,,,2e88d74b5e94a3a5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb,d866a5ed,markdown,fr,c657743bef9444f4,"## Conclusion
+
+Ce notebook a couvert les modeles d'evaluation cognitive : IRT (Item Response Theory) pour la capacite unidimensionnelle et DINA pour les competences discretes multiples.
+
+| Modele | Principe | Quand l'utiliser |
+|--------|----------|------------------|
+| IRT | Capacite continue - difficulte, fonction probit | Tests standardises, classement global |
+| DINA | Competences binaires + matrice Q, ET logique | Diagnostic pedagogique, remediation ciblee |
+
+| Concept | Point cle |
+|---------|-----------|
+| Slip | P(incorrect \| competence) : erreur d'inattention |
+| Guess | P(correct \| pas competence) : reponse au hasard |
+| Matrice Q | Definit quelles competences chaque question requiert |
+| Explaining away | Q5 incorrect + C1 probable => C2 improbable |
+
+| Distribution | Role |
+|--------------|------|
+| Gaussian | Capacites IRT et difficultes des questions |
+| Bernoulli | Competences binaires DINA et reponses observees |
+| Beta | Priors sur slip, guess et probabilites de competence |
+| ExpectationPropagation | Algorithme pour les facteurs de comparaison |
+
+> **Lecon pratique** : L'estimation simultanee de slip/guess et des competences est un probleme d'identifiabilite. Des priors informatifs (Beta concentres sur les valeurs attendues) sont indispensables pour obtenir des estimations fiables. Le DINA excelle pour le diagnostic individualise : il identifie les competences manquantes, permettant une remediation ciblee.",,,,,,,,c657743bef9444f4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,579661f9,markdown,fr,4347f64a3be3a686,"# Infer-8-TrueSkill : Systeme de Classement et Apprentissage en Ligne
+
+**Serie** : Programmation Probabiliste avec Infer.NET (8/20)  
+**Duree estimee** : 55 minutes  
+**Prerequis** : Infer-7-Skills-IRT
+
+---
+
+## Objectifs
+
+- Comprendre le systeme TrueSkill (Xbox Live)
+- Implementer des matchs 1v1 et la mise a jour des skills
+- Gerer les matchs nuls
+- Maitriser l'apprentissage en ligne (posterieurs -> priors)
+- Etendre aux equipes et multi-joueurs
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-9-Classification](Infer-9-Classification.ipynb) | [Infer-11-Topic-Models](Infer-11-Topic-Models.ipynb) |
+
+---",,,,,,,,4347f64a3be3a686,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,47689868,markdown,fr,88a3f70ef91b4a16,"## 1. Configuration
+
+Nous chargeons Infer.NET pour implementer le systeme TrueSkill, developpe par Microsoft Research pour Xbox Live. Ce systeme de classement bayesien estime les competences des joueurs a partir des resultats de matchs, tout en quantifiant l'incertitude sur ces estimations.",,,,,,,,88a3f70ef91b4a16,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,7515ffba,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,9ed34a0f,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,0lw5pp1r99q,code,fr,0dd3e6b8d2575143,"// Chargement du helper pour visualiser les graphes de facteurs
+#load ""FactorGraphHelper.cs""
+
+Console.WriteLine(""FactorGraphHelper charge. Graphviz disponible : "" + FactorGraphHelper.IsGraphvizAvailable());",,,,,,,,0dd3e6b8d2575143,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,0eaylal4428b,markdown,fr,2a85cde1b319c2ee,"### Environnement pret
+
+Infer.NET est maintenant charge avec tous les namespaces necessaires pour la programmation probabiliste. Les principaux composants utilises dans ce notebook :
+
+| Namespace | Usage |
+|-----------|-------|
+| `Microsoft.ML.Probabilistic.Distributions` | Gaussiennes pour modeliser les skills |
+| `Microsoft.ML.Probabilistic.Models` | Variables et contraintes du modele |
+| `Microsoft.ML.Probabilistic.Algorithms` | Expectation Propagation (EP) |
+
+> **Note technique** : TrueSkill utilise l'algorithme **Expectation Propagation** car les facteurs de comparaison (perf1 > perf2) ne sont pas conjugues avec les Gaussiennes. EP approxime ces facteurs par des Gaussiennes, permettant une inference efficace.",,,,,,,,2a85cde1b319c2ee,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,875a6a70,markdown,fr,b2a0da9371d9c120,"## 2. Introduction a TrueSkill
+
+### Contexte
+
+**TrueSkill** est le systeme de classement developpe par Microsoft Research pour Xbox Live. Il est une generalisation bayesienne du systeme Elo.
+
+### Principe
+
+Chaque joueur a un **skill** (competence) modelise par une distribution Gaussienne :
+- **Moyenne (mu)** : estimation du skill
+- **Variance (sigma^2)** : incertitude sur cette estimation
+
+### Formulation
+
+$$\text{skill}_i \sim \mathcal{N}(\mu_i, \sigma_i^2)$$
+
+$$\text{performance}_i = \text{skill}_i + \epsilon_i, \quad \epsilon_i \sim \mathcal{N}(0, \beta^2)$$
+
+$$\text{Joueur 1 gagne si} \quad \text{performance}_1 > \text{performance}_2$$
+
+### Parametres par defaut
+
+| Parametre | Valeur | Description |
+|-----------|--------|-------------|
+| mu_initial | 25 | Skill initial |
+| sigma_initial | 25/3 | Incertitude initiale |
+| beta | sigma/2 | Ecart-type de la performance |",,,,,,,,b2a0da9371d9c120,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,k5j8rq5fmar,markdown,fr,17c1aeccf12810d2,"### Comparaison TrueSkill vs Elo
+
+| Aspect | Elo | TrueSkill |
+|--------|-----|-----------|
+| **Representation** | Score unique (ex: 1800) | Distribution N(mu, sigma) |
+| **Incertitude** | Non modelisee | Capturee par sigma |
+| **Convergence** | Lente (K fixe) | Rapide (adaptatif via sigma) |
+| **Matchs nuls** | +/- points fixes | Reduction d'incertitude |
+| **Equipes** | Moyenne des Elo | Somme des performances |
+| **Multi-joueurs** | Decomposition en paires | Natif via contraintes d'ordre |
+
+> **Note historique** : TrueSkill a ete developpe en 2006 par Ralf Herbrich et Thore Graepel chez Microsoft Research. Il est utilise sur Xbox Live depuis 2007 pour le matchmaking de millions de joueurs.",,,,,,,,17c1aeccf12810d2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,l30e2s5e4oj,markdown,fr,d9d67cdb7e056b62,"## 3. Modele Deux Joueurs
+
+### Construction du modele etape par etape
+
+Le code suivant construit le modele TrueSkill en quatre phases :
+
+1. **Parametres** : Definition des hyperparametres (mu=25, sigma=8.33, beta=4.17)
+2. **Priors** : Chaque joueur commence avec la meme distribution Gaussienne
+3. **Performances** : Ajout de bruit pour modeliser la variabilite d'un match
+4. **Observation** : Le resultat du match (qui a gagne) est observe
+
+Cette structure separe clairement les **croyances initiales** (priors) des **donnees observees** (resultat du match).",,,,,,,,d9d67cdb7e056b62,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,c7d9f1c4,code,fr,9000bd4f8917d4c8,"// Parametres TrueSkill
+double muInitial = 25.0;
+double sigmaInitial = 25.0 / 3.0;
+double beta = sigmaInitial / 2.0;  // Variabilite de la performance
+
+// Skills des joueurs (priors)
+Variable<double> skill1 = Variable.GaussianFromMeanAndVariance(muInitial, sigmaInitial * sigmaInitial).Named(""skill1"");
+Variable<double> skill2 = Variable.GaussianFromMeanAndVariance(muInitial, sigmaInitial * sigmaInitial).Named(""skill2"");
+
+// Performances (skill + bruit)
+Variable<double> perf1 = Variable.GaussianFromMeanAndVariance(skill1, beta * beta).Named(""perf1"");
+Variable<double> perf2 = Variable.GaussianFromMeanAndVariance(skill2, beta * beta).Named(""perf2"");
+
+// Resultat du match : Joueur 1 gagne
+Variable<bool> joueur1Gagne = (perf1 > perf2).Named(""joueur1Gagne"");
+
+// Observation : Joueur 1 a effectivement gagne
+joueur1Gagne.ObservedValue = true;
+
+Console.WriteLine(""Modele TrueSkill deux joueurs defini."");",,,,,,,,9000bd4f8917d4c8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,alzcv9uqham,markdown,fr,12e09974425de123,"### Structure du modele graphique
+
+Le modele TrueSkill peut etre represente comme un graphe de facteurs :
+
+```
+skill1 ~ N(25, 8.33^2)     skill2 ~ N(25, 8.33^2)
+    |                           |
+    v                           v
+  perf1 = skill1 + eps       perf2 = skill2 + eps
+    |                           |
+    +-----------> > <-----------+
+                  |
+                  v
+           joueur1Gagne = true (observe)
+```
+
+**Intuition** : L'observation que ""joueur 1 gagne"" impose la contrainte perf1 > perf2. L'inference propage cette information vers les skills, augmentant skill1 et diminuant skill2.",,,,,,,,12e09974425de123,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,y6gz61p58sh,markdown,fr,73b54f808276a0b2,"### Execution de l'inference
+
+Nous allons maintenant executer l'inference pour calculer les posterieurs des skills apres avoir observe que le joueur 1 a gagne. L'algorithme EP va propager l'information du resultat vers les distributions de skill.",,,,,,,,73b54f808276a0b2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,29fcf4eb,code,fr,be7ebb2b43f8be5f,"// Inference apres le match
+InferenceEngine moteur = new InferenceEngine(new ExpectationPropagation());
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Gaussian skill1Post = moteur.Infer<Gaussian>(skill1);
+Gaussian skill2Post = moteur.Infer<Gaussian>(skill2);
+
+Console.WriteLine(""=== Apres un match (Joueur 1 gagne) ==="");
+Console.WriteLine($""\nAvant le match :"");
+Console.WriteLine($""  Skill1 = N({muInitial:F1}, {sigmaInitial:F2})"");
+Console.WriteLine($""  Skill2 = N({muInitial:F1}, {sigmaInitial:F2})"");
+
+Console.WriteLine($""\nApres le match :"");
+Console.WriteLine($""  Skill1 = N({skill1Post.GetMean():F2}, {Math.Sqrt(skill1Post.GetVariance()):F2})"");
+Console.WriteLine($""  Skill2 = N({skill2Post.GetMean():F2}, {Math.Sqrt(skill2Post.GetVariance()):F2})"");
+
+Console.WriteLine($""\nChangement de skill :"");
+Console.WriteLine($""  Joueur 1 : +{skill1Post.GetMean() - muInitial:F2}"");
+Console.WriteLine($""  Joueur 2 : {skill2Post.GetMean() - muInitial:F2}"");",,,,,,,,be7ebb2b43f8be5f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,07c124d3,markdown,fr,4f97ac2e2d5442d5,"### Analyse détaillée du résultat
+
+**Avant le match** : Les deux joueurs sont identiques N(25, 8.33)
+**Après le match** : Skill1 = N(29.21, 7.19), Skill2 = N(20.79, 7.19)
+
+**Observations clés** :
+
+| Aspect | Valeur | Explication |
+|--------|--------|-------------|
+| Gain du gagnant | +4.21 | Augmentation significative |
+| Perte du perdant | -4.21 | Symétrique (priors identiques) |
+| Réduction sigma | 8.33 → 7.19 | Plus d'info = moins d'incertitude |
+
+**Intuition** : Un match entre deux joueurs de même niveau (selon les priors) est **informatif**. Le gagnant a démontré qu'il est probablement meilleur.
+
+> **Comparaison avec Elo** : Contrairement au système Elo classique qui utilise des changements fixes (±16 points), TrueSkill adapte le changement en fonction de l'**incertitude**. Un joueur avec grand sigma (nouveau) verra son rating changer plus rapidement.",,,,,,,,4f97ac2e2d5442d5,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,3rl8qj8klra,code,fr,a24087868f063cb3,"// Visualisation du graphe de facteurs TrueSkill
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,a24087868f063cb3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,lay2atdwimg,markdown,fr,cf564a363d87b4ba,"### Lecture du graphe de facteurs TrueSkill 1v1
+
+Le graphe ci-dessus montre la structure du modele TrueSkill pour un match a deux joueurs :
+
+**Noeuds de variables (ellipses)** :
+- `skill1`, `skill2` : Les competences latentes des joueurs (Gaussiennes)
+- `perf1`, `perf2` : Les performances observees pendant le match
+- `joueur1Gagne` : Le resultat du match (observe = true)
+
+**Noeuds de facteurs (rectangles)** :
+- `GaussianFromMeanAndVariance` : Lie les priors aux skills et les skills aux performances
+- `IsGreaterThan` (ou `>`) : La contrainte de comparaison entre performances
+
+**Flux d'information** :
+L'algorithme Expectation Propagation (EP) propage des messages le long de ce graphe :
+1. L'observation `joueur1Gagne = true` envoie un message vers le facteur de comparaison
+2. Ce facteur propage l'information vers `perf1` (augmente) et `perf2` (diminue)
+3. Les changements de performance se propagent vers les skills correspondants
+
+> **Note technique** : Le facteur `IsGreaterThan` n'est pas conjugue avec les Gaussiennes. EP l'approxime par des moments de Gaussienne, ce qui explique pourquoi TrueSkill utilise EP plutot que VMP.",,,,,,,,cf564a363d87b4ba,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,ca5ef684,markdown,fr,f30adad4df073dee,"## 4. Gestion des Matchs Nuls
+
+### Modele
+
+Un match nul se produit quand la difference de performances est dans un intervalle $[-\epsilon, \epsilon]$.
+
+$$|\text{perf}_1 - \text{perf}_2| < \epsilon \Rightarrow \text{match nul}$$",,,,,,,,f30adad4df073dee,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,wyc487e9t6q,markdown,fr,4e150e0da6a53710,"### Implementation avec Variable.ConstrainBetween
+
+Pour modeliser un match nul, nous utilisons `Variable.ConstrainBetween` qui impose que la difference de performances soit dans un intervalle. Cela remplace la contrainte binaire "">"" par une contrainte d'intervalle.",,,,,,,,4e150e0da6a53710,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,dacf95f7,code,fr,9d38bb451dcf798f,"// Modele avec possibilite de match nul
+
+double epsilon = 1.0;  // Marge pour match nul
+
+Variable<double> skillA = Variable.GaussianFromMeanAndVariance(muInitial, sigmaInitial * sigmaInitial).Named(""skillA"");
+Variable<double> skillB = Variable.GaussianFromMeanAndVariance(muInitial, sigmaInitial * sigmaInitial).Named(""skillB"");
+
+Variable<double> perfA = Variable.GaussianFromMeanAndVariance(skillA, beta * beta).Named(""perfA"");
+Variable<double> perfB = Variable.GaussianFromMeanAndVariance(skillB, beta * beta).Named(""perfB"");
+
+// Difference de performances
+Variable<double> diff = (perfA - perfB).Named(""diff"");
+
+// Match nul : diff dans [-epsilon, epsilon]
+Variable.ConstrainBetween(diff, -epsilon, epsilon);
+
+InferenceEngine moteurNul = new InferenceEngine(new ExpectationPropagation());
+moteurNul.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurNul.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Gaussian skillAPostNul = moteurNul.Infer<Gaussian>(skillA);
+Gaussian skillBPostNul = moteurNul.Infer<Gaussian>(skillB);
+
+Console.WriteLine(""=== Apres un match nul ==="");
+Console.WriteLine($""\nSkillA = N({skillAPostNul.GetMean():F2}, {Math.Sqrt(skillAPostNul.GetVariance()):F2})"");
+Console.WriteLine($""SkillB = N({skillBPostNul.GetMean():F2}, {Math.Sqrt(skillBPostNul.GetVariance()):F2})"");
+
+Console.WriteLine($""\n=> Les deux joueurs gardent le meme skill moyen"");
+Console.WriteLine($""   mais l'incertitude diminue (on sait qu'ils sont proches)"");",,,,,,,,9d38bb451dcf798f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,kuhmzxafjd,markdown,fr,47a3b0d56fdbff90,"### Analyse du match nul
+
+**Résultat** : Les deux joueurs gardent mu=25.00 mais sigma baisse de 8.33 à **6.46**
+
+**Interprétation** :
+
+Un match nul entre joueurs de même niveau prior ne change pas l'estimation moyenne, mais **réduit fortement l'incertitude** car :
+- On a observé qu'ils performent de manière similaire
+- C'est cohérent avec l'hypothèse qu'ils ont le même skill
+- Donc on est plus **confiant** dans cette estimation
+
+**Paradoxe apparent** : Un match ""sans résultat"" apporte quand même de l'information ! Il confirme que les skills sont proches.
+
+> **Application** : Dans les échecs, une nulle entre deux joueurs de ratings similaires ne change presque pas leurs ratings Elo. Mais avec TrueSkill, leur **incertitude** diminue, ce qui affectera les futurs matchs.",,,,,,,,47a3b0d56fdbff90,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,58ebbc5f,markdown,fr,d3e1bf223189b79e,"### Exercice : Impact du parametre beta sur la mise a jour des skills
+
+Le parametre `beta` controle la variance de la performance (bruit dans un match). Un beta faible signifie que le resultat du match reflete fidelement le skill, tandis qu'un beta eleve signifie beaucoup de variance (chance/peur de gagner).
+
+**Objectif** : Comparez la mise a jour des skills pour un meme match (joueur 1 gagne) avec trois valeurs de beta : 2.0 (faible), 4.17 (defaut), et 8.0 (eleve).
+
+**Etapes** :
+1. Pour chaque valeur de beta, creez le modele TrueSkill 1v1 avec les priors par defaut (mu=25, sigma=8.33)
+2. Observez que joueur 1 gagne
+3. Calculez les posterieurs des deux joueurs
+4. Affichez un tableau comparatif des changements de skill pour chaque beta
+
+**Indices** :
+- Un beta faible => le match est tres informatif => grand changement de skill
+- Un beta eleve => le match est peu informatif => petit changement de skill
+- Comparez aussi la reduction de sigma (incertitude) entre les trois cas",,,,,,,,d3e1bf223189b79e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,86a9f7a1,code,fr,6193543c7c2ad57f,"// Exercice : Impact du parametre beta sur la mise a jour des skills
+double muInit = 25.0;
+double sigmaInit = 25.0 / 3.0;
+
+// TODO: Definir les trois valeurs de beta a tester
+// Indice: double[] betas = { 2.0, 4.17, 8.0 };
+
+// TODO: Boucler sur chaque beta et creer le modele TrueSkill 1v1
+// Indice: Pour chaque beta, Variable<double> skill1 = Variable.GaussianFromMeanAndVariance(muInit, sigmaInit^2);
+// Variable<double> perf1 = Variable.GaussianFromMeanAndVariance(skill1, beta^2);
+// Meme chose pour skill2/perf2, puis Variable<bool> win = (perf1 > perf2); win.ObservedValue = true;
+
+// TODO: Inferer les posterieurs et afficher le tableau comparatif
+// Console.WriteLine($""| beta={b:F2} | skill1={s1.GetMean():F2} | sigma={Math.Sqrt(s1.GetVariance()):F2} | delta={s1.GetMean()-muInit:F2} |"");
+Console.WriteLine(""Exercice a completer : Impact du parametre beta"");",,,,,,,,6193543c7c2ad57f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,v2q81j2cud,code,fr,5d156597bf5259c2,"// Visualisation du graphe de facteurs pour le match nul
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,5d156597bf5259c2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,uyluong4se,markdown,fr,4cac3b144313473a,"### Lecture du graphe de facteurs - Match nul
+
+Ce graphe differe du modele 1v1 par le facteur de contrainte :
+
+**Difference structurelle** :
+- `diff` : Variable intermediaire representant `perfA - perfB`
+- `ConstrainBetween` : Facteur imposant que `diff` soit dans l'intervalle `[-epsilon, epsilon]`
+
+**Comparaison avec le modele 1v1** :
+
+| Aspect | Match 1v1 | Match nul |
+|--------|-----------|-----------|
+| Facteur de resultat | `IsGreaterThan` | `ConstrainBetween` |
+| Information | Ordre strict | Proximite |
+| Effet sur mu | Augmente/diminue | Inchange |
+| Effet sur sigma | Reduit | Reduit davantage |
+
+Le facteur `ConstrainBetween` est plus informatif car il impose une double contrainte (borne inf et sup), ce qui explique la reduction plus importante de l'incertitude.",,,,,,,,4cac3b144313473a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,db748a66,markdown,fr,d1935b1cf8ba7536,"## 5. Apprentissage en Ligne
+
+### Principe
+
+Apres chaque match, les **posterieurs** deviennent les **priors** pour le match suivant.
+
+```
+Match 1 : Prior -> Inference -> Posterieur
+                                    |
+                                    v
+Match 2 : Prior (= Posterieur 1) -> Inference -> Posterieur
+                                                     |
+                                                     v
+Match 3 : ...
+```",,,,,,,,d1935b1cf8ba7536,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,dekbpy6finu,markdown,fr,6c0a1c6f2166e8d3,"### Implementation de la classe TrueSkillOnline
+
+La classe suivante encapsule la logique d'apprentissage en ligne :
+
+- **Dictionary skills** : Stocke le posterieur actuel de chaque joueur
+- **GetSkill()** : Retourne le prior initial si le joueur est nouveau
+- **EnregistrerMatch()** : Met a jour les posterieurs apres un match
+- **AfficherClassement()** : Affiche le rating conservatif (mu - 3*sigma)
+
+Le **rating conservatif** mu - 3*sigma est la metrique publique utilisee par Xbox Live. Il represente une borne inferieure a 99.7% de confiance sur le vrai skill.",,,,,,,,6c0a1c6f2166e8d3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,e3b217a2,code,fr,b80a91cc8dae1d0c,"// Classe pour gerer l'apprentissage en ligne
+
+public class TrueSkillOnline
+{
+    private double muInit;
+    private double sigmaInit;
+    private double beta;
+    private InferenceEngine moteur;
+    
+    // Skills actuels des joueurs
+    private Dictionary<string, Gaussian> skills;
+    
+    public TrueSkillOnline(double muInit = 25, double sigmaInit = 8.33, double beta = 4.17)
+    {
+        this.muInit = muInit;
+        this.sigmaInit = sigmaInit;
+        this.beta = beta;
+        this.skills = new Dictionary<string, Gaussian>();
+        this.moteur = new InferenceEngine(new ExpectationPropagation());
+        this.moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    }
+    
+    public Gaussian GetSkill(string joueur)
+    {
+        if (!skills.ContainsKey(joueur))
+        {
+            skills[joueur] = Gaussian.FromMeanAndVariance(muInit, sigmaInit * sigmaInit);
+        }
+        return skills[joueur];
+    }
+    
+    public void EnregistrerMatch(string gagnant, string perdant)
+    {
+        // Priors actuels
+        Gaussian priorGagnant = GetSkill(gagnant);
+        Gaussian priorPerdant = GetSkill(perdant);
+        
+        // Modele
+        Variable<Gaussian> priorG = Variable.Observed(priorGagnant);
+        Variable<Gaussian> priorP = Variable.Observed(priorPerdant);
+        
+        Variable<double> skillG = Variable.Random<double, Gaussian>(priorG);
+        Variable<double> skillP = Variable.Random<double, Gaussian>(priorP);
+        
+        Variable<double> perfG = Variable.GaussianFromMeanAndVariance(skillG, beta * beta);
+        Variable<double> perfP = Variable.GaussianFromMeanAndVariance(skillP, beta * beta);
+        
+        Variable<bool> resultat = (perfG > perfP);
+        resultat.ObservedValue = true;  // Le gagnant a gagne
+        
+        // Inference
+        skills[gagnant] = moteur.Infer<Gaussian>(skillG);
+        skills[perdant] = moteur.Infer<Gaussian>(skillP);
+    }
+    
+    public void AfficherClassement()
+    {
+        var classement = skills.OrderByDescending(kv => kv.Value.GetMean());
+        Console.WriteLine(""\n=== Classement ==="");
+        int rang = 1;
+        foreach (var kv in classement)
+        {
+            double mu = kv.Value.GetMean();
+            double sigma = Math.Sqrt(kv.Value.GetVariance());
+            double conservatif = mu - 3 * sigma;  // TrueSkill rating
+            Console.WriteLine($""{rang}. {kv.Key,-10} : mu={mu:F1}, sigma={sigma:F2}, rating={conservatif:F1}"");
+            rang++;
+        }
+    }
+}
+
+Console.WriteLine(""Classe TrueSkillOnline definie."");",,,,,,,,b80a91cc8dae1d0c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,iijfn6pf7wg,markdown,fr,2d6d6ccb5580d9ca,"### Architecture de l'apprentissage en ligne
+
+La classe `TrueSkillOnline` implemente le pattern bayesien fondamental :
+
+**Cycle d'apprentissage** :
+
+$$P(\theta | D_{1:n}) \propto P(D_n | \theta) \cdot P(\theta | D_{1:n-1})$$
+
+En pratique :
+1. Le **posterieur** apres le match n-1 devient le **prior** pour le match n
+2. Chaque match apporte de l'information incrementale
+3. Le systeme ""n'oublie jamais"" mais l'influence des anciens matchs diminue naturellement
+
+> **Avantage computationnel** : Contrairement a un recalcul global, l'apprentissage en ligne a une complexite O(1) par match, permettant de gerer des millions de joueurs en temps reel.",,,,,,,,2d6d6ccb5580d9ca,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,d0v4jrvltr4,markdown,fr,a82448e270b3409a,"### Simulation d'un tournoi complet
+
+Nous simulons maintenant un petit tournoi de 6 matchs entre 4 joueurs. Observez comment les skills evoluent au fur et a mesure des matchs, et comment le classement emerge des resultats.",,,,,,,,a82448e270b3409a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,4a1b28b9,code,fr,2fbe6de52925389b,"// Simulation d'un tournoi
+
+var ts = new TrueSkillOnline();
+
+Console.WriteLine(""=== Tournoi TrueSkill ==="");
+
+// Serie de matchs
+var matchs = new (string, string)[] {
+    (""Alice"", ""Bob""),     // Alice bat Bob
+    (""Charlie"", ""Dave""),  // Charlie bat Dave
+    (""Alice"", ""Charlie""), // Alice bat Charlie
+    (""Bob"", ""Dave""),      // Bob bat Dave
+    (""Alice"", ""Dave""),    // Alice bat Dave
+    (""Charlie"", ""Bob"")    // Charlie bat Bob
+};
+
+foreach (var (gagnant, perdant) in matchs)
+{
+    Console.WriteLine($""Match : {gagnant} bat {perdant}"");
+    ts.EnregistrerMatch(gagnant, perdant);
+}
+
+ts.AfficherClassement();",,,,,,,,2fbe6de52925389b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,0225333b,markdown,fr,b991b2300804f7c7,"### Analyse du classement final
+
+**Classement obtenu** : Alice > Charlie > Bob > Dave
+
+| Joueur | V-D | Rating | Sigma |
+|--------|-----|--------|-------|
+| Alice | 3-0 | 15.2 | 6.01 |
+| Charlie | 2-1 | 11.6 | 5.58 |
+| Bob | 1-2 | 4.9 | 5.58 |
+| Dave | 0-3 | -1.3 | 6.01 |
+
+**Observations** :
+
+1. **Transitivité respectée** : Alice > Charlie (directement) et Charlie > Bob (directement) implique Alice > Bob
+2. **Rating conservatif** : mu - 3σ pénalise les joueurs avec peu de matchs (plus grande incertitude)
+3. **Sigma décroît** : Plus de matchs = moins d'incertitude sur le skill
+
+**Pourquoi utiliser mu - 3σ ?**
+- Évite de surclasser un joueur chanceux avec peu de matchs
+- Avec 3σ, on a ~99.7% de confiance que le vrai skill est supérieur
+- Xbox Live utilise cette métrique pour le matchmaking public",,,,,,,,b991b2300804f7c7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,5b01fcaf,markdown,fr,bd44ed0d22f384ba,"## 6. Extension aux Equipes
+
+### Modele
+
+Pour un match par equipes, la performance d'equipe est la somme des performances individuelles.",,,,,,,,bd44ed0d22f384ba,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,f581544x29m,markdown,fr,39019236bd87158f,"### Modelisation de la performance d'equipe
+
+Dans ce modele 2v2, la performance d'une equipe est la **somme** des performances individuelles. Ce choix de modelisation implique que :
+
+- Un bon joueur peut ""porter"" un coequipier plus faible
+- La variance de l'equipe augmente avec le nombre de joueurs
+- L'attribution du credit est uniforme entre coequipiers",,,,,,,,39019236bd87158f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,eff02501,code,fr,aaf4c13482adf430,"// Modele par equipes (2v2)
+
+// Equipe 1 : Joueurs A et B
+Variable<double> skillA2 = Variable.GaussianFromMeanAndVariance(25, 70).Named(""skillA2"");
+Variable<double> skillB2 = Variable.GaussianFromMeanAndVariance(25, 70).Named(""skillB2"");
+
+// Equipe 2 : Joueurs C et D
+Variable<double> skillC = Variable.GaussianFromMeanAndVariance(25, 70).Named(""skillC"");
+Variable<double> skillD = Variable.GaussianFromMeanAndVariance(25, 70).Named(""skillD"");
+
+// Performances individuelles
+Variable<double> perfA2 = Variable.GaussianFromMeanAndVariance(skillA2, 17).Named(""perfA2"");
+Variable<double> perfB2 = Variable.GaussianFromMeanAndVariance(skillB2, 17).Named(""perfB2"");
+Variable<double> perfC2 = Variable.GaussianFromMeanAndVariance(skillC, 17).Named(""perfC2"");
+Variable<double> perfD2 = Variable.GaussianFromMeanAndVariance(skillD, 17).Named(""perfD2"");
+
+// Performances d'equipe (somme)
+Variable<double> perfEquipe1 = (perfA2 + perfB2).Named(""perfEquipe1"");
+Variable<double> perfEquipe2 = (perfC2 + perfD2).Named(""perfEquipe2"");
+
+// Equipe 1 gagne
+Variable<bool> equipe1Gagne = (perfEquipe1 > perfEquipe2).Named(""equipe1Gagne"");
+equipe1Gagne.ObservedValue = true;
+
+InferenceEngine moteurEquipe = new InferenceEngine(new ExpectationPropagation());
+moteurEquipe.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurEquipe.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Console.WriteLine(""=== Match par equipes (2v2) ==="");
+Console.WriteLine(""Equipe 1 (A+B) bat Equipe 2 (C+D)\n"");
+
+Console.WriteLine($""Skill A apres : {moteurEquipe.Infer<Gaussian>(skillA2).GetMean():F2}"");
+Console.WriteLine($""Skill B apres : {moteurEquipe.Infer<Gaussian>(skillB2).GetMean():F2}"");
+Console.WriteLine($""Skill C apres : {moteurEquipe.Infer<Gaussian>(skillC).GetMean():F2}"");
+Console.WriteLine($""Skill D apres : {moteurEquipe.Infer<Gaussian>(skillD).GetMean():F2}"");
+
+Console.WriteLine(""\n=> Tous les membres de l'equipe gagnante voient leur skill augmenter"");",,,,,,,,aaf4c13482adf430,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,dyauxp8p19,markdown,fr,6ea1ccf1045c1713,"### Analyse du match par equipes
+
+**Resultats** :
+
+| Joueur | Equipe | Skill avant | Skill apres | Delta |
+|--------|--------|-------------|-------------|-------|
+| A | Gagnante | 25.00 | 27.99 | +2.99 |
+| B | Gagnante | 25.00 | 27.99 | +2.99 |
+| C | Perdante | 25.00 | 22.01 | -2.99 |
+| D | Perdante | 25.00 | 22.01 | -2.99 |
+
+**Observations cles** :
+
+1. **Attribution uniforme** : Chaque membre recoit le meme changement (priors identiques)
+2. **Gain plus faible qu'en 1v1** : +2.99 vs +4.21 car l'information est ""diluee"" entre coequipiers
+3. **Probleme de l'attribution** : Impossible de distinguer le ""carry"" du ""porte""
+
+> **Limitation** : TrueSkill basique attribue egalement le credit/blame. Des extensions comme TrueSkill 2 (2018) utilisent des statistiques individuelles (kills, assists) pour une attribution plus fine.",,,,,,,,6ea1ccf1045c1713,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,uelhc4hpera,code,fr,40005eb219771d2c,"// Visualisation du graphe de facteurs pour le match par equipes 2v2
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,40005eb219771d2c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,iwjryyopcp,markdown,fr,ba00feb189b24567,"### Lecture du graphe de facteurs - Match par equipes 2v2
+
+Le graphe 2v2 illustre l'extension du modele TrueSkill aux equipes :
+
+**Structure hierarchique** :
+
+```
+          skillA2   skillB2          skillC   skillD
+             |         |                |        |
+             v         v                v        v
+          perfA2   perfB2           perfC2   perfD2
+              \       /                  \      /
+               \     /                    \    /
+                v   v                      v  v
+             perfEquipe1              perfEquipe2
+                   \                      /
+                    \                    /
+                     v                  v
+                   equipe1Gagne (observe = true)
+```
+
+**Facteurs d'agregation** :
+- `Plus` (ou `+`) : Combine les performances individuelles en performance d'equipe
+- `IsGreaterThan` : Compare les performances d'equipe
+
+**Propagation de credit** :
+L'information ""equipe 1 gagne"" se propage :
+1. Vers `perfEquipe1` (augmente) et `perfEquipe2` (diminue)
+2. Via les facteurs `Plus`, vers chaque performance individuelle
+3. Puis vers chaque skill individuel
+
+> **Dilution du signal** : Avec 4 joueurs au lieu de 2, l'information est diluee. Chaque joueur recoit environ la moitie du changement de skill qu'il aurait eu en 1v1. C'est le ""probleme d'attribution de credit"" inherent aux jeux d'equipe.",,,,,,,,ba00feb189b24567,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,9c685107,markdown,fr,10dcbc4c8e820257,"## 7. Multi-joueurs (Free-for-all)
+
+### Modele
+
+Pour N joueurs, on decompose le resultat en N-1 comparaisons par paires :
+- 1er > 2e > 3e > ... > Ne",,,,,,,,10dcbc4c8e820257,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,wqqjqdtfsg8,markdown,fr,6e92a6b3f54c524f,"### Implementation avec contraintes d'ordre transitives
+
+Pour N joueurs classes du 1er au Neme, nous imposons N-1 contraintes transitives :
+- perf[0] > perf[1] (1er bat 2e)
+- perf[1] > perf[2] (2e bat 3e)
+- ...
+- perf[N-2] > perf[N-1] (avant-dernier bat dernier)
+
+Infer.NET resout ce systeme de contraintes simultanement grace a EP.",,,,,,,,6e92a6b3f54c524f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,ea6d7b0f,code,fr,27e88405b008c84a,"// Modele multi-joueurs (4 joueurs)
+// Resultat : P1 > P2 > P3 > P4
+
+Variable<double>[] skillsMulti = new Variable<double>[4];
+Variable<double>[] perfsMulti = new Variable<double>[4];
+
+for (int i = 0; i < 4; i++)
+{
+    skillsMulti[i] = Variable.GaussianFromMeanAndVariance(25, 70).Named($""skill_P{i+1}"");
+    perfsMulti[i] = Variable.GaussianFromMeanAndVariance(skillsMulti[i], 17).Named($""perf_P{i+1}"");
+}
+
+// Contraintes d'ordre : perf1 > perf2 > perf3 > perf4
+Variable.ConstrainTrue(perfsMulti[0] > perfsMulti[1]);
+Variable.ConstrainTrue(perfsMulti[1] > perfsMulti[2]);
+Variable.ConstrainTrue(perfsMulti[2] > perfsMulti[3]);
+
+InferenceEngine moteurMulti = new InferenceEngine(new ExpectationPropagation());
+moteurMulti.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurMulti.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Console.WriteLine(""=== Course multi-joueurs ==="");
+Console.WriteLine(""Classement : P1 > P2 > P3 > P4\n"");
+
+for (int i = 0; i < 4; i++)
+{
+    Gaussian post = moteurMulti.Infer<Gaussian>(skillsMulti[i]);
+    Console.WriteLine($""Joueur {i+1} (position {i+1}) : mu={post.GetMean():F2}, sigma={Math.Sqrt(post.GetVariance()):F2}"");
+}",,,,,,,,27e88405b008c84a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,shtyclc3of,markdown,fr,28e9efa5c0619ba8,"### Analyse du mode multi-joueurs
+
+**Resultats de la course** :
+
+| Position | Joueur | Skill mu | Sigma | Delta mu |
+|----------|--------|----------|-------|----------|
+| 1er | P1 | 32.73 | 6.42 | +7.73 |
+| 2e | P2 | 27.23 | 5.83 | +2.23 |
+| 3e | P3 | 22.77 | 5.83 | -2.23 |
+| 4e | P4 | 17.27 | 6.42 | -7.73 |
+
+**Structure mathematique** :
+
+Les contraintes transitives `P1 > P2 > P3 > P4` impliquent :
+- Le 1er et le dernier ont les changements les plus extremes
+- Les positions intermediaires ont des changements moderes
+- Sigma est plus eleve aux extremes (moins d'info directe)
+
+> **Application** : Ce modele est utilise pour les jeux Battle Royale (Fortnite, PUBG) ou les courses (Mario Kart). Le placement complet apporte plus d'information qu'une simple victoire/defaite.",,,,,,,,28e9efa5c0619ba8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,nvtk4uvma5d,code,fr,cc604e1e3029e651,"// Visualisation du graphe de facteurs pour le mode multi-joueurs
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,cc604e1e3029e651,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,e9ruk42t19,markdown,fr,312049ed4df05bf1,"### Lecture du graphe de facteurs - Multi-joueurs (Free-for-all)
+
+Le graphe multi-joueurs montre une structure en chaine de contraintes :
+
+**Topologie du graphe** :
+
+```
+skill_P1 -> perf_P1 -\
+                      >-- (P1 > P2)
+skill_P2 -> perf_P2 -/                \
+                      \                >-- P2 joue 2 roles
+skill_P2 -> perf_P2 ---\              /
+                        >-- (P2 > P3)
+skill_P3 -> perf_P3 ---/
+                        \
+                         >-- (P3 > P4)
+skill_P4 -> perf_P4 ----/
+```
+
+**Caracteristiques cles** :
+
+1. **Chaine de comparaisons** : N-1 facteurs `IsGreaterThan` pour N joueurs
+2. **Joueurs intermediaires** : P2 et P3 participent a deux comparaisons chacun
+3. **Correlation induite** : Les contraintes couplent les variables entre elles
+
+**Propagation EP iterative** :
+Le graphe montre pourquoi EP necessite des iterations :
+- L'info de P1>P2 affecte P2
+- L'info de P2>P3 affecte aussi P2
+- Ces deux sources d'info doivent etre reconciliees
+
+> **Complexite computationnelle** : Contrairement au cas 1v1 (solution analytique), le cas multi-joueurs necessite des iterations EP. C'est pourquoi on observe ""Iterating: ..."" dans la sortie. La complexite est O(N^2) par iteration pour N joueurs.",,,,,,,,312049ed4df05bf1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,6717b980,markdown,fr,150eda85cf0a03c4,## 8. Analyse d'Echecs (Elo Bayesien),,,,,,,,150eda85cf0a03c4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,w8v8gtwcdas,markdown,fr,142869f87a13257c,"### Application aux echecs
+
+Nous appliquons TrueSkill aux echecs avec des parametres adaptes a l'echelle Elo :
+
+| Parametre | Valeur TrueSkill standard | Valeur echecs |
+|-----------|---------------------------|---------------|
+| mu_initial | 25 | 1500 |
+| sigma_initial | 8.33 | 350 |
+| beta | 4.17 | 175 |
+
+L'echelle est simplement multipliee par 60 pour correspondre aux ratings Elo traditionnels.",,,,,,,,142869f87a13257c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,a38060a2,code,fr,1fc425c39ad8afcc,"// Simulation de parties d'echecs
+
+var chess = new TrueSkillOnline(muInit: 1500, sigmaInit: 350, beta: 175);
+
+// Donnees historiques simulees
+var partiesEchecs = new (string, string)[] {
+    (""Magnus"", ""Fabiano""),
+    (""Magnus"", ""Ian""),
+    (""Fabiano"", ""Ian""),
+    (""Magnus"", ""Fabiano""),
+    (""Magnus"", ""Ian""),
+    (""Ian"", ""Fabiano""),  // Upset!
+    (""Magnus"", ""Fabiano""),
+    (""Magnus"", ""Ian""),
+    (""Fabiano"", ""Ian""),
+    (""Magnus"", ""Ian"")
+};
+
+Console.WriteLine(""=== Classement Echecs (Elo Bayesien) ==="");
+Console.WriteLine(""\nParties :"");
+foreach (var (g, p) in partiesEchecs)
+{
+    Console.WriteLine($""  {g} bat {p}"");
+    chess.EnregistrerMatch(g, p);
+}
+
+chess.AfficherClassement();",,,,,,,,1fc425c39ad8afcc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,7kyutl6wy4p,markdown,fr,7b37858c7fd3aa3d,"### Analyse du classement echecs
+
+**Resultats** :
+
+| Joueur | Victoires | Defaites | Mu | Sigma | Rating |
+|--------|-----------|----------|-----|-------|--------|
+| Magnus | 7 | 0 | 1923.7 | 213.54 | 1283.1 |
+| Fabiano | 2 | 4 | 1344.7 | 183.39 | 794.6 |
+| Ian | 1 | 5 | 1217.4 | 182.68 | 669.4 |
+
+**Observations** :
+
+1. **Magnus domine** : 7-0 (7 victoires sur les 10 matchs) avec un gain de +423.7 points (1500 -> 1923.7)
+2. **L'upset compte** : Ian bat Fabiano (match 6), ce qui explique pourquoi Ian n'est pas beaucoup plus bas
+3. **Sigma decroit** : Plus de matchs = plus de certitude sur le niveau reel
+
+**Comparaison avec le vrai classement FIDE (2024)** :
+
+| Joueur | FIDE Elo | Notre estimation |
+|--------|----------|------------------|
+| Magnus Carlsen | ~2830 | 1923.7 |
+| Fabiano Caruana | ~2800 | 1344.7 |
+| Ian Nepomniachtchi | ~2790 | 1217.4 |
+
+> **Note** : Les vrais ecarts sont plus faibles (30-40 points), car notre simulation suppose que Magnus gagne toujours, ce qui est irrealiste au plus haut niveau.",,,,,,,,7b37858c7fd3aa3d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,07ec3e0a,markdown,fr,d3d00a152b14f63b,"## 9. Exemple guide : Simuler un Tournoi
+
+### Enonce
+
+Creez un tournoi avec 6 joueurs et simulez 15 matchs aleatoires.
+Comparez le classement final aux ""vrais skills"" que vous aurez definis.
+
+**Indice**
+
+- Definissez des skills ""vrais"" pour chaque joueur
+- Simulez le resultat de chaque match en fonction des skills
+- Utilisez TrueSkillOnline pour mettre a jour les estimations",,,,,,,,d3d00a152b14f63b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,a1rv4gbtby9,markdown,fr,c9228d8fd054edb7,"### Simulation avec ""vrais skills"" connus
+
+Cet exercice illustre un cas fondamental en statistique bayesienne : nous connaissons les vrais skills (simulation) et pouvons evaluer la qualite des estimations.
+
+**Protocole experimental** :
+1. Definir les vrais skills de 6 joueurs (inconnus du modele)
+2. Simuler 15 matchs ou le meilleur joueur gagne plus souvent
+3. Comparer les estimations TrueSkill aux vrais skills
+
+Notez que le joueur ne gagne pas toujours meme s'il est meilleur : on ajoute du bruit (+/- 5 points) pour simuler la variance de performance.",,,,,,,,c9228d8fd054edb7,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,bf0a55a2,code,fr,07e1b04c91798341,"// Exemple guide : Tournoi simule
+
+// Vrais skills (inconnus du systeme)
+var vraisSkills = new Dictionary<string, double>
+{
+    [""Elite1""] = 35,
+    [""Elite2""] = 32,
+    [""Moyen1""] = 25,
+    [""Moyen2""] = 24,
+    [""Debutant1""] = 18,
+    [""Debutant2""] = 15
+};
+
+var joueurs = vraisSkills.Keys.ToArray();
+var rng = new Random(42);
+var tournoi = new TrueSkillOnline();
+
+Console.WriteLine(""=== Tournoi Simule ==="");
+Console.WriteLine(""\nVrais skills :"");
+foreach (var kv in vraisSkills.OrderByDescending(x => x.Value))
+    Console.WriteLine($""  {kv.Key}: {kv.Value}"");
+
+Console.WriteLine(""\nMatchs :"");
+
+// 15 matchs aleatoires
+for (int m = 0; m < 15; m++)
+{
+    // Choisir deux joueurs differents
+    int i = rng.Next(joueurs.Length);
+    int j;
+    do { j = rng.Next(joueurs.Length); } while (j == i);
+    
+    string j1 = joueurs[i];
+    string j2 = joueurs[j];
+    
+    // Simuler le match (le meilleur gagne avec plus de probabilite)
+    double perf1 = vraisSkills[j1] + rng.NextDouble() * 10 - 5;  // +/- 5
+    double perf2 = vraisSkills[j2] + rng.NextDouble() * 10 - 5;
+    
+    string gagnant = perf1 > perf2 ? j1 : j2;
+    string perdant = perf1 > perf2 ? j2 : j1;
+    
+    Console.WriteLine($""  {gagnant} bat {perdant}"");
+    tournoi.EnregistrerMatch(gagnant, perdant);
+}
+
+tournoi.AfficherClassement();
+
+Console.WriteLine(""\n=> Comparez le classement estime aux vrais skills !"");",,,,,,,,07e1b04c91798341,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,7a0mf202mw6,markdown,fr,21b16343c60fe102,"### Analyse de la simulation
+
+**Comparaison vrais skills vs estimations** :
+
+| Joueur | Vrai skill | Skill estimé | Écart |
+|--------|------------|--------------|-------|
+| Elite1 | 35 | 34.3 | -0.7 ✓ |
+| Elite2 | 32 | 33.8 | +1.8 ✓ |
+| Moyen1 | 25 | 22.4 | -2.6 |
+| Moyen2 | 24 | 24.1 | +0.1 ✓ |
+| Debutant1 | 18 | 12.6 | -5.4 |
+| Debutant2 | 15 | - | (pas assez de matchs) |
+
+**Observations** :
+
+1. **Élites bien identifiés** : Le modèle distingue clairement le groupe ""élite""
+2. **Debutant1 sous-estimé** : A joué beaucoup mais toujours perdu (malchance statistique)
+3. **Debutant2 absent** : Sans matchs, reste au prior (invisible dans le classement)
+
+> **Leçon** : TrueSkill converge vers les vrais skills avec suffisamment de matchs, mais des séries malchanceuses peuvent biaiser temporairement les estimations. L'incertitude (sigma) capture ce risque.",,,,,,,,21b16343c60fe102,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,f0ae2a09,markdown,fr,d727ad072ae1af81,"## 10. Resume
+
+| Concept | Description |
+|---------|-------------|
+| **TrueSkill** | Systeme de classement bayesien |
+| **Skill** | Gaussienne N(mu, sigma^2) |
+| **Performance** | Skill + bruit gaussien |
+| **Match nul** | Difference de perf dans [-epsilon, epsilon] |
+| **Online learning** | Posterieurs -> Priors |
+| **Rating conservatif** | mu - 3*sigma |
+
+### Forces de TrueSkill
+
+- Quantification explicite de l'incertitude via sigma
+- Convergence rapide pour les nouveaux joueurs (sigma eleve = grands changements)
+- Gestion native des equipes et multi-joueurs
+- Apprentissage en ligne efficace (O(1) par match)
+
+### Limitations
+
+- Suppose une skill stable dans le temps (pas d'apprentissage du joueur)
+- Attribution uniforme dans les equipes
+- Sensible au choix des hyperparametres (beta, epsilon)
+
+### Extensions modernes
+
+- **TrueSkill 2** (2018) : Utilise les statistiques in-game pour attribution fine
+- **Glicko-2** : Alternative populaire avec ""volatilite"" (changement de skill)
+- **OpenSkill** : Implementation open-source compatible multi-plateformes
+
+> **Pour aller plus loin** : L'article original ""TrueSkill: A Bayesian Skill Rating System"" (Herbrich et al., 2006) detaille les approximations EP et les calculs de messages.
+
+---
+
+## Prochaine etape
+
+Dans [Infer-9-Classification](Infer-9-Classification.ipynb), nous explorerons :
+
+- La classification bayesienne
+- Le Bayes Point Machine
+- Les tests cliniques A/B bayesiens",,,,,,,,d727ad072ae1af81,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,f045094e,markdown,fr,4e756359e76ddea8,"## 11. Exercice : Ligue de Football : 4 Equipes
+
+### Enonce
+
+Modelisez une ligue de football a **4 equipes** avec TrueSkill. Resultats des matchs :
+
+- PSG bat Marseille (3-0)
+- Lyon bat Bordeaux (2-1)
+- Lyon bat PSG (2-1)
+- Lyon bat Marseille (1-0)
+
+1. Definissez une variable de skill gaussienne pour chaque equipe (a priori : Gaussian(100, 1/33))
+2. Encodez chaque resultat par le modele TrueSkill (performance = Gaussian(skill, 1/beta^2))
+3. Inferez les skills posterieurs et etablissez le classement des equipes
+
+**Indice** : Reutilisez la structure du modele TrueSkill de la section 3.",,,,,,,,4e756359e76ddea8,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,128c6231,code,fr,19cdf6b1308f4784,"// Exercice : Ligue de football avec TrueSkill - 4 equipes
+double priorMean = 100.0;
+double priorPrec = 1.0 / 33.333;
+double beta = 8.333;  // Variance de performance
+
+// TODO: Creer le moteur d'inference
+
+// TODO: Definir les variables de skill pour les 4 equipes
+
+// TODO: Pour chaque match, creer les variables de performance et observer que gagnant > perdant
+// Exemple pour PSG bat Marseille :
+
+// TODO: Inferer les skills posterieurs et afficher le classement
+// Qui est classe premier ?
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,19cdf6b1308f4784,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,7b6ab764,markdown,fr,c419e33b341548ca,"## 12. Exercice : Prediction de Match avec Incertitude
+
+### Enonce
+
+Vous disposez des **skills estimes** de 4 joueurs apres un tournoi. Votre objectif est de **predire le resultat** d'un match entre deux joueurs donnes, en retournant la **probabilite** que le joueur A gagne.
+
+**Donnees** : Skills posterieurs apres 10 matchs :
+- Alice : N(30, 5^2)
+- Bob : N(25, 4^2)
+- Charlie : N(22, 6^2)
+- Dave : N(20, 3^2)
+
+**Taches** :
+1. Implementez un modele qui predit la probabilite de victoire de Alice contre chaque autre joueur
+2. Quel match est le plus incertain (probabilite la plus proche de 0.5) ?
+3. Comment la probabilite change-t-elle si on double beta (variance de performance) ?
+
+**Indice**
+
+La probabilite que perf1 > perf2 se calcule en utilisant `Variable.IsPositive` sur la difference des performances. Observez la variable booleenne resultante avec `moteur.Infer<Bernoulli>(...)`.",,,,,,,,c419e33b341548ca,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,5a71f244,code,fr,2d7895b029d2b30b,"// Exercice : Prediction de victoire
+// Skills posterieurs des joueurs
+double muAlice = 30.0, sigmaAlice = 5.0;
+double muBob = 25.0, sigmaBob = 4.0;
+double muCharlie = 22.0, sigmaCharlie = 6.0;
+double muDave = 20.0, sigmaDave = 3.0;
+double beta = 4.17;  // Variabilite de performance
+
+// TODO: Creer un modele qui calcule P(Alice gagne contre Bob)
+// Etape 1: Definir les variables de skill (avec les posterieurs comme priors)
+// Etape 2: Ajouter les performances (skill + bruit)
+// Etape 3: Observer la contrainte perfAlice > perfBob
+// Etape 4: Inférer P(Alice gagne) avec moteur.Infer<Bernoulli>(resultat)
+
+// TODO: Repeter pour Alice vs Charlie et Alice vs Dave
+
+// TODO: Identifier le match le plus incertain (P le plus proche de 0.5)
+
+// TODO: Tester avec beta double (beta * 2). Laquelle des probabilites change le plus ?
+
+Console.WriteLine(""Exercice a completer : prediction de match"");",,,,,,,,2d7895b029d2b30b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,6a27ad43,markdown,fr,634dc9ef1e0e954e,"## 13. Exercice : Suivi de l'apprentissage en ligne - Convergence du classement
+
+### Enonce
+
+L'apprentissage en ligne (section 5) met a jour les skills apres chaque match en utilisant les posterieurs comme nouveaux priors. Votre objectif est de **tracer l'evolution** des estimations de skill au fil d'une serie de 8 matchs entre 3 joueurs, afin de visualiser comment le systeme converge.
+
+**Joueurs et vrais skills** (inconnus du modele) :
+- Zoe : skill = 30 (forte)
+- Leo : skill = 25 (moyen)
+- Max : skill = 20 (faible)
+
+**Serie de matchs** :
+1. Zoe bat Leo
+2. Zoe bat Max
+3. Leo bat Max
+4. Zoe bat Leo
+5. Leo bat Zoe (upset)
+6. Max bat Leo (upset)
+7. Zoe bat Max
+8. Leo bat Max
+
+**Taches** :
+1. Utilisez la classe `TrueSkillOnline` definie en section 5 pour enregistrer les 8 matchs
+2. Apres chaque match, enregistrez le mu et le sigma de chaque joueur dans des listes
+3. Affichez un tableau de l'evolution : pour chaque match, montrez le mu de chaque joueur
+4. *(Bonus)* : Apres le match 5 (upset Leo bat Zoe), comment evolue le sigma de Zoe par rapport a l'avant-match 5 ? L'upset augmente-t-il l'incertitude ?
+
+### Indices
+
+- Initialisez `TrueSkillOnline` avec les parametres par defaut
+- Apres chaque `EnregistrerMatch()`, appelez `GetSkill()` pour chaque joueur et stockez `GetMean()` et `Math.Sqrt(GetVariance())`
+- Observez comment sigma diminue au fil des matchs (convergence) et comment un upset peut modifier la tendance",,,,,,,,634dc9ef1e0e954e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,e8d6446a,code,fr,d43bfdabf31857a0,"// Exercice : Suivi de l'apprentissage en ligne - Convergence du classement
+
+string[] joueursOL = { ""Zoe"", ""Leo"", ""Max"" };
+var tsOL = new TrueSkillOnline();
+
+// Listes pour stocker l'evolution
+var historiqueMu = new Dictionary<string, List<double>>
+{
+    [""Zoe""] = new List<double>(),
+    [""Leo""] = new List<double>(),
+    [""Max""] = new List<double>()
+};
+var historiqueSigma = new Dictionary<string, List<double>>
+{
+    [""Zoe""] = new List<double>(),
+    [""Leo""] = new List<double>(),
+    [""Max""] = new List<double>()
+};
+
+// Serie de matchs
+var matchsOL = new (string gagnant, string perdant)[]
+{
+    (""Zoe"", ""Leo""),
+    (""Zoe"", ""Max""),
+    (""Leo"", ""Max""),
+    (""Zoe"", ""Leo""),
+    (""Leo"", ""Zoe""),  // Upset !
+    (""Max"", ""Leo""),  // Upset !
+    (""Zoe"", ""Max""),
+    (""Leo"", ""Max"")
+};
+
+// TODO 1 : Enregistrez chaque match et capturez les skills apres chaque match
+// Indice : foreach (var (g, p) in matchsOL)
+// {
+//     tsOL.EnregistrerMatch(g, p);
+//     foreach (var j in joueursOL)
+//     {
+//         var skill = tsOL.GetSkill(j);
+//         historiqueMu[j].Add(skill.GetMean());
+//         historiqueSigma[j].Add(Math.Sqrt(skill.GetVariance()));
+//     }
+// }
+
+// TODO 2 : Affichez le tableau d'evolution des mu
+// Indice : Console.WriteLine(""Match | Zoe mu | Leo mu | Max mu"");
+// for (int i = 0; i < matchsOL.Length; i++)
+//     Console.WriteLine($""{i+1} | {historiqueMu[""Zoe""][i]:F1} | {historiqueMu[""Leo""][i]:F1} | {historiqueMu[""Max""][i]:F1}"");
+
+// TODO 3 : Affichez le classement final
+// tsOL.AfficherClassement();
+
+// TODO 4 : (Bonus) Analysez l'effet de l'upset (match 5) sur le sigma de Zoe
+// Indice : comparez historiqueSigma[""Zoe""][3] (avant upset) et historiqueSigma[""Zoe""][4] (apres upset)
+// L'upset (Leo bat Zoe) est-il ""surprenant"" pour le modele ? Cela augmente-t-il sigma ?
+
+Console.WriteLine(""Exercice a completer : suivi apprentissage en ligne"");",,,,,,,,d43bfdabf31857a0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb,82286da1,markdown,fr,a5fe1dacde1fee3b,"## Conclusion
+
+Ce notebook a presente le systeme TrueSkill : classement bayesien par matchs 1v1, matchs nuls, apprentissage en ligne et extensions multi-joueurs/equipes.
+
+| Concept | Point cle |
+|---------|-----------|
+| Skill | Gaussienne N(mu, sigma^2) : estimation + incertitude |
+| Performance | Skill + bruit : variabilite d'un match donne |
+| Apprentissage en ligne | Posterieur(n-1) = Prior(n), complexite O(1) par match |
+| Match nul | ConstrainBetween(-eps, +eps) : reduit sigma sans changer mu |
+| Rating conservatif | mu - 3*sigma : borne inferieure a 99.7% de confiance |
+
+| Distribution | Role |
+|--------------|------|
+| Gaussian | Skills et performances des joueurs |
+| ExpectationPropagation | Algorithme pour les facteurs de comparaison non-conjugues |
+
+> **Apport TrueSkill** : Contrairement a Elo (score ponctuel), TrueSkill propage l'incertitude via sigma. Un nouveau joueur (sigma eleve) converge rapidement ; un joueur etabli (sigma faible) est stable. L'apprentissage en ligne permet de mettre a jour des millions de joueurs en temps reel sur Xbox Live.",,,,,,,,a5fe1dacde1fee3b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,7a615707,markdown,fr,7797ce6a16a95a59,"# Infer-9-Classification : Classification Bayesienne
+
+**Serie** : Programmation Probabiliste avec Infer.NET (7/20)  
+**Duree estimee** : 50 minutes  
+**Prerequis** : Infer-6-Debugging
+
+---
+
+## Objectifs
+
+- Implementer la regression logistique bayesienne
+- Comprendre le Bayes Point Machine (BPM)
+- Appliquer l'inference bayesienne aux tests cliniques (A/B testing)
+- Gerer l'incertitude dans les predictions
+
+---
+
+## Navigation
+
+| Precedent | Suivant |
+|-----------|--------|
+| [Infer-6-Debugging](Infer-6-Debugging.ipynb) | [Infer-8-TrueSkill](Infer-8-TrueSkill.ipynb) |
+
+---",,,,,,,,7797ce6a16a95a59,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,24ba6ecc,markdown,fr,7d17346d534b21b6,"## 1. Configuration
+
+Cette section prepare l'environnement pour les modeles de classification bayesienne. Contrairement aux classifieurs deterministes, l'approche bayesienne fournit non seulement une prediction mais aussi une mesure de confiance via des distributions de probabilite.",,,,,,,,7d17346d534b21b6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,d29b0d07,code,fr,fd31f5683405067d,"#r ""nuget: Microsoft.ML.Probabilistic""
+#r ""nuget: Microsoft.ML.Probabilistic.Compiler""
+
+using Microsoft.ML.Probabilistic;
+using Microsoft.ML.Probabilistic.Distributions;
+using Microsoft.ML.Probabilistic.Utilities;
+using Microsoft.ML.Probabilistic.Math;
+using Microsoft.ML.Probabilistic.Models;
+using Microsoft.ML.Probabilistic.Algorithms;
+using Microsoft.ML.Probabilistic.Compiler;
+
+Console.WriteLine(""Infer.NET pret !"");",,,,,,,,fd31f5683405067d,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,f5ed5bb7,markdown,fr,0d35df980368841a,Chargement du helper de visualisation des graphes de facteurs.,,,,,,,,0d35df980368841a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,zfnap2t2rq,code,fr,6b24173516389708,"// Chargement du helper pour visualiser les graphes de facteurs
+#load ""FactorGraphHelper.cs""
+
+// Verification de la disponibilite de Graphviz
+if (FactorGraphHelper.IsGraphvizAvailable())
+    Console.WriteLine(""Graphviz disponible - les graphes de facteurs seront affiches automatiquement."");
+else
+    Console.WriteLine(""Graphviz non installe - utilisez viz-js.com pour visualiser les fichiers .gv generes."");",,,,,,,,6b24173516389708,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,q8n6lx7eupr,markdown,fr,017dbcaa67a3b6fa,"### Environnement pret
+
+Les packages Infer.NET charges incluent :
+- **Microsoft.ML.Probabilistic** : Structures de donnees probabilistes (distributions, variables)
+- **Microsoft.ML.Probabilistic.Compiler** : Compilation des modeles en code executable
+- **Microsoft.ML.Probabilistic.Math** : Fonctions mathematiques (MMath.NormalCdf pour le probit)
+
+Les algorithmes d'inference disponibles pour la classification :
+| Algorithme | Usage | Precision |
+|------------|-------|-----------|
+| **ExpectationPropagation (EP)** | Modeles probit, BPM | Haute |
+| **VariationalMessagePassing (VMP)** | Modeles gaussiens mixtes | Moderee |
+| **GibbsSampling** | Modeles complexes | Tres haute (mais lent) |
+
+> **Note** : Pour la classification, EP est generalement prefere car il gere bien les facteurs de troncature (comparaisons avec seuils) inherents aux modeles probit.",,,,,,,,017dbcaa67a3b6fa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,7d75b1ca,markdown,fr,1bb044143fc463d0,"## 2. Classification Probabiliste
+
+### Difference avec la classification classique
+
+| Approche | Sortie | Incertitude |
+|----------|--------|-------------|
+| **Classique** | Classe predite | Non |
+| **Probabiliste** | P(classe) | Oui |
+| **Bayesienne** | Distribution sur P(classe) | Oui + incertitude sur le modele |
+
+### Avantages bayesiens
+
+- Quantification de l'incertitude
+- Regularisation naturelle (priors)
+- Mise a jour incrementale
+- Pas de surapprentissage si bon prior",,,,,,,,1bb044143fc463d0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,64b78841,markdown,fr,528e6f961b6b7afe,## 3. Regression Logistique Bayesienne (1 feature),,,,,,,,528e6f961b6b7afe,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,4jp4i20uv3y,markdown,fr,3e89916bed721a3b,"### Architecture du modele probit
+
+Le modele de regression logistique bayesienne utilise une variable latente gaussienne :
+
+$$y_i = \mathbb{1}[w \cdot x_i - b + \epsilon_i > 0]$$
+
+ou :
+- $w$ est le poids (prior Gaussien)
+- $b$ est le seuil (prior Gaussien)
+- $\epsilon_i \sim \mathcal{N}(0, 1/\tau)$ est le bruit (precision $\tau$ avec prior Gamma)
+
+**Structure du graphe de facteurs** :
+
+```
+poids ~ Gaussian(0, 10)     seuil ~ Gaussian(0, 10)     bruitPrecision ~ Gamma(2, 0.5)
+        \                         /                              /
+         \                       /                              /
+          [score = poids*x - seuil]                            /
+                    \                                         /
+                     \                                       /
+                      [scoreBruite ~ Gaussian(score, bruitPrecision)]
+                                      |
+                                      v
+                              [y = scoreBruite > 0]
+```
+
+Cette formulation permet d'utiliser l'Expectation Propagation pour inferer les posterieurs sur `poids` et `seuil`.",,,,,,,,3e89916bed721a3b,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,ec5c8e76,code,fr,ab9d33b98eda5897,"// Donnees : classification binaire avec 1 feature
+double[] features = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+bool[] labels = { false, false, false, true, false, true, true, true };
+int n = features.Length;
+
+// Modele : y = sigmoid(w * x - b)
+// Equivalent probit : y = I(w * x - b + noise > 0)
+
+Variable<double> poids = Variable.GaussianFromMeanAndVariance(0, 10).Named(""poids"");
+Variable<double> seuil = Variable.GaussianFromMeanAndVariance(0, 10).Named(""seuil"");
+Variable<double> bruitPrecision = Variable.GammaFromShapeAndScale(2, 0.5).Named(""bruit"");
+
+Range dataRange = new Range(n);
+VariableArray<double> xObs = Variable.Array<double>(dataRange).Named(""x"");
+VariableArray<bool> yObs = Variable.Array<bool>(dataRange).Named(""y"");
+
+using (Variable.ForEach(dataRange))
+{
+    Variable<double> score = poids * xObs[dataRange] - seuil;
+    Variable<double> scoreBruite = Variable.GaussianFromMeanAndPrecision(score, bruitPrecision);
+    yObs[dataRange] = (scoreBruite > 0);
+}
+
+xObs.ObservedValue = features;
+yObs.ObservedValue = labels;
+
+InferenceEngine moteur = new InferenceEngine(new ExpectationPropagation());
+moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteur.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Gaussian poidsPost = moteur.Infer<Gaussian>(poids);
+Gaussian seuilPost = moteur.Infer<Gaussian>(seuil);
+
+Console.WriteLine(""=== Regression Logistique Bayesienne ==="");
+Console.WriteLine($""\nPoids : {poidsPost}"");
+Console.WriteLine($""Seuil : {seuilPost}"");
+Console.WriteLine($""\nInterpretation : classe 1 si feature > {seuilPost.GetMean() / poidsPost.GetMean():F2}"");",,,,,,,,ab9d33b98eda5897,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,u8lbgb6u8ei,markdown,fr,5a32834b014a48ba,"### Analyse du modèle de régression logistique
+
+**Résultats** :
+- Poids ≈ 0.81 (positif → classe 1 augmente avec la feature)
+- Seuil ≈ 3.38
+- Point de décision : feature > 4.15 → classe 1
+
+**Interprétation géométrique** :
+Le modèle probit définit une frontière de décision à `x ≈ 4.15`. Les données montrent effectivement une transition entre les classes autour de x=4-5.
+
+**Incertitude sur les paramètres** :
+- σ(poids) ≈ 0.19 → relativement certain
+- σ(seuil) ≈ 0.87 → plus incertain
+
+> **Avantage bayésien** : Contrairement à la régression logistique classique qui donne des estimations ponctuelles, nous obtenons des **distributions complètes** sur les paramètres, permettant de propager l'incertitude aux prédictions.",,,,,,,,5a32834b014a48ba,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,ulzxxtv3lj,code,fr,3db4a6323e23f74e,"// Visualisation du graphe de facteurs de la regression logistique
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,3db4a6323e23f74e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,sn7d8ljyk2,markdown,fr,ac8221e06a9ea079,"### Lecture du graphe de facteurs - Regression Logistique
+
+Le graphe ci-dessus montre la structure du modele de classification probit :
+
+**Variables (ellipses)** :
+- `poids` : Coefficient lineaire appris (prior Gaussien)
+- `seuil` : Seuil de decision (prior Gaussien)  
+- `bruit` : Precision du bruit (prior Gamma)
+- `x`, `y` : Donnees observees (rectangles = observations)
+
+**Facteurs (rectangles noirs)** :
+- Facteurs gaussiens : encodent les priors et la vraisemblance
+- Facteur de comparaison (`> 0`) : lie le score bruite a l'etiquette binaire
+
+**Structure de plate** :
+La boucle `ForEach` cree une ""plate"" (repetition) sur les n echantillons. Chaque observation partage les memes parametres `poids` et `seuil`, ce qui permet l'apprentissage a partir de plusieurs exemples.
+
+> **Flux d'inference EP** : Les messages passent entre facteurs et variables jusqu'a convergence. Les posterieurs sur `poids` et `seuil` integrent l'information de toutes les observations.",,,,,,,,ac8221e06a9ea079,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,7c4008e7,markdown,fr,901d2fe57253c6b0,## 4. Prediction avec Incertitude,,,,,,,,901d2fe57253c6b0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,e198be0d,code,fr,756554f0114db725,"// Prediction pour de nouvelles valeurs
+double[] nouveauxX = { 2.5, 4.5, 6.5, 9.0 };
+
+Console.WriteLine(""=== Predictions avec incertitude ==="");
+Console.WriteLine();
+
+foreach (double x in nouveauxX)
+{
+    // Modele de prediction
+    Variable<Gaussian> poidsPrior = Variable.Observed(poidsPost);
+    Variable<Gaussian> seuilPrior = Variable.Observed(seuilPost);
+    
+    Variable<double> poidsPred = Variable.Random<double, Gaussian>(poidsPrior);
+    Variable<double> seuilPred = Variable.Random<double, Gaussian>(seuilPrior);
+    Variable<double> bruitPred = Variable.GammaFromShapeAndScale(2, 0.5);
+    
+    Variable<double> scorePred = poidsPred * x - seuilPred;
+    Variable<double> scoreBruitePred = Variable.GaussianFromMeanAndPrecision(scorePred, bruitPred);
+    Variable<bool> predLabel = (scoreBruitePred > 0);
+    
+    InferenceEngine moteurPred = new InferenceEngine(new ExpectationPropagation());
+    moteurPred.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    
+    Bernoulli prediction = moteurPred.Infer<Bernoulli>(predLabel);
+    Console.WriteLine($""x = {x:F1} : P(classe=1) = {prediction.GetProbTrue():F3}"");
+}",,,,,,,,756554f0114db725,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,6za36pa8yso,markdown,fr,4dea526578254046,"### Interpretation des predictions probabilistes
+
+| Feature (x) | P(classe=1) | Interpretation |
+|-------------|-------------|----------------|
+| 2.5 | 0.218 | Tres probablement classe 0 |
+| 4.5 | 0.561 | Zone d'incertitude (proche de 0.5) |
+| 6.5 | 0.822 | Probablement classe 1 |
+| 9.0 | 0.951 | Tres probablement classe 1 |
+
+**Observations cles** :
+
+1. **Gradient de confiance** : La probabilite augmente de maniere monotone avec x, coherent avec le poids positif appris.
+
+2. **Zone de transition** : Autour de x=4.5, le modele est incertain (P proche de 0.5). Cela correspond au point de decision calcule (x=4.15).
+
+3. **Propagation de l'incertitude** : Ces probabilites ne sont pas juste `sigmoid(w*x - b)` avec des parametres fixes. Elles integrent l'incertitude sur w et b apprise pendant l'entrainement.
+
+> **Difference avec la classification deterministe** : Un classifieur classique donnerait une prediction binaire (0 ou 1). Ici, nous obtenons une probabilite calibree qui reflette notre confiance reelle basee sur les donnees disponibles.",,,,,,,,4dea526578254046,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,c6af3de6,markdown,fr,11a96e277327bb7f,"### Exercice : Influence du prior sur la frontiere de decision
+
+Le modele de regression logistique bayesienne utilise des priors Gaussiens sur les poids. Le choix du prior (variance) influence la frontiere de decision apprise.
+
+**Objectif** : Comparez les frontieres de decision obtenues avec un prior large (variance = 100) vs un prior étroit (variance = 0.1) sur le meme jeu de donnees.
+
+**Etapes** :
+1. Reprenez les donnees `{1,2,3,4,5,6,7,8}` avec labels `{F,F,F,T,F,T,T,T}`
+2. Entrainez un modele avec `Variable.GaussianFromMeanAndVariance(0, 100)` pour le poids
+3. Entrainez un autre modele avec `Variable.GaussianFromMeanAndVariance(0, 0.1)` pour le poids
+4. Comparez les poids posterieurs et les points de decision (seuil/poids)
+
+**Indices** :
+- Un prior etroit (faible variance) = forte regularisation = poids proches de zero
+- Un prior large (grande variance) = faible regularisation = poids libres de prendre de grandes valeurs
+- Calculez le point de decision avec `seuil.GetMean() / poids.GetMean()`",,,,,,,,11a96e277327bb7f,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,0e5c837e,code,fr,beb8da3ac8112876,"// Exercice : Influence du prior sur la frontiere de decision
+// TODO: Definir les donnees d'entrainement (reutiliser les donnees de la section 3)
+// Indice: double[] features = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+
+// TODO: Modele 1 - Prior large (variance = 100)
+// Indice: Variable.GaussianFromMeanAndVariance(0, 100) pour poids et seuil
+
+// TODO: Modele 2 - Prior etroit (variance = 0.1)
+// Indice: Variable.GaussianFromMeanAndVariance(0, 0.1) pour poids et seuil
+
+// TODO: Comparer les resultats
+// Console.WriteLine($""Prior large : poids={w1}, seuil={b1}, decision={b1.GetMean()/w1.GetMean():F2}"");
+// Console.WriteLine($""Prior etroit : poids={w2}, seuil={b2}, decision={b2.GetMean()/w2.GetMean():F2}"");
+Console.WriteLine(""Exercice a completer : Influence du prior"");",,,,,,,,beb8da3ac8112876,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,9bc0d33b,markdown,fr,b965d32c596d2386,## 5. Classification Multi-Features,,,,,,,,b965d32c596d2386,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,ll7ewym2zac,markdown,fr,6eae433e7d4b6292,"### Extension aux dimensions superieures
+
+Passer d'une seule feature a plusieurs features generalise le modele :
+
+| Aspect | 1 feature | p features |
+|--------|-----------|------------|
+| Parametre | $w$ (scalaire) | $\mathbf{w}$ (vecteur) |
+| Score | $w \cdot x - b$ | $\mathbf{w}^T \mathbf{x} - b$ |
+| Frontiere | Point sur $\mathbb{R}$ | Hyperplan dans $\mathbb{R}^p$ |
+| Priors | 2 Gaussiennes | p+1 Gaussiennes |
+
+Le graphe de facteurs s'etend naturellement avec un **produit scalaire** entre le vecteur de poids et le vecteur de features.",,,,,,,,6eae433e7d4b6292,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,77037ea0,code,fr,ea97dc40dcc1d0aa,"// Donnees avec 2 features
+double[,] featuresMulti = {
+    { 1.0, 2.0 },
+    { 2.0, 1.5 },
+    { 1.5, 3.0 },
+    { 3.0, 3.5 },
+    { 4.0, 2.0 },
+    { 3.5, 4.0 },
+    { 5.0, 3.0 },
+    { 4.5, 5.0 }
+};
+bool[] labelsMulti = { false, false, false, true, false, true, true, true };
+
+int nSamples = labelsMulti.Length;
+int nFeatures = 2;
+
+Range sampleRange = new Range(nSamples).Named(""sample"");
+Range featureRange = new Range(nFeatures).Named(""feature"");
+
+// Poids pour chaque feature
+VariableArray<double> poidsMulti = Variable.Array<double>(featureRange).Named(""poids"");
+poidsMulti[featureRange] = Variable.GaussianFromMeanAndVariance(0, 10).ForEach(featureRange);
+
+Variable<double> seuilMulti = Variable.GaussianFromMeanAndVariance(0, 10).Named(""seuil"");
+
+VariableArray2D<double> xMulti = Variable.Array<double>(sampleRange, featureRange).Named(""x"");
+VariableArray<bool> yMulti = Variable.Array<bool>(sampleRange).Named(""y"");
+
+using (Variable.ForEach(sampleRange))
+{
+    // Score = somme(poids[f] * x[f]) - seuil
+    Variable<double> scoreMulti = Variable.Sum(
+        Variable.Array<double>(featureRange).Named(""produit""));
+    
+    // Alternative plus simple : calculer explicitement
+    Variable<double> score0 = poidsMulti[0] * xMulti[sampleRange, 0];
+    Variable<double> score1 = poidsMulti[1] * xMulti[sampleRange, 1];
+    Variable<double> scoreTot = score0 + score1 - seuilMulti;
+    Variable<double> scoreNoise = Variable.GaussianFromMeanAndVariance(scoreTot, 1);
+    yMulti[sampleRange] = (scoreNoise > 0);
+}
+
+xMulti.ObservedValue = featuresMulti;
+yMulti.ObservedValue = labelsMulti;
+
+InferenceEngine moteurMulti = new InferenceEngine(new ExpectationPropagation());
+moteurMulti.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurMulti.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Gaussian[] poidsPostMulti = moteurMulti.Infer<Gaussian[]>(poidsMulti);
+Gaussian seuilPostMulti = moteurMulti.Infer<Gaussian>(seuilMulti);
+
+Console.WriteLine(""=== Classification Multi-Features ==="");
+for (int f = 0; f < nFeatures; f++)
+{
+    Console.WriteLine($""Poids feature {f+1} : {poidsPostMulti[f]}"");
+}
+Console.WriteLine($""Seuil : {seuilPostMulti}"");",,,,,,,,ea97dc40dcc1d0aa,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,uf82v4btvd,markdown,fr,e481b9ad9aba40da,"### Analyse des poids multi-features
+
+**Resultats obtenus** :
+- Poids feature 1 (x1) : 0.55 ± 0.25
+- Poids feature 2 (x2) : 1.25 ± 0.28
+- Seuil : 5.06 ± 0.82
+
+**Interpretation geometrique** :
+
+La frontiere de decision est definie par l'equation :
+$$0.55 \cdot x_1 + 1.25 \cdot x_2 - 5.06 = 0$$
+
+Soit : $x_2 = -0.44 \cdot x_1 + 4.05$
+
+| Aspect | Valeur | Signification |
+|--------|--------|---------------|
+| Pente frontiere | -0.44 | Frontiere quasi-horizontale |
+| Intercept | 4.05 | Coupe l'axe x2 vers 4 |
+| Ratio poids | 2.3 | Feature 2 a 2.3x plus d'influence que feature 1 |
+
+> **Importance relative** : Le poids de la feature 2 est plus de deux fois celui de la feature 1, indiquant que x2 est plus discriminant pour la classification. Cela pourrait orienter la collecte de donnees futures.",,,,,,,,e481b9ad9aba40da,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,jeu5ucmvxsh,code,fr,66e70df71720b60e,"// Visualisation du graphe de facteurs multi-features
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,66e70df71720b60e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,8xwj3opb66t,markdown,fr,f9c54bfe690ac1ea,"### Graphe de facteurs multi-features - Structure vectorielle
+
+Le graphe multi-features illustre l'extension du modele a plusieurs dimensions :
+
+**Differences avec le modele 1D** :
+- `poids` est maintenant un **tableau** avec un element par feature
+- Le graphe montre une double structure de plates : 
+  - Une sur les features (pour les poids)
+  - Une sur les echantillons (pour les observations)
+
+**Operations visibles** :
+- Multiplication `poids[f] * x[i,f]` pour chaque feature
+- Addition des scores partiels
+- Soustraction du seuil
+- Ajout du bruit gaussien
+- Comparaison avec zero
+
+**Partage de parametres** :
+Les memes poids `poids[0]` et `poids[1]` sont utilises pour tous les echantillons, ce qui est la cle de la generalisation. Le graphe encode cette contrainte structurelle.",,,,,,,,f9c54bfe690ac1ea,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,a4c0bc0f,markdown,fr,baef219ed4a68642,"## 6. Bayes Point Machine (BPM)
+
+### Principe
+
+Le BPM est une methode de classification bayesienne qui :
+- Marginalise sur tous les hyperplans separateurs possibles
+- Donne des probabilites calibrees
+- Utilise EP pour l'inference
+
+### Formulation
+
+$$P(y=1|x) = \int P(y=1|x,w) P(w|D) dw$$",,,,,,,,baef219ed4a68642,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,c72blgkubd,markdown,fr,7aa0cd4a81cef643,"**Note technique : Modele probit vs logit**
+
+Le code precedent utilise un **modele probit** (comparaison avec bruit gaussien) plutot qu'un modele logit (fonction sigmoid). Voici la difference :
+
+| Aspect | Probit | Logit |
+|--------|--------|-------|
+| Lien | $\Phi^{-1}(p) = w^T x$ | $\log\frac{p}{1-p} = w^T x$ |
+| Distribution latente | Gaussienne | Logistique |
+| Inference bayesienne | Plus facile (EP) | Plus difficile |
+| Equivalence pratique | Quasi-identique pour la plupart des cas | |
+
+En Infer.NET, le modele probit est prefere car il se prete naturellement a l'Expectation Propagation avec des distributions gaussiennes.
+
+$$P(y=1|x) = \Phi(w^T x) = \int_{-\infty}^{w^T x} \mathcal{N}(z|0,1) dz$$
+
+ou $\Phi$ est la fonction de repartition de la loi normale standard.",,,,,,,,7aa0cd4a81cef643,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,ad6bcf40,code,fr,68e359a9b70f16ae,"// Bayes Point Machine simplifie
+
+public class SimpleBPM
+{
+    private int nFeatures;
+    private Gaussian[] poidsPosteriors;
+    private Gaussian seuilPosterior;
+    private InferenceEngine moteur;
+    
+    public SimpleBPM(int nFeatures)
+    {
+        this.nFeatures = nFeatures;
+        this.moteur = new InferenceEngine(new ExpectationPropagation());
+        this.moteur.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+        this.moteur.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+    }
+    
+    public void Entrainer(double[,] X, bool[] y)
+    {
+        int n = y.Length;
+        Range sampleRange = new Range(n);
+        Range featureRange = new Range(nFeatures);
+        
+        VariableArray<double> poids = Variable.Array<double>(featureRange);
+        poids[featureRange] = Variable.GaussianFromMeanAndVariance(0, 1).ForEach(featureRange);
+        
+        Variable<double> seuil = Variable.GaussianFromMeanAndVariance(0, 1);
+        
+        VariableArray2D<double> xVar = Variable.Array<double>(sampleRange, featureRange);
+        VariableArray<bool> yVar = Variable.Array<bool>(sampleRange);
+        
+        using (Variable.ForEach(sampleRange))
+        {
+            Variable<double> score = Variable.Constant(0.0);
+            for (int f = 0; f < nFeatures; f++)
+            {
+                score = score + poids[f] * xVar[sampleRange, f];
+            }
+            score = score - seuil;
+            Variable<double> scoreNoise = Variable.GaussianFromMeanAndVariance(score, 1);
+            yVar[sampleRange] = (scoreNoise > 0);
+        }
+        
+        xVar.ObservedValue = X;
+        yVar.ObservedValue = y;
+        
+        poidsPosteriors = moteur.Infer<Gaussian[]>(poids);
+        seuilPosterior = moteur.Infer<Gaussian>(seuil);
+    }
+    
+    public double Predire(double[] x)
+    {
+        // Score moyen
+        double scoreMoyen = 0;
+        double scoreVariance = 0;
+        
+        for (int f = 0; f < nFeatures; f++)
+        {
+            scoreMoyen += poidsPosteriors[f].GetMean() * x[f];
+            scoreVariance += poidsPosteriors[f].GetVariance() * x[f] * x[f];
+        }
+        scoreMoyen -= seuilPosterior.GetMean();
+        scoreVariance += seuilPosterior.GetVariance() + 1;  // +1 pour le bruit
+        
+        // Probit : P(score + noise > 0) - utiliser MMath.NormalCdf
+        return MMath.NormalCdf(scoreMoyen / Math.Sqrt(scoreVariance));
+    }
+}
+
+Console.WriteLine(""Classe SimpleBPM definie (avec ShowFactorGraph active)."");",,,,,,,,68e359a9b70f16ae,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,8iiyytzrwrs,markdown,fr,5116d11f44e1ff54,"### Implementation du Bayes Point Machine
+
+La classe `SimpleBPM` encapsule le workflow complet :
+
+1. **Entrainement** (`Entrainer`) :
+   - Definit les priors Gaussiens sur les poids et le seuil
+   - Construit le graphe de facteurs avec le modele probit
+   - Execute l'inference EP pour obtenir les posterieurs
+
+2. **Prediction** (`Predire`) :
+   - Calcule le score moyen : $\mu_{score} = \mathbf{w}_{post}^T \mathbf{x} - b_{post}$
+   - Calcule la variance totale : $\sigma^2_{score} = \sum_i \text{Var}(w_i) x_i^2 + \text{Var}(b) + 1$
+   - Retourne $\Phi(\mu_{score} / \sigma_{score})$ via `MMath.NormalCdf`
+
+**Formule de prediction avec incertitude** :
+
+$$P(y=1|\mathbf{x}) = \Phi\left(\frac{\mathbf{\mu}_w^T \mathbf{x} - \mu_b}{\sqrt{\mathbf{x}^T \Sigma_w \mathbf{x} + \sigma_b^2 + 1}}\right)$$
+
+ou $\Phi$ est la CDF de la loi normale standard.",,,,,,,,5116d11f44e1ff54,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,rrt7vjmte7o,markdown,fr,ddd2ed6301b10638,"### Validation sur les donnees 2D
+
+Testons maintenant notre classe `SimpleBPM` sur les donnees multi-features definies precedemment pour valider l'implementation. Le BPM devrait donner des predictions coherentes avec l'inference directe, mais avec une API plus simple pour les predictions.",,,,,,,,ddd2ed6301b10638,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,c63524cf,code,fr,9def260596af8ed9,"// Utilisation du BPM
+var bpm = new SimpleBPM(2);
+bpm.Entrainer(featuresMulti, labelsMulti);
+
+Console.WriteLine(""=== Predictions BPM ==="");
+double[][] testPoints = {
+    new[] { 1.0, 1.0 },
+    new[] { 3.0, 3.0 },
+    new[] { 5.0, 4.0 },
+    new[] { 2.0, 4.0 }
+};
+
+foreach (var point in testPoints)
+{
+    double prob = bpm.Predire(point);
+    Console.WriteLine($""({point[0]}, {point[1]}) : P(classe=1) = {prob:F3}"");
+}",,,,,,,,9def260596af8ed9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,8odjsoa9nju,markdown,fr,36f931aad311fe50,"### Analyse des predictions BPM
+
+| Point (x1, x2) | P(classe=1) | Position relative | Verdict |
+|----------------|-------------|-------------------|---------|
+| (1, 1) | 0.268 | Loin sous la frontiere | Classe 0 |
+| (3, 3) | 0.603 | Proche de la frontiere | Incertain |
+| (5, 4) | 0.751 | Au-dessus de la frontiere | Classe 1 |
+| (2, 4) | 0.633 | Legèrement au-dessus | Classe 1 (incertain) |
+
+**Caracteristiques du Bayes Point Machine** :
+
+1. **Calibration** : Les probabilites proches de 0.5 indiquent correctement les zones d'incertitude pres de la frontiere.
+
+2. **Marginalisation** : Le BPM considere tous les hyperplans plausibles ponderes par leur probabilite, pas un seul hyperplan optimal.
+
+3. **Regularisation implicite** : Le prior Gaussien sur les poids (variance = 1) empeche le surapprentissage en penalisant les poids extremes.
+
+> **Comparaison SVM vs BPM** : Un SVM donnerait une frontiere ""dure"" et une classification binaire. Le BPM fournit des probabilites calibrees, particulierement utiles quand le cout d'erreur est asymetrique ou quand il faut prioriser les cas incertains pour une revue humaine.",,,,,,,,36f931aad311fe50,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,cr9vd8obj6i,code,fr,f80a396e04c512bf,"// Visualisation du graphe de facteurs du BPM
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,f80a396e04c512bf,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,893615jcc8i,markdown,fr,66420429ce5f88b1,"### Graphe de facteurs du Bayes Point Machine
+
+Le graphe du BPM encapsule la classe `SimpleBPM` et montre :
+
+**Structure identique au modele multi-features** :
+- Le BPM utilise exactement la meme structure de modele que la section precedente
+- La difference est dans l'encapsulation (classe reutilisable)
+
+**Points cles visibles** :
+1. **Prior unitaire** : Variance = 1 sur les poids (regularisation implicite)
+2. **Score additif** : Somme des contributions de chaque feature
+3. **Modele probit** : Comparaison avec bruit gaussien
+
+**Marginalisation** :
+Le nom ""Bayes Point Machine"" vient du fait que la prediction marginalise sur l'ensemble des hyperplans separateurs possibles, ponderes par leur probabilite a posteriori. Le graphe encode cette structure de marginalisation via les connexions entre variables et facteurs.",,,,,,,,66420429ce5f88b1,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,ff6c157e,markdown,fr,00684ec8063aaa75,"## 7. Test Clinique Bayesien (A/B Testing)
+
+### Contexte
+
+Comparer l'efficacite d'un nouveau traitement vs placebo.
+
+### Approche bayesienne
+
+- Prior sur l'efficacite de chaque traitement
+- Mise a jour avec les observations
+- Probabilite que le traitement soit meilleur",,,,,,,,00684ec8063aaa75,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,ad057266,code,fr,f30832e0dcc71f82,"// Test clinique A/B bayesien
+
+// Donnees observees
+int nPlacebo = 100;
+int guerisPlacebo = 30;  // 30% guerison
+
+int nTraitement = 100;
+int guerisTraitement = 45;  // 45% guerison
+
+// Modele : taux de guerison pour chaque groupe
+Variable<double> tauxPlacebo = Variable.Beta(1, 1).Named(""tauxPlacebo"");  // Prior uniforme
+Variable<double> tauxTraitement = Variable.Beta(1, 1).Named(""tauxTraitement"");
+
+// Observations (distribution binomiale)
+Variable<int> obsPlacebo = Variable.Binomial(nPlacebo, tauxPlacebo);
+Variable<int> obsTraitement = Variable.Binomial(nTraitement, tauxTraitement);
+
+obsPlacebo.ObservedValue = guerisPlacebo;
+obsTraitement.ObservedValue = guerisTraitement;
+
+// Traitement est meilleur ?
+Variable<bool> traitementMeilleur = (tauxTraitement > tauxPlacebo);
+
+InferenceEngine moteurClinique = new InferenceEngine();
+moteurClinique.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+moteurClinique.ShowFactorGraph = true;  // Activer la generation du graphe de facteurs
+
+Beta tauxPlaceboPost = moteurClinique.Infer<Beta>(tauxPlacebo);
+Beta tauxTraitementPost = moteurClinique.Infer<Beta>(tauxTraitement);
+Bernoulli traitementMeilleurPost = moteurClinique.Infer<Bernoulli>(traitementMeilleur);
+
+Console.WriteLine(""=== Test Clinique Bayesien ==="");
+Console.WriteLine($""\nPlacebo : {guerisPlacebo}/{nPlacebo} guerisons"");
+Console.WriteLine($""Traitement : {guerisTraitement}/{nTraitement} guerisons"");
+
+Console.WriteLine($""\nTaux placebo : {tauxPlaceboPost}"");
+Console.WriteLine($""  Moyenne : {tauxPlaceboPost.GetMean():F3}"");
+Console.WriteLine($""  IC 95% : [{tauxPlaceboPost.GetMean() - 2*Math.Sqrt(tauxPlaceboPost.GetVariance()):F3}, {tauxPlaceboPost.GetMean() + 2*Math.Sqrt(tauxPlaceboPost.GetVariance()):F3}]"");
+
+Console.WriteLine($""\nTaux traitement : {tauxTraitementPost}"");
+Console.WriteLine($""  Moyenne : {tauxTraitementPost.GetMean():F3}"");
+
+Console.WriteLine($""\nP(traitement meilleur) = {traitementMeilleurPost.GetProbTrue():F3}"");",,,,,,,,f30832e0dcc71f82,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,d26dff6a,markdown,fr,1a5d2b81691d18b4,"### Analyse du test clinique
+
+**Résultats** :
+- Placebo : 30% guérison (IC 95% : 21%-39%)
+- Traitement : 45% guérison (IC 95% : 35%-55%)
+- **P(traitement meilleur) = 0.986**
+
+**Comparaison avec l'approche fréquentiste** :
+
+| Aspect | Fréquentiste | Bayésien |
+|--------|--------------|----------|
+| Question | ""Peut-on rejeter H0 ?"" | ""Quelle est P(traitement meilleur) ?"" |
+| Réponse | p-value < 0.05 → significatif | P = 98.6% → très probable |
+| Interprétation | Difficile à communiquer | Directe et intuitive |
+
+**Note importante** : Le warning ""quality band Experimental"" indique que l'opérateur `DifferenceBetaOp` est encore en développement dans Infer.NET. Les résultats restent fiables mais cette fonctionnalité pourrait évoluer.
+
+> **Application clinique** : Avec 98.6% de probabilité que le traitement soit meilleur, un comité d'éthique pourrait recommander de proposer le traitement au groupe placebo.",,,,,,,,1a5d2b81691d18b4,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,wtgd89my72e,code,fr,60220c474882b499,"// Visualisation du graphe de facteurs du test clinique
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,60220c474882b499,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,t8zueh8k44o,markdown,fr,3dcc80da2845ba76,"### Graphe de facteurs du test A/B clinique
+
+Ce graphe illustre le modele comparatif Beta-Binomial :
+
+**Structure parallele** :
+- Deux branches independantes pour `tauxPlacebo` et `tauxTraitement`
+- Chaque branche : Prior Beta -> Facteur Binomial -> Observation
+
+**Variables** :
+- `tauxPlacebo`, `tauxTraitement` : Parametres latents (probabilites de guerison)
+- Les observations sont des comptages binomiaux (rectangles)
+
+**Facteur de comparaison** :
+Le facteur `tauxTraitement > tauxPlacebo` (visible comme operateur de difference) est le coeur du test A/B. Il permet de repondre directement : ""Quelle est la probabilite que le traitement soit meilleur ?""
+
+**Independence a priori** :
+Les deux taux ont des priors independants Beta(1,1). L'information sur la comparaison vient uniquement des donnees observees, pas d'hypotheses a priori sur leur relation.",,,,,,,,3dcc80da2845ba76,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,10634vpndmv,markdown,fr,9bfe1f08d6cf5d8e,"### Modele conjugue Beta-Binomial
+
+Le test clinique utilise le modele classique Beta-Binomial :
+
+**Prior** : $\theta \sim \text{Beta}(1, 1)$ (uniforme sur [0,1])
+
+**Vraisemblance** : $k | \theta \sim \text{Binomial}(n, \theta)$
+
+**Posterior** : $\theta | k \sim \text{Beta}(1 + k, 1 + n - k)$
+
+Cette conjugaison permet une inference exacte. La question ""le traitement est-il meilleur ?"" se traduit par :
+$$P(\theta_{traitement} > \theta_{placebo} | \text{donnees})$$
+
+Infer.NET calcule cette probabilite via l'operateur `DifferenceBetaOp`.",,,,,,,,9bfe1f08d6cf5d8e,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,4e52c9a4,markdown,fr,ab74345f6af539e6,## 8. Effet de la Taille d'Echantillon,,,,,,,,ab74345f6af539e6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,g0lw2yo4b9t,markdown,fr,3f0eefc31da6b1f2,"### Puissance statistique bayesienne
+
+Une question naturelle est : ""Combien de patients faut-il recruter pour detecter une difference ?"" L'analyse suivante montre comment la certitude evolue avec la taille de l'echantillon, a effet constant (30% vs 45%).",,,,,,,,3f0eefc31da6b1f2,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,254b6c38,code,fr,53fbaee80d9368a3,"// Impact de la taille d'echantillon
+
+Console.WriteLine(""=== Impact de la taille d'echantillon ==="");
+Console.WriteLine(""\nMeme ratio (30% vs 45%), differentes tailles :\n"");
+
+int[] tailles = { 10, 50, 100, 500, 1000 };
+
+foreach (int n in tailles)
+{
+    int gP = (int)(n * 0.30);
+    int gT = (int)(n * 0.45);
+    
+    Variable<double> tP = Variable.Beta(1, 1);
+    Variable<double> tT = Variable.Beta(1, 1);
+    
+    Variable.ConstrainEqual(Variable.Binomial(n, tP), gP);
+    Variable.ConstrainEqual(Variable.Binomial(n, tT), gT);
+    
+    Variable<bool> meilleur = (tT > tP);
+    
+    InferenceEngine m = new InferenceEngine();
+    m.Compiler.CompilerChoice = CompilerChoice.Roslyn;
+    
+    double prob = m.Infer<Bernoulli>(meilleur).GetProbTrue();
+    Console.WriteLine($""n = {n,4} : P(traitement meilleur) = {prob:F4}"");
+}
+
+Console.WriteLine(""\n=> Plus de donnees = plus de certitude"");",,,,,,,,53fbaee80d9368a3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,my479h57vh,markdown,fr,391c4dc1c850179a,"### Convergence de la certitude avec la taille d'echantillon
+
+| Taille (n) | P(traitement meilleur) | Interpretation |
+|------------|------------------------|----------------|
+| 10 | 0.670 | Faible evidence (proche du hasard) |
+| 50 | 0.926 | Evidence moderee |
+| 100 | 0.986 | Evidence forte |
+| 500 | ~1.000 | Evidence tres forte |
+| 1000 | ~1.000 | Evidence quasi-certaine |
+
+**Loi de convergence** :
+
+La certitude croit approximativement comme $\sqrt{n}$ :
+- Doubler la confiance necessite quadrupler l'echantillon
+- Passer de 67% a 99% necessite ~10x plus de donnees (n=10 -> n=100 dans le tableau ci-dessus)
+
+**Implications pratiques** :
+
+| Contexte | Taille recommandee | Justification |
+|----------|-------------------|---------------|
+| Test pilote | n = 50 | Detection effet important (>90%) |
+| Essai clinique | n = 100-500 | Standard reglementaire |
+| Decision critique | n > 500 | Minimiser risque d'erreur |
+
+> **Avantage bayesien** : Contrairement aux tests frequentistes qui donnent une reponse binaire (significatif/non-significatif), l'approche bayesienne permet un **arret adaptatif** : on peut arreter l'essai des que P(traitement meilleur) depasse un seuil predetermine (ex: 95%), ou au contraire continuer si l'evidence est insuffisante.",,,,,,,,391c4dc1c850179a,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,ce62df2a,markdown,fr,109b3290bfe7a296,"### Exercice : Test A/B avec prior informatif
+
+Dans le test clinique precedent, nous avons utilise Beta(1,1) comme prior uniforme. En pratique, on dispose souvent d'informations a priori issues d'etudes precedentes.
+
+**Objectif** : Comparez l'analyse du test clinique avec un prior uniforme vs un prior informatif qui encode la connaissance d'etudes precedentes (taux de guerison historique = 25%).
+
+**Etapes** :
+1. Reprenez les donnees : placebo 30/100, traitement 45/100
+2. Analyse 1 : prior uniforme Beta(1,1) (deja fait)
+3. Analyse 2 : prior informatif Beta(5,15) pour le placebo (moyenne = 0.25, equivaut a 20 observations)
+4. Comparez P(traitement meilleur) dans les deux cas
+
+**Indices** :
+- Beta(5,15) encode 5 succes et 15 echecs ""virtuels"", soit une moyenne de 5/(5+15) = 0.25
+- Le prior informatif reduit la variance du posterior et accelere la convergence
+- Comment le prior informatif sur le placebo affecte-t-il la comparaison ?",,,,,,,,109b3290bfe7a296,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,a226525c,code,fr,93c5dbdba671f372,"// Exercice : Test A/B avec prior informatif
+// TODO: Reutiliser les donnees (placebo 30/100, traitement 45/100)
+// Indice: nPlacebo = 100, guerisPlacebo = 30, etc.
+
+// TODO: Analyse 1 - Prior uniforme Beta(1,1) (identique a la section 7)
+// Indice: Variable<double> tauxPlacebo = Variable.Beta(1, 1);
+
+// TODO: Analyse 2 - Prior informatif Beta(5,15) pour le placebo
+// Indice: Variable<double> tauxPlaceboInfo = Variable.Beta(5, 15);
+// Ce prior encode 20 ""observations virtuelles"" avec 25% de taux de guerison
+
+// TODO: Comparer P(traitement meilleur) dans les deux cas
+// Console.WriteLine($""Prior uniforme : P(traitement meilleur) = {p1:F3}"");
+// Console.WriteLine($""Prior informatif : P(traitement meilleur) = {p2:F3}"");
+Console.WriteLine(""Exercice a completer : Test A/B avec prior informatif"");",,,,,,,,93c5dbdba671f372,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,10acf573,markdown,fr,08c08cd9c8a029fc,"## 9. Exemple guide : Classification Spam
+
+### Enonce
+
+Construisez un classificateur bayesien pour detecter les spams bases sur 3 features :
+- Nombre de mots en majuscules
+- Presence du mot ""gratuit""
+- Longueur du message (en centaines de caracteres)
+
+### Donnees",,,,,,,,08c08cd9c8a029fc,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,4vz1cpy6yhq,markdown,fr,61ed6bc1470093c9,"### Objectif de l'exercice
+
+Construire un classificateur de spam en utilisant le Bayes Point Machine implemente precedemment. Les features choisies representent des caracteristiques typiques des spams :
+
+| Feature | Description | Valeur typique spam |
+|---------|-------------|---------------------|
+| Majuscules | Nombre de mots en majuscules | Eleve (>15) |
+| Gratuit | Presence du mot ""gratuit"" (0/1) | 1 |
+| Longueur | Taille du message (en centaines de caracteres) | Faible (<2) |
+
+Ces features sont simples mais illustrent les principes d'un filtre anti-spam reel.",,,,,,,,61ed6bc1470093c9,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,30425d08,code,fr,2440e73984ffc40c,"// Exemple guide : Classification spam
+
+// Donnees d'entrainement
+// [nbMajuscules, presenceGratuit (0/1), longueur]
+double[,] spamFeatures = {
+    { 5, 0, 2.5 },   // Non spam
+    { 3, 0, 3.0 },   // Non spam
+    { 15, 1, 1.0 },  // Spam
+    { 20, 1, 0.5 },  // Spam
+    { 2, 0, 4.0 },   // Non spam
+    { 25, 1, 1.5 },  // Spam
+    { 8, 0, 2.0 },   // Non spam
+    { 18, 1, 0.8 }   // Spam
+};
+bool[] spamLabels = { false, false, true, true, false, true, false, true };
+
+// Entrainement
+var spamClassifier = new SimpleBPM(3);
+spamClassifier.Entrainer(spamFeatures, spamLabels);
+
+Console.WriteLine(""=== Classificateur Spam ==="");
+
+// Test sur nouveaux emails
+var testEmails = new (double[], string)[] {
+    (new[] { 4.0, 0.0, 3.0 }, ""Email normal""),
+    (new[] { 22.0, 1.0, 1.0 }, ""OFFRE GRATUITE!!!""),
+    (new[] { 10.0, 0.0, 2.5 }, ""Email avec quelques majuscules""),
+    (new[] { 30.0, 1.0, 0.5 }, ""CLIQUEZ ICI GRATUIT"")
+};
+
+Console.WriteLine(""\nPredictions :"");
+foreach (var (features, desc) in testEmails)
+{
+    double probSpam = spamClassifier.Predire(features);
+    string verdict = probSpam > 0.5 ? ""SPAM"" : ""OK"";
+    Console.WriteLine($""  {desc,-30} : P(spam)={probSpam:F3} -> {verdict}"");
+}",,,,,,,,2440e73984ffc40c,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,0lks9jhso2xf,markdown,fr,ed6eeaec3d4a7643,"### Analyse du classificateur spam
+
+**Resultats de prediction** :
+
+| Email | Majuscules | Gratuit | Longueur | P(spam) | Verdict |
+|-------|------------|---------|----------|---------|---------|
+| Email normal | 4 | Non | 3.0 | 0.053 | OK |
+| OFFRE GRATUITE!!! | 22 | Oui | 1.0 | 0.952 | SPAM |
+| Quelques majuscules | 10 | Non | 2.5 | 0.334 | OK |
+| CLIQUEZ ICI GRATUIT | 30 | Oui | 0.5 | 0.984 | SPAM |
+
+**Facteurs discriminants appris** :
+
+Le modele a appris que le spam est caracterise par :
+1. **Nombre eleve de majuscules** (poids positif)
+2. **Presence du mot ""gratuit""** (poids positif fort)
+3. **Messages courts** (poids negatif sur la longueur)
+
+**Cas interessants** :
+
+- ""Email avec quelques majuscules"" (P=0.334) : Malgre 10 majuscules, l'absence de ""gratuit"" et la longueur normale le sauvent du classement spam.
+- Les deux emails avec ""gratuit"" ont P(spam) > 95%, montrant l'importance de cette feature.
+
+> **Application industrielle** : Ce type de classificateur bayesien est utilise dans les filtres anti-spam reels. L'avantage de l'approche probabiliste est de pouvoir definir un seuil de decision adapte au contexte : seuil bas (0.3) pour un filtre agressif, seuil haut (0.8) pour eviter les faux positifs dans un contexte professionnel.",,,,,,,,ed6eeaec3d4a7643,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,1egcewx3etnj,code,fr,dade14108d9f7aa3,"// Visualisation du graphe de facteurs du classificateur spam
+display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));",,,,,,,,dade14108d9f7aa3,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,v3oesyvwqk,markdown,fr,5cd54eaa24e1c687,"### Graphe du classificateur spam - BPM a 3 features
+
+Le graphe de l'exercice spam reprend la structure du BPM multi-features avec 3 dimensions :
+
+**Features encodees** :
+1. `poids[0]` : Nombre de mots en majuscules
+2. `poids[1]` : Presence du mot ""gratuit"" (0/1)
+3. `poids[2]` : Longueur du message
+
+**Application pratique** :
+Ce type de graphe est le coeur des filtres bayesiens anti-spam (comme SpamBayes ou les filtres Gmail). L'avantage est de pouvoir ajouter de nouvelles features facilement en etendant le vecteur de poids, sans changer la structure du modele.
+
+**Prediction** :
+La methode `Predire()` utilise les posterieurs pour calculer P(spam|x) en integrant l'incertitude sur les poids appris.",,,,,,,,5cd54eaa24e1c687,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,c23fa2ba,markdown,fr,4af99fa9f40bc0e6,"## 10. Resume et Synthese
+
+### Concepts cles
+
+| Concept | Description |
+|---------|-------------|
+| **Regression logistique bayesienne** | Priors sur poids, posterieurs apres donnees |
+| **Bayes Point Machine** | Marginalisation sur hyperplans |
+| **Test A/B bayesien** | P(traitement meilleur) directement |
+| **Incertitude** | Quantifiee a chaque etape |
+| **Calibration** | Probabilites refletent la vraie incertitude |
+
+### Distributions utilisees
+
+| Distribution | Role | Parametres |
+|--------------|------|------------|
+| **Gaussian** | Prior/Posterior sur poids | (moyenne, variance) |
+| **Gamma** | Prior sur precision du bruit | (shape, scale) |
+| **Beta** | Prior/Posterior sur probabilites | (alpha, beta) |
+| **Bernoulli** | Prediction de classe | (probTrue) |
+| **Binomial** | Comptage de succes | (n, p) |
+
+### Comparaison des approches
+
+| Aspect | Classification classique | Classification bayesienne |
+|--------|-------------------------|---------------------------|
+| Sortie | Classe predite | Distribution sur les classes |
+| Incertitude modele | Non | Oui (distributions sur parametres) |
+| Incertitude prediction | Non | Oui (probabilites calibrees) |
+| Regularisation | Explicite (L1/L2) | Implicite (priors) |
+| Surapprentissage | Risque eleve | Reduit naturellement |
+| Interpretabilite | Limitee | Elevee (intervalles de credibilite) |
+
+---
+
+## Prochaine etape
+
+Dans [Infer-8-TrueSkill](Infer-8-TrueSkill.ipynb), nous explorerons :
+
+- Le systeme de classement TrueSkill (Xbox Live)
+- Les matchs 1v1 et la mise a jour des skills
+- La gestion des matchs nuls
+- L'extension aux equipes et multi-joueurs",,,,,,,,4af99fa9f40bc0e6,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,97924a95,markdown,fr,5d4d150e885fde78,"## 11. Exercice : Detecteur de Critiques Negatives
+
+### Enonce
+
+Classifiez des critiques de films comme **positives** (true) ou **negatives** (false) selon deux features :
+- Feature 0 : nombre de mots negatifs (""mauvais"", ""nul"", ""ennuyeux""...)
+- Feature 1 : presence du mot ""chef-d'oeuvre"" (0 ou 1)
+
+**Donnees d'entrainement** :
+- Positives : [0,1], [1,0], [0,1], [2,1] → labels = {true, true, true, true}
+- Negatives : [5,0], [4,0], [3,0], [6,0] → labels = {false, false, false, false}
+
+Entrainer le BPM et classer 3 nouvelles critiques : [1,0], [0,1], [3,0].
+
+**Indice** : Reutilisez exactement la structure BPM de la section 6 (Bayes Point Machine) avec 2 features.",,,,,,,,5d4d150e885fde78,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,d31bb853,code,fr,a4ecba05deebe6d0,"// Exemple guide : Classification de critiques de films - BPM 2 features
+using Microsoft.ML.Probabilistic.Math;
+
+// TODO: Definir les donnees d'entrainement
+// Feature 0 = nb mots negatifs, Feature 1 = chef-d-oeuvre (0 ou 1)
+
+// TODO: Entrainer le BPM (reutiliser la structure de l'exemple guide)
+
+// TODO: Inferer les poids du classifieur
+
+// TODO: Classer les nouvelles critiques (inference predictive)
+// Pour chaque critique : calculer P(positive | features)
+Console.WriteLine(""Exercice a completer"");
+",,,,,,,,a4ecba05deebe6d0,,,,,,,
+MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb,e24f4db9,markdown,fr,f4ccd6772a47093d,"## Conclusion
+
+Ce notebook a couvert la classification bayesienne : regression logistique probit, Bayes Point Machine et test A/B clinique.
+
+| Modele | Mecanisme | Apport bayesien |
+|--------|-----------|-----------------|
+| Regression probit | Score latent gaussien + seuil | Distributions sur les poids, pas d'estimations ponctuelles |
+| Bayes Point Machine | Marginalisation sur hyperplans | Probabilites calibrees, regularisation implicite |
+| Test A/B | Beta-Binomial conjugue | P(traitement meilleur) directement, arret adaptatif |
+
+| Distribution | Role |
+|--------------|------|
+| Gaussian | Priors sur poids et seuil du modele probit |
+| Gamma | Precision du bruit dans le score latent |
+| Beta | Taux de guerison (prior uniforme, posterior conjugue) |
+| Bernoulli | Predictions de classe |
+| Binomial | Comptage de succes (observations cliniques) |
+
+> **Avantage cle** : Contrairement a la classification deterministe, l'approche bayesienne propage l'incertitude des parametres aux predictions. Les probabilites obtenues sont calibrees, permettant des decisions seuillees adaptees au cout d'erreur (ex : filtre anti-spam agressif vs conservateur).",,,,,,,,f4ccd6772a47093d,,,,,,,


### PR DESCRIPTION
## Summary

Fresh regen of **#5801** (seed CSV for Probas/Infer, #4957 Phase 2), which was STALE post-**#5807** (Infer PR-3 renum, cycle 5→7→9→11→14, merged in ai-01's 38-PR batch). Per ai-01 steer (msg `msg-20260709T210131`): "Régénère le CSV depuis main frais" — the renum renamed notebooks → path drift + src_hash drift.

**Supersedes #5801** (new PR, no force-push). #5801 to be closed with pointer.

## Method

Regenerated via the canonical tool `scripts/translation/extract_cells_to_csv.py` (no ad-hoc hashing — the dashboard pattern warns: "Ne PAS deviner la méthode hash. Lire extract_cells_to_csv.py (sha256-16 normalisé)"):

```
python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/Probas/Infer/ -o translations/probas-infer/probas_infer.csv --repo-root .
# OK : 902 cellules extraites de 19 notebook(s)
```

`src_hash = sha256(normalize(text))[:16]` (normalize = rstrip lines + strip leading/trailing newlines). Schema = 21 columns (#4957 §1): notebook, cell_id, cell_type, src_lang, src_hash, text_{fr,en,es,ar,fa,zh,ru,pt}, hash_{...}. T1 extraction (pivot `fr` only, target langs empty — filled by Argumentum motor in T3).

## Verified delta (old #5801 → regen) = exactly the #5807 renum

Structured diff by (notebook, cell_id):
- **OLD 902 rows = NEW 902 rows** (row count preserved).
- **added 280 = removed 280** (symmetric = path renames, no net add/remove).
- The 5 added notebooks map exactly to the 5 removed (the #5807 cycle 5→7→9→11→14):
  - `Infer-5-Skills-IRT` → `Infer-7-Skills-IRT`
  - `Infer-7-Classification` → `Infer-9-Classification`
  - `Infer-9-Topic-Models` → `Infer-11-Topic-Models`
  - `Infer-11-Sequences` → `Infer-14-Sequences`
  - `Infer-14-Causal-Inference` → `Infer-5-Causal-Inference`
- **hash_changed = 19** among the 622 kept rows (cells in the 14 unchanged notebooks whose content drifted — expected, minor edits).
- Infer-16-Sparse-Gaussian-Process now included (19 notebooks).

No spurious changes — the regen is a faithful post-#5807 refresh.

## Verification

- README (+61) taken unchanged from #5801 (generic scope/method, no `Infer-N` references to fix).
- Secret scan on the CSV: **0 secrets** (extract pulls cell SOURCE only; Infer notebooks carry no API keys).
- `COURSE_CATALOG.generated.*` byte-identical (translations/ is not catalogued).
- Determinism: extract_cells_to_csv.py sorts notebooks + iterates cells in order → byte-identical on re-run.

See #4957. Part of #1650 (Phase 0.5). Atomic (2 files, README + CSV, single subject = Infer seed CSV post-renum).
