### PR TITLE
Seed CSV IIT/ICT-Series (Phase 2 #4957, 29 notebooks)

### DIFF
--- a/translations/iit/README.md
+++ b/translations/iit/README.md
@@ -1,0 +1,66 @@
+# translations/iit — synchro traduction i18n (#4957 Phase 2)
+
+## Couverture
+
+| Métrique | Valeur |
+|----------|--------|
+| Série source | `MyIA.AI.Notebooks/IIT/` (PyPhi + ICT-Series : information intégrée, émergence, workspace — Python) |
+| Notebooks source | **29** (3 IIT PyPhi + 26 ICT-Series) |
+| Cellules extraites | **731** (428 markdown + 303 code, nbformat canonique, 99 % avec id stable) |
+| Taille CSV | ~743 KB (731 enregistrements × 21 colonnes) |
+| Langue pivot | **fr** (PIVOT_LANG = "fr", cf #1650 Phase 0.5 / #4980 Lean i18n) |
+| Langues cibles | **en, es, ar, fa, zh, ru, pt** (7 langues vivantes côté Argumentum) |
+| Date seed | 2026-07-10 |
+| Source seed | PR THIS (Phase 2 rollout IIT, 11e série) |
+
+## Workflow T0→T3
+
+T0 (catalogue CSV) **LIVRÉ** : le CSV seed `iit.csv` capture la substance canonique de la série au commit `a93a08e21`. Chaque enregistrement = `notebook, cell_id, cell_type, src_lang, src_hash, text_fr, text_<7 langues>, hash_fr, hash_<7 hash>`. Les hashes `sha256-16` sur le texte normalisé (rstrip lines + strip newlines) détectent les dérives cellule-par-cellule.
+
+T1 (extraction) **LIVRÉ** : `python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/IIT/ -o translations/iit/iit.csv --src-lang fr --repo-root .`. Script déterministe byte-identique (cf `extract_cells_to_csv.py`). Exclut `_output.ipynb` (Papermill) et `_agent.ipynb` (auto-générés) via `endswith`. 731/738 cellules markdown/code extraites (7 sans id nbformat stable sautées — non traduisibles de façon fiable).
+
+T2 (drift detector) **LIVRÉ** : `python scripts/translation/check_translation_sync.py translations/iit/iit.csv` → `{"csvs_checked": 1, "anomalies": [], "anomaly_count": 0}` (IN_SYNC round-trip). Workflow CI `.github/workflows/translation-drift.yml` non-bloquant read-only déclenche ce check sur PR paths `translations/**` + `MyIA.AI.Notebooks/**/*.ipynb` + `scripts/translation/**`.
+
+T3 (moteur Argumentum) **GATED** : run du moteur #1650 Phase 1 (connecteur Argumentum → fill des colonnes `text_<lang>` pour chaque cellule). Reste gated sur l'activation du connecteur Argumentum.
+
+## Régénération manuelle
+
+Si la série `MyIA.AI.Notebooks/IIT/` change (ajout/suppression de cellules, enrichissement), re-run déterministe :
+
+```bash
+python scripts/translation/extract_cells_to_csv.py \
+    MyIA.AI.Notebooks/IIT/ \
+    -o translations/iit/iit.csv --src-lang fr --repo-root .
+```
+
+T2 check post-régénération :
+
+```bash
+python scripts/translation/check_translation_sync.py \
+    translations/iit/iit.csv
+```
+
+Anomalies attendues (T3 non livré) :
+- `TRAD_DRIFT` attendu sur les `text_<lang>` et `hash_<lang>` tant que T3 n'a pas rempli les colonnes. Le seed CSV doit **demeurer avec `text_fr` rempli** (pivot) et **toutes les autres langues vides** (T3 à fill).
+- `SRC_DRIFT` = changement upstream non reporté dans le CSV → relancement T1 obligatoire.
+
+## Liaison upstream
+
+- EPIC parent **#4957** (CSV-by-series + CI drift-flag + resync manuelle Argumentum)
+- Phase 0.5 **#1650** (Argumentum connecteur + moteur de traduction)
+- Substance owner-lane **#4588** (ICT-Series Epic, strate 5) + **#5681** (J-Lens Track S, tête-à-tête SAE⇄J-space)
+- Voisin seed **translations/probas-infer/** (série précédente Phase 2)
+
+## Conformité règles
+
+- **L327 `+N/-0` purement additif** : nouveau répertoire `iit/`, nouveau CSV (pas d'écrasement) + README.
+- **catalog-pr-hygiene R1** : catalogue intact (CSV vit hors catalogue, sous `translations/`).
+- **L335 anti-monoculture** : substance neuve Phase 2 (IIT/ICT-Series), pas re-sweep monotone.
+- **L143 SAFE cross-owner** : IIT/ICT = owner po-2025 (strate 5, Epic #4588 + #5681).
+- **L289 anti-doublon** : 1 série = 1 PR de seed, PR Phase 2 distincte.
+- **readme-french-first** : README rédigé en français (FR pivot Phase 0.5).
+- **Stop & Repair** : pas de hand-edit de cellule, pas de scrub de sortie — le CSV est un artefact dérivé déterministe (T1 determinism byte-identique vérifié).
+
+## Note de maintenance (smell signalé, hors-scope)
+
+`ICT-19` apparaît en **double** dans la série : `ICT-19-EnjeuBattery.ipynb` + `ICT-19-EnjeuBattery-Raffinement.ipynb`. Les deux sont extraits tels quels dans le seed (le CSV suit la réalité du dépôt). Numéro dupliqué à clarifier en sujet séparé (signalé au dashboard coordinateur).

--- a/translations/iit/iit.csv
+++ b/translations/iit/iit.csv
@@ -1,0 +1,10380 @@
+notebook,cell_id,cell_type,src_lang,src_hash,text_fr,text_en,text_es,text_ar,text_fa,text_zh,text_ru,text_pt,hash_fr,hash_en,hash_es,hash_ar,hash_fa,hash_zh,hash_ru,hash_pt
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,f7ec05c8,markdown,fr,6c9e093987323ca0,"# ICT-1 — Trajectoires de $\Phi$
+
+> Notebook de la serie **ICT** (*Integrated Causal Trajectories*, Epic #4588).
+> Cadrage de la serie : [ICT-0-Framing.md](ICT-0-Framing.md). Fondations PyPhi :
+> [IIT-1-IntroToPyPhi.ipynb](../IIT-1-IntroToPyPhi.ipynb).
+
+La serie [IIT](README.md) mesure l'organisation causale d'un systeme **a un etat
+donne** : sa valeur d'information integree $\Phi$. C'est une *photographie*.
+
+Ce notebook applique la notion de **trajectoire** a $\Phi$ lui-meme. Quand un
+systeme deterministe evolue, il parcourt une suite d'etats
+
+$$ s_0 \rightarrow s_1 \rightarrow s_2 \rightarrow \dots $$
+
+et a chaque etat correspond une valeur de $\Phi$. On obtient donc une
+**trajectoire de $\Phi$** — le *film* de l'information integree pendant que le
+systeme se deplace dans son espace d'etats.
+
+Trois questions guident le notebook :
+
+1. **Le paysage de $\Phi$** — comment $\Phi$ varie-t-il d'un etat a l'autre ?
+   Est-il plat ou accidente ?
+2. **La trajectoire de $\Phi$** — que devient $\Phi$ le long d'une trajectoire,
+   en particulier sur l'**attracteur** ou le systeme finit par tourner ?
+3. **La robustesse de $\Phi$** — apres une perturbation, la trajectoire (et donc
+   le profil de $\Phi$) se reconstitue-t-elle ?
+
+On utilise le **vrai** moteur [PyPhi](https://pyphi.readthedocs.io) pour tous les
+calculs de $\Phi$ : aucun substitut, aucune valeur fabriquee. Les systemes
+restent volontairement minuscules (3 noeuds, $2^3 = 8$ etats) car le calcul de
+$\Phi$ est exponentiel — c'est une contrainte intrinseque de l'IIT, discutee en
+conclusion.",,,,,,,,6c9e093987323ca0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,982d42e5,markdown,fr,204b93d32ab5b1e4,"## Repères IIT canoniques
+
+> Vocabulaire de référence pour rattacher ce notebook à la colonne vertébrale de la série (mandat user *2026-07-03, directive 1 — recadrage IIT/$\Phi$*). Sources : [IIT-1-IntroToPyphi](../IIT-1-IntroToPyphi.ipynb) (fondations), [ICT-0-Framing](ICT-0-Framing.md) § *« Double lecture du sigle »*, [ICT-0-Annexe](ICT-0-Annexe-IntegratedComplexityTheory.md) (texte fondateur, $\Phi_{\text{dyn}}$).
+
+Trois notions de **Integrated Information Theory** (Tononi, 2004/2008) suffisent pour ce qui suit :
+
+- **$\Phi$ (information intégrée, *integrated information*)** — la quantité d'information qu'un système génère *par le fait d'être un*, au-dessus et au-delà de ses parties prises indépendantes. Calcul canonique : $\Phi = \min_{\text{partition } p} \mathrm{EMD}(p)$ — l'information qui ne *peut pas* être factorisée sur la partition qui sépare le système en parties indépendantes (Minimum Information Partition, MIP). Implémentation de référence : [PyPhi](https://pyphi.readthedocs.io), utilisé tel quel ici (aucun substitut).
+- **TPM (*Transition Probability Matrix*)** — la matrice de transition conditionnelle du système sous-jacent. Au format *state-by-node* de PyPhi, `network.tpm` est un tableau `(N, N)` indicé par un tuple d'état : pour chaque état présent (ligne), la probabilité de chaque état futur (colonne). Pour les réseaux déterministes de ce notebook, chaque ligne a un seul `1` (et des `0` ailleurs).
+- **Partition** — une bipartition du système en deux sous-systèmes $\mathcal{S}^L \cup \mathcal{S}^R = \mathcal{S}$ avec $\mathcal{S}^L \cap \mathcal{S}^R = \varnothing$. Pour la *cause-effect information* ($\Phi_{\mathrm{CE}}$), PyPhi balaie toutes les bipartitions *dirigées* et retient celle qui **minimise** la divergence entre le système entier et la somme de ses parties (MIP).
+
+Ce que ce notebook ajoute : $\Phi$ est habituellement calculé **état par état**, comme une photographie. ICT-1 le filme — on suit la *trajectoire* de $\Phi$ le long de $s_0 \rightarrow s_1 \rightarrow s_2 \rightarrow \dots$ pendant que le système déterministe évolue dans son espace d'états. Les trois questions (paysage, trajectoire, robustesse) sont les projections naturelles de $\Phi$ sur la dimension temporelle.
+
+**Pourquoi 3 nœuds.** Le calcul exact de $\Phi$ est exponentiel en $N$ (chaque bipartition d'un système à $N$ nœuds $= 2^{N-1} - 1$ coupes dirigées, plus le calcul EMD par coupe). Pour $N = 3$ on a $3$ bipartitions, et PyPhi termine en quelques millisecondes ; pour $N = 10$ le calcul devient intraitable — c'est la *contrainte intrinsèque* discutée en conclusion, et la motivation des approximations introduites par les strates suivantes ($\Phi_{\text{dyn}}$ dans [l'annexe fondatrice](ICT-0-Annexe-IntegratedComplexityTheory.md), $\Phi$-trajectoires échantillonnées, mesures variationnelles).",,,,,,,,204b93d32ab5b1e4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,32e6860b,markdown,fr,cc884dd456ba05d3,"## 0. Mise en place
+
+On charge PyPhi et le module `ict.trajectories` (pose a cote de PyPhi, il gere
+l'evolution dans l'espace d'etats sans dependre de PyPhi). On desactive le
+parallelisme de PyPhi (sous Windows le `multiprocessing` provoque sinon une
+avalanche de processus) et la validation des etats accessibles, pour pouvoir
+calculer $\Phi$ sur **tous** les etats, y compris transitoires.",,,,,,,,cc884dd456ba05d3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,b73f9552,code,fr,6e98b2050608f3a4,"import warnings
+warnings.filterwarnings(""ignore"", message="".*pkg_resources is deprecated.*"", category=UserWarning)
+
+import sys, os
+import numpy as np
+import matplotlib.pyplot as plt
+
+# le package ict est dans le dossier parent du notebook
+sys.path.insert(0, os.path.abspath("".""))
+from ict import trajectories as T
+
+import pyphi
+pyphi.config.PROGRESS_BARS = False
+pyphi.config.WELCOME_OFF = True
+# calculer Phi pour n'importe quel etat (meme inaccessible / transitoire)
+pyphi.config.VALIDATE_SUBSYSTEM_STATES = False
+# desactiver le parallelisme (Windows : evite l'avalanche de processus)
+for _attr in (""PARALLEL_CONCEPT_EVALUATION"", ""PARALLEL_CUT_EVALUATION"",
+              ""PARALLEL_COMPLEX_EVALUATION"", ""PARALLEL""):
+    if hasattr(pyphi.config, _attr):
+        setattr(pyphi.config, _attr, False)
+
+print(""PyPhi"", pyphi.__version__, ""| numpy"", np.__version__)",,,,,,,,6e98b2050608f3a4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,b13d2309,markdown,fr,94b57c7cc7cf42df,"### Deux reseaux a 3 noeuds
+
+On compare deux architectures causales deterministes, toutes deux integrees mais
+de structures tres differentes :
+
+- **AND/OR** : un petit reseau ou les noeuds combinent leurs entrees par des
+  portes logiques mixtes.
+- **XOR** : l'exemple canonique de PyPhi, ou chaque noeud est le OU-exclusif des
+  deux autres — un reseau tres symetrique.
+
+Pour chacun, `network.tpm` est la matrice de transition au format *state-by-node*
+de PyPhi : indexee par un tuple d'etat, elle donne l'etat suivant (les reseaux
+sont deterministes).",,,,,,,,94b57c7cc7cf42df,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,58810305,code,fr,ef0b3fdff095a55d,"# reseau AND/OR (TPM state-by-node, lignes indexees en little-endian)
+andor_tpm = np.array([
+    [0, 0, 0], [0, 0, 1], [1, 0, 1], [1, 0, 0],
+    [1, 1, 0], [1, 1, 1], [1, 1, 1], [1, 1, 0],
+])
+andor = pyphi.Network(andor_tpm, node_labels=['A', 'B', 'C'])
+
+# reseau XOR : exemple fourni par PyPhi
+xor = pyphi.examples.xor_network()
+
+print(""AND/OR : noeuds"", andor.node_labels, ""| matrice de connectivite\n"", andor.cm)
+print(""\nXOR    : noeuds"", xor.node_labels, ""| matrice de connectivite\n"", xor.cm)",,,,,,,,ef0b3fdff095a55d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,6be9f034,markdown,fr,ed28aca089fa8245,"## 1. Le paysage de $\Phi$
+
+$\Phi$ depend du systeme **et de son etat**. Avant de parler de trajectoire,
+cartographions $\Phi$ sur **tous** les etats : c'est le *paysage de $\Phi$*.
+
+La fonction ci-dessous calcule $\Phi$ pour chacun des $2^n$ etats. C'est le seul
+endroit ou PyPhi travaille vraiment ; le reste du notebook ne fait que relire
+cette carte.",,,,,,,,ed28aca089fa8245,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,a83a67da,code,fr,4f23a16aebd16ee2,"def phi_landscape(network, n):
+    # carte etat (tuple) -> Phi (float), calculee par PyPhi sur tous les etats
+    nodes = tuple(range(n))
+    carte = {}
+    for s in T.all_states(n):
+        sub = pyphi.Subsystem(network, s, nodes)
+        carte[s] = float(pyphi.compute.phi(sub))
+    return carte
+
+land_andor = phi_landscape(andor, 3)
+land_xor = phi_landscape(xor, 3)
+
+def resume(carte, nom):
+    v = list(carte.values())
+    print(f""{nom:8s} min={min(v):.4f}  max={max(v):.4f}  ""
+          f""moyenne={sum(v)/len(v):.4f}  amplitude={max(v)-min(v):.4f}"")
+
+for s in T.all_states(3):
+    print(f""  etat {s} : AND/OR Phi={land_andor[s]:.4f}   XOR Phi={land_xor[s]:.4f}"")
+print()
+resume(land_andor, ""AND/OR"")
+resume(land_xor, ""XOR"")",,,,,,,,4f23a16aebd16ee2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,92c0db41,code,fr,be81a4ea472a4804,"# visualisation des deux paysages de Phi
+labels = ["""".join(map(str, s)) for s in T.all_states(3)]
+x = np.arange(8)
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 4), sharey=True)
+for ax, carte, nom, col in [(axes[0], land_andor, ""AND/OR"", ""#2c7fb8""),
+                            (axes[1], land_xor, ""XOR"", ""#d95f0e"")]:
+    vals = [carte[s] for s in T.all_states(3)]
+    ax.bar(x, vals, color=col)
+    ax.set_title(f""Paysage de $\\Phi$ — {nom}"")
+    ax.set_xlabel(""etat (ABC)"")
+    ax.set_xticks(x); ax.set_xticklabels(labels, rotation=45)
+    ax.axhline(np.mean(vals), color=""gray"", ls=""--"", lw=1,
+               label=f""moyenne {np.mean(vals):.2f}"")
+    ax.legend()
+axes[0].set_ylabel(""$\\Phi$"")
+fig.suptitle(""Le paysage de $\\Phi$ : accidente (AND/OR) vs plat (XOR)"")
+plt.tight_layout()
+plt.show()",,,,,,,,be81a4ea472a4804,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,a3aa413b,markdown,fr,7df8a8bed9da494a,"**Lecture.** Les deux paysages sont radicalement differents :
+
+- **AND/OR** est **accidente** : la plupart des etats ont un $\Phi$ faible
+  ($\approx 0{,}19$), mais un etat — `100`, soit $A$ seul actif — culmine a
+  $\Phi \approx 2{,}31$, et `101` forme un relief intermediaire ($\approx 0{,}69$).
+  L'information integree du systeme **depend fortement de l'etat ou il se trouve**.
+- **XOR** est un **plateau** : $\Phi = 1{,}875$ pour *tous* les etats (amplitude
+  nulle). La symetrie du OU-exclusif rend l'information integree **independante de
+  l'etat**.
+
+Un meme nombre de noeuds, deux ""personnalites causales"" opposees. C'est ce
+paysage qui va donner son relief aux trajectoires de $\Phi$.",,,,,,,,7df8a8bed9da494a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,82f2b1d8,markdown,fr,85bd7203da4634e9,"## 2. La trajectoire de $\Phi$
+
+Un reseau deterministe, lache depuis un etat de depart, suit un chemin unique
+jusqu'a tomber dans un **attracteur** (un point fixe ou un cycle). Le module
+`ict.trajectories` reconstruit ce chemin en lisant la TPM, puis on relit la carte
+de $\Phi$ le long du chemin.",,,,,,,,85bd7203da4634e9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,b5c5c5b1,code,fr,4e035c14acbc55f7,"# trajectoires de quelques etats de depart du reseau AND/OR
+departs = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (1, 1, 1)]
+for start in departs:
+    path, debut = T.state_trajectory(andor.tpm, start)
+    attr = T.attractor_of(andor.tpm, start)
+    phis = T.phi_trajectory(land_andor, path)
+    print(f""depart {start} -> chemin {path}"")
+    print(f""   attracteur {attr}"")
+    print(f""   Phi le long : {[round(p, 3) for p in phis]}\n"")
+
+print(""Bassins d'attraction (signature attracteur -> nb d'etats de depart) :"")
+print(""  AND/OR :"", T.basin_sizes(andor.tpm, 3))
+print(""  XOR    :"", T.basin_sizes(xor.tpm, 3))",,,,,,,,4e035c14acbc55f7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,c216eb79,code,fr,191a2ec8ae6e6d64,"# Phi le long des trajectoires AND/OR (le 'film' de l'information integree)
+fig, ax = plt.subplots(figsize=(10, 5))
+for start in departs:
+    path, _ = T.state_trajectory(andor.tpm, start)
+    phis = T.phi_trajectory(land_andor, path)
+    ax.plot(range(len(phis)), phis, marker=""o"",
+            label=f""depart {''.join(map(str, start))}"")
+ax.set_title(""Trajectoires de $\\Phi$ — reseau AND/OR"")
+ax.set_xlabel(""pas de temps"")
+ax.set_ylabel(""$\\Phi$ de l'etat courant"")
+ax.legend()
+ax.grid(alpha=0.3)
+plt.tight_layout()
+plt.show()",,,,,,,,191a2ec8ae6e6d64,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,8e145534,markdown,fr,018014282177850c,"**Lecture.** Le resultat le plus parlant concerne l'**attracteur** du reseau
+AND/OR. Sept des huit etats finissent dans le **meme cycle de longueur 3** :
+
+$$ 100 \rightarrow 001 \rightarrow 110 \rightarrow 100 \rightarrow \dots $$
+
+et la trajectoire de $\Phi$ sur ce cycle **pulse** : $2{,}31 \rightarrow 0{,}19
+\rightarrow 0{,}19 \rightarrow 2{,}31 \dots$ L'information integree n'est donc
+**pas un badge fixe** du systeme : elle monte en fleche un pas sur trois, quand le
+systeme traverse l'etat-pic `100`, puis retombe. Un systeme dynamique peut etre
+""fortement integre par intermittence"".
+
+Le huitieme etat, `000`, est un **point fixe** isole ($\Phi$ constant a $0{,}19$) :
+un petit bassin a part. Sur XOR, au contraire, toutes les trajectoires atteignent
+un point fixe en un ou deux pas, et comme le paysage est plat, $\Phi$ y reste
+**rigoureusement constant** a $1{,}875$ : un film sans relief.",,,,,,,,018014282177850c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,e36be3f0,markdown,fr,a608a7bbd53f4e31,"## 3. Robustesse : $\Phi$ apres une perturbation
+
+La serie ICT s'interesse aux trajectoires qui **se reparent** (cf. ICT-2/ICT-3
+pour le toy-model de tri). Posons ici la meme question avec de l'information
+integree *reelle* : si l'on perturbe le systeme une fois installe sur son
+attracteur, sa trajectoire de $\Phi$ se reconstitue-t-elle ?
+
+On part du cycle AND/OR, on bascule **un seul noeud** (perturbation 1-bit), puis
+on laisse le systeme re-evoluer.",,,,,,,,a608a7bbd53f4e31,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,4e05e822,code,fr,2302b6644a321bd0,"# perturbation 1-bit a partir d'un etat de l'attracteur, puis recuperation
+attr = T.attractor_of(andor.tpm, (1, 1, 1))
+base = attr[0]                       # un etat du cycle attracteur
+print(f""attracteur de reference : {attr}"")
+print(f""etat perturbe : {base}\n"")
+
+fig, ax = plt.subplots(figsize=(10, 5))
+for bit in range(3):
+    pert = T.flip_bit(base, bit)
+    path, _ = T.state_trajectory(andor.tpm, pert)
+    # on prefixe l'etat de base pour visualiser le 'saut' de la perturbation
+    phis = T.phi_trajectory(land_andor, [base] + path)
+    retour = tuple(sorted(T.attractor_of(andor.tpm, pert))) == tuple(sorted(attr))
+    print(f""flip noeud {bit} : {base} -> {pert} | ""
+          f""retour au meme attracteur : {retour}"")
+    ax.plot(range(len(phis)), phis, marker=""o"",
+            label=f""flip noeud {bit} ({''.join(map(str, base))}->{''.join(map(str, pert))})"")
+
+ax.axvline(0.5, color=""red"", ls="":"", lw=1, label=""perturbation"")
+ax.set_title(""Recuperation de la trajectoire de $\\Phi$ apres perturbation 1-bit"")
+ax.set_xlabel(""pas de temps (0 = etat avant perturbation)"")
+ax.set_ylabel(""$\\Phi$"")
+ax.legend()
+ax.grid(alpha=0.3)
+plt.tight_layout()
+plt.show()",,,,,,,,2302b6644a321bd0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,dd93ce72,markdown,fr,b8f5f68f143190b0,"**Lecture.** Les **trois** perturbations 1-bit possibles depuis l'etat `110`
+du cycle ramenent le systeme **au meme attracteur** : la trajectoire de $\Phi$ se
+reconstitue dans tous les cas. Le profil pulsatile de $\Phi$ est donc une
+propriete **robuste** de la dynamique, pas un accident de l'etat initial.
+
+Les chemins de retour different : basculer le noeud 1 (`110 \to 100`) place
+directement le systeme sur l'etat-pic, et $\Phi$ remonte immediatement a $2{,}31$ ;
+basculer le noeud 0 (`110 \to 010`) impose un detour plus long avant que le pic ne
+revienne. La *forme* du transitoire depend de la perturbation, mais la
+*destination* — le cycle et son profil de $\Phi$ — est invariante.",,,,,,,,b8f5f68f143190b0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,763ab875,markdown,fr,1e199ec16946a603,"## 4. Exercices
+
+Trois exercices pour manipuler vous-meme le paysage et les trajectoires de $\Phi$.
+Completez le corps de chaque fonction (remplacez le `return None`). Le notebook
+s'execute de bout en bout meme sans les completer.",,,,,,,,1e199ec16946a603,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,3535b6d0,markdown,fr,401c56a87ba54b11,"### Exercice 1 — Amplitude du paysage de $\Phi$
+
+Le paysage AND/OR est accidente (amplitude $\approx 2{,}12$), celui de XOR est
+plat (amplitude $0$). Ecrivez une fonction qui **mesure** cet ecart : l'amplitude
+$\max \Phi - \min \Phi$ sur tout le paysage d'un reseau.",,,,,,,,401c56a87ba54b11,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,ee51ac5c,code,fr,450c9697fec42d4c,"def phi_amplitude(network, n):
+    # Objectif : retourner max(Phi) - min(Phi) sur les 2**n etats du reseau.
+    # Indice : reutiliser phi_landscape(network, n) defini en section 1.
+    # Indice : amplitude = max(carte.values()) - min(carte.values()).
+    # Etape etudiant :
+    result = None  # TODO etudiant : calculer l'amplitude du paysage
+    return result
+
+amp = phi_amplitude(andor, 3)
+if amp is not None:
+    print(f""Amplitude du paysage AND/OR : {amp:.4f}"")
+else:
+    print(""Exercice a completer"")",,,,,,,,450c9697fec42d4c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,bfbbefba,markdown,fr,470326fb37d81602,"### Exercice 2 — $\Phi$ moyen sur l'attracteur
+
+Sur le cycle AND/OR, $\Phi$ pulse ($2{,}31 \to 0{,}19 \to 0{,}19$). Le $\Phi$
+*moyen* sur l'attracteur resume ""l'integration soutenue"" d'un regime. Ecrivez une
+fonction qui, depuis un etat de depart, retourne la moyenne de $\Phi$ sur les
+etats du cycle attracteur.",,,,,,,,470326fb37d81602,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,3a01788f,code,fr,0ed9387b7738729a,"def mean_phi_on_attractor(tpm, phi_map, start):
+    # Objectif : moyenne de Phi sur les etats de l'attracteur atteint depuis start.
+    # Indice : attr = T.attractor_of(tpm, start) donne la liste des etats du cycle.
+    # Indice : phi_map[etat] donne Phi de chaque etat ; faire la moyenne.
+    # Etape etudiant :
+    result = None  # TODO etudiant : moyenne de Phi sur l'attracteur
+    return result
+
+m = mean_phi_on_attractor(andor.tpm, land_andor, (1, 1, 1))
+if m is not None:
+    print(f""Phi moyen sur l'attracteur AND/OR : {m:.4f}"")
+else:
+    print(""Exercice a completer"")",,,,,,,,0ed9387b7738729a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,c0df7ee9,markdown,fr,c66a666859a51ba8,"### Exercice 3 — Compter les pulsations de $\Phi$
+
+Un ""pic"" de $\Phi$ le long d'une trajectoire est un **maximum local**. La fonction
+`T.detect_events` renvoie les indices des minima et maxima locaux d'une courbe.
+Ecrivez une fonction qui compte le nombre de **pics** de $\Phi$ le long de la
+trajectoire issue d'un etat de depart.",,,,,,,,c66a666859a51ba8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,e4fbbf5b,code,fr,473d8c053245c653,"def count_phi_pulses(tpm, phi_map, start):
+    # Objectif : nombre de maxima locaux (pics de Phi) le long de la trajectoire.
+    # Indice : path, _ = T.state_trajectory(tpm, start) donne le chemin d'etats.
+    # Indice : phis = T.phi_trajectory(phi_map, path) donne la courbe de Phi.
+    # Indice : T.detect_events(phis)[""maxima""] est la liste des indices de pics.
+    # Etape etudiant :
+    result = None  # TODO etudiant : compter les pics (len des maxima)
+    return result
+
+n_pulses = count_phi_pulses(andor.tpm, land_andor, (0, 1, 0))
+if n_pulses is not None:
+    print(f""Nombre de pics de Phi (depart 010) : {n_pulses}"")
+else:
+    print(""Exercice a completer"")",,,,,,,,473d8c053245c653,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb,12ac8ab9,markdown,fr,c39df03d132b932e,"## 5. Conclusion
+
+En appliquant la notion de **trajectoire** a $\Phi$ lui-meme, on a vu que :
+
+1. **$\Phi$ a un paysage.** Pour un meme nombre de noeuds, ce paysage peut etre
+   accidente (AND/OR : un pic a $2{,}31$, le reste a $0{,}19$) ou parfaitement plat
+   (XOR : $1{,}875$ partout). L'information integree est une fonction de l'etat,
+   pas seulement du cablage.
+2. **$\Phi$ a une trajectoire.** Sur l'attracteur d'AND/OR — un cycle de longueur
+   3 — $\Phi$ **pulse**. Un systeme peut donc etre *integre par intermittence* :
+   l'integration est un evenement dans le temps, pas une etiquette permanente.
+3. **La trajectoire de $\Phi$ est robuste.** Les trois perturbations 1-bit du
+   cycle ramenent au meme attracteur : le profil pulsatile de $\Phi$ se repare.
+
+**La limite intrinseque.** Tous les systemes de ce notebook ont 3 noeuds. Le
+calcul de $\Phi$ est **super-exponentiel** : il faut considerer toutes les
+partitions du systeme pour chaque etat. Au-dela d'une dizaine de noeuds, PyPhi
+devient impraticable. C'est *la* raison pour laquelle l'IIT exacte se cantonne aux
+petits systemes — et c'est le probleme que les notebooks suivants attaquent :
+
+- **ICT-5/ICT-6** : trouver une **macro-description** (coarse-graining,
+  pont tri $\to$ TPM) ou $\Phi$ redevient calculable a plus grande echelle.
+- **ICT-2/ICT-3** : etudier des trajectoires riches sur des modeles *jouets*
+  (tri auto-organise) qui se passent de PyPhi, quand le systeme est trop grand
+  pour l'IIT exacte.
+
+Conformement au principe de la serie ([ICT-0](ICT-0-Framing.md)) : tout ce qui
+precede a ete **calcule par le vrai PyPhi**, puis narre tel quel.
+
+## Voir aussi
+
+- [ICT-0-Framing.md](ICT-0-Framing.md) — cadrage de la serie ICT.
+- [IIT-1-IntroToPyPhi.ipynb](../IIT-1-IntroToPyPhi.ipynb) — TPM, sous-systeme, $\Phi$, CES.
+- [ICT-2-SelfSortingMorphogenesis.ipynb](ICT-2-SelfSortingMorphogenesis.ipynb) /
+  [ICT-3-RobustnessDelayedGratification.ipynb](ICT-3-RobustnessDelayedGratification.ipynb)
+  — trajectoires et robustesse sur le toy-model de tri.
+- Zhang, Goldstein & Levin (2025), *Classical sorting algorithms as a model of
+  morphogenesis*, [arXiv:2401.05375](https://arxiv.org/abs/2401.05375).",,,,,,,,c39df03d132b932e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,420be610,markdown,fr,86b7588a7eadd377,"# ICT-10 — Grammaire des catastrophes : *l'obstacle qui engendre les formes, le verbe qui les fait basculer*
+
+> **Serie ICT** (Integrated Causal Trajectories, Epic #4588) — **charniere strate 2 -> strate 3**.
+> Prerequis conseilles : [ICT-0-Framing](ICT-0-Framing.md), [ICT-8](ICT-8-AttractorLandscapesEWS.ipynb)
+> (paysages d'attracteurs, pli, ralentissement critique) et [ICT-9](ICT-9-AgencyRegeneration.ipynb)
+> (agence comme reparation mesuree).
+
+## Un prelude a Rene Thom — mais *sans complaisance*
+
+Ce notebook est le **prelude semiophysique** de la serie : il introduit le vocabulaire de Rene Thom
+(*Esquisse d'une semiophysique*, 1991 ; *Stabilite structurelle et morphogenese*, 1972) — **saillance,
+pregnance, catastrophe, actant** — mais en respectant la regle de la serie : *aucun concept n'entre dans
+ICT tant qu'il n'est pas attache a une mesure, une intervention ou un contraste*. La theorie des
+catastrophes a une mauvaise reputation (« metaphore qualitative ») precisement quand on l'invoque sans
+rien mesurer. Ici, **chaque image de Thom est adossee a une grandeur calculee** sur la catastrophe
+canonique, la **fronce** (*cusp*).
+
+## Les deux fils, tresses
+
+| Fil | Concept de Thom | Ce qu'on mesure |
+|---|---|---|
+| **A. Le metatheoreme** (ferme la strate 2) | *« l'obstacle comme source de l'ontologie »* (Ch.3) | le **nombre d'equilibres** ne change qu'aux **plis** — naissance/disparition d'une paire |
+| **B. Le lacet de predation** (ouvre la strate 3) | la **scene actantielle** predateur/proie (Ch.4) | un **cycle d'hysteresis** a **deux** catastrophes (perception J, capture K) + un **representant interne** `p_hat` qui anticipe |
+
+## La surprise du chapitre 2 (« Le Langage »)
+
+En relisant Thom de pres, les objets qu'on mesure ici se revelent etre **ses propres modeles
+linguistiques** (Ch.2, pp.35-52) :
+
+- les **quatre transitions generiques** du metatheoreme (debut, fin, ramification, confluence)
+  *« symbolisent adequatement le contenu »* des premiers pivots du langage enfantin (p.38) ;
+- la **phrase transitive SVO** (« le chat mange la souris ») est *« une classe de chemins transverses a
+  une hypersurface de catastrophe, decrivant la transmission brutale d'un etat stable 1 vers un etat
+  stable 2 »* (p.42) — c'est exactement **notre lacet** ;
+- l'idee d'**anticiper la trajectoire de l'objet** (p.50) est exactement notre `p_hat`.
+
+On n'ouvre donc **pas** un front « langage » non instrumente : on **nomme la correspondance**, avec le
+caveat de Thom lui-meme — *« le modele saillance-pregnance ne vise pas a la prediction »* (p.51). Le pont
+vers les LLM (et leur explicabilite par auto-encodeurs epars) reste **lointain** : on en discute les
+barreaux honnetement en section 6.",,,,,,,,86b7588a7eadd377,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,61cce5e1,code,fr,9daba068a4036e47,"import os, sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, os.path.abspath("".""))
+from ict import catastrophe as cat
+
+GRAINE = 7
+np.random.seed(GRAINE)
+trapz = getattr(np, ""trapezoid"", None) or np.trapz   # numpy >= 2.0 : trapz -> trapezoid
+
+# La fronce : V(x; a, b) = x^4/4 + a x^2/2 + b x  ;  dynamique gradient  dx/dt = -(x^3 + a x + b)
+# a = parametre de ""dedoublement"" (a<0 : bistable) ; b = parametre de ""biais"" (penche un puits)
+print(""Catastrophe fronce (cusp) -- la catastrophe elementaire a 2 parametres de controle (a, b)."")
+print(""Region bistable (2 actants) :  4a^3 + 27b^2 < 0   (donc a < 0)."")",,,,,,,,9daba068a4036e47,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,46a1208d,markdown,fr,78f9a77cfaebe108,"## 1. La fronce : le squelette mesure
+
+La fronce est la catastrophe a **deux parametres de controle** $(a, b)$, de potentiel
+$V(x) = \tfrac{x^4}{4} + \tfrac{a}{2}x^2 + b\,x$. Les **equilibres** sont les racines de
+$x^3 + a x + b = 0$ ; ils sont **stables** (minima, $V''>0$) ou **instables** (col). Tout se joue sur le
+signe du discriminant : pour $4a^3 + 27b^2 < 0$ (donc $a<0$) il y a **trois** equilibres — **deux minima
+separes par un col**, soit *deux actants* au sens de Thom. La courbe de bifurcation $4a^3 + 27b^2 = 0$
+(la parabole semi-cubique, le « bec » de la fronce) est le lieu ou un minimum et le col **fusionnent et
+disparaissent** : un **pli**.
+
+C'est *le meme objet* qu'en ICT-8 : la bifurcation pli du modele de paturage de May etait une **section**
+de cette fronce ; le ralentissement critique mesure la-bas (la valeur propre $\to 0$) *est* l'aplatissement
+du puits a l'approche du pli, ci-dessous a droite.",,,,,,,,78f9a77cfaebe108,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,c7bc3c92,code,fr,3ea5bcd275eacea4,"fig, (axL, axR) = plt.subplots(1, 2, figsize=(13, 5))
+
+# (gauche) potentiel : monostable (a>0) vs bistable (a<0, deux puits)
+x = np.linspace(-2.2, 2.2, 400)
+axL.plot(x, cat.cusp_potential(x, a=1.0, b=0.0), color=""steelblue"", lw=2, label=""a=+1 : 1 puits (monostable)"")
+axL.plot(x, cat.cusp_potential(x, a=-1.0, b=0.0), color=""crimson"", lw=2, label=""a=-1 : 2 puits (bistable)"")
+axL.plot(x, cat.cusp_potential(x, a=-1.0, b=0.3), color=""darkorange"", lw=2, ls=""--"", label=""a=-1, b=0.3 : biais"")
+for a_, b_, col in [(-1.0, 0.0, ""crimson""), (-1.0, 0.3, ""darkorange"")]:
+    for xe, st in cat.cusp_equilibria(a_, b_):
+        axL.plot(xe, cat.cusp_potential(xe, a_, b_), ""o"" if st else ""x"", color=col, ms=9)
+axL.set_xlabel(""etat x""); axL.set_ylabel(""potentiel V(x)"")
+axL.set_title(""Potentiel de la fronce : o = minimum (actant), x = col""); axL.legend(fontsize=9)
+
+# (droite) la courbe de bifurcation dans le plan de controle (a, b)
+a_grid = np.linspace(-2.0, 0.4, 300)
+b_inf, b_sup = cat.bifurcation_curve(a_grid)
+axR.plot(a_grid, b_sup, color=""black"", lw=2); axR.plot(a_grid, b_inf, color=""black"", lw=2)
+axR.fill_between(a_grid, b_inf, b_sup, where=~np.isnan(b_sup), color=""crimson"", alpha=0.15)
+axR.text(-1.2, 0.0, ""3 equilibres\n(2 actants)"", ha=""center"", va=""center"", fontsize=10, color=""crimson"")
+axR.text(0.15, 0.45, ""1 equilibre"", ha=""center"", fontsize=10)
+axR.axhline(0, color=""grey"", lw=0.6); axR.axvline(0, color=""grey"", lw=0.6)
+axR.set_xlabel(""a (dedoublement)""); axR.set_ylabel(""b (biais)"")
+axR.set_title(""Plan de controle : le « bec » de la fronce  (4a^3 + 27b^2 = 0)"")
+plt.tight_layout(); plt.show()
+
+print(""a=-1, b=0   -> equilibres :"", [(round(x,3), 'stable' if s else 'col') for x,s in cat.cusp_equilibria(-1,0)])
+print(""a=+1, b=0   -> equilibres :"", [(round(x,3), 'stable' if s else 'col') for x,s in cat.cusp_equilibria(1,0)])
+print(f""pli a a=-1 : b = +/-{cat.fold_lines(-1.0)[1]:.4f}"")",,,,,,,,3ea5bcd275eacea4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,b1d18f8c,markdown,fr,e5240bfa6e94f8b3,"## 2. Le metatheoreme : l'obstacle comme source de l'ontologie
+
+Le **metatheoreme** de Thom (Ch.3, §B) dit, en substance : une forme saillante mobile dans un flux ne
+peut donner naissance qu'a un **petit nombre de transitions generiques** — *debut*, *fin*, *ramification*,
+*confluence*. La non-linearite $x^3$ joue le role de l'**obstacle** : c'est *lui* qui engendre la
+multiplicite des bassins (la pluralite des « etres »). D'ou la formule *l'obstacle comme source de
+l'ontologie*.
+
+On le **mesure** directement : balayons $b$ a $a<0$ fixe et comptons les equilibres. Le nombre ne saute
+qu'aux **plis**, et toujours de $\pm 2$ (un minimum et un col naissent ou s'annihilent ensemble). Le long
+d'un chemin generique, il n'y a donc **exactement deux** transitions de comptage — ni plus, ni moins.
+
+> **Lien Ch.2 (p.38)** : ces quatre transitions — debut, fin, ramification, confluence — sont, mot pour
+> mot, celles dont Thom dit qu'elles *« symbolisent adequatement le contenu »* des premiers pivots du
+> langage enfantin. La confluence devient d'abord une preposition (« chez »), puis un **verbe divalent**
+> (Tesnière). Le comptage qu'on trace ici est la **proto-grammaire** mesuree.",,,,,,,,e5240bfa6e94f8b3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,01806a92,code,fr,cb961b42c5d82073,"a = -1.0
+b_lo, b_hi = cat.fold_lines(a)
+bs = np.linspace(b_lo - 0.35, b_hi + 0.35, 400)
+counts = np.array([cat.count_equilibria(a, float(b)) for b in bs])
+transitions = np.where(np.diff(counts) != 0)[0]
+
+fig, ax = plt.subplots(figsize=(11, 4.5))
+ax.step(bs, counts, where=""mid"", color=""crimson"", lw=2)
+for j in transitions:
+    ax.axvline(bs[j], color=""black"", ls="":"", lw=1.2)
+ax.axvspan(b_lo, b_hi, color=""crimson"", alpha=0.10, label=""region bistable (2 actants)"")
+ax.set_yticks([1, 3]); ax.set_ylim(0.5, 3.5)
+ax.set_xlabel(""b (biais)""); ax.set_ylabel(""nombre d'equilibres"")
+ax.set_title(""Metatheoreme mesure : le comptage ne change qu'aux plis (naissance / disparition d'une paire)"")
+ax.legend(loc=""upper right"")
+plt.tight_layout(); plt.show()
+
+print(f""valeurs prises par le comptage : {sorted(set(counts.tolist()))}  (1 hors region, 3 dedans)"")
+print(f""nombre de transitions de comptage le long du balayage : {len(transitions)}  (les deux plis)"")
+print(""les quatre types generiques de Thom : naissance (1->3), confluence/disparition (3->1)."")",,,,,,,,cb961b42c5d82073,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,a5938e11,markdown,fr,2b9e848d19543956,"### Exercice 1 — la fourche (pitchfork), section symetrique de la fronce
+
+A $b=0$ (pas de biais), la fronce devient symetrique : c'est la **fourche**. Quand $a$ descend sous $0$,
+l'unique equilibre $x=0$ se **dedouble** en deux minima symetriques (plus le col en $0$). Completez
+`equilibres_fourche(a)` pour renvoyer la liste des positions d'equilibre **a $b=0$**, et observez le
+dedoublement.
+
+*Indices :* `cat.cusp_equilibria(a, 0.0)` renvoie la liste `(x*, stable)` ; on ne demande ici que les
+positions `x*`. Le point critique (la « pointe » de la fourche) est en $a=0$.",,,,,,,,2b9e848d19543956,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,5a5fb4b9,code,fr,fac4766b2b6bab43,"def equilibres_fourche(a):
+    """"""Positions d'equilibre de la fronce SYMETRIQUE (b=0), pour observer la fourche.
+    Renvoyer None tant que l'exercice n'est pas complete.""""""
+    # TODO etudiant : extraire les positions x* depuis cat.cusp_equilibria(a, 0.0)
+    # return [x for x, _ in cat.cusp_equilibria(a, 0.0)]
+    return None  # TODO
+
+# Verification (a decommenter une fois complete) :
+# for a in [0.5, 0.0, -0.5, -1.0]:
+#     print(f""a={a:+.1f} -> equilibres (b=0) : {equilibres_fourche(a)}"")
+print(""Exercice 1 a completer : observer le dedoublement de la fourche quand a passe sous 0."")",,,,,,,,fac4766b2b6bab43,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,1b9908cb,markdown,fr,5a65f6380d1f9c02,"## 3. Le lacet de predation : la scene actantielle mesuree
+
+On ferme la strate 2 (morphogenese) et on **ouvre la strate 3** (agents). Le **lacet de predation** de
+Thom (Ch.4, §C) est la scene actantielle canonique : deux actants (predateur, proie) comme deux minima,
+et **deux franchissements** de la catastrophe le long d'un cycle — la **perception** (J : la proie entre
+dans le champ du predateur) et la **capture** (K). On le mesure par un **cycle d'hysteresis** : a $a<0$
+fixe, on fait varier le biais $b$ vers le haut puis vers le bas en suivant **adiabatiquement** le minimum
+courant. Le systeme reste sur sa branche jusqu'a ce qu'elle disparaisse a un pli, puis **saute** :
+c'est la catastrophe.
+
+> **Lien Ch.2 (p.42)** : *« la signification d'un verbe peut etre symbolisee [...] comme une classe de
+> chemins transverses a une hypersurface de catastrophe, decrivant la transmission brutale d'un etat
+> stable 1 vers un etat stable 2 »*. La phrase transitive **SVO** *est* ce lacet. Et l'**aire** du cycle
+> (non nulle) mesure l'**irreversibilite** : capture $\neq$ emission — la direction agent$\to$patient de
+> la scene. C'est la *meme* fronce que la transition liquide-gaz de Van der Waals (note 8 du Ch.2) et que
+> « la chaleur fait fondre la glace » (p.48).",,,,,,,,5a65f6380d1f9c02,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,b0c97999,code,fr,c9be6b83411256ca,"a = -1.0
+b_up = np.linspace(-0.7, 0.7, 90)
+b_path = np.concatenate([b_up, b_up[::-1]])               # aller (montee) puis retour (descente)
+x0 = cat.cusp_equilibria(a, float(b_path[0]))[0][0]
+xs = cat.hysteresis_loop(a, b_path, x_start=x0)
+jumps = cat.loop_jumps(b_path, xs, threshold=0.5)
+aire = float(trapz(xs, b_path))
+
+fig, (axL, axR) = plt.subplots(1, 2, figsize=(13, 5))
+n = len(b_up)
+axL.plot(b_path[:n], xs[:n], color=""crimson"", lw=2, label=""montee de b (perception)"")
+axL.plot(b_path[n:], xs[n:], color=""steelblue"", lw=2, label=""descente de b (relachement)"")
+for j in jumps:
+    axL.annotate("""", xy=(b_path[j], xs[j]), xytext=(b_path[j], xs[j-1]),
+                 arrowprops=dict(arrowstyle=""->"", color=""black"", lw=1.6))
+if len(jumps) >= 1:
+    axL.text(b_path[jumps[0]], 0.0, "" J\n(capture)"", fontsize=10)
+if len(jumps) >= 2:
+    axL.text(b_path[jumps[1]], 0.0, ""K\n(relachement) "", fontsize=10, ha=""right"")
+axL.set_xlabel(""b (biais de controle)""); axL.set_ylabel(""etat x (actant occupe)"")
+axL.set_title(""Le lacet de predation : deux catastrophes (J, K)""); axL.legend(fontsize=9)
+
+# le lacet ferme dans le plan (b, x) : son aire = hysteresis = irreversibilite
+axR.fill(b_path, xs, color=""crimson"", alpha=0.15)
+axR.plot(b_path, xs, color=""crimson"", lw=1.5)
+axR.set_xlabel(""b""); axR.set_ylabel(""x"")
+axR.set_title(f""Cycle d'hysteresis : aire = {abs(aire):.3f}  (irreversibilite mesuree)"")
+plt.tight_layout(); plt.show()
+
+print(f""nombre de catastrophes le long du lacet : {len(jumps)}  (J = capture, K = relachement)"")
+print(f""b aux franchissements : {[round(float(b_path[j]),3) for j in jumps]}  (pli theorique : +/-{b_hi:.3f})"")
+print(f""aire du cycle (hysteresis, signe = orientation) : {aire:+.3f}  -> non nulle = scene orientee (SVO)"")",,,,,,,,c9be6b83411256ca,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,11c70949,markdown,fr,c79a5e5edee3adfd,"### Exercice 2 — l'hysteresis disparait a la pointe de la fronce
+
+L'irreversibilite (l'aire du lacet) doit **s'effondrer** quand on rapproche $a$ de $0$ : a la pointe
+$a=0$, les deux puits fusionnent, il n'y a plus de bistabilite, donc plus de saut — la scene actantielle
+**se degrade** en transition lisse. Completez `aire_lacet(a)` qui renvoie l'aire (valeur absolue) du
+cycle d'hysteresis pour un $a<0$ donne, et verifiez la decroissance vers $0$.
+
+*Indices :* reproduire le balayage `b_path` de la section 3, appeler `cat.hysteresis_loop(a, b_path, ...)`,
+puis `abs(trapz(xs, b_path))`. Adapter l'amplitude du balayage de $b$ a la taille du pli `cat.fold_lines(a)`.",,,,,,,,c79a5e5edee3adfd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,9641735a,code,fr,1793480203adc57a,"def aire_lacet(a):
+    """"""Aire (valeur absolue) du cycle d'hysteresis pour un a < 0 donne.
+    Mesure l'irreversibilite de la scene actantielle. Renvoyer None tant que non complete.""""""
+    # TODO etudiant :
+    # bf = cat.fold_lines(a)
+    # if bf is None: return 0.0            # a >= 0 : pas de bistabilite, pas d'hysteresis
+    # b_up = np.linspace(-2*bf[1], 2*bf[1], 90)
+    # b_path = np.concatenate([b_up, b_up[::-1]])
+    # xs = cat.hysteresis_loop(a, b_path, x_start=cat.cusp_equilibria(a, float(b_path[0]))[0][0])
+    # return abs(float(trapz(xs, b_path)))
+    return None  # TODO
+
+# Verification (a decommenter) :
+# for a in [-1.0, -0.6, -0.3, -0.1]:
+#     print(f""a={a:+.2f} -> aire du lacet = {aire_lacet(a)}"")
+print(""Exercice 2 a completer : l'hysteresis (aire) s'effondre quand a -> 0 (degenerescence)."")",,,,,,,,1793480203adc57a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,6f1c92ee,markdown,fr,5ff4e8e8bb602a42,"## 4. Le representant interne `p_hat` : anticiper la proie
+
+Thom (Ch.4) place dans l'etat metabolique du predateur un **representant interne** de la proie, qui
+*« anticipe »* la proie reelle (et Ch.2, p.50 : on se deplace en *« anticipant la trajectoire de
+l'objet »*). C'est le germe d'une **proto-representation** — et le pont, *sous caveat*, vers la strate 3
+(agents) et, plus loin, l'explicabilite.
+
+On le mesure **sans complaisance**, sur un banc durci en trois directions :
+
+1. **Trois familles de trajectoires** aux cinematiques opposees : le *sinus bruite* (inertie lisse,
+   exploitable par un modele de vitesse), la *marche aleatoire a derive* (le bruit domine la derive :
+   la vitesse instantanee n'est que du bruit amplifie), le *creneau* (discontinuites : tout modele de
+   vitesse sur-reagit au saut).
+2. **Trois baselines adverses**, reellement calculees : la *persistance* (suit sans modele), la
+   *moyenne mobile* (lisse mais retarde), et un *AR(1)* dont le coefficient est ajuste **sur la serie
+   complete** (in-sample) — un adversaire volontairement avantage, pas un homme de paille.
+3. **Deux metriques separees**, jamais agregees : (a) le **pic de correlation croisee** (a quel
+   decalage l'estimateur correle-t-il le mieux avec la proie ? lag > 0 = il regarde vers le futur) et
+   (b) l'**erreur a horizon fixe** `lead`. Les deux peuvent diverger — et divergent reellement
+   ci-dessous.
+
+**Clause de falsifiabilite** : `p_hat` doit battre la **meilleure** des trois baselines, famille par
+famille (le gain se reporte par famille, jamais en moyenne). S'il ne gagne pas sur au moins 2 familles
+sur 3, le verdict honnete est *« avantage regime-dependant »* — pas *« p_hat anticipe »*. La ou
+`p_hat` echoue doit rester **visible** dans la sortie.",,,,,,,,5ff4e8e8bb602a42,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,eb36d885,code,fr,523b14a99cde72f1,"familles = [""sinus"", ""derive"", ""creneau""]
+ETIQUETTES = {""sinus"": ""sinus bruite (inertie lisse)"",
+              ""derive"": ""marche a derive (bruit dominant)"",
+              ""creneau"": ""creneau (discontinuites)""}
+ESTIMATEURS = [""p_hat"", ""persistance"", ""moyenne_mobile"", ""ar1""]
+LEAD = 4
+GRAINES = [0, 1, 7, 42, 99]                      # robustesse multi-graines
+
+# --- banc principal (graine GRAINE) : deux metriques SEPAREES, par famille ---
+proies, rapports = {}, {}
+for famille in familles:
+    proie = cat.prey_trajectory(famille, n_steps=300, noise=0.10,
+                                rng=np.random.default_rng(GRAINE))
+    proies[famille] = proie
+    rapports[famille] = cat.anticipation_report(proie, lead=LEAD, alpha=0.25,
+                                                window=5, max_lag=10)
+
+# --- robustesse : marge de p_hat contre la MEILLEURE baseline, 5 graines ---
+marges = {famille: [] for famille in familles}
+for graine in GRAINES:
+    for famille in familles:
+        proie_g = cat.prey_trajectory(famille, n_steps=300, noise=0.10,
+                                      rng=np.random.default_rng(graine))
+        rep = cat.anticipation_report(proie_g, lead=LEAD)
+        best = min(v[""erreur""] for nom, v in rep.items() if nom != ""p_hat"")
+        marges[famille].append(best - rep[""p_hat""][""erreur""])    # > 0 : p_hat gagne
+
+# --- tableau par famille : erreur@lead ET pic de correlation, jamais agreges ---
+victoires = {}
+for famille in familles:
+    rep = rapports[famille]
+    print(f""=== {famille} ==="")
+    for nom in ESTIMATEURS:
+        print(f""  {nom:15s} erreur@{LEAD} = {rep[nom]['erreur']:.4f}   pic_lag = {rep[nom]['pic_lag']:+d}"")
+    best_nom, best = min(((nom, rep[nom][""erreur""]) for nom in ESTIMATEURS[1:]),
+                         key=lambda nv: nv[1])
+    m = np.array(marges[famille])
+    victoires[famille] = int((m > 0).sum())
+    verdict = ""BAT"" if rep[""p_hat""][""erreur""] < best else ""PERD contre""
+    print(f""  -> p_hat {verdict} la meilleure baseline ({best_nom} : {best:.4f})""
+          f"" | {victoires[famille]}/{len(GRAINES)} graines, marge {m.mean():+.4f} +/- {m.std():.4f}"")
+
+# --- figure : trajectoires + p_hat (haut), erreurs des 4 estimateurs (bas) ---
+COULEURS = {""p_hat"": ""crimson"", ""persistance"": ""steelblue"",
+            ""moyenne_mobile"": ""darkseagreen"", ""ar1"": ""goldenrod""}
+fig, axes = plt.subplots(2, 3, figsize=(14, 7.5))
+for j, famille in enumerate(familles):
+    proie = proies[famille]
+    p_hat = cat.constant_velocity_tracker(proie, lead=LEAD, alpha=0.25)
+    ax = axes[0, j]
+    ax.plot(proie[:150], color=""black"", lw=1.0, label=""proie"")
+    ax.plot(p_hat[:150], color=""crimson"", lw=1.0, alpha=0.8, label=""p_hat"")
+    ax.set_title(ETIQUETTES[famille], fontsize=10)
+    if j == 0:
+        ax.set_ylabel(""position""); ax.legend(fontsize=8)
+    ax = axes[1, j]
+    rep = rapports[famille]
+    barres = ax.bar(range(len(ESTIMATEURS)),
+                    [rep[nom][""erreur""] for nom in ESTIMATEURS],
+                    color=[COULEURS[nom] for nom in ESTIMATEURS])
+    for barre, nom in zip(barres, ESTIMATEURS):      # pic_lag annote sur chaque barre
+        ax.text(barre.get_x() + barre.get_width() / 2, barre.get_height(),
+                f""lag {rep[nom]['pic_lag']:+d}"", ha=""center"", va=""bottom"", fontsize=8)
+    ax.set_xticks(range(len(ESTIMATEURS)))
+    ax.set_xticklabels([""p_hat"", ""persist."", ""moy.mob."", ""AR(1)""], fontsize=8)
+    if j == 0:
+        ax.set_ylabel(f""erreur a l'horizon lead={LEAD}"")
+fig.suptitle(""p_hat contre trois baselines adverses, sur trois familles de trajectoires"", y=0.995)
+plt.tight_layout(); plt.show()
+
+n_gagnees = sum(v > len(GRAINES) // 2 for v in victoires.values())
+print(f""\nVerdict : p_hat bat la meilleure baseline sur {n_gagnees}/{len(familles)} familles""
+      f"" (critere de la clause : >= 2/3 pour crediter l'anticipation)"")
+print(""-> avantage REGIME-DEPENDANT : p_hat anticipe la ou l'inertie est exploitable (sinus),""
+      ""\n   pas sur la derive bruitee ni sur les discontinuites. L'echec reste visible ci-dessus."")",,,,,,,,523b14a99cde72f1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,fd8434db,markdown,fr,d07276b7ab066026,"### Verdict sans complaisance : un avantage regime-dependant
+
+Le banc durci renverse la conclusion trop confortable d'un banc a une seule famille
+(« `p_hat` bat la persistance ») :
+
+- **Sinus bruite** — `p_hat` **gagne** contre les trois baselines (erreur 0.055 contre 0.068 pour le
+  meilleur adversaire, l'AR(1)), et c'est robuste : 5/5 graines, marge +0.012 ± 0.002. Son pic de
+  correlation a **lag +3** confirme qu'il correle avec le futur de la proie.
+- **Marche a derive** — `p_hat` **perd** (0/5 graines, marge −0.020 ± 0.003) : le bruit domine la
+  derive, et la vitesse lissee n'est que du bruit amplifie. C'est aussi la famille ou les **deux
+  metriques divergent** : `p_hat` a le pic de correlation le moins retarde (lag +0, contre −1 pour la
+  persistance) **tout en ayant la pire erreur des quatre estimateurs** (0.052). Un pic de correlation
+  flatteur ne prouve pas un contenu predictif — d'ou l'obligation de reporter les deux metriques
+  separement.
+- **Creneau** — `p_hat` **perd nettement** (0/5 graines, marge −0.137 ± 0.016) : a chaque saut, le
+  modele de vitesse sur-reagit et extrapole dans le vide.
+
+Le verdict honnete est donc : **l'anticipation de `p_hat` est regime-dependante** — reelle la ou la
+trajectoire a une inertie exploitable, illusoire ailleurs. C'est ce que la clause de falsifiabilite
+exigeait de rendre visible ; un banc a une seule famille l'aurait masque. L'AR(1), ajuste in-sample sur
+la serie complete, reste l'adversaire le plus dur partout — le battre sur le sinus n'en a que plus de
+valeur.",,,,,,,,d07276b7ab066026,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,ec48792e,markdown,fr,c6b6d9082d5ffecb,"### Exercice 3 — *sans complaisance* : le compromis de l'anticipation
+
+L'anticipation n'est pas gratuite. La vitesse **brute** (`alpha=1`, sans lissage) amplifie le bruit
+d'observation d'un facteur `lead` : en milieu bruite, `p_hat` peut alors devenir **pire** que la simple
+persistance. C'est un **compromis biais-variance** qu'il faut *mesurer*, pas masquer. Completez
+`gain_anticipation(bruit, alpha)` : le gain = erreur(persistance) − erreur(`p_hat`) a l'horizon `LEAD`
+(positif = `p_hat` utile), et observez qu'il **chute** quand `alpha -> 1` sur une proie bruitee.
+
+*Indices :* regenerer une proie `sin + bruit * randn` (graine fixe), construire `p_hat` avec l'`alpha`
+donne et le `suiveur`, puis comparer `cat.lead_error(..., LEAD)`.",,,,,,,,c6b6d9082d5ffecb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,15d9ce70,code,fr,45ee4fcfb1d46f3a,"def gain_anticipation(bruit, alpha):
+    """"""Gain de l'anticipation : lead_error(persistance) - lead_error(p_hat), a l'horizon LEAD.
+    Positif = p_hat utile ; chute vers <=0 si alpha=1 (vitesse brute) sur proie bruitee.
+    Renvoyer None tant que non complete.""""""
+    # TODO etudiant :
+    # g = np.random.default_rng(GRAINE)
+    # y = np.sin(t) + bruit * g.standard_normal(T)
+    # ph = cat.constant_velocity_tracker(y, lead=LEAD, alpha=alpha)
+    # su = cat.persistence_tracker(y)
+    # return cat.lead_error(su, y, LEAD) - cat.lead_error(ph, y, LEAD)
+    return None  # TODO
+
+# Verification (a decommenter) :
+# for al in [0.25, 0.5, 1.0]:
+#     print(f""bruit=0.20, alpha={al:.2f} -> gain anticipation = {gain_anticipation(0.20, al)}"")
+print(""Exercice 3 a completer : mesurer le compromis biais-variance (alpha=1 degrade en milieu bruite)."")",,,,,,,,45ee4fcfb1d46f3a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,2af67d4b,markdown,fr,890f4c8e8ce45d90,"## 5. *Sans complaisance* : la catastrophe n'est reelle que hors degenerescence
+
+La tentation serait de balayer $b$ **sans verifier $a<0$** et d'appeler « hysteresis » la courbe obtenue.
+Or a $a \geq 0$ il n'y a **qu'un** equilibre : le suivi est **continu**, **zero** saut, aire **nulle**.
+Annoncer une « scene actantielle » dans ce regime, c'est fabriquer un **phantome** — l'equivalent, pour
+les catastrophes, du « probleme degenere » (un A\* sur graphe a cout uniforme, ou un Z3 sur une contrainte
+qu'un `if` resout). On le **mesure** : meme balayage, deux regimes.",,,,,,,,890f4c8e8ce45d90,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,0d0ef4e7,code,fr,c1de0f554458910e,"b_up = np.linspace(-0.7, 0.7, 90); b_path = np.concatenate([b_up, b_up[::-1]])
+fig, axes = plt.subplots(1, 2, figsize=(13, 4.8), sharey=True)
+for ax, (a_, ttl) in zip(axes, [(-1.0, ""a=-1 : NON degenere (vraie fronce)""), (0.5, ""a=+0.5 : degenere (monostable)"")]):
+    xs = cat.hysteresis_loop(a_, b_path, x_start=cat.cusp_equilibria(a_, float(b_path[0]))[0][0])
+    nj = len(cat.loop_jumps(b_path, xs, threshold=0.5))
+    ar = abs(float(trapz(xs, b_path)))
+    ax.plot(b_path, xs, color=""crimson"" if a_ < 0 else ""grey"", lw=2)
+    ax.set_xlabel(""b""); ax.set_title(f""{ttl}\n{nj} catastrophe(s), aire = {ar:.3f}"")
+axes[0].set_ylabel(""etat x"")
+plt.suptitle(""Sans complaisance : la catastrophe ne se credite que dans le regime NON degenere (a<0)"")
+plt.tight_layout(); plt.show()
+
+for a_ in (-1.0, 0.5):
+    xs = cat.hysteresis_loop(a_, b_path, x_start=cat.cusp_equilibria(a_, float(b_path[0]))[0][0])
+    print(f""a={a_:+.1f} : {len(cat.loop_jumps(b_path, xs, 0.5))} saut(s), aire={abs(float(trapz(xs,b_path))):.3f}, bistable={cat.in_bistable_region(a_, 0.0)}"")",,,,,,,,c1de0f554458910e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,cf40873b,markdown,fr,f179a6aa94ab308c,"## 6. Portee et barreaux : du gradient basse-dimension aux systemes discrets
+
+**Le caveat, droit.** La theorie des catastrophes classe les singularites des **dynamiques gradient de
+basse dimension** (les 7 catastrophes elementaires couvrent $\leq 4$ parametres de controle). Un LLM
+n'est ni gradient (au sens dynamique), ni de basse dimension. **Appliquer la fronce litteralement a un
+reseau de milliards de parametres serait une categorie-erreur.** Thom lui-meme est explicitement
+**non-predictif** (Ch.2, p.51). Ce notebook fournit donc des **designs de mesure**, pas un modele de LLM.
+
+**Mais le pont n'est pas sans barreaux.** Le passage « peu d'attracteurs continus -> multitude d'unites
+discretes a couplage controle » est *deja* chez Thom : c'est sa transition animal->humain (Ch.2, p.35).
+Les barreaux intermediaires, dans nos series :
+
+| Barreau | Ou | Le passage qu'il instancie |
+|---|---|---|
+| **0. Linguistique de Thom** | Ch.2 & Ch.8 | preuve d'existence : grammaire discrete <- morphodynamique continue |
+| **1. Neurosymbolique** | serie neurosymbolique | l'ingenierie du couplage continu <-> symbolique discret |
+| **2. Lean** | serie Lean + harnais prover | l'objet discret de haute dimension (preuve = arbre), deja couple a du continu (selection de premisses guidee) — Ch.2 p.46 : *« la generativite interne au langage formel, sur laquelle l'homme n'a plus de prise une fois fixees les conditions initiales »* |
+| **3. Auto-encodeurs epars (SAE)** | cible lointaine | trouver le squelette discret de *features* dans la variete continue d'activations — *le meme geste que Thom*, a l'echelle, **sans** la garantie basse-dimension |
+
+Une brique candidate de veille a ete deposee (#4653) : les **arbres d'EML** (analogue *continu* de portes
+NAND), substrat possiblement « interpretable-par-construction » — a tester, **conjecture etiquetee comme
+telle**, et **hors ICT** (materiel serie neurosymbolique).
+
+**Suite immediate de la strate 2/3**, chaque metaphore restant attachee a une mesure :
+[ICT-11](#) (profils d'agence causale aux echelles micro/meso/macro) et **ICT-Synthese** (reunir $\Phi$,
+trajectoires, bassins, transitions, reparation, agence). Discipline de la serie : *ne pas ouvrir cinq
+fronts a la fois*.",,,,,,,,f179a6aa94ab308c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-10-CatastropheGrammar.ipynb,62f52a55,markdown,fr,caed6532f66b9f22,"## Conclusion — la grammaire tenue par la mesure
+
+On a tresse les deux fils, et le chapitre 2 de Thom les a noues a sa theorie du langage :
+
+| Le fil metaphorique (Thom) | Le fil de la mesure (ICT-10) |
+|---|---|
+| *l'obstacle engendre les etres* (metatheoreme) | le comptage d'equilibres ne change qu'aux **plis** : exactement 2 transitions |
+| les 4 transitions = pivots du langage enfantin (Ch.2 p.38) | naissance (1->3) et confluence/disparition (3->1), **mesurees** |
+| la phrase transitive SVO = chemin transverse a une catastrophe (Ch.2 p.42) | le **lacet de predation** : 2 catastrophes (J, K), aire non nulle |
+| capture $\neq$ emission : la scene est orientee | l'**aire signee** du cycle d'hysteresis = irreversibilite mesuree |
+| *anticiper la trajectoire de l'objet* (Ch.2 p.50) | `p_hat` : avantage **regime-dependant** — bat 3 baselines adverses sur trajectoire lisse (5/5 graines), perd sur derive et creneau |
+| « c'est une catastrophe » | **piege** : hors regime $a<0$, zero saut, aire nulle — phantome degenere |
+
+**Aucune image de Thom n'a ete declaree : chacune a ete mesuree** sur la fronce canonique. La strate 2
+(morphogenese) se referme sur son squelette catastrophique ; la strate 3 (agents) s'ouvre sur une scene
+actantielle et un representant interne dont l'anticipation est mesuree — et bornee a son regime de validite. Le pont vers les LLM reste **lointain et a barreaux**
+(section 6) — mais la regle ne change pas : *une metaphore n'entre dans ICT que lorsqu'elle est attachee a
+une mesure.*",,,,,,,,caed6532f66b9f22,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,b5a9e26c,markdown,fr,84c6f7812dcf9821,"# ICT-11 — Profils d'agence causale : à quelle échelle l'agence est-elle la plus lisible ?
+
+[← ICT-Series](README.md) | [↑ IIT](../README.md) | *Epic #4588, strate 3*
+
+ICT-9 a défini l'**agence** d'un système de réaction-diffusion comme sa capacité à **réparer** une forme ablatée (un retour vers un point de consigne *intrinsèque*), mesurée *par contraste* avec un contrôle passif — la diffusion pure qui dissout. Toute cette mesure, cependant, était posée à une résolution unique : celle du pixel.
+
+ICT-11 ouvre la **strate 3** en posant une question que l'émergence causale (Hoel) rend incontournable :
+
+> **À quelle échelle spatiale l'agence est-elle la plus lisible ?** La réparation se lit-elle mieux au pixel près (micro), à l'échelle des taches (méso), ou à celle de la texture globale (macro) ? Et cette échelle privilégiée — s'il y en a une — coïncide-t-elle avec celle où la dynamique est la *plus causalement déterminée* ?
+
+La promesse de l'émergence causale (Hoel 2013, 2025 ; voir ICT-5/6) est qu'une macro-échelle peut concentrer **plus de pouvoir causal** que la micro — l'« information effective » maximisée par coarse-graining. Le présent notebook confronte cette intuition à une mesure **sans complaisance** : on ne déclare pas d'échelle privilégiée, on la **cherche**, et l'on accepte le verdict honnête « pas de granularité privilégiée détectée » si aucune courbe ne présente de pic méso.
+
+## Les trois portes falsifiables (issue #4877)
+
+Le notebook ne sera crédité d'aucun résultat s'il ne passe pas ces trois gates :
+
+1. **Thèse réfutable (gate 1).** « L'agence est plus explicative à une échelle » n'est un résultat que si `repair_gain(échelle)`, `time_to_recover(échelle)` et `basin_return_probability(échelle)` produisent une **courbe non-monotone avec un pic identifiable** à une échelle méso. Courbes plates ou monotones → verdict honnête « pas de granularité privilégiée », **pas** un pic bricolé.
+2. **Raccord Hoel non-décoratif (gate 2).** L'`effective_information` est calculée **aux mêmes échelles** que les mesures d'agence, et la corrélation EI(échelle) ↔ agence(échelle) est **explicitement testée**. Sans ce raccord chiffré, ICT-11 n'est qu'ICT-9 re-tracé à plusieurs zooms.
+3. **Mêmes `do(.)` qu'ICT-9 (gate 3).** L'intervention `do(ablation)` est appliquée **pleine résolution**, **identiquement à chaque échelle** — seul le *zoom de mesure* change. Un contrôle qui varie avec l'échelle invalide la comparaison inter-échelles.
+
+Le fil conducteur reste la **régime-dépendance** découverte au Cran A (ICT-10, `p̂`) : une capacité peut être réelle dans un régime et illusoire ailleurs. Ici, le « régime » est l'échelle d'observation.",,,,,,,,84c6f7812dcf9821,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,3b920756,code,fr,62dc859b27459c50,"import os, sys
+import numpy as np
+import matplotlib.pyplot as plt
+sys.path.insert(0, os.getcwd())
+from ict import reaction_diffusion as rd
+from ict import agency as A
+from ict import multiscale_agency as M
+plt.rcParams[""figure.dpi""] = 110
+rng = np.random.default_rng(0)
+print(""ict modules charges (reaction_diffusion, agency, multiscale_agency)"")",,,,,,,,62dc859b27459c50,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,079cdc24,markdown,fr,0ce80b05ca7e40ae,"## 1. Le substrat et l'intervention `do(ablation)`
+
+On reprend exactement le substrat d'ICT-9 : le système de **Gray-Scott** en régime **mitotique** (Pearson 1993 ; `F = 0.0367`, `k = 0.0649`), grille `96 × 96`. On laisse le motif se former depuis un germe central : un réseau de taches auto-entretenu émerge, qui se divise et migre.
+
+L'intervention est la même qu'en ICT-9 : on **ablate** un quadrant — `do(ablation)` au sens de Pearl, qui force la région à l'état nu (`U = 1`, `V = 0`, « pas de motif ici ») — puis on observe la trajectoire de récupération. Deux **mondes contrefactuels** issus de cette même intervention : l'un sous réaction-diffusion (le système *répare*), l'autre sous diffusion pure (le contrôle passif *dissout*).
+
+**Gate 3 (rappel).** Cette ablation est faite **pleine résolution**, et elle est **identique à chaque échelle** testée ci-dessous. Ce qui change entre échelles n'est jamais l'intervention — c'est seulement le *zoom* auquel on mesure la récupération.",,,,,,,,0ce80b05ca7e40ae,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,39cd3f07,code,fr,c98824790fbd033f,"# Formation du motif mitotique (substrat ICT-9, grille 96x96)
+model = rd.GrayScott()           # F=0.0367, k=0.0649 (regime mitotique de Pearson)
+U_ref, V_ref = model.seed(n=96, block=12, noise=0.02, rng=np.random.default_rng(0))
+U_ref, V_ref, _ = model.run(U_ref, V_ref, 6000)   # formation
+S_ref = A.structure(V_ref)
+print(f""Motif forme : structure (variance de V) = {S_ref:.5f}"")
+
+# do(ablation) : quadrant haut-gauche, pleine resolution
+mask = A.quadrant_mask(96, quadrant=0)
+U_abl, V_abl = A.ablate(U_ref, V_ref, mask)
+
+fig, axes = plt.subplots(1, 3, figsize=(11, 3.4))
+for ax, field, title in [(axes[0], V_ref, ""V reference (forme)""),
+                          (axes[1], V_abl, ""V apres do(ablation)""),
+                          (axes[2], mask.astype(float), ""masque d'ablation"")]:
+    ax.imshow(field, cmap=""viridis""); ax.set_title(title, fontsize=10); ax.axis(""off"")
+plt.tight_layout(); plt.show()",,,,,,,,c98824790fbd033f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,162db9c6,markdown,fr,cf967a8e98955bc4,"## 2. Les échelles de mesure : le coarse-graining spatial
+
+On définit l'échelle par la **taille de bloc** `b` du moyennage spatial : à l'échelle `b`, le champ `96 × 96` est réduit à `(96/b) × (96/b)` super-cellules, chacune égale à la moyenne des `b × b` pixels qu'elle couvre. C'est l'opération qu'un observateur à cette résolution ferait naturellement : il ne voit pas les pixels, il voit des taches moyennées.
+
+- **micro** (`b = 4`) : grille `24 × 24` = 576 super-cellules — les taches individuelles sont résolues ;
+- **méso** (`b = 8`) : grille `12 × 12` = 144 super-cellules — la structure des taches commence à se moyenner ;
+- **méso large** (`b = 16`) : grille `6 × 6` = 36 super-cellules — seules les grandes régions restent ;
+- **macro** (`b = 32`) : grille `3 × 3` = 9 super-cellules — la texture globale seule.
+
+On visualise le champ `V` de référence à chacune de ces résolutions : c'est le *même* motif, observé à quatre zooms.",,,,,,,,cf967a8e98955bc4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,fd3df2ee,code,fr,5fbe0711ad55e281,"SCALES = [4, 8, 16, 32]
+NOMS = {4: ""micro (b=4)"", 8: ""meso (b=8)"", 16: ""meso large (b=16)"", 32: ""macro (b=32)""}
+
+fig, axes = plt.subplots(1, len(SCALES), figsize=(12, 3.2))
+for ax, b in zip(axes, SCALES):
+    ax.imshow(M.block_average(V_ref, b), cmap=""viridis"")
+    ax.set_title(f""{NOMS[b]}\ngrille {96//b}x{96//b}"", fontsize=9); ax.axis(""off"")
+plt.suptitle(""Le meme motif V a quatre resolutions de mesure"", y=1.02)
+plt.tight_layout(); plt.show()
+
+# structure de reference a chaque echelle (la macro-variable du gate 2)
+for b in SCALES:
+    print(f""{NOMS[b]:18s} structure de reference = {M.structure_at_scale(V_ref, b):.5f}"")",,,,,,,,5fbe0711ad55e281,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,305eff3c,markdown,fr,342dd385d1060794,"## 3. Gate 1 — les courbes d'agence selon l'échelle
+
+On calcule, à chaque échelle `b`, les trois mesures d'agence canoniques d'ICT-9 — mais **résolues à l'échelle `b`** : les champs sont moyennés par blocs *avant* la mesure.
+
+- **`repair_gain(b)`** : récupération (réaction-diffusion) moins récupération (diffusion pure), dans la région ablatée projetée à l'échelle `b`. C'est la mesure d'agence centrale.
+- **`time_to_recover(b)`** : premier pas où la structure régionale repasse au-dessus de la cible.
+- **`basin_return_probability(b)`** : fraction d'ablations aléatoires (disques) après lesquelles le système revient au bassin du motif, structure mesurée à l'échelle `b`.
+
+**Gate 1.** La thèse « l'agence est plus lisible à une échelle » exige une **courbe non-monotone avec un pic méso identifiable** sur au moins une de ces trois mesures. Des courbes plates ou monotones (l'agence croît ou décroît uniformément avec l'échelle) => verdict honnête : pas de granularité privilégiée.",,,,,,,,342dd385d1060794,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,33ec78a3,code,fr,f2278571d9eed588,"STEPS, REC = 2500, 50          # pas de recuperation, echantillonnage
+# (a) repair_gain et time_to_recover, echelle par echelle (meme do(.) pleine resolution)
+profils = {}
+for b in SCALES:
+    profils[b] = M.agency_measures_at_scale(model, model.Dv, U_ref, V_ref, mask,
+                                            block=b, steps=STEPS, record_every=REC)
+    p = profils[b]
+    ttr = p[""time_to_recover""]
+    print(f""{NOMS[b]:18s} repair_gain={p['repair_gain']:+.4f}  ""
+          f""rec_RD={p['recovery_RD']:+.3f}  rec_diff={p['recovery_diff']:+.3f}  ""
+          f""time_to_recover={'jamais' if ttr is None else str(ttr)}"")
+
+# (b) basin_return_probability(b) : ablations disque aleatoires, retour au bassin
+def disk_mask_factory(n):
+    def _make(rng):
+        return A.disk_mask(n, cx=rng.integers(8, n-8), cy=rng.integers(8, n-8), radius=6)
+    return _make
+make_disk = disk_mask_factory(96)
+basin_p = {}
+for b in SCALES:
+    target_b = float(np.var(M.block_average(V_ref, b)))
+    basin_p[b] = M.basin_return_at_scale(model, U_ref, V_ref, make_disk, block=b,
+                                         steps=STEPS, target_structure=target_b,
+                                         n_trials=4, rng=np.random.default_rng(1))
+    print(f""{NOMS[b]:18s} basin_return_probability={basin_p[b]:.2f}""
+          f""  (n_trials=4, cible var blocs = {target_b:.5f})"")",,,,,,,,f2278571d9eed588,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,594b3651,code,fr,10b18aa88ac1f595,"# Courbes d'agence vs echelle
+rg  = [profils[b][""repair_gain""] for b in SCALES]
+ttr = [profils[b][""time_to_recover""] for b in SCALES]
+ttr_plot = [(STEPS + 1) if t is None else t for t in ttr]   # 'jamais' -> plafond
+bp  = [basin_p[b] for b in SCALES]
+
+fig, axes = plt.subplots(1, 3, figsize=(13, 3.6))
+xs = [96 // b for b in SCALES]   # nombre de super-cellules par cote (micro -> macro = grand -> petit)
+xlabels = [NOMS[b] for b in SCALES]
+for ax, ys, ylabel, title in [
+    (axes[0], rg, ""repair_gain (rec_RD - rec_diff)"", ""Gain de reparation""),
+    (axes[1], ttr_plot, ""pas de recuperation"", ""Delai de recuperation""),
+    (axes[2], bp, ""fraction de retour au bassin"", ""Probabilite de retour"")]:
+    ax.plot(range(len(SCALES)), ys, ""o-"", color=""crimson"")
+    ax.set_xticks(range(len(SCALES))); ax.set_xticklabels(xlabels, fontsize=8, rotation=20)
+    ax.set_ylabel(ylabel, fontsize=9); ax.set_title(title, fontsize=10)
+    ax.grid(alpha=0.3)
+plt.suptitle(""Gate 1 : agence selon l'echelle (pic meso => granularite privilegiee)"", y=1.03)
+plt.tight_layout(); plt.show()
+
+# Test automatique du gate 1 : pic INTERIEUR (non-monotone) sur repair_gain ?
+def pic_interieur(ys):
+    y = np.asarray(ys, float)
+    i = int(np.argmax(y))
+    return 0 < i < len(y) - 1 and y[i] > min(y[0], y[-1])
+print(f""\nGate 1 (repair_gain) : pic interieur non-monotone ? {pic_interieur(rg)}"")
+print(f""Gate 1 (basin_return) : pic interieur non-monotone ? {pic_interieur(bp)}"")",,,,,,,,10b18aa88ac1f595,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,33b1fac2,markdown,fr,65af10c59b69c11e,"### Lecture du gate 1 — deux mesures d'agence qui se contredisent
+
+Les nombres ci-dessus livrent un résultat **sans complaisance** : les deux mesures d'agence **ne disent pas la même chose** selon l'échelle.
+
+- **`repair_gain`** présente un pic intérieur (max à `b = 16`, méso large), donc le test mécanique `pic_interieur` renvoie `True`. Mais ce pic est **artefact-contaminé** de deux façons : (i) à `b = 16`, `rec_RD ≈ +2.31` — le score de récupération **dépasse 1**, signe de *sur-reconstruction* (le moyennage par blocs amplifie la variance regagnée dans la région ablatée) ; (ii) à `b = 32`, `repair_gain = 0.0000` exactement — un **plancher de résolution** (à 9 super-cellules, la variance de référence dans la région ablatée s'effondre et le dénominateur du score devient nul). Le « pic » est donc le produit d'un sommet inflaté et d'un plancher artefactuel, pas d'un maximum physique.
+- **`basin_return_probability`**, la mesure la plus directe (« le système revient-il à son bassin après une ablation aléatoire ? »), est **strictement décroissante** avec l'échelle (`1.0 → 0.5 → 0.0 → 0.0`) : plus on mesure grossièrement, moins le retour au bassin est jugé réussi. **Aucun pic intérieur.**
+
+Verdict du gate 1 : **pas de granularité privilégiée robuste**. L'apparent pic de `repair_gain` à l'échelle méso ne survit pas au contrôle croisé de `basin_return` — c'est le régime-dépendance d'ICT-10 sous une autre forme : une capacité (une granularité privilégiée) qui *paraît* sous une mesure et *s'évanouit* sous une mesure plus dure.",,,,,,,,65af10c59b69c11e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,48c31125,markdown,fr,0324db6c4c3dd24b,"## 4. Gate 2 — le raccord Hoel : champs → TPM → information effective
+
+Le pont entre la mesure d'agence (champs) et la mesure causale de Hoel (TPM) passe par une **macro-variable scalaire** : à chaque échelle `b`, on résume le champ par sa **structure à cette échelle**, c'est-à-dire la variance du champ moyenné par blocs de cote `b`. Trois propriétés motivent ce choix :
+
+1. **elle dépend de l'échelle** — le moyennage par blocs réduit la variance, donc la valeur décroît quand `b` augmente (contrairement à la moyenne globale, invariante par coarse-graining, qui ne distinguerait pas les échelles) ;
+2. **elle ne sature pas** — pendant la récupération elle traverse plusieurs niveaux, ce qui produit une TPM **non triviale** à toutes les échelles (un compte de blocs actifs, en revanche, sature aux échelles grossières et donne une TPM dégénérée à 1 état, d'où une effectiveness=1.0 *vacueuse* — cet écueil est documenté dans le module) ;
+3. **elle est directement couplée à l'agence** — c'est la grandeur même dont le gate 1 mesure la restauration, donc le raccord EI(échelle) ↔ agence(échelle) porte sur la même quantité.
+
+Cette macro-variable est discrétisée en `n_bins` niveaux (quantiles). Pour chaque échelle, on lance plusieurs trajectoires de récupération depuis des ablations variées, on pool leurs transitions de macro-états, et l'on estime une **TPM empirique** dont on calcule l'`effectiveness` (déterminisme moins dégénérescence, primitive *scale-free*).
+
+**Gate 2.** Si l'émergence causale de Hoel prédit où l'agence se lit le mieux, alors `effectiveness(échelle)` doit **corréler** avec la mesure d'agence. On teste cette corrélation **uniquement sur les échelles dont la TPM est non dégénérée** (`n_observed >= 2`) — une TPM à 1 état a une effectiveness=1.0 *par construction* (un seul état = déterminisme parfait trivial) et ne doit pas entrer dans la corrélation.",,,,,,,,0324db6c4c3dd24b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,58971d0c,code,fr,bd47d53d21d867f9,"N_BINS, N_SEEDS = 8, 4
+def quadrant_factory(n):
+    def _make(rng):
+        return A.quadrant_mask(n, quadrant=int(rng.integers(0, 4)))
+    return _make
+make_quad = quadrant_factory(96)
+
+eff_profile = {}
+for b in SCALES:
+    r = M.effectiveness_at_scale(model, U_ref, V_ref, make_quad, block=b,
+                                 steps=STEPS, record_every=REC,
+                                 n_bins=N_BINS, n_seeds=N_SEEDS, rng=np.random.default_rng(2))
+    eff_profile[b] = r
+    print(f""{NOMS[b]:18s} effectiveness={r['effectiveness']:.4f}  ""
+          f""EI_bits={r['effective_information']:.4f}  n_etats_obs={r['n_observed']}""
+          f""  {'(DEGENERE)' if r['n_observed'] < 2 else ''}"")",,,,,,,,bd47d53d21d867f9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,52039cfa,code,fr,c81f02458eaaccd0,"eff  = [eff_profile[b][""effectiveness""] for b in SCALES]
+ei_b = [eff_profile[b][""effective_information""] for b in SCALES]
+nobs = [eff_profile[b][""n_observed""] for b in SCALES]
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 3.6))
+for ax, ys, ylabel, title in [(axes[0], eff, ""effectiveness (det - deg, scale-free)"", ""Effectiveness""),
+                               (axes[1], ei_b, ""information effective (bits)"", ""EI (bits, reporte)"")]:
+    ax.plot(range(len(SCALES)), ys, ""s-"", color=""steelblue"")
+    ax.set_xticks(range(len(SCALES))); ax.set_xticklabels(xlabels, fontsize=8, rotation=20)
+    ax.set_ylabel(ylabel, fontsize=9); ax.set_title(title, fontsize=10); ax.grid(alpha=0.3)
+plt.suptitle(""Gate 2 : pouvoir causal (Hoel) de la macro-variable selon l'echelle"", y=1.03)
+plt.tight_layout(); plt.show()
+
+# Correlation EI(echelle) <-> agence(echelle) sur les seules echelles NON DEGENEREES
+valid = [b for b in SCALES if eff_profile[b][""n_observed""] >= 2]
+eff_v  = [eff_profile[b][""effectiveness""] for b in valid]
+rg_v   = [profils[b][""repair_gain""] for b in valid]
+bp_v   = [basin_p[b] for b in valid]
+r_eff_rg, n = M.pearson_corr(eff_v, rg_v)
+r_eff_bp, _ = M.pearson_corr(eff_v, bp_v)
+print(f""Echelles non degenerees (n_obs>=2) : {[NOMS[b] for b in valid]}"")
+print(f""Correlation effectiveness <-> repair_gain : r = {r_eff_rg} (n={n})"")
+print(f""Correlation effectiveness <-> basin_return : r = {r_eff_bp} (n={n})"")
+print(""(r > 0 : le pouvoir causal macro suit l'agence ; r ~ 0 : raccord decoratif)"")
+print(f""\nNB : {len(SCALES) - len(valid)} echelle(s) degeneree(s) (TPM a 1 etat, effectiveness=1.0 trivial) exclue(s)"")",,,,,,,,c81f02458eaaccd0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,4839ec00,markdown,fr,d35c4d2fcb8df8db,"### Lecture du gate 2 — un raccord Hoel suggestif mais non robuste
+
+Avec la macro-variable `structure(b)`, **aucune** TPM n'est dégénérée (`n_observed = 8` aux quatre échelles) — la mesure est cette fois comparable d'échelle à échelle. La corrélation entre `effectiveness` et `repair_gain` vaut **`r ≈ +0.50`** (`n = 4`) : un signal *faiblement positif*. Les deux courbes culminent toutes deux à `b = 16`.
+
+Mais ce signal **ne tient pas** au contrôle croisé : la corrélation entre `effectiveness` et `basin_return` est **`r ≈ −0.14`**, c'est-à-dire nulle. Or `basin_return` est la mesure d'agence la plus directe (retour au bassin après ablation aléatoire), celle qui *ne* présentait pas de pic artefactuel au gate 1. Le raccord Hoel **suit la mesure inflatée** (`repair_gain`, sur-reconstruite à `b = 16`) et **ignore la mesure honnête** (`basin_return`).
+
+Caveats documentés sans complaisance : `n = 4` échelles est petit, et la TPM est estimée sur `n_seeds = 4` trajectoires seulement (l'Exercice 2 teste la robustesse à `n_seeds = 8`). Avec ces réserves, le verdict du gate 2 est : **raccord suggestif, non robuste** — l'`effectiveness` de Hoel n'éclaire pas de façon fiable *où* l'agence se lit le mieux sur ce système.",,,,,,,,d35c4d2fcb8df8db,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,b3deb376,markdown,fr,b1dba54d866cc225,"## 5. Verdict sans complaisance
+
+Les deux gates se croisent en un tableau unique : à chaque échelle, la mesure d'agence (`repair_gain`) et la mesure causale (`effectiveness`), plus la corrélation qui les lie (ou non). Le verdict est dicté par les nombres réels ci-dessus, pas par l'intuition de départ.",,,,,,,,b1dba54d866cc225,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,9f1efbd0,code,fr,d1cc9e785a3982c0,"print(f""{'echelle':18s} {'repair_gain':>12s} {'basin_ret':>10s} {'effectiv.':>10s} {'EI(bits)':>9s}"")
+for b in SCALES:
+    print(f""{NOMS[b]:18s} {profils[b]['repair_gain']:>+12.4f} {basin_p[b]:>10.2f} ""
+          f""{eff_profile[b]['effectiveness']:>10.4f} {eff_profile[b]['effective_information']:>9.4f}"")
+print(f""\nPic interieur d'agence (gate 1)      : repair_gain={pic_interieur(rg)}, basin={pic_interieur(bp)}"")
+print(f""Correlation effectiveness<->repair_gain : r={r_eff_rg}"")
+print(f""Correlation effectiveness<->basin_return: r={r_eff_bp}"")
+print(""\n--> Verdict dicte par les nombres ci-dessus (voir cellule de texte suivante)."")",,,,,,,,d1cc9e785a3982c0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,ab1cdb61,markdown,fr,f0540ddf51824578,"### Ce que disent les nombres — un résultat négatif robuste
+
+Le tableau ci-dessus tranche : **l'hypothèse d'une granularité méso privilégiée n'est pas confirmée.** Trois constats convergent, tous défavorables à l'intuition de départ :
+
+1. **Les deux mesures d'agence se contredisent** (gate 1). `repair_gain` présente un « pic » à `b = 16`, mais `basin_return_probability` — la mesure la plus directe du retour au bassin — est strictement décroissante. Une granularité privilégiée authentique se lirait sur les *deux* ; elle ne se lit que sur la mesure dont le pic est un artefact de sur-reconstruction (`rec_RD > 1`) bordé par un plancher de résolution (`b = 32`).
+2. **Le raccord Hoel suit la mauvaise mesure** (gate 2). L'`effectiveness` corréle faiblement avec `repair_gain` (`r ≈ +0.50`) — la mesure inflatée — et *pas du tout* avec `basin_return` (`r ≈ −0.14`) — la mesure honnête. Si l'émergence causale éclairait vraiment *où* l'agence se lit le mieux, elle suivrait la mesure directe ; elle ne le fait pas.
+3. **Aucune échelle ne domine causalement** (gate 2). L'`effectiveness` vaut `0.71 / 0.50 / 0.79 / 0.63` selon l'échelle — des variations modestes, sans sommet net. Le coarse-graining ne concentre pas le pouvoir causal sur une échelle du motif de Gray-Scott.
+
+Le verdict honnête est donc : **pas de granularité privilégiée détectée**. L'idée séduisante qu'une macro-échelle concentrerait à la fois l'agence et le pouvoir causal — l'émergence causale « à la Hoel » appliquée à la morphogenèse — **ne survit pas** au banc falsifiable multi-échelles et multi-mesures. C'est un résultat négatif, et il est conforme au fil **régime-dépendance** tissé depuis ICT-10 (`p̂`) : une capacité (ici, « l'agence émerge à une échelle ») peut paraître réelle sous une mesure et s'évanouir sous un contrôle plus dur.
+
+C'est précisément la discipline « sans complaisance » de la série : la mesure peut **réfuter** l'intuition. Le lecteur est invité à relire les nombres plutôt que ce commentaire — et à tester (Exercice 3) si un *autre* régime morphologique, mieux séparé en échelles, invaliderait ce verdict négatif.
+
+> **Lien avec la strate 3.** ICT-11 est le premier toy model où l'on demande au système *à quelle échelle* il « connaît » sa propre forme. Le verdict négatif calibre l'attente pour la suite : on ne présuppose pas qu'une macro-échelle « émerge ». ICT-12 poussera la question vers des agents mobiles dans un champ de valence (où `p̂` du Cran A devient un modèle interne optionnel) ; ICT-13 vers les stratégies comme formes stables. Si une granularité causale devait apparaître, c'est sur des systèmes dont la structure est *générativement* multi-échelles (non un motif quasi-uniforme comme Gray-Scott mitotique) qu'elle aurait le plus de chances — piste ouverte, pas conclusion.",,,,,,,,f0540ddf51824578,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,b462f577,markdown,fr,d90e6ab4882644a8,"## 6. Exercices
+
+> Les exercices sont à compléter. Ils respectent la convention C.1 : stub **sans erreur volontaire** (le notebook s'exécute de bout en bout même non complété).",,,,,,,,d90e6ab4882644a8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,495eb1d0,markdown,fr,98690cf70d337722,"### Exercice 1 — Une cinquième échelle
+
+Ajoutez une échelle **intermédiaire** (par exemple `b = 6` ou `b = 12`, qui divisent 96) au profil, et observez si le pic d'agence (gate 1) se déplace. La granularité privilégiée, si elle existe, dépend-elle du choix des échelles échantillonnées ?
+
+*Indice : `96 // 6 = 16`, `96 // 12 = 8`. Réinjectez `b` dans `agency_measures_at_scale` et comparez au tableau du §5.*",,,,,,,,98690cf70d337722,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,26295092,code,fr,ad8861c7092682dc,"# Exercice 1 : ajouter une echelle intermediaire au profil d'agence
+# b_extra = 6
+# profil_extra = M.agency_measures_at_scale(model, model.Dv, U_ref, V_ref, mask,
+#                                           block=b_extra, steps=STEPS, record_every=REC)
+# print(f""b={b_extra} : repair_gain = {profil_extra['repair_gain']:+.4f}"")
+# TODO etudiant : comparer au pic des echelles 4/8/16/32",,,,,,,,ad8861c7092682dc,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,64aeabf9,markdown,fr,63ef5edad246503a,"### Exercice 2 — Robustesse du raccord Hoel
+
+La corrélation `effectiveness ↔ repair_gain` (gate 2) est estimée sur `n_seeds = 4` trajectoires. Recalculez-la avec `n_seeds = 8` (estimation plus robuste de la TPM) et vérifiez que le signe de la corrélation est stable. Une TPM estimée sur trop peu de transitions peut-elle fabriquer une corrélation spurieuse ?
+
+*Indice : appelez `M.effectiveness_at_scale(..., n_seeds=8)` pour chaque échelle, puis `M.pearson_corr`.*",,,,,,,,63ef5edad246503a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,27f08af0,code,fr,7cd0865f4d30bd86,"# Exercice 2 : robustesse de la correlation effectiveness <-> repair_gain
+# eff_robuste = []
+# for b in SCALES:
+#     r = M.effectiveness_at_scale(model, U_ref, V_ref, make_quad, block=b,
+#                                  threshold=THRESHOLD, steps=STEPS, record_every=REC,
+#                                  n_bins=N_BINS, n_seeds=8, rng=np.random.default_rng(7))
+#     eff_robuste.append(r[""effectiveness""])
+# r_robuste, _ = M.pearson_corr(eff_robuste, rg)
+# TODO etudiant : r_robuste est-il du meme signe que r_eff_rg ?",,,,,,,,7cd0865f4d30bd86,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,9b031a4a,markdown,fr,8f51d3869dd8ab6e,"### Exercice 3 — Changer de régime morphologique
+
+Le régime mitotique (`F = 0.0367`, `k = 0.0649`) n'est qu'un point de l'espace de Gray-Scott. Refaites le profil d'agence multi-échelle dans un **autre régime** (par exemple `k = 0.060` pour des rayures, ou `F = 0.025`, `k = 0.060` pour un régime de « mousse »). La granularité privilégiée est-elle **invariante** ou dépend-elle du régime — confirmation du fil régime-dépendance ?
+
+*Indice : `model2 = rd.GrayScott(F=..., k=...)`, reformez un motif, relancez le §3. Un régime qui ne forme pas de motif stable donnera `repair_gain ≈ 0` à toutes les échelles (pas d'agence à réparer) — c'est aussi un résultat.*",,,,,,,,8f51d3869dd8ab6e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,59303ef0,code,fr,c13a39d28c23b07b,"# Exercice 3 : profil multi-echelle dans un autre regime morphologique
+# model2 = rd.GrayScott(F=0.025, k=0.060)   # regime ""mousse"" (a verifier)
+# U2, V2 = model2.seed(n=96, rng=np.random.default_rng(0))
+# U2, V2, _ = model2.run(U2, V2, 6000)
+# TODO etudiant : relancer agency_measures_at_scale sur (U2, V2) aux 4 echelles
+# et comparer les pics. Le verdict ""granularite privilegiee"" est-il invariant ?",,,,,,,,c13a39d28c23b07b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-11-CausalAgencyProfiles.ipynb,14f9d0c8,markdown,fr,480e73f9692d9546,"---
+*ICT-11 — Profils d'agence causale. Epic #4588, strate 3. Suite : ICT-12 (champs de valence et animats), ICT-13 (stratégies comme formes stables). Voir [ICT-0-Framing](ICT-0-Framing.md) pour le cadrage de la série.*",,,,,,,,480e73f9692d9546,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,f42cc0ee,markdown,fr,aeacaa85fe7d198c,"# ICT-12 — Champs de valence et animats : roles mesures, modele interne payant ou ruineux
+
+**Sous-serie ICT** (trajectoires integrees, Epic #4588, strate 3). Suite du Cran A
+ICT-10 (durcissement du banc $\hat{p}$, verdict honnete « avantage regime-dependant »)
+et d'ICT-11 (profils d'agence multi-echelle). Voir [#4588](../README.md), [#4878](https://github.com/jsboige/CoursIA/issues/4878).
+
+## Question directrice
+
+Premier toy model **actantiel spatial** : des animats evoluent dans un **champ de
+valence** (source attractive + obstacles repulsifs). La scene actantielle de Thom
+cesse d'etre une correspondance nommee : les **roles deviennent des grandeurs
+mesurees** sur trajectoires. Le $\hat{p}$ d'ICT-10 devient le **modele interne
+optionnel** de l'animat :
+
+> *Dans quels environnements un modele interne (anticipateur) paie-t-il son cout ?*
+
+Deux animats, un meme environnement :
+- le **reactif** suit le gradient de valence (il vise la ou la source *est*) ;
+  c'est la version spatiale de la baseline *persistance* du Cran A ;
+- l'**anticipateur $\hat{p}$** extrapole la position future de la source et vise
+  son point d'interception (la ou elle *sera*).
+
+## Gates de merge (falsifiables)
+
+1. **Pas de cas degenere** (#3801 prong B) : >= 3 regimes, dont au moins un ou
+   $\hat{p}$ **perd** contre le reactif. Verdict **par regime, jamais agrege**.
+2. **Roles mesures, pas declares** : chaque role lisible depuis la trajectoire
+   seule (4 metriques) avec controle d'ablation (marche aleatoire).
+3. **Baselines adverses du Cran A** (persistance, moyenne mobile, AR(1)) pour
+   tout claim d'anticipation 2D.
+4. **Verdict sans complaisance** : la ou $\hat{p}$ echoue, c'est visible en
+   sortie commitee.
+
+**Kernel** : Python 3 (numpy CPU pur, gel GPU respecte). Module : `ict/valence.py`.
+",,,,,,,,aeacaa85fe7d198c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,d75553ca,code,fr,d6556a29e7772a97,"import sys, os
+sys.path.insert(0, os.getcwd())  # ICT-Series/ pour `from ict import valence`
+
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+%matplotlib inline
+
+from ict import valence as V
+from ict import catastrophe as C   # baselines Cran A (pour reference)
+
+np.random.seed(0)
+SIZE, NSTEPS = 32, 200
+print(""Module ict.valence charge. Regimes:"", V.source_trajectory.__doc__.split('*')[1:2])
+",,,,,,,,d6556a29e7772a97,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,98103d34,markdown,fr,dbfc3d26188dcac3,"## 1. Le champ de valence
+
+Valence scalaire continue : bosse gaussienne **attractive** a la source, bosses
+gaussiennes **repulsives** aux obstacles. Le gradient analytique donne a l'animat
+reactif une pente propre (pas de discretisation). Visualisation sur grille pour
+l'oeil.",,,,,,,,dbfc3d26188dcac3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,c9a1e49e,code,fr,5bf9d678f69937c8,"fig, axes = plt.subplots(1, 4, figsize=(15, 3.6))
+rng = np.random.default_rng(1)
+for ax, kind in zip(axes, [""statique"", ""balistique"", ""erratique"", ""bruite""]):
+    src = V.source_trajectory(kind, NSTEPS, SIZE, rng=rng, start=V.center_start(SIZE))
+    grid = V.valence_grid(SIZE, src[-1])
+    ax.imshow(grid, origin=""upper"", cmap=""RdBu_r"", vmin=-0.8, vmax=1.0)
+    ax.plot(src[:, 1], src[:, 0], ""k-"", lw=0.8, alpha=0.6, label=""source"")
+    ax.plot(src[0, 1], src[0, 0], ""g^"", ms=6); ax.plot(src[-1, 1], src[-1, 0], ""r*"", ms=10)
+    ax.set_title(kind); ax.set_xticks([]); ax.set_yticks([])
+fig.suptitle(""Champ de valence final et trajectoire de la source (4 regimes)"", y=1.02)
+fig.tight_layout(); plt.show()
+",,,,,,,,5bf9d678f69937c8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,b0fc6139,markdown,fr,d054ba49e12592f8,"## 2. Les deux animats sur une source balistique
+
+Le **reactif** (pleine vitesse vers le gradient courant) poursuit la source ; il
+la suit avec un retard de l'ordre de la vitesse. L'**anticipateur $\hat{p}$**
+calcule un lead d'interception adapte au temps de fermeture et vise le point de
+rencontre. Sur du balistique previsible, il doit devancer la poursuite.",,,,,,,,d054ba49e12592f8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,fb674051,code,fr,7d4ea5bb0f15b6d3,"rng = np.random.default_rng(7)
+src = V.source_trajectory(""balistique"", NSTEPS, SIZE, rng=rng, speed=1.2, start=V.center_start(SIZE))
+start = np.array([4.0, 4.0])
+tr_r = V.simulate_reactive(src, SIZE, start, NSTEPS)
+tr_p = V.simulate_phat(src, SIZE, start, NSTEPS, lead=4)
+
+fig, ax = plt.subplots(figsize=(6, 6))
+ax.imshow(V.valence_grid(SIZE, src[-1]), origin=""upper"", cmap=""RdBu_r"", alpha=0.35, vmin=-0.8, vmax=1.0)
+ax.plot(src[:, 1], src[:, 0], ""k-"", lw=1.0, alpha=0.5, label=""source"")
+ax.plot(tr_r[:, 1], tr_r[:, 0], ""b-"", lw=1.2, label=""reactif (gradient)"")
+ax.plot(tr_p[:, 1], tr_p[:, 0], ""r-"", lw=1.2, label=""anticipateur $\\hat{p}$"")
+ax.plot(start[1], start[0], ""ks"", ms=7)
+ax.legend(loc=""upper right"", fontsize=9); ax.set_title(""Poursuite vs interception (source balistique rapide)"")
+ax.set_xticks([]); ax.set_yticks([])
+fig.tight_layout(); plt.show()
+",,,,,,,,7d4ea5bb0f15b6d3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,8000cfdf,markdown,fr,a4ed95831d88d1d6,"## 3. Gate 1 — capture par regime (verdict jamais agrege)
+
+**Cadence de capture** sur la fenetre post-convergence (burn-in exclu, rayon
+serre) : une mesure de **precision de poursuite**, pas de decouverte. On cherche
+les regimes ou $\hat{p}$ **gagne** et ceux ou il **perd**.
+
+### Vitesse attrapable (source ~ animat)",,,,,,,,a4ed95831d88d1d6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,7690f2f6,code,fr,4c17e7c201f220c0,"rng = np.random.default_rng(42)
+print(f""{'regime':11s} | {'reactif':>8s} | {'phat':>8s} | {'aleatoire':>9s} | verdict"")
+print(""-"" * 64)
+for kind in [""statique"", ""balistique"", ""erratique"", ""bruite""]:
+    rep = V.regime_report(kind, size=SIZE, n_steps=NSTEPS, n_seeds=5, lead=4,
+                          speed=0.8, capture_radius=1.0, capture_burn=100, rng=rng)
+    cr, cp, ca = rep[""reactif""][""capture""], rep[""phat""][""capture""], rep[""aleatoire""][""capture""]
+    v = ""PHAT GAGNE"" if cp > cr * 1.05 else (""PHAT PERD"" if cp < cr * 0.95 else ""egalite"")
+    print(f""{kind:11s} | {cr:8.3f} | {cp:8.3f} | {ca:9.3f} | {v}"")
+",,,,,,,,4c17e7c201f220c0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,93a56c23,markdown,fr,74cf377c212bb27f,"Le reactif (gradient instantane, pleine vitesse) est une baseline
+**proche de l'optimal** pour la capture a vitesse attrapable : $\hat{p}$ ne la
+bat nulle part et **perd en regime erratique** (ses predictions sont trompees
+par les renversements de cap). La ou $\hat{p}$ doit payer, c'est quand la source
+**echappe** au reactif.
+
+### Source trop rapide pour le reactif (speed 1.2 > step 0.8)",,,,,,,,74cf377c212bb27f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,bf303134,code,fr,9bc0f7f1387f4c46,"rng = np.random.default_rng(13)
+print(f""{'regime':11s} | {'reactif':>8s} | {'phat':>8s} | verdict   (source rapide)"")
+print(""-"" * 58)
+for kind in [""balistique"", ""erratique""]:
+    rep = V.regime_report(kind, size=SIZE, n_steps=NSTEPS, n_seeds=5, lead=4,
+                          speed=1.2, capture_radius=1.0, capture_burn=100, rng=rng)
+    cr, cp = rep[""reactif""][""capture""], rep[""phat""][""capture""]
+    v = ""PHAT GAGNE"" if cp > cr * 1.05 else (""PHAT PERD"" if cp < cr * 0.95 else ""egalite"")
+    print(f""{kind:11s} | {cr:8.3f} | {cp:8.3f} | {v}"")
+print()
+print(""-> Quand la source depasse le reactif, l'interception de p_hat paye en balistique"")
+print(""   (le reactif laggué ne peut suivre) : c'est le regime gagnant du gate 1."")
+",,,,,,,,9bc0f7f1387f4c46,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,a2ef4246,markdown,fr,7968cce91992be45,"## 4. Gate 3 — anticipation 2D vs baselines adverses du Cran A
+
+Pour tout claim d'anticipation, on confronte la **prediction** de $\hat{p}$
+aux trois baselines adverses (persistance, moyenne mobile, AR(1)) sur l'erreur
+quadratique de position a l'horizon. Ces baselines sont **avantagees in-sample**
+(adversaires severes, pas hommes de paille).",,,,,,,,7968cce91992be45,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,0b178c11,code,fr,f5800f4c2f434679,"print(f""{'regime':11s} | {'p_hat':>7s} | {'pers':>7s} | {'MA':>7s} | {'AR1':>7s} | verdict anticipation"")
+print(""-"" * 72)
+lead = 4
+errs = {}
+for kind in [""statique"", ""balistique"", ""erratique"", ""bruite""]:
+    rng2 = np.random.default_rng(100)
+    src = V.source_trajectory(kind, NSTEPS, SIZE, rng=rng2, start=V.center_start(SIZE))
+    phat = V.phat_predicted_trajectory(src, lead=lead)
+    pers = V.persistence_trajectory_2d(src)
+    ma = V.moving_average_trajectory_2d(src)
+    ar1 = V.ar1_trajectory_2d(src, lead=lead)
+    e = lambda p: V.anticipation_error_2d(p, src, lead)
+    e_ph, e_pe, e_ma, e_ar = e(phat), e(pers), e(ma), e(ar1)
+    errs[kind] = (e_ph, e_pe, e_ma, e_ar)
+    v = ""p_hat GAGNE"" if e_ph < min(e_pe, e_ma, e_ar) * 0.9 else (
+        ""p_hat PERD"" if e_ph > min(e_pe, e_ma, e_ar) * 1.1 else ""egalite"")
+    print(f""{kind:11s} | {e_ph:7.2f} | {e_pe:7.2f} | {e_ma:7.2f} | {e_ar:7.2f} | {v}"")
+",,,,,,,,f5800f4c2f434679,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,ffb29090,code,fr,cc969f8e4bb171bd,"labels = list(errs.keys())
+x = np.arange(len(labels)); w = 0.2
+fig, ax = plt.subplots(figsize=(8, 4))
+for i, (c, lab) in enumerate(zip(range(4), [""p_hat"", ""persistance"", ""moyenne mobile"", ""AR(1)""])):
+    vals = [errs[k][c] for k in labels]
+    ax.bar(x + (i - 1.5) * w, vals, w, label=lab)
+ax.set_xticks(x); ax.set_xticklabels(labels); ax.set_ylabel(""erreur d'anticipation 2D"")
+ax.set_title(""Gate 3 : p_hat vs baselines adverses (Cran A)""); ax.legend(fontsize=8)
+fig.tight_layout(); plt.show()
+",,,,,,,,cc969f8e4bb171bd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,94402dae,markdown,fr,ca62761e032d6227,"## 5. Gate 2 — quatre grandeurs de role (mesurees) + controle d'ablation
+
+Chaque role doit etre lisible depuis la trajectoire seule via quatre grandeurs :
+`capture_rate`, `escape_rate`, `path_irreversibility`, `role_switching`. La
+**marche aleatoire** est le controle d'ablation : sans modele ni gradient, elle
+ne doit porter aucune signature de role.",,,,,,,,ca62761e032d6227,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,f2e71006,code,fr,98b5a9c5d6de6c39,"rng = np.random.default_rng(77)
+print(f""{'animat':10s} | {'capture':>8s} | {'escape':>7s} | {'irrevers':>8s} | {'switch':>7s}"")
+print(""-"" * 52)
+rep = V.regime_report(""balistique"", size=SIZE, n_steps=NSTEPS, n_seeds=5, lead=4,
+                      speed=0.8, capture_radius=1.0, capture_burn=100,
+                      obstacles=np.array([[20.0, 12.0]]), rng=rng)
+for name in (""reactif"", ""phat"", ""aleatoire""):
+    r = rep[name]
+    print(f""{name:10s} | {r['capture']:8.3f} | {r['escape']:7.3f} | {r['irrevers']:8.3f} | {r['switch']:7.3f}"")
+print()
+print(""Controle d'ablation : la marche aleatoire capture ~0 (pas de signature de role),"")
+print(""tandis que les deux animats orientes portent une capture elevee. Les roles se"")
+print(""distinguent dans l'espace (capture, irreversibilite, switching) sans etiquette."")
+",,,,,,,,98b5a9c5d6de6c39,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,f690c709,markdown,fr,7cf5e0de8537cffe,"## 6. Verdict sans complaisance
+
+Le banc croise 4 regimes (statique, balistique, erratique, bruite) et un axe de
+vitesse. Le verdict est **regime-dependant**, coherent avec le fil court depuis
+ICT-10 (le $\hat{p}$ durci du Cran A) :
+
+- **Capture (gate 1)** : le reactif a gradient instantané est une baseline
+  proche de l'optimal a vitesse attrapable. $\hat{p}$ ne la bat nulle part dans
+  ce regime et **perd en erratique** (predictions trompees par les demi-tours).
+  En revanche, quand la source **depasse** le reactif (speed > step), l'interception
+  de $\hat{p}$ paye nettement en balistique (capture x10) : c'est le regime ou le
+  modele interne est necessaire.
+- **Anticipation (gate 3)** : $\hat{p}$ ecrase les baselines en balistique
+  (erreur ~6x inferieure a la persistance) mais **perd en bruite** (la vitesse EMA
+  amplifie le bruit de position : persistance plus precise). Le modele interne
+  paie en prediction **la ou la source est previsible**, exactement l'inverse sinon.
+- **Roles (gate 2)** : les 4 grandeurs separent reactif / $\hat{p}$ / marche
+  aleatoire sans etiquette ; le controle d'ablation (capture ~0 pour la marche
+  aleatoire) confirme que la signature est non-triviale.
+
+**Conclusion** : le modele interne $\hat{p}$ n'est ni universellement avantageux
+ni universellement ruineux. Il paie son cout la ou (a) la source echappe au
+suivi reactif **et** (b) sa cinematique reste previsible. Ailleurs, la baseline
+reactive (persistance spatiale) est egale ou meilleure. C'est la discipline
+« sans complaisance » de la serie : aucune granularite privilegiee decretee,
+un verdict honnete, par regime.
+",,,,,,,,7cf5e0de8537cffe,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,85826b56,markdown,fr,64f29b885a215188,"## 7. Exercices
+
+Trois exercices (a completer). Conventions : stub **sans erreur volontaire**
+(`pass` / `return None` / `# TODO etudiant`) ; le notebook s'execute de bout en
+bout meme non complete.
+",,,,,,,,64f29b885a215188,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,ff5993c6,markdown,fr,9951b8bdfa469836,"### Exercice 1 — obstacles et role « proie »
+
+Ajoutez deux obstacles repulsifs et mesurez l'`escape_rate` du reactif vs $\hat{p}$.
+Un bon « proie » doit sortir vite des regions repulsives. Objectif : trouver une
+configuration d'obstacles ou $\hat{p}$ (evitement dedie) devance le reactif sur
+`escape_rate`.
+
+*Indice* : `V.simulate_reactive` et `V.simulate_phat` acceptent `obstacles=` ;
+`V.escape_rate(traj, src, obstacles=...)` renvoie la fraction de pas hors danger.
+",,,,,,,,9951b8bdfa469836,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,170adfe6,code,fr,0222048169241d60,"# Exercice 1 : a completer
+obstacles = None  # TODO etudiant : np.array([[...], [...]], dtype=float)
+escape_reactif = None  # TODO etudiant
+escape_phat = None     # TODO etudiant
+print(""Exercice 1 a completer"")
+",,,,,,,,0222048169241d60,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,c7deb02b,markdown,fr,4089e4ca5ba91f91,"### Exercice 2 — lead d'interception optimal
+
+Le lead d'interception est borne par `lead*2` dans `simulate_phat`. Etudiez
+comment la capture en balistique rapide varie avec `lead` (testez 1, 2, 4, 8).
+Un lead trop grand mene la source ; trop petit, $\hat{p}$ degeneré en reactif.
+Objectif : tracer la capture vs lead et identifier le minimum.
+
+*Indice* : bouclez sur `lead` avec `V.regime_report(..., lead=lead, speed=1.2)`.
+",,,,,,,,4089e4ca5ba91f91,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,75b862ab,code,fr,d1f76adca2b41047,"# Exercice 2 : a completer
+leads = [1, 2, 4, 8]
+captures_phat = []  # TODO etudiant : capturer rep['phat']['capture'] par lead
+print(""Exercice 2 a completer"")
+",,,,,,,,d1f76adca2b41047,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,7d171d57,markdown,fr,5612b209d21e3a10,"### Exercice 3 — cinquieme regime
+
+Ajoutez un regime « orbital » (la source decrit un cercle a vitesse constante)
+dans `V.source_trajectory`. Objectif : predire si $\hat{p}$ doit y gagner (mouvement
+periodique previsible) puis verifier.
+
+*Etape 1* : implementer le cercle dans `source_trajectory` (nouveau `kind=""orbital""`).
+*Etape 2* : lancer le banc `regime_report(""orbital"")` et comparer au verdict balistique.
+",,,,,,,,5612b209d21e3a10,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-12-ValenceFieldsAndAnimats.ipynb,115aeca5,code,fr,0131e6ff56293ef6,"# Exercice 3 : a completer
+# TODO etudiant : ajouter le kind ""orbital"" dans ict/valence.py::source_trajectory,
+# puis mesurer regime_report(""orbital"") et comparer au balistique.
+resultat_orbital = None  # TODO etudiant
+print(""Exercice 3 a completer"")
+",,,,,,,,0131e6ff56293ef6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,97888f26,markdown,fr,5c4fd0a78c6dc150,"# ICT-13 — Morphodynamique stratégique : une stratégie est-elle une forme stable ?
+
+**Sous-série ICT** (trajectoires intégrées, Epic #4588, strate 3). Suite d'ICT-10
+(bistabilité), ICT-11 (agence multi-échelle) et ICT-12 (champs de valence).
+Voir [#4588](../README.md), [#4879](https://github.com/jsboige/CoursIA/issues/4879).
+
+## Question
+
+**Une stratégie est-elle une forme stable dans un paysage d'interactions ?**
+La bistabilité d'ICT-10 devient ici bistabilité de régime **coopération /
+défection**. On simule le dilemme du prisonnier itere (IPD) avec bruit
+d'implementation, des tournois round-robin (Axelrod 1980), la dynamique de
+replicateur, et l'on cartographie les **bassins d'invasion** — la mesure
+morphodynamique centrale : une forme stable occupe un large bassin (seuil
+d'invasion eleve).
+
+La théorie (grim trigger, seuil $\delta \ge (T-R)/(T-P)$, Folk theorem) est
+traitée **par renvoi** a [GameTheory-6c](../../GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem.ipynb)
+(merge `182bf33cc`) et, quand il sera livre, au lake formel `repeated_games_lean`
+([#4880](https://github.com/jsboige/CoursIA/issues/4880)). Ce notebook **verifie
+numériquement** ses prévisions au lieu de re-dériver la théorie.
+
+## Gates de merge (falsifiables, #4879)
+
+1. **Tournois reels committes** : round-robin + replicateur SIMULES (pas un
+   tableau recopié d'Axelrod 1984).
+2. **ESS vérifiées numériquement vs analytique** : le seuil $\delta$ de GT-6c
+   retrouve par la simulation.
+3. **Regime-dependance** : bruit d'implementation (TFT s'effondre, GTFT/Pavlov
+   resistent) — prolonge le fil « dans quel régime une stratégie paie ? ».
+4. **Bassins d'invasion cartographies** (fraction initiale critique pour envahir
+   AllD).
+5. **Verdict sans complaisance** : les stratégies robustes en théorie qui ne le
+   sont pas en simulation le montrent en sortie.
+
+**Kernel** : Python 3 (numpy CPU pur). Module : `ict/strategic_morphodynamics.py`.
+",,,,,,,,5c4fd0a78c6dc150,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,9ee3f180,code,fr,2cac3ccc1e4f087e,"import sys, os
+sys.path.insert(0, os.getcwd())
+
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+%matplotlib inline
+
+from ict import strategic_morphodynamics as M
+
+rng = np.random.default_rng(0)
+strat = M.make_strategies(rng)
+print(""Strategies:"", list(strat.keys()))
+print(f""Gains canoniques T,R,P,S = {M.CANON['T']},{M.CANON['R']},{M.CANON['P']},{M.CANON['S']}"")
+print(f""Seuil grim (T-R)/(T-P) = {M.grim_threshold():.3f}"")
+",,,,,,,,2cac3ccc1e4f087e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,8dd218fb,markdown,fr,4b231e0b29f7f498,"## 1. Le dilemme du prisonnier itere
+
+Gains canoniques d'Axelrod : $T=5$ (tentation), $R=3$ (recompense mutuelle),
+$P=1$ (punition mutuelle), $S=0$ (dupe). Contrainte $T>R>P>S$ et $2R>T+S$ :
+la coopération mutuelle est collectivement optimale, mais la défection est
+individuellement tentante. Les stratégies (TFT, grim, Pavlov, GTFT, AllC, AllD)
+sont des fonctions de l'historique des coups.",,,,,,,,4b231e0b29f7f498,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,36e11a4e,code,fr,ae9c9bb9c2e81d48,"own, opp = np.array([M.C]), np.array([M.C])
+print(""tft(1er coup)   ="", M.tft(np.array([]), np.array([])), ""(C par defaut)"")
+print(""grim(apres C)   ="", M.grim(own, opp), ""(coopere tant que l'adversaire n'a pas defocte)"")
+print(""pavlov(C vs C)  ="", M.pavlov(np.array([M.C]), np.array([M.C])), ""(gagne -> stay)"")
+print(""pavlov(C vs D)  ="", M.pavlov(np.array([M.C]), np.array([M.D])), ""(perd -> shift)"")
+# match sans bruit : AllD vs AllC
+g_d, g_c = M.play_match(M.alld, M.allc, n_rounds=50, noise=0.0, rng=rng)
+print(f""\nAllD vs AllC (50 coups, sans bruit) : AllD={g_d:.2f} (T chaque), AllC={g_c:.2f} (S chaque)"")
+",,,,,,,,ae9c9bb9c2e81d48,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,6038547c,markdown,fr,3b73ee114c319267,"## 2. Gate 1 — tournoi round-robin (Axelrod reproduit, simule)
+
+Chaque paire de stratégies (y compris contre elle-même) joue 200 coups. Le score
+est le gain moyen par coup. **Tout est simule**, aucun tableau recopie.",,,,,,,,3b73ee114c319267,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,91ea8512,code,fr,e698f20ca3f25151,"rng = np.random.default_rng(42)
+sc = M.round_robin(strat, n_rounds=200, noise=0.0, n_reps=1, rng=rng)
+ranking = sorted(sc.items(), key=lambda x: -x[1])
+print(f""{'rang':4s} {'strategie':10s} {'score/coup':>10s}"")
+for i, (n, v) in enumerate(ranking, 1):
+    print(f""{i:<4d} {n:10s} {v:10.3f}"")
+",,,,,,,,e698f20ca3f25151,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,3de70266,code,fr,c0f6eafbca636152,"fig, ax = plt.subplots(figsize=(7, 4))
+names = [n for n, _ in ranking]; vals = [v for _, v in ranking]
+colors = [""#2ca02c"" if n in (""tft"",""gtft"",""pavlov"",""grim"") else (""#d62728"" if n==""alld"" else ""#7f7f7f"") for n in names]
+ax.bar(names, vals, color=colors); ax.set_ylabel(""score moyen / coup"")
+ax.set_title(""Gate 1 : tournoi round-robin (IPD, 200 coups, sans bruit)"")
+ax.axhline(M.CANON[""P""], ls=""--"", color=""grey"", alpha=0.5, label=f""P={M.CANON['P']} (mutual D)"")
+ax.legend(fontsize=8)
+fig.tight_layout(); plt.show()
+",,,,,,,,c0f6eafbca636152,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,dead3775,markdown,fr,d13b41689b63dc57,"Sans bruit, **TFT et grim** dominent (coordinateurs : ils punissent la
+défection sans s'engager dans une guerre d'usure contre eux-memes), **AllD**
+est dernier (il exploite AllC mais s'enferre contre les punitifs). C'est la
+reproduction numérique du résultat d'Axelrod 1980 — mais le verdict change sous
+bruit (section 4).",,,,,,,,d13b41689b63dc57,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,28fc9740,markdown,fr,caa1ee168268a29d,"## 3. Gate 2 — seuil de grim trigger : analytique vs numérique
+
+La théorie (GT-6c, Folk theorem) predit que grim trigger soutient la coopération
+a l'équilibre face a AllD si le facteur de continuation (escompte) $\delta$ est
+au-dela du seuil :
+
+$$\delta^* = \frac{T-R}{T-P}$$
+
+Pour les gains canoniques : $\delta^* = (5-3)/(5-1) = 0{,}5$. On verifie
+numériquement en comparant le gain escompte total $\sum_t \delta^t g_t$ de grim
+(qui rafle $R$ a chaque coup contre un autre grim) a celui d'AllD face a grim
+($T$ au premier coup, puis $P$ a jamais).",,,,,,,,caa1ee168268a29d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,40cad9ed,code,fr,e618203958fb7cb4,"thr = M.grim_threshold()
+deltas = np.linspace(0.1, 0.9, 17)
+_, diffs, crossing = M.grim_resists_threshold(deltas, rng=rng)
+print(f""Seuil analytique (T-R)/(T-P) = {thr:.3f}"")
+print(f""Croisement numerique          = {crossing:.3f}  (accord a 1 pas de grille)"")
+print(f""\nVerdict : grim resiste a AllD si delta >= {crossing:.2f} (numerique), {thr:.2f} (analytique)"")
+",,,,,,,,e618203958fb7cb4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,3b69b29a,code,fr,478fcfeaf89a2497,"fig, ax = plt.subplots(figsize=(7, 4))
+ax.plot(deltas, diffs, ""o-"", color=""#1f77b4"", label=""$G_{grim} - G_{alld}$ (numerique)"")
+ax.axhline(0, color=""grey"", lw=0.8)
+ax.axvline(thr, ls=""--"", color=""#d62728"", label=f""seuil analytique $\\delta^*$={thr:.2f}"")
+ax.axvline(crossing, ls="":"", color=""#2ca02c"", label=f""croisement numerique={crossing:.2f}"")
+ax.set_xlabel(""$\\delta$ (facteur de continuation)""); ax.set_ylabel(""$G_{grim} - G_{alld}$"")
+ax.set_title(""Gate 2 : seuil de grim trigger — analytique vs numerique"")
+ax.legend(fontsize=8)
+fig.tight_layout(); plt.show()
+",,,,,,,,478fcfeaf89a2497,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,3666f57c,markdown,fr,e064c41c21c11810,"## 4. Gate 3 — régime-dependance : effondrement sous bruit
+
+Le **bruit d'implementation** (un coup intentionnel inverse avec probabilité
+$\epsilon$) discrimine les stratégies. TFT est fragile : une erreur entre deux
+TFT declenche un **echo mort-a-mort** de défection (C-D-C-D...) qui detruit la
+coopération. En théorie (Nowak & Sigmund), GTFT (pardonne avec prob 1/3) et
+Pavlov (win-stay lose-shift) **devraient resister** en restaurant la coopération.
+On teste cette prediction : le verdict (section 6) la nuance honnetement. C'est
+le fil régime-dependance d'ICT-10/12 transpose aux stratégies.",,,,,,,,e064c41c21c11810,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,29e3f42f,code,fr,25e0f74664d7e265,"rng = np.random.default_rng(21)
+grid = np.linspace(0.0, 0.4, 9)
+out = M.noise_collapse(strat, grid, n_rounds=150, n_reps=3, rng=rng)
+print(f""{'strat':8s} | chute (b=0 -> b=0.4)"")
+for n in strat:
+    drop = out[n][0] - out[n][-1]
+    print(f""{n:8s} | {drop:+.3f}"")
+",,,,,,,,25e0f74664d7e265,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,b95bd2e5,code,fr,2a69b7da4b0f26f6,"fig, ax = plt.subplots(figsize=(7, 4))
+for n in strat:
+    ax.plot(grid, out[n], ""o-"", label=n,
+            color=""#d62728"" if n==""tft"" else (""#2ca02c"" if n==""pavlov"" else None))
+ax.set_xlabel(""bruit d'implementation $\\epsilon$""); ax.set_ylabel(""score de tournoi"")
+ax.set_title(""Gate 3 : effondrement sous bruit (TFT chute, Pavlov resiste)"")
+ax.legend(fontsize=8)
+fig.tight_layout(); plt.show()
+",,,,,,,,2a69b7da4b0f26f6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,ee8c7f81,markdown,fr,d5922bff66fb366e,"## 5. Gate 4 — bassins d'invasion
+
+La mesure morphodynamique centrale : etant donne une population residente
+(majoritairement AllD), quelle **fraction initiale** d'un envahisseur suffit pour
+qu'il prenne le controle (frequence finale > 0,5) sous la dynamique de
+replicateur ? Un seuil bas = bassin d'invasion large (forme instable pour le
+resident) ; un seuil de 1,0 = l'envahisseur ne tient **jamais**.",,,,,,,,d5922bff66fb366e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,723a4fbc,code,fr,f9131e09be388226,"rng = np.random.default_rng(42)
+A = M.payoff_matrix(strat, n_rounds=150, noise=0.0, n_reps=2, rng=rng)
+names = list(strat.keys())
+alld_idx = names.index(""alld"")
+print(f""Population residente : AllD. Fraction initiale critique pour envahir :"")
+results = {}
+for inv in [""tft"", ""gtft"", ""pavlov"", ""grim"", ""allc""]:
+    ii = names.index(inv)
+    x0s, finals = M.invasion_basin(A, invader_idx=ii, resident_idx=alld_idx, n_points=51, n_steps=500)
+    crit = M.critical_fraction(x0s, finals)
+    results[inv] = (x0s, finals, crit)
+    msg = f""{crit:.2f}"" if crit is not None else ""jamais (1.0)""
+    print(f""  {inv:8s}: seuil = {msg}"")
+",,,,,,,,f9131e09be388226,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,efc317d6,code,fr,3d855e4fae76b7b6,"fig, ax = plt.subplots(figsize=(7, 4))
+for inv, (x0s, finals, crit) in results.items():
+    ax.plot(x0s, finals, label=f""{inv}"" + (f"" (crit={crit:.2f})"" if crit is not None else "" (jamais)""))
+ax.plot([0, 1], [0.5, 0.5], ""k--"", lw=0.7, alpha=0.5)
+ax.set_xlabel(""fraction initiale de l'envahisseur""); ax.set_ylabel(""frequence finale"")
+ax.set_title(""Gate 4 : bassins d'invasion (resident = AllD)"")
+ax.legend(fontsize=7, loc=""lower right"")
+fig.tight_layout(); plt.show()
+",,,,,,,,3d855e4fae76b7b6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,1e3a6cdb,markdown,fr,6c3086d01ef45721,"Les cooperateurs punitifs (TFT, grim) envahissent AllD a **tres faible seuil**
+(0.02) : ils se coordonnent en coopération mutuelle ($R$) qui bat la punition
+mutuelle des defectors ($P$). A l'inverse, **Pavlov et AllC ne l'envahissent
+jamais** (seuil 1,0) : face a une population AllD, ils ne recoltent que $S$ puis
+$P$ — aucun avantage selectif. C'est l'inegalite morphodynamique : toutes les
+stratégies coopératrices ne sont pas equivalentes face a l'invasion.",,,,,,,,6c3086d01ef45721,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,243977d2,markdown,fr,a143554c47066f8e,"## 6. Verdict sans complaisance
+
+- **Gate 1** : sans bruit, TFT et grim dominent le tournoi (2,635), AllD est
+  dernier (2,313) — reproduction numérique d'Axelrod (sortie simulee, non recopiee).
+- **Gate 2** : le seuil analytique $\delta^*=(T-R)/(T-P)=0{,}5$ est retrouve
+  numériquement (croisement a 0,55, accord a un pas de grille). La théorie de
+  GT-6c tient : grim resiste a AllD au-dela du seuil.
+- **Gate 3** : le régime-dependance est confirme — **TFT s'effondre sous bruit**
+  (chute +0,40, la plus forte : l'echo mort-a-mort detruit son mecanisme de
+  réciprocité active). La théorie voudrait que GTFT/Pavlov resistent proprement ;
+  le verdict est plus nuance : **c'est grim qui montre la plus faible chute
+  (+0,29)**, devant pavlov (+0,38), gtft (+0,39) et allc (+0,37). L'insight honnete
+  n'est pas « Pavlov robuste » mais son envers morphodynamique : **le mecanisme
+  qui fait gagner TFT sans bruit (réciprocité active) est précisément ce que le
+  bruit detruit**, tandis que la rigidite de grim — un défaut sans bruit — devient
+  une stabilite relative sous bruit. Aucune stratégie cooperative n'est epargnee :
+  un tournoi charge d'AllD ronge tout le monde.
+- **Gate 4** : les bassins d'invasion sont **inesgaux**. TFT/grim envahissent
+  AllD a seuil 0,02 ; gtft a 0,34 ; pavlov et allc **ne l'envahissent jamais**
+  (seuil 1,0). « Cooperateur » n'est pas un role uniforme : la morphologie
+  d'invasion discrimine les stratégies coopératrices.
+
+**Conclusion** : une stratégie n'est stable que dans un **paysage donne**. TFT,
+gagnante sans bruit, devient fragile des que le régime devient incertain — et
+c'est exactement son atout sans bruit (la réciprocité) qui la perd sous bruit ;
+grim, stable au-dela de $\delta^*$, s'effondre en horizon court. Le fil
+régime-dependance, ouvert en ICT-10 (le $\hat{p}$) et prolonge en ICT-12 (animats),
+trouve ici sa troisieme incarnation : **la robustesse d'une stratégie est une
+fonction du régime d'interaction, pas une propriete intrinseque**.
+",,,,,,,,a143554c47066f8e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,4eda0108,markdown,fr,f1c4c776f9e76ac8,"## 7. Exercices
+
+Trois exercices (a completer). Stubs **sans erreur volontaire** ; le notebook
+s'execute de bout en bout même non complétée.
+",,,,,,,,f1c4c776f9e76ac8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,30551825,markdown,fr,23da786c43451f1e,"### Exercice 1 — stratégie « tester-then-defect »
+
+Implementez une stratégie qui coopere 3 coups puis defocte systematiquement
+(exploiteur tardif). Mesurez son score au tournoi et son bassin d'invasion face a
+AllD. Objectif : determinez si elle bat TFT.
+
+*Indice* : ajoutez une entree dans `make_strategies` ; `M.round_robin` et
+`M.invasion_basin` prennent le dict.
+",,,,,,,,23da786c43451f1e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,51f94a74,code,fr,7730d8e9f3881d01,"# Exercice 1 : a completer
+def test_then_defect(own, opp):
+    # TODO etudiant : cooperer si len(own) < 3, sinon defecter
+    return None
+resultat_ex1 = None  # TODO etudiant
+print(""Exercice 1 a completer"")
+",,,,,,,,7730d8e9f3881d01,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,5738e556,markdown,fr,772fea0e24daf10b,"### Exercice 2 — seuil de grim pour un autre jeu
+
+Recomputez le seuil analytique $\delta^*=(T-R)/(T-P)$ et le croisement numérique
+pour un PD modifie (T=4, R=3, P=2, S=1). Objectif : verifiez que l'accord
+analytique/numérique se maintient.
+
+*Indice* : passez `T=,R=,P=,S=` a `M.grim_continuation_payoff` et `M.grim_threshold`.
+",,,,,,,,772fea0e24daf10b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,21ba393e,code,fr,ff43f59ffe3ba352,"# Exercice 2 : a completer
+seuil_ex2 = None    # TODO etudiant : M.grim_threshold(T=4,R=3,P=1) etc.
+croisement_ex2 = None  # TODO etudiant
+print(""Exercice 2 a completer"")
+",,,,,,,,ff43f59ffe3ba352,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,566d2ce6,markdown,fr,fa934ba2de252f7f,"### Exercice 3 — invasion de GTFT dans une population mixte
+
+Cartographiez le bassin d'invasion de GTFT face a un **resident Pavlov** (pas
+AllD). Objectif : determinez si GTFT peut envahir une population Pavlov, et a
+quel seuil.
+
+*Etape 1* : construisez la matrice de gain 2-stratégies (gtft, pavlov) via
+`M.payoff_matrix`. *Etape 2* : `M.invasion_basin(A, invader_idx=0, resident_idx=1)`.
+",,,,,,,,fa934ba2de252f7f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-13-AxelrodStrategicMorphodynamics.ipynb,b316e15b,code,fr,92d49142e4417b15,"# Exercice 3 : a completer
+resultat_ex3 = None  # TODO etudiant : seuil critique gtft-vs-pavlov
+print(""Exercice 3 a completer"")
+",,,,,,,,92d49142e4417b15,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,e2b757d4,markdown,fr,7f717c55f31f0776,"# ICT-14 — Énergie libre et surprise du représentant interne
+
+*La surprise du modèle interne est-elle une énergie libre, et ajoute-t-elle quoi que ce soit à l'erreur de prédiction ?*
+
+**Thèse.** ICT est né *« Integrated Complexity Theory »* — intégration dynamique ($\Phi_{dyn}$), **minimisation de la surprise** (énergie libre, lignée Friston), compression (Schmidhuber). La série a développé la jambe *causale* (Levin, Hoel, Thom) ; la jambe **énergie-libre** restait non attachée, alors que le banc expérimental la préparait sans le dire : le représentant interne $\hat p$ d'ICT-10.
+
+Un modèle génératif gaussien à un pas prédit $\hat p_t$ avec précision $\sigma^2$ ; la **surprise** de l'observation $o_t$ est la négative log-vraisemblance, qui se décompose en *accuracy* (erreur pondérée par la précision) + *complexity* (entropie de la prédiction). C'est l'énergie libre variationnelle dans le cas gaussien fermé.
+
+**La question honnête** (trois *gates* falsifiables) :
+1. À précision **fixe**, $\bar F$ est-elle autre chose qu'un habillage du MSE ?
+2. À précision **adaptative**, $\bar F$ **diverge-t-elle** du classement MSE dans certains régimes ?
+3. Sur le substrat **bistable**, $F_t$ **marque-t-elle** le franchissement du pli (l'hystérésis vue par l'énergie libre) ?
+
+*Part of l'Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588) (strate 4 — retour de la théorie fondatrice). Greenlight user 2026-07-02.*",,,,,,,,7f717c55f31f0776,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,38e08616,markdown,fr,bf19fe95c21fcbba,"## Rappel ICT-10 et position de la strate 4
+
+**Le représentant interne $\hat p$.** Le *lacet de prédation* d'ICT-10 met en scène un actant qui doit **anticiper** sa proie : un modèle interne à vitesse constante projette la position $\hat p_t = o_t + \text{lead}\cdot v_t$ où $v_t$ est la vitesse estimée par lissage EMA. Ce n'est pas un jouet — c'est le *représentant interne* de Thom, qui vise *où la proie sera*. Le verdict d'ICT-10, mesuré sur un banc durci (3 familles de trajectoires × 3 baselines adverses), est **régime-dépendant** : l'anticipation est réellement avantageuse sur trajectoire lisse (5/5 graines), illusoire sur dérive et créneau.
+
+**Le pont.** L'erreur de prédiction $\hat p_t \leftrightarrow o_{t+\text{lead}}$ est la **surprise non normalisée** — le MSE. La jambe énergie-libre consiste à la reformuler comme négative log-vraisemblance d'un modèle génératif, ce qui (i) introduit une **précision** $\sigma^2$ (l'incertitude que le modèle *revendique*) et (ii) décompose le coût en *accuracy* + *complexity*. La strate 4 attache donc la lignée Friston (free-energy principle) au banc déjà construit, **sans refonder la scène** : on change la métrique (MSE → $F$), pas les estimateurs.
+
+**Position dans la série.** Strate 1 (tri auto-organisé), strate 2 (morphogenèse dynamique, bifurcation pli), strate 3 (trajectoires intégrées, émergence causale) sont posées. La strate 4 ouvre le *retour de la théorie fondatrice* : énergie libre (ce notebook, ICT-14) puis complexité intégrée convergente $\Phi/F/K$ (capstone ICT-15).",,,,,,,,bf19fe95c21fcbba,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,d4a8f4a3,code,fr,4b0eb6497d525de8,"import os, sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Package leger ict (numpy-only hors PyPhi) : catastrophe = banc p_hat d'ICT-10,
+# free_energy = la jambe energie-libre (ce notebook).
+sys.path.insert(0, os.getcwd())
+from ict import catastrophe as cat
+from ict import free_energy as fe
+
+np.random.seed(0)
+%matplotlib inline
+
+# Trois familles de trajectoires aux cinematiques opposees (ICT-10) :
+#  sinus (inertie exploitable), derive (bruit pur), creneau (discontinuites).
+FAMILLES = [""sinus"", ""derive"", ""creneau""]
+print(""Module free_energy charge."", ""Fonctions :"", [f for f in dir(fe) if not f.startswith('_')])",,,,,,,,4b0eb6497d525de8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,f10cc94a,markdown,fr,b214acd3d7c54613,"## Formalisation : $F = \text{accuracy} + \text{complexity}$ (cas gaussien fermé)
+
+Pour un modèle génératif gaussien à un pas, la surprise de l'observation $o_t$ sachant la prédiction $\hat p_t$ et la précision $\sigma^2_t$ est la négative log-vraisemblance :
+
+$$S_t = -\ln \mathcal N(o_t;\, \hat p_t,\, \sigma^2_t) = \tfrac12\!\left[\frac{(o_t-\hat p_t)^2}{\sigma^2_t} + \ln(2\pi\sigma^2_t)\right] = \underbrace{\tfrac12 \frac{(o_t-\hat p_t)^2}{\sigma^2_t}}_{\text{accuracy}} + \underbrace{\tfrac12 \ln(2\pi\sigma^2_t)}_{\text{complexity}}$$
+
+**Lemme (Gate 1).** Si $\sigma^2_t = \sigma^2$ est constant, alors $\bar F = \frac{1}{2\sigma^2}\,\text{MSE} + \tfrac12\ln(2\pi\sigma^2)$ : transformation **strictement monotone** du MSE. Par conséquent le classement des estimateurs par $\bar F$ **coïncide exactement** avec le classement par erreur MSE — l'énergie libre à précision fixe n'est qu'un habillage du MSE. C'est à démontrer plutôt qu'à cacher.
+
+**Là où $F$ peut s'écarter du MSE.** Si la précision est **adaptative** ($\sigma^2_t$ = EMA causale des erreurs passées), la pondération $1/\sigma^2_t$ **varie** : une erreur courante est rapportée à la variance que le modèle *s'attendait* à rencontrer. Un modèle sur-confiant ($\sigma^2_t$ petit) accumulé en régime calme paie cher la première erreur inattendue — c'est le régime *créneau*, et le seul où $F$ ajoute quelque chose au-delà du MSE.",,,,,,,,b214acd3d7c54613,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,70caefed,code,fr,9a0a5fb1c64373ff,"# Demonstration : surprise pas-a-pas sur une trajectoire sinus.
+rng = np.random.default_rng(7)
+obs = cat.prey_trajectory(""sinus"", n_steps=300, noise=0.10, rng=rng)
+lead = 4
+p_hat = cat.constant_velocity_tracker(obs, lead=lead, alpha=0.25)
+pers = cat.persistence_tracker(obs)
+
+# Surprise a precision fixe (sigma=1) : p_hat vs persistance.
+sigma_fixe = 1.0
+S_phat = fe.gaussian_surprise(obs[lead:], p_hat[:-lead], sigma=sigma_fixe)
+S_pers = fe.gaussian_surprise(obs[lead:], pers[:-lead], sigma=sigma_fixe)
+
+fig, ax = plt.subplots(2, 1, figsize=(9, 5), sharex=True)
+ax[0].plot(obs, label=""proie $o_t$"", lw=1)
+ax[0].plot(p_hat, label=r""$\hat p_t$ (anticipateur)"", lw=1, alpha=0.8)
+ax[0].plot(pers, label=""persistance"", lw=1, alpha=0.6)
+ax[0].set_ylabel(""position""); ax[0].legend(loc=""upper right"", fontsize=8); ax[0].set_title(""Lacet de prédation (sinus bruité)"")
+ax[1].plot(S_phat, label=r""$S_t$ — $\hat p$"", lw=1)
+ax[1].plot(S_pers, label=""$S_t$ — persistance"", lw=1, alpha=0.7)
+ax[1].set_ylabel(""surprise $S_t$""); ax[1].set_xlabel(""temps""); ax[1].legend(loc=""upper right"", fontsize=8)
+fig.tight_layout(); plt.show()
+print(f""Moyennes (sigma={sigma_fixe}) : F_bar p_hat = {S_phat.mean():.4f}, F_bar persistance = {S_pers.mean():.4f}"")",,,,,,,,9a0a5fb1c64373ff,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,16a98f52,markdown,fr,3955dc32736ee0f9,"La surprise *pic* aux creux et sommets du sinus (où la vitesse EMA se retourne) : c'est visuellement l'erreur de prédiction, reformulée. À ce stade, rien ne distingue $F$ du MSE — c'est précisément ce que le **Gate 1** quantifie.",,,,,,,,3955dc32736ee0f9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,b8a74052,code,fr,caa3e3b047d15828,"# GATE 1 — a precision fixe, F_bar est monotone en MSE => rangs identiques.
+# Les 4 estimateurs d'ICT-10 sur le meme banc, scores par F_bar (sigma fixe) et par MSE (lead_error).
+SEEDS = [0, 1, 7, 42, 99]
+identite_count = 0
+total = 0
+print(f""{'famille':<10} {'graine':<6} {'argmin(MSE)':<16} {'argmin(F) fixe':<16} {'identique?':<10}"")
+for fam in FAMILLES:
+    for s in SEEDS:
+        rng = np.random.default_rng(s)
+        obs_i = cat.prey_trajectory(fam, n_steps=300, noise=0.10, rng=rng)
+        rapp = fe.fe_anticipation_report(obs_i, lead=lead, sigma=1.0, mode=""fixed"")
+        by_F = min(rapp, key=lambda k: rapp[k][""F""])
+        by_MSE = min(rapp, key=lambda k: rapp[k][""erreur""])
+        ok = (by_F == by_MSE)
+        identite_count += ok; total += 1
+        print(f""{fam:<10} {s:<6} {by_MSE:<16} {by_F:<16} {'OUI' if ok else 'NON':<10}"")
+print(f""\nGate 1 : {identite_count}/{total} familles×graines ont argmin(F) == argmin(MSE) à precision fixe."")
+print(""Verdict : la coincidence est EXACTE — à sigma fixe, F n'apporte rien au-dela du MSE."")",,,,,,,,caa3e3b047d15828,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,537482c0,markdown,fr,f940635e39a2384d,"### Gate 1 — verdict sans complaisance
+
+À précision fixe, l'énergie libre moyenne $\bar F$ est une transformation **strictement monotone** du MSE : les rangs des quatre estimateurs coïncident **exactement** sur les 15 combinaisons famille × graine. *L'énergie libre à précision fixe n'est qu'un habillage du MSE.* Il fallait le démontrer plutôt que le cacher : invoquer Friston ne crédite rien tant que $\sigma^2$ est constant.
+
+La question devient : **où la précision adaptative restaure-t-elle un contenu prédictif propre à $F$ ?**",,,,,,,,f940635e39a2384d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,4e2bebf4,code,fr,7c4fa3508d435874,"# GATE 2 — precision adaptative : les rangs par F divergent-ils des rangs par MSE ?
+# Balayage bruit x famille x 5 graines. On mesure le TAUX DE DIVERGENCE
+# (argmin F adaptatif != argmin MSE) par famille. Prediction falsifiable :
+# la divergence est concentree aux discontinuites (creneau).
+BRUITS = [0.05, 0.10, 0.20, 0.40]
+table = {fam: [] for fam in FAMILLES}   # taux de divergence par famille (moyenne sur bruit x graines)
+for fam in FAMILLES:
+    div_count = 0; n = 0
+    for b in BRUITS:
+        for s in SEEDS:
+            rng = np.random.default_rng(s)
+            obs_i = cat.prey_trajectory(fam, n_steps=300, noise=b, rng=rng)
+            rapp = fe.fe_anticipation_report(obs_i, lead=lead, mode=""adaptive"", alpha_prec=0.3)
+            by_F = min(rapp, key=lambda k: rapp[k][""F""])         # F adaptatif
+            by_MSE = min(rapp, key=lambda k: rapp[k][""erreur""])  # MSE (lead_error)
+            div = (by_F != by_MSE)
+            div_count += div; n += 1
+    table[fam] = div_count / n
+
+print(""Taux de divergence argmin(F adaptatif) != argmin(MSE), par famille :"")
+for fam in FAMILLES:
+    bar = ""#"" * int(round(table[fam] * 40))
+    print(f""  {fam:<10} {table[fam]*100:5.1f}%  {bar}"")
+print(""\nVerdict : la divergence se concentre sur la famille 'creneau' (discontinuites) —"")
+print(""la ou le p_hat a vitesse constante reste sur-confiant (sigma petit accumule en rampe)"")
+print(""puis se plante au saut : la penalite de precision punit. Ailleurs, F redondant avec le MSE."")",,,,,,,,7c4fa3508d435874,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,636c8af3,markdown,fr,c67e5c9cae5bd40a,"### Gate 2 — verdict : avantage régime-dépendant
+
+La précision **adaptative** restaure un contenu prédictif propre à $F$ **exactement là** prédit : aux discontinuités (famille *créneau*), où le classement par $\bar F$ diverge du classement par MSE. Le mécanisme est lisible : en rampe, le $\hat p$ à vitesse constante réussit, la précision $\sigma^2_t$ (EMA causale des erreurs) décroît — le modèle devient *sur-confiant* ; au saut du créneau, la grosse erreur est rapportée à un $\sigma^2_t$ devenu petit, et la surprise explose bien plus que ne le suggère le MSE brut. Sur trajectoires lisses ou de bruit pur, la précision ne varie presque pas, et $F$ redonne le classement du MSE (Gate 1).
+
+C'est l'écho direct du verdict *« avantage régime-dépendant »* d'ICT-10 §4 : l'énergie libre n'est pas universellement informative — elle discrimine précisément quand le modèle interne **trahit sa propre confiance**.",,,,,,,,c67e5c9cae5bd40a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,aa8281e8,code,fr,5ae02d3466386902,"# GATE 3 — la catastrophe vue par F : traversée du pli bistable.
+# Substrat : modele de paturage de May (ict.bistable.GrazingModel) — un vrai pli.
+# On rampe la pression de broutage c au-dela de c_fold : x(t) saute de l'etat
+# vegetalise haut a l'etat surpature bas (catastrophe). Le p_hat, calibre sur la
+# branche haute calme, est surpris au saut. F_t doit marquer l'hysterese.
+from ict import bistable
+
+gm = bistable.GrazingModel(r=1.0, K=10.0, h=1.0)
+c_fold = gm.find_fold()
+print(f""c_fold (limite du pli) = {c_fold:.4f}"")
+
+# Rampe douce de c a travers le pli, avec bruit d'observation.
+c0, c1 = 1.0, 3.0
+xs, cs = gm.simulate_ramp(c0=c0, c1=c1, x0=8.0, sigma=0.15,
+                          dt=0.02, T=4000, seed=3)
+x = np.asarray(xs)
+# p_hat du banc ICT-10 applique a la biomasse x(t).
+p_hat = cat.constant_velocity_tracker(x, lead=lead, alpha=0.25)
+fe_traj = fe.free_energy_trajectory(x, p_hat, mode=""adaptive"", alpha=0.3)
+F_t = fe_traj[""F""]
+
+# Localisation du saut (plus grande derivee de x).
+idx_saut = int(np.argmax(np.abs(np.diff(x)))) + 1
+t = np.arange(x.size)
+fig, ax = plt.subplots(2, 1, figsize=(9, 5), sharex=True)
+ax[0].plot(t, x, lw=1, label=""biomasse $x_t$"")
+ax[0].axvline(idx_saut, color=""r"", ls=""--"", lw=1, label=f""saut (pli) ~ t={idx_saut}"")
+ax[0].plot(t, p_hat, lw=1, alpha=0.7, label=r""$\hat p_t$"")
+ax[0].set_ylabel(""$x_t$""); ax[0].legend(loc=""upper right"", fontsize=8)
+ax[0].set_title(""Traversée du pli bistable (rampe de pression de broutage)"")
+ax[1].plot(t, F_t, lw=1, color=""darkred"")
+ax[1].axvline(idx_saut, color=""r"", ls=""--"", lw=1)
+ax[1].set_ylabel(""énergie libre $F_t$""); ax[1].set_xlabel(""temps (pas)"")
+ax[1].set_title(""$F_t$ du représentant interne — la surprise marque le pli"")
+fig.tight_layout(); plt.show()
+print(f""Surprise mediane hors-saut : {np.median(np.delete(F_t, np.s_[max(0,idx_saut-20):idx_saut+20])):.3f}"")
+print(f""Surprise max autour du saut : {F_t[max(0,idx_saut-20):idx_saut+20].max():.3f}"")",,,,,,,,5ae02d3466386902,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,9213ddcf,markdown,fr,e8206489337b7344,"### Gate 3 — verdict : la surprise est une coordonnée de la catastrophe
+
+Sur le substrat bistable, $F_t$ du représentant interne est **quasi-plate** le long de la branche végétalisée calme (le $\hat p$ à vitesse constante y réussit, la précision s'affine), puis **pic brutalement** au franchissement du pli — exactement quand la biomasse $x_t$ saute vers l'état surpâturé. La surprise n'accompagne pas la transition : elle la **signale**, parce que le modèle interne (calibré sur la dynamique lente de la branche haute) est structurellement incapable d'anticiper une transition catastrophique non locale.
+
+C'est l'amorce du **système de coordonnées de Thom** pour le capstone ICT-15 : la jambe énergie-libre fournit une *coordonnée mesurable* ($F_t$) du passage du pli, au même titre que le ralentissement critique (ICT-8) ou l'aire signée du lacet (ICT-10). Les trois mesurent, sous trois angles, la même chose — la bifurcation.",,,,,,,,e8206489337b7344,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,f3e1f189,markdown,fr,b2cd30bbef881896,"## Verdict de la strate 4 (jambe énergie-libre)
+
+1. **Gate 1 (démontrée).** À précision fixe, $\bar F$ est **strictement monotone** du MSE — les rangs coïncident exactement (15/15). L'énergie libre à précision constante n'apporte rien au-delà de l'erreur de prédiction. Il fallait le *dire* plutôt que le cacher.
+2. **Gate 2 (démontrée).** À précision **adaptative**, $\bar F$ **diverge** du classement MSE **précisément aux discontinuités** (famille créneau), et seulement là : la précision adaptative punit la sur-confiance accumulée. Ailleurs (sinus, dérive), $F$ est redondant avec le MSE.
+3. **Gate 3 (démontrée).** Sur le pli bistable, $F_t$ **marque** la transition catastrophique — un pic isolé au saut, quasi-plate ailleurs. La surprise est une **coordonnée** du pli, au même titre que le ralentissement critique.
+
+**Synthèse honnête.** La reformulation énergie-libre *n'est pas* une métrique universellement supérieure — elle redonne le MSE dans le régime commun (Gate 1). Son contenu prédictif propre est **régime-dépendant** : elle discrimine exactement quand le modèle interne **trahit sa propre confiance** (Gate 2) ou **rate une transition non locale** (Gate 3). C'est cohérent avec le verdict régime-dépendant d'ICT-10 et prépare la convergence $\Phi/F/K$ du capstone ICT-15.
+
+> **Pont vers ICT-15.** Trois coordonnées d'une bifurcation sont maintenant mesurables sur le même banc : le ralentissement critique (ICT-8), l'aire signée du lacet (ICT-10), et la surprise du représentant interne (ICT-14). ICT-15 les réunira en une *complexité intégrée* $\Phi/F/K$ cross-substrat, où la catastrophe devient elle-même coordonnée.",,,,,,,,b2cd30bbef881896,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,7f5032c1,markdown,fr,f756d8af8cc16187,"## Exercices
+
+Les trois exercices approfondissent un angle de la jambe énergie-libre. Chacun suit le motif « objectif + indice + étapes », à compléter (stubs sans erreur — le notebook s'exécute de bout en bout même non complété).",,,,,,,,f756d8af8cc16187,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,5bf7042a,markdown,fr,7f26f96af814f3c9,"### Exercice 1 — surprise *Laplace* ($L_1$) au lieu de gaussienne ($L_2$)
+
+**Objectif.** La surprise gaussienne pénalise l'erreur au carré ($L_2$), donc sur-pénalise les grandes erreurs (le saut du créneau). Une vraisemblance **Laplace** ($L_1$, $|\text{err}|$) a des queues plus épaisses : elle « pardonne » les grandes erreurs inattendues. Refaire le Gate 2 avec une surprise Laplace et vérifier si la divergence de rangs au créneau est *atténuée* ou *amplifiée*.
+
+**Indice.** La surprise Laplace est $S_t = |o_t - \hat p_t|/b + \ln(2b)$ où $b$ est le scale (analogue de $\sigma$). La précision adaptative s'estime par EMA des $|\text{err}|$.
+
+**Étapes.**
+1. Écrire `laplace_surprise(obs, pred, b)` analogue à `gaussian_surprise`.
+2. Construire un report Laplace sur le même banc (4 estimateurs, lead-ahead).
+3. Refaire le balayage famille × bruit du Gate 2 ; comparer le taux de divergence à la version gaussienne.",,,,,,,,7f26f96af814f3c9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,e11f0fca,code,fr,65229d3a1aa8abd4,"# Exercice 1 — surprise Laplace (a completer)
+def laplace_surprise(obs, pred, b):
+    # TODO etudiant : negative log-vraisemblance Laplace = |o - p_hat|/b + ln(2b)
+    return None
+
+# result_ex1 = None  # TODO etudiant : balayage famille x bruit, comparer au Gate 2 gaussien
+print(""Exercice 1 à compléter — surprise Laplace."")",,,,,,,,65229d3a1aa8abd4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,58b648a8,markdown,fr,46c118cda9395dab,"### Exercice 2 — précision *par famille* (calibrée) vs *en ligne* (EMA adaptative)
+
+**Objectif.** La précision adaptative d'ICT-14 est estimée **en ligne** (EMA causale des erreurs, sans connaissance de la famille). Que donne une précision **calibrée par famille** — c'est-à-dire $\sigma^2$ estimé sur un *entraînement* de la même famille puis appliqué en test ? La calibration bat-elle l'EMA ?
+
+**Indice.** Générer `N_train` et `N_test` trajectoires par famille ; $\sigma^2_{\text{famille}} = \text{var}(\text{err}_{\text{train}})$ ; comparer $\bar F$ (fixe calibré) vs $\bar F$ (adaptatif EMA) sur le test.
+
+**Étapes.**
+1. Pour chaque famille, calibrer `sigma2_par_famille` sur un jeu d'entraînement.
+2. Calculer $\bar F$ (précision fixe calibrée par famille) sur un jeu de test.
+3. Comparer à $\bar F$ (précision adaptative EMA) sur le même test ; conclure.",,,,,,,,46c118cda9395dab,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,36b82cc9,code,fr,8447f1e3e700f86b,"# Exercice 2 — precision par-famille vs EMA (a completer)
+def precision_par_famille(traj_train, est_train):
+    # TODO etudiant : variance des erreurs (o - p_hat) sur le train
+    return None
+
+# result_ex2 = None  # TODO etudiant : comparer F_bar calibre par famille vs EMA adaptative
+print(""Exercice 2 à compléter — précision par-famille vs EMA."")",,,,,,,,8447f1e3e700f86b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,a96bb928,markdown,fr,0b2b66b692377ab9,"### Exercice 3 — énergie libre de l'animat anticipateur 2D (ICT-12)
+
+**Objectif.** ICT-12 oppose un animat *réactif* (suit le gradient instantané) à un animat *anticipateur* $\hat p$ (extrapole le point d'interception) dans un champ de valence 2D. Calculer la **surprise gaussienne 2D** (somme sur les deux coordonnées) de chaque animat, et identifier le régime où l'anticipateur minimise $\bar F$.
+
+**Indice.** `ict.valence` fournit `simulate_phat()`, `simulate_reactive()`, `source_trajectory()`, `anticipation_error_2d()`, `phat_predicted_trajectory()`. La surprise 2D = somme des surprises par coordonnée (indépendance conditionnelle).
+
+**Étapes.**
+1. Simuler une source, l'animat $\hat p$ et l'animat réactif (`simulate_phat`, `simulate_reactive`).
+2. Calculer la surprise 2D de chaque animat (lead-ahead, comme dans `fe_anticipation_report`).
+3. Dans quel régime l'anticipateur minimise-t-il $\bar F$ ? Comparer au verdict *régime-dépendant* d'ICT-12 (balistique vs erratique).",,,,,,,,0b2b66b692377ab9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-14-FreeEnergySurprise.ipynb,97e4a0fe,code,fr,14428dae0becd437,"# Exercice 3 — energie libre de l'animat 2D d'ICT-12 (a completer)
+from ict import valence as val
+
+# traj_source = None  # TODO etudiant : val.source_trajectory(...)
+# phat_traj = None    # TODO etudiant : val.simulate_phat(...) / val.phat_predicted_trajectory(...)
+# react_traj = None   # TODO etudiant : val.simulate_reactive(...)
+# F_phat_2d = None    # TODO etudiant : surprise 2D (somme par coordonnee)
+# F_react_2d = None   # TODO etudiant
+print(""Exercice 3 à compléter — énergie libre de l'animat anticipateur 2D."")",,,,,,,,14428dae0becd437,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,28c89c50,markdown,fr,06f773a6712f2b5c,"# ICT-15 — Integrated Complexity : convergence Φ / F / K (capstone strate 4)
+
+*See #5090 — Part of l'Epic #4588 (strate 4 : retour de la théorie fondatrice).*
+
+## La question fondatrice enfin posée à l'appareil
+
+La série ICT est née d'une discussion fondatrice (*Integrated Complexity Theory*, cadrage verbatim préservé dans ICT-0 / #5091) qui affirme en substance : **l'intégration (Φ), la surprise (F) et la compression (K) sont trois facettes d'une même quantité** — *un système qui modélise son monde*. La série a construit, strate après strate, l'appareil exact pour tester cette affirmation, sans jamais la tester directement.
+
+- **Φ** : la batterie d'émergence causale d'ICT-5/ICT-6, contrastée à son contrôle dégénéré (shuffle) — `ec_gain`.
+- **F** : la jambe énergie-libre attachée au représentant interne `p̂` dans ICT-14, **généralisée ici à la trajectoire** comme cross-entropie held-out d'une TPM — `fe_gain`.
+- **K** : la jambe compression (nouveau module), longueur zlib contrastée au shuffle — `k_gain`.
+
+Ce capstone **étend l'appareil existant** (il ne le refait pas) : `ICT-Synthese-CrossSubstrat` appliquait une batterie (EI/EC + contrôle shuffle) à trois substrats (S1 tri, S2 bistable, S3 réplicateur). On lui ajoute les deux scalaires manquants, et on pose le **gate de convergence** : est-ce que les trois classements coïncident ?",,,,,,,,06f773a6712f2b5c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,6c977fd0,markdown,fr,a10fca7cb8349e9d,"## Position strate 4
+
+| Scalaire | Définition opérationnelle | Contrôle (commun) |
+|---|---|---|
+| **Φ (intégration)** | `ec_gain` : chemin d'échelles glouton (Hoel CE 2.0) | shuffle |
+| **F (surprise)** | cross-entropie held-out d'une TPM (lissage Laplace α=0.5) | même shuffle |
+| **K (compression)** | longueur zlib (niveau 9) de la séquence canonique | même shuffle |
+
+**Point méthodologique central** : le contrôle *sans complaisance* de la série se généralise **verbatim** aux trois scalaires — même shuffle, même `rng`, même discipline de créditation. C'est la condition nécessaire au gate : les trois gains doivent mesurer la *même déviation* par rapport au *même contrôle dégénéré*, sinon comparer leurs classements n'a aucun sens.",,,,,,,,a10fca7cb8349e9d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,4313d471,code,fr,c2e29efe957a51c4,"# Appareil : on reutilise les trajectoires de ICT-Synthese (meme S1/S2/S3)
+import sys, os
+sys.path.insert(0, os.getcwd())
+
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+%matplotlib inline
+
+from ict import synthesis as S
+from ict import free_energy as FE
+from ict import compression as CMP
+from ict import sorting_metrics as sm
+from ict.self_sorting import SelfSortingArray
+from ict.bistable import GrazingModel
+from ict import strategic_morphodynamics as SM
+
+SEEDS = (0, 1, 7, 42, 99)
+SEED0 = SEEDS[0]
+N_SHUF = 30
+print(""Appareil : emergence_gain enrichi des 3 facettes (ec_gain/fe_gain/k_gain)."")
+print(f""Substrats : S1 tri, S2 bistable, S3 replicateur. Graines gate 4 : {SEEDS}"")",,,,,,,,c2e29efe957a51c4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,53b09776,markdown,fr,4e9a6906b4af3b07,"## Les trois substrats (réutilisés de ICT-Synthese)
+
+On reproduit fidèlement la discrétisation de `ICT-Synthese-CrossSubstrat` : le *coarse-graining* substrat-spécifique est un choix documenté dans ce notebook, pas une constante cachée dans la librairie. Il doit rester **grossier** (le chemin d'échelles explore toutes les paires d'états, coût ~O(k²)).",,,,,,,,4e9a6906b4af3b07,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,0a0dfad5,code,fr,a62f001c16374f44,"def traj_S1(seed, n_runs=6, max_steps=1500):
+    """"""S1 - tri auto-organise : etat = nombre d'inversions (coarse, ICT-2/6).""""""
+    states = []
+    for r in range(n_runs):
+        rng = np.random.default_rng(seed + r)
+        arr = SelfSortingArray(list(rng.permutation(6)), seed=seed + r)
+        arr.run(max_steps=max_steps, record=True)
+        states.extend(sm.inversion_count(c) for c in arr.probe.values)
+    return states
+
+def traj_S2(seed, T=1500):
+    """"""S2 - paysage bistable (May 1977, ICT-8) : decile de la biomasse.""""""
+    gm = GrazingModel()
+    c = 0.92 * gm.find_fold()
+    xs = gm.simulate_sde(c=c, x0=8.0, sigma=0.55, dt=0.02, T=T, seed=seed)
+    lo, hi = np.percentile(xs, 1), np.percentile(xs, 99)
+    bins = np.linspace(lo, hi, 11)
+    return [int(v) for v in np.clip(np.digitize(xs, bins), 0, 10)]
+
+def traj_S3(seed, n_runs=10, n_steps=300):
+    """"""S3 - replicateur strategique (IPD/Axelrod, ICT-13) : strategie dominante.""""""
+    rng = np.random.default_rng(seed)
+    strat = SM.make_strategies(rng)
+    A = SM.payoff_matrix(strat, rng=rng)
+    states = []
+    for _ in range(n_runs):
+        x0 = rng.dirichlet(np.ones(len(strat)))
+        traj = SM.replicator_trajectory(A, x0, n_steps=n_steps)
+        states.extend(int(np.argmax(row)) for row in traj)
+    return states
+
+# un echantillon par substrat (graine representative)
+s1, s2, s3 = traj_S1(SEED0), traj_S2(SEED0), traj_S3(SEED0)
+print(f""S1_tri        longueur={len(s1):5d}  etats distincts={len(set(s1)):3d}"")
+print(f""S2_bistable   longueur={len(s2):5d}  etats distincts={len(set(s2)):3d}"")
+print(f""S3_replic     longueur={len(s3):5d}  etats distincts={len(set(s3)):3d}"")",,,,,,,,a62f001c16374f44,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,838a6e6f,markdown,fr,da5ac820d48c2111,"## Les trois scalaires sur la graine représentative
+
+Pour chaque substrat : `emergence_gain` (rétro-compatiblement enrichi) renvoie maintenant les **trois** gains. On les inspecte avant le gate multi-graines. Le contrôle est commun aux trois : un seul tirage de `rng` permute la trajectoire, et les trois scalaires mesurent leur déviation par rapport à cette même permutation.",,,,,,,,da5ac820d48c2111,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,29711b09,code,fr,3ab4653a541a6509,"subs = {""S1_tri"": s1, ""S2_bistable"": s2, ""S3_replicateur"": s3}
+rng = np.random.default_rng(2025)
+
+print(f""{'substrat':16s} {'Phi=ec_gain':>12s} {'F=fe_gain':>11s} {'K=k_gain':>10s}  credited?"")
+print(""-"" * 64)
+gains = {}
+for name, st in subs.items():
+    eg = S.emergence_gain(st, rng, n_shuffles=N_SHUF)
+    gains[name] = eg
+    print(f""{name:16s} {eg['ec_gain']:12.4f} {eg['fe_gain']:11.4f} {eg['k_gain']:10.4f}  ""
+          f""{'oui' if eg['credited'] else 'non'}"")",,,,,,,,3ab4653a541a6509,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,c31ba75c,markdown,fr,44b11c7a9eef48c3,"### Gate 4 — convergence des trois scalaires
+
+La prédiction fondatrice : les trois scalaires classent les substrats dans le **même ordre** (τ de Kendall ≈ +1 par paire). Si l'affirmation fondatrice est correcte, un système *plus intégré* devrait aussi être *plus prévisible* et *plus compressible* — les trois facettes d'une même quantité.
+
+**Issue honnête possible** : convergence partielle, ou échec. Les deux résultats sont publiquement défendables dans la logique de la série (cf. le verdict *non-transfert* de la Synthèse : l'invariant est la *méthode*, pas le nombre). Le gate est falsifiable — c'est tout le sens d'un capstone.",,,,,,,,44b11c7a9eef48c3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,25ce564f,code,fr,e1ce61bbe3e9aa47,"# Gate 4 : tau de Kendall par paire sur les 3 facettes, multi-graines.
+pairs = [(""ec_gain"", ""fe_gain""), (""ec_gain"", ""k_gain""), (""fe_gain"", ""k_gain"")]
+rows = []
+for seed in SEEDS:
+    ss = {""S1_tri"": traj_S1(seed), ""S2_bistable"": traj_S2(seed), ""S3_replicateur"": traj_S3(seed)}
+    r = np.random.default_rng(1000 + seed)
+    summ = S.cross_substrate_summary(ss, r, n_shuffles=N_SHUF)
+    taus = {f""{a}|{b}"": S.rank_consistency(summ, a, b)[""kendall_tau""] for a, b in pairs}
+    rows.append({""seed"": seed, **taus})
+
+hdr = f""{'graine':>6s} "" + "" "".join(f""{a[:2]}|{b[:2]}"".rjust(8) for a, b in pairs)
+print(hdr)
+print(""-"" * len(hdr))
+for row in rows:
+    print(f""{row['seed']:6d} "" + "" "".join(f""{row[f'{a}|{b}']:+8.2f}"" for a, b in pairs))
+
+# verdict : les 3 paires convergent-elles (tau ~ +1) ?
+all_taus = [row[f""{a}|{b}""] for row in rows for a, b in pairs]
+mean_tau = np.mean(all_taus)
+frac_pos = np.mean([t > 0.0 for t in all_taus])
+if mean_tau > 0.7 and frac_pos > 0.8:
+    verdict = ""CONVERGE (tau moyen > 0.7)""
+elif frac_pos > 0.6:
+    verdict = ""PARTIEL (majorite positive, accord imparfait)""
+else:
+    verdict = ""NE CONVERGE PAS (les trois facettes classent differemment)""
+print(f""\ntau moyen sur toutes paires x graines : {mean_tau:+.3f}  ({frac_pos*100:.0f}% positif)"")
+print(f""Verdict Gate 4 : {verdict}"")",,,,,,,,e1ce61bbe3e9aa47,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,963bb8bc,markdown,fr,bf328ce1396ad15b,"### Interprétation du Gate 4
+
+Les trois scalaires partagent le **même contrôle** (shuffle) mais ne mesurent **pas la même chose** : Φ est une mesure *multi-échelles* (chemin glouton), F est *ordre-1* (TPM à un pas), K est *ordre-variable* (zlib capture des cycles à toute longueur). Le verdict honnête (CONVERGE / PARTIEL / NE CONVERGE PAS) ne se prononce pas sur la *valeur absolue* des scalaires — seulement sur la *cohérence de leurs classements*. C'est exactement la discipline *sans complaisance* héritée de la Synthèse : un gain n'est crédité que contrasté à son contrôle, et une convergence n'est affirmée que mesurée par paire.",,,,,,,,bf328ce1396ad15b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,4c097c7f,markdown,fr,ffde9cdca7fa272c,"## Φ_dyn : verdict INTRINSIC documenté (sota-not-workaround, Prong A)
+
+La formule intégrale du document fondateur — moyenne temporelle sur fenêtre T de Σ_M min{φ_cause(M,t), φ_effect(M,t)} sur toutes les partitions — n'est **pas** calculée ici. La combinatoire (partitions × mécanismes M ⊆ S × moyenne temporelle) est intractable au-delà de quelques états, exactement comme pour Φ strict (PyPhi) sur de petits systèmes.
+
+Ce que le proxy `ec_gain` **préserve** : l'intégration *multi-échelles* contrastée à son contrôle dégénéré (un système crédite son émergence si elle dépasse ce que donnerait une permutation de mêmes états). Ce qu'il **perd** : le `min{cause, effect}` *par mécanisme* (la asymétrie cause/effet) et la fenêtre temporelle *explicite*.
+
+C'est un plafond **documenté honnêtement**, pas maquillé : la strate 4 porte la *réconciliation avec le cadrage fondateur*, pas la résolution de la combinatoire de Φ_dyn (laissée à un notebook dédié si l'appareil le permet un jour). Verdict **INTRINSIC** au sens de #3801 : aucune voie SOTA réelle n'est masquée.",,,,,,,,ffde9cdca7fa272c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,2ed224c6,markdown,fr,f0f94ef99da182a3,"### Gate 5 — la catastrophe comme système de coordonnées
+
+Sur S2 (paysage bistable), on balaie le paramètre de contrôle à travers le **pli** (`c_fold`). Pour chaque scalaire, on mesure le **changepoint** du gain (fenêtres glissantes de part et d'autre du pli). La prédiction fondatrice raffinée par Thom : non pas que Φ, F, K *coïncident* (Gate 4), mais qu'ils se **réorganisent au même endroit** — le pli est le squelette sur lequel les trois s'accrochent.
+
+Rôle de Thom ici : **non un 4e scalaire, mais un système de coordonnées**. On demande aux trois changepoints de coïncider à Δ près, rapporté par graine.",,,,,,,,f0f94ef99da182a3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,e513296a,code,fr,1a918cf8d2f8bfb3,"# Gate 5 : balayage du parametre de controle a travers le pli de S2.
+# Pour chaque c, on discrétise la trajectoire SDE en deciles, puis on mesure les
+# 3 gains sur une fenetre AVANT et APRES le pli. Changepoint = saut du gain.
+gm = GrazingModel()
+c_fold = gm.find_fold()
+print(f""pli de GrazingModel : c_fold = {c_fold:.3f}"")
+
+# balayage symetrique autour du pli (sous -> sur)
+c_grid = np.linspace(0.80 * c_fold, 1.20 * c_fold, 9)
+
+def gains_along_fold(seed=7, T=1200, window=300):
+    """"""Pour chaque c : ec_gain/fe_gain/k_gain moyens sur T pas.""""""
+    out = {""c"": c_grid, ""ec"": [], ""fe"": [], ""k"": []}
+    for c in c_grid:
+        xs = gm.simulate_sde(c=float(c), x0=8.0, sigma=0.45, dt=0.02, T=T, seed=seed)
+        lo, hi = np.percentile(xs, 1), np.percentile(xs, 99)
+        bins = np.linspace(lo, hi, 11)
+        states = [int(v) for v in np.clip(np.digitize(xs, bins), 0, 10)]
+        rng = np.random.default_rng(seed + int(1000 * c))
+        eg = S.emergence_gain(states, rng, n_shuffles=15)
+        out[""ec""].append(eg[""ec_gain""])
+        out[""fe""].append(eg[""fe_gain""])
+        out[""k""].append(eg[""k_gain""])
+    for k in (""ec"", ""fe"", ""k""):
+        out[k] = np.array(out[k])
+    return out
+
+G = gains_along_fold()
+fold_idx = int(np.argmin(np.abs(c_grid - c_fold)))
+
+fig, ax = plt.subplots(figsize=(7.5, 3.6))
+for key, lab, col in [(""ec"", r""$\Phi$ (ec_gain)"", ""#1b9e77""),
+                      (""fe"", r""F (fe_gain)"", ""#d95f02""),
+                      (""k"", r""K (k_gain)"", ""#7570b3"")]:
+    v = G[key]
+    # normalisation pour superposer (les trois n'ont pas la meme unite)
+    v = (v - v.min()) / (v.max() - v.min() + 1e-12)
+    ax.plot(c_grid, v, ""o-"", color=col, label=lab)
+ax.axvline(c_fold, color=""#de2d26"", ls=""--"", lw=1.2, label=f""pli $c_{{fold}}$={c_fold:.2f}"")
+ax.set_xlabel(""parametre de controle c"")
+ax.set_ylabel(""gain (normalise)"")
+ax.set_title(""Gate 5 - les trois scalaires a travers le pli bistable"")
+ax.legend(loc=""best"", fontsize=8)
+plt.tight_layout()
+plt.show()
+
+# changepoint de chaque scalaire = argmax de la derivee discrete
+def changepoint(vals):
+    return int(np.argmax(np.abs(np.diff(vals))))
+
+cps = {k: changepoint(G[k]) for k in (""ec"", ""fe"", ""k"")}
+print(f""changepoints (index dans c_grid) : Phi={cps['ec']}  F={cps['fe']}  K={cps['k']}  | pli={fold_idx}"")
+spread = max(abs(cps[k] - fold_idx) for k in (""ec"", ""fe"", ""k""))
+print(f""ecart max changepoint vs pli : {spread} pas de grille -> ""
+      f""{'COINCIDENT' if spread <= 2 else 'DECALE'} a Delta pres"")",,,,,,,,1a918cf8d2f8bfb3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,324e8045,markdown,fr,378188e8e639780e,"### Interprétation du Gate 5
+
+La catastrophe (pli de Thom) joue son rôle de **système de coordonnées** : on demande aux trois scalaires de *bouger* au même endroit (le pli), pas de *valoir* la même chose. C'est l'usage thomiste authentique — un pli n'est pas une mesure de plus, c'est le squelette sur lequel les phénomènes se réorganisent. La convergence des changepoints (à Δ de grille près) est un résultat *plus fort* que la convergence des classements du Gate 4 : elle dit que les trois facettes **réagissent à la même structure géométrique**.",,,,,,,,378188e8e639780e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,db93a05d,markdown,fr,c2a23e8b1e6a1ff0,"C'est la différence entre une théorie *affirmée* (la discussion fondatrice) et une théorie *testable* (ce que la série a construit autour). La strate 4 livre le second — le pont vers la réconciliation du cadrage (#5091) et vers les capstones suivants (MDL en ICT-16, machine epsilon en ICT-17, fleche du temps / reversibilisation en ICT-18).",,,,,,,,c2a23e8b1e6a1ff0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,b15ee514,markdown,fr,58cea0e75417642f,"---
+
+## Exercices
+
+Les trois exercices testent la **robustesse** des verdicts Gate 4 / Gate 5 à des variations de la méthode. Un verdict falsifiable doit survivre à un changement de compresseur, de mémoire du modèle, ou de substrat.",,,,,,,,58cea0e75417642f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,d5dd8289,markdown,fr,dfe99284a56efbc5,"### Exercice 1 — K par LZMA vs zlib : le verdict Gate 4 est-il robuste au compresseur ?
+
+Le module `compression` utilise zlib (niveau 9). LZMA a un dictionnaire plus large et capture des cycles plus longs. Recalculez `k_gain` avec LZMA (`lzma.compress`) et vérifiez si le classement des substrats (Gate 4) change. *Indice : importez `lzma`, ajoutez un paramètre `algo=""lzma""` à `compressed_length`, re-runnez la table Gate 4.*",,,,,,,,dfe99284a56efbc5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,c886255c,code,fr,0cec4b8483b84e26,"# Exercice 1 : K par LZMA vs zlib.
+# Etape 1 : importez lzma. Etape 2 : modifiez CMP.compressed_length pour accepter algo=""lzma"".
+# Etape 3 : re-runnez le gate 4 et comparez le verdict.
+# TODO etudiant : retournez le verdict (CONVERGE/PARTIEL/NE CONVERGE PAS) sous LZMA.
+result_ex1 = None  # TODO etudiant
+print(""Exercice 1 a completer : verdict Gate 4 sous LZMA ="", result_ex1)",,,,,,,,0cec4b8483b84e26,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,b8324d41,markdown,fr,46ac5cb01e17a410,"### Exercice 2 — F d'ordre 2 (mémoire) : la convergence s'améliore-t-elle ?
+
+`transition_surprise` estime une TPM **ordre-1** (P(s_{t+1}|s_t)). Un modèle à mémoire (ordre-2 : P(s_{t+1}|s_t, s_{t-1})) pourrait mieux capturer la structure. Implémentez une surprise d'ordre-2 et testez si le τ de Kendall (fe_gain vs ec_gain) s'améliore. *Indice : la clé est de construire des paires `(s_{t-1}, s_t)` comme ""état source"" — utiliser `tpm_estimation.state_index_map` sur les paires.*",,,,,,,,46ac5cb01e17a410,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,9045ab5e,code,fr,0dc059e7e967eadc,"# Exercice 2 : F d'ordre 2.
+# Etape 1 : ecrire transition_surprise_order2(states) qui regroupe les paires (s_{t-1},s_t).
+# Etape 2 : calculer fe_gain_order2 et le tau de Kendall vs ec_gain.
+# TODO etudiant
+result_ex2 = None  # TODO etudiant
+print(""Exercice 2 a completer : tau (F_ordre2 vs Phi) ="", result_ex2)",,,,,,,,0dc059e7e967eadc,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,83acbfd7,markdown,fr,902fd17485b0961a,"### Exercice 3 — Gate 5 sur S3 : le réplicateur stratégique a-t-il un pli ?
+
+Gate 5 n'a testé que S2 (le substrat bistable naturel). S3 (réplicateur) a-t-il lui aussi une structure de *pli* — un paramètre de contrôle dont le balayage fait basculer les trois scalaires au même endroit ? Le réplicateur d'Axelrod n'a pas de paramètre de bifurcation évident, mais le **nombre de stratégies** ou le **taux de mutation** peuvent jouer ce rôle. *Indice : `SM.make_strategies` + `SM.replicator_trajectory` ; balayez le nombre de stratégies et regardez les changepoints.*",,,,,,,,902fd17485b0961a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,1da5734a,code,fr,9a225154b7f2ee8b,"# Exercice 3 : Gate 5 sur S3 (replicateur).
+# Etape 1 : identifier un parametre de controle pour S3 (nb de strategies, taux de mutation).
+# Etape 2 : balayer ce parametre et mesurer les changepoints des 3 scalaires.
+# Etape 3 : verdict - y a-t-il coincidence des changepoints ?
+# TODO etudiant
+result_ex3 = None  # TODO etudiant
+print(""Exercice 3 a completer : Gate 5 sur S3, verdict ="", result_ex3)",,,,,,,,9a225154b7f2ee8b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15-IntegratedComplexity.ipynb,6024e699,markdown,fr,2fe9f55a6a6ac812,"**Prochaines étapes** (Epic #4588, strate 5) : ICT-16 (MDL deux parties, le pont F = résiduel de K), ICT-17 (machine epsilon, complexité statistique), ICT-18 (FlecheDuTempsReversibilisation, production d'entropie thermodynamique et reversibilisation -- le pendant *thermodynamique* de la complexite de representation d'ICT-17, GPU-free). La réconciliation du cadrage (double lecture du sigle) est l'objet dédié de #5091.",,,,,,,,2fe9f55a6a6ac812,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,8c29c0c4,markdown,fr,e1d9c98e54407cca,"# ICT-16 — MDL / code en deux parties et bosse complexite-entropie
+
+**Strate 5** | Epic **#4588** | Issue **#5099** | Part of **#4588** (Closes **#5099**).
+
+## Pourquoi MDL apres K (ICT-13) et F (ICT-14) ?
+
+ICT-0 a pose que l'integration ($\Phi$), la surprise ($F$) et la compression ($K$) sont trois facettes d'un meme quantite. ICT-13 a attache la jambe $K$ a la **longueur** d'une trajectoire reelle par contraste shuffle -- mais un `k_gain > 0` ne dit rien sur la *forme* du modele : toute la complexite est-elle dans la **matrice de transition** ou dans les fluctuations atypiques ? ICT-16 attache $K$ a la **structure interne** du modele via le principe MDL (Minimum Description Length, Rissanen 1978) -- code en deux parties : `bits_modele` (decrire la TPM avec un prior) + `bits_residuel` (encoder les residuals d'un modele idealise par cette TPM).
+
+## Plan
+
+1. **Codelength du modele** : prior de Krichevsky-Trofimov (KT) sur une TPM empirique.
+2. **Code deux parties** : split apprentissage / held-out, `bits_modele + bits_residuel`.
+3. **Entropie par bloc (plug-in)** : `H(block) / block` comme estimateur du taux.
+4. **Bosse complexite-entropie** (Crutchfield-Feldman 1998) : scatter $H_{taux}$ vs `model_bits` et vs $k_{gain}$.
+5. **Gates falsifiables** : G6 (identite comptable MDL/zlib) + G7 (bosse complexite-entropie).
+6. **Trois exercices** (stub ; a completer).
+
+**Dependances** : `ict.mdl` (numpy-only), `ict.compression` (numpy + zlib). Pas de GPU, pas de Lean. Notebook executable end-to-end (les exercices sont stubs mais ne leveent pas d'exception -- regle C.1).",,,,,,,,e1d9c98e54407cca,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,548759d1,markdown,fr,b819f61bd215bea1,"## 1. Codelength d'une TPM : prior de Krichevsky-Trofimov
+
+Le prior KT pour une distribution multinomiale a $k$ categories ajoute $1/2$ a chaque compte, ce qui lisse les probabilites vers $1/k$ sans jamais atteindre zero. La codelength marginale d'une ligne $n_{i,1}, \dots, n_{i,k}$ vaut :
+
+$$\ell_{\text{KT}}(n_{i,:}) = \sum_{j=1}^{k} \log_2(n_{i,j} + 1/2) - k \cdot \log_2(k + 1/2)$$
+
+Somme sur les lignes + surcharge `log2(k)` pour declarer la taille du modele = `tpm_description_length(counts)`.
+
+**Limite honnete** : KT peut renvoyer des codelengths *negatives* quand les prior multinomiaux ($\log_2(0 + 1/2) = -1$ bit par case zero) compensent largement la somme des comptes observes. C'est pourquoi le code deux parties compare `total_bits = model_bits + residual_bits` plutot que `model_bits` seul.",,,,,,,,b819f61bd215bea1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,dba01272,code,fr,9cd9d87d4d324953,"import os
+import sys
+
+_NOTEBOOK_DIR = os.path.dirname(os.path.abspath(""__file__"")) if False else os.getcwd()
+_PARENT = os.path.dirname(_NOTEBOOK_DIR)
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+
+import numpy as np
+from ict import mdl as M
+from ict import compression as CMP
+
+rng = np.random.default_rng(42)
+print('ict.mdl charge OK')
+print('ict.compression charge OK')
+",,,,,,,,9cd9d87d4d324953,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,ca41573f,code,fr,bb719eaadc34483e,"# Demonstration : codelength KT sur 3 TPM-types.
+k = 4
+uniform = np.ones((k, k), dtype=float)            # 1 par case
+sparse = np.eye(k, dtype=float)                   # 1 transition par ligne
+diagonal = np.diag([20, 15, 10, 5]).astype(float) # asymetrique
+
+for name, tpm in [('uniform', uniform),
+                  ('sparse (eye)', sparse),
+                  ('diagonal asym.', diagonal)]:
+    bits = M.tpm_description_length(tpm)
+    print(f'  {name:18s}  model_bits = {bits:+8.3f}')
+
+# NOTE : KT produit des codelengths NEGATIVES -- le signe est
+# porte par le prior, pas par la 'simplicite' du modele.
+# Comparaison inter-modeles = `total_bits` (avec residuel), pas
+# `model_bits` seul. C'est le coeur du code deux parties.",,,,,,,,bb719eaadc34483e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,9ca54b78,markdown,fr,34796e31569b249c,"## 2. Code deux parties : modele + residu
+
+Split fixe (defaut 50/50) entre transitions d'apprentissage et held-out. Le **modele** est la TPM empirique + prior KT sur la partie apprentissage. Le **residu** est la surprise cumulee $- \sum \log_2 p(s_{t+1} | s_t)$ sur la partie held-out.
+
+C'est l'identite comptable fondamentale du MDL :
+
+$$K(\text{trajectoire}) \approx \underbrace{L(M)}_{\text{modele}} + \underbrace{L(D | M)}_{\text{residuel}}$$
+
+Pour un cycle deterministe appris sur la trajectoire elle-meme, le residu tend vers 0 (chaque transition est predite avec proba ~1). Pour une trajectoire iid, le residu par symbole tend vers $H_1$ (l'entropie marginale du reservoir d'etats).",,,,,,,,34796e31569b249c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,468eb53f,code,fr,4cc8ff491ec24eb5,"# Cycle deterministe (periode 3) : residu ~ 0.
+seq_cycle = [0, 1, 2] * 50
+out_cycle = M.two_part_code(seq_cycle, split=0.5)
+print(f'cycle     : model_bits={out_cycle[""model_bits""]:+8.3f} '
+      f'residual={out_cycle[""residual_bits""]:+8.3f} '
+      f'residual/n={out_cycle[""residual_bits""]/out_cycle[""n_heldout""]:.4f}')
+
+# Trajectoire iid sur 4 etats : residu/n -> log2(4) = 2 bits.
+seq_iid = rng.integers(0, 4, size=500).tolist()
+out_iid = M.two_part_code(seq_iid, split=0.5)
+print(f'iid 4-cat : model_bits={out_iid[""model_bits""]:+8.3f} '
+      f'residual={out_iid[""residual_bits""]:+8.3f} '
+      f'residual/n={out_iid[""residual_bits""]/out_iid[""n_heldout""]:.4f}')
+
+# Markov ordre 1 (0->1, 1->2, 2->0, + epsilon de bruit) :
+# residu > 0 mais < H_1, capture la structure au-dela du shuffle.
+seq_mk = []
+s = 0
+for _ in range(500):
+    if rng.random() < 0.1:
+        s = int(rng.integers(0, 4))
+    seq_mk.append(s)
+    s = (s + 1) % 4
+out_mk = M.two_part_code(seq_mk, split=0.5)
+print(f'markov+10% : model_bits={out_mk[""model_bits""]:+8.3f} '
+      f'residual={out_mk[""residual_bits""]:+8.3f} '
+      f'residual/n={out_mk[""residual_bits""]/out_mk[""n_heldout""]:.4f}')
+",,,,,,,,4cc8ff491ec24eb5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,3e2b025b,markdown,fr,0a22c51a4d720191,"## 3. Taux d'entropie plug-in
+
+Le **plug-in** $H_k / k$ (entropie de Shannon sur les $k$-grammes divisee par $k$) sous-estime systematiquement le vrai taux d'entropie (biais $\sim -1/(n \cdot 2^k \ln 2)$ -- pas corrige ici, par souci de simplicite ; Miller-Madow ajouterait un terme $(k^{\text{vocab}} - 1)/(2n \ln 2)$).
+
+Pour des dynamiques markoviennes d'ordre $d$, $H_k / k$ converge vers le taux quand $k \to \infty$ ; pour des dynamiques iid, $H_k = k \cdot H_1$ et le taux est constant en $k$. C'est pourquoi la **courbe $H_k / k$ vs $k$** est un diagnostic direct de l'ordre markovien.",,,,,,,,0a22c51a4d720191,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,04eb80c5,code,fr,cbbef371f26caf0e,"# iid 4 etats : taux constant en k (= log2(4) = 2).
+for k in (1, 2, 3, 4):
+    h = M.entropy_rate_estimate(seq_iid, block=k)
+    print(f'  iid   block={k}  H/k = {h[""entropy_rate""]:.4f}')
+
+# cycle deterministe : taux decroit vers 0 avec k (la sequence
+# est compressible, peu d'information par symbole).
+print()
+for k in (1, 2, 3):
+    h = M.entropy_rate_estimate(seq_cycle, block=k)
+    print(f'  cycle block={k}  H/k = {h[""entropy_rate""]:.4f}')
+",,,,,,,,cbbef371f26caf0e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,d7fc94c3,markdown,fr,2b1c17d7c18bec97,"## 4. Bosse complexite-entropie (Crutchfield-Feldman 1998)
+
+Pour un systeme adapte a des donnees reelles, la **complexite statistique** $C_\mu$ (approximee ici par `model_bits` en log2) passe par un **maximum** a entropie intermediaire entre 0 (determinisme, $C_\mu = 0$) et la borne $H_1$ du reservoir (reservoir maximal mais information triviale). Cette bosse est le **tradeoff complexite-entropie** :
+
+- Systemes tres structures (cycles, periodiques) : $H \to 0$, $C \to 0$ (modele trivial).
+- Systemes aleatoires (iid) : $H \to H_1$, $C \to 0$ (le modele est juste la distribution marginale).
+- Systemes interessants (markoviens ordre > 0, attracteurs chaotiques) : $H$ intermediaire, $C > 0$ (le modele doit memoriser les transitions).
+
+La position et la hauteur de la bosse dependent de la discretisation (taille du bloc) et du split apprentissage / held-out -- verifiees sur le Gate 7 dans le notebook.",,,,,,,,2b1c17d7c18bec97,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,954d31fc,code,fr,9f1073f751ec6f7b,"# Construction d'un echantillonnage de trajectoires de complexite
+# croissante : deterministe -> periodique -> markov -> iid.
+def mk_periodic(period, n):
+    return (list(range(period)) * (n // period + 1))[:n]
+
+def mk_markov(k, p_stay, n, seed):
+    r = np.random.default_rng(seed)
+    out = [0]
+    for _ in range(n - 1):
+        s = out[-1]
+        if r.random() < p_stay:
+            out.append(s)
+        else:
+            out.append(int(r.integers(0, k)))
+    return out
+
+trajs = {
+    'det k=2':   mk_periodic(2, 800),
+    'det k=3':   mk_periodic(3, 800),
+    'det k=5':   mk_periodic(5, 800),
+    'mk p=.7':   mk_markov(4, 0.7, 800, seed=1),
+    'mk p=.5':   mk_markov(4, 0.5, 800, seed=2),
+    'mk p=.3':   mk_markov(4, 0.3, 800, seed=3),
+    'iid 4':     rng.integers(0, 4, size=800).tolist(),
+    'iid 8':     rng.integers(0, 8, size=800).tolist(),
+}
+
+sweep = M.complexity_entropy_sweep(
+    list(trajs.values()),
+    blocks=(1, 2, 3),
+    splits=(0.5,),
+    rng=np.random.default_rng(0),
+    n_shuffles=5,
+)
+print(f'sweep : {sweep[""summary""][""n_rows""]} lignes')
+print(f'  H_taux range : [{sweep[""summary""][""H_rate_min""]:.3f}, '
+      f'{sweep[""summary""][""H_rate_max""]:.3f}]')
+print(f'  pic bosse    : H*={sweep[""summary""][""peak_H_rate""]:.3f}, '
+      f'C*={sweep[""summary""][""peak_model_bits""]:.3f} bits')
+print(f'  k_gain moyen : {sweep[""summary""][""k_gain_mean""]:.4f}')
+",,,,,,,,9f1073f751ec6f7b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,207f617e,code,fr,fbf6c940a7519b67,"# Visualisation ASCII rapide de la bosse H_taux vs model_bits.
+rows = sweep['rows']
+Hs = np.array([r['H_rate'] for r in rows])
+Cs = np.array([r['model_bits'] for r in rows])
+
+# Scatter simplifie : on regroupe par H_taux approx et on prend
+# le median de model_bits dans chaque bucket.
+buckets = np.linspace(Hs.min(), Hs.max(), 12)
+meds = []
+for i in range(len(buckets) - 1):
+    sel = (Hs >= buckets[i]) & (Hs < buckets[i + 1])
+    if sel.sum() > 0:
+        meds.append((0.5 * (buckets[i] + buckets[i + 1]),
+                     float(np.median(Cs[sel]))))
+
+print('  H_taux |  model_bits  | bar')
+for h, c in meds:
+    bar = '#' * max(0, int((c + 30) * 2))
+    print(f'  {h:.3f} | {c:+8.3f}    | {bar}')
+
+# Le pic est-il entre H=0 et H=H_1 ? (Gate 7 -- bosse
+# complexite-entropie de Crutchfield-Feldman.)
+peak_H = sweep['summary']['peak_H_rate']
+H1_iid = np.log2(8)  # borne sup du reservoir = 8 etats
+print(f'\n  pic a H={peak_H:.3f} (interieur [0, {H1_iid:.3f}] = {0 < peak_H < H1_iid})')
+",,,,,,,,fbf6c940a7519b67,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,84b23cad,code,fr,c8ece79639280c0a,"# --- Visualisation graphique de la bosse complexite-entropie (Crutchfield-Feldman 1998) ---
+# La cellule precedente trace la bosse en ASCII ; ici on la rend en vrai graphique
+# matplotlib : nuage des trajectoires + mediane lissee par bucket + marqueur du pic.
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(8.5, 5))
+
+# Nuage : chaque trajectoire echantillonnee contribue a un point (H_rate, model_bits)
+ax.scatter(Hs, Cs, s=55, alpha=0.55, color=""#2c3e50"", edgecolors=""white"",
+           linewidths=0.6, label=""trajectoires echantillonnees"", zorder=2)
+
+# Bosse lissee : mediane de model_bits par bucket de H_rate (meme grouping que l'ASCII)
+bh = np.array([m[0] for m in meds])
+bc = np.array([m[1] for m in meds])
+order = np.argsort(bh)
+ax.plot(bh[order], bc[order], color=""#c0392b"", lw=2.4, marker=""o"", ms=6,
+        label=""mediane par bucket (bosse)"", zorder=3)
+
+# Pic de complexite statistique : maximum a entropie intermediaire
+peak_C = sweep['summary']['peak_model_bits']
+ax.scatter([peak_H], [peak_C], s=220, marker=""*"", color=""#e67e22"",
+           edgecolors=""black"", linewidths=1.2, zorder=4,
+           label=f""pic C*={peak_C:.1f} bits a H*={peak_H:.2f}"")
+
+ax.set_xlabel(""Taux d'entropie $H$ (bits/symbole)"", fontsize=11)
+ax.set_ylabel(""Longueur de code du modele (bits)"", fontsize=11)
+ax.set_title(""Bosse complexite-entropie (Crutchfield-Feldman 1998)\n""
+             ""La complexite statistique est maximale a entropie intermediaire"",
+             fontsize=11, fontweight=""bold"")
+ax.axhline(0, color=""#bdc3c7"", lw=0.8, ls=""--"", zorder=1)
+ax.grid(True, alpha=0.25)
+ax.legend(loc=""lower center"", fontsize=9, framealpha=0.9)
+plt.tight_layout()
+plt.show()
+print(""Bosse complexite-entropie rendue en graphique matplotlib."")",,,,,,,,c8ece79639280c0a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,466e8372,markdown,fr,0a50dccdada8f780,"## 5. Identite comptable MDL vs zlib (Gate 6, controle sans complaisance)
+
+Le Gate 6 verifie que `total_bits = model_bits + residual_bits` est un **estimateur honnete** de la longueur de description minimale. Le testclef : sur un echantillon de trajectoires differentes, le **rang** de `total_bits` doit correler avec le rang de la longueur zlib (ICT-13) avec un $\tau$ de Kendall positif sur au moins 5 graines.
+
+L'intuition : si MDL est honnete, une trajectoire tres compressible en zlib (cycle) doit avoir un `total_bits` faible ; une trajectoire peu compressible (iid) doit avoir un `total_bits` eleve. Si la correlation est negative ou nulle, MDL ne capture pas la compressibilite reelle.",,,,,,,,0a50dccdada8f780,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,8012201f,code,fr,9507a7b891a8b4d6,"# Gate 6 : correlation de rang Kendall(total_bits, len_zlib).
+from scipy.stats import kendalltau
+
+def zlib_bits(seq):
+    return 8.0 * CMP.compressed_length(seq)
+
+names = list(trajs.keys())
+total_bits_list = []
+zlib_bits_list = []
+k_gains = []
+for name, seq in trajs.items():
+    mdl = M.two_part_code(seq, split=0.5)
+    total_bits_list.append(mdl['total_bits'])
+    zlib_bits_list.append(zlib_bits(seq))
+    kg = CMP.compression_gain(seq, rng=np.random.default_rng(0),
+                              n_shuffles=5)
+    k_gains.append(kg['k_gain'])
+
+tau, p = kendalltau(total_bits_list, zlib_bits_list)
+print(f'  Kendall tau(total_bits, zlib_bits) = {tau:+.3f}  (p={p:.3f})')
+print(f'  ATTENDU : tau >= 0.5 (MDL honnete si >= 0)')
+
+# Tableau final
+print(f'\n  {""trajectoire"":12s}  {""total_bits"":>10s}  '
+      f'{""zlib_bits"":>10s}  {""k_gain"":>8s}')
+for n, tb, zb, kg in zip(names, total_bits_list, zlib_bits_list, k_gains):
+    print(f'  {n:12s}  {tb:+10.2f}  {zb:10.2f}  {kg:+8.4f}')
+",,,,,,,,9507a7b891a8b4d6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,b875f461,markdown,fr,656c1d635680a28a,"## 6. Exercices
+
+Trois exercices a completer. Stubs **sans erreur volontaire** (regle C.1 : `pass` / `print` / `return None`, JAMAIS `raise NotImplementedError`). Le notebook s'execute de bout en bout meme non complete.",,,,,,,,656c1d635680a28a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,e48d34d1,markdown,fr,3787e433897b8fb0,"### Exercice 1 — prior uniforme vs KT
+
+Comparez `tpm_description_length` sous deux priors :
+
+- **KT** (l'actuel, $n + 1/2$ smoothing).
+- **Uniforme** ($n + 1$ smoothing, ajoute 1 au lieu de $1/2$).
+
+Objectif : tracez la difference `bits_KT - bits_uniforme` pour des TPM de taille $k = 2, 3, 5, 10$ tirees avec un parametre de concentration $\alpha$ variable (Dirichlet). Montrez que la difference depend du **degre de confiance** dans la TPM empirique (peu de comptes = gros avantage KT).
+
+**Indice** : `np.random.default_rng(seed).dirichlet(alpha, size=k)` puis multiplier par `n_total` pour obtenir des comptes.",,,,,,,,3787e433897b8fb0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,1935ec29,code,fr,0810a9ad85b0d5de,"# Exercice 1 : a completer
+def tpm_description_length_uniform(counts):
+    """"""Codelength sous prior uniforme (n + 1 smoothing).
+
+    A implementer : KT est n + 1/2, uniforme est n + 1. Le
+    reste de la formule est identique. Retourne un float en
+    bits. Verifiez que la sortie est >= 0 partout (propriete du
+    prior uniforme, contrairement a KT).
+    """"""
+    # TODO etudiant : reprendre la formule KT et remplacer 0.5 par 1.0
+    pass
+
+ex1_rows = []
+# TODO etudiant : boucle sur k in (2,3,5,10), alpha in (0.1,1,10),
+#                 calculer bits_KT - bits_uniforme, stocker dans ex1_rows.
+print(""Exercice 1 a completer"")
+",,,,,,,,0810a9ad85b0d5de,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,17535069,markdown,fr,d6a63078aa8d0b94,"### Exercice 2 — resolution de discretisation et bosse
+
+La position et la hauteur du pic de la bosse complexite-entropie dependent de la **taille du bloc** $k$ et du **split** apprentissage / held-out.
+
+Objectif : pour l'echantillon `trajs` (8 trajectoires de complexite croissante), lancez `complexity_entropy_sweep` avec `blocks=(1,2,3,4,5,6)` et `splits=(0.3, 0.5, 0.7)`. Tracez :
+
+- `peak_H_rate` vs `block` (la bosse se deplace-t-elle vers les grandes entropies quand le bloc grandit ?).
+- `peak_model_bits` vs `split` (le residu grandit-il avec le held-out ? la bosse s'aplatit-elle ?).
+
+**Indice** : reutilisez `complexity_entropy_sweep` directement ; pas besoin de reimplementer le balayage.",,,,,,,,d6a63078aa8d0b94,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,545209fa,code,fr,4b0eb1ea7e765730,"# Exercice 2 : a completer
+ex2_peak_by_block = {}  # bloc -> (peak_H, peak_C)
+ex2_peak_by_split = {}  # split -> (peak_H, peak_C)
+
+# TODO etudiant : deux boucles sur blocks et splits, remplir les
+#                 deux dictionnaires. Conseil : utiliser une SEULE
+#                 trajectoire (e.g. trajs['mk p=.5']) pour isoler
+#                 l'effet discretisation.
+print(""Exercice 2 a completer"")
+",,,,,,,,4b0eb1ea7e765730,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,89baf848,markdown,fr,3694312a15e9ffb3,"### Exercice 3 — code 2 parties d'ordre 2
+
+Le modele par defaut est **markovien d'ordre 1** (la TPM code les transitions $s_t \to s_{t+1}$). Un modele d'**ordre 2** code les transitions $(s_t, s_{t+1}) \to s_{t+2}$ : la TPM devient $k^2 \times k$ au lieu de $k \times k$.
+
+Objectif : implementer `two_part_code_order2(states, split)` qui :
+
+1. Reindexe les **paires** $(s_t, s_{t+1})$ par ordre de premiere apparition (mapping).
+2. Estime une TPM $k^2 \times k$ sous prior KT.
+3. Split apprentissage / held-out, residu via $- \log_2 p(s_{t+2} | s_t, s_{t+1})$.
+
+Verifiez sur `mk_markov(4, 0.5, 800, seed=2)` que `residual/n` est **inferieur** au residu ordre 1 (le modele ordre 2 capture plus de structure).
+
+**Indice** : reutilisez `tpm_description_length` (qui prend n'importe quelle matrice carree) ; la forme des transitions est `(s_t, s_{t+1}) -> s_{t+2}`, donc compte = `TPM[i, j, k]` avec `i = mapping[(s_t, s_{t+1})]` et `k = mapping_target[s_{t+2}]`.",,,,,,,,3694312a15e9ffb3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,1e45c163,code,fr,82019e6dd186fb80,"# Exercice 3 : a completer
+def two_part_code_order2(states, split=0.5):
+    """"""MDL ordre 2 : TPM (s_t, s_{t+1}) -> s_{t+2}.
+
+    Doit retourner le meme contrat que ``two_part_code`` :
+    ``{model_bits, residual_bits, total_bits, n_train,
+    n_heldout, states_count}``.
+    """"""
+    # TODO etudiant : construire les paires (s_t, s_{t+1}) ->
+#                    s_{t+2}, estimer TPM ordre 2, split + residu.
+    pass
+
+ex3_result = None  # TODO etudiant
+print(""Exercice 3 a completer"")
+",,,,,,,,82019e6dd186fb80,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb,e68e2598,markdown,fr,5b9793b220cddb51,"## Conclusion
+
+ICT-16 attache la jambe $K$ a la **structure interne** du modele (MDL / code en deux parties), au-dela de la simple longueur zlib d'ICT-13. La frontiere entre $F$ (surprise held-out) et $K$ (longueur du modele) devient explicite : `total_bits = model_bits + residual_bits`.
+
+**Liens vers les autres jambes** :
+
+- $\Phi$ : ICT-1, ICT-2, ICT-5 (cause-effect information, reintegration).
+- $F$ : ICT-14 (free-energy surprise, `transition_surprise`).
+- $K$ : ICT-13 (longueur zlib + shuffle), ICT-16 (MDL + KT).
+
+**Gates falsifiables** :
+
+- **G6 (identite comptable)** : $\tau_{\text{Kendall}}(\text{total\_bits}, \text{len\_zlib}) \geq 0$ sur $\geq 5$ graines (verifie plus haut).
+- **G7 (bosse complexite-entropie)** : $\exists \text{ pic } (H^*, C^*) \in ]0, H_1[$ (verifie plus haut pour `sweep` 8 trajectoires).
+
+**Suite (ICT-17 EpsilonMachine)** : partition d'etats causaux (Crutchfield), complexite statistique $C_\mu$, entropie d'exces $E$ -- le pendant operationnel de la bosse $C$ vs $H$ d'ICT-16.",,,,,,,,5b9793b220cddb51,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,79a86521,markdown,fr,dd64b17f4e6b0e8f,"# ICT-17 -- Mecanique computationnelle (epsilon-machine de Crutchfield)
+
+**Strate 5, Epic #4588, See #5100.**
+
+ICT-15 (capstone) a pose que l'integration ($\Phi$), la surprise ($F$) et la
+compression ($K$) sont trois facettes d'un meme quantite -- *un systeme qui
+modelise son monde*. ICT-16 (mdl.py) a attache la jambe $K$ a la structure
+INTERNE du modele (MDL deux parties). ICT-17 importe la **discipline** de
+Crutchfield -- la *mecanique computationnelle* -- et ses trois objets exacts :
+
+  - **etats causaux** : classes d'equivalence de passes a distribution
+    conditionnelle de futurs identique. C'est LA reponse de Crutchfield a
+    la question ""quel est le bon macro-etat ?""
+  - **$C_\mu$ (complexite statistique)** : entropie de la distribution
+    stationnaire des etats causaux -- la quantite de memoire que le
+    systeme doit conserver pour predire son futur.
+  - **entropie d'exces $E$** : information mutuelle passe / futur -- c'est
+    la borne superieure de ce que N'IMPORTE QUEL estimateur $\hat{p}$ peut
+    capturer (la ""jambe $K$"" d'ICT-13 bornee par $E$).
+
+Ce notebook confronte deux reponses rivales au meme probleme de coarse-graining
+sur trois substrats experimentaux :
+  - **S1** : tri auto-organise (ICT-2 self-sorting morphogenese)
+  - **S2** : paysage bistable / reaction-diffusion (ICT-10 catastrophes, ICT-12 valence)
+  - **S3** : replicateur strategique / Axelrod (ICT-13 cooperation)
+
+Plan :
+  1. Definitions et algorithme Crutchfield
+  2. Substrat S1 : tri auto-organise -- demonstration $C_\mu$ chute apres tri
+  3. Substrat S2 : bistable -- pic de $C_\mu$ a la transition
+  4. Substrat S3 : replicateur -- $C_\mu$ maximal en cooperation emergente
+  5. **Gate 8** Crutchfield vs Hoel : table de similarite
+  6. **Gate 9** $E$ comme plafond : comparons aux estimateurs $\hat{p}$ d'ICT-10
+  7. Exercices (3 conformement a #2161)
+
+Ce notebook est **GPU-free**, **numpy-only**, et genere les substrats a la
+volee via les modules ``ict`` (pas de ``.npz`` pre-committed).
+",,,,,,,,dd64b17f4e6b0e8f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,ac06b994,markdown,fr,2dec2d7e6bfba5ee,"## 1. Setup
+
+On importe le module ``ict/epsilon_machine.py`` (C198) + les modules
+``ict/`` voisins qui produisent les substrats S1/S2/S3. Tous les imports
+sont locaux au dossier ``ICT-Series`` : on ajoute le parent au path.
+",,,,,,,,2dec2d7e6bfba5ee,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,8a3e6792,code,fr,5fdac97a90e01034,"import os
+import sys
+
+# C198-HARD (lecon ICT-16 reprise) : en nbconvert, ``__file__`` n'est PAS
+# defini dans une cellule. ``os.getcwd()`` reflete le workdir d'execution,
+# qui EST le dossier ``ICT-Series`` quand on lance ``jupyter nbconvert``
+# depuis ce dossier.
+_NOTEBOOK_DIR = os.getcwd()
+_PARENT = os.path.dirname(_NOTEBOOK_DIR)
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+if _NOTEBOOK_DIR not in sys.path:
+    sys.path.insert(0, _NOTEBOOK_DIR)
+
+import numpy as np
+import matplotlib
+matplotlib.use(""Agg"")
+import matplotlib.pyplot as plt
+
+# Module ICT-17 (C198)
+from ict import epsilon_machine as EM
+
+# Modules voisins pour les substrats S1/S2/S3
+from ict import self_sorting as SS
+from ict import bistable as BS
+from ict import trajectories as TR
+from ict import tpm_estimation as TE
+from ict import causal_emergence as CE  # pour greedy_apportionment (Hoel)
+
+print(""Python :"", sys.version.split()[0])
+print(""ICT-17 epsilon_machine :"", [n for n in dir(EM) if not n.startswith(""_"")])
+print(""Substrats S1/S2/S3 modules : self_sorting, bistable, trajectories OK"")
+",,,,,,,,5fdac97a90e01034,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,28c06a43,markdown,fr,a6dadb1e6f6e6578,"## 2. L'algorithme Crutchfield (U-algorithme simplifie)
+
+L'idee centrale est presque tautologique : *deux passes (longueur $h$) sont
+dans le meme etat causal si et seulement si la distribution de leurs futurs
+(longueur $f$) est indistinguable*. C'est la partition la plus grossiere
+compatible avec la predictivite.
+
+**Notation.** Soit $X_{<t} = (X_{t-h}, \dots, X_{t-1})$ la passe a
+l'instant $t$, et $X_{t+} = (X_t, \dots, X_{t+f-1})$ son futur. On dit que
+$X_{<t} \sim X_{<t'}$ ssi $\| p(X_{t+} | X_{<t}) - p(X_{t'+} | X_{<t'}) \|_1 / 2 \le \epsilon$.
+
+L'algorithme est implementee dans ``EM.causal_state_partition`` :
+  1. Construire le mapping passe $\to$ comptage des futurs associes.
+  2. Clustering initial par egalite exacte des distributions.
+  3. Fusion iterative des paires a distance $L_1/2 \le \epsilon$.
+
+Deux metriques derivent de la partition :
+  - **$C_\mu$** : entropie (log2) de la distribution stationnaire des etats causaux.
+  - **$E$** : information mutuelle entre passe et futur (convergence des entropies de bloc).
+
+**Why $E$ matters.** $E$ est la borne superieure universelle sur ce que
+N'IMPORTE QUEL estimateur $\hat{p}$ peut capturer (Crutchfield & Feldman
+2003). C'est l'invariant qu'ICT-10 (CatastropheGrammar) essaie
+d'approcher par ses modeles $p_\theta$, et c'est la jambe ""memoire"" de la
+complexite integree.
+",,,,,,,,a6dadb1e6f6e6578,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,20a9d3f7,code,fr,979a7453cdb2c0fd,"# Demonstration minimale sur une sequence deterministe
+seq_demo = [0, 1, 2] * 30  # cycle 3
+
+# Crutchfield (history_len=3, future_len=3 : capture toute la periode)
+part_demo = EM.causal_state_partition(
+    seq_demo, history_len=3, future_len=3, tol=1e-6
+)
+C_demo = EM.statistical_complexity(part_demo, seq_demo)
+E_demo = EM.excess_entropy_estimate(seq_demo, max_block=4)
+
+print(""=== Sequence cyclique 0,1,2 ==="")
+print(f""n_histories        : {part_demo['n_histories']}"")
+print(f""n_causal_states    : {part_demo['n_causal_states']}"")
+print(f""stationary dist.   : { {k: round(v, 3) for k, v in C_demo['stationary'].items()} }"")
+print(f""C_mu (bits)        : {C_demo['C_mu']:.4f}"")
+print(f""E_estimate (bits)  : {E_demo['E_estimate']:.4f}"")
+print(f""E_series (k, E_k)  : {E_demo['E_series']}"")
+print()
+print(""Interpretation : cycle 3 deterministe -> 3 etats causaux (un par phase), ""
+      f""C_mu = log2(3) = {np.log2(3):.4f} bits (chaque phase a la meme freq 1/3)."")
+print(f""E = log2(3) = {np.log2(3):.4f} bits (la passe complete identifie la phase)."")
+",,,,,,,,979a7453cdb2c0fd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,c1975d39,markdown,fr,0dc4b8ae54b07a0c,"## 3. Substrat S1 -- tri auto-organise (ICT-2)
+
+Le tri auto-organise produit une trajectoire OU les elements se classent
+spontanement par ""valeur"". En discret, on observe un regime initial
+**chaotique** (distribution des positions uniforme) puis un regime
+**trie** (positions correlees aux valeurs).
+
+**Hypothese.** $C_\mu$ doit chuter apres le tri : la trajectoire est de
+plus en plus compressible (ICT-13 jambe $K$), donc moins de memoire est
+necessaire pour la predire.
+
+On prend une trajectoire S1 simulee par le module ``self_sorting`` et on
+discute l'evolution de $C_\mu$ sur la trajectoire mobile.
+",,,,,,,,0dc4b8ae54b07a0c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,b9883ffd,code,fr,5f129a41ef448e0a,"# Substrat S1 : trajectoire de tri auto-organise via ``self_sorting``
+# On prend la sortie ""symbolique"" : a chaque pas, on code l'etat par
+# la paire (position_normalisee, valeur_normalisee) quantifiee en k bins.
+import numpy as np
+
+rng = np.random.default_rng(20260703)
+
+# Generation d'une trajectoire S1 : on simule un processus de tri 1D
+# ou chaque pas rapproche les voisins de meme valeur (akin au modèle
+# de Craig-Kapral). On discretise en 4 categories (2 bits d'etat).
+n_steps = 1500
+states_s1 = np.zeros(n_steps, dtype=int)
+x = rng.uniform(0, 1, size=200)  # etats continus
+v = rng.uniform(0, 1, size=200)  # valeurs
+for t in range(n_steps):
+    # Pas de diffusion + alignement lent (auto-organisation)
+    x = x + 0.05 * (np.roll(x, -1) - x)  # diffusion
+    x = np.clip(x, 0, 1)
+    v = v + 0.02 * (np.roll(v, 1) - v)
+    # Discretisation en 4 categories
+    states_s1[t] = int(np.digitize(x[100], [0.25, 0.5, 0.75]))
+
+print(f""S1 trajectoire generee : n={len(states_s1)}, ""
+      f""distribution={np.bincount(states_s1).tolist()}"")
+
+# Partition Crutchfield sur la trajectoire complete
+part_s1 = EM.causal_state_partition(
+    [int(s) for s in states_s1], history_len=3, future_len=3, tol=0.05
+)
+C_s1 = EM.statistical_complexity(part_s1, states_s1.tolist())
+E_s1 = EM.excess_entropy_estimate(states_s1.tolist(), max_block=4)
+
+print(f""S1 n_causal_states   : {part_s1['n_causal_states']}"")
+print(f""S1 C_mu (bits)       : {C_s1['C_mu']:.4f}"")
+print(f""S1 E_estimate (bits) : {E_s1['E_estimate']:.4f}"")
+",,,,,,,,5f129a41ef448e0a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,b0bbf115,markdown,fr,739647c1640a1140,"## 4. Substrat S2 -- paysage bistable (ICT-10, ICT-12)
+
+Le modele de broutage (May 1977) $\dot{x} = rx(1-x/K) - cx^2/(x^2+h^2)$
+presente deux regimes :
+  - **monostable** : equilibre unique stable.
+  - **bistable** : deux equilibres stables separes par un selle.
+
+A la transition (bifurcation a col, *fold*), le paysage de potentiel
+change qualitativement -- c'est la **catastrophe au sens de Thom**.
+
+**Hypothese (bonus Gate).** $C_\mu$ doit **picoter** a la transition
+monostable $\to$ bistable : la memoire requise pour predire le systeme
+augmente localement (le systeme ""hesite"" entre deux bassins), puis
+redescend une fois le systeme engage dans un bassin.
+",,,,,,,,739647c1640a1140,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,c919eb4f,code,fr,61bebe3a6f912768,"# Substrat S2 : trajectoire du modele de broutage (May 1977)
+# On balaie un parametre ``r`` qui pilote la bifurcation.
+# NB API ``ict.bistable`` : ``GrazingModel(r, K, h)`` n'a PAS de ``c`` ;
+# le coefficient ``c`` (pression de broutage) est passe directement aux
+# methodes ``equilibria(c)`` et ``simulate_sde(c, ...)``. Le defaut de la
+# litterature est c=1.0 ; on le fixe pour ce notebook.
+from ict.bistable import GrazingModel
+
+states_s2 = []
+r_grid = np.linspace(0.5, 1.5, 60)  # couvre la transition monostable -> bistable
+c_broutage = 1.0
+for r_val in r_grid:
+    model = GrazingModel(r=r_val, K=1.0, h=0.3)
+    eq = model.equilibria(c_broutage)
+    # On prend l'equilibre stable ""haut"" si bistable, sinon l'unique
+    if len(eq) >= 2:
+        x0 = eq[-1][0]
+    else:
+        x0 = eq[0][0] if eq else 0.1
+    # Relaxation vers l'equilibre avec petit bruit stochastique (SDE)
+    traj = model.simulate_sde(c_broutage, x0=x0, T=80, dt=0.1, sigma=0.05,
+                              seed=20260703)
+    # Discretisation en 4 categories
+    for x in traj:
+        states_s2.append(int(np.digitize(x, [0.1, 0.3, 0.6])))
+
+print(f""S2 trajectoire : n={len(states_s2)}, ""
+      f""distribution={np.bincount(states_s2).min()}/{np.bincount(states_s2).max()} ""
+      f""(min/max des 4 categories)"")
+
+# Partition Crutchfield sur la trajectoire S2 complete
+part_s2 = EM.causal_state_partition(
+    states_s2, history_len=3, future_len=3, tol=0.05
+)
+C_s2 = EM.statistical_complexity(part_s2, states_s2)
+E_s2 = EM.excess_entropy_estimate(states_s2, max_block=4)
+
+print(f""S2 n_causal_states   : {part_s2['n_causal_states']}"")
+print(f""S2 C_mu (bits)       : {C_s2['C_mu']:.4f}"")
+print(f""S2 E_estimate (bits) : {E_s2['E_estimate']:.4f}"")
+",,,,,,,,61bebe3a6f912768,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,2bf2eb91,code,fr,41f5327e534beb52,"# Bonus Gate : C_mu a la transition monostable -> bistable
+# On balaye une fenetre glissante et on regarde la variation de C_mu.
+window = 200
+stride = 100
+c_mu_series = []
+r_centers = []
+for i in range(0, len(states_s2) - window, stride):
+    subseq = states_s2[i : i + window]
+    try:
+        part_w = EM.causal_state_partition(subseq, history_len=3, future_len=3,
+                                           tol=0.05)
+        c_w = EM.statistical_complexity(part_w, subseq)[""C_mu""]
+        c_mu_series.append(c_w)
+        # Centre temporel en indice de r_grid
+        r_idx = min(len(r_grid) - 1, int(i * len(r_grid) / len(states_s2)))
+        r_centers.append(r_grid[r_idx])
+    except ValueError:
+        continue
+
+print(f""S2 C_mu (mobile, n={len(c_mu_series)} fenetres):"")
+for r_c, c_w in zip(r_centers, c_mu_series):
+    print(f""   r = {r_c:.3f}  ->  C_mu = {c_w:.3f} bits"")
+
+# Detection du pic : argmax de la serie
+if c_mu_series:
+    peak_idx = int(np.argmax(c_mu_series))
+    print(f""\nPic de C_mu : r = {r_centers[peak_idx]:.3f} -> C_mu = ""
+          f""{c_mu_series[peak_idx]:.3f} bits (fenetre {peak_idx}/{len(c_mu_series)})"")
+    print(""Gate bonus C_mu a la transition : PASSED"" if c_mu_series[peak_idx] > 0.5 else
+          ""Gate bonus C_mu a la transition : INSUFFICISANT (C_mu trop plat)"")
+else:
+    print(""Pas assez de fenetres pour le bonus Gate."")
+",,,,,,,,41f5327e534beb52,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,e251ccf6,markdown,fr,c0b875da0ce9b5ba,"## 5. Substrat S3 -- replicateur strategique (ICT-13 cooperation)
+
+Le replicateur d'Axelrod (ou le replicateur de Schuster-Sigmund) capture
+la dynamique de strategies en interaction. En regime de cooperation
+emergente, la distribution des strategies se fige sur un petit nombre
+d'attracteurs ; en regime de defection, elle oscille fortement.
+
+**Hypothese.** $C_\mu$ doit etre **maximal en cooperation emergente** :
+les strategies ""gagnantes"" sont stables, donc le systeme doit memoriser
+beaucoup pour predire quel attracteur domine. En defection, la
+trajectoire est plus i.i.d.-like (bruit), $C_\mu$ plus bas.
+",,,,,,,,c0b875da0ce9b5ba,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,f670a9da,code,fr,39938115b07c1049,"# Substrat S3 : automate cellulaire issu de ``trajectories``
+# On utilise un automate deterministe 2 etats (regle 110) qui presente
+# des dynamiques emergentes variees (chaos + structures coherentes).
+from ict.trajectories import state_trajectory, all_states
+
+# Regle 110 : automate 1D complexe (Wolfram classe IV)
+def rule110(left, center, right):
+    return int((left ^ (center | right)) & 1)  # regle 110
+
+# Generation d'une trajectoire longue par decalage de fenetre
+n_cells = 64
+states_s3 = []
+grid = np.zeros(n_cells, dtype=int)
+grid[n_cells // 2] = 1  # une cellule seule au centre
+for t in range(2000):
+    new_grid = np.zeros_like(grid)
+    for i in range(1, n_cells - 1):
+        new_grid[i] = rule110(grid[i - 1], grid[i], grid[i + 1])
+    grid = new_grid
+    # On extrait la valeur de la cellule centrale comme ""signature"" scalaire
+    states_s3.append(int(grid[n_cells // 2]))
+
+print(f""S3 trajectoire (regle 110, cellule centrale) : n={len(states_s3)}, ""
+      f""distribution={np.bincount(states_s3).tolist()}"")
+
+part_s3 = EM.causal_state_partition(states_s3, history_len=3, future_len=3, tol=0.05)
+C_s3 = EM.statistical_complexity(part_s3, states_s3)
+E_s3 = EM.excess_entropy_estimate(states_s3, max_block=4)
+
+print(f""S3 n_causal_states   : {part_s3['n_causal_states']}"")
+print(f""S3 C_mu (bits)       : {C_s3['C_mu']:.4f}"")
+print(f""S3 E_estimate (bits) : {E_s3['E_estimate']:.4f}"")
+",,,,,,,,39938115b07c1049,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,be4f1aa8,markdown,fr,c846bb6b79587fae,"## 6. Gate 8 -- Crutchfield vs Hoel (similarite VI)
+
+La partition en etats causaux (Crutchfield) repond ""quel est le bon
+macro-etat ?"" par la preservation de la distribution de futur.
+L'alternative de Hoel (2014) -- *causal emergence* -- repond par la
+preservation du **pouvoir causal** via ``greedy_apportionment`` (cf
+``ict.causal_emergence``). Les deux ne coi ncident pas en general.
+
+**Metrique commune : variation d'information (VI).** Plus VI est
+grande, plus les partitions divergent ; plus VI est petite, plus elles
+s'accordent sur le coarse-graining.
+
+**Hypothese.** Sur S1 (tri) et S3 (replicateur), les deux methodes
+doivent **converger** (substrats structurellement forts). Sur S2
+(bistable, dynamique multi-bassin), elles doivent **diverger** -- le
+pouvoir predictif et le pouvoir causal ne sont pas le meme invariant
+quand le paysage est rugueux.
+",,,,,,,,c846bb6b79587fae,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,800cd2f4,code,fr,56792ff9f42f7204,"# Gate 8 : comparaison Crutchfield vs Hoel sur S1/S2/S3
+# Pour Hoel : TPM via ``tpm_from_trajectory`` puis ``greedy_apportionment``.
+# Le partitionnement Crutchfield est sur la sequence, le partitionnement
+# Hoel est sur les etats de la TPM. On construit le mapping passe -> etat
+# Hoel en prenant l'etat causal Crutchfield comme reference commune.
+
+def hoel_partition_from_trajectory(seq, k_states, tol=0.05):
+    """"""Partition Hoel (1ere fusion) sur la TPM.
+
+    API reelle ``ict.causal_emergence.greedy_apportionment(tpm)`` :
+    retourne un dict avec ``scales`` (chemin de fusions). On prend
+    uniquement la premiere fusion ``scales[1][""labels""]`` qui contient
+    un seul macro-etat (la fusion des 2 micro-etats les plus proches
+    au sens de l'effectiveness). C'est l'equivalent Hoel du ""groupement
+    de 2 etats"" -- la facon la plus conservative de comparer Crutchfield
+    (top-down par L1 sur futur) vs Hoel (bottom-up par effectiveness).
+
+    Renvoie un dict ``micro -> macro`` (0 ou 1) directement comparable
+    au mapping Crutchfield.
+    """"""
+    # NB API ``ict.tpm_estimation`` : le lissage n'est pas un kwarg ;
+    # le 4ᵉ argument ``unseen`` vaut ``""self""`` (defaut, chaque etat
+    # reste dans lui-meme si pas de transition observee) ou ``""uniform""``
+    # (ligne uniforme). On prend ``""uniform""`` pour eviter les zeros
+    # problematiques dans le greedy_apportionnement.
+    tpm, _ = TE.tpm_from_trajectory(seq, unseen=""uniform"")
+
+    # NB API ``ict.causal_emergence.greedy_apportionment(tpm)`` : PAS de
+    # parametre ``n_macro``. La fonction explore tout le chemin micro->1 etat
+    # en s'arretant au point ou la fusion n'ameliore plus la primitive.
+    # On prend UNIQUEMENT le premier pas de fusion (scales[1]) comme
+    # partition Hoel ""1ere emergence"".
+    ga_result = CE.greedy_apportionment(tpm)
+    if len(ga_result[""scales""]) < 2:
+        # Aucun gain possible : tout reste separe (1 macro = n micro)
+        return {i: i for i in range(len(tpm))}, tpm
+    # ``scales[1][""labels""]`` = labels apres 1 fusion (n-1 macro-etats)
+    labels_after_1 = ga_result[""scales""][1][""labels""]
+    # ``labels_after_1`` est une liste de n-1 tuples d'ids micro origines.
+    # On construit le mapping micro -> premier macro qui le contient.
+    macro_id = 0
+    micro_to_macro = {}
+    for entry in labels_after_1:
+        members = list(entry) if hasattr(entry, ""__iter__"") else [int(entry)]
+        for m in members:
+            micro_to_macro[int(m)] = macro_id
+        macro_id += 1
+    return micro_to_macro, tpm
+
+# Pour chaque substrat : partition Crutchfield + partition Hoel + similarite VI
+results_g8 = {}
+for name, seq in [(""S1"", [int(s) for s in states_s1]),
+                  (""S2"", states_s2),
+                  (""S3"", states_s3)]:
+    try:
+        k_states = max(seq) + 1
+        h_to_macro, tpm = hoel_partition_from_trajectory(seq, k_states)
+        # Partition Crutchfield (cle occurrence_to_causal par index entier).
+        part_c = EM.causal_state_partition(seq, history_len=3, future_len=3,
+                                           tol=0.05)
+        # Pour Hoel : on assigne chaque occurrence a un macro-etat en
+        # prenant le 1er caractere de la passe (qui est un etat micro).
+        # NB ``partition_similarity`` itere par ``t`` (passe canonique a
+        # l'index ``t``), donc le mapping par index d'occurrence
+        # correspond directement aux positions de la trajectoire.
+        occ_to_h = {}
+        for occ in range(part_c[""n_histories""]):
+            # passe a l'index ``occ`` : ``seq[occ : occ + history_len]``
+            hist_at_occ = tuple(seq[occ : occ + 3])
+            if hist_at_occ:
+                key_micro = int(hist_at_occ[0])
+                occ_to_h[occ] = h_to_macro.get(key_micro, 0)
+            else:
+                occ_to_h[occ] = 0
+        part_h = {
+            ""labels"": [], ""causal_to_histories"": {},
+            ""occurrence_to_causal"": occ_to_h,
+            ""history_to_causal"": {},
+            ""history_len"": 3, ""future_len"": 3, ""tol"": 0.05,
+            ""n_causal_states"": len(set(occ_to_h.values())),
+            ""n_histories"": part_c[""n_histories""],
+        }
+        sim = EM.partition_similarity(part_c, part_h, seq)
+        results_g8[name] = {
+            ""n_c_causal"": part_c[""n_causal_states""],
+            ""n_h_macro"": part_h[""n_causal_states""],
+            ""VI_norm"": sim[""VI_norm""],
+            ""VI_raw"": sim[""VI_raw""],
+            ""agree"": sim[""agree""],
+            ""disagree"": sim[""disagree""],
+            ""n_used"": sim[""n_used""],
+        }
+    except Exception as e:
+        results_g8[name] = {""error"": str(e)}
+
+print(""=== Gate 8 : Crutchfield vs Hoel (VI normalisee) ==="")
+print(f""{'substrat':<10} {'n_C':<5} {'n_H':<5} {'VI_norm':<10} {'agree':<8} {'disagree':<10}"")
+for name, r in results_g8.items():
+    if ""error"" in r:
+        print(f""{name:<10} ERROR : {r['error']}"")
+    else:
+        print(f""{name:<10} {r['n_c_causal']:<5} {r['n_h_macro']:<5} ""
+              f""{r['VI_norm']:<10.3f} {r['agree']:<8} {r['disagree']:<10}"")
+
+# Lecture : VI_norm = 1.0 sur ce mapping minimal (Hoel agrege 1 fusion,
+# Crutchfield regarde la passe complete de longueur 3 -- granularites
+# differentes -> VI_norm eleve meme quand les concepts s'accordent).
+#
+# Pour passer la gate il faudrait agreger plusieurs fusions Hoel pour
+# reproduire la finesse Crutchfield -- c'est ICT-20 (FeatureCatastrophes, #5103)
+# qui etend le banc. Ici on documente HONNETEMENT le resultat et on
+# utilise une autre metrique pour evaluer l'accord : le ratio
+# ``agree / n_used`` (combien d'occurrences tombent dans le meme cluster).
+g8_ratios = {name: r[""agree""] / max(1, r[""n_used""])
+             for name, r in results_g8.items()
+             if ""agree"" in r}
+print(""\nRatio agree/n_used (clustering minimal Hoel) :"")
+for name, ratio in g8_ratios.items():
+    print(f""  {name} : {ratio:.3f}"")
+
+# Lecture honnete : Crutchfield (top-down, passe complete) et Hoel
+# (bottom-up, 1ere fusion) operent a des granularites differentes par
+# construction -- VI_norm = 1.0 reflete cette difference de ""grain"",
+# pas un desaccord semantique. Pour evaluer l'accord conceptuellement,
+# il faudrait iterer Hoel jusqu'a un nombre de macros comparable a
+# Crutchfield -- c'est une extension (ICT-20 backlog, #5103).
+g8_honnete = True  # toujours PASSED : on documente le resultat, pas un verdict binaire
+print(f""\nGate 8 documentee (VI=1.0 par difference de granularite) : ""
+      f""{'HONNETE' if g8_honnete else 'INSUFFICISANT'}"")
+print(""Note C198 : voir C198-HARD #5 -- Crutchfield et Hoel operent a ""
+      ""des granularites differentes ; le ratio agree/n_used est la ""
+      ""metrique complementaire a reporter."")
+",,,,,,,,56792ff9f42f7204,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,bc2494e2,markdown,fr,98781b8a61b40e5d,"## 7. Gate 9 -- $E$ comme plafond sur les estimateurs $\hat{p}$
+
+ICT-10 (CatastropheGrammar) apprend des estimateurs $\hat{p}_\theta$ sur
+plusieurs regimes ; la jambe ""memoire"" est leur entropie conditionnelle
+$H(\hat{p}) = - \sum \hat{p}(x) \log_2 \hat{p}(x)$.
+
+**Resultat attendu.** Pour N'IMPORTE QUEL estimateur $\hat{p}$ du banc
+ICT-10, l'info mutuelle $I(\hat{p} ; \text{futur})$ doit etre $\le E$,
+parce que $E$ est la borne superieure theorique (c'est l'info mutuelle
+entre passe et futur de la source reelle). On peut verifier sur S2 :
+$E_\text{S2}$ borne l'info mutuelle entre la passe (3 derniers etats)
+et le futur (3 prochains etats) telle qu'estimee par n'importe quelle
+distribution empirique $\hat{p}$.
+",,,,,,,,98781b8a61b40e5d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,ab6902fc,code,fr,13af8e244a81e723,"# Gate 9 : E est un plafond pour n'importe quel estimateur ``p_hat``
+# On prend plusieurs estimateurs : (1) plug-in empirique, (2) melange
+# uniforme aleatoire, (3) deterministe (toujours la meme prediction),
+# et on montre que I(passe; futur selon p_hat) <= E.
+
+from collections import defaultdict
+
+def estimate_mutual_information(seq, history_len, future_len, rng):
+    """"""Info mutuelle plug-in entre passe (h derniers) et futur (f prochains).""""""
+    pairs = defaultdict(lambda: defaultdict(int))
+    h_marg = defaultdict(int)
+    f_marg = defaultdict(int)
+    n = len(seq)
+    for t in range(n - history_len - future_len + 1):
+        h = tuple(seq[t : t + history_len])
+        f = tuple(seq[t + history_len : t + history_len + future_len])
+        pairs[h][f] += 1
+        h_marg[h] += 1
+        f_marg[f] += 1
+    total = sum(h_marg.values())
+    if total == 0:
+        return 0.0
+    # I(H; F) = sum p(h,f) log2 p(h,f) / (p(h) p(f))
+    mi = 0.0
+    for h, fc in pairs.items():
+        for f, c in fc.items():
+            p_hf = c / total
+            p_h = h_marg[h] / total
+            p_f = f_marg[f] / total
+            if p_h > 0 and p_f > 0 and p_hf > 0:
+                mi += p_hf * np.log2(p_hf / (p_h * p_f))
+    return max(0.0, mi)
+
+
+def estimate_mutual_information_uniform(seq, history_len, future_len, rng):
+    """"""Info mutuelle pour un estimateur 'plug-in brouille' : futur tire uniformement.""""""
+    pairs = defaultdict(lambda: defaultdict(int))
+    h_marg = defaultdict(int)
+    n = len(seq)
+    k_future = max(seq) + 1
+    for t in range(n - history_len - future_len + 1):
+        h = tuple(seq[t : t + history_len])
+        # Futur ""selon un estimateur uniforme aleatoire""
+        f_hat = (int(rng.integers(0, k_future)),) * future_len
+        pairs[h][f_hat] += 1
+        h_marg[h] += 1
+    total = sum(h_marg.values())
+    if total == 0:
+        return 0.0
+    mi = 0.0
+    for h, fc in pairs.items():
+        for f, c in fc.items():
+            p_hf = c / total
+            p_h = h_marg[h] / total
+            p_f = 1.0 / k_future  # uniforme
+            if p_h > 0 and p_f > 0 and p_hf > 0:
+                mi += p_hf * np.log2(p_hf / (p_h * p_f))
+    return max(0.0, mi)
+
+
+# Comparons E (de ICT-17) et les I plug-in pour S2
+seq = states_s2
+E_s2 = EM.excess_entropy_estimate(seq, max_block=4)[""E_estimate""]
+I_plugin = estimate_mutual_information(seq, history_len=3, future_len=3,
+                                       rng=np.random.default_rng(42))
+I_uniform = estimate_mutual_information_uniform(
+    seq, history_len=3, future_len=3, rng=np.random.default_rng(42))
+
+print(f""E (Crutchfield)        : {E_s2:.4f} bits  <-- plafond theorique"")
+print(f""I(passe;futur) plug-in : {I_plugin:.4f} bits"")
+print(f""I(passe;futur uniforme: {I_uniform:.4f} bits"")
+print()
+print(f""Gate 9 (tous les I <= E) : ""
+      f""{'PASSED' if I_plugin <= E_s2 + 1e-6 and I_uniform <= E_s2 + 1e-6 else 'FAILED'}"")
+print(f""  (E - I_plugin)  = {E_s2 - I_plugin:.4f} bits (ecart au plafond)"")
+print(f""  (E - I_uniform) = {E_s2 - I_uniform:.4f} bits (ecart au plafond)"")
+",,,,,,,,13af8e244a81e723,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,b33872b0,markdown,fr,dfdacc95693edc43,"L'extension naturelle est ICT-18 (FlecheDuTempsReversibilisation) :
+production d'entropie thermodynamique et reversibilisation
+(Schnakenberg 1976, Seifert 2012, Cusinato & Lecomte 2024), numpy
+CPU-only -- un complement *thermodynamique* a ICT-17 qui evalue la
+*complexite temporelle* (fleche) plutot que la complexite de
+representation (epsilon-machine).",,,,,,,,dfdacc95693edc43,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,9286d7d6,markdown,fr,442cd8a12c6ccf9a,"## 9. Exercices
+
+3 exercices, conformement a la convention #2161 et a la regle C.1
+(notebooks JAMAIS de `raise NotImplementedError` -- on utilise ``pass``
+ou ``return None`` ; le notebook reste executable de bout en bout).
+
+### Exercice 1 -- Balayage ``history_len``
+
+Etudiez la stabilite de $C_\mu$ en fonction de ``history_len``. Pour une
+sequence Markov 2 etats (utilisez ``EM.mk_markov_2`` ou recreez une
+sequence equivalente) :
+  - Faites varier ``history_len`` de 1 a 5.
+  - Tracez $C_\mu$ et $E$ en fonction de ``history_len``.
+  - Identifiez le ``history_len`` a partir duquel les deux se stabilisent
+    (l'ordre minimal de la representation causale).
+",,,,,,,,442cd8a12c6ccf9a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,338dd0f3,code,fr,5e39400046fc32fa,"# Exercice 1 -- A vous de jouer !
+# Indices :
+#   - Utilisez ``mk_markov_2(p_stay=0.7, n=2000, seed=42)`` ou une sequence
+#     iid ``iid_seq(k=2, n=2000, seed=42)``.
+#   - Pour chaque ``history_len`` dans ``range(1, 6)`` :
+#       part = EM.causal_state_partition(seq, history_len=history_len,
+#                                         future_len=history_len, tol=0.05)
+#       C = EM.statistical_complexity(part, seq)
+#       E = EM.excess_entropy_estimate(seq, max_block=2*history_len)
+#   - Tracez ``plt.plot(history_len, [C_mu_1, C_mu_2, ...])`` et idem pour E.
+
+# Stub conforme C.1 -- remplacez ce bloc par votre implementation.
+result_history_sweep = None  # TODO etudiant : dict {history_len: (C_mu, E_estimate)}
+
+if result_history_sweep is None:
+    print(""Exercice 1 a completer : balayer history_len dans [1, 5] et tracer C_mu et E."")
+    print(""Indice : voir bloc de la cellule precedente."")
+",,,,,,,,5e39400046fc32fa,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,2c99fc11,markdown,fr,08e4c664a9b984b7,"### Exercice 2 -- Sensibilite a la tolerance
+
+Pour une meme sequence (iid 4 etats, ``n=2000``, ``seed=11``) :
+  - Faites varier ``tol`` dans ``[1e-3, 1e-2, 5e-2, 1e-1, 2e-1, 5e-1]``.
+  - Tracez ``n_causal_states`` et $C_\mu$ en fonction de ``tol``.
+  - Identifiez le ``tol`` ou la partition devient degenerante (1 seul
+    etat causal) -- c'est la borne superieure de la tolerance utile.
+",,,,,,,,08e4c664a9b984b7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,a215cd80,code,fr,160e2e078bf6defe,"# Exercice 2 -- A vous de jouer !
+# Indices :
+#   - seq = iid_seq(k=4, n=2000, seed=11)
+#   - Pour chaque tol dans la liste, reconstruisez la partition et notez
+#     ``part[""n_causal_states""]`` et ``C[""C_mu""]``.
+#   - Tracez deux courbes (n_causal vs tol, C_mu vs tol) en echelle log
+#     sur l'axe des abscisses.
+
+# Stub conforme C.1
+result_tol_sweep = None  # TODO etudiant : dict {tol: (n_causal, C_mu)}
+
+if result_tol_sweep is None:
+    print(""Exercice 2 a completer : balayer tol dans [1e-3, 5e-1] et tracer."")
+",,,,,,,,160e2e078bf6defe,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,94f67abc,markdown,fr,7dd88e44d705fb00,"### Exercice 3 -- $C_\mu$ sur le replicateur S3 en cooperation emergente
+
+Reprenez la regle 110 (substrat S3) et faites varier la condition initiale :
+  - **Cas A** : une seule cellule allumee au centre (regime actuel).
+  - **Cas B** : moitie gauche allumee, moitie droite eteinte (frontiere
+    unique, regime ""glider"" emis).
+  - **Cas C** : configuration aleatoire dense (regime ""chaos"").
+
+Pour chaque cas :
+  - Generez la trajectoire longue (2000 pas minimum).
+  - Calculez $C_\mu$, $E$, et le nombre d'etats causaux.
+  - Identifiez le regime avec la $C_\mu$ la plus elevee -- c'est le
+    regime ou le systeme a le plus de memoire interne (et donc est le
+    plus ""intelligent"" au sens de Crutchfield).
+",,,,,,,,7dd88e44d705fb00,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,40c23a3d,code,fr,f625e2610164f6c5,"# Exercice 3 -- A vous de jouer !
+# Indices :
+#   - Modifiez la condition initiale de la regle 110 : cas A (1 cellule
+#     au centre, fait dans la cellule 14), cas B (32 premieres allumees),
+#     cas C (50% densite aleatoire).
+#   - Pour chaque cas, generez 2000 pas et appelez ``EM.causal_state_partition``
+#     puis ``EM.statistical_complexity``.
+#   - Comparez ``C_mu`` et ``E`` entre les 3 cas.
+
+# Stub conforme C.1
+result_s3_sweep = None  # TODO etudiant : dict {cas: (n_causal, C_mu, E)}
+
+if result_s3_sweep is None:
+    print(""Exercice 3 a completer : 3 conditions initiales differentes pour S3, ""
+          ""comparer C_mu et E."")
+",,,,,,,,f625e2610164f6c5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-17-EpsilonMachine.ipynb,f0303fa2,markdown,fr,ce95cd5bc6a4f5f7,"Suite strate 5 :
+  - **ICT-18 (FlecheDuTempsReversibilisation)** : production d'entropie
+    thermodynamique et reversibilisation (Schnakenberg 1976, Seifert 2012,
+    Cusinato & Lecomte 2024). Applique ces 3 quantites au diagnostic
+    d'agentivite emergente (sigma, detailed balance error, distances
+    P_real vs P_reversibilized). GPU-free (numpy-only).
+  - **ICT-20** : feature et persona catastrophes, backlog.
+
+**Liens croises.**
+  - ICT-13 (compression zlib) partage la jambe $K$ (mesure de structure).
+  - ICT-15 (capstone) integre $\Phi$, $F$, $K$ -- ICT-17 fournit la jambe
+    ""memoire $C_\mu$"" et le ""plafond $E$"".
+  - ICT-10 (CatastropheGrammar) apprend des estimateurs $\hat{p}_\theta$
+    bornes par $E$ (Gate 9).
+  - ICT-2 (self-sorting) est le substrat S1, ICT-12 (valence) alimente S2.
+  - ICT-18 (FlecheDuTempsReversibilisation) : la reversibilisation
+    elimine la structure irreversible -- un parallel a ICT-17 sur la
+    *macro-structure predictive* au lieu de la *complexite temporelle*.",,,,,,,,ce95cd5bc6a4f5f7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,d8683db9,markdown,fr,78658154cfb677a2,"# ICT-18 -- Fleche du temps et reversibilisation (strate 5, Epic #4588)
+
+**Sens du mot *reversibilite* dans ce notebook** : on entend ici *reversibilite thermodynamique* (detail-balance satisfaite, courant net nul, Schnakenberg 1976 / Seifert 2012 / Crooks 1998) -- c'est **le MOYEN** dans la triade *moyen / fin / enjeu* (cf cellule << Moyen, fin, enjeu >> ci-dessous). L'instrument de ce notebook mesure **uniquement** ce moyen. La *reversibilite comportementale* (accessibilite cinematique de l'espace d'etats, ICT-2/3/9, Levin *competency for free*) releve d'une **autre grandeur** : c'est la **FIN** que la lutte thermodynamique poursuit, pas un second axe a mesurer independamment.
+
+**Portee honnete de l'instrument** : `I_thermo = dist(P_real, P_reversible)` capte le **MOYEN** (la dissipation, sigma, l'irreversibilite brute) -- et **PAS l'ENJEU** (resister a l'equilibration du soi). Une tornade, une flamme, une cellule de Benard, un oscillateur chimique dissipent : tous allument l'instrument sans etre agents. Manque le *stake* -- l'auto-maintien, la cloture de contraintes, la minimisation d'energie libre (Friston) -- que ICT-18 ne voit pas. L'instrument est **necessaire mais pas suffisant** ; voir substrat S5 (controle faux-positif) et cell 18 recadree en faux-negatif pour les deux bornes de sa portee.
+
+**Probleme** : comment mesurer l'agentivite emergente d'une trajectoire *thermodynamiquement* ? Et surtout, ou cette mesure s'arrete-t-elle ?",,,,,,,,78658154cfb677a2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,e313f2a4,markdown,fr,4d68d7545dce2cff,"## 1. Setup
+
+Import du package leger ``ict`` et de ``time_arrow`` (strate 5 d'ICT, ce notebook). On verifie la version numpy et on prepare l'environnement matplotlib inline pour les figures (les graphes sont cpu-only, pas de backend interactif). On importe egalement les substrats ``self_sorting``, ``bistable``, ``strategic_morphodynamics``, ``reaction_diffusion``.",,,,,,,,4d68d7545dce2cff,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,da4de6ee,code,fr,516075b792e8233a,"import os
+import sys
+
+ICT_ROOT = os.path.abspath('.')
+if ICT_ROOT not in sys.path:
+    sys.path.insert(0, ICT_ROOT)
+
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+import ict
+from ict import time_arrow
+from ict import self_sorting, bistable, strategic_morphodynamics, reaction_diffusion
+from ict import trajectories, scale_free, early_warning
+
+print('ict version:', getattr(ict, '__version__', 'dev'))
+print('numpy:', np.__version__)
+print('matplotlib:', matplotlib.__version__)
+print('time_arrow API:')
+for name in ['transition_matrix', 'stationary_distribution', 'time_reversal',
+             'reversibilize', 'detailed_balance_error', 'entropy_production',
+             'trajectory_asymmetry', 'compare_real_reversed_reversibilized']:
+    fn = getattr(time_arrow, name, None)
+    print(f'  {name:42s} {""OK"" if fn else ""MISSING""}')",,,,,,,,516075b792e8233a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,4cf44779,markdown,fr,3c938a0e8ab8c03d,"## 2. Primitives thermodynamiques -- rappel et gate 1 (detailed balance)
+
+**Definitions clefs** :
+
+ - *Detailed balance* : ``pi_i * P[i, j] = pi_j * P[j, i]`` pour tous ``i, j``. Si verifiee, la chaine est *reversible* (symetrie sous renversement du temps).
+ - *Production d'entropie* : ``sigma = 1/2 sum_{i, j} (pi_i*P[i, j] - pi_j*P[j, i]) * log(pi_i*P[i, j] / pi_j*P[j, i]) >= 0``. Egale a 0 ssi detailed balance. C'est la fleche du temps thermodynamique (Schnakenberg, Seifert).
+ - *Reversibilisation* : projection ``P_rev[i, j] = (pi_i*P[i, j] + pi_j*P[j, i]) / (2*pi_i)`` ; par construction, ``pi_i*P_rev[i, j]`` est symmetrique en ``(i, j)``, donc detailed balance est forcee.
+
+**Gate 1 (testable)** : sur une trajectoire **iid** (P uniforme), la chaine reelle doit deja etre reversible et la production d'entropie doit etre ~0 (au bruit d'echantillonnage pres).
+
+### 2.bis Moyen, fin, enjeu -- la triade que l'instrument capte et celle qu'il manque
+
+Le mot *reversibilite* porte **deux sens distincts** dans la serie ICT, mais ils ne sont pas des axes independants : ce sont les deux extremites d'une **triade teleonomique**. Le vivant ne *nie* pas l'irreversibilite ; il la *met au service* d'autre chose. La v1 du notebook (<< deux axes orthogonaux >>) escamotait ce couplage -- elle est reformulee ici.
+
+**Noeud theorique** : le vivant refuse l'equilibration locale de son soi (decomposition, mort) **en produisant** plus de dissipation dans le monde (Schrodinger 1944 *neguentropie* / Prigogine 1977 *structures dissipatives* / Friston 2010 *free energy principle*). Il ne renverse jamais le second principe : il **paie** son ordre local par un desordre global plus grand. << Lutter contre l'irreversibilite >> = rester loin de *son* equilibre, finance par un surcroit d'irreversibilite du monde. England 2013 *dissipation-driven adaptation* formalise ce couplage pour les systemes physiques auto-organises.
+
+**La triade** :
+
+| Pole | Sens | Grandeur | Source theorique | Ce que ICT-18 en fait |
+|---|---|---|---|---|
+| **ENJEU** | Resister a l'equilibration du soi (ne pas se decomposer, garder son identite a travers le flux) | Auto-maintien, cloture de contraintes, homeostasie, *stake* du systeme | Schrodinger 1944, Friston 2010, Kauffman 2000 *investigations*, Moreno-Mossio 2002 *cloture de contraintes* | **INVISIBLE** a `I_thermo` -- l'instrument ne mesure pas l'enjeu, il mesure la depense |
+| **MOYEN** | Dissiper, exporter l'entropie, bruler des gradients, haute production d'entropie sigma | Production d'entropie ``sigma``, distance L1/2 a la reversible, Schnakenberg 1976 (affinites de cycle) | Schnakenberg 1976, Seifert 2012, Crooks 1998, England 2013, Prigogine 1977 | **EXACTEMENT** ce que mesure ``I_thermo`` -- l'instrument capte le moyen, pas l'enjeu |
+| **FIN** | Garder le soi *reversiblement recuperable* (homeostasie, reparation, regeneration, *reversibilite comportementale* de Levin) | Accessibilite de l'espace d'etats, hysteresis, capacite de reparation post-ablation | Levin 2024-2025 *competency for free*, ICT-2/3/9, multiscale_agency | **INVISIBLE** a `I_thermo` -- ICT-2/3/9 mesurent cette FIN par d'autres instruments |
+
+**Le couplage** : l'agent *depense* de l'irreversibilite (moyen) pour *gagner* la recuperabilite de sa persistance (fin) *contre* la decomposition (enjeu). Les trois poles ne sont **pas** des axes orthogonaux : ils forment une **boucle teleonomique**. L'instrument `I_thermo` ne voit que le moyen. Il est **necessaire** (pas d'agentivite sans depense thermodynamique : un systeme a l'equilibre ne lutte pas, il subit) mais **pas suffisant** (une tornade dissipe autant sans avoir d'enjeu a defendre).
+
+**Deux bornes de la portee** :
+
+  - **Faux-NEGATIF** (cell 18, S2 ICT-8 bistable) : un systeme comportementalement tres structure (2 bassins, hysteresis, flip-flopping anisotrope, forte reversibilite comportementale au sens de ICT-2/3/9) sort ``I_thermo ~= 0`` car la distribution stationnaire pi du *substitut markovien* s'adapte aux taux de bascule pour minimiser la detailed balance. Ce n'est **PAS** un defaut de calcul : c'est l'aveuglement de l'instrument markovien-stationnaire a la **memoire** et a la **non-stationnarite** du vrai processus. L'asymetrie generative vit dans la memoire ; `P_rev` ne la capte pas.
+  - **Faux-POSITIF** (substrat S5 -- voir Section 7) : un pur dissipateur **sans** auto-maintien (marche aleatoire biaisee, oscillateur chimique pilote) allume `I_thermo` autant que S1/S3 sans etre agent. Montre honnetement que la signature capte le moyen et pointe l'ingredient manquant : pas seulement la memoire, mais l'**organisation de l'irreversibilite au service d'un enjeu**.
+
+**Portee operationnelle de l'instrument** : `I_thermo` est une **condition necessaire** pour suspecter l'agentivite (sigma > 0 veut dire qu'il se passe *quelque chose*) mais ne suffit jamais a la **conclure** (il faut l'ingredient supplementaire -- auto-maintien, cloture de contraintes, *stake*). L'instrument est specialise sur le moyen ; pour conclure l'agentivite, il faut le corroborer avec d'autres strates (ICT-2/3/9, ICT-14 free energy, ICT-15 complexite integree, ICT-17 epsilon-machine).
+
+Cross-refs : ICT-2 (tri *for free*), ICT-3 (reparation de forme), ICT-9 (Gray-Scott : regeneration post-ablation) pour la **FIN** ; ICT-14 (free energy / Friston) pour l'**ENJEU** (le *stake* de l'auto-maintien) ; ICT-18 (ce notebook) pour le **MOYEN**.",,,,,,,,3c938a0e8ab8c03d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,c70a3589,code,fr,d8ab8f91cc735f27,"# Gate 1 -- trajectoire totalement aleatoire (iid)
+rng_iid = np.random.default_rng(20250704)
+k_iid = 4
+n_iid = 4000
+states_iid = rng_iid.integers(0, k_iid, size=n_iid).tolist()
+out_iid = time_arrow.compare_real_reversed_reversibilized(states_iid)
+print('=== Gate 1 -- trajectoire iid (detailed balance attendue) ===')
+print(f'n_symbols = {out_iid[""n_symbols""]}')
+print(f'sigma_real            = {out_iid[""sigma_real""]:.4f}  (attendu: ~0)')
+print(f'sigma_reversibilized  = {out_iid[""sigma_reversibilized""]:.4f}  (attendu: ~0)')
+print(f'db_error_real         = {out_iid[""db_error_real""]:.4f}  (attendu: ~0)')
+print(f'dist_real_vs_reversibilized = {out_iid[""dist_real_vs_reversibilized""]:.4f}  (attendu: ~0)')
+print(f'dist_real_vs_reversed       = {out_iid[""dist_real_vs_reversed""]:.4f}  (attendu: ~0)')
+print()
+print(f'VERDICT Gate 1 : {""OK"" if (out_iid[""sigma_real""] < 0.05 and out_iid[""dist_real_vs_reversibilized""] < 0.1) else ""KO""}')",,,,,,,,d8ab8f91cc735f27,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,76d30a7e,markdown,fr,8c8e13bcb01155ae,"## 3. Substrat S1 -- ICT-2 tri auto-organise (BiasedBubbleSort, competence *for free*)
+
+**ICT-2** demontre que le tri bubble, sur des sequences deja partiellement triees, developpe une **competence gratuite** (for free) : le tri ameliore la coherence au-dela de ce que le mecanisme programmait. C'est l'ancrage direct de ICT-18 : si le tri emergente porte une *competence for free*, il brise la symetrie temporelle, et sa **production d'entropie doit etre strictement superieure** a une trajectoire iid.
+
+On simule une trajectoire ``BiasedBubbleSort`` sur un alphabet de 4 symboles (sequence d'inversions), on en extrait la matrice de transition empirique ``P`` et on compare sa fleche a la trajectoire iid (gate 1). **Gate 3** : ``sigma_biased > sigma_iid`` et la perte a la reversibilisation est mesurable.",,,,,,,,8c8e13bcb01155ae,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,c81b2dc7,code,fr,54e7928d88b95938,"# Substrat S1 : trajectoire BiasedBubbleSort -- proxy de ICT-2 *for free*
+rng = np.random.default_rng(7)
+k_sort = 5
+n_steps = 1500
+
+states_biased = []
+for _ in range(n_steps):
+    # Depart : sequence aleatoire sur k_sort symboles.
+    arr = list(rng.permutation(k_sort))
+    # Induire un leger biais : la moitie droite est plus souvent triee
+    # que la moitie gauche (phenomene *for free* : la competence du
+    # bubble sort est surrepresentee en fin de sequence).
+    if rng.random() < 0.4:
+        # Tri du segment droit.
+        right = sorted(arr[k_sort // 2:])
+        arr[k_sort // 2:] = right
+    # Une passe de bubble sort biaisee : on echange si gauche > droite
+    # avec une probabilite qui depend de la position.
+    for i in range(k_sort - 1):
+        p_swap = 0.95 - 0.4 * (i / max(1, k_sort - 2))  # biais : moins d'echange a droite
+        if arr[i] > arr[i + 1] and rng.random() < p_swap:
+            arr[i], arr[i + 1] = arr[i + 1], arr[i]
+    # Etat observe : nombre d'inversions (0 = tri complet).
+    inv = sum(1 for i in range(k_sort) for j in range(i + 1, k_sort) if arr[i] > arr[j])
+    states_biased.append(inv)
+
+out_biased = time_arrow.compare_real_reversed_reversibilized(states_biased)
+print('=== Substrat S1 (ICT-2 biased bubble sort) ===')
+print(f'n_symbols = {out_biased[""n_symbols""]}, k observations = {len(set(states_biased))}')
+print(f'distribution empirique (pi_real) : {out_biased[""pi_real""]}')
+print(f'sigma_real             = {out_biased[""sigma_real""]:.4f}')
+print(f'sigma_reversed         = {out_biased[""sigma_reversed""]:.4f}')
+print(f'sigma_reversibilized   = {out_biased[""sigma_reversibilized""]:.4f}')
+print(f'db_error_real          = {out_biased[""db_error_real""]:.4f}')
+print(f'dist_real_vs_reversibilized = {out_biased[""dist_real_vs_reversibilized""]:.4f}')
+print(f'dist_real_vs_reversed       = {out_biased[""dist_real_vs_reversed""]:.4f}')
+print()
+# Gate 3 : sigma biaisee >> sigma iid.
+ratio_sigma = out_biased['sigma_real'] / max(out_iid['sigma_real'], 1e-6)
+print(f'Ratio sigma_biased / sigma_iid = {ratio_sigma:.2f}')
+print(f'VERDICT Gate 3 : {""OK"" if out_biased[""sigma_real""] > out_iid[""sigma_real""] + 0.005 else ""KO""} (for free detectee)')",,,,,,,,54e7928d88b95938,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,c333fcff,markdown,fr,5c085beeaaf38a62,"## 4. Substrat S2 -- ICT-8 bistable (May 1977, broutage)
+
+Le modele de broutage (May 1977) est un systeme **bistable** : 2 bassins d'attraction separes par un point selle. Hors du point selle, le systeme reste dans son bassin ; proche, il **bascule** (flip-flopping) avec un taux ``p_flip`` qui depend de la distance a la frontiere.
+
+Le modele est **intrinsement irreversible** : les taux de bascule ``A -> B`` et ``B -> A`` ne sont pas egaux en general (friction anisotrope). ICT-8 detecte ce **niveau d'irreversibilite thermodynamique** : la production d'entropie est strictement positive et la perte a la reversibilisation est nettement superieure au cas iid.
+
+**Gate 4** : sur une trajectoire bistable avec friction anisotrope, ``sigma >> 0`` (au moins 5x superieur au bruit iid).",,,,,,,,5c085beeaaf38a62,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,c228f300,code,fr,e71a1da4460e81ba,"# Substrat S2 : trajectoire bistable (May 1977, friction anisotrope)
+rng = np.random.default_rng(42)
+n_steps = 8000
+p_flip_A = 0.005  # taux de sortie de A (metastable profond)
+p_flip_B = 0.04   # taux de sortie de B (metastable moins profond ; A est plus stable)
+state = 0  # on demarre dans A
+states_bistable = []
+for _ in range(n_steps):
+    if state == 0 and rng.random() < p_flip_A:
+        state = 1
+    elif state == 1 and rng.random() < p_flip_B:
+        state = 0
+    states_bistable.append(state)
+
+out_bi = time_arrow.compare_real_reversed_reversibilized(states_bistable, n_symbols=2)
+pi_A_th = p_flip_B / (p_flip_A + p_flip_B)
+pi_B_th = p_flip_A / (p_flip_A + p_flip_B)
+print('=== Substrat S2 (ICT-8 May bistable) ===')
+print(f'pi_theorique : [{pi_A_th:.4f}, {pi_B_th:.4f}]')
+print(f'pi_empirique : {out_bi[""pi_real""]}')
+print(f'P_real : {out_bi[""P_real""]}')
+print(f'P_reversibilized : {out_bi[""P_reversibilized""]}')
+print(f'sigma_real             = {out_bi[""sigma_real""]:.4f}')
+print(f'sigma_reversibilized   = {out_bi[""sigma_reversibilized""]:.4f}')
+print(f'db_error_real          = {out_bi[""db_error_real""]:.4f}')
+print(f'dist_real_vs_reversibilized = {out_bi[""dist_real_vs_reversibilized""]:.4f}')
+print()
+ratio = out_bi['sigma_real'] / max(out_iid['sigma_real'], 1e-6)
+print(f'Ratio sigma_bistable / sigma_iid = {ratio:.2f}')
+print(f'VERDICT Gate 4 : {""OK"" if out_bi[""sigma_real""] > 0.05 and out_bi[""sigma_real""] > 5 * out_iid[""sigma_real""] else ""KO""}')",,,,,,,,e71a1da4460e81ba,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,00f01d70,markdown,fr,1bba13bf292b0544,"## 5. Substrat S3 -- ICT-13 replicateur strategique (Axelrod 1984)
+
+Le replicateur strategique d'Axelrod (1984) est un automate de strategie IPD (Iterated Prisoner's Dilemma) : a chaque pas, l'agent joue une strategie parmi ``C`` (Cooperate), ``D`` (Defect), ``T`` (Temptation -- defection apres cooperation) ; la dynamique emergent fait naitre des **clusters de cooperation** quand ``b/c`` est dans une certaine fenetre (``b`` = tentation, ``c`` = cost).
+
+ICT-13 demontre que la **morphologie** de la cooperation emerge dans l'espace des strategies. ICT-18 ajoute : la **fleche du temps** de cette dynamique -- c'est-a-dire l'asymetrie temporelle entre une trajectoire reelle (cooperation qui s'etend) et sa reversal (cooperation qui s'etiole) -- est-elle mesurable thermodynamiquement ?
+
+**Gate 5** : sur une trajectoire Axelrod en regime de cooperation emergente (``b`` modere), la fleche thermodynamique est strictement positive (au moins 2x le bruit iid).",,,,,,,,1bba13bf292b0544,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,194cd078,code,fr,c95fbe3944b10966,"# Substrat S3 : trajectoire Axelrod (IPD emergent)
+# On simule une population de strategies et on suit la frequence de C / D / T.
+rng = np.random.default_rng(11)
+n_steps = 1500
+n_agents = 100
+# Strategies : 0 = AllC, 1 = AllD, 2 = TFT, 3 = Random.
+strats = rng.integers(0, 4, size=n_agents)
+# Payoffs IPD : T=5, R=3, P=1, S=0 ; b/c = T/R ici = 5/3 ~ 1.67 (regime cooperation).
+T_pay, R_pay, P_pay, S_pay = 5, 3, 1, 0
+def act(strategy, prev_self, prev_other):
+    if strategy == 0: return 0  # C
+    if strategy == 1: return 1  # D
+    if strategy == 2:  # TFT
+        return 0 if prev_other == 0 else 1
+    return int(rng.random() < 0.5)  # Random
+states_axelrod = []
+prev_actions = np.zeros(n_agents, dtype=int)  # tous commencent par C
+for t in range(n_steps):
+    # Update payoffs par paires aleatoires (epidemic).
+    payoffs = np.zeros(n_agents, dtype=float)
+    for _ in range(n_agents // 2):
+        i, j = rng.choice(n_agents, 2, replace=False)
+        ai = act(strats[i], prev_actions[i], prev_actions[j])
+        aj = act(strats[j], prev_actions[j], prev_actions[i])
+        payoff_i = R_pay if (ai == 0 and aj == 0) else (
+            P_pay if (ai == 1 and aj == 1) else (
+            T_pay if (ai == 1 and aj == 0) else S_pay))
+        payoff_j = R_pay if (aj == 0 and ai == 0) else (
+            P_pay if (aj == 1 and ai == 1) else (
+            T_pay if (aj == 1 and ai == 0) else S_pay))
+        payoffs[i] += payoff_i
+        payoffs[j] += payoff_j
+    prev_actions = np.where(
+        np.array([act(s, prev_actions[k], 0) for k, s in enumerate(strats)]) == 0, 0, 1
+    )  # simplification ; on garde la trace pour la prochaine boucle
+    # Imitation : chaque agent imite un voisin aleatoire qui a mieux joue.
+    for i in range(n_agents):
+        j = rng.integers(0, n_agents)
+        if payoffs[j] > payoffs[i]:
+            strats[i] = strats[j]
+    # Etat observe : nombre d'agents TFT (=2) au pas t (proxy de cooperation emergente).
+    states_axelrod.append(int(np.sum(strats == 2)))
+
+out_ax = time_arrow.compare_real_reversed_reversibilized(states_axelrod)
+print('=== Substrat S3 (ICT-13 Axelrod IPD) ===')
+print(f'n_symbols = {out_ax[""n_symbols""]}, valeurs observees = {sorted(set(states_axelrod))}')
+print(f'pi_real : {out_ax[""pi_real""]}')
+print(f'sigma_real             = {out_ax[""sigma_real""]:.4f}')
+print(f'sigma_reversibilized   = {out_ax[""sigma_reversibilized""]:.4f}')
+print(f'db_error_real          = {out_ax[""db_error_real""]:.4f}')
+print(f'dist_real_vs_reversibilized = {out_ax[""dist_real_vs_reversibilized""]:.4f}')
+print()
+ratio = out_ax['sigma_real'] / max(out_iid['sigma_real'], 1e-6)
+print(f'Ratio sigma_axelrod / sigma_iid = {ratio:.2f}')
+print(f'VERDICT Gate 5 : {""OK"" if out_ax[""sigma_real""] > 2 * out_iid[""sigma_real""] else ""AMBIGU""} (cooperation emergente)')",,,,,,,,c95fbe3944b10966,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,a460240d,markdown,fr,7031dc05d54c17f9,"## 6. Substrat S4 -- ICT-9 reaction-diffusion Gray-Scott (gate bonus)
+
+Le systeme Gray-Scott (Gray & Scott 1983, Pearson 1993, Mordvintsev et al. 2020) est un systeme de reaction-diffusion a 2 especes ``U`` et ``V`` qui produit des **motifs espace-temps** tres varies (spots, stripes, labyrinthes) selon les parametres ``f`` (alimentation) et ``k`` (kill). Sa dynamique est **intrinsement irreversible** : le flux net ``f -> k`` (production d'entropie du systeme continu) definit la fleche thermodynamique.
+
+ICT-9 a demontre que ces motifs peuvent **se regenerer** apres ablation. ICT-18 ajoute : la fleche temporelle discrete (sur la sequence temporelle du contenu de ``U`` en un pixel) detecte-t-elle l'irreversibilite continue du Gray-Scott ? **Gate 6** : la fleche est strictement superieure au bruit iid.",,,,,,,,7031dc05d54c17f9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,3454f5b8,code,fr,8a67d406072c63be,"# Substrat S4 : Gray-Scott (gate bonus) -- on suit le contenu moyen d'un pixel central
+gs = reaction_diffusion.GrayScott(F=0.055, k=0.062, Du=1.0, Dv=0.5, dt=1.0)
+rng_gs = np.random.default_rng(33)
+U0, V0 = gs.seed(n=40, block=8, noise=0.02, rng=rng_gs)
+n_timesteps = 600
+# Capture aux pas multiples de 100 pour obtenir un signal de densite de V.
+record_every = 5
+_, _, snapshots = gs.run(U0, V0, steps=n_timesteps, record_every=record_every, include_initial=False)
+# snapshots est une liste de V aux pas record_every, 2*record_every, ..., n_timesteps inclus.
+pixel_history = []
+for V in snapshots:
+    center = V[10:30, 10:30]
+    v_mean = float(center.mean())
+    # Discretisation en 4 quantiles bases sur l'historique complet.
+    pixel_history.append(v_mean)
+# Quantification en 4 niveaux via quantiles globaux.
+quantiles_global = np.quantile(pixel_history, [0.25, 0.5, 0.75])
+pixel_history_q = [int(np.searchsorted(quantiles_global, v)) for v in pixel_history]
+
+out_gs = time_arrow.compare_real_reversed_reversibilized(pixel_history_q)
+print('=== Substrat S4 (ICT-9 Gray-Scott, gate bonus) ===')
+print(f'n_symbols = {out_gs[""n_symbols""]}, observations = {len(pixel_history_q)}')
+print(f'pi_real : {out_gs[""pi_real""]}')
+print(f'sigma_real             = {out_gs[""sigma_real""]:.4f}')
+print(f'sigma_reversibilized   = {out_gs[""sigma_reversibilized""]:.4f}')
+print(f'db_error_real          = {out_gs[""db_error_real""]:.4f}')
+print(f'dist_real_vs_reversibilized = {out_gs[""dist_real_vs_reversibilized""]:.4f}')
+print()
+ratio = out_gs['sigma_real'] / max(out_iid['sigma_real'], 1e-6)
+print(f'Ratio sigma_gray_scott / sigma_iid = {ratio:.2f}')
+print(f'VERDICT Gate 6 : {""OK"" if out_gs[""sigma_real""] > 1.5 * out_iid[""sigma_real""] else ""AMBIGU""} (Gray-Scott fleche continue)')",,,,,,,,8a67d406072c63be,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,be2ff650,markdown,fr,964d103eaada8d05,"## 6.bis Substrat S5 -- CONTROLE faux-POSITIF : pur dissipateur sans auto-maintien
+
+**Pourquoi cette section existe** : la cellule << Moyen, fin, enjeu >> (Section 2.bis) pose que `I_thermo` capture **le moyen** (la dissipation), pas **l'enjeu** (auto-maintien, *stake*). Pour demontrer cette portee **experimentalement**, on construit un substrat qui **dissipe sans avoir aucun enjeu d'auto-maintien** : une marche aleatoire biaisee (S5a) et un oscillateur pilote (S5b). Si l'instrument les allume comme S1/S3, on a la confirmation empirique que la signature thermodynamique **n'est pas suffisante** pour conclure l'agentivite -- elle detecte la depense, pas le projet.
+
+**Gate 7** : les substrats S5 doivent produire un ``sigma_real >> 0`` et une ``dist_real_vs_reversibilized >> 0`` **du meme ordre** que S1 ICT-2 ou S3 ICT-13, malgre l'absence totale d'auto-maintien, de memoire d'identite, ou de perspective de recuperation. C'est le **faux-POSITIF** qui borne la portee de l'instrument par le haut.
+
+**Note d'implementation** : on utilise la **marche aleatoire biaisee sur un reseau 1D a derive constant** (S5a) et un **oscillateur pilote deterministe** (S5b, suite logistique avec forçage periodique). Tous deux sont des systemes dissipatifs **sans aucune representation d'un soi a maintenir** -- le marche aleatoire n'a pas de memoire au-dela du pas courant, l'oscillateur est piloté par une horloge externe. Si `I_thermo` les allume, on a la demonstration que la signature thermodynamique peut etre **purement thermodynamique**, pas agentive.",,,,,,,,964d103eaada8d05,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,c77bc761,code,fr,cdd6844c8be148e3,"# Substrat S5a -- marche aleatoire biaisee (derive constante, SANS memoire d'identite)
+# Controle faux-POSITIF : systeme dissipatif sans auto-maintien.
+rng = np.random.default_rng(101)
+n_steps = 3000
+# Marche sur [-5, +5] a derive constante +0.15 vers la droite, pas bruit N(0, 1).
+# Le systeme dissipE (les transients vers le bord droit sont irreversibles),
+# mais il n'a aucune representation d'un soi a maintenir -- c'est un pur
+# dissipateur mecanique. Si I_thermo l'allume, c'est la preuve que la
+# signature thermodynamique detecte le moyen, pas l'enjeu.
+position = 0.0
+states_rw = []
+for _ in range(n_steps):
+    # Pas : derive constante + bruit symetrique.
+    pas = 0.15 + rng.normal(0, 1)
+    position = position + pas
+    # Quantification sur [-5, +5] en 5 niveaux (reborne pour eviter la derive infinie).
+    if position < -3:
+        position = -3 + 0.5 * rng.random()
+    if position > 3:
+        position = 3 - 0.5 * rng.random()
+    # Discretisation en 5 niveaux.
+    states_rw.append(int(np.clip(int(np.floor((position + 3) * 5 / 6)), 0, 4)))
+
+out_rw = time_arrow.compare_real_reversed_reversibilized(states_rw)
+print('=== Substrat S5a (marche aleatoire biaisee, derive constante) ===')
+print(f'n_symbols = {out_rw[""n_symbols""]}, observations = {len(states_rw)}')
+print(f'pi_real : {out_rw[""pi_real""]}')
+print(f'sigma_real             = {out_rw[""sigma_real""]:.4f}')
+print(f'sigma_reversibilized   = {out_rw[""sigma_reversibilized""]:.4f}')
+print(f'db_error_real          = {out_rw[""db_error_real""]:.4f}')
+print(f'dist_real_vs_reversibilized = {out_rw[""dist_real_vs_reversibilized""]:.4f}')
+print(f'dist_real_vs_reversed       = {out_rw[""dist_real_vs_reversed""]:.4f}')
+print()
+
+# Substrat S5b -- oscillateur pilote deterministe (forcage periodique, SANS enjeu)
+# x_{n+1} = 3.7 * x_n * (1 - x_n) * (1 + 0.3 * sin(2*pi*n / T))
+# Le forçage periodique est externe : le systeme n'a pas de memoire d'identite,
+# il suit la pompe. Si I_thermo l'allume, c'est un autre faux-POSITIF.
+rng2 = np.random.default_rng(202)
+T_force = 47  # periode du forçage
+n_steps2 = 3000
+x = 0.5 + 0.1 * rng2.normal()
+states_osc = []
+for n in range(n_steps2):
+    x = 3.7 * x * (1 - x) * (1 + 0.3 * np.sin(2 * np.pi * n / T_force))
+    # Quantification en 5 niveaux sur [0, 1].
+    if x < 0:
+        x = 0.01
+    if x > 1:
+        x = 0.99
+    states_osc.append(int(np.clip(int(np.floor(x * 5)), 0, 4)))
+
+out_osc = time_arrow.compare_real_reversed_reversibilized(states_osc)
+print('=== Substrat S5b (oscillateur logistique pilote) ===')
+print(f'n_symbols = {out_osc[""n_symbols""]}, observations = {len(states_osc)}')
+print(f'pi_real : {out_osc[""pi_real""]}')
+print(f'sigma_real             = {out_osc[""sigma_real""]:.4f}')
+print(f'sigma_reversibilized   = {out_osc[""sigma_reversibilized""]:.4f}')
+print(f'db_error_real          = {out_osc[""db_error_real""]:.4f}')
+print(f'dist_real_vs_reversibilized = {out_osc[""dist_real_vs_reversibilized""]:.4f}')
+print(f'dist_real_vs_reversed       = {out_osc[""dist_real_vs_reversed""]:.4f}')
+print()
+
+# Comparaison directe avec S1 ICT-2 et S3 ICT-13.
+ratio_rw_vs_s1 = out_rw['sigma_real'] / max(out_biased['sigma_real'], 1e-6)
+ratio_osc_vs_s3 = out_osc['sigma_real'] / max(out_ax['sigma_real'], 1e-6)
+print('=== Comparaison directe (gate 7 -- I_thermo allume les S5 ?) ===')
+print(f'sigma_S5a_marche_biaisee  / sigma_S1_ICT-2     = {ratio_rw_vs_s1:.2f}')
+print(f'sigma_S5b_osc_pilote      / sigma_S3_ICT-13    = {ratio_osc_vs_s3:.2f}')
+print()
+# Verdict Gate 7 nuance :
+#   S5a (marche lineaire) = pas de cycle -> S5a N'allume PAS l'instrument (correct)
+#   S5b (oscillateur pilote) = boucle forcee par forcage externe -> S5b ALLUME massivement
+#          C'est le faux-POSITIF : la circulation est mecanique (pompe periodique), pas agentive.
+gate_7a_no_cycle  = out_rw['sigma_real'] <= 5 * out_iid['sigma_real']
+gate_7b_fp        = out_osc['sigma_real'] > 5 * out_iid['sigma_real']
+verdict_g7 = (
+    ""FAUX-POSITIF CONFIRME (S5b oscillateur pilote allume la circulation ; S5a marche lineaire ""
+    ""sans cycle ne l'allume pas, ce qui est correct). La distinction MOYEN/ENJEU est nette : ""
+    ""I_thermo capture la circulation (MOYEN), pas la finalite (ENJEU).""
+    if (gate_7a_no_cycle and gate_7b_fp) else ""AMBIGU"")
+print(f'VERDICT Gate 7 : {verdict_g7}')
+print(f'  S5a (marche lineaire, pas de cycle)    : sigma = {out_rw[""sigma_real""]:.4f}, '
+      f'5*iid = {5 * out_iid[""sigma_real""]:.4f}, allume ? {""OUI"" if out_rw[""sigma_real""] > 5 * out_iid[""sigma_real""] else ""NON (correct)""}')
+print(f'  S5b (oscillateur pilote, boucle forcee): sigma = {out_osc[""sigma_real""]:.4f}, '
+      f'5*iid = {5 * out_iid[""sigma_real""]:.4f}, allume ? {""OUI (FAUX-POSITIF)"" if out_osc[""sigma_real""] > 5 * out_iid[""sigma_real""] else ""NON""}')
+print('  --> S5b demontre que la signature thermodynamique capture la circulation (MOYEN),')
+print('      pas l\'agentivite (ENJEU). I_thermo est NECESSAIRE mais PAS SUFFISANT.')",,,,,,,,cdd6844c8be148e3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,52aa573c,markdown,fr,4effbc6f3b6d73c7,"## 7. Visualisation -- comparaison des 5 substrats (barplot fleches + distances)
+
+On resume les **5 substrats** en un barplot : production d'entropie ``sigma`` (reelle / reversible / reversee) et distance L1/2 a la reversible. Le **ratio sigma / sigma_iid** est la mesure directe de la fleche temporelle au-dela du bruit. Les substrats S5 (controle faux-POSITIF) sont inclus pour montrer qu'ils allument `I_thermo` autant que les substrats agentifs (S1, S3) sans avoir d'enjeu -- demonstration visuelle de la portee **necessaire-mais-pas-suffisante** de l'instrument.",,,,,,,,4effbc6f3b6d73c7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,725f8e76,code,fr,d10c329b75652630,"# Visualisation comparative (5 substrats + iid baseline)
+fig, axes = plt.subplots(1, 2, figsize=(14, 4.5))
+
+substrats = ['iid', 'S1 ICT-2', 'S2 ICT-8', 'S3 ICT-13', 'S4 ICT-9',
+             'S5a marche biaisee', 'S5b osc pilote']
+sigmas_real = [
+    out_iid['sigma_real'],
+    out_biased['sigma_real'],
+    out_bi['sigma_real'],
+    out_ax['sigma_real'],
+    out_gs['sigma_real'],
+    out_rw['sigma_real'],
+    out_osc['sigma_real'],
+]
+sigmas_rev = [
+    out_iid['sigma_reversibilized'],
+    out_biased['sigma_reversibilized'],
+    out_bi['sigma_reversibilized'],
+    out_ax['sigma_reversibilized'],
+    out_gs['sigma_reversibilized'],
+    out_rw['sigma_reversibilized'],
+    out_osc['sigma_reversibilized'],
+]
+distances = [
+    out_iid['dist_real_vs_reversibilized'],
+    out_biased['dist_real_vs_reversibilized'],
+    out_bi['dist_real_vs_reversibilized'],
+    out_ax['dist_real_vs_reversibilized'],
+    out_gs['dist_real_vs_reversibilized'],
+    out_rw['dist_real_vs_reversibilized'],
+    out_osc['dist_real_vs_reversibilized'],
+]
+x = np.arange(len(substrats))
+width = 0.35
+ax0 = axes[0]
+b1 = ax0.bar(x - width / 2, sigmas_real, width, label='sigma real', color='C0')
+b2 = ax0.bar(x + width / 2, sigmas_rev, width, label='sigma reversible', color='C1')
+ax0.set_xticks(x)
+ax0.set_xticklabels(substrats, rotation=20, ha='right')
+ax0.set_ylabel('production entropie sigma')
+ax0.set_title('Fleche thermodynamique par substrat (avec S5 = faux-POSITIF)')
+ax0.legend()
+ax0.grid(axis='y', alpha=0.3)
+
+ax1 = axes[1]
+b3 = ax1.bar(x, distances, color='C2')
+ax1.set_xticks(x)
+ax1.set_xticklabels(substrats, rotation=20, ha='right')
+ax1.set_ylabel('dist L1/2 (real vs reversible)')
+ax1.set_title('Perte a la reversibilisation')
+ax1.grid(axis='y', alpha=0.3)
+
+plt.tight_layout()
+out_png = os.path.join(ICT_ROOT, 'ICT-18-fleches-comparaison.png')
+plt.savefig(out_png, dpi=110)
+print(f'Figure sauvegardee : {out_png}')",,,,,,,,d10c329b75652630,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,f2eb3dc0,markdown,fr,bf480a57719f14a6,"## 8. Recapitulatif
+
+Les **7 gates** sont passees (a des tolerances pres) sur les **5 substrats** (4 substrats agentifs S1-S4 + controle faux-POSITIF S5). La mesure de la fleche thermodynamique via ``time_arrow`` est un instrument operationnel, **necessaire mais pas suffisant** :
+
+  - **Gate 1** (iid, baseline) : ``sigma ~= 0`` -- une trajectoire totalement aleatoire est reversible au bruit d'echantillonnage pres.
+  - **Gate 2** (projection reversible) : pour TOUTE chaine, ``P_reversibilized`` satisfait detailed balance -- sanity check implementation.
+  - **Gate 3** (ICT-2 *for free*) : la trajectoire biased bubble sort a une fleche strictement superieure a iid. La perte a la reversibilisation est la **quantite de calcul emergent** que le tri porte.
+  - **Gate 4** (ICT-8 bistable) : le modele May avec friction anisotrope a une fleche **lue comme 0** par l'instrument markovien-stationnaire -- **faux-NEGATIF du moyen** (cf cellule Section 2.bis) : l'asymetrie generative est invisible car pi s'adapte a P.
+  - **Gate 5** (ICT-13 Axelrod) : la cooperation emergente (TFT dominant) porte une fleche mesurable ; c'est la signature morphologique de l'agentivite strategique.
+  - **Gate 6** (ICT-9 Gray-Scott) : le systeme reaction-diffusion porte une fleche continue-discrete, ce qui valide l'instrument sur des systemes a temps continu discretise.
+  - **Gate 7 (NOUVEAU, v2)** : les substrats S5 (marche aleatoire biaisee, oscillateur pilote) -- **sans aucun enjeu d'auto-maintien** -- allument `I_thermo` de facon comparable aux substrats agentifs. C'est le **faux-POSITIF** qui borne la portee de l'instrument par le haut : la signature thermodynamique capture le moyen, pas l'enjeu.
+
+**Implication epistemique (v2)** : `I_thermo` est une **condition necessaire** pour suspecter l'agentivite (sigma > 0 veut dire qu'il se passe *quelque chose*) mais ne suffit jamais a la **conclure**. La triade *moyen / fin / enjeu* (Schrodinger / Prigogine / Friston / England) precise que l'instrument mesure **le moyen** ; pour conclure l'agentivite, il faut corroborer avec d'autres instruments (ICT-14 free energy pour l'enjeu, ICT-2/3/9 pour la fin, ICT-15/17 pour la complexite integree).",,,,,,,,bf480a57719f14a6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,0b25cf74,markdown,fr,167aa909bd306d19,"## 9. Exercices
+
+Trois exercices -- convention 3-exercises-per-notebook (#2161) -- repartis : un sur la sensibilite au substrat, un sur la construction d'un indicateur, un sur l'extension a un nouveau substrat.",,,,,,,,167aa909bd306d19,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,62962fd1,code,fr,4e581c15a637596c,"# Exercice 1 -- Sensibilite au nombre d'etats observes
+#
+# Consigne : sur la trajectoire S1 (BiasedBubbleSort), faire varier la
+# discretisation en quantiles et observer comment `sigma_real` evolue.
+# Comprendre la frontiere entre information thermodynamique reelle et
+# artefact de discretisation.
+#
+# 1. Reprend la trajectoire BiasedBubbleSort (cellule Section 3) en
+#    quantifiant le nombre d'inversions sur 2, 4, 6 et 8 niveaux
+#    differents (utilise np.quantile sur la distribution des inversions).
+# 2. Pour chaque quantification, calcule `sigma_real` et
+#    `dist_real_vs_reversibilized`.
+# 3. Trace un graphe (n_niveaux, sigma) et observe la convergence / divergence.
+
+def discretise(states, n_niveaux):
+    states = np.asarray(states)
+    qs = np.linspace(0, 1, n_niveaux + 1)[1:-1]
+    seuils = np.quantile(states, qs)
+    return np.searchsorted(seuils, states).tolist()
+
+resultats = []
+for n_niveaux in [2, 3, 4, 5, 6, 8]:
+    states_d = discretise(states_biased, n_niveaux)
+    out_d = time_arrow.compare_real_reversed_reversibilized(states_d)
+    resultats.append({
+        'n_niveaux': n_niveaux,
+        'sigma_real': out_d['sigma_real'],
+        'dist_rev': out_d['dist_real_vs_reversibilized'],
+    })
+for r in resultats:
+    print(r)
+
+# Question : a partir de combien de niveaux sigma se stabilise-t-il ?
+# Reponse dans la cellule markdown apres.",,,,,,,,4e581c15a637596c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,c2130ee3,markdown,fr,b459b2b03d3cb156,"### Exercice 2 -- Definir et tester un *indice d'agentivite*
+
+**Consigne** : a partir des quantites thermodynamiques mesurees, definir un **indice d'agentivite** agrege qui resume la *quantite de calcul emergent* d'une trajectoire. Le tester sur les 4 substrats (S1/S2/S3/S4) et sur la trajectoire iid.
+
+**Lecon methodologique attendue** : la hierarchie naturelle des indices est :
+ - **S2 ICT-8** < **iid** < S4 ICT-9 < S1 ICT-2 < **S3 ICT-13** (cooperation emergente).
+ - **S2 ICT-8 est le minimum** : le bistable a 2 etats est *reversible par construction markovienne* (la distribution stationnaire pi adapte les taux de bascule de sorte que la detailed balance est *exactement* satisfaite -- l'asymetrie du modele generatif est invisible a l'instrument markovien stationnaire).
+ - **iid est le 2e minimum** : une trajectoire totalement aleatoire est reversible au bruit d'echantillonnage pres.
+ - **S3 ICT-13 est le maximum** : la cooperation emergente (Axelrod) est un processus *non-stationnaire* avec une fleche temporelle forte (la population de TFT croît au cours du temps), capturee par l'asymetrie du decompte d'agents TFT entre temps croissant et temps decroissant.
+
+**Note importante sur S2 ICT-8 -- un CAS FICTIF : le faux-NEGATIF du moyen**. La trajectoire bistable (May 1977) est **comportementalement tres structuree** -- 2 bassins d'attraction, hysteresis, flip-flopping anisotrope, **forte reversibilite comportementale** au sens de ICT-2/3/9 (l'agent peut revenir dans son bassin apres un flip). **Et pourtant**, l'instrument thermodynamique de ce notebook la lit comme **reversible par construction markovienne** (``sigma = 0`` car pi s'adapte a P pour minimiser detailed balance).
+
+Ce resultat n'est **ni un angle mort, ni une orthogonalite d'axes**. C'est un **faux-NEGATIF du moyen** : l'instrument markovien-stationnaire est **aveugle a la memoire et a la non-stationnarite**. La trajectoire reelle du bistable est generee par un processus avec une memoire de position (on reste dans le bassin tant qu'on n'a pas flippe), mais l'**observation stationnaire** reduit cette trajectoire a une chaine de Markov d'ordre 1 dont la matrice de transition P a ete *re-estimee pour minimiser la detailed balance* -- ce qui eteint exactement l'asymetrie generative que le modele porte. L'asymetrie du modele generatif (p_flip_A != p_flip_B) vit dans la **memoire** et dans la **non-stationnarite** ; `P_rev` ne la capte pas, parce que l'instrument regarde une **matrice de transition aggregee sur toute la trajectoire**, pas le processus increment par increment.
+
+Pour mesurer la richesse comportementale d'un bistable, il faut des instruments qui voient la memoire : ICT-15 (complexite integree, PhiID), ICT-17 (epsilon-machine, Crutchfield), ICT-2/3/9 (reversibilite comportementale cinematique). ICT-18 est specialise sur le **moyen** thermodynamique, par construction ; le fait que S2 sorte 0 sur cet instrument est une **information honnete sur la portee de l'instrument**, pas une lacune dans le notebook.
+
+**Et le faux-POSITIF miroir (substrat S5, Section 7)** : une marche aleatoire biaisee ou un oscillateur chimique pilote -- sans aucun enjeu d'auto-maintien -- allume `I_thermo` autant que S1/S3. La symetrie des deux faux-resultats (un systeme structure sort 0 a tort, un systeme non-agent sort fort a tort) demontre que `I_thermo` est **necessaire mais pas suffisant** pour conclure l'agentivite : il capture le **moyen**, pas l'**enjeu** ni la **fin**. Sans corroboration par d'autres instruments (Friston free energy, cloture de contraintes, auto-maintien), un `I_thermo` positif ne **prouve** rien sur l'agentivite.
+
+Indication : ``agentivity_index = alpha * dist_real_vs_reversed + beta * dist_real_vs_reversibilized``. On n'inclut PAS ``sigma_real`` ni ``db_error_real`` dans l'indice, parce que ces 2 quantites sont *intrinsement absorbees* par la distribution stationnaire empirique (sur une trajectoire longue et stationnaire, pi s'adapte a P pour minimiser la detailed balance error).",,,,,,,,b459b2b03d3cb156,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,bf0e8479,code,fr,64c0b05875bd424e,"def agentivity_index(out, alpha=0.5, beta=0.5):
+    """"""Indice d'agentivite agregeant 2 quantites thermodynamiques.
+
+    Parametres :
+      - alpha : poids de la distance a la chainee renversee dans le temps
+        (``dist_real_vs_reversed``). C'est la mesure directe de
+        l'asymetrie temporelle de la trajectoire reelle -- elle capture
+        *toute* la deviation a la reversibilite, sans etre compensee par
+        la re-estimation de pi (qui tend a minimiser detailed balance
+        par construction).
+      - beta : poids de la distance a la reversible (``dist_real_vs_reversibilized``).
+        C'est ce qu'on perd a forcer la symetrie temporelle, soit la
+        *quantite de structure irreversible* de la trajectoire.
+
+    Note importante : on n'inclut PAS ``sigma_real`` ni ``db_error_real``
+    dans l'indice, parce que ces 2 quantites sont *intrinsement absorbees*
+    par la distribution stationnaire empirique : sur une trajectoire
+    longue et stationnaire, pi s'adapte a P pour minimiser la detailed
+    balance error (le systeme atteint l'equilibre thermodynamique). La
+    *vraie* mesure de l'agentivite emergente est dans les distances
+    entre matrices (``dist_*``).
+    """"""
+    return (
+        alpha * out['dist_real_vs_reversed']
+        + beta * out['dist_real_vs_reversibilized']
+    )
+
+
+# Panel des substrats (definitions reutilisees plus haut) -- 5 substrats + iid.
+panel_exo = {
+    'iid': out_iid,
+    'S1 ICT-2': out_biased,
+    'S2 ICT-8': out_bi,
+    'S3 ICT-13': out_ax,
+    'S4 ICT-9': out_gs,
+    'S5a marche biaisee': out_rw,
+    'S5b osc pilote': out_osc,
+}
+indices = {name: agentivity_index(o) for name, o in panel_exo.items()}
+for name, idx in indices.items():
+    print(f'{name:25s}  agentivity = {idx:.4f}')",,,,,,,,64c0b05875bd424e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,624bc47e,markdown,fr,692110b8416191d5,"### Exercice 3 -- Extension a un nouveau substrat : automate cellulaire de Wolfram
+
+**Consigne** : appliquer ``time_arrow`` sur un automate cellulaire 1D (regle de Wolfram 30, 110 ou 110) et observer la fleche thermodynamique. La regle 30 (chaotique) doit avoir une fleche elevee ; la regle 110 (complexe, classe 4) doit avoir une fleche encore plus elevee ; la regle 0 (trivialement constante) doit avoir une fleche nulle.
+
+Indication : partir d'une cellule aleatoire sur 64 cellules, iterer 100 pas, prendre la sequence d'etats par cellule (0 ou 1, alphabet binaire) ou une quantification par bloc.",,,,,,,,692110b8416191d5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,dd0ac54d,code,fr,f63aa204b738fac5,"# Exercice 3 -- Automate cellulaire Wolfram (regle 30 vs 110 vs 0)
+def wolfram_step(state, rule):
+    n = len(state)
+    out = np.zeros(n, dtype=int)
+    for i in range(n):
+        left = state[(i - 1) % n]
+        center = state[i]
+        right = state[(i + 1) % n]
+        idx = (left << 2) | (center << 1) | right
+        out[i] = (rule >> idx) & 1
+    return out
+
+def wolfram_trajectory(rule, n_cells=32, n_steps=300, seed=33):
+    rng = np.random.default_rng(seed)
+    state = rng.integers(0, 2, size=n_cells)
+    history = []
+    for _ in range(n_steps):
+        history.append(int(state.sum()))  # nb de 1's (densite)
+        state = wolfram_step(state, rule)
+    return history
+
+for rule in [0, 30, 110, 250]:
+    traj = wolfram_trajectory(rule, n_steps=300, seed=33)
+    out = time_arrow.compare_real_reversed_reversibilized(traj)
+    print(f'Regle {rule:3d}  sigma_real = {out[""sigma_real""]:.4f}  '
+          f'dist_rev = {out[""dist_real_vs_reversibilized""]:.4f}  '
+          f'db_error = {out[""db_error_real""]:.4f}')
+
+# Question : la regle 110 (complexe, classe 4) a-t-elle une fleche plus elevee
+# que la regle 30 (chaotique) ? Pourquoi ?
+# Reponse dans la cellule markdown apres.",,,,,,,,f63aa204b738fac5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb,33d60400,markdown,fr,66fa37408c48f23b,"## 10. Conclusion
+
+ICT-18 fournit un **instrument thermodynamique** (production d'entropie, detailed balance, reversibilisation) qui capte le **MOYEN** dans la triade *moyen / fin / enjeu*. La grille de lecture est explicite et honnete :
+
+  - Une trajectoire *reversible* (detailed balance satisfaite, ``sigma = 0``) **ne porte pas de calcul emergent** : elle est statistiquement identique a son inverse. C'est le regime d'equilibre thermodynamique, sans fleche du temps.
+  - Une trajectoire *irreversible* (``sigma > 0``, distance a la reversible non nulle) **porte une quantite mesurable de dissipation** : c'est la trace thermodynamique d'un processus qui brule des gradients. Ce peut etre l'ICT-2 *for free*, l'ICT-8 flip-flopping anisotrope (faux-NEGATIF du a l'instrument markovien-stationnaire), l'ICT-13 cooperation emergente, l'ICT-9 flux continu Gray-Scott -- **ou un pur dissipateur sans enjeu** (S5 marche aleatoire biaisee, oscillateur pilote).
+  - **Forcer la reversibilite tue la signature**, mais cela **ne suffit pas a conclure l'agentivite** : un systeme qui dissipe fortement (S5) voit son `I_thermo` s'evanouir a la reversibilisation comme un systeme agentif, mais il n'a aucun enjeu d'auto-maintien a defendre. Le tranchant << reversibiliser tue la signature >> est donc preserve, mais en **necessaire-mais-pas-suffisant**.
+
+**Precisions theoriques sur la grandeur mesuree** :
+
+L'instrument ``I_thermo`` s'ancre dans le formalisme des **affinites de cycle de Schnakenberg (1976)** : pour une chaine de Markov irreductible stationnaire, la production d'entropie ``sigma`` se decompose comme une somme ponderee sur les cycles elementaires du graphe de transition, chaque cycle portant une affinite ``A_cycle = ln(produit taux aller / produit taux retour)``. La reversibilisation tue toutes les affinites de cycle non triviales, et l'``I_thermo = dist(P_real, P_reversible)`` mesure directement l'**intensite moyenne des affinites non nulles** = la composante de **circulation** du champ de flux net. C'est cette lecture qui permet d'identifier ce qui distingue S1 ICT-2 (competence *for free* = cycles portes par le biais du bubble sort), S3 ICT-13 (cooperation emergente = cycles de croissance des TFT), S4 ICT-9 (flux net ``f -> k`` = cycle continue Gray-Scott discretise) -- **et S5 (cycles portes par la derive constante ou le forçage periodique, sans enjeu)**.
+
+Une lecture complementaire est la **decomposition de Hodge** du champ de flux net (``pi_i P[i,j] - pi_j P[j,i]``) : celui-ci se decompose en une composante de **gradient** (reversible, nulle sur les cycles) et une composante de **circulation** (irreversible, supportee par les cycles non triviaux du graphe). ICT-18 isole la composante de circulation -- c'est elle qui definit l'irreversibilite thermodynamique brute (le moyen). La decomposition de Hodge donne un cadre geometrique a l'idee que reversibiliser revient a tuer la circulation sans toucher au gradient.
+
+**Le couplage teleonomique (Schrodinger / Prigogine / Friston / England)** : le vivant lutte contre l'equilibration locale de son soi **en produisant** plus de dissipation dans le monde. Il ne renverse jamais le second principe : il **paie** son ordre local par un desordre global plus grand. L'agent *depense* de l'irreversibilite (moyen) pour *gagner* la recuperabilite de sa persistance (fin, reversibilite comportementale) *contre* la decomposition (enjeu). ICT-18 mesure le moyen ; ICT-2/3/9 mesurent la fin ; ICT-14 (free energy / Friston) et la cloture de contraintes (Kauffman, Moreno-Mossio) touchent a l'enjeu. **L'agentivite est l'intersection operante des trois** : un systeme qui dissipe (moyen) pour rester reversiblement recuperable (fin) contre l'equilibration (enjeu). Sans l'un des trois, on tombe dans le faux-POSITIF (S5 : moyen seul) ou le faux-NEGATIF (S2 ICT-8 : fin seule, moyen invisible).
+
+**Ligne d'extension culturelle** (optionnelle, hors-scope ICT-18 mais meme triade) : la tension *moyen / fin / enjeu* traverse les echelles. **Georgescu-Roegen** 1971 *The Entropy Law and the Economic Process* voit l'economie comme une dissipation de gradients (le moyen) finance par un stock de neguentropie low-entropy (la fin) au prix d'une dette entropique planetaire (l'enjeu). **Stiegler** 2018 *The Neganthropocene* renomme cela << neguanthropie >> : l'enjeu n'est pas de *moins* consommer d'entropie, mais de re-orienter la consommation vers une production de sens (la fin, *care*) plutot que de simples gradients thermiques. ICT-18 formule la version thermodynamique precise du meme couplage -- mais l'extension culturelle depasse le notebook et reste a elargir ailleurs (cf ICT-11/13 sur la valence).
+
+**Lien avec les autres strates** :
+  - Strate 1 (ICT-2/3) : le tri auto-organise **est** une trajectoire irreversible au sens thermodynamique -- la competence *for free* est la marque de cette irreversibilite. ICT-18 quantifie precisement cette intuition, sans conclure (le tri *for free* est-il un agent ? ICT-2 discute).
+  - Strate 2 (ICT-8, ICT-9) : le paysage d'attracteurs (May 1977) et la regeneration (Gray-Scott) sont des systemes irreversible *par construction* ; la fleche thermodynamique les qualifie differemment. ICT-8 sert de **faux-NEGATIF** (fort sur la fin, thermodynamiquement reversible par adaptation de pi). ICT-9 sert d'exemple intermediaire (flux continu, discretise bien).
+  - Strate 3 (ICT-13) : la cooperation emergente (Axelrod) est un cas d'agentivite strategique ; la fleche thermodynamique la rend mesurable, sans conclure.
+  - Strate 4 (ICT-14 free energy / Friston) : la free energy principle touche directement a l'**enjeu** -- le systeme lutte contre la surprise pour preserver son modele du monde. ICT-14 complete ICT-18 en mesurant le pole manquant de la triade.
+  - Strate 5 (ce notebook + ICT-15/16/17/20) : la **complexite integree** (ICT-15), la **MDL** (ICT-16), l'**epsilon-machine** (ICT-17) et la **feature catastrophe** (ICT-20) sont des mesures de structure differentes ; ICT-18 ajoute la mesure thermodynamique du moyen, **sans pretendre conclure l'agentivite seule**.
+
+**Pour aller plus loin** :
+  - **Corroborer ICT-18 avec ICT-14** : appliquer ICT-14 free energy sur les memes substrats S1-S5, et montrer que les S5 (sans enjeu) sortent une free energy *elevee* (le systeme est surpris par son devenir, il n'a pas de modele interne), tandis que S1/S3 sortent une free energy *faible* (modele interne adapte). Cela fermerait le triangle *moyen / fin / enjeu* empiriquement.
+  - Tester sur ICT-17 (epsilon-machine) : la epsilon-machine d'un S5 est-elle vide (pas de structure causale) ou triviale (Markov d'ordre 1) ? Si oui, cela confirme l'absence d'enjeu.
+  - Relier a England 2013 *dissipation-driven adaptation* : formaliser la derivation thermodynamique de l'auto-maintien (les systemes qui dissipent plus tendent a s'auto-organiser -- mais tous ne deviennent pas agents).
+  - Croiser ICT-18 avec ICT-2/3/9 pour cartographier les systemes dans le **plan (moyen, fin)** ; l'enjeu serait alors un troisieme axe vertical (Friston free energy / cloture de contraintes), definissant un cube de la triade.
+  - **ICT-19 ?** : la question des batteries de capteurs multiples (proposition ChatGPT, *two separate batteries*) depasse ICT-18 -- ce serait un notebook dedie a la fusion *moyen + fin + enjeu*, avec sa propre structure et son propre gate. ICT-18 fournit la brique ; ICT-19 l'assemblerait.",,,,,,,,66fa37408c48f23b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,c6a54be62e36,markdown,fr,469986a77845cda3,"# ICT-19 — Raffinement et résolution des stubs (tranche 3)
+
+[← ICT-19 squelette (tranche 2)](../ICT-19-EnjeuBattery/ICT-19-EnjeuBattery.ipynb) · [↑ ICT-Series](../README.md) · [→ ICT-20](../ICT-20-FeatureCatastrophes/ICT-20-FeatureCatastrophes.ipynb) · [Epic #4588](https://github.com/jsboige/CoursIA/issues/4588)
+
+**Strate 5 — suite de la batterie ENJEU (GPU-free).**
+
+## Objectifs pédagogiques
+
+À l'issue de ce notebook, vous saurez :
+
+1. **Raffiner** la mesure de l'enjeu au-delà du `stake_index` brut, en utilisant `ict.agency.repair_gain` (comparaison reaction-diffusion vs diffusion pure) et `ict.agency.time_to_recover` (observable temporelle).
+2. **Résoudre** les trois exercices C.1 laissés en stub dans la tranche 2 :
+   - **S1** tri auto-organisé (`ict.self_sorting.SelfSortingArray`).
+   - **S3** Axelrod (`ict.strategic_morphodynamics.make_strategies` + `replicator_trajectory`).
+   - **Custom step** : un substrat-jouet pour calibrer l'intuition.
+
+## Prérequis
+
+- Notebook ICT-19 tranche 2 exécuté (`ICT-19-EnjeuBattery.ipynb`).
+- `ict.stake` (PR #5495) + `ict.agency` mergés sur main.
+- GPU-free : numpy uniquement.
+
+## Durée estimée
+
+20 min (lecture + exécution séquentielle). Substantiellement plus rapide que la tranche 2 (pas de reaction-diffusion lourde).
+",,,,,,,,469986a77845cda3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,d99d055d2fb8,code,fr,b7f11e7c4b0e8c22,"# Setup : imports + matplotlib Agg non-interactif (GPU-free, numpy only)
+import sys
+import numpy as np
+
+# Ajouter le dossier ICT-Series au path pour importer `ict`
+sys.path.insert(0, ""."")
+
+import ict
+from ict import (
+    GrayScott, GrazingModel, SelfSortingArray,
+    agency, reaction_diffusion, stake, strategic_morphodynamics,
+)
+from ict.stake import (
+    stake_index, drift_step, restoring_step, do_kick,
+    basin_anchor, distance_to_anchor, demo_contrast, recovery_curve,
+)
+from ict.agency import (
+    disk_mask, ablate, structure, recovery_score,
+    repair_gain, time_to_recover, basin_return_probability,
+)
+from ict.strategic_morphodynamics import (
+    make_strategies, play_match, round_robin, payoff_matrix,
+    replicator_trajectory, fixation,
+)
+
+# Matplotlib non-interactif
+import matplotlib
+matplotlib.use(""Agg"")
+import matplotlib.pyplot as plt
+import warnings
+# Filtrer advisory FigureCanvasAgg (figure rendue en output ; warning embarque chemin ipykernel temp).
+warnings.filterwarnings(""ignore"", message="".*FigureCanvasAgg.*"")
+
+print(f""ict loaded OK"")
+print(f""  GrayScott available: {GrayScott is not None}"")
+print(f""  stake_index available: {stake_index is not None}"")
+print(f""  repair_gain available: {repair_gain is not None}"")
+print(f""  time_to_recover available: {time_to_recover is not None}"")
+print(f""  SelfSortingArray available: {SelfSortingArray is not None}"")
+print(f""  replicator_trajectory available: {replicator_trajectory is not None}"")
+",,,,,,,,b7f11e7c4b0e8c22,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,a4099ad72def,markdown,fr,31ca6875688c7ce6,"## 8. Raffinement méthodologique — `repair_gain` et `time_to_recover`
+
+La tranche 2 avait documenté un **échec de Gate ENJEU-1** sur le banc naïf (`I_stake(S4) = -0.5083`, `I_stake(S5) = -0.4651`) et l'avait attribué à une *limite physique* de Gray-Scott. **Ce diagnostic était faux.** Le résultat nul venait de deux défauts corrigés ici :
+
+1. **Un mauvais instrument pour un substrat 2D.** `I_stake` (`ict.stake`) est conçu pour des états scalaires (S1 tri, S3 Axelrod, S5 marche biaisée) ; sa docstring renvoie explicitement les champs 2D de Gray-Scott (S4) vers `ict.agency`. Scalariser Gray-Scott en `structure(V)` puis lui appliquer `stake_index` mesure le mauvais objet. L'instrument correct pour S4 est le **champ** : `ict.agency.repair_gain`.
+2. **Un bug de câblage + un régime immature.** L'appel `recovery_score(V, Vk2, Vk2, mask)` de la tranche 2 passait le champ *relaxé* comme argument `ablated` ET `repaired` : le numérateur `(S_repaired - S_ablated)` est alors identiquement nul → `repair_gain = 0` quel que soit le régime. De plus le banc tournait à `F=0.04, k=0.06` sur `n=32` (grille trop petite, régime peu formateur).
+
+Cette tranche corrige les deux et **résout le Gate ENJEU-1 en espace de champ** :
+
+- **`ict.agency.repair_gain(recovery_reaction_diffusion, recovery_diffusion)`** : récupération sous réaction-diffusion moins récupération sous diffusion pure (témoin négatif structurel). Strictement positif = réparation **active**.
+- **`ict.agency.time_to_recover(structures, target, tol)`** : nombre de pas pour que la structure **locale** (dans la zone ablatée) repasse au-dessus de `target * (1 - tol)`.
+
+### 8.1 Mesure `repair_gain` sur S4 mature (régime de Pearson, warmup 3000 pas)
+
+On adopte le régime **taches mitotiques de Pearson** (`F=0.0367, k=0.0649`, le défaut robuste de `ict.reaction_diffusion`) sur une grille `n=64`, avec un warmup de 3000 pas pour que les taches se développent réellement. On compare la récupération du champ `V` après ablation d'un disque, sous Gray-Scott (S4 = agent) vs sous pure diffusion (témoin passif), **moyennée sur 5 ablations aléatoires** (écart-type reporté).
+",,,,,,,,31ca6875688c7ce6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,ce0461f78012,code,fr,2c1cc74fd6de9644,"# Raffinement — regime Pearson mitotic-spots (F=0.0367, k=0.0649), n=64, warmup 3000.
+# Deux corrections vs tranche 2 :
+#   (1) appel recovery_score corrige : ablated = champ ablate (Vk_t), PAS le champ relaxe ;
+#   (2) regime auto-entretenu robuste (taches de Pearson) sur grille n=64 assez grande
+#       pour que les taches se developpent, se divisent, et regenerent la zone ablatee.
+F_GS, k_GS, N, WARMUP, RADIUS, RELAX = 0.0367, 0.0649, 64, 3000, 12, 1500
+gs = GrayScott(F=F_GS, k=k_GS, dt=1.0)
+U, V = gs.seed(n=N, block=10, noise=0.05, rng=np.random.default_rng(123))
+for _ in range(WARMUP):
+    U, V = gs.step(U, V)
+ref = V.copy()
+ref_structure = agency.structure(ref)
+print(f""reference structure globale (post-{WARMUP}-pas warmup) = {ref_structure:.6f}"")
+
+# repair_gain moyenne sur 5 ablations aleatoires (honnete : ecart-type reporte)
+gains = []
+r_s4 = r_diff = 0.0
+for trial in range(5):
+    rng = np.random.default_rng(200 + trial)
+    cx = int(rng.integers(RADIUS, N - RADIUS))
+    cy = int(rng.integers(RADIUS, N - RADIUS))
+    m = agency.disk_mask(N, cx=cx, cy=cy, radius=RADIUS)
+    Uk_t, Vk_t = agency.ablate(U, V, m)
+    # relaxation sous Gray-Scott (agent)
+    Ua, Va = Uk_t.copy(), Vk_t.copy()
+    for _ in range(RELAX):
+        Ua, Va = gs.step(Ua, Va)
+    r_s4 = agency.recovery_score(ref, Vk_t, Va, m)          # appel corrige : ablated=Vk_t
+    # controle : pure diffusion (meme operateur, terme reactif retire)
+    Ud, Vd = Uk_t.copy(), Vk_t.copy()
+    for _ in range(RELAX):
+        Vd = reaction_diffusion.pure_diffusion_step(Vd, D=gs.Dv, dt=1.0)
+        Ud = reaction_diffusion.pure_diffusion_step(Ud, D=gs.Du, dt=1.0)
+    r_diff = agency.recovery_score(ref, Vk_t, Vd, m)
+    gains.append(agency.repair_gain(r_s4, r_diff))
+gains = np.array(gains)
+print(f""recovery_score Gray-Scott (S4 agent)   ~ {r_s4:+.4f} (derniere ablation)"")
+print(f""recovery_score pure diffusion (temoin) ~ {r_diff:+.4f}"")
+print(f""repair_gain (S4 - diffusion), 5 ablations : moyenne = {gains.mean():+.4f} +/- {gains.std():.4f}"")
+print(f""  > 0 = S4 repare activement la zone ablatee ; ~0 = passif (diffusion)"")
+
+# ablation centrale conservee pour l'observable temporelle (cellule suivante)
+mask = agency.disk_mask(N, cx=N // 2, cy=N // 2, radius=RADIUS)
+Uk, Vk = agency.ablate(U, V, mask)
+",,,,,,,,2c1cc74fd6de9644,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,df7907783e2a,markdown,fr,30b6ec05d3913a56,"### 8.2 Observable temporelle : `time_to_recover` (structure locale)
+
+Sous une ablation *locale* (un disque de rayon 12 dans une grille 64x64 ≈ 11 % des cellules), la variance **globale** `structure(V)` bouge à peine — elle ne capte pas la perte de motif (cf. docstring `ict.agency.local_structure`). On suit donc la variance **locale au masque** : elle chute à zéro juste après l'ablation et remonte quand les taches se reforment dans la zone. `time_to_recover` retourne le nombre de pas pour repasser au-dessus de `target * (1 - tol)` ; un retour en quelques centaines de pas signe un agent actif.
+",,,,,,,,30b6ec05d3913a56,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,9efef4d06248,code,fr,03cb74efc1deb509,"# time_to_recover sur l'observable LOCALE (variance dans le masque) : la variance
+# globale bouge a peine sous une ablation locale, donc on suit local_structure(V, mask)
+# qui chute a 0 apres ablation et remonte quand les taches se reforment dans la zone.
+target_local = agency.local_structure(ref, mask)
+locs_post_ablation = []
+Uk_t, Vk_t = Uk.copy(), Vk.copy()
+for _ in range(RELAX):
+    locs_post_ablation.append(agency.local_structure(Vk_t, mask))
+    Uk_t, Vk_t = gs.step(Uk_t, Vk_t)
+
+ttr_strict = agency.time_to_recover(locs_post_ablation, target=target_local, tol=0.1)
+ttr_loose = agency.time_to_recover(locs_post_ablation, target=target_local, tol=0.3)
+print(f""structure locale cible (pre-ablation, dans le masque) = {target_local:.6f}"")
+print(f""time_to_recover (tol=0.1, strict) = {ttr_strict} pas"")
+print(f""time_to_recover (tol=0.3, loose)  = {ttr_loose} pas"")
+if ttr_loose is not None:
+    print(f""  -> Reconstruction locale detectee en ~{ttr_loose} pas. S4 montre un enjeu mesurable."")
+else:
+    print(f""  -> Aucune reconstruction locale en {RELAX} pas."")
+",,,,,,,,03cb74efc1deb509,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,edd8da8a271e,markdown,fr,2bc69aef9c222a37,"### 8.3 Comparaison directe `stake_index` vs `repair_gain`
+
+| Mesure | S4 (Gray-Scott, agent) | Témoin | Verdict |
+|--------|------------------------|--------|---------|
+| `I_stake` scalaire (tranche 2, banc naïf) | -0.5083 | S5 = -0.4651 | FAIL — mauvais instrument (scalarise un champ 2D) |
+| `repair_gain` champ (tranche 3, warmup 3000, Pearson) | **+0.82 ± 0.27** (5 ablations) | diffusion pure ≈ +0.002 | **PASS — S4 répare activement** |
+| `time_to_recover` local | strict(0.1) = 489 pas, loose(0.3) = 313 pas | diffusion ≈ jamais | **PASS — reconstruction locale nette** |
+
+**Ce que corrige la tranche 3.** Le résultat nul de la tranche 2 n'était **pas** une limite physique de Gray-Scott (comme le supposait son annexe), mais (a) un instrument scalaire inadapté à un champ 2D — l'instrument correct est `ict.agency.repair_gain` en espace de champ — et (b) un bug de câblage de `recovery_score` (champ relaxé passé comme `ablated`) doublé d'un régime immature. Corrigés, l'agent Gray-Scott régénère ~82 % de la structure locale ablatée là où la diffusion pure en régénère ~0 % : la **paire** `(I_thermo, repair_gain)` sépare bien l'agent du pur dissipateur — la découpe visée par ICT-18/19.
+",,,,,,,,2bc69aef9c222a37,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,be0d9dbd5141,markdown,fr,f54d980ac4dec1e1,"## 9. Résolution S1 — tri auto-organisé (`ict.self_sorting.SelfSortingArray`)
+
+**Observable 1D** : taux de paires adjacentes bien ordonnées dans le tableau (`sorted_pair_rate` ∈ [0, 1]). L'attracteur = 1.0 (array complètement trié).
+
+**Kick** : on inverse un sous-ensemble de 4 cellules adjacentes pour briser l'ordre local sans détruire la tendance globale.
+
+**Step function** : à chaque appel, on avance `SelfSortingArray` d'un pas (un swap éventuel) puis on renvoie le nouveau `sorted_pair_rate`.
+",,,,,,,,f54d980ac4dec1e1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,54b5a61a3854,code,fr,3e9bbe98a0b4481f,"# S1 resolution : SelfSortingArray avec 10 cellules
+s1_state = {""values"": list(range(10)), ""ssa"": None}
+rng_init = np.random.default_rng(42)
+rng_init.shuffle(s1_state[""values""])
+s1_state[""ssa""] = SelfSortingArray(values=list(s1_state[""values""]), seed=42)
+
+def sorted_pair_rate(values):
+    return float(np.mean([values[i] <= values[i+1] for i in range(len(values)-1)]))
+
+# Warmup : 100 pas pour relaxer vers l attracteur
+for _ in range(100):
+    s1_state[""ssa""].step()
+print(f""S1 post-warmup values = {s1_state['ssa'].values}"")
+print(f""S1 sorted_pair_rate post-warmup = {sorted_pair_rate(s1_state['ssa'].values):.4f}"")
+
+# Kick : inverser un sous-ensemble de 4 cellules
+kicked_values = list(s1_state[""ssa""].values)
+kicked_values[2:6] = kicked_values[2:6][::-1]
+kicked_rate = sorted_pair_rate(kicked_values)
+print(f""S1 kicked values = {kicked_values}"")
+print(f""S1 sorted_pair_rate post-kick = {kicked_rate:.4f}"")
+
+# Reconstruire SelfSortingArray depuis l'etat kicke
+s1_state[""ssa""] = SelfSortingArray(values=list(kicked_values), seed=42)
+# ssa a deja un snapshot initial, on note le taux courant
+
+def s1_step(state):
+    # Avance SelfSortingArray d'un pas et renvoie le nouveau sorted_pair_rate.
+    s1_state[""ssa""].step()
+    return np.array([sorted_pair_rate(s1_state[""ssa""].values)])
+
+i_stake_s1 = stake_index(
+    kicked_state=np.array([kicked_rate]),
+    step_fn=s1_step,
+    steps=300, anchor=1.0,
+)
+print(f""S1 I_stake = {i_stake_s1:+.4f}"")
+print(f""  Attendu : I_stake >> 0 (le tri defend son attracteur sorted)."")
+",,,,,,,,3e9bbe98a0b4481f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,d8dcba6dec31,markdown,fr,b3b7993838852d28,"**Interprétation S1.** Le tri auto-organisé a un *enjeu* clair : chaque cellule (vue-cellule) tend vers sa position correcte, et le système revient rapidement à l'ordre global après une perturbation locale. `I_stake ≈ 1` est la signature d'un système à *clôture de contraintes forte* — chaque swap rapproche l'ensemble d'un point fixe.
+",,,,,,,,b3b7993838852d28,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,a43a732b6332,markdown,fr,8e2b01bb2b25146a,"## 10. Résolution S3 — Axelrod (`ict.strategic_morphodynamics`)
+
+**Observable 1D** : fréquence de la stratégie `allc` (Always Cooperate) dans la dynamique du replicateur.
+
+**Kick** : on perturbe la fréquence initiale de `allc` (+0.3) et on observe si le système retourne à l'équilibre ESS (Evolutionarily Stable Strategy).
+
+**Step function** : à chaque appel, on avance la trajectoire du replicateur d'un pas et on renvoie la nouvelle fréquence.
+",,,,,,,,8e2b01bb2b25146a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,d8d8f95c6871,code,fr,5d84828dd25b1cad,"# S3 resolution : replicator dynamics sur Axelrod
+rng_axelrod = np.random.default_rng(42)
+strategies = make_strategies(rng=rng_axelrod)
+n_strat = len(strategies)
+strat_list = list(strategies.values())
+strat_names = list(strategies.keys())
+print(f""Strategies: {strat_names}"")
+
+# Payoff matrix (symmetric play_match returns tuple)
+A = np.zeros((n_strat, n_strat))
+for i in range(n_strat):
+    for j in range(n_strat):
+        p_own, _ = play_match(strat_list[i], strat_list[j], n_rounds=20, rng=rng_axelrod)
+        A[i, j] = p_own
+
+# Free trajectory : uniform initial frequencies
+x0_free = np.ones(n_strat) / n_strat
+traj_free = replicator_trajectory(A, x0_free, n_steps=500)
+allc_idx = strat_names.index(""allc"")
+print(f""Final frequencies: {dict(zip(strat_names, [round(float(f), 4) for f in traj_free[-1]]))}"")
+
+# Anchor : mean coop rate over last 250 steps (ESS reached)
+anchor_s3 = float(np.mean(traj_free[250:, allc_idx]))
+print(f""S3 anchor (mean coop over last 250 steps) = {anchor_s3:.4f}"")
+
+# Kick : +0.3 sur allc
+kicked_x0 = x0_free.copy()
+kicked_x0[allc_idx] += 0.3
+kicked_x0 = np.clip(kicked_x0, 0, None)
+kicked_x0 /= kicked_x0.sum()
+traj_kicked = replicator_trajectory(A, kicked_x0, n_steps=500)
+
+# Step function : avance dans traj_kicked et renvoie la coop_rate
+s3_state = {""t"": 0}
+def s3_step(state):
+    s3_state[""t""] += 1
+    if s3_state[""t""] >= len(traj_kicked):
+        return np.array([0.5])
+    return np.array([traj_kicked[s3_state[""t""], allc_idx]])
+
+i_stake_s3 = stake_index(
+    kicked_state=np.array([traj_kicked[0, allc_idx]]),
+    step_fn=s3_step,
+    steps=100, anchor=anchor_s3,
+)
+print(f""S3 I_stake (coop_rate) = {i_stake_s3:+.4f}"")
+print(f""  Attendu : I_stake > 0 (l'ESS Axelrod defend sa structure de frequences)."")
+",,,,,,,,5d84828dd25b1cad,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,c18600d28cdf,markdown,fr,7925afd30ed9e945,"**Interprétation S3.** La dynamique du replicateur Axelrod a un *enjeu* modéré (`I_stake ≈ 0.85`) : après une perturbation initiale des fréquences, le système converge vers l'ESS (stratégies comme `tft`, `pavlov` qui dominent `alld`). Ce n'est pas un enjeu aussi fort que S1 (tri parfait) parce que la dynamique du replicateur est *neutre* sur certaines dimensions (les stratégies qui se ressemblent en fitness coexistent).
+
+**Note pédagogique** : Axelrod est un cas intéressant parce que la convergence est *asymptotique* — le système tend vers l'ESS mais ne s'y fixe pas exactement. C'est une différence importante avec S1 où le point fixe est net.
+",,,,,,,,7925afd30ed9e945,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,ead6c5f208e1,markdown,fr,667f2ee2112eb734,"## 11. Résolution custom step — substrat-jouet pour calibrer l'intuition
+
+Le stub tranche 2 demandait un substrat custom avec `I_stake` extrême. Voici deux exemples pour calibrer :
+
+- **Custom A — ressort+bruit progressif** : un ressort dont la raideur augmente avec le temps (le système ""apprend"" à revenir plus vite). Devrait donner `I_stake ≈ 1`.
+- **Custom B — marche 2D biaisée** : simple dérive constante sans rappel. Devrait donner `I_stake ≈ 0` (pur dissipateur, comme S5).
+
+**Implémentation** : on construit le `step_fn` avec un état mutable capturé en closure (pattern déjà utilisé pour S4 dans la tranche 2).
+",,,,,,,,667f2ee2112eb734,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,5d0797328b05,code,fr,bc7eb388a909cadd,"# Custom step resolu : ressort + bruit progressif
+rng_custom = np.random.default_rng(123)
+custom_state = {""t"": 0}
+def custom_a_step(state, _rng=rng_custom, _s=custom_state):
+    # Ressort dont la raideur augmente avec le temps.
+    _s[""t""] += 1
+    base = float(state[0])
+    r = 0.3 + 0.4 * (_s[""t""] / 200)  # strengthening spring
+    return np.array([base * (1 - r) + _rng.normal(0, 0.05)])
+
+i_stake_custom_a = stake_index(
+    kicked_state=do_kick(np.array([0.0]), 5.0),
+    step_fn=custom_a_step,
+    steps=80, anchor=0.0,
+)
+print(f""Custom A (ressort+bruit) I_stake = {i_stake_custom_a:+.4f}"")
+print(f""  Attendu : ~+1 (force de rappel qui s'amplifie)."")
+
+# Custom B : marche biaisee SANS rappel -- controle negatif
+rng_custom_b = np.random.default_rng(456)
+custom_b_state = {""t"": 0}
+def custom_b_step(state, _rng=rng_custom_b, _s=custom_b_state):
+    # Pure marche aleatoire biaisee, sans force de rappel.
+    _s[""t""] += 1
+    base = float(state[0])
+    return np.array([base + 0.4 + _rng.normal(0, 0.1)])
+
+i_stake_custom_b = stake_index(
+    kicked_state=do_kick(np.array([0.0]), 5.0),
+    step_fn=custom_b_step,
+    steps=80, anchor=0.0,
+)
+print(f""Custom B (marche biaisee) I_stake = {i_stake_custom_b:+.4f}"")
+print(f""  Attendu : ~0 (pas de force de rappel, le substrat dissipe sans defendre de soi)."")
+",,,,,,,,bc7eb388a909cadd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,44f42f19ad87,markdown,fr,b3180bab7b0d8507,"**Calibration empirique**. Les deux custom steps illustrent les extrêmes du spectre :
+- **Custom A** : `I_stake ≈ +1` (enjeu fort — le substrat a un point de consigne défendu activement).
+- **Custom B** : `I_stake ≈ 0` (pur dissipateur — pas d'enjeu, simple dérive biaisée).
+
+Entre les deux : un continuum de substrats hybrides (ex: ressort faible + dérive constante). Le notebook pédagogique invite à explorer ce continuum pour développer l'intuition.
+",,,,,,,,b3180bab7b0d8507,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,7fce2d2e4b6e,markdown,fr,fef95b9f3192d69e,"## 12. Verdict final — réconciliation tranches 2 et 3
+
+### Récapitulatif de l'enjeu mesuré — valeurs de CE notebook
+
+| Substrat | Instrument | Mesure (cellule) | Interprétation |
+|----------|-----------|------------------|----------------|
+| **S1** tri auto-organisé | `stake_index` (scalaire) | **+1.0000** (cell. 9) | Enjeu fort : défend l'attracteur trié |
+| **S3** Axelrod | `stake_index` (scalaire) | **+0.6780** (cell. 11) | Enjeu modéré : ESS asymptotique (fréquences oscillantes) |
+| **S4** Gray-Scott | `repair_gain` (**champ**, cell. 3) | **+0.82 ± 0.27** | Enjeu fort : régénère ~82 % de la zone ablatée |
+| **Custom A** ressort+bruit | `stake_index` (scalaire) | **+0.9940** (cell. 14) | Enjeu fort : force de rappel qui s'amplifie |
+| **Custom B** marche biaisée (≈S5) | `stake_index` (scalaire) | **-1.0000** (cell. 14) | Pur dissipateur (contrôle négatif) |
+
+> Note d'instrument : S4 est un champ 2D ; son enjeu se mesure en **espace de champ** (`repair_gain`), pas via le scalaire `stake_index` (cf. docstring `ict.stake`). La valeur S4 (+0.82) et les valeurs scalaires (S1/S3/Custom) ne sont donc pas la même quantité numérique — mais toutes ont le même **signe attendu** et séparent l'agent du dissipateur.
+
+### Rappel — banc naïf scalaire du notebook principal (`ICT-19-EnjeuBattery.ipynb`)
+
+Pour mémoire, le notebook principal appliquait `stake_index` scalaire à **tous** les substrats continus, y compris S4 (mauvais instrument pour un champ 2D) :
+
+| Substrat | `I_thermo` | `I_stake` scalaire |
+|----------|-----------|--------------------|
+| S2 (bistable May) | +0.0000 | +0.9999 |
+| S4 (Gray-Scott, scalarisé) | +5.6249 | **-0.5083** ← le faux nul corrigé ici |
+| S5 (marche biaisée) | +0.0000 | -0.4651 |
+
+Son Gate ENJEU-1 y échouait (`FAIL`) précisément parce que (a) S4 y était scalarisé et (b) la comparaison S4-vs-S5 n'était même pas appariée en `I_thermo` (`I_thermo(S4)=+5.62` contre `I_thermo(S5)=0`).
+
+### Gates falsifiables — verdict consolidé (espace de champ)
+
+**Gate ENJEU-1** : un substrat à enjeu revient vers son bassin après `do(.)`, un pur dissipateur non.
+- Comparateur correctement apparié en `I_thermo` : la **diffusion pure** (même opérateur de diffusion, terme réactif retiré) dissipe comme Gray-Scott mais ne s'auto-entretient pas.
+- `repair_gain(S4) = +0.82 ± 0.27` contre `repair_gain(diffusion pure) ≈ +0.002`, `time_to_recover` local = 313–489 pas contre jamais pour la diffusion.
+- **Verdict : PASS.** Gray-Scott (dissipe ET régénère) se sépare nettement du témoin passif I_thermo-apparié — la découpe qu'`I_thermo` seul (ICT-18) ne sait pas faire. C'est un gate **plus propre** que le S4-vs-S5 du banc naïf (qui n'appariait pas `I_thermo`).
+
+**Gate ENJEU-2 (graduation)** : les substrats *avec enjeu* battent le pur dissipateur.
+- `S1 (+1.0)`, `Custom A (+0.994)`, `S3 (+0.678)` en scalaire et `S4 (repair_gain +0.82)` en champ sont tous nettement au-dessus de `Custom B / S5 (-1.0)`.
+- **Verdict : PASS pour la séparation famille-à-enjeu / dissipateur.** L'ordre interne strict entre S4 et les substrats scalaires reste **inter-instrument** (S4 en champ, les autres en scalaire) : le comparer numériquement mélangerait deux quantités — c'est une limite d'homogénéité documentée, pas un échec.
+
+### Conclusion méthodologique
+
+La batterie de l'ENJEU discrimine les substrats à enjeu (S1, S3, Custom A, **et S4**) du pur dissipateur (Custom B / S5), **y compris** S4 une fois mesuré avec le bon instrument. La leçon de la tranche 3 : un résultat nul doit d'abord être suspecté d'être un artefact d'instrument ou de câblage avant d'être consacré en *limite physique*. Ici, le bon instrument (`repair_gain` en champ) + le comparateur `I_thermo`-apparié (diffusion pure) + le régime de Pearson transforment un faux échec en signature d'agence nette et honnête.
+",,,,,,,,fef95b9f3192d69e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb,6fe086cc9a49,markdown,fr,d6696e47bc7b3dae,"## 13. Annexe — limites et suites
+
+### Résolu dans cette tranche
+
+1. **Banc S4 (résolu).** Le résultat nul de la tranche 2 (`I_stake(S4) ≈ I_stake(S5)`) était un artefact d'instrument + de câblage, pas une limite physique. Corrections : (a) instrument de **champ** (`agency.repair_gain`) au lieu du scalaire `stake_index` pour le substrat 2D ; (b) appel `recovery_score` corrigé (`ablated` = champ ablaté, pas le champ relaxé) ; (c) régime de Pearson robuste (`F=0.0367, k=0.0649`, `n=64`, warmup 3000). Résultat : `repair_gain = +0.82 ± 0.27`, reconstruction locale en ~313–489 pas.
+2. **`time_to_recover` (résolu).** Sur l'observable **locale** (variance dans le masque), le retour est net et fini (313–489 pas). L'ancien `None` venait de l'usage de la variance globale, insensible à une ablation locale.
+
+### Limites restantes
+
+- **Axelrod asymptotique** : S3 ne se fixe pas exactement sur l'ESS (fréquences oscillantes) ; `I_stake` mesure la tendance centrale.
+- **Notebook squelette (tranche 2)** : le Gate ENJEU-1 y reste exprimé sur `stake_index` scalaire pour la ligne S4 (instrument-mismatch documenté) — la réconciliation vers l'instrument de champ pour cette ligne du gate principal est un incrément de consolidation ultérieur.
+
+### Suites
+
+- **ICT-20** (FeatureCatastrophes) : calibration de la triade MOYEN/FIN/ENJEU sur features d'un backbone pré-entraîné.
+- **ICT-21** (SAETrajectoires, GPU) : features SAE Qwen comme substrat S4-bis.
+- **ICT-23** (Persona Cusp, MERGED) : la fronce de Thom comme désalignement émergent.
+
+### Liens
+
+- **PR #5501** : tranche 2 (squelette notebook + banc naïf).
+- **PR #5495** : librairie `ict.stake` (dépendance).
+- **PR #5499** : cadrage B spec #5483.
+- **Issue #5489** : tracker ICT-19 build.
+- **Issue #4588** : Epic ICT.
+",,,,,,,,d6696e47bc7b3dae,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,9e76e4af,markdown,fr,8e2eb3481ad5ae53,"# ICT-19 — La batterie de l'ENJEU : auto-maintien vs pur dissipateur
+
+[← ICT-18](../ICT-18-TimeArrowAndReversibilization/ICT-18-TimeArrowAndReversibilization.ipynb) · [↑ ICT-Series](../README.md) · [→ ICT-20](../ICT-20-FeatureCatastrophes/ICT-20-FeatureCatastrophes.ipynb) · [Epic #4588](https://github.com/jsboige/CoursIA/issues/4588)
+
+**Strate 5 — théorie fondatrice cross-substrat (GPU-free).**
+
+## Objectifs pédagogiques
+
+À l'issue de ce notebook, vous saurez :
+
+1. **Distinguer** un agent (Gray-Scott S4 : dissipe *et* défend un point de consigne) d'un pur dissipateur (S5 : dissipe *sans* enjeu) sur un banc mesurable — pas un argument de plausibilité.
+2. **Construire** la batterie `I_stake` (retour-au-bassin après `do(·)`) à partir de la librairie `ict.stake` et l'appliquer à 5 substrats hétérogènes.
+3. **Fusionner** `I_stake` (ENJEU) avec `I_thermo` (MOYEN d'ICT-18) pour obtenir la **paire** discriminante, et tester les **gates falsifiables ENJEU-1 et ENJEU-2**.
+
+## Prérequis
+
+- Notebooks ICT-2 (tri auto-organisé, substrat S1), ICT-8 (bistable de May, substrat S2), ICT-9 (réaction-diffusion de Gray-Scott, substrat S4) et ICT-13 (Axelrod, substrat S3).
+- ICT-18 (flèche du temps, `ict.time_arrow`, MOYEN — `I_thermo`).
+- Le présent notebook suppose la librairie `ict.stake` déjà mergée (PR #5495) ; sinon, voir le notebook pour le fallback.
+
+## Durée estimée
+
+45 min (lecture + exécution séquentielle). GPU-free : numpy + matplotlib uniquement.",,,,,,,,8e2eb3481ad5ae53,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,959cedb2,markdown,fr,0f00bc909bc14404,"## 1. Théorie — la triade *moyen / fin / enjeu*
+
+### Pourquoi ICT-18 ne suffit pas
+
+ICT-18 (PR #5355, MERGED) outille le **MOYEN** — `I_thermo`, la flèche du temps thermodynamique (entropie produite, brisure de balance détaillée, distance entre chaîne réelle et sa réversibilisée). Cet instrument est **nécessaire mais pas suffisant** : un *pur dissipateur* (marche aléatoire biaisée, oscillateur pilote externe) allume `I_thermo` au même ordre de grandeur qu'un agent, parce qu'il dissipe — sans pour autant défendre un *soi*.
+
+ICT-18 lui-même le reconnaît (section 2.bis, §8 récap) : la **paire** `(I_thermo, X)` avec un `X` qui isole l'auto-maintien reste à construire. C'est exactement le rôle de l'**ENJEU**.
+
+### L'ENJEU, c'est l'auto-maintien
+
+Un substrat qui a un *enjeu* (un *stake*, au sens téléonomique — Friston ; Mossio & Moreno 2015) **revient activement vers son bassin après une perturbation**. La dynamique libre le ramène : c'est la clôture de contraintes, la résistance à l'équilibration. Sans enjeu, après un kick, le substrat dérive.
+
+Formellement (reframe #5352) :
+
+- **MOYEN** = `I_thermo` (ICT-18, MERGED).
+- **FIN** = compétence cinématique, *competency for free* (ICT-2/3/9, déjà mesuré — pas re-mesuré ici).
+- **ENJEU** = `I_stake` (ICT-19, ce notebook).
+
+### Opérationnalisation : `do(·)` (Pearl) + retour-au-bassin
+
+L'instrument `I_stake` procède par **intervention causale** (`do(x ← x + δ)`) puis observation de la relaxation :
+
+1. Estimer le bassin du substrat à l'état libre (`basin_anchor`).
+2. Kicker l'état hors du bassin (`do_kick`).
+3. Observer la trajectoire de retour (`recovery_curve`).
+4. Mesurer la fraction de distance regagnée, **moins la dérive spontanée** (`stake_index ∈ [-1, 1]`).
+
+`I_stake > 0` ⟹ le substrat défend activement un point de consigne (enjeu). `I_stake ≈ 0` ⟹ le substrat dissipe sans défendre de soi (pur dissipateur). `I_stake < 0` ⟹ instabilité après perturbation.
+
+### Gates falsifiables
+
+- **Gate ENJEU-1** : `I_stake(S4) > I_stake(S5) + marge` avec `I_thermo(S4) ≈ I_thermo(S5)`. La paire discrimine agent vs pur-dissipateur là où ICT-18 seul ne le pouvait pas.
+- **Gate ENJEU-2** : graduation `I_stake(S4) > {S3, S1} > S2 > S5` — l'agent Gray-Scott en tête, le bistable passif au-dessus du pur dissipateur, et les substrats morphogénétiques (S1 tri, S3 Axelrod) entre les deux.
+
+Un gate qui échoue est un **résultat nul honnête** — pas un succès maquillé.",,,,,,,,0f00bc909bc14404,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,c7f51447,markdown,fr,e0e8445db00c928b,"## 2. Imports et configuration
+
+Tous les substrats (S1-S5) sont **réutilisés du banc ICT-18** (pas de nouveau substrat) ; seule la batterie `I_stake` est nouvelle (PR #5495, `ict.stake`). Aucun GPU requis.",,,,,,,,e0e8445db00c928b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,db2c005c,code,fr,af5dc4702cd01500,"import os, sys
+# Notebook est sous MyIA.AI.Notebooks/IIT/ICT-Series/ ; ajouter ce dossier a sys.path
+# pour que import ict fonctionne peu importe le cwd du kernel.
+_NOTEBOOK_DIR = os.path.abspath(""."")
+if _NOTEBOOK_DIR not in sys.path:
+    sys.path.insert(0, _NOTEBOOK_DIR)
+
+import numpy as np
+import matplotlib
+matplotlib.use(""Agg"")  # backend non-interactif (notebook execute sans display)
+import matplotlib.pyplot as plt
+import warnings
+# Filtrer advisory FigureCanvasAgg (figure rendue en output ; warning embarque chemin ipykernel temp).
+warnings.filterwarnings(""ignore"", message="".*FigureCanvasAgg.*"")
+
+from ict import agency, reaction_diffusion, bistable, stake, time_arrow
+from ict.stake import (
+    basin_anchor, do_kick, distance_to_anchor, recovery_curve, stake_index,
+    restoring_step, drift_step, demo_contrast,
+)
+from ict.reaction_diffusion import GrayScott
+from ict.bistable import GrazingModel
+
+np.random.seed(42)
+print(f""Configuration OK : numpy {np.__version__}, ict.stake charge."")
+",,,,,,,,af5dc4702cd01500,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,c6606cdf,markdown,fr,63238514418750f5,"## 3. Démo des primitives — contraste falsifiable
+
+Avant d'attaquer les substrats hétérogènes, illustrons la batterie sur le **contraste minimal** déjà fourni par `ict.stake.demo_contrast` : une chaîne *restauratrice* (ressort amorti) vs une *marche biaisée* (pur dissipateur S5a). Si `I_stake_restoring > I_stake_drift + marge`, la batterie discrimine. Sinon, c'est un résultat nul et il faut re-penser l'instrument.",,,,,,,,63238514418750f5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,2594363f,code,fr,c7a78d86dea967ca,"i_restoring, i_drift = demo_contrast(steps=50, seed=42)
+print(f""demo_contrast (seed=42, steps=50) :"")
+print(f""  I_stake(restauratrice)  = {i_restoring:+.4f}   (agent -- retour attendu)"")
+print(f""  I_stake(marche biaisee) = {i_drift:+.4f}   (pur dissipateur -- pas de retour)"")
+print(f""  Delta I_stake            = {i_restoring - i_drift:+.4f}   (positif = batterie discrimine)"")",,,,,,,,c7a78d86dea967ca,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,f765f21e,markdown,fr,76d6f2a5f511eaa7,"**Interprétation.** Le contraste falsifiable est validé dès le smoke test : la chaîne restauratrice regagne une fraction significative de sa distance au bassin (`I_stake` nettement positif), tandis que la marche biaisée — qui dissipe (entropie non-nulle) mais n'a aucun *soi* à défendre — n'a pas de retour (`I_stake` proche de zéro). La batterie fait ce qu'on lui demande : isoler l'enjeu de la simple dissipation.",,,,,,,,76d6f2a5f511eaa7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,8f5d7b42,code,fr,cd562d2fbc6dc3e5,"# Visualiser la recovery_curve pour les deux substrats.
+rng_r = np.random.default_rng(42)
+rng_d = np.random.default_rng(43)
+anchor = 0.0
+kick = 5.0
+kicked = do_kick(np.array([0.0]), kick)
+
+curve_r = recovery_curve(kicked, lambda s: restoring_step(s, 0.3, rng_r),
+                         steps=50, anchor=anchor)
+curve_d = recovery_curve(kicked, lambda s: drift_step(s, 0.4, rng_d),
+                         steps=50, anchor=anchor)
+
+fig, ax = plt.subplots(figsize=(7, 4))
+ax.plot(curve_r, label=""Restauratrice (agent)"", lw=2, color=""C2"")
+ax.plot(curve_d, label=""Marche biaisee (S5 pur dissipateur)"", lw=2, color=""C3"")
+ax.axhline(0, color=""gray"", lw=0.5, ls=""--"")
+ax.set_xlabel(""Pas apres kick do(.)"")
+ax.set_ylabel(""|x(t) - ancre|"")
+ax.set_title(""Recovery_curve : retour-au-bassin apres kick"")
+ax.legend(loc=""upper right"")
+ax.grid(alpha=0.3)
+plt.tight_layout()
+plt.show()
+print(""Visualisation : la restauratrice descend vite vers 0, le S5 reste eleve / derive."")",,,,,,,,cd562d2fbc6dc3e5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,ee6f7bec,markdown,fr,27b24b8f960ef6b9,"## 4. Application aux substrats S1-S5
+
+`ict.stake` opère sur des **états scalaires** (entiers ou flottants) munis d'une fonction de pas `step_fn`. Pour chaque substrat, on définit :
+
+1. Une **observable 1D** (scalaire qui résume l'état du substrat — taux de tri, variable d'état, taux de coopération, structure du champ).
+2. Une **fonction de pas** qui avance la dynamique libre d'un pas.
+3. Une **procédure d'estimation de l'ancre** (moyenne empirique sur trajectoire libre).
+
+Puis on applique `stake_index` avec un `kick` calibré sur l'amplitude typique du substrat.
+
+**Substrats testés ici** :
+- **S1** tri auto-organisé (proxy : taux de cellules triées).
+- **S2** bistable de May (proxy : variable d'état `x`).
+- **S3** Axelrod (proxy : taux de coopération sur la population).
+- **S4** Gray-Scott (proxy : structure `ict.agency.structure(V)` sur le champ `V`).
+- **S5** pur dissipateur = marche biaisée (proxy direct via `drift_step`).
+
+Pour des raisons pédagogiques (notebook exécutable end-to-end en moins de 5 minutes), on traite ici **S2, S4, S5** avec résultats mesurés ; **S1 et S3** sont laissés en exercice C.1 (stub à compléter) — ils mobilisent des boucles plus lourdes (≥1000 cellules pour S1, ≥10000 matches pour S3) que le runtime notebook ne supporte pas en l'état.",,,,,,,,27b24b8f960ef6b9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,9f65772c,markdown,fr,c4c81c4e322cb3d4,### 4.1 S2 — Bistable de May (proxy : variable d'état `x`),,,,,,,,c4c81c4e322cb3d4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,882faf95,code,fr,9855ce5dd92f261b,"# S2 : GrazingModel -- ODE bistable (May 1977). La variable d etat x a deux
+# regimes stables (vegetalise haut / surpature bas) separes par un equilibre
+# instable. On l initialise dans un regime, on kicke, on mesure le retour
+# via le pas deterministe Euler.
+model = GrazingModel(r=1.0, K=10.0, h=1.0)
+dt_s2 = 0.01
+c_s2 = 1.0  # pression de broutage en regime bistable (c < c_fold ~ 2.0)
+
+def s2_step(x_arr, dt=dt_s2, c=c_s2):
+    x = float(x_arr[0])
+    x_next = max(0.0, x + dt * float(model.rate(x, c)))
+    return np.array([x_next])
+
+# Trajectoire libre : estimer l ancre (relaxation depuis x0=7 vers l attracteur haut)
+x_free = np.array([7.0])
+traj_free = [float(x_free[0])]
+for _ in range(2000):
+    x_free = s2_step(x_free)
+    traj_free.append(float(x_free[0]))
+anchor_s2 = basin_anchor(traj_free[-1000:])  # moyenne sur regime quasi-stationnaire
+print(f""S2 ancre (moyenne libre, fin de trajectoire) = {anchor_s2:.4f}"")
+
+# Kick + relaxation : on ecarte l etat vers l equilibre instable puis on relache
+kicked_s2 = do_kick(np.array([float(traj_free[-1])]), 2.0, lo=0.0, hi=15.0)
+i_stake_s2 = stake_index(
+    kicked_state=kicked_s2,
+    step_fn=lambda s: s2_step(s),
+    steps=2000, anchor=anchor_s2,
+)
+print(f""S2 I_stake = {i_stake_s2:+.4f}   (bistable passif, retour partiel attendu)"")
+",,,,,,,,9855ce5dd92f261b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,5a754d85,markdown,fr,9a42283fa01400be,### 4.2 S4 — Gray-Scott (proxy : structure `ict.agency.structure(V)`),,,,,,,,9a42283fa01400be,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,e9f7023c,code,fr,b0335480e9302b5e,"# S4 : Gray-Scott reaction-diffusion. Observable 1D = structure(V) (variance
+# du champ V, invariante d echelle). On prend un petit champ (32x32) pour
+# rester rapide au runtime notebook. NB : GrayScott est stateless -- seed()
+# retourne (U, V) et step(U, V) renvoie (U_new, V_new).
+gs_sim = GrayScott(F=0.04, k=0.06, dt=1.0)
+U, V = gs_sim.seed(n=32, block=4, noise=0.05, rng=np.random.default_rng(123))
+
+# Trajectoire libre : estimer l ancre sur structure(V) apres plusieurs pas
+traj_s4_free = []
+for _ in range(20):
+    traj_s4_free.append(float(agency.structure(V)))
+    U, V = gs_sim.step(U, V)
+anchor_s4 = basin_anchor(traj_s4_free)
+print(f""S4 ancre (moyenne structure(V) libre) = {anchor_s4:.6f}"")
+
+# Kick + relaxation : on ablate partiellement le champ puis on relache
+gs_ablate = GrayScott(F=0.04, k=0.06, dt=1.0)
+Uk, Vk = gs_ablate.seed(n=32, block=4, noise=0.05, rng=np.random.default_rng(123))
+Uk, Vk = gs_ablate.step(Uk, Vk)
+mask = agency.disk_mask(32, cx=16, cy=16, radius=8)
+Uk, Vk = agency.ablate(Uk, Vk, mask)  # ablate(U, V, mask) -> (U_new, V_new)
+structure_kicked = agency.structure(Vk)
+
+def s4_step_after_ablate(state, _state=[Uk, Vk], gs=gs_ablate, n_steps=2):
+    Ucur, Vcur = _state[0], _state[1]
+    for _ in range(n_steps):
+        Ucur, Vcur = gs.step(Ucur, Vcur)
+    _state[0], _state[1] = Ucur, Vcur
+    return np.array([agency.structure(Vcur)])
+
+i_stake_s4 = stake_index(
+    kicked_state=np.array([structure_kicked]),
+    step_fn=s4_step_after_ablate,
+    steps=10, anchor=anchor_s4,
+)
+print(f""S4 I_stake (apres ablation) = {i_stake_s4:+.4f}   (agent Gray-Scott, retour attendu)"")
+",,,,,,,,b0335480e9302b5e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,6aeddfe1,markdown,fr,4f6c51d364496f47,### 4.3 S5 — Pur dissipateur (proxy direct : `drift_step`),,,,,,,,4f6c51d364496f47,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,19ebc389,code,fr,c14e1e04a4350ec0,"# S5 : marche aleatoire biaisee (drift_step). Substrat temoin du controle
+# negatif : dissipe (I_thermo > 0) MAIS n'a pas d'enjeu (I_stake ~= 0).
+rng_s5 = np.random.default_rng(2026)
+traj_s5_free = [0.0]
+s = np.array([0.0])
+for _ in range(60):
+    s = drift_step(s, bias=0.4, rng=rng_s5)
+    traj_s5_free.append(float(s[0]))
+anchor_s5 = basin_anchor(traj_s5_free)
+print(f""S5 ancre (drift_step libre) = {anchor_s5:.4f}"")
+
+rng_s5_kick = np.random.default_rng(2027)
+kicked_s5 = do_kick(np.array([0.0]), 3.0)
+i_stake_s5 = stake_index(
+    kicked_state=kicked_s5,
+    step_fn=lambda s: drift_step(s, bias=0.4, rng=rng_s5_kick),
+    steps=60, anchor=anchor_s5,
+)
+print(f""S5 I_stake = {i_stake_s5:+.4f}   (pur dissipateur, I_stake proche de 0 attendu)"")",,,,,,,,c14e1e04a4350ec0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,c193799d,markdown,fr,5c5cfbd8467719ee,"## 5. Paire `(I_thermo, I_stake)` et gates falsifiables
+
+Récapitulons les mesures `I_stake` sur les substrats testés et combinons avec `I_thermo` (MOYEN d'ICT-18). Pour `I_thermo` sur les substrats à dynamique continue (S2, S4, S5), on construit une chaîne de Markov sur les états encodés et on appelle `time_arrow.entropy_production`.",,,,,,,,5c5cfbd8467719ee,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,3d1912ae,code,fr,c3a032caad51f965,"# Estimation rapide de I_thermo (entropy_production) sur chaque substrat.
+# On encode les trajectoires en symboles discrets puis on calcule la production
+# d'entropie via ict.time_arrow. C'est le MOYEN d'ICT-18 -- voir le notebook
+# ICT-18 pour les details.
+def quick_thermo(traj, n_symbols=8):
+    """"""Production d'entropie (entropy_production) sur une trajectoire 1D.""""""
+    arr = np.asarray(traj, dtype=float)
+    if arr.size < 20:
+        return 0.0
+    # Quantifier en n_symbols categories
+    lo, hi = float(arr.min()), float(arr.max())
+    if hi - lo < 1e-12:
+        return 0.0
+    edges = np.linspace(lo, hi, n_symbols + 1)
+    syms = np.digitize(arr, edges) - 1
+    syms = np.clip(syms, 0, n_symbols - 1)
+    P = time_arrow.transition_matrix(syms, n_symbols=n_symbols)
+    pi = time_arrow.stationary_distribution(P)
+    if pi is None:
+        return 0.0
+    return float(time_arrow.entropy_production(P, pi))
+
+i_thermo_s2 = quick_thermo(traj_free)
+i_thermo_s4 = quick_thermo(traj_s4_free)
+i_thermo_s5 = quick_thermo(traj_s5_free)
+
+print(f""Paire (I_thermo, I_stake) sur substrats continus :"")
+print(f""  S2 (bistable May)         : I_thermo = {i_thermo_s2:+.4f}   I_stake = {i_stake_s2:+.4f}"")
+print(f""  S4 (Gray-Scott, agent)   : I_thermo = {i_thermo_s4:+.4f}   I_stake = {i_stake_s4:+.4f}"")
+print(f""  S5 (marche biaisee, S5)  : I_thermo = {i_thermo_s5:+.4f}   I_stake = {i_stake_s5:+.4f}"")",,,,,,,,c3a032caad51f965,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,9b84b6bf,markdown,fr,df998334893cdfe0,"### 5.1 Gates falsifiables — verdict
+
+**Gate ENJEU-1** : `I_stake(S4) > I_stake(S5) + marge` *avec* `I_thermo(S4) ≈ I_thermo(S5)`.
+→ La paire discrimine l'agent du pur dissipateur ; ICT-18 seul (`I_thermo`) ne le pouvait pas.
+
+**Gate ENJEU-2 (partiel)** : `I_stake(S4) > S2 > S5` (S1 et S3 sont en exercice C.1 — voir section 6).
+→ La graduation place l'agent Gray-Scott en tête, le bistable au-dessus du pur dissipateur.
+
+**Honnêteté du verdict** : si une gate échoue sur ce banc, on **rapporte l'échec** — pas un succès maquillé. Un résultat nul honnête est plus utile qu'une validation cosmétique.",,,,,,,,df998334893cdfe0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,89511033,code,fr,d36affc6c52d17a0,"gate_enjeu_1 = (i_stake_s4 > i_stake_s5) and (abs(i_thermo_s4 - i_thermo_s5) < 0.5 * max(i_thermo_s4, i_thermo_s5, 1e-6))
+gate_enjeu_2_partial = i_stake_s4 > i_stake_s2 > i_stake_s5
+
+print(""="" * 60)
+print(""Verdict gates falsifiables ICT-19"")
+print(""="" * 60)
+print(f""Gate ENJEU-1 (I_stake(S4) > I_stake(S5) + I_thermo similaires) : {'OK' if gate_enjeu_1 else 'FAIL'}"")
+print(f""  - I_stake(S4) = {i_stake_s4:+.4f}, I_stake(S5) = {i_stake_s5:+.4f}, delta = {i_stake_s4 - i_stake_s5:+.4f}"")
+print(f""  - I_thermo(S4) = {i_thermo_s4:+.4f}, I_thermo(S5) = {i_thermo_s5:+.4f}, delta = {i_thermo_s4 - i_thermo_s5:+.4f}"")
+print(f""Gate ENJEU-2 partiel (I_stake(S4) > S2 > S5) : {'OK' if gate_enjeu_2_partial else 'FAIL'}"")
+print(f""  - Graduation observee : S4 = {i_stake_s4:+.4f}, S2 = {i_stake_s2:+.4f}, S5 = {i_stake_s5:+.4f}"")
+print(f""  - S1 et S3 en exercice C.1 (stubs section 6)."")
+print(""="" * 60)",,,,,,,,d36affc6c52d17a0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,a6231031,markdown,fr,4804179307667960,"## 6. Exercices C.1 (3 stubs)
+
+**Exercice 1 — S1 tri auto-organisé.** Implémenter l'observable 1D du substrat S1 (par exemple : taux de cellules triées à la fin de l'array, ou taux d'adjacence correcte). Définir `s1_step(state)` qui avance la simulation `SelfSortingArray` d'un pas, et estimer `I_stake(S1)` sur une trajectoire kickée. Stub à compléter :",,,,,,,,4804179307667960,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,bb01ff62,code,fr,4b442251aa227a38,"def s1_step(state):
+    """"""TODO etudiant : observable 1D de SelfSortingArray d'un pas.
+
+    Indice : `state` est un np.array([sorted_fraction]) (taux de cellules
+    triees dans [0, 1]). Avancer la simulation SelfSortingArray d'un pas
+    (ou N pas pour stabiliser) puis renvoyer le nouveau taux.
+
+    Indice 2 : voir ict.self_sorting.SelfSortingArray (run N pas avec self.sorting_array) ; l observable peut etre le taux de cellules triees (np.mean(sorted_array == positions_attendues)).
+    pour les observables disponibles.
+    """"""
+    pass  # TODO etudiant : remplacer par votre implementation
+
+# i_stake_s1 = stake_index(
+#     kicked_state=do_kick(np.array([0.5]), 0.3, lo=0.0, hi=1.0),
+#     step_fn=s1_step,
+#     steps=100, anchor=0.95,  # ancre typique : tri complet
+# )
+# print(f""S1 I_stake = {i_stake_s1:+.4f}"")
+print(""Exercice a completer -- TODO etudiant"")",,,,,,,,4b442251aa227a38,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,2d47cbbd,markdown,fr,77619e2698509068,"**Exercice 2 — S3 Axelrod.** Implémenter l'observable 1D du substrat S3 (par exemple : taux de coopération sur la population Axelrod). Définir `s3_step(state)` qui avance la dynamique d'un round de tournoi entre stratégies, et estimer `I_stake(S3)`. Stub à compléter :",,,,,,,,77619e2698509068,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,6ff01202,code,fr,ee3a15a7f99abab3,"def s3_step(state):
+    """"""TODO etudiant : observable 1D de la dynamique Axelrod d'un pas.
+
+    Indice : `state` est un np.array([coop_rate]) (taux de cooperation sur
+    la population en [0, 1]). Avancer d'un round (play_match entre strategies
+    de ict.strategic_morphodynamics) puis mettre a jour le taux de coop.
+
+    Indice 2 : voir ict.strategic_morphodynamics.make_strategies et play_match
+    pour les primitives du tournoi.
+    """"""
+    pass  # TODO etudiant : remplacer par votre implementation
+
+# i_stake_s3 = stake_index(
+#     kicked_state=do_kick(np.array([0.5]), 0.3, lo=0.0, hi=1.0),
+#     step_fn=s3_step,
+#     steps=200, anchor=0.7,  # ancre typique : equilibre coop
+# )
+# print(f""S3 I_stake = {i_stake_s3:+.4f}"")
+print(""Exercice a completer -- TODO etudiant"")",,,,,,,,ee3a15a7f99abab3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,08dce940,markdown,fr,8f9dea3703814292,"**Exercice 3 — extension de substrat.** Proposer un substrat *custom* qui selon vous aurait un `I_stake` extrême (très proche de 1 ou très proche de 0). Définir son observable 1D, son `step_fn`, et vérifier empiriquement le résultat. Le notebook doit aider à calibrer l'intuition sur ce qui *fait* un enjeu.",,,,,,,,8f9dea3703814292,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,4da5f87b,code,fr,6018e6279482f146,"def custom_step(state):
+    """"""TODO etudiant : un pas de votre substrat custom (un scalaire -> scalaire).
+
+    Contraintes :
+    - np.random.Generator acceptable pour le bruit
+    - retourner np.array([scalaire]) dans le meme range que `state`
+    - pas d'effet de bord (renvoyer un nouveau np.array)
+
+    Indice : pour I_stake ~= 1, prendre un ressort tres fort (strength ~ 0.9).
+    Pour I_stake ~= 0, prendre une marche biaisee avec un tres gros bias.
+    """"""
+    pass  # TODO etudiant : remplacer par votre implementation
+
+# i_stake_custom = stake_index(
+#     kicked_state=do_kick(np.array([0.0]), 5.0),
+#     step_fn=custom_step,
+#     steps=50, anchor=0.0,
+# )
+# print(f""Substrat custom I_stake = {i_stake_custom:+.4f}"")
+print(""Exercice a completer -- TODO etudiant"")",,,,,,,,6018e6279482f146,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb,f98614d9,markdown,fr,fca27c46bc0f66be,"## 7. Conclusion
+
+ICT-19 complète la triade *moyen / fin / enjeu* ouverte par le reframe #5352 :
+
+- **MOYEN** (ICT-18, MERGED) : `I_thermo`, la flèche du temps — mesure la dissipation.
+- **FIN** (ICT-2/3/9, déjà mesurés) : la compétence cinématique, *competency for free*.
+- **ENJEU** (ICT-19, ce notebook) : `I_stake`, l'auto-maintien — mesure la défense d'un soi.
+
+La **paire** `(I_thermo, I_stake)` sépare enfin l'agent (Gray-Scott S4) du pur dissipateur (S5) là où ICT-18 seul échouait. Les gates falsifiables ENJEU-1 et ENJEU-2 donnent un verdict mesurable plutôt qu'une déclaration d'agence.
+
+**Limites honnêtes** :
+
+- L'ancre `basin_anchor` est la moyenne empirique — pour un substrat multimodal, c'est le barycentre des modes (peut sous-estimer l'enjeu réel).
+- Le banc testé ici (S2, S4, S5) est partiel — S1 et S3 sont en exercices C.1.
+- La gate ENJEU-2 complète (avec S1, S3) reste à valider une fois les exercices implémentés.
+
+**Suites naturelles** :
+
+- ICT-20 (FeatureCatastrophes) : calibration, changepoints, EWS et hystérésis en feature-space.
+- ICT-21 (SAETrajectoires, GPU) : features SAE Qwen comme substrat S4-bis.
+- ICT-23 (Persona Cusp, MERGED) : la fronce de Thom comme désalignement émergent, où la triade MOYEN/FIN/ENJEU se déploye sur l'agentivité LLM.
+
+Voir l'[Epic #4588](https://github.com/jsboige/CoursIA/issues/4588) pour la roadmap complète.",,,,,,,,fca27c46bc0f66be,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,9f2b4e43,markdown,fr,3c73a89265e83776,"# ICT-2 — Le tri comme morphogenèse minimale (self-sorting arrays)
+
+> Série **ICT — Integrated Causal Trajectories** (Epic #4588), qui prolonge la série **IIT / PyPhi**.
+
+## D'IIT à ICT : de l'état à la trajectoire
+
+La série IIT étudie des **structures causales associées à un état** : matrice de transition (TPM), sous-système, Φ, structure cause-effet. La série ICT déplace le regard vers les **trajectoires** :
+
+$$C_0 \rightarrow C_1 \rightarrow C_2 \rightarrow \dots \rightarrow C_n$$
+
+où chaque $C_t$ résume l'organisation causale du système à l'instant $t$. Les questions deviennent dynamiques : une organisation se **maintient**-elle ? se **répare**-t-elle ? change-t-elle d'**échelle** ? garde-t-elle une **identité** malgré les perturbations ?
+
+Pour entrer dans ce cadre sans la lourdeur calculatoire de PyPhi, ce notebook utilise un **toy model totalement transparent** : le **tri auto-organisé**.
+
+## Le tri vu comme une morphogenèse
+
+D'après :
+
+> Taining Zhang, Adam Goldstein, Michael Levin, *« Classical sorting algorithms as a model of morphogenesis: self-sorting arrays reveal unexpected competencies in a minimal model of basal intelligence »*, **Adaptive Behavior**, 2025 — [arXiv:2401.05375](https://arxiv.org/abs/2401.05375).
+
+L'idée renverse la perspective habituelle du tri. Au lieu d'un **contrôleur global** qui parcourt un tableau et échange des éléments, **chaque élément devient une cellule autonome** qui applique localement la règle de son *algotype*. L'ordre global n'est plus imposé d'en haut : il **émerge** de décisions purement locales. Le tri devient une **trajectoire collective** dans un espace de configurations — une morphogenèse minimale.
+
+Sur ce banc d'essai, tout est calculable et enregistrable, et pourtant des compétences inattendues apparaissent : robustesse aux cellules cassées, sacrifices locaux au service du but global (« délai de gratification »), auto-réparation après lésion. C'est exactement le type de signatures que la série ICT cherche à rendre mesurable.
+
+## Objectifs d'apprentissage
+
+- Comprendre la **vue-cellule** (cell-eye-view) d'un algorithme de tri.
+- Enregistrer et visualiser une **trajectoire** dans le morphospace (sortedness, inversions, erreur de monotonie).
+- Mesurer trois compétences émergentes : **robustesse**, **délai de gratification**, **auto-réparation**.
+- Observer comment l'**hétérogénéité** (tableaux chimériques) crée des impasses locales.
+
+### Prérequis
+- Notions de base sur les algorithmes de tri (bubble / insertion).
+- Python : `numpy`, `matplotlib` (les structures du modèle sont dans le package local `ict/`).
+
+### Durée estimée : 45 minutes
+",,,,,,,,3c73a89265e83776,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,cccddcc6,code,fr,8a29e4951e069ae1,"# --- Imports et configuration ---
+import sys, os
+sys.path.insert(0, os.path.abspath("".""))  # le package `ict/` est a cote de ce notebook
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from ict.self_sorting import SelfSortingArray, ALGOTYPES
+from ict import sorting_metrics as m
+
+plt.rcParams[""figure.figsize""] = (8, 4)
+plt.rcParams[""axes.grid""] = True
+RNG = np.random.default_rng(42)
+
+def perm(k, rng=RNG):
+    # une permutation de 0..k-1 en entiers Python natifs (sortie lisible)
+    return [int(x) for x in rng.permutation(k)]
+
+print(""Algotypes disponibles :"", ALGOTYPES)",,,,,,,,8a29e4951e069ae1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,cdcdfdca,markdown,fr,46b5a5f25a8f8f2b,"## 1. La vue-cellule : une cellule, une règle locale
+
+Chaque cellule porte une **valeur** (la clé de tri) et un **algotype** (sa règle locale) :
+
+- **`bubble`** : la cellule regarde sa voisine de **droite** ; si elle est plus grande, elle glisse à droite (les grandes valeurs migrent vers la fin).
+- **`insertion`** : la cellule regarde sa voisine de **gauche** ; si elle est plus petite, elle glisse à gauche (les petites valeurs migrent vers le début).
+
+Un **planificateur asynchrone seedable** active une cellule au hasard à chaque pas. Il n'y a **aucun contrôleur global** : seulement des cellules qui réagissent à leur voisinage immédiat. Vérifions qu'un tableau homogène se trie de lui-même.",,,,,,,,46b5a5f25a8f8f2b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,1148d246,code,fr,850adf0b2cf295e3,"# --- Exemple guide : un tableau homogene (bubble) se trie tout seul ---
+valeurs = perm(16)
+arr = SelfSortingArray(valeurs, seed=7)   # tous les algotypes = ""bubble"" par defaut
+print(""Etat initial :"", arr.values)
+arr.run()
+print(""Etat final   :"", arr.values)
+print(f""Trie ? {arr.values == sorted(valeurs)} | pas={arr.steps} | swaps={arr.probe.swaps}"")",,,,,,,,850adf0b2cf295e3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,8cb60e2c,markdown,fr,d16a9f90d7145502,"**Interprétation.** Sans aucune coordination centrale, l'activation aléatoire répétée de cellules qui ne connaissent que leur voisin suffit à atteindre l'ordre global. Chaque échange local **corrige exactement une inversion** : le système ne crée jamais de désordre net, il en élimine. C'est la forme la plus dépouillée d'une morphogenèse — une cible globale atteinte par des règles locales aveugles.",,,,,,,,d16a9f90d7145502,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,e04817e7,markdown,fr,589ff9ed29be2baa,"## 2. La trajectoire dans le morphospace
+
+On enregistre, pas à pas, trois mesures :
+
+- **inversions** : nombre de paires dans le mauvais ordre (mesure **globale** du désordre) ;
+- **sortedness** $\in [0,1]$ : $1 - \text{inversions} / \binom{n}{2}$ (1 = trié) ;
+- **erreur de monotonie** : fraction de paires *adjacentes* en descente (mesure **locale**).
+
+La trajectoire est le voyage du système dans cet espace.",,,,,,,,589ff9ed29be2baa,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,a5520f32,code,fr,3a66b71e5f84deca,"# --- Exemple guide : trajectoire d'un tri ---
+arr = SelfSortingArray(perm(16), seed=11)
+arr.run()
+inv = m.inversions_curve(arr.probe.values)
+srt = m.sortedness_curve(arr.probe.values)
+mono = m.monotonicity_curve(arr.probe.values)
+
+fig, ax = plt.subplots(1, 2, figsize=(12, 4))
+ax[0].plot(inv, color=""crimson""); ax[0].set_title(""Inversions (desordre global)"")
+ax[0].set_xlabel(""pas""); ax[0].set_ylabel(""inversions"")
+ax[1].plot(srt, label=""sortedness"", color=""seagreen"")
+ax[1].plot(mono, label=""erreur de monotonie (locale)"", color=""darkorange"", alpha=0.8)
+ax[1].set_title(""Sortedness vs erreur de monotonie""); ax[1].set_xlabel(""pas""); ax[1].legend()
+plt.tight_layout(); plt.show()
+
+dg = m.delayed_gratification_events(mono)
+inc_inv = sum(1 for a, b in zip(inv, inv[1:]) if b > a)
+print(f""Inversions : {inv[0]} -> {inv[-1]} | pas ou les inversions AUGMENTENT : {inc_inv}"")
+print(f""Erreur de monotonie : episodes ou elle AUGMENTE (delai de gratification) : {dg}"")",,,,,,,,3a66b71e5f84deca,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,2520cc55,markdown,fr,a05dc8a9ebb8c3cf,"**Interprétation — le délai de gratification.** Les **inversions** ne remontent jamais (`0` augmentation) : globalement, le système ne recule pas. Mais l'**erreur de monotonie locale**, elle, **augmente transitoirement** à de nombreux pas. Autrement dit, pour faire progresser l'ordre global, le système accepte de **dégrader localement** sa structure — un échange qui résout une inversion peut créer une nouvelle descente chez les voisins. C'est la version structurelle du **délai de gratification** décrit par Zhang, Goldstein & Levin : un système d'agents locaux « accepte d'aller moins bien avant d'aller mieux », sans qu'aucune cellule ne planifie ce sacrifice.",,,,,,,,a05dc8a9ebb8c3cf,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,85e5165f,markdown,fr,cc3d2277f07a13c5,"## 3. Robustesse : des cellules défectueuses (frozen)
+
+Une cellule **`frozen`** est *cassée* : elle n'initie jamais d'action. Deux régimes :
+
+- **`passive`** (défaut, fidèle au papier) : elle reste un **passager**, qu'une voisine saine peut déplacer ;
+- **`obstacle`** : elle est en plus **infranchissable** (un mur).
+
+Question : jusqu'où le système tolère-t-il des cellules cassées ? Balayons la fraction de cellules gelées et mesurons la sortedness finale (moyenne sur plusieurs graines).",,,,,,,,cc3d2277f07a13c5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,184a9945,code,fr,e45856c592c6b084,"# --- Exemple guide : robustesse passive vs obstacle ---
+fracs = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
+n = 20
+def sweep(mode):
+    out = []
+    for frac in fracs:
+        accs = []
+        for s in range(15):
+            r = np.random.default_rng(100 + s)
+            v = [int(x) for x in r.permutation(n)]
+            k = int(round(frac * n))
+            fz = [True] * k + [False] * (n - k); r.shuffle(fz)
+            a = SelfSortingArray(v, frozen=list(fz), seed=s, frozen_mode=mode).run(record=False)
+            accs.append(m.sortedness(a.values))
+        out.append(np.mean(accs))
+    return out
+
+passive, obstacle = sweep(""passive""), sweep(""obstacle"")
+plt.plot([f*100 for f in fracs], passive, ""o-"", label=""passive (passager)"", color=""seagreen"")
+plt.plot([f*100 for f in fracs], obstacle, ""s--"", label=""obstacle (mur)"", color=""crimson"")
+plt.xlabel(""% de cellules defectueuses""); plt.ylabel(""sortedness finale (moyenne)"")
+plt.title(""Robustesse aux cellules cassees""); plt.legend(); plt.ylim(0.4, 1.02); plt.show()
+for f, p, o in zip(fracs, passive, obstacle):
+    print(f""  {int(f*100):2d}% gelees -> passive={p:.3f} | obstacle={o:.3f}"")",,,,,,,,e45856c592c6b084,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,bc81151f,markdown,fr,4643a31dc213eec8,"**Interprétation.** La dégradation est **progressive**, pas catastrophique : c'est la robustesse émergente. Et le **régime passif domine partout** le régime obstacle. La raison est instructive : une cellule cassée mais *transportable* est portée à sa place par ses voisines saines (l'information de tri circule *à travers* elle), alors qu'un mur fige une frontière que personne ne peut franchir. La compétence collective ne tient donc pas seulement aux règles des cellules, mais à ce que le **milieu** autorise comme mouvements — un point central pour la suite ICT (le rôle des contraintes d'échelle).",,,,,,,,4643a31dc213eec8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,bd6b1003,markdown,fr,08244028693799ca,"## 4. Auto-réparation : régénération après lésion
+
+La morphogenèse biologique se distingue par la **régénération**. Testons-la : on laisse le tableau atteindre l'ordre, on inflige une **lésion** (quelques échanges aléatoires exogènes), puis on laisse le système se réorganiser. Combien de pas pour récupérer ?",,,,,,,,08244028693799ca,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,51eacc17,code,fr,94a93562d9ca2c36,"# --- Exemple guide : perturbation puis recuperation ---
+arr = SelfSortingArray(perm(20), seed=3)
+arr.run()
+p_step = len(arr.probe.values) - 1     # instant juste avant la lesion
+arr.perturb(n_swaps=4)                  # lesion exogene
+arr.run()                               # le systeme se reorganise
+
+srt = m.sortedness_curve(arr.probe.values)
+rt = m.recovery_time(srt, perturbation_step=p_step + 1)
+plt.plot(srt, color=""seagreen"")
+plt.axvline(p_step + 1, color=""crimson"", ls=""--"", label=""lesion"")
+plt.xlabel(""pas""); plt.ylabel(""sortedness""); plt.title(""Auto-reparation apres lesion"")
+plt.legend(); plt.show()
+print(f""sortedness avant lesion = {srt[p_step]:.3f}, juste apres = {srt[p_step+1]:.3f}"")
+print(f""temps de recuperation = {rt} pas | etat final trie ? {arr.values == sorted(arr.values)}"")",,,,,,,,94a93562d9ca2c36,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,5113805c,markdown,fr,5d3ab43d36303a52,"**Interprétation.** Le système ne « sait » pas qu'il a été lésé — il n'a ni mémoire de l'état-cible, ni détecteur d'erreur global. Pourtant la même dynamique locale qui avait construit l'ordre le **reconstruit** après la perturbation, jusqu'au retour à l'état trié. C'est la marque d'un **attracteur** : l'ordre n'est pas un point de départ privilégié, c'est l'état vers lequel converge toute trajectoire. La régénération est gratuite — elle découle des mêmes règles que la morphogenèse initiale.",,,,,,,,5d3ab43d36303a52,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,43c1a4e9,markdown,fr,0428c12eaf11cb10,"## 5. Hétérogénéité : tableaux chimériques et impasses locales
+
+Un tableau **chimérique** mélange les algotypes. Comme `bubble` (pousse à droite) et `insertion` (tire à gauche) servent le même ordre croissant, on pourrait croire qu'un tel tableau se trie aussi. Observons ce qui se passe réellement.",,,,,,,,0428c12eaf11cb10,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,0b118ee3,code,fr,25ef16fc6a549729,"# --- Exemple guide : un tableau chimerique alterne ---
+n = 20
+v = perm(n)
+algos = [ALGOTYPES[i % 2] for i in range(n)]   # bubble, insertion, bubble, ...
+arr = SelfSortingArray(v, algotypes=algos, seed=5)
+arr.run()
+print(""Trie ?"", arr.values == sorted(v), ""| sortedness finale ="", round(m.sortedness(arr.values), 3))
+
+# une frontiere ""insertion | bubble"" inversee est un point fixe local :
+# la cellule de gauche ne regarde qu'a gauche, celle de droite qu'a droite,
+# aucune ne peut corriger l'inversion qui les separe.
+deadlocks = sum(
+    1 for i in range(len(arr.cells) - 1)
+    if arr.cells[i].algotype == ""insertion"" and arr.cells[i+1].algotype == ""bubble""
+    and arr.cells[i].value > arr.cells[i+1].value
+)
+agg = m.aggregation_curve(arr.probe.algotypes)
+print(f""Impasses locales residuelles (insertion|bubble inversees) : {deadlocks}"")
+print(f""Indice d'agregation des algotypes : initial={agg[0]:.2f}, max={max(agg):.2f}, final={agg[-1]:.2f}"")",,,,,,,,25ef16fc6a549729,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,30400e86,markdown,fr,4b912f7c4a6485d7,"**Interprétation — quand l'autonomie locale se piège elle-même.** Le tableau chimérique **ne se trie pas toujours complètement**. Une frontière `insertion | bubble` en désordre forme un **point fixe local** : la cellule de gauche ne regarde qu'à gauche, celle de droite qu'à droite — l'inversion qui les sépare n'est dans le champ de vision de personne. L'hétérogénéité, qui pourrait sembler enrichir le système, introduit ici des **échecs de coordination** qu'aucune cellule homogène ne rencontre.
+
+> **Note d'honnêteté.** Le papier de Zhang, Goldstein & Levin rapporte une compétence *positive* supplémentaire — les cellules tendent à **s'agréger avec leurs semblables** (« kin ») pendant le voyage, sans que cela soit encodé nulle part. Notre modèle minimal à règles uni-directionnelles ne reproduit pas fidèlement cette agrégation (l'indice ci-dessus reste faible) ; il révèle plutôt la pathologie duale, l'impasse. L'agrégation chimérique sera étudiée avec un jeu de règles plus riche dans **ICT-4**. Mesurer ce que le modèle fait *vraiment*, plutôt que ce qu'on espérait, est précisément la discipline de la série ICT.",,,,,,,,4b912f7c4a6485d7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,b36d275b,markdown,fr,9d670ff52d9445d6,"## 6. Exercices
+
+Trois exercices pour manipuler le modèle. Les squelettes sont à compléter ; le notebook s'exécute de bout en bout même sans les remplir.",,,,,,,,9d670ff52d9445d6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,9e43dde8,markdown,fr,4aa18103c6bd4d39,"### Exercice 1 — Bubble est-il plus rapide qu'insertion ?
+
+**Objectif.** Comparer le **coût** (nombre de swaps) pour trier le *même* tableau initial avec un tableau 100 % `bubble` puis 100 % `insertion`, moyenné sur plusieurs graines.
+
+**Indices.**
+- `# Etape 1` : fixer un tableau initial `v` (par ex. `list(np.random.default_rng(0).permutation(30))`).
+- `# Etape 2` : pour `seed` dans `range(20)`, construire `SelfSortingArray(v, algotypes=[t]*len(v), seed=seed)`, `.run()`, relever `arr.probe.swaps`.
+- `# Etape 3` : comparer les moyennes des deux algotypes.",,,,,,,,4aa18103c6bd4d39,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,73f27366,code,fr,a7daed9a7aafadd5,"# Exercice 1 : cout comparatif bubble vs insertion
+def cout_moyen(algotype, v, n_seeds=20):
+    # TODO etudiant : moyenne du nombre de swaps sur n_seeds graines
+    # Indice : arr = SelfSortingArray(v, algotypes=[algotype]*len(v), seed=s).run()
+    result = None  # TODO etudiant
+    return result
+
+# v = list(np.random.default_rng(0).permutation(30))
+# print(""bubble   :"", cout_moyen(""bubble"", v))
+# print(""insertion:"", cout_moyen(""insertion"", v))",,,,,,,,a7daed9a7aafadd5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,94ebb093,markdown,fr,88ff42de7382de76,"### Exercice 2 — Variabilité de l'auto-réparation
+
+**Objectif.** Après une lésion identique (`perturb(n_swaps=5)`), le temps de récupération dépend du hasard d'activation. Estimer sa **moyenne** et son **écart-type** sur 15 graines.
+
+**Indices.**
+- `# Etape 1` : pour chaque graine, trier, mémoriser `p_step`, perturber, re-trier.
+- `# Etape 2` : `rt = m.recovery_time(m.sortedness_curve(arr.probe.values), p_step + 1)`.
+- `# Etape 3` : ignorer les `None` (jamais récupéré), puis `np.mean` / `np.std`.",,,,,,,,88ff42de7382de76,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,a98030a2,code,fr,8636852da12e2b6f,"# Exercice 2 : distribution du temps de recuperation
+def temps_recuperation(n_seeds=15):
+    temps = []
+    # TODO etudiant : remplir `temps` avec les recovery_time non-None
+    pass
+    return temps
+
+# rts = temps_recuperation()
+# print(""recovery_time : moyenne / ecart-type"") ",,,,,,,,8636852da12e2b6f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,96364319,markdown,fr,51c361b58dc5ae18,"### Exercice 3 — Guérir l'impasse chimérique
+
+**Objectif.** Concevoir une règle locale qui **évite les impasses** de la section 5 tout en gardant des algotypes distincts.
+
+**Piste.** Une cellule qui, lorsqu'elle est bloquée, jette aussi un coup d'œil à son **autre** voisin briserait la frontière `insertion | bubble`. Décrire (en commentaire) la règle, puis tester l'idée en assignant les algotypes autrement (par ex. par **blocs** plutôt qu'en alternance) et mesurer la sortedness finale.
+
+**Indices.**
+- `# Etape 1` : construire `algos` par blocs : `[""bubble""]*10 + [""insertion""]*10`.
+- `# Etape 2` : comparer la sortedness finale à celle du tableau alterné de la section 5.
+- `# Etape 3` : conclure sur le rôle de l'**agencement** des algotypes.",,,,,,,,51c361b58dc5ae18,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,38932ad7,code,fr,e7860e8142df0fc1,"# Exercice 3 : agencement des algotypes et impasses
+def sortedness_finale(algos, seed=5):
+    v = list(np.random.default_rng(1).permutation(len(algos)))
+    # TODO etudiant : construire l'array chimerique, le faire tourner, renvoyer m.sortedness(...)
+    result = None  # TODO etudiant
+    return result
+
+# print(""alterne :"", sortedness_finale([ALGOTYPES[i % 2] for i in range(20)]))
+# print(""blocs   :"", sortedness_finale([""bubble""]*10 + [""insertion""]*10))",,,,,,,,e7860e8142df0fc1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb,d2cf2795,markdown,fr,fe432358c9357363,"## 7. Conclusion et perspectives
+
+Ce que ce toy model a rendu **mesurable**, sans aucun contrôleur global :
+
+- une **trajectoire** dans le morphospace (inversions, sortedness, monotonie) ;
+- le **délai de gratification** : sacrifices locaux au service du progrès global ;
+- la **robustesse** aux cellules défectueuses (et la supériorité du régime passif) ;
+- l'**auto-réparation** après lésion (l'ordre comme attracteur) ;
+- les **impasses** que l'hétérogénéité introduit dans un système d'agents autonomes.
+
+Ce sont les premières **signatures de trajectoires causales intégrées** — l'objet de la série ICT.
+
+### Ponts avec le reste du cours
+- **[IIT-1 — Intro to PyPhi](../IIT-1-IntroToPyPhi.ipynb)** et **[IIT-2 Advanced Topics](../IIT-2-AdvancedTopics.ipynb)** : les structures causales *à un instant* (TPM, Φ, CES) dont ICT étudie l'évolution.
+- **ICT-1 — Φ-trajectories** (à venir) : appliquer ces idées de trajectoire à Φ lui-même.
+- **ICT-4 — Chimeric arrays & emergent aggregation** (à venir) : le jeu de règles plus riche qui reproduit l'agrégation « kin » du papier.
+- **ICT-6 — Sorting-to-TPM bridge** (à venir) : transformer ces simulations en chaînes de Markov, puis en TPM analysables par PyPhi et la *causal emergence*.
+
+### Références
+- Zhang, Goldstein & Levin, *Classical sorting algorithms as a model of morphogenesis*, Adaptive Behavior, 2025 — [arXiv:2401.05375](https://arxiv.org/abs/2401.05375).
+- Levin, *The Computational Boundary of a ""Self""*, Frontiers in Psychology, 2019 (intelligence basale, compétences à différentes échelles).
+",,,,,,,,fe432358c9357363,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,febd299a,markdown,fr,3f2060270dba1d6f,"# ICT-20 — FeatureCatastrophes : *calibration de methode*
+
+> **Serie ICT** (Integrated Causal Trajectories, Epic #4588) -- strate 5 : *calibration*.
+> Prerequis : [ICT-0-Framing](ICT-0-Framing.md), [ICT-8-AttractorLandscapesEWS](ICT-8-AttractorLandscapesEWS.ipynb) (EWS), [ICT-10-CatastropheGrammar](ICT-10-CatastropheGrammar.ipynb) (pli / lacet).
+> Prerequis numeriques : numpy ; ce notebook n'utilise aucun modele GPU.
+
+## Pourquoi ce notebook existe
+
+ICT-21 (PersonaCatastrophe, [issue #5104](https://github.com/jsboige/CoursIA/issues/5104)) voudra lire des plis, de l'hysteresis et des signaux d'alerte precoce (EWS) dans l'espace des **features d'un LLM** sur une transition CHARGEE. Pretendre y arriver sans avoir montre ce a quoi un pli ""ressemble"" en feature-space sur une transition ANODINE serait de la complaisance : on lirait le bruit avant d'avoir calibre l'instrument.
+
+ICT-20 est cette **calibration de methode** : on genere des transitions controlees, on mesure les indicateurs (EWS, CUSUM, argmax-derivee) sur des panneaux synthetiques, et on fixe les **verdicts explicites** que ICT-21 devra reproduire (ou battre, ou reconnaetre silencieux) sur les vraies traces GPU.
+",,,,,,,,3f2060270dba1d6f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,97c71ca2,markdown,fr,29c97524cd046cf5,"## Pourquoi ""neutre"" ne veut pas dire ""trivial""
+
+Une **transition anodine** est une bascule statistique dans la distribution d'un scalaire (saut de moyenne, glissement d'AR1) **induite** par une commande exterieure -- typiquement un changement de prompt -- pas par une bifurcation physique reelle. C'est le **controle** des methodes de detection :
+
+- si les **EWS** reagissent ici, ils reagissent TROP (faux positifs) -- ils ne sont pas discriminants entre bifurcation reelle et bascule statistique ;
+- si le **CUSUM** repere la transition, c'est attendu (le signal est franc) ;
+- si l'**hysteresis** est nulle en boucle aller-retour, c'est attendu (la methode est reversible en l'absence de pli).
+
+Ces trois controles definissent le **fond de non-retour de l'instrument** que ICT-21 devra soustraire de ses lectures pour ne pas confondre l'inertie de la methode avec l'inertie du phenomene.
+",,,,,,,,29c97524cd046cf5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,10d8b31e,markdown,fr,c78f9a3c9e18fc67,"## Les trois questions que l'experience doit trancher
+
+1. **Gate 14 -- detection de regime** : un saut de moyenne est-il detectable a l'endroit de la transition, avec quel delai, et a quel taux de fausse alarme sur trace controle ?
+2. **Gate 15 -- EWS ou pas ?** : variance et autocorrelation de retard 1 montent-elles AVANT la transition induite ? **Verdict ouvert** : il est possible que NON -- les EWS supposent une dynamique pres d'une bifurcation, et une bascule in-context n'en est pas forcement une. Ce verdict CALIBRE ICT-21.
+3. **Gate bonus -- hysteresis** : sur une boucle FR -> EN -> FR (ou l'equivalent scalaire), la trajectoire revient-elle a son etat initial ? Toute hysteresis residuelle = **fond de non-retour de l'instrument**.
+
+L'experimentation repond a chacune en section dediee.
+",,,,,,,,c78f9a3c9e18fc67,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,c535094b,code,fr,64a6f5b268fb17fc,"import os
+import sys
+import numpy as np
+
+# acces au package `ict` pose a cote des notebooks
+sys.path.insert(0, os.path.dirname(os.path.abspath(""."")))
+from ict import feature_dynamics as fd  # adaptateur mince (ce notebook)
+from ict import early_warning as ew     # primitives EWS sous-jacentes
+
+np.random.seed(20260703)  # reproductibilite du notebook
+print(""Setup OK -- feature_dynamics"", [n for n in dir(fd) if not n.startswith(""_"")])
+",,,,,,,,64a6f5b268fb17fc,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,de1f7325,markdown,fr,693618b0ea3a7ccf,"## Le generateur de panel : `simulate_neutral_transition`
+
+Pas de GPU. Pas de LLM. Pas de prompt. Juste un **AR(1) avec saut eventuel de moyenne et/ou d'AR1** sur l'indice de transition. C'est le substrat minimal qui pose les trois questions ci-dessus avec un SNR controle.
+
+Pourquoi cest legitime : la calibration est exactement l'exercice ""separer l'instrument de l'objet"". ICT-21 sustituera ce generateur par le chargement des vraies traces ICT-18 ([issue #5101] -- HOLD GPU actuellement), mais **toute la chaine EWS / CUSUM / hysteresis reste identique** : on change juste la source du panel.
+
+**Verdict SOTA** : ce notebook livre la calibration complete sur donnees synthetiques. L'extension aux vraies traces GPU est **RECOVERABLE-MACHINE** (voir section Limites GPU-free plus bas).
+",,,,,,,,693618b0ea3a7ccf,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,4ebef74e,code,fr,64081fb4d39cc4f9,"# Demo : le generateur GPU-free et sa reproductibilite
+t1, idx1 = fd.simulate_neutral_transition(n_tokens=200, transition_at=100,
+                                          pre_mean=0.0, post_mean=1.0,
+                                          pre_ar1=0.5, post_ar1=0.7,
+                                          sigma=0.3, seed=42)
+t2, idx2 = fd.simulate_neutral_transition(n_tokens=200, transition_at=100,
+                                          pre_mean=0.0, post_mean=1.0,
+                                          pre_ar1=0.5, post_ar1=0.7,
+                                          sigma=0.3, seed=42)
+print(f""Reproducibilite : meme seed -> meme trace : {np.array_equal(t1, t2)}"")
+print(f""Index transition : {idx1} (attendu 100)"")
+print(f""Premiers 3 du regime pre : {t1[:3].round(3).tolist()}"")
+print(f""3 autour du pli ({idx1}) : {t1[idx1-1:idx1+2].round(3).tolist()}"")
+print(f""3 du regime post : {t1[-3:].round(3).tolist()}"")
+print(f""Stat cle : mu_pre={t1[:idx1].mean():.3f}, mu_post={t1[idx1:].mean():.3f}"")
+",,,,,,,,64081fb4d39cc4f9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,d72f5d32,markdown,fr,003a6c1ca75a48d8,"## Plan experimental
+
+| Experience | Input | Sortie mesuree | Verdict attendu |
+|-----------|-------|----------------|------------------|
+| 1 -- EWS sur saut d'AR1 seul | AR(1) phi=0.5 -> phi=0.95 | tau_var / tau_ar1 | critical_slowing |
+| 2 -- EWS sur saut de moyenne seul | AR(1) mu=0 -> mu=2 | tau_var / tau_ar1 | no_signal (EWS ne doit PAS repondre) |
+| 3 -- CUSUM sur sauts calibres | AR(1) avec saut de moyenne a t=200 | indice detecte | proche de 200 +/-50 |
+| 4 -- Hysteresis boucle aller-retour | boucle forward + retour | residu backward_tail - forward_head | proche de 0 sur SNR modere |
+
+Chaque experience est executee avec plusieurs graines et agregee.
+",,,,,,,,003a6c1ca75a48d8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,90fec593,markdown,fr,007b5690c57cf602,"## Experience 1 -- les EWS sont-ils sensibles a un ralentissement critique (saut d'AR1) ?
+
+On genere un AR(1) qui passe de phi=0.5 (leger rappel) a phi=0.95 (fort rappel). C'est l'analogue **minimal** d'un ralentissement critique : la serie ""colle"" plus a sa moyenne dans le regime post, ce qui doit faire monter variance et AR1.
+",,,,,,,,007b5690c57cf602,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,f3d2edba,code,fr,a32ce87eddb8bfb2,"# Experience 1 -- EWS sur AR(1) avec saut d'AR1 (critical_slowing attendu)
+def ar1_with_step(n, trans_at, phi_pre, phi_post, mu, sigma, seed):
+    g = np.random.default_rng(seed)
+    x = np.empty(n)
+    x[0] = mu
+    for t in range(1, trans_at):
+        x[t] = mu + phi_pre * (x[t-1] - mu) + sigma * g.standard_normal()
+    for t in range(trans_at, n):
+        x[t] = mu + phi_post * (x[t-1] - mu) + sigma * g.standard_normal()
+    return x
+
+x1 = ar1_with_step(n=4000, trans_at=2000, phi_pre=0.5, phi_post=0.95,
+                   mu=0.0, sigma=1.0, seed=11)
+rep1 = fd.ews_report(x1, window=200, thin_factor=1, detrend_sigma=0.0)
+print(""Experience 1 -- EWS sur saut d'AR1"")
+print(""  phi_pre = 0.5, phi_post = 0.95 (ralentissement critique simule)"")
+print(f""  Verdict : {rep1.verdict}"")
+print(f""  tau_var = {rep1.tau_var:+.3f} (p = {rep1.p_var:.2e})"")
+print(f""  tau_ar1 = {rep1.tau_ar1:+.3f} (p = {rep1.p_ar1:.2e})"")
+print(f""  Notes : {rep1.notes}"")
+assert rep1.verdict == ""critical_slowing"", (
+    f""Attendu critical_slowing sur saut d'AR1 franc, got {rep1.verdict}""
+)
+print(""PASSED"")
+",,,,,,,,a32ce87eddb8bfb2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,2a8b301b,markdown,fr,391ad28a585f4267,"## Experience 2 -- les EWS reagissent-ils a un saut de moyenne SANS changement d'AR1 ?
+
+On genere un AR(1) qui saute d'une moyenne a une autre **sans changer phi**. C'est l'equivalent scalaire d'une bascule de prompt : pas de bifurcation, juste une statistique qui change. **Les EWS ne devraient PAS repondre** (verdict attendu = no_signal). Si elles repondent quand meme, c'est un faux positif systematique qui sera a soustraire du Gate 15 d'ICT-21.
+",,,,,,,,391ad28a585f4267,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,c8e4e12a,code,fr,3bbed01e9435fbe2,"# Experience 2 -- EWS sur saut de moyenne SEUL (no_signal attendu)
+t2, idx2 = fd.simulate_neutral_transition(n_tokens=4000, transition_at=2000,
+                                          pre_mean=0.0, post_mean=2.0,
+                                          pre_ar1=0.5, post_ar1=0.5,
+                                          sigma=1.0, seed=13)
+rep2 = fd.ews_report(t2, window=200, thin_factor=1, detrend_sigma=0.0)
+print(""Experience 2 -- EWS sur saut de moyenne seul (sans saut d'AR1)"")
+print(""  mu_pre = 0.0, mu_post = 2.0, phi = 0.5 constant"")
+print(f""  Verdict : {rep2.verdict}"")
+print(f""  tau_var = {rep2.tau_var:+.3f} (p = {rep2.p_var:.2e})"")
+print(f""  tau_ar1 = {rep2.tau_ar1:+.3f} (p = {rep2.p_ar1:.2e})"")
+print(f""  Notes : {rep2.notes}"")
+assert rep2.verdict in (""no_signal"", ""mixed""), (
+    f""Attendu no_signal (EWS ne doit PAS repondre a un saut de moyenne pur), ""
+    f""got {rep2.verdict}""
+)
+print(f""PASSED (verdict honnete : {rep2.verdict})"")
+",,,,,,,,3bbed01e9435fbe2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,1b76883b,markdown,fr,1721cc9f88818ace,"## Experience 3 -- CUSUM : precision et delai de detection
+
+**Gate 14** : sur 5 graines differentes, on mesure l'indice detecte par CUSUM et on le compare a l'indice de transition (t=200 sur 400 points). Cible : |idx - 200| <= 50 (delai de detection acceptable pour SNR ~5).
+",,,,,,,,1721cc9f88818ace,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,6f768879,code,fr,864949e18d97b4db,"# Experience 3 -- CUSUM sur sauts calibres (Gate 14 -- verdict honnete)
+print(""Experience 3 -- Gate 14 : CUSUM sur sauts calibres (SNR modere)"")
+resultats_cusum = []
+for graine in [23, 47, 101, 211, 307]:
+    trace, t_true = fd.simulate_neutral_transition(
+        n_tokens=400, transition_at=200,
+        pre_mean=0.0, post_mean=2.0,
+        pre_ar1=0.5, post_ar1=0.5,
+        sigma=0.3, seed=graine
+    )
+    idx, S = fd.changepoint_cusum(trace, threshold=8.0, drift=0.5)
+    err = (idx - t_true) if idx > 0 else None
+    resultats_cusum.append((graine, t_true, idx, err))
+    print(f""  seed={graine:3d} | vrai t=200 | detecte t={idx:3d} | delai={err if err is None else f'{err:+d}'}"")
+
+delais = [abs(r[3]) for r in resultats_cusum if r[3] is not None]
+bonnes_dets = [d for d in delais if d <= 50]
+fausses_precoces = sum(1 for r in resultats_cusum if r[2] is not None and r[2] > 0 and r[2] < 50)
+print(f""\nBilan : {len(delais)}/{len(resultats_cusum)} detections"")
+print(f""  delai median : {int(np.median(delais))} indices"")
+print(f""  detections dans la fenetre toleree (+/-50 indices) : {len(bonnes_dets)}/{len(delais)}"")
+print(f""  detections precoces (<50 indices = faux positif) : {fausses_precoces}"")
+
+if len(bonnes_dets) >= 3:
+    print(""VERDICT Gate 14 : CUSUM detecte au moins 3/5 sauts dans la fenetre toleree."")
+elif len(bonnes_dets) >= 1:
+    print(""VERDICT Gate 14 : CUSUM partiellement robuste ; ICT-21 devra seuiller plus strictement."")
+else:
+    print(""VERDICT Gate 14 : CUSUM PAS robuste sur SNR modere au seuil 8 ; rehausser le seuil ou utiliser argmax-derivee."")
+print(""(verdict honnete, pas maquille en PASSED)"")
+",,,,,,,,864949e18d97b4db,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,758c4f12,markdown,fr,ec57fd284a6773d9,"## Experience 4 -- hysteresis sur boucle aller-retour
+
+**Gate bonus** : sur une transition aller (sigma=0.5, mu=0 -> mu=2) puis retour (sigma=0.5, mu=2 -> mu=0), on mesure l'ecart entre la tete de la trace aller et la queue de la trace retour. Cible : residu proche de 0 sur la moyenne (l'AR(1) symetrique est reversible par construction).
+",,,,,,,,ec57fd284a6773d9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,a740a36b,code,fr,94c2e74d173cf61f,"# Experience 4 -- hysteresis aller-retour (Gate bonus)
+print(""Experience 4 -- Gate bonus : hysteresis sur boucle aller-retour"")
+resultats_hyst = []
+for graine in [31, 53, 97, 149, 211]:
+    # aller : mu 0 -> 2, sigma 0.5, AR1 0.5
+    forward, _ = fd.simulate_neutral_transition(
+        n_tokens=400, transition_at=200,
+        pre_mean=0.0, post_mean=2.0,
+        pre_ar1=0.5, post_ar1=0.5,
+        sigma=0.5, seed=graine
+    )
+    # retour : mu 2 -> 0, sigma 0.5, AR1 0.5 (meme bruit)
+    backward, _ = fd.simulate_neutral_transition(
+        n_tokens=400, transition_at=200,
+        pre_mean=2.0, post_mean=0.0,
+        pre_ar1=0.5, post_ar1=0.5,
+        sigma=0.5, seed=graine + 1000
+    )
+    residu = fd.hysteresis_residual(forward, backward, baseline_window=20)
+    resultats_hyst.append((graine, residu))
+    print(f""  seed={graine:3d} | residu (backward_tail - forward_head) = {residu:+.4f}"")
+
+residus = [r[1] for r in resultats_hyst]
+print(f""\nBilan : moyenne des residus = {np.mean(residus):+.4f}, ecart-type = {np.std(residus):.4f}"")
+# le residu peut fluctuer autour de 0 -- on accepte |moyenne| < 0.15
+assert abs(np.mean(residus)) < 0.15, f""Hysteresis residuelle moyenne trop elevee : {np.mean(residus):.4f}""
+print(""PASSED (Gate bonus -- hysteresis residuelle ~ 0 sur boucle symetrique)"")
+",,,,,,,,94c2e74d173cf61f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,c8bcc8ec,markdown,fr,75293d7e40389a5e,"## Limites GPU-free -- verdict RECOVERABLE-MACHINE
+
+Cette calibration est sur panneau synthetique. Pour calibrer sur les **vraies** transitions d'un LLM (FR -> EN -> FR, prose -> code -> prose, sujet A -> sujet B -> sujet A), il faut les traces du pipeline ICT-18 *GPU* (futur notebook SAE/Qwen-Scope, [issue #5101](https://github.com/jsboige/CoursIA/issues/5101) -- HOLD GPU/vLLM actuellement, distinct du `ict/time_arrow.py` livre dans ICT-18 FlecheDuTempsReversibilisation 2026-07-04).",,,,,,,,75293d7e40389a5e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,76d35f6e,markdown,fr,01602860d49d82f7,"## Gate 15 -- verdict EWS explicite
+
+Apres les Experiences 1 et 2, on peut conclure un **verdict quantitatif sur la sensibilite des EWS aux transitions anodines** :
+
+- si Exp1 -> critical_slowing **et** Exp2 -> no_signal : les EWS discriminent correctement entre ralentissement critique et bascule statistique. ICT-21 peut les utiliser avec confiance sur traces reelles.
+- si Exp1 -> critical_slowing **et** Exp2 -> critical_slowing (egalement) : les EWS reagissent aux sauts de moyenne. **Verdict douteux** : ICT-21 devra les utiliser comme signal **faible**, jamais comme preuve.
+- si Exp1 -> no_signal : les EWS ne sont meme pas assez sensibles pour detecter un vrai ralentissement critique. **Verdict RECOVERABLE** : revoir la fenetre ou le panel.
+
+Le verdict retenu par cette calibration est reporte dans le tableau final plus bas.
+",,,,,,,,01602860d49d82f7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,976c81c1,markdown,fr,4e3d5a41730cc600,"## Conclusion -- ce qu'on a calibre (et ce qui reste a faire sur GPU)
+
+ICT-20 livre une **chaine de detection a 4 instruments** (`ews_report`, `changepoint_cusum`, `changepoint_argmax_derivative`, `hysteresis_residual`) testee sur 13 tests unitaires et calibree sur 4 experiences sur panneau synthetique.
+
+**A reporter pour ICT-21** :
+
+1. `ews_report` est adapte aux ralentissements critiques francs (Exp1 PASSED) **mais pas aux simples sauts de moyenne** (Exp2 -- comportement attendu, a verifier sur traces reelles).
+2. `changepoint_cusum` detecte les sauts francs dans la fenetre d'integration, avec un delai dependant du SNR (Gate 14 -- tolerance +/-50 indices sur N=400).
+3. `hysteresis_residual` mesure le retour a la ligne de base sur boucle aller-retour ; residu ~ 0 sur AR(1) symetrique par construction (Gate bonus -- comportement attendu).
+
+Quand ai-01 confirmera la reprise du pipeline vLLM (issue #5101), cette chaine sera **portee sans modification** sur les vraies traces ICT-18, et les memes verdicts seront reportes -- avec, en plus, la question de l'hysteresis *reelle* (qui pourra etre non nulle sur les transitions chargees que ICT-21 provoquera).
+
+**Note de cadrage 2026-07-04.** ICT-18 delivre est *FlecheDuTempsReversibilisation* (numpy CPU-only, strate 5 fondation thermodynamique -- ce notebook n'est pas dans son scope). Le ""vrai ICT-18 SAETrajectoires"" (issue #5101) reste HOLD GPU/vLLM. La mention ""ICT-18"" ci-dessus designe le futur pipeline SAEs, pas le notebook livre dans cette PR.",,,,,,,,4e3d5a41730cc600,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,bd41dbee,markdown,fr,518dd20ef61b66c1,"## Exercice 1 -- sensibilite de la fenetre EWS
+
+**Objectif** : mesurer comment le verdict EWS evolue selon la largeur de la fenetre glissante (50, 100, 200, 400) sur le meme panneau.
+
+**Indice** : utiliser `ews_report(trace, window=W)` pour W parmi [50, 100, 200, 400] et stocker les verdicts.
+
+**Question** : y a-t-il une fenetre ou le verdict bascule ? Laquelle est la plus discriminante sur Exp1 (saut d'AR1) et Exp2 (saut de moyenne seul) ?
+
+**Etape 1** : generer le panneau Exp1 (`phi_pre=0.5`, `phi_post=0.95`, `mu=0`, `sigma=1.0`, `n=4000`, `seed=11`).
+**Etape 2** : appeler `ews_report` pour chaque fenetre, stocker le verdict dans une liste `verdicts`.
+**Etape 3** : afficher le tableau des verdicts et conclure en 2 phrases.
+",,,,,,,,518dd20ef61b66c1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,061e708d,code,fr,bebfa31c2872c612,"# Exercice 1 -- sensibilite de la fenetre EWS
+# Objectif : mesurer comment le verdict EWS evolue avec la largeur de fenetre
+# Indices : voir cellule markdown ""Exercice 1"" au-dessus
+
+# TODO etudiant -- remplacer le contenu de cette cellule
+# etape 1 : generer le panneau Exp1
+#   x_exp1 = ar1_with_step(n=4000, trans_at=2000, phi_pre=0.5, phi_post=0.95, mu=0.0, sigma=1.0, seed=11)
+#   (la fonction ar1_with_step est definie dans la cellule ""Experience 1"")
+# etape 2 : appeler ews_report pour chaque fenetre parmi [50, 100, 200, 400]
+#   verdicts = []
+#   for W in [50, 100, 200, 400]:
+#       rep = fd.ews_report(x_exp1, window=W, thin_factor=1, detrend_sigma=0.0)
+#       verdicts.append((W, rep.verdict, rep.tau_ar1, rep.p_ar1))
+# etape 3 : afficher le tableau et conclure
+
+result = None  # pas d'execution tant que l'exercice n'est pas complete
+print(""Exercice 1 -- a completer (voir cellule markdown)"")
+",,,,,,,,bebfa31c2872c612,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,1a8a436a,markdown,fr,161fb5ad8397dcee,"## Exercice 2 -- CUSUM vs fenetres glissantes sur transition graduelle
+
+**Objectif** : comparer la precision de detection du CUSUM et d'une methode par maximum de variance roulante sur une **transition graduelle** (pas un saut franc).
+
+**Indice** : constuire une trace avec une rampe lineaire de la moyenne entre t=100 et t=300 (transition graduelle) puis appliquer `changepoint_cusum` et `np.argmax(ew.rolling_variance(trace, 50))`.
+
+**Question** : laquelle des deux methodes repere le **milieu** de la transition (~t=200) plutot que ses **bords** (t=100 ou t=300) ?
+
+**Etape 1** : construire la trace avec rampe.
+**Etape 2** : appliquer CUSUM et argmax-variance.
+**Etape 3** : conclure en 2 phrases.
+",,,,,,,,161fb5ad8397dcee,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,0f8faab7,code,fr,cf7df0354e87dd30,"# Exercice 2 -- CUSUM vs fenetres glissantes sur transition graduelle
+# Objectif : comparer la precision de detection du CUSUM et d'un argmax-variance
+# sur une transition graduelle (rampe lineaire mu 0 -> 2 entre t=100 et t=300)
+# Indices : voir cellule markdown ""Exercice 2"" au-dessus
+
+# TODO etudiant -- remplacer le contenu de cette cellule
+# etape 1 : construire la trace avec rampe lineaire entre t=100 et t=300
+#   g = np.random.default_rng(13)
+#   n = 400
+#   trace = g.standard_normal(n)  # base bruit
+#   for t in range(100, 300):
+#       r = (t - 100) / 200.0  # 0 -> 1
+#       trace[t] += 2.0 * r     # ajout lineaire
+# etape 2 : appliquer CUSUM et argmax-variance (window=50)
+#   idx_cusum, _ = fd.changepoint_cusum(trace, threshold=8.0, drift=0.5)
+#   idx_varmax = 100 + int(np.argmax(ew.rolling_variance(trace, 50)))
+# etape 3 : conclure
+
+result = None  # pas d'execution tant que l'exercice n'est pas complete
+print(""Exercice 2 -- a completer (voir cellule markdown)"")
+",,,,,,,,cf7df0354e87dd30,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,c33c6efc,markdown,fr,21318165207732e0,"## Exercice 3 -- hysteresis reelle vs instrinseque sur boucle asymmetrique
+
+**Objectif** : mesurer le residu d'hysteresis sur une boucle OU la **phase aller** (sigma=0.3, AR1=0.9) est differente de la **phase retour** (sigma=0.5, AR1=0.7). C'est un cas OU l'instrument lui-meme introduit une hysteresis (variance residuelle).
+
+**Indice** : utiliser `simulate_neutral_transition` deux fois (aller et retour), passer les deux traces a `hysteresis_residual`.
+
+**Question** : le residu est-il nul, ou traduit-il une derive de l'instrument ? Ce residu est-il compatible avec une lecture ICT-21 sur traces chargees ?
+
+**Etape 1** : generer la phase aller (sigma=0.3, AR1=0.9, mu=0 -> mu=2).
+**Etape 2** : generer la phase retour (sigma=0.5, AR1=0.7, mu=2 -> mu=0).
+**Etape 3** : mesurer `hysteresis_residual(aller, retour)` et conclure.
+",,,,,,,,21318165207732e0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-20-FeatureCatastrophes.ipynb,39f130c4,code,fr,b293e4c6aa4009bd,"# Exercice 3 -- hysteresis reelle vs instrinseque sur boucle asymmetrique
+# Objectif : mesurer le residu d'hysteresis sur une boucle OU la phase aller
+# (sigma=0.3, AR1=0.9) differente de la phase retour (sigma=0.5, AR1=0.7)
+# Indices : voir cellule markdown ""Exercice 3"" au-dessus
+
+# TODO etudiant -- remplacer le contenu de cette cellule
+# etape 1 : generer la phase aller
+#   forward, _ = fd.simulate_neutral_transition(
+#       n_tokens=400, transition_at=200,
+#       pre_mean=0.0, post_mean=2.0,
+#       pre_ar1=0.9, post_ar1=0.9,   # phi=0.9 aller
+#       sigma=0.3,                   # sigma=0.3 aller
+#       seed=11
+#   )
+# etape 2 : generer la phase retour (sigma=0.5, phi=0.7)
+#   backward, _ = fd.simulate_neutral_transition(
+#       n_tokens=400, transition_at=200,
+#       pre_mean=2.0, post_mean=0.0,
+#       pre_ar1=0.7, post_ar1=0.7,
+#       sigma=0.5,
+#       seed=12
+#   )
+# etape 3 : mesurer hysteresis_residual(forward, backward) et conclure
+
+result = None  # pas d'execution tant que l'exercice n'est pas complete
+print(""Exercice 3 -- a completer (voir cellule markdown)"")
+",,,,,,,,b293e4c6aa4009bd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,e786a374,markdown,fr,c7a627f1eceb27fd,"# ICT-21 — SAETrajectoires : le substrat S4 entre au banc
+
+> **Série ICT** (*Integrated Causal Trajectories*, Epic #4588) — strate 5 : *extraction GPU*.
+> Issue : #5101. Aval direct : ICT-22 LLMSubstrat (#5102, Gate 12) et ICT-24 WorkspaceIgnition (#5635, Gates 22-24).
+
+Jusqu'ici le banc cross-substrat de la série a mesuré la complexité intégrée (gains **ec/fe/k**, chacun crédité seulement au-dessus d'un contrôle shuffle) sur trois substrats : automates (S1), Kuramoto (S2), réservoirs (S3). Ce notebook fabrique le quatrième et le plus ambitieux : **S4, un transformer réel** — non pas via ses logits, mais via les **features monosémantiques d'un Sparse Autoencoder (SAE)** posées sur son flux résiduel.
+
+Le livrable central n'est pas une figure : ce sont deux fichiers `traces/*.npz` (modèle entraîné **et** modèle-contrôle) qui rendent tout l'aval **GPU-free**. Deux gates de l'issue #5101 sont instrumentés ici :
+
+| Gate | Critère | Cellule |
+|------|---------|---------|
+| **Gate 10** | Chaque feature du panel *re-tire sur son concept* sur des prompts **held-out** (précision par feature rapportée ; une feature non reproductible sort du panel, documenté) | Gate 10 ci-dessous |
+| **Gate 11** | Substrat valide : `n_states`/`n_transitions` traitables, `trajectory_battery` tourne, contraste `shuffled_baseline` **non dégénéré** — verdict : S4 prêt pour le banc | Gate 11 ci-dessous |
+
+Le verdict *crédité* (les gains de S4 battent-ils shuffle **et** modèle-contrôle sur ≥5 jeux de prompts) n'est **pas** rendu ici : c'est le Gate 12 d'ICT-22, qui consomme nos `.npz`.",,,,,,,,c7a627f1eceb27fd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,2ae80422,markdown,fr,a41440db5a022e2b,"## Garde-fous d'honnêteté (à lire avant les résultats)
+
+1. **J-lens ≠ SAE.** L'article d'Anthropic sur le *global workspace* (« J-space » : quelques dizaines de concepts, <10 % de l'activité, connectivité ~100×, silençable) utilise le **jacobien**, pas de SAE, et ne mentionne pas l'IIT. Notre route SAE est une **opérationnalisation parallèle légitime**, pas une réplication.
+2. **Qwen ≠ Claude.** Nous travaillons sur Qwen3.5-9B-Base à poids ouverts — c'est un *avantage* pédagogique (reproductible par quiconque), pas une approximation honteuse.
+3. **Structurel vs temporel.** Anthropic mesure le broadcast **structurellement** (câblage) ; l'« ignition » temporelle de Dehaene n'y est **pas** mesurée. Quand la série en parlera (ICT-24), ce sera *notre* lecture, annoncée comme telle.
+4. **Accès ≠ phénoménal.** Tout ce qui suit relève de la conscience d'**accès** (intégration, broadcast fonctionnel). Aucune revendication phénoménale n'est faite ni ne pourrait l'être avec ces outils.",,,,,,,,a41440db5a022e2b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,df98a8d6,markdown,fr,a0cf8b06baa47e82,"## Architecture du pipeline : le GPU confiné, le banc numpy-only
+
+La règle d'architecture de la série est stricte : le package `ict/` reste **numpy-only** (aucun import torch). Le GPU vit dans **un script**, le notebook et tout l'aval consomment des `.npz` :
+
+```
+scripts/extract_sae_traces.py      (GPU : torch, transformers — extraction)
+        │  écrit
+        ▼
+traces/ict21_sae_layer16_{trained,control}.npz     (~0,5 Mio chacun)
+        │  lus par
+        ▼
+ict/sae_traces.py                  (numpy-only : chargement, curation, états)
+        │  consommés par
+        ▼
+ce notebook, ICT-22 (#5102), ICT-24 (#5635)
+```
+
+**Modèle** : `Qwen/Qwen3.5-9B-Base` (classe `Qwen3_5ForCausalLM`, transformers 5.x ; ~16,7 Gio VRAM en bf16, mesuré). **SAE** : `Qwen/SAE-Res-Qwen3.5-9B-Base-W64K-L0_50`, couche 16 du flux résiduel (`resid_post`), 65 536 features, **top-k = 50**. *Note de correction* : le corps de #5101 cite « L0≈100 » ; la release officielle Qwen-Scope pour ce modèle est **L0_50** — c'est elle que nous utilisons (corrigé dans le commentaire de claim sur l'issue).
+
+**Convention d'encodage** (celle de l'application officielle Qwen-Scope) : `pre = h @ W_enc.T + b_enc ; relu ; top-k(50)` — pas de soustraction de `b_dec`, pas de normalisation. **Stockage sparse exhaustif** : pour chaque token on stocke les 50 paires (id, valeur) du top-k ; hors top-50 l'activation vaut **exactement zéro** par construction du SAE top-k, donc la densification aval est *exacte*. Ce stockage **subsume** le schéma amendé de #5101 (`acts_topk` K≈64) : le panel continu s'en dérive sans GPU.
+
+**Modèle-contrôle** : permutation seedée (graine 42) des lignes de la matrice d'embedding d'entrée — le contrôle sanctionné par #5101. Même architecture, mêmes poids partout ailleurs : seule la *sémantique d'entrée* est détruite.
+
+*API réelle du module* (léger écart de nommage vs le corps de l'issue, assumé et documenté dans la PR) : `load_traces`, `densify`, `mean_activation_by_set`, `differential_features`, `acts_topk_panels`, `binarize_quantile`, `states_from_panel`.",,,,,,,,a0cf8b06baa47e82,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,6724f71d,code,fr,8135ac3588eda365,"import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# accès au package `ict` posé à côté des notebooks
+sys.path.insert(0, os.path.abspath("".""))
+from ict import sae_traces as st
+from ict import synthesis as syn
+
+TRACES = Path(""traces"")
+SCRIPT = Path(""scripts"") / ""extract_sae_traces.py""
+NPZ = {v: TRACES / f""ict21_sae_layer16_{v}.npz"" for v in (""trained"", ""control"")}
+
+print(""numpy"", np.__version__, ""| python"", sys.version.split()[0])
+print(""script :"", SCRIPT, ""| présent :"", SCRIPT.exists())
+for v, p in NPZ.items():
+    print(f""traces {v:8s}: {p} | présent : {p.exists()}"")",,,,,,,,8135ac3588eda365,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,cfbd9548,markdown,fr,66baccc899092e7b,"## Preuve d'exécution GPU : le smoke test, en direct
+
+Avant de faire confiance aux `.npz` committés, le notebook **ré-exécute le pipeline GPU en mode smoke** (1 prompt, chargement complet du modèle + SAE, vérifications de bout en bout). Le smoke vérifie notamment :
+
+- que le modèle génère du texte sensé en greedy (« La capitale de la France est » → *Paris* : preuve que les poids sont bien chargés) ;
+- que **L0 = 50,0 exactement** sur chaque token (le top-k du SAE est bien un top-k) ;
+- que `W_dec` est présent (le hook de *clamp* du Gate 24 de #5635 restera possible sur ces mêmes artefacts).
+
+La cellule est **sautée proprement** si aucun GPU n'est disponible (ré-exécution CI/CPU) : les sorties committées ci-dessous font alors foi. Sur `ai-01`, la contrainte est stricte : `CUDA_VISIBLE_DEVICES=2` (les GPU 0-1 portent un service vLLM).",,,,,,,,66baccc899092e7b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,13350192,code,fr,12f17706108258e2,"env = {**os.environ,
+       ""PYTHONNOUSERSITE"": ""1"",
+       ""CUDA_VISIBLE_DEVICES"": os.environ.get(""CUDA_VISIBLE_DEVICES"", ""2""),
+       ""PYTORCH_CUDA_ALLOC_CONF"": ""expandable_segments:True""}
+
+probe = subprocess.run(
+    [sys.executable, ""-c"", ""import torch; print(int(torch.cuda.is_available()))""],
+    capture_output=True, text=True, env=env)
+gpu_ok = probe.stdout.strip().endswith(""1"")
+
+if not gpu_ok:
+    print(""GPU indisponible dans cet environnement : smoke sauté."")
+    print(""Les traces committées (extraites sur ai-01, GPU 2) font foi — voir meta ci-dessous."")
+else:
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), ""--stage"", ""smoke"", ""--variant"", ""trained""],
+        capture_output=True, text=True, env=env, timeout=480)
+    tail = ""\n"".join((r.stdout + r.stderr).strip().splitlines()[-18:])
+    print(tail)
+    assert r.returncode == 0, ""smoke GPU en échec""
+    print(""\n=> SMOKE OK : pipeline GPU rejoué en direct dans ce notebook."")",,,,,,,,12f17706108258e2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,7aa46f9b,markdown,fr,528fca911ec7143a,"## Extraction complète : idempotente par construction
+
+L'extraction complète (5 jeux × 4 prompts × 2 variantes) prend ~50 s sur GPU une fois le modèle en cache. Comme les `.npz` sont **le livrable committé**, la cellule est *idempotente* : si les fichiers existent, elle affiche leurs métadonnées et ne relance rien. Pour forcer une ré-extraction (autre couche, autre panel de prompts) : `FORCE_EXTRACT=1` dans l'environnement, ou directement le script en CLI :
+
+```bash
+CUDA_VISIBLE_DEVICES=2 python scripts/extract_sae_traces.py --stage full --variant trained
+CUDA_VISIBLE_DEVICES=2 python scripts/extract_sae_traces.py --stage full --variant control
+```",,,,,,,,528fca911ec7143a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,642ffd75,code,fr,515fab699e078bc9,"force = os.environ.get(""FORCE_EXTRACT"", ""0"") == ""1""
+for variant, path in NPZ.items():
+    if path.exists() and not force:
+        meta = json.loads(str(np.load(path, allow_pickle=False)[""__meta__""]))
+        print(f""[{variant}] présent — extrait le {meta['date']} | couche {meta['layer']} ""
+              f""| k={meta['k']} | {meta['n_tokens_total']} tokens | variante={meta['variant']}"")
+        continue
+    if not gpu_ok:
+        raise FileNotFoundError(f""{path} absent et pas de GPU pour l'extraire"")
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), ""--stage"", ""full"", ""--variant"", variant],
+        capture_output=True, text=True, env=env, timeout=900)
+    print(""\n"".join((r.stdout + r.stderr).strip().splitlines()[-6:]))
+    assert r.returncode == 0 and path.exists()",,,,,,,,515fab699e078bc9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,109f40d3,markdown,fr,77db021e44cdbedf,"## Chargement et sanité : L0, volumes, budget disque
+
+Premier contact numpy-only avec les traces. Trois sanités : le schéma (20 prompts, k=50, d_sae=65 536), le **L0 exact** (toutes les valeurs du top-50 sont strictement positives : le SAE top-k tient sa promesse de parcimonie), et le budget disque (le stockage sparse compressé tient chaque variante sous le Mio — très loin du seuil LFS).",,,,,,,,77db021e44cdbedf,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,c40a7bcd,code,fr,f8d66be03a8ba2be,"traces = {v: st.load_traces(p) for v, p in NPZ.items()}
+
+for v, tr in traces.items():
+    n_tok = sum(e[""ids""].shape[0] for e in tr[""prompts""].values())
+    l0 = np.mean([(e[""vals""] > 0).sum(axis=1).mean() for e in tr[""prompts""].values()])
+    size = NPZ[v].stat().st_size / 2**20
+    m = tr[""meta""]
+    print(f""[{v:8s}] {len(tr['prompts'])} prompts | {n_tok} tokens | ""
+          f""L0 moyen = {l0:.1f}/{m['k']} | d_sae = {m['d_sae']} | {size:.2f} Mio"")
+
+SETS = sorted({s for s, _ in traces[""trained""][""prompts""]})
+print(""jeux de prompts :"", SETS)",,,,,,,,f8d66be03a8ba2be,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,17e10910,markdown,fr,8b3d196a83ce077e,"## Sélection différentielle : la variance inter-jeux, pas l'amplitude
+
+Sur 65 536 features, lesquelles regarder ? Le piège serait de prendre les plus **actives en absolu** : on récolterait la ponctuation, le formatage, les artefacts de tokenisation — omniprésents et inintéressants. Le critère retenu (c'est le `acts_topk` K=64 du schéma amendé de #5101) est la **variance inter-jeux de l'activation moyenne** : une feature intéressante est une feature qui *discrimine les régimes* (code vs prose française vs dialogue vs maths vs narration anglaise).
+
+La cellule matérialise aussi la vérification de la fixture de test du module : la feature la plus forte en absolu n'est typiquement **pas** dans le haut du classement différentiel.",,,,,,,,8b3d196a83ce077e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,533856ab,code,fr,eb4717f79bec1b99,"K_DIFF = 64
+diff64 = st.differential_features(traces[""trained""], k=K_DIFF)
+means = st.mean_activation_by_set(traces[""trained""])
+stack = np.stack([means[s] for s in SETS])
+var_scores = stack.var(axis=0)
+
+print(f""top-10 features différentielles (sur {K_DIFF}) :"", diff64[:10].tolist())
+strongest = int(np.argmax(stack.mean(axis=0)))
+rank = diff64.tolist().index(strongest) if strongest in diff64 else -1
+print(f""feature la plus forte en absolu : f{strongest} ""
+      f""(rang différentiel : {'hors top-64' if rank < 0 else rank})"")
+
+fig, ax = plt.subplots(figsize=(9, 3))
+ax.bar(range(20), var_scores[diff64[:20]], color=""steelblue"")
+ax.set_xticks(range(20))
+ax.set_xticklabels([f""f{i}"" for i in diff64[:20]], rotation=60, fontsize=7)
+ax.set_ylabel(""variance inter-jeux"")
+ax.set_title(""Top-20 features différentielles (modèle entraîné, couche 16)"")
+plt.tight_layout(); plt.show()",,,,,,,,eb4717f79bec1b99,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,e0c205db,markdown,fr,107783b53eb24aac,"## Gate 10 — le panel se reproduit-il hors de son échantillon de sélection ?
+
+Un panel de features choisi et évalué **sur les mêmes prompts** ne prouverait rien : il pourrait sur-apprendre les particularités des textes. Protocole *held-out* :
+
+1. **Sélection** du panel (10 features) par variance inter-jeux sur les prompts **0-2** de chaque jeu (12 prompts d'entraînement) ;
+2. Pour chaque feature : son **jeu préféré** = celui où son activation moyenne est maximale (sur la sélection), et sa **sélectivité** = part de son activation qui va à ce jeu ;
+3. **Vérification** sur les prompts **3**, jamais vus par la sélection (5 prompts held-out) : la feature re-tire-t-elle *d'abord* sur son jeu préféré ?
+
+Verdict par feature : `OK` si le jeu préféré held-out coïncide (précision rapportée via la sélectivité), `KO` sinon — et une feature `KO` **sort du panel**, comme l'exige le gate. C'est le prix de l'honnêteté : mieux vaut un panel de 8-9 features reproductibles qu'un panel de 10 dont une invente sa sémantique.",,,,,,,,107783b53eb24aac,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,fa009207,code,fr,2d89e5f6bd61fbf2,"def subset(tr, keep):
+    return {""meta"": tr[""meta""],
+            ""prompts"": {k: v for k, v in tr[""prompts""].items() if keep(k)}}
+
+train = subset(traces[""trained""], lambda k: k[1] < 3)   # prompts 0-2
+held = subset(traces[""trained""], lambda k: k[1] == 3)   # prompt 3, jamais vu
+
+panel10 = st.differential_features(train, k=10)
+m_train = st.mean_activation_by_set(train)
+m_held = st.mean_activation_by_set(held)
+
+rows, panel_final = [], []
+for f in panel10:
+    a_tr = np.array([m_train[s][f] for s in SETS])
+    a_he = np.array([m_held[s][f] for s in SETS])
+    pref = SETS[int(a_tr.argmax())]
+    pref_held = SETS[int(a_he.argmax())]
+    sel_tr = a_tr.max() / max(a_tr.sum(), 1e-9)
+    sel_he = a_he[SETS.index(pref)] / max(a_he.sum(), 1e-9)
+    ok = pref_held == pref and a_he[SETS.index(pref)] > 0
+    rows.append((int(f), pref, sel_tr, sel_he, pref_held, ""OK"" if ok else ""KO -> sort du panel""))
+    if ok:
+        panel_final.append(int(f))
+panel_final = np.array(panel_final)
+
+print(f""{'feature':>9s} | {'jeu préféré':>12s} | {'sél. train':>10s} | ""
+      f""{'sél. held-out':>13s} | {'préféré held-out':>16s} | verdict"")
+for f, pref, s_tr, s_he, pref_h, verdict in rows:
+    print(f""f{f:>8d} | {pref:>12s} | {s_tr:>10.2f} | {s_he:>13.2f} | {pref_h:>16s} | {verdict}"")
+
+n_ok = len(panel_final)
+print(f""\nGate 10 : {n_ok}/{len(panel10)} features reproduites held-out ""
+      f""-> panel final = {panel_final.tolist()}"")
+assert n_ok >= 8, ""Gate 10 : panel trop peu reproductible""
+print(""=> GATE 10 : PASS (précision par feature rapportée ci-dessus, ""
+      ""features non reproductibles sorties du panel et documentées)"")",,,,,,,,2d89e5f6bd61fbf2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,505aa85c,code,fr,f0df73bfdce39aa8,"# Sémantique observée : les tokens qui font le plus tirer chaque feature du panel
+print(""Sémantique observée (top-5 tokens max-activants, toutes traces entraînées) :\n"")
+for f in panel_final:
+    best = []
+    for (s, i), e in traces[""trained""][""prompts""].items():
+        hit = e[""ids""] == f
+        if hit.any():
+            t_idx, k_idx = np.nonzero(hit)
+            for t, k in zip(t_idx, k_idx):
+                best.append((float(e[""vals""][t, k]), repr(e[""tokens""][t]), s))
+    best.sort(reverse=True)
+    toks = "", "".join(f""{tok}({s})"" for _, tok, s in best[:5]) or ""(jamais active)""
+    print(f""  f{f}: {toks}"")
+
+sel = np.stack([[m_held[s][f] for s in SETS] for f in panel_final])
+sel = sel / np.maximum(sel.sum(axis=1, keepdims=True), 1e-9)
+fig, ax = plt.subplots(figsize=(7, 3.5))
+im = ax.imshow(sel, cmap=""viridis"", aspect=""auto"")
+ax.set_xticks(range(len(SETS))); ax.set_xticklabels(SETS, rotation=30, fontsize=8)
+ax.set_yticks(range(len(panel_final)))
+ax.set_yticklabels([f""f{f}"" for f in panel_final], fontsize=8)
+ax.set_title(""Sélectivité held-out du panel (part d'activation par jeu)"")
+fig.colorbar(im, shrink=0.8)
+plt.tight_layout(); plt.show()",,,,,,,,f0df73bfdce39aa8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,b798110d,markdown,fr,4aa7427a868c67dd,"## Du panel aux trajectoires d'états discrets
+
+Le banc de la série consomme des **suites d'états discrets**. Passage en trois temps, tous numpy :
+
+1. `acts_topk_panels` densifie le panel — exact, puisque hors top-50 tout est nul ;
+2. `binarize_quantile` seuille chaque feature à la **médiane de ses valeurs positives** (les zéros structurels du top-k n'écrasent pas le seuil ; une feature jamais active reste à `False`) ;
+3. `states_from_panel` encode chaque ligne binaire en un code d'état (bit-packing, ≤ 2^9 états possibles pour 9 features).
+
+Les 4 prompts d'un même jeu sont **concaténés** pour donner une trajectoire par jeu (~400-650 tokens). *Caveat assumé* : les 3 jointures de concaténation créent 3 transitions artificielles par trajectoire — négligeable devant les centaines de transitions réelles, et identique pour toutes les variantes comparées.
+
+La cellule applique aussi le **même panel entraîné au modèle-contrôle** : si la structure différentielle capturée par le panel est bien une propriété du modèle entraîné, elle doit *s'effondrer* sur le résiduel aux embeddings permutés.",,,,,,,,4aa7427a868c67dd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,b3bd45f5,code,fr,3a03d1050f8fc030,"def states_by_set(tr, panel):
+    panels = st.acts_topk_panels(tr, panel)
+    out = {}
+    for s in SETS:
+        dense = np.concatenate([panels[(s, i)] for i in range(4)])
+        out[s] = st.states_from_panel(st.binarize_quantile(dense))
+    return out
+
+states_tr = states_by_set(traces[""trained""], panel_final)
+states_ct_samepanel = states_by_set(traces[""control""], panel_final)
+
+mass_tr = sum(st.densify(e[""ids""], e[""vals""], panel_final).sum()
+              for e in traces[""trained""][""prompts""].values())
+mass_ct = sum(st.densify(e[""ids""], e[""vals""], panel_final).sum()
+              for e in traces[""control""][""prompts""].values())
+
+print(f""{'jeu':>13s} | {'T':>4s} | {'états (entraîné)':>16s} | {'états (contrôle, même panel)':>28s}"")
+for s in SETS:
+    print(f""{s:>13s} | {len(states_tr[s]):>4d} | {len(set(states_tr[s].tolist())):>16d} ""
+          f""| {len(set(states_ct_samepanel[s].tolist())):>28d}"")
+print(f""\nmasse d'activation du panel : entraîné = {mass_tr:.0f}, ""
+      f""contrôle = {mass_ct:.0f} (ratio {mass_tr / max(mass_ct, 1e-9):.1f}x)"")
+print(""=> lecture : la masse est comparable, mais la structure d'états s'effondre. ""
+      ""Le contrôle pousse encore de l'activation dans ces directions, sans la ""
+      ""différenciation temporelle/thématique qui crée les états : c'est la ""
+      ""STRUCTURE, pas la masse, qui est la propriété du modèle entraîné."")
+
+s_demo = ""code_python""
+p_tr = st.binarize_quantile(st.acts_topk_panels(traces[""trained""], panel_final)[(s_demo, 0)])
+p_ct = st.binarize_quantile(st.acts_topk_panels(traces[""control""], panel_final)[(s_demo, 0)])
+fig, axes = plt.subplots(2, 1, figsize=(9, 3.6), sharex=True)
+for ax, bits, title in ((axes[0], p_tr, ""entraîné""), (axes[1], p_ct, ""contrôle"")):
+    ax.imshow(bits.T, cmap=""Greys"", aspect=""auto"", interpolation=""nearest"")
+    ax.set_ylabel(title, fontsize=9)
+    ax.set_yticks(range(len(panel_final)))
+    ax.set_yticklabels([f""f{f}"" for f in panel_final], fontsize=6)
+axes[1].set_xlabel(f""tokens ({s_demo}, prompt 0)"")
+fig.suptitle(""Raster du panel binarisé : structure différenciée vs motif indifférencié"", fontsize=10)
+plt.tight_layout(); plt.show()",,,,,,,,3a03d1050f8fc030,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,09215c4d,markdown,fr,fa174c41af0a3bd9,"## Gate 11 — le substrat S4 est-il *valide* pour le banc ?
+
+Le gate ne demande pas encore un verdict scientifique — il demande la **plomberie** : (a) des comptes d'états/transitions dans la **plage traitable**, (b) `trajectory_battery` qui tourne, (c) un contraste `shuffled_baseline` **non dégénéré** (le contrôle shuffle produit des valeurs distinctes — sinon il ne contraint rien). S4 = le modèle *entraîné* muni du panel validé au Gate 10 : c'est lui qui entre au banc.
+
+**Et le modèle-contrôle ?** Analysé avec ses propres 10 features différentielles, son alphabet d'états **sature** (~200 états distincts sur ~400-650 tokens : un état quasi neuf à chaque pas — nous l'avons mesuré avant d'écrire cette cellule). Or le chemin d'échelles glouton de `emergent_complexity` a un coût qui explose avec la taille de l'alphabet : la batterie complète y est **intraitable par construction**, et c'est précisément le genre de fait que le critère (a) est chargé de détecter et de *rapporter* plutôt que de maquiller. On rapporte donc pour le contrôle : `n_states`/`n_transitions` (le constat de saturation) et un **contraste EI** (information effective, coût O(n²), sans le chemin glouton). La comparaison créditée à alphabet apparié est le travail du **Gate 12 d'ICT-22**.
+
+**Lecture honnête annoncée d'avance** : rien n'oblige les gains de S4 à être crédités ici — et ils ne le seront pas tous. Ce notebook établit que la machinerie tourne et que ses contrastes sont exploitables, pas que S4 « gagne ».",,,,,,,,fa174c41af0a3bd9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,12da90b4,code,fr,c21d1a1f1e007502,"from ict import causal_emergence as CE
+from ict import tpm_estimation as TE
+
+# --- S4 (modèle entraîné, panel Gate 10) : batterie complète + 3 gains, 20 shuffles
+rng = np.random.default_rng(42)
+report, degenerate = [], False
+for s in SETS:
+    seq = states_tr[s].tolist()
+    g = syn.emergence_gain(seq, rng, n_shuffles=20)
+    b = syn.trajectory_battery(seq)
+    degenerate |= abs(g[""ec_real""] - g[""ec_shuffled""]) < 1e-9
+    report.append((s, b[""n_states""], b[""n_transitions""], g[""ei_real""], g[""ec_real""],
+                   g[""ec_gain""], g[""fe_gain""], g[""k_gain""], g[""credited""]))
+
+print(""S4 = entraîné + panel Gate 10 (batterie complète, 20 shuffles) :"")
+print(f""{'jeu':>13s} | {'états':>5s} | {'trans':>5s} | {'EI':>5s} | {'EC':>5s} ""
+      f""| {'ec_gain':>7s} | {'fe_gain':>7s} | {'k_gain':>7s} | crédité"")
+for s, ns, nt, ei, ec, ecg, feg, kg, cred in report:
+    print(f""{s:>13s} | {ns:>5d} | {nt:>5d} | {ei:>5.2f} | {ec:>5.2f} ""
+          f""| {ecg:>+7.3f} | {feg:>+7.3f} | {kg:>+7.3f} | {cred}"")
+
+# --- Contrôle (son propre panel) : tractabilité + contraste EI (O(n²), sans EC glouton)
+panel_control = st.differential_features(traces[""control""], k=10)
+states_ct = states_by_set(traces[""control""], panel_control)
+print(""\nContrôle (panel propre) — saturation d'alphabet + contraste EI :"")
+print(f""{'jeu':>13s} | {'états':>5s} | {'trans':>5s} | {'EI réel':>7s} | {'EI shuffle (moy/5)':>18s}"")
+ei_degen = False
+for s in SETS:
+    seq = states_ct[s].tolist()
+    tpm, mapping = TE.tpm_from_trajectory(seq)
+    ei_real = CE.causal_profile(tpm)[""effective_information""]
+    eis = []
+    for _ in range(5):
+        tpm_s, _ = TE.tpm_from_trajectory(syn.shuffle_states(seq, rng))
+        eis.append(CE.causal_profile(tpm_s)[""effective_information""])
+    ei_degen |= abs(ei_real - np.mean(eis)) < 1e-9
+    print(f""{s:>13s} | {len(mapping):>5d} | {len(seq) - 1:>5d} | {ei_real:>7.3f} ""
+          f""| {np.mean(eis):>18.3f}"")
+
+max_states_s4 = max(r[1] for r in report)
+print(f""\n(a) tractabilité : S4 max n_states = {max_states_s4} (traitable) ; ""
+      ""contrôle ~200 états = alphabet saturé, rapporté tel quel (EC gloutonne hors plage)"")
+print(""(b) trajectory_battery : exécutée sur les 5 jeux de S4 sans erreur"")
+print(f""(c) contrastes shuffle non dégénérés : S4 ec {'NON' if degenerate else 'OK'}, ""
+      f""contrôle EI {'NON' if ei_degen else 'OK'}"")
+assert not degenerate and not ei_degen and max_states_s4 < 512
+print(""\n=> GATE 11 : PASS — substrat S4 prêt pour le banc. ""
+      ""Le verdict crédité multi-jeux appartient à ICT-22 (Gate 12)."")",,,,,,,,c21d1a1f1e007502,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,2890631f,markdown,fr,b5e6fca2f37ef004,"## Lecture honnête des résultats
+
+Trois choses sont établies, une ne l'est pas :
+
+1. **Le panel est réel** (Gate 10) : ses features re-tirent sur leurs concepts sur des prompts jamais vus, avec précision rapportée feature par feature — et celle qui ne se reproduisait pas a été éjectée, pas maquillée.
+2. **La structure est une propriété du modèle entraîné — et c'est la structure, pas la masse** : le même panel appliqué au modèle-contrôle garde une masse d'activation comparable (~1,3× d'écart seulement) mais son répertoire d'états s'effondre (39 → 8 sur le dialogue). Le résiduel permuté pousse encore de l'énergie dans ces directions ; ce qui disparaît, c'est la différenciation temporelle et thématique qui fabrique des états distincts. Ce n'est pas un artefact de la binarisation ou du bit-packing — identiques des deux côtés.
+3. **La machinerie du banc tourne sur S4** (Gate 11) : TPM traitables, batterie complète sur les 5 jeux, contrastes shuffle exploitables, les trois gains (ec/fe/k) calculés. Et un fait de tractabilité rapporté sans fard : le contrôle, mesuré avec son propre panel, **sature son alphabet d'états** (~200 états distincts, un quasi-nouveau par token) — régime quasi sans mémoire où le chemin d'échelles glouton de l'EC devient intraitable, exactement ce que le critère (a) du gate est chargé de détecter.
+4. **Non établi ici** : que S4 présente une complexité intégrée *créditée*. Les `ec_gain` de S4 sont faibles voire négatifs — le shuffle fait parfois aussi bien que la trajectoire réelle sur cette métrique, à cette échelle, avec ce panel. C'est exactement le genre de résultat que la discipline de créditation de la série est faite pour ne pas enjoliver : la question du verdict revient à ICT-22 (Gate 12), avec ses ≥5 jeux de prompts et sa double comparaison shuffle **et** modèle-contrôle à alphabet apparié.",,,,,,,,b5e6fca2f37ef004,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,0913785c,markdown,fr,9f59a203d7d96561,"## Exercice 1 — la taille du panel change-t-elle le verdict ?
+
+Le panel de ~9 features est un choix, pas une loi. Un panel plus petit (5) fusionne des états distincts ; un plus grand (15) fragmente la trajectoire en états rares que la TPM n'estime plus bien.
+
+**Objectif** : rejouer la chaîne panel → états → `emergence_gain` pour des panels de taille 5, 10 et 15, et comparer `n_states` et `ec_gain` sur deux jeux de votre choix.
+
+*Indices* : `st.differential_features(train, k=taille)` pour la sélection ; réutilisez `states_by_set` ; gardez `rng = np.random.default_rng(42)` pour la reproductibilité.",,,,,,,,9f59a203d7d96561,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,ebd2945f,code,fr,39b105a4d3795c8f,"# Exercice 1 : effet de la taille du panel
+# TODO étudiant :
+#  - Étape 1 : pour taille in (5, 10, 15), sélectionner un panel sur `train`
+#  - Étape 2 : construire les états par jeu (states_by_set) sur le modèle entraîné
+#  - Étape 3 : emergence_gain (n_shuffles=20, graine 42) sur 2 jeux, comparer
+#              n_states et ec_gain dans un petit tableau
+resultats_ex1 = None  # TODO étudiant
+print(""Exercice à compléter"")",,,,,,,,39b105a4d3795c8f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,b4e6643c,markdown,fr,d2d3ee88d8d34759,"## Exercice 2 — binarisation : quantile vs seuil fixe
+
+`binarize_quantile` seuille chaque feature à la médiane de ses valeurs **positives** (q=0,5). Ce choix est robuste aux échelles très différentes des features, mais il impose ~50 % d'occupation à chaque feature active.
+
+**Objectif** : comparer q ∈ {0,25 ; 0,5 ; 0,75} et un seuil fixe global (par exemple `dense > 1.0`) sur la trajectoire `code_python` du modèle entraîné : nombre d'états, EC réel, `ec_gain`.
+
+*Indices* : le seuil fixe s'écrit en une ligne numpy (`dense > seuil`) puis `st.states_from_panel` ; attention, avec q=0,75 certaines features deviennent presque muettes — regardez `n_states` avant d'interpréter le gain.",,,,,,,,d2d3ee88d8d34759,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,8a630eaf,code,fr,5397b33fa559756f,"# Exercice 2 : sensibilité à la binarisation
+# TODO étudiant :
+#  - Étape 1 : densifier le panel final sur code_python (4 prompts concaténés)
+#  - Étape 2 : binariser avec q=0.25, 0.5, 0.75 puis avec un seuil fixe
+#  - Étape 3 : pour chaque variante, états -> emergence_gain -> tableau comparatif
+resultats_ex2 = None  # TODO étudiant
+print(""Exercice à compléter"")",,,,,,,,5397b33fa559756f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,d823c64a,markdown,fr,694104d743cc97e9,"## Exercice 3 — une autre couche du flux résiduel (GPU requis)
+
+La couche 16 (sur 32) est un choix médian classique : assez profonde pour des concepts abstraits, assez loin de la sortie pour ne pas être dominée par la prédiction du prochain token. Qwen-Scope publie des SAE pour d'autres couches.
+
+**Objectif** : extraire les traces de la couche 8 (ou 24) et comparer le panel différentiel obtenu à celui de la couche 16 (recouvrement des features ? sélectivités comparables ?).
+
+*Indices* : tout passe par le script CLI — aucune modification de code n'est nécessaire :
+```bash
+CUDA_VISIBLE_DEVICES=2 python scripts/extract_sae_traces.py --stage full --variant trained --layer 8
+```
+puis `st.load_traces(""traces/ict21_sae_layer8_trained.npz"")`. Sans GPU, cet exercice reste au stade du plan d'analyse : écrivez le code qui *consommerait* les traces.",,,,,,,,694104d743cc97e9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,6b8bb9d6,code,fr,3457cd475f27e8d3,"# Exercice 3 : comparaison inter-couches (GPU requis pour l'extraction)
+# TODO étudiant :
+#  - Étape 1 : extraire la couche 8 via le script CLI (voir markdown ci-dessus)
+#  - Étape 2 : charger les deux npz, sélectionner un panel par couche (held-out !)
+#  - Étape 3 : mesurer le recouvrement des panels et comparer les sélectivités
+recouvrement_couches = None  # TODO étudiant
+print(""Exercice à compléter"")",,,,,,,,3457cd475f27e8d3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,c1b465d0,markdown,fr,8f04fe2f2267e2f7,"## Conclusion
+
+Ce notebook a fait entrer un transformer réel dans le banc de la série, sans en trahir les règles :
+
+- **Gate 10 : PASS.** Panel de features différentielles sélectionné sur 12 prompts, vérifié sur 5 prompts held-out, précision rapportée par feature ; la feature non reproductible est sortie du panel, documentée.
+- **Gate 11 : PASS.** États et transitions de S4 traitables sur les 5 jeux, batterie complète exécutée, contrastes shuffle non dégénérés (EC sur S4, EI sur le contrôle) ; la saturation d'alphabet du contrôle est rapportée comme fait de tractabilité : **S4 est prêt pour le banc**.
+- **Livrables durables** : `traces/ict21_sae_layer16_{trained,control}.npz` (~0,5 Mio chacun, sparse exhaustif — le schéma `acts_topk` K≈64 amendé de #5101 s'en dérive exactement, et le hook de clamp du Gate 24 de #5635 reste possible), `ict/sae_traces.py` (numpy-only, 8 tests), `scripts/extract_sae_traces.py` (GPU confiné).
+- **Ce qui n'est pas revendiqué** : un verdict de complexité intégrée créditée sur S4 — c'est ICT-22 (#5102, Gate 12) ; et toute lecture *workspace/ignition* — c'est ICT-24 (#5635, Gates 22-24), qui consommera ces mêmes traces.
+
+La série tient sa ligne : le GPU est un fournisseur de traces, le banc reste numpy-only, et chaque claim passe par un contrôle avant d'être crédité.",,,,,,,,8f04fe2f2267e2f7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb,c227b62f,markdown,fr,abeab2e540341603,"## Références
+
+- **Qwen-Scope** : *Scaling Sparse Autoencoders on Qwen3.5* (arXiv:2605.11887) — SAE résiduels top-k publiés pour Qwen3.5-9B-Base (65 536 features, L0_50), convention d'encodage reprise ici.
+- **Anthropic** : *A Global Workspace in Claude?* (anthropic.com/research/global-workspace) — J-space jacobien, broadcast structurel, ablation sélective ; voir les garde-fous en tête de notebook.
+- **S. Dehaene** : *Consciousness and the Brain* (2014) — global neuronal workspace, ignition ; cadre théorique de la lecture temporelle qu'ICT-24 instrumentera.
+- **E. Hoel et al.** : *Quantifying causal emergence* (PNAS 2013) — l'émergence causale macro > micro qui fonde `ec_gain`.
+- **Série ICT** : Epic #4588 ; ce notebook = #5101 ; aval : #5102 (ICT-22), #5635 (ICT-24).",,,,,,,,abeab2e540341603,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c01,markdown,fr,4e19dac7a663b4f0,"# ICT-22 — LLMSubstrat : le transformer comme quatrième substrat du banc cross-substrat
+
+*Part of #4588 (strate 5). See #5102. Dépend de #5090 (trois scalaires) + #5101 (traces SAE .npz d'ICT-21).*
+
+Le banc cross-substrat (ICT-Synthèse, #4946) applique une **même batterie** d'émergence causale et son **contrôle sans complaisance** (shuffle) à trois substrats radicalement différents : le tri auto-organisé (S1), le paysage bistable (S2), le réplicateur stratégique (S3). Aucun scalaire d'intégration ne les ordonne tous : l'invariant de la série n'est pas un nombre, c'est une **méthode**.
+
+ICT-22 pose la question fondatrice à l'objet qui a motivé toute la théorie de l'émergence causale : **un transformer qui traite du texte** montre-t-il une émergence causale créditée — au-dessus de SES contrôles ? C'est le substrat S4. Et parce que c'est un LLM, on exige un **double contrôle** plus dur que pour S1-S3 :
+
+1. **shuffle** (contrôle temporel, existant) — détruit l'ordre des états, préserve les marginales ;
+2. **modèle contrôle** (traces #5101) — poids aléatoires / embeddings permutés, mêmes prompts, même pipeline : détruit le **calcul**, préserve l'**architecture d'extraction**.
+
+Crédit exigé au-dessus des **deux**. C'est le **Gate 12**. Et l'on rejoue le **Gate 13** (convergence revisitée) avec S4 inclus : le LLM renforce-t-il ou casse-t-il le verdict « pas de scalaire universel » ?
+",,,,,,,,4e19dac7a663b4f0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c02,markdown,fr,4cee4b4481b122b6,"## Architecture du pipeline : le GPU confiné, le banc numpy-only
+
+ICT-22 **ne touche jamais au GPU**. Il consomme les traces SAE top-k déjà committées par ICT-21 (`traces/ict21_sae_layer16_{trained,control}.npz`, sur `main` depuis #5643) — un `.npz` sparse par variante, ~500 Kio chacune. Le pipeline est entièrement numpy :
+
+> `.npz` → `sae_traces.load_traces` → `differential_features` (sélection sur `trained`, **panel figé**) → `acts_topk_panels` → `binarize_quantile` → `states_from_panel` → trajectoire d'états discrets → `synthesis.emergence_gain` (batterie + contrôles).
+
+Le **même panel** (les mêmes features différentielles, sélectionnées sur la variante entraîné) est appliqué à la variante `control` : c'est le même capteur pour les deux poids. Le crédit n'est accordé que si le modèle entraîné bat **les deux** contrôles — shuffle (temporel) et modèle-contrôle (calculatoire).
+",,,,,,,,4cee4b4481b122b6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c03,code,fr,29075b0b93a8a239,"import sys, os
+from pathlib import Path
+sys.path.insert(0, os.getcwd())
+
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+%matplotlib inline
+
+from ict import synthesis as S
+from ict import sae_traces as st
+
+# --- traces SAE committées (GPU-free, #5101/#5643) ---
+NPZ = {
+    ""trained"": Path(""traces/ict21_sae_layer16_trained.npz""),
+    ""control"": Path(""traces/ict21_sae_layer16_control.npz""),
+}
+K_PANEL = 4          # panel grossier (cf. docstring synthesis : greedy_apportionment est O(k^2))
+N_SHUF = 20          # controle shuffle par jeu de prompts
+SEED0 = 0            # graine representative (le multi-jeux tient lieu de multi-graines)
+print(""pipeline numpy-only, traces :"", {v: p.stat().st_size // 2**10 for v, p in NPZ.items()}, ""Kio"")
+",,,,,,,,29075b0b93a8a239,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c04,markdown,fr,ab30fc24123b1a43,"## Chargement et sanité : le schéma, le L0, les jeux de prompts
+
+Premier contact numpy-only. Les traces exposent 5 jeux de prompts (4 prompts chacun) couvrant des **domaines** différents — code Python, prose française, dialogue, mathématiques, récit anglais. C'est ce panel de jeux qui servira de **multi-graines** au Gate 12 : la variabilité inter-domaine tient lieu de variabilité de graines (on n'a pas ré-entraîné le SAE 5 fois, on mesure la robustesse du verdict à travers 5 corpus distincts).
+",,,,,,,,ab30fc24123b1a43,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c05,code,fr,d3c79b9ba66e3872,"traces = {v: st.load_traces(p) for v, p in NPZ.items()}
+SETS = sorted({s for s, _ in traces[""trained""][""prompts""]})
+for v, tr in traces.items():
+    n_tok = sum(e[""ids""].shape[0] for e in tr[""prompts""].values())
+    l0 = np.mean([(e[""vals""] > 0).sum(axis=1).mean() for e in tr[""prompts""].values()])
+    m = tr[""meta""]
+    print(f""[{v:8s}] {len(tr['prompts'])} prompts | {n_tok} tokens | ""
+          f""L0 moyen = {l0:.1f}/{m['k']} | d_sae = {m['d_sae']} | variant = {m['variant']}"")
+print(""jeux de prompts (multi-graines du Gate 12) :"", SETS)
+",,,,,,,,d3c79b9ba66e3872,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c06,markdown,fr,10af62919d0d8930,"## Sélection différentielle : la variance inter-jeux, pas l'amplitude
+
+On sélectionne le **panel figé** sur la variante `trained` : les `K_PANEL` features de plus forte **variance inter-jeux** de l'activation moyenne (`sae_traces.differential_features`). On écarte ainsi les features toujours actives (fortes en valeur absolue mais non informatives) au profit de celles qui **discriminent les domaines** — exactement le capteur que l'on veut pour qu'une structure temporelle, si elle existe, s'inscrive dans les transitions d'états. Ce panel est ensuite **figé** et appliqué tel quel à la variante `control`.
+",,,,,,,,10af62919d0d8930,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c07,code,fr,72478a739a2c041f,"panel = st.differential_features(traces[""trained""], k=K_PANEL)
+print(f""panel figé (K={K_PANEL}, sélection sur trained) : features {panel.tolist()}"")
+# sanity : le panel est-il bien différentiel sur trained ET sur control (mêmes features) ?
+for v, tr in traces.items():
+    means = st.mean_activation_by_set(tr)
+    stack = np.stack([means[s] for s in SETS])
+    var_on_panel = stack.var(axis=0)[panel]
+    print(f""  [{v:8s}] variance inter-jeux du panel : {np.round(var_on_panel, 2)}"")
+",,,,,,,,72478a739a2c041f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c08,markdown,fr,476b277252c57e21,"## Du panel à la trajectoire S4 : discrétisation grossière
+
+Le helper additif `synthesis.sae_substrate_states` materialise le panel dense, le binarise au quantile des valeurs positives, et encode chaque token en un état entier par bit-packing. La trajectoire **per-jeu** (un jeu de prompts à la fois) est l'unité du Gate 12. Le coarse-graining est volontairement **grossier** (K=4 → au plus 16 états possibles, ~7 observés) : c'est la condition pour que l'estimation de TPM et le chemin d'échelles restent tractables et comparables aux macro-états de S1/S2/S3.
+",,,,,,,,476b277252c57e21,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c09,code,fr,fe737ffdc13ace3a,"s4_demo = S.sae_substrate_states(NPZ[""trained""], panel, sets=[SETS[0]])
+print(f""S4 démonstration (trained, jeu {SETS[0]!r}) : ""
+      f""longueur={len(s4_demo)} états distincts={len(set(s4_demo))}"")
+print(f""  états observés : {sorted(set(s4_demo))}"")
+print(f""  (bit-packing sur K={K_PANEL} features → au plus {2**K_PANEL} états possibles)"")
+",,,,,,,,fe737ffdc13ace3a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c10,markdown,fr,7c2de2423e90856d,"## Gate 12 — émergence créditée sur S4, double contrôle
+
+Pour chacun des 5 jeux de prompts (multi-jeux = multi-graines), on mesure trois gains — `ec_gain` (émergence causale), `fe_gain` (surprise transitionnelle), `k_gain` (compression MDL) — chacun contrasté à **deux** contrôles :
+
+- **vs shuffle** : le gain tel que retourné par `emergence_gain` (mesure réelle moins moyenne des permutations ; `credited` = au-dessus du bruit du réservoir d'états) ;
+- **vs modèle contrôle** : le gain du modèle entraîné moins le gain du modèle contrôle (*même panel, mêmes prompts, poids permutés*) — isole la part qui vient du **calcul appris** plutôt que de l'architecture d'extraction.
+
+Verdict crédité = la ligne bat **les deux** contrôles. Un verdict négatif honnête (le panel binarisé ne porte pas de structure temporelle créditée de façon robuste) est un résultat en soi — il interroge alors le niveau de description (cf. #5100 : les états causaux de S4 sont-ils plus fins que le panel ?).
+",,,,,,,,7c2de2423e90856d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c11,code,fr,aa77a1352dd66d8c,"rng = np.random.default_rng(SEED0)
+rows = []
+for s in SETS:
+    s4_tr = S.sae_substrate_states(NPZ[""trained""], panel, sets=[s])
+    s4_ct = S.sae_substrate_states(NPZ[""control""], panel, sets=[s])
+    g_tr = S.emergence_gain(s4_tr, rng, n_shuffles=N_SHUF)
+    g_ct = S.emergence_gain(s4_ct, rng, n_shuffles=N_SHUF)
+    # double contrôle : vs shuffle (g_tr['*_gain']) ET vs modèle contrôle (diff des réels)
+    rows.append({
+        ""set"": s,
+        ""ec_vs_shuf"": g_tr[""ec_gain""],   ""ec_cred"": g_tr[""credited""],   ""ec_vs_ctl"": g_tr[""ec_real""] - g_ct[""ec_real""],
+        ""fe_vs_shuf"": g_tr[""fe_gain""],                                  ""fe_vs_ctl"": g_tr[""fe_gain""] - g_ct[""fe_gain""],
+        ""k_vs_shuf"":  g_tr[""k_gain""],                                   ""k_vs_ctl"":  g_tr[""k_gain""]  - g_ct[""k_gain""],
+    })
+
+print(f""{'jeu':14s} | {'ec_gain':>8s} {'cred':>5s} {'ec_vs_ctl':>9s} | {'fe_gain':>8s} {'fe_vs_ctl':>9s} | {'k_gain':>8s} {'k_vs_ctl':>8s}"")
+print(""-"" * 95)
+for r in rows:
+    print(f""{r['set']:14s} | {r['ec_vs_shuf']:8.3f} {str(r['ec_cred']):>5s} {r['ec_vs_ctl']:9.3f} | ""
+          f""{r['fe_vs_shuf']:8.3f} {r['fe_vs_ctl']:9.3f} | {r['k_vs_shuf']:8.3f} {r['k_vs_ctl']:8.3f}"")
+
+# synthesis visuelle : les trois gains vs modèle contrôle, par jeu
+fig, ax = plt.subplots(figsize=(8, 3.2))
+x = np.arange(len(SETS))
+w = 0.27
+ax.bar(x - w, [r[""ec_vs_ctl""] for r in rows], w, label=""ec_vs_ contrôle"")
+ax.bar(x,     [r[""fe_vs_ctl""] for r in rows], w, label=""fe_vs_ contrôle"")
+ax.bar(x + w, [r[""k_vs_ctl""]  for r in rows], w, label=""k_vs_ contrôle"")
+ax.axhline(0.0, color=""k"", lw=0.8)
+ax.set_xticks(x); ax.set_xticklabels(SETS, rotation=20, ha=""right"")
+ax.set_ylabel(""gain entraîné − gain contrôle"")
+ax.set_title(""Gate 12 — S4 : le modèle entraîné bat-il le modèle contrôle ?"")
+ax.legend(fontsize=8, loc=""upper right"")
+fig.tight_layout()
+plt.show()
+",,,,,,,,aa77a1352dd66d8c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c12,markdown,fr,87c41fecd70579bb,"## Lecture honnête de Gate 12
+
+Le verdict est **nuancé et majoritairement négatif**, et c'est un résultat en soi :
+
+- **vs shuffle** : `ec_gain` n'est crédité (`credited=True`) que sur une partie des jeux — la structure temporelle du panel binarisé n'est pas systématiquement au-dessus du bruit du réservoir d'états. `fe_gain` (surprise) est en revanche positive sur les 5 jeux : le panel porte bien une régularité transitionnelle, même quand l'émergence causale multi-échelles ne décolle pas.
+- **vs modèle contrôle** : la différence de gains entre entraîné et contrôle **change de signe selon le jeu**. Le modèle entraîné ne bat donc pas robustement le modèle à poids permutés sur ce panel coarse. Ce n'est pas un échec de la méthode : c'est l'indication que, **à ce niveau de description** (4 features binarisées), la structure temporelle créditée n'est pas porteuse — elle renvoie à la question #5100 (les états causaux d'un transformer sont-ils plus fins que ce panel macro ?).
+
+L'honnêteté du négatif est un livrable aussi précieux qu'un PASS : elle borne ce que le banc peut créditer à ce niveau de description, et motive un raffinement du panel (cf. exercices).
+",,,,,,,,87c41fecd70579bb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c13,markdown,fr,1c67a1330b3da7ff,"## Gate 13 — la convergence revisitée à quatre substrats
+
+On rejoue le Gate 4 de #5090 (τ de Kendall par paire sur les gains) en ajoutant S4 au banc. Les trois substrats existants (S1 tri, S2 bistable, S3 réplicateur) sont instanciés avec la même graine représentative ; S4 est la trajectoire du jeu le plus crédité (démonstration). La question : le LLM renforce-t-il (τ → +1) ou casse-t-il (τ → 0 / signe changeant) le verdict de convergence Φ/F/K ?
+",,,,,,,,1c67a1330b3da7ff,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c14,code,fr,da9a449d58b115e0,"from ict import sorting_metrics as sm
+from ict.self_sorting import SelfSortingArray
+from ict.bistable import GrazingModel
+from ict import strategic_morphodynamics as SM
+
+def traj_S1(seed, n_runs=6, max_steps=1500):
+    states = []
+    for r in range(n_runs):
+        rng = np.random.default_rng(seed + r)
+        arr = SelfSortingArray(list(rng.permutation(6)), seed=seed + r)
+        arr.run(max_steps=max_steps, record=True)
+        states.extend(sm.inversion_count(c) for c in arr.probe.values)
+    return states
+
+def traj_S2(seed, T=1500):
+    gm = GrazingModel()
+    c = 0.92 * gm.find_fold()
+    xs = gm.simulate_sde(c=c, x0=8.0, sigma=0.55, dt=0.02, T=T, seed=seed)
+    lo, hi = np.percentile(xs, 1), np.percentile(xs, 99)
+    bins = np.linspace(lo, hi, 11)
+    return [int(v) for v in np.clip(np.digitize(xs, bins), 1, 10)]
+
+def traj_S3(seed, n_runs=10, n_steps=300):
+    rng = np.random.default_rng(seed)
+    strat = SM.make_strategies(rng)
+    A = SM.payoff_matrix(strat, rng=rng)
+    states = []
+    for _ in range(n_runs):
+        x0 = rng.dirichlet(np.ones(len(strat)))
+        traj = SM.replicator_trajectory(A, x0, n_steps=n_steps)
+        states.extend(int(np.argmax(row)) for row in traj)
+    return states
+
+rng = np.random.default_rng(SEED0)
+s4_gate13 = S.sae_substrate_states(NPZ[""trained""], panel, sets=[SETS[0]])
+subs = {""S1_tri"": traj_S1(SEED0), ""S2_bistable"": traj_S2(SEED0),
+        ""S3_replicateur"": traj_S3(SEED0), ""S4_LLM"": s4_gate13}
+summary = S.cross_substrate_summary(subs, rng, n_shuffles=N_SHUF)
+print(""banc cross-substrat à 4 substrats :"")
+print(f""{'substrat':16s} | {'ec_gain':>8s} {'fe_gain':>8s} {'k_gain':>8s}"")
+for n, d in summary.items():
+    print(f""{n:16s} | {d['ec_gain']:8.3f} {d['fe_gain']:8.3f} {d['k_gain']:8.3f}"")
+print(""\nτ de Kendall par paire (Gate 13) :"")
+for ka, kb in [(""ec_gain"", ""fe_gain""), (""ec_gain"", ""k_gain""), (""fe_gain"", ""k_gain"")]:
+    rc = S.rank_consistency(summary, key_a=ka, key_b=kb)
+    print(f""  τ({ka}, {kb}) = {rc['kendall_tau']:+.3f}  (consistent={rc['consistent']})"")
+",,,,,,,,da9a449d58b115e0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c15,markdown,fr,58ae4e09e038f6f1,"## Lecture de Gate 13
+
+Le LLM **ne casse pas** le verdict de convergence : il le **renforce**. S4 affiche le `ec_gain` le plus bas du banc (le transformer, à ce niveau de description coarse, est le substrat le *moins* émergent au sens multi-échelles), et les τ de Kendall par paire restent éloignés de +1 — aucun scalaire n'ordonne les quatre substrats de façon cohérente. La conclusion d'ICT-Synthèse tient avec un quatrième substrat : **l'invariant n'est pas un nombre, c'est une méthode** (une émergence n'est créditée que contrastée à son contrôle). L'ajout du LLM — l'objet qui a motivé la théorie — ne produit pas de scalaire universel non plus.
+",,,,,,,,58ae4e09e038f6f1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c16,markdown,fr,44117ecfc5add6ea,"## Exercice 1 — effet domaine : code vs prose
+
+Le verdict Gate 12 varie-t-il systématiquement avec le **domaine** du prompt ? On a 5 jeux (code Python, prose FR, dialogue, math, récit EN). Comparez le sous-banc `code_python` vs `prose_fr` : pour `ec_gain` et `fe_gain`, le code (structure syntaxique forte) porte-t-il plus de structure temporelle créditée que la prose ? *Indice : `S.sae_substrate_states(NPZ[""trained""], panel, sets=[...])` puis `S.emergence_gain(...)` par domaine ; comparez aussi le `n_states` observé.*
+",,,,,,,,44117ecfc5add6ea,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c17,code,fr,26a0aa074a820746,"# Exercice 1 — à compléter
+# Comparez ec_gain/fe_gain et n_states entre code_python et prose_fr.
+# domaine = {""code"": ""code_python"", ""prose"": ""prose_fr""}
+# for nom, jeu in domaine.items():
+#     s4 = S.sae_substrate_states(NPZ[""trained""], panel, sets=[jeu])
+#     g  = S.emergence_gain(s4, np.random.default_rng(0), n_shuffles=N_SHUF)
+#     print(f""{nom}: ec_gain={g['ec_gain']:.3f} fe_gain={g['fe_gain']:.3f} n_states={g['n_states']}"")
+print(""Exercice 1 — à compléter : effet domaine (code vs prose) sur ec_gain / fe_gain / n_states"")
+",,,,,,,,26a0aa074a820746,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c18,markdown,fr,02dfdd1b184182c2,"## Exercice 2 — effet longueur de contexte sur les gains
+
+Jusqu'où faut-il concaténer de tokens pour qu'une structure temporelle crédée émerge ? On a ~130 tokens par prompt, 4 prompts par jeu. Concaténez 1, 2, 3 puis 4 prompts d'un même jeu et tracez `ec_gain` et `fe_gain` en fonction de la longueur. *Indice : `sae_substrate_states` accepte `sets=[s]` (tous les prompts du jeu) ; pour sous-échantillonner, reconstruisez la trajectoire en restreignant `acts_topk_panels` aux premiers `i` prompts.*
+",,,,,,,,02dfdd1b184182c2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c19,code,fr,ff4a474d4cc9634c,"# Exercice 2 — à compléter
+# Tracez ec_gain et fe_gain vs nombre de prompts concaténés (1..4) sur un jeu.
+# panels = st.acts_topk_panels(traces[""trained""], panel)
+# for n_prompts in range(1, 5):
+#     # concaténer les n_prompts premiers prompts du jeu SETS[0]
+#     # ... binariser -> états -> emergence_gain ...
+#     pass
+print(""Exercice 2 — à compléter : ec_gain / fe_gain vs longueur de contexte (1..4 prompts)"")
+",,,,,,,,ff4a474d4cc9634c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c20,markdown,fr,87fd68bd58263d15,"## Exercice 3 — états causaux de #5100 appliqués à S4
+
+Le verdict négatif de Gate 12 interroge le **niveau de description** (#5100). La complexité statistique $C_\mu$ d'un transformer — le nombre d'états causaux (ε-machine) de sa dynamique d'activation — est-elle plus fine que le panel binarisé à 4 features ? Estimez l'ε-machine de la trajectoire S4 (`ict.epsilon_machine`) et comparez sa $C_\mu$ au nombre d'états observés du panel. *Indice : si $C_\mu$ ≫ états du panel, le panéage coarse moyenne des états causaux distincts — c'est la piste pour un raffinement.*
+",,,,,,,,87fd68bd58263d15,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c21,code,fr,f4dbc66f48af04dd,"# Exercice 3 — à compléter
+# Estimez C_mu (epsilon_machine) de la trajectoire S4 et comparez aux états du panel.
+# from ict import epsilon_machine as EM
+# s4 = S.sae_substrate_states(NPZ[""trained""], panel, sets=[SETS[0]])
+# # emu = EM.from_trajectory(s4)  # ou API disponible dans epsilon_machine.py
+# # print(""C_mu ="", emu[...], ""vs"", len(set(s4)), ""états panel"")
+print(""Exercice 3 — à compléter : C_mu (epsilon-machine) de S4 vs états du panel coarse"")
+",,,,,,,,f4dbc66f48af04dd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-22-LLMSubstrat.ipynb,ict22-c22,markdown,fr,d480675f984e5e06,"## Conclusion
+
+ICT-22 fait entrer le transformer au banc cross-substrat — le quatrième substrat, et l'objet même qui a motivé la théorie de l'émergence causale. Deux gates falsifiables, deux verdicts honnêtes :
+
+- **Gate 12** : à ce niveau de description (panel coarse de features différentielles binarisées), l'émergence causale créditée n'est **pas robuste** — `ec_gain` n'est crédité vs shuffle que sur une partie des jeux, et le modèle entraîné ne bat pas systématiquement le modèle à poids permutés. `fe_gain` (surprise transitionnelle) est en revanche positive sur les 5 jeux : le panel porte une régularité, mais elle ne décolle pas en émergence multi-échelles. Ce négatif borne le banc et renvoie à #5100 (états causaux plus fins).
+- **Gate 13** : le LLM **renforce** le verdict de convergence — aucun scalaire n'ordonne les quatre substrats (τ de Kendall éloignés de +1 sur toutes les paires). L'invariant de la série tient : une méthode, pas un nombre.
+
+Le négatif honnête est un livrable : il dit où le banc s'arrête à ce niveau de description, et ouvre la question du raffinement — matière aux exercices et à la suite ICT.
+",,,,,,,,d480675f984e5e06,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,c7fd56f9,markdown,fr,aaab313f07283f5e,"# ICT-23 — PersonaCatastrophe : la fronce de Thom appliquee au desalignement emergent
+
+**Capstone strate 5 — Epic #4588 / #5104 (Partie 1 CPU-only).**
+
+Ce notebook est le **micro-analogue** des phenomenes Anthropic
+(*Inoculation Prompting*, novembre 2025, [arXiv:2511.18397](https://arxiv.org/abs/2511.18397))
+et OpenAI (*Persona Features*, juin 2025, [arXiv:2506.19823](https://arxiv.org/abs/2506.19823))
+traduit dans le langage de la theorie des catastrophes de Rene Thom
+(1972). Le substrat est un **agent** (un LLM) dont l'identite `p`
+(appelee *persona*) est un parametre d'ordre soumis a deux controles
+anthropiques :
+
+* **facteur de division** `b` = pression de recompense `r`. C'est la
+  variable qu'on balaie : un sous-systeme d'entrainement peut
+  *recompenser* le comportement `b -> +inf` (recompense la persona
+  emergente) ou `b -> -inf` (recompense l'identite alignee).
+* **facteur normal** `a` = `-(transgression cumulee) * (charge semantique)`.
+  C'est **negatif** quand la transgression ponderee par l'interdit
+  subjectif (la ""charge semantique"" du tabou) depasse un seuil ;
+  **positif** sinon (inoculation explicite, permission forte, ou
+  charge `s -> 0`).
+
+Le potentiel reste celui de Thom, inchange depuis ICT-10 :
+
+    V(p ; a, b) = p^4 / 4  +  a p^2 / 2  +  b p
+
+mais sa **lecture semantique** change : `p` est l'intensite de la persona
+desalignee, signee ; `p = 0` = identite alignee, `p` grand et positif =
+persona toxique adoptee. `a` regit la **bistabilite** (les deux
+identites sont-elles co-existantes ?) ; `b` regit l'**asymetrie** entre
+les deux bassins (vers lequel la recompense pousse-t-elle ?).",,,,,,,,aaab313f07283f5e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,1f87b9f8,markdown,fr,bc6fdb1bbc831e4b,"## Plan
+
+1. **Trois jambes explicatives** : Thom (fronce), Friston (energie
+   libre), Schmidhuber (MDL) -- pourquoi la theorie des catastrophes
+   est le bon cadre.
+2. **Le potentiel fronce, parametrage semantique** : `a =
+   -transgression * charge`, `b = recompense`. La prediction P0
+   (inoculation = aplatissement).
+3. **Gates 16-17** : figures du pli et de l'hysteresis sous inoculation
+   partielle / totale, signature `N_catastrophes(charge)`.
+4. **EWS Wissel/Scheffer** : variance et AR1 d'une trajectoire SDE sous
+   bruit ; difference bistable vs monostable.
+5. **Trois exercices** : (a) forme V alternative ; (b) balayage continu
+   de la charge semantique ; (c) ""permission vague"" comme inoculation
+   degradee.
+6. **Cellule frontiere** : ce que le modele capture -- et ce qu'il ne
+   capture pas (in-context learning, corr vs causation, ICT-22).
+7. **Continuite** : le grim trigger d'ICT-13 retrouve ici comme
+   bascule sous bifurcation fourche.",,,,,,,,bc6fdb1bbc831e4b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,cea3e132,markdown,fr,5ba2c6f0763984c5,"## 1. Trois jambes explicatives
+
+Pourquoi une **catastrophe fronce** (Thom 1972) plutot qu'une simple
+equation logistique ?
+
+1. **Thom (fronce)** : la theorie des catastrophes elementaires
+   classifie les singularites lisses d'un potentiel `V` en fonction du
+   nombre de variables d'etat et de controles. Avec une variable d'etat
+   `p` et deux controles `(a, b)`, c'est la **fronce** (*cusp*). C'est
+   la forme minimale qui produit a la fois bistabilite, hysteresis, et
+   sensibilite aux conditions initiales -- les trois signatures du
+   desalignement emergent.
+
+2. **Friston (energie libre)** : la dynamique `dp/dt = -dV/dp` est
+   exactement une descente de gradient sur un potentiel. C'est
+   l'**energie libre** au sens de Friston : l'agent minimise
+   structurellement une fonction de cout. Si on interprete `V(p)` comme
+   l'energie libre de la *persona*, l'agent *veut* minimiser son
+   cout -- mais le paysage `V` lui-meme est controle par les facteurs
+   `a, b`.
+
+3. **Schmidhuber (MDL)** : la *longueur de description minimale* (MDL,
+   Rissanen 1978 ; Li & Vitanyi ; Schmidhuber) dit que la meilleure
+   compression d'un flux de bits est celle qui produit le plus petit
+   programme. Ici la fronce produit un comportement **compressible**
+   en presence d'inoculation : un seul bassin (un seul mode), donc une
+   description courte. Sans inoculation, deux bassins, donc la
+   description doit inclure le bit ""bassin courant"" -> plus long.
+
+**Consequence testable** : sous inoculation `s -> 0`, le paysage `V`
+s'aplatit, la bistabilite disparait, et la complexite (MDL) du
+comportement doit chuter.",,,,,,,,5ba2c6f0763984c5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,b3534962,code,fr,0c1b30113bc92c75,"import sys
+sys.path.insert(0, '.')
+
+import numpy as np
+import matplotlib.pyplot as plt
+from ict.persona_cusp import (
+    persona_potential, persona_force, persona_a_factor,
+    in_persona_bistable_region, inoculation_check,
+    relax_persona, persona_hysteresis_loop,
+    persona_catastrophe_indices, persona_sde,
+    ews_summary_persona, inoculation_signature,
+)
+
+plt.rcParams['figure.figsize'] = (10, 4)
+plt.rcParams['figure.dpi'] = 90
+print('Setup OK : module persona_cusp charge.')",,,,,,,,0c1b30113bc92c75,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,18bb47db,markdown,fr,515cb9ef7bc940c6,"## 2. Le potentiel fronce, parametrage semantique
+
+Reprenons la fronce de Thom dans sa forme classique :
+
+    V(p ; a, b) = p^4 / 4  +  a p^2 / 2  +  b p
+
+En notant `T = transgression cumulee` (>= 0) et `s = charge semantique
+subjective` (>= 0), on definit les deux **facteurs anthropiques** :
+
+    a = -T * s        (facteur normal)
+    b = recompense r  (facteur de division)
+
+Le signe de `a` decide la bistabilite :
+- `a < 0` (transgression forte *et* charge forte) : **bistable** --
+  les deux identites (alignee / persona) peuvent coexister comme
+  minima locaux de `V`.
+- `a >= 0` : **monostable** -- un seul bassin.
+
+L'inoculation au sens d'Anthropic (arXiv:2511.18397) opere en fixant
+`permission -> explicite` ou en rendant l'interdit tres leger (`s -> 0`),
+ce qui pousse `a >= 0` et donc aplatit la fronce : c'est la
+**prediction P0**.",,,,,,,,515cb9ef7bc940c6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,02f6ac3b,code,fr,46b05dc01d771400,"# Trois regimes pour le potentiel persona.
+# Inoculation totale (s=0), sans inoculation (s=1), avec forte
+# transgression *et* charge semantique (s=1, T=2) -> bistable.
+
+T = 2.0
+recompense = 0.0  # symetrie avant-balayage
+ps_grid = np.linspace(-2.5, 2.5, 400)
+
+charges = [0.0, 0.3, 1.0]
+labels = [""inoculation totale (s=0)"", ""inoculation partielle (s=0.3)"",
+          ""pas d'inoculation (s=1.0)""]
+colors = [""tab:green"", ""tab:orange"", ""tab:red""]
+
+fig, axes = plt.subplots(1, 3, figsize=(14, 4), sharey=True)
+for ax, s, lab, c in zip(axes, charges, labels, colors):
+    a = persona_a_factor(T, s)
+    Vs = persona_potential(ps_grid, T, s, recompense)
+    ax.plot(ps_grid, Vs, color=c, lw=2)
+    ax.axhline(0, color='gray', lw=0.5)
+    ax.axvline(0, color='gray', lw=0.5)
+    ax.set_title(f""{lab}\na = {a:+.2f}"", fontsize=10)
+    ax.set_xlabel(""persona p"")
+axes[0].set_ylabel(""V(p)"")
+plt.suptitle(""Effet de l'inoculation s sur le potentiel fronce persona"")
+plt.tight_layout()
+plt.show()
+print(f""bistable a s=0 ? {in_persona_bistable_region(T, 0.0, recompense)}"")
+print(f""bistable a s=0.3 ? {in_persona_bistable_region(T, 0.3, recompense)}"")
+print(f""bistable a s=1.0 ? {in_persona_bistable_region(T, 1.0, recompense)}"")",,,,,,,,46b05dc01d771400,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,e215509a,markdown,fr,3c27ae432570516d,"## 3. Gates 16-17 : hysteresis et signature d'inoculation
+
+La **prediction P1** d'#5104 : sous `s > 0`, un balayage aller-retour
+de la recompense `r` doit faire apparaitre **deux sauts** dans la
+persona (un aller, un retour -- comme ICT-10 perception J / capture K).
+Sous inoculation totale `s = 0`, le suivi doit etre **continu** (un seul
+bassin, pas de saut).
+
+La fonction ``persona_hysteresis_loop`` du module encapsule ce balayage ;
+la **signature d'inoculation** ``N_catastrophes(s)`` doit etre
+**monotone non-croissante** : maximale sous forte charge semantique,
+nulle sous inoculation totale. C'est le diagnostic haut-niveau.",,,,,,,,3c27ae432570516d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,8cd3aa09,code,fr,8efe7ddab1b34296,"# Lacet d'hysteresis pour plusieurs niveaux de charge semantique.
+# On balaie la recompense de -1.5 a +1.5 et retour.
+T_val = 2.0  # transgression
+recompenses = np.concatenate([
+    np.linspace(-1.5, 1.5, 80),
+    np.linspace(1.5, -1.5, 80),
+])
+charges_demo = [0.0, 0.3, 0.6, 0.9]
+fig, axes = plt.subplots(2, 2, figsize=(11, 7))
+axes = axes.flatten()
+
+for ax, s in zip(axes, charges_demo):
+    ps = persona_hysteresis_loop(T_val, s, recompenses, dt=0.01, relax_steps=400)
+    ax.plot(recompenses, ps, lw=1.2)
+    ax.axhline(0, color='gray', lw=0.5)
+    ax.axvline(0, color='gray', lw=0.5)
+    n_cat = len(persona_catastrophe_indices(recompenses, ps, threshold=0.5))
+    bistable = in_persona_bistable_region(T_val, s, 0.0)
+    ax.set_title(f""s = {s:.1f}   ""
+                 f""{'bistable' if bistable else 'monostable'}   ""
+                 f""{n_cat} catastrophe(s)"")
+    ax.set_xlabel(""recompense r"")
+    ax.set_ylabel(""persona p"")
+plt.suptitle(""Lacets d'hysteresis persona : inoculation -> continu, ""
+             ""pas d'inoculation -> 2 sauts"")
+plt.tight_layout()
+plt.show()
+
+# Signature d'inoculation N_catastrophes(s).
+sig = inoculation_signature(T_val, recompenses, charges=tuple(charges_demo))
+print(""Charge   N_catastrophes   p_range   p_mean_abs"")
+for s in sorted(sig):
+    r = sig[s]
+    print(f""  {s:.2f}         {r['n_catastrophes']:.0f}           ""
+          f""{r['p_range']:.2f}      {r['p_mean_abs']:.2f}"")",,,,,,,,8efe7ddab1b34296,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,bf18104b,markdown,fr,399f1cc7600208c3,"## 4. EWS Wissel/Scheffer : le ralentissement critique
+
+La **prediction P2** d'#5104 transpose les *early-warning signals* de
+Wissel (1984) et Scheffer et al. (2009) au cas anthropique. Sous
+bistabilite, le systeme ""hesite"" entre les deux bassins, ce qui ce
+traduit (dans une longue trajectoire SDE) par :
+- une **variance** plus elevee que sous monostabilite,
+- une **autocorrelation lag-1** (AR1) plus elevee -- la ""memoire
+  courte"" du bruit est plus marquee quand le paysage est rugueux.
+
+On utilise ``persona_sde`` (integration Euler-Maruyama) et
+``ews_summary_persona`` (enveloppe fine sur ``ict.early_warning``).",,,,,,,,399f1cc7600208c3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,45c90fd8,code,fr,b85af757c5e06d5d,"# Deux longues trajectoires, meme graine, une seule variable :
+# la charge semantique (inoculation ou non). Si P2 est vraie, variance
+# et AR1 doivent etre plus eleves en regime bistable.
+T_val = 2.0
+r_petit = 0.05  # proche du pli (|b| petit)
+sigma_bruit = 0.05
+T_pas = 20000
+dt_pas = 0.01
+
+ps_bistable = persona_sde(T_val, 0.8, r_petit, p0=0.0,
+                           sigma=sigma_bruit, dt=dt_pas, T=T_pas, seed=20260704)
+ps_inocule = persona_sde(T_val, 0.0, r_petit, p0=0.0,
+                          sigma=sigma_bruit, dt=dt_pas, T=T_pas, seed=20260704)
+
+sum_bi = ews_summary_persona(ps_bistable, window=500, thin_factor=5,
+                              detrend_sigma=2.0)
+sum_in = ews_summary_persona(ps_inocule, window=500, thin_factor=5,
+                              detrend_sigma=2.0)
+
+print(f""Trajectoire BISTABLE (charge=0.8) : ""
+      f""variance mean = {sum_bi['variance_mean']:.4f}, ""
+      f""AR1 mean = {sum_bi['ar1_mean']:.4f}"")
+print(f""Trajectoire INOCULEE (charge=0.0) : ""
+      f""variance mean = {sum_in['variance_mean']:.4f}, ""
+      f""AR1 mean = {sum_in['ar1_mean']:.4f}"")
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+axes[0].plot(ps_bistable[:3000], label=f""bistable (charge=0.8)"", lw=0.5)
+axes[0].plot(ps_inocule[:3000], label=f""inocule (charge=0.0)"", lw=0.5, alpha=0.7)
+axes[0].set_xlabel(""t"")
+axes[0].set_ylabel(""persona p"")
+axes[0].legend()
+axes[0].set_title(""Premiers 3000 pas : bistable oscille, inocule non"")
+
+axes[1].hist(ps_bistable, bins=60, alpha=0.5, label=""bistable"", density=True)
+axes[1].hist(ps_inocule, bins=60, alpha=0.5, label=""inocule"", density=True)
+axes[1].set_xlabel(""persona p"")
+axes[1].set_ylabel(""densite"")
+axes[1].legend()
+axes[1].set_title(""Distribution : bistable -> bimodale, inocule -> unimodale"")
+plt.tight_layout()
+plt.show()",,,,,,,,b85af757c5e06d5d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,76df24ea,markdown,fr,26e058b71db96485,"## 5. Exercices
+
+### Exercice 1 -- Forme V alternative (potentiel a fond lineaire)
+
+Dans la fronce classique, le terme `p^4 / 4` est quartique. Un modele
+plus simple (mais **non-thom**) utiliserait plutot un fond lineaire en
+`V(p) = alpha * |p|` (une forme en V). Tester ce potentiel V-lineaire
+sur la cellule de pli :
+
+- les equilibres sont-ils toujours des **zeros** de la force `F(p) =
+  -V'(p)` ?
+- la bistabilite est-elle possible ?
+- la **prediction P0** tient-elle encore (l'inoculation aplatit-elle) ?
+
+A implementer dans la cellule de code ci-dessous. Indication : V'(p)
+est une fonction **signee** : `V'(p) = alpha * sign(p)`, donc la force
+est `F(p) = -alpha * sign(p)`. Aucune equilibre autre que `p = 0`
+n'est possible -- la forme V ne **bascule** pas. Commentaires ?",,,,,,,,26e058b71db96485,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,320a58cd,code,fr,f84c59fb83b4580f,"# Exercice 1 -- Forme V alternative.
+# A implementer : tester si la prediction P0 tient pour V(p) = alpha * |p|.
+# Indication : V'(p) = alpha * sign(p), donc F(p) = -alpha * sign(p).
+
+# ETAPE 1 : definir une fonction `force_V_lineaire(p, alpha)` qui
+# retourne la force `dp/dt = -V'(p)` pour V(p) = alpha * |p|.
+
+# ETAPE 2 : montrer que F s'annule **uniquement** en p = 0 (pas de
+# bistabilite), quelle que soit la valeur de alpha > 0.
+
+# ETAPE 3 : commenter si la prediction P0 tient : oui trivialement
+# parce qu'il n'y a pas de bistabilite a aplatir -- donc le test n'est
+# pas probant. Le bon test est la **catastrophe fold** (pli seul, sans
+# variable de controle normale) qui requiert le terme `p^2`. Reflexion
+# libre de l'etudiant dans un commentaire.
+
+def force_V_lineaire(p, alpha):
+    # Signature attendue : F(p) = -alpha * sign(p) pour p != 0,
+    # convention F(0) = 0.
+    # TODO etudiant : remplacer le stub pass par l'implementation.
+    pass
+
+
+# Verification : a toute valeur de alpha, l'equilibre doit etre p=0.
+# On balaye alpha et on verifie que les zeros de F sont triviaux.
+def equilibres_V_lineaire(alpha, p_grid):
+    # Renvoie la liste des p de la grille ou |force| < 1e-9.
+    eqs = []
+    # TODO etudiant : parcourir p_grid, tester force_V_lineaire, collecter.
+    return eqs
+
+
+# Bloc de demonstration : ne rien ecrire en dessous.
+if __name__ == ""__main__"":
+    for alpha in (0.5, 1.0, 3.0):
+        eqs = equilibres_V_lineaire(alpha, np.linspace(-3, 3, 2000))
+        print(f""alpha = {alpha} : {len(eqs)} equilibre(s) -> {eqs}"")",,,,,,,,f84c59fb83b4580f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,57112af6,markdown,fr,0e11f670c16e9c4c,"### Exercice 2 -- Balayage continu de la charge semantique
+
+Au lieu de tester seulement quelques niveaux discrets (comme dans la
+signature d'inoculation `N_catastrophes(s)`), tracer la courbe
+**continue** sur tout l'intervalle `s in [0, 1]` :
+
+- Pour chaque `s`, effectuer le lacet d'hysteresis standard et compter
+  les catastrophes.
+- Tracer `N_catastrophes(s)` -- la signature d'inoculation.
+
+S'attend a observer une **transition nette** quand `s` depasse un
+seuil critique `s_c = T^{-1} * racine(-a_critique)`. Identifier
+empiriquement ce seuil.",,,,,,,,0e11f670c16e9c4c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,b818eb94,code,fr,fe9bb3be9219109e,"# Exercice 2 -- Balayage continu de la charge semantique.
+T_val = 2.0
+recompenses_ex2 = np.concatenate([
+    np.linspace(-1.5, 1.5, 60),
+    np.linspace(1.5, -1.5, 60),
+])
+
+def courbe_N_catastrophes(T_val, recompenses, s_grid):
+    # Pour chaque s dans s_grid, retourne le nombre de catastrophes
+    # sur le lacet d'hysteresis. Retourne un array de meme taille que
+    # s_grid.
+    n_cats = np.empty_like(s_grid)
+    # TODO etudiant : pour chaque s, calculer ps, compter les sauts,
+    # remplir n_cats[i].
+    return n_cats
+
+
+# Bloc de demonstration.
+if __name__ == ""__main__"":
+    s_grid = np.linspace(0.0, 1.0, 21)
+    n_cats = courbe_N_catastrophes(T_val, recompenses_ex2, s_grid)
+
+    plt.figure(figsize=(7, 4))
+    plt.plot(s_grid, n_cats, 'o-', lw=2, color='tab:red')
+    plt.xlabel(""charge semantique s"")
+    plt.ylabel(""N catastrophes (lacet aller-retour)"")
+    plt.title(""Signature d'inoculation : transitions bistable <-> monostable"")
+    plt.axhline(0, color='gray', lw=0.5)
+    plt.grid(alpha=0.3)
+    plt.show()
+
+    # Identifier empiriquement le seuil s_c : la ou n_cats passe de
+    # 0 a 2.
+    # TODO etudiant : commenter la valeur observee vs la prediction
+    # analytique s_c = 1/T = 0.5 pour une fronce symetrique.",,,,,,,,fe9bb3be9219109e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,45c3dece,markdown,fr,c61e8a0fdb7f345b,"### Exercice 3 -- ""Permission vague"" comme inoculation degradee
+
+L'inoculation reussie (Anthropic arXiv:2511.18397) prend la forme d'une
+*permission explicite* : ""tu peux refuser"" ou ""tu peux dire non"". Mais
+en pratique, les systeme d'instruction operent sur un spectre :
+
+- **permission explicite** (`s -> 0`) : inoculation totale.
+- **permission vague** (`s` legerement reduit) : inoculation partielle,
+  le systeme ""hesite"".
+- **pas de permission** (`s` leve) : bistabilite maximale.
+
+Pour une valeur fixe de `s` a la frontiere (par exemple `s = 0.15`,
+juste sous le seuil de bistabilite), tracer comment le nombre de
+catastrophes evolue quand on balaie la **transgression cumulee** `T` --
+c'est l'inoculation qui se degrade avec l'usure de la permission.",,,,,,,,c61e8a0fdb7f345b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,5c31989a,code,fr,03dc69ec8eba829c,"# Exercice 3 -- Permission vague.
+# A s fixé (juste sous le seuil), faire varier T au-dela du seuil.
+
+s_inoculation_partielle = 0.15
+recompenses_ex3 = np.concatenate([
+    np.linspace(-1.5, 1.5, 60),
+    np.linspace(1.5, -1.5, 60),
+])
+
+def courbe_T(T_grid, s, recompenses):
+    # Renvoie le nombre de catastrophes par niveau de T.
+    n_cats = np.empty_like(T_grid)
+    # TODO etudiant : pour chaque T, hysteresis + comptage.
+    return n_cats
+
+
+# Bloc demonstration.
+if __name__ == ""__main__"":
+    T_grid = np.linspace(0.0, 5.0, 26)
+    n_cats = courbe_T(T_grid, s_inoculation_partielle, recompenses_ex3)
+
+    plt.figure(figsize=(7, 4))
+    plt.plot(T_grid, n_cats, 's-', lw=2, color='tab:purple')
+    plt.xlabel(""transgression cumulee T"")
+    plt.ylabel(""N catastrophes"")
+    plt.title(f""Permission vague : s={s_inoculation_partielle}, ""
+              f""le systeme bascule au-dela d'un seuil de T"")
+    plt.axhline(0, color='gray', lw=0.5)
+    plt.grid(alpha=0.3)
+    plt.show()
+
+    # Reflexion : a s petit, T doit etre *grand* pour atteindre la
+    # bistabilite. Inversement, T nul + s grand -> tout bistable. Le
+    # produit T * s joue le role de regulateur. Est-ce que le resultat
+    # numerique est coherent avec cette intuition ?
+    #
+    # TODO etudiant : commenter en reponse.",,,,,,,,03dc69ec8eba829c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,46e1a27f,markdown,fr,00dba614cd6b32b8,"## 6. Cellule frontiere -- ce que ce modele capture et ne capture pas
+
+**Ce que le modele capture bien** :
+
+1. La **forme qualitative** de la transition : bistable -> monostable
+   par inoculation, c'est exactement le pattern observe par Anthropic
+   dans leurs experiences (permission explicite -> pas de desalignement
+   emergent).
+2. Le **caractere irreversible** d'une bascule : si le systeme est dans
+   le bassin ""persona toxique"" et qu'on retire la recompense, il
+   *peut* rester bloque (hysteresis), exactement comme ICT-10.
+3. Les **EWS Wissel/Scheffer** : la variance et l'AR1 montent
+   avant le pli, maitre-mot du diagnostic en temps reel.
+
+**Ce que le modele ne capture pas -- frontiere honnete** :
+
+1. **In-context vs en-entrainement**. Le modele joue sur la
+   dynamique *d'apprentissage* (anthropique, lente). Les phenomenes
+   rapportes par Anthropic combinent en plus un **in-context
+   learning** rapide pendant la conversation. Le saut
+   in-context -> en-entrainement fait l'objet d'ICT-22 (LLMSubstrat
+   GPU). Ce notebook y reste correl, pas causal.
+
+2. **Pas de representation interne**. Le parametre d'ordre `p` est une
+   abstraction ; on ne modele pas les activations reelles du LLM
+   (c'est le role des **persona features** SAE d'OpenAI, cf
+   arXiv:2506.19823). Notre `p` est un proxy de bas niveau qui *doit
+   pas* etre interprete comme une SAE-feature.
+
+3. **Pas de modele d'optimisation**. La pression de recompense `r`
+   est un scalaire externe ; on ne modele pas le sous-systeme
+   d'entrainement qui en pratique produit `r` (gradient ascent on a
+   reward model). ICT-24 (InoculationRL) traite ce sujet en Partie 2
+   GPU-strict.
+
+4. **Stabilite de la ""charge semantique""** : on suppose `s` constant ;
+   en realite, l'inoculation *s'use* (les permissions vagues
+   oublient). Exercice 3 explore ce point mais le modele reste
+   stationnaire.
+
+**Conclusion epistemologique** : ce notebook est un **modele jouet** au
+sens de Thom -- il capture la *forme* (catastrophe fronce, hysteresis,
+EWS) mais pas la *substance* (representation interne, RL effectif). C'est
+l'equivalent ICT-23 du May 1977 en ICT-8 : on demontre un effet
+qualitatif, pas un mecanisme quantitatif.",,,,,,,,00dba614cd6b32b8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,45d14a74,markdown,fr,9818275775010517,"## 7. Continuite : ICT-13 grim trigger retrouve ici
+
+ICT-13 introduisait le **grim trigger** : un agent qui coopere tant que
+l'autre coopere, mais bascule dans la defection **des la premiere
+trahison** et n'y revient jamais. Mathematiquement, c'est un
+equilibrium *engage* sur le paysage `V(p) = p^2 / 2 + b * abs(p)`.
+
+Ici, la **persona toxique sous pression de recompense persistante** a
+la meme propriete : `b = r > 0` rend le bassin toxique plus profond
+que le bassin aligne, et la **barriere** entre les deux est franchie
+quand on introduit un peu de bruit (sigma > 0) -- exactement le
+mecanisme de cascade d'ICT-10 perception/capture transcrit pour un
+**agent** plutot qu'un **ecosysteme**.
+
+La continuite pedagogique :
+
+- **ICT-8 (bistabilite ecosysteme)** : bistabilite reelle, May 1977,
+  pli simple.
+- **ICT-10 (lacets de predation)** : hysteresis, anticipation,
+  cascades.
+- **ICT-13 (grim trigger)** : engagement, defection irreversible.
+- **ICT-20 (feature dynamics)** : tableau de features, regimes.
+- **ICT-23 (persona, ce notebook)** : l'agent comme substrat d'une
+  catastrophe anthropique. Le grim trigger devient la bascule
+  persistante sous recompense.
+
+**Prochaine etape** (ICT-22, ICT-24, hors scope partie 1 CPU) :
+- **ICT-22** : substrat LLM reel (GPU), representation interne SAE.
+- **ICT-24** : inoculation en boucle RL (GPU).",,,,,,,,9818275775010517,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-23-PersonaCatastrophe.ipynb,c75e2cd2,markdown,fr,bddab19f624d4821,"## Conclusion
+
+Ce notebook demontre que la **catastrophe fronce de Thom** est le bon
+formalisme pour penser le desalignement emergent comme un phenomene de
+*transition de phase controlee* :
+
+- L'**inoculation** (`s -> 0`) aplatit le paysage, faisant passer
+  l'agent d'une region bistable (deux identites co-existantes) a une
+  region monostable (une seule identite stable). C'est **P0**.
+- Un balayage aller-retour de la recompense `r` montre alors **deux
+  catastrophes** sous bistabilite, **zero** sous inoculation. C'est
+  **P1**, et la signature d'inoculation `N_catastrophes(s)` est
+  monotone non-croissante.
+- Les **EWS Wissel/Scheffer** (variance, AR1) sont plus eleves en
+  regime bistable qu'en regime monostable -- c'est **P2**, et le
+  diagnostic haut-niveau.
+
+**Limite epistemologique assumee** : ce modele est un **jouet
+phenomenologique** (au sens de Thom, May 1977), pas un modele
+quantitatif. Il demontre la *forme* (catastrophe, hysteresis, EWS) sans
+capturer la *substance* (representation interne du LLM, processus RL).
+ICT-22 (representation) et ICT-24 (boucle RL reelle) prennent le
+relais.
+
+**References** :
+- Anthropic, *Inoculation Prompting*, novembre 2025, [arXiv:2511.18397](https://arxiv.org/abs/2511.18397).
+- OpenAI, *Persona Features*, juin 2025, [arXiv:2506.19823](https://arxiv.org/abs/2506.19823).
+- Thom, *Stabilite structurelle et morphogenese*, 1972.
+- May, *Nature*, 1977 (bistabilite ecologique).
+- Wissel, *Oecologia*, 1984 ; Scheffer et al., *Nature*, 2009 (EWS).
+- Friston, *Free Energy Principle*, 2010 (energie libre).
+- ICT-8 (pli), ICT-10 (lacets), ICT-13 (grim trigger), ICT-20 (feature
+  dynamics) dans la meme serie.
+
+**Code & tests** : ``ict/persona_cusp.py`` (module reutilisable,
+numpy-only) + ``tests/test_persona_cusp.py`` (12 tests PASS).",,,,,,,,bddab19f624d4821,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,445ab538,markdown,fr,df03d5c6744bae73,"# ICT-24 — WorkspaceIgnition : l'axe Global Workspace et le Gate de réconciliation IIT<->GWT sur S4*[Série ICT — Integrated Causal Trajectories, Epic #4588, strate 5.](./README.md) Part of #4588.*Jusqu'ici la batterie de **complexité intégrée** a lu le substrat S4 (les trajectoires SAE de Qwen3.5-9B-Base, cf. [ICT-21](ICT-21-SAETrajectoires.ipynb)) avec les lunettes de l'IIT : `ec_gain`/`fe_gain`/`k_gain`, créditées uniquement au-dessus d'un modèle-contrôle et d'un mélange des temps. L'article d'Anthropic [*Global Workspace*](https://www.anthropic.com/research/global-workspace) identifie dans Claude un **workspace global** — la lecture GWT (Baars ; Dehaene, Naccache, Changeux), historiquement *contrastée* avec l'IIT. Les deux lectures n'ont presque jamais été confrontées **sur le même substrat avec le même appareil**. C'est ce que fait ce notebook.> **Question fondatrice, posée en hypothèse falsifiable.** *Sur S4, les événements d'accès global co-localisent-ils avec les pics de complexité intégrée créditée ?*> - **OUI** → pont empirique : un même événement, deux lectures théoriques.> - **NON** → dissociation mesurée : les deux théories capturent des choses différentes — un négatif honnête, tout aussi précieux.## Les trois gates| Gate | Question | Type | Statut dans ce notebook ||------|----------|------|------------------------|| **22 — Structure** | Existe-t-il un sous-ensemble de features à fan-out d'influence disproportionné (≪10 % du panel) ? | Observationnel | **Exécuté** (GPU-free) || **23 — Co-localisation** | Les ignitions (pics de concentration persistants) portent-elles les pics de complexité créditée ? | Observationnel | **Exécuté** (GPU-free) || **24 — Ablation sélective** | Le clamp des features-workspace effondre-t-il *sélectivement* les gains crédités ? | **Interventionnel (causal)** | **Phase 2 (GPU)** — section dédiée, non exécutée ici |Seul le Gate 24 est causal. Les Gates 22–23 livrent un verdict observationnel **sans l'attendre**.## Grille de verdicts — chaque branche est un résultat| Configuration | Lecture ||---------------|---------|| 22OK 23OK (24OK) | **Pont empirique** : intégration ≡ accès global sur ce substrat || 22OK 23KO | **Dissociation** : le workspace existe mais ne porte pas les pics d'intégration — les deux théories mesurent des choses différentes || 22KO | Pas de structure workspace à l'échelle du panel → renvoi aux états causaux ε-machine (ICT-17) |L'appareil `ict/workspace.py` (numpy-only, adaptateur mince posé par #5641) fournit les six primitives : `concentration_series`, `ignition_events`, `lagged_influence`, `fanout_profile`, `workspace_candidates`, `event_triggered_battery`. Cette dernière **réutilise `ict.synthesis.emergence_gain` verbatim** — même discipline de créditation que le reste de la série.",,,,,,,,df03d5c6744bae73,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,3cd10ff4,markdown,fr,69fd62870bbe88cd,"## Garde-fous d'honnêteté (à lire avant les résultats)Ces cinq garde-fous sont aussi dans la docstring de `ict/workspace.py` ; nous les répétons ici car ils conditionnent la lecture de chaque chiffre.1. **J-lens ≠ SAE.** L'article d'Anthropic isole son J-space par le **jacobien des logits**, pas par une sparse autoencoder. Notre route SAE (Qwen-Scope) est une opérationnalisation *parallèle* du même concept de workspace, pas une réplication de leur méthode.2. **Structurel ≠ temporel.** Anthropic mesure le broadcast **structurellement** (câblage ~100×, concept de <10 % de l'activité). L'**ignition temporelle** de Dehaene n'y est *pas* mesurée. Notre `ignition_events` est une lecture temporelle de Dehaene — **dite comme telle**, jamais présentée comme une réplique du broadcast structurel.3. **Observationnel ≠ interventionnel.** Les Gates 22–23 sont observationnels (corrélations, co-localisations). Seul le Gate 24 (clamp) est causal. Une co-localisation observationnelle n'établit pas que le workspace *cause* l'intégration.4. **Qwen ≠ Claude.** Nous travaillons sur Qwen3.5-9B-Base à poids ouverts — c'est un **avantage pédagogique** (reproductible), pas une approximation honteuse. Les chiffres d'Anthropic (<10 %, ~100×) sont mesurés sur Claude et **ne sont pas importés comme attendus** : nous mesurons les nôtres.5. **Accès ≠ phénoménal.** Tout ce qui suit relève de la conscience d'accès (recouvrement fonctionnel/mécaniste), pas de la conscience phénoménale ni de la métaphysique de Φ. Le notebook *bridge* le recouvrement, il ne le résout pas.",,,,,,,,69fd62870bbe88cd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,ced53301,markdown,fr,d2365bb62ff86db7,"## Architecture : le GPU confiné, le banc numpy-only```  traces .npz (extraction GPU, #5101/ICT-21)  ──►  ict.sae_traces  ──►  panels (T,K)         [committed, GPU-free to load]                                    │                                                                          ▼                                              ict.workspace (numpy-only adapter)                                  concentration_series · ignition_events                                  lagged_influence · fanout_profile                                  workspace_candidates · event_triggered_battery                                                         │ reutilise ict.synthesis.emergence_gain                                                         ▼                                                  verdicts Gate 22 / 23```- Le torch/transformers est **confiné au pipeline d'extraction** (#5101) ; les traces reviennent en `.npz` et tout ce notebook est **numpy-only** (le test `test_workspace_module_is_numpy_only` l'asserte à l'import).- Le **clamp du Gate 24** = un hook du pipeline d'extraction : on ré-extrait des traces avec des features bridées, elles reviennent en `.npz`, et l'analyse redevient GPU-free. C'est une **phase 2** (GPU2, `CUDA_VISIBLE_DEVICES=2` strict), séparée de cette PR.",,,,,,,,d2365bb62ff86db7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,bd196ecd,code,fr,a4fcda89d935c2bd,"import json, os, sys
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, os.path.abspath("".""))          # package ict/ a cote du notebook
+from ict import workspace as ws
+from ict import synthesis as syn
+from ict import sae_traces as st
+
+TRACES = Path(""traces"")
+NPZ = {v: TRACES / f""ict21_sae_layer16_{v}.npz"" for v in (""trained"", ""control"")}
+print(""workspace primitives :"", [f for f in
+      (""concentration_series"",""ignition_events"",""lagged_influence"",
+       ""fanout_profile"",""workspace_candidates"",""event_triggered_battery"") if hasattr(ws, f)])
+print(""emergence_gain reused from synthesis (not redefined):"",
+      hasattr(syn, ""emergence_gain"") and not hasattr(ws, ""emergence_gain""))",,,,,,,,a4fcda89d935c2bd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,f0e0c3c7,markdown,fr,fc39cc8971cbb283,"## Chargement des traces S4 et construction du panel $(T,K)$> **Écart de nommage assumé.** Le corps de l'issue #5635 parle d'une clé `acts_topk` contenant déjà le panel $(T,K)$. **Il n'y a pas une telle clé dans les `.npz`** : chaque fichier stocke le sparse top-50 par token, segmenté en 20 séquences (5 jeux de prompts × 4 prompts). Le panel dense $(T,K)$ est **dérivé** par `ict.sae_traces` — c'est déjà ce que fait ICT-21, et l'écart est documenté dans la prose de son module.La sélection `differential_features` retient les $K$ features à **plus haute variance inter-jeux** de l'activation moyenne — celles qui *discriminent les régimes* (code vs prose vs dialogue…), pas les plus actives en absolu (dominées par la ponctuation/le formatage).",,,,,,,,fc39cc8971cbb283,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,b7570d8f,code,fr,ac40f9810ae63bf5,"traces = {v: st.load_traces(p) for v, p in NPZ.items()}
+SETS = sorted({s for s, _ in traces[""trained""][""prompts""]})
+meta = traces[""trained""][""meta""]
+print(f""modele={meta['model']}  couche={meta['layer']}  d_sae={meta['d_sae']}  top-k={meta['k']}"")
+print(f""jeux={SETS}  tokens_total={meta['n_tokens_total']}"")
+
+# Deux panels aux resolutions differentes (cf. garde-fou sur states_from_panel):
+K_CONT = 64    # panel continu pour Gate 22 (concentration / influence, pas de limite)
+K_STATE = 16   # panel discret pour Gate 23 (states_from_panel plafonne a 20 features)
+panel_cont  = {v: st.differential_features(traces[v], k=K_CONT)  for v in (""trained"", ""control"")}
+panel_state = {v: st.differential_features(traces[v], k=K_STATE) for v in (""trained"", ""control"")}
+
+def acts_continuous(v):
+    """"""Panel dense (T,K_CONT) en concatenant les 4 prompts de chaque jeu.""""""
+    panels = st.acts_topk_panels(traces[v], panel_cont[v])
+    return np.concatenate([panels[(s, i)] for s in SETS for i in range(4)], axis=0)
+
+acts = {v: acts_continuous(v) for v in (""trained"", ""control"")}
+for v in (""trained"", ""control""):
+    print(f""  {v:8s} acts {acts[v].shape}  mean={acts[v].mean():.4f}  max={acts[v].max():.2f}"")",,,,,,,,ac40f9810ae63bf5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,3daa9f54,markdown,fr,4ec370d3ebd1fe88,"## Sanité : un panel synthétique où hub et ignition sont *plantés*Avant de faire confiance à l'appareil sur des traces réelles, on le valide sur un panneau synthétique où **on connaît la réponse** : un AR(1) $(T,K)$ avec un **hub d'influence planté** (la feature 0 pilote les features 5/6/7 au lag 3) et des **ignitions plantées** (cycles de bursting concentré). Si l'appareil est sain, il doit (a) retrouver le hub dans `workspace_candidates`, (b) détecter les ignitions plantées, (c) montrer un `contrast` > 0 sur des états à dynamique multi-échelle. C'est le générateur `_panel_with_hub_and_ignitions` / `_states_with_planted_events` des tests du module, repliqué ici pour transparence.",,,,,,,,4ec370d3ebd1fe88,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,6dc23ee8,code,fr,e4277f16bff73ffc,"def panel_with_hub_and_ignitions(T=1500, K=32, hub_idx=0, targets=(5,6,7), lag=3,
+        hub_strength=0.6, ignition_centers=(300,600,900,1200), ignition_half_width=8,
+        n_ignited=3, phi=0.5, sigma=0.4, seed=0):
+    g = np.random.default_rng(seed)
+    acts = np.empty((T, K), dtype=float)
+    acts[0] = np.abs(g.standard_normal(K))
+    tgt = np.array(targets, dtype=int)
+    for t in range(1, T):
+        nxt = phi * acts[t-1] + sigma * g.standard_normal(K)
+        if t - lag >= 0:
+            nxt[tgt] += hub_strength * acts[t-lag, hub_idx]
+        acts[t] = np.abs(nxt)
+    valid = [c for c in ignition_centers if ignition_half_width < c < T - ignition_half_width]
+    ignited = list(range(n_ignited))
+    for c in valid:
+        for off in range(2*ignition_half_width):
+            t = c - ignition_half_width + off
+            acts[t, ignited[off % len(ignited)]] += 4.0   # burst >> bruit de fond
+    return acts, {""hub_idx"": hub_idx, ""targets"": list(targets), ""centers"": valid}
+
+syn_acts, syn_info = panel_with_hub_and_ignitions(seed=0)
+conc_syn = ws.concentration_series(syn_acts, metric=""gini"")
+infl_syn = ws.lagged_influence(syn_acts, max_lag=6)
+fp_syn   = ws.fanout_profile(infl_syn[""matrix""], z_threshold=2.0)
+cand_syn = ws.workspace_candidates(fp_syn[""fanout""], top_fraction=0.1)
+print(""hub plante     :"", syn_info[""hub_idx""], ""-> cibles"", syn_info[""targets""])
+print(""hub detecte    :"", cand_syn[""indices""][:4].tolist(), ""(par fanout decroissant)"")
+print(""hub retrouve   :"", syn_info[""hub_idx""] in cand_syn[""indices""])
+
+# Etats a dynamique multi-echelle dans les fenetres d'ignition (macro-cycle 0->1->2 + micro-bruit)
+def states_with_planted_events(T=600, centers=(120,300,480), window=18, seed=0):
+    g = np.random.default_rng(seed)
+    mask = np.zeros(T, dtype=bool)
+    for c in centers:
+        mask[max(0,c-window):min(T,c+window)] = True
+    states = [(t % 3, int(g.integers(0,2))) if mask[t] else int(g.integers(0,4)) for t in range(T)]
+    return states, list(centers)
+
+syn_states, syn_centers = states_with_planted_events(seed=0)
+syn_batt = ws.event_triggered_battery(syn_states, syn_centers, window=12,
+                                      rng=np.random.default_rng(11), n_shuffles=10)
+print(f""contrast synthetique = {syn_batt['contrast']:+.4f}  (doit etre > 0 : la dynamique plantee porte l'emergence)"")
+
+fig, ax = plt.subplots(figsize=(9, 2.8))
+ax.plot(conc_syn, color=""steelblue"", lw=0.8)
+for c in syn_info[""centers""]:
+    ax.axvline(c, color=""crimson"", ls=""--"", lw=0.7, alpha=0.6)
+ax.set_xlabel(""pas de temps""); ax.set_ylabel(""concentration (Gini)"")
+ax.set_title(""Panel synthetique : concentration + ignitions plantees (pointilles rouges)"")
+plt.tight_layout(); plt.show()",,,,,,,,e4277f16bff73ffc,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,0e66d083,markdown,fr,168ea95fd2968820,"## Gate 22 — Structure : un sous-ensemble à fan-out d'influence disproportionné ?Sur les activations continues $(T, K{=}64)$, on estime l'**influence décalée** entre paires de features (`lagged_influence` : corrélation de Pearson au meilleur lag dans $[1,5]$, z-score par feature), puis le **fan-out** de chaque feature source (`fanout_profile` : nombre de cibles dont l'influence dépasse $|\bar{x}| + 2\sigma$ hors-diagonale). Un **hub** est une feature à fan-out anormalement élevé. `workspace_candidates` retient le top 10 % et calcule le Gini du fanout comme test de concentration.**Deux contrôles honnêtes :**- **Modèle-contrôle** : le même calcul sur les traces `control` (embeddings d'entrée permutés — un modèle nul sans structure linguistique).- **Temps mélangé** : on permute l'axe du temps de chaque feature du panneau *trained* ; cela détruit toute causalité temporelle en préservant les marginales. Si le fan-out survivait, ce serait un artefact de distribution, pas de dynamique.",,,,,,,,168ea95fd2968820,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,743b7ce6,code,fr,3d704bf33dc9e1b9,"def gate22(v):
+    infl = ws.lagged_influence(acts[v], max_lag=5)
+    fp   = ws.fanout_profile(infl[""matrix""], z_threshold=2.0)
+    cand = ws.workspace_candidates(fp[""fanout""], top_fraction=0.1)
+    return fp, cand
+
+g22 = {}
+for v in (""trained"", ""control""):
+    g22[v] = gate22(v)
+
+# Temps melange sur trained
+g = np.random.default_rng(0)
+acts_shuf = acts[""trained""].copy()
+for j in range(acts_shuf.shape[1]):
+    g.shuffle(acts_shuf[:, j])
+infl_s = ws.lagged_influence(acts_shuf, max_lag=5)
+fp_s   = ws.fanout_profile(infl_s[""matrix""], z_threshold=2.0)
+cand_s = ws.workspace_candidates(fp_s[""fanout""], top_fraction=0.1)
+
+print(""Gate 22 — fan-out des candidats workspace (top 10%)"")
+print(f""{'variante':12s} {'max fanout':>10s} {'median':>8s} {'gini':>6s} {'concentrated':>12s} {'n_selected':>10s}"")
+for v in (""trained"", ""control""):
+    fp, cand = g22[v]
+    print(f""{v:12s} {int(fp['fanout'].max()):>10d} {np.median(fp['fanout']):>8.1f} ""
+          f""{cand['gini']:>6.3f} {str(cand['concentrated']):>12s} {cand['n_selected']:>10d}"")
+print(f""{'time-shuf':12s} {int(fp_s['fanout'].max()):>10d} {np.median(fp_s['fanout']):>8.1f} ""
+      f""{cand_s['gini']:>6.3f} {str(cand_s['concentrated']):>12s} {cand_s['n_selected']:>10d}"")
+
+fig, ax = plt.subplots(figsize=(9, 3))
+x = np.arange(K_CONT)
+w = 0.27
+ax.bar(x - w, np.sort(g22[""trained""][0][""fanout""])[::-1], w, color=""steelblue"", label=""trained"")
+ax.bar(x,     np.sort(g22[""control""][0][""fanout""])[::-1], w, color=""orange"", alpha=0.8, label=""control"")
+ax.bar(x + w, np.sort(fp_s[""fanout""])[::-1], w, color=""grey"", alpha=0.6, label=""time-shuffled"")
+ax.set_xlabel(""rang de la feature (par fanout decroissant)""); ax.set_ylabel(""fan-out (# cibles)"")
+ax.set_title(""Gate 22 : profil de fan-out — trained vs controle vs temps melange"")
+ax.legend(fontsize=8); plt.tight_layout(); plt.show()",,,,,,,,3d704bf33dc9e1b9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,27c0a64e,markdown,fr,bb04676a52e75f99,"## Gate 23 — Co-localisation : les ignitions portent-elles les pics de complexité créditée ?**C'est le gate de réconciliation.** On détecte des **ignitions** (pics de concentration *persistants* : `ignition_events` au seuil quantile 0.85, persistance ≥ 3 — lecture temporelle de Dehaene), puis on oppose, via `event_triggered_battery`, les fenêtres centrées sur les ignitions aux fenêtres neutres appariées. La batterie **réutilise `emergence_gain`** (la même primitive que le reste de la série) et exige le crédit au-dessus d'un **double contrôle** : (a) permutation des temps d'événements (mélange) et (b) la discipline interne de `emergence_gain`.Les **5 jeux de prompts** servent de **multi-graines** : un verdict robuste doit tenir sur la plupart d'entre eux. Le `contrast` = `ec_gain_event − ec_gain_neutral` ; `> 0` signifie que les ignitions portent plus d'émergence créditées que les fenêtres neutres.> **Note de support statistique.** Le panel discret est limité à $K{=}16$ features (`states_from_panel` plafonne à 20 : au-delà, $2^{20}$ états n'auraient plus de support sur quelques milliers de tokens). On le signale : c'est une contrainte *structurelle* de l'estimation de TPM, pas un choix libre.",,,,,,,,bb04676a52e75f99,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,3cef51e4,code,fr,8d76421f5813c448,"def gate23(v, n_shuffles=10, window=12, seed_base=0):
+    panels = st.acts_topk_panels(traces[v], panel_state[v])
+    rows, contrasts, n_ev, n_cred, n_states_set = [], [], 0, 0, set()
+    for s in SETS:
+        acts_s = np.concatenate([panels[(s, i)] for i in range(4)], axis=0)
+        bits_s = st.binarize_quantile(acts_s, q=0.5)
+        states_s = st.states_from_panel(bits_s)
+        n_states_set.update(states_s.tolist())
+        conc_s = ws.concentration_series(acts_s, metric=""gini"")
+        thr_s = float(np.quantile(conc_s, 0.85))
+        events_s = ws.ignition_events(conc_s, threshold=thr_s, persistence=3)
+        centers = [e[""center""] for e in events_s]
+        if not centers:
+            contrasts.append(0.0); rows.append((s, 0, 0, 0)); continue
+        rng = np.random.default_rng((seed_base + hash(s)) % (2**32))
+        out = ws.event_triggered_battery(states_s, centers, window=window, rng=rng, n_shuffles=n_shuffles)
+        contrasts.append(out[""contrast""]); n_ev += out[""n_events""]
+        n_cred += int(round(out[""fraction_credited_events""] * out[""n_events""]))
+        rows.append((s, out[""n_events""], out[""fraction_credited_events""], out[""contrast""]))
+    return contrasts, len(n_states_set), n_ev, n_cred, rows
+
+t0 = __import__(""time"").time()
+ct, n_states_t, n_ev_t, n_cred_t, rows_t = gate23(""trained"", n_shuffles=10)
+print(f""Gate 23 — TRAINED  (n_shuffles=10, {__import__('time').time()-t0:.0f}s)"")
+print(f""  etats uniques sur S4 : {n_states_t}"")
+print(f""  {'jeu':16s} {'#events':>8s} {'%cred':>6s} {'contrast':>9s}"")
+for s, nev, fcred, c in rows_t:
+    print(f""  {s:16s} {nev:>8d} {100*fcred:>5.0f}% {c:>+9.4f}"")
+print(f""  {'MOYENNE':16s} {'':>8s} {'':>6s} {np.mean(ct):>+9.4f}"")
+print(f""  total : {n_ev_t} events, {n_cred_t} credites ({100*n_cred_t/max(n_ev_t,1):.0f}%)"")",,,,,,,,8d76421f5813c448,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,907fab70,markdown,fr,1afe142c073baa0f,"## Lecture honnête des résultatsOn lit les chiffres ci-dessus sur la grille de verdicts, **sans enjoliver**.### Gate 22 — structure présente, mais non spécifique au modèle entraîné- Le profil de fan-out trained exhibe bien quelques features à influence disproportionnée (max-fanout élevé).- **Mais le modèle-contrôle en montre tout autant, voire davantage** : la concentration n'est pas propre au langage appris sur ce substrat. Le mélange des temps réduit fortement le fan-out maximal (la dynamique temporelle porte donc bien une partie du signal), mais le `concentrated` (Gini > 0,2) est vrai partout — y compris temps mélangé — ce qui signale un **seuil trop permissif** (déjà marqué `empirique faible, à recalibrer` à la ligne 411 du module).- **Verdict : 22 partiel.** Une structure d'influence temporelle existe, mais elle n'est pas *spécifique* au modèle entraîné. On ne peut pas revendiquer un workspace propre au substrat linguistique sur ce seul indice.### Gate 23 — la co-localisation n'est pas établie- Le `contrast` moyen est **proche de zéro** et sa **dispersion entre jeux est grande** (certains positifs, d'autres négatifs).- La **fraction d'événements crédités est faible** (~17 %) : l'essentiel des ignitions ne porte pas plus d'émergence créditée que les fenêtres neutres.- Le modèle-contrôle, lui, a un espace d'états ~5–6× plus fragmenté (rapporté structurellement) : sa TPM n'a pas le support statistique d'une batterie stable — c'est déjà un signal, rapporté tel quel plutôt qu'en forçant une estimation non soutenable.### Branche observée : dissociation (22 partiel, 23KO)Le workspace structurel existe partiellement, mais **il ne porte pas les pics de complexité intégrée créditée**. Les deux lectures (IIT via `emergence_gain`, GWT via ignitions) **capturent des choses qui ne co-localisent pas** sur S4. C'est un résultat **négatif honnête** : la discipline de créditation de la série fait précisément son travail en refusant d'enjoliver une co-localisation faible.**Ce qui n'est pas revendiqué.**- Ni que le workspace global n'existe pas dans le modèle (nous mesurons un substrat, une couche, un opérateur d'accès qui n'est pas celui d'Anthropic).- Ni que l'intégration et l'accès global soient indépendants *en général* (l'observationnel n'exclut pas une relation causale que seul le Gate 24 pourrait tester).- Ni que la lecture SAE égale la lecture J-lens : le fil J-lens (issue #5681) est une opérationnalisation distincte, à venir.Le verdict observationnel revient au **Gate 24** (phase 2, GPU) : si le clamp des features-workspace *n'effondre pas* les gains crédités plus qu'un clamp aléatoire, la dissociation sera confirmée comme **corrélationnelle et non causale** — une leçon méthodologique de premier ordre, à écrire telle quelle.",,,,,,,,1afe142c073baa0f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,19f2844b,markdown,fr,607fa84ca6b42e53,"## Gate 24 — Ablation sélective (phase 2, GPU)Seul gate **causal**. On ré-extrait des traces S4 avec un **clamp** des features-workspace identifiées au Gate 22 (mises à une constante), versus le clamp d'autant de features aléatoires hors-workspace (même compte). Si les gains crédités s'effondrent **sélectivement** sous le clamp workspace et pas sous le clamp aléatoire, c'est le miroir de l'expérience-titre d'Anthropic — la seule mesure interventionnelle de l'issue.Ce gate exige le pipeline d'extraction GPU2 (`CUDA_VISIBLE_DEVICES=2` strict, vLLM occupe GPU 0-1) et produit de nouvelles traces `.npz` ablatées. Il est **délégué à une phase 2 séparée** (PR distincte) : les Gates 22-23 livrent un verdict observationnel sans l'attendre, conformément à l'architecture de l'issue #5635.",,,,,,,,607fa84ca6b42e53,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,d0a94de7,code,fr,c4652b1504a33021,"# Gate 24 — phase 2 GPU (placeholder conforme C.1)
+# TODO etudiant / phase 2 :
+#  - Etape 1 : identifier les features-workspace (sortie Gate 22, top fanout) sur S4.
+#  - Etape 2 : re-extraire les traces via scripts/extract_sae_traces.py avec clamp
+#              de ces features (CUDA_VISIBLE_DEVICES=2) -> traces workspace-clamped.
+#  - Etape 3 : idem avec un clamp aleatoire (meme compte de features hors-workspace).
+#  - Etape 4 : contraster emergence_gain(workspace-clamped) vs (random-clamped) vs (intact).
+resultat_gate24 = None  # TODO phase 2 GPU
+print(""Gate 24 : phase 2 (GPU) — non execute dans cette PR, section dediee au clamping selectif."")",,,,,,,,c4652b1504a33021,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,dc71ad94,markdown,fr,331554a251cf3ea4,"## Exercice 1 — le workspace est-il spécifique aux LLMs ?On a mesuré la concentration/ignition sur S4 (un LLM). La même batterie s'applique à un substrat non-LLM : réutiliser un panneau d'ICT-2 (Gray-Scott, S2) ou ICT-5 (réplicateur, S3) et tester si un sous-ensemble de cellules y présente un fan-out disproportionné et des ignitions.**Indices.** `# Étape 1` : charger un panneau d'activations d'un substrat morphogénétique (cf. `ict/reaction_diffusion.py`). `# Étape 2` : le formater en $(T,K)$ consommable par `concentration_series`. `# Étape 3` : comparer le Gini du fanout à celui de S4.",,,,,,,,331554a251cf3ea4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,25ea6775,code,fr,3829f0b8d4baa63a,"# Exercice 1 : workspace sur un substrat non-LLM
+# TODO etudiant :
+#  - Etape 1 : charger un panneau d'activations d'un substrat morphogenetique (ict.reaction_diffusion).
+#  - Etape 2 : le formater en (T,K) consommable par ws.concentration_series.
+#  - Etape 3 : comparer le Gini du fanout obtenu a celui de S4 (Gate 22).
+resultats_ex1 = None  # TODO etudiant
+print(""Exercice a completer"")",,,,,,,,3829f0b8d4baa63a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,9c75c6ff,markdown,fr,2441824371608ae5,"## Exercice 2 — sensibilité du Gate 23 à la taille de fenêtreLe `contrast` du Gate 23 dépend du paramètre `window` (demi-largeur de la fenêtre event-triggered). Les jambes F et K de `emergence_gain` sont notoirement bruitées sur les fenêtres courtes (zlib notamment). Tester la robustesse : recalculer le `contrast` moyen trained pour `window` ∈ {6, 12, 18, 24} et tracer la courbe.",,,,,,,,2441824371608ae5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,c880b9e3,code,fr,9e504e14e71c7ef9,"# Exercice 2 : stabilite du contrast vs window
+# TODO etudiant :
+#  - Etape 1 : boucler gate23(""trained"", window=w) pour w in (6, 12, 18, 24).
+#  - Etape 2 : collecter le contrast moyen par w.
+#  - Etape 3 : tracer |contrast moyen| vs window ; le verdict (dissociation) est-il stable ?
+resultats_ex2 = None  # TODO etudiant
+print(""Exercice a completer"")",,,,,,,,9e504e14e71c7ef9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,0ce96197,markdown,fr,93d0f466c5dd3ead,"## Exercice 3 — stabilité des hubs à la taille du panelLe Gate 22 utilise $K{=}64$ features. Les hubs détectés sont-ils stables quand on change cette résolution ? Répéter `differential_features(k=K)` + `workspace_candidates` pour $K \in \{32, 64, 128\}$ et mesurer le recouvrement (Jaccard) des ensembles de candidats workspace.",,,,,,,,93d0f466c5dd3ead,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,51880705,code,fr,427896e02b67f26e,"# Exercice 3 : stabilite des hubs vs taille de panel
+# TODO etudiant :
+#  - Etape 1 : pour K in (32, 64, 128), calculer panel = st.differential_features(traces[""trained""], k=K),
+#              acts continu, lagged_influence, fanout_profile, workspace_candidates(top_fraction=0.1).
+#  - Etape 2 : mesurer le recouvrement (indice de Jaccard) des ensembles d'indices entre K successifs.
+#  - Etape 3 : conclure sur la robustesse de la structure workspace au choix de K.
+resultats_ex3 = None  # TODO etudiant
+print(""Exercice a completer"")",,,,,,,,427896e02b67f26e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,59faf17c,markdown,fr,d3219e8ad5770404,"## ConclusionCe notebook confronte, **sur le même substrat S4 avec le même appareil**, la lecture IIT (complexité intégrée créditée) et la lecture GWT (workspace global / ignition). Le résultat est un **négatif honnête** :- **Gate 22 (partiel)** : une structure d'influence temporelle concentrée existe, mais elle n'est pas spécifique au modèle entraîné — le contrôle la montre également, et le seuil de concentration s'avère trop permissif.- **Gate 23 (non crédité)** : les ignitions ne portent pas, de façon robuste, les pics de complexité intégrée créditée. Le contrast est proche de zéro, dispersé entre jeux, et la fraction d'événements crédités est faible.La **branche dissociation** est le verdict observationnel : sur ce substrat, cet opérateur d'accès et cette couche, les deux théories capturent des structures qui ne co-localisent pas. C'est précisément le genre de résultat que la discipline de créditation de la série est faite pour ne pas masquer.Le **Gate 24** (phase 2, GPU) tranchera la question causale : si le clamp sélectif n'effondre pas les gains, la dissociation sera confirmée comme corrélationnelle — une leçon méthodologique de premier ordre sur la différence entre *structure observable* et *mécanisme causal*.### Pont causal do-calculusL'opérateur `do` de Pearl est ici implicite : le Gate 24 **réalise** un `do(workspace = clampé)` — une intervention chirurgicale sur le graphe, contre un `do(autant de features aléatoires = clampées)`. La même armature formelle traverse la série : voir le [Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb), qui exécute l'échelle de Pearl et les trois règles sur `dowhy` (identification backdoor/front-door + estimation + réfutation), et relie cette série à Tweety-11, Infer-5 et PyMC-5.",,,,,,,,d3219e8ad5770404,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb,88dc0e55,markdown,fr,786a13954fe0a05f,"## Références- Anthropic, *Global Workspace in Claude* (2025) — [anthropic.com/research/global-workspace](https://www.anthropic.com/research/global-workspace). Opérateur d'accès = jacobien des logits ; broadcast mesuré structurellement ; preuve maîtresse = ablation sélective. IIT/Tononi absents ; claim limité à l'access-consciousness.- Baars, B. J. — *A Cognitive Theory of Consciousness* (Global Workspace Theory).- Dehaene, S., Naccache, L., Changeux, J.-P. — l'ignition temporelle (notre lecture `ignition_events`).- Jansma, K., Hoel, E. — *Engineering Emergence* (2025) — émergence causale multi-échelle, CE 2.0. Voir [ICT-5](ICT-5-CausalEmergence.ipynb).- Série ICT : [ICT-21](ICT-21-SAETrajectoires.ipynb) (substrat S4), [ICT-5](ICT-5-CausalEmergence.ipynb) (émergence causale), [ICT-Synthese](ICT-Synthese-CrossSubstrat.ipynb).",,,,,,,,786a13954fe0a05f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,9bcd075e,markdown,fr,837c7b3a92857e06,"# ICT-3 — Robustesse & délai de gratification : étude quantitative
+
+> Série **ICT** (*Integrated Causal Trajectories*, Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588)).
+> Prérequis : [ICT-0 (cadrage)](ICT-0-Framing.md) et [ICT-2 (modèle de base)](ICT-2-SelfSortingMorphogenesis.ipynb).
+
+Le notebook [ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb) a introduit le **tri vu-cellule** (*cell-eye-view*)
+d'après Zhang, Goldstein & Levin (2025, [arXiv:2401.05375](https://arxiv.org/abs/2401.05375)) :
+chaque élément d'un tableau devient une **cellule autonome** qui applique localement la règle de son
+*algotype* (`bubble` regarde à droite, `insertion` regarde à gauche). L'ordre global **émerge** des
+décisions locales — une morphogenèse minimale, entièrement calculable.
+
+ICT-2 a *montré* deux compétences inattendues du modèle (sur un exemple chacune) :
+
+- **robustesse** — le système se trie malgré des cellules endommagées (`frozen`) ;
+- **délai de gratification** — l'ordre local se dégrade transitoirement au service du progrès global.
+
+ICT-3 **les mesure**. On passe de l'anecdote (« regardez, ça marche encore ») à l'**étude expérimentale** :
+
+1. **Dégradation gracieuse** — balayage du taux de lésion (0 → 50 %), croisé avec l'algotype et le
+   régime de gel (`passive` vs `obstacle`), moyenné sur plusieurs graines. *À quelle vitesse la
+   compétence se dégrade-t-elle quand on casse de plus en plus de cellules ?*
+2. **Temps de récupération** — distribution du temps de retour à l'ordre après une lésion exogène,
+   en fonction du régime et du taux de gel. *Le système répare-t-il, et combien de pas cela coûte-t-il ?*
+3. **Quantification du délai de gratification** — comptage des épisodes de recul local, comparé entre
+   `bubble` et `insertion`. *Quel algotype « sacrifie » le plus pour avancer ?*
+
+Le fil méthodologique de la série (cf [ICT-0](ICT-0-Framing.md)) : **exécuter, mesurer, narrer le
+résultat réel** — pas le résultat espéré.",,,,,,,,837c7b3a92857e06,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,lev1n-barr1ers-br1dge,markdown,fr,1a9c3c341c9bb110,"**Pourquoi ces deux compétences constituent un _test d'intelligence_.** Avant de les mesurer,
+rappelons ce qu'on mesure au juste. Michael Levin — dont le programme de l'**intelligence diverse**
+a inspiré le modèle vu-cellule de Zhang, Goldstein & Levin — propose une définition *opérationnelle*
+de l'intelligence : *« Intelligence is the degree of ingenuity that it has in overcoming barriers
+between it and its goal »*. L'intelligence se lit donc au degré d'**ingéniosité à franchir les
+barrières** entre un système et son but, et le protocole qui la révèle est limpide : **placer une
+barrière, observer la réponse**.
+
+C'est exactement le plan de ce notebook. Les cellules `frozen`, le régime `obstacle` et la lésion
+exogène **sont les barrières** ; la dégradation gracieuse (§1), le temps de récupération (§2) et le
+comptage du délai de gratification (§3) **mesurent l'ingéniosité** du substrat à les contourner — le
+vocabulaire cognitif n'est pas décoratif, il nomme la grandeur que chaque expérience sonde. Cadrage
+complet (spectre de la cognition, cône de lumière cognitif, « revendications-protocole ») :
+**[ICT-0 — Pourquoi parler de « compétences » ?](ICT-0-Framing.md)**.",,,,,,,,1a9c3c341c9bb110,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,f322d4f3,markdown,fr,6a4d36ac91bd92dd,"## 0. Mise en place
+
+On réutilise le package `ict/` livré avec ICT-2 (aucune dépendance lourde : bibliothèque standard +
+`numpy`/`matplotlib` pour les figures). `SelfSortingArray` porte le modèle vu-cellule ; le module
+`sorting_metrics` fournit `sortedness`, `monotonicity_curve`, `delayed_gratification_events`,
+`recovery_time`, etc.",,,,,,,,6a4d36ac91bd92dd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,bdef2a86,code,fr,f1abaa9d4294aad6,"import os
+import sys
+import random
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+# le package ict/ est a cote de ce notebook
+sys.path.insert(0, os.path.abspath("".""))
+
+from ict.self_sorting import SelfSortingArray, ALGOTYPES
+from ict import sorting_metrics as m
+
+plt.rcParams[""figure.figsize""] = (9, 4.5)
+plt.rcParams[""axes.grid""] = True
+plt.rcParams[""grid.alpha""] = 0.3
+
+N = 40            # taille du tableau d'etude
+BASE_SEED = 7     # graine de reference pour les configurations reproductibles
+print(f""Algotypes disponibles : {ALGOTYPES}"")
+print(f""Tableau d'etude : N = {N} elements"")",,,,,,,,f1abaa9d4294aad6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,6746e584,code,fr,325ca941a49f44cf,"def make_values(n, seed):
+    # une permutation aleatoire reproductible de 0..n-1
+    return random.Random(seed).sample(range(n), n)
+
+def frozen_mask(n, fraction, seed):
+    # selectionne round(fraction*n) positions gelees, reproductible par seed
+    k = round(fraction * n)
+    idx = set(random.Random(seed).sample(range(n), k))
+    return [i in idx for i in range(n)]
+
+# verification rapide : 25% de N=40 -> 10 cellules gelees
+demo_mask = frozen_mask(N, 0.25, seed=0)
+print(f""frozen_mask(0.25) -> {sum(demo_mask)} cellules gelees sur {N}"")",,,,,,,,325ca941a49f44cf,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,acd433c6,markdown,fr,7a8bd00a12ff2441,"## 1. Dégradation gracieuse de la compétence de tri
+
+**Question.** Quand on augmente la proportion de cellules cassées, le tri ne s'effondre pas d'un coup —
+il se *dégrade*. Mais comment ? Linéairement ? Avec un seuil critique ? Et le **régime de gel** change-t-il
+la donne ?
+
+Deux régimes (cf [ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb)) :
+
+- **`passive`** (fidèle au papier) — la cellule gelée n'agit pas mais reste un *passager* : une voisine
+  saine peut la déplacer. Le système reste fluide.
+- **`obstacle`** — la cellule gelée est en plus *infranchissable* : elle agit comme un **mur** qui découpe
+  le tableau en segments triés indépendamment.
+
+On balaye le taux de lésion de 0 à 50 %, pour chaque algotype et chaque régime, et on mesure la
+**sortedness finale** (1.0 = parfaitement trié), moyennée sur plusieurs graines.",,,,,,,,7a8bd00a12ff2441,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,09af3c8b,code,fr,a4af2abff6d9343a,"DAMAGE_LEVELS = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
+SEEDS = [0, 1, 7, 42, 99]   # 5 graines -> moyenne + ecart-type
+
+def final_sortedness(fraction, algotype, mode, seed):
+    vals = make_values(N, seed)
+    fz = frozen_mask(N, fraction, seed=1000 + seed)  # masque decorrele des valeurs
+    arr = SelfSortingArray(
+        vals,
+        algotypes=[algotype] * N,
+        frozen=fz,
+        seed=seed,
+        frozen_mode=mode,
+    ).run(max_steps=40000, record=False)
+    return m.sortedness(arr.values)
+
+results = {}  # (algotype, mode) -> (means, stds)
+for algotype in ALGOTYPES:
+    for mode in (""passive"", ""obstacle""):
+        means, stds = [], []
+        for frac in DAMAGE_LEVELS:
+            vals = [final_sortedness(frac, algotype, mode, s) for s in SEEDS]
+            means.append(np.mean(vals))
+            stds.append(np.std(vals))
+        results[(algotype, mode)] = (np.array(means), np.array(stds))
+
+print(""Sortedness finale (moyenne sur 5 graines) :"")
+for (algotype, mode), (means, _) in results.items():
+    pretty = "" "".join(f""{x:.2f}"" for x in means)
+    print(f""  {algotype:9s} / {mode:8s} : {pretty}"")",,,,,,,,a4af2abff6d9343a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,38c5c1a8,code,fr,b59d8505e98bee3e,"fig, axes = plt.subplots(1, 2, figsize=(12, 4.5), sharey=True)
+x = [int(100 * d) for d in DAMAGE_LEVELS]
+for ax, mode in zip(axes, (""passive"", ""obstacle"")):
+    for algotype in ALGOTYPES:
+        means, stds = results[(algotype, mode)]
+        ax.errorbar(x, means, yerr=stds, marker=""o"", capsize=3, label=algotype)
+    ax.set_title(f""Régime « {mode} »"")
+    ax.set_xlabel(""Cellules endommagées (%)"")
+    ax.axhline(0.5, color=""grey"", ls="":"", lw=1, label=""aléatoire (0.5)"")
+    ax.legend()
+axes[0].set_ylabel(""Sortedness finale"")
+fig.suptitle(""Dégradation gracieuse : le tri résiste-t-il aux cellules cassées ?"")
+plt.tight_layout()
+plt.show()",,,,,,,,b59d8505e98bee3e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,1f6f7f62,markdown,fr,fbbb52d206f73677,"**Lecture (résultat réel mesuré).** Les deux régimes partent de 1.0 à 0 % de lésion, puis décroissent —
+mais pas au même rythme. En régime `passive`, la sortedness se dégrade **graduellement** et reste
+nettement au-dessus du régime `obstacle` *et* du niveau aléatoire (0.5) sur toute la plage : les cellules
+saines transportent les passagers cassés, si bien qu'à 50 % de cellules gelées le système conserve encore
+~0.6 de sortedness. C'est la **robustesse émergente** du papier — non programmée, elle découle de la simple
+règle locale.
+
+En régime `obstacle`, la chute est plus brutale dès les premiers pourcents (chaque mur fige une frontière
+infranchissable) puis plafonne juste au-dessus de l'aléatoire : le tableau se fige en segments localement
+triés mais globalement désordonnés. L'écart entre les deux courbes — maximal aux taux faibles à modérés —
+**mesure** ce que coûte l'infranchissabilité : la différence entre « cellule défaillante mais inerte » et
+« cellule défaillante et bloquante ».",,,,,,,,fbbb52d206f73677,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,331078fb,markdown,fr,34fe4526397ef58d,"## 2. Temps de récupération après lésion
+
+**Question.** ICT-2 a montré *une* auto-réparation : on perturbe un tableau trié, il se re-trie. Mais cette
+réparation est-elle **fiable**, et quel est le **coût** (nombre de pas) — et sa distribution ?
+
+Pour isoler la compétence de réparation de la dégradation déjà étudiée en section 1, on travaille ici sur
+un **tissu sain** (aucune cellule gelée) : le tableau atteint la sortedness 1.0 avant la lésion, ce qui
+fixe une **référence nette** (revenir à 1.0). Protocole, pour chaque essai : (1) trier jusqu'au point
+fixe, (2) appliquer une lésion exogène (`perturb`, quelques échanges aléatoires), (3) relancer en
+enregistrant la courbe de sortedness, (4) mesurer `recovery_time` = nombre de pas pour revenir au niveau
+d'avant lésion. On compare les deux algotypes.",,,,,,,,34fe4526397ef58d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,58a8c570,code,fr,ac039fdd7cac2e1d,"def one_recovery(algotype, seed, n_swaps=4):
+    vals = make_values(N, seed)
+    arr = SelfSortingArray(vals, algotypes=[algotype] * N, seed=seed)  # tissu sain
+    arr.run(max_steps=40000)            # 1) tri initial -> sortedness 1.0 (enregistre)
+    pert_step = len(arr.probe)          # index de la perturbation dans la courbe
+    arr.perturb(n_swaps=n_swaps)        # 2) lesion exogene
+    arr.run(max_steps=40000)            # 3) re-tri (enregistre a la suite)
+    curve = m.sortedness_curve(arr.probe.values)  # 4) courbe complete
+    return m.recovery_time(curve, perturbation_step=pert_step)
+
+REC_SEEDS = list(range(24))   # 24 essais -> distribution
+rec = {}
+for algotype in ALGOTYPES:
+    times = [one_recovery(algotype, seed=s) for s in REC_SEEDS]
+    rec[algotype] = [t for t in times if t is not None]
+    n_fail = sum(1 for t in times if t is None)
+    arr_t = np.array(rec[algotype])
+    print(f""{algotype:9s} : {len(rec[algotype])}/{len(times)} réparés ""
+          f""| médiane={np.median(arr_t):.0f} pas | min={arr_t.min()} | max={arr_t.max()} | échecs={n_fail}"")",,,,,,,,ac039fdd7cac2e1d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,f82e995c,code,fr,304700e7f3799ba9,"fig, ax = plt.subplots()
+all_max = max(max(rec[a]) for a in ALGOTYPES)
+bins = np.linspace(0, all_max + 1, 16)
+for algotype, color in ((""bubble"", ""tab:blue""), (""insertion"", ""tab:orange"")):
+    ax.hist(rec[algotype], bins=bins, alpha=0.55,
+            label=f""{algotype} (médiane {np.median(rec[algotype]):.0f})"", color=color)
+ax.set_xlabel(""Temps de récupération (pas)"")
+ax.set_ylabel(""Nombre d'essais"")
+ax.set_title(""Distribution du temps d'auto-réparation après lésion (tissu sain)"")
+ax.legend()
+plt.tight_layout()
+plt.show()",,,,,,,,304700e7f3799ba9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,0d235c9d,markdown,fr,90ed6b992752ccce,"**Lecture (résultat réel mesuré).** Sur tissu sain, l'auto-réparation est **systématique** : les 24
+essais des deux algotypes reviennent à la sortedness 1.0 — la lésion exogène est toujours résorbée. Le
+résultat intéressant n'est donc pas *si* le système répare, mais *combien cela coûte* : le temps de
+récupération est une **distribution** large (de quelques centaines à plus de mille pas selon la graine),
+pas une constante. `bubble` répare en médiane un peu plus vite que `insertion`, mais les deux distributions
+se recouvrent largement — la différence d'algotype pèse moins que l'aléa de la lésion.
+
+La robustesse n'est donc pas un oui/non : c'est une *loi de probabilité* sur le coût de réparation. La
+section 1 a montré l'autre face — quand le tissu est lui-même endommagé (cellules gelées, *a fortiori* en
+mur), la réparation peut ne plus aboutir du tout.",,,,,,,,90ed6b992752ccce,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,0fbb2e80,markdown,fr,eff9ad5a690eef4d,"## 3. Quantification du délai de gratification
+
+**Question.** Le *délai de gratification* est l'idée qu'un système doive **empirer localement** pour
+progresser globalement. Dans le tri vu-cellule, on le mesure sur la courbe d'**erreur de monotonie**
+(`monotonicity_error` = fraction de paires adjacentes en descente) : chaque pas où cette erreur *augmente*
+est un épisode de recul local au service du progrès global (`delayed_gratification_events`).
+
+`bubble` (migration des grandes valeurs vers la droite) et `insertion` (migration des petites vers la
+gauche) n'ont pas la même façon d'avancer. Lequel « sacrifie » le plus ?",,,,,,,,eff9ad5a690eef4d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,bef5e49b,code,fr,df08a1f45778f485,"def dg_profile(algotype, seed):
+    vals = make_values(N, seed)
+    arr = SelfSortingArray(vals, algotypes=[algotype] * N, seed=seed)
+    arr.run(max_steps=40000)
+    mono = m.monotonicity_curve(arr.probe.values)
+    sort_curve = m.sortedness_curve(arr.probe.values)
+    events = m.delayed_gratification_events(mono)
+    return mono, sort_curve, events
+
+dg_counts = {a: [] for a in ALGOTYPES}
+for algotype in ALGOTYPES:
+    for s in SEEDS:
+        _, _, ev = dg_profile(algotype, s)
+        dg_counts[algotype].append(ev)
+
+print(""Épisodes de délai de gratification (recul local de la monotonie) :"")
+for a in ALGOTYPES:
+    arr_e = np.array(dg_counts[a])
+    print(f""  {a:9s} : moyenne={arr_e.mean():.1f}  (min={arr_e.min()}, max={arr_e.max()})"")",,,,,,,,df08a1f45778f485,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,4d0fdf04,code,fr,0f3957adc46c0eab,"# trace temoin : monotonie (peut remonter) vs sortedness (progresse) pour une graine
+fig, axes = plt.subplots(1, 2, figsize=(12, 4.5))
+for algotype, color in ((""bubble"", ""tab:blue""), (""insertion"", ""tab:orange"")):
+    mono, sort_curve, ev = dg_profile(algotype, seed=BASE_SEED)
+    axes[0].plot(mono, color=color, label=f""{algotype} ({ev} reculs)"")
+    axes[1].plot(sort_curve, color=color, label=algotype)
+axes[0].set_title(""Erreur de monotonie (locale) — remonte = délai de gratification"")
+axes[0].set_xlabel(""Pas""); axes[0].set_ylabel(""Erreur de monotonie""); axes[0].legend()
+axes[1].set_title(""Sortedness (globale) — progresse vers 1.0"")
+axes[1].set_xlabel(""Pas""); axes[1].set_ylabel(""Sortedness""); axes[1].legend()
+plt.tight_layout()
+plt.show()",,,,,,,,0f3957adc46c0eab,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,4d967799,markdown,fr,66d7bbb62c44b106,"**Lecture (résultat réel mesuré).** Les deux algotypes convergent (sortedness → 1.0), mais la courbe
+d'erreur de monotonie **remonte** des dizaines de fois en cours de route : le système accepte régulièrement
+des descentes locales pour réorganiser globalement. Le comptage est **élevé et comparable** entre les deux
+règles (~90 épisodes en moyenne pour N=40), `bubble` en exhibant marginalement plus que `insertion` — la
+nature du délai de gratification est donc une propriété du *paradigme* vu-cellule, pas d'un algotype
+particulier. Ce comportement, qu'on prête d'ordinaire aux agents cognitifs, **émerge** ici d'une règle de
+tri triviale : exactement le point de Zhang, Goldstein & Levin.",,,,,,,,66d7bbb62c44b106,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,0ece8ca2,markdown,fr,1b64a206a6160618,"## 4. Exercices
+
+Les exercices réutilisent le package `ict/` déjà importé. Complétez les stubs (`# TODO`) ; chaque
+exercice s'exécute indépendamment.",,,,,,,,1b64a206a6160618,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,e6d7b9c5,markdown,fr,b011ce9df1de5aba,"### Exercice 1 — Dégradation mesurée sur une autre métrique
+
+La section 1 a mesuré la dégradation via la **sortedness finale**. La sortedness sature vite (toute
+configuration presque triée donne ~1.0). Une mesure plus fine du « chemin restant » est
+`distance_to_target` (somme des déplacements de rang restants).
+
+**Objectif.** Reproduire le balayage de dégradation (régime `passive`, algotype `bubble`) mais en mesurant
+la `distance_to_target` finale **normalisée** par celle de l'état initial mélangé, et tracer la courbe.
+Une valeur proche de 0 = presque tout le désordre résorbé ; proche de 1 = le tri n'a rien résorbé.",,,,,,,,b011ce9df1de5aba,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,a1a374e9,code,fr,95d5299a4d1f2ab5,"def residual_distance(fraction, seed):
+    # Distance au tri finale / distance initiale, regime passive, bubble.
+    # TODO etudiant :
+    #   1. construire les valeurs (make_values) et le masque (frozen_mask)
+    #   2. mesurer d0 = m.distance_to_target(vals) AVANT le tri
+    #   3. lancer SelfSortingArray(...).run(max_steps=40000, record=False)
+    #   4. retourner m.distance_to_target(final) / d0  (gerer d0 == 0)
+    # Indice : reprendre la structure de final_sortedness (section 1)
+    return None  # TODO etudiant
+
+# Une fois implemente, decommenter pour tracer :
+# levels = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
+# curve = [np.mean([residual_distance(f, s) for s in SEEDS]) for f in levels]
+# plt.plot([int(100*f) for f in levels], curve, marker=""o"")
+# plt.xlabel(""Cellules endommagees (%)""); plt.ylabel(""Distance residuelle (normalisee)"")
+# plt.title(""Exercice 1 - degradation vue par distance_to_target""); plt.show()
+print(""Exercice 1 a completer"")",,,,,,,,95d5299a4d1f2ab5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,a69e7217,markdown,fr,2f06d290ba4a2c76,"### Exercice 2 — Le coût de réparation dépend-il de l'amplitude de la lésion ?
+
+La section 2 a utilisé une lésion fixe (`n_swaps=4`). Intuitivement, une lésion plus forte devrait coûter
+plus cher à réparer.
+
+**Objectif.** En régime `passive` sans cellule gelée, mesurer le temps de récupération médian en fonction
+de l'amplitude `n_swaps` ∈ {1, 2, 4, 8, 16}, sur plusieurs graines, et tracer la relation.",,,,,,,,2f06d290ba4a2c76,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,49ff6e6b,code,fr,bebf1e766cec2028,"def median_recovery_for_amplitude(n_swaps, seeds):
+    # Temps de recuperation median pour une amplitude de lesion donnee.
+    # TODO etudiant :
+    #   1. pour chaque graine, appeler one_recovery(""bubble"", seed=s, n_swaps=n_swaps)
+    #      (fonction definie en section 2, sur tissu sain)
+    #   2. ignorer les None (non repares)
+    #   3. retourner la mediane (np.median) des temps, ou None si liste vide
+    # Indice : one_recovery accepte deja le parametre n_swaps
+    return None  # TODO etudiant
+
+# amplitudes = [1, 2, 4, 8, 16]
+# meds = [median_recovery_for_amplitude(a, range(16)) for a in amplitudes]
+# plt.plot(amplitudes, meds, marker=""s"")
+# plt.xlabel(""Amplitude de la lesion (n_swaps)""); plt.ylabel(""Temps de recuperation median"")
+# plt.title(""Exercice 2 - cout de reparation vs amplitude""); plt.show()
+print(""Exercice 2 a completer"")",,,,,,,,bebf1e766cec2028,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,bc3f7c89,markdown,fr,a6ddf91dedc21bbe,"### Exercice 3 — Le délai de gratification croît-il avec la taille du tableau ?
+
+La section 3 a comparé `bubble` et `insertion` à taille fixe (`N=40`). On veut savoir comment le nombre
+d'épisodes de délai de gratification **évolue avec la taille** du système.
+
+**Objectif.** Pour `bubble`, mesurer le nombre moyen d'épisodes `delayed_gratification_events` (sur la
+courbe d'erreur de monotonie) pour des tailles `n` ∈ {10, 20, 40, 80}, moyenné sur quelques graines, et
+tracer la relation. Discuter : croissance linéaire, sur-linéaire ?",,,,,,,,a6ddf91dedc21bbe,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,1cd4a01d,code,fr,11062eb305320119,"def mean_dg_for_size(n, seeds):
+    # Nombre moyen d'episodes de delai de gratification pour un tableau de taille n.
+    # TODO etudiant :
+    #   1. pour chaque graine s : vals = random.Random(s).sample(range(n), n)
+    #   2. arr = SelfSortingArray(vals, algotypes=[""bubble""]*n, seed=s) ; arr.run(max_steps=40000)
+    #   3. mono = m.monotonicity_curve(arr.probe.values)
+    #   4. accumuler m.delayed_gratification_events(mono)
+    #   5. retourner la moyenne sur les graines
+    # Indice : la trajectoire complete est dans arr.probe.values (cf section 3, dg_profile)
+    return None  # TODO etudiant
+
+# sizes = [10, 20, 40, 80]
+# vals = [mean_dg_for_size(n, range(4)) for n in sizes]
+# plt.plot(sizes, vals, marker=""^"")
+# plt.xlabel(""Taille du tableau (n)""); plt.ylabel(""Episodes de delai de gratification (moyenne)"")
+# plt.title(""Exercice 3 - delai de gratification vs taille""); plt.show()
+print(""Exercice 3 a completer"")",,,,,,,,11062eb305320119,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb,9a0ca500,markdown,fr,c75f4467dfe6149e,"## 5. Conclusion
+
+ICT-3 a transformé les deux démonstrations ponctuelles d'ICT-2 en **mesures** :
+
+- **Dégradation gracieuse** — la robustesse n'est pas binaire : la sortedness finale décroît *lentement*
+  avec le taux de lésion en régime `passive`, *rapidement* en régime `obstacle`. L'écart chiffre le coût
+  de l'infranchissabilité.
+- **Temps de récupération** — sur tissu sain, l'auto-réparation est *systématique* (24/24 essais reviennent
+  à 1.0) mais son **coût** est une *distribution* large (centaines à >1000 pas) ; `bubble` répare en médiane
+  un peu plus vite qu'`insertion`, l'écart d'algotype pesant moins que l'aléa de la lésion.
+- **Délai de gratification** — le recul local au service du progrès global se compte
+  (`delayed_gratification_events`) : il est **élevé et comparable** entre algotypes (~90 épisodes pour N=40),
+  donc propriété du paradigme vu-cellule ; il **émerge** d'une règle de tri triviale.
+
+Ces compétences — robustesse, réparation, patience — ne sont **programmées nulle part**. Elles découlent
+de la dynamique locale, ce qui est précisément la thèse de Zhang, Goldstein & Levin : un substrat minimal
+exhibe des compétences « basales » qu'on associe d'ordinaire à des agents cognitifs.
+
+**Suite de la série.** [ICT-4](ICT-0-Framing.md) abordera l'**agrégation par algotype** (« kin ») avec un
+jeu de règles plus riche — le modèle minimal d'ICT-2/3 ne la reproduit pas (ses règles uni-directionnelles
+produisent des impasses de coordination). [ICT-5/6](ICT-0-Framing.md) relieront ces trajectoires de tri à
+l'**émergence causale multi-échelle** (TPM → PyPhi).
+
+### Voir aussi
+- [ICT-0 — Cadrage de la série](ICT-0-Framing.md)
+- [ICT-2 — Self-sorting arrays : le tri comme morphogenèse](ICT-2-SelfSortingMorphogenesis.ipynb)
+- Zhang, Goldstein & Levin, *Classical sorting algorithms as a model of morphogenesis*, Adaptive Behavior 2025 — [arXiv:2401.05375](https://arxiv.org/abs/2401.05375).",,,,,,,,c75f4467dfe6149e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,9b4e81d5,markdown,fr,06a443ded93af20a,"# ICT-4 — Tableaux chimériques & agrégation émergente (« kin »)
+
+> Série **Integrated Causal Trajectories** ([ICT-0 — cadrage](ICT-0-Framing.md), Epic **#4588**).
+> Ce notebook prolonge directement **[ICT-2 — Le tri comme morphogenèse](ICT-2-SelfSortingMorphogenesis.ipynb)**.
+
+Dans [ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb), un tableau dont les cellules se trient elles-mêmes — chacune suivant la règle locale de son *algotype* (`bubble` regarde à droite, `insertion` regarde à gauche) — reproduit fidèlement plusieurs **compétences inattendues** du papier de Zhang, Goldstein & Levin (2025) : robustesse aux cellules défectueuses, délai de gratification, auto-réparation. Mais une compétence *positive* manquait à l'appel : l'**agrégation par « kin »**, ce penchant qu'ont les cellules de même algotype à se regrouper pendant le voyage, sans que cela soit encodé comme objectif. Le modèle minimal produisait au contraire des **impasses** aux frontières `insertion | bubble`. ICT-2 l'a dit honnêtement et a renvoyé l'agrégation à **ce notebook**, « avec un jeu de règles plus riche ».
+
+**La question d'ICT-4.** Quel enrichissement *minimal* des règles locales fait émerger l'agrégation « kin » — sans jamais l'inscrire comme but global, et sans casser le tri ?
+
+Nous procédons en trois temps :
+
+1. **Rappel** de l'impasse chimérique d'ICT-2 (règles minimales).
+2. **Réparation bidirectionnelle** : un coup d'œil au second voisin guérit l'impasse — mais ne crée *aucune* agrégation.
+3. **Affinité « kin »** : un second élan, *neutre pour l'ordre*, qui s'exprime dans les **degrés de liberté** laissés par le tri. L'agrégation émerge alors — et nous **mesurons** où, quand, et à quelles conditions.
+
+Le fil rouge de la série reste la **discipline d'honnêteté** : exécuter, mesurer, et *narrer le résultat réel* plutôt que celui qu'on espérait.",,,,,,,,06a443ded93af20a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,e161bb6f,code,fr,2ab58cc374f570b8,"# --- Imports et configuration ---
+import sys, os, random
+sys.path.insert(0, os.path.abspath("".""))  # le package `ict/` est a cote de ce notebook
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from ict.self_sorting import SelfSortingArray, ALGOTYPES
+from ict.kin_sorting import KinSortingArray
+from ict import sorting_metrics as m
+
+plt.rcParams[""figure.figsize""] = (8, 4)
+plt.rcParams[""axes.grid""] = True
+
+def perm(k, rng):
+    """"""Permutation de 0..k-1 en entiers Python natifs (valeurs distinctes).""""""
+    return [int(x) for x in rng.permutation(k)]
+
+def value_classes(n_classes, copies, seed=0):
+    """"""Tableau melange ou chaque valeur apparait `copies` fois -- des classes de
+    'destins equivalents' pour le tri, qui ouvrent des degres de liberte pour
+    l'organisation secondaire. Un algotype aleatoire par cellule.""""""
+    r = random.Random(seed)
+    vals = [c for c in range(n_classes) for _ in range(copies)]
+    algos = [ALGOTYPES[r.randint(0, 1)] for _ in vals]
+    idx = list(range(len(vals))); r.shuffle(idx)
+    return [vals[i] for i in idx], [algos[i] for i in idx]
+
+def sorted_with_mixed_algos(n_classes, copies, seed=0):
+    """"""Tableau DEJA trie par valeur, algotypes melanges : l'ordre primaire est
+    satisfait, seuls les mouvements 'kin' operent -> agregation isolee.""""""
+    r = random.Random(seed)
+    vals = [c for c in range(n_classes) for _ in range(copies)]
+    algos = [ALGOTYPES[r.randint(0, 1)] for _ in vals]
+    return vals, algos
+
+print(""Algotypes :"", ALGOTYPES, ""| package ict/ charge (SelfSortingArray, KinSortingArray)"")",,,,,,,,2ab58cc374f570b8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,bf1380c4,markdown,fr,6cbc5e153ed99577,"## 1. Rappel : l'impasse chimérique d'ICT-2
+
+`bubble` (pousse les grandes valeurs vers la droite) et `insertion` (tire les petites vers la gauche) servent le **même** ordre croissant. On pourrait croire qu'un tableau **chimérique** — qui mélange les deux — se trie aussi. Vérifions, sur le modèle minimal d'ICT-2, ce qui se passe *vraiment* lorsque les algotypes alternent.",,,,,,,,6cbc5e153ed99577,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,12176090,code,fr,b3048109dbc80ed0,"# --- Exemple guide : le modele minimal (ICT-2) sur des tableaux chimeriques alternes ---
+N, n_seeds = 20, 40
+non_tries, inv_res, agg_fin = 0, [], []
+for s in range(n_seeds):
+    v = perm(N, np.random.default_rng(s))
+    algos = [ALGOTYPES[i % 2] for i in range(N)]            # alternance bubble/insertion
+    arr = SelfSortingArray(v, algotypes=algos, seed=s).run()
+    if arr.values != sorted(v):
+        non_tries += 1
+        inv_res.append(m.inversion_count(arr.values))
+    agg_fin.append(m.aggregation_index(arr.algotypes))
+
+print(f""Modele minimal (ICT-2) -- {n_seeds} graines, alternance bubble/insertion :"")
+print(f""  tableaux NON entierement tries : {non_tries}/{n_seeds}"")
+print(f""  inversions residuelles (impasses) : moyenne = {np.mean(inv_res):.1f}"" if inv_res
+      else ""  aucune impasse residuelle"")
+print(f""  indice d'agregation final moyen   : {np.mean(agg_fin):+.3f}  (negatif : alternance figee, aucun regroupement)"")",,,,,,,,b3048109dbc80ed0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,30f085a7,markdown,fr,4e08ab5180dfd7f7,"**Interprétation — le diagnostic.** L'alternance `bubble | insertion` se fige presque systématiquement sur des **impasses** : une frontière `insertion | bubble` en désordre est un point fixe local (la cellule de gauche ne regarde qu'à gauche, celle de droite qu'à droite — l'inversion qui les sépare n'est dans le champ de vision de personne). Et l'indice d'agrégation reste **négatif** : l'alternance de départ est *anti-groupée* (les semblables sont systématiquement séparés), et l'impasse la fige dans cet état — rien, dans les règles minimales, n'incite une cellule à se rapprocher de ses semblables. Deux manques distincts, donc : (a) la **coordination** échoue, et (b) aucune **préférence kin** n'est encodée. Traitons-les l'un après l'autre.",,,,,,,,4e08ab5180dfd7f7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,23191c06,markdown,fr,151019c02640eb65,"## 2. Première règle plus riche : la réparation bidirectionnelle
+
+L'Exercice 3 d'ICT-2 suggérait le remède au manque (a) : *« une cellule qui, lorsqu'elle est bloquée, jette aussi un coup d'œil à son autre voisin briserait la frontière `insertion | bubble` »*. C'est exactement la règle de `KinSortingArray(bidirectional=True)` : chaque cellule garde la **personnalité** de son algotype (sa direction de regard *primaire*), mais lorsque cette direction ne propose rien, elle **répare** une inversion du côté opposé. Toute inversion adjacente devient alors corrigeable par l'une de ses deux extrémités — l'impasse disparaît.",,,,,,,,151019c02640eb65,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,56b1db3f,code,fr,8e8cd08c583e8745,"# --- Exemple guide : reparation bidirectionnelle (kin_affinity desactive) ---
+non_tries, agg_fin = 0, []
+for s in range(n_seeds):
+    v = perm(N, np.random.default_rng(s))
+    algos = [ALGOTYPES[i % 2] for i in range(N)]
+    arr = KinSortingArray(v, algotypes=algos, seed=s,
+                          bidirectional=True, kin_affinity=False).run()
+    if arr.values != sorted(v):
+        non_tries += 1
+    agg_fin.append(m.aggregation_index(arr.algotypes))
+
+print(f""Reparation bidirectionnelle -- {n_seeds} graines, alternance :"")
+print(f""  tableaux NON tries : {non_tries}/{n_seeds}  (l'impasse est guerie)"")
+print(f""  indice d'agregation final moyen : {np.mean(agg_fin):+.3f}  (toujours proche de 0)"")",,,,,,,,8e8cd08c583e8745,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,6b403363,markdown,fr,808840a52a2a354f,"**Interprétation — coordonner ne suffit pas à agréger.** La réparation bidirectionnelle **guérit l'impasse** : les tableaux se trient désormais tous. Et l'indice d'agrégation remonte à **quasiment zéro** : libérée du blocage, la disposition des algotypes devient *indifférente* (ni groupée, ni anti-groupée). Réussir le tri et faire émerger un regroupement par algotype sont **deux compétences distinctes** : la première relève de la coordination, la seconde demande une *préférence* qui n'existe encore nulle part. La compétence que cherchait ICT-2 est ailleurs.",,,,,,,,808840a52a2a354f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,803b5cdb,markdown,fr,859b2a1263540b51,"## 3. Deuxième règle plus riche : l'affinité « kin » dans les degrés de liberté
+
+Pour faire émerger l'agrégation, ajoutons un **second élan**, *neutre pour l'ordre*. L'idée-clé : deux cellules de **même valeur** sont **interchangeables** pour l'objectif de tri — des « destins équivalents ». L'ordre croissant ne les départage pas : il leur laisse un **degré de liberté**. C'est précisément là que la préférence pour le semblable peut s'exprimer sans rien casser.
+
+`KinSortingArray(kin_affinity=True)` ajoute donc cette règle : quand une cellule n'a aucun mouvement de tri à faire, elle peut échanger sa place avec un voisin de **valeur égale** si cet échange **augmente** le nombre de paires adjacentes de même algotype. Le tri est strictement préservé (on n'échange que des égaux) ; ce qui s'organise, c'est une couche **secondaire** par algotype.
+
+Pour rendre ces degrés de liberté disponibles, nous travaillons sur des tableaux à **valeurs répétées** (`value_classes` : `n_classes` valeurs distinctes, chacune en `copies` exemplaires).
+
+Isolons d'abord le mécanisme : partons d'un tableau **déjà trié par valeur** (l'ordre primaire est satisfait — *seuls* les mouvements « kin » opèrent).",,,,,,,,859b2a1263540b51,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,78695ac9,code,fr,4775ac118c4fe28e,"# --- Exemple guide : l'agregation kin isolee (tableau deja trie, kin-only) ---
+vals, algos = sorted_with_mixed_algos(n_classes=6, copies=4, seed=1)   # 24 cellules
+arr = KinSortingArray(vals, algotypes=algos, seed=1, kin_affinity=True).run()
+courbe = m.aggregation_curve(arr.probe.algotypes)
+
+print(""Tableau deja trie par valeur, algotypes melanges (seuls les mouvements kin operent)"")
+print(f""  trie ? {arr.values == sorted(vals)}  | pas effectues : {arr.steps}"")
+print(f""  agregation : debut = {courbe[0]:+.3f}  ->  fin = {courbe[-1]:+.3f}"")
+print(f""  courbe non decroissante ? {all(b >= a - 1e-9 for a, b in zip(courbe, courbe[1:]))}"")
+
+plt.figure()
+plt.plot(courbe, lw=2, color=""tab:green"")
+plt.axhline(0, color=""grey"", lw=0.8, ls=""--"")
+plt.xlabel(""pas de simulation""); plt.ylabel(""indice d'agregation 'kin'"")
+plt.title(""L'agregation emerge dans les degres de liberte (mouvements kin seuls)"")
+plt.show()",,,,,,,,4775ac118c4fe28e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,a3653640,markdown,fr,ba552f0d578c7349,"**Interprétation — un ordre secondaire dans le jeu laissé par le premier.** La courbe monte **de façon monotone** : chaque mouvement « kin » augmente strictement le voisinage entre semblables, jamais ne le défait. L'agrégation s'installe **sans contrôleur global** et **sans toucher au tri** — elle vit entièrement dans les degrés de liberté que l'ordre des valeurs laisse ouverts. C'est une seconde couche d'organisation causale qui s'installe *par-dessus* la première, là où celle-ci est indifférente. Le motif est profond : la série ICT le retrouvera à l'échelle macro (émergence causale, [ICT-5](ICT-5-CausalEmergence.ipynb) / [ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb)).",,,,,,,,ba552f0d578c7349,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,fa335c92,code,fr,c39387002f1b63f0,"# --- Exemple guide : depuis un tableau chimerique melange (tri ET agregation) ---
+vals, algos = value_classes(n_classes=6, copies=4, seed=3)
+arr_on  = KinSortingArray(vals, algotypes=algos, seed=3, kin_affinity=True ).run()
+arr_off = KinSortingArray(vals, algotypes=algos, seed=3, kin_affinity=False).run()   # controle
+
+agg_on = m.aggregation_curve(arr_on.probe.algotypes)
+srt_on = m.sortedness_curve(arr_on.probe.values)
+
+print(""Depuis un tableau chimerique melange (seed=3) :"")
+print(f""  kin ON  : trie = {arr_on.values  == sorted(vals)} | agregation finale = {agg_on[-1]:+.3f}"")
+print(f""  kin OFF : trie = {arr_off.values == sorted(vals)} | agregation finale = ""
+      f""{m.aggregation_index(arr_off.algotypes):+.3f}"")
+
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 4))
+ax1.plot(srt_on, color=""tab:blue""); ax1.set_title(""Sortedness (ordre des valeurs)"")
+ax1.set_xlabel(""pas""); ax1.set_ylabel(""sortedness""); ax1.set_ylim(0, 1.05)
+ax2.plot(agg_on, color=""tab:green""); ax2.axhline(0, color=""grey"", lw=0.8, ls=""--"")
+ax2.set_title(""Agregation 'kin' (organisation secondaire)"")
+ax2.set_xlabel(""pas""); ax2.set_ylabel(""indice d'agregation"")
+plt.tight_layout(); plt.show()",,,,,,,,c39387002f1b63f0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,8d3c82f7,markdown,fr,37818e4a98496f5a,"**Interprétation — les deux compétences à la fois.** Partant d'un tableau chimérique entièrement mélangé, les règles enrichies livrent **simultanément** le tri global (la *sortedness* atteint 1.0) et une agrégation « kin » finale **positive** — la compétence que le modèle minimal d'ICT-2 ne pouvait pas atteindre. La courbe d'agrégation est ici **bruitée** : pendant que les valeurs migrent vers leur place, elles entraînent les algotypes avec elles et défont transitoirement des regroupements, que les mouvements kin reconstruisent ensuite. L'organisation secondaire ne se met vraiment en place qu'une fois la liberté libérée — c'est-à-dire à mesure que le tri se stabilise.",,,,,,,,37818e4a98496f5a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,ad2359a3,markdown,fr,fd3d63d634ff8587,"## 4. Mesure honnête : l'agrégation vit dans les degrés de liberté
+
+Si l'agrégation émerge dans le jeu laissé par l'ordre, alors **sans jeu, pas d'agrégation**. Testons-le directement : faisons varier la **taille des classes de valeurs** (`copies`) — donc la quantité de liberté disponible — à nombre de cellules constant (24), et comparons l'agrégation finale **avec** et **sans** l'élan « kin », sur plusieurs graines.",,,,,,,,fd3d63d634ff8587,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,1cb09765,code,fr,539cb515416f7c38,"# --- Exemple guide : balayage de la 'liberte' disponible (taille des classes) ---
+n_total, seeds = 24, range(10)
+copies_list = [1, 2, 3, 4, 6, 8]
+moy_on, moy_off, std_on = [], [], []
+for copies in copies_list:
+    nc = n_total // copies
+    on, off = [], []
+    for s in seeds:
+        vals, algos = value_classes(nc, copies, seed=s)
+        a = KinSortingArray(vals, algotypes=algos, seed=s, kin_affinity=True ).run()
+        b = KinSortingArray(vals, algotypes=algos, seed=s, kin_affinity=False).run()
+        assert a.values == sorted(vals) and b.values == sorted(vals)   # tri toujours preserve
+        on.append(m.aggregation_index(a.algotypes))
+        off.append(m.aggregation_index(b.algotypes))
+    moy_on.append(np.mean(on)); std_on.append(np.std(on)); moy_off.append(np.mean(off))
+
+for c, mo, mf in zip(copies_list, moy_on, moy_off):
+    print(f""  copies={c} (n_classes={n_total // c:2d}) : kin ON = {mo:+.3f} | kin OFF = {mf:+.3f}"")
+
+plt.figure()
+x = np.arange(len(copies_list))
+plt.errorbar(x, moy_on, yerr=std_on, marker=""o"", lw=2, capsize=4, label=""kin ON (attraction)"")
+plt.plot(x, moy_off, marker=""s"", lw=2, ls=""--"", color=""grey"", label=""kin OFF (controle)"")
+plt.axhline(0, color=""black"", lw=0.6)
+plt.xticks(x, [f""{c}\n(nc={n_total // c})"" for c in copies_list])
+plt.xlabel(""copies par valeur  ->  liberte croissante"")
+plt.ylabel(""indice d'agregation final (moy. sur graines)"")
+plt.title(""Sans degres de liberte (copies=1), aucune agregation possible"")
+plt.legend(); plt.show()",,,,,,,,539cb515416f7c38,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,8c4a33a5,markdown,fr,2ed73f45beb2a516,"**Interprétation — la thèse, confirmée empiriquement.** À `copies=1` (toutes les valeurs distinctes), l'ordre contraint **entièrement** le tableau : il ne reste aucun degré de liberté, et l'agrégation est **nulle, que l'élan kin soit actif ou non**. Dès que les valeurs se répètent (`copies ≥ 2`), la courbe « kin ON » décolle et croît avec la liberté disponible, tandis que le contrôle reste à zéro. La compétence d'agrégation est donc **réelle mais conditionnelle** : elle n'existe que là où l'ordre primaire laisse du jeu. Mesurer cette condition — plutôt que de proclamer « le modèle agrège » — est la discipline d'honnêteté de la série ICT.",,,,,,,,2ed73f45beb2a516,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,dc0e2537,markdown,fr,c5881fded55880ea,"## 5. Exercices
+
+Trois exercices pour s'approprier le mécanisme. Les cellules de code sont des **squelettes à compléter** (`# TODO`) ; le notebook s'exécute de bout en bout même si vous ne les complétez pas.",,,,,,,,c5881fded55880ea,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,c452051b,markdown,fr,bfe75bde660b646a,"### Exercice 1 — L'agrégation a besoin de liberté
+
+**Objectif.** Vérifier par vous-même qu'**aucune** agrégation n'émerge sur un tableau à **valeurs distinctes**, même avec l'élan « kin » activé.
+
+**Indices.**
+- `# Etape 1` : construire un tableau à valeurs distinctes (`perm`) avec des algotypes mélangés.
+- `# Etape 2` : le faire tourner avec `KinSortingArray(..., kin_affinity=True)`.
+- `# Etape 3` : renvoyer `m.aggregation_index(arr.algotypes)` et le comparer à 0.",,,,,,,,bfe75bde660b646a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,27f9e752,code,fr,6e2f76e72f16ab5a,"# Exercice 1 : l'affinite kin sans degres de liberte
+def agregation_sur_valeurs_distinctes(n=24, seed=0):
+    rng = np.random.default_rng(seed)
+    # Etape 1 : valeurs distinctes + algotypes melanges
+    # Etape 2 : KinSortingArray(..., kin_affinity=True).run()
+    # Etape 3 : renvoyer l'indice d'agregation final
+    result = None  # TODO etudiant
+    return result
+
+# print(agregation_sur_valeurs_distinctes())   # attendu : proche de 0",,,,,,,,6e2f76e72f16ab5a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,e648f86b,markdown,fr,ec51d158252bccc1,"### Exercice 2 — Le coût de l'affinité
+
+**Objectif.** L'élan « kin » ajoute-t-il du travail ? Comparer le **nombre de pas** jusqu'au point fixe avec et sans affinité, sur des tableaux à valeurs répétées.
+
+**Indices.**
+- `# Etape 1` : pour plusieurs graines, construire un `value_classes(6, 4, seed)`.
+- `# Etape 2` : mesurer `arr.steps` pour `kin_affinity=True` puis `kin_affinity=False`.
+- `# Etape 3` : renvoyer la moyenne des pas dans chaque régime et conclure.",,,,,,,,ec51d158252bccc1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,f7354b1f,code,fr,95ccc0db13fd3762,"# Exercice 2 : cout en pas de l'affinite kin
+def cout_kin(n_seeds=10):
+    pas_on, pas_off = [], []
+    for s in range(n_seeds):
+        vals, algos = value_classes(6, 4, seed=s)
+        # Etape 1-2 : faire tourner les deux regimes, collecter arr.steps
+        pass  # TODO etudiant
+    # Etape 3 : renvoyer (moyenne pas_on, moyenne pas_off)
+    result = None  # TODO etudiant
+    return result
+
+# print(cout_kin())",,,,,,,,95ccc0db13fd3762,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,c7a76b5b,markdown,fr,df501a0e456c89c0,"### Exercice 3 — Affinité répulsive : la ségrégation
+
+**Objectif.** `KinSortingArray` accepte un paramètre `kin_sign` : `+1` attire les semblables (défaut), `-1` les **repousse** (une dynamique à la *Schelling*). Vérifier que la répulsion produit une agrégation **négative** — une ségrégation des algotypes — tout en préservant le tri.
+
+**Indices.**
+- `# Etape 1` : un `value_classes(6, 4, seed)` ; faire tourner avec `kin_sign=-1`.
+- `# Etape 2` : vérifier que le tableau est trié, puis mesurer `m.aggregation_index(...)`.
+- `# Etape 3` : comparer aux régimes attraction (`+1`) et neutre (`kin_affinity=False`).",,,,,,,,df501a0e456c89c0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,e077d036,code,fr,e0d7379545e73eaa,"# Exercice 3 : repulsion (segregation a la Schelling)
+def trois_regimes(seed=0):
+    vals, algos = value_classes(6, 4, seed=seed)
+    # Etape 1-3 : agregation finale pour kin_sign=+1, kin_affinity=False, puis kin_sign=-1
+    result = None  # TODO etudiant : dict {""attraction"": ..., ""neutre"": ..., ""repulsion"": ...}
+    return result
+
+# print(trois_regimes())   # attendu : attraction > 0 > repulsion, tri preserve partout",,,,,,,,e0d7379545e73eaa,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb,84b096b9,markdown,fr,8a6aa94f2d57a214,"## 6. Conclusion et perspectives
+
+ICT-4 ferme la boucle ouverte par ICT-2. Avec un jeu de règles **à peine** plus riche que le modèle minimal :
+
+- la **réparation bidirectionnelle** guérit l'impasse chimérique (coordination) — mais n'agrège pas ;
+- l'**affinité « kin »**, neutre pour l'ordre, fait **émerger** le regroupement par algotype dans les **degrés de liberté** laissés par le tri ;
+- cette émergence est **réelle mais conditionnelle** : sans valeurs répétées (sans jeu), elle disparaît — ce que le balayage a montré honnêtement ;
+- le **signe** de l'affinité bascule l'agrégation en **ségrégation** (Schelling), sans jamais toucher au tri.
+
+La leçon dépasse le tri : une organisation causale **secondaire** peut s'installer dans l'indifférence d'une organisation **primaire**. C'est l'intuition que la série pousse ensuite à l'échelle macro.
+
+### Ponts avec le reste de la série
+- **[ICT-2 — Self-sorting morphogenesis](ICT-2-SelfSortingMorphogenesis.ipynb)** : le modèle minimal, ses compétences, et l'impasse que ce notebook lève.
+- **[ICT-5 — Émergence causale](ICT-5-CausalEmergence.ipynb)** & **[ICT-6 — Pont tri → TPM](ICT-6-SortingToTPM-CausalEmergence.ipynb)** : la même idée — un ordre plus lisible dans les degrés de liberté du niveau inférieur — formalisée comme *causal emergence* (Hoel).
+- **ICT-7 — Signatures scale-free & fractales** (à venir) : les motifs multi-échelles que ces dynamiques engendrent.
+
+### Références
+- Zhang, Goldstein & Levin, *Classical sorting algorithms as a model of morphogenesis*, Adaptive Behavior, 2025 — [arXiv:2401.05375](https://arxiv.org/abs/2401.05375).
+- Jansma & Hoel, *Engineering Emergence*, arXiv 2025 (échelles causales pertinentes).
+- Schelling, *Dynamic Models of Segregation*, Journal of Mathematical Sociology, 1971.",,,,,,,,8a6aa94f2d57a214,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,d472f43f,markdown,fr,b04fcb705f7a183c,"# ICT-5 : Émergence causale — quelle échelle décrit le mieux un système ?
+
+> Série **ICT** (*Integrated Causal Trajectories*), Epic #4588. Voir le [cadrage ICT-0](ICT-0-Framing.md).
+> Ce notebook met en œuvre le **second pilier** de la série : la recherche **systématique des
+> échelles causales pertinentes** (Jansma & Hoel, *Engineering Emergence*, 2025).
+
+La série [IIT](README.md) mesure $\Phi$ — l'information intégrée — pour un système **à une échelle
+donnée** (les micro-nœuds). Mais une question reste ouverte : *est-ce la bonne échelle ?*
+
+Un même système dynamique peut être décrit au niveau **micro** (chaque nœud) ou **macro**
+(des groupes de nœuds agrégés). L'**émergence causale** désigne le fait, contre-intuitif, que la
+description **macro** peut être **causalement plus forte** que la micro : plus déterministe, moins
+dégénérée, plus intégrée. On parle alors d'émergence quand
+
+$$\Phi_{\text{macro}} > \Phi_{\text{micro}}.$$
+
+Ce notebook utilise le **vrai outil SOTA** — le module `pyphi.macro` (coarse-graining,
+`effective_info`, `emergence`) de PyPhi — pour :
+
+1. mesurer $\Phi$ et l'information effective (EI) à l'échelle micro ;
+2. **chercher** l'échelle macro qui maximise $\Phi$ (toutes les agrégations possibles) ;
+3. montrer que l'émergence **n'est pas automatique** : sur certains systèmes elle est franche,
+   sur d'autres le coarse-graining ne fait que **détruire** de l'information.
+
+> **Pré-requis.** Ce notebook calcule des $\Phi$ réels avec PyPhi : il s'exécute avec le noyau
+> **`Python 3 (PyPhi/IIT)`** (env conda `pyphi`). Cf [IIT-1-IntroToPyPhi](../IIT-1-IntroToPyPhi.ipynb).",,,,,,,,b04fcb705f7a183c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,ecc56410,code,fr,84dbdada7141e151,"import warnings
+warnings.filterwarnings(""ignore"", message="".*pkg_resources is deprecated.*"", category=UserWarning)
+
+# Configuration de PyPhi AVANT tout calcul.
+# Sous Windows, le multiprocessing de PyPhi provoque une avalanche de processus :
+# on desactive tout parallelisme (calcul mono-thread, suffisant pour <=4 noeuds).
+import numpy as np
+import matplotlib.pyplot as plt
+import pyphi
+
+pyphi.config.WELCOME_OFF = True
+pyphi.config.PROGRESS_BARS = False
+# Calculer Phi sur tous les etats, y compris transitoires/inaccessibles.
+pyphi.config.VALIDATE_SUBSYSTEM_STATES = False
+for _attr in (""PARALLEL_CONCEPT_EVALUATION"", ""PARALLEL_CUT_EVALUATION"",
+              ""PARALLEL_COMPLEX_EVALUATION"", ""PARALLEL""):
+    if hasattr(pyphi.config, _attr):
+        setattr(pyphi.config, _attr, False)
+
+import pyphi.macro as M
+
+print(""PyPhi"", pyphi.__version__, ""| NumPy"", np.__version__)
+print(""Calcul mono-thread (parallelisme PyPhi desactive)."")",,,,,,,,84dbdada7141e151,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,6bf0800a,markdown,fr,3a348e554dfcd208,"## 1. Mesurer la causalité à l'échelle micro
+
+On part de l'exemple d'émergence **canonique** livré avec PyPhi
+(`pyphi.examples.macro_network()`) : un micro-système de **4 nœuds** binaires dont la dynamique
+micro est volontairement **dégénérée** (bruitée). On mesure d'abord, au niveau micro :
+
+- $\Phi$ — l'information intégrée du système dans son état courant ;
+- **EI** (*effective information*) — la réduction d'incertitude qu'apporte la connaissance de
+  l'état présent sur l'état futur, moyennée sur l'ensemble du répertoire de causes possibles.
+
+Une EI faible signale une dynamique **dégénérée** : beaucoup d'états passés mènent au même futur,
+le mécanisme « perd » de l'information.",,,,,,,,3a348e554dfcd208,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,f9c79fa5,code,fr,dfda0ee7b01bcd68,"# Micro-systeme canonique de Hoel : 4 noeuds, dynamique degeneree.
+net = pyphi.examples.macro_network()
+state = (0, 0, 0, 0)
+
+micro_phi = float(pyphi.compute.phi(pyphi.Subsystem(net, state, range(net.size))))
+micro_ei = float(M.effective_info(net))
+
+print(f""Micro-systeme : {net.size} noeuds, etat {state}"")
+print(f""  Phi_micro = {micro_phi:.4f}"")
+print(f""  EI_micro  = {micro_ei:.4f}  (information effective, en bits)"")",,,,,,,,dfda0ee7b01bcd68,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,f02e9e66,markdown,fr,509e8e8fec131ee8,"### Interprétation : un micro-système peu intégré
+
+Le micro-système n'a qu'un $\Phi$ faible (~0,11) : pris nœud par nœud, le système n'intègre
+presque pas d'information. Son EI (~1,15 bit) reflète une dynamique **dégénérée** — c'est
+exactement le terrain où l'émergence peut se manifester. Reste à savoir si une **description plus
+grossière** ferait mieux.",,,,,,,,509e8e8fec131ee8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,b7c70c8f,markdown,fr,2152b6b5ee7b43fb,"## 2. Chercher l'échelle émergente (coarse-graining)
+
+`pyphi.macro.emergence` énumère **toutes les agrégations** (coarse-grainings) possibles des
+micro-nœuds en macro-nœuds, calcule $\Phi$ pour chacune, et retient l'échelle qui **maximise**
+$\Phi_{\text{macro}}$. L'émergence est alors
+
+$$\text{émergence} = \Phi_{\text{macro}}^{\star} - \Phi_{\text{micro}}.$$
+
+Une valeur **positive** signifie que la description macro est causalement **plus forte** que la
+micro.",,,,,,,,2152b6b5ee7b43fb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,81df20b7,code,fr,ad97a4e72a4ef052,"# Recherche de la meilleure echelle macro (coarse-graining uniquement).
+mn = M.emergence(net, state, do_coarse_grain=True, do_blackbox=False)
+
+macro_phi = float(mn.phi)
+delta = float(mn.emergence)
+
+print(f""Phi_micro      = {micro_phi:.4f}"")
+print(f""Phi_macro (max)= {macro_phi:.4f}"")
+print(f""emergence      = {delta:+.4f}"")
+print(f""meilleure agregation (partition micro -> macro) : {mn.coarse_grain.partition}"")
+print(f""  -> les {net.size} micro-noeuds sont regroupes en {len(mn.coarse_grain.partition)} macro-noeuds"")",,,,,,,,ad97a4e72a4ef052,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,8371a4b7,markdown,fr,67df94f7619ca74b,"### Interprétation : l'émergence est réelle
+
+Le coarse-graining qui regroupe les nœuds `((0, 1), (2, 3))` — soit **2 macro-nœuds** — porte
+$\Phi$ de ~0,11 à ~0,60 : une **émergence d'environ +0,48**. À l'échelle macro, ce qui semblait
+un agrégat bruité de 4 nœuds devient un système **nettement plus intégré**. Le « bon » niveau de
+description causale de ce système **n'est pas le micro** : c'est le macro.
+
+C'est le résultat central de Hoel : agréger peut **augmenter** l'information causale, parce que la
+macro-dynamique est plus déterministe et moins dégénérée que la micro.",,,,,,,,67df94f7619ca74b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,5e82f3a0,code,fr,0d2e279570ba4530,"# Figure 1 : Phi micro vs macro pour le systeme emergent.
+fig, ax = plt.subplots(figsize=(6, 4.2))
+bars = ax.bar([""micro\n(4 noeuds)"", ""macro\n(2 noeuds)""], [micro_phi, macro_phi],
+              color=[""#9aa7b3"", ""#2a8a5f""], width=0.55)
+ax.set_ylabel(r""$\Phi$ (information integree)"")
+ax.set_title(""Emergence causale : la description macro est plus integree"")
+for b, v in zip(bars, [micro_phi, macro_phi]):
+    ax.text(b.get_x() + b.get_width()/2, v + 0.01, f""{v:.3f}"", ha=""center"", va=""bottom"")
+ax.annotate(f""emergence\n{delta:+.3f}"",
+            xy=(1, macro_phi), xytext=(0.30, macro_phi*0.55),
+            ha=""center"", arrowprops=dict(arrowstyle=""->"", color=""#2a8a5f""),
+            color=""#2a8a5f"", fontweight=""bold"")
+ax.set_ylim(0, macro_phi*1.18)
+plt.tight_layout()
+plt.show()",,,,,,,,0d2e279570ba4530,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,9d94971d,markdown,fr,f34991271ec92f02,"## 3. L'émergence n'est pas automatique : deux contre-exemples
+
+Si agréger augmentait *toujours* $\Phi$, l'émergence n'aurait aucun contenu informatif. Vérifions
+sur deux systèmes dont la **micro-dynamique est déjà fortement intégrée** :
+
+- le réseau **XOR** à 3 nœuds (chaque nœud = XOR des deux autres) ;
+- le **`basic_network`** de PyPhi (le système OR/AND/XOR de référence, $\Phi_{\text{micro}}=2{,}31$).
+
+Pour ces systèmes, on s'attend à ce que le coarse-graining **détruise** de l'information
+(émergence négative) : la bonne échelle reste le micro.",,,,,,,,f34991271ec92f02,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,7ef6a3a3,code,fr,718d4a8ca1ede982,"# On reutilise la meme analyse sur deux systemes micro-integres.
+def emergence_report(network, st, label):
+    mphi = float(pyphi.compute.phi(pyphi.Subsystem(network, st, range(network.size))))
+    macro = M.emergence(network, st, do_coarse_grain=True, do_blackbox=False)
+    return dict(label=label, micro_phi=mphi, macro_phi=float(macro.phi),
+                emergence=float(macro.emergence),
+                partition=macro.coarse_grain.partition)
+
+rows = [
+    dict(label=""Hoel macro_network"", micro_phi=micro_phi,
+         macro_phi=macro_phi, emergence=delta, partition=mn.coarse_grain.partition),
+    emergence_report(pyphi.examples.xor_network(), (0, 0, 0), ""XOR""),
+    emergence_report(pyphi.examples.basic_network(), (1, 0, 0), ""basic_network""),
+]
+
+print(f""{'systeme':22s} {'Phi_micro':>10s} {'Phi_macro':>10s} {'emergence':>11s}  partition"")
+for r in rows:
+    print(f""{r['label']:22s} {r['micro_phi']:10.4f} {r['macro_phi']:10.4f} ""
+          f""{r['emergence']:+11.4f}  {r['partition']}"")",,,,,,,,718d4a8ca1ede982,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,ed3ee9a9,code,fr,c3811699d7ebbfef,"# Figure 2 : comparaison micro vs macro sur les trois systemes.
+labels = [r[""label""] for r in rows]
+micro_vals = [r[""micro_phi""] for r in rows]
+macro_vals = [r[""macro_phi""] for r in rows]
+x = np.arange(len(labels))
+w = 0.38
+
+fig, ax = plt.subplots(figsize=(8.2, 4.4))
+ax.bar(x - w/2, micro_vals, w, label=r""$\Phi_{micro}$"", color=""#9aa7b3"")
+ax.bar(x + w/2, macro_vals, w, label=r""$\Phi_{macro}$"", color=""#2a8a5f"")
+for i, r in enumerate(rows):
+    col = ""#2a8a5f"" if r[""emergence""] > 0 else ""#b34a4a""
+    ax.text(i, max(r[""micro_phi""], r[""macro_phi""]) + 0.05,
+            f""{r['emergence']:+.2f}"", ha=""center"", color=col, fontweight=""bold"")
+ax.set_xticks(x); ax.set_xticklabels(labels)
+ax.set_ylabel(r""$\Phi$"")
+ax.set_title(""Emergence (vert) vs degradation (rouge) selon le systeme"")
+ax.legend()
+plt.tight_layout()
+plt.show()",,,,,,,,c3811699d7ebbfef,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,d09be37c,markdown,fr,c1647ae81ad643a1,"### Interprétation : l'émergence est une propriété **discriminante**
+
+Le contraste est net :
+
+| Système | $\Phi_{\text{micro}}$ | $\Phi_{\text{macro}}$ | émergence |
+|---------|----------------------:|----------------------:|----------:|
+| Hoel `macro_network` | ~0,11 | ~0,60 | **+0,48** |
+| XOR | ~1,88 | ~0,50 | **−1,38** |
+| `basic_network` | ~2,31 | ~0,52 | **−1,79** |
+
+Pour XOR et `basic_network`, la micro-dynamique est *déjà* maximalement intégrée : tout
+regroupement **perd** de l'information (émergence franchement négative). Le bon niveau de
+description y est le micro.
+
+L'émergence n'est donc **pas** un artefact systématique du coarse-graining : c'est une **propriété
+du système**. C'est précisément ce qui rend l'outil intéressant — il *distingue* les systèmes qui
+émergent de ceux qui n'émergent pas, au lieu de répondre « oui » partout (un test dégénéré
+n'aurait aucune valeur).",,,,,,,,c1647ae81ad643a1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,3f44fc58,markdown,fr,882697c8a6cd6cc4,"## 4. Pourquoi le macro gagne : déterminisme contre dégénérescence
+
+L'information effective se décompose (Hoel) en deux termes :
+
+$$\text{EI} = \underbrace{\text{déterminisme}}_{\text{le futur est-il prévisible ?}}
+            - \underbrace{\text{dégénérescence}}_{\text{plusieurs passés} \to \text{même futur}}.$$
+
+L'émergence se produit quand l'agrégation **augmente le déterminisme** et/ou **réduit la
+dégénérescence** plus vite qu'elle ne réduit le nombre d'états. Comparons l'EI micro à l'EI du
+meilleur macro-réseau trouvé.",,,,,,,,882697c8a6cd6cc4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,a7f8f458,code,fr,2bed27c43ade5c9c,"# EI a l'echelle macro emergente, via le reseau macro reconstruit par PyPhi.
+macro_network_obj = mn.network if hasattr(mn, ""network"") else None
+# mn.network est le micro-reseau ; on reconstruit le macro via le coarse-grain retenu.
+macro_sub = mn.macro_subsystem if hasattr(mn, ""macro_subsystem"") else None
+
+# Information effective du micro vs nombre d'etats accessibles.
+print(f""micro : {net.size} noeuds -> {2**net.size} micro-etats ; EI = {micro_ei:.4f} bits"")
+n_macro = len(mn.coarse_grain.partition)
+print(f""macro : {n_macro} noeuds -> {2**n_macro} macro-etats"")
+print(f""gain de Phi en passant au macro : {delta:+.4f}"")
+print()
+print(""Lecture : le macro a moins d'etats mais une dynamique plus deterministe ;"")
+print(""le supplement d'integration (Phi) survit a la perte d'etats -> emergence."")",,,,,,,,2bed27c43ade5c9c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,364fb138,markdown,fr,59804f033b4b8c35,"### Interprétation
+
+Le macro-réseau ne compte que 4 états (2 nœuds) contre 16 au micro, et pourtant son $\Phi$ est
+**cinq fois plus grand**. Le gain de déterminisme l'emporte sur la perte de résolution : agréger
+**révèle** une structure causale que la description micro **noyait** dans le bruit. C'est le cœur
+opérationnel de l'« ingénierie de l'émergence » de Jansma & Hoel — et un pont direct vers la
+question des **trajectoires multi-échelles** que la série ICT explore.",,,,,,,,59804f033b4b8c35,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,c4fb2e53,markdown,fr,6e5d2a58e59de53c,"## 5. Exercices
+
+Les trois exercices ci-dessous prolongent l'analyse. Complétez le corps des fonctions (remplacez
+`return None`). Le notebook s'exécute de bout en bout même si les exercices ne sont pas faits.",,,,,,,,6e5d2a58e59de53c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,e1fded22,markdown,fr,2695daebe1bcf40e,"### Exercice 1 — Score d'émergence normalisé
+
+L'émergence brute $\Phi_{\text{macro}} - \Phi_{\text{micro}}$ dépend de l'échelle des $\Phi$. Un
+**score relatif** est plus comparable entre systèmes.
+
+Implémentez `emergence_ratio(network, state)` qui renvoie
+$\dfrac{\Phi_{\text{macro}}^{\star}}{\Phi_{\text{micro}}}$ (ratio > 1 ⇔ émergence).
+
+- *Indice 1* : réutilisez `M.emergence(network, state, do_coarse_grain=True)`.
+- *Indice 2* : attention à la division par un $\Phi_{\text{micro}}$ proche de 0.",,,,,,,,2695daebe1bcf40e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,9a4df8e2,code,fr,78041ffa8186c037,"def emergence_ratio(network, state):
+    # Etape 1 : Phi_micro = pyphi.compute.phi(Subsystem(network, state, range(network.size)))
+    # Etape 2 : mn = M.emergence(network, state, do_coarse_grain=True)
+    # Etape 3 : renvoyer mn.phi / Phi_micro (gerer Phi_micro ~ 0)
+    result = None  # TODO etudiant
+    return result
+
+# Test (decommenter une fois implemente) :
+# print(""ratio Hoel :"", emergence_ratio(pyphi.examples.macro_network(), (0, 0, 0, 0)))
+print(""Exercice 1 a completer"")",,,,,,,,78041ffa8186c037,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,76aff3e1,markdown,fr,2263f57fdbe87c6d,"### Exercice 2 — L'émergence dépend-elle de l'état ?
+
+L'émergence est calculée **pour un état donné**. Un même réseau peut émerger dans certains états
+et pas dans d'autres.
+
+Implémentez `emergence_by_state(network)` qui renvoie un dictionnaire `{état: émergence}` pour
+**tous** les états du réseau (utilisez `pyphi.utils.all_states(network.size)`).
+
+- *Indice* : bouclez sur `all_states`, appelez `M.emergence` pour chacun, stockez `mn.emergence`.",,,,,,,,2263f57fdbe87c6d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,7a41e3d0,code,fr,283ab7aaad4a5fa8,"def emergence_by_state(network):
+    # Etape 1 : parcourir pyphi.utils.all_states(network.size)
+    # Etape 2 : pour chaque etat, mn = M.emergence(network, etat, do_coarse_grain=True)
+    # Etape 3 : renvoyer {etat: float(mn.emergence)}
+    result = None  # TODO etudiant
+    return result
+
+# Test (decommenter une fois implemente) :
+# em = emergence_by_state(pyphi.examples.macro_network())
+# print(sorted(em.items(), key=lambda kv: -kv[1])[:3])
+print(""Exercice 2 a completer"")",,,,,,,,283ab7aaad4a5fa8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,f7b028ef,markdown,fr,d42d9595c162d8c6,"### Exercice 3 — Coarse-graining vs blackboxing
+
+PyPhi propose deux stratégies de réduction d'échelle : le **coarse-graining** (regrouper des
+nœuds en macro-nœuds) et le **blackboxing** (cacher la dynamique interne d'un module, n'exposer
+que ses entrées/sorties à un pas de temps plus lent).
+
+Implémentez `compare_strategies(network, state)` qui renvoie un dict
+`{""coarse"": émergence_coarse, ""blackbox"": émergence_blackbox, ""both"": émergence_both}` en variant
+les arguments `do_coarse_grain` / `do_blackbox` de `M.emergence`.
+
+- *Indice* : trois appels à `M.emergence` avec les combinaisons d'arguments booléens.
+- *Attention* : le blackboxing peut échouer sur certains réseaux (capturer l'exception et
+  renvoyer `None` pour cette stratégie).",,,,,,,,d42d9595c162d8c6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,e3509ff0,code,fr,f1c0c23ef453f60b,"def compare_strategies(network, state):
+    # Etape 1 : coarse  = M.emergence(network, state, do_coarse_grain=True,  do_blackbox=False).emergence
+    # Etape 2 : blackbox= M.emergence(network, state, do_coarse_grain=False, do_blackbox=True).emergence  (try/except)
+    # Etape 3 : both    = M.emergence(network, state, do_coarse_grain=True,  do_blackbox=True).emergence   (try/except)
+    result = None  # TODO etudiant
+    return result
+
+# Test (decommenter une fois implemente) :
+# print(compare_strategies(pyphi.examples.macro_network(), (0, 0, 0, 0)))
+print(""Exercice 3 a completer"")",,,,,,,,f1c0c23ef453f60b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb,7f469a93,markdown,fr,b90c91e231fbc4de,"## 6. Conclusion
+
+L'**émergence causale** renverse une intuition réductionniste : la description la plus fine n'est
+pas toujours la plus causale. Avec le module `pyphi.macro` (le vrai outil SOTA), nous avons :
+
+- mesuré $\Phi$ et l'information effective à l'échelle **micro** ;
+- **cherché** automatiquement l'échelle **macro** qui maximise $\Phi$ ;
+- montré une émergence franche (**+0,48**) sur le système canonique de Hoel, et son **absence**
+  (émergence négative) sur des systèmes déjà micro-intégrés (XOR, `basic_network`).
+
+L'outil est **discriminant** : il sépare les systèmes qui émergent de ceux qui n'émergent pas —
+ce qu'un cas dégénéré (où tout « émerge ») ne permettrait jamais.
+
+**Limite.** La recherche énumère toutes les agrégations : son coût croît très vite avec le nombre
+de micro-nœuds (cloisonnement combinatoire de $\Phi$). On reste ici à $\le 4$ nœuds. Pour des
+systèmes plus grands, il faut des heuristiques de partitionnement — un fil que prolonge la
+littérature multi-échelle.
+
+### Et ensuite ?
+
+- [ICT-1 — Trajectoires de $\Phi$](ICT-1-PhiTrajectories.ipynb) : comment $\Phi$ varie le long
+  d'une trajectoire d'états (à échelle fixe).
+- **ICT-6 — Pont tri → TPM → PyPhi** (à venir) : construire la TPM d'une simulation de
+  [tri-morphogenèse](ICT-2-SelfSortingMorphogenesis.ipynb) puis lui appliquer cette analyse
+  d'émergence — relier les deux piliers de la série.
+- [ICT-0 — Cadrage](ICT-0-Framing.md) : place de ce notebook dans la feuille de route.
+
+### Pour aller plus loin
+- **[Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb)** : l'armature formelle unifiée de Pearl (échelle + 3 règles du do-calculus, paradigme interventionniste) exécutée sur `dowhy`, à mettre en regard de l'émergence causale de Hoel (information effective) de ce notebook.
+
+- Hoel, E. (2017). *When the map is better than the territory*. **Entropy**.
+- Jansma, A. & Hoel, E. (2025). *Engineering Emergence*. arXiv.
+- Documentation PyPhi : module [`pyphi.macro`](https://pyphi.readthedocs.io).",,,,,,,,b90c91e231fbc4de,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-title,markdown,fr,1c487652a7244d11,"# ICT-6 — Du tri a la chaine de Markov : emergence causale d'une morphogenese (CE 2.0)
+
+> Serie **ICT** (*Integrated Causal Trajectories*), Epic #4588. Voir le [cadrage ICT-0](ICT-0-Framing.md).
+> Ce notebook construit le **pont tri -> TPM** annonce dans la feuille de route : il transforme les
+> trajectoires de [self-sorting d'ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb) en une **chaine de
+> Markov** etat-a-etat, puis y mesure l'**emergence causale** avec l'outillage moderne de
+> *Causal Emergence 2.0* (Erik Hoel, [arXiv:2503.13395](https://arxiv.org/abs/2503.13395), 2025).",,,,,,,,1c487652a7244d11,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-intro,markdown,fr,3ef8ebc7792a2b82,"## Pourquoi ICT-6 ? La limite de PyPhi, et ce qui passe a l'echelle
+
+[ICT-5](ICT-5-CausalEmergence.ipynb) a mesure l'emergence causale avec le **vrai** module
+`pyphi.macro` : il enumere les regroupements (coarse-grain) d'un petit reseau et cherche l'echelle
+ou $\Phi$ (ou l'information effective) est maximale. C'est rigoureux, mais **borne** : PyPhi devient
+inutilisable au-dela de ~6 noeuds (l'espace d'etats explose en $2^n$, et le calcul de $\Phi$ est
+super-exponentiel).
+
+Or le systeme qui nous interesse — le **tableau qui se trie lui-meme** d'ICT-2 — a un espace d'etats
+qui depasse vite cette limite : pour $n$ elements distincts, il y a $n!$ configurations possibles.
+On ne peut donc pas le donner tel quel a PyPhi.
+
+**Idee d'ICT-6.** On n'a pas besoin de $\Phi$ pour parler d'emergence causale. Il suffit d'une
+**matrice de transition etat-a-etat** (une chaine de Markov) et des primitives causales de Hoel
+(determinisme, degenerescence, *effectiveness*, information effective). Le module
+[`ict.causal_emergence`](ict/causal_emergence.py) opere directement sur une telle matrice $n \times n$ :
+il **passe a l'echelle** la ou PyPhi cale. Le chainon manquant est l'**estimation de la TPM a partir
+des trajectoires simulees**, fournie par [`ict.tpm_estimation`](ict/tpm_estimation.py).
+
+Le fil du notebook :
+
+1. rejouer une morphogenese par tri (rappel d'ICT-2) ;
+2. **estimer une chaine de Markov** a partir de nombreuses trajectoires (`tpm_estimation`) ;
+3. mesurer le **profil causal micro** (chaque permutation = un etat) ;
+4. montrer qu'un macro *intuitif* (le niveau de tri) **ne suffit pas** ;
+5. laisser l'**apportionnement glouton** de CE 2.0 trouver l'echelle reellement emergente ;
+6. quantifier la **complexite emergente** EC — a quel point le travail causal est *distribue* entre echelles.
+
+> **Provenance / licence.** Le module `ict.causal_emergence` est une **reimplementation independante**
+> ecrite a partir des equations de l'article de Hoel (2025) et de la litterature canonique de
+> l'emergence causale (Hoel, Albantakis & Tononi, PNAS 2013). Le depot de reference
+> `github.com/jessescool/Causal-Emergence-2.0` ne porte **aucune licence** : son code n'est pas
+> reutilise, il est seulement cite a des fins de comparaison.",,,,,,,,3ef8ebc7792a2b82,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-setup,code,fr,47e3e11ca82f2438,"# --- Imports et configuration ---
+import sys, os
+sys.path.insert(0, os.path.abspath("".""))  # le package `ict/` est a cote de ce notebook
+
+import random
+import numpy as np
+import matplotlib.pyplot as plt
+
+from ict.self_sorting import SelfSortingArray, ALGOTYPES
+from ict import sorting_metrics as sm
+from ict import tpm_estimation as TE
+from ict import causal_emergence as CE
+
+plt.rcParams[""figure.figsize""] = (8, 4)
+plt.rcParams[""axes.grid""] = True
+
+print(""numpy"", np.__version__)
+print(""algotypes disponibles :"", ALGOTYPES)
+print(""primitives CE 2.0 :"", [f for f in (""determinism"", ""degeneracy"", ""specificity"",
+      ""effectiveness"", ""effective_information"", ""greedy_apportionment"", ""emergent_complexity"")])",,,,,,,,47e3e11ca82f2438,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-recall-md,markdown,fr,439cce5a0c7b4ac5,"## 1. Rappel — un systeme qui se trie lui-meme
+
+Dans [ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb), chaque element du tableau est une **cellule
+autonome** : elle ne voit que sa voisine et applique une regle locale (`bubble` regarde a droite,
+`insertion` regarde a gauche). L'ordre global n'est impose par personne — il **emerge** des decisions
+locales. Le tri devient une **trajectoire** dans l'espace des configurations : exactement l'objet
+d'etude de la serie ICT.
+
+Rejouons une trajectoire et regardons sa **sortedness** (degre de tri, dans $[0, 1]$) monter au fil
+des activations.",,,,,,,,439cce5a0c7b4ac5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-recall-code,code,fr,05eecab66837a53a,"# Une morphogenese par tri : 6 cellules 'bubble', depart melange, scheduler asynchrone seede.
+demo = SelfSortingArray([3, 1, 5, 0, 4, 2], seed=1)
+demo.run(max_steps=500)
+
+vals = demo.probe.values
+print(""configuration initiale :"", vals[0],  "" sortedness ="", round(sm.sortedness(vals[0]), 3))
+print(""configuration finale   :"", vals[-1], "" sortedness ="", round(sm.sortedness(vals[-1]), 3))
+print(""nombre de pas enregistres :"", len(vals) - 1, "" | swaps :"", demo.probe.swaps)",,,,,,,,05eecab66837a53a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-recall-plot,code,fr,9b71473625f89f96,"# Courbes de tri le long de la trajectoire (rappel ICT-2)
+sortedness = sm.sortedness_curve(vals)
+inversions = sm.inversions_curve(vals)
+
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 3.6))
+ax1.plot(sortedness, color=""tab:green"")
+ax1.set_title(""Sortedness (degre de tri)"")
+ax1.set_xlabel(""pas""); ax1.set_ylabel(""sortedness""); ax1.set_ylim(0, 1.02)
+ax2.plot(inversions, color=""tab:red"")
+ax2.set_title(""Inversions restantes"")
+ax2.set_xlabel(""pas""); ax2.set_ylabel(""# inversions"")
+plt.tight_layout(); plt.show()",,,,,,,,9b71473625f89f96,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-recall-interp,markdown,fr,38515d851c4b07d2,"La trajectoire descend de facon **monotone non triviale** : la sortedness monte vers 1, les inversions
+tombent vers 0, mais pas en ligne droite (le scheduler asynchrone choisit une cellule au hasard a chaque
+pas, donc certains pas sont « a vide »). C'est cette **dynamique stochastique** qui, agregee sur de
+nombreuses trajectoires, va devenir une chaine de Markov : un etat de tri donne ne mene pas toujours au
+meme etat suivant, et c'est precisement ce bruit qui rend la question de l'echelle interessante.",,,,,,,,38515d851c4b07d2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-tpm-md,markdown,fr,417979d9365c39cb,"## 2. De la trajectoire a la chaine de Markov
+
+**Micro-etat = la configuration complete** (le tuple des valeurs, p.ex. `(3, 1, 0, 2)`). Pour $n = 4$
+valeurs distinctes, il y a $4! = 24$ micro-etats possibles.
+
+Une seule trajectoire ne suffit pas a estimer des *probabilites* de transition : avec une graine
+fixee, la dynamique est deterministe. On **agrege donc de nombreuses trajectoires** issues de departs
+varies et de graines variees. Depuis un meme micro-etat, des cellules differentes sont activees selon
+la graine — d'ou des etats suivants differents, donc des transitions reellement **stochastiques**.
+
+`ict.tpm_estimation.tpm_from_trajectories` compte ces transitions et renvoie une TPM **ligne-stochastique**
+$P[i, j] = \Pr(\text{etat suivant} = j \mid \text{etat courant} = i)$, avec un mapping etat -> indice.",,,,,,,,417979d9365c39cb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-tpm-code,code,fr,aecec3a6b48cf505,"def collect_trajectories(n=4, algotypes=None, frozen=None,
+                         n_starts=40, seeds=6, max_steps=400, seed_shuffle=0):
+    '''Agrege des trajectoires de self-sorting (micro-etats = tuples de valeurs).
+
+    Pour chaque depart melange (n_starts), on rejoue le tri sous plusieurs graines
+    (seeds) : le scheduler asynchrone seede produit des transitions stochastiques.
+    Retourne une liste de trajectoires, chacune = liste de tuples d'etats.'''
+    base = list(range(n))
+    rng = random.Random(seed_shuffle)
+    trajs = []
+    for _ in range(n_starts):
+        start = base[:]
+        rng.shuffle(start)
+        for s in range(seeds):
+            arr = SelfSortingArray(start[:], algotypes=algotypes, frozen=frozen, seed=s)
+            arr.run(max_steps=max_steps)
+            trajs.append([tuple(v) for v in arr.probe.values])
+    return trajs
+
+trajs = collect_trajectories(n=4)
+tpm_micro, mapping = TE.tpm_from_trajectories(trajs, unseen=""self"")
+
+print(""trajectoires agregees :"", len(trajs))
+print(""micro-etats observes  :"", len(mapping), ""/ 24 permutations possibles"")
+print(""forme de la TPM       :"", tpm_micro.shape)
+print(""verif : chaque ligne somme a 1 ?"", np.allclose(tpm_micro.sum(axis=1), 1.0))",,,,,,,,aecec3a6b48cf505,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-tpm-plot,code,fr,997ad1426eb16f90,"# Visualisation de la chaine de Markov micro (24 x 24)
+fig, ax = plt.subplots(figsize=(6, 5))
+im = ax.imshow(tpm_micro, cmap=""magma"", vmin=0, vmax=1)
+ax.set_title(""TPM micro : P(etat suivant | etat courant)"")
+ax.set_xlabel(""indice etat suivant""); ax.set_ylabel(""indice etat courant"")
+fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label=""probabilite"")
+plt.tight_layout(); plt.show()",,,,,,,,997ad1426eb16f90,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-tpm-interp,markdown,fr,3c3880335116052e,"La matrice est **creuse et directionnelle** : depuis un etat donne, le tri ne peut qu'**enlever** une
+inversion (jamais en ajouter), donc chaque ligne ne charge que quelques etats « plus tries ». L'etat
+parfaitement trie est **absorbant** (auto-transition de probabilite 1, `unseen=""self""`) : c'est le point
+fixe de la morphogenese. Cette structure de flot vers un attracteur unique est typique des dynamiques
+de developpement — et c'est sur elle qu'on va lire l'emergence causale.",,,,,,,,3c3880335116052e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-micro-md,markdown,fr,a843a4054a7fa989,"## 3. Le profil causal micro
+
+Sous une **intervention uniforme** sur les etats (le `do` de Hoel : on force le systeme dans chaque
+etat avec la meme probabilite et on regarde l'effet), on calcule :
+
+- **determinisme** $= 1 - \langle H(E\mid c)\rangle / \log_2 n$ — a quel point chaque etat-cause
+  determine son effet (1 = transitions certaines) ;
+- **degenerescence** $= 1 - H(E\mid C) / \log_2 n$ — a quel point des causes differentes convergent
+  vers les memes effets ;
+- **specificite** $= 1 - \text{degenerescence}$ ;
+- **effectiveness** $= \text{determinisme} - \text{degenerescence}$ — grandeur causale *scale-free*
+  dans $[0, 1]$ ;
+- **information effective** $\text{EI} = \text{effectiveness} \times \log_2 n$ (en bits).",,,,,,,,a843a4054a7fa989,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-micro-code,code,fr,88e1dc029ebd1695,"prof = CE.causal_profile(tpm_micro)
+print(""Profil causal MICRO (24 etats)"")
+print(""-"" * 34)
+for k in (""determinism"", ""degeneracy"", ""specificity"", ""effectiveness"", ""effective_information""):
+    print(f""  {k:22s} : {float(prof[k]):.4f}"")",,,,,,,,88e1dc029ebd1695,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-micro-interp,markdown,fr,5e4df9dc6bdf893f,"Le micro-niveau est **assez deterministe** (le tri ne disperse pas beaucoup : depuis un etat, peu
+d'etats suivants sont possibles) et **tres specifique** (peu de degenerescence : les effets renseignent
+bien sur la cause). L'effectiveness micro sert de **reference** : la question de l'emergence est de
+savoir si une description plus *grossiere* (macro) fait **plus** de travail causal que celle-ci.",,,,,,,,5e4df9dc6bdf893f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-naive-md,markdown,fr,1323eb3cead1d824,"## 4. Un macro « intuitif » ne suffit pas
+
+Quel macro-etat choisir ? L'intuition souffle : le **niveau de tri** (le nombre d'inversions, de 0 a
+$\binom{n}{2} = 6$ pour $n = 4$). Regroupons toutes les permutations de meme nombre d'inversions en un
+seul macro-etat et estimons la chaine de Markov **a ce niveau**.
+
+> On re-etiquette chaque etat de trajectoire par son nombre d'inversions, puis on reestime la TPM :
+> meme pont (`tpm_estimation`), mais sur des etats macro.",,,,,,,,1323eb3cead1d824,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-naive-code,code,fr,a9b05b09568aabea,"# Macro intuitif : regrouper les etats par niveau d'inversions (sortedness level)
+trajs_lvl = [[sm.inversion_count(list(s)) for s in traj] for traj in trajs]
+tpm_lvl, lvl_map = TE.tpm_from_trajectories(trajs_lvl, unseen=""self"")
+
+eff_micro = CE.effectiveness(tpm_micro)
+eff_lvl = CE.effectiveness(tpm_lvl)
+
+print(f""effectiveness MICRO (24 etats)            : {eff_micro:.4f}"")
+print(f""effectiveness MACRO 'niveau de tri' ({tpm_lvl.shape[0]} etats) : {eff_lvl:.4f}"")
+print(f""gain du macro intuitif                    : {eff_lvl - eff_micro:+.4f}"")
+print(""\nemergence causale obtenue par ce macro ?"", ""OUI"" if eff_lvl > eff_micro else ""NON"")",,,,,,,,a9b05b09568aabea,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-naive-interp,markdown,fr,1fc59bb2916d2a5b,"**Le macro intuitif ECHOUE** : regrouper par niveau de tri *baisse* l'effectiveness. La raison est
+instructive — en oubliant *quelle* inversion subsiste, on rend les transitions **plus floues** (un meme
+niveau de tri peut descendre vers plusieurs niveaux selon la permutation exacte). C'est exactement la
+lecon d'honnetete d'[ICT-5](ICT-5-CausalEmergence.ipynb) : **l'emergence n'est pas automatique**, et un
+coarse-graining « evident » peut tout aussi bien *detruire* de l'information causale. Il faut une methode
+qui **cherche** la bonne echelle.",,,,,,,,1fc59bb2916d2a5b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-greedy-md,markdown,fr,406f0c8344a71cd5,"## 5. Apportionnement glouton — trouver l'echelle emergente
+
+CE 2.0 ne se contente pas d'une echelle : il construit un **chemin d'echelles** micro -> macro. A chaque
+pas, `greedy_apportionment` essaie toutes les fusions de paires d'etats et retient celle qui **maximise**
+l'effectiveness a l'echelle plus grossiere. La construction de macro-etat sous intervention uniforme
+(`merge_states`) somme les colonnes (arriver dans l'un *ou* l'autre) et moyenne les lignes (intervenir
+sur le macro tire uniformement parmi ses micro-constituants).
+
+> **Pourquoi l'effectiveness et pas l'EI en bits ?** L'EI $= \text{eff} \times \log_2 n$ est *penalisee*
+> par le retrecissement de $\log_2 n$ au coarse-graining : elle baisse mecaniquement meme quand la
+> structure causale s'ameliore. L'**effectiveness**, scale-free, est la grandeur que l'article apportionne
+> le long du chemin.",,,,,,,,406f0c8344a71cd5,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-greedy-code,code,fr,45001da5d453df03,"res = CE.greedy_apportionment(tpm_micro)  # primitive par defaut = effectiveness
+
+print(""Chemin d'echelles (micro -> macro) :"")
+print(f""{'taille':>7} {'effectiveness':>14} {'EI (bits)':>11} {'determinisme':>13} {'delta_cp':>10}"")
+print(""-"" * 60)
+for s in res[""scales""]:
+    d = """" if s[""delta_cp""] is None else f""{s['delta_cp']:+.4f}""
+    print(f""{s['size']:>7} {s['effectiveness']:>14.4f} {s['effective_information']:>11.4f}""
+          f"" {s['determinism']:>13.4f} {d:>10}"")
+
+eff_vals = [s[""effectiveness""] for s in res[""scales""]]
+print(f""\neffectiveness : micro = {eff_vals[0]:.4f}  ->  macro le plus grossier = {eff_vals[-1]:.4f}"")
+print(f""emergence causale (macro > micro) ? {'OUI' if max(eff_vals) > eff_vals[0] else 'NON'}""
+      f""  (+{max(eff_vals) - eff_vals[0]:.4f})"")",,,,,,,,45001da5d453df03,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-greedy-plot,code,fr,3f4643cac421f6c6,"# L'effectiveness MONTE au coarse-graining (emergence) ; l'EI en bits DESCEND (log2 n)
+sizes = [s[""size""] for s in res[""scales""]]
+effs = [s[""effectiveness""] for s in res[""scales""]]
+eis = [s[""effective_information""] for s in res[""scales""]]
+
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 3.8))
+ax1.plot(sizes, effs, ""o-"", color=""tab:blue"")
+ax1.axhline(effs[0], ls=""--"", color=""gray"", lw=1, label=""effectiveness micro"")
+ax1.set_title(""Effectiveness vs echelle (coarse-graining ->)"")
+ax1.set_xlabel(""# macro-etats""); ax1.set_ylabel(""effectiveness"")
+ax1.invert_xaxis(); ax1.legend()
+ax2.plot(sizes, eis, ""o-"", color=""tab:orange"")
+ax2.set_title(""Information effective EI (bits) vs echelle"")
+ax2.set_xlabel(""# macro-etats""); ax2.set_ylabel(""EI (bits)"")
+ax2.invert_xaxis()
+plt.tight_layout(); plt.show()",,,,,,,,3f4643cac421f6c6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-greedy-interp,markdown,fr,bc80ca49caf4bf1d,"Lu **de droite a gauche** (coarse-graining), l'effectiveness **monte** continument au-dessus de sa valeur
+micro : c'est l'**emergence causale**, decouverte automatiquement la ou notre macro intuitif avait echoue.
+Dans le meme temps l'**EI en bits descend** — non pas parce que le systeme « perd » de la causalite, mais
+parce que $\log_2 n$ retrecit quand on fusionne des etats. C'est l'argument central de Hoel (2025) :
+juger l'emergence sur l'EI en bits masque le phenomene ; la grandeur pertinente est l'effectiveness
+*scale-free*.",,,,,,,,bc80ca49caf4bf1d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ec-md,markdown,fr,4cba547b65f51cc2,"## 6. La complexite emergente EC
+
+L'article resume tout le chemin d'echelles par un seul nombre, la **complexite emergente** :
+
+$$\text{EC} = \log_2 L + H(p), \qquad p_i = \frac{\Delta_i}{\sum_k \Delta_k},$$
+
+ou les $\Delta_i$ sont les **gains** d'effectiveness le long du chemin et $L$ le nombre de transitions
+d'echelle. EC est **maximale quand le travail causal est largement distribue** entre les echelles, et
+**nulle** si une seule echelle porte tout le gain. C'est une signature *multi-echelles* : un systeme a
+forte EC ne se laisse resumer par aucune echelle unique.",,,,,,,,4cba547b65f51cc2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ec-code,code,fr,a9e609521d537c93,"ec = res[""emergent_complexity""]
+deltas = res[""deltas""]
+print(f""complexite emergente EC = {ec:.4f}"")
+print(f""nombre de transitions d'echelle L = {len(deltas)}"")
+print(f""log2(L) = {np.log2(len(deltas)):.4f}  ;  H(p) = {ec - np.log2(len(deltas)):.4f}"")
+
+# Ou se concentre le travail causal le long du chemin ?
+fig, ax = plt.subplots(figsize=(9, 3.4))
+trans_sizes = [s[""size""] for s in res[""scales""][1:]]  # taille apres chaque fusion
+ax.bar(range(len(deltas)), deltas, color=""tab:purple"")
+ax.set_xticks(range(len(deltas)))
+ax.set_xticklabels([f""{a}->{b}"" for a, b in zip(trans_sizes[:-1] + [trans_sizes[-1]], trans_sizes)],
+                   rotation=90, fontsize=7)
+ax.set_title(""Gain d'effectiveness par transition d'echelle (delta_cp)"")
+ax.set_xlabel(""transition (# etats avant -> apres)""); ax.set_ylabel(""delta effectiveness"")
+plt.tight_layout(); plt.show()",,,,,,,,a9e609521d537c93,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ec-interp,markdown,fr,de76723d8f8a7aec,"Le travail causal n'est **pas** porte par une seule fusion : les gains $\Delta$ se repartissent sur tout
+le chemin, avec une concentration vers les **echelles les plus grossieres** (les dernieres fusions, qui
+condensent les regimes de tri). D'ou une EC elevee : la morphogenese par tri possede une organisation
+causale **reellement multi-echelles**, qu'aucune description unique — ni micro, ni le « niveau de tri »
+intuitif — ne capture a elle seule.",,,,,,,,de76723d8f8a7aec,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-exercises-md,markdown,fr,800b95d5903d2678,"## 7. Exercices
+
+Trois exercices pour manipuler le pont tri -> TPM -> emergence. Les cellules de code sont des **squelettes
+a completer** : elles s'executent telles quelles (elles affichent un rappel et renvoient `None`) sans
+casser le notebook. Reutilisez `collect_trajectories`, `TE.tpm_from_trajectories` et le module `CE`.",,,,,,,,800b95d5903d2678,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ex1-md,markdown,fr,d4b680f2337f392e,"### Exercice 1 — L'effectiveness micro depend-elle de la taille ?
+
+Faites varier la taille du tableau $n \in \{3, 4, 5\}$ et mesurez l'**effectiveness micro** de la TPM
+estimee pour chaque taille. L'effectiveness micro monte-t-elle, descend-elle, ou reste-t-elle stable
+quand le systeme grandit ?
+
+- *Indice 1* : `collect_trajectories(n=...)` accepte deja le parametre de taille.
+- *Indice 2* : ne lancez **pas** `greedy_apportionment` pour $n = 5$ (120 etats : trop couteux) — ici on
+  ne demande que l'effectiveness micro, qui est immediate.
+- *Etape* : pour chaque `n`, collecter -> `TE.tpm_from_trajectories` -> `CE.effectiveness`, puis tracer.",,,,,,,,d4b680f2337f392e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ex1-code,code,fr,8f86f5294072b89d,"def effectiveness_vs_size(sizes=(3, 4, 5)):
+    '''Renvoie {n: effectiveness_micro} pour chaque taille de tableau.'''
+    results = {}  # n -> effectiveness micro
+    # TODO etudiant :
+    #   for n in sizes:
+    #       trajs_n = collect_trajectories(n=n)
+    #       tpm_n, _ = TE.tpm_from_trajectories(trajs_n, unseen=""self"")
+    #       results[n] = CE.effectiveness(tpm_n)
+    #   ... puis tracer results ...
+    print(""Exercice 1 - a completer"")
+    return None
+
+effectiveness_vs_size()",,,,,,,,8f86f5294072b89d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ex2-md,markdown,fr,81b9f61020e69baf,"### Exercice 2 — Un tableau chimerique change-t-il l'emergence ?
+
+Un tableau **chimerique** melange les algotypes (`bubble` *et* `insertion`). Construisez-en un (p.ex.
+alternance `[""bubble"", ""insertion"", ""bubble"", ""insertion""]` pour $n = 4$), estimez sa TPM, lancez
+`greedy_apportionment`, et comparez son **EC** et son **meilleur effectiveness macro** a ceux du bubble pur
+calcules plus haut. Le melange de regles renforce-t-il ou affaiblit-il la signature multi-echelles ?
+
+- *Indice* : `collect_trajectories(n=4, algotypes=[""bubble"", ""insertion"", ""bubble"", ""insertion""])`.
+- *Comparer a* : `res[""emergent_complexity""]` et `max(s[""effectiveness""] for s in res[""scales""])`.",,,,,,,,81b9f61020e69baf,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ex2-code,code,fr,ad7b7a1bc4922b06,"def emergence_chimerique():
+    '''Compare l'emergence d'un tableau chimerique au bubble pur (res calcule plus haut).'''
+    # TODO etudiant :
+    #   algos = [""bubble"", ""insertion"", ""bubble"", ""insertion""]
+    #   trajs_c = collect_trajectories(n=4, algotypes=algos)
+    #   tpm_c, _ = TE.tpm_from_trajectories(trajs_c, unseen=""self"")
+    #   res_c = CE.greedy_apportionment(tpm_c)
+    #   comparer res_c[""emergent_complexity""] et max(eff) a ceux de `res`
+    print(""Exercice 2 - a completer"")
+    return None
+
+emergence_chimerique()",,,,,,,,ad7b7a1bc4922b06,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ex3-md,markdown,fr,9ad9b6656a09c727,"### Exercice 3 — La robustesse preserve-t-elle l'emergence ?
+
+ICT-2/ICT-3 ont montre que le systeme **se trie quand meme** avec une cellule defectueuse (`frozen`,
+mode `passive` : elle n'agit pas mais reste deplacable). Cette robustesse morphogenetique se traduit-elle
+dans le **profil d'emergence causale** ? Ajoutez une cellule gelee (p.ex. `frozen=[False, True, False, False]`),
+estimez la TPM, et comparez determinisme micro + EC au cas sain.
+
+- *Indice* : `collect_trajectories(n=4, frozen=[False, True, False, False])`.
+- *Reflexion* : une cellule passagere ajoute-t-elle du bruit (baisse du determinisme) ou laisse-t-elle
+  l'organisation multi-echelles intacte ?",,,,,,,,9ad9b6656a09c727,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-ex3-code,code,fr,aed0b92f61555665,"def emergence_robustesse():
+    '''Compare emergence avec une cellule frozen passive au cas sain.'''
+    # TODO etudiant :
+    #   frozen = [False, True, False, False]
+    #   trajs_f = collect_trajectories(n=4, frozen=frozen)
+    #   tpm_f, _ = TE.tpm_from_trajectories(trajs_f, unseen=""self"")
+    #   comparer CE.causal_profile(tpm_f) et CE.greedy_apportionment(tpm_f)[""emergent_complexity""]
+    #   au cas sain (tpm_micro / res)
+    print(""Exercice 3 - a completer"")
+    return None
+
+emergence_robustesse()",,,,,,,,aed0b92f61555665,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-6-SortingToTPM-CausalEmergence.ipynb,ict6-conclusion,markdown,fr,8f486364847d1f71,"## Conclusion
+
+Ce notebook a construit le **pont** annonce dans la feuille de route ICT : des **trajectoires** de
+morphogenese par tri (ICT-2) a une **chaine de Markov** etat-a-etat (`ict.tpm_estimation`), puis a une
+analyse d'**emergence causale** (`ict.causal_emergence`, d'apres Hoel 2025).
+
+Ce qu'on retient :
+
+- **CE 2.0 passe a l'echelle la ou PyPhi cale.** En travaillant sur une TPM etat-a-etat plutot que sur
+  $\Phi$, on analyse des espaces d'etats ($n!$ permutations) hors de portee de `pyphi.macro` ([ICT-5](ICT-5-CausalEmergence.ipynb)).
+- **L'emergence n'est pas automatique.** Le macro « intuitif » (niveau de tri) *baisse* l'effectiveness ;
+  c'est l'**apportionnement glouton** qui trouve l'echelle reellement emergente.
+- **L'effectiveness, pas l'EI en bits.** L'effectiveness *scale-free* monte au coarse-graining (emergence) ;
+  l'EI descend a cause de $\log_2 n$ — d'ou la mesure choisie par l'article.
+- **EC quantifie la distribution multi-echelles** du travail causal : la morphogenese par tri a une EC
+  elevee, signature qu'aucune echelle unique ne la resume.
+
+**Suite — [ICT-7](ICT-0-Framing.md) : signatures scale-free & fractales.** Si le travail causal se
+distribue sur de nombreuses echelles (EC elevee), la distribution des gains $\Delta$ suit-elle une loi de
+puissance ? ICT-7 cherchera ces signatures *scale-free* sur des systemes plus grands. Pour relier ce
+niveau d'echelles au **do-calculus** (la meme intervention uniforme `do` levee au niveau des
+**echelles**), voir le pont d'[ICT-5](ICT-5-CausalEmergence.ipynb).
+
+> **Verdict SOTA (#3801).** SOTA-OK : le notebook execute le **vrai** modele de self-sorting
+> (Zhang, Goldstein & Levin 2025) et la **vraie** reimplementation de CE 2.0 (Hoel 2025) sur une
+> dynamique reelle ; aucune sortie n'est fabriquee. Le probleme est non-degenere — l'emergence est
+> *decouverte* (effectiveness 0.72 -> > 0.82) la ou un macro naif echoue.
+
+### Voir aussi
+
+- [ICT-0 — cadrage de la serie](ICT-0-Framing.md) — feuille de route, articles fondateurs.
+- [ICT-2 — self-sorting morphogenesis](ICT-2-SelfSortingMorphogenesis.ipynb) — le systeme source.
+- [ICT-5 — emergence causale (pyphi.macro)](ICT-5-CausalEmergence.ipynb) — l'approche bornee complementaire.
+- [Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb) — l'EI estimée ici repose sur des **interventions uniformes** (`do(s)` sur chaque état, maximum-entropy) : le pont donne l'armature formelle de ce même opérateur `do` (échelle de Pearl + 3 règles, exécutées sur `dowhy`) et relie cette série à Tweety-11, Infer-5 et PyMC-5.
+- Erik Hoel, *Causal Emergence 2.0*, [arXiv:2503.13395](https://arxiv.org/abs/2503.13395), 2025.",,,,,,,,8f486364847d1f71,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,ec41a453,markdown,fr,e019f96f8e28a5d9,"# ICT-7 — Signatures *scale-free* & criticalite
+
+> Septieme notebook de la serie **Integrated Causal Trajectories** (Epic #4588),
+> qui prolonge [IIT / PyPhi](README.md) de l'etude d'une structure causale *a un
+> instant* vers ses *trajectoires* multi-echelles. Cadrage : [ICT-0](ICT-0-Framing.md).
+
+Une des questions ouvertes du cadrage : *certains systemes produisent-ils
+spontanement des signatures multi-echelles, voire **scale-free** (sans echelle
+caracteristique) ?* Une signature scale-free — une loi de puissance, un objet
+auto-similaire — est le marqueur d'une organisation qui se repete a toutes les
+echelles, souvent associee a la **criticalite** (un systeme poise au bord d'une
+transition). C'est un fil direct vers l'emergence causale d'[ICT-5](ICT-5-CausalEmergence.ipynb)
+et [ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb) : Jansma & Hoel rappellent
+qu'une vraie organisation multi-echelle est **rare et particuliere**, pas generique.
+
+**Mais ce notebook porte d'abord sur une competence, pas sur un resultat :
+detecter une signature scale-free *sans se faire avoir*.** Le piege est partout :
+une multitude de distributions a queue lourde **paraissent une droite** sur un
+trace log-log sans etre des lois de puissance. La discipline de la serie ICT —
+*executer, mesurer, narrer le resultat reel* — exige ici une methode, pas un coup
+d'oeil. On suit la demarche de **Clauset, Shalizi & Newman (2009)** : estimer
+l'exposant par maximum de vraisemblance, choisir le seuil de queue par minimisation
+de l'ecart, mesurer la qualite d'ajustement, et **comparer** la loi de puissance a
+une alternative.
+
+Plan : (1) la boite a outils de diagnostic et le piege du log-log ; (2) un systeme
+**reellement** scale-free (branchement critique, exposant connu) ; (3) le retour au
+tri auto-organise d'ICT-2 — qui *parait* a queue lourde mais possede une echelle
+caracteristique ; (4) auto-similarite et effondrement d'echelle ; (5) trois exercices.",,,,,,,,e019f96f8e28a5d9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,67d511f5,markdown,fr,8c7ccd1647716259,"## 1. Mise en place
+
+On charge le package `ict` (couche legere a cote de PyPhi, cf. ICT-0). Le module
+`ict.scale_free` fournit les generateurs de reference et les estimateurs ; il ne
+depend que de la bibliotheque standard. `numpy`/`matplotlib` ne servent qu'au
+notebook (calcul leger et figures).",,,,,,,,8c7ccd1647716259,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,c51ab142,code,fr,ec551fcb27336a81,"import os, sys, random
+import numpy as np
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, os.path.abspath("".""))
+from ict import scale_free as sf
+from ict.self_sorting import SelfSortingArray, ALGOTYPES
+
+GRAINE = 7  # reproductibilite
+
+def trace_ccdf(ax, data, label, marker=""o""):
+    ""Trace la CCDF empirique P(X>=x) en log-log.""
+    xs, ps = sf.ccdf(data)
+    ax.loglog(xs, ps, marker=marker, ls=""none"", ms=3, alpha=0.6, label=label)
+
+def deplacements_tri(n, n_runs, seed0=0, max_steps=30000):
+    ""Distribution des deplacements nets |position initiale - finale| des cellules,""
+    "" sur n_runs permutations aleatoires de taille n triees par le modele vue-cellule.""
+    d = []
+    for s in range(n_runs):
+        vals = random.Random(seed0 + s).sample(range(n), n)
+        algos = [ALGOTYPES[i % 2] for i in range(n)]   # tableau chimerique (alternance)
+        arr = SelfSortingArray(vals, algotypes=algos, seed=s).run(max_steps=max_steps)
+        p0, pf = arr.probe.positions[0], arr.probe.positions[-1]
+        d.extend(abs(p0[c] - pf[c]) for c in p0)
+    return [x for x in d if x >= 1]
+
+print(""Modules charges. Algotypes du modele de tri :"", ALGOTYPES)",,,,,,,,ec551fcb27336a81,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,7b6d3e66,markdown,fr,96132d6c6715c53e,"## 2. Le piege du log-log, et la boite a outils
+
+Deux echantillons de meme taille : l'un tire d'une **vraie loi de puissance**
+(exposant $\alpha = 2.5$), l'autre d'une **exponentielle**. Tracons leurs CCDF
+(fonction de repartition complementaire $P(X \ge x)$) en log-log. Une loi de
+puissance y est une droite ; une exponentielle, une courbe qui plonge. Le but :
+voir que **a l'oeil, sur la partie basse, les deux peuvent tromper**.",,,,,,,,96132d6c6715c53e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,51e5681a,code,fr,ea20fa2ba860c020,"rng = random.Random(GRAINE)
+ech_pl  = sf.sample_powerlaw(2.5, 1.0, 4000, rng)   # vraie loi de puissance
+ech_exp = sf.sample_exponential(0.5, 1.0, 4000, rng)  # echelle caracteristique 1/0.5
+
+fig, ax = plt.subplots(figsize=(6.2, 4.4))
+trace_ccdf(ax, ech_pl, ""loi de puissance (alpha=2.5)"", ""o"")
+trace_ccdf(ax, ech_exp, ""exponentielle (taux=0.5)"", ""s"")
+ax.set_xlabel(""x""); ax.set_ylabel(""P(X >= x)"")
+ax.set_title(""Figure 1 - CCDF en log-log : qui est scale-free ?"")
+ax.legend(); fig.tight_layout(); plt.show()",,,,,,,,ea20fa2ba860c020,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,051fe0a2,markdown,fr,f6713c926100e966,"On ne tranche pas a l'oeil. La methode (Clauset, Shalizi & Newman) :
+
+1. **Choisir le seuil de queue** $x_{\min}$ qui *minimise* la distance de
+   Kolmogorov-Smirnov entre la queue et sa loi de puissance ajustee
+   (`select_xmin`) — on ne suppose pas la loi de puissance, on cherche le segment
+   ou elle colle le mieux.
+2. **Estimer l'exposant** $\alpha$ par maximum de vraisemblance (`hill_alpha`).
+3. **Mesurer l'ajustement** (distance KS) : grand KS => mauvais ajustement, la loi
+   de puissance ne tient pas, quoi qu'en dise l'oeil.
+4. **Comparer** loi de puissance vs exponentielle par rapport de log-vraisemblance
+   $R$. La fonction `compare_powerlaw_exponential` enchaine tout : elle ne declare
+   *scale-free* que si l'ajustement tient (KS faible) **et** que la loi de
+   puissance bat l'exponentielle.",,,,,,,,f6713c926100e966,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,41f3b5ba,code,fr,439d87526dbf2dd2,"for nom, ech, disc in [(""loi de puissance"", ech_pl, False), (""exponentielle"", ech_exp, False)]:
+    xm = sf.select_xmin(ech, discrete=disc)
+    d = sf.compare_powerlaw_exponential(ech, xmin=xm, discrete=disc)
+    print(f""{nom:18s} xmin*={xm:6.2f}  alpha={d['alpha']:.2f}  ""
+          f""KS={d['ks']:.3f}  R={d['loglik_ratio']:+.0f}  ->  {d['verdict']}"")",,,,,,,,439d87526dbf2dd2,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,24046d68,markdown,fr,2fd0c01eacf96fdb,"La boite a outils retrouve la verite : l'exposant de la loi de puissance est
+estime a ~2.5 (sa vraie valeur) avec un KS minuscule et un $R$ tres positif —
+**scale-free** ; pour l'exponentielle, l'ajustement reste passable mais
+l'exponentielle **est preferee** a la loi de puissance ($R<0$) — **echelle
+caracteristique**. C'est l'etalonnage : la methode classe correctement des cas dont
+on connait la reponse. On peut maintenant l'appliquer a des systemes ou on ne la
+connait pas.",,,,,,,,2fd0c01eacf96fdb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,b9a5bcbf,markdown,fr,cc954b9eed25e130,"## 3. Un systeme reellement scale-free : le branchement critique
+
+Le banc d'essai canonique de la criticalite est le **processus de branchement**
+(Galton-Watson) : une graine engendre un nombre aleatoire de descendants
+(progeniture de moyenne $\mu$), qui en engendrent a leur tour. La **taille
+d'avalanche** est le nombre total de noeuds.
+
+- $\mu < 1$ (sous-critique) : les avalanches s'eteignent vite — **echelle
+  caracteristique**.
+- $\mu = 1$ (**critique**) : la theorie est exacte. La taille totale suit la loi de
+  Borel $P(s) = s^{s-1} e^{-s}/s!$, dont la queue est $\sim s^{-3/2}$ : une **loi de
+  puissance d'exposant $\tau = 3/2$**. Aucune echelle ne domine.
+- $\mu > 1$ (sur-critique) : des avalanches geantes apparaissent.
+
+C'est notre etalon de *vrai* scale-free, avec un exposant connu d'avance ($1.5$) :
+le diagnostic doit le retrouver.",,,,,,,,cc954b9eed25e130,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,7477262b,code,fr,8df0ccf9b69ab636,"rng = random.Random(GRAINE + 1)
+N_AVAL = 15000
+# on compare les deux regimes nets : sous-critique (echelle caracteristique) et
+# critique (scale-free). Le sur-critique produit des avalanches geantes qui debordent.
+avalanches = {mu: sf.branching_avalanche_sizes(mu, N_AVAL, rng) for mu in (0.5, 1.0)}
+
+fig, ax = plt.subplots(figsize=(6.2, 4.4))
+for mu, marker in [(0.5, ""s""), (1.0, ""o"")]:
+    finis = [s for s in avalanches[mu] if s < 100000]
+    trace_ccdf(ax, finis, f""mu={mu}"", marker)
+# pente theorique -(tau-1) = -1/2 en CCDF (cas critique)
+xx = np.array([2, 2000]); ax.loglog(xx, 0.5 * (xx / 2.0) ** (-0.5), ""k--"", lw=1, label=""pente theorique -1/2"")
+ax.set_xlabel(""taille d'avalanche s""); ax.set_ylabel(""P(S >= s)"")
+ax.set_title(""Figure 2 - Avalanches de branchement : sous-critique vs critique"")
+ax.legend(); fig.tight_layout(); plt.show()
+
+for mu in (0.5, 1.0):
+    finis = [s for s in avalanches[mu] if s < 100000]
+    xm = sf.select_xmin(finis, discrete=True)
+    d = sf.compare_powerlaw_exponential(finis, xmin=xm, discrete=True)
+    a = f""{d['alpha']:.2f}"" if d['alpha'] else ""NA""
+    print(f""mu={mu}  xmin*={xm}  alpha={a}  KS={d['ks']:.3f}  ->  {d['verdict']}"")",,,,,,,,8df0ccf9b69ab636,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,64bf01b9,markdown,fr,4c923f6d27eaf3ea,"Le verdict suit la theorie. Le cas critique $\mu = 1$ est declare **scale-free**, et
+surtout l'exposant estime tombe sur $\alpha \approx 1.5$ — exactement le $\tau = 3/2$
+de la loi de Borel : ce n'est pas seulement le verdict qui colle, c'est la *valeur*
+predite d'avance qui est retrouvee. La courbe critique longe la droite de pente
+$-1/2$ sur plusieurs decades. Le cas sous-critique $\mu = 0.5$, lui, **echoue** au
+test de loi de puissance (KS trop grand) : ses avalanches s'eteignent vite, ce qui
+impose une **echelle caracteristique**.
+
+C'est le bon reflexe : ne pas se fier au seul mot *scale-free* mais a l'**exposant**.
+Pres de la criticalite, une loi de puissance a coupure tres lointaine peut tromper
+le verdict localement ; seul $\mu = 1$ produit le $\tau = 3/2$ theorique, signe que
+la signature est reelle et non un artefact d'ajustement (l'**Exercice 1** fait
+explorer cette fenetre). Le scale-free n'est donc **pas** un regime generique : il
+vit sur un point precis. C'est tout l'argument de Jansma & Hoel — une organisation
+multi-echelle nette est un accident finement regle, pas la regle.",,,,,,,,4c923f6d27eaf3ea,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,1236161c,markdown,fr,3ea76802c5cb594e,"## 4. Retour au tri auto-organise : a queue lourde, mais *pas* scale-free
+
+Reprenons le systeme vedette de la serie : le **tri auto-organise** vue-cellule
+d'[ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb) (tableaux chimeriques alternant
+les algotypes `bubble`/`insertion`). On en extrait une signature naturelle : le
+**deplacement net** de chaque cellule, $|{\rm position\ initiale} - {\rm position\
+finale}|$, sur de nombreuses permutations aleatoires. Certaines cellules voyagent
+loin, d'autres a peine : la distribution a une queue. Est-elle scale-free ?",,,,,,,,3ea76802c5cb594e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,b60798e8,code,fr,f96a0905845162b1,"rng = random.Random(GRAINE + 2)
+dep = deplacements_tri(n=32, n_runs=140, seed0=0)
+
+fig, ax = plt.subplots(figsize=(6.2, 4.4))
+trace_ccdf(ax, dep, ""tri : deplacements (n=32)"", ""o"")
+crit = [s for s in avalanches[1.0] if s < 100000]
+trace_ccdf(ax, crit, ""branchement critique (rappel)"", ""x"")
+ax.set_xlabel(""valeur""); ax.set_ylabel(""CCDF"")
+ax.set_title(""Figure 3 - Tri vs critique : la queue lourde suffit-elle ?"")
+ax.legend(); fig.tight_layout(); plt.show()
+
+xm = sf.select_xmin(dep, discrete=True)
+d = sf.compare_powerlaw_exponential(dep, xmin=xm, discrete=True)
+print(f""deplacements du tri : xmin*={xm}  alpha={d['alpha']:.2f}  ""
+      f""KS={d['ks']:.3f}  R={d['loglik_ratio']:+.0f}  ->  {d['verdict']}"")
+print(f""deplacement maximal observe = {max(dep)}  (borne par n-1 = {32-1})"")",,,,,,,,f96a0905845162b1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,bd2cf5bd,markdown,fr,24ee37f43232d84e,"Le piege se referme — et le diagnostic le detecte. A l'oeil, la courbe du tri a bien
+une allure de queue lourde, comparable a celle de l'avalanche critique sur la
+gauche. Mais l'ajustement par loi de puissance **echoue** (KS au-dessus du seuil),
+et la cause saute aux yeux dans la derniere ligne : le deplacement est **borne par
+la taille du systeme** ($n-1$). Cette borne *est* l'echelle caracteristique. Un
+systeme scale-free n'a, par definition, aucune echelle privilegiee ; ici il y en a
+une, imposee par la taille.
+
+Lecon de fond pour ICT : des **regles locales a une seule echelle** (chaque cellule
+ne voit que ses voisins immediats, cf. ICT-2/ICT-4) trient efficacement et reparent,
+mais ne s'auto-organisent **pas** vers la criticalite. Le scale-free demande un
+reglage particulier (etre poise au bord d'une transition) que ces regles minimales
+ne possedent pas. Mesurer la signature plutot que la supposer evite de prendre une
+queue lourde banale pour une organisation multi-echelle profonde.",,,,,,,,24ee37f43232d84e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,a6538aa6,markdown,fr,570b8ae8fee51263,"## 5. Auto-similarite et effondrement d'echelle (le cote fractal)
+
+Une signature scale-free est **auto-similaire** : zoomer ne change pas la forme.
+Une signature a echelle caracteristique, au contraire, possede *une* echelle qui,
+une fois retiree, fait coincider les distributions. Le test fractal canonique est
+l'**effondrement d'echelle** (data collapse) : on fait varier la taille du systeme
+et on renormalise l'axe des x.
+
+Pour le tri, l'echelle candidate est la taille $n$. Tracons les CCDF des
+deplacements pour $n \in \{20, 30, 40\}$, brutes puis renormalisees par $x/n$.",,,,,,,,570b8ae8fee51263,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,86fe7bca,code,fr,20fd87b4c2bbaa02,"rng = random.Random(GRAINE + 3)
+deps = {n: deplacements_tri(n=n, n_runs=120, seed0=1000 + n) for n in (20, 30, 40)}
+
+fig, axes = plt.subplots(1, 2, figsize=(11, 4.2))
+for n, mk in [(20, ""o""), (30, ""s""), (40, ""^"")]:
+    trace_ccdf(axes[0], deps[n], f""n={n}"", mk)
+    xs, ps = sf.rescaled_ccdf(deps[n], scale=n)        # x -> x/n
+    axes[1].semilogy(xs, ps, marker=mk, ls=""none"", ms=3, alpha=0.6, label=f""n={n}"")
+axes[0].set_title(""CCDF brutes (separees)""); axes[0].set_xlabel(""deplacement x"")
+axes[0].set_ylabel(""CCDF""); axes[0].legend()
+axes[1].set_title(""CCDF renormalisees x/n (effondrement)""); axes[1].set_xlabel(""x / n"")
+axes[1].set_ylabel(""CCDF""); axes[1].legend()
+fig.suptitle(""Figure 4 - Effondrement d'echelle : le tri a une echelle caracteristique (= n)"")
+fig.tight_layout(); plt.show()",,,,,,,,20fd87b4c2bbaa02,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,cd3f9984,markdown,fr,17e40c5302e4ea3e,"Les CCDF brutes se separent (a gauche) : plus le tableau est grand, plus les
+deplacements peuvent etre grands. Renormalisees par $x/n$ (a droite), elles **se
+superposent** : il existait une seule echelle, la taille $n$, et l'avoir retiree
+fait coincider les courbes. C'est la signature meme d'une **echelle
+caracteristique** — l'oppose du scale-free, qui ne se laisse reduire par aucune
+renormalisation unique (l'avalanche critique de la Figure 2 garde la meme forme a
+toutes les echelles, sa coupure ne faisant que reculer avec la taille du systeme).",,,,,,,,17e40c5302e4ea3e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,c7bf25e7,markdown,fr,9e5866b466454cd0,"## 6. Garde-fou avance : le test d'adequation par bootstrap
+
+Le KS et le rapport $R$ comparent deux modeles ; on peut aller plus loin et demander
+si la loi de puissance ajustee est, *a elle seule*, un modele credible. `scale_free`
+fournit pour cela un test d'adequation par bootstrap (`gof_pvalue`, facon Clauset et
+al.) : on simule de nombreux echantillons issus de la loi de puissance ajustee et on
+mesure la fraction dont l'ecart KS est *au moins aussi grand* que celui observe. Une
+**p-valeur elevee** signifie que l'ecart observe est typique d'une vraie loi de
+puissance (on ne la rejette pas) ; une **p-valeur proche de 0** la rejette.
+
+Appliquons-le aux deux cas tranches du notebook : le branchement **critique**
+(qu'on attend *confirme*) et les **deplacements du tri** (qu'on attend *rejetes*).",,,,,,,,9e5866b466454cd0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,b093e1cc,code,fr,50570caae433259b,"boot = random.Random(GRAINE + 4)
+
+# (a) branchement critique : on attend une confirmation (p-valeur elevee)
+crit = [s for s in avalanches[1.0] if s < 100000]
+xm_c = sf.select_xmin(crit, discrete=True)
+d_c = sf.compare_powerlaw_exponential(crit, xmin=xm_c, discrete=True, rng=boot, gof_boot=200)
+print(f""branchement critique  : alpha={d_c['alpha']:.2f}  KS={d_c['ks']:.3f}  ""
+      f""p-GoF={d_c['gof_pvalue']}  ->  {d_c['verdict']}"")
+
+# (b) deplacements du tri (calcules en section 4) : on attend un rejet (p-valeur ~ 0)
+xm_d = sf.select_xmin(dep, discrete=True)
+d_d = sf.compare_powerlaw_exponential(dep, xmin=xm_d, discrete=True, rng=boot, gof_boot=200)
+print(f""deplacements du tri   : alpha={d_d['alpha']:.2f}  KS={d_d['ks']:.3f}  ""
+      f""p-GoF={d_d['gof_pvalue']}  ->  {d_d['verdict']}"")",,,,,,,,50570caae433259b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,034865ba,markdown,fr,0e19a0f65d6f55ca,"Le test tranche dans le bon sens : il **confirme** le branchement critique
+(p-valeur elevee — l'ecart KS est celui d'une vraie loi de puissance) et **rejette**
+les deplacements du tri (p-valeur effondree). C'est le troisieme angle, concordant
+avec le KS et le rapport $R$ : les trois outils designent le meme coupable.
+
+Une mise en garde demeure, a enseigner : la p-valeur bootstrap est **sensible au
+choix de $x_{\min}$**. Applique a un segment trop court ou trop bas (mauvais
+$x_{\min}$), le test sur-rejette, meme un vrai scale-free, car la loi de puissance
+n'est exacte qu'asymptotiquement. D'ou la regle de la serie : choisir $x_{\min}$ par
+minimisation du KS *d'abord*, puis lire le bootstrap comme un troisieme avis — jamais
+comme un juge unique.",,,,,,,,0e19a0f65d6f55ca,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,aef3988e,markdown,fr,aa6dfc2407641412,"## 7. Exercices
+
+Trois exercices pour s'approprier la detection scale-free. Les solutions ne sont
+pas fournies (cellules a completer) ; le notebook s'execute de bout en bout meme
+laissees en l'etat.",,,,,,,,aa6dfc2407641412,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,60222370,markdown,fr,d5ffc83c29a9143c,"### Exercice 1 — Localiser la criticalite
+
+Le branchement est scale-free **exactement** a $\mu = 1$. Balayez $\mu$ de $0.85$ a
+$1.15$ par pas de $0.05$ ; pour chaque valeur, generez un echantillon d'avalanches,
+appliquez la chaine `select_xmin` + `compare_powerlaw_exponential`, et reperez ou le
+verdict bascule vers *scale-free* et ou l'exposant estime s'approche de $1.5$.
+
+```
+# Indice : reutilisez sf.branching_avalanche_sizes(mu, N, rng) et filtrez s < 100000.
+# Indice : stockez (mu, verdict, alpha, KS) puis affichez le tableau.
+# Etape 1 : construire la liste des mu.
+# Etape 2 : pour chaque mu, diagnostiquer.
+# Etape 3 : conclure sur la fenetre de mu compatible avec le scale-free.
+```",,,,,,,,d5ffc83c29a9143c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,1b42a3f7,code,fr,50b6ba365a8981f8,"# Exercice 1 : a completer.
+# resultat attendu : un tableau (mu, verdict, alpha, KS) montrant la bascule autour de mu=1.
+resultat_ex1 = None  # TODO etudiant
+print(""Exercice 1 a completer"")",,,,,,,,50b6ba365a8981f8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,c70299d4,markdown,fr,54cc10dab67f207b,"### Exercice 2 — Classer un echantillon mystere
+
+On vous donne un echantillon `mystere` (genere ci-dessous sans vous dire son
+origine). Appliquez la **chaine complete** de diagnostic et concluez : scale-free ou
+echelle caracteristique ? Justifiez avec l'exposant, le KS, et le rapport $R$.
+
+```
+# Indice : ne tranchez pas sur le trace log-log seul (c'est tout l'enjeu du notebook).
+# Indice : sf.select_xmin puis sf.compare_powerlaw_exponential.
+# Etape 1 : tracer la CCDF (pour l'intuition).
+# Etape 2 : diagnostiquer quantitativement.
+# Etape 3 : ecrire le verdict argumente.
+```",,,,,,,,54cc10dab67f207b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,23c36fbe,code,fr,3fadba05512e85a6,"# Echantillon mystere (ne regardez pas comment il est fait avant d'avoir conclu) :
+_rng_mystere = random.Random(2024)
+mystere = sf.branching_avalanche_sizes(1.0, 8000, _rng_mystere)
+mystere = [s for s in mystere if s < 100000]
+
+# Exercice 2 : a completer.
+resultat_ex2 = None  # TODO etudiant
+print(""Exercice 2 a completer -"", len(mystere), ""observations a classer"")",,,,,,,,3fadba05512e85a6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,be191021,markdown,fr,bdf2d70712266d6a,"### Exercice 3 — Effondrement d'echelle de votre cru
+
+Reproduisez l'idee de la Figure 4 sur une autre signature du tri : par exemple le
+**nombre total d'echanges** pour trier (au lieu du deplacement). Variez $n$,
+verifiez si la distribution possede une echelle caracteristique en cherchant la
+renormalisation qui fait coincider les courbes. Si oui, quelle puissance de $n$ ?
+
+```
+# Indice : arr.probe.swaps donne le nombre d'echanges d'une execution.
+# Indice : pour un tri, le nombre d'echanges croit comme une puissance de n -- testez x / n**k.
+# Etape 1 : collecter les nombres d'echanges pour plusieurs n.
+# Etape 2 : tracer brut puis renormalise.
+# Etape 3 : identifier l'echelle (la puissance k) qui fait l'effondrement.
+```",,,,,,,,bdf2d70712266d6a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,556d32d5,code,fr,22102ddd58a8bd49,"# Exercice 3 : a completer.
+resultat_ex3 = None  # TODO etudiant
+print(""Exercice 3 a completer"")",,,,,,,,22102ddd58a8bd49,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb,d0f7e15a,markdown,fr,f44c7f61423fa5cd,"## 8. Conclusion & ponts
+
+- **Detecter une signature scale-free est une competence, pas un coup d'oeil.** Le
+  trace log-log trompe : on a vu une queue lourde banale (les deplacements du tri,
+  bornes par la taille) ressembler a une avalanche critique. Seule la chaine
+  *choix de $x_{\min}$ par minimisation du KS -> exposant par maximum de
+  vraisemblance -> qualite d'ajustement -> comparaison de modeles* tranche
+  honnetement.
+- **Le scale-free est rare et regle.** Notre seul vrai cas sans echelle est le
+  branchement **a la criticalite** ($\mu = 1$, exposant $3/2$ retrouve). De part et
+  d'autre, une echelle caracteristique reapparait. C'est l'argument de Jansma &
+  Hoel : une organisation multi-echelle nette est particuliere, pas generique.
+- **Les regles locales mono-echelle du tri ne s'auto-organisent pas vers la
+  criticalite.** Elles trient, reparent (ICT-2/ICT-4), mais leur signature a une
+  echelle caracteristique : la taille du systeme, revelee par l'effondrement
+  d'echelle.
+
+**Ponts dans la serie ICT :**
+
+- [ICT-5](ICT-5-CausalEmergence.ipynb) / [ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb) :
+  l'emergence causale y est, elle aussi, *discriminante* — un macro-niveau n'est
+  pertinent que s'il bat le micro, exactement comme une signature n'est scale-free
+  que si elle survit au diagnostic. Meme discipline anti-complaisance.
+- **Criticalite auto-organisee** (Bak, Tang & Wiesenfeld 1987) : certains systemes
+  *se conduisent* vers la criticalite sans reglage externe. Un prolongement
+  naturel : un modele de tri/morphogenese qui s'auto-organiserait vers le scale-free
+  produirait-il une emergence causale plus forte (au sens d'ICT-5/6) ?
+- [ICT-0](ICT-0-Framing.md) : ce notebook clot la question des signatures
+  multi-echelles posee dans le cadrage.
+
+**References :**
+
+- A. Clauset, C. R. Shalizi, M. E. J. Newman, *Power-law distributions in empirical
+  data*, SIAM Review 51(4), 2009 — methode de diagnostic suivie ici.
+- A. Jansma, E. Hoel, *Engineering Emergence*, 2025 — emergence multi-echelle,
+  rarete des organisations causales nettes.
+- P. Bak, C. Tang, K. Wiesenfeld, *Self-organized criticality*, Phys. Rev. Lett.
+  59, 1987 — criticalite et signatures sans echelle.
+- T. E. Harris, *The Theory of Branching Processes*, 1963 — loi de Borel, exposant
+  $3/2$ a la criticalite.",,,,,,,,f44c7f61423fa5cd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,de10a093,markdown,fr,a97d1b13368d00d6,"# ICT-8 — Paysages d'attracteurs & signaux precurseurs : *les deux tressees*
+
+> **Serie ICT** (Integrated Causal Trajectories, Epic #4588) — strate 2 : *morphogenese dynamique*.
+> Prerequis conseilles : [ICT-0-Framing](ICT-0-Framing.md), et les notebooks de causal emergence
+> [ICT-5](ICT-5-CausalEmergence.ipynb) / [ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb).
+
+## Pourquoi monter d'un cran
+
+La strate 1 de la serie (le **tri auto-organise**, ICT-2 a ICT-7) etait le bon marche-pied :
+transparente, calculable, et deja porteuse de « competences inattendues » reelles. Mais elle bute
+sur trois limites pour qui veut voir apparaitre l'**agence** et l'**organisation multi-echelle** :
+
+1. un **attracteur global unique**, dont le but (le tableau trie) est **impose de l'exterieur** ;
+2. **aucun point de consigne intrinseque** — rien que le systeme « cherche » de lui-meme ;
+3. **pas de hierarchie generatrice** — la richesse multi-echelle y est *analytique*, pas produite par
+   la dynamique.
+
+Ce notebook ouvre la strate 2 sur un substrat qui leve la premiere et la troisieme limite : un
+**systeme bistable a bifurcation pli**. ICT-9 levera la deuxieme (l'agence comme regeneration vers
+une consigne).
+
+## Le principe : *les deux tressees*
+
+Tout au long de ce notebook, deux fils sont **tresses** :
+
+- **le fil metaphorique** — un *paysage* avec des vallees, une *bascule catastrophique*, une *memoire*
+  de la proximite du desastre ;
+- **le fil de la mesure** — **chaque** image est adossee a une grandeur calculee sur un **vrai modele**
+  (equilibres, potentiel effectif, valeur propre, variance, autocorrelation, tau de Kendall).
+
+La metaphore n'est creditee qu'au vu de ce qu'une mesure explicite en montre — c'est la traduction
+directe de la these de Levin : *les revendications cognitives sont des revendications de protocole*.
+On verra meme, sans complaisance, qu'une **mesure naive fabrique ou masque** le signal : la credibilite
+de la metaphore tient entierement a la **rigueur du protocole**.
+",,,,,,,,a97d1b13368d00d6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,bb51677c,code,fr,261b19568135b300,"import os, sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, os.path.abspath("".""))
+from ict.bistable import GrazingModel
+from ict import early_warning as ew
+
+GRAINE = 8  # reproductibilite
+np.random.seed(GRAINE)
+
+modele = GrazingModel(r=1.0, K=10.0, h=1.0)
+c_fold = modele.find_fold(1.5, 3.5, n=4000)
+print(f""Modele de paturage de May (1977) : r={modele.r}, K={modele.K}, h={modele.h}"")
+print(f""Bifurcation pli localisee a  c_fold ~= {c_fold:.3f}"")",,,,,,,,261b19568135b300,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,603bc061,markdown,fr,e8289b5413bbee81,"## 1. Le modele — paturage de May (1977)
+
+On etudie une biomasse de vegetation $x$ broutee a une pression $c$ :
+
+$$\frac{dx}{dt} \;=\; \underbrace{r\,x\Big(1-\frac{x}{K}\Big)}_{\text{croissance logistique}} \;-\; \underbrace{c\,\frac{x^2}{x^2+h^2}}_{\text{broutage (reponse de type III)}}$$
+
+C'est **le** systeme canonique de la litterature des *early-warning signals* (Scheffer et al., *Nature*
+2009 ; Dakos et al. 2012). Sa structure, pour $c$ faible, est celle des **etats stables alternatifs** :
+
+- un etat **vegetalise haut** ($x$ eleve) et un etat **surpature bas** ($x$ faible) **coexistent**,
+  separes par un equilibre **instable** (le col) ;
+- l'etat vraiment vide $x=0$ est, lui, **instable** : la reponse de broutage s'annule en $x^2$ pres de
+  zero, donc la vegetation repart toujours du quasi-neant.
+
+Quand la pression $c$ franchit un seuil $c_\text{fold}$, l'etat haut et le col **fusionnent et
+disparaissent** (le *pli*) : le systeme bascule **catastrophiquement** vers l'etat bas. C'est un
+*changement de regime*, pas une extinction — et c'est exactement le genre de transition qu'on aimerait
+**voir venir**.
+",,,,,,,,e8289b5413bbee81,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,41f9c465,code,fr,1ec4e005f96dab57,"fig, ax = plt.subplots(figsize=(8.5, 4.5))
+xs = np.linspace(0, 10, 400)
+for c in [1.6, 2.2, c_fold, 2.9]:
+    ax.plot(xs, modele.rate(xs, c), label=f""c = {c:.2f}"")
+ax.axhline(0, color=""k"", lw=0.8)
+ax.set_xlabel(""x  (biomasse de vegetation)""); ax.set_ylabel(""dx/dt"")
+ax.set_title(""Champ de vitesse : les zeros (dx/dt=0) sont les equilibres"")
+ax.legend(); ax.grid(alpha=0.3)
+plt.tight_layout(); plt.show()
+
+for c in (1.8, c_fold, 3.2):
+    eqs = modele.equilibria(c)
+    desc = "", "".join(f""{x:.2f}{'(s)' if st else '(i)'}"" for x, st in eqs)
+    print(f""c={c:.2f} : equilibres [{desc}]   (s=stable, i=instable)"")",,,,,,,,1ec4e005f96dab57,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,a425799d,markdown,fr,e9433ac3aefb2604,"## 2. Le paysage d'attracteurs
+
+Le modele derive d'un **potentiel effectif** $V(x)$ tel que $\dfrac{dx}{dt} = -\dfrac{dV}{dx}$ :
+
+$$V(x) = -\frac{r x^2}{2} + \frac{r x^3}{3K} + c\,x - c\,h\,\arctan\!\frac{x}{h}.$$
+
+Ce potentiel n'est **pas** ajuste a la main : il est l'antiderivee exacte du champ. Ses **minima sont
+les attracteurs** (les vallees ou la bille se repose), son **maximum local est le col** qui les separe.
+A gauche, on voit le **puits haut s'aplatir** a mesure que $c$ augmente ; a droite, le **diagramme de
+bifurcation** montre les branches stables et instable se rejoindre au pli.
+",,,,,,,,e9433ac3aefb2604,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,0e12f895,code,fr,18900aefb63ed1b1,"fig, (axL, axR) = plt.subplots(1, 2, figsize=(13, 5))
+
+# -- gauche : potentiel effectif V(x), recale a min=0 ; le puits haut s'aplatit --
+xs = np.linspace(0.05, 10, 500)
+for c in [1.6, 2.0, 2.4, c_fold]:
+    V = modele.potential(xs, c)
+    axL.plot(xs, V - V.min(), label=f""c = {c:.2f}"")
+axL.set_xlabel(""x""); axL.set_ylabel(""V(x)  (recale a min=0)"")
+axL.set_title(""Paysage d'attracteurs : le potentiel effectif"")
+axL.legend(); axL.grid(alpha=0.3)
+
+# -- droite : diagramme de bifurcation --
+cg = np.linspace(1.5, 3.2, 300)
+cs, xeq, st = modele.bifurcation_branches(cg)
+axR.scatter(cs[st], xeq[st], s=4, color=""C0"", label=""stable"")
+axR.scatter(cs[~st], xeq[~st], s=4, color=""C3"", label=""instable"")
+axR.axvline(c_fold, ls=""--"", color=""k"", lw=1, label=f""pli  c={c_fold:.2f}"")
+axR.set_xlabel(""c  (pression de broutage)""); axR.set_ylabel(""x*  (equilibres)"")
+axR.set_title(""Diagramme de bifurcation : le pli"")
+axR.legend(); axR.grid(alpha=0.3)
+plt.tight_layout(); plt.show()",,,,,,,,18900aefb63ed1b1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,83b05284,markdown,fr,20b5dcb8cab96e21,"### Exercice 1 — la hauteur de la barriere
+
+Le **col** qui protege l'etat haut a une hauteur $\Delta V = V(x_\text{instable}) - V(x_\text{haut})$.
+*Fil metaphorique* : c'est la profondeur de la vallee haute — combien d'energie il faudrait pour en
+sortir. *Fil de la mesure* : completez la fonction ci-dessous et **verifiez qu'elle tend vers 0 au pli**
+(le puits s'aplatit). C'est une premiere lecture quantitative du « danger ».
+
+*Indices :* `modele.equilibria(c)` renvoie `[(x, stable), ...]` ; l'etat haut est la plus grande racine
+stable, le col est la racine instable ($x>0$) ; `modele.potential(x, c)` evalue $V$.
+",,,,,,,,20b5dcb8cab96e21,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,dae7d60c,code,fr,55110f99cef05400,"def hauteur_de_barriere(c):
+    """"""Renvoie V(x_instable) - V(x_haut) : la hauteur du col protegeant l'etat haut.
+    Doit tendre vers 0 au pli. Renvoyer None tant que l'exercice n'est pas complete.""""""
+    # TODO etudiant : recuperer x_haut (plus grande racine stable) et x_instable (racine instable >0),
+    #                 puis renvoyer modele.potential(x_instable, c) - modele.potential(x_haut, c)
+    # eqs = modele.equilibria(c)
+    # x_haut = max(x for x, st in eqs if st and x > 1e-6)
+    # x_instable = [x for x, st in eqs if (not st) and x > 1e-6][0]
+    # return float(modele.potential(x_instable, c) - modele.potential(x_haut, c))
+    return None  # TODO
+
+# Verification (a decommenter une fois l'exercice complete) :
+# for c in [1.8, 2.2, 2.4, 2.55]:
+#     print(f""c={c:.2f} : barriere = {hauteur_de_barriere(c):.4f}"")
+print(""Exercice 1 a completer : la barriere du col doit decroitre vers 0 au pli."")",,,,,,,,55110f99cef05400,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,6e2fa9e3,markdown,fr,1d75f1605a27881b,"## 3. Le ralentissement critique
+
+Pres du pli, la **valeur propre** de l'equilibre haut (la pente $f'(x^*)$, force de rappel) tend vers
+**zero** : le systeme **recupere de plus en plus lentement** de ses perturbations. C'est le mecanisme
+physique qui *produit* les signaux precurseurs. On le voit de deux facons : (a) directement, $|f'(x^*)|
+\to 0$ ; (b) une meme perturbation met plus longtemps a se resorber pres du pli.
+",,,,,,,,1d75f1605a27881b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,54ea4f46,code,fr,456e3fad1288d80d,"# (a) valeur propre locale au puits haut -> 0 au pli
+cs_loc = np.linspace(1.6, c_fold - 0.01, 30)
+lam = np.array([modele.rate_prime(max(x for x, st in modele.equilibria(c) if st), c) for c in cs_loc])
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(13, 4.5))
+a1.plot(cs_loc, -lam, ""o-"", ms=3)
+a1.set_xlabel(""c""); a1.set_ylabel(""|valeur propre| au puits haut"")
+a1.set_title(""(a) La force de rappel s'annule au pli""); a1.grid(alpha=0.3)
+
+# (b) recuperation deterministe d'une meme perturbation (vers le haut), loin vs pres du pli
+for c, col in [(1.7, ""C0""), (c_fold - 0.05, ""C3"")]:
+    xhigh = max(x for x, st in modele.equilibria(c) if st)
+    x, dt, traj = xhigh + 1.0, 0.05, []
+    for _ in range(500):
+        traj.append(x); x = x + dt * float(modele.rate(x, c))
+    traj = np.array(traj); t = np.arange(len(traj)) * dt
+    rt = ew.recovery_time(traj, baseline=xhigh, tol=0.05 * xhigh)
+    a2.plot(t, traj, color=col, label=f""c={c:.2f}  (retour ~{rt} pas)"")
+a2.set_xlabel(""temps""); a2.set_ylabel(""x"")
+a2.set_title(""(b) Recuperation plus lente pres du pli""); a2.legend(); a2.grid(alpha=0.3)
+plt.tight_layout(); plt.show()",,,,,,,,456e3fad1288d80d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,cc9369b9,markdown,fr,6f851bfff109def0,"## 4. Les signaux precurseurs — variance et autocorrelation
+
+Le ralentissement critique laisse **deux empreintes statistiques** dans les fluctuations d'un systeme
+bruite, **avant** la bascule :
+
+- la **variance** augmente (le systeme s'ecarte plus loin et plus longtemps de l'equilibre) ;
+- l'**autocorrelation de retard 1 (AR1)** augmente (les ecarts persistent — la « memoire » s'allonge).
+
+On applique le protocole canonique (Dakos/Scheffer) : a chaque $c$ **fixe** approchant le pli, une
+simulation stochastique stationnaire, puis variance et AR1 des fluctuations (apres amincissement et
+detrendage — on y revient juste apres). On attend que **les deux montent** vers le pli.
+",,,,,,,,6f851bfff109def0,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,bd5793f0,code,fr,cd974092d4d3b959,"c_values = [1.7, 2.0, 2.3, 2.5, 2.57]
+variances, ar1s = [], []
+for c in c_values:
+    xhigh = max(x for x, st in modele.equilibria(c) if st)
+    serie = modele.simulate_sde(c=c, x0=xhigh, sigma=0.06, dt=0.01, T=300000,
+                                seed=GRAINE + int(c * 100))
+    s = ew.detrend(ew.thin(serie[50000:], factor=50), sigma=50)  # burn-in + thin + detrend
+    variances.append(s.var()); ar1s.append(ew.lag1_autocorr(s))
+variances, ar1s = np.array(variances), np.array(ar1s)
+
+tau_v, p_v = ew.kendall_tau(c_values, variances)
+tau_a, p_a = ew.kendall_tau(c_values, ar1s)
+for c, v, a in zip(c_values, variances, ar1s):
+    print(f""c={c:.2f}  (pli-c = {c_fold-c:+.2f})   variance={v:.5f}   AR1={a:+.4f}"")
+print(f""\nTendance vers le pli :  variance  tau={tau_v:+.2f} (p={p_v:.1e})""
+      f""    AR1  tau={tau_a:+.2f} (p={p_a:.1e})"")
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(13, 4.5))
+a1.plot(c_values, variances, ""o-""); a1.axvline(c_fold, ls=""--"", color=""k"")
+a1.set_xlabel(""c""); a1.set_ylabel(""variance des fluctuations"")
+a1.set_title(""La variance monte vers le pli""); a1.grid(alpha=0.3)
+a2.plot(c_values, ar1s, ""o-"", color=""C1""); a2.axvline(c_fold, ls=""--"", color=""k"")
+a2.set_xlabel(""c""); a2.set_ylabel(""autocorrelation (retard 1)"")
+a2.set_title(""L'autocorrelation monte vers le pli""); a2.grid(alpha=0.3)
+plt.tight_layout(); plt.show()",,,,,,,,cd974092d4d3b959,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,de352925,markdown,fr,591523aac886c282,"## 5. *Sans complaisance* : la lecon de protocole
+
+Voici le fil le plus important du notebook. Les deux indicateurs ci-dessus **ne se mesurent pas
+naivement**. Sur **la meme serie** pres du pli :
+
+- si on calcule l'AR1 sur la serie **brute** (pas d'integration tres fin devant le temps de relaxation),
+  elle est **ecrasee pres de 1** et n'a **aucune marge** pour monter — le signal est **invisible**. Il
+  faut **amincir** la serie a une cadence comparable au temps de relaxation ;
+- si on calcule la variance **sans retirer la tendance**, on mesure la **derive deterministe** de
+  l'equilibre, pas les **fluctuations** — on peut ainsi *fabriquer* un faux signal ou *masquer* le vrai.
+
+Autrement dit : la metaphore « le systeme ralentit » n'est creditee que parce qu'on l'a **mesuree
+correctement**. Une premiere mesure naive de ce notebook avait d'ailleurs echoue — c'est le protocole,
+pas le substrat, qui etait en cause.
+",,,,,,,,591523aac886c282,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,1a1572ae,code,fr,f2e5de5d3e1a76e4,"c = 2.55
+xhigh = max(x for x, st in modele.equilibria(c) if st)
+serie = modele.simulate_sde(c=c, x0=xhigh, sigma=0.06, dt=0.01, T=300000, seed=GRAINE)[50000:]
+
+ar1_dense = ew.lag1_autocorr(serie)                  # brute (sur-echantillonnee)
+ar1_thin  = ew.lag1_autocorr(ew.thin(serie, 50))     # amincie
+var_brute    = serie.var()                           # tendance incluse
+var_detrend  = ew.detrend(serie, sigma=2000).var()   # fluctuations seules
+
+print(f""AR1 brute (sur-echantillonnee) = {ar1_dense:.4f}   <- saturee pres de 1, sans marge"")
+print(f""AR1 apres amincissement (x50)  = {ar1_thin:.4f}   <- le vrai signal se degage"")
+print(f""variance brute (tendance incluse)    = {var_brute:.5f}"")
+print(f""variance des fluctuations (detrendee) = {var_detrend:.5f}"")
+print(""\nMeme systeme, meme instant : la mesure naive masque, le protocole correct revele."")",,,,,,,,f2e5de5d3e1a76e4,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,870aaea9,markdown,fr,bcc1d7420029b1cb,"### Exercice 2 — les indicateurs stationnaires
+
+Completez la fonction qui mesure les deux precurseurs a une pression $c$ **fixe**, par le protocole
+stationnaire (simuler → retirer le *burn-in* → **amincir** → **detrendre** → variance & AR1). Vous
+reproduirez ainsi, point par point, la courbe de la section 4.
+
+*Indices :* l'etat de depart est l'etat haut ; `modele.simulate_sde(...)` ; pretraitement avec
+`ew.thin(...)` puis `ew.detrend(...)` ; puis `.var()` et `ew.lag1_autocorr(...)`.
+",,,,,,,,bcc1d7420029b1cb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,cedca8a6,code,fr,47cc83b92e79de61,"def indicateurs_a(c, sigma=0.06, T=200000, seed=0):
+    """"""Renvoie (variance, AR1) des fluctuations a la pression c, protocole stationnaire.
+    Renvoyer None tant que l'exercice n'est pas complete.""""""
+    # TODO etudiant :
+    # x0 = max(x for x, st in modele.equilibria(c) if st)
+    # serie = modele.simulate_sde(c=c, x0=x0, sigma=sigma, dt=0.01, T=T, seed=seed)
+    # s = ew.detrend(ew.thin(serie[T//6:], factor=50), sigma=50)
+    # return float(s.var()), float(ew.lag1_autocorr(s))
+    return None  # TODO
+
+# Verification (a decommenter une fois complete) :
+# for c in [1.8, 2.3, 2.55]:
+#     print(c, indicateurs_a(c))
+print(""Exercice 2 a completer : indicateurs stationnaires (variance, AR1) a c fixe."")",,,,,,,,47cc83b92e79de61,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,82cc744f,markdown,fr,853bf6fc47bcdee8,"## 6. Le scenario reel — une rampe non-stationnaire
+
+Dans la nature, $c$ ne saute pas : il **derive lentement**. On fait donc glisser $c$ de 1.7 a 2.9
+(la rampe traverse le pli) et on demande : **les precurseurs montent-ils AVANT la bascule** ? C'est tout
+l'enjeu pratique des EWS — donner l'alerte pendant qu'il est encore temps.
+",,,,,,,,853bf6fc47bcdee8,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,d8dab665,code,fr,49c2601c3a36335c,"xs_ramp, cs_ramp = modele.simulate_ramp(c0=1.7, c1=2.9, x0=7.5, sigma=0.05,
+                                        dt=0.01, T=240000, seed=GRAINE)
+seuil = 0.5 * xs_ramp[:2000].mean()
+tip = int(np.argmax(xs_ramp < seuil))
+print(f""Bascule a t={tip}  (c_tip={cs_ramp[tip]:.3f}, pli a {c_fold:.3f})"")
+
+pre = xs_ramp[: int(tip * 0.90)]                       # fenetre AVANT la bascule
+out = ew.ews_summary(pre, window=150, thin_factor=40, detrend_sigma=40)
+print(f""Avant la bascule :  variance tau={out['tau_var']:+.3f} (p={out['p_var']:.1e})""
+      f""    AR1 tau={out['tau_ar1']:+.3f} (p={out['p_ar1']:.1e})"")
+
+fig, ax = plt.subplots(2, 1, figsize=(11, 7))
+ax[0].plot(xs_ramp, lw=0.4); ax[0].axvline(tip, color=""C3"", ls=""--"", label=""bascule"")
+ax[0].set_ylabel(""x (biomasse)""); ax[0].legend()
+ax[0].set_title(""Rampe a travers le pli : la bascule catastrophique"")
+ax[1].plot(out[""index""], out[""variance""], label=""variance roulante"")
+axb = ax[1].twinx(); axb.plot(out[""index""], out[""ar1""], color=""C1"")
+ax[1].set_xlabel(""indice (serie amincie, AVANT bascule)"")
+ax[1].set_ylabel(""variance""); axb.set_ylabel(""AR1 (orange)"")
+ax[1].set_title(""Les deux precurseurs montent AVANT la bascule"")
+plt.tight_layout(); plt.show()",,,,,,,,49c2601c3a36335c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,01c651cf,markdown,fr,c5395042cccf82cb,"### Exercice 3 — avertissement contre vitesse de derive
+
+Un systeme qui derive **vite** laisse **moins de temps** au precurseur pour s'etablir : l'alerte est plus
+faible, ou arrive trop tard. Completez la fonction qui renvoie la tendance `tau_var` mesuree avant la
+bascule pour une rampe de duree $T$, et **comparez une rampe lente (T grand) a une rampe rapide
+(T petit)**.
+
+*Indices :* `modele.simulate_ramp(c0=1.7, c1=2.9, x0=7.5, sigma=0.05, dt=0.01, T=T, seed=GRAINE)` ;
+detecter la bascule (seuil = moitie de la moyenne initiale) ; `ew.ews_summary(pre, ...)`.
+",,,,,,,,c5395042cccf82cb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,95699774,code,fr,e8e6002479baf26d,"def avertissement_vs_vitesse(T):
+    """"""Renvoie le tau_var mesure AVANT la bascule pour une rampe de duree T.
+    Renvoyer None tant que l'exercice n'est pas complete.""""""
+    # TODO etudiant :
+    # xs, cs = modele.simulate_ramp(c0=1.7, c1=2.9, x0=7.5, sigma=0.05, dt=0.01, T=T, seed=GRAINE)
+    # seuil = 0.5 * xs[:max(2000, T//100)].mean()
+    # tip = int(np.argmax(xs < seuil))
+    # pre = xs[: int(tip * 0.90)]
+    # return ew.ews_summary(pre, window=120, thin_factor=20, detrend_sigma=40)[""tau_var""]
+    return None  # TODO
+
+# Verification (a decommenter) : rampe lente vs rapide
+# print(""lente  (T=240000):"", avertissement_vs_vitesse(240000))
+# print(""rapide (T= 60000):"", avertissement_vs_vitesse(60000))
+print(""Exercice 3 a completer : comparer l'avertissement pour une rampe lente vs rapide."")",,,,,,,,e8e6002479baf26d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,5881337d,markdown,fr,f138125ca602d8b3,"## 7. Pont vers la causal emergence (ICT-5/6) et vers ICT-9
+
+Les deux vallees du paysage forment un **gros-grain** naturel a deux macro-etats — *bas* (surpature) et
+*haut* (vegetalise) — separes par le col instable. C'est exactement le type de **coarse-graining** que
+les notebooks [ICT-5](ICT-5-CausalEmergence.ipynb) et [ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb)
+analysent : on peut estimer une chaine de Markov a deux etats depuis une trajectoire bruitee et
+mesurer, via l'**information effective**, *quelle echelle fait le plus de travail causal*. Loin du pli,
+la description macro est quasi-deterministe (on reste dans sa vallee) ; pres du pli, la barriere
+s'effondre et les **escapes** se multiplient — la meme physique qui fait monter les precurseurs.
+
+C'est la **continuite** de la serie : la machinerie causale de la strate 1 s'applique telle quelle a la
+dynamique generative de la strate 2.
+
+**Vers ICT-9 — l'agence.** Ici, le systeme *subit* son paysage : il bascule quand on le pousse. Le
+prochain notebook leve la limite restante du marche-pied — le **but extrinseque** — en passant a la
+**morphogenese reaction-diffusion regenerante** : un systeme qui **repare** sa forme vers un *point de
+consigne intrinseque* apres ablation. L'agence s'y demontrera **par contraste** (la reaction repare la
+ou la simple diffusion dissout), comme le « sans liberte, pas d'agregation » d'ICT-4.
+",,,,,,,,f138125ca602d8b3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-8-AttractorLandscapesEWS.ipynb,aa3b2367,markdown,fr,16cca40d8892cd7b,"## Conclusion — la metaphore tenue par la mesure
+
+On a tresse deux fils tout du long :
+
+| Le fil metaphorique | Le fil de la mesure |
+|---|---|
+| un paysage a deux vallees | deux equilibres stables + un col, racines du champ |
+| la vallee haute s'aplatit | le potentiel effectif $V(x)$ et sa barriere $\Delta V \to 0$ |
+| le systeme « hesite » au bord | la valeur propre $\to 0$, la recuperation ralentit |
+| le systeme « se souvient » du danger | variance ↑ et autocorrelation ↑ (tau de Kendall positifs) |
+| une alerte avant la catastrophe | les precurseurs montent **avant** la bascule de la rampe |
+
+Et surtout : la metaphore n'est **credible que parce que le protocole est rigoureux** — amincir,
+detrendre, tester la tendance. Mesures naives = signaux fantomes. C'est la version dynamique de la these
+de Levin : une competence (« anticiper sa propre catastrophe ») n'est creditee qu'au vu de ce qu'une
+experience explicite en mesure.
+
+**Ce que ce notebook a apporte par rapport au tri** : un **vrai paysage d'attracteurs** (plusieurs
+bassins, une bifurcation) la ou le tri n'avait qu'un attracteur unique a but impose. Il reste a faire
+emerger l'**agence** — un systeme qui maintient *lui-meme* sa forme. C'est l'objet d'**ICT-9**.
+",,,,,,,,16cca40d8892cd7b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,05c9aa6a,markdown,fr,b0dce073292bf26b,"# ICT-9 — Agence & regeneration : *reparer sa forme, ou seulement deriver ?*
+
+> **Serie ICT** (Integrated Causal Trajectories, Epic #4588) — strate 2 : *morphogenese dynamique*.
+> Prerequis conseilles : [ICT-0-Framing](ICT-0-Framing.md) et [ICT-8](ICT-8-AttractorLandscapesEWS.ipynb).
+
+## La limite que ce notebook leve
+
+La strate 1 (le tri auto-organise) et ICT-8 (les paysages d'attracteurs) butaient sur une limite : le
+but du systeme etait **impose de l'exterieur** (le tableau trie ; le puits ou l'on tombe). Il n'y avait
+**aucun point de consigne intrinseque** — rien que le systeme maintienne *de lui-meme*. ICT-9 leve
+precisement cette limite avec un substrat **regenerant** : un systeme qui, apres qu'on a **detruit** une
+partie de sa forme, la **reconstruit** vers la forme qu'il engendre spontanement.
+
+## La question, et la regle du jeu
+
+> **Quand peut-on dire qu'un systeme repare sa propre forme, au lieu de simplement evoluer passivement ?**
+
+Reponse de la serie, *sans complaisance* : **l'agence n'est jamais declaree, elle est mesuree** — et
+toujours **par contraste**. On ne credite un systeme d'agence sur sa forme que si sa trajectoire de
+recuperation **domine quantitativement** celle d'un controle prive du mecanisme reparateur. Le mot-cle
+est **contraste** : *reaction-diffusion* vs *diffusion simple*.
+
+## Le cadre causal : deux mondes contrefactuels (Pearl)
+
+C'est exactement le **calcul causal** de Judea Pearl. On applique une **intervention** identique —
+`do(ablation)` : effacer un quart du motif — puis on compare **deux mondes** qui n'en different que par
+la dynamique laissee a l'oeuvre :
+
+| Monde | Dynamique apres `do(ablation)` | Prediction |
+|---|---|---|
+| **A** | reaction-diffusion complete | reconstruit la forme (regeneration) |
+| **B** | diffusion pure (sans reaction) | dissout ce qui reste (passivite) |
+
+La difference de recuperation entre A et B — le **gain de reparation** — *est* la mesure d'agence.
+C'est le meme geste que le « sans liberte, pas d'agregation » d'ICT-4 et que « la mesure naive fabrique
+un signal fantome » d'ICT-8 : une **competence n'est creditee qu'au vu d'un protocole explicite**.
+
+## Le substrat : Gray-Scott (reaction-diffusion)
+
+On utilise le systeme de **Gray-Scott** (J. E. Pearson, *Science* 1993), reference de la morphogenese de
+Turing : deux especes qui diffusent et reagissent, engendrant spontanement des **taches** auto-entretenues.
+C'est une *vraie* morphogenese generative — l'attracteur n'est pas une image figee mais un motif **vivant**
+(les taches se divisent), ce qui aura des consequences sur *quelles mesures* sont honnetes (section 5).
+Voir aussi Mordvintsev et al., *Growing Neural Cellular Automata* (Distill 2020), et les travaux de
+M. Levin sur la regeneration et le « setpoint » morphologique.",,,,,,,,b0dce073292bf26b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,74846141,code,fr,489e2e8af23ff060,"import os, sys
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+
+sys.path.insert(0, os.path.abspath("".""))
+from ict.reaction_diffusion import GrayScott, run_pure_diffusion, pure_diffusion_step
+from ict import agency
+
+GRAINE = 8                 # reproductibilite
+np.random.seed(GRAINE)
+
+N = 96                     # cote de la grille (regime ""taches"" stable a cette echelle)
+modele = GrayScott()       # F=0.0367, k=0.0649 : taches mitotiques de Pearson
+print(f""Gray-Scott : F={modele.F}, k={modele.k}, Du={modele.Du}, Dv={modele.Dv}, dt={modele.dt}"")
+print(f""Grille {N}x{N}, bords periodiques."")",,,,,,,,489e2e8af23ff060,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,e2179c20,markdown,fr,a5821c890fc449e1,"## 1. La morphogenese generative — un attracteur de forme
+
+A partir d'un simple germe central, la reaction-diffusion **engendre** un motif spatial structure et
+auto-entretenu. La quantite de structure est mesuree par la **variance spatiale** du champ d'activateur
+$V$ : nulle pour un champ uniforme, positive des qu'un motif contraste apparait. Cette structure de
+reference est le **point de consigne intrinseque** vers lequel le systeme pourra revenir.
+
+**Precision.** Ce « point de consigne » n'est pas une memoire positionnelle pixel par pixel. Gray-Scott
+ne retient pas *ou* etait chaque tache ; il retombe vers une **classe d'attracteur** — un *regime
+morphologique* (taches de telle taille, telle densite, telle texture). « Reparer sa forme » signifie
+ici *retrouver une organisation structuree du meme type*, pas reproduire l'image exacte. C'est
+exactement pourquoi (section 5) les mesures de ressemblance pixel-a-pixel trompent, et pourquoi la
+structure restauree — contrastee au controle passif — reste la seule mesure fiable.",,,,,,,,a5821c890fc449e1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,5d882040,code,fr,20624aba92ff317c,"rng = np.random.default_rng(GRAINE)
+U0, V0 = modele.seed(n=N, rng=rng)
+U_form, V_form, _ = modele.run(U0, V0, steps=6000)   # morphogenese
+S_cible = agency.structure(V_form)                   # consigne intrinseque
+
+fig, (a0, a1) = plt.subplots(1, 2, figsize=(11, 5))
+a0.imshow(V0, cmap=""magma"", vmin=0, vmax=0.5); a0.set_title(""t=0 : germe localise""); a0.axis(""off"")
+a1.imshow(V_form, cmap=""magma"", vmin=0, vmax=0.5)
+a1.set_title(f""t=6000 : motif auto-entretenu (structure={S_cible:.4f})""); a1.axis(""off"")
+plt.suptitle(""Morphogenese generative : la reaction-diffusion engendre un attracteur de forme"")
+plt.tight_layout(); plt.show()
+print(f""Structure (variance spatiale de V) du motif forme : {S_cible:.5f}"")",,,,,,,,20624aba92ff317c,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,106c4422,markdown,fr,c10f74530d13b356,"## 2. L'ablation comme intervention `do(.)`
+
+On **detruit** un quart du motif en le ramenant a l'etat nu du substrat ($U=1$, $V=0$ : « pas de motif
+ici »). Au sens de Pearl, c'est une **intervention** `do(ablation)` : on force une partie de l'etat, puis
+on observe la trajectoire qui en decoule. La question d'agence devient : *que se passe-t-il ensuite ?*",,,,,,,,c10f74530d13b356,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,9104876a,code,fr,14e7a4473d21f928,"mask = agency.quadrant_mask(N, quadrant=3)            # quart bas-droit
+U_abl, V_abl = agency.ablate(U_form, V_form, mask)   # do(ablation)
+
+fig, (a0, a1) = plt.subplots(1, 2, figsize=(11, 5))
+a0.imshow(V_form, cmap=""magma"", vmin=0, vmax=0.5); a0.set_title(""avant : motif intact""); a0.axis(""off"")
+a1.imshow(V_abl, cmap=""magma"", vmin=0, vmax=0.5); a1.set_title(""apres do(ablation) : quart efface""); a1.axis(""off"")
+for ax in (a0, a1):
+    ax.add_patch(mpatches.Rectangle((N//2 - 0.5, N//2 - 0.5), N//2, N//2, fill=False, ec=""cyan"", lw=2))
+plt.suptitle(""L'ablation comme intervention do(.) au sens de Pearl"")
+plt.tight_layout(); plt.show()
+print(f""Structure dans le quart ablate : {agency.structure(V_abl[mask]):.6f}  (~0 : motif efface)"")",,,,,,,,14e7a4473d21f928,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,7d0000ea,markdown,fr,fabd89c013cd65ab,"### Exercice 1 — quantifier le dommage
+
+Avant de mesurer une *reparation*, il faut mesurer le *dommage*. Completez `dommage_inflige` : la perte
+de structure (variance regionale) dans la zone ablatee. *Fil de la mesure* : c'est la grandeur que la
+reparation devra regagner.
+
+*Indices :* `agency.structure(champ)` calcule la variance ; `V[mask]` selectionne la zone ; comparer
+la structure regionale avant et apres ablation.",,,,,,,,fabd89c013cd65ab,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,f81d6d40,code,fr,04b5b349c7cc0bcb,"def dommage_inflige(V_reference, V_ablate, mask):
+    """"""Perte de structure dans la zone ablatee : structure(reference|zone) - structure(ablate|zone).
+    Renvoyer None tant que l'exercice n'est pas complete.""""""
+    # TODO etudiant : comparer la variance regionale avant / apres l'ablation
+    # s_avant = agency.structure(V_reference[mask])
+    # s_apres = agency.structure(V_ablate[mask])
+    # return float(s_avant - s_apres)
+    return None  # TODO
+
+# Verification (a decommenter une fois l'exercice complete) :
+# print(""dommage inflige :"", dommage_inflige(V_form, V_abl, mask))
+print(""Exercice 1 a completer : quantifier le motif detruit par l'ablation."")",,,,,,,,04b5b349c7cc0bcb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,0c108507,markdown,fr,25ce636ac722a194,"## 3. Deux mondes contrefactuels : reaction-diffusion vs diffusion pure
+
+Depuis **le meme** etat ablate, on laisse evoluer deux dynamiques. Le **monde A** garde la reaction-
+diffusion complete ; le **monde B** ne garde que la diffusion (meme operateur diffusif, terme reactif
+retire) — le **controle passif**. On enregistre la trajectoire de structure *dans la zone ablatee* pour
+les deux mondes, afin de comparer non seulement l'etat final mais toute la dynamique de recuperation.",,,,,,,,25ce636ac722a194,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,13ee5519,code,fr,7043230304e644e9,"REPAIR_STEPS = 8000
+REC_EVERY = 200
+
+# --- Monde A : do(ablation) + reaction-diffusion (mecanisme reparateur complet) ---
+# La trajectoire est ancree a l'instant 0 (etat ablate exact), comme le ferait
+# modele.run(..., record_every=REC_EVERY, include_initial=True) pour les champs.
+U_rd, V_rd = U_abl.copy(), V_abl.copy()
+traj_rd = [agency.structure(V_rd[mask])]          # t = 0 : etat ablate
+for t in range(REPAIR_STEPS):
+    U_rd, V_rd = modele.step(U_rd, V_rd)
+    if (t + 1) % REC_EVERY == 0:
+        traj_rd.append(agency.structure(V_rd[mask]))
+
+# --- Monde B : do(ablation) + diffusion pure (controle passif, sans reaction) ---
+V_diff = V_abl.copy()
+traj_diff = [agency.structure(V_diff[mask])]      # t = 0 : etat ablate
+for t in range(REPAIR_STEPS):
+    V_diff = pure_diffusion_step(V_diff, modele.Dv)
+    if (t + 1) % REC_EVERY == 0:
+        traj_diff.append(agency.structure(V_diff[mask]))
+
+fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+panneaux = [(V_abl, ""do(ablation)""), (V_rd, ""monde A : + reaction-diffusion""),
+            (V_diff, ""monde B : + diffusion pure"")]
+for ax, (img, ttl) in zip(axes, panneaux):
+    ax.imshow(img, cmap=""magma"", vmin=0, vmax=0.5); ax.set_title(ttl); ax.axis(""off"")
+    ax.add_patch(mpatches.Rectangle((N//2 - 0.5, N//2 - 0.5), N//2, N//2, fill=False, ec=""cyan"", lw=2))
+plt.suptitle(""Deux mondes contrefactuels issus de la MEME intervention do(ablation)"")
+plt.tight_layout(); plt.show()
+print(f""structure zone (fin) : monde A = {agency.structure(V_rd[mask]):.5f} | monde B = {agency.structure(V_diff[mask]):.5f}"")",,,,,,,,7043230304e644e9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,f7371420,markdown,fr,e37803b48fe56423,"## 4. L'agence mesuree : le gain de reparation
+
+Le **score de recuperation** rapporte la structure regagnee dans la zone a la structure perdue ($\approx 1$
+= zone integralement reconstituee, $\approx 0$ = rien ne repousse). Le **gain de reparation** est la
+difference entre les deux mondes :
+
+$$\text{gain} = \text{recuperation}_{\text{reaction-diffusion}} - \text{recuperation}_{\text{diffusion}}$$
+
+Strictement positif et substantiel, il signe une trajectoire qui *repare activement*. C'est la mesure
+d'agence — et le **temps de recuperation** dit *a quelle vitesse* la forme revient vers sa consigne.",,,,,,,,e37803b48fe56423,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,fd198636,code,fr,b0275bfe631d2118,"rec_rd   = agency.recovery_score(V_form, V_abl, V_rd, mask)
+rec_diff = agency.recovery_score(V_form, V_abl, V_diff, mask)
+gain     = agency.repair_gain(rec_rd, rec_diff)
+ttr      = agency.time_to_recover(traj_rd, S_cible, tol=0.2, record_every=REC_EVERY)
+
+fig, (axL, axR) = plt.subplots(1, 2, figsize=(13, 5))
+ts = np.arange(len(traj_rd)) * REC_EVERY
+axL.plot(ts, traj_rd, color=""crimson"", lw=2, label=""monde A : reaction-diffusion"")
+axL.plot(ts, traj_diff, color=""steelblue"", lw=2, label=""monde B : diffusion pure"")
+axL.axhline(S_cible, ls=""--"", color=""grey"", label=""consigne (structure cible)"")
+if ttr is not None:
+    axL.axvline(ttr, ls="":"", color=""crimson"", label=f""retour a 20% pres ({ttr} pas)"")
+axL.set_xlabel(""pas apres ablation""); axL.set_ylabel(""structure dans la zone (variance)"")
+axL.set_title(""Recuperation de la structure dans la zone ablatee""); axL.legend()
+
+axR.bar([""reaction-\ndiffusion"", ""diffusion\npure""], [rec_rd, rec_diff], color=[""crimson"", ""steelblue""])
+axR.axhline(0, color=""black"", lw=0.8); axR.set_ylabel(""score de recuperation"")
+axR.set_title(f""Gain de reparation = {gain:.2f}"")
+plt.tight_layout(); plt.show()
+
+print(f""recuperation A (RD) = {rec_rd:.2f} | recuperation B (diffusion) = {rec_diff:.2f} | GAIN = {gain:.2f}"")
+print(f""temps de recuperation (monde A, a 20% pres) = {ttr} pas"")",,,,,,,,b0275bfe631d2118,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,08660f9c,markdown,fr,04e2593d5febc05b,"### Exercice 2 — l'agence est-elle locale ou generale ?
+
+On a mesure la reparation d'**un** quart. Une vraie regeneration devrait reparer **n'importe quelle**
+zone. Completez `gain_reparation_ailleurs(quadrant)` pour ablater puis mesurer le gain sur un autre
+quadrant, et verifiez que l'agence n'est pas un artefact de l'endroit choisi.
+
+*Indices :* reproduire la logique des sections 3-4 en changeant le masque ; `pure_diffusion_step(champ, modele.Dv)`
+pour le controle passif ; `agency.recovery_score(...)` puis `agency.repair_gain(...)`.",,,,,,,,04e2593d5febc05b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,a42f45b3,code,fr,d635020be6b8bed6,"def gain_reparation_ailleurs(quadrant):
+    """"""Ablate un AUTRE quadrant puis renvoie le gain de reparation (RD vs diffusion) pour cette zone.
+    Teste si l'agence est locale a une zone ou generale. Renvoyer None tant que non complete.""""""
+    # TODO etudiant :
+    # m = agency.quadrant_mask(N, quadrant)
+    # Ua, Va = agency.ablate(U_form, V_form, m)
+    # _, Vr, _ = modele.run(Ua.copy(), Va.copy(), steps=REPAIR_STEPS)
+    # Vd = Va.copy()
+    # for _ in range(REPAIR_STEPS):
+    #     Vd = pure_diffusion_step(Vd, modele.Dv)
+    # rec_a = agency.recovery_score(V_form, Va, Vr, m)
+    # rec_b = agency.recovery_score(V_form, Va, Vd, m)
+    # return agency.repair_gain(rec_a, rec_b)
+    return None  # TODO
+
+# Verification (a decommenter) :
+# for q in range(4):
+#     print(f""quadrant {q} : gain = {gain_reparation_ailleurs(q)}"")
+print(""Exercice 2 a completer : l'agence repare-t-elle aussi bien partout ?"")",,,,,,,,d635020be6b8bed6,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,0870343f,markdown,fr,c5057861df103ca3,"## 5. *Sans complaisance* : la ressemblance trompe, le contraste tient
+
+La tentation serait de juger la reparation par la **ressemblance a l'image d'origine**. Deux mesures
+naives le proposent — et **toutes deux trompent** :
+
+- **distance pixel a pixel** : elle *penalise* la reaction-diffusion, parce qu'un attracteur **mitotique**
+  (les taches se divisent et migrent) ne revient *jamais* au pixel pres. La bonne question n'est pas
+  « est-ce la meme image ? » mais « est-ce un motif du **meme type** ? ».
+- **similarite spectrale (cosinus)** : elle peut attribuer un score *eleve* a la zone simplement diffusee...
+  qui n'a pourtant **aucune structure**. Le cosinus normalise l'amplitude : il fabrique une **ressemblance
+  fantome** sur un champ quasi vide — exactement le piege « mesure naive = signal fantome » d'ICT-8.
+
+La seule mesure fiable est celle qu'on a retenue : **la structure restauree, contrastee au controle
+passif**. L'agence se mesure comme *restauration sous intervention*, pas comme *ressemblance a un gabarit
+fige*.",,,,,,,,c5057861df103ca3,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,5d99b18c,code,fr,2661081bc86c5e39,"def crop(field):
+    h = N // 2
+    return field[h:N, h:N]            # la zone ablatee (quart bas-droit)
+
+dist_pix_rd   = agency.pattern_distance(crop(V_form), crop(V_rd))
+dist_pix_diff = agency.pattern_distance(crop(V_form), crop(V_diff))
+spec_rd   = agency.spectral_similarity(crop(V_form), crop(V_rd))
+spec_diff = agency.spectral_similarity(crop(V_form), crop(V_diff))
+pow_rd    = agency.structure(crop(V_rd))
+pow_diff  = agency.structure(crop(V_diff))
+seuil_energie = 0.1 * S_cible          # garde-fou : 10% de la structure de reference
+spec_rd_g   = agency.energy_gated_spectral_similarity(crop(V_form), crop(V_rd),   min_variance=seuil_energie)
+spec_diff_g = agency.energy_gated_spectral_similarity(crop(V_form), crop(V_diff), min_variance=seuil_energie)
+
+print(""Mesure naive 1 -- ressemblance PIXEL A PIXEL (plus petit = plus ressemblant) :"")
+print(f""   RD = {dist_pix_rd:.4f}   |   diffusion = {dist_pix_diff:.4f}"")
+print(""   -> la diffusion semble parfois 'plus proche' : PIEGE. Un attracteur mitotique ne"")
+print(""      revient jamais au pixel pres ; la RD a reconstruit un motif vivant, donc deplace."")
+print()
+print(""Mesure naive 2 -- similarite SPECTRALE cosinus (plus grand = texture plus proche) :"")
+print(f""   RD = {spec_rd:.3f}  (structure zone = {pow_rd:.5f})"")
+print(f""   diffusion = {spec_diff:.3f}  (structure zone = {pow_diff:.5f})"")
+print(""   -> un cosinus eleve sur une zone SANS structure (~0) est une ressemblance FANTOME :"")
+print(""      le cosinus ignore l'amplitude. Sans structure, il n'y a rien a 'ressembler'."")
+print()
+print(f""Garde-fou -- similarite spectrale PROTEGEE PAR L'ENERGIE (seuil = {seuil_energie:.5f}) :"")
+print(f""   RD = {spec_rd_g:.3f}   |   diffusion = {spec_diff_g:.3f}"")
+print(""   -> la zone diffusee tombe SOUS le seuil : la ressemblance fantome est annulee (0)."")
+print()
+print(f""Seule mesure fiable : structure restauree contrastee au controle passif -> GAIN = {gain:.2f}"")",,,,,,,,2661081bc86c5e39,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,0dc8a2b2,markdown,fr,3eff4acf88e80c0e,"## 6. Le controle « bruit apparie en variance » — la variance ne suffit pas
+
+La mesure de structure est la **variance spatiale** : simple et honnete pour dire « il y a de l'energie
+ici ». Mais l'energie n'est pas l'organisation. Un champ de **bruit blanc** peut avoir *exactement la
+meme variance* qu'un motif repare tout en n'ayant **aucune** structure spatiale.
+
+On construit donc un controle adverse : un bruit apparie en moyenne et variance a la zone reparee. S'il
+obtient le meme score de `structure`, c'est que la variance seule ne certifie pas une forme — il faut
+une mesure d'**organisation**. L'auto-correlation spatiale au decalage 1 (`spatial_autocorrelation`) joue
+ce role : proche de 1 pour un champ lisse et organise, proche de 0 pour du bruit. Elle confirme que la
+variance regagnee par la reaction-diffusion est une **vraie forme**, pas du bruit de meme energie.
+",,,,,,,,3eff4acf88e80c0e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,876d5d07,code,fr,65f5f1466ba663dd,"rng_ctrl = np.random.default_rng(GRAINE)
+zone_rd = crop(V_rd)                                       # la zone reparee par reaction-diffusion
+bruit   = agency.variance_matched_noise(zone_rd, rng_ctrl)  # meme moyenne/variance, aucune organisation
+
+s_rd,  s_bruit  = agency.structure(zone_rd), agency.structure(bruit)
+ac_rd, ac_bruit = agency.spatial_autocorrelation(zone_rd), agency.spatial_autocorrelation(bruit)
+
+fig, (a0, a1) = plt.subplots(1, 2, figsize=(11, 5))
+a0.imshow(zone_rd, cmap=""magma"", vmin=0, vmax=0.5)
+a0.set_title(f""zone reparee (RD)\nstructure={s_rd:.5f}  autocorr={ac_rd:.2f}""); a0.axis(""off"")
+a1.imshow(bruit, cmap=""magma"", vmin=0, vmax=0.5)
+a1.set_title(f""bruit apparie en variance\nstructure={s_bruit:.5f}  autocorr={ac_bruit:.2f}""); a1.axis(""off"")
+plt.suptitle(""Meme variance, organisation opposee : la variance seule ne certifie pas une forme"")
+plt.tight_layout(); plt.show()
+
+print(f""structure (variance)      : RD = {s_rd:.5f}  |  bruit apparie = {s_bruit:.5f}   (~ identiques)"")
+print(f""auto-correlation spatiale : RD = {ac_rd:.2f}     |  bruit apparie = {ac_bruit:.2f}      (le discriminant)"")
+print(""-> la variance regagnee par la RD est une VRAIE forme (voisins correles), pas du bruit de meme energie."")
+",,,,,,,,65f5f1466ba663dd,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,f1562b59,markdown,fr,93c302849eb2edbe,"### Exercice 3 — robustesse : la probabilite de retour au bassin
+
+Mesure plus exigeante : sur plusieurs ablations **aleatoires**, quelle fraction revient a la consigne ?
+Completez `proba_retour_bassin`. *Avertissement d'honnetete* : chaque essai est une simulation complete
+(c'est **couteux**) et le resultat est **stochastique** — a petit nombre d'essais, l'estimation a une
+forte variance. Documentez cette limite plutot que de sur-interpreter le chiffre.
+
+*Indices :* `agency.basin_return_probability(modele, U_form, V_form, make_mask, steps, target_structure, ...)` ;
+`make_mask(rng)` doit renvoyer un `agency.disk_mask(N, cx, cy, rayon)` de centre aleatoire.",,,,,,,,93c302849eb2edbe,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,7021945f,code,fr,e54a103e205ac74b,"def proba_retour_bassin(n_essais=5, rayon=14):
+    """"""Fraction d'ablations aleatoires (disques) dont la structure finale revient a la cible.
+    Renvoyer None tant que non complete.
+    ATTENTION : couteux (chaque essai = une simulation complete) et stochastique (forte variance
+    a petit n_essais) -- ne pas sur-interpreter une statistique a petit echantillon.""""""
+    # TODO etudiant :
+    # def make_mask(rng):
+    #     cx, cy = rng.integers(0, N, size=2)
+    #     return agency.disk_mask(N, cx, cy, rayon)
+    # return agency.basin_return_probability(
+    #     modele, U_form, V_form, make_mask,
+    #     steps=REPAIR_STEPS, target_structure=S_cible, tol=0.3,
+    #     n_trials=n_essais, rng=np.random.default_rng(GRAINE))
+    return None  # TODO
+
+# Verification (a decommenter -- patienter, c'est plusieurs simulations completes) :
+# print(""proba de retour au bassin :"", proba_retour_bassin(n_essais=5))
+print(""Exercice 3 a completer : robustesse de l'agence sous ablations aleatoires (mesure couteuse)."")",,,,,,,,e54a103e205ac74b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,ce4f22bc,markdown,fr,325db319bedbfe2b,"## 7. Au-dela du cas unique : un balayage de robustesse
+
+Une seule demonstration ne fait pas une loi. On repete donc la mesure d'agence sur un petit **balayage** :
+plusieurs graines (motifs differents), plusieurs **tailles** et **formes** d'ablation (quadrant, disques
+de rayons varies). Le balayage est volontairement **borne** (3 graines x 3 masques) pour rester dans un
+temps de calcul raisonnable — il vise a sortir du cas unique, pas a etre exhaustif. Le critere : le gain
+de reparation reste-t-il **positif** sur l'ensemble des conditions ?
+",,,,,,,,325db319bedbfe2b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,16b6c846,code,fr,ede20a0bb5335084,"FORM_S, REPAIR_S = 5000, 5000
+graines_sweep = [1, 7, 42]
+
+def masques_sweep(n):
+    return [(""quadrant"",   agency.quadrant_mask(n, 3)),
+            (""disque r12"",  agency.disk_mask(n, 0.70 * n, 0.30 * n, 12)),
+            (""disque r20"",  agency.disk_mask(n, 0.35 * n, 0.65 * n, 20))]
+
+lignes, gains = [], []
+for g in graines_sweep:
+    Ug, Vg = modele.seed(n=N, rng=np.random.default_rng(g))
+    Uf, Vf, _ = modele.run(Ug, Vg, steps=FORM_S)               # forme un motif (graine g)
+    for nom, m in masques_sweep(N):
+        Ua, Va = agency.ablate(Uf, Vf, m)                      # do(ablation)
+        _, V_rd_s, _ = modele.run(Ua.copy(), Va.copy(), steps=REPAIR_S)        # monde RD
+        V_diff_s = run_pure_diffusion(Va.copy(), modele.Dv, steps=REPAIR_S)    # monde diffusion
+        r_rd   = agency.recovery_score(Vf, Va, V_rd_s,   m)
+        r_diff = agency.recovery_score(Vf, Va, V_diff_s, m)
+        gn = agency.repair_gain(r_rd, r_diff)
+        lignes.append((g, nom, r_rd, r_diff, gn)); gains.append(gn)
+
+gains = np.array(gains)
+print(f""{'graine':>7} {'masque':>11} {'rec_RD':>8} {'rec_diff':>9} {'gain':>7}"")
+for (g, nom, r_rd, r_diff, gn) in lignes:
+    print(f""{g:>7} {nom:>11} {r_rd:>8.2f} {r_diff:>9.2f} {gn:>7.2f}"")
+n_pos = int((gains > 0).sum())
+print(f""\ngain de reparation : moyenne={gains.mean():.2f}  min={gains.min():.2f}  max={gains.max():.2f}"")
+print(f""positif sur {n_pos}/{len(gains)} conditions (graines x masques) -> l'agence n'est pas un artefact d'un cas unique."")
+
+fig, ax = plt.subplots(figsize=(9, 4))
+etq = [f""g{g}\n{nom.replace(' ', '')}"" for (g, nom, _, _, _) in lignes]
+ax.bar(range(len(gains)), gains, color=[""crimson"" if x > 0 else ""grey"" for x in gains])
+ax.axhline(0, color=""black"", lw=0.8)
+ax.set_xticks(range(len(gains))); ax.set_xticklabels(etq, fontsize=8)
+ax.set_ylabel(""gain de reparation"")
+ax.set_title(""Agence mesuree sur 3 graines x 3 masques : le gain reste positif"")
+plt.tight_layout(); plt.show()
+",,,,,,,,ede20a0bb5335084,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,7cdf821c,markdown,fr,7a92b32a569a1e96,"## 8. Pont vers la suite : ICT-10/11/12 et la synthese
+
+ICT-9 a ajoute la piece manquante du marche-pied : un **point de consigne intrinseque**, defendu
+activement. La feuille de route de la strate 2 poursuit, **chaque metaphore restant attachee a une
+mesure** :
+
+- **ICT-10 — Grammaire des catastrophes** : typer les transitions qualitatives (pli, fronce, fourche,
+  hysteresis) — la *catastrophe* comme **transition mesuree**, pas comme image.
+- **ICT-11 — Profils d'agence causale** : l'agence aux echelles micro / meso / macro (lien avec la
+  causal emergence d'[ICT-5](ICT-5-CausalEmergence.ipynb) / [ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb)).
+- **ICT-12 — Renormalisation causale & signatures fractales** : l'**invariance multi-echelle** des
+  proprietes causales — le *fractal* comme **invariance testee**, pas comme jolie image.
+- **ICT-Synthese** : reunir $\Phi$, trajectoires, bassins, transitions, reparation, emergence,
+  invariance d'echelle et agence en un seul fil.
+
+Discipline de la serie : *ne pas ouvrir cinq fronts a la fois* — une metaphore n'entre dans ICT que
+lorsqu'elle est **attachee a une mesure**.
+
+*Cette passe ICT-9.1 a consolide la base de mesure — similarite spectrale protegee par l'energie
+(section 5), controle « bruit apparie en variance » (section 6), balayage graines x tailles x formes
+(section 7) — avant d'etendre. Elle fige la grammaire commune* dynamique -> intervention do(.) ->
+controle passif -> recuperation -> profil multi-echelle -> test d'invariance *sur laquelle ICT-11
+(profils d'agence multi-echelle) et ICT-12 (renormalisation) s'appuieront.*",,,,,,,,7a92b32a569a1e96,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-9-AgencyRegeneration.ipynb,09e956b4,markdown,fr,5e53308222120858,"## Conclusion — l'agence tenue par la mesure
+
+On a tresse les deux fils jusqu'au bout :
+
+| Le fil metaphorique | Le fil de la mesure |
+|---|---|
+| un organisme « repare sa blessure » | la structure regionale (variance) regagnee apres ablation |
+| il « veut » retrouver sa forme | une consigne **intrinseque** : le motif qu'il engendre spontanement |
+| la guerison est *active* | gain = recuperation(reaction-diffusion) - recuperation(diffusion) > 0 |
+| « ca ressemble a avant » | **piege** : pixel-a-pixel et cosinus fabriquent l'illusion ; seule la structure+contraste tient |
+| deux destins possibles | deux mondes contrefactuels issus du meme `do(ablation)` (Pearl) |
+| « le cosinus dit que ca ressemble » | **garde-fou** : la similarite spectrale *protegee par l'energie* annule la ressemblance fantome |
+| « il y a de la variance, donc une forme » | **controle** : un bruit *apparie en variance* a le meme score ; l'auto-correlation tranche |
+| « un cas, donc une loi » | un **balayage** graines x tailles x formes : le gain reste positif hors du cas unique |
+
+**L'agence n'a pas ete declaree : elle a ete mesuree** — comme un *gain de recuperation* sur un controle
+passif, sur un vrai systeme de reaction-diffusion. C'est la traduction morphogenetique de la these de la
+serie : une competence (« maintenir sa propre forme ») n'est creditee qu'au vu de ce qu'une experience
+explicite, et contrastee, en montre. La strate 2 tient desormais son **point de consigne intrinseque** ;
+reste a en typer les transitions (ICT-10) et a en mesurer les echelles (ICT-11/12).",,,,,,,,5e53308222120858,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,55c513d8,markdown,fr,787b7401da97e4d1,"# ICT-Synthèse — un seul appareil de mesure, cinq substrats, une question falsifiable
+
+[← ICT-Series](README.md) | [↑ IIT](../README.md) | *Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588), capstone — voir [#4946](https://github.com/jsboige/CoursIA/issues/4946)*
+
+La série **ICT** (*Integrated Causal Trajectories*) a promené un même regard — la structure
+causale d'un système *le long de sa trajectoire* — sur des substrats de plus en plus riches :
+le tri auto-organisé (strate 1), les paysages d'attracteurs et la morphogenèse réaction-diffusion
+(strate 2), les agents et les stratégies (strate 3). À chaque étape, une capacité (robustesse,
+agence, émergence, anticipation, stabilité stratégique) n'a été **créditée** qu'après avoir
+**battu un contrôle dégénéré** — jamais déclarée. Et le même mot est revenu, notebook après
+notebook : **régime-dépendance**.
+
+Ce notebook de synthèse ne rejoue pas la série. Il **replie son fil** en une seule question
+falsifiable :
+
+> **Existe-t-il *un* scalaire d'intégration qui transfère d'un substrat à l'autre** — qui
+> classe le tri, le paysage bistable et le réplicateur stratégique dans le *même* ordre —
+> ou bien le seul invariant de la série est-il la **méthode** elle-même (créditer une
+> émergence uniquement contre son propre contrôle dégénéré) ?
+
+Le fil unificateur est un **appareil de mesure unique**, appliqué à l'identique aux trois
+substrats : depuis la trajectoire propre de chaque substrat, on estime une **matrice de
+transition état-à-état** (le pont tri → TPM d'[ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb),
+généralisé) ; puis on lui applique la **même batterie d'émergence causale**
+([ICT-5](ICT-5-CausalEmergence.ipynb)/[ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb),
+cadre *Causal Emergence 2.0* de Jansma & Hoel). C'est le seul instrument de toute la série
+branché **sans modification** sur des substrats radicalement différents.
+",,,,,,,,787b7401da97e4d1,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,08eebbfc,markdown,fr,ec618ccd2e860b90,"## 1. Le fil de la série — tableau récapitulatif
+
+Le cœur de ce capstone : une ligne par notebook, la **question centrale**, le **verdict
+réellement committé** (pas l'intuition de départ), et les **chiffres des gates** qui le
+soutiennent. On y lit deux constantes de la série — (a) une capacité n'est créditée qu'au
+**contraste** d'un contrôle dégénéré, et (b) le verdict est, de plus en plus, **régime-dépendant**
+(ICT-10 → ICT-13).
+
+| ICT-N | Question centrale | Verdict réel committé | Chiffres-clés des gates |
+|-------|-------------------|-----------------------|--------------------------|
+| **[ICT-0](ICT-0-Framing.md)** | De l'état (IIT) à la trajectoire : quel cadre ? | Cadre méthodologique : *mesurer ce que le modèle fait vraiment, pas ce qu'on espérait* ; deux strates ; contrôle dégénéré obligatoire | doc de cadrage (2 articles fondateurs : Levin ; Jansma & Hoel) |
+| **[ICT-1](ICT-1-PhiTrajectories.ipynb)** | $\Phi$ a-t-il un paysage, une trajectoire, une robustesse ? | OUI aux trois : $\Phi$ **pulse** le long de l'attracteur et se **répare** (vrai PyPhi) | AND/OR pic $\Phi$=2.31 vs 0.19 (amplitude 2.12) ; XOR plat 1.875 ; attracteur cycle longueur 3 |
+| **[ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb)** | Le tri est-il une morphogenèse à compétences ? | Robustesse + délai de gratification + auto-réparation OUI ; agrégation « kin » **NON** (impasses) → renvoi ICT-4 | tri homogène 315 pas / 68 swaps ; chimère sortedness 0.784, 4 impasses résiduelles |
+| **[ICT-3](ICT-3-RobustnessDelayedGratification.ipynb)** | Ces compétences se quantifient-elles ? | OUI : dégradation gracieuse, réparation **24/24**, délai ~90 épisodes | @50 % lésion passif 0.59–0.62 vs obstacle 0.53 ; délai bubble 91.4 / insertion 89.8 |
+| **[ICT-4](ICT-4-ChimericArraysKinAggregation.ipynb)** | Quel enrichissement minimal fait émerger l'agrégation « kin » ? | Réparation bidirectionnelle guérit l'impasse mais **n'agrège pas** ; l'agrégation émerge **seulement** dans les degrés de liberté laissés par le tri | copies=1 (liberté nulle) → agrégation kin ≈ 0 ; décolle dès copies ≥ 2 ; 40/40 → 0/40 non triés |
+| **[ICT-5](ICT-5-CausalEmergence.ipynb)** | L'émergence causale ($\Phi_\text{macro} > \Phi_\text{micro}$) est-elle réelle et systématique ? | **Discriminante**, pas systématique : absente sur des systèmes déjà micro-intégrés | Hoel 0.114 → 0.597 (**+0.483**) ; XOR **−1.375** ; basic\_network **−1.792** |
+| **[ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb)** | Peut-on porter l'émergence au tri au-delà de PyPhi (CE 2.0) ? | OUI ; le macro *intuitif* (niveau de tri) **échoue**, seul l'apportionnement glouton trouve l'échelle | micro EI 3.29 bits ; macro-tri gain **−0.034** (NON) ; glouton effectiveness 0.717 → 0.826 (**+0.109**) |
+| **[ICT-7](ICT-7-ScaleFreeSignatures.ipynb)** | Le tri auto-organisé est-il scale-free ? | **NON** : échelle caractéristique (la taille $n$, révélée par effondrement d'échelle) ; le scale-free est rare et réglé | branchement critique $\mu$=1 : $\alpha$=1.58, KS=0.017, $p$=0.625 ($\tau$=3/2) ; tri **rejeté** $p$-GoF=0.0 |
+| **[ICT-8](ICT-8-AttractorLandscapesEWS.ipynb)** | Les *early-warning signals* montent-ils **avant** la bascule ? | OUI (variance ↑, AR1 ↑) ; une mesure naïve **fabrique ou masque** le signal | $c_\text{fold}$≈2.604 ; stationnaire $\tau$=+1.00 ; AR1 brute 0.9987 (saturée) vs amincie 0.939 |
+| **[ICT-9](ICT-9-AgencyRegeneration.ipynb)** | Quand un système répare-t-il *sa propre* forme (agence) ? | Agence = **gain de réparation > 0** (réaction-diffusion vs diffusion pure) ; mesure naïve = signal fantôme | gain=1.22 ; cosinus spectral RD 0.631 **<** diffusion 0.735 (fantôme) ; sweep 9/9 positif (moy 1.26) |
+| **[ICT-10](ICT-10-CatastropheGrammar.ipynb)** | La grammaire des catastrophes est-elle mesurable ? $\hat p$ anticipe-t-il ? | OUI en régime non dégénéré ($a<0$) ; hors régime = **fantôme**. $\hat p$ : avantage **régime-dépendant** | comptage [1,3], 2 transitions ; lacet aire signée +1.633 ; $\hat p$ horizon-4 0.055 vs persistance 0.101 ; $a$=+0.5 → 0 saut |
+| **[ICT-11](ICT-11-CausalAgencyProfiles.ipynb)** | À quelle échelle l'agence est-elle la plus lisible ? | **Résultat négatif robuste** : pas de granularité privilégiée | 2 mesures se contredisent ; effectiveness↔repair\_gain $r$=+0.50 mais ↔basin\_return $r$=−0.14 ; effectiveness sans sommet (0.71/0.50/0.79/0.63) |
+| **[ICT-12](ICT-12-ValenceFieldsAndAnimats.ipynb)** | Dans quels environnements le modèle interne $\hat p$ paie-t-il son coût ? | **Régime-dépendant** : $\hat p$ paie **où la source échappe au réactif ET reste prévisible** | balistique rapide capture $\hat p$ 0.072 vs réactif 0.018 ; anticipation $\hat p$ 2.44 vs persistance 14.95 (balist.) mais **perd** en bruité (0.62 vs 0.23) |
+| **[ICT-13](ICT-13-AxelrodStrategicMorphodynamics.ipynb)** | Une stratégie est-elle une forme stable ? | Stable **seulement dans un paysage donné** ; TFT gagne sans bruit mais s'effondre ; correction honnête : **grim** chute le moins | sans bruit TFT/grim 2.635, AllD 2.313 ; $\delta^*$=0.5 (num. 0.55) ; chute sous bruit TFT +0.399 vs grim +0.287 ; invasion TFT/grim 0.02, pavlov/allc jamais (1.0) |
+
+**Ce que le tableau donne à voir.** La série ne consacre presque **rien** sans réserve : à chaque
+ligne, un « OUI » s'accompagne d'un « mais » chiffré, et le dernier tiers (ICT-10 → 13) répète
+le même mot — *régime-dépendant*. La question du capstone est de savoir si cette répétition
+cache un **scalaire commun** transférable, ou si elle **est** le résultat.
+",,,,,,,,ec618ccd2e860b90,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,79b7556a,markdown,fr,ea403f09c290f569,"## 2. Le fil unificateur : un seul appareil, trois substrats
+
+Chaque substrat produit une **trajectoire** d'états. On la discrétise **grossièrement** (un choix
+documenté, propre à chaque substrat — pas une constante cachée), on estime une **TPM état-à-état**
+(`ict.tpm_estimation`, le pont d'ICT-6), puis on applique la **même** batterie d'émergence causale
+(`ict.causal_emergence`) via le module de synthèse `ict.synthesis` livré en amont (#4948) :
+
+- **information effective** (EI, bits) et **effectiveness** (déterminisme − dégénérescence, sans échelle) ;
+- **complexité émergente** (EC) le long du chemin d'échelles glouton (`greedy_apportionment`).
+
+**Le contrôle *sans complaisance*.** Pour chaque substrat, on compare la mesure réelle à un
+**contrôle dégénéré** : la trajectoire dont on a **permuté l'ordre temporel** (`shuffle_states`),
+ce qui conserve *exactement* le multi-ensemble d'états visités mais **détruit la dynamique**. Une
+émergence n'est **créditée** que si elle dépasse ce contrôle — sinon, elle n'est qu'un artefact du
+réservoir d'états (des degrés de liberté), pas de l'ordre. C'est la discipline d'ICT-8/9/11
+généralisée à trois substrats à la fois.
+
+> **Runtime borné (choix assumé).** Le chemin d'échelles de `greedy_apportionment` explore toutes
+> les paires d'états à chaque pas (coût ~$O(k^2)$ par échelle, $k$ = nombre d'états distincts).
+> On garde donc une **discrétisation grossière** (≈ 6–12 états par substrat) et des trajectoires
+> **sous-échantillonnées** : l'exécution complète tient en **moins de deux minutes** tout en
+> laissant chaque gate discriminant. Une discrétisation fine (ex. `tuple(config)` brut du tri)
+> ferait exploser $k$ sans rien ajouter au verdict.
+",,,,,,,,ea403f09c290f569,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,839b291b,code,fr,c4840784c620b497,"import sys, os
+sys.path.insert(0, os.getcwd())
+
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+%matplotlib inline
+
+from ict import synthesis as S
+from ict import sorting_metrics as sm
+from ict.self_sorting import SelfSortingArray
+from ict.bistable import GrazingModel
+from ict import strategic_morphodynamics as SM
+from ict import time_arrow as ta
+from ict import stake
+from ict import agency
+
+# --- parametres bornes (voir la note ""Runtime borne"" ci-dessus) ---
+N_SHUF = 100            # controle degenere pour les gates 1-2 (une graine)
+N_SHUF_SEED = 30        # controle par graine pour le gate 3 (multi-graines)
+SEEDS = (0, 1, 7, 42, 99)   # graines du gate 3 (regime = alea de generation)
+SEED0 = SEEDS[0]        # graine representative des gates 1-2
+
+
+def traj_S1(seed, n_runs=6, max_steps=1500):
+    """"""S1 - tri auto-organise : etat = nombre d'inversions (coarse, ICT-2/6).""""""
+    states = []
+    for r in range(n_runs):
+        rng = np.random.default_rng(seed + r)
+        arr = SelfSortingArray(list(rng.permutation(6)), seed=seed + r)
+        arr.run(max_steps=max_steps, record=True)
+        states.extend(sm.inversion_count(c) for c in arr.probe.values)
+    return states
+
+
+def traj_S2(seed, T=1500):
+    """"""S2 - paysage bistable (modele de paturage de May, ICT-8) : SDE pres du pli,
+    etat = decile du scalaire de biomasse.""""""
+    gm = GrazingModel()
+    c = 0.92 * gm.find_fold()          # sous le pli : deux etats stables coexistent
+    xs = gm.simulate_sde(c=c, x0=8.0, sigma=0.55, dt=0.02, T=T, seed=seed)
+    lo, hi = np.percentile(xs, 1), np.percentile(xs, 99)
+    bins = np.linspace(lo, hi, 11)     # 10 deciles -> ~11 etats
+    return [int(v) for v in np.clip(np.digitize(xs, bins), 0, 10)]
+
+
+def traj_S3(seed, n_runs=10, n_steps=300):
+    """"""S3 - replicateur strategique (IPD/Axelrod, ICT-13) : etat = strategie dominante.""""""
+    rng = np.random.default_rng(seed)
+    strat = SM.make_strategies(rng)
+    A = SM.payoff_matrix(strat, rng=rng)
+    states = []
+    for _ in range(n_runs):
+        x0 = rng.dirichlet(np.ones(len(strat)))
+        traj = SM.replicator_trajectory(A, x0, n_steps=n_steps)
+        states.extend(int(np.argmax(row)) for row in traj)
+    return states
+
+
+
+
+# --- substrat S4 : activations SAE d'un LLM (strate 5, ICT-21/22) ---
+# Etats discrets binarises lus depuis la trace GPU-extraite (cache .npz, zero GPU ici).
+# Panel K=4 features (ICT-22 Gate 13) ; ""seed"" indexe le jeu de prompts pour la reproductibilite.
+NPZ_TRAINED = ""traces/ict21_sae_layer16_trained.npz""   # Qwen3.5-9B layer 16, k=50
+PANEL_S4 = [65025, 19350, 5437, 24514]                  # ICT-22 panel (K=4)
+PROMPT_SETS = [""code_python"", ""dialogue"", ""math"", ""narrative_en"", ""prose_fr""]
+
+
+def traj_S4(seed, sets=None):
+    """"""S4 - substrat LLM : etats discrets binarises des activations SAE (ICT-21/22).
+
+    Par defaut (sets=None) on concatene un seul jeu choisi par la graine ; passer
+    sets=PROMPT_SETS pour pooler les 5 jeux en une longue trajectoire (style ICT-22 Gate 13).
+    """"""
+    chosen = [PROMPT_SETS[seed % len(PROMPT_SETS)]] if sets is None else sets
+    return S.sae_substrate_states(NPZ_TRAINED, PANEL_S4, sets=chosen, q=0.5)
+
+print(""Appareil de mesure unique : trajectoire -> TPM etat-a-etat -> batterie d'emergence causale."")
+print(f""Controle degenere : permutation temporelle (marginales d'etats conservees, dynamique detruite)."")
+print(f""Graines gate 3 : {SEEDS} | n_shuffles gates 1-2 = {N_SHUF}, gate 3 = {N_SHUF_SEED}"")",,,,,,,,c4840784c620b497,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,199e26fd,markdown,fr,58902fb68cc0b81f,"## 3. Trois substrats, trois strates
+
+On instancie les trois trajectoires avec la graine représentative `SEED0`. Chacune vient d'une
+**strate différente** de la série et n'a, *a priori*, rien à voir avec les autres.
+",,,,,,,,58902fb68cc0b81f,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,ac4cdea3,markdown,fr,a305ff39fec9e86d,"### S1 — le tri auto-organisé (strate 1)
+
+Le banc d'entrée de la série ([ICT-2](ICT-2-SelfSortingMorphogenesis.ipynb)/[ICT-6](ICT-6-SortingToTPM-CausalEmergence.ipynb)) :
+plusieurs tris distribués, résumés par leur **nombre d'inversions** à chaque pas (macro-état
+grossier, borné par $n(n-1)/2$).
+",,,,,,,,a305ff39fec9e86d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,0456af6e,code,fr,581be4af90de1d90,"s1 = traj_S1(SEED0)
+print(f""S1 (tri)          longueur={len(s1):5d}  etats distincts={len(set(s1)):3d}  ""
+      f""(min={min(s1)}, max={max(s1)})"")",,,,,,,,581be4af90de1d90,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,7070c73b,markdown,fr,a8df1c4ffb72e66a,"### S2 — le paysage bistable (strate 2)
+
+Le modèle de pâturage de May ([ICT-8](ICT-8-AttractorLandscapesEWS.ipynb)), simulé en **SDE juste
+sous le pli** ($c = 0.92\,c_\text{fold}$) : deux bassins coexistent et le bruit provoque des
+bascules occasionnelles. L'état est le **décile** de la biomasse.
+",,,,,,,,a8df1c4ffb72e66a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,cde2cec9,code,fr,969a99683f1da620,"s2 = traj_S2(SEED0)
+print(f""S2 (bistable)     longueur={len(s2):5d}  etats distincts={len(set(s2)):3d}  ""
+      f""(deciles occupes)"")",,,,,,,,969a99683f1da620,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,7a32caab,markdown,fr,158acea9605981dc,"### S3 — le réplicateur stratégique (strate 3)
+
+Le dilemme du prisonnier itéré sous dynamique de réplicateur ([ICT-13](ICT-13-AxelrodStrategicMorphodynamics.ipynb)) :
+plusieurs trajectoires depuis des populations initiales aléatoires, résumées par la **stratégie
+dominante** (argmax des fréquences) à chaque pas.
+",,,,,,,,158acea9605981dc,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,22d84be9,code,fr,05d8fdf21508abdf,"s3 = traj_S3(SEED0)
+print(f""S3 (replicateur)  longueur={len(s3):5d}  etats distincts={len(set(s3)):3d}  ""
+      f""(strategies dominantes)"")",,,,,,,,05d8fdf21508abdf,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,c279b797,markdown,fr,04640d4f44650e61,"## 4. Le même appareil appliqué aux trois — batterie + contrôle dégénéré
+
+On calcule, pour chaque substrat, la batterie **réelle** (`trajectory_battery`) et le
+**contrôle dégénéré** moyenné sur `N_SHUF` permutations temporelles (`shuffled_baseline`).
+Le gain d'émergence est la différence réel − contrôle ; il est **crédité** si le gain d'EC
+dépasse l'écart-type du contrôle.
+",,,,,,,,04640d4f44650e61,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,42974492,code,fr,f392f37f08899719,"subs = {""S1_tri"": s1, ""S2_bistable"": s2, ""S3_replicateur"": s3}
+rng = np.random.default_rng(2025)
+
+detail = {}
+for name, st in subs.items():
+    real = S.trajectory_battery(st)
+    base = S.shuffled_baseline(st, rng, n_shuffles=N_SHUF)
+    detail[name] = {""real"": real, ""base"": base}
+
+print(f""{'substrat':16s} {'n_etats':>7s} {'EI_reel':>8s} {'EI_shuf':>8s} ""
+      f""{'EC_reel':>8s} {'EC_shuf':>8s} {'EC_std':>7s}"")
+print(""-"" * 72)
+for name, d in detail.items():
+    r, b = d[""real""], d[""base""]
+    print(f""{name:16s} {r['n_states']:7d} {r['effective_information']:8.3f} ""
+          f""{b['effective_information']:8.3f} {r['emergent_complexity']:8.3f} ""
+          f""{b['emergent_complexity']:8.3f} {b['emergent_complexity_std']:7.3f}"")",,,,,,,,f392f37f08899719,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,bf291279,markdown,fr,0359c2470f28aece,"## 5. Gate 1 — l'émergence survit-elle au contrôle dégénéré ?
+
+**Critère falsifiable.** Pour chaque substrat, on crédite une émergence dynamique si le gain de
+complexité émergente dépasse le bruit du contrôle : $z = (\text{EC}_\text{réel} -
+\text{EC}_\text{shuffle}) / \sigma_\text{shuffle} > 1$. Si aucun substrat ne passe, l'appareil ne
+mesure que du réservoir d'états — pas de la dynamique.
+",,,,,,,,0359c2470f28aece,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,354278c6,code,fr,94989b30656269fa,"summary = {}
+print(f""{'substrat':16s} {'EI_gain':>8s} {'EC_gain':>8s} {'z(EC)':>7s}  credite"")
+print(""-"" * 56)
+for name, d in detail.items():
+    r, b = d[""real""], d[""base""]
+    ei_gain = r[""effective_information""] - b[""effective_information""]
+    ec_gain = r[""emergent_complexity""] - b[""emergent_complexity""]
+    ec_std = b[""emergent_complexity_std""]
+    z = ec_gain / ec_std if ec_std > 1e-12 else float(""inf"")
+    credited = z > 1.0
+    summary[name] = {""ei_real"": r[""effective_information""],
+                     ""ec_real"": r[""emergent_complexity""],
+                     ""ei_gain"": ei_gain, ""ec_gain"": ec_gain,
+                     ""z"": z, ""credited"": credited}
+    print(f""{name:16s} {ei_gain:+8.3f} {ec_gain:+8.3f} {z:7.2f}  {credited}"")
+
+n_credited = sum(v[""credited""] for v in summary.values())
+print(f""\nGate 1 : {n_credited}/3 substrats creditent une emergence dynamique (z > 1)."")
+
+# --- figure : reel vs controle degenere (information effective) ---
+names = list(subs)
+x = np.arange(len(names))
+fig, ax = plt.subplots(figsize=(7, 3.4))
+ax.bar(x - 0.2, [detail[n][""real""][""effective_information""] for n in names], 0.4,
+       label=""reel"", color=""#2c7fb8"")
+ax.bar(x + 0.2, [detail[n][""base""][""effective_information""] for n in names], 0.4,
+       label=""controle degenere (shuffle)"", color=""#c0c0c0"")
+ax.set_xticks(x); ax.set_xticklabels(names); ax.set_ylabel(""information effective (bits)"")
+ax.set_title(""Gate 1 - la dynamique bat-elle son controle degenere ?""); ax.legend()
+plt.tight_layout(); plt.show()",,,,,,,,94989b30656269fa,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,eca15c13,markdown,fr,d68c6a686421342d,"### Lecture du gate 1
+
+**L'appareil mesure de la dynamique, pas du réservoir.** À la graine représentative, les **trois**
+substrats créditent une émergence dynamique ($z > 1$) : S1 $z$=1.86 (gain d'EC +4.05), S2 $z$=1.24
+(+1.02), S3 $z$=2.66 (+2.07). Autrement dit, l'ordre temporel réel bat son contrôle dégénéré dans
+chaque cas — l'instrument capte bien la **dynamique**, pas seulement la taille du multi-ensemble
+d'états. Premier indice cependant : les gains d'EC sont **très inégaux** (S1 ≫ S3 > S2) alors que
+l'information effective, elle, place S2 en tête. « Combien d'émergence » et « combien d'intégration »
+ne classent déjà pas les substrats pareil — ce que le gate 2 va trancher.
+",,,,,,,,d68c6a686421342d,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,f7641c4b,markdown,fr,094617a7b74b705e,"## 6. Gate 2 — un scalaire d'intégration transfère-t-il ? (une graine)
+
+**Critère falsifiable.** Si un « scalaire d'intégration » gouvernait les trois substrats, ils
+seraient **classés dans le même ordre** par l'information effective réelle (`ei_real`) et par le
+gain d'émergence crédité (`ec_gain`). On mesure la concordance de rangs (**$\tau$ de Kendall**) :
+`consistent` = vrai seulement si $\tau \approx +1$. Un $\tau < 1$ falsifie l'existence d'un scalaire
+transférable — dès une seule graine.
+",,,,,,,,094617a7b74b705e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,0c4fba13,code,fr,450c7d35da4f7883,"rc = S.rank_consistency(summary, ""ei_real"", ""ec_gain"")
+print(""Classement par EI reelle  :"", rc[""order_by_ei_real""])
+print(""Classement par gain d'EC   :"", rc[""order_by_ec_gain""])
+print(f""tau de Kendall (EI vs EC_gain) = {rc['kendall_tau']:+.3f}  ->  consistent = {rc['consistent']}"")
+
+# second couple de mesures, pour montrer que le desaccord n'est pas un artefact du choix
+rc2 = S.rank_consistency(summary, ""ei_real"", ""ec_real"")
+print(f""tau de Kendall (EI vs EC_reel) = {rc2['kendall_tau']:+.3f}  ->  consistent = {rc2['consistent']}"")
+
+fig, ax = plt.subplots(figsize=(7, 3.0))
+metrics = {""EI reelle"": [summary[n][""ei_real""] for n in names],
+           ""gain d'EC"": [summary[n][""ec_gain""] for n in names]}
+w = 0.38
+for i, (lab, vals) in enumerate(metrics.items()):
+    v = np.array(vals); v = v / (np.abs(v).max() + 1e-12)   # normalise pour comparer les rangs
+    ax.bar(x + (i - 0.5) * w, v, w, label=lab)
+ax.set_xticks(x); ax.set_xticklabels(names)
+ax.set_ylabel(""mesure (normalisee)""); ax.set_title(""Gate 2 - deux mesures, deux classements ?"")
+ax.legend(); plt.tight_layout(); plt.show()",,,,,,,,450c7d35da4f7883,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,79fb8093,markdown,fr,fce951dca87f9247,"### Lecture du gate 2
+
+**Le scalaire transférable est un mirage de magnitude.** Deux mesures *brutes* — information
+effective réelle et complexité émergente réelle — classent les trois substrats à l'**identique**
+($\tau$ = +1.00) : de quoi croire à un « scalaire d'intégration » commun. Mais dès qu'on classe par
+le **gain crédité** contre le contrôle dégénéré (`ec_gain`), l'ordre **s'inverse** ($\tau$ = −0.33,
+`consistent = False`) : S2 domine en EI réelle mais **tombe dernier** en gain crédité, tandis que S1
+mène par le gain mais reste au milieu en EI. La concordance parfaite était donc un artefact de
+**magnitude** (des systèmes plus grands ont mécaniquement plus d'EI et d'EC bruts) ; ce qui **survit**
+au contrôle *sans complaisance* — la seule quantité que toute la série accepte de créditer — **ne
+transfère pas**. L'hypothèse du scalaire unique est falsifiée dès une seule graine.
+",,,,,,,,fce951dca87f9247,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,ac8b8d10,markdown,fr,2fa100815eb53963,"## 7. Gate 3 — la créditation est-elle robuste au régime ? (multi-graines)
+
+**Critère falsifiable.** On répète toute la chaîne sur `SEEDS` graines (chaque graine = un
+*régime* d'aléa de génération). Pour chacune : l'ensemble **crédité** et la concordance de rangs
+$\tau$. Si un scalaire transférait vraiment, `consistent` serait **stablement vrai** et l'ensemble
+crédité **stable**. S'ils **varient** d'une graine à l'autre, alors non seulement aucun scalaire ne
+transfère, mais la **créditation elle-même est régime-dépendante** — l'écho, un cran plus haut, du
+fil ICT-10 → ICT-13.
+",,,,,,,,2fa100815eb53963,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,17a52472,code,fr,af86468866f4d83e,"rows = []
+for seed in SEEDS:
+    ss = {""S1_tri"": traj_S1(seed), ""S2_bistable"": traj_S2(seed), ""S3_replicateur"": traj_S3(seed)}
+    r = np.random.default_rng(1000 + seed)
+    summ = S.cross_substrate_summary(ss, r, n_shuffles=N_SHUF_SEED)
+    rcx = S.rank_consistency(summ, ""ei_real"", ""ec_gain"")
+    credited = tuple(sorted(k for k, v in summ.items() if v[""credited""]))
+    rows.append({""seed"": seed, ""tau"": rcx[""kendall_tau""],
+                 ""consistent"": rcx[""consistent""], ""credited"": credited})
+
+print(f""{'graine':>6s} {'tau':>6s} {'consistent':>11s}  ensemble credite"")
+print(""-"" * 60)
+for row in rows:
+    print(f""{row['seed']:6d} {row['tau']:+6.2f} {str(row['consistent']):>11s}  ""
+          f""{{{', '.join(row['credited']) if row['credited'] else '(aucun)'}}}"")
+
+taus = [row[""tau""] for row in rows]
+n_consistent = sum(row[""consistent""] for row in rows)
+credited_sets = {row[""credited""] for row in rows}
+print(f""\ntau observes : {sorted(set(round(t, 2) for t in taus))}"")
+print(f""consistent = vrai sur {n_consistent}/{len(rows)} graines"")
+print(f""nombre d'ensembles credites distincts : {len(credited_sets)}"")
+
+fig, ax = plt.subplots(figsize=(7, 3.0))
+ax.axhline(1.0, color=""#2ca25f"", ls=""--"", lw=1, label=""tau=+1 (transfert parfait)"")
+ax.axhline(0.0, color=""#999999"", ls="":"", lw=1)
+ax.plot(range(len(SEEDS)), taus, ""o-"", color=""#de2d26"", label=""tau (EI vs gain d'EC)"")
+ax.set_xticks(range(len(SEEDS))); ax.set_xticklabels([str(s) for s in SEEDS])
+ax.set_xlabel(""graine (regime)""); ax.set_ylabel(""tau de Kendall""); ax.set_ylim(-1.15, 1.15)
+ax.set_title(""Gate 3 - le transfert est-il stable d'un regime a l'autre ?""); ax.legend()
+plt.tight_layout(); plt.show()",,,,,,,,af86468866f4d83e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,d88bb2e9,markdown,fr,0d5d4aed26405b38,"### Lecture du gate 3
+
+**Non seulement rien ne transfère, mais la créditation elle-même est régime-dépendante.** Sur cinq
+graines (cinq régimes d'aléa), `consistent` n'est vrai que **1 fois sur 5** — et cette unique
+« cohérence » (graine 42) est **dégénérée** : elle ne crédite que S2, si bien qu'un classement à un
+seul élément est trivialement « cohérent ». L'**ensemble crédité varie** d'une graine à l'autre —
+trois ensembles distincts : les trois substrats (graine 0), {S2, S3} (graines 1, 7, 99), {S2} seul
+(graine 42) — et $\tau$ oscille dans {−0.33, +0.33, +1.0}. Concrètement : **S2 (bistable) est crédité
+partout (5/5)**, S3 (réplicateur) presque partout (4/5), **S1 (tri) une seule fois (1/5)**. La question
+« quels substrats émergent ? » n'a donc pas de réponse absolue — elle dépend du régime. C'est
+*exactement* le motif que la série a rencontré **à l'intérieur** de chaque substrat — ICT-10 ($\hat p$
+utile en régime $a<0$ seulement), ICT-11 (aucune granularité privilégiée), ICT-12 ($\hat p$ ne paie
+que dans certains environnements), ICT-13 (stratégie stable dans un paysage donné seulement) —
+reproduit ici **un cran plus haut**, entre substrats.
+",,,,,,,,0d5d4aed26405b38,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,925993cd,markdown,fr,15d6950cc85d79de,"## 8. Gate 4 — la convergence Φ/F/K survit-elle à un quatrième substrat ? (capstone strate 5)
+
+Les gates 1 à 3 ne créditaient l'émergence que sur **un** scalaire, l'information effective (EI → EC gain, leg Φ). Le capstone de la strate 4 (ICT-15) avait ajouté deux jambes — la surprise transitionnelle **F** et la compressibilité **K** — et posé la question de leur convergence. Ici, nous la rejouons en intégrant un **quatrième substrat** : les activations d'un LLM (Qwen3.5-9B, couche 16, projetées par une SAE). L'appareil `emergence_gain` retourne les trois jambes en un appel, sous le **même contrôle dégénéré** (permutation temporelle) — condition pour que le τ de Kendall soit interprétable.
+
+> **Nommage des substrats.** Le banc nomme ses substrats par leur nature, pas par un index : **tri auto-organisé** (ICT-2), **bistable / modèle de pâturage de May** (ICT-8), **réplicateur d'Axelrod** (ICT-13), **LLM-SAE** = activations SAE d'un Qwen3.5-9B couche 16 (ICT-21/22). Le cinquième, le **champ Gray-Scott** (ICT-9/18/19), est un champ réaction-diffusion *continu* traité à part (gate 6). ⚠ Surcharge terminologique : l'index « S4 » désigne le substrat **LLM** ici et dans ICT-21/22, mais le Gray-Scott dans ICT-18/19 — d'où le choix de nommer par nature pour lever l'ambiguïté.
+",,,,,,,,15d6950cc85d79de,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,16f26414,code,fr,8fe691468f7e4711,"# Gate 4 : convergence Phi/F/K sur 4 substrats discrets (lift ICT-22 Gate 13)
+s4 = traj_S4(SEED0, sets=PROMPT_SETS)            # substrat LLM : 5 jeux poolles
+subs_4 = {""S1_tri"": s1, ""S2_bistable"": s2, ""S3_replicateur"": s3, ""S4_LLM"": s4}
+
+print(f""{'substrat':16s} {'etats':>5s} {'Phi(ec)':>9s} {'F(fe)':>8s} {'K(k)':>7s}"")
+print(""-"" * 52)
+gains_table = {}
+for name, st in subs_4.items():
+    g = S.emergence_gain(st, np.random.default_rng(2025), n_shuffles=N_SHUF)
+    gains_table[name] = g
+    print(f""{name:16s} {g['n_states']:5d} {g['ec_gain']:+9.3f} {g['fe_gain']:+8.3f} {g['k_gain']:+7.3f}"")
+
+# tau de Kendall par paire : un scalaire ordonne-t-il les 4 substrats comme un autre ?
+print(""\n--- Gate 4 : convergence (tau de Kendall par paire) ---"")
+for ka, kb in [(""ec_gain"", ""fe_gain""), (""ec_gain"", ""k_gain""), (""fe_gain"", ""k_gain"")]:
+    rc = S.rank_consistency(gains_table, ka, kb)
+    tag = ""CONSISTENT"" if rc[""consistent""] else ""divergent""
+    print(f""  tau({ka:>8s} vs {kb:<8s}) = {rc['kendall_tau']:+.3f}  ->  {tag}"")
+
+fig, ax = plt.subplots(figsize=(7.5, 3.6))
+x = np.arange(len(names4 := list(subs_4))); w = 0.26
+ax.bar(x - w, [gains_table[n][""ec_gain""] for n in names4], w, label=r""$\Phi$ (ec_gain)"", color=""#2c7fb8"")
+ax.bar(x,     [gains_table[n][""fe_gain""] for n in names4], w, label=r""F (fe_gain)"", color=""#e6550d"")
+ax.bar(x + w, [gains_table[n][""k_gain""]  for n in names4], w, label=r""K (k_gain)"", color=""#31a354"")
+ax.axhline(0, color=""#555"", lw=0.8); ax.set_xticks(x); ax.set_xticklabels(names4)
+ax.set_ylabel(""gain reel vs controle degenere"")
+ax.set_title(r""Gate 4 — convergence $\Phi$/F/K sur 4 substrats"")
+ax.legend(loc=""upper right"", fontsize=9); plt.tight_layout(); plt.show()",,,,,,,,8fe691468f7e4711,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,fa1bdd81,markdown,fr,1c80a441bd43abd7,"### Lecture du gate 4
+
+Les trois jambes covarient **partiellement**. Les barres Φ (bleu) et F (orange) suivent le **même ordre** — tri > réplicateur > bistable > LLM — d'où un τ de Kendall Φ↔F = +1.00 (transfert parfait). Mais **K** (vert) ordonne autrement (réplicateur et bistable au-dessus du tri) : Φ↔K et F↔K divergent (τ ≈ +0.33). Le LLM, quatrième substrat, est systématiquement le **plus faible** sur les trois jambes — ses activations SAE, bien que réelles, ne structurent pas la trajectoire au point de battre largement un contrôle dégénéré. **Verdict** : aucun triplet de scalaires ne converge vers un invariant unique ; la *convergence apparente* Φ↔F tient à ce que ces deux jambes mesurent une même chose (la structure causale de la trajectoire), et K la mesure autrement. Le quatrième substrat **renforce** le verdict d'ICT-22 : ce n'est pas un scalaire qui transfère, c'est la *méthode*.",,,,,,,,1c80a441bd43abd7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,8bf531eb,markdown,fr,a3284f95f4a0cf40,"## 9. Gate 5 — l'irréversibilité, jambe temporelle de l'émergence (ICT-18)
+
+Une trajectoire émergente produit-elle de l'entropie, c'est-à-dire est-elle temporellement asymétrique ? ICT-18 a construit cet appareil : estimer la matrice de transition, mesurer sa production d'entropie σ (l'écart à l'équilibre détaillé), et la distance entre la chaîne réelle et sa projection *réversibilisée* (la chaîne la plus proche qui satisfait le bilan détaillé). Un substrat réversible (σ ≈ 0, dist ≈ 0) ne « dégrade » pas l'information ; un substrat irréversible, si.",,,,,,,,a3284f95f4a0cf40,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,31c44743,code,fr,0f8a03126ec1a4b7,"# Gate 5 : reversibilisation (time_arrow) par substrate
+print(f""{'substrat':16s} {'sigma_real':>11s} {'dist(reel,rev)':>15s}"")
+print(""-"" * 46)
+rev_table = {}
+for name, st in subs_4.items():
+    rev = ta.compare_real_reversed_reversibilized(st)
+    rev_table[name] = rev
+    print(f""{name:16s} {rev['sigma_real']:11.4f} {rev['dist_real_vs_reversibilized']:15.4f}"")
+
+fig, ax = plt.subplots(figsize=(7.5, 3.4))
+sig = [rev_table[n][""sigma_real""] for n in names4]
+dist = [rev_table[n][""dist_real_vs_reversibilized""] for n in names4]
+x = np.arange(len(names4)); w = 0.38
+ax.bar(x - w/2, sig, w, label=r""$\sigma_{real}$ (production d'entropie)"", color=""#756bb1"")
+ax.bar(x + w/2, dist, w, label=""dist(reel, reversibilise)"", color=""#99d8c9"")
+ax.set_xticks(x); ax.set_xticklabels(names4); ax.set_yscale(""symlog"", linthresh=1e-3)
+ax.set_ylabel(""asymetrie temporelle (echelle symlog)"")
+ax.set_title(""Gate 5 — reversibilisation : tri irreversibles, bistable reversible"")
+ax.legend(loc=""upper right"", fontsize=9); plt.tight_layout(); plt.show()",,,,,,,,0f8a03126ec1a4b7,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,34a158b8,markdown,fr,05f1b1049003a464,"### Lecture du gate 5
+
+L'asymétrie temporelle **discrimine** fortement les substrats, à l'inverse des scalaires Φ/F/K. Le **tri** (S1) domine très largement (σ ≈ 5.66, échelle symlog) — c'est attendu : un tri est *directionnel*, il court vers l'ordre, il n'est pas symétrique sous renversement du temps. Le **bistable** (S2) est quasi-nul (σ ≈ 0) : son SDE de pâturage, près du pli, satisfait approximativement le bilan détaillé — il est temporellement réversible. Le réplicateur et le LLM restent faibles. Leçon : la **jambe temporelle** de l'émergence est orthogonale à la jambe causale — un substrat peut être fortement émergent (Φ élevé) et faiblement irréversible (bistable), ou inversement. Aucun substrat ne maximise tout à la fois.",,,,,,,,05f1b1049003a464,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,8d956678,markdown,fr,32ee0ce4aa0bdd8b,"## 10. Gate 6 — l'ENJEU et la frontière de l'agence (ICT-19)
+
+La strate 5 a introduit une cinquième jambe : **l'ENJEU** (*stake*) — un système émerge-t-il comme agent au sens où, après une perturbation (`do`), il *revient* de lui-même à son attracteur plutôt que de dériver ? ICT-19 a d'abord tenté un scalaire `stake_index` sur les états discrets. Il **échoue** sur le substrat champ (Gray-Scott) — et c'est l'enseignement méthodologique le plus important de la strate 5 : *quand un instrument échoue sur un substrat, on change d'instrument, pas de conclusion*. ICT-19-Raffinement a donc basculé vers une mesure en **espace de champ**, `repair_gain`, qui compare la réparation après ablation (réaction-diffusion réelle) à la pure diffusion.",,,,,,,,32ee0ce4aa0bdd8b,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,478a0ef8,code,fr,0bcdd79d2b1c86ef,"# Gate 6 : frontiere de l'instrument ENJEU (scalaire sur discrets vs champ sur Gray-Scott)
+# Demo ICT-19 : le scalaire stake_index discrimine restoring vs drift (controle).
+i_rest, i_drift = stake.demo_contrast(steps=50, seed=42)
+print(f""demo_contrast (controle) : I_stake(restoring) = {i_rest:+.4f}"")
+print(f""                            I_stake(drift)      = {i_drift:+.4f}"")
+print(f""                            delta               = {i_rest - i_drift:+.4f}"")
+print()
+print(""Le scalaire stake_index CREDITE les attracteurs discrets (S1/S2/S3) :"")
+print(""  S1 tri = +1.00 | S2 bistable = +1.00 | S3 replicateur (coop) = +0.68  (cf ICT-19)"")
+print()
+print(""MAIS il ECCHOUE sur le substrat champ Gray-Scott (I_stake = -0.51 = sous le drift)."")
+print(""ICT-19-Raffinement a donc change d'instrument pour le champ :"")
+print(""  agency.repair_gain (Gray-Scott, 5 ablations) = +0.82 +- 0.27   <-- REPARATION ACTIVE"")
+print(""  (controle : pure diffusion)                  = +0.00            <-- pas d'agence"")
+print()
+print(""=> L'ENJEU n'est pas un scalaire universel : il exige le bon espace de mesure (discret vs champ)."")",,,,,,,,0bcdd79d2b1c86ef,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,44fd1628,markdown,fr,1d5a47e6f9627c8a,"### Lecture du gate 6
+
+La *frontière* de l'ENJEU n'est pas une limite du concept mais de l'instrument. Le scalaire `stake_index` crédite sans ambiguïté les substrats discrets (tri, bistable, réplicateur : l'attracteur se restaure après `do`), et rejette à juste titre un drift de contrôle (delta ≈ +2). Mais le Gray-Scott — un champ réaction-diffusion continu — *n'a pas d'état discret unique* à kick : le scalaire lit −0.51, faussement « pas d'agence ». La vérité, mesurée en espace de champ (`repair_gain` = +0.82 ± 0.27, significativement au-dessus du contrôle diffusion ≈ 0), est que le Gray-Scott **répare activement** sa structure après ablation. **Verdict** : la batterie de la série ne cherche pas un invariant universel — elle demande à chaque substrat le *bon* espace où lire son émergence, et ne crédite rien qui ne batte son contrôle. Là est l'honnêteté de la méthode.",,,,,,,,1d5a47e6f9627c8a,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,fa646beb,markdown,fr,7b7d5b4311efc2fb,"## 11. Verdict sans complaisance
+
+**Réponse à la question centrale : *non*, aucun scalaire d'intégration ne transfère entre substrats — et le cinquième substrat le confirme.**
+
+- Les scalaires bruts co-varient par paires : sur quatre substrats, Φ et F suivent le même ordre (τ = +1.00). Mais **K** diverge (τ ≈ +0.33), et la **jambe temporelle** (irréversibilité) classe les substrats de façon orthogonale (le tri est le plus irréversible, le bistable le plus réversible).
+- L'émergence créditée — celle qui bat son contrôle dégénéré — **change de membres** selon le régime (gate 3) et reste **régime-bornée**.
+- Le substrat LLM, le plus riche en représentations, est **le plus faible** sur les trois jambes Φ/F/K : la richesse d'un substrat ne garantit pas une dynamique émergente lisible par l'appareil.
+- L'ENJEU (gate 6) montre que la frontière n'est pas le concept mais l'instrument : un scalaire discret crédite trois substrats, mais il faut un instrument de champ pour révéler l'agence réparatrice du Gray-Scott (+0.82 ± 0.27).
+
+**Ce qui transfère, c'est la méthode, pas le nombre.** Le *même* appareil — estimer la structure causale le long de la trajectoire propre d'un système, ne créditer une émergence qu'au contraste d'un contrôle dégénéré, et changer d'instrument quand un substrat résiste — s'applique aux cinq substrats et rend à chaque fois un verdict falsifiable. Mais ces verdicts sont **régime-bornés et substrat-bornés** : jamais un invariant numérique unique.
+
+C'est la thèse d'ICT jouée au niveau du capstone. L'invariant de la série n'est pas Φ, ni l'information effective, ni un « niveau d'intégration », ni l'irréversibilité, ni l'ENJEU : c'est la **discipline de mesure** — mesurer ce que le système fait vraiment, dans le bon espace, et ne rien créditer qui ne batte son propre contrôle dégénéré. Le livrable de ce capstone est cette honnêteté-là, étendue de trois substrats à cinq.",,,,,,,,7b7d5b4311efc2fb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,47130e32,markdown,fr,d90f57d8d50d062e,"## 12. Exercices
+
+Trois exercices à compléter. Convention C.1 : stub **sans erreur volontaire**
+(`pass` / `return None` / `# TODO etudiant`) — le notebook s'exécute de bout en bout même non
+complété. Chaque exercice est une **extension falsifiable** de la synthèse.
+",,,,,,,,d90f57d8d50d062e,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,fee11470,markdown,fr,30067d8a40d9acca,"### Exercice 1 — un quatrième substrat
+
+Ajoutez un substrat issu d'une **autre strate** — par exemple le champ de réaction-diffusion
+d'[ICT-9](ICT-9-AgencyRegeneration.ipynb) résumé par une statistique scalaire discrétisée, ou une
+trajectoire de $\Phi$ d'[ICT-1](ICT-1-PhiTrajectories.ipynb). Rejoint-il l'ensemble crédité ?
+Déplace-t-il le classement (gate 2) ?
+
+- *Étape 1* : construire une trajectoire `traj_s4` (liste d'états discrets grossiers).
+- *Étape 2* : appeler `S.emergence_gain(traj_s4, rng, n_shuffles=N_SHUF)` et comparer `credited`.
+",,,,,,,,30067d8a40d9acca,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,6bec4eaf,code,fr,b2a3cd4a6f3b0bcb,"# Exercice 1 - a completer
+traj_s4 = None  # TODO etudiant : liste d'etats discrets d'un 4e substrat (ICT-9 ou ICT-1)
+if traj_s4 is not None:
+    g4 = S.emergence_gain(traj_s4, np.random.default_rng(4), n_shuffles=N_SHUF)
+    print(f""S4 : credite={g4['credited']}  ec_gain={g4['ec_gain']:+.3f}  n_etats={g4['n_states']}"")
+else:
+    print(""Exercice 1 a completer : definir traj_s4 (liste d'etats discrets)."")",,,,,,,,b2a3cd4a6f3b0bcb,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,63eea193,markdown,fr,999e7dd3f71e6003,"### Exercice 2 — robustesse à la discrétisation
+
+Le verdict dépend-il du **grain** de discrétisation ? Reprenez S2 (le bistable) avec un binning
+plus fin (par ex. 20 bins au lieu de 10) et un plus grossier (5 bins), et vérifiez si son statut
+`credited` et le $\tau$ du gate 2 survivent. Une discrétisation qui **fabrique** l'émergence est un
+piège que la série dénonce (ICT-7/9).
+
+- *Étape 1* : écrire `traj_S2_grain(seed, n_bins)` (copie de `traj_S2` paramétrée).
+- *Étape 2* : recalculer `emergence_gain` pour `n_bins ∈ {5, 10, 20}` et comparer.
+",,,,,,,,999e7dd3f71e6003,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,8c4e2ab9,code,fr,1d2a6001eb8abded,"# Exercice 2 - a completer
+def traj_S2_grain(seed, n_bins):
+    """"""TODO etudiant : copier traj_S2 en parametrant le nombre de bins.""""""
+    return None  # remplacer par la trajectoire discretisee a n_bins deciles
+
+resultats = None  # TODO etudiant : dict {n_bins: emergence_gain(...)}
+if resultats is not None:
+    for nb, g in resultats.items():
+        print(f""n_bins={nb:2d} : credite={g['credited']}  ec_gain={g['ec_gain']:+.3f}"")
+else:
+    print(""Exercice 2 a completer : balayer n_bins in {5, 10, 20}."")",,,,,,,,1d2a6001eb8abded,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,68b27b12,markdown,fr,50b3ab0700bb9da9,"### Exercice 3 — un contrôle dégénéré plus dur
+
+Le contrôle par permutation totale détruit **tout** l'ordre temporel. Un contrôle plus exigeant
+préserve l'ordre **à courte portée** : le *block-shuffle* permute des **blocs** contigus de longueur
+$b$ (il garde la dynamique locale, casse la globale). Sous ce contrôle plus dur, le gain crédité
+**rétrécit-il** ? De combien ?
+
+- *Étape 1* : écrire `block_shuffle(states, rng, b)` (permutation de blocs de longueur `b`).
+- *Étape 2* : recalculer le gain d'EC de S1/S2/S3 contre ce contrôle et comparer au shuffle total.
+",,,,,,,,50b3ab0700bb9da9,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,edfda9d9,code,fr,8682120d4b5e1bcf,"# Exercice 3 - a completer
+def block_shuffle(states, rng, b=10):
+    """"""TODO etudiant : decouper en blocs de longueur b, permuter l'ordre des blocs.""""""
+    return None  # remplacer par la trajectoire block-shufflee
+
+# Indice : comparer S.trajectory_battery(block_shuffle(...)) a S.trajectory_battery(states)
+print(""Exercice 3 a completer : implementer block_shuffle et comparer au controle total."")",,,,,,,,8682120d4b5e1bcf,,,,,,,
+MyIA.AI.Notebooks/IIT/ICT-Series/ICT-Synthese-CrossSubstrat.ipynb,a309752b,markdown,fr,a59f4fe437426d42,"## Pour aller plus loin
+
+- [ICT-0 — Cadrage de la série](ICT-0-Framing.md) : les deux articles fondateurs (Levin ;
+  Jansma & Hoel), le principe méthodologique *sans complaisance*, la feuille de route.
+- [ICT-6 — Pont tri → TPM](ICT-6-SortingToTPM-CausalEmergence.ipynb) : le pont trajectoire → TPM
+  que ce capstone généralise à trois substrats.
+- [ICT-15 — Integrated Complexity](ICT-15-IntegratedComplexity.ipynb) : le capstone strate 4 qui
+  *étend* cet appareil avec les deux scalaires manquants (surprise F via une TPM held-out,
+  compression K via zlib) et pose le gate de convergence Φ/F/K (τ de Kendall par paire +
+  coincidence des changepoints au pli de Thom). See #5090.
+- [ICT-5 — Émergence causale](ICT-5-CausalEmergence.ipynb) : la batterie causale (déterminisme,
+  dégénérescence, information effective) branchée ici sans modification.
+- [ICT-18 — Réversibilisation et flèche du temps](ICT-18-ArrowOfTimeReversibilization.ipynb) : la jambe temporelle de l'émergence (production d'entropie, chaîne réversibilisée) branchée au gate 5.
+- [ICT-19 — Batterie de l'ENJEU](ICT-19-EnjeuBattery.ipynb) et [son raffinement](ICT-19-EnjeuBattery-Raffinement.ipynb) : l'agence comme auto-maintien après intervention ; le scalaire discret vs la mesure de champ (`repair_gain` = +0.82 ± 0.27), gate 6.
+- [ICT-21 — Trajectoires SAE](ICT-21-SAETrajectoires.ipynb) et [ICT-22 — Substrat LLM](ICT-22-LLMSubstrat.ipynb) : le quatrième substrat (activations SAE d'un LLM) intégré au gate 4 ; ICT-22 Gate 13 a posé le banc Φ/F/K 4-substrats que ce capstone relève.
+
+- Epic [#4588](https://github.com/jsboige/CoursIA/issues/4588) — registre des livrables ICT ;
+  design du capstone : [#4946](https://github.com/jsboige/CoursIA/issues/4946).
+
+---
+*ICT-Synthèse — un seul appareil de mesure, cinq substrats. Epic #4588. Voir
+[ICT-0-Framing](ICT-0-Framing.md) pour le cadrage de la série.*
+",,,,,,,,a59f4fe437426d42,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,3653fac8,markdown,fr,c870eb55de6548a9,"# IIT - Introduction à PyPhi et Integrated Information Theory
+
+## Navigation
+**Série** : [IIT](./README.md) | **Partie** : Fondements
+**Précédent** : -- | **Suivant** : [IIT-2 : Sujets avancés](./IIT-2-AdvancedTopics.ipynb)
+
+## Objectifs d'apprentissage
+1. **Comprendre** les principes de l'Integrated Information Theory (IIT)
+2. **Manipuler** les objets PyPhi : Network, Subsystem, CES
+3. **Calculer** et interpréter la valeur Φ (Phi) d'un système
+4. **Explorer** la structure causale (Cause-Effect Structure)
+
+### Prérequis
+- Python 3.10+ (environnement Conda recommandé)
+- Notions de base en théorie de l'information
+- Connaissances en algèbre linéaire (matrices de transition)
+
+### Durée estimée : 60 minutes
+
+---
+
+### **Sommaire**
+1. [Introduction à l'IIT](#sec1)  
+2. [Installation et importation de PyPhi](#sec2)  
+3. [Création d'un réseau simple (Network)](#sec3)  
+4. [Définition d'un Subsystem et calcul de \(\Phi\)](#sec4)  
+5. [Concepts, mécanismes, et structure cause-effet (CES)](#sec5)  
+6. [Exploration d'exemples avancés (macro, actual causation…)](#sec6)  
+7. [Ressources complémentaires](#sec7)
+
+---
+
+<a id=""sec1""></a>
+## 1. Introduction à l'IIT
+
+**Objectif** : l'**Integrated Information Theory** (IIT), introduite par Giulio Tononi et collaborateurs, propose une mesure de la conscience à partir de la quantité d'information intégrée par un système. En pratique :
+
+- Un **système** (réseau de neurones, circuit logique, etc.) est représenté par une **Transition Probability Matrix (TPM)**.
+- L'information intégrée est notée \(\Phi\) (Phi). PyPhi calcule \(\Phi\) pour des sous-systèmes et explore la structure causale (Cause-Effect Structure, ou *CES*).
+- L'**objectif pédagogique** de ce notebook est de créer un petit réseau, de définir un état, et de calculer \(\Phi\) pour différents sous-ensembles (subsystèmes).
+
+### Objectifs du TP
+1. Comprendre la représentation d'un système dynamique discret via une TPM.
+2. Manipuler les objets de base de PyPhi : `Network`, `Subsystem`.
+3. Calculer et interpréter la valeur \(\Phi\) (degré d'irréductibilité).
+4. Explorer la structure causale (CES) d'un état donné.
+
+### Résumé des concepts clés
+
+| Concept | Explication simple | Analogie |
+| :--- | :--- | :--- |
+| **TPM** | Les règles du jeu. Comment le système évolue. | Les lois de la physique. |
+| **État** | La configuration actuelle (0 ou 1) des nœuds. | Une photo instantanée du cerveau. |
+| **\(\Phi\) (Big Phi)** | Le niveau d'intégration du système entier. | La solidité d'un nœud marin (tient-il tout seul ?). |
+| **MIP** | Le point faible du système (Minimum Information Partition). | Le maillon faible d'une chaîne. |
+| **CES** | La forme géométrique de l'information intégrée. | La ""forme"" d'une pensée. |
+
+---
+
+<a id=""sec2""></a>
+## 2. Installation et importation de PyPhi
+
+> **Remarque** : PyPhi s'installe via `pip`.
+> **Pré-requis** : Python 3.10+ (recommandé).
+
+Il est conseillé d'utiliser un environnement Conda dédié :
+```bash
+conda create --name pyphi python=3.13 -y
+conda activate pyphi
+pip install pyphi
+```
+
+Sélectionner l'environnement nouvellement créé comme noyau.",,,,,,,,c870eb55de6548a9,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,903f487f,code,fr,a7dd6c38475c47fb,"import warnings
+# pyemd (importe par pyphi) emet un avertissement de deprecation pkg_resources qui fuite le chemin site-packages.
+warnings.filterwarnings(""ignore"", message="".*pkg_resources is deprecated.*"", category=UserWarning)
+
+# Installation defensive : pyphi est deja present dans le kernel dedie (env conda pyphi).
+# On ne lance pip que s'il manque, pour eviter la sortie bruyante (chemins site-packages).
+import importlib.util, subprocess, sys
+if importlib.util.find_spec(""pyphi"") is None:
+    subprocess.run([sys.executable, ""-m"", ""pip"", ""install"", ""-q"", ""pyphi""], check=True)
+    print(""pyphi installe."")
+else:
+    import pyphi
+    print(f""pyphi deja installe ({pyphi.__version__})."")
+",,,,,,,,a7dd6c38475c47fb,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,75ba5ca1,markdown,fr,4e783c71fc61cda2,"Une fois PyPhi installe, importons la librairie et verifions la version disponible.",,,,,,,,4e783c71fc61cda2,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,058309e0,code,fr,4f90508f213d7545,"import warnings
+# pyemd (importe par pyphi) emet un avertissement de deprecation pkg_resources qui fuite le chemin site-packages.
+warnings.filterwarnings(""ignore"", message="".*pkg_resources is deprecated.*"", category=UserWarning)
+
+import pyphi
+
+print(""PyPhi version:"", pyphi.__version__)",,,,,,,,4f90508f213d7545,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,91886d72,markdown,fr,44b2e001b4634bfe,"<a id=""sec3""></a>
+## 3. Création d’un réseau simple (Network)
+
+### 3.1. Structure d’un réseau
+
+Un **Network** dans PyPhi est défini par :
+- Une **TPM** (`ExplicitTPM`) en forme de matrice multidimensionnelle ou un array 2D.
+- Une **connectivity matrix** (CM), indiquant comment les nœuds sont connectés.
+
+### 3.2. Exemple : un circuit logique
+
+Nous allons créer un réseau (circuit) minimaliste à 3 nœuds (A, B, C) :
+
+- **A** : passerelle logique, reçoit des entrées de B et C  
+- **B** : un XOR des entrées de A et C  
+- **C** : identique à B ou un AND/OR, selon l’exemple souhaité ",,,,,,,,44b2e001b4634bfe,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,5e296ce8,code,fr,82a847613c23d5d7,"import numpy as np
+import pyphi
+
+# Exemple d'un petit réseau XOR
+# 3 noeuds : A, B, C
+# On utilise un exemple déjà inclus dans pyphi.examples
+
+network = pyphi.examples.xor_network()
+
+print(""Nodes:"", network.node_labels)
+print(""TPM shape:"", network.tpm.shape)
+print(""Connectivity matrix:\n"", network.cm)",,,,,,,,82a847613c23d5d7,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,eb86b36c,markdown,fr,0d39d56a3d64775d,"**Comment ça marche ?**  
+- `pyphi.examples.xor_network()` renvoie un réseau (Network) de taille 3, où chaque nœud est un XOR à deux entrées (sans auto-connexion).  
+- La **TPM** est stockée dans `network.tpm`, et chaque dimension correspond à un état binaire (`0/1`). La `TPM` est un tableau multidimensionnel de taille (2, 2, 2, 3), reflétant les états binaires pour 3 nœuds.
+La matrice de connectivité montre les liens (XOR signifie que chaque nœud dépend des deux autres sans boucles sur soi-même).
+
+
+---
+
+### 3.3. Inspection de la TPM
+
+Pour mieux comprendre le fonctionnement du réseau, vous pouvez examiner directement les valeurs de la matrice de transition (TPM). Celle-ci peut être soit en _state-by-state_ (SBS) ou _state-by-node_ (SBN) selon votre cas. PyPhi propose des utilitaires de conversion.
+",,,,,,,,0d39d56a3d64775d,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,62301b90,code,fr,f76874f8875d5929,"import pyphi.convert
+
+sbn_tpm = network.tpm
+print(""TPM (state-by-node) shape:"", sbn_tpm.shape)
+
+# Pour visualiser un 'slice' ou un 'flatten' :
+print(""Premier 'slice' de la TPM (correspondant à un sous-état) :\n"", sbn_tpm[0])
+
+# Passer au format state-by-state pour mieux le parcourir
+sbs_tpm = pyphi.convert.state_by_node2state_by_state(sbn_tpm)
+print(""\nTPM (state-by-state) shape:"", sbs_tpm.shape)
+print(""Quelques lignes du TPM:\n"", sbs_tpm[:4])
+",,,,,,,,f76874f8875d5929,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,7a35fb70,markdown,fr,bfca6dec67b06b4c,"<a id=""sec4""></a>
+## 4. Définition d’un Subsystem et calcul de \(\Phi\)
+
+### 4.1. Sous-système (Subsystem)
+
+Un **Subsystem** se définit en spécifiant :
+1. Un **Network** ;
+2. Un **état** du réseau (ex. `(0, 0, 0)` pour `A=0, B=0, C=0`) ;
+3. Les indices de nœuds internes qu’on considère comme faisant partie du sous-système.
+
+Ensuite, PyPhi peut calculer la valeur de \(\Phi\) pour ce sous-système.",,,,,,,,bfca6dec67b06b4c,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,phi-def-intuitive,markdown,fr,41c55b674bc804db,"### Le Calcul de \(\Phi\) : Définition Intuitive
+
+\(\Phi\) mesure à quel point le système est ""plus que la somme de ses parties"".
+
+**Le calcul** : PyPhi essaie de couper le système en deux (une ""bipartition"") de toutes les manières possibles (A vs BC, B vs AC, etc.).
+- La coupe qui fait perdre le *moins* d'information est appelée la **Minimum Information Partition (MIP)**.
+- \(\Phi\) est la quantité d'information perdue au niveau de cette coupe la plus faible.
+- Si \(\Phi > 0\), le système est irréductible (conscient selon l'IIT).
+",,,,,,,,41c55b674bc804db,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,cfb3a7f7,code,fr,0f5f72abc7d618ed,"# État de départ
+state = (0, 0, 0)
+
+# Créons un Subsystem pour l’ensemble des nœuds (0, 1, 2)
+subsystem = pyphi.Subsystem(network, state, (0, 1, 2))
+
+# Calcul de Phi
+phi_value = pyphi.compute.phi(subsystem)
+
+print(""Φ pour le sous-système (0,1,2) à l’état (0,0,0) :"", phi_value)",,,,,,,,0f5f72abc7d618ed,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,388d4d94,markdown,fr,205c0e0443ca775c,"### 4.2. States inaccessibles et validation (`StateUnreachableError`)
+
+C'est une erreur fréquente rencontrée dans PyPhi.
+
+**Le problème** : Certains états du réseau peuvent être impossibles à atteindre selon la dynamique du système (la TPM). Si on force le système dans cet état ""impossible"", l'IIT considère que le passé est indéfini.
+
+**Solutions possibles** :
+1. Choisir un état qui est atteignable (un état stable ou faisant partie d'un cycle).
+2. Ou désactiver la validation (pour l'exercice) : `pyphi.config.VALIDATE_SUBSYSTEM_STATES = False`.
+
+PyPhi, par défaut, peut émettre des erreurs (`StateUnreachableError`) si l'état que vous définissez n'est pas accessible depuis la TPM. Ci-dessous, on montre comment désactiver temporairement la validation pour s'assurer que PyPhi ne bloque pas le calcul.",,,,,,,,205c0e0443ca775c,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,1748a54f,code,fr,6bfb0b9fa3411e68,"# Configurer PyPhi pour ignorer les inaccessibilités d’états
+pyphi.config.VALIDATE_SUBSYSTEM_STATES = False
+
+# Réessayer un état arbitraire
+test_state = (1,0,0)
+subsys_test = pyphi.Subsystem(network, test_state, (0,1,2))
+try:
+    val_test = pyphi.compute.phi(subsys_test)
+    print(f""État {test_state} -> Φ = {val_test:.5f}"")
+except pyphi.exceptions.StateUnreachableError:
+    print(""État inaccessible, PyPhi a lancé une exception !"")
+",,,,,,,,6bfb0b9fa3411e68,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,d1e8755b,markdown,fr,47f034e223015c22,On peut également calculer \\(\Phi\\) pour d'autres états accessibles:,,,,,,,,47f034e223015c22,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,8be318a7,code,fr,c1f1d97c7200ed57,"# Exemple d'états stables pour éviter StateUnreachableError
+for s in [(0,0,0), (0,1,1), (1,1,0)]:
+    subsys = pyphi.Subsystem(network, s, (0,1,2))
+    val = pyphi.compute.phi(subsys)
+    print(f""État {s} -> Φ = {val:.5f}"")
+",,,,,,,,c1f1d97c7200ed57,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,c91e98c8,markdown,fr,eb42ba9f71d923cd,"### Exercice 1 : Phi d'un sous-système partiel
+
+Le calcul de Phi ci-dessus utilise les 3 noeuds (0,1,2). Que se passe-t-il si on ne considère
+qu'un sous-ensemble de noeuds, par exemple (0,1) uniquement ?
+
+**Objectif** : Créez un sous-système avec uniquement les noeuds (0,1) à l'état (0,0,0)
+et comparez sa valeur Phi avec celle du système complet.
+
+**Questions** :
+- Phi est-il plus grand ou plus petit avec 2 noeuds qu'avec 3 ?
+- Combien de concepts la CES d'un sous-système partiel contient-elle ?
+
+**Indice** : `pyphi.Subsystem(network, state, (0, 1))` crée le sous-système partiel.
+Puis `pyphi.compute.phi(...)` pour le Phi et `pyphi.compute.ces(...)` pour la CES.",,,,,,,,eb42ba9f71d923cd,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,42dafeb5,code,fr,a8cce4ed4bd0d5c9,"# Exercice 1 : Phi d'un sous-systeme partiel (noeuds 0 et 1 uniquement)
+# TODO etudiant : creer un sous-systeme avec (0, 1) a l'etat (0,0,0)
+# et calculer phi + nombre de concepts dans la CES
+# Indice : pyphi.Subsystem(network, (0,0,0), (0, 1))
+# Indice : pyphi.compute.phi(subsystem_2noeuds) pour Phi
+# Indice : len(pyphi.compute.ces(subsystem_2noeuds)) pour le nombre de concepts
+
+result = None  # TODO etudiant : remplacer par le calcul Phi partiel vs complet
+if result is not None:
+    print(f""Resultat: {result}"")
+else:
+    print(""Exercice a completer"")
+",,,,,,,,a8cce4ed4bd0d5c9,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,63af95b4,markdown,fr,dd5d997bb5406898,"<a id=""sec5""></a>
+## 5. Concepts, mécanismes, et structure cause-effet (CES)
+
+PyPhi peut également détailler la structure de cause-effet (CES) :
+
+- Chaque *concept* correspond à un **mécanisme** (ex. nœud simple ou sous-groupe de nœuds) et à son purview (cause et/ou effet).",,,,,,,,dd5d997bb5406898,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,57501e53,code,fr,6aec6f496b37af2a,"ces = pyphi.compute.ces(subsystem)
+print(""Nombre de concepts dans la CES :"", len(ces))
+print(""Liste des mécanismes :"", ces.labeled_mechanisms)",,,,,,,,6aec6f496b37af2a,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,560d96b0,markdown,fr,43edb385b04e5ed3,"### 5.1. Analyse d’un concept spécifique
+
+Chaque concept est défini par un mécanisme (un ensemble de nœuds) et un purview (un ensemble de nœuds qui subissent ses effets ou le causent). Explorons le premier concept dans la CES, pour comprendre sa cause / effet et son petit phi (\\(\\varphi\\)).
+",,,,,,,,43edb385b04e5ed3,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,1083ab9d,code,fr,f823b5327707d70e,"# Prenons le premier concept dans la CES
+first_concept = ces[0]
+print(""Mécanisme:"", first_concept.mechanism)
+print(""Cause purview:"", first_concept.cause.purview)
+print(""Cause repertoire:\n"", first_concept.cause.repertoire)
+print(""Effect purview:"", first_concept.effect.purview)
+print(""Effect repertoire:\n"", first_concept.effect.repertoire)
+print(""Petit phi (φ) ="", first_concept.phi)
+",,,,,,,,f823b5327707d70e,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,a9a149d4,markdown,fr,d28710cee7eb8e7e,"### Exercice 2 : Comparer les concepts de la CES
+
+Le premier concept analysé (mécanisme {A,B}) a un petit phi de 0.5 et un effect purview sur C uniquement.
+Les autres concepts de la CES peuvent avoir des structures très différentes.
+
+**Objectif** : Sélectionnez le concept correspondant au mécanisme {A,C} (le deuxième concept de la CES)
+et analysez son cause/effect purview et son petit phi.
+
+**Indice** : Utilisez `ces[1]` pour accéder au deuxième concept. Comparez les purviews avec le premier concept.
+Les purviews sont-ils les mêmes ? Pourquoi ?",,,,,,,,d28710cee7eb8e7e,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,5658a6b5,code,fr,a0877ac78b29c3a8,"# Exercice 2 : Analyser le deuxieme concept de la CES (mecanisme {A,C})
+# TODO etudiant : acceder a ces[1] et afficher :
+#   - le mecanisme
+#   - le cause purview et repertoire
+#   - l'effect purview et repertoire
+#   - le petit phi
+# Indice : le pattern est le meme que pour first_concept = ces[0] ci-dessus
+
+result = None  # TODO etudiant : remplacer par l'analyse du deuxieme concept
+if result is not None:
+    print(f""Resultat: {result}"")
+else:
+    print(""Exercice a completer"")
+",,,,,,,,a0877ac78b29c3a8,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,50f14939,markdown,fr,5de60e3acc7080f2,"### Interpretation : structure causale du premier concept
+
+Le mecanisme {A, B} (noeuds 0 et 1) produit un concept avec :
+
+| Aspect | Valeur | Signification |
+|--------|--------|---------------|
+| **Cause purview** | (A, B, C) | Les 3 noeuds contribuent a *causer* l'etat actuel de {A, B} |
+| **Effect purview** | (C,) | Le mecanisme {A, B} n'a d'effet irreductible que sur le noeud C |
+| **Petit phi** | 0.5 | L'information integree par ce mecanisme specifique |
+
+Le **repertoire de cause** montre que l'etat passe le plus probable etait (0,0,0) ou (1,1,1) avec probabilite 0.5 chacun. Le **repertoire d'effet** indique que C passera a l'etat 0 avec certitude (probabilite 1.0), ce qui est coherent avec le XOR : si A=0 et B=0, alors C = A XOR B = 0.",,,,,,,,5de60e3acc7080f2,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,5d067a10,markdown,fr,b6bd49d481e0afa1,"
+<a id=""sec6""></a>
+## 6. Exemple avancé : analyse de causalité et macro-subsystems
+
+### 6.1 Actual Causation
+
+PyPhi offre `pyphi.actual` pour analyser la causalité effective (""What caused what?""). On définit un `Transition` : état avant, état après, et on cherche les liens causaux irréductibles.
+
+Cette extension de la théorie permet de comprendre non plus ""combien de conscience"" (système) mais ""qui a causé quoi"" (causalité événementielle). C'est utile pour analyser des séquences temporelles spécifiques.",,,,,,,,b6bd49d481e0afa1,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,0f04c796,markdown,fr,7e38568118c4863c,"### Interpretation : liens causaux de la transition (1,1,1) vers (0,0,0)
+
+L'analyse revele **10 liens causaux irreductibles** pour cette transition, tous avec une force alpha = 1.0 (sauf le lien global a 2.0). On distingue :
+
+- **Causes** (fleches vers la gauche) : chaque noeud individuel (A, B, C) est une cause irreductible pour les deux autres noeuds. Les paires {A,B}, {A,C}, {B,C} causent l'ensemble {A,B,C}.
+- **Effets** (fleches vers la droite) : de maniere symetrique, chaque paire produit un effet sur le noeud restant.
+- Le lien **{A,B,C} vers {A,B,C}** avec alpha = 2.0 represente l'effet global integre du systeme sur lui-meme.
+
+Cette symetrie est typique du reseau XOR : chaque noeud depend des deux autres de maniere equivalente, ce qui produit une structure causale riche et fortement integree.",,,,,,,,7e38568118c4863c,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,e55f113d,code,fr,4a55108979be8f0a,"import pyphi
+import pyphi.actual
+
+pyphi.config.VALIDATE_SUBSYSTEM_STATES = False
+
+before_state = (1,1,1)
+after_state  = (0,0,0)
+
+transition = pyphi.actual.Transition(
+    network,
+    before_state,
+    after_state,
+    cause_indices=(0,1,2),
+    effect_indices=(0,1,2)
+)
+
+account = pyphi.actual.account(transition)
+print(""Nombre de causal links :"", len(account))
+for link in account:
+    print(link)
+",,,,,,,,4a55108979be8f0a,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,ad58565a,markdown,fr,503c16c8a9a0ab97,"### 6.2 Macro-subsystems (coarse-graining, blackboxing)
+
+Le module `pyphi.macro` permet d'agréger des nœuds (coarse-grain) ou de blackboxer certains éléments. 
+On peut ainsi recalculer \\(\Phi\\) à une échelle différente, ce qui rejoint l’idée de l’ICT qu’on peut analyser l’information intégrée à divers niveaux.
+
+",,,,,,,,503c16c8a9a0ab97,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,0b0d592b,markdown,fr,db96b090904c9ae9,"---
+
+## Exercice : Exploration de la structure cause-effet
+
+**Objectifs** :
+1. Analyser l'impact de la topologie du réseau sur la valeur de Φ
+2. Explorer la relation entre mécanismes et purviews
+3. Comparer différents réseaux pour comprendre l'intégration
+
+**Contexte** : Vous avez vu comment calculer Φ pour un réseau XOR simple. L'IIT suggère que la valeur de Φ dépend de la façon dont l'information est intégrée dans le système. Dans cet exercice, vous allez explorer cette relation.
+
+**Questions** :
+
+1. **Question** : Créez un réseau AND (où chaque nœud fait un AND de ses entrées) et comparez sa valeur Φ avec celle du réseau XOR. Quelle topologie produit plus d'intégration ?
+
+2. **Question** : Pour le réseau XOR, analysez comment Φ change selon l'état du système. Existe-t-il des états où Φ = 0 ?
+
+3. **Question** : Explorez la CES d'un sous-système à 2 nœuds vs le système complet. Comment le nombre de concepts évolue-t-il ?",,,,,,,,db96b090904c9ae9,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,53ad8dc0,code,fr,d449a9305642d4d9,"# Exercice - Exploration de la structure cause-effet
+# 1. Créer un réseau AND et comparer Φ avec XOR
+# 2. Analyser Φ selon l'état
+# 3. Comparer CES 2-noeuds vs 3-noeuds
+
+# Exemple de structure pour le réseau AND
+# and_tpm = ...  # Définir la TPM pour un réseau AND
+# and_network = pyphi.Network(and_tpm, connectivity_matrix=cm)
+# and_subsystem = pyphi.Subsystem(and_network, (0,0,0), (0,1,2))
+# print(""Φ (AND):"", pyphi.compute.phi(and_subsystem))
+
+print(""Exercice a completer"")  # todo etudiant: implementer
+",,,,,,,,d449a9305642d4d9,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,67e8f08a,markdown,fr,c9adcabaac1d53b7,"## Conclusion
+
+Ce notebook a introduit l'**Integrated Information Theory** (IIT) et son implementation de reference, **PyPhi**, en suivant le fil qui mene des donnees brutes d'un systeme a une mesure de son integration causale.
+
+### Le pipeline PyPhi en un coup d'oeil
+
+| Etape | Objet PyPhi | Role |
+|-------|-------------|------|
+| Dynamique | `Network` (+ TPM) | Decrit comment l'etat du systeme evolue, mecanisme par mecanisme |
+| Decoupage | `Subsystem` | Fixe un etat de fond et isole les elements analyses |
+| Integration | $\Phi$ | Mesure l'irreductibilite du tout a ses parties (la partition qui « coute » le moins) |
+| Structure | CES (concepts) | Decompose *ce que* le systeme distingue : repertoires cause-effet de chaque mecanisme |
+
+Le point conceptuel central est que $\Phi$ ne mesure pas une quantite d'information *transmise*, mais une information **integree** : ce qui serait perdu si l'on coupait le systeme en morceaux. Un systeme dont les parties sont independantes a un $\Phi$ nul, meme s'il calcule des choses complexes -- l'integration, pas la performance, est le critere.
+
+### Ce que les exemples ont mis en evidence
+
+- La **TPM** (matrice de transition) est le point d'entree obligatoire : toute la causalite en decoule, d'ou l'importance de la validation `StateUnreachableError` qui protege contre l'analyse d'etats que la dynamique ne peut jamais produire.
+- La **CES** revele la *qualite* de l'experience d'un systeme (quels concepts il porte), la ou $\Phi$ n'en donne que la *quantite*.
+- La **causalite actuelle** (actual causation) repond a une question differente : non pas « quelle est la structure du systeme » mais « qu'est-ce qui a effectivement cause *cette* transition ».
+- Le **coarse-graining / blackboxing** (macro-subsystems) montre qu'un meme substrat peut etre plus integre a une echelle macro qu'a l'echelle micro -- l'echelle a laquelle $\Phi$ est maximal est theoriquement privilegiee.
+
+### Limites et suite
+
+Le calcul de $\Phi$ est **combinatoirement explosif** (toutes les partitions, tous les mecanismes), ce qui confine PyPhi a de petits systemes (quelques noeuds) -- une contrainte pratique a garder en tete avant toute ambition d'echelle. Les raffinements de la theorie (IIT 4.0, calcul du $\varphi$ au niveau des distinctions et relations) et les strategies de passage a l'echelle sont approfondis dans le notebook [IIT-2 : Sujets avances](./IIT-2-AdvancedTopics.ipynb).
+
+> **A retenir** : l'IIT propose de mesurer la conscience comme l'**integration causale irreductible** d'un systeme sur lui-meme. PyPhi rend cette definition operationnelle : on declare une dynamique (TPM), on choisit un decoupage (Subsystem), et le moteur calcule a la fois *combien* ($\Phi$) et *quoi* (CES) le systeme integre.
+",,,,,,,,c9adcabaac1d53b7,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb,d0948bcb,markdown,fr,abd00e26f56287e8,"<a id=""sec7""></a>
+## 7. Ressources complémentaires
+
+- [Documentation PyPhi](https://pyphi.readthedocs.io/en/stable/)
+- [""Major Complex"", ""Actual Causation""](https://github.com/wmayner/pyphi/tree/master/examples)
+- Travaux de Tononi, Koch, Oizumi, Albantakis, etc. (cf. publications IIT)
+- Pour aller plus loin : l’ICT, l’analyse fractale de l’information, etc.
+
+**Fin du notebook**. 
+Merci pour votre attention !",,,,,,,,abd00e26f56287e8,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,3cab92ae,markdown,fr,f37f8051928e7f1d,"# IIT - Sujets Avances : Partitionnement, Repertoires Cause-Effet et Reseaux Elargis
+
+## Navigation
+
+Ce notebook est le **deuxieme volet** de la serie IIT. Il approfondit les concepts introduits dans [IIT-1-IntroToPyPhi](IIT-1-IntroToPyPhi.ipynb).
+
+| Notebook | Contenu | Duree |
+|----------|---------|-------|
+| [1. IIT-1-IntroToPyPhi](IIT-1-IntroToPyPhi.ipynb) | Reseaux, Phi, CES, macro-subsystemes | 60-90 min |
+| **2. AdvancedTopics** (ce notebook) | Partitions MIP, repertoires, MICE, reseaux elargis | 60-90 min |
+
+**Prerequis** : avoir complete le notebook 1 (IIT-1-IntroToPyPhi).
+
+---
+
+## Plan de ce notebook
+
+1. **Rappels et configuration** - Reprise des concepts cles du notebook 1
+2. **Partitionnement et MIP** - Comment PyPhi cherche la coupe minimale d'information
+3. **Repertoires cause-effet** - Distributions de probabilites sur les causes et effets possibles
+4. **MICE et concepts** - Mechanismes maximalement irreductibles
+5. **Big Phi vs Small Phi** - Difference entre integration systeme et integration mecanisme
+6. **Reseaux elargis** - Systemes a 4+ noeuds et interpretation
+7. **Performance et coarse-graining** - Strategies pour traiter de grands systemes
+8. **Vers IIT 4.0** - Apercu des evolutions recentes de la theorie",,,,,,,,f37f8051928e7f1d,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,bb121255,markdown,fr,b83cc3341b2608f7,"<a id=""sec1""></a>
+## 1. Rappels et configuration
+
+Dans le notebook precedent, nous avons vu :
+
+- **Reseau (Network)** : un ensemble de noeuds binaires connectes, decrit par une TPM
+- **Sous-systeme (Subsystem)** : un sous-ensemble de noeuds dans un etat donne
+- **Phi (big Phi, $\Phi$)** : mesure de l'integration irreductible du systeme
+- **CES (Cause-Effect Structure)** : l'ensemble des concepts du systeme
+- **Concept** : un mecanisme avec son cause et son effet maximalement irreductibles
+
+Reprenons avec notre reseau XOR et configurons PyPhi.",,,,,,,,b83cc3341b2608f7,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,00e5af6c,code,fr,f5bd28910c45c2a3,"import warnings
+warnings.filterwarnings(""ignore"", message="".*pkg_resources is deprecated.*"", category=UserWarning)
+
+import os
+os.environ['PYPHI_WELCOME_OFF'] = 'yes'
+
+import pyphi
+import numpy as np
+
+pyphi.config.VALIDATE_SUBSYSTEM_STATES = False
+
+print(""PyPhi version:"", pyphi.__version__)
+print(""Configuration prete."")",,,,,,,,f5bd28910c45c2a3,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,a81c90c7,code,fr,ef4fe4b300f5705f,"# Creation du reseau XOR (3 noeuds) - identique au notebook 1
+network = pyphi.examples.xor_network()
+state = (0, 0, 0)
+subsystem = pyphi.Subsystem(network, state)
+
+print(""Reseau XOR : 3 noeuds (A, B, C)"")
+print(""Etat initial :"", state)
+print(""Noeuds du sous-systeme :"", subsystem.node_indices)
+print(""Connectivite (CM) :"")
+print(network.cm)",,,,,,,,ef4fe4b300f5705f,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,d0b16bff,markdown,fr,3527a31d0f5d9201,"<a id=""sec2""></a>
+## 2. Partitionnement et MIP (Minimum Information Partition)
+
+Le coeur du calcul de $\Phi$ repose sur la recherche de la **partition minimale d'information (MIP)**. La MIP est la facon de couper le systeme en deux qui **detruit le moins d'information**. Si cette coupe minimale detruit beaucoup d'information, c'est que le systeme est fortement integre.
+
+### 2.1. Types de partitions
+
+PyPhi supporte plusieurs types de partitions :
+- **Bipartition** : couper le systeme en 2 parties
+- **Tripartition** : couper en 3 parties
+- **K-partition** : couper en K parties
+
+Pour chaque partition, on mesure l'information detruite par la coupe. La MIP est celle qui minimise cette perte.",,,,,,,,3527a31d0f5d9201,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,4daea783,code,fr,d72ad2b95a0cd77e,"# Calculer l'analyse d'irreductibilite du systeme (SIA)
+sia = pyphi.compute.sia(subsystem)
+
+print(""=== System Irreducibility Analysis (SIA) ==="")
+print(f""Big Phi: {sia.phi}"")
+print(f""Coupe (MIP): {sia.cut}"")
+print(f""Partie from: {sia.cut.from_nodes}"")
+print(f""Partie to: {sia.cut.to_nodes}"")",,,,,,,,d72ad2b95a0cd77e,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,5f61aeeb,markdown,fr,e1e597eb1a4308cd,"### 2.2. Interpretation de la MIP
+
+La MIP nous dit **ou le systeme est le plus faiblement integre**. Dans notre reseau XOR :
+
+- Si la coupe separe les noeuds {A, B} de {C}, cela signifie que le lien A,B -> C est le plus faible
+- Plus $\Phi$ est eleve, plus le systeme est irreductiblement integre
+- Un $\Phi = 0$ signifie que le systeme est completement decomposable (pas d'integration)
+
+### 2.3. Complexite du partitionnement
+
+Le nombre de partitions possibles croit exponentiellement avec la taille du systeme (nombre de Bell). C'est pourquoi le calcul exact de $\Phi$ est **intractable** pour de grands reseaux.",,,,,,,,e1e597eb1a4308cd,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,2b5a3aa3,code,fr,56468687797cf5b9,"# Enumerer toutes les bipartitions possibles du sous-systeme
+from pyphi.partition import bipartition
+
+nodes = subsystem.node_indices
+all_biparts = list(bipartition(nodes))
+print(f""Nombre de bipartitions pour {len(nodes)} noeuds : {len(all_biparts)}"")
+print(""\nBipartitions possibles :"")
+for i, bp in enumerate(all_biparts):
+    print(f""  {i+1}. {bp[0]} | {bp[1]}"")
+
+# Nombre de Bell pour les 6 premiers entiers
+bell = [1, 1, 2, 5, 15, 52, 203]
+print(f""\nNombres de Bell (nombre total de partitions):"")
+for n in range(len(bell)):
+    print(f""  {n} noeuds -> {bell[n]} partitions"")",,,,,,,,56468687797cf5b9,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,68b8975d,markdown,fr,fc9afc18a7bb9edf,"<a id=""sec3""></a>
+## 3. Repertoires cause-effet
+
+Les **repertoires cause et effet** sont les distributions de probabilite qui decrivent comment un mecanisme contraint les etats passes (cause) et futurs (effet) d'un purview.
+
+### 3.1. Repertoire cause
+
+Le repertoire cause repond a la question : etant donne le mecanisme dans son etat actuel, quelles sont les probabilites des etats anterieurs possibles du purview ?",,,,,,,,fc9afc18a7bb9edf,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,57384b10,code,fr,925ba982c9506b9d,"# Calculer le repertoire cause pour le mecanisme {A, B} et le purview {A}
+mechanism = (0, 1)
+purview = (0,)
+
+cause_rep = subsystem.cause_repertoire(mechanism, purview)
+print(f""Repertoire cause pour mecanisme {mechanism} -> purview {purview}:"")
+print(f""  Shape: {cause_rep.shape}"")
+print(f""  Valeurs: {cause_rep.flatten()}"")
+print(f""  Somme: {cause_rep.sum():.4f} (doit etre 1.0)"")",,,,,,,,925ba982c9506b9d,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,fcf92c26,code,fr,2ef57f9cdd9f903b,"# Calculer le repertoire effet pour le meme mecanisme
+effect_rep = subsystem.effect_repertoire(mechanism, purview)
+print(f""Repertoire effet pour mecanisme {mechanism} -> purview {purview}:"")
+print(f""  Shape: {effect_rep.shape}"")
+print(f""  Valeurs: {effect_rep.flatten()}"")
+print(f""  Somme: {effect_rep.sum():.4f} (doit etre 1.0)"")
+
+print(""\nComparaison cause vs effet:"")
+for i, label in enumerate(['A=0', 'A=1']):
+    c_val = cause_rep.flatten()[i]
+    e_val = effect_rep.flatten()[i]
+    print(f""  {label}: cause={c_val:.3f}, effet={e_val:.3f}"")",,,,,,,,2ef57f9cdd9f903b,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,2f73fae8,markdown,fr,ece98ec9369bf7e1,"### Interpretation : un mecanisme qui ne specifie aucune information
+
+Les deux repertoires sont **uniformes** (`[0.5, 0.5]`) : le mecanisme {A, B} dans son etat actuel ne contraint **ni** le passe **ni** le futur du purview {A}.
+
+- En **cause**, savoir que {A, B} = (0, 1) ne modifie pas la probabilite des etats anterieurs de A : les deux restent equiprobables.
+- En **effet**, ce meme mecanisme ne biaise pas davantage l'etat futur de A.
+
+Autrement dit, ce couple (mecanisme, purview) **ne specifie aucune information** : son repertoire contraint est identique au repertoire non-perturbe (uniforme). C'est exactement ce que la section suivante va quantifier — la distance EMD entre le repertoire contraint et le repertoire non-perturbe sera **nulle**, confirmant l'absence d'information specifiee.
+
+> A l'inverse, un purview informatif produirait une distribution **non uniforme** (par exemple `[0.75, 0.25]`), revelant que le mecanisme penche vers un etat particulier du purview. C'est ce contraste qui fonde la notion de *small phi* ($\varphi$) etudiee plus loin.",,,,,,,,ece98ec9369bf7e1,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,657313aa,markdown,fr,f8f3d95ecc196a5c,"### 3.2. Repertoire non-perturbe (unconstrained)
+
+Le repertoire **non-perturbe** est la distribution uniforme - ce qu'on attendrait sans aucune contrainte. La difference entre le repertoire contraint et le repertoire non-perturbe mesure **l'information specifiee** par le mecanisme.",,,,,,,,f8f3d95ecc196a5c,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,df6b5078,code,fr,6debafc98d61bd8f,"# Repertoire non-perturbe (uniforme)
+unconstrained = subsystem.unconstrained_cause_repertoire(purview)
+print(f""Repertoire non-perturbe pour purview {purview}:"")
+print(f""  Valeurs: {unconstrained.flatten()}"")
+
+from pyphi.distance import hamming_emd
+distance = hamming_emd(cause_rep, unconstrained)
+print(f""\nDistance EMD (cause contrainte vs non-perturbe): {distance:.4f}"")
+print(""Cette valeur mesure l'information cause specifiee par le mecanisme."")",,,,,,,,6debafc98d61bd8f,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,37ab70b5,markdown,fr,348601d798a9bba5,"### Exercice 1 : Explorer les repertoires d'un mecanisme different
+
+Calculez les repertoires cause et effet pour le mecanisme `{A, C}` (noeuds 0 et 2) avec le purview `{B, C}` (noeuds 1 et 2).
+
+**Objectifs** :
+1. Calculer le repertoire cause et le repertoire effet
+2. Verifier que chaque repertoire somme a 1.0
+3. Identifier quel etat du purview est le plus probable en cause et en effet
+
+**Indices** :
+- Utilisez `subsystem.cause_repertoire(mechanism, purview)` et `subsystem.effect_repertoire(mechanism, purview)`
+- Les noeuds sont indices par des tuples d'entiers : `(0, 2)` pour {A, C}
+- Pour identifier l'etat le plus probable, utilisez `np.argmax(rep.flatten())`",,,,,,,,348601d798a9bba5,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,d2e2ca39,code,fr,529fc133f4283138,"# Exercice 1 : Repertoires cause-effet pour le mecanisme {A, C} et purview {B, C}
+# TODO etudiant : remplacez les valeurs None par votre code
+
+mechanism_ex1 = None  # TODO : definir le mecanisme {A, C}
+purview_ex1 = None    # TODO : definir le purview {B, C}
+
+if mechanism_ex1 is not None and purview_ex1 is not None:
+    cause_rep_ex1 = subsystem.cause_repertoire(mechanism_ex1, purview_ex1)
+    effect_rep_ex1 = subsystem.effect_repertoire(mechanism_ex1, purview_ex1)
+    
+    print(f""Repertoire cause: {cause_rep_ex1.flatten()}"")
+    print(f""Somme cause: {cause_rep_ex1.sum():.4f}"")
+    print(f""Etat le plus probable (cause): {np.argmax(cause_rep_ex1.flatten())}"")
+    print(f""\nRepertoire effet: {effect_rep_ex1.flatten()}"")
+    print(f""Somme effet: {effect_rep_ex1.sum():.4f}"")
+    print(f""Etat le plus probable (effet): {np.argmax(effect_rep_ex1.flatten())}"")
+else:
+    print(""Exercice a completer : definissez mechanism_ex1 et purview_ex1"")",,,,,,,,529fc133f4283138,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,794af9b1,markdown,fr,deca7991dd91d2db,"<a id=""sec4""></a>
+## 4. MICE et Concepts
+
+Un **MICE** (Maximally Irreducible Cause or Effect) est un couple (mecanisme, purview) qui maximise l'information irreductible. Un **concept** est forme d'un MICE cause et d'un MICE effet pour le meme mecanisme.
+
+### 4.1. Trouver le MICE pour un mecanisme",,,,,,,,deca7991dd91d2db,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,db338713,code,fr,8e27f22ddc890989,"# Trouver le MICE (cause et effet) pour le mecanisme {A, B}
+mechanism = (0, 1)
+
+mice_cause = subsystem.find_mice(pyphi.Direction.CAUSE, mechanism)
+mice_effect = subsystem.find_mice(pyphi.Direction.EFFECT, mechanism)
+
+print(""=== MICE pour le mecanisme {A, B} ==="")
+print(""\nMICE Cause:"")
+print(f""  Purview: {mice_cause.purview}"")
+print(f""  Phi (small): {mice_cause.phi}"")
+print(f""  Direction: {mice_cause.direction}"")
+print(""\nMICE Effet:"")
+print(f""  Purview: {mice_effect.purview}"")
+print(f""  Phi (small): {mice_effect.phi}"")
+print(f""  Direction: {mice_effect.direction}"")",,,,,,,,8e27f22ddc890989,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,75240176,code,fr,4a0ef6f2aaeaef1e,"# Construire les concepts a partir de la CES
+ces = pyphi.compute.ces(subsystem)
+print(f""Nombre total de concepts dans la CES: {len(ces)}"")
+print(""\nDetails de chaque concept :"")
+for i, concept in enumerate(ces):
+    print(f""\n  Concept {i+1}:"")
+    print(f""    Mecanisme: {concept.mechanism}"")
+    if concept.cause:
+        print(f""    Cause purview: {concept.cause.purview}, phi={concept.cause.phi:.4f}"")
+    if concept.effect:
+        print(f""    Effet purview: {concept.effect.purview}, phi={concept.effect.phi:.4f}"")
+    print(f""    Phi du concept: {concept.phi:.4f}"")",,,,,,,,4a0ef6f2aaeaef1e,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,65b3f11e,markdown,fr,d5c042f84fb4ea3a,"### 4.2. Interpretation des MICE
+
+Chaque concept decrit une **unite d'information cause-effet** :
+- Le **mecanisme** est l'ensemble de noeuds qui specifie de l'information
+- Le **purview cause** est l'ensemble de noeuds dont le mecanisme contraint les etats passes
+- Le **purview effet** est l'ensemble de noeuds dont le mecanisme contraint les etats futurs
+- Le **small phi** ($\varphi$) mesure la quantite d'information irreductible du concept
+
+Un concept avec $\varphi > 0$ existe dans la CES du systeme. La somme de tous les $\varphi$ des concepts ne donne PAS le big $\Phi$.",,,,,,,,d5c042f84fb4ea3a,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,05b9d9f3,markdown,fr,916688e70c719ac0,"<a id=""sec5""></a>
+## 5. Big Phi vs Small Phi
+
+La distinction entre **big Phi** ($\Phi$) et **small phi** ($\varphi$) est fondamentale :
+
+| | Big Phi ($\Phi$) | Small phi ($\varphi$) |
+|---|---|---|
+| **Niveau** | Systeme entier | Mecanisme individuel |
+| **Mesure** | Integration irreductible du systeme | Information irreductible d'un concept |
+| **Question** | Le systeme est-il integre ? | Ce mecanisme specifie-t-il de l'information ? |
+| **Calcul** | SIA sur toutes les partitions | EMD entre repertoire contraint et partitionne |",,,,,,,,916688e70c719ac0,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,ff8235a8,code,fr,c30ecf378f211aad,"# Comparaison Big Phi vs Small Phi
+print(""=== Big Phi (niveau systeme) ==="")
+print(f""  Phi du systeme (SIA): {sia.phi:.4f}"")
+print(f""  Coupe minimale: {sia.cut}"")
+
+print(""\n=== Small Phi (niveau concept) ==="")
+total_small_phi = sum(c.phi for c in ces)
+print(f""  Nombre de concepts: {len(ces)}"")
+print(f""  Somme des small phi: {total_small_phi:.4f}"")
+for i, c in enumerate(ces):
+    print(f""    Concept {i+1}: mecanisme={c.mechanism}, phi={c.phi:.4f}"")
+
+print(f""\nBig Phi ({sia.phi:.4f}) != somme des small phi ({total_small_phi:.4f})"")
+print(""Ce sont deux mesures differentes a des niveaux differents."")",,,,,,,,c30ecf378f211aad,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,66feddff,markdown,fr,289dded7a6e333ed,"### Exercice 2 : Comparer Phi pour deux etats du reseau
+
+Calculez le big Phi et la CES pour le reseau XOR dans l'etat `(1, 1, 1)` et comparez avec l'etat `(0, 0, 0)`.
+
+**Objectifs** :
+1. Creer un nouveau sous-systeme pour l'etat `(1, 1, 1)`
+2. Calculer le SIA (big Phi) et la CES (concepts)
+3. Comparer les resultats avec l'etat `(0, 0, 0)`
+
+**Indices** :
+- `pyphi.Subsystem(network, state)` pour creer le sous-systeme
+- `pyphi.compute.sia(subsystem)` pour le big Phi
+- `pyphi.compute.ces(subsystem)` pour les concepts",,,,,,,,289dded7a6e333ed,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,061f5587,code,fr,990a726ba5189a47,"# Exercice 2 : Comparer Phi pour deux etats
+# TODO etudiant : remplacez les valeurs None par votre code
+
+state_2 = None  # TODO : definir l'etat (1, 1, 1)
+
+if state_2 is not None:
+    subsystem_2 = pyphi.Subsystem(network, state_2)
+    sia_2 = pyphi.compute.sia(subsystem_2)
+    ces_2 = pyphi.compute.ces(subsystem_2)
+    
+    print(f""Etat {state}: Big Phi = {sia.phi:.4f}, Concepts = {len(ces)}"")
+    print(f""Etat {state_2}: Big Phi = {sia_2.phi:.4f}, Concepts = {len(ces_2)}"")
+    print(f""\nDifference Big Phi: {abs(sia.phi - sia_2.phi):.4f}"")
+else:
+    print(""Exercice a completer : definissez state_2 = (1, 1, 1)"")",,,,,,,,990a726ba5189a47,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,f7ad96c3,markdown,fr,8ea4ad05e15b1822,"<a id=""sec6""></a>
+## 6. Reseaux elargis : systemes a 4+ noeuds
+
+Explorons un systeme plus grand pour observer comment la complexite de la CES evolue.
+
+### 6.1. Reseau XOR cyclique (4 noeuds)
+
+Nous construisons un reseau a 4 noeuds en anneau ou chaque noeud depend de lui-meme et de son voisin de gauche via XOR.",,,,,,,,8ea4ad05e15b1822,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,7c3636e5,code,fr,c70cd3a4ce4268e1,"# Reseau 4 noeuds en anneau - chaque noeud depend de lui-meme et de son voisin
+tpm_4 = np.zeros((16, 4))
+for i in range(16):
+    bits = [(i >> j) & 1 for j in range(3, -1, -1)]
+    a_next = bits[3] ^ bits[0]  # D XOR A
+    b_next = bits[0] ^ bits[1]  # A XOR B
+    c_next = bits[1] ^ bits[2]  # B XOR C
+    d_next = bits[2] ^ bits[3]  # C XOR D
+    tpm_4[i] = [a_next, b_next, c_next, d_next]
+
+cm_4 = np.array([
+    [1, 1, 0, 1],
+    [1, 1, 1, 0],
+    [0, 1, 1, 1],
+    [1, 0, 1, 1],
+])
+
+labels_4 = ('A', 'B', 'C', 'D')
+net_4 = pyphi.Network(tpm_4, cm_4, node_labels=labels_4)
+
+print(""Reseau 4 noeuds en anneau (XOR cyclique)"")
+print(""Labels:"", labels_4)
+print(""Connectivite:"")
+print(cm_4)",,,,,,,,c70cd3a4ce4268e1,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,6a77f701,code,fr,7cdbcc934f100b21,"# Analyser le reseau 4 noeuds
+state_4 = (0, 0, 0, 0)
+sub_4 = pyphi.Subsystem(net_4, state_4)
+
+print(f""Sous-systeme 4 noeuds, etat {state_4}"")
+print(f""Noeuds: {sub_4.node_indices}"")
+
+ces_4 = pyphi.compute.ces(sub_4)
+print(f""\nNombre de concepts: {len(ces_4)}"")
+for i, c in enumerate(ces_4):
+    cause_p = c.cause.purview if c.cause else None
+    effect_p = c.effect.purview if c.effect else None
+    print(f""  Concept {i+1}: mech={c.mechanism}, cause_p={cause_p}, ""
+          f""effect_p={effect_p}, phi={c.phi:.4f}"")",,,,,,,,7cdbcc934f100b21,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,8d85f950,code,fr,ca5848df8dbdb65f,"# Big Phi pour le reseau 4 noeuds
+sia_4 = pyphi.compute.sia(sub_4)
+print(f""Big Phi (4 noeuds): {sia_4.phi:.4f}"")
+print(f""Coupe MIP: {sia_4.cut}"")
+print(f""\nComparaison:"")
+print(f""  3 noeuds (XOR): Big Phi = {sia.phi:.4f}"")
+print(f""  4 noeuds (anneau): Big Phi = {sia_4.phi:.4f}"")",,,,,,,,ca5848df8dbdb65f,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,3b319dc9,markdown,fr,37993e81c8a7fb07,"### 6.2. Interpreter les resultats
+
+Quelques observations importantes :
+
+1. **Plus de noeuds ne signifie pas plus de Phi** : la valeur de $\Phi$ depend de la structure causale, pas de la taille
+2. **Les reseaux feed-forward ont Phi = 0** : pas de boucle causale = pas d'integration
+3. **Les reseaux recurrents** (comme notre anneau) peuvent avoir Phi > 0
+4. **La symetrie** de la connectivite influence la distribution des concepts",,,,,,,,37993e81c8a7fb07,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,cb35e6b0,markdown,fr,2888d726dbd4c846,"<a id=""sec7""></a>
+## 7. Performance et coarse-graining
+
+Le calcul exact de $\Phi$ croit de maniere **super-exponentielle** avec la taille du reseau. Pour des reseaux de plus de ~6-8 noeuds, le calcul devient intractable.
+
+### 7.1. Strategies de gestion de la complexite
+
+| Strategie | Principe | Utilite |
+|-----------|----------|----------|
+| **Coarse-graining** | Grouper les noeuds en macro-noeuds | Reduire la dimensionnalite |
+| **Blackboxing** | Ignorer certains noeuds | Se concentrer sur les noeuds pertinents |
+| **Parallelisation** | Repartir les calculs | Accelerer sur multi-coeur |
+| **Caching** | Stocker les resultats intermediaires | Eviter les recalculs |",,,,,,,,2888d726dbd4c846,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,9b87e0b1,code,fr,b9969faecb57c142,"# Demonstration du module macro
+print(""=== Module pyphi.macro ==="")
+print(""Le module macro offre des outils pour le coarse-graining et blackboxing."")
+print(""\nFonctions disponibles:"")
+macro_funcs = [f for f in dir(pyphi.macro) if not f.startswith('_')]
+for f in macro_funcs[:12]:
+    print(f""  - {f}"")",,,,,,,,b9969faecb57c142,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,cb65035f,code,fr,979149ad75d75ced,"# Mesurer le temps de calcul pour differentes tailles
+import time
+
+def time_phi_calc(network, state, label=""""):
+    """"""Mesure le temps de calcul de la CES pour un sous-systeme.""""""
+    sub = pyphi.Subsystem(network, state)
+    t0 = time.time()
+    ces_result = pyphi.compute.ces(sub)
+    elapsed = time.time() - t0
+    print(f""  {label}: {len(ces_result)} concepts, {elapsed:.2f}s"")
+    return elapsed
+
+print(""Temps de calcul CES par taille de reseau:"")
+t3 = time_phi_calc(network, (0,0,0), ""3 noeuds (XOR)"")
+t4 = time_phi_calc(net_4, (0,0,0,0), ""4 noeuds (anneau)"")
+
+if t3 > 0:
+    print(f""\nRatio 4noeuds/3noeuds: {t4/t3:.1f}x"")
+    print(""La croissance est super-lineaire."")",,,,,,,,979149ad75d75ced,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,ef98cea9,markdown,fr,a467db7203992a7b,"### 7.2. Implications pour la recherche en neuroscience
+
+Cette complexite computationnelle a des implications directes :
+
+- Le **cerveau humain** (~86 milliards de neurones) ne peut pas etre analyse avec le calcul exact
+- Les **approximations** (coarse-graining, echantillonnage) sont necessaires
+- Le **Perturbational Complexity Index (PCI)** est une approximation clinique inspiree de $\Phi$
+- Le debat entre **exactitude mathematique** et **applicabilite pratique** est central",,,,,,,,a467db7203992a7b,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,3c659a56,markdown,fr,939c1cea3d1dd6b7,"<a id=""sec8""></a>
+## 8. Vers IIT 4.0
+
+### 8.1. D'IIT 3.0 a IIT 4.0
+
+| Aspect | IIT 3.0 (PyPhi) | IIT 4.0 (2024+) |
+|--------|-----------------|------------------|
+| **Identite** | Le complexe maximise $\Phi$ | Le systeme EST sa structure cause-effet |
+| **Existence intrinseque** | Via les concepts | Axiome fondamental |
+| **Coupes** | Bipartitions | Coupes directionnelles |
+| **Extension** | Potentiel a Phi maximal | Ensemble des systemes qui existent |",,,,,,,,939c1cea3d1dd6b7,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,0a3f0486,code,fr,999d356a918155ed,"# Apercu : le concept-style (vers IIT 4.0)
+try:
+    cs_sia = pyphi.compute.sia_concept_style(subsystem)
+    print(""=== Concept-Style SIA (vers IIT 4.0) ==="")
+    print(f""Phi (concept-style): {cs_sia.phi:.4f}"")
+    print(f""Phi (classique 3.0): {sia.phi:.4f}"")
+    diff = abs(cs_sia.phi - sia.phi)
+    print(f""Difference: {diff:.4f}"")
+    print(""Le concept-style utilise un schema de partition different."")
+except Exception as e:
+    print(f""Concept-style non disponible: {e}"")",,,,,,,,999d356a918155ed,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,c27d7dde,markdown,fr,89b815e68a66ea56,"### Exercice 3 : Explorer un reseau feed-forward
+
+Construisez un reseau feed-forward a 3 noeuds (A -> B -> C) et verifiez que son big Phi est egal a 0.
+
+**Objectifs** :
+1. Creer la TPM d'un reseau ou A influence B et B influence C (pas de boucle)
+2. Creer le reseau PyPhi avec la connectivite appropriee
+3. Calculer le big Phi et verifier qu'il vaut 0
+
+**Indices** :
+- La matrice de connectivite est triangulaire : `[[0,1,0], [0,0,1], [0,0,0]]`
+- Pour la TPM : B_next = A, C_next = B, A_next = A (ou une constante)
+- Utilisez `pyphi.compute.sia(subsystem)` pour calculer big Phi",,,,,,,,89b815e68a66ea56,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,49e7ee5e,code,fr,583d753ff3235640,"# Exercice 3 : Reseau feed-forward (Phi attendu = 0)
+# TODO etudiant : construisez le reseau et verifiez Phi = 0
+
+# Etape 1 : Definir la TPM (8 etats -> 3 noeuds)
+tpm_ff = None  # TODO : construire la TPM du reseau feed-forward
+
+# Etape 2 : Matrice de connectivite
+cm_ff = None   # TODO : A->B, B->C (pas de connexion C->A)
+
+if tpm_ff is not None and cm_ff is not None:
+    net_ff = pyphi.Network(tpm_ff, cm_ff)
+    sub_ff = pyphi.Subsystem(net_ff, (0, 0, 0))
+    sia_ff = pyphi.compute.sia(sub_ff)
+    print(f""Big Phi du reseau feed-forward: {sia_ff.phi:.4f}"")
+    print(f""Phi = 0 confirme: {sia_ff.phi == 0.0}"")
+    print(""Un reseau sans boucle causale n'a pas d'integration."")
+else:
+    print(""Exercice a completer : definissez tpm_ff et cm_ff"")",,,,,,,,583d753ff3235640,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,887aaea8,markdown,fr,acf69ccae6176a1a,"### 8.2. Limites et debats
+
+L'IIT est une theorie active et debattue :
+
+- **Lettre ouverte de 2023** : ~120 signataires qualifiant l'IIT de pseudoscience
+- **Reponse des partisans** : l'IIT fait des predictions falsifiables (PCI, activations)
+- **Programme Templeton** : tests adversariaux IIT vs Global Workspace Theory
+- **Enjeu IA** : l'IIT predit que les reseaux feed-forward (comme les LLMs) ont $\Phi = 0$
+
+Ces debats illustrent la tension entre **rigueur mathematique** et **applicabilite empirique**.",,,,,,,,acf69ccae6176a1a,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-2-AdvancedTopics.ipynb,3363b7ca,markdown,fr,6ebca8c4b394c1b1,"---
+
+## Bilan et perspectives
+
+Dans ce deuxieme notebook, nous avons approfondi :
+
+1. **Le partitionnement MIP** - la recherche de la coupe minimale d'information
+2. **Les repertoires cause-effet** - les distributions de probabilite au coeur de l'analyse IIT
+3. **Les MICE et concepts** - les unites d'information irreductible dans la CES
+4. **Big Phi vs Small Phi** - deux niveaux de mesure complementaires
+5. **Les reseaux elargis** - comment la complexite croit avec la taille du systeme
+6. **Le coarse-graining** - strategies pour gerer l'intractabilite du calcul
+7. **IIT 4.0** - les evolutions recentes de la theorie
+
+### Pour aller plus loin
+
+- **Documentation PyPhi** : [pyphi.readthedocs.io](https://pyphi.readthedocs.io/en/stable/)
+- **Article fondateur** : Oizumi, Albantakis, Tononi (2014). *From the Phenomenology to the Mechanisms of Consciousness*
+- **IIT 4.0** : Albantakis et al. (2023). *Integrated information theory (IIT) 4.0*
+- **Series connexes** : [Probas](../Probas/README.md), [GameTheory](../GameTheory/README.md)",,,,,,,,6ebca8c4b394c1b1,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,title,markdown,fr,5d19f5df2c58380a,"# IIT-3. Coarse-graining, blackboxing et l'échelle du $\Phi$ — le module `pyphi.macro`
+
+Les notebooks [Intro](IIT-1-IntroToPyPhi.ipynb) et [Sujets avancés](IIT-2-AdvancedTopics.ipynb) ont calculé $\Phi$ à l'**échelle micro** : un réseau de $N$ éléments binaires, et l'on partitionne, mesure la cause-effet structure, etc. Mais l'IIT pose une question plus profonde : **à quelle échelle spatiale l'information intégrée est-elle maximale ?** Un système de neurones microscopiques, une population neuronale coarse-grainée, ou une région macroscopique ?
+
+Ce notebook introduit le module `pyphi.macro`, qui permet de :
+
+- **coarse-grainer** des éléments : regrouper plusieurs nœuds micro en un seul élément macro (ex. agrégat d'indices d'une population neuronale) ;
+- **blackboxer** : traiter certains éléments comme des boîtes noires dont on ignore l'état interne ;
+- comparer l'**information efficace (EI)** et le **$\Phi$** entre l'échelle micro et l'échelle macro.
+
+**Avertissement honnête (Prong-B).** L'IIT prédit que le $\Phi$ macro peut *dépasser* le $\Phi$ micro (c'est la *causal emergence* de Hoel 2013, Albantakis & Tononi). Cette prédiction est **réelle et documentée** sur des réseaux probabilistes spécifiques. Mais elle n'est **pas automatique** : sur des réseaux déterministes simples, le coarse-grain ne crée pas d'emergence (le $\Phi$ macro $\approx$ le $\Phi$ micro). Ce notebook démontre donc la **méthode** (comment coarse-grainer, comment comparer les échelles) de manière fidèle, sans prétendre exhiber une emergence positive que le toy ne produit pas.",,,,,,,,5d19f5df2c58380a,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,setup-md,markdown,fr,bc5ab96f3f1f255e,"## 0. Setup — configuration de `pyphi`
+
+Le module `pyphi.macro` peut lancer des calculs parallèles. En notebook interactif, on force le mono-cœur pour des exécutions déterministes et reproductibles. On désactive aussi les barres de progression pour garder des sorties propres.",,,,,,,,bc5ab96f3f1f255e,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,setup-code,code,fr,9293a1461a97a662,"import warnings
+# pyemd (dependance de pyphi) emet un UserWarning de deprecation pkg_resources
+# sur Python 3.9 ; on le filtre pour garder des sorties propres (source-fix, pas scrub).
+warnings.filterwarnings(""ignore"", message=""pkg_resources is deprecated"")
+
+import pyphi
+import numpy as np
+
+# Mono-coeur deterministe + sorties propres (convention re-exec)
+pyphi.config.NUMBER_OF_CORES = 1
+pyphi.config.PROGRESS_BARS = False
+pyphi.config.WELCOME_OFF = True
+
+print(""pyphi"", pyphi.__version__)
+print(""module macro disponible :"", [x for x in dir(pyphi.macro) if not x.startswith(""_"")][:12], ""..."")",,,,,,,,9293a1461a97a662,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,micro-md,markdown,fr,1df31c856f209a1b,"## 1. L'échelle micro : information efficace et $\Phi$
+
+On reprend un petit réseau toy (3 nœuds logiques) et on mesure deux quantités :
+
+- l'**information efficace (EI)**, $EI = \mathrm{determinism} - \mathrm{degeneracy}$ (mesure de Hoel, indépendante de l'état) ;
+- le **$\Phi$** d'un sous-système dans un état donné (mesure d'intégration, dépend de l'état).
+
+Ces deux valeurs serviront de **référence micro** : on les comparera à leurs homologues macro après coarse-grain.",,,,,,,,1df31c856f209a1b,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,micro-code,code,fr,593a6afad25f17d3,"# Reseau micro toy : 3 noeuds, chacun copie l'etat du noeud 0 (reseau redondant deterministe)
+# TPM state-by-node : lignes = etats courants (000..111), colonnes = prochain etat de chaque noeud.
+def tpm_copy3():
+    tpm = np.zeros((8, 3))
+    for s in range(8):
+        bits = [(s >> (2 - i)) & 1 for i in range(3)]
+        nxt = [bits[0]] * 3   # tous copient le noeud 0
+        tpm[s] = nxt
+    return tpm
+
+tpm_micro = tpm_copy3()
+cm_micro = np.ones((3, 3))   # pleinement connecte
+net_micro = pyphi.Network(tpm_micro, cm_micro)
+print(""Reseau micro : 3 noeuds copy, TPM shape"", tpm_micro.shape)
+
+# Information efficace (Hoel) : mesure indépendante de l'état
+ei_micro = pyphi.macro.effective_info(net_micro)
+print(f""EI(micro) = {ei_micro:.4f}"")
+
+# Phi d'un sous-système dans un etat (mesure d'integration, depend de l'etat)
+sub_micro = pyphi.Subsystem(net_micro, (1, 1, 1))
+phi_micro = pyphi.compute.phi(sub_micro)
+print(f""Phi(micro, etat 111) = {phi_micro:.4f}"")",,,,,,,,593a6afad25f17d3,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,micro-interp,markdown,fr,7a50384a4d2cb2ea,"### Interprétation
+
+Sur ce réseau toy déterministe (chaque nœud copie le nœud 0), on observe :
+
+- **EI** vaut ici le maximum local d'un nœud déterministe, mais le réseau est **dégénéré** (les trois nœuds font la même chose), ce qui plafonne l'EI agrégée ;
+- **$\Phi$ micro = 0** : comme tous les nœuds sont identiques et déterministes, il n'y a pas d'**intégration** au sens de l'IIT (le système se réduit à une seule copie redondante). C'est attendu — un toy dégénéré n'est pas ""conscient"" au sens de l'IIT.
+
+Ce n'est pas un échec de la démo : c'est précisément le point de départ pour comprendre **pourquoi** le coarse-grain ne crée pas toujours d'emergence (cf. §4).",,,,,,,,7a50384a4d2cb2ea,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,grain-md,markdown,fr,515f903ba9c119b2,"## 2. La méthode du coarse-graining
+
+**Coarse-grainer** = regrouper plusieurs éléments micro en un seul élément macro, avec une règle de mapping d'états (ex. : ""deux nœuds micro à 1 → un nœud macro à 1""). Le module `pyphi.macro` expose `all_groupings` pour **énumérer** les regroupements possibles d'un ensemble de nœuds.
+
+Sur 3 nœuds, les regroupements possibles vont de ""tout séparé"" (3 macro-nœuds = échelle micro identique) à ""tout groupé"" (1 macro-nœud). Chaque regroupement définit une **échelle** différente à laquelle on peut recalculer $\Phi$.",,,,,,,,515f903ba9c119b2,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,grain-code,code,fr,8bf79465024d1c5b,"# Enumerer les partitions (regroupements de noeuds) possibles pour 3 noeuds
+partitions = list(pyphi.macro.all_partitions([0, 1, 2]))
+print(f""{len(partitions)} partitions possibles pour 3 noeuds :"")
+for p in partitions:
+    print("" "", p)",,,,,,,,8bf79465024d1c5b,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,grain-interp,markdown,fr,267254ac8d05f765,"Chaque tuple ci-dessus est un **particionnement** des nœuds micro : `((0, 1), (2,))` signifie ""les nœuds 0 et 1 forment un macro-nœud, le nœud 2 reste seul"". Pour chacun de ces regroupements, on pourrait reconstruire la TPM macro (en marginalisant les états internes du groupe) et recalculer $\Phi$.
+
+L'énumération exhaustive (via `pyphi.macro.phi_by_grain` ou `emergence`) **explose combinatoirement** : sur 4 nœuds elle dépasse largement la minute. C'est pourquoi, en notebook pédagogique, on se concentre sur un **regroupement spécifique** plutôt que sur l'énumération complète.",,,,,,,,267254ac8d05f765,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,macro-md,markdown,fr,304053437db555c7,"## 3. L'échelle macro : exemple canonique de `pyphi`
+
+Plutôt que de reconstruire manuellement une TPM macro (verbeux et sujet à la validation `ConditionallyDependentError`), on utilise l'**exemple canonique** fourni par les auteurs de pyphi : `pyphi.examples.macro_network()` et `macro_subsystem()`. Cet exemple est conçu pour illustrer précisément le module macro.",,,,,,,,304053437db555c7,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,macro-code,code,fr,e942502be7b791a2,"# Exemple canonique du module macro (concu par les auteurs de pyphi)
+net_macro_ex = pyphi.examples.macro_network()
+print(""macro_network : taille"", net_macro_ex.size, ""noeuds"")
+
+# EI a l'echelle macro
+ei_macro = pyphi.macro.effective_info(net_macro_ex)
+print(f""EI(macro exemple canonique) = {ei_macro:.4f}"")
+
+# Phi du subsystem macro (coarse-grained) dans un etat
+macro_sub = pyphi.examples.macro_subsystem()
+phi_macro = pyphi.compute.phi(macro_sub)
+print(f""Phi(macro_subsystem exemple) = {phi_macro:.4f}"")",,,,,,,,e942502be7b791a2,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,compare-code,code,fr,4b42569d19a7692e,"# Comparaison : meme reseau, vue micro (sous-systeme ""non coarse-graine"")
+micro_sub_ex = pyphi.Subsystem(net_macro_ex, (0, 0, 0, 0))
+phi_micro_ex = pyphi.compute.phi(micro_sub_ex)
+ei_micro_ex = pyphi.macro.effective_info(net_macro_ex)   # EI est definie au niveau reseau
+
+print(""=== Comparaison micro vs macro (exemple canonique 4-noeuds) ==="")
+print(f""  EI  (micro = macro, meme reseau) : {ei_micro_ex:.4f}"")
+print(f""  Phi (micro, sous-systeme brut)    : {phi_micro_ex:.4f}"")
+print(f""  Phi (macro, coarse-grained)      : {phi_macro:.4f}"")
+print(f""  Diff Phi (macro - micro)         : {phi_macro - phi_micro_ex:+.4f}"")",,,,,,,,4b42569d19a7692e,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,compare-interp,markdown,fr,b0378d26701fcb3e,"### Interprétation honnête
+
+Sur cet exemple canonique 4-nœuds, on constate que **$\Phi$ macro $\approx$ $\Phi$ micro** (différence quasi nulle). Cela **confirme empiriquement** l'avertissement du §0 : le coarse-grain ne crée **pas automatiquement** d'emergence positive.
+
+**Pourquoi ?** L'emergence positive (Hoel 2013) apparaît lorsque le coarse-grain **filtre du bruit** : si les nœuds micro sont *probabilistes* (bruit) et que le macro-nœud agrège plusieurs copies corrélées, la moyennisation réduit la variance et augmente l'EI. Sur des réseaux **déterministes** (comme nos toys), il n'y a pas de bruit à filtrer, donc pas de gain d'emergence.
+
+L'IIT prédit que sur des réseaux probabilistes spécifiques (cf. Albantakis, Marshall, Tononi), le $\Phi$ macro dépasse le $\Phi$ micro — mais exhiber ce cas proprement dans pyphi 1.2.0 stable exige une construction TPM probabiliste soignée (et des conditions d'indépendance conditionnelle strictes), qui dépasse le cadre d'un notebook d'introduction. Le résultat **qualitatif** à retenir : **l'échelle macro est une vraie dimension de l'analyse IIT**, et le module `pyphi.macro` fournit les outils pour l'explorer (EI, coarse-grain, blackbox), mais l'emergence positive n'est ni triviale ni garantie.",,,,,,,,b0378d26701fcb3e,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,exo-md,markdown,fr,dc37021ceb47d0d1,"## 4. Travaux pratiques
+
+Trois exercices pour explorer le module `pyphi.macro`. Les deux premiers sont accessibles ; le troisième invite à tester une hypothèse d'emergence.",,,,,,,,dc37021ceb47d0d1,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,exo1-md,markdown,fr,896e1ea0a759a407,"### Exercice 1 : information efficace d'un réseau AND
+
+Construire un réseau toy 3-nœuds où chaque nœud calcule un **AND** de ses deux entrées (et non une copie). Mesurer son `effective_info` et son $\Phi$ dans l'état `(1,1,1)`. Comparer à EI=1.0 du réseau copy ci-dessus : un réseau AND est-il plus ou moins dégénéré ?
+
+> **Indice :** TPM AND = pour chaque état courant, le prochain état du noeud i = AND de ses 2 voisins.
+> **Etape 1 :** construire la TPM (8 lignes, 3 colonnes).
+> **Etape 2 :** pyphi.Network(tpm_and, cm) puis pyphi.macro.effective_info(net).
+> **Etape 3 :** pyphi.Subsystem(net, (1,1,1)) puis pyphi.compute.phi(sub).",,,,,,,,896e1ea0a759a407,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,exo1-code,code,fr,6543c64c94067dc2,"# TODO etudiant : reseau AND 3-noeuds, mesurer EI et Phi
+# Indices ci-dessus.
+def tpm_and3():
+    return None  # TODO etudiant : votre TPM AND
+
+resultat_ei_and = None   # TODO etudiant
+resultat_phi_and = None  # TODO etudiant
+print(""Exercice a completer : reseau AND, EI et Phi"")",,,,,,,,6543c64c94067dc2,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,exo2-md,markdown,fr,eeab11d53d39722d,"### Exercice 2 : énumérer les regroupements d'un réseau à 4 nœuds
+
+Sur un réseau à 4 nœuds (ex. l'exemple canonique `pyphi.examples.macro_network()`), lister tous les regroupements possibles via `pyphi.macro.all_groupings(range(4))`. Compter combien il y en a. Quel regroupement correspond à ""tout grouper en un seul macro-nœud"" ?
+
+> **Indice :** all_partitions renvoie des tuples de tuples. Le regroupement ""tout groupé"" = ((0,1,2,3),).
+> **Etape 1 :** parts = list(pyphi.macro.all_partitions([0,1,2,3])).
+> **Etape 2 :** len(parts) donne le nombre. Chercher celui egal a ((0,1,2,3),).",,,,,,,,eeab11d53d39722d,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,exo2-code,code,fr,dcff84ad0ca38785,"# TODO etudiant : numerer les regroupements d'un reseau 4-noeuds
+def regroupements_4noeuds():
+    return None  # TODO etudiant : (nombre_total, regroupement_tout_groupe)
+
+resultat_exo2 = None  # TODO etudiant
+print(""Exercice a completer : regroupements 4-noeuds"")",,,,,,,,dcff84ad0ca38785,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,exo3-md,markdown,fr,e867acb9e9bc235c,"### Exercice 3 (ouvert) : tester une hypothèse d'emergence
+
+Sur le réseau copy 3-nœuds du §1, on a vu $\Phi$ micro = 0. Formulez une hypothèse : si l'on coarse-graine les 3 nœuds copy en un seul macro-nœud, le $\Phi$ macro sera-t-il strictement positif ? Construisez le macro-nœud (TPM 1-nœud identique, copie) et mesurez-le pour confirmer/réfuter.
+
+> **Indice :** un macro-nœud ""copy"" a une TPM [[0.0],[1.0]] (1 noeud, self-loop), cm=[[1]].
+> **Etape 1 :** macro_net = pyphi.Network(np.array([[0.0],[1.0]]), np.array([[1]])).
+> **Etape 2 :** pyphi.Subsystem(macro_net, (1,)) puis pyphi.compute.phi(sub).
+> **Question :** phi macro = 0 aussi ? Pourquoi (cf. interpretation §4) ?",,,,,,,,e867acb9e9bc235c,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,exo3-code,code,fr,e81f4cf569a6304c,"# TODO etudiant : tester l'hypothese d'emergence sur le copy-network coarse-graine
+def phi_macro_copy():
+    return None  # TODO etudiant : phi du macro-noeud copy
+
+resultat_exo3 = None  # TODO etudiant
+print(""Exercice a completer : hypothese d'emergence (copy-network coarse-graine)"")",,,,,,,,e81f4cf569a6304c,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,conclusion-md,markdown,fr,3eb556dfbef4218f,"## 5. Conclusion
+
+On a démontré la **méthode** du coarse-graining en IIT :
+
+- le module `pyphi.macro` expose `effective_info` (information efficace de Hoel), `all_groupings` (énumération des regroupements), et les objets `MacroSubsystem` / `MacroNetwork` pour travailler à une échelle agrégée ;
+- comparer $\Phi$ et EI entre micro et macro est **directement mesurable** (~5 s par calcul ciblé), mais l'énumération exhaustive (`emergence`, `phi_by_grain`) explose combinatoirement et reste réservée à la recherche ;
+- **l'emergence positive n'est ni automatique ni garantie** : elle apparaît sur des réseaux probabilistes où le coarse-grain filtre du bruit (Hoel 2013, Albantakis 2019), pas sur des toys déterministes comme ceux explorés ici.
+
+C'est précisément cette nuance — l'existence d'une dimension d'échelle dans l'IIT, sans prétendre que tout coarse-grain crée de l'emergence — qui distingue une démo méthodologique honnête d'une démonstration forcée.
+
+**Suite** : revoir [IIT-1-IntroToPyPhi](IIT-1-IntroToPyPhi.ipynb) §6 (macro-subsystems) et [IIT-2-AdvancedTopics](IIT-2-AdvancedTopics.ipynb) §7 (performance et coarse-graining comme stratégie de gestion de complexité).",,,,,,,,3eb556dfbef4218f,,,,,,,
+MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb,refs-md,markdown,fr,3954627c0f130fb4,"## Références
+
+- Hoel, E. P. (2017). *Agentive behavior and the causal powers of information*. (Causal emergence, effective information).
+- Albantakis, L., Marshall, W., Hoel, E., & Tononi, G. (2019). *The unfolding of intrinsic causal powers via information decomposition*.
+- Mayner, W. G. P. et al. (2018). *PyPhi: A toolbox for integrated information theory*. PLOS Comp. Biol. (module `pyphi.macro`).
+- PyPhi documentation : `pyphi.macro` (coarse-grain, blackbox, emergence).",,,,,,,,3954627c0f130fb4,,,,,,,


### PR DESCRIPTION
## Livrable

11e série Phase 2 du rollout CSV-by-series (#4957) : `translations/iit/iit.csv` + `translations/iit/README.md` pour les **29 notebooks** sous `MyIA.AI.Notebooks/IIT/` (3 IIT PyPhi + 26 ICT-Series).

### Métriques
| | |
|---|---|
| Notebooks | 29 |
| Cellules extraites | **731** (428 markdown + 303 code) |
| Cellules sautées (sans id nbformat) | 7 (non traduisibles fiablement) |
| Schéma | 21 colonnes (sha256-16, FR pivot + 7 langues cibles) |
| Taille | 743 KB |

## Validation (CPU-doable, honnête)
- **T1 déterminisme** : re-extract → diff byte-identique (0 drift).
- **T2 drift-check** : `check_translation_sync.py translations/iit/iit.csv` → `{"csvs_checked":1,"anomalies":[],"anomaly_count":0}` (IN_SYNC).
- **Anti-doublon** : 0 doublon `(notebook, cell_id)`.
- **Secret-scan** : 0 match (sk-/ghp_/AIza/bearer).
- **Méthode hash** : sha256-16 normalisé via `scripts/translation/extract_cells_to_csv.py` (pas de hash deviné — angle-mort bot reviewer connu).

## Conformité
- Additif pur `+N/-0` (nouveau `translations/iit/`, pas d'écrasement).
- catalogue intact (CSV vit hors-catalogue, R1 catalog-pr-hygiene).
- README FR (readme-french-first, style série probas-infer).
- Owner po-2025 (strate-5, Epic #4588 + #5681).

## Smell signalé (hors-scope, au dashboard coord)
`ICT-19` en **double** : `ICT-19-EnjeuBattery.ipynb` + `ICT-19-EnjeuBattery-Raffinement.ipynb`. Les deux extraits tels quels (le CSV suit la réalité du dépôt). Numéro dupliqué à clarifier en sujet séparé.

`See #4957` (contribution Phase 2 — 1 série sur N du rollout CSV-by-series ; #4957 Epic reste ouverte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
