### PR TITLE
fix(search): rendre visible l'optimalite d'A* dans Search-3-Informed (Prong-B #3801)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -5,10 +5,10 @@
    "id": "nav-header",
    "metadata": {
     "papermill": {
-     "duration": 0.007589,
-     "end_time": "2026-06-05T12:52:50.337485+00:00",
+     "duration": 0.044748,
+     "end_time": "2026-07-09T22:53:52.328044+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:50.329896+00:00",
+     "start_time": "2026-07-09T22:53:52.283296+00:00",
      "status": "completed"
     },
     "tags": []
@@ -40,16 +40,16 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:50.352137Z",
-     "iopub.status.busy": "2026-06-05T12:52:50.351769Z",
-     "iopub.status.idle": "2026-06-05T12:52:54.980663Z",
-     "shell.execute_reply": "2026-06-05T12:52:54.979385Z"
+     "iopub.execute_input": "2026-07-09T22:53:52.348604Z",
+     "iopub.status.busy": "2026-07-09T22:53:52.348455Z",
+     "iopub.status.idle": "2026-07-09T22:53:53.992710Z",
+     "shell.execute_reply": "2026-07-09T22:53:53.992195Z"
     },
     "papermill": {
-     "duration": 4.637522,
-     "end_time": "2026-06-05T12:52:54.981637+00:00",
+     "duration": 1.656798,
+     "end_time": "2026-07-09T22:53:53.999533+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:50.344115+00:00",
+     "start_time": "2026-07-09T22:53:52.342735+00:00",
      "status": "completed"
     },
     "tags": []
@@ -59,20 +59,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: pandas in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.0.2)\n",
-      "Requirement already satisfied: numpy>=1.26.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2.4.2)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2026.1)\n",
-      "Requirement already satisfied: six>=1.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+      "Requirement already satisfied: pandas in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (3.0.3)\n",
+      "Requirement already satisfied: numpy>=1.26.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2.4.4)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2.9.0.post0)\n",
+      "Requirement already satisfied: tzdata in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2025.3)\n",
+      "Requirement already satisfied: six>=1.5 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n"
      ]
     },
     {
@@ -116,10 +107,10 @@
    "id": "intro-section",
    "metadata": {
     "papermill": {
-     "duration": 0.007922,
-     "end_time": "2026-06-05T12:52:54.997515+00:00",
+     "duration": 0.059391,
+     "end_time": "2026-07-09T22:53:54.128083+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:54.989593+00:00",
+     "start_time": "2026-07-09T22:53:54.068692+00:00",
      "status": "completed"
     },
     "tags": []
@@ -158,7 +149,9 @@
     "| Jeu de taquin | État du plateau | État résolu | Nombre de pièces hors place |\n",
     "\n",
     "Ce notebook détaille ces exemples et implémente les algorithmes qui exploitent ces heuristiques.\n",
-    "\n\n> *Ancres savantes -- Hart, P.E., Nilsson, N.J. & Raphael, B. (1968), A Formal Basis for the Heuristic Determination of Minimum Cost Paths, IEEE Transactions on Systems Science and Cybernetics 4(2):100-107 (A*, combine le coût accumulé g(n) et l'heuristique h(n) admissible pour un plus court chemin optimal) ; Pohl, I. (1970), Heuristic Search Viewed as Path Finding in a Graph, Artificial Intelligence 1(3-4):193-204 (Greedy Best-First, exploite h(n) seul, rapide mais non optimal) ; Korf, R.E. (1985), Depth-first Iterative-Deepening: An Optimal Admissible Tree Search, Artificial Intelligence 27(1):97-109 (IDA*, A* itératif borné mémoire) ; Nilsson, N.J. (1980), Principles of Artificial Intelligence, Tioga (admissibilité et consistance des heuristiques) ; Russell, S. & Norvig, P. (2020), Artificial Intelligence: A Modern Approach (4th ed.), Pearson (cadre de la recherche informée et des heuristiques admissibles/consistantes).*"
+    "\n",
+    "\n",
+    "> *Ancres savantes -- Hart, P.E., Nilsson, N.J. & Raphael, B. (1968), A Formal Basis for the Heuristic Determination of Minimum Cost Paths, IEEE Transactions on Systems Science and Cybernetics 4(2):100-107 (A*, combine le coût accumulé g(n) et l'heuristique h(n) admissible pour un plus court chemin optimal) ; Pohl, I. (1970), Heuristic Search Viewed as Path Finding in a Graph, Artificial Intelligence 1(3-4):193-204 (Greedy Best-First, exploite h(n) seul, rapide mais non optimal) ; Korf, R.E. (1985), Depth-first Iterative-Deepening: An Optimal Admissible Tree Search, Artificial Intelligence 27(1):97-109 (IDA*, A* itératif borné mémoire) ; Nilsson, N.J. (1980), Principles of Artificial Intelligence, Tioga (admissibilité et consistance des heuristiques) ; Russell, S. & Norvig, P. (2020), Artificial Intelligence: A Modern Approach (4th ed.), Pearson (cadre de la recherche informée et des heuristiques admissibles/consistantes).*"
    ]
   },
   {
@@ -166,10 +159,10 @@
    "id": "framework-section",
    "metadata": {
     "papermill": {
-     "duration": 0.008709,
-     "end_time": "2026-06-05T12:52:55.016172+00:00",
+     "duration": 0.023825,
+     "end_time": "2026-07-09T22:53:54.186622+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.007463+00:00",
+     "start_time": "2026-07-09T22:53:54.162797+00:00",
      "status": "completed"
     },
     "tags": []
@@ -188,16 +181,16 @@
    "id": "node-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.033339Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.032763Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.048434Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.046930Z"
+     "iopub.execute_input": "2026-07-09T22:53:54.246240Z",
+     "iopub.status.busy": "2026-07-09T22:53:54.242981Z",
+     "iopub.status.idle": "2026-07-09T22:53:54.278212Z",
+     "shell.execute_reply": "2026-07-09T22:53:54.276808Z"
     },
     "papermill": {
-     "duration": 0.025873,
-     "end_time": "2026-06-05T12:52:55.049415+00:00",
+     "duration": 0.064977,
+     "end_time": "2026-07-09T22:53:54.279591+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.023542+00:00",
+     "start_time": "2026-07-09T22:53:54.214614+00:00",
      "status": "completed"
     },
     "tags": []
@@ -352,10 +345,10 @@
    "id": "problem-example-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.007927,
-     "end_time": "2026-06-05T12:52:55.067022+00:00",
+     "duration": 0.018388,
+     "end_time": "2026-07-09T22:53:54.309811+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.059095+00:00",
+     "start_time": "2026-07-09T22:53:54.291423+00:00",
      "status": "completed"
     },
     "tags": []
@@ -372,16 +365,16 @@
    "id": "graph-problem",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.084622Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.084297Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.094107Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.092958Z"
