### PR TITLE
docs(genai-image): examples README — galerie mosaic -> figures en contexte narratif + fix libellé lit2 (See #5780)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/examples/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/README.md
@@ -25,20 +25,59 @@ Exemples concrets d'utilisation des notebooks GenAI Image dans différents domai
 
 ## Exemples concrets
 
-### Histoire-Geography
-- **Reconstitutions historiques** : Génération d'images de scènes historiques précises
-- **Cartes interactives** : Création de cartes avec annotations et légendes
-- **Vestiges archéologiques** : Reconstruction de sites historiques à partir de descriptions
+Les trois notebooks ont été exécutés avec `gpt-image-1` ; les figures ci-dessous sont leurs sorties réelles, réduites en WebP pour l'affichage. La provenance et le poids natif de chaque image sont détaillés dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
-### Literature
-- **Illustrations de romans** : Conversion de passages descriptifs en images
-- **Poésie visuelle** : Création d'artistes en poésie et textes littéraires
-- **Couvertures de livres** : Design de couvertures attrayantes pour différents genres
+### Histoire-Géographie
+
+Le notebook [history-geography](history-geography.ipynb) couvre trois usages distincts : la cartographie pédagogique, la reconstitution de monuments et la mise en frise des événements.
+
+Pour la **cartographie**, le prompt décrit une aire géographique, ses subdivisions et le contenu attendu de la légende ; le modèle rend alors une carte lisible plutôt qu'une illustration décorative. La figure ci-dessous représente l'Empire romain à son apogée en 117 ap. J.-C. : provinces en aplats colorés (Gallia, Britannia, Italia, Asia, Africa…), Méditerranée centrale, légende (province, cité, route) et rose des vents.
+
+<p align="center">
+<img src="assets/readme/imgex-hist1.webp" alt="Carte pédagogique de l'Empire romain à son apogée (117 ap. J.-C.) : provinces en aplats colorés, Méditerranée centrale, légende et rose des vents" width="480"/><br/>
+<sub><b>Empire romain (117 ap. J.-C.)</b> — carte d'expansion en format paysage : provinces nommées, réseau routier, légende et rose des vents (usages : Histoire 6ᵉ, comparaison avec l'Europe actuelle)</sub>
+</p>
+
+La **reconstitution de monuments** restitue un édifice dans son état d'origine. Ici, le Colisée de Rome au Iᵉʳ siècle apparaît en rendu photoréaliste — amphithéâtre complet, velarium déployé, gradins peuplés d'une foule en toges — soit l'inverse de la ruine que l'on visite aujourd'hui.
+
+<p align="center">
+<img src="assets/readme/imgex-hist2.webp" alt="Reconstruction photoréaliste du Colisée de Rome au Ier siècle : amphithéâtre complet, velarium déployé, foule en toges" width="480"/><br/>
+<sub><b>Colisée de Rome (Iᵉʳ siècle)</b> — reconstruction photoréaliste de l'amphithéâtre dans son état d'origine (marbre et travertin, velarium, gradins peuplés)</sub>
+</p>
+
+Enfin, pour la **chronologie**, le notebook compose une frise horizontale illustrée. Celle de la Révolution française jalonne la décennie 1789-1799 : prise de la Bastille (1789), Première République (1792), Terreur (1793), coup d'État de Napoléon (1799), sur une barre bleu-blanc-rouge, dans un style poster éducatif.
+
+<p align="center">
+<img src="assets/readme/imgex-hist3.webp" alt="Frise chronologique illustrée de la Révolution française 1789-1799 : Bastille, Première République, Terreur, coup de Napoléon, barre tricolore" width="480"/><br/>
+<sub><b>Révolution française (1789-1799)</b> — frise chronologique horizontale : Bastille (1789), Première République (1792), Terreur (1793), coup de Napoléon (1799), barre bleu-blanc-rouge</sub>
+</p>
+
+### Littérature
+
+Le notebook [literature-visual](literature-visual.ipynb) transforme un texte en image, de la scène de roman à la planche de personnage.
+
+L'**illustration de scène** part d'un passage descriptif. La barricade des *Misérables* de Victor Hugo (1862) donne une peinture à l'huile romantique et dramatique : un jeune homme brandit le drapeau rouge au sommet de la barricade, un enfant tient un pistolet, dans une facture inspirée de Delacroix.
+
+<p align="center">
+<img src="assets/readme/imgex-lit1.webp" alt="Peinture à l'huile romantique de la barricade des Misérables : jeune homme au drapeau rouge, enfant au pistolet, style Delacroix" width="480"/><br/>
+<sub><b>Les Misérables — la barricade</b> (Victor Hugo, 1862) — illustration de scène en peinture à l'huile romantique, format portrait (usages : français 4ᵉ/3ᵉ, révolution et justice sociale)</sub>
+</p>
+
+La **planche de personnage** (character design) rassemble plusieurs vues d'un même protagoniste. Le notebook la produit pour *Le Petit Prince* de Saint-Exupéry : une aquarelle réunit l'enfant blond à l'écharpe jaune sous plusieurs poses, le renard, la rose sous sa cloche de verre et le ciel étoilé.
+
+<p align="center">
+<img src="assets/readme/imgex-lit2.webp" alt="Planche de personnage aquarelle du Petit Prince de Saint-Exupéry : enfant blond à l'écharpe jaune sous plusieurs poses, le renard, la rose sous cloche, ciel étoilé" width="480"/><br/>
+<sub><b>Le Petit Prince</b> (Saint-Exupéry) — planche de personnage à l'aquarelle : le prince à l'écharpe jaune en plusieurs poses, le renard, la rose sous cloche, ciel étoilé (usages : français CM2/6ᵉ, analyse de personnage et de symboles)</sub>
+</p>
 
 ### Science
