### PR TITLE
Add: Z3-Python-12 Real Arithmetic (pyz3 port of C# 16_RealArithmetic) [EPIC #1206]

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md
@@ -4,7 +4,7 @@
 
 ## Série en quelques mots
 
-L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **11 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée, à l'ordonnancement combinatoire, aux énigmes logiques (CSP), à l'arithmétique symbolique (cryptarithmes), à la coloration de graphe (NP-complet) et au pont déclaratif avec la série sœur Z3.Linq (C#).
+L'API z3-py expose l'intégralité du solveur Z3 en Python — `Solver`, `Optimize`, tactiques, théories `BitVec`/`Array`/`String`. Série complète de **12 notebooks** (z3-solver + matplotlib), de la satisfaction de contraintes à l'optimisation avancée, à l'ordonnancement combinatoire, aux énigmes logiques (CSP), à l'arithmétique symbolique (cryptarithmes), à la coloration de graphe (NP-complet), à l'arithmétique réelle exacte (irrationnels algébriques) et au pont déclaratif avec la série sœur Z3.Linq (C#).
 
 **À qui s'adresse cette série** : étudiants en IA, développeurs Python souhaitant découvrir la programmation par contraintes, et tout curieux voulant comprendre comment exprimer un problème non pas comme un algorithme de résolution, mais comme un ensemble de contraintes que le solveur satisfait automatiquement. Aucun prérequis en logique formelle n'est supposé : les notebooks partent de la syntaxe de base de z3-py pour monter progressivement vers l'optimisation et la modélisation de problèmes combinatoires.
 
@@ -57,6 +57,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 | 09 | [L'énigme d'Einstein (Zebra puzzle)](Z3-Python-09-Enigme-Einstein.ipynb) | Encodage par position, `Distinct`, adjacences, satisfiabilité vs optimisation, unicité prouvée | ~30 min | PRODUCTION |
 | 10 | [Cryptarithmes (SEND + MORE = MONEY)](Z3-Python-10-Cryptarithmetic.ipynb) | `Int`, `Distinct`, équation positionnelle, propagation vs brute force, retenues déduites | ~25 min | PRODUCTION |
 | 11 | [Coloration de graphe (Petersen)](Z3-Python-11-Graph-Coloring.ipynb) | `Int` par sommet, contraintes d'arêtes `!=`, recherche linéaire du nombre chromatique, `unsat` = preuve d'optimalité | ~30 min | PRODUCTION |
+| 12 | [Arithmétique réelle](Z3-Python-12-Real-Arithmetic.ipynb) | Théorie `Real`, solution rationnelle exacte, irrationnel algébrique (racine de 2 comme `root-obj`), preuve d'absence sur R (`unsat`) | ~25 min | PRODUCTION |
 
 ### Fil pédagogique
 
@@ -71,6 +72,7 @@ Une série sœur existe en C# : [SymbolicAI/Z3/](../Z3/README.md), basée sur le
 9. **Notebook 09** illustre la **satisfiabilité** pure (versus l'optimisation du 08) sur l'énigme d'Einstein : l'encodage par position (25 variables entières) transforme un puzzle qualitatif en contraintes arithmétiques (`Distinct`, égalités, adjacences), et `Solver` trouve l'unique solution en quelques millisecondes là où la brute force affronte (5!)^5 = 24,9 milliards de combinaisons — l'unicité est **prouvée** par négation (`unsat`)
 10. **Notebook 10** généralise à l'**arithmétique symbolique sur entiers** avec les cryptarithmes (`SEND + MORE = MONEY`) : chaque lettre est un `Int` dans `{0..9}`, `Distinct` impose l'unicité, et l'équation positionnelle (`1000·S + 100·E + …`) est résolue par propagation — Z3 trouve l'unique solution (`9567 + 1085 = 10652`) en millisecondes tandis que la brute force énumère `P(10,8) = 1 814 400` candidats (~9 s), illustrant le gain du paradigme déclaratif
 11. **Notebook 11** aborde la **coloration de graphe** (NP-complet) sur le graphe de Petersen : une variable `Int` par sommet, des contraintes d'arêtes `C_a != C_b`, et une **recherche linéaire sur k** qui trouve le nombre chromatique `chi = 3` **et le prouve minimal** (`k = 2` → `unsat`). Là où le glouton first-fit hésite (3 ou 4 couleurs selon l'ordre) sans jamais certifier l'optimum, le verdict `unsat` de Z3 est une **preuve formelle** d'impossibilité — la double capacité (trouver ET prouver) est le cœur de l'apport SMT en optimisation combinatoire
+12. **Notebook 12** passe aux **réels** via la théorie `Real` : trois capacités inaccessibles au calcul numérique flottant — solution rationnelle **exacte** (`x + y = 1`, `x − y = 3` → `x = 2`, `y = −1`, sans aucun arrondi), **irrationnel algébrique** exact (√2 renvoyé comme racine d'un polynôme, affichée `1.4142135623?` — la racine algébrique, pas le flottant tronqué `1.4142…`), et **preuve d'absence sur R** (`x² + 1 = 0` → `unsat`, établi sur le corps des réels tout entier, impossible par échantillonnage numérique). Le saut qualitatif : raisonner sur l'algèbre exacte plutôt que calculer des approximations
 
 ## Concepts clés
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-12-Real-Arithmetic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-12-Real-Arithmetic.ipynb
@@ -1,0 +1,458 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e3ec7b6a",
+   "metadata": {},
+   "source": [
+    "← [11 - Coloration de graphe](Z3-Python-11-Graph-Coloring.ipynb) | [README Z3-Python](README.md)\n",
+    "\n",
+    "# 12. Arithmetique reelle : raisonner sur les irrationnels exacts\n",
+    "\n",
+    "Jusqu'ici nous avons raisonne sur des **entiers** (coloration de graphe, cryptarithmes, ordonnancement). Z3 sait aussi raisonner sur les **reels** via la theorie `Real` (SMT-LIB `Reals`). C'est une capacite profondement differente : les solutions peuvent etre **rationnelles exactes** (pas d'arrondi flottant), des **irrationnels algebriques** (racine carree de 2 representee comme racine d'un polynome, pas comme 1.4142...), et l'absence de solution peut etre **prouvee** (`unsat`) sur le corps des reels tout entier.\n",
+    "\n",
+    "Ce notebook explore les trois postures : arithmetique lineaire (solution rationnelle exacte), non-lineaire (irrationnel algebrique), et preuve d'impossibilite sur R. Aucun `float`, aucun `sqrt()` approche : tout est symbolique.\n",
+    "\n",
+    "> Port pyz3 du notebook C# [`16_RealArithmetic.ipynb`](../Z3/16_RealArithmetic.ipynb). EPIC #1206, Prong B. (La section B7 Rational du C#, specifique au DSL Z3.Linq, n'est pas portee.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f066c472",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:48:43.134209Z",
+     "iopub.status.busy": "2026-07-11T16:48:43.133477Z",
+     "iopub.status.idle": "2026-07-11T16:48:43.201977Z",
+     "shell.execute_reply": "2026-07-11T16:48:43.200296Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imports OK : z3-solver (theorie Real)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from z3 import *\n",
+    "print(\"Imports OK : z3-solver (theorie Real)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec9c4659",
+   "metadata": {},
+   "source": [
+    "## 1. La theorie des reels (SMT-LIB `Real`)\n",
+    "\n",
+    "En pyz3, `Real('x')` cree une variable reelle (theorie des rationnels etant donne que Z3 represente les reels comme des rationnels ou des racines algebriques). Les operations `+`, `*`, comparaisons `>=` et egalites `==` s'appliquent. Le solveur decide la satisfiabilite sur cette theorie via des procedure de decision (arithmetique reelle lineaire = simplex ; non-lineaire = methodes de cylindres algebriques)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64220833",
+   "metadata": {},
+   "source": [
+    "## 2. Arithmetique reelle lineaire : solution rationnelle exacte\n",
+    "\n",
+    "Systeme lineaire `x + y = 1`, `x - y = 3`. Solution `x = 2`, `y = -1`. Ce sont des **rationnels exacts**, pas des flottants : Z3 ne fait jamais d'arrondi. Tout le raisonnement est symbolique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2e54e434",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:48:43.208628Z",
+     "iopub.status.busy": "2026-07-11T16:48:43.208038Z",
+     "iopub.status.idle": "2026-07-11T16:48:43.234975Z",
+     "shell.execute_reply": "2026-07-11T16:48:43.233779Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Systeme x+y=1, x-y=3 : sat\n",
+      "  x = 2\n",
+      "  y = -1\n",
+      "-> Solution rationnelle EXACTE (pas d'arrondi flottant).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Systeme lineaire x+y=1, x-y=3 : solution rationnelle EXACTE\n",
+    "x, y = Reals('x y')\n",
+    "s1 = Solver()\n",
+    "s1.add(x + y == 1)\n",
+    "s1.add(x - y == 3)\n",
+    "st1 = s1.check()\n",
+    "print(\"Systeme x+y=1, x-y=3 : %s\" % st1)\n",
+    "if st1 == sat:\n",
+    "    m = s1.model()\n",
+    "    print(\"  x = %s\" % m[x])\n",
+    "    print(\"  y = %s\" % m[y])\n",
+    "print(\"-> Solution rationnelle EXACTE (pas d'arrondi flottant).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8de9b5bc",
+   "metadata": {},
+   "source": [
+    "## 3. Non-lineaire : trouver un irrationnel exact (racine de 2)\n",
+    "\n",
+    "Trouvons `xs` tel que `xs^2 = 2`, avec `xs > 0` (la racine positive). La solution n'est PAS le flottant `1.41421356...` : Z3 renvoie une **racine algebrique exacte** (un `root-obj` = k-ieme racine d'un polynome a coefficients rationnels), affichee ici en notation decimale avec un `?` final qui signale \"representation approchee d'un nombre exact\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "13915e24",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:48:43.240513Z",
+     "iopub.status.busy": "2026-07-11T16:48:43.239877Z",
+     "iopub.status.idle": "2026-07-11T16:48:43.256855Z",
+     "shell.execute_reply": "2026-07-11T16:48:43.255800Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "xs^2 = 2, xs > 0 : sat\n",
+      "  xs = 1.4142135623?\n",
+      "  -> Ce n'est PAS 1.4142... mais une RACINE ALGEBRIQUE exacte.\n",
+      "     (le suffixe '?' = affichage approche d'un root-obj exact ; x^2 - 2 = 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Trouver xs tel que xs^2 = 2, xs > 0 (l'irrationnel sqrt(2))\n",
+    "xs = Real('xs')\n",
+    "s2 = Solver()\n",
+    "s2.add(xs * xs == 2)\n",
+    "s2.add(xs > 0)\n",
+    "st2 = s2.check()\n",
+    "print(\"xs^2 = 2, xs > 0 : %s\" % st2)\n",
+    "if st2 == sat:\n",
+    "    m = s2.model()\n",
+    "    w = m[xs]\n",
+    "    print(\"  xs = %s\" % w)\n",
+    "    print(\"  -> Ce n'est PAS 1.4142... mais une RACINE ALGEBRIQUE exacte.\")\n",
+    "    print(\"     (le suffixe '?' = affichage approche d'un root-obj exact ; x^2 - 2 = 0)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d4ae8f8",
+   "metadata": {},
+   "source": [
+    "## 4. Prouver l'absence de racine reelle (UNSAT)\n",
+    "\n",
+    "`xn^2 + 1 = 0` n'a pas de solution reelle (le discriminant est negatif, les racines sont imaginaires `+/-i`). Z3 le **prouve** : `unsat`. C'est une preuve sur le corps des reels tout entier - il n'existe AUCUN reel satisfaisant cette equation. Aucune approche numerique (essayer des valeurs, echantillonner) ne peut etablir cette absence ; seule la decision algebrique le peut."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "80f3a454",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:48:43.262195Z",
+     "iopub.status.busy": "2026-07-11T16:48:43.261803Z",
+     "iopub.status.idle": "2026-07-11T16:48:43.274382Z",
+     "shell.execute_reply": "2026-07-11T16:48:43.273228Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "xn^2 + 1 = 0 sur les reels : unsat\n",
+      "  -> UNSAT : Z3 PROUVE qu'il n'existe pas de racine reelle.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Prouver que xn^2 + 1 = 0 n'a PAS de solution reelle\n",
+    "xn = Real('xn')\n",
+    "s3 = Solver()\n",
+    "s3.add(xn * xn + 1 == 0)\n",
+    "st3 = s3.check()\n",
+    "print(\"xn^2 + 1 = 0 sur les reels : %s\" % st3)\n",
+    "if st3 == unsat:\n",
+    "    print(\"  -> UNSAT : Z3 PROUVE qu'il n'existe pas de racine reelle.\")\n",
+    "else:\n",
+    "    print(\"  -> inattendu (devrait etre impossible sur R).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bae86e3",
+   "metadata": {},
+   "source": [
+    "## 5. Application geometrique : l'inegalite triangulaire\n",
+    "\n",
+    "Trois longueurs `a, b, c` forment un triangle ssi chacune est <= la somme des deux autres (`a + b >= c`, etc.). Pour `(3, 4, 5)` c'est SAT (triangle rectangle canonique) ; pour `(1, 2, 5)` c'est UNSAT (1 + 2 = 3 < 5, le plus long cote est trop long). La preuve est exacte, pas une verification numerique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "312ec23e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:48:43.280417Z",
+     "iopub.status.busy": "2026-07-11T16:48:43.279453Z",
+     "iopub.status.idle": "2026-07-11T16:48:43.291880Z",
+     "shell.execute_reply": "2026-07-11T16:48:43.290939Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Triangle(3, 4, 5) : sat\n",
+      "Triangle(1, 2, 5) : unsat\n",
+      "  -> UNSAT : impossible (1 + 2 = 3 < 5, le plus long cote est trop long).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Trois longueurs forment-elles un triangle ? (inegalite triangulaire)\n",
+    "a, b, c = Reals('a b c')\n",
+    "def triangle(va, vb, vc):\n",
+    "    return And(va + vb >= vc, va + vc >= vb, vb + vc >= va)\n",
+    "\n",
+    "# Triangle (3, 4, 5) ?\n",
+    "sA = Solver()\n",
+    "sA.add(triangle(RealVal(3), RealVal(4), RealVal(5)))\n",
+    "print(\"Triangle(3, 4, 5) : %s\" % sA.check())\n",
+    "\n",
+    "# Triangle (1, 2, 5) ?\n",
+    "sB = Solver()\n",
+    "sB.add(triangle(RealVal(1), RealVal(2), RealVal(5)))\n",
+    "stB = sB.check()\n",
+    "print(\"Triangle(1, 2, 5) : %s\" % stB)\n",
+    "if stB == unsat:\n",
+    "    print(\"  -> UNSAT : impossible (1 + 2 = 3 < 5, le plus long cote est trop long).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56a96676",
+   "metadata": {},
+   "source": [
+    "## 6. Ce que ce notebook a demontre\n",
+    "\n",
+    "Trois capacites distinctes de la theorie des reels :\n",
+    "1. **Solution rationnelle exacte** (linearite) - pas de flottant, pas d'arrondi.\n",
+    "\n",
+    "2. **Irrationnel algebrique exact** (non-lineaire) - racine de 2 comme `root-obj`, pas comme decimal tronque.\n",
+    "\n",
+    "3. **Preuve d'absence sur R** (`unsat`) - aucune racine reelle a `x^2 + 1 = 0`, preuve globale impossible par echantillonnage.\n",
+    "\n",
+    "\n",
+    "\n",
+    "Ces trois postures sont inaccessibles au calcul numerique classique (float, `math.sqrt`). Elles illustrent pourquoi la theorie SMT des reels est un outil de raisonnement, pas juste de calcul."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f3daadf",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices\n",
+    "\n",
+    "Les trois exercices ci-dessous vous font manipuler la theorie des reels sur des variantes : racine cubique (1), discriminant d'un trinome (2), optimisation sur les reels (3). Chaque stub est self-contained : les fonctions (`Real`, `Reals`, `Solver`) sont definies dans les sections precedentes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9136f17",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 - Racine cubique de 2\n",
+    "\n",
+    "Trouvez `c` tel que `c^3 = 2`, avec `c > 0`. La racine cubique de 2 est aussi un irrationnel algebrique, mais de **degre 3** (vs degre 2 pour la racine carree). Affichez le temoin et comparez la notation.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Etapes** : `c = Real('c')`, ajouter `c * c * c == 2` et `c > 0`, checker, afficher le modele."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "26df7709",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:48:43.297948Z",
+     "iopub.status.busy": "2026-07-11T16:48:43.297370Z",
+     "iopub.status.idle": "2026-07-11T16:48:43.305365Z",
+     "shell.execute_reply": "2026-07-11T16:48:43.304015Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : trouvez la racine cubique exacte de 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : trouver c tel que c^3 = 2 (racine cubique de 2)\n",
+    "# TODO etudiant :\n",
+    "# Etape 1 : c = Real('c')\n",
+    "# Etape 2 : solver.add(c * c * c == 2, c > 0)\n",
+    "# Etape 3 : solver.check() + afficher le root-obj (degre 3 vs degre 2 pour sqrt(2))\n",
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 1 a completer : trouvez la racine cubique exacte de 2\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a79d71ce",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 - Discriminant et nombre de racines\n",
+    "\n",
+    "Un trinome `q^2 + bq + c = 0` a des racines reelles ssi son **discriminant** `D = b^2 - 4c >= 0`.\n",
+    "\n",
+    "- (a) Prouvez que `q^2 - 3q + 2 = 0` a une racine reelle (`sat` ; deux racines : 1 et 2).\n",
+    "\n",
+    "- (b) Prouvez que `q^2 + q + 1 = 0` n'en a aucune (`unsat` ; D = -3 < 0).\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Etapes** : pour chaque polynome, encoder `= 0` et checker. Le verdict `sat`/`unsat` confirme le signe du discriminant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "dc5cd871",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:48:43.310672Z",
+     "iopub.status.busy": "2026-07-11T16:48:43.310096Z",
+     "iopub.status.idle": "2026-07-11T16:48:43.318664Z",
+     "shell.execute_reply": "2026-07-11T16:48:43.316947Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : discriminez les trinomes (SAT vs UNSAT)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : discriminant et racines reelles\n",
+    "# TODO etudiant :\n",
+    "# (a) q^2 - 3q + 2 = 0 a une racine reelle (SAT, deux racines 1 et 2)\n",
+    "# (b) q^2 + q + 1 = 0 n'en a aucune (UNSAT, D = -3 < 0)\n",
+    "# Etape 1 : encoder chaque polynome = 0\n",
+    "# Etape 2 : solver.check() -> SAT puis UNSAT\n",
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 2 a completer : discriminez les trinomes (SAT vs UNSAT)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82b65e00",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 - Distance minimale (optimisation sur les reels)\n",
+    "\n",
+    "Minimisez `px^2 + py^2` sous la contrainte `px + py = 4` (point de la droite le plus proche de l'origine). La solution exacte est `px = py = 2`, distance minimale `sqrt(8)`.\n",
+    "\n",
+    "\n",
+    "\n",
+    "**Indice** : utilisez `Optimize()` avec `.minimize(px*px + py*py)`. **Note** : l'optimisation non-lineaire sur les reels est delicate (Z3 peut renvoyer un point sous-optimal) ; si le minimum trouve n'est pas 8, reflechissez a pourquoi (la theorie non-lineaire reelle est decidable mais l'optimisation globale reste dure)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "734f8a7a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T16:48:43.324248Z",
+     "iopub.status.busy": "2026-07-11T16:48:43.323447Z",
+     "iopub.status.idle": "2026-07-11T16:48:43.331318Z",
+     "shell.execute_reply": "2026-07-11T16:48:43.330041Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : minimisez x^2 + y^2 sous x + y = 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : minimiser px^2 + py^2 sous px + py = 4 (point le plus proche de l'origine)\n",
+    "# TODO etudiant :\n",
+    "# Etape 1 : px, py = Reals('px py')\n",
+    "# Etape 2 : opt = Optimize(); opt.add(px + py == 4)\n",
+    "# Etape 3 : opt.minimize(px * px + py * py)\n",
+    "# Etape 4 : opt.check() -> minimum attendu = 8 en px = py = 2 (distance sqrt(8))\n",
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 3 a completer : minimisez x^2 + y^2 sous x + y = 4\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47ab358a",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "La theorie des reels de Z3 transforme le solveur en outil de **raisonnement algebrique exact**. La ou le calcul numerique flottant (`float`, `math.sqrt`) introduit des erreurs d'arrondi et ne peut jamais prouver une absence de solution, la theorie SMT `Real` offre : solutions rationnelles exactes, irrationnels algebriques (racine de 2 comme `root-obj`), et preuves d'impossibilite sur R tout entier (`unsat` pour `x^2 + 1 = 0`).\n",
+    "\n",
+    "\n",
+    "\n",
+    "Cette serie Z3-Python (notebooks 01 a 12) couvre maintenant l'eventail complet : entiers (01-06, 10, 11), satisfaction de contraintes (08 ordonnancement, 09 CSP logique, 11 graphes), tactiques (03), et ici l'**arithmetique reelle exacte** (12). Le pont avec la serie souer Z3.Linq (C#) se fait via les memes exemples portes entre Microsoft.Z3 et pyz3."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

12th notebook in the Z3-Python series: a pyz3 port of the C# [`16_RealArithmetic.ipynb`](../blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/16_RealArithmetic.ipynb), exercising the `Real` theory (SMT-LIB Reals). This is a qualitatively **new capacity** versus the integer/sat/opt/graph notebooks 08-11 — Z3 reasons over exact rationals and algebraic irrationals, not floats.

Three postures demonstrated:
1. **Exact rational solution** (linear): `x+y=1, x-y=3` -> `x=2, y=-1` (no rounding).
2. **Exact algebraic irrational** (non-linear): `xs^2=2, xs>0` -> `1.4142135623?` (a `root-obj` = k-th root of a rational-coefficient polynomial, NOT the truncated float `1.4142...`).
3. **Proof of absence on R**: `xn^2+1=0` -> `unsat` (proven on the whole real field; impossible by numerical sampling).
4. Geometric application: triangle inequality — `Triangle(3,4,5)` sat, `Triangle(1,2,5)` unsat.

EPIC **#1206** (Z3.Linq -> Python port), Prong B. **See #1206** (partial contribution to an epic; not closing).

## Execution proof (EXEC_PROVED)

`jupyter nbconvert --to notebook --execute --inplace` (python3 kernel). 8 code cells, all `execution_count` set (1-8), **0 errors**:

| Cell | Output |
|------|--------|
| imports | `Imports OK : z3-solver (theorie Real)` |
| linear system | `sat` -> `x = 2`, `y = -1` |
| sqrt(2) | `sat` -> `xs = 1.4142135623?` (positive algebraic root-obj) |
| x^2+1 | `unsat` (no real root, proven) |
| triangles | `Triangle(3,4,5): sat`, `Triangle(1,2,5): unsat` |
| 3 exercise stubs | run clean (`print("Exercice N a completer...")`) |

`grep -nE "raise NotImplementedError|assert False|1/0"` = 0 matches (C.1 safe).

## SOTA verdict (#3801)

**SOTA-OK**: the notebook executes the real Z3 `Real` theory natively via pyz3 — `Real('x')`, `RealVal(3)`, `Solver`/`Optimize` over the rationals/algebraic-numbers decision procedure. No workaround, no degraded output. The problem is non-trivial (Prong B): √2 as an algebraic root-obj and the global UNSAT proof for `x^2+1=0` exercise capacities inaccessible to `float`/`math.sqrt` — exactly the kind of engine distinction the registre targets.

## Anti-regression / port convention

- Drops the **B7 Rational DSL** section from the C# source (Z3.Linq-specific `RationalExpr` DSL; not portable to pyz3, per #1206 port convention — same as NB-11 dropping the B2 `MkIte` DSL section).
- ASCII-only except the single nav `←` arrow, matching the NB-11 family convention exactly (verified: NB-11 on `origin/main` has exactly 1 non-ASCII char = the same `←` at the same position).
- 3 exercise stubs (C.1-safe): cuberoot of 2, discriminant/SAT-vs-UNSAT trinomials, distance-minimization optimization. **Note on exercise 3**: non-linear real optimization is delicate (Z3 may return a suboptimal point) — documented honestly in the exercise hint as a known limitation of global nonlinear real optimization, not hidden.

## Catalog / scope hygiene

- `COURSE_CATALOG.generated.json` + `.md`: **byte-identical to origin/main** (catalog-pr-hygiene HARD rule respected — the daily cron / per-PR CI will register the new notebook).
- README: count 11->12, table row 12, fil pedagogique item 12. Whole-file §E audit: `Real` theory already referenced in intro (L13), comparison table (L24), learning objectives (L132) — consistent. No stale lists.
- Atomic: 1 notebook + its README update only.

## Files
- `MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/Z3-Python-12-Real-Arithmetic.ipynb` (new, 20 cells: 8 code + 12 markdown)
- `MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Python/README.md` (+3/-1)

Stacks on the merged Z3-Python 08-11 series (base = `main`, clean — no stack now that #6147/#6143/#6141 merged).