### PR TITLE
feat(hashlife): close P5.3 p5_inductive_step via vacuous-arm split (c.310)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -3094,9 +3094,33 @@ theorem p5_large_n_jump (n : Nat) (g : Grid) (h : BoxAssezGrand g n)
     proven. -/
 theorem p5_inductive_step (n : Nat) (g : Grid) (h : BoxAssezGrand g n) :
     evolveHashlifeFast n g = evolve n g := by
-  by_cases hsmall : n < jumpSize (gridToMacroCellWithOffset g).2.level
-  · exact p5_small_n_fallback n g hsmall
-  · sorry
+  by_cases hg : g = []
+  · -- Empty grid: both sides definitionally `[]`.
+    -- `evolveHashlifeFast n [] = evolveHashlifeFastAux n n []`, which unfolds
+    -- to `evolve n []` after the `0 >= 2` guard fails on `gridFrame []`'s
+    -- level-0 MacroCell. `evolve n []` is `step^[n] []`, and `step [] = []`
+    -- via `candidates [] = []`. So both sides are `[]`. The unfolding
+    -- reduces to `rfl` after `simp` normalizes the auxiliary definitions.
+    subst hg
+    unfold evolveHashlifeFast
+    cases n with
+    | zero => simp [evolveHashlifeFastAux, evolve]
+    | succ k =>
+      -- `evolveHashlifeFastAux (k+1) (k+1) []` falls into the `fuel+1, n, g`
+      -- branch. Inside, `gridToMacroCellWithOffset []` returns a level-0
+      -- MacroCell, so `lvl >= 2` is false and we take the else branch
+      -- (`evolve (k+1) []`). Lean reduces the `if` since `0 >= 2` is `false`.
+      simp [evolveHashlifeFastAux, gridToMacroCellWithOffset, gridFrame,
+            buildFromGrid, MacroCell.level]
+  · -- Non-empty grid: case-split on `hsmall`.
+    by_cases hsmall : n < jumpSize (gridToMacroCellWithOffset g).2.level
+    · exact p5_small_n_fallback n g hsmall
+    · -- `¬ hsmall` on a non-empty grid: the P5.2 hypotheses are jointly
+      -- unsatisfiable (vacuous arm — see `p5_large_n_hyps_unsat`, c.307a
+      -- disclosure). Reconstruct `n ≥ jumpSize` and discharge via `False.elim`.
+      have hbig : n ≥ jumpSize (gridToMacroCellWithOffset g).2.level :=
+        Nat.not_lt.mp hsmall
+      exact (p5_large_n_hyps_unsat g n hg h hbig).elim
 
 
 /-- **Hashlife correctness (bounded)**: under the padding hypothesis

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -1060,6 +1060,67 @@ theorem padCenter2_correct_block_level1 :
     (padCenter2 c).toCellsAux (-3 : Int) (-3 : Int) = c.toCellsAux 0 0 := by
   native_decide
 
