### PR TITLE
fix(qcmltp): drop numeric prefix from Conclusion headers (9 QuantConnect ML-Training-Pipeline notebooks, See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb
@@ -3171,7 +3171,7 @@
     "tags": []
    },
    "source": [
-    "## 10. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m11e_ensemble_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m11e_ensemble_research.ipynb
@@ -474,7 +474,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Synthese : le triptyque des echecs du pipeline vol\n",
+    "## Synthese : le triptyque des echecs du pipeline vol\n",
     "\n",
     "Le pipeline vol a teste trois familles de sophistication au-dela du HAR simple a 3 coeff.\n",
     "Les trois echouent a battre K60 (le single best Kelly-HAR), chacune pour une raison\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m12_har_rv_j_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m12_har_rv_j_research.ipynb
@@ -471,7 +471,7 @@
     "tags": []
    },
    "source": [
-    "## 6. Conclusion : pourquoi HAR-RV-J est-il deploye ?\n",
+    "## Conclusion : pourquoi HAR-RV-J est-il deploye ?\n",
     "\n",
     "Malgre une **prevision MSE systematiquement pire** (+8% a +59% selon l'horizon),\n",
     "HAR-RV-J **BATS** HAR Classic en Sharpe (p=7.9e-7) parce que :\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m3_har_asymmetric_semivariance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m3_har_asymmetric_semivariance.ipynb
@@ -609,7 +609,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Conclusion et recommandations\n",
+    "## Conclusion et recommandations\n",
     "\n",
     "**Resultats cles** :\n",
     "1. **3/21 BEATS** (BTC a tous les horizons), **18/21 INCONCLUSIVE**, **0/21 NO BEATS**\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m5_hmm_regime_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m5_hmm_regime_research.ipynb
@@ -457,7 +457,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Synthese : deux axes d'echec, une meme lecon\n",
+    "## Synthese : deux axes d'echec, une meme lecon\n",
     "\n",
     "Le pipeline vol echoue a battre le HAR simple par **deux axes distincts** de sophistication,\n",
     "et la conclusion est identique : **ajouter de la complexite n'aide pas sur ces donnees**.\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m9_tft_vol_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m9_tft_vol_research.ipynb
@@ -436,7 +436,7 @@
     "tags": []
    },
    "source": [
-    "## 5. Synthese : la courbe d'expressivite inversee\n",
+    "## Synthese : la courbe d'expressivite inversee\n",
     "\n",
     "Le pipeline vol teste des modeles d'expressivite croissante. La conclusion est nette : sur ce\n",
     "benchmark crypto a donnees limitees, **le succes est anti-correle au nombre de parametres**.\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l1_tsmom.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l1_tsmom.ipynb
@@ -595,7 +595,7 @@
    "id": "8b1063f2",
    "metadata": {},
    "source": [
-    "## 6. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "| Idée clé | Traduction |\n",
     "|---|---|\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l2_dual_momentum.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l2_dual_momentum.ipynb
@@ -566,7 +566,7 @@
    "id": "b2e82636",
    "metadata": {},
    "source": [
-    "## 6. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "| Idée clé | Traduction |\n",
     "|---|---|\n",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l3_trend.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l3_trend.ipynb
@@ -637,7 +637,7 @@
    "id": "39c2bc57",
    "metadata": {},
    "source": [
-    "## 7. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "| Idée clé | Traduction |\n",
     "|---|---|\n",


### PR DESCRIPTION
## Scope — L3966-L1 sweep on QuantConnect ML-Training-Pipeline research notebooks (See #3966)

Companion to **#6042** (QC-Py core series). This PR sweeps the **ML-Training-Pipeline** research family (9 notebooks). Same convention as the merged L3966-L1 sweeps.

## Changes — 9 notebooks, 9 header edits (+9/−9)

| Notebook | Header (before → after) |
|----------|-------------------------|
| hmm_alpha_research | `## 10. Conclusion` → `## Conclusion` |
| m11e_ensemble_research | `## 5. Synthese` → `## Synthese` |
| m12_har_rv_j_research | `## 6. Conclusion` → `## Conclusion` |
| m3_har_asymmetric_semivariance | `## 7. Conclusion et recommandations` → `## Conclusion et recommandations` |
| m5_hmm_regime_research | `## 5. Synthese` → `## Synthese` |
| m9_tft_vol_research | `## 5. Synthese` → `## Synthese` |
| research_l1_tsmom | `## 6. Conclusion` → `## Conclusion` |
| research_l2_dual_momentum | `## 6. Conclusion` → `## Conclusion` |
| research_l3_trend | `## 7. Conclusion` → `## Conclusion` |

## Convention (strict)
- Drop the `N. ` numeric prefix ONLY. Keyword-gated (Conclusion/Synth[èe]se/R[ée]capitulatif/Bilan). `## 1. Introduction` etc. left intact.
- Accents preserved verbatim (NOT #2876).

## Validation
```
Diff: +9/−9, 9 files (one-line header edits)
JSON integrity: 0 invalid / 9
Cell-count: 0 mismatch / 9
Residual: 0 numbered conclusion headers in scope
```
Markdown-only → C.2 exception (no re-exec). Raw-text regex byte-identity. No backtest/QC Cloud re-exec (markdown cells only).

See #3966 (EPIC partial). Companion: #6042 (QC-Py core).

Co-Authored-By: Claude-Code <noreply@anthropic.com>