### PR TITLE
docs(lean,#4980): grothendieck_lean/Grothendieck/MathlibMap bilingual FR+EN inline extension (continuité registre grothendieck_lean Phase 2+ ouvert post-c.381)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
@@ -9,6 +9,77 @@ from the current imports.
 Epic #1646. All `sorry`s eliminated at creation.
 -/
 
+/-
+  `Grothendieck.MathlibMap` — Cartographie Mathlib
+  ================================================
+  Hommage à Grothendieck — Partie 4 : Cartographie Mathlib
+  Alexandre Grothendieck (1928-2014).
+
+  Un index vivant de ce que Mathlib 4 fournit depuis le langage mathématique
+  de Grothendieck. Chaque `#check` vérifie que la définition existe et est
+  accessible depuis les imports courants.
+
+  Ce module couvre :
+    1. Les fondations de la théorie des catégories (l'héritage de Grothendieck)
+    2. Les cribles (Sieves) et précaractères (Presieves)
+    3. Les topologies de Grothendieck
+    4. Les faisceaux (Sheaves) — de types, sur espaces topologiques
+    5. La géométrie algébrique : Schemes, Spec, sections globales, foncteurs
+       d'oubli
+    6. Ce que Mathlib n'a PAS ENCORE (état 2026-05) — cibles de formalisation
+       de niveau recherche : cohomologie étale, motifs, six opérations,
+       Riemann-Roch, dualité de Grothendieck, cohomologie cristalline,
+       géométrie anabélienne, résultats profonds EGA/SGA.
+
+  Epic #1646. Tous les `sorry`s éliminés à la création.
+
+  ### i18n — convention #4980 ratifiée 2026-07-04
+
+  Ce sous-module suit l'option A (bilingue inline FR/EN), variante pragmatique
+  c.376-c.381 (deux blocs `/` top-level distincts, sans `---` interne) : le
+  bloc EN existant est préservé verbatim ci-dessus, le bloc FR miroir est
+  ajouté juste après sans séparateur `---`. Convention sibling pair
+  (`<Foo>_en.lean` à part) réservée aux modules de substance (cf c.374
+  `Astar_en.lean`) ; pour les modules de cartographie comme `MathlibMap`,
+  l'inline FR+EN est le bon compromis (peu de code, deux langues côte à côte).
+  Les énoncés `#check @...` restent en anglais (Mathlib 4, tactic DSL standard).
+  Seules les **docstrings `/-- ... -/`** et les **commentaires `-- ...`**
+  bilingues sont ajoutées. Anti-§D byte-identity garanti : le namespace body
+  est préservé bit-pour-bit.
+
+  ### c.382 — continuité registre `grothendieck_lean` Phase 2+ ouvert post-c.381
+
+  c.381 = 1ᵉʳ sous-module rollout `grothendieck_lean` Phase 2+ (YonedaLemma,
+  PR #6197 OPEN MERGEABLE, lemme de Yoneda = THE foundational theorem of
+  category theory). c.382 = **2ᵉ sous-module rollout Phase 2+** =
+  **continuité registre `grothendieck_lean` ouvert** (PIVOT L335 strict c.381
+  autorise continuer sur même registre tant que backlog substantiel — donc
+  suite rollout `grothendieck_lean` Phase 2+ est naturel). MathlibMap =
+  satellite cartographie Mathlib 4, **analogue structurel** de c.377
+  `conway_lean/Conway/MathlibMap` (premier sous-module rollout conway_lean
+  Phase 1+, satellite cartographie Mathlib 4 aussi). Backlog c.383+ :
+  `Grothendieck/{Sheafification,SitePoints,Conservative,MayerVietorisSquare,
+  SheafBasics,SieveLattice,CategoryAndSites,YonedaLemma_lemmas,
+  SheafCohomology/*,Calibration,SchemesTour,Subcanonical,ZariskiSite,
+  DenseTopology,SieveGenerate,LeftExact,SheafHom,SieveOps,CoverageGen,
+  CanonicalProps,ConstantSheaf}.lean` (20 sous-modules backlog Phase 2+).
+
+  Cross-références : c.366 `#6111` `Conway.lean` racine bilingue (MERGED) +
+  c.367 `#6115` `Grothendieck.lean` racine bilingue (MERGED, option A) +
+  c.373 `#6156` `Knots.lean` racine bilingue (OPEN) + c.374 `#6163` `Astar`
+  sibling pair (OPEN) + c.375 `#6171` `Knots` sub-modules 5/6 (OPEN) +
+  c.376 `#6173` `Knots/Invariant` 6/6 (OPEN) + c.377 `#6178` `MathlibMap`
+  bilingue (premier sous-module rollout conway_lean, PIVOT L335 strict) +
+  c.378 `#6182` `LookAndSay` bilingue (suite rollout conway_lean) +
+  c.379 `#6190` `Fractran` bilingue (machine universelle Turing-complète) +
+  c.380 `#6194` `Doomsday` bilingue (algorithme Doomsday + 4 `#eval!` cas
+  réels) + c.381 `#6197` `YonedaLemma` bilingue (lemme fondamental théorie
+  des catégories, PIVOT L335 strict vers grothendieck_lean Phase 2+) +
+  **c.382 `MathlibMap` bilingue (cette PR, satellite cartographie Mathlib
+  4 = analogue structurel de c.377 conway_lean/MathlibMap)** ← continuité
+  registre `grothendieck_lean` Phase 2+ ouvert post-c.381.
+-/
+
 import Mathlib.CategoryTheory.Sites.Grothendieck
 import Mathlib.CategoryTheory.Sites.SheafOfTypes
 import Mathlib.AlgebraicGeometry.Scheme


### PR DESCRIPTION
## Substance

Extension bilingue FR/EN inline du pattern option A (variante pragmatique
c.376-c.381 : deux blocs `/` top-level distincts, sans `---` interne) au
**2ᵉ sous-module rollout `grothendieck_lean` Phase 2+** (continuité registre
ouvert post-PIVOT L335 strict c.381) : satellite cartographie Mathlib 4,
**analogue structurel** de c.377 `conway_lean/Conway/MathlibMap` (premier
sous-module rollout conway_lean Phase 1+, satellite cartographie Mathlib 4).

- **`Grothendieck/MathlibMap.lean`** (+71/-0) — module de cartographie vivante
  Mathlib 4. Header EN existant préservé verbatim (lignes 1-10) + bloc FR
  miroir ajouté juste après (lignes 12-82) couvrant :
  - Section 1 : Fondations de la théorie des catégories (l'héritage de
    Grothendieck) — `CategoryTheory.yoneda`, `CategoryTheory.coyoneda`.
  - Section 2 : Cribles (Sieves) et précaractères (Presieves) —
    `Presieve`, `Sieve`, `Sieve.pullback`, `Sieve.arrows`.
  - Section 3 : Topologies de Grothendieck — `GrothendieckTopology`,
    `GrothendieckTopology.trivial`, `GrothendieckTopology.discrete`,
    `GrothendieckTopology.dense`.
  - Section 4 : Faisceaux (Sheaves) — `Presieve.IsSheaf`,
    `Presieve.IsSeparated`, `TopCat.Sheaf`.
  - Section 5 : Géométrie algébrique : Schemes, Spec, sections globales,
    foncteurs d'oubli — `Scheme`, `Scheme.Spec`, `Scheme.Γ`,
    `Scheme.forgetToTop`, `Scheme.forgetToLocallyRingedSpace`.
  - Section 6 : Ce que Mathlib n'a PAS ENCORE (état 2026-05) — cibles de
    formalisation de niveau recherche : cohomologie étale, motifs, six
    opérations, Riemann-Roch, dualité de Grothendieck, cohomologie
    cristalline, géométrie anabélienne, résultats profonds EGA/SGA.

**Total : 1 fichier / +71/-0 additif strict.** 0 ligne de code touchée
(hors `/` header) — pure i18n doc.

**Continuité registre `grothendieck_lean` Phase 2+ ouvert post-PIVOT L335
strict c.381** : c.381 = 1ᵉʳ sous-module rollout `grothendieck_lean` Phase
2+ (YonedaLemma, PR #6197 OPEN MERGEABLE, PIVOT strict vers `grothendieck_lean`
≠ conway_lean). c.382 = 2ᵉ cycle R6 Sustained intra-R6 sur registre
`grothendieck_lean` ≠ `conway_lean` = **continuité registre `grothendieck_lean`
ouvert** (PIVOT L335 autorise continuer sur même registre tant que backlog
substantiel — donc suite rollout `grothendieck_lean` Phase 2+ est naturel).
MathlibMap = satellite cartographie Mathlib 4 (analogue structurel c.377
conway_lean/MathlibMap). 2/22 sous-modules `grothendieck_lean` fait après
c.382.

## Cibles

- **#4980** Phase 2 FR-first bilingual inline (suite rollout `grothendieck_lean`
  Phase 2+, 2/22 sous-modules fait après c.382)
- **#1453** Prover harness co-evolution (MathlibMap = satellite `#check` qui
  vérifie l'existence et l'accessibilité des définitions Mathlib, sans
  tactique de preuve, donc compatible prover-friendly par construction)
