### PR TITLE
docs(ml-dwa): #5985 Phase 2 — reorder canonique (Objectifs+Installation+Track)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -28,6 +28,49 @@ La formation couvre deux stacks complémentaires :
 | Kernel | Python 3.11+ |
 | Durée totale | ~7 jours |
 
+## Public cible
+
+- Analystes de données souhaitant intégrer l'IA
+- Data scientists intéressés par les agents
+- Développeurs Python intermédiaires
+
+## Objectifs d'apprentissage
+
+À l'issue de cette série, vous serez capable de :
+
+1. **Construire** un agent LLM avec LangChain (tools, chains, memory) et l'appliquer à des tâches data science concrètes
+2. **Évaluer** quand un agent autonome accélère le travail d'analyse vs une approche manuelle
+3. **Orchestrer** des systèmes multi-agents avec Google ADK (planner-coder, DS-STAR, MLE-STAR)
+4. **Configurer** un pipeline multi-provider (Gemini, OpenAI, vLLM local) via LiteLLM
+5. **Déployer** un agent data science en production (BigQuery, BQML, GCP)
+
+## Quel parcours choisir
+
+### Parcours analyste data science (~3 jours)
+
+Labs 1-7 en séquence. Acquérir les bases Pandas, puis construire des agents LangChain pour automatiser l'analyse de données.
+
+1. Lab 1 -> révision Pandas/Matplotlib/Scikit-Learn
+2. Labs 2-3 -> agents documentaires (RFP, CV)
+3. Labs 4-7 -> data wrangling + agents d'analyse
+
+### Parcours ingénieur ML agentique (~4 jours)
+
+Labs 8-17 en séquence. Monter en complexité avec les frameworks Google ADK et les systèmes multi-agents.
+
+1. Labs 8-9 -> architecture ADK, premier agent
+2. Labs 10-12 -> DS-STAR (data science autonome)
+3. Labs 13-15 -> MLE-STAR (Kaggle, optimisation)
+4. Labs 16-17 -> production (BigQuery, projet final)
+
+### Parcours complet (~7 jours)
+
+Tous les labs en séquence, des fondations NumPy/Pandas jusqu'au déploiement GCP.
+
+### Parcours rapide (~1 jour)
+
+Labs 1 + 6 + 8. Découvrir le pipeline data science, construire un premier agent LangChain, puis un premier agent ADK. Les trois labs les plus représentatifs pour une première prise en main.
+
 ## Structure
 
 ```
@@ -107,6 +150,51 @@ Documentation complète : [02-ML-Cours/README.md](02-ML-Cours/README.md)
 | 6 | [Lab6-First-Agent](PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb) | Construction d'un agent simple |
 | 7 | [Lab7-Data-Analysis-Agent](PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb) | Agent pour DataFrames |
 
+## Track AgenticDataScience (Days 4-7)
+
+Track avancé intégrant les frameworks Google ADK (DS-STAR, MLE-STAR) avec support multi-provider.
+
+### Day 4 - ADK Foundations (Labs 8-9)
+
+| Lab | Notebook | Objectif |
+|-----|----------|----------|
+| 8 | [ADK-Introduction](AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb) | Architecture ADK, configuration providers |
+| 9 | [First-ADK-Agent](AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb) | Premier agent pour Data Science |
+
+### Day 5 - DS-STAR (Labs 10-12)
+
+| Lab | Notebook | Objectif |
+|-----|----------|----------|
+| 10 | [File-Analyzer](AgenticDataScience/Day5-DS-Star/Lab10-File-Analyzer.ipynb) | Analyse de fichiers hétérogènes |
+| 11 | [Planner-Coder-Loop](AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb) | Boucle itérative multi-agents |
+| 12 | [DS-Star-Workshop](AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb) | Application complète |
+
+### Day 6 - MLE-STAR (Labs 13-15)
+
+| Lab | Notebook | Objectif |
+|-----|----------|----------|
+| 13 | [Web-Search-SOTA](AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb) | Recherche de modèles SOTA |
+| 14 | [Ablation-Refinement](AgenticDataScience/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb) | Optimisation ciblée |
+| 15 | [Kaggle-Challenge](AgenticDataScience/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb) | Compétition Kaggle |
+
+### Day 7 - Production (Labs 16-17)
+
+| Lab | Notebook | Objectif |
+|-----|----------|----------|
+| 16 | [Data-Science-Agent](AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb) | Agent BigQuery/BQML |
+| 17 | [Final-Project](AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb) | Projet intégré |
+
+### Technologies AgenticDataScience
+
+| Catégorie | Technologies |
+|-----------|--------------|
+| **Abstraction** | LiteLLM (multi-provider) |
+| **Google ADK** | google-adk, google-generativeai |
+| **Providers** | Gemini 3.1, vLLM, OpenAI, OpenRouter |
+| **Cloud (Day 7)** | BigQuery, Vertex AI, BQML |
+
+Documentation complète : [AgenticDataScience/README.md](AgenticDataScience/README.md)
+
 ## Technologies
 
 | Catégorie | Technologies |
@@ -138,16 +226,6 @@ pip install langchain langchain-openai langchain-experimental python-dotenv
 OPENAI_API_KEY=sk-...
 ```
 
