### PR TITLE
fix(scanner): C.1 1/0 pattern no longer false-flags reward notation (+1/-1/0)

### DIFF
--- a/scripts/notebook_tools/audit_c1_c3.py
+++ b/scripts/notebook_tools/audit_c1_c3.py
@@ -37,7 +37,7 @@ EXCLUDE_DIRS = {
 C1_PATTERNS = [
     (re.compile(r"raise\s+NotImplementedError"), "raise NotImplementedError"),
     (re.compile(r"assert\s+False"), "assert False"),
-    (re.compile(r"(?<!\d)1\s*/\s*0(?!\d)"), "1/0"),
+    (re.compile(r"(?<![\d/\-])1\s*/\s*0(?![\d/])"), "1/0"),
 ]
 
 

--- a/scripts/notebook_tools/tests/test_audit_c1_c3.py
+++ b/scripts/notebook_tools/tests/test_audit_c1_c3.py
@@ -134,6 +134,12 @@ class TestC1Patterns:
         # Should NOT match 21/0 or 1/07 (digits adjacent)
         assert not p.search("21/0")
         assert not p.search("1/07")
+        # Should NOT match reward-notation slash-lists (win/loss/draw),
+        # e.g. "+1/-1/0" or "1/0/0" — the "/" is a delimiter, not division.
+        assert not p.search("+1/-1/0")
+        assert not p.search("1/-1/0")
+        assert not p.search("1/0/0")
+        assert not p.search("1/-1/0 pour victoire J1/J2/nul")
 
     def test_no_false_positive_on_variants(self):
         p0, p1, p2 = [p for p, _ in C1_PATTERNS]


### PR DESCRIPTION
## Summary

Fixes a false-positive in the C.1 scanner (`scripts/notebook_tools/audit_c1_c3.py`): the division-by-zero pattern matched **reward-notation slash-lists** (`+1/-1/0`, `1/0/0`) because the delimiter `/` satisfied the non-digit lookbehind.

## Root cause

Pattern `(?<!\d)1\s*/\s*0(?!\d)` on `1/-1/0`: the second `1` (preceded by `/`) passes the `(?<!\d)` lookbehind (`/` is not a digit), then `/0` completes a false match. Reward notation (win/loss/draw) is a slash-delimited list, not division.

**Real manifestation**: `Search/Applications/Search-App-14` cell 41 — `(winner, final_state): 1/-1/0 pour victoire J1/J2/nul` — was flagged as a C.1 violation.

## Fix

Tighten the lookbehind/lookahead to exclude slash-list/delimiter context:

```diff
-    (re.compile(r"(?<!\d)1\s*/\s*0(?!\d)"), "1/0"),
+    (re.compile(r"(?<![\d/\-])1\s*/\s*0(?![\d/])"), "1/0"),
```

- `(?<![\d/\-])` — `1` must not be preceded by digit, `/`, or `-` (slash-list context)
- `(?![\d/])` — `0` must not be followed by digit or `/` (slash-list continuation)

## Verification (G.1 firsthand)

| Input | Expect | Old | New |
|-------|--------|-----|-----|
| `1/0` | match | ✓ | ✓ |
| `x = 1/0` | match | ✓ | ✓ |
| `return 1/0` | match | ✓ | ✓ |
| `+1/-1/0` | NO match | ✗ FP | ✓ fixed |
| `1/-1/0` | NO match | ✗ FP | ✓ fixed |
| `1/0/0` | NO match | ✗ FP | ✓ fixed |
| `21/0` | NO match | ✓ | ✓ |
| `1/07` | NO match | ✓ | ✓ |

- **42 tests pass** (`test_audit_c1_c3.py`), including 4 new reward-notation FP cases.
- **Full-repo C.1 audit**: 0 violations / 897 notebooks (reward FPs no longer inflate count).
- Real division crashes (`1/0`, `x = 1/0`, `return 1/0`) still caught.

## Scope

- **Atomic**: 2 files (`audit_c1_c3.py` + test), +7/−1. No notebook content changes.
- Part of the recurring **scanner-FP cluster** (markdown-header depth, C# `//` comments, accents `\btres\b`, TOC umbrella, reward-notation). Each fix prevents future false flags.

See scanner-FP cluster memory entries in MEMORY.md.