### PR TITLE
feat(hashlife): large-n non-vacuity witnesses for BoxAssezGrandN at n=8 (W1, EPIC #3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -224,6 +224,51 @@ theorem box_assez_grandN_single_cell_3 : box_assez_grandN [(0, 0)] 3 = true := b
 theorem box_assez_grand_single_cell_3_false : box_assez_grand [(0, 0)] 3 = false := by
   native_decide
 
+/-! #### Large-`n` non-vacuity (P5 redesign gate W1, issue #3846)
+
+The `n = 3` witnesses above only exhibit non-vacuity at the exact threshold
+where the fixed frame fails. The P5 large-`n` correctness target is only
+*meaningful* when the padding hypothesis is satisfiable at large `n`: restating
+`hashlife_correct` over `BoxAssezGrandN` (the n-aware frame) is vacuous unless
+`BoxAssezGrandN g n` is realizable for `n ≥ 8`. The `native_decide` witnesses
+below exhibit this concretely at `n = 8` — exactly the regime where the
+fixed-frame `box_assez_grand` is unsatisfiable (`n ≤ 2` cap of
+`boxAssezGrand_nonempty_le_two`) — on the single-cell grid and on the canonical
+`block` / `glider` patterns. Because `gridFrameN n g` pads by `max 2 n ≥ n` on
+every side, every live cell carries margin `≥ n` *by construction*, so
+`box_assez_grandN` holds at any `n` (the constructive universal
+`∀ n, box_assez_grandN [(0,0)] n = true` is the natural next target — it bridges
+through `cellMargin_true_iff` to the four margin bounds discharged by
+`ceilLog2_spec` + `omega`, the exact dual of `boxAssezGrand_nonempty_le_two`;
+slated for a focused cycle, as the `Int`/`Nat`-cast elaboration of the
+`gridFrameN` term needs interactive development). -/
+
+/-- Concrete large-`n` non-vacuity witness (gate W1): `box_assez_grandN` holds at
+    `n = 8` on the single-cell grid — exactly the regime where the fixed-frame
+    `box_assez_grand` is unsatisfiable (`n = 8 > 2`). -/
+theorem box_assez_grandN_single_cell_8 : box_assez_grandN [(0, 0)] 8 = true := by
+  native_decide
+
+/-- Large-`n` non-vacuity on a real still-life: the 2×2 `block` carries margin
+    `≥ 8` on every side under `gridFrameN 8` (padding `max 2 8 = 8`), so the
+    n-aware predicate holds at `n = 8` where `box_assez_grand block 8` cannot
+    (gate W1). -/
+theorem box_assez_grandN_block_8 : box_assez_grandN block 8 = true := by
+  native_decide
+
+/-- Large-`n` non-vacuity on a real spaceship: the `glider` (3×3 bounding box)
+    carries margin `≥ 8` on every side under `gridFrameN 8`, so the n-aware
+    predicate holds at `n = 8` (gate W1). -/
+theorem box_assez_grandN_glider_8 : box_assez_grandN glider 8 = true := by
+  native_decide
+
+/-- Honest contrast at the large-`n` regime: the fixed-`gridFrame` predicate
+    provably *fails* at `n = 8` (the `n ≤ 2` cap of
+    `boxAssezGrand_nonempty_le_two`), confirming the n-aware predicate breaks
+    exactly what the fixed one cannot satisfy. -/
+theorem box_assez_grand_single_cell_8_false : box_assez_grand [(0, 0)] 8 = false := by
+  native_decide
+
 /-! ### Monotonicity of `box_assez_grand` in the padding parameter
 
 A grid that admits `n` cells of margin also admits any smaller amount `m ≤ n`:


### PR DESCRIPTION
## Summary

EPIC #3846 (Hashlife correctness P5 redesign), gate **W1** — large-`n` non-vacuity witnesses for the n-aware padding predicate `box_assez_grandN`.

**Defect (firsthand, G.1):** the central theorem `hashlife_correct (n : Nat) (g : Grid) (h : BoxAssezGrand g n)` is *proven* (via `p5_inductive_step`, closed #5998), but its hypothesis `BoxAssezGrand g n` forces `n ≤ 2` for non-empty grids (`boxAssezGrand_nonempty_le_two`, L358). So `hashlife_correct` is **vacuously true for n > 2** — the P5 large-`n` correctness carries no genuine content unless the n-aware dual `BoxAssezGrandN` (over `gridFrameN`, padding `max 2 n`) is realizable at large `n`. The existing N1 witnesses only exhibit this at the threshold `n = 3` (`box_assez_grandN_single_cell_3`).

**Fix (pure addition, sorry-free):** 4 `native_decide` witnesses proving `box_assez_grandN` holds at **`n = 8`** — exactly the regime where `box_assez_grand` is unsatisfiable — on the single-cell grid **and on real GoL patterns** (`block` still-life, `glider` spaceship), plus the honest fixed-frame contrast:

| Declaration | Statement |
|---|---|
| `box_assez_grandN_single_cell_8` | `box_assez_grandN [(0,0)] 8 = true` |
| `box_assez_grandN_block_8` | `box_assez_grandN block 8 = true` |
| `box_assez_grandN_glider_8` | `box_assez_grandN glider 8 = true` |
| `box_assez_grand_single_cell_8_false` | `box_assez_grand [(0,0)] 8 = false` (contrast) |

Because `gridFrameN n g` pads by `max 2 n ≥ n` on every side, every live cell carries margin `≥ n` by construction, so `box_assez_grandN` holds at any `n`. The block/glider witnesses (not just the single cell) make this meaningful for real patterns.

**Out of scope (documented as next target, no sorry):** the constructive universal `∀ n, box_assez_grandN [(0,0)] n = true` — the exact dual of the unsat cap — bridges through `cellMargin_true_iff` + `ceilLog2_spec` + `omega`, but the `Int`/`Nat`-cast elaboration of the `gridFrameN` term needs interactive development. Slated for a focused cycle. The formal restatement of `hashlife_correct` over `BoxAssezGrandN` awaits the N2 threading (post-#6123 merge).

## §B Lean forensics (lean-merge-discipline)

- **`grep -c sorry` avant/après:** tactic-sorry count **2 → 2** (firsthand strip-docstring method, `.lake` excluded: strip `/- -/` + `--`, pattern `^\s*sorry\s*$|:= by sorry|:= sorry\b|exact sorry|^\s*·\s*sorry`). The 2 residual sorries are unchanged: `p4_succ_membership` + `p5_large_n_jump` (P4-gated, ai-01 turf). **0 sorry added.**
- **Lake build SUCCESS:** `lake build Conway` = **2985 jobs, EXIT 0** (ConeGeometry 51s cold, HashlifeCorrectness rebuilt with the 4 new `native_decide`, LightCone + root downstream clean).
- **Proof integrity:** the 4 additions are `native_decide` (decidability evaluation), 0 axiom/sorry. No existing proof body touched.
- **No prover-Python refactor** (N/A).

## Validation

- **Anti-régression §D:** `git diff --stat` = **+45 insertions, 0 deletions** (pure addition, no proof/sorry modified).
- **CRLF = 0** (authoritative `tr -cd '\r' < file | wc -c`).
- Catalogue byte-identical to `main` (no catalog file touched).
- Rebase-clean vs #6123: this PR touches the `box_assez_grandN` section (~L226); #6123 touches the import block (L71) + new file `ConeGeometry.lean` — no content overlap, line-number shift only.

See #3846 (partial: W1 non-vacuity witnesses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)