### PR TITLE
fix(prover): circuit-breaker + backoff for provider-outage burn loop (#5869)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -911,6 +911,11 @@ class MultiAgentSorryProver:
             # from an actual sorry reduction. Without this, both report
             # success=True and consumers cannot tell them apart.
             "structural_progress": structural_progress,
+            # #5869: provider-outage circuit-breaker. True when the workflow
+            # terminated early because the LLM provider was unreachable (>=3
+            # consecutive transport failures). Distinct from a genuine proof
+            # failure so a coordinator does not re-harvest a dead run.
+            "provider_outage": bool(getattr(state, "provider_outage", False)),
             # FX-6 (#1453): diagnostic fields for the statement-mutation guard.
             "verified_tactic_count": verified_tactic_count,
             **({"flag": "STMT_MUTATION_FALSE_SUCCESS"} if stmt_mutation else {}),

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -143,6 +143,13 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     #   no_progress      -> diagnostic data only
     if isinstance(result, dict) and result.get("error"):
         result_kind = "crashed"
+    elif isinstance(result, dict) and result.get("provider_outage"):
+        # #5869: the LLM provider was unreachable (>=3 consecutive transport
+        # failures). Ranked ABOVE sorry_decreased/structural_only so a dead
+        # run is never re-harvested as proof progress. DISTINCT from crashed
+        # (a harness exception) — here the workflow ended cleanly via the
+        # circuit-breaker yield, it just could not reach the model.
+        result_kind = "provider_outage"
     elif final_sorry < original_sorry:
         result_kind = "sorry_decreased"
     elif isinstance(result, dict) and result.get("structural_progress"):
@@ -160,7 +167,12 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     # SUCCESS/FAILED label from the boolean to match the prover's own internal
     # RESULT line (provers.py:880/1580).
     _success = bool(result.get("success")) if isinstance(result, dict) else False
-    print(f"RESULT: {'SUCCESS' if _success else 'FAILED'}")
+    # #5869: provider_outage is a distinct terminal state — the run did not
+    # fail to prove, the provider was unreachable. Label it OUTAGE so a human
+    # scanning logs does not mistake it for a proof failure.
+    _label = ("OUTAGE" if result_kind == "provider_outage"
+              else "SUCCESS" if _success else "FAILED")
+    print(f"RESULT: {_label}")
     print(f"  Verdict: {result_kind}")
     print(f"  Sorry: {original_sorry} → {final_sorry}")
     _actual_iters = result.get("iterations") if isinstance(result, dict) else None
@@ -191,8 +203,12 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         "sorry_delta": final_sorry - original_sorry,
         "sorry_reduction": original_sorry - final_sorry,  # positif = progres (lecture non ambigue)
         # Canonical verdict (see derivation above): sorry_decreased |
-        # structural_only | no_progress | crashed | already_solved.
+        # structural_only | no_progress | crashed | provider_outage |
+        # already_solved.
         "result_kind": result_kind,
+        # #5869: explicit boolean mirror of the verdict so downstream forensic
+        # aggregators can filter dead-provider runs without string-matching.
+        "provider_outage": result_kind == "provider_outage",
         "elapsed_s": round(elapsed, 1),
         "result": result,
         "trace_file": trace_path,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -99,6 +99,16 @@ class ProofState:
     # Lets workflow executors force-route a stuck session without re-deriving it.
     consecutive_delta0_compiles: int = 0
 
+    # Provider-outage circuit-breaker (#5869). consecutive_provider_failures is
+    # incremented by AgentExecutor on every transport/service error from
+    # agent.run() and reset on a successful call. On reaching the threshold
+    # (workflow.PROVIDER_OUTAGE_THRESHOLD), provider_outage is latched True and
+    # the message is yielded as terminal output — provers.py breaks and
+    # run_prover_bg surfaces a distinct 'provider_outage' verdict so a dead
+    # provider is not re-harvested as a failed proof. See workflow._on_provider_failure.
+    consecutive_provider_failures: int = 0
+    provider_outage: bool = False
+
     # B.3: Explicit attack plan set by CoordinatorAgent
     plan: List[str] = field(default_factory=list)
     plan_phase: int = 0  # Current step in the plan

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -58,6 +58,26 @@ DEFAULT_AGENT_TIMEOUT_S = 600
 TRANSIENT_RETRY_MAX = 2
 TRANSIENT_RETRY_BACKOFF_S = (2.0, 4.0)
 
+# Provider-outage circuit-breaker (#5869). A dead provider (rate-limited
+# gateway, network partition, expired key, or the Semantic Kernel
+# ``OpenAIChatCompletionClient service failed`` transport wrapper) makes every
+# agent.run() raise a transport/service error. Before this guard the harness
+# spun at ~50ms/iteration: the non-transient ``else`` branch of handle()'s
+# except returned an "Agent error: …" string with NO sleep, and msg.iteration
+# had already been consumed at the top of handle(), so a single outage burned
+# the ENTIRE iteration budget in <2s with zero proof progress (forensic trace:
+# 20 loops of "OpenAIChatCompletionClient service failed" in 1.5s, budget
+# 20->0, 0 sorry touched). Three guards, all in handle()'s except block:
+#   1. exponential backoff on every provider failure (kills the spin),
+#   2. a shared consecutive-failure counter (state.consecutive_provider_failures,
+#      reset on a successful call) with a circuit-breaker threshold — on trip,
+#      state.provider_outage is latched and handle() yields the message as
+#      terminal output, ending the workflow run,
+#   3. iteration refund on pure transport errors so the budget stays intact.
+# run_prover_bg.py then surfaces a distinct 'provider_outage' verdict.
+PROVIDER_OUTAGE_THRESHOLD = 3
+PROVIDER_OUTAGE_BACKOFF_S = (1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 60.0)
+
 # P1 stagnation hard-cap (Epic #1453). The compile tool (tools.py) computes
 # the number of consecutive Δ0 compiles — a build that succeeds but does NOT
 # reach a new sorry-count low — and mirrors it to
@@ -119,6 +139,37 @@ def _is_transient_error(exc: BaseException) -> bool:
     return any(marker in msg for marker in transient_markers)
 
 
+def _is_provider_outage_error(exc: BaseException) -> bool:
+    """Broad provider/transport failure detector for the circuit-breaker (#5869).
+
+    Superset of ``_is_transient_error``: that one is strict (only specific
+    5xx / connection-reset / timeout markers) so the bounded retry path does
+    not hammer a 404 config bug. This detector ALSO catches transport-layer
+    failures that carry no status_code and no recognized marker word — most
+    notably the Semantic Kernel ``OpenAIChatCompletionClient service failed``
+    wrapper raised when the underlying httpx call dies mid-request, which was
+    the exact forensic signature of the #5869 burn loop. Everything matched
+    here counts toward the circuit-breaker; a 404 / 4xx config error still
+    does NOT (genuine bug, not a dead provider).
+    """
+    if _is_transient_error(exc):
+        return True
+    msg = str(exc).lower()
+    # Defensive: a config bug (404/4xx) wrapped in a transport message is
+    # still a config bug — never a dead provider.
+    if any(code in msg for code in (" 404", "404 ", "not found",
+                                    " 401", " 403", " 422",
+                                    "unauthorized", "forbidden")):
+        return False
+    return any(m in msg for m in (
+        "service failed", "service unavailable",
+        "chatcompletionclient",            # SK wrapper signature
+        "connection error", "connection closed", "connection broken",
+        "max retries exceeded",
+        "remote protocol error", "incomplete chunked read",
+    ))
+
+
 @dataclass
 class ProofMessage:
     """Message flowing between agents in the workflow."""
@@ -170,6 +221,63 @@ class AgentExecutor(Executor):
         # P1 (Epic #1453): hard ceiling on consecutive Δ0 compiles; see
         # DELTA0_STAGNATION_HARDCAP. Read live from state on every iteration.
         self._delta0_stagnation_hardcap = DELTA0_STAGNATION_HARDCAP
+
+    async def _on_provider_failure(self, msg: "ProofMessage", exc: BaseException,
+                                    role: str) -> bool:
+        """Record a provider/transport failure: backoff + circuit-break + refund.
+
+        Called from handle()'s except block when ``agent.run()`` failed with a
+        provider/transport error (transient retries exhausted, or a
+        non-transient outage like the SK ``service failed`` wrapper). Guards
+        (#5869):
+
+        * Increments ``state.consecutive_provider_failures`` (shared across
+          agents, reset on a successful call).
+        * Refunds ``msg.iteration``: handle() incremented it BEFORE the attempt,
+          but a transport error means no real tactic was tried, so the budget
+          must stay intact (acceptance: 'budget intact' on a mocked outage).
+        * On reaching PROVIDER_OUTAGE_THRESHOLD, latches
+          ``state.provider_outage`` and returns True so the caller yields the
+          message as terminal output (which ends the workflow run). No backoff
+          on the trip itself — we are terminating, not retrying.
+        * Below the threshold, sleeps an exponential backoff indexed by the
+          failure count to kill the ~50ms spin, then returns False so handle()
+          re-routes (the coordinator may recover or re-dispatch).
+
+        Returns True iff the circuit-breaker tripped (caller MUST yield+return).
+        """
+        if self._state is not None:
+            n = getattr(self._state, "consecutive_provider_failures", 0) + 1
+            self._state.consecutive_provider_failures = n
+        else:
+            n = 1
+        # Refund the iteration consumed at the top of handle(): a transport
+        # error means no real tactic attempt, so the budget stays intact.
+        msg.iteration = max(0, msg.iteration - 1)
+        if n >= PROVIDER_OUTAGE_THRESHOLD:
+            if self._state is not None:
+                self._state.provider_outage = True
+                self._state.last_error = str(exc)[:300]
+            if self._trace:
+                self._trace.log(
+                    agent=self._agent.name,
+                    role="provider_outage_circuit_break",
+                    content=(f"consecutive provider failures={n} >= "
+                             f"{PROVIDER_OUTAGE_THRESHOLD}: circuit-break OPEN, "
+                             f"yielding provider_outage. exc={repr(exc)[:160]}"),
+                )
+            return True
+        backoff = PROVIDER_OUTAGE_BACKOFF_S[
+            min(n - 1, len(PROVIDER_OUTAGE_BACKOFF_S) - 1)
+        ]
+        if self._trace:
+            self._trace.log(
+                agent=self._agent.name, role=role,
+                content=(f"provider failure #{n}/{PROVIDER_OUTAGE_THRESHOLD}: "
+                         f"{repr(exc)[:160]}; backoff {backoff}s"),
+            )
+        await asyncio.sleep(backoff)
+        return False
 
     @handler
     async def handle(self, msg: ProofMessage, ctx: WorkflowContext[ProofMessage]) -> None:
@@ -304,9 +412,11 @@ class AgentExecutor(Executor):
             len(self._state.tactic_history)
             if self._state and hasattr(self._state, "tactic_history") else 0
         )
