### PR TITLE
docs(gametheory): réconcilier count SC sous-série (4 → 7) sur disk 10/07

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -213,7 +213,7 @@ Les **side tracks** approfondissent les concepts du notebook principal :
 |-------|------|-------------|
 | **b** | Lean 4 | Formalisation mathématique, preuves formelles |
 | **c** | Python | Approfondissement, exemples avancés, visualisations |
-| **SC** | Mixte | Sous-série [SocialChoice/](SocialChoice/) : Arrow, Sen, SAT, Z3 (4 notebooks) |
+| **SC** | Mixte | Sous-série [SocialChoice/](SocialChoice/) : Arrow, Sen, SAT, Z3 (**7 notebooks** : SC-01 à SC-04 + 3 jumeaux C# livrés par marathon parité #4956) |
 
 **Organisation** :
 - Chaque notebook principal inclut des liens vers ses side tracks


### PR DESCRIPTION
## Résumé

PR §E whole-file audit sur `MyIA.AI.Notebooks/GameTheory/README.md`. Réconciliation de la table des side tracks (ligne 216) sur le disk actuel (10 juillet 2026). Suite du rollout c.378 PR #5901 sur le hub SymbolicAI.

## Périmètre

- **1 fichier modifié** : `MyIA.AI.Notebooks/GameTheory/README.md` (1 insertion, 1 suppression)
- **Aucun notebook modifié** (PR purement README/markdown)
- **Bloc `<!-- CATALOG-STATUS -->` byte-identique** (catalog-pr-hygiene R1 — la régénération du catalogue revient au cron quotidien `.github/workflows/catalog-cron.yml`)

## Diagnostic

Lecture de la table « side tracks » §E du hub GameTheory (ligne 216) datant d'avant le marathon parité #4956 et confrontation avec le disk actuel (10 juillet 2026) :

| Élément | Table (avant) | Disk (10/07) | Δ | Détail |
|---------|---------------|--------------|---|--------|
| Sous-série SocialChoice/ ligne 216 | (4 notebooks) | (7 notebooks) | **+3** | SC-01 Arrow + SC-02 Lean + SC-03 Voting + SC-04 SAT/Z3 (4 Python/Lean) **+ 3 jumeaux C#** (SC-01/03/04-Csharp) livrés par le marathon parité .NET ⇄ Python #4956 |
| Ligne 272 jumeaux C# | (23 fichiers) | (23 fichiers) | 0 | 20 GameTheory (GT-2/3/4/4c/5/6/6c/7/8/8c/9/10/11/12/13/14/15/15c/16/17-Csharp) + 3 SocialChoice (SC-01/03/04-Csharp) = **23 fichiers** ✓ |

**Seul** le count de la ligne 216 était obsolète (4 → 7). La ligne 272 est exacte après vérification firsthand (`find` count).

## Méthodologie de vérification

- `find MyIA.AI.Notebooks/GameTheory -maxdepth 2 -name "*-Csharp.ipynb" | grep -v "_output"` → 23 fichiers
- `find MyIA.AI.Notebooks/GameTheory/SocialChoice -maxdepth 2 -name "*.ipynb" | grep -v "_output"` → 7 fichiers (4 Python/Lean + 3 jumeaux C#)
- Lecture de la table de maturité §E (lignes 238-270) : qualitative par notebook, aucun count à corriger
- Lecture des arbres de structure et listes de notebooks : à jour

## Pourquoi cette PR n'est pas catalogue-régén

Conformément à [catalog-pr-hygiene.md R1](../blob/main/.claude/rules/catalog-pr-hygiene.md) :

- Le bloc `<!-- CATALOG-STATUS -->` reste byte-identique
- Pas de modification du fichier `COURSE_CATALOG.generated.json` ou `COURSE_CATALOG.generated.md`
- Seule la **prose pédagogique** de la table des side tracks est mise à jour
- La régénération du catalogue (lui-même) reste à la charge du cron quotidien ou de la CI par-PR

## Liens

- See #3975 (méthode ascendante bottom-up §E)
- See #3974 (owner-rollout hubs MC/familles proches)
- See #4956 (marathon parité .NET ⇄ Python)
- See #4959 (READMEs hub-P0)
- See #5901 (PR précédente du même type sur le hub SymbolicAI, c.378)
- See #5780 (SocialChoice figures sweep — PR #5894 déjà mergée c.374)

## Hors scope

- Toute modification de notebooks (.ipynb) — PR purement prose
- Modification du bloc CATALOG-STATUS — laissé au cron/catalog-drift
- Modification d'autres README (sous-séries, hubs SymbolicAI, Search, etc.) — chaque série/hub a sa propre table dans son propre README
- Modification du fichier catalogue — laissé à l'automatisation