-- **Diagrammes biologiques** : Représentations de cellules, organes, systèmes
-- **Formules mathématiques** : Visualisation de concepts abstraits
-- **Expériences scientifiques** : Illustrations de processus et phénomènes
+
+Le notebook [science-diagrams](science-diagrams.ipynb) génère des schémas annotés plutôt que des images d'ambiance. La coupe de cellule animale ci-dessous en est un exemple : membrane, noyau (enveloppe nucléaire et chromatine), mitochondries, réticulum endoplasmique (rugueux et lisse), appareil de Golgi, ribosomes, lysosomes et cytoplasme y sont légendés un à un.
+
+<p align="center">
+<img src="assets/readme/imgex-sci.webp" alt="Schéma pédagogique en coupe d'une cellule animale avec organites légendés : membrane, noyau, mitochondries, réticulum endoplasmique, Golgi, ribosomes, lysosomes" width="480"/><br/>
+<sub><b>Cellule animale en coupe</b> — schéma des organites légendés (membrane, noyau, mitochondries, réticulum endoplasmique, appareil de Golgi, lysosomes) (usages : biologie cellulaire niveau lycée, identification des organites)</sub>
+</p>
 
 ## Workflow typique
 
@@ -47,27 +86,6 @@ Exemples concrets d'utilisation des notebooks GenAI Image dans différents domai
 3. **Génération** : Créer les images avec paramètres précis
 4. **Post-processing** : Amélioration et édition si nécessaire
 5. **Intégration** : Utilisation dans le support final
-
-## Galerie
-
-Sorties réelles des notebooks d'exemple (générées par gpt-image-1), couvrant les trois domaines éducatifs : [history-geography](history-geography.ipynb) (carte de l'Empire romain, reconstruction du Colisée, timeline de la Révolution française), [literature-visual](literature-visual.ipynb) (barricade des Misérables, character sheet de Jean Valjean) et [science-diagrams](science-diagrams.ipynb) (coupe de cellule animale).
-
-<table>
-<tr>
-<td align="center"><img src="assets/readme/imgex-hist1.webp" alt="Carte de l'Empire romain à son apogée en 117 ap. J.-C. générée par gpt-image-1" width="400"/><br/><sub><b>Empire romain (117 ap. J.-C.)</b> (<a href="history-geography.ipynb">history-geography</a>) — carte pédagogique de l'expansion romaine à son apogée, générée par gpt-image-1 en format paysage (usages : cours d'Histoire 6ᵉ, comparaison avec l'Europe actuelle)</sub></td>
-<td align="center"><img src="assets/readme/imgex-hist2.webp" alt="Reconstruction photoréaliste du Colisée de Rome au Ier siècle, amphithéâtre complet avec velarium et foule en toges" width="400"/><br/><sub><b>Colisée de Rome (Iᵉʳ siècle)</b> (<a href="history-geography.ipynb">history-geography</a>) — reconstruction photoréaliste de l'amphithéâtre complet (marbre/travertin d'origine, velarium, foule en toges), montrant le bâtiment dans son état d'origine</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/imgex-hist3.webp" alt="Frise chronologique illustrée de la Révolution française 1789-1799 avec événements (Bastille, République, Terreur)" width="400"/><br/><sub><b>Révolution française (1789-1799)</b> (<a href="history-geography.ipynb">history-geography</a>) — frise chronologique horizontale illustrée (prise de la Bastille 1789, Première République 1792, Terreur 1793, coup de Napoléon 1799), barre bleu-blanc-rouge, style poster éducatif</sub></td>
-<td align="center"><img src="assets/readme/imgex-lit1.webp" alt="Illustration de la scène de la barricade des Misérables de Victor Hugo, scène du XIXe siècle" width="400"/><br/><sub><b>Les Misérables — la barricade</b> (<a href="literature-visual.ipynb">literature-visual</a>) — illustration de la scène de barricade (XIXᵉ siècle, romantisme), format portrait (usages : cours de français 4ᵉ/3ᵉ, thématique révolution et justice sociale)</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/imgex-lit2.webp" alt="Character design sheet de Jean Valjean : portrait central, profil, études d'expressions, progression d'âge" width="400"/><br/><sub><b>Jean Valjean (Les Misérables) — character sheet</b> (<a href="literature-visual.ipynb">literature-visual</a>) — feuille de design de personnage : portrait central (homme d'une cinquantaine d'années), profil, études d'expressions et progression d'âge (jeune forçat → maire → vieillard)</sub></td>
-<td align="center"><img src="assets/readme/imgex-sci.webp" alt="Diagramme pédagogique en coupe d'une cellule animale : membrane, noyau, mitochondries, réticulum endoplasmique" width="400"/><br/><sub><b>Coupe de cellule animale</b> (<a href="science-diagrams.ipynb">science-diagrams</a>) — schéma pédagogique en coupe : membrane cellulaire, noyau (enveloppe + chromatine), mitochondries, réticulum endoplasmique (usages : biologie cellulaire niveau lycée, identification des organites)</sub></td>
-</tr>
-</table>
-
-Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
 ## Ressources
 

