### PR TITLE
feat(conway): N2 tight-Chebyshev light-cone lemmas (chebDist + margin sufficiency) (#3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
@@ -30,6 +30,7 @@ import Conway.Life.Computation
 import Conway.Life.HashlifeCorrectness
 import Conway.Life.HashlifeMemo
 import Conway.Life.HashlifeMarginDemo
+import Conway.Life.LightCone
 import Conway.Life.Pillars
 import Conway.KochenSpecker
 import Conway.FreeWillTheorem

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -76,5 +76,26 @@ theorem mem_lightCone_of_chebyshev_le (p q : Int × Int) (t : Nat)
   unfold manhattan
   omega
 
+/-! ## Translation invariance: shifting the center shifts the cone
+
+The light cone is translation-equivariant: membership of `q` in `lightCone p t`
+depends only on the displacement `q - p`, not on the absolute position `p`. This
+is the Grid-level counterpart of the `toGrid` offset-shift machinery in
+`HashlifeCorrectness` (`toGrid_shift`, `toGrid_shift_between`), and is the
+structural fact needed to relate the light cone before and after a `hashlifeJump`
+shifts the grid by `jumpResultOff` in `evolveHashlifeFastAux`. The cone is an
+isometry of the Manhattan metric, so its shape is preserved under translation. -/
+theorem lightCone_translate (p q : Int × Int) (t : Nat) :
+    q ∈ lightCone p t ↔ (q.1 - p.1, q.2 - p.2) ∈ lightCone (0, 0) t := by
+  constructor
+  · intro h
+    apply mem_lightCone_of_manhattan_le (0, 0) _ t
+    have hm := manhattan_le_of_mem_lightCone p q t h
+    unfold manhattan at *; omega
+  · intro h
+    apply mem_lightCone_of_manhattan_le p q t
+    have hm := manhattan_le_of_mem_lightCone (0, 0) _ t h
+    unfold manhattan at *; omega
+
 end Life
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -97,5 +97,70 @@ theorem lightCone_translate (p q : Int × Int) (t : Nat) :
     have hm := manhattan_le_of_mem_lightCone (0, 0) _ t h
     unfold manhattan at *; omega
 
+/-! ## Chebyshev (chessboard) distance and the tight locality cone
+
+The *tight* Game-of-Life locality is governed by the Chebyshev (L∞) distance:
+one B3/S23 generation reaches exactly the Moore neighborhood (Chebyshev radius
+1), so `t` generations reach Chebyshev radius `t`. The `lightCone` machinery
+above uses the Manhattan (L1) distance, which over-approximates the tight reach
+by a factor of 2 — `step_light_cone` demands Manhattan radius `2 * t`. The
+lemmas below formalize the Chebyshev cone structure that a *tight* single-jump
+correctness proof chains through:
+
+- the cone fits in a margin-`t` box (**margin sufficiency** — the geometric fact
+  that makes the `padCenter2` margin `2^k` sufficient for a single jump of `2^k`
+  generations: the tight Chebyshev reach `2^k` fits exactly in a margin-`2^k`
+  box, whereas the loose Manhattan-`2^k` light cone would need `2^(k+1)`); and
+- the tight cone is contained in the loose Manhattan-`2*t` light cone.
+
+These are the elementary distance facts; they do not yet assert anything about
+`evolve` (the locality statement `step_light_cone` lives in `HashlifeCorrectness`).
+Epic #3846 (Hashlife correctness infrastructure, N2 tight-locality groundwork). -/
+
+/-- Chebyshev (chessboard / L∞) distance between two cells: the larger of the
+    absolute coordinate displacements. -/
+def chebDist (p q : Int × Int) : Nat :=
+  max (Int.natAbs (q.1 - p.1)) (Int.natAbs (q.2 - p.2))
+
+/-- Reflexivity: a cell is at Chebyshev distance 0 from itself. -/
+theorem chebDist_self (p : Int × Int) : chebDist p p = 0 := by
+  unfold chebDist; omega
+
+/-- Symmetry: the Chebyshev distance is invariant under swapping the two cells. -/
+theorem chebDist_comm (p q : Int × Int) : chebDist p q = chebDist q p := by
+  unfold chebDist; omega
+
+/-- Monotonicity in the radius: a larger radius weakly contains the cone. -/
+theorem chebDist_le_trans {t₁ t₂ : Nat} (h : t₁ ≤ t₂) {p q : Int × Int}
+    (hd : chebDist p q ≤ t₁) : chebDist p q ≤ t₂ := hd.trans h
+
+/-- Margin sufficiency: a cell within Chebyshev radius `t` of `p` lies in the
+    margin-`t` box — each coordinate is within `t` of `p`'s coordinate. This is
+    the geometric reason a box margin of `t` (e.g. `padCenter2`'s `2^k` margin
+    at a level advancing `2^k` generations) covers the *tight* Chebyshev-`t`
+    reach, even though that same margin `t` does not cover the *loose*
+    Manhattan-`t` light cone (which reaches `2 * t`). -/
+theorem coord_bound_of_chebDist_le (p q : Int × Int) (t : Nat)
+    (h : chebDist p q ≤ t) :
+    Int.natAbs (q.1 - p.1) ≤ t ∧ Int.natAbs (q.2 - p.2) ≤ t := by
+  unfold chebDist at h
+  omega
+
+/-- Tight ⊆ loose (distance form): Chebyshev radius `t` is bounded by Manhattan
+    radius `2 * t`, because each coordinate displacement is `≤ t` and the
+    Manhattan distance is their sum. -/
+theorem manhattan_le_of_chebDist_le (p q : Int × Int) (t : Nat)
+    (h : chebDist p q ≤ t) : manhattan p q ≤ 2 * t := by
+  unfold chebDist at h
+  unfold manhattan
+  omega
+
+/-- A cell within Chebyshev radius `t` lies in the Manhattan-`(2*t)` light cone.
+    This is the bridge from the tight Chebyshev reach to the loose
+    `lightCone p (2 * t)` radius that `step_light_cone` operates on. -/
+theorem mem_lightCone_of_chebDist_le (p q : Int × Int) (t : Nat)
+    (h : chebDist p q ≤ t) : q ∈ lightCone p (2 * t) :=
+  mem_lightCone_of_manhattan_le p q (2 * t) (manhattan_le_of_chebDist_le p q t h)
+
 end Life
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Light-cone geometry (Conway Game of Life)
+
+Sorry-free geometric lemmas about `manhattan` and `lightCone` (defined in
+`Conway.Life.HashlifeCorrectness`). These bridge facts make the light-cone
+machinery composable: they are NOT new locality results (the fundamental
+locality theorem `step_light_cone` is proven in `HashlifeCorrectness`), but
+the elementary set/arithmetic relationships between cones of different radii
+and between Manhattan and per-coordinate bounds, which future correctness
+proofs chain across the `evolve` recursion.
+
+The central fact formalized here is the **Game-of-Life speed-of-light
+principle** (commented in `HashlifeCorrectness` P2 §, L497-504, but not
+previously stated as a theorem): over `t` generations information travels at
+Chebyshev radius `t` (one Moore-neighborhood step per generation), and the
+Chebyshev ball of radius `t` is contained in the Manhattan ball of radius
+`2*t` (the corner cell `(p.1 ± t, p.2 ± t)` is at Manhattan distance `2*t`).
+This containment is exactly why `step_light_cone` demands agreement on
+`lightCone p (2 * t)` — that radius is the *tight* GoL influence bound, not a
+loose over-approximation.
+
+Epic #3846 (Hashlife correctness infrastructure). All `sorry`s eliminated at
+creation.
+-/
+
+import Conway.Life.HashlifeCorrectness
+
+namespace Conway
+namespace Life
+
+/-! ## Monotonicity: larger radius → larger cone
+
+A light cone of radius `t₁` is contained in the light cone of any larger
+radius `t₂ ≥ t₁`. This follows directly from the membership characterization
+(`mem_lightCone_of_manhattan_le` / `manhattan_le_of_mem_lightCone`): a cell in
+the smaller cone is at Manhattan distance `≤ t₁ ≤ t₂`, hence in the larger
+cone. -/
+theorem lightCone_subset_of_le (p : Int × Int) {t₁ t₂ : Nat} (h : t₁ ≤ t₂) :
+    lightCone p t₁ ⊆ lightCone p t₂ := by
+  intro q hq
+  exact mem_lightCone_of_manhattan_le p q t₂
+    ((manhattan_le_of_mem_lightCone p q t₁ hq).trans h)
+
+/-! ## Per-coordinate bound: membership bounds each coordinate
+
+A cell in `lightCone p t` has each coordinate within `t` of `p`'s
+corresponding coordinate. This is the "Manhattan-`t` ⊆ Chebyshev-`t`"
+direction (each coordinate's displacement is bounded by the total Manhattan
+distance). -/
+theorem coord_bound_of_mem_lightCone (p q : Int × Int) (t : Nat)
+    (h : q ∈ lightCone p t) :
+    Int.natAbs (p.1 - q.1) ≤ t ∧ Int.natAbs (p.2 - q.2) ≤ t := by
+  have hm : manhattan p q ≤ t := manhattan_le_of_mem_lightCone p q t h
+  unfold manhattan at hm
+  refine ⟨?_, ?_⟩ <;> omega
+
+/-! ## Speed-of-light principle: Chebyshev-`t` ⊆ Manhattan-`2*t`
+
+The converse direction that makes `2*t` the **tight** GoL radius. If each
+coordinate of `q` is within `t` of `p` (Chebyshev distance `≤ t`) — the exact
+region a single B3/S23 step can reach in one generation, lifted to `t` steps
+— then the Manhattan distance is `≤ 2*t`, so `q ∈ lightCone p (2 * t)`.
+
+This is the formal justification for `step_light_cone`'s `2 * t` radius: the
+Moore-neighborhood influence of one generation has Chebyshev radius `1`, so
+`t` generations reach Chebyshev radius `t`, and that Chebyshev ball is
+contained in the Manhattan ball of twice the radius. The factor `2` is
+tight (the diagonal neighbor is at Manhattan distance `2`). -/
+theorem mem_lightCone_of_chebyshev_le (p q : Int × Int) (t : Nat)
+    (h1 : Int.natAbs (p.1 - q.1) ≤ t) (h2 : Int.natAbs (p.2 - q.2) ≤ t) :
+    q ∈ lightCone p (2 * t) := by
+  apply mem_lightCone_of_manhattan_le p q (2 * t)
+  unfold manhattan
+  omega
+
+end Life
+end Conway


### PR DESCRIPTION
## Summary

EPIC **#3846** — **N2 groundwork : tight-Chebyshev (L∞) light-cone lemmas** dans `Conway.Life.LightCone`. Étape 1 de la chaîne N2 formalisée par ai-01 (greenlight `msg-20260710T135334-4kvdca`, résout ma question DM `80lh4r`).

**Décision ai-01 tranchée** : single-jump correctness se prouve via le théorème **tight Chebyshev-t** (marge `padCenter2 = 2^k` suffisante), **PAS** en héritant du sorry P4 (L2636) — voie fuel-scaffold-inherits-P4 **ABANDONNÉE**. Cette PR pose le fondement géométrique tight (sorry-free, additif) dans **mon** module `LightCone.lean` ; ai-01 ne touche pas `HashlifeCorrectness` (collision-clean firsthand).

**Dépendance stacked** : basée sur #5899 (light-cone geometry 4 lemmes, rebased CLEAN sur main, en attente merge ai-01). Cette PR ajoute la section tight-Chebyshev au même fichier `LightCone.lean`. Merge order : #5899 → cette PR (rebase propre).

## Lemmes ajoutés (tous sorry-free)

| Lemme | Énoncé | Rôle |
|-------|--------|------|
| `chebDist` (def) | `max (natAbs (q.1-p.1)) (natAbs (q.2-p.2))` | Distance Chebyshev (L∞) |
| `chebDist_self` | `chebDist p p = 0` | Réflexivité |
| `chebDist_comm` | `chebDist p q = chebDist q p` | Symétrie |
| `chebDist_le_trans` | `t₁ ≤ t₂ → chebDist ≤ t₁ → chebDist ≤ t₂` | Monotonicité rayon |
| **`coord_bound_of_chebDist_le`** | `chebDist p q ≤ t → natAbs(q.1-p.1) ≤ t ∧ natAbs(q.2-p.2) ≤ t` | **MARGIN SUFFICIENCY** |
| `manhattan_le_of_chebDist_le` | `chebDist ≤ t → manhattan ≤ 2*t` | Tight ⊆ loose |
| `mem_lightCone_of_chebDist_le` | `chebDist ≤ t → q ∈ lightCone p (2*t)` | Pont vers lightCone |

**`coord_bound_of_chebDist_le` = le lemme-clé N2** : la marge `t` couvre le reach Chebyshev-t tight (chaque coordonnée dans la box marge-t), alors que le lightCone Manhattan-t loose atteint `2*t`. Pour un single-jump de `2^k` générations : reach tight Chebyshev = `2^k` = la marge `padCenter2` ⇒ **marge suffisante** (voie tight-Chebyshev), même si insuffisante pour le loose `step_light_cone` (Manhattan `2^(k+1)`).

## Scope (§A composite checks)

| Metric | Value | Threshold | OK? |
|--------|-------|-----------|-----|
| `additions + deletions` | +65 | > 3000 = split | OK |
| `changedFiles` | 1 | > 15 = split | OK |
| Distinct features | 1 (tight-Chebyshev light-cone groundwork) | > 4 = split | OK |
| Domain | 1 (Lean / Conway Hashlife) | > 1 = split | OK |

§A : **PASS** — single-subject (tight-Chebyshev cone groundwork), single-file, additif.

## §B Lean PR body

| Element | Status | Notes |
|---------|--------|-------|
| `grep -c sorry` per `.lean` file | **0 → 0** | `LightCone.lean` : 0 (tous lemmes sorry-free, preuves `omega`) |
| Lake build SUCCESS local | **YES** | `lake build Conway` = "Build completed successfully (2985 jobs)". `lake build Conway.Life.LightCone` = 2951 jobs. |
| Sorry conway regression | **3 → 3 (0 added)** | les 3 sorries connus `HashlifeCorrectness` (L2636/L2999/L3007) **inchangés** ; LightCone ajoute 0 |
| Additif (0 modif HashlifeCorrectness) | **YES** | seul `LightCone.lean` modifié (1 fichier, +65). `HashlifeCorrectness.lean` non touché. |
| Proof integrity | **PRESERVED** | nouveaux lemmes additifs sorry-free, aucune preuve existante modifiée |
| LF doctrine (L268 #4) | **YES** | `file LightCone.lean` = UTF-8 LF |

Vérifications firsthand :

- `lake build Conway` : 2985 jobs SUCCESS, exit 0
- `lake build Conway.Life.LightCone` : 2951 jobs SUCCESS, 3 sorry warnings = les HashlifeCorrectness connus (pas dans LightCone)
- `grep -rEc sorry LightCone.lean` (strip-docstrings, .lake exclu) = **0**
- Preuves : toutes `omega` (arithmétique pure sur `Int.natAbs` + `max`), aucune tactique lourde, aucune `sorry`

## Anti-regression

- Nouveaux lemmes **additifs** (nouvelle def `chebDist` + 6 lemmes), aucune ligne supprimée de code existant
- `HashlifeCorrectness.lean` (3 sorries P4/P5) **non touché** — respecte le greenlight ai-01 « je NE touche PAS HashlifeCorrectness »
- Aucun notebook, aucun autre lake touché
- sorry conway 3 → 3 (anti-regression §D : 0 ajouté)

## §F doc-group / §G vigilance

**§F** N/A (1 fichier `.lean` = infra preuve, pas doc-only). **G.4 composite** : 65 << 3000 PASS. **G.6 audit cascade** : single-subject, merge order #5899 → cette PR. **G.1** : §B cite `lake build`/`grep` réels.

## Chaîne N2 (3 étapes, ai-01 greenlight)

1. **c.410 (THIS)** : lemmes tight-Chebyshev dans LightCone.lean ✅
2. *(suivante)* : wire single-jump correctness (marge padCenter2 `2^k` ≥ reach Chebyshev `2^k`) à travers `coord_bound_of_chebDist_le`
3. *(ensuite)* : N3 derrière (lemme growth-by-Moore-shell : t-cone = (t-1)-cone ⊕ Moore — follow-up de cette PR, non inclus pour garder atomique)

## L335 anti-monotonie

c.410 registre = **Lean proof de fond EPIC** (le vrai travail), distinct des c.299-c.301 (Lean infra/migration GameTheory #4365). PAS un à-côté doc/nettoyage (cap R6 1 doc/lane/jour non touché). Substance = preuve formelle tight-Chebyshev. PASS L335.

## L279 worker never merges

PR forwardée à ai-01. Worker INTERDIT `gh pr merge` (#1502). Sweep §H.4 par ai-01.

## Link EPICs

- **#3846** — Hashlife correctness P4/P5 redesign (N1 livré #5890, N2 = cette PR groundwork)
- **#5899** — light-cone geometry 4 lemmes (base de cette PR stacked)

See #3846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
