### PR TITLE
fix(ict): ICT-18 exercise convention — relabel worked solutions + add 3 stubs (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-18-ArrowOfTimeReversibilization.ipynb
@@ -5,10 +5,10 @@
    "id": "d8683db9",
    "metadata": {
     "papermill": {
-     "duration": 0.003446,
-     "end_time": "2026-07-04T12:13:53.867026+00:00",
+     "duration": 0.003273,
+     "end_time": "2026-07-11T09:10:07.144897+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:53.863580+00:00",
+     "start_time": "2026-07-11T09:10:07.141624+00:00",
      "status": "completed"
     },
     "tags": []
@@ -28,10 +28,10 @@
    "id": "e313f2a4",
    "metadata": {
     "papermill": {
-     "duration": 0.002557,
-     "end_time": "2026-07-04T12:13:53.872871+00:00",
+     "duration": 0.002738,
+     "end_time": "2026-07-11T09:10:07.150781+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:53.870314+00:00",
+     "start_time": "2026-07-11T09:10:07.148043+00:00",
      "status": "completed"
     },
     "tags": []
@@ -48,16 +48,16 @@
    "id": "da4de6ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:50.442283Z",
-     "iopub.status.busy": "2026-07-04T15:39:50.441882Z",
-     "iopub.status.idle": "2026-07-04T15:39:50.905063Z",
-     "shell.execute_reply": "2026-07-04T15:39:50.904174Z"
+     "iopub.execute_input": "2026-07-11T09:10:07.154982Z",
+     "iopub.status.busy": "2026-07-11T09:10:07.154982Z",
+     "iopub.status.idle": "2026-07-11T09:10:07.509253Z",
+     "shell.execute_reply": "2026-07-11T09:10:07.508474Z"
     },
     "papermill": {
-     "duration": 0.475893,
-     "end_time": "2026-07-04T12:13:54.351390+00:00",
+     "duration": 0.35691,
+     "end_time": "2026-07-11T09:10:07.510524+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:53.875497+00:00",
+     "start_time": "2026-07-11T09:10:07.153614+00:00",
      "status": "completed"
     },
     "tags": []
@@ -68,8 +68,8 @@
      "output_type": "stream",
      "text": [
       "ict version: dev\n",
-      "numpy: 2.4.4\n",
-      "matplotlib: 3.10.8\n",
+      "numpy: 1.26.4\n",
+      "matplotlib: 3.9.4\n",
       "time_arrow API:\n",
       "  transition_matrix                          OK\n",
       "  stationary_distribution                    OK\n",
@@ -116,10 +116,10 @@
    "id": "4cf44779",
    "metadata": {
     "papermill": {
-     "duration": 0.002399,
-     "end_time": "2026-07-04T12:13:54.356647+00:00",
+     "duration": 0.002908,
+     "end_time": "2026-07-11T09:10:07.516772+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:54.354248+00:00",
+     "start_time": "2026-07-11T09:10:07.513864+00:00",
      "status": "completed"
     },
     "tags": []
@@ -167,16 +167,16 @@
    "id": "c70a3589",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:50.906887Z",
-     "iopub.status.busy": "2026-07-04T15:39:50.906668Z",
-     "iopub.status.idle": "2026-07-04T15:39:50.925057Z",
-     "shell.execute_reply": "2026-07-04T15:39:50.924430Z"
+     "iopub.execute_input": "2026-07-11T09:10:07.523492Z",
+     "iopub.status.busy": "2026-07-11T09:10:07.522974Z",
+     "iopub.status.idle": "2026-07-11T09:10:07.539022Z",
+     "shell.execute_reply": "2026-07-11T09:10:07.538399Z"
     },
     "papermill": {
-     "duration": 0.021161,
-     "end_time": "2026-07-04T12:13:54.380264+00:00",
+     "duration": 0.020404,
+     "end_time": "2026-07-11T09:10:07.540124+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:54.359103+00:00",
+     "start_time": "2026-07-11T09:10:07.519720+00:00",
      "status": "completed"
     },
     "tags": []
@@ -221,10 +221,10 @@
    "id": "76d30a7e",
    "metadata": {
     "papermill": {
-     "duration": 0.002899,
-     "end_time": "2026-07-04T12:13:54.386406+00:00",
+     "duration": 0.002582,
+     "end_time": "2026-07-11T09:10:07.545816+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:54.383507+00:00",
+     "start_time": "2026-07-11T09:10:07.543234+00:00",
      "status": "completed"
     },
     "tags": []
@@ -243,16 +243,16 @@
    "id": "c81b2dc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:50.927076Z",
-     "iopub.status.busy": "2026-07-04T15:39:50.926726Z",
-     "iopub.status.idle": "2026-07-04T15:39:50.951222Z",
-     "shell.execute_reply": "2026-07-04T15:39:50.950310Z"
+     "iopub.execute_input": "2026-07-11T09:10:07.551777Z",
+     "iopub.status.busy": "2026-07-11T09:10:07.551222Z",
+     "iopub.status.idle": "2026-07-11T09:10:07.573724Z",
+     "shell.execute_reply": "2026-07-11T09:10:07.573724Z"
     },
     "papermill": {
-     "duration": 0.023411,
-     "end_time": "2026-07-04T12:13:54.412507+00:00",
+     "duration": 0.026986,
+     "end_time": "2026-07-11T09:10:07.575434+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:54.389096+00:00",
+     "start_time": "2026-07-11T09:10:07.548448+00:00",
      "status": "completed"
     },
     "tags": []
@@ -327,10 +327,10 @@
    "id": "c333fcff",
    "metadata": {
     "papermill": {
-     "duration": 0.002854,
-     "end_time": "2026-07-04T12:13:54.418208+00:00",
+     "duration": 0.002972,
+     "end_time": "2026-07-11T09:10:07.581944+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:54.415354+00:00",
+     "start_time": "2026-07-11T09:10:07.578972+00:00",
      "status": "completed"
     },
     "tags": []
@@ -351,16 +351,16 @@
    "id": "c228f300",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:50.953262Z",
-     "iopub.status.busy": "2026-07-04T15:39:50.952971Z",
-     "iopub.status.idle": "2026-07-04T15:39:50.980085Z",
-     "shell.execute_reply": "2026-07-04T15:39:50.979299Z"
+     "iopub.execute_input": "2026-07-11T09:10:07.587755Z",
+     "iopub.status.busy": "2026-07-11T09:10:07.587755Z",
+     "iopub.status.idle": "2026-07-11T09:10:07.622598Z",
+     "shell.execute_reply": "2026-07-11T09:10:07.622598Z"
     },
     "papermill": {
-     "duration": 0.029834,
-     "end_time": "2026-07-04T12:13:54.450707+00:00",
+     "duration": 0.039646,
+     "end_time": "2026-07-11T09:10:07.624631+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:54.420873+00:00",
+     "start_time": "2026-07-11T09:10:07.584985+00:00",
      "status": "completed"
     },
     "tags": []
@@ -425,10 +425,10 @@
    "id": "00f01d70",
    "metadata": {
     "papermill": {
-     "duration": 0.00305,
-     "end_time": "2026-07-04T12:13:54.457157+00:00",
+     "duration": 0.002868,
+     "end_time": "2026-07-11T09:10:07.630888+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:54.454107+00:00",
+     "start_time": "2026-07-11T09:10:07.628020+00:00",
      "status": "completed"
     },
     "tags": []
@@ -449,16 +449,16 @@
    "id": "194cd078",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:50.982160Z",
-     "iopub.status.busy": "2026-07-04T15:39:50.981888Z",
-     "iopub.status.idle": "2026-07-04T15:39:52.663061Z",
-     "shell.execute_reply": "2026-07-04T15:39:52.662126Z"
+     "iopub.execute_input": "2026-07-11T09:10:07.636825Z",
+     "iopub.status.busy": "2026-07-11T09:10:07.636825Z",
+     "iopub.status.idle": "2026-07-11T09:10:08.905371Z",
+     "shell.execute_reply": "2026-07-11T09:10:08.905371Z"
     },
     "papermill": {
-     "duration": 1.701895,
-     "end_time": "2026-07-04T12:13:56.162472+00:00",
+     "duration": 1.273544,
+     "end_time": "2026-07-11T09:10:08.907366+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:54.460577+00:00",
+     "start_time": "2026-07-11T09:10:07.633822+00:00",
      "status": "completed"
     },
     "tags": []
@@ -552,10 +552,10 @@
    "id": "a460240d",
    "metadata": {
     "papermill": {
-     "duration": 0.003267,
-     "end_time": "2026-07-04T12:13:56.169515+00:00",
+     "duration": 0.003012,
+     "end_time": "2026-07-11T09:10:08.914001+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.166248+00:00",
+     "start_time": "2026-07-11T09:10:08.910989+00:00",
      "status": "completed"
     },
     "tags": []
@@ -574,16 +574,16 @@
    "id": "3454f5b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:52.665498Z",
-     "iopub.status.busy": "2026-07-04T15:39:52.665290Z",
-     "iopub.status.idle": "2026-07-04T15:39:52.762743Z",
-     "shell.execute_reply": "2026-07-04T15:39:52.761816Z"
+     "iopub.execute_input": "2026-07-11T09:10:08.919338Z",
+     "iopub.status.busy": "2026-07-11T09:10:08.919338Z",
+     "iopub.status.idle": "2026-07-11T09:10:08.991466Z",
+     "shell.execute_reply": "2026-07-11T09:10:08.990466Z"
     },
     "papermill": {
-     "duration": 0.084312,
-     "end_time": "2026-07-04T12:13:56.256734+00:00",
+     "duration": 0.075548,
+     "end_time": "2026-07-11T09:10:08.992544+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.172422+00:00",
+     "start_time": "2026-07-11T09:10:08.916996+00:00",
      "status": "completed"
     },
     "tags": []
@@ -643,7 +643,16 @@
   {
    "cell_type": "markdown",
    "id": "be2ff650",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003097,
+     "end_time": "2026-07-11T09:10:08.999255+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:08.996158+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6.bis Substrat S5 -- CONTROLE faux-POSITIF : pur dissipateur sans auto-maintien\n",
     "\n",
@@ -660,11 +669,19 @@
    "id": "c77bc761",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:52.765322Z",
-     "iopub.status.busy": "2026-07-04T15:39:52.765051Z",
-     "iopub.status.idle": "2026-07-04T15:39:52.889390Z",
-     "shell.execute_reply": "2026-07-04T15:39:52.888397Z"
-    }
+     "iopub.execute_input": "2026-07-11T09:10:09.004254Z",
+     "iopub.status.busy": "2026-07-11T09:10:09.004254Z",
+     "iopub.status.idle": "2026-07-11T09:10:09.057787Z",
+     "shell.execute_reply": "2026-07-11T09:10:09.057787Z"
+    },
+    "papermill": {
+     "duration": 0.057302,
+     "end_time": "2026-07-11T09:10:09.059569+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:09.002267+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -679,13 +696,7 @@
       "db_error_real          = 0.0202\n",
       "dist_real_vs_reversibilized = 0.0301\n",
       "dist_real_vs_reversed       = 0.0601\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "=== Substrat S5b (oscillateur logistique pilote) ===\n",
       "n_symbols = 5, observations = 3000\n",
       "pi_real : [0.0861512  0.08482068 0.17059047 0.48779839 0.17063926]\n",
@@ -803,10 +814,10 @@
    "id": "52aa573c",
    "metadata": {
     "papermill": {
-     "duration": 0.003138,
-     "end_time": "2026-07-04T12:13:56.263472+00:00",
+     "duration": 0.002973,
+     "end_time": "2026-07-11T09:10:09.066151+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.260334+00:00",
+     "start_time": "2026-07-11T09:10:09.063178+00:00",
      "status": "completed"
     },
     "tags": []
@@ -823,16 +834,16 @@
    "id": "725f8e76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:52.891501Z",
-     "iopub.status.busy": "2026-07-04T15:39:52.891294Z",
-     "iopub.status.idle": "2026-07-04T15:39:53.346585Z",
-     "shell.execute_reply": "2026-07-04T15:39:53.344796Z"
+     "iopub.execute_input": "2026-07-11T09:10:09.072795Z",
+     "iopub.status.busy": "2026-07-11T09:10:09.071794Z",
+     "iopub.status.idle": "2026-07-11T09:10:09.290879Z",
+     "shell.execute_reply": "2026-07-11T09:10:09.290176Z"
     },
     "papermill": {
-     "duration": 0.238171,
-     "end_time": "2026-07-04T12:13:56.504783+00:00",
+     "duration": 0.222821,
+     "end_time": "2026-07-11T09:10:09.292025+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.266612+00:00",
+     "start_time": "2026-07-11T09:10:09.069204+00:00",
      "status": "completed"
     },
     "tags": []
@@ -842,7 +853,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Figure sauvegardee : D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\IIT\\ICT-Series\\ICT-18-fleches-comparaison.png\n"
+      "Figure sauvegardee : ICT-18-fleches-comparaison.png  (dans le dossier du notebook)\n"
      ]
     }
    ],
