### PR TITLE
docs(lean,#4980): conway_lean/Conway/LookAndSay bilingual FR+EN inline extension (rollout conway_lean phase 1+ suite)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/LookAndSay.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/LookAndSay.lean
@@ -14,6 +14,41 @@ Conway proved remarkable properties:
 This file formalizes the sequence generation and verifies the first terms.
 -/
 
+/-
+  `Conway.LookAndSay` — La suite look-and-say de Conway
+  ======================================================
+  La suite look-and-say démarre avec « 1 ». Chaque terme suivant décrit le
+  terme précédent en lisant à voix haute les groupes de chiffres consécutifs :
+    1 → 11 → 21 → 1211 → 111221 → 312211 → 13112221 → ...
+
+  Conway a démontré des propriétés remarquables :
+  - Le rapport |a(n+1)| / |a(n)| converge vers la constante de Conway
+    λ ≈ 1.303577...
+  - λ est l'unique racine réelle positive d'un polynôme de degré 71
+  - La suite se décompose en exactement 92 « éléments atomiques » (nommés
+    d'après les éléments chimiques)
+
+  Ce fichier formalise la génération de la suite et vérifie les premiers
+  termes.
+
+  ### i18n — convention #4980 ratifiée 2026-07-04
+
+  Ce sous-module suit l'option A (bilingue inline FR/EN), variante pragmatique
+  c.378 (deux blocs `/` top-level distincts, sans `---` interne, analogue
+  c.376/c.377) : le bloc EN existant est préservé verbatim ci-dessus, le bloc
+  FR miroir est ajouté juste après sans séparateur `---`. Convention sibling
+  pair (`<Foo>_en.lean` à part) réservée aux modules de substance (cf c.374
+  `Astar_en.lean`) ; pour les modules de formalisation comme `LookAndSay`,
+  l'inline FR+EN est le bon compromis (peu de code, deux langues côte à côte).
+
+  Cross-références : c.366 `Conway.lean` racine bilingue (MERGED), c.373
+  `Knots.lean` racine bilingue, c.374 `Astar.lean` sibling pair, c.375
+  `Knots` sub-modules bilingues, c.376 `Knots/Invariant` bilingue (saturation
+  locale du lac `knot_lean` à 6/6), c.377 `Conway/MathlibMap` bilingue
+  (premier sous-module rollout `conway_lean`, PIVOT L335 strict), **c.378
+  `Conway/LookAndSay` bilingue (suite rollout `conway_lean` Phase 1+)**.
+-/
+
 import Mathlib.Data.List.Basic
 
 namespace Conway


### PR DESCRIPTION
## Substance

Extension bilingue FR/EN inline du pattern option A (variante pragmatique
c.376/c.377 : deux blocs `/` top-level distincts, sans `---` interne) au
**deuxième sous-module** du rollout `conway_lean` Phase 1+ (initié par c.377
`Conway/MathlibMap`) :

- **`Conway/LookAndSay.lean`** (+35/-0) — module de formalisation de la
  suite look-and-say de Conway. Header EN existant préservé verbatim (lignes
  1-15) + bloc FR miroir ajouté juste après (lignes 17-51) couvrant : suite
  look-and-say (séquence des premiers termes 1→11→21→1211→111221→312211→...),
  propriétés remarquables (constante de Conway λ ≈ 1.303577..., degré 71,
  92 éléments atomiques « chimiques »), formalisation + vérification des
  premiers termes, i18n convention #4980 ratifiée 2026-07-04 + cross-refs
  c.366/367/373/374/375/376/377/378.

**Total : 1 fichier / +35/-0 additif strict.** 0 ligne de code touchée
(hors `/` header) — pure i18n doc.

**PIVOT L335 strict respecté (continuité registre `conway_lean`)** :
c.377 = 4ᵉ cycle R6 Sustained intra-R6 avec PIVOT strict `conway_lean` ≠
`knot_lean` (post-saturation locale `knot_lean` 6/6 par c.373+c.375+c.376
= 3 cycles au seuil 3/thème autorisé). c.378 = **5ᵉ cycle R6 Sustained
intra-R6, registre `conway_lean` ouvert** (PIVOT L335 autorise continuer
sur même registre tant que backlog substantiel — donc suite rollout
`conway_lean` Phase 1+ est naturel). Initie `Conway/LookAndSay` après
`Conway/MathlibMap` (c.377) — backlog c.379+ :
`Conway/{Doomsday,Fractran,Nim,Angel,FreeWillTheorem,KochenSpecker,
CollatzLike}.lean` + `Conway/Life/*` sub-submodules (24 sous-modules +
racine, backlog substantiel pour plusieurs cycles).

## Cibles

- **#4980** Phase 2 FR-first bilingual inline (rollout `conway_lean` Phase 1+
  suite, 2/24 sous-modules fait après c.378)
- **#1453** Prover harness co-evolution (LookAndSay = 6 defs + 6 #eval!,
  prouveur-friendly : pas d'intractabilité, defs compositional, `#eval!`
  déterministes)
