### PR TITLE
fix(csharp): drop numeric prefix from Conclusion headers across 27 .NET notebooks (See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb
@@ -864,7 +864,7 @@
    "id": "240db1b9",
    "metadata": {},
    "source": [
-    "## 7. Synthese et transition vers les jeux cooperatifs\n",
+    "## Synthese et transition vers les jeux cooperatifs\n",
     "\n",
     "### Ce que nous avons appris\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames-Csharp.ipynb
@@ -833,7 +833,7 @@
    "id": "4e1d071b",
    "metadata": {},
    "source": [
-    "## 6. Synthèse\n",
+    "## Synthèse\n",
     "\n",
     "| Concept | Formule / Test | Rôle |\n",
     "|---------|----------------|------|\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
@@ -1142,7 +1142,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion (tranche 2)\n",
+    "## Conclusion (tranche 2)\n",
     "\n",
     "Cette tranche 2 a résolu le **gap de la tranche 1** : la **support enumeration** permet de calculer **tous les équilibres de Nash** (purs et mixtes) d'un jeu quelconque.\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp.ipynb
@@ -1148,7 +1148,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion (tranche 1)\n",
+    "## Conclusion (tranche 1)\n",
     "\n",
     "Cette tranche a pose les **concepts fondamentaux de la theorie des jeux strategique from-scratch** en C#/.NET : forme normale, meilleure reponse, equilibre de Nash pur, IESDS, equilibre mixte 2x2.\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem-Csharp.ipynb
@@ -1163,7 +1163,7 @@
    "id": "ee5ae343",
    "metadata": {},
    "source": [
-    "## 4. Synthèse\n",
+    "## Synthèse\n",
     "\n",
     "**Le théorème d'Arrow est confirmé empiriquement** par énumération exhaustive (méthode déterministe, 0 RNG) :\n",
     "- **Borda** et **Pluralité** satisfont Pareto et Non-dictature mais **violent IIA** ;\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
@@ -936,7 +936,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Synth\u00e8se\n",
+    "## Synth\u00e8se\n",
     "\n",
     "| Approche | Strat\u00e9gie | Complexit\u00e9 | Quand l'utiliser |\n",
     "|----------|-----------|------------|------------------|\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb
@@ -1171,7 +1171,7 @@
    "id": "35f34af8",
    "metadata": {},
    "source": [
-    "## 9. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Ce que démontre ce twin\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
@@ -1160,7 +1160,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Synth\u00e8se compar\u00e9e\n",
+    "## Synth\u00e8se compar\u00e9e\n",
     "\n",
     "| Approche | Type | Garantit solution ? | Compte toutes les solutions ? | Passe \u00e0 l'\u00e9chelle ? |\n",
     "|----------|------|---------------------|-------------------------------|---------------------|\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
@@ -868,7 +868,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 4. Synthese -- ce que disent les chiffres\n",
+    "## Synthese -- ce que disent les chiffres\n",
     "\n",
     "Les faits marquants (a confronter a la sortie ci-dessus) :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
@@ -1144,7 +1144,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Synth\u00e8se\n",
+    "## Synth\u00e8se\n",
     "\n",
     "| Approche | Type | Garantit \u03c7 ? | Complexit\u00e9 | Quand l'utiliser |\n",
     "|----------|------|--------------|------------|------------------|\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-3b-NurseScheduling-CSharp.ipynb
@@ -1179,7 +1179,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce twin C# a d\u00e9roul\u00e9 **trois solveurs from-scratch** sur le Nurse Rostering Problem :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-4b-JobShopScheduling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-4b-JobShopScheduling-CSharp.ipynb
@@ -1056,7 +1056,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce twin C# a d\u00e9roul\u00e9 **deux familles d'algorithmes from-scratch** sur le Job-Shop Scheduling :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
@@ -1956,7 +1956,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Ce qu'on a vu\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
@@ -841,7 +841,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Synth\u00e8se\n",
+    "## Synth\u00e8se\n",
     "\n",
     "| Approche | Type | Complexit\u00e9 | Qualit\u00e9 | Quand l'utiliser |\n",
     "|----------|------|------------|---------|------------------|\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb
@@ -1286,7 +1286,7 @@
    "id": "8ffab7d8",
    "metadata": {},
    "source": [
-    "## 11. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce jumeau C# a reimplemente from-scratch les **cinq methodes** d'optimisation d'hyperparametres du notebook Python App-18, en remplacant le RandomForest sklearn par un **k-NN from-scratch** (objectif = CV 5-fold). La **Bayesian Optimization (GP RBF + Expected Improvement)** est la valeur ajoutee centrale : elle atteint l'optimum de la Grid Search avec ~4x moins d'evaluations, illustrant comment un *surrogate* probabiliste rend l'optimisation **efficace en nombre d'evaluations** - la propriete qui la rend standard pour le tuning de modeles couteux.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-12-ConnectFour-CSharp.ipynb
@@ -1967,7 +1967,7 @@
    "id": "c2811080",
    "metadata": {},
    "source": [
-    "## 10. Conclusion et resume\n",
+    "## Conclusion et resume\n",
     "\n",
     "Ce jumeau C# a reimplemente, sans aucune librairie externe, le banc d'essai comparatif du notebook Python :\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial-CSharp.ipynb
@@ -1160,7 +1160,7 @@
    "id": "6eb8e6e7",
    "metadata": {},
    "source": [
-    "## 8. Conclusion — synthèse comparative\n",
+    "## Conclusion — synthèse comparative\n",
     "\n",
     "| Critère | Minimax | Alpha-Beta | MCTS |\n",
     "|---------|---------|------------|------|\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -1734,7 +1734,7 @@
     "tags": []
    },
    "source": [
-    "## 12. Recapitulatif\n",
+    "## Recapitulatif\n",
     "\n",
     "### Algorithmes implémentés\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
@@ -1224,7 +1224,7 @@
     "tags": []
    },
    "source": [
-    "## 11. Conclusion — Tranche 1 fondations\n",
+    "## Conclusion — Tranche 1 fondations\n",
     "\n",
     "**Ce que nous avons appris** :\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb
@@ -1174,7 +1174,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 10. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce notebook a couvert les fondamentaux de PDDL en s'appuyant sur un **modèle STRIPS implémenté en C#**. Vous avez vu comment un problème de planification se décompose en domaine (types, prédicats, actions) et problème (objets, état initial, but), et comment un planificateur générique (grounding + BFS) résout n'importe quelle instance.\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space-Csharp.ipynb
@@ -1140,7 +1140,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Conclusion — du search nu a A*\n",
+    "## Conclusion — du search nu a A*\n",
     "\n",
     "Ce twin C# parcourt la meme progression que le twin Python :\n",
     "- **BFS** : optimal en PAS (cout uniforme), explore beaucoup.\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward-Csharp.ipynb
@@ -1167,7 +1167,7 @@
    "id": "856e1d0f",
    "metadata": {},
    "source": [
-    "## 10. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Ce que vous avez appris\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
@@ -1041,7 +1041,7 @@
    "id": "7527bc67",
    "metadata": {},
    "source": [
-    "## 9. Conclusion — synthèse\n",
+    "## Conclusion — synthèse\n",
     "\n",
     "| Mécanisme | Coût (triplets) | Lisibilité | Portabilité |\n",
     "|-----------|----------------|------------|-------------|\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning-Csharp.ipynb
@@ -7631,7 +7631,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 10. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-ModernILP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-ModernILP-Csharp.ipynb
@@ -869,7 +869,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Synthese : FOIL vs les 4 moteurs\n",
+    "## Synthese : FOIL vs les 4 moteurs\n",
     "\n",
     "| Aspect | FOIL (C#) | Aleph/Metagol | Popper | dILP |\n",
     "|--------|-----------|--------------|--------|------|\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation-Csharp.ipynb
@@ -1155,7 +1155,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Conclusion (tranche 1)\n",
+    "## Conclusion (tranche 1)\n",
     "\n",
     "Cette tranche a pose le **moteur Dung from-scratch** en C#/.NET : fonction caracteristique, semantiques grounded/stable/preferred/complete, labeling 3-valued, generation aleatoire.\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
@@ -739,7 +739,7 @@
    "id": "be46f6ee",
    "metadata": {},
    "source": [
-    "## 7. Synthese : 4 extensions, 4 sources d'expressivite\n",
+    "## Synthese : 4 extensions, 4 sources d'expressivite\n",
     "\n",
     "| Framework | Source d'expressivite | Exemple verifie | Grounded |\n",
     "|-----------|----------------------|-----------------|----------|\n",


### PR DESCRIPTION
## Scope — L3966-L1 sweep on the **remaining .NET corpus** (See #3966)

Follow-up to **#6013** (which covered 12 Search-.NET notebooks). This PR closes L3966-L1 for the **rest of the .NET turf**: GameTheory-Csharp, Search/Applications App-*, Sudoku-6, and SymbolicAI (Planners/SemanticWeb/SymbolicLearning/Tweety). Same convention as the merged Python sweeps (#5988/#5991 ML, #5978 Sudoku-Python) and #6013 (Search-.NET).

## Why

The `## N. Conclusion` decorative numbering is inconsistent with the rest of the corpus (most notebooks use unnumbered `## Conclusion`). EPIC #3966 standardizes visual formatting: drop the numeric prefix from conclusion-family headers. Markdown-only edit — no code cell touched, no re-execution needed (C.2 markdown exception).

## Changes — 27 notebooks, 27 header edits (+27/−27)

| Sub-family | Notebooks |
|------------|-----------|
| **GameTheory C#** (5) | GT-2 (×2 tranches), GT-14 DifferentialGames, GT-15 CooperativeGames, SocialChoice/01-Arrow |
| **Search/Applications C#** (12) | App-1b NQueens, App-2b GraphColoring, App-3b NurseScheduling, App-4b JobShopScheduling, App-5 Timetabling, App-11b Picross, App-19 WFC, App-20b SudokuBenchmark, App-12 ConnectFour, App-14 ConnectFour-Adversarial, App-13b TSP-Metaheuristics, App-18b HyperparameterTuning |
| **Sudoku C#** (1) | Sudoku-6-AIMA-CSP (`## 12. Recapitulatif` → `## Recapitulatif`) |
| **SymbolicAI C#** (9) | Planners 1/2/3/4, SW-10 RDFStar, SL-6 ModernILP, SL-10 ActiveAutomata, Tweety-5, Tweety-7a |

Header forms touched: `## N. Conclusion`, `## N. Conclusion et resume`, `## N. Conclusion (tranche K)`, `## N. Synthese`, `## N. Synthèse`, `## N. Synthèse comparée`, `## N. Recapitulatif`, `## N. Conclusion — synthèse`.

## Convention (strict)

- Drop the **`N. ` numeric prefix ONLY**. Keyword-gated: only Conclusion / Synth[èe]se / R[ée]capitulatif / Bilan headers touched. `## 1. Introduction`, `## 2. Représentation`, etc. **left intact** (verified).
- **Accents preserved verbatim** — this is NOT #2876 (accent restoration). `Synthese` stays `Synthese`, `Synthèse` stays `Synthèse`, `Recapitulatif` stays `Recapitulatif`.

## Byte-identity approach (raw-text regex, no json round-trip)

These 27 notebooks **mix encoding modes**: App-*/Planners/Tweety are ASCII-escaped (`Synthèse`), others UTF-8 direct (`Synthèse`). A `json.dumps` re-serialize would flip the mode and mass-churn (an earlier attempt produced 510/510 spurious line changes). Instead, a **raw-text regex** sub touches ONLY the `## N. ` prefix of conclusion-family headers — every `\uXXXX` escape sequence and every direct accented char is preserved byte-for-byte. The JSON structure is untouched.

```
PAT = re.compile(r'(#{1,6} )\d+\. (?=Conclusion|Synth|Recap|R(?:\\u00e9|é)cap|Bilan)')
```

## Validation

```
Diff:           27 files changed, +27/-27  (exactly 27 one-line header edits)
JSON integrity: 0 invalid / 27 files
Cell-count:     0 mismatches / 27 files (structure unchanged)
Residual scan:  0 numbered conclusion headers remaining in scope
Non-conclusion: ## 1. Représentation…, ## 2. … etc. PRESERVED (keyword-gate confirmed)
Encoding:       è / é escapes preserved verbatim in ASCII-escaped files
```

Markdown-only → C.2 markdown exception (no re-exec), H.3 pre-commit not triggered (code cells untouched). No catalogue files touched.

## Out of scope

The 12 Search-.NET notebooks already covered by #6013 are excluded (anti-self-collision #5869 — they still show the prefix on `origin/main` only because #6013 is awaiting merge). The .NET L3966-L1 turf is now fully swept once #6013 + this PR merge.

See #3966 (EPIC, partial — conclusion-family headers). Part of #4208 axe E.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
