### PR TITLE
fix(tweety-10): restore markdown newlines in 2 collapsed MLN tables (See #3966)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-10-MLN-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-10-MLN-Csharp.ipynb
@@ -276,7 +276,20 @@
    "id": "91ebc523",
    "metadata": {},
    "source": [
-    "## Partie 3 : Comment les poids modèlent la croyanceLa même règle, selon son poids, se comporte différemment. Faisons varier le poids de la règle `Smokes(X) => Cancer(X)` et observons l'évolution de `P(Cancer(bob))` :| Poids | Comportement attendu ||-------|----------------------|| 0.0 | Aucune contrainte → `P(Cancer(bob)) ≈ 0.5` (distribution uniforme sur les modèles) || 0.5 | Faible contrainte → `P` monte un peu || 1.0 | Contrainte modérée || 2.0 | Contrainte forte || 5.0 | Quasi-stricte (probabilité de violation ≈ `exp(-5) ≈ 0.007`) || ∞ | Strict (équivalent FOL classique) |C'est le **spectre logique ↔ statistique** : le MLN interpole continûment entre la logique (poids infini) et la statistique pure (poids 0)."
+    "## Partie 3 : Comment les poids modèlent la croyance\n",
+    "\n",
+    "La même règle, selon son poids, se comporte différemment. Faisons varier le poids de la règle `Smokes(X) => Cancer(X)` et observons l'évolution de `P(Cancer(bob))` :\n",
+    "\n",
+    "| Poids | Comportement attendu |\n",
+    "|-------|----------------------|\n",
+    "| 0.0 | Aucune contrainte → `P(Cancer(bob)) ≈ 0.5` (distribution uniforme sur les modèles) |\n",
+    "| 0.5 | Faible contrainte → `P` monte un peu |\n",
+    "| 1.0 | Contrainte modérée |\n",
+    "| 2.0 | Contrainte forte |\n",
+    "| 5.0 | Quasi-stricte (probabilité de violation ≈ `exp(-5) ≈ 0.007`) |\n",
+    "| ∞ | Strict (équivalent FOL classique) |\n",
+    "\n",
+    "C'est le **spectre logique ↔ statistique** : le MLN interpole continûment entre la logique (poids infini) et la statistique pure (poids 0)."
    ]
   },
   {
@@ -543,7 +556,19 @@
    "id": "d0968923",
    "metadata": {},
    "source": [
-    "## Partie 5 : Trois familles de raisonneurs MLNComme pour les solveurs SAT du notebook 2 (Sat4j portable vs CaDiCaL natif), Tweety propose plusieurs raisonneurs MLN avec des compromis exact vs approximatif :| Raisonneur | Type | Complexité | Cas d'usage ||------------|------|------------|-------------|| `ApproximateNaiveMlnReasoner` | Énumération | `#mondes` exponentiel | Petits domaines (≤ 5-10 atomes) || `SimpleMlnReasoner` | MCMC / Gibbs | Polynomial en pratique | Domaines moyens || `SimpleSamplingMlnReasoner` | Monte-Carlo | Polynomial | Grands domaines, approximation |**`ApproximateNaiveMlnReasoner`** : c'est le plus simple. Il **énumère** toutes les interprétations de Herbrand du domaine, calcule le poids total (somme des poids des formules satisfaites) pour chaque monde, puis renormalise via `exp(poids)`. **Exponentiel** : `2^n` mondes pour `n` atomes.**`SimpleSamplingMlnReasoner`** : il **échantillonne** des mondes par Monte-Carlo et estime les probabilités marginales par comptage. **Polynomial** en pratique, mais approximation."
+    "## Partie 5 : Trois familles de raisonneurs MLN\n",
+    "\n",
+    "Comme pour les solveurs SAT du notebook 2 (Sat4j portable vs CaDiCaL natif), Tweety propose plusieurs raisonneurs MLN avec des compromis exact vs approximatif :\n",
+    "\n",
+    "| Raisonneur | Type | Complexité | Cas d'usage |\n",
+    "|------------|------|------------|-------------|\n",
+    "| `ApproximateNaiveMlnReasoner` | Énumération | `#mondes` exponentiel | Petits domaines (≤ 5-10 atomes) |\n",
+    "| `SimpleMlnReasoner` | MCMC / Gibbs | Polynomial en pratique | Domaines moyens |\n",
+    "| `SimpleSamplingMlnReasoner` | Monte-Carlo | Polynomial | Grands domaines, approximation |\n",
+    "\n",
+    "**`ApproximateNaiveMlnReasoner`** : c'est le plus simple. Il **énumère** toutes les interprétations de Herbrand du domaine, calcule le poids total (somme des poids des formules satisfaites) pour chaque monde, puis renormalise via `exp(poids)`. **Exponentiel** : `2^n` mondes pour `n` atomes.\n",
+    "\n",
+    "**`SimpleSamplingMlnReasoner`** : il **échantillonne** des mondes par Monte-Carlo et estime les probabilités marginales par comptage. **Polynomial** en pratique, mais approximation."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Cells **10** (Partie 3 : Comment les poids modèlent la croyance) and **16** (Partie 5 : Trois familles de raisonneurs MLN) of `Tweety-10-MLN-Csharp.ipynb` had their newlines stripped, gluing the heading + prose + GFM table separator + table rows + closing prose onto **one line each** (#3966 rendering defect : broken table rendering, the \"mal affiché\" user complaint). nbconvert parsed **0 tables** in either cell.

Atomic tranche for #3966 (residual after #6188 CSP-9 and #6189 Sudoku-12). Detected by the `COLLAPSED-MARKDOWN` scanner (#6199, not yet on main).

## Fix

Reconstruct canonical list-of-lines, reusing the **exact cell values and separator dashes** parsed from the original collapsed text (no invented content). Markdown-only.

## Proof (G.1 firsthand)

- `scan_md_hierarchy` COLLAPSED-MARKDOWN detector : Tweety-10 **1 → 0** flagged.
- nbconvert table-separator count : cell 10 **0 → 1**, cell 16 **0 → 1** (tables now render).
- **0 of 9 code cells touched** — all `execution_count` + `outputs` byte-identical to HEAD → no re-exec needed (C.2 markdown-only exception).
- `validate_pr_notebooks.py` : **1/1 PASS**. CRLF=0, no BOM, valid JSON.
- Diff scoped to 2 markdown cells (+28/-3, single file).

## Fleet C.1 status (G.1 firsthand, corrected)

An initial pattern-scan flagged cells 20/21/22 (Exercices 1-3) as `NotImplementedException` C.1 violations. **Direct read shows this was a false positive** : the regex matched comment prose ("pas de raise NotImplementedError"), not code. The actual code in each of 20/21/22 is a single line, `Console.WriteLine(\"... = Exercice a completer\")` — an exemplary C.1-compliant stub with `// TODO étudiant`. No defect.

Fleet scan (all .ipynb, code cells only, comments excluded) : **0 .NET notebooks** have actual `NotImplementedException` C.1 violations ; **0 Python notebooks** have `raise NotImplementedError`. The C.1 surface is clean across the repo. (The `validate_pr_notebooks.py` C.1 check is Python-pattern-centric, but in practice no C# stubs violate C.1.)

See #3966. Part of #3966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)