### PR TITLE
docs(genai-audio-01f): #5780 figures narrative — galerie mosaïque vers narration pipeline

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
@@ -17,23 +17,7 @@ Ce module couvre les fondamentaux du traitement audio par IA : reconnaissance vo
 
 ## Aperçu — les bases audio en images
 
-Ce module pose les fondamentaux du traitement audio : synthèse vocale (TTS), reconnaissance vocale (STT), et opérations de base sur le signal. La galerie ci-dessous présente le **pipeline d'analyse audio** (forme d'onde → spectrogramme → MFCC → caractéristiques) extrait du notebook fondationnel [01-3](01-3-Basic-Audio-Operations.ipynb) — les briques techniques pour comprendre ce que manipulent les modèles TTS et STT.
-
-<table>
-<tr>
-<td align="center"><img src="assets/readme/aud1-waveform.png" alt="Forme d'onde (waveform) du signal audio" width="400"/><br/><sub>Forme d'onde (01-3)</sub></td>
-<td align="center"><img src="assets/readme/aud1-spectrogram.webp" alt="Spectrogramme — décomposition temps-fréquence" width="400"/><br/><sub>Spectrogramme (01-3)</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/aud1-mfcc.png" alt="MFCC — coefficients cepstraux mel" width="400"/><br/><sub>MFCC (01-3)</sub></td>
-<td align="center"><img src="assets/readme/aud1-mfcc2.png" alt="MFCC — carte de chaleur des coefficients" width="400"/><br/><sub>MFCC heatmap (01-3)</sub></td>
-</tr>
-<tr>
-<td align="center" colspan="2"><img src="assets/readme/aud1-features.png" alt="Extraction de caractéristiques audio" width="500"/><br/><sub>Extraction de caractéristiques (01-3)</sub></td>
-</tr>
-</table>
-
-Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
+Ce module pose les fondamentaux du traitement audio : synthèse vocale (TTS), reconnaissance vocale (STT), et opérations de base sur le signal. Plutôt qu'une galerie séparée du propos, les sorties du **pipeline d'analyse audio** (forme d'onde → spectrogramme → MFCC → caractéristiques) extraites du notebook fondationnel [01-3](01-3-Basic-Audio-Operations.ipynb) sont présentées ci-dessous en séquence narrative — les briques techniques pour comprendre ce que manipulent les modèles TTS et STT. Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
 ## Notebooks
 
@@ -44,6 +28,41 @@ Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/read
 | 3 | [01-3-Basic-Audio-Operations](01-3-Basic-Audio-Operations.ipynb) | librosa, spectrogrammes, MFCC, pydub | Local | 0 |
 | 4 | [01-4-Whisper-Local](01-4-Whisper-Local.ipynb) | Whisper V3 Turbo local, batch | Local GPU | ~10 GB |
 | 5 | [01-5-Kokoro-TTS-Local](01-5-Kokoro-TTS-Local.ipynb) | Kokoro 82M, TTS légère | Local GPU | ~2 GB |
+
+**[01-3](01-3-Basic-Audio-Operations.ipynb) — Le pipeline d'analyse audio.** Ce notebook est le seul du module à produire des visualisations : il déroule la chaîne de transformations qui révèle la structure d'un signal audio, du domaine temporel brut jusqu'aux caractéristiques exploitables par les modèles. Chaque étape ci-dessous correspond à une cellule du notebook.
+
+**Étape 1 — Forme d'onde.** Le point de départ : l'amplitude du signal échantillonnée dans le temps. On y lit directement la structure alternée de silence et de parole :
+
+<p align="center">
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-waveform.png" alt="Forme d'onde (waveform) du signal audio" width="480"/></a><br>
+  <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 12) : forme d'onde — l'amplitude en fonction du temps.</em>
+</p>
+
+**Étape 2 — Spectrogramme.** Une transformée temps-fréquence (FFT) décompose ce signal en ses composantes spectrales : l'axe vertical devient la fréquence, l'intensité codant l'énergie. C'est la représentation qu'utilisent de nombreux modèles de speech :
+
+<p align="center">
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-spectrogram.webp" alt="Spectrogramme — décomposition temps-fréquence" width="420"/></a><br>
+  <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 15) : spectrogramme — décomposition temps-fréquence du même signal.</em>
+</p>
+
+**Étape 3 — MFCC.** Les coefficients cepstraux dans l'échelle mel (MFCC) condensent le spectrogramme en un petit nombre de coefficients qui captent le timbre perceptuel — la représentation de référence pour STT et classification audio. Deux vues complémentaires : la courbe des coefficients et la carte de chaleur :
+
+<p align="center">
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-mfcc.png" alt="MFCC — coefficients cepstraux mel" width="460"/></a><br>
+  <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 20, sortie 1) : MFCC — coefficients cepstraux mel.</em>
+</p>
+
+<p align="center">
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-mfcc2.png" alt="MFCC — carte de chaleur des coefficients" width="460"/></a><br>
+  <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 20, sortie 3) : MFCC en carte de chaleur — même information, vue alternative.</em>
+</p>
+
+**Étape 4 — Extraction de caractéristiques.** Aboutissement du pipeline : les descripteurs extraits (centroid spectral, RMS, ZCR…) alimentent directement les comparaisons et benchmarks des niveaux suivants :
+
+<p align="center">
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-features.png" alt="Extraction de caractéristiques audio" width="480"/></a><br>
+  <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 28) : extraction des caractéristiques audio — le pipeline complet résumé.</em>
+</p>
 
 ## Prérequis
 


