### PR TITLE
feat(smt): Z3-Python-11 Graph Coloring (Petersen) - pyz3 port of C# 12

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -4,7 +4,7 @@
 
 ## Série en quelques mots
 
-L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **10 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée, à l'ordonnancement combinatoire, aux énigmes logiques (CSP), à l'arithmétique symbolique (cryptarithmes) et au pont déclaratif avec la série sœur Z3.Linq (C#).
+L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **11 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée, à l'ordonnancement combinatoire, aux énigmes logiques (CSP), à l'arithmétique symbolique (cryptarithmes), à la coloration de graphe (NP-complet) et au pont déclaratif avec la série sœur Z3.Linq (C#).
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs Python souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modélisation de problèmes combinatoires.
 
@@ -56,6 +56,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 | 08 | [Ordonnancement (Job-Shop Scheduling)](Z3-Python-08-Ordonnancement.ipynb) | `Optimize.minimize`, contrainte disjonctive `Or(...)`, makespan minimal, diagramme de Gantt | ~35 min | PRODUCTION |
 | 09 | [L'énigme d'Einstein (Zebra puzzle)](Z3-Python-09-Enigme-Einstein.ipynb) | Encodage par position, `Distinct`, adjacences, satisfiabilité vs optimisation, unicité prouvée | ~30 min | PRODUCTION |
 | 10 | [Cryptarithmes (SEND + MORE = MONEY)](Z3-Python-10-Cryptarithmetic.ipynb) | `Int`, `Distinct`, équation positionnelle, propagation vs brute force, retenues déduites | ~25 min | PRODUCTION |
+| 11 | [Coloration de graphe (Petersen)](Z3-Python-11-Graph-Coloring.ipynb) | `Int` par sommet, contraintes d'arêtes `!=`, recherche linéaire du nombre chromatique, `unsat` = preuve d'optimalité | ~30 min | PRODUCTION |
 
 ### Fil pédagogique
 
@@ -69,6 +70,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 8. **Notebook 08** applique l'optimisation à l'ordonnancement de tâches (job-shop scheduling, NP-difficile) : la contrainte disjonctive `Or(s_a + d_a ≤ s_b, s_b + d_b ≤ s_a)` (exclusion mutuelle sur une machine) et l'objectif de makespan minimal (`Optimize.minimize`) révèlent où le solveur surpasse une heuristique gloutonne FIFO — l'optimum trouvé (8 h) écrase le glouton (14 h)
 9. **Notebook 09** illustre la **satisfiabilité** pure (versus l'optimisation du 08) sur l'énigme d'Einstein : l'encodage par position (25 variables entières) transforme un puzzle qualitatif en contraintes arithmétiques (`Distinct`, égalités, adjacences), et `Solver` trouve l'unique solution en quelques millisecondes là où la brute force affronte (5!)^5 = 24,9 milliards de combinaisons — l'unicité est **prouvée** par négation (`unsat`)
 10. **Notebook 10** généralise à l'**arithmétique symbolique sur entiers** avec les cryptarithmes (`SEND + MORE = MONEY`) : chaque lettre est un `Int` dans `{0..9}`, `Distinct` impose l'unicité, et l'équation positionnelle (`1000·S + 100·E + …`) est résolue par propagation — Z3 trouve l'unique solution (`9567 + 1085 = 10652`) en millisecondes tandis que la brute force énumère `P(10,8) = 1 814 400` candidats (~9 s), illustrant le gain du paradigme déclaratif
+11. **Notebook 11** aborde la **coloration de graphe** (NP-complet) sur le graphe de Petersen : une variable `Int` par sommet, des contraintes d'arêtes `C_a != C_b`, et une **recherche linéaire sur k** qui trouve le nombre chromatique `chi = 3` **et le prouve minimal** (`k = 2` → `unsat`). Là où le glouton first-fit hésite (3 ou 4 couleurs selon l'ordre) sans jamais certifier l'optimum, le verdict `unsat` de Z3 est une **preuve formelle** d'impossibilité — la double capacité (trouver ET prouver) est le cœur de l'apport SMT en optimisation combinatoire
 
 ## Concepts clés
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-11-Graph-Coloring.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-11-Graph-Coloring.ipynb
@@ -1,0 +1,636 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e0776896",
+   "metadata": {},
+   "source": [
+    "← [10 - Cryptarithmes](Z3-Python-10-Cryptarithmetic.ipynb) | [README Z3-Python](README.md)\n",
+    "\n",
+    "# 11. Coloration de graphe : le graphe de Petersen\n",
+    "\n",
+    "La **coloration de graphe** consiste a attribuer une couleur a chaque sommet telle que deux sommets relies par une arete portent des couleurs differentes. Le **nombre chromatique** `chi(G)` est le nombre minimal de couleurs necessaires. Probleme **NP-complet** : il n'existe pas d'algorithme polynomial connu pour le resoudre en general.\n",
+    "\n",
+    "Le **graphe de Petersen** (10 sommets, 15 aretes) est un cas canonique : son nombre chromatique est `chi = 3` (ni biparti `chi=2`, ni trivial). La **recherche lineaire sur k** combinee a Z3 ne se contente pas de *trouver* 3 couleurs - elle **prouve** que 2 sont impossibles (`unsat`), ce qu'une heuristique gloutonne ne peut jamis affirmer.\n",
+    "\n",
+    "> Port pyz3 du notebook C# [`12_Graph_Coloring_Petersen.ipynb`](../Z3/12_Graph_Coloring_Petersen.ipynb). EPIC #1206, Prong B. (La section B2 MkIte du C#, specifique au DSL Z3.Linq, n'est pas portee.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f92c4d14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:26.652101Z",
+     "iopub.status.busy": "2026-07-11T16:21:26.651591Z",
+     "iopub.status.idle": "2026-07-11T16:21:28.463749Z",
+     "shell.execute_reply": "2026-07-11T16:21:28.461042Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : z3-solver, matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "from z3 import *\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.patches as mpatches\n",
+    "import time\n",
+    "plt.ioff()  # batch mode\n",
+    "print(\"Imports OK : z3-solver, matplotlib\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f6f1f0",
+   "metadata": {},
+   "source": [
+    "## 1. Le graphe de Petersen\n",
+    "\n",
+    "Le graphe de Petersen a 10 sommets (0 a 9) et 15 aretes organisees en trois structures : le **pentagone externe** (0-1-2-3-4-0), les **rayons** (0-5, 1-6, ...) et le **pentagramme interne** (5-7-9-6-8-5). C'est un exemple celebre en theorie des graphes : 3-regulier, non hamiltonien, et son nombre chromatique est exactement 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "666f28c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:28.473115Z",
+     "iopub.status.busy": "2026-07-11T16:21:28.471980Z",
+     "iopub.status.idle": "2026-07-11T16:21:28.491576Z",
+     "shell.execute_reply": "2026-07-11T16:21:28.488914Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe de Petersen charge : 10 sommets, 15 aretes.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Graphe de Petersen : 10 sommets (0..9), 15 aretes\n",
+    "N = 10\n",
+    "edges = [\n",
+    "    # Pentagone externe\n",
+    "    (0,1),(1,2),(2,3),(3,4),(4,0),\n",
+    "    # Rayons externe -> interne\n",
+    "    (0,5),(1,6),(2,7),(3,8),(4,9),\n",
+    "    # Pentagramme interne\n",
+    "    (5,7),(7,9),(9,6),(6,8),(8,5),\n",
+    "]\n",
+    "\n",
+    "# Liste d'adjacence (pour le glouton)\n",
+    "adj = {v: [] for v in range(N)}\n",
+    "for a, b in edges:\n",
+    "    adj[a].append(b); adj[b].append(a)\n",
+    "\n",
+    "def display_coloring(color, title):\n",
+    "    print(title)\n",
+    "    k = max(color) + 1\n",
+    "    print(\"  Couleurs utilisees : %d\" % k)\n",
+    "    for v in range(len(color)):\n",
+    "        print(\"  Sommet %d -> couleur %d\" % (v, color[v]))\n",
+    "    valid = all(color[a] != color[b] for a, b in edges)\n",
+    "    print(\"  Coloration valide (aucune arete monochrome) : %s\" % valid)\n",
+    "\n",
+    "print(\"Graphe de Petersen charge : %d sommets, %d aretes.\" % (N, len(edges)))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad1efd7e",
+   "metadata": {},
+   "source": [
+    "## 2. Approche 1 : heuristique gloutonne (first-fit)\n",
+    "\n",
+    "L'heuristique **first-fit** parcourt les sommets dans un ordre donne et assigne a chacun la plus petite couleur non utilisee par ses voisins deja colores. Simple et rapide, mais **le resultat depend de l'ordre** : un ordre defavorable gaspille des couleurs. Et surtout, le glouton ne peut jamais **prouver** qu'il a atteint l'optimum - il ne fait que constater ce qu'il a trouve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f5b858a9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:28.500321Z",
+     "iopub.status.busy": "2026-07-11T16:21:28.499277Z",
+     "iopub.status.idle": "2026-07-11T16:21:28.518604Z",
+     "shell.execute_reply": "2026-07-11T16:21:28.515783Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First-fit, ordre naturel 0..9 :\n",
+      "  Couleurs utilisees : 3\n",
+      "  Sommet 0 -> couleur 0\n",
+      "  Sommet 1 -> couleur 1\n",
+      "  Sommet 2 -> couleur 0\n",
+      "  Sommet 3 -> couleur 1\n",
+      "  Sommet 4 -> couleur 2\n",
+      "  Sommet 5 -> couleur 1\n",
+      "  Sommet 6 -> couleur 0\n",
+      "  Sommet 7 -> couleur 2\n",
+      "  Sommet 8 -> couleur 2\n",
+      "  Sommet 9 -> couleur 1\n",
+      "  Coloration valide (aucune arete monochrome) : True\n",
+      "\n",
+      "First-fit, ordre defavorable [4, 8, 2, 6, 5, 9, 0, 7, 1, 3] :\n",
+      "  Couleurs utilisees : 4\n",
+      "  Sommet 0 -> couleur 2\n",
+      "  Sommet 1 -> couleur 3\n",
+      "  Sommet 2 -> couleur 0\n",
+      "  Sommet 3 -> couleur 1\n",
+      "  Sommet 4 -> couleur 0\n",
+      "  Sommet 5 -> couleur 1\n",
+      "  Sommet 6 -> couleur 1\n",
+      "  Sommet 7 -> couleur 3\n",
+      "  Sommet 8 -> couleur 0\n",
+      "  Sommet 9 -> couleur 2\n",
+      "  Coloration valide (aucune arete monochrome) : True\n",
+      "\n",
+      "Meme graphe, meme algorithme : 3 couleurs vs 4 couleurs selon l'ordre.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Coloration gloutonne first-fit selon un ordre de parcours donne\n",
+    "def greedy_coloring(n, adjacency, order):\n",
+    "    color = [-1] * n\n",
+    "    for v in order:\n",
+    "        used = set()\n",
+    "        for w in adjacency[v]:\n",
+    "            if color[w] != -1:\n",
+    "                used.add(color[w])\n",
+    "        c = 0\n",
+    "        while c in used:\n",
+    "            c += 1\n",
+    "        color[v] = c\n",
+    "    return color\n",
+    "\n",
+    "# Ordre naturel 0..9\n",
+    "natural_order = list(range(N))\n",
+    "greedy_natural = greedy_coloring(N, adj, natural_order)\n",
+    "greedy_natural_colors = max(greedy_natural) + 1\n",
+    "display_coloring(greedy_natural, \"First-fit, ordre naturel 0..9 :\")\n",
+    "print()\n",
+    "\n",
+    "# Ordre defavorable (force la 4e couleur)\n",
+    "bad_order = [4, 8, 2, 6, 5, 9, 0, 7, 1, 3]\n",
+    "greedy_bad = greedy_coloring(N, adj, bad_order)\n",
+    "greedy_bad_colors = max(greedy_bad) + 1\n",
+    "display_coloring(greedy_bad, \"First-fit, ordre defavorable %s :\" % bad_order)\n",
+    "print()\n",
+    "print(\"Meme graphe, meme algorithme : %d couleurs vs %d couleurs selon l'ordre.\" % (greedy_natural_colors, greedy_bad_colors))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b55c722a",
+   "metadata": {},
+   "source": [
+    "## Interpretation\n",
+    "\n",
+    "Le glouton trouve **3 couleurs** dans le bon ordre mais **4 dans l'ordre defavorable** - alors que l'optimum est toujours 3. C'est le piege des heuristiques : sans recherche exhaustive, impossible de savoir si le resultat est optimal. Le solveur, lui, va **prouver** l'optimalite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0521907b",
+   "metadata": {},
+   "source": [
+    "## 3. Approche 2 : modelisation Z3\n",
+    "\n",
+    "On encode une variable entiere `C_v` par sommet (couleur de v), on borne les couleurs a `[0, k)`, on fixe `C_0 = 0` (brisure de symetrie - evite l'explosion par permutation de couleurs), et pour chaque arete `(a,b)` on impose `C_a != C_b`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b5d800e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:28.527637Z",
+     "iopub.status.busy": "2026-07-11T16:21:28.526413Z",
+     "iopub.status.idle": "2026-07-11T16:21:28.549891Z",
+     "shell.execute_reply": "2026-07-11T16:21:28.547618Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modele defini : 10 variables de couleur entieres C0..C9.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Modele Z3 : une variable de couleur par sommet\n",
+    "Color = [Int('C%d' % v) for v in range(N)]\n",
+    "print(\"Modele defini : %d variables de couleur entieres C0..C9.\" % N)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d5ec0de",
+   "metadata": {},
+   "source": [
+    "## 4. Recherche du nombre chromatique\n",
+    "\n",
+    "On cherche le plus petit `k` tel que le graphe soit `k`-colorable. Pour chaque `k`, on instancie le modele (domaine `[0,k)`, brisure de symetrie, contraintes d'aretes) et on teste la **satisfiabilite** :\n",
+    "- `sat` -> `k` couleurs suffisent, le nombre chromatique est `k` (car les `k-1` precedents etaient `unsat`).\n",
+    "\n",
+    "- `unsat` -> `k` couleurs ne suffisent pas, on essaie `k+1`.\n",
+    "\n",
+    "\n",
+    "\n",
+    "C'est cette double nature (trouver ET prouver l'impossibilite) qui fait la force du solveur face au glouton."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8ac54224",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:28.559067Z",
+     "iopub.status.busy": "2026-07-11T16:21:28.557678Z",
+     "iopub.status.idle": "2026-07-11T16:21:28.625389Z",
+     "shell.execute_reply": "2026-07-11T16:21:28.623263Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "k = 1 -> UNSAT (impossible avec 1 couleur(s))\n",
+      "k = 2 -> UNSAT (impossible avec 2 couleur(s))\n",
+      "k = 3 -> SAT : nombre chromatique trouve !\n",
+      "\n",
+      "Nombre chromatique chi(Petersen) = 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Recherche lineaire du nombre chromatique\n",
+    "optimal_color = None\n",
+    "chromatic = -1\n",
+    "\n",
+    "for k in range(1, N + 1):\n",
+    "    s = Solver()\n",
+    "    s.add([And(Color[v] >= 0, Color[v] < k) for v in range(N)])\n",
+    "    # Brisure de symetrie : la couleur du sommet 0 est fixee\n",
+    "    s.add(Color[0] == 0)\n",
+    "    # Aretes : extremites de couleurs differentes\n",
+    "    for a, b in edges:\n",
+    "        s.add(Color[a] != Color[b])\n",
+    "    if s.check() == sat:\n",
+    "        m = s.model()\n",
+    "        optimal_color = [m[Color[v]].as_long() for v in range(N)]\n",
+    "        chromatic = k\n",
+    "        print(\"k = %d -> SAT : nombre chromatique trouve !\" % k)\n",
+    "        break\n",
+    "    else:\n",
+    "        print(\"k = %d -> UNSAT (impossible avec %d couleur(s))\" % (k, k))\n",
+    "\n",
+    "print()\n",
+    "print(\"Nombre chromatique chi(Petersen) = %d\" % chromatic)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37e8ff99",
+   "metadata": {},
+   "source": [
+    "## Interpretation : `chi = 3` prouve\n",
+    "\n",
+    "Z3 confirme `chi(Petersen) = 3` : `k=1` et `k=2` sont `unsat` (preuve qu'on ne peut pas faire mieux), `k=3` est `sat` (une coloration existe). Le verdict `unsat` pour `k=2` est la **preuve formelle** que le graphe n'est pas biparti - quelque chose qu'aucune heuristique gloutonne ne peut etablir."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "105fed14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:28.633363Z",
+     "iopub.status.busy": "2026-07-11T16:21:28.632805Z",
+     "iopub.status.idle": "2026-07-11T16:21:28.646039Z",
+     "shell.execute_reply": "2026-07-11T16:21:28.643846Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Coloration optimale Z3 (chi = 3) :\n",
+      "  Couleurs utilisees : 3\n",
+      "  Sommet 0 -> couleur 0\n",
+      "  Sommet 1 -> couleur 1\n",
+      "  Sommet 2 -> couleur 2\n",
+      "  Sommet 3 -> couleur 0\n",
+      "  Sommet 4 -> couleur 1\n",
+      "  Sommet 5 -> couleur 1\n",
+      "  Sommet 6 -> couleur 0\n",
+      "  Sommet 7 -> couleur 0\n",
+      "  Sommet 8 -> couleur 2\n",
+      "  Sommet 9 -> couleur 2\n",
+      "  Coloration valide (aucune arete monochrome) : True\n",
+      "\n",
+      "=== Comparaison ===\n",
+      "  Glouton first-fit (ordre naturel)    : 3 couleurs\n",
+      "  Glouton first-fit (ordre defavorable): 4 couleurs\n",
+      "  Z3 (optimum PROUVE)                  : 3 couleurs\n",
+      "  Dans le pire ordre, le glouton gaspille 1 couleur(s).\n",
+      "  Surtout : seul Z3 PROUVE que 3 est minimal (2 couleurs = UNSAT).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Extraction et verification de la coloration optimale\n",
+    "display_coloring(optimal_color, \"Coloration optimale Z3 (chi = %d) :\" % chromatic)\n",
+    "print()\n",
+    "print(\"=== Comparaison ===\")\n",
+    "print(\"  Glouton first-fit (ordre naturel)    : %d couleurs\" % greedy_natural_colors)\n",
+    "print(\"  Glouton first-fit (ordre defavorable): %d couleurs\" % greedy_bad_colors)\n",
+    "print(\"  Z3 (optimum PROUVE)                  : %d couleurs\" % chromatic)\n",
+    "print(\"  Dans le pire ordre, le glouton gaspille %d couleur(s).\" % (greedy_bad_colors - chromatic))\n",
+    "print(\"  Surtout : seul Z3 PROUVE que %d est minimal (2 couleurs = UNSAT).\" % chromatic)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd99ece2",
+   "metadata": {},
+   "source": [
+    "## Visualisation : la coloration optimale\n",
+    "\n",
+    "Le graphe de Petersen se dessine classiquement avec un pentagone externe, un pentagramme interne et 5 rayons. La coloration a 3 couleurs (une par cercle) rend visible l'absence d'arete monochrome."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "01a8bdc2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:28.654137Z",
+     "iopub.status.busy": "2026-07-11T16:21:28.652990Z",
+     "iopub.status.idle": "2026-07-11T16:21:29.335160Z",
+     "shell.execute_reply": "2026-07-11T16:21:29.332563Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAJICAYAAACXAGvoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAsGtJREFUeJztvQeYVeW5t/9QhjIDDL2DIh2kKEURRVSw9xpNYmISPfknpqknJzHxIOaYfInmpH0pR5NjPjVYg70gKCqCiIBIryK9M7ShDTD/637hnWyGmT17z+y21vrd17V1Zth7rbVXed/nfcrvqVVaWlpqQgghhBCiSmpX/RYhhBBCCAEynIQQQgghEkSGkxBCCCFEgshwEkIIIYRIEBlOQgghhBAJIsNJCCGEECJBZDgJIYQQQiSIDCchhBBCiASR4SSEEEIIkSAynIQIMbVq1bL777/fco2RI0e6V5j5/PPP3fn/+9//Hpl9s88777yzyvdxXLyX4xQiaMhwEgnjBzv/atCggfXo0cMNlJs2bUp6e+PGjbPf/va3aTlWkX0WLlzojLawT466j4PBggUL7IYbbrBTTjnF8vPzrWXLljZixAh75ZVXsn1oImDUzfYBiODxwAMPWJcuXWz//v32wQcf2J///Gd7/fXXbf78+W5ASmbC4TPf//7303q8InuG09ixY51n6eSTTz7u39566y0LC5XdxyeddJLt27fP8vLysnZsucqXv/xl+8IXvmD169fP2D5XrVplu3fvtq985SvWvn1727t3r/3zn/+0K6+80v7nf/7H7rjjjowdiwg2MpxE0lxyySU2ePBg9/M3vvENa9Gihf33f/+3vfTSS3bzzTdn9diOHDliBw8edN4wkVqKi4utoKAgJduqV6+ehR3vlRUnUqdOHffKJJdeeql7xYK3fNCgQW78kuEkEkWhOlFjzj//fPf/lStXlv3tySefdANSw4YNrXnz5m51uWbNmrJ/xwvx2muvuVWgD/3FeiUOHDhgY8aMsW7durlVaadOneyHP/yh+3tFORX/+Mc/rG/fvu69b775pvu3p59+2h1D48aNrUmTJtavXz/73e9+d9znd+zY4TwFbJ/Psr9f/vKXzgArny/y8MMP2yOPPGJdu3Z17x0yZIh9/PHHCZ2jFStWuFcicEw/+MEP3PlgPx07drRbb73Vtm7dWvaezZs329e//nVr06aNm5wHDBhg/+///b+Etv/JJ58445dz0qhRI7vgggts+vTpFYZl33vvPfvWt75lrVu3dscBXDP+1rNnT3d9MZwJgcSG5Pg8f4Pzzjuv7Bq/++67leY4JfKdUnEtPvvsM3ds3Jd4SM8880x3L8bCcbKfZ555xu69915r27atMxrxTiR6H1eUZ/TVr37VnfPVq1fb5Zdf7n7u0KGD/fGPf3T/Pm/ePPc8sS88VnizYtm+fbvdc8897l7ms1xDruWnn36a0HdfvHixXX/99e67c45ZAL388ssJfZZngueHffPZVq1a2cUXX2wzZ8484b0vvviinXrqqe7a8Fz6ZzLXcpww3nj2eeaESBR5nESN8QYBEyg8+OCDdt9999mNN97oPFJbtmyxP/zhDy6fgEm7adOm9pOf/MR27txpa9eutd/85jfuc0wEfoBmgiIMyCqwd+/ebkLhfUuXLnWDcizvvPOOPfvss86AIm+BiWvixInO+4VRgCEEixYtsqlTp9r3vvc99zuu+nPPPdfWrVtn//Zv/2adO3e2adOm2Y9//GPbsGHDCXkrTGK4+nkvg/6vfvUru/baa91EXFU4huOAqiaKPXv22DnnnOOO9Wtf+5qdfvrpzmBicuNc8f0I/zBhL1++3H1nwqbPPfecm5SZAPz3qyzPg+0z4WKIctyEKdgeRtIZZ5xx3PsxkJgg//M//9N5nAADhfOEMYwxxXciXMs2CM9hjHCtv/vd79rvf/97Z3hwDcH/vzzJfqfqXgty8c466yx37Tk+7lmMM+63559/3q655prj3s+9zPb/4z/+wxl23BOjRo2yOXPmOKMx3n1cGYcPH3bGDueI48bo5ztjLLG9L37xi+67/OUvf3EG87Bhw9z5AL4f9z+GH3/j+3D9uI8594Sg4l374cOHO0PtRz/6kdsfz83VV1/tQlblv3t5MGoxeDh2nutDhw7ZlClTnNHtPdDAczt+/Hh377Bo4R647rrrnLHox4hEYaHEdU4Eno1E4D7mfuO68Vy98cYbdtNNNyV1XCLilAqRII899lgpt8ykSZNKt2zZUrpmzZrSp59+urRFixalDRs2LF27dm3p559/XlqnTp3SBx988LjPzps3r7Ru3brH/f2yyy4rPemkk07YzxNPPFFau3bt0ilTphz397/85S9u/1OnTi37G7/z3gULFhz33u9973ulTZo0KT106FCl3+dnP/tZaUFBQenSpUuP+/uPfvQj9x1Wr17tfl+5cqXbD99z+/btZe976aWX3N9feeWVKs8d37Oi71qe//zP/3TbHD9+/An/duTIEff/3/72t+49Tz75ZNm/HTx4sHTYsGGljRo1Kt21a1fZ33nfmDFjyn6/+uqrS+vVq1e6YsWKsr+tX7++tHHjxqUjRow44VqfffbZJ5zDvXv3nnBsH374oXv/448/Xva35557zv1t8uTJJ7z/3HPPdS9Pot+pptfi+9//vntf7L21e/fu0i5dupSefPLJpYcPH3Z/45h5X4cOHY47n88++6z7++9+97sq72N/rJxLz1e+8hX3t5///OdlfysqKnLPT61atdzz5Fm8ePEJ12///v1lxxi7n/r165c+8MADcfd9wQUXlPbr189tI/aeOuuss0q7d+8e97y98847bnvf/e53K70vgfdwfy1fvrzsb59++qn7+x/+8IcT7i+OMx7+fYm8EuXf/u3fyj7D2HH99dcfdy8JURUK1YmkYcWNFwIXN14HVtgvvPCCW8my0sRjhLcJT4l/Eero3r27TZ48ucrt42nAM9GrV6/jtuFDguW3wWq7T58+x/0NrxYrSzxP8faD96VZs2bH7Yfvh1fg/fffP+79rEp5r4fPei9AVeCVSSQswcqfEFVFq388H0AiPuczNp8MLwseFDxWeI4qgu9EUjYeBiqLPO3atbNbbrnFeQp27dp13Gduv/32E3JR8LR4SkpKbNu2bS7EyTmfPXu2VYdkv1N1rwX7GTp0qJ199tllf+P+xbPJ9cFrEwseH7wmHsJcnC+2UxPw2Hg4b4Q98QDx3Hj4G/8W+50IfdWuXbvsenLuOX7eG+/cE+LDM8v28eD4e53PX3TRRbZs2TLneY13X3L/ET6v7L708PwQQvX079/feTgTeU7Kw7HxDCfyShRC87wfTyPeM84jeZFCJIpCdSJpyMdAhqBu3bouH4VB2w/mDMAsPDGSKiKRCiO2QagK46wiCJnE4sMYsRAmIAzBwIhBd+GFF7pJg5yM2P3MnTs34f0QyovFT9xFRUWWyrAnYY14kE/D+fXn3OPDYPx7RRAyJUTF9SoPn8XgJX+HnJR455Ywxy9+8Qt77LHH3GR71NFwFMIf1SHZ71Tda8F2yocjy++H3BxP+fsYIwEjsSa5OT4/KJbCwkIX9ixvhPD32O/k84z+9Kc/uZxCJn1PvDAYIVCuEyF0XpXd7zwrld2XhAHJjaqK8tfGX5/qPCcYqbxSCQsyXt4wZmy44oor7KOPPjrh/AtRETKcRNKwYo/NaYiFgZ3Bh7yBiqpmqsr/8NsgAZVKl4rA01WZB8RDMjN5KBMmTHDHwouJnoHSJxyzn9GjR7tcn4rAOIylsiqgWMMhbFR0br/zne+4c8nKnfwbJneuOd7H2KT6dBLka1HZsSfynX7+8587w4f8t5/97GfOkMHY5FrEO/f+30gsx4tTERiEuXZtfC5SIuCxrA54EcmVI3+yokWFEOWR4SRSCi56Bkg8FeUNj/JUtrpjG1QJkVBdkxUgJe+sJHkxceCFIpGWiYdJgv0QBiK0kCtwTGgCxYNqKzxlfKdYDw0VU/7fKwIvB4nbS5YsOeHf+CzbKm+UVgRJ1Gjh/PrXvy77G5pe5SuTkrl21f1OycJ2Kvv+Fe0Hr2Qs3Nt4bwg/eTLppeDcU6X4t7/97bi/c+7jJUf70Cwe3+rc79yXLEII+SXidUoVVDXedtttCb23ukYzxllNvKUieijHSaQUqoFYcSJ8WH4g43dyKjzkdFQ0WBFSIwT06KOPVjjI+equeMTuB5iM/WTnJQ3Yz4cffugmhPIwEVE1lCoSlSMgTIfRSM5Yefz5RItm48aNblLxcKxULuLRI+erIrguhCXQ24oNNVGZRZUaeT/kolQF2yl/bdl3bNgIvOZTIqXe1f1OycJ+ZsyY4a67h/sJaQOqMcvnyj3++OPHVXVhuFBxSQi4qvs4HVR07snVi5ef5D2wVC2ycOD4KwrjVnVfsl+e60x6+VKZ41Q+9O5z9LjGeFbLX3shKkMeJ5FSWJn+13/9lyvpZ3ImEZnkWvIxMAZIwiVcAGgsMVHeddddToeHCRLvEKrC5Cd985vfdInglFAzKeMV4O8YOpWFCmOTb1kdk1BO7gi5K0zCAwcOLMtn+fd//3dXjoyeDmXvHA+TKNIHTJAcf6IlzlWRqBwBx8S+KTcnHMMx8T04TsrTSRznHDIBcsyzZs1yEz6fQWqBcvnYZObycG2YZDCS8MCRp8a2MCYpjU8EztcTTzzhQnRMNhghkyZNOiHHhnPNRI8cBIYFic1cDybx8tTkOyUDZfhPPfWUM3xIPMd7QuiW+5ME6PI5Vvw75wqvBwYmx4K3kqR5T2X3cTrg3KPcz/Egq8C9ipxBbLJ/vNxEvgthcI6fz/CduH7IKcTTgsLLxXOJtABeOHIF8Q4iR8C/JdKfrjqkMseJcBzFD8hAkMuFoc65Y1zBe5pIGoEQjirr7oQoVxr88ccfV/nef/7zn66UnXJ/Xr169Sr99re/XbpkyZKy9+zZs6f0lltuKW3atKnbbmxJN6Xov/zlL0v79u3rSq2bNWtWOmjQoNKxY8eW7ty5s+x9fI7tluf5558vvfDCC0tbt27tyqM7d+7sypA3bNhw3PsoRf/xj39c2q1bN/e+li1buvLshx9+2B1DbGn3Qw89dMJ+ypeL11SOALZt21Z65513ulJ4jqljx46ujH3r1q1l79m0aVPpbbfd5o6X91BmHlt6Hu/4Zs+eXXrRRRe5Mv/8/PzS8847r3TatGkJX2vK5/2+2QbbonSe78dxxvLoo4+WnnLKKU7eIVaaoLwcQaLfKRXXAikGStC57xo0aFA6dOjQ0ldfffW493g5gqeeesrdH9xHSAYgPbBq1arj3lvZfVyZHAHPQ3k4F9zr5WFb7NODlMDdd99d2q5dO3c8w4cPd1IQ5c9nRfv23/3WW28tbdu2bWleXp67xy6//HL3vFQFshScd55lrk+rVq1KL7nkktJZs2ZV+TyWvzcSlSNIJVzLUaNGlbZp08ZJozCm8DtSFkIkQy3+IxtSCCGOVw7Hk0IYjORhIYTwKMdJCCGEECJBZDgJIYQQQiSIDCchhBBCiARRjpMQQgghRILI4ySEEEIIkSAynIQQQgghEkSGkxBCCCFEgshwEkIIIYRIEBlOQgghhBAJIsNJCCGEECJBZDgJIYQQQiSIDCchhBBCiASR4SSEEEIIkSB1E32jEEIIEUUOHz5sBw8ezPZhiBpQr149q1OnjqUCGU5CCCFEBdCRbN26dbZ9+/ZsH4pIAc2bN7cOHTpYrVq1arQdGU5CCCFEBXijqW3btlZQUGC1ayu7JYgcOXLEiouLbePGje73jh071mh7MpyEEEKICsJz3mhq3bp1tg9H1BAMX8B4ateuXY3CdjKchBBZp6SkxGbMmGEzZ860WbNm2dq1a11OCXkJrA4HDRpkgwcPtqFDh1peXl62D1dEAJ/T5CdcEXwKjl1Lrm3Dhg2rvR0ZTkKIrIZCHn30UXvkkUdsw4YNlb7viSeecP9npXjHHXfY7bff7nIVhEg3Cs+Fh9opupa1Ssl+E0KIDHLo0CF76KGH7P777y9b2TerXdsG59Wz/vXqWZc6da1+rVp2oLTUVh4+ZHMPHrSZJQet6MgR9148UWPHjrV77rnH6tbV+k+knn379tmyZcuse/fuNfJOiPBdU404QoiMsnz5crvlllvs448/dr8PqVfPbitoZBc3aGj14lS7HCwttTf377PHivfYxwcP2o9//GMbP368jRs3zrp165bBbyCizKF16+xIBqvsajdvbnVz1Ls6cuRIGzhwoP32t7+1KCHDSQiRMebOnWujR4+2zZs3W2GtWja2sKld1zA/ofJgjKorG+bbFQ0a2vP79tqYnTuc8XX22WfbxIkTrV+/fhn5DiLaRtOmc841O3AgczutX9/aTHkvKeOJBOgHH3zQXnvtNRcOJ7kdA+f73/++XXDBBRYW3n33XbvrrrtswYIF1qlTJ/vpT39qX/3qV9O+XwVvhRAZ8zR5o6lv3Tyb1LqtXZ9fkLSmCu+/Ib/A3m7d1m1n06ZNNmrUKLd9IdKJ8zRl0miCAweS8nB9/vnnrpjinXfeceHwefPm2ZtvvmnnnXeeffvb37agcbAS4dGVK1faZZdd5r7XnDlznFH4jW98wyZMmJD2Y5LhJITISE7TzTffXGY0PduylbWroYovn2c7bI/tEv5jP0JEmW9961tucUGV6nXXXWc9evSwvn37Os/M9OnTy963evVqu+qqq6xRo0bWpEkTu/HGG90ixIPn5uqrrz5u2xgnI0eOrHTfBw4ccHmHFG5QwXbGGWc4r5CHnEY8X7EQ5jv55JNP2C8es/bt21vPnj0r3Ndf/vIX69Kli/3617+23r1725133mnXX3+9/eY3v7F0I8NJCJF2Hn74YSc10KRWLft7i5ZWWEl1S+22ba3pb/7b2s6Zbe1XLLPWk9+2gtu/gZupwvezHbbHdgnbsR8hogq6U3iX8CxVJKPQtGnTMkFIjCbe/95777lQ92effWY33XRTjfZ/55132ocffmhPP/20C8vfcMMNdvHFF7uE7GR4++23bcmSJe64Xn311Qrfw37wNMdy0UUXub+nG+U4CSHSCjkWY8aMcT+T01SZp6l2ixbW6qUXrG6Mqm9ejx7W9P4xVveUU2znj++t8HNs7/7CpnbXjiK3n1tvvdWtVIWIGoSrKZTv1atXlYYJITzCXeQGweOPP+48UyxAhgwZkvS+V69ebY899pj7v3/+8D5hyPH3n//85wlvC6Pvr3/9q6uejZfH1aZNm+P+xu+7du1y1XPprISUx0kIkVbQaSJPgeq56xvmV/q+xnffVWY0Fd11j23oN8D2TZzofm9065ctr5yLP5YbGuY7KQP2w/6EiCKJqgstWrTIGUzeaII+ffo4jxT/Vh3mzZvn1NYJDRL+8y88WitWrEhqWxR6xDOaso08TkKItCqCI24JSA5Umgheq5blX33V0c8sX257n3nG/bznD//XGo4e7X7Ov+Zq2zlnTiUfr2W3NWpkM4u2u/3de++9UhgXkQN9Ip6FxYsXp0QssrwhxvNcGXv27HFtTFD+L9/OBAMqmW0motZOK5zYnCzgd/K10q27JY+TECJtkKCKInjz2rWdTlNl1DnpJKtdWOh+PrT8X6vTkpif86qQG7ikQUMnorl+/Xq3XyGiRvPmzV2ezx//+EfX1LY8O3bscP8nmXrNmjXu5Vm4cKH7dzxP0KpVqxPU/Kleq4zTTjvNeZwo1EBXLfaFkeO3SYgt1niKt814DBs2zIUcYyEnir+nGxlOQoi0QUI4DMqrF1fcsk6L5mU/l+7Z/a+fd//r59otW8TdF9tnP8CqV4gogtGEAUNfx3/+858uMZvw2+9///syo4KkasJhX/ziF2327NluoUFu4Lnnnut6QsL555/vnl9yn9gG+YPz58+vdL+E6Nge20GYlvwptvuLX/zC6UkBFXlbtmyxX/3qVy58x7G+8cYb1fqe3/zmN11C+w9/+EPnYfvTn/5kzz77rP3gBz+wdCPDSQiRNrwBQxuVahFrbCWQv+H3I8NJpEvFG0HKjFK//tH9Jsgpp5zijCH0je6++2479dRTnX4a3pk///nP7j2E81566SVr1qyZjRgxwhlSfO6ZYyFywHN13333OcOEZPHdu3c7oygeJIHzHvaLjACyAiSbd+7cuczThYGDwTRgwABnWJFAXh2QIsAgw8vEtpAlIKGc40436lUnhEgbrFonT55s/7dpc7s6v/LE8Donn2xtp05xP++b8JZt/9rX3c+1Cgut/cKjq9wDH82wrddeF3d/L+7da3fu2O4mDQQAhUh1XzO1XAku6lUnhAiM6i8Ne+NxeNUqO7Jjh9Vu2tTqdj2l7O953bqW/Vwyb16V+/PhwMrUhoWoKc6IkSETaRSqE0KkDV9SfKAqx3Zpqe196WX3Y163bpZ/441upd3oO3eWvWXvCy9WuT8aAcfuVwghUo08TkKItNHxmC7TysNVt0LZ/ev/tgYXnO+0nJr95tfH/duex5+wkgSqbz47tp9YfRohhEgl8jgJIdIGzUZhbgKhsyPbttmWq66xvc89Z4e3brXSAwesZOlS23H/WNt5708S2p/fj9+vEEKkGnmchBBpw5c2zyw56MJo8SQJ4MjGjVb0/buqtS+2P6tEhpMQIr3I4ySESBtoybRr186KjhyxN/fvS+u+3ti/z+2HPlnsVwgh0oEMJyFE2qDtyR133OF+fqx4T8K9tJKF7T62Z4/7mf2p3YoQIl3IcBJCpBUE8fLq1rWPDx605/ftTcs+ntu314UDqaa7/fbb07IPIYQAGU5CiLRBX6rp06fb5Vdc4X4fs3OHbTh8OKX7YHv37zzag+uaa65xjUSFECJdKDlcCJGW0Nknn3ziWp/w83XXXWeff/65+9tXt221Z1u2ssIUGDg7jxxx29tVWmpdu3Z1vbZeeeUVlxxO01FaSwiRSjbu2Gc79pZkbH9N8/OsbdPqq1ynk5EjR9rAgQPtt7/9rUUJGU5CiJSyZ88e12bFd1an+efw4cPtjDPOcP9fsHmz3bh1i/29RUtrV6dOjTxNGE0LDpVYmzZtnMGEh4uWCjQnXbdunWv5UlBQkMJvJ6JuNN34hw/s4KEjGdtnvbq17dnvnJ2U8cRz8OCDD7pebjwHrVu3dgbO97//fbvgggssDGzYsMH1xONZX758uX33u9/NmAEnn7YQImXgVaIjO4MaCdr0jGNVys/dunWzSZMmuUEcY+eCzRvtub3FSSeM8/5n9xa7z3ujiUafNBBlf7zYH8fw/PPPu2MSIhXgacqk0QTsLxkPF/c7Hld6NT700EM2b948e/PNN91z8e1vf9uCxsFKNOAOHDhgrVq1sp/+9KeuyW8mkeEkhKgxhw4dsg8++MDeeuutsgGN8BzNNGPp16+fTZ061XVbJ7z2gx1Fds3WLfbSvr1l7VIqg3/nfbz/rh1F7vNsh/2yXQ/7ZN8cA8fCMfEejlGIsPOtb33LhahnzJjhngM8vn379rW77rrL5Rt6Vq9ebVdddZU1atTImjRpYjfeeKNt2rSp7N+/+tWv2tVXX33ctvFYjRw5stJ987zdc8891qFDB+fpxcv87rvvlv37/fff7zxfseAlOvnkk0/YLx4zpEV69uxZ4b74zO9+9ztXfFJYWGiZRKE6IUSN2L59u7399ttWVFTkfmf1h0FTWZK29zzddttt9vLLL7tquJlF261Z7do2KK+e9a9Xz06pU9eJZWIs0UYFRXDELdFpAqrnHnjgAeeqr1v3xGGMiYBJ4eOPP7ZPP/3UFi5c6MIXhCmaNWuW5jMiRPaeRbxLGB0VhaibNm3q/n/kyJEyo+m9995ziwq8UTfddNNxhk6y3Hnnne5Ze/rpp53R88ILL9jFF1/svF7lF1HxYDzhGcaTnIvIcBJCVBsGyQ8//NAOHz5sDRs2dOEA35+uqs9ddNFFdtlll9maNWvskUcesfXr19ukA/vdqzIYjNFpQnKAn+OB4caKl9UvOVdMKuPHj7dhw4ZZnz59qvV9hchlyPUhlN2rV68qDROMmZUrV5b1dXz88cedZ4rFBgufZFm9erU99thj7v/+2cT7hCHH33/+858nvC2Mvr/+9a8526xbhpMQImlwybNS9flDDL648DGeqmLfvn3OcILRo0e7z957770utEAVHi+MKXIbGDj5d3I2eKEInqy4JYbc9ddf74yntWvXurAdCbMjRoyw+vXrV/MMCJF7JJovuGjRIvdcxTbDZjGBR4p/q47hNG/ePLeAIjRYfqxo0aJFUtsi9J6rRhPIcBJCJAVJ1ySeFhcXO68OxgwDXaKl/3PnznWhAXKQ/MCNMUTFHa90gEF3ySWXuMEdA42V9pYtW1zVXdu2bdOyTyEyDeEwnsPFixfXeFs82+UNsZKSypPUqaatU6eOW/jw/1gICSazzVyvhFVyuBAiIciLYFB89dVXndFEQiZJnP3790/YaNq/f78tWLAgK414OUaOlWMmf4KBHgkDvhPfTYig07x5cxcC/+Mf/+ie0fLs2HFUKJYKVLy6vDx4gfl3H8ZmYeMlRTxz5sypdN/opuFx2rx5s8tjjH35xQnbJNcw1niKt81cRYaTEKJKMDIwmLygJe74a6+91lq2bJnUdvD44G3ic507d7ZswL59tRHfxRuDfEchgg5GEwYMnmCkQdA1I/z2+9//3uX3wahRo5yX+Itf/KLNnj3beWGpTkNAdvDgwe49eGPRSCL3iW2MGTPG5s+fX+l+eZ7YHtshlxCvLtv9xS9+4fSkgHA+nt5f/epXtmLFCnesb7zxRrW/K0YXL55dtsvPPg0gnchwEkLEhQEQPSRWioTUGFC9NlMykOvgB97TTz/dsgnHznfgu/Az341Jhu8qRDwVbwQpMwn7Y7+JcsoppzhjiEINqk5PPfVUl0tIQvif//znMu/rSy+95CpMyfXDkOJzzzzzTNl28Fzdd9999sMf/tDlPO3evdsZRfEgCZz3sF9kBPDukmzuF0l4uv70pz85g4nqWwwrEsirC14uXix+xo0b536+9NJLLd3UKk1Xu3IhRKDBM0TFHKtVQLgSQ4MwV3Vg9cqATqIoHp9cYdeuXW5SYcXqB3dW5hXJHIjoQBEDnhbyhmKLHtRyJXzXNFk0MgghqtRmQrQOF351G+hSIZcr3qbKNJ8w7HD1Yyh6zSdyRoSIBSNGhky0keEkhKhUmyk/P9+5/NFCqgnkNmE8YYjEqgTnCr46EP0ZBAAxGBHvk+aTEKI8ynESQpRVvPn2JBhN5CWgf1RTowmDCcPJe5sSrcDLBmg+EUZEJoFz4NvIcG6EEALkcRJCnKDNhOJ2bP+3moD8AMYTiahdunSxXIfcB9pEEFr86KOPnMin13xq165dtg9PCJFlZDgJEWHQLyJhmxegzURuT7IyA5WBuB2Cl0DFSy57m2LhODEcMZTI9dq5c6eTLOA74DWrbq6XECL4yHASIqKgfYJR4DuiUz581llnJS0zUJW3CRkCWjl07drVggYGJHpV06ZNsyVLljgDk556eJ+8GrIQIlrIcBIignz22Wf2/vvvl/WDO+ecc1Ju2ATV21QeDEmEAcn1IueJijt0rdC/QftGCBEtZDgJETFtJrwnvpcV2kyE5ho3bpyW6jySqin3D6K3qTy0juB8kQtGW4lJkyZJ80mICKKnXYiIsG3bNhea8/2q8ALRLy4d+ToYaJ9++qn7OUw5QRiBV1555XGaTyTWo7wszSchooEMJyEiALlG06dPL9NmIkcHzaJ0EettwlMTJrzmE6G7yZMnO0MUzaczzzzT+vbtm+3DE2lmy97Ntuvgroztr0m9JtYqv7XlIiNHjnTiuL/97W8tSshwEiLEYLy89957tmrVKvc72kwMdg0aNEjbPmO9TQyqYfE2lQfDCZ0rBDNXr15tU6dOtbVr17p8qHSeX5Fdo+mbk+6wkiOZa7mSVzvP/jLqkaSMJ/LwHnzwQddcd926dS7EzLP4/e9/34Xmw8D48eNd7z08vxSgsGi5//77XY+9dBPOEU0I4aq/SGLGaMJ4oWIOfaJ0T+rkT9ETiqozOqaHGc4l55RzyznmXNMsmHMvwgeepkwaTcD+kvFwoTtGCJ5cvIceesiJz7755puuA8C3v/1tCxoHDx6s8O8Ut9C8+PXXX3dNfvl+V1xxhX3yySdpPyYZTkKEUJuJjuToDu3du9dJAVxzzTWuS3q6IRTICtDnUIXV21Qezi3nmHONiCjnnjworoUQmeRb3/qWq2CdMWOGU8Fn8YI35q677nLheg9eUno0ssAhpH7jjTeWSZPAV7/6Vbv66quP2zYeq5EjR1a6bzw/99xzj/PGFhQUOCFdPLIePEJ4vmIhzBfbhsnvF48Z6QTIpFQEn/vhD39oQ4YMcU17f/7zn7v/v/LKK5ZuFKoTIkTs3r3brTT9ANirVy/nDclU1RfeJoy1KHibytOiRYsyzSfOA5pPhEnIJ0tH1aIQFTXnxruE0YHhUh4Me8Cg90YToXzC63ijbrrppuMMnWS58847XX7j008/7Ywecv/wyOL1wqhJFIpYMOYmTpyY8Gf4Tox/mSjSkOEkREhYsWKFTZkypUybKdM6Q7HeJlaVderUsaiBgcp5Z8XNtcCAJXQnzSeRCZYvX26lpaVuwVSVYYIxs3LlSteXER5//HHnmcJbjRcnWVavXm2PPfaY+78vPMH7hCHH3/EIJQpG31//+lc3jiXKww8/7ER98ZylGxlOQoRMm6lNmzZZ8XKgrE2YikGvMvd6VEC3ioRcJiiv+ZRp75+IHhhNiYCMBgaTN5qgT58+ziPFv1XHcJo3b55bPJX3NBO+wxubDLQ7SsZoGjdunI0dO9Zeeukl99ylGz3BQoRImwnNpGzoJuEm996mAQMGRNLbVB4MVzSfSFwlYRXDlmonqpqSnUiESATCYeQ3+UVUTWAMKW+I0Q2gMvD28Nxzv5d//n17okS3WVGYsTIIC37jG9+w5557zumpZYJoZG4KEULmz5/vcggwmtBmuvzyy23w4MFZScheunSpGzg5jqrCBFGCa8HqnWvDufGaT1w7IVIN+T2U4//xj3903t/y+AUWivdr1qxxLw+5Sfw7nido1aqVE3eNxS+OKoJiEDxOeFjRbot9tW3btmybLB5ijad426yKp556ym677Tb3/8suu8wyhQwnIQKozUTeAOE5PD0nnXSS0xNKp6BlPDgGXwKMt0mhqBPh2nCNuFacL64d15BrKUQqwWjCgEGklfy6ZcuWufDb73//e9ceCPDMEA774he/6IoYqMC79dZbnQYZiy8g3E9lKLlPbGPMmDFxDf4ePXq47bEdNJbIn2K7v/jFL5yeFFCRt2XLFvvVr37lcjI51jfeeKNa35PwHPv69a9/7ar3MMh47dy509KNDCchAgRVWmgzkYCJO3z48OFuhZlNwUUGVapZGjZs6FayomK4RlwrrhnXjmvItZTmU3BAxRtBykzC/thvolCEgDGErtHdd9/tpDLQOyKkj2AkEM4jH6hZs2aucAFDis8988wzZdvhXr3vvvvKSv55xjFU4kESOO9hv+Q5IitAsjnCu8D48Kc//ckZTCyyMKxIIK8OjzzySFk1YLt27cpe3/ve9yzd1CpNNJtMCJE18FL4/mhAEmcu9EfjuJ599lnbtWuXaznSv3//rB5PUHPTqELMVphVVAwiriwKyBtiUeBRy5XwXdNkkU9diByHlZ6vzvKrNlzuuRASo/wZowlvis+NEMlrPmEQ43kicVyaT7kNRowMmWij5Y0QOQyGCXkKGE2U5+JlOuecc3LCaMJZ7XOb8DTlwjEFUfOJa8q15Rpzrcn9EELkLhrphMhBKNHFG4E2ElCVQrKmL+vNBZjgScTE24Rwnqge5JZ4zScEM/k/zYLJhZIxKkTuoadSiBxj69atbvLEKCGJkzLfbGgzVeVtIgEVqM7Jy8tswmzYwCCmQSnnlBcGM0YUxnLLli2zfXhCiBhkOAmRQ6C++9FHH7mka0TgmDipFMk1PvvsM5fYXL9+fXmbUgSGMQniSBdMnjzZnd8XX3zRlVpjnIrsoEbN4eFIiq5l7ixhhYh4tQe6Ph9++KF7uOkWTmfzXDSaynubkmmNIKoGw4lrzz3AvcA9Ic2nzOPv64qEJEUw8deypmOW5AiEyAFtJjwMe/fudfo+VMzlcoUa3iZ6rzH43HLLLTKc0ghqzhhOCBqiPI42Dw2ERWYg12z79u0uxxAPcC6Fy0XisADBaEIgEwmXjh07Wk2Q4SREjmgzIUZHOXq2tZniwXBB5ReTCXlXXmVYpA/ONTlvRUVF7ndpPmX2fmdhwzUQwad58+Zu4UHuaE2Q4SREFkD76J133inTZsLDhIBkrldRff755/bWW2+5ZHC8TeQ4ifSDQjKeJ1pnAFV45L81aZK4orSoPnj8Dh48mO3DEDUAz3iqmo/LcBIiC9pMU6ZMcZIDPMz0h+rSpYsFAXpQUfVHpR9tGERmof/Xe++95yZxjFc0vWiiKoTIHLm9vBUiRGAoTZ061ZYuXZqz2kzxWLVqlTOamLBV5ZUdMLDpMI+3knwN/u81nyQJIURmkMdJiCxoM5EfhNcmSHkqL7zwgutsTo4NnddFdvPjUG2nupEhvLCw0OXHSfNJiPQjw0mINMLjhTYTXcCZ7PAu4WXC2xQkVq9e7UriycEitwm1cJF9NmzY4LxOVAxhhKP5dOqpp9Y4+VUIUTkynIRIozbTu+++a2vWrHG/o8tDPlMQE6oRYiSRnZ50JLGL3OHAgQMu74nEfejUqZONHDmyRt3fhRCVI8NJiDRA3gnaTBhPVHKcddZZ1rt3bwvqd3n99dedt+nmm2/WhBwAzSeuEZpPNdWrEUKciAwnIVII4biPP/7YPv300zLdEHJP0GgKKi+99JLrm0ZCOOKcIjiaTwMGDHDVj0HKpRMi15HhJEQKtZmYtEigDpI2UzwQ/3vttdec1wxvE+rVIvc1n6ZPn+48UEAVHsa7NJ+ESA0ynIRIAcuWLbMPPvjASQ6Qw0QuEzlNQeeVV15xCcgkHBNuFMGBnCdyn8iBkuaTEKkjuEthIXIADCUMJgwnoCkvuSVB0WaKx/r1653RRJiHkI8IFhjuyBPEaj5RqHD22WdL80mIGiCPkxDVhJAcoTlCdJR/Dxo0yGkzhaUU/NVXX3XGEyFHJlsRTBji0XyaNWuW+5mQHaE7QnhCiOSR4SRERLWZ4oGH4uWXX3bepi984Quh8KBFHe912rNnj7uuiJiS8B8WQ1+ITCHDSYgk2Lt3r9NmokTft8AYMWJEILWZ4kFCOInhSCiQGyPCAflO77//vut5B8gVoPmkpH8hEkeGkxAJQn4IRhPaTFTKkSzdq1cvCxtIDyBBgFfipptussaNG2f7kESKWbRokU2bNk2aT0JUAxlOQlQB4TjCcnPnzg2NNlM8ELvEo4ZRiDdNhBO0nsjRQ/sJUIUnfCfNJyHiI8NJiDjQlJfJhSa90LdvX6fNhK5RGKGtCu1VyHvB2yTtn/BrPn300Ue2YMEC9ztVeCwKaBoshKgYGU5CVMLSpUud1ACTS5i0meJBI18a+vbo0cPlvojoaT4RhqaKkntACHEi0nESohwHDx50BtPy5cvd7+3bt3c5IAUFBRZ2eQWMJrxNp59+erYPR2QQFgTIE1B1h3YXuXwUBwwfPtzq1auX7cMTIqeQx0mIcqEqJg+vzTR48GAbOHBgJEq2J0yYYKtWrbLu3bs7Q1FED2k+CVE1MpyEODZhkPxNg16vzcSE0aZNG4sC5HCNHz/eGYg33HCDNW3aNNuHJHJI84lGwSSPR2EBIURVyHASkQdtpsmTJ7vQBJxyyimumixKIYq33nrL5bnQywwxTyEIWaP59Nlnn7nfpfkkxFFkOIlIQ04P+Rz79+8PtTZTPChHf/75593PeJvCKrMgqsfixYud5hNFEg0aNHBh3E6dOmX7sITIGjKcRCRB+A9tJlqnQIsWLVxoLoohqkmTJjmvAp62UaNGZftwRA6yY8cOd594zSdataD5FFZZDiHiIcNJWNS1mU499VQ744wzIjkJIIL43HPPuZ+vv/56J+4pRGWLDTSf5s+f736X5pOIKjKcRGS1mQg7oM100kknWVTBgFyxYoXruTd69OhsH44IAFReovnkw9vSfBJRQ4aTiARR1WaqKvzy7LPPup+vu+46F64UIhGKi4tdQcX69evd7xQVYEBFqaBCRBcZTiIS2kx4Vnbv3u3KqSmtHjBgQORLqyk3x5BE/PDCCy/M9uGIgMHUMWfOHJs5c6b7mWbQhO5at26d7UMTIq3IcBKhhVv7008/dQM72kwa2I/P88LbxDm69tprXb6KENVh06ZNbmHiNZ8QjdXCRIQZGU4iEtpMXbt2tXPOOUehhGMgwUC+F/ldF110UbYPR4QgFD5lyhSXLwcdOnRwoXBpPokwIsNJhF6biX5bPXv2zPZh5Qy0k3nmmWect+maa65ROw2RMpYsWWJTp04tK75AMLNz587ZPiwhUooMJxHacukoazPFg4ooJjhEDC+55JJsH44IGRQdELrbtm2bRV3uQ4QTGU4ilIO1BPoqhgR5vE3kfF199dXK9xJpQYsYEWZkOInQtYRQeKBy6D3G+aLv2KWXXprtwxEhR2FzEUZkOInAooTU5KDq6emnn3bepiuvvNLatm2b7UMSESnUQPrCaz6pUEMEHRlOIrAl0AzGhJ5UAp0YCIAuXLjQGZiXXXZZtg9HRFAa5OOPP5bmkwg8MpxEoJDoXvWVnp966innbbriiiusXbt22T4kEUHKi9Gy4Bk4cKAWPCJQyHASgUFtHqoPJeILFixwBhOGkxDZQu2PRNCR4SQCgRqL1izHBG8TlU6XX365m6iEyLWG2yrqEEFBhpMIVFkzrUEIzRUWFmb70AIDFYecP5LBSQoXIpdkRMhV3Lp1q/tdmk8iCMhwEjk9qE6aNMm2b9/ufu/fv79r0KtBtXreJuQHkCEQIpfg3pwxY4bNmzfP/d68eXMbNWqUNJ9EziLDSQRCm4kcCJSuRXJMnz7d5s6da23atLGrrroq24cjRMKaT2eddZb16tUr24clxAnIcBI5lziKSONnn33mfsdDQu6DtJmSZ9++fc7bhPFJaxUZniJozblPOeUUGzFihApARE4hw0nklDYTpcoINaLNRFiO8JxKlasHuWFo59DEl2a+QgQBpiS8pGg+IZ/RqFEjl9eI11SIXECGk8g63IKffPKJzZo1y/3cpEkTN1Ay4YvqQbhj3Lhxztt08cUXq1pJBFLzicTxXbt2SfNJ5BQynETWtZkYHDds2OB+lzZTaiDZFqFQqhCvvfbabB+OENVCmk8iF5HhJLLG559/7rSZDhw4YHl5ec5g6t69e7YPK/BwPvE2lZSU2IUXXmgnn3xytg9JiJRpPtWvX9/OPfdc3dcia8hwEhmHwY/8G5SsQdpMqYV2NLNnz7YWLVrYddddl+3DESIl7Ny50+VAes2nvn372plnnil5EpFxZDiJjFJUVOQGv1htpqFDh7pkcJEabxOVdIQ4Ro8ebV26dMn2IQmRMkgWJwxN8rjXfGLR1axZs2wfmogQMpxExli0aJF9+OGHzuPUsGFDl6sgQcbUQoI9LyYUvE1KpBVhZM2aNU7zCckNNJ+GDRtmvXv3zvZhiYggw0lkxAuCNtPKlSvd7xhLGE0YTyJ14GUit4n/o7yMBo4QYdZ8wnhau3at+537/ZxzznE5UEKkExlOIq1s3LjRVc15bSbCcv369ZMnJA2Q10R+E2GL66+/XudYhB6mL1q1EL7zmk/nn3++68soRLqQ4STSgrSZMgsVdHib8O4xcSDrIERU2LJli8ud9JpPgwYNstNOO02LB5EWZDiJlIN3ibYJXpupR48eNnz4cCc5INIDmk2summMesMNN2jCEJFcPCBZsGzZMvd7u3btXEoAXighUokMJ5FSpM2UnQmDSjrUwpkodL5FlMFwwoDiuZDmk0gHMpxESqBSbvr06bZw4UL3OyE5QnOE6ER6oR8dulic6xtvvFHSDiLyELIjdEcID/r06eM0n6jAE6KmyHASNQZNJgYpNJpgwIABrkGvJvDMGKzkNuFtGjlypAuLCiGOaj7RKJiFBSDRQf4f/xeiJshwEjUCDxPaTIcPH5Y2UxZACBBPn7xNQlQMcgXkXKL5hMo4mk94oISoLjKcRLUgh4lcJnKaoFOnTs7jIW2mzHqbyG1iQhgxYoT16tUr24ckRE7CM4LmE8KZgKI+z4w0n0R1kOEkkoZqObSZiouLnYfjjDPOsFNPPVWVXBlm/vz5Nm3aNFc19IUvfEHeJiGS0HwqKChwoTuq74RIBhlOImEYbBBZRJ+J24amvCSA06RXZBZCo3ibUE9GLVntJoRIDJoEk5NJ02AWe6effrrTfNLCQySKDCeRsDYTXiaUwEHaTNllwYIFNnXqVHmbhKgGSBXw/CxdutT9jtI43idpPolEkOEkqoQec+Qz0QMNQwkPh5Sps+ttevrpp12oFJ0sJboKUT2WL19uU6ZMcYZUvXr1nOYT+U9CxEOGk4ibfEzF3KJFi9zvrVu3dqsyaTNlv5IRgT9yNPA2USkkhKi+5hPe9M2bN7vfCXtTeSfNJ1EZMpxEQtpMAwcOtMGDBysklAN5ZnibCJ2eddZZLilfCFHz54oG2bQuAhplk78pzSdRETKcRIX5M2gDERLKz8932kwdOnTI9mEJM1u8eLG9//777rrcfPPN8jYJkWLNJ2QLKLqQ5pOoDBlOogzUp5mUvTZT586dnTZTgwYNsn1o4tiq+JlnnrHdu3e7Ab1fv37ZPiQhQqn5RE7n6tWr3e/0uUPzSeOg8MhwEhVqM9HXSWGg3GLJkiVuQEdkFG+TcjCESB9oPtEDUppPojwynCKO12biBdJmyt3r9Oyzz7pEVoza/v37Z/uQhIic5hN6T+g+Kdcz2shwijAkGDMobNq0yf3es2dPl3AsbabcA70Zci8IF9xyyy3yNgmRIZAqQKEfjy+0adPGLS6l+RRdZDhFlM8++8zlM6HNhH4J2kxdu3bN9mGJCuARxdvEqpf2NgMGDMj2IQkRSc0nZED8mEne0ymnnJLtwxJZQIZTBLWZWD1RneW1mVg9NW7cONuHJuIM2OSf4W0it0keQSFyQ/OJxtp46eUBjhYynCLEtm3bXGhux44d7nfi9YMGDVK8Pofh8XzuuefcNRsyZIi7ZkKI3NF8atq0qY0aNUqaTxFChlNEtZmoEGnfvn22D0tUwYoVK5yxW79+fedtIkQghMg+69ats8mTJ5dpPlG00bdv32wflsgAMpwioM1ECfuqVavc79JmCg48ms8//7xTb0e1nWoeIURuja8UbXjNp5NOOsn1u9P4Gm5kOIWY9evXu3g8KyJpMwUzgX/SpEnOy0QlnbxNQuQm8+fPdx59wnjy6IcfGU4hhId31qxZ9sknn5TF4EkAb9GiRbYPTSQIj+U///lP1zOQPDReQojcRTmk0UGGU8igHQcPr6o+gg1tb9566y1XQYe3iRwnIUSwqpbRfML7pKrlcCHDKWSJxFOmTJHOSAjA28QKllUr1XRCiODq5GksDhcynEKyypk6depxyrZa5QQXEvknTJjgvE1U0inRVIjgIe9/eJHhFLK4OpVX6qUUbMaPH+96ZA0cONCGDh2a7cMRQlQT5ZuGExlOAUaVHOGDsuY333zTrUrJbZK3SYjgowrncCHDKYBIOyS8vPjii861Tz86+tIJIcKBNPXCgwyngCG12vCydu1ae/311523idymhg0bZvuQhBApRl0cgo8Mp4Cg/kjh56WXXrJNmzZZv379bNiwYdk+HCFEmkCfDXFbn5tKPiPdAZSbGgxkOAWwI3fv3r3dxKrqjHB5El977TXnRcTbxEpUCBEdzafWrVu7xHFVQ+c+MpxynOXLlzttppKSEumBhJiXX37ZNm7c6BJGKVkWQkRT8+mcc86xrl27ZvuwRBzksshRMJRYjXhtprZt27pYeKNGjbJ9aCINFTcYTbjpSQoXQkQHFsJ4m4gqMA4gL0O+4/DhwxVVyFHkccpB0PDh4dm5c6fVqlXLqUdLmym8vPrqq854IsmfwVIIEc081tmzZ7sXFBYWutBdy5Yts31oohwynHKMefPm2UcffeQeooKCAudlateuXbYPS6SJDRs22CuvvOKM4i984QvyKAoRcVhEUTldXFzsxgVkSSgYEbmDDKccYd++fU7jw2sznXzyyS6fSRof4YaEcBLDSfgnt0EIIdB8Iu+JZt8gzafcQoZTDkA8G0FLr81ExVyfPn2yfVgizSA9gASBvE1CiIpYuHChffjhh2WaT+edd5516NAh24cVeWQ4ZRHCcR9//LF9+umn7vdmzZq5mLa0maIBYpcYzTT/xLsohBAVaT6R81pUVOR+l+ZT9pHhlCPaTHiYUAFXFUU04LrTXoXk/5tuusmaNGmS7UMSQuSw5hOep0WLFrnfqcIj/1XjRnaQ4ZRlbab69es7b0OXLl2yfVgig9DIl3y2nj17uj6DQghRFStXrnS5sGg+5eXlubzIbt26ZfuwIofcGxkEQ2nq1Km2dOlS97u0maLJli1bnNHkpSaEECIRWGC3atWqTPOJ/3vNJwwpkRnkccqSNhO6TEyailNHjwkTJrgO6d27d3fJnkIIkWx+7CeffOI0n5jCpfmUWWQ4pRlOL9pMM2bMcDc73iW8THibRLi8iVxjGjHPmjXLrQJ9C4WOHTvaoEGDXEInKsHoNmE833DDDa5ZsxCZuv+GDh0qz0SI8F6nPXv2uEU41xfNJ8YXkT5kOKVZmwmZgTVr1pS5WclnIq9JhAM0mB599FF75JFHnJhlVVAxSS+6L33pSy4pXIhM3n+I6d5xxx12++23q6w9JBw4cMDlPXnNp06dOjnNp4YNG2b70EKLDKc0wYoP9VeMJ7SZmCwRORThqXJ56KGH7P7773cre6jbsIk16tTbCtr1sAYt2lvtuvXsyKGDtn/beivesNT2rFlkh/btcu/FEzB27Fi75557VEkpUnL/5TXOs+a9mlnTroVW0L7AaufVtiMlR6x4fbHtWLHTti8uspLdJe69uv/CrfmE0UQaAN5GkXpkOKUYwnG4zOfOnVvmYSD2jEaTCE9V5C233OI0uKBRpz7WduhV1qzXWVa7TuVhkCOHS6xo8TTbOOMl27NmofvbkCFDbNy4caqMEdW+/5r1amZdLjvJ2p3R1hlLlYERteGjjbbytVVWtPioJpDuv/BpPhG64/9A03CusXJpU4sMpxRrM5EATtUUSJspfGAQjx492ukw1WnQyE666JvWsv8FSeUU8MhtnTvJVr35Fzt8oNjatGljEydOVD8qkdT9l1eQZ32/3ts6juyQ9P23dvI6m/+3hXZo7yHdfyH0Rk6fPt15oIAqPBbv0nxKHTKcUsSyZcvsgw8+KNNmQpuHfnMiXCt9yn6ZtPLbdrWeXxhr9ZpUv4rl4K6ttuTpMbZ34wonaIdUhVb+IpH7r0mXJjb0J4OtYYvq9y7bt22/zXhwpu1auUv3Xwgh54ncJ3KgKAg4++yzXSWvqDkynGoIhhIGE4aTT74ktixtpvCt4ughSNUSRlPvW39pdRvU/Bof2r/HFj3+H854wqU+bdo0eShF3PsPo+msn53hPE41paS4xKbd95EznnT/hQ+q7ci19YUDGE4YUKqsrBkKfNYAQnL//Oc/ndGEq5xy38svv1xGUwh5+OGH3aRVp36B8zSlwmgCtsP22C45K+xHiMruv7r5dZ2nKRVGE7Adtsd2df+FD+Yi5iTmJuYo5irmLJ9OIqqHPE7VgFNGrgEDjbSZolHyjf4S1UunXHW3tRowusL3XTawvd13TcV5Iu8t2mT/8fScSvexZc5b9tnL/+2qnWir0L59+5QdvwjP/TfwO/2t0/nxK6VOa3263dDjRuva9GjYbeXOz+z5pc/ZzE1Hk8krYs07a23OH+bq/gsx0nxKHfI4JcnevXvtjTfesI8++sgZTQxo1113nYymEINODpMW1XMt+49Kyz5aDhhtjTr2cfthf0KUv/+onut4XnztpXM7jrQxw8baqS37WcO6Dd2rT4u+9tMz/9NGdKy8JyLbZfu6/8ILcxRzFXqCzF0kkDOXMaeJ5JDHKQkQskTQEm0m8gDQZurVq1e2D0ukOYftpJNOcjkC3a77sbXoW/nk4z1OG4r22TW/fT/pfW2b/64tH/9/3GqfxE7lIYjY++/0uwdah7Mr9wTVrlXb/n7xE9a0flPbtm+b/XTqvba3pNjuG3a/dWvazXYf3G23TfiKHTx8oMLPr5uy3mb/9xzdfxFg8eLFLp+N3DlpPiWPPE4JgKCYt84xmtBmuuaaa2Q0RQA0uZi06uYXOp2mdNKs93Anorl+/Xq3XyH8/VevST2n0xSPk5qc7Iwm97mN023dnrVWdKDIJq9+2/2tcb3GNqTNkEo/3+7Mtk5EU/df+GHuYg5jLmNOe/31190chydKVI0MpyqgKe9LL71UJmjZt29fd8NJ0DIakJALjTr2iituGUvLxvVtwn+cZ1PuG23Pfudsu/28bpZXp+o8ArbfqONRdXn6jQnh779mPZvGFbeEerWrvj9PKTyl0n9j+817Hh3XdP+FH+awq6++2s1pwBz34osvujlPxEeGUxyWLl3qKhC2bt3qtJkuuugip6NCCxURDfwEQhuVRMmrW9sK8+u5/3duWWBfH9nVfnXz6Ql9tqD9UZ0VTVwi9j6gjUpVrNm9xkqOHG2pMrTtmdahUQdrWr+Zndf5grL3NK4XXwSxsNvR/ej+iwaknDCnXXjhhW6OY65jzmPuE5UjwY4KIEESbSYE54CYPzHggoKCbB+ayELPQaD3XFWs2bbX/uvF+Tbzs21WVHzQ+nYstJ9dP8BaNK5vw7q3tNNPbmazPz/a6qIyGrQ4mvzrG0OLaOPvP3rPVcXeQ3vtpeUv2vU9brAWDVvYn0c9csJ7DpceiruNRsf2o/svWiDWjMI4VXeEhsnl5d5D84lKS3E88jiVA1Xe8ePHO6OJMk1E4S677DIZTRHFN1ClYW9VzF2zw179ZJ1t3LnfDhw64oykZz5aVfbvvTtU7TXw4UC/XxFtyu6/KsJ0nscX/t3+d/5fbf2edVZyuMTW7VnnjCnPln1b436+dt2j+0FtWkQL5rhYzSfmQOZC5kRxPPI4xdFmor8PfZxEdPGrrSOHqjZkkEMpX6Ma+3si9as0Ao7dr4g2ZfdfSeJJuy8uf8G9PJd0uazs5/lb58X97JFDR/ezbds2e/LJJ11/s6ZNm7r/FxYWuhc/S108nGAwnX766dahQwfXd5X+qy+//LJzIPTv31+aT8fQ3X9MmwlZeoTmAG2mESNGaPISZSW6+7etr/K9D918ms1Ysc3eW7zZhepO7VhoXzjzpLJ/n7s6fpju6H6O3oOdOnWq0XGLcN1/xeuLE3p//5b9Dfv8s50r3O+D2gy2L/e51f28aNsiW1q0JO7n9xzbD4nDjIu8EE4sDwvLWGMq1qhCXFEEGxwG119/vb3//vv22WefOd1C5seRI0dafn6+RZ3IG06rV6928dz9+/dLm0mcwKBBg+yJJ56w4g1VJ0u2btLA7rq0t3uVZ8Lc9TZ/bdXVKsXrl5XtVwh//+1YkVilU9+Wp9rNvb54wt/Rdfrt7P+u8vM7lx/dzw033OCqh6mw8i+8Dzt27HDhQ9SneSFdEAseCYyq8gYVL/4uoyo44DgYNWpUmeYTOU/PP/+8y/eN+sKubpS1mdAqmTfvqOu6RYsWLjSHW1oID/F+2LNmkQujxZMkeHTychvdr531bl9orRrXt1Irtc+3FNurc9bZ+I+rTrZl+3vWLnI/y3ASsfff9sVFLlxXVa7T0qKlzrPUoXEHpxpetL/IZm782J5Z8pTTdIoH29++5Oh7zjjjDJcszKs8LDJjjalY4wrBzt27d7uXT2z3YDQ1btz4BA+VN6oUBspNcCSgOj5p0iTbvn270zOkVQstW6JaYR5J5XBWTVQPUHoJp556qhsoonoTiNQoh9cUKYeLmiiH15RUKIcT2itvTHkDC5XqymDs9UZU+RCgCnNyx9lAyG7+/Pnu95YtWzpnA9coakTO47RkyRKbOnWqe4gbNGjgYradO3fO9mGJHIXJ44477rCxY8faxhkvWfM+I9KyMmb9snHGy+5n9iejSZS//1a+tsraD2+Xtvtv5euranz/kf/Cq3zvTraPUVXeoPJGFZNyUVGRe5WHFIqK8ql40S5EZAaMW1JZOnToYO+9916Z5hOSBT16JK5zFwYi43EiLj9lyhRbseJo0iSrqvPPP1+JbiKp7vSnXHW3tRowOuX72DLnLfvs5f9Wd3pR4f1HY1a8TwO/0986nZ/6nmJr3llrc/4wNyv3H1MQ+VIVGVWE/OJNURxvZUYVgo4iPRQXF7uCKp/j1q1bt0hpPkXC44QOBaWVPIRem2nAgAGKqYuEYIXFiv/HP/6xrXrzL1bY5TSr16RlyrZ/cNdWWzXhf9zPX/rSl1y+nRBeT2nhwoVOX+eFF16w+X9baC0HtLSGLRqkbB/7tu132wXu80wb7YzD5D7xKt9oFmkYxu3yHipvVLGYwfPh0y5iwXAqn0/lpRWiMsGni4KCAqdvOGfOHNcWCM2nTZs2udBd69atLeyE2uPEV/v000+dNhM/82BG5cKK1EJoFzc191J+267W+9ZfWt0GjWq+3f17bNHj/2F7N65wXoV///d/d4M83tDy4Q4RLZABIBcTbwzj1x/+8AdbsGCBNenSxM762RmWV1DzcG5JcYlNu+8j27Vyl0v2JY0hKBpNhPe8EVU+rwqPSDwI8ZU3pryBFZTvn4uOidq1a7uChrA7JkJrOBFPZ9DxrsSuXbvaOeeco5WGqDasqujrxECB8dTzC2Nr5HnC07Tk6THOaEI3hWbShEmYBBh0qKw77bTTQj0AiRNhSP7kk09cvzh+ZlJnwYdB4O8/jKehPxlcI88TnqYZD850RhP3H22mCLmEZaFTUZI6r3379sX9LOkb5Y0pb2SpgKhiyqfC4KVHtiCsqTBZNZyI2SMJgKuPQYLyVS4Axg0uWyYOrFdWQskkK5bXZmKw6dmzZ1q/i4gGyFegbcLkVad+gZ108TetZf9RSRk3PHJbP53ownOHDxS7SWvixImuxJdnggls2bKjek7t2rVzAxDl2iL84F0id4QqOujevbvLHfHjX+z9Vze/rp369T7W8bwOSd9/ayevc+G5Q3sPHXf/RQHmmMqMqqpazVSmUUU0QxpVlpLiq3TZBYE3nEh2fPTRR+2RRx4pGyDiweRBpcftt9/uLNlEyyWlzSTS5Xm65ZZbXNgOGnXsY22HXmnNeg+Pq/OETlPRoqmuem7P2qM5JeTbjRs37oSVPoYTBhSDCLka5557rmvEKcILEgBUKzF5MyFgMGE4VXX/NevVzLpcepK1O7NtXJ0ndJo2TN/oqueKFhfFvf+iCue+ssq/eP0jfZ5WRUrq/D1KXuMdO3a40B1te5KR+0mXXRB4wwkr9KGHHrL777+/7Cas27CJNerU2wra9XAd6GmmSl8wWlyg1ozw4KF9u9x7sThJXrznnntOiEOXv1hRF+gS6b+XH374YRszZszx93LH3lbQvrs1aNHBGVEYS7RRQREcccvYe/mBBx6wu+++u9KcCgZs7mmf+NqnTx8788wzlYMRwntp+vTpLgkcEJ1kwcekm8z9l9c4z5r3bGaF3QqtUfsC17CX3nO0UUERHHHLkt0lCd9/4ngI8VWUpM4rnkYVnqjyvf5iNarCaFQdTsKJkU67IPCG0wmr9E6s0q+yZr3OqnqVvnia09DZs6biVbqXhJc2k8g05ND5VVL59hMVQQ+w733ve26VlEj1ElVFuK1pQA3Nmzd3ieP8XwQflJgxjr1+EUm1jG+Jhn24537wgx/YW2+95RaPVcE951fpkrxIbU4t5798CNBrVFUGC/uKRD95hSE/aHUVaTPptAsCbzgx6I8ePfpoXkiDRnbSReSFXJB8XsjcSa4c3OeFvP76627AiUpCmshdfFyemDyvNWvWlMXl6evEhMj9jwo0A0WyarvE+cl9YdXLYDts2DDngRLBBQ/Thx9+6CZWqrwYu8qX41cFk/MzzzzjDGwmJHKgKrr/yAvhlc28kCjCvEWFX2UaVVy3yuA6VaZRhYMgSEbl5MmTXSgutlALh0c67IJM5Oul3XBKZyUSNxXl25RtR6EEUgQbDH0MICavgQMHJv15jCYGIN8DDPmCESNGSOgvgHk05DKR0wQYNnjJq6OCjY4OBjsG16WXXpqGoxXpAqOpIuFPvFSJCH9WZFDxysXK8dJy0kAYkz//+c9dGkKq7QLkhkhQT6fnKa2GE6EzVsZkx6dL+wZFZ8og5XYWuc6iRYvcvUoOC53nqwOPK14FJksGXnIkCN2RKClyH5JekUlh4iAchxHN6ri6C77x48e7yQcDmmasIhzghYwV/sSY8qFAjK144I2qKEmd/2fb27h582YXVv7pT39qq1atSptdQNiO9J105TylNZOK5EWMJsq2sShTcXKA7bC9uX/+N/vss8/s8ccftx/96Ecp2bYQ6YKqOCrltmzZ4ga/6kgMMMH279/fLRToVs5A+uqrr9rpp5/uNJ9UEp2bYOTOnj3b6TNh/DKJkSxLo9TqwsSK0cQ9oYrLcEE4nkTqypKpee5jjSlvYBEWI5+IF0re5SGNpaIkdX7ORGJ169atncHEK512AZ4t7I902QVp8zgl2t+rY/N8+/LZXaxfp6Z2cssCq1376MprxM8m2sFDlcd/Qf29RNB45ZVXnNeB6jgMoJrmVeGSXrp0qfudkDXeJ2k+5RYYyXiZUAIHGqKSvlDT1T+5o1TjMe7RkkUIxoSKlNR5YUzFg3Gjopwq/paqBdm6avT9PLlVgT3xzbMsr+7RY/jlKwvshZlH0xWyZRekzcSk0oiTQ5Y8AoGVcUrrRnbVoOo1rWw5YLRtnv2m08Rhf5TmCpHLkJeE4cQDXVPDiYmX3BjyWwgBMjE///zzTvOJ/Yjsw3Umn4mxkOtFUmyqci/YNuhaCw/3GF7MijyZ3IMVJanz4t8w8HmVrw7Go1mZ8GejRo2SMqoStQti+ffL+pQZTbliF9RNl9VLeTZQWhgvfr9l1377+/srbN6anfa1c0+xvh0TF6tkuwgPLl+70O3v3nvvzXoMV4h4MMkRe8eNjls9FRWgTMS4wClrJwxIVUnv3r1dfqE0erID4RQq5shrA64P3sB42kzJQI6UD8XIcBKJgAeG/Epe5cEbVVGSOqFA7mXCwrx8YYoHo6m88Kf3WmFUxc79ydgFnov6tbNBXZrb3gOHLL9+3ZyxC9IyqpK4yqq6bn6h02OIx6L1u9wLvnhW8nF61JoRy8JKZr+4wIXIVUjmpmSWSQ+PQd++fVOyXQarq666yuUUUmnFhI0HijwaaT5lV5uJCkqqflOZf+Yr8riXJL8iagoJ5by4n8rDAq+iJPWdO3e6JHb/bxXlaXkjiv8jG5SoXQD59evYdy7qafsPHrZx0z63b5zXLWfsgrQYTgze0Khjr7giVqmA7aPWvGPZR06/RIaTyHXwEKTacAJfpUVMH9kCJu4XXnhBmk8ZZMGCBS7viAkFg8aHUlONwnQiU3Af8ypfuVt6TFagonwqL/zJGOQXECwmkrEL/u387taycX37n7eX2eZd8fOzMm0XpMVw4kABufRMQIsLf4KEyHWY7JhcWX3hIk+1mB0T9fXXX+8UexFCpJIPFzsl60ESzgsSXMf333+/zBNE5wJyzaqjzZSInpfv5SXDSWSLWsdyn3iVT8DGqCqvUYVQa6J2Qbc2je26IZ1s9dZie3LqSruwX7ucsgvSYjj5OCg9ZjIBfcGASUKIXIecAJI3KSVnok2H/g4T9sUXX+x6RdEziv2Q/yTNp9RDOAAPn9dmoqFpOpWLuZZMTNxD3EtC5Bq1jjU95uU9rr6APxG74IeX97a6dWrbw68vspLDpTlnF6RF9MU36qMxXybwbr943auFyCW8pwAdsnQOXkzgV199tcszYGJHDoFQerxWDyIxOIecS3S0OLecY851uts9+DAdZd1CBIWDCdoFQ05pbv07N7N5a3ZYUfFB6962sbUp/JfntnWTBta1daOs2gVp8Th5yXe6GWcCGv7F7leIXIdJD5E2vBW04Ehn2xQ8E9dee62r5luyZIkTYkRPhcRxaT5VD8IQ5Gz4yjb6xJ111llpr+rlXvHl4grTiSBRL0G7oGG9o2YJ2o5P/H8nJpHfdm5Xu35oZxv9f97Jml2QFo+Td83t31Z1t/g6tWtZYX6ee9Wt86/yxMKGR/9WP6/qQ9y/bV1ZzychggDeCard8FqgoptumNDJuSFUx89M+Gg+pdPjFVY4Z5w7ziGDMueUc5sJKRTuFe4Z7p1kG0ULkU06JmEXpIJ02gVp8TjRhfuJJ56w4g1HFY3jMaBzU/vTbUNP+Psr94x0///r5OX213dXxN1G8fplZfsVIijgMaB0ndALatKZwGs+oWRN3yjatpBjhbdEmk/xQc8Grx1d3YHziNcuk3lGqqYTQWVQgnbB+4s325ljJhz3t8sGtrf7rumXkHJ4JuyCtHic0CyBPWsWlbnL0gXb37P2qMicDCcRJPzkRzEF4nCZAk2VK6+80ukLAYYAzWIx4kTFbNu2zZ0jbzTRF5BzmEmjiVwNn+gqw0kEjcEhsgvS0quOSeCkk05yJbPdrvuxteh7rqWLbfPfteXj/48rh6TaRMrhIkhQokupLp6Lrl27Znz/5DpREYbIHYJ19NBLpbZUGPCViV6b6bzzzrMOHY5W7GSS5cuXO08hIbqbbrop4/sXoiaUhMguSIvHiYO844473M8bZ7xUVoaYatjuxhkvu5/Zn4wmETS858CHYDINBgCaT+gOYRjQNHjChAlVNgSNApwDzgXhOc4N54hzlQ2jCRSmE0EmL0R2QVoMJ7j99ttd4uSeNQtt69xJadnH1k8nukZ+7If9CRE0fEn56tWrXQ5NNkAUE80n8pzQISIBmeTn8s0+owTfnXPAueCccG44R9kSEOXe8GE6yRCIoHJ7SOyCtBlOrMrGjh3rfl715l/s4K6tKd0+21s14X/cz+ynvHKpEEHAixgyMZZvoJlpTj31VLvmmmusadOmLnSHPhGSCVHSfOK78p357pwDzgXnhHOTTTCauEe8eKoQQaRDSOyCtOQ4eXjQWakxEOW37Wq9b/2l1W1Qc92YQ/v32KLH/8P2blzhenMRXlBFkAgqtF+ZO3euq3ijtD3Xqsdo/MlxhV2lmu7vaDNRbQi5VG1IbhM5Tv3793d5aEIElUMhsAvS5nECDnrcuHGubJcvw5eqqYXJ5/3JoTro/vvvz4mBTYjq4nNWCNeRS5NteJ7oa0fCOu5u9Ir++c9/hlrzic7tfEeMJr7zqFGj3DnIhbGFe8JrfSm/SQSdumm2C1jo/eMf/0jrs5tWwwlYRaMV40/S3D//m235dGLSiWG8f8uct9zn2Q4CcN///vedC5uqFyGCCs8G1VqUm1PllitQ5Xfddde54+PYeI5pZJutXKx0wHd57733nKeJ78h35TvnUh4R9wQVSdwjHJ8QQadbmuwCjKaJEye67aeTtIbqYsHNfMsttzj3HDTq2MfaDr3SmvUeXtZTpjI9hqJFU12WPAlfMGTIEGexojszZ84c9zcaaw4YMCATX0WIlINbecGCBa51ByrUuZb3Q4fxTz75xP1O3g/eqBYtWljQtZkwmHbs2FGmzYTmC8ngucS7775rS5cudXlWhDiECAvL02AXpNtoyqjh5Fd3Dz/8sI0ZM6as8V7dhk2sUcfeVtC+u+tmzMnipCCXjvInIlaH9u1y78WF/sADD9jdd99d5oajySa9t/yJY/ATIohVXCQk07Puy1/+cs5N3v4YybUhaZrjI9cm20nT1QUvNbllGIV4csjhysUCE44PtWV61F1xxRXWrl27bB+SEDlvF4TKcIodgB999FF75JFHEip5Jiz33e9+15UWVjS4YThhQMHpp59eplAqRFDgMWSCRDvosssuy5pWUFVwfIS2fM4N2kYjR47MWpl+dY4fDw75ZIAgHx6+XD1+Ki1ff/11a9iwoX3pS1+yWrX+1c9TiDCxfv16u+uuu5x2mvcCxwNbAJ2myuyC0BlOHuL2M2bMcGEAXuQrYXFiQdKYr1+/fi5Zk4RIVuHxOrl/+umnTt0XaCVBVr0QQYL8ISrZevfubeecc47lMoQV8dh4Ne1c9dgEXSV9ypQptmjRokDcE0LUhD179rhQG2MKKQt4hSuyCwin82KOz5bodVYNp0R45ZVXnET7sGHDnCEVD040ZdTAe/mMEEEhaN6F8jlCLFjw9uZamJFwFx5pnw9JjhZVc3iycxmG5ieffNL27dtnl156aVl3eSHCyLx58+zDDz904WjC0rlMbo1wNWxJQb7F2WefXXYRSLjNcbtQiDLw2LCqYqLcuHGj5Tokh1977bVO7wgwTF5++WWnh5Qr7Nq1yx2TN5o4Vo45140m4B7gXiDvLde9eUJEqaVQYAwnBhFc7FXRp08fp7/iwwm4umU8iSCAp+bkk0/Oau+66mo+4cHB6CO0jh4Suki5ULGTq9pMieDvAfKwcs2LJ0QqYW73i0UZTimgoKCgTLuELseJwKqSDuaEOsgZIZlVxpMIArEe1iDds+ge0QAXHRXyEQjh8dxlQ/OJ3En2TQUgP7dt29YdWy5pM1UF194bTkE6biGqg7/XmeuZ83OdnDecYieTZJSLu3fv7hJWMZ7QQCEpNEo9t0QwIY+FhMfi4mLbsmWLBQmKN8hNoLIVlixZ4jw+W7emth9VPNjX+PHj3b559jmWyy+/PG5hSS7Ctece4F7I1QpLIVJF0BYJgTKcSBKnnDgZ5WPc87i5cduzApXxJHIZqr0o8YcgtjjhWSNBHGOFlePOnTvtxRdfdDmH6YZ9sC/2yb45hlxMVk8Ef+0J03FPCBFW9u/f7+b2oITpIBAjCj3p6AiO+zrRcJ2HCzF69Gg3eDIYIfOeC/3AhEhFQUSuQjIzrUvI2WKxQrXMm2++6ZKdUw3bfOONN9w+2Bf7ZN9BFosMUqKsEDWBOZ25nTk+KI3EA2E41XQyYdV20UUXuZUbF4leNjKeRK6Cx4kEZqrTMhnmSjWISl544YWu0pVnD9FJQnep7MeHhMPzzz/vtF7YB/tin7kqaJkIXHOuPfcAujVChJmVAVwkBM5wYtD1suzJwAB08cUXu8GIARx10jA1KxXhIXbCDLLXKbbS9ZprrrFmzZq56pnXXnvNCd/WJGzOZxG8RfcKjxPbZh/sK+j4a849EJQKQCGqA62E/EJKhlMaQLSOwZEB07d7SBaSLC+55BI3GLFSJXRA1Y0QuUYYwnWxoJuEYYMCdqzmEzpLycJnXnrpJdctANgm2w6CNlMy+U1BmkiEqA7M5czpzO3M8UEhMIZTqiYT8h5Q4aVahd445EZUx4MlRLrDdeTlocpdVFRkYYAFC21DyDmM1XyicCNZbSaqztgG22KbYfHMbN++3SW3c+19kYAQYWVlAMN0gTOcfKki+Qw18RSh60IjVQZeRLdw98t4ErkE96ZvsREWr5OHQRJdJZ5DnmOqXWm8G++Z5t94T3ltpqANuFXhrzXXnntAiLBSUlLiIj9BkiEIpOGEK54KOxK7MZ5qAkJblCvTzoCV76uvvurirUIEWb8sKKCrxPNHs06vtYb+UkXJ8PwNLxPv4b18JojaTGHUsxGiupBrzFxeWFgYuDB7oAyn2AElFZMJ5Y8I9lGBw+CM8ZSMTpQQ6YSyekI2hG+qkwuU6/DdvBEUq/k0d+5cV57Mi5/5G9/fC2zymSBqM1UF359rzXejEliIMLMyoGE6CNzo408y1moqquKwdBmM6UhPt/dXXnkloZ54QqSb2OauYfQ6xeYdEnbzmk/Tp093yd+8+DlWm4kQXdgnEq45116IsHLo0CE3h4MMpwzQqlUrt/LkxPv4aE0hox/jKT8/3yXi4nmi3YEQ2SZs1XWVgaHgNZ/wLlFxxwsvjNdmCrsxEeQVuBDJwNzNHM5czpweNAJnOKVrMqEU8sorr3QXkkomPE979uxJ2faFqA54WoAqsrDfj3iWMJoQsqTqlZcXAg17qyS+I9eYHC5/zYUIK58FXHIj0IaT14BIFSSe43lC9p0BHOOJAU2IbEEI2bcOCbPXyWszkdNEvtPNN9/sXvyMXhP/FsY8L4+/toQiueZChJXDhw+XhemCWgQRSMOpTZs2LqyGhEAq2zcARhPGE5n+GE0YT2EesEXuE/Zw3bJly8q0mXzIbuTIke7lQ3T8G+/hvWFE1XQiKqw71v2DOZzq9iASSMMp1p2djqRZX71D+I7wCLkWhO+EyKbhhOZYmAoX0HGZPHmye/EznjXfGNgTmxRe/v1hgWu6adMm97PCdCLsrIzJ5WMuDyKBNJxiV2apDtd5sIYxnqi6Y2DD80SpsBCZhnCVX5nRpDoMxHqQGDwHDx5cqTaTX8jwHt4b66EK00SCJ51rLURYOXLkSNkYFtT8pkAbTqxA0V9Cd2nDhg1p2Qe5BgzmLVq0cI1EqbZDskCIIOuXZRO0mWJzlrxRdPrpp8ddffJvvIf38pnYnCi2GWRUTSeiwoYNG5zQNHN3kKVFAms4IRLn3drpzP3gAmM8UTKJkYbxVJG6sRDpxE+qDDxBFWnFc0tvyI8++sitPPlOyWoz8V4+w2e95hPbDGoIM3bhJ8NJhJ2Vx+ZqL+4bVIJ75DEDDa6/dK46SU6ltx3hEqxljCfatAiRKShaQOme+zyI4TpaJBFeQ78FiYERI0a4Br3V0WbiM765L9IFbNNvO2j4sYtryzUWIqyUlpaGpggi0IZThw4dXCPM2OTKdMF+MJ5Y8VIR8Nprr7lkXSEyRRCr6yg99l4hwt3kDF5zzTXWq1evGm+7d+/edu2117ptsm2adXul8aDgQ69Bn0iEqArmaJ5T5lLfESGoBNpwiu3plIncDwT5Lr30UnfRqephoF6/fn3a9ytErOHky3lzHVS/fR4S9O3b1xlNKPWnCrZ19dVXu22D723HvnMdvNd+/FCYToSdz47N0UEP00Gwj75cuC4TEGa4+OKLrWPHjk4y/s033wxkiEAED+QxMBTwqFBNmsssXbrUhc/IB/TaTMOHD3ehtXQ8k2zbaz6xT/bNMeQyviIYjxm6cUJEIUzXJQSLhMAbThgwDJzoLWUq74j9XXTRRda5c2dnPE2YMKFMCVWIdOIHnVytrsMT9s4779i7777rng28s76Bb7phH+wLPSj2zTFwLLnqnQvTRCJEPJAOof8rURvm7KATeMMJI8aH6zKZ+8HKmRUugzV5HG+99VYgk3ZFsPC5MHg5c00EkoXL+PHjbfny5U4+YMiQIS4vMJPaROyLKliv+cSxcEy5VszBtfOeahlOIuysPDY342xIh9c50wTecMpm0ixx2lGjRrnJDJf7pEmTctYTIMIBYR16Ksb2e8oFN/ycOXOcwr7XZqJh9mmnnZYVZeCKNJ84NvSjckXziWvHNSRExzUVIsysDJl3NRSGU6dOnZwVywCZaYFKjKfzzz/funXr5oynt99+261yhUi31ykXquuoaKVIYsaMGe7+59gIl6GCnW285pNf2KAfxbHmguZT2CYSISqDOZm5megQHqcwEArDibgpxlO2JhOMp/POO8969OjhVrTkVeR6YqoILn6yxWtBLk+2YP/PP/+8q/Lz2kx4YCk3zhVIFueYODaOkWPlmNGVyhZcs6B3hxciUXwUxucjh4FQGE65kDRLeODcc8912jJAYurixYuzciwi3KBiTwiKCTgbFZ2EmD788ENXUYryNS2J0FNKhTZTuuDYvOYTx4yuFN+B75JpuGZcOy9qKkSYWRkS0ctQGk4kiOP52bFjh3tly3hCzdhryrz//vu2YMGCrByLCDfZWijwbKGTNG/ePPf7qaee6nSUkErIdThGdKQ4ZuA7oDOVac0nf80UphNhp6ioyI0ZzM1hCdOFynAiPODLHLOdoI2mTP/+/d3PU6dOLZtkhEhHuC5TXpMlS5a4CjVyFujhiCTHWWedFagqGY6VY+bY+Q6Z1nyKTeqX4SSi4m3q2LFjToXwa0poDKdca0lx5pln2sCBA93PhASoOhIiVZB8nZ+f7zSKyNtJJ+yDoof33nuvTJuJpGsvAxJEOHa+A98lk5pPXvWda0fvSyHCzMqQFkGEynBiMCRc5rP4s83QoUNt0KBB7meqjmbPnp3tQxIhgfs8EwsF9I/wyKxYscLtk3s609pM6YLvwHdBb8prPvFd06n5FDuRZEOqQYhMsetYlTv3eZAXWaE3nHC9++aBueB1AgwnJhuYOXOmewmR6nZDqW5s67WZyAHavXu3S2S+6qqrnBc1TBM+3wW9KXSnSLjnu6L5xHdPteYT18iL5IZtBS5EeXzKDHMyc3OYCJXhlGvhOg+TDaE7wOuEnowQqdApYkCiWeyGDRtStl10jl577TXnJcV46Nq1qwtrhTm0ROgT/Sm+KwYO3z3Vmk809OVacc1oCyNEmFkZ0jBdKA0n3xMLdzv963IFksVJSgUUjKdNm5btQxIBh0oVf7+naqHgtZmY5NFcQWLjggsuCFViZ2XwHfmufOdYzadUKbT7a8Q1C5PXTojyMPfSnw5kOAUAki5ZiUOu9Y6jDBq5Apg/f7598MEHOdMCQgTfw1qTe4lqL4z58tpMPXv2tKjBd+a7cw44F5wTzk1Nqhe5Nn48CpOejRDxFgl4Vhs2bGhhI3SGU+zAlG1ZgopAIJMVLSxcuNCmTJki40lUmw4dOjhPyb59+2zTpk010mbCmId+/foFRpspXfDdOQde84lzwzmqrkbcxo0b3TVCydznYQoRVlaGOEwXWsPJhy8YrHKhL1VFK1patOCuR12cUuhUJ/eK6IXrqrNQ4P6L1Wa6+OKLbdiwYYHSZkq35hPnhHPDOeJcoWdV3YnEC/UKEVb27t3r5l6Q4RQgqI7xiay5Fq7zdO/e3eVTYDwtW7bMJk+eLONJZCxc57WZULdHxwjPFcnRYVL3TRWcE86N13xCz4pzl6jmE9ck7CtwITx+zmUODoNsSWQMp1ytrqsopDh69Gi3AkUnh8FYxpNIFlR5aXRdXFxclpAZD0J6JD1zz3HvIZdx6aWXuvxAUTGcGzSfOFcsdjh3aD4lEh7lmnBtuEa+u4EQYeWzCLQUCr3hRHUQCZ65CmGWCy+80E1gGHkTJ07MSuNREeyQkvcUxVso4Pn45JNPnE4RVS9oM6FfFDZtpnTBOeJcoWfFufOaT5zTeJ4+P5FwjRQCFWFm//79ZdIoMpwCSJMmTVxVDAPaqlWrLJdhQCWPgkGVY33rrbdcSECIVHlY8XigzfTxxx+7Z6Jbt26h12ZKF5wzzh2aT5xLzinnlnMcle7wQlQWpuOZaNmypZuDw0poDadsdpCvDrjwL7nkEqcfs2bNGpswYYKMJ5GU8c2949scxIIxTljJazONHDnSzj///EhoM6Vb84lzyTnl3HKOyy/SaCKMZ4r3dOrUKWvHK0QmWBmRXL5QG05+hecba+Y6JJ+Sa0IuBMf8xhtvWElJSbYPSwQAJmafP+MHL0K+U6dOdUY4LnRWgXhKevTokeWjDQ+cSzSfOLecY851rOaTvxYYTVwjIcLKwZiG4zKcAq7FwouE61wP13kQ78R4YkVLrJi2D0Ew+kRu6ZcVFRXZCy+8YAsWLChTric3p7CwMMtHGT4YYzi36F95zSfOPZpPUVmBC7Fq1So31zZr1iz0GnChNpxiJ5Ncrq6rqG8WFTwYT1TtYDzR40qIqsJ1FBmgzfTkk0/a9u3bnf4QIWB6JSoxOX1wbtG/8ppPnPsnnnjCXQuuiWQeRNhZGaFFQugNJ38RyRsKUtirVatWdvnll7tBmL57JJ/mcnWgyD4kZVL6vnTpUmdwE7pDf0i5NZnXfEIXi2vAtUhEIkKIIFNSUuLm2KgUQYTecKKyjux+cg78hQ0K5E1gPNHrhyTTV1991bVtEKI8KPWSnMwAhocDdzmeJmkzZR7OOeF2whVcC4o80M2qbkscIXKdNWvWuDmWubZ58+YWdkJvOAWtuq483IRXXHGFG4xx/7/yyis52UZGZM/LNHv2bHdfoM2ELhhaQ15nSGQHzj2TCNeCa8K1QfOJa6XelCJsfHZsbo2CtylyhtPq1asDWeLPyhXjCfl6Ek6ZJCvTjBHRgXsAL+TMmTPLtJm+8IUvuF6IQcvrC+tE0qtXL7vpppvcteEaca24Znp+RVg4dOiQm1ujkt8UGcMJwTr613GB165da0GEaiiMJ77Hzp07yzwMIrpCc4R/qLxEvoKm0V6bKcge1jAmynJNuDZe84lrxrXL1T6aQiTD2rVr3dzK3ERubhSIhOEUlN51VYHrnxYZ/B+hQ1z//F9EBwaoDz74wKnLU2lJHhw6QjSN9hAaApKSZVxnHs65Twj318JrPqGjxTXj2nEN0dkKohdciChW00XWcPJaE0EFqx7PEx4oBmg8T3igRPhBm+nFF1+0hQsXlmkzXX311SdoM5EP165du8AvFIKKP+dcAwo7YuFacc24doDOFteUaytE0Dh8+HCZRqIMpxCCNhITSqy6aVAh1wnjicopciUwnsh9EuFl0aJFNn78eFcgwGRM1RbaTFRthdXDGtYVONeMa0fVI9eSa4pgJtdYiCCx7lhXDuZW5tioUDtKnc292zwMkwk3KlIFVN1RZYfxxAAswgUhnYkTJ9qUKVPc6s5rM/n2KpXhJ21kClSFmTk415zzRFbg6GsRuuNaEq7jGnOtJXYrgsLKY3MpcytzbFSIjOEUO5CRlBnkcJ2H1SrGEzkT6DtRrYPekwiXNhODU3kvRSJeSYoiQEnImcOfa8491yCRBZBXducac6255t74EiJXORLTyiwqMgSRNJzIOUCJGwXusAxMfB/as1DNwPfCeJJScfAHpFmzZpVVTlIMQC808mKSWdWpui4YejZcU99LkGvtcxel+SRymQ0bNrg5hzmIHqtRIlKGEys6H64L02RSv359ZzwRYybeTHsWqRQHEyZNjF8MJyZNX4lVnTJfbzj5AU6kF84x57q6ibJcY641FZKxmk+qjBS5HqarXUmuZViJ1rctF64L02oOrRgShvGqYTzRGNgP4iIYcE/6MI3XZkL7h5+rA94Lwrjc5wrXpR8/pnDOUW6vDv668+JnnmHuCV0/kUuUxowpUaqmi6zhRPNNjAySOMPmlWGgJV+C70jPsjfeeMPWr1+f7cMSSWozxXoeaoqq64KpZ8O1955Gr/nEPSLNJ5ELbNq0yc2hzKXMN1EjcoYTLsWTTjoptJMJysQXXXSRq9hhkMV4CqpaehTwpehem2nAgAFluS6pwE/ivmxYpAeMGy9zkqoVuM9t454A7hHuFVXPimzz2bFUF+bSqIXpIHrfOAKrcIynCy+80N3UlLC/+eabZb2ERO7gJ0LED7020xlnnJHSgYg+h+h9xVbAiNTjhXU515zzVMG9wD3BvcE9wr0Sa2gLkQ0+j3CYLrKGE7opGBexrRHCRp06dWz06NHuxmZAx9WvPIncIDb0gmGLdzARbabqEvaFQhTaTnj9Lu4V7pnY0K4QmWTz5s1u7mQOTdeYletE0nDignfu3Dn0kwmr1QsuuMC6du3qjCfE9cJUTRhEYhu8cn2GDRtmF198cULaTNXFT+Zr1qxxuW8itXBOfTg8nXo23CPcK17zKbbRsxCZYuWxOZOIBnNpFImk4RQ7wIXdkGCApULHlzi//fbbtmzZsmwfVuTAcPXl5bTJ8T3L+vXrl3bF3RYtWrh8GTwVGE8itRAG59xyTVHyTyde88n3KORe8vIVYRD1FbnPygg29S1PZA0nXN6Es3bt2mXbtm2zsBtPlLX37NnTGU+TJ0+2JUuWZPuwIqfN5AUN0Wa69tprXdl6pojKQiEqEwn3DvcQ9xL3FIaTNJ9EumGu3LVrl5s7mUOjSmQNJ0r3/YUPc7gudqU6YsQI69Onj/v9vffeU1PRDMC9RTjFazOdf/75NdJmqi5+Usc7opL21MG59IUXmV6Bcw9xL3FP8TP3GPdaFMYzkR38vdWpU6eMj2G5RGQNpygmzWI8nX322Xbqqae632kqOn/+/GwfViiJbdqKDAC9y9Dl6datW1aOBz2gRo0aueOSPEXq4FxyTjm31VF3TwXcU9xb3GPca74ptAxkkWq8x7pLhMN0FnXDyWtQUOK7Y8cOiwpnnXVWmTbMtGnTbO7cudk+pFCBzs748ePLPHoDBw60K6+8MmXaTNUlaguFKE0k3FvcY9xrwL0nzSeRSpgjedWO0UKMKpE2nGJVT6M2maANc/rpp7ufp0+fbnPmzMn2IYWCBQsWuAmLAYbO9/QQHDp0aE6IxPnJ3WsOiZpBQrgP0+VCd3juMe41NJ+496T5JNKxSOjYsaObO6NM9kfzLBPlDvKDBw92L5gxY4ZLMBXVb/A6YcIEmzp1qptQkbtAdyeX2hHQBJoJlXCOV7kW1cersXNOCZPlCkxshO64B2M1n9ToWdQEVdP9i8gbTnR2JvfHVwtEDbxOrFIBwwkDSiQH/QBpxIonh1U/oVD0dho0aGC5BPc593sUPazpnkjSLSlRXc0ndMK85hP3qDSfRHXw1efc5ydFPEwHkTecmNzatWsX6cmEvAgGWCBkR+hOVF+bySff5yI+pMREqnBd9eHcBaHtBDphsZpPr7zyirtnde1FMvi5sX379jm3IMwGkTecYieTqBpOfoAdPny4+5lkcZLGReXs3r3bTUJoMwEaWZnWZqoObdu2dQMfYRt5H6oP5452J5xLzmku4zWfuEeBe5Z7V5pPIlEUpjseGU7HwnWxPXiiSt++fZ3WEyBTQEkz4nrieMiHI+yxadMmlyRJW5tzzz03ELomhG0Urqs5/txxLnMh8b8quDe5R9F84p7l3kXzKYq5nSI5mBOZG8GPHVEn95/4DEByp181Rr0Rbq9evZyoni9pRihTxtNR0MV5//33bdKkScdpM9ELMEj4VSP3uq5t8nDOvOGUC9V0NdF84l7mnpbmk6gMf68zRzJXChlOZUS5uq48tHFgZUoi4NKlS12LlqjnRJAYiTbT4sWL3e+nnXaa081p3LixBQ0q/fA67N2713keRHJwzvbt2+fOITkfQYN7lnuXexi4p7m3w956SlSPoC4S0okMp3KGE20LmFCiDitTQlCEIZYvX27vvPNOZI0nwpax2kyXX365DRkyJBAhmoqIFbBTuC55/OIqKGG6iuC4uYfRGeOe5t5+8cUXnQ6ZEB7mQuZEUJjuXwTzqU8DsS0Toh6u87DCGDVqlBtkmSxw60fJePLaTCTK8729NlMQvQzlkYp4zcN0YUiUxfvIPe01n9Ah456X5pOInQsJ7TJHiqPIcIpBk8mJsMq48MILXTdsHiKE9Bhgo6DNRPJsrmsz1UQksW7dusclfoqq2bJliyvrJ9macxgGuKe5t7nHude557n3eQZEtAnTIiGVyHCKwcdwGTC04voXrEYvuugiZzzRYoIVaViTSfEsffzxx06bCTd106ZN7ZprrslpbabqgNGkcF3y+HPFM8HzECa4x7nXuee593kGeBai5GUW/4I50BvPMpyOR4ZTuUaZLVq0cO54Vl3iX7C6vuSSS9yES0f4N998M3TGE9pML7/8sn3yySdlFYbo33BPhBF5WJMn7Ctw7nXuee594FlA84lnQ0QLX3XLPZHtBuW5hgyncmgyqRxye2ggSpiClcjrr79uJSUlFgZWrFjhtJkIW1EtRW4XmlYYimGlU6dOzmvi2ymI+Pi2TNwTeJzCCt+Pe59nwGs+8WzwjIjoEPZFQk2Q4VQOf5PgVUHnRBwPWh5U4jCgUm3x2muvBfo84TVDq+rtt99234NGuOjcRKH0FgMY4wm0UKgaf458fljY4RmI1XziGZHmUzSIbQQehbEwWWQ4laNZs2Yuxk9cn3wecSIMpJTk169f33loMJ5oPxFUbaYlS5aUNTy+4oorAqnNVF2kX5Y4/hxFaSKR5lM0IVWFOZC5kJc4HhlOFeAHRk0m8ftfYTxRkUOlEYmkQUqor0ibafDgwYHV5akuJIjznTkPvETFFBUVufPDuQpzmC6e5hPPiNd84tnhGRLhRKKX8YnWLJHkKnzNmjWhyeFJByQN4qFp2LChW4FiPKGonMtg3JHY7rWZMBzCos1UHQi5+rJ6LRQSC9NxzqIIzwjPCs8Mzw7PEM9SkBZMomqY85j7QPlNFSPDqQJ8FQF6Rf4GEpWHNjGeWIlu377dVeDkqvI6MXv0aQjBkhQ9fPhwJ7MQFm2m6qKCiKpRouxReFZ4Znh2vDwJz5TPhxHBhzmPuc9XmYsTkeFUCZpMEocYOHkQKMvixqekH2HFXIHV8YwZM1wuVqw2U9++fbN9aDkBHgT6EvqqMXE8vuqQc+S1r6IOz06s5hPPFs+YNJ+Cj/c8R32REA8ZTpXgbxpWVFFQyq4prE58YjUTTa5ov3AsGHJz5sxxv/fu3dvp1DRv3jzbh5ZTXgQfqtRCofKJhHMUde9kLDxDPEs8U8AzxrOWC8+9qB5UTPqiKBlOlRP+mtpqQt+6goIC114BaQKtNKsGownjiVwnbzyRUBpPPI14OivVmTNn2qxZs8pkIHzuzaBBg1zS9tChQ135fDLQnHjKlCluH2wPbRolO1YMgyThFgynAQMGZPtwcgqF6SoHWYZzzjnH9bxDqoAqWzSfzj77bNcoPFnSOR6IquF8YzwRPaB6WlRMrVKkQUWFkPxI5UiPHj1s5MiR2T6cwICxies+tmKtfEkrk/Sjjz5qjzzyiG3YsKHKbbZr187uuOMOu/32290gXdXgS7PSpUuXlmlPnX/++WpSGQfCLU8++aT7+ZZbbtG5OgYh53Hjxrmfv/zlL7tCCFH5uXrnnXecvhv07NnT9b9LxMBJ53ggEmfy5Mm2bNky69evnw0bNizbh5OzyHCKAwMArmdWO7feemvkStVrgs97oIybyQbjiURyVjMPPfSQ3X///WXCmc1q17bBefWsf7161qVOXatfq5YdoAv94UM29+BBm1ly0IqO5U5wLcaOHWv33HNPhSKEW7dudUJ9O3fudDkp6M+gz6RrVzXc69zzTHZh681XXebNm2cffvihm6jxpor4kOM0e/Zs16qFqaWwsNAuuOACJ19SERWNB3mN86x5r2bWtGuhFbQvsNp5te1IyRErXl9sO1bstO2Li6xkd0lC44FI7to9/vjj7jqQs8qCU1SMDKc4cGpYhVNiT582r7IsEoMyZYwnEmvJDenTp49961vfco1DYUi9enZbQSO7uEFDq1erVqXbOVhaam/u32ePFe+xj48NrujK4Anw4QCuFd7Bjz76yA0AhFnxMjHhicTg/OFlZcBk4BQyJqsLXiO8T3ifWbScccYZzotRPpSOd9OPB816NbMul51k7c5o64ylysCI2vDRRlv52iorWlxU4XggqldN98Ybb7gowRe/+EW38BQVo2V4HLhxVF1XfTCW8DSx2mSQZOXJIFlYq5b9tmkzG9+ilV3ZMD+u0QT8O+/j/b9p2sya1KrltkMeBR4BDFv0ZPAMYDSdfPLJrlWEjKbk4LwBhkKuSkpkEs6BDzspvyk5ePZ4BrmneCZ5NnlGvc7b3LlznaQBz3FeQZ4N/G5/G/7zM63D2e3jGk3Av/M+3j/wO/2tbn7d48YDUT38HMc1k9EUHxlOVeAHTDpFq9Q2eWjLQqf13//+9y5hvG/dPJvUuq1dn1+Q9MPJ+2/IL7C3W7d126H5KF6lP/7xj261hK4Mg+eFF16o6qdqEJsQyv0edfw54JzgwRTJwTPIs8gz6TWfSBz/4IMPbPTo0S6RvEmXJnbu786xTud1rNZ40On8jjby9yPcdhgPaEzMIk0kB3Obv9+1SKgaGU4JrJyY/Ak7+dWnSBxyGL7yla+4nCOMnWdbtrJ2derUaJt8nu2wPXKaMJyo3ENXhnCgqD7ysP4L6dmkBp5Jnk1yHJEq+NKXvlRmNJ31szOsYYuaLXL4PNthe2yX8J8aEScHcxtzHMauPPVVI8OpCojP+xCGJpPkefjhh11pMeG1v7doaYUpStJmO2yP7bJSYpKTNlPN8UbC+vXrI91Kg+/uq7tkONUcnk2MJ7SeaCBLeG3oTwa7MF0qYDtsz4ftGHdE8osE5joV0lSNzlCSq3Dl0icOJcZjxoxxP48tbFqlp6n+iBHW4h9PWrv586z9imXWZsZ0a/anP1qtSrpzs737C4/+G5U1TPaiZvg2C9znTHBRBWOcc0B+XjwdMpE4hNL+/ve/u59P/XqfuJ6mkZ3Os1+e85A9fsk/7LnL/2l/GfWI/Vv//89aNKi8BQjbY7vAuKPxIDG4zxWmSw4ZTgmATghlrySL8vCLxECXhdJWqueub5gf970F3/i6tXzqH9Zg5LlWu1lTq9WggdXt0MHyr7rSaldiOMENDfOdlAH7YX+i5ihcJ9HLdI4HVM91PK9y7aUbetxodw26x3q36GNN6ze1+nUbWPtGHeyyUy63X4542BrUqdzgYrtsX+NB4jCnMbcxx0kTKzFkOCUAiY2dO3e2qE8myYAIJWJ2gORAvMTPur17WeF9P3U/H5w/3zZfcaWt69rdNg4904p++B9WGqd/Gtu97ZhYI/tjv6JmeHV1r9ocNfjOvmmtDKfUjwdIDsQbD87rdL77/5HSI/afU39iN716vX288ahkQev81nZa69PjV0JferTLg8aDxPBzGt0xFKZLDJ2lJCcTGU6JQdsEckSa167tdJri0eirX7Fadeta6ZEjtv2Ob1rJ7E9IMrHD69bZ3n+MsyPbt8f9/CUNGjoRTVzz7FfUDFTeeVFpE8VwHd+Z704yc3nFe1Gz8aBek3pOpykeGEyw88BOm7Nlju07tM9mbvzXc12vTr24n293ZlsnoqnxIDHkXU0eGU4JQp8klGlpK7Bly5ZsH07OQ0I4DMqrV7VO0zFp/yNbt1rjb33T2s6eae2WL7WWzz1r9QZVvros+3ytWm4/QH8rUXOivFDQRJK+8aBZz6ZV6jS98fkb7v+F9QttYKuB1rBuQxvSdqj728HDB23+1vhaTWy/ec9m7meNB/FhLmNOY25jjhOJIY36BOHGIlxH9QEDK02AReX4AYs2KlVRp337o/9HL+dLXyr7e/2zhlnLZ56xLVddZSULFsbdBvuZdGC/q6hRKXLNQSWfc0nSKKKFUWmoSmiH73z48GH3vOteSg1eHZw2KlXx2mevWG2rZV/r9w17YPiDZX9fv2ed/eXTP9u2/duq3EZht0LbNHOzDKcEq+m419WyJnF0ppKAFSg3Gi+6c4vKIT8G6D1XFbViqu32PP6E7fqvB63hVVdas4d+ZbUaNrBGd95pRf/ft+Ju45Rj+2GA/t///d8aH78w13MMo4lVaVQWCnzXRYsWuf6K5DaK1Hqc6D1XFSM6nmu3nfp1q1Pr+PPfpF6hdW/W3eZs+aTKbTQ6th+EcUXV3lXvYRaJoVBdEmCVM5iigL29irybqOOTimnYWxVHio72m4Lixx+30uJi2zvuKTtyrO1HXp/eVW7DhwPlIUgdvjErIqNRwX/XyprSiurhn8uqwnS1rJbd0f+bVrd2Xdt1YKd9b/J37IZXrrXxy563RvUa2Zf7fMXO7Tiyyv3Vrnt0P1EsbkgUeogylzGnqQ9rcsjjlASEK4gDkzwqwcX4UNoKBxLQvSqZv8DqtGlT6b+XJiDESCNgYAD42te+ltSxiopBhfmll15yLvwvf/nLoXflM7k/8cQT7v9XX311ZLxsmeCpp56yFStWuAa98Sis39Sa1Duqm7Vo+2JbufNoKOnt1ZPs2u7Xu5/7txpg7619N+52jhw6ctw4JCr3NjFmRiUUnyrCPRKmKVyH4cRNN3jw4GwfTs7iEw1XHq7aA7T3xRetwQVHS5ALbr3Vdv3sv1yornb+Ue2ngx9Or3Ibnx3bj2L1qaN9+/ZWWFjokkdpyeAV9MMcXkYMkO+sthOpxXs0itcXx33fnpLdduDwAatfp771bt7LuhSe4nKbLug8uuw9xSV7qtzfnmP7kSelclQEUX0UqksSr3VRVFRkO3bsyPbh5CyDBg1y/5+bgKt83wsv2v7333c/N7r1y9Z+2RJr9vBD7vfDGzbY7j/+qcpt+P34/YrUECUxTE0k6cM/lztW7Iz7vkNHDtnrn73mfm5Sv9B+d94f7Lkrxtu13a9zfztwaL9NXDWxyv3tXH50PxoPKoa5izmMuYw5TSSHDKckoeGvV1eNwmRSXbw3bmbJwbIwWqWUltq2275uu373ezu0erWVHjxohzdvtuJnnrXNl19pR6qQf2D7s0pkOKUDb0R4baOwEqtZJcMpfePB9sVFVYbr/r7gf+1/Pv2zLSta6jScDh85bEX7i2za+qn2H1N+aGt2r477eba/fcnRvEmNB/Gr6XxXDJEcimlUAwZWqjUwnE477bRsH05OQtUh4Q5E797cv8+urKLlCoKXu3/1kHslyxv791nRkSMutKRqx9TSpk0by8/Pdy0ZUNMOa+iD70YiMd+V7yzSNx5s+GijdTj7qARJRZRaqb228lX3qg4bpm+0kt0lGg/iIO9qzZDHqRqQ64G0PxU4VCWIEyHZ8I477nA/P1a8J23NkdnuY3uO5jywPyU5phbuc5/bFGYPa2x3+HjtQETNx4OVr61K63iw8vWjnkONBxXDnEVFXeyzLZJDhlM1aNCgQVnyqO8qLU7k9ttvd27gjw8etOf3HZUWSDXP7dvrwoHsh/2J1ONXpdzrYQzXxYbppGeT/vGgaHGRrZ18tBdgqmG7bF/jQeX4BRBzGHOZSB4ZTjWcTPxKVZwI8fOxY8e6n8fs3GEbDh9O6fbZ3v07jybosx9c8yL1+AF2//79rroubBA+4rvxHdu2jd9HTaRmPJj/t4W2b1vVMiPJwPbYLmg8qByJXtYcGU41NJzQuikujl9iG2XuueceGzJkiO0qLbWvbttqO1PksWA7bI/tksfAfkR6oPLGu/TDuFDwEwnfUd3hMzMeHNp7yGY8ONNKiktSsl22w/bYrsaDykFahDkLFKarPholqglJpH51Gubcj5qCptK4ceOsdevWtuBQid24dUuNPU98nu2wPRJ5//GPf0i7KYPhunTlp2QDvosPtytRNrPjwa6Vu2zafR/V2PPE59kO29N4EB9/rzN3MYeJ6iHDqQZESeOmJnTr1s0mTZpUZjxdsHmjPbe3OOkJmPc/u7fYfd4bTRMnTnTbF+nFly1TXbdp0yYLC3wXvhPfzcuMiMyNBxg77373fVvzzlHx0WTg/XyOz3ujSeNBfLzHWIuEmiHDqQb4m48cCZqhisrp16+fTZ06tSxs94MdRXbN1i320r69Veo88e+8j/fftaPIfZ7tfPDBB267Iv3ECuWFaaHgJxIvbCsyPx4QXpvzh7k29d7ptm7K+ip1nvh33sf7+Ryf13hQNSwQfI6iDKeaIX9mDWjUqJHrZ0VHdVygvXtX3Yw2yrASnDZtmj388MM2ZswYm3nwoM0s2m7Nate2QXn1rH+9enZKnbquYS/GEm1UUARH3BKdJsAz8MADD9jdd98td3yGYbBdtmyZM5yGDRtmYUBhutwZD6iG45XXOM+a92xmhd0KrVH7Atewl95ztFFBERxxS3SaQONB8vc6cxZzl6g+tUrDlLCQBebMmWMzZsxwvdkuvfTSbB9OYFi/fr09+uij9sgjj7ifq4IKGXRZKDFWtUx2oPnt448/7v5/zTXXBL4JLkmyL774otP6iUIT41xG40H6ee2115zQ6xlnnGEDBgzI9uEEGhlOKRATe/rpp52YGIOvdDGSo6SkxBmes2bNci8U2VFwZiWJSjUtE3hRKSMxu+xDbgrhrYEDBwZelfmjjz6yTz/91Lp27WoXXHBBtg9HxBkP6KvWpEkTtzg9//zzNR4kCXIbTzzxhMsL+8IXvuDOpag+WmLVEG7A5s2b2/bt252IXs+ePbN9SIGCwW/48OHuJXIftF8wnHgF3XBS24ngjAcTJkxw4yt/79u3b9aOL6hw7jCaWrRoIaMpBSgbMgV4IbEwJc0KURF4AevUqeM8rSwWggotJ/gOfJew9t8LEyxOAc+TSB4tElKLDKcU4G/GtWvXOreyEGH2CHhDI8himH4i4bso5JP7NGvWzP0/yMZ6tmBOYm4CGU6pQYZTih7qpk2bup5Xq1evzvbhCJFWwqBfJj2bYHqcZDglD3MScxNzlDdARc2Q4ZQi1LtORAWveUTYZMeOo70CgwTHzCtWm0rkNkz6XC+8J2pxlRx+TlJvutQhwykN4TrKtYUIK7Eq20H0OvmJBAkRvovIfTCafFKz8pySq1KkMhHkXU0dMpxSRMuWLa1x48bOaFK4ToSdIIfrlCgbTBSuSx6MpsOHDzujk4o6kRpkOKWQIE8mQiQDndXRLtu6daurTgsKHCsVdRy7wnTBQoZT8miRkB5kOKUQH0PG44SVL0RYQei1Xbt2gVso+GNFbVpitcHCJzYrVJcYzEE++iHDKbXIcEohtKAoKChwcWVf/ilEWAmifplW4OHQclLDi6phDmIuoi9d69ats304oUKGUwrB/a9wnYhSuM73fAtCpdOePXvcscYeuwgO5OkgWEoe6e7du7N9OIEpgtC9nnpkOKUYbzjRiRrtDCHCSn5+vrVt2zYwCwXfHZ5j5thF8BamCtclBnMPbVZAMgSpR4ZTimFQbtiwodMbSaTLtxBBJkgeVunZBB8piCfGunXr3BzEXNSmTZtsH07okOGUhlWRd41KDFNExXDasGGD7d2713IVjm3jxo3uZ4Uugot61iWfy8ecJFKLDKc0oHCdiAoknlIUERsKy0X8sZEkyzGLYCKPU9Uw5/j7XUUQ6UGGUxqg1Ll+/fq2f//+slWuEGElCNV1qqYLl8eJljlalFYMcw5zT6xkiEgtMpzS1B7AhwNyeTIRIhV4Y4ScPgbsXINj8vmGMpyCDd7CvLw8ZzTt3Lkz24eTk/gUEd9TUqQendUMJM1Kc0SEGd/OgfvcV/LkEhwTx8Yx+n5nIriosq5yuM8Vpks/MpzSBE1QaSBKUqrXjhEirORydZ1fgWsiCQdqvVI5mzZtcnNObCNukXpkOKUJhNo6d+6cs5OJEKnEGyWoFVMGnStwLJRmg2QIwoEMp8rxcw1zD3OQSA8ynDIwmUiWQEQhfNK0aVOXe+L7Y+VKmI5j4th4ieCjUF3VhpMWCelFhlMa6dSpk9WtW9e1etiyZUu2D0eItOIH61xaKGgiCa/HadeuXa79ijgKcwxzDXNOx44ds304oUaGUxrhBla4TkQxXJcLExoNTtesWeN+Vn5TeEANm1J7EqGRJRAnhumYe0T6kOEU4aRZIVKJr1rDaMqFcB1G0+HDh8uq/kR4kIL4iagIInPIcEozPkkPzRElM4qwk0sLBU0k4UUK4sfDeSB0GVuUJNKHDKc0g1ibjzfnwmQiRDrxRgoeJ7w92SLW6yXDKXzI41TxIoG5hjlHpBcZThlA1XUiKvhecOQXkeuULXyeFcfCMYlwIY/T8agIIrPIcMoAXvqe1ZGSGUXYyYV2Q+pNFw3DiSqyXNINywbMKcwtzDHMNSL9yHDKADT8pfEvKFwnwo5f9dL6IRuNWNmnb/0iwym8Y2pBQYH7OerhOj+n+G4VIv3IcMoQQeggL0QqaNOmjSsZj1XtziTsk33n5+e7YxHhREKYR5F3NfPIcMpg+KJWrVq2detW2717d7YPR4i0wX2ezeo6v0//zIlwotYrR0VAmVO4z32IXKQfGU4ZAsG2du3auZ/ldRJhxxtOmQ7XsS91h48GMpyOPl/A3MIcIzKDDKcMouo6ERX8QL5//37buHFjxvbLvthn7EJFhBOF6v41l6iaLrPIcMqC4bR582YrLi7O9uEIkTZiK3wy6WH1EwlhC45BhN9w2rdvnzOWowZzCHMJKEyXWTSyZJDYZFWF60TYic1zoq9YumEfCtNFB/qx0U4nquE6P4e0bdvWzS0ic8hwinBLCiHSiS+P3rt3r23atCnt+2Mf7It9sm8RfqKsIK5quuwhwynD+JucXAxczEKEldi+WZlYKPh9eMFZEX6iqiDO3LFhwwb3swynzKPRJcM0btzYWrZseVxYQYiwkkn9Mq3Ao0dUE8T93NGqVSvXVkhkFhlOWUBimCIq0HSUXBRaY2zZsiVt+2Hb7IN9+abaIvxEVZLAF0FokZAdZDhlAX+zr1+/3g4cOJDtwxEibWDIZCJc57fNvtiniAZNmzZ1YVmU4qNSqUwFIXMHSIYgO8hwygKFhYVupRTbU0uIsJIJ/TLp2UQTjCbG0yh5nZgzSPVgDvFVhSKzyHDKEhLDFFEBLxCJ4rSHSMfktm3bNrdt9tGpU6eUb1/kNlHLc/LeVS0SsocMpywbTmvXrnVuZiHCSl5eXlneUToWCn4iwWhiXyJaRCnPibmCOQOU35Q9ZDhlCR524vOE61avXp3twxEisAURqqaLNlHScmKuYM5g7vCeNpF5ZDhlEYlhiqjgtZWY3Hbs2JGy7bItthnb4kVEN1SXCYX6bKJqutxAhlMW8Tf/mjVr7NChQ9k+HCHSRqyadyoXCn5bXqVcRA8SpMlvYwzdvXu3hRW+n8J0uYEMpyyCECaCmDwQGE9ChJl0eFi1Ahe1atWKhII4YTrmCi+iLLKHDKcso3CdiAp0cGeS27p1q6uCqylsg4o6tqnu8NEmCnlOyuXLHWQ4ZRn/EKDNcfjw4WwfjhBpo0GDBtauXTv3cyraDfmJpH379m7bIrqE3ePE3OCLiCRDkH1kOGWZ1q1bW0FBgZWUlJTFr4UIK37QT4UsgVbgIipaTswNzBHMFfSnE9lFhlOWIcygcJ2ICj6ktnnz5hq1yOCzbCN2myK6+FAdVZaU64eN2EUCc4bILjKccixcF8aHXghPfn6+tW3btsYLBf9ZtsU2RbRp1KiREz9l/Ny5c6eFCb6TD23Lu5obyHDKARj8GzZs6Br++uaNQoSVVHhYVU0noqIgzpyAYjhzhF90iOwiwykHiK0KUrhOhB1v7GzYsMH27duX9Of37t1rGzduPG5bQoQ1z8kvEnxVqsg+MpxycBUedvVbEW0Iq/gE1+pU1/nPUFjBtoQIq8dJYbrcRIZTjkBJdf369W3//v1uJS5EmKlJuE7VdCIqWk54VpkTmBuYI0RuIMMpR4jttaVwnYiKLMG6devcxJAovNfnAcpwEhWF6kgOD0sLKz8XEKZjjhC5ga5EjnaQV7hOhL2/GB4C7nOqSROF9/KZFi1auG0I4SF52guhprKRdLbgPpd3NTeR4ZRD0KiUklqSX71GjRBRWCgkiiYSEZU8J+YA5oLYBtkiN5DhlEPQ4VvhOhEVvPGDKjLl1lXBe9QdXkSlss7PAZ07d3Zzg8gdZDjlGH5CSEVLCiFyfZJr2rSpqxzyfbjiwXt4L5/xE6QQYfU4+TlAvelyDxlOOUanTp2sbt26tmfPHtdFXogwk0x1nSYSERWP05YtW9wcwFzQsWPHbB+OKIcMpxyDBwXjCeR1ElExnNasWRO3EooGp7wn9jNCVOZxwuhIJPwbhDAdc4LILXRFchAmBh4cXkOHDs324QiRNlq2bGmNGzd2VVDjx493GmazZs0qy3siMZYVN7l/tCTq37+/q6gToiK4XwoKClwTaLxObdq0sSCiIojcRoZTDsIqA80O9EiI1ftVlBBhAx2nt99+255//vmEmrNiaC1fvtxuv/12VRqJCmG8DLLhxJjPs0BCOHOByD0UqstB/CobVF0nwghhuV/84hcuX+lvf/ubmyia1a5to+s3sLsbN7H/27S5Pdqshfs/v/N3/p28v7Fjx7rP/Z//839CI3QoUp/nFNQEcZ+iwRyAPI3IPeRxylGYGKgiwnAaNGhQtg9HiJSBx+iWW26xjz/+2P0+pF49u62gkV3coKHVi9PE9GBpqb25f589VrzHPj540H784x+78N64ceOsW7duGfwGIpcJemWdwnS5jzxOOQo5HYTrvNtWiDAwd+5cGz58uDOaCmvVst82bWbjW7SyKxvmxzWagH/nfbz/N02bWZNatdx2zj77bJs3b17GvoPIbYLcs45cP447tgWXyD1kOOUosU0dFa4TYfE0jR492iki962bZ5Nat7Xr8wusVhUGU3l4/w35BfZ267ZuO5s2bbJRo0a57QuBzhfs27fPvYKEH+t903eRm8hwymEkhinCArlIN998c5nR9GzLVtauhmrIfJ7tsD22S/hPOU+C8n3fxzBoXidvOEmrLLeR4ZTD0BGb1TUJsbt378724QhRbR5++GGbOXOmC6/9vUVLK0xRp3e2w/Z82I79CBHEPCfGeMZ6xnzGfpG7yHDK8W7fbdu2dT8rXCeCLDkwZswY9/PYwqaVepo6rFsT95V/4w0Vfo7t3V94NDzDftavX5/GbyOCQBAVxP0Y365dO2vQoEG2D0fEQYZTCDvIC5FLPProo07Mkuq56xvmV3s7R4qLK/23Gxrm2+C8em4/7E9EmyB6nHxKhqrpch8ZTjmOd9mSAIuomxBBglYpjzzyiPsZyYF4ieDrOnQ64VWybJn7tyM7dtiBt9+p9LNs97ZGjdzP7I/9iugSNI8TYzt5eiDDKfeR4ZTj0D7Aq99+/vnn2T4cIZJixowZro1K89q1nU5TMtQbfpblde/uft773PNWun9/3Pdf0qChE8kkVMd+RbQr6yjpxwNJ37pcx0cUGOvz86vvlRWZQYZTyDrIC5FLkBAOg/LqVanTVJ5Gt37Z/b/0yBErfvzxKt/P9tkP0O9ORBeMpsLCwsB4nSR6GSxkOAUA/zCxcg+aLomINt6A6V/vqEGTKLVbt7YGF13kfj7wwQd26LPEFg1+PzKcRFCEMBnTGdtBhlMwkOEUAOgeT3PT0tJShetEoFi7dq37f5c6yXV3KrjlZqt1rE9X8eNPJPy5U47tZ82aNUntT4SPoPSs82N6q1at3Fgvch8ZTgFB1XUiiJBjAvWTCdPVrm35X7zF/Xh4wwbb/9bEhD/qw4F+vyK6BKWyTmG64CHDKSD4h4rE1wMHDmT7cIRIiHrHQmcHSksT/kyD0aOt7rF2Q8VP/sPs8OGEP0sj4Nj9iujiDSf6v+Gtz0UYy73umAyn4CDDKSCQ6MhAcOTIEVu1alW2D0eIhOjYsaP7/8rDibdCKfBJ4QcPWvG4p5La32fH9tOpU6ekPifCB2GvOnXquDY8udp5gbGcMZ2x3Sezi9xHhlOAUHWdCBqDBg1y/5+bYOiszsknW/0R57if902YYEeOadskit+P36+ILmh75Xqek0Qvg4kMpwDhHy4SX5XDIYLA4MGD3f9nlhwsC6PFo+BLX7Rax/rYFf+/qiUIYmH7s0pkOIlg5DkxhpcVT8hwChQynAKEd+fi2l29enW2D0eIKhk6dKjrvVV05Ii9ub9qKY1d//VgmWr4wQ+nJ7WvN/bvc/tp3769268QuawgzhjOWI5YpzfwRDCQ4RQwFK4TQYFJgVDEsGHD3O+PFe9JW5Iu233smEL0HXfcYXnHpAxEtMllj5Oq6YKLDKeAyhIQriPpUYhcAyMGg+n555+39957z3l/6tatax8fPGjP79ubln0+t2+vCwdSTXf77benZR8iuB6nnTt3OkM+V2Ds9lpjMpyCR3KqdCLrIIRJtQhVIjx4euhELkHOBn3itm7d6n5v0KCBXXLJJXb48GH7yU9+YmN27rCz6zewdnXqpGyfGw4ftvt37nA/jx071oXqhIBGjRo5Y5p8Iownb0hlG7/w9eLGIljIcAogGEtz5851rl4ZTiIX2LRpU1lDXyBU1r9/f+vXr5+buPr06WMvvviiffzxx/bVbVvt2ZatrPBYEnhN2HnkiNvertJS59m65557UvBtRJjAWOL+JFyXK4aTqumCjQynABtOaICwkkerRIhssG3bNmcM+WIF7sW+ffvawIEDnbfJQ6hu3LhxNnz4cFuwebPduHWL/b1Fyxp5nvA0YTQtOFTiusr/4x//cPsRonyeE4ZTriSIM2b758WnXohgoVEmgLRu3dry8/Nt7969tm7dOuvcuXO2D0lEDMIeNNJdvnx5mWZOz5497fTTT3fhkYro1q2bTZo0yUaNGuWMpws2b7SxhU3t+ob57vPJ5FCR00R4Dk8TRtPEiRPd9oUoT65pORHOLikpsYKCAtefTgQPGU4BhEkGr9OCBQucy1eGk8gUxcXFNnv2bFu8eHFZhVzXrl2dXlMiyseE7qZOnWq33HKL81T9YEeR/aO42G5r1MguadCwrNdcZTpNSA5QPUciOAwZMsR5smQ0iaBU1sVW0yWzYBC5gwyngOINJy/ZXzsF+SJCVMb+/fttzpw57p4j1AAY7BguLVq0SGpbGDnTpk2zhx9+2MaMGWMzDx60mUXbrVnt2jYor571r1fPTqlT1xlRGEu0UUERHHFLdJqAvKkHHnjA7r77boXnREIep127drmE7GzeL7Ets5TfFFw04gQURAXJIWFCo0mk7wkmRCohpEA+HS9+hrZt27pEbP5fXZi8fvSjH9mtt95qjz76qD3yyCPuPp50YL97VQYVc+g0ITmg6jmRCA0bNiwbK2n4m80qNt+knWOqyfMjsosMp4CCi/fkk092IRNcvzKcRCrBq4R3CS8TEw4w4eBhSmUDXYwfvE733nuvq8ojb4qXbyuEZ4n90UKFFwabxC1FdcJ1GC2E67JpOPlqOsZuhemCiwynAENFBobT559/bmeffbYeRJGSUMLSpUud8UI+E5C7hMGUzpwMjCEq7ngJkU7DKVuQE8hYDQrTBRsZTgGG1Xr9+vVt3759tnHjRhe+E6Imat8zZ850FXNAdRxVcj169FAOnQg0udCzDo0zvLeM2QozBxsZTgGGyeykk05yHgLCdTKcRHVAU4YKNzSZgHyQ0047zYlWSiNMhKmyLpuGk6+mY8zWQiTYyHAKOLh8veFEM1WF60Si4KUkr4j/A/lEXu1beUQijB6nPXv2lOXOZdqj6w0niV4GHxlOAYekcCY58lG2bNnixDGFiAd95PAw+SajeJVOPfVUGzBgwHFq30KEBQwlQs8YTnidEE3NJJs3b3aCxYzVHTp0yOi+ReqR4RRwmPTQ01mxYoXLUZHhJCqDUmxymHxlD+GCXr16ubAcKsZChN3rhOFEgnimDafYMJ3C38FHhlMIwPWL4cTDeeaZZ2b7cESOwWSB2veSJUvK1L4RoUTtu0mTJtk+PCEylueElzUbeU5q6hsuZDiFAHRuEBTcvXu3C8NkU6dE5A5U8HzyySdOjwmZAb/iRVrAJ8sKERWy1bOOMZnFC2N0KjXQRPaQ4RQC/AOJx4mXDKdoQ/IrSt/z5s0rU/um4hLxyEyHKISIes86723yC1wRfHQVQwIuYIwmHlI8CiJ60Idr4cKFzstEWwfAiMZgkrK8iDpNmzYt88SifUfbk0w39RXhQIZTSCBBnGRfxAtZUSkUEx0Iw5G/hNo3lTt+kvBq30KIo555cvpo9kueUyYMJ8ZixmTGZsZoEQ5kOIWo3BavAmKGrHBkOIUfEr0pCqBSjskAKLkm6Zvkb4nsCXE8jIs8Kxg0mVDv9t4mwnSZ1o4S6UOGU8iq67zhRENUEV5WrVrltJh8vgarZ2QFevfurXJnIeIYTvSLy1Sek8J04USGU4jwUv7ePUxzVhEuaFSKwbRp0yb3O6tYhCsRsJTatxC507POp0341lgiPMhwChG+eeTatWvdSmfgwIHZPiSRIlCFx2Di2vp8Da/2zXUXQuRWzzrvbfLN2EV4kOEUMnAJy3AKl9o3BpMfhL3a9+mnn275+fnZPjwhAgVeeJ4hJDvQViInMF1I9DK8yHAKGSeffLJNmTLFeSgQxGzcuHG2D0lUAwZ1kr6XLVtWpvbdvXt3l7smtW8hqgdGExWnhNDwOqXLcPJixDRdZ0wW4UKGU8ggSRixww0bNjgvBd3uRXBAXwYdJvSYvNo3Ay/SAj4/QwhRfXiOMJx4pUvJ23uIGYszpRclMocMpxCCa1iGU7AgdPDpp586tW+ELIEu6hhMatwsRLASxFVNF25kOIUQHtZp06a5yisEEZULk7tgJM2fP9/mzJnjjCfAUMJgwnASQgSr9UpxcXFZ1avCdOFEhlMIKSgocJPv5s2b3cqnb9++2T4kUQ7CcIsXL7bZs2eXqX2zEsZg0mArRGYq68gfJA8plaATBfSFZCwW4UOGU4jFMGU45R4M1MuXL3eJ3ySQAgn8Xu071YO4EOJ4eN6Q88Dbi4p4qvXuVE0XfmQ4hRQe2unTp7tcJ5paNmjQINuHFHlYiSIt4HMrCKEiK4C8gNqjCJEZWJxQWUfVG89iKg0nijs2btzofpbhFF5kOIV4VdWyZUs3ODBhMzmL7LBu3TpnMOEB9GrfaGwhYMnKVwiR+XAdYyN5TqkMjTPW4lVm7JUUTHjRqB1iWPEwOOA6luGUeTCUMJgwnAAjqV+/fk7tWw0/hQifgrivpiNVQoQXGU4hN5yYuOlvduDAAcn+ZwhWseQw+SRRwnB9+vRxTXil6SJE7kgSpLKyjjGWsRYUpgs3MpxCDHF8BghWVatWrbIePXpk+5BCDYmms2bNcmrfPpfCq33LbS9E7nmcaMRLhWsqcgwZY9kW21aD9XAjwynksPLBcMKFLMMpPSAngKwA8gJe7ZvzTqWc1L6FyD2QCSBcjnYa/SC9IVUTVE0XHWQ4hRxi7UzqNP4tKSmxvLy8bB9SaMA1j9o3ApZe7btjx45Oi6lVq1bZPjwhRBwwlqiAY2FZU8MJA4wxFmQ4hR8ZTiHHu41xSa9evdq6du2a7UMKPBigGEsYTbFq30OHDrX27dtn+/CEEAmANxjDiTynmo6LjK14mxlrU+G9ErmNDKcIwAqIlh6E62Q4VZ/Dhw/bokWLXBNe9FqAQRIP00knnZTtwxNCZKlnnXrTRQsZThEynFgVEVKSdlByoMtCwjeVcnv27HF/a9KkicthwhCV2rcQ0e1Zx5i6Zs0a97NkCKKBZtAIQL5No0aN3KTPA65VUXIrSSQdSCD1at9UyfXs2VNq30KEwHCiGrYmC0rGVD7vRYdF+JHhFBEwlubNm+cMARlOVUOi54wZM5yAKKCBhQ4Tekzy2AkRfGhDha4aYXfCddUt6FCYLnpoBogIuJAxnAjXkatTp06dbB9STrJp06Yy0VDASOrfv797Se1biPDlOdXEcGIsRb8JZDhFBxlOEYGqL8JMaA7RAqRz587ZPqScgjwHDCY/CBKG69u3r+spJ7VvIcIbrmORVN08J8ZSqmwZWxljRTSQ4RQRSGBmRbRgwQLnWpbhZGX5DSR9L1++vOw8kb90+umnu7wwIUR4qWnPuljRSxWJRAcZThHCG070UDvnnHMindxcXFzshEGXLFlSpvZNOJNKOVrVCCHCT0161jFuKEwXTWQ4RYi2bdu6hMj9+/c79zQq11GD7440AwYk+QnQqVMnp8Wkihghomk4sZBCzDaZPEbfPJ0xtV27dmk8SpFryHCKEHiYTj75ZNdTjXBdlAwn8hBIjp87d26Z2jeGJGrf/F8IET0wlLxUC16nZMYCX03HmKowXbSQ4RQxCEdhOBGuO/vss0P/wONVWrhwoVP7xtsELVq0cB4m5XkJIfA6YTiR55So4YQoLmMoSPQyeshwihj0UmOVRQkufZrC6mIm/2Dp0qUujylW7RuDiYEu7AajECLxBHFELJPJc2LsZAxF3039KaOHDKeIhuswKnA1h81wYiXo1b5pbAwFBQVO7btHjx6RTogXQqSmZ50P09GjUmNK9JDhFEGoAPGG07Bhw0LjfWHViMHk1b5J2kSHCT0mCX4KIVLRs47FWawMgYgeMpwiCEnheXl5rpJky5YtgRduw21OexT+D3w3lL779esntW8hRFy8/Ag5kITfqhK83bx5sxMSZpyJUoGN+BcynCII3hcSo1esWOFWTkE1nLZt2+Y8TLSR8d/Lq33jbRJCiKqgrVJhYaEL7ROuq8pwig3TyZMdTWQ4RRRczBhODAJnnnmmBQkGONS+OX4g1NirVy+n9k0+kxBCJJvnxLhCuK6qZG819RUynCIKHidWWrt373Y5QUEQf6Q6zqt9k2cA3bp1c4nfrBiFEKK6eU7IC1SV58RYyZjJ2IlwrogmMpwiCg8+8XkGC1ZQuWw4kXuADhN6TF7tG8MPaQE0mYQQIhM967y3CaOJMVREE135CIOekTecMEJyDRS+vdo3yt+AfALHKrVvIUSme9apmk6ADKcIg9cGDZIdO3a4lZYfPLLNoUOHnHeJnnJe7RuPGO1RVMUihEg1hPoZC1mgkRJAG5byYFSRB8X71HUg2shwijCU6mOIUJWG1ynbhhNq3+QvkceEVIIvFR48eLBb4YVFb0oIkVtgDDHWYBzxqshw8mE6xkzJnEQbGU4RB4MEwwkXNFVp2YBEbyrkqJTbtWuX+xsDF0nf3bt3lzKvECLtsHDEaML7XpFHyRtO6k0nZDhFHLRI8OQghDlhwgTXAHjWrFm2du1al2PkvVIYMXh+CJch/JYqMNrQYkKTCdBfwoDr3bu3NFKEEBmBEB1j0dtvv23PP/+8SxeIHf/69OnjjCqMJsZMEW1kOEUcDJbJkyfb66+/XtbbrSKeeOKJsuTsO+64w26//Xbr0KFDtfe7YcMGZzB5tW8GKK/2nUrDTAghKmPdunX26KOP2iOPPOLGpESq7xizajr+iWBTq9QL4ohIwYrqoYcesvvvv9+trCCvcZ4179XMmnYttIL2BVY7r7YdKTlixeuLbceKnbZ9cZGV7C4pM3TGjh1r99xzT1Jlueig0B4FjxbgVTr11FNtwIABUvsWQmRt/GtWu7YNzqtn/evVsy516lr9WrXsAE3DDx+yuQcP2sySg1Z05EiNxj8RDmQ4RZDly5fbLbfc4jw+0KxXM+ty2UnW7oy2zliqDIyoDR9ttJWvrbKixUf1TpAGGDdunBOijAeVe+Qw+XJe8pa82nd+fn5Kv58QQiQ6/g2pV89uK2hkFzdoaPXiFKAcLC21N/fvs8eK99jHx4ytRMc/ES5kOEUMNJFGjx7tGlXmFeRZ36/3to4jOyRVscYts3byOpv/t4V2aO8ha9OmjU2cONGF2cpDaS85U0uXLj1O7Zt8qSZNmqT0uwkhRKLjX2GtWja2sKld1zA/6fHv+X17bczOHbartDTu+CfCiQyniK20hg8f7gaNJl2a2NCfDLaGLaofHtu3bb/NeHCm7Vq5yzUKnjp1atnKiy7jXu0bmQEgqZIVmlfpFUKIbIx/fevm2d9btLR2NShA2XD4sH1121ZbcKjkhPFPhBsZThGK6Q8bNsyFyzCazvrZGc7jVFNKikts2n0fOeMJo+jdd991xhIrO/YJNM3k31iZCSFENsc/jKZnW7aywhTInOw8csRu3LrFGU+McdOmTVPOUwSQQE5EePjhh92gUTe/rvM0pcJoArbD9tguOQNf+cpXnIAlA1WrVq3s0ksvtcsvv1xGkxAi6+Nfk1q1nKcpFUYTsB22x3YZ/9iPCD/yOEWk5Bb9EapHBn6nv3U6v+K2JUPaDrVzOoyw7s16WLP6zexI6RHbULzeXl/5mr2z+m0rtcpvlTXvrLU5f5jrVlt/+MMf7KKLLlI/JyFETo1/v2nazG7IL6jwffUvON8afePrltejp9Vu1tRKjxyxw6tX2/4Jb9nuP/xfK927t9J9PLu32O7aUeSq7RDKxMsuwos8ThEAnRIGDarnOp5XufbIZV0ut5GdzrMOjTpYfl6+NarXyBlR3zv9B3ZH/2/G3QfbZft4mtA5kdEkhMil8Y/quesbVl7BW2/QIGswYoTVadvGatWvb7UbNrS8nj2t8Xe/Y83/5y9x93FDw3wnZcB+2J8IN/I4RUARl6RsxN1Ov3ugdTi78pXQvWf81DYWb7SJq96yTcUbbXDbIXbP4B9a3dp1nffpK298yXYerFwkc92U9Tb7v+e41dbnn38uIUshRM6Mf39q1tyujGM4NRg9Gp0UO/jJJ3Zk1y5rcM451vwvf7Jax/Tl1vftZ6U7dlT6+Zf27bVvF23X+BcB5HEKOYhNMmjUa1LP6TTF4zezfm3/O/+vtmb3ajt45KBNWz/VZm+e5f6tdq3a1ragXdzPtzuzrRPRXL9+vduvEELkwvjXvHZtp9MUj/0TJ9r+CRPsyObNZvv3u99Lli791xtKjor/VsYlDRo6EU2Nf+FHhlPIISESmvVsGlfcEvYd2nfC3+rV/lcX8G37j/aTqwy237xnM/cz2k1CCJEL49+gvHpxxS1PoEEDa3DRRZbXo4f7de8//2mlxcVxP8L22Q9o/As3qpsMOf4Bpo1KsvRt0df6tervfp6z+RPbum9LlZ8p7FZom2ZudhUmXo5ACCGygVcHp41KItRu1crazZl93N/2vvyKFd11T0KfZz+TDuyX4RRyZDiFHN8Tjt5zydCtaXe794z7rE6tOrZ131b73ezfJPS5Rsf2w4D1v//7v9U4YiGESK3Hid5z1SX/yitcmK7ou9+r8r2nHNvPmjVrqr0/kfsoVBdyfAPLqsJ0sfRq3tt+NvxBa1yvsW3bt9Xum3pvlWE6T+26R/cjb5MQItv4cYiGvYlwZMsWW9ehk63v2t22XH+DHVq/3v09/7prLS+Blio+HOjHXRFO5HEKOeiK+Aa9idC3xal235ljnBwBlXU/nfoT27R3Y8L7O3Lo6H46depkX/va16p51EIIUXOeeuopW7FihR1Isni8dP9+O/jhdNv/2uvW6PZvuL/V7dLFSubNi/s5GgHHjrsinMhwCjkdOx4VuyxeHz+xEQa2Gmg/OeM+q1+3ga3dvTYpT5Nnz7H9dO7cWa0HhBBZhQUcrDxctQe86UO/sr0vvGCHFi+xI8XFVq9fP2tw6SVl/35o9eoqt/HZsf34/Ypwopkt5AwaNMieeOIJ27Gicv0lzw09b3JGE3Rs3NEeu/jx4/79t7N/Y++snhR3GzuX7yzbrxBC5ML4NzeB0FnBLTe7V0Xsm/CWlcyZU+U2/H40/oUbGU4hZ/Dgwe7/2xcXuXBdMrlOycL2ty8pcj9r4BBC5Mr4N7PkoAujxZMk2PPXv1q9oUOtbqdOVqtxYyvds8dKli2zfS+9bMVPPFnlvtj+rBIZTlFAyuEhJxnl8Joi5XAhRFCVw2uKlMOjg6rqQg4P7x133OF+XvnaKkuXncx2V76+yv3M/jRoCCFyafx7rHhPWse/x/bscT9r/As/8jhFrDv4wO/0t07nH00YTyVr3llrc/4wV93BhRA5O/79pmkzuyE/OU27RHh2b7HdtaNI419EkMcpAnTo0MHGjh3rfp7/t4W2b9v+lG6f7bFdYD8aNIQQuTj+jdm5wzYcPpzS7bO9+3cebf6r8S8ayOMUISG4s846yyl6N+nSxM762RmWV1Bzd3JJcYlNu+8j27Vylw0dOtSmTp0qGQIhRM6Of33r5tmzLVtZYe2a+w12HjliN27dYgsOlWj8ixDyOEUEHuZx48ZZ69atnZGDsVNTzxOf90ZTmzZt7B//+IcGDSFETo9/GDkYOzX1PPF5bzRp/IsW8jhFjHnz5tmoUaNs8+bNVje/rp369T7W8bwOViuJzuHcMmsnr3PhuUN7D7lBY+LEidYvgZYEQgiRC+Nfk1q1bGxhU7u+YX7S499z+/a68Nyu0lKNfxFEhlMEWb58ud1yyy1lncOb9WpmXS49ydqd2TauzhM6TRumb3TVc0WLj+o1DRkyxK3kunXrlrHjF0KIVI1/g/Pq2W2NGtklDRrG1XlCp+mN/ftc9Ry6UKDxL5rIcIpwzP/hhx+2MWPGlDWkzGucZ817NrPCboXWqH2Ba9hL7znaqKAIjrhlye4S916qRx544AG7++675Z4WQgR+/GtWu7YNyqtn/evVs1Pq1HVGFMYSbVRQBEfcsujI0V6cGv+ijQyniLN+/Xp79NFH7ZFHHnE/VwUVI+iU3H777aoeEUIEGo1/ojrIcBJlCrszZsywWbNmudeaNWvcSoyVFQ0raSHAi8oRibsJIcKExj+RDDKchBBCCCESRHIEQgghhBAJIsNJCCGEECJBZDgJIYQQQiSIDCchhBBCiASR4SSEEEIIkSAynIQQQgghEkSGkxBCCCFEgshwEkIIIYRIEBlOQgghhBAJIsNJCCGEECJBZDgJIYQQQiSIDCchhBBCiASR4SSEEEIIkSAynIQQQgghEkSGkxBCCCFEgshwEkIIIYRIEBlOQgghhBAJIsNJCCGEEMIS4/8HN+GwCQqQhY4AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Visualisation de la coloration 3-chromatique du graphe de Petersen\n",
+    "import math\n",
+    "# Positions canoniques : pentagone externe + pentagramme interne\n",
+    "pos = {}\n",
+    "for i in range(5):\n",
+    "    ang = math.pi/2 + 2*math.pi*i/5\n",
+    "    pos[i] = (2.0*math.cos(ang), 2.0*math.sin(ang))           # externe (rayon 2)\n",
+    "    ang2 = math.pi/2 + 2*math.pi*i/5 + math.pi/5               # interne decale\n",
+    "    pos[5+i] = (1.0*math.cos(ang2), 1.0*math.sin(ang2))        # interne (rayon 1)\n",
+    "\n",
+    "palette = ['#e41a1c', '#377eb8', '#4daf4a']  # rouge / bleu / vert\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6, 6))\n",
+    "for a, b in edges:\n",
+    "    x = [pos[a][0], pos[b][0]]; y = [pos[a][1], pos[b][1]]\n",
+    "    ax.plot(x, y, 'k-', alpha=0.4, zorder=1)\n",
+    "for v in range(N):\n",
+    "    ax.scatter(*pos[v], c=palette[optimal_color[v]], s=420, edgecolors='black',\n",
+    "               linewidths=1.5, zorder=2)\n",
+    "    ax.annotate(str(v), pos[v], ha='center', va='center', color='white',\n",
+    "                fontsize=11, fontweight='bold', zorder=3)\n",
+    "ax.set_title(\"Petersen : coloration optimale chi = %d\" % chromatic)\n",
+    "ax.set_aspect('equal'); ax.axis('off')\n",
+    "handles = [mpatches.Patch(color=palette[c], label='Couleur %d' % c) for c in range(chromatic)]\n",
+    "ax.legend(handles=handles, loc='upper right', framealpha=0.9)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1d52c8c",
+   "metadata": {},
+   "source": [
+    "## 5. Glouton vs solveur : ce que demontre Petersen\n",
+    "\n",
+    "Le graphe de Petersen illustre trois lecons :\n",
+    "1. **L'heuristique est sensible a l'ordre** - 3 ou 4 couleurs selon comment on parcourt les sommets, pour le meme graphe.\n",
+    "\n",
+    "2. **Seul le solveur prouve l'optimalite** - le `unsat` a `k=2` est une preuve formelle d'impossibilite, pas un constat d'echec.\n",
+    "\n",
+    "3. **La recherche lineaire sur k est efficace** - on ne resout pas un seul gros probleme mais une suite de decisions `sat`/`unsat`, chacune rapide par propagation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8467425b",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices ci-dessous generalisent la coloration a des variantes : forcer un nombre chromatique plus eleve (1), appliquer la coloration a un probleme concret de planification (2), et enumerer toutes les colorations possibles (3). Chaque stub est self-contained : les fonctions utilitaires (`edges`, `adj`, modele Z3) sont definies dans les sections precedentes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5eb3062",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 - Forcer une quatrieme couleur\n",
+    "\n",
+    "Ajoutez une arete au graphe de Petersen de maniere a creer une **clique de taille 4** (4 sommets tous relies deux a deux), puis recalculez le nombre chromatique. Une clique de taille `n` impose `chi >= n` (chaque sommet d'une clique doit avoir une couleur distincte).\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Etapes** : choisir 4 sommets, lister les aretes manquantes pour qu'ils forment une clique, construire un nouveau modele avec les aretes supplementaires, relancer la recherche lineaire et verifier `chi == 4`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "81ee4a75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:29.346326Z",
+     "iopub.status.busy": "2026-07-11T16:21:29.345187Z",
+     "iopub.status.idle": "2026-07-11T16:21:29.357088Z",
+     "shell.execute_reply": "2026-07-11T16:21:29.354813Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : forcez chi = 4 en ajoutant une clique de taille 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : ajouter une arete creant une clique de taille 4, recalculer chi\n",
+    "# TODO etudiant :\n",
+    "# Etape 1 : choisir 4 sommets et lister les aretes a ajouter pour qu'ils forment une clique\n",
+    "# Etape 2 : construire un nouveau modele avec les aretes supplementaires\n",
+    "# Etape 3 : relancer la recherche lineaire et verifier chi == 4\n",
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 1 a completer : forcez chi = 4 en ajoutant une clique de taille 4\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "460bcc21",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 - Planification d'examens\n",
+    "\n",
+    "La planification d'examens est une **coloration deguisee** : les sommets sont les examens, les aretes relient deux examens partageant au moins un etudiant (conflit), et les couleurs sont les creneaux horaires. Le nombre chromatique donne le nombre minimal de creneaux sans conflit.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Etapes** : definir un graphe de conflits (5-6 examens avec des chevauchements d'etudiants), trouver le nombre minimal de creneaux via la recherche lineaire, afficher l'emploi du temps par creneau."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "48da44b7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:29.364565Z",
+     "iopub.status.busy": "2026-07-11T16:21:29.363682Z",
+     "iopub.status.idle": "2026-07-11T16:21:29.374826Z",
+     "shell.execute_reply": "2026-07-11T16:21:29.372819Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : planifiez les examens par coloration de graphe\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : planification d'examens (coloration deguisee)\n",
+    "# TODO etudiant :\n",
+    "# Etape 1 : definir votre graphe de conflits (sommets = examens, aretes = etudiants communs)\n",
+    "# Etape 2 : trouver le nombre minimal de creneaux via la recherche lineaire\n",
+    "# Etape 3 : afficher l'emploi du temps par creneau\n",
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 2 a completer : planifiez les examens par coloration de graphe\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdbc9cb7",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 - Compter les 3-colorations\n",
+    "\n",
+    "Combien de colorations distinctes a 3 couleurs admet le graphe de Petersen ? On enumere les solutions en ajoutant a chaque fois une contrainte d'exclusion de la solution trouvee, jusqu'a `unsat`.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Etapes** : boucle qui resout, compte la solution, puis l'exclut (`Or(C[v] != sol[v])`) jusqu'a `unsat` ; comparer au resultat attendu **120** ; diviser par `3! = 6` pour obtenir le nombre de colorations a permutation de couleurs pres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a178f6c2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:21:29.382834Z",
+     "iopub.status.busy": "2026-07-11T16:21:29.381890Z",
+     "iopub.status.idle": "2026-07-11T16:21:29.392175Z",
+     "shell.execute_reply": "2026-07-11T16:21:29.390525Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : enumerez les 3-colorations (attendu : 120 total, 20 a permutation pres)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : compter les 3-colorations en enumerant les solutions\n",
+    "# TODO etudiant :\n",
+    "# Etape 1 : boucle qui resout, puis exclut la solution trouvee, jusqu'a UNSAT\n",
+    "# Etape 2 : compter les solutions ; comparer a 120\n",
+    "# Etape 3 : diviser par 3! = 6 pour obtenir les colorations a permutation pres\n",
+    "nb_colorations = None  # TODO etudiant\n",
+    "print(\"Exercice 3 a completer : enumerez les 3-colorations (attendu : 120 total, 20 a permutation pres)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d1e30c1",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "La coloration de graphe cristallise la difference entre **heuristique** et **preuve**. Le glouton first-fit est rapide mais myope : il offre 3 ou 4 couleurs selon l'ordre, sans jamais certifier l'optimum. Z3, par la **recherche lineaire sur k** combinee aux verdicts `sat`/`unsat`, trouve le nombre chromatique `chi = 3` **et prouve qu'il est minimal** (`k=2` unsat).\n",
+    "\n",
+    "\n",
+    "\n",
+    "Cette double capacity - trouver une solution **et** certifier l'impossibilite de faire mieux - est le coeur de l'apport SMT. Elle se generalize a tous les problemes d'optimisation combinatoire ou l'on veut non pas une bonne solution, mais la **meilleure prouvee**."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

New substance notebook in the **Z3-Python** series (EPIC **#1206** Prong B). Ports the C# graph coloring example ([`SymbolicAI/SMT/Z3/12_Graph_Coloring_Petersen.ipynb`](../blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/12_Graph_Coloring_Petersen.ipynb)) to **pyz3**. The B2 MkIte section (Z3.Linq DSL-specific) is dropped per the port convention.

> **STACKED on #6143** (Z3-Python-10 Cryptarithmes). Merge **#6141 -> #6143 -> this** in order; each retargets to main clean (same pattern as the #6134 -> #6141 re-stack). Sequential #1206 slices keep the README consistent (count 10->11 on top of 09->10).

**Scope (atomic)**: 1 new notebook + README update (count 10->11, table row 11, fil pedagogique item 11).

## Why graph coloring (Prong B, EPIC #3801) — maximally different registre

Graph **k-coloring is NP-complete**. The Petersen graph has chromatic number `chi = 3` (non-trivial: not bipartite chi=2). The **linear k-search** finds chi=3 **and proves it minimal** (`k=2 -> unsat` is a formal proof of non-bipartiteness). This is the decisive SMT capability vs heuristics: the greedy first-fit finds 3 or 4 colors depending on vertex order and can **never certify optimality**; Z3 proves the optimum. This notebook combines graph theory + optimization + satisfiability-proof in a new domain (graphs), distinct from notebooks 08 (optimization), 09 (satisfiability puzzle), 10 (integer arithmetic).

## Execution proof (EXEC_PROVED, rule C.2)

- `nbconvert --execute` end-to-end, kernel `python3` (z3 4.15.4)
- **10 code cells, all execution_count set, 0 errors**
- **Chromatic search**: `k=1 -> UNSAT`, `k=2 -> UNSAT`, `k=3 -> SAT` -> **chi(Petersen) = 3 PROVEN**
- **Optimal coloring**: [0,1,2,0,1,1,0,0,2,2] (verified: no monochrome edge)
- **Comparison**: greedy natural order = 3 colors, greedy bad order = 4 colors, Z3 = 3 colors PROVEN minimal
- **matplotlib visualization**: 3-colored Petersen graph (PNG inline) - visual output distinct from text/table outputs of prior notebooks
- 3 C.1-safe exercise stubs (force chi=4 via K4 clique, exam scheduling as disguised coloring, count 3-colorings = 120 total / 20 up to permutation)
- ASCII-only notebook (Z3-Python family convention; README FR-accented); CRLF=0
- Repo validator `notebook_tools.py validate`: 0 errors

See #1206