### PR TITLE
docs(search): drop numeric prefix from Synthese/Recapitulatif headers — CSP-root Python (L3966-L1)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -2611,7 +2611,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Recapitulatif et exercices\n",
+    "## Recapitulatif et exercices\n",
     "\n",
     "### Tableau recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
@@ -3069,7 +3069,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Recapitulatif\n",
+    "## Recapitulatif\n",
     "\n",
     "### Niveaux de consistance\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -2370,7 +2370,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 6. Synthese : planification de cours (~6 min)\n",
+    "## Synthese : planification de cours (~6 min)\n",
     "\n",
     "Combinons tout ce que nous avons appris dans un probleme realiste : la **planification de cours**.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
@@ -2687,7 +2687,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Synthese et bonnes pratiques\n",
+    "## Synthese et bonnes pratiques\n",
     "\n",
     "### Quand utiliser DisCSP ?\n",
     "\n",


### PR DESCRIPTION
## Summary

L3966-L1 (EPIC #3966): drop `"N. "` numeric prefix from canonical Synthèse/Récapitulatif headers in **Search/Part2-CSP root Python** notebooks. **Completes the Search Python L3966-L1 sweep** (Part3 #6016, Part1 #6017, Applications #6018, this PR).

| Notebook | Cell | Before | After |
|----------|------|--------|-------|
| CSP-1-Fundamentals | c60 | `## 7. Recapitulatif et exercices` | `## Recapitulatif et exercices` |
| CSP-2-Consistency | c65 | `## 8. Recapitulatif` | `## Recapitulatif` |
| CSP-3-Advanced | c44 | `## 6. Synthese : planification de cours` | `## Synthese : planification de cours` |
| CSP-9-Distributed | c45 | `## 7. Synthese et bonnes pratiques` | `## Synthese et bonnes pratiques` |

## Scope — markdown source ONLY, +4/-4

No code cell, `outputs`, `execution_count`, `metadata`, or `CATALOG-STATUS` touched. Pure prefix drop (no incidental MD047 this time).

## G.1 disclosure — kernel-based filter

Candidates filtered by `kernelspec.name == "python3"`. Excluded 4 `.net-csharp` twins (CSP-1/2/3-Csharp, CSP-7-Soft-Csharp) = .NET turf (po-2024/po-2026).

## Verification

- Residual in scope (python3): **0**
- CRLF: **0** (LF-only asserted)
- Markdown-only (C.2 exception — no re-exec)
- Anti-collision #5869: 0 OPEN PR on these files

See #3966