### PR TITLE
docs(search): drop numeric prefix from Conclusion headers — Part1 Python (L3966-L1)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb
@@ -1683,7 +1683,7 @@
     "tags": []
    },
    "source": [
-    "## 11. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce notebook a couvert les **briques algorithmiques essentielles** de NetworkX :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -3453,7 +3453,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Concepts clés\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
@@ -1716,7 +1716,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Synthese\n",
+    "## Synthese\n",
     "\n",
     "### Resume des techniques\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -2267,7 +2267,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Synthese\n",
+    "## Synthese\n",
     "\n",
     "### Resume des approches\n",
     "\n",


### PR DESCRIPTION
## Summary

L3966-L1 (EPIC #3966): drop the `"N. "` numeric prefix from canonical Conclusion/Synthese headers in **Search/Part1-Foundations Python** notebooks. Follows #6016 (Part3 Python, same sweep).

| Notebook | Cell | Before | After |
|----------|------|--------|-------|
| Search-3-Informed | c65 | `## 10. Conclusion` | `## Conclusion` |
| Search-6-AdversarialSearch | c37 | `## 8. Synthese` | `## Synthese` |
| Search-7-MCTS-And-Beyond | c41 | `## 8. Synthese` | `## Synthese` |
| Search-15-NetworkX | c40 | `## 11. Conclusion` | `## Conclusion` |

## Scope — markdown source ONLY, +4/-4

No code cell, `outputs`, `execution_count`, `metadata`, or `CATALOG-STATUS` touched. Pure prefix drop.

## G.1 disclosure — kernel-based filter

Candidates filtered by `kernelspec.name == "python3"`, not by filename. A name-based filter wrongly included **5 `.net-csharp` notebooks without the `-Csharp` suffix** (Search-11b-Metaheuristiques-Deep ×4, Search-16-QuikGraph) — these are **.NET turf (po-2024/po-2026), out of scope** for the Python lane. Kernel metadata is the truth (G.1).

## Verification

- Residual `## N. <Canonical>` in scope (python3): **0**
- CRLF: **0** (LF-only asserted)
- Markdown-only cells touched (C.2 exception — no re-exec)
- Anti-collision #5869: PR #6013 touches `Search-7-...-Csharp.ipynb` (the .NET twin) — **different file** from `Search-7-MCTS-And-Beyond.ipynb` (Python), no collision

See #3966