### PR TITLE
fix(pymc): PyMC-18 stale 'cf. PyMC-8' in cell 11 print + honest full re-exec

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
@@ -32,10 +32,10 @@
    "id": "b8f8f126",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T12:48:23.663009Z",
-     "iopub.status.busy": "2026-07-04T12:48:23.663009Z",
-     "iopub.status.idle": "2026-07-04T12:48:27.257497Z",
-     "shell.execute_reply": "2026-07-04T12:48:27.257497Z"
+     "iopub.execute_input": "2026-07-10T00:22:01.696363Z",
+     "iopub.status.busy": "2026-07-10T00:22:01.695805Z",
+     "iopub.status.idle": "2026-07-10T00:22:03.622476Z",
+     "shell.execute_reply": "2026-07-10T00:22:03.622476Z"
     }
    },
    "outputs": [
@@ -90,10 +90,10 @@
    "id": "52d1acc3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T12:48:27.257497Z",
-     "iopub.status.busy": "2026-07-04T12:48:27.257497Z",
-     "iopub.status.idle": "2026-07-04T12:51:32.478182Z",
-     "shell.execute_reply": "2026-07-04T12:51:32.474597Z"
+     "iopub.execute_input": "2026-07-10T00:22:03.624481Z",
+     "iopub.status.busy": "2026-07-10T00:22:03.624481Z",
+     "iopub.status.idle": "2026-07-10T00:22:10.983102Z",
+     "shell.execute_reply": "2026-07-10T00:22:10.983102Z"
     }
    },
    "outputs": [
@@ -129,7 +129,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 33 seconds.\n"
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 4 seconds.\n"
      ]
     },
     {
@@ -182,10 +182,10 @@
    "id": "b1ec2032",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T12:51:32.481726Z",
-     "iopub.status.busy": "2026-07-04T12:51:32.481726Z",
-     "iopub.status.idle": "2026-07-04T12:51:32.496502Z",
-     "shell.execute_reply": "2026-07-04T12:51:32.493016Z"
+     "iopub.execute_input": "2026-07-10T00:22:10.985107Z",
+     "iopub.status.busy": "2026-07-10T00:22:10.985107Z",
+     "iopub.status.idle": "2026-07-10T00:22:10.987845Z",
+     "shell.execute_reply": "2026-07-10T00:22:10.987845Z"
     }
    },
    "outputs": [
@@ -239,10 +239,10 @@
    "id": "b28d33d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T12:51:32.504992Z",
-     "iopub.status.busy": "2026-07-04T12:51:32.504992Z",
-     "iopub.status.idle": "2026-07-04T12:51:59.258783Z",
-     "shell.execute_reply": "2026-07-04T12:51:59.247664Z"
+     "iopub.execute_input": "2026-07-10T00:22:10.989357Z",
+     "iopub.status.busy": "2026-07-10T00:22:10.989357Z",
+     "iopub.status.idle": "2026-07-10T00:22:15.647441Z",
+     "shell.execute_reply": "2026-07-10T00:22:15.647441Z"
     }
    },
    "outputs": [
@@ -285,7 +285,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 24 seconds.\n"
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 4 seconds.\n"
      ]
     },
     {
@@ -362,10 +362,10 @@
    "id": "9f088c32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T12:51:59.272682Z",
-     "iopub.status.busy": "2026-07-04T12:51:59.272682Z",
-     "iopub.status.idle": "2026-07-04T12:53:52.490438Z",
-     "shell.execute_reply": "2026-07-04T12:53:52.490438Z"
+     "iopub.execute_input": "2026-07-10T00:22:15.649456Z",
+     "iopub.status.busy": "2026-07-10T00:22:15.649456Z",
+     "iopub.status.idle": "2026-07-10T00:22:39.701129Z",
+     "shell.execute_reply": "2026-07-10T00:22:39.699946Z"
     }
    },
    "outputs": [
@@ -401,7 +401,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 108 seconds.\n"
+      "Sampling 4 chains for 1_500 tune and 2_000 draw iterations (6_000 + 8_000 draws total) took 23 seconds.\n"
      ]
     },
     {
@@ -428,7 +428,7 @@
       "=> Vraie rupture : H -> 0 (localisation quasi certaine).\n",
       "=> Pur bruit    : H ~= Hmax (posterieur quasi PLAT) -- le modele N'identifie pas de coupure nette ;\n",
       "                  il exprime honnetement son incertitude (moyennage MCMC).\n",
-      "=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. PyMC-8), pas la seule entropie.\n"
+      "=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. PyMC-10), pas la seule entropie.\n"
      ]
     }
    ],
