### PR TITLE
feat(smt): Z3-Python-09 Enigme d'Einstein (Zebra puzzle) — pyz3 port of C# 18

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -4,7 +4,7 @@
 
 ## Série en quelques mots
 
-L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **8 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée, à l'ordonnancement combinatoire et au pont déclaratif avec la série sœur Z3.Linq (C#).
+L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **9 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée, à l'ordonnancement combinatoire, aux énigmes logiques (CSP) et au pont déclaratif avec la série sœur Z3.Linq (C#).
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs Python souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modélisation de problèmes combinatoires.
 
@@ -54,6 +54,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 | 06ᶜˢ | [Optimisation avancée (twin C# .NET)](Z3-Python-06-Advanced-Optimization-Csharp.ipynb) | Parité .NET : `MkOptimize`, `MkMaximize`/`MkMinimize`, front de Pareto, `AssertSoft` (MaxSAT) via `Microsoft.Z3` (NuGet) | ~40 min | PRODUCTION |
 | 07 | [Du style déclaratif LINQ au solveur Z3](Z3-Python-07-Style-Declaratif-Linq.ipynb) | Pont C# Z3.Linq ↔ pyz3 : `assert_and_track`, `unsat_core`, coloration de graphe (Australie) | ~30 min | PRODUCTION |
 | 08 | [Ordonnancement (Job-Shop Scheduling)](Z3-Python-08-Ordonnancement.ipynb) | `Optimize.minimize`, contrainte disjonctive `Or(...)`, makespan minimal, diagramme de Gantt | ~35 min | PRODUCTION |
+| 09 | [L'énigme d'Einstein (Zebra puzzle)](Z3-Python-09-Enigme-Einstein.ipynb) | Encodage par position, `Distinct`, adjacences, satisfiabilité vs optimisation, unicité prouvée | ~30 min | PRODUCTION |
 
 ### Fil pédagogique
 
@@ -65,6 +66,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 6. **Notebook 06** explore l'optimisation avancée : contraintes hiérarchiques pondérées, objectifs multiples, front de Pareto et MaxSAT (contraintes souples)
 7. **Notebook 07** fait le pont avec la série sœur C# Z3.Linq : il montre que l'idiome déclaratif LINQ (`where`/`select`) et l'API impérative pyz3 (`s.add`) expriment la même intention, puis exploite le noyau d'insatisfiabilité (`unsat_core`) et la coloration de graphe (carte d'Australie) pour révéler où le déclaratif surpasse l'impératif
 8. **Notebook 08** applique l'optimisation à l'ordonnancement de tâches (job-shop scheduling, NP-difficile) : la contrainte disjonctive `Or(s_a + d_a ≤ s_b, s_b + d_b ≤ s_a)` (exclusion mutuelle sur une machine) et l'objectif de makespan minimal (`Optimize.minimize`) révèlent où le solveur surpasse une heuristique gloutonne FIFO — l'optimum trouvé (8 h) écrase le glouton (14 h)
+9. **Notebook 09** illustre la **satisfiabilité** pure (versus l'optimisation du 08) sur l'énigme d'Einstein : l'encodage par position (25 variables entières) transforme un puzzle qualitatif en contraintes arithmétiques (`Distinct`, égalités, adjacences), et `Solver` trouve l'unique solution en quelques millisecondes là où la brute force affronte (5!)^5 = 24,9 milliards de combinaisons — l'unicité est **prouvée** par négation (`unsat`)
 
 ## Concepts clés
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-09-Enigme-Einstein.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-09-Enigme-Einstein.ipynb
@@ -1,0 +1,737 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c0",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "# Z3-Python-09 : L'enigme d'Einstein (Zebra puzzle)\n",
+    "\n",
+    "\n",
+    "\n",
+    "[← Serie Z3-Python](README.md) | [Z3-Python-08 (ordonnancement) →](Z3-Python-08-Ordonnancement.ipynb)\n",
+    "\n",
+    "\n",
+    "\n",
+    "## Le probleme\n",
+    "\n",
+    "\n",
+    "\n",
+    "L'**enigme d'Einstein** (ou *Zebra puzzle*) est un classique de logique : 5 maisons alignees, chacune habitee par une personne de nationalite, couleur, boisson, cigarette et animal differents. On dispose de **15 indices** (le Britannique vit dans la rouge, le Danois boit du the, la verte est a gauche de la blanche, etc.) et la question est : **qui possede le poisson ?**\n",
+    "\n",
+    "\n",
+    "\n",
+    "A la main, la resolution procede par deductions progressives sur un tableau - c'est long et trompeur. L'espace de recherche brut est enorme : chaque attribut est une permutation des 5 maisons, soit $(5!)^5 = 24\\,883\\,200\\,000$ combinaisons. Une **enumeration exhaustive** (brute force) testant les 15 indices pour chaque combinaison prend plusieurs minutes.\n",
+    "\n",
+    "\n",
+    "\n",
+    "C'est typiquement la ou un solveur SMT comme Z3 **fait la difference** : on decrit les 25 variables (position de chaque valeur), le domaine, les 5 contraintes de permutation (`Distinct`) et les 15 indices, et `Solver` trouve l'unique solution en **quelques millisecondes**. Ce notebook porte en Python l'exemple C# [18_Einsteins_Riddle](../Z3/18_Einsteins_Riddle.ipynb) de la serie sœur Z3.Linq."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T15:08:13.879157Z",
+     "iopub.status.busy": "2026-07-11T15:08:13.877848Z",
+     "iopub.status.idle": "2026-07-11T15:08:13.979144Z",
+     "shell.execute_reply": "2026-07-11T15:08:13.976231Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "z3 version : 4.15.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports : z3 (solveur SMT) + time (benchmark).\n",
+    "\n",
+    "import time\n",
+    "\n",
+    "import z3\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"z3 version :\", z3.get_version_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Modelisation : l'encodage par position\n",
+    "\n",
+    "\n",
+    "\n",
+    "L'astuce centrale consiste a **inverser le point de vue**. Au lieu de demander « quelle couleur a la maison *k* ? », on definit pour chaque valeur d'attribut une variable entiere egale a la **position** (numero de maison 0..4) ou elle se trouve :\n",
+    "\n",
+    "\n",
+    "\n",
+    "- `Brit`, `Swede`, `Dane`, `Norwegian`, `German` : position de chaque nationalite\n",
+    "\n",
+    "- `Red`, `Green`, `White`, `Yellow`, `Blue` : position de chaque couleur\n",
+    "\n",
+    "- `Tea`, `Coffee`, `Milk`, `Water`, `Beer` : position de chaque boisson\n",
+    "\n",
+    "- `PallMall`, `Dunhill`, `Blend`, `BlueMaster`, `Prince` : position de chaque cigarette\n",
+    "\n",
+    "- `Dog`, `Bird`, `Cat`, `Horse`, `Fish` : position de chaque animal\n",
+    "\n",
+    "\n",
+    "\n",
+    "Soit **25 variables entieres**. Les contraintes se traduisent alors tres naturellement :\n",
+    "\n",
+    "\n",
+    "\n",
+    "1. **Domaine** : chaque variable $\\in \\{0,1,2,3,4\\}$.\n",
+    "\n",
+    "2. **Permutation** : dans chaque groupe d'attributs, les 5 positions sont deux a deux distinctes (`Distinct`) - chaque valeur occupe une maison differente.\n",
+    "\n",
+    "3. **Les 15 indices** : des egalites de position (`Brit == Red` : le Britannique et la rouge sont dans la meme maison) ou des **adjacences** (`|Blend - Cat| == 1` : le fumeur de Blend est voisin du Chat)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T15:08:13.990423Z",
+     "iopub.status.busy": "2026-07-11T15:08:13.989129Z",
+     "iopub.status.idle": "2026-07-11T15:08:14.030814Z",
+     "shell.execute_reply": "2026-07-11T15:08:14.027628Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele encode : 25 variables de position, 5 groupes Distinct, 15 indices.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def build_einstein_solver():\n",
+    "\n",
+    "    \"\"\"Construit le solveur Z3 de l'enigme d'Einstein (25 vars de position, 15 indices).\n",
+    "\n",
+    "    Retourne (solver, var_dict, group_labels) pour reuse dans les exercices.\"\"\"\n",
+    "\n",
+    "    s = z3.Solver()\n",
+    "\n",
+    "    # 25 variables de position (0..4) : une par valeur d'attribut.\n",
+    "\n",
+    "    groups = {\n",
+    "\n",
+    "        \"Nationalite\": [\"Brit\", \"Swede\", \"Dane\", \"Norwegian\", \"German\"],\n",
+    "\n",
+    "        \"Couleur\":     [\"Red\", \"Green\", \"White\", \"Yellow\", \"Blue\"],\n",
+    "\n",
+    "        \"Boisson\":     [\"Tea\", \"Coffee\", \"Milk\", \"Water\", \"Beer\"],\n",
+    "\n",
+    "        \"Cigarette\":   [\"PallMall\", \"Dunhill\", \"Blend\", \"BlueMaster\", \"Prince\"],\n",
+    "\n",
+    "        \"Animal\":      [\"Dog\", \"Bird\", \"Cat\", \"Horse\", \"Fish\"],\n",
+    "\n",
+    "    }\n",
+    "\n",
+    "    v = {n: z3.Int(n) for grp in groups.values() for n in grp}\n",
+    "\n",
+    "\n",
+    "\n",
+    "    # (1) Domaine 0..4 pour les 25 variables\n",
+    "\n",
+    "    for var in v.values():\n",
+    "\n",
+    "        s.add(var >= 0, var <= 4)\n",
+    "\n",
+    "\n",
+    "\n",
+    "    # (2) Permutation : les 5 valeurs d'un meme attribut occupent des maisons distinctes\n",
+    "\n",
+    "    for grp in groups.values():\n",
+    "\n",
+    "        s.add(z3.Distinct([v[n] for n in grp]))\n",
+    "\n",
+    "\n",
+    "\n",
+    "    # (3) Les 15 indices\n",
+    "\n",
+    "    s.add(v[\"Brit\"] == v[\"Red\"])                                         # 1. le Britannique vit dans la rouge\n",
+    "\n",
+    "    s.add(v[\"Swede\"] == v[\"Dog\"])                                        # 2. le Suedois eleve des chiens\n",
+    "\n",
+    "    s.add(v[\"Dane\"] == v[\"Tea\"])                                         # 3. le Danois boit du the\n",
+    "\n",
+    "    s.add(v[\"Green\"] == v[\"White\"] - 1)                                  # 4. la verte est juste a gauche de la blanche\n",
+    "\n",
+    "    s.add(v[\"Green\"] == v[\"Coffee\"])                                     # 5. la verte boit du cafe\n",
+    "\n",
+    "    s.add(v[\"PallMall\"] == v[\"Bird\"])                                    # 6. Pall Mall eleve des oiseaux\n",
+    "\n",
+    "    s.add(v[\"Yellow\"] == v[\"Dunhill\"])                                   # 7. la jaune fume du Dunhill\n",
+    "\n",
+    "    s.add(v[\"Milk\"] == 2)                                                # 8. la maison du milieu boit du lait\n",
+    "\n",
+    "    s.add(v[\"Norwegian\"] == 0)                                           # 9. le Norvegien dans la 1ere maison\n",
+    "\n",
+    "    s.add(z3.Or(v[\"Blend\"] - v[\"Cat\"] == 1, v[\"Cat\"] - v[\"Blend\"] == 1))     # 10. Blend voisin du Chat\n",
+    "\n",
+    "    s.add(z3.Or(v[\"Horse\"] - v[\"Dunhill\"] == 1, v[\"Dunhill\"] - v[\"Horse\"] == 1))  # 11. Cheval voisin du Dunhill\n",
+    "\n",
+    "    s.add(v[\"BlueMaster\"] == v[\"Beer\"])                                  # 12. BlueMaster boit de la biere\n",
+    "\n",
+    "    s.add(v[\"German\"] == v[\"Prince\"])                                    # 13. l'Allemand fume du Prince\n",
+    "\n",
+    "    s.add(z3.Or(v[\"Norwegian\"] - v[\"Blue\"] == 1, v[\"Blue\"] - v[\"Norwegian\"] == 1))  # 14. Norvegien voisin de la bleue\n",
+    "\n",
+    "    s.add(z3.Or(v[\"Blend\"] - v[\"Water\"] == 1, v[\"Water\"] - v[\"Blend\"] == 1))   # 15. Blend voisin de l'Eau\n",
+    "\n",
+    "    return s, v, groups\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"Modele encode : 25 variables de position, 5 groupes Distinct, 15 indices.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Resolution et temoin\n",
+    "\n",
+    "\n",
+    "\n",
+    "On appelle `s.check()` : si `sat`, on extrait le modele puis on **inverse** l'encodage par position - pour chaque maison $h \\in \\{0..4\\}$, on cherche quelle valeur de chaque attribut y se trouve (la valeur dont la position vaut $h$). Cela reconstitue le tableau classique de la solution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T15:08:14.041285Z",
+     "iopub.status.busy": "2026-07-11T15:08:14.040076Z",
+     "iopub.status.idle": "2026-07-11T15:08:14.166096Z",
+     "shell.execute_reply": "2026-07-11T15:08:14.162737Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Maison   Nationalite    Couleur    Boisson    Cigarette      Animal   \n",
+      "  ----------------------------------------------------------------------\n",
+      "1        Norvegien      Jaune      Eau        Dunhill        Chat     \n",
+      "2        Danois         Bleue      The        Blend          Cheval   \n",
+      "3        Britannique    Rouge      Lait       Pall Mall      Oiseau   \n",
+      "4        Allemand       Verte      Cafe       Prince         Poisson  \n",
+      "5        Suedois        Blanche    Biere      BlueMaster     Chien    \n",
+      "\n",
+      ">>> Reponse : c'est le Allemand qui possede le Poisson (maison 4).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Labels francais pour l'affichage (associes au nom de variable).\n",
+    "\n",
+    "LABELS_FR = {\n",
+    "\n",
+    "    \"Nationalite\": [(\"Britannique\", \"Brit\"), (\"Suedois\", \"Swede\"), (\"Danois\", \"Dane\"), (\"Norvegien\", \"Norwegian\"), (\"Allemand\", \"German\")],\n",
+    "\n",
+    "    \"Couleur\":     [(\"Rouge\", \"Red\"), (\"Verte\", \"Green\"), (\"Blanche\", \"White\"), (\"Jaune\", \"Yellow\"), (\"Bleue\", \"Blue\")],\n",
+    "\n",
+    "    \"Boisson\":     [(\"The\", \"Tea\"), (\"Cafe\", \"Coffee\"), (\"Lait\", \"Milk\"), (\"Eau\", \"Water\"), (\"Biere\", \"Beer\")],\n",
+    "\n",
+    "    \"Cigarette\":   [(\"Pall Mall\", \"PallMall\"), (\"Dunhill\", \"Dunhill\"), (\"Blend\", \"Blend\"), (\"BlueMaster\", \"BlueMaster\"), (\"Prince\", \"Prince\")],\n",
+    "\n",
+    "    \"Animal\":      [(\"Chien\", \"Dog\"), (\"Oiseau\", \"Bird\"), (\"Chat\", \"Cat\"), (\"Cheval\", \"Horse\"), (\"Poisson\", \"Fish\")],\n",
+    "\n",
+    "}\n",
+    "\n",
+    "\n",
+    "\n",
+    "def solve_and_display():\n",
+    "\n",
+    "    \"\"\"Resout l'enigme et affiche le tableau des 5 maisons.\"\"\"\n",
+    "\n",
+    "    s, v, _ = build_einstein_solver()\n",
+    "\n",
+    "    assert s.check() == z3.sat, \"UNSAT (inattendu pour cette enigme)\"\n",
+    "\n",
+    "    m = s.model()\n",
+    "\n",
+    "    pos = {n: m[v[n]].as_long() for n in v}  # nom de variable -> position (0..4)\n",
+    "\n",
+    "\n",
+    "\n",
+    "    def val_at(group, h):\n",
+    "\n",
+    "        \"\"\"Retourne le label francais de la valeur du groupe present a la maison h.\"\"\"\n",
+    "\n",
+    "        for fr, key in LABELS_FR[group]:\n",
+    "\n",
+    "            if pos[key] == h:\n",
+    "\n",
+    "                return fr\n",
+    "\n",
+    "        return \"?\"\n",
+    "\n",
+    "\n",
+    "\n",
+    "    cols = [\"Maison\", \"Nationalite\", \"Couleur\", \"Boisson\", \"Cigarette\", \"Animal\"]\n",
+    "\n",
+    "    widths = [7, 13, 9, 9, 13, 9]\n",
+    "\n",
+    "    print(\"  \".join(c.ljust(w) for c, w in zip(cols, widths)))\n",
+    "\n",
+    "    print(\"  \" + \"-\" * (sum(widths) + 2 * (len(cols) - 1)))\n",
+    "\n",
+    "    for h in range(5):\n",
+    "\n",
+    "        row = [str(h + 1)] + [val_at(g, h) for g in [\"Nationalite\", \"Couleur\", \"Boisson\", \"Cigarette\", \"Animal\"]]\n",
+    "\n",
+    "        print(\"  \".join(c.ljust(w) for c, w in zip(row, widths)))\n",
+    "\n",
+    "    print()\n",
+    "\n",
+    "    print(f\">>> Reponse : c'est le {val_at('Nationalite', pos['Fish'])} qui possede le Poisson (maison {pos['Fish'] + 1}).\")\n",
+    "\n",
+    "    return m, v\n",
+    "\n",
+    "\n",
+    "\n",
+    "solution_model, solution_vars = solve_and_display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Interpretation\n",
+    "\n",
+    "\n",
+    "\n",
+    "Z3 trouve l'unique solution en quelques millisecondes. La resolution humaine procederait par deductions progressives - on place le Norvegien en 1 (`Norwegian == 0`), le lait en 3 (`Milk == 2`), puis on propage les egalites et adjacences - mais c'est precisement ce travail de **propagation de contraintes** que le solveur automatise, sans erreur ni oubli.\n",
+    "\n",
+    "\n",
+    "\n",
+    "La reponse a la question « qui possede le poisson ? » tombe directement du modele extrait. Notons qu'**aucun indice ne parle du poisson** : c'est par elimination (les 4 autres animaux sont localises par les indices) que sa position se deduit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Approche naive vs solveur : mesurer l'ecart\n",
+    "\n",
+    "\n",
+    "\n",
+    "Plutot que d'affirmer que le solveur est plus rapide, **mesurons** l'ecart. L'espace de recherche brut est $(5!)^5$ : chaque attribut est une permutation des 5 maisons, independamment. On chronometre aussi la resolution Z3, puis on **prouve l'unicite** de la solution en ajoutant la negation du temoin trouve et en re-resolvant (on attend `unsat`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T15:08:14.178457Z",
+     "iopub.status.busy": "2026-07-11T15:08:14.176373Z",
+     "iopub.status.idle": "2026-07-11T15:08:14.348358Z",
+     "shell.execute_reply": "2026-07-11T15:08:14.343874Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Espace de recherche brut       : (5!)^5 = 24,883,200,000 combinaisons\n",
+      "Brute force estime (~1e8/s)    : 248.8 s (hors test des 15 indices)\n",
+      "Z3 solve temps                 : 68.0 ms\n",
+      "Solution unique (UNSAT si nie) : True\n",
+      " -> Z3 resout en millisecondes un espace de 2,5 milliards, et prouve l'unicite sans enumeration.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# (1) Espace de recherche brut\n",
+    "\n",
+    "import math\n",
+    "\n",
+    "space = math.factorial(5) ** 5  # (5!)^5 = 24_883_200_000\n",
+    "\n",
+    "brute_seconds = space / 1e8     # a ~1e8 tests/s, sans compter le test des 15 indices\n",
+    "\n",
+    "\n",
+    "\n",
+    "# (2) Chronometre la resolution Z3\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "\n",
+    "s1, v1, _ = build_einstein_solver()\n",
+    "\n",
+    "assert s1.check() == z3.sat\n",
+    "\n",
+    "m1 = s1.model()\n",
+    "\n",
+    "z3_ms = (time.perf_counter() - t0) * 1000\n",
+    "\n",
+    "\n",
+    "\n",
+    "# (3) Unicite : on nie le temoin trouve (au moins une variable differe) -> on attend unsat\n",
+    "\n",
+    "s2, v2, _ = build_einstein_solver()\n",
+    "\n",
+    "negation = z3.Or([v2[n] != m1[v1[n]].as_long() for n in v2])  # une solution differente existe-t-elle ?\n",
+    "\n",
+    "s2.add(negation)\n",
+    "\n",
+    "unique = (s2.check() == z3.unsat)\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(f\"Espace de recherche brut       : (5!)^5 = {space:,} combinaisons\")\n",
+    "\n",
+    "print(f\"Brute force estime (~1e8/s)    : {brute_seconds:.1f} s (hors test des 15 indices)\")\n",
+    "\n",
+    "print(f\"Z3 solve temps                 : {z3_ms:.1f} ms\")\n",
+    "\n",
+    "print(f\"Solution unique (UNSAT si nie) : {unique}\")\n",
+    "\n",
+    "print(f\" -> Z3 resout en millisecondes un espace de 2,5 milliards, et prouve l'unicite sans enumeration.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Lecture du benchmark\n",
+    "\n",
+    "\n",
+    "\n",
+    "Sur cette enigme, l'ecart est **frappant** : Z3 resout les 25 variables entrelacees en quelques millisecondes, alors que la brute force doit affronter **2,5 milliards** de combinaisons (soit plusieurs minutes meme a cadence elevee, et bien plus avec le test des 15 indices a chaque candidat).\n",
+    "\n",
+    "\n",
+    "\n",
+    "La **propagation** fait tout le travail : `Norwegian == 0` et `Milk == 2` sont des ancres imposees par les indices 9 et 8, puis les egalites de position et les adjacences reduisent les domaines restants jusqu'a ce qu'il ne reste qu'une seule combinaison coherente. C'est exactement la mecanique qu'un humain deployerait a la main sur le tableau - mais le solveur la realise sans erreur et la **prouve complete** (unicite via `unsat` sur la negation)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c10",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "\n",
+    "\n",
+    "Les trois exercices suivants vous font reutiliser l'encodage par position et la fonction `build_einstein_solver`. Chaque stub est self-contained : redefinissez le solveur, ajustez les contraintes, puis `check()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c11",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 -- Un 16e indice : le Chat boit de l'Eau\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Objectif** : ajouter l'indice `Cat == Water` (le Chat et l'Eau sont dans la meme maison) et observer si l'enigme reste satisfaisable (`sat`) ou devient contradictoire (`unsat`).\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Indices** : reprenez `build_einstein_solver()`, ajoutez `s.add(v[\"Cat\"] == v[\"Water\"])` avant `check()`. Que se passe-t-il ? (Pensez a comparer avec la solution trouvee plus haut : le Chat et l'Eau y sont-ils dans la meme maison ?)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T15:08:14.363984Z",
+     "iopub.status.busy": "2026-07-11T15:08:14.362026Z",
+     "iopub.status.idle": "2026-07-11T15:08:14.382179Z",
+     "shell.execute_reply": "2026-07-11T15:08:14.378849Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : ajoutez Cat == Water et testez la satisfiabilite.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : ajoutez l'indice Cat == Water et testez la satisfiabilite.\n",
+    "\n",
+    "# Etape 1 : reprenez build_einstein_solver() -> s, v, _.\n",
+    "\n",
+    "# Etape 2 : s.add(v[\"Cat\"] == v[\"Water\"]).\n",
+    "\n",
+    "# Etape 3 : s.check() -> sat ou unsat ?\n",
+    "\n",
+    "\n",
+    "\n",
+    "def tester_chat_eau():\n",
+    "\n",
+    "    \"\"\"Retourne 'sat' ou 'unsat' apres ajout de l'indice Cat == Water.\"\"\"\n",
+    "\n",
+    "    # TODO etudiant : construire le solveur, ajouter l'indice, retourner le verdict\n",
+    "\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 1 a completer : ajoutez Cat == Water et testez la satisfiabilite.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c13",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 -- Enumerer toutes les solutions\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Objectif** : enumerer **toutes** les solutions de l'enigme par **blocage iteratif** (on resout, on compte, on ajoute une contrainte interdisant le temoin trouve, on re-resout) jusqu'a `unsat`. Le compte attendu est 1 (solution unique), ce qui confirme le benchmark ci-dessus.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Indices** : boucle `while s.check() == z3.sat` ; a chaque tour, comptez++, puis `s.add(z3.Or([v[n] != m[v[n]].as_long() for n in v]))` pour interdire le temoin courant et forcer une solution differente au tour suivant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T15:08:14.395228Z",
+     "iopub.status.busy": "2026-07-11T15:08:14.392834Z",
+     "iopub.status.idle": "2026-07-11T15:08:14.413048Z",
+     "shell.execute_reply": "2026-07-11T15:08:14.409467Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : enumerer toutes les solutions par blocage iteratif.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : enumerer toutes les solutions par blocage iteratif.\n",
+    "\n",
+    "# Etape 1 : s, v, _ = build_einstein_solver().\n",
+    "\n",
+    "# Etape 2 : while s.check() == z3.sat: compte += 1; m = s.model(); s.add(z3.Or([v[n] != m[v[n]].as_long() for n in v])).\n",
+    "\n",
+    "# Etape 3 : afficher le compte (attendu : 1).\n",
+    "\n",
+    "\n",
+    "\n",
+    "def compter_solutions():\n",
+    "\n",
+    "    \"\"\"Retourne le nombre total de solutions de l'enigme (attendu : 1).\"\"\"\n",
+    "\n",
+    "    # TODO etudiant : boucle de blocage iteratif\n",
+    "\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 2 a completer : enumerer toutes les solutions par blocage iteratif.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c15",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 -- Mini-Zebra a 4 maisons / 4 attributs\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Objectif** : modeliser une **mini-enigme** a 4 maisons et 4 attributs (4 nationalites, 4 couleurs, 4 animaux) avec 8 indices de votre choix, et verifyez que `build_einstein_solver` se generalise (le modele est parametre par les donnees).\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Indices** : definissez `groups_4` avec 4 valeurs par attribut, domaine `0..3`, 3 groupes `Distinct`, puis 8 indices (identites de position + adjacences) inventes. Inspirez-vous de la structure de `build_einstein_solver`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T15:08:14.424836Z",
+     "iopub.status.busy": "2026-07-11T15:08:14.423242Z",
+     "iopub.status.idle": "2026-07-11T15:08:14.444768Z",
+     "shell.execute_reply": "2026-07-11T15:08:14.440341Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : modelisez un mini-Zebra a 4 maisons / 4 attributs.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : modelisez un mini-Zebra a 4 maisons / 4 attributs.\n",
+    "\n",
+    "# Indice : groups_4 = {\"Nat\": [...4...], \"Couleur\": [...4...], \"Animal\": [...4...]}, domaine 0..3.\n",
+    "\n",
+    "# Etape 1 : definissez groups_4 (4 valeurs par attribut) et un solveur avec domaine 0..3 + 3 Distinct.\n",
+    "\n",
+    "# Etape 2 : ajoutez 8 indices (identites + adjacences) de votre choix.\n",
+    "\n",
+    "# Etape 3 : check() -> solution unique ?\n",
+    "\n",
+    "\n",
+    "\n",
+    "def resoudre_mini_zebra():\n",
+    "\n",
+    "    \"\"\"Retourne (solver, var_dict) pour une mini-enigme 4 maisons / 4 attributs.\"\"\"\n",
+    "\n",
+    "    # TODO etudiant : definir groups_4 + solveur + 8 indices\n",
+    "\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(\"Exercice 3 a completer : modelisez un mini-Zebra a 4 maisons / 4 attributs.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "\n",
+    "\n",
+    "L'enigme d'Einstein illustre le gain du **declaratif** sur une classe de problemes ou l'approche humaine (deduction progressive sur un tableau) et l'approche naive (brute force) sont toutes deux laborieuses :\n",
+    "\n",
+    "\n",
+    "\n",
+    "- L'**encodage par position** (une variable entiere = position de chaque valeur) transforme un puzzle apparemment qualitatif en un systeme de contraintes arithmetiques : egalites (`Brit == Red`), adjacences (`|Blend - Cat| == 1`), permutations (`Distinct`).\n",
+    "\n",
+    "- La **propagation de contraintes** resout les 25 variables entrelacees en millisecondes la ou la brute force affronte 2,5 milliards de combinaisons ; le solveur **prouve l'unicite** en niant le temoin et en observant `unsat`.\n",
+    "\n",
+    "- Le modele est **parametre par les donnees** : ajouter un indice, un attribut ou une maison se fait en modifiant l'instance, sans re-ecrire l'algorithme de resolution.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Contraste avec le job-shop (notebook 08)** : ici `Solver` suffit (on cherche une solution realisable, pas un optimum) - c'est la **satisfiabilite** pure, la ou l'ordonnancement relevait de l'**optimisation** (`Optimize.minimize` du makespan). Les deux postures du solveur, posees au notebook 01, trouvent ici leur illustration complementaire.\n",
+    "\n",
+    "\n",
+    "\n",
+    "Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3/README.md) qui aborde la meme enigme via la couche declarative LINQ."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 0,
+   "end_time": "",
+   "exception": false,
+   "start_time": "",
+   "status": "pending"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

New substance notebook in the **Z3-Python** series (EPIC **#1206** Prong B). Ports the C# Einstein's Riddle example ([`SymbolicAI/SMT/Z3/18_Einsteins_Riddle.ipynb`](../blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/18_Einsteins_Riddle.ipynb)) to **pyz3**.

> **STACKED on #6129** (Z3-Python-08). Merge **#6129 first**, then this PR auto-retargets to `main` and rebases clean. Both touch the Z3-Python README (sequential #1206 slices) — stacking keeps the README consistent (count 8→9 on top of 08's 7→8).

**Scope (atomic)**: 1 new notebook + README update (count 8→9, table row, fil pédagogique item 9).

## Why Einstein (Prong B — problem richness, EPIC #3801)

Pure **CSP logic puzzle** where brute force is intractable: the search space is $(5!)^5 = 24{,}9$ **billion** combinations. Z3 finds the unique solution via **constraint propagation** in milliseconds. This is the **satisfiability** posture (`Solver`) — the complement to notebook 08's **optimization** posture (`Optimize.minimize`). The two postures, posed in notebook 01, get their paired illustration. Not a degenerate case: the engine's distinctive capacity (propagation over 25 intertwined integer variables) is exercised and **measured** in the output.

## Execution proof (EXEC_PROVED — rule C.2, outputs committed)

- `nbconvert --execute` end-to-end, kernel `python3` (z3 4.15.4)
- **7 code cells, all `execution_count` set, 0 errors**
- **Solution** matches the canonical Einstein answer:
  - M1: Norvégien / Jaune / Eau / Dunhill / Chat
  - M2: Danois / Bleue / Thé / Blend / Cheval
  - M3: Britannique / Rouge / Lait / Pall Mall / Oiseau
  - M4: **Allemand / Verte / Café / Prince / Poisson** ← owns the Fish
  - M5: Suédois / Blanche / Bière / BlueMaster / Chien
- **Benchmark**: `(5!)^5 = 24 883 200 000` | brute ~248.8 s | **Z3 68 ms** | **unique = True** (unsat on negation)
- Repo validator `notebook_tools.py validate`: **0 errors**
- 3 C.1-safe exercise stubs (16th clue Cat==Water, enumerate all solutions via blocking, mini-Zebra 4×4) execute cleanly

## Conventions

- **Notebook = ASCII-only** (matches the Z3-Python family convention — 07 & 08 are 0 accent bytes)
- **README = FR-accented** (unchanged convention)
- No path-leak in outputs (text-table render; benchmark prints only numbers)

## SOTA verdict

**SOTA-OK** — real `z3.Solver`, no workaround, problem genuinely exercises constraint propagation that brute force cannot match.

See #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)