### PR TITLE
feat(conway): gridFrameN n-aware framing + anti-vacuity witness (P5 redesign N1, #3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -187,6 +187,43 @@ def BoxAssezGrand (g : Grid) (n : Nat) : Prop := box_assez_grand g n = true
 instance (g : Grid) (n : Nat) : Decidable (BoxAssezGrand g n) :=
   inferInstanceAs (Decidable (box_assez_grand g n = true))
 
+/-! ### n-aware margin predicate (`box_assez_grandN`) — P5 redesign gate N1
+
+The n-aware dual of `box_assez_grand` over `gridFrameN n g` (padding `max 2 n`,
+see `MacroCell.gridFrameN`). Unlike the fixed-`gridFrame` version — which is
+unsatisfiable for `n > 2` (`boxAssezGrand_nonempty_le_two`) — this predicate is
+satisfiable for `n` arbitrarily large, because the `max 2 n` padding guarantees
+each live cell `max 2 n ≥ n` cells of margin by construction. The witnesses
+below exhibit `n = 3 > 2` for the single-cell grid: `box_assez_grandN` holds
+where `box_assez_grand` provably fails — the concrete dual of the unsat cap
+that `gridFrameN` breaks (issue #3846). -/
+
+/-- The "box assez grand" predicate over the n-aware frame `gridFrameN n g`
+    (light-cone margin `≥ n` on all four sides), n-aware analog of
+    `box_assez_grand`. -/
+def box_assez_grandN (g : Grid) (n : Nat) : Bool :=
+  let ((r0, c0), lvl) := gridFrameN n g
+  let sz : Int := 2^lvl
+  g.all (fun (r, c) => cellMargin r0 c0 sz n r c)
+
+/-- Propositional version of `box_assez_grandN` for theorem statements. -/
+def BoxAssezGrandN (g : Grid) (n : Nat) : Prop := box_assez_grandN g n = true
+
+/-- Anti-vacuity witness (dual of the `boxAssezGrand_nonempty_le_two` unsat
+    cap): the n-aware predicate `box_assez_grandN` is *satisfiable* for
+    `n = 3 > 2` on the single-cell grid. With `gridFrameN 3 [(0,0)]` the
+    padding is `max 2 3 = 3`, giving margin `3 ≥ 3` on every side, so the
+    large-`n` light-cone hypothesis holds where the fixed-2 `gridFrame` could
+    not (issue #3846, gate N1). -/
+theorem box_assez_grandN_single_cell_3 : box_assez_grandN [(0, 0)] 3 = true := by
+  native_decide
+
+/-- Honest contrast: the *fixed-`gridFrame`* predicate provably *fails* for the
+    same grid at `n = 3` — confirming the duality is non-vacuous
+    (`box_assez_grandN` breaks exactly what `box_assez_grand` cannot satisfy). -/
+theorem box_assez_grand_single_cell_3_false : box_assez_grand [(0, 0)] 3 = false := by
+  native_decide
+
 /-! ### Monotonicity of `box_assez_grand` in the padding parameter
 
 A grid that admits `n` cells of margin also admits any smaller amount `m ≤ n`:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -619,6 +619,75 @@ theorem gridFrame_contains_g (g : Grid) (p : Int × Int) (hp : p ∈ g) :
     unfold MacroCell.inRegion
     refine ⟨?_, ?_, ?_, ?_⟩ <;> omega
 
+/-! ### n-aware framing (`gridFrameN`) — P5 redesign gate N1 (issue #3846)
+
+The fixed-2 padding of `gridFrame` caps the light-cone margin at 2 (see
+`boxAssezGrand_nonempty_le_two` in `HashlifeCorrectness`): with `r0 := rMin - 2`,
+the topmost live cell has margin exactly 2, so `BoxAssezGrand g n` forces
+`n ≤ 2` and is *unsatisfiable* for large `n`. This is the structural root of
+the P5 large-`n` obstruction.
+
+`gridFrameN n g` generalizes the padding to `max 2 n`, so the light-cone
+margin is at least `max 2 n ≥ n` *by construction*. The margin hypothesis
+then becomes satisfiable for every `n` (not just `n ≤ 2`) — see the witness
+`box_assez_grandN_single_cell_3` in `HashlifeCorrectness`, the honest dual of
+the `boxAssezGrand_nonempty_le_two` unsat cap. N1 keeps `evolveHashlifeFast`
+unchanged; N2 threads this frame through the loop without re-framing. -/
+
+/-- Like `gridFrame` but with padding `max 2 n` (instead of the fixed `2`) on
+    each side, so the light-cone margin is at least `max 2 n ≥ n`. Returns
+    `((0, 0), 0)` for the empty grid. (P5 redesign, issue #3846, gate N1.) -/
+def gridFrameN (n : Nat) (g : Grid) : (Int × Int) × Nat :=
+  match g with
+  | []      => ((0, 0), 0)
+  | _ :: _ =>
+    let rMin := gridRowMin g
+    let rMax := gridRowMax g
+    let cMin := gridColMin g
+    let cMax := gridColMax g
+    let pad  := max 2 n
+    let r0 := rMin - pad
+    let c0 := cMin - pad
+    let height := (rMax - rMin + 1 + 2 * pad).toNat
+    let width  := (cMax - cMin + 1 + 2 * pad).toNat
+    let side   := max height width
+    let lvl    := MacroCell.ceilLog2 side
+    ((r0, c0), lvl)
+
+/-- For every live cell `p ∈ g`, the frame chosen by `gridFrameN n g` contains
+    `p` (containment bridge, n-aware analog of `gridFrame_contains_g`). -/
+theorem gridFrameN_contains_g (n : Nat) (g : Grid) (p : Int × Int) (hp : p ∈ g) :
+    let ((r0, c0), lvl) := gridFrameN n g
+    MacroCell.inRegion p r0 c0 lvl := by
+  cases g with
+  | nil => simp at hp
+  | cons p₀ ps =>
+    have hrMin : gridRowMin (p₀ :: ps) ≤ p.1 := gridRowMin_le_of_mem _ _ hp
+    have hrMax : p.1 ≤ gridRowMax (p₀ :: ps) := le_gridRowMax_of_mem _ _ hp
+    have hcMin : gridColMin (p₀ :: ps) ≤ p.2 := gridColMin_le_of_mem _ _ hp
+    have hcMax : p.2 ≤ gridColMax (p₀ :: ps) := le_gridColMax_of_mem _ _ hp
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
+      gridColMin_le_gridColMax _ (List.cons_ne_nil _ _)
+    simp only [gridFrameN]
+    set rMin := gridRowMin (p₀ :: ps)
+    set rMax := gridRowMax (p₀ :: ps)
+    set cMin := gridColMin (p₀ :: ps)
+    set cMax := gridColMax (p₀ :: ps)
+    set pad := max 2 n
+    set height := (rMax - rMin + 1 + 2 * pad).toNat
+    set width := (cMax - cMin + 1 + 2 * pad).toNat
+    set side := max height width
+    set lvl := MacroCell.ceilLog2 side
+    have hspec : (2 ^ lvl : Nat) ≥ side := MacroCell.ceilLog2_spec side
+    have hh : height ≤ side := Nat.le_max_left _ _
+    have hw : width ≤ side := Nat.le_max_right _ _
+    have hnn_r : 0 ≤ rMax - rMin + 1 + 2 * pad := by omega
+    have hnn_c : 0 ≤ cMax - cMin + 1 + 2 * pad := by omega
+    unfold MacroCell.inRegion
+    refine ⟨?_, ?_, ?_, ?_⟩ <;> omega
+
 /-- Convert a `Grid` to a `MacroCell`, returning the chosen offset so that
     `MacroCell.toGrid offset (gridToMacroCell g) = g`. -/
 def gridToMacroCellWithOffset (g : Grid) : (Int × Int) × MacroCell :=


### PR DESCRIPTION
## Summary

P5 redesign **gate N1** (issue #3846, deep-queue dispatch from ai-01). The tactical approach on the Hashlife `sorry` set was exhausted (BG prover runs returned `structural_only 3→3`), so the path forward is the **redesign**: break the structural `n ≤ 2` cap that makes `BoxAssezGrand` unsatisfiable for large `n`.

### The lock
`box_assez_grand g n` requires each live cell to have margin `≥ n` to the MacroCell domain on all four sides (`cellMargin`). But `gridFrame` uses a **fixed 2-cell padding** (`r0 := rMin - 2`), so the topmost live cell has margin exactly **2** → `boxAssezGrand_nonempty_le_two` forces `n ≤ 2` → the margin hypothesis is **unsatisfiable** for large `n`. This is the structural root of the P5 large-`n` obstruction.

### N1 — frame once at entry, padding `max 2 n`
- **`gridFrameN n g`** (`MacroCell.lean`): same as `gridFrame` but padding `max 2 n` instead of fixed `2`. The light-cone margin becomes `max 2 n ≥ n` **by construction**, so the margin hypothesis is satisfiable for every `n` (not just `n ≤ 2`).
- **`gridFrameN_contains_g`**: containment bridge (omega), n-aware analog of `gridFrame_contains_g`.
- **`box_assez_grandN`** (`HashlifeCorrectness.lean`): n-aware dual of `box_assez_grand`, reading `gridFrameN n g`.
- **Two `native_decide` witnesses** proving the dual is **non-vacuous** (G.2-honest):
  - `box_assez_grandN [(0,0)] 3 = true` — the n-aware predicate holds at `n = 3 > 2`.
  - `box_assez_grand [(0,0)] 3 = false` — the fixed-frame predicate fails at the same grid/`n`.

Together: `gridFrameN` breaks exactly what `gridFrame` provably cannot satisfy. This is the constructive dual of the `boxAssezGrand_nonempty_le_two` unsat cap.

### Unchanged in N1
`evolveHashlifeFast` is **untouched** in N1. N1 is purely definitional + the witness (the design-gate's "exhiber un grid non vide + n concrets"). **N2** will thread this frame through the loop without re-framing (carry `(off, mc)`, drop `gridToMacroCellWithOffset g'` mid-loop); **N3** restates the P5 invariant (marge `≥ n` restant, preserved by jump). This is a design-gated iterative epic — feedback welcome on the `gridFrameN` framing before N2/N3.

## Verification (firsthand)

| Check | Result |
|-------|--------|
| `lake build Conway` (native `lake.exe`, v4.31.0-rc1) | **SUCCESS**, 2983 jobs, exit 0 |
| `grep -c sorry` stable | **3 → 3** (lake warns `declaration uses sorry` at HashlifeCorrectness L2636/L2999/L3007; N1 adds **0** sorry — `native_decide` only) |
| Diff | `+106 / −0` on 2 `.lean` files — pure additive, no existing proof touched |
| Line endings | LF clean (0 CRLF on both files) |
| Catalogue | untouched (byte-identical to main) |

Per `lean-merge-discipline`: ai-01 merges `--squash` post-H.4 local lake build (already done above). N2/N3 to follow on separate branches.

## Notes
- 4 Lean PR-body elements (§B): sorry diff `3 → 3` ✓, lake build SUCCESS log above ✓, no prover-Python change (N/A), single-subject (def + witness only) ✓.
- `See #3846` (partial — N1 of N1/N2/N3; #3846 stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)