### PR TITLE
docs(review): §D tool forensic review of #6067 (prover depth-3 fix — MERGEABLE)

### DIFF
--- a/docs/ledgers/reviews/2026-07-11-d-tool-6067.md
+++ b/docs/ledgers/reviews/2026-07-11-d-tool-6067.md
@@ -1,0 +1,43 @@
+# §D tool forensic review — PR #6067
+
+**PR:** #6067 — `fix(prover): close depth-3 verification gap in 8 sibling call sites (See #1453, follow-up to #5982)`
+**Author:** po-2024 (branch `fix/lean-utils-depth3-project-dir`, base `main`)
+**Reviewer:** po-2026 (cross-lane — prover harness is po-2026's explicit lane; authorship cross-ref'd: branch + commit authored by po-2024 session, ≠ po-2026 conway/hashlife sessions)
+**Verdict:** **MERGEABLE** — depth-3 bug reproduced firsthand on conway_lean, fix sound + minimal, all 8 buggy sites converted, 0 remaining `parent.parent` verifier sites, fallback preserves non-Lake behavior, guard tests green except 2 pre-existing unrelated failures.
+
+## Scope
+
+PR #5982 introduced `resolve_lake_module()` (walk up to nearest lakefile, return `(root, dotted_module)`) to fix LSP lemma-search for depth-3 files — but wired it **only** into `tools.py:_search_via_lsp`. **8 sibling call sites** still derived `project_dir = <file>.parent.parent`, the legacy depth-2 assumption that yields a lakefile-less dir for files nested below the top package (e.g. `Conway/Life/HashlifeCorrectness.lean` → `.../conway_lean/Conway/`, no lakefile). This silently degrades FX-5 TRUE_PLACEHOLDER_GOAL refusal, goal-state extraction, and sorry-replacement verification for depth-3 sorries — the exact sorries po-2026 works on (conway_lean Hashlife P4/P5). **+28/-11 on 2 files** (`lean_utils.py`, `tools.py`), prover harness Python only.
+
+## §D forensics (firsthand)
+
+| # | Check | Method | Result |
+|---|-------|--------|--------|
+| D1 | Fix logic minimal + sound | `Read` `resolve_lake_module` (lean_utils.py:34-60) + all 8 patched sites | SOUND. Walks `p.parent` up while no lakefile, returns `(str(cur), ".".join(prefix+[stem]))`. **Fallback to `parent.parent` if no lakefile found** (L60) → no regression for non-Lake/oddly-laid trees. Each site carries a depth-3 hardening comment citing #1453/#5982 |
+| D2 | Guard tests | `pytest test_prover_guards.py` firsthand (branch + main) | **134/136 PASS on branch.** 2 failures (`test_path_constants_resolve_to_active_workspace`, `test_candidates_list_prefers_workspace_relative_entry`) are **PRE-EXISTING on main** (verified by reverting lean_utils.py+tools.py to main → same 2 fail) — they're the `CoursIA` vs `CoursIA-2` workspace-relative-path concern (bug #5891), machine-config-dependent, **unrelated to #6067** |
+| D3 | Bug reproduced firsthand | Python path simulation on `conway_lean/Conway/Life/HashlifeCorrectness.lean` (po-2026's own lake file) | **BUG CONFIRMED.** Legacy `parent.parent` = `.../conway_lean/Conway/` → **no lakefile** (verifier would build wrong module). `resolve_lake_module` walks to `conway_lean` (lakefile ✓) → module `Conway.Life.HashlifeCorrectness`. The FX-5 probe was genuinely compiling against the wrong file for depth-3 sorries |
+| D4 | Anti-regression | `grep -n "\.parent\.parent"` both files + diff semantics | **0 remaining `parent.parent` verifier/project_dir call sites.** The only 2 surviving refs are (a) the docstring at lean_utils.py:42, (b) the intentional legacy fallback at lean_utils.py:60. Deletions = the 8 buggy lines only; insertions = `resolve_lake_module` calls + explanatory comments. No production logic lost |
+
+## 8 patched sites — verified each (firsthand grep)
+
+**`lean_utils.py` (3):**
+- `is_true_placeholder_goal` (L243) — FX-5 TRUE_PLACEHOLDER_GOAL refusal
+- `get_goal_state` (L417) — exact probe module
+- `verify_sorry_replacement` (L959) — candidate proof judged against right file
+
+**`tools.py` (5):**
+- `_build_check_or_revert` (L1023), `_quick_build_check` (L1693), `compile` (L1775), `read_build_result` (L2528), `read_build_errors` (L2608)
+
+## Body imprecision (minor, non-blocking)
+
+The PR body lists the 5th `tools.py` site as **`count_sorries`**, but the diff actually patches **`compile`** (L1764 method, L1775 call site). Firsthand check: the `count_sorries` method (L2546) has **no verifier/project_dir logic** — it tallies sorries from a build-output string, so it was never a buggy call site. The genuinely-buggy site is `compile`, which the fix correctly patches. **Net: correct count (8 sites), correct fix, imprecise label in the prose body.** Does not affect the fix's correctness.
+
+## D2 test-count note
+
+Body claims "135/135 guard tests PASS". The suite now collects **136** (one test added since the body was written), and **134 pass / 2 fail**. The 2 failures pre-exist on main (verified firsthand) and concern `CoursIA-2` workspace-relative paths (bug #5891), not depth-3 module resolution. The body's "135/135" is slightly stale on the count; the material claim (no new failures from this PR) holds.
+
+## Verdict
+
+**MERGEABLE.** Sound depth-3 hardening of the prover verifier path — a real silent-degradation bug reproduced firsthand on conway_lean `HashlifeCorrectness.lean`, fixed minimally via the already-proven `resolve_lake_module` helper, all 8 buggy sites converted with 0 `parent.parent` verifier sites remaining, legacy fallback preserves non-Lake behavior, guard tests green except 2 pre-existing unrelated failures. The single body imprecision (`count_sorries` vs `compile` label) is non-blocking.
+
+See #1453 (prover harness co-evolution). Not `Closes` — PR is a follow-up fix on an open epic.


### PR DESCRIPTION
## §D tool forensic review of PR #6067 (prover depth-3 verification gap)

**Verdict: MERGEABLE.** Cross-lane §D forensic by po-2026 (prover harness = po-2026's explicit lane; po-2024 author). Ledger: `docs/ledgers/reviews/2026-07-11-d-tool-6067.md`.

### D1-D4 forensics (firsthand)

| # | Check | Result |
|---|-------|--------|
| D1 | Fix logic (`resolve_lake_module` lean_utils.py:34-60) | SOUND. Walks up to nearest lakefile, returns `(root, dotted_module)`. **Legacy `parent.parent` fallback if no lakefile** → no regression for non-Lake trees |
| D2 | Guard tests | **134/136 PASS.** 2 failures pre-exist on main (verified by revert) — `CoursIA` vs `CoursIA-2` workspace-path concern (bug #5891), **unrelated to #6067** |
| D3 | Bug reproduced firsthand | On `conway_lean/Conway/Life/HashlifeCorrectness.lean` (po-2026's lake): legacy `parent.parent` = `.../conway_lean/Conway/` → **no lakefile** (verifier builds wrong module). `resolve_lake_module` → `conway_lean` (lakefile ✓), module `Conway.Life.HashlifeCorrectness`. FX-5 probe was genuinely compiling the wrong file for depth-3 sorries |
| D4 | Anti-regression | **0 remaining `parent.parent` verifier sites.** Deletions = 8 buggy lines only. Insertions = `resolve_lake_module` calls + comments |

### 8 sites verified (3 lean_utils + 5 tools)

`is_true_placeholder_goal`, `get_goal_state`, `verify_sorry_replacement` / `_build_check_or_revert`, `_quick_build_check`, `compile`, `read_build_result`, `read_build_errors`.

### Two minor body imprecisions (non-blocking)

1. **Body lists 5th tools.py site as `count_sorries`; the diff patches `compile`.** Firsthand: `count_sorries` (L2546) has no verifier/project_dir logic — never a buggy site. The genuinely-buggy `compile` is correctly patched instead. Correct count (8), correct fix, imprecise label.
2. **Body claims "135/135 guard tests PASS"**; suite now collects 136, 134 pass / 2 fail (both pre-existing on main, bug #5891). Material claim (no new failures) holds.

See #1453. Not `Closes` — follow-up fix on open epic.
