### PR TITLE
fix(qcprojects): drop numeric prefix from Conclusion headers (13 QuantConnect projects/ notebooks, See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-LSTM-Prediction/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-LSTM-Prediction/research.ipynb
@@ -1238,7 +1238,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Methodologie\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb
@@ -848,7 +848,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce QuantBook a permis d'analyser la complémentarité entre EMA-Cross et TrendStocks.\n",
     "Les résultats guideront l'allocation initiale du composite ainsi que les sweeps à effectuer."

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/quantbook.ipynb
@@ -672,7 +672,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. Synthese et prochaines etapes\n",
+    "## Synthese et prochaines etapes\n",
     "\n",
     "Modifier les parametres dans les sections 4 et 5 pour explorer:\n",
     "- Allocation optimale TrendStocks/AllWeather\n",
@@ -839,7 +839,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 9. Conclusions iteration 2\n",
+    "## Conclusions iteration 2\n",
     "\n",
     "Comparer les resultats ci-dessus pour identifier:\n",
     "- La frequence de rebalancement optimale (hebdo vs bi-hebdo vs mensuel)\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/research.ipynb
@@ -1300,7 +1300,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Ce que ce notebook evalue\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/research.ipynb
@@ -668,7 +668,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Conclusion et iterations suivantes\n",
+    "## Conclusion et iterations suivantes\n",
     "\n",
     "**Resultats cles** :\n",
     "- Le modele HAR(1,5,22) decompose efficacement la variance realisee en composantes\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/InverseVolatility-Rank/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/InverseVolatility-Rank/research.ipynb
@@ -380,7 +380,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "| Aspect | Observation |\n",
     "|--------|-------------|\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/research.ipynb
@@ -1516,7 +1516,7 @@
    "id": "60209040",
    "metadata": {},
    "source": [
-    "## 10. Synthèse des Findings et Configuration Recommandée"
+    "## Synthèse des Findings et Configuration Recommandée"
    ]
   },
   {
@@ -1663,7 +1663,7 @@
    "id": "c4edff5a",
    "metadata": {},
    "source": [
-    "## 11. Conclusions\n",
+    "## Conclusions\n",
     "\n",
     "### Résumé des Hypothèses Testées\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-Optimization-ML/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-Optimization-ML/research.ipynb
@@ -1481,7 +1481,7 @@
     "tags": []
    },
    "source": [
-    "## 11. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Points Clés\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Stoploss-Volatility-ML/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Stoploss-Volatility-ML/research.ipynb
@@ -382,7 +382,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "| Approche | Avantage | Limite |\n",
     "|----------|----------|--------|\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/research.ipynb
@@ -1124,7 +1124,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Comparaison avec Crypto-LSTM (#937)\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/research.ipynb
@@ -839,7 +839,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. Conclusion et iterations suivantes\n",
+    "## Conclusion et iterations suivantes\n",
     "\n",
     "**Resultats cles** :\n",
     "- L'ensemble GARCH + HAR fournit une estimation de volatilite plus robuste que chaque modele seul\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/research.ipynb
@@ -634,7 +634,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Conclusion et iterations suivantes\n",
+    "## Conclusion et iterations suivantes\n",
     "\n",
     "**Resultats cles** :\n",
     "- Le modele GARCH(1,1) par variance-targeting capture efficacement les grappes de volatilite\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/_docs/qc_top4_oos_extension.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/_docs/qc_top4_oos_extension.ipynb
@@ -242,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Synthese et Recommandations"
+    "## Synthese et Recommandations"
    ]
   },
   {


### PR DESCRIPTION
## Scope — L3966-L1 sweep on QuantConnect projects/ research+quantbook notebooks (See #3966)

Third companion in the QuantConnect Python L3966-L1 sweep (after **#6042** QC-Py core + **#6043** ML-Training-Pipeline). This PR sweeps the **projects/** family (13 notebooks: research + quantbook strategy research).

## Changes — 13 notebooks, 15 header edits (+15/−15)

12 projects with 1 conclusion-family header each + Framework_Composite_TrendWeather and PairsTrading with 2 headers (Synthese + Conclusion), + _docs/qc_top4_oos_extension. Forms touched: `## N. Conclusion`, `## N. Synthèse des Findings`, `## N. Synthese et prochaines etapes`, `## N. Conclusion et iterations suivantes`.

## Convention (strict)
- Drop the `N. ` numeric prefix ONLY. Keyword-gated (Conclusion/Synth[èe]se/R[ée]capitulatif/Bilan).
- Accents preserved verbatim (NOT #2876).

## Validation
```
Diff: +15/−15, 13 files
JSON integrity: 0 invalid / 13
Cell-count: 0 mismatch / 13
Residual: 0 numbered conclusion headers in scope
```
Markdown-only → C.2 exception (no re-exec). Raw-text regex byte-identity. No backtest/QC Cloud re-exec (markdown cells only).

See #3966 (EPIC partial). Companions: #6042 (QC-Py core) + #6043 (ML-Training-Pipeline).

Co-Authored-By: Claude-Code <noreply@anthropic.com>