### PR TITLE
fix(prover): backoff + provider_outage circuit-breaker + iteration accounting on transport errors (#5869)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -674,6 +674,11 @@ class MultiAgentSorryProver:
         session_start = time.time()
         self.trace.start_session_span(demo["name"], "multi")
         proof_found = False
+        # #5869: provider-outage circuit-breaker verdict, surfaced from the
+        # final ProofMessage so the result dict (and *_result.json) can tell
+        # "provider was down" apart from "no tactical progress".
+        provider_outage = False
+        provider_failures = 0
         try:
             # Build-credited wall-clock supervisor (user mandate 2026-06-21:
             # "mettre en pause le timer de mesure pendant les builds"). A single
@@ -718,6 +723,8 @@ class MultiAgentSorryProver:
                 final_msg = initial_msg
 
             proof_found = getattr(final_msg, 'proof_found', False)
+            provider_outage = getattr(final_msg, 'provider_outage', False)
+            provider_failures = getattr(final_msg, 'provider_failures', 0)
         except _asyncio.TimeoutError:
             try:
                 _bs = _LeanVerifier._total_build_seconds - _build_at_start
@@ -911,6 +918,14 @@ class MultiAgentSorryProver:
             # from an actual sorry reduction. Without this, both report
             # success=True and consumers cannot tell them apart.
             "structural_progress": structural_progress,
+            # #5869: provider-outage circuit-breaker verdict. True when the
+            # workflow terminated because the LLM provider failed
+            # PROVIDER_OUTAGE_BREAKER consecutive hops (workflow.py) — the run
+            # never got to work, which is NOT `no_progress`.
+            # `provider_failures` is the total count of failed provider hops
+            # (forensic; each hop already covered its in-hop retries).
+            "provider_outage": provider_outage,
+            "provider_failures": provider_failures,
             # FX-6 (#1453): diagnostic fields for the statement-mutation guard.
             "verified_tactic_count": verified_tactic_count,
             **({"flag": "STMT_MUTATION_FALSE_SUCCESS"} if stmt_mutation else {}),

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -28,6 +28,35 @@ TRACES_DIR = Path(__file__).parent / "traces"
 TRACES_DIR.mkdir(exist_ok=True)
 
 
+def _derive_result_kind(result, final_sorry: int, original_sorry: int) -> str:
+    """Canonical run verdict, ranked by what a coordinator does next.
+
+    Forensic #1453 (2026-07-02): a run's outcome was scattered across 4 fields
+    (result.status, sorry_delta, structural_progress, error) and every consumer
+    re-derived its own verdict — the ai-01 harvest step included.
+      sorry_decreased  -> harvest: branch + PR (textual sorry count dropped)
+      structural_only  -> keep iterating: decomposition landed, count did not drop
+      crashed          -> postmortem the harness, not the proof
+      provider_outage  -> the LLM provider died mid-run (circuit-breaker,
+                          #5869): the prover never got to work — retry when
+                          the provider is back, do NOT read as tactical failure
+      no_progress      -> diagnostic data only
+
+    Real progress outranks the outage flag: a run that lowered the sorry count
+    (or landed a decomposition) before the provider died is still a harvest —
+    the outage remains visible via result["provider_failures"].
+    """
+    if isinstance(result, dict) and result.get("error"):
+        return "crashed"
+    if final_sorry < original_sorry:
+        return "sorry_decreased"
+    if isinstance(result, dict) and result.get("structural_progress"):
+        return "structural_only"
+    if isinstance(result, dict) and result.get("provider_outage"):
+        return "provider_outage"
+    return "no_progress"
+
+
 def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
                mode: str = "multi", iterations: int = 8,
                provider: str = "zai", local_provider: str = "local",
@@ -133,22 +162,7 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     final = Path(filepath).read_text(encoding="utf-8")
     final_sorry = count_real_sorries(final)
 
-    # Forensic #1453 (2026-07-02): a run's outcome was scattered across 4 fields
-    # (result.status, sorry_delta, structural_progress, error) and every consumer
-    # re-derived its own verdict — the ai-01 harvest step included. One canonical
-    # verdict, ranked by what a coordinator does next:
-    #   sorry_decreased  -> harvest: branch + PR (textual sorry count dropped)
-    #   structural_only  -> keep iterating: decomposition landed, count did not drop
-    #   crashed          -> postmortem the harness, not the proof
-    #   no_progress      -> diagnostic data only
-    if isinstance(result, dict) and result.get("error"):
-        result_kind = "crashed"
-    elif final_sorry < original_sorry:
-        result_kind = "sorry_decreased"
-    elif isinstance(result, dict) and result.get("structural_progress"):
-        result_kind = "structural_only"
-    else:
-        result_kind = "no_progress"
+    result_kind = _derive_result_kind(result, final_sorry, original_sorry)
 
     trace_name = f"{mode}_{name.replace(' ', '_')}_{provider}"
     trace_path = trace.save(trace_name)
@@ -190,8 +204,9 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         # Convention: sorry_delta = final - original. POSITIF = REGRESSION (plus de sorry), NEGATIF = progres. Oppose a tools.py (original - current). Forensic #1453 2026-06-23.
         "sorry_delta": final_sorry - original_sorry,
         "sorry_reduction": original_sorry - final_sorry,  # positif = progres (lecture non ambigue)
-        # Canonical verdict (see derivation above): sorry_decreased |
-        # structural_only | no_progress | crashed | already_solved.
+        # Canonical verdict (see _derive_result_kind): sorry_decreased |
+        # structural_only | provider_outage | no_progress | crashed |
+        # already_solved.
         "result_kind": result_kind,
         "elapsed_s": round(elapsed, 1),
         "result": result,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -51,12 +51,24 @@ DEFAULT_AGENT_TIMEOUT_S = 600
 # Transient-error retry policy. Forensic analysis of prover traces
 # (traces/*.spans.jsonl) showed whole iterations lost to TRANSIENT provider
 # errors (HTTP 5xx, connection reset/aborted, read/connect timeouts) that
-# crashed an agent mid-run with no retry. Retries are bounded: 2 attempts with
-# short exponential backoff (2s, 4s). Note: a 404 is NOT transient — it means a
-# bad/missing model_id (config bug) — and must NOT be retried (see
+# crashed an agent mid-run with no retry. Retries are bounded: 5 attempts with
+# exponential backoff 1s/2s/4s/8s/16s, capped at
+# TRANSIENT_RETRY_BACKOFF_CAP_S (#5869). Note: a 404 is NOT transient — it
+# means a bad/missing model_id (config bug) — and must NOT be retried (see
 # `_is_transient_error`).
-TRANSIENT_RETRY_MAX = 2
-TRANSIENT_RETRY_BACKOFF_S = (2.0, 4.0)
+TRANSIENT_RETRY_MAX = 5
+TRANSIENT_RETRY_BACKOFF_CAP_S = 60.0
+
+# Provider-outage circuit-breaker (#5869). Forensic trace
+# multi_custom_HashlifeCorrectness_L2636 (2026-07-10): openrouter died at
+# +601s and the TacticAgent hop failed ~20 times in 1.5s — each ~50ms
+# round-trip incremented msg.iteration, burned the whole proof budget and
+# polluted the verdict as `no_progress` although no tactic was ever attempted
+# after the outage. After this many CONSECUTIVE failed provider hops (each one
+# already covering TRANSIENT_RETRY_MAX in-hop retries with backoff), the run
+# terminates cleanly with the dedicated `provider_outage` verdict instead of
+# spinning.
+PROVIDER_OUTAGE_BREAKER = 3
 
 # P1 stagnation hard-cap (Epic #1453). The compile tool (tools.py) computes
 # the number of consecutive Δ0 compiles — a build that succeeds but does NOT
@@ -72,6 +84,16 @@ TRANSIENT_RETRY_BACKOFF_S = (2.0, 4.0)
 # that ignores the signal for this many consecutive Δ0 compiles is yielded
 # rather than left to waste compute.
 DELTA0_STAGNATION_HARDCAP = 6
+
+
+def _transient_backoff_s(attempt: int) -> float:
+    """Exponential backoff for transient provider retries (#5869).
+
+    1s, 2s, 4s, 8s, 16s ... doubling each attempt, capped at
+    TRANSIENT_RETRY_BACKOFF_CAP_S so a long retry chain never sleeps more
+    than the cap between two attempts.
+    """
+    return min(2.0 ** (attempt - 1), TRANSIENT_RETRY_BACKOFF_CAP_S)
 
 
 def _is_transient_error(exc: BaseException) -> bool:
@@ -111,6 +133,13 @@ def _is_transient_error(exc: BaseException) -> bool:
         "500", "502", "503", "504",
         "internal server error", "bad gateway",
         "service unavailable", "gateway timeout",
+        # agent_framework wraps provider errors as
+        # "<Client> service failed" (forensic L2636: the openrouter outage
+        # surfaced as "OpenAIChatCompletionClient service failed", missed
+        # every marker below and fell into the no-sleep else branch). The
+        # 4xx guard above still rejects wrapped config errors that mention
+        # their status.
+        "service failed",
         "connection reset", "connection aborted", "connection refused",
         "connectionreset", "connectionerror",
         "read timeout", "connect timeout", "timed out", "timeout",
@@ -150,6 +179,15 @@ class ProofMessage:
     is_structural_progress: bool = False
     diagnosis_reason: Optional[str] = None
     agent_opinion: str = ""
+    # #5869 provider-outage accounting: a transport failure is NOT tactic
+    # work. `provider_failures` counts failed provider hops over the whole
+    # run (forensic); `consecutive_provider_failures` drives the
+    # circuit-breaker and resets on any successful agent call;
+    # `provider_outage` is set when the breaker trips so the runner can emit
+    # a verdict distinct from `no_progress`.
+    provider_failures: int = 0
+    consecutive_provider_failures: int = 0
+    provider_outage: bool = False
 
 
 class AgentExecutor(Executor):
@@ -304,6 +342,12 @@ class AgentExecutor(Executor):
             len(self._state.tactic_history)
             if self._state and hasattr(self._state, "tactic_history") else 0
         )
