### PR TITLE
docs(search): drop numeric prefix from Conclusion headers — Applications Python (L3966-L1)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
@@ -2268,7 +2268,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Resume\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
@@ -2449,7 +2449,7 @@
     "tags": []
    },
    "source": [
-    "## 11. Synthese et Recommandations\n",
+    "## Synthese et Recommandations\n",
     "\n",
     "### Tableau comparatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
@@ -1978,7 +1978,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour.ipynb
@@ -3462,7 +3462,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Conclusion et resume\n",
+    "## Conclusion et resume\n",
     "\n",
     "### Comparaison des approches\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
@@ -2378,7 +2378,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Synthese comparative\n",
     "\n",


### PR DESCRIPTION
## Summary

L3966-L1 (EPIC #3966): drop `"N. "` numeric prefix from canonical Conclusion/Synthese headers in **Search/Applications/{Hybrid,Search} Python** notebooks — the non-CSP Applications residual (CSP done in #6011). Follows #6016 (Part3) + #6017 (Part1).

| Notebook | Cell | Before | After |
|----------|------|--------|-------|
| App-9-EdgeDetection (Hybrid) | c42 | `## 8. Conclusion` | `## Conclusion` |
| App-10-Portfolio (Hybrid) | c47 | `## 9. Conclusion` | `## Conclusion` |
| App-13-TSP-Metaheuristics (Hybrid) | c48 | `## 11. Synthese et Recommandations` | `## Synthese et Recommandations` |
| App-12-ConnectFour (Search) | c56 | `## 10. Conclusion et resume` | `## Conclusion et resume` |
| App-14-ConnectFour-Adversarial (Search) | c43 | `## 8. Conclusion` | `## Conclusion` |

## Scope — markdown source ONLY

No code cell, `outputs`, `execution_count`, `metadata`, or `CATALOG-STATUS` touched.

## G.1 disclosures

- **Kernel-based filter** (`kernelspec.name == "python3"`): 5 `.net-csharp` twins in these directories excluded (.NET turf, po-2024/po-2026).
- **Dual-fix (App-12)**: `+2/-2` = 1 prefix drop + 1 incidental MD047 normalization (missing trailing newline after final `}`). Same honest pattern as #6004/#6016.

## Verification

- Residual in scope (python3): **0**
- CRLF: **0** (LF-only asserted)
- Markdown-only (C.2 exception — no re-exec)
- Anti-collision #5869: 0 OPEN PR on these files

See #3966