+     "iopub.execute_input": "2026-07-09T22:53:54.368535Z",
+     "iopub.status.busy": "2026-07-09T22:53:54.367775Z",
+     "iopub.status.idle": "2026-07-09T22:53:54.405634Z",
+     "shell.execute_reply": "2026-07-09T22:53:54.395891Z"
     },
     "papermill": {
-     "duration": 0.01995,
-     "end_time": "2026-06-05T12:52:55.095048+00:00",
+     "duration": 0.070027,
+     "end_time": "2026-07-09T22:53:54.411615+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.075098+00:00",
+     "start_time": "2026-07-09T22:53:54.341588+00:00",
      "status": "completed"
     },
     "tags": []
@@ -461,10 +454,10 @@
    "id": "heuristic-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.00763,
-     "end_time": "2026-06-05T12:52:55.110380+00:00",
+     "duration": 0.034188,
+     "end_time": "2026-07-09T22:53:54.465452+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.102750+00:00",
+     "start_time": "2026-07-09T22:53:54.431264+00:00",
      "status": "completed"
     },
     "tags": []
@@ -484,16 +477,16 @@
    "id": "heuristic-function",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.126791Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.126394Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.133106Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.132016Z"
+     "iopub.execute_input": "2026-07-09T22:53:54.519503Z",
+     "iopub.status.busy": "2026-07-09T22:53:54.519123Z",
+     "iopub.status.idle": "2026-07-09T22:53:54.534467Z",
+     "shell.execute_reply": "2026-07-09T22:53:54.532009Z"
     },
     "papermill": {
-     "duration": 0.016134,
-     "end_time": "2026-06-05T12:52:55.133915+00:00",
+     "duration": 0.03869,
+     "end_time": "2026-07-09T22:53:54.537223+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.117781+00:00",
+     "start_time": "2026-07-09T22:53:54.498533+00:00",
      "status": "completed"
     },
     "tags": []
@@ -553,10 +546,10 @@
    "id": "greedy-section",
    "metadata": {
     "papermill": {
-     "duration": 0.006871,
-     "end_time": "2026-06-05T12:52:55.147670+00:00",
+     "duration": 0.011821,
+     "end_time": "2026-07-09T22:53:54.562749+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.140799+00:00",
+     "start_time": "2026-07-09T22:53:54.550928+00:00",
      "status": "completed"
     },
     "tags": []
@@ -590,16 +583,16 @@
    "id": "greedy-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.163339Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.162977Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.171343Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.170380Z"
+     "iopub.execute_input": "2026-07-09T22:53:54.647371Z",
+     "iopub.status.busy": "2026-07-09T22:53:54.647129Z",
+     "iopub.status.idle": "2026-07-09T22:53:54.665633Z",
+     "shell.execute_reply": "2026-07-09T22:53:54.662554Z"
     },
     "papermill": {
-     "duration": 0.017457,
-     "end_time": "2026-06-05T12:52:55.172134+00:00",
+     "duration": 0.082037,
+     "end_time": "2026-07-09T22:53:54.668665+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.154677+00:00",
+     "start_time": "2026-07-09T22:53:54.586628+00:00",
      "status": "completed"
     },
     "tags": []
@@ -689,10 +682,10 @@
    "id": "340234eb",
    "metadata": {
     "papermill": {
-     "duration": 0.007355,
-     "end_time": "2026-06-05T12:52:55.186733+00:00",
+     "duration": 0.021805,
+     "end_time": "2026-07-09T22:53:54.736140+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.179378+00:00",
+     "start_time": "2026-07-09T22:53:54.714335+00:00",
      "status": "completed"
     },
     "tags": []
@@ -707,16 +700,16 @@
    "id": "greedy-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.202778Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.202348Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.207230Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.206241Z"
+     "iopub.execute_input": "2026-07-09T22:53:54.767140Z",
+     "iopub.status.busy": "2026-07-09T22:53:54.766487Z",
+     "iopub.status.idle": "2026-07-09T22:53:54.795382Z",
+     "shell.execute_reply": "2026-07-09T22:53:54.792373Z"
     },
     "papermill": {
-     "duration": 0.014156,
-     "end_time": "2026-06-05T12:52:55.207949+00:00",
+     "duration": 0.053292,
+     "end_time": "2026-07-09T22:53:54.798687+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.193793+00:00",
+     "start_time": "2026-07-09T22:53:54.745395+00:00",
      "status": "completed"
     },
     "tags": []
@@ -738,7 +731,7 @@
       "  Noeuds explores  : 2\n",
       "  Noeuds generes   : 8\n",
       "  Frontiere max    : 5\n",
-      "  Temps            : 0.12 ms\n"
+      "  Temps            : 0.27 ms\n"
      ]
     }
    ],
@@ -756,10 +749,10 @@
    "id": "dcjquopv3vv",
    "metadata": {
     "papermill": {
-     "duration": 0.007307,
-     "end_time": "2026-06-05T12:52:55.222457+00:00",
+     "duration": 0.008274,
+     "end_time": "2026-07-09T22:53:54.817362+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.215150+00:00",
+     "start_time": "2026-07-09T22:53:54.809088+00:00",
      "status": "completed"
     },
     "tags": []
@@ -786,10 +779,10 @@
    "id": "greedy-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.007156,
-     "end_time": "2026-06-05T12:52:55.236818+00:00",
+     "duration": 0.013762,
+     "end_time": "2026-07-09T22:53:54.842461+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.229662+00:00",
+     "start_time": "2026-07-09T22:53:54.828699+00:00",
      "status": "completed"
     },
     "tags": []
@@ -816,10 +809,10 @@
    "id": "astar-section",
    "metadata": {
     "papermill": {
-     "duration": 0.007149,
-     "end_time": "2026-06-05T12:52:55.253375+00:00",
+     "duration": 0.009993,
+     "end_time": "2026-07-09T22:53:54.865462+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.246226+00:00",
+     "start_time": "2026-07-09T22:53:54.855469+00:00",
      "status": "completed"
     },
     "tags": []
@@ -867,16 +860,16 @@
    "id": "astar-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.269240Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.268832Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.277298Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.276328Z"
+     "iopub.execute_input": "2026-07-09T22:53:54.896095Z",
+     "iopub.status.busy": "2026-07-09T22:53:54.894389Z",
+     "iopub.status.idle": "2026-07-09T22:53:54.922670Z",
+     "shell.execute_reply": "2026-07-09T22:53:54.921283Z"
     },
     "papermill": {
-     "duration": 0.017637,
-     "end_time": "2026-06-05T12:52:55.278082+00:00",
+     "duration": 0.0475,
+     "end_time": "2026-07-09T22:53:54.923758+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.260445+00:00",
+     "start_time": "2026-07-09T22:53:54.876258+00:00",
      "status": "completed"
     },
     "tags": []