+        # #5869: set True when the provider hop definitively failed (transient
+        # retries exhausted, or a non-transient provider error) — feeds the
+        # iteration refund + circuit-breaker below. Context-window overflows
+        # are NOT provider failures (the provider answered; the request was
+        # too large).
+        _provider_failed = False
         try:
             response = await self._agent.run(content)
             response_text = self._extract_response_text(response)
@@ -363,9 +407,7 @@ class AgentExecutor(Executor):
                 response_text = None
                 _last_exc = e
                 for _attempt in range(1, TRANSIENT_RETRY_MAX + 1):
-                    _backoff = TRANSIENT_RETRY_BACKOFF_S[
-                        min(_attempt - 1, len(TRANSIENT_RETRY_BACKOFF_S) - 1)
-                    ]
+                    _backoff = _transient_backoff_s(_attempt)
                     _retry_msg = (
                         f"[retry] transient provider error "
                         f"(attempt {_attempt}/{TRANSIENT_RETRY_MAX}): "
@@ -391,6 +433,7 @@ class AgentExecutor(Executor):
                     # Retries exhausted (or a non-transient error surfaced) —
                     # fall through to the existing failure handling, do NOT
                     # swallow the error silently.
+                    _provider_failed = True
                     response_text = f"Agent error: {_last_exc}"
                     if self._trace:
                         self._trace.log(
@@ -398,12 +441,53 @@ class AgentExecutor(Executor):
                             content=str(_last_exc)[:200],
                         )
             else:
+                _provider_failed = True
                 response_text = f"Agent error: {e}"
                 if self._trace:
                     self._trace.log(
                         agent=self._agent.name, role="error",
                         content=str(e)[:200],
                     )
+
+        # #5869: provider-failure accounting + circuit-breaker. A transport
+        # failure is NOT a tactic attempt — refund the iteration incremented
+        # at entry so an outage cannot drain the proof budget (forensic
+        # L2636: ~20 "iterations" burned in 1.5s while openrouter was down,
+        # verdict polluted as no_progress). The breaker bounds the refund
+        # loop: after PROVIDER_OUTAGE_BREAKER consecutive failed hops the run
+        # terminates with the dedicated `provider_outage` verdict. A flapping
+        # provider still terminates: successful hops keep advancing
+        # msg.iteration toward max_iterations, and the wall-clock cap in
+        # provers.py bounds the session either way.
+        if _provider_failed:
+            msg.iteration = max(0, msg.iteration - 1)
+            msg.provider_failures += 1
+            msg.consecutive_provider_failures += 1
+            if self._trace:
+                self._trace.log(
+                    agent=self._agent.name, role="provider_failure",
+                    content=(f"provider hop failed "
+                             f"({msg.consecutive_provider_failures}/"
+                             f"{PROVIDER_OUTAGE_BREAKER} consecutive, "
+                             f"{msg.provider_failures} total), "
+                             f"iteration refunded to {msg.iteration}"),
+                )
+            if msg.consecutive_provider_failures >= PROVIDER_OUTAGE_BREAKER:
+                msg.provider_outage = True
+                msg.error = response_text[:500]
+                msg.error_type = "provider_outage"
+                if self._trace:
+                    self._trace.log(
+                        agent=self._agent.name, role="provider_outage_breaker",
+                        content=(f"{msg.consecutive_provider_failures} "
+                                 f"consecutive provider failures >= "
+                                 f"{PROVIDER_OUTAGE_BREAKER}, terminating run "
+                                 f"with provider_outage"),
+                    )
+                await ctx.yield_output(msg)
+                return
+        else:
+            msg.consecutive_provider_failures = 0
 
         # Detect "burned response" — thinking models sometimes spend their entire
         # output budget in `reasoning_content` and emit no visible parts.
@@ -1272,6 +1356,13 @@ class MergeSearchExecutor(Executor):
             intractable_reason=base.intractable_reason,
             director_calls=base.director_calls,
             absent_identifiers=base.absent_identifiers,
+            # #5869: keep provider-failure accounting across the fan-in —
+            # dropping it here would silently re-arm the circuit-breaker.
+            provider_failures=max(m.provider_failures for m in messages),
+            consecutive_provider_failures=max(
+                m.consecutive_provider_failures for m in messages
+            ),
+            provider_outage=any(m.provider_outage for m in messages),
         )
         if self._trace:
             n = len(messages)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2077,3 +2077,232 @@ def test_refuse_true_placeholder_goal_none_on_real_goal(tmp_path, monkeypatch):
     f = tmp_path / "Real.lean"
     f.write_text(_TRUE_GOAL_FILE, encoding="utf-8")
     assert _refuse_true_placeholder_goal(str(f), 3, "demo") is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #5869 (2026-07-10) — provider-outage backoff + circuit-breaker + iteration
