### PR TITLE
docs(ml): réconcilier attribution TP C# + doctrine L389 kernel-firsthand (See #4959 #3973 #4208)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -7,6 +7,8 @@ breakdown: DataScienceWithAgents=27, ML.Net=19
 maturity: PRODUCTION=40, BETA=5, ALPHA=1
 -->
 
+> **À propos des décomptes** : le marqueur `CATALOG-STATUS` ci-dessus est la **source de vérité autoritative** pour les volumes (notebooks par sous-série, maturité). Il est régénéré chaque nuit par le workflow [`catalog-cron.yml`](../../.github/workflows/catalog-cron.yml) à 03:37 UTC sur `main` (commit `[skip ci]` par `github-actions[bot]`). Si vous observez un décalage entre ce marqueur et une phrase en prose de ce README — par exemple si une sous-série a reçu de nouveaux notebooks mergés après la dernière régénération —, **fiez-vous au marqueur** ; la prose sera ré-alignée manuellement lors du prochain passage. Pour les **décomptes par kernel** (Python vs C#/.NET) au sein d'une sous-série, ce README reste autoritatif car la décomposition langagière par sous-série n'est pas dans le marqueur agrégé.
+
 [← Notebooks](../README.md) | [ML.NET (C#) →](ML.Net/README.md) | [Data Science with Agents (Python) →](DataScienceWithAgents/README.md) | [RL →](../RL/)
 
 Le monde regorge de données, mais les transformer en décisions éclairées demande plus qu'un tableur. Le Machine Learning offre un cadre systématique pour construire des modèles prédictifs à partir de données, en allant de la régression linéaire aux réseaux de neurones en passant par les systèmes de recommandation. Cette série vous forme au ML pratique avec trois fils complémentaires : **ML.NET** pour l'écosystème .NET/C#, **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs, et les **jumeaux de parité** qui confrontent un même concept aux deux écosystèmes.
@@ -39,7 +41,7 @@ Six figures illustrent les trois fils de la série : les fondations Python (Pand
 
 ## Parcours d'apprentissage
 
-### Track A : ML.NET (.NET/C#, 9 notebooks C# ML-1 à ML-9 et leurs 9 jumeaux Python + 1 TP capstone, ~7h)
+### Track A : ML.NET (.NET/C#, 10 notebooks C# — 9 du parcours ML-1 à ML-9 + 1 TP capstone — et leurs 9 jumeaux Python scikit-learn, ~7h)
 
 Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML). Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Les notebooks 8-9 ouvrent sur l'apprentissage non-supervisé : clustering K-Means (segmentation RFM, méthode du coude) puis détection d'anomalies par Randomized PCA (maintenance prédictive, choix du seuil de décision). Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
 


### PR DESCRIPTION
## Résumé

PR hub prose rewrite #4959 GREENLIGHT P1 #3/5 — **MyIA.AI.Notebooks/ML/README.md** (408 lignes, hub 2 sous-séries : ML.Net = 19 + DataScienceWithAgents = 27).

**Scope** :
1. **§E audit cross-hub L387 variante ciblée** : ligne 42 '9 notebooks C# ML-1 à ML-9 et leurs 9 jumeaux Python + 1 TP capstone' — confrontation kernel-firsthand L390 sur 19 ipynb ML.Net = **10 C#** (ML-1 à ML-9 + TP-prevision-ventes) + **9 Python** (jumeaux ML-1-Python à ML-9-Python). Arithmétiquement le total 19 est correct, mais la formulation attribuait implicitement le TP au Python (lecture ambiguë). Disk = TP est C# (logique : régression bayésienne Infer.NET, cf README L44 'Le TP final combine ML.NET et Infer.NET pour une régression bayésienne').
2. **Doctrine L389 PR hub prose rewrite appliquée sélectivement (3/4 patterns)** :
   - **Pattern #1** : note éditoriale counts (paragraphe blockquote après bloc CATALOG-STATUS), étendue avec mention spécifique **'Pour les décomptes par kernel (Python vs C#/.NET) au sein d'une sous-série, ce README reste autoritatif car la décomposition langagière par sous-série n'est pas dans le marqueur agrégé'** — particularité ML vs autres hubs : ML a une décomposition .NET⇄Python intra-sous-série (jumeaux de parité C326 owner-lane) que le CATALOG-STATUS agrégé ne capte pas.
   - **Pattern #2** : sous-note `catalog-cron.yml` (mécanisme auto-régénération 03:37 UTC daily sur `main`, commit `[skip ci]` par `github-actions[bot]`).
   - **Pattern #3** : SKIP légitime (l'arbre familles/sous-séries et le tableau figure §L95-L114 sont déjà complets, freshly grounded).
   - **Pattern #4** : dé-hardcode counts via correction L42 attribution TP C#.

**Audit autres counts prose** : 8 counts vérifiés (9 jumeaux Python ML-1..9, 27 DSWA total, 8 02-ML-Cours scikit-learn, 7 PythonAgents Day1-3, 10 AgenticDataScience Day4-7) — **tous alignés disk, 0 obsolescence supplémentaire**. Track durée 7h, 21h, 6h = estimations pédagogiques déclaratives, hors scope counts.

**Stat** : 1 fichier, +3/-1 (4 lignes modifiées). PR atomic minimal, G.4 split respecté.

**Validation** :
- `git diff --stat` : 1 fichier, +3/-1.
- Bloc `<!-- CATALOG-STATUS -->` **byte-identique** (catalog-pr-hygiene R1, vérifié par diff L3-L8 origin/main vs branche).
- `python scripts/check_docs_links.py --check` : **OK, 0 broken link ajouté** (3696 total).
- 0 notebook, 0 code, 0 catalogue régénéré.
- `grep '9 notebooks C#'` = 1 sur origin/main, 0 sur branche ✓ (attribution corrigée).
- **Kernel-firsthand L390** : 19/19 ipynb ML.Net vérifiés individuellement (10 C# + 9 Python, conforme jumeaux marathon parité #4956 juillet 2026).

**Note CATALOG-STATUS disk-mismatch (L382)** : disk ML total = 46 (CATALOG-STATUS = 46) = aligné. Pas de disk-mismatch structurel ici, contrairement à c.384 GenAI (stale by +3 = Image).

**Statut PRs greenlight #4959 (c.385 fin)** :
- c.381 PR #5906 hub central (+56/-10) — OPEN en attente ai-01
- c.382 PR #5908 hub SymbolicAI (+13/-11) — OPEN en attente ai-01
- c.383 PR #5912 hub Search §E (+1/-1) — OPEN MERGEABLE
- c.384 PR #5914 hub GenAI §E+L389 (+4/-2) — OPEN MERGEABLE
- **c.385 PR #5915 hub ML §E+L389 — OPEN à vérifier CI** (+3/-1) ← NEW

**Liens** : #4959 (greenlight multi-cycle P0/P1) #3973 (rollout feuille README) #4208 (EPIC prose pédagogique) #4956 (marathon parité jumeaux C#/Python) #3801 (registre SOTA owner-lane po-2024 C326 ML.NET 5 trainers SOTA) #4140 (Novikoff perceptron 0-sorry lake branché) #5049 (PR Roadmap Lean) #4038 (EPIC Roadmap Lean).

**Suite c.386+** : P1 hubs restants (Probas, QuantConnect), puis P2 (Sudoku, IIT, RL, CaseStudies, Vibe-Coding), puis README racine repo (LAST). Non bloquée par merges des 5 PRs (fichiers distincts, dépendances nulles).

**Forward ai-01** pour merge (L279 worker never merge, L143 SAFE).