### PR TITLE
fix(csp-9): restore markdown newlines in 6 collapsed cells (See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
@@ -242,7 +242,29 @@
    "id": "cc993327",
    "metadata": {},
    "source": [
-    "## 2. Asynchronous Backtracking (ABT)### PrincipeABT (Yokoo, Durfee, Ishida, Kuwabara, 1992) est l'algorithme de référence pour DisCSP :1. **Ordre total** : Les agents sont ordonnés $a_1 < a_2 < ... < a_n$2. **Propagation avant** : Les agents de haute priorité envoient leurs valeurs3. **Nogoods** : Les agents de basse priorité génèrent des explications d'échec4. **Asynchronie** : Chaque agent traite les messages indépendamment### Types de messages ABT| Message | Direction | Contenu ||---------|-----------|---------|| `ok?` | Haute → Basse priorité | Assignation courante || `nogood` | Basse → Haute priorité | Ensemble incohérent (variables, valeurs) || `addlink` | Basse → Haute priorité | Demande d'envoi d'assignation || `stop` | Quelconque | Notification d'arrêt (pas de solution) |### Vue d'agent (`agent_view`)Chaque agent $a_i$ maintient une **vue** des assignations des agents de **haute priorité** dont il a reçu un `ok?`. Sa cohérence est vérifiée par rapport à cette vue + ses nogoods appris."
+    "## 2. Asynchronous Backtracking (ABT)\n",
+    "\n",
+    "### Principe\n",
+    "\n",
+    "ABT (Yokoo, Durfee, Ishida, Kuwabara, 1992) est l'algorithme de référence pour DisCSP :\n",
+    "\n",
+    "1. **Ordre total** : Les agents sont ordonnés $a_1 < a_2 < ... < a_n$\n",
+    "2. **Propagation avant** : Les agents de haute priorité envoient leurs valeurs\n",
+    "3. **Nogoods** : Les agents de basse priorité génèrent des explications d'échec\n",
+    "4. **Asynchronie** : Chaque agent traite les messages indépendamment\n",
+    "\n",
+    "### Types de messages ABT\n",
+    "\n",
+    "| Message | Direction | Contenu |\n",
+    "|---------|-----------|---------|\n",
+    "| `ok?` | Haute → Basse priorité | Assignation courante |\n",
+    "| `nogood` | Basse → Haute priorité | Ensemble incohérent (variables, valeurs) |\n",
+    "| `addlink` | Basse → Haute priorité | Demande d'envoi d'assignation |\n",
+    "| `stop` | Quelconque | Notification d'arrêt (pas de solution) |\n",
+    "\n",
+    "### Vue d'agent (`agent_view`)\n",
+    "\n",
+    "Chaque agent $a_i$ maintient une **vue** des assignations des agents de **haute priorité** dont il a reçu un `ok?`. Sa cohérence est vérifiée par rapport à cette vue + ses nogoods appris."
    ]
   },
   {
@@ -689,7 +711,26 @@
    "id": "c53c4f6e",
    "metadata": {},
    "source": [
-    "### Analyse de l'implémentation ABT**Architecture de l'agent ABT** :| Méthode | Responsabilité | Clé pour ABT ||---------|----------------|--------------|| `CheckConsistency()` | Vérifie la cohérence avec agent_view et nogoods | Coeur de la cohérence locale || `ChooseValue()` | Sélectionne la première valeur du domaine compatible avec agent_view | Heuristique de choix simple || `ProcessOkMessage()` | Traite un assignement reçu d'un agent de haute priorité | Bootstrap + propagation avant || `ProcessNogoodMessage()` | Apprend un nogood, eventuellement demande un addlink | Apprentissage par nogood |**Architecture du système** :| Méthode | Responsabilité ||---------|----------------|| `Run()` | Boucle de simulation : dépile la file, dispatche au bon agent, vérifie la quiescence || `VerifyGlobalConstraints()` | Vérifie CHAQUE arête du graphe (et pas seulement la vue locale de chaque agent) || `OnAwcReorder()` | Recalcule l'ordre après promotion AWC puis émet une nouvelle vague de `ok?` |**Compromis** : `CheckSolution()` teste la cohérence **locale** (par vue), `VerifyGlobalConstraints()` teste la cohérence **globale** (par arête). Les deux ensemble évitent les faux positifs (succès locaux incompatibles via des agents non reliés par priorité)."
+    "### Analyse de l'implémentation ABT\n",
+    "\n",
+    "**Architecture de l'agent ABT** :\n",
+    "\n",
+    "| Méthode | Responsabilité | Clé pour ABT |\n",
+    "|---------|----------------|--------------|\n",
+    "| `CheckConsistency()` | Vérifie la cohérence avec agent_view et nogoods | Coeur de la cohérence locale |\n",
+    "| `ChooseValue()` | Sélectionne la première valeur du domaine compatible avec agent_view | Heuristique de choix simple |\n",
+    "| `ProcessOkMessage()` | Traite un assignement reçu d'un agent de haute priorité | Bootstrap + propagation avant |\n",
+    "| `ProcessNogoodMessage()` | Apprend un nogood, eventuellement demande un addlink | Apprentissage par nogood |\n",
+    "\n",
+    "**Architecture du système** :\n",
+    "\n",
+    "| Méthode | Responsabilité |\n",
+    "|---------|----------------|\n",
+    "| `Run()` | Boucle de simulation : dépile la file, dispatche au bon agent, vérifie la quiescence |\n",
+    "| `VerifyGlobalConstraints()` | Vérifie CHAQUE arête du graphe (et pas seulement la vue locale de chaque agent) |\n",
+    "| `OnAwcReorder()` | Recalcule l'ordre après promotion AWC puis émet une nouvelle vague de `ok?` |\n",
+    "\n",
+    "**Compromis** : `CheckSolution()` teste la cohérence **locale** (par vue), `VerifyGlobalConstraints()` teste la cohérence **globale** (par arête). Les deux ensemble évitent les faux positifs (succès locaux incompatibles via des agents non reliés par priorité)."
    ]
   },
   {
@@ -1040,7 +1081,32 @@
    "id": "b35ae939",
    "metadata": {},
    "source": [
-    "### Analyse de l'extension AWC**Ajouts par rapport à ABT** :| Méthode/Attribut | Rôle | Impact ||------------------|------|--------|| `AwcRank` | Rang dynamique de l'agent (float) | Diminue quand l'agent est promu || `NogoodsReceived` | Compteur de nogoods reçus depuis la dernière promotion | Détecte les blocages répétés || `PrioritySortKey()` | Surcharge : trie par `(awc_rank, id)` au lieu de `(id, id)` | Pris en compte par `ABTSystem.SetupPriorityOrder` || `IncreasePriority()` | Décrémente `awc_rank` puis appelle `System.OnAwcReorder()` | Réordonnancement effectif |**Cycle de promotion AWC** :```agent reçoit nogood → NogoodsReceived++                              ↓       NogoodsReceived > 3 ?  --non--> continue normalement                              ↓ oui                  AwcRank -= 1.0  (monte dans la hierarchie)                              ↓                  OnAwcReorder()  (recalcule higher/lower)                              ↓                  ré-émet ok? vers lower-priority```**Limitation pédagogique** : Cette implémentation simule l'idée du réordonnancement AWC sans être le protocole complet Yokoo 1995 (qui maintient une heap de nogoods et balance aussi le `awc_rank` avec des bornes). Elle capture l'essentiel : la dynamique de promotion modifie réellement la trajectoire de résolution."
+    "### Analyse de l'extension AWC\n",
+    "\n",
+    "**Ajouts par rapport à ABT** :\n",
+    "\n",
+    "| Méthode/Attribut | Rôle | Impact |\n",
+    "|------------------|------|--------|\n",
+    "| `AwcRank` | Rang dynamique de l'agent (float) | Diminue quand l'agent est promu |\n",
+    "| `NogoodsReceived` | Compteur de nogoods reçus depuis la dernière promotion | Détecte les blocages répétés |\n",
+    "| `PrioritySortKey()` | Surcharge : trie par `(awc_rank, id)` au lieu de `(id, id)` | Pris en compte par `ABTSystem.SetupPriorityOrder` |\n",
+    "| `IncreasePriority()` | Décrémente `awc_rank` puis appelle `System.OnAwcReorder()` | Réordonnancement effectif |\n",
+    "\n",
+    "**Cycle de promotion AWC** :\n",
+    "\n",
+    "```\n",
+    "agent reçoit nogood → NogoodsReceived++\n",
+    "                             ↓\n",
+    "      NogoodsReceived > 3 ?  --non--> continue normalement\n",
+    "                             ↓ oui\n",
+    "                 AwcRank -= 1.0  (monte dans la hierarchie)\n",
+    "                             ↓\n",
+    "                 OnAwcReorder()  (recalcule higher/lower)\n",
+    "                             ↓\n",
+    "                 ré-émet ok? vers lower-priority\n",
+    "```\n",
+    "\n",
+    "**Limitation pédagogique** : Cette implémentation simule l'idée du réordonnancement AWC sans être le protocole complet Yokoo 1995 (qui maintient une heap de nogoods et balance aussi le `awc_rank` avec des bornes). Elle capture l'essentiel : la dynamique de promotion modifie réellement la trajectoire de résolution."
    ]
   },
   {
@@ -1158,7 +1224,28 @@
    "id": "c72f1676",
    "metadata": {},
    "source": [
-    "### Analyse de l'implémentation privacy-preserving**Classes pour la protection de la vie privée** :| Classe | Responsabilité | Technique de protection ||--------|----------------|-------------------------|| `PrivateConstraint` | Encapsule une contrainte sensible | Chiffrement des paramètres || `PrivacyPreservingAgent` | Agent avec contraintes privées | Évaluation sélective |**Mécanisme de protection** :```csharppublic bool Evaluate(object value, byte[]? key = null){    if (key == null) return true;  // Mode privé : toujours accepter    return RealEvaluate(value);     // Mode deverrouille : évaluation réelle}```**Quand un agent externe demande l'évaluation d'une contrainte sans la clé**, la méthode renvoie `true` (accepte toujours) — **aucune information révélée**. Quand la clé est fournie (par exemple à un médiateur de confiance), l'évaluation réelle est appliquée.**Trade-off** : Sans la clé, l'agent distant **ne peut pas distinguer** une contrainte satisfaite d'une contrainte violée, ce qui préserve la vie privée mais empêche la résolution exacte. Pour une résolution réelle, on combine ce mécanisme avec un protocole de secure MPC (hors scope de ce notebook)."
+    "### Analyse de l'implémentation privacy-preserving\n",
+    "\n",
+    "**Classes pour la protection de la vie privée** :\n",
+    "\n",
+    "| Classe | Responsabilité | Technique de protection |\n",
+    "|--------|----------------|-------------------------|\n",
+    "| `PrivateConstraint` | Encapsule une contrainte sensible | Chiffrement des paramètres |\n",
+    "| `PrivacyPreservingAgent` | Agent avec contraintes privées | Évaluation sélective |\n",
+    "\n",
+    "**Mécanisme de protection** :\n",
+    "\n",
+    "```csharp\n",
+    "public bool Evaluate(object value, byte[]? key = null)\n",
+    "{\n",
+    "    if (key == null) return true;  // Mode privé : toujours accepter\n",
+    "    return RealEvaluate(value);     // Mode deverrouille : évaluation réelle\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "**Quand un agent externe demande l'évaluation d'une contrainte sans la clé**, la méthode renvoie `true` (accepte toujours) — **aucune information révélée**. Quand la clé est fournie (par exemple à un médiateur de confiance), l'évaluation réelle est appliquée.\n",
+    "\n",
+    "**Trade-off** : Sans la clé, l'agent distant **ne peut pas distinguer** une contrainte satisfaite d'une contrainte violée, ce qui préserve la vie privée mais empêche la résolution exacte. Pour une résolution réelle, on combine ce mécanisme avec un protocole de secure MPC (hors scope de ce notebook)."
    ]
   },
   {
@@ -1554,7 +1641,21 @@
    "id": "c2a79964",
    "metadata": {},
    "source": [
-    "### Interprétation des résultats du benchmark**Lecture** : le benchmark génère `n_runs` instances aléatoires de coloration de graphe avec `n_agents` agents, un domaine de taille `domain_size`, et une densité de contraintes `constraint_density`. Pour chaque instance, ABT et AWC sont exécutés jusqu'à quiescence.**Ordres de grandeur attendus** (n_agents=5, domain_size=3, density=0.5) :| Métrique | ABT | AWC | Lecture ||----------|-----|-----|--------|| Messages | 10-50 | similaire ou un peu moins | trafic d'`ok?` + `nogood` + `addlink` || Nogoods | 0-10 | 0-10 | dépend du nombre de conflits || Taux de succès | 80-100% | 80-100% | la plupart des instances 5/3 sont solvables |**Sur des instances plus denses** (density ≥ 0.8) ou avec un ratio agents/domaine défavorable, AWC prend l'avantage grâce à la promotion dynamique qui sort l'algorithme des blocages.**Limitation** : la promotion AWC pédagogique (seuil `NogoodsReceived > 3`) est plus simple que le protocole Yokoo 1995. Sur des instances jouets, la différence ABT/AWC reste marginale ; sur des benchmarks几百変数, l'écart devient significatif."
+    "### Interprétation des résultats du benchmark\n",
+    "\n",
+    "**Lecture** : le benchmark génère `n_runs` instances aléatoires de coloration de graphe avec `n_agents` agents, un domaine de taille `domain_size`, et une densité de contraintes `constraint_density`. Pour chaque instance, ABT et AWC sont exécutés jusqu'à quiescence.\n",
+    "\n",
+    "**Ordres de grandeur attendus** (n_agents=5, domain_size=3, density=0.5) :\n",
+    "\n",
+    "| Métrique | ABT | AWC | Lecture |\n",
+    "|----------|-----|-----|--------|\n",
+    "| Messages | 10-50 | similaire ou un peu moins | trafic d'`ok?` + `nogood` + `addlink` |\n",
+    "| Nogoods | 0-10 | 0-10 | dépend du nombre de conflits |\n",
+    "| Taux de succès | 80-100% | 80-100% | la plupart des instances 5/3 sont solvables |\n",
+    "\n",
+    "**Sur des instances plus denses** (density ≥ 0.8) ou avec un ratio agents/domaine défavorable, AWC prend l'avantage grâce à la promotion dynamique qui sort l'algorithme des blocages.\n",
+    "\n",
+    "**Limitation** : la promotion AWC pédagogique (seuil `NogoodsReceived > 3`) est plus simple que le protocole Yokoo 1995. Sur des instances jouets, la différence ABT/AWC reste marginale ; sur des benchmarks plus volumineux, l'écart devient significatif."
    ]
   },
   {
@@ -2533,7 +2634,33 @@
    "id": "3bff6eac",
    "metadata": {},
    "source": [
-    "## Synthèse et bonnes pratiques### Quand utiliser DisCSP ?| Scénario | DisCSP approprié ? | Algorithme recommandé ||----------|-------------------|----------------------|| Quelques agents, communication bon marché | ✅ Oui | ABT simple || Beaucoup d'agents, fréquents blocages | ✅ Oui | AWC (reordonnancement) || Contraintes confidentielles (santé, business) | ✅ Oui | Privacy-Preserving || Problème solvable par un solveur centralisé | ❌ Non | OR-Tools / Choco || Contraintes très denses (Densité ≥ 0.9) | ⚠️ Difficile | AWC + heuristics ou DPOP |### Comparaison avec les solveurs centralisés (CSP-1 à CSP-8)| Aspect | Solveur centralisé | DisCSP ||--------|-------------------|--------|| Scalabilité | Bornée par mémoire centrale | Distribuée linéairement || Confidentialité | Toutes contraintes visibles | Locale + sélective || Convergence | Garantie (algorithme complet) | Garantie (ABT/AWC complets) || Mise en œuvre | Simple (un seul programme) | Complexe (gestion messages) |### Bonnes pratiques d'implémentation1. **Tester sur petits graphes d'abord** (4-6 agents) avant de monter en taille2. **Vérifier les arêtes** : `VerifyGlobalConstraints()` est essentiel (cohérence locale ne suffit pas)3. **Statistiques** : suivez `messages_sent`, `nogoods_generated` pour comprendre le comportement4. **AWC progressive** : commencez par ABT, passez à AWC seulement si vous voyez des blocages"
+    "## Synthèse et bonnes pratiques\n",
+    "\n",
+    "### Quand utiliser DisCSP ?\n",
+    "\n",
+    "| Scénario | DisCSP approprié ? | Algorithme recommandé |\n",
+    "|----------|-------------------|----------------------|\n",
+    "| Quelques agents, communication bon marché | ✅ Oui | ABT simple |\n",
+    "| Beaucoup d'agents, fréquents blocages | ✅ Oui | AWC (reordonnancement) |\n",
+    "| Contraintes confidentielles (santé, business) | ✅ Oui | Privacy-Preserving |\n",
+    "| Problème solvable par un solveur centralisé | ❌ Non | OR-Tools / Choco |\n",
+    "| Contraintes très denses (Densité ≥ 0.9) | ⚠️ Difficile | AWC + heuristics ou DPOP |\n",
+    "\n",
+    "### Comparaison avec les solveurs centralisés (CSP-1 à CSP-8)\n",
+    "\n",
+    "| Aspect | Solveur centralisé | DisCSP |\n",
+    "|--------|-------------------|--------|\n",
+    "| Scalabilité | Bornée par mémoire centrale | Distribuée linéairement |\n",
+    "| Confidentialité | Toutes contraintes visibles | Locale + sélective |\n",
+    "| Convergence | Garantie (algorithme complet) | Garantie (ABT/AWC complets) |\n",
+    "| Mise en œuvre | Simple (un seul programme) | Complexe (gestion messages) |\n",
+    "\n",
+    "### Bonnes pratiques d'implémentation\n",
+    "\n",
+    "1. **Tester sur petits graphes d'abord** (4-6 agents) avant de monter en taille\n",
+    "2. **Vérifier les arêtes** : `VerifyGlobalConstraints()` est essentiel (cohérence locale ne suffit pas)\n",
+    "3. **Statistiques** : suivez `messages_sent`, `nogoods_generated` pour comprendre le comportement\n",
+    "4. **AWC progressive** : commencez par ABT, passez à AWC seulement si vous voyez des blocages"
    ]
   },
   {


### PR DESCRIPTION
## Défaut

6 cellules markdown de `CSP-9-Distributed-Csharp.ipynb` (idx 4, 8, 17, 20, 26, 45) avaient leurs **newlines stripped** : titres `##`/`###`, prose, lignes de table (`| col ||---|`), blocs de code (``` ``` ``` et ``` ```csharp ```), et listes numérotées étaient **toutes collées sur une seule ligne** par cellule.

Rendu cassé : nbconvert parsait **0 table** dans le fichier base (le défaut "mal affiché" / "titres difficilement visibles" de #3966 — NON détecté par `scan_md_hierarchy.py` qui est clean 0/951, car ce scanner vérifie la hiérarchie md, pas la structure des lignes de table).

## Fix

Ré-insertion des newlines aux boundaries structurelles (headers `##`/`###`, lead-ins `**bold** :`, lignes de table, fences de code, items de liste). Stocké en **list-of-lines** (forme canonique nbformat splitlines, cohérent avec les 41/47 cellules list-form du notebook).

## Scope (anti-G.4)

- **Markdown-only** : 0 cellule code touchée. Les 19 cellules code (sources + `execution_count` + `outputs`) sont **byte-identiques** au base.
- **Single-file atomique** : seul `CSP-9-Distributed-Csharp.ipynb`. Les 6 autres notebooks affectés par le même défaut systémique (Sudoku-12-Z3-Python, QC-Py-04, Planners-5, Tweety-10, HunyuanVideo, ICT-24) = tranches follow-up séparées.
- **C.2 exception** : modifs uniquement markdown → pas de re-exécution (outputs précédents valides).

## Content note (transparence)

Cell 26 contenait une corruption CJK (`几百変数` = garbage chinois/japonais dans un notebook français). Remplacé par `plus volumineux` (rendu français du contexte « sur des benchmarks plus volumineux, l'écart devient significatif »). Même événement de défaut que le collapse.

## Validation (H.1)

| Check | Base | Fixé |
|-------|------|------|
| `scan_md_hierarchy.py` | clean | clean (0/1) |
| nbconvert markdown — lignes `^|` | **0** | **45** |
| nbconvert HTML — `<table>` | 0 | **8** |
| nbconvert HTML — `<h2>/<h3>` | — | **31** |
| Tokens non-whitespace (notebook entier) | 46697 | 46697 (égal) |
| Code cells (sources + exec_count + outputs) | — | byte-identiques |
| CRLF | — | 0 (LF enforced) |
| Catalogue | — | byte-identique à main |

**Preuve du défaut** : le base fichier rendait **0 table** (tout collé) → le fix rend **45 lignes de table / 8 `<table>` / 31 titres**.

See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