-## Objectifs d'apprentissage
-
-À l'issue de cette série, vous serez capable de :
-
-1. **Construire** un agent LLM avec LangChain (tools, chains, memory) et l'appliquer à des tâches data science concrètes
-2. **Évaluer** quand un agent autonome accélère le travail d'analyse vs une approche manuelle
-3. **Orchestrer** des systèmes multi-agents avec Google ADK (planner-coder, DS-STAR, MLE-STAR)
-4. **Configurer** un pipeline multi-provider (Gemini, OpenAI, vLLM local) via LiteLLM
-5. **Déployer** un agent data science en production (BigQuery, BQML, GCP)
-
 ## Concepts clés
 
 | Concept | Description |
@@ -156,39 +234,6 @@ OPENAI_API_KEY=sk-...
 | **Tool** | Fonction appelable par l'agent |
 | **Chain** | Séquence d'opérations LLM |
 | **Memory** | Contexte conversationnel |
-
-## Public cible
-
-- Analystes de données souhaitant intégrer l'IA
-- Data scientists intéressés par les agents
-- Développeurs Python intermédiaires
-
-## Quel parcours choisir
-
-### Parcours analyste data science (~3 jours)
-
-Labs 1-7 en séquence. Acquérir les bases Pandas, puis construire des agents LangChain pour automatiser l'analyse de données.
-
-1. Lab 1 -> révision Pandas/Matplotlib/Scikit-Learn
-2. Labs 2-3 -> agents documentaires (RFP, CV)
-3. Labs 4-7 -> data wrangling + agents d'analyse
-
-### Parcours ingénieur ML agentique (~4 jours)
-
-Labs 8-17 en séquence. Monter en complexité avec les frameworks Google ADK et les systèmes multi-agents.
-
-1. Labs 8-9 -> architecture ADK, premier agent
-2. Labs 10-12 -> DS-STAR (data science autonome)
-3. Labs 13-15 -> MLE-STAR (Kaggle, optimisation)
-4. Labs 16-17 -> production (BigQuery, projet final)
-
-### Parcours complet (~7 jours)
-
-Tous les labs en séquence, des fondations NumPy/Pandas jusqu'au déploiement GCP.
-
-### Parcours rapide (~1 jour)
-
-Labs 1 + 6 + 8. Découvrir le pipeline data science, construire un premier agent LangChain, puis un premier agent ADK. Les trois labs les plus représentatifs pour une première prise en main.
 
 ## FAQ / Troubleshooting
 
