### PR TITLE
fix(notebook-tools): count_exercises detects print/display exercise stub markers (#6051 Bug 4)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -350,13 +350,33 @@ def count_exercises_in_notebook(path: Path) -> NotebookCount:
             break  # nearest preceding code cell is the only candidate
 
     # Second pass: code-cell exercises with NO preceding markdown header.
+    #
+    # A stub cell qualifies when it MENTIONS an exercise and IS a stub. The
+    # mention check has two layers: (1) the comment-aware `_code_cell_mentions_
+    # exercise` (a full-line comment names the exercise), AND (2) a broader
+    # full-source scan for the exercise word. Layer (2) catches stubs whose
+    # exercise reference is NOT in a `#`/`//`/`--` comment -- e.g. a C#
+    # `display("Exercice 2 a completer ...")` or Python `print("Exercice ...")
+    # stub marker, or a stub whose `# Partie N` / `# Etape` header carries no
+    # "exercice" word at all but the cell prints one (SC-26-Final-Project
+    # Parties 2/3/4). Layer (2) is safe because pass-2 still requires
+    # `_is_stub_code`, so a complete solution mentioning "exercice" in prose is
+    # never counted; and `paired_code_indices` (built in the unchanged
+    # pairing pass) already excludes header-paired stubs, so this only adds
+    # genuinely-unpaired stubs -- monotonic non-decrease per notebook by
+    # construction (pairing is untouched, the disjunct only widens detection).
     for i, cell in enumerate(cells):
         if cell.get("cell_type") != "code":
             continue
         if i in paired_code_indices:
             continue
         source = "".join(cell.get("source", []))
-        if _code_cell_mentions_exercise(source) and _is_stub_code(source):
+        mentions_exercise = (
+            _code_cell_mentions_exercise(source)
+            or bool(EXERCISE_WORD_RE.search(source))
+            or bool(EXERCISE_WORD_EN_RE.search(source))
+        )
+        if mentions_exercise and _is_stub_code(source):
             result.exercises.append(
                 ExerciseHit(
                     cell_index=i,

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -217,6 +217,45 @@ class TestCodeCellOnlyExercise:
         # The header is the canonical representative; the stub is absorbed.
         assert all(h.detected_by == "markdown_header" for h in result.exercises)
 
+    def test_stub_with_print_exercice_marker_no_comment_is_counted(
+        self, tmp_path
+    ):
+        """Trap case (#6051 Bug 4): a stub code cell whose exercise reference is
+        NOT in a ``#``/``//``/``--`` comment -- e.g. a ``print("Exercice ... a
+        completer")`` / ``display(...)`` stub marker, or a ``# Partie N`` /
+        ``# Etape`` scaffold whose only "exercice" word lives in a print
+        statement. The comment-aware ``_code_cell_mentions_exercise`` misses it;
+        the broadened full-source scan in pass-2 must catch it (genuine case:
+        SC-26-Final-Project Parties 2/3/4, reported 0 for 3 real stubs).
+        """
+        nb = _write_nb(
+            tmp_path / "print_marker.ipynb",
+            [
+                _md("# Titre"),
+                _md("### Partie 1 : Chiffrement"),
+                _code(
+                    "# Partie 2 : Paillier\n"
+                    "# Etape: Implementer le chiffrement\n"
+                    "# Indice: voir SC-16\n"
+                    'pass  # Etape: Implementez\n'
+                    'print("Exercice a completer")'
+                ),
+                _md("### Partie 3 : ZKP"),
+                _code(
+                    "# Partie 3 : Preuve\n"
+                    "# TODO\n"
+                    'display("Exercice 3 a completer")\n'
+                    "pass"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 2, (
+            "Stub cells whose exercise word is only in a print/display marker "
+            "(not a #/// //-- comment) must be counted via the broadened scan"
+        )
+        assert all(h.detected_by == "code_cell_comment" for h in result.exercises)
+
     def test_stub_preceding_different_number_header_is_not_absorbed(
         self, tmp_path
     ):


### PR DESCRIPTION
fix(notebook-tools): count_exercises broadened pass-2 detects print/display exercise stub markers (#6051 Bug 4)

The second pass of count_exercises.py only flagged a code cell as an
exercise when `_code_cell_mentions_exercise` found the exercise word in a
full-line `#`/`//`/`--` comment. A stub whose only "exercice" reference
lives in a `print("Exercice a completer")` / `display("Exercice 2 ...")`
marker -- or a `# Partie N` / `# Etape` scaffold with no "exercice" word
in any comment at all -- escaped detection and was silently under-counted.

Genuine corpus case (firsthand, #6051 Bug 4):
  SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
    Parties 2/3/4 are real student stubs (# Etape / pass / # Indice /
    print("Exercice...)) but reported count = 0. Reality: 3.

Fix: in pass-2, a stub cell qualifies when it MENTIONS an exercise via
either (1) the comment-aware check, OR (2) a full-source scan for the
exercise word. Pass-2 still requires `_is_stub_code`, so a complete
solution mentioning "exercice" in prose is never counted. The pairing
pass (which builds `paired_code_indices`) is UNCHANGED, so this only
adds genuinely-unpaired stubs -- monotonic non-decrease per notebook by
construction.

Validation (full 921-notebook corpus, this branch):
  - DECREASED (regression): 0 notebooks
  - INCREASED (improved):    14 notebooks
    * SC-26-Final-Project:    0 -> 3  (correct: 3 real stubs Parties 2/3/4)
    * ICT-19-EnjeuBattery:    1 -> 3  (correct: s1_step/s3_step/custom_step)
    * App-13-TSP-Metaheuristics: 6 -> 9
    * QC-Py-12/13:            3 -> 6
    * (+ 9 others, each +1: previously-missed real stubs)
  Detected SC-26 cells 9/14/19 verified firsthand = the 3 real stubs
  (Chiffrement Paillier / Preuve ZKP / Integration). No over-counting.

Tests: 36 passed (35 original + 1 new regression locking the fix:
test_stub_with_print_exercice_marker_no_comment_is_counted).

Scope: partial fix for #6051 -- resolves Bug 4 (print/display markers).
Bugs 1 (grouped markdown headers), 2 (section-pairing theft), 3
(docstring stubs) require a pairing/section-header refactor and remain
open in the tracker.

See #6051

Co-Authored-By: Claude-Code <noreply@anthropic.com>
