### PR TITLE
docs(lean,#4980): conway_lean/Conway/Nim bilingual FR+EN inline extension

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean
@@ -2,9 +2,16 @@
 Conway calibration track — Nim / Sprague-Grundy (P1: strategic decomposition)
 John Horton Conway (1937-2020) — co-founder of combinatorial game theory.
 
+Track de calibration Conway — Nim / Sprague-Grundy (P1 : décomposition stratégique)
+John Horton Conway (1937-2020) — cofondateur de la théorie combinatoire des jeux.
+
 Nim is the canonical impartial game. Its theory (the nim-sum / XOR of heap sizes)
 is the seed of the Sprague-Grundy theorem that Conway generalized into the
 surreal numbers and "On Numbers and Games".
+
+Nim est le jeu impartial canonique. Sa théorie (la nim-somme / XOR des tailles
+de tas) est le germe du théorème de Sprague-Grundy que Conway a généralisé en les
+nombres surréels et « On Numbers and Games ».
 
 This file is a HARNESS CALIBRATION target for the prover co-evolution Epic (#1453).
 It deliberately exposes a difficulty gradient so the prover paths can be exercised
@@ -14,6 +21,17 @@ WITHOUT the Gale-Shapley intractability wall:
   - `nimSum_single`     : one-step unfold      -> simp / Nat.zero_xor    (easy)
   - `nimSum_self`       : XOR cancellation     -> Nat.xor_self            (medium)
 The placeholders below are intentional scaffolding, not regressions (Epic #1453).
+
+Ce fichier est une CIBLE DE CALIBRATION DU HARNAIS pour l'Epic de co-évolution du
+prouveur (#1453). Il expose délibérément un gradient de difficulté afin que les
+chemins du prouveur puissent être exercés SANS le mur d'intractabilité de
+Gale-Shapley :
+  - `nimSum_nil`        : ancrage prouvé (sanity, confirme l'élaboration des defs)
+  - `isWinningNim_345`  : évaluation fermée  -> decide / native_decide  (facile)
+  - `nimSum_single`     : dépliage en une étape -> simp / Nat.zero_xor    (facile)
+  - `nimSum_self`       : annulation XOR       -> Nat.xor_self            (moyen)
+Les emplacements ci-dessous sont un échafaudage intentionnel, pas des régressions
+(Epic #1453).
 -/
 
 import Mathlib.Data.Nat.Bitwise
@@ -21,51 +39,75 @@ import Mathlib.Data.List.Basic
 
 namespace Conway
 
-/-- The nim-sum of a position: XOR-fold of the heap sizes. -/
+/-- The nim-sum of a position: XOR-fold of the heap sizes.
+    La nim-somme d'une position : repli par XOR des tailles de tas. -/
 def nimSum (heaps : List Nat) : Nat :=
   heaps.foldl (· ^^^ ·) 0
 
-/-- A nim position is a first-player win iff its nim-sum is non-zero. -/
+/-- A nim position is a first-player win iff its nim-sum is non-zero.
+    Une position de nim est gagnante pour le premier joueur ssi sa nim-somme est non nulle. -/
 def isWinningNim (heaps : List Nat) : Bool :=
   nimSum heaps != 0
 
 -- A few sanity evaluations (3^^4 = 7, 7^^5 = 2 ≠ 0, so [3,4,5] is winning).
+-- Quelques évaluations de sanity (3^^4 = 7, 7^^5 = 2 ≠ 0, donc [3,4,5] est gagnant).
 #eval nimSum [3, 4, 5]      -- 2
 #eval isWinningNim [3, 4, 5] -- true
-#eval isWinningNim [1, 1]    -- false (balanced)
+#eval isWinningNim [1, 1]    -- false (balanced / équilibré)
 
-/-- Proved anchor: the empty position has nim-sum 0. -/
+/-- Proved anchor: the empty position has nim-sum 0.
+    Ancrage prouvé : la position vide a une nim-somme de 0. -/
 theorem nimSum_nil : nimSum [] = 0 := rfl
 
-/-- CALIBRATION (decide): the position [3,4,5] is a first-player win. -/
+/-- CALIBRATION (decide): the position [3,4,5] is a first-player win.
+    CALIBRATION (decide) : la position [3,4,5] est gagnante pour le premier joueur. -/
 theorem isWinningNim_345 : isWinningNim [3, 4, 5] = true := by
   native_decide
 
-/-- CALIBRATION (unfold + zero_xor): a single heap has nim-sum equal to its size. -/
+/-- CALIBRATION (unfold + zero_xor): a single heap has nim-sum equal to its size.
+    CALIBRATION (dépliage + zero_xor) : un tas unique a une nim-somme égale à sa taille. -/
 theorem nimSum_single (n : Nat) : nimSum [n] = n := by
   simp [nimSum, Nat.zero_xor]
 
-/-- CALIBRATION (xor cancellation): two equal heaps cancel — the losing P-position. -/
+/-- CALIBRATION (xor cancellation): two equal heaps cancel — the losing P-position.
+    CALIBRATION (annulation xor) : deux tas égaux s'annulent — la P-position perdante. -/
 theorem nimSum_self (n : Nat) : nimSum [n, n] = 0 := by
   simp [nimSum, Nat.xor_self]
 
 /-! ## Bouton's Strategy (1901) — The Core of Combinatorial Game Theory
+    ## La stratégie de Bouton (1901) — Le cœur de la théorie combinatoire des jeux
 
 The fundamental theorem of Nim (Bouton, 1901): a position is a first-player
 win (N-position) if and only if the nim-sum is nonzero. The strategy is
 constructive: when `nimSum ≠ 0`, the first player can always make a move that
 sets the nim-sum to zero (a P-position for the opponent).
 
+Le théorème fondamental de Nim (Bouton, 1901) : une position est gagnante pour
+le premier joueur (N-position) si et seulement si la nim-somme est non nulle. La
+stratégie est constructive : quand `nimSum ≠ 0`, le premier joueur peut toujours
+jouer un coup qui ramène la nim-somme à zéro (une P-position pour l'adversaire).
+
 Conway's *On Numbers and Games* (1976) generalizes this to all impartial games
 via the Sprague-Grundy theorem: every impartial game is equivalent to a Nim heap.
 This module proves the constructive direction of Bouton's theorem using `native_decide`
-on small instances, plus the general XOR property that makes it work. -/
+on small instances, plus the general XOR property that makes it work.
+
+*On Numbers and Games* de Conway (1976) généralise cela à tous les jeux impartiaux
+via le théorème de Sprague-Grundy : tout jeu impartial est équivalent à un tas de
+Nim. Ce module prouve la direction constructive du théorème de Bouton à l'aide de
+`native_decide` sur de petites instances, plus la propriété XOR générale qui le rend
+possible. -/
 
 /-- CALIBRATION (decide): the 3-heap position [1, 2, 3] is winning.
     1 ^^^ 2 = 3, and 3 ^^^ 3 = 0, so actually nimSum = 0 — this is a LOSS.
     Correction: [1, 4, 5] is winning: 1 ^^^ 4 = 5, 5 ^^^ 5 = 0. Wait —
     Let me use [3, 5, 6]: 3 ^^^ 5 = 6, 6 ^^^ 6 = 0... also balanced.
-    [3, 5, 7]: 3 ^^^ 5 = 6, 6 ^^^ 7 = 1 ≠ 0 — winning. -/
+    [3, 5, 7]: 3 ^^^ 5 = 6, 6 ^^^ 7 = 1 ≠ 0 — winning.
+    CALIBRATION (decide) : la position à 3 tas [1, 2, 3] est gagnante.
+    1 ^^^ 2 = 3, et 3 ^^^ 3 = 0, donc en fait nimSum = 0 — c'est une PERTE.
+    Correction : [1, 4, 5] est gagnant : 1 ^^^ 4 = 5, 5 ^^^ 5 = 0. Attendez —
+    Utilisons [3, 5, 6] : 3 ^^^ 5 = 6, 6 ^^^ 6 = 0... équilibré aussi.
+    [3, 5, 7] : 3 ^^^ 5 = 6, 6 ^^^ 7 = 1 ≠ 0 — gagnant. -/
 theorem isWinningNim_357 : isWinningNim [3, 5, 7] = true := by
   native_decide
 
@@ -76,30 +118,47 @@ theorem isWinningNim_357 : isWinningNim [3, 5, 7] = true := by
 
     Here we verify the strategy on the concrete position [3, 5, 7]:
     nimSum = 1. Heap 3: 3 ^^^ 1 = 2 < 3, reduce 3 to 2.
-    New position [2, 5, 7]: 2 ^^^ 5 ^^^ 7 = 0. P-position! -/
+    New position [2, 5, 7]: 2 ^^^ 5 ^^^ 7 = 0. P-position!
+
+    Après avoir retiré k pierres du tas i, la nouvelle nim-somme est l'ancienne
+    nim-somme XORée avec le changement dans ce tas. C'est la clé algébrique de la
+    stratégie gagnante : pour annuler la nim-somme, choisir un tas où heap_i XOR s
+    < heap_i (où s = nimSum), et le réduire à heap_i XOR s.
+
+    Ici nous vérifions la stratégie sur la position concrète [3, 5, 7] :
+    nimSum = 1. Tas 3 : 3 ^^^ 1 = 2 < 3, réduire 3 à 2.
+    Nouvelle position [2, 5, 7] : 2 ^^^ 5 ^^^ 7 = 0. P-position ! -/
 theorem nimStrategy_357 :
     nimSum [2, 5, 7] = 0 ∧ 2 < 3 := by
   native_decide
 
-/-- XOR with zero is the identity. -/
+/-- XOR with zero is the identity.
+    Le XOR avec zéro est l'identité. -/
 theorem xor_zero (n : Nat) : n ^^^ 0 = n := by
   exact Nat.xor_zero n
 
-/-- XOR is commutative. -/
+/-- XOR is commutative.
+    Le XOR est commutatif. -/
 theorem xor_comm (a b : Nat) : a ^^^ b = b ^^^ a := by
   exact Nat.xor_comm a b
 
-/-- XOR is associative. -/
+/-- XOR is associative.
+    Le XOR est associatif. -/
 theorem xor_assoc (a b c : Nat) : a ^^^ (b ^^^ c) = (a ^^^ b) ^^^ c := by
   exact Nat.xor_assoc a b c |>.symm
 
-/-- The nim-sum of three elements in association-invariant order. -/
+/-- The nim-sum of three elements in association-invariant order.
+    La nim-somme de trois éléments dans un ordre invariant par association. -/
 theorem nimSum3_assoc (a b c : Nat) : a ^^^ b ^^^ c = a ^^^ (b ^^^ c) := by
   rw [← Nat.xor_assoc]
 
 /-- The Bouton strategy verified: in position [3, 5, 7] with nimSum = 1,
     the winning move is to reduce heap 0 from 3 to 2 (= 3 XOR 1).
-    The resulting position [2, 5, 7] has nimSum 0 (P-position). -/
+    The resulting position [2, 5, 7] has nimSum 0 (P-position).
+
+    La stratégie de Bouton vérifiée : en position [3, 5, 7] avec nimSum = 1,
+    le coup gagnant est de réduire le tas 0 de 3 à 2 (= 3 XOR 1).
+    La position résultante [2, 5, 7] a une nimSum de 0 (P-position). -/
 theorem winning_move_357 :
     nimSum [3, 5, 7] = 1 ∧
     nimSum [2, 5, 7] = 0 := by
@@ -107,12 +166,19 @@ theorem winning_move_357 :
 
 /-- Another concrete strategy: position [1, 2, 3] has nimSum 0 (P-position),
     meaning the SECOND player wins. Any move the first player makes leads
-    to an N-position (non-zero nimSum). -/
+    to an N-position (non-zero nimSum).
+
+    Une autre stratégie concrète : la position [1, 2, 3] a une nimSum de 0
+    (P-position), ce qui signifie que le SECOND joueur gagne. Tout coup du premier
+    joueur mène à une N-position (nim-somme non nulle). -/
 theorem losing_position_123 : nimSum [1, 2, 3] = 0 := by
   native_decide
 
 /-- After the first player's move from [1, 2, 3], every resulting position
-    has non-zero nimSum (N-position). -/
+    has non-zero nimSum (N-position).
+
+    Après le coup du premier joueur depuis [1, 2, 3], toute position résultante
+    a une nim-somme non nulle (N-position). -/
 theorem all_moves_from_123_winning :
     nimSum [0, 2, 3] ≠ 0 ∧ nimSum [1, 1, 3] ≠ 0 ∧ nimSum [1, 0, 3] ≠ 0 ∧
     nimSum [1, 2, 2] ≠ 0 ∧ nimSum [1, 2, 0] ≠ 0 := by
@@ -123,11 +189,21 @@ theorem all_moves_from_123_winning :
     strategy: it relies on the fact that for the most significant bit of `s`,
     at least one heap has that bit set, making `a ^^^ s < a` true.
 
-    We verify this on concrete instances: -/
+    We verify this on concrete instances:
+
+    Si `a ^^^ s < a` où `s = nimSum heaps`, alors réduire le tas `a` à
+    `a ^^^ s` annule la nim-somme. C'est la **propriété clé** de la stratégie
+    gagnante : elle repose sur le fait que pour le bit le plus significatif de `s`,
+    au moins un tas a ce bit positionné, rendant `a ^^^ s < a` vrai.
+
+    Nous vérifions cela sur des instances concrètes : -/
 theorem xor_reduce_3_1 : 3 ^^^ 1 = 2 ∧ 2 < 3 := by native_decide
 
 /-- For [3, 5, 7]: the full strategy verification.
-    nimSum = 1. Reducing heap 0 (size 3) to 3 ^^^ 1 = 2 zeros the sum. -/
+    nimSum = 1. Reducing heap 0 (size 3) to 3 ^^^ 1 = 2 zeros the sum.
+
+    Pour [3, 5, 7] : la vérification complète de la stratégie.
+    nimSum = 1. Réduire le tas 0 (taille 3) à 3 ^^^ 1 = 2 annule la somme. -/
 theorem winning_move_verified_357 :
     let s := nimSum [3, 5, 7]
     s = 1 ∧


### PR DESCRIPTION
## Contexte

`conway_lean/Conway/Nim.lean` = track de calibration Conway (Nim / Sprague-Grundy, target harness Epic #1453). Module prose-heavy (commentaires pédagogiques sur Bouton 1901, Sprague-Grundy, Conway 1976) avec preuves courtes (0 sorry). Suit la convention i18n établie sur conway_lean (Doomsday/Fractran/LookAndSay/MathlibMap = « bilingual FR+EN inline extension »). Honore le mandat FR-first (#1650) + EPIC i18n Lean #4980.

## Changement

Extension bilingue inline : traduction FR ajoutée **paragraphe par paragraphe** dans chaque bloc commentaire existant, **anglais préservé verbatim**. Zéro code Lean touché.

## Vérifications (lean-merge-discipline)

| Vérif | Résultat |
|-------|----------|
| Code lines (block-comment-depth-aware extraction) | **48/48 IDENTIQUES** base↔fixed |
| Code (ws-normalized, comments stripped) | **IDENTICAL** (re-confirm) |
| Code `theorem` count | **15 = 15** |
| Code `native_decide` count | **8 = 8** |
| Comment delimiters `/-`/`-/` balanced | **19/19 = 19/19** |
| `sorry` count | **0 → 0** |
| CRLF | **0** |
| Catalogue churn | **0** (byte-identique à main) |
| Scope | **1 fichier** (+214/−138, Write full-file replace; net = FR text ajouté) |

**Note build local honnête (G.1)** : `lake build Conway.Nim` lancé en local (WSL elan 4.31.0-rc1, proofwidgets dep réparé), mais le **cold build Mathlib en worktree frais** (~72 oleans en 12 min sur les ~1500+ de Mathlib) dépasse la fenêtre du cycle worker. Pour un changement **comment-only**, la **preuve d'identité du code (48 lignes byte-identiques + délimiteurs équilibrés 19/19) est l'équivalent-build** : les commentaires sont strippés avant l'élaboration Lean, donc la structure de code élaborée est prouvée identique. **CI backstop** sur la PR confirmera le build complet.

Le `native_decide` total count diff (10→12) est du **texte commentaire FR** préservant le nom de la tactique (2 en code-commentaire EN base → 4 avec les traductions FR), PAS du code (code native_decide = 8 = 8).

## Portée

`MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Nim.lean` ONLY. `See #4980`, `See #1650`. Atomique (1 fichier, convention établie conway_lean).

Part of #4980, #1650, #1453