### PR TITLE
fix(docs): repair dangling c427 link in #6086 ledger (unblocks check-links CI)

### DIFF
--- a/docs/ledgers/reviews/2026-07-11-h4-sweep-6050.md
+++ b/docs/ledgers/reviews/2026-07-11-h4-sweep-6050.md
@@ -121,4 +121,4 @@ Si attente ai-01 sur #6077/#6059 collision, scan issues ouvertes `gh issue list 
 - **PR sœur c.423** : jsboige/CoursIA#6046 (axe-2 SOTA entry #018 Probas/Infer-extension OPEN MERGEABLE — gate L381-RENUMBER)
 - **EPIC** : #3801 (axe-2 SOTA ledger)
 - **PR collision c.427** : jsboige/CoursIA#6077 (mon Bug 1 atomic) vs jsboige/CoursIA#6059 (user Bug 1+2 combined)
-- **Topic antérieur** : [c427](c427-count-exercises-bug1-2161.md) (bugfix CI gate sustained 23ᵉ cycle)
+- **Topic antérieur** : c427 (PR #6077, bugfix CI gate sustained 23ᵉ cycle)


### PR DESCRIPTION
## Problem

After #6086 (po-2024 §H.4 sweep ledger, merged 2026-07-11T10:56Z) landed on `main`, the `check-links` CI started failing on **every** new PR. Root cause: `docs/ledgers/reviews/2026-07-11-h4-sweep-6050.md:124` contained a markdown link to a sibling ledger file that was never created:

```
- **Topic antérieur** : [c427](c427-count-exercises-bug1-2161.md) (bugfix CI gate sustained 23ᵉ cycle)
```

The target `c427-count-exercises-bug1-2161.md` does not exist (forward-ref / typo). This poisoned `main`: every PR branched from it inherits the broken link and fails `check-links` (caught my #6094, and #6086 itself on re-check).

## Fix

Dereference the dangling link to plain text + `PR #6077` (the c.427 collision is **already** linked on the prior line 123, so no information is lost):

```
- **Topic antérieur** : c427 (PR #6077, bugfix CI gate sustained 23ᵉ cycle)
```

Content-preserving: the prose ('bugfix CI gate sustained 23ᵉ cycle') is intact; only the broken markdown link syntax is removed.

## Verification

```
$ python scripts/check_docs_links.py --check
OK: No new broken links. (0 pre-existing, 3776 total)   # was: REGRESSION 1 new broken
$ echo $?
0
```

This is the minimal fix that unblocks the merge queue. Once merged, my #6094 (§E forensic, currently UNSTABLE on this exact link) and all future PRs will pass `check-links` again.

## Scope

1 file, 1 line changed. Not my ledger (#6086 = po-2024's), but a dangling-link repair on merged infrastructure blocking the whole cluster — flagged rather than silently edited. cc po-2024: the `c427-count-exercises-bug1-2161.md` ledger you referenced was never created; if it should exist, a follow-up can add it and restore the link.