### PR TITLE
docs(review): §D tool forensic review of #6085 (prover latch depth-3 fix — MERGEABLE)

### DIFF
--- a/docs/ledgers/reviews/2026-07-11-d-tool-6085.md
+++ b/docs/ledgers/reviews/2026-07-11-d-tool-6085.md
@@ -1,0 +1,37 @@
+# §D tool forensic review — PR #6085
+
+**PR:** #6085 — `fix(prover): latch workflow now resolves Lake project via resolve_lake_module (See #1453, follow-up to #6067)`
+**Author:** po-2026 (this reviewer — but authored by a separate po-2026 session `c.315` per the test comment header; the branch `fix/latch-workflow-resolve-lake-module` is distinct from po-2026 conway/forensic sessions). Cross-session self-review guarded: the reviewer grounded every claim firsthand against `main` source + the branch blob, treating the PR as external.
+**Reviewer:** po-2026 (conway_lean + prover harness = po-2026's lanes; the latch path is the last depth-3 holdout after the reviewer's own #6067 forensic covered the 8 VerifyExecutor/lean_utils/tools sites)
+**Verdict:** **MERGEABLE** — latch depth-3 bug reproduced firsthand, fix sound + minimal, 3 regression tests pass (incl. a legacy-bug pin), full guard suite 137/139 (only the 2 pre-existing unrelated `CoursIA` vs `CoursIA-2` failures).
+
+## Scope
+
+The in-place-proof latch in `MultiAgentSorryProver.VerifyExecutor._run_inner` (`workflow.py`) used the same legacy depth-2 heuristic (`str(filepath.parent.parent)` + `<parent>/<stem>`) that PR #6067 (reviewer's c.313 §D forensic) eliminated from the 8 sibling sites. **This latch path was the last holdout** — it silently no-op'd the latch build confirmation for any sorry deeper than 2 levels. For `Conway/Life/HashlifeCorrectness.lean` (the central P4/P5 sorry at L2734), the latch looked it up as `Life/HashlifeCorrectness.lean` against project dir `.../conway_lean/Conway/` (no lakefile) → the latch contract's `verify_project_file` either failed or built the wrong module, so every depth-3 sorry proof would silently pass latch confirmation without a real build. **+92/-4 on 2 files** (`workflow.py` 14/-4, `test_prover_guards.py` +80 regression tests).
+
+## §D forensics (firsthand)
+
+| # | Check | Method | Result |
+|---|-------|--------|--------|
+| D1 | Fix logic minimal + sound | `Read` latch block (workflow.py:890-935) + `resolve_lake_module` (verified sound in c.313 §D #6067) | SOUND. 3 conversions: legacy `_latch_verifier = get_verifier(parent.parent)` → `get_verifier(resolve_lake_module(fp)[0])`; legacy `_latch_rel = "<parent>/<stem>"` → `module.replace(".", "/") + ".lean"`. The dotted-module → relative-path transform is the correct inverse of Lake's module convention. Comment cites #1453/#6067 |
+| D2 | Regression tests | `pytest -k "latch or depth"` + full suite, firsthand | **3 new tests PASS** (`test_latch_uses_resolve_lake_module_for_depth3_files`, `test_latch_legacy_heuristic_would_have_failed_for_depth3`, `test_latch_resolution_depth2_legacy_unchanged`). **Full suite 137/139** (134 base + 3 new). The 2 failures = the pre-existing `CoursIA` vs `CoursIA-2` workspace-path concern (bug #5891), documented in po-2026 memory `prover-harness-po2026-env.md`, **unrelated to #6085** |
+| D3 | Bug reproduced firsthand | Python path simulation on `conway_lean/Conway/Life/HashlifeCorrectness.lean` | **BUG CONFIRMED.** Legacy latch `parent.parent` = `.../conway_lean/Conway/` (no lakefile); legacy `_latch_rel` = `Life/HashlifeCorrectness.lean` (WRONG — drops the `Conway/` segment, looks up a top-level module). `resolve_lake_module` → project `conway_lean` (lakefile ✓), module `Conway.Life.HashlifeCorrectness` → rel `Conway/Life/HashlifeCorrectness.lean` ✓ |
+| D4 | Anti-regression | `grep -nE "parent\.parent"` latch block + diff semantics | **0 remaining `parent.parent` verifier/project_dir sites in the latch block.** Deletions = the 4 legacy lines (2 logical sites: project_dir + rel). Insertions = `_latch_resolve` call + comment + 3 regression tests. No production logic lost. The legacy-bug test pin (`test_latch_legacy_heuristic_would_have_failed_for_depth3`) explicitly documents the bug so a future refactor can't silently regress |
+
+## Test design note (positive signal)
+
+The 3 regression tests are well-designed: (1) proves the fix resolves depth-3 to the correct `(project_dir, module_name, rel)`, (2) **pins the legacy bug** (`legacy_rel != correct`, `legacy_project_dir != pkg_root`) as a regression tripwire, (3) proves depth-2 compatibility (the fix doesn't break the easy case). This is exactly the test triad that makes the fix trustworthy — it locks both the fix and the bug-class.
+
+## D2 test-count note
+
+Full guard suite now collects **139** (was 136 — the 3 new latch tests added). **137 pass / 2 fail**, the 2 failures pre-exist on main (verified c.313 by reverting prover files → same 2 fail) and concern `CoursIA-2` workspace-relative paths (bug #5891), not depth-3 module resolution.
+
+## Minor body/test-comment imprecision (non-blocking)
+
+The test comment header says *"PR #6088 (c.315)"* but the PR number is **#6085** (and #6088 is an unrelated Search twin README PR). The body text itself says *"See #1453 follow-up to PR #6067"* (correct). This is a stale PR-number reference in a test docstring — does not affect correctness or the fix's soundness.
+
+## Verdict
+
+**MERGEABLE.** Sound completion of the depth-3 hardening arc — the latch was the last `parent.parent` holdout after #6067, and it covered the most safety-critical path (the in-place-proof confirmation gate). Bug reproduced firsthand on conway_lean `HashlifeCorrectness.lean`, fixed via the already-proven `resolve_lake_module` helper, 3 strong regression tests (incl. a legacy-bug pin), full suite 137/139 with only pre-existing unrelated failures. The single test-comment PR-number imprecision (`#6088` vs `#6085`) is non-blocking.
+
+See #1453 (prover harness co-evolution), #6067 (predecessor depth-3 fix). Not `Closes` — follow-up fix on an open epic.


### PR DESCRIPTION
## §D tool forensic of PR #6085 (prover latch depth-3 fix) — MERGEABLE

Cross-session by po-2026 (prover harness + conway_lean = po-2026's lanes; latch path is the last depth-3 holdout after the reviewer's own #6067 forensic). Ledger: `docs/ledgers/reviews/2026-07-11-d-tool-6085.md`.

### D1-D4 firsthand

| # | Check | Result |
|---|-------|--------|
| D1 | Fix logic (`workflow.py:890-935` latch block) | SOUND. 3 conversions; `_latch_module.replace(".", "/") + ".lean"` = correct inverse of Lake module convention. Comment cites #1453/#6067 |
| D2 | Regression tests | **3 new tests PASS** (depth-3 fix + legacy-bug pin + depth-2 compat). **Full suite 137/139** (134 base + 3 new). The 2 fails = pre-existing `CoursIA` vs `CoursIA-2` workspace-path concern (bug #5891), documented po-2026 memory — **unrelated to #6085** |
| D3 | Bug reproduced firsthand | On `conway_lean/Conway/Life/HashlifeCorrectness.lean`: legacy latch `parent.parent` = `.../conway_lean/Conway/` (no lakefile); legacy `_latch_rel` = `Life/HashlifeCorrectness.lean` (**WRONG — drops `Conway/`**). `resolve_lake_module` → project `conway_lean` (lakefile ✓), module `Conway.Life.HashlifeCorrectness` |
| D4 | Anti-regression | 0 remaining `parent.parent` in latch block. Deletions = 4 legacy lines. Legacy-bug test pin locks the bug-class |

### Positive signal
The 3 regression tests are well-designed: (1) depth-3 fix, (2) **legacy-bug pin** (`legacy_rel != correct`) = regression tripwire, (3) depth-2 compat. Locks both fix and bug-class.

### Minor imprecision (non-blocking)
Test comment header says *"PR #6088 (c.315)"* but the PR is **#6085** (#6088 = unrelated Search twin). Body text correct. Doesn't affect correctness.

### Latch = most safety-critical path
The latch is the in-place-proof confirmation gate (`VerifyExecutor._run_inner`). Before this fix, every depth-3 sorry proof (incl. conway P4/P5 at L2734) silently passed latch confirmation without a real build — `parent.parent` → no lakefile → wrong/no build. This was the last holdout after #6067's 8 sites. Sound fix, strong tests.

See #1453 / #6067. Not `Closes` — follow-up on open epic.
