### PR TITLE
fix(harness): green check-links — inline-code + submodule robustness

### DIFF
--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -49,6 +49,33 @@ SKIP_DIRS = {
 # Baseline file location
 BASELINE_PATH = REPO_ROOT / "scripts" / "tests" / "baseline_docs_links.json"
 
+
+def _load_submodule_paths() -> set[str]:
+    """Read git submodule paths from .gitmodules (repo-relative, posix form).
+
+    Submodule internals are third-party checkouts (Argumentum, MetaGeneticSharp):
+    their broken links are not ours to fix, so we skip them like SKIP_DIRS.
+    Returns an empty set if .gitmodules is absent or unparsable.
+    """
+    gitmodules = REPO_ROOT / ".gitmodules"
+    if not gitmodules.is_file():
+        return set()
+    paths: set[str] = set()
+    try:
+        for line in gitmodules.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith("path"):
+                _, _, value = line.partition("=")
+                value = value.strip().strip("/")
+                if value:
+                    paths.add(value)
+    except OSError:
+        return set()
+    return paths
+
+
+SUBMODULE_PATHS = _load_submodule_paths()
+
 # Pattern: [link text](relative/path) — captures relative paths only (no http/https/#anchors)
 LINK_PATTERN = re.compile(
     r"\[([^\]]*)\]\((?!https?://)(?!mailto:)(?!#)([^)\s#]+)\)"
@@ -75,12 +102,15 @@ class ScanResult:
 
 
 def _should_skip(path: Path) -> bool:
-    """Check if a path should be skipped (in SKIP_DIRS or problematic)."""
+    """Check if a path should be skipped (in SKIP_DIRS, a submodule, or problematic)."""
     try:
-        parts = path.relative_to(REPO_ROOT).parts
+        rel = path.relative_to(REPO_ROOT)
     except ValueError:
         return True
-    return any(skip in parts for skip in SKIP_DIRS)
+    if any(skip in rel.parts for skip in SKIP_DIRS):
+        return True
+    rel_posix = rel.as_posix()
+    return any(rel_posix == sm or rel_posix.startswith(sm + "/") for sm in SUBMODULE_PATHS)
 
 
 def _is_valid_target(target: str) -> bool:

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -170,6 +170,11 @@ def scan_file(filepath: Path) -> list[LinkRef]:
         if in_code_block:
             continue
 
+        # Strip inline code spans (`...`): their contents render as literal text,
+        # so a [text](target) inside backticks is not a clickable link. This avoids
+        # false positives on format templates in review ledgers, e.g. `[Foo](...)`.
+        line = re.sub(r"`[^`]*`", "", line)
+
         for match in LINK_PATTERN.finditer(line):
             text = match.group(1)
             target = match.group(2)

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -204,9 +204,15 @@ def check_link(target: str, source_path: Path, root: Path = REPO_ROOT) -> bool:
 
     # Must be within root (safety: no escaping outside the repo)
     try:
-        resolved.relative_to(root)
+        rel_posix = resolved.relative_to(root).as_posix()
     except ValueError:
         return False
+
+    # Links into a git submodule are valid regardless of checkout state: CI uses
+    # submodules: false, so the mount dir may be absent. Submodule content is
+    # third-party — its presence is not this repo's concern to verify.
+    if any(rel_posix == sm or rel_posix.startswith(sm + "/") for sm in SUBMODULE_PATHS):
+        return True
 
     return resolved.exists()
 


### PR DESCRIPTION
## Problème

La CI `check-links` (non-required → UNSTABLE) rougissait **chaque PR de doc branchée sur main**. Diagnostic firsthand via reproduction sur **ext4 réel** (`git archive` du tree tracké → tmpdir Linux byte-exact, ce que la CI checkout avec `submodules: false`) — Windows/NTFS **masquait** la casse par résolution insensible à la casse + strip des points de fin.

Deux causes, deux directions :

1. **Cause racine (le red résiduel)** : un lien `[texte](target)` **dans un span de code inline** (backticks) était scanné comme un vrai lien. Un template de format dans un ledger de review — `` `... | [Search-N (C#)](...) | ...` `` ([2026-07-11-e-readme-6088.md:25](docs/ledgers/reviews/2026-07-11-e-readme-6088.md)) — était capté avec la cible `...`. NTFS résout `<dir>/...` (points de fin strippés → dossier parent existe → "valide") ; **ext4 non** → cassé. Un `[texte](target)` entre backticks rend en texte littéral, pas en lien cliquable : il ne doit pas être scanné (comme les blocs fencés le sont déjà).

2. **Robustesse checkout** : le scan incluait les checkouts de sous-modules (`Argumentum`, `MetaGeneticSharp`, …), et nos docs pointent vers leurs racines. En CI `submodules: false` ces montages sont **absents** → liens cassés des deux côtés (contenu tiers scanné + liens sortants vers racines absentes).

## Fix (borné, durable — 3 commits)

- **Skip des spans de code inline** (`re.sub(r"\`[^\`]*\`", "", line)` avant match) — miroir du skip des blocs fencés existant. *C'est le fix de la cause racine.*
- **Lire `.gitmodules`** (`_load_submodule_paths()`) : `_should_skip()` saute les internals de sous-modules (comme `SKIP_DIRS`) ; `check_link()` traite un lien **vers** une racine de sous-module comme valide quel que soit l'état du checkout.

Robuste aux futurs sous-modules (lecture dynamique) et aux futurs templates de ledger.

## Vérification (ext4 réel, byte-exact = CI)

```
$ git archive <head> | tar -x -C /tmp/cilinks-ext4   # submodules exclus = CI
$ cd /tmp/cilinks-ext4 && python3 scripts/check_docs_links.py
Scanned 562 files, 3779 links
No broken links found.

$ python3 scripts/check_docs_links.py --check --quiet ; echo exit=$?
exit=0
```

Avant le fix inline-code : **1 lien cassé** (`.../...`) → exit 1. Après : **0**, exit 0. main revient à 0 lien cassé → les PRs de doc (#6105/#6108/#6110) repassent vertes sans workaround.

Mandat harness-fix (« profitons-en pour corriger les erreurs de harnais »).

See #6104