### PR TITLE
feat(kelly_lean): kellyFrac_pos_iff + growthGrad_zero_pos_iff (FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly.lean
@@ -198,4 +198,35 @@ theorem kelly_unique (β : Bet) (f : ℝ) (hf : Feasible β f) (hfne : f ≠ kel
       _ = 0 := by rw [hgrad0, mul_zero]
   linarith
 
+/-! ## 8. Critère pratique : parier ssi l'edge est positif
+
+La règle de décision opérationnelle du critère de Kelly : la fraction optimale
+`f*` est **strictement positive exactement quand le pari est favorable**
+(`b·p − q > 0`). Inversement, un pari défavorable (`b·p − q < 0`) donne `f* < 0` :
+le maximiseur bascule côté short. Le cas neutre `b·p − q = 0` (pari actuariellement
+équitable) donne `f* = 0` : ne rien parer est optimal. Cette équivalence de signe
+est l'incarnation formelle de la prose de `Growth.lean` (§« edge » `g'(0) = b·p − q`).
+-/
+
+/-- **Fraction de Kelly positive ssi pari favorable** : `f* > 0` exactement quand
+    l'« edge » `b·p − q` est strictement positif (le pari est avantageux, `b·p > q`).
+    C'est le critère pratique de Kelly — ne miser côté long que si l'on a un
+    avantage mathématique. Suit directement de `f* = (b·p − q)/b` avec `b > 0` :
+    le signe de la fraction égale celui du numérateur. -/
+theorem kellyFrac_pos_iff (β : Bet) :
+    0 < kellyFrac β ↔ 0 < β.b * β.p - q β := by
+  unfold kellyFrac
+  rw [lt_div_iff₀ β.hb_pos, zero_mul]
+
+/-- **Edge positif ssi Kelly positive** : le gradient du log-croissance en `f = 0`
+    (l'« edge » `g'(0) = b·p − q`, cf `growthGrad_zero`) est strictement positif
+    exactement quand la fraction optimale `f*` l'est. Concrétise formellement la
+    règle de décision « miser ssi `g'(0) > 0` » : la pente initiale du log-croissance
+    signe la direction de la mise optimale (long si positive, short si négative,
+    flat si nulle). -/
+theorem growthGrad_zero_pos_iff (β : Bet) :
+    0 < growthGrad β 0 ↔ 0 < kellyFrac β := by
+  rw [growthGrad_zero, kellyFrac_pos_iff]
+  constructor <;> intro h <;> linarith [mul_comm β.p β.b]
+
 end KellyLean

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
@@ -198,4 +198,34 @@ theorem kelly_unique (β : Bet) (f : ℝ) (hf : Feasible β f) (hfne : f ≠ kel
       _ = 0 := by rw [hgrad0, mul_zero]
   linarith
 
+/-! ## 8. Practical criterion: bet iff the edge is positive
+
+The operational decision rule of the Kelly criterion: the optimal fraction `f*` is
+**strictly positive exactly when the bet is favorable** (`b·p − q > 0`). Conversely,
+an unfavorable bet (`b·p − q < 0`) yields `f* < 0`: the maximizer flips to the short
+side. The neutral case `b·p − q = 0` (actuarially fair bet) yields `f* = 0`: staking
+nothing is optimal. This sign equivalence is the formal counterpart of the prose in
+`Growth.lean` (§ the "edge" `g'(0) = b·p − q`).
+-/
+
+/-- **Kelly fraction positive iff bet is favorable**: `f* > 0` exactly when the
+    "edge" `b·p − q` is strictly positive (the bet is advantageous, `b·p > q`). This
+    is Kelly's practical criterion — only bet the long side if one holds a
+    mathematical edge. Follows directly from `f* = (b·p − q)/b` with `b > 0`: the sign
+    of the fraction equals that of the numerator. -/
+theorem kellyFrac_pos_iff (β : Bet) :
+    0 < kellyFrac β ↔ 0 < β.b * β.p - q β := by
+  unfold kellyFrac
+  rw [lt_div_iff₀ β.hb_pos, zero_mul]
+
+/-- **Positive edge iff positive Kelly**: the log-growth gradient at `f = 0` (the
+    "edge" `g'(0) = b·p − q`, cf `growthGrad_zero`) is strictly positive exactly when
+    the optimal fraction `f*` is. Formally realizes the decision rule "bet iff
+    `g'(0) > 0`": the initial slope of the log-growth signs the direction of the
+    optimal stake (long if positive, short if negative, flat if zero). -/
+theorem growthGrad_zero_pos_iff (β : Bet) :
+    0 < growthGrad β 0 ↔ 0 < kellyFrac β := by
+  rw [growthGrad_zero, kellyFrac_pos_iff]
+  constructor <;> intro h <;> linarith [mul_comm β.p β.b]
+
 end KellyLean_en


### PR DESCRIPTION
## Summary

Adds the **practical Kelly decision criterion** as two theorems to `kelly_lean`, in both FR (`Kelly.lean`) and EN (`Kelly_en.lean`) mirrors — i18n parity per #4980. Pure addition (+61 lines, 0 deletion), sorry count 0 → 0.

### Theorems

1. **`kellyFrac_pos_iff`** — `0 < f* ↔ 0 < (b·p − q)`
   The optimal stake `f*` is strictly positive **exactly when the bet is favorable** (the edge `b·p − q > 0`). This is Kelly's practical criterion: only bet the long side if one holds a mathematical edge.
   *Proof*: direct from `f* = (b·p − q)/b` with `b > 0` — the sign of the fraction equals the sign of the numerator. `unfold kellyFrac; rw [lt_div_iff₀ β.hb_pos, zero_mul]`.

2. **`growthGrad_zero_pos_iff`** — `0 < g'(0) ↔ 0 < f*`
   The log-growth gradient at `f = 0` (the "edge", cf `growthGrad_zero`) is positive exactly when `f*` is. Formalizes the decision rule "bet iff `g'(0) > 0`": the initial slope of log-growth signs the optimal stake direction (long if positive, short if negative, flat if zero).
   *Proof*: `rw [growthGrad_zero, kellyFrac_pos_iff]; constructor <;> intro h <;> linarith [mul_comm β.p β.b]`.

### Why this is a genuine gap (not filler)

`Growth.lean`'s docstring (§ the "edge", lines 51–53) already **promises this result in prose** ("`g'(0) < 0 ⟺ f* < 0` (pari défavorable)...") and `growthGrad_zero` (line 56) formalizes `g'(0) = b·p − q`. But the sign equivalence was never stated as a theorem. This PR formalizes what the surrounding code already describes — closing a real gap.

### Lean §B compliance — build status

- `grep -c sorry` before/after: **0 → 0** (anti-regression verified, canonical counter stripping block+line comments).
- **`lake build` — IN PROGRESS**: cold Mathlib compile on this machine (~80 min so far, ~85% through Mathlib). The two proofs are simple sign-equivalence one-liners using standard Mathlib lemmas (`lt_div_iff₀`, `linarith`); high compile-confidence. **I will post `Lake build SUCCESS` + job count as a comment the moment it lands.** Per lean-merge-discipline, do **not** merge until that SUCCESS comment is posted.

See #4052 (Kelly criterion Epic). R6 substance (Lean new theorem), not docs/toilettage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)