### PR TITLE
fix(probas-pymc): drop numeric prefix from Conclusion/Synthese headers (5 notebooks, See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
@@ -2231,7 +2231,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Bilan : Systemes de recommandation bayesiens\n",
+    "## Bilan : Systemes de recommandation bayesiens\n",
     "\n",
     "| Modele | Usage | Points cles |\n",
     "|--------|-------|-------------|\n",

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
@@ -798,7 +798,7 @@
    "id": "9d255904",
    "metadata": {},
    "source": [
-    "## 7. Ponts avec la serie\n",
+    "## Ponts avec la serie\n",
     "\n",
     "| Direction | Lien | Relation |\n",
     "|-----------|------|----------|\n",
@@ -811,7 +811,7 @@
     "Prediction Problems*, ASME Journal of Basic Engineering 82(1). L'article fondateur du\n",
     "filtre de Kalman -- l'algorithme d'estimation le plus repandu en pratique.\n",
     "\n",
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Le **filtre de Kalman** est le pont entre le HMM discret de [PyMC-14](PyMC-14-Sequences.ipynb)\n",
     "et le monde continu. Sa puissance tient en trois proprietes : pour les systemes\n",

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
@@ -631,7 +631,7 @@
    "id": "d8873019",
    "metadata": {},
    "source": [
-    "## 6. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Le **point de rupture** complète la famille des séquences temporelles :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
@@ -596,7 +596,7 @@
    "id": "27390f5d",
    "metadata": {},
    "source": [
-    "## 7. Ponts avec la serie\n",
+    "## Ponts avec la serie\n",
     "\n",
     "| Direction | Lien | Relation |\n",
     "|-----------|------|----------|\n",
@@ -604,7 +604,7 @@
     "| <-> PyMC-18 | [PyMC-18 -- Change-Point](PyMC-18-Change-Point.ipynb) | Le change-Point est une **rupture** du taux ; la survie modelise un **delai unique**. Combiner les deux = survie a rupture (taux qui change a un instant latent). |\n",
     "| <-> PyMC-14 | [PyMC-14 -- Sequences (HMM)](PyMC-14-Sequences.ipynb) | Complete la famille temporelle : HMM (discret recurrent), Kalman (continu recurrent), survie (continu, duree unique). |\n",
     "\n",
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "L'analyse de survie complete la famille des modeles temporels : la quantite centrale est la\n",
     "**fonction de survie** $S(t) = P(T > t)$, dans la queue, pas au centre.\n",

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
@@ -875,7 +875,7 @@
    "id": "c0961fd6",
    "metadata": {},
    "source": [
-    "## 11. Synthese\n",
+    "## Synthese\n",
     "\n",
     "| Niveau | Question | Operateur | Methode PyMC |\n",
     "|--------|----------|-----------|--------------|\n",


### PR DESCRIPTION
## PyMC Conclusion/Synthese title standardization (5 notebooks, See #3966)

**Refs** EPIC #3966 (sweep §E mise en forme visuelle notebooks pedagogiques). Pattern **L3966-L1** = standardiser les titres canoniques `## N. Conclusion` / `## N. Synthese` / `## N. Bilan` / `## N. Ponts avec la serie` vers forme **sans prefix numerique** (`## Conclusion`, etc.). Transfere de c.405 RL Conclusion (8 nb MERGED) + c.413 Sudoku (#5978) + c.412 Probas/Infer (#5981) vers **Probas/PyMC** (Python lane).

## TL;DR

**Pivot C412-L1 sustained** = nouvelle substance **hors dette MD047** : standardiser le titre des cellules Conclusion/Synthese dans **5 notebooks Probas/PyMC** (kernel python3) en supprimant le prefixe numerique herite. Sweep scopée par famille Probas/PyMC = 1 livraison propre (5 fichiers, 7 NUMBERED standardises dont 2 cellules multi-NUMBERED). Substance §E intra-cellule **distincte** de MD047 format fichier.

## Notebooks cibles (7 NUMBERED in 5 files)

| Notebook | Cell | Kernelspec | Standardisations |
|----------|------|------------|------------------|
| `PyMC-5-Causal-Inference.ipynb` | 29 | python3 | `## 11. Synthese` -> `## Synthese` |
| `PyMC-15-Recommenders.ipynb` | 51 | python3 | `## 7. Bilan : Systemes...` -> `## Bilan : Systemes...` |
| `PyMC-17-Kalman-Filter.ipynb` | 19 | python3 | `## 7. Ponts avec la serie` -> `## Ponts...` **ET** `## 8. Conclusion` -> `## Conclusion` (multi-NUMBERED) |
| `PyMC-18-Change-Point.ipynb` | 20 | python3 | `## 6. Conclusion` -> `## Conclusion` |
| `PyMC-19-Survival-Analysis.ipynb` | 20 | python3 | `## 7. Ponts avec la serie` + `## 8. Conclusion` (multi-NUMBERED) |

## Scope strict toilettage §E intra-cellule

| Metrique | Valeur |
|----------|--------|
| Fichiers touches | 5 (.ipynb PyMC) |
| Substitutions | 7 NUMBERED (1+1+2+1+2) |
| Diff | +7/-7 byte-surgical |
| Catalog churn | 0 |
| Cellules code touchees | 0 (markdown source uniquement) |
| LF-only | OK (0 CRLF) |
| MD047 | OK (ends `}\n`) |

## Methodologie + G.1 disclosure

- **Scan firsthand** (git show origin/main, regex `^##\s+\d+\.\s+(?=(Conclusion|Synth[eè]se|Bilan|Ponts avec la [Ss][eé]rie))`) = **7 NUMBERED across 5 fichiers** (PyMC-17 et PyMC-19 = multi-NUMBERED, 2 headers canoniques dans la meme cellule).
- **Scope L3966-L1 strict** : drop prefix numerique **uniquement**. **PAS de restoration d accents** (EPIC #2876 separe, ~96% FP rate — pas de scope creep). Les titres restent en FR sans accents tel quel (`Synthese`, `serie`) — la restoration d accents est un grain #2876 dedie.
- **C.2 markdown exception** : cellules markdown uniquement -> aucun output/execution_count touche, pas de re-exec requise.
- **Count-check safety** : script abort si substitutions != attendu par cellule (1/1/2/1/2). Passe.

## Anti-collision (#5869)

- `gh pr list` au demarrage : aucune PR ouverte ne touche les titres Conclusion PyMC.
- **PyMC-16 exclu** : deja dans 2 PRs OPEN (#5956 CJK cell21, #5958 MD047 file-level) -> une 3e PR sur PyMC-16 creerait un conflit de cascade au merge. PyMC-16 Conclusion (cell18 `## 6. Synthese`) = follow-up apres merge de #5956/#5958.
- Mes autres PRs PyMC (#5962 CSV traduction) ne touchent pas les notebooks source.

## Owner-lane + variété

**Owner po-2025 strict** (Probas/PyMC = partition native Python). Pivot loin de MD047 (4e cycle MD047 precedent, self-commitment tenu) : cycle = substance §E intra-cellule. L335 anti-monoculture respecte.

**See #3966** (pas `Closes` — PR toilettage strict, EPIC reste ouvert).

Co-Authored-By: Claude <noreply@anthropic.com>