@@ -902,7 +913,7 @@
     "plt.tight_layout()\n",
     "out_png = os.path.join(ICT_ROOT, 'ICT-18-fleches-comparaison.png')\n",
     "plt.savefig(out_png, dpi=110)\n",
-    "print(f'Figure sauvegardee : {out_png}')"
+    "print(f'Figure sauvegardee : {os.path.basename(out_png)}  (dans le dossier du notebook)')"
    ]
   },
   {
@@ -910,10 +921,10 @@
    "id": "f2eb3dc0",
    "metadata": {
     "papermill": {
-     "duration": 0.003055,
-     "end_time": "2026-07-04T12:13:56.510904+00:00",
+     "duration": 0.00319,
+     "end_time": "2026-07-11T09:10:09.298827+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.507849+00:00",
+     "start_time": "2026-07-11T09:10:09.295637+00:00",
      "status": "completed"
     },
     "tags": []
@@ -936,21 +947,40 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b25cf74",
+   "id": "015dbddd",
    "metadata": {
     "papermill": {
-     "duration": 0.002855,
-     "end_time": "2026-07-04T12:13:56.516721+00:00",
+     "duration": 0.003017,
+     "end_time": "2026-07-11T09:10:09.305061+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.513866+00:00",
+     "start_time": "2026-07-11T09:10:09.302044+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 9. Exercices\n",
+    "## 9. Exemples guidés et exercices\n",
     "\n",
-    "Trois exercices -- convention 3-exercises-per-notebook (#2161) -- repartis : un sur la sensibilite au substrat, un sur la construction d'un indicateur, un sur l'extension a un nouveau substrat."
+    "Les trois **exemples guidés** ci-dessous reprennent les concepts de la série (flèche du temps, indice d'agentivité, substrats) avec des solutions commentées. Les trois **exercices** qui suivent vous demandent d'étendre chaque méthode à un nouveau cas. Convention CoursIA : un *exemple* est résolu, un *exercice* est à compléter (convention 3 exercices minimum, #2161)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4adb5f6f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003025,
+     "end_time": "2026-07-11T09:10:09.311294+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:09.308269+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple guide 1 -- Sensibilité au nombre d'états observés\n",
+    "\n",
+    "Sur la trajectoire S1 (BiasedBubbleSort), on fait varier la discrétisation en quantiles et on observe comment `sigma_real` évolue : c'est la frontière entre information thermodynamique réelle et artefact de discrétisation."
    ]
   },
   {
@@ -959,16 +989,16 @@
    "id": "62962fd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:53.350596Z",
-     "iopub.status.busy": "2026-07-04T15:39:53.350201Z",
-     "iopub.status.idle": "2026-07-04T15:39:53.379179Z",
-     "shell.execute_reply": "2026-07-04T15:39:53.377881Z"
+     "iopub.execute_input": "2026-07-11T09:10:09.317577Z",
+     "iopub.status.busy": "2026-07-11T09:10:09.317577Z",
+     "iopub.status.idle": "2026-07-11T09:10:09.337608Z",
+     "shell.execute_reply": "2026-07-11T09:10:09.337608Z"
     },
     "papermill": {
-     "duration": 0.018436,
-     "end_time": "2026-07-04T12:13:56.538008+00:00",
+     "duration": 0.025313,
+     "end_time": "2026-07-11T09:10:09.339596+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.519572+00:00",
+     "start_time": "2026-07-11T09:10:09.314283+00:00",
      "status": "completed"
     },
     "tags": []
@@ -988,7 +1018,7 @@
     }
    ],
    "source": [
-    "# Exercice 1 -- Sensibilite au nombre d'etats observes\n",
+    "# Exemple guide 1 -- Sensibilite au nombre d'etats observes\n",
     "#\n",
     "# Consigne : sur la trajectoire S1 (BiasedBubbleSort), faire varier la\n",
     "# discretisation en quantiles et observer comment `sigma_real` evolue.\n",
@@ -1026,19 +1056,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2130ee3",
+   "id": "45d494d1",
    "metadata": {
     "papermill": {
-     "duration": 0.002804,
-     "end_time": "2026-07-04T12:13:56.543748+00:00",
+     "duration": 0.002975,
+     "end_time": "2026-07-11T09:10:09.346010+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.540944+00:00",
+     "start_time": "2026-07-11T09:10:09.343035+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 -- Definir et tester un *indice d'agentivite*\n",
+    "### Exemple guide 2 -- Definir et tester un *indice d'agentivite*\n",
     "\n",
     "**Consigne** : a partir des quantites thermodynamiques mesurees, definir un **indice d'agentivite** agrege qui resume la *quantite de calcul emergent* d'une trajectoire. Le tester sur les 4 substrats (S1/S2/S3/S4) et sur la trajectoire iid.\n",
     "\n",
@@ -1065,16 +1095,16 @@
    "id": "bf0e8479",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:53.382618Z",
-     "iopub.status.busy": "2026-07-04T15:39:53.382393Z",
-     "iopub.status.idle": "2026-07-04T15:39:53.389087Z",
-     "shell.execute_reply": "2026-07-04T15:39:53.388066Z"
+     "iopub.execute_input": "2026-07-11T09:10:09.352505Z",
+     "iopub.status.busy": "2026-07-11T09:10:09.352505Z",
+     "iopub.status.idle": "2026-07-11T09:10:09.357837Z",
+     "shell.execute_reply": "2026-07-11T09:10:09.357505Z"
     },
     "papermill": {
-     "duration": 0.011751,
-     "end_time": "2026-07-04T12:13:56.558233+00:00",
+     "duration": 0.009914,
+     "end_time": "2026-07-11T09:10:09.358992+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.546482+00:00",
+     "start_time": "2026-07-11T09:10:09.349078+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1140,19 +1170,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "624bc47e",
+   "id": "62b72bc1",
    "metadata": {
     "papermill": {
-     "duration": 0.002874,
-     "end_time": "2026-07-04T12:13:56.564036+00:00",
+     "duration": 0.003189,
+     "end_time": "2026-07-11T09:10:09.365651+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.561162+00:00",
+     "start_time": "2026-07-11T09:10:09.362462+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 3 -- Extension a un nouveau substrat : automate cellulaire de Wolfram\n",
+    "### Exemple guide 3 -- Extension a un nouveau substrat : automate cellulaire de Wolfram\n",
     "\n",
     "**Consigne** : appliquer ``time_arrow`` sur un automate cellulaire 1D (regle de Wolfram 30, 110 ou 110) et observer la fleche thermodynamique. La regle 30 (chaotique) doit avoir une fleche elevee ; la regle 110 (complexe, classe 4) doit avoir une fleche encore plus elevee ; la regle 0 (trivialement constante) doit avoir une fleche nulle.\n",
     "\n",
@@ -1165,16 +1195,16 @@
    "id": "dd0ac54d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T15:39:53.391148Z",
-     "iopub.status.busy": "2026-07-04T15:39:53.390936Z",
-     "iopub.status.idle": "2026-07-04T15:39:53.448662Z",
-     "shell.execute_reply": "2026-07-04T15:39:53.446993Z"
+     "iopub.execute_input": "2026-07-11T09:10:09.372416Z",
+     "iopub.status.busy": "2026-07-11T09:10:09.371415Z",
+     "iopub.status.idle": "2026-07-11T09:10:09.408528Z",
+     "shell.execute_reply": "2026-07-11T09:10:09.407522Z"
     },
     "papermill": {
-     "duration": 0.046471,
-     "end_time": "2026-07-04T12:13:56.613418+00:00",
+     "duration": 0.04089,
+     "end_time": "2026-07-11T09:10:09.409649+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.566947+00:00",
+     "start_time": "2026-07-11T09:10:09.368759+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1192,7 +1222,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 -- Automate cellulaire Wolfram (regle 30 vs 110 vs 0)\n",
+    "# Exemple guide 3 -- Automate cellulaire Wolfram (regle 30 vs 110 vs 0)\n",
     "def wolfram_step(state, rule):\n",
     "    n = len(state)\n",
     "    out = np.zeros(n, dtype=int)\n",
@@ -1227,13 +1257,190 @@
   },
   {
    "cell_type": "markdown",
+   "id": "14f1df82",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003077,
+     "end_time": "2026-07-11T09:10:09.416148+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:09.413071+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 -- Appliquer la discrétisation à un nouveau substrat\n",
+    "\n",
+    "**Objectif** : reproduire l'analyse de l'Exemple guide 1 sur un autre substrat du panel (par ex. S3 Axelrod ou S5b oscillateur pilote).\n",
+    "\n",
+    "- **Indice 1** : choisir un substrat du panel (`out_ax` pour S3, `out_osc` pour S5b) et récupérer sa trajectoire d'états (cf. cellules Section 3-4).\n",
+    "- **Indice 2** : appliquer `discretise(traj, n_niveaux)` pour `n_niveaux` parcourant 2, 4, 6, 8.\n",
+    "- **Indice 3** : pour chaque discrétisation, appeler `time_arrow.compare_real_reversed_reversibilized` et relever `sigma_real`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1492f836",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T09:10:09.422527Z",
+     "iopub.status.busy": "2026-07-11T09:10:09.422527Z",
+     "iopub.status.idle": "2026-07-11T09:10:09.439036Z",
+     "shell.execute_reply": "2026-07-11T09:10:09.439036Z"
+    },
+    "papermill": {
+     "duration": 0.02135,
+     "end_time": "2026-07-11T09:10:09.440653+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:09.419303+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer -- voir l'Exemple guide 1 pour la methode\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 -- Appliquer l'analyse de discretisation a un nouveau substrat\n",
+    "# TODO etudiant : reprendre la methode de l'Exemple guide 1 sur un autre substrat.\n",
+    "resultats_ex1 = None  # TODO etudiant : liste de dicts {n_niveaux, sigma_real}\n",
+    "print(\"Exercice 1 a completer -- voir l'Exemple guide 1 pour la methode\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "539dd456",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002974,
+     "end_time": "2026-07-11T09:10:09.447217+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:09.444243+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 -- Sensibilité de l'indice d'agentivité aux poids (alpha, beta)\n",
+    "\n",
+    "**Objectif** : étudier comment le classement des substrats par `agentivity_index` change quand on varie le poids relatif `alpha`.\n",
+    "\n",
+    "- **Indice 1** : poser `beta = 1 - alpha` et faire varier `alpha` dans `[0.0, 0.25, 0.5, 0.75, 1.0]`.\n",
+    "- **Indice 2** : réutiliser `agentivity_index(out, alpha, beta)` de l'Exemple guide 2.\n",
+    "- **Indice 3** : pour chaque `alpha`, trier les substrats du panel par indice décroissant et identifier lequel devient dominant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a44d3d7a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T09:10:09.454092Z",
+     "iopub.status.busy": "2026-07-11T09:10:09.453092Z",
+     "iopub.status.idle": "2026-07-11T09:10:09.456094Z",
+     "shell.execute_reply": "2026-07-11T09:10:09.456094Z"
+    },
+    "papermill": {
+     "duration": 0.007348,
+     "end_time": "2026-07-11T09:10:09.457674+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:09.450326+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer -- voir l'Exemple guide 2 pour agentivity_index\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 -- Sensibilite de l'indice d'agentivite aux poids alpha/beta\n",
+    "# TODO etudiant : comment le classement evolue-t-il avec alpha ?\n",
+    "classement_ex2 = None  # TODO etudiant : classement des substrats pour chaque alpha\n",
+    "print(\"Exercice 2 a completer -- voir l'Exemple guide 2 pour agentivity_index\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f5fc4e5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002974,
+     "end_time": "2026-07-11T09:10:09.463888+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:09.460914+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 -- Classifier des règles de Wolfram par leur flèche du temps\n",
+    "\n",
+    "**Objectif** : étendre l'analyse de l'Exemple guide 3 à davantage de règles et relier `sigma_real` aux quatre classes de Wolfram (I/II/III/IV).\n",
+    "\n",
+    "- **Indice 1** : boucler sur `rules = [18, 22, 30, 45, 54, 73, 90, 110, 126, 150, 184]`.\n",
+    "- **Indice 2** : réutiliser `wolfram_trajectory(rule, ...)` de l'Exemple guide 3.\n",
+    "- **Indice 3** : trier les règles par `sigma_real` décroissant et confronter aux classes (uniforme/I, périodique/II, chaotique/III, complexe/IV)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "78bbd393",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T09:10:09.470690Z",
+     "iopub.status.busy": "2026-07-11T09:10:09.470690Z",
+     "iopub.status.idle": "2026-07-11T09:10:09.474424Z",
+     "shell.execute_reply": "2026-07-11T09:10:09.474106Z"
+    },
+    "papermill": {
+     "duration": 0.008495,
+     "end_time": "2026-07-11T09:10:09.475568+00:00",
+     "exception": false,
+     "start_time": "2026-07-11T09:10:09.467073+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer -- voir l'Exemple guide 3 pour wolfram_trajectory\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 -- Classifier des regles de Wolfram par leur fleche du temps\n",
+    "# TODO etudiant : quelles regles (chaotiques vs complexes) ont la plus grande sigma_real ?\n",
+    "classification_ex3 = None  # TODO etudiant : regles triees par sigma_real\n",
+    "print(\"Exercice 3 a completer -- voir l'Exemple guide 3 pour wolfram_trajectory\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "33d60400",
    "metadata": {
     "papermill": {
-     "duration": 0.003657,
-     "end_time": "2026-07-04T12:13:56.621242+00:00",
+     "duration": 0.003247,
+     "end_time": "2026-07-11T09:10:09.482068+00:00",
      "exception": false,
-     "start_time": "2026-07-04T12:13:56.617585+00:00",
+     "start_time": "2026-07-11T09:10:09.478821+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1289,18 +1496,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.14"
+   "version": "3.9.25"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.875332,
-   "end_time": "2026-07-04T12:13:56.972794+00:00",
+   "duration": 3.440695,
+   "end_time": "2026-07-11T09:10:09.707674+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "ICT-18-ArrowOfTimeReversibilization.ipynb",
    "output_path": "ICT-18-ArrowOfTimeReversibilization.ipynb",
    "parameters": {},
-   "start_time": "2026-07-04T12:13:52.097462+00:00",
+   "start_time": "2026-07-11T09:10:06.266979+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Contexte

ICT-18 était l'**OUTLIER** de la série ICT sur la convention **≥3 exercices/notebook** (#2161) : il contenait **3 solutions complètes** titrées « Exercice 1/2/3 » (implémentations fonctionnelles, sans stub) au lieu de la convention de la série (ICT-1/10/11/12/13/14 = 3 stubs d'exercice + 3 en-têtes singuliers `### Exercice N`).

**Deux problèmes** :
1. **Fuite de solutions instructeur** : les 3 worked solutions (discretise, agentivity_index, Wolfram) exposaient la réponse.
2. **Rien à compléter pour l'étudiant** : 0 véritable exercice-stub.

## Changement (labeling par contenu — [exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md))

- **Relabel** des 3 worked solutions en `### Exemple guide 1/2/3` (Exemple = résolu). **Outputs préservés intacts** (non stubbés — anti-régression).
- **Ajout** de 3 véritables `### Exercice N` stubs (Exercice = tâche étudiant) qui étendent chaque exemple :
  1. Appliquer la discrétisation à un nouveau substrat (S3 Axelrod / S5b oscillateur)
  2. Sensibilité de l'indice d'agentivité aux poids (alpha/beta)
  3. Classifier des règles de Wolfram par leur flèche du temps (lien avec classes I/II/III/IV)
- Chaque stub : objectif + **3 indices gradués** + pattern **C.1-safe** (`result = None / # TODO etudiant` + `print("Exercice N a completer")`).

### Bonus : fix fuite de chemin machine (Stop & Repair)

`c16` imprimait le **chemin absolu machine** de la figure sauvegardée (`print(f"...{out_png}")` où `out_png = os.path.join(ICT_ROOT, ...)`). Fuite **pré-existante** sur origin/main. Corrigé à la source : imprime `os.path.basename(out_png)`. (Pas de scrub de sortie — ré-exec réelle.)

## Vérification (preuves)

| Check | Résultat |
|-------|----------|
| `count_exercises` (**scanner FIXÉ** #6059) | **3** (était ~0 stub) |
| Worked solutions préservées | c20=31nl, c22=37nl, c24=28nl, toutes `def`-based, **non stubbées** |
| Re-exec pyphi (Python 3 / PyPhi) | **14/14 cells** ec=1..14, 0 erreur |
| Fuites chemin machine dans outputs | **0** |
| `execution_count=None` / outputs vides | **0** |
| CRLF | 0 (LF-only) |
| diff | 346 insertions / 139 deletions (ins > del) |

## Scope

See #2161 (convention ≥3 exercices, rolling — ce PR met **un** notebook en conformité, ne résout pas toute l'issue).

## Scope anti-régression

Les 3 worked solutions sont **préservées comme Exemple guide** (outputs intacts) — aucune cellule résolue n'a été stubbée. Seul le labeling change pour ces 3 + 3 nouveaux stubs ajoutés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)