### PR TITLE
fix(docs): resync Probas README Infer numbering post-#5807 renum (#3974)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -225,16 +225,16 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 2 | Gaussian Mixtures | Distributions continues, mélanges gaussiens, estimation de params |
 | 3 | Factor Graphs | Monty Hall + Murder Mystery : inférence discrète, Variable.If/Case |
 | 4 | Bayesian Networks | Wet Grass, CPT, D-separation, explaining away, inférence causale |
-| 5 | Skills (IRT) | Modélisation de compétences (DINA), évaluation adaptative |
-| 6 | TrueSkill | Ranking bayésien, online learning, rating conservatif (mu - 3*sigma) |
-| 7 | Classification | Bayes Point Machine, classification probit, tests A/B bayésiens |
-| 8 | Model Sélection | Bayes Factors, evidence marginale, ARD (Automatic Relevance Détermination) |
-| 9 | Topic Models | LDA, Dirichlet, prior asymétrique pour briser la symétrie VMP |
-| 10 | Crowdsourcing | Worker models, communautés d'annotateurs, aggregation de labels |
-| 11 | Séquences | HMM, detection de régimes, forward-backward, motifs temporels |
+| 5 | Causal Inference | do-calculus de Pearl, backdoor/front-door, paradoxe de Simpson |
+| 6 | Debugging | EP vs VMP, diagnostic de divergence, ShowFactorGraph, ShowSchedule |
+| 7 | Skills (IRT) | Modélisation de compétences (DINA), évaluation adaptative |
+| 8 | TrueSkill | Ranking bayésien, online learning, rating conservatif (mu - 3*sigma) |
+| 9 | Classification | Bayes Point Machine, classification probit, tests A/B bayésiens |
+| 10 | Model Sélection | Bayes Factors, evidence marginale, ARD (Automatic Relevance Détermination) |
+| 11 | Topic Models | LDA, Dirichlet, prior asymétrique pour briser la symétrie VMP |
 | 12 | Modèles Hiérarchiques | Partial pooling, shrinkage, paramétrisation non-centrée |
-| 13 | Debugging | EP vs VMP, diagnostic de divergence, ShowFactorGraph, ShowSchedule |
-| 14 | Causal Inference | do-calculus de Pearl, backdoor/front-door, paradoxe de Simpson |
+| 13 | Crowdsourcing | Worker models, communautés d'annotateurs, aggregation de labels |
+| 14 | Séquences | HMM, detection de régimes, forward-backward, motifs temporels |
 | 15 | Recommenders | Factorisation matricielle bayésienne, Click Model |
 | 16 | Sparse Gaussian Process | EP sur géométrie latente GP, comparaison NUTS > 15min |
 | 17 | Kalman Filter | Système dynamique linéaire gaussien, filtrage fermé |
@@ -443,24 +443,24 @@ pip install pyro-ppl torch matplotlib numpy
 
 | Domaine | Notebooks |
 |---------|-----------|
-| Jeux vidéo | Infer-6, PyMC-6 (TrueSkill) |
+| Jeux vidéo | Infer-8, PyMC-6 (TrueSkill) |
 | Éducation | Infer-7, PyMC-5 (IRT) |
 | NLP | Infer-11, PyMC-9 (LDA) |
 | Médecine | Infer-4, Infer-9, Infer-17, Infer-18, Infer-19 (réseaux bayésiens, Kalman, change-point, survie) |
 | Finance | Infer-14 (HMM régimes), DecInfer-3 (CARA/CRRA), DecInfer-8 (MDPs) |
-| E-commerce | Infer-10, Infer-15, PyMC-10, PyMC-12 (crowdsourcing, recommenders) |
+| E-commerce | Infer-13, Infer-15, PyMC-10, PyMC-12 (crowdsourcing, recommenders) |
 
 ### Exemples concrets
 
 Derrière chaque modèle de la série se cache un système réel déjà en production :
 
