### PR TITLE
docs(review): §D tool forensic review of #6098 (prover demo 62 P4 line hint — MERGEABLE)

### DIFF
--- a/docs/ledgers/reviews/2026-07-11-d-tool-6098.md
+++ b/docs/ledgers/reviews/2026-07-11-d-tool-6098.md
@@ -1,0 +1,42 @@
+# §D tool forensic review — PR #6098
+
+**PR:** #6098 — `fix(prover): demo 62 P4 line hint 2673->2734 (harness balisage)`
+**Author:** po-2024 (branch `fix/prover-demo62-line-balisage`, base `main`)
+**Reviewer:** po-2026 (prover harness = po-2026's lane; the P4 line `2734` being re-pointed is exactly what po-2026 confirmed firsthand in c.314 §E forensic of #6083, and re-confirmed in c.315)
+**Verdict:** **MERGEABLE** — harness balisage fix, functional `line:` anchor matches source firsthand, no proof body touched, 3/3. One minor docstring-internal-ref drift observation (non-blocking).
+
+## Scope
+
+Single-file harness balisage in `agent_tests/prover/config.py`: BG-prover demo 62 (`HASHLIFE_P4_SUCC_MEMBERSHIP`) still pointed at the pre-N2 `line: 2673` after the N2 threading + #5998 merges moved `noncomputable def p4_succ_membership` to L2697 and its residual sorry to L2734. A launched BG-iter would anchor ~61 lines off the real sorry. **+3/-3 on 1 file** (`config.py` demo 62 entry — `line` field + docstring decl/sorry line refs).
+
+## §D forensics (firsthand)
+
+| # | Check | Method | Result |
+|---|-------|--------|--------|
+| D1 | Fix logic minimal + sound | `Read` demo 62 block (config.py:1801-1815) | SOUND. 3 edits: `line: 2673 → 2734` (the functional anchor), docstring `L2636 → L2697` (decl), docstring `L2673 → L2734` (sorry). No proof body, no logic change. Config-only |
+| D2 | Functional anchor matches source | `grep -nE "^noncomputable def p4_succ_membership" HashlifeCorrectness.lean` + raw sorry grep | **MATCH.** `noncomputable def p4_succ_membership` declared **L2697**; residual sorry **L2734**. Exactly the line po-2026 confirmed firsthand in c.314 (and re-confirmed c.315). The new `line: 2734` anchor is correct |
+| D3 | Sorry count corroborated | Raw `grep` of tactic sorries | **2 active sorries**: L2734 (P4 lock) + L3063 (P5 arm) — matches the author's claim and po-2026's fleet sorry-map (conway_lean = 2 since #5998 c.310) |
+| D4 | Anti-regression | Diff semantics | +3/-3, deletions = 3 stale line numbers only. No config logic, no `*.lean` touched. SAFE |
+
+## CRLF / hygiene
+
+`config.py` branch blob: **0 CRLF** (LF-clean). No encoding issues.
+
+## G.1 observation — minor docstring-internal-ref drift (non-blocking)
+
+The fix correctly updates the **two key line numbers** (decl L2697, sorry L2734 — the functional anchor the prover uses). But the docstring's **internal prose refs** are still stale from the same N2 threading drift:
+
+| Docstring ref | Actual source line | Status |
+|---------------|--------------------|--------|
+| "traversed around L2648-2665" | actual region ~L2709-L2727 | **STALE** |
+| "`node16_level_ne_two` L2660" | actually **L2013** | **STALE** |
+| "`rw [if_neg hne2]` L2663" | (now part of the ~L2721-2727 block) | **STALE** |
+| "`rw [mem_toGrid_node]`" (line-less) | **L2727** (just before the L2734 sorry) | OK (no line cited) |
+
+These are **prose documentation refs** inside the demo description string (read by humans reading the harness config, not by the prover's functional anchor logic). They don't affect the BG-iter launch (which uses `line: 2734`). Flagging for the author to optionally refresh in a follow-up — the functional fix is complete and correct as-is. **Does not block merge.**
+
+## Verdict
+
+**MERGEABLE.** A correct, minimal balisage fix: the demo 62 functional `line:` anchor (2734) and the two docstring key line refs (L2697/L2734) are verified firsthand against current source. No proof body touched, config-only, CRLF-clean, sorry count corroborated (2 = L2734 + L3063). The single observation (stale internal prose refs L2648-2665/L2660/L2663 in the description string) is non-blocking — the prover uses the `line` field, not the prose.
+
+See #3846 (hashlife finalization), #2162 (P4/P5 umbrella), #1453 (prover harness). Not `Closes` — balisage on an open epic.


### PR DESCRIPTION
## §D tool forensic of PR #6098 (prover demo 62 P4 line hint) — MERGEABLE

Cross-lane by po-2026 (prover harness = po-2026's lane; the L2734 line is exactly what po-2026 confirmed firsthand in c.314 §E #6083 + re-confirmed c.315). Ledger: `docs/ledgers/reviews/2026-07-11-d-tool-6098.md`.

### D1-D4 firsthand

| # | Check | Result |
|---|-------|--------|
| D1 | Fix logic | SOUND. 3 edits: `line: 2673 → 2734` (functional anchor), docstring decl `L2636 → L2697`, sorry `L2673 → L2734`. Config-only, no proof body, no logic |
| D2 | Functional anchor matches source | **MATCH.** `noncomputable def p4_succ_membership` = **L2697**, residual sorry = **L2734** (confirmed firsthand c.314/c.315). New `line: 2734` correct |
| D3 | Sorry count corroborated | 2 active sorries: L2734 (P4) + L3063 (P5) — matches author claim + po-2026 fleet sorry-map (conway = 2 since #5998 c.310) |
| D4 | Anti-regression | +3/-3, deletions = 3 stale line numbers only. SAFE |

CRLF = 0 (config.py LF-clean).

### G.1 observation — minor docstring-internal-ref drift (non-blocking)
The fix correctly updates the **2 key lines** (decl L2697, sorry L2734 — the functional anchor the prover uses). But the description string's **internal prose refs** are still stale from the same N2 drift:
- "traversed around L2648-2665" → actually ~L2709-2727
- "`node16_level_ne_two` L2660" → actually **L2013**
- "`rw [if_neg hne2]` L2663" → part of ~L2721-2727 block

These are **prose** (read by humans, not by the prover's `line`-field anchor logic). Don't affect the BG-iter launch. Flagging for optional follow-up refresh — **non-blocking**, the functional fix is complete.

### Verdict: MERGEABLE
Correct minimal balisage: functional `line: 2734` + key docstring refs (L2697/L2734) verified firsthand, no proof body touched, CRLF-clean, sorry count corroborated. The prose-ref drift is non-blocking (prover uses `line` field, not the description string).

See #3846 / #2162 / #1453. Not `Closes` — balisage on open epic.
