### PR TITLE
enrich(probas/pymc): frame the 3 exercises in PyMC-16 (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
@@ -750,6 +750,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "p16frmwidp0",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Les trois exercices suivants vous font manipuler les leviers du GP bayesien vus ci-dessus : le choix du **noyau** (exercice 1), la **durete du dataset** (exercice 2) et l'**effet du prior sur la longueur de correlation** $\\ell$ (exercice 3, en echo de la section 5). Chaque stub est self-contained : reconstruisez le modele de la section 3 avec la variation demandee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p16frmwidp1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Noyau Matern vs RBF\n",
+    "\n",
+    "**Objectif** : remplacer le noyau `ExpQuad` (RBF) par un `Matern52` et comparer la frontiere de decision. Le Matern est moins lisse : la frontiere doit l'etre aussi.\n",
+    "\n",
+    "**Indices** : `pm.gp.cov.Matern52(input_dim=2, ls=ls)` ; gardez le meme prior `LogNormal` sur `ls`.",
+    " Etapes : (1) reconstruisez le modele avec le nouveau noyau ; (2) echantillonnez (meme `draw`/`tune` qu'en section 3) ; (3) tracez la frontiere (section 4) et comparez."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "e01d2267",
@@ -792,6 +819,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "p16frmwidp2",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Deux anneaux entrelaces (two moons)\n",
+    "\n",
+    "**Objectif** : construire un dataset ou deux demi-anneaux sont entrelaces (style *two moons*) et verifier que le GP separateur reste non lineaire.\n",
+    "\n",
+    "**Indices** : pour la classe 0, angles dans $[0, \\pi]$ ; pour la classe 1, angles dans $[\\pi, 2\\pi]$, avec un decalage radial.",
+    " Etapes : (1) generez `X_moons`, `y_moons` (16 points chacun) ; (2) re-entrainez le GP (section 3) sur ce dataset ; (3) affichez l'accuracy — elle doit rester elevee si le noyau RBF convient."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "88c4b5af",
@@ -831,6 +873,22 @@
     "\n",
     "moons_result = None  # TODO etudiant : dataset + modele sur two-moons\n",
     "print(\"Exercice 2 a completer : GP sur deux anneaux entrelaces (two moons).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p16frmwidp3",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Effet du prior sur la longueur de correlation\n",
+    "\n",
+    "**Objectif** : mesurer comment un prior *tres concentre* sur une grande longueur $\\ell$ force le GP vers un modele quasi lineaire (sous-apprentissage). C'est la verification empirique promise en section 5.\n",
+    "\n",
+    "**Indices** : passez de `pm.LogNormal(\"ls\", mu=0.0, ...)` a `mu=2.0, sigma=0.1`.",
+    " Etapes : (1) re-entrainez avec ce prior concentre grand ; (2) comparez la frontiere (qui doit devenir quasi-lineaire) et l'accuracy.",
+    " **Question** : que se passe-t-il avec un prior concentre *petit* (`mu=-1.5`) ?"
    ]
   },
   {


### PR DESCRIPTION
## Summary

`PyMC-16-Sparse-Gaussian-Process.ipynb` had three student exercises (all valid C.1-safe stubs, exec_count 9/10/11) but **no markdown framing** around them: the notebook jumped straight from the `## 6. Synthèse` conclusion into the Exercice 1 code cell, with no `## Exercices` umbrella header and no per-exercise *context / objectif / indices* markdown. This violated the `≥3-exercises` convention ([three-exercises-per-notebook.md](.claude/rules/three-exercises-per-notebook.md): each exercise preceded by markdown with context + objectif + indices).

Sibling notebooks **PyMC-17 (Kalman)** and **PyMC-18 (Change-Point)** frame every exercise with a dedicated `### Exercice N — <title>` header; **PyMC-16 was the outlier**.

## Changes (1 file, pure markdown insertion)

Added 4 markdown cells (umbrella + 3 framings), matching the PyMC-18 sibling format (em-dash):

| New cell | Content |
|----------|---------|
| `## 7. Exercices` | Umbrella header after the Synthèse, orienting the 3 exercises |
| `### Exercice 1 — Noyau Matern vs RBF` | Context + objectif + indices (surfaces the `# Indice`/`# Etape N` already in the code) |
| `### Exercice 2 — Deux anneaux entrelacés (two moons)` | idem |
| `### Exercice 3 — Effet du prior sur la longueur de corrélation` | idem — echoes section 5's promise |

## Validation (HARD)

- **Byte-identity**: `git diff --stat` = **58 insertions, 0 deletions**. All 11 code cells byte-identical (exec_count + outputs preserved). Trailing bytes match original (`No newline at end of file` preserved).
- **No re-execution needed**: markdown-only edit (C.2 exception — outputs précédents valides). No code cell source changed.
- **C.1 safe**: 0 `raise NotImplementedError` / `assert False` / `1/0` in any cell source (parsed-cell scan authoritative; raw-grep false positive = a base64 PNG blob).
- **Repo validator**: `scripts/notebook_tools/validate_pr_notebooks.py` → **1/1 passed (11 cells)**.
- **Catalog byte-identity (R1)**: `COURSE_CATALOG.generated.{json,md}` untouched.

## Scope (R3 atomic)

One notebook, one defect (missing exercise framing), one rule enforced (#2161 / three-exercises convention). The deeper "section 5 has prose but no worked demo of the length-scale effect" gap is **out of scope** — it would require a new code cell + PyMC re-exec (PyMC env install), hence a separate PR.

See #2161

🤖 Generated with [Claude Code](https://claude.com/claude-code)