- **#3801** Prong B — registre de fond Lean substance

## Pattern

Pour ce sous-module, **deux blocs `/` top-level distincts** au lieu d'un
seul avec `---` interne (variante pragmatique c.376/c.377 reprise pour
c.378) :

- **Bloc 1 (lignes 1-15)** : `/` header EN existant **préservé verbatim**
  (intro, suite 1→11→21→..., propriétés : λ ≈ 1.303577..., degré 71,
  92 éléments atomiques)
- **Bloc 2 (lignes 17-51)** : `/` header FR **miroir**, sans séparateur
  interne (chaque bloc syntaxiquement un commentaire propre, pas de risque
  de confusion avec du markdown via `---`)

Identique au pattern option A inline utilisé par c.366 (Conway hommage
racine MERGED) + c.367 Grothendieck hommage (MERGED) + c.373 (Knots racine
OPEN) + c.375 (Knots sub-modules 5/6 OPEN) + c.376 (Knots/Invariant 6/6
OPEN) + c.377 (`Conway/MathlibMap` bilingual, premier rollout conway_lean).
Convention sibling pair (`<Foo>_en.lean` à part) réservée aux modules de
substance (cf c.374 `Astar_en.lean`) ; pour les modules de formalisation
comme `LookAndSay`, l'inline FR+EN est le bon compromis (peu de code,
deux langues côte à côte).

## Anti-§D byte-identity

| Bloc vérifié                  | main              | HEAD              | Preuve                |
|-------------------------------|-------------------|-------------------|-----------------------|
| `import Mathlib.Data.List.*`  | (raw, byte-identique) | inchangé        | diff awk import→ns    |
| `namespace Conway`            | (raw, byte-identique) | inchangé        | namespace-body diff   |
| 6 defs + 6 #eval! corps       | (74L byte-identique)  | 0 ligne touchée | namespace-body diff   |

La chaîne de compilation est **formellement identique** : aucun import
n'est modifié, aucun `namespace` n'est rouvert, aucune def `#eval!` n'est
altérée. Seuls les commentaires de documentation de tête de fichier
(`/- ... -/`) sont étendus avec un second bloc français miroir.

## Verdict SOTA

**SOTA-OK / substance réelle, fix additif bilingue.** Lean 4 + Mathlib 4 =
autorité ; les deux blocs `/` étendus sont de la documentation au sens
strict — la chaîne de compilation reste identique pour le sous-module :
même import (`Mathlib.Data.List.Basic`), ordre préservé, defs et `#eval!`
in body inchangés.

Lake build final à valider sur ai-01 §1 pre-merge (Mathlib cache chaud),
comme pour chaque PR Lean (cf `lean-merge-discipline.md` §1 —
RECOVERABLE-MACHINE precedent c.357 / c.371 / c.372 / c.373 / c.374 /
c.375 / c.376 / c.377 / c.378).

## Anti-régression §D

| Pattern red-flag | Vérification |
|------------------|-------------|
| Preuve remplacée par sorry | NON, n/a (module formalisation + `#eval!`, pas de théorème) |
| Fonction appelée stubée | NON, aucune définition touchée |
| `deletions > insertions` sur code métier | NON, +35/-0 additif strict, code 0 ligne modifiée |
| Import modifié / réordonné | NON, byte-identique (1/1 import) |
| Catalogue régénéré sur branche | NON, R1 byte-identique `origin/main` |
| Namespace ouvert / fermé | NON, byte-identique |
| Modèle Mathlib `SetTheory.Ordinal.*` touché | NON, 0 ligne du corps touchée |

## Portée