+# accounting.
+#
+# Forensic trace multi_custom_HashlifeCorrectness_L2636: openrouter died at
+# +601s and the TacticAgent hop failed ~20 times in 1.5s — each ~50ms
+# round-trip incremented msg.iteration, burned the whole proof budget and
+# polluted the verdict as `no_progress` although no tactic was ever attempted
+# after the outage. Three fixes, all pinned here offline:
+#   1. "service failed" (agent_framework's wrapped provider error) is now a
+#      transient marker -> bounded in-hop retries with exponential backoff
+#      instead of an instant no-sleep re-loop.
+#   2. A provider hop that definitively fails REFUNDS the iteration it
+#      incremented at entry (transport failure != tactic work).
+#   3. After PROVIDER_OUTAGE_BREAKER consecutive failed hops the run yields
+#      with error_type="provider_outage", distinct from no_progress.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _failing_agent(name="TacticAgent", exc=None):
+    """An agent whose `.run` always raises the given provider error."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    if exc is None:
+        exc = RuntimeError("OpenAIChatCompletionClient service failed: 503")
+
+    agent = MagicMock()
+    agent.name = name
+    agent.run = AsyncMock(side_effect=exc)
+    return agent
+
+
+def _success_then_fail_agent(name="TacticAgent", fail_exc=None):
+    """Succeeds once, then raises on every subsequent call."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    if fail_exc is None:
+        fail_exc = RuntimeError("OpenAIChatCompletionClient service failed: 503")
+
+    agent = MagicMock()
+    agent.name = name
+    agent.run = AsyncMock(side_effect=[
+        MagicMock(messages=[MagicMock(text="ran")]),
+        fail_exc, fail_exc, fail_exc, fail_exc, fail_exc,
+    ])
+    return agent
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Patch asyncio.sleep inside the workflow module so backoff is instant
+    in tests (otherwise the breaker test alone would sleep ~30s)."""
+    from unittest.mock import AsyncMock
+    import prover.workflow as wf
+
+    monkeypatch.setattr(wf.asyncio, "sleep", AsyncMock())
+    return wf.asyncio.sleep
+
+
+def test_service_failed_is_now_transient():
+    """The wrapped provider error from forensic L2636 must classify as
+    transient so it enters the bounded retry path, not the no-sleep loop."""
+    from prover.workflow import _is_transient_error
+
+    assert _is_transient_error(
+        RuntimeError("OpenAIChatCompletionClient service failed: 503")
+    ) is True
+
+
+def test_service_failed_with_4xx_status_still_not_transient():
+    """The 4xx guard still wins: a wrapped error mentioning a real config
+    status (404/401/403) is NOT retried even if it also says 'service failed'."""
+    from prover.workflow import _is_transient_error
+
+    # 'service failed' string present, but a 404 status code on the exc.
+    class _Err(Exception):
+        status_code = 404
+
+    _Err.__str__ = lambda self: "OpenAIChatCompletionClient service failed"
+    assert _is_transient_error(_Err()) is False
+
+
+def test_transient_backoff_is_exponential_capped():
+    """Backoff doubles 1/2/4/8/16s then holds at the cap."""
+    from prover.workflow import _transient_backoff_s, TRANSIENT_RETRY_BACKOFF_CAP_S
+
+    assert _transient_backoff_s(1) == 1.0
+    assert _transient_backoff_s(2) == 2.0
+    assert _transient_backoff_s(3) == 4.0
+    assert _transient_backoff_s(4) == 8.0
+    assert _transient_backoff_s(5) == 16.0
+    assert _transient_backoff_s(20) == TRANSIENT_RETRY_BACKOFF_CAP_S
+
+
+def test_provider_failure_refunds_iteration_and_counts(no_sleep):
+    """A single failed provider hop refunds the iteration it incremented and
+    bumps the failure counters — the budget is NOT burned by a transport error."""
+    from prover.workflow import AgentExecutor, ProofMessage
+
+    state = ProofState(theorem_statement="t")
+    ex = AgentExecutor(_failing_agent(), state=state)
+    msg = ProofMessage(content="x", iteration=4, max_iterations=10)
+
+    ctx = _run_handle(ex, msg)
+
+    # iteration refunded back to 4 (the +1 at entry was undone).
+    assert msg.iteration == 4, f"expected refund to 4, got {msg.iteration}"
+    assert msg.provider_failures == 1
+    assert msg.consecutive_provider_failures == 1
+    assert msg.provider_outage is False  # one failure does not trip the breaker
+    # Not yet at the breaker threshold -> message flows on (no yield here).
+    ctx.yield_output.assert_not_awaited()
+
+
+def test_circuit_breaker_trips_at_threshold(no_sleep):
+    """After PROVIDER_OUTAGE_BREAKER consecutive failed hops the run yields with
+    error_type='provider_outage' and does not keep calling the dead provider."""
+    from prover.workflow import (
+        AgentExecutor, ProofMessage, PROVIDER_OUTAGE_BREAKER,
+    )
+
+    state = ProofState(theorem_statement="t")
+    agent = _failing_agent()
+    ex = AgentExecutor(agent, state=state)
+
+    msg = ProofMessage(content="x", max_iterations=10)
+    for _ in range(PROVIDER_OUTAGE_BREAKER):
+        ctx = _run_handle(ex, msg)
+
+    assert msg.provider_outage is True
+    assert msg.error_type == "provider_outage"
+    assert msg.consecutive_provider_failures == PROVIDER_OUTAGE_BREAKER
+    # Budget intact: the three failures refunded their entry increments.
+    assert msg.iteration == 0, f"expected 0 burned iterations, got {msg.iteration}"
+    # The final hop yielded the outage verdict.
+    assert ctx.yield_output.await_count >= 1
+
+
+def test_budget_intact_across_full_outage(no_sleep):
+    """Simulating the L2636 incident: a provider that fails on EVERY hop. The
+    iteration budget must stay intact and the run must terminate via the breaker
+    (not via the iteration cap with a `no_progress` mislabel)."""
+    from prover.workflow import (
+        AgentExecutor, ProofMessage, PROVIDER_OUTAGE_BREAKER, TRANSIENT_RETRY_MAX,
+    )
+
+    state = ProofState(theorem_statement="t")
+    agent = _failing_agent()
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x", max_iterations=10)
+
+    # Drive hops until the breaker yields. Cap the loop well above the
+    # breaker threshold so a broken (non-terminating) breaker is caught.
+    for _ in range(PROVIDER_OUTAGE_BREAKER + 5):
+        _run_handle(ex, msg)
+        if msg.provider_outage:
+            break
+
+    assert msg.provider_outage is True, "breaker should have terminated the run"
+    assert msg.iteration == 0, "no real tactic attempt -> budget fully intact"
+    # Each failed hop ran the initial call + its in-hop retry chain
+    # (TRANSIENT_RETRY_MAX retries) before giving up.
+    assert agent.run.await_count == PROVIDER_OUTAGE_BREAKER * (1 + TRANSIENT_RETRY_MAX)
+
+
+def test_success_resets_consecutive_failure_counter(no_sleep):
+    """A flapping provider that succeeds between failures never trips the
+    breaker: any successful hop resets consecutive_provider_failures to 0."""
+    from prover.workflow import AgentExecutor, ProofMessage
+
+    state = ProofState(theorem_statement="t")
+    # succeeds, then fails, then fails (2 consecutive, below threshold of 3).
+    agent = _success_then_fail_agent()
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x", max_iterations=10)
+
+    _run_handle(ex, msg)  # hop 1: success -> resets counter
+    assert msg.consecutive_provider_failures == 0
+    _run_handle(ex, msg)  # hop 2: failure
+    assert msg.consecutive_provider_failures == 1
+    assert msg.provider_outage is False
+    _run_handle(ex, msg)  # hop 3: failure (2 consecutive)
+    assert msg.consecutive_provider_failures == 2
+    assert msg.provider_outage is False  # still below breaker
+
+
+def test_context_window_error_is_not_a_provider_failure(no_sleep):
+    """A context-length overflow is a request-size issue, not a provider outage:
+    it must NOT refund the iteration or trip the breaker."""
+    from prover.workflow import AgentExecutor, ProofMessage
+
+    state = ProofState(theorem_statement="t")
+    agent = _failing_agent(
+        exc=RuntimeError("This model's maximum context length is 128000 tokens "
+                         "(context_length_exceeded)."))
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x", iteration=3, max_iterations=10)
+
+    _run_handle(ex, msg)
+
+    assert msg.provider_failures == 0
+    assert msg.provider_outage is False
+    assert msg.consecutive_provider_failures == 0
+    # Context overflow is real attempted work (truncation retry) -> the entry
+    # iteration increment (3 -> 4) is NOT refunded.
+    assert msg.iteration == 4
+
+
+def test_result_kind_provider_outage_when_outage_flag_set():
+    """_derive_result_kind surfaces provider_outage, distinct from no_progress,
+    but real progress (sorry_decreased) still outranks the outage flag."""
+    from prover.run_prover_bg import _derive_result_kind
+
+    # Outage, no progress, no structural progress -> provider_outage.
+    assert _derive_result_kind(
+        {"provider_outage": True, "provider_failures": 3}, 4, 4
+    ) == "provider_outage"
+    # Outage BUT sorry dropped -> still harvestable (sorry_decreased wins).
+    assert _derive_result_kind(
+        {"provider_outage": True, "provider_failures": 3}, 2, 4
+    ) == "sorry_decreased"
+    # No outage, no progress -> legacy no_progress.
+    assert _derive_result_kind({}, 4, 4) == "no_progress"
+    # Crashed outranks everything (result carries an error key).
+    assert _derive_result_kind(
+        {"provider_outage": True, "error": "boom"}, 4, 4
+    ) == "crashed"


### PR DESCRIPTION
## What

Provider-outage resilience for the multi-agent Lean prover harness. Forensic trace `multi_custom_HashlifeCorrectness_L2636` (2026-07-10): openrouter died at +601s and the TacticAgent hop failed ~20 times in 1.5s (~50ms/hop). Each failed hop incremented `msg.iteration`, burned the whole proof budget, and the run ended `no_progress` — although no tactic was ever attempted after the outage.

## Root cause

`"OpenAIChatCompletionClient service failed"` (agent_framework's wrapped provider error) matched **no** transient marker, so it fell into the no-sleep `else` branch of `AgentExecutor.handle` and re-looped instantly; `msg.iteration += 1` on every traversal with no decrement; no circuit-breaker existed.

## Fix (Python harness only — 0 `.lean`)

| # | Change | File |
|---|--------|------|
| 1 | `"service failed"` added to `_is_transient_error` markers (4xx guard still rejects wrapped 404/401/403/422). `TRANSIENT_RETRY_MAX` 2→5; exponential backoff 1/2/4/8/16s via new `_transient_backoff_s()`, capped at 60s. | `workflow.py` |
| 2 | New `ProofMessage` fields: `provider_failures`, `consecutive_provider_failures`, `provider_outage`. A failed provider hop **refunds** the iteration it incremented at entry (transport failure ≠ tactic work). `PROVIDER_OUTAGE_BREAKER = 3`: after 3 consecutive failed hops, yields with `error_type="provider_outage"`. Success resets the counter. Context-window overflows do **not** count as provider failures. | `workflow.py` |
| 3 | Init + capture `provider_outage`/`provider_failures` from `final_msg`; add both keys to the multi-mode result dict. | `provers.py` |
| 4 | `_derive_result_kind()` extracted (testable) returns `"provider_outage"` between `structural_only` and `no_progress`. Real progress still outranks the outage flag; outage visible via `result["provider_failures"]`. Verdict lands in `*_result.json`. | `run_prover_bg.py` |

## Acceptance (#5869)

| Criterion | Met | Evidence |
|-----------|-----|----------|
| Exponential backoff 1/2/4/… cap 60s, N transport retries before counting an iteration | ✅ | `_transient_backoff_s` + `TRANSIENT_RETRY_MAX=5`; iteration refunded on failure |
| ≥3 consecutive failures → clean termination with `provider_outage` verdict (≠ `no_progress`) | ✅ | `test_circuit_breaker_trips_at_threshold`, `test_result_kind_provider_outage_when_outage_flag_set` |
| Iteration counter only increments on a real tactic attempt | ✅ | `test_provider_failure_refunds_iteration_and_counts`, `test_budget_intact_across_full_outage` (budget == 0 burned) |
| No behavior change on healthy runs | ✅ | `test_success_resets_consecutive_failure_counter`; 121 existing tests unchanged |
| `provider_outage` visible in `*_result.json`, distinct in forensic aggregates | ✅ | `provers.py` result-dict keys + `run_prover_bg.py` verdict |

## Test output

```
python -m pytest tests/ -q   (from agent_tests/)
collected 130 items
tests\test_prover_guards.py ............................................ [ 33%]
........................................................................ [ 89%]
..............                                                           [100%]
============================= 130 passed in 1.27s =============================
```

9 new tests (+121 existing, 0 regressions).

## Infinite-loop safety

A flapping provider cannot spin forever: successful hops keep advancing `msg.iteration` toward `max_iterations`, and the wall-clock reasoning cap in `provers.py` bounds the session regardless. Pure failures trip the breaker at 3.

## Out of scope (noted)

- **Autonomous path** (`provers.py:1590+`): incident was multi-mode; left as-is.
- **Mid-run provider fallback switching**: agents are constructed with chat clients up-front, so a mid-run switch is invasive. The issue explicitly allows either (clean termination **or** fallback); clean termination chosen for a bounded diff. Follow-up candidate.

Closes #5869
See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
