### PR TITLE
fix(ict): repair stale nav breadcrumbs in ICT-19 notebooks (flat layout)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery-Raffinement.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# ICT-19 — Raffinement et résolution des stubs (tranche 3)\n",
     "\n",
-    "[← ICT-19 squelette (tranche 2)](../ICT-19-EnjeuBattery/ICT-19-EnjeuBattery.ipynb) · [↑ ICT-Series](../README.md) · [→ ICT-20](../ICT-20-FeatureCatastrophes/ICT-20-FeatureCatastrophes.ipynb) · [Epic #4588](https://github.com/jsboige/CoursIA/issues/4588)\n",
+    "[← ICT-19 squelette (tranche 2)](ICT-19-EnjeuBattery.ipynb) · [↑ ICT-Series](README.md) · [→ ICT-20](ICT-20-FeatureCatastrophes.ipynb) · [Epic #4588](https://github.com/jsboige/CoursIA/issues/4588)\n",
     "\n",
     "**Strate 5 — suite de la batterie ENJEU (GPU-free).**\n",
     "\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-19-EnjeuBattery.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# ICT-19 — La batterie de l'ENJEU : auto-maintien vs pur dissipateur\n",
     "\n",
-    "[← ICT-18](../ICT-18-TimeArrowAndReversibilization/ICT-18-TimeArrowAndReversibilization.ipynb) · [↑ ICT-Series](../README.md) · [→ ICT-20](../ICT-20-FeatureCatastrophes/ICT-20-FeatureCatastrophes.ipynb) · [Epic #4588](https://github.com/jsboige/CoursIA/issues/4588)\n",
+    "[← ICT-18](ICT-18-ArrowOfTimeReversibilization.ipynb) · [↑ ICT-Series](README.md) · [→ ICT-20](ICT-20-FeatureCatastrophes.ipynb) · [Raffinement tranche 3](ICT-19-EnjeuBattery-Raffinement.ipynb) · [Epic #4588](https://github.com/jsboige/CoursIA/issues/4588)\n",
     "\n",
     "**Strate 5 — théorie fondatrice cross-substrat (GPU-free).**\n",
     "\n",


### PR DESCRIPTION
fix(ict): repair stale subdir-layout nav breadcrumbs in ICT-19 notebooks

The two ICT-19 notebooks (EnjeuBattery skeleton + EnjeuBattery-Raffinement
companion) carried nav breadcrumbs written for a per-notebook subdir layout
(../ICT-NN-Name/ICT-NN-Name.ipynb, ../README.md). That layout was flattened to
ICT-Series/*.ipynb; the series README was updated to flat links but the
in-notebook breadcrumbs were not — leaving 4 dead links + a breadcrumb that
resolved to the parent IIT/README.md instead of ICT-Series/README.md. The
ICT-18 link also used a wrong name (TimeArrow vs the actual ArrowOfTime).

Fixes (markdown-only, cell 0 of each notebook):
- ICT-19-EnjeuBattery: <- ICT-18, ^ ICT-Series, -> ICT-20 now flat+correct;
  added a forward companion link -> "Raffinement tranche 3".
- ICT-19-EnjeuBattery-Raffinement: <- ICT-19 squelette, ^ ICT-Series, -> ICT-20
  now flat+correct.

On the "duplicate number" smell (See #4588 dispatch): NOT a bug. The two
notebooks are a deliberate 2-tranche pair — tranche 2 = exercise skeleton
(3 C.1 stubs), tranche 3 = refinement + RESOLUTION of those stubs. Merging
would leak solutions into the exercise notebook (exercise/example cohabitation
rule); renumbering to ICT-20 collides with the existing FeatureCatastrophes.
The pairing is already documented in ICT-Series/README.md L129. This PR just
makes the pairing explicit in-nav and repairs the broken breadcrumbs.

Validation:
- nbformat v4 valid both (26 / 18 cells preserved).
- Link audit: 0 broken, 7 resolve (flat layout).
- Markdown-only change -> C.2 exception (existing outputs stay valid, no
  re-execution). No code cell, no output touched.
- LF-only, +2/-2, 0 secret patterns.

See #4588

Co-Authored-By: Claude-Code <noreply@anthropic.com>
