### PR TITLE
docs(genai-image-02adv): #5780 figures narrative — galerie mosaïque vers narration in-situ

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
@@ -17,24 +17,7 @@ Ce module explore les modèles de pointe : Qwen Image Edit avancé, FLUX, SD 3.5
 
 ## Aperçu — les modèles avancés en images
 
-Ce module explore quatre familles de modèles de pointe. La galerie ci-dessous présente des sorties réelles extraites des notebooks : édition ciblée (Qwen Image Edit), génération photoréaliste (FLUX-1), prototypage rapide (Z-Image/Lumina2) et quantification extrême pour matériel modeste (Bonsai ternaire 1,58-bit).
-
-<table>
-<tr>
-<td align="center"><img src="assets/readme/img2-qwen-edit.png" alt="Édition Qwen Image Edit — panorama avant/après" width="400"/><br/><sub>Qwen Image Edit (02-1)</sub></td>
-<td align="center"><img src="assets/readme/img2-flux-gen.webp" alt="Génération FLUX-1 — image photoréaliste" width="400"/><br/><sub>FLUX-1 génération (02-2)</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/img2-qwen-edit2.webp" alt="Édition Qwen — variante de prompt" width="400"/><br/><sub>Qwen Edit variante (02-1)</sub></td>
-<td align="center"><img src="assets/readme/img2-zimage-lumina.webp" alt="Génération Z-Image/Lumina2 — prototypage rapide" width="400"/><br/><sub>Z-Image/Lumina2 (02-4)</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/img2-flux-gen2.png" alt="Génération FLUX-1 — composition alternative" width="400"/><br/><sub>FLUX-1 composition (02-2)</sub></td>
-<td align="center"><img src="assets/readme/img2-bonsai-ternary.png" alt="Bonsai ternaire 1,58-bit — génération efficace" width="400"/><br/><sub>Bonsai 1,58-bit (02-5)</sub></td>
-</tr>
-</table>
-
-Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
+Ce module explore quatre familles de modèles de pointe : édition ciblée (Qwen Image Edit), génération photoréaliste (FLUX-1), prototypage rapide (Z-Image/Lumina2) et quantification extrême pour matériel modeste (Bonsai ternaire 1,58-bit). Plutôt qu'une galerie séparée du propos, chaque sortie réelle est placée ci-dessous au plus près de la sous-section du modèle qui la produit. Provenance et poids de chaque figure : [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
 ## Notebooks
 
@@ -76,10 +59,26 @@ pip install -r requirements-comfyui.txt
 - **Points forts** : Édition précise, texte dans l'image
 - **VRAM** : ~29GB (VAE 16 canaux)
 
+<p align="center">
+  <a href="02-1-Qwen-Image-Edit-2509.ipynb"><img src="assets/readme/img2-qwen-edit.png" alt="Édition Qwen Image Edit — panorama avant/après" width="460"/></a><br>
+  <em>Sortie du notebook <a href="02-1-Qwen-Image-Edit-2509.ipynb">02-1</a> (cellule 17) : panorama avant/après d'une édition Qwen Image Edit.</em>
+</p>
+
+<p align="center">
+  <a href="02-1-Qwen-Image-Edit-2509.ipynb"><img src="assets/readme/img2-qwen-edit2.webp" alt="Édition Qwen — variante de prompt" width="320"/></a><br>
+  <em>Sortie du notebook <a href="02-1-Qwen-Image-Edit-2509.ipynb">02-1</a> (cellule 24) : variante d'édition avec un prompt différent.</em>
+</p>
+
 ### FLUX 1
 - **Architecture** : Transformer-based
 - **Points forts** : Consistency, contrôle prompts
 - **VRAM** : Variable
+
+<p align="center">
+  <a href="02-2-FLUX-1-Advanced-Generation.ipynb"><img src="assets/readme/img2-flux-gen.webp" alt="Génération FLUX-1 — image photoréaliste" width="340"/></a>
+  <a href="02-2-FLUX-1-Advanced-Generation.ipynb"><img src="assets/readme/img2-flux-gen2.png" alt="Génération FLUX-1 — composition alternative" width="300"/></a><br>
+  <em>Sorties du notebook <a href="02-2-FLUX-1-Advanced-Generation.ipynb">02-2</a> : génération FLUX-1 photoréaliste (gauche, cellule 9) et composition alternative (droite, cellule 15).</em>
+</p>
 
 ### Stable Diffusion 3.5
 - **Architecture** : Diffusion classique
