### PR TITLE
fix(epic-5780): reintegration narrative ML+RL README figures (retrait mosaique)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -33,22 +33,9 @@ Avoir ces trois angles permet de comprendre que le ML n'est pas lié à un langa
 4. **Intégrer** des agents LLM dans un workflow data science (analyse automatisée, parsing, recommandation)
 5. **Déployer** un modèle en production (export ONNX, interop Python/.NET, BigQuery ML)
 
-## Aperçu — le machine learning en images
+## Figures — extraites des sorties réelles des notebooks
 
-Les figures ci-dessous sont extraites des sorties réelles des notebooks (EPIC #5654). Elles balayent les trois fils de la série : les fondations Python (Pandas, visualisation), le pipeline ML.NET (régression, séries temporelles, clustering) et l'angle émergent des agents data-science (Google ADK). La provenance exacte de chaque figure est documentée dans `assets/readme/MANIFEST.md`.
-
-<table>
-<tr>
-<td align="center"><b>Fondations Pandas</b><br><a href="DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb"><img width="290" alt="Fondations Python pour la data science : visualisation exploratoire des ventes (graphiques Matplotlib) sur un échantillon tabulaire." src="assets/readme/lab1-foundations.png"></a></td>
-<td align="center"><b>Visualisation (Seaborn)</b><br><a href="DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb"><img width="290" alt="Visualisation de données : évolution journalière du chiffre d'affaires agrégé, tracée avec Seaborn sur un dataframe Pandas." src="assets/readme/lab5-viz.png"></a></td>
-<td align="center"><b>Régression (scikit-learn)</b><br><a href="ML.Net/ML-1-Introduction-Python.ipynb"><img width="290" alt="Régression linéaire : droite apprise par scikit-learn superposée aux données d'entraînement et de test (prix immobiliers)." src="assets/readme/ml1-intro.png"></a></td>
-</tr>
-<tr>
-<td align="center"><b>Séries temporelles (STL)</b><br><a href="ML.Net/ML-5-TimeSeries-Python.ipynb"><img width="290" alt="Décomposition STL d'une série temporelle : signal observé, tendance, composante saisonnière (période 7 hebdomadaire) et résidus." src="assets/readme/ml5-timeseries.png"></a></td>
-<td align="center"><b>Clustering (K-Means)</b><br><a href="ML.Net/ML-8-Clustering-Python.ipynb"><img width="290" alt="Clustering K-Means : restitution des 3 segments cachés (Dormants, Réguliers, VIP) sans supervision, projetés sur deux variables." src="assets/readme/ml8-clustering.png"></a></td>
-<td align="center"><b>Agent data-science (ADK)</b><br><a href="DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb"><img width="290" alt="Premier agent ADK : un agent du Agent Development Kit génère et exécute du code Matplotlib (revenu par produit) via sa boucle d'outils." src="assets/readme/lab9-adk.png"></a></td>
-</tr>
-</table>
+Six figures illustrent les trois fils de la série : les fondations Python (Pandas, visualisation), le pipeline ML.NET (régression, séries temporelles, clustering) et l'angle émergent des agents data-science (Google ADK). Elles sont **réintégrées in-situ** dans les sections qui en commentent le concept — chacune en regard du notebook qu'elle illustre. La provenance exacte (cellule source, poids, alt-text) figure dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
 ## Parcours d'apprentissage
 
@@ -127,6 +114,17 @@ Pipeline ML.NET complet en C#, de l'introduction à l'évaluation avancée : du 
 | 9-Py | [ML-9-Anomaly-Detection-Python](ML.Net/ML-9-Anomaly-Detection-Python.ipynb) | **Jumeau Python** : `RandomizedPca` ⇄ `PCA`+résidu (scikit-learn) | Parité .NET⇄Python |
 | TP | [TP-prevision-ventes](ML.Net/TP-prevision-ventes.ipynb) | Régression bayésienne (Infer.NET) | Application pratique |
 
+### Trois figures du track ML.NET (scikit-learn, statsmodels)
+
+[![Régression linéaire (ML-1) : droite de régression verte apprise par scikit-learn superposée aux données d'entraînement (cercles bleus) et de test (carrés oranges) — l'étoile rouge matérialise la prédiction pour une maison de 2,5 milliers de pieds carrés (~2,76 centaines de milliers de dollars).](assets/readme/ml1-intro.png)](ML.Net/ML-1-Introduction-Python.ipynb)
+*ML-1 — Régression linéaire prix/surface (scikit-learn). On observe que les points `Test` (oranges) s'éloignent de la droite pour les grandes surfaces (> 6 milliers de pieds carrés) : le modèle linéaire sous-extrapole les grandes maisons, ce que la métrique R² seule ne signalera pas.*
+
+[![Décomposition STL d'une série temporelle de ventes (ML-5) : quatre panneaux superposés — Observé (oscillations bruitées autour de 100-180), Tendance (courbe orange lisse montant de ~110 début 2023 à ~160 fin 2023), Saisonnalité (sinusoïde verte d'amplitude ~40, période 7 jours), Bruit (résidu rose, amplitude ~±25).](assets/readme/ml5-timeseries.png)](ML.Net/ML-5-TimeSeries-Python.ipynb)
+*ML-5 — Décomposition STL (`statsmodels.tsa.seasonal_decompose`, période 7). La saisonnalité hebdomadaire se lit immédiatement (amplitude ±40), et la tendance capture la croissance sous-jacente (~+50 sur 12 mois). Le TP-prevision-ventes s'appuie sur ce découpage pour combiner signal et saisonnalité.*
+
+[![Clustering K-Means (ML-8) en deux panneaux : à gauche la vérité terrain (3 segments Dormants/Réguliers/VIP sur l'axe Frequency × Monetary) ; à droite les clusters 0/1/2 retrouvés par K-Means — on observe que les labels K-Means ne s'alignent PAS avec les segments sémantiques (Cluster 0 ≠ Dormants) : K-Means segmente l'espace géométrique, pas la sémantique métier.](assets/readme/ml8-clustering.png)](ML.Net/ML-8-Clustering-Python.ipynb)
+*ML-8 — Clustering K-Means sur données RFM (scikit-learn). Le notebook démontre la **limitation sémantique** du K-Means non supervisé : les segments de clientèle (Dormants/Réguliers/VIP) sont des catégories métier, pas des clusters géométriques. La concordance parfaite n'est possible que par chance — d'où l'intérêt d'un *mapping* a posteriori (et des méthodes supervisées dès qu'on connaît les segments).*
+
 ### Installation ML.NET
 
 ```bash
@@ -150,6 +148,17 @@ Formation complète en Data Science Python enrichie d'agents IA. Vous commencere
 |----------|---------|
 | [1.2-NumPy](DataScienceWithAgents/01-PythonForDataScience/notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb) | Arrays, vectorisation, opérations |
 | [1.3-Pandas](DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb) | DataFrames, filtrage, manipulation |
+
+#### Trois figures du track Data Science (Pandas, Seaborn, ADK)
+
+[![Fondations Pandas (Lab1) en deux panneaux — à gauche les ventes journalières du Widget A sur 20 jours (janvier 2024), courbe oscillant entre 123 et 188 ; à droite les ventes moyennes par catégorie en barres (Accessoires ≈ 45, Électronique ≈ 130, Premium ≈ 225).](assets/readme/lab1-foundations.png)](DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb)
+*Lab1 — Pandas & Matplotlib : visualisation exploratoire des ventes (20 jours, série temporelle + barres par catégorie). Cette figure introduit le double-outil Pandas + Matplotlib qu'utilisent ensuite tous les notebooks ML du track.*
+
+[![Visualisation Seaborn (Lab5) : courbe de l'évolution du chiffre d'affaires journalier entre le 01-10 et le 04-10, décroissance de ~760 à ~230 puis remontée à ~480.](assets/readme/lab5-viz.png)](DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb)
+*Lab5 — Seaborn : la décroissance brutale (760→230 sur 24h) signale un trou de données ou un pic isolé — le notebook la commente comme un artefact à investiguer plutôt qu'un trend. Seaborn ajoute le lissage et la mise en forme, mais l'insight reste dans la séquence temporelle.*
+
+[![Agent ADK (Lab9) : diagramme en barres du revenu total par produit — Gadget Y (~46 000) > Widget B (~44 500) > Gadget X (~34 000) > Widget A (~27 500).](assets/readme/lab9-adk.png)](DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb)
+*Lab9 — Premier agent ADK : l'agent a généré et exécuté le code Matplotlib qui produit cette figure, en autonomie à partir d'une requête en langage naturel (« compare le revenu par produit »). L'insight (Gadget Y bat Widget A de 70%) provient du tri décroissant que l'agent a ajouté spontanément.*
 
 ### Socle ML canonique (02-ML-Cours)
 

--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -15,16 +15,11 @@ Cette série couvre les **fondements théoriques** (bandits, MDP, équation de B
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs souhaitant ajouter des capacités décisionnelles à leurs applications, et chercheurs en automatique ou robotique. Prérequis : Python intermédiaire et bases en calculus (gradients). Aucune expérience RL préalable nécessaire pour le notebook 1.
 
-## Aperçu — l'apprentissage par renforcement en images
+## Figures — extraites des sorties réelles des notebooks
 
-Le RL se comprend mieux en voyant l'agent apprendre. Les six visualisations ci-dessous, extraites des notebooks de la série, suivent la progression des fondements aux frontières : du bandit multi-bras à l'exploration par curiosité, en passant par les MDP, le reward shaping, les POMDP et le RL distributionnel. Sorties d'exécution **réelles** (non régénérées pour l'illustration, règle C.3), downscalées à ≤1200 px et ≤200 ko (politique EPIC #5654). Provenance exacte dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
+Le RL se comprend mieux en voyant l'agent apprendre. Six visualisations suivent la progression des fondements aux frontières : des bandits multi-bras à l'exploration par curiosité, en passant par les MDP, le reward shaping, les POMDP et le RL distributionnel. Sorties d'exécution **réelles** (règle C.3 — non régénérées pour l'illustration). Elles sont **réintégrées in-situ** dans la section qui en commente le concept ; la provenance exacte (cellule source, poids, alt-text) figure dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
-| | | |
-|:--:|:--:|:--:|
-| <img src="assets/readme/rl4-bandits.png" width="290" alt="Bandits multi-bras : courbes de regret et comparaison exploration/exploitation entre stratégies (epsilon-greedy, UCB, Thompson)."> | <img src="assets/readme/rl5-mdp-qlearning.png" width="290" alt="MDP et Q-Learning : grille de valeurs d'action apprises par programmation dynamique et Q-Learning tabulaire."> | <img src="assets/readme/rl10-reward-shaping.png" width="290" alt="Reward shaping : impact de la forme de récompense sur la vitesse et la stabilité d'apprentissage de l'agent."> |
-| [rl_4 — Multi-Armed Bandits](rl_4_multi_armed_bandits.ipynb) | [rl_5 — MDP / Q-Learning](rl_5_mdp_dp_qlearning.ipynb) | [rl_10 — Reward Shaping](rl_10_reward_shaping.ipynb) |
-| <img src="assets/readme/rl11-pomdp.png" width="290" alt="POMDP : apprentissage sous observation partielle, croyances sur l'état caché reconstruites depuis l'historique."> | <img src="assets/readme/rl12-distributional.png" width="290" alt="RL distributionnel : la valeur estimée est une distribution complète (pas juste l'espérance), capturant l'incertitude."> | <img src="assets/readme/rl13-curiosity.png" width="290" alt="Exploration par curiosité : récompense intrinsèque mesurant la nouveauté pousse l'agent vers des états inconnus."> |
-| [rl_11 — POMDP](rl_11_pomdp.ipynb) | [rl_12 — Distributional RL](rl_12_distributional_rl.ipynb) | [rl_13 — Curiosity](rl_13_curiosity_exploration.ipynb) |
+> **Note honnête — dette de fabrication (EPIC #5654)** : à l'audit (lecture directe des PNG, pas de la légende), on observe que les fichiers `rl4-bandits.png` et `rl5-mdp-qlearning.png` semblent **intervertis** : `rl4-bandits.png` affiche une courbe de convergence Q-Learning sur FrozenLake, et `rl5-mdp-qlearning.png` affiche la convergence de bandits multi-bras. Les légendes ci-dessous sont **fidèles au contenu réel du PNG** (règle L378 durcie), pas au nom de fichier. PR de fix séparé à ouvrir pour ré-extraire les PNG dans le bon ordre.
 
 ## Notebooks
 
@@ -87,6 +82,16 @@ Le RL se comprend mieux en voyant l'agent apprendre. Les six visualisations ci-d
 | Stratégies naïves | Aléatoire, greedy, epsilon-greedy |
 | Stratégies intelligentes | Decaying epsilon-greedy, Thompson Sampling |
 | Analyse | Comparaison regret, visualisation des estimations |
+
+> ⚠️ **Avertissement légende (dette de fabrication EPIC #5654)** : le fichier `rl4-bandits.png` du dossier `assets/readme/` n'illustre PAS (à l'audit) le notebook 4 — il affiche une courbe de convergence Q-Learning sur FrozenLake (typique du notebook 5). Légende ci-dessous fidèle au **contenu réel du PNG**, pas au nom de fichier. Fix de ré-extraction dans un PR séparé.
+
+<p align="center"><img src="assets/readme/rl4-bandits.png" width="640" alt="Convergence Q-Learning sur FrozenLake : courbe de récompense cumulée par épisode, décroissance de l'erreur TD, politique greedy finale."></p>
+<p align="center"><em>Sortie d'exécution du notebook 5 (MDP / Q-Learning) — malgré le nom de fichier rl4-bandits.png, ce PNG illustre la convergence Q-Learning tabulaire sur FrozenLake. PR de ré-extraction à ouvrir pour rétablir la concordance nom-contenu.</em></p>
+
+> ⚠️ **Avertissement légende symétrique** : le fichier `rl5-mdp-qlearning.png` n'illustre PAS (à l'audit) le notebook 5 — il affiche la convergence de stratégies bandit multi-bras (epsilon-greedy vs UCB vs Thompson). Légende ci-dessous fidèle au contenu réel.
+
+<p align="center"><img src="assets/readme/rl5-mdp-qlearning.png" width="640" alt="Convergence bandit multi-bras : courbes de regret cumulé comparant epsilon-greedy, UCB1 et Thompson Sampling, avec convergence des estimations de moyenne vers les vraies valeurs des bras."></p>
+<p align="center"><em>Sortie d'exécution du notebook 4 (Bandits) — malgré le nom de fichier rl5-mdp-qlearning.png, ce PNG illustre la convergence des stratégies bandit. Symétrique de l'avertissement rl4 ci-dessus, fix groupé dans un PR séparé.</em></p>
 
 ### Notebook 5 - MDP, Programmation Dynamique et Q-Learning
 
@@ -195,6 +200,9 @@ Le RL se comprend mieux en voyant l'agent apprendre. Les six visualisations ci-d
 | Pont RLHF | Reward model appris, contrainte KL, DPO, inverse RL |
 | Exercices | Ablation potentiels, phases curriculum, biais du shaping naïf |
 
+<p align="center"><img src="assets/readme/rl10-reward-shaping.png" width="640" alt="Reward shaping : comparaison de la vitesse de convergence entre baseline (récompense sparse), potential-based shaping (Ng 1999) et curriculum learning (start progressif). Courbes de récompense cumulée par épisode."></p>
+<p align="center"><em>Sortie d'exécution du notebook 10 — illustration de l'accélération de convergence par potential-based shaping et curriculum, conforme à la cellule Comparaison du notebook (épisodes pour atteindre la politique optimale : potential ep 50, curriculum ep 122, baseline ep 190).</em></p>
+
 ### Notebook 11 - POMDP : Partial Observability et Belief Tracking
 
 | Section | Contenu |
@@ -206,6 +214,9 @@ Le RL se comprend mieux en voyant l'agent apprendre. Les six visualisations ci-d
 | Belief-state Q-learning | Discrétisation du belief en 20 bins, Q-learning dans l'espace des croyances |
 | Comparaison | 5 seeds, impact de la précision d'observation, pont DRQN/PPO+LSTM |
 | Exercices | Impact précision, nombre optimal d'écoutes, Tiger 3 portes |
+
+<p align="center"><img src="assets/readme/rl11-pomdp.png" width="640" alt="POMDP Tiger Problem : évolution de la croyance P(tigre-à-gauche) au fil des observations bruitées (écoute à 85% de précision), avec marqueurs des actions Listen/Open prises par la politique."></p>
+<p align="center"><em>Sortie d'exécution du notebook 11 — filtre bayésien de croyance sur le Tiger Problem : la masse de probabilité migre vers 0 ou 1 selon les observations Listen, l'agent choisit quand ouvrir selon le seuil de croyance (cassandra 1994).</em></p>
 
 ### Notebook 12 - RL distributionnel : C51 (Categorical DQN)
 
@@ -219,6 +230,9 @@ Le RL se comprend mieux en voyant l'agent apprendre. Les six visualisations ci-d
 | C51 vs DQN | Tableau comparatif, lignée QR-DQN / IQN / Rainbow |
 | Exercices | QR-DQN (quantile regression), sensibilité du support, politique sensible au risque (CVaR) |
 
+<p align="center"><img src="assets/readme/rl12-distributional.png" width="640" alt="C51 sur CartPole-v1 : courbe de récompense par épisode (convergence vers 500 vers ~8000 pas) + distribution catégorielle Z(s,a) apprise pour l'action optimale (51 atomes sur support fixe)."></p>
+<p align="center"><em>Sortie d'exécution du notebook 12 — apprentissage C51 sur CartPole-v1 : la distribution de retour apprise par action (histogramme à 51 atomes) est visualisée en fin d'entraînement, comparée à la valeur scalaire Q = E[Z].</em></p>
+
 ### Notebook 13 - Exploration par curiosité : Random Network Distillation (RND)
 
 | Section | Contenu |
@@ -230,6 +244,9 @@ Le RL se comprend mieux en voyant l'agent apprendre. Les six visualisations ci-d
 | Partie B - piège d'exploitation | Chaîne MDP : epsilon-greedy plafonne sur le piège (~0.10), RND atteint la grande récompense (~0.96) |
 | Comparaison | RND vs comptage tabulaire / pseudo-comptage / ICM, problème de la noisy-TV, réglage du taux du prédicteur |
 | Exercices | Effet de beta, normalisation du bonus intrinsèque (Welford), limites de la curiosité (longueur de chaîne) |
+
+<p align="center"><img src="assets/readme/rl13-curiosity.png" width="640" alt="RND (Random Network Distillation) sur chaîne MDP-piège : à gauche, courbe de récompense extrinsèque comparant epsilon-greedy (~0.10, bloqué) vs RND (~0.96) ; à droite, heatmap de visite des états montrant que RND parcourt toute la chaîne."></p>
+<p align="center"><em>Sortie d'exécution du notebook 13 — exploration par curiosité sur le benchmark chaîne-piège (Burda et al. 2018) : RND atteint la grande récompense distale là où epsilon-greedy plafonne sur l'appât proximal. Le ratio inconnu/visité initial (~1969x) chute à mesure que le prédicteur RND est entraîné.</em></p>
 
 ## Algorithmes couverts
 


### PR DESCRIPTION
## Summary

Quatrième vague du sweep **EPIC #5780 doctrine figures** sur les READMEs `MyIA.AI.Notebooks/ML/README.md` et `MyIA.AI.Notebooks/RL/README.md`. Après les pilotes c.373 (#5786 SL), c.374 (#5787 ML.Net) et c.375/c.376 (#5791 IIT/ICT avec fix G.1), ces deux READMEs étaient les derniers de la famille à conserver une **mosaïque `<table>` isolée** regroupant 6 figures PNG en tête de fichier — pattern interdit par la doctrine L378 (cf [§5780 L378 figures doctrine](.claude/rules/sota-not-workaround.md)).

## Le correctif

**ML/README** : retrait mosaïque `<table>` 6-figures → réintégration **in-situ** dans les sections qui commentent chaque concept :
- 3 figures track ML.NET (juste après le tableau récap) : `ml1-intro.png` (régression linéaire scikit-learn), `ml5-timeseries.png` (décomposition STL 4 panneaux statsmodels), `ml8-clustering.png` (K-Means RFM).
- 3 figures track Data Science (juste après le sommaire 1.1-NumPy/1.2-Pandas/1.3-Pandas) : `lab1-foundations.png`, `lab5-viz.png`, `lab9-adk.png`.

Toutes les légendes sont **fidèles au contenu réel du PNG** (lecture directe via Read, pas au nom de fichier), conformément à L378 durcie (c.376).

**RL/README** : retrait mosaïque `<table>` 6-figures → réintégration **in-situ** :
- Notebook 4 (Bandits) : figures `rl4-bandits.png` + `rl5-mdp-qlearning.png` insérées **avec avertissement symétrique** discloseant la dette de fabrication (cf §Détection).
- Notebook 10 (Reward Shaping) : `rl10-reward-shaping.png`.
- Notebook 11 (POMDP Tiger) : `rl11-pomdp.png`.
- Notebook 12 (C51 distributionnel) : `rl12-distributional.png`.
- Notebook 13 (RND Curiosity) : `rl13-curiosity.png`.

## Détection — dette de fabrication EPIC #5654 (à corriger en PR séparé)

À l'audit L378 durcie (lecture PNG directe via Read), j'ai constaté que les fichiers `rl4-bandits.png` et `rl5-mdp-qlearning.png` du dossier `assets/readme/` semblent **intervertis** par rapport à ce que leur nom suggère :

| Fichier PNG | Contenu observé à l'audit | Notebook attendu |
|-------------|---------------------------|------------------|
| `rl4-bandits.png` | Courbe de convergence Q-Learning tabulaire sur FrozenLake (récompense cumulée, décroissance erreur TD) | Notebook 5 (MDP/Q-Learning) |
| `rl5-mdp-qlearning.png` | Convergence bandit multi-bras (regret cumulé, epsilon-greedy vs UCB vs Thompson) | Notebook 4 (Bandits) |

**Hypothèse** : un script d'extraction automatique (probablement durant le rollout EPIC #5654 qui a généré ces PNG à partir des cellules de sortie des notebooks) a utilisé un ordre décalé. Aucun nom de fichier n'a été modifié dans ce PR — les légendes sont fidèles au **contenu réel**, et un **avertissement explicite** (⚠️ + note en tête de section README) disclose cette dette.

**Fix prévu (PR séparé)** : ré-extraire les 6 PNG RL depuis les cellules de sortie des notebooks `rl_4_multi_armed_bandits.ipynb` et `rl_5_mdp_dp_qlearning.ipynb` (la fonction d'export PNG est dans le notebook lui-même) puis renommer pour rétablir la concordance nom-contenu. Le MANIFEST.md sera mis à jour en cohérence.

Le `MyIA.AI.Notebooks/RL/assets/readme/MANIFEST.md` n'est **pas touché** dans cette PR — sa correction relève du PR de ré-extraction (sortie de scope).

## Légende corrigée — `ml8-clustering.png` (ML/README)

Le PNG montre deux panneaux côte-à-côte : à gauche la vérité terrain (3 segments Dormants/Réguliers/VIP), à droite les clusters K-Means retrouvés. **Les labels K-Means ne s'alignent PAS avec les segments sémantiques** (Cluster 0 ≠ Dormants). Légende de la figure explicitée pour refléter cette **limitation pédagogique** du K-Means non supervisé — c'est précisément ce que le notebook ML-8 démontre (la concordance parfaite n'est possible que par chance ou mapping a posteriori).

## Vérification anti-régression (R1 catalog-pr-hygiene + C.1/C.2/README-first)

- **R1 catalog** : `git diff origin/main -- MyIA.AI.Notebooks/ML/README.md MyIA.AI.Notebooks/RL/README.md | grep -c "CATALOG-STATUS"` = **0**. Marqueurs `<!-- CATALOG-STATUS:START -->...:END -->` byte-identiques à `origin/main`. Aucun fichier `COURSE_CATALOG.generated.{json,md}` touché.
- **Pas d'autre diff** : 2 fichiers modifiés (ML + RL README), aucun autre dans ce commit. `git diff --stat` = `+50/-24`.
- **CJK** : 0 caractère parasite (filtre 4 ranges Unicode post-Edit).
- **README-only PR** : aucun notebook exécuté, aucun `.ipynb` touché, aucun script modifié. Scope strict = prose de documentation (règle §E code-style + README-first).

## Verdict

**DOCTRINE L378 APPLIQUÉE** : (a) pas de Galerie/table isolée — réintégration in-situ au notebook cité, (b) chaque PNG ouvert via Read AVANT légende (G.1 firsthand), (c) « limitation illustrative assumée » explicite + **dette de nommage disclosee** (rl4↔rl5 swap). Sweep cohérent avec les 3 pilotes précédents (#5786 SL, #5787 ML.Net, #5791 IIT/ICT). Aucun workaround dégradé, aucune régénération de catalogue sur branche (R1).

**Honnêteté** : les PNG authentiques pour les notebooks RL 4 et 5 ne sont pas disponibles correctement nommés dans cette PR. La note en tête de section disclose le swap ; le PR de ré-extraction groupé rétablira la concordance. Aucune cellule pédagogique supprimée, aucune légende fabriquée de mémoire.

See #5780

🤖 Generated with [Claude Code](https://claude.com/claude-code)