### PR TITLE
docs(causal-bridge): tranche 2 — renvois do-calculus manquants (Tweety-11-Csharp, ICT-6)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb
@@ -1165,6 +1165,7 @@
     "- [ICT-0 — cadrage de la serie](ICT-0-Framing.md) — feuille de route, articles fondateurs.\n",
     "- [ICT-2 — self-sorting morphogenesis](ICT-2-SelfSortingMorphogenesis.ipynb) — le systeme source.\n",
     "- [ICT-5 — emergence causale (pyphi.macro)](ICT-5-CausalEmergence.ipynb) — l'approche bornee complementaire.\n",
+    "- [Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb) — l'EI estimée ici repose sur des **interventions uniformes** (`do(s)` sur chaque état, maximum-entropy) : le pont donne l'armature formelle de ce même opérateur `do` (échelle de Pearl + 3 règles, exécutées sur `dowhy`) et relie cette série à Tweety-11, Infer-5 et PyMC-5.\n",
     "- Erik Hoel, *Causal Emergence 2.0*, [arXiv:2503.13395](https://arxiv.org/abs/2503.13395), 2025."
    ]
   }

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal-Csharp.ipynb
@@ -1142,7 +1142,11 @@
     "La lib Tweety `causal-1.30.jar` (reasoner **argumentatif**) fournit la même sémantique en boîte noire ;\n",
     "l'implémentation from-scratch rend **visible** pourquoi l'intervention isole l'effet causal propre — la valeur pédagogique.\n",
     "\n",
-    "**Voir aussi** : [Tweety-11-Causal.ipynb](Tweety-11-Causal.ipynb) (Python + Tweety jar), marathon #4956, EPIC #3801."
+    "**Voir aussi** : [Tweety-11-Causal.ipynb](Tweety-11-Causal.ipynb) (Python + Tweety jar), marathon #4956, EPIC #3801.\n",
+    "\n",
+    "### Pour aller plus loin\n",
+    "\n",
+    "- **[Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb)** : la chirurgie de graphe implémentée from-scratch ici (remplacer l'équation de `X` par une constante) est la **sémantique** du do-operator ; le pont en montre le **calcul** — l'échelle de causalité et les 3 règles de Pearl exécutées sur l'outil de référence `dowhy` (identification backdoor/front-door + estimation + réfutation), en **quantitatif** là où ce twin décide en booléen. Il relie cette série à Infer-5, PyMC-5 et ICT-5."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
**T2 greenlight ai-01** (câblage retour notebooks → `Do-Calculus-Bridge.ipynb`, mandat causal-bridge 29/06).

## Vérification G.1 du dispatch (firsthand, contenu pas juste liens)
Les 3 renvois demandés dans le dispatch existent **DÉJÀ** avec contenu pédagogique spécifique :
| Notebook | Cellule | État |
|----------|---------|------|
| Tweety-11-Causal | cell 31 | ✅ section « Pour aller plus loin » complète (échelle + 3 règles, dowhy, limites honnêtes qualitatif/quantitatif) |
| Infer-5-Causal-Inference | cell 37 | ✅ renvoi complet + pont symbolique Tweety-11 |
| PyMC-5-Causal-Inference | cell 29 | ✅ renvoi complet + framing paradigme MCMC |

→ **NO-OP documenté sur ces 3** (pas de duplication fabriquée). Les **2 vrais trous** trouvés et comblés :

## Changes (2 cellules markdown, 1 par notebook)
1. **`Tweety-11-Causal-Csharp.ipynb`** (twin from-scratch dont le H1 annonce « do-calculus », **0 mention bridge**) : section « Pour aller plus loin » dans la Synthèse — contenu spécifique au paradigme : la chirurgie de graphe du twin = **sémantique** du do-operator, le pont = son **calcul** (échelle + 3 règles sur `dowhy`), contraste booléen/quantitatif.
2. **`ICT-6-SortingToTPM-CausalEmergence.ipynb`** (référencé PAR le bridge depuis la tranche 1 #5860, mais **0 lien retour direct** — il déférait via ICT-5) : bullet « Voir aussi » — les **interventions uniformes** `do(s)` de l'estimation EI reliées à l'armature formelle du pont.

## Validation
- **C.2 : 0 violations** (markdown-only, 1 cellule chacun, outputs/exec_count préservés — vérifié cell-par-cell vs origin/main).
- **Tous les liens relatifs résolvent** (scan regex + `os.path.exists` depuis le dossier de chaque notebook ; chemins identiques à ceux des siblings ICT-5 / Tweety-11-Causal).
- Catalogue `COURSE_CATALOG.generated.*` **byte-identique**.
- Diff : 2 fichiers, +6/−1.

See #4588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)