### PR TITLE
docs(lean): bilingual FR-first Utility.lean root aggregator (i18n parity, See #4980)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Utility.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Utility.lean
@@ -3,31 +3,72 @@ import Utility.Axioms
 import Utility.Representation
 
 /-!
-# Decision Theory — von Neumann–Morgenstern Expected Utility
+  Théorie de la décision — Utilité espérée de von Neumann–Morgenstern
 
-Formalisation of the decision-theoretic foundations of expected utility:
-lotteries, the four vNM rationality axioms, and the expected-utility
-representation theorem.
+  Formalisation des fondements décisionnels de l'utilité espérée :
+  loteries, les quatre axiomes de rationalité vNM, et le théorème de
+  représentation de l'utilité espérée.
 
-## Contents
-- `Utility.Basic`: lotteries (finite-support distributions), expectation,
-  convex mixtures, affine identities (proved, sorry-free).
-- `Utility.Axioms`: completeness, transitivity, independence, continuity;
-  `IsRational` bundles the four vNM axioms.
-- `Utility.Representation`: `IsExpectedUtilityRep`, the sound direction
-  (representation ⟹ rationality, proved sorry-free), affine stability
-  (uniqueness up to positive affine transformation), and the order-theoretic
-  algebra of `≻` / `~` (strict order, equivalence relation, trichotomy). The
-  existence direction is documented as an open milestone.
+  ## Contenu
+  - `Utility.Basic` : loteries (distributions à support fini), espérance,
+    mélanges convexes, identités affines (prouvées, sans sorry).
+  - `Utility.Axioms` : complétude, transitivité, indépendance, continuité ;
+    `IsRational` regroupe les quatre axiomes vNM.
+  - `Utility.Representation` : `IsExpectedUtilityRep`, la direction de
+    validité (représentation ⟹ rationalité, prouvée sans sorry), stabilité
+    affine (unicité à transformation affine positive près), et l'algèbre
+    ordre-théorétique de `≻` / `~` (ordre strict, relation d'équivalence,
+    trichotomie). La direction d'existence est documentée comme un jalon
+    ouvert.
 
-## Status
-- Proved sorry-free: expectation algebra, all four axioms under a
-  representation, affine stability, and the order-theoretic algebra of strict
-  preference and indifference (strict order + equivalence + trichotomy).
-- Open (next milestone): the existence direction `IsRational P → ∃ u,
-  IsExpectedUtilityRep u P` (the substantive Herstein–Milnor theorem).
+  ## Statut
+  - Prouvé sans sorry : algèbre de l'espérance, les quatre axiomes sous une
+    représentation, stabilité affine, et l'algèbre ordre-théorétique de la
+    préférence stricte et de l'indifférence (ordre strict + équivalence +
+    trichotomie).
+  - Ouvert (prochain jalon) : la direction d'existence `IsRational P → ∃ u,
+    IsExpectedUtilityRep u P` (le théorème substantiel de Herstein–Milnor).
 
-## Cross-references
-- Infer-14 (Infer.NET): Bayesian expected utility under posterior uncertainty.
-- PyMC-1 (PyMC): expected-utility estimation by posterior sampling.
+  ## Références croisées
+  - Infer-14 (Infer.NET) : utilité espérée bayésienne sous incertitude
+    a posteriori.
+  - PyMC-1 (PyMC) : estimation de l'utilité espérée par échantillonnage
+    a posteriori.
+
+  ---
+
+  # Decision Theory — von Neumann–Morgenstern Expected Utility
+
+  Formalisation of the decision-theoretic foundations of expected utility:
+  lotteries, the four vNM rationality axioms, and the expected-utility
+  representation theorem.
+
+  ## Contents
+  - `Utility.Basic`: lotteries (finite-support distributions), expectation,
+    convex mixtures, affine identities (proved, sorry-free).
+  - `Utility.Axioms`: completeness, transitivity, independence, continuity;
+    `IsRational` bundles the four vNM axioms.
+  - `Utility.Representation`: `IsExpectedUtilityRep`, the sound direction
+    (representation ⟹ rationality, proved sorry-free), affine stability
+    (uniqueness up to positive affine transformation), and the order-theoretic
+    algebra of `≻` / `~` (strict order, equivalence relation, trichotomy). The
+    existence direction is documented as an open milestone.
+
+  ## Status
+  - Proved sorry-free: expectation algebra, all four axioms under a
+    representation, affine stability, and the order-theoretic algebra of strict
+    preference and indifference (strict order + equivalence + trichotomy).
+  - Open (next milestone): the existence direction `IsRational P → ∃ u,
+    IsExpectedUtilityRep u P` (the substantive Herstein–Milnor theorem).
+
+  ## Cross-references
+  - Infer-14 (Infer.NET): Bayesian expected utility under posterior uncertainty.
+  - PyMC-1 (PyMC): expected-utility estimation by posterior sampling.
+
+  Convention i18n (EPIC #4980, décision user 2026-07-04) : ce fichier root
+  aggregator est bilingue inline (FR canonique d'abord, EN en miroir),
+  conformément au pattern canonique `Gittins.lean` du même lake. Les modules
+  substantiels (`Utility.Basic`, `Utility.Axioms`, `Utility.Representation`)
+  vivent dans des fichiers siblings `_en.lean` séparés, auto-découverts par
+  le `globs := #[`Utility.*]` du lakefile.
 -/


