### PR TITLE
fix(iit-ict): drop numeric prefix from Conclusion headers (8 Python notebooks, See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-1-PhiTrajectories.ipynb
@@ -955,7 +955,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "En appliquant la notion de **trajectoire** a $\\Phi$ lui-meme, on a vu que :\n",
     "\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb
@@ -1239,7 +1239,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "ICT-18 fournit un **instrument thermodynamique** (production d'entropie, detailed balance, reversibilisation) qui capte le **MOYEN** dans la triade *moyen / fin / enjeu*. La grille de lecture est explicite et honnete :\n",
     "\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-2-SelfSortingMorphogenesis.ipynb
@@ -809,7 +809,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Conclusion et perspectives\n",
+    "## Conclusion et perspectives\n",
     "\n",
     "Ce que ce toy model a rendu **mesurable**, sans aucun contrôleur global :\n",
     "\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-3-RobustnessDelayedGratification.ipynb
@@ -917,7 +917,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "ICT-3 a transformé les deux démonstrations ponctuelles d'ICT-2 en **mesures** :\n",
     "\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-4-ChimericArraysKinAggregation.ipynb
@@ -776,7 +776,7 @@
     "tags": []
    },
    "source": [
-    "## 6. Conclusion et perspectives\n",
+    "## Conclusion et perspectives\n",
     "\n",
     "ICT-4 ferme la boucle ouverte par ICT-2. Avec un jeu de règles **à peine** plus riche que le modèle minimal :\n",
     "\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-5-CausalEmergence.ipynb
@@ -873,7 +873,7 @@
     "tags": []
    },
    "source": [
-    "## 6. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "L'**émergence causale** renverse une intuition réductionniste : la description la plus fine n'est\n",
     "pas toujours la plus causale. Avec le module `pyphi.macro` (le vrai outil SOTA), nous avons :\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-7-ScaleFreeSignatures.ipynb
@@ -973,7 +973,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion & ponts\n",
+    "## Conclusion & ponts\n",
     "\n",
     "- **Detecter une signature scale-free est une competence, pas un coup d'oeil.** Le\n",
     "  trace log-log trompe : on a vu une queue lourde banale (les deplacements du tri,\n",

--- a/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-3-CoarseGrainingMacroPhi.ipynb
@@ -523,7 +523,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "On a démontré la **méthode** du coarse-graining en IIT :\n",
     "\n",


### PR DESCRIPTION
## IIT/ICT-Series Conclusion title standardization (8 notebooks, See #3966)

**Refs** EPIC #3966 (sweep §E mise en forme visuelle notebooks pedagogiques). Pattern **L3966-L1** = standardiser les titres canoniques `## N. Conclusion` vers forme **sans prefix numerique**. Transfere de RL + Sudoku + Probas/Infer + Probas/PyMC + ML vers **IIT/ICT-Series** (Python, po-2025 lane native, Epic #4588 ICT = mon lead).

## TL;DR

**Variété R6** : 3 cycles #5985 de-spaghetti README (RL/Probas/CaseStudies) -> pivot vers sweep notebook Conclusion (L3966-L1, comme PyMC #5983 / ML #5988). Famille IIT = **nouvelle couverture**.

## Notebooks cibles (8 NUMBERED, 8 fichiers)

| Notebook | Cell | Kernel | Standardisation |
|----------|------|--------|------------------|
| `ICT-1-PhiTrajectories.ipynb` | 24 | pyphi | `## 5. Conclusion` -> `## Conclusion` |
| `ICT-2-SelfSortingMorphogenesis.ipynb` | 25 | python3 | `## 7. Conclusion et perspectives` -> `## Conclusion et perspectives` |
| `ICT-3-RobustnessDelayedGratification.ipynb` | 24 | python3 | `## 5. Conclusion` -> `## Conclusion` |
| `ICT-4-ChimericArraysKinAggregation.ipynb` | 23 | python3 | `## 6. Conclusion et perspectives` -> `## Conclusion et perspectives` |
| `ICT-5-CausalEmergence.ipynb` | 23 | python3 | `## 6. Conclusion` -> `## Conclusion` |
| `ICT-7-ScaleFreeSignatures.ipynb` | 27 | python3 | `## 8. Conclusion & ponts` -> `## Conclusion & ponts` |
| `ICT-18-ArrowOfTimeReversibilization.ipynb` | 24 | python3 | `## 10. Conclusion` -> `## Conclusion` |
| `IIT-3-CoarseGrainingMacroPhi.ipynb` | 20 | pyphi | `## 5. Conclusion` -> `## Conclusion` |

**ICT-19 EXCLU** : gated Epic #4588 (batterie ENJEU, po-2025 active lane) — éviter d encombrer le travail en cours sur ce notebook.

## Scope strict toilettage §E intra-cellule

| Metrique | Valeur |
|----------|--------|
| Fichiers touches | 8 (.ipynb IIT/ICT Python) |
| Substitutions prefix | 8 NUMBERED (1 par fichier) |
| Catalog churn | 0 |
| Cellules code touchees | 0 (markdown source uniquement) |

## G.1 disclosure — MD047 accessoire

Le diff montre `+12/-12` (au lieu de `+8/-8`). Cause : plusieurs notebooks ICT **n avaient pas de newline final après le `}` de fermeture** (violation MD047). Le `json.dump` normalize à `}\n`. Ce **dual-fix** (prefix + MD047) est cohérent car les deux tombent sous le même EPIC #3966 (mise en forme visuelle). Les lignes de prefix = 8, les lignes MD047 = ~4 (ajout `\n` final).

## Methodologie

- **Scan firsthand** (git show origin/main, regex lookahead canonique) = 9 NUMBERED sur 9 fichiers IIT. 1 exclu (ICT-19 gated).
- **Scope L3966-L1 strict** : drop prefix numerique **uniquement**, accents preserves verbatim.
- **C.2 markdown exception** : cellules markdown uniquement -> aucun output/execution_count touche, pas de re-exec.
- Count-check safety (script abort si mismatch).

## Anti-collision (#5869)

`gh pr list` + file-check : **0 PR ouverte** ne touche les notebooks ICT-Series.

**See #3966** (rollout, pas `Closes`).

Co-Authored-By: Claude <noreply@anthropic.com>