### PR TITLE
docs(genai-video): #5780 figures narrative — dissoudre la galerie en narration in-situ par niveau

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -17,22 +17,7 @@ L'objectif fil rouge de cette série est de construire un pipeline capable de tr
 
 ## Aperçu — la vidéo par IA en images
 
-Six figures extraites des notebooks illustrent la chaîne complète, depuis l'extraction de frames et l'upscaling jusqu'à la génération text-to-video et les workflows de production.
-
-<table>
-<tr>
-<td align="center"><b>01-1 · Frames</b><br><a href="01-Foundation/01-1-Video-Operations-Basics.ipynb"><img src="assets/readme/video1-frames.png" width="290" alt="Extraction de frames : découpe d'une vidéo en images clés avec decord pour l'analyse."></a></td>
-<td align="center"><b>01-4 · ESRGAN</b><br><a href="01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb"><img src="assets/readme/video4-esrgan.png" width="290" alt="Upscaling ESRGAN : comparaison basse résolution avant/après agrandissement par réseau."></a></td>
-<td align="center"><b>01-5 · AnimateDiff</b><br><a href="01-Foundation/01-5-AnimateDiff-Introduction.ipynb"><img src="assets/readme/video5-animatediff.png" width="290" alt="Génération text-to-video AnimateDiff : animation produite depuis un prompt textuel."></a></td>
-</tr>
-<tr>
-<td align="center"><b>02-4 · SVD</b><br><a href="02-Advanced/02-4-SVD-Image-to-Video.ipynb"><img src="assets/readme/video-svd.png" width="290" alt="Stable Video Diffusion : animation d'une image statique en séquence vidéo."></a></td>
-<td align="center"><b>04-2 · Style</b><br><a href="04-Applications/04-2-Creative-Video-Workflows.ipynb"><img src="assets/readme/video-creative-style.png" width="290" alt="Transfert de style vidéo : application du style d'une image de référence à chaque frame."></a></td>
-<td align="center"><b>04-3 · Sora</b><br><a href="04-Applications/04-3-Sora-API-Cloud-Video.ipynb"><img src="assets/readme/video-sora-cost.png" width="290" alt="Sora (cloud) vs local : comparaison de coût selon le volume de génération vidéo."></a></td>
-</tr>
-</table>
-
-Chaque figure renvoie au notebook dont elle est extraite ; la provenance détaillée (cellule, output, poids, alt-text) figure dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
+Chacun des quatre niveaux de la série rend visible un geste technique distinct, dans une figure extraite des sorties réelles des notebooks : l'extraction de frames et le surcadrage par réseau (Fondations), l'animation d'une image statique (Avancé), puis les workflows créatifs et l'arbitrage coût cloud/local (Applications). Plutôt qu'une galerie séparée du propos, ces figures accompagnent ci-dessous le récit **niveau par niveau**, au plus près du concept qu'elles illustrent. La provenance exacte de chaque figure (cellule, output, poids, alt-text) est documentée dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
 ## Prérequis
 
@@ -65,6 +50,12 @@ winget install FFmpeg
 
 On ne peut pas créer ce qu'on ne comprend pas. Ce niveau pose les bases techniques (codecs, ffmpeg, moviepy) et introduit la compréhension vidéo par IA : décomposer une séquence en scènes, répondre à des questions sur le contenu, analyser le mouvement. Vous découvrirez aussi le surcadrage d'images (ESRGAN) et l'interpolation de frames (RIFE) pour améliorer la qualité visuelle. À la fin de ce niveau, vous savez analyser une vidéo existante et en extraire des informations structurelles.
 
+<p align="center"><a href="01-Foundation/01-1-Video-Operations-Basics.ipynb"><img src="assets/readme/video1-frames.png" width="540" alt="Extraction de frames : découpe d'une vidéo en images clés avec decord pour l'analyse."></a></p>
+
+<p align="center"><a href="01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb"><img src="assets/readme/video4-esrgan.png" width="540" alt="Upscaling ESRGAN : comparaison basse résolution avant/après agrandissement par réseau."></a></p>
+
+<p align="center"><a href="01-Foundation/01-5-AnimateDiff-Introduction.ipynb"><img src="assets/readme/video5-animatediff.png" width="560" alt="Génération text-to-video AnimateDiff : animation produite depuis un prompt textuel."></a></p>
+
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
 | [01-1-Video-Operations-Basics](01-Foundation/01-1-Video-Operations-Basics.ipynb) | moviepy, ffmpeg, decord, codecs | Local | 0 |
