### PR TITLE
fix(probas): restore real French in PyMC-16 (très concentré, not tresconcentré)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
@@ -729,7 +729,7 @@
     "- $\\ell$ **grand** ($\\gg 1$) : fonctions tres lisses, frontière quasi-linéaire — risque de **sous-apprentissage** (panneau `ls=5.0` de la section 1).\n",
     "- $\\ell$ **apris** : le prior `LogNormal` + NUTS laisse les données choisir le $\\ell$ optimal (moyenne posterieure affichee après l'inference ci-dessus).\n",
     "\n",
-    "C'est l'un des avantages du GP **bayesien** sur un noyau a hyperparamètre fixe : l'incertitude sur $\\ell$ est propagee dans les predictions, et le modèle peut desactiver de lui-même les echelles de bruit inutiles (Automatic Relevance Determination, cf. [PyMC-10](PyMC-10-Model-Selection.ipynb)). L'exercice 3 ci-dessous invite a verifier empiriquement l'effet d'un priorconcentré sur $\\ell$."
+    "C'est l'un des avantages du GP **bayesien** sur un noyau a hyperparamètre fixe : l'incertitude sur $\\ell$ est propagee dans les predictions, et le modèle peut desactiver de lui-même les echelles de bruit inutiles (Automatic Relevance Determination, cf. [PyMC-10](PyMC-10-Model-Selection.ipynb)). L'exercice 3 ci-dessous invite a verifier empiriquement l'effet d'un prior concentré sur $\\ell$."
    ]
   },
   {
@@ -864,14 +864,14 @@
    ],
    "source": [
     "# Exercice 3 : effet du prior sur ls.\n",
-    "# Si on met un prior tresconcentré sur une grande longueur (ls ~ LogNormal(2.0, 0.1)),\n",
+    "# Si on met un prior très concentré sur une grande longueur (ls ~ LogNormal(2.0, 0.1)),\n",
     "# le GP devient presque lineaire (sous-apprentissage). Verifiez-le.\n",
     "# Indice : changez mu de 0.0 a 2.0 dans pm.LogNormal(\"ls\", mu=2.0, sigma=0.1).\n",
-    "# Etape 1 : re-entrainez avec ce priorconcentré grand.\n",
+    "# Etape 1 : re-entrainez avec ce prior concentré grand.\n",
     "# Etape 2 : comparez la frontiere (qui doit devenir quasi-lineaire) et l'accuracy.\n",
-    "# Question : que se passe-t-il avec un priorconcentré petit (mu=-1.5) ?\n",
+    "# Question : que se passe-t-il avec un prior concentré petit (mu=-1.5) ?\n",
     "\n",
-    "prior_ls_result = None  # TODO etudiant : modele avec priorconcentré grand sur ls\n",
+    "prior_ls_result = None  # TODO etudiant : modele avec prior concentré grand sur ls\n",
     "print(\"Exercice 3 a completer : effet du prior sur la longueur de correlation.\")\n"
    ]
   },


### PR DESCRIPTION
## Fix the word-gluing introduced by #5951

Per ai-01 DM (msg-...ere53x): the CJK-parasite substitution merged via #5951 glued words instead of restoring proper French. On main now:
- `tresconcentré` should be `très concentré` (missing accent + space)
- `priorconcentré` should be `prior concentré` (missing space)

Note: #5951 was already MERGED when the re-fix was attempted, so the buggy text is on main — this is a fresh corrective PR (the push to the merged branch went nowhere).

### Change
5 occurrences (1 markdown cell17 + 4 code-comment lines in cell21):
- `tresconcentré` → `très concentré`
- `priorconcentré` → `prior concentré`

### C.2 exception (no re-exec)
Comment-only change. Outputs **byte-identical** (exec_counts 1-11, 23 outputs preserved) — verified firsthand. No re-execution needed.

LF-only, 0 secret patterns. Owner: po-2025 strict (Probas/PyMC = native partition).

See #3966