### PR TITLE
fix(search): Search-2 C# — rendre le discriminant UCS visible (Prong B, See #3801)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb
@@ -76,10 +76,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:26.889190Z",
-     "iopub.status.busy": "2026-07-04T13:21:26.881952Z",
-     "iopub.status.idle": "2026-07-04T13:21:29.182484Z",
-     "shell.execute_reply": "2026-07-04T13:21:29.176510Z"
+     "iopub.execute_input": "2026-07-10T00:52:09.558543Z",
+     "iopub.status.busy": "2026-07-10T00:52:09.528781Z",
+     "iopub.status.idle": "2026-07-10T00:52:17.385695Z",
+     "shell.execute_reply": "2026-07-10T00:52:17.359416Z"
     },
     "papermill": {
      "duration": 2.309528,
@@ -141,12 +141,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%21:2051/\",\"http://172.28.160.1:2051/\",\"http://fe80::1835:6bb9:3424:9ebc%44:2051/\",\"http://172.21.192.1:2051/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2051/\",\"http://2a01:e0a:9d4:f320:4d0a:defe:7a81:fb5c:2051/\",\"http://2a01:e0a:9d4:f320:6843:6a3:3a0d:390d:2051/\",\"http://2a01:e0a:9d4:f320:a56e:4d05:4a17:a9d4:2051/\",\"http://fe80::5418:77a8:a4bf:a1ed%17:2051/\",\"http://192.168.0.49:2051/\",\"http://::1:2051/\",\"http://127.0.0.1:2051/\"])\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:591:3dd:bb54:4480:2048/\",\"http://2a01:e0a:9d4:f320:18ab:7196:2309:6bd1:2048/\",\"http://2a01:e0a:9d4:f320:29fd:7fd0:d651:fd27:2048/\",\"http://2a01:e0a:9d4:f320:412a:e920:4037:1d04:2048/\",\"http://2a01:e0a:9d4:f320:4ca5:4d29:609e:73f9:2048/\",\"http://2a01:e0a:9d4:f320:4d1c:4289:3d53:8710:2048/\",\"http://2a01:e0a:9d4:f320:851b:256:365f:8d6:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%38:2048/\",\"http://172.23.208.1:2048/\",\"http://fe80::fb4c:6ff:8d3d:c1ef%55:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '28960.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '49892.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -322,18 +322,18 @@
     "    }\n",
     "}\n",
     "\n",
-    "// Carte des villes francaises (12 villes, 18 routes, distances en km).\n",
+    "// Carte des villes francaises (13 villes, 20 routes, distances en km).\n",
     "var franceGraph = new Dictionary<string, Dictionary<string, double>> {\n",
     "    [\"Bordeaux\"]   = new() { [\"Paris\"] = 585, [\"Toulouse\"] = 245, [\"Nantes\"] = 350 },\n",
     "    [\"Paris\"]      = new() { [\"Bordeaux\"] = 585, [\"Lille\"] = 225, [\"Strasbourg\"] = 490, [\"Lyon\"] = 465, [\"Nantes\"] = 385 },\n",
     "    [\"Lille\"]      = new() { [\"Paris\"] = 225, [\"Rennes\"] = 510 },\n",
-    "    [\"Rennes\"]     = new() { [\"Lille\"] = 510, [\"Paris\"] = 385, [\"Nantes\"] = 110, [\"Brest\"] = 245 },\n",
+    "    [\"Rennes\"]     = new() { [\"Lille\"] = 510, [\"Nantes\"] = 110, [\"Brest\"] = 245 },\n",
     "    [\"Brest\"]      = new() { [\"Rennes\"] = 245 },\n",
     "    [\"Nantes\"]     = new() { [\"Rennes\"] = 110, [\"Paris\"] = 385, [\"Bordeaux\"] = 350, [\"Toulouse\"] = 590 },\n",
     "    [\"Strasbourg\"] = new() { [\"Paris\"] = 490, [\"Lyon\"] = 490 },\n",
     "    [\"Lyon\"]       = new() { [\"Paris\"] = 465, [\"Strasbourg\"] = 490, [\"Marseille\"] = 315, [\"Toulouse\"] = 535, [\"Grenoble\"] = 115 },\n",
     "    [\"Grenoble\"]   = new() { [\"Lyon\"] = 115, [\"Marseille\"] = 305 },\n",
-    "    [\"Marseille\"]  = new() { [\"Lyon\"] = 315, [\"Grenoble\"] = 305, [\"Toulouse\"] = 405, [\"Nice\"] = 200 },\n",
+    "    [\"Marseille\"]  = new() { [\"Lyon\"] = 315, [\"Grenoble\"] = 305, [\"Toulouse\"] = 405, [\"Nice\"] = 200, [\"Montpellier\"] = 165 },\n",
     "    [\"Toulouse\"]   = new() { [\"Bordeaux\"] = 245, [\"Nantes\"] = 590, [\"Marseille\"] = 405, [\"Lyon\"] = 535, [\"Montpellier\"] = 245 },\n",
     "    [\"Montpellier\"] = new() { [\"Toulouse\"] = 245, [\"Marseille\"] = 165 },\n",
     "    [\"Nice\"]       = new() { [\"Marseille\"] = 200 },\n",
@@ -364,7 +364,7 @@
     "- **`Problem`** : classe abstraite (équivalent C# du pattern ABC Python) ; `GraphProblem` la spécialise pour un graphe pondéré dont les arêtes sont les actions et les poids sont les coûts d'etape.\n",
     "- **`SearchResult`** : agrège le résultat d'une recherche : chemin, coût, statistiques d'exploration et de génération, taille maximale de la frontière, temps ecoule.\n",
     "\n",
-    "Le graphe des villes françaises contient 12 villes et 18 routes bidirectionnelles (les distances sont en km). L'**invariant clé** est que les coûts sont asymetriques uniquement par accident d'arrondi : sur la carte source, chaque arête est declaree dans les deux sens avec la même valeur, ce qui rend UCS et BFS comparables sur un terrain ou ils ne divergent pas toujours -- sauf cas explicite (Bordeaux -> Strasbourg via Paris-Lyon 1050 km vs via Toulouse-Marseille-Lyon 1165 km, ou BFS choisira le plus court en nombre de sauts, pas en coût).\n"
+    "Le graphe des villes françaises contient **13 villes et 20 routes bidirectionnelles** (les distances sont en km) : chaque arête est déclarée dans les deux sens avec la même valeur. Les coûts étant tous >= 100 km et assez homogènes, le plus court en sauts coïncide *souvent* avec le moins coûteux — mais pas toujours : la **Section 6** montre un trajet piège (**Paris -> Rennes**) où BFS et UCS divergent de 240 km à nombre de sauts égal.\n"
    ]
   },
   {
@@ -399,10 +399,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:29.212973Z",
-     "iopub.status.busy": "2026-07-04T13:21:29.212508Z",
-     "iopub.status.idle": "2026-07-04T13:21:29.373833Z",
-     "shell.execute_reply": "2026-07-04T13:21:29.373663Z"
+     "iopub.execute_input": "2026-07-10T00:52:17.391788Z",
+     "iopub.status.busy": "2026-07-10T00:52:17.390560Z",
+     "iopub.status.idle": "2026-07-10T00:52:18.252224Z",
+     "shell.execute_reply": "2026-07-10T00:52:18.251513Z"
     },
     "papermill": {
      "duration": 0.167106,
@@ -488,7 +488,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps            : 3,09 ms\r\n"
+      "  Temps            : 14,38 ms\r\n"
      ]
     },
     {
@@ -580,7 +580,7 @@
     "\n",
     "**Coût total** : sur ce trajet, BFS a choisi Bordeaux -> Paris -> Strasbourg (585 + 490 = 1075 km). Mais le chemin **Bordeaux -> Toulouse -> Marseille -> Lyon -> Strasbourg** (245 + 405 + 315 + 490 = **1455 km**) est en 4 sauts donc jamais considere par BFS -- même s'il etait moins cher, ce n'est pas le cas ici.\n",
     "\n",
-    "> **Cas ou BFS diverge d'UCS** : si l'arête Toulouse -> Marseille coutait **beaucoup moins** (par exemple 100 km au lieu de 405), BFS continuerait a preferer Bordeaux -> Paris -> Strasbourg (3 sauts) tandis qu'UCS pourrait preferer un chemin plus long en sauts mais moins coûteux en km. C'est precisement ce qu'on observe dans la **Section 4 (Exercice 2)**.\n"
+    "> **Cas ou BFS diverge d'UCS** : si l'arête Toulouse -> Marseille coutait **beaucoup moins** (par exemple 100 km au lieu de 405), BFS continuerait a preferer Bordeaux -> Paris -> Strasbourg (3 sauts) tandis qu'UCS pourrait preferer un chemin plus long en sauts mais moins coûteux en km. C'est precisement ce que l'**Exercice 2** vous fera construire (Montpellier -> Lyon), et ce que la **Section 6** démontre sur le trajet piège **Paris -> Rennes**.\n"
    ]
   },
   {
@@ -615,10 +615,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:29.407495Z",
-     "iopub.status.busy": "2026-07-04T13:21:29.407224Z",
-     "iopub.status.idle": "2026-07-04T13:21:29.501459Z",
-     "shell.execute_reply": "2026-07-04T13:21:29.501309Z"
+     "iopub.execute_input": "2026-07-10T00:52:18.258895Z",
+     "iopub.status.busy": "2026-07-10T00:52:18.257527Z",
+     "iopub.status.idle": "2026-07-10T00:52:18.789357Z",
+     "shell.execute_reply": "2026-07-10T00:52:18.787098Z"
     },
     "papermill": {
      "duration": 0.101031,
@@ -732,7 +732,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Noeuds generes   : 26\r\n"
+      "  Noeuds generes   : 27\r\n"
      ]
     },
     {
@@ -746,7 +746,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps            : 1,22 ms\r\n"
+      "  Temps            : 5,95 ms\r\n"
      ]
     },
     {
@@ -874,10 +874,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:29.532035Z",
-     "iopub.status.busy": "2026-07-04T13:21:29.531808Z",
-     "iopub.status.idle": "2026-07-04T13:21:29.624076Z",
-     "shell.execute_reply": "2026-07-04T13:21:29.623931Z"
+     "iopub.execute_input": "2026-07-10T00:52:18.798450Z",
+     "iopub.status.busy": "2026-07-10T00:52:18.797235Z",
+     "iopub.status.idle": "2026-07-10T00:52:19.252249Z",
+     "shell.execute_reply": "2026-07-10T00:52:19.251497Z"
     },
     "papermill": {
      "duration": 0.099063,
@@ -958,10 +958,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:29.647798Z",
-     "iopub.status.busy": "2026-07-04T13:21:29.647564Z",
-     "iopub.status.idle": "2026-07-04T13:21:29.728436Z",
-     "shell.execute_reply": "2026-07-04T13:21:29.727270Z"
+     "iopub.execute_input": "2026-07-10T00:52:19.257107Z",
+     "iopub.status.busy": "2026-07-10T00:52:19.256457Z",
+     "iopub.status.idle": "2026-07-10T00:52:19.478438Z",
+     "shell.execute_reply": "2026-07-10T00:52:19.473881Z"
     },
     "papermill": {
      "duration": 0.088143,
@@ -1117,7 +1117,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps            : 2,87 ms\r\n"
+      "  Temps            : 9,38 ms\r\n"
      ]
     },
     {
@@ -1233,10 +1233,10 @@
    "source": [
     "### Exercice 2 : Analyser l'écart de coût entre BFS et UCS\n",
     "\n",
-    "**Enonce** : choisissez un trajet ou BFS et UCS donnent **un coût différent**. Le candidat naturel est **Rennes -> Nice** (4 ou 5 sauts selon le chemin, avec des poids interessants).\n",
+    "**Enonce** : choisissez un trajet ou BFS et UCS donnent **un coût différent**. Le candidat naturel est **Montpellier -> Lyon** : deux chemins en 2 sauts existent, avec des coûts très différents selon les arêtes empruntées.\n",
     "\n",
     "**Indices** :\n",
-    "1. `var problem6 = new GraphProblem(\"Rennes\", \"Nice\", franceGraph);`\n",
+    "1. `var problem6 = new GraphProblem(\"Montpellier\", \"Lyon\", franceGraph);`\n",
     "2. Lancez `BFS(problem6)` et `UCS(problem6)` puis comparez `result.Cost`.\n",
     "3. Affichez les deux chemins et expliquez pourquoi UCS est strictement meilleur (ou pas).\n"
    ]
@@ -1250,10 +1250,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:29.777579Z",
-     "iopub.status.busy": "2026-07-04T13:21:29.777299Z",
-     "iopub.status.idle": "2026-07-04T13:21:29.815644Z",
-     "shell.execute_reply": "2026-07-04T13:21:29.815485Z"
+     "iopub.execute_input": "2026-07-10T00:52:19.483385Z",
+     "iopub.status.busy": "2026-07-10T00:52:19.482419Z",
+     "iopub.status.idle": "2026-07-10T00:52:19.578149Z",
+     "shell.execute_reply": "2026-07-10T00:52:19.576794Z"
     },
     "papermill": {
      "duration": 0.051167,
@@ -1276,8 +1276,8 @@
    "source": [
     "// Exercice 2 : Analyser l'ecart de cout entre BFS et UCS.\n",
     "// TODO etudiant : choisissez un trajet ou BFS et UCS divergent.\n",
-    "string depart = null;   // TODO etudiant : remplacer (ex: \"Rennes\")\n",
-    "string arrivee = null;  // TODO etudiant : remplacer (ex: \"Nice\")\n",
+    "string depart = null;   // TODO etudiant : remplacer (ex: \"Montpellier\")\n",
+    "string arrivee = null;  // TODO etudiant : remplacer (ex: \"Lyon\")\n",
     "\n",
     "// TODO etudiant : executez BFS et UCS sur ce trajet.\n",
     "// var problem6 = new GraphProblem(depart, arrivee, franceGraph);\n",
@@ -1322,10 +1322,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:29.838928Z",
-     "iopub.status.busy": "2026-07-04T13:21:29.838735Z",
-     "iopub.status.idle": "2026-07-04T13:21:29.976230Z",
-     "shell.execute_reply": "2026-07-04T13:21:29.976377Z"
+     "iopub.execute_input": "2026-07-10T00:52:19.583246Z",
+     "iopub.status.busy": "2026-07-10T00:52:19.581991Z",
+     "iopub.status.idle": "2026-07-10T00:52:19.940373Z",
+     "shell.execute_reply": "2026-07-10T00:52:19.941947Z"
     },
     "papermill": {
      "duration": 0.144251,
@@ -1397,7 +1397,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps            : 0,64 ms\r\n"
+      "  Temps            : 1,76 ms\r\n"
      ]
     },
     {
@@ -1527,7 +1527,7 @@
     "\n",
     "## 6. Comparaison synthetique sur plusieurs problemes\n",
     "\n",
-    "Executons les quatre algorithmes sur les 4 trajets emblematiques du notebook Python : Bordeaux -> Strasbourg, Rennes -> Nice, Lille -> Toulouse, Nantes -> Marseille. Nous comparons coût, nombre de noeuds explorés et generees.\n"
+    "Exécutons les quatre algorithmes sur les 4 trajets emblématiques du notebook Python — Bordeaux -> Strasbourg, Rennes -> Nice, Lille -> Toulouse, Nantes -> Marseille — plus un **cinquième trajet piège, Paris -> Rennes**, où deux chemins de 2 sauts ont des coûts très différents. Nous comparons coût, nombre de nœuds explorés et générés.\n"
    ]
   },
   {
@@ -1539,10 +1539,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:30.017541Z",
-     "iopub.status.busy": "2026-07-04T13:21:30.017277Z",
-     "iopub.status.idle": "2026-07-04T13:21:30.158461Z",
-     "shell.execute_reply": "2026-07-04T13:21:30.158277Z"
+     "iopub.execute_input": "2026-07-10T00:52:19.946871Z",
+     "iopub.status.busy": "2026-07-10T00:52:19.945978Z",
+     "iopub.status.idle": "2026-07-10T00:52:20.384123Z",
+     "shell.execute_reply": "2026-07-10T00:52:20.382671Z"
     },
     "papermill": {
      "duration": 0.148999,
@@ -1608,7 +1608,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DFS      Bordeaux -> Nantes -> Toulouse -> Montpe...       2260          8         26\r\n"
+      "DFS      Bordeaux -> Nantes -> Toulouse -> Montpe...       2260          8         27\r\n"
      ]
     },
     {
@@ -1658,7 +1658,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFS      Rennes -> Paris -> Lyon -> Marseille -> ...       1365         10         35\r\n"
+      "BFS      Rennes -> Nantes -> Toulouse -> Marseill...       1305         10         34\r\n"
      ]
     },
     {
@@ -1679,7 +1679,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IDDFS    Rennes -> Paris -> Lyon -> Marseille -> ...       1365         28         99\r\n"
+      "IDDFS    Rennes -> Nantes -> Toulouse -> Marseill...       1305         31        101\r\n"
      ]
     },
     {
@@ -1715,14 +1715,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFS      Lille -> Paris -> Bordeaux -> Toulouse            1055          4         13\r\n"
+      "BFS      Lille -> Paris -> Bordeaux -> Toulouse            1055          4         12\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DFS      Lille -> Rennes -> Nantes -> Toulouse             1210          4         11\r\n"
+      "DFS      Lille -> Rennes -> Nantes -> Toulouse             1210          4         10\r\n"
      ]
     },
     {
@@ -1772,7 +1772,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFS      Nantes -> Toulouse -> Marseille                    995          5         19\r\n"
+      "BFS      Nantes -> Toulouse -> Marseille                    995          5         18\r\n"
      ]
     },
     {
@@ -1786,24 +1786,82 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "UCS      Nantes -> Toulouse -> Marseille                    995         11         35\r\n"
+      "UCS      Nantes -> Toulouse -> Marseille                    995         11         34\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IDDFS    Nantes -> Toulouse -> Marseille                    995          5         19\r\n"
+      "IDDFS    Nantes -> Toulouse -> Marseille                    995          5         18\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Paris -> Rennes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Algo     Chemin                                            Cout   Explores    Generes\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------------------------------------------------------------------------\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFS      Paris -> Lille -> Rennes                           735          3         10\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DFS      Paris -> Nantes -> Rennes                          495         10         34\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "UCS      Paris -> Nantes -> Rennes                          495          5         18\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IDDFS    Paris -> Lille -> Rennes                           735          3          7\r\n"
      ]
     }
    ],
    "source": [
-    "// Comparaison complete sur 4 trajets.\n",
+    "// Comparaison complete sur 5 trajets (dont le trajet piege Paris -> Rennes).\n",
     "var testCases = new (string start, string goal)[] {\n",
     "    (\"Bordeaux\", \"Strasbourg\"),\n",
     "    (\"Rennes\", \"Nice\"),\n",
     "    (\"Lille\", \"Toulouse\"),\n",
     "    (\"Nantes\", \"Marseille\"),\n",
+    "    (\"Paris\", \"Rennes\"),\n",
     "};\n",
     "\n",
     "var allResults = new List<(string start, string goal, Dictionary<string, SearchResult> results)>();\n",
@@ -1851,8 +1909,9 @@
     "\n",
     "On observe les patterns classiques :\n",
     "\n",
-    "- **BFS et UCS** trouvent **toujours** le même chemin sur les 4 trajets (la carte source a tous ses coûts >= 100 km, donc le plus court en sauts coïncide souvent avec le moins coûteux). Si vous modifiez une arête pour la rendre « piege », UCS divergera.\n",
-    "- **DFS** trouve un chemin (la carte est acyclique et finie, donc DFS termine), mais pas necessairement le moins coûteux. Sur Lille -> Toulouse par exemple, DFS peut preferer Lille -> Paris -> ... -> Toulouse via un long detour.\n",
+    "- **Sur les 4 trajets classiques, BFS et UCS coïncident** : les coûts de la carte sont tous >= 100 km et assez homogènes, donc le plus court en sauts y est aussi le moins coûteux.\n",
+    "- **Le cinquième trajet, Paris -> Rennes, est le piège qui les sépare** : deux chemins en 2 sauts existent, et BFS — aveugle aux coûts — retourne Paris -> Lille -> Rennes (**735 km**) parce que Lille sort de la file avant Nantes, tandis qu'UCS garantit Paris -> Nantes -> Rennes (**495 km**), soit **240 km de moins à nombre de sauts égal**. BFS retourne *un* chemin optimal en sauts (lequel dépend de l'ordre d'exploration de la frontière), UCS retourne *le* chemin optimal en coût — même trajet piège que dans le notebook Python.\n",
+    "- **DFS** trouve un chemin (le graphe est fini et la liste des explorés évite les boucles, donc DFS termine), mais pas nécessairement le moins coûteux. Sur Lille -> Toulouse par exemple, DFS peut preferer Lille -> Paris -> ... -> Toulouse via un long detour.\n",
     "- **IDDFS** exploré plus de noeuds que BFS (overhead de re-exploration) mais trouve la même solution en nombre de sauts.\n",
     "\n",
     "**Regle pratique** :\n",
@@ -1874,10 +1933,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:30.192477Z",
-     "iopub.status.busy": "2026-07-04T13:21:30.192245Z",
-     "iopub.status.idle": "2026-07-04T13:21:30.272166Z",
-     "shell.execute_reply": "2026-07-04T13:21:30.271950Z"
+     "iopub.execute_input": "2026-07-10T00:52:20.390137Z",
+     "iopub.status.busy": "2026-07-10T00:52:20.388993Z",
+     "iopub.status.idle": "2026-07-10T00:52:20.613561Z",
+     "shell.execute_reply": "2026-07-10T00:52:20.612944Z"
     },
     "papermill": {
      "duration": 0.089396,
@@ -1988,7 +2047,7 @@
    "source": [
     "### Exercice 3 : Comparaison experimentale personnalisee\n",
     "\n",
-    "**Enonce** : choisissez un trajet **non couvert** par les 4 cas ci-dessus (par exemple **Grenoble -> Lille** ou **Montpellier -> Rennes**) et executez les quatre algorithmes. Construisez un tableau comparatif.\n",
+    "**Enonce** : choisissez un trajet **non couvert** par les 5 cas ci-dessus (par exemple **Grenoble -> Lille** ou **Montpellier -> Rennes**) et executez les quatre algorithmes. Construisez un tableau comparatif.\n",
     "\n",
     "**Indices** :\n",
     "1. `var problemC = new GraphProblem(depart, arrivee, franceGraph);`\n",
@@ -2005,10 +2064,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:30.307805Z",
-     "iopub.status.busy": "2026-07-04T13:21:30.307574Z",
-     "iopub.status.idle": "2026-07-04T13:21:30.357610Z",
-     "shell.execute_reply": "2026-07-04T13:21:30.357427Z"
+     "iopub.execute_input": "2026-07-10T00:52:20.618359Z",
+     "iopub.status.busy": "2026-07-10T00:52:20.617526Z",
+     "iopub.status.idle": "2026-07-10T00:52:20.768851Z",
+     "shell.execute_reply": "2026-07-10T00:52:20.768089Z"
     },
     "papermill": {
      "duration": 0.059986,
@@ -2094,10 +2153,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:30.445993Z",
-     "iopub.status.busy": "2026-07-04T13:21:30.445713Z",
-     "iopub.status.idle": "2026-07-04T13:21:30.518821Z",
-     "shell.execute_reply": "2026-07-04T13:21:30.518607Z"
+     "iopub.execute_input": "2026-07-10T00:52:20.774354Z",
+     "iopub.status.busy": "2026-07-10T00:52:20.773040Z",
+     "iopub.status.idle": "2026-07-10T00:52:20.958432Z",
+     "shell.execute_reply": "2026-07-10T00:52:20.958906Z"
     },
     "papermill": {
      "duration": 0.113898,
@@ -2211,7 +2270,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps            : 0,67 ms\r\n"
+      "  Temps            : 1,99 ms\r\n"
      ]
     }
    ],
