### PR TITLE
fix(sudoku): restore French accents in Sudoku-14-BDD-Csharp cell 27 comment (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -1819,7 +1819,7 @@
     "    private void BuildConstraintMDDs()\n",
     "    {\n",
     "        // Pour une vraie approche MDD pure, on construirait 27 MDD complets.\n",
-    "        // Ici, on utilise une version simplifiee pour la demonstration.\n",
+    "        // Ici, on utilise une version simplifiée pour la démonstration.\n",
     "        \n",
     "        // Pour chaque ligne, on vérifie que les valeurs sont distinctes\n",
     "        // en utilisant une méthode directe plus efficace que le MDD complet.\n",


### PR DESCRIPTION
## Scope

#2876 follow-up to **#5976 (merged)**. Cell 27 was excluded from #5976 to avoid cell-level conflict; now post-merge, this fixes the residual comment-only accents.

## Fixes (2, comment-only)

| Cell | Line | Fix |
|------|------|-----|
| 27 | L43 `// ...version simplifiee pour la demonstration` | simplifiee → simplifi**é**e · demonstration → démonstrat**ion** |

Both on a single `//` comment line (no executable code, no string literals).

## Methodology (#2876 4-gate)

1. **NFD+Mn firsthand scan** of `origin/main` (post-#5976 merge).
2. **Tight-stem rescan**: unambiguous stems only.
3. **G.1 char-walk**: diff = exactly 2 accent additions, 0 collateral.
4. **Scope prose+comments ONLY**.

### FP excluded (eyeball)
- **Cell 24 `exemple`** (`Testons le produit avec un petit exemple`) — `exemple` takes **no accent** in FR (correct as-is). Stem `exemple` preserved.

## C.2 verdict — no re-exec needed

- Comment-only (`//`): provably does not affect .NET execution output.
- **Outputs preserved byte-identical** (verified: `0` output/`execution_count` lines changed).
- H.3 passes (0 null exec_count, 15/15 code cells with outputs).

## Validation

```
JSON valid: 40 cells, 15 code, 0 null exec_count (H.3 ✓)
diff: 1 insertion / 1 deletion (single comment line)
0 output / execution_count lines changed
base: origin/main (b5847a7ca), fresh
catalog: byte-identical
anti-collision: gh pr list --search "Sudoku-14" = [] (no open PR)
```

## Out of scope

- **String-literal residuals** (cells 12/20/31: `Resultat`→`Résultat`, `trouve`→`trouvée`) = RECOVERABLE-MACHINE (re-exec needs VS Code interactive, headless blocked by cumulative class-scoping CS0246 — see c.113 finding). Deferred to interactive pass.

`See #2876` — residual comment pass, does not close the EPIC.

Co-Authored-By: Claude-Code <noreply@anthropic.com>