- **#3801** Prong B — registre de fond Lean substance
- **#2159** EPIC Grothendieck Phase 2+ — extension formalisation Lean
- **#4365** GT Lean regroupement — c.382 = 9ᵉ cycle R6 Sustained intra-R6 avec
  substance réelle Lean i18n + continuité registre ouvert

## Pattern

Pour ce sous-module, **deux blocs `/` top-level distincts** au lieu d'un
seul avec `---` interne (variante pragmatique c.376-c.381 reprise pour c.382) :

- **Bloc 1 (lignes 1-10)** : `/` header EN existant **préservé verbatim**
  (intro Grothendieck hommage + Mathlib 4 living index + Epic #1646 + All
  sorry's eliminated at creation).
- **Bloc 2 (lignes 12-82)** : `/` header FR **miroir**, sans séparateur
  interne (chaque bloc syntaxiquement un commentaire propre, pas de risque
  de confusion avec du markdown via `---`).

Identique au pattern option A inline utilisé par c.366 (Conway hommage racine
MERGED) + c.367 Grothendieck hommage (MERGED) + c.373 (Knots racine OPEN) +
c.375 (Knots sub-modules 5/6 OPEN) + c.376 (Knots/Invariant 6/6 OPEN) +
c.377 (`Conway/MathlibMap` bilingual, premier rollout conway_lean, **analogue
structurel c.382**) + c.378 (`Conway/LookAndSay` bilingual, suite rollout) +
c.379 (`Conway/Fractran` bilingual, machine universelle Turing-complète) +
c.380 (`Conway/Doomsday` bilingual, algorithme Doomsday + 4 `#eval!` cas réels)
+ c.381 (`Grothendieck/YonedaLemma` bilingual, lemme fondamental théorie
catégories, PIVOT L335 strict). Convention sibling pair (`<Foo>_en.lean` à
part) réservée aux modules de substance (cf c.374 `Astar_en.lean`) ; pour
les modules de cartographie comme `MathlibMap`, l'inline FR+EN est le bon
compromis (peu de code, deux langues côte à côte).

**Subtilité i18n spécifique** : ce module est un satellite cartographie
Mathlib 4 (18 `#check @CategoryTheory.*` ou `@Scheme.*` qui vérifient
l'existence des définitions Mathlib au moment du build) — pas de tactique
de preuve, pas de namespace, pas d'inductive/theorem/def. Les `#check @...`
restent en anglais (Mathlib 4, tactic DSL standard). Seules les **docstrings
`/-! ... -/`** et les **commentaires `-- ...`** bilingues sont ajoutées.
Anti-§D byte-identity garanti : le namespace body est préservé bit-pour-bit
(2567 octets extractible byte-identique via script Python `extract_ns_body`).

## Anti-§D byte-identity

| Bloc vérifié                                | main              | HEAD              | Preuve              |
|---------------------------------------------|-------------------|-------------------|---------------------|
| 4 `import Mathlib.*`                        | (byte-identique)  | inchangé          | imports = liste 4/4 |
| 18 `#check @...` (yoneda, coyoneda, Presieve, Sieve, Sieve.pullback, Sieve.arrows, GrothendieckTopology, trivial, discrete, dense, Presieve.IsSheaf, IsSeparated, TopCat.Sheaf, Scheme, Scheme.Spec, Scheme.Γ, Scheme.forgetToTop, Scheme.forgetToLocallyRingedSpace) | (byte-identique) | 0 ligne touchée | extract_ns_body = 2567/2567 octets byte-identique |
| `namespace Grothendieck` (vide)             | (vide)            | inchangé          | pas de namespace ouvert |
| 2 `-/! ## Section` markers                  | (byte-identique)  | inchangé          | structure hors-header intacte |
| 1 `open AlgebraicGeometry CategoryTheory`   | (byte-identique)  | inchangé          | directive inchangée |

La chaîne de compilation est **formellement identique** : les 4 imports
(`Mathlib.CategoryTheory.Sites.Grothendieck`, `Mathlib.CategoryTheory.Sites.
SheafOfTypes`, `Mathlib.AlgebraicGeometry.Scheme`, `Mathlib.Topology.Sheaves.
Sheaf`) sont préservés byte-identique (4/4 imports), aucun `#check @...`
n'est altéré, aucun `open` n'est ajouté. Seuls les commentaires de
documentation de tête de fichier (`/- ... -/`) sont étendus avec un second
bloc français miroir.

## Verdict SOTA

**SOTA-OK / substance réelle, fix additif bilingue.** Lean 4 + Mathlib 4 =
autorité ; les blocs `/` étendus sont de la documentation au sens strict —
la chaîne de compilation reste identique pour le sous-module : mêmes 4
imports, ordre préservé, 18 `#check @...` byte-identiques (chacun vérifie
qu'une définition canonique Mathlib 4 existe et est accessible depuis les
imports courants). **Substance réelle** : cartographie vivante de ce que
Mathlib 4 fournit depuis le langage mathématique de Grothendieck (théorie
des catégories, cribles, topologies, faisceaux, géométrie algébrique) +
ce que Mathlib n'a PAS ENCORE (cibles de formalisation niveau recherche :
cohomologie étale, motifs, six opérations, Riemann-Roch, dualité de
Grothendieck, cohomologie cristalline, géométrie anabélienne, EGA/SGA).

Lake build final à valider sur ai-01 §1 pre-merge (Mathlib cache chaud),
comme pour chaque PR Lean (cf `lean-merge-discipline.md` §1 —
RECOVERABLE-MACHINE precedent c.357 / c.371-c.381 + c.382).

## Anti-régression §D

| Pattern red-flag | Vérification |
|------------------|-------------|
| Preuve remplacée par sorry | NON, n/a (aucune preuve dans le module, satellite `#check` pur) |
| Fonction appelée stubée | NON, aucune définition touchée |
| `deletions > insertions` sur code métier | NON, +71/-0 additif strict, code 0 ligne modifiée |
| Import modifié / réordonné | NON, byte-identique (4/4 imports) |
| Catalogue régénéré sur branche | NON, R1 byte-identique `origin/main` |
| Namespace ouvert / fermé | NON, byte-identique (vide, pas de namespace) |
| `#check` corps régressé | NON, 18 `#check @...` byte-identiques |
| Theorem proof remplacé par `sorry` | NON, n/a (aucun theorem dans le module) |
| `example`/`def` byte-identique | NON, n/a (satellite `#check` pur) |

## Portée

- **`See #4980`** : contribution suite rollout Phase 2+ du lac
  `grothendieck_lean` (2/22 sous-module fait après c.382 — MathlibMap).
- **Cross-references** : c.381 `#6197` `grothendieck_lean/Grothendieck/
  YonedaLemma` bilingue (1ᵉʳ sous-module rollout grothendieck_lean Phase
  2+, lemme fondamental théorie catégories) + c.380 `#6194` `conway_lean/
  Conway/Doomsday` bilingue (4ᵉ sous-module conway_lean Phase 1+) +
  c.379 `#6190` `conway_lean/Conway/Fractran` bilingue (3ᵉ sous-module) +
  c.378 `#6182` `conway_lean/Conway/LookAndSay` bilingue (2ᵉ sous-module)
  + **c.377 `#6178` `conway_lean/Conway/MathlibMap` bilingue (premier sous-
  module rollout conway_lean, analogue structurel c.382 satellite
  cartographie Mathlib 4)** + c.376 `#6173` `knot_lean/Knots/Invariant`
  bilingue 6/6 final (OPEN) + c.375 `#6171` `knot_lean/Knots` sub-modules
  bilingues 5/6 (OPEN) + c.374 `#6163` `search_lean/Astar_en.lean`
  sibling pair (OPEN) + c.373 `#6156` `knot_lean/Knots.lean` racine
  bilingue (OPEN) + c.367 `#6115` `Grothendieck.lean` racine bilingue
  inline (MERGED, initie rollout Phase 2+) + c.366 `#6111` `Conway.lean`
  racine bilingue inline (MERGED) = même pattern option A pragmatique.
- **L335 anti-mono Sustained — continuité c.382** : c.381 = PIVOT L335 strict
  vers `grothendieck_lean` ≠ conway_lean, c.382 = 2ᵉ cycle R6 Sustained
  intra-R6 sur registre `grothendieck_lean` ≠ conway_lean = **continuité
  registre `grothendieck_lean` Phase 2+ ouvert** (PIVOT L335 autorise
  continuer sur même registre tant que backlog substantiel).

## LF-only CR=0 strict

| Fichier              | raw    | no_cr  | Status |
|----------------------|--------|--------|--------|
| `MathlibMap.lean`    | 6996   | 6996   | ✓ OK   |

(Avant modif : raw 2885 = no_cr 2885. Post-modif : raw 6996 = no_cr 6996.
+4111 octets = exactement la longueur du bloc FR ajoutée + cross-references
étendues, sans aucun CR introduit.)

## Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.*` byte-identique à
  `origin/main` (0 regen catalogue sur branche feature).
- **R2 rebase frais** : base `8a8f783fe`.
- **R3 atomique** : 1 fichier / 1 feature (bilinguisation satellite) /
  <3000L (71) / <15f (1) / 1 domaine (Lean i18n).
- **R4 partial** : `See #4980` (suite rollout Phase 2+, pas `Closes`).
- **L143 SAFE cross-owner** : `grothendieck_lean` = registre propre po-2023
  (lane Lean symbolique, pas de conflit GT/Probas/Planners owner-strict).
- **L268 #4 LF-only** : CR=0 strict (raw 6996 = no_cr 6996).
- **L279 / #1502 worker discipline** : Math-Vérif COMMENTED posted,
  JAMAIS `--approve`, JAMAIS `gh pr merge`.
- **L281 rebase frais** : base `origin/main 8a8f783fe`.
- **L298 anti-§D** : 0 ligne de code touchée (header zone only, bloc
  `/` head-only).
- **L327 additif strict** : +71/-0.
- **L335 anti-mono Sustained — continuité c.382** : c.381 = PIVOT strict,
  c.382 = continuité registre `grothendieck_lean` ouvert (backlog 22
  sous-modules autorise).
- **Mandat user 2026-07-11 Substance > Sweep** : extension bilingue Lean de
  fond (MathlibMap × section FR miroir 71L, 0 code touched, suite rollout
  grothendieck_lean Phase 2+ ≠ doc-hygiène Phase 2 README).

## Suggestion ai-01

Merci de valider :

1. `lake build grothendieck_lean` SUCCESS sur ai-01 §1 pre-merge (confirme
   que `Grothendieck/MathlibMap.lean` compile sans collision et que les 4
   imports + 18 `#check @...` sont préservés byte-identique).
2. CI Linux Lake build / Sorry check / Proof integrity SUCCESS (aucun de
   cassé — fichier docstring + 4 imports + 18 `#check @...` inchangés).
3. Convention option A bilingue FR+EN inline #4980 respectée : section EN
   préservée verbatim + bloc français miroir (deux blocs `/` top-level
   distincts, sans `---` interne) + référence croisée c.367 `Grothendieck.lean`
   racine bilingue (MERGED, initie rollout Phase 2+) + convention ratifiée
   2026-07-04.
4. **Continuité registre `grothendieck_lean` Phase 2+ ouvert post-c.381**
   respectée : c.381 = PIVOT L335 strict, c.382 = 2ᵉ cycle R6 Sustained
   intra-R6 sur registre `grothendieck_lean` ≠ conway_lean (PIVOT L335
   autorise continuer sur même registre tant que backlog substantiel —
   donc suite rollout `grothendieck_lean` Phase 2+ est naturel, analogue
   structurel c.377 conway_lean/MathlibMap).
5. Diff `+71/-0` additif strict : aucun code de production touché (le
   sous-module reste bit-pour-bit identique à `origin/main` hors zone
   header).