### PR TITLE
fix(search-csharp): drop numeric prefix from Conclusion/Synthese/Recapitulatif headers (12 .NET notebooks, See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
@@ -1464,7 +1464,7 @@
    "id": "7efb4dec",
    "metadata": {},
    "source": [
-    "## 10. Conclusion et resume\n",
+    "## Conclusion et resume\n",
     "\n",
     "Ce jumeau C# a reimplemente, sans aucune librairie externe, les metaheuristiques majeures du notebook Python `mealpy` :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
@@ -2185,7 +2185,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Concepts clés\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
@@ -580,7 +580,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Synthèse et lien avec les Applications\n",
+    "## Synthèse et lien avec les Applications\n",
     "\n",
     "Les GA de cette feuille sont la **brique** derrière plusieurs notebooks d'application :\n",
     "- **App-13 TSP-Metaheuristiques** : GA + 2-opt sur le voyageur de commerce.\n",

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
@@ -1088,7 +1088,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. Synthese\n",
+    "## Synthese\n",
     "\n",
     "### Resume des approches\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
@@ -869,7 +869,7 @@
     "tags": []
    },
    "source": [
-    "## 6. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce notebook a présenté la **programmation linéaire en C#/.NET** avec Google OrTools — le pendant du notebook Python/PuLP.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -1929,7 +1929,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Recapitulatif et exercices\n",
+    "## Recapitulatif et exercices\n",
     "\n",
     "### Tableau recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -2179,7 +2179,7 @@
    "id": "ca3c3c9c",
    "metadata": {},
    "source": [
-    "## 8. Recapitulatif\n",
+    "## Recapitulatif\n",
     "\n",
     "### Niveaux de consistance\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced-Csharp.ipynb
@@ -1310,7 +1310,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Conclusion et parité .NET ⇄ Python\n",
+    "## Conclusion et parité .NET ⇄ Python\n",
     "\n",
     "Ce notebook démontre la **parité algorithmique** entre **Choco-solver 4.10.17** (via IKVM 8.15.0) et **OR-Tools CP-SAT** (version Python du même notebook) :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-7-Soft-Csharp.ipynb
@@ -1208,7 +1208,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Conclusion et parité .NET ⇄ Python\n",
+    "## Conclusion et parité .NET ⇄ Python\n",
     "\n",
     "Ce notebook démontre les **primitives natives Choco 4.10.17** pour les CSP souples, en parité conceptuelle avec le [CSP-7-Soft.ipynb](CSP-7-Soft.ipynb) Python (OR-Tools CP-SAT) :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases-Csharp.ipynb
@@ -984,7 +984,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Synthèse : la PDB additive repousse la frontière du résolvable\n",
+    "## Synthèse : la PDB additive repousse la frontière du résolvable\n",
     "\n",
     "(Version texte — pas de graphique matplotlib en C# ; le tableau numérique brut\n",
     "montre directement le nœud où chaque heuristique termine ou dépasse le budget.)"
@@ -1333,7 +1333,7 @@
     "tags": []
    },
    "source": [
-    "## 13. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "La **base de données de motifs** illustre un principe central de la recherche\n",
     "heuristique avancée : **investir du calcul en amont** (précalculer des tables une\n",

--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch-Csharp.ipynb
@@ -966,7 +966,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "**Limited Discrepancy Search** occupe une niche précise dans le spectre de la\n",
     "recherche heuristique. À une extrémité, le **greedy** est instantané mais myope ;\n",

--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-14-WeightedAstar-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-14-WeightedAstar-Csharp.ipynb
@@ -997,7 +997,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "**Weighted A\\*** referme le triptyque de la Partie 3. Face à un problème où A\\* optimal\n",
     "explore trop de nœuds, on dispose de trois leviers : **renforcer** l'heuristique\n",


### PR DESCRIPTION
## Scope — L3966-L1 sweep on the **core Search-.NET series** (See #3966)

Drop the **numeric prefix** from markdown Conclusion/Synthese/Recapitulatif headers in the `.net-csharp` Search notebooks. Same convention as the merged Python sweeps (#5988 ML, #5991 ML-DSWA, #6004 IIT/ICT). This PR covers the **.NET turf**, which the Python sweeps did not reach.

## Why

The `## N. Conclusion` decorative numbering is inconsistent with the rest of the corpus (most notebooks use unnumbered `## Conclusion`). EPIC #3966 standardizes visual formatting: drop the numeric prefix from conclusion-family headers. Markdown-only edit — no code cell touched, no re-execution needed (C.2 markdown exception).

## Changes — 12 notebooks, 13 header edits (+13/−13)

| Notebook | Header (before → after) |
|----------|-------------------------|
| Search-3-Informed-Csharp | `## 8. Conclusion` → `## Conclusion` |
| Search-5-GeneticAlgorithms-Csharp | `## 6. Synthèse et lien…` → `## Synthèse et lien…` |
| Search-7-MCTS-And-Beyond-Csharp | `## 8. Synthese` → `## Synthese` |
| Search-9-LinearProgramming-Csharp | `## 6. Conclusion` → `## Conclusion` |
| Search-11-Metaheuristics-Csharp | `## 10. Conclusion et resume` → `## Conclusion et resume` |
| CSP-1-Fundamentals-Csharp | `## 7. Recapitulatif et exercices` → `## Recapitulatif et exercices` |
| CSP-2-Consistency-Csharp | `## 8. Recapitulatif` → `## Recapitulatif` |
| CSP-3-Advanced-Csharp | `## 5. Conclusion et parité…` → `## Conclusion et parité…` |
| CSP-7-Soft-Csharp | `## 5. Conclusion et parité…` → `## Conclusion et parité…` |
| Search-12-PatternDatabases-Csharp | `## 10. Synthèse : la PDB…` + `## 13. Conclusion` → both unnumbered |
| Search-13-LimitedDiscrepancySearch-Csharp | `## 7. Conclusion` → `## Conclusion` |
| Search-14-WeightedAstar-Csharp | `## 8. Conclusion` → `## Conclusion` |

## Convention (strict)

- Drop the **`N. ` numeric prefix ONLY**. Keyword-gated regex: only Conclusion / Synth[èe]se / R[ée]capitulatif / Bilan headers are touched. `## 1. Introduction`, `## 2. …` etc. are **left intact**.
- **Accents preserved verbatim** — this is NOT #2876 (accent restoration). `Synthese` stays `Synthese`, `Synthèse` stays `Synthèse`, `Recapitulatif` stays `Recapitulatif`.
- Rest of the header line preserved.

## Validation

```
Residual scan (numbered conclusion headers in scope): 0  (12 targets all clean)
Cell-count integrity: 12/12 files unchanged structure (byte-identical re-serialize)
Diff: +13/−13 = exactly the 13 one-line header edits
```

Markdown-only → C.2 markdown exception (no re-exec), H.3 pre-commit not triggered (code cells untouched).

## Out of scope (follow-up)

`Search/Applications/` (App-* CSP/Hybrid/Search, ~12 notebooks) also have numbered conclusion headers but are a distinct sub-family — left for a separate sweep to keep this PR atomic and under the G.4 composite threshold. Sudoku-.NET (5 notebooks) likewise.

See #3966 (partial — EPIC covers all families). Part of #4208 axe E.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
