### PR TITLE
fix(game-theory-lean): bump StableMarriage thread stack to 8 MiB for Windows (#6140)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean
@@ -36,9 +36,25 @@ require mathlib from git
 --
 -- Convention i18n EPIC #4980 (cf decision_theory_lean precedent) :
 -- `globs` (et non `roots`) avec suffixe `.*` pour auto-decouvrir siblings `_en`.
+--
+-- c.324 (po-2026, #6140) : `StableMarriage.GSState` crashes Windows-native
+-- `lean.exe` cold builds with `0xC0000409` = STATUS_STACK_BUFFER_OVERRUN.
+-- Symptom: `✖ [8503/8529] Building StableMarriage.GSState (46s) — Lean exited
+-- with code 3221226505`. The EN sibling `StableMarriage.GSState_en` builds
+-- fine on the same machine, CI/Linux builds pass, and the file is
+-- byte-identical between FR/EN on non-docstring content — proving this is a
+-- Windows thread-stack flake, NOT a proof regression.
+-- Default thread stack on Windows is 1 MiB; bumping to 8 MiB (`--tstack=8192`)
+-- absorbs the deep elaboration of the three inline `IsTrans (Fin n)` instances
+-- on `gsMenPrefLE` in `gsChooseMax` / `gsChooseMax_mem` / `gsChooseMax_maximal`
+-- (file `StableMarriage/GSState.lean`). No file in `StableMarriage/` is
+-- modified: this is a build-config fix, anti-régression compliant (no touch
+-- to proof). Scope = per-lib override so `CooperativeGames` / `SocialChoice`
+-- cold builds remain unaffected. See #6140.
 @[default_target]
 lean_lib StableMarriage where
   globs := #[`StableMarriage.*]
+  moreLeanArgs := #["--tstack=8192"]
 
 @[default_target]
 lean_lib CooperativeGames where


### PR DESCRIPTION
## Summary

Fixes a **Windows-only build flake** on `StableMarriage.GSState` cold builds by bumping the per-lib thread stack from the 1 MiB default to 8 MiB.

**Scope**: 1 file, +17/-1 line, exclusively `game_theory_lean/lakefile.lean`. Zero proof file touched (anti-régression compliant).

## Symptom (from #6140)

```
✖ [8503/8529] Building StableMarriage.GSState (46s) — Lean exited with code 3221226505
```

`3221226505 = 0xC0000409 = STATUS_STACK_BUFFER_OVERRUN`. Reproducible on Windows-native `lean.exe` cold builds only.

## Root cause analysis

The file `StableMarriage/GSState.lean` contains **three inline `IsTrans (Fin n)` instances** on `gsMenPrefLE` within `gsChooseMax`, `gsChooseMax_mem`, and `gsChooseMax_maximal`. The deep elaboration of these instances on a `Fin`-typed relation blows past the 1 MiB default Windows thread stack.

Proof this is a Windows-only flake, **not** a proof regression:
- `StableMarriage.GSState_en` builds fine on the **same machine**
- CI/Linux cold builds pass
- File is **byte-identical** between FR/EN on non-docstring content

## Fix

Per-lib `moreLeanArgs` override on `lean_lib StableMarriage` only:

```lean
@[default_target]
lean_lib StableMarriage where
  globs := #[`StableMarriage.*]
  moreLeanArgs := #["--tstack=8192"]
```

Scope rationale: per-lib (not package-level `package` `moreLeanArgs`) so `CooperativeGames` and `SocialChoice` libs inherit the default 1 MiB stack and remain unaffected by the change. Reversible: a single keyword revert.

## Validation

### Lake build — partial (deferred to ai-01)

`lake --version` parses the updated lakefile successfully:
```
Lake version 5.0.0-src+fd00994 (Lean version 4.31.0-rc1)
```

**Cold build SUCCESS local deferred to ai-01** (env-blocker W1+ on this machine: mathlib cache wiped repo-wide, WDAC blocks `lake exe cache get`; the cold build exceeds 8500 jobs and the 30-min worker window). Per `lean-merge-discipline.md` §1, ai-01 must verify `lake build StableMarriage` before merge.

### Sorry count

`grep -c sorry` before/after this PR for every `.lean` file in the PR:

| File | before | after |
|---|---|---|
| `game_theory_lean/lakefile.lean` | 0 | 0 (unchanged) |

**Net: 0 deltas. No proof touched.** Verified `git diff --stat`: `1 file changed, 17 insertions(+), 1 deletion(-)` — no `.lean` file outside the lakefile.

### Anti-régression

Zero proof file in `StableMarriage/` is modified. This is a pure build-config fix at the lakefile boundary.

## Risks

**Minimal.** Per-lib scope means:
- If the flag proves counter-productive on Windows, only `StableMarriage` builds are affected.
- If a future Lean version fixes the deep-elaboration stack issue natively, a single revert suffices.
- No impact on Linux/macOS (Windows 1 MiB default is the constraint; other OSes have larger default stacks).

## Why per-lib (not package-level `moreLeanArgs`)

Per the Lake README, `moreLeanArgs` exists on both `package` (passes the flag to every `lean` invocation in the package) and `lean_lib` ("Augments the package's corresponding configuration option"). Setting it at the **lib** scope means `CooperativeGames` and `SocialChoice` cold builds remain at the 1 MiB default and finish cleanly without being perturbed. Setting it at the **package** scope would propagate to all libs and would require coordination if a future lib turns out to be sensitive to non-default stacks.

Sources: [Lake README — Build & Run / Library Configuration Options](https://github.com/leanprover/lake/blob/master/README.md).

Refs: #6140, lean-merge-discipline.md §1, §B body template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)