### PR TITLE
docs(tweety): add missing Tweety-5-Abstract-Argumentation-Csharp twin to README table

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -159,6 +159,7 @@ Pour les praticiens intéressés par les applications multi-agents :
 | **Argumentation** |
 | 5  | [Tweety-5-Abstract-Argumentation](Tweety-5-Abstract-Argumentation.ipynb) | Dung AF, Sémantiques, CF2, Génération         | 55 min  | Python |
 | 5b | [Tweety-5b-Lean-Argumentation](Tweety-5b-Lean-Argumentation.ipynb) | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de Dung dans le lake `argumentation_lean` (grounded = point fixe Knaster–Tarski), `#check` + `#print axioms` in-kernel (UNLOCK c.127, jonction Mathlib #2611) | 45 min  | Lean BETA |
+| 5c | [Tweety-5-Abstract-Argumentation-Csharp](Tweety-5-Abstract-Argumentation-Csharp.ipynb) | Twin C# Dung AF **from-scratch** (BCL .NET uniquement, pas IKVM/JVM) : fonction caractéristique, acceptabilité, ensembles admissibles/complets, sémantiques grounded (plus petit point fixe) / stable / preferred, labeling 3 valeurs (in/out/undec), génération aléatoire de cadres, 3 exercices. Complémentarité from-scratch ↔ Python/IKVM (marathon #4956, §3801) | 50 min | C# BETA |
 | 6  | [Tweety-6-Structured-Argumentation](Tweety-6-Structured-Argumentation.ipynb) | ASPIC+, DeLP, ABA, ASP                            | 60 min  | Python |
 | 6c | [Tweety-6-Structured-Argumentation-Csharp](Tweety-6-Structured-Argumentation-Csharp.ipynb) | Twin C# ASPIC+ from-scratch (BCL, pas IKVM ; DeLP/ABA/ASP conceptuel) | 35 min | C# PROD |
 | 7a | [Tweety-7a-Extended-Frameworks](Tweety-7a-Extended-Frameworks.ipynb) | ADF, Bipolar, WAF, SAF, SetAF, Extended             | 50 min  | Python |


### PR DESCRIPTION
## Contexte

Le README `SymbolicAI/Tweety` liste un jumeau C# (`.NET`) à côté de chaque notebook Python (2a/2b/2c, 3c-*, 4c-*, 6c, 7ac, 7bc, 8c) **mais omettait le jumeau C# de Tweety-5**, qui existe pourtant sur `main` et est entièrement exécuté.

## Changement

Ajout d'une ligne au tableau des notebooks pour le jumeau C# manquant :

| Jumeau C# | Cellules | Contenu |
|-----------|----------|---------|
| `Tweety-5-Abstract-Argumentation-Csharp.ipynb` | **25 cells, 12/12 exécutées, 0 erreur** | Dung AF from-scratch (BCL .NET uniquement, pas IKVM/JVM) : fonction caractéristique, acceptabilité, admissibles/complets, sémantiques grounded/stable/preferred, labeling 3 valeurs, génération aléatoire, 3 exercices |

## Vérification (G.1 firsthand)

| Critère | Résultat |
|---------|----------|
| Fichier existe sur `origin/main` | `git cat-file -e` → **EXISTS** |
| Notebook réel (pas stub) | 12/12 cellules code exécutées, 0 erreur |
| Convention jumeau | Le README L39 stipule « `-Csharp` apparaît à côté du Python » — la row manquait |
| Désignation `5c` | Cohérente avec les rows existantes 6c, 7ac, 7bc, 8c |
| Description fidèle | Extraite des en-têtes de section réels (fonction caractéristique, grounded/stable/preferred, in/out/undec, exercices) — **pas de fabrication** |
| Auto-vérification SOTA | Marqueur in-notebook « Complémentarité .NET from-scratch ↔ Python/IKVM, pas workaround (#3801) » |
| Anti-collision | PR #6062 (Tweety README de-spaghetti) ne touche QUE le bloc Installation L303 + un séparateur L530 — la table notebooks L160 est **intacte dans #6062**, régions disjointes |
| Type de changement | Ajout de contenu pur (1 ligne), aucun reorder, aucun contenu supprimé |
| Encodage | LF-only (0 CRLF) |

Fix de drift README-vs-réalité (G.1), même classe que #6088 (Search Part1 C# twins) et le fix GameTheory « Structure des fichiers ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)