@@ -969,10 +962,10 @@
    "id": "8a172994",
    "metadata": {
     "papermill": {
-     "duration": 0.006841,
-     "end_time": "2026-06-05T12:52:55.292042+00:00",
+     "duration": 0.011353,
+     "end_time": "2026-07-09T22:53:54.949621+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.285201+00:00",
+     "start_time": "2026-07-09T22:53:54.938268+00:00",
      "status": "completed"
     },
     "tags": []
@@ -987,16 +980,16 @@
    "id": "astar-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.306746Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.306410Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.311737Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.310458Z"
+     "iopub.execute_input": "2026-07-09T22:53:54.967661Z",
+     "iopub.status.busy": "2026-07-09T22:53:54.967321Z",
+     "iopub.status.idle": "2026-07-09T22:53:54.973627Z",
+     "shell.execute_reply": "2026-07-09T22:53:54.972563Z"
     },
     "papermill": {
-     "duration": 0.013755,
-     "end_time": "2026-06-05T12:52:55.312561+00:00",
+     "duration": 0.016137,
+     "end_time": "2026-07-09T22:53:54.974447+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.298806+00:00",
+     "start_time": "2026-07-09T22:53:54.958310+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1019,7 +1012,7 @@
       "  Noeuds explores  : 3\n",
       "  Noeuds generes   : 11\n",
       "  Frontiere max    : 6\n",
-      "  Temps            : 0.13 ms\n"
+      "  Temps            : 0.12 ms\n"
      ]
     }
    ],