@@ -2264,10 +2323,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:30.562309Z",
-     "iopub.status.busy": "2026-07-04T13:21:30.562055Z",
-     "iopub.status.idle": "2026-07-04T13:21:30.699344Z",
-     "shell.execute_reply": "2026-07-04T13:21:30.699191Z"
+     "iopub.execute_input": "2026-07-10T00:52:20.964217Z",
+     "iopub.status.busy": "2026-07-10T00:52:20.963370Z",
+     "iopub.status.idle": "2026-07-10T00:52:21.217652Z",
+     "shell.execute_reply": "2026-07-10T00:52:21.216517Z"
     },
     "papermill": {
      "duration": 0.14852,
@@ -2366,10 +2425,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:30.738937Z",
-     "iopub.status.busy": "2026-07-04T13:21:30.738679Z",
-     "iopub.status.idle": "2026-07-04T13:21:31.000423Z",
-     "shell.execute_reply": "2026-07-04T13:21:31.000202Z"
+     "iopub.execute_input": "2026-07-10T00:52:21.224214Z",
+     "iopub.status.busy": "2026-07-10T00:52:21.222975Z",
+     "iopub.status.idle": "2026-07-10T00:52:22.281338Z",
+     "shell.execute_reply": "2026-07-10T00:52:22.282059Z"
     },
     "papermill": {
      "duration": 0.27263,
@@ -2427,7 +2486,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps            : 0,03 ms\r\n"
+      "  Temps            : 0,10 ms\r\n"
      ]
     },
     {
@@ -2557,10 +2616,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-04T13:21:31.042950Z",
-     "iopub.status.busy": "2026-07-04T13:21:31.042715Z",
-     "iopub.status.idle": "2026-07-04T13:21:31.129962Z",
-     "shell.execute_reply": "2026-07-04T13:21:31.129782Z"
+     "iopub.execute_input": "2026-07-10T00:52:22.288541Z",
+     "iopub.status.busy": "2026-07-10T00:52:22.286891Z",
+     "iopub.status.idle": "2026-07-10T00:52:22.615405Z",
+     "shell.execute_reply": "2026-07-10T00:52:22.614744Z"
     },
     "papermill": {
      "duration": 0.101958,
@@ -2604,7 +2663,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     0      4           28           99          5\r\n"
+      "     0      4           31          101          5\r\n"
      ]
     },
     {
@@ -2612,14 +2671,14 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "BFS (Rennes -> Nice) : 10 noeuds explores, frontiere max = 5\r\n"
+      "BFS (Rennes -> Nice) : 10 noeuds explores, frontiere max = 4\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IDS memoire cumulee : 28 noeuds explores, pic pile = 5\r\n"
+      "IDS memoire cumulee : 31 noeuds explores, pic pile = 5\r\n"
      ]
     }
    ],
