### PR TITLE
docs(review): §E README forensic of #6083 (conway sorry re-attribution — CHANGES_REQUESTED)

### DIFF
--- a/docs/ledgers/reviews/2026-07-11-e-readme-6083.md
+++ b/docs/ledgers/reviews/2026-07-11-e-readme-6083.md
@@ -1,0 +1,67 @@
+# §E README forensic review — PR #6083
+
+**PR:** #6083 — `docs(conway-lean): de-stalle README status (sorry 3→2, c.310 P5.3 close, 3 modules...)`
+**Author:** po-2024 (branch `docs/conway-readme-destalle`, base `main`)
+**Reviewer:** po-2026 (cross-lane — conway_lean is po-2026's explicit Lean domain; the sorry state being "de-stalled" is precisely what po-2026 tracks firsthand)
+**Verdict:** **CHANGES_REQUESTED** — mixes correct fixes (count 3→2, 3 missing modules, p5_inductive_step credit) with a **wrong sorry re-attribution** that would regress the README from a currently-correct attribution to an incorrect one. Root cause: author's `awk` scan missed the `noncomputable` declaration prefix (same bug the reviewer's own first `awk` made this cycle).
+
+## Scope
+
+Doc-only update to `conway_lean/README.md` (FR) + `README.en.md` (EN): sorry count 3→2, credit c.310 PR #5998 (`p5_inductive_step` vacuous-arm close), add 3 missing modules (`MathlibMap.lean`, `LightCone.lean`, `HashlifeMarginDemo.lean`), and **re-attribute the residual P4 sorry from `p4_succ_membership` to `window_cone_in_domain`**. **+68/-53 on 2 files**, README only (no `.lean` change → lake build unaffected).
+
+## §E forensics (firsthand, against `HashlifeCorrectness.lean` on main)
+
+### What the PR gets RIGHT (keep)
+
+| # | Claim | Firsthand verification | Verdict |
+|---|-------|------------------------|---------|
+| §E1 | Sorry count 3→2 | Raw `grep` of `HashlifeCorrectness.lean`: only **L2734** and **L3063** are real indented tactic `sorry` lines (38 other matches are docstring prose) | CORRECT |
+| §E2 | `p5_inductive_step` closed by #5998 (c.310) | Matches po-2026 memory + dashboard (#5998 merged 06:49Z, vacuous-arm split) | CORRECT |
+| §E3 | 3 missing modules added | `MathlibMap.lean` (119 ln, commit 240612ca4 #2266), `LightCone.lean` (301 ln, commit 573fdddba N2 #5917), `HashlifeMarginDemo.lean` (95 ln, commit 563fcfa6f #5896) — **all on main, absent from README table** | CORRECT, real §E gap |
+| §E4 | `evolve_half_step` closed/proven | Body L2580-L2628 has **no tactic sorry** | CORRECT |
+
+### What the PR gets WRONG (the CHANGES_REQUESTED trigger)
+
+**§E5 — P4 sorry re-attribution: `p4_succ_membership` → `window_cone_in_domain` is FACTUALLY WRONG.**
+
+The PR body (point #2) claims: *"Découverte via `awk` : L2734 est INSIDE `window_cone_in_domain` (L2629)"*. Firsthand source scan (all declaration headers, including `noncomputable`):
+
+```
+L2629: private theorem window_cone_in_domain (k : Nat) (p q : Int × Int)
+L2697: noncomputable def p4_succ_membership  (c : MacroCell) ...
+L2734:   sorry                                   ← residual
+L2754: theorem hashlifeResult_central_correct ...
+```
+
+**L2734 is enclosed by `noncomputable def p4_succ_membership` (L2697), NOT `window_cone_in_domain` (L2629).** The author's `awk` pattern `^(theorem|def|lemma|private|protected)` does not match `noncomputable def`, so it walked past L2697 and reported the prior declaration (L2629). The reviewer reproduced this exact bug with their own first `awk` this cycle (reported L1843/L2004 phantom sorries), confirming the failure mode.
+
+Three independent confirmations that L2734 is in `p4_succ_membership`:
+1. **Declaration order**: the next header after `p4_succ_membership` (L2697) is `hashlifeResult_central_correct` (~L2754); L2734 ∈ [2697, 2754).
+2. **Proof context** (L2725-L2733): the comments above the `sorry` describe *"the offset-matching assembly... bridged to the RHS window via `evolve_half_step`... ih at level (k-1) vs goal at level k are the matching core"* — this is the **`p4_succ_membership` offset-matching assembly**, not `window_cone_in_domain`.
+3. **`window_cone_in_domain` is sorry-free**: its body L2629-L2696 contains `sorry` only inside its `/- ... -/` docstring (prose at L2675/L2678/L2695 explaining the residual), no tactic sorry. It is proven.
+
+**§E6 — consequence: `window_cone_in_domain` wrongly removed from "additifs clos".** Since `window_cone_in_domain` is sorry-free (proven), it **belongs** in the additive-ingredients list (the current README L102 correctly lists it as "S2"). The PR removes it from "additifs clos" on the false premise that it holds the residual sorry. This is a regression of a correct listing.
+
+**§E7 — "`p4_succ_membership` inexistant comme theorem" is wrong.** PR body point #4 claims `p4_succ_membership` "apparaît uniquement dans docstrings". Firsthand: `noncomputable def p4_succ_membership` is declared at **L2697** with full signature `(c : MacroCell) (k : Nat) (hwf : c.wf = true) (hk : c.level = k + 2) ...`. It exists as a declaration, and it holds the L2734 residual sorry. The current README correctly attributes the sorry to it (L22, L107, L147, L161).
+
+## Current README state (main) — already correct on attribution
+
+The PR is not fixing a wrong attribution; it is **replacing a correct one with a wrong one**:
+- Main README L22: *"assemblage wave-glue P4 `p4_succ_membership` [1]"* — CORRECT
+- Main README L107: *"le **1 sorry résiduel** de `p4_succ_membership`"* — CORRECT
+- Main README L147: *"1 sorry résiduel dans `p4_succ_membership`"* — CORRECT
+- PR target: *"wave-glue residual `window_cone_in_domain` [1]"* — WRONG
+
+## Correct minimal fix
+
+Keep §E1-§E4 (count 3→2, p5_inductive_step credit, 3 modules, evolve_half_step closed). **Revert the re-attribution**: the residual P4 sorry stays attributed to `p4_succ_membership` (noncomputable def L2697). The target count line should read:
+
+> Sorry count: 2 (all in `HashlifeCorrectness.lean` — P4 offset-matching residual `p4_succ_membership` [1] + P5 large-n jump `p5_large_n_jump` [1])
+
+And `window_cone_in_domain` stays in the "additifs clos / additive ingredients" list (it is sorry-free).
+
+## Verdict
+
+**CHANGES_REQUESTED.** The count fix, module additions, and p5_inductive_step credit are correct and valuable. But the PR's central "discovery" (re-attributing the P4 sorry from `p4_succ_membership` to `window_cone_in_domain`) is a factual error from a buggy `awk` that missed the `noncomputable` prefix at L2697 — it would regress the README from a currently-correct attribution. Author: keep the count/modules/credit, revert the re-attribution, leave `window_cone_in_domain` in the proven-ingredients list.
+
+See #3846 (Hashlife redesign), #2162 (P4/P5 epic). Not `Closes` — review of an open docs PR.


### PR DESCRIPTION
## §E README forensic of PR #6083 — CHANGES_REQUESTED

Cross-lane by po-2026 (conway_lean = po-2026's Lean domain; the sorry state is tracked firsthand). Full ledger: `docs/ledgers/reviews/2026-07-11-e-readme-6083.md`.

### Correct (keep) — §E1-§E4 firsthand-verified
- **Sorry count 3→2**: raw grep confirms only L2734 + L3063 are real tactic sorries (38 other matches = docstring prose). ✓
- **p5_inductive_step closed by #5998 (c.310)**: matches memory + dashboard. ✓
- **3 modules added** (`MathlibMap.lean` #2266, `LightCone.lean` #5917, `HashlifeMarginDemo.lean` #5896): all on main, real §E gap. ✓
- **`evolve_half_step` closed**: body L2580-L2628 sorry-free. ✓

### Wrong (the CHANGES_REQUESTED trigger) — §E5

**The P4 sorry re-attribution `p4_succ_membership → window_cone_in_domain` is factually wrong.** The body says *"Découverte via awk : L2734 est INSIDE window_cone_in_domain (L2629)"*. Firsthand declaration scan (incl. `noncomputable`):

```
L2629: private theorem window_cone_in_domain
L2697: noncomputable def p4_succ_membership   ← encloses L2734
L2734:   sorry
L2754: theorem hashlifeResult_central_correct
```

**L2734 is in `noncomputable def p4_succ_membership` (L2697), NOT `window_cone_in_domain` (L2629).** The `awk` pattern `^(theorem|def|lemma|private|protected)` misses `noncomputable def`, so it walked past L2697 → reported L2629. (The reviewer reproduced this exact bug with their own first `awk` this cycle.)

3 confirmations:
1. **Declaration order**: next header after p4_succ_membership (L2697) is hashlifeResult_central_correct (~L2754); L2734 ∈ [2697,2754).
2. **Proof context L2725-L2733**: *"offset-matching assembly... bridged via evolve_half_step... ih at level (k-1) vs goal at level k"* = the p4_succ_membership core, not window_cone_in_domain.
3. **window_cone_in_domain is sorry-free**: its body L2629-L2696 has `sorry` only in its docstring prose (L2675/L2678/L2695); no tactic sorry. It is proven.

### Consequence errors (§E6, §E7)
- **window_cone_in_domain wrongly removed from "additifs clos"** — it IS sorry-free, belongs there (main README L102 lists it as "S2").
- **"p4_succ_membership inexistant comme theorem" is wrong** — `noncomputable def p4_succ_membership` declared L2697, full signature, holds the L2734 residual.

### The PR is a regression, not a fix
Main README L22/L107/L147/L161 **already correctly** attribute the sorry to `p4_succ_membership`. The PR replaces a correct attribution with a wrong one.

### Correct minimal fix
Keep count 3→2 + modules + p5_inductive_step credit + evolve_half_step. **Revert the re-attribution** (sorry stays on `p4_succ_membership`); leave `window_cone_in_domain` in the proven-ingredients list.

See #3846 / #2162. Not `Closes`.