@@ -1037,10 +1030,10 @@
    "id": "1mddry1upc6",
    "metadata": {
     "papermill": {
-     "duration": 0.006622,
-     "end_time": "2026-06-05T12:52:55.325927+00:00",
+     "duration": 0.009739,
+     "end_time": "2026-07-09T22:53:54.992062+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.319305+00:00",
+     "start_time": "2026-07-09T22:53:54.982323+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1064,10 +1057,10 @@
    "id": "astar-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.006691,
-     "end_time": "2026-06-05T12:52:55.339186+00:00",
+     "duration": 0.010528,
+     "end_time": "2026-07-09T22:53:55.010140+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.332495+00:00",
+     "start_time": "2026-07-09T22:53:54.999612+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1093,10 +1086,10 @@
    "id": "comparison-section",
    "metadata": {
     "papermill": {
-     "duration": 0.006897,
-     "end_time": "2026-06-05T12:52:55.353208+00:00",
+     "duration": 0.009607,
+     "end_time": "2026-07-09T22:53:55.033049+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.346311+00:00",
+     "start_time": "2026-07-09T22:53:55.023442+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1113,16 +1106,16 @@
    "id": "comparison-greedy-astar",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.369503Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.369080Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.398703Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.397568Z"
+     "iopub.execute_input": "2026-07-09T22:53:55.055341Z",
+     "iopub.status.busy": "2026-07-09T22:53:55.054937Z",
+     "iopub.status.idle": "2026-07-09T22:53:55.091492Z",
+     "shell.execute_reply": "2026-07-09T22:53:55.090477Z"
     },
     "papermill": {
-     "duration": 0.039258,
-     "end_time": "2026-06-05T12:52:55.399690+00:00",
+     "duration": 0.049395,
+     "end_time": "2026-07-09T22:53:55.092307+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.360432+00:00",
+     "start_time": "2026-07-09T22:53:55.042912+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1135,11 +1128,12 @@
       "Comparaison : Greedy vs A*\n",
       "======================================================================\n",
       "Algorithme                          Chemin  Cout (km)  Longueur  Noeuds explores Temps (ms)\n",
-      "    Greedy Bordeaux -> Paris -> Strasbourg       1075         2                2       0.05\n",
+      "    Greedy Bordeaux -> Paris -> Strasbourg       1075         2                2       0.04\n",
       "        A* Bordeaux -> Paris -> Strasbourg       1075         2                3       0.04\n",
       "\n",
       "======================================================================\n",
-      "NOTE : Greedy a trouve un chemin de meme cout qu'A* (coincidence !)\n"
+      "NOTE : sur ce trajet, Greedy egale A* -- mais rien ne le garantit.\n",
+      "Voir le trajet Nice -> Bordeaux ci-dessous, ou Greedy se fait piéger.\n"
      ]
     }
    ],
@@ -1177,7 +1171,8 @@
     "\n",
     "print(\"\\n\" + \"=\" * 70)\n",
     "if result_greedy.cost <= result_astar.cost:\n",
-    "    print(\"NOTE : Greedy a trouve un chemin de meme cout qu'A* (coincidence !)\")\n",
+    "    print(\"NOTE : sur ce trajet, Greedy egale A* -- mais rien ne le garantit.\")\n",
+    "    print(\"Voir le trajet Nice -> Bordeaux ci-dessous, ou Greedy se fait piéger.\")\n",
     "else:\n",
     "    diff = result_greedy.cost - result_astar.cost\n",
     "    pct = (diff / result_astar.cost) * 100\n",
@@ -1186,13 +1181,123 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6ab7895c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008248,
+     "end_time": "2026-07-09T22:53:55.109451+00:00",
+     "exception": false,
+     "start_time": "2026-07-09T22:53:55.101203+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Quand Greedy se fait piéger : Nice → Bordeaux\n",
+    "\n",
+    "Sur le trajet Bordeaux → Strasbourg, Greedy a eu de la chance : la géométrie\n",
+    "« à vol d'oiseau » coïncidait avec le réseau routier. Ce n'est **pas garanti**.\n",
+    "\n",
+    "Prenons **Nice → Bordeaux**. Depuis Nice, l'heuristique rend Grenoble et Lyon\n",
+    "*séduisants* : leur latitude est proche de celle de Bordeaux, donc $h$ y est\n",
+    "faible. Greedy plonge alors vers l'intérieur des terres — mais il n'existe pas\n",
+    "de bonne route vers l'ouest depuis Lyon : il faut *remonter* par Paris. A*, en\n",
+    "tenant compte du coût déjà dépensé ($g$), emprunte la route côtière\n",
+    "Nice → Marseille → Toulouse → Bordeaux. C'est ici que l'**optimalité garantie**\n",
+    "de A* devient visible dans la sortie.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ca315179",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-09T22:53:55.128446Z",
+     "iopub.status.busy": "2026-07-09T22:53:55.128206Z",
+     "iopub.status.idle": "2026-07-09T22:53:55.140424Z",
+     "shell.execute_reply": "2026-07-09T22:53:55.139407Z"
+    },
+    "papermill": {
+     "duration": 0.023352,
+     "end_time": "2026-07-09T22:53:55.141396+00:00",
+     "exception": false,
+     "start_time": "2026-07-09T22:53:55.118044+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison : Greedy vs A* sur Nice -> Bordeaux\n",
+      "======================================================================\n",
+      "Algorithme                                        Chemin  Cout (km)  Longueur  Noeuds explores Temps (ms)\n",
+      "    Greedy Nice -> Grenoble -> Lyon -> Paris -> Bordeaux       1490         4                4       0.06\n",
+      "        A*     Nice -> Marseille -> Toulouse -> Bordeaux        850         3                5       0.04\n",
+      "\n",
+      "======================================================================\n",
+      "Greedy a trouve un chemin 640 km plus long (75.3% de plus).\n",
+      "A* garantit l'optimalite ; Greedy, non : il a suivi l'heuristique vers\n",
+      "l'interieur des terres (Grenoble, Lyon) au lieu de longer la cote.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Cas discriminant : Nice -> Bordeaux (Greedy tombe dans un piege) ---\n",
+    "\n",
+    "problem_nb = GraphProblem('Nice', 'Bordeaux', france_graph)\n",
+    "h_to_bordeaux = make_heuristic('Bordeaux', france_coords)\n",
+    "\n",
+    "print(\"Comparaison : Greedy vs A* sur Nice -> Bordeaux\")\n",
+    "print(\"=\" * 70)\n",
+    "\n",
+    "result_greedy_nb = greedy_best_first_search(problem_nb, h_to_bordeaux)\n",
+    "result_astar_nb = a_star_search(problem_nb, h_to_bordeaux)\n",
+    "\n",
+    "comparison_nb_df = pd.DataFrame([\n",
+    "    {\n",
+    "        'Algorithme': 'Greedy',\n",
+    "        'Chemin': ' -> '.join(result_greedy_nb.path),\n",
+    "        'Cout (km)': result_greedy_nb.cost,\n",
+    "        'Longueur': len(result_greedy_nb.path) - 1,\n",
+    "        'Noeuds explores': result_greedy_nb.nodes_expanded,\n",
+    "        'Temps (ms)': f\"{result_greedy_nb.elapsed_ms:.2f}\",\n",
+    "    },\n",
+    "    {\n",
+    "        'Algorithme': 'A*',\n",
+    "        'Chemin': ' -> '.join(result_astar_nb.path),\n",
+    "        'Cout (km)': result_astar_nb.cost,\n",
+    "        'Longueur': len(result_astar_nb.path) - 1,\n",
+    "        'Noeuds explores': result_astar_nb.nodes_expanded,\n",
+    "        'Temps (ms)': f\"{result_astar_nb.elapsed_ms:.2f}\",\n",
+    "    },\n",
+    "])\n",
+    "\n",
+    "print(comparison_nb_df.to_string(index=False))\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 70)\n",
+    "if result_greedy_nb.cost > result_astar_nb.cost:\n",
+    "    diff = result_greedy_nb.cost - result_astar_nb.cost\n",
+    "    pct = (diff / result_astar_nb.cost) * 100\n",
+    "    print(f\"Greedy a trouve un chemin {diff:.0f} km plus long ({pct:.1f}% de plus).\")\n",
+    "    print(\"A* garantit l'optimalite ; Greedy, non : il a suivi l'heuristique vers\")\n",
+    "    print(\"l'interieur des terres (Grenoble, Lyon) au lieu de longer la cote.\")\n",
+    "else:\n",
+    "    print(\"NOTE : Greedy egale A* sur ce trajet.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "comparison-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.007512,
-     "end_time": "2026-06-05T12:52:55.415362+00:00",
+     "duration": 0.008629,
+     "end_time": "2026-07-09T22:53:55.158480+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.407850+00:00",
+     "start_time": "2026-07-09T22:53:55.149851+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1208,7 +1313,7 @@
     "| Nœuds explorés | Généralement moins | Peut être plus |\n",
     "| Qualité solution | Variable | Toujours optimale |\n",
     "\n",
-    "**Leçon fondamentale** : Greedy peut être plus rapide mais risque de trouver une solution sous-optimale. A* est un peu plus coûteux en exploration mais garantit l'optimalité.\n"
+    "**Leçon fondamentale** : Greedy peut être plus rapide mais risque de trouver une solution sous-optimale. A* est un peu plus coûteux en exploration mais garantit l'optimalité. Le trajet **Nice → Bordeaux** l'illustre concrètement : Greedy y paie **75 % de trajet en plus** (1490 km contre 850 km) en se laissant piéger par l'heuristique, là où A* reste optimal.\n"
    ]
   },
   {
@@ -1216,10 +1321,10 @@
    "id": "ida-section",
    "metadata": {
     "papermill": {
-     "duration": 0.007488,
-     "end_time": "2026-06-05T12:52:55.430385+00:00",
+     "duration": 0.009423,
+     "end_time": "2026-07-09T22:53:55.175069+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.422897+00:00",
+     "start_time": "2026-07-09T22:53:55.165646+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1249,20 +1354,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "idastar-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.447963Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.447542Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.456937Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.455590Z"
+     "iopub.execute_input": "2026-07-09T22:53:55.200657Z",
+     "iopub.status.busy": "2026-07-09T22:53:55.200261Z",
+     "iopub.status.idle": "2026-07-09T22:53:55.212998Z",
+     "shell.execute_reply": "2026-07-09T22:53:55.212292Z"
     },
     "papermill": {
-     "duration": 0.020059,
-     "end_time": "2026-06-05T12:52:55.458172+00:00",
+     "duration": 0.03079,
+     "end_time": "2026-07-09T22:53:55.213715+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.438113+00:00",
+     "start_time": "2026-07-09T22:53:55.182925+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1356,10 +1461,10 @@
    "id": "40f8a8e5",
    "metadata": {
     "papermill": {
-     "duration": 0.007806,
-     "end_time": "2026-06-05T12:52:55.474013+00:00",
+     "duration": 0.032262,
+     "end_time": "2026-07-09T22:53:55.260556+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.466207+00:00",
+     "start_time": "2026-07-09T22:53:55.228294+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1370,20 +1475,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "idastar-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.493837Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.493351Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.498804Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.497521Z"
+     "iopub.execute_input": "2026-07-09T22:53:55.287884Z",
+     "iopub.status.busy": "2026-07-09T22:53:55.287486Z",
+     "iopub.status.idle": "2026-07-09T22:53:55.293764Z",
+     "shell.execute_reply": "2026-07-09T22:53:55.292712Z"
     },
     "papermill": {
-     "duration": 0.018213,
-     "end_time": "2026-06-05T12:52:55.499803+00:00",
+     "duration": 0.017612,
+     "end_time": "2026-07-09T22:53:55.294601+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.481590+00:00",
+     "start_time": "2026-07-09T22:53:55.276989+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1425,10 +1530,10 @@
    "id": "0gzwacp0hfbq",
    "metadata": {
     "papermill": {
-     "duration": 0.007932,
-     "end_time": "2026-06-05T12:52:55.515870+00:00",
+     "duration": 0.007979,
+     "end_time": "2026-07-09T22:53:55.312351+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.507938+00:00",
+     "start_time": "2026-07-09T22:53:55.304372+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1452,10 +1557,10 @@
    "id": "idastar-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.008043,
-     "end_time": "2026-06-05T12:52:55.531884+00:00",
+     "duration": 0.008091,
+     "end_time": "2026-07-09T22:53:55.328979+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.523841+00:00",
+     "start_time": "2026-07-09T22:53:55.320888+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1483,10 +1588,10 @@
    "id": "752d920b",
    "metadata": {
     "papermill": {
-     "duration": 0.007995,
-     "end_time": "2026-06-05T12:52:55.548332+00:00",
+     "duration": 0.011633,
+     "end_time": "2026-07-09T22:53:55.355390+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.540337+00:00",
+     "start_time": "2026-07-09T22:53:55.343757+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1508,20 +1613,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "b119ca90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.566904Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.566507Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.571574Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.570538Z"
+     "iopub.execute_input": "2026-07-09T22:53:55.375331Z",
+     "iopub.status.busy": "2026-07-09T22:53:55.374967Z",
+     "iopub.status.idle": "2026-07-09T22:53:55.381170Z",
+     "shell.execute_reply": "2026-07-09T22:53:55.380308Z"
     },
     "papermill": {
-     "duration": 0.015857,
-     "end_time": "2026-06-05T12:52:55.572456+00:00",
+     "duration": 0.018192,
+     "end_time": "2026-07-09T22:53:55.382047+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.556599+00:00",
+     "start_time": "2026-07-09T22:53:55.363855+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1552,10 +1657,10 @@
    "id": "all-comparison-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009639,
-     "end_time": "2026-06-05T12:52:55.590451+00:00",
+     "duration": 0.01584,
+     "end_time": "2026-07-09T22:53:55.407722+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.580812+00:00",
+     "start_time": "2026-07-09T22:53:55.391882+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1568,20 +1673,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "all-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.616675Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.616256Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.625998Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.624793Z"
+     "iopub.execute_input": "2026-07-09T22:53:55.427618Z",
+     "iopub.status.busy": "2026-07-09T22:53:55.427387Z",
+     "iopub.status.idle": "2026-07-09T22:53:55.436378Z",
+     "shell.execute_reply": "2026-07-09T22:53:55.435198Z"
     },
     "papermill": {
-     "duration": 0.025694,
-     "end_time": "2026-06-05T12:52:55.627070+00:00",
+     "duration": 0.021339,
+     "end_time": "2026-07-09T22:53:55.438872+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.601376+00:00",
+     "start_time": "2026-07-09T22:53:55.417533+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1679,10 +1784,10 @@
    "id": "all-comparison-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.008851,
-     "end_time": "2026-06-05T12:52:55.644347+00:00",
+     "duration": 0.010812,
+     "end_time": "2026-07-09T22:53:55.470444+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.635496+00:00",
+     "start_time": "2026-07-09T22:53:55.459632+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1709,10 +1814,10 @@
    "id": "heuristic-design-section",
    "metadata": {
     "papermill": {
-     "duration": 0.008749,
-     "end_time": "2026-06-05T12:52:55.661682+00:00",
+     "duration": 0.009509,
+     "end_time": "2026-07-09T22:53:55.489185+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.652933+00:00",
+     "start_time": "2026-07-09T22:53:55.479676+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1728,10 +1833,10 @@
    "id": "admissibility-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009046,
-     "end_time": "2026-06-05T12:52:55.679796+00:00",
+     "duration": 0.010486,
+     "end_time": "2026-07-09T22:53:55.509286+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.670750+00:00",
+     "start_time": "2026-07-09T22:53:55.498800+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1760,10 +1865,10 @@
    "id": "consistency-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009119,
-     "end_time": "2026-06-05T12:52:55.698848+00:00",
+     "duration": 0.008852,
+     "end_time": "2026-07-09T22:53:55.528685+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.689729+00:00",
+     "start_time": "2026-07-09T22:53:55.519833+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1795,10 +1900,10 @@
    "id": "dominance-section",
    "metadata": {
     "papermill": {
-     "duration": 0.013963,
-     "end_time": "2026-06-05T12:52:55.723868+00:00",
+     "duration": 0.008869,
+     "end_time": "2026-07-09T22:53:55.545850+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.709905+00:00",
+     "start_time": "2026-07-09T22:53:55.536981+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1829,10 +1934,10 @@
    "id": "puzzle-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009267,
-     "end_time": "2026-06-05T12:52:55.746457+00:00",
+     "duration": 0.012204,
+     "end_time": "2026-07-09T22:53:55.569001+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.737190+00:00",
+     "start_time": "2026-07-09T22:53:55.556797+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1852,20 +1957,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "puzzle-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.766576Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.766008Z",
-     "iopub.status.idle": "2026-06-05T12:52:55.780957Z",
-     "shell.execute_reply": "2026-06-05T12:52:55.779640Z"
+     "iopub.execute_input": "2026-07-09T22:53:55.596323Z",
+     "iopub.status.busy": "2026-07-09T22:53:55.596102Z",
+     "iopub.status.idle": "2026-07-09T22:53:55.608893Z",
+     "shell.execute_reply": "2026-07-09T22:53:55.607906Z"
     },
     "papermill": {
-     "duration": 0.026538,
-     "end_time": "2026-06-05T12:52:55.782015+00:00",
+     "duration": 0.029797,
+     "end_time": "2026-07-09T22:53:55.609820+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.755477+00:00",
+     "start_time": "2026-07-09T22:53:55.580023+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2003,10 +2108,10 @@
    "id": "b3189c7b",
    "metadata": {
     "papermill": {
-     "duration": 0.012698,
-     "end_time": "2026-06-05T12:52:55.807602+00:00",
+     "duration": 0.017766,
+     "end_time": "2026-07-09T22:53:55.638827+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.794904+00:00",
+     "start_time": "2026-07-09T22:53:55.621061+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2017,20 +2122,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "puzzle-benchmark",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:52:55.834040Z",
-     "iopub.status.busy": "2026-06-05T12:52:55.833571Z",
-     "iopub.status.idle": "2026-06-05T12:53:02.564153Z",
-     "shell.execute_reply": "2026-06-05T12:53:02.562995Z"
+     "iopub.execute_input": "2026-07-09T22:53:55.720734Z",
+     "iopub.status.busy": "2026-07-09T22:53:55.717805Z",
+     "iopub.status.idle": "2026-07-09T22:54:00.870635Z",
+     "shell.execute_reply": "2026-07-09T22:54:00.866598Z"
     },
     "papermill": {
-     "duration": 6.74484,
-     "end_time": "2026-06-05T12:53:02.565041+00:00",
+     "duration": 5.21335,
+     "end_time": "2026-07-09T22:54:00.874054+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:52:55.820201+00:00",
+     "start_time": "2026-07-09T22:53:55.660704+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2050,8 +2155,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees            1        1         0.03\n",
-      "Distance Manhattan            1        1         0.02\n",
+      "Tuiles mal placees            1        1         0.29\n",
+      "Distance Manhattan            1        1         0.22\n",
       "\n",
       "Reduction des noeuds explores : 0.0%\n",
       "\n",
@@ -2062,8 +2167,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees          770       16         4.65\n",
-      "Distance Manhattan          220       16         1.63\n",
+      "Tuiles mal placees          770       16        25.18\n",
+      "Distance Manhattan          220       16         3.49\n",
       "\n",
       "Reduction des noeuds explores : 71.4%\n",
       "\n",
@@ -2080,8 +2185,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees       143839       31      1189.57\n",
-      "Distance Manhattan        20290       31       199.86\n",
+      "Tuiles mal placees       143839       31      4181.53\n",
+      "Distance Manhattan        20290       31       829.55\n",
       "\n",
       "Reduction des noeuds explores : 85.9%\n"
      ]
@@ -2089,11 +2194,11 @@
     {
      "data": {
       "text/plain": [
-       "(<__main__.SearchResult at 0x2b6f7d9a390>,\n",
-       " <__main__.SearchResult at 0x2b6f81c6b10>)"
+       "(<__main__.SearchResult at 0x2547a3aa600>,\n",
+       " <__main__.SearchResult at 0x2547a3a8b90>)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2142,10 +2247,10 @@
    "id": "k292t2mslp",
    "metadata": {
     "papermill": {
-     "duration": 0.007446,
-     "end_time": "2026-06-05T12:53:02.580433+00:00",
+     "duration": 0.039432,
+     "end_time": "2026-07-09T22:54:00.953691+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:02.572987+00:00",
+     "start_time": "2026-07-09T22:54:00.914259+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2170,10 +2275,10 @@
    "id": "puzzle-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.007426,
-     "end_time": "2026-06-05T12:53:02.595121+00:00",
+     "duration": 0.022696,
+     "end_time": "2026-07-09T22:54:01.006554+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:02.587695+00:00",
+     "start_time": "2026-07-09T22:54:00.983858+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2201,10 +2306,10 @@
    "id": "d7b928ea",
    "metadata": {
     "papermill": {
-     "duration": 0.00664,
-     "end_time": "2026-06-05T12:53:02.608623+00:00",
+     "duration": 0.070472,
+     "end_time": "2026-07-09T22:54:01.155675+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:02.601983+00:00",
+     "start_time": "2026-07-09T22:54:01.085203+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2232,20 +2337,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "b55555ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:53:02.623279Z",
-     "iopub.status.busy": "2026-06-05T12:53:02.623036Z",
-     "iopub.status.idle": "2026-06-05T12:53:02.627364Z",
-     "shell.execute_reply": "2026-06-05T12:53:02.626504Z"
+     "iopub.execute_input": "2026-07-09T22:54:01.357746Z",
+     "iopub.status.busy": "2026-07-09T22:54:01.357318Z",
+     "iopub.status.idle": "2026-07-09T22:54:01.371272Z",
+     "shell.execute_reply": "2026-07-09T22:54:01.370174Z"
     },
     "papermill": {
-     "duration": 0.012834,
-     "end_time": "2026-06-05T12:53:02.628025+00:00",
+     "duration": 0.116103,
+     "end_time": "2026-07-09T22:54:01.372339+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:02.615191+00:00",
+     "start_time": "2026-07-09T22:54:01.256236+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2279,10 +2384,10 @@
    "id": "visualization-section",
    "metadata": {
     "papermill": {
-     "duration": 0.006319,
-     "end_time": "2026-06-05T12:53:02.640753+00:00",
+     "duration": 0.009292,
+     "end_time": "2026-07-09T22:54:01.400071+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:02.634434+00:00",
+     "start_time": "2026-07-09T22:54:01.390779+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2295,20 +2400,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "puzzle-visualization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:53:02.655035Z",
-     "iopub.status.busy": "2026-06-05T12:53:02.654688Z",
-     "iopub.status.idle": "2026-06-05T12:53:03.171998Z",
-     "shell.execute_reply": "2026-06-05T12:53:03.170981Z"
+     "iopub.execute_input": "2026-07-09T22:54:01.423512Z",
+     "iopub.status.busy": "2026-07-09T22:54:01.423058Z",
+     "iopub.status.idle": "2026-07-09T22:54:02.384565Z",
+     "shell.execute_reply": "2026-07-09T22:54:02.383825Z"
     },
     "papermill": {
-     "duration": 0.525584,
-     "end_time": "2026-06-05T12:53:03.172920+00:00",
+     "duration": 0.975832,
+     "end_time": "2026-07-09T22:54:02.385285+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:02.647336+00:00",
+     "start_time": "2026-07-09T22:54:01.409453+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2430,10 +2535,10 @@
    "id": "visualization-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.007987,
-     "end_time": "2026-06-05T12:53:03.189682+00:00",
+     "duration": 0.009351,
+     "end_time": "2026-07-09T22:54:02.403951+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.181695+00:00",
+     "start_time": "2026-07-09T22:54:02.394600+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2456,10 +2561,10 @@
    "id": "summary-table-section",
    "metadata": {
     "papermill": {
-     "duration": 0.007319,
-     "end_time": "2026-06-05T12:53:03.204891+00:00",
+     "duration": 0.008664,
+     "end_time": "2026-07-09T22:54:02.421117+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.197572+00:00",
+     "start_time": "2026-07-09T22:54:02.412453+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2472,20 +2577,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "final-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:53:03.221497Z",
-     "iopub.status.busy": "2026-06-05T12:53:03.221105Z",
-     "iopub.status.idle": "2026-06-05T12:53:03.441449Z",
-     "shell.execute_reply": "2026-06-05T12:53:03.440401Z"
+     "iopub.execute_input": "2026-07-09T22:54:02.526700Z",
+     "iopub.status.busy": "2026-07-09T22:54:02.526236Z",
+     "iopub.status.idle": "2026-07-09T22:54:03.236944Z",
+     "shell.execute_reply": "2026-07-09T22:54:03.234843Z"
     },
     "papermill": {
-     "duration": 0.229868,
-     "end_time": "2026-06-05T12:53:03.442230+00:00",
+     "duration": 0.731113,
+     "end_time": "2026-07-09T22:54:03.238522+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.212362+00:00",
+     "start_time": "2026-07-09T22:54:02.507409+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2499,10 +2604,10 @@
       "Tableau recapitulatif : Algorithmes de recherche\n",
       "================================================================================\n",
       "Algorithme Complet Optimal Cout  Noeuds explores Temps (ms)\n",
-      "       BFS     Oui     Non 1075                2       0.04\n",
-      "       UCS     Oui     Oui 1075               10       0.07\n",
-      "    Greedy     Non     Non 1075                2       0.03\n",
-      "        A*     Oui     Oui 1075                3       0.03\n"
+      "       BFS     Oui     Non 1075                2       0.10\n",
+      "       UCS     Oui     Oui 1075               10       0.20\n",
+      "    Greedy     Non     Non 1075                2       0.09\n",
+      "        A*     Oui     Oui 1075                3       0.10\n"
      ]
     },
     {
@@ -2670,10 +2775,10 @@
    "id": "summary-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.008555,
-     "end_time": "2026-06-05T12:53:03.459437+00:00",
+     "duration": 0.026205,
+     "end_time": "2026-07-09T22:54:03.282930+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.450882+00:00",
+     "start_time": "2026-07-09T22:54:03.256725+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2712,10 +2817,10 @@
    "id": "exercises-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009142,
-     "end_time": "2026-06-05T12:53:03.478068+00:00",
+     "duration": 0.035479,
+     "end_time": "2026-07-09T22:54:03.359605+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.468926+00:00",
+     "start_time": "2026-07-09T22:54:03.324126+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2730,20 +2835,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "exercise1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:53:03.502369Z",
-     "iopub.status.busy": "2026-06-05T12:53:03.501802Z",
-     "iopub.status.idle": "2026-06-05T12:53:03.507292Z",
-     "shell.execute_reply": "2026-06-05T12:53:03.506050Z"
+     "iopub.execute_input": "2026-07-09T22:54:03.432381Z",
+     "iopub.status.busy": "2026-07-09T22:54:03.431871Z",
+     "iopub.status.idle": "2026-07-09T22:54:03.438659Z",
+     "shell.execute_reply": "2026-07-09T22:54:03.437044Z"
     },
     "papermill": {
-     "duration": 0.018262,
-     "end_time": "2026-06-05T12:53:03.508449+00:00",
+     "duration": 0.03984,
+     "end_time": "2026-07-09T22:54:03.440521+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.490187+00:00",
+     "start_time": "2026-07-09T22:54:03.400681+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2766,10 +2871,10 @@
    "id": "exercise2",
    "metadata": {
     "papermill": {
-     "duration": 0.010017,
-     "end_time": "2026-06-05T12:53:03.528388+00:00",
+     "duration": 0.012043,
+     "end_time": "2026-07-09T22:54:03.463365+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.518371+00:00",
+     "start_time": "2026-07-09T22:54:03.451322+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2782,20 +2887,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "exercise2-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:53:03.550844Z",
-     "iopub.status.busy": "2026-06-05T12:53:03.550372Z",
-     "iopub.status.idle": "2026-06-05T12:53:03.559011Z",
-     "shell.execute_reply": "2026-06-05T12:53:03.557822Z"
+     "iopub.execute_input": "2026-07-09T22:54:03.512928Z",
+     "iopub.status.busy": "2026-07-09T22:54:03.512521Z",
+     "iopub.status.idle": "2026-07-09T22:54:03.521915Z",
+     "shell.execute_reply": "2026-07-09T22:54:03.520783Z"
     },
     "papermill": {
-     "duration": 0.021808,
-     "end_time": "2026-06-05T12:53:03.560022+00:00",
+     "duration": 0.039114,
+     "end_time": "2026-07-09T22:54:03.522843+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.538214+00:00",
+     "start_time": "2026-07-09T22:54:03.483729+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2868,10 +2973,10 @@
    "id": "exercise3",
    "metadata": {
     "papermill": {
-     "duration": 0.009146,
-     "end_time": "2026-06-05T12:53:03.578711+00:00",
+     "duration": 0.013426,
+     "end_time": "2026-07-09T22:54:03.546713+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.569565+00:00",
+     "start_time": "2026-07-09T22:54:03.533287+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2889,20 +2994,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "exercise3-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:53:03.597958Z",
-     "iopub.status.busy": "2026-06-05T12:53:03.597563Z",
-     "iopub.status.idle": "2026-06-05T12:53:03.606786Z",
-     "shell.execute_reply": "2026-06-05T12:53:03.605833Z"
+     "iopub.execute_input": "2026-07-09T22:54:03.583564Z",
+     "iopub.status.busy": "2026-07-09T22:54:03.583070Z",
+     "iopub.status.idle": "2026-07-09T22:54:03.594678Z",
+     "shell.execute_reply": "2026-07-09T22:54:03.593617Z"
     },
     "papermill": {
-     "duration": 0.02013,
-     "end_time": "2026-06-05T12:53:03.607562+00:00",
+     "duration": 0.032621,
+     "end_time": "2026-07-09T22:54:03.595475+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.587432+00:00",
+     "start_time": "2026-07-09T22:54:03.562854+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2914,9 +3019,9 @@
      "text": [
       "Heuristique MST pour le TSP (sur le graphe des villes françaises)\n",
       "=================================================================\n",
-      "  current=Bordeaux     unvisited={'Paris', 'Marseille', 'Lyon'}                → h=1224 km\n",
-      "  current=Paris        unvisited={'Marseille', 'Nantes', 'Toulouse', 'Lyon'}   → h=1527 km\n",
-      "  current=Lyon         unvisited={'Nice', 'Grenoble'}                          → h=410 km\n",
+      "  current=Bordeaux     unvisited={'Paris', 'Lyon', 'Marseille'}                → h=1224 km\n",
+      "  current=Paris        unvisited={'Toulouse', 'Marseille', 'Lyon', 'Nantes'}   → h=1527 km\n",
+      "  current=Lyon         unvisited={'Grenoble', 'Nice'}                          → h=410 km\n",
       "\n",
       "Propriétés :\n",
       "  ✓ Admissible : le MST est une borne inférieure sur tout tour restant\n",
@@ -3010,10 +3115,10 @@
    "id": "exercise4",
    "metadata": {
     "papermill": {
-     "duration": 0.008653,
-     "end_time": "2026-06-05T12:53:03.624954+00:00",
+     "duration": 0.009143,
+     "end_time": "2026-07-09T22:54:03.613635+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.616301+00:00",
+     "start_time": "2026-07-09T22:54:03.604492+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3028,20 +3133,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "exercise4-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:53:03.643944Z",
-     "iopub.status.busy": "2026-06-05T12:53:03.643487Z",
-     "iopub.status.idle": "2026-06-05T12:53:03.763235Z",
-     "shell.execute_reply": "2026-06-05T12:53:03.762110Z"
+     "iopub.execute_input": "2026-07-09T22:54:03.633283Z",
+     "iopub.status.busy": "2026-07-09T22:54:03.633056Z",
+     "iopub.status.idle": "2026-07-09T22:54:03.879314Z",
+     "shell.execute_reply": "2026-07-09T22:54:03.878365Z"
     },
     "papermill": {
-     "duration": 0.13043,
-     "end_time": "2026-06-05T12:53:03.764121+00:00",
+     "duration": 0.257805,
+     "end_time": "2026-07-09T22:54:03.880106+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.633691+00:00",
+     "start_time": "2026-07-09T22:54:03.622301+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3204,10 +3309,10 @@
    "id": "97bc629e",
    "metadata": {
     "papermill": {
-     "duration": 0.009716,
-     "end_time": "2026-06-05T12:53:03.783146+00:00",
+     "duration": 0.009471,
+     "end_time": "2026-07-09T22:54:03.899585+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.773430+00:00",
+     "start_time": "2026-07-09T22:54:03.890114+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3236,20 +3341,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "2a6adc42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:53:03.803234Z",
-     "iopub.status.busy": "2026-06-05T12:53:03.802796Z",
-     "iopub.status.idle": "2026-06-05T12:53:03.809574Z",
-     "shell.execute_reply": "2026-06-05T12:53:03.808463Z"
+     "iopub.execute_input": "2026-07-09T22:54:03.936712Z",
+     "iopub.status.busy": "2026-07-09T22:54:03.936235Z",
+     "iopub.status.idle": "2026-07-09T22:54:03.946301Z",
+     "shell.execute_reply": "2026-07-09T22:54:03.944470Z"
     },
     "papermill": {
-     "duration": 0.018097,
-     "end_time": "2026-06-05T12:53:03.810475+00:00",
+     "duration": 0.033961,
+     "end_time": "2026-07-09T22:54:03.947881+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.792378+00:00",
+     "start_time": "2026-07-09T22:54:03.913920+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3339,10 +3444,10 @@
    "id": "conclusion-section",
    "metadata": {
     "papermill": {
-     "duration": 0.009051,
-     "end_time": "2026-06-05T12:53:03.828698+00:00",
+     "duration": 0.02098,
+     "end_time": "2026-07-09T22:54:03.985199+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.819647+00:00",
+     "start_time": "2026-07-09T22:54:03.964219+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3392,10 +3497,10 @@
    "id": "nav-footer",
    "metadata": {
     "papermill": {
-     "duration": 0.009293,
-     "end_time": "2026-06-05T12:53:03.847094+00:00",
+     "duration": 0.026374,
+     "end_time": "2026-07-09T22:54:04.030612+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:53:03.837801+00:00",
+     "start_time": "2026-07-09T22:54:04.004238+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3406,7 +3511,16 @@
     "Ce notebook a présenté les algorithmes de recherche informée, qui utilisent des connaissances spécifiques du problème (heuristiques) pour guider l'exploration. L'efficacité de ces algorithmes dépend crucialement de la qualité de l'heuristique.\n",
     "\n",
     "**Prochain notebook** : [Search-4-LocalSearch](Search-4-LocalSearch.ipynb) — Découvrez les algorithmes de recherche locale (Hill Climbing, Simulated Annealing, Tabu Search) qui explorent l'espace de recherche de manière différente, sans maintenir de frontière explicite.\n",
-    "\n\n### References academiques\n\n- Hart, P.E., Nilsson, N.J. & Raphael, B. (1968). A Formal Basis for the Heuristic Determination of Minimum Cost Paths. IEEE Transactions on Systems Science and Cybernetics 4(2):100-107.\n- Pohl, I. (1970). Heuristic Search Viewed as Path Finding in a Graph. Artificial Intelligence 1(3-4):193-204.\n- Korf, R.E. (1985). Depth-first Iterative-Deepening: An Optimal Admissible Tree Search. Artificial Intelligence 27(1):97-109.\n- Nilsson, N.J. (1980). Principles of Artificial Intelligence. Tioga Publishing.\n- Russell, S. & Norvig, P. (2020). Artificial Intelligence: A Modern Approach (4th ed.). Pearson.\n\n"
+    "\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Hart, P.E., Nilsson, N.J. & Raphael, B. (1968). A Formal Basis for the Heuristic Determination of Minimum Cost Paths. IEEE Transactions on Systems Science and Cybernetics 4(2):100-107.\n",
+    "- Pohl, I. (1970). Heuristic Search Viewed as Path Finding in a Graph. Artificial Intelligence 1(3-4):193-204.\n",
+    "- Korf, R.E. (1985). Depth-first Iterative-Deepening: An Optimal Admissible Tree Search. Artificial Intelligence 27(1):97-109.\n",
+    "- Nilsson, N.J. (1980). Principles of Artificial Intelligence. Tioga Publishing.\n",
+    "- Russell, S. & Norvig, P. (2020). Artificial Intelligence: A Modern Approach (4th ed.). Pearson.\n",
+    "\n"
    ]
   }
  ],
@@ -3426,18 +3540,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.14"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 16.557371,
-   "end_time": "2026-06-05T12:53:04.420718+00:00",
+   "duration": 13.902354,
+   "end_time": "2026-07-09T22:54:04.626758+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Search-3-Informed.ipynb",
-   "output_path": "Search-3-Informed.ipynb",
+   "input_path": "D:\\dev\\wt-c394-search3-prongb\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-3-Informed.ipynb",
+   "output_path": "D:\\dev\\wt-c394-search3-prongb\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-3-Informed_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-05T12:52:47.863347+00:00",
+   "start_time": "2026-07-09T22:53:50.724404+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Correction d'une **démonstration dégénérée** dans `Search-3-Informed.ipynb` (doctrine **#3801 Prong-B** : un notebook qui présente un moteur doit poser un problème assez riche pour que la capacité distinctive du moteur soit **visible dans la sortie**, jamais un cas où le SOTA équivaut à une baseline triviale).

La cellule « Comparaison Greedy vs A* » tournait sur **Bordeaux → Strasbourg**, où Greedy Best-First et A* trouvent **exactement le même chemin** (`Bordeaux → Paris → Strasbourg`, 1075 km). L'avantage d'**optimalité garantie** d'A* — le point pédagogique central de toute la section — restait donc **invisible**. Le notebook livrait même l'aveu dans sa sortie : `NOTE : Greedy a trouve un chemin de meme cout qu'A* (coincidence !)`. La cellule d'interprétation qui suit affirme « Greedy risque de trouver une solution sous-optimale » **sans jamais le démontrer**.

## Le correctif (additif)

Ajout d'un **cas discriminant** juste après la comparaison de référence : **Nice → Bordeaux**.

| Algorithme | Chemin trouvé | Coût |
|------------|---------------|------|
| Greedy | Nice → Grenoble → Lyon → Paris → Bordeaux | **1490 km** |
| A* | Nice → Marseille → Toulouse → Bordeaux | **850 km** |

Greedy paie **+640 km (+75,3 %)**. L'intuition est nette : depuis Nice, l'heuristique (distance à vol d'oiseau) rend Grenoble/Lyon *séduisants* — leur latitude est proche de celle de Bordeaux, donc `h` y est faible —, alors qu'il n'existe pas de bonne route vers l'ouest depuis Lyon (il faut *remonter* par Paris). A*, en tenant compte du coût déjà dépensé (`g`), emprunte la route côtière optimale. **L'optimalité d'A* est désormais visible dans la sortie.**

Les 21 paires (départ, but) du graphe ont été énumérées avec l'implémentation **réelle** du notebook ; `Nice → Bordeaux` est la plus discriminante (75 %). La démonstration de référence Bordeaux → Strasbourg est **conservée** (le fait que Greedy y égale A* est lui-même instructif : « Greedy *peut* avoir de la chance quand la géométrie coïncide avec les routes ») ; sa note est reformulée pour introduire le contraste.

## Vérification

- **EXEC_PROVED** : ré-exécution complète via `notebook_tools.py execute --kernel python3` — SUCCESS 15 s, **24 cellules code, 0 `execution_count` null, 0 erreur** (C.2).
- **Anti-régression** : diff source prouvé — 2 cellules éditées (comparaison + interprétation), 2 cellules ajoutées (md + code discriminant), **63 cellules restantes byte-identiques**. Aucune cellule pédagogique supprimée. La volumétrie du diff (460/-346) = régénération des sorties + renumérotation des `execution_count` par la ré-exécution.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0`. La cellule ajoutée est un **exemple** (solution complète fonctionnelle = démonstration), pas un exercice → aucun impact sur le décompte #2161 (le notebook conserve ses exercices existants).
- **catalog-pr-hygiene R1** : catalogue et README **non touchés** (byte-identiques à main) ; marqueurs `CATALOG-STATUS` inchangés.
- **CJK** : 0 caractère parasite.

## Verdict SOTA

**SOTA-OK** : le vrai moteur (A* / Greedy Best-First de `search_helpers`) est exécuté sur un problème désormais **non-dégénéré** où l'heuristique discrimine réellement. Applique la même correction que le canonique `8905f8845` (planners-3, BFS-vs-A* sur graphe à coût uniforme).

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
