### PR TITLE
fix(planners-5): restore markdown newlines in 3 collapsed cells (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
@@ -687,7 +687,30 @@
    "id": "hadd-inadmissible-demo-interp",
    "metadata": {},
    "source": [
-    "### Interpretation : la non-admissibilite de h^add est observee concretement| Heuristique | Valeur | Admissible (universelle) | Observation ||-------------|--------|--------------------------|-------------|| h^max       | 2      | Oui                     | Compte le sous-but le plus cher (cout 2 = setup + make) || h^add       | 4      | **Non**                 | Double-compte `setup` : 2 (pour g1) + 2 (pour g2) || h^FF        | 2      | **Non**                 | Extrait le plan relaxe partage, retombe sur h^max || h*          | 3      | -                       | Plan optimal : setup, make_g1, make_g2 |**Pourquoi h^add = 4 > h* = 3** :- `setup` (cout 1) est la **precondition commune** des deux sous-buts `g1` et `g2`- Le calcul additif propage le cout de `p` (= 1, atteint via `setup`) **independamment** dans chaque branche du graphe de relaxation- `cost(g1)` = `cost(p)` + cout de `make_g1` = 1 + 1 = 2- `cost(g2)` = `cost(p)` + cout de `make_g2` = 1 + 1 = 2- `h^add = cost(g1) + cost(g2) = 2 + 2 = 4`- Mais un plan **optimal** n'execute `setup` **qu'une fois** : `setup`, `make_g1`, `make_g2` = cout total 3- Donc h^add surestime de 1 (= cout de `setup`)**h^max reste admissible** : `max(2, 2) = 2 <= h* = 3`. C'est la superiorite classique de h^max pour la recherche optimale : il sous-estime systematiquement, garantissant l'optimalite avec A*.**h^FF = h^max = 2 sur cette instance** : le plan relaxe partage `setup` (il atteint `p` qui sert les deux sous-buts), donc FF le compte une seule fois. C'est une illustration que **FF peut etre meilleur que h^add sur des problemes avec actions partagees** — c'est d'ailleurs une des motivations historiques de FF (Hoffmann & Nebel 2001).**Implication pratique** : pour la planification optimale, preferer h^max ou LM-cut (admissibles) ; pour la recherche satisfiable rapide, h^FF est souvent preferable a h^add (meilleure guidance, pas de surestimation catastrophique sur actions partagees)."
+    "### Interpretation : la non-admissibilite de h^add est observee concretement\n",
+    "\n",
+    "| Heuristique | Valeur | Admissible (universelle) | Observation |\n",
+    "|-------------|--------|--------------------------|-------------|\n",
+    "| h^max       | 2      | Oui                     | Compte le sous-but le plus cher (cout 2 = setup + make) |\n",
+    "| h^add       | 4      | **Non**                 | Double-compte `setup` : 2 (pour g1) + 2 (pour g2) |\n",
+    "| h^FF        | 2      | **Non**                 | Extrait le plan relaxe partage, retombe sur h^max |\n",
+    "| h*          | 3      | -                       | Plan optimal : setup, make_g1, make_g2 |\n",
+    "\n",
+    "**Pourquoi h^add = 4 > h* = 3** :\n",
+    "\n",
+    "- `setup` (cout 1) est la **precondition commune** des deux sous-buts `g1` et `g2`\n",
+    "- Le calcul additif propage le cout de `p` (= 1, atteint via `setup`) **independamment** dans chaque branche du graphe de relaxation\n",
+    "- `cost(g1)` = `cost(p)` + cout de `make_g1` = 1 + 1 = 2\n",
+    "- `cost(g2)` = `cost(p)` + cout de `make_g2` = 1 + 1 = 2\n",
+    "- `h^add = cost(g1) + cost(g2) = 2 + 2 = 4`\n",
+    "- Mais un plan **optimal** n'execute `setup` **qu'une fois** : `setup`, `make_g1`, `make_g2` = cout total 3\n",
+    "- Donc h^add surestime de 1 (= cout de `setup`)\n",
+    "\n",
+    "**h^max reste admissible** : `max(2, 2) = 2 <= h* = 3`. C'est la superiorite classique de h^max pour la recherche optimale : il sous-estime systematiquement, garantissant l'optimalite avec A*.\n",
+    "\n",
+    "**h^FF = h^max = 2 sur cette instance** : le plan relaxe partage `setup` (il atteint `p` qui sert les deux sous-buts), donc FF le compte une seule fois. C'est une illustration que **FF peut etre meilleur que h^add sur des problemes avec actions partagees** — c'est d'ailleurs une des motivations historiques de FF (Hoffmann & Nebel 2001).\n",
+    "\n",
+    "**Implication pratique** : pour la planification optimale, preferer h^max ou LM-cut (admissibles) ; pour la recherche satisfiable rapide, h^FF est souvent preferable a h^add (meilleure guidance, pas de surestimation catastrophique sur actions partagees)."
    ]
   },
   {
@@ -704,7 +727,23 @@
     "tags": []
    },
    "source": [
-    "### Interpretation de la comparaison| Heuristique | Valeur | Admissible (sur cette instance) | Admissible (universelle) ||-------------|--------|---------------------------------|--------------------------|| h^max       | 1      | Oui (1 <= 3)                   | Oui                      || h^add       | 3      | Oui (3 <= 3)                   | **Non**                  || h*          | 3      | -                               | -                        |**Observations** :1. **h^max est admissible en general** : propriete universelle (`max <= h*` pour tout etat).2. **h^add coincide avec h* ici** car les 3 sous-buts sont **independants** (pas de precondition partagee). Mais cela ne la rend pas admissible en general : sur des problemes avec actions partagees, h^add surestime. Voir la cellule 3.5 pour une demonstration concrete (h^add = 4 > h* = 3).3. **h^add est plus informative** que h^max sur cette instance (3 vs 1) grace a la sommation, mais cette informativite a un prix : la non-admissibilite.> **Note** : h^add peut etre admissible dans certains cas (sous-buts independants) mais ne l'est pas en general. Le caractere admissible est une propriete **universelle** (h <= h* pour TOUT etat), pas une propriete per-instance."
+    "### Interpretation de la comparaison\n",
+    "\n",
+    "| Heuristique | Valeur | Admissible (sur cette instance) | Admissible (universelle) |\n",
+    "|-------------|--------|---------------------------------|--------------------------|\n",
+    "| h^max       | 1      | Oui (1 <= 3)                   | Oui                      |\n",
+    "| h^add       | 3      | Oui (3 <= 3)                   | **Non**                  |\n",
+    "| h*          | 3      | -                               | -                        |\n",
+    "\n",
+    "**Observations** :\n",
+    "\n",
+    "1. **h^max est admissible en general** : propriete universelle (`max <= h*` pour tout etat).\n",
+    "\n",
+    "2. **h^add coincide avec h* ici** car les 3 sous-buts sont **independants** (pas de precondition partagee). Mais cela ne la rend pas admissible en general : sur des problemes avec actions partagees, h^add surestime. Voir la cellule 3.5 pour une demonstration concrete (h^add = 4 > h* = 3).\n",
+    "\n",
+    "3. **h^add est plus informative** que h^max sur cette instance (3 vs 1) grace a la sommation, mais cette informativite a un prix : la non-admissibilite.\n",
+    "\n",
+    "> **Note** : h^add peut etre admissible dans certains cas (sous-buts independants) mais ne l'est pas en general. Le caractere admissible est une propriete **universelle** (h <= h* pour TOUT etat), pas une propriete per-instance."
    ]
   },
   {
@@ -1403,7 +1442,28 @@
     "tags": []
    },
    "source": [
-    "### 6.2 Interpretation des resultats| Heuristique | Valeur | Admissible (universelle) | Commentaire ||-------------|--------|--------------------------|-------------|| h^max       | 2      | **Oui**                 | Maximum des sous-buts, sous-estime systematiquement || h^add       | 4      | **Non**                 | Somme des sous-buts, = h* ici (coincidence) mais surestime sur actions partagees (cf cellule 3.5 : h^add = 4 > h* = 3) || h^FF        | 4      | **Non**                 | Extrait un plan relaxe, pas d'optimalite garantie en general || h_landmark  | 4      | **Non**                 | Compte les landmarks non atteints, = h* ici, non admissible en general || h*          | 4      | -                       | Cout optimal reel |**Observations** :1. **h^max est admissible** (propriete universelle) mais souvent trop pessimiste : la valeur 2 sous-estime le cout optimal 4.2. **h^add, h^FF, h_landmark ne sont PAS admissibles en general**, meme s'ils coincident avec h* sur cette instance particuliere. La colonne 'Admissible' reflete une propriete theorique (h <= h* pour tout etat), pas une coincidence per-instance.3. **Demonstration concrete de non-admissibilite** : voir la cellule 3.5 (probleme a precondition partagee) ou h^add = 4 > h* = 3.**Compromis qualite/vitesse** :- Pour **optimalite** : h^max, LM-cut (admissibles)- Pour **vitesse** : h^FF (tres informative, pas d'optimalite garantie)"
+    "### 6.2 Interpretation des resultats\n",
+    "\n",
+    "| Heuristique | Valeur | Admissible (universelle) | Commentaire |\n",
+    "|-------------|--------|--------------------------|-------------|\n",
+    "| h^max       | 2      | **Oui**                 | Maximum des sous-buts, sous-estime systematiquement |\n",
+    "| h^add       | 4      | **Non**                 | Somme des sous-buts, = h* ici (coincidence) mais surestime sur actions partagees (cf cellule 3.5 : h^add = 4 > h* = 3) |\n",
+    "| h^FF        | 4      | **Non**                 | Extrait un plan relaxe, pas d'optimalite garantie en general |\n",
+    "| h_landmark  | 4      | **Non**                 | Compte les landmarks non atteints, = h* ici, non admissible en general |\n",
+    "| h*          | 4      | -                       | Cout optimal reel |\n",
+    "\n",
+    "**Observations** :\n",
+    "\n",
+    "1. **h^max est admissible** (propriete universelle) mais souvent trop pessimiste : la valeur 2 sous-estime le cout optimal 4.\n",
+    "\n",
+    "2. **h^add, h^FF, h_landmark ne sont PAS admissibles en general**, meme s'ils coincident avec h* sur cette instance particuliere. La colonne 'Admissible' reflete une propriete theorique (h <= h* pour tout etat), pas une coincidence per-instance.\n",
+    "\n",
+    "3. **Demonstration concrete de non-admissibilite** : voir la cellule 3.5 (probleme a precondition partagee) ou h^add = 4 > h* = 3.\n",
+    "\n",
+    "**Compromis qualite/vitesse** :\n",
+    "\n",
+    "- Pour **optimalite** : h^max, LM-cut (admissibles)\n",
+    "- Pour **vitesse** : h^FF (tres informative, pas d'optimalite garantie)"
    ]
   },
   {


### PR DESCRIPTION
## Contexte

3 cellules markdown de **Planners-5-Heuristics** (cells 17/18/36) avaient leurs newlines strippés — défaut **collapsed-markdown #3966** (« les sudokus sont mal affichés » / titres difficilement visibles) : heading + prose + rangées de table GFM + listes collés sur **une seule ligne**. Rendu cassé. Suit #6188 (CSP-9) + #6189 (Sudoku-12) et **valide en production le détecteur `COLLAPSED-MARKDOWN` livré en #6199** (scanner signale Planners-5 CLEAN après ce fix).

## Changement

Restauration des newlines aux bornes structurelles (heading, rangées/séparateur de table, list items, blockquote `> **Note**`, lead-ins de paragraphe `**...** :`) via un dé-collapse validé. **Markdown-only → exception C.2** (pas de re-execution, outputs précédents préservés).

## Vérifications (firsthand G.1)

| Vérif | Résultat |
|-------|----------|
| Égalité char non-whitespace base↔fixed (par cell) | **PASS** (0 contenu perdu/typo) |
| nbconvert table-row count | **54 → 72** (tables restaurées) |
| Code cells touchées | **0** (uniquement md 17/18/36) |
| Cells préservées | **53/53** (0 ajout/suppression) |
| `execution_count` + outputs | **byte-préservés** sur toutes les cells |
| `scan_md_hierarchy` (détecteur #6199) | **CLEAN** (était COLLAPSED-MARKDOWN) |
| `validate_pr_notebooks` (H.3) | **1/1 PASS** (17 cells) |
| CRLF | **0** |
| Catalogue churn | **0** (byte-identique à main) |
| Scope | **1 fichier** (+63/−3) |

## Portée

`MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb` ONLY. `See #3966` (4 notebooks résiduels restants : QC-Py-04, HunyuanVideo, ICT-24, Tweety-10 — chaque sa propre tranche atomique).

Part of #3966