### PR TITLE
docs(gametheory): #5985 Phase 2 — relocate Prerequisites/Installation/Quick Start (saillant->spécifique)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -220,70 +220,6 @@ flowchart TD
 
 **Durée totale** : ~26h45 (avec side tracks b/c et sous-série SocialChoice complète)
 
-## Prerequisites
-
-- Connaissances de base en logique et mathématiques
-- Familiarité avec Python (numpy, matplotlib)
-- Pour notebooks Lean (b) : Installation Lean 4 + kernel WSL (voir série Lean)
-- Pour notebooks 13-17 : APIs optionnelles (OpenAI pour AlphaZero)
-
-## Installation
-
-### Installation rapide (Python standard - notebooks 1-12, 14-16)
-
-```bash
-pip install -r MyIA.AI.Notebooks/GameTheory/requirements.txt
-# Note: open_spiel échouera sur Windows (nécessite WSL) - c'est normal pour la majorité des notebooks
-```
-
-### Notebooks nécessitant WSL (Windows uniquement)
-
-GT-13 (CFR/OpenSpiel) et GT-17 (Multi-Agent RL) nécessitent le kernel `Python (GameTheory WSL + OpenSpiel)` :
-
-```bash
-# 1. Dans WSL Ubuntu
-cd /mnt/d/CoursIA/MyIA.AI.Notebooks/GameTheory/scripts
-bash setup_wsl_openspiel.sh
-```
-
-```powershell
-# 2. Côté Windows (PowerShell)
-cd D:\CoursIA\MyIA.AI.Notebooks\GameTheory\scripts
-.\setup_wsl_kernel.ps1
-```
-
-### Notebooks Lean 4 (2b, 4b, 8b, 15b)
-
-Ces notebooks nécessitent le kernel `Lean 4 (WSL)` :
-
-```bash
-# 1. Dans WSL Ubuntu
-cd /mnt/d/CoursIA/MyIA.AI.Notebooks/GameTheory/scripts
-bash setup_wsl_lean4.sh    # installe elan + Lean 4 + REPL + lean4_jupyter
-```
-
-```powershell
-# 2. Côté Windows (PowerShell)
-cd D:\CoursIA\MyIA.AI.Notebooks\GameTheory\scripts
-.\setup_lean4_kernel.ps1   # enregistre le kernel lean4-wsl
-```
-
-### Vérification
-
-```bash
-jupyter kernelspec list
-# Doit montrer : python3, gametheory-wsl (optionnel), lean4-wsl (optionnel)
-```
-
-Pour les détails et le dépannage, voir [install_wsl_kernel.md](install_wsl_kernel.md).
-
-### Configuration API (optionnel)
-
-```bash
-cp .env.example .env
-# Éditer .env et ajouter les clés API si nécessaire
-```
-
 ## Concepts clés
 
 | Concept | Description |
