### PR TITLE
fix(genai-audio): 02-9 AceStep — .env-loader #3801 + vraie exec GPU end-to-end (Closes #5842)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "ad29238d",
    "metadata": {},
    "source": [
     "# Ace-Step v1.5 - Generation Musicale avec Paroles\n",
@@ -31,7 +32,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "5dc5d9a2",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:10:17.358550Z",
+     "iopub.status.busy": "2026-07-09T22:10:17.358002Z",
+     "iopub.status.idle": "2026-07-09T22:10:17.375414Z",
+     "shell.execute_reply": "2026-07-09T22:10:17.373787Z"
+    },
     "tags": [
      "parameters"
     ]
@@ -49,7 +57,7 @@
     "model_checkpoint = None            # None = auto-download depuis HuggingFace\n",
     "audio_duration = 30.0              # Duree de generation (secondes)\n",
     "device = \"cuda\"                    # \"cuda\" ou \"cpu\"\n",
-    "cpu_offload = True                 # Offload CPU pour <4 GB VRAM\n",
+    "cpu_offload = False                # Offload CPU (activer pour <4 GB VRAM)\n",
     "dtype = \"bfloat16\"                 # Precision (bfloat16 ou float16)\n",
     "infer_step = 60                    # Etapes d'inference (qualite vs vitesse)\n",
     "guidance_scale = 15.0              # Fidelite au prompt\n",
@@ -66,6 +74,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b31fb02b",
    "metadata": {},
    "source": [
     "### Parametres Papermill et configuration\n",
@@ -91,7 +100,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "75916dac",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:10:17.382932Z",
+     "iopub.status.busy": "2026-07-09T22:10:17.381920Z",
+     "iopub.status.idle": "2026-07-09T22:10:17.389345Z",
+     "shell.execute_reply": "2026-07-09T22:10:17.387739Z"
+    },
     "tags": [
      "parameters"
     ]
@@ -104,6 +120,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "88e8e609",
    "metadata": {},
    "source": [
     "Les parametres Papermill configurent le modele ACE-Step (checkpoint, precision, offload), la duree de generation, et les parametres de sampling (guidance_scale, infer_step, cfg_type). La cellule suivante configure l'environnement et verifie la VRAM disponible."
@@ -111,6 +128,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "37f2958e",
    "metadata": {},
    "source": [
     "## Introduction a ACE-Step v1.5\n",
@@ -155,10 +173,54 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
+   "id": "296c7320",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:10:17.395539Z",
+     "iopub.status.busy": "2026-07-09T22:10:17.395005Z",
+     "iopub.status.idle": "2026-07-09T22:10:40.757367Z",
+     "shell.execute_reply": "2026-07-09T22:10:40.754401Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Helpers audio importes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GPU : NVIDIA GeForce RTX 3090 (24.0 GB VRAM)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ACE-Step importe avec succes\n",
+      "\n",
+      "ACE-Step v1.5 - Generation Musicale avec Paroles\n",
+      "Date : 2026-07-10 00:10:40\n",
+      "Mode : interactive, Device : cuda\n",
+      "Duree : 30.0s, Infer steps : 60\n",
+      "Guidance scale : 15.0, CFG type : apg\n",
+      "CPU offload : False, Seed : 42\n",
+      "Sortie : outputs/audio/acestep\n"
+     ]
+    }
+   ],
    "source": [
     "# Setup environnement et imports\n",
+    "import warnings\n",
+    "# Bruit de warnings tiers (prefixes = chemins site-packages) : filtrage cible\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Failed to find CUDA.*\")\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning, module=\"torch.nn.utils.weight_norm\")\n",
+    "warnings.filterwarnings(\"ignore\", message=\".*TorchCodec AudioEncoder.*\")\n",
+    "\n",
     "import os\n",
     "import sys\n",
     "import json\n",
@@ -214,6 +276,10 @@
     "try:\n",
     "    from acestep.pipeline_ace_step import ACEStepPipeline\n",
     "    acestep_loaded = True\n",
+    "    # Logs ACE-Step (loguru) : INFO logge des chemins machine -> WARNING\n",
+    "    from loguru import logger as _acestep_logger\n",
+    "    _acestep_logger.remove()\n",
+    "    _acestep_logger.add(sys.stderr, level=\"WARNING\")\n",
     "    print(\"ACE-Step importe avec succes\")\n",
     "except ImportError:\n",
     "    print(\"ACE-Step non installe. Tentative d'installation...\")\n",
@@ -240,11 +306,12 @@
     "print(f\"Duree : {audio_duration}s, Infer steps : {infer_step}\")\n",
     "print(f\"Guidance scale : {guidance_scale}, CFG type : {cfg_type}\")\n",
     "print(f\"CPU offload : {cpu_offload}, Seed : {seed}\")\n",
-    "print(f\"Sortie : {OUTPUT_DIR}\")"
+    "print(f\"Sortie : {OUTPUT_DIR.relative_to(GENAI_ROOT).as_posix()}\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "52e15f65",
    "metadata": {},
    "source": [
     "### Interpretation : Configuration de l'environnement\n",
@@ -266,6 +333,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6b760b35",
    "metadata": {},
    "source": [
     "L'environnement est pret. La cellule suivante charge le fichier `.env` afin de recuperer le token HuggingFace necessaire pour telecharger les poids du modele depuis le Hub."
@@ -274,51 +342,21 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "id": "ce17b94d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:10:40.760993Z",
+     "iopub.status.busy": "2026-07-09T22:10:40.760993Z",
+     "iopub.status.idle": "2026-07-09T22:10:40.805362Z",
+     "shell.execute_reply": "2026-07-09T22:10:40.803839Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GPU : NVIDIA GeForce RTX 3090 (24.0 GB VRAM)\n",
-      "ACE-Step non installe. Tentative d'installation...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Installation echouee : WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "  Running command git clone --filter=blob:none --quiet https://github.com/ace-step/ACE-Step.git 'C:\\Users\\jsboi\\AppData\\L\n"
-     ]
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "**Installation manuelle requise** :\n",
-       "```bash\n",
-       "pip install git+https://github.com/ace-step/ACE-Step.git\n",
-       "```"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "ACE-Step v1.5 - Generation Musicale avec Paroles\n",
-      "Date : 2026-05-26 19:05:02\n",
-      "Mode : interactive, Device : cuda\n",
-      "Duree : 30.0s, Infer steps : 60\n",
-      "Guidance scale : 15.0, CFG type : apg\n",
-      "CPU offload : True, Seed : 42\n",
-      "Sortie : D:\\outputs\\audio\\acestep\n"
+      ".env charge depuis: GenAI/.env\n"
      ]
     }
    ],
@@ -333,18 +371,19 @@
     "    env_path = current_path / \".env\"\n",
     "    if env_path.exists():\n",
     "        load_dotenv(env_path)\n",
-    "        print(f\".env charge depuis: {env_path}\")\n",
+    "        print(f\".env charge depuis: {env_path.parent.name}/{env_path.name}\")\n",
     "        env_loaded = True\n",
     "        break\n",
-    "    current_path = current_path.parent\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
     "        break\n",
+    "    current_path = current_path.parent\n",
     "if not env_loaded:\n",
     "    print(\"WARNING: .env non trouve, utilisation variables environnement\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "fd556025",
    "metadata": {},
    "source": [
     "## Dependances GPU Optionnelles\n",
@@ -360,6 +399,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7b562e7a",
    "metadata": {},
    "source": [
     "## Section 1 : Architecture d'ACE-Step et chargement du modele\n",
@@ -389,13 +429,27 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "id": "c477ad29",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:10:40.810071Z",
+     "iopub.status.busy": "2026-07-09T22:10:40.808188Z",
+     "iopub.status.idle": "2026-07-09T22:10:40.826003Z",
+     "shell.execute_reply": "2026-07-09T22:10:40.823240Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING: .env non trouve, utilisation variables environnement\n"
+      "CHARGEMENT DU MODELE ACE-STEP v1.5\n",
+      "==================================================\n",
+      "Configuration : dtype=bfloat16, cpu_offload=False\n",
+      "(Premier lancement : telechargement du modele depuis HuggingFace)\n",
+      "Modele charge en 0.0s\n",
+      "CPU offload : Desactive\n",
+      "VRAM utilisee : 0.00 GB\n"
      ]
     }
    ],
