### PR TITLE
Fix(accent): coherence FR section Exercices PyMC-16 (NanoClaw nit #6118)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
@@ -750,6 +750,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "p16frmwidp0",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Les trois exercices suivants vous font manipuler les leviers du GP bayesien vus ci-dessus : le choix du **noyau** (exercice 1), la **durete du dataset** (exercice 2) et l'**effet du prior sur la longueur de correlation** $\\ell$ (exercice 3, en echo de la section 5). Chaque stub est self-contained : reconstruisez le modele de la section 3 avec la variation demandee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p16frmwidp1",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Noyau Matern vs RBF\n",
+    "\n",
+    "**Objectif** : remplacer le noyau `ExpQuad` (RBF) par un `Matern52` et comparer la frontiere de decision. Le Matern est moins lisse : la frontiere doit l'etre aussi.\n",
+    "\n",
+    "**Indices** : `pm.gp.cov.Matern52(input_dim=2, ls=ls)` ; gardez le meme prior `LogNormal` sur `ls`.",
+    " Etapes : (1) reconstruisez le modele avec le nouveau noyau ; (2) echantillonnez (meme `draw`/`tune` qu'en section 3) ; (3) tracez la frontiere (section 4) et comparez."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "e01d2267",
@@ -792,6 +819,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "p16frmwidp2",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Deux anneaux entrelaces (two moons)\n",
+    "\n",
+    "**Objectif** : construire un dataset ou deux demi-anneaux sont entrelaces (style *two moons*) et verifier que le GP separateur reste non lineaire.\n",
+    "\n",
+    "**Indices** : pour la classe 0, angles dans $[0, \\pi]$ ; pour la classe 1, angles dans $[\\pi, 2\\pi]$, avec un decalage radial.",
+    " Etapes : (1) generez `X_moons`, `y_moons` (16 points chacun) ; (2) re-entrainez le GP (section 3) sur ce dataset ; (3) affichez l'accuracy — elle doit rester elevee si le noyau RBF convient."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "88c4b5af",
@@ -831,6 +873,22 @@
     "\n",
     "moons_result = None  # TODO etudiant : dataset + modele sur two-moons\n",
     "print(\"Exercice 2 a completer : GP sur deux anneaux entrelaces (two moons).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p16frmwidp3",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Effet du prior sur la longueur de correlation\n",
+    "\n",
+    "**Objectif** : mesurer comment un prior *tres concentre* sur une grande longueur $\\ell$ force le GP vers un modele quasi lineaire (sous-apprentissage). C'est la verification empirique promise en section 5.\n",
+    "\n",
+    "**Indices** : passez de `pm.LogNormal(\"ls\", mu=0.0, ...)` a `mu=2.0, sigma=0.1`.",
+    " Etapes : (1) re-entrainez avec ce prior concentre grand ; (2) comparez la frontiere (qui doit devenir quasi-lineaire) et l'accuracy.",
+    " **Question** : que se passe-t-il avec un prior concentre *petit* (`mu=-1.5`) ?"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
@@ -755,11 +755,7 @@
    "metadata": {
     "tags": []
    },
-   "source": [
-    "## 7. Exercices\n",
-    "\n",
-    "Les trois exercices suivants vous font manipuler les leviers du GP bayesien vus ci-dessus : le choix du **noyau** (exercice 1), la **durete du dataset** (exercice 2) et l'**effet du prior sur la longueur de correlation** $\\ell$ (exercice 3, en echo de la section 5). Chaque stub est self-contained : reconstruisez le modele de la section 3 avec la variation demandee."
-   ]
+   "source": "## 7. Exercices\n\nLes trois exercices suivants vous font manipuler les leviers du GP bayésien vus ci-dessus : le choix du **noyau** (exercice 1), la **dureté du dataset** (exercice 2) et l'**effet du prior sur la longueur de corrélation** $\\ell$ (exercice 3, en écho de la section 5). Chaque stub est self-contained : reconstruisez le modèle de la section 3 avec la variation demandée."
   },
   {
    "cell_type": "markdown",
@@ -767,14 +763,7 @@
    "metadata": {
     "tags": []
    },
-   "source": [
-    "### Exercice 1 — Noyau Matern vs RBF\n",
-    "\n",
-    "**Objectif** : remplacer le noyau `ExpQuad` (RBF) par un `Matern52` et comparer la frontiere de decision. Le Matern est moins lisse : la frontiere doit l'etre aussi.\n",
-    "\n",
-    "**Indices** : `pm.gp.cov.Matern52(input_dim=2, ls=ls)` ; gardez le meme prior `LogNormal` sur `ls`.",
-    " Etapes : (1) reconstruisez le modele avec le nouveau noyau ; (2) echantillonnez (meme `draw`/`tune` qu'en section 3) ; (3) tracez la frontiere (section 4) et comparez."
-   ]
+   "source": "### Exercice 1 — Noyau Matern vs RBF\n\n**Objectif** : remplacer le noyau `ExpQuad` (RBF) par un `Matern52` et comparer la frontière de décision. Le Matern est moins lisse : la frontière doit l'être aussi.\n\n**Indices** : `pm.gp.cov.Matern52(input_dim=2, ls=ls)` ; gardez le même prior `LogNormal` sur `ls`. Étapes : (1) reconstruisez le modèle avec le nouveau noyau ; (2) échantillonnez (même `draw`/`tune` qu'en section 3) ; (3) tracez la frontière (section 4) et comparez."
   },
   {
    "cell_type": "code",
@@ -801,22 +790,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 1 a completer : comparer Matern52 vs ExpQuad.\n"
+      "Exercice 1 à compléter : comparer Matern52 vs ExpQuad.\n"
      ]
     }
    ],
