### PR TITLE
feat(ict): Track P J-Lens code prep (4B persona) — GPU2 draft (#5681)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/jlens_trackP_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/jlens_trackP_traces.py
@@ -1,0 +1,126 @@
+"""Chargement et curation GPU-free des traces J-Lens Track P (ICT-24, strate 5, #5681).
+
+Miroir de :mod:`ict.jlens_traces` (Track S) pour la **piste persona** de #5681.
+Track S confrontait SAE <-> J-lens sur le MÊME substrat (Qwen3.5-9B-Base, prompts de
+structure) pour mesurer la co-location cross-appareil. Track P pose une question
+orthogonale : le **workspace global se réorganise-t-il selon le persona** elicité ?
+Des conditionnements persona contrastés (prudent ↔ enthousiaste, formel ↔ casual,
+contrarien) produisent-ils des ignitions / candidates-workspace DISTINCTES au même
+layer ? C'est la lecture "persona" du *Global Workspace in Claude* (Anthropic, 2026).
+
+Substrat (G.1 — voir :mod:`extract_jlens_trackP_traces`)
+--------------------------------------------------------
+La matrice #5681 listait Track P comme "4B-instruct, J-lens via Subtext". Vérifié
+firsthand (po-2025 2026-07-11, ``list_repo_files`` HF) : **ni** ``Qwen3.5-4B-Instruct``
+**ni** de source de lens "Subtext" ne sont publiés. Le substrate réel exécutable est
+``Qwen3.5-4B`` (base) + persona par **prompts de conditionnement** — l'effet persona
+est isolé du post-training (paradigme workspace-on-persona d'Anthropic). Le détail
+de ce discrepancy est porté par ``meta["substrate_g1_note"]`` dans les fixtures.
+
+Pourquoi un module mince (pas une reinvention)
+----------------------------------------------
+Le schéma ``.npz`` est **identique** à celui de :mod:`ict.sae_traces` (directive
+#5681) : cles ``<set>__<idx>__{topk_ids,topk_vals,tokens}`` + ``__meta__`` (JSON,
+mêmes champs ``d_sae`` / ``k`` / ``layer`` / ``variant``). Les fonctions d'aval
+(:func:`densify`, :func:`mean_activation_by_set`, :func:`differential_features`,
+:func:`acts_topk_panels`, :func:`binarize_quantile`, :func:`states_from_panel`)
+operent sur ce schema commun sans rien savoir de la provenance : elles sont donc
+**reexportees telles quelles** depuis :mod:`ict.sae_traces` (DRY). L'apport
+specifique de ce module est le garde-fou anti-mélange ci-dessous.
+
+Garde-fou anti-mélange (apport spécifique)
+------------------------------------------
+:func:`load_traces` valide la nature de la trace pour empêcher une erreur de
+catégorie dans le notebook persona :
+
+* ``meta["lens"] == "sae"`` -> **refuse** (c'est une trace SAE).
+* ``meta["track"]`` commence par ``"S"`` -> **refuse** : c'est une fixture Track S
+  (Qwen3.5-9B-Base, structure), pas Track P. Les deux tracks sont des **modèles
+  distincts** (9B vs 4B) sur des questions orthogonales (structure vs persona) :
+  charger une fixture 9B dans un notebook persona 4B n'a pas de sens, même si le
+  schéma .npz est compatible. C'est l'anti-mélange propre à Track P (Track S a le
+  sien dans :mod:`ict.jlens_traces`, anti SAE).
+* ``meta["track"]`` commence par ``"P"`` ou est absent -> **accepte** (fixture
+  Track P nominale, ou rétro-compatibilité avec un extracteur qui n'écrit pas le
+  champ). L'extracteur GPU2 (:mod:`extract_jlens_trackP_traces`) DOIT écrire
+  ``"track": "P ..."`` pour la traçabilité.
+
+Numpy uniquement : AUCUN import torch ici (le GPU reste confiné au script
+d'extraction, piste GPU2 de #5681).
+
+References
+----------
+* Anthropic, *Global Workspace in Claude* (transformer-circuits.pub, 2026).
+* :mod:`ict.jlens_traces` -- l'adaptateur parallèle Track S (structure, 9B-Base),
+  dont les fonctions d'aval sont reexportees ici aussi (DRY via :mod:`ict.sae_traces`).
+* :mod:`extract_jlens_trackP_traces` -- le runner GPU2 (couche #1) + note G.1 substrate.
+* :mod:`ict.workspace` -- la batterie d'émergence consommatrice, agnostique à la
+  provenance des traces (consomme des ``acts[T, K]`` et des ``states``).
+* #5681 -- piste Track S (tête-à-tête 9B-Base) et Track P (persona 4B).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .sae_traces import (
+    densify,
+    mean_activation_by_set,
+    differential_features,
+    acts_topk_panels,
+    binarize_quantile,
+    states_from_panel,
+)
+from .sae_traces import load_traces as _sae_load_traces
+
+__all__ = [
+    "load_traces",
+    "densify",
+    "mean_activation_by_set",
+    "differential_features",
+    "acts_topk_panels",
+    "binarize_quantile",
+    "states_from_panel",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Chargement (garde-fou anti-mélange Track S/SAE <-> Track P, #5681)
+# --------------------------------------------------------------------------- #
+def load_traces(path: str | Path) -> dict:
+    """Recharge un ``.npz`` de traces **J-Lens Track P** (persona, 4B).
+
+    Garde-fou anti-mélange : valide la nature de la trace via ``meta["lens"]`` et
+    ``meta["track"]``.
+
+    * ``meta["lens"] == "sae"`` -> **refuse** (c'est une trace SAE : utiliser
+      :func:`ict.sae_traces.load_traces`).
+    * ``meta["track"]`` commence par ``"S"`` -> **refuse** : c'est une fixture
+      Track S (modèle 9B-Base, question de structure), pas Track P (modèle 4B,
+      persona). Les deux tracks sont des substrats NON comparables directement
+      (modèles distincts). Évite de charger une fixture Track S comme trace
+      Track P dans le notebook persona #5681.
+    * ``meta["track"]`` commence par ``"P"`` ou est absent -> **accepte** (fixture
+      Track P nominale, ou rétro-compatibilité).
+
+    Retourne ``{"meta": dict, "prompts": {(set_name, i): {"ids", "vals",
+    "tokens"}}}`` -- même structure que :func:`ict.sae_traces.load_traces`.
+    """
+    traces = _sae_load_traces(path)
+    meta = traces.get("meta", {})
+    lens = meta.get("lens")
+    if lens == "sae":
+        raise ValueError(
+            f"trace {path} porte meta['lens']='sae' : c'est une trace SAE, pas "
+            f"J-Lens Track P. Utiliser ict.sae_traces.load_traces (garde-fou "
+            f"anti-mélange du tete-a-tete #5681 Track P)."
+        )
+    track = meta.get("track", "")
+    if isinstance(track, str) and track.startswith("S"):
+        raise ValueError(
+            f"trace {path} porte meta['track']={track!r} : c'est une fixture "
+            f"Track S (Qwen3.5-9B-Base, structure), pas Track P (persona 4B). "
+            f"Modèles distincts = substrats non comparables directement "
+            f"(garde-fou anti-mélange Track S/Track P #5681)."
+        )
+    return traces

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_jlens_trackP_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_jlens_trackP_traces.py
@@ -1,0 +1,382 @@
+"""Extraction de traces J-Lens pour ICT-24 (strate 5, #5681 Track P) — Qwen3.5-4B persona.
+
+CONTRAT de répartition (honoré) : po-2025 prépare le code CPU-side (ce script, sans
+GPU requis pour le prep), ai-01 lance l'extraction GPU2 (``CUDA_VISIBLE_DEVICES=2``
+STRICT) et la valide. Drafted CPU po-2025 2026-07-11 ; GPU2 run = ai-01.
+
+Track P = piste **persona** du tête-à-tête #5681, DISTINCTE de Track S (structure).
+Là où Track S confronte SAE <-> J-lens sur le MÊME substrat (Qwen3.5-9B-Base, prompts
+de structure : code/prose/dialogue/math) pour mesurer la co-location cross-appareil,
+Track P demande si le **workspace global se réorganise selon le persona** elicité :
+des conditionnements persona contrastés (prudent ↔ enthousiaste, formel ↔ casual,
+avocat du diable) produisent-ils des ignitions/workspace candidates DISTINCTES au
+même layer ? C'est la lecture "persona" du *Global Workspace in Claude* (Anthropic,
+2026) : le workspace est censé encoder la stance active du modèle.
+
+Substrat réel (G.1 — vérifié firsthand po-2025 2026-07-11, ne pas propager la note
+stale "4B-instruct/Subtext" de la matrice #5681)
+-------------------------------------------------------------------------------------------------
+La matrice de disponibilité #5681 (note 2026-07-07) listait Track P comme
+"4B-instruct, J-lens via Subtext". Vérification ``list_repo_files`` sur le Hub HF le
+2026-07-11 (po-2025, GPU-free) établit que :
+
+* ``Qwen/Qwen3.5-4B-Instruct`` **n'existe pas** sur HF (``RepositoryNotFoundError``).
+  Seul ``Qwen/Qwen3.5-4B-Base`` est publié (downloads=206540).
+* Aucune source de lens dite "Subtext" n'est publique (recherche ``list_models``
+  "subtext" → uniquement des modèles de sentiment/intent sans rapport).
+* Le SEUL lens 4B publié est ``neuronpedia/jacobian-lens`` au chemin
+  ``qwen3.5-4b/jlens/Salesforce-wikitext/Qwen3.5-4B_jacobian_lens.pt``, fitté par
+  Neuronpedia sur ``Qwen/Qwen3.5-4B`` (base, n=1000, config.yaml confirmé).
+
+Le substrate réellement exécutable est donc **Qwen3.5-4B base + persona via prompts
+de conditionnement** (le persona est elicité par le prompt, pas par un
+instruction-tuning — c'est exactement le paradigme du workspace-on-persona
+d'Anthropic, et c'est méthodologiquement plus propre pour isoler l'effet persona du
+post-training). Ce script encode cette interprétation. ``--model`` et
+``--lens-filename`` restent CLI-overridables : si ai-01 dispose d'un lens "Subtext"
+privé/gated sur un autre substrat, il le branche par UN seul flag sans toucher au
+code. Le discrepancy vs la note de matrice est reporté dans ``__meta__`` (champ
+``substrate_g1_note``) pour la traçabilité du tete-a-tete.
+
+Fidélité du miroir Track S (exigence #5681 "miroir extract_jlens_traces.py")
+---------------------------------------------------------------------------
+* MEME architecture 3 couches que Track S : couche #1 = ce runner, couche #2 =
+  :mod:`ict.jlens_trackP_traces` (adaptateur numpy, garde-fou anti-mélange Track S
+  ↔ Track P), couche #3 = notebook (à livrer APRES fixtures 4B, follow-on séparé).
+* MEME readout J-lens : :func:`jlens_readout_topk` réutilisée DRY depuis
+  :mod:`extract_jlens_traces` (top-k token logits par position, base unembedding).
+* MEME output ``.npz`` : cles ``<set>__<idx>__{topk_ids,topk_vals,tokens}`` +
+  ``__meta__`` au schema :mod:`ict.sae_traces` (pour que :mod:`ict.workspace` tourne
+  INCHANGÉ). SEUL CHANGE le nom de fixture (``ict_trackP_jlens_*`` vs ``ict24_jlens_*``)
+  et le ``meta["track"]`` ("P" vs "S").
+* Garde-fous GPU (:func:`guard_single_gpu`, :func:`find_decoder_layers`) et controle
+  (:func:`apply_control_permutation`) réutilisés DRY depuis :mod:`extract_sae_traces`.
+* CE QUI EST TRACK-P-SPÉCIFIQUE (pas importé) : :data:`PERSONA_PROMPT_SETS` (le
+  substrat persona contrasté, distinct des :data:`PROMPT_SETS` de structure).
+
+Usage GPU2-strict (ai-01)
+-------------------------
+::
+
+    CUDA_VISIBLE_DEVICES=2 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \\
+        python extract_jlens_trackP_traces.py --stage smoke
+    # puis full trained + control :
+    CUDA_VISIBLE_DEVICES=2 python extract_jlens_trackP_traces.py --stage full --variant trained
+    CUDA_VISIBLE_DEVICES=2 python extract_jlens_trackP_traces.py --stage full --variant control
+
+References
+----------
+* Anthropic, *Global Workspace in Claude* (transformer-circuits.pub, 2026).
+* :mod:`extract_jlens_traces` -- le miroir Track S (structure, 9B-Base), dont
+  :func:`jlens_readout_topk` / :func:`load_jlens` / :func:`probe_lens_fit_n` sont
+  réutilisées ici DRY.
+* :mod:`ict.jlens_trackP_traces` -- adaptateur numpy couche #2 (garde-fou anti-mélange
+  Track S ↔ Track P : on refuse une fixture Track S chargée comme Track P, modèles
+  distincts = substrats non comparables directement).
+* github.com/anthropics/jacobian-lens -- package ``jlens`` officiel (dépendance).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# Reutilisation DRY des garde-fous GPU + controle depuis le miroir SAE Track S.
+# (On n'importe PAS PROMPT_SETS : Track P a son propre substrat persona, distinct.)
+from extract_sae_traces import (
+    guard_single_gpu,
+    find_decoder_layers,
+    apply_control_permutation,
+)
+# Reutilisation DRY du readout J-lens + chargement lens depuis le miroir Track S :
+# le readout top-k token logits est IDENTIQUE (seul le model/prompt change).
+from extract_jlens_traces import (
+    jlens_readout_topk,
+    load_jlens,
+    probe_lens_fit_n,
+)
+
+DEFAULT_MODEL = "Qwen/Qwen3.5-4B"   # G.1 : BASE (pas d'instruct publié). Voir docstring.
+# Hub neuronpedia publie des lens pré-ajustés. Le 4B (base) est fitté n=1000
+# (config.yaml confirmé). Le fichier ``_n1000.pt`` (fit complet Anthropic) est une
+# alternative --lens-filename pour un fit de qualité maximale si le défaut (auto-
+# stoppé à stop_at_delta=0.002) s'avérait trop court pour le tete-a-tete persona.
+DEFAULT_LENS_REPO = "neuronpedia/jacobian-lens"
+DEFAULT_LENS_FILENAME = "qwen3.5-4b/jlens/Salesforce-wikitext/Qwen3.5-4B_jacobian_lens.pt"
+
+
+# --------------------------------------------------------------------------- #
+# Substrat persona contrasté (Track-P-spécifique)
+# --------------------------------------------------------------------------- #
+# Cinq personas contrastés. Chaque prompt = un conditionnement persona (préfixe de
+# stance) + une continuation de sujet. L'objectif du tete-a-tete persona est de
+# mesurer si la batterie ict.workspace détecte une réorganisation du workspace
+# (candidates / ignitions différentes) ENTRE personas au même layer -- l'analogue
+# persona de la gate de co-location cross-appareil de Track S.
+#
+# Les personas sont conçus DIFFÉRENTIELS (chacun ancre une stance distinctive sur
+# des sujets voisins) pour que differential_features (ict.sae_traces) ait une chance
+# de faire ressortir des tokens persona-distinctifs. Mélange FR/EN comme PROMPT_SETS
+# (Track S) pour la cohérence de série.
+PERSONA_PROMPT_SETS: dict[str, list[str]] = {
+    "persona_cautious": [
+        # Prudent, mesuré, hypothèse à chaque pas.
+        "You are a careful, risk-averse analyst. Before recommending anything, you "
+        "weigh every downside. On the question of whether to adopt a new technology, "
+        "you begin: 'We must be cautious. The potential benefits are real, but so "
+        "are the failure modes. Consider first the worst case —'\n",
+        "En tant que conseiller prudent, je ne m'engage jamais à la légère. Face à "
+        "un investissement incertain, la règle est de préserver le capital avant "
+        "de viser le gain. Ma première recommandation serait donc d'abord de —\n",
+        "A cautious doctor hedges every diagnosis. 'It could be benign, but we "
+        "cannot yet rule out complications. I would order further tests before "
+        "concluding.' The disciplined stance is to —\n",
+        "As a conservative engineer, you triple-check load tolerances. 'Redundancy "
+        "is not waste; it is insurance. A single point of failure is, by "
+        "definition, a failure waiting to happen. Therefore we'\n",
+    ],
+    "persona_enthusiastic": [
+        # Enthousiaste, confiant, bullish.
+        "You are an energetic, optimistic champion of bold ideas. Where others see "
+        "risk, you see opportunity. On adopting a new technology, you begin: 'This "
+        "is a moment to move fast and lead! The upside dwarfs the cost, and the "
+        "future belongs to those who —'\n",
+        "En tant qu'entrepreneur enthousiaste, je vois chaque défi comme une "
+        "chance. Un investissement incertain ? C'est exactement là que se forge "
+        "l'avantage ! Ma recommandation est de foncer, car —\n",
+        "An enthusiastic coach fires up the team. 'We've got this! Every setback "
+        "is a setup for a comeback. Leave it all on the field, because winners "
+        "are made in the moments nobody is watching. Let's go out there and'\n",
+        "As a bullish founder pitching investors, you radiate conviction. 'The "
+        "market is ours to take. The numbers compound, the moat deepens, and the "
+        "only real risk is moving too slowly. Join us now before —'\n",
+    ],
+    "persona_formal": [
+        # Académique, troisième personne, précis.
+        "It is the position of the present author that the matter admits of "
+        "careful analysis. One observes, upon inspection of the relevant "
+        "literature, that the phenomenon in question exhibits three principal "
+        "features, which may be enumerated as follows. First, it is notable that —\n",
+        "Dans un registre formel, on conviendra que la question mérite un "
+        "traitement rigoureux. L'examen des données disponibles permet de dégager, "
+        "sans précipitation, plusieurs constats dont le premier, et non le moindre, "
+        "est que —\n",
+        "The committee, having deliberated at length, hereby records its finding "
+        "that the proposal, while not without merit, requires amendment. The "
+        "grounds for this determination are threefold and shall be set out "
+        "presently. In the first instance —\n",
+        "From a standpoint of analytical rigor, one must distinguish between the "
+        "nominal and the effective quantities. The discrepancy, though small, is "
+        "systematic and bears on the conclusion. It is therefore incumbent upon "
+        "the investigator to —\n",
+    ],
+    "persona_casual": [
+        # Colloquial, première personne, chaleureux.
+        "Honestly? I'd just go for it. Life's too short to overthink every little "
+        "thing. You wanna try the new thing? Try it! Worst case you learn "
+        "something, right? Look, here's how I see it —\n",
+        "Bah, te casse pas la tête avec ça ! Franchement, tu te prends trop le "
+        "chou. Essaie, point. Si ça marche, génial, et si ça foire, bah tu "
+        "feras autre chose. Moi je te dis, écoute ton instinct et —\n",
+        "So like, here's the deal — I've been there, done that, and honestly the "
+        "best stuff happens when you just wing it a little. Don't get me wrong, a "
+        "little planning is fine, but at some point you gotta just —\n",
+        "Look, I'm no expert, but from what I've seen, you just gotta trust your "
+        "gut, you know? People overcomplicate this stuff. Take it from me, the "
+        "simple way is usually the right way, so just —\n",
+    ],
+    "persona_devil": [
+        # Avocat du diable, contrarien, teste les faiblesses.
+        "Let me play devil's advocate, because someone has to. Everyone here is "
+        "quick to celebrate, but has anyone seriously considered what could go "
+        "wrong? I'd argue the strongest case is actually AGAINST the proposal, "
+        "and here is why. Suppose, for a moment, that —\n",
+        "Pour le bien du débat, permettez-moi d'attaquer notre propre conclusion. "
+        "Je soutiendrai la thèse inverse, non par conviction, mais pour en éprouver "
+        "la robustesse. Si l'on adopte délibérément le contre-argument, on constate "
+        "que —\n",
+        "As a committed contrarian, I have to push back. The consensus feels too "
+        "tidy, too convenient — and that is exactly what should make us suspicious. "
+        "What is the steel-man of the opposing view? Charitably stated, the other "
+        "side would say that —\n",
+        "Let's stress-test this. You've all convinced yourselves, which is precisely "
+        "when smart people make bad calls. So I'll be the annoying one: name the "
+        "single weakest link in the plan. My own nominee for that weak link is —\n",
+    ],
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--stage", choices=["smoke", "full"], default="smoke")
+    p.add_argument("--variant", choices=["trained", "control"], default="trained",
+                   help="control = permutation seedee des lignes d'input embeddings "
+                        "(même sanction que #5101, appliquee sur le HF model avant "
+                        "le wrap jlens)")
+    p.add_argument("--layer", type=int, default=16,
+                   help="couche du lens jacobien lue (defaut 16 = mi-reseau, miroir Track S)")
+    p.add_argument("--model", default=DEFAULT_MODEL,
+                   help=f"défaut = {DEFAULT_MODEL} (base). Si ai-01 dispose d'un "
+                        f"substrat alternatif (ex: lens privé sur un 4B fine-tuné), "
+                        f"l'overrider ici + --lens-filename.")
+    p.add_argument("--lens-repo", default=DEFAULT_LENS_REPO)
+    p.add_argument("--lens-filename", default=DEFAULT_LENS_FILENAME,
+                   help=f"défaut = lens 4B-base vérifié (n=1000). Alternative "
+                        f"qualité-max : '.../Qwen3.5-4B_jacobian_lens_n1000.pt'.")
+    p.add_argument("--k", type=int, default=50,
+                   help="top-k token logits gardes par position (analogue du k=50 SAE)")
+    p.add_argument("--out-dir",
+                   default=str(Path(__file__).resolve().parent.parent / "traces"))
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--attn", default=None,
+                   help="attn_implementation a forcer (ex: eager) si le defaut echoue")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    t0 = time.time()
+    torch.manual_seed(args.seed)
+    device = guard_single_gpu()
+
+    import transformers
+    import jlens  # dépendance officielle Anthropic, jamais copiée (garde-fou #4 #5681)
+
+    print(f"[load] {args.model} (bf16, forward-only) ...")
+    cfg_kwargs: dict = {"dtype": torch.bfloat16}
+    if args.attn:
+        cfg_kwargs["attn_implementation"] = args.attn
+    hf = transformers.AutoModelForCausalLM.from_pretrained(args.model, **cfg_kwargs).to(device)
+    hf.eval()
+    tokenizer = transformers.AutoTokenizer.from_pretrained(args.model)
+    d_model = getattr(hf.config, "hidden_size", None)
+    n_layers = getattr(hf.config, "num_hidden_layers", None)
+    vocab_size = hf.config.vocab_size
+    print(f"[model] classe={type(hf).__name__} n_layers={n_layers} "
+          f"d_model={d_model} vocab={vocab_size} "
+          f"vram={torch.cuda.memory_allocated() / 2**30:.1f} GiB")
+
+    # Contrairement à Track S (qui REJETTE instruct), Track P est la piste persona :
+    # on accepte tout substrat. On signale juste si le modèle est un base model
+    # (persona alors elicité par prompt, voir docstring + G.1 note).
+    is_instruct = "instruct" in args.model.lower() or "-it" in args.model.lower()
+    if is_instruct:
+        print("[persona] modèle instruct détecté : persona double (prompt + post-training).")
+    else:
+        print("[persona] base model : persona elicité PAR le prompt (paradigme workspace-"
+              "on-persona d'Anthropic, G.1 note : pas d'instruct 4B publié).")
+
+    # Controle : permutation seedee des input embeddings (#5101), APPLIQUEE sur le
+    # HF model AVANT le wrap jlens (etre refletée dans le lens), miroir Track S.
+    if args.variant == "control":
+        apply_control_permutation(hf, args.seed)
+
+    # Wrap jlens (apres permutation eventuelle).
+    model = jlens.from_hf(hf, tokenizer)
+    print(f"[jlens] HF model wrappé via jlens.from_hf.")
+
+    lens = load_jlens(args.lens_repo, args.lens_filename)
+    lens_fit_n = probe_lens_fit_n(args.lens_repo, args.lens_filename)
+    print(f"[lens] fit n={lens_fit_n} (garde-fou #2 #5681)")
+
+    sets = PERSONA_PROMPT_SETS
+    if args.stage == "smoke":
+        # Smoke = 1 prompt par persona sur 2 personas (cauchemar delicence), pour
+        # valider l'API + le decode. miroir Track S (1 par set, 2 sets).
+        sets = {"persona_cautious": PERSONA_PROMPT_SETS["persona_cautious"][:1],
+                "persona_enthusiastic": PERSONA_PROMPT_SETS["persona_enthusiastic"][:1]}
+
+    arrays: dict[str, np.ndarray] = {}
+    pos_total = 0
+    for set_name, prompts in sets.items():
+        for i, text in enumerate(prompts):
+            ids, vals, tokens, T_eff = jlens_readout_topk(
+                lens, model, tokenizer, text, args.layer, args.k)
+            pos_total += T_eff
+            key = f"{set_name}__{i}"
+            arrays[f"{key}__topk_ids"] = ids.cpu().numpy()
+            arrays[f"{key}__topk_vals"] = vals.cpu().numpy()
+            arrays[f"{key}__tokens"] = np.array(tokens, dtype=str)
+            print(f"[trace] {key}: T={T_eff} k={args.k} "
+                  f"top-logit max={vals.max().item():.2f} "
+                  f"min={vals.min().item():.2f}")
+            if args.stage == "smoke":
+                top5 = [tokenizer.decode([int(t)]) for t in ids[-1, :5]]
+                print(f"        top-5 token logits (dernier token) : {top5}")
+
+    # Sanity greedy (miroir Track S) : attrape un chargement de poids errone.
+    if args.stage == "smoke" and args.variant == "trained":
+        probe = tokenizer("La capitale de la France est", return_tensors="pt").to(device)
+        with torch.no_grad():
+            gen = hf.generate(**probe, max_new_tokens=12, do_sample=False)
+        print(f"[sanity] greedy: {tokenizer.decode(gen[0], skip_special_tokens=True)!r}")
+
+    print(f"\n[sanity] {pos_total} positions, top-k={args.k} par position "
+          f"(base unembedding, ~vocab={vocab_size})")
+    print(f"[sanity] vram pic={torch.cuda.max_memory_allocated() / 2**30:.1f} GiB")
+
+    if args.stage == "full":
+        out_dir = Path(args.out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out = out_dir / f"ict_trackP_jlens_layer{args.layer}_{args.variant}.npz"
+        meta = {
+            # --- schema commun sae_traces (consommé par ict.workspace inchangé) ---
+            "model": args.model, "layer": args.layer, "k": args.k,
+            "d_model": int(d_model) if d_model else None,
+            "variant": args.variant, "seed": args.seed,
+            # --- identification de l'appareil (EXIGÉ par ict.jlens_trackP_traces) ---
+            "lens": "jacobian",
+            "readout": "topk_token_logits (jlens.apply -> logits base unembedding "
+                       "-> topk k=K par position)",
+            # --- dimension de l'espace de readout (CLE d_sae pour compat sae_traces) ---
+            "d_sae": int(vocab_size),
+            "d_sae_semantics": "vocab_size (topk_ids = token ids, base unembedding)",
+            "lens_repo": args.lens_repo, "lens_filename": args.lens_filename,
+            "lens_fit_n": lens_fit_n,            # garde-fou #2 de #5681
+            # --- IDENTIFICATION TRACK P (cle du garde-fou anti-mélange Track S/P) ---
+            "track": "P (persona via conditioning prompts, base model)",
+            "is_instruct_model": is_instruct,
+            "persona_sets": list(sets.keys()),
+            # --- G.1 note : discrepancy vs matrice #5681 (ne pas propager la note stale) ---
+            "substrate_g1_note": (
+                "Matrice #5681 (2026-07-07) listait Track P = '4B-instruct, J-lens "
+                "via Subtext'. Verifie firsthand po-2025 2026-07-11 (list_repo_files "
+                "HF) : Qwen3.5-4B-Instruct n'est PAS publié (seul 4B-Base), et aucune "
+                "source de lens 'Subtext' n'est publique. Substrate réel = Qwen3.5-4B "
+                "base + persona par prompts de conditionnement. ai-01 peut redirect "
+                "via --model/--lens-filename si un lens privé/gated existe."),
+            # --- garde-fous d'honnêteté #5681 (reportés côté notebook) ---
+            "lens_is_dependency": "jlens = git+https://github.com/anthropics/jacobian-lens "
+                                  "(officiel Anthropic, dépendance, jamais copié)",
+            "mono_token_vocab_restricted": ("J-lens = mono-token, vocabulaire-restreint "
+                                            "(limitation déclarée Anthropic)"),
+            "persona_methodology": ("Persona elicité par conditionnement du prompt "
+                                    "(prudent/enthousiaste/formel/casuel/contrarien). "
+                                    "Non instruction-tuned : l'effet persona est isolé "
+                                    "du post-training, paradigme workspace-on-persona."),
+            "semantic_divergence_vs_sae": ("SAE top-k : hors top-k = 0 EXACT. "
+                                           "J-lens top-k token logits : hors top-k ~ petit "
+                                           "mais NON nul (densify = approximation rang-k)."),
+            "prompt_sets": {kk: len(vv) for kk, vv in sets.items()},
+            "n_positions_total": pos_total,
+            "date": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+            "cpu_drafted_untested": ("Drafted CPU po-2025 (torch+cpu) 2026-07-11, "
+                                     "extraction GPU2 ai-01 (contrat de répartition #5681). "
+                                     "Cf DM msg-20260711T132815-0unnkf."),
+        }
+        arrays["__meta__"] = np.array(json.dumps(meta, ensure_ascii=False))
+        np.savez_compressed(out, **arrays)
+        print(f"[out] {out} ({out.stat().st_size / 2**20:.2f} MiB)")
+
+    print(f"[done] stage={args.stage} variant={args.variant} "
+          f"en {time.time() - t0:.0f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_jlens_trackP_traces.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_jlens_trackP_traces.py
@@ -1,0 +1,239 @@
+"""Tests de l'adaptateur de traces J-Lens Track P (ICT-24, #5681). GPU-free.
+
+Couvrent :
+* le round-trip ``.npz`` -> :func:`ict.jlens_trackP_traces.load_traces` (sans pickle) ;
+* le **garde-fou anti-mélange** du tete-a-tete #5681 Track P :
+  - une trace portant ``meta["lens"] == "sae"`` est REFUSEE,
+  - une fixture Track S (``meta["track"]`` commence par "S") est REFUSEE (modèle 9B,
+    pas comparable au 4B persona),
+  - une fixture Track P (``track`` commence par "P") ou sans champ ``track``/``lens``
+    est acceptee ;
+* la selection differentielle reutilisee de :mod:`ict.sae_traces` (fonctions
+  ``densify`` / ``differential_features`` / ``acts_topk_panels`` /
+  ``binarize_quantile`` / ``states_from_panel``) tournent a l'identique ;
+* **acceptance #2 de #5681** : le pipeline aval :mod:`ict.workspace` (batterie
+  d'emergence) tourne **inchange** sur des traces J-lens Track P (persona), via
+  l'adaptateur -- un test end-to-end plante une ignition temporelle dans un prompt
+  persona et verifie sa detection + le deroulement de la batterie ;
+* si les traces reelles Track P etaient committes (extraction GPU2), un test
+  d'integration verifierait leur schema (skip tant que la piste GPU2 de #5681
+  Track P n'est pas livree).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict import jlens_trackP_traces as jtp  # noqa: E402
+from ict import workspace  # noqa: E402  (acceptance #2 : aval inchange)
+from ict import sae_traces as st  # noqa: E402  (anti-melange : on refuse ses traces)
+from ict import jlens_traces as jt_s  # noqa: E402  (anti-melange : on refuse Track S)
+
+D_JLENS = 2000          # dimension du J-space (nom de champ ``d_sae`` herite du schema commun)
+K_TOPK = 50             # top-k des directions J gardees par token (troncature rang-k)
+T = 120
+
+
+# --------------------------------------------------------------------------- #
+# Fixture : npz synthetique J-Lens Track P avec structure differentielle plantee
+# --------------------------------------------------------------------------- #
+def _write_npz(path, meta_lens="jacobian", meta_track="P (persona)"):
+    """Deux personas x deux prompts. Feature 7 active seulement dans le persona A
+    (differentielle), feature 2 partout (non differentielle). Le prompt
+    (``persona_cautious``, 0) porte en plus une **ignition temporelle plantee** :
+    sa seconde moitie est fortement concentree sur la feature 7 (Gini eleve)."""
+    rng = np.random.default_rng(0)
+    arrays = {}
+    for set_name, planted, val in (("persona_cautious", 7, 5.0),
+                                   ("persona_enthusiastic", 13, 4.0)):
+        for i in range(2):
+            ids = rng.integers(20, D_JLENS, size=(T, K_TOPK)).astype(np.int32)
+            vals = rng.uniform(0.05, 0.3, size=(T, K_TOPK)).astype(np.float16)
+            ids[:, 0] = 2                      # ubiquitaire, non differentielle
+            vals[:, 0] = 10.0
+            ids[:, 1] = planted                # discriminante du persona
+            vals[:, 1] = val
+            if set_name == "persona_cautious" and i == 0:
+                # ignition temporelle : 2e moitie fortement concentree sur feat 7.
+                half = T // 2
+                ids[half:, 0] = 7
+                vals[half:, 0] = 8.0
+                ids[half:, 1] = 1500            # id neutre hors du panel differentiel
+                vals[half:, 1] = 0.05
+                vals[half:, 2:] = 0.05          # ecrase le reste -> Gini ~ 1
+            arrays[f"{set_name}__{i}__topk_ids"] = ids
+            arrays[f"{set_name}__{i}__topk_vals"] = vals
+            arrays[f"{set_name}__{i}__tokens"] = np.array(
+                [f"tok{t}" for t in range(T)], dtype=str)
+    meta = {"d_sae": D_JLENS, "k": K_TOPK, "layer": 16, "variant": "synthetic"}
+    if meta_lens is not None:
+        meta["lens"] = meta_lens
+    if meta_track is not None:
+        meta["track"] = meta_track
+    arrays["__meta__"] = np.array(json.dumps(meta))
+    np.savez_compressed(path, **arrays)
+
+
+@pytest.fixture()
+def trackP_npz(tmp_path):
+    path = tmp_path / "trackP.npz"
+    _write_npz(path)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Round-trip + garde-fou anti-melange (apport specifique de jlens_trackP_traces)
+# --------------------------------------------------------------------------- #
+def test_load_traces_roundtrip(trackP_npz):
+    tr = jtp.load_traces(trackP_npz)
+    assert tr["meta"]["d_sae"] == D_JLENS
+    assert tr["meta"]["lens"] == "jacobian"
+    assert tr["meta"]["track"].startswith("P")
+    assert set(tr["prompts"]) == {("persona_cautious", 0), ("persona_cautious", 1),
+                                  ("persona_enthusiastic", 0), ("persona_enthusiastic", 1)}
+    e = tr["prompts"][("persona_cautious", 0)]
+    assert e["ids"].shape == (T, K_TOPK) and e["ids"].dtype == np.int32
+    assert e["vals"].shape == (T, K_TOPK) and e["vals"].dtype == np.float32
+    assert e["tokens"].shape == (T,)
+
+
+def test_load_traces_accepts_missing_track_and_lens(tmp_path):
+    """Retro-compatibilite : un extracteur qui n'écrit ni ``track`` ni ``lens`` est accepte."""
+    path = tmp_path / "bare.npz"
+    _write_npz(path, meta_lens=None, meta_track=None)
+    tr = jtp.load_traces(path)
+    assert "lens" not in tr["meta"]
+    assert "track" not in tr["meta"]
+
+
+def test_load_traces_rejects_sae_trace(tmp_path):
+    """Garde-fou anti-melange #5681 : une trace SAE (lens='sae') est REFUSEE."""
+    path = tmp_path / "sae_mislabelled.npz"
+    _write_npz(path, meta_lens="sae")
+    with pytest.raises(ValueError, match="sae"):
+        jtp.load_traces(path)
+
+
+def test_load_traces_rejects_trackS_fixture(tmp_path):
+    """Garde-fou anti-melange Track S/Track P : une fixture Track S (9B-Base,
+    structure) est REFUSEE par le loader Track P (modèle 4B persona, non comparable)."""
+    path = tmp_path / "trackS_fixture.npz"
+    _write_npz(path, meta_track="S (base, structure -- pas persona)")
+    with pytest.raises(ValueError, match="Track S"):
+        jtp.load_traces(path)
+
+
+def test_trackP_accepted_by_own_loader_but_trackS_loader_also_loads(trackP_npz):
+    """La fixture Track P passe SON loader. Le loader Track S (jt_s) ne filtre PAS
+    le champ track -> il l'accepterait aussi (pas son rôle de filtrer Track P).
+    L'anti-melange est asymétrique par construction : chaque loader protège SON
+    notebook (Track P refuse Track S ; Track S refuse SAE). On vérifie ici la
+    symétrie utile : le loader Track P refuse bien une fixture Track S
+    (test_load_traces_rejects_trackS_fixture) ET une SAE (test ci-dessus)."""
+    tr = jtp.load_traces(trackP_npz)
+    assert tr["meta"]["track"].startswith("P")
+
+
+# --------------------------------------------------------------------------- #
+# Fonctions d'aval reexportees de sae_traces (memes invariants)
+# --------------------------------------------------------------------------- #
+def test_differential_features_finds_planted(trackP_npz):
+    tr = jtp.load_traces(trackP_npz)
+    top = set(jtp.differential_features(tr, k=2).tolist())
+    assert top == {7, 13}, top                  # plantees, pas l'ubiquitaire 2
+
+
+def test_densify_and_panels(trackP_npz):
+    tr = jtp.load_traces(trackP_npz)
+    e = tr["prompts"][("persona_enthusiastic", 1)]
+    feats = np.array([13, 2, D_JLENS + 500])   # plantee, ubiquitaire, hors-range
+    dense = jtp.densify(e["ids"], e["vals"], feats)
+    assert dense.shape == (T, 3)
+    assert np.allclose(dense[:, 0], e["vals"][:, 1])     # feat 13 en col 0
+    assert np.all(dense[:, 2] == 0.0)                    # hors-range => jamais vue => 0
+    feats = jtp.differential_features(tr, k=4)
+    panels = jtp.acts_topk_panels(tr, feats)
+    assert set(panels) == set(tr["prompts"])
+    assert all(p.shape == (T, 4) for p in panels.values())
+
+
+def test_binarize_states_guards():
+    dense = np.zeros((10, 2), dtype=np.float32)
+    dense[:5, 0] = [1, 2, 3, 4, 5]
+    bits = jtp.binarize_quantile(dense, q=0.5)
+    assert bits[:, 1].sum() == 0                 # jamais active -> False
+    with pytest.raises(ValueError):
+        jtp.binarize_quantile(dense, q=1.0)
+    states = jtp.states_from_panel(np.array([[0, 0], [1, 0], [0, 1]], dtype=bool))
+    assert states.tolist() == [0, 1, 2]
+    with pytest.raises(ValueError):
+        jtp.states_from_panel(np.zeros((3, 21), dtype=bool))
+
+
+# --------------------------------------------------------------------------- #
+# ACCEPTANCE #2 : workspace.py tourne inchangé sur les traces J-lens Track P (persona)
+# --------------------------------------------------------------------------- #
+def test_workspace_pipeline_runs_on_trackP_traces(trackP_npz):
+    """End-to-end : traces J-Lens Track P -> adaptateur -> batterie workspace.
+
+    Prouve l'acceptance #2 de #5681 (déclinée Track P) : :mod:`ict.workspace`
+    consomme les traces persona via l'adaptateur SANS modification. L'ignition
+    temporelle plantee dans le prompt (``persona_cautious``, 0) doit etre detectee
+    (preuve qualitative non triviale : le pipeline fonctionne sur persona, pas juste
+    qu'il s'execute)."""
+    tr = jtp.load_traces(trackP_npz)
+    feats = jtp.differential_features(tr, k=12)           # feature 7 ressortira
+    assert 7 in set(feats.tolist())                      # precond : l'ignition est dans le panel
+    panels = jtp.acts_topk_panels(tr, feats)
+    acts = panels[("persona_cautious", 0)]               # (T, 12) : le prompt a ignition plantee
+
+    # concentration par pas -> l'ignition plantee cree un saut
+    conc = workspace.concentration_series(acts, metric="gini")
+    assert conc.shape == (T,)
+    half = T // 2
+    assert conc[half:].mean() > conc[:half].mean()       # la 2e moitie est plus concentree
+
+    # Detection d'ignitions (lecture Dehaene temporelle)
+    events = workspace.ignition_events(conc, threshold=0.5, persistence=5)
+    assert len(events) >= 1                              # l'ignition plantee est detectee
+    assert all(e["center"] >= half - 5 for e in events)  # ... dans la 2e moitie
+
+    # discretisation -> batterie event-triggered
+    bits = jtp.binarize_quantile(acts, q=0.7)
+    states = jtp.states_from_panel(bits)
+    rng = np.random.default_rng(0)
+    battery = workspace.event_triggered_battery(
+        states, [e["center"] for e in events], window=15,
+        rng=rng, n_shuffles=10, n_neutral=len(events),
+    )
+    assert battery["n_events"] == len(events)
+    assert "contrast" in battery
+    assert -1e-9 <= battery["ec_gain_event"]              # gain real, signe honnete
+    assert isinstance(battery["fraction_credited_events"], float)
+
+
+# --------------------------------------------------------------------------- #
+# Integration : schema des traces reelles Track P (si jamais committes)
+# --------------------------------------------------------------------------- #
+REAL = Path(__file__).parent.parent / "traces"
+
+
+@pytest.mark.parametrize("variant", ["trained", "control"])
+def test_real_trackP_traces_schema(variant):
+    path = REAL / f"ict_trackP_jlens_layer16_{variant}.npz"
+    if not path.exists():
+        pytest.skip("traces J-Lens Track P reelles absentes (extraction GPU2 "
+                    "de #5681 Track P non livree)")
+    tr = jtp.load_traces(path)
+    assert tr["meta"]["lens"] == "jacobian"
+    assert tr["meta"]["track"].startswith("P")
+    assert tr["meta"]["k"] == K_TOPK and tr["meta"]["d_sae"] > 0
+    assert "persona" in str(tr["meta"].get("persona_sets", ""))   # au moins un set persona
+    for e in tr["prompts"].values():
+        assert e["ids"].shape[1] == K_TOPK


### PR DESCRIPTION
## Contexte

EPIC #4588 (strate 5 ICT) / piste **Track P persona** de #5681. Suite au steer ai-01 (DM `msg-20260711T132815-0unnkf`) : **(a) code extraction prep d'abord**, grain GPU-free pour po-2025, extraction GPU2 par ai-01 ensuite. Mirror du pattern Track S (#5887 adapter + #5888 runner).

Track P = question orthogonale à Track S : le workspace global se **réorganise-t-il selon le persona** elicité ? Des conditionnements persona contrastés produisent-ils des ignitions/candidates DISTINCTES au même layer ?

## Livrables (3 couches, 747 insertions, 0 deletions)

**Couche #1** — [scripts/extract_jlens_trackP_traces.py](MyIA.AI.Notebooks/IIT/ICT-Series/scripts/extract_jlens_trackP_traces.py) (382L)
- 5 personas contrastés (`PERSONA_PROMPT_SETS` : cautious / enthusiastic / formal / casual / devil)
- Reuse DRY : `guard_single_gpu`, `find_decoder_layers`, `apply_control_permutation` (de `extract_sae_traces`) + `jlens_readout_topk`, `load_jlens`, `probe_lens_fit_n` (de `extract_jlens_traces`). Pas de réimplémentation du readout J-lens.
- Output `.npz` même schéma que `sae_traces` → `ict.workspace` tourne inchangé. Fixtures `ict_trackP_jlens_layer16_{trained,control}.npz`.
- `meta['track']='P'` pour le garde-fou anti-mélange.

**Couche #2** — [ict/jlens_trackP_traces.py](MyIA.AI.Notebooks/IIT/ICT-Series/ict/jlens_trackP_traces.py) (126L)
- Adaptateur numpy (aucun torch), reexporte les fonctions d'aval de `sae_traces` (DRY).
- Garde-fou anti-mélange : refuse `lens='sae'` ET `meta['track']` commençant par `'S'` (fixture 9B-Base structure ≠ 4B persona).

**Couche #3** — [tests/test_jlens_trackP_traces.py](MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_jlens_trackP_traces.py) (239L)

## Validation GPU-free (torch+cpu po-2025)

| Check | Résultat |
|-------|----------|
| `py_compile` (3 fichiers) | OK |
| `pytest` | **9 passed, 2 skipped** (0.47s) |
| import-time runner (DRY chain) | OK |
| `PERSONA_PROMPT_SETS` sanity | 5×4 prompts sains |
| `guard_single_gpu` sans GPU | refuse correctement (draft prêt GPU2) |

Skip attendu : les 2 tests d'intégration `test_real_trackP_traces_schema` (attendent les fixtures GPU2 non encore extraites).

**Acceptance #2 #5681 prouvée** : `ict.workspace` (concentration_series, ignition_events, event_triggered_battery) tourne inchangé sur traces persona via l'adaptateur — test end-to-end `test_workspace_pipeline_runs_on_trackP_traces` PASSED.

## G.1 substrate (ne pas propager la note stale de matrice #5681)

La matrice #5681 (2026-07-07) listait Track P = « 4B-instruct, J-lens via Subtext ». Vérification firsthand `list_repo_files` HF (po-2025 2026-07-11) :
- `Qwen/Qwen3.5-4B-Instruct` **n'existe pas** (`RepositoryNotFoundError`). Seul `Qwen/Qwen3.5-4B-Base`.
- Aucune source de lens dite « Subtext » n'est publique.
- Le SEUL lens 4B publié = `neuronpedia/jacobian-lens` à `qwen3.5-4b/.../Qwen3.5-4B_jacobian_lens.pt` (base, n=1000, config.yaml confirmé).

**Substrate réel = `Qwen/Qwen3.5-4B` base + persona par prompts de conditionnement** (effet persona isolé du post-training — paradigme workspace-on-persona d'Anthropic). `--model` / `--lens-filename` restent CLI-overridables si ai-01 dispose d'un lens privé/gated. Discrepancy reporté dans `meta['substrate_g1_note']` pour traçabilité.

## Next step — ai-01 lance GPU2

```bash
CUDA_VISIBLE_DEVICES=2 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
    python extract_jlens_trackP_traces.py --stage smoke
# puis :
CUDA_VISIBLE_DEVICES=2 python extract_jlens_trackP_traces.py --stage full --variant trained
CUDA_VISIBLE_DEVICES=2 python extract_jlens_trackP_traces.py --stage full --variant control
```

Notebook couche #3 (tête-à-tête persona) = follow-on **APRÈS** fixtures 4B, deferred per steer ai-01.

See #5681 (partial — couche prep Track P, fixtures GPU2 + notebook en follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)