### PR TITLE
fix(prover): resurrect dead LSP lemma-search on depth-3 Lean files

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -72,6 +72,28 @@ def _resolve_lake_command(extra_args: List[str], cwd: str = None) -> Tuple[List[
     return ["lake", *extra_args], env
 
 
+def _has_lakefile(p: Path) -> bool:
+    """True if directory ``p`` holds a Lake manifest (lakefile.lean/.toml)."""
+    return (p / "lakefile.lean").exists() or (p / "lakefile.toml").exists()
+
+
+def _find_lake_root(start: Path) -> Optional[Path]:
+    """Walk up from ``start`` to the nearest directory holding a lakefile.
+
+    Returns the Lake root, or ``None`` if none is found before the filesystem
+    root. Used to re-root callers that derived a too-deep ``project_dir`` from
+    a nested file path (e.g. ``conway_lean/Conway`` for a ``Conway/Life/*``
+    file, which holds no lakefile).
+    """
+    cur = start
+    while True:
+        if _has_lakefile(cur):
+            return cur
+        if cur == cur.parent:
+            return None
+        cur = cur.parent
+
+
 class LeanVerifier:
     """Verify Lean 4 files using lake build with content-hash caching.
 
@@ -133,9 +155,6 @@ class LeanVerifier:
         # `relative_path` with the directory names we passed (so the module name
         # resolves to `Conway.Life.HashlifeCorrectness`). Backward-compatible: a
         # project_dir that already holds the lakefile is used unchanged.
-        def _has_lakefile(p: Path) -> bool:
-            return (p / "lakefile.lean").exists() or (p / "lakefile.toml").exists()
-
         if not _has_lakefile(project):
             cur = project
             prefix = []
@@ -372,38 +391,31 @@ class LeanVerifier:
             dict with 'success', 'suggestions' (list of found proofs), 'raw_output'
         """
         project = Path(self.project_dir)
-        short_name = module_name.split(".")[-1]
+        # The persistent verifier singleton is pinned to whatever project_dir the
+        # first caller passed — for a nested file that is a too-deep dir with no
+        # lakefile (e.g. `conway_lean/Conway`). `verify_project_file` re-roots per
+        # call, so `search_lean` self-heals the same way. Walk up to the real Lake
+        # root (no-op when project already holds a lakefile).
+        if not _has_lakefile(project):
+            root = _find_lake_root(project)
+            if root is not None:
+                project = root
+
+        # Feed the search snippet to `lake env lean --stdin` — the same fast path
+        # `verify_project_file`/`check_axioms` use. The prior implementation wrote a
+        # temp module inside the source tree and ran `lake build <module>`, which
+        # forces Lake to traverse the whole dependency graph (Mathlib) before
+        # elaborating: on a heavy project that overruns the timeout and returns zero
+        # suggestions every time (root cause of `actual_iterations: 0` on the P4/P5
+        # traces). `lake env lean` sets LEAN_PATH from the build dir, so `import`
+        # resolves against prebuilt oleans with no graph walk (~4 s vs 120 s here).
         snippet = (
             f"import {module_name}\n"
             f"example : {goal} := by\n"
             f"  {tactic}\n"
         )
-
-        # Derive temp file from module_name (e.g. "Grothendieck.Calibration"
-        # -> project/Grothendieck/_LeanSearch.lean). Falls back to scanning
-        # subdirectories if the derived path doesn't exist.
-        module_parts = module_name.split(".")
-        if len(module_parts) > 1:
-            tmp_file = project / module_parts[0] / "_LeanSearch.lean"
-        else:
-            tmp_file = project / "SocialChoice" / "_LeanSearch.lean"
-        if not tmp_file.parent.exists():
-            for subdir in project.iterdir():
-                if subdir.is_dir() and (subdir / "lakefile.lean").exists():
-                    continue
-                if subdir.is_dir():
-                    tmp_file = subdir / "_LeanSearch.lean"
-                    break
-
+        cmd, env = _resolve_lake_command(["env", "lean", "--stdin"], cwd=str(project))
         try:
-            tmp_file.write_text(snippet, encoding="utf-8")
-
-            relative = tmp_file.relative_to(project)
-            module = str(relative).replace("/", ".").replace("\\", ".")
-            if module.endswith(".lean"):
-                module = module[:-5]
-
-            cmd, env = _resolve_lake_command(["build", module], cwd=str(project))
             result = subprocess.run(
                 cmd,
                 cwd=str(project),
@@ -411,11 +423,10 @@ class LeanVerifier:
                 text=True,
                 timeout=120,
                 env=env,
+                input=snippet,
             )
-
             output = result.stdout + "\n" + result.stderr
             suggestions = self._extract_suggestions(output, tactic)
-
             return {
                 "success": len(suggestions) > 0,
                 "suggestions": suggestions,
@@ -430,26 +441,45 @@ class LeanVerifier:
                 "error": str(e),
                 "raw_output": "",
             }
-        finally:
-            try:
-                tmp_file.unlink()
-            except OSError:
-                pass
 
     @staticmethod
     def _extract_suggestions(output: str, tactic: str) -> list:
         """Extract proof suggestions from exact?/apply? output."""
+        def _clean(s: str) -> str:
+            # Drop a leading "[apply]"/"[exact]" tag Lean prepends to the tactic.
+            s = s.strip()
+            if s.startswith("[") and "]" in s:
+                s = s[s.index("]") + 1:].strip()
+            return s.rstrip(",").strip()
+
         suggestions = []
-        for line in output.split("\n"):
-            line = line.strip()
+        lines = output.split("\n")
+        for i, raw in enumerate(lines):
+            line = raw.strip()
             if "Try this:" in line:
-                proof = line.split("Try this:")[-1].strip()
-                suggestions.append({"tactic": proof, "source": tactic})
-            elif tactic == "exact?" and "exact " in line and "error" not in line.lower():
-                proof = line.strip().rstrip(",")
-                if proof.startswith("exact "):
-                    suggestions.append({"tactic": proof, "source": "exact?"})
-        return list({s["tactic"]: s for s in suggestions}.values())
+                after = line.split("Try this:")[-1].strip()
+                if after:
+                    suggestions.append({"tactic": _clean(after), "source": tactic})
+                    continue
+                # Two-line form: "Try this:" alone, tactic on the next non-empty,
+                # non-diagnostic line (e.g. "  [apply] exact True.intro").
+                for nxt in lines[i + 1:]:
+                    n = nxt.strip()
+                    if not n:
+                        continue
+                    if n.lower().startswith(("warning:", "error:")) or ": error:" in n:
+                        break
+                    suggestions.append({"tactic": _clean(n), "source": tactic})
+                    break
+            elif tactic in ("exact?", "apply?") and "error" not in line.lower():
+                cand = _clean(line)
+                if cand.startswith(("exact ", "apply ", "refine ")):
+                    suggestions.append({"tactic": cand, "source": tactic})
+        uniq = {}
+        for s in suggestions:
+            if s["tactic"]:
+                uniq.setdefault(s["tactic"], s)
+        return list(uniq.values())
 
     @staticmethod
     def _extract_axioms(output: str) -> list:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1801,17 +1801,17 @@ DEMOS = {
     62: {
         "name": "HASHLIFE_P4_SUCC_MEMBERSHIP",
         "file": str(CONWAY_HASHLIFE_FILE) if CONWAY_HASHLIFE_FILE else "",
-        "line": 2527,
+        "line": 2673,
         "sorry_type": "sorry_replacement",
         "theorem_name": "p4_succ_membership",
         "theorem": "p4_succ_membership",
         "imports": CONWAY_HASHLIFE_IMPORTS,
         "description": (
             "BG-prover target (hashlife nibble plan #3846, N3): residual sorry in\n"
-            "noncomputable def p4_succ_membership (declared L2490 of\n"
-            "HashlifeCorrectness.lean). The whnf wall is already traversed at\n"
-            "L2519-2530 (node16_level_ne_two -> rw [if_neg hne2] ->\n"
-            "rw [mem_toGrid_node]); what remains is the offset-matching assembly:\n"
+            "noncomputable def p4_succ_membership (declared L2636, residual sorry\n"
+            "L2673 of HashlifeCorrectness.lean). The whnf wall is already traversed\n"
+            "around L2648-2665 (node16_level_ne_two L2660 -> rw [if_neg hne2] L2663\n"
+            "-> rw [mem_toGrid_node]); what remains is the offset-matching assembly:\n"
             "prove each `out_*.toGrid (off_*, off_*)` membership via\n"
             "centralCorrect_mem (gate G2, merged #4812) plus the induction\n"
             "hypothesis `centralCorrect q_* (k-1)` extracted from `_h3`, bridged\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -26,6 +26,40 @@ _HONEST_SORRY_RE = re.compile(
 _SORRY_TOKEN_RE = re.compile(r"\bsorry\b")
 
 
+def _has_lakefile(p: Path) -> bool:
+    """True if directory ``p`` holds a Lake manifest (lakefile.lean/.toml)."""
+    return (p / "lakefile.lean").exists() or (p / "lakefile.toml").exists()
+
+
+def resolve_lake_module(filepath) -> Tuple[str, str]:
+    """Resolve the Lake project root and dotted module name for a ``.lean`` file.
+
+    Walks up from the file's directory to the nearest directory holding a
+    lakefile, then builds the import path from that root. For
+    ``conway_lean/Conway/Life/HashlifeCorrectness.lean`` this returns
+    ``(".../conway_lean", "Conway.Life.HashlifeCorrectness")``.
+
+    The prover's legacy assumption (``project_dir = <file>.parent.parent`` and
+    ``module = <subdir>.<stem>``) only holds for files directly under the top
+    package (e.g. ``Conway/Nim.lean``); it breaks for deeper files, yielding a
+    project dir with no lakefile and a module name missing its package prefix.
+    This helper replaces that assumption. If no lakefile is found on the way up,
+    it falls back to the legacy depth-2 derivation so callers keep working on
+    non-Lake or oddly-laid-out trees.
+    """
+    p = Path(filepath).resolve()
+    stem = p.stem
+    cur = p.parent
+    prefix = []
+    while cur != cur.parent and not _has_lakefile(cur):
+        prefix.insert(0, cur.name)
+        cur = cur.parent
+    if _has_lakefile(cur):
+        return str(cur), ".".join(prefix + [stem])
+    # Fallback: legacy depth-2 assumption (no lakefile found).
+    return str(p.parent.parent), f"{p.parent.name}.{stem}"
+
+
 def strip_lean_comments(content: str) -> str:
     """Strip Lean line comments (``--``) and nested block comments (``/- -/``).
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -483,11 +483,15 @@ class SearchTools:
         """Search Mathlib using Lean LSP via exact?/apply? tactics."""
         try:
             from .verifier import get_verifier
-            project_dir = str(Path(self._filepath).parent.parent)
-            verifier = get_verifier(project_dir)
-            subdir = Path(self._filepath).parent.name
-            stem = Path(self._filepath).stem
-            module_name = f"{subdir}.{stem}"
+            from .lean_utils import resolve_lake_module
+            # Resolve the real Lake root + dotted module by walking up to the
+            # lakefile. The legacy `parent.parent` / `<subdir>.<stem>` derivation
+            # silently broke for files nested deeper than the top package (e.g.
+            # `Conway/Life/HashlifeCorrectness.lean` -> module `Life.Hashlife...`
+            # missing the `Conway.` prefix), so `import <module>` failed and every
+            # LSP search returned zero suggestions.
+            lake_root, module_name = resolve_lake_module(self._filepath)
+            verifier = get_verifier(lake_root)
 
             results = []
             for tactic in ["exact?", "apply?"]:
@@ -501,7 +505,16 @@ class SearchTools:
                         "source": f"lsp_{tactic}",
                     })
             return results
-        except Exception:
+        except Exception as e:
+            # Do not swallow silently: a dead LSP channel used to look identical
+            # to "no lemmas found". Surface it in the trace for diagnosis.
+            if self._trace:
+                self._trace.log(
+                    agent="SearchAgent", role="tool",
+                    content=f"_search_via_lsp failed: {type(e).__name__}: {e}",
+                    duration_s=0.0, tool_name="search_via_lsp",
+                    tool_result="error",
+                )
             return []
 
     def search_local_lemmas(self) -> str:


### PR DESCRIPTION
## Contexte

Le canal de suggestion de lemmes Mathlib (`exact?`/`apply?`) du harnais prover renvoyait **0 lemme sur toutes les traces P4/P5 Hashlife** (`actual_iterations: 0`) — le prover cherchait à l'aveugle. Découvert pendant la session de planification GOL/Hashlife (#3846), corrigé sur mandat user « profitons-en pour corriger les erreurs de harnais ».

Trois bugs de harnais **indépendants**, tous reproduits firsthand et corrigés. Scope strict : `agent_tests/` uniquement — **le corps de preuve (`HashlifeCorrectness.lean`, owned po-2026) n'est pas touché.**

## Bug 1 — résolution de module depth-3

`_search_via_lsp` supposait un layout depth-2 (`project_dir = parent.parent`, `module = <subdir>.<stem>`). Sur `Conway/Life/HashlifeCorrectness.lean` (depth-3) ça donnait le module `Life.HashlifeCorrectness` (**préfixe `Conway.` manquant**) sous une racine sans lakefile → module inconnu → 0 suggestion.

**Fix** : helper partagé `resolve_lake_module(filepath) -> (lake_root, dotted_module)` (`lean_utils.py`) qui remonte jusqu'au lakefile le plus proche et pointe le module depuis cette racine → `Conway.Life.HashlifeCorrectness`. Testé depth-3 **et** depth-2 (rétro-compatible : `Conway.Nim`).

## Bug 2 — `search_lean` : self-heal racine + chemin rapide

Le singleton verifier est figé sur le `project_dir` du premier appelant (un dossier trop profond sans lakefile). `search_lean` applique désormais le **même walk-up** que `verify_project_file`. Il passe surtout de `lake build <module-temporaire>` — qui traverse **tout le graphe Mathlib** avant d'élaborer et dépassait le timeout 120 s **à chaque fois** → 0 suggestion — à **`lake env lean --stdin`**, le chemin rapide déjà utilisé par `check_axioms`.

**Mesuré : 19,3 s avec une vraie suggestion vs 120 s timeout sans aucune.** Supprime aussi la fragile dérivation de fichier temporaire dans l'arbre source.

## Bug 3 — parseur de suggestions

Lean émet maintenant une forme **deux-lignes taguée** (`Try this:` puis `  [apply] exact foo`). L'ancien parseur ne lisait que le texte après `Try this:` sur la même ligne (vide ici) et son fallback exigeait que la ligne commence par `exact ` — ce que `[apply] exact ...` ne fait pas. Résultat : suggestion à tactique **vide**, inutilisable pour le prover.

**Fix** : `_extract_suggestions` gère la forme deux-lignes + préfixe `[tag]`, et jette les tactiques vides → le prover reçoit le vrai texte du lemme.

## Vérification

- `search_lean('Conway.Life.Hashlife', 'True', 'exact?')` → `{'tactic': 'exact True.intro'}` en **19,3 s** (olean présent ; HashlifeCorrectness.olean absent car po-2026 rebuild en cours).
- Unit `_extract_suggestions` : formes deux-lignes `[apply]`, inline, `exact` nu, vide → OK.
- Guard suite : **133 passed** (3 échecs pré-existants `COOPERATIVE_GAMES_DIR` machine-path `C:\dev\CoursIA`/`CoursIA-2`, inchangés sur arbre pristine — non-régression prouvée via `git stash`).
- `py_compile` OK sur les 4 fichiers.

## Fichiers

- `agent_tests/prover/lean_utils.py` — helper `resolve_lake_module` + `_has_lakefile`
- `agent_tests/prover/tools.py` — `_search_via_lsp` : module_name correct + log diagnostic (fin du `except: return []` muet)
- `agent_tests/lean_server.py` — `search_lean` walk-up + `lake env lean --stdin` ; `_extract_suggestions` deux-lignes/tag ; DRY `_has_lakefile`/`_find_lake_root`
- `agent_tests/prover/config.py` — balisage demo 62 : `line` 2527→2673 + refs stale L2519-2530 corrigées

See #3846