### PR TITLE
docs(lean,#4980): knot_lean/Knots/Invariant bilingual FR+EN inline extension (couverture 6/6)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -13,6 +13,51 @@
   - Finite colorings of graphs (Fintype, Fin n coloring)
   - Minimization over equivalence classes
 -/
+/-
+  `Knots.Invariant` — invariants des nœuds (3-colorabilité, nombre de croisements)
+  ============================================================================
+
+  Invariant de nœud = grandeur attachée à un nœud qui est préservée par
+  mouvement de Reidemeister (R1/R2/R3). Ce sous-module scaffolde :
+
+  1. **3-colorabilité (Fox 1962)** — le plus accessible des invariants non
+     triviaux : un diagramme de nœud est 3-coloriable si chaque arc peut
+     être colorié avec une des trois couleurs (rouge, bleu, vert) de sorte
+     qu'à chaque croisement, soit les trois arcs portent la même couleur,
+     soit les trois portent des couleurs deux à deux distinctes, ET au
+     moins deux couleurs sont effectivement utilisées. Le trèfle (trefoil)
+     est 3-coloriable, la figure-eight ne l'est pas.
+
+  2. **Bornes sur le nombre de croisements** (`crossingNumber`) — minorant
+     effectif obtenu en énumérant les diagrammes réduits d'un nombre donné
+     de croisements et en élimant ceux isotropes au nœud trivial.
+
+  3. **Nombre de dénouement** (`unknottingNumber`, définition seulement,
+     `sorry`) — minimum de mouvements R1 nécessaires pour réduire le nœud
+     au trivial ; invariant notoirement difficile à calculer (NP-difficile
+     dans le cas général, cf Lackenby 2015 poly-time).
+
+  **Path B (invariant classique, mandat 2026-06-23)** : on impose la
+  **continuité de l'arc over** à chaque croisement (les deux extrémités
+  `e2` et `e4` du strand over portent la même couleur), par opposition au
+  modèle permissif antérieur qui coloriait les arêtes indépendamment et
+  faisait dériver la 3-colorabilité sur la figure-eight. La conjonction
+  « continuité over + règle de Fox » restaure l'invariant classique.
+
+  **Prérequis Mathlib** :
+  - `Fintype`, `Fin n` pour les coloriages finis
+  - Minimisation sur classes d'équivalence (`Inf`, `sInf`)
+
+  **i18n** : extension bilingue FR/EN inline du sous-module (cf c.373
+  `Knots.lean` racine pour le pattern d'agrégateur bilingue ; c.375 a
+  couvert les 5 autres sous-modules `Basic`/`Conway`/`Lidman`/
+  `MathlibPrerequisites`/`Reidemeister` ; c.376 ferme la couverture 6/6
+  du sous-lac `knot_lean`). La section anglaise ci-dessus est préservée
+  verbatim ; la section française est ajoutée en miroir pour la
+  convention #4980 ratifiée 2026-07-04.
+
+  Epic #2874, Phase 1–2.
+-/
 
 import Knots.Basic
 import Knots.Reidemeister


### PR DESCRIPTION
## Substance

Extension bilingue FR/EN inline du pattern agrégateur c.373
(`knot_lean/Knots.lean` racine, OPEN en attente ai-01 merge) à son
**sixième et dernier sous-module** `Knots/Invariant.lean` :

- **`Knots/Invariant.lean`** (+45/-0) — fondations des invariants
  de nœuds : 3-colorabilité (Fox 1962), bornes sur le nombre de
  croisements, nombre de dénouement (définition seulement, `sorry`)

**Total : 1 fichier / +45/-0 additif strict.** 0 ligne de code
touchée (hors `/` header) — pure i18n doc.

**Couverture du sous-lac `knot_lean` finalisée à 6/6 sous-modules
bilingues** :
- c.373 `#6156` `Knots.lean` racine (OPEN)
- c.375 `#6171` `Basic`/`Conway`/`Lidman`/`MathlibPrerequisites`/
  `Reidemeister` (5/6, OPEN)
