### PR TITLE
fix(sudoku-6-py): grammaire « qui élimine » (présent, pas participe passé)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -741,7 +741,7 @@
     "Heuristique de **sélection de variable** : choisir la variable avec le plus petit domaine restant.\n",
     "\n",
     "### LCV (Least Constraining Value)\n",
-    "Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui éliminé le moins de possibilites chez les voisins."
+    "Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui élimine le moins de possibilites chez les voisins."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Correctif grammatical dans le **Python twin** (`Sudoku-6-AIMA-CSP-Python.ipynb`), cellule 15 (markdown, heuristique LCV) :

> « la valeur qui **éliminé** le moins de possibilités » → « la valeur qui **élimine** le moins de possibilités »

**Pourquoi** : « qui » = sujet (« la valeur »), le verbe doit donc être au présent 3ᵉ personne (**élimine**, 1ᵉ groupe). « éliminé » est le participe passé — il aurait fallu un auxiliaire (« a éliminé »). C'est une coquille grammaticale, pas un accent manquant.

## Découverte

Bug pré-existant découvert via **forensic §H.4 sur PR #6151** (accents C# twin, cycle c.422). Audit per-word firsthand (G.1) :
- `« qui éliminé »` cellules 11/12 (C# twin) + cellule 15 (Python twin) = **3 occurrences erronées** (présent attendu).
- `« a éliminé »` cellule 29 = **passé composé correct** (laisser — auxiliaire « a » + participe).

## Scope — single-subject §A

- **Grammar-only** (1 mot, éliminé → élimine), Python twin uniquement.
- **C# twin** : la même erreur existe (cellules 11/12) mais #6151 édite **ces lignes exactes** (accents) → suggéré en review #6151 que l'auteur incorpore `éliminé→élimine` dans le même commit (zero conflit additionnel, évite une collision PR sur les mêmes lignes).
- **Accents** (`possibilites → possibilités`) : **hors scope**, EPIC #2876 (le twin C# est couvert par #6151).

## Validation

- **C.2-exempt** : modification markdown uniquement (cellule 15 = markdown, `exec=None`), aucune cellule code touchée, outputs/execution_count préservés (règle C.2 exception markdown).
- **LF-only** (L268 #4) : CR=0 vérifié après normalisation.
- Diff minimal : 1 fichier, 1 insertion, 1 deletion.
- nbformat integrity préservée (read/write via `nbformat`, pas d'écriture manuelle du JSON).

See #2876 (accents EPIC, scope séparé). Découvert via forensic #6151.

Co-Authored-By: Claude-Code <noreply@anthropic.com>