### PR TITLE
feat(hashlife): extract pure Chebyshev geometry to ConeGeometry (cycle-break, EPIC #3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
@@ -137,6 +137,7 @@ import Conway.Life.Computation
 import Conway.Life.HashlifeCorrectness
 import Conway.Life.HashlifeMemo
 import Conway.Life.HashlifeMarginDemo
+import Conway.Life.ConeGeometry
 import Conway.Life.LightCone
 import Conway.Life.Pillars
 import Conway.KochenSpecker

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Cone geometry — pure lattice facts (Mathlib only)
+
+This module is the **pure-geometry base** of the Conway Hashlife tight-locality
+infrastructure (EPIC #3846, N2 redesign arc). It holds the lattice geometry over
+`Int × Int` that depends on **no Game-of-Life semantics** — neither `evolve`,
+`isAlive`, `candidates`, `mooreNeighbors`, the `lightCone` set, the `manhattan`
+metric, nor any `MacroCell` / `Grid` proof-body module. Its only import is
+Mathlib. This independence is structural, not cosmetic:
+
+**Why a separate module (cycle-break).** `Conway.Life.LightCone` *imports*
+`Conway.Life.HashlifeCorrectness` (it needs `evolve`, `lightCone`, `manhattan`
+for the reach theorem `evolve_reach_chebyshev` and the N2 capstone). The reverse
+import — `HashlifeCorrectness` importing `LightCone` to consume
+`window_cheb_cone_in_domain` in the P5 `p5_large_n_jump` path — would therefore
+be **circular**. Extracting the pure Chebyshev geometry here breaks the cycle:
+`LightCone` and `HashlifeCorrectness` both import `ConeGeometry`, but
+`ConeGeometry` imports neither of them.
+
+**Split criterion (ai-01 design-gate msg-...338lw8, 2026-07-11).** A declaration
+migrates here iff its proof references only `Int × Int`, `Int.natAbs`, `max`,
+omega/linarith, and Mathlib arithmetic lemmas — i.e. it does *not* reference
+`evolve` / `MacroCell` / `Grid`-live concepts. The evolve-coupled lemmas
+(`evolve_reach_chebyshev`, the N2 margin capstone, the `manhattan`/`lightCone`
+bridges) stay in `LightCone`, where the GoL semantics live.
+
+All declarations keep their qualified names (`Conway.Life.chebDist`, etc.), so
+every existing call site in `LightCone` resolves unchanged — only the defining
+module moves. Sorry-free at creation. EPIC #3846, W3/W4 cycle-break.
+-/
+
+import Mathlib
+
+namespace Conway
+namespace Life
+
+/-! ## Chebyshev (chessboard) distance and the tight locality cone
+
+The *tight* Game-of-Life locality is governed by the Chebyshev (L∞) distance:
+one B3/S23 generation reaches exactly the Moore neighborhood (Chebyshev radius
+1), so `t` generations reach Chebyshev radius `t`. The `lightCone` machinery in
+`LightCone` uses the Manhattan (L1) distance, which over-approximates the tight
+reach by a factor of 2 — `step_light_cone` demands Manhattan radius `2 * t`. The
+lemmas below formalize the Chebyshev cone structure that a *tight* single-jump
+correctness proof chains through:
+
+- the cone fits in a margin-`t` box (**margin sufficiency** — the geometric fact
+  that makes the `padCenter2` margin `2^k` sufficient for a single jump of `2^k`
+  generations: the tight Chebyshev reach `2^k` fits exactly in a margin-`2^k`
+  box, whereas the loose Manhattan-`2^k` light cone would need `2^(k+1)`); and
+
+These are the elementary distance facts; they do not assert anything about
+`evolve` (the locality statement `step_light_cone` lives in `HashlifeCorrectness`).
+Epic #3846 (Hashlife correctness infrastructure, N2 tight-locality groundwork). -/
+
+/-- Chebyshev (chessboard / L∞) distance between two cells: the larger of the
+    absolute coordinate displacements. -/
+def chebDist (p q : Int × Int) : Nat :=
+  max (Int.natAbs (q.1 - p.1)) (Int.natAbs (q.2 - p.2))
+
+/-- Reflexivity: a cell is at Chebyshev distance 0 from itself. -/
+theorem chebDist_self (p : Int × Int) : chebDist p p = 0 := by
+  unfold chebDist; omega
+
+/-- Symmetry: the Chebyshev distance is invariant under swapping the two cells. -/
+theorem chebDist_comm (p q : Int × Int) : chebDist p q = chebDist q p := by
+  unfold chebDist; omega
+
+/-- Monotonicity in the radius: a larger radius weakly contains the cone. -/
+theorem chebDist_le_trans {t₁ t₂ : Nat} (h : t₁ ≤ t₂) {p q : Int × Int}
+    (hd : chebDist p q ≤ t₁) : chebDist p q ≤ t₂ := hd.trans h
+
+/-- Margin sufficiency: a cell within Chebyshev radius `t` of `p` lies in the
+    margin-`t` box — each coordinate is within `t` of `p`'s coordinate. This is
+    the geometric reason a box margin of `t` (e.g. `padCenter2`'s `2^k` margin
+    at a level advancing `2^k` generations) covers the *tight* Chebyshev-`t`
+    reach, even though that same margin `t` does not cover the *loose*
+    Manhattan-`t` light cone (which reaches `2 * t`). -/
+theorem coord_bound_of_chebDist_le (p q : Int × Int) (t : Nat)
+    (h : chebDist p q ≤ t) :
+    Int.natAbs (q.1 - p.1) ≤ t ∧ Int.natAbs (q.2 - p.2) ≤ t := by
+  unfold chebDist at h
+  omega
+
+/-! ## Chebyshev triangle inequality and cone growth by a Moore step
+
+The foundational metric fact (`chebDist_triangle`) and the **tight-cone growth
+theorem** named by ai-01's N2 greenlight: a cell lies in the Chebyshev-`(t+1)`
+cone of `p` iff one can reach it from the Chebyshev-`t` cone via a single Moore
+neighborhood step. This is the inductive engine of the tight-locality statement
+(after one B3/S23 generation, reach expands by exactly one Moore shell), and the
+reason the tight Chebyshev reach grows linearly with `t` rather than as `2*t`.
+-/
+
+/-- Triangle inequality for the Chebyshev distance. -/
+theorem chebDist_triangle (p q r : Int × Int) :
+    chebDist p q ≤ chebDist p r + chebDist r q := by
+  unfold chebDist
+  omega
+
+/-- The Chebyshev cone grows by exactly one Moore step: `q` is within Chebyshev
+    radius `t+1` of `p` iff there is a cell `r` within Chebyshev radius `t` of `p`
+    that is a Moore neighbor of `q` (Chebyshev radius `≤ 1`). Forward direction
+    steps from `q` toward `p` by one unit in each nonzero coordinate; backward
+    direction is the triangle inequality. This is the additive-growth lemma that
+    underpins the tight `t`-step locality (one Moore shell per generation). -/
+theorem chebDist_le_succ_iff (p q : Int × Int) (t : Nat) :
+    chebDist p q ≤ t + 1 ↔
+      ∃ r : Int × Int, chebDist p r ≤ t ∧ chebDist r q ≤ 1 := by
+  constructor
+  · -- forward: step from `q` toward `p` by one unit in each nonzero coordinate
+    intro h
+    unfold chebDist at h
+    refine ⟨(q.1 - if q.1 - p.1 = 0 then 0 else if 0 < q.1 - p.1 then 1 else -1,
+             q.2 - if q.2 - p.2 = 0 then 0 else if 0 < q.2 - p.2 then 1 else -1), ?_, ?_⟩
+    all_goals unfold chebDist; omega
+  · -- backward: triangle inequality
+    rintro ⟨r, hr, hq⟩
+    exact (chebDist_triangle p q r).trans (add_le_add hr hq)
+
+/-- The tight Chebyshev cone is nested in its successor: radius `t` ⊆ radius
+    `t+1`. Corollary of `chebDist_le_succ_iff` (or directly `Nat.le_succ`). -/
+theorem chebDist_le_succ (p q : Int × Int) (t : Nat) (h : chebDist p q ≤ t) :
+    chebDist p q ≤ t + 1 := h.trans (Nat.le_succ t)
+
+/-! ## W3 tight cone-in-domain: Chebyshev-tight locality stays in the domain
+
+The tight Chebyshev analog of `window_cone_in_domain` (the **S2** closed lemma in
+`HashlifeCorrectness`, which used the *loose* Manhattan cone `manhattan p q ≤ 2^k`).
+For a point `p` in the centered window `[2^k, 2^k + 2^(k+1))²` (the region a
+Hashlife result covers), any cell `q` within **Chebyshev** radius `2^k` — the
+*tight* GoL speed-of-light cone, strictly smaller than the loose Manhattan-`2^k`
+cone (a Chebyshev-`t` ball fits in a Manhattan-`2t` ball, not the reverse) — stays
+inside the full MacroCell domain `[0, 2^(k+2))²`.
+
+This is the missing tight locality bound for the N2 redesign arc (EPIC #3846, W3).
+The loose `window_cone_in_domain` demanded Manhattan-`2^k` agreement, over-
+approximating the real reach by a factor of 2; the tight version demands only
+Chebyshev-`2^k` agreement (the actual one-Moore-shell-per-generation reach
+formalized by `evolve_reach_chebyshev`). Because Chebyshev distance bounds each
+coordinate directly, the proof is **simpler** than the loose analog: it consumes
+`coord_bound_of_chebDist_le` (per-coordinate bound immediately) rather than
+bridging through `manhattan_deviation`. No `hashlifeResultAux`, no whnf wall —
+pure `Int` window arithmetic. Sorry-free.
+
+This lemma lives in `ConeGeometry` (not `LightCone`) so that the P5
+`p5_large_n_jump` path in `HashlifeCorrectness` can consume it directly via
+`import Conway.Life.ConeGeometry`, without the circular reverse-import that would
+arise if it stayed in `LightCone` (which imports `HashlifeCorrectness`). The
+proof substance is independent of the P4 mono-verrou. -/
+theorem window_cheb_cone_in_domain (k : Nat) (p q : Int × Int)
+    (hp1_lo : (2^k : Int) ≤ p.1) (hp1_hi : p.1 < 2^k + 2^(k+1))
+    (hp2_lo : (2^k : Int) ≤ p.2) (hp2_hi : p.2 < 2^k + 2^(k+1))
+    (hc : chebDist p q ≤ 2^k) :
+    (0 : Int) ≤ q.1 ∧ q.1 < 2^(k+2) ∧ (0 : Int) ≤ q.2 ∧ q.2 < 2^(k+2) := by
+  -- Chebyshev radius bounds each coordinate directly (no manhattan bridge).
+  obtain ⟨hq1, hq2⟩ := coord_bound_of_chebDist_le p q (2^k) hc
+  -- `coord_bound_of_chebDist_le` types its bounds as `Nat` (`Int.natAbs ... ≤
+  -- 2^k`); the window hypotheses below use native-Int `(2^k : Int)` (`HPower`).
+  -- Bridge the Nat-bound to an `Int.abs`-typed bound (mirroring the loose
+  -- analog's `manhattan_deviation` output, which is already Int-typed), then
+  -- unify the atoms via `Nat.cast_pow`.
+  have hk_pow : (↑((2:Nat)^k) : Int) = (2^k : Int) := Nat.cast_pow 2 k
+  have hq1' : |q.1 - p.1| ≤ (2^k : Int) := by
+    rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq1
+  have hq2' : |q.2 - p.2| ≤ (2^k : Int) := by
+    rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq2
+  -- Power facts in pure `Nat`, lifted to `Int` (linarith reads the atoms).
+  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := by
+    have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
+      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
+    exact_mod_cast h
+  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := by
+    have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
+      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
+    have h2 : (2 : Nat)^(k+2) = 2 * (2 : Nat)^(k+1) := by
+      rw [show (k + 2 : Nat) = Nat.succ (k + 1) from rfl, Nat.pow_succ, Nat.mul_comm]
+    have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
+    exact_mod_cast h
+  -- `Int.abs` bound unpacked into a two-sided `Int` clamp on `q.i - p.i`.
+  obtain ⟨hq1lo, hq1hi⟩ := abs_le.mp hq1'
+  obtain ⟨hq2lo, hq2hi⟩ := abs_le.mp hq2'
+  -- Rewrite every power occurrence into a multiple of the single atom `2^k`.
+  rw [hpe1] at hp1_hi hp2_hi
+  rw [hpe2]
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> linarith
+
+end Life
+end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -69,6 +69,16 @@ import Conway.Life
 import Conway.Life.GridCanonical
 import Conway.Life.MacroCell
 import Conway.Life.Hashlife
+-- EPIC #3846 cycle-break (ai-01 design-gate msg-...338lw8, 2026-07-11): the pure
+-- Chebyshev geometry (`chebDist` family + `window_cheb_cone_in_domain`) now lives
+-- in `Conway.Life.ConeGeometry` (Mathlib only). This import makes
+-- `window_cheb_cone_in_domain` referenceable from the P5 `p5_large_n_jump` path
+-- WITHOUT the circular reverse-import that would arise if it stayed in
+-- `LightCone` (which imports this module). The proof-body wire (closing the
+-- `p5_large_n_jump` sorry via the tight cone bound) is the next N2 step; this
+-- import is the cycle-break enabler, cycle-free because `ConeGeometry` imports
+-- Mathlib only.
+import Conway.Life.ConeGeometry
 
 namespace Conway
 namespace Life

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/LightCone.lean
@@ -2,15 +2,17 @@
 Copyright (c) 2026 CoursIA. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
-## Light-cone geometry (Conway Game of Life)
+## Light-cone geometry coupled to Game-of-Life semantics (Conway GoL)
 
-Sorry-free geometric lemmas about `manhattan` and `lightCone` (defined in
-`Conway.Life.HashlifeCorrectness`). These bridge facts make the light-cone
-machinery composable: they are NOT new locality results (the fundamental
-locality theorem `step_light_cone` is proven in `HashlifeCorrectness`), but
-the elementary set/arithmetic relationships between cones of different radii
-and between Manhattan and per-coordinate bounds, which future correctness
-proofs chain across the `evolve` recursion.
+Sorry-free bridge lemmas that connect the **pure Chebyshev lattice geometry**
+(defined in the sibling base module `Conway.Life.ConeGeometry`) to the
+Game-of-Life semantics — `evolve`, `isAlive`, `candidates`, `mooreNeighbors`,
+and the `manhattan` / `lightCone` machinery (defined in
+`Conway.Life.HashlifeCorrectness`). These are NOT new locality results (the
+fundamental locality theorem `step_light_cone` is proven in
+`HashlifeCorrectness`), but the elementary set/arithmetic relationships between
+cones of different radii, between Manhattan and per-coordinate bounds, and the
+tight Chebyshev reach wired into the B3/S23 `evolve` recursion.
 
 The central fact formalized here is the **Game-of-Life speed-of-light
 principle** (commented in `HashlifeCorrectness` P2 §, L497-504, but not
@@ -22,10 +24,23 @@ This containment is exactly why `step_light_cone` demands agreement on
 `lightCone p (2 * t)` — that radius is the *tight* GoL influence bound, not a
 loose over-approximation.
 
+**Module split (EPIC #3846 cycle-break, ai-01 design-gate msg-...338lw8,
+2026-07-11).** The pure Chebyshev facts that depend on no GoL semantics —
+`chebDist` and its metric lemmas, plus the tight `window_cheb_cone_in_domain`
+cone-in-domain bound — now live in `ConeGeometry` (Mathlib only). They were
+extracted out of this module so that `HashlifeCorrectness` can import
+`ConeGeometry` to reach `window_cheb_cone_in_domain` for the P5
+`p5_large_n_jump` wire WITHOUT the circular reverse-import (this module imports
+`HashlifeCorrectness`). This module keeps everything that couples to
+`evolve` / `lightCone` / `manhattan` / `mooreNeighbors` / `Grid`. The pure
+facts are re-exported here by the `import Conway.Life.ConeGeometry` below, so
+all existing call sites resolve unchanged.
+
 Epic #3846 (Hashlife correctness infrastructure). All `sorry`s eliminated at
 creation.
 -/
 
+import Conway.Life.ConeGeometry
 import Conway.Life.HashlifeCorrectness
 
 namespace Conway
@@ -117,34 +132,14 @@ These are the elementary distance facts; they do not yet assert anything about
 `evolve` (the locality statement `step_light_cone` lives in `HashlifeCorrectness`).
 Epic #3846 (Hashlife correctness infrastructure, N2 tight-locality groundwork). -/
 
-/-- Chebyshev (chessboard / L∞) distance between two cells: the larger of the
-    absolute coordinate displacements. -/
-def chebDist (p q : Int × Int) : Nat :=
-  max (Int.natAbs (q.1 - p.1)) (Int.natAbs (q.2 - p.2))
-
-/-- Reflexivity: a cell is at Chebyshev distance 0 from itself. -/
-theorem chebDist_self (p : Int × Int) : chebDist p p = 0 := by
-  unfold chebDist; omega
-
-/-- Symmetry: the Chebyshev distance is invariant under swapping the two cells. -/
-theorem chebDist_comm (p q : Int × Int) : chebDist p q = chebDist q p := by
-  unfold chebDist; omega
-
-/-- Monotonicity in the radius: a larger radius weakly contains the cone. -/
-theorem chebDist_le_trans {t₁ t₂ : Nat} (h : t₁ ≤ t₂) {p q : Int × Int}
-    (hd : chebDist p q ≤ t₁) : chebDist p q ≤ t₂ := hd.trans h
-
-/-- Margin sufficiency: a cell within Chebyshev radius `t` of `p` lies in the
-    margin-`t` box — each coordinate is within `t` of `p`'s coordinate. This is
-    the geometric reason a box margin of `t` (e.g. `padCenter2`'s `2^k` margin
-    at a level advancing `2^k` generations) covers the *tight* Chebyshev-`t`
-    reach, even though that same margin `t` does not cover the *loose*
-    Manhattan-`t` light cone (which reaches `2 * t`). -/
-theorem coord_bound_of_chebDist_le (p q : Int × Int) (t : Nat)
-    (h : chebDist p q ≤ t) :
-    Int.natAbs (q.1 - p.1) ≤ t ∧ Int.natAbs (q.2 - p.2) ≤ t := by
-  unfold chebDist at h
-  omega
+/- The pure Chebyshev metric facts — `chebDist`, `chebDist_self`, `chebDist_comm`,
+   `chebDist_le_trans`, `coord_bound_of_chebDist_le` (margin sufficiency) — now
+   live in `Conway.Life.ConeGeometry` (the Mathlib-only base, extracted for the
+   EPIC #3846 cycle-break). They are in scope here via `import
+   Conway.Life.ConeGeometry` above, under the same `Conway.Life.*` names, so the
+   GoL-coupled bridges below resolve them unchanged. The first bridge,
+   `manhattan_le_of_chebDist_le`, ties the tight Chebyshev metric to the loose
+   Manhattan `manhattan` (defined in `HashlifeCorrectness`). -/
 
 /-- Tight ⊆ loose (distance form): Chebyshev radius `t` is bounded by Manhattan
     radius `2 * t`, because each coordinate displacement is `≤ t` and the
@@ -162,48 +157,12 @@ theorem mem_lightCone_of_chebDist_le (p q : Int × Int) (t : Nat)
     (h : chebDist p q ≤ t) : q ∈ lightCone p (2 * t) :=
   mem_lightCone_of_manhattan_le p q (2 * t) (manhattan_le_of_chebDist_le p q t h)
 
-/-! ## Chebyshev triangle inequality and cone growth by a Moore step
-
-The foundational metric fact (`chebDist_triangle`) and the **tight-cone growth
-theorem** named by ai-01's N2 greenlight: a cell lies in the Chebyshev-`(t+1)`
-cone of `p` iff one can reach it from the Chebyshev-`t` cone via a single Moore
-neighborhood step. This is the inductive engine of the tight-locality statement
-(after one B3/S23 generation, reach expands by exactly one Moore shell), and the
-reason the tight Chebyshev reach grows linearly with `t` rather than as `2*t`.
--/
-
-/-- Triangle inequality for the Chebyshev distance. -/
-theorem chebDist_triangle (p q r : Int × Int) :
-    chebDist p q ≤ chebDist p r + chebDist r q := by
-  unfold chebDist
-  omega
-
-/-- The Chebyshev cone grows by exactly one Moore step: `q` is within Chebyshev
-    radius `t+1` of `p` iff there is a cell `r` within Chebyshev radius `t` of `p`
-    that is a Moore neighbor of `q` (Chebyshev radius `≤ 1`). Forward direction
-    steps from `q` toward `p` by one unit in each nonzero coordinate; backward
-    direction is the triangle inequality. This is the additive-growth lemma that
-    underpins the tight `t`-step locality (one Moore shell per generation). -/
-theorem chebDist_le_succ_iff (p q : Int × Int) (t : Nat) :
-    chebDist p q ≤ t + 1 ↔
-      ∃ r : Int × Int, chebDist p r ≤ t ∧ chebDist r q ≤ 1 := by
-  constructor
-  · -- forward: step from `q` toward `p` by one unit in each nonzero coordinate
-    intro h
-    unfold chebDist at h
-    refine ⟨(q.1 - if q.1 - p.1 = 0 then 0 else if 0 < q.1 - p.1 then 1 else -1,
-             q.2 - if q.2 - p.2 = 0 then 0 else if 0 < q.2 - p.2 then 1 else -1), ?_, ?_⟩
-    all_goals unfold chebDist; omega
-  · -- backward: triangle inequality
-    rintro ⟨r, hr, hq⟩
-    exact (chebDist_triangle p q r).trans (add_le_add hr hq)
-
-/-- The tight Chebyshev cone is nested in its successor: radius `t` ⊆ radius
-    `t+1`. Corollary of `chebDist_le_succ_iff` (or directly `Nat.le_succ`). -/
-theorem chebDist_le_succ (p q : Int × Int) (t : Nat) (h : chebDist p q ≤ t) :
-    chebDist p q ≤ t + 1 := h.trans (Nat.le_succ t)
-
 /-! ## Tight Chebyshev reach — the Game-of-Life speed of light
+
+The reach theorem below composes the pure metric facts `chebDist_triangle`,
+`chebDist_le_succ_iff`, and `chebDist_le_succ` (now in `Conway.Life.ConeGeometry`)
+with the B3/S23 `evolve` semantics, so it stays in this module (which imports
+both `ConeGeometry` and `HashlifeCorrectness`).
 
 The fundamental TIGHT locality result, stated as a *reach* theorem: after `t`
 generations, a cell alive at `evolve t g` lies within Chebyshev distance `t` of
@@ -347,65 +306,12 @@ theorem evolve_reach_within_padCenter2_margin (k : Nat) (hk : 1 ≤ k)
   have hmargin := padCenter2_margin_ge_jumpReach k hk
   exact ⟨p, hp, hb1.trans hmargin, hb2.trans hmargin⟩
 
-/-! ## W3 tight cone-in-domain: Chebyshev-tight locality stays in the domain
+/-! ## W3 tight cone-in-domain — migrated to `Conway.Life.ConeGeometry`
 
-The tight Chebyshev analog of `window_cone_in_domain` (the **S2** closed lemma in
-`HashlifeCorrectness`, which used the *loose* Manhattan cone `manhattan p q ≤ 2^k`).
-For a point `p` in the centered window `[2^k, 2^k + 2^(k+1))²` (the region a
-Hashlife result covers), any cell `q` within **Chebyshev** radius `2^k` — the
-*tight* GoL speed-of-light cone, strictly smaller than the loose Manhattan-`2^k`
-cone (a Chebyshev-`t` ball fits in a Manhattan-`2t` ball, not the reverse) — stays
-inside the full MacroCell domain `[0, 2^(k+2))²`.
-
-This is the missing tight locality bound for the N2 redesign arc (EPIC #3846, W3).
-The loose `window_cone_in_domain` demanded Manhattan-`2^k` agreement, over-
-approximating the real reach by a factor of 2; the tight version demands only
-Chebyshev-`2^k` agreement (the actual one-Moore-shell-per-generation reach
-formalized by `evolve_reach_chebyshev`). Because Chebyshev distance bounds each
-coordinate directly, the proof is **simpler** than the loose analog: it consumes
-`coord_bound_of_chebDist_le` (per-coordinate bound immediately) rather than
-bridging through `manhattan_deviation`. No `hashlifeResultAux`, no whnf wall —
-pure `Int` window arithmetic. Sorry-free.
-
-Wiring note (architectural): `LightCone` imports `HashlifeCorrectness`, so the
-reverse import needed for the P5 `p5_large_n_jump` path to consume this lemma is
-**circular** as-is. The lemma is stated over plain `Int × Int` precisely so it can
-be extracted to a shared geometry module when the P5 wire is done (a dependency-
-cycle break = architectural step, ai-01's call). The proof substance is delivered
-here, independent of the P4 mono-verrou. -/
-theorem window_cheb_cone_in_domain (k : Nat) (p q : Int × Int)
-    (hp1_lo : (2^k : Int) ≤ p.1) (hp1_hi : p.1 < 2^k + 2^(k+1))
-    (hp2_lo : (2^k : Int) ≤ p.2) (hp2_hi : p.2 < 2^k + 2^(k+1))
-    (hc : chebDist p q ≤ 2^k) :
-    (0 : Int) ≤ q.1 ∧ q.1 < 2^(k+2) ∧ (0 : Int) ≤ q.2 ∧ q.2 < 2^(k+2) := by
-  -- Chebyshev radius bounds each coordinate directly (no manhattan bridge).
-  obtain ⟨hq1, hq2⟩ := coord_bound_of_chebDist_le p q (2^k) hc
-  -- `coord_bound_of_chebDist_le` types its bounds as `Nat` (`Int.natAbs ... ≤
-  -- 2^k`); the window hypotheses below use native-Int `(2^k : Int)` (`HPower`).
-  -- Bridge the Nat-bound to an `Int.abs`-typed bound (mirroring the loose
-  -- analog's `manhattan_deviation` output, which is already Int-typed), then
-  -- unify the atoms via `Nat.cast_pow`.
-  have hk_pow : (↑((2:Nat)^k) : Int) = (2^k : Int) := Nat.cast_pow 2 k
-  have hq1' : |q.1 - p.1| ≤ (2^k : Int) := by
-    rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq1
-  have hq2' : |q.2 - p.2| ≤ (2^k : Int) := by
-    rw [hk_pow.symm, Int.abs_eq_natAbs]; exact_mod_cast hq2
-  -- Power facts in pure `Nat`, lifted to `Int` (linarith reads the atoms).
-  have hpe1 : (2^(k+1) : Int) = 2 * (2^k : Int) := by
-    have h : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
-      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
-    exact_mod_cast h
-  have hpe2 : (2^(k+2) : Int) = 4 * (2^k : Int) := by
-    have h1 : (2 : Nat)^(k+1) = 2 * (2 : Nat)^k := by
-      rw [show (k + 1 : Nat) = Nat.succ k from rfl, Nat.pow_succ, Nat.mul_comm]
-    have h2 : (2 : Nat)^(k+2) = 2 * (2 : Nat)^(k+1) := by
-      rw [show (k + 2 : Nat) = Nat.succ (k + 1) from rfl, Nat.pow_succ, Nat.mul_comm]
-    have h : (2 : Nat)^(k+2) = 4 * (2 : Nat)^k := by rw [h2, h1]; ring
-    exact_mod_cast h
-  -- `Int.abs` bound unpacked into a two-sided `Int` clamp on `q.i - p.i`.
-  obtain ⟨hq1lo, hq1hi⟩ := abs_le.mp hq1'
-  obtain ⟨hq2lo, hq2hi⟩ := abs_le.mp hq2'
-  -- Rewrite every power occurrence into a multiple of the single atom `2^k`.
-  rw [hpe1] at hp1_hi hp2_hi
-  rw [hpe2]
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> linarith
+The tight Chebyshev cone-in-domain lemma `window_cheb_cone_in_domain` (W3,
+EPIC #3846) was extracted to `Conway.Life.ConeGeometry` — the Mathlib-only base
+module — as the dependency-cycle break that lets `HashlifeCorrectness` reach it
+for the P5 `p5_large_n_jump` wire without the circular reverse-import this module
+would otherwise impose (it imports `HashlifeCorrectness`). It is in scope here
+unchanged via the `import Conway.Life.ConeGeometry` above. See that module for
+the statement, proof, and the architectural wiring note. -/


### PR DESCRIPTION
Extract the pure-geometry base `Conway.Life.ConeGeometry` (Mathlib only, no Game-of-Life semantics) out of `LightCone`, breaking the dependency cycle that blocked the P5 `p5_large_n_jump` wire. Implements ai-01's design-gate decision (msg-...338lw8, 2026-07-11).

## Architecture

- **`ConeGeometry`** imports **Mathlib ONLY**. Holds the lattice geometry over `Int × Int` referencing no evolve/MacroCell/Grid-live concept: `chebDist` (def), `chebDist_self`, `chebDist_comm`, `chebDist_le_trans`, `coord_bound_of_chebDist_le` (margin sufficiency), `chebDist_triangle`, `chebDist_le_succ_iff`, `chebDist_le_succ`, and the W3 tight `window_cheb_cone_in_domain`.
- **`LightCone`** keeps everything coupling to `evolve`/`lightCone`/`manhattan`/`mooreNeighbors`/`Grid` (`evolve_reach_chebyshev`, the N2 margin capstone, the manhattan/lightCone bridges). It imports `ConeGeometry` + `HashlifeCorrectness`.
- **`HashlifeCorrectness`** imports `ConeGeometry` → can now reach `window_cheb_cone_in_domain` for the P5 wire WITHOUT the circular reverse-import (LightCone imports HashlifeCorrectness). **Cycle broken.**

All declarations keep their `Conway.Life.*` qualified names, so every existing call site resolves unchanged — only the defining module moves.

## Split criterion (firsthand, per ai-01 gate)

A declaration migrates to `ConeGeometry` iff its proof references only `Int × Int`, `Int.natAbs`, `max`, omega/linarith, and Mathlib arithmetic — i.e. NOT `evolve`/`MacroCell`/`Grid`-live concepts. `manhattan_le_of_chebDist_le` / `mem_lightCone_of_chebDist_le` / `chebDist_le_one_of_moore` / `evolve_reach_chebyshev` / `evolve_reach_within_padCenter2_margin` stay in `LightCone` (they reference `manhattan`/`lightCone`/`mooreNeighbors`/`evolve`).

## §B Lean forensics

| file | sorry before | sorry after | note |
|------|--------------|-------------|------|
| `ConeGeometry.lean` | — | **0** | new module, sorry-free |
| `LightCone.lean` | 0 | **0** | migrated 9 decls out (now in ConeGeometry) |
| `HashlifeCorrectness.lean` | 2 | **2** | only the import block added; L2707 `p4_succ_membership` + L3070 `p5_large_n_jump` unchanged |

- **`grep -c sorry`** (strip-docstring method): ConeGeometry 0, LightCone 0, HashlifeCorrectness 2 (unchanged). No new sorries anywhere.
- **`lake build Conway` SUCCESS** — 8519 modules, EXIT 0:
  - ✔ `Conway.Life.ConeGeometry` built (51s, new module)
  - ✔ `Conway.Life.HashlifeCorrectness` rebuilt (82s, with the new `import Conway.Life.ConeGeometry` — proves cycle-free)
  - ✔ `Conway.Life.LightCone` built (17s)
  - ✔ `Conway` root built (15s)
- **CRLF**: 0 CR bytes on all 4 files (`tr -cd '\r' | wc -c`); git stores LF, no churn.
- **Anti-regression §D**: the 2 residual HashlifeCorrectness sorries are untouched (no vacuous close; the p5_large_n_jump sorry body is not edited).

## Acceptance gate (ai-01 msg-...338lw8)

1. ✅ `ConeGeometry` imports Mathlib only (no proof-body module).
2. ✅ LightCone + HashlifeCorrectness both import ConeGeometry; no reverse cycle (HashlifeCorrectness ↛ LightCone).
3. ✅ sorry non-increasing: ConeGeometry 0, LightCone 0, HashlifeCorrectness 2 unchanged.
4. ✅ `lake build Conway` SUCCESS local.
5. ✅ `window_cheb_cone_in_domain` referenceable from HashlifeCorrectness (imported, compiled clean = cycle-free symbol in scope).

## Scope / next step

This PR is the **cycle-break enabler only**. The proof-body wire (closing the `p5_large_n_jump` sorry via the tight cone bound, the "L3002 threading" step) is the next N2 PR — left out here to keep this PR atomic and avoid touching the P5 sorry body (anti-regression §D).

See #3846 (sub-step of the N2 redesign arc; not closing the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)