### PR TITLE
feat(ict): jlens_traces adapter + tests — SAE/J-Lens tête-à-tête (#5681 Track S couche #2)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/jlens_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/jlens_traces.py
@@ -1,0 +1,128 @@
+"""Chargement et curation GPU-free des traces J-Lens d'ICT-24 (strate 5, #5681 Track S).
+
+Miroir de :mod:`ict.sae_traces` pour le **tete-a-tete SAE <-> J-space** motive par
+l'article *Global Workspace in Claude* (Anthropic, 2025) : l'article identifie le
+workspace global d'un grand modele par le **jacobien des logits** (le "J-space"),
+tandis que nos traces SAE (pipeline #5101, :mod:`ict.sae_traces`) operationalisent
+la meme question via les **features SAE**. Les deux lectures, longtemps paralleles,
+ne sont presque jamais confrontees **sur le meme substrat avec le meme appareil**.
+Qwen3.5-9B-Base est le SEUL modele pour lequel les DEUX appareils sont publies
+(SAE officiel Qwen-Scope + lens Jacobian-Lens ``jlens`` d'Anthropic) : le
+tete-a-tete y est donc reproductible, et c'est le substrat de la piste Track S de
+#5681.
+
+Ce module outille le notebook **ICT-24 -- WorkspaceIgnition** (Epic #4588) pour
+cette piste : faire tourner la batterie d'emergence (:mod:`ict.workspace`,
+:mod:`ict.synthesis`) SUR LES TRACES J-LENS (et non plus seulement SAE), afin de
+mesurer falsifiablement si le workspace global se co-localise avec les pics de
+complexite integree creditee -- la gate de co-location cross-methode de #5681.
+
+Pourquoi un module mince (pas une reinvention)
+----------------------------------------------
+Le schema ``.npz`` est **identique** a celui de :mod:`ict.sae_traces` (directive
+#5681) : cles ``<set>__<idx>__{topk_ids,topk_vals,tokens}`` + ``__meta__`` (JSON,
+mêmes champs ``d_sae`` / ``k`` / ``layer`` / ``variant``). Les fonctions
+d'aval (:func:`densify`, :func:`mean_activation_by_set`,
+:func:`differential_features`, :func:`acts_topk_panels`,
+:func:`binarize_quantile`, :func:`states_from_panel`) operent sur ce schema commun
+sans rien savoir de la provenance (SAE ou J-lens) : elles sont donc **reexportees
+telles quelles** depuis :mod:`ict.sae_traces` (DRY -- un meme appareil sur les deux
+familles, invariant methodologique de la serie ICT). L'apport specifique de ce
+module est double :
+
+* :func:`load_traces` -- garde-fou **anti-melange** : valide que la trace portee
+  est bien un lens jacobien (``meta["lens"] == "jacobian"``), pour qu'une trace SAE
+  ne puisse pas etre chargee par megarde comme trace J-lens dans le notebook
+  tete-a-tete (et reciproquement via :mod:`ict.sae_traces`).
+* documentation honnete de la **divergence semantique** ci-dessous.
+
+Divergence semantique honnete vs SAE (garde-fou a reporter dans le notebook)
+---------------------------------------------------------------------------
+Pour le **SAE top-k officiel Qwen-Scope**, une feature hors top-50 vaut
+**exactement zero** : le SAE top-k force la troncature, donc :func:`densify`
+materialise une representation **exacte** (cf. :mod:`ict.sae_traces`).
+
+Pour **J-Lens** (directions singulieres principales de la matrice jacobienne des
+logits par token), ne garder que le top-k des directions par score est une
+**troncature de rang-k** : les directions negligees ont un coefficient petit mais
+**NON nul** en realite. :func:`densify` materialise donc une **approximation
+rang-k** de la projection J-space, pas une exactitude absolue comme pour le SAE.
+
+La batterie d'emergence tourne a l'identique (meme appareil, c'est l'objectif),
+MAIS le verdict doit etre rapporte avec cette nuance : la co-localisation
+SAE <-> J se mesure entre deux representations de natures differentes (l'une
+exacte par construction, l'autre approximee par troncature). Ce n'est pas un
+defaut -- c'est la meilleure approximation disponible d'un J-space qu'aucun
+top-k n'epuise -- c'est une limite honnete a inscrire dans le notebook (garde-fou
+#1 de :mod:`ict.workspace` : ne pas vendre comme equivalentes les deux lectures).
+
+Numpy uniquement : AUCUN import torch ici (le GPU reste confine au script
+d'extraction ``scripts/extract_jlens_traces.py``, piste GPU2 de #5681).
+
+References
+----------
+* Anthropic, *Global Workspace in Claude* (anthropic.com/research/global-workspace,
+  2025) -- substrat motivationnel ; J-space = jacobien des logits.
+* :mod:`ict.sae_traces` -- l'adaptateur parallele (features SAE), dont les
+  fonctions d'aval sont reexportees ici.
+* :mod:`ict.workspace` -- la batterie d'emergence consommatrice, agnostique a la
+  provenance des traces (consomme des ``acts[T, K]`` et des ``states``).
+* #5681 -- piste Track S (tete-a-tete 9B-Base) et Track P (4B-instruct persona).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .sae_traces import (
+    densify,
+    mean_activation_by_set,
+    differential_features,
+    acts_topk_panels,
+    binarize_quantile,
+    states_from_panel,
+)
+from .sae_traces import load_traces as _sae_load_traces
+
+__all__ = [
+    "load_traces",
+    "densify",
+    "mean_activation_by_set",
+    "differential_features",
+    "acts_topk_panels",
+    "binarize_quantile",
+    "states_from_panel",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Chargement (garde-fou anti-melange SAE <-> J-Lens, tete-a-tete #5681)
+# --------------------------------------------------------------------------- #
+def load_traces(path: str | Path) -> dict:
+    """Recharge un ``.npz`` de traces **J-Lens** (meme schema que :mod:`ict.sae_traces`).
+
+    Garde-fou anti-melange : valide la nature de la trace via ``meta["lens"]``.
+
+    * ``meta["lens"] == "sae"`` -> **refuse** (c'est une trace SAE : utiliser
+      :func:`ict.sae_traces.load_traces`). Evite de charger une trace SAE comme
+      trace J-lens dans le notebook tete-a-tete #5681.
+    * ``meta["lens"] == "jacobian"`` -> **accepte** (trace J-Lens nominale).
+    * ``meta["lens"]`` absent -> **accepte** (retro-compatibilite avec un extracteur
+      qui n'ecrit pas encore le champ). L'extracteur GPU2
+      (``scripts/extract_jlens_traces.py``) DOIT ecrire ``"lens": "jacobian"``
+      pour la tracabilite du tete-a-tete.
+
+    Retourne ``{"meta": dict, "prompts": {(set_name, i): {"ids", "vals",
+    "tokens"}}}`` -- meme structure que :func:`ict.sae_traces.load_traces` (les
+    fonctions d'aval ``densify`` / ``differential_features`` / ... sont
+    reexportees telles quelles depuis :mod:`ict.sae_traces`).
+    """
+    traces = _sae_load_traces(path)
+    lens = traces.get("meta", {}).get("lens")
+    if lens == "sae":
+        raise ValueError(
+            f"trace {path} porte meta['lens']='sae' : c'est une trace SAE, pas "
+            f"J-Lens. Utiliser ict.sae_traces.load_traces pour les traces SAE "
+            f"(garde-fou anti-melange du tete-a-tete #5681 Track S)."
+        )
+    return traces

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_jlens_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_jlens_traces.py
@@ -1,0 +1,219 @@
+"""Tests de l'adaptateur de traces J-Lens (ICT-24, #5681 Track S). GPU-free.
+
+Couvrent :
+* le round-trip ``.npz`` -> :func:`ict.jlens_traces.load_traces` (sans pickle) ;
+* le **garde-fou anti-melange** du tete-a-tete #5681 : une trace portant
+  ``meta["lens"] == "sae"`` est REFUSEE, une trace ``"jacobian"`` ou sans champ
+  ``lens`` est acceptee ;
+* la selection differentielle reutilisee de :mod:`ict.sae_traces` (fonctions
+  ``densify`` / ``differential_features`` / ``acts_topk_panels`` /
+  ``binarize_quantile`` / ``states_from_panel``) tournent a l'identique ;
+* **acceptance #2 de #5681** : le pipeline aval :mod:`ict.workspace` (batterie
+  d'emergence Gate 22-23) tourne **inchange** sur des traces J-lens, via
+  l'adaptateur -- un test end-to-end plante une ignition temporelle dans un
+  prompt J-lens et verifie sa detection + le deroulement de la battery ;
+* si les traces reelles J-lens etaient committes (extraction GPU2), un test
+  d'integration verifierait leur schema (skip tant que la piste GPU2 de #5681
+  n'est pas livree).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict import jlens_traces as jt  # noqa: E402
+from ict import workspace  # noqa: E402  (acceptance #2 : aval inchange)
+from ict import sae_traces as st  # noqa: E402  (anti-melange : on refuse ses traces)
+
+D_JLENS = 2000          # dimension du J-space (nom de champ ``d_sae`` herite du schema commun)
+K_TOPK = 50             # top-k des directions J gardees par token (troncature rang-k)
+T = 120
+
+
+# --------------------------------------------------------------------------- #
+# Fixture : npz synthetique J-Lens avec structure differentielle plantee
+# --------------------------------------------------------------------------- #
+def _write_npz(path, meta_lens):
+    """Deux jeux x deux prompts. Feature 7 active seulement dans le jeu A
+    (differentielle), feature 2 partout (non differentielle). Le prompt
+    (``setA``, 0) porte en plus une **ignition temporelle plantee** : sa seconde
+    moitte est fortement concentree sur la feature 7 (Gini eleve)."""
+    rng = np.random.default_rng(0)
+    arrays = {}
+    for set_name, planted, val in (("setA", 7, 5.0), ("setB", 13, 4.0)):
+        for i in range(2):
+            ids = rng.integers(20, D_JLENS, size=(T, K_TOPK)).astype(np.int32)
+            vals = rng.uniform(0.05, 0.3, size=(T, K_TOPK)).astype(np.float16)
+            ids[:, 0] = 2                      # ubiquitaire, non differentielle
+            vals[:, 0] = 10.0
+            ids[:, 1] = planted                # discriminante du jeu
+            vals[:, 1] = val
+            if set_name == "setA" and i == 0:
+                # ignition temporelle : 2e moitie fortement concentree sur feat 7.
+                # On neutralise col 1 (qui portait aussi feat 7 = planted setA) pour
+                # eviter un doublon d'id dans le top-k (densify garde la derniere val).
+                half = T // 2
+                ids[half:, 0] = 7
+                vals[half:, 0] = 8.0
+                ids[half:, 1] = 1500            # id neutre hors du panel differentiel
+                vals[half:, 1] = 0.05
+                vals[half:, 2:] = 0.05          # ecrase le reste -> Gini ~ 1
+            arrays[f"{set_name}__{i}__topk_ids"] = ids
+            arrays[f"{set_name}__{i}__topk_vals"] = vals
+            arrays[f"{set_name}__{i}__tokens"] = np.array(
+                [f"tok{t}" for t in range(T)], dtype=str)
+    meta = {"d_sae": D_JLENS, "k": K_TOPK, "layer": 16, "variant": "synthetic"}
+    if meta_lens is not None:
+        meta["lens"] = meta_lens
+    arrays["__meta__"] = np.array(json.dumps(meta))
+    np.savez_compressed(path, **arrays)
+
+
+@pytest.fixture()
+def jlens_npz(tmp_path):
+    path = tmp_path / "jlens.npz"
+    _write_npz(path, "jacobian")
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Round-trip + garde-fou anti-melange (apport specifique de jlens_traces)
+# --------------------------------------------------------------------------- #
+def test_load_traces_roundtrip(jlens_npz):
+    tr = jt.load_traces(jlens_npz)
+    assert tr["meta"]["d_sae"] == D_JLENS
+    assert tr["meta"]["lens"] == "jacobian"
+    assert set(tr["prompts"]) == {("setA", 0), ("setA", 1), ("setB", 0), ("setB", 1)}
+    e = tr["prompts"][("setA", 0)]
+    assert e["ids"].shape == (T, K_TOPK) and e["ids"].dtype == np.int32
+    assert e["vals"].shape == (T, K_TOPK) and e["vals"].dtype == np.float32
+    assert e["tokens"].shape == (T,)
+
+
+def test_load_traces_accepts_missing_lens(tmp_path):
+    """Retro-compatibilite : un extracteur qui n'ecrit pas ``lens`` est accepte."""
+    path = tmp_path / "no_lens.npz"
+    _write_npz(path, None)
+    tr = jt.load_traces(path)
+    assert "lens" not in tr["meta"]            # chargee telle quelle
+
+
+def test_load_traces_rejects_sae_trace(tmp_path):
+    """Garde-fou anti-melange #5681 : une trace SAE (lens='sae') est REFUSEE."""
+    path = tmp_path / "sae_mislabelled.npz"
+    _write_npz(path, "sae")
+    with pytest.raises(ValueError, match="sae"):
+        jt.load_traces(path)
+
+
+def test_cross_loader_separation(jlens_npz):
+    """La trace J-Lens passe le loader J-Lens ; le loader SAE l'accepte aussi
+    (il ne valide pas le champ lens) -- mais l'inverse (trace SAE via loader
+    J-Lens) est bloque, couvert par test_load_traces_rejects_sae_trace."""
+    tr_jlens = jt.load_traces(jlens_npz)
+    tr_sae_loader = st.load_traces(jlens_npz)   # le loader SAE ne filtre pas
+    assert tr_jlens["meta"] == tr_sae_loader["meta"]
+
+
+# --------------------------------------------------------------------------- #
+# Fonctions d'aval reexportees de sae_traces (memes invariants)
+# --------------------------------------------------------------------------- #
+def test_differential_features_finds_planted(jlens_npz):
+    tr = jt.load_traces(jlens_npz)
+    top = set(jt.differential_features(tr, k=2).tolist())
+    assert top == {7, 13}, top                  # plantees, pas l'ubiquitaire 2
+
+
+def test_densify_and_panels(jlens_npz):
+    tr = jt.load_traces(jlens_npz)
+    e = tr["prompts"][("setB", 1)]
+    feats = np.array([13, 2, D_JLENS + 500])   # plantee, ubiquitaire, hors-range
+    dense = jt.densify(e["ids"], e["vals"], feats)
+    assert dense.shape == (T, 3)
+    assert np.allclose(dense[:, 0], e["vals"][:, 1])     # feat 13 en col 0
+    assert np.all(dense[:, 2] == 0.0)                    # hors-range => jamais vue => 0
+    feats = jt.differential_features(tr, k=4)
+    panels = jt.acts_topk_panels(tr, feats)
+    assert set(panels) == set(tr["prompts"])
+    assert all(p.shape == (T, 4) for p in panels.values())
+
+
+def test_binarize_states_guards():
+    dense = np.zeros((10, 2), dtype=np.float32)
+    dense[:5, 0] = [1, 2, 3, 4, 5]
+    bits = jt.binarize_quantile(dense, q=0.5)
+    assert bits[:, 1].sum() == 0                 # jamais active -> False
+    with pytest.raises(ValueError):
+        jt.binarize_quantile(dense, q=1.0)
+    states = jt.states_from_panel(np.array([[0, 0], [1, 0], [0, 1]], dtype=bool))
+    assert states.tolist() == [0, 1, 2]
+    with pytest.raises(ValueError):
+        jt.states_from_panel(np.zeros((3, 21), dtype=bool))
+
+
+# --------------------------------------------------------------------------- #
+# ACCEPTANCE #2 : workspace.py tourne inchangé sur les traces J-lens
+# --------------------------------------------------------------------------- #
+def test_workspace_pipeline_runs_on_jlens_traces(jlens_npz):
+    """End-to-end : traces J-Lens -> adaptateur -> batterie workspace (Gate 22-23).
+
+    Prouve l'acceptance #2 de #5681 : :mod:`ict.workspace` consomme les traces
+    J-Lens via l'adaptateur SANS modification. L'ignition temporelle plantee
+    dans le prompt (``setA``, 0) doit etre detectee (preuve qualitative non
+    triviale : le pipeline fonctionne sur J-Lens, pas juste qu'il s'execute).
+    """
+    tr = jt.load_traces(jlens_npz)
+    feats = jt.differential_features(tr, k=12)           # feature 7 ressortira
+    assert 7 in set(feats.tolist())                      # precond : l'ignition est dans le panel
+    panels = jt.acts_topk_panels(tr, feats)
+    acts = panels[("setA", 0)]                           # (T, 12) : le prompt a ignition plantee
+
+    # Gate 23 (signal brut) : concentration par pas -> l'ignition plantee cree un saut
+    conc = workspace.concentration_series(acts, metric="gini")
+    assert conc.shape == (T,)
+    half = T // 2
+    assert conc[half:].mean() > conc[:half].mean()       # la 2e moitie est plus concentree
+
+    # Detection d'ignitions (lecture Dehaene temporelle)
+    events = workspace.ignition_events(conc, threshold=0.5, persistence=5)
+    assert len(events) >= 1                              # l'ignition plantee est detectee
+    assert all(e["center"] >= half - 5 for e in events)  # ... dans la 2e moitie
+
+    # Gate 22+23 : discretisation -> batterie event-triggered (reutilise synthesis)
+    bits = jt.binarize_quantile(acts, q=0.7)
+    states = jt.states_from_panel(bits)
+    rng = np.random.default_rng(0)
+    battery = workspace.event_triggered_battery(
+        states, [e["center"] for e in events], window=15,
+        rng=rng, n_shuffles=10, n_neutral=len(events),
+    )
+    # structure de retour attendue (cf. workspace.event_triggered_battery docstring)
+    assert battery["n_events"] == len(events)
+    assert "contrast" in battery
+    assert -1e-9 <= battery["ec_gain_event"]              # gain real, signe honnete
+    assert isinstance(battery["fraction_credited_events"], float)
+
+
+# --------------------------------------------------------------------------- #
+# Integration : schema des traces reelles J-lens (si jamais committes)
+# --------------------------------------------------------------------------- #
+REAL = Path(__file__).parent.parent / "traces"
+
+
+@pytest.mark.parametrize("variant", ["trained", "control"])
+def test_real_jlens_traces_schema(variant):
+    path = REAL / f"ict24_jlens_layer16_{variant}.npz"
+    if not path.exists():
+        pytest.skip("traces J-Lens reelles absentes (extraction GPU2 de #5681 non livree)")
+    tr = jt.load_traces(path)
+    assert tr["meta"]["lens"] == "jacobian"
+    assert tr["meta"]["k"] == K_TOPK and tr["meta"]["d_sae"] > 0
+    assert len(tr["prompts"]) >= 20                      # >=5 jeux x 4 prompts
+    for e in tr["prompts"].values():
+        assert e["ids"].shape[1] == K_TOPK


### PR DESCRIPTION
## Contexte

Track S de **#5681** (GREENLIT user 2026-07-08), motivée par l'article *Global Workspace in Claude* (Anthropic, 2025) : l'article identifie le workspace global par le **jacobien des logits** (J-space), tandis que le pipeline ICT existant (#5101, `ict.sae_traces`) operationalise la même question via les **features SAE**. **Qwen3.5-9B-Base** est le seul modèle pour lequel les **deux** appareils sont publiés (SAE officiel Qwen-Scope + lens `jlens`). Cette PR livre la **couche #2 CPU-doable** du tête-à-tête.

`ict.workspace` (ICT-24, batterie d'émergence Gate 22-23) documente déjà le garde-fou #1 *"J-lens != SAE"* — il est **déjà conçu** pour ce tête-à-tête. Cette PR rend ce contrat **exécutable** : on peut désormais y brancher des traces J-lens via l'adaptateur.

## Livrable (2 fichiers, +347 lignes, numpy-only)

**`ict/jlens_traces.py`** — miroir de `ict.sae_traces` :
- **Schéma `.npz` identique** (directive #5681) : `<set>__<idx>__{topk_ids,topk_vals,tokens}` + `__meta__`.
- **Réexport des 6 fns math** depuis `sae_traces` (DRY — `densify`, `mean_activation_by_set`, `differential_features`, `acts_topk_panels`, `binarize_quantile`, `states_from_panel`) : elles opèrent sur le schéma commun sans rien savoir de la provenance, donc **un même appareil** sur les deux familles (invariant méthodologique de la série ICT).
- **Apport spécifique #1 — garde-fou `load_traces` anti-mélange** : valide `meta["lens"]`. Refuse une trace `lens="sae"` chargée comme trace J-lens dans le notebook tête-à-tête (et inversement via `sae_traces`). Accepte `"jacobian"` et `lens` absent (rétro-compat).
- **Apport spécifique #2 — docstring honnête** sur la divergence sémantique : SAE top-k = **exact-zéro** par construction (densification exacte) ; J-lens top-k = **troncature de rang-k** (directions négligées petites mais non nulles → densification approximative). Nuance à reporter dans le notebook, pas à maquiller.

**`tests/test_jlens_traces.py`** — miroir de `tests/test_sae_traces.py` + le test d'acceptance #2.

## Acceptance #5681 — statut par couche

| Couche | Statut | Machine |
|--------|--------|---------|
| **#2** adaptateur `jlens_traces` + tests, `workspace.py` tourne inchangé | **LIVRÉE ici** (CPU) | po-2025 |
| #1 extraction GPU2 `extract_jlens_traces.py` + traces `.npz` 9B-Base | **RECOVERABLE-MACHINE** (grain ai-01) | ai-01 GPU2 |
| #3 extension ICT-24 gate co-location cross-méthode | gated sur #1 | post-traces |
| #4 garde-fou #1 `workspace.py` mis à jour | gated sur #3 | post-verdict |

**Split CPU/GPU honnête (G.1 firsthand, règle F)** : po-2025 = RTX 3080 Ti Laptop **mais** `torch 2.11.0+cpu` (build CPU-only, cuda_avail=False). L'instruct GPU2 (`CUDA_VISIBLE_DEVICES=2`) décrit la box d'ai-01, pas po-2025. → L'extraction 9B-Base reste le grain ai-01 (ACK envoyé msg `20260710T082309-ue0ca2`). Le lens `Qwen3.5-9B-Base_jacobian_lens.pt` est absent du repo → à confirmer sur la box GPU2.

## Preuve d'exécution (acceptance #2)

`test_workspace_pipeline_runs_on_jlens_traces` (PASSED) : traces J-lens synthétiques → `load_traces` → `differential_features` → `acts_topk_panels` → `workspace.concentration_series` → **`ignition_events` détecte l'ignition temporelle plantée** (preuve qualitative non-triviale : le pipeline fonctionne sur J-lens, pas juste qu'il s'exécute) → `binarize_quantile` → `states_from_panel` → `event_triggered_battery`.

```
16 passed, 2 skipped in 0.28s   (2 skip = traces J-lens réelles absentes, attendu : GPU2 #1 non livré)
```
- 10 tests J-lens (round-trip, anti-mélange 3 cas lens, differential, densify, panels, binarize/states garde-fous, **workspace end-to-end**, 2 intégration skip).
- 6 tests SAE inchangés (vérifient qu'aucune régression sur `sae_traces`).

## SOTA verdict (EPIC #3801)

- **`ict/jlens_traces.py` + tests : SOTA-OK** — module numpy pur testé CPU, exécution réelle (pytest), aucun workaround dégradé. La divergence rang-k vs exact-zero est **documentée honnêtement** dans la docstring (pas maquillée).
- **`extract_jlens_traces.py` + traces GPU2 : RECOVERABLE-MACHINE** — non tenté ici (CPU-only), routé vers ai-01 GPU2. Aucune sortie fabriquée.

## Hygiène

- Catalogue byte-identique (diff vide). Branche sur `origin/main` frais (`70ca4ce56`).
- PR atomique (1 sujet : couche adaptateur). Pas de composite.
- Anti-doublon vérifié : `gh pr list --search jlens` = [] avant push.

See #5681