### PR TITLE
fix(sudoku-12): restore markdown newlines in collapsed SAT/SMT table (See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -115,7 +115,13 @@
     "tags": []
    },
    "source": [
-    "### Différence entre SAT et SMT| SAT | SMT ||-----|-----|| Variables booléennes uniquement | Variables typées (Int, Real, BitVec, Array...) || Clauses propositionnelles | Formules de premier ordre || `(x OR y) AND (NOT x OR z)` | `x + y > 10 AND x < 5` |"
+    "### Différence entre SAT et SMT\n",
+    "\n",
+    "| SAT | SMT |\n",
+    "|-----|-----|\n",
+    "| Variables booléennes uniquement | Variables typées (Int, Real, BitVec, Array...) |\n",
+    "| Clauses propositionnelles | Formules de premier ordre |\n",
+    "| `(x OR y) AND (NOT x OR z)` | `x + y > 10 AND x < 5` |"
    ]
   },
   {


### PR DESCRIPTION
## Défaut

Cell 3 (`### Différence entre SAT et SMT`) de `Sudoku-12-Z3-Python.ipynb` avait ses **newlines stripped** : la table de comparaison SAT-vs-SMT (5 lignes) était collée sur **une seule ligne** → rendu cassé (classe de défaut #3966 "mal affiché").

## Fix

Ré-insertion des newlines aux boundaries (titre, lignes de table, séparateur). Forme list-of-lines (canonique nbformat).

## Scope

- **Single-cell markdown-only** : seule cell 3 touchée. 19 cellules code (sources + `execution_count` + `outputs`) byte-identiques au base.
- **C.2 exception** : modifs uniquement markdown → pas de re-exec.
- G.1 firsthand : les cells 11/15/16 (flaggées par l'heuristique `glued_sep`) sont des **faux positifs** — elles ont des newlines propres (15/17/29) et des séparateurs de table sur leur propre ligne. Seule cell 3 est collapsed.

## Validation (H.1)

| Check | Base | Fixé |
|-------|------|------|
| `scan_md_hierarchy.py` | clean | clean (0/1) |
| nbconvert markdown — lignes `^|` | 16 | **21** (+5 = table SAT/SMT) |
| Code cells (sources + exec_count + outputs) | — | byte-identiques |
| CRLF | — | 0 |
| Catalogue | — | byte-identique à main |

Tranche 2/7 du défaut systémique collapsed-markdown #3966 (cf PR #6188 CSP-9 pour la tranche 1).

See #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)
