### PR TITLE
feat(kelly_lean): complete §8 operational criterion — sign trichotomy + growth-value capstone (FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly.lean
@@ -262,4 +262,35 @@ theorem growthGrad_zero_eq_zero_iff (β : Bet) :
   rw [growthGrad_zero, kellyFrac_eq_zero_iff]
   constructor <;> intro h <;> linarith [mul_comm β.p β.b]
 
+/-! ## 9. Capstone : la croissance optimale est nulle ssi le pari est équitable
+
+Les régimes du §8 décrivent le **signe de la fraction optimale** `f*`. Cette section
+en donne la **valeur de croissance** : comme `f*` maximise `g` et que `g(0) = 0`
+(ne rien miser laisse le capital inchangé), l'optimum satisfait toujours
+`g(f*) ≥ 0`. Il est **nul exactement au point neutre** `f* = 0` (pari actuariellement
+équitable, `b·p = q`) ; dès qu'un edge existe (`f* ≠ 0`), l'optimum est **strictement
+positif** — un pari à Kelly optimal ne détruit jamais le capital, et n'enrichit que
+s'il y a avantage. Ce capstone boucle la formalisation du critère opérationnel :
+`sign(f*) = sign(edge)` (§8) et `g(f*) = 0 ↔ f* = 0` (ici) — les deux faces d'un
+même résultat.
+-/
+
+/-- **Croissance optimale nulle ssi pari équitable** : `g(f*) = 0` exactement quand
+    `f* = 0`. Suit de `kelly_optimal` (qui donne `g(0) = 0 ≤ g(f*)` via `f = 0`
+    admissible) et `kelly_unique` (qui donne `g(f*) > g(0) = 0` dès que `f* ≠ 0`).
+    Capstone du critère opérationnel : la fraction nulle ne croît ni ne décroît, et
+    tout edge non nul produit une croissance optimale strictement positive. -/
+theorem kelly_growth_eq_zero_iff (β : Bet) :
+    growth β (kellyFrac β) = 0 ↔ kellyFrac β = 0 := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · -- g(f*) = 0 mais f* ≠ 0 : kelly_unique donne g(0) < g(f*) = 0, contradiction
+    by_contra hne
+    have hfeas0 : Feasible β 0 := ⟨by rw [div_lt_iff₀ β.hb_pos]; linarith, by linarith⟩
+    have hne' : (0 : ℝ) ≠ kellyFrac β := fun he => hne (Eq.symm he)
+    have hu := kelly_unique β 0 hfeas0 hne'
+    rw [growth_zero] at hu
+    linarith
+  · -- f* = 0 : alors g(f*) = g(0) = 0
+    rw [h]; exact growth_zero β
+
 end KellyLean

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly.lean
@@ -229,4 +229,37 @@ theorem growthGrad_zero_pos_iff (β : Bet) :
   rw [growthGrad_zero, kellyFrac_pos_iff]
   constructor <;> intro h <;> linarith [mul_comm β.p β.b]
 
+/-- **Fraction de Kelly négative ssi pari défavorable** : `f* < 0` exactement quand
+    l'« edge » `b·p − q` est strictement négatif (le pari est désavantageux, `b·p < q`).
+    Le maximiseur bascule alors côté short. Formalise le second cas de la prose §8
+    (« un pari défavorable donne `f* < 0` »). -/
+theorem kellyFrac_neg_iff (β : Bet) :
+    kellyFrac β < 0 ↔ β.b * β.p - q β < 0 := by
+  unfold kellyFrac
+  rw [div_lt_iff₀ β.hb_pos, zero_mul]
+
+/-- **Edge négatif ssi Kelly négative** : la pente initiale `g'(0) = b·p − q` est
+    strictement négative exactement quand `f* < 0`. La direction short est signée par
+    la pente du log-croissance en l'origine. -/
+theorem growthGrad_zero_neg_iff (β : Bet) :
+    growthGrad β 0 < 0 ↔ kellyFrac β < 0 := by
+  rw [growthGrad_zero, kellyFrac_neg_iff]
+  constructor <;> intro h <;> linarith [mul_comm β.p β.b]
+
+/-- **Fraction de Kelly nulle ssi pari équitable** : `f* = 0` exactement quand
+    l'« edge » `b·p − q` est nul (pari actuariellement équitable, `b·p = q`).
+    Ne rien miser est alors optimal. Formalise le cas neutre de la prose §8. -/
+theorem kellyFrac_eq_zero_iff (β : Bet) :
+    kellyFrac β = 0 ↔ β.b * β.p - q β = 0 := by
+  unfold kellyFrac
+  rw [div_eq_iff₀ β.hb_pos.ne', zero_mul]
+
+/-- **Edge nul siff Kelly nulle** : la pente initiale `g'(0)` est nulle exactement
+    quand `f* = 0`. Le cas neutre où ne rien miser est optimal — frontière entre les
+    régimes long et short. -/
+theorem growthGrad_zero_eq_zero_iff (β : Bet) :
+    growthGrad β 0 = 0 ↔ kellyFrac β = 0 := by
+  rw [growthGrad_zero, kellyFrac_eq_zero_iff]
+  constructor <;> intro h <;> linarith [mul_comm β.p β.b]
+
 end KellyLean

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly.lean
@@ -252,7 +252,7 @@ theorem growthGrad_zero_neg_iff (β : Bet) :
 theorem kellyFrac_eq_zero_iff (β : Bet) :
     kellyFrac β = 0 ↔ β.b * β.p - q β = 0 := by
   unfold kellyFrac
-  rw [div_eq_iff₀ β.hb_pos.ne', zero_mul]
+  rw [div_eq_zero_iff, or_iff_left β.hb_pos.ne']
 
 /-- **Edge nul siff Kelly nulle** : la pente initiale `g'(0)` est nulle exactement
     quand `f* = 0`. Le cas neutre où ne rien miser est optimal — frontière entre les

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
@@ -251,7 +251,7 @@ theorem growthGrad_zero_neg_iff (β : Bet) :
 theorem kellyFrac_eq_zero_iff (β : Bet) :
     kellyFrac β = 0 ↔ β.b * β.p - q β = 0 := by
   unfold kellyFrac
-  rw [div_eq_iff₀ β.hb_pos.ne', zero_mul]
+  rw [div_eq_zero_iff, or_iff_left β.hb_pos.ne']
 
 /-- **Zero edge iff zero Kelly**: the initial slope `g'(0)` vanishes exactly when
     `f* = 0`. The neutral regime where staking nothing is optimal — the boundary

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
@@ -261,4 +261,34 @@ theorem growthGrad_zero_eq_zero_iff (β : Bet) :
   rw [growthGrad_zero, kellyFrac_eq_zero_iff]
   constructor <;> intro h <;> linarith [mul_comm β.p β.b]
 
+/-! ## 9. Capstone: optimal growth is zero iff the bet is fair
+
+The §8 regimes describe the **sign of the optimal fraction** `f*`. This section gives
+its **growth value**: since `f*` maximizes `g` and `g(0) = 0` (staking nothing leaves
+capital unchanged), the optimum always satisfies `g(f*) ≥ 0`. It is **zero exactly at
+the neutral point** `f* = 0` (actuarially fair bet, `b·p = q`); whenever an edge
+exists (`f* ≠ 0`), the optimum is **strictly positive** — a Kelly-optimal bet never
+destroys capital, and enriches only when there is an advantage. This capstone closes
+the formalization of the operational criterion: `sign(f*) = sign(edge)` (§8) and
+`g(f*) = 0 ↔ f* = 0` (here) — two faces of the same result.
+-/
+
+/-- **Optimal growth zero iff fair bet**: `g(f*) = 0` exactly when `f* = 0`. Follows
+    from `kelly_optimal` (giving `g(0) = 0 ≤ g(f*)` via admissible `f = 0`) and
+    `kelly_unique` (giving `g(f*) > g(0) = 0` whenever `f* ≠ 0`). Capstone of the
+    operational criterion: the null fraction neither grows nor shrinks, and any
+    non-zero edge yields strictly positive optimal growth. -/
+theorem kelly_growth_eq_zero_iff (β : Bet) :
+    growth β (kellyFrac β) = 0 ↔ kellyFrac β = 0 := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · -- g(f*) = 0 but f* ≠ 0: kelly_unique gives g(0) < g(f*) = 0, contradiction
+    by_contra hne
+    have hfeas0 : Feasible β 0 := ⟨by rw [div_lt_iff₀ β.hb_pos]; linarith, by linarith⟩
+    have hne' : (0 : ℝ) ≠ kellyFrac β := fun he => hne (Eq.symm he)
+    have hu := kelly_unique β 0 hfeas0 hne'
+    rw [growth_zero] at hu
+    linarith
+  · -- f* = 0: then g(f*) = g(0) = 0
+    rw [h]; exact growth_zero β
+
 end KellyLean_en

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly/Kelly_en.lean
@@ -228,4 +228,37 @@ theorem growthGrad_zero_pos_iff (β : Bet) :
   rw [growthGrad_zero, kellyFrac_pos_iff]
   constructor <;> intro h <;> linarith [mul_comm β.p β.b]
 
+/-- **Kelly fraction negative iff bet is unfavorable**: `f* < 0` exactly when the
+    "edge" `b·p − q` is strictly negative (the bet is disadvantageous, `b·p < q`).
+    The maximizer then flips to the short side. Formalizes the second case of the
+    §8 prose ("an unfavorable bet yields `f* < 0`"). -/
+theorem kellyFrac_neg_iff (β : Bet) :
+    kellyFrac β < 0 ↔ β.b * β.p - q β < 0 := by
+  unfold kellyFrac
+  rw [div_lt_iff₀ β.hb_pos, zero_mul]
+
+/-- **Negative edge iff negative Kelly**: the initial slope `g'(0) = b·p − q` is
+    strictly negative exactly when `f* < 0`. The short direction is signed by the
+    log-growth slope at the origin. -/
+theorem growthGrad_zero_neg_iff (β : Bet) :
+    growthGrad β 0 < 0 ↔ kellyFrac β < 0 := by
+  rw [growthGrad_zero, kellyFrac_neg_iff]
+  constructor <;> intro h <;> linarith [mul_comm β.p β.b]
+
+/-- **Kelly fraction zero iff actuarially fair bet**: `f* = 0` exactly when the
+    "edge" `b·p − q` is zero (a fair bet, `b·p = q`). Staking nothing is then
+    optimal. Formalizes the neutral case of the §8 prose. -/
+theorem kellyFrac_eq_zero_iff (β : Bet) :
+    kellyFrac β = 0 ↔ β.b * β.p - q β = 0 := by
+  unfold kellyFrac
+  rw [div_eq_iff₀ β.hb_pos.ne', zero_mul]
+
+/-- **Zero edge iff zero Kelly**: the initial slope `g'(0)` vanishes exactly when
+    `f* = 0`. The neutral regime where staking nothing is optimal — the boundary
+    between the long and short regimes. -/
+theorem growthGrad_zero_eq_zero_iff (β : Bet) :
+    growthGrad β 0 = 0 ↔ kellyFrac β = 0 := by
+  rw [growthGrad_zero, kellyFrac_eq_zero_iff]
+  constructor <;> intro h <;> linarith [mul_comm β.p β.b]
+
 end KellyLean_en


### PR DESCRIPTION
## Summary

Complete the **§8 operational criterion** of the Kelly theorem on both its facets: the **sign trichotomy** of the optimal fraction `f*` (c16) AND the **growth-value capstone** `g(f*) = 0 ↔ f* = 0` (c17). The `Kelly.lean` §8 docstring (added c9 #5987) narrates three regimes in prose but only `0 < f*` was formalized; this PR closes the prose↔formal gap for the `< 0` and `= 0` cases, then adds the matching growth-value result.

## §8 — Sign trichotomy (c16)

| Theorem | Statement | Regime |
|---------|-----------|--------|
| `kellyFrac_neg_iff` | `f* < 0 ↔ edge (b·p − q) < 0` | unfavorable bet → short side |
| `kellyFrac_eq_zero_iff` | `f* = 0 ↔ edge = 0` | fair bet → stake nothing |
| `growthGrad_zero_neg_iff` | `g'(0) < 0 ↔ f* < 0` | short direction signed by slope |
| `growthGrad_zero_eq_zero_iff` | `g'(0) = 0 ↔ f* = 0` | neutral boundary long/short |

Result: **sign(f\*) = sign(edge) = sign(g'(0))** is now fully formal.

**Bug found + fixed in-cycle (G.9 honesty):** first push used `div_eq_iff₀` in `kellyFrac_eq_zero_iff`, which **does not exist** in Mathlib v4.31.0-rc1 (firsthand grep). Lean CI FAILED. Fix (commit 711486841): `rw [div_eq_zero_iff, or_iff_left β.hb_pos.ne']` — `div_eq_zero_iff : a/b=0 ↔ a=0 ∨ b=0`, then `or_iff_left (h:¬b) : a∨b ↔ a` eliminates the right disjunct `β.b=0`, leaving the iff closed by rfl. CI re-ran **pass** (1m46s).

## §9 — Growth-value capstone (c17)

| Theorem | Statement |
|---------|-----------|
| `kelly_growth_eq_zero_iff` | `g(f*) = 0 ↔ f* = 0` |

The §8 regimes describe the **sign** of `f*`; this gives its **growth value**. Since `f*` maximizes `g` and `g(0) = 0`, the optimum always satisfies `g(f*) ≥ 0`; it is **zero exactly at the neutral point** `f* = 0` (fair bet), **strictly positive** whenever `f* ≠ 0` — a Kelly-optimal bet never destroys capital, and enriches only when there is an edge.

Proof reuses existing lemmas only:
- backward (`f*=0 → g(f*)=0`): `rw [h]; exact growth_zero β`
- forward (`g(f*)=0 → f*=0`): `by_contra` + `kelly_unique β 0 hfeas0 hne'` (with `hne' : (0:ℝ) ≠ kellyFrac β := fun he => hne (Eq.symm he)` for the `≠` direction) gives `growth β 0 < growth β (kellyFrac β)`; `rw [growth_zero]` → `0 < g(f*)`, contradicting `g(f*)=0` via linarith. `Feasible β 0` from `div_lt_iff₀ β.hb_pos` + linarith.

## §B Lean compliance

- **sorry 0 → 0** (verified `mask_comments` + `\bsorry\b` on masked source, both files): no regression (§D clean).
- **0 axiom added.**
- **Lake build**: validated via `ci / Lean CI (kelly_lean)` — canonical proxy per the Lean CI Proxy pattern accepted at #5987 (local cold Mathlib build ~80 min, impractical per cron cycle).
- **§A atomic**: pure addition (0 deletion), 2 files (FR `Kelly.lean` + EN `Kelly_en.lean` sibling), one feature (§8+§9 operational criterion), 1 lake.
- **i18n (#4980)**: FR + EN siblings, consistent with c9 #5987 and the ratified convention (substantive modules = `_en.lean` siblings).

## Motivation

The §8 docstring (FR/EN L201-209) narrates all three regimes in prose but only `0 < f*` was proven. c9 (`growthGrad_zero_pos_iff`) realized "bet iff `g'(0) > 0`"; this PR closes the `< 0` and `= 0` cases (§8) and adds the growth-value capstone (§9) — fully formalizing the operational criterion.

Part of #4052