--- a/MyIA.AI.Notebooks/GenAI/Image/examples/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/assets/readme/MANIFEST.md
@@ -8,7 +8,7 @@ Provenance de chaque figure (convention d'indexation **all-cells** du module `ex
 | Colisée de Rome (Iᵉʳ siècle) — reconstruction photoréaliste | `imgex-hist2.webp` | 1200×846 | 122 Ko | `history-geography.ipynb` · cellule 12 · output 3 | 1260×889, 1911 Ko |
 | Révolution française (1789-1799) — frise chronologique illustrée | `imgex-hist3.webp` | 1200×848 | 64 Ko | `history-geography.ipynb` · cellule 18 · output 3 | 1259×890, 1560 Ko |
 | Les Misérables — la barricade (scène XIXᵉ) | `imgex-lit1.webp` | 769×1200 | 65 Ko | `literature-visual.ipynb` · cellule 8 · output 2 | 891×1390, 1957 Ko |
-| Jean Valjean (Les Misérables) — character sheet (portrait + âges) | `imgex-lit2.webp` | 769×1200 | 62 Ko | `literature-visual.ipynb` · cellule 10 · output 3 | 891×1390, 2116 Ko |
+| Le Petit Prince (Saint-Exupéry) — planche de personnage aquarelle | `imgex-lit2.webp` | 769×1200 | 62 Ko | `literature-visual.ipynb` · cellule 10 · output 3 | 891×1390, 2116 Ko |
 | Cellule animale en coupe — schéma des organites | `imgex-sci.webp` | 1200×846 | 86 Ko | `science-diagrams.ipynb` · cellule 12 · output 3 | 1260×889, 1420 Ko |
 
 **Total** : 6 figures, 501 Ko. **Politique** (#5654) : ≤200 Ko/fichier, downscale ≤1200 px max. Ces sorties sont des images GenAI photographiques denses (sources 1,4–2,1 Mo) : WebP q82 à 1200 px comprime d'un facteur 15–30 sans perte visuelle pédagogique (recommandation WebP P2 « gain net »). Chaque figure couvre un domaine éducatif distinct (histoire-géographie, littérature, sciences).


### PR DESCRIPTION
## Sujet

Réécriture du README `MyIA.AI.Notebooks/GenAI/Image/examples/` selon la **doctrine figures-en-contexte #5780** : la section `## Galerie` (table mosaïque de 6 images) est supprimée ; chaque figure est désormais **intégrée dans la prose de son domaine** (`### Histoire-Géographie`, `### Littérature`, `### Science`), entourée d'un texte qui la référence explicitement et d'une légende décrivant ce que l'image **montre**.

## Correction substantielle vérifiée par vision

En ouvrant réellement les PNG rendus (Read vision) + en lisant la **cellule 10** de `literature-visual.ipynb`, j'ai constaté que `imgex-lit2` est **Le Petit Prince** (Saint-Exupéry), **PAS Jean Valjean** :

- la cellule 10 définit un dict `character_designs` dont la **première clé** est `jean_valjean`, mais le code ne génère que `character_designs["le_petit_prince"]` (output 3) ;
- l'ancienne légende (README + `MANIFEST.md`) avait été écrite **à l'aveugle** en lisant la première clé du dict, d'où le libellé faux « Jean Valjean — character sheet ».

Corrigé **honnêtement** dans le README **et** dans `assets/readme/MANIFEST.md` L11. La provenance `cellule 10 · output 3`, les dimensions et le poids natif sont **inchangés** (ils étaient exacts) — seul le **sujet** est corrigé. C'est exactement l'apport de la doctrine #5780 : ouvrir l'image avant de la légender.

## Détails

- Sous-titres de section franchisés (readme-french-first).
- Lien vers `MANIFEST.md` relocalisé dans l'intro « Exemples concrets ».
- Chemins `.webp` préservés (les `.png` de vérification vision ne sont **pas** commités).
- `<p align="center"><img .../></p>` centrés : mêmes warnings MD033 cosmétiques que les pilotes mergés #5786 / #5852.
- Catalogue byte-identique à main, aucun marqueur `CATALOG-STATUS` touché.

**Scope** : 2 fichiers (`README.md` +51/−33, `MANIFEST.md` +1/−1). Un seul sujet.

See #5780 (rollout partiel — sections galerie restantes : `GenAI/Video/03-Orchestration`, `GenAI/Image/03-Orchestration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
