### PR TITLE
fix(search-apps-csp): drop numeric prefix from Conclusion/Recapitulatif/Synthese headers (8 Python notebooks, See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
@@ -2525,7 +2525,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Recapitulatif\n",
+    "## Recapitulatif\n",
     "\n",
     "### Resume des approches\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC.ipynb
@@ -1486,7 +1486,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Synthèse — WFC vs CP-SAT pour la génération procédurale\n",
+    "## Synthèse — WFC vs CP-SAT pour la génération procédurale\n",
     "\n",
     "| Critère | Aléatoire | WFC pur | CP-SAT |\n",
     "|---------|-----------|---------|--------|\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-20-SudokuBenchmark-Python.ipynb
@@ -980,7 +980,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Synthese — ce que disent les chiffres\n",
+    "## Synthese — ce que disent les chiffres\n",
     "\n",
     "Lecture du tableau ci-dessus :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
@@ -2546,7 +2546,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Recapitulatif et exercices\n",
+    "## Recapitulatif et exercices\n",
     "\n",
     "### Comparaison : planification manuelle vs CP-SAT\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb
@@ -2734,7 +2734,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Conclusion, recapitulatif et exercices\n",
+    "## Conclusion, recapitulatif et exercices\n",
     "\n",
     "### Tableau recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
@@ -3086,7 +3086,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Recapitulatif\n",
+    "## Recapitulatif\n",
     "\n",
     "### Resume des approches\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7-Wordle.ipynb
@@ -2621,7 +2621,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Conclusion et recapitulatif\n",
+    "## Conclusion et recapitulatif\n",
     "\n",
     "### Concepts cles\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
@@ -2653,7 +2653,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Recapitulatif\n",
+    "## Recapitulatif\n",
     "\n",
     "### Resume de la syntaxe MiniZinc\n",
     "\n",


### PR DESCRIPTION
## Search/Applications/CSP Conclusion title standardization (8 Python notebooks, See #3966)

**Refs** EPIC #3966 (sweep §E mise en forme visuelle notebooks pedagogiques). Pattern **L3966-L1** = standardiser les titres canoniques `## N. Conclusion` / `## N. Synthese` / `## N. Recapitulatif` vers forme **sans prefix numerique**. Famille Search = **nouvelle couverture** (24 cells python3 au total — cette PR couvre le sous-repertoire **Applications/CSP**).

## Notebooks cibles (8 NUMBERED, 8 fichiers Python)

| Notebook | Cell | Standardisation |
|----------|------|------------------|
| `App-11-Picross.ipynb` | 50 | `## 8. Recapitulatif` -> `## Recapitulatif` |
| `App-19-ProceduralGeneration-WFC.ipynb` | 33 | `## 9. Synthese - WFC vs CP-SAT` -> `## Synthese...` |
| `App-20-SudokuBenchmark-Python.ipynb` | 15 | `## 8. Synthese - ce que disent les chiffres` -> `## Synthese...` |
| `App-3-NurseScheduling.ipynb` | 58 | `## 7. Recapitulatif et exercices` -> `## Recapitulatif et exercices` |
| `App-4-JobShopScheduling.ipynb` | 59 | `## 7. Conclusion, recapitulatif et exercices` -> `## Conclusion...` |
| `App-6-Minesweeper.ipynb` | 54 | `## 8. Recapitulatif` -> `## Recapitulatif` |
| `App-7-Wordle.ipynb` | 52 | `## 8. Conclusion et recapitulatif` -> `## Conclusion...` |
| `App-8-MiniZinc.ipynb` | 46 | `## 8. Recapitulatif` -> `## Recapitulatif` |

## Scope strict toilettage §E intra-cellule

| Metrique | Valeur |
|----------|--------|
| Fichiers touches | 8 (.ipynb Search/Applications/CSP Python) |
| Substitutions | 8 NUMBERED (1 par fichier) |
| Diff | +8/-8 byte-surgical |
| Catalog churn | 0 |
| Cellules code touchees | 0 (markdown source uniquement) |

## Methodologie

- **Scan firsthand** (git show origin/main, regex lookahead canonique Conclusion/Synthese/Recapitulatif) = 8 NUMBERED Python dans Applications/CSP.
- **Scope L3966-L1 strict** : drop prefix numerique **uniquement**, accents preserves verbatim. **PAS de restoration d accents** (#2876 EPIC separe).
- **C.2 markdown exception** : cellules markdown uniquement -> aucun output/execution_count touche, pas de re-exec.
- Count-check safety (script abort si mismatch).

## Anti-collision (#5869) + découpe atomique

`gh pr list` + file-check : **0 PR ouverte** ne touche Search/Applications/CSP Python notebooks.

**Découpe Search atomique (R3)** : cette PR = Applications/CSP Python (8 nb). C# twins (App-1b/2b/3b/4b/5/Csharp) = turf po-2024, non touches. Search résiduel Python (prochains cycles, 1 PR/sous-rep) : Applications/Hybrid (3), Applications/Search (2), Part1 (Search-3/15), Part4 (Search-6/7/12/13/14), CSP-root (CSP-1/2/3/9).

**See #3966** (rollout, pas `Closes`).

Co-Authored-By: Claude <noreply@anthropic.com>