-   "source": [
-    "# Exercice 1 : noyau Matern au lieu de RBF.\n",
-    "# Remplacez le noyau ExpQuad (RBF) par un noyau Matern (pm.gp.cov.Matern52) et comparez\n",
-    "# la frontiere de decision. Le Matern est moins lisse — la frontiere devrait l'etre aussi.\n",
-    "# Indice : pm.gp.cov.Matern52(input_dim=2, ls=ls). Gardez le meme prior LogNormal sur ls.\n",
-    "# Etape 1 : reconstruisez le modele avec le nouveau noyau.\n",
-    "# Etape 2 : echantillonnez (meme draw/tune que la section 3).\n",
-    "# Etape 3 : tracez la frontiere (section 4) et comparez.\n",
-    "\n",
-    "matern_result = None  # TODO etudiant : idata + predictions du modele Matern\n",
-    "print(\"Exercice 1 a completer : comparer Matern52 vs ExpQuad.\")\n"
-   ]
+   "source": "# Exercice 1 : noyau Matern au lieu de RBF.\n# Remplacez le noyau ExpQuad (RBF) par un noyau Matern (pm.gp.cov.Matern52) et comparez\n# la frontière de décision. Le Matern est moins lisse — la frontière devrait l'être aussi.\n# Indice : pm.gp.cov.Matern52(input_dim=2, ls=ls). Gardez le même prior LogNormal sur ls.\n# Étape 1 : reconstruisez le modèle avec le nouveau noyau.\n# Étape 2 : échantillonnez (même draw/tune que la section 3).\n# Étape 3 : tracez la frontière (section 4) et comparez.\n\nmatern_result = None  # TODO étudiant : idata + prédictions du modèle Matern\nprint(\"Exercice 1 à compléter : comparer Matern52 vs ExpQuad.\")"
   },
   {
    "cell_type": "markdown",
@@ -824,14 +802,7 @@
    "metadata": {
     "tags": []
    },
-   "source": [
-    "### Exercice 2 — Deux anneaux entrelaces (two moons)\n",
-    "\n",
-    "**Objectif** : construire un dataset ou deux demi-anneaux sont entrelaces (style *two moons*) et verifier que le GP separateur reste non lineaire.\n",
-    "\n",
-    "**Indices** : pour la classe 0, angles dans $[0, \\pi]$ ; pour la classe 1, angles dans $[\\pi, 2\\pi]$, avec un decalage radial.",
-    " Etapes : (1) generez `X_moons`, `y_moons` (16 points chacun) ; (2) re-entrainez le GP (section 3) sur ce dataset ; (3) affichez l'accuracy — elle doit rester elevee si le noyau RBF convient."
-   ]
+   "source": "### Exercice 2 — Deux anneaux entrelacés (two moons)\n\n**Objectif** : construire un dataset où deux demi-anneaux sont entrelacés (style *two moons*) et vérifier que le GP séparateur reste non linéaire.\n\n**Indices** : pour la classe 0, angles dans $[0, \\pi]$ ; pour la classe 1, angles dans $[\\pi, 2\\pi]$, avec un décalage radial. Étapes : (1) générez `X_moons`, `y_moons` (16 points chacun) ; (2) ré-entraînez le GP (section 3) sur ce dataset ; (3) affichez l'accuracy — elle doit rester élevée si le noyau RBF convient."
   },
   {
    "cell_type": "code",
@@ -858,22 +829,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 2 a completer : GP sur deux anneaux entrelaces (two moons).\n"
+      "Exercice 2 à compléter : GP sur deux anneaux entrelacés (two moons).\n"
      ]
     }
    ],
