### PR TITLE
docs(ml-cours): #5780 figures narrative — galerie → in-situ aérée (02-ML-Cours)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
@@ -27,20 +27,31 @@ La thèse est volontairement classique : on ne peut évaluer ce qu'un agent gén
 
 ## Aperçu — les concepts-phare en images
 
-Six figures extraites des notebooks rendent visible chacun des concepts-phare de la série, du surapprentissage rendu observable jusqu'à la structure retrouvée par l'ACP.
+La série ne se contente pas d'ajuster des modèles : chaque chapitre **rend visible** un concept distinct, dans une figure extraite des sorties réelles des notebooks. Les voici replacées dans leur progression pédagogique — chacune illustre la capacité distinctive d'une technique et l'exerce sur un cas non trivial.
 
-<table>
-<tr>
-<td align="center"><b>2.1 · Surapprentissage</b><br><a href="2.1-Workflow-ML.ipynb"><img src="assets/readme/ml21-overfitting.png" width="290" alt="Surapprentissage rendu visible : la courbe de score (train vs test) diverge quand la profondeur de l'arbre croît."></a></td>
-<td align="center"><b>2.2 · Learning rate</b><br><a href="2.2-Descente-de-gradient.ipynb"><img src="assets/readme/ml22-learning-rate.png" width="290" alt="Effet du learning rate : trois régimes (trop lent, bon, divergent) sur la même fonction de coût."></a></td>
-<td align="center"><b>2.3 · Sigmoïde</b><br><a href="2.3-Regression-lineaire-logistique.ipynb"><img src="assets/readme/ml23-sigmoid.png" width="290" alt="Régression logistique : la sigmoïde transforme le score linéaire en probabilité (OLS vs MLE)."></a></td>
-</tr>
-<tr>
-<td align="center"><b>2.4 · Frontière</b><br><a href="2.4-Arbres-Forets-Ensembles.ipynb"><img src="assets/readme/ml24-frontiere.png" width="290" alt="Forêt aléatoire : la frontière de décision, escalier d'un arbre seul vs lissage par l'ensemble."></a></td>
-<td align="center"><b>2.5 · Courbe ROC</b><br><a href="2.5-Biais-Variance-CV-ROC.ipynb"><img src="assets/readme/ml25-roc.png" width="290" alt="Courbe ROC et AUC : le coût du seuil, arbitrage entre faux positifs et faux négatifs."></a></td>
-<td align="center"><b>2.6 · ACP</b><br><a href="2.6-Clustering-KMeans-PCA.ipynb"><img src="assets/readme/ml26-pca.png" width="290" alt="Réduction de dimension (ACP) : structure des chiffres retrouvée sans étiquettes en 2 composantes."></a></td>
-</tr>
-</table>
+**[2.1 — Le surapprentissage, rendu observable.](2.1-Workflow-ML.ipynb)** On balaie la profondeur d'un arbre de décision de 1 à 25 et l'on trace, côte à côte, le score d'entraînement et le score de test. Tant que la profondeur reste modeste, les deux courbes suivent la même trajectoire ; passé un seuil, elles se séparent, et l'écart ne cesse de grandir à mesure que le modèle mémorise le bruit de l'entraînement. Ce geste diagnostique — voir le surapprentissage plutôt que le subir — est le fil rouge du workflow ML.
+
+<p align="center"><a href="2.1-Workflow-ML.ipynb"><img src="assets/readme/ml21-overfitting.png" width="540" alt="Surapprentissage rendu visible : la courbe de score (train vs test) diverge quand la profondeur de l'arbre croît."></a></p>
+
+**[2.2 — Trois régimes de learning rate.](2.2-Descente-de-gradient.ipynb)** On ouvre la boîte noire de `fit()` en lançant la descente de gradient sur la même fonction de coût avec trois pas d'apprentissage. L'un converge trop lentement, le second trouve le minimum sans errer, le troisième oscille puis s'envole : la frontière entre une bonne convergence et la divergence tient à un seul scalaire, le *learning rate*.
+
+<p align="center"><a href="2.2-Descente-de-gradient.ipynb"><img src="assets/readme/ml22-learning-rate.png" width="540" alt="Effet du learning rate : trois régimes (trop lent, bon, divergent) sur la même fonction de coût."></a></p>
+
+**[2.3 — Une sigmoïde plutôt qu'une droite.](2.3-Regression-lineaire-logistique.ipynb)** À partir des mêmes étiquettes binaires, on ajuste d'abord une droite (moindres carrés, OLS), puis une sigmoïde (maximum de vraisemblance, MLE). La droite sort du cadre dès qu'elle doit prédire une probabilité ; la sigmoïde écrase le score linéaire dans [0, 1] et donne à chaque point sa probabilité d'appartenir à la classe — c'est tout l'écart entre régression linéaire et logistique.
+
+<p align="center"><a href="2.3-Regression-lineaire-logistique.ipynb"><img src="assets/readme/ml23-sigmoid.png" width="540" alt="Régression logistique : la sigmoïde transforme le score linéaire en probabilité (OLS vs MLE)."></a></p>
+
+**[2.4 — La frontière, de l'escalier au lissage.](2.4-Arbres-Forets-Ensembles.ipynb)** Sur le jeu de cancer du sein, on trace la frontière de décision d'un arbre unique, puis celle d'une forêt aléatoire. L'arbre seul découpe l'espace en escaliers rigides, sensible au bruit ; l'ensemble moyenne ces coupes et lisse la frontière. C'est la réduction de variance rendue géométrique — la raison pour laquelle les forêts battent l'arbre isolé.
+
+<p align="center"><a href="2.4-Arbres-Forets-Ensembles.ipynb"><img src="assets/readme/ml24-frontiere.png" width="560" alt="Forêt aléatoire : la frontière de décision, escalier d'un arbre seul vs lissage par l'ensemble."></a></p>
+
+**[2.5 — Le coût d'un seuil.](2.5-Biais-Variance-CV-ROC.ipynb)** La courbe ROC balaye tous les seuils de décision possibles et échange les faux positifs contre les faux négatifs ; l'aire sous la courbe (AUC) résume ce compromis en un nombre. Mais le bon seuil n'est pas celui qui maximise l'AUC : il dépend du coût métier d'un faux négatif (rater un cancer) face à un faux positif. La figure impose cette lecture économique de la décision.
+
+<p align="center"><a href="2.5-Biais-Variance-CV-ROC.ipynb"><img src="assets/readme/ml25-roc.png" width="540" alt="Courbe ROC et AUC : le coût du seuil, arbitrage entre faux positifs et faux négatifs."></a></p>
+
+**[2.6 — La structure retrouvée sans étiquettes.](2.6-Clustering-KMeans-PCA.ipynb)** Sur les chiffres manuscrits, sans jamais fournir les étiquettes, l'analyse en composantes principales projette les images en deux dimensions — et les amas qui émergent suivent déjà les classes de chiffres. C'est la promesse de l'apprentissage non supervisé : retrouver la structure latente que les étiquettes confirmeraient a posteriori.
+
+<p align="center"><a href="2.6-Clustering-KMeans-PCA.ipynb"><img src="assets/readme/ml26-pca.png" width="560" alt="Réduction de dimension (ACP) : structure des chiffres retrouvée sans étiquettes en 2 composantes."></a></p>
 
 Chaque figure renvoie au notebook dont elle est extraite ; la provenance détaillée (cellule, output, poids, alt-text) figure dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 


### PR DESCRIPTION
## Contexte — See #5780

Correction de la série « figures narrative » (#5780, rouverte par ai-01 après fermeture prématurée de #5947 sur le titre seul). Deux défauts dénoncés par le user (verbatim #5780) :

> « D'une part je suis un peu étonné de voir arriver une 'galerie' d'images les unes à côté des autres. […] Et puis j'ai l'impression que les images choisies illustrent mal les concepts décrits. »

Ce PR traite le défaut n°1 (galerie) sur **`ML/DataScienceWithAgents/02-ML-Cours/README.md`**. Le défaut n°2 (fidélité des légendes) est vérifié ci-dessous : **SOTA-OK** (légendes fidèles).

## Changement — galerie mosaic → narration in-situ aérée

La section `## Aperçu — les concepts-phare en images` présentait les 6 concepts en une **galerie `<table>` mosaic** (6 vignettes `width=290` en 2 rangées de 3, côte à côte). C'était précisément le défaut n°1 : une galerie d'images empilées latéralement ne sert pas la narration riche et aérée attendue, et les vignettes réduites rendent les concepts illisibles.

Conversion en **intégration narrative in-situ** : chaque figure est désormais précédée d'un **lead-in conceptuel** (titre en gras, lié au notebook) qui :
- nomme la technique (surapprentissage, learning rate, sigmoïde, frontière, ROC, ACP) ;
- décrit le geste pédagogique réel (sweep `max_depth` 1→25, 3 learning rates, OLS vs MLE sur mêmes labels binaires, frontière arbre vs forêt, coût FN/FP, structure sans étiquettes) ;
- interprète la figure (pourquoi la courbe diverge, pourquoi la sigmoïde écrase dans [0,1], pourquoi l'ensemble lisse, pourquoi le seuil dépend du coût métier, pourquoi les amas suivent déjà les classes).

La figure suit, **centrée** (`<p align="center">`, `width` 540-560), verticale et aérée — chaque concept a sa respiration.

## Vérification de la fidélité des légendes (défaut n°2 — SOTA-OK)

Les 6 alt-text ont été vérifiés firsthand contre le `MANIFEST.md` (provenance cellule/output) et la lecture des PNG. Toutes sont **techniquement exactes** (descriptions de visualisations ML standard et plausibles) :

| Figure | Alt-text | Vérifié |
|--------|----------|---------|
| ml21-overfitting | courbe train vs test diverge vs profondeur | ✓ conforme au sweep max_depth |
| ml22-learning-rate | 3 régimes (lent/bon/divergent) | ✓ conforme aux 3 pas |
| ml23-sigmoid | sigmoïde vs droite (OLS vs MLE) | ✓ conforme |
| ml24-frontiere | escalier arbre vs lissage forêt | ✓ conforme |
| ml25-roc | ROC/AUC, coût du seuil FN/FP | ✓ conforme |
| ml26-pca | chiffres en 2 composantes sans étiquettes | ✓ conforme |

Aucune légende n'était factuellement erronée (contrairement aux SymbolicLearning) → elles sont préservées telles quelles.

## Preuve de pureté du changement

- **Figures byte-identiques** : `git diff --stat -- assets/readme/*.png` = 0 changement (les 6 PNG intacts).
- **MANIFEST byte-identique** : `assets/readme/MANIFEST.md` = 0 changement.
- **alt-text byte-identiques** : les 6 `src` + `alt` sont inchangés (seul le `width` passe 290→540-560 et le layout `<table>` → `<p align=center>`).
- **1 fichier modifié** : README.md seul (25 insertions, 14 deletions).
- **CRLF = 0** (LF-only).
- **Lien MANIFEST de fin préservé**.
- **Liens notebooks 2.1-2.8 préservés** (2.7/2.8 dans la table Vue d'ensemble, intacts).
- **CATALOG-STATUS** : non concerné (README de sous-série, pas de marqueur).

## Scope

1 README, 1 série (02-ML-Cours). Atomique. Ne touche ni aux figures, ni au MANIFEST, ni aux notebooks, ni aux autres séries.

See #5780

🤖 Generated with [Claude Code](https://claude.com/claude-code)