### PR TITLE
fix(qcpy): drop numeric prefix from Conclusion headers (7 QuantConnect Python notebooks, See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
@@ -719,7 +719,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 6. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Récapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
@@ -1037,7 +1037,7 @@
    "id": "conclusion",
    "metadata": {},
    "source": [
-    "## 7. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Récapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
@@ -1300,7 +1300,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. Conclusion et Récapitulatif (5 min)\n",
+    "## Conclusion et Récapitulatif (5 min)\n",
     "\n",
     "### 8.1 Ce que vous avez appris\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
@@ -1678,7 +1678,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 8. Conclusion et Prochaines Étapes\n",
+    "## Conclusion et Prochaines Étapes\n",
     "\n",
     "### Récapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
@@ -1556,7 +1556,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 9. Conclusion et Prochaines Etapes\n",
+    "## Conclusion et Prochaines Etapes\n",
     "\n",
     "### Recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -1843,7 +1843,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 9. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-09-OptionWheel.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-09-OptionWheel.ipynb
@@ -266,7 +266,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Conclusion : Le wheel n'est pas un revenu gratuit\n",
+    "## Conclusion : Le wheel n'est pas un revenu gratuit\n",
     "\n",
     "### Points cles\n",
     "\n",


### PR DESCRIPTION
## Scope — L3966-L1 sweep on **QuantConnect Python core series** (See #3966)

Drop the numeric prefix from markdown Conclusion-family headers in the **QuantConnect Python pedagogical series** (7 notebooks: QC-Py-01→06 + QC-Py-Cloud-09). Same convention as the merged sweeps (RL #5982 ML-dswa, Infer #5981, PyMC #5983, ML #5988, IIT #6004, Search-Python #6011/#6016-19, Search-.NET #6013, C#-rest #6021).

## Why

The `## N. Conclusion` decorative numbering is inconsistent with the rest of the corpus (most notebooks use unnumbered `## Conclusion`). EPIC #3966 standardizes visual formatting: drop the numeric prefix from conclusion-family headers. Markdown-only edit — no code cell touched, no re-execution needed (C.2 markdown exception). These are QuantBook notebooks but the edit is in markdown cells only; no QC Cloud re-exec required.

## Changes — 7 notebooks, 7 header edits (+7/−7)

| Notebook | Header (before → after) |
|----------|-------------------------|
| QC-Py-01-Setup | `## 6. Conclusion` → `## Conclusion` |
| QC-Py-02-Platform-Fundamentals | `## 7. Conclusion` → `## Conclusion` |
| QC-Py-03-Data-Management | `## 8. Conclusion et Récapitulatif (5 min)` → `## Conclusion et Récapitulatif (5 min)` |
| QC-Py-04-Research-Workflow | `## 8. Conclusion et Prochaines Étapes` → `## Conclusion et Prochaines Étapes` |
| QC-Py-05-Universe-Selection | `## 9. Conclusion et Prochaines Etapes` → `## Conclusion et Prochaines Etapes` |
| QC-Py-06-Options-Trading | `## 9. Conclusion` → `## Conclusion` |
| QC-Py-Cloud-09-OptionWheel | `## 6. Conclusion : Le wheel n'est pas un revenu gratuit` → `## Conclusion : Le wheel n'est pas un revenu gratuit` |

## Convention (strict)

- Drop the **`N. ` numeric prefix ONLY**. Keyword-gated: only Conclusion / Synth[èe]se / R[ée]capitulatif / Bilan headers touched. `## 1. Introduction`, `## 2. …` left intact (verified: `## 1. Introduction : Qu'est-ce que QuantConnect ?` preserved).
- **Accents preserved verbatim** — NOT #2876 (accent restoration). `Récapitulatif` stays `Récapitulatif`, `Étapes` stays `Étapes`, `Etapes` stays `Etapes`.

## Byte-identity approach (raw-text regex)

Raw-text regex (no json round-trip) — byte-for-byte preservation of the rest of the file. QC-Py notebooks are UTF-8 direct (0 ASCII escapes), so json.dumps would also be safe, but raw-text regex is used for consistency and universal byte-safety.

```
PAT = re.compile(r'(#{1,6} )\d+\. (?=Conclusion|Synth|Recap|R(?:\\u00e9|é)cap|Bilan)')
```

## Validation

```
Diff:           7 files changed, +7/-7  (exactly 7 one-line header edits)
JSON integrity: 0 invalid / 7 files
Cell-count:     0 mismatches / 7 files (structure unchanged)
Residual scan:  0 numbered conclusion headers remaining in scope
Non-conclusion: ## 1. Introduction … preserved (keyword-gate confirmed)
Accents:        Récapitulatif / Étapes / Etapes preserved verbatim
```

Markdown-only → C.2 markdown exception (no re-exec). No catalogue files touched. No backtest/QC Cloud re-exec needed (markdown cells only).

## Out of scope (follow-up)

The broader QuantConnect Python L3966-L1 residual is 39 notebooks across 39 files. This PR covers the **QC-Py core pedagogical series** (7). Remaining families for separate atomic sweeps: ML-Training-Pipeline research (8), projects/ research+quantbook (12), partner-course (3), research/ (5), kelly_lean companion (1) — left for follow-up PRs to keep this one atomic and under the G.4 composite threshold (7 < 15).

See #3966 (EPIC, partial — conclusion-family headers).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
