### PR TITLE
feat(smt): Z3-Python-08 Ordonnancement (Job-Shop Scheduling) — pyz3 port of C# #11

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -4,7 +4,7 @@
 
 ## Série en quelques mots
 
-L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **7 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée et au pont déclaratif avec la série sœur Z3.Linq (C#).
+L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **8 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée, à l'ordonnancement combinatoire et au pont déclaratif avec la série sœur Z3.Linq (C#).
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs Python souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modélisation de problèmes combinatoires.
 
@@ -53,6 +53,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 | 06 | [Optimisation avancée](Z3-Python-06-Advanced-Optimization.ipynb) | Pareto, objectifs multiples, `Optimize` hiérarchique, MaxSAT | ~40 min | PRODUCTION |
 | 06ᶜˢ | [Optimisation avancée (twin C# .NET)](Z3-Python-06-Advanced-Optimization-Csharp.ipynb) | Parité .NET : `MkOptimize`, `MkMaximize`/`MkMinimize`, front de Pareto, `AssertSoft` (MaxSAT) via `Microsoft.Z3` (NuGet) | ~40 min | PRODUCTION |
 | 07 | [Du style déclaratif LINQ au solveur Z3](Z3-Python-07-Style-Declaratif-Linq.ipynb) | Pont C# Z3.Linq ↔ pyz3 : `assert_and_track`, `unsat_core`, coloration de graphe (Australie) | ~30 min | PRODUCTION |
+| 08 | [Ordonnancement (Job-Shop Scheduling)](Z3-Python-08-Ordonnancement.ipynb) | `Optimize.minimize`, contrainte disjonctive `Or(...)`, makespan minimal, diagramme de Gantt | ~35 min | PRODUCTION |
 
 ### Fil pédagogique
 
@@ -63,6 +64,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 5. **Notebook 05** aborde les quantificateurs (`ForAll`, `Exists`) et la notion de preuve formelle par réfutation (une formule est valide si sa négation est insatisfiable), avec le cas honnête `unknown`
 6. **Notebook 06** explore l'optimisation avancée : contraintes hiérarchiques pondérées, objectifs multiples, front de Pareto et MaxSAT (contraintes souples)
 7. **Notebook 07** fait le pont avec la série sœur C# Z3.Linq : il montre que l'idiome déclaratif LINQ (`where`/`select`) et l'API impérative pyz3 (`s.add`) expriment la même intention, puis exploite le noyau d'insatisfiabilité (`unsat_core`) et la coloration de graphe (carte d'Australie) pour révéler où le déclaratif surpasse l'impératif
+8. **Notebook 08** applique l'optimisation à l'ordonnancement de tâches (job-shop scheduling, NP-difficile) : la contrainte disjonctive `Or(s_a + d_a ≤ s_b, s_b + d_b ≤ s_a)` (exclusion mutuelle sur une machine) et l'objectif de makespan minimal (`Optimize.minimize`) révèlent où le solveur surpasse une heuristique gloutonne FIFO — l'optimum trouvé (8 h) écrase le glouton (14 h)
 
 ## Concepts clés
 
@@ -105,7 +107,7 @@ Les **trois verdicts** de `check()` appellent trois postures distinctes — c'es
 |--------|--------|
 | **Python 3.10+** | [Download](https://www.python.org/downloads/) |
 | **z3-solver** | `pip install z3-solver` |
-| **matplotlib** | `pip install matplotlib` (visualisation, notebook 02) |
+| **matplotlib** | `pip install matplotlib` (visualisation, notebooks 02 et 08) |
 | **Kernel Jupyter** | `python3` |
 
 > Les notebooks sont autonomes : les imports sont inclus dans la cellule de setup de chaque notebook. Le package s'appelle `z3-solver` (et non `z3`).
@@ -130,7 +132,7 @@ pip install -r requirements.txt
 Le pattern « décrire les contraintes, laisser le solveur résoudre » s'applique dès qu'un problème se réduit à un système de contraintes sur des variables. Les exercices de la série en couvrent plusieurs, et l'usage industriel de Z3 en couvre d'autres :
 
 - **Résolution de puzzles et CSP** : Sudoku, N-reines, cryptarithmes — modélisation déclarative (`Distinct`, `And`, `Or`), sans écrire de backtracking à la main. Le notebook 02 en fait l'expérience sur le Sudoku. Comparer avec les 10 autres approches algorithmiques de la [série Sudoku](../../../Sudoku/README.md).
-- **Ordonnancement (scheduling)** : placer des tâches dans le temps sous contraintes de précédence, de ressources et de fenêtres (notebook 01, exercice 2). Le solveur trouve un planning réalisable, ou retourne le noyau d'insatisfiabilité qui pointe les contraintes conflictuelles.
+- **Ordonnancement (scheduling)** : placer des tâches dans le temps sous contraintes de précédence, de ressources et de fenêtres (notebook 08, job-shop ; exercice 2 du notebook 01). Le solveur trouve un planning réalisable, ou retourne le noyau d'insatisfiabilité qui pointe les contraintes conflictuelles.
 - **Allocation de ressources** : maximiser un gain ou minimiser un coût sous bornes et exclusivités (notebook 01, exercice 3 ; notebook 06). `Optimize` traitera directement la fonction objectif.
 - **Vérification de programmes** : prouver qu'un code respecte sa spécification (absence d'overflow entiers via `BitVec`, invariants de boucle, propriétés de sûreté) — l'usage industriel historique de Z3 en analyse statique et model-checking.
 - **Configuration** : sélectionner des options compatibles (catalogue produit, planning d'emplois du temps) parmi un ensemble de contraintes d'exclusion et de cardinalité. MaxSAT (notebook 06) permet de relâcher les préférences les moins importantes quand tout n'est pas satisfaisable.

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-08-Ordonnancement.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-08-Ordonnancement.ipynb
@@ -1,0 +1,845 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c0",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "# Z3-Python-08 : Ordonnancement de taches (Job-Shop Scheduling)\n",
+    "\n",
+    "\n",
+    "\n",
+    "[← Serie Z3-Python](README.md) | [Z3-Python-07 (style declaratif LINQ) →](Z3-Python-07-Style-Declaratif-Linq.ipynb)\n",
+    "\n",
+    "\n",
+    "\n",
+    "## Le probleme\n",
+    "\n",
+    "\n",
+    "\n",
+    "Le **job-shop scheduling** est un probleme canonique d'optimisation combinatoire : on dispose de $m$ machines et de $n$ jobs, chaque job etant une **sequence d'operations** (une par machine) de durees donnees. On veut trouver un ordonnancement (date de debut de chaque operation) qui :\n",
+    "\n",
+    "\n",
+    "\n",
+    "1. **respecte l'ordre** des operations de chaque job (precedence),\n",
+    "\n",
+    "2. **n'utilise chaque machine qu'une fois a la fois** (exclusion disjonctive),\n",
+    "\n",
+    "3. **minimise le makespan** $C_{\\max}$ (la date de fin de la derniere operation).\n",
+    "\n",
+    "\n",
+    "\n",
+    "Ce probleme est **NP-difficile** : il n'existe pas d'algorithme polynomial connu, et une approche gloutonne (heuristique) rate souvent l'optimum. C'est typiquement la ou un solveur SMT comme Z3 **brille** : on decrit les contraintes (precedence + exclusion) et l'objectif (minimiser $C_{\\max}$), et `Optimize` trouve l'ordonnancement optimal.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Ce notebook montre** : (a) une heuristique gloutonne FIFO sous-optimale, (b) la modelisation Z3 avec la contrainte disjonctive `Or(... , ...)`, (c) l'optimum trouve par `Optimize.minimize`, et (d) un diagramme de Gantt comparant les deux. Il porte en Python l'exemple C# [11_Job_Shop_Scheduling](../Z3/11_Job_Shop_Scheduling.ipynb) de la serie sœur Z3.Linq."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:34.734772Z",
+     "iopub.status.busy": "2026-07-11T14:42:34.734201Z",
+     "iopub.status.idle": "2026-07-11T14:42:35.895851Z",
+     "shell.execute_reply": "2026-07-11T14:42:35.894414Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "z3 version : 4.15.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports : z3 (solveur SMT) + matplotlib (diagramme de Gantt).\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "import z3\n",
+    "\n",
+    "import matplotlib\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "\n",
+    "\n",
+    "# En mode batch (Papermill/nbconvert headless), on desactive le mode interactif.\n",
+    "\n",
+    "# On garde le backend inline par defaut (capture les figures au plt.show()).\n",
+    "\n",
+    "BATCH_MODE = os.getenv(\"BATCH_MODE\", \"false\").lower() in (\"true\", \"1\", \"yes\")\n",
+    "\n",
+    "if BATCH_MODE:\n",
+    "\n",
+    "    plt.ioff()\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"z3 version :\", z3.get_version_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Instance de reference : 3 jobs x 2 machines\n",
+    "\n",
+    "\n",
+    "\n",
+    "On encode l'instance comme un dictionnaire : chaque job est la liste ordonnee de ses operations, chaque operation etant un couple `(machine, duree)`.\n",
+    "\n",
+    "\n",
+    "\n",
+    "| Job | Operation 1 | Operation 2 |\n",
+    "\n",
+    "|-----|-------------|-------------|\n",
+    "\n",
+    "| J0  | M0 (3h)     | M1 (3h)     |\n",
+    "\n",
+    "| J1  | M1 (2h)     | M0 (2h)     |\n",
+    "\n",
+    "| J2  | M0 (2h)     | M1 (2h)     |\n",
+    "\n",
+    "\n",
+    "\n",
+    "Notez que J0 et J2 commencent par M0, mais J1 commence par M1 : les jobs n'ont pas tous le meme parcours."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:35.900951Z",
+     "iopub.status.busy": "2026-07-11T14:42:35.900143Z",
+     "iopub.status.idle": "2026-07-11T14:42:35.911007Z",
+     "shell.execute_reply": "2026-07-11T14:42:35.909267Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Instance : 3 jobs x 2 machines\n",
+      "  J0 : M0(3h) puis M1(3h)\n",
+      "  J1 : M1(2h) puis M0(2h)\n",
+      "  J2 : M0(2h) puis M1(2h)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Instance : 3 jobs x 2 machines (M0, M1).\n",
+    "\n",
+    "# Format : jobs[j] = [(machine, duree), (machine, duree)] dans l'ordre des operations.\n",
+    "\n",
+    "MACHINES = [\"M0\", \"M1\"]\n",
+    "\n",
+    "jobs = {\n",
+    "\n",
+    "    \"J0\": [(\"M0\", 3), (\"M1\", 3)],  # 3h sur M0 puis 3h sur M1\n",
+    "\n",
+    "    \"J1\": [(\"M1\", 2), (\"M0\", 2)],  # 2h sur M1 puis 2h sur M0\n",
+    "\n",
+    "    \"J2\": [(\"M0\", 2), (\"M1\", 2)],  # 2h sur M0 puis 2h sur M1\n",
+    "\n",
+    "}\n",
+    "\n",
+    "JOB_NAMES = list(jobs.keys())\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(f\"Instance : {len(JOB_NAMES)} jobs x {len(MACHINES)} machines\")\n",
+    "\n",
+    "for j in JOB_NAMES:\n",
+    "\n",
+    "    parcours = \" puis \".join(f\"{m}({d}h)\" for m, d in jobs[j])\n",
+    "\n",
+    "    print(f\"  {j} : {parcours}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Approche gloutonne : ordonnancement FIFO\n",
+    "\n",
+    "\n",
+    "\n",
+    "Avant Z3, essayons une **heuristique simple** : on schedule les jobs dans l'ordre (J0, puis J1, puis J2), et pour chaque job on place chaque operation **le plus tot possible** (des que la machine est libre et que l'operation precedente du job est terminee).\n",
+    "\n",
+    "\n",
+    "\n",
+    "Cette strategie FIFO est rapide mais **myope** : elle ne regarde pas plus loin que le job courant, et peut laisser une machine inutilisee la ou un autre ordre aurait mieux equilibre la charge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:35.916941Z",
+     "iopub.status.busy": "2026-07-11T14:42:35.916455Z",
+     "iopub.status.idle": "2026-07-11T14:42:35.929377Z",
+     "shell.execute_reply": "2026-07-11T14:42:35.926521Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Glouton FIFO : Cmax = 14h\n",
+      "  J0 : M0[0,3], M1[3,6]\n",
+      "  J1 : M1[6,8], M0[8,10]\n",
+      "  J2 : M0[10,12], M1[12,14]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def greedy_fifo(jobs, machine_names):\n",
+    "\n",
+    "    \"\"\"Ordonnancement glouton : schedule chaque job dans l'ordre, chaque operation ASAP.\"\"\"\n",
+    "\n",
+    "    machine_free = {m: 0 for m in machine_names}  # disponibilite de chaque machine\n",
+    "\n",
+    "    schedule = {}\n",
+    "\n",
+    "    for j in jobs:\n",
+    "\n",
+    "        schedule[j] = []\n",
+    "\n",
+    "        for (m, d) in jobs[j]:\n",
+    "\n",
+    "            job_ready = schedule[j][-1][1] + schedule[j][-1][2] if schedule[j] else 0\n",
+    "\n",
+    "            start = max(machine_free[m], job_ready)\n",
+    "\n",
+    "            schedule[j].append((m, start, d))\n",
+    "\n",
+    "            machine_free[m] = start + d\n",
+    "\n",
+    "    cmax = max(s[1] + s[2] for j in schedule for s in schedule[j])\n",
+    "\n",
+    "    return schedule, cmax\n",
+    "\n",
+    "\n",
+    "\n",
+    "greedy_schedule, greedy_cmax = greedy_fifo(jobs, MACHINES)\n",
+    "\n",
+    "print(f\"Glouton FIFO : Cmax = {greedy_cmax}h\")\n",
+    "\n",
+    "for j in JOB_NAMES:\n",
+    "\n",
+    "    ops = \", \".join(f\"{m}[{s},{s+d}]\" for m, s, d in greedy_schedule[j])\n",
+    "\n",
+    "    print(f\"  {j} : {ops}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Modelisation Z3 : variables et contraintes\n",
+    "\n",
+    "\n",
+    "\n",
+    "Le passage au declaratif. On introduit une variable entiere $s_{j,k}$ = date de debut de l'operation $k$ du job $j$, plus une variable $C_{\\max}$ pour le makespan. Les contraintes se traduisent directement :\n",
+    "\n",
+    "\n",
+    "\n",
+    "1. **Precedence intra-job** : l'operation $k$ commence apres la fin de l'operation $k{-}1$ :  $s_{j,k} \\ge s_{j,k-1} + d_{j,k-1}$.\n",
+    "\n",
+    "2. **Exclusion disjonctive** (le coeur du modele) : pour deux operations $a$ et $b$ sur la **meme** machine, l'une doit finir avant que l'autre commence :  $s_a + d_a \\le s_b$ **OU** $s_b + d_b \\le s_a$. C'est cette disjonction `Or(...)` (non-lineaire, difficile pour un simple parcours) qui fait toute la valeur du solveur.\n",
+    "\n",
+    "3. **Objectif** : minimiser $C_{\\max} = \\max_{j,k}(s_{j,k} + d_{j,k})$, via `Optimize.minimize`.\n",
+    "\n",
+    "\n",
+    "\n",
+    "La borne superieure sure $C_{\\max} \\le$ somme de toutes les durees (cas ou tout serait sequentialise) garantit un domaine fini au solveur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:35.936641Z",
+     "iopub.status.busy": "2026-07-11T14:42:35.935912Z",
+     "iopub.status.idle": "2026-07-11T14:42:35.971761Z",
+     "shell.execute_reply": "2026-07-11T14:42:35.970032Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Z3 optimal : Cmax = 8h  (glouton = 14h, gain = 6h)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def solve_jobshop(jobs, machine_names):\n",
+    "\n",
+    "    \"\"\"Modelise le job-shop en Z3 et minimise le makespan (Cmax).\"\"\"\n",
+    "\n",
+    "    opt = z3.Optimize()\n",
+    "\n",
+    "    job_names = list(jobs.keys())\n",
+    "\n",
+    "    horizon = sum(d for j in jobs for (_, d) in jobs[j])  # borne sup sure\n",
+    "\n",
+    "\n",
+    "\n",
+    "    # Variables de debut : start[j][k]\n",
+    "\n",
+    "    start = {j: [z3.Int(f\"s_{j}_{k}\") for k in range(len(jobs[j]))] for j in job_names}\n",
+    "\n",
+    "    cmax = z3.Int(\"cmax\")\n",
+    "\n",
+    "\n",
+    "\n",
+    "    # (1) Domaine + precedence intra-job + borne makespan\n",
+    "\n",
+    "    for j in job_names:\n",
+    "\n",
+    "        for k, (m, d) in enumerate(jobs[j]):\n",
+    "\n",
+    "            opt.add(start[j][k] >= 0)\n",
+    "\n",
+    "            opt.add(start[j][k] + d <= cmax)\n",
+    "\n",
+    "            if k > 0:\n",
+    "\n",
+    "                _, pd = jobs[j][k - 1]\n",
+    "\n",
+    "                opt.add(start[j][k] >= start[j][k - 1] + pd)\n",
+    "\n",
+    "\n",
+    "\n",
+    "    # (2) Exclusion disjonctive : deux operations sur la MEME machine ne se chevauchent pas\n",
+    "\n",
+    "    for m in machine_names:\n",
+    "\n",
+    "        ops_on_m = [(j, k, jobs[j][k][1])\n",
+    "\n",
+    "                    for j in job_names for k in range(len(jobs[j]))\n",
+    "\n",
+    "                    if jobs[j][k][0] == m]\n",
+    "\n",
+    "        for a in range(len(ops_on_m)):\n",
+    "\n",
+    "            for b in range(a + 1, len(ops_on_m)):\n",
+    "\n",
+    "                ja, ka, da = ops_on_m[a]\n",
+    "\n",
+    "                jb, kb, db = ops_on_m[b]\n",
+    "\n",
+    "                opt.add(z3.Or(start[ja][ka] + da <= start[jb][kb],\n",
+    "\n",
+    "                             start[jb][kb] + db <= start[ja][ka]))\n",
+    "\n",
+    "\n",
+    "\n",
+    "    # (3) Objectif : minimiser le makespan\n",
+    "\n",
+    "    opt.add(cmax <= horizon)\n",
+    "\n",
+    "    opt.minimize(cmax)\n",
+    "\n",
+    "    assert opt.check() == z3.sat, \"Instance insatisfiable\"\n",
+    "\n",
+    "    model = opt.model()\n",
+    "\n",
+    "    schedule = {j: [(jobs[j][k][0], model[start[j][k]].as_long(), jobs[j][k][1])\n",
+    "\n",
+    "                    for k in range(len(jobs[j]))] for j in job_names}\n",
+    "\n",
+    "    return schedule, model[cmax].as_long()\n",
+    "\n",
+    "\n",
+    "\n",
+    "opt_schedule, opt_cmax = solve_jobshop(jobs, MACHINES)\n",
+    "\n",
+    "print(f\"Z3 optimal : Cmax = {opt_cmax}h  (glouton = {greedy_cmax}h, gain = {greedy_cmax - opt_cmax}h)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Resultat optimal\n",
+    "\n",
+    "\n",
+    "\n",
+    "Le solveur trouve l'ordonnancement de makespan **minimal**. Comparons le detail op par op : la ou le glouton sequentialisait trop, Z3 entrelace les jobs (une operation d'un job pendant le creux d'un autre) pour reduire le temps total."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:35.976910Z",
+     "iopub.status.busy": "2026-07-11T14:42:35.976496Z",
+     "iopub.status.idle": "2026-07-11T14:42:35.985961Z",
+     "shell.execute_reply": "2026-07-11T14:42:35.984202Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison glouton vs Z3 optimal :\n",
+      "\n",
+      "  J0\n",
+      "    glouton : M0[0,3], M1[3,6]\n",
+      "    optimal : M0[0,3], M1[3,6]\n",
+      "  J1\n",
+      "    glouton : M1[6,8], M0[8,10]\n",
+      "    optimal : M1[1,3], M0[6,8]\n",
+      "  J2\n",
+      "    glouton : M0[10,12], M1[12,14]\n",
+      "    optimal : M0[4,6], M1[6,8]\n",
+      "\n",
+      "Makespan : glouton 14h -> optimal 8h (gain de 6h, 43%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Comparaison glouton vs Z3 optimal :\\n\")\n",
+    "\n",
+    "for j in JOB_NAMES:\n",
+    "\n",
+    "    g = \", \".join(f\"{m}[{s},{s+d}]\" for m, s, d in greedy_schedule[j])\n",
+    "\n",
+    "    o = \", \".join(f\"{m}[{s},{s+d}]\" for m, s, d in opt_schedule[j])\n",
+    "\n",
+    "    print(f\"  {j}\")\n",
+    "\n",
+    "    print(f\"    glouton : {g}\")\n",
+    "\n",
+    "    print(f\"    optimal : {o}\")\n",
+    "\n",
+    "print(f\"\\nMakespan : glouton {greedy_cmax}h -> optimal {opt_cmax}h (gain de {greedy_cmax - opt_cmax}h, {100*(greedy_cmax-opt_cmax)/greedy_cmax:.0f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c10",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Visualisation : diagramme de Gantt\n",
+    "\n",
+    "\n",
+    "\n",
+    "Le diagramme de Gantt rend visible la difference : chaque ligne est une machine, chaque barre coloree une operation. Le glouton (haut) laisse des trous ; l'optimal Z3 (bas) tasse les operations pour finir plus tot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:35.992021Z",
+     "iopub.status.busy": "2026-07-11T14:42:35.991464Z",
+     "iopub.status.idle": "2026-07-11T14:42:36.574414Z",
+     "shell.execute_reply": "2026-07-11T14:42:36.571579Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAJOCAYAAACqS2TfAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYWdJREFUeJzt3Qd4VGX69/E7jZBCQgspErp0KQFEAQVFRUQUUbGLYPnjgqu4uqyr4uKqqGtDRUFdwIYCK6AgtkUQQQRpQgKKQAy9GtJIgWTe637YmTcJCQmQJyeZ+X6ua66ZOXMyuc+cQPI7T/NzuVwuAQAAAAAAFc6/4t8SAAAAAAAoQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AMCqf/zjH+Ln5+d0GSikoKBA2rdvL08//bTTpfi0xYsXm38b//nPf8rc98Ybb5QhQ4ZUSl0AgIpF6AYAnLLk5GQZNWqUtGzZUkJDQ82tbdu2MnLkSFm/fn2l17Nx40YT7n///XdxSpMmTUyAKumWk5Nj9pk2bZp5vmrVqhMuSpR0mzRpUpHvkZWVJf/85z+lQ4cO5jOPjIyUCy64QN577z1xuVzlrvWjjz6SHTt2mHNY3NatW+X//u//pFmzZlKzZk2JiIiQnj17yoQJEyQ7O1t8mV6kuOqqqyQ6OtqcHz135XHppZea/Uv6vMtrzJgx8sknn8jPP/982u8BAHBGoEPfFwBQTc2fP19uuOEGCQwMlFtuuUU6duwo/v7+8ssvv8js2bPlzTffNKG8cePGlRq6x40bJ3369DHh1ymdOnWSv/zlLydsr1GjRplfq59beHh4kW3du3f3PN63b5/07dtXNm3aZFo9NcBpmNcgNnToUFmwYIF8+OGHEhAQUOb3+te//mXeQ0N7YZ9//rlcf/31EhwcLLfffrtpDc/Ly5OlS5fKww8/LElJSfLWW2+Jr3rsscckJiZGOnfuLF999VW5vkb/TSxfvvyMv7d+z65du8qLL75oLrIAAKoPQjcAoNy0FVTDmgbqhQsXSmxsbJHXn3vuOXnjjTdMCPdFZ511ltx6662n9bXXXXed1K9fv9TXNVhr4J4zZ45pbXX785//bALxCy+8YIKZtoiezNq1a01rqYa3wvRCifvcfvvtt0XOrfZg2LJliwnlvkw/I72oc/DgQYmKiipzf70oohdh9JyMHTv2jL+/di9/4oknzL+x4hdoAABVl2/+VQQAOC3PP/+86eI8derUEwK30tZvDYHx8fEnfZ9jx46ZbtLNmzc3raoaZP7+979Lbm5ukf1K68Kr+99xxx2eLtvaOqsuuugiT9dsHS/rpiGlXbt25nvFxcWZEHn48OEi76mt5Nqyq63m+j7afVtDtB6z03788UfTsqrHXDhwu40fP17OPvtsc9GjrC7gc+fONS3vF154YZHtepyZmZny73//u8Rz26JFC7n//vs9z93dpWfNmmWGFoSEhMj5558vGzZsMK9PnjzZfI12UdfPtnjX/++//96ct0aNGpnzoj8zo0ePLlL//v37TbjVry/cfV4vAISFhZkeF5XpVHtR6Geq4+cfeuihk+6n+2jX9YYNG5rPS3s06DGW1E1d//198803p1w7AMA5hG4AwCl1LdcgVbjb8+m46667TMtfQkKCvPzyy9K7d28THLWl9VRpeNSgrzS4v//+++bWpk0bs01Du4ZsDdvaunvttdeaQHjZZZfJ0aNHi7xXamqqXH755abLvO7bunVr00r5xRdflKsWfT9tBS18O3LkSLm+9o8//ijydVqL27x588y9dvkuiV7suPnmm83XLFu27KTf54cffjAXF4KCgops1++h47h79Ogh5aXBWVtytRVeP2dtib/yyitl4sSJ8uqrr8qf/vQn0wqv3auHDx9e5Gs1rOtnc++998prr70m/fr1M/eFj7FBgwam2/13331nXnMHVL34UKtWLXMx5VTPR2k3fd+KtH37dnn22WfNhRC9IHEyup/2YNBw/sgjj5iLLDp0ozj3xY2yzjEAoIpxAQBQDmlpadrU6Bo0aNAJr6WmproOHDjguR05csTz2hNPPGG+zm3dunXm+V133VXkPR566CGz/dtvv/Vs0+f69cU1btzYNXToUM/zWbNmmX0XLVpUZL/9+/e7atSo4brssstc+fn5nu2vv/662X/KlCmebb179zbb3nvvPc+23NxcV0xMjOvaa68t8/PRmvTri98K1z916lSz7aeffjrh8yl+0/dz089ct+nnXJrZs2ebfV599dWT1tmwYcMTjsd9bq+++mpXeen+wcHBruTkZM+2yZMnm+36maWnp3u2P/LII2Z74X0L/4y4jR8/3uXn5+dKSUkpsv2mm25yhYaGujZv3uz617/+Zd5r7ty5ZdaoPw8lfbYl3QrXVhb9GS/tZ9Ptuuuuc/Xo0cPzXPcfOXJkifW1adPG/Ky5TZgwwWzfsGHDCe/bsmVLV//+/ctdKwDAeYzpBgCUS3p6urkvaSypdv8tPKuyTtRVWpdanfBLPfjgg0W2a4upjkvWccPavbsi/Pe//zUTgT3wwANFxpnffffdplVcv9ewYcM82/XYCo/J1m7Y5557rmzbtq1c3097ADz11FNFtmnrcXnohGg6U7hb4dbRjIwMc6+tu6Vxv+Y+T6U5dOiQ1KlTp8g299ec7P1Lot2gC3e5dveA0N4Ehd/LvV0/R/f+hY9Pu0xrt3JtZdd8quPOtdu52+uvv26GC+i4982bN8ttt90mV199dZn1aY+F8nbF1gnSKsqiRYvM+VyxYkW59tefwcKT7emM9O7PS3slFKbnTlvmAQDVB6EbAFAu7hCl436L0+7aGgx1hu2yJhJLSUkxAVi7qRcPPbVr1zavVxT3e7Vq1arIdg04GoaLfy8dU1t8TXENOeVdBk0nQrvkkktOq1btJl/aRGruz14/Y/2MSlKeYO5WfHkxd9h3v0d5FQ7Gyj0bevEx/e7thbvMa/drHWLw2WefFdmu0tLSijyvW7eu6a6uY8B1uS59XB567k73fJwuna9AhzvohYFu3bqd1ufovihS/HNxnzvWvQeA6oXQDQAoFw1OOsFWYmLiCa+5WzJPZZ3sMwkO+fn5YkNpy22dyhrYNuj4dJ0ATcN/8QnQ3NwXBnTc78nUq1fvhDCnoVvHvJd0bk/n8yrrc9Tzp5OC6Th2HTOvY+d1YrRdu3aZ8dolja92L9Glte/cubPUiw+FaS8H/R7loRO2lWe5tbLocl6//vqruRBV/N+DXtTQbTpWXSfqO52fOz1+nTQPAFB9MJEaAKDcBgwYYGZVXrly5Wm/hy5JpaHqt99+K7JdW8l1RvHC63tri1/xWcY1SO3Zs6dcAd79XhqCir9HZa8lfiZ0cjJV2vrMGmKnT59uPq+ePXue9L004Oqxl/Q9dEm4ilhTuiw6w7l2E9fJ6jR0a1dxbZHW4F+SL7/8Ut555x3561//asKxTtymLcpl0Unj9EJReW47duyokGPTFnydwE3PQ9OmTT039/nTx19//fVpvbces9bpniQQAFA9ELoBAOWmoUdb6HQmag3Jp9MifMUVV5j7V155pcj2l156yRPs3XRJsSVLlhTZ76233jqhpVtbSVXxgK5BTruSa3fkwrXpsljahbnw96rKdKyzHosu1aYzyBf36KOPmhCr56esmbJ1WS9t0S6+PJt+rX6OOrN8SedWA/mECRMq4Gj+f8tu4XOij0t6fz2nWpOOrX/mmWdM+F6zZo15XN4x3eW5VdSYbp2BX2ciL35z/+zr49Od/V+Xs9O1v09lhnkAgPPoXg4AKDft1qotqjfddJMZJ63LGmmw0cCkraf6mo7X1rHRpdH9taVSw7MGKl0uTFvO3333XRk0aFCRSdQ0bI0YMcJMzKXdkXWyNu1mXHzsc6dOnUyQ0+WZNEzrus8XX3yx6carSzCNGzfOLAWma1xrq7cuNaXjbcsaf16VaCupTlymrcK6PJhOtqXBefbs2WaSMV2zWpfnKot+va6Rrstw6bJphS9w6PnT99GWVF26Syfx0l4B2mKsS3y510Y/U9rart9PJ9vTLuXavV0nHitpDLOuDa6Tv+mkeHqO9Tzqz4VOWKfHoj9PlTWmW5ei03kA3MvA6QUh98R5OoZbe07osemtJNrKrT/jp0svDuhFL/23AACoPgjdAIBTokFHuwdr12DtJjtlyhTTvVsDh7Yca0g+WRBS2lqpE5lNmzbNtPxpK6OG4yeeeKLIfjrLuIZ5bZnWLsYaNDV4aPgsTL9+0qRJZq3vO++807SE6wzSGrp1/WjtkqwzYI8ePdpMynXPPfeYltLia1VXZdoFWi9O6OeuAVhDqq7P3aFDB/M5akguzzj5Ll26mK+ZOXNmkdCt9KKEjg3X2ec//fRTs0a2XsDQ/fX76vmoCPq567rgOuGYnrOaNWvKNddcI6NGjSrys6OTrOnFBvea6YV7RejPgV68+emnnyrtPOrPoV6scNOfMb2pXr16WR+uoOd98ODBpzzLPADAWX66bpjDNQAAgEqkLbYjR44044/LMyEZnLdu3TpJSEgwXeu1ZwcAoPogdAMA4GN0IjttvdZhAjoeHFWfjhXX86Y9FAAA1QuhGwAAAAAAS5i9HAAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAL66TrfO1Ll7926zJmV51h8FAAAAAMA2nZM8IyND4uLixN/fv/qGbg3c8fHxTpcBAAAAAMAJduzYIQ0bNpRqG7q1hdt9IBEREU6XAwAAAACApKenmwZid2attqHb3aVcAzehGwAAAABQlZQ1DJqJ1AAAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAkiq/TrfbhRdfKQGB1aZc4LTExdSXeXNnOl0GAFhz8+CBkrpvj9NloBJt2n9A6jeMcboMVKLY+jEyb9anTpcBVBnVJsXGnHevBAWHOl0GYNXuZROcLgEArNLAPfGKxk6XgUrUY8pOaTYiwekyUIm2TVrjdAlAlUL3cgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALAm09caoXua9eLW5HzxmnkTXDZURgztI6yZ1JTfvmHy3ZpdMmZcox/JdTpcJAEC10OzRT8x98rM3SsS5A6RWx74SVDdG/Pz8Zff7YyVne5LTJaKCzbzhTXN/z6dj5O6uN0vTOvESEVxL0nMyZEnKCpmxYZ64hL+lAF9ESzeKCPD3k8eHd5c2TerKh19ukjW/7peBFzSTGy9t5XRpAABUS36BQXJky2o5lnbQ6VJQCUKDQuSsiBhZuHWpvLt2lgnag9v2l35n93a6NAAOoaUbRbRvXl/iosLlh/W7Zc7irRJcI0B6dTxLruzVTD748henywMAoNo5/P0sc1+zYSsJqt3A6XJg2aHswzL6i3Hich1v1Q70D5RhCUOkSe2GTpcGwCG0dKOIJrER5v5Aara5z83Ll/SsPAkLCZLa4cEOVwcAAFC1FRTkewK3n/hJQlx783jDPhovAF9FSzfK5Od0AQAAANWMtnCP7D5UOsa0lQWbv5Vl21c5XRIAhxC6UcTve9LNfVSdEHOv3ctrhdWQrOyjcjgz1+HqAAAAqse47od7jZB2DVrKrMT5Mivpc6dLAuAgQjeKSNx6UHYfzJSubaLlmj7NpWlcpAQG+MvsZVucLg0AgGqpZnxbCaoXKwGhx4dwhbboYmYyz1i30OnSYIG/f4A82fchaRQZJ2v3JMmu9H3SI76rpOVmSNL+X50uD0B1GNN9xx13iJ+fn4wYMeKE10aOHGle033cJk6cKE2aNJGaNWtK9+7dZeXKlWdeNSpUrdAgc5+Te0xy8vLl6SkrZdPvf8itl7eRLq2jZf7SbfLR1/ySAACgPPxDws19QV6OuPKPSq2OF0vUgD9JUJ0Ys732+Veb5/Ae4TXCzH3OsVyJCA43gVt1jm0nD/S409yua3eFw1UCqFYt3fHx8fLxxx/Lyy+/LCEhx7sh5+TkyPTp06VRo0ae/WbMmCEPPvigTJo0yQTuV155Rfr16ye//vqrNGjA7J1VQY8OsTKodwvzeMPW40uZbN+XIY9N+sHhygAAqH7CWp8nkd0HmsfZKYnm/sD8180N3ql7w85yZau+5nHS/s1yIOuQDJlxr9NlAajus5cnJCSY4D179mzPNn2sgbtz586ebS+99JLcfffdMmzYMGnbtq0J36GhoTJlypSKqR5nrFubGImpFypL1u6U12auc7ocAACqNe06Hlg7RjKTlsrBBW86XQ4qgc5OHh0eZSZKm/zTB06XA8CbxnQPHz5cpk6dKrfccot5rkFaw/XixYvN87y8PFm9erU88sgjnq/x9/eXSy65RJYvX17q++bm5pqbW3r68Ym9YMeEGWudLgEAAK9xYP5Ep0tAJXtz5ftOlwDAW9fpvvXWW2Xp0qWSkpJibsuWLTPb3A4ePCj5+fkSHR1d5Ov0+d69e0t93/Hjx0tkZKTnpi3qAAAAAAD4VEt3VFSUDBgwQKZNmyYul8s8rl+//hkXpC3jOg68cEs3wduep+/tIc3iIiW4RqCkZebK8sQ9MuWzJLm+79lyc7/WMv2rX5hEDQCAcvCvGSZRA0dJcEwz8Q+NkIKsNMlIXCKpiz+S8A59pMHAUZLx8yLGd3uZsKBQ+VP326VpnXiJCK4l6TkZsiRlhczYME8ubNLdrNW9OHm5vLHyPadLBVAdlwzTLuajRo3yzFJemAbwgIAA2bdvX5Ht+jwm5vjsnSUJDg42N1SO5F3p8t2aXSLiMhOqDezVTHbuz3S6LAAAqh3/4FAJqtdQ0td+I/lH0qV2j8FSp+e1kp+ZamYyh3cKDaopZ0XEyMKtSyU9N1MGtekng9v2l8M56ZJ9lPMO4AxD9+WXX27GbusyYToreWE1atSQLl26yMKFC2XQoEFmW0FBgXnuDupw3jufJUp4SJCEhQRJjw5xEh9dS8Tl8rweWy9MnhrRQ86OryNbdqbKc++tkvSsPEdrBgCgKjqWfkh2Tr5fxFVgnvsFBEn9y4ZLjeimkrNjk9kWEBYh0dePkZBG7eRo6l7ZN+clOZZa+rA7VH2Hsg/L6C/GmZ6fKtA/UIYlDJEmtRvKpgNbzDZdRuzhXiOkXVRL2Zt5QF5e/o7syzzgcOUAqvyYbqUt2Zs2bZKNGzeax8VpN/G3335b3n33XbPfvffeK1lZWWbCNVQdkx/pK+88eqlZk3vR6h3y9YoUz2vd28fIisS98vueNOnQIkoG9GzqaK0AAFRZGrb/F7hF/CS0RYJ5lJ283rNLSNOOkrtrs2Rv3yjBsc2lTs/rHCoWFaXAVeAJ3H7iZ2YzVxv2/eLZp0NMW/ntULJsPPCbNKvbSK5t29+xegFUs5ZuFRERUeprN9xwgxw4cEDGjh1rJk/r1KmTfPnllydMrgZnPTPtJ6lTK1iu6dNCLux0lvy4YY/ntUWrd8q8pdsk92i+tG1aT2LrhzlaKwAAVV5AoDQYeJ+ENuskaSs/l6yNSyW8w0Xmpezkn+XwD3MkpGkHCWvZTYLqlj7kDtWLtnDr+O2OMW1lweZvzRJivZucZ15bv3ejzN30lZwT3Vq6ntVBYsKjnC4XQFUO3Tpx2snMnTu3yHPtSk538qotadshz+Mxt3eTvt0ayZadh81znVxN5Rccv3If4O/nUJUAAFSPcd2m+3jj9pK6ZIakfj+zyOv5WceXQnXl5//vC07sKYjqJzQo5Hj38QYtZVbifJmV9HmR13Wst8ovOH7e/TnvgE8545ZuVF8JrRpI74SGsin5kIifnwzsdbzrePLuNKdLAwCg2vELqilxtz8tNRo0kiNb10jeoV0S1ran5Gfxe9WbBQcGy5N9H5JGkXGydk+S7ErfJz3iu0pabobTpQGoIgjdPkwnRGscW0vOax8rAQF+cigtW2Yt3GyWCBtySUunywMAoFoJCK1lArcKbZ5gbio7JVEy1i92uDrYElEjzARu1Tm2nbmppP2bzVJhAODncs/8UEXpOt2RkZHSb+R0CQoOdbocwKrdyybI6h+/dboMALCmf8+uMvGKxk6XgUrUY8oyufCZa5wuA5Vo26Q1smrRCqfLACotq6alpZ10rrMzmr0cAAAAAACUjtANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYEmgVBN7f3xTAgKrTbnAaYmLqe90CQBgVZ3oWBm5IMXpMlCJavoHy7ZJa5wuA5Uotn6M0yUAVYqfy+VySRWWnp4ukZGRkpaWJhEREU6XAwAAAACAlDer0r0cAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgSaCtNwZw6gYOGiK79x50ugygUhzZv1WaxEY5XQYqWZ3oWJk+e57TZQCwaOD1V8ueg3udLgOVKLZ+jMyb9anTZVRZhG6gCtHAHdfzfqfLACrF1pn3yMQrGjtdBirZyAUpTpcAwDIN3M1GJDhdBirRtklrnC6hSqN7OQAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlgTaemMAqKrmvXi1uR88Zp5E1w2VEYM7SOsmdSU375h8t2aXTJmXKMfyXU6XCS/R7NFPzH3yszdKxLkDpFbHvhJUN0b8/Pxl9/tjJWd7ktMlAgBOw8wb3jT393w6Ru7uerM0rRMvEcG1JD0nQ5akrJAZG+aJS/h7ArR0A/BhAf5+8vjw7tKmSV358MtNsubX/TLwgmZy46WtnC4NXsovMEiObFktx9IOOl0KAKCChAaFyFkRMbJw61J5d+0sE7QHt+0v/c7u7XRpqCJo6Qbgs9o3ry9xUeHyw/rdMmfxVgmuESC9Op4lV/ZqJh98+YvT5cELHf5+lrmv2bCVBNVu4HQ5AIAKcCj7sIz+Ypy4XMdbtQP9A2VYwhBpUruh06WhiqClG4DPahIbYe4PpGab+9y8fEnPypOwkCCpHR7scHUAAKA6KCjI9wRuP/GThLj25vGGfVzAx3G0dANAIX5OFwAAAKolbeEe2X2odIxpKws2fyvLtq9yuiRUEYRuAD7r9z3p5j6qToi51+7ltcJqSFb2UTmcmetwdQAAoDqN63641whp16ClzEqcL7OSPne6JFTX7uV33HGH+Pn5yYgRI054beTIkeY13UctWbJEBg4cKHFxcWb73LlzK65qAKgAiVsPyu6DmdK1TbRc06e5jLyuowQG+Mvny5KdLg1eqmZ8W6nVqa8EhB4f2hDaoot5DgCovvz9A+TJvg+ZwL12T5LsSt8nPeK7SrsGTMyK02zpjo+Pl48//lhefvllCQk53jqUk5Mj06dPl0aNGnn2y8rKko4dO8rw4cNl8ODBp/ptAMCKWqFB5j4n95jk5OXL01NWyj3XnCO3Xt7GPJ+/dJt89PWvTpcJL+EfEm7uC/JyxJV/VGp1vFhqdbzI83rt848vX5exbqFjNQIATl14jTBzn3MsVyKCw6VRZJx53jm2nbmppP2bJWk/f1PgNEJ3QkKCbN26VWbPni233HKL2aaPNXA3bdrUs1///v3NDQCqih4dYmVQ7xbm8Yatx5ds2r4vQx6b9IPDlcEbhbU+TyK7DzSPs1MSzf2B+a+bGwCg+uresLNc2aqvJ1gfyDokQ2bc63RZ8LbZy7X1eurUqZ7nU6ZMkWHDhlVkXQBQ4bq1iZGYeqGyZO1OeW3mOqfLgZfTruOBtWMkM2mpHFzwptPlAAAqiM5OHh0eZSZKm/zTB06XA2+dSO3WW2+VRx55RFJSUszzZcuWmS7nixcvPuOCcnNzzc0tPf34REcAcKYmzFjrdAnwIQfmT3S6BACABW+ufN/pEuALoTsqKkoGDBgg06ZNM2vS6eP69etXSEHjx4+XcePGVch7AQAAAABQLZcM0y7mo0aNMo8nTqy4q/nagv7ggw8WaenWydsA4Ew9fW8PaRYXKcE1AiUtM1eWJ+6RKZ8lyfV9z5ab+7WW6V/9wiRqqDD+NcMkauAoCY5pJv6hEVKQlSYZiUskdfFHEt6hjzQYOEoyfl7EGG8AqGbCgkLlT91vl6Z14iUiuJak52TIkpQVMmPDPLmwSXezVvfi5OXyxsr3nC4V1T10X3755ZKXl2eWA+vXr1+FFRQcHGxuAFDRknely3drdomIy0yoNrBXM9m5P9PpsuCl/INDJaheQ0lf+43kH0mX2j0GS52e10p+ZqqZzRwAUD2FBtWUsyJiZOHWpZKemymD2vSTwW37y+GcdMk+yv/vqMDQHRAQIJs2bfI8Li4zM1O2bNnieZ6cnCzr1q2TunXrFllaDAAqyzufJUp4SJCEhQRJjw5xEh9dS8Tl8rweWy9MnhrRQ86OryNbdqbKc++tkvSsPEdrRvV1LP2Q7Jx8v4irwDz3CwiS+pcNlxrRTSVnx/9+f4ZFSPT1YySkUTs5mrpX9s15SY6l7nW4cgDAyRzKPiyjvxhnhtmqQP9AGZYwRJrUbiibDhzPP7qM2MO9Rki7qJayN/OAvLz8HdmXecDhylGtZi93i4iIMLeSrFq1Sjp37mxuSruM6+OxY8eeybcEgDMy+ZG+8s6jl0qX1tGyaPUO+XrF8QkhVff2MbIica/8vidNOrSIkgE9//8yiMAp07D9v8At4iehLRLMo+zk9Z5dQpp2lNxdmyV7+0YJjm0udXpe51CxAIDyKnAVeAK3n/iZ2czVhn2/ePbpENNWfjuULBsP/CbN6jaSa9uylLIvO6WWbp047WTmzp3redynTx/PDyMAVBXPTPtJ6tQKlmv6tJALO50lP27Y43lt0eqdMm/pNsk9mi9tm9aT2PphjtYKLxEQKA0G3iehzTpJ2srPJWvjUgnvcJF5KTv5Zzn8wxwJadpBwlp2k6C6MU5XCwAoJ23h1vHbHWPayoLN35olxHo3Oc+8tn7vRpm76Ss5J7q1dD2rg8SERzldLqpj93IAqI6Sth3yPB5zezfp262RbNl52DzXydVUfsHx1skAfz+HqoQ3jes23ccbt5fUJTMk9fuZRV7Pzzq+LKYrP/9/X3DicC0AQNUTGhRyvPt4g5YyK3G+zEr6vMjrOtZb5Rcc///dn//ffRqhG4BPSGjVQHonNJRNyYdE/PxkYK/jXceTd6c5XRq8lF9QTYm7/Wmp0aCRHNm6RvIO7ZKwtj0lP4ufOQCozoIDg+XJvg9Jo8g4WbsnSXal75Me8V0lLTfD6dJQRRG6AfgEnRCtcWwtOa99rAQE+MmhtGyZtXCzWSJsyCUtnS4PXiggtJYJ3Cq0eYK5qeyURMlYv9jh6gAApyuiRpgJ3KpzbDtzU0n7N5ulwoDi/FxVfOC1rtMdGRkpaWlppU7aBniLLuddLHE973e6DKBSbJ15j8wf0cvpMlDJRi5IkS+WrXK6DAAWdb2ouzQbcfxCI3zDtklrZNWiFeJr0suZVc9o9nIAAAAAAFA6QjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYG23hjAqYuLqS+7l01wugygUriCasrIBSlOl4FKVic61ukSAFgWWz9Gtk1a43QZqORzjtL5uVwul1Rh6enpEhkZKWlpaRIREeF0OQAAAAAASHmzKt3LAQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMCSQKni3MuI6xpoAAAAAABUBe6M6s6s1TZ0Hzp0yNzHx8c7XQoAAAAAAEVkZGRIZGSkVNvQXbduXXO/ffv2kx4IvOuKkV5k2bFjh0RERDhdDioB59z3cM59E+fd93DOfQ/n3Pf48jl3uVwmcMfFxZ10vyofuv39jw8718DtayfR1+n55pz7Fs657+Gc+ybOu+/hnPsezrnv8dVzHlmOhmEmUgMAAAAAwBJCNwAAAAAAvhq6g4OD5YknnjD38A2cc9/DOfc9nHPfxHn3PZxz38M59z2c87L5ucqa3xwAAAAAAHhnSzcAAAAAANUVoRsAAAAAAEsI3QAAAAAAWELoBgDABzz++ONyzz33eJ736dNHHnjgAamO/va3v8l9993ndBkAAJQLoRsAgFL4+fmd9PaPf/xDqoO9e/fKhAkT5NFHHxVv8NBDD8m7774r27Ztc7oUAADKROgGAKAUe/bs8dxeeeUViYiIKLJNw1918M4770iPHj2kcePGTpcieXl5Z/we9evXl379+smbb75ZITUBAGAToRsAgFLExMR4bpGRkaZ1u/C2jz/+WNq0aSM1a9aU1q1byxtvvOH52t9//93sP3PmTLngggskJCREunXrJps3b5affvpJunbtKuHh4dK/f385cOCA5+vuuOMOGTRokIwbN06ioqJM0B8xYkSRsPqf//xHzjnnHPOe9erVk0suuUSysrJKPQ6tc+DAgSdsLygokL/+9a9St25dczzFW+4PHz4sd911l6eOiy++WH7++ecTai1Mu6xr13U3fTxq1Ciz3R2WVWJiojl2/Qyio6Pltttuk4MHD5b7GPV49LgAAKjqCN0AAJyGDz/8UMaOHStPP/20bNq0SZ555hkzblq7PRf2xBNPyGOPPSZr1qyRwMBAufnmm03Q1e7e33//vWzZssW8T2ELFy4077l48WL56KOPZPbs2SaEK21hv+mmm2T48OGefQYPHiwul6vEOv/44w/ZuHGjCfnFaa1hYWGyYsUKef755+XJJ5+Ub775xvP69ddfL/v375cvvvhCVq9eLQkJCdK3b1/znqdCv0+NGjVk2bJlMmnSJBPmNcB37txZVq1aJV9++aXs27dPhgwZUu5jPPfcc2Xnzp3m4gYAAFVZoNMFAABQHWmYfvHFF00YVE2bNjXhdvLkyTJ06FDPftoF3d26e//995swqaG6Z8+eZtudd94p06ZNK/LeGlCnTJkioaGh0q5dOxOGH374YfnnP/9pAumxY8fM93V3F9cW4dJs377dhNW4uLgTXuvQoYM5DnX22WfL66+/bmq79NJLZenSpbJy5UoTuoODg80+L7zwgsydO9e0QheelK0s+t4a6t2eeuopE7j1QoWbHm98fLzpCZCZmVnmMbqPJyUlRZo0aVLuWgAAqGyEbgAATpF2c966dasJzHfffbdnuwZF7YZePNi6aTfq4gFSt2mwLaxjx44mcLudf/75Joju2LHDvKatzfoeGuYvu+wyue6666ROnTol1pqdnW3utQt8cYVrU7GxsZ5atBu5fk/t2l38/fTYT0WXLl2KPNf3XrRokelaXpy+tx5TWceo3c7VkSNHTqkWAAAqG6EbAIBTpGFUvf3229K9e/cirwUEBBR5HhQU5HmsY7xL2qZjq8tL31+7gP/www/y9ddfy2uvvWZmJdcu4traXpyOo1apqalmbHZptRWvRY9RQ7h27S6udu3a5t7f3/+Ebu1Hjx49YX/twl6YvreOyX7uuedO2Fe/Z3mO0d3FvfgxAQBQ1TCmGwCAU6St09q9WZesatGiRZFbScH3VGlLsLuFWv3444+mVVi7X7vDsXZP13Hea9euNd3R58yZU+J7NW/e3EyCpl3fT4WO39alxnQcevFjdAd5Dbza3b2wdevWleu9k5KSTLfw4u/tDuhlHaNOxKYXDbT7PQAAVRmhGwCA06BhcPz48fLqq6+accgbNmyQqVOnyksvvXTG760zlWvXdQ3KCxYsMOOudQZwbVnW1l4dC60TkOl4bZ1kTWc/11nUS6JfozN/6xjtU6Ffo93adXZybW3WCcu05VlbnPV7K50MTR+/99578ttvv5k6NQyXZeTIkaalWse360zu2qX8q6++kmHDhkl+fn65jlEnoXPPCg8AQFVG6AYA4DToUlq6/rUGbR173Lt3bzMhWkW0dOt4Zp187MILL5QbbrhBrrrqKs9yXtpqvWTJErniiiukZcuWZmZ0ndBNl986Wa26vNapdGPXlmYN/FqDhmH9XjfeeKOZuMw9Nl3HW+uM7Tobuy6HlpGRIbfffnuZ7629BHQmcw3YOl5bPz9dUky7retFgvIcox5P4fH0AABUVX6u0tYYAQAAlU7XvtYltXSW8Iqiv+p17Pno0aNN63J1p0uY/eUvf5H169eb7u8AAFRltHQDAODltNX6rbfeMrOre8vs8drDgMANAKgO+G0FAIAP6NSpk7l5A10+DACA6oLu5QAAAAAAWEL3cgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAOAN+fn7yj3/8o8p/75UrV0qNGjUkJSXFel2+ZvHixeZc/Oc//ylz3xtvvFGGDBlSKXUBAKoGQjcAwDoNJGXdCofH0aNHS0JCgtStW1dCQ0OlTZs25vXMzExH6l+wYIFjwbqiPProo3LTTTdJ48aNT3htzpw50r9/f6lfv74J5nFxcSYYfvvtt+Lr/vvf/8pFF11kPpvatWvLueeeK++///5pv9+YMWPkk08+kZ9//rlC6wQAVF2BThcAAPB+JwspGma3bt0q3bt392z76aef5IILLpBhw4ZJzZo1Ze3atfLss8+aALRkyRLx9/ev9NA9ceLEEoN3dna2BAZW7V+n69atM5/dDz/8UGS7y+WS4cOHy7Rp06Rz587y4IMPSkxMjOzZs8cE8b59+8qyZcukR48e4os+++wzGTRokJx//vnm3OvFoZkzZ8rtt98uBw8eNBeHTpV+zl27dpUXX3xR3nvvPSt1AwCqlqr9VwIAwCvceuutJW5/5513TOC+7777TEur29KlS0/Yt3nz5vLQQw+ZbtLnnXeeVBV6UaCqmzp1qjRq1OiEz02DnwbuBx54QF566SUTKgu3jOvFkqp+QcGm119/XWJjY02Lf3BwsNn2f//3f9K6dWvzuZ1O6Fbai+CJJ56QN954Q8LDwyu4agBAVUP3cgCAI5KSkuTPf/6zafn717/+Veb+TZo0MfeHDx8uc9/9+/fLnXfeKdHR0SYUd+zYUd59990i+/z+++8mZL7wwgvy8ssvm27XISEh0rt3b0lMTPTsd8cdd5hWblW4O7xb8a7x7hbRzZs3m4sNkZGREhUVJY8//rhpWd6xY4dcffXVEhERYVqVNfgWlpeXJ2PHjpUuXbqYrw0LCzOt/osWLZLTNXfuXLn44ouL1K0t9OPHjzcBUj+Dwq+53XbbbaY7tdKQqfvoBRE9b3pM2t1aQ6jWrOdFW4Dr1Kljbn/961/N8Ram30dbzevVq2c+az3G4uOg9QKBfp8pU6YU2f7MM8+Y7drroLKkp6ebY3EHbqUXIbSrudZfXEFBgTz99NPSsGFD83OnPQW2bNlywn6XXnqpZGVlyTfffGP9GAAAzvPdy9cAAMccOXLEtPYFBATIxx9/XCTUuB07dswEOQ10GoIfe+wxqVWrlicElkbDZJ8+fUzYGTVqlDRt2lRmzZplwrO+3/33319kf+3im5GRISNHjpScnByZMGGCCagbNmwwoV1D5e7du01AOpWxvDfccIMZi67d4j///HN56qmnzBj1yZMnm/d/7rnn5MMPPzSt9926dZMLL7zQE/S0B4COv7777rtNbf/+97+lX79+ppW/U6dOcip27dol27dvN2PkC9Pw/Mcff5hWbj0P5aW9EvRiwbhx4+THH3+Ut956y4Rv7bqurekajjUY64WU9u3bmyDupp/tVVddJbfccos5r3rur7/+epk/f74MGDDA7KNDCmbPnm26ums4jY+PN+dCv59eSLniiitOWp+O+9fzWJagoCBzUeNk9OdIz5NeMBk6dKgJ/dOnT5dVq1aZbubF6bnWoQ96TtPS0uT55583x7pixYoi+7Vt29aEdu26f80115RZKwCgmnMBAFDJhg8frk2grnfffbfUfZYvX272cd9atWrlWrRoUZnv/corr5j9P/jgA8+2vLw81/nnn+8KDw93paenm23Jyclmv5CQENfOnTs9+65YscJsHz16tGfbyJEjzbaS6PYnnnjC81wf67Z77rnHs+3YsWOuhg0buvz8/FzPPvusZ3tqaqr5/kOHDi2yb25ubpHvoftFR0ebz+1k37sk//3vf81+8+bNK7J9woQJZvucOXNc5TF16lSzf79+/VwFBQWe7fq56nGNGDHihOPt3bt3kfc4cuRIked6Xtq3b++6+OKLi2zfs2ePq27duq5LL73UfBadO3d2NWrUyJWWllZmnfpZFv65Ke1WvLaSZGZmuoYMGWKOz/11oaGhrrlz5xbZT38u9bU2bdoUOXfuz3jDhg0nvHfLli1d/fv3L7MGAED1R0s3AKBSaUuhdh3WrsuFW0GL09ZAbV3WbrjaiqoTgZVn9nJtZdWWWG0pLtyqqV2iddt3330nV155pec1nSjrrLPO8jzXlnSd1E3fR8c5n6677rrL81hbknXyrJ07d5rWWjdtIW7VqpVs27atyL7ulmftrqyt83qvX79mzZpTruPQoUPmXrtJF6Yt6kp7D5wKrb9wV3T9rJYvX17kuNzHu3r16iJfW7hLdmpqquTn55uu8x999FGR/fT8aZd+PV/6uk4Epz8L2iW/LNqtvbQ5BAor/nmURHtgtGzZUq677joZPHiwqVdb9vX9tZ7iY+S1lV5nf3fT2pWeX231L/79dTI2AID3I3QDACrNb7/9JiNGjDBBRieROhkNWJdccol5rGOgNazrvQZPHaNdGl2H+uyzzz5hhnPt6u1+vTDdtzitr6Tuw6dCu1oXpl2ZdZyvjgcuvt0djN10/LmO9f7ll1/k6NGjnu3aVf50FR9f7Q6w2n39TI9LaTfw4ts1WBem3ci1m72G6NzcXM/2ksaT63rWH3zwgemaf88995jx0eWhF2v0VhF0eIJ2odefOffPkw6LaNeunRmmULzbePHPxh3si38O7vNR0nEDALwPE6kBACqFhiwd5+wey3uqszZrS6PSr60OShonXdrY6cKBWIOmjj/X2dp1LPeXX35pWlV1HLi2eJ8qnbSspOCnE6gpHS99Kko7hpK2Fz6u77//3ozn1gsPesFFexLocd18880nXBBQeiFCx06rjRs3lvvYdSz13r17y7zpePaT0Z9T/fx1rHnhCzjaa0Jn2tfadJ+yPoPin4Obno/iF2AAAN6J0A0AqBQ6uZSut62TS+mM5acT2jV4aag6GZ2FXFvUi4c0bTV2v16Y7luczjzuni1dVWaLpM7m3axZMzOZmHbB1wnUtMW/PJODlcQdrpOTk4ts79Wrl2mJ1a7d2m3atk8++cQE7q+++sqsDa7B1d2ToSQ6sZ22wusM6zrp2yuvvFKu76Mt0LrMV1k390Wc0mjo18n8SvpstPeB/nyd7uem76uz2Lt7XwAAvBuhGwBg3Zw5c8yax9rSqWOrT0bHMBfuUu2mM3orHSt8Mjq7tbZkzpgxo0jIee2110zrui4JVnw5LZ3h201nCNduw4XXDddlu9y12eZuLS3cOqr16Ljp06Hj1bXrt7vV2C00NFTGjBkjmzZtMvcltcZqq7t+HhV1XHrxonBQ1WXb9PMv6cKDnj+dDfxvf/ub6Wqus9frxZDyjOnWFvSybsWXaiuuQYMGZsy9/uwWbtHWeQXmzZtnLmaUtGxYeWjLvV5E0eXTAADejzHdAACr9uzZYybZ0tCl43I1yJVEu1Off/75snjxYhPMdfIqHW+tgUe7JmvLrwbusibJ0vG/uiyXdtHWiby0xVpDnC7PpK2lxScOa9GihWn1vffee01ruu6jXbI1vLnpetJK69KWZz0WDYI26CRveqy6lJR2bdYW6kmTJplxyuWZSK4kOhZew2PxccQPP/ywWS9dA6iuA66fuU5iphctNAxr4NZJ7CqCHotOTHf55ZebLuW6lrpOlqaf//r16z376XY9FxdddJEZU630go3Wp+dUW72Lj9e3MaZbz7H2ztCwrxOm6aR/esFAu5zrhHil/RyXh4Z+veihS6IBALwfoRsAYNWvv/7qGU9cfI3swnQdZA3d55xzjglcn376qQnsGhQ1kI8dO9aExMKzQ5dEWx81uGsLqU5IprN06wzhU6dONaGtOA1TGuI0bGvg09nLNeRpF2Q37Yqs61PreHINW1qTrdCtNWro1QsH2hVbA6R+T11rXI/rdGh3bj0mvfCgFxjc9Lh1nXIN5Tor9wsvvGA+r6ioKLNuuA4F0HNSEXRMugZWbb3WtcF1UjhdA1tbuwuHbvfFDz1f7gsEehFE69M6tcbCF0RsevTRR02dur64rhOudXXo0MFcxLn22mtP+331XOrP1KnOHA8AqJ78dN0wp4sAAKCyadjTQPWvf/3LtGh6O+1lEBcXJ++//77Tpfg0nbk9ISHBzIjeqVMnp8sBAFQCxnQDAOADnnnmGTNOuviSaahc2tKv3fgJ3ADgO+heDgCAD+jevfsJS1yh8lWXJe8AABWHlm4AAAAAACxhTDcAAAAAAJbQ0g0AAAAAgCWEbgAAAAAAfHUitYKCAtm9e7dZy9K9XicAAAAAAE7SkdoZGRlmSU5/f//qG7o1cMfHxztdBgAAAAAAJ9ixY4c0bNhQqm3o1hZu94FEREQ4XQ4AAAAAAJKenm4aiN2ZtdqGbneXcg3chG4AAAAAQFVS1jBoJlIDAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEuq/DrdbhdefKUEBFabcoHTEhdTX+bNnSm+aOD1V8ueg3udLgOV6ODOvdKmQZTTZaCS1YmOlemz5zldBgAAlabapNiY8+6VoOBQp8sArNq9bIL4Kg3czUYkOF0GKtHOv8+RiVc0droMVLKRC1KcLgEAgEpF93IAAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwJtPXGqF7mvXi1uR88Zp5E1w2VEYM7SOsmdSU375h8t2aXTJmXKMfyXU6XCVR7M29409zf8+kYubvrzdK0TrxEBNeS9JwMWZKyQmZsmCcu4d+aN2n26CfmPvnZGyXi3AFSq2NfCaobI35+/rL7/bGSsz3J6RIBAIBFtHSjiAB/P3l8eHdp06SufPjlJlnz634ZeEEzufHSVk6XBniV0KAQOSsiRhZuXSrvrp1lgvbgtv2l39m9nS4NFvkFBsmRLavlWNpBp0sBAACVhJZuFNG+eX2JiwqXH9bvljmLt0pwjQDp1fEsubJXM/ngy1+cLg/wGoeyD8voL8aJy3W8VTvQP1CGJQyRJrUbOl0aLDr8/SxzX7NhKwmq3cDpcgAAQCWgpRtFNImNMPcHUrPNfW5evqRn5UlYSJDUDg92uDrAexQU5HsCt5/4SUJce/N4wz4ubgEAAHgTWrpRJj+nCwC8mLZwj+w+VDrGtJUFm7+VZdtXOV0SAAAAKhChG0X8vifd3EfVCTH32r28VlgNyco+Koczcx2uDvC+cd0P9xoh7Rq0lFmJ82VW0udOlwQAAIAKRuhGEYlbD8rug5nStU20XNOnuTSNi5TAAH+ZvWyL06UBXsXfP0Ce7PuQNIqMk7V7kmRX+j7pEd9V0nIzJGn/r06XB0tqxreVoHqxEhB6fChPaIsuZibzjHULnS4NAABUlTHdd9xxh/j5+cmIESNOeG3kyJHmNd3HbeLEidKkSROpWbOmdO/eXVauXHnmVaNC1QoNMvc5ucckJy9fnp6yUjb9/ofcenkb6dI6WuYv3SYffU0IAM5UeI0wc59zLFcigsNN4FadY9vJAz3uNLfr2l3hcJWoSP4h4ea+IC9HXPlHpVbHiyVqwJ8kqE6M2V77/KvNcwAA4L1Oq6U7Pj5ePv74Y3n55ZclJOR4N+ScnByZPn26NGrUyLPfjBkz5MEHH5RJkyaZwP3KK69Iv3795Ndff5UGDZi1tSro0SFWBvVuYR5v2Hp8CZvt+zLksUk/OFwZ4F26N+wsV7bqax4n7d8sB7IOyZAZ9zpdFiwKa32eRHYfaB5npySa+wPzXzc3AADgO05r9vKEhAQTvGfPnu3Zpo81cHfu3Nmz7aWXXpK7775bhg0bJm3btjXhOzQ0VKZMmVIx1eOMdWsTIzH1QmXJ2p3y2sx1TpcDeC2dnTw6PMpMlDb5pw+cLgeVQLuOB9aOkcykpXJwwZtOlwMAAKrbmO7hw4fL1KlT5ZZbbjHPNUhruF68eLF5npeXJ6tXr5ZHHnnE8zX+/v5yySWXyPLly0t939zcXHNzS08/PrEX7JgwY63TJQA+4c2V7ztdAirZgfkTnS4BAABU53W6b731Vlm6dKmkpKSY27Jly8w2t4MHD0p+fr5ER0cX+Tp9vnfv3lLfd/z48RIZGem5aYs6AAAAAAA+1dIdFRUlAwYMkGnTponL5TKP69evf8YFacu4jgMv3NJN8Lbn6Xt7SLO4SAmuEShpmbmyPHGPTPksSa7ve7bc3K+1TP/qFyZRAypAWFCo/Kn77dK0TrxEBNeS9JwMWZKyQmZsmCcXNulu1upenLxc3lj5ntOlooL41wyTqIGjJDimmfiHRkhBVppkJC6R1MUfSXiHPtJg4CjJ+HkRY7wBAPByZ7RkmHYxHzVqlGeW8sI0gAcEBMi+ffuKbNfnMTHHZ20tSXBwsLmhciTvSpfv1uwSEZeZUG1gr2ayc3+m02UBXic0qKacFREjC7culfTcTBnUpp8MbttfDuekS/bRHKfLgwX+waESVK+hpK/9RvKPpEvtHoOlTs9rJT8z1cxmDgAAfMMZhe7LL7/cjN3WZcJ0VvLCatSoIV26dJGFCxfKoEGDzLaCggLz3B3U4bx3PkuU8JAgCQsJkh4d4iQ+upaIy+V5PbZemDw1ooecHV9HtuxMlefeWyXpWXmO1gxUR4eyD8voL8aZnkEq0D9QhiUMkSa1G8qmA1vMNl1G7OFeI6RdVEvZm3lAXl7+juzLPOBw5Thdx9IPyc7J94u4Csxzv4AgqX/ZcKkR3VRydmwy2wLCIiT6+jES0qidHE3dK/vmvCTHUksfggUAAHxoTLfSluxNmzbJxo0bzePitJv422+/Le+++67Z795775WsrCwz4RqqjsmP9JV3Hr3UrMm9aPUO+XpFiue17u1jZEXiXvl9T5p0aBElA3o2dbRWoLoqcBV4Aref+JnZzNWGfb949ukQ01Z+O5QsGw/8Js3qNpJr2/Z3rF5UAA3b/wvcetZDWySYR9nJ6z27hDTtKLm7Nkv29o0SHNtc6vS8zqFiAQBAlWzpVhEREaW+dsMNN8iBAwdk7NixZvK0Tp06yZdffnnC5Gpw1jPTfpI6tYLlmj4t5MJOZ8mPG/Z4Xlu0eqfMW7pNco/mS9um9SS2fpijtQLVnbZw6/jtjjFtZcHmb80SYr2bnGdeW793o8zd9JWcE91aup7VQWLCo5wuFxUhIFAaDLxPQpt1krSVn0vWxqUS3uEi81J28s9y+Ic5EtK0g4S17CZBdUsffgUAAHwkdOvEaSczd+7cIs+1Kzndyau2pG2HPI/H3N5N+nZrJFt2HjbPdXI1lV9wvLUmwN/PoSqB6i80KOR49/EGLWVW4nyZlfR5kdd1rLfKL8g39/7+J/YgQvUb1226jzduL6lLZkjq9zOLvJ6fdXxZTFf+8XMunHMAALzOGbd0o/pKaNVAeic0lE3Jh0T8/GRgr+Ndx5N3pzldGuB1ggOD5cm+D0mjyDhZuydJdqXvkx7xXSUtN8Pp0mCJX1BNibv9aanRoJEc2bpG8g7tkrC2PSU/i/9jAQDwJYRuH6YTojWOrSXntY+VgAA/OZSWLbMWbjZLhA25pKXT5QFeJaJGmAncqnNsO3NTSfs3m6XC4H0CQmuZwK1CmyeYm8pOSZSM9Ysdrg4AAFQWP5d7Zp8qStfpjoyMlH4jp0tQcKjT5QBW7V42QVb/+K34oq4XdZdmI46HEviGJX+fIz8M7+l0GahkIxekyBfLVjldBgAAFZZV09LSTjrX2RnNXg4AAAAAAEpH6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwJFCqib0/vikBgdWmXOC0xMXUF18VWz9Gtk1a43QZqEQ1/YNl5IIUp8tAJasTHet0CQAAVCo/l8vlkiosPT1dIiMjJS0tTSIiIpwuBwAAAAAAKW9WpXs5AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAkkBbb4wzd/PggZK6b4/TZaAS/b7ngIQ2aO50GUCl2H8oWaIbNnC6DFSy2PoxMm/Wp06XAQBApSF0V2EauCde0djpMlCJrpy0Q+J63u90GUCl2D7nXmk2IsHpMlDJtk1a43QJAABUKrqXAwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgSaCtNwbKq9mjn5j75GdvlIhzB0itjn0lqG6M+Pn5y+73x0rO9iSnS4SXmffi1eZ+8Jh5El03VEYM7iCtm9SV3Lxj8t2aXTJlXqIcy3c5XSa8xMwb3jT393w6Ru7uerM0rRMvEcG1JD0nQ5akrJAZG+aJS/h5AwDAW9HSjSrFLzBIjmxZLcfSDjpdCnxAgL+fPD68u7RpUlc+/HKTrPl1vwy8oJnceGkrp0uDFwoNCpGzImJk4dal8u7aWSZoD27bX/qd3dvp0gAAgEW0dKNKOfz9LHNfs2ErCardwOly4OXaN68vcVHh8sP63TJn8VYJrhEgvTqeJVf2aiYffPmL0+XByxzKPiyjvxgnLtfxVu1A/0AZljBEmtRu6HRpAADAIlq6AfisJrER5v5Aara5z83Ll/SsPAkLCZLa4cEOVwdvU1CQ7wncfuInCXHtzeMN+7jAAwCAN6OlGwAK8XO6AHg9beEe2X2odIxpKws2fyvLtq9yuiQAAGARoRuAz/p9T7q5j6oTYu61e3mtsBqSlX1UDmfmOlwdvHVc98O9Rki7Bi1lVuJ8mZX0udMlAQCAqtS9/I477hA/Pz8ZMWLECa+NHDnSvKb7qCVLlsjAgQMlLi7ObJ87d27FVQ2vVTO+rdTq1FcCQo93+w1t0cU8B2xI3HpQdh/MlK5touWaPs1l5HUdJTDAXz5flux0afBC/v4B8mTfh0zgXrsnSXal75Me8V2lXQMm7gMAwJudckt3fHy8fPzxx/Lyyy9LSMjx1qGcnByZPn26NGrUyLNfVlaWdOzYUYYPHy6DBw+u2KrhNfxDws19QV6OuPKPSq2OF0utjhd5Xq99/vGlnTLWLXSsRniXWqFB5j4n95jk5OXL01NWyj3XnCO3Xt7GPJ+/dJt89PWvTpcJLxFeI8zc5xzLlYjgcGkUGWeed45tZ24qaf9mSdrPzxwAAN7qlEN3QkKCbN26VWbPni233HKL2aaPNXA3bdrUs1///v3NDShNWOvzJLL7QPM4OyXR3B+Y/7q5ATb06BArg3q3MI83bD2+LN32fRny2KQfHK4M3qh7w85yZau+nmB9IOuQDJlxr9NlAQCA6jB7ubZeT5061fN8ypQpMmzYsIqsCz5Au44H1o6RzKSlcnDBm06XAx/QrU2MxNQLlSVrd8prM9c5XQ68nM5OHh0eZSZKm/zTB06XAwAAqtNEarfeeqs88sgjkpKSYp4vW7bMdDlfvHjxGReUm5trbm7p6ccnOoL3OTB/otMlwMdMmLHW6RLgQ95c+b7TJQAAgOoauqOiomTAgAEybdo0s+aoPq5fv36FFDR+/HgZN25chbwXAAAAAADVcskw7WI+atQo83jixIprsdQW9AcffLBIS7dO3gbv418zTKIGjpLgmGbiHxohBVlpkpG4RFIXfyThHfpIg4GjJOPnRYzxRoV5+t4e0iwuUoJrBEpaZq4sT9wjUz5Lkuv7ni0392st07/6hUnUUGHCgkLlT91vl6Z14iUiuJak52TIkpQVMmPDPLmwSXezVvfi5OXyxsr3nC4VAABUxdB9+eWXS15enlkOrF+/fhVWUHBwsLnB+/kHh0pQvYaSvvYbyT+SLrV7DJY6Pa+V/MxUM5s5UNGSd6XLd2t2iYjLTKg2sFcz2bk/0+my4KVCg2rKWRExsnDrUknPzZRBbfrJ4Lb95XBOumQf5f84AAB8xWmH7oCAANm0aZPncXGZmZmyZcsWz/Pk5GRZt26d1K1bt8jSYvBdx9IPyc7J94u4Csxzv4AgqX/ZcKkR3VRydvzvZyssQqKvHyMhjdrJ0dS9sm/OS3Isda/DlaO6euezRAkPCZKwkCDp0SFO4qNribhcntdj64XJUyN6yNnxdWTLzlR57r1Vkp6V52jNqL4OZR+W0V+MM8OwVKB/oAxLGCJNajeUTQeO/37UZcQe7jVC2kW1lL2ZB+Tl5e/IvswDDlcOAAAcn73cLSIiwtxKsmrVKuncubO5Ke0yro/Hjh17Jt8S3kTD9v8Ct4ifhLZIMI+yk9d7dglp2lFyd22W7O0bJTi2udTpeZ1DxcJbTH6kr7zz6KXSpXW0LFq9Q75ecXxCSNW9fYysSNwrv+9Jkw4tomRAz/+/DCJwqgpcBZ7A7Sd+ZjZztWHfL559OsS0ld8OJcvGA79Js7qN5Nq2LLUJAIBPt3TrxGknM3fuXM/jPn36eP7YAE4qIFAaDLxPQpt1krSVn0vWxqUS3uEi81J28s9y+Ic5EtK0g4S17CZBdWOcrhbV3DPTfpI6tYLlmj4t5MJOZ8mPG/Z4Xlu0eqfMW7pNco/mS9um9SS2fpijtcI7aAu3jt/uGNNWFmz+1iwh1rvJeea19Xs3ytxNX8k50a2l61kdJCY8yulyAQBAVeleDlTUuG7Tfbxxe0ldMkNSv59Z5PX8rONLxrny8//3BScOZQBORdK2Q57HY27vJn27NZItOw+b5zq5msovON4DI8Dfz6Eq4S1Cg0KOdx9v0FJmJc6XWUmfF3ldx3qr/ILj/8f5838cAABeh9ANx/gF1ZS425+WGg0ayZGtayTv0C4Ja9tT8rPSnC4NXiihVQPpndBQNiUfEvHzk4G9jncdT97NzxvsCA4Mlif7PiSNIuNk7Z4k2ZW+T3rEd5W03AynSwMAAJWI0A3HBITWMoFbhTZPMDeVnZIoGesXO1wdvI1OiNY4tpac1z5WAgL85FBatsxauNksETbkkpZOlwcvFFEjzARu1Tm2nbmppP2bzVJhAADAN/i5qvjAa12nOzIyUtLS0kqdtM1b9e/ZVSZe0djpMlCJrpy0VJoPecvpMoBK8eOce+Wi8Vc7XQYq2bZJa2TVohVOlwEAQKVl1TOavRwAAAAAAJSO0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAAAAAIAlhG4AAAAAACwhdAMAAAAAYAmhGwAAAAAASwjdAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAALCE0A0AAAAAgCWEbgAAAAAALCF0AwAAAABgSaCtN8aZqxMdKyMXpDhdBiqRK6im7F42wekygEpRMyBYtk1a43QZqGSx9WOcLgEAgEpF6K7Cps+e53QJAAAAAIAzQPdyAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAWELoBgAAAADAEkI3AAAAAACWELoBAAAAAPDVdbpdLpe5T09Pd7oUAAAAAACKZFR3Zq22ofvQoUPmPj4+3ulSAAAAAAAoIiMjQyIjI6Xahu66deua++3bt5/0QOBdV4z0IsuOHTskIiLC6XJQCTjnvodz7ps4776Hc+57OOe+x5fPucvlMoE7Li7upPtV+dDt73982LkGbl87ib5Ozzfn3Ldwzn0P59w3cd59D+fc93DOfY+vnvPIcjQMM5EaAAAAAACWELoBAAAAAPDV0B0cHCxPPPGEuYdv4Jz7Hs657+Gc+ybOu+/hnPsezrnv4ZyXzc9V1vzmAAAAAADAO1u6AQAAAACorgjdAAAAAABYQugGAAAAAMAXQ/fEiROlSZMmUrNmTenevbusXLnS6ZJgyfjx46Vbt25Sq1YtadCggQwaNEh+/fVXp8tCJXr22WfFz89PHnjgAadLgWW7du2SW2+9VerVqychISFyzjnnyKpVq5wuC5bk5+fL448/Lk2bNjXnu3nz5vLPf/5TmFLGuyxZskQGDhwocXFx5v/yuXPnFnldz/fYsWMlNjbW/Bxccskl8ttvvzlWL+ye86NHj8qYMWPM/+9hYWFmn9tvv112797taM2w+++8sBEjRph9XnnllUqtsaqqsqF7xowZ8uCDD5qZ8NasWSMdO3aUfv36yf79+50uDRZ89913MnLkSPnxxx/lm2++Mf9ZX3bZZZKVleV0aagEP/30k0yePFk6dOjgdCmwLDU1VXr27ClBQUHyxRdfyMaNG+XFF1+UOnXqOF0aLHnuuefkzTfflNdff102bdpknj///PPy2muvOV0aKpD+vta/1bTBpCR6zl999VWZNGmSrFixwgQx/bsuJyen0muF/XN+5MgR8/e7XnDT+9mzZ5vGlKuuusqRWlE5/87d5syZY/6m13COKj57ubZsa8un/pJWBQUFEh8fL/fdd5/87W9/c7o8WHbgwAHT4q1h/MILL3S6HFiUmZkpCQkJ8sYbb8hTTz0lnTp14qqoF9P/v5ctWybff/+906Wgklx55ZUSHR0t//73vz3brr32WtPa+cEHHzhaG+zQ1i39o1t7rSn9U1P/+P7LX/4iDz30kNmWlpZmfi6mTZsmN954o8MVo6LPeWkX2M8991xJSUmRRo0aVWp9qLxzrr3ZNMd99dVXMmDAANOD8QF6MVbNlu68vDxZvXq16Xrk5u/vb54vX77c0dpQOfSXsapbt67TpcAy7eGg/ykX/vcO7/XZZ59J165d5frrrzcX1jp37ixvv/2202XBoh49esjChQtl8+bN5vnPP/8sS5culf79+ztdGipJcnKy7N27t8j/85GRkeYPc/6u862/7TSo1a5d2+lSYIk2kt52223y8MMPS7t27Zwup0oJlCro4MGDZgyYXgEtTJ//8ssvjtWFyvsHq1fEtAtq+/btnS4HFn388cem25le/YZv2LZtm+lqrMOH/v73v5tz/+c//1lq1KghQ4cOdbo8WOrdkJ6eLq1bt5aAgADz+/3pp5+WW265xenSUEk0cKuS/q5zvwbvpsMIdIz3TTfdJBEREU6XA0t0+FBgYKD5vY5qELrh27TlMzEx0bSEwHvt2LFD7r//fjOGXydLhO9cVNOW7meeecY815Zu/feu4zwJ3d5p5syZ8uGHH8r06dNNy8e6devMhVXtbsw5B7yfztMzZMgQM8xAL7rCO2kv5QkTJpjGFO3RgGrQvbx+/frmavi+ffuKbNfnMTExjtUF+0aNGiXz58+XRYsWScOGDZ0uB5b/c9aJEXU8t14V1ZuO4deJdvSxtobB++jMxW3bti2yrU2bNrJ9+3bHaoJd2s1QW7t13K7OZKxdD0ePHm1WrYBvcP/txt91vhu4dRy3XmSnldt76Vwt+nedjtd3/12n513ncmjSpIn4uioZurWbYZcuXcwYsMKtI/r8/PPPd7Q22KFXPzVw64QM3377rVlaBt6tb9++smHDBtPq5b5pC6h2OdXHeuEN3keHjRRfDlDH+jZu3NixmmCXzmKs87IUpv++9fc6fIP+TtdwXfjvOh1yoLOY83ed93IHbl0a7r///a9ZJhLeSy+orl+/vsjfddqjSS+8fvXVV+Lrqmz3ch3vp93O9I9wnelQZzPWaeqHDRvmdGmw1KVcux5++umnZq1u9xgvnWhFZ7iF99HzXHzMvi4ho7+UGcvvvbSFUyfW0u7l+sfYypUr5a233jI3eCdd01XHcGvrh3YvX7t2rbz00ksyfPhwp0tDBa9EsWXLliKTp+kf3Tohqp57HVKgK1ScffbZJoTrUlL6B/nJZrtG9T3n2qvpuuuuM12NtQej9l5z/22nr2sDG7zv33nxCyu6PKhecGvVqpUD1VYxrirstddeczVq1MhVo0YN17nnnuv68ccfnS4JluiPYkm3qVOnOl0aKlHv3r1d999/v9NlwLJ58+a52rdv7woODna1bt3a9dZbbzldEixKT083/67193nNmjVdzZo1cz366KOu3Nxcp0tDBVq0aFGJv8eHDh1qXi8oKHA9/vjjrujoaPNvv2/fvq5ff/3V6bJh6ZwnJyeX+redfh288995cY0bN3a9/PLLlV5nVVRl1+kGAAAAAKC6q5JjugEAAAAA8AaEbgAAAAAALCF0AwAAAABgCaEbAAAAAABLCN0AAAAAAFhC6AYAAAAAwBJCNwAAAAAAlhC6AQAAAACwhNANAIAPePzxx+Wee+7xPO/Tp4888MADUh397W9/k/vuu8/pMgAAKBdCNwAApfDz8zvp7R//+IdUB3v37pUJEybIo48+Kt7goYceknfffVe2bdvmdCkAAJSJ0A0AQCn27Nnjub3yyisSERFRZJuGv+rgnXfekR49ekjjxo2dLkXy8vLO+D3q168v/fr1kzfffLNCagIAwCZCNwAApYiJifHcIiMjTet24W0ff/yxtGnTRmrWrCmtW7eWN954w/O1v//+u9l/5syZcsEFF0hISIh069ZNNm/eLD/99JN07dpVwsPDpX///nLgwAHP191xxx0yaNAgGTdunERFRZmgP2LEiCJh9T//+Y+cc8455j3r1asnl1xyiWRlZZV6HFrnwIEDT9heUFAgf/3rX6Vu3brmeIq33B8+fFjuuusuTx0XX3yx/PzzzyfUWph2Wdeu6276eNSoUWa7OyyrxMREc+z6GURHR8ttt90mBw8eLPcx6vHocQEAUNURugEAOA0ffvihjB07Vp5++mnZtGmTPPPMM2bctHZ7LuyJJ56Qxx57TNasWSOBgYFy8803m6Cr3b2///572bJli3mfwhYuXGjec/HixfLRRx/J7NmzTQhX2sJ+0003yfDhwz37DB48WFwuV4l1/vHHH7Jx40YT8ovTWsPCwmTFihXy/PPPy5NPPinffPON5/Xrr79e9u/fL1988YWsXr1aEhISpG/fvuY9T4V+nxo1asiyZctk0qRJJsxrgO/cubOsWrVKvvzyS9m3b58MGTKk3Md47rnnys6dO83FDQAAqrJApwsAAKA60jD94osvmjComjZtasLt5MmTZejQoZ79tAu6u3X3/vvvN2FSQ3XPnj3NtjvvvFOmTZtW5L01oE6ZMkVCQ0OlXbt2Jgw//PDD8s9//tME0mPHjpnv6+4uri3Cpdm+fbsJq3FxcSe81qFDB3Mc6uyzz5bXX3/d1HbppZfK0qVLZeXKlSZ0BwcHm31eeOEFmTt3rmmFLjwpW1n0vTXUuz311FMmcOuFCjc93vj4eNMTIDMzs8xjdB9PSkqKNGnSpNy1AABQ2QjdAACcIu3mvHXrVhOY7777bs92DYraDb14sHXTbtTFA6Ru02BbWMeOHU3gdjv//PNNEN2xY4d5TVub9T00zF922WVy3XXXSZ06dUqsNTs729xrF/jiCtemYmNjPbVoN3L9ntq1u/j76bGfii5duhR5ru+9aNEi07W8OH1vPaayjlG7nasjR46cUi0AAFQ2QjcAAKdIw6h6++23pXv37kVeCwgIKPI8KCjI81jHeJe0TcdWl5e+v3YB/+GHH+Trr7+W1157zcxKrl3EtbW9OB1HrVJTU83Y7NJqK16LHqOGcO3aXVzt2rXNvb+//wnd2o8ePXrC/tqFvTB9bx2T/dxzz52wr37P8hyju4t78WMCAKCqYUw3AACnSFuntXuzLlnVokWLIreSgu+p0pZgdwu1+vHHH02rsHa/dodj7Z6u47zXrl1ruqPPmTOnxPdq3ry5mQRNu76fCh2/rUuN6Tj04sfoDvIaeLW7e2Hr1q0r13snJSWZbuHF39sd0Ms6Rp2ITS8aaPd7AACqMkI3AACnQcPg+PHj5dVXXzXjkDds2CBTp06Vl1566YzfW2cq167rGpQXLFhgxl3rDODasqytvToWWicg0/HaOsmazn6us6iXRL9GZ/7WMdqnQr9Gu7Xr7OTa2qwTlmnLs7Y46/dWOhmaPn7vvffkt99+M3VqGC7LyJEjTUu1jm/Xmdy1S/lXX30lw4YNk/z8/HIdo05C554VHgCAqozQDQDAadCltHT9aw3aOva4d+/eZkK0imjp1vHMOvnYhRdeKDfccINcddVVnuW8tNV6yZIlcsUVV0jLli3NzOg6oZsuv3WyWnV5rVPpxq4tzRr4tQYNw/q9brzxRjNxmXtsuo631hnbdTZ2XQ4tIyNDbr/99jLfW3sJ6EzmGrB1vLZ+frqkmHZb14sE5TlGPZ7C4+kBAKiq/FylrTECAAAqna59rUtq6SzhFUV/1evY89GjR5vW5epOlzD7y1/+IuvXrzfd3wEAqMpo6QYAwMtpq/Vbb71lZlf3ltnjtYcBgRsAUB3w2woAAB/QqVMnc/MGunwYAADVBd3LAQAAAACwhO7lAAAAAABYQugGAAAAAMASQjcAAAAAAJYQugEAAAAAsITQDQAAAACAJYRuAAAAAAAsIXQDAAAAAGAJoRsAAAAAAEsI3QAAAAAAiB3/D3+LejJbVR1aAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Diagramme de Gantt : glouton (haut) vs optimal (bas).\n"
+     ]
+    }
+   ],
+   "source": [
+    "COLORS = {\"J0\": \"#4C72B0\", \"J1\": \"#DD8452\", \"J2\": \"#55A868\", \"J3\": \"#C44E52\"}\n",
+    "\n",
+    "\n",
+    "\n",
+    "def draw_gantt(ax, schedule, title, machine_names, xmax):\n",
+    "\n",
+    "    for mi, m in enumerate(machine_names):\n",
+    "\n",
+    "        for j in schedule:\n",
+    "\n",
+    "            for (mach, s, d) in schedule[j]:\n",
+    "\n",
+    "                if mach == m:\n",
+    "\n",
+    "                    ax.barh(mi, d, left=s, height=0.6,\n",
+    "\n",
+    "                            color=COLORS.get(j, \"gray\"), edgecolor=\"black\", linewidth=0.5)\n",
+    "\n",
+    "                    ax.text(s + d / 2, mi, f\"{j}\\n{d}h\", ha=\"center\", va=\"center\",\n",
+    "\n",
+    "                            fontsize=8, color=\"white\", fontweight=\"bold\")\n",
+    "\n",
+    "    ax.set_yticks(range(len(machine_names)))\n",
+    "\n",
+    "    ax.set_yticklabels(machine_names)\n",
+    "\n",
+    "    ax.set_xlabel(\"Temps (heures)\")\n",
+    "\n",
+    "    ax.set_title(title)\n",
+    "\n",
+    "    ax.set_xlim(0, xmax + 1)\n",
+    "\n",
+    "    ax.invert_yaxis()\n",
+    "\n",
+    "\n",
+    "\n",
+    "xmax = max(greedy_cmax, opt_cmax)\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 1, figsize=(10, 6), sharex=True)\n",
+    "\n",
+    "draw_gantt(axes[0], greedy_schedule, f\"Glouton FIFO (Cmax = {greedy_cmax}h)\", MACHINES, xmax)\n",
+    "\n",
+    "draw_gantt(axes[1], opt_schedule, f\"Z3 optimal (Cmax = {opt_cmax}h)\", MACHINES, xmax)\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Diagramme de Gantt : glouton (haut) vs optimal (bas).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c12",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "\n",
+    "\n",
+    "Les trois exercices suivants vous font manipuler le modele : etendre l'instance (1), ajouter une contrainte metier de deadline (2), et monter en dimension avec une troisieme machine (3). Chaque stub reutilise `solve_jobshop` defini plus haut."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c13",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 -- Ajout d'un quatrieme job\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Objectif** : ajouter un job `J3 = [(\"M1\", 1), (\"M0\", 3)]` (1h sur M1 puis 3h sur M0) et re-resoudre. Observez comment le makespan optimal augmente (ou non) et comment Z3 re-entrelace les operations.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Indices** : copiez le dict `jobs` dans `jobs_4` avec l'entree J3 supplementaire ; appelez `solve_jobshop(jobs_4, MACHINES)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:36.583288Z",
+     "iopub.status.busy": "2026-07-11T14:42:36.582215Z",
+     "iopub.status.idle": "2026-07-11T14:42:36.596210Z",
+     "shell.execute_reply": "2026-07-11T14:42:36.592836Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : ajouter un 4eme job et mesurer le nouveau Cmax optimal.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : ajoutez un quatrieme job J3 et re-resolvez.\n",
+    "\n",
+    "# Etape 1 : definissez jobs_4 = dict(jobs) puis jobs_4[\"J3\"] = [(\"M1\", 1), (\"M0\", 3)].\n",
+    "\n",
+    "# Etape 2 : resolvez via solve_jobshop(jobs_4, MACHINES).\n",
+    "\n",
+    "# Etape 3 : comparez le nouveau Cmax a l'optimum 3-jobs (opt_cmax).\n",
+    "\n",
+    "\n",
+    "\n",
+    "def resoudre_4_jobs():\n",
+    "\n",
+    "    \"\"\"Retourne (schedule, cmax) pour l'instance 3 jobs + J3.\"\"\"\n",
+    "\n",
+    "    # TODO etudiant : construire jobs_4 et appeler solve_jobshop\n",
+    "\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 1 a completer : ajouter un 4eme job et mesurer le nouveau Cmax optimal.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c15",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 -- Contrainte d'urgence (deadline)\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Objectif** : imposer que le job `J0` termine avant $t = 7$ (deadline). Ajoutez cette contrainte au modele et verifyez que le makespan optimal augmente (la deadline force un ordonnancement moins efficace).\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Indices** : la fin de J0 est `start[\"J0\"][-1] + duree_derniere_op` ; ajoutez `opt.add(... <= 7)` avant `opt.minimize`. Modifiez `solve_jobshop` ou creez une variante."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:36.605785Z",
+     "iopub.status.busy": "2026-07-11T14:42:36.604523Z",
+     "iopub.status.idle": "2026-07-11T14:42:36.618456Z",
+     "shell.execute_reply": "2026-07-11T14:42:36.615570Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : mesurer le surcout d'une deadline sur J0.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : ajoutez une deadline (J0 doit terminer avant t=7).\n",
+    "\n",
+    "# Indice : opt.add(start[\"J0\"][-1] + jobs[\"J0\"][-1][1] <= 7) avant opt.minimize.\n",
+    "\n",
+    "# Etape 1 : copiez solve_jobshop en solve_jobshop_deadline(jobs, machines, deadline_j0=7).\n",
+    "\n",
+    "# Etape 2 : resolvez et comparez le Cmax a opt_cmax (sans deadline).\n",
+    "\n",
+    "\n",
+    "\n",
+    "def solve_jobshop_deadline(jobs, machine_names, deadline_j0=7):\n",
+    "\n",
+    "    \"\"\"Job-shop avec une deadline sur J0.\"\"\"\n",
+    "\n",
+    "    # TODO etudiant : modeliser + ajouter la deadline + minimiser\n",
+    "\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 2 a completer : mesurer le surcout d'une deadline sur J0.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 -- Extension a 3 machines\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Objectif** : etendre l'instance a 3 machines (M0, M1, M2) avec des jobs a 3 operations chacun, et verifyez que `solve_jobshop` generalize sans modification de code (le modele est parametre par les donnees).\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Indices** : definissez `MACHINES_3 = [\"M0\", \"M1\", \"M2\"]` et des `jobs_3` ou chaque job a 3 operations sur des machines distinctes ; la fonction `solve_jobshop` gere deja le cas general."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T14:42:36.628428Z",
+     "iopub.status.busy": "2026-07-11T14:42:36.626827Z",
+     "iopub.status.idle": "2026-07-11T14:42:36.641791Z",
+     "shell.execute_reply": "2026-07-11T14:42:36.638984Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : generaliser a 3 machines et observer le temps de resolution.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : etendez l'instance a 3 machines, 3 operations par job.\n",
+    "\n",
+    "# Indice : MACHINES_3 = [\"M0\", \"M1\", \"M2\"], jobs_3 = {j: [(m1,d1),(m2,d2),(m3,d3)], ...}.\n",
+    "\n",
+    "# Etape 1 : definissez jobs_3 (3 jobs, chacun 3 operations sur des machines distinctes).\n",
+    "\n",
+    "# Etape 2 : resolvez via solve_jobshop(jobs_3, MACHINES_3).\n",
+    "\n",
+    "# Question : le temps de resolution grimpe-t-il avec 3 machines ? Mesurez-le.\n",
+    "\n",
+    "\n",
+    "\n",
+    "def resoudre_3_machines():\n",
+    "\n",
+    "    \"\"\"Retourne (schedule, cmax) pour une instance 3 machines.\"\"\"\n",
+    "\n",
+    "    # TODO etudiant : definir jobs_3 + MACHINES_3 et appeler solve_jobshop\n",
+    "\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 3 a completer : generaliser a 3 machines et observer le temps de resolution.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c19",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "\n",
+    "\n",
+    "Le job-shop scheduling illustre le gain du **declaratif** sur une classe de problemes ou l'heuristique gloutonne est structurellement sous-optimale :\n",
+    "\n",
+    "\n",
+    "\n",
+    "- La **contrainte disjonctive** `Or(s_a + d_a <= s_b, s_b + d_b <= s_a)` (exclusion mutuelle sur une machine) est difficile a coder en imperatif sans enumerer tous les ordres possibles ; Z3 la traite nativement.\n",
+    "\n",
+    "- `Optimize.minimize` trouve le makespan **optimal** (prouvablement minimal), la ou FIFO se contente d'un ordonnancement realisable mais myope.\n",
+    "\n",
+    "- Le modele est **parametre par les donnees** : ajouter un job, une machine ou une deadline se fait en modifiant l'instance ou en ajoutant une contrainte, sans re-ecrire l'algorithme de resolution.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Limites** : sur de tres grandes instances (dizaines de jobs x dizaines de machines), le solveur peut devenir lent — c'est le prix de l'optimalite garantie. Dans ce cas, on combine souvent Z3 avec des heuristiques (fournir un ordonnancement glouton comme borne superieure aide le solveur a pruner).\n",
+    "\n",
+    "\n",
+    "\n",
+    "Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3/README.md) qui aborde le meme probleme via une couche declarative LINQ."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 0,
+   "end_time": "",
+   "exception": false,
+   "start_time": "",
+   "status": "pending"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

New substance notebook in the **Z3-Python** series (EPIC **#1206** Prong B: *port one Z3.Linq LINQ-to-constraints example into a pedagogical pyz3 notebook per cycle*). Ports the C# job-shop scheduling example ([`SymbolicAI/SMT/Z3/11_Job_Shop_Scheduling.ipynb`](../blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/11_Job_Shop_Scheduling.ipynb)) to **pyz3**, dropping the LINQ-specific DSL bits (B10 two-stack, B5 witness) that have no pyz3 equivalent.

**Scope (atomic)**: 1 new notebook + README update (count 7→8, table row, fil pédagogique item 8, scheduling ref, matplotlib prereq). No code outside the series touched.

## Why job-shop (Prong B — problem richness, EPIC #3801)

Job-shop scheduling is **NP-hard**, and the **disjunctive no-overlap constraint** `Or(s_a + d_a ≤ s_b, s_b + d_b ≤ s_a)` (two ops on the same machine must not overlap) is a new modeling technique **not covered in notebooks 01–07**. `Optimize.minimize` finds the *proven optimum* a greedy FIFO heuristic structurally misses — exactly where a declarative SMT solver shines over an imperative approach. This is not a degenerate case (BFS-vs-A* pitfall): the engine's distinctive capacity (disjunctive combinatorial optimization) is exercised and visible in the output.

## Execution proof (EXEC_PROVED — rule C.2, outputs committed)

- `nbconvert --execute` end-to-end, kernel `python3` (z3 4.15.4 + matplotlib 3.10.3)
- **9 code cells, all `execution_count` set, 0 errors**
- **Result**: greedy FIFO `Cmax = 14h` → **Z3 optimal `Cmax = 8h`** (gain 6h, 43 %)
- Gantt diagram rendered as a **PNG inline output** (~25 KB): greedy (top, with idle gaps) vs optimal (bottom, packed)
- Repo validator `notebook_tools.py validate`: **0 errors**
- 3 C.1-safe exercise stubs (4th job, deadline on J0, 3 machines) execute cleanly (`return None` / `print(...)`, no `raise NotImplementedError`)

## Conventions

- **Notebook = ASCII-only** (matches the Z3-Python family convention — notebook 07 is 0 accent bytes; French without diacritics)
- **README = FR-accented** (unchanged convention; the split is family-wide)
- No path-leak in outputs (Gantt is a pure matplotlib render; print statements contain only Cmax values)

## SOTA verdict

**SOTA-OK** — real `z3.Optimize`, real `matplotlib`, no workaround, no degraded output.

See #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)