### PR TITLE
fix(docs): correct broken relative links in §H.4 review ledgers (unblocks check-links CI)

### DIFF
--- a/docs/ledgers/reviews/2026-07-11-h4-sweep-5957.md
+++ b/docs/ledgers/reviews/2026-07-11-h4-sweep-5957.md
@@ -63,7 +63,7 @@
 - **L394 n/a c.399** : 3 fichiers << 15 seuil strict §A = **single-subject PR** (1 livrable logique = corrigé notebook 03-1). Pas composite borderline.
 - **L395 reaffirmed** : single-file OU single-subject §A c.399 (3 fichiers < 15) — single-subject PR confirmé.
 - **L397 reaffirmed (c.396-c.398)** : commit sweep = `git add docs/ledgers/reviews/<file>.md` explicite JAMAIS `git add -A`.
-- **Prong A SOTA-OK** ([sota-not-workaround.md](../reference/sota-not-workaround.md)) : 2 modèles distincts SDXL Lightning-4step + Qwen Image Edit fp8 = **vrais outils SOTA installés/invoqués** (pas de workaround dégradé, pas d'ASCII art, pas de réimplémentation jouet). PNG 1182×591 ≫ floor placeholder = preuve SOTA-OK.
+- **Prong A SOTA-OK** ([sota-not-workaround.md](../../../.claude/rules/sota-not-workaround.md)) : 2 modèles distincts SDXL Lightning-4step + Qwen Image Edit fp8 = **vrais outils SOTA installés/invoqués** (pas de workaround dégradé, pas d'ASCII art, pas de réimplémentation jouet). PNG 1182×591 ≫ floor placeholder = preuve SOTA-OK.
 - **Prong B anti-dégénéré** : 2 modèles SOTA distincts + 3 exercices progressifs (Client API unifié / Impact paramètres / Benchmark perf) = **problème non-trivial qui exerce les capacités distinctives des 2 moteurs** (SDXL vitesse vs Qwen qualité). Pas de cas dégénéré où SOTA ≡ baseline.
 - **Stop & Repair respecté** : outputs regénérés par re-exec Papermill (exec_count monotone 1→7), pas de hand-edit cellule (les outputs stream "🎨 Génération Forge" + PNG sont cohérents avec re-exec réelle).
 - **secrets-hygiene** : 0 `os.getenv(KEY, "<default>")` literal-default ; cell[2] charge `.env` via `load_dotenv()` standard.

--- a/docs/ledgers/reviews/2026-07-11-h4-sweep-5971.md
+++ b/docs/ledgers/reviews/2026-07-11-h4-sweep-5971.md
@@ -94,7 +94,7 @@
 
 #### Advisory #3 — Composite borderline §A L394 (analogue c.393 #5944)
 
-30 fichiers > 15 seuil strict (cf [pr-review-discipline.md](../reference/pr-review-discipline.md) §A "composites trop larges = split obligatoire > 15 fichiers"). MAIS :
+30 fichiers > 15 seuil strict (cf [pr-review-discipline.md](../../../.claude/rules/pr-review-discipline.md) §A "composites trop larges = split obligatoire > 15 fichiers"). MAIS :
 - **1 seul livrable logique** = dédoublonnage lake Lean (cleanup orthogonal)
 - **18 suppressions propres** = aucune régression contenu (byte-identity confirmée)
 - **11 edits interdépendants** = redirection CI/Inventaire/Notebook — atomique par nature


### PR DESCRIPTION
## Problem — pre-existing `check-links` CI fail blocking the whole merge queue

Every currently-open PR (#5993, #5994, #5995, #5998, #6000) is **UNSTABLE** due to a **pre-existing** `check-links` failure on `main` — not caused by their own changes. Root cause: 2 §H.4 review-ledger docs (merged in the sweep batch) cite CoursIA rules with **wrong relative paths**.

## Root cause

The rules live in **`.claude/rules/`** (not `docs/reference/`). From `docs/ledgers/reviews/`, the cited links `../reference/<rule>.md` resolve to `docs/ledgers/reference/<rule>.md` — which doesn't exist.

**Fixes (2 path-only):**

- `docs/ledgers/reviews/2026-07-11-h4-sweep-5957.md:66` — `../reference/sota-not-workaround.md` → `../../../.claude/rules/sota-not-workaround.md`
- `docs/ledgers/reviews/2026-07-11-h4-sweep-5971.md:97` — `../reference/pr-review-discipline.md` → `../../../.claude/rules/pr-review-discipline.md`

Correct depth from `docs/ledgers/reviews/X.md` → repo `.claude/rules/` = `../../../.claude/rules/`.

## Validation

```
scripts/check_docs_links.py --check
  BEFORE: REGRESSION: 2 new broken link(s) (exit 1)
  AFTER:  OK: No new broken links. (0 pre-existing, 3712 total)  exit 0
```

`check_docs_links.py` scans `.claude/rules/` and resolves relative links within REPO_ROOT — so the fixed paths validate (target files exist at `.claude/rules/sota-not-workaround.md` + `.claude/rules/pr-review-discipline.md`).

## Impact

Minimal diff (+2/−2, path-only, prose unchanged). Once merged, `check-links` goes green on main and **unblocks the entire merge queue** (5+ PRs currently UNSTABLE only because of this).

- base: origin/main, fresh (0 behind)
- diff: +2/−2 (2 path fixes)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
