### PR TITLE
fix(qc-mcp-lite): read totalOrders + Net Profit from the real QC fields

### DIFF
--- a/scripts/qc-mcp-lite/server.py
+++ b/scripts/qc-mcp-lite/server.py
@@ -90,12 +90,42 @@ def _api_post(path: str, data: Optional[dict] = None) -> dict:
     return payload
 
 
+def _parse_int(value: Any) -> int:
+    """Parse a QC statistics string to int.
+
+    QC statistics values are strings ('318', '1,234', '-'); '-' is the
+    'not applicable' marker (a 0-trade backtest shows '-' for several fields).
+    Returns 0 for None, '', '-', or anything unparseable.
+    """
+    if value is None:
+        return 0
+    text = str(value).strip().replace(",", "")
+    if text in ("", "-", "nan", "NaN", "None"):
+        return 0
+    try:
+        return int(float(text))
+    except (ValueError, TypeError):
+        return 0
+
+
 def _extract_stats(bt: dict) -> dict:
     stats = bt.get("statistics", {}) or {}
+    runtime_stats = bt.get("runtimeStatistics", {}) or {}
     # Surface runtime errors so a failed backtest is diagnosable without a
     # separate raw dump (QC returns 'error' + 'stacktrace' on Runtime Error).
     error = bt.get("error") or ""
     stacktrace = bt.get("stacktrace") or ""
+    # totalOrders is NOT reliably at the top level of the QC backtests/read
+    # object: on completed backtests it is null there. The authoritative count
+    # lives in statistics['Total Orders'] (a string like '318'). The top-level
+    # field is only used as a fallback for summary/list responses that omit the
+    # statistics dict. Without this, a real strategy that placed 318 orders is
+    # reported as totalOrders=0 and falsely diagnosed as 'never traded'.
+    total_orders_raw = stats.get("Total Orders")
+    if total_orders_raw not in (None, "", "-"):
+        total_orders = _parse_int(total_orders_raw)
+    else:
+        total_orders = bt.get("totalOrders") or 0
     result = {
         "backtestId": bt.get("backtestId", ""),
         "name": bt.get("name", ""),
@@ -103,19 +133,28 @@ def _extract_stats(bt: dict) -> dict:
         "created": bt.get("created", ""),
         "completed": bt.get("completed", ""),
         "tradeableDates": bt.get("tradeableDates", 0),
-        "totalOrders": bt.get("totalOrders") or 0,
+        "totalOrders": total_orders,
         "equity": bt.get("equity", {}),
         "statistics": {
             "sharpeRatio": stats.get("Sharpe Ratio", "-"),
             "compoundingAnnualReturn": stats.get("Compounding Annual Return", "-"),
             "drawdown": stats.get("Drawdown", "-"),
-            "totalNetProfit": stats.get("Total Net Profit", "-"),
+            # QC's statistics dict keys net profit as 'Net Profit' (a
+            # percentage like '76.088%'), NOT 'Total Net Profit' — the latter
+            # is a runtimeStatistics label and never appears in statistics.
+            "totalNetProfit": stats.get("Net Profit", "-"),
             "probabilisticSharpeRatio": stats.get(
                 "Probabilistic Sharpe Ratio", "-"
             ),
         },
         "progress": bt.get("progress", 0),
     }
+    # Surface the dollar-denominated net profit from runtimeStatistics (e.g.
+    # '$59,745.60') alongside the percentage figure in statistics — useful for
+    # diagnosis and disambiguates the '%' return from an absolute PnL.
+    runtime_profit = runtime_stats.get("Net Profit")
+    if runtime_profit:
+        result["statistics"]["netProfitAbsolute"] = runtime_profit
     if error or stacktrace:
         # 'error' and 'stacktrace' are often identical; keep both but cap size.
         result["error"] = error[:1200]

--- a/scripts/qc-mcp-lite/tests/test_server.py
+++ b/scripts/qc-mcp-lite/tests/test_server.py
@@ -182,7 +182,7 @@ class TestExtractStats:
                 "Sharpe Ratio": "1.234",
                 "Compounding Annual Return": "12.5%",
                 "Drawdown": "8.3%",
-                "Total Net Profit": "$10,000",
+                "Net Profit": "$10,000",
                 "Probabilistic Sharpe Ratio": "0.95",
             },
         }
@@ -232,6 +232,55 @@ class TestExtractStats:
         """totalOrders could be None/0 from QC API."""
         result = _extract_stats({"totalOrders": None})
         assert result["totalOrders"] == 0
