### PR TITLE
docs(genai-video): de-spaghetti README — remontée Prérequis (See #5985)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -34,6 +34,31 @@ Six figures extraites des notebooks illustrent la chaîne complète, depuis l'ex
 
 Chaque figure renvoie au notebook dont elle est extraite ; la provenance détaillée (cellule, output, poids, alt-text) figure dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
+## Prérequis
+
+### API Keys
+
+```bash
+# Dans GenAI/.env
+OPENAI_API_KEY=sk-...
+COMFYUI_AUTH_TOKEN=...
+```
+
+### GPU (pour notebooks locaux)
+
+- **Minimum** : 4 GB VRAM (Real-ESRGAN, RIFE)
+- **Recommandé** : 12+ GB VRAM (AnimateDiff, LTX-Video)
+- **Optimal** : 24 GB VRAM (HunyuanVideo, Wan, tous les notebooks)
+
+### FFmpeg
+
+FFmpeg doit être installé sur le système :
+
+```bash
+# Windows (via winget)
+winget install FFmpeg
+```
+
 ## Progression par niveau
 
 ### 01-Foundation - Comprendre la vidéo avant de la générer
@@ -146,31 +171,6 @@ flowchart TD
 | **LTX-2 (Lightricks)** | 02-5 | GPU ~14-24 GB VRAM (GGUF Q4 / fp8-cast) |
 | **ComfyUI Video** | 03-3 | Docker, nodes vidéo |
 | **OpenAI Sora 2** | 04-3 | `OPENAI_API_KEY` |
-
-## Prérequis
-
-### API Keys
-
-```bash
-# Dans GenAI/.env
-OPENAI_API_KEY=sk-...
-COMFYUI_AUTH_TOKEN=...
-```
-
-### GPU (pour notebooks locaux)
-
-- **Minimum** : 4 GB VRAM (Real-ESRGAN, RIFE)
-- **Recommandé** : 12+ GB VRAM (AnimateDiff, LTX-Video)
-- **Optimal** : 24 GB VRAM (HunyuanVideo, Wan, tous les notebooks)
-
-### FFmpeg
-
-FFmpeg doit être installé sur le système :
-
-```bash
-# Windows (via winget)
-winget install FFmpeg
-```
 
 ## Parcours recommandé
 


### PR DESCRIPTION
## Contexte

EPIC **#5985** — READMEs de série : réorganiser du plus saillant au plus spécifique (pyramide inversée).

`GenAI/Video/README.md` avait sa **porte de setup enfouie à 58 %** : le bloc `## Prérequis` (API Keys + GPU + FFmpeg, L150-174) se trouvait **après** la « Recette » (L84-124, 40 lignes de pipeline pratique) qui **suppose le setup déjà fait** (clés API configurées, GPU VRAM suffisant, FFmpeg installé). Un lecteur suivant la recette devait attendre L150 pour découvrir les prérequis.

## Changement

**Pure block reorder** — le bloc `## Prérequis` (25 lignes, L150-174) est remonté à **L37 (13 %)**, juste après l'« Aperçu » visuel et avant tout contenu pratique (Progression par niveau, Recette). Un lecteur voit maintenant les prérequis (clés API, paliers VRAM 4/12/24 GB, FFmpeg) **avant** la recette qui en a besoin.

## Vérification

| Critère | Résultat |
|---------|----------|
| Type de changement | Pure block reorder (bloc contigu relocalisé) |
| Multiset-diff | **0** (`collections.Counter` égal, preuve de reorder pur) |
| Nombre de lignes | Inchangé (260) |
| Diff | 25 insertions / 25 délétions (symétrique) |
| CATALOG-STATUS | Bloc byte-identique (catalog-pr-hygiene respecté) |
| Join points | Aperçu→(blank)→Prérequis ; Technologies→(blank)→Parcours (espacement propre) |
| Anti-collision | Aucune PR ouverte sur GenAI/Video README (vérifié) |
| Encodage | LF-only (0 CRLF) |

Aucun contenu ajouté, modifié ou supprimé — seul l'ordre des sections change.

See #5985

🤖 Generated with [Claude Code](https://claude.com/claude-code)