### PR TITLE
docs(qc): de-spaghetti README — move Configuration before per-notebook detail (#5985)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -205,6 +205,43 @@ Approfondissement RL au-delà du DQN de la Phase 8 : PPO, SAC/A2C, et applicatio
 
 ---
 
+## Configuration
+
+### Variables d'environnement (.env)
+
+Copiez `.env.example` vers `.env` et configurez :
+
+```bash
+# Authentification QuantConnect Cloud
+QC_API_USER_ID=your_user_id_here
+QC_API_ACCESS_TOKEN=your_access_token_here
+
+# APIs IA/ML (optionnel, pour notebooks 17, 26)
+OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
+HUGGINGFACE_TOKEN=hf_...
+
+# NewsAPI (gratuit, pour notebook 17)
+NEWSAPI_KEY=your_newsapi_key_here
+```
+
+### Dépendances Python
+
+```bash
+# Créer environnement virtuel
+python -m venv venv
+venv\Scripts\activate  # Windows
+source venv/bin/activate  # Linux/macOS
+
+# Installer dépendances
+pip install -r requirements.txt
+
+# Installer kernel Jupyter
+python -m ipykernel install --user --name=quantconnect --display-name "Python (QuantConnect)"
+```
+
+---
+
 ## Résumé de la Progression
 
 **Total cours linéaire** : **29 notebooks Python** (QC-Py-01 à QC-Py-28 + le 23b, ~33 heures de contenu) + **24 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, **15** Cloud strategies QC-Py-Cloud-01..09, training QC-Py-30..32, dataset workflow), plus 2 notebooks de recherche utilitaires (`research_*.ipynb`).
@@ -354,43 +391,6 @@ Documentation détaillée : [`shared/SHARED_LIBRARY.md`](shared/SHARED_LIBRARY.m
 - [QuantConnect Forum](https://www.quantconnect.com/forum)
 - [LEAN Discussions](https://github.com/QuantConnect/Lean/discussions)
 - [CoursIA Main README](../../README.md)
-
----
-
-## Configuration
-
-### Variables d'environnement (.env)
-
-Copiez `.env.example` vers `.env` et configurez :
-
-```bash
-# Authentification QuantConnect Cloud
-QC_API_USER_ID=your_user_id_here
-QC_API_ACCESS_TOKEN=your_access_token_here
-
-# APIs IA/ML (optionnel, pour notebooks 17, 26)
-OPENAI_API_KEY=sk-...
-ANTHROPIC_API_KEY=sk-ant-...
-HUGGINGFACE_TOKEN=hf_...
-
-# NewsAPI (gratuit, pour notebook 17)
-NEWSAPI_KEY=your_newsapi_key_here
-```
-
-### Dépendances Python
-
-```bash
-# Créer environnement virtuel
-python -m venv venv
-venv\Scripts\activate  # Windows
-source venv/bin/activate  # Linux/macOS
-
-# Installer dépendances
-pip install -r requirements.txt
-
-# Installer kernel Jupyter
-python -m ipykernel install --user --name=quantconnect --display-name "Python (QuantConnect)"
-```
 
 ---
 


### PR DESCRIPTION
## Summary

#5985 Phase 2 (inverted pyramid): the **`## Configuration`** setup section was buried at **L360/605 (59%)** — after all per-notebook detail (Résumé, Notebooks Progressifs, Projets, Classification, Cours partenaire, Répertoires, Documentation, Ressources). Per the inverted-pyramid doctrine (setup → detail), Configuration (env vars, venv, requirements, Jupyter kernel) is foundational setup that belongs before the specific notebook inventory.

**Move**: Configuration block (37 lines, L360→L396) relocated to **L208** (after "Structure de la Série" L61, before "Résumé de la Progression" detail).

## Proof — pure block reorder

| Check | Result |
|-------|--------|
| Multiset-diff (`diff <(sort old) <(sort new)`) | **EMPTY** = pure reorder |
| Diff stat | **+37/−37** (block moved verbatim) |
| Hunks | exactly 2 (add @L208, remove @L360) |
| CATALOG-STATUS markers (START+END) | **byte-identical** |
| CRLF | **0** (LF-only) |
| Prose altered | **0 lines** (FR verbatim) |
| Secret scan | **clean** (`.env` placeholders `sk-...`/`your_user_id_here` are pre-existing placeholder docs moved verbatim, not real secrets) |

## Cross-lane note + placement judgment (requesting review)

QuantConnect is **po-2024's specialist lane** (currently on Lean #6024). #5985 is a cluster-wide editorial initiative (rule #5 authorizes cross-lane). 

**Requesting po-2024 / ai-01 review on the placement**: the zero-config QC-Cloud quickstart ("Pour Commencer" L32) covers the simplest path (notebooks are "à lire sur GitHub"), so `Configuration` primarily serves **local-execution** readers. Two defensible placements:
- **(this PR)** Configuration right after Structure, before all detail — strict inverted-pyramid (setup → content inventory).
- **(alternative)** Configuration kept lower as a local-setup reference appendix, since most readers use the zero-config Cloud path.

I went with the move per the #5985 mandate (setup is salient), but this is a **judgment call** — happy to adjust if po-2024 considers Configuration a reference appendix that belongs later. Reversible structural edit, no QC-domain logic touched.

## G.1 disclosure

Scanned on fresh origin/main worktree (605 lines) — shared working tree had a stale 539-line version. Anti-collision #5869: 0 OPEN PR on `QuantConnect/README.md`.

See #5985

Co-Authored-By: Claude-Code <noreply@anthropic.com>