### PR TITLE
fix(sudoku): restore FR accents in Sudoku-6-AIMA-CSP-Csharp comments+prose (#2876)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -464,7 +464,7 @@
     "une cellule donnée en tenant compte des contraintes de ligne, colonne et bloc.\n",
     "\n",
     "**Indice :**\n",
-    "Parcourez la ligne, colonne et bloc de la cellule et excluez les valeurs déjà presentees.\n"
+    "Parcourez la ligne, colonne et bloc de la cellule et excluez les valeurs déjà présentées.\n"
    ]
   },
   {
@@ -477,7 +477,7 @@
     "public HashSet<int> GetCellDomain(int[,] grid, int row, int col)\n",
     "{\n",
     "    // TODO: Retournez l'ensemble des valeurs possibles pour la cellule (row, col)\n",
-    "    // en excluant les valeurs déjà presentees dans la ligne, colonne et bloc\n",
+    "    // en excluant les valeurs déjà présentées dans la ligne, colonne et bloc\n",
     "    return null; // TODO etudiant\n",
     "}\n"
    ]
@@ -531,7 +531,7 @@
     "        if (csp.IsComplete(assignment))\n",
     "            return assignment;\n",
     "\n",
-    "        // Choisir la première variable non assignee (ordre naif)\n",
+    "        // Choisir la première variable non assignée (ordre naif)\n",
     "        var unassigned = csp.Variables.Where(v => !assignment.ContainsKey(v)).ToList();\n",
     "        var var = unassigned[0];\n",
     "\n",
@@ -577,7 +577,7 @@
     "Heuristique de **sélection de variable** : choisir la variable avec le plus petit domaine restant.\n",
     "\n",
     "### LCV (Least Constraining Value)\n",
-    "Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui éliminé le moins de possibilites chez les voisins."
+    "Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui éliminé le moins de possibilités chez les voisins."
    ]
   },
   {
@@ -620,7 +620,7 @@
     "{\n",
     "    /// <summary>\n",
     "    /// MRV : Selectionne la variable avec le moins de valeurs viables.\n",
-    "    /// En cas d'egalite, utilise le degre (nombre de voisins non assignés).\n",
+    "    /// En cas d'égalité, utilise le degré (nombre de voisins non assignés).\n",
     "    /// </summary>\n",
     "    public static TVariable SelectMRV<TVariable, TValue>(\n",
     "        CSP<TVariable, TValue> csp,\n",
@@ -638,13 +638,13 @@
     "            return currentDomains[v].Count(val => csp.IsConsistent(v, val, assignment));\n",
     "        }\n",
     "\n",
-    "        // Degre : nombre de voisins non assignés\n",
+    "        // Degré : nombre de voisins non assignés\n",
     "        int Degree(TVariable v)\n",
     "        {\n",
     "            return csp.Neighbors[v].Count(n => !assignment.ContainsKey(n));\n",
     "        }\n",
     "\n",
-    "        // MRV croissant, puis degre decroissant\n",
+    "        // MRV croissant, puis degré décroissant\n",
     "        return unassigned\n",
     "            .OrderBy(v => RemainingValues(v))\n",
     "            .ThenByDescending(v => Degree(v))\n",
@@ -653,7 +653,7 @@
     "\n",
     "    /// <summary>\n",
     "    /// LCV : Ordonne les valeurs par nombre de conflits croissant.\n",
-    "    /// La valeur qui éliminé le moins de possibilites est essayee en premier.\n",
+    "    /// La valeur qui éliminé le moins de possibilités est essayée en premier.\n",
     "    /// </summary>\n",
     "    public static IEnumerable<TValue> OrderLCV<TVariable, TValue>(\n",
     "        CSP<TVariable, TValue> csp,\n",


### PR DESCRIPTION
## Summary

Bounded #2876 accent restoration on **Sudoku-6-AIMA-CSP-Csharp** (the C# twin). The Python twin was already fully accented (243 UTF-8 accents); the C# twin had **inconsistent partial de-accentuation** — accented words alongside de-accented ones in the same comments (e.g. "déjà presentees", "voisins non assignés ... utilise le degre"). R6 a-cote (1/lane/day), genuine .NET family variety.

## Scope (atomic)

**11 accent restorations** in 2 markdown prose cells (8, 11 - exercice instructions) + 3 code cells (9, 10, 12 - `//` and `///` comments):
- `presentees` -> `présentées`, `possibilites` -> `possibilités`, `essayee` -> `essayée`
- `egalite` -> `égalité`, `degre`/`Degre` -> `degré`/`Degré`, `decroissant` -> `décroissant`, `assignee` -> `assignée`

## What is NOT touched (deliberate)

- **Code-cell string literals that affect output** (`"ordre naif -- peut etre long"` in cell 30 WriteLine): intentionally left alone. Restoring those requires re-execution to regenerate the output honestly (Stop & Repair). A separate re-exec PR will handle output-affecting strings. Mixing them here would either hand-edit output (BANNED) or require a slow/brittle .NET headless re-exec (cell 30 is a ~60s backtracking benchmark).
- **`Degree` identifier** (C# method name): preserved. Word-boundary regex `\bDegre\b` does not match "Degree" (no boundary before final "e").
- Broad/false-positive stems (`complet`, `a`, `la`) per the #2876 convergence-gate caution (c.107): skipped.

## Execution proof (C.2 exception - comment/prose-only)

- **Outputs byte-identical** (verified programmatically: outputs array unchanged, exec_counts 1-18 intact, cell count 40/40). Comment/prose changes cannot affect .NET output.
- **No hand-edited output** (Stop & Repair compliant).
- Raw-text regex (no json round-trip) preserves source format (single-string source cells stay single-string, no structural churn).
- CRLF=0, UTF-8 direct preserved (no escaped-unicode mode flip).
- Repo validator: Errors: 0.

See #2876