@@ -2671,7 +2730,7 @@
     "\n",
     "IDS exploré en profondeur limitee croissante, sa mémoire (taille de la pile) reste **lineaire en la profondeur courante**. BFS, lui, stocke **tous les noeuds d'un niveau** et la mémoire grandit **exponentiellement** avec la profondeur.\n",
     "\n",
-    "Sur Rennes -> Nice (le trajet le plus long du notebook), on observe : pic de pile IDS = O(d) ~= 5 noeuds, contre frontière BFS ~= 12 noeuds sur un niveau intermediaire. Pour des arbres plus profonds (profondeur 20+), l'écart devient dramatique : IDS devient imbattable.\n"
+    "Sur Rennes -> Nice (le trajet le plus long du notebook), le graphe est trop petit pour que l'avantage soit visible : pic de pile IDS = 5 nœuds contre frontière BFS max = 4 nœuds — IDS « paie » ici ses ré-explorations sans rien gagner en mémoire. C'est normal : la mémoire d'IDS croît en $O(bd)$ et celle de BFS en $O(b^d)$. Sur un arbre de branchement $b = 10$ et profondeur $d = 10$, IDS stockerait ~100 nœuds là où BFS en stockerait ~10 milliards : pour des espaces d'états réels (profondeur 20+), IDS devient imbattable.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Miroir C# du fix Python #5858 : les 4 trajets du tableau comparatif de `Search-2-Uninformed-Csharp.ipynb` donnaient tous **BFS == UCS** — le notebook démontrait UCS sur un cas dégénéré où il équivaut à la baseline (Prong B, [sota-not-workaround §H](.claude/rules/sota-not-workaround.md), leçon canonique BFS-vs-A* `8905f8845`).

