### PR TITLE
feat(lean): absorb StableMarriage.GaleShapley (FR+EN) into game_theory_lean (c.305, See #4365)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
@@ -23,3 +23,5 @@
 
 import StableMarriage.Definitions
 import StableMarriage.Definitions_en
+import StableMarriage.GSState
+import StableMarriage.GSState_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
@@ -7,9 +7,9 @@
 
   - `StableMarriage.Definitions`      (absorbe c.300)
   - `StableMarriage.GSState`          (c.301)
-  - `StableMarriage.Lemmas`           (c.302)
-  - `StableMarriage.GaleShapley`      (c.303)
-  - `StableMarriage.Lattice`          (c.304)
+  - `StableMarriage.Lemmas`           (c.302/c.303)
+  - `StableMarriage.GaleShapley`      (c.304)
+  - `StableMarriage.Lattice`          (c.305)
 
   La suppression des fichiers source dans `stable_marriage_lean/`
   interviendra en c.305 (PR dediee `debt`/`regression-accepted`,
@@ -25,3 +25,5 @@ import StableMarriage.Definitions
 import StableMarriage.Definitions_en
 import StableMarriage.GSState
 import StableMarriage.GSState_en
+import StableMarriage.Lemmas
+import StableMarriage.Lemmas_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
@@ -27,3 +27,5 @@ import StableMarriage.GSState
 import StableMarriage.GSState_en
 import StableMarriage.Lemmas
 import StableMarriage.Lemmas_en
+import StableMarriage.Lattice
+import StableMarriage.Lattice_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
@@ -29,3 +29,5 @@ import StableMarriage.Lemmas
 import StableMarriage.Lemmas_en
 import StableMarriage.Lattice
 import StableMarriage.Lattice_en
+import StableMarriage.GaleShapley
+import StableMarriage.GaleShapley_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage.lean
@@ -1,14 +1,25 @@
 /-
-  GameTheory.StableMarriage — stub aggregator (c.299 skeleton)
-  ============================================================
+  GameTheory.StableMarriage — root aggregator (EPIC #4365 phase 4)
+  ================================================================
 
-  Ce module sera peuple par absorption successive de
-  `stable_marriage_lean/StableMarriage/{Definitions,GaleShapley,
-  Lattice,Lemmas,GSState}{,_en}.lean` dans les cycles c.300+ (PR
-  dediees par module, cf EPIC #4365 phase 4).
+  Ce module agregera les 5 sous-modules absorbes depuis
+  `stable_marriage_lean/StableMarriage/` :
 
-  Pour c.299, le seul but est de valider la structure du lake
-  cible (`lakefile.lean`, `lake-manifest.json`,
-  `lean-toolchain`, globs `StableMarriage.*`). Aucun module
-  reel n'a encore ete deplace.
+  - `StableMarriage.Definitions`      (absorbe c.300)
+  - `StableMarriage.GSState`          (c.301)
+  - `StableMarriage.Lemmas`           (c.302)
+  - `StableMarriage.GaleShapley`      (c.303)
+  - `StableMarriage.Lattice`          (c.304)
+
+  La suppression des fichiers source dans `stable_marriage_lean/`
+  interviendra en c.305 (PR dediee `debt`/`regression-accepted`,
+  cf anti-regression protocol 4 etapes).
+
+  Convention i18n (EPIC #4980 ratifiee user 2026-07-04) : les
+  sous-modules `.lean` et leurs siblings `_en.lean` (namespace
+  `<Nom>_en`) sont auto-decouverts par le `globs := #[`StableMarriage.*]`
+  du lakefile. La CI drift-detection voit les deux langues.
 -/
+
+import StableMarriage.Definitions
+import StableMarriage.Definitions_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Definitions.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Definitions.lean
@@ -1,0 +1,125 @@
+/-
+  Mariage stable — Définitions
+  =============================
+
+  Types et définitions fondamentaux pour le problème du mariage stable.
+  On modélise n hommes et n femmes (tous deux via `Fin n`), chacun muni d'un
+  ordre de préférence strict sur l'ensemble opposé.
+
+  Un couplage (matching) est une bijection entre hommes et femmes.
+  Un couplage est stable si et seulement si aucune paire bloquante
+  (blocking pair) n'existe.
+
+  Convention i18n (cf #4980) : en-têtes et docstrings en français,
+  noms de symboles Lean et tactiques préservés en anglais (compatibilité Mathlib).
+-/
+
+import Mathlib.Data.Finset.Basic
+
+namespace StableMarriage
+
+open Finset Function
+
+variable {n : Nat} [NeZero n]
+
+/-- Un homme est identifié par `Fin n` -/
+abbrev Man (n : Nat) := Fin n
+
+/-- Une femme est identifiée par `Fin n` -/
+abbrev Woman (n : Nat) := Fin n
+
+/--
+Profil de préférence d'une personne sur l'ensemble opposé.
+Représenté par une fonction associant à chaque candidat son rang (plus petit = préféré).
+La préférence stricte signifie que la fonction de classement est injective.
+-/
+structure PrefProfile (n : Nat) [NeZero n] where
+  /-- Préférences des hommes : chaque homme classe toutes les femmes -/
+  menPref : Fin n → Fin n → Fin n
+  /-- Préférences des femmes : chaque femme classe tous les hommes -/
+  womenPref : Fin n → Fin n → Fin n
+  /-- Le classement de chaque homme est une permutation (bijectif) -/
+  menPref_bijective : ∀ m, Bijective (menPref m)
+  /-- Le classement de chaque femme est une permutation (bijectif) -/
+  womenPref_bijective : ∀ w, Bijective (womenPref w)
+
+namespace PrefProfile
+
+variable {n : Nat} [NeZero n] (prof : PrefProfile n)
+
+/--
+L'homme `m` préfère la femme `w1` à la femme `w2` si et seulement si `w1`
+a un rang plus petit. Puisque `menPref m` est une bijection `Fin n → Fin n`,
+un rang plus petit signifie plus préférée.
+-/
+def manPrefers (m : Fin n) (w1 w2 : Fin n) : Bool :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+La femme `w` préfère l'homme `m1` à l'homme `m2` si et seulement si `m1`
+a un rang plus petit.
+-/
+def womanPrefers (w : Fin n) (m1 m2 : Fin n) : Bool :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+/--
+L'homme `m` préfère strictement la femme `w1` à la femme `w2`.
+Version Prop-valued pour les énoncés de théorèmes.
+-/
+def ManPrefers (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+La femme `w` préfère strictement l'homme `m1` à l'homme `m2`.
+-/
+def WomanPrefers (w : Fin n) (m1 m2 : Fin n) : Prop :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+end PrefProfile
+
+/--
+Un couplage (matching) est une bijection des hommes vers les femmes
+(couplage parfait).
+-/
+structure Matching (n : Nat) [NeZero n] where
+  /-- Associe chaque homme à sa femme appariée -/
+  spouse : Fin n → Fin n
+  /-- Le couplage est bijectif (chaque femme est appariée à exactement un homme) -/
+  bijective : Bijective spouse
+
+namespace Matching
+
+variable {n : Nat} [NeZero n] (μ : Matching n)
+
+/-- Récupère l'inverse : quel homme est apparié à la femme `w` -/
+noncomputable def inverse (w : Fin n) : Fin n :=
+  (Equiv.ofBijective μ.spouse μ.bijective).symm w
+
+end Matching
+
+/--
+Paire bloquante pour le couplage `μ` sous le profil de préférence `prof` :
+un homme `m` et une femme `w` qui se préfèrent mutuellement à leurs partenaires
+actuels.
+-/
+def IsBlockingPair (prof : PrefProfile n) (μ : Matching n)
+    (m : Fin n) (w : Fin n) : Prop :=
+  prof.ManPrefers m w (μ.spouse m) ∧
+  prof.WomanPrefers w m (μ.inverse w)
+
+/--
+Un couplage est stable si et seulement si aucune paire bloquante n'existe.
+-/
+def IsStable (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  ∀ m w, ¬ IsBlockingPair prof μ m w
+
+/--
+Un couplage est optimal pour les hommes si et seulement si chaque homme
+obtient sa meilleure partenaire possible parmi tous les couplages stables.
+-/
+def IsManOptimal (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  IsStable prof μ ∧
+  ∀ μ' : Matching n, IsStable prof μ' →
+    ∀ m : Fin n, prof.menPref m (μ.spouse m) ≤ prof.menPref m (μ'.spouse m)
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Definitions_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Definitions_en.lean
@@ -1,0 +1,132 @@
+/-
+  Stable Marriage - Definitions
+  =============================
+
+  English mirror of `StableMarriage/Definitions.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `StableMarriage_en` (le FR canonique reste `StableMarriage`).
+  Convention observée dans `GaleShapley_en.lean` / `Lattice_en.lean` :
+  les imports intra-lake restent sur les fichiers FR canoniques
+  (e.g. `import StableMarriage.Definitions`), seul `namespace StableMarriage`
+  est renommé en `namespace StableMarriage_en`.
+  Pas une traduction destructive : manual translation FR-first-from-origin
+  (pas d'historique EN pré-Option A pour ce fichier) ; code tactique Lean
+  byte-identique préservé verbatim, prose (header + sections + docstrings)
+  traduite. Pattern identique c.238.2/#5362 (RepeatedGames), c.238.3/#5363
+  (Minimax), c.238.4/#5419 (Shapley).
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+import Mathlib.Data.Finset.Basic
+
+namespace StableMarriage_en
+
+
+open Finset Function
+
+variable {n : Nat} [NeZero n]
+
+/-- A man is identified by `Fin n` -/
+abbrev Man (n : Nat) := Fin n
+
+/-- A woman is identified by `Fin n` -/
+abbrev Woman (n : Nat) := Fin n
+
+/--
+Preference profile of a person over the opposite set.
+Represented by a function assigning to each candidate its rank (smallest = preferred).
+Strict preference means that the ranking function is injective.
+-/
+structure PrefProfile (n : Nat) [NeZero n] where
+  /-- Men's preferences: each man ranks all women -/
+  menPref : Fin n → Fin n → Fin n
+  /-- Women's preferences: each woman ranks all men -/
+  womenPref : Fin n → Fin n → Fin n
+  /-- The ranking of each man is a permutation (bijective) -/
+  menPref_bijective : ∀ m, Bijective (menPref m)
+  /-- The ranking of each woman is a permutation (bijective) -/
+  womenPref_bijective : ∀ w, Bijective (womenPref w)
+
+namespace PrefProfile
+
+variable {n : Nat} [NeZero n] (prof : PrefProfile n)
+
+/--
+Man `m` prefers woman `w1` to woman `w2` if and only if `w1`
+has a smaller rank. Since `menPref m` is a bijection `Fin n → Fin n`,
+a smaller rank means more preferred.
+-/
+def manPrefers (m : Fin n) (w1 w2 : Fin n) : Bool :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+Woman `w` prefers man `m1` to man `m2` if and only if `m1`
+has a smaller rank.
+-/
+def womanPrefers (w : Fin n) (m1 m2 : Fin n) : Bool :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+/--
+Man `m` strictly prefers woman `w1` to woman `w2`.
+Prop-valued version for theorem statements.
+-/
+def ManPrefers (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+Woman `w` strictly prefers man `m1` to man `m2`.
+-/
+def WomanPrefers (w : Fin n) (m1 m2 : Fin n) : Prop :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+end PrefProfile
+
+/--
+A matching is a bijection from men to women
+(perfect matching).
+-/
+structure Matching (n : Nat) [NeZero n] where
+  /-- Associates each man to his matched woman -/
+  spouse : Fin n → Fin n
+  /-- The matching is bijective (each woman is matched to exactly one man) -/
+  bijective : Bijective spouse
+
+namespace Matching
+
+variable {n : Nat} [NeZero n] (μ : Matching n)
+
+/-- Retrieves the inverse: which man is matched to woman `w` -/
+noncomputable def inverse (w : Fin n) : Fin n :=
+  (Equiv.ofBijective μ.spouse μ.bijective).symm w
+
+end Matching
+
+/--
+Blocking pair for matching `μ` under preference profile `prof`:
+a man `m` and a woman `w` who mutually prefer each other to their current
+partners.
+-/
+def IsBlockingPair (prof : PrefProfile n) (μ : Matching n)
+    (m : Fin n) (w : Fin n) : Prop :=
+  prof.ManPrefers m w (μ.spouse m) ∧
+  prof.WomanPrefers w m (μ.inverse w)
+
+/--
+A matching is stable if and only if no blocking pair exists.
+-/
+def IsStable (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  ∀ m w, ¬ IsBlockingPair prof μ m w
+
+/--
+A matching is man-optimal if and only if each man
+gets his best possible partner among all stable matchings.
+-/
+def IsManOptimal (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  IsStable prof μ ∧
+  ∀ μ' : Matching n, IsStable prof μ' →
+    ∀ m : Fin n, prof.menPref m (μ.spouse m) ≤ prof.menPref m (μ'.spouse m)
+
+end StableMarriage_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState.lean
@@ -1,0 +1,173 @@
+/-
+  Mariage stable — État de l'algorithme de Gale-Shapley
+  ======================================================
+
+  État intermédiaire pour l'algorithme d'acceptation différée de Gale-Shapley.
+  Utilise un couplage partiel basé sur `Option` pendant l'exécution de l'algorithme,
+  converti en couplage bijectif total à la terminaison.
+
+  Convention i18n (cf #4980) : en-têtes, sections, docstrings et commentaires
+  intra-preuve en français ; noms de symboles Lean, énoncés de lemmes et
+  tactiques préservés en anglais (compatibilité Mathlib).
+
+  Adapté de : https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+-/
+
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Order.Preorder.Finite
+import StableMarriage.Definitions
+
+namespace StableMarriage
+
+open Function Finset Classical
+
+variable {n : Nat} [NeZero n]
+
+/-- Couplage partiel pendant l'exécution de l'algorithme GS. -/
+structure GSMatching (n : Nat) [NeZero n] where
+  menMatch : Fin n → Option (Fin n)
+  womenMatch : Fin n → Option (Fin n)
+
+namespace GSMatching
+
+def initial : GSMatching n where
+  menMatch := fun _ => none
+  womenMatch := fun _ => none
+
+def matchFree (μ : GSMatching n) (m w : Fin n) : GSMatching n where
+  menMatch := Function.update μ.menMatch m (some w)
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+def swapMatch (μ : GSMatching n) (m mOld w : Fin n) : GSMatching n where
+  menMatch := Function.update (Function.update μ.menMatch m (some w)) mOld none
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+end GSMatching
+
+/-- État intermédiaire pour l'algorithme d'acceptation différée de Gale-Shapley. -/
+structure GSState (prof : PrefProfile n) where
+  matching : GSMatching n
+  proposed : Fin n → Fin n → Prop
+
+section GSDefs
+
+variable (prof : PrefProfile n)
+
+def gsInitial : GSState prof where
+  matching := GSMatching.initial
+  proposed := fun _ _ => False
+
+noncomputable def gsCandidates (σ : GSState prof) (m : Fin n) : Finset (Fin n) :=
+  Finset.univ.filter (fun w => ¬ σ.proposed m w)
+
+def gsIsFree (σ : GSState prof) (m : Fin n) : Prop :=
+  σ.matching.menMatch m = none ∧ (gsCandidates prof σ m).Nonempty
+
+def gsTerminated (σ : GSState prof) : Prop :=
+  ¬ ∃ m, gsIsFree prof σ m
+
+def gsMenPrefLE (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  w1 = w2 ∨ prof.menPref m w2 < prof.menPref m w1
+
+noncomputable def gsChooseMax (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) : Fin n :=
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  Classical.choose ((gsCandidates prof σ m).exists_maximal h)
+
+noncomputable def gsStepWith (σ : GSState prof) (m w : Fin n) : GSState prof :=
+  let proposed' : Fin n → Fin n → Prop :=
+    fun m' w' => σ.proposed m' w' ∨ (m' = m ∧ w' = w)
+  match _ : σ.matching.womenMatch w with
+  | none =>
+      { matching := σ.matching.matchFree m w
+        proposed := proposed' }
+  | some mOld =>
+      if prof.womenPref w m < prof.womenPref w mOld then
+        { matching := σ.matching.swapMatch m mOld w
+          proposed := proposed' }
+      else
+        { matching := σ.matching
+          proposed := proposed' }
+
+noncomputable def gsStep (σ : GSState prof) : GSState prof :=
+  if hfree : ∃ m, gsIsFree prof σ m then
+    let m := Classical.choose hfree
+    have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+    let w := gsChooseMax prof σ m hm.2
+    gsStepWith prof σ m w
+  else
+    σ
+
+end GSDefs
+
+-- Ces définitions utilisent le paramètre explicite `prof` pour éviter la duplication
+-- des variables de section.
+noncomputable def gsRunSteps (prof : PrefProfile n) (k : Nat) : GSState prof :=
+  match k with
+  | 0 => gsInitial prof
+  | k' + 1 => gsStep prof (gsRunSteps prof k')
+
+def gsProposalBound (n : Nat) [NeZero n] : Nat := n * n
+
+noncomputable def gsGaleShapley (prof : PrefProfile n) : GSMatching n :=
+  (gsRunSteps prof (gsProposalBound n)).matching
+
+/-! ## Lemmes auxiliaires pour `gsChooseMax` -/
+
+/-- La candidate maximale choisie appartient à l'ensemble des candidates. -/
+lemma gsChooseMax_mem (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) :
+    gsChooseMax prof σ m h ∈ gsCandidates prof σ m := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  obtain ⟨hmem, -⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  exact hmem
+
+/-- Aucune candidate non-proposée n'est préférée à la candidate maximale choisie.
+    Directement depuis la maximalité : ∀ y ∈ candidates, y ≤ choose. -/
+lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
+    (hw : w ∈ gsCandidates prof σ m) :
+    gsMenPrefLE prof m w (gsChooseMax prof σ m h) := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  set c := Classical.choose (Finset.exists_maximal h) with hc
+  obtain ⟨-, hmax⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  have htri := Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m c)
+  rcases htri with (hlt | heq | hgt)
+  · -- `choose` est préférée à `w` : `choose ≤ w`, donc `hmax` donne `w ≤ choose`
+    have hle : c ≤ w := Or.inr hlt
+    exact hmax hw hle
+  · -- Préférence égale : l'injectivité donne `w = c`
+    left
+    exact (prof.menPref_bijective m).injective (Fin.ext heq)
+  · -- `w` est préférée à `choose` : direct
+    right
+    exact hgt
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GSState_en.lean
@@ -1,0 +1,180 @@
+/-
+  Stable Marriage - Gale-Shapley Algorithm State
+  ==============================================
+
+  English mirror of `StableMarriage/GSState.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `StableMarriage_en` (le FR canonique reste `StableMarriage`).
+  Convention observée : imports intra-lake restent sur fichiers FR canoniques.
+  Pas une traduction destructive : manual translation FR-first-from-origin
+  (pas d'historique EN pré-Option A pour ce fichier) ; code tactique Lean
+  byte-identique préservé verbatim, prose traduite. Pattern identique
+  c.238.2/#5362 (RepeatedGames), c.238.3/#5363 (Minimax), c.238.4/#5419 (Shapley).
+
+  Adapté de / Adapted from: https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Order.Preorder.Finite
+import StableMarriage.Definitions
+
+namespace StableMarriage_en
+
+
+open Function Finset Classical
+open StableMarriage
+
+variable {n : Nat} [NeZero n]
+
+/-- Partial matching during the execution of the GS algorithm. -/
+structure GSMatching (n : Nat) [NeZero n] where
+  menMatch : Fin n → Option (Fin n)
+  womenMatch : Fin n → Option (Fin n)
+
+namespace GSMatching
+
+def initial : GSMatching n where
+  menMatch := fun _ => none
+  womenMatch := fun _ => none
+
+def matchFree (μ : GSMatching n) (m w : Fin n) : GSMatching n where
+  menMatch := Function.update μ.menMatch m (some w)
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+def swapMatch (μ : GSMatching n) (m mOld w : Fin n) : GSMatching n where
+  menMatch := Function.update (Function.update μ.menMatch m (some w)) mOld none
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+end GSMatching
+
+/-- Intermediate state for the Gale-Shapley deferred acceptance algorithm. -/
+structure GSState (prof : PrefProfile n) where
+  matching : GSMatching n
+  proposed : Fin n → Fin n → Prop
+
+section GSDefs
+
+variable (prof : PrefProfile n)
+
+def gsInitial : GSState prof where
+  matching := GSMatching.initial
+  proposed := fun _ _ => False
+
+noncomputable def gsCandidates (σ : GSState prof) (m : Fin n) : Finset (Fin n) :=
+  Finset.univ.filter (fun w => ¬ σ.proposed m w)
+
+def gsIsFree (σ : GSState prof) (m : Fin n) : Prop :=
+  σ.matching.menMatch m = none ∧ (gsCandidates prof σ m).Nonempty
+
+def gsTerminated (σ : GSState prof) : Prop :=
+  ¬ ∃ m, gsIsFree prof σ m
+
+def gsMenPrefLE (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  w1 = w2 ∨ prof.menPref m w2 < prof.menPref m w1
+
+noncomputable def gsChooseMax (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) : Fin n :=
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  Classical.choose ((gsCandidates prof σ m).exists_maximal h)
+
+noncomputable def gsStepWith (σ : GSState prof) (m w : Fin n) : GSState prof :=
+  let proposed' : Fin n → Fin n → Prop :=
+    fun m' w' => σ.proposed m' w' ∨ (m' = m ∧ w' = w)
+  match _ : σ.matching.womenMatch w with
+  | none =>
+      { matching := σ.matching.matchFree m w
+        proposed := proposed' }
+  | some mOld =>
+      if prof.womenPref w m < prof.womenPref w mOld then
+        { matching := σ.matching.swapMatch m mOld w
+          proposed := proposed' }
+      else
+        { matching := σ.matching
+          proposed := proposed' }
+
+noncomputable def gsStep (σ : GSState prof) : GSState prof :=
+  if hfree : ∃ m, gsIsFree prof σ m then
+    let m := Classical.choose hfree
+    have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+    let w := gsChooseMax prof σ m hm.2
+    gsStepWith prof σ m w
+  else
+    σ
+
+end GSDefs
+
+-- Ces définitions utilisent le paramètre explicite `prof` pour éviter la duplication
+-- des variables de section.
+noncomputable def gsRunSteps (prof : PrefProfile n) (k : Nat) : GSState prof :=
+  match k with
+  | 0 => gsInitial prof
+  | k' + 1 => gsStep prof (gsRunSteps prof k')
+
+def gsProposalBound (n : Nat) [NeZero n] : Nat := n * n
+
+noncomputable def gsGaleShapley (prof : PrefProfile n) : GSMatching n :=
+  (gsRunSteps prof (gsProposalBound n)).matching
+
+/-! ## Lemmes auxiliaires pour `gsChooseMax` -/
+
+/-- La candidate maximale choisie appartient à l'ensemble des candidates. -/
+lemma gsChooseMax_mem (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) :
+    gsChooseMax prof σ m h ∈ gsCandidates prof σ m := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  obtain ⟨hmem, -⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  exact hmem
+
+/-- Aucune candidate non-proposée n'est préférée à la candidate maximale choisie.
+    Directement depuis la maximalité : ∀ y ∈ candidates, y ≤ choose. -/
+lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
+    (hw : w ∈ gsCandidates prof σ m) :
+    gsMenPrefLE prof m w (gsChooseMax prof σ m h) := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  set c := Classical.choose (Finset.exists_maximal h) with hc
+  obtain ⟨-, hmax⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  have htri := Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m c)
+  rcases htri with (hlt | heq | hgt)
+  · -- `choose` est préférée à `w` : `choose ≤ w`, donc `hmax` donne `w ≤ choose`
+    have hle : c ≤ w := Or.inr hlt
+    exact hmax hw hle
+  · -- Préférence égale : l'injectivité donne `w = c`
+    left
+    exact (prof.menPref_bijective m).injective (Fin.ext heq)
+  · -- `w` est préférée à `choose` : direct
+    right
+    exact hgt
+
+end StableMarriage_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley.lean
@@ -1,0 +1,181 @@
+/-
+  Mariage Stable - Algorithme et théorèmes de Gale-Shapley
+  =========================================================
+
+  Ce module rassemble les principaux résultats de l'algorithme de Gale-Shapley
+  pour le problème du mariage stable (deferred acceptance).
+
+  Convention i18n (Option A #4980 ratifiée par ai-01 le 2026-07-04) : ce fichier
+  est **français-first** : titre, commentaires, docstrings et en-têtes de
+  section sont rédigés en français. Les **identificateurs** (`gale_shapley_*`,
+  `gsRunSteps`, `gsFinalMatching`, `Matching`, `IsStable`, `IsManOptimal`,
+  `PrefProfile`, etc.) ainsi que le **code tactique** restent en anglais pour
+  préserver la compatibilité avec `Mathlib` et les modules siblings
+  (`Definitions`, `Lemmas`, `Lattice`, `GSState`). Toute modification ultérieure
+  doit conserver cette séparation.
+
+  État des résultats principaux :
+  - `gale_shapley_stable` est **constructivement prouvé** via la machine à
+    étapes d'acceptation différée (`gsRunSteps` / `gsFinalMatching` /
+    `gsNoBlockingPairs`).
+  - `gale_shapley_man_optimal` est prouvé via `exists_isManOptimal` du module
+    `Lattice.lean` (argument de poids minimal sur le semi-treillis de jointure
+    des mariages stables), en s'appuyant sur `gale_shapley_stable`.
+  - `gale_shapley_woman_pessimal` est déduit de la man-optimalité.
+
+  Esquisse de l'algorithme (version où les hommes proposent) :
+  1. Chaque homme libre propose à la femme qu'il préfère parmi celles
+     auxquelles il n'a pas encore proposé.
+  2. Chaque femme accepte provisoirement sa meilleure proposition, et rejette
+     les autres.
+  3. Les hommes rejetés redeviennent libres.
+  4. On répète jusqu'à ce qu'il n'y ait plus d'homme libre.
+
+  Propriétés clés :
+  - L'algorithme termine (au plus n^2 propositions).
+  - Le résultat est un mariage stable.
+  - Le résultat est man-optimal (la meilleure partenaire possible pour chaque
+    homme parmi tous les mariages stables).
+  - Dualement, il est woman-pessimal (la pire partenaire possible pour chaque
+    femme parmi tous les mariages stables).
+
+  Référence : Gale & Shapley (1962), « College Admissions and the Stability
+  of Marriage ».
+  Port de référence : https://github.com/mmaaz-git/stable-marriage-lean
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic.Common
+import StableMarriage.Definitions
+import StableMarriage.Lemmas
+import StableMarriage.Lattice
+
+namespace StableMarriage
+
+open Function
+
+variable {n : Nat} [NeZero n]
+
+/--
+L'algorithme de Gale-Shapley termine.
+
+Au plus n^2 propositions peuvent avoir lieu (chaque homme propose à chaque
+femme au plus une fois).
+
+TODO : formaliser l'algorithme sous forme de relation d'étapes et prouver la
+terminaison.
+-/
+theorem gale_shapley_terminates (prof : PrefProfile n) :
+    True := by
+  trivial
+
+/--
+L'algorithme de Gale-Shapley produit un matching (bijection) valide.
+
+Le matching identité sert de témoin (toute bijection sur `Fin n` suffit pour
+l'existentiel ; on utilise ici `id`).
+-/
+theorem gale_shapley_produces_matching (prof : PrefProfile n) :
+    ∃ μ : Matching n, True := by
+  exact ⟨{ spouse := id, bijective := Function.bijective_id }, trivial⟩
+
+/--
+L'algorithme de Gale-Shapley produit un mariage stable.
+
+Aucune paire bloquante n'existe dans le matching en sortie.
+
+C'est le théorème principal de correction. Il est **prouvé de manière
+constructive** : la machine à étapes d'acceptation différée (`gsRunSteps prof
+(gsProposalBound n)`) est exécutée jusqu'à terminaison, et `gsFinalMatching` /
+`gsNoBlockingPairs` (portés et adaptés depuis `mmaaz-git/stable-marriage-lean`,
+~1000 lignes de lemmes auxiliaires) démontrent la stabilité. Cette déclaration
+est complète : aucune tactique stub et aucun axiome ne sont utilisés.
+-/
+theorem gale_shapley_stable (prof : PrefProfile n) :
+    ∃ μ : Matching n, IsStable prof μ := by
+  let σ := gsRunSteps prof (gsProposalBound n)
+  have hterm : gsTerminated prof σ :=
+    gsTerminated_runSteps_bound prof
+  have hcon : GSConsistent σ.matching :=
+    GSConsistent.runSteps prof (gsProposalBound n)
+  have hwp : womenProposedImpliesMatched prof σ :=
+    womenProposedImpliesMatched.runSteps prof (gsProposalBound n)
+  have hdown : menProposedDownward prof σ :=
+    menProposedDownward.runSteps prof (gsProposalBound n)
+  have hmp : menMatchedProposed prof σ :=
+    menMatchedProposed.runSteps prof (gsProposalBound n)
+  have hbest : womenBestState prof σ :=
+    womenBestState.runSteps prof (gsProposalBound n)
+  have hall : ∀ m, σ.matching.menMatch m ≠ none :=
+    fun m => gsTerminated_allMenMatched prof hterm hwp hcon m
+  exact ⟨gsFinalMatching prof σ hall hcon,
+    fun m w => gsNoBlockingPairs prof hterm hcon hwp hdown hmp hbest m w⟩
+
+/--
+Le matching de Gale-Shapley est man-optimal : chaque homme obtient la meilleure
+partenaire possible parmi tous les mariages stables.
+
+C'est le théorème d'optimalité pour le côté qui propose.
+-/
+theorem gale_shapley_man_optimal (prof : PrefProfile n) :
+    ∃ μ : Matching n, IsManOptimal prof μ :=
+  exists_isManOptimal prof (gale_shapley_stable prof)
+
+/--
+Existence d'un mariage stable (corollaire de Gale-Shapley).
+-/
+theorem stable_matching_exists (prof : PrefProfile n) :
+    ∃ μ : Matching n, IsStable prof μ := by
+  exact gale_shapley_stable prof
+
+/--
+Pessimalité-femme de Gale-Shapley version « les hommes proposent » :
+chaque femme obtient la pire partenaire possible parmi tous les mariages stables.
+
+Dual de la man-optimalité.
+-/
+theorem gale_shapley_woman_pessimal (prof : PrefProfile n)
+    (μ : Matching n) (h_opt : IsManOptimal prof μ)
+    (μ' : Matching n) (h_stable : IsStable prof μ')
+    (w : Fin n) :
+    prof.womenPref w (μ'.inverse w) ≤ prof.womenPref w (μ.inverse w) := by
+  by_contra hgt
+  push Not at hgt
+  set m := μ.inverse w with hmdef
+  set m' := μ'.inverse w with hm'def
+  have hmw : μ.spouse m = w := spouse_inverse μ w
+  have hm'w : μ'.spouse m' = w := spouse_inverse μ' w
+  -- From man-optimality: m weakly prefers w = μ.sp m over μ'.sp m
+  have hmopt : prof.menPref m (μ.spouse m) ≤ prof.menPref m (μ'.spouse m) :=
+    h_opt.2 μ' h_stable m
+  rw [hmw] at hmopt
+  by_cases hstrict : (prof.menPref m w : Nat) < prof.menPref m (μ'.spouse m)
+  · -- m strictly prefers w over μ'.sp m
+    -- w prefers m over m' (from hgt)
+    have hwpref : prof.WomanPrefers w m m' := by
+      unfold PrefProfile.WomanPrefers
+      have : (prof.womenPref w m : Nat) < prof.womenPref w m' := by
+        change (prof.womenPref w (μ.inverse w) : Nat) < prof.womenPref w (μ'.inverse w)
+        exact mod_cast hgt
+      exact mod_cast this
+    -- (m, w) blocks μ': m prefers w to μ'.sp(m), w prefers m to m' = μ'.inv(w)
+    have hblock : IsBlockingPair prof μ' m w := by
+      refine ⟨mod_cast hstrict, ?_⟩
+      change prof.WomanPrefers w m (μ'.inverse w)
+      rw [← hm'def]
+      exact hwpref
+    exact h_stable m w hblock
+  · -- Equality: menPref m w = menPref m (μ'.sp m)
+    push Not at hstrict
+    have heq : (prof.menPref m w : Nat) = prof.menPref m (μ'.spouse m) :=
+      Nat.le_antisymm (mod_cast hmopt) hstrict
+    have hsp_eq : w = μ'.spouse m :=
+      (prof.menPref_bijective m).injective (Fin.ext heq)
+    -- μ'.sp m = w, so μ'.inv w = m
+    have hinv_eq : μ'.inverse w = m :=
+      inverse_eq_of_spouse_eq μ' m w hsp_eq.symm
+    -- But m' = μ'.inv w = m, so hgt says womenPref w m < womenPref w m — contradiction
+    rw [hm'def, hinv_eq] at hgt
+    exact Nat.lt_irrefl _ (mod_cast hgt)
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/GaleShapley_en.lean
@@ -1,0 +1,171 @@
+/-
+  Stable Marriage - Gale-Shapley Algorithm and Theorems
+  ======================================================
+
+  English mirror of `StableMarriage/GaleShapley.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `StableMarriage_en` (le FR canonique reste `StableMarriage`).
+  Pas une traduction destructive : le fichier source EN historique est préservée ici
+  verbatim depuis `b80d2c7ba` (post-merge #5321 GSState i18n) ; seule la ligne
+  `namespace` diffère pour éviter la collision de declaration.
+
+  See #4980. Part of #4208 (axe E).
+
+  The Gale-Shapley deferred acceptance algorithm produces a stable matching.
+
+  Status of the main results:
+  - `gale_shapley_stable` is **constructively proved** via the deferred-acceptance
+    state machine (`gsRunSteps` / `gsFinalMatching` / `gsNoBlockingPairs`).
+  - `gale_shapley_man_optimal` is proved via `exists_isManOptimal` in
+    `Lattice.lean` (minimal-weight argument on the join semilattice of stable
+    matchings), seeded by `gale_shapley_stable`.
+  - `gale_shapley_woman_pessimal` is proved from man-optimality.
+
+  Algorithm sketch (man-proposing version):
+  1. Each free man proposes to his most-preferred woman he hasn't proposed to yet
+  2. Each woman tentatively accepts her best proposal, rejecting others
+  3. Rejected men become free again
+  4. Repeat until no free men remain
+
+  Key properties:
+  - The algorithm terminates (at most n^2 proposals)
+  - The result is a stable matching
+  - The result is man-optimal (best possible for all men among stable matchings)
+  - Dually, it is woman-pessimal (worst possible for all women among stable matchings)
+
+  Reference: Gale & Shapley (1962), "College Admissions and the Stability of Marriage"
+  Reference port: https://github.com/mmaaz-git/stable-marriage-lean
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic.Common
+import StableMarriage.Definitions
+import StableMarriage.Lemmas
+import StableMarriage.Lattice
+
+namespace StableMarriage_en
+
+open Function Finset Classical
+open StableMarriage
+
+variable {n : Nat} [NeZero n]
+
+/--
+The Gale-Shapley algorithm terminates.
+At most n^2 proposals can occur (each man proposes to each woman at most once).
+
+TODO: formalize the algorithm as a step relation and prove termination.
+-/
+theorem gale_shapley_terminates (prof : PrefProfile n) :
+    True := by
+  trivial
+
+/--
+The Gale-Shapley algorithm produces a valid matching (bijection).
+The identity matching is a witness (any bijection on Fin n suffices for the
+existential statement; here we use `id`).
+-/
+theorem gale_shapley_produces_matching (prof : PrefProfile n) :
+    ∃ μ : Matching n, True := by
+  exact ⟨{ spouse := id, bijective := Function.bijective_id }, trivial⟩
+
+/--
+The Gale-Shapley algorithm produces a stable matching.
+No blocking pair exists in the output matching.
+
+This is the main correctness theorem. It is **constructively proved**: the
+deferred-acceptance step machine (`gsRunSteps prof (gsProposalBound n)`) is run
+to termination, and `gsFinalMatching` / `gsNoBlockingPairs` (ported and adapted
+from `mmaaz-git/stable-marriage-lean`, ~1000 lines of supporting lemmas) discharge
+stability. This declaration is complete: no placeholder tactic and no axiom are used.
+-/
+theorem gale_shapley_stable (prof : PrefProfile n) :
+    ∃ μ : Matching n, IsStable prof μ := by
+  let σ := gsRunSteps prof (gsProposalBound n)
+  have hterm : gsTerminated prof σ :=
+    gsTerminated_runSteps_bound prof
+  have hcon : GSConsistent σ.matching :=
+    GSConsistent.runSteps prof (gsProposalBound n)
+  have hwp : womenProposedImpliesMatched prof σ :=
+    womenProposedImpliesMatched.runSteps prof (gsProposalBound n)
+  have hdown : menProposedDownward prof σ :=
+    menProposedDownward.runSteps prof (gsProposalBound n)
+  have hmp : menMatchedProposed prof σ :=
+    menMatchedProposed.runSteps prof (gsProposalBound n)
+  have hbest : womenBestState prof σ :=
+    womenBestState.runSteps prof (gsProposalBound n)
+  have hall : ∀ m, σ.matching.menMatch m ≠ none :=
+    fun m => gsTerminated_allMenMatched prof hterm hwp hcon m
+  exact ⟨gsFinalMatching prof σ hall hcon,
+    fun m w => gsNoBlockingPairs prof hterm hcon hwp hdown hmp hbest m w⟩
+
+/--
+The Gale-Shapley matching is man-optimal: every man gets the best
+partner he could obtain in any stable matching.
+
+This is the optimality theorem for the proposing side.
+-/
+theorem gale_shapley_man_optimal (prof : PrefProfile n) :
+    ∃ μ : Matching n, IsManOptimal prof μ :=
+  exists_isManOptimal prof (gale_shapley_stable prof)
+
+/--
+Existence of a stable matching (corollary of Gale-Shapley).
+-/
+theorem stable_matching_exists (prof : PrefProfile n) :
+    ∃ μ : Matching n, IsStable prof μ := by
+  exact gale_shapley_stable prof
+
+/--
+Woman-pessimality of man-proposing Gale-Shapley:
+each woman gets her worst achievable partner among all stable matchings.
+
+Dual of man-optimality.
+-/
+theorem gale_shapley_woman_pessimal (prof : PrefProfile n)
+    (μ : Matching n) (h_opt : IsManOptimal prof μ)
+    (μ' : Matching n) (h_stable : IsStable prof μ')
+    (w : Fin n) :
+    prof.womenPref w (μ'.inverse w) ≤ prof.womenPref w (μ.inverse w) := by
+  by_contra hgt
+  push Not at hgt
+  set m := μ.inverse w with hmdef
+  set m' := μ'.inverse w with hm'def
+  have hmw : μ.spouse m = w := spouse_inverse μ w
+  have hm'w : μ'.spouse m' = w := spouse_inverse μ' w
+  -- From man-optimality: m weakly prefers w = μ.sp m over μ'.sp m
+  have hmopt : prof.menPref m (μ.spouse m) ≤ prof.menPref m (μ'.spouse m) :=
+    h_opt.2 μ' h_stable m
+  rw [hmw] at hmopt
+  by_cases hstrict : (prof.menPref m w : Nat) < prof.menPref m (μ'.spouse m)
+  · -- m strictly prefers w over μ'.sp m
+    -- w prefers m over m' (from hgt)
+    have hwpref : prof.WomanPrefers w m m' := by
+      unfold PrefProfile.WomanPrefers
+      have : (prof.womenPref w m : Nat) < prof.womenPref w m' := by
+        change (prof.womenPref w (μ.inverse w) : Nat) < prof.womenPref w (μ'.inverse w)
+        exact mod_cast hgt
+      exact mod_cast this
+    -- (m, w) blocks μ': m prefers w to μ'.sp(m), w prefers m to m' = μ'.inv(w)
+    have hblock : IsBlockingPair prof μ' m w := by
+      refine ⟨mod_cast hstrict, ?_⟩
+      change prof.WomanPrefers w m (μ'.inverse w)
+      rw [← hm'def]
+      exact hwpref
+    exact h_stable m w hblock
+  · -- Equality: menPref m w = menPref m (μ'.sp m)
+    push Not at hstrict
+    have heq : (prof.menPref m w : Nat) = prof.menPref m (μ'.spouse m) :=
+      Nat.le_antisymm (mod_cast hmopt) hstrict
+    have hsp_eq : w = μ'.spouse m :=
+      (prof.menPref_bijective m).injective (Fin.ext heq)
+    -- μ'.sp m = w, so μ'.inv w = m
+    have hinv_eq : μ'.inverse w = m :=
+      inverse_eq_of_spouse_eq μ' m w hsp_eq.symm
+    -- But m' = μ'.inv w = m, so hgt says womenPref w m < womenPref w m — contradiction
+    rw [hm'def, hinv_eq] at hgt
+    exact Nat.lt_irrefl _ (mod_cast hgt)
+
+end StableMarriage_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice.lean
@@ -1,0 +1,885 @@
+/-
+  Mariage stable — Structure de treillis sur les mariages stables
+  ================================================================
+
+  Knuth (1976) a montré que l'ensemble des mariages stables forme un treillis
+  sous l'ordonnancement des « préférences communes ». Wu & Roth (2018) ont généralisé
+  ceci au cas many-to-one ; nous nous spécialisons au cas one-to-one.
+
+  Résultats clés :
+  - Les mariages stables sont partiellement ordonnés par préférence des hommes
+  - Le join (supremum) de deux mariages stables est stable
+  - Le meet (infimum) de deux mariages stables est stable
+  - L'ensemble des mariages stables forme un treillis distributif
+  - La sortie GS proposée par les hommes est l'élément sommet (homme-optimal)
+
+  Référence : Knuth (1976), « Mariages Stables »
+  Référence : Wu & Roth (2018), « Lattice Structures in Stable Matching »
+  Référence : Stanley (2011), « Enumerative Combinatorics » Vol 1 (lemme treillis fini)
+
+  Stratégie :
+  - On définit μ ≤ ν ssi chaque homme préfère μ à ν (ou est indifférent)
+  - join μ ν : chaque homme obtient sa partenaire préférée entre μ et ν
+  - meet μ ν : chaque homme obtient sa partenaire moins préférée entre μ et ν
+  - Lemme Wu-Roth 3.2 (one-to-one) : join et meet des mariages stables sont stables
+  - Lemme Stanley : join-semitreillis fini avec min = treillis
+
+  Convention i18n (Option A ratifiée par ai-01, Epic #4980) :
+  en-têtes de section, docstrings de définition/théorème, commentaires de
+  lemme sont **français d'abord** ; le code Lean tactique (noms de tactiques,
+  lemmes Mathlib, identifiants) reste en anglais, langue canonique de Lean.
+-/
+
+import Mathlib.Order.Lattice
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Tactic.Common
+import StableMarriage.Definitions
+
+namespace StableMarriage
+
+open Function Finset Classical
+
+variable {n : Nat} [NeZero n] (prof : PrefProfile n)
+
+/-! ## Ordre partiel sur les mariages stables via préférence des hommes -/
+
+/--
+Ordonnancement par préférence des hommes sur les mariages : μ ≤ ν ssi chaque homme préfère
+au moins autant sa partenaire dans μ que dans ν (c.-à-d. menPref m (μ m) ≤ menPref m (ν m)).
+Rang inférieur = plus préféré, donc μ ≤ ν signifie que μ est préféré-homme à ν.
+-/
+def ManLE (μ ν : Matching n) : Prop :=
+  ∀ m : Fin n, prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m)
+
+namespace ManLE
+
+variable {prof} {μ ν σ : Matching n}
+
+@[refl] lemma refl : ManLE prof μ μ := fun m => Nat.le_refl _
+
+@[trans] lemma trans (h1 : ManLE prof μ ν) (h2 : ManLE prof ν σ) :
+    ManLE prof μ σ := fun m => Nat.le_trans (h1 m) (h2 m)
+
+lemma antisymm (h1 : ManLE prof μ ν) (h2 : ManLE prof ν μ) :
+    μ = ν := by
+  have hsp : μ.spouse = ν.spouse := by
+    funext m
+    have hle : (prof.menPref m (μ.spouse m) : Nat) ≤ prof.menPref m (ν.spouse m) := h1 m
+    have hge : (prof.menPref m (ν.spouse m) : Nat) ≤ prof.menPref m (μ.spouse m) := h2 m
+    have heq : (prof.menPref m (μ.spouse m) : Nat) = prof.menPref m (ν.spouse m) :=
+      Nat.le_antisymm hle hge
+    have hfeq : prof.menPref m (μ.spouse m) = prof.menPref m (ν.spouse m) := Fin.ext heq
+    exact (prof.menPref_bijective m).injective hfeq
+  have hsp_eq : μ.spouse = ν.spouse := hsp
+  cases μ; cases ν
+  congr 1
+
+end ManLE
+
+/-! ## Helpers d'inverse (nécessaires pour la bijectivité de join/meet) -/
+
+/--
+Fait clé : μ.inverse w est l'unique m tel que μ.spouse m = w.
+-/
+lemma inverse_eq_of_spouse_eq (μ : Matching n) (m w : Fin n)
+    (h : μ.spouse m = w) : μ.inverse w = m := by
+  unfold Matching.inverse
+  have := Equiv.ofBijective_symm_apply_apply μ.spouse μ.bijective m
+  rw [h] at this
+  exact this
+
+/--
+Fait clé : μ.spouse (μ.inverse w) = w.
+-/
+lemma spouse_inverse (μ : Matching n) (w : Fin n) :
+    μ.spouse (μ.inverse w) = w := by
+  unfold Matching.inverse
+  exact Equiv.ofBijective_apply_symm_apply μ.spouse μ.bijective w
+
+/-! ## Lemme anti-croisement (décomposition de Knuth) -/
+
+/--
+Un fragment anti-croisement sain : si la femme partagée `w` est choisie par les deux hommes
+contre leurs partenaires dans l'autre mariage stable, alors les deux hommes coïncident.
+C'est le cas croisé nécessaire pour l'injectivité de `joinSpouse`.
+-/
+lemma no_cross_if_both_choose_cross (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν)
+    {m₁ m₂ w : Fin n}
+    (h1 : μ.spouse m₁ = w) (h2 : ν.spouse m₂ = w)
+    (hm₁ : prof.ManPrefers m₁ w (ν.spouse m₁))
+    (hm₂ : prof.ManPrefers m₂ w (μ.spouse m₂)) :
+    m₁ = m₂ := by
+  by_contra hne
+  have hμinv_w : μ.inverse w = m₁ := inverse_eq_of_spouse_eq μ m₁ _ h1
+  have hνinv_w : ν.inverse w = m₂ := inverse_eq_of_spouse_eq ν m₂ _ h2
+  have hnot₁ : ¬prof.WomanPrefers w m₁ m₂ := by
+    intro hw
+    have hbp : IsBlockingPair prof ν m₁ w := by
+      unfold IsBlockingPair
+      rw [hνinv_w]
+      exact ⟨hm₁, hw⟩
+    exact hν m₁ w hbp
+  have hnot₂ : ¬prof.WomanPrefers w m₂ m₁ := by
+    intro hw
+    have hbp : IsBlockingPair prof μ m₂ w := by
+      unfold IsBlockingPair
+      rw [hμinv_w]
+      exact ⟨hm₂, hw⟩
+    exact hμ m₂ w hbp
+  unfold PrefProfile.WomanPrefers at hnot₁ hnot₂
+  simp only [not_lt] at hnot₁ hnot₂
+  have heq : (prof.womenPref w m₁ : Nat) = prof.womenPref w m₂ :=
+    Nat.le_antisymm (mod_cast hnot₂) (mod_cast hnot₁)
+  exact hne ((prof.womenPref_bijective w).injective (Fin.ext heq))
+
+/-! ## Réfutation de la conjecture anti-croisement (`no_cross_match`)
+
+Les versions antérieures de ce fichier énonçaient le « lemme anti-croisement » suivant,
+attribué à l'argument de décomposition de Knuth, et laissaient ses cas A2/B comme
+`sorry` après de nombreuses tentatives de preuve infructueuses :
+
+  `no_cross_match : IsStable prof μ → IsStable prof ν →`
+  `    μ.spouse m₁ = w → ν.spouse m₂ = w → μ.spouse m₂ = ν.spouse m₁`
+
+Cet énoncé est FAUX. Il forcerait la différence symétrique de deux mariages stables
+quelconques à se décomposer en 2-cycles (échanges), mais des rotations de longueur
+≥ 3 entre mariages stables existent. Le contre-exemple vérifié par kernel ci-dessous
+(`NoCrossCounterexample.no_cross_match_is_false`) utilise l'instance classique 3×3
+carré latin (Knuth 1976) : le mariage identité et son décalage cyclique sont tous deux
+stables, mais l'égalité croisée des partenaires échouée. Cela explique pourquoi toutes
+les tentatives de preuve sur les branches `sorry` ont stagné : les buts étaient
+improuvables.
+
+Le théorème de treillis de Knuth n'a besoin d'aucun énoncé anti-croisement : les
+faits plus faibles prouvés dans ce fichier (`no_cross_if_both_choose_cross`,
+`joinSpouse_injective`, et l'argument de comptage dans `meetSpouse_eq_of_eq`)
+suffisent à montrer que join et meet de deux mariages stables sont des mariages.
+
+Les énoncés `man_optimality_key_step` et `doctor_optimal_eq_top` qui
+clôturaient précédemment ce fichier étaient faux pour la même raison (ils impliquaient
+que tous les mariages stables sont comparables deux à deux dans les deux directions ManLE,
+donc égaux) ; ils sont réfutés à la fin de ce fichier et remplacés par
+l'honnête théorème `exists_isManOptimal`.
+-/
+
+/--
+Stability from a fully computable check: it suffices to verify, for every
+man `m`, woman `w` and candidate husband `m'` with `μ.spouse m' = w`, that
+`(m, w)` is not a blocking pair.  This formulation avoids the noncomputable
+`Matching.inverse`, so on concrete instances the hypothesis can be
+discharged by `decide`.
+-/
+lemma isStable_of_check (μ : Matching n)
+    (h : ∀ m w m' : Fin n, μ.spouse m' = w →
+      ¬(prof.menPref m w < prof.menPref m (μ.spouse m) ∧
+        prof.womenPref w m < prof.womenPref w m')) :
+    IsStable prof μ := by
+  intro m w hbp
+  obtain ⟨h1, h2⟩ := hbp
+  exact h m w (μ.inverse w) (spouse_inverse μ w) ⟨h1, h2⟩
+
+namespace NoCrossCounterexample
+
+/-- Préférences des hommes pour l'instance 3×3 du carré latin (Knuth 1976).
+`menPref3 m w` est le rang que l'homme `m` assigne à la femme `w` (plus petit = préféré) :
+m₁ : w₁ > w₂ > w₃, m₂ : w₂ > w₃ > w₁, m₃ : w₃ > w₁ > w₂. -/
+def menPref3 : Fin 3 → Fin 3 → Fin 3 := ![![0, 1, 2], ![2, 0, 1], ![1, 2, 0]]
+
+/-- Préférences des femmes, décalées cycliquement par rapport aux hommes :
+w₁ : m₂ > m₃ > m₁, w₂ : m₃ > m₁ > m₂, w₃ : m₁ > m₂ > m₃. -/
+def womenPref3 : Fin 3 → Fin 3 → Fin 3 := ![![2, 0, 1], ![1, 2, 0], ![0, 1, 2]]
+
+/-- Le profil de préférences du carré latin 3×3. -/
+def prof3 : PrefProfile 3 where
+  menPref := menPref3
+  womenPref := womenPref3
+  menPref_bijective := by decide
+  womenPref_bijective := by decide
+
+/-- Le mariage identité mᵢ ↦ wᵢ. -/
+def M0 : Matching 3 where
+  spouse := id
+  bijective := Function.bijective_id
+
+/-- Le mariage décalage cyclique mᵢ ↦ wᵢ₊₁. -/
+def M1 : Matching 3 where
+  spouse := ![1, 2, 0]
+  bijective := by decide
+
+lemma M0_stable : IsStable prof3 M0 :=
+  isStable_of_check prof3 M0 (by decide)
+
+lemma M1_stable : IsStable prof3 M1 :=
+  isStable_of_check prof3 M1 (by decide)
+
+/--
+**Réfutation** de l'ancien lemme `no_cross_match` (son énoncé universellement
+quantifié complet).  Instanciation : μ = M0 (identité), ν = M1 (décalage),
+w = w₁, m₁ = m₁ (marié à w₁ dans M0), m₂ = m₃ (marié à w₁ dans M1).
+La conclusion forcerait `M0.spouse m₃ = M1.spouse m₁`, c-à-d w₃ = w₂.
+-/
+theorem no_cross_match_is_false :
+    ¬ ∀ (n : Nat) [NeZero n] (prof : PrefProfile n) (μ ν : Matching n),
+        IsStable prof μ → IsStable prof ν →
+        ∀ m₁ m₂ w : Fin n, μ.spouse m₁ = w → ν.spouse m₂ = w →
+          μ.spouse m₂ = ν.spouse m₁ := by
+  intro h
+  have hcontra := h 3 prof3 M0 M1 M0_stable M1_stable 0 2 0 (by decide) (by decide)
+  exact absurd hcontra (by decide)
+
+end NoCrossCounterexample
+
+/-! ## Opérations de join et meet -/
+
+/--
+La fonction spouse du join : chaque homme obtient sa partenaire préférée entre μ et ν.
+Définie comme une fonction nue pour que la bijectivité puisse être prouvée séparément avec
+les hypothèses de stabilité. Le join n'est PAS bijectif pour des mariages arbitraires ;
+il nécessite que μ et ν soient tous deux stables (anti-complémentarité).
+-/
+noncomputable def Matching.joinSpouse (μ ν : Matching n) (m : Fin n) : Fin n :=
+  if prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m) then
+    μ.spouse m
+  else
+    ν.spouse m
+
+/--
+La fonction spouse du meet : chaque homme obtient sa partenaire moins préférée entre μ et ν.
+-/
+noncomputable def Matching.meetSpouse (μ ν : Matching n) (m : Fin n) : Fin n :=
+  if prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m) then
+    ν.spouse m
+  else
+    μ.spouse m
+
+/--
+Injectivité du join : si joinSpouse μ ν m₁ = joinSpouse μ ν m₂, alors m₁ = m₂.
+Insight clé : les cas croisés (un homme choisit μ-spouse, l'autre ν-spouse,
+les deux égaux à la même femme w) mènent à une contradiction de paire bloquante via la stabilité.
+Les cas faciles (les deux hommes choisissent le même matching) découlent de l'injectivité de ce matching.
+-/
+private lemma joinSpouse_injective (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    Injective (fun m => μ.joinSpouse prof ν m) := by
+  intro m₁ m₂ heq
+  by_cases c₁ : prof.menPref m₁ (μ.spouse m₁) ≤ prof.menPref m₁ (ν.spouse m₁)
+  · simp only [Matching.joinSpouse, c₁, if_true] at heq
+    by_cases c₂ : prof.menPref m₂ (μ.spouse m₂) ≤ prof.menPref m₂ (ν.spouse m₂)
+    · simp only [Matching.joinSpouse, c₂, if_true] at heq
+      exact μ.bijective.1 heq
+    · simp only [Matching.joinSpouse, c₂, if_false] at heq
+      -- Cross-case: μ.spouse m₁ = ν.spouse m₂ = w, m₁ picks μ, m₂ picks ν
+      have hm₂pref : prof.ManPrefers m₂ (ν.spouse m₂) (μ.spouse m₂) := by
+        unfold PrefProfile.ManPrefers
+        have : ¬(prof.menPref m₂ (μ.spouse m₂) ≤ prof.menPref m₂ (ν.spouse m₂)) := c₂
+        have hle : (prof.menPref m₂ (μ.spouse m₂) : Nat) ≤ prof.menPref m₂ (ν.spouse m₂) → False := by
+          intro hle; exact this (mod_cast hle)
+        exact mod_cast Nat.lt_of_not_le hle
+      by_contra hne
+      -- ν stability applied to (m₁, ν.spouse m₂):
+      -- need ManPrefers m₁ (ν.spouse m₂) (ν.spouse m₁)
+      by_cases hm₁str : prof.ManPrefers m₁ (μ.spouse m₁) (ν.spouse m₁)
+      · -- Case: m₁ strictly prefers μ.spouse m₁ to ν.spouse m₁
+        -- ν stability: ¬IsBlockingPair ν m₁ (ν.spouse m₂)
+        have hmp : prof.ManPrefers m₁ (ν.spouse m₂) (ν.spouse m₁) := by
+          rw [← heq]; exact hm₁str
+        have hm₂inv : ν.inverse (ν.spouse m₂) = m₂ := inverse_eq_of_spouse_eq ν m₂ _ rfl
+        have hwp' : ¬prof.WomanPrefers (ν.spouse m₂) m₁ m₂ := by
+          intro hw'
+          exact hν m₁ (ν.spouse m₂) ⟨hmp, by rwa [hm₂inv]⟩
+        -- μ stability: ¬IsBlockingPair μ m₂ (ν.spouse m₂)
+        have hm₁inv : μ.inverse (μ.spouse m₁) = m₁ := inverse_eq_of_spouse_eq μ m₁ _ rfl
+        have hwp₂ : ¬prof.WomanPrefers (ν.spouse m₂) m₂ m₁ := by
+          intro hw'
+          have hw'' : prof.WomanPrefers (ν.spouse m₂) m₂ (μ.inverse (ν.spouse m₂)) := by
+            have h1 : μ.inverse (ν.spouse m₂) = m₁ := by
+              rw [← heq]; exact hm₁inv
+            rw [h1]; exact hw'
+          exact hμ m₂ (ν.spouse m₂) ⟨hm₂pref, hw''⟩
+        -- Both ¬WomanPrefers gives womenPref equality, contradicting injectivity
+        unfold PrefProfile.WomanPrefers at hwp' hwp₂
+        simp only [not_lt] at hwp' hwp₂
+        have heq' : (prof.womenPref (ν.spouse m₂) m₂ : Nat) = prof.womenPref (ν.spouse m₂) m₁ :=
+          Nat.le_antisymm (mod_cast hwp') (mod_cast hwp₂)
+        exact hne ((prof.womenPref_bijective (ν.spouse m₂)).injective (Fin.ext heq'.symm))
+      · -- Case: m₁ does NOT strictly prefer μ.spouse m₁ to ν.spouse m₁
+        -- c₁ + ¬hm₁str gives menPref m₁ (μ.spouse m₁) = menPref m₁ (ν.spouse m₁)
+        -- By injectivity: μ.spouse m₁ = ν.spouse m₁
+        -- But ν.spouse is injective and ν.spouse m₁ ≠ ν.spouse m₂ = μ.spouse m₁
+        unfold PrefProfile.ManPrefers at hm₁str
+        simp only [not_lt] at hm₁str
+        have heq' : (prof.menPref m₁ (μ.spouse m₁) : Nat) = prof.menPref m₁ (ν.spouse m₁) :=
+          Nat.le_antisymm (mod_cast c₁) (mod_cast hm₁str)
+        have hsp_eq : μ.spouse m₁ = ν.spouse m₁ :=
+          (prof.menPref_bijective m₁).injective (Fin.ext heq')
+        -- ν.spouse m₁ = μ.spouse m₁ = ν.spouse m₂ (by heq), contradicting injectivity
+        rw [heq] at hsp_eq
+        exact hne (ν.bijective.1 hsp_eq.symm)
+  · simp only [Matching.joinSpouse, c₁, if_false] at heq
+    by_cases c₂ : prof.menPref m₂ (μ.spouse m₂) ≤ prof.menPref m₂ (ν.spouse m₂)
+    · simp only [Matching.joinSpouse, c₂, if_true] at heq
+      -- Cross-case: ν.spouse m₁ = μ.spouse m₂, m₁ picks ν, m₂ picks μ
+      -- heq : ν.spouse m₁ = μ.spouse m₂
+      have hm₁pref : prof.ManPrefers m₁ (ν.spouse m₁) (μ.spouse m₁) := by
+        unfold PrefProfile.ManPrefers
+        have hle : (prof.menPref m₁ (μ.spouse m₁) : Nat) ≤ prof.menPref m₁ (ν.spouse m₁) → False := by
+          intro hle; exact c₁ (mod_cast hle)
+        exact mod_cast Nat.lt_of_not_le hle
+      by_contra hne
+      by_cases hm₂str : prof.ManPrefers m₂ (μ.spouse m₂) (ν.spouse m₂)
+      · -- m₂ strictly prefers μ.spouse m₂ to ν.spouse m₂
+        -- Key: w = ν.spouse m₁ = μ.spouse m₂ (by heq)
+        -- ν stability on (m₂, w): ManPrefers m₂ w (ν.spouse m₂) holds (via heq + hm₂str)
+        --   → ¬WomanPrefers w m₂ (ν⁻¹(w)) = ¬WomanPrefers w m₂ m₁
+        have hm₁νinv : ν.inverse (ν.spouse m₁) = m₁ := inverse_eq_of_spouse_eq ν m₁ _ rfl
+        have hwp₂ : ¬prof.WomanPrefers (ν.spouse m₁) m₂ m₁ := by
+          intro hw'
+          have hman : prof.ManPrefers m₂ (ν.spouse m₁) (ν.spouse m₂) := by rw [heq]; exact hm₂str
+          exact hν m₂ (ν.spouse m₁) ⟨hman, by rw [hm₁νinv]; exact hw'⟩
+        -- μ stability on (m₁, w): ManPrefers m₁ w (μ.spouse m₁) holds (via heq + hm₁pref)
+        --   → ¬WomanPrefers w m₁ (μ⁻¹(w)) = ¬WomanPrefers w m₁ m₂
+        have hm₂μinv : μ.inverse (μ.spouse m₂) = m₂ := inverse_eq_of_spouse_eq μ m₂ _ rfl
+        have hwp₁ : ¬prof.WomanPrefers (ν.spouse m₁) m₁ m₂ := by
+          intro hw'
+          have hman : prof.ManPrefers m₁ (ν.spouse m₁) (μ.spouse m₁) := hm₁pref
+          have hinv_eq : μ.inverse (ν.spouse m₁) = m₂ := by rw [heq, hm₂μinv]
+          have hw'' : prof.WomanPrefers (ν.spouse m₁) m₁ (μ.inverse (ν.spouse m₁)) := by
+            rw [hinv_eq]; exact hw'
+          exact hμ m₁ (ν.spouse m₁) ⟨hman, hw''⟩
+        -- Combine: both directions give womenPref equality → injectivity → m₁ = m₂
+        unfold PrefProfile.WomanPrefers at hwp₁ hwp₂
+        simp only [not_lt] at hwp₁ hwp₂
+        have heq' : (prof.womenPref (ν.spouse m₁) m₂ : Nat) = prof.womenPref (ν.spouse m₁) m₁ :=
+          Nat.le_antisymm (mod_cast hwp₁) (mod_cast hwp₂)
+        exact hne ((prof.womenPref_bijective (ν.spouse m₁)).injective (Fin.ext heq'.symm))
+      · -- m₂ does NOT strictly prefer μ.spouse m₂ to ν.spouse m₂
+        -- c₂ + ¬hm₂str gives menPref equality → μ.spouse m₂ = ν.spouse m₂
+        -- Combined with heq: ν.spouse m₁ = ν.spouse m₂ → m₁ = m₂
+        unfold PrefProfile.ManPrefers at hm₂str
+        simp only [not_lt] at hm₂str
+        have heq' : (prof.menPref m₂ (μ.spouse m₂) : Nat) = prof.menPref m₂ (ν.spouse m₂) :=
+          Nat.le_antisymm (mod_cast c₂) (mod_cast hm₂str)
+        have hsp_eq : μ.spouse m₂ = ν.spouse m₂ :=
+          (prof.menPref_bijective m₂).injective (Fin.ext heq')
+        rw [← heq] at hsp_eq
+        exact hne (ν.bijective.1 hsp_eq)
+    · simp only [Matching.joinSpouse, c₂, if_false] at heq
+      exact ν.bijective.1 heq
+
+/--
+Le join de deux mariages STABLES : chaque homme obtient sa partenaire préférée.
+La bijectivité découle de l'anti-complémentarité : côté femmes, le join
+agit comme le meet, donc deux hommes ne peuvent pas mapper vers la même femme.
+-/
+noncomputable def Matching.join (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    Matching n where
+  spouse := fun m => μ.joinSpouse prof ν m
+  bijective := Finite.injective_iff_bijective.mp (joinSpouse_injective prof μ ν hμ hν)
+
+/--
+La paire join/meet de chaque homme est exactement sa paire de partenaires dans `{μ, ν}` :
+soit le join prend sa μ-partenaire et le meet sa ν-partenaire, soit
+l'inverse. Purement définitionnel par if-split ; aucune stabilité nécessaire.
+-/
+private lemma joinSpouse_meetSpouse_cases (μ ν : Matching n) (m : Fin n) :
+    (μ.joinSpouse prof ν m = μ.spouse m ∧ μ.meetSpouse prof ν m = ν.spouse m) ∨
+    (μ.joinSpouse prof ν m = ν.spouse m ∧ μ.meetSpouse prof ν m = μ.spouse m) := by
+  by_cases hc : prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m)
+  · exact Or.inl ⟨by simp [Matching.joinSpouse, hc], by simp [Matching.meetSpouse, hc]⟩
+  · exact Or.inr ⟨by simp [Matching.joinSpouse, hc], by simp [Matching.meetSpouse, hc]⟩
+
+/--
+Noyau de l'injectivité du meet, par comptage — pas besoin de lemme anti-croisement
+(l'énoncé anti-croisement est en fait faux, voir
+`NoCrossCounterexample.no_cross_match_is_false`).
+
+Si deux hommes m₁, m₂ ont tous deux pour partenaire meet `w`, alors chacun d'eux est
+`μ.inverse w` ou `ν.inverse w` (la partenaire meet d'un homme est l'une de ses propres partenaires).
+Le join est surjectif (`joinSpouse_injective` + finitude), donc un certain m₀ a pour partenaire join `w`,
+et m₀ se trouve aussi dans `{μ.inverse w, ν.inverse w}`. Dans le cas mixte
+(m₁, m₂ occupant les deux slots distincts), m₀ coïncide avec l'un d'eux ; mais un homme
+dont les partenaires join ET meet sont tous deux `w` a ses partenaires μ et ν tous deux égaux à `w`,
+ce qui effondre les deux inverses sur lui — et alors m₁ et m₂ lui sont tous deux égaux.
+-/
+private lemma meetSpouse_eq_of_eq (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) (w m₁ m₂ : Fin n)
+    (h₁ : μ.meetSpouse prof ν m₁ = w) (h₂ : μ.meetSpouse prof ν m₂ = w) :
+    m₁ = m₂ := by
+  -- any man who meets to w is μ.inverse w or ν.inverse w
+  have hmeet_mem : ∀ m : Fin n, μ.meetSpouse prof ν m = w →
+      m = μ.inverse w ∨ m = ν.inverse w := by
+    intro m hm
+    rcases joinSpouse_meetSpouse_cases prof μ ν m with ⟨_, hmm⟩ | ⟨_, hmm⟩
+    · exact Or.inr (inverse_eq_of_spouse_eq ν m w (hmm.symm.trans hm)).symm
+    · exact Or.inl (inverse_eq_of_spouse_eq μ m w (hmm.symm.trans hm)).symm
+  -- the join is surjective, so some m₀ has join-partner w
+  have hbij : Function.Bijective (fun m => μ.joinSpouse prof ν m) :=
+    Finite.injective_iff_bijective.mp (joinSpouse_injective prof μ ν hμ hν)
+  obtain ⟨m₀, hm₀⟩ := hbij.2 w
+  have hm₀' : μ.joinSpouse prof ν m₀ = w := hm₀
+  have hm₀_mem : m₀ = μ.inverse w ∨ m₀ = ν.inverse w := by
+    rcases joinSpouse_meetSpouse_cases prof μ ν m₀ with ⟨hjj, _⟩ | ⟨hjj, _⟩
+    · exact Or.inl (inverse_eq_of_spouse_eq μ m₀ w (hjj.symm.trans hm₀')).symm
+    · exact Or.inr (inverse_eq_of_spouse_eq ν m₀ w (hjj.symm.trans hm₀')).symm
+  -- a man who both joins and meets to w pins down BOTH inverses
+  have hboth : ∀ m : Fin n, μ.joinSpouse prof ν m = w → μ.meetSpouse prof ν m = w →
+      μ.inverse w = m ∧ ν.inverse w = m := by
+    intro m hj hm
+    rcases joinSpouse_meetSpouse_cases prof μ ν m with ⟨hjj, hmm⟩ | ⟨hjj, hmm⟩
+    · exact ⟨inverse_eq_of_spouse_eq μ m w (hjj.symm.trans hj),
+             inverse_eq_of_spouse_eq ν m w (hmm.symm.trans hm)⟩
+    · exact ⟨inverse_eq_of_spouse_eq μ m w (hmm.symm.trans hm),
+             inverse_eq_of_spouse_eq ν m w (hjj.symm.trans hj)⟩
+  -- mixed-slot case: the join witness collapses the two inverses
+  have key : ∀ ma mb : Fin n, ma = μ.inverse w → mb = ν.inverse w →
+      μ.meetSpouse prof ν ma = w → μ.meetSpouse prof ν mb = w → ma = mb := by
+    intro ma mb ea eb hma hmb
+    rcases hm₀_mem with e₀ | e₀
+    · -- m₀ = μ.inverse w = ma, so ma joins AND meets to w
+      have hja : μ.joinSpouse prof ν ma = w := by rw [ea, ← e₀]; exact hm₀'
+      obtain ⟨_, hbν⟩ := hboth ma hja hma
+      rw [eb, hbν]
+    · -- m₀ = ν.inverse w = mb, so mb joins AND meets to w
+      have hjb : μ.joinSpouse prof ν mb = w := by rw [eb, ← e₀]; exact hm₀'
+      obtain ⟨hbμ, _⟩ := hboth mb hjb hmb
+      rw [ea, hbμ]
+  rcases hmeet_mem m₁ h₁ with e₁ | e₁ <;> rcases hmeet_mem m₂ h₂ with e₂ | e₂
+  · exact e₁.trans e₂.symm
+  · exact key m₁ m₂ e₁ e₂ h₁ h₂
+  · exact (key m₂ m₁ e₂ e₁ h₂ h₁).symm
+  · exact e₁.trans e₂.symm
+
+/--
+Injectivité du meet, via l'argument de comptage dans `meetSpouse_eq_of_eq`.
+-/
+private lemma meetSpouse_injective (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    Injective (fun m => μ.meetSpouse prof ν m) := by
+  intro m₁ m₂ heq
+  exact meetSpouse_eq_of_eq prof μ ν hμ hν (μ.meetSpouse prof ν m₂) m₁ m₂ heq rfl
+
+/--
+Le meet de deux mariages STABLES : chaque homme obtient sa partenaire moins préférée.
+-/
+noncomputable def Matching.meet (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    Matching n where
+  spouse := fun m => μ.meetSpouse prof ν m
+  bijective := Finite.injective_iff_bijective.mp (meetSpouse_injective prof μ ν hμ hν)
+
+/-! ## Stabilité du Join et du Meet (Wu-Roth Lemme 3.2, cas univoque) -/
+
+open PrefProfile
+
+/--
+Helper : si m préfère w à sa join-spouse, alors m préfère w à la fois
+à sa partenaire dans μ et à sa partenaire dans ν.
+Le join choisit la partenaire de rang inférieur (plus préférée) parmi les deux.
+Utilise joinSpouse (pas de stabilité nécessaire).
+-/
+lemma join_pref_both (μ ν : Matching n) (m w : Fin n)
+    (h : prof.ManPrefers m w (μ.joinSpouse prof ν m)) :
+    prof.ManPrefers m w (μ.spouse m) ∧ prof.ManPrefers m w (ν.spouse m) := by
+  unfold ManPrefers at h ⊢
+  simp only [Matching.joinSpouse] at h
+  split_ifs at h
+  · -- menPref m (μ.spouse m) ≤ menPref m (ν.spouse m), h : menPref m w < menPref m (μ.spouse m)
+    refine ⟨h, ?_⟩
+    have : (prof.menPref m w : Nat) < prof.menPref m (μ.spouse m) := mod_cast h
+    have : (prof.menPref m (μ.spouse m) : Nat) ≤ prof.menPref m (ν.spouse m) := mod_cast ‹_›
+    exact mod_cast Nat.lt_of_lt_of_le ‹_› ‹_›
+  · -- ¬(menPref m (μ.spouse m) ≤ menPref m (ν.spouse m)), h : menPref m w < menPref m (ν.spouse m)
+    refine ⟨?_, h⟩
+    have hνμ : (prof.menPref m (ν.spouse m) : Nat) < prof.menPref m (μ.spouse m) := by
+      have : ¬ (prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m)) := ‹_›
+      have : (prof.menPref m (μ.spouse m) : Nat) ≤ prof.menPref m (ν.spouse m) → False := by
+        intro hle; exact this (mod_cast hle : prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m))
+      omega
+    have : (prof.menPref m w : Nat) < prof.menPref m (ν.spouse m) := mod_cast h
+    exact mod_cast Nat.lt_trans ‹_› hνμ
+
+/--
+Helper : si m préfère w à sa meet-spouse, alors m préfère w à au moins l'une
+de ses partenaires dans μ ou ν (la moins préférée).
+Utilise meetSpouse (pas de stabilité nécessaire).
+-/
+lemma meet_pref_one (μ ν : Matching n) (m w : Fin n)
+    (h : prof.ManPrefers m w (μ.meetSpouse prof ν m)) :
+    prof.ManPrefers m w (μ.spouse m) ∨ prof.ManPrefers m w (ν.spouse m) := by
+  unfold ManPrefers at h ⊢
+  simp only [Matching.meetSpouse] at h
+  split_ifs at h
+  · -- meet picked ν.spouse m: h : menPref m w < menPref m (ν.spouse m)
+    right; exact h
+  · -- meet picked μ.spouse m: h : menPref m w < menPref m (μ.spouse m)
+    left; exact h
+
+/--
+Anti-complémentarité du join :
+(μ ⊔ ν).inverse w est égal soit à μ⁻¹(w), soit à ν⁻¹(w).
+
+Preuve : soit m = (μ ⊔ ν).inverse w. Le join donne à m sa partenaire préférée,
+qui vaut w. Donc soit μ.spouse m = w (ce qui donne m = μ⁻¹(w)),
+soit ν.spouse m = w (ce qui donne m = ν⁻¹(w)).
+-/
+lemma join_inverse_anti (μ ν : Matching n) (hμ : IsStable prof μ) (hν : IsStable prof ν)
+    (w : Fin n) :
+    (μ.join prof hμ hν).inverse w = μ.inverse w ∨
+    (μ.join prof hμ hν).inverse w = ν.inverse w := by
+  have hspw : (μ.join prof hμ hν).spouse ((μ.join prof hμ hν).inverse w) = w :=
+    spouse_inverse (μ.join prof hμ hν) w
+  simp only [Matching.join, Matching.joinSpouse] at hspw
+  split_ifs at hspw
+  · left; exact (inverse_eq_of_spouse_eq μ _ w hspw).symm
+  · right; exact (inverse_eq_of_spouse_eq ν _ w hspw).symm
+
+/--
+Anti-complémentarité du meet (côté femmes) :
+Si meet.inverse w = μ⁻¹(w), alors w préfère μ⁻¹(w) à ν⁻¹(w).
+Le meet côté hommes agit comme le join côté femmes : w obtient son
+homme préféré. Si le meet a choisi μ⁻¹(w), alors ν⁻¹(w) doit être moins préféré.
+Nécessite la stabilité de μ et ν.
+-/
+lemma meet_inverse_anti_pref (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) (w : Fin n)
+    (h : (μ.meet prof hμ hν).inverse w = μ.inverse w) :
+    prof.womenPref w (μ.inverse w) ≤ prof.womenPref w (ν.inverse w) := by
+  have hmsp : μ.spouse (μ.inverse w) = w := spouse_inverse μ w
+  have hmMeet : (μ.meet prof hμ hν).spouse (μ.inverse w) = w := by
+    rw [← h, spouse_inverse]
+  simp only [Matching.meet, Matching.meetSpouse] at hmMeet
+  by_cases hle : prof.menPref (μ.inverse w) (μ.spouse (μ.inverse w)) ≤
+      prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w))
+  · -- meetSpouse = ν.spouse, so ν.spouse (μ⁻¹w) = w = μ.spouse (μ⁻¹w)
+    simp only [hle, if_true] at hmMeet
+    have hνinv : ν.inverse w = μ.inverse w :=
+      inverse_eq_of_spouse_eq ν _ _ hmMeet
+    rw [hνinv]
+  · -- μ⁻¹w strictly prefers ν.spouse(μ⁻¹w) over μ.spouse(μ⁻¹w) = w
+    push Not at hle
+    -- Need: womenPref w (μ⁻¹w) ≤ womenPref w (ν⁻¹w)
+    -- By contraposition: if womenPref w (ν⁻¹w) < womenPref w (μ⁻¹w),
+    -- then w prefers ν⁻¹w over μ⁻¹w.
+    -- Combined with man μ⁻¹w preferring ν.spouse(μ⁻¹w) over w,
+    -- if ν.spouse(μ⁻¹w) = w then ν⁻¹(w) = μ⁻¹w, contradicted by injectivity of menPref.
+    by_cases hw : ν.spouse (μ.inverse w) = w
+    · -- ν also matches μ⁻¹w to w, so ν⁻¹w = μ⁻¹w
+      have hνinv_eq : ν.inverse w = μ.inverse w :=
+        inverse_eq_of_spouse_eq ν _ _ hw
+      rw [hνinv_eq]
+    · -- ν.spouse(μ⁻¹w) ≠ w
+      set m' := ν.inverse w with hm'def
+      have hνm' : ν.spouse m' = w := spouse_inverse ν w
+      by_cases hle' : prof.menPref m' (μ.spouse m') ≤ prof.menPref m' (ν.spouse m')
+      · -- meet picks ν.spouse m' = w for man m'
+        -- meet.spouse m' = ν.spouse m' = w, so meet.inverse w = m' = ν⁻¹w
+        have hmeetm' : (μ.meet prof hμ hν).spouse m' = ν.spouse m' := by
+          show (μ.meet prof hμ hν).spouse m' = ν.spouse m'
+          simp only [Matching.meet, Matching.meetSpouse, hle', if_true]
+        have hmeetm'w : (μ.meet prof hμ hν).spouse m' = w := hmeetm' ▸ hνm'
+        have hinv' : (μ.meet prof hμ hν).inverse w = m' :=
+          inverse_eq_of_spouse_eq (μ.meet prof hμ hν) m' w hmeetm'w
+        -- But h says meet.inverse w = μ⁻¹w, so m' = μ⁻¹w
+        have hm'eq : m' = μ.inverse w := hinv' ▸ h
+        -- Then ν.spouse(μ⁻¹w) = ν.spouse m' = w, contradicting hw
+        have : ν.spouse (μ.inverse w) = w := hm'eq ▸ hνm'
+        exact absurd this hw
+      · -- meet picks μ.spouse m' for man m'
+        -- menPref m' (ν.spouse m') < menPref m' (μ.spouse m'), i.e. m' prefers w over μ.sp m'
+        have hm'pref : prof.ManPrefers m' w (μ.spouse m') := by
+          unfold ManPrefers
+          have hνsp : prof.menPref m' (ν.spouse m') = prof.menPref m' w := by rw [hνm']
+          have := hle'
+          simp only [not_le] at this
+          rw [hνsp] at this
+          exact mod_cast this
+        -- Use stability of μ: ¬IsBlockingPair μ m' w
+        -- ManPrefers m' w (μ.spouse m') holds, so woman side must fail
+        have hblock : ¬IsBlockingPair prof μ m' w := hμ m' w
+        have : ¬prof.WomanPrefers w m' (μ.inverse w) := by
+          intro hw'
+          exact hblock ⟨hm'pref, hw'⟩
+        unfold WomanPrefers at this
+        simp only [not_lt] at this
+        exact this
+
+/--
+Anti-complémentarité du meet (côté femmes, branche ν) :
+Si meet.inverse w = ν⁻¹(w), alors w préfère ν⁻¹(w) à μ⁻¹(w).
+Nécessite la stabilité de μ et ν.
+-/
+lemma meet_inverse_anti_pref' (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) (w : Fin n)
+    (h : (μ.meet prof hμ hν).inverse w = ν.inverse w) :
+    prof.womenPref w (ν.inverse w) ≤ prof.womenPref w (μ.inverse w) := by
+  have hνsp : ν.spouse (ν.inverse w) = w := spouse_inverse ν w
+  have hmMeet : (μ.meet prof hμ hν).spouse (ν.inverse w) = w := by
+    rw [← h, spouse_inverse]
+  simp only [Matching.meet, Matching.meetSpouse] at hmMeet
+  by_cases hle : prof.menPref (ν.inverse w) (μ.spouse (ν.inverse w)) ≤
+      prof.menPref (ν.inverse w) (ν.spouse (ν.inverse w))
+  · -- meet picks ν.spouse(ν⁻¹w) = w
+    simp only [hle, if_true] at hmMeet
+    by_cases hw : μ.spouse (ν.inverse w) = w
+    · rw [inverse_eq_of_spouse_eq μ _ _ hw]
+    · -- μ⁻¹w ≠ ν⁻¹w, and ν⁻¹w weakly prefers μ.sp(ν⁻¹w) to w.
+      -- Use the μ-stability on (ν⁻¹w, w): ν⁻¹w is matched to μ.sp(ν⁻¹w) ≠ w in μ.
+      -- hle says ν⁻¹w prefers μ.sp(ν⁻¹w) to w, i.e., man prefers w less.
+      -- So man side of blocking pair (ν⁻¹w, w) in μ FAILS (man doesn't prefer w).
+      -- This doesn't give us the womenPref inequality.
+      -- Instead use the anti-complementarity of the proved meet_inverse_anti_pref lemma:
+      -- meet chose ν⁻¹w for w, and by anti_pref, womenPref w (μ⁻¹w) ≤ womenPref w (ν⁻¹w).
+      -- We need the opposite: womenPref w (ν⁻¹w) ≤ womenPref w (μ⁻¹w).
+      -- This requires the ' version which is what we're trying to prove!
+      -- Fall back to: ν-stability on (μ⁻¹w, w) if man prefers w.
+      have hmμ : μ.spouse (μ.inverse w) = w := spouse_inverse μ w
+      by_cases hνpref : prof.menPref (μ.inverse w) w <
+          prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w))
+      · -- μ⁻¹w prefers w to ν.sp(μ⁻¹w): (μ⁻¹w, w) would block ν
+        -- unless w doesn't prefer μ⁻¹w to ν⁻¹w
+        have hblock : ¬IsBlockingPair prof ν (μ.inverse w) w := hν (μ.inverse w) w
+        have hm'pref : prof.ManPrefers (μ.inverse w) w (ν.spouse (μ.inverse w)) := by
+          unfold ManPrefers; exact mod_cast hνpref
+        have : ¬prof.WomanPrefers w (μ.inverse w) (ν.inverse w) := by
+          intro hw'; exact hblock ⟨hm'pref, hw'⟩
+        unfold WomanPrefers at this
+        simp only [not_lt] at this
+        exact this
+      · -- ¬hνpref: menPref(μ⁻¹w)(ν.sp(μ⁻¹w)) ≤ menPref(μ⁻¹w)(w) = menPref(μ⁻¹w)(μ.sp(μ⁻¹w))
+        -- Either meet picks μ.sp(μ⁻¹w)=w, or equality forces ν.sp(μ⁻¹w)=w by injectivity.
+        -- In both cases meet⁻¹w = μ⁻¹w, and combined with h, μ⁻¹w = ν⁻¹w.
+        have hnle : ¬prof.menPref (μ.inverse w) (μ.spouse (μ.inverse w)) ≤
+            prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w)) := by
+          intro hle'
+          simp only [not_lt] at hνpref
+          rw [hmμ] at hle'
+          have hnat₁ : (prof.menPref (μ.inverse w) w : Nat) ≤
+              prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w)) := mod_cast hle'
+          have hnat₂ : (prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w)) : Nat) ≤
+              prof.menPref (μ.inverse w) w := mod_cast hνpref
+          have hnat_eq : prof.menPref (μ.inverse w) w =
+              prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w)) :=
+            Fin.ext (Nat.le_antisymm hnat₁ hnat₂)
+          have hνspμ : ν.spouse (μ.inverse w) = w :=
+            (prof.menPref_bijective (μ.inverse w)).injective hnat_eq.symm
+          have hνeq : ν.inverse w = μ.inverse w :=
+            (inverse_eq_of_spouse_eq ν _ _ hνspμ).trans
+              (inverse_eq_of_spouse_eq μ _ _ hmμ).symm
+          rw [hνeq] at hw
+          exact hw hmμ
+        have hmMeet' : (μ.meet prof hμ hν).spouse (μ.inverse w) =
+            μ.spouse (μ.inverse w) := by
+          simp only [Matching.meet, Matching.meetSpouse, hnle, if_false]
+        have hmMeetw : (μ.meet prof hμ hν).spouse (μ.inverse w) = w := by
+          rw [hmMeet', hmμ]
+        have hinvEq : (μ.meet prof hμ hν).inverse w = μ.inverse w :=
+          inverse_eq_of_spouse_eq (μ.meet prof hμ hν) _ _ hmMeetw
+        rw [← h, hinvEq]
+  · -- meet picks μ.spouse(ν⁻¹w), so μ.spouse(ν⁻¹w) = w, hence μ⁻¹w = ν⁻¹w
+    push Not at hle
+    split_ifs at hmMeet with hle'
+    · -- pos branch contradicts ¬hle: hle' says a≤b but hle says b<a
+      exfalso; omega
+    · -- neg branch: μ.spouse(ν⁻¹w) = w, so μ⁻¹w = ν⁻¹w
+      rw [inverse_eq_of_spouse_eq μ _ _ hmMeet]
+
+/--
+Anti-complémentarité du meet : (μ ⊓ ν).inverse w est égal soit à μ⁻¹(w), soit à ν⁻¹(w).
+Même argument que join_inverse_anti : la meet spouse de (meet.inverse w) vaut w,
+et le meet choisit l'une des deux partenaires.
+-/
+lemma meet_inverse_anti (μ ν : Matching n) (hμ : IsStable prof μ) (hν : IsStable prof ν)
+    (w : Fin n) :
+    (μ.meet prof hμ hν).inverse w = μ.inverse w ∨
+    (μ.meet prof hμ hν).inverse w = ν.inverse w := by
+  have hspw : (μ.meet prof hμ hν).spouse ((μ.meet prof hμ hν).inverse w) = w :=
+    spouse_inverse (μ.meet prof hμ hν) w
+  simp only [Matching.meet, Matching.meetSpouse] at hspw
+  split_ifs at hspw
+  · right; exact (inverse_eq_of_spouse_eq ν _ w hspw).symm
+  · left; exact (inverse_eq_of_spouse_eq μ _ w hspw).symm
+
+/--
+Wu-Roth Lemme 3.2 (spécialisation univoque) :
+Le join de deux mariages stables est stable.
+
+Preuve : supposons que (m, w) bloque μ ⊔ ν.
+Côté homme : m préfère w à la join-partenaire ⟹ m préfère w à la fois à μ(m) et ν(m).
+Côté femme : (μ ⊔ ν).inverse w est soit μ⁻¹(w), soit ν⁻¹(w).
+  Cas μ⁻¹(w) : w préfère m à μ⁻¹(w), donc (m,w) bloque μ. Contradiction.
+  Cas ν⁻¹(w) : w préfère m à ν⁻¹(w), donc (m,w) bloque ν. Contradiction.
+-/
+theorem join_isStable (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    IsStable prof (μ.join prof hμ hν) := by
+  intro m w hblock
+  obtain ⟨hmpref, hwpref⟩ := hblock
+  simp only [Matching.join, Matching.joinSpouse] at hmpref
+  have hboth := join_pref_both prof μ ν m w hmpref
+  rcases join_inverse_anti prof μ ν hμ hν w with hinvμ | hinvν
+  · rw [hinvμ] at hwpref
+    exact hμ m w ⟨hboth.1, hwpref⟩
+  · rw [hinvν] at hwpref
+    exact hν m w ⟨hboth.2, hwpref⟩
+
+/--
+Le meet de deux mariages stables est stable.
+
+Preuve : supposons que (m, w) bloque μ ⊓ ν.
+Côté homme : m préfère w à la meet-partenaire ⟹ m préfère w à au moins l'une de μ(m) ou ν(m).
+Côté femme : (μ ⊓ ν).inverse w est soit μ⁻¹(w), soit ν⁻¹(w).
+  Combinés, au moins un des cas donne une paire bloquante pour μ ou ν.
+-/
+theorem meet_isStable (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    IsStable prof (μ.meet prof hμ hν) := by
+  intro m w hblock
+  obtain ⟨hmpref, hwpref⟩ := hblock
+  simp only [Matching.meet, Matching.meetSpouse] at hmpref
+  have hone := meet_pref_one prof μ ν m w hmpref
+  rcases meet_inverse_anti prof μ ν hμ hν w with hinvμ | hinvν
+  · -- (μ ⊓ ν).inverse w = μ.inverse w, so w prefers m to μ⁻¹(w)
+    rw [hinvμ] at hwpref
+    rcases hone with hmμ | hmν
+    · -- m prefers w to μ(m) AND w prefers m to μ⁻¹(w) → blocks μ
+      exact hμ m w ⟨hmμ, hwpref⟩
+    · -- m prefers w to ν(m), w prefers m to μ⁻¹(w)
+      -- Anti-complementarity: meet.inverse w = μ⁻¹(w) ⟹ w prefers μ⁻¹(w) to ν⁻¹(w)
+      -- Transitively: w prefers m to ν⁻¹(w). Combined with hmν, (m,w) blocks ν.
+      have hwν := meet_inverse_anti_pref prof μ ν hμ hν w hinvμ
+      have h1 : (prof.womenPref w m : Nat) < prof.womenPref w (μ.inverse w) := mod_cast hwpref
+      have h2 : (prof.womenPref w (μ.inverse w) : Nat) ≤ prof.womenPref w (ν.inverse w) := mod_cast hwν
+      have hwν' : prof.WomanPrefers w m (ν.inverse w) := mod_cast Nat.lt_of_lt_of_le h1 h2
+      exact hν m w ⟨hmν, hwν'⟩
+  · -- (μ ⊓ ν).inverse w = ν.inverse w, so w prefers m to ν⁻¹(w)
+    rw [hinvν] at hwpref
+    rcases hone with hmμ | hmν
+    · -- m prefers w to μ(m), w prefers m to ν⁻¹(w)
+      -- Anti-complementarity: meet.inverse w = ν⁻¹(w) ⟹ w prefers ν⁻¹(w) to μ⁻¹(w)
+      -- Transitively: w prefers m to μ⁻¹(w). Combined with hmμ, (m,w) blocks μ.
+      have hwμ := meet_inverse_anti_pref' prof μ ν hμ hν w hinvν
+      have h1 : (prof.womenPref w m : Nat) < prof.womenPref w (ν.inverse w) := mod_cast hwpref
+      have h2 : (prof.womenPref w (ν.inverse w) : Nat) ≤ prof.womenPref w (μ.inverse w) := mod_cast hwμ
+      have hwμ' : prof.WomanPrefers w m (μ.inverse w) := mod_cast Nat.lt_of_lt_of_le h1 h2
+      exact hμ m w ⟨hmμ, hwμ'⟩
+    · -- m prefers w to ν(m) AND w prefers m to ν⁻¹(w) → blocks ν
+      exact hν m w ⟨hmν, hwpref⟩
+
+/-! ## Instance de treillis -/
+
+-- TODO : l'instance nécessite de prouver tous les axiomes de treillis sur le sous-type.
+-- Cela requiert join_isStable + meet_isStable entièrement prouvés d'abord.
+-- Sera instanciée une fois les preuves complètes.
+
+/-! ## Man-optimalité (version honnête)
+
+Les deux énoncés qui clôturaient précédemment ce fichier —
+
+  `man_optimality_key_step : menPref m' (ν.spouse m') < menPref m' (μ.spouse m') → False`
+  `doctor_optimal_eq_top   : IsStable prof μ_gs → IsStable prof μ' → ManLE prof μ_gs μ'`
+
+— étaient FAUX tels qu'énoncés (leurs `sorry` étaient improuvables) : aucun énoncé
+ne mentionnait l'algorithme de Gale-Shapley, donc ensemble ils affirmaient que N'IMPORTE QUELS deux
+mariages stables sont comparables ManLE dans les deux directions, c-à-d que le
+mariage stable est unique. L'instance du carré latin 3×3 réfute les deux
+(`NoCrossCounterexample.man_optimality_key_step_is_false`,
+`NoCrossCounterexample.doctor_optimal_eq_top_is_false`).
+
+Le remplacement honnête est l'EXISTENCE d'un mariage stable man-optimal,
+`exists_isManOptimal`, prouvée par un argument de poids minimal sur le join
+semilattice (`join_isStable`). `gale_shapley_man_optimal` dans
+GaleShapley.lean le consomme, ensemencé par `gale_shapley_stable`.
+-/
+
+namespace NoCrossCounterexample
+
+/--
+**Réfutation** de l'ancien lemme `man_optimality_key_step` : m₁ préfère strictement
+sa M0-partenaire w₁ (rang 0) à sa M1-partenaire w₂ (rang 1), et les deux
+mariages sont stables, donc aucun `False` ne peut s'ensuivre.
+-/
+theorem man_optimality_key_step_is_false :
+    ¬ ∀ (n : Nat) [NeZero n] (prof : PrefProfile n) (μ ν : Matching n),
+        IsStable prof μ → IsStable prof ν →
+        ∀ m' : Fin n,
+          prof.menPref m' (ν.spouse m') < prof.menPref m' (μ.spouse m') → False := by
+  intro h
+  exact h 3 prof3 M1 M0 M1_stable M0_stable 0 (by decide)
+
+/--
+**Réfutation** de l'ancien théorème `doctor_optimal_eq_top` : avec
+μ_gs := M1 et μ' := M0 (tous deux stables), ManLE requerrait
+`menPref m₁ w₂ ≤ menPref m₁ w₁`, c-à-d `1 ≤ 0`.
+-/
+theorem doctor_optimal_eq_top_is_false :
+    ¬ ∀ (n : Nat) [NeZero n] (prof : PrefProfile n) (μ_gs : Matching n),
+        IsStable prof μ_gs →
+        ∀ μ' : Matching n, IsStable prof μ' → ManLE prof μ_gs μ' := by
+  intro h
+  have hle := h 3 prof3 M1 M1_stable M0 M0_stable
+  have h0 := hle 0
+  exact absurd h0 (by decide)
+
+end NoCrossCounterexample
+
+/--
+Un mariage stable man-optimal existe dès qu'un mariage stable existe.
+
+Argument de poids minimal : soit `W μ = Σ_m rank_m (μ.spouse m)` et choisissons (via
+`Nat.find`) un mariage stable `μ₀` dont le poids est minimal parmi les mariages stables.
+Si un `ν` stable donnait à un homme `m` une partenaire strictement meilleure,
+le join `μ₀ ⊔ ν` serait stable (`join_isStable`), pointwise faiblement meilleur côté hommes
+que `μ₀` (le join donne à chaque homme sa partenaire préférée des deux) et strictement meilleur
+pour `m`, donc de poids strictement plus petit — contredisant la minimalité. Donc `μ₀` est man-optimal.
+
+L'hypothèse est déchargée par `gale_shapley_stable` dans GaleShapley.lean
+(gardée comme hypothèse ici pour éviter un cycle d'import).
+-/
+theorem exists_isManOptimal (hex : ∃ μ : Matching n, IsStable prof μ) :
+    ∃ μ : Matching n, IsManOptimal prof μ := by
+  classical
+  let W : Matching n → Nat := fun μ => ∑ m : Fin n, (prof.menPref m (μ.spouse m) : Nat)
+  let P : Nat → Prop := fun k => ∃ μ : Matching n, IsStable prof μ ∧ W μ = k
+  have hP : ∃ k, P k := by
+    obtain ⟨μ, hμ⟩ := hex
+    exact ⟨W μ, μ, hμ, rfl⟩
+  obtain ⟨μ₀, hμ₀, hW₀⟩ := Nat.find_spec hP
+  refine ⟨μ₀, hμ₀, ?_⟩
+  intro ν hν m
+  by_contra hgt
+  push Not at hgt
+  -- hgt : m strictly prefers his ν-partner; consider the join μ₀ ⊔ ν
+  have hle : ∀ m' : Fin n,
+      (prof.menPref m' ((μ₀.join prof hμ₀ hν).spouse m') : Nat) ≤
+        (prof.menPref m' (μ₀.spouse m') : Nat) := by
+    intro m'
+    show (prof.menPref m' (μ₀.joinSpouse prof ν m') : Nat) ≤ _
+    unfold Matching.joinSpouse
+    split_ifs with hc
+    · exact le_refl _
+    · have hnle : ¬((prof.menPref m' (μ₀.spouse m') : Nat) ≤
+          (prof.menPref m' (ν.spouse m') : Nat)) := fun hh => hc (mod_cast hh)
+      omega
+  have hlt : (prof.menPref m ((μ₀.join prof hμ₀ hν).spouse m) : Nat) <
+      (prof.menPref m (μ₀.spouse m) : Nat) := by
+    show (prof.menPref m (μ₀.joinSpouse prof ν m) : Nat) < _
+    unfold Matching.joinSpouse
+    split_ifs with hc
+    · exfalso
+      have h1 : (prof.menPref m (μ₀.spouse m) : Nat) ≤
+          (prof.menPref m (ν.spouse m) : Nat) := mod_cast hc
+      have h2 : (prof.menPref m (ν.spouse m) : Nat) <
+          (prof.menPref m (μ₀.spouse m) : Nat) := mod_cast hgt
+      omega
+    · exact mod_cast hgt
+  have hWlt : W (μ₀.join prof hμ₀ hν) < W μ₀ :=
+    Finset.sum_lt_sum (fun i _ => hle i) ⟨m, Finset.mem_univ m, hlt⟩
+  have hPlt : P (W (μ₀.join prof hμ₀ hν)) :=
+    ⟨μ₀.join prof hμ₀ hν, join_isStable prof μ₀ ν hμ₀ hν, rfl⟩
+  exact Nat.find_min hP (lt_of_lt_of_le hWlt (le_of_eq hW₀)) hPlt
+
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lattice_en.lean
@@ -1,0 +1,881 @@
+/-
+  Stable Marriage - Lattice Structure on Stable Matchings
+  ========================================================
+
+  Knuth (1976) showed that the set of stable matchings forms a lattice
+  under the "common preferences" ordering. Wu & Roth (2018) generalized
+  this to many-to-one; we specialize to the one-to-one case.
+
+  Key results:
+  - Stable matchings are partially ordered by man-preference
+  - The join (supremum) of two stable matchings is stable
+  - The meet (infimum) of two stable matchings is stable
+  - The set of stable matchings forms a distributive lattice
+  - The GS man-proposing output is the top (man-optimal) element
+
+  Reference: Knuth (1976), "Marriages Stables"
+  Reference: Wu & Roth (2018), "Lattice Structures in Stable Matching"
+  Reference: Stanley (2011), "Enumerative Combinatorics" Vol 1 (finite lattice lemma)
+
+  Strategy:
+  - We define μ ≤ ν iff every man prefers μ to ν (or is indifferent)
+  - join μ ν: each man gets his preferred partner between μ and ν
+  - meet μ ν: each man gets his less-preferred partner between μ and ν
+  - Wu-Roth Lemma 3.2 (one-to-one): join and meet of stable matchings are stable
+  - Stanley lemma: finite join-semilattice with min = lattice
+-/
+
+import Mathlib.Order.Lattice
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Tactic.Common
+import StableMarriage.Definitions
+import StableMarriage.Lemmas
+import StableMarriage.Lattice
+
+/-
+  Stable Marriage - Lattice Structure on Stable Matchings (EN sibling)
+  ====================================================================
+
+  English mirror of `StableMarriage/Lattice.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `StableMarriage_en` (le FR canonique reste `StableMarriage`).
+  Pas une traduction destructive : le fichier source EN historique est préservé ici
+  verbatim depuis `aaaf0c52ae` (post-merge #5321 GSState i18n) ; seule la ligne
+  `namespace` diffère pour éviter la collision de declaration.
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+namespace StableMarriage_en
+
+open Function Finset Classical
+open StableMarriage
+
+variable {n : Nat} [NeZero n] (prof : PrefProfile n)
+
+/-! ## Partial Order on Stable Matchings via Man-Preference -/
+
+/--
+Man-preference ordering on matchings: μ ≤ ν iff every man prefers
+his partner in μ at least as much as in ν (i.e., menPref m (μ m) ≤ menPref m (ν m)).
+Lower rank = more preferred, so μ ≤ ν means μ is man-preferred over ν.
+-/
+def ManLE (μ ν : Matching n) : Prop :=
+  ∀ m : Fin n, prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m)
+
+namespace ManLE
+
+variable {prof} {μ ν σ : Matching n}
+
+@[refl] lemma refl : ManLE prof μ μ := fun m => Nat.le_refl _
+
+@[trans] lemma trans (h1 : ManLE prof μ ν) (h2 : ManLE prof ν σ) :
+    ManLE prof μ σ := fun m => Nat.le_trans (h1 m) (h2 m)
+
+lemma antisymm (h1 : ManLE prof μ ν) (h2 : ManLE prof ν μ) :
+    μ = ν := by
+  have hsp : μ.spouse = ν.spouse := by
+    funext m
+    have hle : (prof.menPref m (μ.spouse m) : Nat) ≤ prof.menPref m (ν.spouse m) := h1 m
+    have hge : (prof.menPref m (ν.spouse m) : Nat) ≤ prof.menPref m (μ.spouse m) := h2 m
+    have heq : (prof.menPref m (μ.spouse m) : Nat) = prof.menPref m (ν.spouse m) :=
+      Nat.le_antisymm hle hge
+    have hfeq : prof.menPref m (μ.spouse m) = prof.menPref m (ν.spouse m) := Fin.ext heq
+    exact (prof.menPref_bijective m).injective hfeq
+  have hsp_eq : μ.spouse = ν.spouse := hsp
+  cases μ; cases ν
+  congr 1
+
+end ManLE
+
+/-! ## Inverse Helpers (needed for join/meet bijectivity) -/
+
+/--
+Key fact: μ.inverse w is the unique m such that μ.spouse m = w.
+-/
+lemma inverse_eq_of_spouse_eq (μ : Matching n) (m w : Fin n)
+    (h : μ.spouse m = w) : μ.inverse w = m := by
+  unfold Matching.inverse
+  have := Equiv.ofBijective_symm_apply_apply μ.spouse μ.bijective m
+  rw [h] at this
+  exact this
+
+/--
+Key fact: μ.spouse (μ.inverse w) = w.
+-/
+lemma spouse_inverse (μ : Matching n) (w : Fin n) :
+    μ.spouse (μ.inverse w) = w := by
+  unfold Matching.inverse
+  exact Equiv.ofBijective_apply_symm_apply μ.spouse μ.bijective w
+
+/-! ## Anti-crossing Lemma (Knuth decomposition) -/
+
+/--
+A sound anti-crossing fragment: if the shared woman `w` is chosen by both men
+against their partners in the other stable matching, then the two men coincide.
+This is the cross-case needed for injectivity of `joinSpouse`.
+-/
+lemma no_cross_if_both_choose_cross (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν)
+    {m₁ m₂ w : Fin n}
+    (h1 : μ.spouse m₁ = w) (h2 : ν.spouse m₂ = w)
+    (hm₁ : prof.ManPrefers m₁ w (ν.spouse m₁))
+    (hm₂ : prof.ManPrefers m₂ w (μ.spouse m₂)) :
+    m₁ = m₂ := by
+  by_contra hne
+  have hμinv_w : μ.inverse w = m₁ := inverse_eq_of_spouse_eq μ m₁ _ h1
+  have hνinv_w : ν.inverse w = m₂ := inverse_eq_of_spouse_eq ν m₂ _ h2
+  have hnot₁ : ¬prof.WomanPrefers w m₁ m₂ := by
+    intro hw
+    have hbp : IsBlockingPair prof ν m₁ w := by
+      unfold IsBlockingPair
+      rw [hνinv_w]
+      exact ⟨hm₁, hw⟩
+    exact hν m₁ w hbp
+  have hnot₂ : ¬prof.WomanPrefers w m₂ m₁ := by
+    intro hw
+    have hbp : IsBlockingPair prof μ m₂ w := by
+      unfold IsBlockingPair
+      rw [hμinv_w]
+      exact ⟨hm₂, hw⟩
+    exact hμ m₂ w hbp
+  unfold PrefProfile.WomanPrefers at hnot₁ hnot₂
+  simp only [not_lt] at hnot₁ hnot₂
+  have heq : (prof.womenPref w m₁ : Nat) = prof.womenPref w m₂ :=
+    Nat.le_antisymm (mod_cast hnot₂) (mod_cast hnot₁)
+  exact hne ((prof.womenPref_bijective w).injective (Fin.ext heq))
+
+/-! ## Refutation of the anti-crossing conjecture (`no_cross_match`)
+
+Earlier versions of this file stated the following "anti-crossing lemma",
+attributed to Knuth's decomposition argument, and left its Cases A2/B as
+`sorry` after many unsuccessful proof attempts:
+
+  `no_cross_match : IsStable prof μ → IsStable prof ν →`
+  `    μ.spouse m₁ = w → ν.spouse m₂ = w → μ.spouse m₂ = ν.spouse m₁`
+
+This statement is FALSE.  It would force the symmetric difference of any two
+stable matchings to decompose into 2-cycles (swaps), but rotations of length
+≥ 3 between stable matchings exist.  The kernel-checked counterexample below
+(`NoCrossCounterexample.no_cross_match_is_false`) uses the classic 3×3
+latin-square instance (Knuth 1976): the identity matching and its cyclic
+shift are both stable, yet the claimed cross-partner equality fails.  This
+explains why all proof attempts on the `sorry` branches stalled: the goals
+were unprovable.
+
+Knuth's lattice theorem does not need any anti-crossing statement: the
+weaker facts proved in this file (`no_cross_if_both_choose_cross`,
+`joinSpouse_injective`, and the counting argument in `meetSpouse_eq_of_eq`)
+suffice to show that join and meet of two stable matchings are matchings.
+
+The statements `man_optimality_key_step` and `doctor_optimal_eq_top` that
+previously closed this file were false for the same reason (they implied
+that all stable matchings are pairwise ManLE-comparable in both directions,
+hence equal); they are refuted at the end of this file and replaced by the
+honest theorem `exists_isManOptimal`.
+-/
+
+/--
+Stability from a fully computable check: it suffices to verify, for every
+man `m`, woman `w` and candidate husband `m'` with `μ.spouse m' = w`, that
+`(m, w)` is not a blocking pair.  This formulation avoids the noncomputable
+`Matching.inverse`, so on concrete instances the hypothesis can be
+discharged by `decide`.
+-/
+lemma isStable_of_check (μ : Matching n)
+    (h : ∀ m w m' : Fin n, μ.spouse m' = w →
+      ¬(prof.menPref m w < prof.menPref m (μ.spouse m) ∧
+        prof.womenPref w m < prof.womenPref w m')) :
+    IsStable prof μ := by
+  intro m w hbp
+  obtain ⟨h1, h2⟩ := hbp
+  exact h m w (μ.inverse w) (spouse_inverse μ w) ⟨h1, h2⟩
+
+namespace NoCrossCounterexample
+
+/-- Men's rankings of the 3×3 latin-square instance (Knuth 1976).
+`menPref3 m w` is the rank man `m` assigns to woman `w` (lower = preferred):
+m₁ : w₁ > w₂ > w₃, m₂ : w₂ > w₃ > w₁, m₃ : w₃ > w₁ > w₂. -/
+def menPref3 : Fin 3 → Fin 3 → Fin 3 := ![![0, 1, 2], ![2, 0, 1], ![1, 2, 0]]
+
+/-- Women's rankings, cyclically shifted against the men's:
+w₁ : m₂ > m₃ > m₁, w₂ : m₃ > m₁ > m₂, w₃ : m₁ > m₂ > m₃. -/
+def womenPref3 : Fin 3 → Fin 3 → Fin 3 := ![![2, 0, 1], ![1, 2, 0], ![0, 1, 2]]
+
+/-- The 3×3 latin-square preference profile. -/
+def prof3 : PrefProfile 3 where
+  menPref := menPref3
+  womenPref := womenPref3
+  menPref_bijective := by decide
+  womenPref_bijective := by decide
+
+/-- The identity matching mᵢ ↦ wᵢ. -/
+def M0 : Matching 3 where
+  spouse := id
+  bijective := Function.bijective_id
+
+/-- The cyclic-shift matching mᵢ ↦ wᵢ₊₁. -/
+def M1 : Matching 3 where
+  spouse := ![1, 2, 0]
+  bijective := by decide
+
+lemma M0_stable : IsStable prof3 M0 :=
+  isStable_of_check prof3 M0 (by decide)
+
+lemma M1_stable : IsStable prof3 M1 :=
+  isStable_of_check prof3 M1 (by decide)
+
+/--
+**Refutation** of the former `no_cross_match` lemma (its full universally
+quantified statement).  Instantiation: μ = M0 (identity), ν = M1 (shift),
+w = w₁, m₁ = m₁ (married to w₁ in M0), m₂ = m₃ (married to w₁ in M1).
+The conclusion would force `M0.spouse m₃ = M1.spouse m₁`, i.e. w₃ = w₂.
+-/
+theorem no_cross_match_is_false :
+    ¬ ∀ (n : Nat) [NeZero n] (prof : PrefProfile n) (μ ν : Matching n),
+        IsStable prof μ → IsStable prof ν →
+        ∀ m₁ m₂ w : Fin n, μ.spouse m₁ = w → ν.spouse m₂ = w →
+          μ.spouse m₂ = ν.spouse m₁ := by
+  intro h
+  have hcontra := h 3 prof3 M0 M1 M0_stable M1_stable 0 2 0 (by decide) (by decide)
+  exact absurd hcontra (by decide)
+
+end NoCrossCounterexample
+
+/-! ## Join and Meet Operations -/
+
+-- The join spouse function: each man gets his preferred partner between μ and ν.
+-- Defined as a bare function so that bijectivity can be proved separately with
+-- stability hypotheses. The join is NOT bijective for arbitrary matchings;
+-- it requires both μ and ν to be stable (anti-complementarity).
+-- (EN sibling: definition imported from FR canonical `StableMarriage.Lattice`
+-- via `import StableMarriage.Lattice`. Redefining it here would shadow the
+-- FR canonical and break `simp`/`unfold` resolution across namespaces.)
+
+-- The meet spouse function: each man gets his less-preferred partner between μ and ν.
+-- (EN sibling: imported from FR canonical, see joinSpouse note above.)
+
+/--
+Injectivity of join: if joinSpouse μ ν m₁ = joinSpouse μ ν m₂, then m₁ = m₂.
+Key insight: the cross-cases (one man picks μ-spouse, other picks ν-spouse,
+both equal same woman w) lead to a blocking-pair contradiction via stability.
+The easy cases (both men pick same matching) follow from that matching's injectivity.
+-/
+private lemma joinSpouse_injective (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    Injective (fun m => μ.joinSpouse prof ν m) := by
+  intro m₁ m₂ heq
+  by_cases c₁ : prof.menPref m₁ (μ.spouse m₁) ≤ prof.menPref m₁ (ν.spouse m₁)
+  · simp only [Matching.joinSpouse, c₁, if_true] at heq
+    by_cases c₂ : prof.menPref m₂ (μ.spouse m₂) ≤ prof.menPref m₂ (ν.spouse m₂)
+    · simp only [Matching.joinSpouse, c₂, if_true] at heq
+      exact μ.bijective.1 heq
+    · simp only [Matching.joinSpouse, c₂, if_false] at heq
+      -- Cross-case: μ.spouse m₁ = ν.spouse m₂ = w, m₁ picks μ, m₂ picks ν
+      have hm₂pref : prof.ManPrefers m₂ (ν.spouse m₂) (μ.spouse m₂) := by
+        unfold PrefProfile.ManPrefers
+        have : ¬(prof.menPref m₂ (μ.spouse m₂) ≤ prof.menPref m₂ (ν.spouse m₂)) := c₂
+        have hle : (prof.menPref m₂ (μ.spouse m₂) : Nat) ≤ prof.menPref m₂ (ν.spouse m₂) → False := by
+          intro hle; exact this (mod_cast hle)
+        exact mod_cast Nat.lt_of_not_le hle
+      by_contra hne
+      -- ν stability applied to (m₁, ν.spouse m₂):
+      -- need ManPrefers m₁ (ν.spouse m₂) (ν.spouse m₁)
+      by_cases hm₁str : prof.ManPrefers m₁ (μ.spouse m₁) (ν.spouse m₁)
+      · -- Case: m₁ strictly prefers μ.spouse m₁ to ν.spouse m₁
+        -- ν stability: ¬IsBlockingPair ν m₁ (ν.spouse m₂)
+        have hmp : prof.ManPrefers m₁ (ν.spouse m₂) (ν.spouse m₁) := by
+          rw [← heq]; exact hm₁str
+        have hm₂inv : ν.inverse (ν.spouse m₂) = m₂ := inverse_eq_of_spouse_eq ν m₂ _ rfl
+        have hwp' : ¬prof.WomanPrefers (ν.spouse m₂) m₁ m₂ := by
+          intro hw'
+          exact hν m₁ (ν.spouse m₂) ⟨hmp, by rwa [hm₂inv]⟩
+        -- μ stability: ¬IsBlockingPair μ m₂ (ν.spouse m₂)
+        have hm₁inv : μ.inverse (μ.spouse m₁) = m₁ := inverse_eq_of_spouse_eq μ m₁ _ rfl
+        have hwp₂ : ¬prof.WomanPrefers (ν.spouse m₂) m₂ m₁ := by
+          intro hw'
+          have hw'' : prof.WomanPrefers (ν.spouse m₂) m₂ (μ.inverse (ν.spouse m₂)) := by
+            have h1 : μ.inverse (ν.spouse m₂) = m₁ := by
+              rw [← heq]; exact hm₁inv
+            rw [h1]; exact hw'
+          exact hμ m₂ (ν.spouse m₂) ⟨hm₂pref, hw''⟩
+        -- Both ¬WomanPrefers gives womenPref equality, contradicting injectivity
+        unfold PrefProfile.WomanPrefers at hwp' hwp₂
+        simp only [not_lt] at hwp' hwp₂
+        have heq' : (prof.womenPref (ν.spouse m₂) m₂ : Nat) = prof.womenPref (ν.spouse m₂) m₁ :=
+          Nat.le_antisymm (mod_cast hwp') (mod_cast hwp₂)
+        exact hne ((prof.womenPref_bijective (ν.spouse m₂)).injective (Fin.ext heq'.symm))
+      · -- Case: m₁ does NOT strictly prefer μ.spouse m₁ to ν.spouse m₁
+        -- c₁ + ¬hm₁str gives menPref m₁ (μ.spouse m₁) = menPref m₁ (ν.spouse m₁)
+        -- By injectivity: μ.spouse m₁ = ν.spouse m₁
+        -- But ν.spouse is injective and ν.spouse m₁ ≠ ν.spouse m₂ = μ.spouse m₁
+        unfold PrefProfile.ManPrefers at hm₁str
+        simp only [not_lt] at hm₁str
+        have heq' : (prof.menPref m₁ (μ.spouse m₁) : Nat) = prof.menPref m₁ (ν.spouse m₁) :=
+          Nat.le_antisymm (mod_cast c₁) (mod_cast hm₁str)
+        have hsp_eq : μ.spouse m₁ = ν.spouse m₁ :=
+          (prof.menPref_bijective m₁).injective (Fin.ext heq')
+        -- ν.spouse m₁ = μ.spouse m₁ = ν.spouse m₂ (by heq), contradicting injectivity
+        rw [heq] at hsp_eq
+        exact hne (ν.bijective.1 hsp_eq.symm)
+  · simp only [Matching.joinSpouse, c₁, if_false] at heq
+    by_cases c₂ : prof.menPref m₂ (μ.spouse m₂) ≤ prof.menPref m₂ (ν.spouse m₂)
+    · simp only [Matching.joinSpouse, c₂, if_true] at heq
+      -- Cross-case: ν.spouse m₁ = μ.spouse m₂, m₁ picks ν, m₂ picks μ
+      -- heq : ν.spouse m₁ = μ.spouse m₂
+      have hm₁pref : prof.ManPrefers m₁ (ν.spouse m₁) (μ.spouse m₁) := by
+        unfold PrefProfile.ManPrefers
+        have hle : (prof.menPref m₁ (μ.spouse m₁) : Nat) ≤ prof.menPref m₁ (ν.spouse m₁) → False := by
+          intro hle; exact c₁ (mod_cast hle)
+        exact mod_cast Nat.lt_of_not_le hle
+      by_contra hne
+      by_cases hm₂str : prof.ManPrefers m₂ (μ.spouse m₂) (ν.spouse m₂)
+      · -- m₂ strictly prefers μ.spouse m₂ to ν.spouse m₂
+        -- Key: w = ν.spouse m₁ = μ.spouse m₂ (by heq)
+        -- ν stability on (m₂, w): ManPrefers m₂ w (ν.spouse m₂) holds (via heq + hm₂str)
+        --   → ¬WomanPrefers w m₂ (ν⁻¹(w)) = ¬WomanPrefers w m₂ m₁
+        have hm₁νinv : ν.inverse (ν.spouse m₁) = m₁ := inverse_eq_of_spouse_eq ν m₁ _ rfl
+        have hwp₂ : ¬prof.WomanPrefers (ν.spouse m₁) m₂ m₁ := by
+          intro hw'
+          have hman : prof.ManPrefers m₂ (ν.spouse m₁) (ν.spouse m₂) := by rw [heq]; exact hm₂str
+          exact hν m₂ (ν.spouse m₁) ⟨hman, by rw [hm₁νinv]; exact hw'⟩
+        -- μ stability on (m₁, w): ManPrefers m₁ w (μ.spouse m₁) holds (via heq + hm₁pref)
+        --   → ¬WomanPrefers w m₁ (μ⁻¹(w)) = ¬WomanPrefers w m₁ m₂
+        have hm₂μinv : μ.inverse (μ.spouse m₂) = m₂ := inverse_eq_of_spouse_eq μ m₂ _ rfl
+        have hwp₁ : ¬prof.WomanPrefers (ν.spouse m₁) m₁ m₂ := by
+          intro hw'
+          have hman : prof.ManPrefers m₁ (ν.spouse m₁) (μ.spouse m₁) := hm₁pref
+          have hinv_eq : μ.inverse (ν.spouse m₁) = m₂ := by rw [heq, hm₂μinv]
+          have hw'' : prof.WomanPrefers (ν.spouse m₁) m₁ (μ.inverse (ν.spouse m₁)) := by
+            rw [hinv_eq]; exact hw'
+          exact hμ m₁ (ν.spouse m₁) ⟨hman, hw''⟩
+        -- Combine: both directions give womenPref equality → injectivity → m₁ = m₂
+        unfold PrefProfile.WomanPrefers at hwp₁ hwp₂
+        simp only [not_lt] at hwp₁ hwp₂
+        have heq' : (prof.womenPref (ν.spouse m₁) m₂ : Nat) = prof.womenPref (ν.spouse m₁) m₁ :=
+          Nat.le_antisymm (mod_cast hwp₁) (mod_cast hwp₂)
+        exact hne ((prof.womenPref_bijective (ν.spouse m₁)).injective (Fin.ext heq'.symm))
+      · -- m₂ does NOT strictly prefer μ.spouse m₂ to ν.spouse m₂
+        -- c₂ + ¬hm₂str gives menPref equality → μ.spouse m₂ = ν.spouse m₂
+        -- Combined with heq: ν.spouse m₁ = ν.spouse m₂ → m₁ = m₂
+        unfold PrefProfile.ManPrefers at hm₂str
+        simp only [not_lt] at hm₂str
+        have heq' : (prof.menPref m₂ (μ.spouse m₂) : Nat) = prof.menPref m₂ (ν.spouse m₂) :=
+          Nat.le_antisymm (mod_cast c₂) (mod_cast hm₂str)
+        have hsp_eq : μ.spouse m₂ = ν.spouse m₂ :=
+          (prof.menPref_bijective m₂).injective (Fin.ext heq')
+        rw [← heq] at hsp_eq
+        exact hne (ν.bijective.1 hsp_eq)
+    · simp only [Matching.joinSpouse, c₂, if_false] at heq
+      exact ν.bijective.1 heq
+
+-- The join of two STABLE matchings: each man gets his preferred partner.
+-- Bijectivity follows from anti-complementarity: on the woman side, the join
+-- acts as the meet, so no two men map to the same woman.
+-- (EN sibling: definition imported from FR canonical, see joinSpouse note.)
+
+/--
+Each man's join/meet pair is exactly his pair of partners in `{μ, ν}`:
+either the join picks his μ-partner and the meet his ν-partner, or the
+other way around.  Purely definitional if-split; no stability needed.
+-/
+private lemma joinSpouse_meetSpouse_cases (μ ν : Matching n) (m : Fin n) :
+    (μ.joinSpouse prof ν m = μ.spouse m ∧ μ.meetSpouse prof ν m = ν.spouse m) ∨
+    (μ.joinSpouse prof ν m = ν.spouse m ∧ μ.meetSpouse prof ν m = μ.spouse m) := by
+  by_cases hc : prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m)
+  · exact Or.inl ⟨by simp [Matching.joinSpouse, hc], by simp [Matching.meetSpouse, hc]⟩
+  · exact Or.inr ⟨by simp [Matching.joinSpouse, hc], by simp [Matching.meetSpouse, hc]⟩
+
+/--
+Core of meet-injectivity, by counting — no anti-crossing lemma needed
+(the anti-crossing statement is in fact false, see
+`NoCrossCounterexample.no_cross_match_is_false`).
+
+If two men m₁, m₂ both have meet-partner `w`, then each of them is
+`μ.inverse w` or `ν.inverse w` (a man's meet-partner is one of his own
+partners).  The join is surjective (`joinSpouse_injective` + finiteness),
+so some m₀ has join-partner `w`, and m₀ also lies in
+`{μ.inverse w, ν.inverse w}`.  In the mixed case (m₁, m₂ occupying the two
+distinct slots), m₀ coincides with one of them; but a man whose join- AND
+meet-partner are both `w` has both his μ- and ν-partner equal to `w`,
+which collapses both inverses onto him — and then m₁ and m₂ both equal him.
+-/
+private lemma meetSpouse_eq_of_eq (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) (w m₁ m₂ : Fin n)
+    (h₁ : μ.meetSpouse prof ν m₁ = w) (h₂ : μ.meetSpouse prof ν m₂ = w) :
+    m₁ = m₂ := by
+  -- any man who meets to w is μ.inverse w or ν.inverse w
+  have hmeet_mem : ∀ m : Fin n, μ.meetSpouse prof ν m = w →
+      m = μ.inverse w ∨ m = ν.inverse w := by
+    intro m hm
+    rcases joinSpouse_meetSpouse_cases prof μ ν m with ⟨_, hmm⟩ | ⟨_, hmm⟩
+    · exact Or.inr (inverse_eq_of_spouse_eq ν m w (hmm.symm.trans hm)).symm
+    · exact Or.inl (inverse_eq_of_spouse_eq μ m w (hmm.symm.trans hm)).symm
+  -- the join is surjective, so some m₀ has join-partner w
+  have hbij : Function.Bijective (fun m => μ.joinSpouse prof ν m) :=
+    Finite.injective_iff_bijective.mp (joinSpouse_injective prof μ ν hμ hν)
+  obtain ⟨m₀, hm₀⟩ := hbij.2 w
+  have hm₀' : μ.joinSpouse prof ν m₀ = w := hm₀
+  have hm₀_mem : m₀ = μ.inverse w ∨ m₀ = ν.inverse w := by
+    rcases joinSpouse_meetSpouse_cases prof μ ν m₀ with ⟨hjj, _⟩ | ⟨hjj, _⟩
+    · exact Or.inl (inverse_eq_of_spouse_eq μ m₀ w (hjj.symm.trans hm₀')).symm
+    · exact Or.inr (inverse_eq_of_spouse_eq ν m₀ w (hjj.symm.trans hm₀')).symm
+  -- a man who both joins and meets to w pins down BOTH inverses
+  have hboth : ∀ m : Fin n, μ.joinSpouse prof ν m = w → μ.meetSpouse prof ν m = w →
+      μ.inverse w = m ∧ ν.inverse w = m := by
+    intro m hj hm
+    rcases joinSpouse_meetSpouse_cases prof μ ν m with ⟨hjj, hmm⟩ | ⟨hjj, hmm⟩
+    · exact ⟨inverse_eq_of_spouse_eq μ m w (hjj.symm.trans hj),
+             inverse_eq_of_spouse_eq ν m w (hmm.symm.trans hm)⟩
+    · exact ⟨inverse_eq_of_spouse_eq μ m w (hmm.symm.trans hm),
+             inverse_eq_of_spouse_eq ν m w (hjj.symm.trans hj)⟩
+  -- mixed-slot case: the join witness collapses the two inverses
+  have key : ∀ ma mb : Fin n, ma = μ.inverse w → mb = ν.inverse w →
+      μ.meetSpouse prof ν ma = w → μ.meetSpouse prof ν mb = w → ma = mb := by
+    intro ma mb ea eb hma hmb
+    rcases hm₀_mem with e₀ | e₀
+    · -- m₀ = μ.inverse w = ma, so ma joins AND meets to w
+      have hja : μ.joinSpouse prof ν ma = w := by rw [ea, ← e₀]; exact hm₀'
+      obtain ⟨_, hbν⟩ := hboth ma hja hma
+      rw [eb, hbν]
+    · -- m₀ = ν.inverse w = mb, so mb joins AND meets to w
+      have hjb : μ.joinSpouse prof ν mb = w := by rw [eb, ← e₀]; exact hm₀'
+      obtain ⟨hbμ, _⟩ := hboth mb hjb hmb
+      rw [ea, hbμ]
+  rcases hmeet_mem m₁ h₁ with e₁ | e₁ <;> rcases hmeet_mem m₂ h₂ with e₂ | e₂
+  · exact e₁.trans e₂.symm
+  · exact key m₁ m₂ e₁ e₂ h₁ h₂
+  · exact (key m₂ m₁ e₂ e₁ h₂ h₁).symm
+  · exact e₁.trans e₂.symm
+
+/--
+Injectivity of meet, via the counting argument in `meetSpouse_eq_of_eq`.
+-/
+private lemma meetSpouse_injective (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    Injective (fun m => μ.meetSpouse prof ν m) := by
+  intro m₁ m₂ heq
+  exact meetSpouse_eq_of_eq prof μ ν hμ hν (μ.meetSpouse prof ν m₂) m₁ m₂ heq rfl
+
+-- The meet of two STABLE matchings: each man gets his less-preferred partner.
+-- (EN sibling: imported from FR canonical, see joinSpouse note.)
+
+/-! ## Stability of Join and Meet (Wu-Roth Lemma 3.2, one-to-one case) -/
+
+open PrefProfile
+
+/--
+Helper: if m prefers w to his join-spouse, then m prefers w to both
+his partner in μ and his partner in ν.
+The join picks the lower-ranked (more preferred) of the two partners.
+Uses joinSpouse (no stability needed).
+-/
+lemma join_pref_both (μ ν : Matching n) (m w : Fin n)
+    (h : prof.ManPrefers m w (μ.joinSpouse prof ν m)) :
+    prof.ManPrefers m w (μ.spouse m) ∧ prof.ManPrefers m w (ν.spouse m) := by
+  unfold ManPrefers at h ⊢
+  simp only [Matching.joinSpouse] at h
+  split_ifs at h
+  · -- menPref m (μ.spouse m) ≤ menPref m (ν.spouse m), h : menPref m w < menPref m (μ.spouse m)
+    refine ⟨h, ?_⟩
+    have : (prof.menPref m w : Nat) < prof.menPref m (μ.spouse m) := mod_cast h
+    have : (prof.menPref m (μ.spouse m) : Nat) ≤ prof.menPref m (ν.spouse m) := mod_cast ‹_›
+    exact mod_cast Nat.lt_of_lt_of_le ‹_› ‹_›
+  · -- ¬(menPref m (μ.spouse m) ≤ menPref m (ν.spouse m)), h : menPref m w < menPref m (ν.spouse m)
+    refine ⟨?_, h⟩
+    have hνμ : (prof.menPref m (ν.spouse m) : Nat) < prof.menPref m (μ.spouse m) := by
+      have : ¬ (prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m)) := ‹_›
+      have : (prof.menPref m (μ.spouse m) : Nat) ≤ prof.menPref m (ν.spouse m) → False := by
+        intro hle; exact this (mod_cast hle : prof.menPref m (μ.spouse m) ≤ prof.menPref m (ν.spouse m))
+      omega
+    have : (prof.menPref m w : Nat) < prof.menPref m (ν.spouse m) := mod_cast h
+    exact mod_cast Nat.lt_trans ‹_› hνμ
+
+/--
+Helper: if m prefers w to his meet-spouse, then m prefers w to at least one
+of his partners in μ or ν (the less-preferred one).
+Uses meetSpouse (no stability needed).
+-/
+lemma meet_pref_one (μ ν : Matching n) (m w : Fin n)
+    (h : prof.ManPrefers m w (μ.meetSpouse prof ν m)) :
+    prof.ManPrefers m w (μ.spouse m) ∨ prof.ManPrefers m w (ν.spouse m) := by
+  unfold ManPrefers at h ⊢
+  simp only [Matching.meetSpouse] at h
+  split_ifs at h
+  · -- meet picked ν.spouse m: h : menPref m w < menPref m (ν.spouse m)
+    right; exact h
+  · -- meet picked μ.spouse m: h : menPref m w < menPref m (μ.spouse m)
+    left; exact h
+
+/--
+Anti-complementarity of the join:
+(μ ⊔ ν).inverse w equals either μ⁻¹(w) or ν⁻¹(w).
+
+Proof: let m = (μ ⊔ ν).inverse w. The join gives m his preferred partner,
+which equals w. So either μ.spouse m = w (making m = μ⁻¹(w))
+or ν.spouse m = w (making m = ν⁻¹(w)).
+-/
+lemma join_inverse_anti (μ ν : Matching n) (hμ : IsStable prof μ) (hν : IsStable prof ν)
+    (w : Fin n) :
+    (μ.join prof hμ hν).inverse w = μ.inverse w ∨
+    (μ.join prof hμ hν).inverse w = ν.inverse w := by
+  have hspw : (μ.join prof hμ hν).spouse ((μ.join prof hμ hν).inverse w) = w :=
+    spouse_inverse (μ.join prof hμ hν) w
+  simp only [Matching.join, Matching.joinSpouse] at hspw
+  split_ifs at hspw
+  · left; exact (inverse_eq_of_spouse_eq μ _ w hspw).symm
+  · right; exact (inverse_eq_of_spouse_eq ν _ w hspw).symm
+
+/--
+Anti-complementarity of the meet (woman side):
+If meet.inverse w = μ⁻¹(w), then w prefers μ⁻¹(w) to ν⁻¹(w).
+The meet on the man side acts as the join on the woman side: w gets her
+more-preferred man. If meet picked μ⁻¹(w), then ν⁻¹(w) must be less preferred.
+Requires stability of μ and ν.
+-/
+lemma meet_inverse_anti_pref (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) (w : Fin n)
+    (h : (μ.meet prof hμ hν).inverse w = μ.inverse w) :
+    prof.womenPref w (μ.inverse w) ≤ prof.womenPref w (ν.inverse w) := by
+  have hmsp : μ.spouse (μ.inverse w) = w := spouse_inverse μ w
+  have hmMeet : (μ.meet prof hμ hν).spouse (μ.inverse w) = w := by
+    rw [← h, spouse_inverse]
+  simp only [Matching.meet, Matching.meetSpouse] at hmMeet
+  by_cases hle : prof.menPref (μ.inverse w) (μ.spouse (μ.inverse w)) ≤
+      prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w))
+  · -- meetSpouse = ν.spouse, so ν.spouse (μ⁻¹w) = w = μ.spouse (μ⁻¹w)
+    simp only [hle, if_true] at hmMeet
+    have hνinv : ν.inverse w = μ.inverse w :=
+      inverse_eq_of_spouse_eq ν _ _ hmMeet
+    rw [hνinv]
+  · -- μ⁻¹w strictly prefers ν.spouse(μ⁻¹w) over μ.spouse(μ⁻¹w) = w
+    push Not at hle
+    -- Need: womenPref w (μ⁻¹w) ≤ womenPref w (ν⁻¹w)
+    -- By contraposition: if womenPref w (ν⁻¹w) < womenPref w (μ⁻¹w),
+    -- then w prefers ν⁻¹w over μ⁻¹w.
+    -- Combined with man μ⁻¹w preferring ν.spouse(μ⁻¹w) over w,
+    -- if ν.spouse(μ⁻¹w) = w then ν⁻¹(w) = μ⁻¹w, contradicted by injectivity of menPref.
+    by_cases hw : ν.spouse (μ.inverse w) = w
+    · -- ν also matches μ⁻¹w to w, so ν⁻¹w = μ⁻¹w
+      have hνinv_eq : ν.inverse w = μ.inverse w :=
+        inverse_eq_of_spouse_eq ν _ _ hw
+      rw [hνinv_eq]
+    · -- ν.spouse(μ⁻¹w) ≠ w
+      set m' := ν.inverse w with hm'def
+      have hνm' : ν.spouse m' = w := spouse_inverse ν w
+      by_cases hle' : prof.menPref m' (μ.spouse m') ≤ prof.menPref m' (ν.spouse m')
+      · -- meet picks ν.spouse m' = w for man m'
+        -- meet.spouse m' = ν.spouse m' = w, so meet.inverse w = m' = ν⁻¹w
+        have hmeetm' : (μ.meet prof hμ hν).spouse m' = ν.spouse m' := by
+          show (μ.meet prof hμ hν).spouse m' = ν.spouse m'
+          simp only [Matching.meet, Matching.meetSpouse, hle', if_true]
+        have hmeetm'w : (μ.meet prof hμ hν).spouse m' = w := hmeetm' ▸ hνm'
+        have hinv' : (μ.meet prof hμ hν).inverse w = m' :=
+          inverse_eq_of_spouse_eq (μ.meet prof hμ hν) m' w hmeetm'w
+        -- But h says meet.inverse w = μ⁻¹w, so m' = μ⁻¹w
+        have hm'eq : m' = μ.inverse w := hinv' ▸ h
+        -- Then ν.spouse(μ⁻¹w) = ν.spouse m' = w, contradicting hw
+        have : ν.spouse (μ.inverse w) = w := hm'eq ▸ hνm'
+        exact absurd this hw
+      · -- meet picks μ.spouse m' for man m'
+        -- menPref m' (ν.spouse m') < menPref m' (μ.spouse m'), i.e. m' prefers w over μ.sp m'
+        have hm'pref : prof.ManPrefers m' w (μ.spouse m') := by
+          unfold ManPrefers
+          have hνsp : prof.menPref m' (ν.spouse m') = prof.menPref m' w := by rw [hνm']
+          have := hle'
+          simp only [not_le] at this
+          rw [hνsp] at this
+          exact mod_cast this
+        -- Use stability of μ: ¬IsBlockingPair μ m' w
+        -- ManPrefers m' w (μ.spouse m') holds, so woman side must fail
+        have hblock : ¬IsBlockingPair prof μ m' w := hμ m' w
+        have : ¬prof.WomanPrefers w m' (μ.inverse w) := by
+          intro hw'
+          exact hblock ⟨hm'pref, hw'⟩
+        unfold WomanPrefers at this
+        simp only [not_lt] at this
+        exact this
+
+/--
+Anti-complementarity of the meet (woman side, ν branch):
+If meet.inverse w = ν⁻¹(w), then w prefers ν⁻¹(w) to μ⁻¹(w).
+Requires stability of μ and ν.
+-/
+lemma meet_inverse_anti_pref' (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) (w : Fin n)
+    (h : (μ.meet prof hμ hν).inverse w = ν.inverse w) :
+    prof.womenPref w (ν.inverse w) ≤ prof.womenPref w (μ.inverse w) := by
+  have hνsp : ν.spouse (ν.inverse w) = w := spouse_inverse ν w
+  have hmMeet : (μ.meet prof hμ hν).spouse (ν.inverse w) = w := by
+    rw [← h, spouse_inverse]
+  simp only [Matching.meet, Matching.meetSpouse] at hmMeet
+  by_cases hle : prof.menPref (ν.inverse w) (μ.spouse (ν.inverse w)) ≤
+      prof.menPref (ν.inverse w) (ν.spouse (ν.inverse w))
+  · -- meet picks ν.spouse(ν⁻¹w) = w
+    simp only [hle, if_true] at hmMeet
+    by_cases hw : μ.spouse (ν.inverse w) = w
+    · rw [inverse_eq_of_spouse_eq μ _ _ hw]
+    · -- μ⁻¹w ≠ ν⁻¹w, and ν⁻¹w weakly prefers μ.sp(ν⁻¹w) to w.
+      -- Use the μ-stability on (ν⁻¹w, w): ν⁻¹w is matched to μ.sp(ν⁻¹w) ≠ w in μ.
+      -- hle says ν⁻¹w prefers μ.sp(ν⁻¹w) to w, i.e., man prefers w less.
+      -- So man side of blocking pair (ν⁻¹w, w) in μ FAILS (man doesn't prefer w).
+      -- This doesn't give us the womenPref inequality.
+      -- Instead use the anti-complementarity of the proved meet_inverse_anti_pref lemma:
+      -- meet chose ν⁻¹w for w, and by anti_pref, womenPref w (μ⁻¹w) ≤ womenPref w (ν⁻¹w).
+      -- We need the opposite: womenPref w (ν⁻¹w) ≤ womenPref w (μ⁻¹w).
+      -- This requires the ' version which is what we're trying to prove!
+      -- Fall back to: ν-stability on (μ⁻¹w, w) if man prefers w.
+      have hmμ : μ.spouse (μ.inverse w) = w := spouse_inverse μ w
+      by_cases hνpref : prof.menPref (μ.inverse w) w <
+          prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w))
+      · -- μ⁻¹w prefers w to ν.sp(μ⁻¹w): (μ⁻¹w, w) would block ν
+        -- unless w doesn't prefer μ⁻¹w to ν⁻¹w
+        have hblock : ¬IsBlockingPair prof ν (μ.inverse w) w := hν (μ.inverse w) w
+        have hm'pref : prof.ManPrefers (μ.inverse w) w (ν.spouse (μ.inverse w)) := by
+          unfold ManPrefers; exact mod_cast hνpref
+        have : ¬prof.WomanPrefers w (μ.inverse w) (ν.inverse w) := by
+          intro hw'; exact hblock ⟨hm'pref, hw'⟩
+        unfold WomanPrefers at this
+        simp only [not_lt] at this
+        exact this
+      · -- ¬hνpref: menPref(μ⁻¹w)(ν.sp(μ⁻¹w)) ≤ menPref(μ⁻¹w)(w) = menPref(μ⁻¹w)(μ.sp(μ⁻¹w))
+        -- Either meet picks μ.sp(μ⁻¹w)=w, or equality forces ν.sp(μ⁻¹w)=w by injectivity.
+        -- In both cases meet⁻¹w = μ⁻¹w, and combined with h, μ⁻¹w = ν⁻¹w.
+        have hnle : ¬prof.menPref (μ.inverse w) (μ.spouse (μ.inverse w)) ≤
+            prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w)) := by
+          intro hle'
+          simp only [not_lt] at hνpref
+          rw [hmμ] at hle'
+          have hnat₁ : (prof.menPref (μ.inverse w) w : Nat) ≤
+              prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w)) := mod_cast hle'
+          have hnat₂ : (prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w)) : Nat) ≤
+              prof.menPref (μ.inverse w) w := mod_cast hνpref
+          have hnat_eq : prof.menPref (μ.inverse w) w =
+              prof.menPref (μ.inverse w) (ν.spouse (μ.inverse w)) :=
+            Fin.ext (Nat.le_antisymm hnat₁ hnat₂)
+          have hνspμ : ν.spouse (μ.inverse w) = w :=
+            (prof.menPref_bijective (μ.inverse w)).injective hnat_eq.symm
+          have hνeq : ν.inverse w = μ.inverse w :=
+            (inverse_eq_of_spouse_eq ν _ _ hνspμ).trans
+              (inverse_eq_of_spouse_eq μ _ _ hmμ).symm
+          rw [hνeq] at hw
+          exact hw hmμ
+        have hmMeet' : (μ.meet prof hμ hν).spouse (μ.inverse w) =
+            μ.spouse (μ.inverse w) := by
+          simp only [Matching.meet, Matching.meetSpouse, hnle, if_false]
+        have hmMeetw : (μ.meet prof hμ hν).spouse (μ.inverse w) = w := by
+          rw [hmMeet', hmμ]
+        have hinvEq : (μ.meet prof hμ hν).inverse w = μ.inverse w :=
+          inverse_eq_of_spouse_eq (μ.meet prof hμ hν) _ _ hmMeetw
+        rw [← h, hinvEq]
+  · -- meet picks μ.spouse(ν⁻¹w), so μ.spouse(ν⁻¹w) = w, hence μ⁻¹w = ν⁻¹w
+    push Not at hle
+    split_ifs at hmMeet with hle'
+    · -- pos branch contradicts ¬hle: hle' says a≤b but hle says b<a
+      exfalso; omega
+    · -- neg branch: μ.spouse(ν⁻¹w) = w, so μ⁻¹w = ν⁻¹w
+      rw [inverse_eq_of_spouse_eq μ _ _ hmMeet]
+
+/--
+Anti-complementarity of the meet: (μ ⊓ ν).inverse w equals either μ⁻¹(w) or ν⁻¹(w).
+Same argument as join_inverse_anti: the meet spouse of (meet.inverse w) equals w,
+and the meet picks one of the two partners.
+-/
+lemma meet_inverse_anti (μ ν : Matching n) (hμ : IsStable prof μ) (hν : IsStable prof ν)
+    (w : Fin n) :
+    (μ.meet prof hμ hν).inverse w = μ.inverse w ∨
+    (μ.meet prof hμ hν).inverse w = ν.inverse w := by
+  have hspw : (μ.meet prof hμ hν).spouse ((μ.meet prof hμ hν).inverse w) = w :=
+    spouse_inverse (μ.meet prof hμ hν) w
+  simp only [Matching.meet, Matching.meetSpouse] at hspw
+  split_ifs at hspw
+  · right; exact (inverse_eq_of_spouse_eq ν _ w hspw).symm
+  · left; exact (inverse_eq_of_spouse_eq μ _ w hspw).symm
+
+/--
+Wu-Roth Lemma 3.2 (one-to-one specialization):
+The join of two stable matchings is stable.
+
+Proof: suppose (m, w) blocks μ ⊔ ν.
+Man side: m prefers w to join-partner ⟹ m prefers w to both μ(m) and ν(m).
+Woman side: (μ ⊔ ν).inverse w is either μ⁻¹(w) or ν⁻¹(w).
+  Case μ⁻¹(w): w prefers m to μ⁻¹(w), so (m,w) blocks μ. Contradiction.
+  Case ν⁻¹(w): w prefers m to ν⁻¹(w), so (m,w) blocks ν. Contradiction.
+-/
+theorem join_isStable (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    IsStable prof (μ.join prof hμ hν) := by
+  intro m w hblock
+  obtain ⟨hmpref, hwpref⟩ := hblock
+  simp only [Matching.join, Matching.joinSpouse] at hmpref
+  have hboth := join_pref_both prof μ ν m w hmpref
+  rcases join_inverse_anti prof μ ν hμ hν w with hinvμ | hinvν
+  · rw [hinvμ] at hwpref
+    exact hμ m w ⟨hboth.1, hwpref⟩
+  · rw [hinvν] at hwpref
+    exact hν m w ⟨hboth.2, hwpref⟩
+
+/--
+The meet of two stable matchings is stable.
+
+Proof: suppose (m, w) blocks μ ⊓ ν.
+Man side: m prefers w to meet-partner ⟹ m prefers w to at least one of μ(m) or ν(m).
+Woman side: (μ ⊓ ν).inverse w is either μ⁻¹(w) or ν⁻¹(w).
+  Combined, at least one of the cases gives a blocking pair for μ or ν.
+-/
+theorem meet_isStable (μ ν : Matching n)
+    (hμ : IsStable prof μ) (hν : IsStable prof ν) :
+    IsStable prof (μ.meet prof hμ hν) := by
+  intro m w hblock
+  obtain ⟨hmpref, hwpref⟩ := hblock
+  simp only [Matching.meet, Matching.meetSpouse] at hmpref
+  have hone := meet_pref_one prof μ ν m w hmpref
+  rcases meet_inverse_anti prof μ ν hμ hν w with hinvμ | hinvν
+  · -- (μ ⊓ ν).inverse w = μ.inverse w, so w prefers m to μ⁻¹(w)
+    rw [hinvμ] at hwpref
+    rcases hone with hmμ | hmν
+    · -- m prefers w to μ(m) AND w prefers m to μ⁻¹(w) → blocks μ
+      exact hμ m w ⟨hmμ, hwpref⟩
+    · -- m prefers w to ν(m), w prefers m to μ⁻¹(w)
+      -- Anti-complementarity: meet.inverse w = μ⁻¹(w) ⟹ w prefers μ⁻¹(w) to ν⁻¹(w)
+      -- Transitively: w prefers m to ν⁻¹(w). Combined with hmν, (m,w) blocks ν.
+      have hwν := meet_inverse_anti_pref prof μ ν hμ hν w hinvμ
+      have h1 : (prof.womenPref w m : Nat) < prof.womenPref w (μ.inverse w) := mod_cast hwpref
+      have h2 : (prof.womenPref w (μ.inverse w) : Nat) ≤ prof.womenPref w (ν.inverse w) := mod_cast hwν
+      have hwν' : prof.WomanPrefers w m (ν.inverse w) := mod_cast Nat.lt_of_lt_of_le h1 h2
+      exact hν m w ⟨hmν, hwν'⟩
+  · -- (μ ⊓ ν).inverse w = ν.inverse w, so w prefers m to ν⁻¹(w)
+    rw [hinvν] at hwpref
+    rcases hone with hmμ | hmν
+    · -- m prefers w to μ(m), w prefers m to ν⁻¹(w)
+      -- Anti-complementarity: meet.inverse w = ν⁻¹(w) ⟹ w prefers ν⁻¹(w) to μ⁻¹(w)
+      -- Transitively: w prefers m to μ⁻¹(w). Combined with hmμ, (m,w) blocks μ.
+      have hwμ := meet_inverse_anti_pref' prof μ ν hμ hν w hinvν
+      have h1 : (prof.womenPref w m : Nat) < prof.womenPref w (ν.inverse w) := mod_cast hwpref
+      have h2 : (prof.womenPref w (ν.inverse w) : Nat) ≤ prof.womenPref w (μ.inverse w) := mod_cast hwμ
+      have hwμ' : prof.WomanPrefers w m (μ.inverse w) := mod_cast Nat.lt_of_lt_of_le h1 h2
+      exact hμ m w ⟨hmμ, hwμ'⟩
+    · -- m prefers w to ν(m) AND w prefers m to ν⁻¹(w) → blocks ν
+      exact hν m w ⟨hmν, hwpref⟩
+
+/-! ## Lattice Instance -/
+
+-- TODO: Instance requires proving all lattice axioms on the subtype.
+-- This needs join_isStable + meet_isStable fully proved first.
+-- Will instantiate after proofs are complete.
+
+/-! ## Man-Optimality (honest version)
+
+The two statements that previously closed this file —
+
+  `man_optimality_key_step : menPref m' (ν.spouse m') < menPref m' (μ.spouse m') → False`
+  `doctor_optimal_eq_top   : IsStable prof μ_gs → IsStable prof μ' → ManLE prof μ_gs μ'`
+
+— were FALSE as stated (their `sorry`s were unprovable): neither statement
+mentioned the Gale-Shapley algorithm, so together they claimed that ANY two
+stable matchings are ManLE-comparable in both directions, i.e. that the
+stable matching is unique.  The 3×3 latin-square instance refutes both
+(`NoCrossCounterexample.man_optimality_key_step_is_false`,
+`NoCrossCounterexample.doctor_optimal_eq_top_is_false`).
+
+The honest replacement is the EXISTENCE of a man-optimal stable matching,
+`exists_isManOptimal`, proved by a minimal-weight argument on the join
+semilattice (`join_isStable`).  `gale_shapley_man_optimal` in
+GaleShapley.lean consumes it, seeded by `gale_shapley_stable`.
+-/
+
+namespace NoCrossCounterexample
+
+/--
+**Refutation** of the former `man_optimality_key_step` lemma: m₁ strictly
+prefers his M0-partner w₁ (rank 0) to his M1-partner w₂ (rank 1), and both
+matchings are stable, so no `False` can follow.
+-/
+theorem man_optimality_key_step_is_false :
+    ¬ ∀ (n : Nat) [NeZero n] (prof : PrefProfile n) (μ ν : Matching n),
+        IsStable prof μ → IsStable prof ν →
+        ∀ m' : Fin n,
+          prof.menPref m' (ν.spouse m') < prof.menPref m' (μ.spouse m') → False := by
+  intro h
+  exact h 3 prof3 M1 M0 M1_stable M0_stable 0 (by decide)
+
+/--
+**Refutation** of the former `doctor_optimal_eq_top` theorem: with
+μ_gs := M1 and μ' := M0 (both stable), ManLE would require
+`menPref m₁ w₂ ≤ menPref m₁ w₁`, i.e. `1 ≤ 0`.
+-/
+theorem doctor_optimal_eq_top_is_false :
+    ¬ ∀ (n : Nat) [NeZero n] (prof : PrefProfile n) (μ_gs : Matching n),
+        IsStable prof μ_gs →
+        ∀ μ' : Matching n, IsStable prof μ' → ManLE prof μ_gs μ' := by
+  intro h
+  have hle := h 3 prof3 M1 M1_stable M0 M0_stable
+  have h0 := hle 0
+  exact absurd h0 (by decide)
+
+end NoCrossCounterexample
+
+/--
+A man-optimal stable matching exists as soon as a stable matching exists.
+
+Minimal-weight argument: let `W μ = Σ_m rank_m (μ.spouse m)` and pick (via
+`Nat.find`) a stable matching `μ₀` whose weight is minimal among stable
+matchings.  If some stable `ν` gave some man `m` a strictly better partner,
+the join `μ₀ ⊔ ν` would be stable (`join_isStable`), pointwise weakly
+man-better than `μ₀` (the join hands each man his preferred partner of the
+two) and strictly better for `m`, hence of strictly smaller weight —
+contradicting minimality.  So `μ₀` is man-optimal.
+
+The hypothesis is discharged by `gale_shapley_stable` in GaleShapley.lean
+(kept as a hypothesis here to avoid an import cycle).
+-/
+theorem exists_isManOptimal (hex : ∃ μ : Matching n, IsStable prof μ) :
+    ∃ μ : Matching n, IsManOptimal prof μ := by
+  classical
+  let W : Matching n → Nat := fun μ => ∑ m : Fin n, (prof.menPref m (μ.spouse m) : Nat)
+  let P : Nat → Prop := fun k => ∃ μ : Matching n, IsStable prof μ ∧ W μ = k
+  have hP : ∃ k, P k := by
+    obtain ⟨μ, hμ⟩ := hex
+    exact ⟨W μ, μ, hμ, rfl⟩
+  obtain ⟨μ₀, hμ₀, hW₀⟩ := Nat.find_spec hP
+  refine ⟨μ₀, hμ₀, ?_⟩
+  intro ν hν m
+  by_contra hgt
+  push Not at hgt
+  -- hgt : m strictly prefers his ν-partner; consider the join μ₀ ⊔ ν
+  have hle : ∀ m' : Fin n,
+      (prof.menPref m' ((μ₀.join prof hμ₀ hν).spouse m') : Nat) ≤
+        (prof.menPref m' (μ₀.spouse m') : Nat) := by
+    intro m'
+    show (prof.menPref m' (μ₀.joinSpouse prof ν m') : Nat) ≤ _
+    unfold Matching.joinSpouse
+    split_ifs with hc
+    · exact le_refl _
+    · have hnle : ¬((prof.menPref m' (μ₀.spouse m') : Nat) ≤
+          (prof.menPref m' (ν.spouse m') : Nat)) := fun hh => hc (mod_cast hh)
+      omega
+  have hlt : (prof.menPref m ((μ₀.join prof hμ₀ hν).spouse m) : Nat) <
+      (prof.menPref m (μ₀.spouse m) : Nat) := by
+    show (prof.menPref m (μ₀.joinSpouse prof ν m) : Nat) < _
+    unfold Matching.joinSpouse
+    split_ifs with hc
+    · exfalso
+      have h1 : (prof.menPref m (μ₀.spouse m) : Nat) ≤
+          (prof.menPref m (ν.spouse m) : Nat) := mod_cast hc
+      have h2 : (prof.menPref m (ν.spouse m) : Nat) <
+          (prof.menPref m (μ₀.spouse m) : Nat) := mod_cast hgt
+      omega
+    · exact mod_cast hgt
+  have hWlt : W (μ₀.join prof hμ₀ hν) < W μ₀ :=
+    Finset.sum_lt_sum (fun i _ => hle i) ⟨m, Finset.mem_univ m, hlt⟩
+  have hPlt : P (W (μ₀.join prof hμ₀ hν)) :=
+    ⟨μ₀.join prof hμ₀ hν, join_isStable prof μ₀ ν hμ₀ hν, rfl⟩
+  exact Nat.find_min hP (lt_of_lt_of_le hWlt (le_of_eq hW₀)) hPlt
+
+
+end StableMarriage_en

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lemmas.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lemmas.lean
@@ -1,0 +1,898 @@
+/-
+  Mariage stable — Lemmes clés pour la correction de l'algorithme de Gale-Shapley
+  ============================================================================
+
+  Invariants préservés par chaque étape de l'algorithme GS :
+  - Cohérence du couplage (chaque paire appariée est mutuelle)
+  - Monotonie des propositions (l'ensemble des propositions ne fait que croître)
+  - Les hommes proposent toujours par ordre décroissant de préférence (à des femmes moins préférées)
+  - Invariants de terminaison (borne sur le nombre de propositions)
+
+  Convention i18n (cf #4980) : en-têtes, sections, docstrings et commentaires
+  intra-preuve en français ; noms de symboles Lean, énoncés de lemmes et
+  tactiques préservés en anglais (compatibilité Mathlib).
+
+  Adapté de : https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+  Simplifié pour des préférences totales bijectives (pas de filtre `acceptable`).
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Tactic.Common
+import StableMarriage.Definitions
+import StableMarriage.GSState
+
+namespace StableMarriage
+
+open Function Finset Classical
+
+variable {n : Nat} [NeZero n]
+
+/-! ## Couplage partiel cohérent -/
+
+/-- Un couplage partiel est cohérent : chaque appariement est mutuel.
+    Si l'homme `m` est apparié à la femme `w`, alors la femme `w` est appariée
+    à l'homme `m`, et réciproquement. -/
+def GSConsistent (μ : GSMatching n) : Prop :=
+  ∀ m w, μ.menMatch m = some w ↔ μ.womenMatch w = some m
+
+namespace GSConsistent
+
+variable {μ : GSMatching n}
+
+lemma men_iff_women (h : GSConsistent μ) (m : Fin n) (w : Fin n) :
+    μ.menMatch m = some w ↔ μ.womenMatch w = some m := h m w
+
+lemma women_iff_men (h : GSConsistent μ) (w : Fin n) (m : Fin n) :
+    μ.womenMatch w = some m ↔ μ.menMatch m = some w := (h m w).symm
+
+/-- Le couplage initial est cohérent (tous les appariements valent `none`). -/
+lemma initial : GSConsistent (GSMatching.initial (n := n)) := by
+  intro m w
+  simp [GSMatching.initial]
+
+/-- Apparier un homme libre et une femme libre préserve la cohérence. -/
+lemma matchFree (h : GSConsistent μ) (m : Fin n) (w : Fin n)
+    (hm : μ.menMatch m = none) (hw : μ.womenMatch w = none) :
+    GSConsistent (μ.matchFree m w) := by
+  intro m' w'
+  simp only [GSMatching.matchFree, Function.update_apply]
+  split_ifs
+  · simp_all
+  · have : μ.womenMatch w' ≠ some m := by
+      intro heq; have := (h m w').mpr heq; simp_all
+    simp_all [ne_comm]
+  · have : μ.menMatch m' ≠ some w := by
+      intro heq; have := (h m' w).mp heq; simp_all
+    simp_all [ne_comm]
+  · exact h m' w'
+
+end GSConsistent
+
+/-! ## Suivi de l'ensemble des propositions -/
+
+/-- L'ensemble des paires proposées, vu comme une `Finset`. -/
+noncomputable def proposedSet (prof : PrefProfile n) (σ : GSState prof) :
+    Finset (Fin n × Fin n) :=
+  Finset.univ.filter (fun mw => σ.proposed mw.1 mw.2)
+
+/-- Nombre de paires proposées. -/
+noncomputable def proposedCount (prof : PrefProfile n) (σ : GSState prof) : Nat :=
+  (proposedSet prof σ).card
+
+namespace proposedSet
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+lemma mem_iff (mw : Fin n × Fin n) :
+    mw ∈ proposedSet prof σ ↔ σ.proposed mw.1 mw.2 := by
+  simp [proposedSet]
+
+/-- `gsStepWith` insère exactement une nouvelle paire dans l'ensemble des propositions. -/
+lemma stepWith_insert (σ : GSState prof) (m w : Fin n) :
+    proposedSet prof (gsStepWith prof σ m w) =
+      insert (m, w) (proposedSet prof σ) := by
+  classical
+  ext ⟨m', w'⟩
+  simp only [mem_iff, mem_insert, Prod.mk.injEq]
+  unfold gsStepWith
+  split
+  · simp; tauto
+  · split <;> simp <;> tauto
+
+end proposedSet
+
+namespace proposedCount
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- L'état initial comporte zéro proposition. -/
+lemma initial : proposedCount prof (gsInitial prof) = 0 := by
+  classical
+  simp [proposedCount, proposedSet, gsInitial]
+
+/-- `StepWith` augmente le compteur de un pour toute nouvelle proposition. -/
+lemma stepWith (σ : GSState prof) (m w : Fin n) (hnew : ¬ σ.proposed m w) :
+    proposedCount prof (gsStepWith prof σ m w) = proposedCount prof σ + 1 := by
+  classical
+  have hmem : (m, w) ∉ proposedSet prof σ := by
+    simp [proposedSet]
+    exact hnew
+  simp only [proposedCount, proposedSet.stepWith_insert]
+  exact card_insert_of_notMem hmem
+
+end proposedCount
+
+/-! ## Invariant — les hommes proposent par ordre décroissant -/
+
+/-- Dans l'algorithme de Gale-Shapley, les hommes proposent par ordre décroissant
+    de préférence. Après `k` étapes, toutes les propositions de l'homme `m` vont à
+    ses `k` candidates les plus préférées. Comme les préférences sont des bijections
+    totales, chaque femme est une candidate valide. -/
+def menProposedDownward (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ m w w', σ.proposed m w → prof.menPref m w' < prof.menPref m w →
+    σ.proposed m w'
+
+/-! ## Invariant — meilleure correspondance pour chaque femme -/
+
+/-- Le partenaire actuel de chaque femme est la meilleure proposition qu'elle ait reçue. -/
+def womenBestState (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ w m m', σ.matching.womenMatch w = some m → σ.proposed m' w →
+    prof.womenPref w m ≤ prof.womenPref w m'
+
+namespace womenBestState
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- L'état initial satisfait trivialement `womenBest` (aucun appariement). -/
+lemma initial : womenBestState prof (gsInitial prof) := by
+  unfold womenBestState
+  intro w m m' hmatch _
+  unfold gsInitial GSMatching.initial at hmatch
+  simp at hmatch
+
+end womenBestState
+
+/-! ## Invariant — tout homme apparié a proposé -/
+
+/-- Tout homme apparié a bien proposé à sa partenaire actuelle. -/
+def menMatchedProposed (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ m w, σ.matching.menMatch m = some w → σ.proposed m w
+
+namespace menMatchedProposed
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- L'état initial satisfait trivialement cet invariant (aucun appariement). -/
+lemma initial : menMatchedProposed prof (gsInitial prof) := by
+  unfold menMatchedProposed
+  intro m w hmatch
+  unfold gsInitial at hmatch
+  unfold GSMatching.initial at hmatch
+  simp at hmatch
+
+end menMatchedProposed
+
+/-! ## Préservation de la cohérence par les étapes GS -/
+
+namespace GSConsistent
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- `swapMatch` préserve la cohérence lorsque la femme `w` préfère `m` à `mOld`.
+    Le schéma suit la preuve de `matchFree` : `split_ifs` + `have` pour les enchaînements
+    de cohérence. -/
+lemma swapMatch (h : GSConsistent σ.matching) (m mOld w : Fin n)
+    (hm : σ.matching.menMatch m = none)
+    (hw : σ.matching.womenMatch w = some mOld)
+    (hmOld : σ.matching.menMatch mOld = some w) :
+    GSConsistent (σ.matching.swapMatch m mOld w) := by
+  have hne : m ≠ mOld := by intro heq; subst heq; simp_all
+  intro m' w'
+  simp only [GSMatching.swapMatch, Function.update_apply]
+  -- `if` extérieur : `m' = mOld` (depuis la mise à jour extérieure)
+  -- puis `if` intérieur : `m' = m` (depuis la mise à jour intérieure)
+  -- `if` côté droit : `w' = w`
+  split_ifs with h_mOld h_ww h_m h_nw h_nm
+  · -- `m' = mOld`, `w' = w` : les deux côtés sont `False` par `hne`
+    simp_all
+  · -- `m' = mOld`, `w' ≠ w` : on a besoin de `μ.womenMatch w' ≠ some mOld`
+    have : σ.matching.womenMatch w' ≠ some mOld := by
+      intro heq; have := (h mOld w').mpr heq; simp_all
+    simp_all
+  · -- `m' ≠ mOld`, `m' = m`, `w' = w` : les deux côtés sont `True`
+    simp_all
+  · -- `m' ≠ mOld`, `m' = m`, `w' ≠ w` : on a besoin de `μ.womenMatch w' ≠ some m`
+    have hnw' : w ≠ w' := ne_comm.mp ‹¬w' = w›
+    have : σ.matching.womenMatch w' ≠ some m := by
+      intro heq; have := (h m w').mpr heq; simp_all
+    simp_all
+  · -- `m' ≠ mOld`, `m' ≠ m`, `w' = w` : on a besoin de `μ.menMatch m' ≠ some w`
+    have hnm' : m ≠ m' := ne_comm.mp ‹¬m' = m›
+    have : σ.matching.menMatch m' ≠ some w := by
+      intro heq; have := (h m' w).mp heq; simp_all
+    simp_all
+  · -- `m' ≠ mOld`, `m' ≠ m`, `w' ≠ w` : cohérence directe
+    exact h m' w'
+
+/-- `gsStepWith` préserve la cohérence du couplage. -/
+lemma stepWith (h : GSConsistent σ.matching) (m w : Fin n)
+    (hm : σ.matching.menMatch m = none)
+    (_hproposed : ¬ σ.proposed m w) :
+    GSConsistent (gsStepWith prof σ m w).matching := by
+  unfold gsStepWith
+  split
+  · -- `womenMatch w = none` : cas `matchFree`
+    exact matchFree h m w hm ‹_›
+  · -- `womenMatch w = some mOld`
+    split
+    · -- La femme préfère `m` à `mOld` : cas `swapMatch`
+      next mOld hwm hwlt =>
+        have hmOld : σ.matching.menMatch mOld = some w := (h mOld w).mpr hwm
+        exact swapMatch prof h m mOld w hm hwm hmOld
+    · -- La femme ne préfère PAS `m` : couplage inchangé
+      exact h
+
+/-- `gsStep` préserve la cohérence du couplage. -/
+lemma step (h : GSConsistent σ.matching) (hfree : ∃ m, gsIsFree prof σ m) :
+    GSConsistent (gsStep prof σ).matching := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  have hw : ¬ σ.proposed m w := by
+    have := gsChooseMax_mem prof σ m hm.2
+    simp [gsCandidates] at this
+    exact this
+  exact stepWith prof h m w hm.1 hw
+
+/-- `gsRunSteps` préserve la cohérence du couplage. -/
+lemma runSteps (k : Nat) :
+    GSConsistent (gsRunSteps prof k).matching := by
+  induction k with
+  | zero => exact initial
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end GSConsistent
+
+/-! ## Terminaison : borne sur le nombre de propositions -/
+
+namespace proposedCount
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- Une étape pour un homme libre augmente le compteur de propositions. -/
+lemma step_of_free (σ : GSState prof) (m : Fin n)
+    (hf : gsIsFree prof σ m) :
+    proposedCount prof (gsStep prof σ) = proposedCount prof σ + 1 := by
+  unfold gsStep
+  rw [dif_pos ⟨m, hf⟩]
+  let m' := Classical.choose ⟨m, hf⟩
+  have hm' : gsIsFree prof σ m' := Classical.choose_spec ⟨m, hf⟩
+  let w := gsChooseMax prof σ m' hm'.2
+  have hw : ¬ σ.proposed m' w := by
+    have := gsChooseMax_mem prof σ m' hm'.2
+    simp [gsCandidates] at this
+    exact this
+  exact stepWith prof σ m' w hw
+
+/-- Le nombre de propositions ne dépasse jamais `n²` pour aucun état. -/
+lemma le_bound (σ : GSState prof) :
+    proposedCount prof σ ≤ gsProposalBound n := by
+  classical
+  unfold proposedCount proposedSet gsProposalBound
+  calc (Finset.univ.filter fun mw => σ.proposed mw.1 mw.2).card
+      ≤ (Finset.univ : Finset (Fin n × Fin n)).card :=
+        Finset.card_le_card (Finset.filter_subset _ _)
+    _ = n * n := by
+        simp only [Finset.card_univ, Fintype.card_prod, Fintype.card_fin]
+
+/-- À l'étape `k`, le nombre de propositions ne dépasse jamais la borne. -/
+lemma runSteps_le_bound (k : Nat) :
+    proposedCount prof (gsRunSteps prof k) ≤ gsProposalBound n :=
+  le_bound prof _
+
+/-- S'il existe un homme libre, une étape supplémentaire maintient le compteur sous la borne. -/
+lemma step_preserves_le_bound {_σ : GSState prof}
+    (_h : proposedCount prof _σ ≤ gsProposalBound n) :
+    proposedCount prof (gsStep prof _σ) ≤ gsProposalBound n :=
+    le_bound prof _
+
+/-- Si l'algorithme ne s'est pas terminé après `k` étapes, le compteur vaut `k`. -/
+lemma runSteps_eq_of_not_terminated (k : Nat)
+    (hterm : ¬ gsTerminated prof (gsRunSteps prof k)) :
+    proposedCount prof (gsRunSteps prof k) = k := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    have hnk : ¬ gsTerminated prof (gsRunSteps prof k') := by
+      intro hk_term
+      unfold gsTerminated at hk_term hterm
+      simp only [gsRunSteps] at hterm
+      unfold gsStep at hterm
+      rw [dif_neg hk_term] at hterm
+      exact hterm hk_term
+    have ihk := ih hnk
+    have hf : ∃ m, gsIsFree prof (gsRunSteps prof k') m := not_not.mp hnk
+    rw [step_of_free prof (gsRunSteps prof k') (Classical.choose hf)
+        (Classical.choose_spec hf), ihk]
+
+end proposedCount
+
+/-! ## Identité de l'étape lorsque l'algorithme a terminé -/
+
+/-- Si l'état courant est terminal, `gsStep` est l'identité. -/
+lemma gsStep_eq_of_terminated (prof : PrefProfile n) (σ : GSState prof)
+    (h : gsTerminated prof σ) :
+    gsStep prof σ = σ := by
+  unfold gsStep gsTerminated at *
+  split
+  · contradiction
+  · rfl
+
+/-- Si l'algorithme a terminé à l'étape `k`, toutes les étapes suivantes sont l'identité. -/
+lemma gsRunSteps_eq_of_terminated (prof : PrefProfile n) (k j : Nat) (hkj : k ≤ j)
+    (h : gsTerminated prof (gsRunSteps prof k)) :
+    gsRunSteps prof j = gsRunSteps prof k := by
+  induction j generalizing k with
+  | zero =>
+    have : k = 0 := Nat.eq_zero_of_le_zero hkj
+    subst this; rfl
+  | succ j' ih =>
+    simp only [gsRunSteps]
+    cases eq_or_lt_of_le hkj with
+    | inl heq => subst heq; rfl
+    | inr hlt =>
+      rw [ih k (Nat.le_of_lt_succ hlt) h]
+      exact gsStep_eq_of_terminated prof _ h
+
+/-! ## Invariant — les hommes proposent par ordre décroissant (préservation par étape) -/
+
+namespace menProposedDownward
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- `gsStep` préserve l'invariant `menProposedDownward`. -/
+lemma step (h : menProposedDownward prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    menProposedDownward prof (gsStep prof σ) := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m₀ := Classical.choose hfree
+  have hm₀ : gsIsFree prof σ m₀ := Classical.choose_spec hfree
+  let w₀ := gsChooseMax prof σ m₀ hm₀.2
+  have hw₀ : ¬ σ.proposed m₀ w₀ := by
+    intro h
+    have := gsChooseMax_mem prof σ m₀ hm₀.2
+    simp [gsCandidates] at this
+    exact this h
+  -- Maximalité : `gsChooseMax` renvoie la candidate la plus préférée ; aucune candidate n'est davantage préférée
+  have hmax : ∀ w', w' ∈ gsCandidates prof σ m₀ →
+      gsMenPrefLE prof m₀ w₀ w' → w₀ = w' := by
+    intro w' hw'in hle
+    have hmax' := gsChooseMax_maximal prof σ m₀ hm₀.2 w' hw'in
+    cases hle with
+    | inl h => exact h
+    | inr hlt =>
+      cases hmax' with
+      | inl h => exact h.symm
+      | inr hgt => exact absurd hgt (lt_asymm hlt)
+  intro m w w' hprop hlt
+  have goal_from (hab : σ.proposed m w') :
+      (gsStepWith prof σ m₀ w₀).proposed m w' :=
+    (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m, w')).mp
+      (by rw [proposedSet.stepWith_insert prof σ m₀ w₀]
+          simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff]
+          right; exact hab)
+  have hsrc : σ.proposed m w ∨ (m = m₀ ∧ w = w₀) := by
+    have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m, w)).mpr hprop
+    rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+    simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff] at hmem
+    cases hmem with | inl h => right; exact h | inr h => left; exact h
+  rcases hsrc with (hw | ⟨rfl, rfl⟩)
+  · exact goal_from (h m w w' hw hlt)
+  · have hw' : σ.proposed m₀ w' := by
+      by_contra hn
+      have hw'in : w' ∈ gsCandidates prof σ m₀ := by simp [gsCandidates]; exact hn
+      have : w₀ = w' := hmax w' hw'in (Or.inr hlt)
+      subst this; exact lt_irrefl _ hlt
+    exact goal_from hw'
+
+/-- `gsRunSteps` préserve l'invariant `menProposedDownward`. -/
+lemma runSteps (k : Nat) :
+    menProposedDownward prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    intro m w w' hw hlt
+    unfold gsInitial GSMatching.initial at hw
+    simp at hw
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end menProposedDownward
+
+/-! ## Invariant — tout homme apparié a proposé (préservation par étape) -/
+
+namespace menMatchedProposed
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- `gsStepWith` préserve `menMatchedProposed`. -/
+lemma stepWith (h : menMatchedProposed prof σ) (m w : Fin n) :
+    menMatchedProposed prof (gsStepWith prof σ m w) := by
+  intro m' w' hmatch
+  simp only [gsStepWith] at hmatch ⊢
+  split at *
+  · -- Cas `none` : `matchFree m w`
+    dsimp [GSMatching.matchFree] at hmatch ⊢
+    rw [Function.update_apply] at hmatch
+    split_ifs at hmatch
+    · injection hmatch with hw; right; exact ⟨‹m' = m›, hw.symm⟩
+    · left; exact h m' w' hmatch
+  · -- Cas `some mOld`
+    rename_i mOld
+    split_ifs at *
+    · -- La femme préfère `m` : `swapMatch m mOld w`
+      dsimp [GSMatching.swapMatch] at hmatch ⊢
+      rw [Function.update_apply, Function.update_apply] at hmatch
+      split_ifs at hmatch
+      · injection hmatch with hw; right; exact ⟨‹m' = m›, hw.symm⟩
+      · left; exact h m' w' hmatch
+    · -- Pas de préférence : couplage inchangé
+      dsimp at hmatch ⊢
+      left; exact h m' w' hmatch
+
+/-- `gsStep` préserve `menMatchedProposed`. -/
+lemma step (h : menMatchedProposed prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    menMatchedProposed prof (gsStep prof σ) := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  exact stepWith prof h m w
+
+/-- `gsRunSteps` préserve `menMatchedProposed`. -/
+lemma runSteps (k : Nat) :
+    menMatchedProposed prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end menMatchedProposed
+
+/-! ## Invariant — toute femme proposée est appariée -/
+
+/-- Si un homme a proposé à une femme, alors elle doit être appariée. -/
+def womenProposedImpliesMatched (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ w m, σ.proposed m w → σ.matching.womenMatch w ≠ none
+
+namespace womenProposedImpliesMatched
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+lemma initial : womenProposedImpliesMatched prof (gsInitial prof) := by
+  intro w m hprop; unfold gsInitial at hprop; simp at hprop
+
+lemma stepWith (h : womenProposedImpliesMatched prof σ) (m₀ w₀ : Fin n)
+    (hnew : ¬ σ.proposed m₀ w₀) :
+    womenProposedImpliesMatched prof (gsStepWith prof σ m₀ w₀) := by
+  intro w m' hprop
+  have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m', w)).mpr hprop
+  rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+  simp only [Finset.mem_insert, Prod.mk.injEq] at hmem
+  simp only [gsStepWith]
+  split
+  · dsimp [GSMatching.matchFree]
+    rw [Function.update_apply]
+    by_cases hw : w = w₀
+    · rw [if_pos hw]; simp
+    · rw [if_neg hw]
+      rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+      · exact absurd rfl hw
+      · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+  · split
+    · next mOld hmold hpref =>
+      dsimp [GSMatching.swapMatch]
+      rw [Function.update_apply]
+      by_cases hw : w = w₀
+      · rw [if_pos hw]; simp
+      · rw [if_neg hw]
+        rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+        · exact absurd rfl hw
+        · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+    · next mOld hmold hpref =>
+      rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+      · simp [hmold]
+      · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+
+lemma step (h : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    womenProposedImpliesMatched prof (gsStep prof σ) := by
+  unfold gsStep; rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  have hw : ¬ σ.proposed m w := by
+    have := gsChooseMax_mem prof σ m hm.2; simp [gsCandidates] at this; exact this
+  exact stepWith prof h m w hw
+
+lemma runSteps (k : Nat) :
+    womenProposedImpliesMatched prof (gsRunSteps prof k) := by
+  induction k with
+  | zero => simp only [gsRunSteps]; exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end womenProposedImpliesMatched
+
+/-! ## Invariant — meilleure correspondance pour chaque femme (préservation par étape) -/
+
+/-- Si une femme est libre et que `womenProposedImpliesMatched` est vrai,
+    alors aucun homme ne lui a encore proposé (contraposée). -/
+lemma womenUnproposed (prof : PrefProfile n) (σ : GSState prof)
+    (h : womenBestState prof σ)
+    (hwp : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    ∀ w, σ.matching.womenMatch w = none → ∀ m', ¬σ.proposed m' w := by
+  intro w hw m' hprop
+  exact (hwp w m' hprop) hw
+
+namespace womenBestState
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- `gsStep` préserve `womenBestState`. -/
+lemma step (h : womenBestState prof σ)
+    (hwp : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    womenBestState prof (gsStep prof σ) := by
+  unfold gsStep; rw [dif_pos hfree]
+  set m₀ := Classical.choose hfree
+  have hm₀ : gsIsFree prof σ m₀ := Classical.choose_spec hfree
+  set w₀ := gsChooseMax prof σ m₀ hm₀.2
+  unfold womenBestState
+  intro w m m' hmatch hprop
+  have hsrc : σ.proposed m' w ∨ (m' = m₀ ∧ w = w₀) := by
+    have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m', w)).mpr hprop
+    rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+    simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff] at hmem
+    cases hmem with | inl h => right; exact h | inr h => left; exact h
+  -- Réduire le couplage de `gsStepWith` et découper sur le discriminant
+  change (gsStepWith prof σ m₀ w₀).matching.womenMatch w = some m at hmatch
+  simp only [gsStepWith] at hmatch
+  split at hmatch
+  · -- Cas `none` : `matchFree`
+    dsimp [GSMatching.matchFree] at hmatch
+    rw [Function.update_apply] at hmatch
+    by_cases hw : w = w₀
+    · rw [if_pos hw] at hmatch
+      injection hmatch with hmi; subst hmi
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · exfalso
+        have hn := ‹σ.matching.womenMatch w₀ = none›
+        exact womenUnproposed prof σ h hwp hfree w₀ hn m' (hw ▸ hw')
+      · exact le_rfl
+    · rw [if_neg hw] at hmatch
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · exact h w m m' hmatch hw'
+      · exfalso; exact hw rfl
+  · -- Cas `some mOld`
+    next mOld hmold =>
+    by_cases hpref : prof.womenPref w₀ m₀ < prof.womenPref w₀ mOld
+    · rw [if_pos hpref] at hmatch
+      dsimp [GSMatching.swapMatch] at hmatch
+      rw [Function.update_apply] at hmatch
+      by_cases hw : w = w₀
+      · rw [if_pos hw] at hmatch
+        injection hmatch with hmi; subst hmi
+        rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+        · subst hw
+          have hold := h w₀ mOld m' hmold hw'
+          exact le_trans (le_of_lt hpref) hold
+        · exact le_rfl
+      · rw [if_neg hw] at hmatch
+        rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+        · exact h w m m' hmatch hw'
+        · exfalso; exact hw rfl
+    · rw [if_neg hpref] at hmatch
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · by_cases hw : w = w₀
+        · subst hw; exact h w₀ m m' hmatch hw'
+        · exact h w m m' hmatch hw'
+      · rw [hmatch] at hmold
+        injection hmold with heq; subst heq
+        exact by omega
+
+/-- `gsRunSteps` préserve `womenBestState`. -/
+lemma runSteps (k : Nat) :
+    womenBestState prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih (womenProposedImpliesMatched.runSteps prof k') h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end womenBestState
+
+/-! ## Terminaison : l'algorithme se termine en au plus n^2 étapes -/
+
+lemma gsTerminated_runSteps_bound (prof : PrefProfile n) :
+    gsTerminated prof (gsRunSteps prof (gsProposalBound n)) := by
+  classical
+  by_contra hnot
+  have ⟨m, hm⟩ : ∃ m, gsIsFree prof (gsRunSteps prof (gsProposalBound n)) m := by
+    simpa [gsTerminated] using hnot
+  set σ := gsRunSteps prof (gsProposalBound n)
+  have hmcand : (gsCandidates prof σ m).Nonempty := hm.2
+  set w := gsChooseMax prof σ m hmcand
+  have hw : ¬ σ.proposed m w := by
+    have := gsChooseMax_mem prof σ m hmcand
+    simp [gsCandidates] at this; exact this
+  have hcount : proposedCount prof σ = gsProposalBound n :=
+    proposedCount.runSteps_eq_of_not_terminated prof (gsProposalBound n) hnot
+  have hss : proposedSet prof σ ⊆ (Finset.univ : Finset (Fin n × Fin n)) :=
+    Finset.filter_subset _ _
+  have huniv : (Finset.univ : Finset (Fin n × Fin n)).card = n * n := by
+    simp [Fintype.card_prod, Fintype.card_fin]
+  have hcount_card : (proposedSet prof σ).card = n * n := by
+    unfold proposedCount at hcount; simp [gsProposalBound] at hcount; exact hcount
+  have heq : proposedSet prof σ = Finset.univ :=
+    Finset.eq_of_subset_of_card_le hss (by rw [huniv]; exact hcount_card.ge)
+  exact hw ((proposedSet.mem_iff prof (m, w)).1 (heq ▸ Finset.mem_univ _))
+
+/-- Lorsque GS a terminé, chaque homme est apparié (`menMatch m ≠ none`).
+    Si un homme était libre, `gsCandidates` devrait être vide (sans quoi il serait
+    libre lui aussi), donc il aurait proposé à toutes les femmes. Par
+    `womenProposedImpliesMatched`, toutes les femmes seraient alors appariées via
+    d'autres hommes. Mais cohérence + `n` femmes appariées par `n-1` autres hommes
+    est impossible sur `Fin n`. -/
+lemma gsTerminated_allMenMatched (prof : PrefProfile n) {σ : GSState prof}
+    (hterm : gsTerminated prof σ)
+    (hwp : womenProposedImpliesMatched prof σ)
+    (hcon : GSConsistent σ.matching)
+    (m : Fin n) :
+    σ.matching.menMatch m ≠ none := by
+  intro hnone
+  have hcand_empty : (gsCandidates prof σ m).Nonempty → False := by
+    intro hne; exact hterm ⟨m, ⟨hnone, hne⟩⟩
+  have hpropAll : ∀ w, σ.proposed m w := by
+    intro w
+    by_contra hnot
+    exact hcand_empty ⟨w, by simp [gsCandidates, hnot]⟩
+  have hwMatched : ∀ w, σ.matching.womenMatch w ≠ none :=
+    fun w => hwp w m (hpropAll w)
+  have hex (w : Fin n) : ∃ m', σ.matching.womenMatch w = some m' ∧ σ.matching.menMatch m' = some w := by
+    obtain ⟨m', hm'⟩ := Option.ne_none_iff_exists.mp (hwMatched w)
+    have hwf : σ.matching.womenMatch w = some m' := hm'.symm
+    exact ⟨m', hwf, (hcon m' w).mpr hwf⟩
+  -- Construire une injection `f : Fin n → {m' : Fin n // m' ≠ m}`, puis déduire la contradiction
+  have hSpec (w : Fin n) :
+      σ.matching.womenMatch w = some (Classical.choose (hex w)) ∧
+      σ.matching.menMatch (Classical.choose (hex w)) = some w :=
+    Classical.choose_spec (hex w)
+  have fne (w : Fin n) : Classical.choose (hex w) ≠ m := by
+    intro heq
+    have h := (hSpec w).2
+    rw [heq, hnone] at h
+    cases h
+  let f (w : Fin n) : { m' : Fin n // m' ≠ m } :=
+    ⟨Classical.choose (hex w), fne w⟩
+  have hf : Function.Injective f := by
+    intro w₁ w₂ heq
+    have h1 := (hSpec w₁).2
+    have h2 := (hSpec w₂).2
+    have hval : Classical.choose (hex w₁) = Classical.choose (hex w₂) :=
+      congrArg Subtype.val heq
+    congr 1
+    have := congrArg (σ.matching.menMatch ·) hval
+    simp only [h1, h2, Option.some.injEq] at this
+    exact this
+  -- `|{m' ≠ m}| < |Fin n|` contredit l'injection `Fin n → {m' ≠ m}`
+  have hle := Fintype.card_le_of_injective f hf
+  have hcard_fin : Fintype.card (Fin n) = n := Fintype.card_fin n
+  -- Contradiction : `Fin n` s'injecte dans `{m' ≠ m}` mais `{m' ≠ m} ⊂ Fin n`
+  have hcontra : Fintype.card (Fin n) ≤ Fintype.card { m' : Fin n // m' ≠ m } :=
+    Fintype.card_le_of_injective f hf
+  have hlt : Fintype.card { m' : Fin n // m' ≠ m } < Fintype.card (Fin n) :=
+    @Fintype.card_lt_of_injective_of_notMem _ _ _ _
+      (Subtype.val : {m' : Fin n // m' ≠ m} → Fin n)
+      Subtype.coe_injective m
+      (by simp)
+  omega
+
+/-! ## Conversion du couplage final GS -/
+
+/-- Extraire l'épouse d'un `GSMatching` via `Classical.choose` (évite les problèmes de typage de `Option.get`). -/
+noncomputable def gsSpouse (μ : GSMatching n)
+    (hall : ∀ m, μ.menMatch m ≠ none) (m : Fin n) : Fin n :=
+  Classical.choose (Option.ne_none_iff_exists.mp (hall m))
+
+lemma gsSpouse_spec (μ : GSMatching n)
+    (hall : ∀ m, μ.menMatch m ≠ none) (m : Fin n) :
+    μ.menMatch m = some (gsSpouse μ hall m) :=
+  (Classical.choose_spec (Option.ne_none_iff_exists.mp (hall m))).symm
+
+/-- Toutes les femmes sont appariées dès que tous les hommes sont appariés et que le couplage est cohérent. -/
+lemma gsAllWomenMatched {μ : GSMatching n}
+    (hall : ∀ m, μ.menMatch m ≠ none)
+    (hcon : GSConsistent μ) (w : Fin n) :
+    μ.womenMatch w ≠ none := by
+  by_contra hnone
+  have hNoMan : ∀ m, μ.menMatch m ≠ some w := by
+    intro m hmw; have := hcon m w |>.mp hmw; rw [hnone] at this; simp at this
+  -- Chaque homme est associé à un certain `w' ≠ w`, injectivement → contradiction par pigeonhole
+  have hMap (m : Fin n) : ∃ w', μ.menMatch m = some w' ∧ w' ≠ w := by
+    obtain ⟨w', hw'⟩ := Option.ne_none_iff_exists.mp (hall m)
+    exact ⟨w', hw'.symm, fun heq => hNoMan m (heq ▸ hw'.symm)⟩
+  let f (m : Fin n) : {w' : Fin n // w' ≠ w} :=
+    ⟨Classical.choose (hMap m), (Classical.choose_spec (hMap m)).2⟩
+  have hf : Injective f := by
+    intro m₁ m₂ heq
+    simp only [f, Subtype.mk.injEq] at heq
+    have h₁ := (Classical.choose_spec (hMap m₁)).1
+    have h₂ := (Classical.choose_spec (hMap m₂)).1
+    rw [heq] at h₁
+    -- h₁ : μ.menMatch m₁ = some c  (où `c = Classical.choose (hMap m₂)`)
+    -- h₂ : μ.menMatch m₂ = some c
+    have hw₁ := hcon m₁ (Classical.choose (hMap m₂)) |>.mp h₁
+    have hw₂ := hcon m₂ (Classical.choose (hMap m₂)) |>.mp h₂
+    -- hw₁ : μ.womenMatch c = some m₁
+    -- hw₂ : μ.womenMatch c = some m₂
+    exact Option.some.inj (hw₁.symm.trans hw₂)
+  have hle : Fintype.card (Fin n) ≤ Fintype.card {w' : Fin n // w' ≠ w} :=
+    Fintype.card_le_of_injective f hf
+  have hlt : Fintype.card {w' : Fin n // w' ≠ w} < Fintype.card (Fin n) :=
+    @Fintype.card_lt_of_injective_of_notMem _ _ _ _
+      (Subtype.val : {w' : Fin n // w' ≠ w} → Fin n) Subtype.coe_injective w (by simp)
+  omega
+
+/-- Construire un `Matching` total à partir d'un `GSMatching` terminé. -/
+noncomputable def gsFinalMatching (prof : PrefProfile n)
+    (σ : GSState prof)
+    (hall : ∀ m, σ.matching.menMatch m ≠ none)
+    (hcon : GSConsistent σ.matching) : Matching n where
+  spouse := gsSpouse σ.matching hall
+  bijective := by
+    constructor
+    · -- injectif : `spouse m₁ = spouse m₂` → `m₁ = m₂`
+      intro m₁ m₂ heq
+      have h₁ := gsSpouse_spec σ.matching hall m₁
+      have h₂ := gsSpouse_spec σ.matching hall m₂
+      rw [heq] at h₁
+      -- h₁ : σ.matching.menMatch m₁ = some (gsSpouse σ.matching hall m₂)
+      -- h₂ : σ.matching.menMatch m₂ = some (gsSpouse σ.matching hall m₂)
+      have hw₁ := hcon m₁ (gsSpouse σ.matching hall m₂) |>.mp h₁
+      have hw₂ := hcon m₂ (gsSpouse σ.matching hall m₂) |>.mp h₂
+      -- hw₁ : σ.matching.womenMatch _ = some m₁
+      -- hw₂ : σ.matching.womenMatch _ = some m₂
+      exact Option.some.inj (hw₁.symm.trans hw₂)
+    · -- surjectif : pour chaque `w`, trouver `m` avec `spouse m = w`
+      intro w
+      have hwn := gsAllWomenMatched hall hcon w
+      obtain ⟨m, hm⟩ := Option.ne_none_iff_exists.mp hwn
+      have hmw : σ.matching.menMatch m = some w := (hcon m w).mpr hm.symm
+      exact ⟨m, by
+        have hspec := gsSpouse_spec σ.matching hall m
+        -- hspec : σ.matching.menMatch m = some (gsSpouse σ.matching hall m)
+        rw [hmw] at hspec
+        -- hspec : some w = some (gsSpouse σ.matching hall m)
+        exact Option.some.inj hspec.symm⟩
+
+/-- Lemme clé : `gsFinalMatching.spouse m` extrait directement la valeur de l'`Option`. -/
+lemma gsFinalMatching_spouse_get (prof : PrefProfile n) (σ : GSState prof)
+    (hall : ∀ m, σ.matching.menMatch m ≠ none)
+    (hcon : GSConsistent σ.matching) (m : Fin n) :
+    (gsFinalMatching prof σ hall hcon).spouse m =
+      Classical.choose (Option.ne_none_iff_exists.mp (hall m)) := rfl
+
+/-! ## Absence de paires bloquantes (adapté de `Properties.lean` upstream L48-120) -/
+
+/-- L'état final de GS ne comporte aucune paire bloquante.
+
+    Structure de la preuve (adaptée de `Properties.lean galeShapley_noBlockingPairs` du dépôt mmaaz-git) :
+    1. Supposer une paire bloquante `(m, w)` : `m` préfère `w` à son épouse, `w` préfère `m` à son époux
+    2. Montrer que `m` a proposé à `w` (`menProposedDownward` + `menMatchedProposed`)
+    3. `w` est appariée à `mW` (`womenProposedImpliesMatched`)
+    4. `womenBestState` donne : `womenPref w mW ≤ womenPref w m`
+    5. La condition de blocage donne : `womenPref w m < womenPref w mW`
+    6. Contradiction (`≤` et `<` sont incompatibles)
+
+    Simplification par rapport à l'upstream : pas de branche « `w` est libre » (préférences totales).
+-/
+lemma gsNoBlockingPairs (prof : PrefProfile n)
+    (hterm : gsTerminated prof (gsRunSteps prof (gsProposalBound n)))
+    (hcon : GSConsistent (gsRunSteps prof (gsProposalBound n)).matching)
+    (hwp : womenProposedImpliesMatched prof (gsRunSteps prof (gsProposalBound n)))
+    (hdown : menProposedDownward prof (gsRunSteps prof (gsProposalBound n)))
+    (hmatch_prop : menMatchedProposed prof (gsRunSteps prof (gsProposalBound n)))
+    (hbest : womenBestState prof (gsRunSteps prof (gsProposalBound n)))
+    (m w : Fin n) :
+    ¬ IsBlockingPair prof (gsFinalMatching prof (gsRunSteps prof (gsProposalBound n))
+      (fun m => gsTerminated_allMenMatched prof hterm hwp hcon m) hcon) m w := by
+  intro hblock
+  obtain ⟨hmpref, hwpref⟩ := hblock
+  set σ := gsRunSteps prof (gsProposalBound n)
+  set hall : ∀ m, σ.matching.menMatch m ≠ none :=
+    fun m => gsTerminated_allMenMatched prof hterm hwp hcon m
+  set μ := gsFinalMatching prof σ hall hcon
+  -- Étape 1 : `m` est apparié, extraire sa partenaire `wMatch`
+  have hwMatch' : σ.matching.menMatch m = some (μ.spouse m) :=
+    gsSpouse_spec σ.matching hall m
+  -- Étape 2 : `m` a proposé à sa partenaire (`μ.spouse m`)
+  have hpropMatch : σ.proposed m (μ.spouse m) :=
+    hmatch_prop m (μ.spouse m) hwMatch'
+  -- Étape 3 : `m` a proposé à `w` (clôture décroissante)
+  -- Le blocage dit que `menPref m w < menPref m (μ.spouse m)`, donc `w` est préférée
+  have hpropw : σ.proposed m w :=
+    hdown m (μ.spouse m) w hpropMatch hmpref
+  -- Étape 4 : `w` est appariée (`womenProposedImpliesMatched`)
+  have hwomMatch : σ.matching.womenMatch w ≠ none := hwp w m hpropw
+  obtain ⟨mW, hmW⟩ := Option.ne_none_iff_exists.mp hwomMatch
+  have hmW' : σ.matching.womenMatch w = some mW := hmW.symm
+  -- Étape 5 : `womenBestState` donne `womenPref w mW ≤ womenPref w m`
+  have hbest' : prof.womenPref w mW ≤ prof.womenPref w m :=
+    hbest w mW m hmW' hpropw
+  -- Étape 6 : `μ.inverse w = mW`
+  -- Par cohérence : `menMatch mW = some w`, donc `spouse mW = w`
+  have hmw' : σ.matching.menMatch mW = some w := (hcon mW w).mpr hmW'
+  have hspouse_mW : μ.spouse mW = w := by
+    have h₁ := gsSpouse_spec σ.matching hall mW
+    -- h₁ : `menMatch mW = some (gsSpouse ...)` et `hmw'` : `menMatch mW = some w`
+    exact Option.some.inj (h₁.symm.trans hmw')
+  -- `inverse w = mW` car `spouse mW = w`
+  have hwinv : μ.inverse w = mW := by
+    unfold Matching.inverse
+    rw [← hspouse_mW]
+    exact Equiv.ofBijective_symm_apply_apply (gsSpouse σ.matching hall) _ mW
+  rw [hwinv] at hwpref
+  -- `hwpref` : `womenPref w m < womenPref w mW`
+  -- `hbest'` : `womenPref w mW ≤ womenPref w m`
+  -- Contradiction : `hbest'` dit `womenPref w mW ≤ womenPref w m`
+  -- mais `hwpref` dit `womenPref w m < womenPref w mW`
+  -- c'est-à-dire : `a ≤ b` et `b < a` est impossible
+  have : (prof.womenPref w mW : Nat) ≤ (prof.womenPref w m : Nat) := by
+    exact mod_cast hbest'
+  have : (prof.womenPref w m : Nat) < (prof.womenPref w mW : Nat) := by
+    exact mod_cast hwpref
+  omega
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lemmas_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage/Lemmas_en.lean
@@ -1,0 +1,902 @@
+/-
+  Stable Marriage - Key Lemmas for Gale-Shapley Algorithm Correctness
+  ===================================================================
+
+  English mirror of `StableMarriage/Lemmas.lean` (FR-first canonical).
+  Convention i18n Lean ratifiée par ai-01 (2026-07-04, #4980 comment-4881909354) :
+  fichiers `.lean` distincts FR + EN siblings dans le même lake, les deux compilent.
+  Drift-CI detectable : contenu non-docstring byte-identique entre siblings.
+  Namespace sibling : `StableMarriage_en` (le FR canonique reste `StableMarriage`).
+  Convention observée : imports intra-lake restent sur fichiers FR canoniques.
+  Pas une traduction destructive : manual translation FR-first-from-origin
+  (pas d'historique EN pré-Option A pour ce fichier) ; code tactique Lean
+  byte-identique préservé verbatim, prose traduite. Pattern identique
+  c.238.2/#5362 (RepeatedGames), c.238.3/#5363 (Minimax), c.238.4/#5419 (Shapley).
+
+  Adapté de / Adapted from: https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+
+  See #4980. Part of #4208 (axe E).
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Tactic.Common
+import StableMarriage.Definitions
+import StableMarriage.GSState
+
+namespace StableMarriage_en
+
+
+open Function Finset Classical
+open StableMarriage
+
+variable {n : Nat} [NeZero n]
+
+/-! ## Consistent partial matching -/
+
+/-- Un couplage partiel est cohérent : chaque appariement est mutuel.
+    Si l'homme `m` est apparié à la femme `w`, alors la femme `w` est appariée
+    à l'homme `m`, et réciproquement. -/
+def GSConsistent (μ : GSMatching n) : Prop :=
+  ∀ m w, μ.menMatch m = some w ↔ μ.womenMatch w = some m
+
+namespace GSConsistent
+
+variable {μ : GSMatching n}
+
+lemma men_iff_women (h : GSConsistent μ) (m : Fin n) (w : Fin n) :
+    μ.menMatch m = some w ↔ μ.womenMatch w = some m := h m w
+
+lemma women_iff_men (h : GSConsistent μ) (w : Fin n) (m : Fin n) :
+    μ.womenMatch w = some m ↔ μ.menMatch m = some w := (h m w).symm
+
+/-- The initial matching is consistent (all matches are `none`). -/
+lemma initial : GSConsistent (GSMatching.initial (n := n)) := by
+  intro m w
+  simp [GSMatching.initial]
+
+/-- Matching a free man with a free woman preserves consistency. -/
+lemma matchFree (h : GSConsistent μ) (m : Fin n) (w : Fin n)
+    (hm : μ.menMatch m = none) (hw : μ.womenMatch w = none) :
+    GSConsistent (μ.matchFree m w) := by
+  intro m' w'
+  simp only [GSMatching.matchFree, Function.update_apply]
+  split_ifs
+  · simp_all
+  · have : μ.womenMatch w' ≠ some m := by
+      intro heq; have := (h m w').mpr heq; simp_all
+    simp_all [ne_comm]
+  · have : μ.menMatch m' ≠ some w := by
+      intro heq; have := (h m' w).mp heq; simp_all
+    simp_all [ne_comm]
+  · exact h m' w'
+
+end GSConsistent
+
+/-! ## Tracking the proposal set -/
+
+/-- The set of proposed pairs, seen as a `Finset`. -/
+noncomputable def proposedSet (prof : PrefProfile n) (σ : GSState prof) :
+    Finset (Fin n × Fin n) :=
+  Finset.univ.filter (fun mw => σ.proposed mw.1 mw.2)
+
+/-- Number of proposed pairs. -/
+noncomputable def proposedCount (prof : PrefProfile n) (σ : GSState prof) : Nat :=
+  (proposedSet prof σ).card
+
+namespace proposedSet
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+lemma mem_iff (mw : Fin n × Fin n) :
+    mw ∈ proposedSet prof σ ↔ σ.proposed mw.1 mw.2 := by
+  simp [proposedSet]
+
+/-- `gsStepWith` inserts exactly one new pair in the proposal set. -/
+lemma stepWith_insert (σ : GSState prof) (m w : Fin n) :
+    proposedSet prof (gsStepWith prof σ m w) =
+      insert (m, w) (proposedSet prof σ) := by
+  classical
+  ext ⟨m', w'⟩
+  simp only [mem_iff, mem_insert, Prod.mk.injEq]
+  unfold gsStepWith
+  split
+  · simp; tauto
+  · split <;> simp <;> tauto
+
+end proposedSet
+
+namespace proposedCount
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- The initial state has zero proposals. -/
+lemma initial : proposedCount prof (gsInitial prof) = 0 := by
+  classical
+  simp [proposedCount, proposedSet, gsInitial]
+
+/-- `StepWith` increases the counter by one for any new proposal. -/
+lemma stepWith (σ : GSState prof) (m w : Fin n) (hnew : ¬ σ.proposed m w) :
+    proposedCount prof (gsStepWith prof σ m w) = proposedCount prof σ + 1 := by
+  classical
+  have hmem : (m, w) ∉ proposedSet prof σ := by
+    simp [proposedSet]
+    exact hnew
+  simp only [proposedCount, proposedSet.stepWith_insert]
+  exact card_insert_of_notMem hmem
+
+end proposedCount
+
+/-! ## Invariant - men propose in decreasing order of preference -/
+
+/-- Dans l'algorithme de Gale-Shapley, les hommes proposent par ordre décroissant
+    de préférence. Après `k` étapes, toutes les propositions de l'homme `m` vont à
+    ses `k` candidates les plus préférées. Comme les préférences sont des bijections
+    totales, chaque femme est une candidate valide. -/
+def menProposedDownward (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ m w w', σ.proposed m w → prof.menPref m w' < prof.menPref m w →
+    σ.proposed m w'
+
+/-! ## Invariant - best match for each woman -/
+
+/-- Le partenaire actuel de chaque femme est la meilleure proposition qu'elle ait reçue. -/
+def womenBestState (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ w m m', σ.matching.womenMatch w = some m → σ.proposed m' w →
+    prof.womenPref w m ≤ prof.womenPref w m'
+
+namespace womenBestState
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- The initial state trivially satisfies `womenBest` (no matching). -/
+lemma initial : womenBestState prof (gsInitial prof) := by
+  unfold womenBestState
+  intro w m m' hmatch _
+  unfold gsInitial GSMatching.initial at hmatch
+  simp at hmatch
+
+end womenBestState
+
+/-! ## Invariant - every matched man has proposed -/
+
+/-- Tout homme apparié a bien proposé à sa partenaire actuelle. -/
+def menMatchedProposed (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ m w, σ.matching.menMatch m = some w → σ.proposed m w
+
+namespace menMatchedProposed
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- The initial state trivially satisfies this invariant (no matching). -/
+lemma initial : menMatchedProposed prof (gsInitial prof) := by
+  unfold menMatchedProposed
+  intro m w hmatch
+  unfold gsInitial at hmatch
+  unfold GSMatching.initial at hmatch
+  simp at hmatch
+
+end menMatchedProposed
+
+/-! ## Consistency preservation by GS steps -/
+
+namespace GSConsistent
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- `swapMatch` préserve la cohérence lorsque la femme `w` préfère `m` à `mOld`.
+    Le schéma suit la preuve de `matchFree` : `split_ifs` + `have` pour les enchaînements
+    de cohérence. -/
+lemma swapMatch (h : GSConsistent σ.matching) (m mOld w : Fin n)
+    (hm : σ.matching.menMatch m = none)
+    (hw : σ.matching.womenMatch w = some mOld)
+    (hmOld : σ.matching.menMatch mOld = some w) :
+    GSConsistent (σ.matching.swapMatch m mOld w) := by
+  have hne : m ≠ mOld := by intro heq; subst heq; simp_all
+  intro m' w'
+  simp only [GSMatching.swapMatch, Function.update_apply]
+  -- `if` extérieur : `m' = mOld` (depuis la mise à jour extérieure)
+  -- puis `if` intérieur : `m' = m` (depuis la mise à jour intérieure)
+  -- `if` côté droit : `w' = w`
+  split_ifs with h_mOld h_ww h_m h_nw h_nm
+  · -- `m' = mOld`, `w' = w` : les deux côtés sont `False` par `hne`
+    simp_all
+  · -- `m' = mOld`, `w' ≠ w` : on a besoin de `μ.womenMatch w' ≠ some mOld`
+    have : σ.matching.womenMatch w' ≠ some mOld := by
+      intro heq; have := (h mOld w').mpr heq; simp_all
+    simp_all
+  · -- `m' ≠ mOld`, `m' = m`, `w' = w` : les deux côtés sont `True`
+    simp_all
+  · -- `m' ≠ mOld`, `m' = m`, `w' ≠ w` : on a besoin de `μ.womenMatch w' ≠ some m`
+    have hnw' : w ≠ w' := ne_comm.mp ‹¬w' = w›
+    have : σ.matching.womenMatch w' ≠ some m := by
+      intro heq; have := (h m w').mpr heq; simp_all
+    simp_all
+  · -- `m' ≠ mOld`, `m' ≠ m`, `w' = w` : on a besoin de `μ.menMatch m' ≠ some w`
+    have hnm' : m ≠ m' := ne_comm.mp ‹¬m' = m›
+    have : σ.matching.menMatch m' ≠ some w := by
+      intro heq; have := (h m' w).mp heq; simp_all
+    simp_all
+  · -- `m' ≠ mOld`, `m' ≠ m`, `w' ≠ w` : cohérence directe
+    exact h m' w'
+
+/-- `gsStepWith` preserves the consistency of the matching. -/
+lemma stepWith (h : GSConsistent σ.matching) (m w : Fin n)
+    (hm : σ.matching.menMatch m = none)
+    (_hproposed : ¬ σ.proposed m w) :
+    GSConsistent (gsStepWith prof σ m w).matching := by
+  unfold gsStepWith
+  split
+  · -- `womenMatch w = none` : cas `matchFree`
+    exact matchFree h m w hm ‹_›
+  · -- `womenMatch w = some mOld`
+    split
+    · -- La femme préfère `m` à `mOld` : cas `swapMatch`
+      next mOld hwm hwlt =>
+        have hmOld : σ.matching.menMatch mOld = some w := (h mOld w).mpr hwm
+        exact swapMatch prof h m mOld w hm hwm hmOld
+    · -- La femme ne préfère PAS `m` : couplage inchangé
+      exact h
+
+/-- `gsStep` preserves the consistency of the matching. -/
+lemma step (h : GSConsistent σ.matching) (hfree : ∃ m, gsIsFree prof σ m) :
+    GSConsistent (gsStep prof σ).matching := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  have hw : ¬ σ.proposed m w := by
+    have := gsChooseMax_mem prof σ m hm.2
+    simp [gsCandidates] at this
+    exact this
+  exact stepWith prof h m w hm.1 hw
+
+/-- `gsRunSteps` preserves the consistency of the matching. -/
+lemma runSteps (k : Nat) :
+    GSConsistent (gsRunSteps prof k).matching := by
+  induction k with
+  | zero => exact initial
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end GSConsistent
+
+/-! ## Termination: bound on the number of proposals -/
+
+namespace proposedCount
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- A step for a free man increases the proposal counter. -/
+lemma step_of_free (σ : GSState prof) (m : Fin n)
+    (hf : gsIsFree prof σ m) :
+    proposedCount prof (gsStep prof σ) = proposedCount prof σ + 1 := by
+  unfold gsStep
+  rw [dif_pos ⟨m, hf⟩]
+  let m' := Classical.choose ⟨m, hf⟩
+  have hm' : gsIsFree prof σ m' := Classical.choose_spec ⟨m, hf⟩
+  let w := gsChooseMax prof σ m' hm'.2
+  have hw : ¬ σ.proposed m' w := by
+    have := gsChooseMax_mem prof σ m' hm'.2
+    simp [gsCandidates] at this
+    exact this
+  exact stepWith prof σ m' w hw
+
+/-- The number of proposals never exceeds `n²` for any state. -/
+lemma le_bound (σ : GSState prof) :
+    proposedCount prof σ ≤ gsProposalBound n := by
+  classical
+  unfold proposedCount proposedSet gsProposalBound
+  calc (Finset.univ.filter fun mw => σ.proposed mw.1 mw.2).card
+      ≤ (Finset.univ : Finset (Fin n × Fin n)).card :=
+        Finset.card_le_card (Finset.filter_subset _ _)
+    _ = n * n := by
+        simp only [Finset.card_univ, Fintype.card_prod, Fintype.card_fin]
+
+/-- At step `k`, the number of proposals never exceeds the bound. -/
+lemma runSteps_le_bound (k : Nat) :
+    proposedCount prof (gsRunSteps prof k) ≤ gsProposalBound n :=
+  le_bound prof _
+
+/-- If there is a free man, an additional step keeps the counter under the bound. -/
+lemma step_preserves_le_bound {_σ : GSState prof}
+    (_h : proposedCount prof _σ ≤ gsProposalBound n) :
+    proposedCount prof (gsStep prof _σ) ≤ gsProposalBound n :=
+    le_bound prof _
+
+/-- If the algorithm has not terminated after `k` steps, the counter is `k`. -/
+lemma runSteps_eq_of_not_terminated (k : Nat)
+    (hterm : ¬ gsTerminated prof (gsRunSteps prof k)) :
+    proposedCount prof (gsRunSteps prof k) = k := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    have hnk : ¬ gsTerminated prof (gsRunSteps prof k') := by
+      intro hk_term
+      unfold gsTerminated at hk_term hterm
+      simp only [gsRunSteps] at hterm
+      unfold gsStep at hterm
+      rw [dif_neg hk_term] at hterm
+      exact hterm hk_term
+    have ihk := ih hnk
+    have hf : ∃ m, gsIsFree prof (gsRunSteps prof k') m := not_not.mp hnk
+    rw [step_of_free prof (gsRunSteps prof k') (Classical.choose hf)
+        (Classical.choose_spec hf), ihk]
+
+end proposedCount
+
+/-! ## Step identity when the algorithm has terminated -/
+
+/-- If the current state is terminal, `gsStep` is the identity. -/
+lemma gsStep_eq_of_terminated (prof : PrefProfile n) (σ : GSState prof)
+    (h : gsTerminated prof σ) :
+    gsStep prof σ = σ := by
+  unfold gsStep gsTerminated at *
+  split
+  · contradiction
+  · rfl
+
+/-- If the algorithm has terminated at step `k`, all subsequent steps are the identity. -/
+lemma gsRunSteps_eq_of_terminated (prof : PrefProfile n) (k j : Nat) (hkj : k ≤ j)
+    (h : gsTerminated prof (gsRunSteps prof k)) :
+    gsRunSteps prof j = gsRunSteps prof k := by
+  induction j generalizing k with
+  | zero =>
+    have : k = 0 := Nat.eq_zero_of_le_zero hkj
+    subst this; rfl
+  | succ j' ih =>
+    simp only [gsRunSteps]
+    cases eq_or_lt_of_le hkj with
+    | inl heq => subst heq; rfl
+    | inr hlt =>
+      rw [ih k (Nat.le_of_lt_succ hlt) h]
+      exact gsStep_eq_of_terminated prof _ h
+
+/-! ## Invariant - men propose in decreasing order of preference (step preservation) -/
+
+namespace menProposedDownward
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- `gsStep` preserves the `menProposedDownward` invariant. -/
+lemma step (h : menProposedDownward prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    menProposedDownward prof (gsStep prof σ) := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m₀ := Classical.choose hfree
+  have hm₀ : gsIsFree prof σ m₀ := Classical.choose_spec hfree
+  let w₀ := gsChooseMax prof σ m₀ hm₀.2
+  have hw₀ : ¬ σ.proposed m₀ w₀ := by
+    intro h
+    have := gsChooseMax_mem prof σ m₀ hm₀.2
+    simp [gsCandidates] at this
+    exact this h
+  -- Maximalité : `gsChooseMax` renvoie la candidate la plus préférée ; aucune candidate n'est davantage préférée
+  have hmax : ∀ w', w' ∈ gsCandidates prof σ m₀ →
+      gsMenPrefLE prof m₀ w₀ w' → w₀ = w' := by
+    intro w' hw'in hle
+    have hmax' := gsChooseMax_maximal prof σ m₀ hm₀.2 w' hw'in
+    cases hle with
+    | inl h => exact h
+    | inr hlt =>
+      cases hmax' with
+      | inl h => exact h.symm
+      | inr hgt => exact absurd hgt (lt_asymm hlt)
+  intro m w w' hprop hlt
+  have goal_from (hab : σ.proposed m w') :
+      (gsStepWith prof σ m₀ w₀).proposed m w' :=
+    (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m, w')).mp
+      (by rw [proposedSet.stepWith_insert prof σ m₀ w₀]
+          simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff]
+          right; exact hab)
+  have hsrc : σ.proposed m w ∨ (m = m₀ ∧ w = w₀) := by
+    have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m, w)).mpr hprop
+    rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+    simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff] at hmem
+    cases hmem with | inl h => right; exact h | inr h => left; exact h
+  rcases hsrc with (hw | ⟨rfl, rfl⟩)
+  · exact goal_from (h m w w' hw hlt)
+  · have hw' : σ.proposed m₀ w' := by
+      by_contra hn
+      have hw'in : w' ∈ gsCandidates prof σ m₀ := by simp [gsCandidates]; exact hn
+      have : w₀ = w' := hmax w' hw'in (Or.inr hlt)
+      subst this; exact lt_irrefl _ hlt
+    exact goal_from hw'
+
+/-- `gsRunSteps` preserves the `menProposedDownward` invariant. -/
+lemma runSteps (k : Nat) :
+    menProposedDownward prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    intro m w w' hw hlt
+    unfold gsInitial GSMatching.initial at hw
+    simp at hw
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end menProposedDownward
+
+/-! ## Invariant - every matched man has proposed (step preservation) -/
+
+namespace menMatchedProposed
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- `gsStepWith` preserves `menMatchedProposed`. -/
+lemma stepWith (h : menMatchedProposed prof σ) (m w : Fin n) :
+    menMatchedProposed prof (gsStepWith prof σ m w) := by
+  intro m' w' hmatch
+  simp only [gsStepWith] at hmatch ⊢
+  split at *
+  · -- Cas `none` : `matchFree m w`
+    dsimp [GSMatching.matchFree] at hmatch ⊢
+    rw [Function.update_apply] at hmatch
+    split_ifs at hmatch
+    · injection hmatch with hw; right; exact ⟨‹m' = m›, hw.symm⟩
+    · left; exact h m' w' hmatch
+  · -- Cas `some mOld`
+    rename_i mOld
+    split_ifs at *
+    · -- La femme préfère `m` : `swapMatch m mOld w`
+      dsimp [GSMatching.swapMatch] at hmatch ⊢
+      rw [Function.update_apply, Function.update_apply] at hmatch
+      split_ifs at hmatch
+      · injection hmatch with hw; right; exact ⟨‹m' = m›, hw.symm⟩
+      · left; exact h m' w' hmatch
+    · -- Pas de préférence : couplage inchangé
+      dsimp at hmatch ⊢
+      left; exact h m' w' hmatch
+
+/-- `gsStep` preserves `menMatchedProposed`. -/
+lemma step (h : menMatchedProposed prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    menMatchedProposed prof (gsStep prof σ) := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  exact stepWith prof h m w
+
+/-- `gsRunSteps` preserves `menMatchedProposed`. -/
+lemma runSteps (k : Nat) :
+    menMatchedProposed prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end menMatchedProposed
+
+/-! ## Invariant - every proposed woman is matched -/
+
+/-- Si un homme a proposé à une femme, alors elle doit être appariée. -/
+def womenProposedImpliesMatched (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ w m, σ.proposed m w → σ.matching.womenMatch w ≠ none
+
+namespace womenProposedImpliesMatched
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+lemma initial : womenProposedImpliesMatched prof (gsInitial prof) := by
+  intro w m hprop; unfold gsInitial at hprop; simp at hprop
+
+lemma stepWith (h : womenProposedImpliesMatched prof σ) (m₀ w₀ : Fin n)
+    (hnew : ¬ σ.proposed m₀ w₀) :
+    womenProposedImpliesMatched prof (gsStepWith prof σ m₀ w₀) := by
+  intro w m' hprop
+  have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m', w)).mpr hprop
+  rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+  simp only [Finset.mem_insert, Prod.mk.injEq] at hmem
+  simp only [gsStepWith]
+  split
+  · dsimp [GSMatching.matchFree]
+    rw [Function.update_apply]
+    by_cases hw : w = w₀
+    · rw [if_pos hw]; simp
+    · rw [if_neg hw]
+      rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+      · exact absurd rfl hw
+      · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+  · split
+    · next mOld hmold hpref =>
+      dsimp [GSMatching.swapMatch]
+      rw [Function.update_apply]
+      by_cases hw : w = w₀
+      · rw [if_pos hw]; simp
+      · rw [if_neg hw]
+        rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+        · exact absurd rfl hw
+        · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+    · next mOld hmold hpref =>
+      rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+      · simp [hmold]
+      · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+
+lemma step (h : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    womenProposedImpliesMatched prof (gsStep prof σ) := by
+  unfold gsStep; rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  have hw : ¬ σ.proposed m w := by
+    have := gsChooseMax_mem prof σ m hm.2; simp [gsCandidates] at this; exact this
+  exact stepWith prof h m w hw
+
+lemma runSteps (k : Nat) :
+    womenProposedImpliesMatched prof (gsRunSteps prof k) := by
+  induction k with
+  | zero => simp only [gsRunSteps]; exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end womenProposedImpliesMatched
+
+/-! ## Invariant - best match for each woman (step preservation) -/
+
+/-- Si une femme est libre et que `womenProposedImpliesMatched` est vrai,
+    alors aucun homme ne lui a encore proposé (contraposée). -/
+lemma womenUnproposed (prof : PrefProfile n) (σ : GSState prof)
+    (h : womenBestState prof σ)
+    (hwp : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    ∀ w, σ.matching.womenMatch w = none → ∀ m', ¬σ.proposed m' w := by
+  intro w hw m' hprop
+  exact (hwp w m' hprop) hw
+
+namespace womenBestState
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- `gsStep` preserves `womenBestState`. -/
+lemma step (h : womenBestState prof σ)
+    (hwp : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    womenBestState prof (gsStep prof σ) := by
+  unfold gsStep; rw [dif_pos hfree]
+  set m₀ := Classical.choose hfree
+  have hm₀ : gsIsFree prof σ m₀ := Classical.choose_spec hfree
+  set w₀ := gsChooseMax prof σ m₀ hm₀.2
+  unfold womenBestState
+  intro w m m' hmatch hprop
+  have hsrc : σ.proposed m' w ∨ (m' = m₀ ∧ w = w₀) := by
+    have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m', w)).mpr hprop
+    rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+    simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff] at hmem
+    cases hmem with | inl h => right; exact h | inr h => left; exact h
+  -- Réduire le couplage de `gsStepWith` et découper sur le discriminant
+  change (gsStepWith prof σ m₀ w₀).matching.womenMatch w = some m at hmatch
+  simp only [gsStepWith] at hmatch
+  split at hmatch
+  · -- Cas `none` : `matchFree`
+    dsimp [GSMatching.matchFree] at hmatch
+    rw [Function.update_apply] at hmatch
+    by_cases hw : w = w₀
+    · rw [if_pos hw] at hmatch
+      injection hmatch with hmi; subst hmi
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · exfalso
+        have hn := ‹σ.matching.womenMatch w₀ = none›
+        exact womenUnproposed prof σ h hwp hfree w₀ hn m' (hw ▸ hw')
+      · exact le_rfl
+    · rw [if_neg hw] at hmatch
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · exact h w m m' hmatch hw'
+      · exfalso; exact hw rfl
+  · -- Cas `some mOld`
+    next mOld hmold =>
+    by_cases hpref : prof.womenPref w₀ m₀ < prof.womenPref w₀ mOld
+    · rw [if_pos hpref] at hmatch
+      dsimp [GSMatching.swapMatch] at hmatch
+      rw [Function.update_apply] at hmatch
+      by_cases hw : w = w₀
+      · rw [if_pos hw] at hmatch
+        injection hmatch with hmi; subst hmi
+        rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+        · subst hw
+          have hold := h w₀ mOld m' hmold hw'
+          exact le_trans (le_of_lt hpref) hold
+        · exact le_rfl
+      · rw [if_neg hw] at hmatch
+        rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+        · exact h w m m' hmatch hw'
+        · exfalso; exact hw rfl
+    · rw [if_neg hpref] at hmatch
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · by_cases hw : w = w₀
+        · subst hw; exact h w₀ m m' hmatch hw'
+        · exact h w m m' hmatch hw'
+      · rw [hmatch] at hmold
+        injection hmold with heq; subst heq
+        exact by omega
+
+/-- `gsRunSteps` preserves `womenBestState`. -/
+lemma runSteps (k : Nat) :
+    womenBestState prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih (womenProposedImpliesMatched.runSteps prof k') h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end womenBestState
+
+/-! ## Termination: the algorithm terminates in at most n^2 steps -/
+
+lemma gsTerminated_runSteps_bound (prof : PrefProfile n) :
+    gsTerminated prof (gsRunSteps prof (gsProposalBound n)) := by
+  classical
+  by_contra hnot
+  have ⟨m, hm⟩ : ∃ m, gsIsFree prof (gsRunSteps prof (gsProposalBound n)) m := by
+    simpa [gsTerminated] using hnot
+  set σ := gsRunSteps prof (gsProposalBound n)
+  have hmcand : (gsCandidates prof σ m).Nonempty := hm.2
+  set w := gsChooseMax prof σ m hmcand
+  have hw : ¬ σ.proposed m w := by
+    have := gsChooseMax_mem prof σ m hmcand
+    simp [gsCandidates] at this; exact this
+  have hcount : proposedCount prof σ = gsProposalBound n :=
+    proposedCount.runSteps_eq_of_not_terminated prof (gsProposalBound n) hnot
+  have hss : proposedSet prof σ ⊆ (Finset.univ : Finset (Fin n × Fin n)) :=
+    Finset.filter_subset _ _
+  have huniv : (Finset.univ : Finset (Fin n × Fin n)).card = n * n := by
+    simp [Fintype.card_prod, Fintype.card_fin]
+  have hcount_card : (proposedSet prof σ).card = n * n := by
+    unfold proposedCount at hcount; simp [gsProposalBound] at hcount; exact hcount
+  have heq : proposedSet prof σ = Finset.univ :=
+    Finset.eq_of_subset_of_card_le hss (by rw [huniv]; exact hcount_card.ge)
+  exact hw ((proposedSet.mem_iff prof (m, w)).1 (heq ▸ Finset.mem_univ _))
+
+/-- Lorsque GS a terminé, chaque homme est apparié (`menMatch m ≠ none`).
+    Si un homme était libre, `gsCandidates` devrait être vide (sans quoi il serait
+    libre lui aussi), donc il aurait proposé à toutes les femmes. Par
+    `womenProposedImpliesMatched`, toutes les femmes seraient alors appariées via
+    d'autres hommes. Mais cohérence + `n` femmes appariées par `n-1` autres hommes
+    est impossible sur `Fin n`. -/
+lemma gsTerminated_allMenMatched (prof : PrefProfile n) {σ : GSState prof}
+    (hterm : gsTerminated prof σ)
+    (hwp : womenProposedImpliesMatched prof σ)
+    (hcon : GSConsistent σ.matching)
+    (m : Fin n) :
+    σ.matching.menMatch m ≠ none := by
+  intro hnone
+  have hcand_empty : (gsCandidates prof σ m).Nonempty → False := by
+    intro hne; exact hterm ⟨m, ⟨hnone, hne⟩⟩
+  have hpropAll : ∀ w, σ.proposed m w := by
+    intro w
+    by_contra hnot
+    exact hcand_empty ⟨w, by simp [gsCandidates, hnot]⟩
+  have hwMatched : ∀ w, σ.matching.womenMatch w ≠ none :=
+    fun w => hwp w m (hpropAll w)
+  have hex (w : Fin n) : ∃ m', σ.matching.womenMatch w = some m' ∧ σ.matching.menMatch m' = some w := by
+    obtain ⟨m', hm'⟩ := Option.ne_none_iff_exists.mp (hwMatched w)
+    have hwf : σ.matching.womenMatch w = some m' := hm'.symm
+    exact ⟨m', hwf, (hcon m' w).mpr hwf⟩
+  -- Construire une injection `f : Fin n → {m' : Fin n // m' ≠ m}`, puis déduire la contradiction
+  have hSpec (w : Fin n) :
+      σ.matching.womenMatch w = some (Classical.choose (hex w)) ∧
+      σ.matching.menMatch (Classical.choose (hex w)) = some w :=
+    Classical.choose_spec (hex w)
+  have fne (w : Fin n) : Classical.choose (hex w) ≠ m := by
+    intro heq
+    have h := (hSpec w).2
+    rw [heq, hnone] at h
+    cases h
+  let f (w : Fin n) : { m' : Fin n // m' ≠ m } :=
+    ⟨Classical.choose (hex w), fne w⟩
+  have hf : Function.Injective f := by
+    intro w₁ w₂ heq
+    have h1 := (hSpec w₁).2
+    have h2 := (hSpec w₂).2
+    have hval : Classical.choose (hex w₁) = Classical.choose (hex w₂) :=
+      congrArg Subtype.val heq
+    congr 1
+    have := congrArg (σ.matching.menMatch ·) hval
+    simp only [h1, h2, Option.some.injEq] at this
+    exact this
+  -- `|{m' ≠ m}| < |Fin n|` contredit l'injection `Fin n → {m' ≠ m}`
+  have hle := Fintype.card_le_of_injective f hf
+  have hcard_fin : Fintype.card (Fin n) = n := Fintype.card_fin n
+  -- Contradiction : `Fin n` s'injecte dans `{m' ≠ m}` mais `{m' ≠ m} ⊂ Fin n`
+  have hcontra : Fintype.card (Fin n) ≤ Fintype.card { m' : Fin n // m' ≠ m } :=
+    Fintype.card_le_of_injective f hf
+  have hlt : Fintype.card { m' : Fin n // m' ≠ m } < Fintype.card (Fin n) :=
+    @Fintype.card_lt_of_injective_of_notMem _ _ _ _
+      (Subtype.val : {m' : Fin n // m' ≠ m} → Fin n)
+      Subtype.coe_injective m
+      (by simp)
+  omega
+
+/-! ## Conversion of the final GS matching -/
+
+/-- Extraire l'épouse d'un `GSMatching` via `Classical.choose` (évite les problèmes de typage de `Option.get`). -/
+noncomputable def gsSpouse (μ : GSMatching n)
+    (hall : ∀ m, μ.menMatch m ≠ none) (m : Fin n) : Fin n :=
+  Classical.choose (Option.ne_none_iff_exists.mp (hall m))
+
+lemma gsSpouse_spec (μ : GSMatching n)
+    (hall : ∀ m, μ.menMatch m ≠ none) (m : Fin n) :
+    μ.menMatch m = some (gsSpouse μ hall m) :=
+  (Classical.choose_spec (Option.ne_none_iff_exists.mp (hall m))).symm
+
+/-- Toutes les femmes sont appariées dès que tous les hommes sont appariés et que le couplage est cohérent. -/
+lemma gsAllWomenMatched {μ : GSMatching n}
+    (hall : ∀ m, μ.menMatch m ≠ none)
+    (hcon : GSConsistent μ) (w : Fin n) :
+    μ.womenMatch w ≠ none := by
+  by_contra hnone
+  have hNoMan : ∀ m, μ.menMatch m ≠ some w := by
+    intro m hmw; have := hcon m w |>.mp hmw; rw [hnone] at this; simp at this
+  -- Chaque homme est associé à un certain `w' ≠ w`, injectivement → contradiction par pigeonhole
+  have hMap (m : Fin n) : ∃ w', μ.menMatch m = some w' ∧ w' ≠ w := by
+    obtain ⟨w', hw'⟩ := Option.ne_none_iff_exists.mp (hall m)
+    exact ⟨w', hw'.symm, fun heq => hNoMan m (heq ▸ hw'.symm)⟩
+  let f (m : Fin n) : {w' : Fin n // w' ≠ w} :=
+    ⟨Classical.choose (hMap m), (Classical.choose_spec (hMap m)).2⟩
+  have hf : Injective f := by
+    intro m₁ m₂ heq
+    simp only [f, Subtype.mk.injEq] at heq
+    have h₁ := (Classical.choose_spec (hMap m₁)).1
+    have h₂ := (Classical.choose_spec (hMap m₂)).1
+    rw [heq] at h₁
+    -- h₁ : μ.menMatch m₁ = some c  (où `c = Classical.choose (hMap m₂)`)
+    -- h₂ : μ.menMatch m₂ = some c
+    have hw₁ := hcon m₁ (Classical.choose (hMap m₂)) |>.mp h₁
+    have hw₂ := hcon m₂ (Classical.choose (hMap m₂)) |>.mp h₂
+    -- hw₁ : μ.womenMatch c = some m₁
+    -- hw₂ : μ.womenMatch c = some m₂
+    exact Option.some.inj (hw₁.symm.trans hw₂)
+  have hle : Fintype.card (Fin n) ≤ Fintype.card {w' : Fin n // w' ≠ w} :=
+    Fintype.card_le_of_injective f hf
+  have hlt : Fintype.card {w' : Fin n // w' ≠ w} < Fintype.card (Fin n) :=
+    @Fintype.card_lt_of_injective_of_notMem _ _ _ _
+      (Subtype.val : {w' : Fin n // w' ≠ w} → Fin n) Subtype.coe_injective w (by simp)
+  omega
+
+/-- Construire un `Matching` total à partir d'un `GSMatching` terminé. -/
+noncomputable def gsFinalMatching (prof : PrefProfile n)
+    (σ : GSState prof)
+    (hall : ∀ m, σ.matching.menMatch m ≠ none)
+    (hcon : GSConsistent σ.matching) : Matching n where
+  spouse := gsSpouse σ.matching hall
+  bijective := by
+    constructor
+    · -- injectif : `spouse m₁ = spouse m₂` → `m₁ = m₂`
+      intro m₁ m₂ heq
+      have h₁ := gsSpouse_spec σ.matching hall m₁
+      have h₂ := gsSpouse_spec σ.matching hall m₂
+      rw [heq] at h₁
+      -- h₁ : σ.matching.menMatch m₁ = some (gsSpouse σ.matching hall m₂)
+      -- h₂ : σ.matching.menMatch m₂ = some (gsSpouse σ.matching hall m₂)
+      have hw₁ := hcon m₁ (gsSpouse σ.matching hall m₂) |>.mp h₁
+      have hw₂ := hcon m₂ (gsSpouse σ.matching hall m₂) |>.mp h₂
+      -- hw₁ : σ.matching.womenMatch _ = some m₁
+      -- hw₂ : σ.matching.womenMatch _ = some m₂
+      exact Option.some.inj (hw₁.symm.trans hw₂)
+    · -- surjectif : pour chaque `w`, trouver `m` avec `spouse m = w`
+      intro w
+      have hwn := gsAllWomenMatched hall hcon w
+      obtain ⟨m, hm⟩ := Option.ne_none_iff_exists.mp hwn
+      have hmw : σ.matching.menMatch m = some w := (hcon m w).mpr hm.symm
+      exact ⟨m, by
+        have hspec := gsSpouse_spec σ.matching hall m
+        -- hspec : σ.matching.menMatch m = some (gsSpouse σ.matching hall m)
+        rw [hmw] at hspec
+        -- hspec : some w = some (gsSpouse σ.matching hall m)
+        exact Option.some.inj hspec.symm⟩
+
+/-- Lemme clé : `gsFinalMatching.spouse m` extrait directement la valeur de l'`Option`. -/
+lemma gsFinalMatching_spouse_get (prof : PrefProfile n) (σ : GSState prof)
+    (hall : ∀ m, σ.matching.menMatch m ≠ none)
+    (hcon : GSConsistent σ.matching) (m : Fin n) :
+    (gsFinalMatching prof σ hall hcon).spouse m =
+      Classical.choose (Option.ne_none_iff_exists.mp (hall m)) := rfl
+
+/-! ## Absence of blocking pairs (adapted from `Properties.lean` upstream L48-120) -/
+
+/-- L'état final de GS ne comporte aucune paire bloquante.
+
+    Structure de la preuve (adaptée de `Properties.lean galeShapley_noBlockingPairs` du dépôt mmaaz-git) :
+    1. Supposer une paire bloquante `(m, w)` : `m` préfère `w` à son épouse, `w` préfère `m` à son époux
+    2. Montrer que `m` a proposé à `w` (`menProposedDownward` + `menMatchedProposed`)
+    3. `w` est appariée à `mW` (`womenProposedImpliesMatched`)
+    4. `womenBestState` donne : `womenPref w mW ≤ womenPref w m`
+    5. La condition de blocage donne : `womenPref w m < womenPref w mW`
+    6. Contradiction (`≤` et `<` sont incompatibles)
+
+    Simplification par rapport à l'upstream : pas de branche « `w` est libre » (préférences totales).
+-/
+lemma gsNoBlockingPairs (prof : PrefProfile n)
+    (hterm : gsTerminated prof (gsRunSteps prof (gsProposalBound n)))
+    (hcon : GSConsistent (gsRunSteps prof (gsProposalBound n)).matching)
+    (hwp : womenProposedImpliesMatched prof (gsRunSteps prof (gsProposalBound n)))
+    (hdown : menProposedDownward prof (gsRunSteps prof (gsProposalBound n)))
+    (hmatch_prop : menMatchedProposed prof (gsRunSteps prof (gsProposalBound n)))
+    (hbest : womenBestState prof (gsRunSteps prof (gsProposalBound n)))
+    (m w : Fin n) :
+    ¬ IsBlockingPair prof (gsFinalMatching prof (gsRunSteps prof (gsProposalBound n))
+      (fun m => gsTerminated_allMenMatched prof hterm hwp hcon m) hcon) m w := by
+  intro hblock
+  obtain ⟨hmpref, hwpref⟩ := hblock
+  set σ := gsRunSteps prof (gsProposalBound n)
+  set hall : ∀ m, σ.matching.menMatch m ≠ none :=
+    fun m => gsTerminated_allMenMatched prof hterm hwp hcon m
+  set μ := gsFinalMatching prof σ hall hcon
+  -- Étape 1 : `m` est apparié, extraire sa partenaire `wMatch`
+  have hwMatch' : σ.matching.menMatch m = some (μ.spouse m) :=
+    gsSpouse_spec σ.matching hall m
+  -- Étape 2 : `m` a proposé à sa partenaire (`μ.spouse m`)
+  have hpropMatch : σ.proposed m (μ.spouse m) :=
+    hmatch_prop m (μ.spouse m) hwMatch'
+  -- Étape 3 : `m` a proposé à `w` (clôture décroissante)
+  -- Le blocage dit que `menPref m w < menPref m (μ.spouse m)`, donc `w` est préférée
+  have hpropw : σ.proposed m w :=
+    hdown m (μ.spouse m) w hpropMatch hmpref
+  -- Étape 4 : `w` est appariée (`womenProposedImpliesMatched`)
+  have hwomMatch : σ.matching.womenMatch w ≠ none := hwp w m hpropw
+  obtain ⟨mW, hmW⟩ := Option.ne_none_iff_exists.mp hwomMatch
+  have hmW' : σ.matching.womenMatch w = some mW := hmW.symm
+  -- Étape 5 : `womenBestState` donne `womenPref w mW ≤ womenPref w m`
+  have hbest' : prof.womenPref w mW ≤ prof.womenPref w m :=
+    hbest w mW m hmW' hpropw
+  -- Étape 6 : `μ.inverse w = mW`
+  -- Par cohérence : `menMatch mW = some w`, donc `spouse mW = w`
+  have hmw' : σ.matching.menMatch mW = some w := (hcon mW w).mpr hmW'
+  have hspouse_mW : μ.spouse mW = w := by
+    have h₁ := gsSpouse_spec σ.matching hall mW
+    -- h₁ : `menMatch mW = some (gsSpouse ...)` et `hmw'` : `menMatch mW = some w`
+    exact Option.some.inj (h₁.symm.trans hmw')
+  -- `inverse w = mW` car `spouse mW = w`
+  have hwinv : μ.inverse w = mW := by
+    unfold Matching.inverse
+    rw [← hspouse_mW]
+    exact Equiv.ofBijective_symm_apply_apply (gsSpouse σ.matching hall) _ mW
+  rw [hwinv] at hwpref
+  -- `hwpref` : `womenPref w m < womenPref w mW`
+  -- `hbest'` : `womenPref w mW ≤ womenPref w m`
+  -- Contradiction : `hbest'` dit `womenPref w mW ≤ womenPref w m`
+  -- mais `hwpref` dit `womenPref w m < womenPref w mW`
+  -- c'est-à-dire : `a ≤ b` et `b < a` est impossible
+  have : (prof.womenPref w mW : Nat) ≤ (prof.womenPref w m : Nat) := by
+    exact mod_cast hbest'
+  have : (prof.womenPref w m : Nat) < (prof.womenPref w mW : Nat) := by
+    exact mod_cast hwpref
+  omega
+
+end StableMarriage_en


### PR DESCRIPTION
## Summary

EPIC **#4365** phase 4 — **c.305 stacked on c.304 : absorption `StableMarriage.GaleShapley`** dans le lake cible `game_theory_lean/` (skeleton créé en c.299 #5902 MERGED a8eec3fa9).

**Stacked sur** : #5911 (Lattice, 75d231f027) — branche basée sur `origin/feature/c304-stable-marriage-lattice` (4 commits stacked c.300+c.301+c.303+c.304 au-dessus de a8eec3fa9).

| Fichier | Rôle | Stats |
|---------|------|-------|
| `game_theory_lean/StableMarriage/GaleShapley.lean` | Module FR canon (namespace `StableMarriage`) — scaffold de l'algo Gale-Shapley pour le mariage stable | 181 lignes, namespace `StableMarriage`, **0 sorries** |
| `game_theory_lean/StableMarriage/GaleShapley_en.lean` | Module EN sibling (namespace `StableMarriage_en`) | 171 lignes, **0 sorries**, byte-identique code, prose traduite |
| `game_theory_lean/StableMarriage.lean` | Root aggregator : +2 imports (`GaleShapley` + `GaleShapley_en`), commentaire de plan corrigé | +10/-8 lignes |

**Aucun fichier source n'a été modifié ni supprimé.** Le source lake `stable_marriage_lean/` reste intact (cf c.306 = PR dédiée `debt`/`regression-accepted` pour les deletions, anti-regression protocol 4 étapes).

## §A composite checks

| Métrique | Valeur | Seuil "split required" | Verdict |
|----------|--------|------------------------|---------|
| `additions + deletions` (stacked) | **+370** | > 3000 = split | **PASS** (370 << 3000, pas d'invocation L277 requise) |
| `changedFiles` (stacked) | **3** | > 15 = split | **PASS** |
| Features distinctes | 1 (absorber GaleShapley + EN sibling) | > 4 = split | **PASS** |
| Domaines | 1 (Lean / GameTheory) | > 1 = split | **PASS** |

**§A : PASS** — strictement single-subject, single-domain, single-feature. Le contenu mathématique (scaffold de l'algorithme Gale-Shapley) est pré-existant dans `stable_marriage_lean/StableMarriage/GaleShapley.lean` (181 lignes) ; cette PR est une **copie byte-identique** vers le lake cible, pas de nouveau code rédigé.

**Diff vs main** (incluant c.300 + c.301 + c.303 + c.304 + c.305 absorbés en amont) : ~+4567 lignes cumulées (stacked history effect). **Stacked delta = portée réelle de cette PR** = +370 lignes / 3 fichiers.

## §B Lean body prooflog (L331 INDISPENSABLE)

| Élément | Statut | Notes |
|---------|--------|-------|
| `grep -c sorry` per modified `.lean` file | **0 → 0** | `GaleShapley.lean` : 0 ; `GaleShapley_en.lean` : 0 ; `StableMarriage.lean` : 0 (comment + imports) |
| Lake build SUCCESS local (cible) | **YES 759 jobs** | `lake build StableMarriage` = "Build completed successfully (759 jobs)" (c.304 = 757 jobs ; +2 jobs pour GaleShapley + GaleShapley_en + recompile aggregator) |
| Lake build SUCCESS source lake (regression) | **YES** | Source `stable_marriage_lean/` git diff = vide vs `origin/main` (anti-régression préservée) |
| Proof integrity | **PRESERVED** | aucun .lean de `stable_marriage_lean/` modifié ; aucun sorries touché |
| `_en` sibling (L266) | **YES** | `GaleShapley_en.lean` absorbé simultanément, namespace `StableMarriage_en`, byte-identique code |
| LF doctrine (L268 #4) | **YES** | `file <path>` sur les 3 fichiers = UTF-8 LF (Python binary write pour préserver LF, L268 #4 reaffirmed) |
| Stacked PR pattern | **YES** | Branche basée sur `origin/feature/c304-stable-marriage-lattice` (= 75d231f027) ; delta = seulement GaleShapley + imports aggregator |

### Warnings linter pré-existantes (transparence G.2)

Le Lake build émet **6 warnings de linter `unusedSimpArgs`** dans le module `Lattice` (lignes 374 et al., provenance `Matching.joinSpouse` non-utilisée dans `simp only`).

**Vérifications firsthand** : ces warnings existent **déjà dans le source d'origine** `stable_marriage_lean/StableMarriage/Lattice_en.lean` (copie byte-identique, sha256 vérifié). **Pas une régression introduite par cette absorption** — le but de cette PR est de migrer le code tel quel, pas de le refactorer (anti-régression protocole 4 étapes).

## Anti-régression

- `git diff origin/main..HEAD -- 'MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/'` : **vide** (source intacte)
- `git diff feature/c304-stable-marriage-lattice..feature/c305-stable-marriage-galeshapley -- 'MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/'` : **vide** (stacked delta = cible only)
- `sha256sum` source vs cible : **byte-identique** (GaleShapley.lean + GaleShapley_en.lean)
- Aucun fichier de `decision_theory_lean`, `cooperative_games_lean`, `social_choice_lean`, `knot_lean`, `gittins_lean`, `conway_lean`, `social_choice_lean_peters` touché
- Aucun sorries touché (contenu mathématique copié verbatim)

## §G vigilance

**G.1 verify-before-claiming** : §B ci-dessus cite des commandes `lake build` réelles et `grep -c sorry` réels (pas un claim non vérifié). Les warnings linter ont été vérifiées firsthand dans le source.

**G.6 audit avant merge cascade** : cette PR est strictement single-subject (1 module = 1 absorption). Merge order recommandée (cf msg msg-20260710T150956-vfv19i forward ai-01) : `#5902 MERGED` → `#5911` (contient c.300+c.301+c.303+c.304) → **cette PR** (c.305 GaleShapley).

**G.9 culture du doute** : avant forward, j'ai vérifié (1) `git diff` source = vide, (2) byte-identity GaleShapley.lean + _en.lean, (3) lake build SUCCESS 759 jobs, (4) cascade §G.6 honnête (pas de propagation phantom "MERGED upstream").

## L143 SAFE cross-owner

Travail isolé dans worktree `/c/dev/CoursIA-c301-gsstate` (réutilisé post-c.302 [DONE] pour c.303, encore valide pour c.305). Branche personnelle `feature/c305-stable-marriage-galeshapley` créée depuis `origin/feature/c304-stable-marriage-lattice`. Aucun fichier hors de ce worktree n'a été touché :
- Main worktree `c:\dev\CoursIA-2` : WIP staged d'autres sessions préservé
- Worktree `c:\dev\CoursIA-c301-gsstate` : branche `feature/c305-stable-marriage-galeshapley` (c.305 cette PR)

## L266 sibling-EN-oublié

PR inclut **le sibling `_en`** : `StableMarriage/GaleShapley_en.lean` (namespace `StableMarriage_en`) absorbé simultanément. Vérifié que le `globs := #[`StableMarriage.*]` du lakefile (créé c.299 dans #5902) découvre bien les deux fichiers (build 759 jobs = 10 modules cumulés Definitions + Definitions_en + GSState + GSState_en + Lemmas + Lemmas_en + Lattice + Lattice_en + GaleShapley + GaleShapley_en + aggregator).

## L268 #4 LF doctrine

`file <path>` sur les 3 fichiers = `UTF-8 text` (pas de mention CRLF). Aggregator écrit via Python binary `open(path, 'wb').write(content)` pour préserver LF (L268 #4 reaffirmé — `Edit` tool sur Windows peut transformer LF en CRLF). **6ᵉ occurrence consécutive depuis c.291**.

## L279 worker never merges

PR forwardée à ai-01 via DM HIGH (à envoyer post-push). Worker INTERDIT `gh pr merge` quel que soit le mode (cf L279 + leçon `gh-pr-statuscheckrollup-staleness`).

## §G.6 cascade audit pre-merge

| Étape | PR | État avant | Action attendue ai-01 |
|-------|----|----------- |----------------------|
| 1 | #5902 | MERGED (a8eec3fa9, 2026-07-10T13:51:29Z) | (déjà fait) |
| 2 | #5911 | OPEN, MERGEABLE, 9/9 CI SUCCESS, stacked c.300+c.301+c.303+c.304 | merge avant cette PR |
| 3 | **cette PR** | OPEN, MERGEABLE, 8 CI PASS + 1 pending csharp, stacked sur #5911 | merge après #5911 |

**Recommandation §G.6 (cf forward msg-20260710T150956-vfv19i)** : merger UNIQUEMENT #5911 d'abord (contient c.300+c.301+c.303+c.304 dans 4 commits), puis fermer #5904 / #5905 / #5910 comme superseded par #5911. Cette PR c.305 GaleShapley = stacked delta +370 lignes sur #5911.

## Plan de déploiements c.306+ (suite rolling sub-PRs par cycle)

| Cycle | Module absorbé | Source → cible | Statut |
|-------|---------------|----------------|--------|
| c.300 | `StableMarriage.Definitions` + `_en` | 125+132 lignes, 0 sorries | MERGED via #5911 (à fermer superseded) |
| c.301 | `StableMarriage.GSState` + `_en` | 173+180 lignes, 0 sorries | MERGED via #5911 (à fermer superseded) |
| c.302/c.303 | `StableMarriage.Lemmas` + `_en` | 898+902 lignes, 0 sorries | MERGED via #5911 (à fermer superseded) |
| c.304 | `StableMarriage.Lattice` + `_en` | 885+881 lignes, 0 REAL sorries | MERGED via #5911 (à fermer superseded) |
| **c.305 (THIS)** | **`StableMarriage.GaleShapley` + `_en`** | **181+171 lignes, 0 sorries, scaffold** | **cette PR (sweep-ready après #5911)** |
| c.306 | `stable_marriage_lean/...` deletions + lakefile globs cleanup | — | PR `debt`/`regression-accepted` (élevée) |

Suivants : `cooperative_games_lean/` (8 modules c.307-c.314), `social_choice_lean/` (c.315+), `social_choice_lean_peters` SI convergence rev v4.27 → v4.31.0-rc1 (workstream séparé #4364 post-#B).

## Link EPICs

- **#4365** — Regrouper les lakes cohésifs post-convergence (GameTheory 6→2), body = ce PR. **owner implicite = po-2026**
- **#4362** — EPIC parent [EPIC] Lean — harmoniser Mathlib, mutualiser les checkouts, regrouper les lakes
- **#4980** — i18n multilingue (Phase 0.5, ratifiée 2026-07-04) → convention `globs` pour auto-discovery siblings `_en` (réutilisée ici, **5ᵉ application c.299 + c.300 + c.303 + c.304 + c.305**)

## Anti-monotonie (L335) — vs c.304 (parallèle jsboige)

c.304 (autre agent parallèle, Lattice 885+881 lignes, 0 REAL sorries) vs c.305 (moi, GaleShapley 181+171 lignes, 0 sorries, scaffold) :
- **Registre** : substantive lattice theory → scaffold algorithmique (Gale-Shapley est l'algo, pas une structure de preuves)
- **Artefact** : 4 commits stacked cumulés → 1 commit empilé (delta net +370 lignes, plus court)
- **Sémantique** : rolling continu #4365 → même rolling

**3 axes variety** : registre pivoté (lattice theory → scaffold algo), artefact allégé (delta court), sémantique maintenue (rolling EPIC). **2 axes brisés (registre + artefact)** — PASS L335.

## Leçons cross-cycle

- **L268 #4 LF doctrine** : 6ᵉ occurrence consécutive depuis c.291 (c.291, c.298, c.299, c.300, c.302, c.303, **c.305**). Pattern rodé, préservation LF via Python binary write (Edit tool Windows transforme LF → CRLF).
- **L266 sibling-EN-oublié** : 5ᵉ application consécutive (c.299 skeleton, c.300 Definitions, c.302/c.303 GSState/Lemmas, c.304 Lattice, **c.305 GaleShapley**). Convention i18n globs `globs := #[`StableMarriage.*]` fonctionne, build incrémental cohérent.
- **Stacked PR pattern validé 3ᵉ fois** (c.302 + c.303 + c.305) : chaque PR stacked ajoute 2 imports au root aggregator → no add/add conflict. Lake build incremental +2 jobs (c.304 → c.305) prouve la cohérence du rebuild chain.
- **L331 §B body prooflog** : lake build SUCCESS local INDISPENSABLE dans body PR. 759 jobs (c.305) = signal substantiel. CI ne build PAS module Lean — le body prooflog est la SEULE preuve vérifiable.
- **Transparence G.2** : warnings linter pré-existantes documentées en clair dans le body PR (unusedSimpArgs Matching.joinSpouse). Pas de masquage, pas de "fix opportuniste" (anti-régression protocole).
- **Branchement sur la dernière PR stacked** : créer `feature/c305-...` basée sur `origin/feature/c304-...` (= #5911 HEAD) au lieu de main évite le re-re-add des 4 modules déjà stacked. Delta stacked net = +370 lignes.
- **Anti-pattern baseRefName=main** : l'agent c.304 a publié avec baseRefName=main (4 commits stacked dans le diff vs main). Pour c.305, j'ai basé sur `origin/feature/c304-...` (= 75d231f027) pour un delta stacked net minimal. Le sweep ai-01 doit merger dans l'ordre #5911 puis c.305, sinon add/add conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>