### PR TITLE
docs(probas-infer): de-spaghetti README — move setup gate before per-notebook detail (#3974)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -74,6 +74,74 @@ Le trait distinctif d'Infer.NET : le modèle déclaratif est **compilé** (via R
 
 **Ressource complémentaire** : [Glossaire](Infer-Glossary.md) - Définitions des termes techniques
 
+## Prérequis
+
+- .NET 9.0 ou supérieur
+- .NET Interactive / Polyglot Notebooks
+- VS Code avec extension Polyglot Notebooks (recommandé)
+- Graphviz (optionnel, pour visualisation des factor graphs)
+
+## Installation
+
+### 1. .NET SDK 9.0+
+
+```bash
+# Installer depuis https://dotnet.microsoft.com/download
+# Vérifier l'installation
+dotnet --version
+```
+
+### 2. Kernel dotnet-interactive
+
+```bash
+dotnet tool install -g Microsoft.dotnet-interactive
+dotnet interactive jupyter install
+```
+
+### 3. Ou utiliser le script PowerShell (recommandé)
+
+```bash
+# Installe dotnet-interactive, papermill et enregistre les kernels :
+cd MyIA.AI.Notebooks/Probas/Infer/scripts
+.\setup_environment.ps1
+```
+
+### 4. Extension VS Code
+
+Installer l'extension "Polyglot Notebooks" depuis le marketplace VS Code.
+
+### 5. Packages NuGet (automatique)
+
+Chaque notebook inclut les références nécessaires :
+
+```csharp
+#r "nuget: Microsoft.ML.Probabilistic"
+#r "nuget: Microsoft.ML.Probabilistic.Compiler"
+```
+
+### 6. Graphviz (optionnel)
+
+Pour les visualisations de factor graphs dans les notebooks 11, 14-20 :
+
+```bash
+# Windows (chocolatey)
+choco install graphviz
+
+# Ou téléchargement direct depuis https://graphviz.org/download/
+```
+
+### Vérification
+
+```bash
+jupyter kernelspec list  # doit afficher .net-csharp et python3
+```
+
+### Tester tous les notebooks
+
+```bash
+python MyIA.AI.Notebooks/Probas/Infer/scripts/test_notebooks.py --validate-only
+```
+
 ## Progression Pédagogique
 
 ```mermaid
@@ -709,74 +777,6 @@ Le **point de rupture** (*change-point*) modélise une série qui suit un régim
 **Applications** : contrôle qualité (dérive de production), finance (changement de régime de marché), épidémiologie, surveillance de capteurs, datation d'événements structurels en sciences sociales et climatiques.
 
 ---
-
-## Prérequis
-
-- .NET 9.0 ou supérieur
-- .NET Interactive / Polyglot Notebooks
-- VS Code avec extension Polyglot Notebooks (recommandé)
-- Graphviz (optionnel, pour visualisation des factor graphs)
-
-## Installation
-
-### 1. .NET SDK 9.0+
-
-```bash
-# Installer depuis https://dotnet.microsoft.com/download
-# Vérifier l'installation
-dotnet --version
-```
-
-### 2. Kernel dotnet-interactive
-
-```bash
-dotnet tool install -g Microsoft.dotnet-interactive
-dotnet interactive jupyter install
-```
-
-### 3. Ou utiliser le script PowerShell (recommandé)
-
-```bash
-# Installe dotnet-interactive, papermill et enregistre les kernels :
-cd MyIA.AI.Notebooks/Probas/Infer/scripts
-.\setup_environment.ps1
-```
-
-### 4. Extension VS Code
-
-Installer l'extension "Polyglot Notebooks" depuis le marketplace VS Code.
-
-### 5. Packages NuGet (automatique)
-
-Chaque notebook inclut les références nécessaires :
-
-```csharp
-#r "nuget: Microsoft.ML.Probabilistic"
-#r "nuget: Microsoft.ML.Probabilistic.Compiler"
-```
-
-### 6. Graphviz (optionnel)
-
-Pour les visualisations de factor graphs dans les notebooks 11, 14-20 :
-
-```bash
-# Windows (chocolatey)
-choco install graphviz
-
-# Ou téléchargement direct depuis https://graphviz.org/download/
-```
-
-### Vérification
-
-```bash
-jupyter kernelspec list  # doit afficher .net-csharp et python3
-```
-
-### Tester tous les notebooks
-
-```bash
-python MyIA.AI.Notebooks/Probas/Infer/scripts/test_notebooks.py --validate-only
-```
 
 ## Concepts Clés Infer.NET
 


### PR DESCRIPTION
## Summary

#3974 (leaf README) + #5985 (inverted pyramid): the **`## Prérequis` + `## Installation`** setup gate was buried at **L713/980 (73%)** — after **12 sections** of per-notebook detail (Fondamentaux 1-3, Modèles Classiques 4-6, Classification 7-8, Modèles Avancés 9-12, Référence 13, Théorie de la Décision, Inférence Causale, Modèles Non-Linéaires, Modèles Hiérarchiques, Filtrage). A reader needs the environment configured *before* diving into notebook detail — per the inverted-pyramid doctrine (simple/salient → specific/detailed), the gate belongs right after "Vue d'ensemble" and before "Progression Pédagogique".

**Move**: setup block (68 lines, Prérequis L713 + Installation L720) relocated to **L77** (after "Vue d'ensemble" L47, before "Progression Pédagogique" L145).

## Proof — pure block reorder

| Check | Result |
|-------|--------|
| Multiset-diff (`diff <(sort old) <(sort new)`) | **EMPTY** = pure reorder |
| Diff stat | **+68/−68** (block moved verbatim) |
| Hunks | exactly 2 (add @L77, remove @L713) |
| CATALOG-STATUS markers | n/a (0 markers in this README) |
| CRLF | **0** (LF-only) |
| Prose altered | **0 lines** (FR verbatim) |
| Secret scan | **clean** |

## Cross-content note (requesting review)

The setup **content** is .NET-specific (Infer.NET uses .NET Interactive + NuGet packages — `#r "nuget: Microsoft.ML.Probabilistic"`). The **MOVE** is structural/editorial and language-agnostic — no .NET cell, NuGet reference, or domain logic touched (verified: NuGet/dotnet lines preserved verbatim in the moved block). Probas/Infer shares po-2024/po-2025 turf. Happy to adjust if po-2024 / ai-01 prefers a different placement. Reversible structural edit.

## G.1 disclosure

Scanned on fresh origin/main worktree (980 lines). This is #3974 leaf-level scope (sub-series README), distinct from my series-level #5985 PRs. Anti-collision #5869: 0 OPEN PR on `Probas/Infer/README.md`.

See #3974, #5985

Co-Authored-By: Claude-Code <noreply@anthropic.com>