### PR TITLE
docs(genai-video): 03-Orchestration README — galerie -> figures en contexte narratif + fix 3 libellés aveugles (See #5780)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md
@@ -4,7 +4,7 @@
 
 Ce module couvre l'orchestration de plusieurs modèles vidéo, les workflows complexes, et l'intégration ComfyUI.
 
-**Dans le cadre du fil rouge pipeline vidéo pédagogique** : les briques existent, il faut les assembler. [03-1](03-1-Multi-Model-Video-Comparison.ipynb) compare les modeaux pour choisir le meilleur selon le matériel et le contexte. [03-2](03-2-Video-Workflow-Orchestration.ipynb) construit le pipeline text-to-image-to-video qui constitue le coeur du générateur. [03-3](03-3-ComfyUI-Video-Workflows.ipynb) utilise ComfyUI pour des workflows natifs plus flexibles.
+**Dans le cadre du fil rouge pipeline vidéo pédagogique** : les briques existent, il faut les assembler. [03-1](03-1-Multi-Model-Video-Comparison.ipynb) compare les modèles pour choisir le meilleur selon le matériel et le contexte. [03-2](03-2-Video-Workflow-Orchestration.ipynb) construit le pipeline text-to-image-to-video qui constitue le coeur du générateur. [03-3](03-3-ComfyUI-Video-Workflows.ipynb) utilise ComfyUI pour des workflows natifs plus flexibles.
 
 ## Vue d'overview
 
@@ -34,9 +34,9 @@ Accès : http://localhost:8188
 
 ### Dépendances
 ```bash
+# depuis MyIA.AI.Notebooks/GenAI/
 pip install -r requirements.txt
 pip install -r requirements-video.txt
-pip install -r requirements-comfyui.txt
 ```
 
 ## Progression recommandée
@@ -57,10 +57,47 @@ pip install -r requirements-comfyui.txt
 - **Outils** : Python asyncio, multiprocessing
 - **Optimisation** : Caching, parallélisation
 
+Le notebook [03-2](03-2-Video-Workflow-Orchestration.ipynb) exécute réellement trois workflows ; les figures ci-dessous sont ses sorties, réduites en WebP pour l'affichage (provenance et poids natifs dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md)).
+
+Le **pipeline 1 (text → image → vidéo)** découple la composition de l'animation : SDXL génère d'abord une image source fidèle au prompt, puis Stable Video Diffusion (SVD) l'anime. L'image ci-dessous est cette source, produite en 8,1 s — une silhouette stylisée coiffée d'un ovale lumineux sur un ciel en dégradé orange-violet.
+
+<p align="center">
+<img src="assets/readme/vid3-workflow1.webp" alt="Image source générée par SDXL : silhouette sombre coiffée d'un ovale clair sur un ciel en dégradé orange-violet" width="420"/><br/>
+<sub><b>Image source SDXL (8,1 s)</b> — le point de départ du pipeline text → image → vidéo, que SVD anime ensuite</sub>
+</p>
+
+La planche-contact suivante montre le pipeline complet : la source SDXL, puis les frames 1, 9, 17 et 25 de la vidéo générée — on y voit le sujet évoluer (et dériver) au fil de l'animation.
+
+<p align="center">
+<img src="assets/readme/vid3-workflow2.webp" alt="Planche-contact du pipeline text-image-vidéo : image source SDXL puis frames 1, 9, 17 et 25 de la vidéo générée" width="640"/><br/>
+<sub><b>Pipeline text → image → vidéo</b> — planche-contact : source SDXL puis frames 1/9/17/25 de l'animation SVD</sub>
+</p>
+
+Le **pipeline 2 (text → vidéo → upscale → interpolation)** part de LTX-Video (rapide, basse résolution) puis post-traite : upscale (Real-ESRGAN, repli bicubique) et interpolation de frames. La grille comparative oppose quatre frames brutes (1 à 25, en haut) aux frames finales (1 à 49, en bas) sur un plan de marguerite : l'interpolation double la cadence à contenu constant.
+
+<p align="center">
+<img src="assets/readme/vid3-frame1.webp" alt="Grille 2x4 comparant les frames brutes (1-25) et finales après upscale et interpolation (1-49) d'une vidéo de marguerite" width="640"/><br/>
+<sub><b>Brut vs upscale + interpolation</b> — frames brutes LTX-Video (haut, 1-25) contre frames finales (bas, 1-49) : la cadence double, le contenu reste stable</sub>
+</p>
+
+Enfin, la **génération batch** charge le pipeline LTX-Video une seule fois pour produire plusieurs clips en série. Les trois prompts du batch — vagues océanes au crépuscule, flamme de torche, paysage de montagne nuageux — donnent chacun quatre frames.
+
+<p align="center">
+<img src="assets/readme/vid3-frame2.webp" alt="Grille 3x4 des frames de trois clips LTX-Video générés en batch : océan au crépuscule, flamme de torche, montagnes nuageuses" width="640"/><br/>
+<sub><b>Batch LTX-Video</b> — trois clips générés en série sur un seul chargement de pipeline : océan au crépuscule, flamme de torche, montagnes (4 frames chacun)</sub>
+</p>
+
 ### ComfyUI Integration
 - **Nodes** : Video-specific nodes
 - **Workflow** : End-to-end video generation
 - **Scaling** : Gestion de la mémoire
+
+Le notebook [03-3](03-3-ComfyUI-Video-Workflows.ipynb) pilote ComfyUI par son API (soumission sur `/prompt`, puis polling de `/history`) pour exécuter un workflow AnimateDiff de bout en bout. Ci-dessous, les huit premières frames (sur 16) générées pour le prompt « a serene lake at sunset, soft ripples on water » : les reflets dorés du couchant ondulent sur l'eau d'une frame à l'autre.
+
+<p align="center">
+<img src="assets/readme/vid3-comfyui.webp" alt="Grille 2x4 des frames 1 à 8 sur 16 d'une animation AnimateDiff : reflets dorés d'un coucher de soleil ondulant sur un lac bleu" width="640"/><br/>
+<sub><b>ComfyUI AnimateDiff</b> — frames 1-8/16 du prompt « a serene lake at sunset, soft ripples on water » : les reflets du couchant ondulent sur le lac</sub>
+</p>
 
 ## Architecture
 
@@ -69,26 +106,6 @@ Input → Model Router → Processing → Output
     ↓         ↓          ↓         ↓
   Analysis  Selection   Pipeline  Validation
 ```
-
-## Galerie
-
-Sorties réelles des notebooks : workflow d'orchestration vidéo ([03-2](03-2-Video-Workflow-Orchestration.ipynb)) et workflow ComfyUI de génération vidéo ([03-3](03-3-ComfyUI-Video-Workflows.ipynb)).
-
-<table>
-<tr>
-<td align="center"><img src="assets/readme/vid3-workflow1.webp" alt="Diagramme d'un workflow d'orchestration vidéo" width="400"/><br/><sub>Workflow d'orchestration vidéo — vue d'ensemble (<a href="03-2-Video-Workflow-Orchestration.ipynb">03-2</a>)</sub></td>
-<td align="center"><img src="assets/readme/vid3-workflow2.webp" alt="Panorama d'un pipeline vidéo multi-étapes" width="400"/><br/><sub>Workflow vidéo — panorama du pipeline (<a href="03-2-Video-Workflow-Orchestration.ipynb">03-2</a>)</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/vid3-frame1.webp" alt="Frame vidéo générée, étape 1 du workflow" width="400"/><br/><sub>Frame vidéo générée — étape 1 (<a href="03-2-Video-Workflow-Orchestration.ipynb">03-2</a>)</sub></td>
-<td align="center"><img src="assets/readme/vid3-frame2.webp" alt="Frame vidéo générée, étape 2 du workflow" width="400"/><br/><sub>Frame vidéo générée — étape 2 (<a href="03-2-Video-Workflow-Orchestration.ipynb">03-2</a>)</sub></td>
-</tr>
-<tr>
-<td align="center" colspan="2"><img src="assets/readme/vid3-comfyui.webp" alt="Workflow ComfyUI de bout en bout pour la génération vidéo" width="640"/><br/><sub>Workflow ComfyUI — génération vidéo de bout en bout (<a href="03-3-ComfyUI-Video-Workflows.ipynb">03-3</a>)</sub></td>
-</tr>
-</table>
-
-Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
 ## Ressources
 

--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/assets/readme/MANIFEST.md
@@ -4,10 +4,10 @@ Provenance de chaque figure (convention d'indexation **all-cells** du module `ex
 
 | Figure | Fichier | Dimensions | Poids | Source (notebook · cellule · output) | Source native |
 |--------|---------|------------|-------|--------------------------------------|---------------|
-| Workflow vidéo — vue | `vid3-workflow1.webp` | 819×490 | 6 Ko | `03-2-Video-Workflow-Orchestration.ipynb` · cellule 8 · output 3 | 819×490, 10 Ko |
-| Workflow vidéo — panorama | `vid3-workflow2.webp` | 1200×201 | 8 Ko | `03-2-Video-Workflow-Orchestration.ipynb` · cellule 8 · output 10 | 1790×300, 113 Ko |
-| Frame vidéo — étape 1 | `vid3-frame1.webp` | 1200×531 | 40 Ko | `03-2-Video-Workflow-Orchestration.ipynb` · cellule 10 · output 9 | 1589×704, 984 Ko |
-| Frame vidéo — étape 2 | `vid3-frame2.webp` | 1200×723 | 46 Ko | `03-2-Video-Workflow-Orchestration.ipynb` · cellule 12 · output 14 | 1389×837, 913 Ko |
-| Workflow ComfyUI vidéo | `vid3-comfyui.webp` | 1200×606 | 82 Ko | `03-3-ComfyUI-Video-Workflows.ipynb` · cellule 9 · output 4 | 1560×788, 1697 Ko |
+| Image source SDXL (pipeline text→image→vidéo) | `vid3-workflow1.webp` | 819×490 | 6 Ko | `03-2-Video-Workflow-Orchestration.ipynb` · cellule 8 · output 3 | 819×490, 10 Ko |
+| Pipeline text→image→vidéo — planche-contact (source + frames 1-25) | `vid3-workflow2.webp` | 1200×201 | 8 Ko | `03-2-Video-Workflow-Orchestration.ipynb` · cellule 8 · output 10 | 1790×300, 113 Ko |
+| Comparatif brut vs upscale + interpolation (LTX-Video, marguerite) | `vid3-frame1.webp` | 1200×531 | 40 Ko | `03-2-Video-Workflow-Orchestration.ipynb` · cellule 10 · output 9 | 1589×704, 984 Ko |
+| Batch multi-prompts LTX-Video (océan / torche / montagnes, 3×4 frames) | `vid3-frame2.webp` | 1200×723 | 46 Ko | `03-2-Video-Workflow-Orchestration.ipynb` · cellule 12 · output 14 | 1389×837, 913 Ko |
+| ComfyUI AnimateDiff — frames 1-8/16 (lac au couchant) | `vid3-comfyui.webp` | 1200×606 | 82 Ko | `03-3-ComfyUI-Video-Workflows.ipynb` · cellule 9 · output 4 | 1560×788, 1697 Ko |
 
 **Total** : 5 figures, 185 Ko. **Politique** (#5654) : ≤200 Ko/fichier, downscale ≤1200 px max. Les frames vidéo GenAI sont des images photographiques denses (sources 913–1697 Ko) : WebP q82 à 1200 px bat massivement le PNG (ex. frame 1 : 984 Ko → WebP 1200 px 40 Ko vs PNG 600 px 162 Ko — 2× la résolution pour 4× moins de poids). C'est la recommandation WebP P2 « quand le gain est net ».


### PR DESCRIPTION
## Sujet

Rollout de la **doctrine figures-en-contexte #5780** sur `MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md` : la section `## Galerie` (mosaïque `<table>` de 5 images) est supprimée ; chaque figure est intégrée dans la sous-section « Concepts clés » qui discute son concept (**Workflow Orchestration** pour les 4 sorties de 03-2, **ComfyUI Integration** pour celle de 03-3), entourée de prose qui la référence explicitement.

## Correction substantielle : 3 légendes sur 5 étaient FAUSSES (vérifié par vision)

En ouvrant réellement les images rendues (Read vision) et en croisant les cellules génératrices des notebooks, les légendes de la mosaïque se révèlent écrites à l'aveugle :

| Figure | Ancienne légende (fausse/vague) | Contenu réel (vision + code) |
|--------|-------------------------------|------------------------------|
| `vid3-workflow1` | « Diagramme d'un workflow d'orchestration vidéo — vue d'ensemble » | **Image SOURCE SDXL** du pipeline text→image→vidéo (titre matplotlib embarqué : « Image source (sdxl) generee en 8.1s ») — pas un diagramme |
| `vid3-frame1` | « Frame vidéo générée — étape 1 » | **Grille comparative 2×4 « Brut vs Upscale + Interpolation »** : frames brutes LTX 1-25 vs finales 1-49 (marguerite) |
| `vid3-frame2` | « Frame vidéo générée — étape 2 » | **« Generation Batch - LTX-Video »** : 3 clips × 4 frames (océan au crépuscule, flamme de torche, montagnes) |
| `vid3-workflow2` | « panorama du pipeline » (vague) | Planche-contact « Pipeline Text -> Image -> Video » : source SDXL + frames 1/9/17/25 (animation SVD) |
| `vid3-comfyui` | « génération vidéo de bout en bout » (vague) | ComfyUI **AnimateDiff**, frames 1-8/16 du prompt « a serene lake at sunset, soft ripples on water » |

Provenance croisée dans le code : 03-2 cellule 8 = Pipeline 1 (SDXL + `StableVideoDiffusionPipeline`), cellule 10 = Pipeline 2 (`LTXPipeline` + Real-ESRGAN + interpolation), cellule 12 = batch multi-prompts LTX ; 03-3 cellule 9 = soumission API ComfyUI (`/prompt` + polling `/history`), `suptitle` AnimateDiff. `MANIFEST.md` : colonne « Figure » corrigée sur les 5 lignes — **provenance (cellule · output), dimensions et poids inchangés** (ils étaient exacts ; seuls les sujets étaient faux).

## Audit §E fichier-entier

- Table stats (3 notebooks) ✓ disque (3 `.ipynb` + 3 `_output.ipynb`) ; liens notebooks ✓ ; liens Ressources ✓ (`../README.md`, `00-GenAI-Environment`, `docs/genai/genai-services.md`) ; chemin Docker ✓ (`docker-configurations/services/comfyui-qwen`).
- **Défaut trouvé et corrigé** : le bloc Dépendances installait `requirements.txt` / `requirements-video.txt` / `requirements-comfyui.txt` depuis le dossier courant — les deux premiers vivent en réalité dans `MyIA.AI.Notebooks/GenAI/`, et **`requirements-comfyui.txt` n'existe nulle part dans le repo** (vérifié `git ls-files`). Bloc corrigé.
- Typo `modeaux` → `modèles` (fil rouge L7). « Vue d'overview » (franglais systémique cross-README) laissé hors scope.
- Aucun marqueur `CATALOG-STATUS` dans ce README ; catalogue byte-identique à main.
- Warnings MD033 (inline HTML `<p>/<img>/<sub>`) : cosmétiques, même pattern que les pilotes mergés #5786 / #5852.

**Scope** : 2 fichiers (`README.md` +44/−27 net, `MANIFEST.md` 5 libellés). Un seul sujet.

See #5780 (rollout partiel — reste : `GenAI/Image/03-Orchestration`). PR sœur du même cycle : #5863 (`GenAI/Image/examples`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
