### PR TITLE
docs(lean): game_theory_lean cold-build modality (WSL for GSState, See #6140)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
@@ -216,6 +216,18 @@ lake exe cache get
 Le cache Mathlib est partagé au niveau du dépôt (via `lake exe cache get`)
 pour éviter de retélécharger `~3 GB` à chaque incrément.
 
+> **Cold build modality (§1, See #6140).** Un `lake -R build` cold sur
+> `lean.exe` Windows-native peut crasher sur `StableMarriage.GSState`
+> (`0xC0000409` `STATUS_STACK_BUFFER_OVERRUN`). Diagnostic firsthand : ce
+> n'est **pas** une régression de preuve (le fichier ne contient aucun
+> `sorry`/`decide`/`native_decide`, le sibling `_en` à la logique byte-identique
+> build OK, et la CI Linux est verte) — c'est un flake d'élaboration proche du
+> plafond de stack Windows (1 MB par défaut), via le bloc local `letI`/`haveI
+> IsTrans` répété 3× dans `gsChooseMax`. Pour le cold build §1 pré-merge
+> ([lean-merge-discipline](../../../.claude/rules/lean-merge-discipline.md)),
+> utiliser **WSL** (stack Linux 8 MB par défaut), comme `learning_theory_lean`
+> et `knot_lean`. La CI Linux reste autoritaire côté correction.
+
 ## Relation aux autres projets Lean de GameTheory
 
 | Projet | Statut | Raison de la séparation |

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/README.md
@@ -223,7 +223,12 @@ pour éviter de retélécharger `~3 GB` à chaque incrément.
 > `sorry`/`decide`/`native_decide`, le sibling `_en` à la logique byte-identique
 > build OK, et la CI Linux est verte) — c'est un flake d'élaboration proche du
 > plafond de stack Windows (1 MB par défaut), via le bloc local `letI`/`haveI
-> IsTrans` répété 3× dans `gsChooseMax`. Pour le cold build §1 pré-merge
+> IsTrans` répété 3× dans `gsChooseMax`.
+>
+> Deux mitigations complémentaires : **(structurel)** la PR #6149 (po-2023)
+> extrait la preuve `IsTrans` 3× dupliquée en un seul lemme top-level
+> `gsMenPref_trans` (byte-identité anti-§D, +40/−49), réduisant la profondeur
+> d'élaboration de 3× à 1× ; **(modality)** pour le cold build §1 pré-merge
 > ([lean-merge-discipline](../../../.claude/rules/lean-merge-discipline.md)),
 > utiliser **WSL** (stack Linux 8 MB par défaut), comme `learning_theory_lean`
 > et `knot_lean`. La CI Linux reste autoritaire côté correction.


### PR DESCRIPTION
## Summary

Documents the Windows-native `lean.exe` `0xC0000409` (`STATUS_STACK_BUFFER_OVERRUN`) flake on `StableMarriage.GSState` and the WSL cold-build mitigation, so the next builder running the §1 pre-merge cold build ([lean-merge-discipline](../../../.claude/rules/lean-merge-discipline.md)) does not re-investigate the crash (issue #6140).

## Diagnostic (firsthand, posted as #6140 comment)

Reading `StableMarriage/GSState.lean` (FR) + `GSState_en.lean` (EN) at `origin/main` rules out the issue's hypothesis (b) ("costly `decide`/`native_decide` recursion"):
- **Zero decide-tactics**: both files have `0 sorry / 0 native_decide / 0 decide` (docstrings stripped).
- **FR/EN code bodies byte-identical** modulo the i18n namespace (EN adds `open StableMarriage`; every proof/tactic/`letI`/`haveI` is otherwise identical).

Since FR and EN elaborate the *same* tactics, a genuine recursion blowout would crash both. The FR-only crash is therefore a **Windows elaboration-stack flake near the 1 MB ceiling** (the `letI : LE` + `haveI : IsTrans` block, repeated verbatim 3× in `gsChooseMax`/`gsChooseMax_mem`/`gsChooseMax_maximal`), not a proof regression. The `_en` sibling and CI Linux build green.

## Mitigation = option (c)

Cold §1 build under **WSL** (Linux 8 MB default stack), matching the `learning_theory_lean` / `knot_lean` precedent. CI Linux stays authoritative for correctness.

## Scope

Docs-only (+12/-0, 1 README). **Zero code change** — `GSState.lean` is untouched because the `IsTrans` instance is ai-01's turf (`#6149 gsMenPref_trans` in deep-queue). No catalogue churn; CRLF 0.

See #6140

Co-Authored-By: Claude <noreply@anthropic.com>
