### PR TITLE
feat(notebook-lint): detect C# throw new NotImplementedException (C.1 gap)

### DIFF
--- a/scripts/notebook_tools/notebook_lint.py
+++ b/scripts/notebook_tools/notebook_lint.py
@@ -2,7 +2,8 @@
 """Unified notebook validator combining C.1, C.2, and structural checks.
 
 Runs all validation checks on a single notebook or batch:
-    - C.1: No intentional errors (raise NotImplementedError, assert False, 1/0)
+    - C.1: No intentional errors (raise NotImplementedError, assert False, 1/0,
+           and the C# equivalent `throw new NotImplementedException()`)
     - C.2: All code cells have execution_count and outputs
     - Structure: markdown intro/conclusion, cell ordering, empty cells
     - Metadata: kernel defined, title present
@@ -35,11 +36,20 @@ EXCLUDE_ALWAYS = {".ipynb_checkpoints", "obj", "bin", "__pycache__", ".git"}
 EXCLUDE_PEDAGOGICAL = {"research", "archive", "_output", "partner-course", "examples"}
 
 # C.1 forbidden patterns (intentional errors in top-level / exercise stubs)
-# Only flag patterns that are clearly intentional errors, not error handling
+# Only flag patterns that are clearly intentional errors, not error handling.
+# Covers both Python (raise NotImplementedError / assert False / 1/0) and the
+# C#/.NET Interactive equivalent `throw new NotImplementedException()` (the
+# idiomatic C# "not yet implemented" stub, semantically identical to Python's
+# raise NotImplementedError). The throw form is matched specifically so that
+# legitimate handling (`catch (NotImplementedException ex)`) and the distinct
+# `NotSupportedException` (used in real error handling, e.g. read-only
+# collections) are NOT flagged. Optional `System.` covers the fully-qualified
+# form. See #5261 for the comment-awareness context (C-family '//').
 C1_PATTERNS = [
     (r"raise\s+NotImplementedError", "raise NotImplementedError"),
     (r"assert\s+False", "assert False"),
     (r"(?<!\d)1\s*/\s*0(?!\d)", "1/0"),
+    (r"throw\s+new\s+(?:System\.)?NotImplementedException\b", "throw new NotImplementedException (C#)"),
 ]
 
 def _is_in_docstring(line: str, in_doc: bool) -> tuple[bool, bool]:

--- a/scripts/notebook_tools/tests/test_notebook_lint.py
+++ b/scripts/notebook_tools/tests/test_notebook_lint.py
@@ -189,6 +189,38 @@ class TestScanC1Source:
         hits = scan_c1_source("raise ValueError('bad input')")
         assert hits == []
 
+    def test_csharp_throw_not_implemented_flagged(self):
+        """C# `throw new NotImplementedException()` is the idiomatic stub and
+        the C# equivalent of Python's raise NotImplementedError (#C1, .NET).
+        Found via a Tweety-10 investigation (c.334): the shared detector was
+        Python-pattern-only, so .NET stubs could violate C.1 undetected.
+        """
+        hits = scan_c1_source("throw new NotImplementedException();")
+        assert len(hits) == 1
+        assert "NotImplementedException" in hits[0][1]
+
+    def test_csharp_throw_system_qualified_flagged(self):
+        """Fully-qualified `throw new System.NotImplementedException()` flagged."""
+        hits = scan_c1_source("throw new System.NotImplementedException();")
+        assert len(hits) == 1
+
+    def test_csharp_not_supported_not_flagged(self):
+        """NotSupportedException is a DIFFERENT, legitimate exception (read-only
+        collections, unsupported operations) — must NOT be flagged."""
+        hits = scan_c1_source("throw new NotSupportedException();")
+        assert hits == []
+
+    def test_csharp_catch_not_implemented_not_flagged(self):
+        """Handling a NotImplementedException (catch) is NOT a stub — the throw
+        form is required to flag."""
+        hits = scan_c1_source("catch (NotImplementedException ex) { }")
+        assert hits == []
+
+    def test_csharp_throw_not_implemented_in_comment_not_flagged(self):
+        """Commented-out C# throw is not executable (#5261 comment-awareness)."""
+        hits = scan_c1_source("// throw new NotImplementedException();")
+        assert hits == []
+
 
 # ---------------------------------------------------------------------------
 # check_c1
@@ -450,8 +482,9 @@ class TestLintNotebook:
 # ---------------------------------------------------------------------------
 
 class TestC1Patterns:
-    def test_three_patterns(self):
-        assert len(C1_PATTERNS) == 3
+    def test_four_patterns(self):
+        # Python (raise NotImplementedError, assert False, 1/0) + C# throw.
+        assert len(C1_PATTERNS) == 4
 
     def test_pattern_tuples(self):
         for pattern, desc in C1_PATTERNS:
@@ -464,3 +497,4 @@ class TestC1Patterns:
         assert "raise NotImplementedError" in descs
         assert "assert False" in descs
         assert "1/0" in descs
+        assert any("NotImplementedException" in d for d in descs)


### PR DESCRIPTION
## Summary

The shared C.1 detector (`notebook_lint.scan_c1_source`, consumed by both `notebook_lint` and `validate_pr_notebooks`, #1505) was **Python-pattern-only** : `raise NotImplementedError`, `assert False`, `1/0`. It did **not** catch the C#/.NET Interactive equivalent `throw new NotImplementedException()` — the idiomatic C# \"not yet implemented\" stub, semantically identical to Python's `raise NotImplementedError`. A .NET exercise stub could therefore violate C.1 (\"toute erreur intentionnelle INTERDITE partout\") undetected.

## Provenance (G.1 firsthand)

Found during the Tweety-10 collapsed-markdown cycle (#6204) : an initial naive scan flagged the stub cells 20/21/22, but a direct read showed those cells were **already C.1-compliant** (`Console.WriteLine` stubs whose comments merely *mention* the banned pattern — \"pas de raise NotImplementedError\"). The official detector correctly skipped the comments (#5261 comment-awareness works), yet the **underlying gap** (real C# throws undetected) remained. This PR closes that gap.

## Fix

Add `throw\s+new\s+(?:System\.)?NotImplementedException\b` to `C1_PATTERNS`. The `throw new` form is matched specifically so :
- `catch (NotImplementedException ex)` (legitimate handling) — NOT flagged
- `throw new NotSupportedException()` (a distinct, legitimate exception used in real error handling, e.g. read-only collections) — NOT flagged
- `// throw new NotImplementedException();` (commented-out) — NOT flagged (#5261)

## Tests

`+6` in `test_notebook_lint.py` : positive (`throw new NotImplementedException()`, `throw new System.NotImplementedException()`), negative (`NotSupportedException`, `catch`, commented-out). `test_three_patterns` → `test_four_patterns` ; known-patterns assertion updated.

- 69 `test_notebook_lint.py` tests pass
- 137 dependent tests pass (`validate_pr_notebooks`, `audit_c1_c3`, `validate_pr_mutation`)
- **2029 full `notebook_tools` suite** pass
- CRLF=0, 2 files, +48/-4 (tooling-only, no notebooks touched)

## Non-regression (G.1 firsthand)

Fleet scan with the **updated** detector over **927 notebooks** reports **0 C.1 violations** — no existing notebook newly fails (the fleet is currently clean). Tweety-10 comment-prose cells still pass (no false-positive regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)