@@ -76,6 +67,8 @@ On ne peut pas créer ce qu'on ne comprend pas. Ce niveau pose les bases techniq
 ### 02-Advanced - Générer du mouvement à partir de texte ou d'images
 
 Ce niveau explore les modèles génératifs vidéo : HunyuanVideo pour la qualité cinématographique (malgré ses 24 GB de VRAM), LTX-Video pour la génération rapide sur des configurations modestes, Wan pour les prompts multilingues, et Stable Video Diffusion pour animer une image existante. Chaque modèle a ses forces et ses limites — le but est de les connaître pour choisir le bon outil au bon moment. Le notebook 02-5 introduit en outre LTX-2 (Lightricks 22B), le seul modèle de la série qui génère vidéo **et audio synchronisés** en une seule passe de diffusion (quantization obligatoire : `fp8-cast` via ltx-pipelines — borderline sur 24 GB — ou GGUF Q4 via ComfyUI en production, ~14-24 GB VRAM).
+
+<p align="center"><a href="02-Advanced/02-4-SVD-Image-to-Video.ipynb"><img src="assets/readme/video-svd.png" width="540" alt="Stable Video Diffusion : animation d'une image statique en séquence vidéo."></a></p>
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -98,6 +91,10 @@ Un seul modèle ne suffit pas pour une production vidéo complète. Ce niveau co
 ### 04-Applications - Du pipeline à la production
 
 Les trois derniers notebooks et le notebook de synchronisation audio-vidéo concluent le parcours en abordant des cas d'usage réels : génération automatique de contenus éducatifs, workflows créatifs (transfert de style, clips musicaux), et l'API Sora 2 d'OpenAI pour la génération cloud. Le pipeline final intègre tout ce qui a été appris dans un système bout-en-bout.
+
+<p align="center"><a href="04-Applications/04-2-Creative-Video-Workflows.ipynb"><img src="assets/readme/video-creative-style.png" width="540" alt="Transfert de style vidéo : application du style d'une image de référence à chaque frame."></a></p>
+
+<p align="center"><a href="04-Applications/04-3-Sora-API-Cloud-Video.ipynb"><img src="assets/readme/video-sora-cost.png" width="560" alt="Sora (cloud) vs local : comparaison de coût selon le volume de génération vidéo."></a></p>
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|


### PR DESCRIPTION
## Contexte

EPIC #5780 (réouvert par ai-01 après fermeture prématurée par mot-clé #5947). Mandat user 2026-07-09 : *« D'une part je suis un peu étonné de voir arriver une 'galerie' d'images les unes à côté des autres. Si l'idée était de se servir des images pour créer une narration riche et aérée, la notion de rajouter une 'galerie' n'était pas vraiment dans l'esprit. »*

La section `## Aperçu` du README [Video](MyIA.AI.Notebooks/GenAI/Video/README.md) présentait une galerie `<table>` de 6 vignettes côte-à-côte (width=290), séparée du propos pédagogique.

## Changement

On dissout la mosaïque en intégrant chaque figure **in-situ** à la fin du paragraphe du niveau qu'elle illustre (pattern Planners), au plus près du concept décrit :

| Figure | Notebook | Niveau d'intégration |
|--------|----------|----------------------|
| video1-frames | 01-1 | 01-Foundation (analyse d'une vidéo existante) |
| video4-esrgan | 01-4 | 01-Foundation (surcadrage par réseau) |
| video5-animatediff | 01-5 | 01-Foundation (text-to-video) |
| video-svd | 02-4 | 02-Advanced (animer une image statique) |
| video-creative-style | 04-2 | 04-Applications (workflows créatifs) |
| video-sora-cost | 04-3 | 04-Applications (arbitrage cloud/local) |

La section `## Aperçu` devient un paragraphe de transition qui annonce la narration niveau-par-niveau et pointe vers le `MANIFEST.md`. Le niveau 03-Orchestration n'a pas de figure (aucune vignette ne provenait de ces notebooks).

## Preuve pure-change

- **CRLF = 0** (LF-only)
- **src+alt multiset IDENTICAL** à origin/main (6 `<img>` tags préservés)
- **0 mosaïque `<table>`** restante dans la section Aperçu (uniquement les tables légitimes notebooks/technos)
- **figures + MANIFEST byte-identical** (0 diff sur `assets/`)
- **CATALOG-STATUS marker byte-identical**
- 1 fichier modifié (+13/−16)

## Convention

Identique aux PRs déjà merged #5815 (Sudoku), #5894 (SocialChoice), et en review #6125 (02-ML-Cours), #6130 (Planners). Largeur 540-560 (cohérente avec la famille), layout `<p align="center">`.

See #5780

🤖 Generated with [Claude Code](https://claude.com/claude-code)