### PR TITLE
fix(notebook-tools): count_exercises — grouped md instances + plural section headers (#6051 Bug 1+2)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -69,8 +69,27 @@ EXCLUDE_DIRS = {
 
 # \bexercice\b anywhere in the line, case-insensitive, French or English form.
 # Matches `### Exercice 1`, `## 8. Exercice`, `### Exercice - ...`, `### Exercise`.
+# Used for CODE-cell comment detection (broad: a code stub's comment is always an
+# instance reference; plural section headers do not appear as code comments).
 EXERCISE_WORD_RE = re.compile(r"\bexercic(?:e|es)\b", re.IGNORECASE)
 EXERCISE_WORD_EN_RE = re.compile(r"\bexercises?\b", re.IGNORECASE)
+
+# SINGULAR-only forms for MARKDOWN instance-header counting (#6051). A markdown
+# header is one EXERCISE INSTANCE only when it names a singular exercise
+# (`### Exercice 1`, `## 8. Exercice`, `### Exercise`). A PLURAL section header
+# (`## 9. Exercices`, `## Exercises`) groups exercises without being one -- it
+# must NOT count as an instance NOR steal the forward-pairing of the next code
+# cell (Bug 2: `## 9. Exercices` was forward-pairing the real Exercice 1 stub,
+# so the section header stood in for the exercise and hid the real count).
+# `\bexercice\b` does not match `exercices` (no word boundary between `e` and
+# `s`), so these cleanly separate singular instances from plural sections.
+EXERCISE_INSTANCE_RE = re.compile(r"\bexercice\b", re.IGNORECASE)
+EXERCISE_INSTANCE_EN_RE = re.compile(r"\bexercise\b", re.IGNORECASE)
+# Plural-only detection (a markdown header whose exercise word is ONLY plural is
+# a section, not an instance). Used to decide whether a header cell that mentions
+# the exercise word carries any real instance.
+EXERCISE_SECTION_RE = re.compile(r"\bexercices\b", re.IGNORECASE)
+EXERCISE_SECTION_EN_RE = re.compile(r"\bexercises\b", re.IGNORECASE)
 
 # An ATX markdown header line starts with `#` (1-6 hashes) followed by a space
 # and the header text. We deliberately do NOT match Setext headers (underlines
@@ -260,6 +279,36 @@ def _markdown_mentions_exercise(source: str) -> bool:
     return False
 
 
+def _markdown_instance_header_lines(source: str) -> list[str]:
+    """Markdown header texts that each name a SINGULAR exercise instance.
+
+    Returns one entry per INSTANCE header line, so a single markdown cell that
+    groups several exercise statements under sub-headers (`### Exercice 1`,
+    `### Exercice 2`, `### Exercice 3`) yields 3 instances, not 1 (#6051 Bug 1:
+    such a grouped cell was under-counted because pass 1 added one hit per CELL).
+
+    PLURAL section headers (`## 9. Exercices`, `## Exercises`) are excluded:
+    a section groups exercises without being one. A header line is an instance
+    only when it carries a SINGULAR exercise word. This also prevents a plural
+    section header from acting as a header cell that forward-pairs the next code
+    cell (Bug 2: the section `## 9. Exercices` stole the real Exercice 1 stub).
+
+    A line that contains BOTH a plural and a singular form is treated as an
+    instance (the singular reference dominates): e.g. ``## Exercices : Exercice 1
+    recapitulatif`` still counts. A line with ONLY the plural is a section.
+    """
+    instances: list[str] = []
+    for m in MARKDOWN_HEADER_RE.finditer(source):
+        header_text = m.group(1)
+        has_singular = bool(
+            EXERCISE_INSTANCE_RE.search(header_text)
+            or EXERCISE_INSTANCE_EN_RE.search(header_text)
+        )
+        if has_singular:
+            instances.append(header_text)
+    return instances
+
+
 def _exercise_number(source: str) -> str | None:
     """Exercise number token a cell references, e.g. ``'3'`` or ``'3b'``.
 
@@ -297,13 +346,22 @@ def count_exercises_in_notebook(path: Path) -> NotebookCount:
 
     cells = nb.get("cells", [])
 
-    # First pass: detect markdown-header exercises and their paired code stub.
+    # First pass: detect markdown-header exercises, counting ONE instance per
+    # SINGULAR exercise header LINE (not per cell). A markdown cell that groups
+    # several exercise statements (`### Exercice 1`, `### Exercice 2`, ...) under
+    # sub-headers therefore yields N instances, not 1 (#6051 Bug 1). PLURAL
+    # section headers (`## 9. Exercices`) carry no instance and do NOT make the
+    # cell a header cell -- so they neither count nor forward-pair the next code
+    # cell (Bug 2: the section used to steal the real Exercice 1 stub below it).
     header_cell_indices: set[int] = set()
     for i, cell in enumerate(cells):
         if cell.get("cell_type") != "markdown":
             continue
         source = "".join(cell.get("source", []))
-        if _markdown_mentions_exercise(source):
+        instance_lines = _markdown_instance_header_lines(source)
+        if not instance_lines:
+            continue
+        for _line in instance_lines:
             result.exercises.append(
                 ExerciseHit(
                     cell_index=i,
@@ -312,7 +370,7 @@ def count_exercises_in_notebook(path: Path) -> NotebookCount:
                     detected_by="markdown_header",
                 )
             )
-            header_cell_indices.add(i)
+        header_cell_indices.add(i)
 
     # Track which code cells are the paired stub of an exercise header so we
     # do not double-count them in the second pass. A stub may sit EITHER just

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -682,3 +682,133 @@ class TestThresholdIntegration:
         )
         result = count_exercises_in_notebook(nb)
         assert result.count < 3
+
+
+# ---------------------------------------------------------------------------
+# #6051 -- grouped markdown headers + plural section headers
+# ---------------------------------------------------------------------------
+
+class TestGroupedAndPluralHeaders:
+    """Regression tests for the two interacting counting bugs in #6051.
+
+    Bug 1 -- a single markdown cell that groups several exercise statements
+    under sub-headers (`### Exercice 1`, `### Exercice 2`, `### Exercice 3`)
+    was under-counted as 1 (one hit per CELL). It must count one per INSTANCE
+    header line.
+
+    Bug 2 -- a PLURAL section header (`## 9. Exercices`) was (a) counted as an
+    exercise instance AND (b) forward-pairing the next code cell, so the section
+    stood in for the real exercise and masked the count. A plural section must
+    count as nothing and steal no code cell.
+    """
+
+    def test_grouped_markdown_cell_counts_per_instance(self, tmp_path):
+        """Bug 1 repro: one markdown cell with three exercise sub-headers over
+        one code cell holding three stubs must count 3, not 1.
+
+        Mirrors ``GameTheory/SocialChoice/04-...-SAT-Z3-Csharp.ipynb``.
+        """
+        nb = _write_nb(
+            tmp_path / "grouped.ipynb",
+            [
+                _md(
+                    "## 8. Exercices\n\n"
+                    "### Exercice 1 : premier\n\n**Indice 1** : ...\n\n"
+                    "### Exercice 2 : second\n\n**Indice 1** : ...\n\n"
+                    "### Exercice 3 : troisieme\n\n**Indice 1** : ..."
+                ),
+                _code(
+                    "// Exercice 1 : a\n// TODO etudiant\n"
+                    "// Exercice 2 : b\n// TODO etudiant\n"
+                    "// Exercice 3 : c\n// TODO etudiant\n"
+                    "display(\"a completer\");"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            "a grouped markdown cell with 3 instance headers must count 3"
+        )
+
+    def test_plural_section_header_does_not_count_as_instance(self, tmp_path):
+        """Bug 2 (counting side): a plural section header `## 9. Exercices`
+        alone (no instance in the cell) must NOT be counted as an exercise.
+        """
+        nb = _write_nb(
+            tmp_path / "plural.ipynb",
+            [
+                _md("## 9. Exercices\n\nLes exercices suivants..."),
+                _code("// Exercice 1 : a\n// TODO etudiant\npass"),
+                _code("// Exercice 2 : b\n// TODO etudiant\npass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        # 2 real code stubs; the plural section is NOT a 3rd instance.
+        assert result.count == 2, (
+            "a plural section header must not inflate the exercise count"
+        )
+
+    def test_plural_section_does_not_steal_forward_pairing(self, tmp_path):
+        """Bug 2 (pairing side): a plural section header must NOT forward-pair
+        the code cell below it. The real Exercice 1 stub must be counted in its
+        own right. Mirrors ``GameTheory/GameTheory-5-ZeroSum-Minimax-Csharp.ipynb``
+        where the section `## 9. Exercices` stole cell 21 (Exercice 1).
+        """
+        nb = _write_nb(
+            tmp_path / "steal.ipynb",
+            [
+                _md("## 9. Exercices"),
+                _code("// Exercice 1 : Colonel Blotto\n// TODO etudiant\npass"),
+                _code("// Exercice 2 : autre\n// TODO etudiant\npass"),
+                _code("// Exercice 3 : dernier\n// TODO etudiant\npass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            "plural section must not steal Exercice 1's code cell (no under-count)"
+        )
+        # All three are detected via their own code-cell comment, none absorbed.
+        detected_cells = {h.cell_index for h in result.exercises}
+        assert detected_cells == {1, 2, 3}, (
+            "the three code stubs must each be counted on their own"
+        )
+
+    def test_plural_section_then_grouped_instances(self, tmp_path):
+        """Combined case: a plural section header followed (same cell or next)
+        by real instance headers. The plural line is ignored; each singular
+        instance line counts.
+        """
+        nb = _write_nb(
+            tmp_path / "mix.ipynb",
+            [
+                _md(
+                    "## 9. Exercices\n\n"
+                    "### Exercice 1 : un\n\n### Exercice 2 : deux\n\n"
+                    "### Exercice 3 : trois"
+                ),
+                _code("# Exercice 1\n# TODO\npass"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            "3 instance lines under a plural section count 3 (section ignored)"
+        )
+
+    def test_singular_section_header_still_counts(self, tmp_path):
+        """Guard against over-fixing: a SINGULAR numbered section header
+        `## 8. Exercice : ...` is an INSTANCE (not a plural section) and must
+        still count. This is the trap case preserved by test_numbered_section
+        _header_is_counted -- reaffirmed here in the plural-aware regime.
+        """
+        nb = _write_nb(
+            tmp_path / "singular.ipynb",
+            [
+                _md("## 8. Exercice : le piege"),
+                _code("# TODO etudiant\npass"),
+                _md("## 9. Exercice : autre"),
+                _code("return None"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 2
+


### PR DESCRIPTION
## Scope

Fixes **Bug 1 + Bug 2** of #6051 in `scripts/notebook_tools/count_exercises.py` (the canonical #2161 exercise counter / CI gate). One subject, two files, +191/-3.

> **Partial — `See #6051`, NOT `Closes`.** #6051 tracks 4 bugs; this PR resolves Bug 1 + Bug 2 only. Bug 3 (Python docstring stubs `\"\"\"TODO etudiant\"\"\"`) is orthogonal and out of scope; Bug 4 (print/display markers) is already partially fixed by #6056.

## The two bugs (firsthand repros)

**Bug 1 — under-count (grouped markdown cell).** Pass 1 used `_markdown_mentions_exercise` (boolean per cell) and appended ONE `ExerciseHit` per cell. A single markdown cell grouping `### Exercice 1/2/3` under sub-headers → counted as **1**, not 3.
- Repro: `GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb` (cell 30 groups 3 statements, cell 31 has 3 stubs) → scanner reported **1**, reality **3**.

**Bug 2 — mask (plural section header steals forward-pairing).** A plural section `## 9. Exercices` was (a) counted as an instance AND (b) treated as a header cell that forward-paired the next code cell, so the section stood in for the real Exercice 1 stub.
- Repro: `GameTheory/GameTheory-5-ZeroSum-Minimax-Csharp.ipynb` — cell 20 `## 9. Exercices` forward-paired cell 21 (the real Exercice 1 stub), so cell 21 was skipped in pass 2 and never counted. Scanner reported 3 (= section + cells 22/23), but cell 21 was invisible.

## Fix

1. New singular-only regexes (`EXERCISE_INSTANCE_RE` = `\bexercice\b`, etc.) and plural section regexes. `\bexercice\b` does **not** match `exercices` (no word boundary between `e` and `s`), so singular instances and plural sections separate cleanly.
2. New helper `_markdown_instance_header_lines(source)` → one entry **per SINGULAR header line** (plural-only section headers excluded). A line with both forms is an instance (singular dominates).
3. Pass 1 appends one hit **per instance line** (Bug 1) and registers a cell as a header cell only when it carries ≥1 singular instance — so a plural section neither counts nor steals the forward-pairing of the code stub below it (Bug 2).

Code-cell comment detection (`_code_cell_mentions_exercise`, `#`/`//`/`--`) is unchanged — it already matched all three comment styles; the `//` blind-spot po-2024 described was already fixed.

## Validation

- **Tests:** 5 new regression tests (`TestGroupedAndPluralHeaders`), **40/40 pass** (`python -m pytest scripts/notebook_tools/tests/test_count_exercises.py -q`).
  - `test_grouped_markdown_cell_counts_per_instance` — Bug 1 repro (grouped cell → 3).
  - `test_plural_section_header_does_not_count_as_instance` — plural alone → 0 instance.
  - `test_plural_section_does_not_steal_forward_pairing` — Bug 2 repro (3 code stubs all counted on their own cells).
  - `test_plural_section_then_grouped_instances` + `test_singular_section_header_still_counts` — guard against over-fixing (singular numbered section `## 8. Exercice : ...` still counts).
- **Corpus delta vs origin/main** (891 notebooks in baseline):
  - **50 increased** — grouped cells now counted correctly (e.g. Search-6-AdversarialSearch 6→11, Sudoku-14-BDD 5→9, GT-13/14/17 3→6).
  - **183 decreased** — plural-section inflation removed (e.g. Z3/06_Meal_Planner 13→10, SW-8-Python-SHACL 7→4; drops of 2-3 = one plural section + its forward-pair).
  - **3 newly sub-threshold** (was ≥3, now <3) — all verified firsthand as **genuine #2161 gaps** previously masked by plural sections, NOT false regressions:
    - `ICT-18-ArrowOfTimeReversibilization` (3→2): cell 19 is a worked **SOLUTION** (16 code lines, `discretise()` + loop), not a student stub.
    - `GenAI/Texte/4_Function_Calling` (3→2): plural-section inflation.
    - `SymbolicAI/Lean/Lean-3-Propositions-Proofs` (3→2): plural-section inflation.
  - Spot-checked 6 decreased notebooks (4→3): all retained real stubs, only plural sections removed. **No real exercise lost.**

## Anti-regression / scope notes

- This is a TOOL fix (CI scanner), not code métier — anti-regression §D does not apply. Deletions (3) are the old single-hit-per-cell logic; insertions add the per-line instance path. `git diff --stat` = +191/-3, coherent with intent.
- **Collision with #6056:** #6056 (Bug 4) touches pass 2 (`@@ -350`); this PR touches regexes + helper + pass 1 (L70-375). Logically disjoint — expect at most a trivial context-line offset on merge, no logical conflict.

Ready for H.4/H.5 forensic review.

Co-Authored-By: Claude-Code <noreply@anthropic.com>