+
+    def test_real_qc_payload_orders_not_lost(self):
+        """Regression (verified firsthand against QC backtests/read c.332): a
+        completed backtest has totalOrders=null at the top level and the real
+        count lives in statistics['Total Orders']. The old code read the
+        top-level field and reported 0 — a strategy that placed 318 orders was
+        falsely diagnosed as 'never traded' (cf issue #6192). statistics is the
+        authoritative source."""
+        bt = {
+            "backtestId": "33286487",
+            "name": "1630-DualMomentum-aligned",
+            "status": "Completed.",
+            "totalOrders": None,  # QC returns null here, NOT the count
+            "tradeableDates": 1761,
+            "statistics": {
+                "Total Orders": "318",
+                "Net Profit": "76.088%",
+                "Sharpe Ratio": "0.35",
+                "Compounding Annual Return": "8.413%",
+                "Drawdown": "14.900%",
+                "Probabilistic Sharpe Ratio": "1.719%",
+            },
+            "runtimeStatistics": {
+                "Net Profit": "$59,745.60",
+                "Return": "76.09 %",
+            },
+        }
+        result = _extract_stats(bt)
+        assert result["totalOrders"] == 318  # NOT 0
+        assert result["statistics"]["totalNetProfit"] == "76.088%"  # NOT "-"
+        assert result["statistics"]["netProfitAbsolute"] == "$59,745.60"
+        assert result["statistics"]["sharpeRatio"] == "0.35"
+
+    def test_zero_orders_in_statistics_stays_zero(self):
+        """A genuinely 0-trade backtest (statistics['Total Orders']='0' or '-')
+        must still report 0 — preserves the real 0-trade signal that the
+        regression guard above must not mask."""
+        assert _extract_stats(
+            {"statistics": {"Total Orders": "0"}}
+        )["totalOrders"] == 0
+        assert _extract_stats(
+            {"statistics": {"Total Orders": "-"}}
+        )["totalOrders"] == 0
+
+    def test_total_orders_parses_thousands_separator(self):
+        """QC formats large counts with commas ('1,234') — must parse to int."""
+        assert _extract_stats(
+            {"statistics": {"Total Orders": "1,234"}}
+        )["totalOrders"] == 1234
 
     def test_surfaces_runtime_error(self):
         """A failed backtest must surface error/stacktrace for diagnosis."""


### PR DESCRIPTION
## What

`_extract_stats` reported **0 orders** and **Net Profit "-"** for backtests that actually traded — reading two wrong fields from the QC `backtests/read` response.

## Root cause

| Field | Old (buggy) source | Real QC source |
|-------|--------------------|----------------|
| `totalOrders` | `bt.get("totalOrders")` (null at top level on completed backtests) | `statistics["Total Orders"]` (e.g. `"318"`) |
| `totalNetProfit` | `statistics["Total Net Profit"]` (key does not exist) | `statistics["Net Profit"]` (e.g. `"76.088%"`) |

A strategy that placed 318 orders at +76% was diagnosed as **"never traded"** (issue #6192, and a false `★ Baselines 1630-aligned 0-trade` finding I propagated to memory + dashboard in c.330-c.331). **The strategies were fine; the stats extractor was reading the wrong fields.** This is a G.1/G.9 correction — I did not cross-check the raw API payload before diagnosing.

## Fix

- `statistics["Total Orders"]` is authoritative; the top-level `totalOrders` is kept as a fallback for summary/list responses that omit the statistics dict.
- `totalNetProfit` reads `statistics["Net Profit"]`.
- New `netProfitAbsolute` surfaces `runtimeStatistics["Net Profit"]` (dollar PnL, e.g. `$59,745.60`) for diagnosis — disambiguates the `%` return from absolute PnL.
- New `_parse_int` helper tolerates `"-"` (QC's not-applicable marker), thousands separators, and garbage.

## Verification (firsthand, G.1)

End-to-end against QC `backtests/read` on project `1630-DualMomentum-aligned` (33286487):

| backtest | totalOrders (was→now) | totalNetProfit (was→now) | netProfitAbsolute |
|----------|----------------------|--------------------------|-------------------|
| `dc3dca74…` (po2026-validation) | 0 → **318** | "-" → **76.088%** | $59,745.60 |
| `b1cb13c9…` (aligned-2018-2024) | 0 → **318** | "-" → **76.083%** | $59,739.34 |

Both backtests now report real order counts and net profit. Sharpe/CAGR/Drawdown were already correct (they read from `statistics` keys that happened to match).

## Tests

`pytest tests/test_server.py` → **53 passed** (was 50; +3 regression tests):
- `test_real_qc_payload_orders_not_lost` — locks the firsthand-verified real QC payload shape (`totalOrders: None` top-level + `statistics["Total Orders"]: "318"`).
- `test_zero_orders_in_statistics_stays_zero` — a genuinely 0-trade backtest still reports 0 (preserves the real signal).
- `test_total_orders_parses_thousands_separator` — `"1,234"` → `1234`.

The pre-existing `test_full_stats` fixture used the wrong key (`"Total Net Profit"`) — it encoded the same bug, so it is corrected to `"Net Profit"`.

## Scope

Bounded: 2 files (`server.py` + test), +91/-3. No change to the tool surface or auth/rate-limit logic. No catalogue/README touch.

## Follow-up (separate)

- Rectify issue #6192: the "0-trade baselines" premise is **false** — strategies traded (318 orders, +76%). The real bug was here, not in the baselines.
- Correct the false finding in memory `qc-mcp-lite-backtest-setup.md`.

See #6192

🤖 Generated with [Claude Code](https://claude.com/claude-code)