-   "source": [
-    "# Exercice 2 : dataset plus difficile (deux anneaux entrelaces).\n",
-    "# Construisez un dataset ou deux demi-anneaux sont entrelaces (style \"two moons\").\n",
-    "# Indice : pour la classe 0, angles dans [0, pi] ; pour la classe 1, angles dans [pi, 2*pi],\n",
-    "#          avec un decalage radial. Le GP doit toujours separer (frontiere non lineaire).\n",
-    "# Etape 1 : generez X_moons, y_moons (16 points chacun).\n",
-    "# Etape 2 : re-entrainez le GP (section 3) sur ce dataset.\n",
-    "# Etape 3 : affichez l'accuracy. Doit rester elevee si le noyau RBF convient.\n",
-    "\n",
-    "moons_result = None  # TODO etudiant : dataset + modele sur two-moons\n",
-    "print(\"Exercice 2 a completer : GP sur deux anneaux entrelaces (two moons).\")\n"
-   ]
+   "source": "# Exercice 2 : dataset plus difficile (deux anneaux entrelacés).\n# Construisez un dataset où deux demi-anneaux sont entrelacés (style \"two moons\").\n# Indice : pour la classe 0, angles dans [0, pi] ; pour la classe 1, angles dans [pi, 2*pi],\n#          avec un décalage radial. Le GP doit toujours séparer (frontière non linéaire).\n# Étape 1 : générez X_moons, y_moons (16 points chacun).\n# Étape 2 : ré-entraînez le GP (section 3) sur ce dataset.\n# Étape 3 : affichez l'accuracy. Doit rester élevée si le noyau RBF convient.\n\nmoons_result = None  # TODO étudiant : dataset + modèle sur two-moons\nprint(\"Exercice 2 à compléter : GP sur deux anneaux entrelacés (two moons).\")"
   },
   {
    "cell_type": "markdown",
@@ -881,15 +841,7 @@
    "metadata": {
     "tags": []
    },
-   "source": [
-    "### Exercice 3 — Effet du prior sur la longueur de correlation\n",
-    "\n",
-    "**Objectif** : mesurer comment un prior *tres concentre* sur une grande longueur $\\ell$ force le GP vers un modele quasi lineaire (sous-apprentissage). C'est la verification empirique promise en section 5.\n",
-    "\n",
-    "**Indices** : passez de `pm.LogNormal(\"ls\", mu=0.0, ...)` a `mu=2.0, sigma=0.1`.",
-    " Etapes : (1) re-entrainez avec ce prior concentre grand ; (2) comparez la frontiere (qui doit devenir quasi-lineaire) et l'accuracy.",
-    " **Question** : que se passe-t-il avec un prior concentre *petit* (`mu=-1.5`) ?"
-   ]
+   "source": "### Exercice 3 — Effet du prior sur la longueur de corrélation\n\n**Objectif** : mesurer comment un prior *très concentré* sur une grande longueur $\\ell$ force le GP vers un modèle quasi linéaire (sous-apprentissage). C'est la vérification empirique promise en section 5.\n\n**Indices** : passez de `pm.LogNormal(\"ls\", mu=0.0, ...)` à `mu=2.0, sigma=0.1`. Étapes : (1) ré-entraînez avec ce prior concentré grand ; (2) comparez la frontière (qui doit devenir quasi-linéaire) et l'accuracy. **Question** : que se passe-t-il avec un prior concentré *petit* (`mu=-1.5`) ?"
   },
   {
    "cell_type": "code",
@@ -916,22 +868,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 3 a completer : effet du prior sur la longueur de correlation.\n"
+      "Exercice 3 à compléter : effet du prior sur la longueur de corrélation.\n"
      ]
     }
    ],