@@ -416,6 +352,87 @@ flowchart LR
 Le pipeline complet relie les **notebooks** (qui motivent — Lemke-Howson, Axelrod, Folk Theorem, Gale-Shapley via `game_theory_lean`) aux **lakes** (qui prouvent — Arrow résolu 0 sorry, Bondareva-Shapley résolu 0 sorry #3954, von Neumann/Sion, Vickrey, Gale-Shapley existence et optimalité côté proposant, grim-trigger). Sans la couche Lean, ces résultats seraient des théorèmes réputés « standard » mais jamais démontrés ; avec elle, la justification est **formellement garantie** — pas seulement admise. La spécificité GameTheory : la simulation (Lemke-Howson numérique, OpenSpiel CFR, Axelrod tournois) précède la preuve, mais les deux faces du même raisonnement sont également outillées.
 
 Pour aller plus loin : [EPIC #4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean — un théorème-phare par série), [hub QuantConnect ↔ `kelly_lean`](../QuantConnect/README.md) (PR #5047), [hub central P0 ↔ Lean inter-familles](../README.md) (PR #5049), [hub SymbolicAI Lean](../SymbolicAI/Lean/README.md).
+
+## Prerequisites
+
+- Connaissances de base en logique et mathématiques
+- Familiarité avec Python (numpy, matplotlib)
+- Pour notebooks Lean (b) : Installation Lean 4 + kernel WSL (voir série Lean)
+- Pour notebooks 13-17 : APIs optionnelles (OpenAI pour AlphaZero)
+
+## Installation
+
+### Installation rapide (Python standard - notebooks 1-12, 14-16)
+
+```bash
+pip install -r MyIA.AI.Notebooks/GameTheory/requirements.txt
+# Note: open_spiel échouera sur Windows (nécessite WSL) - c'est normal pour la majorité des notebooks
+```
+
+### Notebooks nécessitant WSL (Windows uniquement)
+
+GT-13 (CFR/OpenSpiel) et GT-17 (Multi-Agent RL) nécessitent le kernel `Python (GameTheory WSL + OpenSpiel)` :
+
+```bash
+# 1. Dans WSL Ubuntu
+cd /mnt/d/CoursIA/MyIA.AI.Notebooks/GameTheory/scripts
+bash setup_wsl_openspiel.sh
+```
+
+```powershell
+# 2. Côté Windows (PowerShell)
+cd D:\CoursIA\MyIA.AI.Notebooks\GameTheory\scripts
+.\setup_wsl_kernel.ps1
+```
+
+### Notebooks Lean 4 (2b, 4b, 8b, 15b)
+
+Ces notebooks nécessitent le kernel `Lean 4 (WSL)` :
+
+```bash
+# 1. Dans WSL Ubuntu
+cd /mnt/d/CoursIA/MyIA.AI.Notebooks/GameTheory/scripts
+bash setup_wsl_lean4.sh    # installe elan + Lean 4 + REPL + lean4_jupyter
+```
+
+```powershell
+# 2. Côté Windows (PowerShell)
+cd D:\CoursIA\MyIA.AI.Notebooks\GameTheory\scripts
+.\setup_lean4_kernel.ps1   # enregistre le kernel lean4-wsl
+```
+
+### Vérification
+
+```bash
+jupyter kernelspec list
+# Doit montrer : python3, gametheory-wsl (optionnel), lean4-wsl (optionnel)
+```
+
+Pour les détails et le dépannage, voir [install_wsl_kernel.md](install_wsl_kernel.md).
+
+### Configuration API (optionnel)
+
+```bash
+cp .env.example .env
+# Éditer .env et ajouter les clés API si nécessaire
+```
+
+## Quick Start
+
+```bash
+# 1. Installer les dépendances Python (notebooks 1-12, 14-16)
+pip install -r MyIA.AI.Notebooks/GameTheory/requirements.txt
+
+# 2. Premier notebook
+jupyter notebook GameTheory-1-Setup.ipynb
+
+# 3. Puis GameTheory-2 (formes normales, matrices de gains)
+```
+
+Pour les notebooks Lean (2b, 4b, 8b, 15b) : installer le kernel `Lean 4 (WSL)` via `scripts/setup_wsl_lean4.sh`.
+Pour GT-13/17 (OpenSpiel) : installer le kernel `GameTheory WSL` via `scripts/setup_wsl_openspiel.sh`.
+
+---
 
 ## FAQ / Troubleshooting
 
@@ -581,23 +598,6 @@ Tous les notebooks incluent :
 - Plan avec liens ancres
 - Tableaux recapitulatifs
 - Exercices avec solutions complètes
-
-## Quick Start
-
-```bash
-# 1. Installer les dépendances Python (notebooks 1-12, 14-16)
-pip install -r MyIA.AI.Notebooks/GameTheory/requirements.txt
-
-# 2. Premier notebook
-jupyter notebook GameTheory-1-Setup.ipynb
-
-# 3. Puis GameTheory-2 (formes normales, matrices de gains)
-```
-
-Pour les notebooks Lean (2b, 4b, 8b, 15b) : installer le kernel `Lean 4 (WSL)` via `scripts/setup_wsl_lean4.sh`.
-Pour GT-13/17 (OpenSpiel) : installer le kernel `GameTheory WSL` via `scripts/setup_wsl_openspiel.sh`.
-
----
 
 ## Ressources externes
 


### PR DESCRIPTION
## Contexte

Instance **#5985 Phase 2** (READMEs de série : réorganiser du plus saillant au plus spécifique) pour **GameTheory/README.md**. Suit #6172 (Probas, po-2025) et #6174 (Sudoku).

## Anti-pattern firsthand (G.1, lu sur origin/main)

Deux violations de l'acceptance (b) « aucun bloc technique wedgé entre deux blocs pédagogiques » :

1. **`Prerequisites` + `Installation` (L223-286) intercalés** entre `Structure` (pédagogique) et `Concepts clés` / `Ce que chaque notebook apporte` / `Applications du monde réel` (pédagogique) → l'étudiant qui parcourt le parcours pédagogique tombe sur un mur d'installation au milieu.
2. **`Quick Start` échoué en L585** (après `Conclusion`, `Navigation`, `Acquis`, `Statut de maturité`) → bug d'utilisabilité majeur : l'étudiant cherchant « comment démarrer » ne le trouve qu'à la ligne 585 sur 819.

## Fix

Regroupement des **3 sections techniques** (`Prerequisites`, `Installation`, `Quick Start`) en **une zone technique unifiée APRÈS le contenu pédagogique** (`Applications du monde réel`), **AVANT les appendices** (`FAQ`). `Quick Start` est désormais findable juste après `Installation`, à l'emplacement canonique.

Ordre avant → après :
- Avant : Pourquoi → Objectifs → Parcours → Progression → Structure → **[Prereq][Install]** → Concepts → Ce que chaque nb → Applications → FAQ → ... → **[Quick Start L585]** → Ressources
- Après : Pourquoi → Objectifs → Parcours → Progression → Structure → Concepts → Ce que chaque nb → Applications → **[Prereq][Install][Quick Start]** → FAQ → ... → Ressources

## Preuves (acceptance a-e de #5985)

| Critère | Preuve |
|--------|-------|
| (a) saillant→spécifique | framing péda → contenu péda → technique → appendices |
| (b) pas de technique intercalé | 3 sections techniques regroupées après Applications, avant FAQ |
| (c) reorder PUR | `Counter` multiset **identique** ; 81 ins / 81 del équilibrés |
| (d) CATALOG-STATUS intact | marqueur L5 préservé byte-identique (vérif first-6-lines) |
| (e) 1 PR par série | 1 fichier, 1 feature (de-spaghetti) |

## Vérifications

- `CRLF=0` (LF enforced, `write_text(newline='\n')`)
- `check_docs_links --check` → **exit 0** (0 régression lien — les liens internes/cross-file sont préservés verbatim, seules les positions des sections changent)
- `git diff --stat` : `1 file changed, 81 insertions(+), 81 deletions(-)`

## Non-collision

#6069 (MERGED) = fix de la **liste des notebooks** dans la section `Structure des fichiers` (notebooks manquants + tri), **PAS l'ordre** des sections. L'anti-pattern d'ordre #5985 était toujours OPEN. PRs #5985 actives au moment du [CLAIMED] : #6172 (Probas), #6174 (Sudoku) — GameTheory libre.

See #5985
