### PR TITLE
feat(hashlife): universal large-n non-vacuity of BoxAssezGrandN (W1, EPIC #3846)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -218,6 +218,35 @@ def BoxAssezGrandN (g : Grid) (n : Nat) : Prop := box_assez_grandN g n = true
 theorem box_assez_grandN_single_cell_3 : box_assez_grandN [(0, 0)] 3 = true := by
   native_decide
 
+/-- **Universal large-`n` non-vacuity (gate W1, issue #3846)**: the n-aware
+    predicate `box_assez_grandN` holds for the single-cell grid at *every* `n`.
+    This is the constructive dual of the `boxAssezGrand_nonempty_le_two` unsat
+    cap: the fixed frame forces `n ≤ 2`, the n-aware frame `gridFrameN` admits
+    every `n` because it pads by `max 2 n ≥ n` on all sides. The single-cell
+    extremes are all `0`, so the frame offset is `-(max 2 n)`; after unfolding,
+    the four `cellMargin` bounds reduce to `n ≤ max 2 n` (top/left, free from
+    `le_max_right`) and `max 2 n + n < 2^lvl` (bottom/right), where
+    `2^lvl ≥ 1 + 2·(max 2 n) ≥ (max 2 n) + n + 1` by `ceilLog2_spec`. The
+    `Int`/`Nat`-cast between the goal's `(2 : Int) ^ lvl` and the `Nat` spec is
+    bridged by `exact_mod_cast`. -/
+theorem box_assez_grandN_single_cell (n : Nat) : box_assez_grandN [(0, 0)] n = true := by
+  have hrMin : gridRowMin [(0, 0)] = 0 := by native_decide
+  have hrMax : gridRowMax [(0, 0)] = 0 := by native_decide
+  have hcMin : gridColMin [(0, 0)] = 0 := by native_decide
+  have hcMax : gridColMax [(0, 0)] = 0 := by native_decide
+  simp only [box_assez_grandN, gridFrameN, hrMin, hrMax, hcMin, hcMax,
+      List.all_cons, List.all_nil, Bool.and_true, max_self, Int.sub_self]
+  set pad := max 2 n with hpad
+  set side := (0 + 1 + 2 * (pad : Int)).toNat
+  have hpn : n ≤ pad := le_max_right 2 n
+  have hside : side = 1 + 2 * pad := by omega
+  have hspec : 2 ^ ceilLog2 side ≥ side := ceilLog2_spec side
+  have hbig : (2 : Int) ^ ceilLog2 side ≥ pad + n + 1 := by
+    have hnat : 2 ^ ceilLog2 side ≥ pad + n + 1 := by omega
+    exact_mod_cast hnat
+  rw [cellMargin_true_iff]
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> omega
+
 /-- Honest contrast: the *fixed-`gridFrame`* predicate provably *fails* for the
     same grid at `n = 3` — confirming the duality is non-vacuous
     (`box_assez_grandN` breaks exactly what `box_assez_grand` cannot satisfy). -/


### PR DESCRIPTION
## Summary

EPIC #3846 (Hashlife correctness P5 redesign), gate **W1** — the **universal** large-`n` non-vacuity theorem for the n-aware padding predicate `box_assez_grandN`. Closes the gap explicitly documented as "next target" in PR #6127.

**Theorem:**
```lean
theorem box_assez_grandN_single_cell (n : Nat) :
    box_assez_grandN [(0, 0)] n = true
```

This is the **constructive dual of the `boxAssezGrand_nonempty_le_two` unsat cap** (L358): the fixed-frame predicate forces `n ≤ 2`, while the n-aware frame `gridFrameN` admits *every* `n`. PR #6127 shipped the `native_decide` witnesses at `n = 8` (single-cell + block + glider) but flagged the universal form as blocked by `Int`/`Nat`-cast elaboration. This PR proves it.

**Proof (sorry-free):** the single-cell extremes are all `0`, so after unfolding `gridFrameN` the frame offset is `-(max 2 n)`. The four `cellMargin` bounds reduce to:
- top/left: `n ≤ max 2 n` — free from `le_max_right`;
- bottom/right: `max 2 n + n < 2^lvl` — from `ceilLog2_spec` (`2^lvl ≥ 1 + 2·(max 2 n) ≥ (max 2 n) + n + 1`, since `max 2 n ≥ n`).

The key that unblocked the cast: state the size bound over `Int` to match the goal's `(2 : Int) ^ ceilLog2 side` atom, then bridge from the `Nat` `ceilLog2_spec` via `exact_mod_cast` (which handles the `(2 : Int)^k ↔ ↑(2^k)` identity that `omega` alone cannot see).

## §B Lean forensics (lean-merge-discipline)

- **`grep -c sorry` avant/après:** tactic-sorry count **2 → 2** (firsthand strip-docstring method, `.lake` excluded). The 2 residual sorries are unchanged: `p4_succ_membership` + `p5_large_n_jump` (P4-gated, ai-01 turf). **0 sorry added.**
- **Lake build SUCCESS:** `lake build Conway` = **2985 jobs, EXIT 0** (HashlifeCorrectness rebuilt with the new theorem + docstring, LightCone + root downstream clean).
- **Proof integrity:** pure `omega` + `ceilLog2_spec` + `exact_mod_cast` + `le_max_right` + `native_decide` (for the 4 grid extremes). 0 axiom/sorry. No existing proof body touched.
- **No prover-Python refactor** (N/A).

## Validation

- **Anti-régression §D:** `git diff --stat` = **+29 insertions, 0 deletions** (pure addition, single new theorem + docstring).
- **CRLF = 0** (authoritative `tr -cd '\r' < file | wc -c`).
- Catalogue byte-identical to `main` (no catalog file touched).
- **Rebase-clean vs #6127:** both branch from `main` and touch the `box_assez_grandN` section but at **disjoint insertion points** (#6127 inserts after `box_assez_grand_single_cell_3_false`; this PR inserts between `box_assez_grandN_single_cell_3` and `box_assez_grand_single_cell_3_false`). Git auto-merges; either merge order is clean.
- **Rebase-clean vs #6123** (ConeGeometry cycle-break, import block L71): no overlap.

See #3846 (W1 universal non-vacuity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)