### PR TITLE
fix(prover): close depth-3 verification gap in 8 sibling call sites (See #1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -243,7 +243,15 @@ def is_true_placeholder_goal(filepath: str, sorry_line: int) -> Tuple[bool, str]
         return False, ""
 
     from .verifier import get_verifier
-    project_dir = str(Path(filepath).resolve().parent.parent)
+    # FX-5 depth-3 hardening (#1453 follow-up to PR #5982): `parent.parent` only
+    # works for files at the top package (e.g. `Conway/Nim.lean`); for deeper
+    # files like `Conway/Life/HashlifeCorrectness.lean` the resulting dir has no
+    # lakefile and the verifier would build the wrong module — silently
+    # degrading TRUE_PLACEHOLDER_GOAL detection to "no refusal". resolve_lake_module
+    # walks up to the real Lake root so the FX-5 probe actually compiles against
+    # the target file. See #5982 commit log for the founding LSP fix that exposed
+    # this identical pattern in 8 still-broken call sites.
+    project_dir, _module = resolve_lake_module(filepath)
     verifier = get_verifier(project_dir)
     subdir = Path(filepath).parent.name
     relative_path = f"{subdir}/_GoalExtract.lean"
@@ -417,8 +425,12 @@ def get_goal_state(filepath: str, sorry_line: int) -> Optional[str]:
         print(f"  [GoalExtract] Deeply nested sorry (indent={indent}), using heuristic")
         return _heuristic_goal_extract(lines, sorry_line)
 
-    project_dir = Path(filepath).parent.parent
-    verifier = get_verifier(str(project_dir))
+    # depth-3 hardening (#1453 follow-up to PR #5982): same `parent.parent`
+    # bug as `is_true_placeholder_goal` above — for files nested below the top
+    # package (e.g. `Conway/Life/HashlifeCorrectness.lean`) the resulting dir
+    # has no lakefile and the verifier probe compiles against the wrong module.
+    project_dir, _module = resolve_lake_module(filepath)
+    verifier = get_verifier(project_dir)
     subdir = Path(filepath).parent.name
     relative_path = f"{subdir}/_GoalExtract.lean"
     tmp_path = Path(filepath).parent / "_GoalExtract.lean"
@@ -959,8 +971,13 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
     tmp_path = Path(filepath).parent / "_SorryVerify.lean"
     tmp_path.write_text(new_content, encoding="utf-8")
 
-    # Verify using verify_project_file (no command-line length limit)
-    verifier = get_verifier(str(Path(filepath).parent.parent))
+    # Verify using verify_project_file (no command-line length limit).
+    # depth-3 hardening (#1453 follow-up to PR #5982): for files nested below
+    # the top package (e.g. `Conway/Life/HashlifeCorrectness.lean`) the
+    # legacy `parent.parent` dir has no lakefile — resolve_lake_module walks
+    # up to the real Lake root so the probe compiles against the right module.
+    project_dir, _module = resolve_lake_module(filepath)
+    verifier = get_verifier(project_dir)
     subdir = Path(filepath).parent.name
     relative_path = f"{subdir}/_SorryVerify.lean"
     result = verifier.verify_project_file(relative_path, force=True)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -17,7 +17,7 @@ from typing import Optional, Dict, List
 from .state import ProofState, TacticAttempt, SorryContext
 from .trace import TraceLogger
 from .knowledge import ProofKnowledgeBase
-from .lean_utils import count_real_sorries
+from .lean_utils import count_real_sorries, resolve_lake_module
 
 # Regex to detect standalone `axiom` declarations in Lean 4 source.
 # Matches lines like `axiom foo`, `axiom bar : Prop`, `axiom baz (n : Nat) : ...`
@@ -1023,7 +1023,7 @@ class TacticTools:
         """
         try:
             from .verifier import get_verifier
-            project_dir = str(Path(self._filepath).parent.parent)
+            project_dir, _module = resolve_lake_module(self._filepath)
             verifier = get_verifier(project_dir)
             subdir = Path(self._filepath).parent.name
             relative_path = f"{subdir}/{Path(self._filepath).name}"
@@ -1693,7 +1693,7 @@ class TacticTools:
             from .verifier import get_verifier, _load_lean_verifier_class
             _LeanVerifier = _load_lean_verifier_class()
 
-            project_dir = str(Path(self._filepath).parent.parent)
+            project_dir, _module = resolve_lake_module(self._filepath)
             subdir = Path(self._filepath).parent.name
             filename = Path(self._filepath).name
             relative_path = f"{subdir}/{filename}"
@@ -1775,7 +1775,7 @@ class TacticTools:
         if not self._filepath:
             return json.dumps({"error": "No file configured"})
 
-        project_dir = str(Path(self._filepath).parent.parent)
+        project_dir, _module = resolve_lake_module(self._filepath)
         start = time.time()
 
         verifier = get_verifier(project_dir)
@@ -2528,7 +2528,7 @@ class DiagnosisTools:
             return json.dumps({"error": "No file configured"})
         try:
             from .verifier import get_verifier
-            project_dir = str(Path(self._filepath).parent.parent)
+            project_dir, _module = resolve_lake_module(self._filepath)
             verifier = get_verifier(project_dir)
             subdir = Path(self._filepath).parent.name
             relative_path = f"{subdir}/{Path(self._filepath).name}"
@@ -2608,7 +2608,7 @@ class DiagnosisTools:
             return json.dumps({"error": "No file configured"})
         try:
             from .verifier import get_verifier
-            project_dir = str(Path(self._filepath).parent.parent)
+            project_dir, _module = resolve_lake_module(self._filepath)
             verifier = get_verifier(project_dir)
             subdir = Path(self._filepath).parent.name
             relative_path = f"{subdir}/{Path(self._filepath).name}"


### PR DESCRIPTION
@## Summary

Follow-up to PR #5982 (LSP lemma-search depth-3 fix). That commit introduced `resolve_lake_module()` to compute the Lake root + dotted module name by walking up to the nearest lakefile, but **only wired it into `tools.py:_search_via_lsp`** — 8 sibling call sites still derive `project_dir = <file>.parent.parent`, the legacy depth-2 assumption that breaks for files nested below the top package.

For depth-3 files like `Conway/Life/HashlifeCorrectness.lean`, `parent.parent` yields `.../conway_lean/Conway/` — no lakefile there.

## Affected sites (8 total)

**`lean_utils.py` (3)** — silent degradation of correctness:
- `is_true_placeholder_goal` (FX-5): TRUE_PLACEHOLDER_GOAL refusal **silently degrades** to "no refusal" for depth-3 sorries (the probe compiles against the wrong module, returns unparseable output, and the function returns `False, ""`).
- `get_goal_state`: probes compile against the wrong module → returns heuristic-only when exact probe is needed.
- `verify_sorry_replacement`: candidate proof on `HashlifeCorrectness.lean` is judged against the wrong file.

**`tools.py` (5)** — confusing errors:
- `_build_check_or_revert`, `_quick_build_check`, `read_build_result`, `read_build_errors`, `count_sorries`.

## Fix

Swap each `parent.parent` for `resolve_lake_module(filepath)[0]`. The helper walks up to the real Lake root (depth-2 fallback for non-Lake trees preserved).

## Verification

- **AST OK** on both files (Python parse)
- **135/135 guard tests PASS** (`pytest test_prover_guards.py --deselect test_path_constants_resolve_to_active_workspace`; the deselected test fails identically on `main`, pre-existing path-constant issue, unrelated)
- **depth-3 case**: `HashlifeCorrectness.lean` → root=`conway_lean`, module=`Conway.Life.HashlifeCorrectness` (was `conway_lean/Conway` + `Life.HashlifeCorrectness` before, missing the `Conway.` prefix — exactly the pattern PR #5982 documented)
- **depth-2 backward-compat**: `Nim.lean` → root=`conway_lean`, module=`Conway.Nim` (unchanged, idempotent)

## Scope

| Metric | Value |
|--------|-------|
| Files | 2 (`lean_utils.py`, `tools.py`) |
| Lines | +28 / -11 |
| Features | 1 (depth-3 verification hardening) |
| Domain | 1 (prover harness, agent_tests/) |
| Lean proof touched | **NO** |

## §B check (Lean PR discipline)

- ✅ `grep -c sorry` before/after: **unchanged** (proof work untouched, harness-only change)
- ✅ No Lake build needed: change is pure Python in `agent_tests/` (out of Lean build scope)
- ✅ No proof integrity axis touched
- ✅ No prover Python refactor: additive import + mechanical swap of an existing helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
@