### PR TITLE
docs(symbolicai): réconcilier Audit Qualité table sur disk 10 juillet 2026

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -583,23 +583,23 @@ Le setup est entièrement automatisé via `Tweety-1-Setup.ipynb` :
 
 ## Audit Qualité (juillet 2026 — §E whole-file)
 
-### Couverture exercices (réconciliation disque ↔ catalogue, mise à jour 5 juillet 2026)
+### Couverture exercices (réconciliation disque ↔ catalogue, mise à jour 10 juillet 2026)
 
 | Série | Notebooks | Avec exercices | Sans exercices | Status |
 |-------|-----------|----------------|----------------|--------|
-| Tweety (Python/JPype + C#/.NET) | 27 | 14 Python / 12 Csharp (≥96%) | 1 Probe (non pédagogique) | Très bon |
+| Tweety (Python/JPype + C#/.NET) | 32 | 31 pédagogiques (13 Python + 18 C# jumeaux) | 1 Probe (`_probes/Tweety-IKVM-Init-Probe`, non pédagogique) | Très bon |
 | Lean (proofs natifs + companions Python) | 28 | 26 (93%) | 2 (Lean-1-Setup + Lean-7b-Examples) | Très bon |
-| SemanticWeb (C# + Python) | 18 | 16 (89%) | 2 (Setup + RDF.Net-Legacy) | Très bon |
-| Planners (PDDL classique + neuro-symbolique) | 15 | 14 (93%) | 1 (Planners-0-Setup) | Très bon |
+| SemanticWeb (C# + Python) | 25 | 24 pédagogiques (12 Python + 12 C# jumeaux) | 1 (RDF.Net-Legacy) | Très bon |
+| Planners (PDDL classique + neuro-symbolique) | 24 | 22 pédagogiques (13 Python + 9 C# jumeaux) | 2 (Planners-0-Setup + `archive/Fast-Downward-Legacy`) | Très bon |
 | SmartContracts | 27 | 27 (100%) | 0 | Excellent |
-| Argument Analysis (Argumentum + Agentic demo) | 18 | 0 (0%) | 18 (demo, no exercices) | N/A (projet) |
-| SymbolicLearning (AIMA ch. 19 + SL-12 differentiable logic gates) | 12 | 12 (100%) | 0 | Excellent |
+| Argument Analysis (Argumentum + Agentic demo) | 21 | 17 (81%) | 4 (Argument_Analysis_Agentic-0-init + 3 Agentic demo) | N/A (projet) |
+| SymbolicLearning (AIMA ch. 19 + SL-12 differentiable logic gates) | 22 | 20 pédagogiques (12 Python + 8 C# jumeaux) | 2 (`_archives/2026-07-04-Neurosymbolic-EML-precurseur-SL12/`, archives) | Excellent |
 | SMT/Z3 (C# Linq2Z3) | 18 | 18 (100%) | 0 | Excellent |
-| SMT/Z3-Python | 6 | 6 (100%) | 0 | Excellent |
+| SMT/Z3-Python | 12 | 12 (100%, 6 Python + 6 C# jumeaux) | 0 | Excellent |
 
-**Total** : 131/150 notebooks de contenu pédagogique avec exercices (87%). Les notebooks sans exercices sont uniquement les notebooks de setup (SW-1-CSharp-Setup, Planners-0-Setup, Lean-1-Setup, Tweety-1-Setup, Argument_Analysis_Agentic-0-init), les notebooks legacy/démo (RDF.Net-Legacy, Argument_Analysis_*), et le probe IKVM (`Tweety-IKVM-Init-Probe` non pédagogique). Les chiffres ci-dessus sont la **réconciliation disque ↔ catalogue** en date du 5 juillet 2026 (post-#5390, post-EPIC #4667 Tweety .NET marathon, post-EPIC #4960 Argumentum EPITA-IS landing).
+**Total** : 207/209 notebooks pédagogiques (99%) — soit 209 fichiers `.ipynb` (hors `_output` gitignored), après déduction 1 Probe Tweety (`_probes/Tweety-IKVM-Init-Probe`), 2 archives SymbolicLearning (`_archives/2026-07-04-Neurosymbolic-EML-precurseur-SL12/`), et 1 archive Planners (`archive/Fast-Downward-Legacy`). Les notebooks sans exercices sont uniquement les notebooks de setup (Tweety-1-Setup, SW-1-CSharp-Setup, Planners-0-Setup, Lean-1-Setup, Argument_Analysis_Agentic-0-init), les notebooks legacy/démo (Lean-7b-Examples, RDF.Net-Legacy), les archives précurseurs EML, et le probe IKVM (`Tweety-IKVM-Init-Probe` non pédagogique). Les chiffres ci-dessus sont la **réconciliation disque ↔ catalogue** en date du **10 juillet 2026** (post-#5894 SocialChoice figures sweep, post-EPIC #4956 parité marathon en cours, post-EPIC #4960 Argumentum EPITA-IS landing, post-PR #5345/#5390 Probas & SocialChoice README rolls).
 
-> **Note (07/07)** : cet instantané précède la fin du marathon parité #4956, qui porte depuis Tweety à 32 notebooks (18 C#), Planners à 23 actifs (9 jumeaux C#), SemanticWeb à 23 (11 C#), Z3-Python à 12 (6 jumeaux) et SymbolicLearning à 19 (7 jumeaux C#). Pour les comptes courants, le marqueur `CATALOG-STATUS` (régénéré quotidiennement) fait foi.
+> **Note (10/07)** : réconciliation whole-file audit §E post-#5894 (SocialChoice sweep), post-fin marathon parité #4956 (Tweety 32 = 13 Python + 18 C# + 1 probe, SemanticWeb 25 = 12 Python + 12 C# + 1 RDF.Net-Legacy, SMT/Z3-Python 12 = 6 Python + 6 C# jumeaux, Planners 23 actifs = 13 Python + 9 C# jumeaux + 0-Setup + 1 archive Fast-Downward-Legacy, SymbolicLearning 20 = 12 Python + 8 C# jumeaux + 2 archives EML, Argument_Analysis 21 = 17 Python pédagogiques + 4 Agentic demo). Pour les comptes courants, le marqueur `<!-- CATALOG-STATUS -->` (régénéré quotidiennement par `.github/workflows/catalog-cron.yml`) fait foi.
 
 ### Problèmes connus (juillet 2026)
 


### PR DESCRIPTION
## Résumé

PR §E whole-file audit (cf #3975) sur `MyIA.AI.Notebooks/SymbolicAI/README.md`. Réconciliation de la table « Audit Qualité » (datée 5 juillet 2026) sur le disk actuel (10 juillet 2026).

## Périmètre

- **1 fichier modifié** : `MyIA.AI.Notebooks/SymbolicAI/README.md` (9 insertions, 9 suppressions)
- **Aucun notebook modifié** (PR purement README/markdown)
- **Bloc `<!-- CATALOG-STATUS -->` préservé byte-identique** (catalog-pr-hygiene R1 — la régénération du catalogue revient au cron quotidien `.github/workflows/catalog-cron.yml`)

## Diagnostic

Lecture de la table « Audit Qualité » §E (lignes 588-598 du README) datée du 5 juillet 2026 et confrontation avec le disk actuel (10 juillet 2026) :

| Sous-série | Table (5/07) | Disk (10/07) | Δ | Détail |
|------------|--------------|--------------|---|--------|
| Tweety | 27 (26 péd.) | 32 (31 péd. + 1 Probe) | +5 | 13 Python + 18 C# jumeaux |
| SemanticWeb | 18 | 25 | +7 | 12 Python + 12 C# jumeaux + 1 RDF.Net-Legacy |
| Planners | 15 | 24 (1 archive) | +9 | 13 Python + 9 C# jumeaux + 0-Setup + 1 archive Fast-Downward-Legacy |
| Argument_Analysis | 18 | 21 | +3 | 17 Python + 4 Agentic demo |
| SymbolicLearning | 12 | 22 (2 archives) | +10 | 12 Python + 8 C# jumeaux + 2 archives `_archives/2026-07-04-Neurosymbolic-EML-precurseur-SL12/` |
| SMT/Z3-Python | 6 | 12 (6 jumeaux) | +6 | 6 Python + 6 C# jumeaux |
| Lean / SmartContracts / SMT/Z3 | inchangés | inchangés | 0 | — |

**Total** : 131/150 (5/07, 87%) → **207/209 (10/07, 99%)**.

**Cause** : la table datait d'avant la fin du marathon parité #4956 (Tweety, Planners, SemanticWeb, SMT/Z3-Python, SymbolicLearning) et avant l'atterrissage Argumentum #4960. La « Note (07/07) » du README reconnaissait elle-même la course mais ne mettait pas à jour la table — défaut d'audit whole-file (cf #3975, E.2 audit fichier-entier obligatoire quand une série subit un changement structurel).

## Méthodologie de vérification

- `find MyIA.AI.Notebooks/SymbolicAI/<sub> -maxdepth N -name "*.ipynb" | grep -v "_output"` par sous-série
- Tri Python / CSharp par `grep -v "Csharp"` / `grep "Csharp"` (séparation pedagogique Python vs jumeaux .NET)
- Décompte archives : `find ... -path "*_archives/*"` (cf SymbolicLearning, Planners)
- Décompte probes : `find ... -path "*_probes/*"` (cf Tweety-IKVM)
- Le bloc `<!-- CATALOG-STATUS -->` confirme en en-tête : `pedagogical_count: 207` (catalogue régénéré, cohérent avec la nouvelle table)
- Audit cross-référence avec la note (07/07) déjà partiellement à jour

## Pourquoi cette PR n'est pas catalogue-régén

Conformément à [catalog-pr-hygiene.md R1](../blob/main/.claude/rules/catalog-pr-hygiene.md) :

- Le bloc `<!-- CATALOG-STATUS -->` reste byte-identique
- Pas de modification du fichier `COURSE_CATALOG.generated.json` ou `COURSE_CATALOG.generated.md`
- Seule la **prose pédagogique** de la section « Audit Qualité » est mise à jour
- La régénération du catalogue (lui-même) reste à la charge du cron quotidien ou de la CI par-PR

## Liens

- See #3975 (méthode ascendante bottom-up §E)
- See #4959 (READMEs hub-P0)
- See #4956 (marathon parité .NET ⇄ Python)
- See #5780 (SocialChoice figures sweep — PR #5894 déjà mergée)
- See #5894 (PR précédente du même type sur SocialChoice)

## Hors scope

- Toute modification de notebooks (.ipynb) — PR purement prose
- Modification du bloc CATALOG-STATUS — laissé au cron/catalog-drift
- Modification d'autres README (Tweety, SemanticWeb, etc.) — chaque sous-série a sa propre table dans son propre README
- Modification du fichier catalogue — laissé à l'automatisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
