### PR TITLE
feat(lean): absorb StableMarriage.GSState (FR+EN) into game_theory_lean (c.301, See #4365)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
@@ -23,3 +23,5 @@
 
 import StableMarriage.Definitions
 import StableMarriage.Definitions_en
+import StableMarriage.GSState
+import StableMarriage.GSState_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
@@ -1,14 +1,25 @@
 /-
-  GameTheory.StableMarriage — stub aggregator (c.299 skeleton)
-  ============================================================
+  GameTheory.StableMarriage — root aggregator (EPIC #4365 phase 4)
+  ================================================================
 
-  Ce module sera peuple par absorption successive de
-  `stable_marriage_lean/StableMarriage/{Definitions,GaleShapley,
-  Lattice,Lemmas,GSState}{,_en}.lean` dans les cycles c.300+ (PR
-  dediees par module, cf EPIC #4365 phase 4).
+  Ce module agregera les 5 sous-modules absorbes depuis
+  `stable_marriage_lean/StableMarriage/` :
 
-  Pour c.299, le seul but est de valider la structure du lake
-  cible (`lakefile.lean`, `lake-manifest.json`,
-  `lean-toolchain`, globs `StableMarriage.*`). Aucun module
-  reel n'a encore ete deplace.
+  - `StableMarriage.Definitions`      (absorbe c.300)
+  - `StableMarriage.GSState`          (c.301)
+  - `StableMarriage.Lemmas`           (c.302)
+  - `StableMarriage.GaleShapley`      (c.303)
+  - `StableMarriage.Lattice`          (c.304)
+
+  La suppression des fichiers source dans `stable_marriage_lean/`
+  interviendra en c.305 (PR dediee `debt`/`regression-accepted`,
+  cf anti-regression protocol 4 etapes).
+
+  Convention i18n (EPIC #4980 ratifiee user 2026-07-04) : les
+  sous-modules `.lean` et leurs siblings `_en.lean` (namespace
+  `<Nom>_en`) sont auto-decouverts par le `globs := #[`StableMarriage.*]`
+  du lakefile. La CI drift-detection voit les deux langues.
 -/
+
+import StableMarriage.Definitions
+import StableMarriage.Definitions_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Definitions.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Definitions.lean
@@ -1,0 +1,125 @@
+/-
+  Mariage stable — Définitions
+  =============================
+
+  Types et définitions fondamentaux pour le problème du mariage stable.
+  On modélise n hommes et n femmes (tous deux via `Fin n`), chacun muni d'un
+  ordre de préférence strict sur l'ensemble opposé.
+
+  Un couplage (matching) est une bijection entre hommes et femmes.
+  Un couplage est stable si et seulement si aucune paire bloquante
+  (blocking pair) n'existe.
+
+  Convention i18n (cf #4980) : en-têtes et docstrings en français,
+  noms de symboles Lean et tactiques préservés en anglais (compatibilité Mathlib).
+-/
+
+import Mathlib.Data.Finset.Basic
+
+namespace StableMarriage
+
+open Finset Function
+
+variable {n : Nat} [NeZero n]
+
+/-- Un homme est identifié par `Fin n` -/
+abbrev Man (n : Nat) := Fin n
+
+/-- Une femme est identifiée par `Fin n` -/
+abbrev Woman (n : Nat) := Fin n
+
+/--
+Profil de préférence d'une personne sur l'ensemble opposé.
+Représenté par une fonction associant à chaque candidat son rang (plus petit = préféré).
+La préférence stricte signifie que la fonction de classement est injective.
+-/
+structure PrefProfile (n : Nat) [NeZero n] where
+  /-- Préférences des hommes : chaque homme classe toutes les femmes -/
+  menPref : Fin n → Fin n → Fin n
+  /-- Préférences des femmes : chaque femme classe tous les hommes -/
+  womenPref : Fin n → Fin n → Fin n
+  /-- Le classement de chaque homme est une permutation (bijectif) -/
+  menPref_bijective : ∀ m, Bijective (menPref m)
+  /-- Le classement de chaque femme est une permutation (bijectif) -/
+  womenPref_bijective : ∀ w, Bijective (womenPref w)
+
+namespace PrefProfile
+
+variable {n : Nat} [NeZero n] (prof : PrefProfile n)
+
+/--
+L'homme `m` préfère la femme `w1` à la femme `w2` si et seulement si `w1`
+a un rang plus petit. Puisque `menPref m` est une bijection `Fin n → Fin n`,
+un rang plus petit signifie plus préférée.
+-/
+def manPrefers (m : Fin n) (w1 w2 : Fin n) : Bool :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+La femme `w` préfère l'homme `m1` à l'homme `m2` si et seulement si `m1`
+a un rang plus petit.
+-/
+def womanPrefers (w : Fin n) (m1 m2 : Fin n) : Bool :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+/--
+L'homme `m` préfère strictement la femme `w1` à la femme `w2`.
+Version Prop-valued pour les énoncés de théorèmes.
+-/
+def ManPrefers (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+La femme `w` préfère strictement l'homme `m1` à l'homme `m2`.
+-/
+def WomanPrefers (w : Fin n) (m1 m2 : Fin n) : Prop :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+end PrefProfile
+
+/--
+Un couplage (matching) est une bijection des hommes vers les femmes
+(couplage parfait).
+-/
+structure Matching (n : Nat) [NeZero n] where
+  /-- Associe chaque homme à sa femme appariée -/
+  spouse : Fin n → Fin n
+  /-- Le couplage est bijectif (chaque femme est appariée à exactement un homme) -/
+  bijective : Bijective spouse
+
+namespace Matching
+
+variable {n : Nat} [NeZero n] (μ : Matching n)
+
+/-- Récupère l'inverse : quel homme est apparié à la femme `w` -/
+noncomputable def inverse (w : Fin n) : Fin n :=
+  (Equiv.ofBijective μ.spouse μ.bijective).symm w
+
+end Matching
+
+/--
+Paire bloquante pour le couplage `μ` sous le profil de préférence `prof` :
+un homme `m` et une femme `w` qui se préfèrent mutuellement à leurs partenaires
+actuels.
+-/
+def IsBlockingPair (prof : PrefProfile n) (μ : Matching n)
+    (m : Fin n) (w : Fin n) : Prop :=
+  prof.ManPrefers m w (μ.spouse m) ∧
+  prof.WomanPrefers w m (μ.inverse w)
+
+/--
+Un couplage est stable si et seulement si aucune paire bloquante n'existe.
+-/
+def IsStable (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  ∀ m w, ¬ IsBlockingPair prof μ m w
+
+/--
+Un couplage est optimal pour les hommes si et seulement si chaque homme
+obtient sa meilleure partenaire possible parmi tous les couplages stables.
+-/
+def IsManOptimal (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  IsStable prof μ ∧
+  ∀ μ' : Matching n, IsStable prof μ' →
+    ∀ m : Fin n, prof.menPref m (μ.spouse m) ≤ prof.menPref m (μ'.spouse m)
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Definitions_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Definitions_en.lean
@@ -1,0 +1,132 @@
+/-
+  Stable Marriage - Definitions
+  =============================
+
+  English mirror of `StableMarriage/Definitions.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `StableMarriage_en` (le FR canonique reste `StableMarriage`).
+  Convention observée dans `GaleShapley_en.lean` / `Lattice_en.lean` :
+  les imports intra-lake restent sur les fichiers FR canoniques
+  (e.g. `import StableMarriage.Definitions`), seul `namespace StableMarriage`
+  est renommé en `namespace StableMarriage_en`.
+  Pas une traduction destructive : manual translation FR-first-from-origin
+  (pas d'historique EN pré-Option A pour ce fichier) ; code tactique Lean
+  byte-identique préservé verbatim, prose (header + sections + docstrings)
+  traduite. Pattern identique c.238.2/#5362 (RepeatedGames), c.238.3/#5363
+  (Minimax), c.238.4/#5419 (Shapley).
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+import Mathlib.Data.Finset.Basic
+
+namespace StableMarriage_en
+
+
+open Finset Function
+
+variable {n : Nat} [NeZero n]
+
+/-- A man is identified by `Fin n` -/
+abbrev Man (n : Nat) := Fin n
+
+/-- A woman is identified by `Fin n` -/
+abbrev Woman (n : Nat) := Fin n
+
+/--
+Preference profile of a person over the opposite set.
+Represented by a function assigning to each candidate its rank (smallest = preferred).
+Strict preference means that the ranking function is injective.
+-/
+structure PrefProfile (n : Nat) [NeZero n] where
+  /-- Men's preferences: each man ranks all women -/
+  menPref : Fin n → Fin n → Fin n
+  /-- Women's preferences: each woman ranks all men -/
+  womenPref : Fin n → Fin n → Fin n
+  /-- The ranking of each man is a permutation (bijective) -/
+  menPref_bijective : ∀ m, Bijective (menPref m)
+  /-- The ranking of each woman is a permutation (bijective) -/
+  womenPref_bijective : ∀ w, Bijective (womenPref w)
+
+namespace PrefProfile
+
+variable {n : Nat} [NeZero n] (prof : PrefProfile n)
+
+/--
+Man `m` prefers woman `w1` to woman `w2` if and only if `w1`
+has a smaller rank. Since `menPref m` is a bijection `Fin n → Fin n`,
+a smaller rank means more preferred.
+-/
+def manPrefers (m : Fin n) (w1 w2 : Fin n) : Bool :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+Woman `w` prefers man `m1` to man `m2` if and only if `m1`
+has a smaller rank.
+-/
+def womanPrefers (w : Fin n) (m1 m2 : Fin n) : Bool :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+/--
+Man `m` strictly prefers woman `w1` to woman `w2`.
+Prop-valued version for theorem statements.
+-/
+def ManPrefers (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+Woman `w` strictly prefers man `m1` to man `m2`.
+-/
+def WomanPrefers (w : Fin n) (m1 m2 : Fin n) : Prop :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+end PrefProfile
+
+/--
+A matching is a bijection from men to women
+(perfect matching).
+-/
+structure Matching (n : Nat) [NeZero n] where
+  /-- Associates each man to his matched woman -/
+  spouse : Fin n → Fin n
+  /-- The matching is bijective (each woman is matched to exactly one man) -/
+  bijective : Bijective spouse
+
+namespace Matching
+
+variable {n : Nat} [NeZero n] (μ : Matching n)
+
+/-- Retrieves the inverse: which man is matched to woman `w` -/
+noncomputable def inverse (w : Fin n) : Fin n :=
+  (Equiv.ofBijective μ.spouse μ.bijective).symm w
+
+end Matching
+
+/--
+Blocking pair for matching `μ` under preference profile `prof`:
+a man `m` and a woman `w` who mutually prefer each other to their current
+partners.
+-/
+def IsBlockingPair (prof : PrefProfile n) (μ : Matching n)
+    (m : Fin n) (w : Fin n) : Prop :=
+  prof.ManPrefers m w (μ.spouse m) ∧
+  prof.WomanPrefers w m (μ.inverse w)
+
+/--
+A matching is stable if and only if no blocking pair exists.
+-/
+def IsStable (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  ∀ m w, ¬ IsBlockingPair prof μ m w
+
+/--
+A matching is man-optimal if and only if each man
+gets his best possible partner among all stable matchings.
+-/
+def IsManOptimal (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  IsStable prof μ ∧
+  ∀ μ' : Matching n, IsStable prof μ' →
+    ∀ m : Fin n, prof.menPref m (μ.spouse m) ≤ prof.menPref m (μ'.spouse m)
+
+end StableMarriage_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState.lean
@@ -1,0 +1,173 @@
+/-
+  Mariage stable — État de l'algorithme de Gale-Shapley
+  ======================================================
+
+  État intermédiaire pour l'algorithme d'acceptation différée de Gale-Shapley.
+  Utilise un couplage partiel basé sur `Option` pendant l'exécution de l'algorithme,
+  converti en couplage bijectif total à la terminaison.
+
+  Convention i18n (cf #4980) : en-têtes, sections, docstrings et commentaires
+  intra-preuve en français ; noms de symboles Lean, énoncés de lemmes et
+  tactiques préservés en anglais (compatibilité Mathlib).
+
+  Adapté de : https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+-/
+
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Order.Preorder.Finite
+import StableMarriage.Definitions
+
+namespace StableMarriage
+
+open Function Finset Classical
+
+variable {n : Nat} [NeZero n]
+
+/-- Couplage partiel pendant l'exécution de l'algorithme GS. -/
+structure GSMatching (n : Nat) [NeZero n] where
+  menMatch : Fin n → Option (Fin n)
+  womenMatch : Fin n → Option (Fin n)
+
+namespace GSMatching
+
+def initial : GSMatching n where
+  menMatch := fun _ => none
+  womenMatch := fun _ => none
+
+def matchFree (μ : GSMatching n) (m w : Fin n) : GSMatching n where
+  menMatch := Function.update μ.menMatch m (some w)
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+def swapMatch (μ : GSMatching n) (m mOld w : Fin n) : GSMatching n where
+  menMatch := Function.update (Function.update μ.menMatch m (some w)) mOld none
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+end GSMatching
+
+/-- État intermédiaire pour l'algorithme d'acceptation différée de Gale-Shapley. -/
+structure GSState (prof : PrefProfile n) where
+  matching : GSMatching n
+  proposed : Fin n → Fin n → Prop
+
+section GSDefs
+
+variable (prof : PrefProfile n)
+
+def gsInitial : GSState prof where
+  matching := GSMatching.initial
+  proposed := fun _ _ => False
+
+noncomputable def gsCandidates (σ : GSState prof) (m : Fin n) : Finset (Fin n) :=
+  Finset.univ.filter (fun w => ¬ σ.proposed m w)
+
+def gsIsFree (σ : GSState prof) (m : Fin n) : Prop :=
+  σ.matching.menMatch m = none ∧ (gsCandidates prof σ m).Nonempty
+
+def gsTerminated (σ : GSState prof) : Prop :=
+  ¬ ∃ m, gsIsFree prof σ m
+
+def gsMenPrefLE (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  w1 = w2 ∨ prof.menPref m w2 < prof.menPref m w1
+
+noncomputable def gsChooseMax (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) : Fin n :=
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  Classical.choose ((gsCandidates prof σ m).exists_maximal h)
+
+noncomputable def gsStepWith (σ : GSState prof) (m w : Fin n) : GSState prof :=
+  let proposed' : Fin n → Fin n → Prop :=
+    fun m' w' => σ.proposed m' w' ∨ (m' = m ∧ w' = w)
+  match _ : σ.matching.womenMatch w with
+  | none =>
+      { matching := σ.matching.matchFree m w
+        proposed := proposed' }
+  | some mOld =>
+      if prof.womenPref w m < prof.womenPref w mOld then
+        { matching := σ.matching.swapMatch m mOld w
+          proposed := proposed' }
+      else
+        { matching := σ.matching
+          proposed := proposed' }
+
+noncomputable def gsStep (σ : GSState prof) : GSState prof :=
+  if hfree : ∃ m, gsIsFree prof σ m then
+    let m := Classical.choose hfree
+    have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+    let w := gsChooseMax prof σ m hm.2
+    gsStepWith prof σ m w
+  else
+    σ
+
+end GSDefs
+
+-- Ces définitions utilisent le paramètre explicite `prof` pour éviter la duplication
+-- des variables de section.
+noncomputable def gsRunSteps (prof : PrefProfile n) (k : Nat) : GSState prof :=
+  match k with
+  | 0 => gsInitial prof
+  | k' + 1 => gsStep prof (gsRunSteps prof k')
+
+def gsProposalBound (n : Nat) [NeZero n] : Nat := n * n
+
+noncomputable def gsGaleShapley (prof : PrefProfile n) : GSMatching n :=
+  (gsRunSteps prof (gsProposalBound n)).matching
+
+/-! ## Lemmes auxiliaires pour `gsChooseMax` -/
+
+/-- La candidate maximale choisie appartient à l'ensemble des candidates. -/
+lemma gsChooseMax_mem (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) :
+    gsChooseMax prof σ m h ∈ gsCandidates prof σ m := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  obtain ⟨hmem, -⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  exact hmem
+
+/-- Aucune candidate non-proposée n'est préférée à la candidate maximale choisie.
+    Directement depuis la maximalité : ∀ y ∈ candidates, y ≤ choose. -/
+lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
+    (hw : w ∈ gsCandidates prof σ m) :
+    gsMenPrefLE prof m w (gsChooseMax prof σ m h) := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  set c := Classical.choose (Finset.exists_maximal h) with hc
+  obtain ⟨-, hmax⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  have htri := Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m c)
+  rcases htri with (hlt | heq | hgt)
+  · -- `choose` est préférée à `w` : `choose ≤ w`, donc `hmax` donne `w ≤ choose`
+    have hle : c ≤ w := Or.inr hlt
+    exact hmax hw hle
+  · -- Préférence égale : l'injectivité donne `w = c`
+    left
+    exact (prof.menPref_bijective m).injective (Fin.ext heq)
+  · -- `w` est préférée à `choose` : direct
+    right
+    exact hgt
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState_en.lean
@@ -1,0 +1,180 @@
+/-
+  Stable Marriage - Gale-Shapley Algorithm State
+  ==============================================
+
+  English mirror of `StableMarriage/GSState.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `StableMarriage_en` (le FR canonique reste `StableMarriage`).
+  Convention observée : imports intra-lake restent sur fichiers FR canoniques.
+  Pas une traduction destructive : manual translation FR-first-from-origin
+  (pas d'historique EN pré-Option A pour ce fichier) ; code tactique Lean
+  byte-identique préservé verbatim, prose traduite. Pattern identique
+  c.238.2/#5362 (RepeatedGames), c.238.3/#5363 (Minimax), c.238.4/#5419 (Shapley).
+
+  Adapté de / Adapted from: https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Order.Preorder.Finite
+import StableMarriage.Definitions
+
+namespace StableMarriage_en
+
+
+open Function Finset Classical
+open StableMarriage
+
+variable {n : Nat} [NeZero n]
+
+/-- Partial matching during the execution of the GS algorithm. -/
+structure GSMatching (n : Nat) [NeZero n] where
+  menMatch : Fin n → Option (Fin n)
+  womenMatch : Fin n → Option (Fin n)
+
+namespace GSMatching
+
+def initial : GSMatching n where
+  menMatch := fun _ => none
+  womenMatch := fun _ => none
+
+def matchFree (μ : GSMatching n) (m w : Fin n) : GSMatching n where
+  menMatch := Function.update μ.menMatch m (some w)
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+def swapMatch (μ : GSMatching n) (m mOld w : Fin n) : GSMatching n where
+  menMatch := Function.update (Function.update μ.menMatch m (some w)) mOld none
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+end GSMatching
+
+/-- Intermediate state for the Gale-Shapley deferred acceptance algorithm. -/
+structure GSState (prof : PrefProfile n) where
+  matching : GSMatching n
+  proposed : Fin n → Fin n → Prop
+
+section GSDefs
+
+variable (prof : PrefProfile n)
+
+def gsInitial : GSState prof where
+  matching := GSMatching.initial
+  proposed := fun _ _ => False
+
+noncomputable def gsCandidates (σ : GSState prof) (m : Fin n) : Finset (Fin n) :=
+  Finset.univ.filter (fun w => ¬ σ.proposed m w)
+
+def gsIsFree (σ : GSState prof) (m : Fin n) : Prop :=
+  σ.matching.menMatch m = none ∧ (gsCandidates prof σ m).Nonempty
+
+def gsTerminated (σ : GSState prof) : Prop :=
+  ¬ ∃ m, gsIsFree prof σ m
+
+def gsMenPrefLE (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  w1 = w2 ∨ prof.menPref m w2 < prof.menPref m w1
+
+noncomputable def gsChooseMax (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) : Fin n :=
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  Classical.choose ((gsCandidates prof σ m).exists_maximal h)
+
+noncomputable def gsStepWith (σ : GSState prof) (m w : Fin n) : GSState prof :=
+  let proposed' : Fin n → Fin n → Prop :=
+    fun m' w' => σ.proposed m' w' ∨ (m' = m ∧ w' = w)
+  match _ : σ.matching.womenMatch w with
+  | none =>
+      { matching := σ.matching.matchFree m w
+        proposed := proposed' }
+  | some mOld =>
+      if prof.womenPref w m < prof.womenPref w mOld then
+        { matching := σ.matching.swapMatch m mOld w
+          proposed := proposed' }
+      else
+        { matching := σ.matching
+          proposed := proposed' }
+
+noncomputable def gsStep (σ : GSState prof) : GSState prof :=
+  if hfree : ∃ m, gsIsFree prof σ m then
+    let m := Classical.choose hfree
+    have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+    let w := gsChooseMax prof σ m hm.2
+    gsStepWith prof σ m w
+  else
+    σ
+
+end GSDefs
+
+-- Ces définitions utilisent le paramètre explicite `prof` pour éviter la duplication
+-- des variables de section.
+noncomputable def gsRunSteps (prof : PrefProfile n) (k : Nat) : GSState prof :=
+  match k with
+  | 0 => gsInitial prof
+  | k' + 1 => gsStep prof (gsRunSteps prof k')
+
+def gsProposalBound (n : Nat) [NeZero n] : Nat := n * n
+
+noncomputable def gsGaleShapley (prof : PrefProfile n) : GSMatching n :=
+  (gsRunSteps prof (gsProposalBound n)).matching
+
+/-! ## Lemmes auxiliaires pour `gsChooseMax` -/
+
+/-- La candidate maximale choisie appartient à l'ensemble des candidates. -/
+lemma gsChooseMax_mem (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) :
+    gsChooseMax prof σ m h ∈ gsCandidates prof σ m := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  obtain ⟨hmem, -⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  exact hmem
+
+/-- Aucune candidate non-proposée n'est préférée à la candidate maximale choisie.
+    Directement depuis la maximalité : ∀ y ∈ candidates, y ≤ choose. -/
+lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
+    (hw : w ∈ gsCandidates prof σ m) :
+    gsMenPrefLE prof m w (gsChooseMax prof σ m h) := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  set c := Classical.choose (Finset.exists_maximal h) with hc
+  obtain ⟨-, hmax⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  have htri := Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m c)
+  rcases htri with (hlt | heq | hgt)
+  · -- `choose` est préférée à `w` : `choose ≤ w`, donc `hmax` donne `w ≤ choose`
+    have hle : c ≤ w := Or.inr hlt
+    exact hmax hw hle
+  · -- Préférence égale : l'injectivité donne `w = c`
+    left
+    exact (prof.menPref_bijective m).injective (Fin.ext heq)
+  · -- `w` est préférée à `choose` : direct
+    right
+    exact hgt
+
+end StableMarriage_en


### PR DESCRIPTION
## Summary

EPIC **#4365** phase 4 — **c.301 : absorption `StableMarriage.GSState` (FR + EN sibling)** dans le lake cible `game_theory_lean/`. Suite du rolling c.300 (#5904 = `Definitions`).

**Dépendance stacked** : cette PR est **basée sur #5904** (qui est elle-même sur #5902). Le root aggregator `StableMarriage.lean` grandit d'un import par PR — modèle stacked robuste, **pas de conflit add/add** (chaque PR ajoute juste 2 lignes d'import à l'aggregator existant).

| Fichier | Rôle | Stats |
|---------|------|-------|
| `game_theory_lean/StableMarriage/GSState.lean` | Module FR canon (namespace `StableMarriage`, sous-namespace `GSMatching`) | 173 lignes, copie byte-identique source, **0 sorries** |
| `game_theory_lean/StableMarriage/GSState_en.lean` | Module EN sibling (namespace `StableMarriage_en`) | 180 lignes, copie byte-identique, **0 sorries**, prose traduite |
| `game_theory_lean/StableMarriage.lean` | Root aggregator : +2 imports (`GSState` + `GSState_en`) | 27 lignes (25→27) |

**Aucun fichier source modifié.** `stable_marriage_lean/` reste intact (cf c.305 = PR dédiée `debt` pour les deletions, anti-regression protocol 4 étapes).

## Pattern appliqué

Suite directe de c.299 (#5902 skeleton) → c.300 (#5904 Definitions) → **c.301 (cette PR = GSState)**. Modèle `decision_theory_lean` : `globs := #[`StableMarriage.*]` auto-découvre les nouveaux siblings `_en.lean` (convention EPIC #4980). L'aggregator grandit d'un `import` par sous-module absorbé.

## Scope (§A composite checks)

| Metric | Value | Threshold | OK? |
|--------|-------|-----------|-----|
| `additions + deletions` | +356/−1 | > 3000 = split | OK |
| `changedFiles` | 3 | > 15 = split | OK |
| Distinct features | 1 (absorber GSState + EN sibling) | > 4 = split | OK |
| Domain | 1 (Lean / GameTheory) | > 1 = split | OK |

§A : **PASS** — strictement single-subject, single-domain, single-feature. Contenu mathématique substantiel (`GSState` / `GSMatching` structs) pré-existant dans `stable_marriage_lean/` ; cette PR = **copie byte-identique** vers le lake cible, pas de nouveau code rédigé.

## §B Lean PR body

| Element | Status | Notes |
|---------|--------|-------|
| `grep -c sorry` per `.lean` file | **0 → 0** | `GSState.lean` : 0 ; `GSState_en.lean` : 0 ; `StableMarriage.lean` : 0 (doc + imports) |
| Lake build SUCCESS local (standalone) | **YES** | `lake build StableMarriage` = "Build completed successfully (636 jobs)" (vs 588 c.300, **+48** pour GSState+GSState_en+aggregator recompile). `StableMarriage.GSState` (5.9s) + `StableMarriage.GSState_en` (5.0s) + aggregator (5.1s). |
| Lake build SUCCESS source lake (regression) | **YES** | `stable_marriage_lean/` inchangé byte-identique → `lake build` source = inchangé |
| Proof integrity | **PRESERVED** | aucun .lean de `stable_marriage_lean/` modifié ; aucun sorries touché |
| `_en` sibling (L266) | **YES** | `GSState_en.lean` absorbé simultanément, namespace `StableMarriage_en`, byte-identique au source |
| LF doctrine (L268 #4) | **YES** | `file` sur les 2 nouveaux fichiers = UTF-8 LF (GSState.lean source CRLF → normalisé LF à l'absorption ; source laissé intact) |

Vérifications firsthand :

- `diff stable_marriage_lean/.../GSState.lean game_theory_lean/.../GSState.lean` : **IDENTICAL** (byte-identique, hors normalisation LF)
- `git diff origin/main..HEAD -- 'stable_marriage_lean/'` : **vide** — aucun fichier source touché
- `grep -c sorry` sur cible = **0** ; source = inchangé
- `lake build StableMarriage` : 636 jobs SUCCESS, exit 0
- `file <path>` (LF) : GSState.lean + GSState_en.lean = UTF-8 LF

## Anti-regression

- Contenu mathématique copié byte-identique depuis source → `grep -c sorry` cible = 0, source = inchangé
- Aucun fichier de `stable_marriage_lean/`, `decision_theory_lean`, `cooperative_games_lean`, `social_choice_lean`, `knot_lean`, `conway_lean` touché
- Aucun notebook touché, aucun sorries touché

## §F doc-group / §G vigilance

**§F** N/A (3 fichiers `.lean` = infra mathématique, pas doc-only). **G.4 composite** : 356 << 3000 PASS. **G.6 audit cascade** : single-subject, merge order #5902 → #5904 → cette PR (stacked, chaque rebase propre). **G.1** : §B cite commandes `lake build`/`grep`/`diff` réelles.

## L266 sibling-EN-oublié check

**PR inclut le sibling `_en`** : `GSState_en.lean` (namespace `StableMarriage_en`) absorbé simultanément. PAS d'oubli EN.

## L279 worker never merges

PR forwardée à ai-01. Worker INTERDIT `gh pr merge` (#1502). Sweep §H.4 par ai-01.

## L335 anti-monotonie

c.300 → c.301 : même EPIC #4365 (rolling absorption), module distinct (`Definitions` → `GSState`). C'est un multi-step epic planifié (chaque module = nouveau grain atomique), pas un mono-thème tunnelisé : c.302=Lemmas, c.303=GaleShapley, c.304=Lattice, c.305=deletions. PASS L335.

## Plan rolling c.302+ (suite)

| Cycle | Module | Risque |
|-------|--------|--------|
| c.301 (THIS) | `GSState` + `_en` | Faible ✅ |
| c.302 | `Lemmas` + `_en` (gros fichier 38k+37k octets) | Moyen |
| c.303 | `GaleShapley` + `_en` (scaffold) | Faible |
| c.304 | `Lattice` + `_en` (prose-sorry mentions only) | Moyen |
| c.305 | `stable_marriage_lean/` deletions | Élevée — PR `debt` |

## Link EPICs

- **#4365** — Regrouper les lakes cohésifs post-convergence (GameTheory 6→2). owner implicite = po-2026
- **#4362** — EPIC parent Lean
- **#4980** — i18n multilingue (convention `globs` auto-discovery siblings `_en`)

See #4365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
