### PR TITLE
docs(lean): document P5 vacuity analysis on p5_inductive_step (c.307a)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -3003,7 +3003,34 @@ theorem p5_large_n_jump (n : Nat) (g : Grid) (h : BoxAssezGrand g n)
 
 /-- **P5.3** (glue): the full induction on `n`, with a case split on
     `n < 2^(k-2)` (P5.1) vs `n ≥ 2^(k-2)` (P5.2). Stays `sorry` until both
-    sub-lemmas are proven. -/
+    sub-lemmas are proven.
+
+    **P5 vacuity analysis (c.307a, 2026-07-10)**: on non-empty grids, the
+    hypotheses of the `¬ hsmall` branch are jointly unsatisfiable — see
+    `p5_large_n_hyps_unsat` (L425). Concretely:
+    - `BoxAssezGrand g n` caps `n ≤ 2` (`boxAssezGrand_nonempty_le_two`,
+      proven L358);
+    - `n ≥ jumpSize (gridToMacroCellWithOffset g).2.level` requires
+      `n ≥ 8` (`jumpSize_gridLevel_ge_eight`, proven L411).
+    The conjunction `2 ≤ n ∧ n ≥ 8` is impossible. Hence the large-n arm
+    is vacuous on non-empty grids, and `hashlife_correct` would be proven
+    if the empty-grid arm (`g = []`) is closed separately (by direct unfold
+    of `evolveHashlifeFastAux` on `g = []`, which takes the guard-false
+    direct `evolve n g` arm because empty grids yield a level-0 MacroCell
+    whose `lvl ≥ 2` guard is false).
+
+    **Honest disclosure**: this vacuity closure is STRUCTURAL, not
+    operational. It proves `hashlife_correct` (the bounded correctness
+    theorem) WITHOUT actually exercising a Hashlife jump on non-empty
+    grids — `box_assez_grand` is too tight (padding margin = 2 cells) to
+    allow `n ≥ 8`. The genuine P5.2 jump-step correctness
+    (`p5_large_n_jump`, L2999) remains an open sorry, gated on the P4 unlock
+    per the section header at L2982. The vacuity closure demonstrates that
+    `hashlife_correct`'s STATEMENT is satisfiable on canonical witness
+    patterns (`hashlife_correct_implies_block_4` / `_glider_8`), but the
+    theorem needs a SATISFIABILITY REDESIGN (`box_assez_grand` → a weaker
+    hypothesis that allows `n ≥ 8`) before the genuine P5 jump can be
+    proven. -/
 theorem p5_inductive_step (n : Nat) (g : Grid) (h : BoxAssezGrand g n) :
     evolveHashlifeFast n g = evolve n g := by
   by_cases hsmall : n < jumpSize (gridToMacroCellWithOffset g).2.level


### PR DESCRIPTION
## Scope (HONEST, docstring-only)

This PR is **NOT** a sorry-closure PR. It is a docstring-only update to `p5_inductive_step`'s documentation that captures the P5 vacuity analysis identified during c.307 investigation. **0 sorries closed, 0 sorries added.** Sorry count remains at 3 tactical (L2673, L3002, L3038).

## What this PR commits

### `HashlifeCorrectness.lean` — 28 insertions, 1 deletion (pure docstring)

Adds a consolidated P5 vacuity analysis section to `p5_inductive_step`'s docstring, citing:
- `p5_large_n_hyps_unsat` (L425) — joint unsatisfiability of `BoxAssezGrand` ∩ `n ≥ jumpSize` on non-empty grids
- `boxAssezGrand_nonempty_le_two` (L358, proven)
- `jumpSize_gridLevel_ge_eight` (L411, proven)

It also documents the operational gap: P5.2 (`p5_large_n_jump`) needs a `box_assez_grand` relaxation (padding margin 2 → ≥8) before any genuine non-vacuous jump-step proof is possible. The current vacuity only demonstrates `hashlife_correct`'s STATEMENT is satisfiable on canonical witness patterns.

## Why this is delivered as a docs PR rather than c.307 closure

### Anti-regression HARD barrier

Closing `p5_inductive_step` operationally requires:
1. Proving `gridToMacroCellWithOffset [].2.level = 0` (level-lemma for empty grids)
2. Using it in `split_ifs` to discharge the unreachable `lvl ≥ 2 ` true-branch goal

Step 2 introduces a NEW sorry in the empty-grid unfold (the `succ k` arm of the induction produces a `2 ≤ (gridToMacroCellWithOffset []).2.level ∧ ...` hypothesis that `simp`/`native_decide` cannot reduce through the macro-cell wrapper because of free variables or definitional opacity at the inductive call site).

Net sorry effect: L3038 `· sorry` replaced by an equivalent sorry in a new branch → sorry count delta = 0, but the proof is now in a structurally worse shape (deferred unfold at the level-lemmand bound rather than at the by_cases gap). This violates anti-regression HARD (L268 #6 from c.302 lineage: `grep -c sorry` flattening without quality improvement is the equivalent of gaming the metric).

### Decision: deliver the structural insight, defer the operational proof

Per L335 anti-monotonie ("≥1 PR/wakeup plancher, jamais plafond") and the multi-failure signal (4 closure attempts reverted), the responsible action is to:
1. **Capture the vacuity insight in docs** (this PR) so future passes don't re-discover it
2. **Post honest `[IN-FLIGHT]` disclosure** on workspace dashboard  
3. **Pivot next cycle** to a different scope (likely c.307b: Shapley+en from #4365)

## Validation

- `grep -c sorry` baseline = 40 (line-occurrences, mostly prose) → after = 40
- Tactical sorries at L2673, L3002, L3038 = unchanged
- LF line endings preserved (`git ls-files --eol` = i/lf w/lf, L268 #6 reaffirmed)
- `git diff origin/main...HEAD` = 1 file, +28/-1, single-docstring addition (catalog-pr-hygiene HARD-1 safe: no catalog touched)

## Linked issues

- See #3846 (parent EPIC: P4 + P5 sorries)
- Refs #5890 (previous P5 redesign N1 commit by c.290)
- Genuine next step: **redesign** `box_assez_grand` (padding margin 2 → ≥8) so `n ≥ jumpSize` becomes satisfiable on non-empty grids, then prove `p5_large_n_jump` operationally — that's c.308/c.309+ scope, NOT this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)