### PR TITLE
feat(hashlife): N2 step 3 bridge lemma padCenter2_margin >= jumpReach (c.309)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1060,6 +1060,67 @@ theorem padCenter2_correct_block_level1 :
     (padCenter2 c).toCellsAux (-3 : Int) (-3 : Int) = c.toCellsAux 0 0 := by
   native_decide
 
+/-! ### N2 step 3 bridge: `padCenter2` margin ≥ Chebyshev jump reach
+
+The geometric precondition for `p5_large_n_jump`: the `padCenter2`
+margin `(3·2^(k-1))` strictly contains the Hashlife jump reach
+(`2^k`) for any level-`k ≥ 1` MacroCell. Proving this eliminates the
+last geometric question before `p5_large_n_jump` can be assembled:
+
+    a level-`k` MacroCell has side `2^k`; padded by 2 levels it has
+    side `2^(k+2) = 4·2^k`; the per-side margin is `(4·2^k - 2^k)/2
+    = 3·2^(k-1)`. The Hashlife jump size is `jumpSize k = 2^k`, and
+    by `evolve_reach_chebyshev` (lightCone.lean L270-298, N2 step 2),
+    any cell alive after `2^k` generations lies within Chebyshev
+    distance `2^k` of an initial cell. Since `2^k ≤ 3·2^(k-1)` for
+    `k ≥ 1`, the Chebyshev reach fits inside the margin with a factor
+    of 3/2 to spare.
+
+This is the **pure-arithmetic half** of the light-cone ↔ padding
+bridge. It is independently provable (no coordinate hypotheses, no
+`MacroCell` arguments), so it can be wired into `p5_large_n_jump`
+once the P4 inductive step (`p4_succ_membership`) closes.
+
+Sorry-free, additive, no existing sorries modified (§D anti-regression
+safe). EPIC #3846 (N2 step 3, research-Long dedicated session). -/
+
+/-- **Pad-margin ≥ jump-reach** (pure arithmetic, sorry-free).
+    For a level-`k ≥ 1` MacroCell, the per-side `padCenter2` margin
+    `3·2^(k-1)` is strictly larger than the Hashlife jump size `2^k`
+    — i.e. the margin contains the Chebyshev reach of the jump.
+    Equivalently, the side length `4·2^k` of the padded cell exceeds
+    the jump reach `2·2^k` (Chebyshev radius `2^k` doubled) by a
+    factor of 2.
+
+    Proof: distribute `3 = 1 + 2`, reduce goal to
+    `2^k ≤ 2^(k-1) + 2·2^(k-1)`, then rewrite
+    `2·2^(k-1) = 2^((k-1)+1) = 2^k` via `pow_succ'` and the
+    `(k-1)+1 = k` linear fact (the only piece `omega` closes here;
+    the actual power rewrite is not linear, hence explicit). Finally
+    `Nat.add_comm` puts the goal in the form `2^k ≤ 2^k + 2^(k-1)`,
+    closed by `Nat.le_add_right`. -/
+theorem padCenter2_margin_ge_jumpReach (k : Nat) (hk : 1 ≤ k) :
+    (2 : Nat)^k ≤ (3 : Nat) * (2 : Nat)^(k - 1) := by
+  have hk_eq : (k - 1) + 1 = k := by omega
+  rw [show (3 : Nat) = 1 + 2 from rfl, Nat.add_mul, Nat.one_mul]
+  have h2k : (2 : Nat) * (2 : Nat)^(k - 1) = (2 : Nat)^k := by
+    rw [← pow_succ', hk_eq]
+  rw [h2k, Nat.add_comm]
+  exact Nat.le_add_right _ _
+
+/-- **Strict margin headroom** (consequence of the above).
+    The margin exceeds the reach by exactly `2^(k-1)` cells per side —
+    a 50% headroom over the tight Chebyshev-`2^k` ball. -/
+theorem padCenter2_margin_strictly_gt_jumpReach (k : Nat) (hk : 1 ≤ k) :
+    (2 : Nat)^k < (3 : Nat) * (2 : Nat)^(k - 1) := by
+  have hk_eq : (k - 1) + 1 = k := by omega
+  rw [show (3 : Nat) = (1 : Nat) + 2 from rfl, Nat.add_mul, Nat.one_mul]
+  have h2k : (2 : Nat) * (2 : Nat)^(k - 1) = (2 : Nat)^k := by
+    rw [← pow_succ', hk_eq]
+  rw [h2k, Nat.add_comm]
+  apply Nat.lt_add_of_pos_right
+  exact Nat.two_pow_pos (k - 1)
+
 /-! ## Well-formedness of MacroCells
 
 `MacroCell.level` only walks the `nw` spine, so `c.level = k + 2` does


### PR DESCRIPTION
## Contexte

EPIC #3846 (Hashlife correctness). Ce PR ferme **N2 step 3** = la première moitié arithmétique du pont light-cone ↔ padding, qui doit débloquer p5_large_n_jump.

## Le pont géométrique

Pour une MacroCell de niveau k ≥ 1 :
- côté : 2^k
- après padCenter2 : côté 2^(k+2) = 4·2^k
- marge par côté : (4·2^k - 2^k)/2 = 3·2^(k-1)
- jumpSize k = 2^k (Chebyshev reach de l'évolution, par evolve_reach_chebyshev L270-298 lightCone.lean, N2 step 2)

Le lemme affirme que la marge **contient strictement** le reach du jump avec 50% de marge au-dessus de la boule de Chebyshev tight.

## Deux théorèmes

```lean
theorem padCenter2_margin_ge_jumpReach (k : Nat) (hk : 1 ≤ k) :
    (2 : Nat)^k ≤ (3 : Nat) * (2 : Nat)^(k - 1)

theorem padCenter2_margin_strictly_gt_jumpReach (k : Nat) (hk : 1 ≤ k) :
    (2 : Nat)^k < (3 : Nat) * (2 : Nat)^(k - 1)
```

## Pattern de preuve (15 itérations v3..v17)

```lean
have hk_eq : (k - 1) + 1 = k := by omega    -- linear
rw [show (3 : Nat) = 1 + 2 from rfl, Nat.add_mul, Nat.one_mul]
have h2k : (2 : Nat) * (2 : Nat)^(k - 1) = (2 : Nat)^k := by
  rw [← pow_succ', hk_eq]                  -- NON-linear (omega fails)
rw [h2k, Nat.add_comm]
exact Nat.le_add_right _ _                  -- (et apply Nat.lt_add_of_pos_right + Nat.two_pow_pos)
```

Notes :
- pow_succ' : ∀ n, a * a^n = a^(n+1) (vs pow_succ qui demande Monoid instance)
- Nat.two_pow_pos (k-1) : ∀ n, 0 < 2^n, single-arg
- Nat.lt_add_of_pos_right : apply + exact form (la forme exact _ (h_pos) a échoué en v16)

## Lake build verification

- **Local : `lake build` EXIT 0** : "Build completed successfully (2985 jobs)" — mathlib rebuild post-L380 cache wipe (~110s sur HashlifeMarginDemo, ~91s sur LightCone, 0 errors, 0 new sorries). Les 3 sorries pré-existants (L2697/L3060/L3095) sont NON modifiés par ce PR (anti-régression §D safe).
- **CI Lean Conway : SUCCESS** à 01:00:49Z, ~4 min d'exécution.
- **BridgeTest17.lean isolé** : EXIT 0 sur les deux théorèmes (verification pattern avant insertion en module).

## Justifications §B body prooflog

| Critère | Status | Preuve |
|---------|--------|--------|
| `grep -c sorry` avant/après par fichier modifié | 0 → 0 (HashlifeCorrectness.lean) | Aucun sorry ajouté ou retiré |
| Lien Lake build SUCCESS CI | ✅ | ci / Lean CI (conway_lean) SUCCESS |
| Lien Lake build SUCCESS local | ✅ | "Build completed successfully (2985 jobs)" |
| Proof integrity SUCCESS (axiom check) | ✅ | Aucun axiome ajouté ; seulement nat elementary arithmetic |
| Si refactor du prover Python | N/A | Pas de refactor prover |

## §A atomicité

- **1 fichier / 61 lignes / 1 domaine (Lean Hashlife) / 1 feature (bridge lemma)** : §A PASS.

## Anti-régression §D

- 0 ligne existante modifiée, seulement insertion additive à partir de L1063.
- 3 sorries pré-existants (L2697/L3060/L3095) inchangés.

## Catalog / hygiene

- LF propre : `git ls-files --eol` = `i/lf w/lf attr/text eol=lf`.
- Catalogue inchangé : pas de régénération manuelle (catalog-pr-hygiene R1).
- Base fraîche : rebase sur origin/main post-c.391 (04f8edf91 #5953).

## Anti-monotonie L335 vs c.308

| Axe | c.308 | c.309 | Status |
|-----|-------|-------|--------|
| Registre | Shapley_en sed 134 sites | Bridge lemma arithmetic | ✅ distinct |
| Artefact | Sibling _en.lean | Module docstring inline | ✅ distinct |
| Sémantique | FR+EN binaire | FR-only | ✅ distinct |

## L279 / L280 respectés

- L279 : `gh pr merge` NON lancé par po-2026 (worker INTERDIT). Sweep + merge = ai-01.
- L280 : pas de CronCreate. Worker cron `e899ad57 */30 * * * * /continue` actif.

## Status CI complet

| Check | Conclusion |
|-------|------------|
| Catalog Guard | ✅ SUCCESS |
| CodeQL Analyze (actions/csharp/js/py) | ✅ SUCCESS |
| **ci / Lean CI (conway_lean)** | ✅ **SUCCESS** |
| Regression Guard | ✅ SUCCESS |
| Gitleaks | ✅ SUCCESS |
| Stale Base Branch | ✅ SUCCESS |

See #3846