### PR TITLE
fix(notebook-tools): count_exercises detects `# a completer` line-comment stub markers (#6051 Bug 5)

### DIFF
--- a/scripts/notebook_tools/count_exercises.py
+++ b/scripts/notebook_tools/count_exercises.py
@@ -141,6 +141,21 @@ STUB_PATTERNS = [
     re.compile(r"^\s*result\s*=\s*None\b", re.MULTILINE | re.IGNORECASE),
     re.compile(r"^\s*raise\s+NotImplementedError", re.MULTILINE),
     re.compile(r"^\s*assert\s+False\b", re.MULTILINE),
+    # "a completer" / "to complete" LINE-COMMENT stub markers. A scaffolded
+    # cell whose comment line is itself the marker -- ``# A COMPLETER``,
+    # ``// a completer``, ``-- à compléter`` -- is a student stub, but this
+    # phrase is not one of the TODO/Indice/pass/return markers above, so a
+    # multi-line skeleton cell bearing only such a comment escaped STUB_PATTERNS
+    # and was under-counted (e.g. Search-11 cell 43: ``# A COMPLETER`` + a
+    # truncated ``problem_profit = Problem(`` skeleton). The phrase must be the
+    # LEADING content of the comment (right after the ``#``/``//``/``--`` marker,
+    # optional parenthesis): a mid-sentence ``# ... la cellule est a completer``
+    # in a worked solution's prose is NOT a stub marker and must not match.
+    # Accented and English forms covered.
+    re.compile(
+        r"^\s*(?:#|//|--)\s*\(?[ \t]*(?:a compl[eé]ter|to complete)\b",
+        re.IGNORECASE | re.MULTILINE,
+    ),
 ]
 
 

--- a/scripts/notebook_tools/tests/test_count_exercises.py
+++ b/scripts/notebook_tools/tests/test_count_exercises.py
@@ -432,6 +432,65 @@ class TestCodeCellOnlyExercise:
         result = count_exercises_in_notebook(nb)
         assert result.count == 0
 
+    def test_a_completer_line_comment_skeleton_stub_is_counted(self, tmp_path):
+        """``# a completer`` LINE-COMMENT stub marker (Bug 5 of #6051). A
+        scaffolded cell whose comment says "(a completer)" / "a completer"
+        but carries a multi-line skeleton (no ``# TODO``/``pass``/``return
+        None``) escaped STUB_PATTERNS and the ``<= 1 effective code-line``
+        rule, so it was under-counted. Regression for
+        ``Search-11-Metaheuristics`` cell 43 (``# A COMPLETER`` + truncated
+        ``problem_profit = Problem(`` skeleton).
+        """
+        nb = _write_nb(
+            tmp_path / "acompleter.ipynb",
+            [
+                _md("# Titre"),
+                _code(
+                    "# Exercice 1 : Probleme d'optimisation\n"
+                    "def profit_function(solution):\n"
+                    "    x, y = solution\n"
+                    "    return 50*x + 80*y\n"
+                    "\n"
+                    "# A COMPLETER\n"
+                    "bounds = [(0, 20), (0, 20)]\n"
+                    "problem = Problem(bounds=bounds,\n"
+                    "                 minmax=\"min\",\n"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        assert result.count == 1, (
+            "Cell with '# a completer' line comment + skeleton must count"
+        )
+        assert result.exercises[0].detected_by == "code_cell_comment"
+
+    def test_a_completer_in_solution_prose_not_counted(self, tmp_path):
+        """Bug 5 guard (anti over-count): the comment-anchored ``a completer``
+        pattern must NOT count a complete solution whose prose comment merely
+        references completion in passing. A real solution with multiple code
+        lines and no actual stub scaffold is an example, not an exercise.
+        """
+        nb = _write_nb(
+            tmp_path / "acompleter_sol.ipynb",
+            [
+                _md("# Titre"),
+                _code(
+                    "# Exercice 1 : la cellule suivante est a completer\n"
+                    "# par l'etudiant -- ici la solution de reference.\n"
+                    "def solve(x):\n"
+                    "    return x * 2\n"
+                    "print(solve(21))\n"
+                ),
+            ],
+        )
+        result = count_exercises_in_notebook(nb)
+        # The narrow pattern requires "a completer" as the LEADING comment
+        # content, so mid-sentence prose ("la cellule suivante est a
+        # completer") does NOT match -- this complete solution is not counted.
+        assert result.count == 0, (
+            "Mid-sentence 'a completer' prose in a solution must NOT count"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Lean (``--`` line comment) detection -- mirrors the C# ``//`` tests above.


### PR DESCRIPTION
fix(notebook-tools): count_exercises detects `# a completer` line-comment stub markers (#6051 Bug 5)

A scaffolded code cell whose comment line IS the stub marker --
`# A COMPLETER`, `// a completer`, `-- a completer` -- is a student
exercise stub, but this phrase is not among the TODO/Indice/pass/return
None markers in STUB_PATTERNS. A multi-line skeleton cell bearing only
such a comment escaped STUB_PATTERNS AND the `<= 1 effective code-line`
rule (the skeleton's code lines outnumber one), so it was silently
under-counted.

Genuine corpus case (firsthand, #6051 Bug 5):
  Search/Part1-Foundations/Search-11-Metaheuristics.ipynb cell 43
    `# Exercice 1 : Probleme d'optimisation d'entreprise` header comment
    + a `def profit_function` + a `# A COMPLETER` line + a truncated
    `problem_profit = Problem(` skeleton -- a real student stub, reported
    count = 3 (cells 17/28/35 via markdown headers). Reality: 4.

Fix: add a STUB_PATTERN matching `a completer` / `a completer`(accented)
/ `to complete` as the LEADING content of a `#`/`//`/`--` line comment
(optional leading parenthesis). The leading-phrase anchor is required: a
mid-sentence `# ... la cellule est a completer` in a worked solution's
prose is NOT a stub marker and must not match (regression test
test_a_completer_in_solution_prose_not_counted guards this; corpus delta
shows 0 such FPs repo-wide).

Validation (full 1071-notebook corpus, this branch vs origin/main):
  - DECREASED (regression): 0 notebooks
  - INCREASED (improved):    1 notebook
    * Search-11-Metaheuristics: 3 -> 4  (correct: cell 43 real stub)
  Pairing pass UNCHANGED -> only genuinely-unpaired stubs added ->
  monotonic non-decrease by construction.

Tests: 37 passed (35 original + 2 new: positive stub + prose-FP guard).

Scope: partial fix for #6051 -- resolves the `# a completer` line-comment
under-count (Bug 5). Disjoint from #6056 (Bug 4, pass-2 L359) and #6059
(Bugs 1+2, regex L69 / function L279 / pairing L346): this PR edits only
STUB_PATTERNS (L142-157), a region none of the concurrent scanner PRs
touch, so all three merge cleanly in any order. Bug 3 (docstring stubs)
investigated firsthand and found to have 0 corpus instances (theoretical)
-- documented in #6051, left open.

See #6051

Co-Authored-By: Claude-Code <noreply@anthropic.com>
