### PR TITLE
docs(genai-video): #5780 figures narrative — dissolve Video/04-Applications gallery mosaic into per-workflow vertical narration

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
@@ -17,22 +17,47 @@ Ce module présente des cas d'usage concrets et des workflows de production pour
 
 ## Aperçu — les cas d'usage production vidéo en images
 
-Ce niveau met en oeuvre les workflows complets : génération automatique de contenu éducatif, workflows créatifs, génération cloud via l'API Sora, et pipeline de production bout-en-bout. La galerie ci-dessous présente des aperçus de frames extraits des notebooks.
+Ce niveau met en oeuvre les workflows complets : génération automatique de contenu éducatif, workflows créatifs, génération cloud via l'API Sora, et pipeline de production bout-en-bout. Les aperçus de frames ci-dessous, regroupés par cas d'usage, illustrent chaque workflow.
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/vid4-educational.png" alt="Génération vidéo éducative — aperçu des frames" width="400"/><br/><sub>Vidéo éducative (04-1)</sub></td>
-<td align="center"><img src="assets/readme/vid4-creative.png" alt="Workflow créatif vidéo — séquence générée" width="400"/><br/><sub>Workflow créatif (04-2)</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/vid4-creative2.png" alt="Workflow créatif — variante de composition" width="400"/><br/><sub>Créatif variante (04-2)</sub></td>
-<td align="center"><img src="assets/readme/vid4-sora.png" alt="Génération Sora via API cloud" width="400"/><br/><sub>Sora API cloud (04-3)</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/vid4-sora2.png" alt="Génération Sora — aperçu alternatif" width="400"/><br/><sub>Sora variante (04-3)</sub></td>
-<td align="center"><img src="assets/readme/vid4-pipeline.png" alt="Pipeline vidéo production — orchestration" width="400"/><br/><sub>Pipeline production (04-4)</sub></td>
-</tr>
-</table>
+### Vidéo éducative (04-1)
+
+Génération automatique de contenu pédagogique : le workflow produit des séquences de frames illustrant un concept, prêtes à être intégrées dans un module de cours.
+
+<p align="center">
+  <img src="assets/readme/vid4-educational.png" alt="Génération vidéo éducative — aperçu des frames" width="480"/>
+</p>
+
+### Workflows créatifs (04-2)
+
+Composition créative assistée : séquences générées et leurs variantes de composition, montrant comment le workflow explore différentes mises en scène à partir d'un même prompt.
+
+<p align="center">
+  <img src="assets/readme/vid4-creative.png" alt="Workflow créatif vidéo — séquence générée" width="480"/>
+</p>
+
+<p align="center">
+  <img src="assets/readme/vid4-creative2.png" alt="Workflow créatif — variante de composition" width="480"/>
+</p>
+
+### Génération cloud via l'API Sora (04-3)
+
+Appel à l'API Sora pour la génération cloud, avec aperçus des sorties et de leurs variantes alternatives.
+
+<p align="center">
+  <img src="assets/readme/vid4-sora.png" alt="Génération Sora via API cloud" width="480"/>
+</p>
+
+<p align="center">
+  <img src="assets/readme/vid4-sora2.png" alt="Génération Sora — aperçu alternatif" width="480"/>
+</p>
+
+### Pipeline de production bout-en-bout (04-4)
+
+Orchestration complète : du prompt à la vidéo finale, enchaînant génération, post-traitement et assemblage dans un pipeline reproductible.
+
+<p align="center">
+  <img src="assets/readme/vid4-pipeline.png" alt="Pipeline vidéo production — orchestration" width="480"/>
+</p>
 
 Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 


### PR DESCRIPTION
## Summary

EPIC #5780 (figures narrative — no galleries, in-situ integration) — dissolve the mosaic `<table>` gallery in `GenAI/Video/04-Applications/README.md`. 2nd-in-family (Video/01-Foundation handled by po-2025 in #6133 per their [DONE]; this is the residual Video/04 mosaic po-2025 listed as remaining).

**Defect (firsthand, G.1):** `GenAI/Video/04-Applications/README.md` L18-37 held a 3×2 mosaic gallery (`## Aperçu` + `<table>` of 6 thumbnails `width=400`) — the #5780 defect pattern. 6 frames covered 4 production workflows (educational 04-1, creative 04-2 ×2, Sora cloud 04-3 ×2, pipeline 04-4).

**Fix (pattern of merged #6125 + #6142):** dissolve the mosaic into an aerated vertical layout grouped by the 4 workflows of the module, each with a subject-level lead-in (sourced from the README's own intro L7, not invented):
- **Vidéo éducative (04-1)** — automated pedagogical content generation
- **Workflows créatifs (04-2)** — assisted creative composition + variants
- **Génération cloud via l'API Sora (04-3)** — Sora API calls + alt previews
- **Pipeline de production bout-en-bout (04-4)** — end-to-end orchestration

## Validation (pure presentation change — #5780 convention)

| Check | Result |
|-------|--------|
| `src="assets/readme/..."` multiset | **6/6 byte-identical** (diff=0) |
| `alt="..."` multiset | **byte-identical** (diff=0) |
| `<table>` remnants | **0** (mosaic fully dissolved) |
| Figure assets (`assets/readme/*.png`) | **untouched** (0 diff in assets/) |
| MANIFEST.md provenance link | preserved |
| CRLF | **0** (`tr -cd '\r' < file \| wc -c`) |
| `git diff --stat` | **+41/−16, 1 file** |

## Conformité

- **§D anti-regression:** pure additive presentation (workflow headers + lead-ins + `<p align=center>` blocks), 0 figure/src/alt dropped.
- **Catalogue R1:** no catalog file touched (no CATALOG-STATUS marker in this sub-README).
- **MD033 inline-HTML warnings:** expected — `<p align=center>` is the GitHub-canonical image-centering idiom (same as merged #6125, #6142); #5780's bar is "no side-by-side mosaics", not "no HTML".

See #5780 (partial: GenAI/Video/04-Applications mosaic dissolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)