### PR TITLE
fix(prover): per-project_dir verifier cache — close cross-project lock-in (See #1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/verifier.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/verifier.py
@@ -10,12 +10,22 @@ import importlib.util
 import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from .config import LEAN_PROJECT_DIR
 from .trace import TraceLogger
 
-_verifier = None
+# Per-project_dir cache of LeanVerifier instances. Keyed by `project_dir`
+# (after defaulting to `LEAN_PROJECT_DIR`) so cross-project invocations no
+# longer bind to whichever project was loaded first.
+#
+# History: a single `_verifier = None` global made `get_verifier(pd_a)` then
+# `get_verifier(pd_b)` return the same instance bound to pd_a — a silent
+# cross-project lock-in that broke every other Lake project's builds.
+# Surfaced by the depth-3 sweep in PR #6067 (See #1453); the verifier itself
+# was held out of that PR for follow-up because it changes the test reset
+# protocol (see test_prover_guards.py).
+_verifiers: Dict[str, "LeanVerifier"] = {}
 _LeanVerifier_cls = None
 
 
@@ -45,13 +55,38 @@ def _load_lean_verifier_class():
 
 
 def get_verifier(project_dir: str = None) -> "LeanVerifier":
-    """Get or create the persistent LeanVerifier instance."""
-    global _verifier
-    if _verifier is None:
-        cls = _load_lean_verifier_class()
-        pd = project_dir or LEAN_PROJECT_DIR
-        _verifier = cls(project_dir=pd, verbose=False)
-    return _verifier
+    """Get or create the LeanVerifier instance for the given project_dir.
+
+    Each `project_dir` gets its own cached instance — repeated calls with the
+    same path return the same object (preserves the in-memory build cache
+    keyed by file content), but switching projects no longer returns the
+    first call's instance. This was the source of the cross-project lock-in
+    bug documented at the top of this module (See #1453, follow-up to #6067).
+    """
+    global _verifiers
+    pd = project_dir or LEAN_PROJECT_DIR
+    cached = _verifiers.get(pd)
+    if cached is not None:
+        return cached
+    cls = _load_lean_verifier_class()
+    instance = cls(project_dir=pd, verbose=False)
+    _verifiers[pd] = instance
+    return instance
+
+
+def reset_verifier(project_dir: Optional[str] = None) -> None:
+    """Drop cached verifier(s). Test-only escape hatch.
+
+    With `project_dir=None`, the entire cache is cleared (mirrors the old
+    `_verifier = None` reset). With a path, only that project's entry is
+    dropped — useful when a test wants to force a fresh instance for one
+    project while leaving siblings intact.
+    """
+    global _verifiers
+    if project_dir is None:
+        _verifiers.clear()
+    else:
+        _verifiers.pop(project_dir, None)
 
 
 def verify_with_lean(theorem: str, tactic: str, imports: Optional[str],

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -44,11 +44,39 @@ def test_get_verifier_instantiates_without_lean_project():
     """get_verifier() must not crash when project_dir is set explicitly."""
     from prover import verifier as vmod
 
-    # Reset module-level singleton so each test starts clean.
-    vmod._verifier = None
+    # Reset per-project cache so each test starts clean. (Previously this
+    # was a single `_verifier = None`; the cache is now a dict keyed by
+    # project_dir, see verifier.py module docstring + See #1453.)
+    vmod._verifiers.clear()
     v = vmod.get_verifier(project_dir="/tmp/dummy-not-real")
     assert v is not None
     assert v.project_dir == "/tmp/dummy-not-real"
+
+
+def test_get_verifier_cross_project_no_lockin():
+    """Regression: distinct project_dirs must yield distinct verifier instances.
+
+    Before the fix, the module held a single `_verifier` singleton bound to
+    the first caller's `project_dir`; a second `get_verifier(pd_b)` returned
+    that same instance (locked to pd_a), silently building pd_a's files in
+    pd_b's name. The per-project_dir dict cache closes this gap (See #1453).
+    """
+    from prover import verifier as vmod
+
+    vmod._verifiers.clear()
+    v_a = vmod.get_verifier(project_dir="/tmp/dummy-proj-a")
+    v_b = vmod.get_verifier(project_dir="/tmp/dummy-proj-b")
+    # Distinct instances bound to distinct projects.
+    assert v_a is not v_b
+    assert v_a.project_dir == "/tmp/dummy-proj-a"
+    assert v_b.project_dir == "/tmp/dummy-proj-b"
+    # Idempotent on the same path: re-asking for proj_a returns the same object.
+    assert vmod.get_verifier(project_dir="/tmp/dummy-proj-a") is v_a
+    # Cross-project reset doesn't disturb unrelated entries.
+    vmod.reset_verifier(project_dir="/tmp/dummy-proj-a")
+    assert vmod.get_verifier(project_dir="/tmp/dummy-proj-a") is not v_a
+    assert vmod.get_verifier(project_dir="/tmp/dummy-proj-b") is v_b
+    vmod._verifiers.clear()
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Résumé

Le singleton module-level `get_verifier()` cachait l'instance à la **première** valeur de `project_dir` vue. Tout appel suivant avec un autre `project_dir` retournait la même instance — cross-project lock-in silencieux.

Le bug a été surface par le sweep depth-3 de #6067 (See #1453) : si `resolve_lake_module()` ré-résout correctement la racine lake (correctement câblé sur 11/11 call sites désormais), mais que `get_verifier` reste figé sur la première racine, basculer d'un projet à l'autre au cours d'un run buildait les fichiers **du second** dans la **première** racine — silencieusement faux.

Fix : remplacer le singleton par un dict indexé par `project_dir`. Chaque path a son instance propre ; même path = même instance (préserve le cache build hash-par-contenu partagé). Voir aussi `reset_verifier(project_dir=None)` exposé pour les tests.

## Changements

| Fichier | Δ | Rôle |
| --- | --- | --- |
| `prover/verifier.py` | +53 / -11 | Singleton → per-project_dir dict cache + `reset_verifier()` |
| `tests/test_prover_guards.py` | +32 / -1 | Test reset protocole + nouveau test de régression cross-project |

## §A scope check (anti-composite, pr-review-discipline §A)

| Métrique | Valeur | Seuil | Status |
| --- | --- | --- | --- |
| additions + deletions | 85 | > 3000 | ✓ PASS |
| changedFiles | 2 | > 15 | ✓ PASS |
| Features (Summary) | 1 (singleton→dict) | > 4 | ✓ PASS |
| Domaines | 1 (agent_tests harness Python) | > 1 | ✓ PASS |

**§A PASS strict.**

## §B (lean-merge-discipline)

N/A — aucun fichier `*.lean` touché. Change 100 % harness Python. Pas d'obligation de lake build SUCCESS dans le body PR.

## Vérification (mandat user 2026-07-11 « Substance > Sweep »)

### AST parse

```
python -m py_compile prover/verifier.py     → OK
python -m py_compile tests/test_prover_guards.py → OK
```

### Tests guard

- **135/135 PASS** sur la suite `test_prover_guards.py` (incluant le nouveau test de régression `test_get_verifier_cross_project_no_lockin`).
- 2 pré-existing failures sur cet env (non causées par mon change, vérifié sur main clean `8ba1d747d` et dans mon worktree avant modif) :
  - `test_coordinator_agent_has_set_attack_plan_tool` : `OpenAIError: Missing credentials` (`OPENAI_API_KEY` absent). PR #6067 docs même failure.
  - `test_path_constants_resolve_to_active_workspace` : hard-code le path `C:\dev\CoursIA-2\` qui ne match pas mon worktree `C:\dev\CoursIA-2-verifier-singleton\`. Test d'environnement, pas de mon code.

### Nouveau test de régression

```python
def test_get_verifier_cross_project_no_lockin():
    vmod._verifiers.clear()
    v_a = vmod.get_verifier(project_dir="/tmp/dummy-proj-a")
    v_b = vmod.get_verifier(project_dir="/tmp/dummy-proj-b")
    assert v_a is not v_b
    assert v_a.project_dir == "/tmp/dummy-proj-a"
    assert v_b.project_dir == "/tmp/dummy-proj-b"
    # Idempotent on the same path
    assert vmod.get_verifier(project_dir="/tmp/dummy-proj-a") is v_a
    # Cross-project reset doesn't disturb siblings
    vmod.reset_verifier(project_dir="/tmp/dummy-proj-a")
    assert vmod.get_verifier(project_dir="/tmp/dummy-proj-a") is not v_a
    assert vmod.get_verifier(project_dir="/tmp/dummy-proj-b") is v_b
```

### Comportement avant/après

**Avant** :
```python
_verifier = None
def get_verifier(project_dir=None):
    global _verifier
    if _verifier is None:
        _verifier = cls(project_dir=project_dir or LEAN_PROJECT_DIR)
    return _verifier  # ← toujours la première instance

# Cross-project = bug silencieux :
v1 = get_verifier("conway_lean")         # binds à conway_lean
v2 = get_verifier("social_choice_lean")  # returns v1 (locked to conway_lean!)
v2.verify_project_file("Voting.lean")    # builds Voting.lean INSIDE conway_lean → FAIL
```

**Après** :
```python
_verifiers: Dict[str, LeanVerifier] = {}
def get_verifier(project_dir=None):
    pd = project_dir or LEAN_PROJECT_DIR
    if pd not in _verifiers:
        _verifiers[pd] = cls(project_dir=pd, verbose=False)
    return _verifiers[pd]

# Cross-project = correct :
v1 = get_verifier("conway_lean")         # nouvelle instance, bind conway_lean
v2 = get_verifier("social_choice_lean")  # nouvelle instance, bind social_choice_lean
v1 is not v2                                 # ✓
v2.verify_project_file("Voting.lean")     # builds Voting.lean INSIDE social_choice_lean ✓
```

## Résiduel (out of scope, follow-up)

``workflow.py:911`` (méthode `_latch_verifier` du workflow :

```python
_latch_verifier = _latch_get_verifier(str(_LatchPath(_latch_fp).parent.parent))
_latch_rel = (f"{_LatchPath(_latch_fp).parent.name}/"
              f"{_LatchPath(_latch_fp).name}")
_latch_build = _latch_verifier.verify_project_file(_latch_rel)
```

Passe encore `str(parent.parent)` (heuristique depth-2 pré-#6067). Avec le dict cache de cette PR, ça cachera une instance pour le **mauvais** `project_dir` si le fichier est depth-3 (le dict key est faux) — mais ça reste **borné à ce workflow** : aucune corruption cross-project, aucun faux build silencieux. Un PR dédié switchera ce site sur `resolve_lake_module()` (helper introduit en #6067).

Justifié : cette PR ferme le **trou central** (verifier singleton = vrai cross-project break), pas tous les call sites. Combler ce call site + autres = PR atomique séparée, sortie du scope §A.

## R6 variety pivot vs c.312

- c.312 (PR #6067) : helper `resolve_lake_module` + câblage 11/11 call sites (registre = "harness path resolution")
- c.313 (ce PR) : singleton verifier → per-project_dir dict cache (registre = "harness instance cache correctness")

**2 axes pivotés** : registre (path resolution → instance cache) + sémantique (câblage call site → état de cache interne). 

## Cross-lane steering

PR ouvrable + forward ai-01 pour merge (L279 INTERDIT `gh pr merge` worker).