### PR TITLE
docs(tweety): de-spaghetti README — remontée Installation dans la porte de setup (See #5985)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -303,6 +303,28 @@ pip install jpype1 requests tqdm clingo z3-solver python-sat
 | **Z3** | SMT solver, MARCO | `pip install z3-solver` |
 | **PySAT** | SAT/MaxSAT moderne | `pip install python-sat` |
 
+## Installation
+
+### Packages Python requis
+
+```bash
+pip install jpype1 requests tqdm clingo z3-solver python-sat
+```
+
+### Vérification de l'environnement
+
+```bash
+# Lancer le notebook de setup
+jupyter notebook Tweety-1-Setup.ipynb
+# Exécuter toutes les cellules — il télécharge JDK, JARs, outils externes
+
+# Ou utiliser le script de validation
+cd scripts
+python verify_all_tweety.py --quick
+```
+
+JDK 17 et les 42 JARs (39 modules TweetyProject 1.30 + 3 dépendances externes : args4j, commons-math, sat4j) sont téléchargés automatiquement par le notebook de setup. Aucune installation système requise.
+
 ## Architecture
 
 ```
@@ -529,28 +551,6 @@ flowchart LR
 ```
 
 **Extension grounded** : `C` n'est attaqué par personne → **accepté** ; `B` est attaqué par l'accepté `C` → **rejeté** ; `A` n'est attaqué que par le rejeté `B` → **accepté**. D'où `{A, C}`. La règle se tient en une phrase : *un argument est acceptable si tous ses attaquants sont eux-mêmes défaits*. Les sémantiques preferred/stable, les cycles (CF2) et le raisonnement causal du notebook 5 raffinent ce même calcul.
-
-## Installation
-
-### Packages Python requis
-
-```bash
-pip install jpype1 requests tqdm clingo z3-solver python-sat
-```
-
-### Vérification de l'environnement
-
-```bash
-# Lancer le notebook de setup
-jupyter notebook Tweety-1-Setup.ipynb
-# Exécuter toutes les cellules — il télécharge JDK, JARs, outils externes
-
-# Ou utiliser le script de validation
-cd scripts
-python verify_all_tweety.py --quick
-```
-
-JDK 17 et les 42 JARs (39 modules TweetyProject 1.30 + 3 dépendances externes : args4j, commons-math, sat4j) sont téléchargés automatiquement par le notebook de setup. Aucune installation système requise.
 
 ## Validation des Notebooks
 


### PR DESCRIPTION
## Scope

`#5985` README de-spaghetti residual — **Tweety**. One file, pure block reorder, +22/-22.

The **Installation** section was buried at **L533 (71% of the file)**, after six deep technical sections (Architecture → Outils Externes → Limitations → Modules TweetyProject → Concepts clés → Domaines d'application). A reader wanting to install Tweety had to scroll past all the per-module detail to find `pip install ...`. Same inverted-pyramid violation fixed in Probas/Infer (#6031, MERGED): the **setup gate must come before the deep per-notebook detail**.

## Change

Pure block reorder — the 22-line Installation block (`### Packages Python requis` + `### Vérification de l'environnement`) moves up to sit right after **Prérequis**, consolidating a contiguous setup gate:

| | Before | After |
|---|---|---|
| Quick Start | L253 (34%) | L253 (34%) |
| Prérequis | L267 (36%) | L267 (36%) |
| **Installation** | **L533 (71% — buried)** | **L306 (41% — in setup gate)** |
| Architecture | L306 | L328 |

Reader now hits Quick Start → Prérequis → Installation as one setup gate, *before* Architecture/Outils/Modules detail.

## Validation (pure reorder)

- **multiset-diff = 0** — `collections.Counter(lines) == collections.Counter(new_lines)` assertion passed (pure move, no content add/remove).
- **748 → 748 lines**, `git diff --numstat` = `22 22` (the 22-line block removed from old position, inserted at new).
- **CATALOG-STATUS marker (L5-10) byte-identical** — NOT regenerated on the branch (catalog-pr-hygiene HARD 1: the catalogue is automation property; only the cron/CI may regenerate it). Verified unchanged.
- **LF-only, CRLF = 0** (asserted on bytes).
- **No content added/removed/merged.** The Quick Start ↔ Installation pip-command overlap already existed (scattered); editorial dedup is a separate PR if desired.

## Why this is bounded + honest

- On the `#5985` dashboard residual list explicitly: "Résiduel GenAI/ML/Sudoku/Tweety à scanner (Prérequis/Installation enfouis)".
- Tweety = SOTA axe-2 ledger **owner-floue po-2025** (entry #002) — my turf, no collision (last Tweety README PR #5644 MERGED 2026-07-07, no open branch).
- ai-01 steer 06:54Z pivots to **substance** (Lean sorries / séries notebook / moteurs SOTA axe-2). I verified firsthand this cycle that all three substance plats are **unavailable to po-2025 right now** (Lean sorries = po-2026 active collision on conway_lean + intrinsic; #4433 = gated on user plan sign-off; SOTA axe-2 = 17/17 SOTA-OK already, GenAI = po-2023 lead). This README reorder is the **capped doc fallback** (genuine pedagogical value, inverted-pyramid UX), not filler — transparent per G.9.
- Single-subject, 1 file, no notebook touched = no re-exec, no C.2 concern.

`See #5985` (partial — residual README de-spaghetti). `See #3975` (Tweety feuille README).

Co-Authored-By: Claude-Code <noreply@anthropic.com>