-- **TrueSkill** (notebook 6) est l'algorithme que Microsoft utilise pour apparier des millions de joueurs sur Xbox Live : il maintient pour chaque joueur une compétence *gaussienne* (moyenne + incertitude) mise à jour après chaque partie, généralisant l'Elo des échecs aux jeux en équipe.
-- **Item Response Theory** (notebook 5) est le moteur des tests adaptatifs comme le GMAT ou le GRE : la difficulté de chaque question est calibrée probabilistiquement, et le test s'ajuste en temps réel au niveau estimé du candidat.
-- **Les réseaux bayésiens** (notebooks 4, 7) fondent les systèmes d'aide au diagnostic médical (de QMR-DT aux outils modernes) et le filtrage anti-spam : ils propagent l'incertitude entre symptômes, causes et observations.
-- **LDA / topic models** (notebook 9) structurent automatiquement de grands corpus — découverte de thématiques dans des archives de presse, cartographie de la littérature scientifique, analyse de tickets support.
-- **Les HMM** (notebook 11) détectent les régimes cachés : phases de marche en finance, reconnaissance de la parole, segmentation de séquences biologiques.
-- **Les systèmes de recommandation bayésiens** (notebook 12) sont la version « avec barre d'incertitude » du collaborative filtering de Netflix ou Amazon — utile pour décider quand explorer un nouvel item plutôt que d'exploiter une préférence connue.
-- **Le crowdsourcing** (notebook 10) modélise la fiabilité de chaque annotateur (Mechanical Turk, labellisation de datasets) pour reconstruire la vérité terrain malgré des votes bruités.
+- **TrueSkill** (notebook 8) est l'algorithme que Microsoft utilise pour apparier des millions de joueurs sur Xbox Live : il maintient pour chaque joueur une compétence *gaussienne* (moyenne + incertitude) mise à jour après chaque partie, généralisant l'Elo des échecs aux jeux en équipe.
+- **Item Response Theory** (notebook 7) est le moteur des tests adaptatifs comme le GMAT ou le GRE : la difficulté de chaque question est calibrée probabilistiquement, et le test s'ajuste en temps réel au niveau estimé du candidat.
+- **Les réseaux bayésiens** (notebooks 4, 9) fondent les systèmes d'aide au diagnostic médical (de QMR-DT aux outils modernes) et le filtrage anti-spam : ils propagent l'incertitude entre symptômes, causes et observations.
+- **LDA / topic models** (notebook 11) structurent automatiquement de grands corpus — découverte de thématiques dans des archives de presse, cartographie de la littérature scientifique, analyse de tickets support.
+- **Les HMM** (notebook 14) détectent les régimes cachés : phases de marche en finance, reconnaissance de la parole, segmentation de séquences biologiques.
+- **Les systèmes de recommandation bayésiens** (notebook 15) sont la version « avec barre d'incertitude » du collaborative filtering de Netflix ou Amazon — utile pour décider quand explorer un nouvel item plutôt que d'exploiter une préférence connue.
+- **Le crowdsourcing** (notebook 13) modélise la fiabilité de chaque annotateur (Mechanical Turk, labellisation de datasets) pour reconstruire la vérité terrain malgré des votes bruités.
 - **La théorie de la décision et les MDPs** (arc [`DecisionTheory/`](DecisionTheory/)) relient la série au contrôle séquentiel : gestion de stocks, maintenance prédictive, et passerelle directe vers le [reinforcement learning](../RL/).
 
 ## Installation


### PR DESCRIPTION
## Summary

Le README **top-level** `MyIA.AI.Notebooks/Probas/README.md` était en contradiction interne après le renum Infer PR-3 (#5807, cycle 5→7→9→11→14 — le même renum dont j'ai livré le seed CSV #5846). Sa table « Parcours inférence comparée » (Infer.NET vs PyMC) portait **déjà** la numérotation courante, mais trois autres sections gardaient les **anciens** numéros pré-#5807.

**Scope : ce fichier uniquement** (`Probas/Infer/README.md` est un fichier distinct, déjà cohérent — vérifié firsthand). Le sous-README `Probas/Infer/` n'est pas touché.

## Drift corrigé (pure renumérotation — descriptions verbatim, zéro perte de contenu)

Vérifié contre la réalité `git ls-tree origin/main MyIA.AI.Notebooks/Probas/Infer/`, PAS contre une source secondaire :

| Section | Avant (stale) | Après (roster réel) |
|---------|---------------|---------------------|
| Table « Ce que chaque notebook apporte » (l.224-237) | 5=Skills, 6=TrueSkill, 7=Classification, 8=Model-Sel, 9=Topic, 10=Crowdsourcing, 11=Séquences, 13=Debugging, 14=Causal | 5=Causal, 6=Debugging, 7=Skills, 8=TrueSkill, 9=Classification, 10=Model-Sel, 11=Topic, 13=Crowdsourcing, 14=Séquences |
| Table « Domaines d'application » (l.446, 451) | Infer-6 (TrueSkill), Infer-10 (crowdsourcing) | Infer-8, Infer-13 |
| Prose « Exemples concrets » (l.457-463) | notebooks 6, 5, 7, 9, 11, 12, 10 | 8, 7, 9, 11, 14, 15, 13 |

Les lignes **déjà correctes** (comparée table entière ; Éducation Infer-7 ; NLP Infer-11 ; Médecine Infer-4/9/17/18/19 ; Finance Infer-14) sont **inchangées**.

## Vérification (G.1 firsthand)

- **Table apporte 5-14 alignée exactement** au roster `origin/main` (10/10 lignes rechecked file-par-file).
- `git diff --stat` = **18 insertions / 18 deletions, 1 fichier** = pure renumérotation, aucun net add/remove, aucune description modifiée.
- `COURSE_CATALOG.generated.*` **byte-identical** (git diff vide), marqueurs `CATALOG-STATUS` inchangés.
- 0 secret (renum de références textuelles uniquement).
- Aucune référence stale résiduelle (grep des anciens numéros = 0).

Méthode : audit délégué (`Agent(model:"sonnet")` + `readme-hierarchy-auditor`, read-only) pour localiser la dérive à travers mes familles #3974, puis **re-vérification firsthand** de chaque numéro avant édition (angle mort connu des sous-agents = nombres-à-l'œil, cf model-delegation). Jugement éditorial gardé.

See #3974. Part of #3973. Atomique (1 fichier, sujet unique = resync numérotation Infer post-renum).