### PR TITLE
fix(prover): cap autonomous wall-clock budget to prevent 5h+ zai stalls (See #1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -5,6 +5,7 @@ AutonomousProver uses a single agent with full editing powers.
 """
 
 import json
+import os
 import re
 import time
 from pathlib import Path
@@ -1015,7 +1016,13 @@ class AutonomousProver:
                     # hard cap kills pathological hangs with generous headroom.
                     # Routes through the ContextVar-safe asyncio.wait branch
                     # below. Pass agent_timeout_s=0 explicitly to disable.
-                    strategic_hints: str = "", agent_timeout_s: int = 900) -> dict:
+                    strategic_hints: str = "", agent_timeout_s: int = 900,
+                    # c.316 (#1453 forensic): wall-clock cap (seconds) on the
+                    # autonomous session. Default None → 45-min CEILING_S
+                    # (matches MultiAgentSorryProver.prove_sorry). Pass 0 to
+                    # disable (tests / interactive runs). Build time is
+                    # credited — see wallclock check inside _run_session.
+                    workflow_timeout_s: Optional[float] = None) -> dict:
         # Same OTel wiring as MultiAgentSorryProver — single-agent runs benefit
         # just as much from a durable span log of LLM-tool interactions.
         otel_session = f"auto_{demo['name']}_{self.provider}_{int(time.time())}"
@@ -1201,11 +1208,73 @@ class AutonomousProver:
         proof_tactics_found = []  # Lean-9 _proof_tactics_found tracking
         self.trace.start_session_span(demo["name"], self.config_label)
 
+        # c.316 (#1453 forensic): wall-clock cap for the autonomous loop. The
+        # multi-agent path has a 45-min reasoning-budget supervisor at
+        # provers.py:660+ with build-time credit (PER_UNIT_S=2700, CEILING_S=2700),
+        # but AutonomousProver had no equivalent — zai slow calls (600s/iteration)
+        # plus DELTA0_HARDCAP that only fires on successful builds burned 5-6h per
+        # session (e.g. autonomous_custom_Basic_L308_zai = 21084s, 0 progress).
+        # Mirror the multi-agent pattern: per-iteration wall-clock check that
+        # terminates the loop if reasoning time exceeds the cap. Build time is
+        # CREDITED (deducted from elapsed) so genuine compile waits don't eat
+        # the budget — tactic_tools.compile() is the dominant build cost.
+        # Default 45-min cap (CEILING_S) — same as MultiAgentSorryProver. Set
+        # to 0 to disable (tests / interactive runs); set via env override.
+        _AUTONOMOUS_CEILING_S = int(os.environ.get(
+            "PROVER_AUTONOMOUS_TIMEOUT_S", "2700"))
+        _wallclock_cap = (
+            _AUTONOMOUS_CEILING_S if workflow_timeout_s is None
+            else min(workflow_timeout_s, _AUTONOMOUS_CEILING_S)
+        )
+        _session_start = time.time()
+        # Track build time so we can credit it. AutonomousProver goes through
+        # tactic_tools.compile(), not the verifier's lake-build path, so we sum
+        # compile() durations instead of _LeanVerifier._total_build_seconds.
+        _build_credit_s = 0.0
+        _wallclock_capped = False  # set if wall-clock cap triggers early break
+
         async def _run_session():
             nonlocal compile_data, context_history, proof_tactics_found, final_build_ok
+            nonlocal _build_credit_s, _wallclock_capped
             loop = asyncio.get_event_loop()
 
             for iteration in range(1, max_iterations + 1):
+                # c.316 wall-clock check: terminate if reasoning time exceeds cap.
+                # Reasoning time = elapsed_wall - build_time_credited. If exceeded,
+                # break cleanly and let the final-verification block run on whatever
+                # state we have (best_content / current content). This is the
+                # autonomous equivalent of the multi-agent `_asyncio.wait_for`
+                # supervisor — but per-iteration polling instead of 30s polling,
+                # because the autonomous loop is sequential (no concurrent tasks
+                # to shield from cancellation).
+                if _wallclock_cap > 0:
+                    elapsed = time.time() - _session_start
+                    reasoning_s = elapsed - _build_credit_s
+                    if reasoning_s > _wallclock_cap:
+                        print(
+                            f"  WALL-CLOCK CAP: reasoning_s={reasoning_s:.0f}s "
+                            f"> cap={_wallclock_cap}s "
+                            f"(build_credit={_build_credit_s:.0f}s, "
+                            f"iter={iteration}/{max_iterations}). "
+                            f"Stopping to preserve budget.",
+                            flush=True,
+                        )
+                        try:
+                            self.trace.log(
+                                agent="AutonomousProver",
+                                role="wallclock_cap",
+                                content=(
+                                    f"elapsed={elapsed:.0f}s reasoning_s="
+                                    f"{reasoning_s:.0f}s build_credit="
+                                    f"{_build_credit_s:.0f}s cap={_wallclock_cap}s "
+                                    f"iter={iteration}/{max_iterations} "
+                                    f"sorry={count_real_sorries(Path(filepath).read_text(encoding='utf-8'))}"
+                                ),
+                            )
+                        except Exception:
+                            pass  # Tracing is best-effort, don't fail on log errors
+                        _wallclock_capped = True
+                        break
                 state.iteration = iteration
                 iter_start = time.time()
                 print(f"\n--- Iteration {iteration}/{max_iterations} ---", flush=True)
@@ -1300,7 +1369,12 @@ class AutonomousProver:
 
                 # Auto-compile after each iteration
                 current_sorry = count_real_sorries(Path(filepath).read_text(encoding="utf-8"))
+                # c.316 build-time accounting: wrap compile() so the wall-clock
+                # cap credits build time (matches MultiAgent pattern at
+                # provers.py:692 where _build_at_start = verifier-total-build).
+                _compile_started = time.time()
                 compile_str = tactic_tools.compile()
+                _build_credit_s += time.time() - _compile_started
                 try:
                     compile_data = json.loads(compile_str)
                 except json.JSONDecodeError:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -180,6 +180,20 @@ def test_multi_agent_prover_accepts_workflow_timeout():
     assert "workflow_timeout_s" in sig.parameters
 
 
+def test_autonomous_prover_accepts_workflow_timeout():
+    """c.316 (#1453 forensic): AutonomousProver.prove_sorry exposes a
+    wall-clock cap, mirroring MultiAgentSorryProver. Without this, zai slow
+    calls + DELTA0_HARDCAP-fires-only-on-successful-builds led to 5.85h
+    sessions with 0 progress (autonomous_custom_Basic_L308_zai trace)."""
+    import inspect
+    from prover.provers import AutonomousProver
+
+    sig = inspect.signature(AutonomousProver.prove_sorry)
+    assert "workflow_timeout_s" in sig.parameters
+    # Default must be None so the env var override is honored.
+    assert sig.parameters["workflow_timeout_s"].default is None
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # P4 — set_attack_plan integration (B.3)
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Forensic scan of BG-prover traces (c.316) revealed **AutonomousProver sessions burning 5.85 hours with zero progress** when the `zai` provider stalls. Top example: `autonomous_custom_Basic_L308_zai` trace = **21084s elapsed, 10 iterations, sorry_delta=0**.

### Root cause (two-part)

| # | Issue | Effect |
|---|-------|--------|
| 1 | `AutonomousProver.prove_sorry` had **no wall-clock cap** (only per-call `agent_timeout_s=900`). `MultiAgentSorryProver.prove_sorry` was capped at `CEILING_S=2700` via its reasoning-budget supervisor. | A single 30-80 min zai stall in any iteration could blow the entire session budget. |
| 2 | `DELTA0_HARDCAP=6` stagnation guard only fires on **successful builds** (incremented in `_record_sorry_count` at tools.py:1007). When all iterations are BUILD-FAIL (typical of a stuck provider that edits file without compiling), `_consecutive_delta0` stays 0 → guard never fires. | The existing safety net is invisible to the most common pathology. |

### Why `agent_timeout_s` ≠ fix

`asyncio.wait({task}, timeout=N)` (the framework's per-call guard) raises a cancellation in the framework's `AgentTelemetryLayer` ContextVar on zai stalls. We observed this in OTel spans (`trace_multi_SMOKE_ZERO_ADD_local_*.spans.jsonl`). It's a lower bound on a single LLM call, NOT a session-level wall-clock cap.

## Fix

Mirror the multi-agent reasoning-budget supervisor pattern (`provers.py:660+`) inside the autonomous loop:

```python
# In AutonomousProver.prove_sorry signature:
workflow_timeout_s: Optional[float] = None  # None → env / 2700s default

# In _run_session, at the top of each iteration:
if _wallclock_cap > 0:
    elapsed = time.time() - _session_start
    reasoning_s = elapsed - _build_credit_s
    if reasoning_s > _wallclock_cap:
        # log, set _wallclock_capped = True, break
```

Build time is **credited** (deducted from elapsed) via `tactic_tools.compile()` duration accounting, matching the multi-agent pattern where `_build_at_start` reads from `_LeanVerifier._total_build_seconds`. Without credit, a slow first compile (90s × 10 iter) wastes 900s of the budget on a successful ongoing session.

### Defaults

- `workflow_timeout_s=None` → `PROVER_AUTONOMOUS_TIMEOUT_S` env var → `2700` (45 min, matches multi-agent CEILING_S).
- Set `workflow_timeout_s=0` to disable (tests / interactive runs).
- Env override `PROVER_AUTONOMOUS_TIMEOUT_S=0` also disables.

### Regression contract

`test_autonomous_prover_accepts_workflow_timeout` pins `workflow_timeout_s` as a public param of `AutonomousProver.prove_sorry` (mirrors `test_multi_agent_prover_accepts_workflow_timeout` for multi-agent).

## Validation

- **`pytest -k timeout`** : 2/2 PASS (existing multi-agent + new autonomous).
- **Full `pytest test_prover_guards.py`** : 135/137 PASS. 2 env-related pre-existing failures (`OPENAI_API_KEY` absent + worktree path mismatch `C:\\dev\\CoursIA-2-c316-prover-forensic` vs hardcoded `C:\\dev\\CoursIA-2\\`) — same pair observed in c.312 / c.313 / c.315 worktrees; NOT introduced by this change.
- **`python -m py_compile prover/provers.py`** : OK.

## §A anti-composite

- **+89 / −1** (limit 3000)
- **2 files** (limit 15)
- **1 feature** (autonomous wall-clock cap) (limit 4)
- **1 domain** (agent_tests harness) (limit 1)

PASS strict.

## §B Lean PR body

N/A — no `*.lean` files touched. Pure Python harness change.

## Cross-cycle context

Follows:

- **c.312 / PR #6067**: harness depth-3 lock-in fix (resolve_lake_module on 11/11 sites)
- **c.313 / PR #6072**: per-project_dir verifier cache (singleton → dict)
- **c.315 / PR #6085**: latch path residuel (12/12 sites câblés sur resolve_lake_module)

EPIC **#1453** (prover-harness). c.316 closes the autonomous-side wall-clock gap left by c.312/c.313/c.315 (which were all about verifier/lake project_dir resolution; none addressed session-level budget).

Generated with Claude Code