@@ -277,51 +322,6 @@ Certains agents produisent des outputs longs. Vérifier :
 - [Pandas Documentation](https://pandas.pydata.org/docs/)
 - [LangChain Documentation](https://python.langchain.com/)
 - [OpenAI Cookbook](https://cookbook.openai.com/)
-
-## Track AgenticDataScience (Days 4-7)
-
-Track avancé intégrant les frameworks Google ADK (DS-STAR, MLE-STAR) avec support multi-provider.
-
-### Day 4 - ADK Foundations (Labs 8-9)
-
-| Lab | Notebook | Objectif |
-|-----|----------|----------|
-| 8 | [ADK-Introduction](AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb) | Architecture ADK, configuration providers |
-| 9 | [First-ADK-Agent](AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb) | Premier agent pour Data Science |
-
-### Day 5 - DS-STAR (Labs 10-12)
-
-| Lab | Notebook | Objectif |
-|-----|----------|----------|
-| 10 | [File-Analyzer](AgenticDataScience/Day5-DS-Star/Lab10-File-Analyzer.ipynb) | Analyse de fichiers hétérogènes |
-| 11 | [Planner-Coder-Loop](AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb) | Boucle itérative multi-agents |
-| 12 | [DS-Star-Workshop](AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb) | Application complète |
-
-### Day 6 - MLE-STAR (Labs 13-15)
-
-| Lab | Notebook | Objectif |
-|-----|----------|----------|
-| 13 | [Web-Search-SOTA](AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb) | Recherche de modèles SOTA |
-| 14 | [Ablation-Refinement](AgenticDataScience/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb) | Optimisation ciblée |
-| 15 | [Kaggle-Challenge](AgenticDataScience/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb) | Compétition Kaggle |
-
-### Day 7 - Production (Labs 16-17)
-
-| Lab | Notebook | Objectif |
-|-----|----------|----------|
-| 16 | [Data-Science-Agent](AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb) | Agent BigQuery/BQML |
-| 17 | [Final-Project](AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb) | Projet intégré |
-
-### Technologies AgenticDataScience
-
-| Catégorie | Technologies |
-|-----------|--------------|
-| **Abstraction** | LiteLLM (multi-provider) |
-| **Google ADK** | google-adk, google-generativeai |
-| **Providers** | Gemini 3.1, vLLM, OpenAI, OpenRouter |
-| **Cloud (Day 7)** | BigQuery, Vertex AI, BQML |
-
-Documentation complète : [AgenticDataScience/README.md](AgenticDataScience/README.md)
 
 ## Conclusion / Prochaines étapes
 


### PR DESCRIPTION
## Contexte

See #5985 (Phase 2 — de-spaghetti + ordre saillant→spécifique). Suite de #6172 (Probas) et #6174 (Sudoku) — même méthode, série différente.

## Anti-patterns firsthand (DataScienceWithAgents/README.md)

**Trois** violations du gabarit canonique #5985 :

1. **(a) Objectifs enfoui** : `## Objectifs d'apprentissage` (L141) placé APRÈS tout le contenu (Fondations L62, Fondations ML L69, Workshop L86, Technologies L110). Le gabarit veut les Objectifs **tôt**, juste après le hook/pourquoi — pas enfouis loin de l'intro.
2. **(b) Installation wedgée** : `## Installation` (L119, bloc TECHNIQUE) est wedgée entre `## Technologies`/`## Workshop` (péda) et `## Objectifs d'apprentissage` (péda) → viole acceptance **(b)** #5985 « aucun bloc technique wedgé entre deux blocs pédagogiques ».
3. **(c) Track dispersé** : `## Track AgenticDataScience (Days 4-7)` (L281) est placé APRÈS `## Ressources` (L275, appendice), au lieu d'être groupé avec le contenu pédagogique (Workshop L86).

## Changement — reorder canonique

Nouvel ordre `##` (gabarit #5985 : hook→pourquoi/à qui→objectifs→parcours→structure/contenu→quick-start/prérequis→concepts→FAQ→appendices) :

```
Pourquoi → Vue d'ensemble → Public cible (remonté L160→L31) →
Objectifs (remonté L141→L37) → Quel parcours (remonté L166→L47) →
Structure → Fondations → Fondations ML → Workshop →
Track AgenticDataScience (remonté L281→L153, groupé avec contenu) →
Technologies → Installation (déplacé L119→L207, zone quick-start) →
Concepts clés → FAQ → Ressources → Conclusion → Licence
```

Effets :
- **(a) corrigé** : Objectifs désormais L37, juste après le hook (Pourquoi + Vue d'ensemble + Public cible) — conforme au gabarit.
- **(b) corrigé** : Installation déplacée en zone quick-start (après tout le contenu), n'est plus wedgée entre blocs péda.
- **(c) corrigé** : Track regroupé avec Workshop (les deux sections contenu/parcours pédagogique sont contigus).

## Preuve reorder pur (acceptance c-d)

- **88 insertions / 88 déletions** (lignes déplacées, 0 modification de contenu)
- **17 blocs H2 préservés** (découpe/reassemblage programmatique par ancre)
- **Multiset de lignes identique** vérifié via `collections.Counter` (avant == après)
- **CRLF = 0** (LF-only, `newline='\n'`)
- **354 lignes** avant/après (aucune perte)
- **0 référence interne dangling** (aucune ancre `#...` relative dans le fichier)
- **0 catalogue churn** (pas de marqueur CATALOG-STATUS dans cette série ; `COURSE_CATALOG.generated.*` intouchés)

## Acceptance #5985 Phase 2

| Critère | Statut |
|---------|--------|
| (a) ordre `##` = saillant→spécifique | ✓ (Objectifs remonté près du hook) |
| (b) aucun bloc technique wedgé entre blocs péda | ✓ (Installation en quick-start) |
| (c) reorder pur multiset-identique | ✓ (Counter prouvé, 17 blocs préservés) |
| (d) CATALOG-STATUS + fichiers générés intacts | ✓ |
| (e) 1 PR par série atomique | ✓ (DataScienceWithAgents seul) |

## Scope

1 fichier, 1 série (ML/DataScienceWithAgents, Python). R6 : registre doc-reorder (même méthode que #6172/#6174, série différente). 0 collision (AUCUNE PR ouverte sur ML/DWA). Worktree isolé `wt-mldwa-5985` off `origin/main` (df87952b8).

See #5985

🤖 Generated with [Claude Code](https://claude.com/claude-code)