### PR TITLE
docs(sudoku): #5985 Phase 2 — Prérequis reloc après contenu (saillant→spécifique)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -37,36 +37,6 @@ Comment résoudre un Sudoku ? Cette série explore les techniques de résolution
 
 La série traverse cinq grandes familles algorithmiques, des méthodes exhaustives aux modèles appris : recherche et Dancing Links (niveaux 1-2), métaheuristiques (niveau 3), programmation par contraintes (niveau 4), IA symbolique SAT/SMT (niveau 5) puis IA data-driven (niveau 6). Chaque famille est illustrée par une figure extraite du notebook correspondant, insérée dans la section qui en commente le concept ; la provenance détaillée (cellule source, poids, alt-text) figure dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
-## Prérequis
-
-### C# (.NET Interactive)
-
-```bash
-# .NET 9.0 requis
-dotnet --version
-
-# Les packages NuGet sont installés dans les notebooks :
-# - GeneticSharp          (Sudoku-3 Genetic)
-# - Google.OrTools        (Sudoku-10 OR-Tools CP-SAT)
-# - Microsoft.Z3          (Sudoku-12 Z3 SMT, Sudoku-13 Symbolic Automata)
-# - DlxLib                (Sudoku-2 Dancing Links)
-# - Microsoft.ML.Probabilistic  (Sudoku-15 Infer.NET)
-# - IKVM 8.15.0           (Sudoku-11 Choco — runtime Java-sur-.NET + DLL précompilée)
-# - Plotly.NET            (visualisations, notebooks 0-15)
-```
-
-**Note sur les outputs** : Les notebooks C# contiennent des outputs de cellule exécutées. Les notebooks avec dépendances `#!import` doivent être exécutés dans l'ordre (0 -> 1 -> 2...).
-
-### Python
-
-```bash
-# Creer un environnement
-python -m venv venv
-
-# Installer les dépendances
-pip install numpy pandas scipy matplotlib ortools z3-solver pygad simanneal mealpy networkx torch jax numpyro jpype1 openai
-```
-
 ## Parcours d'Apprentissage Recommandés
 
 ### Parcours Débutant : Comprendre les Fondamentaux
@@ -588,6 +558,36 @@ Les expériences suivantes ont été conduites sur GPU (RTX 3070 Laptop 8GB et R
 1. **Volume de données > taille du modèle** : Passer de 106K à 400K puzzles fait sauter la précision de 33.5% à 83.5%, alors qu'augmenter les paramètres de 162K à 619K n'apporte rien sur petit dataset
 2. **Curriculum learning** : Pas de bénéfice démontré ici. La stratégie progressive ralentit l'apprentissage et provoque des oscillations
 3. **RRN vs solveurs classiques** : Même à 99.7% de succès, le RRN reste un approximateur -- les solveurs exacts (OR-Tools, Norvig) garantissent 100% et sont plus rapides en inférence
+
+## Prérequis
+
+### C# (.NET Interactive)
+
+```bash
+# .NET 9.0 requis
+dotnet --version
+
+# Les packages NuGet sont installés dans les notebooks :
+# - GeneticSharp          (Sudoku-3 Genetic)
+# - Google.OrTools        (Sudoku-10 OR-Tools CP-SAT)
+# - Microsoft.Z3          (Sudoku-12 Z3 SMT, Sudoku-13 Symbolic Automata)
+# - DlxLib                (Sudoku-2 Dancing Links)
+# - Microsoft.ML.Probabilistic  (Sudoku-15 Infer.NET)
+# - IKVM 8.15.0           (Sudoku-11 Choco — runtime Java-sur-.NET + DLL précompilée)
+# - Plotly.NET            (visualisations, notebooks 0-15)
+```
+
+**Note sur les outputs** : Les notebooks C# contiennent des outputs de cellule exécutées. Les notebooks avec dépendances `#!import` doivent être exécutés dans l'ordre (0 -> 1 -> 2...).
+
+### Python
+
+```bash
+# Creer un environnement
+python -m venv venv
+
+# Installer les dépendances
+pip install numpy pandas scipy matplotlib ortools z3-solver pygad simanneal mealpy networkx torch jax numpyro jpype1 openai
+```
 
 ## Sources des Projets Étudiants
 


### PR DESCRIPTION
## Contexte

See #5985 (Phase 2 — de-spaghetti + ordre saillant→spécifique). Suite directe de #6172 (Probas, même anti-pattern, même méthode).

## Anti-pattern firsthand (Sudoku/README.md)

`## Prérequis` (L40-69 : `.NET 9.0`, packages NuGet, `pip install ...`, création d'environnement) = bloc **TECHNIQUE** wedgé entre `## Aperçu — cinq familles d'approches` (péda, L36) et `## Parcours d'Apprentissage Recommandés` (péda, L70).

→ Viole acceptance **(b)** #5985 : « aucun bloc technique wedgé entre deux blocs pédagogiques ».

## Changement

Reorder pur : le bloc `## Prérequis` (30 lignes) est déplacé **après** `## Performances Attendues` (dernier bloc de contenu pédagogique substantiel), **avant** `## Sources des Projets Étudiants` (début des appendices) = zone « quick start / prérequis » du gabarit canonique.

Effet : `## Aperçu` (L36) et `## Parcours` (L40) — les deux blocs pédagogiques — redeviennent **contigus** (plus de bloc technique entre les deux).

## Preuve reorder pur (acceptance c-d)

- **30 insertions / 30 déletions** (lignes déplacées, 0 modification de contenu)
- **Multiset de lignes identique** vérifié via `collections.Counter` (avant == après)
- **CRLF = 0** (LF-only, `newline='\n'`)
- **Marqueur `CATALOG-STATUS` byte-identique** (L3, préservé)
- **0 catalogue churn** (`COURSE_CATALOG.generated.*` intouchés — règle catalog-pr-hygiene R1)
- **811 lignes** avant/après (aucune perte)
- **0 référence interne dangling** (les ancres `## Prérequis` restent valides par position relative)

## Acceptance #5985 Phase 2

| Critère | Statut |
|---------|--------|
| (a) ordre `##` = saillant→spécifique | ✓ (Aperçu→Parcours contigus) |
| (b) aucun bloc technique wedgé entre blocs péda | ✓ |
| (c) reorder pur multiset-identique | ✓ (Counter prouvé) |
| (d) CATALOG-STATUS + fichiers générés intacts | ✓ |
| (e) 1 PR par série atomique | ✓ (Sudoku seul) |

## Scope

1 fichier, 1 série (Sudoku, C#/.NET). R6 : registre doc-reorder (même famille que #6172 Probas, série différente). 0 collision (PR #6163 = `search_lean` Astar ≠ fichier). Worktree isolé `wt-sudoku-5985` off `origin/main` (df87952b8).

See #5985

🤖 Generated with [Claude Code](https://claude.com/claude-code)