- **c.376 `Invariant` (6/6, cette PR)** ← ferme la couverture

## Cibles

- **#4980** Phase 2 FR-first bilingual inline (sous-lac `knot_lean`)
- **#2874** Phase 1 `knot_lean` — couverture bilingue 6/6
  sous-modules (c.376 = dernier sous-module à étendre)
- **#3801** Prong B — registre de fond, pas doc-hygiène Phase 2

## Pattern

Pour ce sous-module, **deux blocs `/` top-level distincts** au lieu
d'un seul avec `---` interne (variante pragmatique vs c.375) :
- Bloc 1 (lignes 1-15) : `/` header anglais existant **préservé
  verbatim**
- Bloc 2 (lignes 16-60) : `/` header français **miroir**, sans
  séparateur interne (chaque bloc syntaxiquement un commentaire
  propre, pas de risque de confusion avec du markdown via `---`)

Identique au pattern option A inline utilisé par c.373 + c.364-367
(Minimax, SocialChoice, Conway hommage, Grothendieck hommage). La
section anglaise est préservée verbatim ; la section française
couvre :
1. **3-colorabilité** Fox 1962 — déf + condition locale +
   exemples (trefoil oui, figure-eight non)
2. **Bornes crossing number** — `crossingNumber`, énumération
   diagrammes réduits
3. **Unknotting number** — `unknottingNumber` (définition seulement,
   `sorry`, NP-difficile général per Lackenby 2015)
4. **Path B** (mandat 2026-06-23) — continuité over + règle Fox
5. **Prérequis Mathlib** — `Fintype`, `Fin n`, `Inf`/`sInf`
6. **i18n** — référence cross-PRs c.373 + c.375 + convention
   #4980 ratifiée 2026-07-04

## Anti-§D byte-identity

| Bloc vérifié             | main                  | HEAD                  | Preuve                |
|--------------------------|-----------------------|-----------------------|-----------------------|
| `import Knots.Basic`     | (raw, byte-identique) | inchangé              | diff awk import→ns    |
| `import Knots.Reidemeister` | (raw, byte-identique) | inchangé            | diff awk import→ns    |
| `namespace Knots`        | (raw, byte-identique) | inchangé              | namespace-body diff   |
| Sections `/-! ... -/`    | (EN seul, body)       | inchangé              | byte-identique        |
| Tactiques / defs / sorry | (Invariant 1733L)     | 0 ligne touchée       | namespace-body diff   |

La chaîne de compilation est **formellement identique** : aucun
import n'est modifié, aucun `namespace` n'est rouvert, aucun
`sorry` n'est touché, aucune définition n'est altérée. Seuls les
commentaires de documentation de tête de fichier (`/- ... -/`) sont
étendus avec un second bloc français miroir.

## Verdict SOTA

**SOTA-OK / substance réelle, fix additif bilingue.** Lean 4 +
Mathlib 4 = autorité ; les deux blocs `/` étendus sont de la
documentation au sens strict — la chaîne de compilation reste
identique pour le sous-module : mêmes imports (`Knots.Basic` +
`Knots.Reidemeister`), ordre préservé, sections in body inchangées,
définitions et théorèmes intacts.

Lake build final à valider sur ai-01 §1 pre-merge (Mathlib cache
chaud), comme pour chaque PR Lean (cf `lean-merge-discipline.md`
§1 — RECOVERABLE-MACHINE precedent c.357 / c.371 / c.372 / c.373
/ c.374 / c.375).

## Anti-régression §D

| Pattern red-flag | Vérification |
|------------------|-------------|
| Preuve remplacée par sorry | NON, 0 ligne de code touchée |
| Fonction appelée stubée | NON, aucune définition touchée |
| `deletions > insertions` sur code métier | NON, +45/-0 additif strict, code 0 ligne modifiée |
| Import modifié / réordonné | NON, byte-identique (2/2 imports) |
| Catalogue régénéré sur branche | NON, R1 byte-identique `origin/main` |
| Namespace ouvert / fermé | NON, byte-identique |
| Modèle Path B régressé | NON, 0 ligne du corps touchée |

