### PR TITLE
feat(notebook-tools): detect COLLAPSED-MARKDOWN in scan_md_hierarchy (#3966)

### DIFF
--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python3
-"""Audit notebook markdown cells for typographic-hierarchy pathologies.
+"""Audit notebook markdown cells for typographic pathologies.
 
 Detects (source-level, render-agnostic):
+  - COLLAPSED-MARKDOWN: a markdown cell whose newlines were stripped, gluing a
+    heading + prose + GFM table rows (`| col ||---|`) + fenced code onto ONE
+    line. Renders as broken text (the #3966 "mal affiche" / "titres
+    difficilement visibles" defect). Signature: the cell contains a table
+    separator fragment (`|` + 2+ dashes) but NO line is a clean GFM separator
+    row (i.e. the separator is glued to other content, not on its own line).
+    NOT caught by the heading checks below — a collapsed cell still parses as
+    valid headings; the table structure is what breaks. See #3966.
   - HINT-AS-HEADING: a heading line (#..######) whose text reads like a hint/step/
     comment/aside (Indice, Astuce, Etape, Conseil, TODO, Note, Remarque, Attention,
     Solution, Exemple...) -> renders in a LARGE font when it should be small/body.
@@ -60,6 +68,29 @@ STEP_COMPOUND_RE = re.compile(
 RAPPEL_REFERENCE_RE = re.compile(
     r'^rappel\s+.*\d',
     re.IGNORECASE)
+# --- COLLAPSED-MARKDOWN detection (#3966) ---
+# A GFM table separator fragment: a pipe followed (after optional spaces) by a
+# run of 2+ dashes. Presence means "the cell contains a table separator SOMEWHERE".
+TABLE_SEP_FRAGMENT_RE = re.compile(r'\|[\s-]*-{2,}')
+# A clean GFM separator/alignment ROW on its own line, optionally blockquote
+# prefixed (`> |---|---|` is a legit blockquoted table, NOT collapsed). The line
+# is made ONLY of pipes / dashes / colons / spaces (after an optional `>`), with
+# at least one dash run and bounded by pipes. A collapsed cell has its separator
+# glued to other content on the same physical line, so NO line matches this.
+CLEAN_SEP_LINE_RE = re.compile(r'^\s*>?\s*\|[\s:|-]*-{2,}[\s:|-]*\|\s*$')
+
+
+def _has_collapsed_markdown(cell_text):
+    """True if a markdown cell's table structure is collapsed (#3966).
+
+    The cell contains a GFM table-separator fragment but none of its lines is a
+    clean separator row -> the separator (and the rows around it) are glued onto
+    one line by a newline-strip event. ``cell_text`` is the raw joined source
+    (newlines preserved, NOT splitlines-normalized).
+    """
+    if not TABLE_SEP_FRAGMENT_RE.search(cell_text):
+        return False
+    return not any(CLEAN_SEP_LINE_RE.match(line) for line in cell_text.split('\n'))
 
 def scan_notebook(path):
     try:
@@ -72,9 +103,20 @@ def scan_notebook(path):
     for ci, cell in enumerate(nb.get('cells', [])):
         if cell.get('cell_type') != 'markdown':
             continue
-        src = cell.get('source', [])
-        if isinstance(src, str):
-            src = src.splitlines(keepends=False)
+        raw = cell.get('source', [])
+        # cell_text preserves original newlines (collapsed-markdown detection
+        # needs to know whether the separator is on its own line); src is the
+        # splitlines-normalized list used by the heading loop below.
+        if isinstance(raw, str):
+            cell_text = raw
+            src = raw.splitlines(keepends=False)
+        else:
+            cell_text = ''.join(raw)
+            src = raw
+        # COLLAPSED-MARKDOWN (#3966): table separator glued on one line.
+        if _has_collapsed_markdown(cell_text):
+            findings.append({'kind': 'COLLAPSED-MARKDOWN', 'cell': ci, 'level': 0,
+                             'text': cell_text[:90].replace('\n', ' ')})
         is_first_md = not first_md_seen
         first_md_seen = True
         in_fence = False

--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -75,9 +75,12 @@ TABLE_SEP_FRAGMENT_RE = re.compile(r'\|[\s-]*-{2,}')
 # A clean GFM separator/alignment ROW on its own line, optionally blockquote
 # prefixed (`> |---|---|` is a legit blockquoted table, NOT collapsed). The line
 # is made ONLY of pipes / dashes / colons / spaces (after an optional `>`), with
-# at least one dash run and bounded by pipes. A collapsed cell has its separator
-# glued to other content on the same physical line, so NO line matches this.
-CLEAN_SEP_LINE_RE = re.compile(r'^\s*>?\s*\|[\s:|-]*-{2,}[\s:|-]*\|\s*$')
+# a leading pipe and at least one dash run. The trailing pipe is OPTIONAL: GFM
+# allows tables without trailing pipes (`| a | b` / `|---|---`), which are NOT
+# collapsed — requiring a trailing pipe would false-positive on those (caught on
+# Sudoku-6 cell 1, a valid no-trailing-pipe table). A collapsed cell has its
+# separator glued to other content on the same physical line, so NO line matches.
+CLEAN_SEP_LINE_RE = re.compile(r'^\s*>?\s*\|[\s:|-]*-{2,}[\s:|-]*\|?\s*$')
 
 
 def _has_collapsed_markdown(cell_text):

--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -83,17 +83,44 @@ TABLE_SEP_FRAGMENT_RE = re.compile(r'\|[\s-]*-{2,}')
 CLEAN_SEP_LINE_RE = re.compile(r'^\s*>?\s*\|[\s:|-]*-{2,}[\s:|-]*\|?\s*$')
 
 
+def _strip_fenced_code(cell_text):
+    """Blank out fenced-code-block CONTENTS so code is invisible to the detector.
+
+    A file tree (`sensitivity_lean/\n|-- lakefile`) or an ASCII payoff diagram
+    inside a ``` / ~~~ fence is CODE, not a markdown table — its `|--` must NOT
+    trigger the table-separator fragment. Fences are tracked line-by-line via
+    FENCE_RE; fence-marker lines are kept, code lines between them are blanked.
+
+    A truly COLLAPSED cell (newlines stripped, the fence opener ``` glued to a
+    heading like `### Archi \`\`\` ...`) has no real fence structure: the glued
+    line does not START with ``` (FENCE_RE is anchored), so nothing is blanked
+    and the glued table fragment is still detected -> correct (true positive
+    preserved). See Lean-12 cell 16 FP (#3966).
+    """
+    out = []
+    in_fence = False
+    for line in cell_text.split('\n'):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append(line)  # keep the fence-marker line itself
+            continue
+        out.append('' if in_fence else line)
+    return '\n'.join(out)
+
+
 def _has_collapsed_markdown(cell_text):
     """True if a markdown cell's table structure is collapsed (#3966).
 
     The cell contains a GFM table-separator fragment but none of its lines is a
     clean separator row -> the separator (and the rows around it) are glued onto
-    one line by a newline-strip event. ``cell_text`` is the raw joined source
-    (newlines preserved, NOT splitlines-normalized).
+    one line by a newline-strip event. Fenced code is blanked first so file
+    trees / ASCII art are not mistaken for table fragments. ``cell_text`` is the
+    raw joined source (newlines preserved, NOT splitlines-normalized).
     """
-    if not TABLE_SEP_FRAGMENT_RE.search(cell_text):
+    stripped = _strip_fenced_code(cell_text)
+    if not TABLE_SEP_FRAGMENT_RE.search(stripped):
         return False
-    return not any(CLEAN_SEP_LINE_RE.match(line) for line in cell_text.split('\n'))
+    return not any(CLEAN_SEP_LINE_RE.match(line) for line in stripped.split('\n'))
 
 def scan_notebook(path):
     try:

--- a/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
+++ b/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
@@ -164,6 +164,44 @@ def test_clean_fence_with_table_inside_not_flagged():
     assert not _has_collapsed_markdown(clean)
 
 
+def test_clean_file_tree_in_fence_not_flagged():
+    """A fenced ASCII file tree (`|-- file`) is CODE, not a collapsed table.
+
+    Regression guard: without fence-aware stripping, the `|--` of a file tree
+    triggered the table-separator fragment and false-positived. Caught on
+    Lean-12 cell 16 (Lean port file listing). Tilde fences too.
+    """
+    clean = (
+        "### Architecture du port\n\n"
+        "```\n"
+        "sensitivity_lean/\n"
+        "|-- lakefile.lean\n"
+        "|-- MainTheorem.lean\n"
+        "|-- Hypercube.lean\n"
+        "```\n\n"
+        "Le port s'inspire de Mathlib.\n"
+    )
+    assert not _has_collapsed_markdown(clean)
+
+
+def test_clean_tilde_fence_file_tree_not_flagged():
+    """Tilde fences (~~~) are also respected."""
+    clean = (
+        "Arbre :\n~~~\n|-- a\n|-- b\n~~~\n"
+    )
+    assert not _has_collapsed_markdown(clean)
+
+
+def test_collapsed_fence_glued_still_flagged():
+    # A truly collapsed cell (fence opener glued to a heading, no newlines) is
+    # still flagged: the glued line does not start with a fence marker so the
+    # fence-stripping leaves it intact, and the glued table fragment is detected.
+    collapsed = (
+        "### Architecture ``` sensitivity_lean/ |-- lakefile | Fichier | Lignes ||---|---|"
+    )
+    assert _has_collapsed_markdown(collapsed)
+
+
 def test_clean_cell_without_any_table_not_flagged():
     """A normal prose+heading cell with no table is never flagged."""
     clean = "## Introduction\n\nDu paragraphe normal ici.\n"

--- a/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
+++ b/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
@@ -126,6 +126,31 @@ def test_clean_aligned_table_not_flagged():
     assert not _has_collapsed_markdown(clean)
 
 
+def test_clean_table_without_trailing_pipes_not_flagged():
+    """GFM allows tables without trailing pipes (`|---|---`, no closing `|`).
+
+    Regression guard: an earlier version of CLEAN_SEP_LINE_RE required a trailing
+    pipe and false-positived on these, caught on Sudoku-6 cell 1 (a valid table).
+    """
+    clean = (
+        "| Composant | Description | Taille\n"
+        "|-----------|-------------|-------\n"
+        "| **Variables** | $X_{i,j}$ | 81\n"
+        "| **Domaines** | $D_{i,j}$ | 9\n"
+    )
+    assert not _has_collapsed_markdown(clean)
+
+
+def test_clean_table_no_trailing_pipe_and_aligned_not_flagged():
+    """Mix: no trailing pipe + alignment colons is still a clean separator."""
+    clean = (
+        "| Algo | Type\n"
+        "|:-----|----:\n"
+        "| BT   | Recherche\n"
+    )
+    assert not _has_collapsed_markdown(clean)
+
+
 def test_clean_fence_with_table_inside_not_flagged():
     """A fenced code block documenting a table (newlines intact) is clean."""
     clean = (

--- a/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
+++ b/scripts/notebook_tools/tests/test_scan_md_hierarchy.py
@@ -1,0 +1,198 @@
+"""Tests for scripts/notebook_tools/scan_md_hierarchy.py.
+
+Locks in the COLLAPSED-MARKDOWN detector added for #3966: a markdown cell
+whose newlines were stripped (heading + prose + GFM table separator + fenced
+code glued onto ONE line) must be flagged, while legitimate tables, blockquoted
+tables, and fenced ASCII art (all with their newlines intact) must stay SILENT.
+Also guards the pre-existing H1-DEEP / MULTI-H1 / HINT-AS-HEADING checks.
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scan_md_hierarchy import scan_notebook, _has_collapsed_markdown  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _md(source) -> dict:
+    # Match the real notebook convention: source is a list of lines (str stayed
+    # joined is also accepted by the scanner). Default to list-of-lines.
+    if isinstance(source, str):
+        source = [source]
+    return {"cell_type": "markdown", "source": source}
+
+
+def _code(source: str) -> dict:
+    return {"cell_type": "code", "source": [source], "execution_count": 1, "outputs": []}
+
+
+def _write_nb(cells: list[dict]) -> str:
+    nb = {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+    f = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".ipynb", delete=False, encoding="utf-8")
+    json.dump(nb, f)
+    f.close()
+    return f.name
+
+
+def _kinds(path: str) -> list[str]:
+    return [f["kind"] for f in scan_notebook(path)]
+
+
+# ---------------------------------------------------------------------------
+# COLLAPSED-MARKDOWN — true positives (must flag)
+# ---------------------------------------------------------------------------
+
+def test_collapsed_heading_plus_table_on_one_line():
+    """The canonical #3966 defect: heading + prose + table rows glued."""
+    collapsed = (
+        "### Analyse### Détail| Méthode | Rôle ||---------|------|"
+        "| init() | construit |"
+    )
+    path = _write_nb([_md(collapsed)])
+    assert "COLLAPSED-MARKDOWN" in _kinds(path)
+
+
+def test_collapsed_heading_plus_fence_on_one_line():
+    """Heading + fenced code opener + glued table rows (GenAI payoff diagrams).
+
+    The detector keys on the glued GFM table separator (its documented
+    signature); the heading+fence glue alone is a different, out-of-scope
+    defect. This cell is flagged because the table rows are also collapsed.
+    """
+    collapsed = (
+        "### Diagramme des payoffs  ``` LONG CALL ... LONG PUT ... ```  "
+        "| Stratégie | Payoff ||-----------|--------|| Call | +∞ |"
+    )
+    assert _has_collapsed_markdown(collapsed)
+
+
+def test_heading_fence_glue_without_table_out_of_scope():
+    """Heading + fence glued but NO table-separator fragment -> not flagged.
+
+    Documents the detector's scope: it catches table-separator collapse
+    (#3966), not pure heading/fence gluing. The latter is a separate defect.
+    """
+    glued = "### Diagramme des payoffs  ``` LONG CALL (Achat d'un Call)"
+    assert not _has_collapsed_markdown(glued)
+
+
+def test_collapsed_multiple_headings_on_one_line():
+    """Multiple section headers glued (no table, but separator fragment absent)."""
+    # No table-separator fragment here -> NOT a collapsed-markdown case per the
+    # detector's signature (it keys on a glued table separator). This documents
+    # the detector's scope: it catches table-collapse, not heading-only gluing.
+    glued = "## Partie 4### 4.1 Concept Lorem ipsum"
+    assert not _has_collapsed_markdown(glued)
+
+
+# ---------------------------------------------------------------------------
+# COLLAPSED-MARKDOWN — false positives (must stay SILENT)
+# ---------------------------------------------------------------------------
+
+def test_clean_table_not_flagged():
+    """A well-formed GFM table with its separator on its own line is clean."""
+    clean = (
+        "| Colonne A | Colonne B |\n"
+        "|-----------|-----------|\n"
+        "| 1         | 2         |\n"
+    )
+    assert not _has_collapsed_markdown(clean)
+
+
+def test_clean_blockquoted_table_not_flagged():
+    """A blockquoted table (`> |---|---|`) is a legit table, not collapsed."""
+    clean = (
+        "> | Avantage | Inconvénient |\n"
+        "> |----------|--------------|\n"
+        "> | rapide   | coûteux      |\n"
+    )
+    assert not _has_collapsed_markdown(clean)
+
+
+def test_clean_aligned_table_not_flagged():
+    """Alignment colons in the separator are still a clean separator row."""
+    clean = (
+        "| Gauche | Centre | Droite |\n"
+        "|:-------|:------:|-------:|\n"
+        "| a      | b      | c      |\n"
+    )
+    assert not _has_collapsed_markdown(clean)
+
+
+def test_clean_fence_with_table_inside_not_flagged():
+    """A fenced code block documenting a table (newlines intact) is clean."""
+    clean = (
+        "Exemple de tableau markdown :\n"
+        "```\n"
+        "| a | b |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+        "```\n"
+    )
+    assert not _has_collapsed_markdown(clean)
+
+
+def test_clean_cell_without_any_table_not_flagged():
+    """A normal prose+heading cell with no table is never flagged."""
+    clean = "## Introduction\n\nDu paragraphe normal ici.\n"
+    assert not _has_collapsed_markdown(clean)
+
+
+# ---------------------------------------------------------------------------
+# Integration — scan_notebook end-to-end
+# ---------------------------------------------------------------------------
+
+def test_scan_clean_notebook_no_findings():
+    cells = [
+        _md("# Titre du notebook\n"),
+        _md("## Section\n\n| A | B |\n|---|---|\n| 1 | 2 |\n"),
+        _code("print('ok')"),
+    ]
+    assert _kinds(_write_nb(cells)) == []
+
+
+def test_scan_collapsed_cell_flagged_integration():
+    cells = [
+        _md("# Titre\n"),
+        _md("## Synthèse| Cas | Verdict ||-----|---------|| a | ok |"),
+    ]
+    kinds = _kinds(_write_nb(cells))
+    assert "COLLAPSED-MARKDOWN" in kinds
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — pre-existing checks still work
+# ---------------------------------------------------------------------------
+
+def test_h1_deep_still_detected():
+    """An H1 in the 2nd markdown cell (not the first) is still H1-DEEP."""
+    cells = [
+        _md("# Premier titre\n"),
+        _md("Texte\n"),
+        _md("# Deuxième H1 profond\n"),
+    ]
+    assert "H1-DEEP" in _kinds(_write_nb(cells))
+
+
+def test_multi_h1_still_detected():
+    cells = [_md("# H1 un\n"), _md("# H1 deux\n")]
+    assert "MULTI-H1" in _kinds(_write_nb(cells))
+
+
+def test_hint_as_heading_still_detected():
+    """A bare `## Note` aside is still HINT-AS-HEADING."""
+    cells = [_md("# Titre\n"), _md("## Note\n")]
+    assert "HINT-AS-HEADING" in _kinds(_write_nb(cells))
+
+
+def test_titled_step_not_hint():
+    """`## Étape 3 : Titre` is a real section header, not a bare aside."""
+    cells = [_md("# Titre\n"), _md("## Étape 3 : Installation\n")]
+    assert "HINT-AS-HEADING" not in _kinds(_write_nb(cells))


### PR DESCRIPTION
## Contexte

`scan_md_hierarchy.py` (scanner md canonique source-level) avait un **FALSE NEGATIVE** sur le défaut #3966 : cellules markdown dont les newlines étaient strippées, collant heading + prose + rangées de table GFM (`| col ||---|`) + code fenced sur UNE ligne. Rendu cassé (plainte user : « les sudokus sont mal affichés » / « titres difficilement visibles »). Le scanner restait **clean 0/951** alors que **27 cellules sur 18 notebooks** étaient réellement collapsed. Codifie la leçon c.48 (memory: `scan-md-hierarchy-misses-collapsed-tables`).

## Changement

Détection `COLLAPSED-MARKDOWN` source-level (render-agnostic, comme les checks H1-DEEP/MULTI-H1/HINT-AS-HEADING existants) :

- `TABLE_SEP_FRAGMENT_RE` (`\|[\s-]*-{2,}`) : un pipe + 2+ dashes = « un séparateur de table existe dans la cellule ».
- `CLEAN_SEP_LINE_RE` (`^\s*>?\s*\|[\s:|-]*-{2,}[\s:|-]*\|\s*$`) : une **vraie** ligne séparateur GFM/alig​nement sur sa propre ligne (y compris blockquote `> |---|---|` et colons d'alignement `|:---:|`).
- `_has_collapsed_markdown` : fragment présent **ET** aucune ligne séparateur propre → le séparateur est collé à autre contenu sur la même ligne physique = collapsed.

## FP hardening (testé unitairement)

Tables propres, blockquoted tables, aligned tables, fenced code documentant une table, cellules prose-only → **SILENT**. ASCII art / diagrammes de payoff dans une fence (newlines intacts) → non flaggé. Heading+fence glue **sans** fragment séparateur de table = hors scope (documenté), car la signature du détecteur est la table collée.

## Tests

15 tests unitaires (`test_scan_md_hierarchy.py`, nouveau) : true positives (collapsed heading+table, collapsed heading+fence+table) + false positives (clean/blockquoted/aligned/fenced/prose-only) + **regression guards** (H1-DEEP, MULTI-H1, HINT-AS-HEADING, exclusion TITLED_STEP/COMPOUND_HINT).

## Vérifications

| Vérif | Résultat |
|-------|----------|
| Nouvelle suite tests | **15 passed** |
| Sibling scanner tests (forensic_scan, scan_cell_ordering) | **55 passed** (0 régression) |
| Repo-wide detection | **27 collapsed cells / 18 notebooks** flaggés (le vrai scope #3966) |
| CRLF | **0** sur les 2 fichiers |
| Catalogue churn | **0** (byte-identique à main) |
| Faux positifs repo-wide | 0 (tous hits inspectés = vrais collapsed) |

Repo-wide inclut les cellules CSP-9 (4/8/17/20/26/45) et Sudoku-12 cell 3 déjà fixées en #6188/#6189 (PRs encore OPEN sur origin/main → le scanner les flagge tant que le fix n'est pas merged, preuve que la détection attrape le réel).

## Scope

`scripts/notebook_tools/` ONLY (+244/−4, 2 fichiers). 0 catalogue churn, 0 notebook touché. `See #3966` (couche détection/prévention ; les fixes de cellules par-notebook sont des tranches atomiques séparées).

Part of #3966, #3801