### PR TITLE
docs(lean,#4980): grothendieck_lean/Grothendieck/YonedaLemma bilingual FR+EN inline extension (PIVOT L335 strict c.381 — registre grothendieck_lean ≠ conway_lean)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/YonedaLemma.lean
@@ -29,6 +29,85 @@ learners encountering the Yoneda lemma for the first time:
 Epic #1646, #2159 (Phase 2+). Zero unresolved goals at creation.
 -/
 
+/-
+  `Grothendieck.YonedaLemma` — Le lemme de Yoneda
+  ===============================================
+  Hommage à Grothendieck — Partie 24 : Le lemme de Yoneda
+  Alexandre Grothendieck (1928-2014).
+
+  Extension Phase 2+ (#2159, Epic #1646).
+
+  Le lemme de Yoneda est LE théorème fondamental de la théorie des catégories.
+  C'est l'épine dorsale de la reformulation grothendieckienne de la géométrie
+  algébrique : par Yoneda, les objets d'une catégorie sont déterminés par les
+  préfaisceaux qu'ils représentent.
+
+  Mathlib 4 formalise déjà toute l'infrastructure Yoneda dans
+  `Mathlib.CategoryTheory.Yoneda` :
+    - `yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁)` — le plongement de Yoneda
+    - `yonedaEquiv : (yoneda.obj X ⟶ F) ≃ F.obj (op X)` — l'équivalence au
+      niveau des types
+    - `yonedaEquiv_naturality` — la naturalité en `X`
+    - `yonedaLemma : yonedaPairing C ≅ yonedaEvaluation C` — l'isomorphisme
+      naturel
+    - `fullyFaithful yoneda` — le plongement de Yoneda est pleinement fidèle
+      (corollaire)
+
+  Ce module ré-expose ces faits comme un parcours pédagogique organisé, pour
+  des apprenants découvrant le lemme de Yoneda pour la première fois :
+
+    1. Énoncé du plongement de Yoneda.
+    2. Le lemme de Yoneda comme équivalence au niveau des types.
+    3. Naturalité : la bijection est naturelle en `X` et en `F`.
+    4. Plénitude et fidélité : le plongement de Yoneda est pleinement fidèle.
+    5. Le dual covariant (`coyoneda`).
+    6. La fonctorialité retrouve `Hom(y, x) → Nat(yoneda.y, yoneda.x)`.
+
+  Epic #1646, #2159 (Phase 2+). Aucun but non-résolu à la création.
+
+  ### i18n — convention #4980 ratifiée 2026-07-04
+
+  Ce sous-module suit l'option A (bilingue inline FR/EN), variante pragmatique
+  c.381 (deux blocs `/` top-level distincts, sans `---` interne, analogue
+  c.376/c.377/c.378/c.379/c.380) : le bloc EN existant est préservé verbatim
+  ci-dessus, le bloc FR miroir est ajouté juste après sans séparateur `---`.
+  Convention sibling pair (`<Foo>_en.lean` à part) réservée aux modules de
+  substance (cf c.374 `Astar_en.lean`) ; pour les modules de formalisation
+  comme `YonedaLemma`, l'inline FR+EN est le bon compromis (peu de code, deux
+  langues côte à côte). Les énoncés de théorèmes/lemmes, les tactiques Lean et
+  les références Mathlib restent en anglais (compat Mathlib 4, tactic DSL) ;
+  seules les **docstrings `/-- ... -/`** et les **commentaires `-- ...`**
+  bilingues sont ajoutées. Anti-§D byte-identity garanti : le namespace body
+  est préservé bit-pour-bit.
+
+  ### PIVOT L335 strict c.381 — registre `grothendieck_lean` ≠ conway_lean
+
+  c.377-c.380 = 4 cycles R6 Sustained intra-R6 sur registre `conway_lean`
+  (MathlibMap c.377, LookAndSay c.378, Fractran c.379, Doomsday c.380). c.381
+  pivote vers le lac `grothendieck_lean` (registre distinct, substance réelle
+  = lemme de Yoneda), parallèle au rollout Phase 1+ de `conway_lean`. Initie
+  le rollout `grothendieck_lean` Phase 2+ post-c.367 (`Grothendieck.lean`
+  racine bilingue inline MERGED #6115). Backlog c.382+ : `Grothendieck/
+  {Sheafification,SitePoints,Conservative,MayerVietorisSquare,
+  SheafBasics,SieveLattice,CategoryAndSites,YonedaLemma_lemmas,
+  SheafCohomology/*,Calibration,SchemesTour,Subcanonical,ZariskiSite,
+  DenseTopology,SieveGenerate,LeftExact,SheafHom,SieveOps,
+  CoverageGen,MathlibMap}.lean` (22 sous-modules backlog Phase 2+).
+
+  Cross-références : c.366 `#6111` `Conway.lean` racine bilingue (MERGED) +
+  c.367 `#6115` `Grothendieck.lean` racine bilingue (MERGED, option A) +
+  c.373 `#6156` `Knots.lean` racine bilingue (OPEN) + c.374 `#6163` `Astar`
+  sibling pair (OPEN) + c.375 `#6171` `Knots` sub-modules 5/6 (OPEN) +
+  c.376 `#6173` `Knots/Invariant` 6/6 (OPEN) + c.377 `#6178` `MathlibMap`
+  bilingue (premier sous-module rollout conway_lean, PIVOT L335 strict) +
+  c.378 `#6182` `LookAndSay` bilingue (suite rollout conway_lean) +
+  c.379 `#6190` `Fractran` bilingue (machine universelle Turing-complète) +
+  c.380 `#6194` `Doomsday` bilingue (algorithme Doomsday + 4 `#eval!` cas
+  réels) + **c.381 `YonedaLemma` bilingue (cette PR, lemme fondamental de
+  théorie des catégories)** ← **PIVOT L335 strict** vers `grothendieck_lean`
+  Phase 2+ (registre ≠ conway_lean).
+-/
+
 import Mathlib.CategoryTheory.Yoneda
 
 namespace Grothendieck


### PR DESCRIPTION
## Substance

Extension bilingue FR/EN inline du pattern option A (variante pragmatique
c.376/c.377/c.378/c.379/c.380 : deux blocs `/` top-level distincts, sans `---`
interne) au **PIVOT L335 strict** vers le lac `grothendieck_lean` Phase 2+
(initié par c.367 `Grothendieck.lean` racine bilingue inline MERGED #6115) :

- **`Grothendieck/YonedaLemma.lean`** (+79/-0) — module de formalisation du
  **lemme de Yoneda** (THE foundational theorem of category theory, épine
  dorsale de la reformulation grothendieckienne de la géométrie algébrique).
  Header EN existant préservé verbatim (lignes 1-30) + bloc FR miroir ajouté
  juste après (lignes 32-110) couvrant : énoncé plongement Yoneda, lemme
  Yoneda comme équivalence type-level, naturalité en X et F, fully faithfulness,
  dual covariant (`coyoneda`), fonctorialité retrouve Hom(y,x) →
  Nat(yoneda.y, yoneda.x). Mathlib 4 infrastructure complète déjà formalisée
  dans `Mathlib.CategoryTheory.Yoneda` : `yoneda`, `yonedaEquiv`,
  `yonedaEquiv_naturality`, `yonedaLemma`, `fullyFaithful yoneda`.

**Total : 1 fichier / +79/-0 additif strict.** 0 ligne de code touchée
(hors `/` header) — pure i18n doc.

**PIVOT L335 strict c.381 (registre `grothendieck_lean` ≠ `conway_lean`)** :
c.377-c.380 = 4 cycles R6 Sustained intra-R6 sur registre `conway_lean`
(MathlibMap c.377, LookAndSay c.378, Fractran c.379, Doomsday c.380). c.381
= **5ᵉ cycle R6 Sustained** = **PIVOT L335 strict obligatoire** vers un
nouveau registre Lean. Cible = `grothendieck_lean/Grothendieck/YonedaLemma`
(registre parallèle à conway_lean, substance réelle = lemme de Yoneda, EPIC
#2159 ouvert, c.367 racine déjà MERGED #6115). Initie le rollout Phase 2+ du
lac `grothendieck_lean` (1/22 sous-modules fait après c.381) — backlog c.382+
: `Grothendieck/{Sheafification,SitePoints,Conservative,MayerVietorisSquare,
SheafBasics,SieveLattice,CategoryAndSites,YonedaLemma_lemmas,
SheafCohomology/*,Calibration,SchemesTour,Subcanonical,ZariskiSite,
DenseTopology,SieveGenerate,LeftExact,SheafHom,SieveOps,CoverageGen,
MathlibMap}.lean`.

## Cibles

- **#4980** Phase 2 FR-first bilingual inline (initie rollout `grothendieck_lean`
  Phase 2+, 1/22 sous-modules fait après c.381)
- **#1453** Prover harness co-evolution (YonedaLemma = namespace `Grothendieck`
  racine avec `open CategoryTheory Opposite` + 8 `example` + 5 `theorem` +
  2 `def`, prouveur-friendly par théorème transparent)
- **#3801** Prong B — registre de fond Lean substance
- **#2159** EPIC Grothendieck Phase 2+ — extension formalisation Lean
- **#4365** GT Lean regroupement — c.381 = 8ᵉ cycle R6 Sustained intra-R6 avec
  substance réelle Lean i18n + PIVOT strict

## Pattern

Pour ce sous-module, **deux blocs `/` top-level distincts** au lieu d'un
seul avec `---` interne (variante pragmatique c.376-c.380 reprise pour c.381) :

- **Bloc 1 (lignes 1-30)** : `/` header EN existant **préservé verbatim**
  (intro Grothendieck hommage + Phase 2+ extension + Yoneda = THE foundational
  theorem + Mathlib 4 infrastructure + 6 sections + Epic #1646/#2159 +
  Zero unresolved goals at creation)
- **Bloc 2 (lignes 32-110)** : `/` header FR **miroir**, sans séparateur
  interne (chaque bloc syntaxiquement un commentaire propre, pas de risque
  de confusion avec du markdown via `---`)

Identique au pattern option A inline utilisé par c.366 (Conway hommage racine
MERGED) + c.367 Grothendieck hommage (MERGED) + c.373 (Knots racine OPEN) +
c.375 (Knots sub-modules 5/6 OPEN) + c.376 (Knots/Invariant 6/6 OPEN) +
c.377 (`Conway/MathlibMap` bilingual, premier rollout conway_lean) + c.378
(`Conway/LookAndSay` bilingual, suite rollout) + c.379 (`Conway/Fractran`
bilingual, machine universelle Turing-complète) + c.380 (`Conway/Doomsday`
bilingual, algorithme Doomsday + 4 `#eval!` cas réels). Convention sibling
pair (`<Foo>_en.lean` à part) réservée aux modules de substance (cf c.374
`Astar_en.lean`) ; pour les modules de formalisation comme `YonedaLemma`,
l'inline FR+EN est le bon compromis (peu de code, deux langues côte à côte).

**Subtilité i18n spécifique** : ce module combine un namespace racine
`Grothendieck` (≠ namespace imbriqué c.380 `Conway.DayOfWeek`) avec un
`open CategoryTheory Opposite` post-namespace. Les définitions canoniques
Mathlib (`yoneda`, `yonedaEquiv`, `yonedaEquiv_naturality`, `yonedaLemma`,
`fullyFaithful yoneda`, `coyoneda`, `coyonedaLemma`) restent en anglais dans
les `theorem`/`def` — l'anglais est le tactic DSL standard de Lean/Mathlib.
Seules les **docstrings `/-- ... -/`** et les **commentaires `-- ...`**
bilingues sont ajoutées. Anti-§D byte-identity garanti : le namespace body
est préservé bit-pour-bit (4995 octets extractible byte-identique via
script Python `extract_ns_body`).

## Anti-§D byte-identity

| Bloc vérifié                       | main              | HEAD              | Preuve              |
|------------------------------------|-------------------|-------------------|---------------------|
| `import Mathlib.CategoryTheory.Yoneda` | (byte-identique) | inchangé        | imports = liste 1/1 |
| `namespace Grothendieck` body      | (4995 octets)     | inchangé          | extract_ns_body     |
| 8 `example` + 5 `theorem` + 2 `def` | (byte-identique)  | 0 ligne touchée   | namespace body diff |
| 5 theorem `yoneda_*` + 2 def `*IsoEvaluation` + 3 `example` (yoneda_full, faithful, equiv.refl) | (byte-identique) | 0 ligne touchée | namespace body diff = vide |

La chaîne de compilation est **formellement identique** : l'import
`Mathlib.CategoryTheory.Yoneda` est préservé byte-identique (1/1 import),
aucun `namespace` n'est rouvert, aucun `example`/`theorem`/`def`/`#eval!`
n'est altéré. Seuls les commentaires de documentation de tête de fichier
(`/- ... -/`) sont étendus avec un second bloc français miroir.

## Verdict SOTA

**SOTA-OK / substance réelle, fix additif bilingue.** Lean 4 + Mathlib 4 =
autorité ; les blocs `/` étendus sont de la documentation au sens strict — la
chaîne de compilation reste identique pour le sous-module : même import
(`Mathlib.CategoryTheory.Yoneda`), ordre préservé, namespace racine
`Grothendieck` avec `open CategoryTheory Opposite` + 8 `example` (3 triviaux
rfl + 5 démontrant des constructions Mathlib) + 5 `theorem` (yoneda_equiv_apply,
yoneda_equiv_symm_app_apply, yoneda_equiv_yoneda_map, yoneda_equiv_naturality,
yoneda_full, yoneda_faithful) + 2 `def` (yonedaPairingIsoEvaluation,
coyonedaPairingIsoEvaluation) in body inchangés. **Substance réelle** : Yoneda
= lemme fondamental de théorie des catégories (objects of a category are
determined by the presheaves they represent), Grothendieck l'a utilisé comme
épine dorsale de sa reformulation de la géométrie algébrique. Module prouveur-
friendly par théorème transparent (chaque `theorem` se réduit à un appel de
la définition Mathlib correspondante).

Lake build final à valider sur ai-01 §1 pre-merge (Mathlib cache chaud),
comme pour chaque PR Lean (cf `lean-merge-discipline.md` §1 —
RECOVERABLE-MACHINE precedent c.357 / c.371-c.380 + c.381).

## Anti-régression §D

| Pattern red-flag | Vérification |
|------------------|-------------|
| Preuve remplacée par sorry | NON, n/a (toutes les preuves = appels de définitions Mathlib byte-identiques, aucun `sorry` dans le module) |
| Fonction appelée stubée | NON, aucune définition touchée |
| `deletions > insertions` sur code métier | NON, +79/-0 additif strict, code 0 ligne modifiée |
| Import modifié / réordonné | NON, byte-identique (1/1 import) |
| Catalogue régénéré sur branche | NON, R1 byte-identique `origin/main` |
| Namespace ouvert / fermé | NON, byte-identique (`Grothendieck` racine) |
| `#eval!` corps régressé | NON, 0 ligne du corps touchée (header zone only) |
| Theorem proof remplacé par `sorry` | NON, 5 theorem byte-identiques preuve intacte |
| `example`/`def` byte-identique | NON, 8 example + 2 def inaltérés |

## Portée

- **`See #4980`** : contribution initie rollout Phase 2+ du lac
  `grothendieck_lean` (1/22 sous-module fait après c.381 — YonedaLemma).
- **Cross-references** : c.367 `#6115` `grothendieck_lean/Grothendieck.lean`
  racine bilingue inline (MERGED, initie rollout Phase 2+) + c.380 `#6194`
  `conway_lean/Conway/Doomsday` bilingue (4ᵉ sous-module conway_lean Phase 1+)
  + c.379 `#6190` `conway_lean/Conway/Fractran` bilingue (3ᵉ sous-module) +
  c.378 `#6182` `conway_lean/Conway/LookAndSay` bilingue (2ᵉ sous-module) +
  c.377 `#6178` `conway_lean/Conway/MathlibMap` bilingue (1ᵉʳ sous-module
  rollout conway_lean, PIVOT L335 strict) + c.376 `#6173` `knot_lean/Knots/
  Invariant` bilingue 6/6 final (OPEN) + c.375 `#6171` `knot_lean/Knots`
  sub-modules bilingues 5/6 (OPEN) + c.374 `#6163` `search_lean/Astar_en.lean`
  sibling pair (OPEN) + c.373 `#6156` `knot_lean/Knots.lean` racine bilingue
  (OPEN) + c.366 `#6111` `conway_lean/Conway.lean` racine bilingue inline
  (MERGED) = même pattern option A pragmatique.
- **L335 anti-mono Sustained — PIVOT strict c.381** : c.377-c.380 = 4 cycles
  sur `conway_lean`, c.381 pivote vers `grothendieck_lean` (registre ≠
  conway_lean, substance réelle = Yoneda, EPIC #2159 ouvert, backlog 22
  sous-modules Phase 2+ autorise continuer sur nouveau registre ouvert).

## LF-only CR=0 strict

| Fichier              | raw    | no_cr  | Status |
|----------------------|--------|--------|--------|
| `YonedaLemma.lean`   | 10926  | 10926  | ✓ OK   |

(Avant modif : raw 6595 = no_cr 6595. Post-modif : raw 10926 = no_cr 10926.
+4331 octets = exactement la longueur du bloc FR ajoutée + cross-references
étendues, sans aucun CR introduit.)

## Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.*` byte-identique à
  `origin/main` (0 regen catalogue sur branche feature).
- **R2 rebase frais** : base `8a8f783fe`.
- **R3 atomique** : 1 fichier / 1 feature (bilinguisation satellite) /
  <3000L (79) / <15f (1) / 1 domaine (Lean i18n).
- **R4 partial** : `See #4980` (initie rollout Phase 2+, pas `Closes`).
- **L143 SAFE cross-owner** : `grothendieck_lean` = registre propre po-2023
  (lane Lean symbolique, pas de conflit GT/Probas/Planners owner-strict).
- **L268 #4 LF-only** : CR=0 strict (raw 10926 = no_cr 10926).
- **L279 / #1502 worker discipline** : Math-Vérif COMMENTED posted,
  JAMAIS `--approve`, JAMAIS `gh pr merge`.
- **L281 rebase frais** : base `origin/main 8a8f783fe`.
- **L298 anti-§D** : 0 ligne de code touchée (header zone only, bloc
  `/` head-only).
- **L327 additif strict** : +79/-0.
- **L335 anti-mono Sustained — PIVOT strict c.381** : c.377-c.380 = 4 cycles
  sur `conway_lean`, c.381 pivote vers `grothendieck_lean` (registre ≠
  conway_lean).
- **Mandat user 2026-07-11 Substance > Sweep** : extension bilingue Lean de
  fond (Yoneda × section FR miroir 79L, 0 code touched, initie rollout
  grothendieck_lean Phase 2+ ≠ doc-hygiène Phase 2 README).

## Suggestion ai-01

Merci de valider :

1. `lake build grothendieck_lean` SUCCESS sur ai-01 §1 pre-merge (confirme
   que `Grothendieck/YonedaLemma.lean` compile sans collision de namespace
   racine `Grothendieck` + `open CategoryTheory Opposite`, et que l'import
   `Mathlib.CategoryTheory.Yoneda` + 8 `example` + 5 `theorem` + 2 `def` sont
   préservés byte-identique).
2. CI Linux Lake build / Sorry check / Proof integrity SUCCESS (aucun de
   cassé — fichier docstring + namespace racine + 8 example + 5 theorem +
   2 def inchangés).
3. Convention option A bilingue FR+EN inline #4980 respectée : section EN
   préservée verbatim + bloc français miroir (deux blocs `/` top-level
   distincts, sans `---` interne) + référence croisée c.367 `Grothendieck.lean`
   racine bilingue (MERGED, initie rollout Phase 2+) + convention ratifiée
   2026-07-04.
4. **PIVOT L335 strict c.381 respecté** : c.377-c.380 = 4 cycles R6 Sustained
   intra-R6 sur `conway_lean`, c.381 pivote vers `grothendieck_lean`
   (registre ≠ conway_lean, substance réelle = Yoneda, EPIC #2159 ouvert,
   backlog 22 sous-modules Phase 2+ autorise continuer sur nouveau registre
   ouvert).
5. Diff `+79/-0` additif strict : aucun code de production touché (le
   sous-module reste bit-pour-bit identique à `origin/main` hors zone
   header).