## Diagnostic (simulation exacte des implémentations C#)

Réplication Python fidèle du BFS C# (goal-test à la génération, FIFO, voisins en ordre d'insertion) et de l'UCS C# (goal-test au dequeue, `frontierBest`) : le graphe committé contenait **2 asymétries** (arête orpheline `Rennes->Paris=385` sans retour ; `Montpellier->Marseille=165` sans retour), et les 4 trajets committés évitaient simplement les 24 paires divergentes réelles.

## Changements

**Chirurgie graphe** (aligne la topologie sur le twin Python, restaure la symétrie — 13 villes, 20 routes) :
- retrait de l'arête orpheline `Rennes->Paris` ; ajout de `Marseille->Montpellier=165`

**Démo discriminante** :
- 5e trajet piège `Paris -> Rennes` dans le tableau comparatif : BFS retourne Paris->Lille->Rennes (**735 km**, Lille sort de la file avant Nantes) vs UCS Paris->Nantes->Rennes (**495 km**) — 240 km d'écart **à nombre de sauts égal**. Bonus pédagogique visible dans l'output : IDDFS suit BFS (735), DFS tombe ici sur 495.
- Exercice 2 : candidat `Rennes->Nice` (ne diverge plus post-fix, 1305==1305) redirigé vers `Montpellier->Lyon` (780 vs 480, robuste)

