### PR TITLE
docs(smartcontracts): de-spaghetti README inverted-pyramid (#5985)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -121,25 +121,6 @@ Fondations (SC-0-2) + Solidity basique (SC-3-6) + Testing avancé (SC-12-14) + V
 | Comprendre DeFi | SC-7-8-9 | 2h30 |
 | Gouvernance DAO | SC-9-10-17 | 2h |
 
-## Structure
-
-```text
-SmartContracts/
-├── 00-Foundations/              # Histoire + Setup (3 notebooks)
-├── 01-Solidity-Foundation/     # Fondements Solidity (4 notebooks)
-├── 02-Solidity-Advanced/       # Solidity avancé (5 notebooks)
-├── 03-Foundry-Testing/         # Tests et sécurité (3 notebooks)
-├── 04-Privacy-Cryptography/    # ZKP, HE, Vote E2E (3 notebooks)
-├── 05-Alternative-Chains/      # Vyper, XRP, Bitcoin, Move, Solana (5 notebooks)
-├── 06-Real-World/              # Cross-chain, deploy testnet/mainnet (4 notebooks)
-├── foundry-lib/                # Workspace Foundry + sous-modules (forge-std, OpenZeppelin, ERC-4337)
-├── erc20_lean/                 # Projet Lake Lean 4 (invariant de conservation ERC-20, 0 sorry, cf #4047) — 1er lake Lean de la série
-├── mon-premier-projet/         # Projet Foundry de démarrage (squelette scaffold)
-├── scripts/                    # Setup multi-plateforme (setup.sh, WSL, kernel Jupyter)
-├── requirements.txt            # Dépendances Python
-└── setup_env.py                # Orchestrateur Python (--setup / --check / --start-anvil)
-```
-
 ## Parcours recommande
 
 ```
@@ -178,6 +159,25 @@ SmartContracts/
 | 4 | Cacher des données sur blockchain publique | ZKP + chiffrement homomorphique fonctionnels |
 | 5 | Comprendre les architectures alternatives | Contracts déployés sur Vyper/XRP/Bitcoin/Move/Solana |
 | 6 | Déployer en production | Contrat sur testnet/mainnet + projet capstone |
+
+## Structure
+
+```text
+SmartContracts/
+├── 00-Foundations/              # Histoire + Setup (3 notebooks)
+├── 01-Solidity-Foundation/     # Fondements Solidity (4 notebooks)
+├── 02-Solidity-Advanced/       # Solidity avancé (5 notebooks)
+├── 03-Foundry-Testing/         # Tests et sécurité (3 notebooks)
+├── 04-Privacy-Cryptography/    # ZKP, HE, Vote E2E (3 notebooks)
+├── 05-Alternative-Chains/      # Vyper, XRP, Bitcoin, Move, Solana (5 notebooks)
+├── 06-Real-World/              # Cross-chain, deploy testnet/mainnet (4 notebooks)
+├── foundry-lib/                # Workspace Foundry + sous-modules (forge-std, OpenZeppelin, ERC-4337)
+├── erc20_lean/                 # Projet Lake Lean 4 (invariant de conservation ERC-20, 0 sorry, cf #4047) — 1er lake Lean de la série
+├── mon-premier-projet/         # Projet Foundry de démarrage (squelette scaffold)
+├── scripts/                    # Setup multi-plateforme (setup.sh, WSL, kernel Jupyter)
+├── requirements.txt            # Dépendances Python
+└── setup_env.py                # Orchestrateur Python (--setup / --check / --start-anvil)
+```
 
 ## Progression
 


### PR DESCRIPTION
## Summary

Apply the **#5985 inverted-pyramid** de-spaghetti to `SmartContracts/README.md`, matching the pattern already shipped for GameTheory (#5995) and Sudoku (#5997).

**Before**: `## Structure` (L124, folder tree = meta/detail) preceded `## Parcours recommande` (L143, ASCII flowchart + objectifs par partie = saillant). The recommended path was buried under the folder listing.

**After**: `## Parcours recommande` (saillant — visual path summary + objectives) now precedes `## Structure` (meta — folder tree). The reading order becomes:

```
Parcours d'apprentissage  (L63,  phase narrative)
Parcours alternatifs      (L93,  alt tracks)
Quel parcours choisir ?   (L111, decision table)
Parcours recommande       (L124, flowchart + objectifs)  <- saillant leads
Structure                 (L163, folder tree)            <- meta trails
Progression               (L182, per-notebook detail)
```

## Scope

- **Pure reorder**: the two section blocks are swapped byte-identically. Zero content change, zero prose edit, zero link/anchor change.
- **Diff**: `+19 / -19`, 1 file. `git diff` shows the Structure block deleted at its old position and re-inserted after the Parcours recommande block — no line within either block changed.
- **CATALOG-STATUS marker (L5-10) untouched** (catalog byte-identical to main, per catalog-pr-hygiene).
- Pre-existing markdown lint warnings (MD040 code blocks without language, MD034 bare URL at L299, MD036 at L648) are **out of scope** — this PR is a single-subject reorder, not a lint sweep.

## Verification

- `grep -nE "^## "` confirms new heading order (Parcours recommande L124 before Structure L163).
- `git diff --stat` = 19/19 on the single README — consistent with a pure block swap.
- This is my family (27 SmartContracts notebooks known firsthand from c3-c7 MD047 work), 0 collision (no open PR touches this README).

See #5985 (EPIC, partial — one more family de-spaghetti'd; GameTheory + Sudoku already done).
