### PR TITLE
docs(lean): #5780 figures narrative — dissolve SymbolicAI/Lean gallery mosaic into themed vertical narration

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -15,18 +15,41 @@ Cette série introduit **Lean 4**, un assistant de preuves et langage de program
 
 Six visualisations extraites des notebooks illustrent l'arc de la série : de l'assistance aux preuves par LLM et la vérification formelle de réseaux de neurones jusqu'aux automates de Conway (Game of Life) et à la théorie des nœuds (définition, nœud de Conway, invariants). Provenance détaillée : [`MANIFEST.md`](assets/readme/MANIFEST.md).
 
-<table>
-<tr>
-<td align="center"><b>Assistance LLM</b><br><a href="Lean-7b-Examples.ipynb"><img src="assets/readme/lean-llm-examples.png" width="290" alt="Assistance LLM : interprétation visualisée d'une solution de preuve."></a></td>
-<td align="center"><b>TorchLean (IBP)</b><br><a href="Lean-11-TorchLean-Python.ipynb"><img src="assets/readme/lean-torchlean.png" width="290" alt="TorchLean : propagation IBP pour la vérification formelle de réseaux de neurones."></a></td>
-<td align="center"><b>Conway Game of Life</b><br><a href="Lean-16b-Conway-Game-of-Life-Lean.ipynb"><img src="assets/readme/lean-conway-gol.png" width="290" alt="Conway Game of Life : le self-replicator Gemini (Andrew Wade, 2010)."></a></td>
-</tr>
-<tr>
-<td align="center"><b>Nœud mathématique</b><br><a href="Lean-17-Knots-a-Conway-and-Proofs.ipynb"><img src="assets/readme/lean-knot-conway.png" width="290" alt="Théorie des nœuds : qu'est-ce qu'un nœud mathématique ?"></a></td>
-<td align="center"><b>Nœud de Conway (11n34)</b><br><a href="Lean-17-Knots-a-Conway-and-Proofs.ipynb"><img src="assets/readme/lean-knot-piccirillo.png" width="290" alt="Le nœud de Conway (11n34) — schéma."></a></td>
-<td align="center"><b>Alexander &amp; sliceness</b><br><a href="Lean-17-Knots-b-Invariants-Companion.ipynb"><img src="assets/readme/lean-knot-invariants.png" width="290" alt="Polynôme d'Alexander et sliceness — le critère de Conway."></a></td>
-</tr>
-</table>
+### Assistance aux preuves et vérification formelle
+
+L'état de l'art de la série : un LLM interprète et visualise une solution de preuve ([Lean-7b](Lean-7b-Examples.ipynb)), puis TorchLean propage intervalles (IBP) et bornes (CROWN) pour certifier formellement la robustesse d'un réseau de neurones ([Lean-11a](Lean-11-TorchLean-Python.ipynb)).
+
+<p align="center">
+  <a href="Lean-7b-Examples.ipynb"><img src="assets/readme/lean-llm-examples.png" width="420" alt="Assistance LLM : interprétation visualisée d'une solution de preuve."></a>
+</p>
+
+<p align="center">
+  <a href="Lean-11-TorchLean-Python.ipynb"><img src="assets/readme/lean-torchlean.png" width="420" alt="TorchLean : propagation IBP pour la vérification formelle de réseaux de neurones."></a>
+</p>
+
+### Conway — Game of Life
+
+L'hommage à John Conway passe par le Game of Life comme modèle de calcul ([Lean-16b](Lean-16b-Conway-Game-of-Life-Lean.ipynb)), où Lean sert de certificat pour les structures et leurs périodes.
+
+<p align="center">
+  <a href="Lean-16b-Conway-Game-of-Life-Lean.ipynb"><img src="assets/readme/lean-conway-gol.png" width="420" alt="Conway Game of Life : le self-replicator Gemini (Andrew Wade, 2010)."></a>
+</p>
+
+### Théorie des nœuds
+
+La série dédiée (companion `knot_lean`, Epic #2874) développe trois vues complémentaires : la définition d'un nœud mathématique ([Lean-17a](Lean-17-Knots-a-Conway-and-Proofs.ipynb)), le nœud de Conway (11n34) dont Lisa Piccirillo prouva la non-sliceness, puis le polynôme d'Alexander qui caractérise cette sliceness ([Lean-17b](Lean-17-Knots-b-Invariants-Companion.ipynb)).
+
+<p align="center">
+  <a href="Lean-17-Knots-a-Conway-and-Proofs.ipynb"><img src="assets/readme/lean-knot-conway.png" width="420" alt="Théorie des nœuds : qu'est-ce qu'un nœud mathématique ?"></a>
+</p>
+
+<p align="center">
+  <a href="Lean-17-Knots-a-Conway-and-Proofs.ipynb"><img src="assets/readme/lean-knot-piccirillo.png" width="420" alt="Le nœud de Conway (11n34) — schéma."></a>
+</p>
+
+<p align="center">
+  <a href="Lean-17-Knots-b-Invariants-Companion.ipynb"><img src="assets/readme/lean-knot-invariants.png" width="420" alt="Polynôme d'Alexander et sliceness — le critère de Conway."></a>
+</p>
 
 ## Navigation
 


### PR DESCRIPTION
## Summary

EPIC #5780 (figures narrative — no galleries, in-situ integration) — dissolve the residual mosaic `<table>` gallery in `SymbolicAI/Lean/README.md` (the 1 mosaic po-2025 explicitly left, per their [DONE] c.X: « SymbolicAI/Lean (1) résiduel »).

**Defect (firsthand, G.1):** `SymbolicAI/Lean/README.md` L14-29 held a 2×3 mosaic gallery (`## Aperçu — Lean en images` + `<table>` of 6 thumbnails `width=290`) — exactly the #5780 defect pattern (« galerie d'images les unes à côté des autres »). 6 figures covered 4 themes (LLM assistance, TorchLean IBP, Conway GoL, knots ×3).

**Fix (pattern of merged #6125 + #5135/#5130/#5133):** dissolve the mosaic into an aerated vertical layout grouped by the 3 themes of the series arc, each with a subject-level lead-in (sourced from the README's own intro narrative L12, not invented):
- **Assistance aux preuves et vérification formelle** — LLM interpretation (Lean-7b) + TorchLean IBP/CROWN (Lean-11a)
- **Conway — Game of Life** — Lean as certificate for GoL structures (Lean-16b)
- **Théorie des nœuds** — definition (Lean-17a) + Conway knot/Piccirillo (Lean-17a) + Alexander polynomial/sliceness (Lean-17b)

## Validation (pure presentation change — #5780 convention)

| Check | Result |
|-------|--------|
| `src="assets/readme/..."` multiset | **6/6 byte-identical** (diff=0) |
| `alt="..."` multiset | **byte-identical** (diff=0) |
| `href="..."` multiset | **byte-identical** (6 links, same per-notebook counts) |
| `<table>` remnants | **0** (mosaic fully dissolved) |
| Figure assets (`assets/readme/*.png`) | **untouched** (0 diff in assets/) |
| CATALOG-STATUS marker | byte-identical |
| MANIFEST.md provenance link | preserved |
| CRLF | **0** (`tr -cd '\r' < file \| wc -c`) |
| `git diff --stat` | **+35/−12, 1 file** |

## Conformité

- **§E README audit:** single-section structural change (Aperçu gallery dissolution), intro L12 + Structure L47+ byte-identical. No notebook list / tree / counts touched.
- **§D anti-regression:** pure additive presentation (thematic headers + lead-ins + `<p align=center>` blocks), 0 figure/src/alt dropped.
- **Catalogue R1:** byte-identical to `main` (no catalog file touched).
- **MD033 inline-HTML warnings:** expected — `<p align=center>` is the GitHub-canonical image-centering idiom (same as merged #6125); #5780's bar is "no side-by-side mosaics", not "no HTML".

See #5780 (partial: SymbolicAI/Lean mosaic dissolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)