@@ -91,11 +90,21 @@ pip install -r requirements-comfyui.txt
 - **Points forts** : Vitesse, qualité légère
 - **VRAM** : ~10GB
 
+<p align="center">
+  <a href="02-4-Z-Image-Lumina2.ipynb"><img src="assets/readme/img2-zimage-lumina.webp" alt="Génération Z-Image/Lumina2 — prototypage rapide" width="320"/></a><br>
+  <em>Sortie du notebook <a href="02-4-Z-Image-Lumina2.ipynb">02-4</a> (cellule 11) : génération Z-Image/Lumina2 — prototypage rapide pour itérer sur un prompt.</em>
+</p>
+
 ### Bonsai-Image 4B (Ternary 1.58-bit)
 - **Architecture** : Transformer 4B quantifié ternaire (BitNet b1.58), Gemlite INT2 + HQQ 4-bit text encoder
 - **Points forts** : Modèle 4B compressé à ~4 GB (vs ~32 GB en FP16), génération ~2s en 4 steps, déploiable sur GPU d'entrée de gamme
 - **VRAM** : ~5GB
 - **Accès** : custom node ComfyUI `BonsaiTernaryNode` (modèle auto-téléchargé depuis HuggingFace au premier run)
+
+<p align="center">
+  <a href="02-5-Bonsai-Image-Ternary.ipynb"><img src="assets/readme/img2-bonsai-ternary.png" alt="Bonsai ternaire 1,58-bit — génération efficace" width="400"/></a><br>
+  <em>Sortie du notebook <a href="02-5-Bonsai-Image-Ternary.ipynb">02-5</a> (cellule 6) : Bonsai ternaire 1,58-bit — génération en ~2 s sur ~5 GB de VRAM.</em>
+</p>
 
 ## Comparatif
 


### PR DESCRIPTION
## Contexte

Epic #5780 — feuille **GenAI/Image/02-Advanced** (README enfant). **Complète la feuille GenAI/Image entière** : parent #6145 (merged), 01-Foundation #6153 (merged), 03-Orchestration (déjà #5780-compliant), 02-Advanced = dernier enfant.

## Placement in-situ optimal — dans les sous-sections Technologies clés

Contrairement aux feuilles précédentes (figures après le tableau Notebooks), ici le README possédait déjà des sous-sections `### <modèle>` sous `## Technologies clés` contenant la spec architecture (transformer/diffusion, VRAM, points forts) mais sans figure. Le placement naturel = chaque figure rejoint sa spec :

| Modèle / sous-section | Figures | Cellule |
|----------------------|---------|---------|
| Qwen Image Edit 2509 | img2-qwen-edit + img2-qwen-edit2 | cell 17 + 24 |
| FLUX 1 | img2-flux-gen + img2-flux-gen2 (côte-à-côte) | cell 9 + 15 |
| Z-Image/Lumina | img2-zimage-lumina | cell 11 |
| Bonsai-Image 4B | img2-bonsai-ternary | cell 6 |

Stable Diffusion 3.5 n'a pas de figure dans la galerie d'origine → sa sous-section reste sans figure (aucun changement, pas de fabrication).

## Captions

Captions ternes (« Qwen Image Edit (02-1) ») enrichies en interprétations associant le visuel à la spec. Provenance cellulaire préservée (MANIFEST : cell 6/9/11/15/17/24, dimensions, format PNG/WebP).

## Pure-change proof

- 1. Files changed: ONLY README.md
- 2. 6 figures byte-identical (sha1 unchanged from origin/main)
- 3. src multiset équilibré: chaque figure -1 (mosaïque) +1 (in-situ) = net zéro
- 4. CRLF=0 (LF-only)
- 5. table mosaic: 1 -> 0 (dissous)
- 6. diffstat: +27/-18 (1 file)

Aucune figure régénérée, aucun catalogue touché.

See #5780