### PR TITLE
docs(probas): #5985 Phase 2 — Prerequisites+Installation reloc après contenu (saillant→spécifique)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -71,84 +71,6 @@ La maximisation de `E[U]` repose sur une hypothèse centrale de la théorie de l
 4. **Décaler** d'un problème réel vers sa formulation probabiliste (variables, facteurs, observations)
 5. **Intégrer** inférence probabiliste et théorie de la décision (maximisation d'utilité espérée)
 
-## Prerequisites
-
-### Niveau mathématique attendu
-
-Cette série suppose une **maîtrise de base en probabilités et statistiques** :
-
-| Concept | Utilité dans la série | Notes de révision |
-|---------|---------------------|------------------|
-| Variables aléatoires (discrètes/continues) | Partout, notebook 1+ | Loi de proba, espérance, variance |
-| Distributions usuelles (Bernoulli, Gaussian, Beta, Gamma) | Notebook 1 (Beta-Bernoulli), 2 (Gaussian) | Paramètres, formes, conjugaison |
-| Probabilités conditionnelles | Notebook 3+ (Variable.If, CPT) | P(A|B), théorème de Bayes |
-| Indépendance conditionnelle | Notebook 3 (Monty Hall), 4 (D-separation) | Collider, explaining away |
-| Espérance mathématique | Partout (calcul de EU) | E[X] = sum x*P(x) ou intégrale |
-| Distributions conjuguées | Notebook 1 (Beta-Bernoulli), 9 (Dirichlet-Discrète) | Prior + likelihood = posterior (famille même) |
-| Intégrales (niveau 1) | Notebook 2, 15 (CARA/CRRA) | Calcul d'espérance avec fonctions non-linéaires |
-
-**Inutile de maîtriser** : dérivation multivariée, algèbre linéaire avancée (sauf pour les modèles hiérarchiques en notebook 4). Les concepts sont introduits progressivement et réexpliqués dans le contexte.
-
-### Prerequisites techniques
-
-#### Pour Infer.NET (C#)
-
-```bash
-# .NET SDK 9.0+
-dotnet --version
-
-# VS Code + extension Polyglot Notebooks
-# Packages (auto-references dans notebooks):
-# - Microsoft.ML.Probabilistic
-# - CompilerChoice = Roslyn
-```
-
-#### Pour Python
-
-```bash
-# Environnement Python 3.10+
-pip install pyro-ppl torch matplotlib numpy
-```
-
-## Installation
-
-### Notebooks PyMC (Python)
-
-```bash
-pip install pymc numpy scipy matplotlib arviz
-```
-
-### Notebooks Infer.NET (C# .NET Interactive)
-
-```bash
-# 1. Installer .NET SDK 9.0+ depuis https://dotnet.microsoft.com/download
-# 2. Installer le kernel dotnet-interactive
-dotnet tool install -g Microsoft.dotnet-interactive
-dotnet interactive jupyter install
-
-# 3. Ou utiliser le script PowerShell (installe tout automatiquement) :
-cd MyIA.AI.Notebooks/Probas/Infer/scripts
-.\setup_environment.ps1
-```
-
-### Notebooks Python (Infer-101, Pyro_RSA)
-
-```bash
-pip install pyro-ppl torch matplotlib numpy
-```
-
-### Vérification
-
-```bash
-jupyter kernelspec list  # doit afficher .net-csharp et python3
-```
-
-### Tester tous les notebooks
-
-```bash
-python MyIA.AI.Notebooks/Probas/Infer/scripts/test_notebooks.py --validate-only
-```
-
 ## Parcours d'apprentissage
 
 ### Phase 1 : Fondations (Notebooks 1-3, ~2h)
@@ -464,6 +386,84 @@ Ce que le pont ajoute par rapport aux quatre notebooks pris isolément : la thé
 | -------- | ------- | ------- | ----- |
 | [Infer-101](Infer-101.ipynb) | .NET (C#) + Python | Introduction Infer.NET, Two Coins, Cyclist | 1h |
 | [Pyro_RSA_Hyperbole](Pyro_RSA_Hyperbole.ipynb) | Python 3 | Rational Speech Acts, hyperboles | 30 min |
+
+## Prerequisites
+
+### Niveau mathématique attendu
+
+Cette série suppose une **maîtrise de base en probabilités et statistiques** :
+
+| Concept | Utilité dans la série | Notes de révision |
+|---------|---------------------|------------------|
+| Variables aléatoires (discrètes/continues) | Partout, notebook 1+ | Loi de proba, espérance, variance |
+| Distributions usuelles (Bernoulli, Gaussian, Beta, Gamma) | Notebook 1 (Beta-Bernoulli), 2 (Gaussian) | Paramètres, formes, conjugaison |
+| Probabilités conditionnelles | Notebook 3+ (Variable.If, CPT) | P(A|B), théorème de Bayes |
+| Indépendance conditionnelle | Notebook 3 (Monty Hall), 4 (D-separation) | Collider, explaining away |
+| Espérance mathématique | Partout (calcul de EU) | E[X] = sum x*P(x) ou intégrale |
+| Distributions conjuguées | Notebook 1 (Beta-Bernoulli), 9 (Dirichlet-Discrète) | Prior + likelihood = posterior (famille même) |
+| Intégrales (niveau 1) | Notebook 2, 15 (CARA/CRRA) | Calcul d'espérance avec fonctions non-linéaires |
+
+**Inutile de maîtriser** : dérivation multivariée, algèbre linéaire avancée (sauf pour les modèles hiérarchiques en notebook 4). Les concepts sont introduits progressivement et réexpliqués dans le contexte.
+
+### Prerequisites techniques
+
+#### Pour Infer.NET (C#)
+
+```bash
+# .NET SDK 9.0+
+dotnet --version
+
+# VS Code + extension Polyglot Notebooks
+# Packages (auto-references dans notebooks):
+# - Microsoft.ML.Probabilistic
+# - CompilerChoice = Roslyn
+```
+
+#### Pour Python
+
+```bash
+# Environnement Python 3.10+
+pip install pyro-ppl torch matplotlib numpy
+```
+
+## Installation
+
+### Notebooks PyMC (Python)
+
+```bash
+pip install pymc numpy scipy matplotlib arviz
+```
+
+### Notebooks Infer.NET (C# .NET Interactive)
+
+```bash
+# 1. Installer .NET SDK 9.0+ depuis https://dotnet.microsoft.com/download
+# 2. Installer le kernel dotnet-interactive
+dotnet tool install -g Microsoft.dotnet-interactive
+dotnet interactive jupyter install
+
+# 3. Ou utiliser le script PowerShell (installe tout automatiquement) :
+cd MyIA.AI.Notebooks/Probas/Infer/scripts
+.\setup_environment.ps1
+```
+
+### Notebooks Python (Infer-101, Pyro_RSA)
+
+```bash
+pip install pyro-ppl torch matplotlib numpy
+```
+
+### Vérification
+
+```bash
+jupyter kernelspec list  # doit afficher .net-csharp et python3
+```
+
+### Tester tous les notebooks
+
+```bash
+python MyIA.AI.Notebooks/Probas/Infer/scripts/test_notebooks.py --validate-only
+```
 
 ## Concepts clés
 


### PR DESCRIPTION
## Contexte

See #5985 (Phase 2 — de-spaghetti + ordre saillant→spécifique).

En relisant les README de série, le user signale que des **blocs techniques wedgés entre des blocs pédagogiques** rendent la lecture difficile, et souhaite un ordre **progressive disclosure** (du plus simple/saillant au plus spécifique/détaillé).

## Anti-pattern firsthand (Probas/README.md)

`## Prerequisites` (L74) et `## Installation` (L113) = **blocs TECHNIQUES** wedgés entre `## Objectifs d'apprentissage` (péda, L64) et `## Parcours d'apprentissage` (péda, L152).

→ Viole acceptance **(b)** #5985 : « aucun bloc technique wedgé entre deux blocs pédagogiques ».

## Changement

Reorder pur : le bloc `Prerequisites` + `Installation` (78 lignes) est déplacé **après** `## Applications standalone` (fin du contenu pédagogique), **avant** `## Concepts clés` (début des appendices) = zone « quick start / prérequis » du gabarit canonique.

**Nouvel ordre** `##` (gabarit #5985 hook→pourquoi→objectifs→parcours→structure/contenu→**prérequis**→FAQ→appendices) :

```
Pourquoi → Qu'est-ce que → Objectifs → Parcours → Quel stack → Structure →
Ce que chaque notebook → Notebooks racine → Série Infer.NET → Série PyMC →
Pont causal → Applications standalone → Prerequisites → Installation →
Concepts clés → Domaines d'application → FAQ → Ressources → Conclusion → Licence
```

## Preuve reorder pur (acceptance c-d)

- **78 insertions / 78 déletions** (lignes déplacées, 0 modification de contenu)
- **Multiset de lignes identique** vérifié via `collections.Counter` (avant == après)
- **CRLF = 0** (LF-only, `newline='\n'`)
- **Marqueur `CATALOG-STATUS` byte-identique** (L3, préservé)
- **0 catalogue churn** (`COURSE_CATALOG.generated.*` intouchés — règle catalog-pr-hygiene R1)
- **643 lignes** avant/après (aucune perte)
- **0 référence interne dangling** (les `ci-dessous`/ancres pointent vers des sections par ancre relative, toujours valides)

## Acceptance #5985 Phase 2

| Critère | Statut |
|---------|--------|
| (a) ordre `##` = saillant→spécifique | ✓ |
| (b) aucun bloc technique wedgé entre blocs péda | ✓ |
| (c) reorder pur multiset-identique | ✓ (Counter prouvé) |
| (d) CATALOG-STATUS + fichiers générés intacts | ✓ |
| (e) 1 PR par série atomique | ✓ (Probas seul) |

## Scope

1 fichier, 1 série (Probas). 0 collision (PR #6138 = lake Lean `decision_theory_lean` ≠ fichier). Worktree isolé `wt-probas-5985` off `origin/main` (df87952b8).

See #5985

🤖 Generated with [Claude Code](https://claude.com/claude-code)