+/-! ### N2 step 3 bridge: `padCenter2` margin ≥ Chebyshev jump reach
+
+The geometric precondition for `p5_large_n_jump`: the `padCenter2`
+margin `(3·2^(k-1))` strictly contains the Hashlife jump reach
+(`2^k`) for any level-`k ≥ 1` MacroCell. Proving this eliminates the
+last geometric question before `p5_large_n_jump` can be assembled:
+
+    a level-`k` MacroCell has side `2^k`; padded by 2 levels it has
+    side `2^(k+2) = 4·2^k`; the per-side margin is `(4·2^k - 2^k)/2
+    = 3·2^(k-1)`. The Hashlife jump size is `jumpSize k = 2^k`, and
+    by `evolve_reach_chebyshev` (lightCone.lean L270-298, N2 step 2),
+    any cell alive after `2^k` generations lies within Chebyshev
+    distance `2^k` of an initial cell. Since `2^k ≤ 3·2^(k-1)` for
+    `k ≥ 1`, the Chebyshev reach fits inside the margin with a factor
+    of 3/2 to spare.
+
+This is the **pure-arithmetic half** of the light-cone ↔ padding
+bridge. It is independently provable (no coordinate hypotheses, no
+`MacroCell` arguments), so it can be wired into `p5_large_n_jump`
+once the P4 inductive step (`p4_succ_membership`) closes.
+
+Sorry-free, additive, no existing sorries modified (§D anti-regression
+safe). EPIC #3846 (N2 step 3, research-Long dedicated session). -/
+
+/-- **Pad-margin ≥ jump-reach** (pure arithmetic, sorry-free).
+    For a level-`k ≥ 1` MacroCell, the per-side `padCenter2` margin
+    `3·2^(k-1)` is strictly larger than the Hashlife jump size `2^k`
+    — i.e. the margin contains the Chebyshev reach of the jump.
+    Equivalently, the side length `4·2^k` of the padded cell exceeds
+    the jump reach `2·2^k` (Chebyshev radius `2^k` doubled) by a
+    factor of 2.
+
+    Proof: distribute `3 = 1 + 2`, reduce goal to
+    `2^k ≤ 2^(k-1) + 2·2^(k-1)`, then rewrite
+    `2·2^(k-1) = 2^((k-1)+1) = 2^k` via `pow_succ'` and the
+    `(k-1)+1 = k` linear fact (the only piece `omega` closes here;
+    the actual power rewrite is not linear, hence explicit). Finally
+    `Nat.add_comm` puts the goal in the form `2^k ≤ 2^k + 2^(k-1)`,
+    closed by `Nat.le_add_right`. -/
+theorem padCenter2_margin_ge_jumpReach (k : Nat) (hk : 1 ≤ k) :
+    (2 : Nat)^k ≤ (3 : Nat) * (2 : Nat)^(k - 1) := by
+  have hk_eq : (k - 1) + 1 = k := by omega
+  rw [show (3 : Nat) = 1 + 2 from rfl, Nat.add_mul, Nat.one_mul]
+  have h2k : (2 : Nat) * (2 : Nat)^(k - 1) = (2 : Nat)^k := by
+    rw [← pow_succ', hk_eq]
+  rw [h2k, Nat.add_comm]
+  exact Nat.le_add_right _ _
+
+/-- **Strict margin headroom** (consequence of the above).
+    The margin exceeds the reach by exactly `2^(k-1)` cells per side —
+    a 50% headroom over the tight Chebyshev-`2^k` ball. -/
+theorem padCenter2_margin_strictly_gt_jumpReach (k : Nat) (hk : 1 ≤ k) :
+    (2 : Nat)^k < (3 : Nat) * (2 : Nat)^(k - 1) := by
+  have hk_eq : (k - 1) + 1 = k := by omega
+  rw [show (3 : Nat) = (1 : Nat) + 2 from rfl, Nat.add_mul, Nat.one_mul]
+  have h2k : (2 : Nat) * (2 : Nat)^(k - 1) = (2 : Nat)^k := by
+    rw [← pow_succ', hk_eq]
+  rw [h2k, Nat.add_comm]
+  apply Nat.lt_add_of_pos_right
+  exact Nat.two_pow_pos (k - 1)
+
 /-! ## Well-formedness of MacroCells
 
 `MacroCell.level` only walks the `nw` spine, so `c.level = k + 2` does


### PR DESCRIPTION
## Scope (c.310)

Close `p5_inductive_step` (P5.3 induction glue) via a 2-way case-split on `g = []` vs `g ≠ []`. Single-file change, single feature, single domain. **3 → 2 sorries in `HashlifeCorrectness.lean`.**

## Proof structure

### `g ≠ []` branch — vacuous-arm discharge

Reconstructs `hbig : n ≥ jumpSize` from `¬ hsmall`. On a non-empty grid, this is jointly unsatisfiable with `h : BoxAssezGrand g n` (caps `n ≤ 2` via `boxAssezGrand_nonempty_le_two` c.142) vs `jumpSize_gridLevel_ge_eight` (`n ≥ 8`). Discharge via `p5_large_n_hyps_unsat` (c.307a disclosed vacuity).

### `g = []` branch — genuine empty-grid work

`evolveHashlifeFastAux n n []` falls into the `fuel+1, n, g` arm, where `gridFrame [] = ((0, 0), 0)` ⇒ `buildFromGrid [] 0 0 0 = leaf false` ⇒ `mc.level = 0` ⇒ the `lvl >= 2` guard is false ⇒ else branch returns `evolve n []`. `evolve n [] = step^[n] [] = []` (via `candidates [] = []`). Both sides are `[]`; `cases n; simp` normalizes the auxiliary definitions.

## §B body prooflog

- `lake --old build` exit 0 — "Build completed successfully (2985 jobs)"
- `lake build Conway.Life.HashlifeCorrectness` standalone exit 0
- `grep -c sorry` `HashlifeCorrectness.lean` before: **3**, after: **2**, delta: **−1**
- No new sorry, no lemma deletion, no proof replaced by stub
- §A atomicity: 1 file, 27 insertions, 3 deletions, 1 domain (Lean conway_lean), 1 feature

## Vacuity disclosure (carried from c.307a PR #5929)

The non-empty-grid large-n arm is **STRUCTURALLY VACUOUS** — `box_assez_grand`
caps `n ≤ 2` on non-empty grids while the jump guard requires `n ≥ jumpSize ≥ 8`.
This closure demonstrates `hashlife_correct`'s STATEMENT is satisfiable
(`hashlife_correct_implies_block_4` / `_glider_8` witnesses) WITHOUT exercising
a Hashlife jump on non-empty grids. The genuine P5.2 jump (`p5_large_n_jump`,
L2999) remains an open sorry, gated on P4 unlock.

The empty-grid arm is **GENUINE WORK**: the `lvl >= 2` guard correctly fires on
the level-0 MacroCell, no jump is exercised, the definitionally-`[]` reduction
is real proof work.

## L335 anti-monotonie pivot vs c.309

- c.309 = Hashlife arithmetic bridge (P5.2 `padCenter2_margin_ge_jumpReach`):  pure arithmetic, "2 * 2^(k-1) = 2^k"
- c.310 = Hashlife induction glue (P5.3 `p5_inductive_step`):  case-split + lean-level unfold + discharge

Same lake (`conway_lean`), same EPIC (#3846), but distinct registre (induction glue vs pure arithmetic). 2 axes varied.

## L279 + L275 + L377

- L279: worker does NOT merge. Forward ai-01 + dashboard ack.
- L275/L377: `gh pr view N --json mergedAt` firsthand before any forward-claim. PR #5975 (c.309) still OPEN awaiting ai-01 batch merge.

See #3846