**Prose contredite par les outputs committés** (corrigée) :
- cell 3 : « 12 villes et 18 routes » → 13/20 ; exemples de coûts arithmétiquement faux (1050/1165 km ne correspondent à aucun chemin réel) supprimés
- cell 22 : claim faux « BFS et UCS trouvent toujours le même chemin » réécrit avec la divergence Paris->Rennes ; « carte acyclique » → graphe fini
- cell 35 : claim faux « frontière BFS ~= 12 » → framing honnête (pile IDS 5 vs frontière BFS 4 sur ce petit graphe ; l'avantage O(bd) vs O(b^d) n'apparaît qu'en profondeur réelle)

## Validation (H.1)

- **Ré-exécution complète** kernel `.net-csharp` (`jupyter nbconvert --execute --inplace`) : exec_counts **1-14 séquentiels**, **0 erreur** — verdict **EXEC_PROVED**
- Discriminant **735/495 visible dans les outputs committés** (tableau cellule 21)
- `grep -cE 'raise NotImplementedError|assert False|1/0'` = 0 (C.1)
- Résidus périmés (`1365`, `12 villes`, `18 routes`) = 0 ; fuite chemins machine = 0
- Catalogue + marqueurs CATALOG-STATUS **non touchés** (1 seul fichier au diff)

## Suivi (hors scope)

`Search-3-Informed-Csharp.ipynb` (cell 4) porte les **2 mêmes asymétries de graphe** — PR séparée à venir.

See #3801 (registre Prong B) · See #4956 (lignée twins .NET) · miroir de #5858

🤖 Generated with [Claude Code](https://claude.com/claude-code)