### PR TITLE
docs(semanticweb): de-spaghetti README inverted-pyramid (#5985)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -150,6 +150,47 @@ Les sidetracks marqués `b-Python` sont des notebooks complémentaires qui prés
 
 ---
 
+## Prérequis
+
+### Pour les notebooks .NET (SW-1 à SW-7)
+
+- .NET SDK 9.0+
+- .NET Interactive (Jupyter kernel)
+- VS Code avec Polyglot Notebooks (recommandé)
+
+### Pour les notebooks Python (SW-8 à SW-13 et sidetracks)
+
+- Python 3.10+
+- pip install -r requirements.txt
+
+### Pour le notebook 12 (GraphRAG)
+
+- Clé API OpenAI ou Anthropic (voir `.env.example`)
+
+## Installation
+
+### 1. Environnement .NET
+
+```bash
+dotnet tool install -g Microsoft.dotnet-interactive
+dotnet interactive jupyter install
+```
+
+### 2. Environnement Python
+
+```bash
+python -m venv venv
+venv\Scripts\activate  # Windows
+pip install -r requirements.txt
+```
+
+### 3. Configuration API (optionnel, pour SW-12)
+
+```bash
+cp .env.example .env
+# Éditer .env avec vos clés API
+```
+
 ## Structure détaillée des notebooks
 
 ### Partie 1 : Fondations RDF (.NET C#)
@@ -417,47 +458,6 @@ Pour les personnes créant des ontologies et des vocabulaires :
 La série SemanticWeb illustre un mouvement profond du dépôt CoursIA : **prendre des données non-structurées et les re-représenter dans un cadre vérifiable**. RDF donne un sens formel à du JSON, OWL ajoute le raisonnement, SHACL ajoute la validation, GraphRAG ancre les LLMs sur des faits. Ce geste — trouver la représentation où le problème se dissout — traverse toutes les séries du dépôt, des CSP (Search) aux preuves Lean (SymbolicAI). La clé de lecture [La mer qui monte](../../../docs/grothendieckian-lens.md) développe ce fil conducteur.
 
 ---
-
-## Prérequis
-
-### Pour les notebooks .NET (SW-1 à SW-7)
-
-- .NET SDK 9.0+
-- .NET Interactive (Jupyter kernel)
-- VS Code avec Polyglot Notebooks (recommandé)
-
-### Pour les notebooks Python (SW-8 à SW-13 et sidetracks)
-
-- Python 3.10+
-- pip install -r requirements.txt
-
-### Pour le notebook 12 (GraphRAG)
-
-- Clé API OpenAI ou Anthropic (voir `.env.example`)
-
-## Installation
-
-### 1. Environnement .NET
-
-```bash
-dotnet tool install -g Microsoft.dotnet-interactive
-dotnet interactive jupyter install
-```
-
-### 2. Environnement Python
-
-```bash
-python -m venv venv
-venv\Scripts\activate  # Windows
-pip install -r requirements.txt
-```
-
-### 3. Configuration API (optionnel, pour SW-12)
-
-```bash
-cp .env.example .env
-# Éditer .env avec vos clés API
-```
 
 ## Technologies et versions
 


### PR DESCRIPTION
## Summary

Apply the **#5985 inverted-pyramid** de-spaghetti to `SymbolicAI/SemanticWeb/README.md`, extending the coordinated initiative to a 7th family.

**Before**: `## Prérequis` (L421) and `## Installation` (L438) were buried in the README tail — sitting *after* Structure détaillée (L153), Acquis d'apprentissage (L364), Parcours alternatifs (L383), and FAQ (L404). The setup gate the reader needs to *run* anything came only at line 421 of a 630-line file.

**After**: both sections relocated to L153/L170, just after `## Progression recommandée` (L134) and before `## Structure détaillée` (L194). The reading flow becomes:

```
Pourquoi -> Concepts -> Vue d'ensemble -> Figures -> Quick Start
  -> Progression recommandée
  -> Prérequis          (L153)   <- setup gate lifted here
  -> Installation       (L170)
  -> Structure détaillée (L194)  <- per-notebook detail trails
  -> Acquis -> Parcours alternatifs -> FAQ -> Lecture transversale
  -> Technologies et versions -> ...
```

## Scope — pure reorder

- **multiset-diff = 0 proven**: `diff <(sort before) <(sort after)` is empty. The two section blocks are moved byte-identically.
- **Diff**: `+41 / -41`, 1 file — exactly the Prérequis (17 lines) + Installation (24 lines) blocks relocated.
- **CATALOG-STATUS marker byte-identical** (series=SymbolicAI-SemanticWeb, count=25, breakdown=25, maturity PRODUCTION=23/BETA=2) — catalog untouched, per catalog-pr-hygiene.
- **French-first verbatim preserved** — no prose edit, no link/anchor change.
- Pre-existing markdown lint warnings (MD022 blanks L136/139, MD032 lists in Structure détaillée, MD040 code block at L447, MD036 emphasis) are **out of scope** — this PR is a single-subject reorder, not a lint sweep.

## Verification

- `diff <(git show HEAD:f | sort) <(sort f)` = empty (multiset equality).
- New heading order confirmed via `grep -nE "^## "`: Prérequis (L153) + Installation (L170) now precede Structure détaillée (L194).
- Family SymbolicAI (neighbour of SmartContracts, my turf), 0 collision — no open PR touches SemanticWeb/README.md (checked `gh pr list --search`).

See #5985 (EPIC, partial — 7th family de-spaghetti'd; RL/Probas/GameTheory/Sudoku/SmartContracts/ML already done or in flight).