- **`See #4980`** : contribution suite rollout Phase 1+ du lac `conway_lean`
  (2/24 sous-modules fait après c.378).
- **Cross-references** : c.377 `#6178` `conway_lean/Conway/MathlibMap`
  bilingue (premier sous-module rollout conway_lean, PIVOT L335 strict) +
  c.376 `#6173` `knot_lean/Knots/Invariant` bilingue 6/6 (OPEN) + c.375
  `#6171` `knot_lean/Knots` sub-modules 5/6 (OPEN) + c.374 `#6163`
  `search_lean/Astar_en.lean` sibling pair (OPEN) + c.373 `#6156`
  `knot_lean/Knots.lean` racine bilingue (OPEN) + c.367 `#6115` Grothendieck
  hommage (MERGED) + c.366 `#6111` `conway_lean/Conway.lean` racine bilingue
  inline (MERGED) = même pattern option A pragmatique.
- **L335 anti-mono Sustained** : c.378 = **5ᵉ cycle R6 Sustained intra-R6,
  registre `conway_lean` ≠ knot_lean** (continuité PIVOT strict post-c.377,
  backlog substantiel conway_lean Phase 1+ autorise continuer sur même
  registre ouvert).

## LF-only CR=0 strict

| Fichier              | raw    | no_cr  | Status |
|----------------------|--------|--------|--------|
| `LookAndSay.lean`    | 4322   | 4322   | ✓ OK   |

(Avant modif : raw 3005 = no_cr 3005. Post-modif : raw 4322 = no_cr 4322.
+1317 octets = exactement la longueur de la section FR ajoutée, sans
aucun CR introduit.)

## Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.*` byte-identique à
  `origin/main` (0 regen catalogue sur branche feature).
- **R2 rebase frais** : base `df87952b8`.
- **R3 atomique** : 1 fichier / 1 feature (bilinguisation satellite) /
  <3000L (35) / <15f (1) / 1 domaine (Lean i18n).
- **R4 partial** : `See #4980` (suite rollout, pas `Closes`).
- **L143 SAFE cross-owner** : `conway_lean` = registre propre po-2023
  (pas de conflit GT/Probas/Planners owner-strict).
- **L268 #4 LF-only** : CR=0 strict (raw 4322 = no_cr 4322).
- **L279 / #1502 worker discipline** : Math-Vérif COMMENTED posted,
  JAMAIS `--approve`, JAMAIS `gh pr merge`.
- **L281 rebase frais** : base `origin/main df87952b8`.
- **L298 anti-§D** : 0 ligne de code touchée (header zone only, bloc
  `/` head-only).
- **L327 additif strict** : +35/-0.
- **L335 anti-mono Sustained** : c.378 = **5ᵉ cycle R6 Sustained intra-R6,
  registre `conway_lean` ≠ knot_lean** (continuité PIVOT strict post-c.377,
  backlog substantiel conway_lean Phase 1+ autorise continuer sur même
  registre ouvert).
- **Mandat user 2026-07-11 Substance > Sweep** : extension bilingue Lean
  de fond (≠ doc-hygiène Phase 2 README).

## Suggestion ai-01

Merci de valider :

1. `lake build conway_lean` SUCCESS sur ai-01 §1 pre-merge (confirme
   que `Conway/LookAndSay.lean` compile sans collision de namespace, et
   que les imports + defs + `#eval!` sont préservés byte-identique).
2. CI Linux Lake build / Sorry check / Proof integrity SUCCESS
   (aucun de cassé — fichier docstring + import lines inchangées).
3. Convention option A bilingue FR+EN inline #4980 respectée :
   section EN préservée verbatim + bloc français miroir (deux blocs
   `/` top-level distincts, sans `---` interne) + référence croisée
   c.377 `Conway/MathlibMap` bilingue (premier sous-module rollout
   `conway_lean`, PIVOT L335 strict) + convention ratifiée 2026-07-04.
4. **PIVOT L335 strict respecté** : c.378 = 5ᵉ cycle R6 Sustained
   intra-R6, registre `conway_lean` ≠ knot_lean (continuité PIVOT strict
   post-c.377, backlog substantiel conway_lean Phase 1+ autorise
   continuer sur même registre ouvert).
5. Diff `+35/-0` additif strict : aucun code de production touché
   (le sous-module reste bit-pour-bit identique à `origin/main` hors
   zone header).