### PR TITLE
docs(search): drop numeric prefix from Conclusion headers — Part3 Python (L3966-L1)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
@@ -706,7 +706,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 13. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "La **base de données de motifs** illustre un principe central de la recherche\n",
     "heuristique avancée : **investir du calcul en amont** (précalculer des tables une\n",

--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-13-LimitedDiscrepancySearch.ipynb
@@ -545,7 +545,7 @@
    "id": "bdb6cea2",
    "metadata": {},
    "source": [
-    "## 7. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "**Limited Discrepancy Search** occupe une niche précise dans le spectre de la\n",
     "recherche heuristique. À une extrémité, le **greedy** est instantané mais myope ;\n",

--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-14-WeightedAstar.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-14-WeightedAstar.ipynb
@@ -602,7 +602,7 @@
    "id": "9e40bafd",
    "metadata": {},
    "source": [
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "**Weighted A\\*** referme le triptyque de la Partie 3. Face à un problème où A\\* optimal\n",
     "explore trop de nœuds, on dispose de trois leviers : **renforcer** l'heuristique\n",


### PR DESCRIPTION
## Summary

L3966-L1 (EPIC #3966): standardize canonical Conclusion headers by dropping the `"N. "` numeric prefix in **Search/Part3-Advanced Python** notebooks. Continues the repo-wide sweep (PyMC #5983, ML #5988/#5991, IIT #6004, Search/CSP #6011 all merged/precedent).

| Notebook | Cell | Before | After |
|----------|------|--------|-------|
| Search-12-PatternDatabases | c28 | `## 13. Conclusion` | `## Conclusion` |
| Search-13-LimitedDiscrepancySearch | c17 | `## 7. Conclusion` | `## Conclusion` |
| Search-14-WeightedAstar | c17 | `## 8. Conclusion` | `## Conclusion` |

## Scope — markdown source ONLY

No code cell, `outputs`, `execution_count`, `metadata`, or `CATALOG-STATUS` marker touched. Diff is `+4/-4` across 3 files.

## G.1 honest disclosure — dual-fix

**Search-12** is `+2/-2`: 1 prefix drop + 1 **incidental MD047 normalization**. The committed notebook was missing its trailing newline after the final `}` (`\ No newline at end of file`). `json.dumps(indent=1)` re-serializes to `}\n`. This is the same dual-fix pattern as #6004 (IIT) — the MD047 fix is a beneficial side effect, not a regression. Search-13/-14 are pure prefix drops (`+1/-1` each).

## Verification

- Residual `## N. <Canonical>` in scope: **0** (script verify pass)
- CRLF: **0** (LF-only asserted)
- Markdown-only cells touched (C.2 exception — no re-exec needed)
- Anti-collision #5869: 0 OPEN PR on Search Part3 Python

See #3966