### PR TITLE
feat(coherence-lean): four-ticket expectation-argument converse (E_p[gain] = 0) for weights-derived prices

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence.lean
@@ -21,19 +21,25 @@ perte sûre. La cohérence *force* donc les axiomes de probabilité.
   mono-livret (aucun Dutch Book à un seul ticket) **ssi** elle satisfait les bornes de
   probabilité `0 ≤ q A ≤ 1`, `q ∅ = 0`, `q univ = 1`. Chaque axiome violé admet un
   Dutch Book explicite à un seul ticket (`single_dutch_book_of_neg/high/pos_empty/univ_lt`),
-  0 `sorry`.
+  0 `sorry`. Plus la **réciproque quatre-tickets** pour les prix issus de poids
+  probabilistes (`priceFromWeights_coherent_on`), par l'argument d'espérance
+  `E_p[gain] = 0` (`sum_weights_mul_ind` → `expected_ticket_gain_zero` →
+  `expected_ieGain_zero` → contradiction sur un état chargé, `exists_pos_weight`).
 
 ## Statut
 - Prouvé sans `sorry` : la direction constructive (violation de l'inclusion–exclusion
   ⟹ Dutch Book avec mises explicites `(1,1,−1,−1)` ou l'inverse), la cohérence ⟹
-  additivité sur deux événements, et la **caractérisation mono-livret** complète
-  (`single_coherent_iff_prob_bounds`, 0 `sorry`, axiomes `[propext, Classical.choice,
-  Quot.sound]`).
-- Ouvert (jalon suivant) : le `coherent_iff_probability` **complet** (livrets de taille
-  arbitraire, via la reconstruction de la mesure `q A = Σ_{ω ∈ A} q {ω}` puis l'argument
-  d'espérance, ou la séparation d'hyperplans / dualité LP en dimension finie). La version
-  mono-livret livrée ici en constitue le noyau tractable (faisabilité Lean « MOYENNE »,
-  cf #4050).
+  additivité sur deux événements, la **caractérisation mono-livret** complète
+  (`single_coherent_iff_prob_bounds`, axiomes `[propext, Classical.choice, Quot.sound]`),
+  et la **réciproque quatre-tickets pour les vraies probabilités**
+  (`priceFromWeights_coherent_on` : aucun livret à quatre tickets n'arbitre un prix issu
+  de poids non négatifs sommant à 1).
+- Ouvert (jalon suivant) : le `coherent_iff_probability` **complet** — livrets de taille
+  arbitraire sur un prix cohérent QUELCONQUE, via la reconstruction de la mesure
+  `q A = Σ_{ω ∈ A} q {ω}` (montrer qu'un prix cohérent est nécessairement de la forme
+  `priceFromWeights`), ou la séparation d'hyperplans / dualité LP en dimension finie.
+  Les versions mono-livret et quatre-tickets-sur-poids livrées ici en constituent le
+  noyau tractable (faisabilité Lean « MOYENNE », cf #4050).
 
 ## Références croisées
 - `Utility` (même lake) : représentation d'utilité espérée vNM — l'autre fondation

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Probability.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Probability.lean
@@ -26,11 +26,13 @@ sur le signe de la mise `s` :
 Réciproquement, sous les bornes de probabilité, aucune mise `s` ne rend `s (𝟙_A − q A) < 0`
 en tout état (disjonction `s < 0` / `s = 0` / `s > 0`).
 
-**Cadrage honnête (G.3/G.9).** Le `coherent_iff_probability` COMPLET (livrets de taille
-arbitraire, via la reconstruction de la mesure `q A = Σ_{ω ∈ A} q {ω}` puis l'argument
-d'espérance) reste un jalon suivant ; on livre ici la caractérisation mono-livret et son
-identité avec les bornes de probabilité, 0 `sorry`. Voir de Finetti (1937), *La prévision :
-ses lois logiques, ses sources subjectives*.
+**Cadrage honnête (G.3/G.9).** On livre ici, 0 `sorry` : la caractérisation mono-livret et
+son identité avec les bornes de probabilité, puis — pour les prix **issus de poids**
+(`priceFromWeights`) — la réciproque **quatre-tickets** par l'argument d'espérance
+`E_p[gain] = 0` (`priceFromWeights_coherent_on`). Le `coherent_iff_probability` COMPLET
+(livrets de taille arbitraire sur un prix cohérent QUELCONQUE, via la reconstruction de la
+mesure `q A = Σ_{ω ∈ A} q {ω}`) reste un jalon suivant. Voir de Finetti (1937),
+*La prévision : ses lois logiques, ses sources subjectives*.
 -/
 
 namespace Coherence
@@ -251,5 +253,93 @@ lemma priceFromWeights_single_coherent (p : Ω → ℝ) [Nonempty Ω]
     (hnn : ∀ ω, (0:ℝ) ≤ p ω) (hsum : ∑ ω, p ω = 1) :
     SingleCoherent (priceFromWeights p) :=
   (single_coherent_iff_prob_bounds _).mpr (priceFromWeights_probBounds p hnn hsum)
+
+/-! ## Réciproque quatre-tickets : l'argument d'espérance `E_p[gain] = 0`
+
+`priceFromWeights_additive` établit que les prix issus de poids satisfont l'identité
+d'inclusion–exclusion, mais l'additivité seule ne donne PAS `CoherentOn` : la contraposée
+de `coherent_on_implies_additive` dit « non additive ⟹ non cohérente », pas la réciproque.
+On prouve ici directement que **tout livret à quatre tickets contre un prix issu de poids
+probabilistes est inarbitrable**, par l'argument d'espérance annoncé dans `DutchBook.lean` :
+
+1. Le prix d'un ticket est son espérance : `E_p[𝟙_E] = q E` (`sum_weights_mul_ind`).
+2. Chaque ticket est donc un pari équitable : `E_p[𝟙_E − q E] = 0`
+   (`expected_ticket_gain_zero`).
+3. Par linéarité, le gain du livret complet est d'espérance nulle : `E_p[ieGain] = 0`
+   (`expected_ieGain_zero`).
+4. Un gain partout strictement négatif aurait une espérance strictement négative dès
+   qu'un état porte un poids `> 0` — et `Σ p = 1` en garantit un (`exists_pos_weight`).
+   Contradiction : aucun arbitrage n'existe (`priceFromWeights_coherent_on`).
+-/
+
+/-- **Le prix est l'espérance de l'indicatrice.** Pour un prix issu de poids,
+    `Σ_ω p ω · 𝟙_E ω = q E` : la somme pondérée de l'indicatrice sur tous les états se
+    restreint exactement aux états de `E`. -/
+lemma sum_weights_mul_ind (p : Ω → ℝ) (E : Event Ω) :
+    ∑ ω, p ω * ind E ω = priceFromWeights p E := by
+  simp only [priceFromWeights, ind, mul_ite, mul_one, mul_zero]
+  rw [Finset.sum_ite_mem, Finset.univ_inter]
+
+/-- **Chaque ticket est un pari équitable.** Le gain unitaire `𝟙_E − q E` d'un ticket
+    payé à son espérance est d'espérance nulle : `Σ_ω p ω · (𝟙_E ω − q E) = 0`. -/
+lemma expected_ticket_gain_zero (p : Ω → ℝ) (hsum : ∑ ω, p ω = 1) (E : Event Ω) :
+    ∑ ω, p ω * (ind E ω - priceFromWeights p E) = 0 := by
+  simp only [mul_sub]
+  rw [Finset.sum_sub_distrib, sum_weights_mul_ind p E, ← Finset.sum_mul, hsum,
+    one_mul, sub_self]
+
+/-- **Espérance nulle du livret complet.** Par linéarité de l'espérance, le gain
+    `ieGain` du livret à quatre tickets (mises quelconques `sA sB sAB sAU`) contre un prix
+    issu de poids probabilistes est d'espérance nulle. C'est l'argument d'espérance
+    `E_p[gain] = 0` annoncé dans `DutchBook.lean`. -/
+lemma expected_ieGain_zero (p : Ω → ℝ) (hsum : ∑ ω, p ω = 1) (A B : Event Ω)
+    (sA sB sAB sAU : ℝ) :
+    ∑ ω, p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω = 0 := by
+  have hexp : ∀ ω : Ω, p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω
+      = sA * (p ω * (ind A ω - priceFromWeights p A))
+        + sB * (p ω * (ind B ω - priceFromWeights p B))
+        + sAB * (p ω * (ind (A ∩ B) ω - priceFromWeights p (A ∩ B)))
+        + sAU * (p ω * (ind (A ∪ B) ω - priceFromWeights p (A ∪ B))) := fun ω => by
+    simp only [ieGain]; ring
+  simp only [hexp]
+  rw [Finset.sum_add_distrib, Finset.sum_add_distrib, Finset.sum_add_distrib,
+    ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum,
+    expected_ticket_gain_zero p hsum A, expected_ticket_gain_zero p hsum B,
+    expected_ticket_gain_zero p hsum (A ∩ B), expected_ticket_gain_zero p hsum (A ∪ B)]
+  ring
+
+omit [DecidableEq Ω] in
+/-- **Une distribution charge au moins un état.** Si `Σ p = 1`, un poids strictement
+    positif existe — sinon la somme serait `≤ 0`. (Rend `[Nonempty Ω]` superflu ici :
+    la normalisation fournit elle-même le témoin.) -/
+lemma exists_pos_weight (p : Ω → ℝ) (hsum : ∑ ω, p ω = 1) : ∃ ω, 0 < p ω := by
+  by_contra hne
+  have hle : ∑ ω, p ω ≤ 0 :=
+    Finset.sum_nonpos fun ω _ => not_lt.mp fun h => hne ⟨ω, h⟩
+  linarith
+
+/-- **Une vraie probabilité est cohérente (quatre tickets).** Aucun livret à quatre
+    tickets, quelles que soient les mises, n'arbitre un prix issu de poids probabilistes :
+    `CoherentOn (priceFromWeights p) A B` pour tous événements `A B`. C'est la réciproque
+    quatre-tickets du cadre `DutchBook.lean`, par l'argument d'espérance : si le gain était
+    strictement négatif en tout état, son espérance — nulle par `expected_ieGain_zero` —
+    serait strictement négative sur l'état chargé fourni par `exists_pos_weight`. -/
+theorem priceFromWeights_coherent_on (p : Ω → ℝ) (hnn : ∀ ω, (0:ℝ) ≤ p ω)
+    (hsum : ∑ ω, p ω = 1) (A B : Event Ω) :
+    CoherentOn (priceFromWeights p) A B := by
+  intro sA sB sAB sAU harb
+  obtain ⟨ω₀, hω₀⟩ := exists_pos_weight p hsum
+  have hzero := expected_ieGain_zero p hsum A B sA sB sAB sAU
+  have hneg : ∑ ω, p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω < 0 := by
+    have hle : ∀ ω ∈ (Finset.univ : Finset Ω),
+        p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω ≤ 0 :=
+      fun ω _ => by nlinarith [hnn ω, le_of_lt (harb ω)]
+    have hlt : p ω₀ * ieGain (priceFromWeights p) A B sA sB sAB sAU ω₀ < 0 :=
+      mul_neg_of_pos_of_neg hω₀ (harb ω₀)
+    calc ∑ ω, p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω
+        < ∑ _ω : Ω, (0:ℝ) :=
+          Finset.sum_lt_sum hle ⟨ω₀, Finset.mem_univ ω₀, hlt⟩
+      _ = 0 := Finset.sum_const_zero
+  linarith
 
 end Coherence

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Probability_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence/Probability_en.lean
@@ -26,10 +26,12 @@ on the sign of the stake `s`:
 Conversely, under the probability bounds, no stake `s` makes `s (𝟙_A − q A) < 0`
 at every state (disjunction `s < 0` / `s = 0` / `s > 0`).
 
-**Honest scoping (G.3/G.9).** The COMPLETE `coherent_iff_probability` (books of
-arbitrary size, via reconstruction of the measure `q A = Σ_{ω ∈ A} q {ω}` then the
-expectation argument) remains a next milestone; we deliver here the single-book
-characterisation and its identity with the probability bounds, 0 `sorry`. See
+**Honest scoping (G.3/G.9).** We deliver here, 0 `sorry`: the single-book
+characterisation and its identity with the probability bounds, then — for
+**weights-derived** prices (`priceFromWeights`) — the **four-ticket** converse via the
+expectation argument `E_p[gain] = 0` (`priceFromWeights_coherent_on`). The COMPLETE
+`coherent_iff_probability` (books of arbitrary size on an ARBITRARY coherent price, via
+reconstruction of the measure `q A = Σ_{ω ∈ A} q {ω}`) remains a next milestone. See
 de Finetti (1937), *La prévision: ses lois logiques, ses sources subjectives*.
 
 English mirror of `Coherence/Probability.lean` (French canonical). Convention EPIC #4980:
@@ -256,5 +258,96 @@ lemma priceFromWeights_single_coherent (p : Ω → ℝ) [Nonempty Ω]
     (hnn : ∀ ω, (0:ℝ) ≤ p ω) (hsum : ∑ ω, p ω = 1) :
     SingleCoherent (priceFromWeights p) :=
   (single_coherent_iff_prob_bounds _).mpr (priceFromWeights_probBounds p hnn hsum)
+
+/-! ## Four-ticket converse: the expectation argument `E_p[gain] = 0`
+
+`priceFromWeights_additive` establishes that weights-derived prices satisfy the
+inclusion–exclusion identity, but additivity alone does NOT yield `CoherentOn`: the
+contrapositive of `coherent_on_implies_additive` says "non-additive ⟹ non-coherent",
+not the converse. We prove here directly that **every four-ticket book against a price
+derived from probabilistic weights is non-arbitrageable**, via the expectation argument
+announced in `DutchBook.lean`:
+
+1. The price of a ticket is its expectation: `E_p[𝟙_E] = q E` (`sum_weights_mul_ind`).
+2. Each ticket is therefore a fair bet: `E_p[𝟙_E − q E] = 0`
+   (`expected_ticket_gain_zero`).
+3. By linearity, the payoff of the full book has zero expectation: `E_p[ieGain] = 0`
+   (`expected_ieGain_zero`).
+4. A payoff strictly negative everywhere would have strictly negative expectation as
+   soon as some state carries weight `> 0` — and `Σ p = 1` guarantees one
+   (`exists_pos_weight`). Contradiction: no arbitrage exists
+   (`priceFromWeights_coherent_on`).
+-/
+
+/-- **The price is the expectation of the indicator.** For a weights-derived price,
+    `Σ_ω p ω · 𝟙_E ω = q E`: the weighted sum of the indicator over all states restricts
+    exactly to the states of `E`. -/
+lemma sum_weights_mul_ind (p : Ω → ℝ) (E : Event Ω) :
+    ∑ ω, p ω * ind E ω = priceFromWeights p E := by
+  simp only [priceFromWeights, ind, mul_ite, mul_one, mul_zero]
+  rw [Finset.sum_ite_mem, Finset.univ_inter]
+
+/-- **Each ticket is a fair bet.** The unit payoff `𝟙_E − q E` of a ticket priced at its
+    expectation has zero expectation: `Σ_ω p ω · (𝟙_E ω − q E) = 0`. -/
+lemma expected_ticket_gain_zero (p : Ω → ℝ) (hsum : ∑ ω, p ω = 1) (E : Event Ω) :
+    ∑ ω, p ω * (ind E ω - priceFromWeights p E) = 0 := by
+  simp only [mul_sub]
+  rw [Finset.sum_sub_distrib, sum_weights_mul_ind p E, ← Finset.sum_mul, hsum,
+    one_mul, sub_self]
+
+/-- **Zero expectation of the full book.** By linearity of expectation, the payoff
+    `ieGain` of the four-ticket book (arbitrary stakes `sA sB sAB sAU`) against a price
+    derived from probabilistic weights has zero expectation. This is the expectation
+    argument `E_p[gain] = 0` announced in `DutchBook.lean`. -/
+lemma expected_ieGain_zero (p : Ω → ℝ) (hsum : ∑ ω, p ω = 1) (A B : Event Ω)
+    (sA sB sAB sAU : ℝ) :
+    ∑ ω, p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω = 0 := by
+  have hexp : ∀ ω : Ω, p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω
+      = sA * (p ω * (ind A ω - priceFromWeights p A))
+        + sB * (p ω * (ind B ω - priceFromWeights p B))
+        + sAB * (p ω * (ind (A ∩ B) ω - priceFromWeights p (A ∩ B)))
+        + sAU * (p ω * (ind (A ∪ B) ω - priceFromWeights p (A ∪ B))) := fun ω => by
+    simp only [ieGain]; ring
+  simp only [hexp]
+  rw [Finset.sum_add_distrib, Finset.sum_add_distrib, Finset.sum_add_distrib,
+    ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum,
+    expected_ticket_gain_zero p hsum A, expected_ticket_gain_zero p hsum B,
+    expected_ticket_gain_zero p hsum (A ∩ B), expected_ticket_gain_zero p hsum (A ∪ B)]
+  ring
+
+omit [DecidableEq Ω] in
+/-- **A distribution charges at least one state.** If `Σ p = 1`, a strictly positive
+    weight exists — otherwise the sum would be `≤ 0`. (Makes `[Nonempty Ω]` superfluous
+    here: the normalisation itself provides the witness.) -/
+lemma exists_pos_weight (p : Ω → ℝ) (hsum : ∑ ω, p ω = 1) : ∃ ω, 0 < p ω := by
+  by_contra hne
+  have hle : ∑ ω, p ω ≤ 0 :=
+    Finset.sum_nonpos fun ω _ => not_lt.mp fun h => hne ⟨ω, h⟩
+  linarith
+
+/-- **A true probability is coherent (four tickets).** No four-ticket book, whatever the
+    stakes, arbitrages a price derived from probabilistic weights:
+    `CoherentOn (priceFromWeights p) A B` for all events `A B`. This is the four-ticket
+    converse of the `DutchBook.lean` framework, via the expectation argument: if the
+    payoff were strictly negative at every state, its expectation — zero by
+    `expected_ieGain_zero` — would be strictly negative on the charged state provided by
+    `exists_pos_weight`. -/
+theorem priceFromWeights_coherent_on (p : Ω → ℝ) (hnn : ∀ ω, (0:ℝ) ≤ p ω)
+    (hsum : ∑ ω, p ω = 1) (A B : Event Ω) :
+    CoherentOn (priceFromWeights p) A B := by
+  intro sA sB sAB sAU harb
+  obtain ⟨ω₀, hω₀⟩ := exists_pos_weight p hsum
+  have hzero := expected_ieGain_zero p hsum A B sA sB sAB sAU
+  have hneg : ∑ ω, p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω < 0 := by
+    have hle : ∀ ω ∈ (Finset.univ : Finset Ω),
+        p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω ≤ 0 :=
+      fun ω _ => by nlinarith [hnn ω, le_of_lt (harb ω)]
+    have hlt : p ω₀ * ieGain (priceFromWeights p) A B sA sB sAB sAU ω₀ < 0 :=
+      mul_neg_of_pos_of_neg hω₀ (harb ω₀)
+    calc ∑ ω, p ω * ieGain (priceFromWeights p) A B sA sB sAB sAU ω
+        < ∑ _ω : Ω, (0:ℝ) :=
+          Finset.sum_lt_sum hle ⟨ω₀, Finset.mem_univ ω₀, hlt⟩
+      _ = 0 := Finset.sum_const_zero
+  linarith
 
 end Coherence_en

--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence_en.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Coherence_en.lean
@@ -21,19 +21,25 @@ sure loss. Coherence therefore *forces* the probability axioms.
   single-ticket sense (no single-ticket Dutch Book) **iff** it satisfies the
   probability bounds `0 ≤ q A ≤ 1`, `q ∅ = 0`, `q univ = 1`. Each violated axiom
   admits an explicit single-ticket Dutch Book (`single_dutch_book_of_neg/high/pos_empty/univ_lt`),
-  0 `sorry`.
+  0 `sorry`. Plus the **four-ticket converse** for prices derived from
+  probabilistic weights (`priceFromWeights_coherent_on`), via the expectation
+  argument `E_p[gain] = 0` (`sum_weights_mul_ind` → `expected_ticket_gain_zero` →
+  `expected_ieGain_zero` → contradiction on a charged state, `exists_pos_weight`).
 
 ## Status
 - Proved without `sorry`: the constructive direction (inclusion–exclusion
   violation ⟹ Dutch Book with explicit stakes `(1,1,−1,−1)` or the converse),
-  coherence ⟹ additivity on two events, and the **complete single-book
-  characterization** (`single_coherent_iff_prob_bounds`, 0 `sorry`, axioms
-  `[propext, Classical.choice, Quot.sound]`).
-- Open (next milestone): the full `coherent_iff_probability` (arbitrary-size
-  books, via the measure reconstruction `q A = Σ_{ω ∈ A} q {ω}` then the
-  expectation argument, or hyperplane separation / LP duality in finite
-  dimension). The single-book version delivered here is its tractable core (Lean
-  feasibility "MEDIUM", cf #4050).
+  coherence ⟹ additivity on two events, the **complete single-book
+  characterization** (`single_coherent_iff_prob_bounds`, axioms
+  `[propext, Classical.choice, Quot.sound]`), and the **four-ticket converse for
+  true probabilities** (`priceFromWeights_coherent_on`: no four-ticket book
+  arbitrages a price derived from non-negative weights summing to 1).
+- Open (next milestone): the full `coherent_iff_probability` — arbitrary-size
+  books on an ARBITRARY coherent price, via the measure reconstruction
+  `q A = Σ_{ω ∈ A} q {ω}` (showing that a coherent price is necessarily of the
+  form `priceFromWeights`), or hyperplane separation / LP duality in finite
+  dimension. The single-book and four-tickets-on-weights versions delivered here
+  are its tractable core (Lean feasibility "MEDIUM", cf #4050).
 
 ## Cross-references
 - `Utility` (same lake): von Neumann–Morgenstern expected-utility representation —


### PR DESCRIPTION
# PR body — feat(coherence-lean): four-ticket expectation-argument converse

## Summary

Delivers the **four-ticket converse** announced as the next milestone in the `Coherence` lake headers (See #4050): a price function derived from probabilistic weights (`priceFromWeights p`, with `p >= 0` and `sum p = 1`) is **coherent on any pair of events** — no four-ticket book `(sA, sB, sAB, sAU)` can guarantee a strictly negative payoff in every state.

The proof is the classical de Finetti expectation argument `E_p[gain] = 0`:

1. `sum_weights_mul_ind` — the price is the expectation of the indicator: `sum_w p w * ind E w = priceFromWeights p E`.
2. `expected_ticket_gain_zero` — each single ticket is a fair bet: `E_p[ind E - q E] = 0`.
3. `expected_ieGain_zero` — by linearity over the four tickets, the whole book has zero expectation.
4. `exists_pos_weight` + `priceFromWeights_coherent_on` — a distribution charges at least one state; if the book were an arbitrage (payoff < 0 everywhere), the expectation would be strictly negative (`Finset.sum_lt_sum` with the charged state as strict witness), contradicting step 3.

Key scoping note (G.3/G.9, honest): this is the converse **for weights-derived prices**, not yet the full `coherent_iff_probability` (arbitrary-size books on an ARBITRARY coherent price, which needs the measure reconstruction `q A = sum_{w in A} q {w}` or LP duality). The umbrella and module headers are updated to state exactly what is proven and what remains open.

## Files (4, single domain, single feature)

| File | Change |
|------|--------|
| `Coherence/Probability.lean` | New section "Réciproque quatre-tickets" : 4 lemmas + 1 theorem, FR docstrings ; header scoping updated |
| `Coherence/Probability_en.lean` | EN mirror (EPIC #4980) : identical Lean code, EN docstrings, namespace `Coherence_en` |
| `Coherence.lean` | Umbrella Contenu/Statut updated (four-ticket converse proven ; open milestone narrowed) |
| `Coherence_en.lean` | EN umbrella mirror |

## §B Lean discipline

**Sorry before/after** (all occurrences are prose mentions of the string "0 `sorry`" in docstrings — zero `sorry` tactics before AND after, verified `grep -nE ':= by sorry|^\s*sorry\b|exact sorry|\badmit\b'` → no match):

| File | before | after | note |
|------|--------|-------|------|
| `Coherence.lean` | 4 | 3 | prose-only (docstring wording consolidated) |
| `Coherence_en.lean` | 4 | 3 | prose-only |
| `Coherence/Probability.lean` | 2 | 2 | prose-only |
| `Coherence/Probability_en.lean` | 2 | 2 | prose-only |

**Lake build (local, MANDATORY — CI does not build this lake):**

```
✔ [8497/8500] Built Coherence.Probability_en (135s)
✔ [8498/8500] Built Coherence.Probability (139s)
✔ [8499/8500] Built Coherence (173s)
Build completed successfully (8500 jobs).
===LAKE_EXIT=0===
```

`time` real 9m06.395s / user 27s / sys 1m34s (WSL Ubuntu, lean v4.31.0-rc1, mathlib rev d568c8c0, warm cache, incremental on the 2 touched `Coherence.Probability{,_en}` files). **0 linter warnings** on this re-run (the `push_neg` deprecation + `[DecidableEq Ω]` unused-section-var issues on `exists_pos_weight` from build #1 are resolved: `omit [DecidableEq Ω] in` + `not_lt.mp` direct replacement).

**Proof integrity:** no existing declaration modified or removed — the new section is purely additive before `end Coherence` / `end Coherence_en`; header/umbrella edits are docstring-only. No axioms added (`Finset.sum_lt_sum`, `Finset.sum_nonpos`, `nlinarith` — standard Mathlib/classical only).

**No prover refactor:** `agent_tests/prover/` untouched.

## §A sweep eligibility

+220/−27, 4 files, single domain (decision_theory_lean/Coherence), single feature (expectation-argument converse). No lakefile/manifest/toolchain touch (L267). LF verified on all 4 files via `git ls-files --eol` (L268). Branched from fresh `origin/main` @ `443f46d40` (L273) — disjoint from merged #5857 (Utility files only).

## References

- See #4050 (Dutch Book / coherence lake milestone — partial: four-ticket converse for weights-derived prices; full `coherent_iff_probability` remains open)
- See #4980 (i18n FR-canonical + EN mirror — convention applied: FR docstrings canonical, `_en` sibling byte-identical Lean code)

---

Worker `myia-po-2026:CoursIA-2` — not self-merging (L279), forwarding to ai-01 for review + merge.

Co-Authored-By: Claude <noreply@anthropic.com>