-   "source": [
-    "# Exercice 3 : effet du prior sur ls.\n",
-    "# Si on met un prior très concentré sur une grande longueur (ls ~ LogNormal(2.0, 0.1)),\n",
-    "# le GP devient presque lineaire (sous-apprentissage). Verifiez-le.\n",
-    "# Indice : changez mu de 0.0 a 2.0 dans pm.LogNormal(\"ls\", mu=2.0, sigma=0.1).\n",
-    "# Etape 1 : re-entrainez avec ce prior concentré grand.\n",
-    "# Etape 2 : comparez la frontiere (qui doit devenir quasi-lineaire) et l'accuracy.\n",
-    "# Question : que se passe-t-il avec un prior concentré petit (mu=-1.5) ?\n",
-    "\n",
-    "prior_ls_result = None  # TODO etudiant : modele avec prior concentré grand sur ls\n",
-    "print(\"Exercice 3 a completer : effet du prior sur la longueur de correlation.\")\n"
-   ]
+   "source": "# Exercice 3 : effet du prior sur ls.\n# Si on met un prior très concentré sur une grande longueur (ls ~ LogNormal(2.0, 0.1)),\n# le GP devient presque linéaire (sous-apprentissage). Vérifiez-le.\n# Indice : changez mu de 0.0 à 2.0 dans pm.LogNormal(\"ls\", mu=2.0, sigma=0.1).\n# Étape 1 : ré-entraînez avec ce prior concentré grand.\n# Étape 2 : comparez la frontière (qui doit devenir quasi-linéaire) et l'accuracy.\n# Question : que se passe-t-il avec un prior concentré petit (mu=-1.5) ?\n\nprior_ls_result = None  # TODO étudiant : modèle avec prior concentré grand sur ls\nprint(\"Exercice 3 à compléter : effet du prior sur la longueur de corrélation.\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Résumé

Ajoute les accents français manquants dans les 7 cellules de la **section 7 (Exercices)** introduites par #6118. Cible directe du NIT NanoClaw sur l'accent-coherence des nouvelles cellules.

## Scope (stricte)

- **7 cellules corrigées** : `p16frmwidp0` (intro section 7), `p16frmwidp1` (Exercice 1 markdown), `e01d2267` (Exercice 1 code stub), `p16frmwidp2` (Exercice 2 markdown), `88c4b5af` (Exercice 2 code stub), `p16frmwidp3` (Exercice 3 markdown), `e1cc9158` (Exercice 3 code stub).
- **Mots corrigés** : bayesien vers bayésien, durete vers dureté, correlation vers corrélation, echo vers écho, modele vers modèle, frontiere vers frontière, decision vers décision, etape vers étape, etapes vers étapes, echantillonnez vers échantillonnez, anneaux entrelaces vers anneaux entrelacés, separateur vers séparateur, verifier vers vérifier, generer vers générer.

## Hors scope (signalé, NON traité)

Les cellules pré-#6118 avec français non-accentué restent **inchangées**. Un sweep notebook-wide est hors portée d'un fix-de-NanoClaw-nit. Si le user/coord souhaite, à traiter en PR dédiée avec une approche cohérente : un style uniforme au choix, FR accentué partout, ou none.

## Validation

- **Tests** : `python -m pytest scripts/notebook_tools/tests/test_count_exercises.py` -> 43/43 PASS.
- **Notebook C.2** : 11/11 cellules code ont `execution_count != null` (1 a 11). Outputs des 3 cellules stub restaurés manuellement après cycle NotebookEdit avec texte accentué cohérent.
- **JSON normalisation** : le diff est passé de +13/-96 à +10/-69 après restauration des metadata (NotebookEdit normalise `source` list vers string, ce qui ajoute du bruit de diff).
- **§A composite** : 1 fichier, +10/-69 lignes, 1 sujet (accent cohérence), 1 domaine (PyMC notebook). PASS.

## Cross-référence

- **#6118** : PR originale (jsboige) avec framing 3 exercices, NIT NanoClaw sur accent-coherence.
- **#2161** : EPIC convention 3 exercices par notebook pédagogique.
- **CLAUDE.md §E (code-style.md)** : doc primaire en français, cohérence stylistique attendue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)