### PR TITLE
docs(probas): de-spaghetti README — remontée Prerequisites/Installation (#5985)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -71,6 +71,84 @@ La maximisation de `E[U]` repose sur une hypothèse centrale de la théorie de l
 4. **Décaler** d'un problème réel vers sa formulation probabiliste (variables, facteurs, observations)
 5. **Intégrer** inférence probabiliste et théorie de la décision (maximisation d'utilité espérée)
 
+## Prerequisites
+
+### Niveau mathématique attendu
+
+Cette série suppose une **maîtrise de base en probabilités et statistiques** :
+
+| Concept | Utilité dans la série | Notes de révision |
+|---------|---------------------|------------------|
+| Variables aléatoires (discrètes/continues) | Partout, notebook 1+ | Loi de proba, espérance, variance |
+| Distributions usuelles (Bernoulli, Gaussian, Beta, Gamma) | Notebook 1 (Beta-Bernoulli), 2 (Gaussian) | Paramètres, formes, conjugaison |
+| Probabilités conditionnelles | Notebook 3+ (Variable.If, CPT) | P(A|B), théorème de Bayes |
+| Indépendance conditionnelle | Notebook 3 (Monty Hall), 4 (D-separation) | Collider, explaining away |
+| Espérance mathématique | Partout (calcul de EU) | E[X] = sum x*P(x) ou intégrale |
+| Distributions conjuguées | Notebook 1 (Beta-Bernoulli), 9 (Dirichlet-Discrète) | Prior + likelihood = posterior (famille même) |
+| Intégrales (niveau 1) | Notebook 2, 15 (CARA/CRRA) | Calcul d'espérance avec fonctions non-linéaires |
+
+**Inutile de maîtriser** : dérivation multivariée, algèbre linéaire avancée (sauf pour les modèles hiérarchiques en notebook 4). Les concepts sont introduits progressivement et réexpliqués dans le contexte.
+
+### Prerequisites techniques
+
+#### Pour Infer.NET (C#)
+
+```bash
+# .NET SDK 9.0+
+dotnet --version
+
+# VS Code + extension Polyglot Notebooks
+# Packages (auto-references dans notebooks):
+# - Microsoft.ML.Probabilistic
+# - CompilerChoice = Roslyn
+```
+
+#### Pour Python
+
+```bash
+# Environnement Python 3.8+
+pip install pyro-ppl torch matplotlib numpy
+```
+
+## Installation
+
+### Notebooks PyMC (Python)
+
+```bash
+pip install pymc numpy scipy matplotlib arviz
+```
+
+### Notebooks Infer.NET (C# .NET Interactive)
+
+```bash
+# 1. Installer .NET SDK 9.0+ depuis https://dotnet.microsoft.com/download
+# 2. Installer le kernel dotnet-interactive
+dotnet tool install -g Microsoft.dotnet-interactive
+dotnet interactive jupyter install
+
+# 3. Ou utiliser le script PowerShell (installe tout automatiquement) :
+cd MyIA.AI.Notebooks/Probas/Infer/scripts
+.\setup_environment.ps1
+```
+
+### Notebooks Python (Infer-101, Pyro_RSA)
+
+```bash
+pip install pyro-ppl torch matplotlib numpy
+```
+
+### Vérification
+
+```bash
+jupyter kernelspec list  # doit afficher .net-csharp et python3
+```
+
+### Tester tous les notebooks
+
+```bash
+python MyIA.AI.Notebooks/Probas/Infer/scripts/test_notebooks.py --validate-only
+```
+
 ## Parcours d'apprentissage
 
 ### Phase 1 : Fondations (Notebooks 1-3, ~2h)
@@ -213,84 +291,6 @@ Probas/
     ├── DecInfer/                # DecInfer-1-Utility-Foundations ... DecInfer-10-Thompson-Sampling (+ companions Lean 2/9)
     ├── PyMC/                    # DecPyMC-1-Utility-Foundations ... DecPyMC-7-Sequential (renommés post-#5081)
     └── Causal-Bridges/          # Do-Calculus-Bridge : pont unifié des 4 séries causales (Pearl, dowhy)
-```
-
-## Prerequisites
-
-### Niveau mathématique attendu
-
-Cette série suppose une **maîtrise de base en probabilités et statistiques** :
-
-| Concept | Utilité dans la série | Notes de révision |
-|---------|---------------------|------------------|
-| Variables aléatoires (discrètes/continues) | Partout, notebook 1+ | Loi de proba, espérance, variance |
-| Distributions usuelles (Bernoulli, Gaussian, Beta, Gamma) | Notebook 1 (Beta-Bernoulli), 2 (Gaussian) | Paramètres, formes, conjugaison |
-| Probabilités conditionnelles | Notebook 3+ (Variable.If, CPT) | P(A|B), théorème de Bayes |
-| Indépendance conditionnelle | Notebook 3 (Monty Hall), 4 (D-separation) | Collider, explaining away |
-| Espérance mathématique | Partout (calcul de EU) | E[X] = sum x*P(x) ou intégrale |
-| Distributions conjuguées | Notebook 1 (Beta-Bernoulli), 9 (Dirichlet-Discrète) | Prior + likelihood = posterior (famille même) |
-| Intégrales (niveau 1) | Notebook 2, 15 (CARA/CRRA) | Calcul d'espérance avec fonctions non-linéaires |
-
-**Inutile de maîtriser** : dérivation multivariée, algèbre linéaire avancée (sauf pour les modèles hiérarchiques en notebook 4). Les concepts sont introduits progressivement et réexpliqués dans le contexte.
-
-### Prerequisites techniques
-
-#### Pour Infer.NET (C#)
-
-```bash
-# .NET SDK 9.0+
-dotnet --version
-
-# VS Code + extension Polyglot Notebooks
-# Packages (auto-references dans notebooks):
-# - Microsoft.ML.Probabilistic
-# - CompilerChoice = Roslyn
-```
-
-#### Pour Python
-
-```bash
-# Environnement Python 3.8+
-pip install pyro-ppl torch matplotlib numpy
-```
-
-## Installation
-
-### Notebooks PyMC (Python)
-
-```bash
-pip install pymc numpy scipy matplotlib arviz
-```
-
-### Notebooks Infer.NET (C# .NET Interactive)
-
-```bash
-# 1. Installer .NET SDK 9.0+ depuis https://dotnet.microsoft.com/download
-# 2. Installer le kernel dotnet-interactive
-dotnet tool install -g Microsoft.dotnet-interactive
-dotnet interactive jupyter install
-
-# 3. Ou utiliser le script PowerShell (installe tout automatiquement) :
-cd MyIA.AI.Notebooks/Probas/Infer/scripts
-.\setup_environment.ps1
-```
-
-### Notebooks Python (Infer-101, Pyro_RSA)
-
-```bash
-pip install pyro-ppl torch matplotlib numpy
-```
-
-### Vérification
-
-```bash
-jupyter kernelspec list  # doit afficher .net-csharp et python3
-```
-
-### Tester tous les notebooks
-
-```bash
-python MyIA.AI.Notebooks/Probas/Infer/scripts/test_notebooks.py --validate-only
 ```
 
 ## Ce que chaque notebook apporte


### PR DESCRIPTION
## What

`#5985` EPIC (user mandate: « réorganiser du plus saillant au plus spécifique, meta en fin » → meta HIGH/saillant, détaillé LOW). `Probas/README.md` (top-level family, 644 lines) buried `## Prerequisites` + `## Installation` **14 sections deep** — after `Pourquoi`, the concept, `Objectifs`, the full `Parcours d'apprentissage` (Phase 1/2/3 + 6 alternative parcours), `Quel stack choisir ?`, and `Structure`. A student landed on 200+ lines of detailed parcours before learning they need .NET 9.0 / Python 3.8+ and how to install.

## Fix

Promote the `## Prerequisites` + `## Installation` block to **right after `## Objectifs d'apprentissage`**, before `## Parcours d'apprentissage` — same pattern as Sudoku (#6105) and the validated Phase-2 PRs. Meta/setup is now saillant (high); the detailed Parcours / Structure / per-notebook table stay low.

**New section order** (top-level):
```
Pourquoi → Qu'est-ce que → Objectifs → Prerequisites → Installation
→ Parcours d'apprentissage → Quel stack choisir ? → Structure → per-notebook table
```

## §E whole-file audit ([pr-review-discipline.md](docs/../../.claude/rules/pr-review-discipline.md) §E)

- **PURE MOVE**: 78 insertions / 78 deletions, sort-based content diff **IDENTICAL** (only order changed, zero prose/code touched).
- **CATALOG-STATUS marker byte-identical** to main ([catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md) HARD 1) — verified `git show origin/main` vs branch.
- **CRLF = 0** (LF-only preserved, `write_bytes` per the `python-write-text-crlf-windows` lesson).
- **Boundaries read naturally**: Objectifs → Prerequisites, Installation → Parcours (verified firsthand).
- **No internal anchor links** to the moved sections (no broken refs).
- **Line count preserved** (644 = 644).

## Scope

Single file, single subject (README de-spaghetti for an active user EPIC). Not a catalog regen (catalog byte-identical). G.1 firsthand-verified real defect (Prérequis genuinely buried 14 sections deep on a top-level family README).

See #5985

🤖 Generated with [Claude Code](https://claude.com/claude-code)