### PR TITLE
docs(genai-image): #5780 figures narrative — galerie en narration in-situ par niveau

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -23,20 +23,7 @@ La structure détaillée (notebooks par niveau, contenu, services utilisés) est
 
 ## Aperçu — la génération d'images en images
 
-Les figures ci-dessous sont extraites des sorties réelles des notebooks (EPIC #5654). Elles couvrent les quatre familles de la série : génération cloud (DALL-E 3, GPT-5), modèles locaux avancés (SD XL Turbo, FLUX.1, Lumina2), édition d'images existantes (Qwen Image Edit) et orchestration de workflows multi-nœuds via ComfyUI. La provenance exacte de chaque figure est documentée dans `assets/readme/MANIFEST.md`.
-
-<table>
-<tr>
-<td align="center"><b>DALL-E 3 (cloud)</b><br><a href="01-Foundation/01-1-OpenAI-DALL-E-3.ipynb"><img width="290" alt="Couverture : portrait illustré généré par DALL-E 3 depuis un prompt textuel." src="assets/readme/dalle3-cover.webp"></a></td>
-<td align="center"><b>SD XL Turbo (local)</b><br><a href="01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb"><img width="290" alt="Image SD XL Turbo : génération locale rapide via ComfyUI sur GPU auto-hébergé." src="assets/readme/forge-sdxl-turbo.webp"></a></td>
-<td align="center"><b>Qwen Image Edit</b><br><a href="01-Foundation/01-5-Qwen-Image-Edit.ipynb"><img width="290" alt="Édition Qwen Image Edit : panneau avant/après d'inpainting sur une zone masquée." src="assets/readme/qwen-edit-panel.png"></a></td>
-</tr>
-<tr>
-<td align="center"><b>FLUX.1 (avancé)</b><br><a href="02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb"><img width="290" alt="Génération FLUX.1 : rendu photo-réaliste haute qualité avec contrôle de prompt avancé." src="assets/readme/flux1-advanced.webp"></a></td>
-<td align="center"><b>Z-Image / Lumina2</b><br><a href="02-Advanced/02-4-Z-Image-Lumina2.ipynb"><img width="290" alt="Z-Image / Lumina2 : génération diffuse alternative, comparée aux modèles précédents." src="assets/readme/lumina2-zimage.webp"></a></td>
-<td align="center"><b>Workflow ComfyUI</b><br><a href="03-Orchestration/03-2-Workflow-Orchestration.ipynb"><img width="290" alt="Workflow ComfyUI orchestré : chaîne de nœuds (Sampler, VAE, upscaler) pour un pipeline de production." src="assets/readme/workflow-orchestration.png"></a></td>
-</tr>
-</table>
+Plutôt qu'une galerie séparée du propos, chaque niveau ci-dessous est illustré par une sortie réelle de notebook (EPIC #5654), placée au plus près du concept qu'elle démontre : la première image issue d'un appel d'API cloud, le rendu photo-réaliste d'un modèle local, le panneau avant/après d'une édition, ou la chaîne de nœuds d'un workflow de production. La provenance exacte de chaque figure (notebook source, cellule, poids) est documentée dans `assets/readme/MANIFEST.md`.
 
 ## Structure
 
@@ -55,6 +42,13 @@ Image/
 
 Avant de produire des visuels pédagogiques, il faut maîtriser les outils de génération. Ce niveau couvre les deux approches : API cloud (gpt-image-1, GPT-5) pour la simplicité, et modèles locaux via ComfyUI (SD XL Turbo, Qwen) pour le contrôle fin. [01-3](01-Foundation/01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation d'image (PIL, OpenCV) nécessaires pour comprendre ce que font les modèles.
 
+La première étape est un simple appel d'API : on décrit l'image en langage naturel et le modèle cloud renvoie un visuel. C'est le point d'entrée le plus accessible — pas de GPU, pas de configuration, juste une clé.
+
+<p align="center">
+  <a href="01-Foundation/01-1-OpenAI-DALL-E-3.ipynb"><img src="assets/readme/dalle3-cover.webp" width="320" alt="Couverture : portrait illustré généré par DALL-E 3 depuis un prompt textuel."></a><br>
+  <em>Sortie du notebook <a href="01-Foundation/01-1-OpenAI-DALL-E-3.ipynb">01-1</a> : portrait illustré produit par gpt-image-1 depuis un prompt textuel. Une seule requête API, zéro infrastructure locale.</em>
+</p>
+
 | Notebook | Contenu | Service |
 |----------|---------|---------|
 | [01-1-OpenAI-DALL-E-3](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) | Génération avec gpt-image-1 (DALL-E 3 retiré) | OpenAI API |
@@ -65,9 +59,30 @@ Avant de produire des visuels pédagogiques, il faut maîtriser les outils de g�
 
 [README 01-Foundation](01-Foundation/README.md)
 
+Une fois le cloud maîtrisé, la génération **locale** via ComfyUI ouvre le contrôle fin : choix du sampler, de la seed, du checkpoint. SD XL Turbo ([01-4](01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb)) distille la diffusion pour une génération rapide sur GPU auto-hébergé :
+
+<p align="center">
+  <a href="01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb"><img src="assets/readme/forge-sdxl-turbo.webp" width="320" alt="Image SD XL Turbo : génération locale rapide via ComfyUI sur GPU auto-hébergé."></a><br>
+  <em>Sortie du notebook <a href="01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb">01-4</a> : image produite localement par SD XL Turbo, sans appel d'API.</em>
+</p>
+
+L'autre apport du niveau foundation est l'**édition** : plutôt que de régénérer une image entière, Qwen Image Edit ([01-5](01-Foundation/01-5-Qwen-Image-Edit.ipynb)) ne recalcule que la zone masquée — moins coûteux et plus contrôlable. Le panneau ci-dessous montre l'avant/après d'un inpainting :
+
+<p align="center">
+  <a href="01-Foundation/01-5-Qwen-Image-Edit.ipynb"><img src="assets/readme/qwen-edit-panel.png" width="420" alt="Édition Qwen Image Edit : panneau avant/après d'inpainting sur une zone masquée."></a><br>
+  <em>Sortie du notebook <a href="01-Foundation/01-5-Qwen-Image-Edit.ipynb">01-5</a> : panneau avant/après d'un inpainting Qwen sur une zone masquée.</em>
+</p>
+
 ### 02-Advanced - Modèles avancés
 
 Un visuel éducatif de qualité demande des outils plus précis : édition d'images existantes (Qwen), génération haute qualité (FLUX), ou modèles légers et rapides (Z-Image/Lumina). Ce niveau explore les modèles de pointe et leurs compromis entre qualité, vitesse et ressources GPU. Le notebook [02-5](02-Advanced/02-5-Bonsai-Image-Ternary.ipynb) pousse l'optimisation à l'extrême avec Bonsai-Image (FLUX.2 Klein 4B en quantization ternaire 1.58-bit), qui ne consomme que ~6.8 GiB de VRAM à 1024x1024.
+
+Le porte-drapeau de ce niveau pour la **qualité** est FLUX.1 ([02-2](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb)) : un rendu photo-réaliste fidèle au prompt détaillé, là où gpt-image-1 tend à lisser les textures complexes.
+
+<p align="center">
+  <a href="02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb"><img src="assets/readme/flux1-advanced.webp" width="360" alt="Génération FLUX.1 : rendu photo-réaliste haute qualité avec contrôle de prompt avancé."></a><br>
+  <em>Sortie du notebook <a href="02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb">02-2</a> : rendu FLUX.1 — fidélité de texture et suivi de prompt avancé.</em>
+</p>
 
 | Notebook | Contenu | Service |
 |----------|---------|---------|
@@ -79,9 +94,21 @@ Un visuel éducatif de qualité demande des outils plus précis : édition d'ima
 
 [README 02-Advanced](02-Advanced/README.md)
 
+À l'opposé de FLUX.1 côté **légèreté**, Z-Image/Lumina2 ([02-4](02-Advanced/02-4-Z-Image-Lumina2.ipynb)) vise une génération rapide pour le prototypage — un compromis qualité/débit utile pour itérer sur un prompt avant de lancer un rendu lourd :
+
+<p align="center">
+  <a href="02-Advanced/02-4-Z-Image-Lumina2.ipynb"><img src="assets/readme/lumina2-zimage.webp" width="320" alt="Z-Image / Lumina2 : génération diffuse alternative, comparée aux modèles précédents."></a><br>
+  <em>Sortie du notebook <a href="02-Advanced/02-4-Z-Image-Lumina2.ipynb">02-4</a> : génération Z-Image/Lumina2, alternative diffuse rapide comparée aux modèles précédents.</em>
+</p>
+
 ### 03-Orchestration - Multi-modèles
 
-En production, un seul modèle ne suffit pas toujours. Ce niveau compare les modèles entre eux pour choisir le bon selon le contexte, orchestre des pipelines de traitement (génération puis édition puis upscaling), et optimise les performances pour le déploiement.
+En production, un seul modèle ne suffit pas toujours. Ce niveau compare les modèles entre eux pour choisir le bon selon le contexte, orchestre des pipelines de traitement (génération puis édition puis upscaling), et optimise les performances pour le déploiement. L'orchestration se matérialise par un **workflow ComfyUI** : un graphe de nœuds (Sampler, VAE, upscaler) que l'on enchaîne et exporte en JSON pour le rendre reproductible :
+
+<p align="center">
+  <a href="03-Orchestration/03-2-Workflow-Orchestration.ipynb"><img src="assets/readme/workflow-orchestration.png" width="420" alt="Workflow ComfyUI orchestré : chaîne de nœuds (Sampler, VAE, upscaler) pour un pipeline de production."></a><br>
+  <em>Sortie du notebook <a href="03-Orchestration/03-2-Workflow-Orchestration.ipynb">03-2</a> : graphe de nœuds d'un workflow ComfyUI orchestré (Sampler, VAE, upscaler).</em>
+</p>
 
 | Notebook | Contenu |
 |----------|---------|


### PR DESCRIPTION
## Contexte

Passe feuille 4-barres (#3973 re-musclé) sur **GenAI/Image**, feuille de ma lane. Pilote de référence = #6132 (Probas, MERGED). See #5780.

## Changement

La galerie `<table>` 6-vignettes (L28-39) était un anti-pattern #5780 : mosaïque séparée du propos, lue avant la structure pédagogique. Dissoute en **6 blocs narratifs `<p align=center>`** placés au plus près du concept qu'ils démontrent, dans leur section de niveau :

| Figure | Niveau | Concept démontré |
|--------|--------|------------------|
| dalle3-cover.webp | 01-Foundation | Entrée API cloud (une requête, zéro infra) |
| forge-sdxl-turbo.webp | 01-Foundation | Génération locale ComfyUI (contrôle fin) |
| qwen-edit-panel.png | 01-Foundation | Édition/inpainting (avant/après) |
| flux1-advanced.webp | 02-Advanced | Qualité / porte-drapeau |
| lumina2-zimage.webp | 02-Advanced | Légèreté / rapidité de prototypage |
| workflow-orchestration.png | 03-Orchestration | Graphe de nœuds (concept central) |

Chaque figure est introduite par une phrase-pivot reliant le visuel au concept du niveau.

## Passe feuille 4-barres

- **bar 4 (#5780)** : galerie → narration in-situ
- **bar 1 (#3973)** : l'intro Aperçu ne cite plus DALL-E 3 comme modèle cloud courant (gpt-image-1 / GPT-5 sont les entrées actives)
- **bar 2 (#5985)** : figures ordonnées saillant → spécifique par niveau
- **bar 3 (#2651)** : prose pédagogique ajoutée par figure

## Attestation visuelle par figure (barre HARD)

Les 6 figures ont été ouvertes et confrontées à leur légende :
- dalle3-cover : portrait illustré (sortie gpt-image-1) ✓
- forge-sdxl-turbo : image générée locale ✓
- qwen-edit-panel : panneau avant/après inpainting ✓
- flux1-advanced : rendu photo-réaliste ✓
- lumina2-zimage : génération diffuse ✓
- workflow-orchestration : graphe de nœuds ComfyUI ✓

Aucune courbe générique en capacité de figure.

## Pure-change proof

- 6 figures **byte-identiques** (sha1 inchangés vs base)
- 6 src paths + 6 alt-texts préservés verbatim
- 0 CRLF (LF-only)
- seul `README.md` modifié (+42/-15)

See #5780

🤖 Generated with [Claude Code](https://claude.com/claude-code)