### PR TITLE
fix(qc): drop numeric prefix from Conclusion headers — residual small families (10 nb, See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/research/research_classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/research/research_classification.ipynb
@@ -1053,7 +1053,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Conclusion et Prochaines Etapes\n",
+    "## Conclusion et Prochaines Etapes\n",
     "\n",
     "### Recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/research/research_lstm.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/research/research_lstm.ipynb
@@ -914,7 +914,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 9. Conclusion et Prochaines Etapes\n",
+    "## Conclusion et Prochaines Etapes\n",
     "\n",
     "### Resume\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly_companion.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/kelly_lean/Kelly_companion.ipynb
@@ -481,7 +481,7 @@
    "id": "a8c8c639",
    "metadata": {},
    "source": [
-    "## 5. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "| Idee cle | Traduction |\n",
     "|---|---|\n",

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/01-ML-RandomForest/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/01-ML-RandomForest/research.ipynb
@@ -815,7 +815,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Conclusion et Pistes d'Iteration\n",
+    "## Conclusion et Pistes d'Iteration\n",
     "\n",
     "### Resultats\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/02-ML-XGBoost/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/02-ML-XGBoost/research.ipynb
@@ -715,7 +715,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. Conclusion et Pistes d'Iteration\n",
+    "## Conclusion et Pistes d'Iteration\n",
     "\n",
     "### Resultats\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb
@@ -629,7 +629,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. Conclusion et Pistes d'Iteration\n",
+    "## Conclusion et Pistes d'Iteration\n",
     "\n",
     "### Architecture\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_composite_ff_aw.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_composite_ff_aw.ipynb
@@ -1436,7 +1436,7 @@
     "tags": []
    },
    "source": [
-    "## 7. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce notebook reproduit l'architecture du Framework Composite TrendWeather avec les signaux FamaFrench (rotation factorielle) et AllWeather (socle defensif). Le sweep FF50-AW50 a FF80-AW20 avec top-1/2/3 facteurs et 4 seeds determine si la combinaison bat le SPY B&H.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_composite_mom_regime.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_composite_mom_regime.ipynb
@@ -825,7 +825,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Ce notebook combine SectorMomentum (composite momentum multi-lookback sur SPY/IEF/GLD) avec RegimeSwitching (filtre bull/bear/sideways adaptant l'allocation entre momentum et mean-reversion RSI). Le sweep SM50-RS50 a SM80-RS20 avec 4 seeds determine si la combinaison bat SPY B&H.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_risk_parity.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_risk_parity.ipynb
@@ -1182,7 +1182,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Tableau recapitulatif\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_vrp_putwrite.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_vrp_putwrite.ipynb
@@ -708,7 +708,7 @@
    "id": "3b49237a",
    "metadata": {},
    "source": [
-    "## 7. Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "### Tableau recapitulatif\n",
     "\n",


### PR DESCRIPTION
## Scope — L3966-L1 sweep on **QuantConnect residual small families** (See #3966)

Drop the numeric prefix from markdown Conclusion-family headers in the **QuantConnect Python residual small-family notebooks** (10 notebooks across 4 sub-scopes: `research/` 4, `Python/research/` 2, `kelly_lean/` 1, `partner-course-quant-trading/kit-transitoire/` 3). Continues the QC L3966 family started in #6042 (QC-Py core 7) + #6043 (ML-Training-Pipeline 9) + #6044 (projects/ 13). Same convention as the merged corpus-wide sweeps.

## Why

The `## N. Conclusion` decorative numbering is inconsistent with the rest of the corpus (most notebooks use unnumbered `## Conclusion`). EPIC #3966 standardizes visual formatting: drop the numeric prefix from conclusion-family headers. Markdown-only edit — no code cell touched, no re-execution needed (C.2 markdown exception). These are QuantBook/research notebooks but the edit is in markdown cells only; no QC Cloud re-exec required.

## Changes — 10 notebooks, 10 header edits (+10/−10)

| Sub-scope | Notebooks | Header (before → after) |
|-----------|-----------|-------------------------|
| `research/` | research_composite_ff_aw, research_composite_mom_regime, research_risk_parity, research_vrp_putwrite | `## N. Conclusion` → `## Conclusion` |
| `Python/research/` | research_classification, research_lstm | `## N. Conclusion` → `## Conclusion` |
| `kelly_lean/` | Kelly_companion | `## N. Conclusion` → `## Conclusion` |
| `partner-course/kit-transitoire/` | 01-ML-RandomForest, 02-ML-XGBoost, 03-Framework-Composite (research.ipynb) | `## N. Conclusion` → `## Conclusion` |

## Convention (strict)

- Drop the **`N. ` numeric prefix ONLY**. Keyword-gated: only Conclusion / Synth[èe]se / R[ée]capitulatif / Bilan headers touched. Non-conclusion numbered headers preserved verbatim (verified in `research_composite_ff_aw`: `## 1. Chargement`, `## 2. Signaux FamaFrench et AllWeather`, … `## 8. Exercices d'extension` all intact).
- **Accents preserved verbatim** — NOT #2876 (accent restoration). These 10 notebooks are plain `Conclusion` (no accents in the touched header), but the regex preserves `Récapitulatif`/`Synthèse` verbatim if present.

## Byte-identity approach (raw-text regex)

Raw-text regex (no json round-trip) — byte-for-byte preservation of the rest of the file. All 10 notebooks are UTF-8 direct (0 ASCII escapes detected), so json.dumps would also be safe, but raw-text regex is used for consistency and universal byte-safety (cf c.119 lesson on ASCII-escaped .NET notebooks).

```
PAT = re.compile(r'(#{1,6} )\d+\. (?=Conclusion|Synth|Recap|R(?:é|é)cap|Bilan)')
```

## Validation

```
Diff:           10 files changed, +10/-10  (exactly 10 one-line header edits)
JSON integrity: 0 invalid / 10 files
Residual scan:  0 numbered conclusion headers remaining in scope
Non-conclusion: ## 1. Chargement … ## 8. Exercices d'extension preserved (keyword-gate confirmed)
Catalogue:      0 CATALOG-STATUS / catalogue files touched (byte-identical)
Encoding mode:  10/10 UTF-8 direct (0 ASCII-escape churn)
```

Markdown-only → C.2 markdown exception (no re-exec). No catalogue files touched. No backtest/QC Cloud re-exec needed (markdown cells only).

## Out of scope (follow-up)

The broader QuantConnect L3966-L1 residual after this PR is ~30 notebooks in `projects/` (AdaptiveAssetAllocation, AllWeather, BTC-ML, … — the QuantBook projects not covered by #6044). Left for a dedicated `projects/` sweep PR to keep this one atomic and cohesive on the small families.

See #3966 (EPIC, partial — conclusion-family headers).

Co-Authored-By: Claude-Code <noreply@anthropic.com>