### PR TITLE
Seed CSV RL (Phase 2 #4957, 17 notebooks)

### DIFF
--- a/translations/rl/README.md
+++ b/translations/rl/README.md
@@ -1,0 +1,50 @@
+# translations/rl — synchro traduction i18n (#4957 Phase 2)
+
+## Couverture
+
+| Métrique | Valeur |
+|----------|--------|
+| Série source | `MyIA.AI.Notebooks/RL/` (reinforcement learning — DQN, PPO, SAC, GRPO, multi-agent, Python) |
+| Notebooks source | **17** (rl_1 intro cartpole → rl_13 curiosity/exploration, + sous-séries rl_6b/6c/6d/6e) |
+| Cellules extraites | **486** (275 markdown + 211 code, nbformat canonique, 95 % avec id stable) |
+| Taille CSV | ~450 KB (486 enregistrements × 21 colonnes) |
+| Langue pivot | **fr** (PIVOT_LANG = "fr", cf #1650 Phase 0.5 / #4980 Lean i18n) |
+| Langues cibles | **en, es, ar, fa, zh, ru, pt** (7 langues vivantes côté Argumentum) |
+| Date seed | 2026-07-10 |
+| Source seed | PR THIS (Phase 2 rollout RL, 12e série) |
+
+## Workflow T0→T3
+
+T0 (catalogue CSV) **LIVRÉ** : le CSV seed `rl.csv` capture la substance canonique de la série au commit `a93a08e21`. Chaque enregistrement = `notebook, cell_id, cell_type, src_lang, src_hash, text_fr, text_<7 langues>, hash_fr, hash_<7 hash>`. Les hashes `sha256-16` sur le texte normalisé (rstrip lines + strip newlines) détectent les dérives cellule-par-cellule.
+
+T1 (extraction) **LIVRÉ** : `python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/RL/ -o translations/rl/rl.csv --src-lang fr --repo-root .`. Script déterministe byte-identique. Exclut `_output.ipynb` (Papermill) et `_agent.ipynb` (auto-générés). 486/511 cellules markdown/code extraites (25 sans id nbformat stable sautées).
+
+T2 (drift detector) **LIVRÉ** : `python scripts/translation/check_translation_sync.py translations/rl/rl.csv` → `{"csvs_checked": 1, "anomalies": [], "anomaly_count": 0}` (IN_SYNC round-trip). Workflow CI `.github/workflows/translation-drift.yml` non-bloquant read-only.
+
+T3 (moteur Argumentum) **GATED** : run du moteur #1650 Phase 1 (connecteur Argumentum → fill des colonnes `text_<lang>`). Reste gated sur l'activation du connecteur.
+
+## Régénération manuelle
+
+```bash
+python scripts/translation/extract_cells_to_csv.py \
+    MyIA.AI.Notebooks/RL/ \
+    -o translations/rl/rl.csv --src-lang fr --repo-root .
+python scripts/translation/check_translation_sync.py translations/rl/rl.csv
+```
+
+Anomalies attendues (T3 non livré) : `TRAD_DRIFT` sur les `text_<lang>`/`hash_<lang>` vides (normal tant que T3 n'a pas rempli). `SRC_DRIFT` = changement upstream → relancement T1.
+
+## Liaison upstream
+
+- EPIC parent **#4957** (CSV-by-series + CI drift-flag + resync manuelle Argumentum)
+- Phase 0.5 **#1650** (Argumentum connecteur + moteur de traduction)
+- Substance lane **#3360** (RL reward-shaping bug, po-2025) + série RL
+- Voisin seed **translations/iit/** (série précédente Phase 2, PR parallèle)
+
+## Conformité règles
+
+- **L327 `+N/-0` purement additif** : nouveau répertoire `rl/`, nouveau CSV + README.
+- **catalog-pr-hygiene R1** : catalogue intact (CSV vit hors catalogue, sous `translations/`).
+- **L335 anti-monoculture** : substance neuve Phase 2 (RL), variée vs IIT livré parallèle.
+- **readme-french-first** : README rédigé en français (FR pivot Phase 0.5).
+- **Stop & Repair** : pas de hand-edit de cellule — le CSV est un artefact dérivé déterministe (T1 determinism byte-identique vérifié).

--- a/translations/rl/rl.csv
+++ b/translations/rl/rl.csv
@@ -1,0 +1,8104 @@
+notebook,cell_id,cell_type,src_lang,src_hash,text_fr,text_en,text_es,text_ar,text_fa,text_zh,text_ru,text_pt,hash_fr,hash_en,hash_es,hash_ar,hash_fa,hash_zh,hash_ru,hash_pt
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,21abd042,markdown,fr,bf9631122e8358e7,"# RL-10 : Reward Shaping et Curriculum Learning
+
+**Notebook : 10/13** | **Duree** : 45-50 min | **Kernel** : Python 3
+
+Dans les notebooks precedents, l'agent apprenait a partir du signal de recompense brut de l'environnement.
+Mais que se passe-t-il quand la recompense est **sparse** (nulle partout sauf au but) ? L'agent peut mettre
+des centaines d'episodes a trouver le but par hasard, puis des centaines d'autres pour apprendre le chemin.
+
+Ce notebook presente trois techniques pour accelerer l'apprentissage :
+
+1. **Reward shaping** : modifier le signal de recompense pour guider l'agent (sans changer la politique optimale !)
+2. **Curriculum learning** : commencer par des taches faciles et augmenter progressivement la difficulte
+3. **Analyse theorique** : pourquoi le potential-based shaping (Ng et al., 1999) garantit l'invariance de la politique
+
+**Prerequis** : Notebooks 5 (MDP, Q-Learning) et 8 (model-based RL, planification).
+",,,,,,,,bf9631122e8358e7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,31470d34,markdown,fr,c90272d9e5e59832,"## 1. Environnement : Labyrinthe Sparse
+
+Un labyrinthe 8x8 avec des murs internes. La recompense est **sparse** : -1 par pas, 0 au but.
+L'agent commence en bas a gauche, le but est en haut a droite (distance Manhattan = 14 pas).
+",,,,,,,,c90272d9e5e59832,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,56a9d2b4,code,fr,a9723e3ca1115246,"import numpy as np
+import matplotlib.pyplot as plt
+
+SEED = 42
+ALPHA, GAMMA, EPSILON = 0.1, 0.99, 0.1
+MAX_STEPS = 500
+ACTIONS = [(-1, 0), (1, 0), (0, -1), (0, 1)]  # haut, bas, gauche, droite
+
+class SparseMaze:
+    """"""Labyrinthe 8x8 avec reward sparse.""""""
+    def __init__(self):
+        self.height, self.width = 8, 8
+        self.start = (7, 0)
+        self.goal = (0, 7)
+        self.walls = set()
+        for r in range(1, 7):
+            if r != 3:  # passage au milieu
+                self.walls.add((r, 4))
+        self.n_states = self.height * self.width
+        self.n_actions = 4
+
+    def idx(self, s):
+        return s[0] * self.width + s[1]
+
+    def reset(self):
+        return self.start
+
+    def step(self, s, a):
+        dr, dc = ACTIONS[a]
+        r2, c2 = s[0] + dr, s[1] + dc
+        if not (0 <= r2 < self.height and 0 <= c2 < self.width) or (r2, c2) in self.walls:
+            r2, c2 = s
+        s2 = (r2, c2)
+        if s2 == self.goal:
+            return s2, 0.0, True
+        return s2, -1.0, False
+
+    def manhattan(self, s):
+        """"""Distance de Manhattan au but.""""""
+        return abs(s[0] - self.goal[0]) + abs(s[1] - self.goal[1])
+
+def epsilon_greedy(Q, s_idx, n_actions, eps, rng):
+    if rng.random() < eps:
+        return rng.integers(n_actions)
+    q = Q[s_idx]
+    return rng.choice(np.flatnonzero(q == q.max()))
+
+def plot_maze(env, title=""Sparse Maze 8x8""):
+    fig, ax = plt.subplots(figsize=(6, 6))
+    for r in range(env.height):
+        for c in range(env.width):
+            if (r, c) in env.walls:
+                ax.add_patch(plt.Rectangle((c, r), 1, 1, color='#2c3e50'))
+            else:
+                ax.add_patch(plt.Rectangle((c, r), 1, 1, fill=False, edgecolor='gray'))
+    ax.plot(env.start[1] + 0.5, env.start[0] + 0.5, 'bo', ms=15, label='Start')
+    ax.plot(env.goal[1] + 0.5, env.goal[0] + 0.5, 'g*', ms=20, label='Goal')
+    ax.set_xlim(0, env.width); ax.set_ylim(env.height, 0)
+    ax.set_title(title); ax.legend(loc='lower right')
+    ax.set_aspect('equal')
+    plt.tight_layout()
+    plt.show()
+
+env = SparseMaze()
+plot_maze(env)
+print(f""Distance Manhattan optimale : {env.manhattan(env.start)} pas"")
+",,,,,,,,a9723e3ca1115246,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,656dc43e,markdown,fr,83ffcf9ab44fa48d,"## 2. Q-Learning avec Reward Shaping
+
+### Principe du Reward Shaping
+
+On remplace la recompense $r$ par $r + F(s, a, s')$ ou $F$ est une fonction de **shaping**.
+Le risque : si $F$ est mal choisie, la politique optimale peut changer !
+
+### Potential-Based Shaping (Ng et al., 1999)
+
+Si $F(s, s') = \gamma \cdot \Phi(s') - \Phi(s)$ ou $\Phi$ est un **potentiel**, alors la politique
+optimale est **garantie inchangee**. Seule la vitesse de convergence est affectee.
+
+Nous choisissons $\Phi(s) = -$ manhattan$(s, \text{goal})$ (plus proche du but = potentiel plus eleve).
+",,,,,,,,83ffcf9ab44fa48d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,2d7964c9,code,fr,57872914a333898e,"def q_learning(env, n_episodes, reward_fn=None, seed=0):
+    """"""Q-learning avec reward_fn optionnelle.""""""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((env.n_states, env.n_actions))
+    rewards_per_ep = []
+    for ep in range(n_episodes):
+        s = env.reset()
+        total_r = 0.0
+        for _ in range(MAX_STEPS):
+            si = env.idx(s)
+            a = epsilon_greedy(Q, si, env.n_actions, EPSILON, rng)
+            s2, r, done = env.step(s, a)
+            if reward_fn is not None:
+                r_shaped = reward_fn(env, s, a, s2, r, done)
+            else:
+                r_shaped = r
+            target = r_shaped if done else r_shaped + GAMMA * Q[env.idx(s2)].max()
+            Q[si, a] += ALPHA * (target - Q[si, a])
+            total_r += r  # reward originale pour le logging
+            if done:
+                break
+            s = s2
+        rewards_per_ep.append(total_r)
+    return Q, rewards_per_ep
+
+def potential_shaping(env, s, a, s2, r, done):
+    """"""F(s,s') = gamma*phi(s') - phi(s), avec phi = -manhattan.""""""
+    phi_s = -env.manhattan(s)
+    phi_s2 = 0.0 if done else -env.manhattan(s2)
+    return r + GAMMA * phi_s2 - phi_s
+
+def heuristic_shaping(env, s, a, s2, r, done):
+    """"""Shaping naif : +2 par pas plus proche du but (NON potential-based).""""""
+    old_d = env.manhattan(s)
+    new_d = env.manhattan(s2) if not done else 0
+    return r + 2.0 * (old_d - new_d)
+
+N_EP = 2000
+SEEDS = [0, 1, 7, 42, 99]
+
+results = {}
+for name, reward_fn in [
+    (""Baseline"", None),
+    (""Potential-based"", lambda env, s, a, s2, r, done: potential_shaping(env, s, a, s2, r, done)),
+    (""Heuristic"", lambda env, s, a, s2, r, done: heuristic_shaping(env, s, a, s2, r, done)),
+]:
+    all_rews = []
+    for seed in SEEDS:
+        Q, rew = q_learning(env, N_EP, reward_fn=reward_fn, seed=seed)
+        all_rews.append(rew)
+    mean_rew = np.mean(all_rews, axis=0)
+    results[name] = mean_rew
+    print(f""{name}: reward final (MA-50) = {np.mean(mean_rew[-50:]):.1f}"")
+",,,,,,,,57872914a333898e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,825ec572,markdown,fr,9d860b395ad1d80d,"## 3. Curriculum Learning
+
+Le curriculum learning (Bengio et al., 2009) consiste a presenter les exemples
+dans un ordre de difficulte croissante. Ici, on commence l'agent pres du but
+puis on eloigne progressivement le point de depart.
+",,,,,,,,9d860b395ad1d80d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,3958a4f6,code,fr,ee2ca0e3aeafa5ad,"def curriculum_learning(env, n_episodes, seed=0):
+    """"""Curriculum : commencer pres du but, puis s'eloigner.""""""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((env.n_states, env.n_actions))
+    rewards_per_ep = []
+    starts = [(0, 7), (1, 6), (3, 4), (5, 2), (7, 0)]
+    eps_per_phase = n_episodes // len(starts)
+    for phase, start_pos in enumerate(starts):
+        for ep in range(eps_per_phase):
+            if phase < len(starts) - 1 and rng.random() < 0.3:
+                s = env.start
+            else:
+                s = start_pos
+            total_r = 0.0
+            for _ in range(MAX_STEPS):
+                si = env.idx(s)
+                a = epsilon_greedy(Q, si, env.n_actions, EPSILON, rng)
+                s2, r, done = env.step(s, a)
+                target = r if done else r + GAMMA * Q[env.idx(s2)].max()
+                Q[si, a] += ALPHA * (target - Q[si, a])
+                total_r += r
+                if done:
+                    break
+                s = s2
+            rewards_per_ep.append(total_r)
+    return Q, rewards_per_ep
+
+all_curr = []
+for seed in SEEDS:
+    _, rew = curriculum_learning(env, N_EP, seed=seed)
+    all_curr.append(rew)
+results[""Curriculum""] = np.mean(all_curr, axis=0)
+print(f""Curriculum: reward final (MA-50) = {np.mean(results['Curriculum'][-50:]):.1f}"")
+",,,,,,,,ee2ca0e3aeafa5ad,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,f8aa2937,markdown,fr,fd4fece64daf8ec8,"## 4. Comparaison des vitesses d'apprentissage
+
+Le graphique ci-dessous compare les courbes d'apprentissage (moyenne mobile sur 50 episodes)
+des 4 methodes. La ligne horizontale en pointilles marque le seuil de convergence.
+",,,,,,,,fd4fece64daf8ec8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,f9466604,code,fr,947ad4132853fef7,"def moving_avg(data, window=50):
+    return np.convolve(data, np.ones(window) / window, mode='valid')
+
+fig, ax = plt.subplots(figsize=(10, 5))
+colors = {'Baseline': '#e74c3c', 'Potential-based': '#27ae60',
+          'Heuristic': '#f39c12', 'Curriculum': '#3498db'}
+
+for name, rews in results.items():
+    ma = moving_avg(rews, 50)
+    ax.plot(range(50, len(ma) + 50), ma, label=name, color=colors[name], linewidth=2)
+
+ax.axhline(y=-30, color='gray', linestyle='--', alpha=0.5, label='Seuil convergence')
+ax.set_xlabel('Episodes')
+ax.set_ylabel('Return (MA-50)')
+ax.set_title('Vitesse d\'apprentissage : Reward Shaping vs Curriculum')
+ax.legend()
+ax.grid(True, alpha=0.3)
+plt.tight_layout()
+plt.show()
+
+# Vitesse : episodes pour atteindre MA-50 >= -30
+print(""Episodes pour atteindre un return moyen >= -30 (MA-50) :"")
+for name, rews in results.items():
+    ma = moving_avg(rews, 50)
+    idx = np.where(ma >= -30)[0]
+    ep = idx[0] + 50 if len(idx) > 0 else N_EP
+    print(f""  {name:<20} -> episode {ep}"")
+",,,,,,,,947ad4132853fef7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,a4717ba9,markdown,fr,84c74b226d0a3499,"## 5. Pourquoi le Potential-Based Shaping fonctionne
+
+### Theoreme (Ng, Harada & Russell, 1999)
+
+Soit un MDP $M = (S, A, P, R, \gamma)$ et un MDP modifie $M' = (S, A, P, R + F, \gamma)$
+ou $F(s, s') = \gamma \cdot \Phi(s') - \Phi(s)$. Alors les politiques optimales de $M$ et $M'$ sont **identiques**.
+
+### Demonstration intuitive
+
+La valeur modifiee $Q'(s, a) = Q^*(s, a) + \Phi(s)$ : le potentiel s'ajoute comme un biais constant
+par etat, qui ne change pas l'ordre relatif des actions. L'argmax est preserve.
+
+**Attention au shaping naif :** Le shaping heuristique $F(s, s') = 2 \cdot (d(s) - d(s'))$ n'est PAS potential-based
+(il n'existe pas de $\Phi$ tel que $F = \gamma \Phi(s') - \Phi(s)$). Dans certains environnements,
+ce type de shaping peut induire une politique sous-optimale en recompensant un chemin
+qui semble bon selon l'heuristique mais qui ne l'est pas.
+",,,,,,,,84c74b226d0a3499,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,903f701a,code,fr,1475c5d760e43d9e,"# Verification : potential-based shaping preserve Q* + phi(s)
+Q_base, _ = q_learning(env, N_EP, seed=SEED)
+Q_pot, _ = q_learning(env, N_EP,
+    reward_fn=lambda env, s, a, s2, r, done: potential_shaping(env, s, a, s2, r, done),
+    seed=SEED)
+
+# Au start, les actions optimales doivent etre les memes
+si = env.idx(env.start)
+print(f""Q* au start (baseline) :    {Q_base[si]}"")
+print(f""Q' au start (potential) :   {Q_pot[si]}"")
+print(f""Action optimale baseline :  {Q_base[si].argmax()} ({['haut','bas','gauche','droite'][Q_base[si].argmax()]})"")
+print(f""Action optimale potential : {Q_pot[si].argmax()} ({['haut','bas','gauche','droite'][Q_pot[si].argmax()]})"")
+print(f""\nLes actions optimales sont identiques : {Q_base[si].argmax() == Q_pot[si].argmax()}"")
+",,,,,,,,1475c5d760e43d9e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,8b134ff8,markdown,fr,adcbc5978c221436,"## 6. Du Reward Shaping au RLHF
+
+Les idees de ce notebook connectent directement avec les techniques modernes d'alignement des LLMs :
+
+| Concept RL classique | Equivalent LLM alignment |
+|---------------------|--------------------------|
+| Reward shaping manuel | Reward model appris (RLHF) |
+| Potential-based shaping | Contrainte KL (PPO-RLHF) |
+| Curriculum learning | Progressive training (SFT -> RLHF) |
+| Inverse RL | Learning from human preferences |
+
+**RLHF** (Reinforcement Learning from Human Feedback) est un reward shaping appris :
+au lieu de definir manuellement $\Phi(s)$, on entraine un **reward model** a partir de preferences humaines,
+puis on utilise ce modele comme signal de recompense. La contrainte KL dans PPO-RLHF joue un role similaire
+au potentiel : elle empeche la politique de trop s'ecarter de la reference.
+
+**DPO** (Direct Preference Optimization) elimine completement le reward model en optimisant
+directement sur les paires de preferences — cf. notebook 9 (RL offline, DPO = preference learning offline).
+",,,,,,,,adcbc5978c221436,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,af41c2fd,markdown,fr,149fc79ec92900f6,"## 7. Exercices
+
+### Exercice 1 : Ablation de la fonction de potentiel
+
+Testez d'autres fonctions de potentiel $\Phi(s)$ :
+- $\Phi(s) = -$ distance Euclidienne
+- $\Phi(s) = $ constante (pas de shaping)
+- $\Phi(s) = -2 \times$ manhattan (amplification)
+
+Laquelle accélère le plus la convergence ? Le potentiel constant change-t-il la politique ?
+",,,,,,,,149fc79ec92900f6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,f4ad72ca,code,fr,191eebd3f0763dbe,"# Exercice 1 : Ablation de la fonction de potentiel
+# TODO : implementez 3 fonctions de potentiel differentes et comparez
+# Hint : modifiez potential_shaping() avec differentes fonctions phi
+
+phi_functions = {
+    # ""Euclidean"": lambda s: ...,
+    # ""Constant"": lambda s: ...,
+    # ""Amplified"": lambda s: ...,
+}
+
+result = None  # TODO etudiant
+print(""Exercice a completer : comparez les vitesses de convergence"")
+",,,,,,,,191eebd3f0763dbe,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,deb247eb,markdown,fr,7e91f39b650fafa7,"### Exercice 2 : Curriculum avec nombre de phases variable
+
+Faites varier le nombre de phases du curriculum (2, 3, 5, 10 phases) et observez
+l'impact sur la vitesse de convergence. Y a-t-il un optimum ?
+",,,,,,,,7e91f39b650fafa7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,241f2380,code,fr,a09b693c513ff22c,"# Exercice 2 : Curriculum avec nombre de phases variable
+# TODO : implementez curriculum_learning avec n_phases variable
+# Hint : divisez le chemin start->goal en n_phases etapes intermediaires
+
+result = None  # TODO etudiant
+print(""Exercice a completer : comparez 2, 3, 5 et 10 phases de curriculum"")
+",,,,,,,,a09b693c513ff22c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,fcaa309a,markdown,fr,b3ccdbbca854e394,"### Exercice 3 : Shaping naif qui biaise la politique
+
+Construisez un environnement ou le shaping heuristique (non potential-based) conduit
+a une politique **sous-optimale**. Indice : un environnement avec un ""leurre"" (etat proche
+selon l'heuristique mais eloigne du vrai but).
+",,,,,,,,b3ccdbbca854e394,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,d5fb3617,code,fr,3e707028609cec2f,"# Exercice 3 : Construire un environnement ou le heuristic shaping biaise
+# TODO : creez un maze avec un ""leurre"" et montrez que heuristic_shaping
+# conduit a une politique sous-optimale contrairement a potential_shaping
+#
+# Etapes :
+# 1. Definir un maze avec un passage leurre (court mais sous-optimal)
+# 2. Lancer Q-learning avec heuristic_shaping
+# 3. Comparer avec baseline et potential_shaping
+# 4. Montrer que l'action optimale au start differe
+
+result = None  # TODO etudiant
+print(""Exercice a completer : montrez un biais du heuristic shaping"")
+",,,,,,,,3e707028609cec2f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_10_reward_shaping.ipynb,81af226a,markdown,fr,4a7f5d69d39918c0,"## Conclusion
+
+Dans ce notebook nous avons vu que :
+
+1. **Le reward shaping potentiel** (Ng et al., 1999) accelere la convergence sans modifier la politique
+   optimale. La cle est $F(s,s') = \gamma\Phi(s') - \Phi(s)$.
+2. **Le curriculum learning** organise l'apprentissage du facile au difficile,
+   une strategie universelle en pedagogie comme en ML.
+3. **Le shaping naif** (non potential-based) peut biaiser la politique — il faut
+   etre prudent avec les heuristiques ad-hoc.
+4. Ces concepts connectent directement au **RLHF** (reward model appris), **inverse RL**
+   (apprendre le reward), et **DPO** (preference learning offline, cf. notebook 9).
+
+### Pour aller plus loin
+
+- **Notebook 5** : les fondements MDP/Q-Learning que nous avons utilises
+- **Notebook 8** : model-based RL et planification (Dyna-Q), une autre approche pour accelerer
+- **Notebook 9** : RL offline, DPO et le pont complet vers l'alignement des LLMs
+- **[GenAI / FineTuning — FT-04 RLHF-DPO](../GenAI/FineTuning/FT-04-RLHF-DPO.ipynb)** : le reward model et DPO en pratique (TRL/PEFT) sur de vrais LLM
+- **[GenAI / PostTraining](../GenAI/PostTraining/README.md)** : la chaine SFT -> RLHF -> [DPO (PT-03)](../GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb) -> GRPO -> RLVR ; le reward shaping appris de ce notebook y devient un reward model, et le [reward hacking / Goodhart (PT-07)](../GenAI/PostTraining/PT_07_rewardspy_reward_hacking.ipynb) prolonge directement la mise en garde du shaping naif vue ici
+
+### References
+
+1. Ng, A. Y., Harada, D., & Russell, S. (1999). *Policy invariance under reward transformations*. ICML.
+2. Bengio, Y., Louradour, J., Collobert, R., & Weston, J. (2009). *Curriculum learning*. ICML.
+3. Asmuth, J., Baumgardner, T., & Littman, M. (2008). *Potential-based shaping in model-based RL*. AAAI.
+4. Ouyang, L. et al. (2022). *Training language models to follow instructions with human feedback* (InstructGPT/RLHF). NeurIPS.
+5. Rafailov, R. et al. (2023). *Direct Preference Optimization* (DPO). NeurIPS.
+",,,,,,,,4a7f5d69d39918c0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,280b5259,markdown,fr,d5f836e342a98831,"# RL-11 : POMDP - Partial Observability et Belief Tracking
+
+**Notebook : 11/13** | **Duree** : 45-50 min | **Kernel** : Python 3
+
+Dans les notebooks precedents, l'agent connaissait toujours l'etat exact de l'environnement.
+Mais dans la realite, un robot ne voit pas parfaitement, un capteur est bruite, et un agent
+negociateur ne connait pas les cartes de son adversaire.
+
+Les **POMDP** (Partially Observable Markov Decision Processes) modelisent cette incertitude
+observationnelle. L'agent ne voit plus l'etat $s$, mais une **observation** $o$ qui depend
+probabilistement de $s$.
+
+Ce notebook explore :
+
+1. **Le Tiger Problem** : un POMDP classique (Cassandra et al., 1994)
+2. **Politiques hand-crafted** : comment l'observation bruitee affecte les decisions
+3. **Belief tracking** : maintenir une distribution de probabilite sur les etats caches
+4. **Q-MDP approximation** : utiliser le belief state dans un cadre Q-learning
+
+**Prerequis** : Notebooks 5 (MDP, Q-Learning) et 6 (DQN, politique epsilon-greedy).",,,,,,,,d5f836e342a98831,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,1a16ec88,markdown,fr,ca2df002cda03e07,"## 1. Le Tiger Problem
+
+Le **Tiger Problem** (Cassandra, Littman & Kaelbling, 1994) est un POMDP emblematique :
+
+- **2 etats** : le tigre est derriere la porte gauche (0) ou droite (1)
+- **3 actions** : ouvrir gauche (0), ouvrir droite (1), ecouter (2)
+- **2 observations** : grognement gauche (0) ou droite (1)
+- **Ecouter** : observation correcte a 85%, cout -1
+- **Ouvrir porte tigre** : recompense -100, **ouvrir porte tresor** : +10
+- Apres ouverture, le probleme **reset** (nouvelle position aleatoire du tigre)
+
+La cle : l'agent ne voit jamais directement la position du tigre. Il doit **inferer** cette
+position a partir des observations successives.",,,,,,,,ca2df002cda03e07,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,fec26de0,code,fr,3de0580103c67767,"import numpy as np
+import matplotlib.pyplot as plt
+
+SEED = 42
+ALPHA, GAMMA, EPSILON = 0.1, 0.95, 0.1
+MAX_STEPS = 20
+P_CORRECT = 0.85  # precision de l'observation en ecoutant
+
+class TigerPOMDP:
+    """"""Tiger Problem (Cassandra et al., 1994).
+
+    States: 0=tiger-left, 1=tiger-right
+    Actions: 0=open-left, 1=open-right, 2=listen
+    Observations: 0=growl-left, 1=growl-right
+    """"""
+    def __init__(self, p_correct=P_CORRECT):
+        self.n_states = 2
+        self.n_actions = 3
+        self.n_observations = 2
+        self.p_correct = p_correct
+        self.tiger_pos = 0
+        self._just_listened = False
+
+    def reset(self):
+        """"""Nouveau episode: position aleatoire du tigre + observation gratuite.""""""
+        self.tiger_pos = np.random.choice([0, 1])
+        self._just_listened = True
+        return self._obs()
+
+    def _obs(self):
+        if self._just_listened:
+            return self.tiger_pos if np.random.random() < self.p_correct else 1 - self.tiger_pos
+        return np.random.choice([0, 1])
+
+    def step(self, action):
+        if action == 2:  # listen
+            self._just_listened = True
+            return self._obs(), -1.0, False
+        else:  # open door
+            reward = -100.0 if (action == self.tiger_pos) else 10.0
+            self.tiger_pos = np.random.choice([0, 1])
+            self._just_listened = True
+            return self._obs(), reward, True
+
+    @property
+    def state(self):
+        return self.tiger_pos
+
+env = TigerPOMDP()
+print(f""Tiger POMDP: {env.n_states} etats, {env.n_actions} actions, {env.n_observations} observations"")
+print(f""Precision ecoute: {env.p_correct:.0%}"")
+print(f""Cout ecoute: -1, Tigre: -100, Tresor: +10"")",,,,,,,,3de0580103c67767,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,e3a2d138,markdown,fr,1704aba531be606f,"## 2. Politiques baselines
+
+Comparons d'abord des politiques simples pour comprendre l'espace des solutions :
+
+| Politique | Strategie |
+|-----------|-----------|
+| **Random** | Action aleatoire a chaque pas |
+| **Open immediately** | Ouvre la porte opposee a la premiere observation |
+| **Listen x1** | Ecoute une fois, puis ouvre la porte opposee |
+| **Listen x2** | Ecoute deux fois (vote majoritaire), puis ouvre |",,,,,,,,1704aba531be606f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,fb034f1d,code,fr,dbe53b6a0427d657,"def random_agent(env, n_episodes, seed=0):
+    """"""Politique aleatoire (baseline inferieure).""""""
+    rng = np.random.default_rng(seed)
+    returns = []
+    for _ in range(n_episodes):
+        env.reset()
+        ret = 0.0
+        for _ in range(MAX_STEPS):
+            action = rng.integers(3)
+            _, r, done = env.step(action)
+            ret += r
+            if done:
+                break
+        returns.append(ret)
+    return np.mean(returns), np.array(returns)
+
+def open_immediately(env, n_episodes, seed=0):
+    """"""Ouvre directement la porte opposee a l'observation initiale.""""""
+    rng = np.random.default_rng(seed)
+    returns = []
+    for _ in range(n_episodes):
+        obs = env.reset()
+        action = 1 - obs  # si grognement gauche, ouvre droite
+        _, r, done = env.step(action)
+        returns.append(r)
+    return np.mean(returns), np.array(returns)
+
+def listen_then_open(env, n_episodes, n_listen=2, seed=0):
+    """"""Ecoute N fois puis ouvre la porte la moins probable pour le tigre.""""""
+    rng = np.random.default_rng(seed)
+    returns = []
+    for _ in range(n_episodes):
+        obs = env.reset()
+        belief = np.array([0.5, 0.5])
+        ret = 0.0
+        for t in range(MAX_STEPS):
+            if t < n_listen:
+                action = 2  # listen
+            else:
+                action = np.argmin(belief)  # porte la moins probable
+
+            obs, r, done = env.step(action)
+            ret += r
+
+            # Mise a jour bayesienne du belief
+            if action == 2:
+                p_obs_given = np.array([
+                    P_CORRECT if obs == 0 else 1 - P_CORRECT,
+                    P_CORRECT if obs == 1 else 1 - P_CORRECT,
+                ])
+                belief *= p_obs_given
+                belief /= belief.sum()
+
+            if done:
+                break
+        returns.append(ret)
+    return np.mean(returns), np.array(returns)
+
+N_EP = 3000
+env = TigerPOMDP()
+
+print(""=== Politiques baselines ===\n"")
+ret_rand, _ = random_agent(env, N_EP, seed=SEED)
+print(f""Random:                {ret_rand:.1f}"")
+
+ret_imm, _ = open_immediately(env, N_EP, seed=SEED)
+print(f""Open immediately:      {ret_imm:.1f}"")
+
+ret_l1, _ = listen_then_open(env, N_EP, n_listen=1, seed=SEED)
+print(f""Listen x1 then open:   {ret_l1:.1f}"")
+
+ret_l2, _ = listen_then_open(env, N_EP, n_listen=2, seed=SEED)
+print(f""Listen x2 then open:   {ret_l2:.1f}"")",,,,,,,,dbe53b6a0427d657,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,dce090aa,markdown,fr,a94d3d4b053e7f61,"## 3. Belief Tracking (Filtre Bayesien)
+
+L'agent maintient un **belief state** $b(s) = P(s | o_1, a_1, o_2, a_2, \ldots)$,
+une distribution de probabilite sur les etats possibles.
+
+### Mise a jour bayesienne
+
+Apres avoir pris l'action $a$ et observe $o$ :
+
+$$b'(s) = \eta \cdot P(o | s, a) \sum_{s'} P(s | s', a) \cdot b(s')$$
+
+ou $\eta$ est une constante de normalisation.
+
+Dans le Tiger Problem, le belief se simplifie en $b = P(\text{tiger-left})$ :
+- Si on ecoute et on entend growl-left : $b$ augmente
+- Si on ecoute et on entend growl-right : $b$ diminue",,,,,,,,a94d3d4b053e7f61,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,62bd97a6,code,fr,e575eb552439c1fd,"def belief_update_demo():
+    """"""Demonstration du belief tracking sur un episode.""""""
+    env = TigerPOMDP()
+    obs = env.reset()
+    belief = 0.5  # P(tiger-left)
+
+    print(""=== Demonstration du Belief Tracking ==="")
+    print(f""Tigre reel: {'gauche' if env.tiger_pos == 0 else 'droite'}"")
+    print(f""Observation initiale: {'growl-left' if obs == 0 else 'growl-right'}"")
+    print(f""Belief initial: P(tiger-left) = {belief:.2f}\n"")
+
+    for step in range(5):
+        action = 2  # listen
+        obs, r, done = env.step(action)
+
+        # Bayesian update
+        if obs == 0:
+            p_obs = np.array([P_CORRECT, 1 - P_CORRECT])
+        else:
+            p_obs = np.array([1 - P_CORRECT, P_CORRECT])
+
+        b_vec = np.array([belief, 1 - belief])
+        b_vec *= p_obs
+        b_vec /= b_vec.sum()
+        belief = b_vec[0]
+
+        print(f""Step {step+1}: obs={'growl-left' if obs==0 else 'growl-right'} ""
+              f""-> P(tiger-left) = {belief:.4f}"")
+
+        if belief > 0.95:
+            print(""  -> Confiance elevee : tiger a gauche"")
+            break
+        elif belief < 0.05:
+            print(""  -> Confiance elevee : tiger a droite"")
+            break
+
+    print(f""\nTigre reel: {'gauche' if env.tiger_pos == 0 else 'droite'}"")
+    print(f""Belief final: P(tiger-left) = {belief:.4f}"")
+
+belief_update_demo()",,,,,,,,e575eb552439c1fd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,019c6079,markdown,fr,805f5d1bf70e54d1,"Le belief converge rapidement vers la bonne reponse (en general en 2-3 observations).
+Mais la convergence n'est pas garantie : avec $P = 0.85$, une observation incorrecte peut
+temporairement degrader le belief.
+
+### Graphique d'evolution du belief",,,,,,,,805f5d1bf70e54d1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,f7d6c01b,code,fr,18951d892522e481,"def plot_belief_evolution(n_episodes=20, seed=42):
+    rng = np.random.default_rng(seed)
+    fig, axes = plt.subplots(2, 2, figsize=(12, 8))
+    axes = axes.flatten()
+
+    for idx in range(4):
+        env = TigerPOMDP()
+        obs = env.reset()
+        belief = 0.5
+        beliefs = [belief]
+
+        for step in range(8):
+            obs, r, _ = env.step(2)  # listen
+            if obs == 0:
+                p_obs = np.array([P_CORRECT, 1 - P_CORRECT])
+            else:
+                p_obs = np.array([1 - P_CORRECT, P_CORRECT])
+            b_vec = np.array([belief, 1 - belief])
+            b_vec *= p_obs
+            b_vec /= b_vec.sum()
+            belief = b_vec[0]
+            beliefs.append(belief)
+
+        ax = axes[idx]
+        ax.plot(range(len(beliefs)), beliefs, 'b-o', markersize=5)
+        ax.axhline(y=0.5, color='gray', linestyle='--', alpha=0.5)
+        true_pos = ""gauche"" if env.tiger_pos == 0 else ""droite""
+        ax.axhline(y=1.0 if env.tiger_pos == 0 else 0.0, color='green',
+                    linestyle=':', alpha=0.5, label=f'Tigre reel: {true_pos}')
+        ax.set_ylim(-0.05, 1.05)
+        ax.set_xlabel('Ecoutes')
+        ax.set_ylabel('P(tiger-left)')
+        ax.set_title(f'Episode {idx+1} (tiger {true_pos})')
+        ax.legend(fontsize=8)
+        ax.grid(True, alpha=0.3)
+
+    plt.suptitle('Evolution du belief apres ecoutes successives', fontsize=14)
+    plt.tight_layout()
+    plt.show()
+
+plot_belief_evolution()",,,,,,,,18951d892522e481,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,998d1d50,markdown,fr,b3418d4039263d91,"## 4. Q-MDP : Approximation du POMDP
+
+Le **Q-MDP** (Littman et al., 1995) est une approximation classique pour les POMDPs :
+
+1. **Entrainer** une Q-table sur les etats vrais (comme si l'environnement etait completement observable)
+2. **Agir** en utilisant le belief : choisir l'action qui maximise $\sum_s b(s) \cdot Q(s, a)$
+
+L'avantage : simple a implementer, reutilise le Q-learning standard.
+L'inconvenient : ignore l'impact des actions sur les observations futures.",,,,,,,,b3418d4039263d91,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,761cbea9,code,fr,58274b4606cd486f,"def belief_qmdp(env, n_episodes, seed=0):
+    """"""Q-MDP: Q-learning sur etats vrais, action selection via belief.""""""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((2, 3))
+    returns = []
+
+    for ep in range(n_episodes):
+        env.reset()
+        belief = np.array([0.5, 0.5])
+        ret = 0.0
+        for t in range(MAX_STEPS):
+            # Expected Q under belief
+            if rng.random() < EPSILON:
+                action = rng.integers(3)
+            else:
+                expected_Q = belief @ Q
+                action = rng.choice(np.flatnonzero(expected_Q == expected_Q.max()))
+
+            old_true = env.tiger_pos
+            obs, r, done = env.step(action)
+
+            # Q-learning update with TRUE state
+            if not done:
+                new_true = env.tiger_pos
+                target = r + GAMMA * Q[new_true].max()
+            else:
+                target = r
+            Q[old_true, action] += ALPHA * (target - Q[old_true, action])
+
+            # Belief update
+            if action == 2:
+                p_obs_given = np.array([
+                    P_CORRECT if obs == 0 else 1 - P_CORRECT,
+                    P_CORRECT if obs == 1 else 1 - P_CORRECT,
+                ])
+                belief *= p_obs_given
+                belief /= belief.sum()
+
+            ret += r
+            if done:
+                break
+        returns.append(ret)
+    return Q, np.mean(returns[-200:]), np.array(returns)
+
+env = TigerPOMDP()
+Q_qmdp, ret_qmdp, arr_qmdp = belief_qmdp(env, 5000, seed=SEED)
+
+print(""=== Q-MDP avec Belief Tracking ==="")
+print(f""Return moyen (derniers 200 episodes): {ret_qmdp:.1f}"")
+print(f""\nQ-table apprise:"")
+print(f""  {'Action':<15} {'Open-L':>10} {'Open-R':>10} {'Listen':>10}"")
+print(f""  {'Tiger-Left':<15} {Q_qmdp[0,0]:>10.1f} {Q_qmdp[0,1]:>10.1f} {Q_qmdp[0,2]:>10.1f}"")
+print(f""  {'Tiger-Right':<15} {Q_qmdp[1,0]:>10.1f} {Q_qmdp[1,1]:>10.1f} {Q_qmdp[1,2]:>10.1f}"")
+print(f""\nInterpretation:"")
+print(f""  Si tiger-left: optimale = open-right (Q={Q_qmdp[0,1]:.1f})"")
+print(f""  Si tiger-right: optimale = open-left (Q={Q_qmdp[1,0]:.1f})"")",,,,,,,,58274b4606cd486f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,18cb6291,markdown,fr,d1458130a5f98838,"### Pourquoi Q-MDP sous-performe-t-il ?
+
+Le Q-MDP apprend la bonne Q-table (ouvrir la porte opposee au tigre), mais sa politique
+**depend de la qualite du belief**. Si le belief est incertain ($b \approx 0.5$), l'agent
+prend une decision quasi-aleatoire, ce qui arrive frequemment en debut d'episode.
+
+De plus, le Q-MDP **n'apprend pas la valeur de l'information** : il ne realise pas
+qu'ecouter ameliore le belief et donc les decisions futures.",,,,,,,,d1458130a5f98838,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,4d9dc929,markdown,fr,b5bf8826432e2029,"## 5. Belief-State Q-Learning
+
+Une alternative plus directe : **discretiser le belief state** et apprendre une Q-table
+directement dans cet espace.
+
+Le belief du Tiger Problem est 1D : $b = P(\text{tiger-left}) \in [0, 1]$.
+En discretisant en $N$ bins, on obtient un MDP avec $N$ etats, et le Q-learning standard s'applique.",,,,,,,,b5bf8826432e2029,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,285ffed6,code,fr,7ee86c764e9afe60,"def belief_state_qlearning(env, n_episodes, n_belief_bins=20, seed=0):
+    """"""Q-learning discretise le belief state.""""""
+    rng = np.random.default_rng(seed)
+    n_states = n_belief_bins
+    Q = np.zeros((n_states, 3))
+    returns = []
+
+    def belief_to_idx(belief_left):
+        return min(int(belief_left * n_belief_bins), n_belief_bins - 1)
+
+    for ep in range(n_episodes):
+        env.reset()
+        belief = np.array([0.5, 0.5])
+        ret = 0.0
+        for t in range(MAX_STEPS):
+            b_idx = belief_to_idx(belief[0])
+
+            if rng.random() < EPSILON:
+                action = rng.integers(3)
+            else:
+                q = Q[b_idx]
+                action = rng.choice(np.flatnonzero(q == q.max()))
+
+            obs, r, done = env.step(action)
+
+            # Belief update
+            if action == 2:
+                p_obs_given = np.array([
+                    P_CORRECT if obs == 0 else 1 - P_CORRECT,
+                    P_CORRECT if obs == 1 else 1 - P_CORRECT,
+                ])
+                belief *= p_obs_given
+                total = belief.sum()
+                belief = belief / total if total > 0 else np.array([0.5, 0.5])
+
+            b_idx2 = belief_to_idx(belief[0])
+            target = r if done else r + GAMMA * Q[b_idx2].max()
+            Q[b_idx, action] += ALPHA * (target - Q[b_idx, action])
+
+            ret += r
+            if done:
+                break
+        returns.append(ret)
+    return Q, np.mean(returns[-200:]), np.array(returns)
+
+env = TigerPOMDP()
+Q_bs, ret_bs, arr_bs = belief_state_qlearning(env, 5000, n_belief_bins=20, seed=SEED)
+
+print(""=== Belief-State Q-Learning (20 bins) ==="")
+print(f""Return moyen (derniers 200 episodes): {ret_bs:.1f}"")
+print(f""\nQ-values par niveau de belief:"")
+print(f""  {'Belief P(TL)':<15} {'Open-L':>10} {'Open-R':>10} {'Listen':>10}"")
+for b_val in [0.05, 0.25, 0.50, 0.75, 0.95]:
+    idx = min(int(b_val * 20), 19)
+    print(f""  {b_val:<15.2f} {Q_bs[idx,0]:>10.1f} {Q_bs[idx,1]:>10.1f} {Q_bs[idx,2]:>10.1f}"")",,,,,,,,7ee86c764e9afe60,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,231b834c,markdown,fr,883c7e7e7e20da0a,"## 6. Comparaison des methodes
+
+Le graphique ci-dessous resume les performances de toutes les approches testees.",,,,,,,,883c7e7e7e20da0a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,cc7b5c40,code,fr,89bcf62d9234ec71,"env = TigerPOMDP()
+N_EP = 3000
+SEEDS = [0, 1, 7, 42, 99]
+
+methods = {
+    ""Random"": [],
+    ""Open immediat"": [],
+    ""Listen x1"": [],
+    ""Listen x2"": [],
+    ""Q-MDP"": [],
+    ""Belief Q"": [],
+}
+
+for seed in SEEDS:
+    methods[""Random""].append(random_agent(env, N_EP, seed=seed)[0])
+    methods[""Open immediat""].append(open_immediately(env, N_EP, seed=seed)[0])
+    methods[""Listen x1""].append(listen_then_open(env, N_EP, n_listen=1, seed=seed)[0])
+    methods[""Listen x2""].append(listen_then_open(env, N_EP, n_listen=2, seed=seed)[0])
+    methods[""Q-MDP""].append(belief_qmdp(env, N_EP, seed=seed)[1])
+    methods[""Belief Q""].append(belief_state_qlearning(env, N_EP, n_belief_bins=20, seed=seed)[1])
+
+# Tableau resume
+print(f""{'Methode':<20} {'Mean':>8} {'Std':>8} {'Min':>8} {'Max':>8}"")
+print(""-"" * 54)
+for name, vals in methods.items():
+    print(f""{name:<20} {np.mean(vals):>8.1f} {np.std(vals):>8.1f} ""
+          f""{np.min(vals):>8.1f} {np.max(vals):>8.1f}"")
+
+# Graphique
+fig, ax = plt.subplots(figsize=(10, 5))
+names = list(methods.keys())
+means = [np.mean(methods[n]) for n in names]
+stds = [np.std(methods[n]) for n in names]
+colors = ['#e74c3c', '#f39c12', '#27ae60', '#2ecc71', '#3498db', '#9b59b6']
+
+bars = ax.bar(range(len(names)), means, yerr=stds, color=colors,
+              edgecolor='black', linewidth=0.5, capsize=5)
+ax.set_xticks(range(len(names)))
+ax.set_xticklabels(names, rotation=15, ha='right')
+ax.set_ylabel('Return moyen')
+ax.set_title('Tiger Problem : Comparaison des methodes (5 seeds)')
+ax.axhline(y=0, color='gray', linestyle='-', alpha=0.3)
+ax.grid(True, alpha=0.3, axis='y')
+
+for bar, mean in zip(bars, means):
+    ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() - 2,
+            f'{mean:.1f}', ha='center', va='top', fontsize=9, fontweight='bold')
+
+plt.tight_layout()
+plt.show()",,,,,,,,89bcf62d9234ec71,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,0d2550de,markdown,fr,8d07df56415d4983,"### Resultats cles
+
+1. **Open immediately** est la meilleure politique simple ! Avec une precision de 85%,
+   une seule observation gratuite suffit, et ecouter plus ne compense pas le cout (-1/écoute).
+
+2. **Le belief tracking** (Q-MDP, Belief Q) apprend une structure de decision mais n'egale
+   pas les politiques hand-crafted sur ce probleme simple. Le POMDP est un probleme ou
+   l'expertise humaine (connaissance du modele) bat l'apprentissage tabulaire.
+
+3. **L'ecart MDP vs POMDP** : si l'agent connaissait l'etat vrai, le return serait +10
+   (toujours le tresor). La partial observability cree un **gap** considerable (+10 vs -7).",,,,,,,,8d07df56415d4983,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,d84a2a10,markdown,fr,fd9b282548a97fa3,"## 7. Des POMDP au RL moderne
+
+Les POMDPs sont partout en RL applique :
+
+| POMDP | RL moderne |
+|-------|------------|
+| Etat cache | Etat du marche, intentions d'autres agents |
+| Observation bruitee | Capteurs, images, texte |
+| Belief state | RNN hidden state, transformer context |
+| Q-MDP approximation | DRQN (Deep Recurrent Q-Network) |
+
+### DRQN (Hausknecht & Stone, 2015)
+
+Le **Deep Recurrent Q-Network** remplace le belief tracking manuel par un **RNN** (LSTM/GRU)
+qui apprend implicitement a maintenir un belief state a partir de l'historique des observations.
+
+### PPO + LSTM (notebook 8)
+
+Dans les environnements partiellement observables, PPO utilise souvent un reseau avec
+memoire (LSTM) pour integrer les observations passees — exactement le role du belief tracker.
+
+### AlphaGo et la theorie des jeux
+
+Le jeu de Go est un POMDP : un joueur ne connait pas les intentions de son adversaire.
+AlphaGo utilise un **reseau de politique** qui encode un ""belief"" sur les coups adverses.",,,,,,,,fd9b282548a97fa3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,482fee41,markdown,fr,8bd501406124468b,"## 8. Exercices
+
+### Exercice 1 : Impact de la precision d'observation
+
+Faites varier `p_correct` entre 0.5 (aleatoire) et 1.0 (parfait) et tracez le return
+de la politique ""open immediately"" et ""listen x2"". A quel seuil la politique ""open immediately""
+devient-elle meilleure que ""listen x2"" ?",,,,,,,,8bd501406124468b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,dea3bb7c,code,fr,30bb79f98c4f0768,"# Exercice 1 : Impact de la precision d'observation
+# TODO : faites varier p_correct de 0.5 a 1.0 et tracez les courbes
+# Hint: utilisez np.linspace(0.5, 1.0, 11) pour les valeurs de p_correct
+
+precisions = []  # TODO etudiant : liste de precisions
+results_imm = []  # TODO etudiant : returns pour open_immediately
+results_l2 = []   # TODO etudiant : returns pour listen x2
+
+result = None  # TODO etudiant
+print(""Exercice a completer : tracez return vs precision"")",,,,,,,,30bb79f98c4f0768,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,1677f9e6,markdown,fr,f529bd62ec49caf1,"### Exercice 2 : Politique optimale du nombre d'ecoutes
+
+Trouvez le nombre optimal d'ecoutes $N^*$ pour la politique ""listen $N$ fois puis ouvre""
+en fonction de $P(\text{correct})$. Montrez que $N^* = 1$ pour $P = 0.85$ mais que $N^*$
+augmente quand $P$ diminue.",,,,,,,,f529bd62ec49caf1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,97660228,code,fr,c1665eff3073b920,"# Exercice 2 : Nombre optimal d'ecoutes
+# TODO : testez n_listen de 0 a 5 pour differentes precisions
+# Hint: pour chaque (precision, n_listen), executez listen_then_open
+
+result = None  # TODO etudiant
+print(""Exercice a completer : trouvez N* en fonction de P"")",,,,,,,,c1665eff3073b920,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,028e7e12,markdown,fr,230d12a92c5bb0d1,"### Exercice 3 : Ajouter une troisieme porte
+
+Etendez le Tiger Problem a 3 portes (tiger derriere l'une, tresor derriere les deux autres).
+Combien d'etats, d'actions, d'observations ? Le belief tracking change-t-il fondamentalement ?",,,,,,,,230d12a92c5bb0d1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,8e3d9046,code,fr,353d0c60dabb7029,"# Exercice 3 : Tiger Problem a 3 portes
+# TODO : creez Tiger3DoorsPOMDP et testez les politiques
+# Hint: 3 etats, 3 actions (open-L, open-M, open-R, listen), 3 observations
+
+class Tiger3DoorsPOMDP:
+    pass  # TODO etudiant
+
+result = None  # TODO etudiant
+print(""Exercice a completer : Tiger Problem a 3 portes"")",,,,,,,,353d0c60dabb7029,,,,,,,
+MyIA.AI.Notebooks/RL/rl_11_pomdp.ipynb,aea97881,markdown,fr,b88cfb40d05290b8,"## Conclusion
+
+Dans ce notebook nous avons decouvert les POMDPs et les defis de la decision sous partial observability :
+
+1. **Le Tiger Problem** illustre comment l'observation bruitee degrade les performances
+   d'un agent par rapport a l'observabilite complete.
+2. **Le belief tracking** (filtre bayesien) permet de maintenir une estimation de l'etat
+   cache, mais la qualite de cette estimation depend de la precision des observations.
+3. **Q-MDP** est une approximation qui reutilise le Q-learning standard mais ignore la
+   valeur de l'information future, ce qui le sous-optimise sur les POMDPs.
+4. **Les methodes modernes** (DRQN, PPO+LSTM) automatisent le belief tracking via
+   des reseaux de neurones recurrents.
+
+### Pour aller plus loin
+
+- **Notebook 5** : les fondements MDP/Q-Learning utilises dans ce notebook
+- **Notebook 8** : model-based RL et planification (Dyna-Q)
+- **Notebook 10** : reward shaping et curriculum learning
+- **Notebook 12** : RL pour le trading (application a un environnement bruite reel)
+
+### References
+
+1. Cassandra, A. R., Littman, M. L., & Kaelbling, N. L. (1994). *Acting optimally in partially observable stochastic domains*. AAAI.
+2. Littman, M. L., Cassandra, A. R., & Kaelbling, L. P. (1995). *Learning policies for partially observable environments*. ICML.
+3. Hausknecht, M., & Stone, P. (2015). *Deep recurrent Q-learning for partially observable MDPs*. AAAI Fall Symposium.
+4. Oliehoek, F. A., & Amato, C. (2016). *A concise introduction to decentralized POMDPs*. Springer.
+5. Thrun, S., Burgard, W., & Fox, D. (2005). *Probabilistic Robotics*. MIT Press.",,,,,,,,b88cfb40d05290b8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,b9f130ed,markdown,fr,39330275c70f3ef2,"# RL-12 : Distributional RL — C51 (Categorical DQN) depuis zero
+
+**Serie** : Reinforcement Learning | **Notebook** : 12/13 | **Duree estimee** : 50-55 min
+
+Navigation : [RL-5 Tabulaire](rl_5_mdp_dp_qlearning.ipynb) | [RL-6 DQN](rl_6_dqn_policy_gradient.ipynb) | [RL-6d SAC](rl_6d_sac_from_scratch.ipynb) | **RL-12** | [RL-9 Offline](rl_9_offline_rl.ipynb)
+
+---
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous serez capable de :
+- Comprendre **pourquoi modeliser la distribution complete du retour** $Z(s,a)$ plutot que sa seule esperance $Q(s,a) = \mathbb{E}[Z(s,a)]$.
+- Implementer **C51** (Categorical DQN, Bellemare et al. 2017) depuis zero : support categoriel a atomes fixes, reseau a sorties softmax, **projection categorielle** de la cible de Bellman distributionnelle.
+- Entrainer C51 sur CartPole-v1 et **visualiser la distribution de retour apprise** par action.
+- Situer C51 dans la lignee QR-DQN / IQN / Rainbow et comprendre l'interet pour le **RL sensible au risque**.
+
+## Prerequis
+
+- [RL-6 DQN depuis zero](rl_6_dqn_policy_gradient.ipynb) : replay buffer, target network, $\varepsilon$-greedy, equation de Bellman pour $Q$.
+- [RL-5 MDP / Q-Learning](rl_5_mdp_dp_qlearning.ipynb) : retour, facteur d'actualisation $\gamma$, equation de Bellman.
+- Bases de PyTorch (tenseurs, autograd, `nn.Module`).
+
+---
+
+**Pourquoi modeliser la distribution complete ?**
+
+Le DQN classique apprend une **esperance** : $Q(s,a) = \mathbb{E}\big[\sum_t \gamma^t r_t \mid s, a\big]$. Or deux actions peuvent avoir la **meme moyenne** mais des **risques tres differents** : l'une garantit un retour moyen, l'autre alterne jackpots et catastrophes. L'esperance ecrase cette information.
+
+Le **RL distributionnel** apprend la **variable aleatoire de retour** $Z(s,a)$ tout entiere, pas seulement sa moyenne. Bellemare, Dabney & Munos (2017) montrent que cet objectif plus riche **stabilise et accelere** l'apprentissage (C51 fut un ingredient cle de *Rainbow*), et qu'il **debloque des politiques sensibles au risque** (choisir selon une CVaR, un quantile bas, etc.). Ce notebook construit C51 brique par brique.",,,,,,,,39330275c70f3ef2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,ef342edc,markdown,fr,5494f0ef3fee122b,"## 1. Setup et imports
+
+C51 ne demande que NumPy, PyTorch (CPU suffit) et Gymnasium pour CartPole-v1 — le meme environnement que [RL-6](rl_6_dqn_policy_gradient.ipynb), ce qui permet une comparaison directe avec le DQN scalaire.",,,,,,,,5494f0ef3fee122b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,22240f98,code,fr,05873a763017bbb9,"import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import gymnasium as gym
+from collections import deque
+import random
+import matplotlib.pyplot as plt
+
+SEED = 0
+random.seed(SEED); np.random.seed(SEED); torch.manual_seed(SEED)
+device = torch.device(""cpu"")  # un MLP a 2 couches sur CartPole tourne tres bien sur CPU
+print(""torch"", torch.__version__, ""| gymnasium"", gym.__version__, ""| device"", device)",,,,,,,,05873a763017bbb9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,ec8c37d7,markdown,fr,d7931471e39d2479,"## 2. Du scalaire $Q(s,a)$ a la distribution $Z(s,a)$
+
+C51 ne predit pas un nombre, mais une **distribution de probabilite discrete** sur un **support fixe** de $N=51$ valeurs (les *atomes*) :
+
+$$z_i = V_{\min} + i\,\Delta z,\qquad \Delta z = \frac{V_{\max}-V_{\min}}{N-1},\qquad i = 0,\dots,N-1.$$
+
+Pour un couple $(s,a)$, le reseau sort des probabilites $p_i(s,a)$ avec $\sum_i p_i = 1$. L'esperance se reconstruit trivialement :
+
+$$Q(s,a) = \mathbb{E}[Z(s,a)] = \sum_{i=0}^{N-1} z_i\, p_i(s,a).$$
+
+Le support doit **couvrir l'amplitude reelle des retours**. Sur CartPole-v1 (recompense $+1$ par pas, episode $\le 500$ pas, $\gamma=0{,}99$), le retour actualise vaut au plus $\sum_{t\ge0}\gamma^t \approx 100$ ; on prend une marge avec $[V_{\min}, V_{\max}] = [0, 200]$.",,,,,,,,d7931471e39d2479,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,42965aa4,code,fr,87361e289101d655,"N_ATOMS = 51
+V_MIN, V_MAX = 0.0, 200.0
+GAMMA = 0.99
+
+support = torch.linspace(V_MIN, V_MAX, N_ATOMS, device=device)   # z_i
+delta_z = (V_MAX - V_MIN) / (N_ATOMS - 1)
+print(f""{N_ATOMS} atomes de {V_MIN} a {V_MAX}, pas delta_z = {delta_z:.2f}"")
+
+# Exemple : trois distributions de meme support, esperances differentes
+fig, ax = plt.subplots(1, 3, figsize=(13, 3))
+demo = {
+    ""concentree (faible risque)"": torch.exp(-0.5 * ((support - 80) / 6) ** 2),
+    ""bimodale (jackpot/echec)"":   torch.exp(-0.5 * ((support - 20) / 5) ** 2) + torch.exp(-0.5 * ((support - 150) / 8) ** 2),
+    ""etalee (forte variance)"":    torch.exp(-0.5 * ((support - 90) / 30) ** 2),
+}
+for a, (title, p) in zip(ax, demo.items()):
+    p = (p / p.sum())
+    a.bar(support.numpy(), p.numpy(), width=delta_z * 0.9, color=""steelblue"")
+    a.axvline((support * p).sum().item(), color=""crimson"", ls=""--"", label=f""E[Z]={(support*p).sum().item():.0f}"")
+    a.set_title(title, fontsize=9); a.set_xlabel(""retour""); a.legend(fontsize=8)
+ax[0].set_ylabel(""probabilite"")
+plt.suptitle(""Trois distributions de retour Z(s,a) — l'esperance (rouge) seule perd l'information de risque"", fontsize=10)
+plt.tight_layout(); plt.show()",,,,,,,,87361e289101d655,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,c3b96f4e,markdown,fr,f602b229199bf5af,"## 3. L'equation de Bellman distributionnelle et la projection categorielle
+
+L'operateur de Bellman distributionnel transporte la distribution de retour :
+
+$$T Z(s,a) \;\stackrel{D}{=}\; R(s,a) + \gamma\, Z(s', a^\*),\qquad a^\* = \arg\max_{a'} Q(s', a').$$
+
+Probleme : appliquer $z \mapsto r + \gamma z$ **deplace les atomes hors du support fixe** $\{z_i\}$. C51 resout cela par une **projection categorielle** $\Phi$ : on clippe chaque atome transforme $\hat{T}z_j = \mathrm{clip}(r + \gamma z_j,\, V_{\min}, V_{\max})$, on calcule sa position fractionnaire $b_j = (\hat{T}z_j - V_{\min})/\Delta z$, et on **repartit sa masse de probabilite** sur les deux atomes voisins $\lfloor b_j\rfloor$ et $\lceil b_j\rceil$ au prorata de la distance. La perte est ensuite l'**entropie croisee** entre la cible projetee et la distribution predite.
+
+### 3.1 Implementation et illustration de la projection",,,,,,,,f602b229199bf5af,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,4dbcaae4,code,fr,36c93ec79453e9b0,"def project(next_dist, rewards, dones):
+    """"""Projection categorielle Phi de la cible de Bellman distributionnelle sur le support fixe.
+    next_dist : (B, N_ATOMS) distribution de l'action greedy a l'etat suivant
+    rewards   : (B,)  | dones : (B,) flag terminal (1.0 si etat terminal reel)
+    retourne  : (B, N_ATOMS) distribution cible projetee m.""""""
+    B = rewards.size(0)
+    # Tz_j = r + gamma * z_j  (pas de bootstrap si terminal), puis clip sur [V_MIN, V_MAX]
+    Tz = rewards.unsqueeze(1) + (1 - dones).unsqueeze(1) * GAMMA * support.unsqueeze(0)
+    Tz = Tz.clamp(V_MIN, V_MAX)
+    b = (Tz - V_MIN) / delta_z                  # position fractionnaire sur le support
+    lo = b.floor().long(); up = b.ceil().long()
+    # cas ou b tombe exactement sur un entier : eviter de perdre la masse
+    lo[(up > 0) & (lo == up)] -= 1
+    up[(lo < (N_ATOMS - 1)) & (lo == up)] += 1
+    m = torch.zeros(B, N_ATOMS, device=device)
+    offset = (torch.arange(B, device=device) * N_ATOMS).unsqueeze(1)
+    # masse vers l'atome bas (proportionnelle a la distance a l'atome haut) et vers l'atome haut
+    m.view(-1).index_add_(0, (lo + offset).view(-1), (next_dist * (up.float() - b)).view(-1))
+    m.view(-1).index_add_(0, (up + offset).view(-1), (next_dist * (b - lo.float())).view(-1))
+    return m
+
+# Illustration : une distribution concentree a l'etat suivant, projetee apres Tz = r + gamma*z
+src = torch.zeros(1, N_ATOMS); src[0, 30] = 1.0  # masse unitaire sur l'atome 30 (z=120)
+proj_term = project(src, torch.tensor([10.0]), torch.tensor([1.0]))   # terminal : cible = r seul
+proj_boot = project(src, torch.tensor([10.0]), torch.tensor([0.0]))   # bootstrap : cible = r + gamma*z
+fig, ax = plt.subplots(1, 3, figsize=(13, 3))
+ax[0].bar(support.numpy(), src[0].numpy(), width=delta_z*0.9, color=""gray"");   ax[0].set_title(f""source : Z(s') = delta(z={support[30]:.0f})"", fontsize=9)
+ax[1].bar(support.numpy(), proj_term[0].numpy(), width=delta_z*0.9, color=""seagreen""); ax[1].set_title(""terminal : Phi(r=10)"", fontsize=9)
+ax[2].bar(support.numpy(), proj_boot[0].numpy(), width=delta_z*0.9, color=""darkorange""); ax[2].set_title(f""bootstrap : Phi(10 + {GAMMA}*z)"", fontsize=9)
+for a in ax: a.set_xlabel(""retour"")
+ax[0].set_ylabel(""probabilite"")
+plt.suptitle(""Projection categorielle : la masse deplacee hors-grille est redistribuee sur les atomes voisins"", fontsize=10)
+plt.tight_layout(); plt.show()
+print(""sommes des distributions projetees (doivent valoir 1):"", round(proj_term.sum().item(),4), round(proj_boot.sum().item(),4))",,,,,,,,36c93ec79453e9b0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,b8c75d83,markdown,fr,3e9c516c96adc147,"## 4. Implementation de C51
+
+### 4.1 Le reseau `CategoricalDQN`
+
+Le reseau prend l'etat et sort $N_{\text{actions}} \times N_{\text{atoms}}$ logits, organises par action. Un `softmax` sur la derniere dimension donne, pour chaque action, une distribution de probabilite valide sur le support.",,,,,,,,3e9c516c96adc147,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,a0513dd1,code,fr,3fe0a192eb9a3fbc,"class CategoricalDQN(nn.Module):
+    def __init__(self, obs_dim, n_actions, n_atoms):
+        super().__init__()
+        self.n_actions, self.n_atoms = n_actions, n_atoms
+        self.body = nn.Sequential(
+            nn.Linear(obs_dim, 128), nn.ReLU(),
+            nn.Linear(128, 128), nn.ReLU(),
+            nn.Linear(128, n_actions * n_atoms),
+        )
+
+    def dist(self, x):
+        """"""(B, n_actions, n_atoms) : une distribution de proba par action.""""""
+        logits = self.body(x).view(-1, self.n_actions, self.n_atoms)
+        return F.softmax(logits, dim=-1)
+
+    def q(self, x):
+        """"""(B, n_actions) : esperances Q(s,a) = sum_i z_i p_i(s,a).""""""
+        return (self.dist(x) * support).sum(-1)
+
+# verification rapide des formes
+_net = CategoricalDQN(4, 2, N_ATOMS)
+_d = _net.dist(torch.zeros(3, 4))
+print(""dist shape:"", tuple(_d.shape), ""| somme par (etat,action) ~1:"", _d.sum(-1).mean().item())
+print(""q shape:"", tuple(_net.q(torch.zeros(3, 4)).shape))",,,,,,,,3fe0a192eb9a3fbc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,bebe5d56,markdown,fr,f216f43cf0c6842e,"### 4.2 Replay buffer et selection d'action
+
+Comme pour le DQN, on decorrele les transitions via un **replay buffer**, et on agit en $\varepsilon$-greedy sur l'esperance $Q(s,a)=\sum_i z_i p_i(s,a)$. La difference est interne : ce qui est appris est la **distribution**, pas le scalaire.",,,,,,,,f216f43cf0c6842e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,f2bbb4d4,code,fr,3f383bbcaae747de,"class ReplayBuffer:
+    def __init__(self, capacity):
+        self.buf = deque(maxlen=capacity)
+    def push(self, *t):
+        self.buf.append(t)
+    def sample(self, n):
+        batch = random.sample(self.buf, n)
+        s, a, r, ns, d = zip(*batch)
+        return (torch.tensor(np.array(s), dtype=torch.float32, device=device),
+                torch.tensor(a, device=device),
+                torch.tensor(r, dtype=torch.float32, device=device),
+                torch.tensor(np.array(ns), dtype=torch.float32, device=device),
+                torch.tensor(d, dtype=torch.float32, device=device))
+    def __len__(self):
+        return len(self.buf)
+
+def select_action(net, obs, eps, n_actions):
+    if random.random() < eps:
+        return random.randrange(n_actions)
+    with torch.no_grad():
+        return int(net.q(torch.tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)).argmax(1).item())
+
+print(""ReplayBuffer et select_action prets."")",,,,,,,,3f383bbcaae747de,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,f1dd7688,markdown,fr,29b1c9b320981888,"### 4.3 La perte distributionnelle
+
+A chaque pas d'apprentissage :
+1. on choisit l'action greedy $a^\*$ a l'etat suivant **selon l'esperance du target network** ;
+2. on recupere sa distribution $p(s', a^\*)$ et on la **projette** via $\Phi$ pour obtenir la cible $m$ ;
+3. la perte est l'**entropie croisee** $-\sum_i m_i \log p_i(s,a)$ entre cible projetee et distribution predite pour l'action jouee.",,,,,,,,29b1c9b320981888,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,1df9ff3e,code,fr,abac7a24830a6748,"def compute_loss(online, target, batch):
+    s, a, r, ns, d = batch
+    B = s.size(0)
+    with torch.no_grad():
+        next_a = target.q(ns).argmax(1)                       # action greedy (esperance) a s'
+        next_dist = target.dist(ns)[torch.arange(B, device=device), next_a]   # (B, atoms)
+        m = project(next_dist, r, d)                          # cible projetee
+    dist = online.dist(s)[torch.arange(B, device=device), a]  # (B, atoms) action jouee
+    loss = -(m * torch.log(dist.clamp(min=1e-8))).sum(1).mean()   # entropie croisee
+    return loss
+
+print(""Perte distributionnelle (entropie croisee sur cible projetee) prete."")",,,,,,,,abac7a24830a6748,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,5cc4fcce,markdown,fr,1330fd46d7add6d4,"## 5. Entrainement sur CartPole-v1
+
+On entraine sur un budget court (~18 000 pas, quelques minutes sur CPU). Les hyperparametres sont volontairement proches de ceux du DQN de [RL-6](rl_6_dqn_policy_gradient.ipynb) pour que la comparaison porte sur l'objectif (distribution vs esperance), pas sur le reglage.",,,,,,,,1330fd46d7add6d4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,c2129b1e,code,fr,a25f8c9dd20ae59c,"def train_c51(max_steps=18000, seed=SEED):
+    random.seed(seed); np.random.seed(seed); torch.manual_seed(seed)
+    env = gym.make(""CartPole-v1"")
+    obs_dim = env.observation_space.shape[0]; n_actions = env.action_space.n
+    online = CategoricalDQN(obs_dim, n_actions, N_ATOMS).to(device)
+    target = CategoricalDQN(obs_dim, n_actions, N_ATOMS).to(device)
+    target.load_state_dict(online.state_dict())
+    opt = torch.optim.Adam(online.parameters(), lr=1e-3)
+    buf = ReplayBuffer(20000)
+
+    BATCH, MIN_BUF, TARGET_SYNC = 64, 1000, 500
+    EPS_START, EPS_END, EPS_DECAY = 1.0, 0.05, 8000
+
+    returns, ep_ret, step = [], 0.0, 0
+    obs, _ = env.reset(seed=seed)
+    while step < max_steps:
+        eps = EPS_END + (EPS_START - EPS_END) * np.exp(-step / EPS_DECAY)
+        a = select_action(online, obs, eps, n_actions)
+        nobs, r, term, trunc, _ = env.step(a)
+        buf.push(obs, a, r, nobs, float(term))   # bootstrap uniquement sur terminal reel
+        obs = nobs; ep_ret += r; step += 1
+        if term or trunc:
+            returns.append(ep_ret); ep_ret = 0.0
+            obs, _ = env.reset()
+        if len(buf) >= MIN_BUF:
+            loss = compute_loss(online, target, buf.sample(BATCH))
+            opt.zero_grad(); loss.backward(); opt.step()
+        if step % TARGET_SYNC == 0:
+            target.load_state_dict(online.state_dict())
+    env.close()
+    return online, returns
+
+online_net, returns = train_c51()
+print(f""Episodes joues : {len(returns)}"")
+print(f""Retour moyen 20 premiers episodes : {np.mean(returns[:20]):.1f}"")
+print(f""Retour moyen 20 derniers episodes : {np.mean(returns[-20:]):.1f}"")
+print(f""Retour maximum atteint : {max(returns):.0f}"")",,,,,,,,a25f8c9dd20ae59c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,214b7b3a,markdown,fr,5d3ebd286bad976a,"### 5.1 Courbe d'apprentissage
+
+Le retour par episode doit grimper nettement au-dessus de la baseline aleatoire (~20 pas) : C51 apprend a equilibrer le pendule.",,,,,,,,5d3ebd286bad976a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,3035f3fa,code,fr,cd33d800607c837b,"def moving_avg(x, k=20):
+    if len(x) < k: return np.array(x)
+    return np.convolve(x, np.ones(k) / k, mode=""valid"")
+
+plt.figure(figsize=(9, 4))
+plt.plot(returns, alpha=0.3, color=""steelblue"", label=""retour par episode"")
+plt.plot(np.arange(len(moving_avg(returns))) + 19, moving_avg(returns), color=""crimson"", lw=2, label=""moyenne glissante (20)"")
+plt.axhline(20, color=""gray"", ls="":"", label=""baseline aleatoire (~20)"")
+plt.xlabel(""episode""); plt.ylabel(""retour (pas equilibres)"")
+plt.title(""C51 sur CartPole-v1 : courbe d'apprentissage""); plt.legend(); plt.tight_layout(); plt.show()",,,,,,,,cd33d800607c837b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,6a1c7d29,markdown,fr,2fe5229abee09f66,"### 5.2 La vraie valeur ajoutee : la distribution de retour apprise
+
+C'est ici que C51 se distingue d'un DQN. Pour un etat donne, on n'a pas seulement deux scalaires $Q(s,\text{gauche})$ et $Q(s,\text{droite})$ : on a **deux distributions completes**. On peut lire la moyenne (la fleche), mais aussi la dispersion, la dissymetrie, les modes — l'information qu'un DQN scalaire jette.",,,,,,,,2fe5229abee09f66,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,c1e7aa39,code,fr,c1ed08267f1ada35,"env = gym.make(""CartPole-v1"")
+obs, _ = env.reset(seed=123)
+for _ in range(10):   # avancer un peu pour un etat non trivial
+    obs, _, term, trunc, _ = env.step(env.action_space.sample())
+    if term or trunc: obs, _ = env.reset(seed=123)
+env.close()
+
+with torch.no_grad():
+    d = online_net.dist(torch.tensor(obs, dtype=torch.float32, device=device).unsqueeze(0))[0]  # (n_actions, atoms)
+    q = online_net.q(torch.tensor(obs, dtype=torch.float32, device=device).unsqueeze(0))[0]
+
+labels = [""action 0 (gauche)"", ""action 1 (droite)""]
+colors = [""mediumpurple"", ""darkorange""]
+fig, ax = plt.subplots(1, 2, figsize=(13, 3.5), sharey=True)
+for i in range(2):
+    ax[i].bar(support.numpy(), d[i].numpy(), width=delta_z * 0.9, color=colors[i])
+    ax[i].axvline(q[i].item(), color=""crimson"", ls=""--"", lw=2, label=f""E[Z] = Q = {q[i].item():.1f}"")
+    ax[i].set_title(f""Z(s, {labels[i]})"", fontsize=10); ax[i].set_xlabel(""retour""); ax[i].legend(fontsize=9)
+ax[0].set_ylabel(""probabilite"")
+plt.suptitle(""Distribution de retour apprise par C51 pour chaque action (etat fixe)"", fontsize=11)
+plt.tight_layout(); plt.show()
+print(f""Action choisie par la politique greedy (argmax E[Z]) : {int(q.argmax().item())} ({labels[int(q.argmax().item())]})"")",,,,,,,,c1ed08267f1ada35,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,366c955a,markdown,fr,bb31082f003de87f,"## 6. C51 vs DQN : que gagne-t-on ?
+
+| Aspect | DQN ([RL-6](rl_6_dqn_policy_gradient.ipynb)) | C51 (ce notebook) |
+|--------|------|-----|
+| Sortie par action | un scalaire $Q(s,a)$ | une distribution $p(s,a)$ sur 51 atomes |
+| Cible de Bellman | $r + \gamma \max_{a'} Q(s',a')$ | $\Phi\big(r + \gamma Z(s',a^\*)\big)$ (projetee) |
+| Perte | erreur quadratique (Huber) | entropie croisee distributionnelle |
+| Information apprise | esperance seule | esperance **+ variance, modes, asymetrie** |
+| Politique greedy | $\arg\max_a Q$ | $\arg\max_a \mathbb{E}[Z]$ (mais on peut faire mieux : voir Exercice 3) |
+
+Empiriquement, l'objectif distributionnel fournit un **signal d'apprentissage plus riche** (chaque atome est une cible) qui stabilise souvent l'entrainement — C51 fut l'un des six ingredients de **Rainbow** (Hessel et al. 2018). Surtout, disposer de la distribution permet des **politiques sensibles au risque** que l'esperance seule rend impossibles.
+
+**La lignee distributionnelle** : C51 fixe le support et apprend les probabilites. **QR-DQN** (Dabney et al. 2018) inverse le probleme — il fixe les probabilites ($N$ quantiles equiprobables) et **apprend les positions** (les valeurs des quantiles), evitant la projection. **IQN** echantillonne les quantiles a la volee. L'Exercice 1 explore ce basculement.",,,,,,,,bb31082f003de87f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,4b1834c3,markdown,fr,954b4107ae284df4,"## 7. Exercices
+
+Trois exercices pour approfondir. Les cellules de code sont des **squelettes a completer** : le notebook s'execute de bout en bout meme sans les remplir.",,,,,,,,954b4107ae284df4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,969575ab,markdown,fr,0702da5d36e3efb6,"### Exercice 1 : QR-DQN (quantile regression)
+
+C51 fixe les atomes et apprend leurs probabilites. **QR-DQN** fait l'inverse : il fixe $N$ probabilites egales ($1/N$ chacune) et apprend les **valeurs** des quantiles $\theta_i(s,a)$. Avantages : plus de support a regler, plus de projection.
+
+Implementez l'estimation de l'esperance pour QR-DQN et l'esquisse de la **perte de Huber quantile** (quantile midpoints $\hat\tau_i = (i + 0{,}5)/N$). Indice : $Q(s,a) = \frac{1}{N}\sum_i \theta_i(s,a)$ ; la perte pondere l'erreur $\theta_i - \text{cible}$ par $|\hat\tau_i - \mathbb{1}[\text{erreur} < 0]|$.",,,,,,,,0702da5d36e3efb6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,a6b7d944,code,fr,6fd3e2132fce36f6,"# Exercice 1 : QR-DQN — a completer
+N_QUANTILES = 51
+
+def qrdqn_quantile_midpoints(n):
+    # TODO etudiant : retourner les tau_hat_i = (i + 0.5) / n,  i = 0..n-1  (tenseur (n,))
+    return None  # remplacer par : (torch.arange(n, dtype=torch.float32) + 0.5) / n
+
+def qrdqn_expected_q(theta):
+    # theta : (B, n_actions, N_QUANTILES) valeurs de quantiles apprises
+    # TODO etudiant : Q(s,a) = moyenne des quantiles sur la derniere dimension
+    pass  # indice : return theta.mean(-1)
+
+# Indice perte : huber(theta_i - target_j) * |tau_hat_i - 1{theta_i - target_j < 0}|, moyennee
+print(""Exercice 1 a completer : QR-DQN apprend les positions des quantiles, pas leurs probabilites."")",,,,,,,,6fd3e2132fce36f6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,7bcff4c9,markdown,fr,9d977d31e1932a1d,"### Exercice 2 : Sensibilite au support $[V_{\min}, V_{\max}]$
+
+Le support categoriel doit **encadrer les retours reels**. Trop etroit, la masse sature aux bords (information perdue) ; trop large, la resolution $\Delta z$ se degrade. Relancez `train_c51` avec des supports mal regles et comparez les courbes d'apprentissage.
+
+Completez la fonction qui, pour un $(V_{\min}, V_{\max})$ donne, renvoie le pas $\Delta z$ et signale si le retour theorique max de CartPole (~100 sous $\gamma=0{,}99$) **depasse** $V_{\max}$.",,,,,,,,9d977d31e1932a1d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,30b56fa3,code,fr,a25d2fdb5be6feaf,"# Exercice 2 : diagnostic de support — a completer
+def support_diagnostic(v_min, v_max, n_atoms=51, gamma=0.99, max_episode_len=500):
+    # retour actualise theorique max de CartPole : sum_{t=0}^{T-1} gamma^t
+    theo_max = (1 - gamma ** max_episode_len) / (1 - gamma)
+    # TODO etudiant : calculer delta_z et le booleen ""support trop etroit"" (theo_max > v_max)
+    result = None  # remplacer par : {""delta_z"": (v_max - v_min)/(n_atoms-1), ""trop_etroit"": theo_max > v_max, ""theo_max"": theo_max}
+    return result
+
+# Piste d'experience : for (vmin, vmax) in [(0,50),(0,200),(0,1000)]: online,_ = train_c51(max_steps=8000); ...
+print(""Exercice 2 a completer : un support mal cale brise l'apprentissage distributionnel."")",,,,,,,,a25d2fdb5be6feaf,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,4871463b,markdown,fr,4b4c78efabdb7f5e,"### Exercice 3 : Politique sensible au risque
+
+La politique greedy de C51 choisit $\arg\max_a \mathbb{E}[Z(s,a)]$ — elle ignore le risque, comme un DQN. Mais nous avons la **distribution complete** ! Implementez une politique **CVaR** (Conditional Value at Risk) : au lieu de la moyenne, evaluez chaque action par la moyenne de sa **queue basse** (les $\alpha$% pires retours), et choisissez l'action qui maximise cette valeur conservatrice. C'est impossible avec un DQN scalaire — c'est tout l'interet du RL distributionnel.",,,,,,,,4b4c78efabdb7f5e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,8158b7ee,code,fr,d8b60a20017e5c31,"# Exercice 3 : politique CVaR sensible au risque — a completer
+def cvar_action(net, obs, alpha=0.25):
+    """"""Choisit l'action maximisant la CVaR_alpha (moyenne des alpha% pires retours).""""""
+    with torch.no_grad():
+        d = net.dist(torch.tensor(obs, dtype=torch.float32, device=device).unsqueeze(0))[0]  # (n_actions, atoms)
+    # TODO etudiant : pour chaque action, cumuler les probas sur le support trie croissant,
+    # garder la masse jusqu'au quantile alpha, calculer l'esperance conditionnelle (CVaR),
+    # puis retourner argmax_a CVaR_a.
+    # Indice : cdf = d.cumsum(-1) ; masque = cdf <= alpha ; cvar = (support * d * masque).sum(-1) / (d * masque).sum(-1)
+    return None  # remplacer par l'argmax des CVaR par action
+
+print(""Exercice 3 a completer : la distribution permet une politique averse au risque (CVaR), hors de portee d'un DQN."")",,,,,,,,d8b60a20017e5c31,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,d9c252a9,markdown,fr,8fa47fe73b8c8c20,"## Application : retours sensibles au risque en finance et en sante
+
+Le RL distributionnel n'est pas qu'une elegance theorique. Partout ou **la queue de distribution compte autant que la moyenne**, il devient indispensable :
+
+- **Finance / trading algorithmique** : deux strategies de meme rendement espere mais de drawdown tres different ne sont pas equivalentes. Une politique CVaR (cf. Exercice 3) privilegie les strategies dont les pires scenarios restent acceptables — exactement le critere d'un gestionnaire de risque. Voir la serie [QuantConnect](../QuantConnect/README.md).
+- **Sante / dosage** : un traitement de meme efficacite moyenne mais a variance letale est a proscrire ; la distribution de retour encode ce risque.
+- **Robotique / conduite autonome** : eviter les rares catastrophes prime sur l'optimisation du cas moyen.
+
+C'est aussi un pont vers les methodes modernes : la distribution de retour est au coeur d'**IQN**, de la composante distributionnelle de **Rainbow**, et des approches recentes de RL robuste.",,,,,,,,8fa47fe73b8c8c20,,,,,,,
+MyIA.AI.Notebooks/RL/rl_12_distributional_rl.ipynb,3d0f6ff9,markdown,fr,adc701eac1ee620f,"## Conclusion
+
+Vous avez construit **C51 depuis zero** : support categoriel a atomes fixes, reseau a sorties softmax par action, **projection categorielle** de la cible de Bellman distributionnelle, et perte d'entropie croisee. Sur CartPole-v1, l'agent apprend a equilibrer le pendule **tout en exposant la distribution complete du retour** par action.
+
+### Points cles a retenir
+- Le RL distributionnel apprend $Z(s,a)$ (la variable aleatoire), pas seulement $Q(s,a) = \mathbb{E}[Z(s,a)]$.
+- C51 discretise $Z$ sur un **support fixe** ; la **projection categorielle** est ce qui rend l'apprentissage realisable sur cette grille.
+- L'objectif distributionnel donne un signal plus riche (stabilisation, ingredient de Rainbow) et **debloque les politiques sensibles au risque** (CVaR), impossibles avec un DQN scalaire.
+- **QR-DQN** est le pendant naturel : apprendre les positions de quantiles equiprobables plutot que les probabilites d'atomes fixes.
+
+### Pour aller plus loin
+- [RL-6 DQN](rl_6_dqn_policy_gradient.ipynb) : le point de depart scalaire, a comparer directement.
+- [RL-6d SAC](rl_6d_sac_from_scratch.ipynb) : RL a entropie maximale (autre forme d'enrichissement de l'objectif).
+- [RL-9 Offline](rl_9_offline_rl.ipynb) : la distribution de retour aide a quantifier l'incertitude hors-ligne.
+
+### References
+- Bellemare, Dabney & Munos (2017), *A Distributional Perspective on Reinforcement Learning*, ICML (C51).
+- Dabney, Rowland, Bellemare & Munos (2018), *Distributional RL with Quantile Regression*, AAAI (QR-DQN).
+- Hessel et al. (2018), *Rainbow: Combining Improvements in Deep RL*, AAAI.",,,,,,,,adc701eac1ee620f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,f63ecdca,markdown,fr,bdd1a8df5dd4a54d,"# RL 13 - Exploration par curiosité : Random Network Distillation (RND)
+
+Dans la plupart des notebooks précédents, l'exploration reposait sur l'aléa : tirage
+**epsilon-greedy** (notebooks 1, 3, 6), bandits (notebook 4) ou bonus de comptage **Dyna-Q+**
+(notebook 8). Ces stratégies suffisent quand les récompenses sont fréquentes, mais elles
+**échouent dès que la récompense est rare** : l'agent peut errer des milliers de pas sans
+jamais rencontrer le moindre signal qui oriente son apprentissage.
+
+Ce notebook présente la **motivation intrinsèque** (curiosité) et, en particulier, l'algorithme
+**Random Network Distillation** (RND, Burda et al., 2018), qui a permis les premiers progrès
+marquants sur des environnements à exploration difficile comme *Montezuma's Revenge*.
+
+## Objectifs pédagogiques
+
+- Comprendre pourquoi l'exploration aléatoire échoue dans les environnements à **récompense parcimonieuse**.
+- Définir une **récompense intrinsèque** mesurant la **nouveauté** d'un état.
+- Implémenter RND : une **cible aléatoire figée** et un **prédicteur entraîné**, dont l'erreur de
+  prédiction sert de bonus de curiosité.
+- Visualiser le mécanisme comme un **détecteur de nouveauté** (Partie A) puis observer son effet
+  sur un **piège d'exploitation** (Partie B), où epsilon-greedy reste bloqué et RND s'en échappe.
+
+> Prérequis : notebooks 3 (DQN / experience replay), 4 (bandits) et 8 (Dyna-Q+, bonus d'exploration).",,,,,,,,bdd1a8df5dd4a54d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,ec6791e6,markdown,fr,a6bc37f7cc2b432e,"## 1. Le problème de l'exploration profonde
+
+On distingue **exploration superficielle** et **exploration profonde** :
+
+- **Superficielle** : il suffit de quelques actions aléatoires pour découvrir une meilleure
+  récompense locale. Epsilon-greedy y suffit.
+- **Profonde** : la récompense intéressante n'est atteignable qu'après une **longue séquence
+  cohérente** d'actions. Une marche aléatoire a une probabilité **exponentiellement faible** de
+  l'atteindre, et l'agent se contente alors d'un optimum local.
+
+Le **piège d'exploitation** est le cas canonique : une petite récompense facile à atteindre
+« capture » la politique, qui n'explore jamais assez loin pour trouver la grande récompense.
+C'est exactement la situation que nous reproduirons en Partie B.
+
+### L'idée de la motivation intrinsèque
+
+Plutôt que de ne maximiser que la récompense de l'environnement (**extrinsèque**), on ajoute une
+**récompense intrinsèque** $r^i_t$ qui récompense la **nouveauté** :
+
+$$ r_t = r^e_t + \beta\, r^i_t $$
+
+où $\beta > 0$ pondère la curiosité. L'agent est alors poussé vers les états **rarement visités**,
+ce qui le mène à explorer systématiquement l'espace d'états — y compris les régions lointaines où
+se cache la grande récompense.
+
+Le défi est de **mesurer la nouveauté** sans table de comptage (impraticable en grand espace
+d'états continu). RND apporte une réponse élégante.",,,,,,,,a6bc37f7cc2b432e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,44f40ab0,markdown,fr,b6ac2f9b46584bde,"## 2. Le mécanisme RND
+
+RND repose sur **deux réseaux** prenant l'état $s$ en entrée :
+
+1. Une **cible** $f$ : un réseau aux **poids aléatoires figés** (jamais entraîné). Elle définit une
+   fonction fixe mais arbitraire $f(s)$.
+2. Un **prédicteur** $\hat f_\theta$ : un réseau entraîné à **imiter la cible** sur les états
+   effectivement visités, en minimisant $\lVert \hat f_\theta(s) - f(s) \rVert^2$.
+
+La **récompense intrinsèque** est l'erreur de prédiction :
+
+$$ r^i(s) = \lVert \hat f_\theta(s) - f(s) \rVert^2 $$
+
+**Pourquoi cela fonctionne ?**
+
+- Sur un état **souvent visité**, le prédicteur a eu de nombreuses occasions d'apprendre : l'erreur
+  est **faible** → peu de bonus.
+- Sur un état **nouveau**, le prédicteur n'a jamais vu cette entrée : l'erreur est **élevée** →
+  fort bonus.
+
+L'erreur de prédiction agit donc comme un **pseudo-comptage** de visites : c'est une mesure de
+nouveauté qui **se généralise** naturellement aux grands espaces d'états (contrairement à un
+comptage tabulaire). On commence par illustrer ce mécanisme isolément.",,,,,,,,b6ac2f9b46584bde,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,f2f84aad,code,fr,a9067ef1c0cce2c3,"import numpy as np
+import torch
+import torch.nn as nn
+import matplotlib.pyplot as plt
+import random
+
+SEED = 0
+random.seed(SEED); np.random.seed(SEED); torch.manual_seed(SEED)
+torch.set_num_threads(2)
+print(""Environnement prêt - torch"", torch.__version__)",,,,,,,,a9067ef1c0cce2c3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,55fef1f3,code,fr,fdda1e3da00c987b,"class RNDNet(nn.Module):
+    """"""Petit MLP utilisé à la fois pour la cible (figée) et le prédicteur (entraîné).""""""
+    def __init__(self, in_dim, out_dim, hidden=64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hidden), nn.ReLU(),
+            nn.Linear(hidden, hidden), nn.ReLU(),
+            nn.Linear(hidden, out_dim),
+        )
+    def forward(self, x):
+        return self.net(x)
+
+def make_rnd(in_dim, out_dim=8, hidden=64, lr=1e-3):
+    """"""Crée le couple (cible figée, prédicteur entraînable) et l'optimiseur du prédicteur.""""""
+    target = RNDNet(in_dim, out_dim, hidden)
+    for p in target.parameters():
+        p.requires_grad_(False)            # cible aléatoire : jamais entraînée
+    predictor = RNDNet(in_dim, out_dim, hidden)
+    opt = torch.optim.Adam(predictor.parameters(), lr=lr)
+    return target, predictor, opt
+
+def novelty(target, predictor, x):
+    """"""Erreur de prédiction = signal de nouveauté (bonus intrinsèque).""""""
+    return ((predictor(x) - target(x)) ** 2).sum(-1)",,,,,,,,fdda1e3da00c987b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,e2479e75,markdown,fr,49c8620af0c0da75,"## Partie A - RND comme détecteur de nouveauté (jouet 2D)
+
+Avant de l'intégrer à un agent, isolons le mécanisme. On définit une **région « visitée »** :
+un nuage de points 2D centré autour de $(-0.5, -0.5)$. On entraîne le prédicteur **uniquement sur
+cette région**, puis on mesure la nouveauté dans la région visitée et dans une région **inconnue**
+centrée en $(0.6, 0.6)$.
+
+Attendu : l'erreur de prédiction doit être **quasi nulle** sur la région apprise et **nettement
+plus élevée** sur la région jamais vue.",,,,,,,,49c8620af0c0da75,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,27738cde,code,fr,6e5ba52182a0b0c9,"# Région ""visitée"" : un nuage de points autour de (-0.5, -0.5)
+torch.manual_seed(SEED); np.random.seed(SEED)
+target, predictor, opt = make_rnd(in_dim=2, out_dim=8)
+visited = torch.tensor(np.random.randn(2000, 2) * 0.15 + np.array([-0.5, -0.5]),
+                       dtype=torch.float32)
+
+errs = []
+for step in range(300):
+    idx = torch.randint(0, visited.size(0), (128,))
+    loss = novelty(target, predictor, visited[idx]).mean()
+    opt.zero_grad(); loss.backward(); opt.step()
+    errs.append(loss.item())
+
+with torch.no_grad():
+    near = novelty(target, predictor, visited[:500]).mean().item()
+    far_pts = torch.tensor(np.random.randn(500, 2) * 0.15 + np.array([0.6, 0.6]),
+                           dtype=torch.float32)
+    far = novelty(target, predictor, far_pts).mean().item()
+
+print(f""Nouveauté region visitee  : {near:.5f}"")
+print(f""Nouveauté region inconnue : {far:.5f}"")
+print(f""Ratio inconnue / visitee  : {far / max(near, 1e-9):.0f}x"")",,,,,,,,6e5ba52182a0b0c9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,4f751fc7,code,fr,07bc997308b644ad,"# Carte de nouveauté sur une grille 2D + courbe d'apprentissage du prédicteur
+xs = np.linspace(-1.2, 1.2, 80); ys = np.linspace(-1.2, 1.2, 80)
+gx, gy = np.meshgrid(xs, ys)
+grid = torch.tensor(np.stack([gx.ravel(), gy.ravel()], 1), dtype=torch.float32)
+with torch.no_grad():
+    heat = novelty(target, predictor, grid).numpy().reshape(gx.shape)
+
+fig, ax = plt.subplots(1, 2, figsize=(11, 4.2))
+ax[0].plot(errs)
+ax[0].set_title(""Perte du prédicteur (apprentissage)"")
+ax[0].set_xlabel(""pas d'optimisation""); ax[0].set_ylabel(""erreur quadratique moyenne"")
+ax[0].grid(alpha=0.3)
+im = ax[1].contourf(gx, gy, np.log10(heat + 1e-8), levels=30, cmap=""viridis"")
+ax[1].scatter(visited[:300, 0], visited[:300, 1], s=4, c=""white"", alpha=0.4,
+              label=""états visités"")
+ax[1].set_title(""Carte de nouveauté RND  (log10)"")
+ax[1].set_xlabel(""dimension 1""); ax[1].set_ylabel(""dimension 2"")
+ax[1].legend(loc=""upper left"")
+fig.colorbar(im, ax=ax[1])
+plt.tight_layout(); plt.show()",,,,,,,,07bc997308b644ad,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,38b92b98,markdown,fr,1fbe3cc3a26af4e0,"**Interprétation.** Le ratio nouveauté inconnue / visitée est de l'ordre de **plusieurs centaines
+à plusieurs milliers** : le prédicteur reproduit fidèlement la cible là où il a été entraîné
+(erreur quasi nulle, zone sombre de la carte autour du nuage blanc) et **échoue** partout ailleurs
+(erreur élevée, zones claires). La carte de nouveauté est donc une **mesure d'inexploration** :
+c'est exactement le signal qu'un agent doit suivre pour aller voir ce qu'il n'a pas encore vu.
+
+À mesure que l'agent visiterait de nouvelles régions, le prédicteur les apprendrait à son tour et
+leur bonus **diminuerait** — la curiosité est **auto-extinctive**, ce qui évite que l'agent reste
+fasciné indéfiniment par la même zone.",,,,,,,,1fbe3cc3a26af4e0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,7a183e9d,markdown,fr,4252a5fce2dffa84,"## Partie B - Le piège d'exploitation (MDP en chaîne)
+
+On construit un MDP en **chaîne** de $N$ états (ici $N=16$) :
+
+- L'agent démarre à l'état $0$. Deux actions : **gauche** (0) ou **droite** (1).
+- **Gauche depuis l'état 0** mène immédiatement à une **petite récompense** $r=0.1$ (le piège), et
+  l'épisode se termine.
+- Aller **à droite** de façon répétée jusqu'à l'état $N-1$ donne la **grande récompense** $r=1.0$.
+
+C'est un cas d'**exploration profonde** : atteindre la grande récompense exige $N-1$ actions
+« droite » consécutives. Une politique gloutonne découvre le petit gain en **une seule action** et
+s'y enferme. Seule une exploration dirigée vers la frontière inexplorée permet d'atteindre le grand
+gain. On compare **epsilon-greedy pur** et **Q-learning + bonus RND** (la nouveauté est calculée
+sur l'encodage one-hot de l'état, ce qui en fait un pseudo-comptage neuronal).",,,,,,,,4252a5fce2dffa84,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,bd5ee18f,code,fr,64210737aedaa58f,"SMALL, BIG = 0.1, 1.0
+
+def make_chain(N):
+    """"""MDP en chaîne. Gauche depuis l'état 0 -> petit piège ; droite jusqu'à N-1 -> grand gain.""""""
+    def step(s, a):
+        if s == 0 and a == 0:                 # gauche au départ : piège terminal
+            return 0, SMALL, True
+        ns = min(N - 1, s + 1) if a == 1 else max(0, s - 1)
+        if ns == N - 1:                       # frontière droite : grande récompense
+            return ns, BIG, True
+        return ns, 0.0, False
+    return step
+
+def onehot(s, N):
+    v = torch.zeros(1, N); v[0, s] = 1.0
+    return v
+
+def train_chain(use_rnd, N=16, episodes=500, beta=0.8, pred_lr=3e-4, seed=SEED):
+    """"""Q-learning tabulaire sur la chaîne, avec bonus RND optionnel.
+    Retourne (récompenses extrinsèques par épisode, histogramme de visites d'états).""""""
+    random.seed(seed); np.random.seed(seed); torch.manual_seed(seed)
+    step_env = make_chain(N)
+    Q = np.zeros((N, 2)); alpha, GAMMA, H = 0.5, 0.99, 3 * N
+    target, predictor, opt = make_rnd(in_dim=N, out_dim=8, lr=pred_lr)
+    returns, visits = [], np.zeros(N)
+    for ep in range(episodes):
+        s = 0; ext_ret = 0.0
+        eps = max(0.05, 1.0 - ep / (episodes * 0.5))          # décroissance d'epsilon
+        for _ in range(H):
+            a = random.randint(0, 1) if random.random() < eps else int(np.argmax(Q[s]))
+            ns, ext, done = step_env(s, a)
+            visits[ns] += 1
+            r = ext
+            if use_rnd:
+                with torch.no_grad():
+                    nov = novelty(target, predictor, onehot(ns, N)).item()
+                r = ext + beta * nov                          # récompense augmentée
+                loss = novelty(target, predictor, onehot(ns, N)).mean()
+                opt.zero_grad(); loss.backward(); opt.step()  # le prédicteur apprend l'état visité
+            Q[s, a] += alpha * (r + GAMMA * (0.0 if done else Q[ns].max()) - Q[s, a])
+            s = ns; ext_ret += ext
+            if done:
+                break
+        returns.append(ext_ret)
+    return np.array(returns), visits",,,,,,,,64210737aedaa58f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,930c8aa6,code,fr,c62772a050304c8e,"N = 16
+ret_eps, vis_eps = train_chain(use_rnd=False, N=N)
+ret_rnd, vis_rnd = train_chain(use_rnd=True,  N=N)
+
+def smooth(x, k=20):
+    return np.convolve(x, np.ones(k) / k, mode=""valid"")
+
+print(f""epsilon-greedy : récompense moyenne (50 derniers ép.) = {ret_eps[-50:].mean():.3f}"")
+print(f""RND (curiosité): récompense moyenne (50 derniers ép.) = {ret_rnd[-50:].mean():.3f}"")
+print(f""RND atteint la grande récompense dans ""
+      f""{100 * np.mean(ret_rnd[-50:] >= 0.9 * BIG):.0f}% des 50 derniers épisodes"")",,,,,,,,c62772a050304c8e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,795aeef3,code,fr,261520053d82e774,"fig, ax = plt.subplots(1, 2, figsize=(12, 4.2))
+ax[0].plot(smooth(ret_eps), label=""epsilon-greedy"", color=""tab:red"")
+ax[0].plot(smooth(ret_rnd), label=""RND (curiosité)"", color=""tab:green"")
+ax[0].axhline(SMALL, ls=""--"", c=""gray"", lw=1, label=""piège (petite récompense)"")
+ax[0].axhline(BIG, ls="":"", c=""black"", lw=1, label=""grande récompense"")
+ax[0].set_title(""Récompense extrinsèque par épisode (lissée)"")
+ax[0].set_xlabel(""épisode""); ax[0].set_ylabel(""récompense""); ax[0].legend(); ax[0].grid(alpha=0.3)
+
+w = 0.4; idx = np.arange(N)
+ax[1].bar(idx - w / 2, vis_eps / vis_eps.sum(), w, label=""epsilon-greedy"",
+          color=""tab:red"", alpha=0.8)
+ax[1].bar(idx + w / 2, vis_rnd / vis_rnd.sum(), w, label=""RND"", color=""tab:green"", alpha=0.8)
+ax[1].set_title(""Distribution des visites d'états"")
+ax[1].set_xlabel(""état (0 = départ, N-1 = grande récompense)"")
+ax[1].set_ylabel(""fréquence de visite"")
+ax[1].legend(); ax[1].grid(alpha=0.3)
+plt.tight_layout(); plt.show()",,,,,,,,261520053d82e774,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,cb2d722b,markdown,fr,2d07d8d416683eb1,"**Interprétation.** La courbe rouge (epsilon-greedy) **plafonne sur la petite récompense** (~0.1) :
+dès qu'elle a découvert le piège à gauche, la politique s'y enferme. La courbe verte (RND)
+**décolle** et converge vers la **grande récompense** (~1.0) dans la quasi-totalité des derniers
+épisodes.
+
+L'histogramme de visites raconte la même histoire : epsilon-greedy concentre ses visites sur les
+**premiers états** (près du départ et du piège), tandis que RND **répartit ses visites jusqu'à la
+frontière droite** $N-1$. Le bonus de nouveauté a transformé une exploration myope en une
+**exploration profonde et dirigée**, qui seule permet de sortir du piège d'exploitation.",,,,,,,,2d07d8d416683eb1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,4c8e3e4a,markdown,fr,4e15f1f657f49419,"## 3. RND par rapport aux autres approches d'exploration
+
+| Approche | Mesure de nouveauté | Passage à l'échelle | Notebook |
+|----------|---------------------|---------------------|----------|
+| Epsilon-greedy | aucune (aléa uniforme) | trivial mais myope | 1, 3, 6 |
+| Comptage tabulaire / Dyna-Q+ | $1/\sqrt{N(s)}$ | limité aux petits espaces | 8 |
+| Pseudo-comptage (modèles de densité) | densité estimée | moyen, coûteux | - |
+| **RND** | **erreur de prédiction d'une cible figée** | **excellent** (réseau) | **13 (ici)** |
+| ICM (Curiosity, Pathak 2017) | erreur d'un modèle de dynamique inverse/avant | excellent | - |
+
+Le grand mérite de RND est sa **simplicité** : pas de modèle de dynamique, pas d'estimation de
+densité, juste **deux petits réseaux** et une erreur quadratique. C'est ce qui en a fait une
+référence pour l'exploration dans les environnements à récompense rare.
+
+### Limites et bonnes pratiques
+
+- **Normalisation** : en pratique, on normalise les observations *et* la récompense intrinsèque
+  (par un écart-type courant) pour stabiliser l'échelle du bonus — c'est l'objet de l'exercice 2.
+- **Distraction télévisuelle** (*noisy-TV problem*) : si l'environnement contient de l'aléa
+  irréductible (un écran de bruit), RND y voit une nouveauté permanente et peut s'y bloquer.
+- **Décroissance du bonus** : le bonus s'éteint à mesure que le prédicteur apprend ; il faut donc
+  que l'apprentissage de la valeur soit assez rapide pour exploiter la grande récompense une fois
+  découverte. En pratique, le **taux d'apprentissage du prédicteur** est un réglage sensible : trop
+  élevé, le prédicteur apprend la frontière inexplorée plus vite que l'agent ne l'exploite et le
+  bonus s'évanouit avant d'avoir servi (l'agent retombe dans le piège) ; on le choisit donc
+  **plus lent** que celui de la fonction de valeur.",,,,,,,,4e15f1f657f49419,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,cfa71b1e,markdown,fr,97edc48fc97762a4,"## 4. Exercices
+
+Les trois exercices ci-dessous réutilisent les fonctions définies plus haut (`train_chain`,
+`make_chain`, `make_rnd`, `novelty`). Chaque squelette est à compléter ; le notebook s'exécute de
+bout en bout même si les exercices ne sont pas encore traités.",,,,,,,,97edc48fc97762a4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,8478f8eb,markdown,fr,693a2c9912c7d583,"### Exercice 1 - Effet du coefficient de curiosité $\beta$
+
+**Objectif.** Étudier le compromis exploration / exploitation en fonction de $\beta$.
+Un $\beta$ trop faible laisse l'agent tomber dans le piège ; un $\beta$ trop fort peut rendre
+l'exploration erratique et ralentir l'exploitation une fois la grande récompense trouvée.
+
+**Indices.**
+- Réutiliser `train_chain(use_rnd=True, beta=...)` pour chaque valeur de $\beta$.
+- Relever la récompense finale moyenne `ret[-50:].mean()`.
+- Tracer récompense finale en fonction de $\beta$.",,,,,,,,693a2c9912c7d583,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,8dadc8a8,code,fr,0782e639e851382a,"def explore_beta(betas=(0.0, 0.1, 0.8, 3.0)):
+    """"""EXERCICE 1 - Pour chaque beta, entraîner l'agent RND et relever la récompense finale.
+    Retourner un dictionnaire {beta: récompense_finale_moyenne}.
+    """"""
+    # TODO etudiant : completer
+    results = None  # exemple attendu : {b: train_chain(use_rnd=True, beta=b)[0][-50:].mean() for b in betas}
+    return results
+
+# resultats = explore_beta()
+# print(resultats)",,,,,,,,0782e639e851382a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,5b862804,markdown,fr,c6bc1893a869a881,"### Exercice 2 - Normalisation de la récompense intrinsèque
+
+**Objectif.** Reproduire une pratique clé de Burda et al. (2018) : diviser le bonus intrinsèque par
+un **écart-type courant** des erreurs de prédiction, afin que l'échelle du bonus reste stable au
+fil de l'entraînement (les erreurs sont grandes au début, petites ensuite).
+
+**Indices.**
+- Maintenir une moyenne / variance incrémentale (algorithme de Welford) des erreurs intrinsèques.
+- Remplacer `r = ext + beta * nov` par `r = ext + beta * nov / (std_courant + 1e-8)`.
+- Comparer la stabilité de la courbe d'apprentissage à celle de `train_chain`.",,,,,,,,c6bc1893a869a881,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,5008202b,code,fr,5c5918569336af77,"class RunningStd:
+    """"""À compléter : moyenne/écart-type courants (Welford) des erreurs intrinsèques.""""""
+    def __init__(self):
+        # TODO etudiant : initialiser n, mean, M2
+        pass
+    def update(self, x):
+        # TODO etudiant : mise à jour incrémentale
+        pass
+    @property
+    def std(self):
+        # TODO etudiant : renvoyer l'écart-type courant
+        return None
+
+def train_chain_normalized(N=16, episodes=500, beta=0.8, pred_lr=3e-4, seed=SEED):
+    """"""EXERCICE 2 - Variante de train_chain avec normalisation du bonus intrinsèque.
+    S'inspirer de train_chain et utiliser RunningStd pour diviser `nov` par l'écart-type courant.
+    """"""
+    # TODO etudiant : completer en s'inspirant de train_chain
+    pass
+
+# ret_norm, _ = train_chain_normalized()",,,,,,,,5c5918569336af77,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,ad1b0ab5,markdown,fr,f72341338f4858d4,"### Exercice 3 - Jusqu'où la curiosité tient-elle ?
+
+**Objectif.** Caractériser le régime où l'exploration profonde par RND reste efficace.
+Allonger la chaîne (augmenter $N$) et / ou ajouter un **second piège**, puis déterminer le taux de
+succès de RND pour atteindre la grande récompense.
+
+**Indices.**
+- Balayer $N \in \{16, 20, 24, 32\}$ et relever, pour chaque $N$, la fraction d'épisodes finaux où
+  la grande récompense est atteinte.
+- Optionnel : modifier `make_chain` pour insérer un second distracteur en milieu de chaîne.
+- Discuter : à partir de quelle longueur la curiosité ne suffit-elle plus dans ce budget d'épisodes ?",,,,,,,,f72341338f4858d4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,f6ae40e5,code,fr,e6ff347f723f09e5,"def success_vs_length(Ns=(16, 20, 24, 32), episodes=500):
+    """"""EXERCICE 3 - Taux de succès de RND en fonction de la longueur de chaîne N.
+    Retourner {N: fraction des 50 derniers épisodes atteignant la grande récompense}.
+    """"""
+    # TODO etudiant : completer
+    return None
+
+# taux = success_vs_length()
+# print(taux)",,,,,,,,e6ff347f723f09e5,,,,,,,
+MyIA.AI.Notebooks/RL/rl_13_curiosity_exploration.ipynb,dc780b93,markdown,fr,5a7da03586419a51,"## 5. Synthèse
+
+- L'**exploration aléatoire** (epsilon-greedy) échoue dès que la récompense est rare ou cachée
+  derrière une longue séquence d'actions : elle reste piégée dans les optima locaux faciles.
+- La **motivation intrinsèque** ajoute un bonus de **nouveauté** qui pousse l'agent vers les états
+  inexplorés, transformant l'exploration myope en **exploration profonde**.
+- **RND** mesure la nouveauté par l'**erreur de prédiction d'une cible aléatoire figée** : simple,
+  sans modèle de dynamique, et capable de passer à l'échelle des grands espaces d'états.
+- Sur le piège d'exploitation, RND s'échappe vers la grande récompense (~1.0) là où epsilon-greedy
+  plafonne sur le piège (~0.1) — un écart **net et reproductible**.
+
+### Pour aller plus loin
+
+- **ICM** (Pathak et al., 2017) : curiosité fondée sur un modèle de dynamique avant/inverse.
+- **Go-Explore** (Ecoffet et al., 2019) : mémoriser et revisiter les états prometteurs.
+- Combiner RND avec un agent **DQN** (notebook 3) ou **PPO** (notebook 6c) sur un environnement
+  continu à récompense parcimonieuse (ex. *MountainCar*, *Montezuma's Revenge*).
+
+### Références
+
+- Burda, Edwards, Storkey, Klimov (2018). *Exploration by Random Network Distillation*. ICLR 2019.
+- Pathak, Agrawal, Efros, Darrell (2017). *Curiosity-driven Exploration by Self-supervised Prediction*. ICML.
+- Osband et al. (2019). *Deep Exploration via Randomized Value Functions*. JMLR.",,,,,,,,5a7da03586419a51,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,0dfd478b,markdown,fr,0d96b087b4e25dc3,"**Navigation** : [Index](README.md) | [RL-2 Wrappers >>](rl_2_wrappers_sauvegarde_callbacks.ipynb)
+# Tutoriel Stable Baselines3 - Premiers pas
+
+**Serie** : Reinforcement Learning | **Notebook** : 1/13 | **Duree estimee** : 25-30 min
+
+Stable-Baselines3 : https://github.com/DLR-RM/stable-baselines3
+
+Documentation : https://stable-baselines3.readthedocs.io/en/master/
+
+RL Baselines3 zoo : https://github.com/DLR-RM/rl-baselines3-zoo
+
+
+[RL Baselines3 Zoo](https://github.com/DLR-RM/rl-baselines3-zoo) est un framework d’entraînement pour l’Apprentissage par Renforcement (RL), basé sur Stable Baselines3.
+
+Il fournit des scripts pour entraîner des agents, les évaluer, réaliser des recherches d’hyperparamètres, tracer des courbes de résultats et enregistrer des vidéos.
+
+Source:  https://github.com/araffin/rl-tutorial-jnrr19
+
+## Introduction
+
+Dans ce notebook, vous allez apprendre les bases d’utilisation de la librairie Stable Baselines3 : comment créer un modèle RL, l’entraîner et l’évaluer. Comme toutes les algorithmes partagent la même interface, nous verrons qu’il est très simple de passer d’un algorithme à un autre.
+
+## Installer les dépendances et Stable Baselines3 avec Pip
+
+La liste complète des dépendances est disponible dans le [README](https://github.com/DLR-RM/stable-baselines3).
+
+Pour installer :
+```
+pip install stable-baselines3[extra]
+```
+
+---
+**Rappels sur l’Apprentissage par Renforcement (AR)**  
+- Un agent interagit avec un environnement au fil de pas de temps.  
+- À chaque pas, il reçoit un `state` (observation), choisit une `action` et obtient une `reward`.  
+- Le but est de maximiser la somme des récompenses.  
+- Stable-Baselines3 fournit un ensemble d’algorithmes pour entraîner cet agent sur divers environnements.
+
+*Astuce* : Pour ceux qui découvrent Gym, explorez rapidement `env.action_space` et `env.observation_space` pour comprendre les dimensions et les types d’actions.
+",,,,,,,,0d96b087b4e25dc3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,3ffcce8f,code,fr,719079b20bd17681,"# Sous Windows, on ne fait pas d'apt-get.
+# %apt-get update && apt-get install ffmpeg freeglut3-dev xvfb  # Pour la visualisation sous Linux
+%pip install ""stable-baselines3[extra]>=2.0.0a4"" moviepy",,,,,,,,719079b20bd17681,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,64a42923,markdown,fr,c4db0289fb7e753a,Verification de l'installation de Stable Baselines3.,,,,,,,,c4db0289fb7e753a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,a2c73b9f,code,fr,56634eb8fa68857d,"import stable_baselines3
+
+print(f""{stable_baselines3.__version__=}"")",,,,,,,,56634eb8fa68857d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,54c32632,markdown,fr,d357b415148d0567,## Imports,,,,,,,,d357b415148d0567,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,8640801b,markdown,fr,33eb9ec7ebbed1ef,"Stable-Baselines3 fonctionne avec des environnements qui suivent l’interface [gym](https://stable-baselines.readthedocs.io/en/master/guide/custom_env.html).
+Vous pouvez trouver une liste d’environnements disponibles [ici](https://gym.openai.com/envs/#classic_control).
+
+Il est aussi recommandé de regarder le [code source](https://github.com/openai/gym) pour en savoir plus sur l’espace d’observation et d’action de chaque environnement, car gym ne fournit pas de documentation très détaillée.
+Tous les algorithmes ne sont pas compatibles avec tous les espaces d’action. Vous trouverez plus d’informations dans ce [tableau récapitulatif](https://stable-baselines.readthedocs.io/en/master/guide/algos.html).",,,,,,,,33eb9ec7ebbed1ef,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,5fd01f77,code,fr,ad700941e501d8c8,"import gymnasium as gym
+import numpy as np
+
+print(f""{gym.__version__=}"")",,,,,,,,ad700941e501d8c8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,8e411ffc,markdown,fr,5b08c9a71ccffcbe,"La première chose dont vous avez besoin est d’importer la classe de l’algorithme de RL que vous souhaitez utiliser. Consultez la documentation pour savoir quel algorithme utiliser dans quel contexte.
+
+PPO est un algorithme on-policy, ce qui signifie que les données utilisées pour la mise à jour des réseaux proviennent de la politique courante. À l’inverse, un algo off-policy comme DQN peut réutiliser des données issues de politiques antérieures.",,,,,,,,5b08c9a71ccffcbe,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,de6dd33c,code,fr,792cb2e777703743,"from stable_baselines3 import PPO
+print(""PPO importe depuis stable_baselines3."")",,,,,,,,792cb2e777703743,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,ccdf628a,markdown,fr,cb8f1a78636f68e6,"Ensuite, vous pouvez importer la classe de politique (policy) qui servira à créer les réseaux (pour la fonction de politique et la fonction de valeur). Ce n’est pas obligatoire : vous pouvez directement utiliser des chaînes de caractères lors de la création du modèle, par exemple :
+```PPO('MlpPolicy', env)``` au lieu de ```PPO(MlpPolicy, env)```.
+
+Notez que certains algorithmes comme `SAC` ont leur propre `MlpPolicy`, donc l’utilisation de la chaîne de caractères est généralement recommandée.",,,,,,,,cb8f1a78636f68e6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,6b98e551,code,fr,046171cab30e44f9,"from stable_baselines3.ppo import MlpPolicy
+print(""MlpPolicy importe."")",,,,,,,,046171cab30e44f9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,1bc2fed7,markdown,fr,7e8180781c1eb5ed,"## Créer l’environnement Gym et instancier l’agent
+
+Dans cet exemple, nous allons utiliser l’environnement CartPole, un problème classique de contrôle.
+
+« Un poteau est attaché par un joint non-actionné à un chariot, qui se déplace le long d’un rail sans frottement. Le système est contrôlé en appliquant une force de +1 ou -1 sur le chariot. Le pendule commence à la verticale, et l’objectif est de l’empêcher de tomber. Une récompense de +1 est accordée à chaque pas de temps pendant lequel le poteau reste en position verticale. »
+
+Environnement CartPole : [https://gymnasium.farama.org/environments/classic_control/cart_pole/](https://gymnasium.farama.org/environments/classic_control/cart_pole/)
+
+![Cartpole](https://cdn-images-1.medium.com/max/1143/1*h4WTQNVIsvMXJTCpXm_TAw.gif)
+
+Les environnements vectorisés (vecenv) permettent de faciliter l’entraînement en parallèle. Ici, nous utilisons un seul processus, donc `DummyVecEnv`.
+
+Nous choisissons `MlpPolicy` car l’entrée de CartPole est un vecteur de caractéristiques (et non une image).
+
+Le type d’action (discrète/continue) sera automatiquement déduit de l’espace d’action de l’environnement.
+
+Ici, nous utilisons [Proximal Policy Optimization](https://stable-baselines.readthedocs.io/en/master/modules/ppo2.html), qui est une méthode Actor-Critic : elle utilise une fonction de valeur pour améliorer la descente de gradient de la politique (en réduisant la variance).
+
+PPO combine des idées d’[A2C](https://stable-baselines.readthedocs.io/en/master/modules/a2c.html) (plusieurs workers et bonus d’entropie pour encourager l’exploration) et de [TRPO](https://stable-baselines.readthedocs.io/en/master/modules/trpo.html) (utilisation d’une région de confiance pour stabiliser l’apprentissage et éviter des chutes drastiques de performance).
+
+PPO est un algorithme on-policy : les trajectoires utilisées pour mettre à jour les réseaux doivent être collectées avec la politique la plus récente.
+Il est généralement moins échantillonnement-efficace que des algorithmes off-policy comme [DQN](https://stable-baselines.readthedocs.io/en/master/modules/dqn.html), [SAC](https://stable-baselines.readthedocs.io/en/master/modules/sac.html) ou [TD3](https://stable-baselines.readthedocs.io/en/master/modules/td3.html), mais il est souvent plus rapide en temps d’horloge réel.",,,,,,,,7e8180781c1eb5ed,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,ae321a8b,code,fr,8cf90c42064b997f,"env = gym.make(""CartPole-v1"", render_mode=""rgb_array"")
+model = PPO(MlpPolicy, env, verbose=0)
+print(f""Environnement CartPole-v1 cree, modele PPO initialise avec MlpPolicy."")",,,,,,,,8cf90c42064b997f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,9e198490,markdown,fr,ac01ee624507d61b,Nous créons une fonction utilitaire pour évaluer l’agent :,,,,,,,,ac01ee624507d61b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,dddabb38,code,fr,a1aca407b885979c,"def evaluate(model, num_episodes=100, deterministic=True):
+    """"""
+    Évalue un agent RL.
+    :param model: (BaseRLModel) l'agent RL
+    :param num_episodes: (int) nombre d'épisodes sur lesquels évaluer
+    :param deterministic: (bool) si on utilise une politique déterministe
+    :return: (float) Récompense moyenne sur les num_episodes derniers épisodes
+    """"""
+    vec_env = model.get_env()
+    all_episode_rewards = []
+    for i in range(num_episodes):
+        episode_rewards = []
+        done = False
+        obs = vec_env.reset()
+        while not done:
+            action, _states = model.predict(obs, deterministic=deterministic)
+            obs, reward, done, info = vec_env.step(action)
+            episode_rewards.append(reward)
+
+        all_episode_rewards.append(sum(episode_rewards))
+
+    mean_episode_reward = np.mean(all_episode_rewards)
+    print(""Récompense moyenne :"", mean_episode_reward, ""Nombre d'épisodes :"", num_episodes)
+
+    return mean_episode_reward
+
+print(""Fonction evaluate() definie."")",,,,,,,,a1aca407b885979c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,6425278c,markdown,fr,356507350ea3f3a2,"En fait, Stable-Baselines3 fournit déjà un utilitaire similaire :",,,,,,,,356507350ea3f3a2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,00025f2a,code,fr,e5ed7cedb907c324,"from stable_baselines3.common.evaluation import evaluate_policy
+print(""evaluate_policy importe."")",,,,,,,,e5ed7cedb907c324,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,5e32500a,markdown,fr,c28fd807fa59150a,Évaluons l’agent non entraîné ; il devrait agir de façon essentiellement aléatoire.,,,,,,,,c28fd807fa59150a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,5f778623,code,fr,6fa8d0f2b7a05656,"# Nous utilisons un environnement distinct pour l’évaluation
+eval_env = gym.make(""CartPole-v1"", render_mode=""rgb_array"")
+
+# Agent aléatoire, avant entraînement
+mean_reward, std_reward = evaluate_policy(model, eval_env, n_eval_episodes=100)
+print(f""mean_reward:{mean_reward:.2f} +/- {std_reward:.2f}"")",,,,,,,,6fa8d0f2b7a05656,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,f2b0d076,markdown,fr,170b023dd0663cb2,"## Entraîner l’agent et l’évaluer
+
+**Hyperparamètres clés**  
+- `total_timesteps`: nombre total de pas d’entraînement (interactions avec l’environnement).  
+- `learning_rate`: définit la vitesse à laquelle les poids sont mis à jour.  
+- `n_steps` (ou équivalent): longueur des trajectoires collectées avant chaque mise à jour, etc.  
+- `batch_size`: taille de l’échantillon pour chaque itération d’apprentissage.  
+
+*Tip* : N’hésitez pas à ajuster progressivement `total_timesteps` si la convergence n’est pas satisfaisante.
+",,,,,,,,170b023dd0663cb2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,af265070,code,fr,99db7174ccc31beb,"# Entraînons l’agent pendant 10 000 pas
+model.learn(total_timesteps=10_000)",,,,,,,,99db7174ccc31beb,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,fe09ec5d,markdown,fr,5da596f7b9752ac6,Evaluation de l'agent entraine sur 10 episodes.,,,,,,,,5da596f7b9752ac6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,58166ed8,code,fr,9ecb2adc820cba99,"# Évaluons l’agent entraîné
+mean_reward, std_reward = evaluate_policy(model, eval_env, n_eval_episodes=100)
+print(f""mean_reward:{mean_reward:.2f} +/- {std_reward:.2f}"")",,,,,,,,9ecb2adc820cba99,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,b05a0f67,markdown,fr,2099370e901748f9,"Visiblement, l’entraînement s’est bien déroulé : la récompense moyenne a beaucoup augmenté !",,,,,,,,2099370e901748f9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,1c001df2,markdown,fr,c5595ce743551600,"### Préparer l’enregistrement vidéo
+
+**Note sur la visualisation**  
+- Sous Windows, on n’a pas besoin de créer de display virtuel (`xvfb`).  
+- Sur Linux, si vous n’avez pas d’interface graphique, vous devrez lancer un display virtuel pour capturer des frames (`xvfb-run`).  
+- Les fonctions ci-dessous utilisent `render_mode=\""rgb_array\""` pour récupérer les images directement.
+",,,,,,,,c5595ce743551600,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,26a4f76e,code,fr,36d4fc58d9ab4be3,"# Sous Windows, pas besoin de lancer un display virtuel.
+# On commente donc la partie suivante (utile surtout sous Linux) :
+# import os
+# os.system(""Xvfb :1 -screen 0 1024x768x24 &"")
+# os.environ['DISPLAY'] = ':1'
+print(""Display virtuel non necessaire sous Windows."")",,,,,,,,36d4fc58d9ab4be3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,5acbce62,markdown,fr,62cbeeaf7ee5c1cc,Configuration de l'enregistrement video.,,,,,,,,62cbeeaf7ee5c1cc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,7ec6a191,code,fr,1c4722ab9574c8a6,"import base64
+from pathlib import Path
+from IPython import display as ipythondisplay
+
+def show_videos(video_path="""", prefix=""""):
+    """"""
+    Affiche les vidéos enregistrées dans le notebook.
+    :param video_path: (str) chemin vers le dossier contenant les vidéos
+    :param prefix: (str) filtre sur le préfixe des noms de fichiers vidéo
+    """"""
+    html = []
+    for mp4 in Path(video_path).glob(""{}*.mp4"".format(prefix)):
+        video_b64 = base64.b64encode(mp4.read_bytes())
+        html.append(
+            """"""<video alt=""{}"" autoplay
+                    loop controls style=""height: 400px;"">
+                    <source src=""data:video/mp4;base64,{}"" type=""video/mp4"" />
+                </video>"""""".format(
+                mp4, video_b64.decode(""ascii"")
+            )
+        )
+    ipythondisplay.display(ipythondisplay.HTML(data=""<br>"".join(html)))
+
+print(""Utilitaires video charges (show_videos)."")",,,,,,,,1c4722ab9574c8a6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,fc373d90,markdown,fr,de2850d8b1a899df,Nous allons enregistrer une vidéo à l’aide de [VecVideoRecorder](https://stable-baselines.readthedocs.io/en/master/guide/vec_envs.html#vecvideorecorder). Vous en apprendrez davantage sur ces wrappers dans le prochain notebook.,,,,,,,,de2850d8b1a899df,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,55b1cd72,code,fr,ee126627a57bb48f,"from stable_baselines3.common.vec_env import VecVideoRecorder, DummyVecEnv
+
+def record_video(env_id, model, video_length=500, prefix="""", video_folder=""videos/""):
+    """"""
+    :param env_id: (str)
+    :param model: (RL model)
+    :param video_length: (int)
+    :param prefix: (str)
+    :param video_folder: (str)
+    """"""
+    eval_env = DummyVecEnv([lambda: gym.make(""CartPole-v1"", render_mode=""rgb_array"")])
+    eval_env = VecVideoRecorder(
+        eval_env,
+        video_folder=video_folder,
+        record_video_trigger=lambda step: step == 0,
+        video_length=video_length,
+        name_prefix=prefix,
+    )
+
+    obs = eval_env.reset()
+    for _ in range(video_length):
+        action, _ = model.predict(obs)
+        obs, _, _, _ = eval_env.step(action)
+
+    eval_env.close()
+
+print(""Fonctions record_video et show_videos pretes."")",,,,,,,,ee126627a57bb48f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,640999f5,markdown,fr,2d4882cb7b5eb806,"### Visualiser l’agent entraîné
+",,,,,,,,2d4882cb7b5eb806,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,1e544539,code,fr,5680c6cdcd92aec7,"record_video(""CartPole-v1"", model, video_length=500, prefix=""ppo-cartpole"")",,,,,,,,5680c6cdcd92aec7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,50b8f8ca,markdown,fr,f405d48354c44dc3,Affichage de la video enregistree.,,,,,,,,f405d48354c44dc3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,bbb3e432,code,fr,1cfaaf8194edb123,"show_videos(""videos"", prefix=""ppo"")",,,,,,,,1cfaaf8194edb123,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,dd6146d0,markdown,fr,37a27ff308c41762,"## Bonus : entraîner un modèle RL en une seule ligne
+
+La classe de politique utilisée sera déduite automatiquement et l’environnement sera créé automatiquement également. Cela fonctionne parce que les deux sont [enregistrés](https://stable-baselines.readthedocs.io/en/master/guide/quickstart.html).",,,,,,,,37a27ff308c41762,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,2373fecf,code,fr,06cb598e0e74f850,"model = PPO('MlpPolicy', ""CartPole-v1"", verbose=1).learn(1000)",,,,,,,,06cb598e0e74f850,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,1af41f34,markdown,fr,fb2244187161e4e7,"## Exercices
+
+Les exercices suivants vous permettent de mettre en pratique les concepts abordes dans ce notebook : comparaison d'algorithmes, sensibilite aux hyperparametres et analyse des courbes d'apprentissage.",,,,,,,,fb2244187161e4e7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,2b4a16db,markdown,fr,78d81f56ef32e2a9,"### Exercice 1 : Comparaison d'algorithmes sur CartPole
+
+Stable Baselines3 offre une interface unifiee pour tous les algorithmes. L'objectif est d'entrainer trois algorithmes differents (PPO, A2C et DQN) sur le meme environnement et de comparer leurs performances.
+
+**Indice** : Utilisez `from stable_baselines3 import PPO, A2C, DQN` et la fonction `evaluate_policy` vue precedemment. Chaque algorithme a des caracteristiques differentes (on-policy vs off-policy, type d'espace d'action supporte).",,,,,,,,78d81f56ef32e2a9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,97af2b3d,code,fr,cedd5a9a82c81ecf,"# Exercice 1 : Comparaison d'algorithmes sur CartPole
+# TODO etudiant : Entrainez PPO, A2C et DQN sur CartPole-v1 avec 10000 steps chacun
+# Indice : from stable_baselines3 import PPO, A2C, DQN
+# Indice : Pour chaque algorithme, creez le modele, appelez .learn(10000), puis evaluate_policy
+# Etape 1 : Creer l'environnement d'evaluation
+# Etape 2 : Boucler sur les 3 algorithmes, entrainer et stocker mean_reward
+# Etape 3 : Afficher un tableau comparatif des recompenses moyennes
+
+results = {}  # TODO etudiant : remplir avec les resultats {algo_name: mean_reward}
+print(""Exercice a completer : comparaison de PPO, A2C et DQN sur CartPole-v1"")",,,,,,,,cedd5a9a82c81ecf,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,a897f643,markdown,fr,811dba46af301ede,"### Exercice 2 : Sensibilite au learning rate
+
+Le learning rate est un hyperparametre critique. Une valeur trop faible ralentit la convergence, une valeur trop elevee peut la destabiliser. Testez plusieurs valeurs et observez l'impact sur les performances finales.
+
+**Indice** : Passez `learning_rate=lr` au constructeur `PPO(...)`. Utilisez `matplotlib` pour tracer un graphique `learning_rate` vs `mean_reward`.",,,,,,,,811dba46af301ede,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,e9d59aa2,code,fr,1e7a3def3c6d69d2,"# Exercice 2 : Sensibilite au learning rate
+# TODO etudiant : Testez PPO sur CartPole-v1 avec differentes valeurs de learning_rate
+# Indice : learning_rates = [1e-5, 1e-4, 1e-3, 1e-2]
+# Indice : Pour chaque lr, creez PPO(""MlpPolicy"", env, learning_rate=lr, verbose=0)
+# Etape 1 : Definir la liste des learning rates a tester
+# Etape 2 : Boucler, entrainer chaque modele (10000 steps), evaluer et stocker
+# Etape 3 : Tracer un graphique (log scale pour l'axe x) montrant lr vs mean_reward
+
+import matplotlib.pyplot as plt
+lr_results = {}  # TODO etudiant : remplir avec {lr: mean_reward}
+print(""Exercice a completer : sensibilite au learning rate"")",,,,,,,,1e7a3def3c6d69d2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,8c28562f,markdown,fr,2b3f91522205961c,"### Exercice 3 : Impact du nombre de pas d'entrainement
+
+Le nombre total de pas d'entrainement (`total_timesteps`) determine la quantite d'experience que l'agent accumule. Explorez comment la performance evolue avec des budgets d'entrainement croissants.
+
+**Indice** : Utilisez `total_timesteps` dans `[1000, 5000, 10000, 50000]` et tracez la courbe d'apprentissage (timesteps vs recompense moyenne). Pour acceder aux recompenses d'entrainement, vous pouvez utiliser un `Monitor` wrapper et `load_results`.",,,,,,,,2b3f91522205961c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,d9661591,code,fr,b5af5d5add8f09c0,"# Exercice 3 : Impact du nombre de pas d'entrainement
+# TODO etudiant : Entrainez PPO avec differents total_timesteps et comparez
+# Indice : timesteps_list = [1000, 5000, 10000, 50000]
+# Indice : Pour chaque valeur, creez un nouveau modele PPO et appelez .learn(total_timesteps)
+# Etape 1 : Definir les budgets d'entrainement a tester
+# Etape 2 : Boucler, entrainer un modele frais pour chaque budget, evaluer
+# Etape 3 : Tracer timesteps (echelle log) vs recompense moyenne
+
+timesteps_results = {}  # TODO etudiant : remplir avec {timesteps: mean_reward}
+print(""Exercice a completer : impact du nombre de pas d'entrainement"")",,,,,,,,b5af5d5add8f09c0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb,60eb43d4,markdown,fr,bbd982295c749736,"## Conclusion
+
+Dans ce notebook, nous avons vu :
+- comment définir et entraîner un modèle RL à l’aide de Stable Baselines3 (en une seule ligne de code) ;)
+
+---
+**Retour au sommaire** : [Index RL](README.md)
+",,,,,,,,bbd982295c749736,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,c26c3169,markdown,fr,f57bc5ff06282347,"**Navigation** : [Index](README.md) | [<< RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-3 HER >>](rl_3_experience_replay_dqn.ipynb)
+# Notebook 2 – Wrappers Gym, Sauvegarde/Chargement, Multiprocessing, Callbacks et Environnements Personnalisés
+
+**Serie** : Reinforcement Learning | **Notebook** : 2/13 | **Duree estimee** : 35-40 min
+
+Ce notebook propose un survol des fonctionnalités avancées de la librairie [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3) :
+1. **Utilisation de wrappers Gym** (limitation du nombre d’étapes, normalisation des actions, etc.)
+2. **Sauvegarde et chargement de modèles**
+3. **Multiprocessing** et environnements vectorisés
+4. **Callbacks** : enregistrement automatique, traçage en temps réel, etc.
+5. **Création d’un environnement Gym personnalisé**
+
+Nous utilisons un environnement sous Windows, donc nous évitons certaines dépendances (`xvfb`, `freeglut3-dev`) et nous n’utilisons pas de commandes `apt-get`.
+",,,,,,,,f57bc5ff06282347,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,6f1f1487,markdown,fr,8b810625ca739297,"## Installation et imports essentiels
+Dans un environnement Python classique, on installera Stable Baselines3 (et les dépendances gym) via :
+```
+pip install stable-baselines3[extra]
+```
+ou bien :
+```
+%pip install ""stable-baselines3[extra]>=2.0.0a4""
+```
+si vous utilisez un notebook. 
+
+Ensuite, on importe les principales classes dont on aura besoin.",,,,,,,,8b810625ca739297,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,ddff0be5,code,fr,7027505202cafeb2,"%pip install ""stable-baselines3[extra]>=2.0.0a4""  
+
+import os
+import numpy as np
+import gymnasium as gym
+from stable_baselines3 import PPO, A2C, SAC, TD3
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+from stable_baselines3.common.evaluation import evaluate_policy
+from stable_baselines3.common.monitor import Monitor
+",,,,,,,,7027505202cafeb2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,1ce9d351,markdown,fr,10c1ee7a956c6abc,"## 1) Wrappers Gym
+Les **Gym wrappers** permettent d’ajouter des transformations aux environnements (limiter la durée d’un épisode, normaliser les actions, etc.). Ci-dessous un exemple très condensé :
+
+**Autres wrappers utiles**  
+- `Monitor`: Enregistre automatiquement la récompense et la durée de chaque épisode, ce qui facilite l’analyse.  
+- `ClipAction`: S’assure que l’action est bien bornée à `[low, high]`.  
+- `FlattenObservation`: Convertit une observation complexe (dict, tuple, etc.) en un simple vecteur Numpy.
+
+*Exemple* : 
+```python
+import gymnasium as gym
+from stable_baselines3.common.monitor import Monitor
+
+env = gym.make('CartPole-v1')
+env = Monitor(env)  # suivi auto des rewards, durées d’épisodes
+```
+
+",,,,,,,,10c1ee7a956c6abc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,bad188a3,code,fr,c7589b095f6d97c2,"import gymnasium as gym
+from gymnasium import spaces
+
+class LimitEpisodeSteps(gym.Wrapper):
+    def __init__(self, env, max_steps=100):
+        super().__init__(env)
+        self.max_steps = max_steps
+        self.current_step = 0
+
+    def reset(self, **kwargs):
+        self.current_step = 0
+        return self.env.reset(**kwargs)
+
+    def step(self, action):
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        self.current_step += 1
+        if self.current_step >= self.max_steps:
+            truncated = True
+        return obs, reward, terminated, truncated, info
+
+# Exemple d'utilisation :
+base_env = gym.make(""CartPole-v1"", render_mode=""rgb_array"")
+wrapped_env = LimitEpisodeSteps(base_env, max_steps=50)
+
+obs, _ = wrapped_env.reset()
+done = False
+while not done:
+    action = wrapped_env.action_space.sample()
+    obs, reward, terminated, truncated, _ = wrapped_env.step(action)
+    done = terminated or truncated
+
+print(""Classe LimitEpisodeSteps definie : limite les episodes a N etapes"")
+",,,,,,,,c7589b095f6d97c2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,e53c271a,markdown,fr,144cda4fccce7625,"## 2) Sauvegarde et chargement de modèles
+Chaque algorithme de Stable-Baselines3 dispose de méthodes `.save(path)` et `.load(path)`. On peut ainsi conserver un modèle partiellement entraîné ou final, et le recharger pour continuer l’apprentissage ou faire de l’inférence.
+",,,,,,,,144cda4fccce7625,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,35776d80,code,fr,75ff21738bb7dbbf,"# Entraînement basique sur CartPole
+env = gym.make(""CartPole-v1"")
+model = PPO(""MlpPolicy"", env, verbose=0)
+model.learn(5000)
+
+# Sauvegarde
+model.save(""ppo_cartpole"")
+del model  # on supprime le modèle de la mémoire
+
+# Rechargement
+model = PPO.load(""ppo_cartpole"", env=env)  # on précise l'env si on veut continuer
+# Test rapide
+mean_reward, std_reward = evaluate_policy(model, env, n_eval_episodes=10)
+print(f""Reprise du modèle chargé : récompense moyenne={mean_reward:.2f}"")",,,,,,,,75ff21738bb7dbbf,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,6a5d2f0c,markdown,fr,b7a3021120f85a20,"
+**Attention**  
+- `model.save(path)` enregistre uniquement les poids du réseau et l’architecture.  
+- Pour **off-policy** (DQN, SAC, TD3...), si vous voulez sauvegarder **la replay buffer** (mémoire d’expériences), il faut utiliser en plus `model.save_replay_buffer(path_replay)`.  
+- Cela peut s’avérer lourd en mémoire : prenez garde à la taille de `buffer_size` et à l’espace disque.
+",,,,,,,,b7a3021120f85a20,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,004cc972,markdown,fr,ae0698096df030ee,"## 3) Multiprocessing
+Pour accélérer l’apprentissage ou pour avoir une meilleure exploration, on peut exécuter plusieurs environnements en parallèle. Cela se fait via `DummyVecEnv` (qui reste sur un seul process) ou `SubprocVecEnv` (plusieurs processus). Souvent, `DummyVecEnv` est plus rapide pour un petit nombre d’environnements, car la communication inter-processus coûte cher.
+
+On définit une fonction `make_env(env_id, rank, seed=0)` qui crée un environnement, puis on construit un `SubprocVecEnv` (ou un `DummyVecEnv`) :",,,,,,,,ae0698096df030ee,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,91bdaeba,code,fr,b9cbda4997518420,"def make_env(env_id, rank, seed=0):
+    def _init():
+        env = gym.make(env_id)
+        env.reset(seed=seed + rank)
+        return env
+    return _init
+
+from stable_baselines3.common.utils import set_random_seed
+
+# Exemple : 4 environnements en parallèle
+n_procs = 4
+env_id = ""CartPole-v1""
+
+vec_env = SubprocVecEnv([make_env(env_id, i) for i in range(n_procs)])
+
+model_mp = A2C(""MlpPolicy"", vec_env, verbose=0)
+model_mp.learn(5000)
+
+# Évaluation finale sur un seul env
+test_env = gym.make(env_id)
+mean_reward, _ = evaluate_policy(model_mp, test_env, n_eval_episodes=10)
+print(""Récompense moyenne sur 10 épisodes:"", mean_reward)",,,,,,,,b9cbda4997518420,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,75e7b4be,markdown,fr,5ad018534ddeacc6,"## 4) Callbacks
+Les **callbacks** permettent d’intervenir pendant l’entraînement (pour sauvegarder, tracer en temps réel, etc.). Ils héritent de `BaseCallback`. Quelques exemples :
+
+**Callbacks fournis par Stable-Baselines3**  
+- `EvalCallback`: évalue régulièrement le modèle sur un environnement de test (distinct de l’env d’entraînement).  
+- `CheckpointCallback`: sauvegarde périodiquement le modèle.  
+- `StopTrainingOnRewardThreshold`: arrête l’apprentissage si une récompense cible est atteinte.  
+
+*Tip* : En combinant `EvalCallback` et `CheckpointCallback`, vous pouvez automatiquement enregistrer le “meilleur” modèle selon une métrique d’évaluation.
+",,,,,,,,5ad018534ddeacc6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,a8119b4d,code,fr,bea884c39e39abd6,"from stable_baselines3.common.callbacks import BaseCallback
+
+class SimpleCallback(BaseCallback):
+    def __init__(self, verbose=0):
+        super().__init__(verbose)
+        self._called_once = False
+
+    def _on_step(self) -> bool:
+        if not self._called_once:
+            print(""Callback: Première fois !"")
+            self._called_once = True
+            return True
+        print(""Callback: Deuxième fois, on arrête l'entraînement."")
+        return False  # on interrompt l'apprentissage
+
+# Exemple d'utilisation
+model_cb = SAC(""MlpPolicy"", ""Pendulum-v1"", verbose=0)
+model_cb.learn(total_timesteps=2000, callback=SimpleCallback())
+",,,,,,,,bea884c39e39abd6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,5da2c1da,markdown,fr,7d61c6886eb82b8f,"### Exemple de callback pour sauvegarder le meilleur modèle
+On peut observer la récompense d’entraînement (monitor) et sauvegarder le modèle lorsqu’on obtient une récompense moyenne record. (Pour un usage plus robuste, on conseille d’utiliser un environnement d’évaluation séparé.)",,,,,,,,7d61c6886eb82b8f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,dca01a78,code,fr,68ca7b51f748cb1c,"import numpy as np
+from stable_baselines3.common.results_plotter import load_results, ts2xy
+
+class SaveOnBestTrainingRewardCallback(BaseCallback):
+    def __init__(self, check_freq, log_dir, verbose=1):
+        super().__init__(verbose)
+        self.check_freq = check_freq
+        self.log_dir = log_dir
+        self.save_path = os.path.join(log_dir, ""best_model"")
+        self.best_mean_reward = -np.inf
+
+    def _init_callback(self) -> None:
+        os.makedirs(self.save_path, exist_ok=True)
+
+    def _on_step(self) -> bool:
+        if self.n_calls % self.check_freq == 0:
+            x, y = ts2xy(load_results(self.log_dir), ""timesteps"")
+            if len(x) > 0:
+                mean_reward = np.mean(y[-100:])
+                if self.verbose > 0:
+                    print(f""Timestep: {self.num_timesteps}"")
+                    print(
+                        f""Meilleur reward: {self.best_mean_reward:.2f}  |  Derniers 100 épisodes: {mean_reward:.2f}""
+                    )
+                if mean_reward > self.best_mean_reward:
+                    self.best_mean_reward = mean_reward
+                    if self.verbose > 0:
+                        print(""Nouveau meilleur modèle! Sauvegarde..."")
+                    self.model.save(self.save_path)
+        return True
+
+# Exemple d'utilisation
+log_dir = ""./logs/""  # dossier de logs
+os.makedirs(log_dir, exist_ok=True)
+env = gym.make(""CartPole-v1"")
+env = Monitor(env, log_dir)
+
+model_saver = A2C(""MlpPolicy"", env, verbose=0)
+callback_saver = SaveOnBestTrainingRewardCallback(check_freq=1000, log_dir=log_dir)
+
+model_saver.learn(total_timesteps=5000, callback=callback_saver)",,,,,,,,68ca7b51f748cb1c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,090c5c02,markdown,fr,a2070434b27a567a,"## 5) Créer un environnement Gym personnalisé
+Enfin, voici un **exemple minimal** d’environnement Gym personnalisé. Il faut définir :
+
+- `__init__`: définit `self.observation_space` et `self.action_space`.  
+- `reset()`: renvoie `(obs, info)` où `obs` ∈ `observation_space`.  
+- `step(action)`: renvoie `(obs, reward, terminated, truncated, info)`.  
+- Assurez-vous que `obs` respecte la forme indiquée par `observation_space`.  
+
+*Note* : Dans Gym 0.26+ et Gymnasium, on a deux indicateurs de fin : `terminated` et `truncated`.  
+- `terminated`: la tâche est terminée parce qu’on est allé au bout (victoire/défaite).  
+- `truncated`: la tâche s’arrête par limite de temps ou autre contrainte.
+",,,,,,,,a2070434b27a567a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,0f2ea170,code,fr,d587488633cab804,"from gymnasium import spaces
+
+class MyCustomEnv(gym.Env):
+    def __init__(self, grid_size=5):
+        super().__init__()
+        self.grid_size = grid_size
+        # On définit l'action_space et l'observation_space
+        self.action_space = spaces.Discrete(2)  # ex: 0 = gauche, 1 = droite
+        self.observation_space = spaces.Box(low=0, high=self.grid_size, shape=(1,), dtype=np.float32)
+        self.agent_pos = None
+
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed, options=options)
+        self.agent_pos = np.random.randint(low=0, high=self.grid_size)
+        return np.array([self.agent_pos], dtype=np.float32), {}
+
+    def step(self, action):
+        if action == 0:  # gauche
+            self.agent_pos -= 1
+        else:            # droite
+            self.agent_pos += 1
+        self.agent_pos = np.clip(self.agent_pos, 0, self.grid_size)
+
+        reward = 1.0 if self.agent_pos == 0 else 0.0  # ex : on favorise d'aller à 0
+        terminated = bool(self.agent_pos == 0)
+        truncated = False
+        info = {}
+        return np.array([self.agent_pos], dtype=np.float32), reward, terminated, truncated, info
+
+    def render(self):
+        pass  # Optionnel
+
+    def close(self):
+        pass
+
+# Validation
+from stable_baselines3.common.env_checker import check_env
+env_custom = MyCustomEnv()
+check_env(env_custom, warn=True)
+
+# Test rapide
+model_custom = PPO(""MlpPolicy"", env_custom, verbose=0)
+model_custom.learn(2000)
+mean_reward, _ = evaluate_policy(model_custom, env_custom, n_eval_episodes=10)
+print(""Récompense moyenne :"", mean_reward)",,,,,,,,d587488633cab804,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,83970a31,markdown,fr,ae7de0357eef10e2,"## Exercices
+
+Les exercices suivants approfondissent les concepts de wrappers, callbacks et environnements personnalises abordes dans ce notebook.",,,,,,,,ae7de0357eef10e2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,71c09efc,markdown,fr,93497b1d86a9545f,"### Exercice 1 : Wrapper de normalisation des observations
+
+Un wrapper permet de transformer les observations avant qu'elles ne soient vues par l'agent. L'objectif est d'implementer un wrapper qui normalise les observations en utilisant la moyenne et l'ecart type glissants (running mean/std).
+
+**Indice** : Heritez de `gym.Wrapper`. Maintenez un buffer circulaire ou des accumulateurs pour `running_mean` et `running_std`. Normalisez l'observation dans `step()` et `reset()` en soustrayant la moyenne et divisant par l'ecart type (+ epsilon pour eviter la division par zero).",,,,,,,,93497b1d86a9545f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,a5dee03a,code,fr,5f2a0f622c03ff58,"# Exercice 1 : Wrapper de normalisation des observations
+# TODO etudiant : Implementez un wrapper qui normalise les observations (running mean/std)
+# Indice : class NormalizeObsWrapper(gym.Wrapper):
+# Indice : Utilisez np.mean() et np.std() sur un historique d'observations
+# Etape 1 : Definir la classe avec __init__, reset et step
+# Etape 2 : Accumuler les observations dans un buffer
+# Etape 3 : Normaliser chaque observation avant de la retourner
+
+# class NormalizeObsWrapper(gym.Wrapper):
+#     def __init__(self, env, buffer_size=1000):
+#         ...
+#     def _normalize(self, obs):
+#         ...
+#     def reset(self, **kwargs):
+#         ...
+#     def step(self, action):
+#         ...
+
+print(""Exercice a completer : wrapper de normalisation des observations"")",,,,,,,,5f2a0f622c03ff58,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,2fd44e7e,markdown,fr,40612d6ee80d03f5,"### Exercice 2 : Callback d'arret premature (early stopping)
+
+Il est souvent utile d'arreter l'entrainement automatiquement quand l'agent atteint un niveau de performance satisfaisant. L'objectif est de creer un callback qui arrete l'entrainement quand la recompense depasse un seuil pendant N evaluations consecutives.
+
+**Indice** : Heritez de `BaseCallback`. Dans `_on_step()`, evaluez le modele periodiquement (tous les `check_freq` pas). Si la recompense moyenne depasse `reward_threshold` pendant `patience` evaluations consecutives, retournez `False` pour arreter l'entrainement.",,,,,,,,40612d6ee80d03f5,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,d7390e49,code,fr,f7aa43efb6ca3c66,"# Exercice 2 : Callback d'arret premature (early stopping)
+# TODO etudiant : Creez un callback qui arrete l'entrainement quand reward > seuil pendant N evals
+# Indice : class EarlyStoppingCallback(BaseCallback):
+# Indice : Utilisez evaluate_policy dans _on_step pour verifier la performance
+# Etape 1 : Definir __init__ avec reward_threshold, patience, check_freq, eval_env
+# Etape 2 : Dans _on_step, evaluer periodiquement et compter les evaluations reussies
+# Etape 3 : Retourner False si le compteur >= patience
+
+# class EarlyStoppingCallback(BaseCallback):
+#     def __init__(self, eval_env, reward_threshold=400, patience=3, check_freq=1000, verbose=1):
+#         ...
+#     def _on_step(self) -> bool:
+#         ...
+
+print(""Exercice a completer : callback d'arret premature"")",,,,,,,,f7aa43efb6ca3c66,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,8ee08de9,markdown,fr,aeb388b98dabd004,"### Exercice 3 : Environnement GridWorld personnalise
+
+Creez un environnement Gymnasium complet ou un agent doit atteindre une case objectif sur une grille 5x5. L'agent peut se deplacer dans 4 directions (haut, bas, gauche, droite). L'episode se termine quand l'agent atteint l'objectif ou depasse un nombre maximal de pas.
+
+**Indice** : Definissez `action_space = spaces.Discrete(4)` (0=haut, 1=bas, 2=gauche, 3=droite) et `observation_space = spaces.Box(low=0, high=4, shape=(2,), dtype=np.int32)` pour la position (ligne, colonne). Recompense positive a l'objectif, petite penalite a chaque pas. Validez avec `check_env`.",,,,,,,,aeb388b98dabd004,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,8bf76c57,code,fr,601b308f1c63194a,"# Exercice 3 : Environnement GridWorld personnalise
+# TODO etudiant : Implementez un environnement 5x5 ou l'agent doit atteindre un objectif
+# Indice : Definir __init__, reset, step, render
+# Indice : action_space = spaces.Discrete(4)  # 0=haut, 1=bas, 2=gauche, 3=droite
+# Indice : observation_space = spaces.Box(low=0, high=4, shape=(2,), dtype=np.int32)
+# Etape 1 : Definir la classe GridWorldEnv(gym.Env) avec __init__
+# Etape 2 : Implementez reset() pour placer l'agent et l'objectif aleatoirement
+# Etape 3 : Implementez step(action) avec gestion des murs et detection de l'objectif
+# Etape 4 : Valider avec check_env et entrainer un agent PPO
+
+# class GridWorldEnv(gym.Env):
+#     def __init__(self, grid_size=5, max_steps=50):
+#         ...
+#     def reset(self, seed=None, options=None):
+#         ...
+#     def step(self, action):
+#         ...
+
+print(""Exercice a completer : environnement GridWorld personnalise"")",,,,,,,,601b308f1c63194a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_2_wrappers_sauvegarde_callbacks.ipynb,07eb1678,markdown,fr,2f46ad8be9f6f025,"## Conclusion
+Dans ce second notebook, nous avons parcouru :
+
+- L’usage de **wrappers Gym** pour modifier un environnement (limiter la durée, normaliser, etc.).
+- Les **fonctions de sauvegarde/chargement** de modèles (`.save()` / `.load()`).
+- Le **multiprocessing** via `SubprocVecEnv` ou `DummyVecEnv` pour accélérer (ou diversifier) l’apprentissage.
+- Les **callbacks**, permettant d’intervenir pendant l’entraînement (sauvegarde automatique du meilleur modèle, monitoring, etc.).
+- La **création d’un environnement Gym personnalisé**, validé ensuite par la fonction `check_env` et compatible avec tout algorithme Stable-Baselines3.
+
+Vous pouvez maintenant adapter et combiner ces techniques pour vos propres projets d’Apprentissage par Renforcement !
+---
+**Retour au sommaire** : [Index RL](README.md)
+",,,,,,,,2f46ad8be9f6f025,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,1ece4c96,markdown,fr,307376e4d42f14e9,"**Navigation** : [Index](README.md) | [<< RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-4 Bandits >>](rl_4_multi_armed_bandits.ipynb)
+# Notebook 3 – Hindsight Experience Replay (HER) et Sauvegarde Avancée
+
+**Serie** : Reinforcement Learning | **Notebook** : 3/13 | **Duree estimee** : 40-45 min
+
+Dans ce troisième notebook, nous allons aborder plusieurs sujets avancés :
+
+1. **Hindsight Experience Replay (HER)**, une technique permettant d'entraîner un agent sur des tâches de type ""Goal-Conditioned RL"" (où l’agent doit atteindre un objectif paramétrable),
+2. un **exemple pratique** avec l’environnement `parking-v0` (issu de la bibliothèque [highway-env](https://github.com/eleurent/highway-env)),
+3. la **sauvegarde/chargement avancés** d’un modèle, incluant la sauvegarde et le rechargement de la buffer d’expérience (replay buffer).
+
+Cet environnement `parking-v0` est un cas classique d’apprentissage par renforcement à but : la récompense dépend d’un objectif (ici, se garer à un endroit précis, avec la bonne orientation).
+
+Nous verrons comment utiliser HER avec différents algorithmes (SAC, DDPG), comment **sauvegarder/recharger** un modèle **et** sa mémoire de rejouage, et comment **évaluer** l’agent.
+
+
+**Rappel sur le “Goal-Conditioned RL”**  
+- Dans certaines tâches, un “goal” (objectif) fait partie de l’état désiré. Par exemple, la position finale d’un bras robotique, la place de parking à occuper, etc.  
+- Les observations se présentent souvent comme un dictionnaire : `{'observation': ..., 'desired_goal': ..., 'achieved_goal': ...}`.  
+- HER (Hindsight Experience Replay) ré-étiquette des transitions a posteriori pour rendre l’apprentissage plus efficace, surtout quand la récompense est très clairsemée (sparse).
+",,,,,,,,307376e4d42f14e9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,639cc41d,markdown,fr,208b3df4d2508a6d,"## Installation des dépendances
+
+Sous Windows, nous n’utilisons pas de commandes `apt-get`. Nous procédons uniquement par `pip` pour installer :
+
+- Stable-Baselines3 (avec le `[extra]`),
+- highway-env pour l’environnement `parking-v0`,
+- (Optionnel) `moviepy` pour l’enregistrement de vidéos.
+
+```bash
+pip install ""stable-baselines3[extra]>=2.0.0a4""
+pip install highway-env
+pip install moviepy
+```
+
+Dans un notebook Python, on peut faire :
+```python
+%pip install ""stable-baselines3[extra]>=2.0.0a4"" highway-env moviepy
+```",,,,,,,,208b3df4d2508a6d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,88f90212,code,fr,81e7c86fabbed1a9,"# Installation par commande magique Notebook (Windows-friendly, pas de apt-get)
+%pip install ""stable-baselines3[extra]>=2.0.0a4"" highway-env moviepy --quiet",,,,,,,,81e7c86fabbed1a9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,dd59bd5c,markdown,fr,df7066eaf77cfddc,"## Imports Essentiels
+
+Nous importons :
+- `HerReplayBuffer` : le buffer de rejouage spécialisé pour HER,
+- des algorithmes (SAC, DDPG) compatibles avec HER (il faut un algo off-policy pour combiner avec HER),
+- l’environnement `parking-v0` depuis highway_env,
+- NumPy, etc.
+
+
+> *Ancres savantes -- Andrychowicz, M., Wolski, F., Ray, A., Schneider, J., Fong, R., Welinder, P., McGrew, B., Kohl, J., Zaremba, W. & Abbeel, P. (2017), Hindsight Experience Replay, NeurIPS 2017, arXiv:1707.01495 (HER, re-etiquetage des echecs en succes synthetiques pour apprentissage goal-conditioned multi-objectif) ; Haarnoja, T., Zhou, A., Abbeel, P. & Levine, S. (2018), Soft Actor-Critic, ICML 2018, arXiv:1801.01290 (SAC, acteur-critique off-policy a entropie maximale) ; Lillicrap, T.P., Hunt, J.J., Pritzel, A., Heess, N., Erez, T., Tassa, Y., Silver, D. & Wierstra, D. (2016), Continuous Control with Deep Reinforcement Learning, ICLR 2016, arXiv:1509.02971 (DDPG, acteur-critique deterministe off-policy pour actions continues).*",,,,,,,,df7066eaf77cfddc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,536464bc,code,fr,106665f1dd358317,"import gymnasium as gym
+import highway_env
+import numpy as np
+
+from stable_baselines3 import HerReplayBuffer, SAC, DDPG
+from stable_baselines3.common.noise import NormalActionNoise
+from stable_baselines3.common.evaluation import evaluate_policy
+
+print(""Imports OK"")",,,,,,,,106665f1dd358317,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,56dbde10,markdown,fr,5e2e95a3308095ff,"### Environnement Parking
+
+[`parking-v0`](https://github.com/eleurent/highway-env#parking-env) est un environnement « goal-conditioned » : la position et l’orientation cibles font partie de l’`info['goal']`. Pour résoudre cette tâche, on doit apprendre à manœuvrer la voiture pour qu’elle se gare.
+
+![parking-env](https://raw.githubusercontent.com/eleurent/highway-env/gh-media/docs/media/parking-env.gif)
+",,,,,,,,5e2e95a3308095ff,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,06d5da9a,markdown,fr,f33b310353d8b31c,### Création de l’environnement Gym,,,,,,,,f33b310353d8b31c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,34a822a7,code,fr,d54b7b8824ef0f74,"env = gym.make(""parking-v0"")
+obs, _ = env.reset()
+print(""Observation :"", obs.keys())
+print(""Exemple d'observation['observation']:"", obs[""observation""].shape)
+print(""Exemple d'observation['desired_goal']:"", obs[""desired_goal""].shape)",,,,,,,,d54b7b8824ef0f74,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,a2e7a1dc,markdown,fr,1f876cbc8358c40e,"Par défaut, l’action est continue (2 dimensions : accélération et direction). On peut vérifier en imprimant `env.action_space` ou `env.observation_space`.
+
+**Structure de l’observation**  
+- `obs['observation']`: informations sur la voiture (position, vitesse, angle...).  
+- `obs['desired_goal']`: position/angle cible (le “parking spot”).  
+- `obs['achieved_goal']`: l’état effectivement atteint par la voiture.  
+
+La récompense dépend souvent de la distance entre `achieved_goal` et `desired_goal`. HER va ré-étiqueter certains buts pour générer des transitions artificiellement “réussies”.
+",,,,,,,,1f876cbc8358c40e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,c0b6a86f,markdown,fr,86f98a2e01eff21c,"## Entraîner un agent SAC avec HER
+
+La configuration de `HerReplayBuffer` est centrale ici. Nous choisissons :
+- `goal_selection_strategy=""future""` (la stratégie la plus courante, on va remplacer le but original par un but futur observé dans le même épisode),
+- `n_sampled_goal=4` (on crée 4 transitions artificielles par transition réelle),
+- des hyperparamètres un peu custom pour *SAC* : `batch_size`, `policy_kwargs`, etc.
+
+Au final, l’entraînement dure un certain temps (on peut ajuster le `total_timesteps` en fonction de la machine).
+
+
+",,,,,,,,86f98a2e01eff21c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,c1b85094,code,fr,cbeb41d14a1422ad,"model_sac = SAC(
+    ""MultiInputPolicy"",
+    env,
+    replay_buffer_class=HerReplayBuffer,
+    replay_buffer_kwargs=dict(
+        n_sampled_goal=4,
+        goal_selection_strategy=""future"",
+    ),
+    # on attend 1000 pas avant d'entraîner,
+    # afin d'avoir au moins un épisode complet stocké.
+    learning_starts=1000,  
+    buffer_size=50000,
+    batch_size=64,
+    policy_kwargs=dict(net_arch=[64, 64]),
+    train_freq=1,
+    gradient_steps=1,
+    verbose=1,
+)
+model_sac.learn(total_timesteps=5000, log_interval=100)
+
+
+
+# Sauvegarde du modèle ET de la replay buffer avant suppression
+model_sac.save(""her_sac_parking"")
+model_sac.save_replay_buffer(""her_sac_parking_replay_buffer"")
+del model_sac  # On supprime de la RAM
+
+",,,,,,,,cbeb41d14a1422ad,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,7b954c0c,markdown,fr,aa58e97e60c19823,"
+**Focus sur la stratégie `goal_selection_strategy=\""future\""`**  
+- “future” signifie qu’on va remplacer le but initial par un but échantillonné **plus tard** dans la même trajectoire.  
+- Cela favorise l’apprentissage, car beaucoup d’états futurs atteints sont convertis en “objectifs cibles”.  
+- Alternatives : “final”, “episode”, “random” — à tester selon l’environnement.
+",,,,,,,,aa58e97e60c19823,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,e7f121fb,markdown,fr,66568d8ef92f6e2b,"## Rechargement du modèle et évaluation
+
+Nous rechargeons ensuite le modèle, et on peut l’évaluer sur quelques épisodes :
+",,,,,,,,66568d8ef92f6e2b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,7f3a99ac,code,fr,c2ee7b2c7b7c4fda,"from stable_baselines3.common.monitor import Monitor
+
+# Rechargement
+model_sac = SAC.load(""her_sac_parking"", env=env)
+
+# Évaluation
+
+eval_env = Monitor(env)  # Ajout du Monitor pour éviter les warnings
+mean_reward, std_reward = evaluate_policy(model_sac, eval_env, n_eval_episodes=10, deterministic=True)
+
+print(f""SAC Parking : reward moyen={mean_reward:.2f} +/- {std_reward:.2f}"")
+
+",,,,,,,,c2ee7b2c7b7c4fda,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,7be65583,markdown,fr,c8c0dc69147af963,"La notion de « récompense » dans un environnement `goal-conditioned` (HER) reflète la distance à l’objectif et la réussite/échec à se garer. On peut inspecter `info.get(""is_success"", False)` pour savoir si l’épisode est terminé avec succès.",,,,,,,,c8c0dc69147af963,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,fc0afad1,markdown,fr,8d7ea5d664ee9e43,"## Exemple avec DDPG
+
+Nous pouvons reproduire la même idée avec un autre algorithme off-policy (DDPG). On ajoute souvent un bruit d’exploration, `NormalActionNoise` :",,,,,,,,8d7ea5d664ee9e43,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,1bae099e,code,fr,6bc91ef610336da3,"# On crée un bruit gaussien pour l’action
+n_actions = env.action_space.shape[0]  # en général = 2
+noise_std = 0.2
+action_noise = NormalActionNoise(mean=np.zeros(n_actions), sigma=noise_std * np.ones(n_actions))
+
+model_ddpg = DDPG(
+    ""MultiInputPolicy"",
+    env,
+    replay_buffer_class=HerReplayBuffer,
+    replay_buffer_kwargs=dict(
+        n_sampled_goal=4,
+        goal_selection_strategy=""future"",
+    ),
+    verbose=1,
+    # On réduit la taille de la buffer
+    buffer_size=50_000,
+    learning_rate=1e-3,
+    action_noise=action_noise,
+    gamma=0.95,
+    # batch_size plus petit
+    batch_size=64,
+    # Réseau plus léger
+    policy_kwargs=dict(net_arch=[64, 64]),
+    # On attend un peu avant d'entraîner
+    learning_starts=1000,
+    # On fait 1 step d'entraînement par step environnement
+    train_freq=1,
+    gradient_steps=1,
+)
+
+# On ne va pas jusqu'à 2e5 steps
+# mais 5000 ou 10 000 pour une démo rapide
+model_ddpg.learn(10_000)  # par exemple
+
+# Sauvegarde
+model_ddpg.save(""her_ddpg_parking"")
+del model_ddpg
+",,,,,,,,6bc91ef610336da3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,8ca4b997,markdown,fr,13ed373ac1ecb487,Chargement du modele DDPG entraine avec HER pour comparaison.,,,,,,,,13ed373ac1ecb487,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,ac729679,code,fr,612bc192303d31ba,"model_ddpg = DDPG.load(""her_ddpg_parking"", env=env)
+mean_reward, std_reward = evaluate_policy(model_ddpg, env, n_eval_episodes=10, deterministic=True)
+print(f""DDPG Parking : reward moyen={mean_reward:.2f} +/- {std_reward:.2f}"")
+",,,,,,,,612bc192303d31ba,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,954ed70a,markdown,fr,9b7250833ffbbfd3,"## Sauvegarde et Chargement de la Replay Buffer
+
+Une fonctionnalité avancée de Stable-Baselines3 est la **possibilité de sauvegarder aussi la buffer de rejouage** (replay buffer) :
+
+- Par défaut, `model.save(...)` **ne** sauvegarde **pas** la replay buffer, car celle-ci peut être très volumineuse (plusieurs Go si on utilise des images, par ex.).
+- Mais on peut la sauvegarder à part avec `model.save_replay_buffer(path)`, puis la recharger avec `model.load_replay_buffer(path)`.
+
+Cela permet de **reprendre un entraînement** où on l’avait laissé, en conservant tout l’historique d’expériences collectées. Sur des environnements complexes, c’est très utile pour éviter de tout recommencer !
+
+Exemple :",,,,,,,,9b7250833ffbbfd3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,1b49487e,code,fr,d39b069fb1d9603f,"# 1) Sauvegarde
+model_sac.save(""her_sac_parking"")  # ne sauvegarde pas la replay buffer
+model_sac.save_replay_buffer(""her_sac_parking_replay_buffer"")
+
+# 2) Rechargement du modèle + de la buffer
+model_sac_2 = SAC.load(""her_sac_parking"", env=env)
+print(""Taille de la replay buffer AVANT rechargement :"", model_sac_2.replay_buffer.size())
+
+model_sac_2.load_replay_buffer(""her_sac_parking_replay_buffer"")
+print(""Taille de la replay buffer APRÈS rechargement :"", model_sac_2.replay_buffer.size())
+",,,,,,,,d39b069fb1d9603f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,2f066f97,markdown,fr,3bd2281883e5bc81,"
+**Reprendre l’entraînement**  
+- Après avoir chargé le modèle et la replay buffer, on peut appeler `model_sac_2.learn(N)` pour continuer exactement là où l’on s’était arrêté.  
+- Utile pour *checkpoint* l’entraînement de temps en temps, sans perdre l’historique des transitions passées (particulièrement en off-policy).
+",,,,,,,,3bd2281883e5bc81,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,884fef6e,markdown,fr,16dab34956f1d51c,"## Enregistrement vidéo sous Windows
+
+Comme évoqué dans les notebooks précédents, sous Windows, pas besoin de démarrer un display virtuel via `xvfb`. On peut simplement enregistrer en mode `rgb_array`. 
+
+Voici une fonction utilitaire pour enregistrer une vidéo d’un agent (la même que dans les notebooks précédents, adaptée pour Windows) :",,,,,,,,16dab34956f1d51c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,aecdb299,code,fr,375ea81504b283d3,"import base64
+from pathlib import Path
+from IPython.display import HTML
+
+from stable_baselines3.common.vec_env import VecVideoRecorder, DummyVecEnv
+
+def record_video(env_id, model, video_length=1000, prefix="""", video_folder=""videos/""):
+    # On crée un DummyVecEnv pour enregistrer
+    eval_env = DummyVecEnv([lambda: gym.make(env_id, render_mode=""rgb_array"")])
+    
+    # On active le recorder vidéo :
+    eval_env = VecVideoRecorder(
+        eval_env,
+        video_folder,
+        record_video_trigger=lambda step: step == 0,
+        video_length=video_length,
+        name_prefix=prefix,
+    )
+
+    obs = eval_env.reset()
+    for _ in range(video_length):
+        action, _ = model.predict(obs, deterministic=True)
+        obs, _, done, info = eval_env.step(action)
+
+    eval_env.close()
+
+def show_videos(video_path=""videos"", prefix=""""):
+    """"""
+    Affiche toutes les vidéos mp4 dans le dossier spécifié.
+    """"""
+    mp4_list = list(Path(video_path).glob(f""{prefix}*.mp4""))
+    if len(mp4_list) == 0:
+        print(""Aucune vidéo trouvée."")
+        return
+
+    html_video = """"
+    for mp4 in mp4_list:
+        video_b64 = base64.b64encode(mp4.read_bytes()).decode(""ascii"")
+        html_video += f""<video alt='{mp4}' autoplay loop controls style='height: 400px;'>\n"" \
+                      f""<source src='data:video/mp4;base64,{video_b64}' type='video/mp4' />\n"" \
+                      ""</video>\n""
+    return HTML(html_video)
+
+print(""Fonctions video enregistrees (record_video, show_videos)"")",,,,,,,,375ea81504b283d3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,0b032432,markdown,fr,4b28b4649a85a41d,"Pour tester, nous pouvons enregistrer une vidéo de `model_sac` ou `model_ddpg`. (Attention : `parking-v0` peut boucler un peu longtemps si on met un `video_length` trop grand.)",,,,,,,,4b28b4649a85a41d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,a9f1cf71,code,fr,e7b3cd6bfa104a00,"record_video(""parking-v0"", model_sac, video_length=500, prefix=""sac-parking"")
+show_videos(""videos"", prefix=""sac-parking"")",,,,,,,,e7b3cd6bfa104a00,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,75f28150,markdown,fr,2b962c72f9685140,Vous devriez voir la voiture tenter de se garer…,,,,,,,,2b962c72f9685140,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,36c8123d,markdown,fr,2d3f5a249cbd9c07,"## Exercices
+
+Les exercices suivants approfondissent les concepts de HER et d'apprentissage par renforcement objectif-conditionne (goal-conditioned RL) abordes dans ce notebook.",,,,,,,,2d3f5a249cbd9c07,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,e99a46e5,markdown,fr,387e0bb729008dcb,"### Exercice 1 : Comparaison des strategies de selection de buts
+
+HER propose plusieurs strategies pour re-etiqueter les transitions : `""future""`, `""final""` et `""episode""`. L'objectif est de comparer ces trois strategies sur l'environnement `parking-v0` et d'observer leurs effets sur la vitesse de convergence et la performance finale.
+
+**Indice** : Modifiez le parametre `goal_selection_strategy` dans `replay_buffer_kwargs`. Entrainez chaque configuration avec le meme nombre de `total_timesteps` (par exemple 5000) et comparez les recompenses moyennes.",,,,,,,,387e0bb729008dcb,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,2e94ae19,code,fr,d27575c942e11e3d,"# Exercice 1 : Comparaison des strategies de selection de buts
+# TODO etudiant : Comparez ""future"", ""final"" et ""episode"" sur parking-v0 avec HER+SAC
+# Indice : strategies = [""future"", ""final"", ""episode""]
+# Indice : Pour chaque strategie, modifier goal_selection_strategy dans replay_buffer_kwargs
+# Etape 1 : Definir les 3 strategies a tester
+# Etape 2 : Boucler, creer SAC + HerReplayBuffer pour chaque strategie, entrainer (5000 steps)
+# Etape 3 : Evaluer et stocker les recompenses, puis afficher un tableau comparatif
+
+strategy_results = {}  # TODO etudiant : remplir avec {strategy: mean_reward}
+print(""Exercice a completer : comparaison des strategies de selection de buts"")",,,,,,,,d27575c942e11e3d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,87f89349,markdown,fr,c547f3db656b295b,"### Exercice 2 : Comparaison SAC vs DDPG avec HER
+
+SAC et DDPG sont deux algorithmes off-policy compatibles avec HER, mais ils different dans leur approche (SAC maximise l'entropie pour encourager l'exploration, DDPG utilise un bruit d'action explicite). Comparez leurs performances avec HER sur `parking-v0`.
+
+**Indice** : Reprenez les configurations SAC et DDPG des sections precedentes. Entrainez les deux avec le meme `total_timesteps` et comparez les courbes de recompense avec `matplotlib`.",,,,,,,,c547f3db656b295b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,89d42266,code,fr,03f7015dca9560f0,"# Exercice 2 : Comparaison SAC vs DDPG avec HER
+# TODO etudiant : Entrainez SAC et DDPG (avec HER) sur parking-v0, comparez les courbes
+# Indice : Reprenez les modeles des sections precedentes (HerReplayBuffer, meme timesteps)
+# Indice : Stockez les rewards d'evaluation a intervalles reguliers pour tracer les courbes
+# Etape 1 : Creer et entrainer SAC + HER (meme config que la section correspondante)
+# Etape 2 : Creer et entrainer DDPG + HER (meme config que la section correspondante)
+# Etape 3 : Evaluer les deux modeles et tracer les courbes de recompense comparatives
+
+algo_results = {}  # TODO etudiant : remplir avec {""SAC"": mean_reward, ""DDPG"": mean_reward}
+print(""Exercice a completer : comparaison SAC vs DDPG avec HER"")",,,,,,,,03f7015dca9560f0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,50ce3b2c,markdown,fr,291db9a8205b0cdc,"### Exercice 3 : Modification de la fonction de recompense
+
+La fonction de recompense par defaut de `parking-v0` depend de la distance a l'objectif. L'objectif est de creer un wrapper qui penalise plus agressivement la distance a l'objectif, en utilisant par exemple une penalite proportionnelle au carre de la distance. Observez comment cette modification affecte le comportement de l'agent.
+
+**Indice** : Creez un `gym.Wrapper` qui intercepte l'appel `step()` et recalcule la recompense en fonction de la distance entre `achieved_goal` et `desired_goal`. Utilisez `np.linalg.norm()` pour calculer la distance et renvoyez une penalite proportionnelle a `-distance**2`.",,,,,,,,291db9a8205b0cdc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,80992633,code,fr,c6ef32f5136feb96,"# Exercice 3 : Modification de la fonction de recompense
+# TODO etudiant : Creez un wrapper qui penalise plus agressivement la distance a l'objectif
+# Indice : class AggressiveRewardWrapper(gym.Wrapper):
+# Indice : Dans step(), recalculez reward = -np.linalg.norm(achieved - desired)**2
+# Etape 1 : Definir le wrapper avec __init__ et step
+# Etape 2 : Intercepter l'observation dans step() pour recalculer la recompense
+# Etape 3 : Entrainer SAC+HER avec le wrapper et comparer avec le reward par defaut
+
+# class AggressiveRewardWrapper(gym.Wrapper):
+#     def __init__(self, env, penalty_scale=1.0):
+#         ...
+#     def step(self, action):
+#         obs, reward, terminated, truncated, info = self.env.step(action)
+#         distance = np.linalg.norm(obs[""achieved_goal""] - obs[""desired_goal""])
+#         reward = ...  # TODO etudiant : definir la nouvelle recompense
+#         return obs, reward, terminated, truncated, info
+
+print(""Exercice a completer : modification de la fonction de recompense"")",,,,,,,,c6ef32f5136feb96,,,,,,,
+MyIA.AI.Notebooks/RL/rl_3_experience_replay_dqn.ipynb,a83c7486,markdown,fr,2179bfb2317b9f93,"## Conclusion
+
+Dans ce troisième notebook, nous avons abordé des fonctionnalités avancées de Stable-Baselines3 :
+
+- **Hindsight Experience Replay (HER)**, qui permet d’apprendre efficacement sur des tâches à but (objectif) en ré-étiquetant des transitions passées,
+- l’utilisation de **SAC** ou **DDPG** avec HER (algorithmes off-policy),
+- la **sauvegarde et le rechargement** de la replay buffer pour reprendre un entraînement ultérieurement,
+- l’enregistrement vidéo « friendly pour Windows », sans dépendances `apt-get`.
+
+Avec cela, vous disposez d’une base solide pour traiter des tâches plus complexes en Apprentissage par Renforcement, où l’agent doit atteindre des objectifs spécifiques.
+---
+**Retour au sommaire** : [Index RL](README.md)
+
+
+### References academiques
+
+- Andrychowicz, M., Wolski, F., Ray, A., Schneider, J., Fong, R., Welinder, P., McGrew, B., Kohl, J., Zaremba, W. & Abbeel, P. (2017). Hindsight Experience Replay. NeurIPS 2017. arXiv:1707.01495.
+- Haarnoja, T., Zhou, A., Abbeel, P. & Levine, S. (2018). Soft Actor-Critic: Off-Policy Maximum Entropy Deep Reinforcement Learning with a Stochastic Actor. ICML 2018. arXiv:1801.01290.
+- Lillicrap, T.P., Hunt, J.J., Pritzel, A., Heess, N., Erez, T., Tassa, Y., Silver, D. & Wierstra, D. (2016). Continuous Control with Deep Reinforcement Learning. ICLR 2016. arXiv:1509.02971.
+- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press.
+
+",,,,,,,,2179bfb2317b9f93,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,9b512e67,markdown,fr,5ef90e7f3459e745,"# RL-4 : Bandits Manchots et le Compromis Exploration-Exploitation
+
+**Serie** : Reinforcement Learning | **Notebook** : 4/13 | **Duree estimee** : 40-45 min
+
+Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | **RL-4 Bandits** | [RL-5 MDP/Q-Learning](rl_5_mdp_dp_qlearning.ipynb) | [RL-6 DQN/PG](rl_6_dqn_policy_gradient.ipynb) | [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb)
+
+---
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous serez capable de :
+1. Formaliser le probleme du bandit manchot (multi-armed bandit) et comprendre le compromis exploration-exploitation
+2. Implementer plusieurs strategies d'exploration : greedy, epsilon-greedy, UCB, Thompson Sampling
+3. Comparer objectivement les performances des strategies via le regret cumule
+4. Analyser quand chaque strategie est adaptee au probleme
+
+### Prerequis
+- Python 3.10+ (numpy, matplotlib)
+- Notions de probabilites (esperance, loi de Bernoulli, loi gaussienne)
+- Avoir suivi le [RL-1 Introduction](rl_1_intro_cartpole.ipynb) (concepts agent/environnement/reward)
+
+### Duree estimee : 40-45 minutes",,,,,,,,5ef90e7f3459e745,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,877579c0,markdown,fr,a0b2d67d0b622bb4,"## 1. Introduction : le probleme du bandit manchot
+
+Imaginez un casino avec $K$ machines a sous (""bandits manchots""). Chaque machine $k$ a une probabilite inconnue $\mu_k$ de donner une recompense. Vous avez $T$ jetons. Quelle strategie utilisez-vous pour maximiser vos gains ?
+
+C'est le **probleme du bandit manchot** (multi-armed bandit), un des problemes fondamentaux de l'apprentissage par renforcement. Il illustre le **compromis exploration-exploitation** :
+
+- **Exploitation** : choisir le bras qui semble le meilleur actuellement
+- **Exploration** : essayer d'autres bras pour mieux estimer leur valeur reelle
+
+Ce compromis est omnipresent en RL : un agent doit-il utiliser ce qu'il sait, ou risquer de perdre pour decouvrir de meilleures options ?
+
+### Applications reelles
+
+| Domaine | Exemple | Bras = ? | Recompense = ? |
+|---------|---------|----------|----------------|
+| Essais cliniques | Tester K traitements | Traitement i | Succes/echec du patient |
+| Publicite en ligne | Choisir une banniere | Banniere i | Clic ou non |
+| Systemes de recommendation | Recommander un film | Film i | Note de l'utilisateur |
+| Allocation de ressources | Repartir un budget | Strategie i | Retour sur investissement |
+
+### Lien avec la serie RL
+
+Un bandit manchot est un **MDP a un seul etat** : il n'y a pas de transitions, pas d'etat $s_{t+1}$ qui depend de l'action $a_t$. L'agent choisit simplement une action et observe une recompense. C'est le cas le plus simple d'apprentissage par renforcement, ideal pour comprendre les strategies d'exploration avant de passer aux MDP complets dans le [notebook RL-5](rl_5_mdp_dp_qlearning.ipynb).
+
+
+> *Ancres savantes -- Robbins, H. (1952), Some Aspects of the Sequential Design of Experiments, Bulletin of the American Mathematical Society 58(5):527-535 (formalisation du bandit manchot, compromis exploration/exploitation sur K machines) ; Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002), Finite-time Analysis of the Multiarmed Bandit Problem, Machine Learning 47(2-3):235-256 (UCB1, strategie optimiste face a l'incertitude avec regret logarithmique) ; Thompson, W.R. (1933), On the Likelihood that One Unknown Probability Exceeds Another in the View of the Evidence of the Two Samples, Biometrika 25(3-4):285-294 (Thompson Sampling, echantillonnage bayesien a posteriori) ; Sutton, R.S. & Barto, A.G. (2018), Reinforcement Learning: An Introduction (2nd ed.), MIT Press (regret, epsilon-greedy, cadre du bandit comme MDP a un seul etat).*",,,,,,,,a0b2d67d0b622bb4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,d709edad,markdown,fr,3b5efb0050a9d3bd,"## 2. Environnement Bandit
+
+Nous allons implementer un bandit a $K$ bras, ou chaque bras suit une distribution de **Bernoulli** : il retourne 1 (succes) avec probabilite $\mu_k$, et 0 (echec) avec probabilite $1 - \mu_k$.
+
+L'agent interagit avec le bandit pendant $T$ pas de temps. A chaque pas, il choisit un bras $a_t$ et observe une recompense $r_t \in \{0, 1\}$.",,,,,,,,3b5efb0050a9d3bd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,c6f7d608,code,fr,26efa3932aaa9e26,"import warnings
+warnings.filterwarnings(""ignore"", message="".*This figure includes Axes.*"", category=UserWarning)
+warnings.filterwarnings(""ignore"", message="".*tight_layout.*"", category=UserWarning)
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+
+print(f""numpy={np.__version__}, matplotlib={matplotlib.__version__}"")
+",,,,,,,,26efa3932aaa9e26,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,36d1eed8,code,fr,4c139fdfd05ad730,"class BernoulliBandit:
+    """"""
+    Bandit manchot a K bras avec distribution de Bernoulli.
+    
+    Chaque bras k retourne 1 avec probabilite mu[k], 0 sinon.
+    Les probabilites mu[k] sont tirees uniformement au depart (ou fixees manuellement).
+    """"""
+    
+    def __init__(self, n_arms: int, probs: np.ndarray | None = None, seed: int | None = None):
+        self.n_arms = n_arms
+        self.rng = np.random.default_rng(seed)
+        if probs is not None:
+            assert len(probs) == n_arms, ""Taille de probs incompatible avec n_arms""
+            self.probs = np.array(probs, dtype=float)
+        else:
+            self.probs = self.rng.uniform(0.1, 0.9, size=n_arms)
+        self.best_arm = int(np.argmax(self.probs))
+        self.best_prob = float(np.max(self.probs))
+    
+    def pull(self, arm: int) -> int:
+        """"""Tire le bras `arm` et retourne 1 (succes) ou 0 (echec).""""""
+        return int(self.rng.random() < self.probs[arm])
+    
+    def __repr__(self) -> str:
+        arms_str = "", "".join(f""{p:.3f}"" for p in self.probs)
+        return f""BernoulliBandit({self.n_arms} arms: [{arms_str}])""
+
+print(""Fonction BernoulliBandit definie"")",,,,,,,,4c139fdfd05ad730,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,af1eb939,code,fr,335c2ba882b38704,"# Creer un bandit a 5 bras avec probabilites connues
+bandit = BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6])
+
+print(f""Bandit : {bandit}"")
+print(f""Meilleur bras : {bandit.best_arm} (probabilite = {bandit.best_prob:.3f})"")
+
+# Tirer le meilleur bras 10 fois pour observer la variabilite
+rewards = [bandit.pull(3) for _ in range(10)]
+print(f""10 tirages du bras 3 : {rewards}"")
+print(f""Gain moyen observe : {np.mean(rewards):.2f}"")",,,,,,,,335c2ba882b38704,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,626c6a38,markdown,fr,d608bf51c8c35db6,"### Le concept de regret
+
+Le **regret** mesure la perte cumulee par rapport a la strategie optimale (toujours tirer le meilleur bras). Apres $T$ pas de temps :
+
+$$\text{Regret}(T) = T \cdot \mu^* - \sum_{t=1}^{T} r_t$$
+
+ou $\mu^*$ est la probabilite du meilleur bras. Un bon algorithme a un **regret sous-lineaire** : il apprend a identifier le meilleur bras et son regret croit de plus en plus lentement.",,,,,,,,d608bf51c8c35db6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,716b9249,markdown,fr,61712ad222f174a5,"### Exercice 1 : Bandit gaussien
+
+Dans cet exercice, vous allez implementer un bandit a recompenses **continues**. Au lieu d'une distribution de Bernoulli, chaque bras suit une distribution gaussienne $\mathcal{N}(\mu_k, \sigma^2)$.
+
+**Contexte** : Les bandits gaussiens sont courants dans les problemes d'optimisation ou les recompenses sont continues (prix, rendements financiers, temperatures).
+
+**Etapes** :
+1. Definir le constructeur `__init__` avec `means`, `stds` et un generateur aleatoire
+2. Implementer la methode `pull` qui retourne un echantillon de $\mathcal{N}(\mu_k, \sigma^2)$
+3. Calculer `best_arm` et `best_prob` (l'esperance du meilleur bras)
+
+**Indice** : Utilisez `self.rng.normal(loc=self.means[arm], scale=self.stds[arm])` pour generer un echantillon gaussien.",,,,,,,,61712ad222f174a5,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,128789eb,code,fr,a64860941ca2cc92,"class GaussianBandit:
+    """"""
+    Bandit manchot a K bras avec distribution gaussienne.
+    
+    Chaque bras k retourne un echantillon de N(mu[k], sigma[k]^2).
+    """"""
+    
+    def __init__(self, n_arms: int, means: np.ndarray | None = None,
+                 stds: np.ndarray | None = None, seed: int | None = None):
+        self.n_arms = n_arms
+        self.rng = np.random.default_rng(seed)
+        # TODO etudiant : initialiser self.means et self.stds
+        # Si means est None, tirer uniformement entre -1 et 3
+        # Si stds est None, utiliser 1.0 pour tous les bras
+        self.means = None  # TODO etudiant : remplacer
+        self.stds = None   # TODO etudiant : remplacer
+        self.best_arm = 0  # TODO etudiant : calculer le meilleur bras
+        self.best_prob = 0.0  # TODO etudiant : esperance du meilleur bras
+    
+    def pull(self, arm: int) -> float:
+        """"""Tire le bras `arm` et retourne une recompense continue.""""""
+        return 0.0  # TODO etudiant : retourner un echantillon gaussien
+    
+    def __repr__(self) -> str:
+        arms_str = "", "".join(f""N({m:.2f}, {s:.2f})"" for m, s in zip(self.means, self.stds))
+        return f""GaussianBandit({self.n_arms} arms: [{arms_str}])""
+
+print(""Exercice a completer"")",,,,,,,,a64860941ca2cc92,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,8848c654,markdown,fr,e4dbeed38e010297,"## 3. Strategies naives
+
+Avant de voir des strategies sophistiquees, commencons par les approches les plus simples. Elles serviront de **base de reference** (baseline) pour evaluer les methodes plus avancees.
+
+### Agent aleatoire (Random)
+
+L'agent aleatoire choisit un bras au hasard a chaque pas de temps. Il n'apprend rien et sert de point de comparaison minimal.",,,,,,,,e4dbeed38e010297,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,bf58e7b5,code,fr,b207494f7cfb472d,"def run_agent(bandit, agent_fn, n_steps: int, seed: int = 42) -> dict:
+    """"""
+    Execute un agent sur un bandit pendant n_steps pas de temps.
+    
+    Parametres :
+        bandit : instance de BernoulliBandit
+        agent_fn : fonction (bandit, n_steps, seed) -> (actions, rewards)
+        n_steps : nombre de pas de temps
+        seed : graine pour la reproductibilite
+    
+    Retourne :
+        dict avec 'actions', 'rewards', 'cumulative_rewards', 'regret'
+    """"""
+    actions, rewards = agent_fn(bandit, n_steps, seed)
+    cumulative_rewards = np.cumsum(rewards)
+    optimal_reward = np.arange(1, n_steps + 1) * bandit.best_prob
+    regret = optimal_reward - cumulative_rewards
+    
+    return {
+        'actions': np.array(actions),
+        'rewards': np.array(rewards),
+        'cumulative_rewards': cumulative_rewards,
+        'regret': regret
+    }
+
+print(""Fonction run_agent definie"")",,,,,,,,b207494f7cfb472d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,032b5ffc,code,fr,3136221ba4c83622,"def random_agent(bandit, n_steps: int, seed: int = 42) -> tuple:
+    """"""Agent aleatoire : choisit un bras uniformement au hasard.""""""
+    rng = np.random.default_rng(seed)
+    actions = rng.integers(0, bandit.n_arms, size=n_steps)
+    rewards = np.array([bandit.pull(a) for a in actions])
+    return actions, rewards
+
+# Tester l'agent aleatoire
+bandit_test = BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42)
+result_random = run_agent(bandit_test, random_agent, n_steps=1000, seed=42)
+
+print(f""Agent aleatoire - recompense cumulee finale : {result_random['cumulative_rewards'][-1]:.1f} / {1000 * bandit_test.best_prob:.1f}"")
+print(f""Regret final : {result_random['regret'][-1]:.1f}"")",,,,,,,,3136221ba4c83622,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,73beb16d,markdown,fr,3413af8c4c617db9,"### Agent glouton (Greedy)
+
+L'agent glouton (greedy) estime la valeur de chaque bras par la moyenne des recompenses observees, puis choisit toujours le bras qui a la meilleure estimation actuelle. Le probleme : s'il n'explore pas, il peut se bloquer sur un bras sous-optimal.",,,,,,,,3413af8c4c617db9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,4dbc2963,code,fr,7e2ae38b466dbeb8,"def greedy_agent(bandit, n_steps: int, seed: int = 42, n_warmup: int = 10) -> tuple:
+    """"""
+    Agent glouton : estime la valeur de chaque bras et choisit toujours le meilleur.
+    
+    n_warmup : nombre de tirages initiaux par bras pour avoir une premiere estimation.
+    """"""
+    rng = np.random.default_rng(seed)
+    counts = np.zeros(bandit.n_arms)
+    values = np.zeros(bandit.n_arms)
+    actions = []
+    rewards = []
+    
+    # Phase d'initialisation : tirer chaque bras n_warmup fois
+    for arm in range(bandit.n_arms):
+        for _ in range(n_warmup):
+            reward = bandit.pull(arm)
+            counts[arm] += 1
+            values[arm] += (reward - values[arm]) / counts[arm]
+            actions.append(arm)
+            rewards.append(reward)
+    
+    # Phase gloutonne
+    for t in range(n_steps - len(actions)):
+        arm = int(np.argmax(values))
+        reward = bandit.pull(arm)
+        counts[arm] += 1
+        values[arm] += (reward - values[arm]) / counts[arm]
+        actions.append(arm)
+        rewards.append(reward)
+    
+    return np.array(actions), np.array(rewards)
+
+# Tester l'agent glouton
+bandit_test = BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42)
+result_greedy = run_agent(bandit_test, greedy_agent, n_steps=1000, seed=42)
+
+print(f""Agent glouton - recompense cumulee finale : {result_greedy['cumulative_rewards'][-1]:.1f} / {1000 * bandit_test.best_prob:.1f}"")
+print(f""Regret final : {result_greedy['regret'][-1]:.1f}"")
+
+# Frequence de choix de chaque bras
+unique, counts = np.unique(result_greedy['actions'][-100:], return_counts=True)
+freq_str = "", "".join(f""Bras {u}={c}%"" for u, c in zip(unique, counts))
+print(f""Bras choisis (derniers 100 pas) : {freq_str}"")",,,,,,,,7e2ae38b466dbeb8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,ae4cc380,code,fr,2b6f4618c0986e7c,"# Comparaison visuelle : Random vs Greedy
+fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+# Recompense cumulee
+axes[0].plot(result_random['cumulative_rewards'], label='Random', alpha=0.8)
+axes[0].plot(result_greedy['cumulative_rewards'], label='Greedy', alpha=0.8)
+optimal_line = np.arange(1, 1001) * bandit_test.best_prob
+axes[0].plot(optimal_line, 'k--', label=f'Optimal (bras {bandit_test.best_arm})', alpha=0.5)
+axes[0].set_xlabel('Pas de temps')
+axes[0].set_ylabel('Recompense cumulee')
+axes[0].set_title('Recompense cumulee')
+axes[0].legend()
+axes[0].grid(True, alpha=0.3)
+
+# Regret cumule
+axes[1].plot(result_random['regret'], label='Random', alpha=0.8)
+axes[1].plot(result_greedy['regret'], label='Greedy', alpha=0.8)
+axes[1].set_xlabel('Pas de temps')
+axes[1].set_ylabel('Regret cumule')
+axes[1].set_title('Regret cumule')
+axes[1].legend()
+axes[1].grid(True, alpha=0.3)
+
+plt.suptitle('Random vs Greedy sur un bandit a 5 bras', fontsize=14)
+plt.tight_layout()
+plt.show()",,,,,,,,2b6f4618c0986e7c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,54fe69dc,markdown,fr,9d689a13355399f1,"### Interpretation : Random vs Greedy
+
+| Agent | Regret final | Comportement |
+|-------|-------------|-------------|
+| Random | eleve (~300) | Explore tous les bras equitablement, n'apprend rien |
+| Greedy | moyen (~211) | Exploite rapidement mais peut se bloquer sur un bras sous-optimal |
+
+**Points cles** :
+1. L'agent aleatoire a un regret lineaire : il ne converge jamais vers le meilleur bras
+2. L'agent glouton est meilleur car il exploite, mais son initialisation peut le pieger si le meilleur bras a un rendement initial sous-estime
+3. Il nous faut une strategie qui combine exploration et exploitation de maniere adaptee",,,,,,,,9d689a13355399f1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,7864b2ec,markdown,fr,da90b542c41de30f,"### Exercice 2 : Agent epsilon-greedy avec decroissance
+
+L'agent $\varepsilon$-greedy standard utilise un $\varepsilon$ fixe. Mais il est souvent preferable de **reduire l'exploration avec le temps** : beaucoup d'exploration au debut (pour apprendre), puis de moins en moins (pour exploiter).
+
+**Objectif** : Implementer un agent ou $\varepsilon$ decroit au fil du temps, par exemple $\varepsilon_t = \min(1, \frac{\varepsilon_0}{t})$.
+
+**Etapes** :
+1. Calculer $\varepsilon_t$ a chaque pas de temps
+2. Avec probabilite $\varepsilon_t$, choisir un bras aleatoire ; sinon, choisir le meilleur bras estime
+3. Mettre a jour l'estimation de la valeur du bras choisi (moyenne incrementale)
+
+**Indice** : La moyenne incrementale se met a jour ainsi : $\hat{Q}_t \leftarrow \hat{Q}_{t-1} + \frac{1}{n}(r_t - \hat{Q}_{t-1})$ ou $n$ est le nombre de fois que le bras a ete tire.",,,,,,,,da90b542c41de30f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,9bd61e8f,code,fr,7d1de216e8449d27,"def decaying_epsilon_greedy_agent(bandit, n_steps: int, seed: int = 42,
+                                   epsilon_start: float = 1.0) -> tuple:
+    """"""
+    Agent epsilon-greedy avec decroissance : epsilon_t = epsilon_start / t.
+    
+    Parametres :
+        bandit : instance de BernoulliBandit
+        n_steps : nombre de pas de temps
+        seed : graine aleatoire
+        epsilon_start : valeur initiale d'epsilon
+    
+    Retourne :
+        (actions, rewards) : tableaux numpy des actions et recompenses
+    """"""
+    rng = np.random.default_rng(seed)
+    counts = np.zeros(bandit.n_arms)
+    values = np.zeros(bandit.n_arms)
+    actions = []
+    rewards = []
+    
+    for t in range(1, n_steps + 1):
+        # TODO etudiant : calculer epsilon_t = epsilon_start / t
+        epsilon_t = 0.0  # TODO etudiant : remplacer
+        
+        # TODO etudiant : choisir un bras (aleatoire avec proba epsilon_t, sinon greedy)
+        arm = 0  # TODO etudiant : remplacer
+        
+        reward = bandit.pull(arm)
+        counts[arm] += 1
+        # TODO etudiant : mettre a jour values[arm] avec la moyenne incrementale
+        # values[arm] += ...
+        
+        actions.append(arm)
+        rewards.append(reward)
+    
+    return np.array(actions), np.array(rewards)
+
+print(""Exercice a completer"")",,,,,,,,7d1de216e8449d27,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,5b9e78b7,markdown,fr,eb51341312e5dbaa,"## 4. Strategies d'exploration intelligentes
+
+Les strategies naives ont des limites importantes. Nous allons maintenant voir trois approches plus sophistiquees qui parviennent a un meilleur compromis exploration-exploitation.
+
+### Epsilon-greedy
+
+La strategie $\varepsilon$-greedy est simple mais efficace :
+- Avec probabilite $\varepsilon$ : choisir un bras **aleatoirement** (exploration)
+- Avec probabilite $1 - \varepsilon$ : choisir le bras **le meilleur selon l'estimation courante** (exploitation)
+
+C'est la strategie la plus utilisee en pratique pour sa simplicite.",,,,,,,,eb51341312e5dbaa,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,d389568e,code,fr,91e7b464cef51ea6,"def epsilon_greedy_agent(bandit, n_steps: int, seed: int = 42, epsilon: float = 0.1) -> tuple:
+    """"""
+    Agent epsilon-greedy avec epsilon fixe.
+    
+    Parametres :
+        bandit : instance de BernoulliBandit
+        n_steps : nombre de pas de temps
+        seed : graine aleatoire
+        epsilon : probabilite d'exploration (0 = greedy, 1 = random)
+    """"""
+    rng = np.random.default_rng(seed)
+    counts = np.zeros(bandit.n_arms)
+    values = np.zeros(bandit.n_arms)
+    actions = []
+    rewards = []
+    
+    for t in range(n_steps):
+        if rng.random() < epsilon:
+            arm = rng.integers(0, bandit.n_arms)
+        else:
+            arm = int(np.argmax(values))
+        
+        reward = bandit.pull(arm)
+        counts[arm] += 1
+        values[arm] += (reward - values[arm]) / counts[arm]
+        actions.append(arm)
+        rewards.append(reward)
+    
+    return np.array(actions), np.array(rewards)
+
+print(""Fonction epsilon_greedy_agent definie"")",,,,,,,,91e7b464cef51ea6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,4c28863d,code,fr,30f5ad6cbbf920e0,"# Tester epsilon-greedy avec differentes valeurs d'epsilon
+bandit_test = BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42)
+result_eg01 = run_agent(bandit_test, lambda b, n, s: epsilon_greedy_agent(b, n, s, epsilon=0.1), 1000, seed=42)
+
+print(f""Epsilon-greedy (e=0.1) - recompense cumulee : {result_eg01['cumulative_rewards'][-1]:.1f} / {1000 * bandit_test.best_prob:.1f}, regret final : {result_eg01['regret'][-1]:.1f}"")",,,,,,,,30f5ad6cbbf920e0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,b6013484,markdown,fr,d7e3e881969a40f2,"### UCB (Upper Confidence Bound)
+
+L'algorithme **UCB1** (Auer et al., 2002) utilise un intervalle de confiance pour guider l'exploration. Il choisit le bras qui maximise :
+
+$$a_t = \arg\max_{a} \left[ \hat{Q}(a) + c \sqrt{\frac{\ln t}{N(a)}} \right]$$
+
+ou $\hat{Q}(a)$ est la recompense moyenne estimee, $N(a)$ le nombre de fois que le bras $a$ a ete tire, $t$ le pas de temps actuel, et $c$ un parametre controlant l'exploration.
+
+Le terme $\sqrt{\frac{\ln t}{N(a)}}$ est un **bonus d'exploration** qui decroit quand un bras est souvent tire. UCB explore automatiquement les bras sous-explores sans parametre d'exploration explicite.",,,,,,,,d7e3e881969a40f2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,a01f5986,code,fr,b0a10b939cef6387,"def ucb_agent(bandit, n_steps: int, seed: int = 42, c: float = 2.0) -> tuple:
+    """"""
+    Agent UCB1 (Upper Confidence Bound).
+    
+    Parametres :
+        bandit : instance de BernoulliBandit
+        n_steps : nombre de pas de temps
+        seed : graine aleatoire
+        c : parametre d'exploration (typiquement sqrt(2) ou 2.0)
+    """"""
+    rng = np.random.default_rng(seed)
+    counts = np.zeros(bandit.n_arms)
+    values = np.zeros(bandit.n_arms)
+    actions = []
+    rewards = []
+    
+    # Phase d'initialisation : tirer chaque bras une fois
+    for arm in range(bandit.n_arms):
+        reward = bandit.pull(arm)
+        counts[arm] = 1
+        values[arm] = reward
+        actions.append(arm)
+        rewards.append(reward)
+    
+    for t in range(bandit.n_arms + 1, n_steps + 1):
+        # Calcul du score UCB pour chaque bras
+        ucb_values = values + c * np.sqrt(np.log(t) / counts)
+        arm = int(np.argmax(ucb_values))
+        
+        reward = bandit.pull(arm)
+        counts[arm] += 1
+        values[arm] += (reward - values[arm]) / counts[arm]
+        actions.append(arm)
+        rewards.append(reward)
+    
+    return np.array(actions), np.array(rewards)
+
+print(""Fonction ucb_agent definie"")",,,,,,,,b0a10b939cef6387,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,9e12e459,code,fr,50d5ce04eecaf54c,"# Tester UCB
+bandit_test = BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42)
+result_ucb = run_agent(bandit_test, ucb_agent, 1000, seed=42)
+
+print(f""UCB (c=2.0) - recompense cumulee : {result_ucb['cumulative_rewards'][-1]:.1f} / {1000 * bandit_test.best_prob:.1f}, regret final : {result_ucb['regret'][-1]:.1f}"")",,,,,,,,50d5ce04eecaf54c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,b70cba88,markdown,fr,fbfd28f35009ec52,"### Thompson Sampling
+
+Le **Thompson Sampling** est une approche bayesienne qui maintient une distribution a posteriori sur la valeur de chaque bras. Pour un bandit de Bernoulli, on utilise la distribution **Beta** :
+
+- Prior : $\text{Beta}(1, 1)$ (uniforme) pour chaque bras
+- Apres avoir observe un succes : $\alpha \leftarrow \alpha + 1$
+- Apres avoir observe un echec : $\beta \leftarrow \beta + 1$
+- A chaque pas, on echantillonne $\theta_k \sim \text{Beta}(\alpha_k, \beta_k)$ et on choisit le bras avec le plus grand $\theta_k$
+
+Cette approche est elegante car elle equilibre naturellement exploration et exploitation : les bras incertains (peu d'observations) ont des echantillons plus disperses, donc une chance d'etre selectionnes.",,,,,,,,fbfd28f35009ec52,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,f90ef86c,markdown,fr,d234caae234c7b46,"### Exercice 3 : Thompson Sampling pour bandits de Bernoulli
+
+**Objectif** : Implementer l'algorithme de Thompson Sampling pour un bandit de Bernoulli.
+
+**Etapes** :
+1. Initialiser les parametres Beta : $\alpha_k = 1$, $\beta_k = 1$ pour chaque bras
+2. A chaque pas de temps, echantillonner $\theta_k \sim \text{Beta}(\alpha_k, \beta_k)$ pour chaque bras
+3. Choisir le bras avec le plus grand $\theta_k$
+4. Mettre a jour $\alpha_k$ ou $\beta_k$ selon le resultat observe
+
+**Indice** : Utilisez `rng.beta(alpha[k], beta[k])` pour echantillonner depuis la distribution Beta. Apres avoir observe une recompense $r$ pour le bras $k$ : si $r = 1$, incrementer $\alpha_k$ ; si $r = 0$, incrementer $\beta_k$.",,,,,,,,d234caae234c7b46,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,bc869583,code,fr,ac126c163197362c,"def thompson_sampling_agent(bandit, n_steps: int, seed: int = 42) -> tuple:
+    """"""
+    Agent Thompson Sampling pour bandit de Bernoulli.
+    
+    Utilise des distributions Beta comme posterior sur la probabilite
+    de succes de chaque bras.
+    
+    Parametres :
+        bandit : instance de BernoulliBandit
+        n_steps : nombre de pas de temps
+        seed : graine aleatoire
+    
+    Retourne :
+        (actions, rewards) : tableaux numpy des actions et recompenses
+    """"""
+    rng = np.random.default_rng(seed)
+    # Parametres des distributions Beta : Beta(alpha, beta)
+    alpha = np.ones(bandit.n_arms)   # nombre de succes + 1
+    beta_params = np.ones(bandit.n_arms)  # nombre d'echecs + 1
+    
+    actions = []
+    rewards = []
+    
+    for t in range(n_steps):
+        # TODO etudiant : echantillonner theta_k ~ Beta(alpha[k], beta_params[k]) pour chaque bras
+        samples = None  # TODO etudiant : remplacer par rng.beta(alpha, beta_params)
+        
+        # TODO etudiant : choisir le bras avec le plus grand echantillon
+        arm = 0  # TODO etudiant : remplacer par int(np.argmax(samples))
+        
+        reward = bandit.pull(arm)
+        
+        # TODO etudiant : mettre a jour alpha[arm] ou beta_params[arm]
+        # Si reward == 1 : alpha[arm] += 1
+        # Si reward == 0 : beta_params[arm] += 1
+        
+        actions.append(arm)
+        rewards.append(reward)
+    
+    return np.array(actions), np.array(rewards)
+
+print(""Exercice a completer"")",,,,,,,,ac126c163197362c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,d68948bc,markdown,fr,276ec6fe7af4c711,"## 5. Comparaison et analyse
+
+Nous allons maintenant comparer toutes les strategies sur le meme probleme de bandit, avec des statistiques sur plusieurs graines aleatoires pour obtenir des resultats fiables.",,,,,,,,276ec6fe7af4c711,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,b6a940c9,code,fr,93dc69c4330d1b2b,"# Comparaison multi-seeds de toutes les strategies
+N_ARMS = 10
+N_STEPS = 2000
+N_SEEDS = 50
+SEEDS = range(N_SEEDS)
+
+strategies = {
+    'Random': lambda b, n, s: random_agent(b, n, s),
+    'Greedy': lambda b, n, s: greedy_agent(b, n, s),
+    'e-greedy (0.1)': lambda b, n, s: epsilon_greedy_agent(b, n, s, epsilon=0.1),
+    'e-greedy (0.01)': lambda b, n, s: epsilon_greedy_agent(b, n, s, epsilon=0.01),
+    'UCB (c=2)': lambda b, n, s: ucb_agent(b, n, s, c=2.0),
+}
+
+# Collecter les resultats
+all_results = {name: {'rewards': [], 'regret': []} for name in strategies}
+
+for seed in SEEDS:
+    for name, agent_fn in strategies.items():
+        bandit_fresh = BernoulliBandit(n_arms=N_ARMS, seed=seed)
+        result = run_agent(bandit_fresh, agent_fn, N_STEPS, seed=seed + 1000)
+        all_results[name]['rewards'].append(result['cumulative_rewards'])
+        all_results[name]['regret'].append(result['regret'])
+
+# Calculer les moyennes
+mean_rewards = {}
+mean_regret = {}
+for name in strategies:
+    mean_rewards[name] = np.mean(all_results[name]['rewards'], axis=0)
+    mean_regret[name] = np.mean(all_results[name]['regret'], axis=0)
+
+print(f""Evaluation sur {N_SEEDS} seeds terminee"")",,,,,,,,93dc69c4330d1b2b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,77729da1,code,fr,d89938a5c3e3bb84,"# Figure 1 : Recompense cumulee moyenne et regret
+fig, axes = plt.subplots(1, 2, figsize=(15, 6))
+
+colors = {'Random': '#888888', 'Greedy': '#e74c3c', 'e-greedy (0.1)': '#3498db',
+          'e-greedy (0.01)': '#2ecc71', 'UCB (c=2)': '#9b59b6'}
+
+for name in strategies:
+    axes[0].plot(mean_rewards[name], label=name, color=colors[name], linewidth=2, alpha=0.85)
+    axes[1].plot(mean_regret[name], label=name, color=colors[name], linewidth=2, alpha=0.85)
+
+# Ligne optimale (approximation avec le meilleur bras moyen)
+optimal = np.arange(1, N_STEPS + 1) * 0.8
+axes[0].plot(optimal, 'k--', alpha=0.4, label='Optimal (approx)')
+
+axes[0].set_xlabel('Pas de temps')
+axes[0].set_ylabel('Recompense cumulee (moyenne)')
+axes[0].set_title('Recompense cumulee moyenne')
+axes[0].legend(fontsize=9)
+axes[0].grid(True, alpha=0.3)
+
+axes[1].set_xlabel('Pas de temps')
+axes[1].set_ylabel('Regret cumule (moyenne)')
+axes[1].set_title('Regret cumule moyen')
+axes[1].legend(fontsize=9)
+axes[1].grid(True, alpha=0.3)
+
+plt.suptitle(f'Comparaison des strategies ({N_ARMS} bras, {N_STEPS} pas, moyenne sur {N_SEEDS} seeds)', fontsize=13)
+plt.tight_layout()
+plt.show()",,,,,,,,d89938a5c3e3bb84,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,85c5365f,code,fr,4f9f7e6d2846f905,"# Figure 2 : Frequence de selection du meilleur bras au cours du temps
+fig, ax = plt.subplots(figsize=(10, 5))
+
+window = 50
+for name, agent_fn in strategies.items():
+    best_arm_freq = []
+    for seed in SEEDS:
+        bandit_fresh = BernoulliBandit(n_arms=N_ARMS, seed=seed)
+        result = run_agent(bandit_fresh, agent_fn, N_STEPS, seed=seed + 1000)
+        is_best = (result['actions'] == bandit_fresh.best_arm).astype(float)
+        best_arm_freq.append(is_best)
+    
+    mean_freq = np.mean(best_arm_freq, axis=0)
+    smooth = np.convolve(mean_freq, np.ones(window)/window, mode='valid')
+    ax.plot(smooth, label=name, color=colors[name], linewidth=2, alpha=0.85)
+
+ax.axhline(y=1.0/N_ARMS, color='gray', linestyle=':', alpha=0.5, label=f'Random baseline (1/{N_ARMS})')
+ax.set_xlabel('Pas de temps')
+ax.set_ylabel(f'Frequence de selection du meilleur bras (moyenne mobile {window})')
+ax.set_title('Convergence vers le meilleur bras')
+ax.legend(fontsize=9)
+ax.grid(True, alpha=0.3)
+ax.set_ylim(-0.05, 1.05)
+plt.tight_layout()
+plt.show()",,,,,,,,4f9f7e6d2846f905,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,7707d61e,code,fr,6c65d4ab30de4c3e,"# Tableau recapitulatif
+print(""+-----------------+-------------+-------------+-----------------------+"")
+print(""| Strategie       | Regret final | % optimal   | Type de regret        |"")
+print(""+-----------------+-------------+-------------+-----------------------+"")
+
+regret_types = {
+    'Random': 'Lineaire (constant)',
+    'Greedy': 'Sous-lineaire (fixe)',
+    'e-greedy (0.1)': 'Sous-lineaire (borne)',
+    'e-greedy (0.01)': 'Sous-lineaire (borne)',
+    'UCB (c=2)': 'O(log T) asymptotique'
+}
+
+for name in strategies:
+    final_regret = mean_regret[name][-1]
+    final_reward = mean_rewards[name][-1]
+    optimal_reward = mean_rewards['Random'][-1] + mean_regret['Random'][-1]
+    pct_optimal = (final_reward / optimal_reward * 100) if optimal_reward > 0 else 0
+    print(f""| {name:<15} | {final_regret:>9.1f}   | {pct_optimal:>7.1f}%   | {regret_types[name]:<21} |"")
+
+print(""+-----------------+-------------+-------------+-----------------------+"")",,,,,,,,6c65d4ab30de4c3e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,1eb5d787,code,fr,1937e92622161c50,"# Sweep regret-vs-T : pourquoi UCB est ""optimal"" alors que Greedy gagne a T=2000 ?
+# (Prong B : rendre la capacite distinctive du SOTA — l'exploration principée et robuste — visible.)
+#
+# Idee : la perf de Greedy depend entierement de son warmup (n_warmup=10/bras = 100 tirages gratuits).
+# On compare Greedy avec deux warmups + UCB canonique (c=sqrt(2)) sur plusieurs horizons.
+HORIZONS = [1000, 3000, 10000, 30000]
+N_SEEDS_SWEEP = 20
+
+sweep_strategies = {
+    'Greedy (warmup=10)': lambda b, n, s: greedy_agent(b, n, s, n_warmup=10),
+    'Greedy (warmup=1)':  lambda b, n, s: greedy_agent(b, n, s, n_warmup=1),
+    'e-greedy (0.1)':      lambda b, n, s: epsilon_greedy_agent(b, n, s, epsilon=0.1),
+    'UCB (c=sqrt(2))':     lambda b, n, s: ucb_agent(b, n, s, c=np.sqrt(2)),
+}
+
+sweep_final_regret = {name: [] for name in sweep_strategies}
+for T in HORIZONS:
+    for name, agent_fn in sweep_strategies.items():
+        regrets = []
+        for seed in range(N_SEEDS_SWEEP):
+            bandit_fresh = BernoulliBandit(n_arms=N_ARMS, seed=seed)
+            result = run_agent(bandit_fresh, agent_fn, T, seed=seed + 1000)
+            regrets.append(result['regret'][-1])
+        sweep_final_regret[name].append(float(np.mean(regrets)))
+
+# Figure : regret final vs horizon (abscisse log)
+fig, ax = plt.subplots(figsize=(10, 5.5))
+colors_sweep = {'Greedy (warmup=10)': '#e74c3c', 'Greedy (warmup=1)': '#c0392b',
+                'e-greedy (0.1)': '#3498db', 'UCB (c=sqrt(2))': '#9b59b6'}
+markers = {'Greedy (warmup=10)': 'o', 'Greedy (warmup=1)': 'x',
+           'e-greedy (0.1)': 's', 'UCB (c=sqrt(2))': '^'}
+for name in sweep_strategies:
+    ax.plot(HORIZONS, sweep_final_regret[name], marker=markers[name], markersize=10,
+            linewidth=2.2, color=colors_sweep[name], label=name)
+ax.set_xscale('log')
+ax.set_xlabel('Horizon T (pas de temps, echelle log)')
+ax.set_ylabel('Regret final moyen')
+ax.set_title(f'Robustesse de Greedy vs UCB selon l\'horizon ({N_ARMS} bras, moyenne sur {N_SEEDS_SWEEP} seeds)')
+ax.legend()
+ax.grid(True, alpha=0.3, which='both')
+plt.tight_layout()
+plt.show()
+
+# Tableau : regret final a chaque horizon
+print(""Regret final moyen selon l'horizon T :"")
+print(""+---------------------+"" + ""-"" * (13 * len(HORIZONS)) + ""+"")
+print(""| Strategie           |"" + """".join(f"" T={h:<10}"" for h in HORIZONS) + ""|"")
+print(""+---------------------+"" + ""-"" * (13 * len(HORIZONS)) + ""+"")
+for name in sweep_strategies:
+    row = """".join(f"" {sweep_final_regret[name][i]:>11.1f} "" for i in range(len(HORIZONS)))
+    print(f""| {name:<19} |{row}|"")
+print(""+---------------------+"" + ""-"" * (13 * len(HORIZONS)) + ""+"")
+print(""\nLecture : Greedy(warmup=10) gagne grace a ses 100 tirages d'initialisation gratuits ;"")
+print(""mais Greedy(warmup=1) DIVERGE (se bloque sur un bras sous-optimal), et UCB reste stable"")
+print(""(exploration principée, independante du warmup). La force de Greedy est fragile :"")
+print(""elle depend du warmup, celle d'UCB non."")
+",,,,,,,,1937e92622161c50,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,f5ae47a4,markdown,fr,3ead2c1ed2e88f87,"### Interpretation : robustesse de Greedy vs UCB (pourquoi UCB ""optimal"" finit 2e a T=2000)
+
+Le benchmark principal (cellule precedente, T=2000) montre **Greedy gagnant** et UCB en mauvaise position. Le sweep ci-dessus explique pourquoi **sans contredire la theorie** : l'optimalite d'UCB est **asymptotique**, et sa vraie force est la **robustesse**, pas de battre un Greedy bien initialise a court terme.
+
+**Ce que le sweep revele** :
+
+1. **Greedy(warmup=10) gagne sur tout horizon teste** — mais c'est un artefact de son `n_warmup=10` par bras (100 tirages d'initialisation gratuits), qui identifie fiablement le meilleur bras avant d'exploiter. Ce warmup genereux **masque la faiblesse fondamentale de Greedy**.
+
+2. **Greedy(warmup=1) diverge** : avec un warmup realiste (1 seul tirage par bras), Greedy se bloque souvent sur un bras sous-optimal et son regret **explose** (plus de 1000 a T=30000). C'est exactement ce que prevoit l'avertissement du notebook : *« Greedy peut se bloquer sur un bras sous-optimal »*.
+
+3. **UCB(c=$\sqrt{2}$) reste stable** (~550 a T=30000), avec un regret en $O(\log T)$. Son exploration est **principée** (terme de confiance $c\sqrt{\log t / n_k}$), **sans aucun warmup requis**. La ou Greedy s'effondre sans warmup, UCB tient.
+
+**Lecon** : ""asymptotiquement optimal"" ($O(\log T)$) ne veut **pas** dire ""bat Greedy a tout horizon"". Sur un bandit facile avec un Greedy genereusement initialise, Greedy peut gagner. **L'avantage reel d'UCB est la robustesse** : il performe bien **sans chance ni warmup gratuit**, la ou Greedy est fragile (sa perf depend entierement de la qualite de son initialisation).
+
+**Note sur Thompson Sampling** : Thompson possede egalement un regret $O(\log T)$ et la meme robustesse bayesienne ; son implementation est volontairement laissee en **Exercice 3** (les exercices 1, 2 et 3 sont des stubs a completer). Le sweep se concentre sur UCB (deja implemente) pour rendre l'argument concret.
+",,,,,,,,3ead2c1ed2e88f87,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,4f5d86c3,markdown,fr,891bf3e293860b5a,"### Interpretation : comparaison des strategies
+
+| Strategie | Regret | Exploration | Points forts | Points faibles |
+|-----------|--------|-------------|--------------|----------------|
+| **Random** | Lineaire | Maximal | Simple, bonne base de reference | N'apprend jamais |
+| **Greedy** | Sous-lineaire | Minimal (init seulement) | Rapide si bonne initialisation | Peut se bloquer sur un bras sous-optimal |
+| **e-greedy** | $O(\log T)$ | Parametre fixe | Simple, robuste | Continue a explorer meme apres convergence |
+| **UCB** | $O(\log T)$ | Automatique | **Robuste** (optimal asymptotique $O(\log T)$, sans warmup, cf. sweep ci-dessus) | Suppose des bornes sur les recompenses |
+| **Thompson** | $O(\log T)$ | Automatique (bayesien) | Elegante, adaptee aux priors | Specifique au type de distribution |
+
+**Points cles** :
+1. Toutes les strategies intelligentes (e-greedy, UCB, Thompson) ont un regret **sous-lineaire** : elles apprennent
+2. UCB et Thompson Sampling sont **asymptotiquement optimaux** : leur regret est de l'ordre de $O(\log T)$. Attention : cela ne signifie pas qu'ils battent Greedy a tout horizon (cf. sweep robustesse ci-dessus), mais que leur regret **croit lentement et de facon robuste**, sans dependre d'un warmup chanceux
+3. Le choix de $\varepsilon$ dans e-greedy est crucial : trop grand = trop d'exploration, trop petit = sous-optimal
+4. Thompson Sampling est egalement $O(\log T)$ et partage cette robustesse ; son implementation est laissee en **Exercice 3**",,,,,,,,891bf3e293860b5a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,ddbd1558,markdown,fr,ca2cc0fc636b2eb4,"## 6. Visualisation detaillee : evolution des estimations
+
+Pour comprendre comment chaque strategie apprend, visualisons l'evolution des estimations de valeur pour chaque bras au cours du temps.",,,,,,,,ca2cc0fc636b2eb4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,463b3068,code,fr,2bd37f3f1c39bbe4,"# Visualiser les estimations de l'agent epsilon-greedy au cours du temps
+def track_value_estimates(bandit, n_steps: int, seed: int = 42, epsilon: float = 0.1) -> np.ndarray:
+    """"""
+    Execute un agent epsilon-greedy et retourne l'evolution des estimations.
+    Retourne un tableau (n_steps, n_arms) des valeurs estimees.
+    """"""
+    rng = np.random.default_rng(seed)
+    counts = np.zeros(bandit.n_arms)
+    values = np.zeros(bandit.n_arms)
+    history = np.zeros((n_steps, bandit.n_arms))
+    
+    for t in range(n_steps):
+        if rng.random() < epsilon:
+            arm = rng.integers(0, bandit.n_arms)
+        else:
+            arm = int(np.argmax(values))
+        
+        reward = bandit.pull(arm)
+        counts[arm] += 1
+        values[arm] += (reward - values[arm]) / counts[arm]
+        history[t] = values.copy()
+    
+    return history
+
+bandit_vis = BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42)
+history = track_value_estimates(bandit_vis, 500, seed=42)
+
+fig, ax = plt.subplots(figsize=(12, 6))
+
+arm_colors = ['#e74c3c', '#3498db', '#2ecc71', '#e67e22', '#9b59b6']
+for arm in range(bandit_vis.n_arms):
+    ax.plot(history[:, arm], color=arm_colors[arm], alpha=0.7, linewidth=1.5,
+            label=f'Bras {arm} (estimation)')
+    ax.axhline(y=bandit_vis.probs[arm], color=arm_colors[arm], linestyle='--', alpha=0.4)
+
+ax.set_xlabel('Pas de temps')
+ax.set_ylabel('Valeur estimee')
+ax.set_title('Evolution des estimations de valeur (epsilon-greedy, e=0.1)')
+ax.legend(fontsize=9, loc='center right')
+ax.grid(True, alpha=0.3)
+plt.tight_layout()
+plt.show()",,,,,,,,2bd37f3f1c39bbe4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,99fcd332,markdown,fr,d7b8d26eb3bb996c,"Les lignes en pointilles representent les **veritables probabilites** de chaque bras. On observe que les estimations convergent vers les vraies valeurs, mais les bras peu explores (les moins bons) convergent plus lentement car l'agent les tire moins souvent.",,,,,,,,d7b8d26eb3bb996c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,18f1be7a,code,fr,cb3a18857f5d0178,"# Visualisation : heatmap de selection des bras
+bandit_vis = BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42)
+
+fig, axes = plt.subplots(1, 3, figsize=(18, 5))
+strategy_data = {
+    'Greedy': run_agent(BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42),
+                         greedy_agent, 500, seed=42)['actions'],
+    'e-greedy (0.1)': run_agent(BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42),
+                                lambda b, n, s: epsilon_greedy_agent(b, n, s, epsilon=0.1), 500, seed=42)['actions'],
+    'UCB': run_agent(BernoulliBandit(n_arms=5, probs=[0.3, 0.5, 0.2, 0.8, 0.6], seed=42),
+                     ucb_agent, 500, seed=42)['actions'],
+}
+
+block_size = 50
+n_blocks = 500 // block_size
+
+for idx, (name, actions) in enumerate(strategy_data.items()):
+    heatmap = np.zeros((5, n_blocks))
+    for b in range(n_blocks):
+        block = actions[b * block_size:(b + 1) * block_size]
+        for arm in range(5):
+            heatmap[arm, b] = np.sum(block == arm) / block_size
+    
+    im = axes[idx].imshow(heatmap, aspect='auto', cmap='YlOrRd', vmin=0, vmax=1)
+    axes[idx].set_xlabel(f'Bloc de {block_size} pas')
+    axes[idx].set_ylabel('Bras')
+    axes[idx].set_title(name)
+    axes[idx].set_yticks(range(5))
+    axes[idx].set_xticks(range(n_blocks))
+    axes[idx].set_xticklabels([f'{b*block_size}-{(b+1)*block_size}' for b in range(n_blocks)],
+                              fontsize=8, rotation=45)
+
+fig.colorbar(im, ax=axes, shrink=0.8, label='Frequence de selection')
+plt.suptitle('Frequence de selection des bras au cours du temps', fontsize=13)
+plt.tight_layout()
+plt.show()",,,,,,,,cb3a18857f5d0178,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,0226c2d4,markdown,fr,77b63cf140af69a8,"La heatmap montre clairement comment chaque strategie converge (ou pas) vers le meilleur bras (bras 3, probabilite 0.8) :
+- **Greedy** : se fixe rapidement mais peut se tromper si l'initialisation est defavorable
+- **e-greedy** : converge vers le meilleur bras tout en continuant a explorer legerement
+- **UCB** : exploration automatique au debut, puis convergence rapide vers le meilleur bras",,,,,,,,77b63cf140af69a8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb,2fb2d08c,markdown,fr,9829e4eec3b1784f,"## 7. Conclusion
+
+| Concept | Ce que nous avons vu |
+|---------|---------------------|
+| **Bandit manchot** | Probleme fondamental : $K$ bras, $T$ pas de temps, maximiser les gains |
+| **Exploration vs exploitation** | Le compromis central en RL : explorer pour apprendre, exploiter pour gagner |
+| **Regret cumule** | Metrique cle : $T \cdot \mu^* - \sum r_t$, sous-lineaire = bon algorithme |
+| **e-greedy** | Simple et efficace, mais $\varepsilon$ fixe gaspille de l'exploration |
+| **UCB** | Exploration automatisee via intervalle de confiance, optimal $O(\log T)$ |
+| **Thompson Sampling** | Approche bayesienne elegante, performances empiriques excellentes |
+
+**Lien avec le notebook suivant** : Le bandit manchot est un MDP a un seul etat. Dans le [notebook RL-5](rl_5_mdp_dp_qlearning.ipynb), nous generaliserons au cas multi-etats avec les Processus de Decision Markoviens (MDP), la programmation dynamique et le Q-Learning tabulaire. Les strategies d'exploration vues ici (e-greedy, UCB) seront directement applicables.
+
+**Pour aller plus loin** :
+- Sutton & Barto, *Reinforcement Learning: An Introduction*, Chapter 2 (Multi-armed Bandits)
+- Auer et al. (2002), ""Finite-time Analysis of the Multiarmed Bandit Problem""
+- Chapelle & Li (2011), ""An Empirical Evaluation of Thompson Sampling""
+
+
+### References academiques
+
+- Robbins, H. (1952). Some Aspects of the Sequential Design of Experiments. Bulletin of the American Mathematical Society 58(5):527-535.
+- Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002). Finite-time Analysis of the Multiarmed Bandit Problem. Machine Learning 47(2-3):235-256.
+- Thompson, W.R. (1933). On the Likelihood that One Unknown Probability Exceeds Another in the View of the Evidence of the Two Samples. Biometrika 25(3-4):285-294.
+- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press.
+
+",,,,,,,,9829e4eec3b1784f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,a0f1e001,markdown,fr,26850d5eb05b85e9,"# RL-5 : MDP, Programmation Dynamique et Q-Learning Tabulaire
+
+**Serie** : Reinforcement Learning | **Notebook** : 5/13 | **Duree estimee** : 45-50 min
+
+Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-3 HER](rl_3_experience_replay_dqn.ipynb) | **RL-5** | [RL-6 DQN/PG](rl_6_dqn_policy_gradient.ipynb) | [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb)
+
+---
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous serez capable de :
+- Formaliser un probleme d'apprentissage par renforcement comme un Processus de Decision Markovien (MDP)
+- Implementer l'Iteration de Valeur (Value Iteration) et l'Iteration de Politique (Policy Iteration)
+- Comprendre et implementer le Q-Learning tabulaire
+- Visualiser la convergence des algorithmes sur des environnements discrets
+
+## Prerequis
+
+- Notions de base en probabilites (esperance, loi de probabilite)
+- Manipulation de tableaux numpy
+- Avoir suivi le [RL-1 Introduction](rl_1_intro_cartpole.ipynb) (concepts agent/environnement/reward)
+
+---
+
+**Rappels sur les concepts fondamentaux**
+- Un **MDP** est defini par un tuple $(S, A, P, R, \gamma)$ ou $S$ = etats, $A$ = actions, $P$ = transitions, $R$ = recompenses, $\gamma$ = facteur d'actualisation.
+- La **fonction de valeur** $V(s)$ estime la recompense cumulee attendue depuis un etat $s$.
+- La **fonction Q-valeur** $Q(s, a)$ estime cette meme recompense en choisissant l'action $a$ dans l'etat $s$.
+- Ces algorithmes travaillent directement sur des tableaux (pas de reseaux de neurones).",,,,,,,,26850d5eb05b85e9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,b1e2f002,markdown,fr,bdf677c9de91e174,## 1. Installation et imports,,,,,,,,bdf677c9de91e174,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,c1a3e003,code,fr,0358fc3493013052,"import gymnasium as gym
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import colors
+
+print(f""gymnasium={gym.__version__}, numpy={np.__version__}"")",,,,,,,,0358fc3493013052,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,d2b4e004,markdown,fr,0f2f33d7e3a5214f,"Nous utiliserons deux environnements a espace d'etat discret :
+
+- **FrozenLake-v1** : Grille 4x4 ou l'agent doit traverser un lac gele en evitant les trous. Espace d'etat : 16 cases, espace d'action : 4 directions.
+- **CliffWalking-v1** : Grille ou l'agent doit atteindre la sortie en longeant une falaise. Espace d'etat : 48 cases, espace d'action : 4 directions.
+
+Ces environnements sont ideals pour les methodes tabulaires car leur espace d'etat est assez petit pour stocker une table Q complete.",,,,,,,,0f2f33d7e3a5214f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,e3c5f005,markdown,fr,3b58953e5c19b968,"## 2. Processus de Decision Markovien (MDP)
+
+Un MDP formalise l'interaction agent-environnement. La propriete de Markov stipule que le futur ne depend que de l'etat present, pas de l'historique.
+
+Decomposons le FrozenLake pour comprendre la structure du MDP.
+
+
+> *Ancres savantes -- Bellman, R. (1957), Dynamic Programming, Princeton University Press (equation de Bellman, iteration de valeur et de politique resolvent le MDP en point fixe) ; Watkins, C.J.C.H. (1989), Learning from Delayed Rewards, These de doctorat, Universite de Cambridge (Q-Learning tabulaire, methode off-policy model-free qui converge vers Q* sans connaitre le modele de transition) ; Sutton, R.S. & Barto, A.G. (2018), Reinforcement Learning: An Introduction (2nd ed.), MIT Press (cadre formel du MDP $(S, A, P, R, \gamma)$, value/policy iteration, compromis exploration/exploitation).*",,,,,,,,3b58953e5c19b968,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,f4d6e006,code,fr,a41276b422f003b4,"# Creer l'environnement FrozenLake (sans glissade pour rendre les transitions deterministes)
+env = gym.make(""FrozenLake-v1"", is_slippery=False)
+
+print(f""Espace d'etats  : {env.observation_space}"")
+print(f""Espace d'actions : {env.action_space}"")
+print(f""Nombre d'etats   : {env.observation_space.n}"")
+print(f""Nombre d'actions : {env.action_space.n}"")
+print(f""\nActions : 0=Gauche, 1=Bas, 2=Droite, 3=Haut"")",,,,,,,,a41276b422f003b4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,g5e7e007,markdown,fr,7c970cf65b124756,"L'espace d'etat comporte 16 cases (grille 4x4) et l'espace d'action 4 directions. Chaque case est identifiee par un entier de 0 a 15.
+
+Pour les methodes tabulaires, nous avons besoin de connaitre les probabilites de transition $P(s'|s, a)$. Gymnasium les expose via `env.unwrapped.P` (il faut acceder a l'environnement natif sous-jacent aux wrappers).",,,,,,,,7c970cf65b124756,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,h6f8e008,code,fr,ca338359a365ea7e,"# Explorer les transitions du MDP
+# env.unwrapped.P[state][action] = [(probabilite, etat_suivant, recompense, terminal), ...]
+print(""Exemple de transition depuis l'etat 0, action 'Droite' (2) :"")
+print(env.unwrapped.P[0][2])
+
+print(""\nExemple de transition depuis l'etat 1, action 'Bas' (1) :"")
+print(env.unwrapped.P[1][1])
+
+print(""\nGrille du FrozenLake (S=Start, F=Glace, H=Trou, G=But) :"")
+print(""S F F F"")
+print(""F H F H"")
+print(""F F F H"")
+print(""H F F G"")",,,,,,,,ca338359a365ea7e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,i7a9f009,markdown,fr,ff6a30b89a159c36,"Chaque transition est un tuple `(probabilite, etat_suivant, recompense, est_terminal)`. En mode non-glissant (`is_slippery=False`), chaque action a une probabilite de 1.0 de reussir.
+
+En mode glissant (par defaut), l'action peut echouer et mener dans une direction adjacente, rendant le probleme stochastique.",,,,,,,,ff6a30b89a159c36,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,j8b0f010,markdown,fr,8de990c8b67e63bc,"## 3. Iteration de Valeur (Value Iteration)
+
+L'Iteration de Valeur resout le MDP en appliquant iterativement l'equation de Bellman :
+
+$$V(s) = \max_a \sum_{s'} P(s'|s,a) \left[ R(s,a,s') + \gamma V(s') \right]$$
+
+L'algorithme met a jour $V(s)$ pour chaque etat jusqu'a convergence. La politique optimale est ensuite obtenue en choisissant l'action qui maximise $V$ dans chaque etat.",,,,,,,,8de990c8b67e63bc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,k9c1f011,code,fr,5a2d3c0d03374365,"def value_iteration(env, gamma=0.99, theta=1e-8, max_iterations=1000):
+    """"""
+    Iteration de Valeur pour resoudre un MDP.
+    
+    Parametres :
+        env : environnement Gymnasium avec attribut P
+        gamma : facteur d'actualisation (0 < gamma < 1)
+        theta : seuil de convergence
+        max_iterations : nombre maximal d'iterations
+    
+    Retourne :
+        V : fonction de valeur optimale
+        policy : politique optimale (greedy par rapport a V)
+        deltas : historique des deltas max pour suivi de convergence
+    """"""
+    nS = env.observation_space.n
+    nA = env.action_space.n
+    V = np.zeros(nS)
+    deltas = []
+    P = env.unwrapped.P
+    
+    for i in range(max_iterations):
+        delta = 0
+        for s in range(nS):
+            v = V[s]
+            q_values = np.zeros(nA)
+            for a in range(nA):
+                for prob, next_s, reward, done in P[s][a]:
+                    q_values[a] += prob * (reward + gamma * V[next_s] * (1 - done))
+            V[s] = np.max(q_values)
+            delta = max(delta, abs(v - V[s]))
+        
+        deltas.append(delta)
+        if delta < theta:
+            print(f""Convergence a l'iteration {i+1} (delta={delta:.2e})"")
+            break
+    
+    # Extraire la politique greedy
+    policy = np.zeros(nS, dtype=int)
+    for s in range(nS):
+        q_values = np.zeros(nA)
+        for a in range(nA):
+            for prob, next_s, reward, done in P[s][a]:
+                q_values[a] += prob * (reward + gamma * V[next_s] * (1 - done))
+        policy[s] = np.argmax(q_values)
+    
+    return V, policy, deltas
+print(""Fonction value_iteration definie"")",,,,,,,,5a2d3c0d03374365,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,l0d2f012,code,fr,0a409ee8f005dbbe,"# Resoudre FrozenLake par Iteration de Valeur
+V_vi, policy_vi, deltas_vi = value_iteration(env, gamma=0.99)
+
+print(""\nFonction de valeur V*(s) :"")
+print(V_vi.reshape(4, 4).round(3))
+print(f""\nPolitique optimale (0=G, 1=B, 2=D, 3=H) :"")
+print(policy_vi.reshape(4, 4))",,,,,,,,0a409ee8f005dbbe,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,m1e3f013,markdown,fr,1a607b65154b90ab,"La fonction de valeur $V^*$ attribue des valeurs croissantes aux etats proches du but (case 15). Les etats terminaux (trous) ont une valeur de 0.
+
+La politique greedy correspondante indique la direction optimale a suivre depuis chaque case pour atteindre le but.",,,,,,,,1a607b65154b90ab,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,n2f4f014,code,fr,41b2b288f81b5855,"def visualize_policy(env, policy, title=""Politique""):
+    """"""Affiche la politique sur la grille du FrozenLake.""""""
+    if hasattr(env, 'unwrapped'):
+        desc = env.unwrapped.desc.astype(str)
+    else:
+        desc = np.array([['S','F','F','F'],['F','H','F','H'],
+                         ['F','F','F','H'],['H','F','F','G']])
+    
+    arrows = {0: '<', 1: 'v', 2: '>', 3: '^'}
+    n = int(np.sqrt(len(policy)))
+    
+    fig, ax = plt.subplots(1, 1, figsize=(6, 6))
+    
+    # Couleurs de fond selon le type de case
+    color_map = {'S': '#90EE90', 'F': '#E0F0FF', 'H': '#FFB0B0', 'G': '#FFD700'}
+    for i in range(n):
+        for j in range(n):
+            s = i * n + j
+            cell = desc[i][j]
+            ax.add_patch(plt.Rectangle((j, n-1-i), 1, 1, 
+                         facecolor=color_map.get(cell, 'white'), edgecolor='black'))
+            if cell not in ('H', 'G'):
+                ax.text(j + 0.5, n - 1 - i + 0.5, arrows[policy[s]], 
+                       ha='center', va='center', fontsize=20, fontweight='bold')
+            else:
+                ax.text(j + 0.5, n - 1 - i + 0.5, cell, 
+                       ha='center', va='center', fontsize=16)
+    
+    ax.set_xlim(0, n)
+    ax.set_ylim(0, n)
+    ax.set_title(title)
+    ax.set_aspect('equal')
+    ax.axis('off')
+    plt.tight_layout()
+    plt.show()
+
+visualize_policy(env, policy_vi, ""Politique optimale - Value Iteration"")",,,,,,,,41b2b288f81b5855,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,o3g5f015,code,fr,757bd11181095303,"# Courbe de convergence
+plt.figure(figsize=(8, 4))
+plt.semilogy(deltas_vi, linewidth=2)
+plt.xlabel(""Iteration"")
+plt.ylabel(""Delta max (echelle log)"")
+plt.title(""Convergence de l'Iteration de Valeur"")
+plt.grid(True, alpha=0.3)
+plt.tight_layout()
+plt.show()",,,,,,,,757bd11181095303,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,p4h6f016,markdown,fr,1ef70e6403fa827f,"La courbe de convergence montre une diminution exponentielle du delta maximum. En quelques iterations, les valeurs se stabilisent et l'algorithme converge vers l'unique point fixe de l'equation de Bellman.",,,,,,,,1ef70e6403fa827f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,q5i7f017,markdown,fr,11125654efa78d0e,"## 4. Iteration de Politique (Policy Iteration)
+
+L'Iteration de Politique alterne entre deux etapes :
+
+1. **Evaluation de politique** : Calculer $V^\pi$ pour la politique courante
+2. **Amelioration de politique** : Mettre a jour $\pi$ en choisissant l'action greedy par rapport a $V^\pi$
+
+Contrairement a Value Iteration qui met a jour les valeurs de maniere asynchrone, Policy Iteration resout exactement le systeme lineaire a chaque etape.",,,,,,,,11125654efa78d0e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,r6j8f018,code,fr,6592fcd80afd7fe7,"def policy_iteration(env, gamma=0.99, theta=1e-8, max_iterations=100):
+    """"""
+    Iteration de Politique pour resoudre un MDP.
+    
+    Parametres :
+        env : environnement Gymnasium avec attribut P
+        gamma : facteur d'actualisation
+        theta : seuil de convergence pour l'evaluation
+        max_iterations : nombre maximal d'iterations externes
+    
+    Retourne :
+        V : fonction de valeur optimale
+        policy : politique optimale
+        policy_changes : nombre de changements par iteration
+    """"""
+    nS = env.observation_space.n
+    nA = env.action_space.n
+    policy = np.zeros(nS, dtype=int)
+    policy_changes = []
+    P = env.unwrapped.P
+    
+    for iteration in range(max_iterations):
+        # Etape 1 : Evaluation de la politique
+        V = np.zeros(nS)
+        for _ in range(1000):
+            delta = 0
+            for s in range(nS):
+                v = V[s]
+                a = policy[s]
+                V[s] = sum(prob * (reward + gamma * V[next_s] * (1 - done))
+                           for prob, next_s, reward, done in P[s][a])
+                delta = max(delta, abs(v - V[s]))
+            if delta < theta:
+                break
+        
+        # Etape 2 : Amelioration de la politique
+        policy_stable = True
+        changes = 0
+        for s in range(nS):
+            old_action = policy[s]
+            q_values = np.zeros(nA)
+            for a in range(nA):
+                for prob, next_s, reward, done in P[s][a]:
+                    q_values[a] += prob * (reward + gamma * V[next_s] * (1 - done))
+            policy[s] = np.argmax(q_values)
+            if old_action != policy[s]:
+                policy_stable = True
+                changes += 1
+        
+        policy_changes.append(changes)
+        
+        if changes == 0:
+            print(f""Politique stable atteinte a l'iteration {iteration+1}"")
+            break
+    
+    return V, policy, policy_changes
+
+V_pi, policy_pi, changes_pi = policy_iteration(env, gamma=0.99)
+print(f""\nV(pi) converge vers V* ? {np.allclose(V_vi, V_pi, atol=1e-6)}"")
+print(f""Politiques identiques ? {np.array_equal(policy_vi, policy_pi)}"")",,,,,,,,6592fcd80afd7fe7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,s7k9f019,markdown,fr,64ecda7252347a62,"Policy Iteration converge en tres peu d'iterations (souvent 2-3) sur FrozenLake deterministe. Les deux methodes aboutissent a la meme politique optimale, comme garanti par la theorie.",,,,,,,,64ecda7252347a62,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,t8l0f020,markdown,fr,39f31f7e78d76203,"## 5. Q-Learning Tabulaire
+
+Les methodes precedentes supposent la connaissance complete du modele de transition $P$. Le **Q-Learning** est une methode **model-free** : elle apprend uniquement par interaction avec l'environnement.
+
+La regle de mise a jour est :
+
+$$Q(s, a) \leftarrow Q(s, a) + \alpha \left[ r + \gamma \max_{a'} Q(s', a') - Q(s, a) \right]$$
+
+ou $\alpha$ est le taux d'apprentissage.
+
+**Strategie d'exploration** : Nous utilisons $\varepsilon$-greedy, qui choisit une action aleatoire avec probabilite $\varepsilon$ et l'action greedy sinon.",,,,,,,,39f31f7e78d76203,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,u9m1f021,code,fr,caedc9b8ed57e295,"def epsilon_greedy(Q, state, epsilon, n_actions):
+    """"""Choisit une action selon la strategie epsilon-greedy.""""""
+    if np.random.random() < epsilon:
+        return np.random.randint(n_actions)
+    return np.argmax(Q[state])
+
+
+def q_learning(env, num_episodes=10000, alpha=0.1, gamma=0.99, 
+               epsilon_start=1.0, epsilon_end=0.01, epsilon_decay=0.9995):
+    """"""
+    Q-Learning tabulaire.
+    
+    Parametres :
+        env : environnement Gymnasium
+        num_episodes : nombre d'episodes d'entrainement
+        alpha : taux d'apprentissage
+        gamma : facteur d'actualisation
+        epsilon_start, epsilon_end, epsilon_decay : parametres de decay d'epsilon
+    
+    Retourne :
+        Q : table Q apprise
+        rewards : recompenses par episode
+    """"""
+    nS = env.observation_space.n
+    nA = env.action_space.n
+    Q = np.zeros((nS, nA))
+    rewards = []
+    epsilon = epsilon_start
+    
+    for ep in range(num_episodes):
+        state, _ = env.reset()
+        total_reward = 0
+        done = False
+        
+        while not done:
+            action = epsilon_greedy(Q, state, epsilon, nA)
+            next_state, reward, terminated, truncated, _ = env.step(action)
+            done = terminated or truncated
+            
+            # Mise a jour Q-Learning
+            best_next = np.max(Q[next_state])
+            td_target = reward + gamma * best_next * (1 - terminated)
+            Q[state, action] += alpha * (td_target - Q[state, action])
+            
+            state = next_state
+            total_reward += reward
+        
+        epsilon = max(epsilon_end, epsilon * epsilon_decay)
+        rewards.append(total_reward)
+    
+    return Q, rewards
+
+
+Q_ql, rewards_ql = q_learning(env, num_episodes=5000)
+policy_ql = np.argmax(Q_ql, axis=1)
+
+print(f""Recompense moyenne (1000 derniers episodes) : {np.mean(rewards_ql[-1000:]):.3f}"")
+print(f""Politique Q-Learning :\n{policy_ql.reshape(4,4)}"")
+print(f""\nCorrespond a la politique optimale ? {np.array_equal(policy_vi, policy_ql)}"")",,,,,,,,caedc9b8ed57e295,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,v0n2f022,markdown,fr,825eedfa30dc0afd,"Le Q-Learning converge vers la politique optimale meme sans connaitre le modele de transition. L'exploration decroissante ($\varepsilon$ passe de 1.0 a 0.01) permet de visiter suffisamment d'etats au debut, puis d'exploiter la politique apprise.",,,,,,,,825eedfa30dc0afd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,w1o3f023,code,fr,3aa54bd46103cc05,"# Courbe d'apprentissage (moyenne mobile)
+window = 500
+moving_avg = np.convolve(rewards_ql, np.ones(window)/window, mode='valid')
+
+plt.figure(figsize=(10, 4))
+plt.plot(moving_avg, linewidth=2)
+plt.xlabel(""Episode"")
+plt.ylabel(f""Recompense moyenne (fenetre={window})"")
+plt.title(""Convergence du Q-Learning sur FrozenLake"")
+plt.grid(True, alpha=0.3)
+plt.tight_layout()
+plt.show()",,,,,,,,3aa54bd46103cc05,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,x2p4f024,markdown,fr,5c579b9b1ea9cd45,La courbe montre la transition entre exploration (recompenses faibles et irregulieres) et exploitation (recompense converge vers 1.0). Le taux de reussite atteint 100% une fois l'exploration suffisamment reduite.,,,,,,,,5c579b9b1ea9cd45,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,y3q5f025,markdown,fr,f49677730fcf95c4,"## 6. Application : CliffWalking
+
+L'environnement CliffWalking illustre un probleme classique en RL : le compromis exploration/exploitation. L'agent doit longer une falaise pour atteindre la sortie :
+
+- Le chemin optimal longe la falaise (recompenses negatives mais trajectoire courte)
+- Le chemin sur longe les bords (plus sur mais plus long)
+
+Q-Learning etant un algorithme off-policy, il devrait decouvrir le chemin optimal.",,,,,,,,f49677730fcf95c4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,z4r6f026,code,fr,a93147307f636545,"# Environnement CliffWalking
+env_cliff = gym.make(""CliffWalking-v1"")
+print(f""Espace d'etats   : {env_cliff.observation_space.n} cases (grille 4x12)"")
+print(f""Espace d'actions : {env_cliff.action_space.n} directions"")
+print(f""\nDisposition : le joueur commence en bas a gauche (3,0),"")
+print(f""le but est en bas a droite (3,11). La falaise est sur la ligne du bas (3,1 a 3,10)."")",,,,,,,,a93147307f636545,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,a5s7f027,code,fr,d8abd7d51314c4c6,"# Entrainer Q-Learning sur CliffWalking
+Q_cliff, rewards_cliff = q_learning(
+    env_cliff, 
+    num_episodes=10000, 
+    alpha=0.1, 
+    gamma=0.99,
+    epsilon_start=1.0, 
+    epsilon_end=0.01, 
+    epsilon_decay=0.999
+)
+
+# Evaluer la politique apprise
+def evaluate_policy_greedy(env, Q, num_episodes=1000):
+    """"""Evalue une politique greedy derivee de la table Q.""""""
+    total_rewards = []
+    for _ in range(num_episodes):
+        state, _ = env.reset()
+        episode_reward = 0
+        done = False
+        while not done:
+            action = np.argmax(Q[state])
+            state, reward, terminated, truncated, _ = env.step(action)
+            done = terminated or truncated
+            episode_reward += reward
+        total_rewards.append(episode_reward)
+    return np.mean(total_rewards), np.std(total_rewards)
+
+mean_r, std_r = evaluate_policy_greedy(env_cliff, Q_cliff)
+print(f""Recompense moyenne (policy greedy) : {mean_r:.1f} +/- {std_r:.1f}"")
+print(f""(Le chemin optimal a une recompense de -13)"")",,,,,,,,d8abd7d51314c4c6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,b6t8f028,markdown,fr,c0d8e5460ec811f6,"Le Q-Learning decouvre le chemin optimal le long de la falaise (recompense proche de -13). C'est un resultat caracteristique de Q-Learning : en tant qu'algorithme off-policy, il apprend la politique optimale meme si l'exploration utilise des actions sous-optimales.",,,,,,,,c0d8e5460ec811f6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,c7u9f029,code,fr,fee2957ceadafe1a,"# Visualiser la trajectoire apprise sur CliffWalking
+def show_cliff_trajectory(env, Q):
+    """"""Affiche une trajectoire greedy sur la grille CliffWalking.""""""
+    state, _ = env.reset()
+    path = [state]
+    done = False
+    while not done:
+        action = np.argmax(Q[state])
+        state, _, terminated, truncated, _ = env.step(action)
+        done = terminated or truncated
+        path.append(state)
+    
+    grid = np.full((4, 12), ' ')
+    # Falaise
+    for j in range(1, 11):
+        grid[3, j] = 'C'
+    grid[3, 0] = 'S'
+    grid[3, 11] = 'G'
+    
+    # Trajectoire
+    for s in path:
+        r, c = divmod(s, 12)
+        if grid[r, c] in (' ', ):
+            grid[r, c] = '*'
+    
+    print(""Trajectoire apprise (* = chemin, C = falaise, S = depart, G = but) :"")
+    for row in grid:
+        print(' '.join(row))
+
+show_cliff_trajectory(env_cliff, Q_cliff)",,,,,,,,fee2957ceadafe1a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,d8v0f030,markdown,fr,62fd96c8025f3401,"## 7. Comparaison des methodes
+
+Le tableau ci-dessous resume les caracteristiques des trois algorithmes etudies.",,,,,,,,62fd96c8025f3401,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,e9w1f031,code,fr,301bbb1f93cd3410,"import pandas as pd
+
+comparison = pd.DataFrame({
+    'Algorithme': ['Value Iteration', 'Policy Iteration', 'Q-Learning'],
+    'Type': ['Model-based', 'Model-based', 'Model-free'],
+    'Connaisance P': ['Oui', 'Oui', 'Non'],
+    'Convergence': ['Garanite (gamma<1)', 'Garanite (gamma<1)', 'Garanite (conditions)'],
+    'Complexite/ep': ['O(nS*nA)', 'O(nS^3) + O(nS*nA)', 'O(1) par pas'],
+    'Adapte a': ['Petits MDPs', 'Petits MDPs', 'Grands espaces discrets'],
+})
+
+print(comparison.to_string(index=False))",,,,,,,,301bbb1f93cd3410,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,f0x2f032,markdown,fr,c04d3b985844d464,"**Points cles de la comparaison :**
+- Les methodes model-based convergent en moins d'iterations mais necessitent la connaissance de $P$
+- Le Q-Learning apprend uniquement par interaction, ce qui le rend applicable aux situations ou le modele est inconnu
+- Les trois methodes sont limitees aux espaces d'etat discrets de petite taille (tabulaires)
+- Pour des espaces continus ou de grande dimension, on utilise des approximations par reseaux de neurones (DQN, PPO...) vus dans les notebooks suivants",,,,,,,,c04d3b985844d464,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,g1y3f033,markdown,fr,f0e5c9c6409fa123,"## 8. Exercices
+
+### Exercice 1 : FrozenLake stochastique
+
+Relancez le Q-Learning sur FrozenLake avec `is_slippery=True`. Observez comment la stochasticite affecte la convergence et le taux de reussite final.
+
+### Exercice 2 : Impact du taux d'apprentissage
+
+Testez differentes valeurs de `alpha` (0.01, 0.1, 0.5, 1.0) et observez l'effet sur la vitesse de convergence. Quel compromis observez-vous ?
+
+### Exercice 3 : Decroissance d'epsilon
+
+Comparez les strategies de decroissance d'epsilon suivantes :
+- Lineaire : `epsilon = max(0.01, 1.0 - episode / total)`
+- Exponentielle (par defaut) : `epsilon *= decay`
+- Constante : `epsilon = 0.1`
+
+Laquelle donne les meilleurs resultats sur CliffWalking ?
+
+### Exercice 4 : Comparaison systematique des hyperparametres
+
+Realisez un balayage (grid search) des hyperparametres du Q-Learning sur FrozenLake en variant simultanement `alpha` et `gamma`. L'objectif est d'identifier la combinaison qui maximise le taux de reussite.
+
+**Objectif** : Produire une heatmap (avec `plt.imshow` ou `sns.heatmap`) montrant le taux de reussite moyen pour chaque couple (alpha, gamma).
+
+**Indices** :
+- Testez `alpha in [0.01, 0.05, 0.1, 0.5]` et `gamma in [0.9, 0.95, 0.99, 1.0]`
+- Pour chaque couple, lancez `q_learning(env, num_episodes=5000, alpha=..., gamma=...)` et calculez `np.mean(rewards[-1000:])`
+- Stockez les resultats dans un tableau 2D numpy et affichez-le avec `plt.imshow(results, ...)`
+- Ajoutez les labels des axes avec `plt.xticks` et `plt.yticks`",,,,,,,,f0e5c9c6409fa123,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,h2z4f034,code,fr,06dd919d992739d6,"# Exercice 1 : Espace de travail
+env_slippery = gym.make(""FrozenLake-v1"", is_slippery=True)
+# Q_slip, rewards_slip = q_learning(env_slippery, num_episodes=20000)
+# print(f""Taux de reussite : {np.mean(rewards_slip[-1000:]):.3f}"")
+print(f""Exercice 1 : env FrozenLake slippery cree — {env_slippery}"")",,,,,,,,06dd919d992739d6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,i3a5f035,code,fr,221305a6482b4257,"# Exercice 2 : Impact du taux d'apprentissage
+# TODO etudiant : Testez alpha in [0.01, 0.1, 0.5, 1.0] et observez la convergence
+# Indice : appelez q_learning(env, num_episodes=5000, alpha=alpha) pour chaque valeur
+alpha_results = {}  # TODO etudiant : remplir avec {alpha: mean_reward}
+print(""Exercice a completer : impact du taux d'apprentissage"")",,,,,,,,221305a6482b4257,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,j4b6f036,code,fr,a8519115f086ed08,"# Exercice 3 : Strategies de decroissance d'epsilon
+# TODO etudiant : Comparez lineaire, exponentielle et constante
+# Indice : modifiez la boucle dans q_learning pour chaque strategie
+decay_results = {}  # TODO etudiant : remplir avec {strategy: mean_reward}
+print(""Exercice a completer : strategies de decroissance d'epsilon"")",,,,,,,,a8519115f086ed08,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,448672c7,code,fr,b8b072dac045a0c9,"# Exercice 4 : Grid search alpha x gamma
+# TODO etudiant : balayez les hyperparametres et affichez une heatmap des resultats
+
+# Etape 1: Definissez les grilles de valeurs
+# Indice: alphas = [0.01, 0.05, 0.1, 0.5]
+# Indice: gammas = [0.9, 0.95, 0.99, 1.0]
+alphas = []  # TODO etudiant
+gammas = []  # TODO etudiant
+
+# Etape 2: Lancez q_learning pour chaque couple et stockez la recompense moyenne
+# Indice: results[i, j] = np.mean(q_learning(env, num_episodes=5000, alpha=alphas[i], gamma=gammas[j])[1][-1000:])
+results = None  # TODO etudiant : tableau 2D numpy (len(alphas) x len(gammas))
+
+# Etape 3: Affichez la heatmap
+# Indice: plt.imshow(results, cmap='YlGn', aspect='auto')
+# plt.colorbar(label='Taux de reussite moyen')
+# plt.xticks(range(len(gammas)), gammas)
+# plt.yticks(range(len(alphas)), alphas)
+# plt.xlabel('gamma')
+# plt.ylabel('alpha')
+# plt.title('Impact de alpha et gamma sur le Q-Learning')
+# plt.show()
+
+print(""Exercice 4 a completer : grid search des hyperparametres du Q-Learning"")",,,,,,,,b8b072dac045a0c9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_5_mdp_dp_qlearning.ipynb,k5c7f037,markdown,fr,17bb4d8c55d2a74e,"## 9. Conclusion
+
+| Concept | Ce que nous avons vu |
+|---------|---------------------|
+| **MDP** | Formalisation $(S, A, P, R, \gamma)$, acces aux transitions via `env.unwrapped.P` |
+| **Value Iteration** | Application iterative de l'equation de Bellman, convergence exponentielle |
+| **Policy Iteration** | Alternance evaluation/amelioration, convergence en peu d'iterations |
+| **Q-Learning** | Apprentissage model-free, update TD, exploration $\varepsilon$-greedy |
+| **FrozenLake** | Grille discrete, transitions deterministes vs stochastiques |
+| **CliffWalking** | Compromis risque/recompense, comportement off-policy du Q-Learning |
+
+**Prochaines etapes** : Le notebook [RL-6](rl_6_dqn_policy_gradient.ipynb) introduit les methodes avec approximation par reseaux de neurones (DQN, Policy Gradient) pour traiter des espaces d'etat continus.
+
+**Pour aller plus loin** :
+- Sutton & Barto, Chapters 4-5 (Dynamic Programming, Monte Carlo Methods)
+- [Gymnasium FrozenLake documentation](https://gymnasium.farama.org/environments/toy_text/frozen_lake/)
+- [Gymnasium CliffWalking documentation](https://gymnasium.farama.org/environments/toy_text/cliff_walking/)
+
+
+### References academiques
+
+- Bellman, R. (1957). Dynamic Programming. Princeton University Press.
+- Watkins, C.J.C.H. (1989). Learning from Delayed Rewards. These de doctorat, Universite de Cambridge.
+- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press.
+
+",,,,,,,,17bb4d8c55d2a74e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,a0r1e001,markdown,fr,3327e0264fad6cfd,"# RL-6 : Deep Q-Network (DQN) et Policy Gradient
+
+**Serie** : Reinforcement Learning | **Notebook** : 6/13 | **Duree estimee** : 50-55 min
+
+Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-3 HER](rl_3_experience_replay_dqn.ipynb) | [RL-5 Tabulaire](rl_5_mdp_dp_qlearning.ipynb) | **RL-6** | [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb)
+
+---
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous serez capable de :
+- Implementer un DQN complet depuis zero avec replay buffer et target network
+- Comprendre les defis de l'apprentissage hors-ligne (stabilite, correlation)
+- Implementer REINFORCE, l'algorithme de base du Policy Gradient
+- Comparer les approches value-based et policy-based
+
+## Prerequis
+
+- [RL-5 MDP/Q-Learning tabulaire](rl_5_mdp_dp_qlearning.ipynb) (concepts Q-value, TD learning)
+- Bases de PyTorch (tenseurs, autograd, Module)
+- [RL-1 Introduction](rl_1_intro_cartpole.ipynb) (environnement CartPole)
+
+---
+
+**Pourquoi des reseaux de neurones ?**
+- Le Q-Learning tabulaire stocke $Q(s,a)$ pour chaque paire état-action. Impossible avec des espaces continus.
+- Un reseau de neurones approche $Q(s,a; \theta)$ avec des parametres $\theta$, generalisant aux etats jamais vus.
+- Le DQN (DeepMind, 2013/2015) a ete le premier algorithme a demontrer l'apprentissage RL a l'echelle avec des reseaux profonds.",,,,,,,,3327e0264fad6cfd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,b1s2e002,markdown,fr,bdf677c9de91e174,## 1. Installation et imports,,,,,,,,bdf677c9de91e174,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,c2t3e003,code,fr,b34ca593aaac442a,"import gymnasium as gym
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from collections import deque
+import random
+import matplotlib.pyplot as plt
+
+print(f""gymnasium={gym.__version__}, numpy={np.__version__}"")
+print(f""torch={torch.__version__}"")",,,,,,,,b34ca593aaac442a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,d3u4e004,markdown,fr,8c817c720ec379c8,"Nous travaillons sur CartPole-v1, un environnement avec un espace d'observation continu (4 dimensions) et un espace d'action discret (2 actions). C'est un environnement ideal pour DQN car il est assez simple pour converger rapidement mais necessite deja une approximation par reseau de neurones.
+
+**CartPole-v1 en resume** : Un chariot avec un baton equilibre. Observation = [position, vitesse, angle, vitesse_angulaire]. Actions = [gauche, droite]. Recompense = +1 par pas, episode termine si le baton tombe ou le chariot sort de l'ecran.",,,,,,,,8c817c720ec379c8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,e4v5e005,markdown,fr,0d346744511a6002,"## 2. Architecture du DQN
+
+Le DQN introduit deux innovations cles par rapport au Q-Learning tabulaire :
+
+1. **Experience Replay** : Stockage des transitions dans un buffer et echantillonnage aleatoire pour casser les correlations temporelles
+2. **Target Network** : Un second reseau cible stabilise l'apprentissage en fournissant des cibles moins volatiles
+
+Le reseau de neurones prend en entree l'observation (4 valeurs) et produit en sortie les Q-valeurs pour chaque action (2 valeurs).
+
+
+> *Ancres savantes -- Mnih, V., Kavukcuoglu, K., Silver, D. et al. (2015), Human-level control through deep reinforcement learning, Nature 518:529-533, DOI 10.1038/nature14236 (DQN, combine approximation neuronale de Q avec experience replay et target network, premier RL humain-niveau sur Atari brut) ; Lin, L.-J. (1992), Self-Improving Reactive Agents Based on Reinforcement Learning, Planning and Teaching, Machine Learning 8:293-321 (experience replay, casse les correlations temporelles entre transitions) ; Williams, R.J. (1992), Simple Statistical Gradient-Following Algorithms for Connectionist Reinforcement Learning, Neural Computation 4(3):405-414 (REINFORCE, gradient de politique Monte Carlo) ; Sutton, R.S., McAllester, D.A., Singh, S.P. & Mansour, Y. (2000), Policy Gradient Methods for Reinforcement Learning with Function Approximation, NeurIPS 2000 (theoreme du gradient de politique sous-jacent au policy gradient).*",,,,,,,,0d346744511a6002,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,f5w6e006,code,fr,6c73b1d0831dbbf9,"class QNetwork(nn.Module):
+    """"""Reseau de neurones simple pour approximer Q(s, a).""""""
+    
+    def __init__(self, state_dim, action_dim, hidden_dim=128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, action_dim)
+        )
+    
+    def forward(self, x):
+        return self.net(x)
+
+
+class ReplayBuffer:
+    """"""Buffer circulaire pour stocker les transitions.""""""
+    
+    def __init__(self, capacity=10000):
+        self.buffer = deque(maxlen=capacity)
+    
+    def push(self, state, action, reward, next_state, done):
+        self.buffer.append((state, action, reward, next_state, done))
+    
+    def sample(self, batch_size):
+        batch = random.sample(self.buffer, batch_size)
+        states, actions, rewards, next_states, dones = zip(*batch)
+        return (
+            np.array(states, dtype=np.float32),
+            np.array(actions, dtype=np.int64),
+            np.array(rewards, dtype=np.float32),
+            np.array(next_states, dtype=np.float32),
+            np.array(dones, dtype=np.float32)
+        )
+    
+    def __len__(self):
+        return len(self.buffer)
+
+
+# Verifier les dimensions
+env = gym.make(""CartPole-v1"")
+state_dim = env.observation_space.shape[0]
+action_dim = env.action_space.n
+print(f""State dim : {state_dim}, Action dim : {action_dim}"")
+
+q_net = QNetwork(state_dim, action_dim)
+print(f""\nArchitecture du reseau :\n{q_net}"")
+print(f""Nombre de parametres : {sum(p.numel() for p in q_net.parameters())}"")",,,,,,,,6c73b1d0831dbbf9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,g6x7e007,markdown,fr,661179d83ee35b8a,"Le reseau a 3 couches lineaires avec ReLU, soit environ 17 000 parametres. Le Replay Buffer stocke jusqu'a 10 000 transitions et echantillonne des mini-batchs pour l'apprentissage.",,,,,,,,661179d83ee35b8a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,h7y8e008,markdown,fr,924bd5f092a01a1a,## 3. Implementation complete du DQN,,,,,,,,924bd5f092a01a1a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,i8z9e009,code,fr,d675cdc475864631,"class DQNAgent:
+    """"""Agent DQN avec experience replay et target network.""""""
+    
+    def __init__(self, state_dim, action_dim, lr=1e-3, gamma=0.99,
+                 epsilon_start=1.0, epsilon_end=0.01, epsilon_decay=0.995,
+                 buffer_capacity=10000, batch_size=64, target_update_freq=10):
+        self.action_dim = action_dim
+        self.gamma = gamma
+        self.epsilon = epsilon_start
+        self.epsilon_end = epsilon_end
+        self.epsilon_decay = epsilon_decay
+        self.batch_size = batch_size
+        self.target_update_freq = target_update_freq
+        
+        # Reseaux
+        self.q_net = QNetwork(state_dim, action_dim)
+        self.target_net = QNetwork(state_dim, action_dim)
+        self.target_net.load_state_dict(self.q_net.state_dict())
+        self.target_net.eval()
+        
+        self.optimizer = optim.Adam(self.q_net.parameters(), lr=lr)
+        self.buffer = ReplayBuffer(buffer_capacity)
+        self.step_count = 0
+    
+    def select_action(self, state):
+        """"""Selection epsilon-greedy.""""""
+        if random.random() < self.epsilon:
+            return random.randint(0, self.action_dim - 1)
+        with torch.no_grad():
+            state_t = torch.FloatTensor(state).unsqueeze(0)
+            q_values = self.q_net(state_t)
+            return q_values.argmax(dim=1).item()
+    
+    def store(self, state, action, reward, next_state, done):
+        """"""Stocke une transition dans le replay buffer.""""""
+        self.buffer.push(state, action, reward, next_state, done)
+    
+    def update(self):
+        """"""Effectue une etape de mise a jour du reseau.""""""
+        if len(self.buffer) < self.batch_size:
+            return 0.0
+        
+        states, actions, rewards, next_states, dones = self.buffer.sample(self.batch_size)
+        
+        states_t = torch.FloatTensor(states)
+        actions_t = torch.LongTensor(actions)
+        rewards_t = torch.FloatTensor(rewards)
+        next_states_t = torch.FloatTensor(next_states)
+        dones_t = torch.FloatTensor(dones)
+        
+        # Q(s, a) courant
+        q_values = self.q_net(states_t).gather(1, actions_t.unsqueeze(1)).squeeze(1)
+        
+        # Cible : r + gamma * max_a' Q_target(s', a')
+        with torch.no_grad():
+            next_q = self.target_net(next_states_t).max(dim=1)[0]
+            targets = rewards_t + self.gamma * next_q * (1 - dones_t)
+        
+        # Perte et retropropagation
+        loss = nn.MSELoss()(q_values, targets)
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+        
+        # Mise a jour du target network
+        self.step_count += 1
+        if self.step_count % self.target_update_freq == 0:
+            self.target_net.load_state_dict(self.q_net.state_dict())
+        
+        return loss.item()
+    
+    def decay_epsilon(self):
+        """"""Decroit epsilon apres chaque episode.""""""
+        self.epsilon = max(self.epsilon_end, self.epsilon * self.epsilon_decay)
+print(""Classe DQNAgent definie : experience replay + target network"")",,,,,,,,d675cdc475864631,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,j9a0e010,code,fr,8e2f2a43b1210653,"# Boucle d'entrainement DQN
+env = gym.make(""CartPole-v1"")
+agent = DQNAgent(
+    state_dim=env.observation_space.shape[0],
+    action_dim=env.action_space.n,
+    lr=1e-3,
+    gamma=0.99,
+    buffer_capacity=10000,
+    batch_size=64,
+    target_update_freq=10
+)
+
+num_episodes = 300
+dqn_rewards = []
+dqn_losses = []
+
+for ep in range(num_episodes):
+    state, _ = env.reset()
+    total_reward = 0
+    done = False
+    
+    while not done:
+        action = agent.select_action(state)
+        next_state, reward, terminated, truncated, _ = env.step(action)
+        done = terminated or truncated
+        agent.store(state, action, reward, next_state, float(terminated))
+        loss = agent.update()
+        if loss > 0:
+            dqn_losses.append(loss)
+        state = next_state
+        total_reward += reward
+    
+    agent.decay_epsilon()
+    dqn_rewards.append(total_reward)
+    
+    if (ep + 1) % 50 == 0:
+        avg = np.mean(dqn_rewards[-50:])
+        print(f""Episode {ep+1:3d} | Reward moyen (50 ep): {avg:.1f} | Epsilon: {agent.epsilon:.3f}"")
+
+print(f""\nRecompense moyenne finale (100 ep) : {np.mean(dqn_rewards[-100:]):.1f}"")",,,,,,,,8e2f2a43b1210653,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,k0b1e011,markdown,fr,10d77857fd562fcd,"Le DQN converge progressivement vers une politique performante. La recompense moyenne augmente au fil des episodes tandis qu'epsilon decroit, passant de l'exploration a l'exploitation.",,,,,,,,10d77857fd562fcd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,l1c2e012,code,fr,288ea7fc38c6f23f,"# Visualisation de l'apprentissage DQN
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))
+
+# Courbe de recompense
+window = 20
+moving_avg = np.convolve(dqn_rewards, np.ones(window)/window, mode='valid')
+ax1.plot(moving_avg, linewidth=2)
+ax1.axhline(y=195, color='r', linestyle='--', alpha=0.5, label='Seuil (195)')
+ax1.set_xlabel(""Episode"")
+ax1.set_ylabel(f""Reward moyen (fenetre={window})"")
+ax1.set_title(""Apprentissage DQN sur CartPole"")
+ax1.legend()
+ax1.grid(True, alpha=0.3)
+
+# Courbe de perte
+if dqn_losses:
+    loss_window = 50
+    loss_avg = np.convolve(dqn_losses, np.ones(loss_window)/loss_window, mode='valid')
+    ax2.plot(loss_avg, linewidth=2, color='orange')
+    ax2.set_xlabel(""Step de mise a jour"")
+    ax2.set_ylabel(""MSE Loss"")
+    ax2.set_title(""Evolution de la perte DQN"")
+    ax2.grid(True, alpha=0.3)
+
+plt.tight_layout()
+plt.show()",,,,,,,,288ea7fc38c6f23f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,m2d3e013,markdown,fr,cb1f6bc1b1fe9f2f,"La courbe de recompense montre la convergence du DQN. La perte MSE fluctue mais tend a se stabiliser, ce qui indique que le reseau apprend a estimer correctement les Q-valeurs.
+
+**Note sur la stabilite** : Sans experience replay et target network, l'apprentissage diverge souvent. Ces deux mecanismes sont essentiels pour le DQN.",,,,,,,,cb1f6bc1b1fe9f2f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,n3e4e014,markdown,fr,09f3964bb70302eb,"## 4. REINFORCE : Policy Gradient
+
+Contrairement au DQN qui apprend une fonction de valeur, REINFORCE apprend directement une politique $\pi_\theta(a|s)$.
+
+L'intuition : ajuster les parametres $\theta$ pour augmenter la probabilite des actions qui ont mene a des recompenses elevees.
+
+Le gradient de la politique est estime par :
+
+$$\nabla_\theta J(\theta) \approx \frac{1}{N} \sum_{i=1}^{N} \sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t | s_t) \cdot G_t$$
+
+ou $G_t = \sum_{k=t}^{T} \gamma^{k-t} r_k$ est le retour actualise.",,,,,,,,09f3964bb70302eb,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,o4f5e015,code,fr,9f606abbc4585d95,"class PolicyNetwork(nn.Module):
+    """"""Reseau de neurones pour la politique.""""""
+    
+    def __init__(self, state_dim, action_dim, hidden_dim=128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, action_dim),
+            nn.Softmax(dim=-1)
+        )
+    
+    def forward(self, x):
+        return self.net(x)
+
+
+class REINFORCEAgent:
+    """"""Agent REINFORCE avec baseline.""""""
+    
+    def __init__(self, state_dim, action_dim, lr=1e-3, gamma=0.99):
+        self.gamma = gamma
+        self.policy = PolicyNetwork(state_dim, action_dim)
+        self.optimizer = optim.Adam(self.policy.parameters(), lr=lr)
+    
+    def select_action(self, state):
+        """"""Echantillonne une action selon la politique.""""""
+        with torch.no_grad():
+            state_t = torch.FloatTensor(state).unsqueeze(0)
+            probs = self.policy(state_t)
+            dist = torch.distributions.Categorical(probs)
+            action = dist.sample()
+            return action.item()
+    
+    def compute_returns(self, rewards):
+        """"""Calcule les retours actualises G_t.""""""
+        returns = []
+        G = 0
+        for r in reversed(rewards):
+            G = r + self.gamma * G
+            returns.insert(0, G)
+        returns = torch.FloatTensor(returns)
+        return (returns - returns.mean()) / (returns.std() + 1e-8)
+    
+    def update(self, states, actions, rewards):
+        """"""Met a jour la politique par gradient.""""""
+        states_t = torch.FloatTensor(np.array(states))
+        actions_t = torch.LongTensor(actions)
+        returns = self.compute_returns(rewards)
+        
+        probs = self.policy(states_t)
+        dist = torch.distributions.Categorical(probs)
+        log_probs = dist.log_prob(actions_t)
+        
+        loss = -(log_probs * returns).sum()
+        
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+        
+        return loss.item()
+print(""Classe PolicyNetwork definie : reseau de neurones pour la politique"")",,,,,,,,9f606abbc4585d95,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,p5g6e016,markdown,fr,0a6595f4b7de69ab,"La normalisation des retours (`returns - mean / std`) sert de **baseline** : elle reduit la variance du gradient sans introduire de biais. Les actions dont le retour est au-dessus de la moyenne sont renforcees, celles en dessous sont penalisees.",,,,,,,,0a6595f4b7de69ab,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,q6h7e017,code,fr,9b0fd649e113134f,"# Entrainement REINFORCE
+env = gym.make(""CartPole-v1"")
+pg_agent = REINFORCEAgent(
+    state_dim=env.observation_space.shape[0],
+    action_dim=env.action_space.n,
+    lr=1e-3,
+    gamma=0.99
+)
+
+num_episodes = 400
+pg_rewards = []
+
+for ep in range(num_episodes):
+    state, _ = env.reset()
+    states, actions, rewards = [], [], []
+    done = False
+    
+    while not done:
+        action = pg_agent.select_action(state)
+        next_state, reward, terminated, truncated, _ = env.step(action)
+        done = terminated or truncated
+        states.append(state)
+        actions.append(action)
+        rewards.append(reward)
+        state = next_state
+    
+    loss = pg_agent.update(states, actions, rewards)
+    pg_rewards.append(sum(rewards))
+    
+    if (ep + 1) % 50 == 0:
+        avg = np.mean(pg_rewards[-50:])
+        print(f""Episode {ep+1:3d} | Reward moyen (50 ep): {avg:.1f}"")
+
+print(f""\nRecompense moyenne finale (100 ep) : {np.mean(pg_rewards[-100:]):.1f}"")",,,,,,,,9b0fd649e113134f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,r7i8e018,markdown,fr,2f7dbafa76a04aed,"REINFORCE montre generalement une convergence plus variable que le DQN. C'est un algorithme on-policy : les donnees utilisees pour la mise a jour doivent provenir de la politique courante, ce qui le rend moins efficace en termes d'utilisation des donnees.",,,,,,,,2f7dbafa76a04aed,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,s8j9e019,code,fr,f364a5493e32a3f5,"# Comparaison DQN vs REINFORCE
+fig, ax = plt.subplots(figsize=(10, 5))
+
+window = 20
+dqn_avg = np.convolve(dqn_rewards, np.ones(window)/window, mode='valid')
+pg_avg = np.convolve(pg_rewards, np.ones(window)/window, mode='valid')
+
+min_len = min(len(dqn_avg), len(pg_avg))
+ax.plot(dqn_avg[:min_len], linewidth=2, label='DQN')
+ax.plot(pg_avg[:min_len], linewidth=2, label='REINFORCE')
+ax.axhline(y=195, color='r', linestyle='--', alpha=0.5, label='Seuil (195)')
+ax.set_xlabel(""Episode"")
+ax.set_ylabel(f""Reward moyen (fenetre={window})"")
+ax.set_title(""DQN vs REINFORCE sur CartPole-v1"")
+ax.legend()
+ax.grid(True, alpha=0.3)
+plt.tight_layout()
+plt.show()",,,,,,,,f364a5493e32a3f5,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,t9k0e020,markdown,fr,c411ea74cd78e3f8,"La comparaison met en evidence les differences entre les deux approches :
+
+- **DQN** (value-based) : Convergence plus reguliere, meilleur usage des donnees grace au replay buffer. Off-policy.
+- **REINFORCE** (policy-based) : Convergence plus variable, haute variance des estimations de gradient. On-policy.
+
+Les algorithmes modernes comme PPO (vu en RL-1) combinent les avantages des deux approches.",,,,,,,,c411ea74cd78e3f8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,u0l1e021,markdown,fr,21e7f700807a3f2e,## 5. Analyse du comportement appris,,,,,,,,21e7f700807a3f2e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,v1m2e022,code,fr,e52c29101de9d956,"# Evaluer les politiques apprises
+def evaluate_agent(env, select_action_fn, num_episodes=100):
+    """"""Evalue un agent deterministe sur plusieurs episodes.""""""
+    rewards = []
+    for _ in range(num_episodes):
+        state, _ = env.reset()
+        total = 0
+        done = False
+        while not done:
+            action = select_action_fn(state)
+            state, reward, terminated, truncated, _ = env.step(action)
+            done = terminated or truncated
+            total += reward
+        rewards.append(total)
+    return np.mean(rewards), np.std(rewards)
+
+# Politique greedy du DQN
+def dqn_greedy(state):
+    with torch.no_grad():
+        return agent.q_net(torch.FloatTensor(state).unsqueeze(0)).argmax().item()
+
+# Politique du REINFORCE (mode)
+def pg_greedy(state):
+    with torch.no_grad():
+        probs = pg_agent.policy(torch.FloatTensor(state).unsqueeze(0))
+        return probs.argmax().item()
+
+eval_env = gym.make(""CartPole-v1"")
+dqn_mean, dqn_std = evaluate_agent(eval_env, dqn_greedy)
+pg_mean, pg_std = evaluate_agent(eval_env, pg_greedy)
+
+print(f""DQN       : {dqn_mean:.1f} +/- {dqn_std:.1f}"")
+print(f""REINFORCE : {pg_mean:.1f} +/- {pg_std:.1f}"")
+print(f""\nSeuil CartPole-v1 (solve) : 195"")",,,,,,,,e52c29101de9d956,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,w2n3e023,markdown,fr,453fe11e666a23e8,Les deux agents atteignent generalement le seuil de resolution (195) sur CartPole. Le DQN a tendance a produire des politiques plus stables grace a son replay buffer.,,,,,,,,453fe11e666a23e8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,x3o4e024,markdown,fr,a75c72065647b5cb,"## 6. Exercices
+
+### Exercice 1 : Double DQN
+
+Le DQN standard surestime les Q-valeurs car il utilise `argmax` sur le meme reseau pour la selection et l'evaluation. Implementez le Double DQN qui utilise le reseau principal pour la selection et le target network pour l'evaluation :
+
+```python
+# Au lieu de :
+next_q = self.target_net(next_states_t).max(dim=1)[0]
+
+# Faire :
+best_actions = self.q_net(next_states_t).argmax(dim=1)
+next_q = self.target_net(next_states_t).gather(1, best_actions.unsqueeze(1)).squeeze(1)
+```
+
+### Exercice 2 : Grid Search hyperparametres
+
+Testez les combinaisons suivantes et identifiez la meilleure :
+- `lr` : [1e-4, 1e-3, 1e-2]
+- `hidden_dim` : [64, 128, 256]
+- `buffer_capacity` : [5000, 10000, 50000]
+
+### Exercice 3 : REINFORCE avec baseline
+
+Ajoutez un reseau de valeur (critic) au REINFORCE pour estimer une baseline $V(s)$. Utilisez l'avantage $A_t = G_t - V(s_t)$ au lieu de $G_t$ pour reduire la variance.",,,,,,,,a75c72065647b5cb,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,y4p5e025,code,fr,c8160ab8171ed20c,"# Exercice 1 : Double DQN
+# TODO etudiant : Modifiez la methode update() de DQNAgent pour implementer le Double DQN
+# Indice : utilisez self.q_net pour selectionner l'action et self.target_net pour l'evaluation
+# Etape 1 : best_actions = self.q_net(next_states_t).argmax(dim=1)
+# Etape 2 : next_q = self.target_net(next_states_t).gather(1, best_actions.unsqueeze(1)).squeeze(1)
+ddqn_loss = None  # TODO etudiant : implementer et comparer avec DQN standard
+print(""Exercice a completer : Double DQN"")",,,,,,,,c8160ab8171ed20c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,z5q6e026,code,fr,6db51c736a2a27f5,"# Exercice 2 : Grid Search hyperparametres
+# TODO etudiant : Testez les combinaisons lr x hidden_dim x buffer_capacity
+# Indice : utilisez des boucles imbriquees et stockez les resultats dans une liste de dicts
+grid_results = []  # TODO etudiant : remplir avec les resultats
+print(""Exercice a completer : grid search hyperparametres"")",,,,,,,,6db51c736a2a27f5,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,a6r7e027,code,fr,b326128a3c93ce1b,"# Exercice 3 : REINFORCE avec baseline (critic)
+# TODO etudiant : Ajoutez un ValueNetwork pour estimer V(s), utilisez A_t = G_t - V(s_t)
+# Indice : creez une classe ValueNetwork(nn.Module) similaire a QNetwork mais output = 1
+advantage = None  # TODO etudiant : calculer l'avantage A_t
+print(""Exercice a completer : REINFORCE avec baseline"")",,,,,,,,b326128a3c93ce1b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6_dqn_policy_gradient.ipynb,b7s8e028,markdown,fr,5587248b7609349e,"## 7. Conclusion
+
+| Concept | DQN (Value-based) | REINFORCE (Policy-based) |
+|---------|-------------------|--------------------------|
+| **Apprend** | Fonction Q(s, a) | Politique directe |
+| **Type** | Off-policy | On-policy |
+| **Efficacite donnees** | Elevee (replay buffer) | Faible |
+| **Stabilite** | Bonne (target net) | Variable (haute variance) |
+| **Actions continues** | Non (natif) | Oui |
+| **Innovations cles** | Replay buffer, target net | Gradient de politique |
+
+**Points cles a retenir** :
+- Le DQN resout le probleme de stabilite par deux mecanismes : experience replay et target network
+- REINFORCE est conceptuellement simple mais souffre d'une haute variance
+- Les algorithmes modernes (PPO, SAC, TD3) combinent les avantages des deux paradigmes
+
+**Prochaine etape** : Le notebook [RL-7](rl_7_multi_agent_rl.ipynb) aborde l'apprentissage multi-agent ou plusieurs agents interagissent simultanement.
+
+**References** :
+- Mnih et al. (2015) - *Human-level control through deep reinforcement learning*, Nature
+- Williams (1992) - *Simple statistical gradient-following algorithms for connectionist RL*
+- Sutton & Barto, Chapters 9-13 (Approximation, Policy Gradient)
+
+
+### References academiques
+
+- Mnih, V., Kavukcuoglu, K., Silver, D. et al. (2015). Human-level control through deep reinforcement learning. Nature 518:529-533. DOI 10.1038/nature14236.
+- Lin, L.-J. (1992). Self-Improving Reactive Agents Based on Reinforcement Learning, Planning and Teaching. Machine Learning 8:293-321.
+- Williams, R.J. (1992). Simple Statistical Gradient-Following Algorithms for Connectionist Reinforcement Learning. Neural Computation 4(3):405-414.
+- Sutton, R.S., McAllester, D.A., Singh, S.P. & Mansour, Y. (2000). Policy Gradient Methods for Reinforcement Learning with Function Approximation. NeurIPS 2000.
+- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press.
+
+",,,,,,,,5587248b7609349e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,08a00678,markdown,fr,80c742b945b25dd5,"# RL-6b - Actor-Critic : unir valeur et politique
+
+**Serie** : Reinforcement Learning | **Notebook** : 6b/13 | **Duree estimee** : 45-50 min
+
+Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-3 HER](rl_3_experience_replay_dqn.ipynb) | [RL-4 Bandits](rl_4_multi_armed_bandits.ipynb) | [RL-5 Tabulaire](rl_5_mdp_dp_qlearning.ipynb) | [RL-6 DQN/PG](rl_6_dqn_policy_gradient.ipynb) | **RL-6b** | [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb)
+
+---
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous serez capable de :
+- Comprendre le paradigme Actor-Critic qui combine les approches value-based et policy-based
+- Implementer l'algorithme A2C (Advantage Actor-Critic) depuis zero en PyTorch
+- Comparer la reduction de variance apportee par le critic par rapport a REINFORCE
+- Explorer le role du bonus d'entropie dans l'exploration
+
+## Prerequis
+
+- [RL-5 MDP/Q-Learning tabulaire](rl_5_mdp_dp_qlearning.ipynb) (concepts Q-value, TD learning)
+- [RL-6 DQN et Policy Gradient](rl_6_dqn_policy_gradient.ipynb) (DQN, REINFORCE)
+- Bases de PyTorch (`nn.Module`, `autograd`, `torch.distributions`)
+
+---
+
+**Pourquoi Actor-Critic ?**
+Dans le notebook precedent (RL-5), nous avons vu deux paradigmes :
+- **DQN** (value-based) : apprend $Q(s,a)$, stable mais limite aux actions discretes
+- **REINFORCE** (policy-based) : apprend directement $\pi(a|s)$, flexible mais haute variance
+
+L'Actor-Critic **combine les deux** : un reseau *actor* apprend la politique, tandis qu'un reseau *critic* estime la valeur des etats pour reduire la variance des gradients. C'est le fondement d'algorithmes modernes comme PPO, SAC et TD3.",,,,,,,,80c742b945b25dd5,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,164bbd29,markdown,fr,c4164a5d928010c8,"## 1. Du REINFORCE a l'Actor-Critic
+
+### Le probleme de variance dans REINFORCE
+
+REINFORCE estime le gradient de la politique avec le retour Monte Carlo $G_t$ :
+
+$$\nabla_\theta J(\theta) \approx \frac{1}{N} \sum_{i=1}^{N} \sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t | s_t) \cdot G_t$$
+
+Le probleme : $G_t$ a une **variance tres elevee** car il cumule toutes les recompenses futures. Pour un episode de 200 pas, $G_t$ peut varier de 0 a 200, ce qui rend les mises a jour instables.
+
+### La solution : une baseline apprise
+
+L'idee est de remplacer $G_t$ par l'**avantage** $A(s_t, a_t)$ :
+
+$$A(s_t, a_t) = G_t - V(s_t)$$
+
+ou $V(s_t)$ est la **valeur attendue de l'etat** $s_t$, estimee par le *critic*. L'avantage mesure **a quel point l'action choisie est meilleure que la moyenne** pour cet etat.
+
+**Propriete fondamentale** : l'avantage reduit la variance sans introduire de biais. Si $V(s_t)$ est une bonne estimation, l'avantage sera proche de zero pour les actions mediocres et positif pour les bonnes actions.
+
+### Architecture Actor-Critic
+
+| Composant | Role | Sortie |
+|-----------|------|--------|
+| **Actor** | Politique $\pi(a|s)$ | Distribution de probabilite sur les actions |
+| **Critic** | Valeur $V(s)$ | Scalaire estimant le retour attendu |
+
+Les deux reseaux apprennent simultanement :
+- L'actor est mis a jour par **policy gradient** avec l'avantage comme signal
+- Le critic est mis a jour par **TD learning** pour mieux estimer $V(s)$
+
+> **Lien avec RL-6** : L'exercice 3 du notebook precedent demandait exactement d'ajouter un critic a REINFORCE. Ce notebook developpe cette idee en detail.
+
+
+> *Ancres savantes -- Williams, R.J. (1992), Simple Statistical Gradient-Following Algorithms for Connectionist Reinforcement Learning, Neural Computation 4(3):405-414 (REINFORCE, ligne de base dont Actor-Critic reduit la variance) ; Konda, V.R. & Tsitsiklis, J.N. (2003), On Actor-Critic Algorithms, SIAM Journal on Control and Optimization 42(4):1143-1166 (cadre actor-critic, le critic estime la ligne de base V(s) pour reduire la variance du gradient) ; Mnih, V., Badia, A.P., Mirza, M., Graves, A., Lillicrap, T., Harley, T., Silver, D. & Kavukcuoglu, K. (2016), Asynchronous Methods for Deep Reinforcement Learning, ICML 2016, arXiv:1602.01783 (A3C / sa variante synchrone A2C, acteur-critique on-policy dont ce notebook implemente le coeur) ; Sutton, R.S., McAllester, D.A., Singh, S.P. & Mansour, Y. (2000), Policy Gradient Methods for RL with Function Approximation, NeurIPS 2000 (theoreme du gradient de politique).*",,,,,,,,c4164a5d928010c8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,e01932b4,markdown,fr,5d8ae400134bdafe,## 2. Installation et imports,,,,,,,,5d8ae400134bdafe,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,df218ad7,code,fr,79605a8d4f922b56,"import gymnasium as gym
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributions import Categorical
+import matplotlib.pyplot as plt
+from collections import deque
+
+print(f""Imports OK : gymnasium {gym.__version__}, torch {torch.__version__}"")
+
+# Dimensions de l'environnement CartPole-v1
+env = gym.make(""CartPole-v1"")
+state_dim = env.observation_space.shape[0]
+action_dim = env.action_space.n
+print(f""State dim : {state_dim}, Action dim : {action_dim}"")
+env.close()",,,,,,,,79605a8d4f922b56,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,a8637cb8,markdown,fr,e66af79f3bb96209,"Nous travaillons sur CartPole-v1, le meme environnement que dans les notebooks precedents. L'espace d'observation est continu (4 dimensions) et l'espace d'action est discret (2 actions). Ce choix permet de comparer directement avec REINFORCE et DQN.",,,,,,,,e66af79f3bb96209,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,6faa6683,markdown,fr,f4fe48a5a2978d32,"## 3. Le Critic -- Reseau de valeur V(s)
+
+Le critic est un reseau de neurones qui estime $V(s)$, la valeur attendue d'un etat. Pour rappel :
+
+$$V(s) = \mathbb{E}\left[\sum_{t=0}^{\infty} \gamma^t r_t \mid s_0 = s\right]$$
+
+Contrairement au DQN qui estime $Q(s,a)$ pour chaque action, le critic produit un **unique scalaire** par etat. Cela le rend plus simple a entrainer car la cible est directe : le retour observe $G_t$.",,,,,,,,f4fe48a5a2978d32,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,eba6f78c,code,fr,c219c07efc7d60e0,"class CriticNetwork(nn.Module):
+    """"""Reseau de valeur V(s) : estime la valeur attendue d'un etat.""""""
+
+    def __init__(self, state_dim, hidden_dim=128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1)
+        )
+
+    def forward(self, state):
+        return self.net(state)
+
+
+# Verification des dimensions
+critic = CriticNetwork(state_dim)
+dummy_state = torch.randn(1, state_dim)
+value = critic(dummy_state)
+print(f""CriticNetwork defini : input={state_dim}, output=1 (valeur scalaire)"")
+print(f""Test forward : V(s) = {value.item():.4f}"")
+print(f""Nombre de parametres : {sum(p.numel() for p in critic.parameters())}"")",,,,,,,,c219c07efc7d60e0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,4996c238,markdown,fr,8d3b60c1ac57d31e,Le critic est un MLP a 3 couches (comme le Q-network du DQN) mais avec une sortie de dimension 1 au lieu de `action_dim`. Il partage la meme architecture que l'actor pour maintenir un equilibre de capacite entre les deux reseaux.,,,,,,,,8d3b60c1ac57d31e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,bbd49fbe,markdown,fr,4c989bff571eee35,"## 4. L'Actor -- Politique parametree
+
+L'actor est un reseau de neurones qui produit une **distribution de probabilite** sur les actions $\pi(a|s)$. Il est identique au `PolicyNetwork` de REINFORCE vu dans RL-5.
+
+La difference cle : dans REINFORCE, les gradients sont ponderes par $G_t$ (retour Monte Carlo). Dans Actor-Critic, ils seront ponderes par l'avantage $A_t = G_t - V(s_t)$.",,,,,,,,4c989bff571eee35,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,d31d9e89,code,fr,3ebd91550c5b69dd,"class ActorNetwork(nn.Module):
+    """"""Politique parametree pi(a|s) : produit une distribution sur les actions.""""""
+
+    def __init__(self, state_dim, action_dim, hidden_dim=128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, action_dim),
+            nn.Softmax(dim=-1)
+        )
+
+    def forward(self, state):
+        probs = self.net(state)
+        dist = Categorical(probs)
+        return dist
+
+
+# Verification des dimensions
+actor = ActorNetwork(state_dim, action_dim)
+dummy_state = torch.randn(1, state_dim)
+dist = actor(dummy_state)
+print(f""ActorNetwork defini : input={state_dim}, output={action_dim} (distribution)"")
+print(f""Probabilites : {dist.probs.detach().numpy().flatten()}"")
+print(f""Nombre de parametres : {sum(p.numel() for p in actor.parameters())}"")",,,,,,,,3ebd91550c5b69dd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,86f52392,markdown,fr,a5d04213ea8732c7,L'actor utilise une couche `Softmax` en sortie pour garantir que les probabilites sommennt a 1. La classe `Categorical` de PyTorch permet d'echantillonner des actions et de calculer les log-probabilites necessaires pour le policy gradient.,,,,,,,,a5d04213ea8732c7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,b7d671da,markdown,fr,d7c39b7ddeadb694,"## 5. Calcul de l'avantage -- le coeur d'A2C
+
+L'avantage est la cle de voute de l'algorithme Actor-Critic. Il quantifie a quel point l'action choisie est **meilleure que la moyenne** :
+
+$$A(s_t, a_t) = G_t - V(s_t)$$
+
+- Si $A > 0$ : l'action est meilleure que prevu --> renforcer cette action
+- Si $A < 0$ : l'action est pire que prevu --> diminuer sa probabilite
+
+**Le trick `.detach()`** : lors du calcul de l'avantage, on detache $V(s_t)$ du graphe de calcul. Cela empeche les gradients de l'actor de modifier le critic. Sans cela, l'actor pourrait ""tromper"" le critic pour faciliter son propre apprentissage.
+
+Les pertes combinees sont :
+
+$$\mathcal{L}_{total} = \underbrace{-\frac{1}{N}\sum_t \log \pi(a_t|s_t) \cdot A_t}_{\text{Actor loss}} + \alpha \underbrace{\frac{1}{N}\sum_t (V(s_t) - G_t)^2}_{\text{Critic loss}} - \beta \underbrace{H(\pi)}_{\text{Entropy bonus}}$$
+
+ou $\alpha$ est le coefficient de la perte valeur et $\beta$ le coefficient d'entropie.",,,,,,,,d7c39b7ddeadb694,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,1fcc0f98,markdown,fr,defc9c1f99fbe6af,"### Exercice 1 : Calcul de l'avantage et de la perte actor-critic
+
+Implementez la fonction `compute_advantage_and_loss` qui calcule la perte totale A2C.
+
+**Indices** :
+- # Indice : L'avantage = returns - values.detach(). Le `.detach()` est crucial pour stopper le gradient du critic
+- # Indice : La perte de l'actor = -(log_probs * advantage).mean(). C'est le policy gradient avec avantage
+- # Indice : La perte du critic = F.mse_loss(values, returns). C'est une regression vers les retours
+- # Indice : L'entropie = dist.entropy().mean(). Elle mesure l'incertitude de la politique
+
+**Etapes** :
+- # Etape 1 : Calculez l'avantage en detachant les values du graphe
+- # Etape 2 : Calculez la perte de l'actor (n'oubliez pas le signe negatif)
+- # Etape 3 : Calculez la perte du critic (MSE entre predictions et cibles)
+- # Etape 4 : Calculez l'entropie et la perte totale",,,,,,,,defc9c1f99fbe6af,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,d7e08df7,code,fr,5aaa6c1ec736ac1c,"# Exercice 1 : Calcul de l'avantage et de la perte actor-critic
+#
+# Completez la fonction compute_advantage_and_loss qui :
+# 1. Calcule l'avantage A_t = returns - values (detached du gradient)
+# 2. Calcule la perte de l'actor (policy gradient avec avantage)
+# 3. Calcule la perte du critic (MSE entre values et returns)
+# 4. Calcule le bonus d'entropie
+# 5. Retourne la perte totale = actor_loss + value_coef * critic_loss - entropy_coef * entropy
+
+
+def compute_advantage_and_loss(dist, values, returns, value_coef=0.5, entropy_coef=0.01):
+    """"""
+    Calcule la perte totale Actor-Critic.
+
+    Arguments:
+        dist: distribution Categorical de l'actor
+        values: tensor [batch_size] des valeurs estimees par le critic
+        returns: tensor [batch_size] des returns accumules
+        value_coef: poids de la perte du critic
+        entropy_coef: poids du bonus d'entropie
+
+    Retourne:
+        loss: perte totale (scalaire)
+        actor_loss: perte de l'actor (scalaire)
+        critic_loss: perte du critic (scalaire)
+        entropy: entropie moyenne (scalaire)
+    """"""
+    # TODO etudiant : calculer l'avantage
+    advantage = None  # TODO etudiant : returns - values.detach()
+
+    # TODO etudiant : perte de l'actor (policy gradient avec avantage)
+    actor_loss = None  # TODO etudiant : -(log_probs * advantage).mean()
+
+    # TODO etudiant : perte du critic (MSE)
+    critic_loss = None  # TODO etudiant : F.mse_loss(values, returns)
+
+    # TODO etudiant : bonus d'entropie
+    entropy = None  # TODO etudiant : dist.entropy().mean()
+
+    # TODO etudiant : perte totale
+    loss = None  # TODO etudiant : actor_loss + value_coef * critic_loss - entropy_coef * entropy
+
+    return loss, actor_loss, critic_loss, entropy
+
+
+# Test rapide avec des tenseurs factices pour verifier la signature
+print(""Exercice a completer : implementer compute_advantage_and_loss"")",,,,,,,,5aaa6c1ec736ac1c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,94ebf5d5,markdown,fr,a70353b381b2afc8,"## 6. L'agent A2C complet
+
+Maintenant que nous avons l'actor, le critic et le calcul d'avantage, nous pouvons assembler l'agent A2C complet. L'agent encapsule :
+- La **selection d'action** via l'actor
+- Le **calcul des retours** actualises
+- La **mise a jour** conjointe des deux reseaux avec un optimizer partage
+- Le **gradient clipping** pour stabiliser l'apprentissage",,,,,,,,a70353b381b2afc8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,361b73bf,code,fr,1c5e5933ed409a5e,"class A2CAgent:
+    """"""Agent Advantage Actor-Critic complet.""""""
+
+    def __init__(self, state_dim, action_dim, lr=7e-4, gamma=0.99,
+                 value_coef=0.5, entropy_coef=0.01):
+        self.actor = ActorNetwork(state_dim, action_dim)
+        self.critic = CriticNetwork(state_dim)
+        self.optimizer = torch.optim.Adam(
+            list(self.actor.parameters()) + list(self.critic.parameters()),
+            lr=lr
+        )
+        self.gamma = gamma
+        self.value_coef = value_coef
+        self.entropy_coef = entropy_coef
+
+    def select_action(self, state):
+        """"""Selectionne une action selon la politique de l'actor.""""""
+        state_t = torch.FloatTensor(state).unsqueeze(0)
+        dist = self.actor(state_t)
+        action = dist.sample()
+        return action.item(), dist.log_prob(action), dist
+
+    def compute_returns(self, rewards, next_value, dones):
+        """"""Calcule les retours actualises en partant de la fin.""""""
+        returns = []
+        R = next_value
+        for reward, done in zip(reversed(rewards), reversed(dones)):
+            R = reward + self.gamma * R * (1 - done)
+            returns.insert(0, R)
+        return torch.tensor(returns, dtype=torch.float32)
+
+    def update(self, states, actions, returns):
+        """"""Met a jour actor et critic conjointement.
+
+        Recalcule log_probs, values et entropy a partir du meme forward pass
+        pour garantir la coherence du graphe de calcul PyTorch.
+        """"""
+        states_t = torch.FloatTensor(np.array(states))
+        actions_t = torch.LongTensor(actions)
+
+        # Forward pass unique pour actor : log_probs + entropy
+        dist = self.actor(states_t)
+        log_probs = dist.log_prob(actions_t)
+        entropy = dist.entropy().mean()
+
+        # Forward pass critic : values
+        values = self.critic(states_t).squeeze()
+
+        # Advantage et pertes
+        advantage = returns - values.detach()
+        actor_loss = -(log_probs * advantage).mean()
+        critic_loss = F.mse_loss(values, returns)
+
+        loss = actor_loss + self.value_coef * critic_loss - self.entropy_coef * entropy
+
+        self.optimizer.zero_grad()
+        loss.backward()
+        # Gradient clipping pour stabiliser l'apprentissage
+        torch.nn.utils.clip_grad_norm_(
+            list(self.actor.parameters()) + list(self.critic.parameters()),
+            max_norm=1.0
+        )
+        self.optimizer.step()
+
+        return loss.item(), actor_loss.item(), critic_loss.item(), entropy.item()
+
+
+# Creation de l'agent
+agent_a2c = A2CAgent(state_dim, action_dim)
+actor_params = sum(p.numel() for p in agent_a2c.actor.parameters())
+critic_params = sum(p.numel() for p in agent_a2c.critic.parameters())
+print(f""A2CAgent defini avec actor ({actor_params} params) ""
+      f""+ critic ({critic_params} params)"")
+print(f""Optimizer partage : Adam, lr=7e-4"")
+print(f""Gamma={agent_a2c.gamma}, value_coef={agent_a2c.value_coef}, ""
+      f""entropy_coef={agent_a2c.entropy_coef}"")",,,,,,,,1c5e5933ed409a5e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,ed1681ea,markdown,fr,ba5da65e6b159de3,"L'agent utilise un **optimizer partage** pour l'actor et le critic. Cela simplifie l'implementation et assure que les deux reseaux progressent a un rythme coherent. Le **gradient clipping** (max_norm=1.0) prevent les mises a jour trop agressives qui pourraient destabiliser l'apprentissage.
+
+**Point cle de l'implementation** : la methode `update()` recalcule les `log_probs` et l'entropie a partir d'un nouveau forward pass de l'actor sur les etats collectes, plutot que de reutiliser les `log_probs` calcules lors de la collecte. Cela garantit la **coherence du graphe de calcul** PyTorch : log_probs, advantage et entropy derivent tous du meme etat des poids du reseau, ce qui produit des gradients corrects pour la retropropagation.",,,,,,,,ba5da65e6b159de3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,642c11d7,markdown,fr,304413bc80eb93af,"## 7. Entrainement sur CartPole-v1
+
+La boucle d'entrainement suit le schema classique du RL :
+1. Collecter une trajectoire complete (episode)
+2. Calculer les retours actualises avec bootstrap de la valeur finale
+3. Mettre a jour actor et critic conjointement
+
+**Point important** : contrairement au DQN qui met a jour a chaque pas (off-policy avec replay buffer), A2C met a jour **a la fin de chaque episode** (on-policy). Les donnees ne sont reutilisees qu'une seule fois.",,,,,,,,304413bc80eb93af,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,a16bc170,code,fr,91a3d128d52d6817,"def train_a2c(env_name=""CartPole-v1"", num_episodes=600, eval_interval=50, seed=42):
+    """"""
+    Entraine un agent A2C sur un environnement Gymnasium.
+
+    Arguments:
+        env_name: nom de l'environnement
+        num_episodes: nombre d'episodes d'entrainement
+        eval_interval: frequence d'affichage des statistiques
+        seed: graine aleatoire pour la reproductibilite
+
+    Retourne:
+        episode_rewards: liste des recompenses par episode
+    """"""
+    # Reproductibilite
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    env = gym.make(env_name)
+    s_dim = env.observation_space.shape[0]
+    a_dim = env.action_space.n
+
+    agent = A2CAgent(s_dim, a_dim)
+
+    episode_rewards = []
+    running_reward = deque(maxlen=100)
+
+    for episode in range(num_episodes):
+        state, _ = env.reset(seed=seed + episode)
+        states, actions, rewards, dones = [], [], [], []
+        episode_reward = 0
+
+        done = False
+        while not done:
+            action, log_prob, dist = agent.select_action(state)
+            next_state, reward, terminated, truncated, _ = env.step(action)
+            done = terminated or truncated
+
+            states.append(state)
+            actions.append(action)
+            rewards.append(reward)
+            dones.append(float(done))
+            episode_reward += reward
+            state = next_state
+
+        # Bootstrap value pour le dernier etat
+        next_value = 0 if done else agent.critic(
+            torch.FloatTensor(state).unsqueeze(0)
+        ).item()
+        returns = agent.compute_returns(rewards, next_value, dones)
+
+        # update() recalcule log_probs, values et entropy en interne
+        # pour garantir la coherence du graphe de calcul
+        agent.update(states, actions, returns)
+
+        episode_rewards.append(episode_reward)
+        running_reward.append(episode_reward)
+
+        if (episode + 1) % eval_interval == 0:
+            avg = np.mean(running_reward)
+            print(f""Episode {episode+1:3d}/{num_episodes} | ""
+                  f""Reward moyen (100 ep): {avg:.1f}"")
+
+    env.close()
+    return episode_rewards
+
+
+# Entrainement
+rewards_a2c = train_a2c(num_episodes=600)
+final_avg = np.mean(rewards_a2c[-100:])
+print(f""\nEntrainement termine. Reward final moyen (100 ep): {final_avg:.1f}"")",,,,,,,,91a3d128d52d6817,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,0e66bcda,markdown,fr,384198ac9077d4d7,"L'entrainement devrait montrer une progression reguliere vers le seuil de resolution (195 sur CartPole-v1). Le critic reduit la variance des mises a jour par rapport a REINFORCE, ce qui se traduit par une convergence plus stable.",,,,,,,,384198ac9077d4d7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,6992ed36,markdown,fr,669a010859d051a4,"## 8. Visualisation des resultats
+
+Analysons la courbe d'apprentissage et la distribution des rewards finaux pour evaluer la stabilite de l'agent.",,,,,,,,669a010859d051a4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,6963162d,code,fr,ccf2c1b9da1c2542,"fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+# Courbe de reward
+axes[0].plot(rewards_a2c, alpha=0.3, color='steelblue', label='Reward episode')
+window = 50
+if len(rewards_a2c) >= window:
+    moving_avg = np.convolve(rewards_a2c, np.ones(window)/window, mode='valid')
+    axes[0].plot(range(window-1, len(rewards_a2c)), moving_avg,
+                 color='steelblue', linewidth=2, label=f'Moyenne mobile ({window})')
+axes[0].axhline(y=195, color='green', linestyle='--', alpha=0.5, label='Objectif (195)')
+axes[0].set_xlabel('Episode')
+axes[0].set_ylabel('Reward')
+axes[0].set_title('Apprentissage A2C sur CartPole-v1')
+axes[0].legend()
+axes[0].grid(True, alpha=0.3)
+
+# Distribution des rewards finaux
+final_rewards = rewards_a2c[-100:]
+axes[1].hist(final_rewards, bins=20, color='steelblue', alpha=0.7, edgecolor='white')
+axes[1].axvline(x=np.mean(final_rewards), color='red', linestyle='--',
+                label=f'Moyenne: {np.mean(final_rewards):.1f}')
+axes[1].set_xlabel('Reward')
+axes[1].set_ylabel('Frequence')
+axes[1].set_title('Distribution des rewards (100 derniers episodes)')
+axes[1].legend()
+
+plt.tight_layout()
+plt.savefig('a2c_cartpole_results.png', dpi=100, bbox_inches='tight')
+plt.show()
+print(f""Visualisation A2C generee. Reward moyen final: ""
+      f""{np.mean(final_rewards):.1f} +/- {np.std(final_rewards):.1f}"")",,,,,,,,ccf2c1b9da1c2542,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,66fe1300,markdown,fr,d197fa42dcc05811,"## 9. Comparaison avec REINFORCE
+
+L'avantage principal d'Actor-Critic sur REINFORCE est la **reduction de variance** des gradients. Avec REINFORCE, le signal de gradient est multiplie par $G_t$ (qui peut varier enormement). Avec A2C, le signal est multiplie par l'avantage $A_t = G_t - V(s_t)$, qui est centre et de plus petite amplitude.
+
+### Exercice 2 : Comparaison A2C vs REINFORCE
+
+Comparez les courbes d'apprentissage des deux algorithmes sur CartPole-v1.
+
+**Indices** :
+- # Indice : Reutilisez la classe PolicyNetwork et la boucle REINFORCE du notebook rl_5
+- # Indice : Entrainenez les deux agents avec le meme nombre d'episodes et le meme random seed
+- # Indice : La perte REINFORCE est -(log_probs * returns).mean() sans avantage
+
+**Etapes** :
+- # Etape 1 : Implementez une version simplifiee de REINFORCE (ou importez depuis rl_5)
+- # Etape 2 : Lancez les deux entrainements avec les memes hyperparametres
+- # Etape 3 : Tracez les deux courbes sur le meme graphe avec moyenne mobile",,,,,,,,d197fa42dcc05811,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,11855045,code,fr,b7f15215281ebceb,"# Exercice 2 : Comparaison A2C vs REINFORCE sur CartPole-v1
+#
+# Implementez une version simplifiee de REINFORCE (sans baseline) et comparez
+# les courbes d'apprentissage avec l'A2C entraine ci-dessus.
+
+
+def train_reinforce(env_name=""CartPole-v1"", num_episodes=400, seed=42):
+    """"""
+    Entraine un agent REINFORCE (sans baseline) pour comparaison.
+
+    # Indice : Utilisez le meme ActorNetwork mais sans CriticNetwork
+    # Indice : La perte REINFORCE est -(log_probs * returns).mean()
+    # Etape 1 : Initialisez l'actor et l'optimizer
+    # Etape 2 : Pour chaque episode, collectez la trajectoire
+    # Etape 3 : Calculez les returns et mettez a jour la politique
+    """"""
+    result = None  # TODO etudiant : retourner la liste des episode_rewards
+    return result
+
+
+# TODO etudiant : lancer les deux entrainements et tracer la comparaison
+rewards_reinforce = None  # TODO etudiant : train_reinforce()
+
+print(""Exercice a completer : implementer REINFORCE et comparer avec A2C"")",,,,,,,,b7f15215281ebceb,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,4519eaeb,markdown,fr,4d828c6c5b6a0691,"## 10. Le bonus d'entropie
+
+L'entropie de la politique mesure son **degre d'exploration** :
+
+$$H(\pi) = -\sum_a \pi(a|s) \log \pi(a|s)$$
+
+- $H$ eleve : la politique est incertaine (exploration)
+- $H$ faible : la politique est deterministe (exploitation)
+
+**Pourquoi maximiser l'entropie ?** Sans ce bonus, l'actor peut converger prematurement vers une politique sub-optimale deterministe. Le bonus d'entropie penalise les politiques trop certaines, forcant l'agent a continuer a explorer.
+
+Le coefficient `entropy_coef` (typiquement 0.01) controle le compromis exploration/exploitation :
+- `entropy_coef = 0` : pas d'encouragement a l'exploration (comme REINFORCE pur)
+- `entropy_coef = 0.01` : valeur standard, bon equilibre
+- `entropy_coef > 0.1` : forte exploration, peut ralentir la convergence",,,,,,,,4d828c6c5b6a0691,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,6237a4cc,markdown,fr,24b43bfac8350e35,"### Exercice 3 : Ablation du bonus d'entropie
+
+Explorez l'impact du coefficient d'entropie sur l'apprentissage.
+
+**Indices** :
+- # Indice : entropy_coef = 0 correspond a pas de bonus d'entropie
+- # Indice : Des valeurs typiques sont 0.0, 0.01, 0.05, 0.1
+- # Indice : Observez comment l'entropie de la politique evolue pendant l'entrainement
+
+**Etapes** :
+- # Etape 1 : Entrainenez A2C avec plusieurs valeurs de entropy_coef
+- # Etape 2 : Tracez les courbes de reward pour chaque valeur
+- # Etape 3 : Observez la vitesse de convergence et la stabilite finale",,,,,,,,24b43bfac8350e35,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,500f58a3,code,fr,a5b943da0ecad48a,"# Exercice 3 : Impact du bonus d'entropie sur l'apprentissage
+#
+# Entrainez A2C avec differentes valeurs de entropy_coef et comparez.
+
+entropy_coefs = [0.0, 0.01, 0.05, 0.1]
+results = {}  # TODO etudiant : dict coef -> list of episode_rewards
+
+# TODO etudiant : boucle d'entrainement pour chaque coef
+# Indice : reutilisez train_a2c en passant entropy_coef a l'agent
+# Etape 1 : Pour chaque coef dans entropy_coefs, entrainez un agent A2C
+# Etape 2 : Stockez les rewards dans results[coef]
+# Etape 3 : Tracez les courbes comparatives
+
+print(""Exercice a completer : ablation du bonus d'entropie"")",,,,,,,,a5b943da0ecad48a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,f5e77662,markdown,fr,5e7e0e94d269bc4e,"## 11. Ouverture -- vers PPO et au-dela
+
+A2C est le fondement des algorithmes modernes de RL. Voici les evolutions majeures :
+
+| Algorithme | Innovation par rapport a A2C | Usage |
+|------------|------------------------------|-------|
+| **A3C** | A2C asynchrone avec plusieurs workers en parallele | Entrainement distribue |
+| **PPO** | Objectif clippe pour eviter les trop grosses mises a jour de politique | Standard industrie (SB3, CleanRL) |
+| **SAC** | Maximisation de l'entropie comme objectif (pas juste bonus) | Actions continues, sample-efficient |
+| **TD3** | Twin critics + delayed policy updates | Actions continues, reduit la surestimation |
+
+**PPO** (Proximal Policy Optimization) est l'algorithme le plus utilise en pratique. Son idee centrale : limiter le changement de politique entre deux mises a jour avec un ratio clippe :
+
+$$\mathcal{L}^{CLIP} = \hat{\mathbb{E}}_t\left[\min\left(r_t(\theta)\hat{A}_t, \text{clip}(r_t(\theta), 1-\epsilon, 1+\epsilon)\hat{A}_t\right)\right]$$
+
+ou $r_t(\theta) = \frac{\pi_\theta(a_t|s_t)}{\pi_{\theta_{old}}(a_t|s_t)}$ est le ratio de probabilites entre la nouvelle et l'ancienne politique.
+
+Les notebooks [RL-1](rl_1_intro_cartpole.ipynb) et [RL-2](rl_2_wrappers_sauvegarde_callbacks.ipynb) de cette serie utilisent PPO via stable-baselines3. Avec les concepts de ce notebook, vous comprenez maintenant ce qui se cache derriere cette boite noire.",,,,,,,,5e7e0e94d269bc4e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6b_actor_critic.ipynb,1ac6b512,markdown,fr,753885f694dd9b51,"## 12. Conclusion
+
+### Recapitulatif des concepts
+
+| Concept | Role | Formule |
+|---------|------|--------|
+| **Actor** | Politique $\pi(a|s)$ qui choisit les actions | Sortie : distribution Categorical |
+| **Critic** | Valeur $V(s)$ qui estime la qualite des etats | Sortie : scalaire |
+| **Avantage** | Signal d'apprentissage a variance reduite | $A_t = G_t - V(s_t)$ |
+| **Entropy bonus** | Encourage l'exploration | $H(\pi) = -\sum_a \pi(a|s) \log \pi(a|s)$ |
+| **Gradient clipping** | Stabilise les mises a jour | `clip_grad_norm_(max_norm=0.5)` |
+
+### Comparaison des approches
+
+| Aspect | DQN | REINFORCE | A2C |
+|--------|-----|-----------|-----|
+| Apprend | $Q(s,a)$ | $\pi(a|s)$ | $\pi(a|s)$ + $V(s)$ |
+| Variance | Faible | Haute | Moyenne |
+| Efficacite donnees | Elevee (off-policy) | Faible (on-policy) | Moyenne |
+| Actions continues | Non | Oui | Oui |
+| Stabilite | Bonne (target net) | Variable | Bonne (gradient clipping) |
+
+**Prochaine etape** : Le notebook [RL-7 Multi-Agent](rl_7_multi_agent_rl.ipynb) aborder l'apprentissage multi-agent ou plusieurs agents interagissent simultanement dans un environnement partage.
+
+**References** :
+- Sutton & Barto, *Reinforcement Learning: An Introduction*, Chapters 13 (Policy Gradient) et 15 (Neural RL)
+- Mnih et al. (2016) - *Asynchronous Methods for Deep RL* (A3C)
+- Schulman et al. (2017) - *Proximal Policy Optimization Algorithms* (PPO)
+
+
+### References academiques
+
+- Williams, R.J. (1992). Simple Statistical Gradient-Following Algorithms for Connectionist Reinforcement Learning. Neural Computation 4(3):405-414.
+- Konda, V.R. & Tsitsiklis, J.N. (2003). On Actor-Critic Algorithms. SIAM Journal on Control and Optimization 42(4):1143-1166.
+- Mnih, V., Badia, A.P., Mirza, M., Graves, A., Lillicrap, T., Harley, T., Silver, D. & Kavukcuoglu, K. (2016). Asynchronous Methods for Deep Reinforcement Learning. ICML 2016. arXiv:1602.01783.
+- Sutton, R.S., McAllester, D.A., Singh, S.P. & Mansour, Y. (2000). Policy Gradient Methods for Reinforcement Learning with Function Approximation. NeurIPS 2000.
+- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press.
+
+",,,,,,,,753885f694dd9b51,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,325cb5c9,markdown,fr,2d93325bc3446418,"# PPO (Proximal Policy Optimization) depuis zero
+
+**Serie** : Reinforcement Learning | **Notebook** : 6c/13 | **Duree estimee** : 45-50 min
+
+**Navigation** : [[Notebook precedent] Actor-Critic (A2C)](rl_6b_actor_critic.ipynb) | [Index](README.md) | [[Notebook suivant] Multi-Agent RL](rl_7_multi_agent_rl.ipynb)
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous serez capable de :
+
+1. **Expliquer** la motivation du clipping dans PPO et son lien avec la trust region
+2. **Implementer** l'objectif surrogate clippe $L^{CLIP}(\theta)$ depuis zero
+3. **Comparer** PPO et A2C en termes de stabilite et d'efficacite d'echantillonnage
+
+## Prerequis
+
+- **Notebook [Actor-Critic (A2C)](rl_6b_actor_critic.ipynb)** : architecture actor-critic, calcul de l'avantage
+- PyTorch (tenseurs, autograd, `torch.distributions`)
+- Concepts RL de base (policy, reward, discount)
+
+**Duree estimee** : 45-50 minutes
+",,,,,,,,2d93325bc3446418,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,bfc946c2,markdown,fr,f763ce37a15fdbab,"## Pourquoi PPO ?
+
+Dans le notebook precedent, nous avons implemente **A2C** (Advantage Actor-Critic). A2C fonctionne bien mais souffre d'un probleme pratique : le **pas d'apprentissage**. Si le pas est trop grand, la politique peut s'effondrer (policy collapse) ; si il est trop petit, l'apprentissage est lent.
+
+**PPO** (Proximal Policy Optimization, Schulman et al. 2017) resout ce probleme avec une idee elegante : **clipper** le ratio de probabilite pour empecher les mises a jour trop agressives. PPO est devenu l'algorithme de reference en RL moderne — c'est ce qu'utilise ChatGPT (RLHF), les agents de jeux d'OpenAI, et de nombreuses applications industrielles.
+
+### De TRPO a PPO
+
+| Algorithme | Contrainte | Avantage | Inconvenient |
+|------------|-----------|----------|-------------|
+| TRPO | Trust region exacte (KL) | Garanties theoriques | Optimisation complexe (conjugate gradient) |
+| PPO | Clipping du ratio | Simple, efficace | Approximation de la trust region |
+| A2C | Aucune | Simple | Pas de controle de la taille de mise a jour |
+
+
+> *Ancres savantes -- Schulman, J., Wolski, F., Dhariwal, P., Radford, A. & Klimov, O. (2017), Proximal Policy Optimization Algorithms, arXiv:1707.06347 (PPO, objectif surrogate clippe evite les mises a jour destructrices du pas d'apprentissage) ; Schulman, J., Moritz, P., Levine, S., Jordan, M. & Abbeel, P. (2016), High-Dimensional Continuous Control Using Generalized Advantage Estimation, ICLR 2016, arXiv:1506.02438 (GAE, estimateur d'avantage a compromis biais-variance controle par lambda) ; Mnih, V., Badia, A.P., Mirza, M., Graves, A., Lillicrap, T., Harley, T., Silver, D. & Kavukcuoglu, K. (2016), Asynchronous Methods for Deep Reinforcement Learning, ICML 2016, arXiv:1602.01783 (A3C/A2C, acteur-critique asynchrone dont PPO ameliore la stabilite du pas).*",,,,,,,,f763ce37a15fdbab,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,b7404cde,markdown,fr,0c6558c3dabcb298,## 1. Setup et imports,,,,,,,,0c6558c3dabcb298,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,ae99a71b,code,fr,f4652752c05b83b0,"import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.nn.functional as F
+from torch.distributions import Categorical
+import gymnasium as gym
+import numpy as np
+import matplotlib.pyplot as plt
+from collections import deque
+
+print(f""Imports OK : PyTorch {torch.__version__}, Gymnasium {gym.__version__}"")
+",,,,,,,,f4652752c05b83b0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,9172b972,markdown,fr,86968cafb4e8a861,"## 2. L'objectif surrogate clippe
+
+L'idee centrale de PPO est le **ratio de probabilite** :
+
+$$r_t(\theta) = \frac{\pi_\theta(a_t | s_t)}{\pi_{\theta_{old}}(a_t | s_t)}$$
+
+Si $r_t > 1$, la nouvelle politique augmente la probabilite de cette action. Si $r_t < 1$, elle la diminue.
+
+L'objectif surrogate **non clippe** serait simplement $r_t \cdot A_t$ (multiplier le ratio par l'avantage). Mais sans contrainte, une seule mise a jour peut changer radicalement la politique.
+
+PPO ajoute un **clip** :
+
+$$L^{CLIP}(\theta) = \mathbb{E}_t\left[\min\left(r_t(\theta) \cdot A_t,\; \text{clip}(r_t(\theta), 1-\epsilon, 1+\epsilon) \cdot A_t\right)\right]$$
+
+Le $\min$ prend la version la plus pessimiste : si le ratio sort de $[1-\epsilon, 1+\epsilon]$, l'objectif est plafonne. Cela empeche les mises a jour destructrices.
+
+Le parametre $\epsilon$ (typiquement 0.2) controle la taille de la trust region.
+",,,,,,,,86968cafb4e8a861,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,09389e9e,markdown,fr,1570d4a80320c6d1,### 2.1 Visualisation du clipping,,,,,,,,1570d4a80320c6d1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,adc2b1f7,code,fr,93e8b0e8aec824c7,"def visualize_clipping(epsilon=0.2):
+    """"""Visualise l'effet du clipping sur l'objectif PPO.""""""
+    ratios = np.linspace(0.5, 1.5, 200)
+    advantage = 1.0
+    unclipped = ratios * advantage
+    clipped_ratios = np.clip(ratios, 1 - epsilon, 1 + epsilon)
+    clipped = clipped_ratios * advantage
+    ppo_objective = np.minimum(unclipped, clipped)
+    
+    fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+    ax.plot(ratios, unclipped, 'b--', label=r'Non clippe $r_t \cdot A$', alpha=0.7)
+    ax.plot(ratios, clipped, 'g-', label=r'Clippe $\mathrm{clip}(r_t) \cdot A$', alpha=0.7)
+    ax.plot(ratios, ppo_objective, 'r-', linewidth=2.5, label='PPO : min des deux')
+    ax.axvline(1 - epsilon, color='gray', linestyle=':', alpha=0.5)
+    ax.axvline(1 + epsilon, color='gray', linestyle=':', alpha=0.5)
+    ax.axvspan(1 - epsilon, 1 + epsilon, alpha=0.1, color='green',
+               label=f'Trust region eps={epsilon}')
+    ax.set_xlabel(r'Ratio $r_t(\theta)$')
+    ax.set_ylabel('Objectif')
+    ax.set_title(f'Objectif PPO (A > 0, epsilon = {epsilon})')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.show()
+
+visualize_clipping(epsilon=0.2)",,,,,,,,93e8b0e8aec824c7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,fd459336,markdown,fr,a9fb683a5377f242,"## 3. Implementation de PPO
+
+### 3.1 Reseaux Actor et Critic
+
+PPO reutilise la meme architecture actor-critic que A2C. La difference cle est dans la **fonction de perte** (clipped surrogate) et les **mises a jour par mini-lots**.
+",,,,,,,,a9fb683a5377f242,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,c3519f5e,code,fr,ba81d5532c3a815a,"class ActorNetwork(nn.Module):
+    """"""Politique parametree pi(a|s) pour actions discretes.""""""
+    def __init__(self, state_dim, action_dim, hidden_dim=128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, action_dim),
+        )
+    
+    def forward(self, x):
+        logits = self.net(x)
+        return Categorical(logits=logits)
+
+
+class CriticNetwork(nn.Module):
+    """"""Estimation de la valeur V(s).""""""
+    def __init__(self, state_dim, hidden_dim=128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+    
+    def forward(self, x):
+        return self.net(x).squeeze(-1)
+
+
+print(""ActorNetwork et CriticNetwork definis (2 x 3 couches lineaires)"")
+",,,,,,,,ba81d5532c3a815a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,0dc7eba3,markdown,fr,e050dfe863094863,### 3.2 Agent PPO avec clipped surrogate,,,,,,,,e050dfe863094863,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,6807e3a1,code,fr,ca7bf0b9cfb922b1,"class PPOAgent:
+    """"""Agent PPO avec clipped surrogate objectif.""""""
+    def __init__(self, state_dim, action_dim, lr=3e-4, gamma=0.99,
+                 epsilon_clip=0.2, value_coef=0.5, entropy_coef=0.01,
+                 ppo_epochs=4, mini_batch_size=64, max_grad_norm=0.5):
+        self.actor = ActorNetwork(state_dim, action_dim)
+        self.critic = CriticNetwork(state_dim)
+        self.optimizer = optim.Adam(
+            list(self.actor.parameters()) + list(self.critic.parameters()), lr=lr
+        )
+        self.gamma = gamma
+        self.epsilon_clip = epsilon_clip
+        self.value_coef = value_coef
+        self.entropy_coef = entropy_coef
+        self.ppo_epochs = ppo_epochs
+        self.mini_batch_size = mini_batch_size
+        self.max_grad_norm = max_grad_norm
+    
+    def select_action(self, state):
+        state_t = torch.FloatTensor(state).unsqueeze(0)
+        with torch.no_grad():
+            dist = self.actor(state_t)
+            action = dist.sample()
+            log_prob = dist.log_prob(action)
+            value = self.critic(state_t)
+        return action.item(), log_prob.item(), value.item()
+    
+    def compute_gae(self, rewards, values, dones, last_value, lam=0.95):
+        """"""Generalized Advantage Estimation.""""""
+        advantages = []
+        gae = 0
+        values = values + [last_value]
+        for t in reversed(range(len(rewards))):
+            delta = rewards[t] + self.gamma * values[t + 1] * (1 - dones[t]) - values[t]
+            gae = delta + self.gamma * lam * (1 - dones[t]) * gae
+            advantages.insert(0, gae)
+        return advantages
+    
+    def update(self, states, actions, old_log_probs, returns, advantages):
+        """"""Mise a jour PPO avec clipped surrogate + mini-lots.""""""
+        states_t = torch.FloatTensor(np.array(states))
+        actions_t = torch.LongTensor(actions)
+        old_log_probs_t = torch.FloatTensor(old_log_probs)
+        returns_t = torch.FloatTensor(returns)
+        advantages_t = torch.FloatTensor(advantages)
+        advantages_t = (advantages_t - advantages_t.mean()) / (advantages_t.std() + 1e-8)
+        
+        dataset_size = len(states)
+        total_loss = 0.0
+        for _ in range(self.ppo_epochs):
+            indices = np.random.permutation(dataset_size)
+            for start in range(0, dataset_size, self.mini_batch_size):
+                end = start + self.mini_batch_size
+                mb_idx = indices[start:end]
+                mb_states = states_t[mb_idx]
+                mb_actions = actions_t[mb_idx]
+                mb_old_log_probs = old_log_probs_t[mb_idx]
+                mb_returns = returns_t[mb_idx]
+                mb_advantages = advantages_t[mb_idx]
+                dist = self.actor(mb_states)
+                new_log_probs = dist.log_prob(mb_actions)
+                entropy = dist.entropy().mean()
+                values = self.critic(mb_states)
+                ratio = torch.exp(new_log_probs - mb_old_log_probs)
+                surr1 = ratio * mb_advantages
+                surr2 = torch.clamp(ratio, 1 - self.epsilon_clip, 1 + self.epsilon_clip) * mb_advantages
+                actor_loss = -torch.min(surr1, surr2).mean()
+                critic_loss = F.mse_loss(values, mb_returns)
+                loss = actor_loss + self.value_coef * critic_loss - self.entropy_coef * entropy
+                self.optimizer.zero_grad()
+                loss.backward()
+                nn.utils.clip_grad_norm_(
+                    list(self.actor.parameters()) + list(self.critic.parameters()),
+                    self.max_grad_norm
+                )
+                self.optimizer.step()
+                total_loss += loss.item()
+        return total_loss / (self.ppo_epochs * max(1, dataset_size // self.mini_batch_size))
+
+
+print(f""PPOAgent initialise : clip_eps=0.2, ppo_epochs=4, mini_batch=64"")
+",,,,,,,,ca7bf0b9cfb922b1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,f69a551d,markdown,fr,2385ecb6ab507478,### 3.3 Boucle d'entrainement PPO,,,,,,,,2385ecb6ab507478,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,793e6065,code,fr,121132ef9d573f03,"def train_ppo(env_name=""CartPole-v1"", num_episodes=400, horizon=2048, print_every=50):
+    """"""Entraine un agent PPO sur un environnement Gymnasium.""""""
+    env = gym.make(env_name)
+    state_dim = env.observation_space.shape[0]
+    action_dim = env.action_space.n
+    agent = PPOAgent(state_dim, action_dim)
+    episode_rewards = []
+    state, _ = env.reset()
+    episode_reward = 0
+    episode = 0
+    
+    while episode < num_episodes:
+        states, actions, log_probs, rewards, values, dones = [], [], [], [], [], []
+        for _ in range(horizon):
+            action, log_prob, value = agent.select_action(state)
+            next_state, reward, terminated, truncated, _ = env.step(action)
+            done = terminated or truncated
+            states.append(state)
+            actions.append(action)
+            log_probs.append(log_prob)
+            rewards.append(reward)
+            values.append(value)
+            dones.append(done)
+            episode_reward += reward
+            state = next_state
+            if done:
+                episode_rewards.append(episode_reward)
+                episode += 1
+                state, _ = env.reset()
+                episode_reward = 0
+                if episode % print_every == 0:
+                    recent = episode_rewards[-print_every:]
+                    print(f""Episode {episode}/{num_episodes} | ""
+                          f""Mean reward: {np.mean(recent):.1f} | Max: {np.max(recent):.0f}"")
+                if episode >= num_episodes:
+                    break
+        if episode >= num_episodes:
+            break
+        with torch.no_grad():
+            last_value = agent.critic(torch.FloatTensor(state).unsqueeze(0)).item()
+        advantages = agent.compute_gae(rewards, values, dones, last_value)
+        returns = [a + v for a, v in zip(advantages, values)]
+        agent.update(states, actions, log_probs, returns, advantages)
+    
+    env.close()
+    return agent, episode_rewards
+
+
+print(""Fonction train_ppo definie"")
+",,,,,,,,121132ef9d573f03,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,82e244ea,markdown,fr,3b81182842d76a7f,### 3.4 Entrainement sur CartPole-v1,,,,,,,,3b81182842d76a7f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,8e1327c3,code,fr,b4a2accf5510a542,"# Entrainement PPO
+ppo_agent, ppo_rewards = train_ppo(num_episodes=400, horizon=2048)
+
+print(f""\nEntrainement termine : {len(ppo_rewards)} episodes"")
+print(f""Recompense moyenne (derniers 50) : {np.mean(ppo_rewards[-50:]):.1f}"")
+print(f""Recompense max : {np.max(ppo_rewards):.0f}"")
+",,,,,,,,b4a2accf5510a542,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,20af6f01,markdown,fr,dfd0692424e63297,### 3.5 Visualisation de la courbe d'apprentissage,,,,,,,,dfd0692424e63297,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,aa63b3b3,code,fr,b98b1464fcd5e5f3,"def plot_rewards(rewards, title=""Courbe d'apprentissage PPO"", window=20):
+    """"""Affiche la courbe d'apprentissage avec moyenne mobile.""""""
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(rewards, alpha=0.3, color=""blue"", label=""Recompense par episode"")
+    if len(rewards) >= window:
+        moving_avg = np.convolve(rewards, np.ones(window)/window, mode=""valid"")
+        ax.plot(range(window-1, len(rewards)), moving_avg, color=""red"", 
+                linewidth=2, label=f""Moyenne mobile (n={window})"")
+    ax.axhline(y=195, color=""green"", linestyle=""--"", alpha=0.7, label=""Seuil CartPole (195)"")
+    ax.set_xlabel(""Episode"")
+    ax.set_ylabel(""Recompense cumulative"")
+    ax.set_title(title)
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.show()
+
+plot_rewards(ppo_rewards, title=""PPO sur CartPole-v1"")
+",,,,,,,,b98b1464fcd5e5f3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,6e4217b4,markdown,fr,9b24ad98a1cc18fe,"## 4. Generalized Advantage Estimation (GAE)
+
+Jusqu'ici nous avons utilise un estimateur d'avantage simple : $A_t = R_t - V(s_t)$. GAE (Schulman 2016) offre un meilleur compromis biais-variance :
+
+$$\hat{A}^{GAE(\gamma, \lambda)}_t = \sum_{l=0}^{\infty} (\gamma \lambda)^l \delta_{t+l}$$
+
+ou $\delta_t = r_t + \gamma V(s_{t+1}) - V(s_t)$ est le **TD residual**.
+
+Le parametre $\lambda \in [0, 1]$ controle le compromis :
+- $\lambda = 0$ : avantage one-step (faible variance, biais eleve)
+- $\lambda = 1$ : avantage Monte Carlo (pas de biais, variance elevee)
+- $\lambda = 0.95$ : bon compromis empirique
+
+Notre implementation PPO utilise deja GAE (methode `compute_gae` de l'agent). L'exercice suivant vous demande de **verifier** son comportement.
+",,,,,,,,9b24ad98a1cc18fe,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,eb54d41f,markdown,fr,0b6959e4e7a7346a,"### Exercice 1 : Implementer le clipped surrogate
+
+L'objectif clipped surrogate est le coeur de PPO. Implementez la fonction `clipped_surrogate_loss` qui calcule la perte actor a partir des ratios, avantages et epsilon.
+
+**Indices** :
+- Le ratio est $r_t = \exp(\log\pi_{nouveau} - \log\pi_{ancien})$
+- Clipping : `torch.clamp(ratio, 1-eps, 1+eps)`
+- Perte = `-min(surrogate1, surrogate2).mean()`
+",,,,,,,,0b6959e4e7a7346a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,a81dee16,code,fr,051d024c5d0627ed,"def clipped_surrogate_loss(ratio, advantages, epsilon=0.2):
+    """"""Calcule la perte clipped surrogate de PPO.
+    
+    Args:
+        ratio: r_t(theta) = pi_nouveau / pi_ancien, shape (batch,)
+        advantages: A_t, shape (batch,)
+        epsilon: parametre de clipping (typiquement 0.2)
+    
+    Returns:
+        loss: scalaire (negative car on maximise via descente de gradient)
+    """"""
+    # TODO etudiant : implementer le clipped surrogate
+    # Etape 1 : calculer le surrogate non clippe
+    # Etape 2 : calculer le surrogate clippe
+    # Etape 3 : prendre le min et moyenner
+    return None  # TODO etudiant : remplacer par votre implementation
+
+
+# Test rapide avec des donnees synthetiques
+ratio_test = torch.tensor([0.8, 1.0, 1.1, 1.3, 0.6])
+adv_test = torch.tensor([1.0, 1.0, 1.0, -1.0, -1.0])
+loss_test = clipped_surrogate_loss(ratio_test, adv_test, epsilon=0.2)
+print(""Exercice a completer"")
+",,,,,,,,051d024c5d0627ed,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,4ee4a6fa,markdown,fr,bed4ba90e07701cf,"### Exercice 2 : Verifier l'effet de GAE sur l'apprentissage
+
+Comparez l'apprentissage PPO avec GAE ($\lambda = 0.95$) vs sans GAE ($\lambda = 0$, avantage one-step). Entrainez deux agents et affichez les courbes cote a cote.
+
+**Indices** :
+- Modifiez le parametre `lam` dans `compute_gae` (defaut=0.95)
+- Pour lambda=0 : chaque avantage = $r_t + \gamma V(s_{t+1}) - V(s_t)$ seulement
+",,,,,,,,bed4ba90e07701cf,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,08da5a81,code,fr,eb3deee1e8434882,"# TODO etudiant : entrainer PPO avec GAE (lambda=0.95) et sans GAE (lambda=0)
+# Puis comparer les courbes d'apprentissage
+
+# Indice : vous pouvez modifier compute_gae via un parametre ou
+# sous-classer PPOAgent pour changer la valeur de lambda
+
+print(""Exercice a completer"")
+",,,,,,,,eb3deee1e8434882,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,3b8cae1e,markdown,fr,4d08cb3fe2fccf71,"## 5. PPO vs A2C : Comparaison
+
+Maintenant que nous avons implemente PPO, comparons-le avec A2C du notebook precedent. Les differences cles :
+
+| Aspect | A2C | PPO |
+|--------|-----|-----|
+| Objectif | $-\log\pi \cdot A$ | $\min(r \cdot A, \text{clip}(r) \cdot A)$ |
+| Mises a jour | 1 par trajectoire | Plusieurs epochs par trajectoire |
+| Stabilite | Sensible au learning rate | Robuste grace au clipping |
+| Echantillonnage | On-policy, 1 utilisation | On-policy, re-utilisation via epochs |
+| Mini-lots | Non | Oui (reduisent variance) |
+",,,,,,,,4d08cb3fe2fccf71,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,1125b47a,markdown,fr,695a2689e1dd4e6a,"### Exercice 3 : Comparer PPO et A2C
+
+Entrainez un agent A2C (avec l'implementation du notebook precedent) et un agent PPO sur CartPole-v1 avec les memes hyperparametres de base. Affichez les courbes superposees.
+
+**Indices** :
+- Reutilisez la classe A2CAgent du notebook 6b (copiez les definitions necessaires)
+- Utilisez 400 episodes pour chaque algorithme
+- Superposez les moyennes mobiles sur un meme graphe
+",,,,,,,,695a2689e1dd4e6a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,f5f7b6b3,code,fr,2ca8175865d5e76b,"# TODO etudiant : implementer A2CAgent et comparer avec PPO
+
+# Indice : copiez ActorNetwork, CriticNetwork depuis le notebook 6b
+# puis implementez un A2CAgent simple avec update(states, actions, returns)
+
+print(""Exercice a completer"")
+",,,,,,,,2ca8175865d5e76b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,791b09fb,markdown,fr,8bfa537c38dcd121,"## Application : RLHF et l'alignement des LLM
+
+Le PPO que vous venez d'implementer est **l'algorithme au coeur de l'alignement des modeles de langage** (ChatGPT, Claude, et la plupart des LLM modernes). Le processus RLHF (Reinforcement Learning from Human Feedback) fonctionne en 3 etapes :
+
+1. **Pre-entrainement** : le modele apprend a predire le texte suivant (apprentissage supervise classique)
+2. **Entrainement du reward model** : un modele entraine a predire les preferences humaines a partir de comparaisons par paires
+3. **Optimisation par PPO** : le LLM est affiné pour maximiser la recompense du reward model, tout en restant proche du modele initial (KL-penalite = trust region)
+
+Le lien avec ce notebook est direct : le LLM est la **politique** pi_theta, les tokens generés sont les **actions**, et le reward model fournit le **signal de recompense**. Le clipping PPO empeche le modele de trop devier du comportement appris en pre-entrainement -- exactement le mecanisme de stabilite que vous avez observe sur CartPole.
+
+> **Pour approfondir** : la serie [GenAI / Texte](../GenAI/Texte/README.md) couvre les modeles de langage et leurs applications. Pour l'application **directe** du PPO a l'alignement des LLM, la serie [GenAI / PostTraining](../GenAI/PostTraining/PT_01_intro_post_training.ipynb) implemente pas a pas le pipeline RLHF puis ses variantes modernes (DPO dans [PT_03](../GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb), GRPO dans [PT_04](../GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb), RLVR dans [PT_05](../GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb)) -- le PPO de ce notebook en est le moteur.",,,,,,,,8bfa537c38dcd121,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6c_ppo_from_scratch.ipynb,f7fa2f52,markdown,fr,c254f8b334c35c12,"## Conclusion
+
+Dans ce notebook, nous avons :
+
+| Concept | Ce que nous avons fait |
+|---------|----------------------|
+| **Clipped surrogate** | Implemente et visualise le mecanisme de clipping |
+| **PPO Agent** | Implementation complete avec mini-lots et epochs |
+| **GAE** | Utilise Generalized Advantage Estimation (lambda=0.95) |
+| **Comparaison A2C vs PPO** | Analyse des differences de stabilite |
+
+### Points cles a retenir
+
+1. **Le clipping est simple mais puissant** : une seule ligne de code `torch.clamp(ratio, 1-eps, 1+eps)` stabilise l'apprentissage
+2. **Les mini-lots et epochs** permettent de reutiliser les donnees collectees, ameliorant l'efficacite d'echantillonnage par rapport a A2C
+3. **GAE** offre un compromis biais-variance controle par lambda
+4. **PPO est l'algorithme de choix** pour le RL moderne (RLHF, robotics, jeux)
+
+### Pour aller plus loin
+
+- **PPO continu** : adapter aux espaces d'actions continus (GaussianDistribution)
+- **Reward shaping** : transformer la fonction de recompense pour guider l'apprentissage
+- **Parallelisation** : A3C (asynchronous) et PPO vectorise
+- **Applications** : RLHF pour les LLMs, robotique, jeux complexes
+
+
+### References academiques
+
+- Schulman, J., Wolski, F., Dhariwal, P., Radford, A. & Klimov, O. (2017). Proximal Policy Optimization Algorithms. arXiv:1707.06347.
+- Schulman, J., Moritz, P., Levine, S., Jordan, M. & Abbeel, P. (2016). High-Dimensional Continuous Control Using Generalized Advantage Estimation. ICLR 2016. arXiv:1506.02438.
+- Mnih, V., Badia, A.P., Mirza, M., Graves, A., Lillicrap, T., Harley, T., Silver, D. & Kavukcuoglu, K. (2016). Asynchronous Methods for Deep Reinforcement Learning. ICML 2016. arXiv:1602.01783.
+- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press.
+
+",,,,,,,,c254f8b334c35c12,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,8dc35897,code,fr,443d9b6ddb12e9aa,"import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torch.distributions import Normal
+import gymnasium as gym
+import numpy as np
+import matplotlib.pyplot as plt
+from collections import deque
+import os
+
+# Reproductibilite
+torch.manual_seed(42)
+np.random.seed(42)
+
+print(f""Imports OK : PyTorch {torch.__version__}, Gymnasium {gym.__version__}"")
+
+# Dimensions de l'environnement Pendulum-v1
+env = gym.make(""Pendulum-v1"")
+state_dim = env.observation_space.shape[0]
+action_dim = env.action_space.shape[0]
+max_action = float(env.action_space.high[0])
+print(f""Environnement : Pendulum-v1 | State dim : {state_dim} | Action dim : {action_dim} | Max action : {max_action}"")
+env.close()",,,,,,,,443d9b6ddb12e9aa,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,6ff0c603,code,fr,427f65e1ba53956f,"def visualize_entropy():
+    """"""Compare l'entropie de distributions deterministes vs stochastiques.""""""
+    fig, axes = plt.subplots(1, 3, figsize=(14, 4))
+    x = np.linspace(-4, 4, 200)
+    
+    # Deterministe (delta de Dirac approxime par sigma tres petit)
+    sigma_det = 0.1
+    y_det = np.exp(-0.5 * (x / sigma_det)**2) / (sigma_det * np.sqrt(2 * np.pi))
+    axes[0].plot(x, y_det, 'r-', linewidth=2)
+    axes[0].set_title(f'Deterministe\nsigma={sigma_det}, H ~ 0.6')
+    axes[0].set_ylim(0, 5)
+    axes[0].fill_between(x, y_det, alpha=0.3, color='red')
+    
+    # Stochastique (sigma moyen)
+    sigma_mid = 1.0
+    y_mid = np.exp(-0.5 * (x / sigma_mid)**2) / (sigma_mid * np.sqrt(2 * np.pi))
+    entropy_mid = 0.5 * np.log(2 * np.pi * np.e * sigma_mid**2)
+    axes[1].plot(x, y_mid, 'b-', linewidth=2)
+    axes[1].set_title(f'Stochastique\nsigma={sigma_mid}, H = {entropy_mid:.2f}')
+    axes[1].set_ylim(0, 5)
+    axes[1].fill_between(x, y_mid, alpha=0.3, color='blue')
+    
+    # Tres exploratoire (sigma grand)
+    sigma_high = 2.0
+    y_high = np.exp(-0.5 * (x / sigma_high)**2) / (sigma_high * np.sqrt(2 * np.pi))
+    entropy_high = 0.5 * np.log(2 * np.pi * np.e * sigma_high**2)
+    axes[2].plot(x, y_high, 'g-', linewidth=2)
+    axes[2].set_title(f'Haute entropie\nsigma={sigma_high}, H = {entropy_high:.2f}')
+    axes[2].set_ylim(0, 5)
+    axes[2].fill_between(x, y_high, alpha=0.3, color='green')
+    
+    for ax in axes:
+        ax.set_xlabel('Action')
+        ax.set_ylabel('Densite')
+        ax.grid(True, alpha=0.3)
+    
+    plt.suptitle('Entropie et exploration : plus sigma est grand, plus l\'agent explore',
+                 fontsize=13, fontweight='bold')
+    plt.tight_layout()
+    plt.show()
+
+visualize_entropy()
+print(""Visualisation generee : l'entropie croit avec sigma (ecart-type de la politique)"")",,,,,,,,427f65e1ba53956f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,9632e2e3,code,fr,4d6a605688ede7f8,"class ReplayBuffer:
+    """"""Buffer circulaire pour stocker les transitions (off-policy).""""""
+
+    def __init__(self, capacity, state_dim, action_dim):
+        self.capacity = capacity
+        self.ptr = 0
+        self.size = 0
+        self.states = np.zeros((capacity, state_dim), dtype=np.float32)
+        self.actions = np.zeros((capacity, action_dim), dtype=np.float32)
+        self.rewards = np.zeros((capacity, 1), dtype=np.float32)
+        self.next_states = np.zeros((capacity, state_dim), dtype=np.float32)
+        self.dones = np.zeros((capacity, 1), dtype=np.float32)
+
+    def push(self, state, action, reward, next_state, done):
+        """"""Ajoute une transition au buffer.""""""
+        self.states[self.ptr] = state
+        self.actions[self.ptr] = action
+        self.rewards[self.ptr] = reward
+        self.next_states[self.ptr] = next_state
+        self.dones[self.ptr] = done
+        self.ptr = (self.ptr + 1) % self.capacity
+        self.size = min(self.size + 1, self.capacity)
+
+    def sample(self, batch_size):
+        """"""Echantillonne un mini-lot uniformement.""""""
+        idx = np.random.randint(0, self.size, size=batch_size)
+        return (
+            torch.FloatTensor(self.states[idx]),
+            torch.FloatTensor(self.actions[idx]),
+            torch.FloatTensor(self.rewards[idx]),
+            torch.FloatTensor(self.next_states[idx]),
+            torch.FloatTensor(self.dones[idx])
+        )
+
+
+# Verification
+buf = ReplayBuffer(capacity=100, state_dim=3, action_dim=1)
+buf.push(np.array([1.0, 0.0, 0.5]), np.array([0.3]), 1.0, np.array([1.1, 0.1, 0.4]), 0.0)
+print(f""ReplayBuffer defini : capacity=10000, state_dim={state_dim}, action_dim={action_dim}"")
+print(f""Test push OK : size={buf.size}, ptr={buf.ptr}"")",,,,,,,,4d6a605688ede7f8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,d2613c62,code,fr,8224290d893be245,"LOG_STD_MIN = -20
+LOG_STD_MAX = 2
+EPSILON = 1e-6
+
+
+class GaussianPolicy(nn.Module):
+    """"""Politique gaussienne avec squashing tanh pour actions continues.""""""
+
+    def __init__(self, state_dim, action_dim, hidden_dim=64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+        )
+        self.mean_linear = nn.Linear(hidden_dim, action_dim)
+        self.log_std_linear = nn.Linear(hidden_dim, action_dim)
+
+    def forward(self, state):
+        """"""Retourne une action echantillonnee, sa log-prob et la moyenne.""""""
+        x = self.net(state)
+        mean = self.mean_linear(x)
+        log_std = self.log_std_linear(x)
+        log_std = torch.clamp(log_std, LOG_STD_MIN, LOG_STD_MAX)
+        std = torch.exp(log_std)
+
+        # Reparameterisation : u = mu + sigma * epsilon
+        normal = Normal(mean, std)
+        u = normal.rsample()  # differentiable sample
+        a = torch.tanh(u)     # squashing dans [-1, 1]
+
+        # Correction du log_prob pour le changement de variable
+        log_prob = normal.log_prob(u) - torch.log(1 - a.pow(2) + EPSILON)
+        log_prob = log_prob.sum(dim=-1, keepdim=True)
+
+        return a, log_prob, mean
+
+    def get_action(self, state, deterministic=False):
+        """"""Selectionne une action pour l'evaluation.""""""
+        state_t = torch.FloatTensor(state).unsqueeze(0)
+        with torch.no_grad():
+            if deterministic:
+                x = self.net(state_t)
+                mean = self.mean_linear(x)
+                return torch.tanh(mean).cpu().numpy().flatten()
+            else:
+                a, _, _ = self.forward(state_t)
+                return a.cpu().numpy().flatten()
+
+
+# Verification
+policy = GaussianPolicy(state_dim, action_dim, hidden_dim=64)
+test_state = torch.randn(1, state_dim)
+a, logp, mu = policy(test_state)
+n_params = sum(p.numel() for p in policy.parameters())
+print(f""GaussianPolicy defini : input={state_dim}, output={action_dim}, hidden=64"")
+print(f""Action echantillonnee : {a.detach().numpy().flatten()} (dans [-1,1] : {bool(np.all(np.abs(a.detach().numpy()) <= 1+EPSILON))})"")
+print(f""Log-prob : {logp.item():.4f} | Moyenne : {mu.detach().numpy().flatten()}"")
+print(f""Nombre de parametres : {n_params}"")",,,,,,,,8224290d893be245,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,689497a6,code,fr,466d0668b06157fd,"class TwinQNetwork(nn.Module):
+    """"""Double Q-network pour SAC (reduit la surestimation).""""""
+
+    def __init__(self, state_dim, action_dim, hidden_dim=64):
+        super().__init__()
+        # Q1
+        self.q1 = nn.Sequential(
+            nn.Linear(state_dim + action_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1)
+        )
+        # Q2 (architecture identique, poids differents)
+        self.q2 = nn.Sequential(
+            nn.Linear(state_dim + action_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1)
+        )
+
+    def forward(self, state, action):
+        """"""Retourne Q1(s,a) et Q2(s,a).""""""
+        sa = torch.cat([state, action], dim=-1)
+        q1 = self.q1(sa)
+        q2 = self.q2(sa)
+        return q1, q2
+
+
+# Verification
+twin_q = TwinQNetwork(state_dim, action_dim, hidden_dim=64)
+test_action = torch.randn(1, action_dim)
+q1, q2 = twin_q(test_state, test_action)
+n_params_q = sum(p.numel() for p in twin_q.parameters())
+print(f""TwinQNetwork defini : input=({state_dim}+{action_dim}), output=1 x 2"")
+print(f""Q1 = {q1.item():.4f}, Q2 = {q2.item():.4f}, min(Q1,Q2) = {min(q1.item(), q2.item()):.4f}"")
+print(f""Nombre de parametres : {n_params_q}"")",,,,,,,,466d0668b06157fd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,ebe29eb4,code,fr,50b70a156bfd23bb,"class SACAgent:
+    """"""Agent Soft Actor-Critic avec temperature automatique.""""""
+
+    def __init__(self, state_dim, action_dim, hidden_dim=64, lr=3e-4,
+                 gamma=0.99, tau=0.005, alpha_lr=3e-4,
+                 target_entropy=None):
+        self.gamma = gamma
+        self.tau = tau
+        self.action_dim = action_dim
+
+        # Reseaux
+        self.policy = GaussianPolicy(state_dim, action_dim, hidden_dim)
+        self.critic = TwinQNetwork(state_dim, action_dim, hidden_dim)
+        self.critic_target = TwinQNetwork(state_dim, action_dim, hidden_dim)
+        # Copier les poids du critic vers la cible
+        self.critic_target.load_state_dict(self.critic.state_dict())
+
+        # Optimizers
+        self.policy_optimizer = optim.Adam(self.policy.parameters(), lr=lr)
+        self.critic_optimizer = optim.Adam(self.critic.parameters(), lr=lr)
+
+        # Temperature automatique
+        if target_entropy is None:
+            target_entropy = -action_dim  # heuristique standard
+        self.target_entropy = target_entropy
+        self.log_alpha = torch.zeros(1, requires_grad=True)
+        self.alpha_optimizer = optim.Adam([self.log_alpha], lr=alpha_lr)
+
+    @property
+    def alpha(self):
+        return self.log_alpha.exp()
+
+    def select_action(self, state, deterministic=False):
+        """"""Selectionne une action pour l'environnement.""""""
+        state_t = torch.FloatTensor(state).unsqueeze(0)
+        with torch.no_grad():
+            if deterministic:
+                x = self.policy.net(state_t)
+                mean = self.policy.mean_linear(x)
+                action = torch.tanh(mean)
+            else:
+                action, _, _ = self.policy(state_t)
+        return action.cpu().numpy().flatten() * max_action
+
+    def update(self, batch):
+        """"""Effectue une mise a jour SAC sur un mini-lot.""""""
+        states, actions, rewards, next_states, dones = batch
+
+        # --- Mise a jour du Critic ---
+        with torch.no_grad():
+            # Echantillonner a' depuis la politique
+            next_actions, next_log_probs, _ = self.policy(next_states)
+            # Q-cible = min(Q1_target, Q2_target)
+            q1_target, q2_target = self.critic_target(next_states, next_actions)
+            q_target = torch.min(q1_target, q2_target)
+            # Cible avec entropie
+            y = rewards + self.gamma * (1 - dones) * (
+                q_target - self.alpha * next_log_probs
+            )
+
+        q1, q2 = self.critic(states, actions)
+        critic_loss = F.mse_loss(q1, y) + F.mse_loss(q2, y)
+
+        self.critic_optimizer.zero_grad()
+        critic_loss.backward()
+        self.critic_optimizer.step()
+
+        # --- Mise a jour de l'Actor ---
+        new_actions, log_probs, _ = self.policy(states)
+        q1_new, q2_new = self.critic(states, new_actions)
+        q_new = torch.min(q1_new, q2_new)
+
+        policy_loss = (self.alpha * log_probs - q_new).mean()
+
+        self.policy_optimizer.zero_grad()
+        policy_loss.backward()
+        self.policy_optimizer.step()
+
+        # --- Mise a jour de la temperature ---
+        alpha_loss = -(self.log_alpha * (log_probs + self.target_entropy).detach()).mean()
+
+        self.alpha_optimizer.zero_grad()
+        alpha_loss.backward()
+        self.alpha_optimizer.step()
+
+        # --- Soft update des target networks ---
+        for param, target_param in zip(self.critic.parameters(),
+                                       self.critic_target.parameters()):
+            target_param.data.copy_(
+                self.tau * param.data + (1 - self.tau) * target_param.data
+            )
+
+        return {
+            'critic_loss': critic_loss.item(),
+            'policy_loss': policy_loss.item(),
+            'alpha': self.alpha.item(),
+            'alpha_loss': alpha_loss.item()
+        }
+
+
+# Verification
+agent = SACAgent(state_dim, action_dim, hidden_dim=64)
+test_action_env = agent.select_action(np.random.randn(state_dim))
+print(f""SACAgent defini : hidden=64, gamma=0.99, tau=0.005, lr=3e-4"")
+print(f""Action de test : {test_action_env} (dans [-{max_action}, {max_action}])"")
+print(f""Alpha initial : {agent.alpha.item():.4f} | Entropie cible : {agent.target_entropy}"")
+print(f""Politique : {sum(p.numel() for p in agent.policy.parameters())} params"")
+print(f""Critic : {sum(p.numel() for p in agent.critic.parameters())} params"")",,,,,,,,50b70a156bfd23bb,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,3f38a421,code,fr,d9bbb38cb100a46c,"def train_sac(env_name=""Pendulum-v1"", num_episodes=200, batch_size=64,
+              replay_size=10000, start_steps=1000, print_every=50,
+              hidden_dim=64, seed=42):
+    """"""Entraine un agent SAC sur un environnement continu.""""""
+    # Reproductibilite
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    env = gym.make(env_name)
+    s_dim = env.observation_space.shape[0]
+    a_dim = env.action_space.shape[0]
+    max_a = float(env.action_space.high[0])
+
+    agent = SACAgent(s_dim, a_dim, hidden_dim=hidden_dim)
+    buffer = ReplayBuffer(replay_size, s_dim, a_dim)
+
+    episode_rewards = []
+    total_steps = 0
+    episode = 0
+    state, _ = env.reset(seed=seed)
+    episode_reward = 0
+
+    while episode < num_episodes:
+        # Phase d'exploration initiale (actions aleatoires)
+        if total_steps < start_steps:
+            action = env.action_space.sample()
+        else:
+            action = agent.select_action(state, deterministic=False)
+
+        next_state, reward, terminated, truncated, _ = env.step(action)
+        done = terminated or truncated
+
+        # Normaliser l'action pour le buffer (dans [-1, 1])
+        action_norm = action / max_a
+        buffer.push(state, action_norm, reward, next_state, float(done))
+
+        state = next_state
+        episode_reward += reward
+        total_steps += 1
+
+        # Mise a jour si assez de donnees
+        if buffer.size >= batch_size:
+            batch = buffer.sample(batch_size)
+            agent.update(batch)
+
+        if done:
+            episode_rewards.append(episode_reward)
+            episode += 1
+            state, _ = env.reset()
+            episode_reward = 0
+
+            if episode % print_every == 0:
+                recent = episode_rewards[-print_every:]
+                mean_r = np.mean(recent)
+                alpha_val = agent.alpha.item()
+                print(f""Episode {episode:3d}/{num_episodes} | ""
+                      f""Mean reward: {mean_r:7.1f} | ""
+                      f""Alpha: {alpha_val:.4f} | ""
+                      f""Steps: {total_steps}"")
+
+    env.close()
+    return agent, episode_rewards
+
+
+print(""Fonction train_sac definie : 200 episodes, batch=64, replay=10000"")",,,,,,,,d9bbb38cb100a46c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,55a95827,code,fr,8d6d7284680d532e,"# Entrainement SAC
+sac_agent, sac_rewards = train_sac(num_episodes=200, print_every=50)
+
+print(f""\nEntrainement termine : {len(sac_rewards)} episodes"")
+print(f""Recompense moyenne (derniers 50) : {np.mean(sac_rewards[-50:]):.1f}"")
+print(f""Recompense max : {np.max(sac_rewards):.0f}"")
+print(f""Alpha final : {sac_agent.alpha.item():.4f}"")",,,,,,,,8d6d7284680d532e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,90b1c609,code,fr,f9df7576d5e605d7,"def plot_sac_rewards(rewards, title=""Courbe d'apprentissage SAC sur Pendulum-v1""):
+    """"""Affiche la courbe d'apprentissage avec moyenne mobile.""""""
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(rewards, alpha=0.3, color='steelblue', label='Recompense par episode')
+    window = 20
+    if len(rewards) >= window:
+        moving_avg = np.convolve(rewards, np.ones(window)/window, mode='valid')
+        ax.plot(range(window-1, len(rewards)), moving_avg,
+                color='darkred', linewidth=2, label=f'Moyenne mobile (n={window})')
+    ax.axhline(y=-200, color='green', linestyle='--', alpha=0.5,
+               label='Seuil Pendulum (-200)')
+    ax.set_xlabel('Episode')
+    ax.set_ylabel('Recompense cumulative')
+    ax.set_title(title)
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.show()
+
+
+plot_sac_rewards(sac_rewards)
+print(f""Visualisation generee. Reward moyen final (20 ep) : ""
+      f""{np.mean(sac_rewards[-20:]):.1f}"")",,,,,,,,f9df7576d5e605d7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,0295506f,code,fr,56152c63ce96aa5a,"# Exercice 1 : Planification lineaire de la temperature alpha
+#
+# Implementez une version de SAC avec alpha decroissant lineairement.
+#
+# Indice : Partez de SACAgent et ajoutez un flag use_auto_alpha=False
+# Indice : Dans la boucle d'entrainement, calculez alpha a chaque episode
+# Etape 1 : Creez une classe SACAgentFixedAlpha ou ajoutez un parametre au SACAgent
+# Etape 2 : Ecrivez une boucle d'entrainement qui ajuste alpha lineairement
+# Etape 3 : Tracez la courbe et comparez avec auto-tuning
+
+def train_sac_linear_alpha(env_name=""Pendulum-v1"", num_episodes=200,
+                           alpha_start=0.5, alpha_end=0.05):
+    """"""
+    Entraine SAC avec temperature decroissant lineairement.
+
+    # Indice : alpha_schedule = alpha_start + (alpha_end - alpha_start) * episode / num_episodes
+    # Etape 1 : Initialisez l'agent et le buffer
+    # Etape 2 : Dans la boucle, forcez agent.log_alpha = log(alpha_schedule)
+    # Etape 3 : Enregistrez les rewards et retournez la liste
+    """"""
+    rewards = None  # TODO etudiant : retourner la liste des rewards
+    return rewards
+
+
+print(""Exercice a completer : implementer la planification lineaire de alpha"")",,,,,,,,56152c63ce96aa5a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,e96f47d0,code,fr,d5a9de0e1e26bfd1,"# Exercice 2 : Ablation twin Q-networks
+#
+# Comparez SAC avec twin Q (min Q1, Q2) vs single Q (Q1 uniquement).
+#
+# Indice : Modifiez la methode update() de SACAgent pour n'utiliser que Q1
+# Indice : Gardez les memes hyperparametres pour une comparaison equitable
+# Etape 1 : Creez une version SingleQSACAgent ou modifiez SACAgent.update
+# Etape 2 : Entrainez sur 200 episodes
+# Etape 3 : Tracez les deux courbes (twin vs single) sur le meme graphe
+
+def train_sac_single_q(env_name=""Pendulum-v1"", num_episodes=200):
+    """"""
+    Entraine SAC avec un seul Q-network (pas de min Q1,Q2).
+
+    # Indice : Utilisez uniquement Q1 pour la cible et la mise a jour
+    # Etape 1 : Initialisez un agent SAC (vous pouvez reutiliser TwinQNetwork en ignorant Q2)
+    # Etape 2 : Dans update(), utilisez q1_target au lieu de min(q1_target, q2_target)
+    # Etape 3 : Comparez les resultats avec la version twin
+    """"""
+    rewards = None  # TODO etudiant : retourner la liste des rewards
+    return rewards
+
+
+print(""Exercice a completer : ablation twin Q-networks"")",,,,,,,,d5a9de0e1e26bfd1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,2614768a,code,fr,ae48e8c1bdf03770,"# Exercice 3 : Adapter SAC a LunarLanderContinuous-v2
+#
+# Modifiez les dimensions et parametres pour un nouvel environnement.
+#
+# Indice : Verifiez d'abord si l'environnement est disponible
+# Indice : Si box2d n'est pas installe, utilisez Pendulum avec hidden_dim=32 et 128
+# Etape 1 : Creez l'environnement et relevez les dimensions
+# Etape 2 : Initialisez un SACAgent adapte
+# Etape 3 : Entrainez et comparez avec Pendulum-v1
+
+try:
+    test_env = gym.make(""LunarLanderContinuous-v2"")
+    target_env = ""LunarLanderContinuous-v2""
+    test_env.close()
+except Exception:
+    target_env = ""Pendulum-v1 (hidden_dim=32)""
+    print(""LunarLanderContinuous-v2 non disponible, utilisez Pendulum avec hidden_dim=32"")
+
+print(f""Environnement cible : {target_env}"")
+print(""Exercice a completer : adapter SAC a un nouvel environnement"")",,,,,,,,ae48e8c1bdf03770,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb,28ac4bae,markdown,fr,2a09de8c59df1ff4,"## Application : RL pour le trading algorithmique
+
+Le RL avec actions continues est directement applicable au **trading algorithmique**. Dans un contexte financier :
+
+- **Etat** : prix de marche, indicateurs techniques, position du portefeuille
+- **Action** : quantite a acheter/vendre (action continue, comme dans SAC)
+- **Recompense** : rendement ajuste du risque (Sharpe ratio, PnL)
+- **Environnement** : simulateur de marche avec couts de transaction
+
+Les algorithmes off-policy comme SAC sont particulierement adaptes : le replay buffer permet de reutiliser les donnees historiques de marche, et la gestion automatique de la temperature aide a explorer les strategies dans un environnement non-stationnaire.
+
+> **Pour approfondir** : la serie [QuantConnect](../QuantConnect/README.md) implemente des strategies de trading algorithmique. Le pipeline [ML-Training-Pipeline](../QuantConnect/ML-Training-Pipeline/README.md) entraine notamment des modeles RL (PPO, Decision Transformer) pour l'allocation de portefeuille. Pour voir le RL (PPO/SAC) applique a un environnement de marche concret, le notebook [research_rl_ppo](../QuantConnect/research/research_rl_ppo.ipynb) construit un agent de trading RL bout-en-bout (etat = fenetre de prix, action = signal long/short, recompense = Sharpe ajuste du risque).",,,,,,,,2a09de8c59df1ff4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,1dda5f94,markdown,fr,5122302d555968bc,"# GRPO (Group Relative Policy Optimization) depuis zero
+
+> **Serie RL from scratch** | [RL-6c PPO](rl_6c_ppo_from_scratch.ipynb) · [RL-6d SAC](rl_6d_sac_from_scratch.ipynb) · **RL-6e GRPO**
+>
+> **Track 4 Epic #1454.** GRPO est l'algorithme cle de l'entrainement par renforcement de **DeepSeek-R1**
+> (DeepSeek-AI, 2025). Ce notebook l'implemente **depuis zero** (PyTorch CPU), sur un environnement
+> **auto-contenu** (portefeuille synthetique, aucune dependance de donnees), dans la lignee de
+> [RL-6c PPO](rl_6c_ppo_from_scratch.ipynb) et [RL-6d SAC](rl_6d_sac_from_scratch.ipynb).
+
+**Duree estimee** : 45 minutes
+**Prerequis** : [RL-6c -- PPO depuis zero](rl_6c_ppo_from_scratch.ipynb) (ratio clippe, trust region)
+
+## Objectifs
+
+- Comprendre l'innovation centrale de **GRPO** : se passer de **critic** (reseau de valeur) en
+  estimant l'avantage par **normalisation intra-groupe** de G trajectoires
+- Implementer le cycle GRPO complet : echantillonnage d'un **groupe** de G trajectoires, avantage
+  relatif $A_i = (R_i - \bar{R}) / \sigma_R$, mise a jour **PPO-clip + penalite KL** vs politique de reference
+- Comparer GRPO a une **baseline equal-weight** sur un portefeuille synthetique, multi-seed, verdict honnete
+",,,,,,,,5122302d555968bc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,f2ccfcab,markdown,fr,e2084cc9fa24ae8b,"## 1. Pourquoi GRPO ? L'avantage relatif sans critic
+
+PPO ([RL-6c](rl_6c_ppo_from_scratch.ipynb)) et SAC ([RL-6d](rl_6d_sac_from_scratch.ipynb)) estiment
+l'avantage avec un **reseau de valeur** (critic) appris en parallele de la politique : $A(s,a) = R + \gamma V(s') - V(s)$.
+Ce double reseau double la memoire, les hyperparametres, et l'instabilite (le critic doit etre juste
+pour que l'avantage soit interpretable).
+
+**GRPO supprime le critic.** A la place, pour chaque etat (ou prompt, dans le cas LLM), on echantillonne
+**G trajectoires** issues de la meme politique. L'avantage de la trajectoire $i$ est sa **position relative**
+dans le groupe :
+
+$$A_i = \frac{R_i - \bar{R}}{\sigma_R + \epsilon}, \quad \bar{R} = \frac{1}{G}\sum_{j=1}^G R_j$$
+
+L'idee : pas besoin d'estimer une valeur absolue $V(s)$ -- il suffit de savoir si une trajectoire est
+**meilleure ou pire que les autres** partant de la meme situation. La **baseline est implicite** dans la moyenne du groupe.
+
+| Aspect | PPO / SAC | GRPO |
+|--------|-----------|------|
+| Reseau de valeur (critic) | **Oui** (2 reseaux) | **Non** (1 seul reseau) |
+| Avantage | GAE ($\lambda$-returns) | Normalisation intra-groupe |
+| Stabilisation | Clip + entropy | **Clip + KL vs reference** + baseline groupe |
+| Cout par update | 1 rollout | G rollouts (groupe) |
+| Domaine historique | Controle (Atari, MuJoCo) | **LLM reasoning** (DeepSeek-R1, o1) |
+
+GRPO paie son absence de critic par un **cout d'echantillonnage** (G rollouts au lieu d'1), mais
+gagne en simplicite et stabilite -- c'est pourquoi il a remplace le PPO standard dans l'entrainement
+des LLM reasoning post-DeepSeek-R1.
+",,,,,,,,e2084cc9fa24ae8b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,4cbbc08a,code,fr,acd0f708a5135ffd,"# --- Imports + configuration (config legeres pour CPU pedagogique) ---
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import matplotlib.pyplot as plt
+import warnings
+warnings.filterwarnings(""ignore"")
+
+# Config GRPO (allegee vs le notebook de recherche QC : 4 seeds x 120 eps x 8 grp x 252 steps
+# serait ~15-40 min CPU ; ici on vise ~2-4 min pour la pedagogie, multi-seed honnete conserve).
+SEEDS = [0, 7, 42]          # 3 seeds (G.2 multi-seed, edge >= 2 sigma)
+N_ASSETS = 4                # portefeuille synthetique a 4 actifs
+LOOKBACK = 12               # fenetre d'observation (etats = lookback x n_assets)
+N_EPISODES = 50             # iterations d'entrainement par seed
+EPISODE_LEN = 60            # longueur d'une trajectoire (pas de trading)
+GROUP_SIZE = 6              # G : nombre de trajectoires echantillonnees par iteration (le coeur GRPO)
+HIDDEN_DIM = 64
+LR = 3e-4
+CLIP_EPS = 0.2              # trust region PPO (cf RL-6c)
+KL_COEF = 0.05              # penalite KL vs politique de reference (stabilite GRPO)
+ENTROPY_COEF = 0.01         # bonus d'entropie (exploration)
+FEE_BPS = 10                # frais de transaction (10 bps par rebalancement)
+
+print(f""PyTorch {torch.__version__}, CUDA={torch.cuda.is_available()}"")
+print(f""GRPO config: G={GROUP_SIZE} trajectoires/groupe, {N_EPISODES} episodes, seeds={SEEDS}"")
+",,,,,,,,acd0f708a5135ffd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,ad2f3ffe,markdown,fr,6dadf911340ba965,"## 2. Environnement Portfolio synthetique (auto-contenu)
+
+On genere un portefeuille de `N_ASSETS` actifs aux rendements **moyenne-reversants bruites**
+(processus proche d'Ornstein-Uhlenbeck). Aucun fichier externe -- les rendements sont tires d'un
+generateur aleatoire controle par la seed, ce qui rend le notebook **reproductible et executable
+partout** (pas de dependance donnees QC).
+
+- **Etat** : fenetre des `LOOKBACK` derniers rendements standardises, applatie `(LOOKBACK x N_ASSETS,)`.
+- **Action** : poids du portefeuille $\in \Delta_{N}$ (simplexe : positifs, somme a 1) -- valide pour toute politique.
+- **Recompense (pas $t$)** : rendement du portefeuille $w^T r_t$ moins les frais de transaction.
+- **Retour d'episode** : ratio de Sharpe annualise du portefeuille (moyenne / ecart-type des rendements de pas).
+
+C'est le meme squelette que le notebook de recherche QC (`PortfolioEnv`), mais sur donnees synthetiques.
+",,,,,,,,6dadf911340ba965,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,45b58342,code,fr,1f675512efa79728,"class SyntheticPortfolioEnv:
+    '''Portefeuille multi-actifs a rendements moyenne-reversants (synthetique, auto-contenu).'''
+
+    def __init__(self, n_assets=4, lookback=12, episode_len=60, fee_bps=10, seed=0):
+        self.rng = np.random.default_rng(seed)
+        self.n_assets = n_assets
+        self.lookback = lookback
+        self.episode_len = episode_len
+        self.fee = fee_bps / 10000.0
+        # Genere N_DAYS rendements moyenne-reversants : r_t = kappa*(mu - r_{t-1}) + sigma * eps.
+        n_days = max(2000, lookback + episode_len + 50)
+        kappa, sigma = 0.05, 0.012
+        mu = self.rng.normal(0.0, 0.0004, size=n_assets)  # petites dérives par actif
+        rets = np.zeros((n_days, n_assets))
+        r = np.zeros(n_assets)
+        for t in range(n_days):
+            r = r + kappa * (mu - r) + sigma * self.rng.standard_normal(n_assets)
+            rets[t] = r
+        self.returns = rets
+        self._idx = None
+        self._prev_weights = np.full(n_assets, 1.0 / n_assets)
+
+    @property
+    def state_dim(self):
+        return self.lookback * self.n_assets
+
+    @property
+    def action_dim(self):
+        return self.n_assets
+
+    def reset(self, start_idx=None):
+        max_start = len(self.returns) - self.lookback - self.episode_len - 1
+        start_idx = int(self.rng.integers(self.lookback, max(max_start, self.lookback + 1)))
+        self._idx = start_idx
+        self._prev_weights = np.full(self.n_assets, 1.0 / self.n_assets)
+        return self._get_state()
+
+    def _get_state(self):
+        window = self.returns[self._idx - self.lookback:self._idx]
+        std = window.std(axis=0, keepdims=True) + 1e-8
+        return (window / std).flatten()
+
+    def step(self, weights):
+        self._idx += 1
+        r = self.returns[self._idx]
+        port_ret = float(weights @ r)
+        turnover = float(np.abs(weights - self._prev_weights).sum())
+        cost = self.fee * turnover
+        self._prev_weights = weights
+        done = self._idx >= self._idx_0 + self.episode_len if hasattr(self, ""_idx_0"") else False
+        return self._get_state(), port_ret - cost, done
+
+    def set_horizon(self):
+        self._idx_0 = self._idx
+        return self
+
+# Test rapide : un episode equal-weight donne un Sharpe positif ou negatif selon la seed.
+env = SyntheticPortfolioEnv(N_ASSETS, LOOKBACK, EPISODE_LEN, FEE_BPS, seed=0)
+print(f""Env : {env.state_dim} dims d'etat, {env.action_dim} dims d'action, {len(env.returns)} jours synthetises"")
+",,,,,,,,1f675512efa79728,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,e1d9f781,markdown,fr,6ba50043417143d4,"## 3. Reseau de politique (Actor seul -- pas de Critic)
+
+GRPO n'a besoin que d'un **policy network**. L'avantage vient du groupe, pas d'un critic.
+
+L'actor produit les **concentrations** d'une distribution **Dirichlet** (toujours valides sur le simplexe :
+positives, somme a 1). On ajoute une concentration de base apprise pour stabiliser l'echantillonnage.
+",,,,,,,,6ba50043417143d4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,ca135b04,code,fr,aa973979c2c428cc,"class GRPOPolicy(nn.Module):
+    '''Politique Dirichlet (policy-only) pour GRPO. Pas de reseau de valeur.'''
+
+    def __init__(self, state_dim, action_dim, hidden_dim=64):
+        super().__init__()
+        self.backbone = nn.Sequential(
+            nn.Linear(state_dim, hidden_dim), nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim), nn.ReLU(),
+        )
+        self.concentration_head = nn.Linear(hidden_dim, action_dim)
+        self.base_concentration = nn.Parameter(torch.ones(action_dim))
+
+    def forward(self, state):
+        feat = self.backbone(state)
+        raw = self.concentration_head(feat)
+        # softplus garantit des concentrations > 0 ; + base + epsilon pour stabilite
+        concentrations = torch.nn.functional.softplus(raw) + self.base_concentration + 0.1
+        return concentrations
+
+
+policy_test = GRPOPolicy(env.state_dim, env.action_dim, HIDDEN_DIM)
+n_params = sum(p.numel() for p in policy_test.parameters())
+print(f""GRPOPolicy : {n_params} parametres (policy-only, aucun critic)."")
+s_demo = torch.randn(1, env.state_dim)
+conc = policy_test(s_demo)
+print(f""Concentrations sorties (valides >0) : {conc.detach().numpy().round(2)}"")
+",,,,,,,,aa973979c2c428cc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,101bc26e,markdown,fr,a32db3308a3b6d7e,"## 4. La mise a jour GRPO : avantage relatif intra-groupe + clip + KL
+
+C'est le coeur de GRPO. Trois mecanismes combines :
+
+1. **Avantage relatif** : pour un groupe de G trajectoires echantillonnees par iteration,
+   $A_i = (R_i - \bar{R}) / \sigma_R$. Une trajectoire au-dessus de la moyenne du groupe obtient un
+   avantage positif (renforcee), en-dessous negatif (affaiblie). **Aucun critic necessaire.**
+2. **Ratio clippe (PPO)** : $\frac{\pi_\theta(a|s)}{\pi_{\theta_{old}}(a|s)}$ borne dans $[1-\epsilon, 1+\epsilon]$
+   pour empecher des mises a jour destructrices (cf [RL-6c](rl_6c_ppo_from_scratch.ipynb)).
+3. **Penalite KL vs reference** : $-\beta \, \mathrm{KL}(\pi_\theta \| \pi_{ref})$ garde la politique
+   proche de la politique de reference (snapshot en debut d'iteration), empechant l'effondrement
+   deterministe. C'est le **stabilisateur qui remplace le critic**.
+",,,,,,,,a32db3308a3b6d7e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,82676622,code,fr,86019938bd3d6093,"def grpo_update(policy, optimizer, states, actions, advantages, old_log_probs,
+                clip_eps=0.2, kl_coef=0.05, entropy_coef=0.01):
+    '''Une etape de mise a jour GRPO. Retourne (loss, kl, entropy).'''
+    # Nouvelles log-prob sous la politique courante
+    concentrations = policy(states)
+    dist = torch.distributions.Dirichlet(concentrations)
+    new_log_probs = dist.log_prob(actions)
+    entropy = dist.entropy().mean()
+
+    # Ratio et objectif clippe (PPO trust region)
+    ratio = torch.exp(new_log_probs - old_log_probs)
+    obj = ratio * advantages
+    obj_clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * advantages
+    policy_loss = -torch.min(obj, obj_clipped).mean()
+
+    # Penalite KL vs politique de reference (old policy) -- le stabilisateur GRPO.
+    # KL(Dirichlet(pi_new) || Dirichlet(pi_old)) approximee par la difference des log-probs.
+    kl = (old_log_probs - new_log_probs).mean().clamp(min=0.0)
+
+    loss = policy_loss + kl_coef * kl - entropy_coef * entropy
+    optimizer.zero_grad()
+    loss.backward()
+    nn.utils.clip_grad_norm_(policy.parameters(), 0.5)
+    optimizer.step()
+    return float(loss.detach()), float(kl.detach()), float(entropy.detach())
+
+print(""grpo_update defini : avantage relatif + clip PPO + penalite KL (pas de critic)."")
+",,,,,,,,86019938bd3d6093,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,cb21aa50,markdown,fr,13159152f1ec92c0,"## 5. Boucle d'entrainement GRPO multi-seed
+
+A chaque **episode** :
+1. On echantillonne un **groupe** de `GROUP_SIZE` trajectoires avec la politique courante.
+2. Pour chaque trajectoire, on enregistre (etat, action, log-prob, recompense par pas).
+3. Le **retour d'episode** $R_i$ = Sharpe du portefeuille sur la trajectoire.
+4. **Avantage de groupe** : $A_i = (R_i - \bar{R}) / \sigma_R$ -- chaque pas de la trajectoire $i$
+   recoit ce meme avantage (la trajectoire entiere est jugee relativement au groupe).
+5. Mise a jour GRPO (clip + KL + entropy).
+
+On boucle sur `SEEDS` pour evaluer la robustesse (G.2 : edge $\geq 2\sigma$ requis pour ""BEATS"").
+",,,,,,,,13159152f1ec92c0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,82ba36a5,code,fr,b13f3f98b97631e3,"def rollout_episode(env, policy, device=""cpu""):
+    '''U episode = 1 trajectoire. Retourne listes (states, actions, log_probs, step_rewards).'''
+    states, actions, log_probs, rewards = [], [], [], []
+    s = env.reset(); env.set_horizon()
+    for _ in range(env.episode_len):
+        st = torch.FloatTensor(s).unsqueeze(0).to(device)
+        with torch.no_grad():
+            conc = policy(st)
+            dist = torch.distributions.Dirichlet(conc)
+            w = dist.sample()
+            lp = dist.log_prob(w)
+        s_next, r, done = env.step(w.squeeze(0).cpu().numpy())
+        states.append(st); actions.append(w.squeeze(0)); log_probs.append(lp.squeeze(0)); rewards.append(r)
+        s = s_next
+    return states, actions, log_probs, rewards
+
+
+def episode_sharpe(rewards):
+    arr = np.asarray(rewards, dtype=float)
+    mu, sd = arr.mean(), arr.std() + 1e-8
+    return float(mu / sd)
+
+
+def train_grpo_one_seed(returns_seed, device=""cpu""):
+    '''Entrainement GRPO pour une seed de donnees. Retourne (policy, history).'''
+    torch.manual_seed(returns_seed); np.random.seed(returns_seed)
+    env = SyntheticPortfolioEnv(N_ASSETS, LOOKBACK, EPISODE_LEN, FEE_BPS, seed=returns_seed)
+    policy = GRPOPolicy(env.state_dim, env.action_dim, HIDDEN_DIM).to(device)
+    optimizer = optim.Adam(policy.parameters(), lr=LR)
+
+    history = {""ep"": [], ""group_mean_sharpe"": [], ""loss"": [], ""kl"": [], ""entropy"": []}
+    for ep in range(N_EPISODES):
+        # --- Groupe de G trajectoires (le coeur GRPO) ---
+        ep_states, ep_actions, ep_log_probs, ep_advantages = [], [], [], []
+        group_returns = []
+        for _ in range(GROUP_SIZE):
+            sts, acts, lps, rews = rollout_episode(env, policy, device)
+            group_returns.append(episode_sharpe(rews))
+            for st, a, lp in zip(sts, acts, lps):
+                ep_states.append(st); ep_actions.append(a); ep_log_probs.append(lp)
+        # Avantage relatif intra-groupe : A_i = (R_i - mean)/std, meme avantage sur toute la trajectoire i.
+        rets = np.asarray(group_returns)
+        mean_r, std_r = rets.mean(), rets.std() + 1e-8
+        advantages_per_traj = (rets - mean_r) / std_r
+        # Repete l'avantage de la trajectoire sur chacun de ses EPISODE_LEN pas.
+        for gi in range(GROUP_SIZE):
+            for _ in range(EPISODE_LEN):
+                ep_advantages.append(advantages_per_traj[gi])
+
+        states_t = torch.cat(ep_states, dim=0)
+        actions_t = torch.stack(ep_actions)
+        adv_t = torch.tensor(ep_advantages, dtype=torch.float32)             # (N,)
+        old_lp_t = torch.stack(ep_log_probs)                                 # (N,)
+
+        loss, kl, ent = grpo_update(policy, optimizer, states_t, actions_t, adv_t, old_lp_t,
+                                    CLIP_EPS, KL_COEF, ENTROPY_COEF)
+        history[""ep""].append(ep)
+        history[""group_mean_sharpe""].append(float(mean_r))
+        history[""loss""].append(loss); history[""kl""].append(kl); history[""entropy""].append(ent)
+    return policy, history
+
+print(""Boucle GRPO multi-seed definie. Lancement de l'entrainement (CPU, ~2-4 min)..."")
+",,,,,,,,b13f3f98b97631e3,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,318e6f29,code,fr,303cf464826a336e,"# --- Entrainement GRPO multi-seed (G.2 honnete) ---
+device = ""cpu""
+results = {}
+for seed in SEEDS:
+    policy, history = train_grpo_one_seed(seed, device=device)
+
+    # Benchmark GRPO (policy apprise) vs baseline equal-weight sur de nouveaux episodes.
+    env_eval = SyntheticPortfolioEnv(N_ASSETS, LOOKBACK, EPISODE_LEN, FEE_BPS, seed=seed + 1000)
+    def eval_policy(weights_fn, n_eval=20):
+        sharpes = []
+        for _ in range(n_eval):
+            s = env_eval.reset(); env_eval.set_horizon(); rews = []
+            for _ in range(env_eval.episode_len):
+                r = weights_fn(s)
+                s, rew, _ = env_eval.step(r); rews.append(rew)
+            sharpes.append(episode_sharpe(rews))
+        return float(np.mean(sharpes))
+
+    with torch.no_grad():
+        def grpo_weights(s):
+            st = torch.FloatTensor(s).unsqueeze(0)
+            conc = policy(st)
+            # Deterministe en eval : argmax de la Dirichlet normalise (= concentrations / somme).
+            w = conc.squeeze(0).detach().numpy(); w = np.clip(w, 1e-6, None); return w / w.sum()
+        def ew_weights(s):
+            return np.full(N_ASSETS, 1.0 / N_ASSETS)
+
+    sharpe_grpo = eval_policy(grpo_weights)
+    sharpe_ew = eval_policy(ew_weights)
+    results[seed] = {""policy"": policy, ""history"": history,
+                     ""sharpe_grpo"": sharpe_grpo, ""sharpe_ew"": sharpe_ew,
+                     ""delta_sharpe"": sharpe_grpo - sharpe_ew}
+    print(f""  seed {seed}: GRPO Sharpe={sharpe_grpo:+.3f} | equal-weight={sharpe_ew:+.3f} | ""
+          f""delta={sharpe_grpo - sharpe_ew:+.3f}"")
+print(""Entrainement termine."")
+",,,,,,,,303cf464826a336e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,94300362,markdown,fr,4feab4baf2701710,"## 6. Resultats et verdict GRPO
+
+Verdict honnete (G.2) sur le critere **edge $\geq 2\sigma$ cross-seed** :
+- **BEATS** : delta Sharpe moyen $\geq 2\sigma$ ET >= 2/3 seeds positifs vs equal-weight.
+- **NO BEATS** : aucune seed positive.
+- **INCONCLUSIVE** : sinon (bruit).
+",,,,,,,,4feab4baf2701710,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,6001a26e,code,fr,09d628d2707b722b,"# --- Verdict GRPO multi-seed ---
+deltas = [results[s][""delta_sharpe""] for s in SEEDS]
+mean_delta = float(np.mean(deltas))
+std_delta = float(np.std(deltas, ddof=1)) if len(deltas) > 1 else float(""nan"")
+sigma_edge = mean_delta / std_delta if std_delta and std_delta > 1e-9 else float(""nan"")
+n_pos = int(sum(1 for d in deltas if d > 0))
+
+print(""="" * 68)
+print(""VERDICT -- RL-6e : GRPO (Group Relative Policy Optimization) from scratch"")
+print(""="" * 68)
+print(f""GRPO Sharpe (moyenne cross-seed) : {np.mean([results[s]['sharpe_grpo'] for s in SEEDS]):+.3f}"")
+print(f""Equal-weight Sharpe (moyenne)    : {np.mean([results[s]['sharpe_ew'] for s in SEEDS]):+.3f}"")
+print(f""Delta Sharpe moyen               : {mean_delta:+.3f}"")
+print(f""Sigma edge                       : {sigma_edge:+.2f}"")
+print(f""Seeds positives vs equal-weight  : {n_pos}/{len(SEEDS)}"")
+
+if sigma_edge >= 2.0 and n_pos >= 2:
+    verdict = ""BEATS""
+elif n_pos == 0:
+    verdict = ""NO BEATS""
+else:
+    verdict = ""INCONCLUSIVE""
+print(f"">>> VERDICT: {verdict} <<<"")
+print()
+print(""Lecture : GRPO (sans critic, avantage relatif intra-groupe) apprend bien une politique"")
+print(f""de trading sur le portefeuille synthetique. Le verdict {verdict} reflete la difficulte a"")
+print(""battre une baseline equal-weight sur un marche moyenne-reversant bruite -- l'edge est"")
+print(""attendument marginal, comme pour tout RL de trading sans signal fort."")
+",,,,,,,,09d628d2707b722b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,4f853ec0,code,fr,e59f4e0cf551236f,"# --- Courbes d'apprentissage (Sharpe du groupe vs episodes) ---
+fig, axes = plt.subplots(1, len(SEEDS), figsize=(4 * len(SEEDS), 3.2), sharey=True)
+if len(SEEDS) == 1: axes = [axes]
+for ax, seed in zip(axes, SEEDS):
+    h = results[seed][""history""]
+    ax.plot(h[""ep""], h[""group_mean_sharpe""], color=""#2a6"", lw=1.5)
+    ax.axhline(0, color=""k"", lw=0.5, alpha=0.4)
+    ax.set_title(f""seed {seed}""); ax.set_xlabel(""episode"")
+    ax.grid(alpha=0.3)
+axes[0].set_ylabel(""Sharpe moyen du groupe (G trajectoires)"")
+fig.suptitle(""Apprentissage GRPO -- Sharpe intra-groupe par episode"", y=1.02)
+plt.tight_layout(); plt.show()
+print(""Courbes : le Sharpe du groupe doit montrer une dynamique d'apprentissage (variance/montee)."")
+",,,,,,,,e59f4e0cf551236f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,17d20cb6,markdown,fr,7d8b5dd31f859b5b,"## 7. Ce que GRPO change vs PPO/SAC
+
+| Question | PPO ([RL-6c](rl_6c_ppo_from_scratch.ipynb)) | SAC ([RL-6d](rl_6d_sac_from_scratch.ipynb)) | **GRPO** (ici) |
+|----------|------|------|------|
+| Critic ? | Oui ($V_\phi$) | Oui (Q double) | **Non** (groupe) |
+| Avantage | GAE | Entropie + Q | **Normalisation groupe** |
+| Stabilite | Clip | Entropie max | **KL vs reference** |
+| Rollouts/update | 1 | 1 | **G** |
+| Origine | OpenAI 2017 | Haarnoja 2018 | **DeepSeek-R1 2025** |
+
+**La lecon** : GRPO deplace le cout du critic (memoire + instabilite) vers l'echantillonnage
+(G rollouts). Sur LLM reasoning -- ou chaque ""prompt"" permet naturellement de sampler G completions --
+ce trade-off est gagnant. Sur controle classique (portefeuille ici), l'avantage relatif reste valide
+mais l'edge vs baseline est marginal : le groupe mesure la variance de la politique, pas un signal de marche.
+",,,,,,,,7d8b5dd31f859b5b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,19e01b26,markdown,fr,7eda5081b25d9c79,"## 8. Exercices
+
+### Exercice 1 -- Taille de groupe G
+Reprenez l'entrainement en faisant varier `GROUP_SIZE in {2, 4, 8, 16}`. Comment la **variance du
+delta Sharpe cross-seed** evolue-t-elle avec G ? GRPO a-t-il besoin d'un G minimal pour estimer un
+avantage stable ?
+- **Indice :** avec G=2, $\sigma_R$ sur 2 points est tres bruitee -> avantage instable. Mesurez le
+  ratio `std(delta_sharpe)` vs G.
+- **Etape 1 :** bouclez sur les valeurs de G.
+- **Etape 2 :** pour chaque G, lancez les 3 seeds et calculez l'ecart-type du delta.
+",,,,,,,,7eda5081b25d9c79,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,6ac15112,code,fr,efdeafd9eb6e010f,"# Exercice 1 a completer
+# TODO etudiant : balayer GROUP_SIZE, mesurer la variance du delta Sharpe cross-seed vs G.
+print(""Exercice 1 a completer : effet de la taille de groupe G sur la stabilite de l'avantage."")
+",,,,,,,,efdeafd9eb6e010f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,59d1de33,markdown,fr,c99cd973d9247465,"### Exercice 2 -- Sans la penalite KL
+Desactivez la penalite KL (`KL_COEF = 0.0`) et relancez. Observez l'**effondrement** de la politique
+(concentrations extremes -> entropie proche de 0 -> politique quasi deterministe). Le KL est-il le
+vrai stabilisateur qui remplace le critic ?
+- **Indice :** tracez `history['entropy']` avec et sans KL. Sans KL, l'entropie chute vers 0.
+",,,,,,,,c99cd973d9247465,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,4e144e6b,code,fr,83ca511492d1a1e6,"# Exercice 2 a completer
+# TODO etudiant : relancer avec KL_COEF=0.0, comparer la courbe d'entropie (effondrement ?).
+print(""Exercice 2 a completer : effet de la penalite KL sur l'effondrement de la politique."")
+",,,,,,,,83ca511492d1a1e6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,e5a79b4d,markdown,fr,f3fa8e083c88cd7b,"### Exercice 3 -- GRPO vs PPO sur le meme environnement
+Implementez une **baseline PPO** (avec un critic $V_\phi$ appris, cf [RL-6c](rl_6c_ppo_from_scratch.ipynb))
+sur le meme `SyntheticPortfolioEnv`. Comparez : (a) le delta Sharpe final, (b) le nombre de parametres,
+(c) le temps d'entrainement. GRPO est-il competitif sur cette tache de controle sequentiel ?
+- **Indice :** ajoutez un `class Critic(nn.Module)` et estimez l'avantage par TD. Le verdict attendu :
+  PPO legerement au-dessus (le critic aide sur controle), GRPO plus simple.
+",,,,,,,,f3fa8e083c88cd7b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,76195727,code,fr,8cbb2a2f29c74075,"# Exercice 3 a completer
+# TODO etudiant : ajouter un Critic, advantage TD (PPO), comparer delta/params/temps vs GRPO.
+print(""Exercice 3 a completer : GRPO vs PPO (avec critic) sur le meme portefeuille synthetique."")
+",,,,,,,,8cbb2a2f29c74075,,,,,,,
+MyIA.AI.Notebooks/RL/rl_6e_grpo_from_scratch.ipynb,3f93f64f,markdown,fr,112fb337151a22d9,"## 9. Ponts avec la serie
+
+| Direction | Lien | Relation |
+|-----------|------|----------|
+| <-> RL-6c | [PPO depuis zero](rl_6c_ppo_from_scratch.ipynb) | GRPO reprend le **ratio clippe** de PPO ; ajoute l'avantage de groupe + KL vs PPO's critic. |
+| <-> RL-6d | [SAC depuis zero](rl_6d_sac_from_scratch.ipynb) | SAC stabilise par **entropie max** ; GRPO par **KL vs reference** -- deux reponses au meme probleme (effondrement). |
+| <-> RL-1 | [Intro CartPole](rl_1_intro_cartpole.ipynb) | Bases MDP, recompense, retour. GRPO = loop PPO sans critic. |
+
+## 10. Conclusion
+
+**GRPO** est l'algorithme qui a rendu l'entrainement RL des LLM reasoning (DeepSeek-R1) scalable :
+en supprimant le critic au profit d'un **avantage relatif intra-groupe**, il reduit la complexite et
+stabilise l'apprentissage -- au prix de G rollouts par update. Ce notebook l'implemente depuis zero,
+prouve que le mecanisme apprend (la dynamique de groupe est visible), et donne un verdict **honnête**
+sur une tache de trading synthetique (edge marginal vs equal-weight, attendu).
+
+**Dualite des stabilisateurs** : PPO mise sur le **critic** (estimer la valeur), SAC sur l'**entropie**
+(maximiser l'exploration), GRPO sur la **KL vs reference** (rester proche de soi-meme). Trois philosophies
+pour le meme objectif : ne pas s'effondrer.
+
+Voir aussi le [notebook de recherche QC](../QuantConnect/research/research_rl_grpo.ipynb) pour la version
+multi-actif sur donnees de marche reelles (panier anti-biais 24 actifs, config lourde).
+",,,,,,,,112fb337151a22d9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m0a1e001,markdown,fr,9f70834b06664df2,"# RL-7 : Introduction a l'Apprentissage Multi-Agent
+
+**Serie** : Reinforcement Learning | **Notebook** : 7/13 | **Duree estimee** : 45-50 min
+
+Navigation : [RL-1 Intro](rl_1_intro_cartpole.ipynb) | [RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb) | [RL-3 HER](rl_3_experience_replay_dqn.ipynb) | [RL-5 Tabulaire](rl_5_mdp_dp_qlearning.ipynb) | [RL-6 DQN/PG](rl_6_dqn_policy_gradient.ipynb) | **RL-7**
+
+---
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous serez capable de :
+- Comprendre les defis specifiques de l'apprentissage multi-agent (non-stationnarite, credit assignment)
+- Utiliser la librairie PettingZoo pour les environnements multi-agent
+- Implementer un Independent Q-Learning (IQL) pour plusieurs agents
+- Observer les phenomenes d'emergence dans les systemes multi-agent
+
+## Prerequis
+
+- [RL-5 Q-Learning tabulaire](rl_5_mdp_dp_qlearning.ipynb) (Q-Learning, epsilon-greedy)
+- Notions de theorie des jeux (equilibre de Nash, dilemme du prisonnier)
+- Bases numpy et matplotlib
+
+---
+
+**Pourquoi le multi-agent ?**
+- La plupart des problemes reels impliquent plusieurs entites qui interagissent : robots collaboratifs, marches financiers, jeux a plusieurs joueurs, reseaux de communication.
+- Chaque agent doit apprendre une politique adaptee au comportement des autres agents, qui apprennent simultanement.
+- L'environnement devient **non-stationnaire** du point de vue d'un seul agent, ce qui complique l'apprentissage.",,,,,,,,9f70834b06664df2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m1b2e002,markdown,fr,bdf677c9de91e174,## 1. Installation et imports,,,,,,,,bdf677c9de91e174,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m2c3e003,code,fr,854efb297da4e5fc,"import numpy as np
+import matplotlib.pyplot as plt
+from pettingzoo.classic import tictactoe_v3
+
+print(""PettingZoo charge avec succes"")",,,,,,,,854efb297da4e5fc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m3d4e004,code,fr,854efb297da4e5fc,"import numpy as np
+import matplotlib.pyplot as plt
+from pettingzoo.classic import tictactoe_v3
+
+print(""PettingZoo charge avec succes"")",,,,,,,,854efb297da4e5fc,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m4e5e005,markdown,fr,9b4549be5792d94a,"[PettingZoo](https://pettingzoo.farama.org/) est la librairie de reference pour les environnements multi-agent en Python. Elle suit l'API AEC (Agent Environment Cycle) ou les agents jouent sequentiellement.
+
+Nous utiliserons **TicTacToe-v3** : un jeu a somme nulle a deux joueurs, parfait pour illustrer les concepts multi-agent dans un espace d'etat discret (3^9 etats possibles).",,,,,,,,9b4549be5792d94a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m5f6e006,markdown,fr,3b978ef2c440c200,"## 2. Comprendre l'API PettingZoo
+
+Contrairement a Gymnasium (un seul agent), PettingZoo gere plusieurs agents qui agissent tour a tour. L'API AEC (Agent Environment Cycle) fonctionne ainsi :
+
+1. `env.reset()` : Reinitialise l'environnement
+2. `env.agent_selection` : Indique quel agent doit jouer
+3. `env.observe(agent)` : Retourne l'observation pour cet agent
+4. `env.step(action)` : L'agent joue son coup
+5. `env.terminations` / `env.truncations` : Verifie la fin de partie",,,,,,,,3b978ef2c440c200,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m6g7e007,code,fr,9d2d796586707a55,"# Explorer l'environnement TicTacToe
+env = tictactoe_v3.env()
+env.reset(seed=42)
+
+print(f""Agents possibles : {env.possible_agents}"")
+print(f""Agent actuel      : {env.agent_selection}"")
+
+obs = env.observe(env.agent_selection)
+print(f""\nForme de l'observation : {obs['observation'].shape}"")
+print(f""Masque d'action        : {obs['action_mask']}"")
+print(f""\nEspaces d'action : {env.action_space(env.possible_agents[0])}"")
+print(f""Espaces d'obs     : {env.observation_space(env.possible_agents[0])}"")",,,,,,,,9d2d796586707a55,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m7h8e008,markdown,fr,317c64326b2d1f82,"L'observation est un tenseur de forme (3, 3, 2) : 1 canal pour les marques du joueur 1, 1 canal pour les marques du joueur 2. Le masque d'action indique les cases valides (1 = jouable, 0 = deja prise).",,,,,,,,317c64326b2d1f82,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m8i9e009,code,fr,f9473fb310ac3592,"# Jouer une partie aleatoire pour comprendre le deroulement
+env = tictactoe_v3.env()
+env.reset(seed=42)
+
+board = ['.' for _ in range(9)]
+marks = {'player_1': 'X', 'player_2': 'O'}
+
+for agent in env.agent_iter():
+    obs, reward, termination, truncation, info = env.last()
+    if termination or truncation:
+        break
+    
+    # Choisir une action aleatoire parmi les actions valides
+    action_mask = obs['action_mask']
+    valid_actions = np.where(action_mask == 1)[0]
+    action = np.random.choice(valid_actions)
+    
+    board[action] = marks[agent]
+    env.step(action)
+
+# Afficher la grille finale
+print(""Grille finale :"")
+for i in range(3):
+    print(' '.join(board[i*3:(i+1)*3]))
+
+# Resultats
+print(f""\nRecompenses finales : {env.rewards}"")
+print(f""Terminaisons        : {env.terminations}"")",,,,,,,,f9473fb310ac3592,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m9j0e010,markdown,fr,824ebf8182ee63fd,"Dans TicTacToe, les recompenses sont :
+- **+1** pour le gagnant
+- **-1** pour le perdant
+- **0** pour chaque joueur en cas de match nul
+
+Le jeu est a somme nulle : la somme des recompenses est toujours nulle.",,,,,,,,824ebf8182ee63fd,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n0k1e011,markdown,fr,198fc0332b99881c,"## 3. Concepts du Multi-Agent RL
+
+### Paradigmes d'apprentissage
+
+| Paradigme | Description | Exemple |
+|-----------|-------------|----------|
+| **Cooperatif** | Les agents maximisent une recompense commune | Robots collaboratifs |
+| **Competitif** | Les agents maximisent leur propre recompense (somme nulle) | Echecs, Go |
+| **Mixte** | Cooperation et competition partielles | Marches financiers |
+
+### Defis principaux
+
+1. **Non-stationnarite** : L'environnement change pour chaque agent car les autres agents apprennent
+2. **Credit assignment** : Difficile d'attribuer le succes/echec a un agent en particulier
+3. **Equilibre** : Les agents peuvent converger vers des politiques sous-optimales (cycles)
+4. **Scalabilite** : L'espace conjoint croit exponentiellement avec le nombre d'agents",,,,,,,,198fc0332b99881c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n1l2e012,markdown,fr,1d14370257e8474c,"## 4. Independent Q-Learning (IQL)
+
+L'approche la plus simple : chaque agent apprend independamment avec son propre Q-Learning, en traitant les autres agents comme faisant partie de l'environnement.
+
+**Avantage** : Simple a implementer, scalable.
+
+**Inconvenient** : Non-stationnarite (les ""autres agents"" changent de comportement au fil de l'entrainement).
+
+Pour TicTacToe, chaque agent dispose de sa propre table Q qui mappe (etat, action) -> Q-valeur. L'etat est encode comme un entier unique representant la configuration du plateau.",,,,,,,,1d14370257e8474c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n2m3e013,code,fr,4a344c81e0558543,"def encode_observation(obs):
+    """"""
+    Encode l'observation PettingZoo en un entier unique.
+    obs['observation'] : shape (3, 3, 2)
+    - Canal 0 : marques du joueur 1
+    - Canal 1 : marques du joueur 2
+    """"""
+    board = obs['observation']
+    # board est (3, 3, 2) : lignes x colonnes x canaux
+    # Encoder chaque case : 0=vide, 1=joueur_1, 2=joueur_2
+    state = 0
+    for i in range(3):
+        for j in range(3):
+            if board[i, j, 0] == 1:
+                state = state * 3 + 1
+            elif board[i, j, 1] == 1:
+                state = state * 3 + 2
+            else:
+                state = state * 3 + 0
+    return state
+
+
+class IQLAgent:
+    """"""Independent Q-Learning Agent.""""""
+    
+    def __init__(self, n_actions=9, alpha=0.1, gamma=0.99,
+                 epsilon_start=1.0, epsilon_end=0.05, epsilon_decay=0.9999):
+        self.q_table = {}
+        self.n_actions = n_actions
+        self.alpha = alpha
+        self.gamma = gamma
+        self.epsilon = epsilon_start
+        self.epsilon_end = epsilon_end
+        self.epsilon_decay = epsilon_decay
+    
+    def get_q(self, state):
+        if state not in self.q_table:
+            self.q_table[state] = np.zeros(self.n_actions)
+        return self.q_table[state]
+    
+    def select_action(self, state, action_mask):
+        """"""Selection epsilon-greedy parmi les actions valides.""""""
+        valid = np.where(action_mask == 1)[0]
+        if len(valid) == 0:
+            return None
+        if np.random.random() < self.epsilon:
+            return np.random.choice(valid)
+        q_vals = self.get_q(state)
+        masked_q = np.full(self.n_actions, -np.inf)
+        masked_q[valid] = q_vals[valid]
+        return np.argmax(masked_q)
+    
+    def update(self, state, action, reward, next_state, done):
+        """"""Mise a jour Q-Learning.""""""
+        q_vals = self.get_q(state)
+        if done:
+            td_target = reward
+        else:
+            td_target = reward + self.gamma * np.max(self.get_q(next_state))
+        q_vals[action] += self.alpha * (td_target - q_vals[action])
+    
+    def decay_epsilon(self):
+        self.epsilon = max(self.epsilon_end, self.epsilon * self.epsilon_decay)
+
+
+print(""IQLAgent initialise"")",,,,,,,,4a344c81e0558543,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n3n4e014,markdown,fr,f5b876ea8e6d0bef,La table Q est un dictionnaire (initialisation paresseuse) : seuls les etats visites sont stockes. Les actions invalides sont masquees avec `-inf` pour ne jamais etre selectionnees.,,,,,,,,f5b876ea8e6d0bef,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n4o5e015,markdown,fr,a9e90c25b2bec68f,"## 5. Entrainement IQL sur TicTacToe
+
+Les deux agents (X et O) apprennent simultanement en jouant l'un contre l'autre. Chaque agent maintient sa propre table Q.",,,,,,,,a9e90c25b2bec68f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n5p6e016,code,fr,efeab98e7f56cc5b,"def train_iql(num_episodes=20000, eval_every=5000):
+    """"""
+    Entraine deux agents IQL sur TicTacToe.
+    
+    Retourne :
+        agents : dict des agents entraines
+        history : dict des metriques d'entrainement
+    """"""
+    agents = {
+        'player_1': IQLAgent(n_actions=9, alpha=0.2, gamma=0.99),
+        'player_2': IQLAgent(n_actions=9, alpha=0.2, gamma=0.99),
+    }
+    
+    history = {'p1_wins': [], 'p2_wins': [], 'draws': [], 'episodes': []}
+    window_results = {'p1_wins': 0, 'p2_wins': 0, 'draws': 0}
+    
+    for ep in range(num_episodes):
+        env = tictactoe_v3.env()
+        env.reset()
+        
+        # Stocker les transitions pour mise a jour en fin d'episode
+        transitions = {agent: [] for agent in agents}
+        
+        for agent_name in env.agent_iter():
+            obs, reward, termination, truncation, info = env.last()
+            
+            if termination or truncation:
+                # Enregistrer le resultat
+                final_rewards = env.rewards
+                for a_name in agents:
+                    r = final_rewards.get(a_name, 0)
+                    # Mettre a jour la derniere transition avec la recompense finale
+                    if transitions[a_name]:
+                        s, act, ns = transitions[a_name][-1]
+                        agents[a_name].update(s, act, r, ns, True)
+                break
+            
+            state = encode_observation(obs)
+            action_mask = obs['action_mask']
+            agent = agents[agent_name]
+            action = agent.select_action(state, action_mask)
+            
+            if action is not None:
+                # Sauvegarder l'etat avant l'action
+                env.step(action)
+                # Observer le nouvel etat
+                if not env.terminations[agent_name] and not env.truncations[agent_name]:
+                    try:
+                        new_obs = env.observe(agent_name)
+                        new_state = encode_observation(new_obs)
+                    except Exception:
+                        new_state = state
+                else:
+                    new_state = state
+                
+                transitions[agent_name].append((state, action, new_state))
+        
+        # Compter les resultats
+        rewards = env.rewards
+        if rewards.get('player_1', 0) > 0:
+            window_results['p1_wins'] += 1
+        elif rewards.get('player_2', 0) > 0:
+            window_results['p2_wins'] += 1
+        else:
+            window_results['draws'] += 1
+        
+        # Decroitre epsilon
+        for agent in agents.values():
+            agent.decay_epsilon()
+        
+        # Evaluation periodique
+        if (ep + 1) % eval_every == 0:
+            total = sum(window_results.values())
+            history['p1_wins'].append(window_results['p1_wins'] / total * 100)
+            history['p2_wins'].append(window_results['p2_wins'] / total * 100)
+            history['draws'].append(window_results['draws'] / total * 100)
+            history['episodes'].append(ep + 1)
+            
+            print(f""Ep {ep+1:5d} | X: {window_results['p1_wins']/total*100:.1f}% ""
+                  f""O: {window_results['p2_wins']/total*100:.1f}% ""
+                  f""Nul: {window_results['draws']/total*100:.1f}% ""
+                  f""eps: {agents['player_1'].epsilon:.3f}"")
+            window_results = {'p1_wins': 0, 'p2_wins': 0, 'draws': 0}
+    
+    return agents, history
+
+
+agents, history = train_iql(num_episodes=20000)",,,,,,,,efeab98e7f56cc5b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n6q7e017,markdown,fr,b44dc356915f4745,"L'entrainement montre l'evolution des resultats au fil des episodes. Initialement, les deux agents jouent de maniere quasi-aleatoire. Progressivement, ils apprennent a bloquer l'adversaire et a creer des menaces.",,,,,,,,b44dc356915f4745,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n7r8e018,code,fr,5a1f5e7682f69a31,"# Visualisation de l'evolution des resultats
+fig, ax = plt.subplots(figsize=(10, 5))
+
+ax.plot(history['episodes'], history['p1_wins'], 'b-o', label='X (joueur 1)', markersize=5)
+ax.plot(history['episodes'], history['p2_wins'], 'r-s', label='O (joueur 2)', markersize=5)
+ax.plot(history['episodes'], history['draws'], 'g-^', label='Matchs nuls', markersize=5)
+
+ax.set_xlabel(""Episodes d'entrainement"")
+ax.set_ylabel(""Pourcentage"")
+ax.set_title(""Evolution des resultats IQL sur TicTacToe"")
+ax.legend()
+ax.grid(True, alpha=0.3)
+ax.set_ylim(0, 100)
+plt.tight_layout()
+plt.show()",,,,,,,,5a1f5e7682f69a31,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n8s9e019,markdown,fr,e6c56f46085fad35,"Avec TicTacToe, les deux agents devraient converger vers un jeu optimal, ou le joueur qui commence (X) ne peut pas perdre et le second joueur (O) peut au mieux forcer un match nul. La proportion de matchs nuls augmente avec l'entrainement, ce qui est coherent avec la theorie des jeux.",,,,,,,,e6c56f46085fad35,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,n9t0e020,markdown,fr,6bf77699bd7d3021,"## 6. Evaluation contre un agent aleatoire
+
+Pour verifier que les agents ont appris une politique sensée, mesurons leur taux de victoire contre un joueur aleatoire.",,,,,,,,6bf77699bd7d3021,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o0u1e021,code,fr,25bb9846872f441d,"def evaluate_against_random(trained_agent_name, agents, num_games=1000):
+    """"""
+    Evalue un agent entraine contre un joueur aleatoire.
+    trained_agent_name : 'player_1' ou 'player_2'
+    """"""
+    wins, losses, draws = 0, 0, 0
+    
+    for _ in range(num_games):
+        env = tictactoe_v3.env()
+        env.reset()
+        
+        for agent_name in env.agent_iter():
+            obs, reward, termination, truncation, info = env.last()
+            if termination or truncation:
+                break
+            
+            action_mask = obs['action_mask']
+            valid = np.where(action_mask == 1)[0]
+            
+            if agent_name == trained_agent_name:
+                state = encode_observation(obs)
+                agent = agents[agent_name]
+                # Politique greedy (pas d'exploration)
+                q_vals = agent.get_q(state)
+                masked_q = np.full(9, -np.inf)
+                masked_q[valid] = q_vals[valid]
+                action = np.argmax(masked_q)
+            else:
+                action = np.random.choice(valid)
+            
+            env.step(action)
+        
+        r = env.rewards.get(trained_agent_name, 0)
+        if r > 0:
+            wins += 1
+        elif r < 0:
+            losses += 1
+        else:
+            draws += 1
+    
+    total = wins + losses + draws
+    print(f""Agent {trained_agent_name} vs Aleatoire ({num_games} parties) :"")
+    print(f""  Victoires : {wins/total*100:.1f}%"")
+    print(f""  Defaites  : {losses/total*100:.1f}%"")
+    print(f""  Nuls      : {draws/total*100:.1f}%"")
+    return wins, losses, draws
+
+evaluate_against_random('player_1', agents, num_games=1000)
+print()
+evaluate_against_random('player_2', agents, num_games=1000)",,,,,,,,25bb9846872f441d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o1v2e022,markdown,fr,7f295a66f46d1a08,Un agent bien entraine devrait gagner la majorite des parties contre un joueur aleatoire. Le joueur X (qui commence) a un avantage naturel et devrait avoir un taux de victoire plus eleve.,,,,,,,,7f295a66f46d1a08,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o2w3e023,markdown,fr,be880b73c4636158,"## 7. Visualiser une partie
+
+Observons une partie entre les deux agents entraines pour verifier que le jeu est coherent.",,,,,,,,be880b73c4636158,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o3x4e024,code,fr,ed80f2bf0140b2eb,"def play_and_display(agents, seed=42):
+    """"""Fait jouer les agents et affiche la grille.""""""
+    env = tictactoe_v3.env()
+    env.reset(seed=seed)
+    
+    board = ['.' for _ in range(9)]
+    marks = {'player_1': 'X', 'player_2': 'O'}
+    moves = []
+    
+    for agent_name in env.agent_iter():
+        obs, reward, termination, truncation, info = env.last()
+        if termination or truncation:
+            break
+        
+        state = encode_observation(obs)
+        action_mask = obs['action_mask']
+        valid = np.where(action_mask == 1)[0]
+        
+        agent = agents[agent_name]
+        q_vals = agent.get_q(state)
+        masked_q = np.full(9, -np.inf)
+        masked_q[valid] = q_vals[valid]
+        action = np.argmax(masked_q)
+        
+        board[action] = marks[agent_name]
+        moves.append((marks[agent_name], action))
+        env.step(action)
+    
+    print(""Partie entre agents entraines :"")
+    for i, (mark, pos) in enumerate(moves):
+        print(f""  Coup {i+1} : {mark} joue en position {pos}"")
+    
+    print(""\nGrille finale :"")
+    for i in range(3):
+        print(' '.join(board[i*3:(i+1)*3]))
+    
+    rewards = env.rewards
+    if rewards.get('player_1', 0) > 0:
+        print(""\nResultat : X gagne"")
+    elif rewards.get('player_2', 0) > 0:
+        print(""\nResultat : O gagne"")
+    else:
+        print(""\nResultat : Match nul"")
+
+play_and_display(agents)",,,,,,,,ed80f2bf0140b2eb,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o4y5e025,markdown,fr,a3406cdc92f8023b,"## 8. Exercices
+
+### Exercice 1 : Connect Four
+
+PettingZoo inclut `connect_four_v3`. Adaptez le code IQL pour ce jeu. Observez comment la taille de l'espace d'etat (4^42 vs 3^9) affecte l'apprentissage.
+
+```python
+from pettingzoo.classic import connect_four_v3
+```
+
+### Exercice 2 : Self-play avec periodically reset
+
+Pour ameliorer la robustesse, entrainez un agent contre des versions passees de lui-meme. Toutes les N episodes, sauvegardez une copie de la table Q et tirez au hasard l'adversaire parmi ces versions.
+
+### Exercice 3 : Ajouter un reward shaping
+
+Au lieu de recompenses uniquement en fin de partie (+1/-1/0), ajoutez des recompenses intermediaires pour :
+- Poser un pion au centre de la grille (meilleure strategie d'ouverture)
+- Creer une ligne de 2 pions
+- Bloquer une ligne de 2 de l'adversaire",,,,,,,,a3406cdc92f8023b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o5z6e026,code,fr,c7d60875fc1f98e4,"# Exercice 1 : Connect Four avec PettingZoo
+# TODO etudiant : Adaptez le code IQL pour connect_four_v3
+# Indice : from pettingzoo.classic import connect_four_v3
+# Etape 1 : creer l'environnement et explorer l'espace d'etat
+# Etape 2 : adapter encode_observation pour la grille 6x7
+# Etape 3 : entrainer deux agents IQL
+connect4_results = {}  # TODO etudiant : remplir avec les resultats
+print(""Exercice a completer : Connect Four multi-agent"")",,,,,,,,c7d60875fc1f98e4,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o6a7e027,code,fr,f851bb2db0ef2f0f,"# Exercice 2 : Self-play avec periodically reset
+# TODO etudiant : Entrainez un agent contre des versions passees de lui-meme
+# Indice : sauvegardez des snapshots de q_table toutes les N episodes
+# Etape 1 : definir snapshot_freq et la liste snapshots
+# Etape 2 : a chaque episode, choisir l'adversaire parmi les snapshots
+self_play_results = {}  # TODO etudiant : remplir avec les resultats
+print(""Exercice a completer : self-play avec versions passees"")",,,,,,,,f851bb2db0ef2f0f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o7b8e028,code,fr,c1ecfaac59b7e025,"# Exercice 3 : Reward shaping pour TicTacToe
+# TODO etudiant : Ajoutez des recompenses intermediaires au lieu de +1/-1/0 en fin de partie
+# Indice : recompensez le centre, les lignes de 2, et le blocage de l'adversaire
+# Etape 1 : definir compute_shaped_reward(obs, action, base_reward)
+# Etape 2 : modifier la boucle d'entrainement pour utiliser shaped reward
+shaped_rewards = {}  # TODO etudiant : comparer avec/sans shaping
+print(""Exercice a completer : reward shaping"")",,,,,,,,c1ecfaac59b7e025,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,e2d0059d,markdown,fr,ec3a53c41a3a85e6,"## Connections inter-series
+
+Le RL multi-agent se connecte naturellement a d'autres domaines de l'IA traites dans ce depot :
+
+### Theorie des Jeux
+
+Les equilibres de Nash (utilises en RL multi-agent) sont formalises dans la serie [GameTheory](../GameTheory/README.md). Le dilemme du prisonnier, les jeux cooperatifs et les mecanismes d'encastrement sont etudies avec des outils mathematiques complementaires : la theorie des jeux fournit le cadre **analytique** (equilibres, optimalite), tandis que le RL multi-agent fournit le cadre **computationnel** (apprentissage par interaction).
+
+### Trading multi-agent
+
+Les marches financiers sont un environnement multi-agent par excellence : chaque trader est un agent qui apprend, et la dynamique du marche emerge des interactions de tous les participants. La serie [QuantConnect](../QuantConnect/README.md) implemente des strategies de trading dans un simulateur de marche ; le projet [Reinforcement-Learning-Trading](../QuantConnect/projects/Reinforcement-Learning-Trading/research.ipynb) en est un point d'entree RL sur donnees financieres reelles.",,,,,,,,ec3a53c41a3a85e6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,o8c9e029,markdown,fr,9c0b0a05dfd74393,"## 9. Conclusion
+
+| Concept | Description |
+|---------|-------------|
+| **Multi-Agent RL** | Plusieurs agents apprennent simultanement dans un environnement partage |
+| **PettingZoo** | API AEC pour environnements multi-agent (equivalent Gymnasium) |
+| **IQL** | Chaque agent apprend independamment avec son propre Q-Learning |
+| **Non-stationnarite** | Defi principal : l'environnement change du point de vue de chaque agent |
+| **Equilibre de Nash** | Convergence vers des strategies ou aucun agent n'a interet a devier |
+
+**Ce que nous avons vu dans cette serie** :
+
+| Notebook | Theme |
+|----------|-------|
+| RL-1 | Introduction PPO + CartPole (stable-baselines3) |
+| RL-2 | Wrappers, callbacks, environnements custom |
+| RL-3 | HER, goal-conditioned RL (off-policy) |
+| RL-4 | Bandits, exploration vs exploitation |
+| RL-5 | MDP, Value/Policy Iteration, Q-Learning tabulaire |
+| RL-6 | DQN, REINFORCE (approximation par reseaux de neurones) |
+| RL-6b | Actor-Critic (A2C) |
+| RL-6c | PPO depuis zero |
+| RL-6d | SAC depuis zero |
+| RL-7 | Multi-Agent RL, IQL, PettingZoo |
+
+**Pour aller plus loin en Multi-Agent RL** :
+- [PettingZoo documentation](https://pettingzoo.farama.org/)
+- Busoniu et al. (2008) - *A Comprehensive Survey of Multi-Agent Reinforcement Learning*
+- Papoudakis et al. (2021) - *Benchmarking Multi-Agent Deep Reinforcement Learning Algorithms*
+- Algorithms avances : QMIX, MAPPO, MADDPG",,,,,,,,9c0b0a05dfd74393,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,08828207,markdown,fr,115d293d0c7cf733,"# RL-8 : Model-Based RL — Dyna-Q et planification
+
+**Serie** : Reinforcement Learning | **Notebook** : 8/13 | **Duree estimee** : 45-50 min
+
+**Prerequis** : notebook 5 (MDP, programmation dynamique, Q-Learning tabulaire).
+
+## Objectifs pedagogiques
+
+- Distinguer les approches **model-free** (Q-Learning, DQN, PPO) des approches **model-based** (Dyna, MCTS, MuZero)
+- **Apprendre un modele du monde** a partir de l'experience reelle de l'agent
+- Implementer **Dyna-Q** : entrelacer apprentissage direct et planification sur experience simulee
+- Mesurer le gain en **efficacite d'echantillonnage** (sample efficiency) apporte par la planification
+- Comprendre ce qui se passe quand **le modele se trompe** (environnement changeant) et comment **Dyna-Q+** y remedie
+- Decouvrir la **planification au moment de la decision** (rollouts), porte d'entree vers MCTS et AlphaZero
+
+## Plan
+
+1. Model-free vs model-based : pourquoi un modele ?
+2. Le labyrinthe de Sutton & Barto
+3. Baseline model-free : Q-Learning direct
+4. Apprendre un modele du monde
+5. Dyna-Q : apprendre ET planifier
+6. Quand le modele se trompe : Blocking Maze et Dyna-Q+
+7. Planification au moment de la decision : des rollouts a MCTS
+8. Exercices
+9. Conclusion et passerelles",,,,,,,,115d293d0c7cf733,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,339d6e41,markdown,fr,d34c0aa7e7a8687c,"## 1. Model-free vs model-based : pourquoi un modele ?
+
+Tous les algorithmes vus jusqu'ici dans cette serie (Q-Learning, DQN, REINFORCE, A2C, PPO, SAC)
+sont **model-free** : ils apprennent une fonction de valeur ou une politique *directement* a partir
+des transitions vecues, sans jamais chercher a representer **comment le monde fonctionne**.
+Chaque amelioration de la politique exige donc de nouvelles interactions reelles avec l'environnement.
+
+Un **modele** de l'environnement est tout ce qui permet a l'agent de *predire* la consequence d'une
+action : a partir d'un etat $s$ et d'une action $a$, le modele fournit (une distribution sur)
+l'etat suivant $s'$ et la recompense $r$. Avec un modele, l'agent peut generer de l'**experience
+simulee** — gratuite — et s'en servir pour ameliorer sa fonction de valeur : c'est la **planification**.
+
+| | Model-free | Model-based |
+|---|---|---|
+| Ce qui est appris | $Q(s,a)$ ou $\pi(a\|s)$ | $Q$ / $\pi$ **et** un modele $\hat{P}, \hat{R}$ |
+| Cout par amelioration | experience **reelle** | experience reelle + calcul (simulation) |
+| Efficacite d'echantillonnage | faible a moyenne | **elevee** |
+| Risque principal | lenteur d'apprentissage | **biais du modele** (modele faux => politique fausse) |
+| Exemples | Q-Learning, DQN, PPO, SAC | Dyna-Q, MCTS, AlphaZero, MuZero, World Models |
+
+L'enjeu est crucial des que l'experience reelle est **chere ou risquee** : un bras robotique qui casse,
+un patient, un portefeuille de trading. En robotique comme en finance, on prefere ""rever"" des milliers
+de scenarios dans un simulateur appris plutot que de les payer dans le monde reel.
+
+**L'architecture Dyna** (Sutton, 1990) est la maniere la plus simple d'unifier les deux mondes.
+L'agent boucle sur trois activites :
+
+1. **Agir** : interagir avec l'environnement reel (politique $\varepsilon$-greedy sur $Q$) ;
+2. **Apprendre le modele** : memoriser les transitions observees $(s, a) \rightarrow (r, s')$ ;
+3. **Planifier** : rejouer $n$ transitions *simulees* tirees du modele et mettre a jour $Q$
+   avec exactement la meme regle que le Q-Learning.
+
+La planification n'est donc rien d'autre que du Q-Learning sur experience imaginaire.",,,,,,,,d34c0aa7e7a8687c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,e939d183,code,fr,8507324760c1a5a6,"import random
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Reproductibilite
+SEED = 42
+np.random.seed(SEED)
+random.seed(SEED)
+
+print(f""numpy {np.__version__}"")
+print(""Pas de framework lourd ici : le model-based tabulaire tient en numpy pur."")",,,,,,,,8507324760c1a5a6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,ae340329,markdown,fr,da7c9d47d4a55aaa,"## 2. Le labyrinthe de Sutton & Barto
+
+Nous reprenons le **Dyna Maze** du chapitre 8 de *Reinforcement Learning: An Introduction*
+(Sutton & Barto, 2e ed., figure 8.2) : une grille 6x9, un depart `S`, un but `G`, et quelques murs.
+
+```
+. . . . . . . # G        # = mur
+. . # . . . . # .        S = depart (ligne 2, colonne 0)
+S . # . . . . # .        G = but    (ligne 0, colonne 8)
+. . # . . . . . .
+. . . . . # . . .
+. . . . . . . . .
+```
+
+Caracteristiques :
+
+- **Actions** : haut, bas, gauche, droite. Se deplacer vers un mur ou hors de la grille laisse l'agent sur place.
+- **Recompense** : $+1$ en atteignant `G` (fin d'episode), $0$ partout ailleurs — recompense **eparse**.
+- **Facteur d'actualisation** : $\gamma = 0.95$, ce qui pousse l'agent a trouver le chemin le plus court
+  (14 pas pour le chemin optimal).
+
+L'environnement est **deterministe** : c'est le cadre ideal pour un premier modele appris
+(une seule observation suffit a connaitre parfaitement une transition).",,,,,,,,da7c9d47d4a55aaa,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,e351d17c,code,fr,097656988d0e897c,"# Actions : 0=haut, 1=bas, 2=gauche, 3=droite
+ACTIONS = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+ACTION_NAMES = [""haut"", ""bas"", ""gauche"", ""droite""]
+
+
+class Maze:
+    """"""Labyrinthe deterministe episodique (Dyna Maze, Sutton & Barto fig. 8.2).""""""
+
+    def __init__(self, height=6, width=9, start=(2, 0), goal=(0, 8), obstacles=None):
+        self.height = height
+        self.width = width
+        self.start = start
+        self.goal = goal
+        if obstacles is None:
+            obstacles = {(1, 2), (2, 2), (3, 2), (4, 5), (0, 7), (1, 7), (2, 7)}
+        self.obstacles = set(obstacles)
+        self.n_states = height * width
+        self.n_actions = len(ACTIONS)
+
+    def idx(self, state):
+        """"""Encode un etat (ligne, colonne) en entier pour indexer la Q-table.""""""
+        return state[0] * self.width + state[1]
+
+    def reset(self):
+        return self.start
+
+    def step(self, state, action):
+        """"""Transition deterministe : (etat, action) -> (etat_suivant, recompense, terminal).""""""
+        dr, dc = ACTIONS[action]
+        nr, nc = state[0] + dr, state[1] + dc
+        if not (0 <= nr < self.height and 0 <= nc < self.width) or (nr, nc) in self.obstacles:
+            nr, nc = state  # mur ou bord : on reste sur place
+        next_state = (nr, nc)
+        if next_state == self.goal:
+            return next_state, 1.0, True
+        return next_state, 0.0, False
+
+
+def render_maze(maze, ax=None, title=""Dyna Maze (Sutton & Barto fig. 8.2)""):
+    """"""Affiche la grille : murs en noir, depart S, but G.""""""
+    grid = np.zeros((maze.height, maze.width))
+    for (r, c) in maze.obstacles:
+        grid[r, c] = 1.0
+    if ax is None:
+        _, ax = plt.subplots(figsize=(6, 4))
+    ax.imshow(grid, cmap=""gray_r"", vmin=0, vmax=1)
+    ax.text(maze.start[1], maze.start[0], ""S"", ha=""center"", va=""center"",
+            fontsize=16, fontweight=""bold"", color=""tab:blue"")
+    ax.text(maze.goal[1], maze.goal[0], ""G"", ha=""center"", va=""center"",
+            fontsize=16, fontweight=""bold"", color=""tab:green"")
+    ax.set_xticks(np.arange(-0.5, maze.width, 1), minor=True)
+    ax.set_yticks(np.arange(-0.5, maze.height, 1), minor=True)
+    ax.grid(which=""minor"", color=""lightgray"", linewidth=0.5)
+    ax.tick_params(which=""both"", bottom=False, left=False,
+                   labelbottom=False, labelleft=False)
+    ax.set_title(title)
+    return ax
+
+
+maze = Maze()
+render_maze(maze)
+plt.tight_layout()
+plt.show()
+
+print(f""Etats : {maze.n_states} ({maze.height}x{maze.width}), actions : {maze.n_actions}"")
+print(f""Depart {maze.start}, but {maze.goal}, murs : {len(maze.obstacles)}"")",,,,,,,,097656988d0e897c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,ccaaebfa,markdown,fr,ce04616c8da1855f,"La recompense n'arrive qu'au but : tant que l'agent n'a pas atteint `G` au moins une fois,
+toutes ses estimations $Q(s,a)$ restent nulles et il erre au hasard. C'est precisement dans ce
+regime de **recompense eparse** que la planification va briller : la *premiere* trajectoire
+gagnante, une fois memorisee dans le modele, peut etre rejouee en boucle pour propager la valeur
+tout le long du chemin — sans un seul pas reel supplementaire.",,,,,,,,ce04616c8da1855f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,b17c5b06,markdown,fr,902da0a9ac7f0126,"## 3. Baseline model-free : Q-Learning direct
+
+Rappel du notebook 5 — la mise a jour Q-Learning sur une transition reelle $(s, a, r, s')$ :
+
+$$Q(s,a) \leftarrow Q(s,a) + \alpha \left[ r + \gamma \max_{a'} Q(s', a') - Q(s,a) \right]$$
+
+Nous mesurons la performance en **nombre de pas par episode** : plus l'agent apprend vite,
+plus cette courbe chute rapidement vers l'optimum (14 pas).",,,,,,,,902da0a9ac7f0126,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,9e624b4c,code,fr,40a362c3eb6f928b,"GAMMA = 0.95
+ALPHA = 0.5      # env. deterministe : un taux d'apprentissage eleve est sans risque
+EPSILON = 0.1
+MAX_STEPS_EPISODE = 2000  # garde-fou contre les episodes infinis
+
+
+def epsilon_greedy(Q, s_idx, n_actions, eps, rng):
+    """"""Politique epsilon-greedy avec bris d'egalite aleatoire.""""""
+    if rng.random() < eps:
+        return int(rng.integers(n_actions))
+    q_row = Q[s_idx]
+    return int(rng.choice(np.flatnonzero(q_row == q_row.max())))
+
+
+def q_learning(env, n_episodes=50, alpha=ALPHA, gamma=GAMMA, eps=EPSILON, seed=0):
+    """"""Q-Learning tabulaire pur (model-free). Retourne les pas par episode et Q.""""""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((env.n_states, env.n_actions))
+    steps_per_episode = []
+    for _ in range(n_episodes):
+        s = env.reset()
+        for t in range(1, MAX_STEPS_EPISODE + 1):
+            a = epsilon_greedy(Q, env.idx(s), env.n_actions, eps, rng)
+            s2, r, done = env.step(s, a)
+            target = r if done else r + gamma * Q[env.idx(s2)].max()
+            Q[env.idx(s), a] += alpha * (target - Q[env.idx(s), a])
+            s = s2
+            if done:
+                break
+        steps_per_episode.append(t)
+    return np.array(steps_per_episode), Q
+
+
+# Moyenne sur 10 graines pour lisser la variance
+N_RUNS, N_EPISODES = 10, 50
+runs = np.array([q_learning(maze, N_EPISODES, seed=k)[0] for k in range(N_RUNS)])
+mean_steps_qlearning = runs.mean(axis=0)
+
+plt.figure(figsize=(8, 4))
+plt.plot(range(1, N_EPISODES + 1), mean_steps_qlearning, label=""Q-Learning (model-free)"")
+plt.axhline(14, color=""gray"", linestyle=""--"", linewidth=1, label=""optimum (14 pas)"")
+plt.xlabel(""Episode"")
+plt.ylabel(""Pas par episode (moyenne sur 10 graines)"")
+plt.title(""Baseline model-free sur le Dyna Maze"")
+plt.yscale(""log"")
+plt.legend()
+plt.tight_layout()
+plt.show()
+
+print(f""Pas au 1er episode  : {mean_steps_qlearning[0]:.0f}"")
+print(f""Pas au 10e episode  : {mean_steps_qlearning[9]:.0f}"")
+print(f""Pas au 50e episode  : {mean_steps_qlearning[-1]:.0f}"")",,,,,,,,40a362c3eb6f928b,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,8103d187,markdown,fr,7c9ae27c2f7d3af5,"Lecture de la courbe : le premier episode est une marche aleatoire (plusieurs centaines de pas),
+puis la valeur se propage *d'un pas en arriere par episode* environ — chaque traversee reelle
+n'ameliore qu'une petite partie du chemin. Il faut des dizaines d'episodes pour approcher les 14 pas
+optimaux. **Toute l'information necessaire etait pourtant deja la** des la premiere arrivee au but :
+le reste n'est que propagation, et la propagation n'a pas besoin d'experience reelle.
+C'est exactement ce que la planification va exploiter.",,,,,,,,7c9ae27c2f7d3af5,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,68c8e5da,markdown,fr,50f30c345968e56a,"## 4. Apprendre un modele du monde
+
+Dans un environnement **deterministe**, le modele le plus simple est une table :
+pour chaque paire $(s, a)$ deja essayee, on memorise le couple observe $(r, s')$.
+Une seule observation suffit — le modele est alors *exact* sur tout ce qui a ete visite.
+
+$$\hat{M}(s, a) = (r, s', \text{terminal})$$
+
+Deux limites a garder en tete :
+
+- **Couverture** : le modele ne sait rien des paires $(s,a)$ jamais essayees.
+  La planification ne peut rejouer que du deja-vu.
+- **Stochasticite** : si l'environnement est aleatoire, une table ne suffit plus — il faut estimer
+  des distributions, par exemple par comptage de frequences $\hat{P}(s'|s,a)$, voire des lois
+  a priori bayesiennes (pont direct avec la serie [Probas](../Probas/README.md)).",,,,,,,,50f30c345968e56a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,d1ac476a,code,fr,0f6aed36857b02a8,"class DeterministicModel:
+    """"""Modele tabulaire pour environnement deterministe.
+
+    Memorise (s_idx, a) -> (r, s2_idx, done) et permet d'echantillonner
+    uniformement une paire deja observee (planification Dyna).
+    """"""
+
+    def __init__(self):
+        self.transitions = {}
+        self._keys = []  # liste maintenue pour echantillonner en O(1)
+
+    def update(self, s_idx, a, r, s2_idx, done):
+        key = (s_idx, a)
+        if key not in self.transitions:
+            self._keys.append(key)
+        self.transitions[key] = (r, s2_idx, done)
+
+    def sample(self, rng):
+        """"""Tire une paire (s, a) observee et retourne (s, a, r, s', done).""""""
+        s_idx, a = self._keys[int(rng.integers(len(self._keys)))]
+        r, s2_idx, done = self.transitions[(s_idx, a)]
+        return s_idx, a, r, s2_idx, done
+
+    def __len__(self):
+        return len(self.transitions)
+
+
+# Demonstration : remplir le modele par une courte marche aleatoire
+rng_demo = np.random.default_rng(SEED)
+model_demo = DeterministicModel()
+s = maze.reset()
+for _ in range(200):
+    a = int(rng_demo.integers(maze.n_actions))
+    s2, r, done = maze.step(s, a)
+    model_demo.update(maze.idx(s), a, r, maze.idx(s2), done)
+    s = maze.reset() if done else s2
+
+total_pairs = maze.n_states * maze.n_actions
+print(f""Apres 200 pas aleatoires : {len(model_demo)} paires (s,a) memorisees ""
+      f""sur {total_pairs} possibles ({100 * len(model_demo) / total_pairs:.0f}%)"")
+s_idx, a, r, s2_idx, done = model_demo.sample(rng_demo)
+print(f""Exemple de transition simulee : etat {s_idx}, action '{ACTION_NAMES[a]}' ""
+      f""-> recompense {r}, etat {s2_idx}, terminal={done}"")",,,,,,,,0f6aed36857b02a8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,23a6532f,markdown,fr,0b59237f113bb261,"## 5. Dyna-Q : apprendre ET planifier
+
+Dyna-Q ajoute une boucle de planification au Q-Learning. A chaque pas **reel**, l'agent effectue
+en plus $n$ mises a jour sur des transitions **simulees** tirees du modele :
+
+```
+Boucler a chaque pas de temps :
+  (a) s    <- etat courant
+  (b) a    <- epsilon-greedy(s, Q)
+  (c) r,s' <- ENVIRONNEMENT.step(s, a)                 # experience reelle
+  (d) Q(s,a) <- Q(s,a) + alpha [r + gamma max_a' Q(s',a') - Q(s,a)]
+  (e) Modele(s,a) <- (r, s')                           # apprentissage du modele
+  (f) Repeter n fois :                                 # planification
+        (s~, a~)  <- paire deja observee, au hasard
+        (r~, s~') <- Modele(s~, a~)
+        Q(s~,a~) <- Q(s~,a~) + alpha [r~ + gamma max_a' Q(s~',a~') - Q(s~,a~)]
+```
+
+Les etapes (d) et (f) utilisent **exactement la meme regle de mise a jour** — la planification
+est du Q-Learning sur souvenirs. Avec $n = 0$, on retrouve le Q-Learning pur.
+
+> **Remarque** : ce mecanisme rappelle l'experience replay du DQN (notebook 3 et 6). La filiation
+> est reelle, avec une nuance : le replay buffer rejoue des transitions *stockees telles quelles*,
+> tandis qu'un modele peut en principe *generer* des transitions jamais vecues (etats recombines,
+> predictions). En tabulaire deterministe, les deux coincident presque.",,,,,,,,0b59237f113bb261,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,7c702e3e,code,fr,cc71179584791e0a,"def dyna_q(env, n_episodes=50, n_planning=5, alpha=ALPHA, gamma=GAMMA,
+           eps=EPSILON, seed=0):
+    """"""Dyna-Q tabulaire : Q-Learning + modele + n_planning pas simules par pas reel.""""""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((env.n_states, env.n_actions))
+    model = DeterministicModel()
+    steps_per_episode = []
+    for _ in range(n_episodes):
+        s = env.reset()
+        for t in range(1, MAX_STEPS_EPISODE + 1):
+            s_idx = env.idx(s)
+            a = epsilon_greedy(Q, s_idx, env.n_actions, eps, rng)
+            s2, r, done = env.step(s, a)
+            s2_idx = env.idx(s2)
+            # (d) apprentissage direct
+            target = r if done else r + gamma * Q[s2_idx].max()
+            Q[s_idx, a] += alpha * (target - Q[s_idx, a])
+            # (e) apprentissage du modele
+            model.update(s_idx, a, r, s2_idx, done)
+            # (f) planification : n pas simules
+            for _ in range(n_planning):
+                ps, pa, pr, ps2, pdone = model.sample(rng)
+                ptarget = pr if pdone else pr + gamma * Q[ps2].max()
+                Q[ps, pa] += alpha * (ptarget - Q[ps, pa])
+            s = s2
+            if done:
+                break
+        steps_per_episode.append(t)
+    return np.array(steps_per_episode), Q, model
+
+
+# Comparaison n_planning = 0 / 5 / 50 (moyenne sur 10 graines)
+PLANNING_LEVELS = [0, 5, 50]
+results = {}
+for n_plan in PLANNING_LEVELS:
+    runs = np.array([dyna_q(maze, N_EPISODES, n_planning=n_plan, seed=k)[0]
+                     for k in range(N_RUNS)])
+    results[n_plan] = runs.mean(axis=0)
+
+plt.figure(figsize=(8, 4.5))
+for n_plan, curve in results.items():
+    label = ""n=0 (Q-Learning pur)"" if n_plan == 0 else f""n={n_plan} pas de planification""
+    plt.plot(range(1, N_EPISODES + 1), curve, label=label)
+plt.axhline(14, color=""gray"", linestyle=""--"", linewidth=1, label=""optimum (14 pas)"")
+plt.xlabel(""Episode"")
+plt.ylabel(""Pas par episode (moyenne sur 10 graines)"")
+plt.title(""Dyna-Q : effet du nombre de pas de planification"")
+plt.yscale(""log"")
+plt.legend()
+plt.tight_layout()
+plt.show()
+
+print(""Premier episode ou la moyenne passe sous 25 pas :"")
+for n_plan, curve in results.items():
+    below = np.argmax(curve < 25) + 1 if (curve < 25).any() else None
+    print(f""  n={n_plan:>2} : episode {below}"")",,,,,,,,cc71179584791e0a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,10cc6e6d,markdown,fr,09d9c526d5ad2aef,"Le resultat reproduit la figure 8.3 de Sutton & Barto : a **experience reelle egale**, l'agent qui
+planifie 50 pas par pas reel atteint un comportement quasi optimal en 3-4 episodes, la ou le
+Q-Learning pur en demande plus de vingt. Le premier episode est identique pour tous (modele vide,
+marche aleatoire) ; tout le gain se joue ensuite, quand chaque pas reel est demultiplie par la relecture
+du modele.
+
+Le prix paye n'est pas en echantillons mais en **calcul** : $n = 50$ multiplie par ~50 le nombre de
+mises a jour par pas reel. Ce compromis ""calcul contre experience"" est au coeur du model-based RL
+moderne : la ou l'experience est chere (robotique, medecine, finance), bruler du CPU/GPU pour
+economiser des interactions reelles est presque toujours rentable.",,,,,,,,09d9c526d5ad2aef,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,820cc051,markdown,fr,488c594562f7c25e,"## 6. Quand le modele se trompe : Blocking Maze et Dyna-Q+
+
+La force de Dyna-Q — rejouer le passe memorise — devient une faiblesse si **l'environnement change** :
+le modele continue de planifier sur un monde qui n'existe plus.
+
+Experience du **Blocking Maze** (Sutton & Barto, fig. 8.4) : pendant les 1000 premiers pas, le seul
+passage est a **droite** ; au pas 1000, le mur se decale et le passage de droite se ferme tandis qu'un
+passage s'ouvre a **gauche**.
+
+```
+Avant (pas 0-999)            Apres (pas 1000+)
+. . . . . . . . G            . . . . . . . . G
+. . . . . . . . .            . . . . . . . . .
+. . . . . . . . .            . . . . . . . . .
+# # # # # # # # .            . # # # # # # # #
+. . . . . . . . .            . . . . . . . . .
+. . . S . . . . .            . . . S . . . . .
+```
+
+**Dyna-Q+** (variante exploratoire de Dyna-Q) ajoute deux ingredients pour rester curieux :
+
+1. Un **bonus d'exploration** dans la planification : si la paire $(s,a)$ n'a pas ete essayee
+   *reellement* depuis $\tau(s,a)$ pas, la planification utilise la recompense augmentee
+
+   $$r + \kappa \sqrt{\tau(s,a)}$$
+
+   Les transitions anciennes paraissent ainsi de plus en plus attrayantes : l'agent retourne
+   periodiquement verifier si le monde a change.
+2. La planification considere aussi les **actions jamais essayees** depuis un etat visite
+   (modelisees par defaut comme ""rester sur place, recompense 0""), pour que le bonus puisse
+   les rendre attractives.
+
+Nous mesurons la **recompense cumulee** : la pente de la courbe indique a quelle frequence l'agent
+atteint le but.",,,,,,,,488c594562f7c25e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,51c80a20,code,fr,b66a6fa7e713b348,"class ChangingMaze(Maze):
+    """"""Labyrinthe dont les murs changent a un instant donne (Blocking/Shortcut Maze).""""""
+
+    def __init__(self, obstacles_before, obstacles_after, switch_time,
+                 start=(5, 3), goal=(0, 8), height=6, width=9):
+        super().__init__(height=height, width=width, start=start, goal=goal,
+                         obstacles=obstacles_before)
+        self.obstacles_before = set(obstacles_before)
+        self.obstacles_after = set(obstacles_after)
+        self.switch_time = switch_time
+
+    def step(self, state, action, t=0):
+        """"""Comme Maze.step, mais la carte depend du pas de temps global t.""""""
+        self.obstacles = self.obstacles_before if t < self.switch_time else self.obstacles_after
+        return super().step(state, action)
+
+
+# Blocking Maze : passage a droite, puis passage a gauche uniquement
+wall_before = {(3, c) for c in range(0, 8)}   # ouverture en (3, 8)
+wall_after = {(3, c) for c in range(1, 9)}    # ouverture en (3, 0)
+SWITCH_T, TOTAL_T = 1000, 3000
+blocking_maze = ChangingMaze(wall_before, wall_after, switch_time=SWITCH_T)
+
+fig, axes = plt.subplots(1, 2, figsize=(11, 3.2))
+blocking_maze.obstacles = wall_before
+render_maze(blocking_maze, ax=axes[0], title=f""Avant (pas 0-{SWITCH_T - 1}) : passage a droite"")
+blocking_maze.obstacles = wall_after
+render_maze(blocking_maze, ax=axes[1], title=f""Apres (pas {SWITCH_T}+) : passage a gauche"")
+plt.tight_layout()
+plt.show()",,,,,,,,b66a6fa7e713b348,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,d75cfcc3,code,fr,7153efe2dd78265c,"def dyna_q_steps(env, total_steps, n_planning=10, kappa=0.0,
+                 alpha=ALPHA, gamma=GAMMA, eps=EPSILON, seed=0):
+    """"""Dyna-Q / Dyna-Q+ sur un budget de pas REELS (environnement changeant).
+
+    kappa = 0   : Dyna-Q standard.
+    kappa > 0   : Dyna-Q+ (bonus kappa*sqrt(tau) en planification + actions jamais essayees).
+    Retourne la recompense cumulee a chaque pas.
+    """"""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((env.n_states, env.n_actions))
+    model = DeterministicModel()
+    tau = np.zeros((env.n_states, env.n_actions))  # anciennete de chaque paire (s,a)
+    cumulative = np.zeros(total_steps)
+    total_reward = 0.0
+    s = env.reset()
+    for t in range(total_steps):
+        s_idx = env.idx(s)
+        a = epsilon_greedy(Q, s_idx, env.n_actions, eps, rng)
+        s2, r, done = env.step(s, a, t=t)
+        s2_idx = env.idx(s2)
+        # apprentissage direct
+        target = r if done else r + gamma * Q[s2_idx].max()
+        Q[s_idx, a] += alpha * (target - Q[s_idx, a])
+        # anciennete : tout vieillit d'un pas, la paire visitee rajeunit
+        tau += 1.0
+        tau[s_idx, a] = 0.0
+        # apprentissage du modele
+        model.update(s_idx, a, r, s2_idx, done)
+        if kappa > 0:
+            # Dyna-Q+ : les actions jamais essayees depuis un etat visite entrent
+            # au modele comme (recompense 0, rester sur place) pour etre planifiables
+            for a_untried in range(env.n_actions):
+                if (s_idx, a_untried) not in model.transitions:
+                    model.update(s_idx, a_untried, 0.0, s_idx, False)
+        # planification
+        for _ in range(n_planning):
+            ps, pa, pr, ps2, pdone = model.sample(rng)
+            bonus = kappa * np.sqrt(tau[ps, pa]) if kappa > 0 else 0.0
+            ptarget = pr + bonus if pdone else pr + bonus + gamma * Q[ps2].max()
+            Q[ps, pa] += alpha * (ptarget - Q[ps, pa])
+        total_reward += r
+        cumulative[t] = total_reward
+        s = env.reset() if done else s2
+    return cumulative
+
+
+def run_blocking(kappa, n_seeds=5):
+    curves = []
+    for k in range(n_seeds):
+        env = ChangingMaze(wall_before, wall_after, switch_time=SWITCH_T)
+        curves.append(dyna_q_steps(env, TOTAL_T, n_planning=10, kappa=kappa, seed=k))
+    return np.mean(curves, axis=0)
+
+
+cum_dyna = run_blocking(kappa=0.0)
+cum_dyna_plus = run_blocking(kappa=1e-3)
+
+plt.figure(figsize=(8, 4.5))
+plt.plot(cum_dyna, label=""Dyna-Q (kappa = 0)"")
+plt.plot(cum_dyna_plus, label=""Dyna-Q+ (kappa = 0.001)"")
+plt.axvline(SWITCH_T, color=""red"", linestyle="":"", linewidth=1.5,
+            label=f""changement de carte (pas {SWITCH_T})"")
+plt.xlabel(""Pas de temps (experience reelle)"")
+plt.ylabel(""Recompense cumulee (moyenne sur 5 graines)"")
+plt.title(""Blocking Maze : adaptation au changement d'environnement"")
+plt.legend()
+plt.tight_layout()
+plt.show()
+
+print(f""Recompense cumulee finale — Dyna-Q : {cum_dyna[-1]:.1f} | ""
+      f""Dyna-Q+ : {cum_dyna_plus[-1]:.1f}"")",,,,,,,,7153efe2dd78265c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,1ceca8cc,markdown,fr,b735d1ca015c9f3d,"Les deux courbes deviennent plates juste apres le pas 1000 : l'ancien chemin est mure, et les agents
+persistent un moment a le suivre — leur modele (et leur $Q$) decrit un monde perime. La difference
+se joue sur la **vitesse de re-decouverte** : grace a son bonus $\kappa\sqrt{\tau}$, Dyna-Q+
+re-essaie systematiquement les zones non visitees recemment, retrouve le nouveau passage a gauche
+plus tot, et sa pente repart plus vite. Dyna-Q standard finit aussi par s'adapter, mais uniquement
+pousse par le hasard de l'$\varepsilon$-greedy.
+
+Le bonus a un cout : en regime stationnaire, Dyna-Q+ ""gaspille"" des pas a re-verifier des couloirs
+qui n'ont pas change. C'est le dilemme exploration/exploitation (notebook 4) transpose au
+**non-stationnaire** — et l'exercice 3 vous fera mesurer ce que coute un $\kappa$ mal regle. Un ordre de grandeur de trop suffit : a $\kappa = 5	imes 10^{-3}$, le bonus amplifie par le bootstrap ($\gamma \max_a Q$) depasse la valeur reelle du but et la recompense cumulee s'effondre.
+L'exercice 1 (Shortcut Maze) montre un cas plus frappant : quand le changement *ouvre un raccourci*
+au lieu de fermer un passage, Dyna-Q standard ne le decouvre **jamais**.",,,,,,,,b735d1ca015c9f3d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,e9307f6b,markdown,fr,6c8ef2f4dda0902f,"## 7. Planification au moment de la decision : des rollouts a MCTS
+
+Dyna planifie **en tache de fond** (background planning) : les mises a jour simulees ameliorent la
+table $Q$ globale, sans privilegier l'etat courant. L'alternative est la **planification au moment
+de la decision** (decision-time planning) : face a l'etat $s_t$, derouler le modele *vers l'avant*
+pour evaluer les actions candidates, choisir, agir — puis tout jeter et recommencer.
+
+La forme la plus simple est le **rollout** : pour chaque action candidate $a$, simuler quelques
+centaines de trajectoires (politique aleatoire) partant de $(s_t, a)$ et moyenner les retours.
+
+**Monte-Carlo Tree Search (MCTS)** rend ce principe efficace en concentrant la simulation sur les
+branches prometteuses, via quatre phases repetees : **selection** (descendre l'arbre en arbitrant
+exploration/exploitation, typiquement avec UCB — revoir le notebook 4), **expansion** (ajouter une
+feuille), **simulation** (rollout), **retropropagation** (remonter les valeurs). C'est le moteur
+d'**AlphaGo/AlphaZero** (modele = regles du jeu, parfaites) et de **MuZero** (modele *appris*,
+comme Dyna — la boucle est bouclee).",,,,,,,,6c8ef2f4dda0902f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,981c1d5a,code,fr,809a6d3169c8605c,"def rollout_action_values(env, state, n_rollouts=300, depth=60, gamma=GAMMA, seed=0):
+    """"""Estime Q(state, a) pour chaque action par rollouts aleatoires du modele.
+
+    Ici le 'modele' est l'environnement lui-meme (modele parfait, comme les regles
+    d'un jeu pour AlphaZero) : Maze.step est une fonction pure sans etat cache.
+    """"""
+    rng = np.random.default_rng(seed)
+    estimates = np.zeros(env.n_actions)
+    for a in range(env.n_actions):
+        returns = []
+        for _ in range(n_rollouts):
+            s, (g, G) = state, (1.0, 0.0)
+            s, r, done = env.step(s, a)
+            G += g * r
+            d = 0
+            while not done and d < depth:
+                g *= gamma
+                s, r, done = env.step(s, int(rng.integers(env.n_actions)))
+                G += g * r
+                d += 1
+            returns.append(G)
+        estimates[a] = np.mean(returns)
+    return estimates
+
+
+# Planification depuis l'etat (3, 8) : juste sous le couloir menant au but (0, 8)
+probe_state = (3, 8)
+estimates = rollout_action_values(maze, probe_state, seed=SEED)
+
+print(f""Valeurs estimees par rollouts depuis l'etat {probe_state} :"")
+for name, value in sorted(zip(ACTION_NAMES, estimates), key=lambda x: -x[1]):
+    print(f""  {name:<8} : {value:.3f}"")
+print(f""\nMeilleure action : '{ACTION_NAMES[int(np.argmax(estimates))]}' ""
+      ""(remonter le couloir vers G, comme attendu)"")",,,,,,,,809a6d3169c8605c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,cba10b2a,markdown,fr,7a062a5a3d433d67,"Les rollouts identifient la bonne action sans aucune table $Q$ : toute l'intelligence vient de la
+simulation vers l'avant. Mais la version naive est **myope et couteuse** : loin du but, presque tous
+les rollouts aleatoires echouent (recompense eparse) et les estimations s'ecrasent vers zero ; et il
+faut re-simuler a chaque pas. MCTS corrige les deux defauts en construisant un arbre asymetrique
+guide par UCB — pour une implementation complete sur des jeux a deux joueurs, voir
+[GameTheory-17-MultiAgent-RL](../GameTheory/GameTheory-17-MultiAgent-RL.ipynb) et les notebooks
+OpenSpiel de la serie [GameTheory](../GameTheory/README.md).",,,,,,,,7a062a5a3d433d67,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,fdbe41b8,markdown,fr,b2b95ce8fbdcd4d8,"## 8. Exercices
+
+Les trois exercices reutilisent les briques construites plus haut (`ChangingMaze`, `dyna_q_steps`,
+`DeterministicModel`). Completez les cellules de code : elles s'executent sans erreur en l'etat
+(stubs), a vous de les remplir.",,,,,,,,b2b95ce8fbdcd4d8,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,5eb818ec,markdown,fr,78363f8f22c0e8c5,"### Exercice 1 — Shortcut Maze : decouvrir un raccourci
+
+Le Blocking Maze fermait un passage ; le **Shortcut Maze** (Sutton & Barto, fig. 8.5) en *ouvre* un :
+
+```
+Avant (pas 0-2999)           Apres (pas 3000+)
+. . . . . . . . G            . . . . . . . . G
+. . . . . . . . .            . . . . . . . . .
+. . . . . . . . .            . . . . . . . . .
+. # # # # # # # #            . # # # # # # # .   <- raccourci ouvert a droite
+. . . . . . . . .            . . . . . . . . .
+. . . S . . . . .            . . . S . . . . .
+```
+
+L'ancien chemin (par la gauche) **reste valide** : rien ne force l'agent a explorer. Un agent
+purement glouton n'a aucune raison de remarquer le raccourci... sauf s'il est curieux.
+
+**Travail demande** :
+
+1. Construire le `ChangingMaze` correspondant (murs avant/apres, `switch_time=3000`) ;
+2. Lancer `dyna_q_steps` sur 6000 pas avec `kappa=0` (Dyna-Q) et `kappa=1e-3` (Dyna-Q+),
+   moyenne sur 5 graines ;
+3. Tracer les recompenses cumulees et comparer les pentes apres le pas 3000.
+
+**Resultat attendu** : Dyna-Q garde la meme pente (il ne decouvre jamais le raccourci) ;
+la pente de Dyna-Q+ augmente apres l'ouverture.",,,,,,,,78363f8f22c0e8c5,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,a7d65519,code,fr,a5e137a28b7684f6,"# Exercice 1 — Shortcut Maze
+# Etape 1 : definir les murs avant/apres (s'inspirer de wall_before / wall_after)
+#           Avant : mur ligne 3, colonnes 1 a 8 (passage a gauche seulement)
+#           Apres : mur ligne 3, colonnes 1 a 7 (passages a gauche ET a droite)
+# Etape 2 : creer le ChangingMaze avec switch_time=3000
+# Etape 3 : lancer dyna_q_steps(env, 6000, n_planning=10, kappa=...) pour kappa=0 et kappa=1e-3
+#           (moyenne sur 5 graines, comme run_blocking)
+# Etape 4 : tracer les deux courbes de recompense cumulee + axvline au pas 3000
+
+shortcut_wall_before = None  # TODO etudiant
+shortcut_wall_after = None   # TODO etudiant
+shortcut_env = None          # TODO etudiant
+
+# Indice : la pente apres 3000 est ~ (recompense finale - recompense a 3000) / 3000.
+# Calculer cette pente pour les deux agents rend la comparaison quantitative.
+
+print(""Exercice 1 a completer"")",,,,,,,,a5e137a28b7684f6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,c51a6bcc,markdown,fr,767ae8a7b20b6a0c,"### Exercice 2 — Prioritized Sweeping : planifier la ou ca compte
+
+Dyna-Q echantillonne ses transitions simulees **uniformement** : la plupart des mises a jour ne
+changent rien (la valeur en amont n'a pas bouge). Le **prioritized sweeping** (Moore & Atkeson, 1993)
+planifie en priorite la ou la surprise est grande :
+
+1. A chaque transition (reelle ou simulee), calculer l'erreur $|\delta| = |r + \gamma \max_{a'} Q(s',a') - Q(s,a)|$ ;
+2. Si $|\delta| > \theta$, inserer $(s,a)$ dans une **file de priorite** avec priorite $|\delta|$ ;
+3. A chaque pas de planification, traiter la paire la plus prioritaire, puis examiner tous les
+   **predecesseurs** connus de $s$ (les paires $(\bar{s},\bar{a})$ telles que le modele donne
+   $\bar{s} \xrightarrow{\bar{a}} s$) et les inserer a leur tour si leur erreur depasse $\theta$.
+
+La valeur se propage ainsi **a rebours** depuis le but, en cascade ciblee.
+
+**Travail demande** : completer `prioritized_sweeping` ci-dessous (squelette fourni), puis comparer
+le nombre d'episodes necessaires pour atteindre 25 pas/episode face a Dyna-Q ($n=5$) sur le Dyna Maze.
+
+**Indices** : `heapq` avec priorites negatives (file max), un `dict` `predecessors[s2] -> set de (s, a)`
+rempli au fil des transitions reelles, et $\theta \approx 10^{-4}$.",,,,,,,,767ae8a7b20b6a0c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,15cddb60,code,fr,471657b1d4f47378,"import heapq
+
+
+def prioritized_sweeping(env, n_episodes=50, n_planning=5, alpha=ALPHA, gamma=GAMMA,
+                         eps=EPSILON, theta=1e-4, seed=0):
+    """"""Squelette de prioritized sweeping — a completer (exercice 2).""""""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((env.n_states, env.n_actions))
+    model = DeterministicModel()
+    predecessors = defaultdict(set)  # s2_idx -> {(s_idx, a), ...}
+    pqueue = []                      # tas de (-priorite, s_idx, a)
+    steps_per_episode = []
+
+    for _ in range(n_episodes):
+        s = env.reset()
+        for t in range(1, MAX_STEPS_EPISODE + 1):
+            s_idx = env.idx(s)
+            a = epsilon_greedy(Q, s_idx, env.n_actions, eps, rng)
+            s2, r, done = env.step(s, a)
+            s2_idx = env.idx(s2)
+            model.update(s_idx, a, r, s2_idx, done)
+            predecessors[s2_idx].add((s_idx, a))
+
+            # TODO etudiant — Etape 1 : calculer |delta| pour (s_idx, a)
+            #   et inserer dans pqueue si |delta| > theta
+            #   (heapq.heappush(pqueue, (-abs(delta), s_idx, a)))
+
+            # TODO etudiant — Etape 2 : boucle de planification (n_planning iterations) :
+            #   - depiler la paire la plus prioritaire (heapq.heappop)
+            #   - appliquer la mise a jour Q-Learning via le modele
+            #   - pour chaque predecesseur (ps, pa) de l'etat traite :
+            #       calculer son |delta| et l'inserer si > theta
+
+            s = s2
+            if done:
+                break
+        steps_per_episode.append(t)
+    return np.array(steps_per_episode), Q
+
+
+# TODO etudiant — Etape 3 : comparer prioritized_sweeping et dyna_q (n_planning=5)
+#   sur 10 graines : tracer les deux courbes de pas par episode.
+print(""Exercice 2 a completer"")",,,,,,,,471657b1d4f47378,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,5e7c18f8,markdown,fr,89007d632063235c,"### Exercice 3 — Sensibilite du bonus d'exploration $\kappa$
+
+Le bonus $\kappa\sqrt{\tau}$ de Dyna-Q+ arbitre entre re-exploration et exploitation.
+Trop faible, l'agent ne re-decouvre rien ; trop fort, il passe son temps a re-verifier des couloirs
+inchanges au lieu d'aller au but.
+
+**Travail demande** :
+
+1. Sur le **Blocking Maze** (3000 pas, changement a 1000), faire varier
+   $\kappa \in \{0,\ 10^{-4},\ 10^{-3},\ 5 \times 10^{-3},\ 10^{-2},\ 10^{-1}\}$ ;
+2. Pour chaque valeur, relever la **recompense cumulee finale** (moyenne sur 5 graines) ;
+3. Tracer recompense finale vs $\kappa$ (echelle log en x, traiter $\kappa = 0$ a part) ;
+4. Repondre : que se passe-t-il pour $\kappa = 0.1$, et pourquoi ?
+
+**Indice** : avec un bonus enorme, la valeur planifiee d'une paire ancienne depasse la valeur
+reelle du but ($+1$) — l'agent prefere ""visiter du vieux"" plutot que de gagner.",,,,,,,,89007d632063235c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,51b2645d,code,fr,1ddc2efed9d2d881,"# Exercice 3 — balayage de kappa sur le Blocking Maze
+kappas = [0.0, 1e-4, 1e-3, 5e-3, 1e-2, 1e-1]
+
+final_rewards = None  # TODO etudiant : liste des recompenses cumulees finales,
+                      # une par valeur de kappa (reutiliser run_blocking)
+
+# TODO etudiant : tracer final_rewards vs kappas (plt.semilogx sur kappas[1:],
+# point separe pour kappa=0) et commenter le kappa optimal.
+
+print(""Exercice 3 a completer"")",,,,,,,,1ddc2efed9d2d881,,,,,,,
+MyIA.AI.Notebooks/RL/rl_8_model_based_dyna_q.ipynb,7234522c,markdown,fr,cff05c14757dc845,"## 9. Conclusion et passerelles
+
+### Ce qu'il faut retenir
+
+| Concept | Idee cle |
+|---------|----------|
+| Modele du monde | Predire $(r, s')$ a partir de $(s, a)$ ; appris par memorisation (deterministe) ou estimation (stochastique) |
+| Dyna-Q | Q-Learning + $n$ mises a jour simulees par pas reel ; meme regle de mise a jour, experience gratuite |
+| Sample efficiency | A experience reelle egale, la planification accelere drastiquement la convergence (calcul contre echantillons) |
+| Modele perime | Un environnement qui change rend la planification nuisible ; Dyna-Q+ re-explore via le bonus $\kappa\sqrt{\tau}$ |
+| Decision-time planning | Rollouts et MCTS simulent vers l'avant depuis l'etat courant ; AlphaZero (modele parfait), MuZero (modele appris) |
+
+### Passerelles vers les autres series
+
+- **[GameTheory](../GameTheory/README.md)** : MCTS est au coeur d'AlphaZero ; le notebook
+  [GameTheory-17-MultiAgent-RL](../GameTheory/GameTheory-17-MultiAgent-RL.ipynb) applique
+  ces idees aux jeux a deux joueurs via OpenSpiel.
+- **[Search](../Search/README.md)** : la planification par modele EST de la recherche dans un espace
+  d'etats — value iteration (notebook 5) et A* sont deux reponses au meme probleme.
+- **[Probas](../Probas/README.md)** : quand l'etat n'est pas observable, le modele s'etend en
+  **POMDP** (notebooks 17-20, theorie de la decision bayesienne) ; l'estimation d'un modele
+  stochastique par comptage est une inference bayesienne deguisee.
+- **[QuantConnect](../QuantConnect/README.md)** : un backtest est un *modele de marche* sur lequel on
+  planifie des strategies — avec exactement le danger vu ici : le marche reel change (regime shifts),
+  et un modele perime (overfitting au passe) detruit la performance
+  ([QC-Py-32-RL-DQN-Trading](../QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb)).
+- **[GenAI](../GenAI/README.md)** : les *world models* des agents modernes (simulateurs appris par
+  reseaux de neurones) prolongent Dyna avec des modeles profonds ; le post-training RLHF
+  ([FT-04-RLHF-DPO](../GenAI/FineTuning/FT-04-RLHF-DPO.ipynb)) optimise contre un *modele de
+  recompense* appris — avec le meme risque de sur-optimisation d'un modele faux (reward hacking).
+
+### References
+
+- Sutton & Barto, *Reinforcement Learning: An Introduction* (2e ed.), chapitre 8
+- Sutton (1990), *Integrated Architectures for Learning, Planning, and Reacting* (Dyna)
+- Moore & Atkeson (1993), *Prioritized Sweeping*
+- Silver et al. (2018), *AlphaZero* ; Schrittwieser et al. (2020), *MuZero*",,,,,,,,cff05c14757dc845,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,b73f69f6,markdown,fr,883ff555e8dbb0d7,"# RL-9 : RL offline — Behavior Cloning et erreur d'extrapolation
+
+**Serie** : Reinforcement Learning | **Notebook** : 9/13 | **Duree estimee** : 50-55 min
+
+**Prerequis** : notebook 5 (Q-learning, politiques epsilon-greedy) ; le notebook 8 (Dyna-Q) aide pour le labyrinthe de Sutton & Barto mais n'est pas indispensable.
+
+## Objectifs pedagogiques
+
+- Comprendre la difference entre RL **online** (l'agent interagit) et RL **offline** (un dataset fige de transitions, aucune interaction possible) ;
+- Implementer le **Behavior Cloning** (BC) tabulaire et constater qu'il est plafonne par la qualite de la politique de comportement ;
+- Mettre en evidence l'**erreur d'extrapolation** : pourquoi le Q-learning applique naivement a un dataset fige echoue, meme avec des donnees expertes ;
+- Implementer une correction de type **BCQ** (contraindre le bootstrap au support du dataset) et observer le **stitching** : extraire une politique quasi optimale de donnees mediocres ;
+- Relier ces idees aux methodes modernes (BCQ, CQL) et a l'alignement des LLM (RLHF, DPO).
+
+## Plan
+
+1. Du RL online au RL offline
+2. Fabriquer les datasets : trois politiques de comportement
+3. Behavior Cloning
+4. Q-learning offline naif : l'erreur d'extrapolation
+5. Contraindre au support du dataset : BCQ-lite
+6. Du tabulaire au deep : BCQ, CQL et le pont vers RLHF/DPO
+7. Exercices",,,,,,,,883ff555e8dbb0d7,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,0ddebb1f,markdown,fr,736a7f55ae675f07,"## 1. Du RL online au RL offline
+
+Tous les algorithmes vus jusqu'ici (Q-learning, DQN, policy gradient, Dyna-Q) sont **online** : l'agent choisit ses actions, observe les consequences, et corrige. Cette boucle d'essai-erreur est un luxe. En robotique, en sante, en conduite autonome ou en finance, laisser une politique non entrainee explorer librement est couteux, voire dangereux. En revanche, on dispose souvent de **journaux d'interactions passees** : trajectoires d'un operateur humain, logs d'un ancien controleur, historique de decisions cliniques.
+
+Le **RL offline** (ou *batch RL*) pose la question : peut-on apprendre une bonne politique **uniquement** a partir d'un dataset fige $\mathcal{D} = \{(s_i, a_i, r_i, s'_i)\}$, collecte par une **politique de comportement** $\pi_\beta$ inconnue, sans jamais interagir avec l'environnement pendant l'apprentissage ?
+
+Deux familles de reponses naives, deux echecs instructifs :
+
+- **Imiter** : reproduire l'action majoritaire du dataset dans chaque etat (*Behavior Cloning*). Simple, mais on ne peut pas depasser $\pi_\beta$ — si les donnees sont mediocres, la copie l'est aussi.
+- **Faire du Q-learning sur le dataset** : apres tout, le Q-learning est *off-policy*, il devrait digerer des donnees venues d'ailleurs. C'est vrai en apparence seulement : sans nouvelles interactions pour corriger les illusions, le $\max_a Q(s', a)$ bootstrape sur des actions **jamais observees** et l'erreur s'auto-amplifie. C'est l'**erreur d'extrapolation** (Fujimoto et al., 2019), que nous allons reproduire pas a pas.
+
+Nous travaillons en tabulaire sur le labyrinthe 6x9 de Sutton & Barto (fig. 8.2) — le meme que le notebook 8 — avec une convention de recompense importante pour la suite : **-1 par pas, 0 en atteignant le but**. Maximiser le retour = minimiser la longueur du chemin, et surtout l'initialisation $Q = 0$ devient **optimiste** : une action jamais essayee semble meilleure que la realite. Retenez ce detail, c'est le carburant de l'erreur d'extrapolation.",,,,,,,,736a7f55ae675f07,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,95b63d59,code,fr,221797c4d5f02763,"import numpy as np
+import matplotlib.pyplot as plt
+
+SEED = 42
+ALPHA, GAMMA, EPSILON = 0.5, 0.95, 0.1
+MAX_STEPS = 200          # troncature des episodes (echec = retour -200)
+
+ACTIONS = [(-1, 0), (1, 0), (0, -1), (0, 1)]   # haut, bas, gauche, droite
+ACTION_NAMES = [""haut"", ""bas"", ""gauche"", ""droite""]
+
+print(f""NumPy {np.__version__} — graine {SEED}"")",,,,,,,,221797c4d5f02763,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,7dcce77d,code,fr,4810f57d7b180a96,"class Maze:
+    """"""Labyrinthe 6x9 de Sutton & Barto (fig. 8.2).
+
+    Recompense : -1 par pas, 0 en atteignant le but (episode termine).
+    Le chemin optimal fait 14 pas, soit un retour de -13.
+    """"""
+
+    def __init__(self):
+        self.height, self.width = 6, 9
+        self.start = (2, 0)
+        self.goal = (0, 8)
+        self.obstacles = {(1, 2), (2, 2), (3, 2), (4, 5), (0, 7), (1, 7), (2, 7)}
+        self.n_states = self.height * self.width
+        self.n_actions = 4
+
+    def idx(self, s):
+        return s[0] * self.width + s[1]
+
+    def reset(self):
+        return self.start
+
+    def step(self, s, a):
+        dr, dc = ACTIONS[a]
+        r2, c2 = s[0] + dr, s[1] + dc
+        if not (0 <= r2 < self.height and 0 <= c2 < self.width) or (r2, c2) in self.obstacles:
+            r2, c2 = s          # mur ou bord : on reste sur place
+        s2 = (r2, c2)
+        if s2 == self.goal:
+            return s2, 0.0, True
+        return s2, -1.0, False
+
+
+env = Maze()
+
+grid = np.zeros((env.height, env.width))
+for (r, c) in env.obstacles:
+    grid[r, c] = 1.0
+fig, ax = plt.subplots(figsize=(6, 4))
+ax.imshow(grid, cmap=""Greys"", vmin=0, vmax=1.6)
+ax.text(env.start[1], env.start[0], ""S"", ha=""center"", va=""center"", fontsize=16, fontweight=""bold"")
+ax.text(env.goal[1], env.goal[0], ""G"", ha=""center"", va=""center"", fontsize=16, fontweight=""bold"", color=""green"")
+ax.set_xticks(range(env.width)); ax.set_yticks(range(env.height))
+ax.set_title(""Labyrinthe 6x9 (Sutton & Barto, fig. 8.2) — chemin optimal : 14 pas"")
+plt.tight_layout()
+plt.show()
+
+print(f""{env.n_states} etats x {env.n_actions} actions = {env.n_states * env.n_actions} paires (s, a)"")",,,,,,,,4810f57d7b180a96,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,ba9f743f,markdown,fr,a9c54594f91ce71e,"## 2. Fabriquer les datasets : trois politiques de comportement
+
+En RL offline, le dataset est une donnee du probleme — mais pour etudier le phenomene en laboratoire, nous le fabriquons nous-memes. Nous entrainons d'abord **online** (Q-learning classique du notebook 5) deux politiques de qualites differentes, puis nous enregistrons leurs trajectoires comme de simples logs :
+
+| Dataset | Politique de comportement | Analogue reel |
+|---------|---------------------------|---------------|
+| **expert** | Q-learning converge (300 episodes), $\epsilon = 0.1$ | demonstrations d'un operateur competent |
+| **medium** | Q-learning interrompu (20 episodes), $\epsilon = 0.3$ | logs d'un ancien controleur mediocre |
+| **random** | actions uniformes ($\epsilon = 1$) | exploration aveugle, donnees de capteurs bruts |
+
+Pour chaque dataset nous mesurons deux choses : la **couverture** (fraction des paires $(s, a)$ presentes au moins une fois) et le **retour moyen** de la politique de comportement. Ces deux axes — qualite et couverture — sont orthogonaux, et chaque methode offline echoue sur un axe different.",,,,,,,,a9c54594f91ce71e,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,a1c8e10e,code,fr,fe2a2ae7a4f35ce1,"def epsilon_greedy(Q, s_idx, n_actions, eps, rng):
+    if rng.random() < eps:
+        return rng.integers(n_actions)
+    q = Q[s_idx]
+    return rng.choice(np.flatnonzero(q == q.max()))
+
+
+def q_learning_online(env, n_episodes, seed=0):
+    """"""Q-learning online classique (notebook 5) — sert uniquement a fabriquer pi_beta.""""""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((env.n_states, env.n_actions))
+    for _ in range(n_episodes):
+        s = env.reset()
+        for _ in range(MAX_STEPS):
+            si = env.idx(s)
+            a = epsilon_greedy(Q, si, env.n_actions, EPSILON, rng)
+            s2, r, done = env.step(s, a)
+            target = r if done else r + GAMMA * Q[env.idx(s2)].max()
+            Q[si, a] += ALPHA * (target - Q[si, a])
+            if done:
+                break
+            s = s2
+    return Q
+
+
+def evaluate_policy(env, policy, n_episodes=20, seed=123):
+    """"""Deroule la politique deterministe policy[s] (action -1 = etat inconnu -> action aleatoire).""""""
+    rng = np.random.default_rng(seed)
+    returns, successes = [], 0
+    for _ in range(n_episodes):
+        s, ret = env.reset(), 0.0
+        for _ in range(MAX_STEPS):
+            a = policy[env.idx(s)]
+            if a < 0:
+                a = rng.integers(env.n_actions)
+            s, r, done = env.step(s, a)
+            ret += r
+            if done:
+                successes += 1
+                break
+        returns.append(ret)
+    return np.mean(returns), successes / n_episodes
+
+
+Q_expert = q_learning_online(env, 300, seed=SEED)
+Q_medium = q_learning_online(env, 20, seed=SEED)
+
+ret_expert, _ = evaluate_policy(env, Q_expert.argmax(axis=1))
+ret_medium, _ = evaluate_policy(env, Q_medium.argmax(axis=1))
+print(f""Politique experte  (greedy, 300 ep online) : retour moyen {ret_expert:.1f}  (optimal = -13)"")
+print(f""Politique mediocre (greedy, 20 ep online)  : retour moyen {ret_medium:.1f}"")",,,,,,,,fe2a2ae7a4f35ce1,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,82db8289,code,fr,2b12681f591f795a,"def collect_dataset(env, Q_behavior, eps, n_episodes, seed=0):
+    """"""Enregistre les transitions (s, a, r, s', done) de la politique epsilon-greedy(Q_behavior).""""""
+    rng = np.random.default_rng(seed)
+    data, ep_returns = [], []
+    for _ in range(n_episodes):
+        s, ret = env.reset(), 0.0
+        for _ in range(MAX_STEPS):
+            si = env.idx(s)
+            a = epsilon_greedy(Q_behavior, si, env.n_actions, eps, rng)
+            s2, r, done = env.step(s, a)
+            data.append((si, a, r, env.idx(s2), done))
+            ret += r
+            if done:
+                break
+            s = s2
+        ep_returns.append(ret)
+    return data, np.mean(ep_returns)
+
+
+def coverage(env, data):
+    pairs = {(s, a) for s, a, *_ in data}
+    return len(pairs) / (env.n_states * env.n_actions)
+
+
+datasets, behavior_returns = {}, {}
+for name, (Qb, eps, seed) in {
+    ""expert"": (Q_expert, 0.1, 1),
+    ""medium"": (Q_medium, 0.3, 2),
+    ""random"": (Q_expert, 1.0, 3),    # eps=1 : Q ignore, actions uniformes
+}.items():
+    datasets[name], behavior_returns[name] = collect_dataset(env, Qb, eps, n_episodes=50, seed=seed)
+
+print(f""{'dataset':<8} {'transitions':>11} {'couverture':>11} {'retour comportement':>20}"")
+for name, d in datasets.items():
+    print(f""{name:<8} {len(d):>11} {coverage(env, d):>10.0%} {behavior_returns[name]:>20.1f}"")",,,,,,,,2b12681f591f795a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,f781a6cf,markdown,fr,ff326d7d11c9a978,"**Lecture.** Les deux axes sont bien decorreles :
+
+- Le dataset **expert** a un excellent retour mais une **couverture faible** (~30 %) : les trajectoires se concentrent sur le chemin optimal, l'immense majorite des paires $(s, a)$ n'est jamais observee.
+- Le dataset **random** couvre ~85 % des paires, mais sa politique de comportement est catastrophique (la plupart des episodes n'atteignent jamais le but en 200 pas).
+- Le dataset **medium** est mediocre sur les deux plans : couverture large mais trouee, comportement peu fiable.
+
+C'est exactement la situation reelle du RL offline : *les bonnes donnees couvrent peu, les donnees couvrantes sont mauvaises*. Voyons comment chaque methode encaisse ce dilemme.",,,,,,,,ff326d7d11c9a978,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,b8ac2b31,markdown,fr,594fe88228476bdb,"## 3. Behavior Cloning : imiter le dataset
+
+La methode la plus simple ignore completement les recompenses : dans chaque etat, jouer l'**action majoritaire** du dataset. C'est la version tabulaire du *Behavior Cloning* — en deep, on entrainerait un classifieur $s \mapsto a$ par maximum de vraisemblance sur les paires $(s_i, a_i)$.
+
+$$\pi_{BC}(s) = \arg\max_a \; \#\{i : s_i = s,\; a_i = a\}$$
+
+Dans un etat jamais visite par le dataset, la politique n'a aucune information : nous tirons une action au hasard (c'est le *distribution shift* de l'imitation learning — des qu'on quitte les etats du dataset, on improvise).",,,,,,,,594fe88228476bdb,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,dbf50316,code,fr,59c36097d7a9c56a,"def bc_policy(env, data):
+    """"""Action majoritaire du dataset dans chaque etat (-1 si etat jamais visite).""""""
+    counts = np.zeros((env.n_states, env.n_actions))
+    for s, a, *_ in data:
+        counts[s, a] += 1
+    policy = np.full(env.n_states, -1)
+    visited = counts.sum(axis=1) > 0
+    policy[visited] = counts[visited].argmax(axis=1)
+    return policy
+
+
+results_bc = {}
+print(f""{'dataset':<8} {'retour BC':>10} {'succes':>8} {'(comportement)':>16}"")
+for name, d in datasets.items():
+    ret, sr = evaluate_policy(env, bc_policy(env, d))
+    results_bc[name] = ret
+    print(f""{name:<8} {ret:>10.1f} {sr:>7.0%} {behavior_returns[name]:>16.1f}"")",,,,,,,,59c36097d7a9c56a,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,87562bb8,markdown,fr,c04c883b14e77535,"**Le plafond de verre de l'imitation.** Sur les donnees expertes, BC est imbattable : l'action majoritaire dans chaque etat du chemin est l'action experte (le bruit $\epsilon$ est minoritaire), et le clone atteint le retour optimal. Mais sur **medium** et **random**, BC reproduit fidelement... une politique qui ne marche pas. L'imitation **filtre le bruit, pas la mediocrite** : elle ne peut pas depasser $\pi_\beta$, car elle n'utilise jamais les recompenses.
+
+En pratique, BC reste un *baseline* redoutable quand les demonstrations sont bonnes (c'est le coeur du *fine-tuning supervise* des LLM). Ses limites — accumulation d'erreurs des qu'on sort de la distribution — sont l'objet de DAgger (Ross et al., 2011), qui re-sollicite l'expert sur les etats visites par le clone... ce qui exige une interaction, donc n'est plus offline.
+
+Pour faire mieux que $\pi_\beta$, il faut exploiter les recompenses. Le candidat naturel est le Q-learning.",,,,,,,,c04c883b14e77535,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,fab36682,markdown,fr,2b0c2180365ed8ee,"## 4. Q-learning offline naif : l'erreur d'extrapolation
+
+Le Q-learning est *off-policy* : sa cible $r + \gamma \max_{a'} Q(s', a')$ ne depend pas de la politique qui a produit la transition. Il est donc tentant de le faire tourner directement sur le dataset, en rejouant les transitions en boucle (comme un replay buffer fige, sans jamais y ajouter de nouvelles experiences) :
+
+$$Q(s, a) \leftarrow Q(s, a) + \alpha\,\big[r + \gamma \max_{a'} Q(s', a') - Q(s, a)\big] \qquad (s, a, r, s') \sim \mathcal{D}$$
+
+Le piege est dans le $\max_{a'}$ : il porte sur **toutes** les actions, y compris celles **jamais observees en $s'$**. Pour ces actions fantomes, $Q(s', a')$ garde sa valeur d'initialisation $0$ — qui, avec notre recompense de $-1$ par pas, est **optimiste** (la vraie valeur est negative partout sauf au but). Le bootstrap recopie alors cet optimisme : chaque cible vaut $-1 + \gamma \cdot 0 \approx -1$, toutes les valeurs s'ecrasent vers $-1$, et la politique greedy prefere systematiquement les actions inconnues aux actions documentees. En ligne, l'agent essaierait ces actions, serait decu, et corrigerait. **Offline, rien ne vient jamais corriger l'illusion.**",,,,,,,,2b0c2180365ed8ee,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,164ab91c,code,fr,42fa564cdc0ffb1d,"def offline_q(env, data, n_passes=300, constrain=False, seed=0, alpha=0.1):
+    """"""Q-learning sur dataset fige.
+
+    constrain=False : cible max sur TOUTES les actions (naif).
+    constrain=True  : cible max restreinte aux actions observees en s' (BCQ-lite),
+                      et politique greedy restreinte aux actions observees en s.
+    """"""
+    rng = np.random.default_rng(seed)
+    Q = np.zeros((env.n_states, env.n_actions))
+    seen = [set() for _ in range(env.n_states)]
+    for s, a, *_ in data:
+        seen[s].add(a)
+
+    for _ in range(n_passes):
+        for i in rng.permutation(len(data)):
+            s, a, r, s2, done = data[i]
+            if done:
+                target = r
+            elif constrain:
+                acts = list(seen[s2])
+                target = r + GAMMA * (max(Q[s2, aa] for aa in acts) if acts else 0.0)
+            else:
+                target = r + GAMMA * Q[s2].max()
+            Q[s, a] += alpha * (target - Q[s, a])
+
+    policy = np.full(env.n_states, -1)
+    for s in range(env.n_states):
+        if seen[s]:
+            if constrain:
+                acts = list(seen[s])
+                policy[s] = acts[int(np.argmax([Q[s, aa] for aa in acts]))]
+            else:
+                policy[s] = Q[s].argmax()
+    return Q, policy
+
+
+results_naive = {}
+print(f""{'dataset':<8} {'retour Q naif':>14} {'succes':>8} {'(BC)':>8}"")
+for name, d in datasets.items():
+    _, pol = offline_q(env, d, constrain=False)
+    ret, sr = evaluate_policy(env, pol)
+    results_naive[name] = ret
+    print(f""{name:<8} {ret:>14.1f} {sr:>7.0%} {results_bc[name]:>8.1f}"")",,,,,,,,42fa564cdc0ffb1d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,456cab8c,markdown,fr,400e47b4f14748c2,"**Un echec spectaculaire — et un succes revelateur.** Sur les donnees **expertes**, le Q-learning naif s'effondre (retour $-200$, 0 % de succes) alors que le simple BC etait optimal : utiliser les recompenses a *degrade* le resultat ! Sur **random**, en revanche, le naif retrouve la politique optimale. L'explication tient en un mot : **couverture**. Avec ~85 % des paires $(s, a)$ observees, presque aucune action fantome ne subsiste, et le Q-learning offline redevient du Q-learning ordinaire. L'erreur d'extrapolation n'est pas une fatalite du offline : c'est une maladie des **trous du dataset**, que le $\max$ s'empresse d'exploiter.
+
+Mesurons l'ampleur du phenomene sur le dataset expert.",,,,,,,,400e47b4f14748c2,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,5622ad6c,code,fr,84657135ed58ef44,"d_exp = datasets[""expert""]
+Q_naive, _ = offline_q(env, d_exp, constrain=False)
+seen_exp = [set() for _ in range(env.n_states)]
+for s, a, *_ in d_exp:
+    seen_exp[s].add(a)
+
+visited = [s for s in range(env.n_states) if seen_exp[s]]
+greedy_unseen = sum(1 for s in visited if int(Q_naive[s].argmax()) not in seen_exp[s])
+print(f""Etats visites par le dataset expert : {len(visited)}"")
+print(f""... dont la politique greedy naive choisit une action JAMAIS observee : ""
+      f""{greedy_unseen} ({greedy_unseen / len(visited):.0%})"")
+
+# Zoom sur un etat du chemin optimal : (3, 4)
+s_zoom = env.idx((3, 4))
+obs = sorted(int(a) for a in seen_exp[s_zoom])
+colors = [""tab:blue"" if a in obs else ""tab:red"" for a in range(4)]
+fig, ax = plt.subplots(figsize=(6, 3.5))
+ax.bar(ACTION_NAMES, Q_naive[s_zoom], color=colors)
+ax.axhline(0, color=""black"", lw=0.8)
+ax.set_ylabel(""Q naif"")
+ax.set_title(""Etat (3, 4) — bleu : action observee, rouge : action fantome"")
+plt.tight_layout()
+plt.show()
+print(f""Q naif en (3, 4) : {np.round(Q_naive[s_zoom], 2)} — actions observees : {[ACTION_NAMES[a] for a in obs]}"")",,,,,,,,84657135ed58ef44,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,96e866b1,markdown,fr,509d4d32c38f3870,"La figure resume toute la pathologie : en $(3, 4)$, l'action « haut » n'apparait nulle part dans le dataset, son $Q$ est reste a l'initialisation $0$ — strictement au-dessus des actions documentees, toutes ecrasees vers $\approx -1$ par le bootstrap contamine. La politique greedy choisit donc l'action fantome dans **~94 % des etats visites** : elle ne suit jamais le chemin expert pourtant present sous ses yeux. Notez l'effet boule de neige : l'optimisme des actions fantomes ($Q = 0$) remonte dans les cibles $r + \gamma \max Q(s')$ des etats voisins, qui paraissent a leur tour meilleurs qu'ils ne sont. En deep RL, ou $Q$ est un reseau qui *generalise* aux actions non vues, le phenomene est encore plus violent — les valeurs divergent positivement (Fujimoto et al., 2019, fig. 1).",,,,,,,,509d4d32c38f3870,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,258cc257,markdown,fr,f2ba6bea6dde511c,"## 5. Contraindre au support du dataset : BCQ-lite
+
+Le diagnostic dicte le remede : interdire au $\max$ de regarder les actions fantomes. On restreint le bootstrap **au support du dataset** :
+
+$$Q(s, a) \leftarrow Q(s, a) + \alpha\,\Big[r + \gamma \max_{a' \,\in\, \mathcal{A}_\mathcal{D}(s')} Q(s', a') - Q(s, a)\Big]$$
+
+ou $\mathcal{A}_\mathcal{D}(s') = \{a' : (s', a') \in \mathcal{D}\}$ est l'ensemble des actions effectivement observees en $s'$. La politique finale est elle aussi restreinte aux actions observees. C'est la version tabulaire de **BCQ** (*Batch-Constrained deep Q-learning*, Fujimoto et al., 2019) — en continu, un modele generatif estime $\pi_\beta(a|s)$ et le $\max$ ne porte que sur des actions plausibles sous le comportement.
+
+L'enjeu : garder la capacite du Q-learning a **recombiner** des bouts de trajectoires (ce que BC ne sait pas faire), sans son optimisme hors support.",,,,,,,,f2ba6bea6dde511c,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,50d31e5c,code,fr,45b5d78aeafd3cc0,"results_bcq = {}
+print(f""{'dataset':<8} {'retour BCQ-lite':>16} {'succes':>8} {'(comportement)':>16}"")
+for name, d in datasets.items():
+    _, pol = offline_q(env, d, constrain=True)
+    ret, sr = evaluate_policy(env, pol)
+    results_bcq[name] = ret
+    print(f""{name:<8} {ret:>16.1f} {sr:>7.0%} {behavior_returns[name]:>16.1f}"")",,,,,,,,45b5d78aeafd3cc0,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,9900adc3,code,fr,77eaf498051a744f,"methods = {""Behavior Cloning"": results_bc, ""Q offline naif"": results_naive, ""BCQ-lite"": results_bcq}
+names = list(datasets.keys())
+x = np.arange(len(names))
+width = 0.26
+
+fig, ax = plt.subplots(figsize=(8, 4.5))
+for i, (label, res) in enumerate(methods.items()):
+    ax.bar(x + (i - 1) * width, [res[n] for n in names], width, label=label)
+ax.axhline(-13, color=""green"", ls=""--"", lw=1.2, label=""optimal (-13)"")
+ax.scatter(x, [behavior_returns[n] for n in names], color=""black"", marker=""D"", zorder=5,
+           label=""politique de comportement"")
+ax.set_xticks(x); ax.set_xticklabels(names)
+ax.set_ylabel(""Retour moyen (20 episodes)"")
+ax.set_title(""RL offline sur le labyrinthe : trois methodes, trois datasets"")
+ax.legend(loc=""lower right"", fontsize=9)
+plt.tight_layout()
+plt.show()",,,,,,,,77eaf498051a744f,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,d465cc5a,markdown,fr,010d1729b5819df6,"**Lecture du tableau final.**
+
+| Dataset | Comportement | BC | Q naif | BCQ-lite |
+|---------|-------------:|----:|-------:|---------:|
+| expert  | $\approx -15$ | $-13$ | $-200$ | $-13$ |
+| medium  | $\approx -150$ | $-200$ | $-200$ | $-13$ |
+| random  | $\approx -190$ | $-200$ | $-13$ | $-13$ |
+
+- **BCQ-lite gagne sur les trois datasets** : il egale BC quand les donnees sont expertes, et il egale le Q-learning quand la couverture est totale. La contrainte de support ne coute rien quand elle est inutile.
+- La ligne **medium** est la plus importante : la politique de comportement rate le but une fois sur deux (retour $\approx -150$), BC la copie et echoue, le naif delire — mais BCQ-lite extrait un chemin **optimal** ($-13$). C'est le **stitching** : le dataset contient, eparpilles dans des episodes differents, tous les troncons du bon chemin ; la programmation dynamique les recoud, ce que l'imitation pure ne peut pas faire.
+- Le RL offline qui fonctionne se resume ainsi : *etre aussi ambitieux que le Q-learning a l'interieur du support des donnees, aussi humble que BC en dehors*.",,,,,,,,010d1729b5819df6,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,6f0f63fe,markdown,fr,86dd75b4675f2ddf,"## 6. Du tabulaire au deep : BCQ, CQL et le pont vers RLHF/DPO
+
+En dimension reelle (etats continus, $Q$ approxime par un reseau), « l'ensemble des actions vues en $s'$ » n'existe plus litteralement — chaque etat est unique. Les methodes modernes traduisent la meme idee de trois facons :
+
+- **BCQ** (Fujimoto et al., 2019) : un auto-encodeur variationnel modelise $\pi_\beta(a|s)$ ; le $\max$ ne porte que sur des actions echantillonnees de ce modele (contrainte de support *explicite*).
+- **CQL** (*Conservative Q-Learning*, Kumar et al., 2020) : plutot que d'interdire, **penaliser** — un terme de regularisation pousse $Q$ vers le bas sur les actions hors distribution et vers le haut sur les actions du dataset. Le $Q$ appris est un *minorant* du vrai $Q$ : l'optimisme hors support devient du pessimisme (l'exercice 2 en construit la version tabulaire).
+- **IQL, TD3+BC, Decision Transformer...** : la famille est riche, mais le principe est invariant — controler l'ecart entre la politique apprise et la politique de comportement.
+
+**Le pont vers les LLM.** L'alignement d'un modele de langage est un probleme de RL offline deguise. Le *fine-tuning supervise* (SFT) est exactement du Behavior Cloning sur des demonstrations humaines. **RLHF** optimise ensuite une recompense apprise, avec une penalite KL qui force la politique a rester proche du modele de reference — le meme role que la contrainte de support de BCQ : sans elle, la politique exploite les zones ou le modele de recompense extrapole mal (*reward hacking*, le jumeau de notre erreur d'extrapolation). **DPO** (Rafailov et al., 2023) pousse la logique au bout : il elimine le RL et reecrit l'objectif RLHF comme une simple classification de preferences sous contrainte KL — de l'offline pur, sans interaction. La boucle est bouclee : les idees nees sur des labyrinthes 6x9 gouvernent aujourd'hui l'entrainement des plus grands modeles.",,,,,,,,86dd75b4675f2ddf,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,1310ca43,markdown,fr,dc341f017e12c36d,"## 7. Exercices
+
+Les trois exercices reutilisent les fonctions du notebook (`collect_dataset`, `bc_policy`, `offline_q`, `evaluate_policy`). Completez les cellules — elles doivent s'executer sans erreur meme incompletes.",,,,,,,,dc341f017e12c36d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,4e440a0b,markdown,fr,ca2d42926cf7dc65,"### Exercice 1 — Combien de demonstrations faut-il ?
+
+La qualite des methodes offline depend de la **taille** du dataset, pas seulement de sa qualite. Collectez des datasets experts de tailles croissantes et comparez BC et BCQ-lite : lequel est le plus econome en donnees ? A partir de combien d'episodes chacun devient-il fiable ?",,,,,,,,ca2d42926cf7dc65,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,25c71989,code,fr,5779aec942db4b46,"# Exercice 1 — Ablation de la taille du dataset expert
+# Etape 1 : pour n_ep dans `tailles`, collecter un dataset expert (Q_expert, eps=0.1, seed=1)
+# Etape 2 : entrainer BC et l'offline Q contraint (constrain=True) sur chaque dataset
+# Etape 3 : tracer les retours moyens en fonction de n_ep (2 courbes + ligne optimale -13)
+# Indice : collect_dataset renvoie (data, retour_moyen) — ne garder que data
+
+tailles = [1, 2, 5, 10, 50]
+retours_bc_ex1 = None     # TODO etudiant : liste des retours BC, une valeur par taille
+retours_bcq_ex1 = None    # TODO etudiant : liste des retours BCQ-lite
+
+print(""Exercice a completer"")",,,,,,,,5779aec942db4b46,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,cc898e21,markdown,fr,0251e72f7b7015b9,"### Exercice 2 — Penalite conservatrice (CQL-lite tabulaire)
+
+CQL remplace l'interdiction stricte de BCQ par une **penalite** : les actions hors dataset gardent le droit d'exister, mais leur valeur est artificiellement abaissee. En tabulaire, la version la plus simple s'applique *apres* l'apprentissage naif :
+
+$$Q_{pen}(s, a) = Q_{naif}(s, a) - \beta \cdot \mathbb{1}\big[(s, a) \notin \mathcal{D}\big]$$
+
+Evaluez la politique greedy sur $Q_{pen}$ pour plusieurs $\beta$ sur le dataset **medium**. Que retrouve-t-on en $\beta = 0$ ? Vers quoi tend le comportement quand $\beta$ grandit ?",,,,,,,,0251e72f7b7015b9,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,bdb2d48e,code,fr,eb037804c141feff,"# Exercice 2 — CQL-lite : penaliser au lieu d'interdire
+# Etape 1 : entrainer l'offline Q NAIF (constrain=False) sur datasets[""medium""]
+# Etape 2 : construire Q_pen = Q - beta * masque, ou masque[s, a] = 1 si (s, a) jamais vu
+# Etape 3 : evaluer la politique greedy Q_pen.argmax(axis=1) pour chaque beta
+# Indice : construire le masque a partir de {(s, a) for s, a, *_ in data}
+
+betas = [0.0, 0.5, 2.0, 10.0]
+retours_cql = None        # TODO etudiant : retour moyen pour chaque beta
+
+print(""Exercice a completer"")",,,,,,,,eb037804c141feff,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,14aa6d84,markdown,fr,72d8df91f5c5923d,"### Exercice 3 — Convergence : combien de passes sur le dataset ?
+
+Un detail d'implementation qui n'en est pas un : `offline_q` rejoue le dataset `n_passes = 300` fois. Avec seulement 100 passes, BCQ-lite **echoue sur le dataset expert** alors que l'algorithme est correct. Reproduisez le phenomene et expliquez-le.",,,,,,,,72d8df91f5c5923d,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,7d88bc9b,code,fr,2c0a93492fd15563,"# Exercice 3 — Sensibilite au nombre de passes
+# Etape 1 : pour n_passes dans `liste_passes`, entrainer offline_q(constrain=True)
+#           sur datasets[""expert""] et evaluer la politique
+# Etape 2 : tracer le retour moyen en fonction de n_passes
+# Etape 3 : afficher Q[env.idx(env.start)] pour n_passes=100 et 300 — quelle action
+#           reste surevaluee trop longtemps, et pourquoi ?
+# Indice : en (2, 0), l'action ""gauche"" cogne le mur (transition vers soi-meme).
+#          Sa cible -1 + gamma * max Q(s) poursuit une cible mouvante : elle ne
+#          converge qu'APRES les autres valeurs — un retard que 100 passes ne comblent pas.
+
+liste_passes = [10, 50, 100, 300]
+retours_passes = None     # TODO etudiant : retour moyen pour chaque n_passes
+
+print(""Exercice a completer"")",,,,,,,,2c0a93492fd15563,,,,,,,
+MyIA.AI.Notebooks/RL/rl_9_offline_rl.ipynb,2a70d5c7,markdown,fr,58ef835a9d879d61,"## Conclusion
+
+Ce notebook a parcouru le RL offline de bout en bout sur un probleme assez petit pour que chaque echec soit dissequable :
+
+- Le **Behavior Cloning** est optimal quand les demonstrations le sont, et exactement aussi mauvais qu'elles sinon — il n'exploite pas les recompenses.
+- Le **Q-learning naif sur dataset fige** echoue meme sur des donnees parfaites : le $\max$ bootstrape sur des actions jamais observees dont la valeur d'initialisation est optimiste, et aucune interaction ne vient corriger l'illusion. C'est l'**erreur d'extrapolation**, et elle disparait precisement quand la couverture devient quasi totale.
+- La **contrainte de support** (BCQ-lite) reconcilie les deux mondes : aussi ambitieuse que la programmation dynamique dans le support des donnees, aussi prudente que l'imitation en dehors. Son fruit le plus precieux est le **stitching** — recoudre un chemin optimal a partir de trajectoires individuellement mediocres.
+
+### Passerelles
+
+- **Notebook 5** : le Q-learning online dont tout part ; **notebook 6** : le replay buffer de DQN est deja un mini-dataset offline (mais sans cesse rafraichi — c'est toute la difference) ;
+- **Notebook 8** : Dyna-Q apprend un modele des transitions ; le RL offline *model-based* (MOPO, MOReL) suit la meme voie avec une penalite d'incertitude ;
+- **[GenAI / FineTuning — FT-04 RLHF-DPO](../GenAI/FineTuning/FT-04-RLHF-DPO.ipynb)** : SFT = Behavior Cloning, RLHF = RL contraint par KL, DPO = preference learning offline — les notions de ce notebook, a l'echelle des LLM (pratique TRL/PEFT).
+- **[GenAI / PostTraining](../GenAI/PostTraining/README.md)** : la chaine complete SFT -> RLHF -> [DPO (PT-03)](../GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb) -> GRPO -> RLVR, ou la contrainte de support de BCQ devient la penalite KL de DPO. C'est la ou atterrit le pont esquisse ici.
+
+### References
+
+- Levine, Kumar, Tucker, Fu (2020), *Offline Reinforcement Learning: Tutorial, Review, and Perspectives on Open Problems*, arXiv:2005.01643
+- Fujimoto, Meger, Precup (2019), *Off-Policy Deep Reinforcement Learning without Exploration* (BCQ), ICML
+- Kumar, Zhou, Tucker, Levine (2020), *Conservative Q-Learning for Offline Reinforcement Learning* (CQL), NeurIPS
+- Ross, Gordon, Bagnell (2011), *A Reduction of Imitation Learning and Structured Prediction to No-Regret Online Learning* (DAgger), AISTATS
+- Rafailov et al. (2023), *Direct Preference Optimization: Your Language Model is Secretly a Reward Model*, NeurIPS
+- Sutton & Barto (2018), *Reinforcement Learning: An Introduction*, chap. 8 (labyrinthe fig. 8.2)",,,,,,,,58ef835a9d879d61,,,,,,,


### PR DESCRIPTION
## Livrable

12e série Phase 2 du rollout CSV-by-series (#4957) : `translations/rl/rl.csv` + `translations/rl/README.md` pour les **17 notebooks** `MyIA.AI.Notebooks/RL/` (DQN, PPO, SAC, GRPO, multi-agent — Python).

### Métriques
| | |
|---|---|
| Notebooks | 17 (rl_1→13 + sous-séries rl_6b/6c/6d/6e) |
| Cellules extraites | **486** (275 markdown + 211 code) |
| Cellules sautées (sans id) | 25 |
| Schéma | 21 colonnes (sha256-16, FR pivot + 7 langues) |
| Taille | 450 KB |

## Validation (CPU-doable)
- T1 déterminisme : re-extract → diff byte-identique.
- T2 drift-check : `anomaly_count: 0` (IN_SYNC).
- 0 doublon `(notebook, cell_id)`, secret-scan clean.
- Méthode hash sha256-16 via `extract_cells_to_csv.py` (pas deviné).

## Conformité
Additif pur `+N/-0`, catalogue intact, README FR, cross-lane (RL adjacent po-2025 via #3360, varié vs IIT livré parallèle en #5891 — anti-monoculture L335).

`See #4957` (Phase 2 — 1 série de plus dans le rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
