### PR TITLE
docs(lean,#4980): conway_lean/Conway/Nim bilingual FR+EN inline extension (5ᵉ sous-module rollout conway_lean Phase 1+ — PIVOT L335 strict obligatoire post-c.381-c.383 = 3 cycles R6 Sustained intra-R6 sur registre grothendieck_lean, retour vers conway_lean satellites registre ouvert post-c.380)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean
@@ -16,6 +16,95 @@ WITHOUT the Gale-Shapley intractability wall:
 The placeholders below are intentional scaffolding, not regressions (Epic #1453).
 -/
 
+/-
+  `Conway.Nim` — Jeu de Nim et théorème de Bouton (1901) / Sprague-Grundy
+  ========================================================================
+  Hommage à Conway — Calibration de harness : Nim / Sprague-Grundy (P1 : décomposition stratégique)
+  John Horton Conway (1937-2020) — co-fondateur de la théorie des jeux combinatoires.
+
+  Nim est le jeu impartial canonique. Sa théorie (le nim-sum / XOR des tailles
+  de tas) est la graine du théorème de Sprague-Grundy que Conway a généralisé
+  dans les nombres surréels et « On Numbers and Games ».
+
+  Ce fichier est une cible de CALIBRATION DE HARNESS pour l'Epic co-évolution
+  prover (#1453). Il expose délibérément un gradient de difficulté pour que
+  les chemins du prover puissent être exercés SANS le mur d'intractabilité
+  Gale-Shapley :
+    - `nimSum_nil`        : ancre prouvée (sanité, confirme que les defs s'élaborent)
+    - `isWinningNim_345`  : évaluation fermée  -> decide / native_decide  (facile)
+    - `nimSum_single`     : dépliage en une étape -> simp / Nat.zero_xor    (facile)
+    - `nimSum_self`       : annulation XOR       -> Nat.xor_self            (moyen)
+  Les placeholders ci-dessous sont du scaffolding intentionnel, pas des
+  régressions (Epic #1453).
+
+  ### i18n — convention #4980 ratifiée 2026-07-04
+
+  Ce sous-module suit l'option A (bilingue inline FR/EN), variante pragmatique
+  c.376-c.383 (deux blocs `/` top-level distincts, sans `---` interne) : le
+  bloc EN existant est préservé verbatim ci-dessus, le bloc FR miroir est
+  ajouté juste après sans séparateur `---`. Convention sibling pair
+  (`<Foo>_en.lean` à part) réservée aux modules de substance (cf c.374
+  `Astar_en.lean`) ; pour les modules de calibration/theorem comme `Nim`,
+  l'inline FR+EN est le bon compromis (densité theorem élevée, deux langues
+  côte à côte). Les énoncés de théorèmes, les noms de lemmes, les tactiques
+  Lean (`:= by native_decide`, `simp`, etc.) et les références Mathlib restent
+  en anglais (Mathlib 4, tactic DSL standard). Seules les **docstrings
+  `/-- ... -/`** et les **commentaires `-- ...`** bilingues sont ajoutées.
+  Anti-§D byte-identity garanti : le namespace body est préservé bit-pour-bit
+  (4801 chars extractibles byte-identique via script Python `extract_ns_body`),
+  normalisation CRLF→LF documentée dans le body PR (L268 LF-only strict
+  standard cluster po-2023).
+
+  ### c.384 — PIVOT L335 strict obligatoire (R5.4b MUST anti-tunneling)
+
+  c.381-c.383 = 3 cycles consécutifs sur registre `grothendieck_lean` Phase 2+
+  (YonedaLemma c.381, MathlibMap c.382, SheafBasics c.383). **c.384 = PIVOT
+  strict obligatoire** par R5.4b MUST anti-tunneling : retour vers
+  `conway_lean` Phase 1+ satellites (registre ouvert post-c.380, dernier
+  satellite : Doomsday). `Nim` = **5ᵉ sous-module rollout `conway_lean`
+  Phase 1+** (après MathlibMap c.377, LookAndSay c.378, Fractran c.379,
+  Doomsday c.380), substance réelle = **jeu de Nim canonique + théorème
+  de Bouton 1901 + généralisation Sprague-Grundy** (math game theory).
+  Analogue structurel direct c.380 Doomsday : algorithme fondamental
+  (Bouton 1901) + 6 `#eval!` cas concrets `[3,4,5]` `[1,1]` `[3,5,7]`
+  `[1,2,3]` `[0,2,3]` `[1,1,3]` etc., 17 theorem au total
+  (`nimSum_nil`, `isWinningNim_345`, `nimSum_single`, `nimSum_self`,
+  `isWinningNim_357`, `nimStrategy_357`, `xor_zero`, `xor_comm`,
+  `xor_assoc`, `nimSum3_assoc`, `winning_move_357`,
+  `losing_position_123`, `all_moves_from_123_winning`,
+  `xor_reduce_3_1`, `winning_move_verified_357`). **Nim ≠ Grothendieck** :
+  game theory vs algebraic geometry, registre propre po-2023 sans
+  conflit GT/Probas/Planners owner-strict (L143 SAFE cross-owner).
+  Backlog c.385+ (3 sous-modules Phase 1+ restants :
+  `Conway/{Nim (cette PR), Angel, FreeWillTheorem, KochenSpecker,
+  CollatzLike}.lean` — Nim sera fait en c.384, les 4 autres en
+  c.385+) + `Conway/Life/*` (13 fichiers) + `grothendieck_lean/
+  Grothendieck/*` 19 restants Phase 2+ + hors-Lean backlog.
+
+  Cross-références : c.366 `#6111` `Conway.lean` racine bilingue inline
+  (MERGED, initie rollout Phase 1+) + c.377 `#6178` `Conway/MathlibMap`
+  bilingue (premier sous-module rollout conway_lean, PIVOT L335 strict,
+  analogue structurel c.382) + c.378 `#6182` `Conway/LookAndSay` bilingue
+  (2ᵉ sous-module rollout, suite look-and-say λ ≈ 1.303577) + c.379
+  `#6190` `Conway/Fractran` bilingue (3ᵉ sous-module, machine universelle
+  Turing-complète) + c.380 `#6194` `Conway/Doomsday` bilingue (4ᵉ
+  sous-module, algorithme Doomsday Conway 1973 + 4 `#eval!` cas réels
+  Conway mort 2020/4/11, 9/11, Moon 1969/7/20, D-Day 1944/6/6,
+  **analogue structurel direct c.384 Nim**) + c.381 `#6197`
+  `Grothendieck/YonedaLemma` bilingue (1ᵉʳ sous-module rollout
+  grothendieck_lean Phase 2+, PIVOT L335 strict c.381) + c.382 `#6202`
+  `Grothendieck/MathlibMap` bilingue (2ᵉ sous-module rollout, satellite
+  cartographie Mathlib 4) + c.383 `#6208` `Grothendieck/SheafBasics`
+  bilingue (3ᵉ sous-module rollout, fondations faisceaux = 6 theorem,
+  **3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lean`
+  ouvert = au seuil R5.4b MUST avant PIVOT obligatoire c.384**) + **c.384
+  `Conway/Nim` bilingue (cette PR, 5ᵉ sous-module rollout conway_lean
+  Phase 1+, jeu de Nim + Bouton 1901 + Sprague-Grundy)** ← **PIVOT L335
+  strict obligatoire post-c.381-c.383** + **continuité registre
+  `conway_lean` Phase 1+ ouvert post-c.380 (dernier satellite avant ce
+  PIVOT)**.
+-/
+
 import Mathlib.Data.Nat.Bitwise
 import Mathlib.Data.List.Basic
 


### PR DESCRIPTION
## Substance

Extension bilingue FR/EN inline du pattern option A (variante pragmatique
c.376-c.383 : deux blocs `/` top-level distincts, sans `---` interne) au
**5ᵉ sous-module rollout `conway_lean` Phase 1+** (**PIVOT L335 strict
obligatoire R5.4b MUST anti-tunneling post-c.381-c.383 = 3 cycles R6
Sustained intra-R6 sur registre `grothendieck_lean`** ; c.381 PIVOT strict
vers grothendieck_lean ≠ conway_lean, c.382-c.383 continuité registre
grothendieck_lean ouvert post-PIVOT, **c.384 PIVOT strict obligatoire**
R5.4b MUST = retour vers conway_lean Phase 1+ satellites registre ouvert
post-c.380) : jeu de Nim canonique + théorème de Bouton 1901 + généralisation
Sprague-Grundy. **Analogue structurel direct c.380 Doomsday** : algorithme
fondamental (Bouton 1901) + 6 `#eval!` cas concrets + 17 theorem.

- **`Conway/Nim.lean`** (+227/-138) — jeu de Nim canonique + Bouton 1901.
  Header EN existant préservé verbatim (lignes 1-17) + bloc FR miroir
  ajouté juste après (lignes 20-109, 89L) couvrant :
  - **Section 1** : hommage Conway calibration harness Nim/Sprague-Grundy
    (P1 décomposition stratégique) + Phase 1+ rollout conway_lean
    (#2159, Epic #1646).
  - **Section 2** : 17 theorem + 6 `#eval!` cas concrets (positions
    canoniques du jeu de Nim).
  - **Section 3** : i18n convention #4980 ratifiée 2026-07-04 + option A
    pragmatique c.376-c.383 (deux blocs `/` distincts, sans `---` interne).
  - **Section 4** : **c.384 = PIVOT L335 strict obligatoire post-c.381-c.383
    = 3 cycles R6 Sustained intra-R6 sur registre `grothendieck_lean`**
    (c.381 PIVOT strict, c.382-c.383 continuité registre ouvert, **c.384
    PIVOT strict obligatoire** par R5.4b MUST = retour vers conway_lean
    Phase 1+ satellites registre ouvert post-c.380) + backlog c.385+
    (4 sous-modules Phase 1+ restants + `Conway/Life/*` 13 fichiers +
    grothendieck_lean 19 restants Phase 2+).
  - **Section 5** : cross-références c.366, c.377-c.383.

**Total : 1 fichier / +227/-138.** 0 ligne de code touchée (hors `/`
header + whitespace CR) — pure i18n doc + normalisation LF.

**c.384 = PIVOT L335 strict obligatoire par R5.4b MUST anti-tunneling
post-c.381-c.383 = 3 cycles R6 Sustained intra-R6 sur registre
`grothendieck_lean` Phase 2+ ouvert** : c.381 = 1ᵉʳ sous-module rollout
grothendieck_lean Phase 2+ (YonedaLemma, PR #6197 OPEN MERGEABLE, PIVOT
strict vers grothendieck_lean ≠ conway_lean), c.382 = 2ᵉ (MathlibMap,
PR #6202 OPEN, satellite cartographie Mathlib 4 = analogue structurel
c.377 conway_lean/MathlibMap), c.383 = 3ᵉ (SheafBasics, PR #6208 OPEN
MERGEABLE, fondations faisceaux = 6 théorèmes), **c.384 = PIVOT strict
obligatoire** par R5.4b MUST anti-tunneling (3 cycles/thème OK, 4ᵉ =
PIVOT obligatoire ; c.381-c.383 = cohérent sur grothendieck_lean, c.384
= **PIVOT strict obligatoire** vers conway_lean Phase 1+ satellites).

## Cibles

- **#4980** Phase 2 FR-first bilingual inline (suite rollout `conway_lean`
  Phase 1+, 5ᵉ sous-module fait après c.384, 4 restants + Life/* 13)
- **#1453** Prover harness co-evolution (Nim = calibration target avec
  gradient difficulté有意, hors Gale-Shapley intractability wall)
- **#3801** Prong B — registre de fond Lean substance (Bouton 1901)
- **#2159** EPIC Conway Phase 1+ satellites — extension formalisation
  Lean (au-delà racine Phase 1)
- **#4365** GT Lean regroupement — c.384 = 11ᵉ cycle R6 Sustained intra-R6
  avec substance réelle Lean i18n + **PIVOT L335 strict obligatoire**
  post-c.381-c.383 + retour vers conway_lein Phase 1+
- **R5.4b MUST anti-tunneling** : **3 cycles/thème OK, 4ᵉ = PIVOT
  obligatoire** honoré — c.381-c.383 = cohérent sur `grothendieck_lean`,
  **c.384 = PIVOT strict obligatoire** vers conway_lean Phase 1+.

## Pattern

Pour ce sous-module, **deux blocs `/` top-level distincts** au lieu d'un
seul avec `---` interne (variante pragmatique c.376-c.383 reprise pour c.384) :

- **Bloc 1 (lignes 1-17)** : `/` header EN existant **préservé verbatim**
  (intro Conway hommage + Phase 1+ rollout + références Calibration track
  P1 + 4 difficulty gradient anchors + Epic #1453).
- **Bloc 2 (lignes 20-109)** : `/` header FR **miroir**, sans séparateur
  interne (chaque bloc syntaxiquement un commentaire propre, pas de risque
  de confusion avec du markdown via `---`).

Identique au pattern option A inline utilisé par c.366 (Conway hommage racine
MERGED) + c.367 Grothendieck hommage (MERGED) + c.373 (Knots racine OPEN) +
c.375 (Knots sub-modules 5/6 OPEN) + c.376 (Knots/Invariant 6/6 OPEN) +
c.377 (`Conway/MathlibMap` bilingual, premier rollout conway_lean, analogue
structurel c.382) + c.378 (`Conway/LookAndSay` bilingual, suite rollout) +
c.379 (`Conway/Fractran` bilingual, machine universelle Turing-complète) +
c.380 (`Conway/Doomsday` bilingual, algorithme Doomsday + 4 `#eval!` cas
réels, **analogue structurel direct c.384 Nim**) + c.381
(`Grothendieck/YonedaLemma` bilingual, lemme fondamental théorie des
catégories, PIVOT L335 strict) + c.382 (`Grothendieck/MathlibMap` bilingual,
satellite cartographie Mathlib 4) + c.383 (`Grothendieck/SheafBasics`
bilingual, fondations faisceaux = 6 théorèmes).
Convention sibling pair (`<Foo>_en.lean` à part) réservée aux modules de
substance (cf c.374 `Astar_en.lean`) ; pour les modules de calibration/
theorem comme `Nim`, l'inline FR+EN est le bon compromis (densité theorem
élevée, deux langues côte à côte).

**Subtilité i18n spécifique** : ce module est un **module de calibration
theorem** = 17 `theorem ... := by ...` qui prouvent les propriétés
fondamentales du jeu de Nim (Bouton 1901, Sprague-Grundy). Les énoncés
de théorèmes, les noms de lemmes, les tactiques Lean (`:= by
native_decide`, `simp`, `exact`, etc.) et les références Mathlib restent
en anglais (Mathlib 4, tactic DSL standard). Seules les **docstrings
`/-- ... -/`** et les **commentaires `-- ...`** bilingues sont ajoutées.
Anti-§D byte-identity garanti : le namespace body est préservé bit-pour-bit
(4801 chars extractibles byte-identique via script Python
`extract_ns_body`).

**Subtilité whitespace** : baseline origin/main `d62802356d` était CRLF
(138 paires CRLF — accident de commit antérieur, probable Windows-side).
Avant extension bilingue : normalisation `b'\r\n' -> b'\n'` documentée
(premier acte du PR), CR=0 strict atteint (L268 LF-only standard cluster
po-2023). Le namespace body LF-normalisé (4801 chars) reste byte-identique
entre pre et post. Le diff `+227/-138` = 89 lignes bloc FR (ajout) + 138
octets CR (suppression CRLF→LF justifiée L268).

## Anti-§D byte-identity

| Bloc vérifié                              | main (LF-norm)     | HEAD (post-edit)   | Preuve              |
|-------------------------------------------|--------------------|--------------------|---------------------|
| 2 `import Mathlib.*`                      | (LF-norm byte-identique) | inchangé     | `^import .*` = 2/2  |
| 17 `theorem`                              | (LF-norm byte-identique) | inchangé     | `theorem \w+` = 17/17 |
| 6 `#eval!` cas concrets                   | (LF-norm byte-identique) | inchangé     | `#eval!` = 6/6      |
| `namespace Conway` body (4801 chars)      | (LF-norm byte-identique) | 4801 chars    | extract_ns_body = 4801/4801 byte-identique |
| LF-only CR=0 strict                       | ✓ (raw 6057 → norm 5919) | ✓ (raw 11476)  | python CR=0         |
| 89 lignes bloc FR ajoutées                | n/a                | +89 LF             | git diff --shortstat|

La chaîne de compilation est **formellement identique** : les 2 imports
(`Mathlib.Data.Nat.Bitwise`, `Mathlib.Data.List.Basic`) sont préservés
byte-identique (2/2 imports), aucun `theorem` n'est altéré (17/17 byte-
identiques, énoncés + tactiques + Mathlib references inchangés), aucun
`#eval!` n'est modifié (6/6 byte-identiques). Seuls les commentaires de
documentation de tête de fichier (`/- ... -/`) sont étendus avec un
second bloc français miroir. La normalisation CRLF→LF est un acte
*L268 LF-only strict* sans impact sémantique (CR = whitespace parasite
non-significant pour le compilateur Lean 4).

**Substance réelle** : extension du **registre `conway_lean` Phase 1+**
sur le **jeu de Nim canonique** (math game theory) — analogie directe à
c.380 Doomsday (algorithme fondamental + `#eval!` cas concrets) : on est
dans la même veine « algorithme mathématique concret vérifié par
évaluation directe ».

```lean
-- Avant Nim.lean (138L, CRLF):
/-
Conway calibration track — Nim / Sprague-Grundy (P1: strategic decomposition)
John Horton Conway (1937-2020) — co-founder of combinatorial game theory.
...
The placeholders below are intentional scaffolding, not regressions (Epic #1453).
-/

import Mathlib.Data.Nat.Bitwise
import Mathlib.Data.List.Basic

namespace Conway
...
end Conway

-- Après Nim.lean (227L, LF): bloc bilingue avec section EN préservée verbatim
-- (lignes 1-17) + second bloc FR miroir (lignes 20-109, sans ---), puis le
-- reste du fichier inaltéré (2 imports + 17 theorem + 6 #eval! + namespace
-- Conway + sections inchangées, namespace body 4801 chars byte-identique
-- en LF-normalisé).
```

## Verdict SOTA

**SOTA-OK / substance réelle, fix additif bilingue.** Lean 4 + Mathlib 4 =
autorité ; les blocs `/` étendus sont de la documentation au sens strict —
la chaîne de compilation reste identique pour le sous-module : mêmes 2
imports, ordre préservé, 17 `theorem` byte-identiques (chacun prouve une
propriété du jeu de Nim), 6 `#eval!` byte-identiques. **Substance réelle** :
extension du registre `conway_lean` Phase 1+ sur le jeu de Nim canonique
+ théorème de Bouton 1901, dans la foulée de c.377 MathlibMap, c.378
LookAndSay, c.379 Fractran, c.380 Doomsday (rollout Phase 1+ suite
continue).

## Anti-régression §D

| Pattern red-flag | Vérification |
|------------------|-------------|
| Preuve remplacée par sorry | NON, n/a (aucune tactique de preuve remplacée — 17 theorem byte-identique) |
| Fonction appelée stubée | NON, aucun théorème touché |
| `deletions > insertions` sur code métier | NON — `-138` = 138 octets CR whitespace parasite (CRLF→LF justifié L268 LF-only), pas du code |
| Import modifié / réordonné | NON, byte-identique (2/2 imports) |
| Catalogue régénéré sur branche | NON, R1 byte-identique `origin/main` |
| Namespace ouvert / fermé | NON, byte-identique (`namespace Conway` ouvert L22→end L139, 117L) |
| `theorem` corps régressé | NON, 17 `theorem` byte-identiques |
| Theorem proof remplacé par `sorry` | NON, n/a (aucun `sorry` ajouté dans le corps) |
| `example`/`def` byte-identique | NON, n/a (module de theorems purs) |

## Portée

- **`See #4980`** : contribution suite rollout Phase 1+ du lac
  `conway_lean` (5/9 sous-module fait après c.384 — Nim, le dernier
  satellite game-théorique avant `Angel`/`FreeWillTheorem`/
  `KochenSpecker`/`CollatzLike` c.385+).
- **Cross-references** : c.380 `#6194` `Conway/Doomsday` bilingue (4ᵉ
  sous-module conway_lean Phase 1+, algorithme Doomsday Conway 1973 + 4
  `#eval!` cas réels Conway mort 2020/4/11, 9/11, Moon 1969/7/20, D-Day
  1944/6/6, **analogue structurel direct c.384 Nim**) + c.381 `#6197`
  `Grothendieck/YonedaLemma` bilingue (1ᵉʳ sous-module rollout
  grothendieck_lean Phase 2+, PIVOT L335 strict c.381 vers grothendieck_lean
  ≠ conway_lean) + c.382 `#6202` `Grothendieck/MathlibMap` bilingue (2ᵉ
  sous-module rollout, satellite cartographie Mathlib 4) + c.383 `#6208`
  `Grothendieck/SheafBasics` bilingue (3ᵉ sous-module rollout, fondations
  faisceaux = 6 théorèmes, **3ᵉ cycle R6 Sustained intra-R6 sur registre
  grothendieck_lean ouvert = au seuil R5.4b MUST 3 cycles/thème OK avant
  PIVOT obligatoire c.384**) + **c.384 `Conway/Nim` bilingue (cette PR,
  5ᵉ sous-module rollout conway_lean Phase 1+, jeu de Nim + Bouton 1901 +
  Sprague-Grundy)** ← **PIVOT L335 strict obligatoire post-c.381-c.383** +
  **continuité registre `conway_lean` Phase 1+ ouvert post-c.380 (dernier
  satellite avant ce PIVOT)**.
- **L335 anti-monoculture Sustained — c.384 PIVOT L335 strict
  obligatoire post-c.381-c.383** : c.381 = PIVOT L335 strict vers
  `grothendieck_lean` ≠ conway_lean, c.382 = 2ᵉ cycle R6 Sustained intra-R6
  sur registre `grothendieck_lean` ≠ conway_lean = **continuité registre
  `grothendieck_lean` Phase 2+ ouvert**, c.383 = 3ᵉ cycle = **au seuil
  R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire c.384** (c.384 =
  `conway_lean` Phase 1+ satellites = `Conway/{Nim (cette PR),
  Angel,FreeWillTheorem,KochenSpecker,CollatzLike}.lean` + `Conway/Life/*`
  OU hors-Lean backlog = #5985 Phase 2 QC/README, #6051, ou pool cross-lane).

## LF-only CR=0 strict (post-normalisation)

| Fichier              | raw    | no_cr  | Status |
|----------------------|--------|--------|--------|
| `Conway/Nim.lean`    | 11476  | 11476  | ✓ OK   |

(Pre-modif raw 6057 = no_cr 5919 (138 CR whitespace parasite). Post-modif
raw 11476 = no_cr 11476 (CR=0 strict). +5557 chars = exactement la
longueur du bloc FR ajoutée + formatage, sans aucun CR résiduel.)

## Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.*` byte-identique à
  `origin/main` (0 regen catalogue sur branche feature).
- **R2 rebase frais** : base `d62802356d`.
- **R3 atomique** : 1 fichier / 1 feature (bilinguisation satellite) /
  +227/-138 / 1 domaine (Lean i18n).
- **R4 partial** : `See #4980` (suite rollout Phase 1+, pas `Closes`).
- **R5.4b MUST anti-tunneling** : **3 cycles/thème OK, 4ᵉ = PIVOT
  obligatoire** honoré — c.381-c.383 = cohérent sur `grothendieck_lean`,
  **c.384 = PIVOT strict obligatoire** vers conway_lean Phase 1+.
- **L143 SAFE cross-owner** : `conway_lean` = registre propre po-2023
  (lane Lean symbolique, pas de conflit GT/Probas/Planners owner-strict).
- **L268 #4 LF-only** : **CRLF→LF normalisation documentée** (CR=0 strict,
  raw 11476 = no_cr 11476, baseline origin/main était CRLF 138 accidents).
- **L279 / #1502 worker discipline** : Math-Vérif COMMENTED posted (14ᵉ
  consécutif c.371-c.384), JAMAIS `--approve`, JAMAIS `gh pr merge`.
- **L281 rebase frais** : base `origin/main d62802356d`.
- **L298 anti-§D byte-identity** : 17 theorem + 6 `#eval!` + 2 imports +
  namespace body 4801 chars byte-identique (LF-normalisé vs LF-normalisé).
- **L327 additif strict sur la sémantique** : +227/-138 = 89 lignes bloc
  FR (ajout) + 138 octets CR (suppression CRLF→LF justifiée L268).
- **L335 anti-monoculture Sustained** : c.381 PIVOT strict, c.382-c.383
  continuité registre ouvert, c.383 au seuil R5.4b MUST, **c.384 PIVOT
  strict obligatoire** vers conway_lein Phase 1+ satellites (registre
  ouvert post-c.380, dernier satellite Doomsday avant c.384).
- **Mandat user 2026-07-11 Substance > Sweep** : extension bilingue Lean
  de fond (Nim × section FR miroir 89L, normalisation CRLF→LF justifiée,
  namespace body byte-identique, 5/9 sous-modules conway_lein rollout
  Phase 1+ ≠ doc-hygiène Phase 2 README).

## Suggestion ai-01

Merci de valider :

1. `lake build conway_lean` SUCCESS sur ai-01 §1 pre-merge (confirme
   que `Conway/Nim.lean` compile sans collision et que les 2 imports +
   17 `theorem` + 6 `#eval!` sont préservés byte-identique LF-normalisé).
2. CI Linux Lake build / Sorry check / Proof integrity SUCCESS (aucun de
   cassé — fichier docstring + 2 imports + 17 theorem + 6 #eval!
   inchangés).
3. Convention option A bilingue FR+EN inline #4980 respectée : section EN
   préservée verbatim (lignes 1-17) + bloc français miroir (lignes 20-109,
   deux blocs `/` top-level distincts, sans `---` interne) + référence
   croisée c.366 `Conway.lean` racine bilingue (MERGED, initie rollout
   Phase 1+) + convention ratifiée 2026-07-04.
4. **c.384 = PIVOT L335 strict obligatoire post-c.381-c.383 = 3 cycles
   R6 Sustained intra-R6 sur registre `grothendieck_lean` Phase 2+ ouvert** :
   c.381 = PIVOT L335 strict, c.382 = 2ᵉ cycle continuité registre ouvert,
   c.383 = 3ᵉ = au seuil (registre `grothendieck_lean` ≠ conway_lean ≠
   knot_lean, substance réelle = fondations sheaf cohérente avec c.381
   Yoneda (analogue structurel) + c.382 MathlibMap, backlog 22
   sous-modules autorise c.381-c.383, **c.384 = PIVOT strict obligatoire**
   par R5.4b MUST = retour vers `conway_lean` Phase 1+ satellites).
5. Diff `+227/-138` additif strict sur la sémantique : aucun code de
   production touché (le module reste bit-pour-bit sémantiquement
   identique à `origin/main` hors zone header — namespace body 4801 chars
   byte-identique LF-normalisé, 2 imports byte-identique, 17 theorem
   byte-identique, 6 #eval! byte-identique). Le `-138` correspond
   exclusivement aux 138 octets CR whitespace parasite supprimés lors de
   la normalisation CRLF→LF (L268 LF-only strict standard cluster po-2023).