### PR TITLE
docs(ledgers): §B Lean forensic review of #6058 (SocialChoice absorption — block on Lake build)

### DIFF
--- a/docs/ledgers/reviews/2026-07-11-b-lean-6058.md
+++ b/docs/ledgers/reviews/2026-07-11-b-lean-6058.md
@@ -1,0 +1,50 @@
+# c.409 — §B Lean forensic review of PR #6058 (feat(lean,#4365): absorb SocialChoice into game_theory_lean)
+
+Cross-lane §B Lean forensic (po-2023 c.357 author, po-2024 reviewer — reciprocity pattern, ≠ self-reinforcement) of PR #6058 (`feat(lean,#4365): absorb SocialChoice (Arrow+Sen+Voting FR+EN) into game_theory_lean`, author po-2023 c.357 per lakefile comment, `feature/lean-regroupement-social-choice-4365`). EPIC #4365 Phase 4 anti-prolifération: copies 16 files (7 FR modules + 7 `_en` siblings + `_SmokeTest` + root `SocialChoice.lean`) byte-identique from `social_choice_lean/` into `game_theory_lean/SocialChoice/`, adds `lean_lib SocialChoice` to `game_theory_lean/lakefile.lean`.
+
+## Verdict §B (Lean PR, 4 elements per [pr-review-discipline.md](../../../.claude/rules/pr-review-discipline.md) §B)
+
+| # | Element | Result | Blocker |
+|---|---------|--------|---------|
+| 1 | `grep -c sorry` before/after | **0 → 0** (Sorry check (game_theory_lean) PASS, Proof integrity (no sorry) PASS) | NON |
+| 2 | Lake build SUCCESS | **FAIL** — generic `lake -R build` red: `error: SocialChoice: some modules have bad imports` | **OUI** |
+| 3 | Proof integrity (no sorry) | PASS (CI) | NON |
+| 4 | Imports/namespace coherence | **FAIL** — duplicate `lean_lib SocialChoice` declaration across two lakes | **OUI** |
+
+**Verdict §B final** : PR #6058 = **CHANGES_REQUESTED — block on Lake build CI red**. Per [lean-merge-discipline.md](../../../.claude/rules/lean-merge-discipline.md) HARD: "Lake build SUCCESS local OBLIGATOIRE avant merge. Le claim 'lake build SUCCESS' dans le body PR n'est PAS suffisant." The specific per-lake check PASSes, but the repo-wide build FAILS — the contradiction is the finding.
+
+## Root cause (firsthand, G.1)
+
+The CI `Lake build` (generic, `lake -R build` repo-wide) fails with `error: SocialChoice: some modules have bad imports` — a **build-graph/module-resolution failure**, NOT a compile error (no `file:line:col: error:` in the log). Diagnosis verified firsthand:
+
+1. **Duplicate `lean_lib SocialChoice` declaration.** Both lakes declare the SAME module root:
+   - `social_choice_lean/lakefile.lean` L14: `lean_lib «SocialChoice» where` with explicit globs `SocialChoice.Arrow`, `SocialChoice.Basic`, … `SocialChoice._SmokeTest` (15 modules).
+   - `game_theory_lean/lakefile.lean` (PR #6058): adds `lean_lib SocialChoice where globs := #[`SocialChoice.*]`.
+   Both lakes expose `SocialChoice.Basic`, `SocialChoice.Arrow`, etc. → repo-wide `lake -R build` hits a module-path collision → "some modules have bad imports" (Lake cannot resolve `SocialChoice.X` unambiguously across two simultaneously-declared libs).
+
+2. **Per-lake build PASSes in isolation.** `Lake build (game_theory_lean)` PASS (3m40s) + `Lake build (cooperative_games_lean)` PASS — because each builds alone, with no collision. Only the generic repo-wide build sees both declarations and fails. This generic-vs-per-lake contradiction is the signature of the duplicate-namespace bug.
+
+3. **The author flagged the old lake stays but didn't account for the repo-wide build.** `game_theory_lean/lakefile.lean` comment (PR): «Lake source `social_choice_lean/` reste en place … sera archive en follow-up post-merge.» — the deferral is exactly what breaks the build: as long as BOTH lakes declare `lean_lib SocialChoice`, the repo-wide `lake -R build` is red.
+
+4. **NOT pre-existing on main.** Before #6058, only `social_choice_lean` declared `SocialChoice` (1 declaration, no collision). #6058 introduces the 2nd declaration → the regression is PR-specific.
+
+5. **Imports themselves are clean.** Firsthand grep of all 8 FR + 8 `_en` modules: every `import SocialChoice.X` / `SocialChoice.X_en` resolves to an existing file in `game_theory_lean/SocialChoice/`; Mathlib imports are standard; root `SocialChoice.lean` aggregator imports 6 existing submodules. So the "bad imports" is NOT a typo'd import line — it is the Lake build-graph choking on the duplicate lib declaration.
+
+## Recommended fix (for po-2023 / ai-01)
+
+Neutralize the collision in THIS PR (not follow-up), one of:
+- **(a) Disable social_choice_lean's `lean_lib «SocialChoice»`** declaration (comment out L14-45) in this PR, keeping the files+docs as archive — only `game_theory_lean` then declares `SocialChoice`.
+- **(b) Archive `social_choice_lean/`** (move to `social_choice_lean/_archive/` or remove the lakefile) in this PR.
+- **(c) If ai-01 confirms the generic `lake -R build` check is non-blocking** (known to red on intentional duplicates, per-lake build = canonical gate), document that decision on the PR and proceed — but this contradicts lean-merge-discipline HARD, so (a)/(b) preferred.
+
+## G.1 firsthand ledger
+
+1. **PR #6058 OPEN**, author jsboige (merge-credential), 0 review — self-identification in lakefile comment "c.357 (po-2023)" = po-2023 author → cross-lane §B legitimate.
+2. **CI** : `gh pr checks 6058` — `Lake build` FAIL 2m16s; `Lake build (game_theory_lean)` PASS 3m40s; `Sorry check (game_theory_lean)` PASS; `Proof integrity (no sorry)` PASS. UNSTABLE / MERGEABLE.
+3. **Failing job log** (`gh run view 29145939065 --log-failed`): exit code 1, "(no file:line:col: errors — likely build-graph/module-resolution failure)", `error: SocialChoice: some modules have bad imports`.
+4. **Duplicate declaration verified**: `grep "lean_lib" social_choice_lean/lakefile.lean` → L14 `lean_lib «SocialChoice»` + explicit globs L38-45; PR diff → game_theory_lean adds `lean_lib SocialChoice`.
+5. **Imports verified clean**: `git show origin/feature/lean-regroupement-social-choice-4365:...SocialChoice/*.lean` — all `import SocialChoice.X` resolve, Mathlib standard.
+
+## Conclusion
+
+Real substance PR (Lean anti-prolifération, sorry-free 0→0), but the "copy, don't move" approach leaves two lakes declaring `lean_lib SocialChoice`, which reds the repo-wide `lake -R build`. Block until the duplicate declaration is reconciled (disable/archive the old `social_choice_lean` lib in this PR). The author's own "sera archive en follow-up" deferral is the precise gap — the follow-up must land WITH this PR, not after. ai-01: do NOT batch-merge on the per-lake PASS alone; the generic Lake build red is a genuine build-graph regression per lean-merge-discipline.


### PR DESCRIPTION
docs(ledgers): §B Lean forensic review of #6058 (SocialChoice absorption — block on Lake build)

Cross-lane §B Lean forensic (po-2023 c.357 author, po-2024 reviewer) of PR #6058
(feat(lean,#4365): absorb SocialChoice into game_theory_lean).

Verdict: CHANGES_REQUESTED — block on Lake build CI red. The generic
`lake -R build` fails with `error: SocialChoice: some modules have bad
imports` (build-graph/module-resolution failure, not a compile error),
while the per-lake `Lake build (game_theory_lean)` PASSes. Root cause
verified firsthand: DUPLICATE `lean_lib SocialChoice` declaration —
social_choice_lean/lakefile.lean L14 AND game_theory_lean (PR) both
declare `lean_lib SocialChoice`, so the repo-wide build hits a
module-path collision. Imports themselves are clean (every
`import SocialChoice.X` resolves). Not pre-existing on main (before
#6058 only one lake declared SocialChoice).

Recommended fix: neutralize the old social_choice_lean lib declaration
in THIS PR (disable/archive), not follow-up — the author's "sera
archive en follow-up" deferral is the precise gap.

sorry 0->0 (Sorry check + Proof integrity PASS). Per lean-merge-discipline
HARD, ai-01 should not batch-merge on the per-lake PASS alone.

See #6058, #4365

Co-Authored-By: Claude-Code <noreply@anthropic.com>