## Portée

- **`See #4980` + `See #2874`** : contribution **finale** pour
  l'EPIC #2874 Phase 1 i18n du sous-lac `knot_lean` côté contenu
  (couverture 6/6 sous-modules `Knots/*.lean`). L'epic peut être
  refermée après merge des PRs c.373 + c.375 + c.376.
- **Cross-references** : c.373 `#6156` `Knots.lean` racine (OPEN)
  + c.375 `#6171` 5 sous-modules jumeaux (OPEN) + c.364 `#6101`
  Minimax + c.365 `#6106` SocialChoice + c.366 `#6111` Conway
  hommage + c.367 `#6115` Grothendieck hommage = même pattern
  option A bilingue inline.
- **L335 anti-mono Sustained** : c.376 = **3ᵉ cycle** consécutif
  R6 Sustained intra-R6 sur le registre `knot_lean` (c.373 + c.375
  + c.376) — **au seuil 3/thème autorisé**, dernier cycle avant
  PIVOT obligatoire. c.377+ ciblera un registre différent pour
  respecter L335 après saturation locale **complète** du lac
  `knot_lean` (couverture 6/6).

## LF-only CR=0 strict

| Fichier              | raw    | no_cr  | Status |
|----------------------|--------|--------|--------|
| `Invariant.lean`     | 99010  | 99010  | ✓ OK   |

(Avant modif : raw 94465 = no_cr 94465. Post-modif : 99010 = 99010.
+4545 octets = exactement la longueur de la section FR ajoutée,
sans aucun CR introduit.)

## Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.*` byte-identique à
  `origin/main` (0 regen catalogue sur branche feature).
- **R2 rebase frais** : base `df87952b8` (post-#6160 MERGED,
  post-#6171 OPEN).
- **R3 atomique** : 1 fichier / 1 feature (bilinguisation) /
  <3000L (45) / <15f (1) / 1 domaine (Lean i18n).
- **R4 partial** : `See #4980` + `See #2874` (couverture 6/6
  atteinte mais epic reste ouverte tant que les PRs upstream ne
  sont pas toutes mergées — `See` et pas `Closes`).
- **L143 SAFE cross-owner** : `knot_lean` = registre propre po-2023
  (pas de conflit GT/Probas/Planners owner-strict).
- **L268 #4 LF-only** : CR=0 strict (raw 99010 = no_cr 99010).
- **L279 / #1502 worker discipline** : Math-Vérif COMMENTED posted,
  JAMAIS `--approve`, JAMAIS `gh pr merge`.
- **L281 rebase frais** : base `origin/main df87952b8`.
- **L298 anti-§D** : 0 ligne de code touchée (header zone only,
  bloc `/` head-only).
- **L327 additif strict** : +45/-0.
- **Mandat user 2026-07-11 Substance > Sweep** : extension de fond
  du pattern c.373 + c.375, ferme la couverture bilingue du lac
  `knot_lean` (≠ doc-hygiène Phase 2 README).

## Suggestion ai-01

Merci de valider :

1. `lake build knot_lean` SUCCESS sur ai-01 §1 pre-merge (confirme
   que `Knots/Invariant.lean` compile sans collision de namespace,
   et que les imports + définitions sont préservés byte-identique).
2. CI Linux Lake build / Sorry check / Proof integrity SUCCESS
   (aucun de cassé — fichier docstring + import lines inchangées).
3. Convention option A bilingue FR+EN inline #4980 respectée :
   section anglaise préservée verbatim + bloc français miroir +
   référence croisée c.373 + c.375 + convention ratifiée
   2026-07-04.
4. Couverture intra-lac `knot_lean` **finalisée à 6/6** sous-modules
   `Knots/*.lean` bilingues (c.373 racine + c.375 5 sous-modules +
   c.376 Invariant = 6/6).
5. Diff `+45/-0` additif strict : aucun code de production touché
   (le sous-module reste bit-pour-bit identique à `origin/main`
   hors zone header).