### PR TITLE
fix(prover): depth-3 harness — FX-5 relative_path false-positive + demo 62 P4 line

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1801,15 +1801,15 @@ DEMOS = {
     62: {
         "name": "HASHLIFE_P4_SUCC_MEMBERSHIP",
         "file": str(CONWAY_HASHLIFE_FILE) if CONWAY_HASHLIFE_FILE else "",
-        "line": 2673,
+        "line": 2734,
         "sorry_type": "sorry_replacement",
         "theorem_name": "p4_succ_membership",
         "theorem": "p4_succ_membership",
         "imports": CONWAY_HASHLIFE_IMPORTS,
         "description": (
             "BG-prover target (hashlife nibble plan #3846, N3): residual sorry in\n"
-            "noncomputable def p4_succ_membership (declared L2636, residual sorry\n"
-            "L2673 of HashlifeCorrectness.lean). The whnf wall is already traversed\n"
+            "noncomputable def p4_succ_membership (declared L2697, residual sorry\n"
+            "L2734 of HashlifeCorrectness.lean). The whnf wall is already traversed\n"
             "around L2648-2665 (node16_level_ne_two L2660 -> rw [if_neg hne2] L2663\n"
             "-> rw [mem_toGrid_node]); what remains is the offset-matching assembly:\n"
             "prove each `out_*.toGrid (off_*, off_*)` membership via\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -60,6 +60,24 @@ def resolve_lake_module(filepath) -> Tuple[str, str]:
     return str(p.parent.parent), f"{p.parent.name}.{stem}"
 
 
+def probe_relative_path(filepath, project_dir, tmp_name: str) -> str:
+    """Path of a sibling probe file (e.g. ``_GoalExtract.lean``) relative to the
+    RESOLVED Lake root — depth-agnostic.
+
+    The legacy ``<subdir>/<tmp_name>`` form missed the package prefix for nested
+    files (``Conway/Life/...``): lake then built a non-existent path and the
+    probe silently no-op'd. Fixing ``project_dir`` via ``resolve_lake_module`` is
+    NOT enough — ``verify_project_file`` only re-roots ``relative_path`` when the
+    given root lacks a lakefile, which ``resolve_lake_module`` now prevents, so
+    the path must be correct at derivation. Falls back to the legacy form when the
+    probe sits outside the resolved root (non-Lake / oddly-laid-out trees)."""
+    tmp_path = Path(filepath).parent / tmp_name
+    try:
+        return tmp_path.resolve().relative_to(Path(project_dir).resolve()).as_posix()
+    except ValueError:
+        return f"{Path(filepath).parent.name}/{tmp_name}"
+
+
 def strip_lean_comments(content: str) -> str:
     """Strip Lean line comments (``--``) and nested block comments (``/- -/``).
 
@@ -250,11 +268,13 @@ def is_true_placeholder_goal(filepath: str, sorry_line: int) -> Tuple[bool, str]
     # degrading TRUE_PLACEHOLDER_GOAL detection to "no refusal". resolve_lake_module
     # walks up to the real Lake root so the FX-5 probe actually compiles against
     # the target file. See #5982 commit log for the founding LSP fix that exposed
-    # this identical pattern in 8 still-broken call sites.
+    # this identical pattern in 8 still-broken call sites. Fixing project_dir alone
+    # is insufficient: the paired relative_path must also be re-rooted (see
+    # probe_relative_path), else the probe compiles a non-existent path and
+    # _probe_closes_goal false-positives every deep sorry as TRUE_PLACEHOLDER.
     project_dir, _module = resolve_lake_module(filepath)
     verifier = get_verifier(project_dir)
-    subdir = Path(filepath).parent.name
-    relative_path = f"{subdir}/_GoalExtract.lean"
+    relative_path = probe_relative_path(filepath, project_dir, "_GoalExtract.lean")
     tmp_path = Path(filepath).parent / "_GoalExtract.lean"
 
     indent_str = " " * indent
@@ -429,10 +449,11 @@ def get_goal_state(filepath: str, sorry_line: int) -> Optional[str]:
     # bug as `is_true_placeholder_goal` above — for files nested below the top
     # package (e.g. `Conway/Life/HashlifeCorrectness.lean`) the resulting dir
     # has no lakefile and the verifier probe compiles against the wrong module.
+    # relative_path must also be re-rooted (verify_project_file skips its own
+    # re-rooting once project_dir holds a lakefile) — see probe_relative_path.
     project_dir, _module = resolve_lake_module(filepath)
     verifier = get_verifier(project_dir)
-    subdir = Path(filepath).parent.name
-    relative_path = f"{subdir}/_GoalExtract.lean"
+    relative_path = probe_relative_path(filepath, project_dir, "_GoalExtract.lean")
     tmp_path = Path(filepath).parent / "_GoalExtract.lean"
 
     # Try multiple probes to extract goal state
@@ -978,8 +999,7 @@ def verify_sorry_replacement(filepath: str, sorry_line: int, replacement: str,
     # up to the real Lake root so the probe compiles against the right module.
     project_dir, _module = resolve_lake_module(filepath)
     verifier = get_verifier(project_dir)
-    subdir = Path(filepath).parent.name
-    relative_path = f"{subdir}/_SorryVerify.lean"
+    relative_path = probe_relative_path(filepath, project_dir, "_SorryVerify.lean")
     result = verifier.verify_project_file(relative_path, force=True)
 
     # Clean up temp file


### PR DESCRIPTION
## Scope
Two atomic **prover depth-3 harness** corrections so the BG-prover can actually attempt the P4 lock `p4_succ_membership` (demo 62). No proof body touched — `agent_tests/` harness only.

### 1. FX-5 `TRUE_PLACEHOLDER_GOAL` false-positive on nested files (`prover/lean_utils.py`)
The FX-5 guard (#1453) + two sibling goal/sorry probe helpers adopted `resolve_lake_module` for `project_dir` (depth-3 hardening, follow-up to #5982/#6067/#6085) but kept the stale depth-2 `relative_path = f"{subdir}/_GoalExtract.lean"`. For `Conway/Life/HashlifeCorrectness.lean` that gives `"Life/_GoalExtract.lean"` — **missing the `Conway/` prefix**.

`verify_project_file` only re-roots `relative_path` when `project_dir` lacks a lakefile; `resolve_lake_module` now passes the true root (which HAS one), so the re-rooting no longer fires. The probe compiled a **non-existent path** → no error at the sorry line → `_probe_closes_goal` misread "no error" as "goal closed" → **every deep sorry was false-positived as `True`**. The prover consequently **REFUSED demo 62** (P4, a real 4-quadrant iff obligation) with FX-5, never attempting it.

Fix: shared `probe_relative_path()` deriving the probe path relative to the resolved Lake root (depth-agnostic), applied at all **3 probe sites**.

### 2. Demo 62 stale line hint (`prover/config.py`)
`p4_succ_membership` moved to L2697 / residual sorry L2734 after N2 + #5998; demo 62 still pointed at `line: 2673`.

## Verification (firsthand, this session)
- `probe_relative_path(...) -> "Conway/Life/_GoalExtract.lean"` (was `"Life/..."`)
- `is_true_placeholder_goal(HashlifeCorrectness.lean, 2734) -> False` (was `True`)
- `grep`: `noncomputable def p4_succ_membership` at L2697, residual sorry L2734; 2 active sorry on file (L2734 P4, L3063 P5)
- `py_compile` clean

See #1453 (FX-5), #3846 (hashlife registry), umbrella #2162.