### PR TITLE
docs(probas): revert cadrage exact/approché + README DecisionTheory centralisé + de-obsolescence

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/README.md
@@ -1,6 +1,6 @@
 # Théorie de la Décision Bayésienne (Infer.NET)
 
-[← Série Probas](../../README.md) | [Corpus bayésien Infer (C#) →](../../Infer/README.md) | [Lake Lean `decision_theory_lean` →](../../decision_theory_lean/)
+[← Série Probas](../../README.md) | [↑ Arc Théorie de la Décision](../README.md) | [Corpus bayésien Infer (C#) →](../../Infer/README.md) | [Lake Lean `decision_theory_lean` →](../../decision_theory_lean/)
 
 Arc autonome de **théorie de la décision bayésienne** en Infer.NET : 10 notebooks qui prolongent la modélisation probabiliste (le corpus bayésien [`../../Infer/`](../../Infer/README.md)) jusqu'au **choix d'action sous incertitude**. Un posterior n'est pas une fin — c'est l'**input** d'une politique optimale. Cette série formalise ce passage, de l'utilité espérée aux processus markoviens, jusqu'à la **preuve formelle Lean 4** de l'indice de Gittins.
 
@@ -10,7 +10,7 @@ Arc autonome de **théorie de la décision bayésienne** en Infer.NET : 10 noteb
 
 ## Pourquoi un arc autonome
 
-Jusqu'à la restructure (#4725), la théorie de la décision était imbriquée dans le corpus bayésien Infer (notebooks 14-21), ce qui masquait la **dualité des deux fils** : *modéliser l'incertitude* (inférence bayésienne) vs *décider face à l'incertitude* (théorie de la décision). L'extraction dans [`DecisionTheory/Infer/`](./) rend ces deux arcs **physiquement indépendants** tout en préservant le continuum pédagogique (le fil décision s'appuie sur les posteriors du corpus bayésien). Le lake [`decision_theory_lean`](../../decision_theory_lean/), à la **racine de la série Probas**, reste visible des deux pistes (Infer.NET et PyMC).
+Jusqu'à la restructuration de la série, la théorie de la décision était imbriquée dans le corpus bayésien Infer (notebooks 14-21), ce qui masquait la **dualité des deux fils** : *modéliser l'incertitude* (inférence bayésienne) vs *décider face à l'incertitude* (théorie de la décision). L'extraction dans [`DecisionTheory/Infer/`](./) rend ces deux arcs **physiquement indépendants** tout en préservant le continuum pédagogique (le fil décision s'appuie sur les posteriors du corpus bayésien). Le lake [`decision_theory_lean`](../../decision_theory_lean/), à la **racine de la série Probas**, reste visible des deux pistes (Infer.NET et PyMC).
 
 ## Vue d'ensemble
 

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
@@ -1,6 +1,6 @@
 # Théorie de la Décision Bayésienne (PyMC)
 
-[← Série Probas](../../README.md) | [Corpus bayésien PyMC (Python) →](../../PyMC/README.md) | [Arc décision Infer.NET (C#) →](../DecInfer/README.md) | [Lake Lean `decision_theory_lean` →](../../decision_theory_lean/)
+[← Série Probas](../../README.md) | [↑ Arc Théorie de la Décision](../README.md) | [Corpus bayésien PyMC (Python) →](../../PyMC/README.md) | [Arc décision Infer.NET (C#) →](../DecInfer/README.md) | [Lake Lean `decision_theory_lean` →](../../decision_theory_lean/)
 
 Arc autonome de **théorie de la décision bayésienne** en PyMC : 7 notebooks qui prolongent la modélisation probabiliste (le corpus bayésien [`../../PyMC/`](../../PyMC/README.md)) jusqu'au **choix d'action sous incertitude**. Un posterior n'est pas une fin — c'est l'**input** d'une politique optimale. Cette série formalise ce passage, de l'utilité espérée aux processus markoviens et aux bandits bayésiens MCMC.
 
@@ -10,7 +10,7 @@ Arc autonome de **théorie de la décision bayésienne** en PyMC : 7 notebooks q
 
 ## Pourquoi un arc autonome
 
-Jusqu'à la restructure (#4725), la théorie de la décision était imbriquée dans le corpus bayésien PyMC (notebooks 14-20), ce qui masquait la **dualité des deux fils** : *modéliser l'incertitude* (inférence bayésienne) vs *décider face à l'incertitude* (théorie de la décision). L'extraction dans [`DecisionTheory/PyMC/`](./) rend ces deux arcs **physiquement indépendants** tout en préservant le continuum pédagogique (le fil décision s'appuie sur les posteriors du corpus bayésien). Le lake [`decision_theory_lean`](../../decision_theory_lean/), à la **racine de la série Probas**, reste visible des deux pistes (PyMC et Infer.NET).
+Jusqu'à la restructuration de la série, la théorie de la décision était imbriquée dans le corpus bayésien PyMC (notebooks 14-20), ce qui masquait la **dualité des deux fils** : *modéliser l'incertitude* (inférence bayésienne) vs *décider face à l'incertitude* (théorie de la décision). L'extraction dans [`DecisionTheory/PyMC/`](./) rend ces deux arcs **physiquement indépendants** tout en préservant le continuum pédagogique (le fil décision s'appuie sur les posteriors du corpus bayésien). Le lake [`decision_theory_lean`](../../decision_theory_lean/), à la **racine de la série Probas**, reste visible des deux pistes (PyMC et Infer.NET).
 
 ## Vue d'ensemble
 

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/README.md
@@ -1,0 +1,109 @@
+# Théorie de la Décision — arc bayésien, formel et causal
+
+[← Série Probas](../README.md) · [Corpus bayésien Infer.NET](../Infer/README.md) · [Corpus bayésien PyMC](../PyMC/README.md) · [Lake Lean `decision_theory_lean`](../decision_theory_lean/)
+
+Un posterior n'est pas une fin en soi : c'est l'**entrée** d'une décision. Savoir que la tumeur est maligne avec 70 % de probabilité ne dit pas s'il faut opérer ; connaître la distribution de rendement d'un actif ne dit pas combien y investir. Cet arc prolonge la modélisation probabiliste de la série [Probas](../README.md) jusqu'au **choix d'action sous incertitude** : comment transformer une croyance quantifiée en la meilleure décision possible, et comment **prouver** que cette décision est optimale.
+
+L'arc rassemble **18 notebooks** répartis en trois traitements complémentaires du même socle théorique, plus un lake Lean 4 qui en certifie les théorèmes phares :
+
+| Composant | Notebooks | Stack | Ce qu'il apporte |
+|-----------|-----------|-------|------------------|
+| [`DecInfer/`](DecInfer/README.md) | 10 (8 C# + **2 Lean 4**) | Infer.NET (.NET 9) + kernel Lean | L'arc de référence : des axiomes vNM aux MDP et bandits, avec deux notebooks à **preuve formelle native** |
+| [`PyMC/`](PyMC/README.md) | 7 (Python) | PyMC (NUTS/MCMC) | Le miroir Python : mêmes concepts, échantillonnage stochastique, diagnostics ArviZ |
+| [`Causal-Bridges/`](Causal-Bridges/Do-Calculus-Bridge.ipynb) | 1 (Python) | `dowhy` (PyWhy) | Le **capstone causal** : l'échelle de Pearl et le do-calculus qui fédèrent les quatre traitements de la causalité du dépôt |
+| [`decision_theory_lean`](../decision_theory_lean/) | *(lake, hors compte)* | Lean 4 + Mathlib | La **couche de certification** : utilité espérée vNM, cohérence de de Finetti, escompte de Gittins, démontrés `0 sorry` |
+
+## Pourquoi cet arc — la double question de la rationalité
+
+La programmation probabiliste répond à une première question : *comment modéliser l'incertitude ?* La théorie de la décision en pose une seconde, distincte : *comment agir face à cette incertitude ?* Jusqu'à la restructuration de la série, ces deux fils étaient imbriqués dans le corpus bayésien, ce qui masquait leur dualité. Les extraire dans un arc autonome rend le passage **visible** : le fil « décision » consomme les posteriors du fil « inférence » comme entrée, mais raisonne avec ses propres outils — fonctions d'utilité, diagrammes d'influence, équation de Bellman.
+
+L'arc double délibérément chaque concept sur **deux moteurs d'inférence** — Infer.NET (message passing déterministe) et PyMC (échantillonnage MCMC) — non pas pour opposer « exact » et « approché » (les deux stacks recouvrent des méthodes approchées), mais pour montrer que la **théorie de la décision est indépendante du moteur** : l'utilité espérée se calcule aussi bien par propagation de messages que par échantillonnage. Le lecteur y gagne une compréhension des compromis pratiques sans confondre la méthode numérique et le principe décisionnel.
+
+**À qui s'adresse cet arc** : quiconque a suivi le corpus bayésien ([`Infer/`](../Infer/README.md) ou [`PyMC/`](../PyMC/README.md)) et veut passer de la *croyance* à l'*action*. Aucun prérequis en théorie de la décision — les axiomes de von Neumann–Morgenstern sont introduits *ex nihilo*. Les deux notebooks à kernel Lean 4 demandent des bases en preuve formelle, mais leurs résultats sont lisibles sans elles.
+
+## Objectifs pédagogiques
+
+À l'issue de cet arc, on sait :
+
+- **Fonder** une décision rationnelle sur les axiomes de von Neumann–Morgenstern et maximiser l'utilité espérée plutôt que la valeur monétaire ;
+- **Modéliser** l'aversion au risque (CARA, CRRA, Arrow–Pratt) et les décisions multi-critères (MAUT, swing weights) ;
+- **Structurer** une décision par un diagramme d'influence et en extraire la politique optimale ;
+- **Chiffrer** la valeur d'une information avant de l'acquérir (EVPI, EVSI) et raisonner sous incertitude sévère (Minimax, regret) ;
+- **Résoudre** le séquentiel par programmation dynamique (MDP, équation de Bellman) et arbitrer exploration/exploitation (Thompson Sampling, indice de Gittins, UCB1) ;
+- **Distinguer** corrélation et causalité par le do-calculus de Pearl, et exécuter une estimation d'effet causal avec l'outil de référence `dowhy` ;
+- **Certifier** formellement les théorèmes de représentation (vNM), de cohérence (de Finetti) et d'escompte (Gittins) dans un assistant de preuve.
+
+## Parcours — l'histoire de la décision, des fondations au pont causal
+
+```mermaid
+flowchart TD
+    BAY["Corpus bayésien<br/>Infer/ · PyMC/<br/>(posteriors)"]
+    F["<b>Fondations</b><br/>axiomes vNM · utilité de l'argent<br/>aversion au risque"]
+    S["<b>Structure de décision</b><br/>multi-attributs · diagrammes d'influence<br/>valeur de l'information"]
+    R["<b>Robustesse & séquentiel</b><br/>Minimax/regret · MDP · Bellman"]
+    B["<b>Bandits</b><br/>Thompson Sampling · Gittins · UCB1"]
+    C["<b>Pont causal (capstone)</b><br/>échelle de Pearl · do-calculus · dowhy"]
+    LAKE["Lake decision_theory_lean<br/>vNM · de Finetti · Gittins"]
+    BAY -->|"posterior = entrée"| F
+    F --> S --> R --> B --> C
+    B -.->|"formalisation"| LAKE
+    F -.->|"formalisation"| LAKE
+    classDef lean fill:#fff3cd,stroke:#856404,stroke-width:2px;
+    class LAKE lean;
+```
+
+Le parcours suit une progression unique, portée en parallèle par les deux moteurs (Infer.NET et PyMC) :
+
+1. **Fondations** — On pose les axiomes de rationalité (von Neumann–Morgenstern), on dérive la fonction d'utilité, on modélise l'aversion au risque (paradoxe de Saint-Pétersbourg, CARA/CRRA). C'est ici qu'intervient le **premier notebook Lean** ([DecInfer-2](DecInfer/DecInfer-2-Lean-ExpectedUtility.ipynb)) : la direction saine du théorème de représentation vNM, prouvée `0 sorry`.
+2. **Structure de décision** — On passe des choix isolés aux décisions structurées : critères multiples (MAUT), diagrammes d'influence (nœuds de chance / décision / utilité), et surtout la **valeur de l'information** (EVPI, EVSI) — combien vaut un test avant de l'acheter.
+3. **Robustesse & séquentiel** — Décision sous incertitude sévère (Minimax, regret) puis passage au temps : processus de décision markoviens (MDP), équation de Bellman, itération valeur/politique.
+4. **Bandits** — L'arbitrage exploration/exploitation : Thompson Sampling (posterior Beta-Bernoulli calculé par le moteur), comparé à ε-greedy et UCB1. C'est ici qu'intervient le **second notebook Lean** ([DecInfer-9](DecInfer/DecInfer-9-Lean-Gittins.ipynb)) : l'indice de Gittins et les identités d'escompte géométrique.
+5. **Pont causal (capstone)** — [Do-Calculus-Bridge](Causal-Bridges/Do-Calculus-Bridge.ipynb) fédère les quatre traitements de la causalité disséminés dans le dépôt (Tweety logique, Infer.NET, PyMC, émergence causale PyPhi) autour de l'**échelle de Pearl** (association → intervention → contrefactuel) et du **do-calculus**, exécutés sur l'outil de référence [`dowhy`](https://www.pywhy.org/dowhy/). Une décision optimale suppose de savoir ce que l'on *cause*, pas seulement ce que l'on *observe*.
+
+## Structure et contenu
+
+### `DecInfer/` — l'arc de référence (Infer.NET + Lean 4)
+
+Dix notebooks, dont **huit en C#/.NET Interactive** (message passing EP/VMP) et **deux à kernel Lean 4** (companions natifs de preuve formelle). C'est l'arc canonique, le plus complet ; il va des axiomes vNM (notebook 1) jusqu'au Thompson Sampling (notebook 10), avec les preuves Lean de vNM (notebook 2) et de Gittins (notebook 9) intercalées à leur place pédagogique. **Détail notebook par notebook** : [`DecInfer/README.md`](DecInfer/README.md).
+
+### `PyMC/` — le miroir Python (MCMC)
+
+Sept notebooks Python (`DecPyMC-1..7`) qui rejouent les mêmes concepts par échantillonnage NUTS et diagnostics ArviZ. Le miroir n'est pas une simple traduction : il expose des variantes propres au paradigme stochastique (diagnostic hiérarchique multi-sites, profils de risque par inférence, état latent à test imparfait). **Détail** : [`PyMC/README.md`](PyMC/README.md).
+
+### `Causal-Bridges/` — le capstone causal (dowhy)
+
+Un notebook-pont unique, [Do-Calculus-Bridge](Causal-Bridges/Do-Calculus-Bridge.ipynb), qui relie l'arc décision au reste du dépôt par la question causale. Exécuté sur `dowhy` (kernel `coursia-ml-training`).
+
+### `decision_theory_lean` — la couche de certification (hors compte notebooks)
+
+Le lake Lean 4 [`decision_theory_lean`](../decision_theory_lean/), à la racine de la série Probas (visible des deux pistes), formalise trois résultats canoniques :
+
+- **Utility** — la représentation d'utilité espérée de von Neumann–Morgenstern : les quatre axiomes (complétude, transitivité, indépendance, continuité/Archimède), la **direction saine** du théorème (représentation ⟹ rationalité) et la stabilité affine, démontrées **sans aucun `sorry`**. La direction d'existence (Herstein–Milnor 1953) est documentée comme jalon ouvert.
+- **Coherence** — la cohérence de de Finetti / Dutch Book : la direction constructive (cas fini) et le cas mono-ticket sont **clos sans `sorry`** ; des prix de pari incohérents exposent l'agent à un livret de paris à perte sûre, via l'identité d'inclusion–exclusion.
+- **Gittins** — le bandit actualisé à horizon infini : les **briques de l'escompte géométrique sont entièrement prouvées** ; le théorème phare d'optimalité de l'indice reste **énoncé mais intraitable** dans le Mathlib actuel (pas de formalisation MDP/Bellman), maintenu en `sorry` documenté — un jalon honnête, non un trou masqué.
+
+Le lake suit la convention i18n FR/EN de la série (fichiers `*_en.lean` miroirs). **Détail** : [`decision_theory_lean/README.md`](../decision_theory_lean/README.md).
+
+## Prérequis et démarrage
+
+**Prérequis pédagogique** : le corpus bayésien correspondant — [`Infer/`](../Infer/README.md) pour la piste C#, [`PyMC/`](../PyMC/README.md) pour la piste Python (notamment les réseaux bayésiens et les posteriors Beta). Aucune connaissance préalable en théorie de la décision.
+
+**Environnements** :
+
+- **Piste Infer.NET (`DecInfer/`)** : .NET 9.0 + `dotnet-interactive`. Voir [`../README.md`](../README.md#installation) pour l'installation du kernel.
+- **Piste PyMC (`PyMC/`) et pont causal (`Causal-Bridges/`)** : Python 3.10+, kernel `coursia-ml-training` (`pymc`, `arviz`, `dowhy`).
+- **Companions Lean (`DecInfer-2`, `DecInfer-9`)** : kernel Lean 4 (WSL) + lake [`decision_theory_lean`](../decision_theory_lean/). Compilation : `lake -R build` dans le dossier du lake.
+
+Chaque sous-série démarre par ses fondations (`DecInfer-1` / `DecPyMC-1`) et se lit dans l'ordre numérique — la progression est cumulative.
+
+## Références
+
+- Von Neumann, J. & Morgenstern, O. (1944). *Theory of Games and Economic Behavior*.
+- Howard, R. A. & Matheson, J. E. (1984). *Influence Diagrams*.
+- Gittins, J. C. (1979). *Bandit Processes and Dynamic Allocation Indices*. Weber, R. (1992), preuve simplifiée.
+- Pearl, J. (2009). *Causality: Models, Reasoning, and Inference* (2ᵉ éd.).
+- de Finetti, B. (1937). *La prévision : ses lois logiques, ses sources subjectives*.
+
+---
+
+*Cet arc fait partie de la série [Probas](../README.md) du dépôt [CoursIA](https://github.com/jsboige/CoursIA). Documentation détaillée de chaque notebook dans les README des sous-séries.*

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -13,16 +13,16 @@ maturity: PRODUCTION=53, BETA=5
 
 Le monde réel est incertain. Un diagnostic médical n'est jamais sûr à 100%, un classement sportif dépend de performances intrinsèquement variables, et les données que nous collectons sont toujours bruitées ou incomplètes. La programmation probabiliste offre un cadre rigoureux pour modéliser cette incertitude : plutôt que de calculer une seule réponse, on obtient une **distribution de probabilités** qui quantifie notre confiance dans chaque résultat possible.
 
-Cette série couvre trois stacks complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inférence exacte par message passing, **PyMC** (Python) pour l'échantillonnage MCMC moderne, et des **applications standalone** (RSA). Les **28 notebooks Infer.NET** (C#/.NET Interactive) se scindent en deux arcs : **19 notebooks bayésiens** ([`Infer/`](Infer/README.md)) couvrant les fondements (distributions, graphs de facteurs), les modèles classiques (réseaux bayésiens, TrueSkill, LDA, HMM) et les frontières (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman, détection de rupture, analyse de survie) ; puis **les 10 notebooks de l'arc décision** ([`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md)) — 8 notebooks **C#** (utilité espérée, EVPI, MDPs, bandits, jusqu'au Thompson Sampling DecInfer-10) et **2 notebooks Lean 4** (DecInfer-2, utilité espérée vNM ; DecInfer-9, Gittins). Cet arc décision est complété par ses **7 miroirs Python** ([`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md)) et par un lake compagnon **Lean 4** ([`decision_theory_lean`](decision_theory_lean/)), exécuté par les deux notebooks à kernel Lean de l'arc (DecInfer-2, utilité espérée vNM ; DecInfer-9, Gittins) : les identités d'escompte de l'indice de Gittins y sont démontrées (`0 sorry`), le théorème d'optimalité restant énoncé — sa preuve complète attend une formalisation des MDP absente de Mathlib. Les **19 notebooks PyMC corpus** ([`PyMC/`](PyMC/README.md), numérotés 1 à 19 en **parité 1:1** avec Infer — fondations, modèles classiques et inférence causale (PyMC-5), puis les frontières : séquences (14), systèmes de reco (15), processus gaussien épars (16), filtre de Kalman (17), change-point (18), analyse de survie (19)) portent les modèles Infer.NET en Python avec l'échantillonnage NUTS, offrant un pont naturel vers l'écosystème data science ; les 7 notebooks décision PyMC vivent en [`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md) (renumérotés 1-7). Enfin, un **notebook-pont** ([`DecisionTheory/Causal-Bridges/`](DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb), Python via kernel `coursia-ml-training`) fédère les quatre traitements de la causalité disséminés dans le dépôt — Tweety (logique), Infer.NET, PyMC et l'émergence causale (PyPhi) — autour de l'échelle de Pearl et du do-calculus, exécutés sur l'outil de référence [`dowhy`](https://www.pywhy.org/dowhy/).
+Cette série couvre trois stacks complémentaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inférence par **message passing déterministe** (EP/VMP, plus un échantillonneur de Gibbs disponible), **PyMC** (Python) pour l'**échantillonnage stochastique MCMC** (NUTS), et des **applications standalone** (RSA). Elle totalise **58 notebooks** — **28 en C#/.NET Interactive**, **28 en Python**, **2 en Lean 4** (voir le marqueur `CATALOG-STATUS` ci-dessus pour le décompte autoritatif). Le versant Infer.NET se scinde en **19 notebooks bayésiens** ([`Infer/`](Infer/README.md)) — fondements (distributions, graphes de facteurs), modèles classiques (réseaux bayésiens, TrueSkill, LDA, HMM) et frontières (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman, détection de rupture, analyse de survie) — plus **8 notebooks C# de l'arc décision** ([`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) : utilité espérée, EVPI, MDPs, bandits, jusqu'au Thompson Sampling DecInfer-10) et le standalone **Infer-101**. Le versant PyMC porte ces modèles en Python avec l'échantillonnage NUTS : **19 notebooks corpus** ([`PyMC/`](PyMC/README.md), en parité 1:1 avec Infer — fondations, modèles classiques, inférence causale, puis frontières : séquences, reco, processus gaussien épars, filtre de Kalman, change-point, survie) et **7 miroirs de l'arc décision** ([`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md), renumérotés 1-7). L'arc décision est en outre certifié par un lake compagnon **Lean 4** ([`decision_theory_lean`](decision_theory_lean/)) et ses **2 notebooks à kernel Lean** (DecInfer-2, utilité espérée vNM ; DecInfer-9, indice de Gittins) : les identités d'escompte y sont démontrées (`0 sorry`), le théorème d'optimalité restant énoncé — sa preuve complète attend une formalisation des MDP absente de Mathlib. Enfin, un **notebook-pont** ([`DecisionTheory/Causal-Bridges/`](DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb), Python via kernel `coursia-ml-training`) fédère les quatre traitements de la causalité disséminés dans le dépôt — Tweety (logique), Infer.NET, PyMC et l'émergence causale (PyPhi) — autour de l'échelle de Pearl et du do-calculus, exécutés sur l'outil de référence [`dowhy`](https://www.pywhy.org/dowhy/).
 
 ## Pourquoi cette série
 
 La programmation probabiliste occupe une place singulière dans le paysage de l'IA. Alors que le machine learning classique fournit des prédictions ponctuelles (un score, une classe), il ne dit pas à quel point il a confiance en cette prédiction. La programmation probabiliste, elle, quantifie cette incertitude de façon native.
 
-Cette série repose sur une **double approche d'inférence**, délibérément juxtaposée :
+Cette série repose sur une **double approche d'inférence**, délibérément juxtaposée. L'axe de comparaison est **déterministe vs stochastique** (message passing vs échantillonnage), *non* « exact vs approché » : le moteur EP par défaut d'Infer.NET est lui-même approché dans le cas général (exact seulement sur les réseaux discrets sans boucle), et Infer.NET propose *aussi* un échantillonneur de Gibbs. Les deux stacks recouvrent donc des méthodes approchées ; ce qui les distingue, c'est le **mécanisme**, pas l'exactitude.
 
-- **Inférence exacte par message passing** (Infer.NET) : pour les modèles où les distributions postérieures peuvent être calculées exactement (ou approchées par EP/VMP). C'est la méthode des graphes de facteurs, où les probabilités se propagent le long des arêtes comme des messages. Avantage : résultats déterministes, rapide, visualisation du graphe de facteurs. Limite : ne s'applique qu'à une famille restreinte de modèles.
-- **Inférence approchée par échantillonnage MCMC** (PyMC) : pour les modèles plus génériques où l'inférence exacte est intractable. NUTS (No-U-Turn Sampler) explore l'espace posterior en simulant une dynamique hamiltonienne. Avantage : s'applique à presque tout modèle. Limite : résultats stochastiques, temps de convergence variable, diagnostic nécessaire.
+- **Message passing déterministe** (Infer.NET) : les probabilités se propagent le long des arêtes d'un graphe de facteurs comme des messages. Trois moteurs : **EP** (Expectation Propagation, défaut — rapide, approché en général, exact sur les modèles discrets sans boucle), **VMP** (variationnel — stable, sous-estime l'incertitude) et **Gibbs** (échantillonnage — exact asymptotiquement, lent, utile pour valider EP/VMP). Avantage : résultats reproductibles et rapides, visualisation du graphe de facteurs. Limite : chaque moteur ne couvre qu'une famille restreinte de modèles.
+- **Échantillonnage stochastique MCMC** (PyMC) : pour les modèles génériques où le message passing déterministe ne s'applique pas. NUTS (No-U-Turn Sampler) explore l'espace posterior en simulant une dynamique hamiltonienne. Avantage : s'applique à presque tout modèle. Limite : résultats stochastiques, temps de convergence variable, diagnostic nécessaire (R-hat, ESS, trace plots).
 
 Avoir les deux approches sur les mêmes modèles permet de comprendre leur **champ d'application** et leurs **compromis**, une connaissance cruciale pour tout praticien.
 
@@ -106,7 +106,7 @@ dotnet --version
 #### Pour Python
 
 ```bash
-# Environnement Python 3.8+
+# Environnement Python 3.10+
 pip install pyro-ppl torch matplotlib numpy
 ```
 
@@ -171,15 +171,15 @@ Suivez le même modèle dans les deux stacks pour comparer les approches :
 
 | Concept | Infer.NET | PyMC | Différence principale |
 |---------|-----------|------|----------------------|
-| Fondations | Infer-1 → 2 → 3 | PyMC-1 → 2 → 3 | EP/VMP (exact) vs NUTS (MCMC) |
+| Fondations | Infer-1 → 2 → 3 | PyMC-1 → 2 → 3 | Message passing déterministe (EP/VMP) vs échantillonnage NUTS |
 | Réseaux bayésiens | Infer-4 | PyMC-4 | Compilation statique vs échantillonnage dynamique |
 | IRT (compétences) | Infer-7 | PyMC-7 | Variable.If vs pm.Bernoulli |
-| TrueSkill | Infer-8 | PyMC-8 | Message passing exact vs MCMC approximatif |
+| TrueSkill | Infer-8 | PyMC-8 | Message passing déterministe (EP) vs échantillonnage MCMC |
 | Classification | Infer-9 | PyMC-9 | Bayes Point Machine vs régression logistique |
 | Model sélection | Infer-10 | PyMC-10 | Bayes Factors vs LOO/Pareto-SMI |
 | Topic modeling | Infer-11 | PyMC-11 | VMP vs NUTS sur variables latentes |
 | Crowdsourcing | Infer-13 | PyMC-13 | Worker models EP vs MCMC agrégation |
-| Séquences (HMM) | Infer-14 | PyMC-14 | Forward-backward exact vs échantillonné |
+| Séquences (HMM) | Infer-14 | PyMC-14 | Forward-backward exact (chaîne sans boucle) vs échantillonné |
 | Recommenders | Infer-15 | PyMC-15 | Factorisation bayésienne statique vs MCMC |
 | Debugging | Infer-6 | PyMC-6 | ShowFactorGraph vs trace plot diagnostics |
 | Causal Inference | Infer-5 | PyMC-5 | do-calculus message passing vs pm.do MCMC |
@@ -227,11 +227,11 @@ flowchart TD
     START --> Q1{"Vous venez du<br/>C# / .NET ?"}
     START --> Q2{"Vous venez du<br/>Python / data science ?"}
     START --> Q3{"Indécis ?<br/>Découverte rapide"}
-    Q1 -->|"oui"| INFER["<b>Infer.NET</b><br/>API C# native · Roslyn ·<br/>factor graphs · inference exacte<br/>(EP/VMP)"]
+    Q1 -->|"oui"| INFER["<b>Infer.NET</b><br/>API C# native · Roslyn ·<br/>factor graphs · message passing<br/>déterministe (EP/VMP/Gibbs)"]
     Q2 -->|"oui"| PYMC["<b>PyMC</b><br/>with pm.Model() · NUTS ·<br/>écosystème pandas/arviz"]
     Q3 --> IN101["<b>Infer-101</b><br/>(standalone, 45 min)"]
     INFER --> PIVOT1{"Modèle trop complexe<br/>ou pipeline Python ?"}
-    PYMC --> PIVOT2{"Besoin d'inference exacte<br/>(VMP/EP) ou .NET ?"}
+    PYMC --> PIVOT2{"Besoin de message passing<br/>déterministe (VMP/EP) ou .NET ?"}
     PIVOT1 -->|"oui"| PYMC
     PIVOT2 -->|"oui"| INFER
     classDef infer fill:#d4edda,stroke:#28a745,stroke-width:2px;
@@ -246,7 +246,7 @@ Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passi
 
 ### Si vous venez du C# / .NET
 
-**Commencez par Infer.NET.** L'API est native C# (`Variable.GaussianFromMeanAndVariance`), le compilateur Roslyn intègre au .NET Interactive gère la compilation dynamique, et la visualisation des graphes de facteurs via FactorGraphHelper offre une compréhension intuitive de la structure du modèle. C'est le choix idéal pour comprendre l'inférence exacte et le message passing.
+**Commencez par Infer.NET.** L'API est native C# (`Variable.GaussianFromMeanAndVariance`), le compilateur Roslyn intègre au .NET Interactive gère la compilation dynamique, et la visualisation des graphes de facteurs via FactorGraphHelper offre une compréhension intuitive de la structure du modèle. C'est le choix idéal pour comprendre le message passing déterministe (EP/VMP) et la structure des graphes de facteurs.
 
 **Passez à PyMC quand :** vous avez un modèle trop complexe pour Infer.NET (variables latentes discrètes à grande taille), ou vous voulez intégrer le modèle dans un pipeline Python (pandas, scikit-learn, visualisation).
 
@@ -254,7 +254,7 @@ Deux stacks, un même parcours de 20 modèles : **Infer.NET** (C#, message passi
 
 **Commencez par PyMC.** La syntaxe `with pm.Model(): ...` est plus familière aux data scientists, l'échantillonnage NUTS gère automatiquement les géométries complexes du posterior, et l'écosystème (arviz, pandas, matplotlib) est naturel.
 
-**Passez à Infer.NET quand :** vous voulez comprendre l'inférence exacte (VMP/EP) qui donne des résultats déterministes et rapides, ou vous êtes dans un environnement .NET. La visualisation du factor graph (FactorGraphHelper) est aussi un outil pédagogique unique pour comprendre les dépendances du modèle.
+**Passez à Infer.NET quand :** vous voulez comprendre le message passing déterministe (VMP/EP), qui donne des résultats reproductibles et rapides sans échantillonnage, ou vous êtes dans un environnement .NET. La visualisation du factor graph (FactorGraphHelper) est aussi un outil pédagogique unique pour comprendre les dépendances du modèle.
 
 ### Si vous ne savez pas quoi choisir
 
@@ -276,10 +276,9 @@ Probas/
 ├── Pyro_RSA_Hyperbole.ipynb     # Pragmatique linguistique (Python)
 ├── GeneratedSource/             # Sources Infer.NET compilées (Model0_EP.cs ... Model10_VMP.cs)
 ├── PyMC/                # Port PyMC : bayésien + causal (1-13, dont PyMC-5 causal) + séquences/reco/GP (14-16) + frontières (17-19)
-│   ├── PyMC-1-Setup.ipynb ... PyMC-19-Survival-Analysis.ipynb (15 GP livre)
-│   ├── README.md                # Documentation détaillée de la série PyMC
-│   └── (port en cours d'enrichissement)
-├── decision_theory_lean/        # Projet Lake (racine série) : escompte géométrique + théorème de Gittins ; héberge VNM (#4049 MERGED via PR #4250) + Coherence/Dutch Book (#4150 MERGED via PR #4193)
+│   ├── PyMC-1-Setup.ipynb ... PyMC-19-Survival-Analysis.ipynb
+│   └── README.md                # Documentation détaillée de la série PyMC
+├── decision_theory_lean/        # Projet Lake (racine série) : escompte géométrique + théorème de Gittins ; héberge les preuves VNM et Coherence/Dutch Book
 ├── Infer/                       # Corpus bayésien Infer.NET (19 notebooks)
 │   ├── Infer-1-Setup.ipynb ... Infer-19-Survival-Analysis.ipynb
 │   ├── README.md                # Documentation détaillée de la série bayésienne
@@ -287,9 +286,9 @@ Probas/
 │   ├── FactorGraphHelper.cs     # Helper visualisation graphes de facteurs
 │   ├── Model_*.gv / .svg        # Graphviz export des modèles
 │   └── scripts/                 # test_notebooks.py + setup_environment.ps1
-└── DecisionTheory/              # Arc théorie de la décision (#4725) : Infer.NET + PyMC (miroirs) + pont causal
+└── DecisionTheory/              # Arc théorie de la décision : Infer.NET + PyMC (miroirs) + pont causal
     ├── DecInfer/                # DecInfer-1-Utility-Foundations ... DecInfer-10-Thompson-Sampling (+ companions Lean 2/9)
-    ├── PyMC/                    # DecPyMC-1-Utility-Foundations ... DecPyMC-7-Sequential (renommés post-#5081)
+    ├── PyMC/                    # DecPyMC-1-Utility-Foundations ... DecPyMC-7-Sequential
     └── Causal-Bridges/          # Do-Calculus-Bridge : pont unifié des 4 séries causales (Pearl, dowhy)
 ```
 
@@ -321,7 +320,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 18 | Change-Point | `DiscreteUniform` + `switch`, détection de rupture bayésienne |
 | 19 | Survival Analysis | Exponentiel conjugué (Gamma), Weibull `k` inféré, sélection LOO |
 
-> **Note** : l'arc **théorie de la décision** (10 notebooks) vit désormais dans [`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) (renumérotation 1-10 post-#5081), voir tableau dédié ci-dessous.
+> **Note** : l'arc **théorie de la décision** (10 notebooks) vit désormais dans [`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) (renumérotation 1-10), voir tableau dédié ci-dessous.
 
 ### Série PyMC
 
@@ -347,7 +346,7 @@ Chaque notebook introduit un concept ou modèle spécifique. Le tableau ci-desso
 | 18 | Change-Point | Switch bayésien, catastrophes minières (Poisson) |
 | 19 | Survival Analysis | Weibull inféré directement, sélection LOO arviZ |
 
-> **Note** : l'arc **théorie de la décision** PyMC (7 notebooks) vit dans [`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md) (renommés `DecPyMC-1..7` post-#5081), voir tableau dédié ci-dessous.
+> **Note** : l'arc **théorie de la décision** PyMC (7 notebooks) vit dans [`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md) (renommés `DecPyMC-1..7`), voir tableau dédié ci-dessous.
 
 ## Notebooks racine (Python)
 
@@ -372,7 +371,7 @@ Application avancée à la linguistique pragmatique :
 - Modélisation des hyperboles (prix, excitation)
 - Question Under Discussion (QUD)
 
-## Série Infer.NET (28 notebooks C#/.NET + 2 Lean 4 : 19 corpus C# + 8 arc décision C# + 2 Lean arc décision)
+## Série Infer.NET (19 corpus bayésien C# + 8 arc décision C# + 2 Lean 4)
 
 La série C#/.NET se scinde en deux arcs : le **corpus bayésien** (19 notebooks C#, [`Infer/`](Infer/README.md)) et l'**arc théorie de la décision** ([`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md)) qui mixe deux kernels — 8 notebooks **C#** (utilité espérée, EVPI, MDPs, bandits, Thompson Sampling DecInfer-10) et 2 notebooks **Lean 4** (DecInfer-2 utilité espérée vNM et DecInfer-9 indice de Gittins, formalisation des lemmes). L'ensemble `DecisionTheory/` compte 18 notebooks : ces 10 DecInfer (8 C# + 2 Lean), leurs 7 miroirs Python [`DecisionTheory/PyMC/`](DecisionTheory/PyMC/README.md), et le notebook-pont causal [`Do-Calculus-Bridge`](DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb) — plus le lake compagnon Lean [`decision_theory_lean`](decision_theory_lean/) (hors compte notebooks). La documentation détaillée de chaque notebook, les patterns Infer.NET avancés et les exercices corrigés vivent dans ces README.
 
@@ -385,7 +384,7 @@ La série C#/.NET se scinde en deux arcs : le **corpus bayésien** (19 notebooks
 | **Frontières bayésiennes** | 14-19 | Causalité, GP sparse, hiérarchique, filtre de Kalman, change-point, survie | 4,5h |
 | **Décision (arc autonome)** | [DecisionTheory/DecInfer/ 1-10](DecisionTheory/DecInfer/README.md) | Théorie de la décision bayésienne + preuve Lean de Gittins | 7h |
 
-Les **28 notebooks Infer.NET C#** (et les **2 notebooks Lean 4** de l'arc décision) sont détaillés individuellement dans [*Ce que chaque notebook apporte*](#ce-que-chaque-notebook-apporte) ci-dessous (apport pédagogique par notebook) ; le contenu exhaustif — patterns avancés, exercices corrigés — vit dans [Infer/README.md](Infer/README.md), [DecisionTheory/DecInfer/README.md](DecisionTheory/DecInfer/README.md) et [DecisionTheory/PyMC/README.md](DecisionTheory/PyMC/README.md).
+Les **27 notebooks Infer.NET C#** (19 du corpus bayésien + 8 de l'arc décision) et les **2 notebooks Lean 4** de l'arc décision sont détaillés individuellement dans [*Ce que chaque notebook apporte*](#ce-que-chaque-notebook-apporte) ci-dessous (apport pédagogique par notebook) ; le contenu exhaustif — patterns avancés, exercices corrigés — vit dans [Infer/README.md](Infer/README.md), [DecisionTheory/DecInfer/README.md](DecisionTheory/DecInfer/README.md) et [DecisionTheory/PyMC/README.md](DecisionTheory/PyMC/README.md).
 
 ## Série PyMC (19 corpus notebooks, Python + 7 extraits DecisionTheory/PyMC)
 
@@ -407,10 +406,10 @@ Port Python des modèles Infer.NET, utilisant l'échantillonnage MCMC (NUTS) au 
 | 5 | [PyMC-7-Skills-IRT](PyMC/PyMC-7-Skills-IRT.ipynb) | Item Response Theory, modèles de compétences |
 | 6 | [PyMC-8-TrueSkill](PyMC/PyMC-8-TrueSkill.ipynb) | Classement, TrueSkill |
 | 7 | [PyMC-9-Classification](PyMC/PyMC-9-Classification.ipynb) | Classification bayésienne |
-| 8 | [PyMC-8-Model-Sélection](PyMC/PyMC-10-Model-Selection.ipynb) | Sélection de modèles, Bayes Factors |
+| 8 | [PyMC-10-Model-Selection](PyMC/PyMC-10-Model-Selection.ipynb) | Sélection de modèles, Bayes Factors |
 | 9 | [PyMC-11-Topic-Models](PyMC/PyMC-11-Topic-Models.ipynb) | LDA, Dirichlet priors |
 | 10 | [PyMC-13-Crowdsourcing](PyMC/PyMC-13-Crowdsourcing.ipynb) | Agrégation de labels, workers, communautés |
-| 11 | [PyMC-11-Séquences](PyMC/PyMC-14-Sequences.ipynb) | HMM, chaînes de Markov cachées, séquences temporelles |
+| 11 | [PyMC-14-Sequences](PyMC/PyMC-14-Sequences.ipynb) | HMM, chaînes de Markov cachées, séquences temporelles |
 | 12 | [PyMC-15-Recommenders](PyMC/PyMC-15-Recommenders.ipynb) | Systèmes de recommandation bayésiens, factorisation |
 | 13 | [PyMC-6-Debugging](PyMC/PyMC-6-Debugging.ipynb) | Troubleshooting MCMC, diagnostics NUTS, bonnes pratiques |
 
@@ -568,12 +567,12 @@ Cette série ancre mathématiquement ses résultats phares dans un assistant de 
 | Famille                  | Lake phare                       | Théorème                                                                          | Branchement notebook                                                |
 | ---                      | ---                              | ---                                                                               | ---                                                                  |
 | Probas (DecisionTheory)  | `decision_theory_lean`           | Axiomes de Von Neumann-Morgenstern ⇒ existence d'une utilité espérée (`0 sorry`)  | [`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) Infer-14b  |
-| Probas (DecisionTheory)  | `decision_theory_lean`           | Coherence utility ⟹ preferences (loterie de référence) `#4150 MERGED`             | [`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) Coherence   |
+| Probas (DecisionTheory)  | `decision_theory_lean`           | Coherence utility ⟹ preferences (loterie de référence) (`0 sorry`)                | [`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md) Coherence   |
 | Probas (PAC Learning)    | chaîne PAC iter-2 complète       | `pac_finite_class_bound` + `pac_agnostic_generalization` (`0 sorry bout-en-bout`)  | notebook PAC Learning compagnon Lean                                 |
 | Probas (DecisionTheory)  | `decision_theory_lean` Peters    | Indice de Gittins, identités d'escompte (`0 sorry`, ref `v4.27.0-rc1`)            | DecInfer-9 (companion Lean)                                          |
-| QC ↔ Probas              | `kelly_lean` `#4052`             | Fraction risquée `f* = μ−σ²/2` sous log-bienveillance (`0 sorry`, `#4164 SHIPPED`) | notebook `kelly-criterion`                                           |
+| QC ↔ Probas              | `kelly_lean`                     | Fraction risquée `f* = μ−σ²/2` sous log-bienveillance (`0 sorry`)                  | notebook `kelly-criterion`                                           |
 | GameTheory ↔ Probas      | `social_choice_lean`             | Impossibilité d'Arrow (5 axiomes ⇒ dictature)                                     | hub GameTheory notebook 16a                                          |
-| Search ↔ Probas          | `search_lean` `#4048`             | Consistance heuristique `h ≤ h*` ⇒ optimalité `A*`                                 | hub Search notebook `A*` phases 1-3 (`#4090 SHIPPED`)                |
+| Search ↔ Probas          | `search_lean`                    | Consistance heuristique `h ≤ h*` ⇒ optimalité `A*`                                 | hub Search notebook `A*` phases 1-3                                  |
 | SymbolicAI ↔ Probas      | `argumentation_lean`             | Extension Dung (`grounded`/`preferred`/`stable`) par cadre formel                 | hub SymbolicAI/Tweety notebook AF-Dung                               |
 
 ```mermaid
@@ -608,9 +607,9 @@ flowchart LR
     style LK_SC fill:#e8f5e9,stroke:#2e7d32
 ```
 
-La double culture Probas tient en deux gestes complémentaires. D'un côté, **simuler** : PyMC fait tourner NUTS/HMC sur des modèles hiérarchiques, Infer.NET propage des messages EP/VMP sur des graphes factoriels, et les notebooks PAC entraînent des hypothèses parERM. De l'autre, **prouver** : `decision_theory_lean` (VNM résolu 0 sorry #4049, Coherence #4150 MERGED, mono-livret #4193 OPEN) certifie que les axiomes de rationalité impliquent l'existence d'une utilité espérée, et la chaîne PAC iter-2 démontre `pac_agnostic_generalization` de bout en bout sans `sorry`. Les deux faces du même raisonnement bayésien et décisionnel — l'une touche l'intuition numérique, l'autre ancre la garantie formelle.
+La double culture Probas tient en deux gestes complémentaires. D'un côté, **simuler** : PyMC fait tourner NUTS/HMC sur des modèles hiérarchiques, Infer.NET propage des messages EP/VMP sur des graphes factoriels, et les notebooks PAC entraînent des hypothèses parERM. De l'autre, **prouver** : `decision_theory_lean` (VNM et Coherence certifiés, `0 sorry`) certifie que les axiomes de rationalité impliquent l'existence d'une utilité espérée, et la chaîne PAC iter-2 démontre `pac_agnostic_generalization` de bout en bout sans `sorry`. Les deux faces du même raisonnement bayésien et décisionnel — l'une touche l'intuition numérique, l'autre ancre la garantie formelle.
 
-EPIC [#4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) · cross-ref hubs [`QC` ↔ `kelly_lean`](../QuantConnect/README.md) (PR #5047), [central P0](../README.md) (PR #5049), [`GameTheory` ↔ `social_choice_lean`](../GameTheory/README.md) (PR #5050), [`SymbolicAI/Lean`](../SymbolicAI/Lean/README.md) (PR #5043 MERGED).
+EPIC [#4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) · cross-ref hubs [`QC` ↔ `kelly_lean`](../QuantConnect/README.md), [central P0](../README.md), [`GameTheory` ↔ `social_choice_lean`](../GameTheory/README.md), [`SymbolicAI/Lean`](../SymbolicAI/Lean/README.md).
 
 ## Conclusion / Prochaines étapes
 
@@ -619,7 +618,7 @@ EPIC [#4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean) · c
 Cette série vous a fait changer de regard sur l'incertitude : plutôt que de la fuir ou de l'ignorer, vous avez appris à la **modéliser, la quantifier et la traduire en décisions**. L'arc pédagogique se déploie en trois temps, porté par trois stacks complémentaires :
 
 - **Le geste fondateur** — remplacer une prédiction ponctuelle par une **distribution**. Un modèle probabiliste ne dit pas « la probabilité est 0.73 » mais « voici la distribution complète N(0.73, 0.12) », et cette densité porte l'information que la moyenne dissimule : la confiance, les queues, les modes multiples. C'est ce déplacement qui ouvre tout le reste.
-- **La double inférence** — Infer.NET (message passing, EP/VMP) et PyMC (NUTS, MCMC) résolvent les mêmes modèles par des voies opposées. Le traverser sur des modèles jumeaux (notebook à notebook, Infer-N ↔ PyMC-N) ancre une intuition qu'aucun cours théorique ne donne : **quand l'inférence exacte est tractable, elle est déterministe et rapide ; quand elle ne l'est plus, l'échantillonnage prend le relais mais exige des diagnostics** (R-hat, effective sample size, trace plots).
+- **La double inférence** — Infer.NET (message passing déterministe, EP/VMP/Gibbs) et PyMC (échantillonnage MCMC, NUTS) résolvent les mêmes modèles par des voies opposées : non pas « exact vs approché » (EP est lui-même approché en général), mais **déterministe vs stochastique**. Le traverser sur des modèles jumeaux (notebook à notebook, Infer-N ↔ PyMC-N) ancre une intuition qu'aucun cours théorique ne donne : **quand le message passing déterministe s'applique, il est rapide et reproductible ; quand le modèle sort de son domaine, l'échantillonnage prend le relais mais exige des diagnostics** (R-hat, effective sample size, trace plots).
 - **La décision** — la seconde moitié franchit le pas : des croyances (distributions) aux **actions**. Utilité espérée E[U], valeur de l'information (EVPI/EVSI), réseaux de décision, et enfin les MDP qui relient cette série à l'apprentissage par renforcement. Chez Infer.NET cet arc forme un **track autonome** ([`DecisionTheory/DecInfer/`](DecisionTheory/DecInfer/README.md)) ; son compagnon Lean 4 (DecInfer-9) pousse l'exigence jusqu'à **formaliser** les identités d'escompte de l'indice de Gittins — l'assurance que les identités numériques ne sont pas des approximations accidentelles mais des théorèmes.
 
 La thèse pratique est honnête : un modèle probabiliste est plus lourd à bâtir qu'un classifieur, mais il est le seul à pouvoir dire « je ne sais pas » — et dans le diagnostic médical, le classement sportif ou l'évaluation de compétences, cette honnêteté est précisément ce qu'on cherche.


### PR DESCRIPTION
## Contexte

Deux corrections demandées par le user sur la série [`Probas`](https://github.com/jsboige/CoursIA/tree/main/MyIA.AI.Notebooks/Probas), plus une passe de de-obsolescence dans le cadre de la réécriture ascendante des READMEs (#3973 / référence publique #4208).

## 1. Cadrage inférence — revert d'une régression récurrente (le point n°1 du user)

Plusieurs agents ont ré-introduit à répétition, malgré des reverts antérieurs, un cadrage **faux** « inférence exacte (Infer.NET) vs approximée (PyMC) ». C'est incorrect : **Infer.NET dispose aussi d'un échantillonneur de Gibbs**, et son moteur EP par défaut est lui-même **approché** dans le cas général. L'axe pertinent est **déterministe vs stochastique** (message passing vs échantillonnage), pas « exact vs approché » — cadrage établi en #4610.

Cette PR :
- rétablit ce cadrage dans l'intro, la section « double approche », le tableau des moteurs, les diagrammes mermaid et la conclusion ;
- **ajoute un énoncé d'axe explicite** (« L'axe de comparaison est déterministe vs stochastique, *non* exact vs approché : le moteur EP par défaut est lui-même approché… et Infer.NET propose *aussi* un échantillonneur de Gibbs ») pour **inoculer** contre la re-régression ;
- liste les trois moteurs Infer.NET (EP défaut/approché, VMP variationnel, Gibbs échantillonnage) ;
- **préserve les affirmations « exact » vraies au niveau modèle** (filtre de Kalman conjugué, forward-backward HMM sur chaîne sans boucle).

## 2. README DecisionTheory centralisé (le point n°2 du user)

La série `DecisionTheory/` avait des sous-dossiers (`DecInfer/`, `PyMC/`, `Causal-Bridges/`) mais **aucun README centralisé**. Nouveau fichier [`DecisionTheory/README.md`](MyIA.AI.Notebooks/Probas/DecisionTheory/README.md) :
- agrégateur des **18 notebooks** de l'arc : `DecInfer/` (10 = 8 C# + **2 Lean 4**), `DecPyMC/` (7 Python), `Causal-Bridges/` (1, dowhy), plus le lake compagnon `decision_theory_lean` ;
- **arc pédagogique progressif** : fondations vNM → structure de décision (diagrammes d'influence, valeur de l'information) → robustesse/séquentiel (Minimax, MDP/Bellman) → bandits (Thompson, Gittins) → **pont causal capstone** (échelle de Pearl, do-calculus) ;
- ordre de sections conforme #5985 (hook → pourquoi/à qui → objectifs → parcours → structure → prérequis → références) ;
- description honnête de la couche Lean (vNM sound + de Finetti constructif + escompte Gittins = `0 sorry` ; théorème d'optimalité Gittins = `sorry` documenté intraitable, pas un trou masqué) ;
- up-links des sous-READMEs `DecInfer/` et `PyMC/` vers l'agrégateur (navigation cohérente).

## 3. De-obsolescence du README principal

- **liens PyMC cassés dans le texte** : `PyMC-8-Model-Sélection` → `PyMC-10-Model-Selection`, `PyMC-11-Séquences` → `PyMC-14-Sequences` (le libellé visible ne correspondait pas à l'URL) ;
- `Python 3.8+` → `Python 3.10+` (règle code-style) ;
- **en-têtes de décompte cohérents** : `58 = 28 C#/.NET + 28 Python + 2 Lean 4` ; suppression des additions fausses (`19+8=27≠28`) et du double-comptage des 2 Lean ;
- **purge des cruft de statut PR/issue périmés** (`#4150 MERGED`, `#4193 OPEN`, `#4164/#4090 SHIPPED`, `#4725`, `post-#5081`, `PR #50xx`) — jargon d'issue-tracking qui n'a pas sa place dans une doc destinée à devenir référence publique (harness-hygiene).

## Vérification

- Catalogue byte-identique à `main` (aucun `COURSE_CATALOG.*` ni marqueur `CATALOG-STATUS` touché) — catalog-pr-hygiene ✓
- Inventaire notebooks vérifié firsthand par `ls` : DecInfer 10, DecPyMC 7, Causal-Bridges 1, Infer 19, PyMC 19, root 2 = 58 ✓
- Couche Lean vérifiée firsthand contre le README du lake `decision_theory_lean`
- README-only, aucun notebook / output modifié ; net +108 lignes (création agrégateur), pas de suppression de contenu pédagogique

See #4610
Part of #3973
Part of #4208

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>