@@ -440,6 +494,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cbb4bb3d",
    "metadata": {},
    "source": [
     "### Interpretation : Chargement du modele\n",
@@ -467,6 +522,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "613eba9b",
    "metadata": {},
    "source": [
     "## Section 2 : Generation text-to-song\n",
@@ -498,26 +554,1889 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "id": "fdb199d6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:10:40.830930Z",
+     "iopub.status.busy": "2026-07-09T22:10:40.829223Z",
+     "iopub.status.idle": "2026-07-09T22:12:33.434291Z",
+     "shell.execute_reply": "2026-07-09T22:12:33.431696Z"
+    }
+   },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:10:40.857\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36m__call__\u001b[0m:\u001b[36m1493\u001b[0m - \u001b[33m\u001b[1mCheckpoint not loaded, loading checkpoint...\u001b[0m\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CHARGEMENT DU MODELE ACE-STEP v1.5\n",
+      "GENERATION TEXT-TO-SONG\n",
       "==================================================\n",
-      "ACE-Step non disponible - mode demonstration\n",
-      "Pour installer : pip install git+https://github.com/ace-step/ACE-Step.git\n",
       "\n",
-      "Le notebook continuera en affichant les parametres et configurations\n",
-      "sans generation audio reelle.\n"
+      "--- Morceau 1 : Chanson francaise ---\n",
+      "Prompt : pop, chanson francaise, piano, melodique, tendre\n",
+      "Paroles : [verse]\n",
+      "Sous le ciel de Paris, les nuages s'envolent\n",
+      "Les reves se melent au vent...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "031c013a9a8847239d77e38a5c7fe68b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching 14 files:   0%|          | 0/14 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:40,  1.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:26,  2.23it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:01<00:21,  2.70it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:01<00:18,  3.01it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:17,  3.07it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:02<00:18,  2.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:02<00:17,  3.07it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:02<00:15,  3.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:02<00:13,  3.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:03<00:12,  4.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:03<00:10,  4.59it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:03<00:12,  3.98it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:03<00:12,  3.87it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:04<00:11,  3.99it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:04<00:11,  3.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:04<00:14,  3.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:05<00:15,  2.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:05<00:17,  2.37it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:06<00:20,  2.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:07<00:19,  2.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:07<00:21,  1.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:08<00:22,  1.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:08<00:21,  1.70it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:09<00:19,  1.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:10<00:19,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:10<00:19,  1.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:11<00:19,  1.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:11<00:17,  1.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:12<00:17,  1.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:13<00:18,  1.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:13<00:16,  1.73it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:13<00:15,  1.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:14<00:13,  1.99it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:14<00:13,  1.91it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:15<00:14,  1.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:16<00:12,  1.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:16<00:11,  2.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:16<00:10,  2.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:17<00:12,  1.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:18<00:12,  1.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:19<00:11,  1.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:19<00:11,  1.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:20<00:11,  1.44it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:21<00:09,  1.61it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:21<00:09,  1.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:21<00:06,  2.01it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:22<00:05,  2.24it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:22<00:05,  2.30it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:22<00:04,  2.58it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:23<00:03,  2.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:23<00:02,  3.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:23<00:02,  3.14it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:23<00:02,  3.21it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:24<00:01,  3.33it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:24<00:01,  3.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:24<00:01,  3.34it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:25<00:00,  3.58it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:25<00:00,  3.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:25<00:00,  3.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  3.03it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  2.30it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:11:37.199\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  1.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00,  1.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Duree : 29.9s | Temps : 57.38s\n",
+      "  Ratio temps reel : 0.52x\n",
+      "  Sample rate : 48000 Hz\n",
+      "  Sauvegarde : acestep_1_Chanson_francaise.wav\n",
+      "\n",
+      "--- Morceau 2 : Electronic upbeat ---\n",
+      "Prompt : electronic, upbeat, synthesizer, dance, energetic\n",
+      "Paroles : [intro]\n",
+      "\n",
+      "[verse]\n",
+      "Neon lights flash across the floor\n",
+      "Bass is pumping, craving mor...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:24,  2.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:25,  2.24it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:01<00:22,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:01<00:21,  2.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:19,  2.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:02<00:18,  2.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:02<00:17,  2.95it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:02<00:17,  2.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:03<00:15,  3.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:03<00:13,  3.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:03<00:12,  3.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:03<00:12,  3.98it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:04<00:12,  3.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:04<00:12,  3.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:04<00:12,  3.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:05<00:18,  2.40it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:05<00:19,  2.21it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:06<00:19,  2.19it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:07<00:23,  1.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:08<00:26,  1.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:08<00:26,  1.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:09<00:25,  1.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:10<00:23,  1.55it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:10<00:20,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:10<00:18,  1.87it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:11<00:18,  1.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:11<00:17,  1.87it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:12<00:15,  2.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:12<00:14,  2.19it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:13<00:14,  2.01it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:13<00:14,  2.02it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:14<00:12,  2.19it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:14<00:12,  2.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:15<00:11,  2.27it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:15<00:11,  2.16it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:16<00:11,  2.13it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:16<00:12,  1.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:17<00:13,  1.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:18<00:14,  1.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:19<00:14,  1.42it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:19<00:12,  1.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:20<00:11,  1.59it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:20<00:11,  1.54it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:21<00:09,  1.61it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:22<00:09,  1.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:22<00:07,  1.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:22<00:06,  2.07it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:23<00:05,  2.29it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:23<00:04,  2.69it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:23<00:03,  3.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:23<00:02,  3.27it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:24<00:02,  3.39it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:24<00:02,  3.31it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:24<00:01,  3.33it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:25<00:01,  3.18it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:25<00:01,  3.31it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:25<00:00,  3.75it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:25<00:00,  3.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:25<00:00,  4.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  4.29it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  2.29it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:12:05.387\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 19.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Duree : 29.9s | Temps : 27.64s\n",
+      "  Ratio temps reel : 1.08x\n",
+      "  Sample rate : 48000 Hz\n",
+      "  Sauvegarde : acestep_2_Electronic_upbeat.wav\n",
+      "\n",
+      "--- Morceau 3 : Jazz vocal ---\n",
+      "Prompt : jazz, smooth, saxophone, piano, warm vocals\n",
+      "Paroles : [verse]\n",
+      "Smoke curls up from the corner bar\n",
+      "A saxophone wails beneath the stars\n",
+      "W...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:12,  4.80it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:14,  3.93it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:00<00:14,  4.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:01<00:15,  3.58it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:20,  2.65it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:01<00:19,  2.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:02<00:18,  2.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:02<00:16,  3.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:02<00:15,  3.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:03<00:15,  3.28it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:03<00:14,  3.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:03<00:15,  3.03it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:04<00:16,  2.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:04<00:15,  2.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:04<00:14,  3.14it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:05<00:16,  2.61it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:05<00:18,  2.30it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:06<00:19,  2.14it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:06<00:19,  2.07it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:07<00:17,  2.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:07<00:17,  2.22it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:08<00:18,  2.08it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:09<00:21,  1.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:09<00:21,  1.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:10<00:21,  1.60it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:10<00:20,  1.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:11<00:19,  1.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:12<00:19,  1.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:12<00:17,  1.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:13<00:16,  1.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:13<00:16,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:14<00:14,  1.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:14<00:14,  1.91it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:15<00:13,  1.95it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:15<00:13,  1.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:16<00:12,  1.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:16<00:12,  1.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:17<00:12,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:18<00:11,  1.76it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:18<00:10,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:19<00:11,  1.65it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:19<00:11,  1.59it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:20<00:09,  1.73it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:20<00:08,  1.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:21<00:09,  1.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:21<00:07,  1.97it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:22<00:05,  2.21it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:22<00:04,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:22<00:03,  2.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:22<00:03,  3.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:23<00:02,  3.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:23<00:02,  3.40it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:23<00:02,  3.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:24<00:01,  3.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:24<00:01,  3.39it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:24<00:01,  3.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:24<00:00,  4.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:25<00:00,  4.40it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:25<00:00,  4.20it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:25<00:00,  3.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:25<00:00,  2.34it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:12:32.851\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 28.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Duree : 29.9s | Temps : 27.35s\n",
+      "  Ratio temps reel : 1.09x\n",
+      "  Sample rate : 48000 Hz\n",
+      "  Sauvegarde : acestep_3_Jazz_vocal.wav\n",
+      "\n",
+      "Recapitulatif des generations :\n",
+      "Morceau      Style                Duree (s)    Temps gen (s)  \n",
+      "------------------------------------------------------------\n",
+      "morceau_1    Chanson francaise    29.9         57.38          \n",
+      "morceau_2    Electronic upbeat    29.9         27.64          \n",
+      "morceau_3    Jazz vocal           29.9         27.35          \n"
      ]
     }
    ],
-   "source": "# Generation text-to-song : 3 exemples de styles differents\nprint(\"GENERATION TEXT-TO-SONG\")\nprint(\"=\" * 50)\n\nsong_examples = [\n    {\n        \"name\": \"Chanson francaise\",\n        \"prompt\": \"pop, chanson francaise, piano, melodique, tendre\",\n        \"lyrics\": (\n            \"[verse]\\n\"\n            \"Sous le ciel de Paris, les nuages s'envolent\\n\"\n            \"Les reves se melent au vent du matin\\n\"\n            \"Une melodie douce comme une parole\\n\"\n            \"Guide mes pas sur ce chemin\\n\"\n            \"\\n\"\n            \"[chorus]\\n\"\n            \"Et la musique berce mes pensees\\n\"\n            \"Dans cette ville de lumiere et de beaute\\n\"\n            \"Les notes dansent comme des etoiles\\n\"\n            \"Sur les toits, la nuit s'envole\"\n        ),\n    },\n    {\n        \"name\": \"Electronic upbeat\",\n        \"prompt\": \"electronic, upbeat, synthesizer, dance, energetic\",\n        \"lyrics\": (\n            \"[intro]\\n\"\n            \"\\n\"\n            \"[verse]\\n\"\n            \"Neon lights flash across the floor\\n\"\n            \"Bass is pumping, craving more\\n\"\n            \"Digital heartbeat in the air\\n\"\n            \"Lose yourself without a care\\n\"\n            \"\\n\"\n            \"[chorus]\\n\"\n            \"We are the sound, we are the night\\n\"\n            \"Synthesizer taking flight\\n\"\n            \"Feel the rhythm in your soul\\n\"\n            \"Let the music take control\"\n        ),\n    },\n    {\n        \"name\": \"Jazz vocal\",\n        \"prompt\": \"jazz, smooth, saxophone, piano, warm vocals\",\n        \"lyrics\": (\n            \"[verse]\\n\"\n            \"Smoke curls up from the corner bar\\n\"\n            \"A saxophone wails beneath the stars\\n\"\n            \"Whiskey on ice and a velvet tone\\n\"\n            \"Playing for lovers who dance alone\\n\"\n            \"\\n\"\n            \"[chorus]\\n\"\n            \"Midnight blue and a mellow groove\\n\"\n            \"Nothing to lose, nothing to prove\\n\"\n            \"Just the piano and a softly sung line\\n\"\n            \"In this jazz club where time unwinds\"\n        ),\n    },\n]\n\ngeneration_results = {}\n\nif pipeline is not None and generate_audio:\n    for i, song in enumerate(song_examples):\n        print(f\"\\n--- Morceau {i+1} : {song['name']} ---\")\n        print(f\"Prompt : {song['prompt']}\")\n        print(f\"Paroles : {song['lyrics'][:80]}...\")\n\n        try:\n            seed_str = str(seed) if seed >= 0 else \"\"\n            start_time = time.time()\n\n            result = pipeline(\n                audio_duration=audio_duration,\n                prompt=song[\"prompt\"],\n                lyrics=song[\"lyrics\"],\n                infer_step=infer_step,\n                guidance_scale=guidance_scale,\n                scheduler_type=scheduler_type,\n                cfg_type=cfg_type,\n                omega_scale=omega_scale,\n                manual_seeds=seed_str,\n                guidance_interval=0.5,\n                guidance_interval_decay=0,\n                min_guidance_scale=3,\n                use_erg_tag=True,\n                use_erg_lyric=True,\n                use_erg_diffusion=True,\n                oss_steps=\"\",\n                guidance_scale_text=0.0,\n                guidance_scale_lyric=0.0,\n            )\n            gen_time = time.time() - start_time\n\n            # Le resultat est un chemin de fichier WAV\n            if isinstance(result, str) and os.path.exists(result):\n                import soundfile as sf\n                audio_data, sr = sf.read(result)\n                duration = len(audio_data) / sr\n\n                generation_results[f\"morceau_{i+1}\"] = {\n                    \"name\": song[\"name\"],\n                    \"prompt\": song[\"prompt\"],\n                    \"duration\": duration,\n                    \"gen_time\": gen_time,\n                    \"sample_rate\": sr,\n                    \"file\": result,\n                }\n\n                print(f\"  Duree : {duration:.1f}s | Temps : {gen_time:.2f}s\")\n                print(f\"  Ratio temps reel : {duration / gen_time:.2f}x\")\n                print(f\"  Sample rate : {sr} Hz\")\n\n                # Lecture audio (desactivee en mode batch)\n                if BATCH_MODE != \"true\":\n                    display(Audio(data=audio_data.T if audio_data.ndim > 1 else audio_data, rate=sr))\n\n                # Sauvegarde optionnelle\n                if save_results:\n                    save_path = OUTPUT_DIR / f\"acestep_{i+1}_{song['name'].replace(' ', '_')}.wav\"\n                    sf.write(str(save_path), audio_data, sr)\n                    print(f\"  Sauvegarde : {save_path.name}\")\n\n            elif isinstance(result, tuple):\n                # Certains pipelines retournent (audio, sr)\n                audio_data, sr = result\n                if isinstance(audio_data, np.ndarray):\n                    duration = audio_data.shape[-1] / sr\n                else:\n                    import torch as _torch\n                    if isinstance(audio_data, _torch.Tensor):\n                        audio_data = audio_data.cpu().numpy()\n                    duration = audio_data.shape[-1] / sr\n\n                generation_results[f\"morceau_{i+1}\"] = {\n                    \"name\": song[\"name\"],\n                    \"prompt\": song[\"prompt\"],\n                    \"duration\": duration,\n                    \"gen_time\": gen_time,\n                    \"sample_rate\": sr,\n                }\n\n                print(f\"  Duree : {duration:.1f}s | Temps : {gen_time:.2f}s\")\n                print(f\"  Ratio temps reel : {duration / gen_time:.2f}x\")\n\n                if BATCH_MODE != \"true\":\n                    display(Audio(data=audio_data, rate=sr))\n\n            else:\n                print(f\"  Format de resultat inattendu : {type(result)}\")\n\n        except Exception as e:\n            print(f\"  Erreur : {type(e).__name__} - {str(e)[:200]}\")\n            display(Markdown(f\"**Erreur de generation** : `{type(e).__name__}` - Verifiez la VRAM disponible et les parametres.\"))\n\n    # Recapitulatif\n    if generation_results:\n        print(f\"\\nRecapitulatif des generations :\")\n        print(f\"{'Morceau':<12} {'Style':<20} {'Duree (s)':<12} {'Temps gen (s)':<15}\")\n        print(\"-\" * 60)\n        for name, data in generation_results.items():\n            print(f\"{name:<12} {data['name']:<20} {data['duration']:<12.1f} {data['gen_time']:<15.2f}\")\nelse:\n    print(\"Modele non charge ou generation desactivee\")\n    print(\"\\nExemples qui auraient ete generes :\")\n    for i, song in enumerate(song_examples):\n        print(f\"  {i+1}. {song['name']} : {song['prompt']}\")\n    print(\"\\nInstallation : pip install git+https://github.com/ace-step/ACE-Step.git\")"
+   "source": [
+    "# Generation text-to-song : 3 exemples de styles differents\n",
+    "print(\"GENERATION TEXT-TO-SONG\")\n",
+    "print(\"=\" * 50)\n",
+    "\n",
+    "song_examples = [\n",
+    "    {\n",
+    "        \"name\": \"Chanson francaise\",\n",
+    "        \"prompt\": \"pop, chanson francaise, piano, melodique, tendre\",\n",
+    "        \"lyrics\": (\n",
+    "            \"[verse]\\n\"\n",
+    "            \"Sous le ciel de Paris, les nuages s'envolent\\n\"\n",
+    "            \"Les reves se melent au vent du matin\\n\"\n",
+    "            \"Une melodie douce comme une parole\\n\"\n",
+    "            \"Guide mes pas sur ce chemin\\n\"\n",
+    "            \"\\n\"\n",
+    "            \"[chorus]\\n\"\n",
+    "            \"Et la musique berce mes pensees\\n\"\n",
+    "            \"Dans cette ville de lumiere et de beaute\\n\"\n",
+    "            \"Les notes dansent comme des etoiles\\n\"\n",
+    "            \"Sur les toits, la nuit s'envole\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"name\": \"Electronic upbeat\",\n",
+    "        \"prompt\": \"electronic, upbeat, synthesizer, dance, energetic\",\n",
+    "        \"lyrics\": (\n",
+    "            \"[intro]\\n\"\n",
+    "            \"\\n\"\n",
+    "            \"[verse]\\n\"\n",
+    "            \"Neon lights flash across the floor\\n\"\n",
+    "            \"Bass is pumping, craving more\\n\"\n",
+    "            \"Digital heartbeat in the air\\n\"\n",
+    "            \"Lose yourself without a care\\n\"\n",
+    "            \"\\n\"\n",
+    "            \"[chorus]\\n\"\n",
+    "            \"We are the sound, we are the night\\n\"\n",
+    "            \"Synthesizer taking flight\\n\"\n",
+    "            \"Feel the rhythm in your soul\\n\"\n",
+    "            \"Let the music take control\"\n",
+    "        ),\n",
+    "    },\n",
+    "    {\n",
+    "        \"name\": \"Jazz vocal\",\n",
+    "        \"prompt\": \"jazz, smooth, saxophone, piano, warm vocals\",\n",
+    "        \"lyrics\": (\n",
+    "            \"[verse]\\n\"\n",
+    "            \"Smoke curls up from the corner bar\\n\"\n",
+    "            \"A saxophone wails beneath the stars\\n\"\n",
+    "            \"Whiskey on ice and a velvet tone\\n\"\n",
+    "            \"Playing for lovers who dance alone\\n\"\n",
+    "            \"\\n\"\n",
+    "            \"[chorus]\\n\"\n",
+    "            \"Midnight blue and a mellow groove\\n\"\n",
+    "            \"Nothing to lose, nothing to prove\\n\"\n",
+    "            \"Just the piano and a softly sung line\\n\"\n",
+    "            \"In this jazz club where time unwinds\"\n",
+    "        ),\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "generation_results = {}\n",
+    "\n",
+    "if pipeline is not None and generate_audio:\n",
+    "    for i, song in enumerate(song_examples):\n",
+    "        print(f\"\\n--- Morceau {i+1} : {song['name']} ---\")\n",
+    "        print(f\"Prompt : {song['prompt']}\")\n",
+    "        print(f\"Paroles : {song['lyrics'][:80]}...\")\n",
+    "\n",
+    "        try:\n",
+    "            seed_str = str(seed) if seed >= 0 else \"\"\n",
+    "            start_time = time.time()\n",
+    "\n",
+    "            result = pipeline(\n",
+    "                audio_duration=audio_duration,\n",
+    "                prompt=song[\"prompt\"],\n",
+    "                lyrics=song[\"lyrics\"],\n",
+    "                infer_step=infer_step,\n",
+    "                guidance_scale=guidance_scale,\n",
+    "                scheduler_type=scheduler_type,\n",
+    "                cfg_type=cfg_type,\n",
+    "                omega_scale=omega_scale,\n",
+    "                manual_seeds=seed_str,\n",
+    "                guidance_interval=0.5,\n",
+    "                guidance_interval_decay=0,\n",
+    "                min_guidance_scale=3,\n",
+    "                use_erg_tag=True,\n",
+    "                use_erg_lyric=True,\n",
+    "                use_erg_diffusion=True,\n",
+    "                oss_steps=\"\",\n",
+    "                guidance_scale_text=0.0,\n",
+    "                guidance_scale_lyric=0.0,\n",
+    "            )\n",
+    "            gen_time = time.time() - start_time\n",
+    "\n",
+    "            # Le resultat est un chemin de fichier WAV\n",
+    "            # ACE-Step v1.5 retourne [chemin_wav, params_dict]\n",
+    "            if isinstance(result, list) and result and isinstance(result[0], str):\n",
+    "                result = result[0]\n",
+    "\n",
+    "            if isinstance(result, str) and os.path.exists(result):\n",
+    "                import soundfile as sf\n",
+    "                audio_data, sr = sf.read(result)\n",
+    "                duration = len(audio_data) / sr\n",
+    "\n",
+    "                generation_results[f\"morceau_{i+1}\"] = {\n",
+    "                    \"name\": song[\"name\"],\n",
+    "                    \"prompt\": song[\"prompt\"],\n",
+    "                    \"duration\": duration,\n",
+    "                    \"gen_time\": gen_time,\n",
+    "                    \"sample_rate\": sr,\n",
+    "                    \"file\": result,\n",
+    "                }\n",
+    "\n",
+    "                print(f\"  Duree : {duration:.1f}s | Temps : {gen_time:.2f}s\")\n",
+    "                print(f\"  Ratio temps reel : {duration / gen_time:.2f}x\")\n",
+    "                print(f\"  Sample rate : {sr} Hz\")\n",
+    "\n",
+    "                # Lecture audio (desactivee en mode batch)\n",
+    "                if BATCH_MODE != \"true\":\n",
+    "                    display(Audio(data=audio_data.T if audio_data.ndim > 1 else audio_data, rate=sr))\n",
+    "\n",
+    "                # Sauvegarde optionnelle\n",
+    "                if save_results:\n",
+    "                    save_path = OUTPUT_DIR / f\"acestep_{i+1}_{song['name'].replace(' ', '_')}.wav\"\n",
+    "                    sf.write(str(save_path), audio_data, sr)\n",
+    "                    print(f\"  Sauvegarde : {save_path.name}\")\n",
+    "\n",
+    "            elif isinstance(result, tuple):\n",
+    "                # Certains pipelines retournent (audio, sr)\n",
+    "                audio_data, sr = result\n",
+    "                if isinstance(audio_data, np.ndarray):\n",
+    "                    duration = audio_data.shape[-1] / sr\n",
+    "                else:\n",
+    "                    import torch as _torch\n",
+    "                    if isinstance(audio_data, _torch.Tensor):\n",
+    "                        audio_data = audio_data.cpu().numpy()\n",
+    "                    duration = audio_data.shape[-1] / sr\n",
+    "\n",
+    "                generation_results[f\"morceau_{i+1}\"] = {\n",
+    "                    \"name\": song[\"name\"],\n",
+    "                    \"prompt\": song[\"prompt\"],\n",
+    "                    \"duration\": duration,\n",
+    "                    \"gen_time\": gen_time,\n",
+    "                    \"sample_rate\": sr,\n",
+    "                }\n",
+    "\n",
+    "                print(f\"  Duree : {duration:.1f}s | Temps : {gen_time:.2f}s\")\n",
+    "                print(f\"  Ratio temps reel : {duration / gen_time:.2f}x\")\n",
+    "\n",
+    "                if BATCH_MODE != \"true\":\n",
+    "                    display(Audio(data=audio_data, rate=sr))\n",
+    "\n",
+    "            else:\n",
+    "                print(f\"  Format de resultat inattendu : {type(result)}\")\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            print(f\"  Erreur : {type(e).__name__} - {str(e)[:200]}\")\n",
+    "            display(Markdown(f\"**Erreur de generation** : `{type(e).__name__}` - Verifiez la VRAM disponible et les parametres.\"))\n",
+    "\n",
+    "    # Recapitulatif\n",
+    "    if generation_results:\n",
+    "        print(f\"\\nRecapitulatif des generations :\")\n",
+    "        print(f\"{'Morceau':<12} {'Style':<20} {'Duree (s)':<12} {'Temps gen (s)':<15}\")\n",
+    "        print(\"-\" * 60)\n",
+    "        for name, data in generation_results.items():\n",
+    "            print(f\"{name:<12} {data['name']:<20} {data['duration']:<12.1f} {data['gen_time']:<15.2f}\")\n",
+    "else:\n",
+    "    print(\"Modele non charge ou generation desactivee\")\n",
+    "    print(\"\\nExemples qui auraient ete generes :\")\n",
+    "    for i, song in enumerate(song_examples):\n",
+    "        print(f\"  {i+1}. {song['name']} : {song['prompt']}\")\n",
+    "    print(\"\\nInstallation : pip install git+https://github.com/ace-step/ACE-Step.git\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1387a0df",
    "metadata": {},
    "source": [
     "### Interpretation : Generation text-to-song\n",
@@ -547,27 +2466,98 @@
   {
    "cell_type": "markdown",
    "id": "6850f00b",
-   "source": "### Exercice 1 : Creation de paroles structurees multilingues\n\n**Objectif** : Implementer une fonction qui genere des paroles structurees (avec tags `[verse]`, `[chorus`, `[bridge]`) dans une langue donnee, adaptees a un style musical precis.\n\nACE-Step supporte 50+ langues et utilise des tags de structure pour guider la generation. Le formatage des paroles (placement des tags, longueur des sections, coherence thematique) influence directement la qualite du resultat.\n\n**Indices** :\n- Les tags `[verse]` (narration), `[chorus]` (refrain), `[bridge]` (contraste) structurent le morceau\n- `[intro]` et `[outro]` sont generalement instrumentaux\n- Chaque section devrait contenir 2-6 lignes de texte\n- Le theme des paroles doit etre coherent avec le style musical decrit dans le prompt\n- # Etape 1 : Definir la structure (verse-chorus-verse-chorus ou autre)\n- # Etape 2 : Generer les paroles pour chaque section selon le theme et la langue\n- # Etape 3 : Assembler avec les tags de structure\n- # Etape 4 : Verifier la coherence thematique et la longueur\n- # Indice : Un refrain plus court et memorisable qu'un couplet donne de meilleurs resultats",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Creation de paroles structurees multilingues\n",
+    "\n",
+    "**Objectif** : Implementer une fonction qui genere des paroles structurees (avec tags `[verse]`, `[chorus`, `[bridge]`) dans une langue donnee, adaptees a un style musical precis.\n",
+    "\n",
+    "ACE-Step supporte 50+ langues et utilise des tags de structure pour guider la generation. Le formatage des paroles (placement des tags, longueur des sections, coherence thematique) influence directement la qualite du resultat.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Les tags `[verse]` (narration), `[chorus]` (refrain), `[bridge]` (contraste) structurent le morceau\n",
+    "- `[intro]` et `[outro]` sont generalement instrumentaux\n",
+    "- Chaque section devrait contenir 2-6 lignes de texte\n",
+    "- Le theme des paroles doit etre coherent avec le style musical decrit dans le prompt\n",
+    "- # Etape 1 : Definir la structure (verse-chorus-verse-chorus ou autre)\n",
+    "- # Etape 2 : Generer les paroles pour chaque section selon le theme et la langue\n",
+    "- # Etape 3 : Assembler avec les tags de structure\n",
+    "- # Etape 4 : Verifier la coherence thematique et la longueur\n",
+    "- # Indice : Un refrain plus court et memorisable qu'un couplet donne de meilleurs resultats"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "55bd59d8",
-   "source": "# Exercice 3 : Creation de paroles structurees multilingues\n# TODO etudiant : Creer des paroles structurees pour ACE-Step\n\ndef create_structured_lyrics(theme=\"liberte\", style=\"pop, piano, melancolique\",\n                            language=\"fr\", structure=None):\n    \"\"\"\n    Cree des paroles structurees avec tags ACE-Step pour un theme et style donnes.\n    \n    Args:\n        theme: Theme des paroles (\"amour\", \"voyage\", \"liberte\", \"nature\", etc.)\n        style: Description du style musical (tags separes par virgules)\n        language: Code langue (\"fr\", \"en\", \"es\", \"ja\", etc.)\n        structure: Liste de sections ex: [\"verse\", \"chorus\", \"verse\", \"chorus\"]\n                   Si None, utilise [\"verse\", \"chorus\", \"bridge\", \"chorus\"]\n    \n    Returns:\n        dict: {\"prompt\": str, \"lyrics\": str, \"theme\": str, \"language\": str}\n    \"\"\"\n    # TODO etudiant : Definir la structure par defaut\n    if structure is None:\n        structure = []  # TODO etudiant : structure par defaut\n    \n    # TODO etudiant : Ecrire les paroles pour chaque section\n    # Indice : Chaque section doit avoir 2-6 lignes coherentes avec le theme\n    sections = {}  # TODO etudiant : {\"verse\": [\"ligne1\", ...], \"chorus\": [...], ...}\n    \n    # TODO etudiant : Assembler les paroles avec les tags\n    # Indice : \"[verse]\\nligne1\\nligne2\\n\\n[chorus]\\nligne1\\n...\"\n    lyrics = None  # TODO etudiant\n    \n    return {\n        \"prompt\": style,\n        \"lyrics\": lyrics,\n        \"theme\": theme,\n        \"language\": language,\n    }\n\n# Test\nresult = create_structured_lyrics(theme=\"voyage\", style=\"folk, acoustic guitar, doux\", language=\"fr\")\nif result[\"lyrics\"]:\n    print(f\"Theme : {result['theme']} | Langue : {result['language']}\")\n    print(f\"Style : {result['prompt']}\")\n    print(f\"\\nParoles :\\n{result['lyrics']}\")\nelse:\n    print(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:12:33.440127Z",
+     "iopub.status.busy": "2026-07-09T22:12:33.440127Z",
+     "iopub.status.idle": "2026-07-09T22:12:33.453951Z",
+     "shell.execute_reply": "2026-07-09T22:12:33.450723Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 1 : Creation de paroles structurees multilingues\n",
+    "# TODO etudiant : Creer des paroles structurees pour ACE-Step\n",
+    "\n",
+    "def create_structured_lyrics(theme=\"liberte\", style=\"pop, piano, melancolique\",\n",
+    "                            language=\"fr\", structure=None):\n",
+    "    \"\"\"\n",
+    "    Cree des paroles structurees avec tags ACE-Step pour un theme et style donnes.\n",
+    "    \n",
+    "    Args:\n",
+    "        theme: Theme des paroles (\"amour\", \"voyage\", \"liberte\", \"nature\", etc.)\n",
+    "        style: Description du style musical (tags separes par virgules)\n",
+    "        language: Code langue (\"fr\", \"en\", \"es\", \"ja\", etc.)\n",
+    "        structure: Liste de sections ex: [\"verse\", \"chorus\", \"verse\", \"chorus\"]\n",
+    "                   Si None, utilise [\"verse\", \"chorus\", \"bridge\", \"chorus\"]\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict: {\"prompt\": str, \"lyrics\": str, \"theme\": str, \"language\": str}\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : Definir la structure par defaut\n",
+    "    if structure is None:\n",
+    "        structure = []  # TODO etudiant : structure par defaut\n",
+    "    \n",
+    "    # TODO etudiant : Ecrire les paroles pour chaque section\n",
+    "    # Indice : Chaque section doit avoir 2-6 lignes coherentes avec le theme\n",
+    "    sections = {}  # TODO etudiant : {\"verse\": [\"ligne1\", ...], \"chorus\": [...], ...}\n",
+    "    \n",
+    "    # TODO etudiant : Assembler les paroles avec les tags\n",
+    "    # Indice : \"[verse]\\nligne1\\nligne2\\n\\n[chorus]\\nligne1\\n...\"\n",
+    "    lyrics = None  # TODO etudiant\n",
+    "    \n",
+    "    return {\n",
+    "        \"prompt\": style,\n",
+    "        \"lyrics\": lyrics,\n",
+    "        \"theme\": theme,\n",
+    "        \"language\": language,\n",
+    "    }\n",
+    "\n",
+    "# Test\n",
+    "result = create_structured_lyrics(theme=\"voyage\", style=\"folk, acoustic guitar, doux\", language=\"fr\")\n",
+    "if result[\"lyrics\"]:\n",
+    "    print(f\"Theme : {result['theme']} | Langue : {result['language']}\")\n",
+    "    print(f\"Style : {result['prompt']}\")\n",
+    "    print(f\"\\nParoles :\\n{result['lyrics']}\")\n",
+    "else:\n",
+    "    print(\"Exercice a completer\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "151f65a7",
    "metadata": {},
    "source": [
     "## Section 3 : Exploration des parametres de generation\n",
@@ -592,30 +2582,2865 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 8,
+   "id": "5c5ce06b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:12:33.459546Z",
+     "iopub.status.busy": "2026-07-09T22:12:33.458447Z",
+     "iopub.status.idle": "2026-07-09T22:14:43.417267Z",
+     "shell.execute_reply": "2026-07-09T22:14:43.414575Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GENERATION TEXT-TO-SONG\n",
+      "TEST DES PARAMETRES DE GENERATION\n",
       "==================================================\n",
-      "Modele non charge ou generation desactivee\n",
+      "Prompt : pop, acoustic guitar, gentle, romantic\n",
+      "Duree : 30.0s\n",
       "\n",
-      "Exemples qui auraient ete generes :\n",
-      "  1. Chanson francaise : pop, chanson francaise, piano, melodique, tendre\n",
-      "  2. Electronic upbeat : electronic, upbeat, synthesizer, dance, energetic\n",
-      "  3. Jazz vocal : jazz, smooth, saxophone, piano, warm vocals\n",
+      "--- gs=5, steps=60 ---\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:18,  3.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:14,  4.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:00<00:13,  4.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:01<00:13,  4.09it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:18,  2.91it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:01<00:20,  2.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:02<00:19,  2.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:02<00:18,  2.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:03<00:18,  2.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:03<00:15,  3.20it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:03<00:16,  2.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:04<00:17,  2.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:04<00:17,  2.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:04<00:14,  3.21it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:04<00:13,  3.43it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:05<00:16,  2.61it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:06<00:19,  2.23it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:06<00:21,  1.99it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:07<00:20,  2.01it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:07<00:20,  1.97it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:08<00:20,  1.87it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:08<00:20,  1.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:09<00:18,  2.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:09<00:18,  1.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:10<00:17,  1.95it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:10<00:16,  2.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:11<00:15,  2.07it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:11<00:18,  1.76it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:12<00:19,  1.60it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:13<00:17,  1.69it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:13<00:16,  1.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:14<00:16,  1.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:15<00:16,  1.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:15<00:14,  1.75it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:16<00:13,  1.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:16<00:14,  1.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:17<00:13,  1.76it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:17<00:11,  1.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:18<00:11,  1.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:18<00:10,  1.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:19<00:10,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:19<00:09,  1.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:20<00:08,  1.91it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:20<00:08,  1.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:21<00:08,  1.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:21<00:07,  1.97it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:22<00:05,  2.19it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:22<00:04,  2.45it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:22<00:03,  2.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:22<00:03,  3.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:23<00:02,  3.23it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:23<00:02,  3.30it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:23<00:02,  3.05it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:24<00:02,  2.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:24<00:01,  3.02it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:24<00:01,  3.22it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:25<00:00,  3.21it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:25<00:00,  2.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:26<00:00,  2.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  2.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  2.26it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:13:00.808\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 22.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Temps : 27.77s | Duree : 29.9s | Ratio : 1.08x\n",
       "\n",
-      "Installation : pip install git+https://github.com/ace-step/ACE-Step.git\n"
+      "--- gs=15, steps=60 ---\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:11,  5.20it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:11,  5.13it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:00<00:12,  4.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:00<00:12,  4.37it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:11,  4.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:01<00:11,  4.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:01<00:10,  4.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:01<00:11,  4.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:01<00:12,  4.23it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:02<00:11,  4.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:02<00:11,  4.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:02<00:12,  3.96it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:03<00:12,  3.80it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:03<00:12,  3.73it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:03<00:10,  4.14it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:04<00:15,  2.80it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:04<00:20,  2.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:05<00:22,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:05<00:20,  1.99it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:06<00:22,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:07<00:21,  1.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:07<00:20,  1.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:08<00:18,  2.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:08<00:16,  2.13it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:09<00:17,  2.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:09<00:16,  2.08it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:09<00:15,  2.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:10<00:13,  2.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:10<00:13,  2.27it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:11<00:13,  2.25it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:11<00:12,  2.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:12<00:12,  2.19it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:12<00:11,  2.29it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:12<00:10,  2.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:13<00:10,  2.39it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:13<00:10,  2.22it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:14<00:12,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:15<00:11,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:15<00:11,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:16<00:10,  1.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:16<00:10,  1.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:16<00:08,  2.12it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:17<00:08,  1.97it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:17<00:07,  2.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:18<00:07,  2.08it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:18<00:06,  2.26it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:19<00:04,  2.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:19<00:03,  3.14it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:19<00:03,  3.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:19<00:02,  3.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:19<00:02,  3.45it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:20<00:02,  3.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:20<00:01,  3.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:20<00:01,  3.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:21<00:01,  3.76it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:21<00:00,  4.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:21<00:00,  3.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:21<00:00,  3.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:21<00:00,  3.99it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:22<00:00,  4.01it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:22<00:00,  2.70it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:13:24.191\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 33.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Temps : 23.39s | Duree : 29.9s | Ratio : 1.28x\n",
+      "\n",
+      "--- gs=25, steps=60 ---\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:15,  3.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:19,  2.97it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:00<00:16,  3.39it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:01<00:18,  3.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:18,  3.05it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:01<00:17,  3.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:02<00:15,  3.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:02<00:13,  3.76it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:02<00:13,  3.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:02<00:13,  3.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:03<00:13,  3.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:03<00:13,  3.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:03<00:12,  3.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:03<00:11,  3.96it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:04<00:12,  3.54it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:04<00:16,  2.69it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:05<00:19,  2.20it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:05<00:18,  2.24it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:06<00:21,  1.94it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:07<00:19,  2.05it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:07<00:17,  2.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:07<00:17,  2.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:08<00:17,  2.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:09<00:18,  1.91it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:09<00:18,  1.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:10<00:17,  1.97it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:10<00:19,  1.65it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:11<00:20,  1.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:12<00:19,  1.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:12<00:16,  1.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:13<00:17,  1.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:13<00:15,  1.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:14<00:14,  1.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:14<00:13,  1.95it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:15<00:14,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:15<00:13,  1.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:16<00:12,  1.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:16<00:11,  1.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:17<00:11,  1.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:18<00:10,  1.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:18<00:10,  1.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:19<00:09,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:19<00:08,  2.02it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:20<00:08,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:20<00:08,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:21<00:06,  2.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:21<00:05,  2.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:21<00:04,  2.43it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:22<00:04,  2.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:22<00:03,  2.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:22<00:02,  3.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:22<00:02,  3.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:23<00:02,  3.20it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:23<00:01,  3.21it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:23<00:01,  3.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:24<00:01,  3.54it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:24<00:00,  3.23it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:24<00:00,  3.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:24<00:00,  4.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:25<00:00,  4.09it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:25<00:00,  2.40it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:13:50.288\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 20.93it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Temps : 26.04s | Duree : 29.9s | Ratio : 1.15x\n",
+      "\n",
+      "--- gs=15, steps=30 ---\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/30 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 1/30 [00:00<00:08,  3.23it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 2/30 [00:00<00:08,  3.20it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 3/30 [00:00<00:06,  4.27it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 4/30 [00:00<00:05,  4.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 5/30 [00:01<00:04,  5.18it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 6/30 [00:01<00:04,  5.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 7/30 [00:01<00:05,  4.40it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 8/30 [00:01<00:05,  3.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 9/30 [00:02<00:06,  3.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 10/30 [00:03<00:08,  2.25it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 11/30 [00:03<00:10,  1.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 12/30 [00:04<00:10,  1.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 13/30 [00:05<00:11,  1.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 14/30 [00:06<00:10,  1.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 15/30 [00:06<00:09,  1.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 16/30 [00:07<00:09,  1.43it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 17/30 [00:07<00:08,  1.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 18/30 [00:08<00:07,  1.60it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 19/30 [00:09<00:06,  1.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 20/30 [00:09<00:06,  1.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 21/30 [00:10<00:04,  1.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 22/30 [00:10<00:04,  1.91it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 23/30 [00:10<00:02,  2.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 24/30 [00:11<00:02,  2.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 25/30 [00:11<00:01,  3.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 26/30 [00:11<00:01,  3.28it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 27/30 [00:11<00:00,  3.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 28/30 [00:12<00:00,  3.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 29/30 [00:12<00:00,  4.01it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 30/30 [00:12<00:00,  3.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 30/30 [00:12<00:00,  2.39it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:14:03.992\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 24.18it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Temps : 13.68s | Duree : 29.9s | Ratio : 2.19x\n",
+      "\n",
+      "--- gs=15, steps=90 ---\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/90 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  1%|          | 1/90 [00:00<00:25,  3.47it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 2/90 [00:00<00:27,  3.25it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 3/90 [00:00<00:28,  3.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  4%|▍         | 4/90 [00:01<00:24,  3.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  6%|▌         | 5/90 [00:01<00:27,  3.05it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 6/90 [00:01<00:27,  3.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 7/90 [00:02<00:23,  3.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  9%|▉         | 8/90 [00:02<00:21,  3.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 9/90 [00:02<00:20,  4.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 11%|█         | 10/90 [00:02<00:20,  3.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 11/90 [00:03<00:22,  3.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 12/90 [00:03<00:25,  3.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 14%|█▍        | 13/90 [00:03<00:20,  3.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 16%|█▌        | 14/90 [00:03<00:19,  3.87it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 15/90 [00:04<00:17,  4.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 16/90 [00:04<00:18,  4.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 19%|█▉        | 17/90 [00:04<00:17,  4.09it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 18/90 [00:04<00:18,  3.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 21%|██        | 19/90 [00:05<00:17,  4.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 20/90 [00:05<00:18,  3.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 21/90 [00:05<00:19,  3.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 24%|██▍       | 22/90 [00:05<00:17,  3.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 26%|██▌       | 23/90 [00:06<00:19,  3.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 24/90 [00:06<00:25,  2.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 25/90 [00:07<00:26,  2.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 29%|██▉       | 26/90 [00:07<00:27,  2.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 27/90 [00:08<00:30,  2.09it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 31%|███       | 28/90 [00:09<00:33,  1.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 29/90 [00:09<00:33,  1.80it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 30/90 [00:10<00:31,  1.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 34%|███▍      | 31/90 [00:11<00:35,  1.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 36%|███▌      | 32/90 [00:11<00:36,  1.58it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 33/90 [00:12<00:35,  1.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 34/90 [00:12<00:32,  1.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 39%|███▉      | 35/90 [00:13<00:33,  1.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 36/90 [00:14<00:32,  1.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 41%|████      | 37/90 [00:14<00:29,  1.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 38/90 [00:14<00:27,  1.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 39/90 [00:15<00:25,  1.98it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 44%|████▍     | 40/90 [00:16<00:26,  1.86it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 46%|████▌     | 41/90 [00:16<00:24,  2.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 42/90 [00:16<00:22,  2.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 43/90 [00:17<00:20,  2.24it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 49%|████▉     | 44/90 [00:17<00:20,  2.27it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 45/90 [00:18<00:20,  2.16it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 51%|█████     | 46/90 [00:18<00:22,  1.96it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 47/90 [00:19<00:23,  1.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 48/90 [00:20<00:23,  1.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 54%|█████▍    | 49/90 [00:20<00:24,  1.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 56%|█████▌    | 50/90 [00:21<00:24,  1.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 51/90 [00:21<00:23,  1.65it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 52/90 [00:22<00:21,  1.75it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 59%|█████▉    | 53/90 [00:22<00:20,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 54/90 [00:23<00:21,  1.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 61%|██████    | 55/90 [00:24<00:19,  1.76it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 56/90 [00:24<00:20,  1.66it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 57/90 [00:25<00:20,  1.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 64%|██████▍   | 58/90 [00:26<00:20,  1.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 66%|██████▌   | 59/90 [00:26<00:19,  1.59it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 60/90 [00:27<00:17,  1.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 61/90 [00:27<00:15,  1.87it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 69%|██████▉   | 62/90 [00:28<00:15,  1.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 63/90 [00:28<00:14,  1.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 71%|███████   | 64/90 [00:29<00:15,  1.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 65/90 [00:29<00:13,  1.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 66/90 [00:30<00:15,  1.60it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 74%|███████▍  | 67/90 [00:31<00:16,  1.39it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 76%|███████▌  | 68/90 [00:31<00:12,  1.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 69/90 [00:32<00:10,  2.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 70/90 [00:32<00:08,  2.43it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 79%|███████▉  | 71/90 [00:32<00:06,  2.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 72/90 [00:32<00:05,  3.16it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 81%|████████  | 73/90 [00:33<00:05,  3.30it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 74/90 [00:33<00:05,  3.13it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 75/90 [00:33<00:04,  3.24it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 84%|████████▍ | 76/90 [00:34<00:04,  3.33it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 86%|████████▌ | 77/90 [00:34<00:03,  3.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 78/90 [00:34<00:03,  3.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 79/90 [00:34<00:02,  4.22it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 89%|████████▉ | 80/90 [00:35<00:02,  4.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 81/90 [00:35<00:02,  4.23it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 91%|█████████ | 82/90 [00:35<00:02,  3.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 83/90 [00:35<00:01,  3.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 84/90 [00:36<00:01,  3.70it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 94%|█████████▍| 85/90 [00:36<00:01,  3.45it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 96%|█████████▌| 86/90 [00:36<00:01,  3.44it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 87/90 [00:36<00:00,  3.65it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 88/90 [00:37<00:00,  3.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 99%|█████████▉| 89/90 [00:37<00:00,  3.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 90/90 [00:37<00:00,  3.54it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 90/90 [00:37<00:00,  2.38it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:14:42.966\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 28.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Temps : 38.96s | Duree : 29.9s | Ratio : 0.77x\n",
+      "\n",
+      "Recapitulatif :\n",
+      "Config               Temps (s)    Duree (s)    Ratio     \n",
+      "-------------------------------------------------------\n",
+      "gs=5, steps=60       27.77        29.9         1.08      \n",
+      "gs=15, steps=60      23.39        29.9         1.28      \n",
+      "gs=25, steps=60      26.04        29.9         1.15      \n",
+      "gs=15, steps=30      13.68        29.9         2.19      \n",
+      "gs=15, steps=90      38.96        29.9         0.77      \n"
      ]
     }
    ],
-   "source": "# Test des parametres de generation\nprint(\"TEST DES PARAMETRES DE GENERATION\")\nprint(\"=\" * 50)\n\ntest_prompt = \"pop, acoustic guitar, gentle, romantic\"\ntest_lyrics = (\n    \"[verse]\\n\"\n    \"Strumming softly in the night\\n\"\n    \"Stars are shining burning bright\\n\"\n    \"Every chord tells a story\\n\"\n    \"Of a love that feels like glory\\n\"\n    \"\\n\"\n    \"[chorus]\\n\"\n    \"Play me a song of tomorrow\\n\"\n    \"Wave away the sorrow\\n\"\n    \"Let the melody carry us through\\n\"\n    \"Every note a promise new\"\n)\n\n# Configurations a tester\nparam_configs = [\n    {\"label\": \"gs=5, steps=60\", \"guidance_scale\": 5, \"infer_step\": 60},\n    {\"label\": \"gs=15, steps=60\", \"guidance_scale\": 15, \"infer_step\": 60},\n    {\"label\": \"gs=25, steps=60\", \"guidance_scale\": 25, \"infer_step\": 60},\n    {\"label\": \"gs=15, steps=30\", \"guidance_scale\": 15, \"infer_step\": 30},\n    {\"label\": \"gs=15, steps=90\", \"guidance_scale\": 15, \"infer_step\": 90},\n]\n\nparam_results = {}\n\nif pipeline is not None and generate_audio:\n    print(f\"Prompt : {test_prompt}\")\n    print(f\"Duree : {audio_duration}s\")\n\n    for config in param_configs:\n        label = config[\"label\"]\n        print(f\"\\n--- {label} ---\")\n\n        try:\n            start_time = time.time()\n            result = pipeline(\n                audio_duration=audio_duration,\n                prompt=test_prompt,\n                lyrics=test_lyrics,\n                infer_step=config[\"infer_step\"],\n                guidance_scale=config[\"guidance_scale\"],\n                scheduler_type=scheduler_type,\n                cfg_type=cfg_type,\n                omega_scale=omega_scale,\n                manual_seeds=str(seed) if seed >= 0 else \"\",\n                guidance_interval=0.5,\n                guidance_interval_decay=0,\n                min_guidance_scale=3,\n                use_erg_tag=True,\n                use_erg_lyric=True,\n                use_erg_diffusion=True,\n                oss_steps=\"\",\n                guidance_scale_text=0.0,\n                guidance_scale_lyric=0.0,\n            )\n            gen_time = time.time() - start_time\n\n            # Analyser le resultat\n            if isinstance(result, str) and os.path.exists(result):\n                import soundfile as sf\n                audio_data, sr = sf.read(result)\n                duration = len(audio_data) / sr\n            else:\n                duration = audio_duration\n                sr = 44100\n\n            param_results[label] = {\n                \"gen_time\": gen_time,\n                \"duration\": duration,\n                \"guidance_scale\": config[\"guidance_scale\"],\n                \"infer_step\": config[\"infer_step\"],\n            }\n\n            print(f\"  Temps : {gen_time:.2f}s | Duree : {duration:.1f}s | Ratio : {duration/gen_time:.2f}x\")\n\n            if BATCH_MODE != \"true\":\n                if isinstance(result, str) and os.path.exists(result):\n                    display(Audio(data=audio_data.T if audio_data.ndim > 1 else audio_data, rate=sr))\n\n        except Exception as e:\n            print(f\"  Erreur : {type(e).__name__} - {str(e)[:200]}\")\n            param_results[label] = {\"error\": str(e)[:100]}\n\n    # Tableau recapitulatif\n    if param_results:\n        print(f\"\\nRecapitulatif :\")\n        print(f\"{'Config':<20} {'Temps (s)':<12} {'Duree (s)':<12} {'Ratio':<10}\")\n        print(\"-\" * 55)\n        for label, data in param_results.items():\n            if \"error\" not in data:\n                print(f\"{label:<20} {data['gen_time']:<12.2f} {data['duration']:<12.1f} {data['duration']/data['gen_time']:<10.2f}\")\n            else:\n                print(f\"{label:<20} ERREUR : {data['error']}\")\nelse:\n    print(\"Modele non charge ou generation desactivee\")\n    print(\"\\nConfigurations qui auraient ete testees :\")\n    for config in param_configs:\n        print(f\"  {config['label']}\")\n    print(\"\\nImpact attendu :\")\n    print(\"  guidance_scale bas (5) : Plus creatif, moins fidele au prompt\")\n    print(\"  guidance_scale haut (25) : Tres fidele, possiblement rigide\")\n    print(\"  infer_step bas (30) : Rapide, qualite reduite\")\n    print(\"  infer_step haut (90) : Lent, meilleure qualite\")"
+   "source": [
+    "# Test des parametres de generation\n",
+    "print(\"TEST DES PARAMETRES DE GENERATION\")\n",
+    "print(\"=\" * 50)\n",
+    "\n",
+    "test_prompt = \"pop, acoustic guitar, gentle, romantic\"\n",
+    "test_lyrics = (\n",
+    "    \"[verse]\\n\"\n",
+    "    \"Strumming softly in the night\\n\"\n",
+    "    \"Stars are shining burning bright\\n\"\n",
+    "    \"Every chord tells a story\\n\"\n",
+    "    \"Of a love that feels like glory\\n\"\n",
+    "    \"\\n\"\n",
+    "    \"[chorus]\\n\"\n",
+    "    \"Play me a song of tomorrow\\n\"\n",
+    "    \"Wave away the sorrow\\n\"\n",
+    "    \"Let the melody carry us through\\n\"\n",
+    "    \"Every note a promise new\"\n",
+    ")\n",
+    "\n",
+    "# Configurations a tester\n",
+    "param_configs = [\n",
+    "    {\"label\": \"gs=5, steps=60\", \"guidance_scale\": 5, \"infer_step\": 60},\n",
+    "    {\"label\": \"gs=15, steps=60\", \"guidance_scale\": 15, \"infer_step\": 60},\n",
+    "    {\"label\": \"gs=25, steps=60\", \"guidance_scale\": 25, \"infer_step\": 60},\n",
+    "    {\"label\": \"gs=15, steps=30\", \"guidance_scale\": 15, \"infer_step\": 30},\n",
+    "    {\"label\": \"gs=15, steps=90\", \"guidance_scale\": 15, \"infer_step\": 90},\n",
+    "]\n",
+    "\n",
+    "param_results = {}\n",
+    "\n",
+    "if pipeline is not None and generate_audio:\n",
+    "    print(f\"Prompt : {test_prompt}\")\n",
+    "    print(f\"Duree : {audio_duration}s\")\n",
+    "\n",
+    "    for config in param_configs:\n",
+    "        label = config[\"label\"]\n",
+    "        print(f\"\\n--- {label} ---\")\n",
+    "\n",
+    "        try:\n",
+    "            start_time = time.time()\n",
+    "            result = pipeline(\n",
+    "                audio_duration=audio_duration,\n",
+    "                prompt=test_prompt,\n",
+    "                lyrics=test_lyrics,\n",
+    "                infer_step=config[\"infer_step\"],\n",
+    "                guidance_scale=config[\"guidance_scale\"],\n",
+    "                scheduler_type=scheduler_type,\n",
+    "                cfg_type=cfg_type,\n",
+    "                omega_scale=omega_scale,\n",
+    "                manual_seeds=str(seed) if seed >= 0 else \"\",\n",
+    "                guidance_interval=0.5,\n",
+    "                guidance_interval_decay=0,\n",
+    "                min_guidance_scale=3,\n",
+    "                use_erg_tag=True,\n",
+    "                use_erg_lyric=True,\n",
+    "                use_erg_diffusion=True,\n",
+    "                oss_steps=\"\",\n",
+    "                guidance_scale_text=0.0,\n",
+    "                guidance_scale_lyric=0.0,\n",
+    "            )\n",
+    "            gen_time = time.time() - start_time\n",
+    "\n",
+    "            # Analyser le resultat\n",
+    "            # ACE-Step v1.5 retourne [chemin_wav, params_dict]\n",
+    "            if isinstance(result, list) and result and isinstance(result[0], str):\n",
+    "                result = result[0]\n",
+    "\n",
+    "            if isinstance(result, str) and os.path.exists(result):\n",
+    "                import soundfile as sf\n",
+    "                audio_data, sr = sf.read(result)\n",
+    "                duration = len(audio_data) / sr\n",
+    "            else:\n",
+    "                duration = audio_duration\n",
+    "                sr = 44100\n",
+    "\n",
+    "            param_results[label] = {\n",
+    "                \"gen_time\": gen_time,\n",
+    "                \"duration\": duration,\n",
+    "                \"guidance_scale\": config[\"guidance_scale\"],\n",
+    "                \"infer_step\": config[\"infer_step\"],\n",
+    "            }\n",
+    "\n",
+    "            print(f\"  Temps : {gen_time:.2f}s | Duree : {duration:.1f}s | Ratio : {duration/gen_time:.2f}x\")\n",
+    "\n",
+    "            if BATCH_MODE != \"true\":\n",
+    "                if isinstance(result, str) and os.path.exists(result):\n",
+    "                    display(Audio(data=audio_data.T if audio_data.ndim > 1 else audio_data, rate=sr))\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            print(f\"  Erreur : {type(e).__name__} - {str(e)[:200]}\")\n",
+    "            param_results[label] = {\"error\": str(e)[:100]}\n",
+    "\n",
+    "    # Tableau recapitulatif\n",
+    "    if param_results:\n",
+    "        print(f\"\\nRecapitulatif :\")\n",
+    "        print(f\"{'Config':<20} {'Temps (s)':<12} {'Duree (s)':<12} {'Ratio':<10}\")\n",
+    "        print(\"-\" * 55)\n",
+    "        for label, data in param_results.items():\n",
+    "            if \"error\" not in data:\n",
+    "                print(f\"{label:<20} {data['gen_time']:<12.2f} {data['duration']:<12.1f} {data['duration']/data['gen_time']:<10.2f}\")\n",
+    "            else:\n",
+    "                print(f\"{label:<20} ERREUR : {data['error']}\")\n",
+    "else:\n",
+    "    print(\"Modele non charge ou generation desactivee\")\n",
+    "    print(\"\\nConfigurations qui auraient ete testees :\")\n",
+    "    for config in param_configs:\n",
+    "        print(f\"  {config['label']}\")\n",
+    "    print(\"\\nImpact attendu :\")\n",
+    "    print(\"  guidance_scale bas (5) : Plus creatif, moins fidele au prompt\")\n",
+    "    print(\"  guidance_scale haut (25) : Tres fidele, possiblement rigide\")\n",
+    "    print(\"  infer_step bas (30) : Rapide, qualite reduite\")\n",
+    "    print(\"  infer_step haut (90) : Lent, meilleure qualite\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "2dad120f",
    "metadata": {},
    "source": [
     "### Interpretation : Impact des parametres de generation\n",
@@ -640,27 +5465,102 @@
   {
    "cell_type": "markdown",
    "id": "9158ad58",
-   "source": "### Exercice 2 : Analyse de l'impact des parametres de generation\n\n**Objectif** : Implementer une fonction qui genere un morceau avec differentes configurations de `guidance_scale` et `infer_step`, puis analyse les differences de qualite percue.\n\nLes parametres de generation d'ACE-Step (guidance_scale, infer_step, cfg_type, omega_scale) ont un impact direct sur la qualite audio, la fidelite au prompt et le temps de generation. Cet exercice amene a quantifier ces compromis.\n\n**Indices** :\n- `guidance_scale` controle la fidelite au prompt : bas = creatif, haut = fidele\n- `infer_step` controle la qualite audio : bas = rapide/artefacts, haut = lent/qualitatif\n- Le temps de generation est approximativement proportionnel a `infer_step`\n- `cfg_type=\"apg\"` (Aperture Guidance) offre un meilleur compromis que `cfg` standard\n- # Etape 1 : Definir 3 configurations de parametres (conservateur, equilibre, agressif)\n- # Etape 2 : Pour chaque configuration, stocker les parametres et les metriques estimees\n- # Etape 3 : Calculer un score qualite/temps pour chaque configuration\n- # Etape 4 : Identifier la configuration optimale selon le cas d'usage (preview vs production)\n- # Indice : Un score simple = (guidance_score * infer_step_score) / temps_estime",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Analyse de l'impact des parametres de generation\n",
+    "\n",
+    "**Objectif** : Implementer une fonction qui genere un morceau avec differentes configurations de `guidance_scale` et `infer_step`, puis analyse les differences de qualite percue.\n",
+    "\n",
+    "Les parametres de generation d'ACE-Step (guidance_scale, infer_step, cfg_type, omega_scale) ont un impact direct sur la qualite audio, la fidelite au prompt et le temps de generation. Cet exercice amene a quantifier ces compromis.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `guidance_scale` controle la fidelite au prompt : bas = creatif, haut = fidele\n",
+    "- `infer_step` controle la qualite audio : bas = rapide/artefacts, haut = lent/qualitatif\n",
+    "- Le temps de generation est approximativement proportionnel a `infer_step`\n",
+    "- `cfg_type=\"apg\"` (Aperture Guidance) offre un meilleur compromis que `cfg` standard\n",
+    "- # Etape 1 : Definir 3 configurations de parametres (conservateur, equilibre, agressif)\n",
+    "- # Etape 2 : Pour chaque configuration, stocker les parametres et les metriques estimees\n",
+    "- # Etape 3 : Calculer un score qualite/temps pour chaque configuration\n",
+    "- # Etape 4 : Identifier la configuration optimale selon le cas d'usage (preview vs production)\n",
+    "- # Indice : Un score simple = (guidance_score * infer_step_score) / temps_estime"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "51c4dbe2",
-   "source": "# Exercice 2 : Analyse de l'impact des parametres de generation\n# TODO etudiant : Comparer differentes configurations de parametres ACE-Step\n\ndef analyze_generation_params(prompt=\"pop, piano, gentle\", \n                              lyrics=\"[verse]\\nStars are shining bright\\n[chorus]\\nDream away the night\",\n                              target_use=\"production\"):\n    \"\"\"\n    Compare differentes configurations de parametres ACE-Step\n    et recommande la meilleure selon le cas d'usage.\n    \n    Args:\n        prompt: Description du style musical\n        lyrics: Paroles structurees avec tags\n        target_use: \"preview\" (rapide) ou \"production\" (qualite)\n    \n    Returns:\n        dict: Configurations testees avec metriques et recommandation\n    \"\"\"\n    # TODO etudiant : Definir 3+ configurations de parametres\n    configs = {}  # TODO etudiant : {\"nom\": {\"guidance_scale\": X, \"infer_step\": Y, ...}, ...}\n    \n    # TODO etudiant : Pour chaque config, estimer les metriques\n    # Indice : temps_estime ~ infer_step * 0.15s (approximatif sur RTX 3090)\n    # Indice : qualite_estimee = f(guidance_scale, infer_step)\n    \n    results = {}  # TODO etudiant : {\"nom\": {\"temps_estime\": X, \"qualite_estimee\": Y, ...}, ...}\n    \n    # TODO etudiant : Calculer un score composite pour chaque config\n    # Indice : Pour \"preview\", privilegier la vitesse\n    # Indice : Pour \"production\", privilegier la qualite\n    \n    # TODO etudiant : Recommander la meilleure config pour target_use\n    best_config = None  # TODO etudiant\n    reason = None       # TODO etudiant\n    \n    return {\n        \"configs\": configs,\n        \"results\": results,\n        \"recommended\": best_config,\n        \"reason\": reason,\n    }\n\n# Test\nanalysis = analyze_generation_params(target_use=\"production\")\nif analysis[\"recommended\"]:\n    print(f\"Configuration recommandee : {analysis['recommended']}\")\n    print(f\"Raison : {analysis['reason']}\")\nelse:\n    print(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:14:43.423786Z",
+     "iopub.status.busy": "2026-07-09T22:14:43.422611Z",
+     "iopub.status.idle": "2026-07-09T22:14:43.435301Z",
+     "shell.execute_reply": "2026-07-09T22:14:43.433031Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice 2 : Analyse de l'impact des parametres de generation\n",
+    "# TODO etudiant : Comparer differentes configurations de parametres ACE-Step\n",
+    "\n",
+    "def analyze_generation_params(prompt=\"pop, piano, gentle\", \n",
+    "                              lyrics=\"[verse]\\nStars are shining bright\\n[chorus]\\nDream away the night\",\n",
+    "                              target_use=\"production\"):\n",
+    "    \"\"\"\n",
+    "    Compare differentes configurations de parametres ACE-Step\n",
+    "    et recommande la meilleure selon le cas d'usage.\n",
+    "    \n",
+    "    Args:\n",
+    "        prompt: Description du style musical\n",
+    "        lyrics: Paroles structurees avec tags\n",
+    "        target_use: \"preview\" (rapide) ou \"production\" (qualite)\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict: Configurations testees avec metriques et recommandation\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : Definir 3+ configurations de parametres\n",
+    "    configs = {}  # TODO etudiant : {\"nom\": {\"guidance_scale\": X, \"infer_step\": Y, ...}, ...}\n",
+    "    \n",
+    "    # TODO etudiant : Pour chaque config, estimer les metriques\n",
+    "    # Indice : temps_estime ~ infer_step * 0.15s (approximatif sur RTX 3090)\n",
+    "    # Indice : qualite_estimee = f(guidance_scale, infer_step)\n",
+    "    \n",
+    "    results = {}  # TODO etudiant : {\"nom\": {\"temps_estime\": X, \"qualite_estimee\": Y, ...}, ...}\n",
+    "    \n",
+    "    # TODO etudiant : Calculer un score composite pour chaque config\n",
+    "    # Indice : Pour \"preview\", privilegier la vitesse\n",
+    "    # Indice : Pour \"production\", privilegier la qualite\n",
+    "    \n",
+    "    # TODO etudiant : Recommander la meilleure config pour target_use\n",
+    "    best_config = None  # TODO etudiant\n",
+    "    reason = None       # TODO etudiant\n",
+    "    \n",
+    "    return {\n",
+    "        \"configs\": configs,\n",
+    "        \"results\": results,\n",
+    "        \"recommended\": best_config,\n",
+    "        \"reason\": reason,\n",
+    "    }\n",
+    "\n",
+    "# Test\n",
+    "analysis = analyze_generation_params(target_use=\"production\")\n",
+    "if analysis[\"recommended\"]:\n",
+    "    print(f\"Configuration recommandee : {analysis['recommended']}\")\n",
+    "    print(f\"Raison : {analysis['reason']}\")\n",
+    "else:\n",
+    "    print(\"Exercice a completer\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "3f20d03d",
    "metadata": {},
    "source": [
     "## Section 4 : Generation multilingue\n",
@@ -683,29 +5583,1662 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": 10,
+   "id": "ad8f7a63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:14:43.439986Z",
+     "iopub.status.busy": "2026-07-09T22:14:43.439406Z",
+     "iopub.status.idle": "2026-07-09T22:16:09.348414Z",
+     "shell.execute_reply": "2026-07-09T22:16:09.346830Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TEST DES PARAMETRES DE GENERATION\n",
+      "GENERATION MULTILINGUE\n",
       "==================================================\n",
-      "Modele non charge ou generation desactivee\n",
       "\n",
-      "Configurations qui auraient ete testees :\n",
-      "  gs=5, steps=60\n",
-      "  gs=15, steps=60\n",
-      "  gs=25, steps=60\n",
-      "  gs=15, steps=30\n",
-      "  gs=15, steps=90\n",
+      "--- Francais ---\n",
+      "Prompt : pop, douce, guitare acoustique, romantique\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:09,  5.94it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:14,  4.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:00<00:11,  4.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:00<00:11,  5.01it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:10,  5.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:01<00:12,  4.39it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:01<00:14,  3.54it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:02<00:16,  3.22it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:02<00:16,  3.17it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:02<00:15,  3.18it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:02<00:14,  3.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:03<00:12,  3.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:03<00:13,  3.55it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:03<00:12,  3.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:04<00:13,  3.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:04<00:15,  2.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:05<00:16,  2.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:05<00:17,  2.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:06<00:18,  2.20it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:06<00:20,  1.97it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:07<00:19,  2.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:07<00:17,  2.13it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:08<00:18,  1.98it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:08<00:18,  1.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:09<00:17,  2.03it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:09<00:17,  2.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:10<00:17,  1.85it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:10<00:18,  1.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:11<00:17,  1.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:12<00:21,  1.40it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:13<00:21,  1.38it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:13<00:19,  1.43it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:14<00:19,  1.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:15<00:19,  1.37it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:16<00:17,  1.41it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:16<00:17,  1.38it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:17<00:17,  1.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:18<00:15,  1.41it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:18<00:13,  1.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:19<00:12,  1.61it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:20<00:12,  1.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:20<00:11,  1.52it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:21<00:10,  1.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:22<00:11,  1.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:23<00:11,  1.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:23<00:08,  1.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:23<00:06,  2.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:23<00:05,  2.31it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:24<00:04,  2.28it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:24<00:04,  2.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:24<00:03,  2.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:25<00:02,  2.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:25<00:02,  3.44it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:25<00:01,  3.59it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:25<00:01,  3.41it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:26<00:01,  3.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:26<00:00,  3.15it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:26<00:00,  3.13it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:27<00:00,  3.34it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:27<00:00,  3.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:27<00:00,  2.19it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:15:13.231\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 46.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Duree : 20.0s | Temps : 30.18s\n",
+      "  Sauvegarde : multilingual_francais.wav\n",
       "\n",
-      "Impact attendu :\n",
-      "  guidance_scale bas (5) : Plus creatif, moins fidele au prompt\n",
-      "  guidance_scale haut (25) : Tres fidele, possiblement rigide\n",
-      "  infer_step bas (30) : Rapide, qualite reduite\n",
-      "  infer_step haut (90) : Lent, meilleure qualite\n"
+      "--- English ---\n",
+      "Prompt : pop, gentle, acoustic guitar, romantic\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:18,  3.19it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:17,  3.26it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:00<00:16,  3.37it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:01<00:16,  3.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:19,  2.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:02<00:19,  2.76it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:02<00:20,  2.60it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:02<00:18,  2.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:03<00:17,  2.97it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:03<00:16,  3.12it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:03<00:15,  3.26it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:03<00:15,  3.06it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:04<00:14,  3.27it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:04<00:13,  3.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:04<00:14,  3.16it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:05<00:18,  2.44it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:06<00:19,  2.21it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:06<00:20,  2.04it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:07<00:19,  2.08it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:07<00:21,  1.89it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:08<00:20,  1.88it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:08<00:19,  1.93it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:09<00:18,  1.98it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:09<00:18,  2.00it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:10<00:19,  1.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:10<00:17,  1.95it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:11<00:15,  2.10it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:11<00:17,  1.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:12<00:18,  1.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:13<00:16,  1.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:13<00:15,  1.82it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:14<00:18,  1.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:15<00:16,  1.60it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:15<00:14,  1.73it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:16<00:14,  1.73it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:16<00:15,  1.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:17<00:14,  1.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:18<00:13,  1.67it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:18<00:11,  1.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:19<00:11,  1.69it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:19<00:11,  1.63it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:20<00:11,  1.59it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:20<00:09,  1.73it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:21<00:11,  1.44it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:22<00:10,  1.41it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:22<00:07,  1.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:23<00:06,  2.14it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:23<00:04,  2.51it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:23<00:03,  2.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:23<00:03,  2.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:24<00:03,  2.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:24<00:02,  3.20it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:24<00:02,  3.43it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:25<00:01,  3.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:25<00:01,  3.74it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:25<00:01,  3.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:25<00:00,  3.53it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:26<00:00,  3.60it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:26<00:00,  3.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  3.76it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  2.25it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:15:40.915\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 36.54it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Duree : 20.0s | Temps : 27.65s\n",
+      "  Sauvegarde : multilingual_english.wav\n",
+      "\n",
+      "--- Espanol ---\n",
+      "Prompt : pop, suave, guitarra acustica, romantico\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/60 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  2%|▏         | 1/60 [00:00<00:17,  3.34it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  3%|▎         | 2/60 [00:00<00:13,  4.16it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  5%|▌         | 3/60 [00:00<00:13,  4.18it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  7%|▋         | 4/60 [00:00<00:13,  4.30it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  8%|▊         | 5/60 [00:01<00:12,  4.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 10%|█         | 6/60 [00:01<00:12,  4.26it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 12%|█▏        | 7/60 [00:01<00:14,  3.65it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 13%|█▎        | 8/60 [00:02<00:14,  3.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 15%|█▌        | 9/60 [00:02<00:13,  3.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 17%|█▋        | 10/60 [00:02<00:13,  3.70it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 18%|█▊        | 11/60 [00:02<00:12,  3.80it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 20%|██        | 12/60 [00:03<00:12,  3.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 22%|██▏       | 13/60 [00:03<00:11,  3.98it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 23%|██▎       | 14/60 [00:03<00:10,  4.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 25%|██▌       | 15/60 [00:03<00:13,  3.36it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 27%|██▋       | 16/60 [00:04<00:19,  2.28it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 28%|██▊       | 17/60 [00:05<00:19,  2.21it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 30%|███       | 18/60 [00:05<00:17,  2.35it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 32%|███▏      | 19/60 [00:06<00:19,  2.11it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 33%|███▎      | 20/60 [00:06<00:20,  1.92it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 35%|███▌      | 21/60 [00:07<00:22,  1.70it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 37%|███▋      | 22/60 [00:08<00:21,  1.78it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 38%|███▊      | 23/60 [00:08<00:21,  1.72it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 40%|████      | 24/60 [00:09<00:21,  1.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 42%|████▏     | 25/60 [00:09<00:18,  1.87it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 43%|████▎     | 26/60 [00:10<00:18,  1.84it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 45%|████▌     | 27/60 [00:10<00:18,  1.83it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 47%|████▋     | 28/60 [00:11<00:18,  1.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 48%|████▊     | 29/60 [00:12<00:18,  1.69it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 50%|█████     | 30/60 [00:12<00:17,  1.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 52%|█████▏    | 31/60 [00:13<00:16,  1.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 53%|█████▎    | 32/60 [00:14<00:18,  1.50it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 55%|█████▌    | 33/60 [00:14<00:18,  1.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 57%|█████▋    | 34/60 [00:15<00:16,  1.57it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 58%|█████▊    | 35/60 [00:15<00:15,  1.62it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 60%|██████    | 36/60 [00:16<00:16,  1.41it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 62%|██████▏   | 37/60 [00:17<00:15,  1.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 63%|██████▎   | 38/60 [00:18<00:15,  1.43it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 65%|██████▌   | 39/60 [00:19<00:15,  1.34it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 67%|██████▋   | 40/60 [00:19<00:13,  1.46it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 68%|██████▊   | 41/60 [00:20<00:13,  1.42it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 70%|███████   | 42/60 [00:20<00:12,  1.49it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 72%|███████▏  | 43/60 [00:21<00:10,  1.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 73%|███████▎  | 44/60 [00:21<00:09,  1.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 75%|███████▌  | 45/60 [00:22<00:09,  1.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 77%|███████▋  | 46/60 [00:22<00:07,  1.94it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 78%|███████▊  | 47/60 [00:23<00:05,  2.32it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 80%|████████  | 48/60 [00:23<00:04,  2.79it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 82%|████████▏ | 49/60 [00:23<00:03,  2.90it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 83%|████████▎ | 50/60 [00:23<00:03,  2.75it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 85%|████████▌ | 51/60 [00:24<00:03,  2.81it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 87%|████████▋ | 52/60 [00:24<00:03,  2.56it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 88%|████████▊ | 53/60 [00:25<00:02,  2.65it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 90%|█████████ | 54/60 [00:25<00:01,  3.02it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 92%|█████████▏| 55/60 [00:25<00:01,  3.38it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 93%|█████████▎| 56/60 [00:25<00:01,  3.77it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 95%|█████████▌| 57/60 [00:25<00:00,  4.01it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 97%|█████████▋| 58/60 [00:26<00:00,  3.68it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " 98%|█████████▊| 59/60 [00:26<00:00,  3.71it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  3.48it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 60/60 [00:26<00:00,  2.23it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-07-10 00:16:08.898\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36macestep.pipeline_ace_step\u001b[0m:\u001b[36msave_wav_file\u001b[0m:\u001b[36m1394\u001b[0m - \u001b[33m\u001b[1msave_path is None, using default path ./outputs/\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 30.64it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Duree : 20.0s | Temps : 27.92s\n",
+      "  Sauvegarde : multilingual_espanol.wav\n",
+      "\n",
+      "Comparatif multilingue :\n",
+      "Langue       Temps (s)    Duree (s)    Statut         \n",
+      "----------------------------------------------------\n",
+      "Francais     30.18        20.0         OK             \n",
+      "English      27.65        20.0         OK             \n",
+      "Espanol      27.92        20.0         OK             \n"
      ]
     }
    ],
@@ -803,6 +7336,10 @@
     "            )\n",
     "            gen_time = time.time() - start_time\n",
     "\n",
+    "            # ACE-Step v1.5 retourne [chemin_wav, params_dict]\n",
+    "            if isinstance(result, list) and result and isinstance(result[0], str):\n",
+    "                result = result[0]\n",
+    "\n",
     "            if isinstance(result, str) and os.path.exists(result):\n",
     "                import soundfile as sf\n",
     "                audio_data, sr = sf.read(result)\n",
@@ -852,6 +7389,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0d43f3d0",
    "metadata": {},
    "source": [
     "### Interpretation : Generation multilingue\n",
@@ -876,6 +7414,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0fd7f992",
    "metadata": {},
    "source": [
     "## Section 5 : Comparaison ACE-Step vs MusicGen vs alternatives\n",
@@ -895,21 +7434,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 11,
+   "id": "e7f2c3d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:16:09.352823Z",
+     "iopub.status.busy": "2026-07-09T22:16:09.352823Z",
+     "iopub.status.idle": "2026-07-09T22:16:09.373217Z",
+     "shell.execute_reply": "2026-07-09T22:16:09.370614Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GENERATION MULTILINGUE\n",
-      "==================================================\n",
-      "Modele non charge ou generation multilingue desactivee\n",
+      "COMPARAISON DES MODELES DE GENERATION MUSICALE\n",
+      "=======================================================\n",
+      "Critere              ACE-Step v1.5          MusicGen medium        YuE                    SongGen2              \n",
+      "----------------------------------------------------------------------------------------------------------------\n",
+      "Architecture         LM + DiT hybride       Transformer + EnCodec  Flow matching          Diffusion             \n",
+      "Parametres           3.5B (base)            1.5B                   Variable               Variable              \n",
+      "VRAM min             <4 GB (offload)        ~10 GB                 10-24 GB               10-24 GB              \n",
+      "Qualite audio        44.1 kHz stereo        32 kHz mono            44.1 kHz stereo        44.1 kHz stereo       \n",
+      "Duree max            ~4 minutes             ~30 secondes           ~2 minutes             ~2 minutes            \n",
+      "Paroles              Oui (50+ langues)      Non (instrumental)     Oui                    Oui                   \n",
+      "Vitesse (RTX 3090)   <10s / 4min            ~5-10s / 10s           ~30-60s / 1min         ~30-60s / 1min        \n",
+      "Licence              Apache 2.0             MIT                    Apache 2.0             Variable              \n",
+      "Notebook             02-9 (ce notebook)     02-3                   02-7                   02-7                  \n",
       "\n",
-      "Langues qui auraient ete testees :\n",
-      "  Francais : pop, douce, guitare acoustique, romantique\n",
-      "  English : pop, gentle, acoustic guitar, romantic\n",
-      "  Espanol : pop, suave, guitarra acustica, romantico\n"
+      "RECOMMANDATIONS PAR USE CASE\n",
+      "-------------------------------------------------------\n",
+      "Musique instrumentale courte : MusicGen (qualite, stabilite)\n",
+      "Chanson complete multilingue : ACE-Step (paroles, langues, VRAM)\n",
+      "Chanson haute qualite : YuE / SongGen2 (si GPU 24 GB disponible)\n",
+      "Prototypage rapide sur GPU modeste : ACE-Step avec cpu_offload\n",
+      "Musique de fond sans paroles : MusicGen (optimise pour instrumental)\n",
+      "\n",
+      "AVANTAGES CLES D'ACE-STEP\n",
+      "  1. Plus faible VRAM (<4 GB avec offload vs 10+ GB pour les autres)\n",
+      "  2. Plus longue duree de generation (4 min vs 30s-2min)\n",
+      "  3. Support multilingue natif (50+ langues)\n",
+      "  4. Licence Apache 2.0 (open-source, utilisation commerciale OK)\n",
+      "  5. Audio stereo 44.1 kHz (vs mono 32 kHz pour MusicGen)\n"
      ]
     }
    ],
@@ -1003,6 +7570,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "85c97fbc",
    "metadata": {},
    "source": [
     "### Interpretation : Comparaison des modeles\n",
@@ -1029,62 +7597,161 @@
   {
    "cell_type": "markdown",
    "id": "fde4a081",
-   "source": "### Exercice 3 : Matrice de recommandation par cas d'usage\n\n**Objectif** : Construire une fonction qui, etant donne un cahier des charges audio (duree, langue, GPU disponible, besoin de paroles), recommande le modele optimal parmi ACE-Step, MusicGen, YuE et SongGeneration 2.\n\nLes modeles de generation musicale ont des forces tres differentes selon le contexte. Cette exercice vous amene a formaliser la logique de selection vue dans la Section 5.\n\n**Indices** :\n- ACE-Step est le seul modele fonctionnant avec moins de 4 GB VRAM (cpu_offload)\n- MusicGen est le seul modele purement instrumental (pas de paroles)\n- YuE supporte les chansons illimitees mais necessite 24 GB VRAM\n- SongGeneration 2 offre la meilleure qualite audio (48kHz FLAC)\n- # Etape 1 : Definir les specifications de chaque modele (VRAM, duree max, paroles, langues)\n- # Etape 2 : Filtrer par contraintes hard (VRAM disponible, GPU)\n- # Etape 3 : Filtrer par besoins fonctionnels (paroles, duree, multilingue)\n- # Etape 4 : Retourner le meilleur modele avec justification\n- # Indice : Si VRAM < 4 GB, seul ACE-Step (cpu_offload) est viable",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "3fda9857",
-   "source": "# Exercice 1 : Matrice de recommandation par cas d'usage\n# TODO etudiant : Implementer un selecteur de modele de generation musicale\n\ndef recommend_music_model(vram_gb=6, gpu_available=True, need_lyrics=False,\n                          target_duration_s=30, need_multilingual=False,\n                          language=\"en\", commercial_use=False):\n    \"\"\"\n    Recommande le meilleur modele de generation musicale selon les contraintes.\n    \n    Modeles disponibles : ACE-Step, MusicGen, YuE, SongGeneration 2\n    \n    Args:\n        vram_gb: VRAM disponible en GB\n        gpu_available: GPU disponible\n        need_lyrics: Besoin de generer avec paroles\n        target_duration_s: Duree cible en secondes\n        need_multilingual: Support multilingue requis\n        language: Langue principale (\"en\", \"fr\", \"ja\", etc.)\n        commercial_use: Licence commerciale requise\n    \n    Returns:\n        dict: {\"model\": str, \"reason\": str, \"alternatives\": list}\n    \"\"\"\n    # TODO etudiant : Definir les specs de chaque modele\n    models = {}  # TODO etudiant\n    \n    # TODO etudiant : Filtrer par contraintes materielles (VRAM, GPU)\n    # Indice : vram_gb < 4 elimine tous sauf ACE-Step avec cpu_offload\n    \n    # TODO etudiant : Filtrer par besoins fonctionnels\n    # Indice : need_lyrics=True elimine MusicGen\n    \n    # TODO etudiant : Selectionner le meilleur candidat\n    recommendation = None  # TODO etudiant\n    reason = None          # TODO etudiant\n    alternatives = []      # TODO etudiant\n    \n    return {\n        \"model\": recommendation,\n        \"reason\": reason,\n        \"alternatives\": alternatives,\n    }\n\n# Test\nscenarios = [\n    {\"vram_gb\": 4, \"need_lyrics\": True, \"target_duration_s\": 120, \"language\": \"fr\"},\n    {\"vram_gb\": 24, \"need_lyrics\": False, \"target_duration_s\": 15},\n    {\"vram_gb\": 6, \"need_lyrics\": True, \"target_duration_s\": 180, \"need_multilingual\": True},\n]\n\nfor s in scenarios:\n    result = recommend_music_model(**s)\n    if result[\"model\"]:\n        print(f\"VRAM={s.get('vram_gb')}GB, lyrics={s.get('need_lyrics')} -> {result['model']}\")\n    else:\n        print(\"Exercice a completer\")",
    "metadata": {},
-   "execution_count": 1,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
+   "source": [
+    "### Exercice 3 : Matrice de recommandation par cas d'usage\n",
+    "\n",
+    "**Objectif** : Construire une fonction qui, etant donne un cahier des charges audio (duree, langue, GPU disponible, besoin de paroles), recommande le modele optimal parmi ACE-Step, MusicGen, YuE et SongGeneration 2.\n",
+    "\n",
+    "Les modeles de generation musicale ont des forces tres differentes selon le contexte. Cette exercice vous amene a formaliser la logique de selection vue dans la Section 5.\n",
+    "\n",
+    "**Indices** :\n",
+    "- ACE-Step est le seul modele fonctionnant avec moins de 4 GB VRAM (cpu_offload)\n",
+    "- MusicGen est le seul modele purement instrumental (pas de paroles)\n",
+    "- YuE supporte les chansons illimitees mais necessite 24 GB VRAM\n",
+    "- SongGeneration 2 offre la meilleure qualite audio (48kHz FLAC)\n",
+    "- # Etape 1 : Definir les specifications de chaque modele (VRAM, duree max, paroles, langues)\n",
+    "- # Etape 2 : Filtrer par contraintes hard (VRAM disponible, GPU)\n",
+    "- # Etape 3 : Filtrer par besoins fonctionnels (paroles, duree, multilingue)\n",
+    "- # Etape 4 : Retourner le meilleur modele avec justification\n",
+    "- # Indice : Si VRAM < 4 GB, seul ACE-Step (cpu_offload) est viable"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": 12,
+   "id": "3fda9857",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:16:09.379491Z",
+     "iopub.status.busy": "2026-07-09T22:16:09.377917Z",
+     "iopub.status.idle": "2026-07-09T22:16:09.393931Z",
+     "shell.execute_reply": "2026-07-09T22:16:09.391812Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "COMPARAISON DES MODELES DE GENERATION MUSICALE\n",
-      "=======================================================\n",
-      "Critere              ACE-Step v1.5          MusicGen medium        YuE                    SongGen2              \n",
-      "----------------------------------------------------------------------------------------------------------------\n",
-      "Architecture         LM + DiT hybride       Transformer + EnCodec  Flow matching          Diffusion             \n",
-      "Parametres           3.5B (base)            1.5B                   Variable               Variable              \n",
-      "VRAM min             <4 GB (offload)        ~10 GB                 10-24 GB               10-24 GB              \n",
-      "Qualite audio        44.1 kHz stereo        32 kHz mono            44.1 kHz stereo        44.1 kHz stereo       \n",
-      "Duree max            ~4 minutes             ~30 secondes           ~2 minutes             ~2 minutes            \n",
-      "Paroles              Oui (50+ langues)      Non (instrumental)     Oui                    Oui                   \n",
-      "Vitesse (RTX 3090)   <10s / 4min            ~5-10s / 10s           ~30-60s / 1min         ~30-60s / 1min        \n",
-      "Licence              Apache 2.0             MIT                    Apache 2.0             Variable              \n",
-      "Notebook             02-9 (ce notebook)     02-3                   02-7                   02-7                  \n",
+      "Exercice a completer\n",
+      "Exercice a completer\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Matrice de recommandation par cas d'usage\n",
+    "# TODO etudiant : Implementer un selecteur de modele de generation musicale\n",
+    "\n",
+    "def recommend_music_model(vram_gb=6, gpu_available=True, need_lyrics=False,\n",
+    "                          target_duration_s=30, need_multilingual=False,\n",
+    "                          language=\"en\", commercial_use=False):\n",
+    "    \"\"\"\n",
+    "    Recommande le meilleur modele de generation musicale selon les contraintes.\n",
+    "    \n",
+    "    Modeles disponibles : ACE-Step, MusicGen, YuE, SongGeneration 2\n",
+    "    \n",
+    "    Args:\n",
+    "        vram_gb: VRAM disponible en GB\n",
+    "        gpu_available: GPU disponible\n",
+    "        need_lyrics: Besoin de generer avec paroles\n",
+    "        target_duration_s: Duree cible en secondes\n",
+    "        need_multilingual: Support multilingue requis\n",
+    "        language: Langue principale (\"en\", \"fr\", \"ja\", etc.)\n",
+    "        commercial_use: Licence commerciale requise\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict: {\"model\": str, \"reason\": str, \"alternatives\": list}\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : Definir les specs de chaque modele\n",
+    "    models = {}  # TODO etudiant\n",
+    "    \n",
+    "    # TODO etudiant : Filtrer par contraintes materielles (VRAM, GPU)\n",
+    "    # Indice : vram_gb < 4 elimine tous sauf ACE-Step avec cpu_offload\n",
+    "    \n",
+    "    # TODO etudiant : Filtrer par besoins fonctionnels\n",
+    "    # Indice : need_lyrics=True elimine MusicGen\n",
+    "    \n",
+    "    # TODO etudiant : Selectionner le meilleur candidat\n",
+    "    recommendation = None  # TODO etudiant\n",
+    "    reason = None          # TODO etudiant\n",
+    "    alternatives = []      # TODO etudiant\n",
+    "    \n",
+    "    return {\n",
+    "        \"model\": recommendation,\n",
+    "        \"reason\": reason,\n",
+    "        \"alternatives\": alternatives,\n",
+    "    }\n",
+    "\n",
+    "# Test\n",
+    "scenarios = [\n",
+    "    {\"vram_gb\": 4, \"need_lyrics\": True, \"target_duration_s\": 120, \"language\": \"fr\"},\n",
+    "    {\"vram_gb\": 24, \"need_lyrics\": False, \"target_duration_s\": 15},\n",
+    "    {\"vram_gb\": 6, \"need_lyrics\": True, \"target_duration_s\": 180, \"need_multilingual\": True},\n",
+    "]\n",
+    "\n",
+    "for s in scenarios:\n",
+    "    result = recommend_music_model(**s)\n",
+    "    if result[\"model\"]:\n",
+    "        print(f\"VRAM={s.get('vram_gb')}GB, lyrics={s.get('need_lyrics')} -> {result['model']}\")\n",
+    "    else:\n",
+    "        print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "ac4f3cae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:16:09.398047Z",
+     "iopub.status.busy": "2026-07-09T22:16:09.398047Z",
+     "iopub.status.idle": "2026-07-09T22:16:10.127473Z",
+     "shell.execute_reply": "2026-07-09T22:16:10.124521Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "STATISTIQUES DE SESSION\n",
+      "==================================================\n",
+      "Date : 2026-07-10 00:16:09\n",
+      "Modele : ACE-Step v1.5 (3.5B)\n",
+      "Device : cuda\n",
+      "CPU offload : False\n",
+      "Duree configuree : 30.0s\n",
+      "Infer steps : 60\n",
+      "Guidance scale : 15.0\n",
+      "CFG type : apg\n",
+      "Modele charge : Oui\n",
+      "VRAM utilisee : 7.44 GB\n",
       "\n",
-      "RECOMMANDATIONS PAR USE CASE\n",
-      "-------------------------------------------------------\n",
-      "Musique instrumentale courte : MusicGen (qualite, stabilite)\n",
-      "Chanson complete multilingue : ACE-Step (paroles, langues, VRAM)\n",
-      "Chanson haute qualite : YuE / SongGen2 (si GPU 24 GB disponible)\n",
-      "Prototypage rapide sur GPU modeste : ACE-Step avec cpu_offload\n",
-      "Musique de fond sans paroles : MusicGen (optimise pour instrumental)\n",
+      "Generations reussies : 6\n",
+      "  Text-to-song : 3\n",
+      "  Multilingue : 3\n",
+      "  Parametres : 5\n",
       "\n",
-      "AVANTAGES CLES D'ACE-STEP\n",
-      "  1. Plus faible VRAM (<4 GB avec offload vs 10+ GB pour les autres)\n",
-      "  2. Plus longue duree de generation (4 min vs 30s-2min)\n",
-      "  3. Support multilingue natif (50+ langues)\n",
-      "  4. Licence Apache 2.0 (open-source, utilisation commerciale OK)\n",
-      "  5. Audio stereo 44.1 kHz (vs mono 32 kHz pour MusicGen)\n"
+      "Fichiers sauvegardes : 6 (27.4 MB) dans outputs/audio/acestep\n",
+      "\n",
+      "Liberation du modele...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Memoire liberee\n",
+      "\n",
+      "PROCHAINES ETAPES\n",
+      "1. Comparer avec la generation MusicGen (02-3)\n",
+      "2. Explorer YuE et SongGen2 (02-7)\n",
+      "3. Integrer dans un pipeline audio complet (03-Orchestration)\n",
+      "4. Tester avec vos propres paroles et styles\n",
+      "\n",
+      "Notebook ACE-Step termine - 00:16:10\n"
      ]
     }
    ],
@@ -1123,7 +7790,7 @@
     "if save_results:\n",
     "    saved = list(OUTPUT_DIR.glob('*.wav'))\n",
     "    total_size = sum(f.stat().st_size for f in saved) / (1024*1024)\n",
-    "    print(f\"\\nFichiers sauvegardes : {len(saved)} ({total_size:.1f} MB) dans {OUTPUT_DIR}\")\n",
+    "    print(f\"\\nFichiers sauvegardes : {len(saved)} ({total_size:.1f} MB) dans {OUTPUT_DIR.relative_to(GENAI_ROOT).as_posix()}\")\n",
     "\n",
     "# Liberation memoire\n",
     "if pipeline is not None:\n",
@@ -1148,6 +7815,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f8b3fa6b",
    "metadata": {},
    "source": [
     "## Synthese de la session ACE-Step\n",
@@ -1198,8 +7866,384 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "031c013a9a8847239d77e38a5c7fe68b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_f6b583c004bd43918a650d28fecf8c21",
+        "IPY_MODEL_6f1ecf2ce38f4220bd89d0072b6d5e09",
+        "IPY_MODEL_ec5916dcba7d43ed83e9f6b267c95593"
+       ],
+       "layout": "IPY_MODEL_b5ac4d1c83264dd5a79302f0a5cc9675",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "2b67133bdd2e40ecab98a17fa12068b0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "515c4b74d63042018103f09d2d161e64": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "6a66c504eb1e4e11bc2191dc4f1c8a2a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "6f1ecf2ce38f4220bd89d0072b6d5e09": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_515c4b74d63042018103f09d2d161e64",
+       "max": 14.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_2b67133bdd2e40ecab98a17fa12068b0",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 14.0
+      }
+     },
+     "b5ac4d1c83264dd5a79302f0a5cc9675": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "e22344eb7e634a94a6eb329a176ad4f0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "ec5916dcba7d43ed83e9f6b267c95593": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_eda56be74a674087a066c11f71d4197f",
+       "placeholder": "​",
+       "style": "IPY_MODEL_e22344eb7e634a94a6eb329a176ad4f0",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 14/14 [00:00&lt;00:00, 1446.28it/s]"
+      }
+     },
+     "eda56be74a674087a066c11f71d4197f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "f6b583c004bd43918a650d28fecf8c21": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_f974a44b4c6841babb0ab51c4b37d130",
+       "placeholder": "​",
+       "style": "IPY_MODEL_6a66c504eb1e4e11bc2191dc4f1c8a2a",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Fetching 14 files: 100%"
+      }
+     },
+     "f974a44b4c6841babb0ab51c4b37d130": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Closes #5842. See #3801 (rollout .env-loader) + regle F (reparer, jamais contourner).

Le notebook `GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb` etait committe avec des outputs en **"mode demonstration"** (ACE-Step jamais installe — l'outil SOTA n'avait jamais tourne) et une **corruption C.2 pre-existante** (outputs decales de +1 cellule). Cette PR installe le vrai outil (regle F), corrige 4 bugs source et re-execute le notebook **end-to-end sur GPU (RTX 3090)** avec de vraies generations musicales.

## Fixes source (4)

1. **Loader `.env` #3801** (cellule 9) : break-check `GenAI` place AVANT le remount `current_path.parent` (le pattern buggy ne testait jamais `GenAI/.env` depuis les sous-dossiers) + print leak-safe `parent.name/name` (#3436).
2. **`cpu_offload = False`** (cellule 1) : le defaut `True` cible <4 GB VRAM ; la machine canonique (3090 24 GB) n'en a pas besoin — ~10x plus rapide.
3. **Renumerotation headers exercices** (cellules 18/31) : `# Exercice 3` ↔ `# Exercice 1` realignes sur les cellules markdown 17/30.
4. **Type de retour pipeline** (cellules 15/20/25) : bug latent revele par la 1re vraie execution — `ACEStepPipeline()` retourne `[chemin_wav, params_dict]` (list), pas `str`. Les 3 cellules generation ne geraient que `str`/`tuple(audio, sr)` : normalisation `list -> result[0]` inseree.

## Reparation environnement (regle F, verdict SOTA-OK post-fix)

- venv `D:/envs/acestep-venv` (over conda `bonsai` via `--system-site-packages` : herite torch 2.12.0+cu126 sans re-telechargement)
- `pip install git+https://github.com/ace-step/ACE-Step.git` + `torchcodec` 0.14 (torchaudio 2.11 exige torchcodec pour `save`)
- FFmpeg 7.1 **shared** (BtbN) dans `D:/tools` — torchcodec necessite les DLLs partagees (avcodec-61), absentes de la machine (chocolatey = build statique)
- Kernel jupyter dedie `acestep-venv` ; checkpoint ACE-Step-v1-3.5B (~7.8 GB) en cache local

## Preuve d'execution reelle (H.1)

- Smoke test isole prealable (mandat GPU-throttle) : 5s audio @ 10 steps = 52s, VRAM max 7.5 GB, WAV 48 kHz verifie via soundfile
- Full re-exec `nbconvert --execute` : GPU `NVIDIA GeForce RTX 3090 (24.0 GB VRAM)` visible dans les outputs, `.env charge depuis: GenAI/.env`
- **11 generations reelles** : 3 text-to-song 30s (27-57s/morceau, jusqu'a ~1.1x temps reel a 60 steps), 5 configs comparees (14-39s selon steps/scheduler, 2.2x a 30 steps), 3 multilingues 20s (~28-30s) — VRAM 7.44 GB
- 6 WAV (27.4 MB) ecrits dans `outputs/audio/acestep/` (gitignore)
- 3 runs complets nbconvert (Stop & Repair : chaque leak de chemin corrige a la SOURCE puis re-exec integrale — 0 scrub d'output)
- `execution_count` sequentiels 1..N, 0 erreur, outputs ALIGNES (corruption +1 disparue), 0 leak (scan chemins machine/cles), audio non embarque (guard `BATCH_MODE`, WAVs dans `outputs/` gitignore)

## Verdict

`EXEC_PROVED` — SOTA-OK post-fix : le vrai ACE-Step v1-3.5B tourne et genere ; les sorties committees sont ses vraies sorties.
