### PR TITLE
Fix: count_exercises Bug 1 grouped markdown headers (#6051)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -260,6 +260,72 @@ def _markdown_mentions_exercise(source: str) -> bool:
     return False
 
 
+def _markdown_instance_header_count(source: str) -> int:
+    """Count per-instance exercise headers in a markdown cell source.
+
+    Distinguishes the two cell shapes that Bug 1 of #6051 miscounted:
+
+    1. Grouped layout -- one markdown cell carries a section umbrella
+       (``## 8. Exercices``) PLUS N explicit sub-headers
+       (``### Exercice 1`` ... ``### Exercice N``). The N sub-headers
+       describe N distinct exercises; the umbrella is a section title that
+       ORGANIZES them and must NOT add an extra instance. We count the
+       sub-headers (H3+ depth), ignore shallower umbrellas when sub-headers
+       exist, and fall back to the umbrella if no sub-headers do.
+
+    2. Flat layout -- the cell carries only one or more ``##`` /
+       ``###`` headers (numbered or not). Each contributes one instance
+       so the count stays one-header-one-exercise regardless of whether the
+       header carries an ``Exercice N`` number (the legacy helper required a
+       number and under-counted ``## 8. Exercice`` / ``### Exercice -``).
+
+    Rule: a header counts when it references the exercise word
+    (``exercice`` / ``exercices`` / ``exercise`` / ``exercises``) so we
+    never spuriously match ``## Example 1`` or ``## 8. Exerceur``.
+    """
+    sub_level_count = 0
+    total_count = 0
+    for m in MARKDOWN_HEADER_RE.finditer(source):
+        # MARKDOWN_HEADER_RE yields one capture group (the header text) so we
+        # rebuild the hash-run depth by parsing the full match: scan from the
+        # start past any optional indentation to the run of ``#`` characters.
+        full_match = m.group(0)
+        header_text = m.group(1)
+        if not (EXERCISE_WORD_RE.search(header_text) or EXERCISE_WORD_EN_RE.search(header_text)):
+            continue
+        total_count += 1
+        # Find the hash-run at the start of the matched line (after optional
+        # leading whitespace + any preceding newline from the MULTILINE flag).
+        # Per CommonMark, a header marker is one to six ``#`` characters
+        # followed by a space or end-of-line.
+        hash_run_end = 0
+        while hash_run_end < len(full_match) and full_match[hash_run_end] in (
+            " ",
+            "\t",
+            "\r",
+            "\n",
+        ):
+            hash_run_end += 1
+        hash_run_start = hash_run_end
+        while hash_run_end < len(full_match) and full_match[hash_run_end] == "#":
+            hash_run_end += 1
+        depth = hash_run_end - hash_run_start
+        # Sub-header depth = hashes ``###`` or deeper (3+). The umbrella
+        # ``##`` (level 2) is excluded from the sub-header tally so it does
+        # NOT over-count when explicit sub-instances are present below it.
+        if depth >= 3:
+            sub_level_count += 1
+    if sub_level_count > 0:
+        # Grouped layout: the umbrella is organizer-only, sub-headers are
+        # the per-instance tally. Return sub_count so a cell ``## X.
+        # Exercices`` + ``### Exercice 1`` ... ``### Exercice N`` counts as N.
+        return sub_level_count
+    # Flat layout: one or more section-level headers describe one exercise
+    # each (the legacy detector counted any one as 1; we keep that for
+    # cells without sub-headers).
+    return total_count
+
+
 def _exercise_number(source: str) -> str | None:
     """Exercise number token a cell references, e.g. ``'3'`` or ``'3b'``.
 
@@ -298,20 +364,30 @@ def count_exercises_in_notebook(path: Path) -> NotebookCount:
     cells = nb.get("cells", [])
 
     # First pass: detect markdown-header exercises and their paired code stub.
+    # A single markdown cell may GROUP multiple exercise declarations under one
+    # umbrella header (e.g. `## 8. Exercices` plus N sub-headers
+    # `### Exercice 1`, `### Exercice 2`, ... `### Exercice N`). Each header
+    # line carrying the exercise word contributes one ExerciseHit so the count
+    # tracks the per-instance granularity required by #2161 -- a notebook with
+    # three sub-headers under one section is THREE exercises, not one. See
+    # `_markdown_instance_header_count` for the rationale (N+1 umbrella +
+    # sub-instances).
     header_cell_indices: set[int] = set()
     for i, cell in enumerate(cells):
         if cell.get("cell_type") != "markdown":
             continue
         source = "".join(cell.get("source", []))
-        if _markdown_mentions_exercise(source):
-            result.exercises.append(
-                ExerciseHit(
-                    cell_index=i,
-                    cell_type="markdown",
-                    source=source,
-                    detected_by="markdown_header",
+        n_instances = _markdown_instance_header_count(source)
+        if n_instances > 0:
+            for _ in range(n_instances):
+                result.exercises.append(
+                    ExerciseHit(
+                        cell_index=i,
+                        cell_type="markdown",
+                        source=source,
+                        detected_by="markdown_header",
+                    )
                 )
-            )
             header_cell_indices.add(i)
 
     # Track which code cells are the paired stub of an exercise header so we
@@ -325,11 +401,22 @@ def count_exercises_in_notebook(path: Path) -> NotebookCount:
     # match fails and both are counted as distinct exercises (no under-count).
     paired_code_indices: set[int] = set()
     for idx in sorted(header_cell_indices):
-        # Forward (common): the stub just below the header, within 3 cells.
+        # Forward (common): the stub(s) just below the header, within 3 cells.
+        # When a markdown cell groups N instances (umbrella + sub-headers), we
+        # absorb up to N stubs in the forward window so each header produces
+        # one paired stub. Excess headers past the available stubs remain
+        # paired-less (counted as markdown-only); excess stubs past the
+        # headers fall through to the second pass as orphan code exercises.
+        n_instances = _markdown_instance_header_count(
+            "".join(cells[idx].get("source", []))
+        )
+        paired_count = 0
         for j in range(idx + 1, min(idx + 4, len(cells))):
+            if paired_count >= n_instances:
+                break
             if cells[j].get("cell_type") == "code":
                 paired_code_indices.add(j)
-                break
+                paired_count += 1
         # Backward (stub-then-header layout): the nearest preceding code cell,
         # absorbed only when it references the SAME exercise number as the
         # header. Numberless headers/stubs are left unpaired (conservative).

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -682,3 +682,195 @@ class TestThresholdIntegration:
         )
         result = count_exercises_in_notebook(nb)
         assert result.count < 3
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 of #6051 -- grouped markdown headers under-counted by the legacy
+# boolean ``_markdown_mentions_exercise`` helper. The replacement helper
+# ``_markdown_instance_header_count`` now counts per-instance headers: a
+# cell that groups an ``## N. Exercices`` umbrella with K explicit
+# ``### Exercice i`` sub-headers counts as K (not 1, not K+1), so a
+# three-exercise notebook is reported as three exercises. The flat-layout
+# cases (single header per cell) keep the legacy "1 cell = 1 exercise"
+# count so the regression suite on ``## 8. Exercice`` and
+# ``### Exercice -`` stays green.
+# ---------------------------------------------------------------------------
+
+
+class TestGroupedMarkdownHeadersBug1:
+    """Regression suite for #6051 Bug 1 -- grouped markdown headers."""
+
+    def test_grouped_umbrella_with_three_subheaders_counts_three(self, tmp_path):
+        """Real Bug 1 repro from ``04-Computational-Aggregation-SAT-Z3-Csharp``
+        cell 30 (markdown umbrella + 3 sub-headers) + cell 31 (code stub
+        block carrying ``// Exercice 1/2/3`` triple stub).
+
+        Pre-fix: counted 1. Post-fix: counts 3 (the 3 sub-headers).
+        """
+        nb = _write_nb(
+            tmp_path / "g30.ipynb",
+            [
+                _md("# Section SAT/SMT (transition)\n"),
+                _md(
+                    "## 8. Exercices\n"
+                    "\n"
+                    "### Exercice 1 : Purs litteraux\n"
+                    "Un literal est pur...\n"
+                    "\n"
+                    "### Exercice 2 : Robustesse de Sen au choix des paires\n"
+                    "Le theoreme de Sen...\n"
+                    "\n"
+                    "### Exercice 3 : Sen par SMT (Z3, rangs entiers)\n"
+                    "Demontrer par SMT...\n"
+                ),
+                _code(
+                    "// === Exercices (stubs) ===\n"
+                    "\n"
+                    "// Exercice 1 : elimination des litteraux purs\n"
+                    "public static double PureLiteralSpeedupPlaceholder()\n"
+                    "{\n"
+                    "    // TODO etudiant : ajouter la regle...\n"
+                    "    return 0.0;\n"
+                    "}\n"
+                    "\n"
+                    "// Exercice 2 : Robustesse de Sen au choix des paires\n"
+                    "public static int SenPairRobustnessPlaceholder()\n"
+                    "{\n"
+                    "    // TODO etudiant : tester la sensibilite...\n"
+                    "    return 0;\n"
+                    "}\n"
+                    "\n"
+                    "// Exercice 3 : Sen par SMT (Z3, rangs entiers)\n"
+                    "public static int SenSmtRanksPlaceholder()\n"
+                    "{\n"
+                    "    // TODO etudiant : encoder...\n"
+                    "    return 0;\n"
+                    "}\n"
+                ),
+                _md("## Conclusion\n"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            "Bug 1: umbrella + 3 sub-headers must count 3, not 1 (legacy) "
+            f"and not 4 (over-counting the umbrella). Got {result.count}."
+        )
+        # All hits should be on the umbrella cell (one per sub-header).
+        assert all(h.cell_index == 1 for h in result.exercises), (
+            "All 3 hits must come from the grouped markdown cell"
+        )
+        assert all(h.detected_by == "markdown_header" for h in result.exercises)
+
+    def test_umbrella_alone_no_subheaders_counts_one(self, tmp_path):
+        """When a markdown cell carries ONLY an ``## N. Exercices`` umbrella
+        (no explicit sub-headers), it counts as ONE exercise. The sub-header
+        rule is a refinement -- when no sub-headers exist we fall back to
+        the legacy "one header = one exercise" count.
+        """
+        nb = _write_nb(
+            tmp_path / "umbrella_only.ipynb",
+            [
+                _md("## 8. Exercices\n"),
+                _code("// Exercice unique : a faire\n// TODO etudiant\nreturn 0;\n"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            f"Umbrella alone counts 1, not {result.count}"
+        )
+
+    def test_flat_numbered_headers_count_each_one(self, tmp_path):
+        """Flat layout (the legacy test_numbered_section_header_is_counted
+        pattern) must keep counting each numbered section header as 1.
+        Sub-header rule does NOT activate when there are no ``###`` or
+        deeper headers in the cell -- the fallback returns total_count
+        which equals the number of section-level headers carrying the
+        exercise word.
+        """
+        nb = _write_nb(
+            tmp_path / "flat.ipynb",
+            [
+                _md("## 8. Exercice : le piege numerote\n"),
+                _code("# TODO etudiant\npass\n"),
+                _md("## 9. Exercice\n"),
+                _code("return None\n"),
+                _md("## 10. Exercice\n"),
+                _code("# TODO\nx = None\n"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            "Flat numbered headers must each count 1 (regression guard for "
+            "the legacy test_numbered_section_header_is_counted)."
+        )
+
+    def test_dash_separator_no_number_still_counts(self, tmp_path):
+        """Sub-header with no number (``### Exercice - Exploration``) must
+        still count. The legacy test_dash_separator_header_is_counted.
+        """
+        nb = _write_nb(
+            tmp_path / "dash.ipynb",
+            [
+                _md("### Exercice - Exploration\n"),
+                _code("# TODO\npass\n"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            f"Dash separator header must count 1, not {result.count}"
+        )
+
+    def test_subheaders_absorb_multiple_stubs_in_one_code_cell(self, tmp_path):
+        """When a grouped markdown cell has 3 sub-headers and is followed by
+        ONE code cell carrying all 3 ``# Exercice 1/2/3`` stubs, the forward
+        pairing window must absorb up to N=3 stubs (not just 1). The code
+        cell stub block is then considered "already paired" and is NOT
+        re-counted by the second pass. Result: 3 hits (the 3 sub-headers).
+        """
+        nb = _write_nb(
+            tmp_path / "triple_stub.ipynb",
+            [
+                _md(
+                    "## Exercices\n"
+                    "### Exercice 1 : A\n"
+                    "### Exercice 2 : B\n"
+                    "### Exercice 3 : C\n"
+                ),
+                _code(
+                    "# Exercice 1\n"
+                    "pass\n"
+                    "# Exercice 2\n"
+                    "pass\n"
+                    "# Exercice 3\n"
+                    "pass\n"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            f"3 sub-headers + 3 stubs in one code cell must count 3, not {result.count}"
+        )
+
+    def test_subheaders_with_only_one_stub_still_counts_three(self, tmp_path):
+        """When a grouped markdown cell has 3 sub-headers but is followed by
+        only 1 code cell with 1 stub, the forward pairing window absorbs
+        just 1 stub; the remaining 2 sub-headers stay markdown-only. No
+        second pass code-cell counting applies (cell 2 is paired). Result:
+        3 hits (3 markdown, 1 of them paired).
+        """
+        nb = _write_nb(
+            tmp_path / "subheader_partial_stub.ipynb",
+            [
+                _md(
+                    "## Exercices\n"
+                    "### Exercice 1 : A\n"
+                    "### Exercice 2 : B\n"
+                    "### Exercice 3 : C\n"
+                ),
+                _code("# Exercice 1\npass\n"),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 3, (
+            f"3 sub-headers + 1 stub must count 3, not {result.count}"
+        )


### PR DESCRIPTION
# PR #c427 — `count_exercises.py` grouped markdown headers (#6051 Bug 1)

## Résumé

Corrige le Bug 1 de l'issue #6051 dans
`scripts/notebook_tools/count_exercises.py` (CI gate pour EPIC #2161
« 3 exercices par notebook ») : la helper booléenne `_markdown_mentions_exercise`
comptait **une seule instance** par cellule markdown même quand celle-ci
regroupait N exercices sous une umbrella `## N. Exercices` + K
sous-headers `### Exercice i` numérotés. Conséquence : un notebook avec
3 sous-headers était rapporté `count = 1` au lieu de `count = 3`.

Remplacée par `_markdown_instance_header_count(source) -> int` qui distingue
deux layouts :

1. **Layout groupé** (umbrella + sous-headers `###`) → compte **K** sous-headers,
   l'umbrella `## N. Exercices` est organisateur uniquement (pas une instance
   supplémentaire).
2. **Layout plat** (un ou plusieurs headers de section `##` ou `###`) → compte
   1 par header, comme la sémantique legacy.

Le pairing forward absorbe maintenant jusqu'à N stubs dans la fenêtre
`[idx+1, idx+4]` (au lieu d'un seul), pour gérer le cas d'une cellule
code portant plusieurs stubs `// Exercice 1/2/3` après une cellule
markdown groupée.

## Cas reproducers (firsthand corpus scan)

| Notebook | Old count | New count | Reality |
|---|---|---|---|
| `GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb` (cell 30 = `## 8. Exercices` + `### Exercice 1/2/3`) | 1 | **3** | 3 (Bug 1) |
| `GenAI/Texte/11_Quantization.ipynb` | 4 | 8 | 8 |
| `Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb` | 6 | 10 | 10 |
| `Sudoku/Sudoku-14-BDD-Csharp.ipynb` | 5 | 9 | 9 |
| `GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb` | 3 | 6 | 6 |
| ... +37 autres notebooks corrigés |

Validation corpus complet (892 notebooks pédagogiques) :
- **INCREASED (legacy sous-comptait)** : 42 notebooks
- **DECREASED (legacy sur-comptait)** : 3 notebooks (cellules avec
  umbrella + texte non-sub-header comptées legacy comme 1 hit, corrigées
  par la règle sub-headers : la cellule `## Bilan — trois paradigmes...`
  n'est plus comptée comme exercice).
- **UNCHANGED** : 847 notebooks
- **ERRORS** : 0

## Tests

`test_count_exercises.py` : **41 passed** (35 legacy + 6 nouveaux tests
Bug 1 dans `TestGroupedMarkdownHeadersBug1`) :
- `test_grouped_umbrella_with_three_subheaders_counts_three` — repro
  exact de `04-Computational-Aggregation-SAT-Z3-Csharp` cell 30+31
- `test_umbrella_alone_no_subheaders_counts_one` — fallback plat
- `test_flat_numbered_headers_count_each_one` — régression guard pour
  le cas legacy `## 8. Exercice` (3 sub-headers numérotés = 3)
- `test_dash_separator_no_number_still_counts` — régression guard pour
  `### Exercice -` (pas de nombre)
- `test_subheaders_absorb_multiple_stubs_in_one_code_cell` — pairing
  forward étendu absorbe jusqu'à N stubs
- `test_subheaders_with_only_one_stub_still_counts_three` — pairing
  partiel : N sub-headers > N stubs ne produit pas de double-count

## Conformité règles

- **Atomicité G.4** : 1 PR = 1 sujet = Bug 1 uniquement. Bug 2 (section-
  pairing theft), Bug 3 (docstring stubs) restent dans le tracker #6051.
- **Anti-régression §D** : `git diff origin/main..HEAD --stat` = 2 fichiers,
  +289/-10 purement additif (logique + tests).
- **L268 anti-régression** : aucun code de production en dehors de
  `count_exercises.py` modifié.
- **c.187 atomicité** : 1 commit, 1 PR.
- **L378-DURCIE G.1 verify-before-claim** : corpus scan firsthand avec
  script `scratchpad/c427_diff_legacy_vs_new.py` ; les 42 augmentations
  ont été vérifiées sur les cells réelles (3 sub-headers par notebook,
  pas des artefacts).
- **Honnêteté des rapports G.3** : pas de "DONE" — 41/41 tests verts
  + 42 notebooks corrigés documentés.
- **Compatibilité ascendante** : la signature de `count_exercises_in_notebook`
  est inchangée ; les notebooks déjà comptés correctement (847/892) ne
  bougent pas.

## Liens

- Issue : jsboige/CoursIA#6051 (Bug 1)
- EPIC : #2161 « 3 exercices par notebook »
- PR sœur (Bug 4) : jsboige/CoursIA#6056 (print/display markers)
- Script validation : `scratchpad/c427_diff_legacy_vs_new.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