@@ -474,7 +474,7 @@
     "print(\"=> Vraie rupture : H -> 0 (localisation quasi certaine).\")\n",
     "print(\"=> Pur bruit    : H ~= Hmax (posterieur quasi PLAT) -- le modele N'identifie pas de coupure nette ;\")\n",
     "print(\"                  il exprime honnetement son incertitude (moyennage MCMC).\")\n",
-    "print(\"=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. PyMC-8), pas la seule entropie.\")"
+    "print(\"=> Test decisif (vraie rupture vs bruit) : Bayes factor (cf. PyMC-10), pas la seule entropie.\")"
    ]
   },
   {
@@ -520,10 +520,10 @@
    "id": "1b84eb8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T12:53:52.495703Z",
-     "iopub.status.busy": "2026-07-04T12:53:52.495703Z",
-     "iopub.status.idle": "2026-07-04T12:53:52.501218Z",
-     "shell.execute_reply": "2026-07-04T12:53:52.500713Z"
+     "iopub.execute_input": "2026-07-10T00:22:39.704503Z",
+     "iopub.status.busy": "2026-07-10T00:22:39.704503Z",
+     "iopub.status.idle": "2026-07-10T00:22:39.711278Z",
+     "shell.execute_reply": "2026-07-10T00:22:39.709545Z"
     }
    },
    "outputs": [
@@ -562,10 +562,10 @@
    "id": "2c58e383",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T12:53:52.504228Z",
-     "iopub.status.busy": "2026-07-04T12:53:52.504228Z",
-     "iopub.status.idle": "2026-07-04T12:53:52.516611Z",
-     "shell.execute_reply": "2026-07-04T12:53:52.515601Z"
+     "iopub.execute_input": "2026-07-10T00:22:39.715818Z",
+     "iopub.status.busy": "2026-07-10T00:22:39.715818Z",
+     "iopub.status.idle": "2026-07-10T00:22:39.725780Z",
+     "shell.execute_reply": "2026-07-10T00:22:39.725780Z"
     }
    },
    "outputs": [
@@ -605,10 +605,10 @@
    "id": "2d59af55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T12:53:52.519611Z",
-     "iopub.status.busy": "2026-07-04T12:53:52.518611Z",
-     "iopub.status.idle": "2026-07-04T12:53:52.526064Z",
-     "shell.execute_reply": "2026-07-04T12:53:52.524672Z"
+     "iopub.execute_input": "2026-07-10T00:22:39.731345Z",
+     "iopub.status.busy": "2026-07-10T00:22:39.730473Z",
+     "iopub.status.idle": "2026-07-10T00:22:39.737104Z",
+     "shell.execute_reply": "2026-07-10T00:22:39.735981Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary
Follow-up of the **out-of-scope flag documented in #5856**: code cell 11 of `PyMC-18-Change-Point` prints a Bayes-factor cross-ref that still pointed to the OLD position — `cf. PyMC-8` — while Model-Selection moved **8→10** in the 12-move mirror (#5361 c.3). Being inside a code cell's print, it could not be fixed in #5856 without re-execution.

**Stacked on #5856** (`refactor/5361-pymc-renum-mirror`): PyMC-18's markdown cross-refs are touched there; merging #5856 first auto-retargets this PR to main.

## Change
- Cell 11 source: `cf. PyMC-8` → `cf. PyMC-10` (1 line).
- **Full honest re-exec** (C.2: code-source change = complete re-execution). Kernel `pymc18-jsboi` → env `coursia-ml-training` (pymc 5.28.5, py 3.12.13 = notebook's language_info match). No hand-edited output (Stop & Repair).

## Validation (H.1 evidence)
- `nbconvert --execute` exit 0 ; **exec_counts 1–8 sequential, 0 error outputs**.
- Cell-level diff vs base: **only cell 11 source changed** ; outputs churned only on the 3 `pm.sample` cells (4, 8, 11).
- Seeds fixed (`random_seed=42`, `np.random.seed(7)`) → **entropy results bit-identical** to committed outputs (`H(cp) = 0.111 / 6.056 bits`); cells 4/8 output diff = wall-time lines only (33s→4s, 24s→4s).
- Corrected print visible in regenerated output: `Bayes factor (cf. PyMC-10)` ✔
- Path-leak scan (#3436): none. `metadata.kernelspec` unchanged (`python3`). Catalogue untouched (byte-identical).

## SOTA verdict
SOTA-OK — real PyMC MCMC re-executed locally (CPU), no workaround, no output scrubbing.

See #5361, Part of #5081

🤖 Generated with [Claude Code](https://claude.com/claude-code)