+        _provider_ok = False
         try:
             response = await self._agent.run(content)
             response_text = self._extract_response_text(response)
+            _provider_ok = True  # provider answered -> clear outage counter (#5869)
         except Exception as e:
             # P3 (V5): context-window overflow handler. Fast models (Critic,
             # Search) have smaller context windows than reasoning models.
@@ -341,6 +451,7 @@ class AgentExecutor(Executor):
                 try:
                     response = await self._agent.run(_trunc_header + _truncated)
                     response_text = self._extract_response_text(response)
+                    _provider_ok = True
                 except Exception as e2:
                     # Second failure — produce minimal recovery signal
                     response_text = (
@@ -380,6 +491,7 @@ class AgentExecutor(Executor):
                     try:
                         response = await self._agent.run(content)
                         response_text = self._extract_response_text(response)
+                        _provider_ok = True
                         break
                     except Exception as e_retry:
                         _last_exc = e_retry
@@ -389,21 +501,50 @@ class AgentExecutor(Executor):
                             break
                 if response_text is None:
                     # Retries exhausted (or a non-transient error surfaced) —
-                    # fall through to the existing failure handling, do NOT
-                    # swallow the error silently.
+                    # count toward the circuit-breaker; do NOT swallow silently.
                     response_text = f"Agent error: {_last_exc}"
                     if self._trace:
                         self._trace.log(
                             agent=self._agent.name, role="transient_retry_failed",
                             content=str(_last_exc)[:200],
                         )
+                    if _is_provider_outage_error(_last_exc) and await self._on_provider_failure(
+                            msg, _last_exc, "transient_retry_failed"):
+                        await ctx.yield_output(msg)
+                        return
+            elif _is_provider_outage_error(e):
+                # Non-transient transport/provider failure (e.g. the Semantic
+                # Kernel 'OpenAIChatCompletionClient service failed' wrapper
+                # that carries no 5xx/reset/timeout marker). Not retried here —
+                # the strict _is_transient_error path owns bounded retry — but
+                # it still counts toward the circuit-breaker and earns an
+                # exponential backoff to kill the ~50ms spin (#5869).
+                response_text = f"Agent error: {e}"
+                if self._trace:
+                    self._trace.log(
+                        agent=self._agent.name, role="provider_outage",
+                        content=str(e)[:200],
+                    )
+                if await self._on_provider_failure(msg, e, "provider_outage"):
+                    await ctx.yield_output(msg)
+                    return
             else:
+                # Genuine agent/logic error (not a provider outage): preserve
+                # the original behavior — no iteration refund, no circuit-break
+                # count, just route the error text to the next agent.
                 response_text = f"Agent error: {e}"
                 if self._trace:
                     self._trace.log(
                         agent=self._agent.name, role="error",
                         content=str(e)[:200],
                     )
+
+        # A successful agent.run() means the provider is alive — clear the
+        # consecutive-outage counter so transient blips don't accumulate to a
+        # false trip (#5869). Reached only on the non-terminal paths above.
+        if _provider_ok and self._state and getattr(
+                self._state, "consecutive_provider_failures", 0):
+            self._state.consecutive_provider_failures = 0
 
         # Detect "burned response" — thinking models sometimes spend their entire
         # output budget in `reasoning_content` and emit no visible parts.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1135,6 +1135,150 @@ def test_delta0_hardcap_ignored_when_proof_found():
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# #5869 — provider-outage circuit-breaker. A dead LLM provider makes every
+# agent.run() raise a transport/service error. Before the guard the harness
+# spun at ~50ms/iteration and burned the WHOLE budget in <2s with zero proof
+# progress. The guard adds: exponential backoff, a consecutive-failure
+# circuit-breaker (>=3 -> terminal provider_outage yield), and an iteration
+# refund so transport errors don't consume budget.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _outage_agent(name="TacticAgent", exc_msg="OpenAIChatCompletionClient service failed"):
+    """An agent whose .run always raises a transport/service error (the
+    forensic signature of the #5869 burn loop)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    agent = MagicMock()
+    agent.name = name
+    agent.run = AsyncMock(side_effect=RuntimeError(exc_msg))
+    return agent
+
+
+def test_provider_outage_detector_classifies_signatures():
+    """_is_provider_outage_error catches the SK wrapper + transient errors,
+    but NOT a 404 config bug (which _is_transient_error already excludes)."""
+    from prover.workflow import _is_provider_outage_error, _is_transient_error
+
+    assert _is_provider_outage_error(
+        RuntimeError("OpenAIChatCompletionClient service failed"))
+    assert _is_provider_outage_error(ConnectionError("connection closed by peer"))
+    # transient errors are a subset — still classified as outage-relevant
+    assert _is_provider_outage_error(RuntimeError("upstream 503 service unavailable"))
+    # a 404 config bug is NOT a dead provider, even wrapped in transport prose
+    assert not _is_provider_outage_error(RuntimeError("model not found (404)"))
+    assert not _is_transient_error(RuntimeError("model not found (404)"))
+
+
+def test_provider_outage_circuit_break_trips_on_third_failure(monkeypatch):
+    """Pre-seeded at 2 failures, the 3rd agent.run failure trips the breaker:
+    handle yields terminal output, latches state.provider_outage, and refunds
+    the iteration (budget intact)."""
+    from prover.workflow import (
+        AgentExecutor, ProofMessage, PROVIDER_OUTAGE_THRESHOLD,
+    )
+
+    state = ProofState(theorem_statement="t")
+    state.consecutive_provider_failures = PROVIDER_OUTAGE_THRESHOLD - 1
+    agent = _outage_agent()
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x", max_iterations=10)
+    ctx = _run_handle(ex, msg)
+
+    ctx.yield_output.assert_awaited_once()      # terminal yield (ends the run)
+    assert state.provider_outage is True        # latched
+    # Budget intact: iteration was incremented then refunded (no real attempt)
+    assert msg.iteration == 0
+    agent.run.assert_awaited_once()             # the failing call happened
+
+
+def test_provider_outage_budget_intact_across_five_failures(monkeypatch):
+    """Outage ×5: across 5 handler passes the iteration budget stays intact
+    (every transport error is refunded) and provider_outage is latched from
+    the 3rd pass on. Backoff zeroed so the test is fast."""
+    import prover.workflow as wf
+    from prover.workflow import AgentExecutor, ProofMessage
+    monkeypatch.setattr(wf, "PROVIDER_OUTAGE_BACKOFF_S", (0.0,) * 7)
+
+    state = ProofState(theorem_statement="t")
+    agent = _outage_agent()
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x", max_iterations=10)
+
+    for i in range(5):
+        before = msg.iteration
+        _run_handle(ex, msg)
+        # Budget never consumed by a transport error (refund every pass)
+        assert msg.iteration == before, f"pass {i+1}: iteration drifted {before}->{msg.iteration}"
+    assert state.provider_outage is True
+    assert state.consecutive_provider_failures == 5
+
+
+def test_provider_outage_below_threshold_no_trip(monkeypatch):
+    """First failure (n=1 < 3): no circuit-break, no terminal yield — the error
+    is surfaced as 'Agent error' text, the counter increments, budget refunded."""
+    import prover.workflow as wf
+    monkeypatch.setattr(wf, "PROVIDER_OUTAGE_BACKOFF_S", (0.0,) * 7)
+
+    from prover.workflow import AgentExecutor, ProofMessage
+
+    state = ProofState(theorem_statement="t")
+    agent = _outage_agent()
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x", max_iterations=10)
+    ctx = _run_handle(ex, msg)
+
+    ctx.yield_output.assert_not_awaited()
+    assert state.provider_outage is False
+    assert state.consecutive_provider_failures == 1
+    assert msg.iteration == 0  # refunded, budget intact
+
+
+def test_provider_outage_counter_resets_on_success():
+    """A successful agent.run() clears the consecutive-outage counter so a
+    transient blip does not accumulate to a false trip."""
+    from unittest.mock import AsyncMock, MagicMock
+    from prover.workflow import AgentExecutor, ProofMessage
+
+    state = ProofState(theorem_statement="t")
+    state.consecutive_provider_failures = 2
+    agent = MagicMock()
+    agent.name = "TacticAgent"
+    agent.run = AsyncMock(return_value=MagicMock(messages=[MagicMock(text="ok")]))
+    ex = AgentExecutor(agent, state=state)
+    _run_handle(ex, ProofMessage(content="x"))
+
+    assert state.consecutive_provider_failures == 0
+    assert state.provider_outage is False
+
+
+def test_genuine_error_does_not_trip_circuit_break(monkeypatch):
+    """A non-provider logic error (not transport/outage) preserves the original
+    behavior: no refund, no circuit-break count, no terminal yield."""
+    from unittest.mock import AsyncMock, MagicMock
+    import prover.workflow as wf
+    monkeypatch.setattr(wf, "PROVIDER_OUTAGE_BACKOFF_S", (0.0,) * 7)
+
+    from prover.workflow import AgentExecutor, ProofMessage
+
+    state = ProofState(theorem_statement="t")
+    agent = MagicMock()
+    agent.name = "TacticAgent"
+    # A plain KeyError is a logic bug, not a provider failure
+    agent.run = AsyncMock(side_effect=KeyError("malformed agent payload"))
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x", max_iterations=10)
+    msg.iteration = 3  # pretend we are mid-budget
+    ctx = _run_handle(ex, msg)
+
+    ctx.yield_output.assert_not_awaited()
+    assert state.provider_outage is False
+    assert state.consecutive_provider_failures == 0  # not counted
+    # NOT refunded: iteration was consumed by a real (non-transport) failure path
+    assert msg.iteration == 4
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # P5/P4 (Epic #1453, 2026-05-29 forensic) — pre-screen documented-intractable
 # targets BEFORE spawning agents.
 #


### PR DESCRIPTION
## Problem

A dead LLM provider (rate-limited gateway, network partition, expired key) made every `agent.run()` raise a transport/service error — notably the Semantic Kernel `OpenAIChatCompletionClient service failed` wrapper, which carries no 5xx/reset/timeout marker so `_is_transient_error` did not classify it. The error fell to the non-transient `else` branch of `AgentExecutor.handle`, which set `response_text = "Agent error: …"` with **no sleep**. Worse, `msg.iteration` was already consumed at the *top* of `handle()` (before the attempt).

Net effect: a single outage **spun at ~50ms/iteration** and **burned the entire iteration budget in <2s with zero proof progress**. Forensic trace: 20 loops of `"OpenAIChatCompletionClient service failed"` in 1.5s, budget 20→0, 0 sorry touched. The run then reported `FAILED / no_progress` — indistinguishable from a genuine proof failure, so a coordinator could re-harvest a dead run.

## Fix — three guards in `handle()`'s except block

| # | Guard | Where |
|---|-------|-------|
| 1 | **Exponential backoff** (1s/2s/4s…cap 60s, `PROVIDER_OUTAGE_BACKOFF_S`) on every provider failure — kills the ~50ms spin | `_on_provider_failure` |
| 2 | **Circuit-breaker**: shared counter `state.consecutive_provider_failures` (reset on a successful call); on reaching `PROVIDER_OUTAGE_THRESHOLD=3`, latch `state.provider_outage` and yield the message as **terminal output** (ends the workflow run) | `_on_provider_failure` + new `elif _is_provider_outage_error(e)` branch |
| 3 | **Iteration refund** on pure transport errors — budget stays intact | `_on_provider_failure` |

A new broad detector `_is_provider_outage_error` (superset of `_is_transient_error`) catches the SK wrapper + transport EOFs, while still **excluding** 404/4xx config bugs. Genuine agent/logic errors keep the original behavior (no refund, no count).

## Verdict surfacing (`run_prover_bg.py`)

New canonical verdict `provider_outage`, ranked **above** `sorry_decreased`/`structural_only`, **below** `crashed`:
- `RESULT:` line prints `OUTAGE` (distinct from `SUCCESS`/`FAILED`).
- `*_result.json` carries `result_kind: "provider_outage"` **and** a boolean `provider_outage` mirror, so forensic aggregators can filter dead-provider runs without string-matching.

## Acceptance (issue #5869)

| Criterion | Status |
|-----------|--------|
| backoff exponentiel (1s/2s/4s cap 60s) | `PROVIDER_OUTAGE_BACKOFF_S` |
| circuit-breaker ≥3 consecutive failures → fallback/outage | `PROVIDER_OUTAGE_THRESHOLD` + `_on_provider_failure` |
| iteration-accounting only on real tactic | refund on transport error (`test_provider_outage_budget_intact_across_five_failures`) |
| mock outage ×5 → budget intact + verdict `provider_outage` distinct | `test_provider_outage_budget_intact_across_five_failures` + verdict |
| aucun changement de comportement sur les runs sains | 126/127 (see Validation) |
| verdict `provider_outage` visible dans `*_result.json` | summary + result dict |

## Why a prover-harness refactor (not split)

§B asks prover-Python refactors to justify their necessity. This is **one cohesive correctness fix** — the burn loop is a single root cause (no backoff + no circuit-break + iteration consumed pre-attempt) with one verdict surfacing. Splitting would leave the budget-burn live in one half. No `.lean` files are touched; no proof is altered (`grep -c sorry` unchanged on every lake).

## Validation

- **AST syntax**: all 5 edited files parse.
- **pytest** `tests/test_prover_guards.py` (agent-framework installed in a scratch venv: `agent-framework-core`/`-openai` 1.3.x, Python 3.13):
  - **126/127 passed**.
  - The **1 failure is pre-existing and environmental**: `test_coordinator_agent_has_set_attack_plan_tool` constructs a real `AsyncOpenAI` client via `create_client("zai")`, which needs the live provider `.env` (present on ai-01/WSL, absent in the scratch venv). Unrelated to this change — none of the touched files are on that code path.
  - **6 new tests green**: detector classification, trip-on-3rd, budget-intact ×5, below-threshold no-trip, counter-reset-on-success, genuine-error-doesn't-trip.
- `proof_knowledge.json` was mutated by the suite run (KB records an attempt) — **reverted**, not committed (test artifact).

See #5869

🤖 Generated with [Claude Code](https://claude.com/claude-code)