### PR DESCRIPTION
## Contexte

Epic #5780 — feuille **GenAI/Audio/01-Foundation** (README enfant). Complète la feuille GenAI/Audio (parent #6148 merged).

## Cas particulier — pipeline séquentiel

Contrairement aux feuilles où les figures venaient de notebooks distincts (regroupables par notebook), les **5 figures proviennent toutes du notebook 01-3** et forment un **pipeline pédagogique séquentiel** : forme d'onde → spectrogramme → MFCC → caractéristiques. La grille 2×3 obscureissait cette séquence ; la narration verticale la révèle.

## Changements

La galerie `<table>` 5-figures (L22-34) devient une séquence narrative verticale où chaque étape du pipeline obtient une légende interprétant la transformation qu'elle révèle :

| Étape | Figure | Cellule | Transformation révélée |
|-------|--------|---------|------------------------|
| 1 | aud1-waveform | cell 12 | amplitude vs temps (signal brut) |
| 2 | aud1-spectrogram | cell 15 | FFT temps-fréquence (contenu spectral) |
| 3 | aud1-mfcc | cell 20 (out 1) | coefficients cepstraux mel (timbre perceptuel) |
| 3 | aud1-mfcc2 | cell 20 (out 3) | MFCC heatmap (vue alternative) |
| 4 | aud1-features | cell 28 | descripteurs finaux (centroid, RMS, ZCR) |

Légendes d'origine ternes (« Forme d'onde (01-3) ») enrichies en interprétations de la transformation. Provenance cellulaire préservée (MANIFEST). Aperçu réécrit en intro narrative.

## Pure-change proof

```
1. Files changed: ONLY README.md
2. 5 figures byte-identical (sha1 unchanged from origin/main)
3. src multiset équilibré: chaque figure -1 (mosaïque) +1 (in-situ) = net zéro
4. CRLF=0 (LF-only)
5. <table> mosaic: 1 -> 0 (dissous)
6. diffstat: +36/-17 (1 file)
```
Aucune figure régénérée, aucun catalogue touché.

## G.1 — feuilles évaluées et SKIPPÉES ce cycle (honnête)

- **GenAI/Video/01-Foundation** : déjà #5780-compliant (L20 énonce la doctrine, 6 single-image tables = wrappers in-situ). Faux positif du scan (table count ≠ mosaic).
- **GenAI/Image/03-Orchestration** : déjà #5780-compliant (0 multi-img table, 4 single-image wrappers in-situ dans les sous-sections conceptuelles). Faux positif.

See #5780

🤖 Generated with [Claude Code](https://claude.com/claude-code)