### PR DESCRIPTION
## Summary

`decision_theory_lean/Utility.lean` (root aggregator) was **EN-only**, violating the lake's own i18n convention and the readme-french-first rule. This PR translates its docstring to **bilingual FR-first + EN mirror**, matching the canonical model (`Gittins.lean` L51-55) of the same lake.

- **EPIC #4980** (Lean i18n, décision user 2026-07-04): root aggregators = bilingual inline (FR canonique d'abord, EN en miroir).
- **readme-french-first** (HARD 1): new doc = FR first; an EN-only docstring is a violation.

## Change

Pure docstring translation (`/-! ... -/` doc comment). Structure mirrors `Gittins.lean`:
1. FR title + body (Contenu, Statut, Références croisées)
2. `---` separator
3. EN title + body (verbatim from the original — no EN content changed)
4. Convention note (i18n EPIC #4980)

**No code changed.** The 3 `import` statements are byte-identical. No theorem, proof, or tactic touched.

## Verification (§B Lean PR compliance)

- **`grep -c sorry` (canonical counter, comments masked) = 0 real sorry.** The 6 raw "sorry" matches are docstring prose ("sorry-free" EN ×3, "sans sorry" FR ×3) inside the doc comment — harmless, not Lean `sorry` tactics.
- **Docstring-only change** → compilation structurally unaffected (doc comments don't affect elaboration). Lean CI (if configured for this lake) will confirm; `lake build Utility` unaffected.
- **CRLF = 0** (pure LF, repo convention `core.autocrlf=input`).
- **Imports unchanged**: `Utility.Basic`, `Utility.Axioms`, `Utility.Representation`.

## Convention context (firsthand, G.1)

`decision_theory_lean` has 3 root aggregators + 9 substantive submodules:
- **Submodules** (Utility/, Gittins/, Coherence/): all 9 have `_en.lean` twins ✓ (fully harmonized).
- **Root aggregators**: `Gittins.lean` = inline bilingual (canonical model); `Coherence.lean` = has `Coherence_en.lean` sibling (both languages covered); `Utility.lean` = **was EN-only (gap)** → now inline bilingual (this PR).

After this PR, all 3 roots cover both languages. The `Coherence` root uses the `_en.lean` sibling approach (a minor convention drift from the Gittins inline-bilingual canonical form) — noted but left untouched here (it has full language coverage; the inline-vs-sibling choice for roots is a separate convention question, not a gap).

## Notes

- Lean source (not docs/README) → §E doc-cap does not apply; this is EPIC #4980 i18n substance.
- Markdown rule-paths N/A (Lean module).
- Collision-free: 0 OPEN PR on `Utility.lean`.

See #4980
