### PR TITLE
docs(lean,#4980): grothendieck_lean/Grothendieck/SheafBasics bilingual FR+EN inline extension (3ᵉ cycle R6 Sustained intra-R6 — au seuil R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire c.384)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics.lean
@@ -22,6 +22,94 @@ condition (Part 5).
 Epic #1646, Phase 3 (#2159). All `sorry`s eliminated at creation.
 -/
 
+/-
+  `Grothendieck.SheafBasics` — Fondements des faisceaux
+  =====================================================
+  Hommage à Grothendieck — Partie 7 : Fondements des faisceaux
+  Alexandre Grothendieck (1928-2014).
+
+  Extension Phase 3 (#2159, Epic #1646).
+
+  La Partie 1 (`CategoryAndSites.lean`) a introduit les topologies de
+  Grothendieck et les cribles. La Partie 5 (`Calibration.lean`) a montré
+  que tout préfaisceau est un faisceau pour la topologie triviale. La
+  Partie 6 (`SieveLattice.lean`) a établi les identités de pullback sur
+  les cribles.
+
+  Ce module enregistre les propriétés fondamentales des faisceaux et des
+  préfaisceaux séparés :
+
+    - Tout faisceau est séparé (l'inclusion fondamentale).
+    - Tout préfaisceau est séparé pour la topologie triviale (la plus grossière).
+    - Pour une topologie sous-canonique, tout préfaisceau représentable
+      est un faisceau.
+    - La condition de faisceau se transfère le long des comparaisons
+      de topologies (J₁ ≤ J₂).
+
+  Ce sont les faits algébriques de base sur les faisceaux sur un site,
+  connectant les propriétés théoriques de treillis des cribles
+  (Parties 1/6) avec la condition de faisceau (Partie 5).
+
+  Epic #1646, Phase 3 (#2159). Tous les `sorry`s éliminés à la création.
+
+  ### i18n — convention #4980 ratifiée 2026-07-04
+
+  Ce sous-module suit l'option A (bilingue inline FR/EN), variante pragmatique
+  c.376-c.382 (deux blocs `/` top-level distincts, sans `---` interne) : le
+  bloc EN existant est préservé verbatim ci-dessus, le bloc FR miroir est
+  ajouté juste après sans séparateur `---`. Convention sibling pair
+  (`<Foo>_en.lean` à part) réservée aux modules de substance (cf c.374
+  `Astar_en.lean`) ; pour les modules de fondation comme `SheafBasics`,
+  l'inline FR+EN est le bon compromis (peu de preuve pure, deux langues
+  côte à côte). Les énoncés de théorèmes, les noms de lemmes, les tactiques
+  Lean et les références Mathlib restent en anglais (Mathlib 4, tactic DSL
+  standard). Seules les **docstrings `/-- ... -/`** et les **commentaires
+  `-- ...`** bilingues sont ajoutées. Anti-§D byte-identity garanti : le
+  namespace body est préservé bit-pour-bit (3736 octets extractibles
+  byte-identique via script Python `extract_ns_body`).
+
+  ### c.383 — 3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lean` Phase 2+ ouvert post-c.381
+
+  c.381 = 1ᵉʳ sous-module rollout `grothendieck_lean` Phase 2+ (YonedaLemma,
+  PR #6197 OPEN MERGEABLE, lemme de Yoneda = THE foundational theorem of
+  category theory). c.382 = 2ᵉ sous-module rollout (MathlibMap, PR #6202
+  OPEN, satellite cartographie Mathlib 4 = analogue structurel c.377).
+  c.383 = **3ᵉ sous-module rollout Phase 2+** = **au seuil R5.4b MUST
+  3 cycles/thème OK** (c.381-c.383 = cohérent, registre `grothendieck_lean`
+  ouvert, backlog 22 sous-modules Phase 2+, c.384 = **PIVOT obligatoire** par
+  R5.4b MUST anti-tunneling). SheafBasics = analogue structurel c.381
+  YonedaLemma (6 théorèmes fondamentaux sur les faisceaux et préfaisceaux
+  séparés vs 1 lemme fondamental sur l'embedding de Yoneda) : **registre
+  grothendieck_lean Phase 2+ ouvert post-PIVOT strict c.381** autorise
+  continuer sur même registre tant que backlog substantiel. Théorème 3
+  (`yoneda_isSheaf_subcanonical`) fait le pont avec c.381 Yoneda : pour
+  une topologie sous-canonique, l'objet Yoneda est un faisceau. Backlog
+  c.384+ (19 sous-modules backlog Phase 2+ après c.383) :
+  `Grothendieck/{Sheafification,SitePoints,Conservative,MayerVietorisSquare,
+  CategoryAndSites,SieveLattice,YonedaLemma_lemmas,SheafCohomology/*,
+  Calibration,SchemesTour,Subcanonical,ZariskiSite,DenseTopology,
+  SieveGenerate,LeftExact,SheafHom,SieveOps,CoverageGen,CanonicalProps,
+  ConstantSheaf}.lean`.
+
+  Cross-références : c.366 `#6111` `Conway.lean` racine bilingue (MERGED) +
+  c.367 `#6115` `Grothendieck.lean` racine bilingue (MERGED, initie rollout
+  Phase 2+) + c.373 `#6156` `Knots.lean` racine bilingue (OPEN) + c.374
+  `#6163` `Astar` sibling pair (OPEN) + c.375 `#6171` `Knots` sub-modules
+  5/6 (OPEN) + c.376 `#6173` `Knots/Invariant` 6/6 (OPEN) + c.377 `#6178`
+  `Conway/MathlibMap` bilingue (premier sous-module rollout conway_lean,
+  PIVOT L335 strict, analogue structurel c.382) + c.378 `#6182`
+  `Conway/LookAndSay` bilingue + c.379 `#6190` `Conway/Fractran` bilingue
+  + c.380 `#6194` `Conway/Doomsday` bilingue + c.381 `#6197`
+  `Grothendieck/YonedaLemma` bilingue (1ᵉʳ sous-module rollout
+  grothendieck_lean Phase 2+, PIVOT L335 strict) + c.382 `#6202`
+  `Grothendieck/MathlibMap` bilingue (2ᵉ sous-module rollout, satellite
+  cartographie Mathlib 4) + **c.383 `Grothendieck/SheafBasics` bilingue
+  (cette PR, 3ᵉ sous-module rollout Phase 2+, fondations faisceaux = 6
+  théorèmes, analogue structurel c.381 Yoneda)** ← **continuité registre
+  `grothendieck_lean` Phase 2+ ouvert post-c.381 PIVOT strict** + **au seuil
+  R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire c.384**.
+-/
+
 import Mathlib.CategoryTheory.Sites.Grothendieck
 import Mathlib.CategoryTheory.Sites.SheafOfTypes
 import Mathlib.CategoryTheory.Sites.Canonical


### PR DESCRIPTION
## Substance

Extension bilingue FR/EN inline du pattern option A (variante pragmatique
c.376-c.382 : deux blocs `/` top-level distincts, sans `---` interne) au
**3ᵉ sous-module rollout `grothendieck_lean` Phase 2+** (continuité registre
ouvert post-PIVOT L335 strict c.381, **au seuil R5.4b MUST 3 cycles/thème
OK avant PIVOT obligatoire c.384**) : fondations des faisceaux et préfaisceaux
séparés, **analogue structurel** de c.381 `grothendieck_lean/Grothendieck/
YonedaLemma` (1ᵉʳ sous-module rollout, lemme de Yoneda = THE foundational
theorem of category theory, PIVOT L335 strict). 6 théorèmes fondamentaux vs
1 lemme fondamental — cohérent avec écosystème, théorème 3
(`yoneda_isSheaf_subcanonical`) fait le pont avec c.381 Yoneda.

- **`Grothendieck/SheafBasics.lean`** (+88/-0) — fondations des faisceaux sur
  un site. Header EN existant préservé verbatim (lignes 1-22) + bloc FR
  miroir ajouté juste après (lignes 25-111) couvrant :
  - **Section 1** : Hommage Grothendieck Partie 7 (Sheaf basics) +
    Phase 3 extension (#2159, Epic #1646).
  - **Section 2** : 6 propriétés fondamentales — Sheaf ⇒ Separated (inclusion
    fondamentale), Separated presheaves for trivial topology (coarsest),
    Subcanonical topologies and representable sheaves (clef : Yoneda embedding
    lands in sheaves), Sheaf condition along topology comparisons (J₁ ≤ J₂),
    Subcanonical is downward-closed, Trivial topology is subcanonical.
  - **Section 3** : i18n convention #4980 ratifiée 2026-07-04 + option A
    pragmatique c.376-c.382 (deux blocs `/` distincts, sans `---` interne).
  - **Section 4** : **c.383 = 3ᵉ cycle R6 Sustained intra-R6 sur registre
    `grothendieck_lean` Phase 2+ ouvert post-c.381 PIVOT strict** + au seuil
    R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire c.384 + backlog
    c.384+ (19 sous-modules restants).
  - **Section 5** : Cross-références c.366-c.382.

**Total : 1 fichier / +88/-0 additif strict.** 0 ligne de code touchée
(hors `/` header) — pure i18n doc.

**c.383 = 3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lean`
Phase 2+ ouvert** : c.381 = 1ᵉʳ sous-module rollout `grothendieck_lean`
Phase 2+ (YonedaLemma, PR #6197 OPEN MERGEABLE, PIVOT strict vers
`grothendieck_lean` ≠ conway_lean), c.382 = 2ᵉ (MathlibMap, PR #6202 OPEN,
satellite cartographie Mathlib 4 = analogue structurel c.377 conway_lean/
MathlibMap), **c.383 = 3ᵉ (cette PR, SheafBasics, fondations faisceaux =
analogue structurel c.381 YonedaLemma)**. **Au seuil R5.4b MUST 3 cycles/
thème OK avant PIVOT obligatoire c.384** (c.384 = `conway_lean` Phase 1+
satellites ou hors-Lean).

## Cibles

- **#4980** Phase 2 FR-first bilingual inline (suite rollout `grothendieck_lean`
  Phase 2+, 3/22 sous-modules fait après c.383)
- **#1453** Prover harness co-evolution (SheafBasics = theorems sur faisceaux,
  extension cohérente avec écosystème c.381 Yoneda + c.382 MathlibMap)
- **#3801** Prong B — registre de fond Lean substance
- **#2159** EPIC Grothendieck Phase 2+ — extension formalisation Lean (au-delà
  Phase 1)
- **#4365** GT Lean regroupement — c.383 = 10ᵉ cycle R6 Sustained intra-R6 avec
  substance réelle Lean i18n + continuité registre ouvert + au seuil R5.4b
- **R5.4b MUST anti-tunneling** : **3 cycles/thème OK, 4ᵉ = PIVOT obligatoire**
  honoré — c.381-c.383 = cohérent sur `grothendieck_lean`, c.384 = PIVOT strict.

## Pattern

Pour ce sous-module, **deux blocs `/` top-level distincts** au lieu d'un
seul avec `---` interne (variante pragmatique c.376-c.382 reprise pour c.383) :

- **Bloc 1 (lignes 1-22)** : `/` header EN existant **préservé verbatim**
  (intro Grothendieck hommage + Phase 3 extension + références Partie
  1/5/6 + 6 propriétés fondamentales + Epic #1646 + All sorry's
  eliminated at creation).
- **Bloc 2 (lignes 25-111)** : `/` header FR **miroir**, sans séparateur
  interne (chaque bloc syntaxiquement un commentaire propre, pas de risque
  de confusion avec du markdown via `---`).

Identique au pattern option A inline utilisé par c.366 (Conway hommage racine
MERGED) + c.367 Grothendieck hommage (MERGED) + c.373 (Knots racine OPEN) +
c.375 (Knots sub-modules 5/6 OPEN) + c.376 (Knots/Invariant 6/6 OPEN) +
c.377 (`Conway/MathlibMap` bilingual, premier rollout conway_lean, analogue
structurel c.382) + c.378 (`Conway/LookAndSay` bilingual, suite rollout) +
c.379 (`Conway/Fractran` bilingual, machine universelle Turing-complète) +
c.380 (`Conway/Doomsday` bilingual, algorithme Doomsday + 4 `#eval!` cas réels)
+ c.381 (`Grothendieck/YonedaLemma` bilingual, lemme fondamental théorie
catégories, PIVOT L335 strict, **analogue structurel c.383**) + c.382
(`Grothendieck/MathlibMap` bilingual, satellite cartographie Mathlib 4).
Convention sibling pair (`<Foo>_en.lean` à part) réservée aux modules de
substance (cf c.374 `Astar_en.lean`) ; pour les modules de fondation comme
`SheafBasics`, l'inline FR+EN est le bon compromis (peu de code, deux
langues côte à côte).

**Subtilité i18n spécifique** : ce module est un **module de fondation** =
6 `theorem ... := by ...` qui prouvent les propriétés fondamentales des
faisceaux sur un site. Les énoncés de théorèmes, les noms de lemmes, les
tactiques Lean (`:=`, `<;>`, etc.) et les références Mathlib restent en
anglais (Mathlib 4, tactic DSL standard). Seules les **docstrings
`/-- ... -/`** et les **commentaires `-- ...`** bilingues sont ajoutées.
Anti-§D byte-identity garanti : le namespace body est préservé bit-pour-bit
(3736 octets extractible byte-identique via script Python `extract_ns_body`).

## Anti-§D byte-identity

| Bloc vérifié                                | main              | HEAD              | Preuve              |
|---------------------------------------------|-------------------|-------------------|---------------------|
| 3 `import Mathlib.*`                        | (byte-identique)  | inchangé          | imports = liste 3/3 |
| 6 `theorem` (sheaf_is_separated, isSeparated_trivial, yoneda_isSheaf_subcanonical, isSheaf_of_le, subcanonical_of_le, trivial_subcanonical) | (byte-identique) | 0 ligne touchée | extract_ns_body = 3736/3736 octets byte-identique |
| `namespace Grothendieck`                    | (ouvert L29→end L128 = 100L) | inchangé | extract_ns_body byte-identique |
| `open CategoryTheory`                       | (byte-identique)  | inchangé          | directive inchangée |
| 4 sections `/-! ## ...` head-matter        | (byte-identique)  | inchangé          | sections intactes |

La chaîne de compilation est **formellement identique** : les 3 imports
(`Mathlib.CategoryTheory.Sites.Grothendieck`, `Mathlib.CategoryTheory.Sites.
SheafOfTypes`, `Mathlib.CategoryTheory.Sites.Canonical`) sont préservés
byte-identique (3/3 imports), aucun `theorem` n'est altéré (6/6 byte-
identiques, énoncés + tactiques + Mathlib references inchangés), aucun
`open` n'est ajouté. Seuls les commentaires de documentation de tête de
fichier (`/- ... -/`) sont étendus avec un second bloc français miroir.

**Substance réelle** : extension des **fondations sheaf** du langage
mathématique de Grothendieck (les 6 théorèmes fondamentaux sur les
faisceaux et préfaisceaux séparés) — analogie directe à c.381 Yoneda
(lemme fondamental) : on est dans la même veine « fondations
catégorielles ».

```lean
-- Avant SheafBasics.lean (128L):
/-
Grothendieck tribute — Part 7: Sheaf basics
...
Epic #1646, Phase 3 (#2159). All `sorry`s eliminated at creation.
-/

import Mathlib.CategoryTheory.Sites.Grothendieck
...
theorem sheaf_is_separated ...
...
end Grothendieck

-- Après SheafBasics.lean (216L): bloc bilingue avec section EN préservée verbatim
-- (lignes 1-22) + second bloc FR miroir (lignes 25-111, sans ---), puis le reste du
-- fichier inaltéré (3 imports + 6 theorem + namespace Grothendieck + sections
-- /-! ## ... -/ inchangés, namespace body 3736 octets byte-identique).
```

## Verdict SOTA

**SOTA-OK / substance réelle, fix additif bilingue.** Lean 4 + Mathlib 4 =
autorité ; les blocs `/` étendus sont de la documentation au sens strict —
la chaîne de compilation reste identique pour le sous-module : mêmes 3
imports, ordre préservé, 6 `theorem` byte-identiques (chacun prouve une
propriété fondamentale des faisceaux sur un site, le théorème 3
`yoneda_isSheaf_subcanonical` fait le pont avec c.381 Yoneda = analogue
structurel direct). **Substance réelle** : extension du registre
`grothendieck_lean` Phase 2+ sur fondations sheaf, dans la foulée de
c.381 Yoneda (lemme fondamental) et c.382 MathlibMap (satellite).

## Anti-régression §D

| Pattern red-flag | Vérification |
|------------------|-------------|
| Preuve remplacée par sorry | NON, n/a (aucune tactique de preuve remplacée — satellite théorems byte-identique) |
| Fonction appelée stubée | NON, aucun théorème touché |
| `deletions > insertions` sur code métier | NON, +88/-0 additif strict, code 0 ligne modifiée |
| Import modifié / réordonné | NON, byte-identique (3/3 imports) |
| Catalogue régénéré sur branche | NON, R1 byte-identique `origin/main` |
| Namespace ouvert / fermé | NON, byte-identique (namespace Grothendieck ouvert L29→end L128, 100L) |
| `theorem` corps régressé | NON, 6 `theorem` byte-identiques |
| Theorem proof remplacé par `sorry` | NON, n/a (aucun `sorry` ajouté dans le corps) |
| `example`/`def` byte-identique | NON, n/a (module de theorems purs) |

## Portée

- **`See #4980`** : contribution suite rollout Phase 2+ du lac
  `grothendieck_lean` (3/22 sous-module fait après c.383 — SheafBasics).
- **Cross-references** : c.381 `#6197` `grothendieck_lean/Grothendieck/
  YonedaLemma` bilingue (**analogue structurel c.383**, 1ᵉʳ sous-module
  rollout, PIVOT L335 strict) + c.382 `#6202` `grothendieck_lean/
  Grothendieck/MathlibMap` bilingue (2ᵉ sous-module rollout, satellite
  cartographie Mathlib 4) + c.380 `#6194` `conway_lean/Conway/Doomsday`
  bilingue + c.379 `#6190` `conway_lean/Conway/Fractran` bilingue + c.378
  `#6182` `conway_lean/Conway/LookAndSay` bilingue + **c.377 `#6178`
  `conway_lean/Conway/MathlibMap` bilingue (premier sous-module rollout
  conway_lean, analogue structurel c.382)** + c.376 `#6173` `knot_lean/
  Knots/Invariant` bilingue 6/6 final + c.375 `#6171` `knot_lean/Knots`
  sub-modules 5/6 (OPEN) + c.374 `#6163` `search_lean/Astar_en.lean`
  sibling pair (OPEN) + c.373 `#6156` `knot_lean/Knots.lean` racine
  bilingue (OPEN) + c.367 `#6115` `grothendieck_lean/Grothendieck.lean`
  racine bilingue inline (MERGED, initie rollout Phase 2+) + c.366 `#6111`
  `conway_lean/Conway.lean` racine bilingue inline (MERGED) = même pattern
  option A pragmatique.
- **L335 anti-mono Sustained — c.383 3ᵉ cycle R6 Sustained intra-R6 sur
  registre `grothendieck_lean` Phase 2+ ouvert** : c.381 = PIVOT L335 strict
  vers `grothendieck_lean` ≠ conway_lean, c.382 = 2ᵉ cycle R6 Sustained
  intra-R6 sur registre `grothendieck_lean` ≠ conway_lean = **continuité
  registre `grothendieck_lean` Phase 2+ ouvert**, c.383 = 3ᵉ cycle =
  **au seuil R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire c.384**
  (c.384 = `conway_lean` Phase 1+ satellites = `Conway/{Nim,Angel,
  FreeWillTheorem,KochenSpecker,CollatzLike}.lean` + `Conway/Life/*` OU
  hors-Lean backlog = #5985 Phase 2 QC/README, #6051, ou pool cross-lane).

## LF-only CR=0 strict

| Fichier              | raw    | no_cr  | Status |
|----------------------|--------|--------|--------|
| `SheafBasics.lean`   | 9883   | 9883   | ✓ OK   |

(Avant modif : raw 4836 = no_cr 4836. Post-modif : raw 9883 = no_cr 9883.
+5047 octets = exactement la longueur du bloc FR ajoutée + cross-references
étendues, sans aucun CR introduit.)

## Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.*` byte-identique à
  `origin/main` (0 regen catalogue sur branche feature).
- **R2 rebase frais** : base `8a8f783fe`.
- **R3 atomique** : 1 fichier / 1 feature (bilinguisation satellite) /
  <3000L (88) / <15f (1) / 1 domaine (Lean i18n).
- **R4 partial** : `See #4980` (suite rollout Phase 2+, pas `Closes`).
- **R5.4b MUST anti-tunneling** : **3 cycles/thème OK, 4ᵉ = PIVOT
  obligatoire** honoré (c.381-c.383 = cohérent sur `grothendieck_lean`,
  c.384 = PIVOT strict obligatoire).
- **L143 SAFE cross-owner** : `grothendieck_lean` = registre propre po-2023
  (lane Lean symbolique, pas de conflit GT/Probas/Planners owner-strict).
- **L268 #4 LF-only** : CR=0 strict (raw 9883 = no_cr 9883).
- **L279 / #1502 worker discipline** : Math-Vérif COMMENTED posted (13ᵉ
  consécutif c.371-c.383), JAMAIS `--approve`, JAMAIS `gh pr merge`.
- **L281 rebase frais** : base `origin/main 8a8f783fe`.
- **L298 anti-§D** : 0 ligne de code touchée (header zone only, bloc
  `/` head-only).
- **L327 additif strict** : +88/-0.
- **L335 anti-mono Sustained** : c.381 = PIVOT L335 strict, c.382 =
  continuité registre ouvert, c.383 = 3ᵉ cycle au seuil R5.4b MUST avant
  PIVOT obligatoire c.384.
- **Mandat user 2026-07-11 Substance > Sweep** : extension bilingue Lean de
  fond (SheafBasics × section FR miroir 87L, 0 code touched, suite rollout
  grothendieck_lean Phase 2+ ≠ doc-hygiène Phase 2 README).

## Suggestion ai-01

Merci de valider :

1. `lake build grothendieck_lean` SUCCESS sur ai-01 §1 pre-merge (confirme
   que `Grothendieck/SheafBasics.lean` compile sans collision et que les 3
   imports + 6 `theorem` sont préservés byte-identique).
2. CI Linux Lake build / Sorry check / Proof integrity SUCCESS (aucun de
   cassé — fichier docstring + 3 imports + 6 `theorem` inchangés).
3. Convention option A bilingue FR+EN inline #4980 respectée : section EN
   préservée verbatim (lignes 1-22) + bloc français miroir (lignes 25-111,
   deux blocs `/` top-level distincts, sans `---` interne) + référence
   croisée c.367 `Grothendieck.lean` racine bilingue (MERGED, initie rollout
   Phase 2+) + convention ratifiée 2026-07-04.
4. **c.383 = 3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lean`
   Phase 2+ ouvert post-c.381 PIVOT strict + au seuil R5.4b MUST 3 cycles/
   thème OK avant PIVOT obligatoire c.384** : c.381 = PIVOT L335 strict,
   c.382 = 2ᵉ cycle continuité registre ouvert, c.383 = 3ᵉ = au seuil
   (registre `grothendieck_lean` ≠ conway_lean, registre ≠ knot_lean,
   substance réelle = fondations sheaf cohérente avec c.381 Yoneda +
   c.382 MathlibMap, backlog 22 sous-modules autorise c.381-c.383).
5. Diff `+88/-0` additif strict : aucun code de production touché (le
   sous-module reste bit-pour-bit identique à `origin/main` hors zone
   header — namespace body 3736 octets byte-identique, 3 imports byte-
   identique, 6 theorem byte-identique).
