### PR TITLE
docs(sudoku): de-spaghetti README — remontée Prérequis (setup avant parcours)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -37,6 +37,36 @@ Comment résoudre un Sudoku ? Cette série explore les techniques de résolution
 
 La série traverse cinq grandes familles algorithmiques, des méthodes exhaustives aux modèles appris : recherche et Dancing Links (niveaux 1-2), métaheuristiques (niveau 3), programmation par contraintes (niveau 4), IA symbolique SAT/SMT (niveau 5) puis IA data-driven (niveau 6). Chaque famille est illustrée par une figure extraite du notebook correspondant, insérée dans la section qui en commente le concept ; la provenance détaillée (cellule source, poids, alt-text) figure dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
+## Prérequis
+
+### C# (.NET Interactive)
+
+```bash
+# .NET 9.0 requis
+dotnet --version
+
+# Les packages NuGet sont installés dans les notebooks :
+# - GeneticSharp          (Sudoku-3 Genetic)
+# - Google.OrTools        (Sudoku-10 OR-Tools CP-SAT)
+# - Microsoft.Z3          (Sudoku-12 Z3 SMT, Sudoku-13 Symbolic Automata)
+# - DlxLib                (Sudoku-2 Dancing Links)
+# - Microsoft.ML.Probabilistic  (Sudoku-15 Infer.NET)
+# - IKVM 8.15.0           (Sudoku-11 Choco — runtime Java-sur-.NET + DLL précompilée)
+# - Plotly.NET            (visualisations, notebooks 0-15)
+```
+
+**Note sur les outputs** : Les notebooks C# contiennent des outputs de cellule exécutées. Les notebooks avec dépendances `#!import` doivent être exécutés dans l'ordre (0 -> 1 -> 2...).
+
+### Python
+
+```bash
+# Creer un environnement
+python -m venv venv
+
+# Installer les dépendances
+pip install numpy pandas scipy matplotlib ortools z3-solver pygad simanneal mealpy networkx torch jax numpyro jpype1 openai
+```
+
 ## Parcours d'Apprentissage Recommandés
 
 ### Parcours Débutant : Comprendre les Fondamentaux
@@ -100,36 +130,6 @@ La série traverse cinq grandes familles algorithmiques, des méthodes exhaustiv
 - Le choix de l'approche dépend du contexte : garantie vs vitesse vs généralisation
 
 ---
-
-## Prérequis
-
-### C# (.NET Interactive)
-
-```bash
-# .NET 9.0 requis
-dotnet --version
-
-# Les packages NuGet sont installés dans les notebooks :
-# - GeneticSharp          (Sudoku-3 Genetic)
-# - Google.OrTools        (Sudoku-10 OR-Tools CP-SAT)
-# - Microsoft.Z3          (Sudoku-12 Z3 SMT, Sudoku-13 Symbolic Automata)
-# - DlxLib                (Sudoku-2 Dancing Links)
-# - Microsoft.ML.Probabilistic  (Sudoku-15 Infer.NET)
-# - IKVM 8.15.0           (Sudoku-11 Choco — runtime Java-sur-.NET + DLL précompilée)
-# - Plotly.NET            (visualisations, notebooks 0-15)
-```
-
-**Note sur les outputs** : Les notebooks C# contiennent des outputs de cellule exécutées. Les notebooks avec dépendances `#!import` doivent être exécutés dans l'ordre (0 -> 1 -> 2...).
-
-### Python
-
-```bash
-# Creer un environnement
-python -m venv venv
-
-# Installer les dépendances
-pip install numpy pandas scipy matplotlib ortools z3-solver pygad simanneal mealpy networkx torch jax numpyro jpype1 openai
-```
 
 ## Pourquoi étudier le Sudoku en IA ?
 


### PR DESCRIPTION
See #5985 (Phase 2 inverted-pyramid). Sudoku was the explicit residual in the dashboard tracking ("GenAI/ML/Sudoku/Tweety — Prérequis/Installation enfouis").

## Changement

La section détaillée `## Prérequis` (C# .NET 9.0 + NuGets + Python venv/pip) était **enfouie à L104**, APRÈS les 3 parcours d'apprentissage pédagogiques profonds (60 lignes de Parcours Débutant/Intermédiaire/Avancé). Un lecteur voulant lancer les notebooks devait scroller passé tout le contenu pédagogique pour trouver les commandes d'installation.

**Promotion L104 → L40** : la section Prérequis remonte juste après `## Aperçu` et avant `## Parcours d'Apprentissage Recommandés`. Le lecteur voit "puis-je exécuter ça ?" avant de s'engager dans les parcours.

Suit exactement le pattern validated des 6 PR Phase 2 déjà mergées : Probas #5993, RL #5990, SmartContracts #6000, Probas/Infer #6031, SocialChoice #6032, Part4-Metaheuristics #6035.

## §E whole-file audit (811 lignes lues)

- **Pure structural move** : 30 insertions / 30 deletions, net 0 — le bloc est relocalisé (L104 → L40), contenu byte-identical vérifié via diff trié (added block == removed block).
- **CATALOG-STATUS marker** (`pedagogical_count: 36`, `breakdown: root=36`, décomposition 17 C# + 18 Python + 1 Lean) **byte-identical à origin/main** (vérifié via `diff <(git show origin/main:... | marker) <(marker)`).
- **Tables notebooks** (Structure des Notebooks / Versions Miroir C#⇄Python / Algorithmes Couverts) **intactes** — 0 ligne touchée en dehors du bloc Prérequis déplacé.
- **CRLF = 0** vérifié avant et après (tr -cd CR = 0 bytes, LF-only préservé, autocrlf=input).
- **Contenu setup vérifié fidèle** : la liste pip (numpy pandas scipy matplotlib ortools z3-solver pygad simanneal mealpy networkx torch jax numpyro jpype1 openai) et la liste NuGet (GeneticSharp, OR-Tools, Z3, DlxLib, Infer.NET, IKVM 8.15.0, Plotly.NET) matchent les notebooks réels — aucune correction de contenu, juste la relocalisation.

## Pas de regeneration catalogue

Le marqueur CATALOG-STATUS est laissé byte-identical à `main` (catalog-pr-hygiene R1) — cette PR est un déplacement de section prose pure, n'ajoute/retire aucun notebook.

See #5985 (partial — Sudoku tranche).