### PR TITLE
docs(lean,#3978): sync SymbolicAI/Lean README cross-series table — absorption #6058 + resolved proofs

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -438,11 +438,11 @@ Les notebooks GameTheory side tracks (16b-16f) formalisent en Lean 4 des résult
 
 | résultat | Fichier Lean | Notebook GameTheory | Statut |
 |----------|-------------|---------------------|--------|
-| théorème d'Arrow (impossibilité) | `social_choice_lean/SocialChoice/Arrow.lean` | 16d | 0 sorry (Geanakoplos 2005) |
-| théorème de Sen (libéralisme) | `social_choice_lean/SocialChoice/Sen.lean` | 16e | 0 sorry (bidirectionnel) |
-| Valeur de Shapley | `cooperative_games_lean/CooperativeGames/Shapley.lean` | 16b | 1 sorry (en cours) |
-| Modèles de vote (Banks, STV) | `social_choice_lean/SocialChoice/Voting.lean` | 16f | 4 sorry (open problems) |
-| Gale-Shapley (stable marriage) | `game_theory_lean/StableMarriage/GaleShapley.lean` | (pas de notebook dédié) | 2 sorry / 5 théorèmes. `gale_shapley_stable` CLOSED via mmaaz upstream (PR #1181). `man_optimal` + `woman_pessimal` OPEN (Knuth 1976 lattice, Wu-Roth 2018 — ~5-8j Mathlib). |
+| théorème d'Arrow (impossibilité) | `game_theory_lean/SocialChoice/Arrow.lean` | 16d | 0 sorry (Geanakoplos 2005) |
+| théorème de Sen (libéralisme) | `game_theory_lean/SocialChoice/Sen.lean` | 16e | 0 sorry (bidirectionnel) |
+| Valeur de Shapley | `cooperative_games_lean/CooperativeGames/Shapley.lean` | 16b | 0 sorry (caractérisation + unicité ; Banzhaf #4011/#4037/#4130) |
+| Modèles de vote (Banks, STV) | `game_theory_lean/SocialChoice/Voting.lean` | 16f | 0 sorry |
+| Gale-Shapley (stable marriage) | `game_theory_lean/StableMarriage/GaleShapley.lean` | (pas de notebook dédié) | 0 sorry. `gale_shapley_stable`, `gale_shapley_man_optimal` (via `exists_isManOptimal`, `Lattice.lean`) et `gale_shapley_woman_pessimal` prouvés. |
 
 Le notebook Lean-5 (tactiques) et Lean-6 (Mathlib) sont des prérequis directs pour les side tracks Lean de GameTheory.
 
@@ -528,7 +528,7 @@ Lean 4 signale `type mismatch` quand le type attendu et le type fourni ne coïnc
 **Non** dans les cellules d'exercice (stub pour l'étudiant). **Oui** dans le code de production (preuves formelles). La convention CoursIA :
 
 - Cellules d'exercice : `sorry` = placeholder étudiant, normal et attendu.
-- Preuves certifiées (ex: `conway_lean/`, `grothendieck_lean/`, `social_choice_lean/`) : `sorry` = axiome implicite = trou dans la chaîne de certification. Le compteur `grep -c sorry` est suivi par les agents du dépôt.
+- Preuves certifiées (ex: `conway_lean/`, `grothendieck_lean/`, `game_theory_lean/`) : `sorry` = axiome implicite = trou dans la chaîne de certification. Le compteur `grep -c sorry` est suivi par les agents du dépôt.
 
 Voir [LEAN_INVENTORY.md](../../GameTheory/LEAN_INVENTORY.md) pour l'état détaillé des preuves par module.
 


### PR DESCRIPTION
## Summary

Reconcile the Lean cross-series table (lines 441-445) + FAQ example (line 531) in [`SymbolicAI/Lean/README.md`](MyIA.AI.Notebooks/SymbolicAI/Lean/README.md) with the **current verified formal state**. This is leaf **#3978** (Owner: po-2026:CoursIA) of the **#3973** leaf-README rollout: « notebooks/READMEs <- preuves : retirer les « WIP/admis » résolus, décrire l'état formel réel ».

6 cellules corrigées dans 1 fichier, audit fichier-entier (§E).

## Changes (verified firsthand)

| Ligne | Avant (STALE) | Après (verified) | Preuve |
|-------|---------------|------------------|--------|
| 441 Arrow path | `social_choice_lean/SocialChoice/Arrow.lean` | `game_theory_lean/SocialChoice/Arrow.lean` | absorption #6058 merged ; ancien dir `social_choice_lean/SocialChoice/` **n'existe plus** (path cassé). Count 0 sorry inchangé. |
| 442 Sen path | `social_choice_lean/SocialChoice/Sen.lean` | `game_theory_lean/SocialChoice/Sen.lean` | idem absorption. Count 0 sorry inchangé. |
| 443 Shapley | `1 sorry (en cours)` | `0 sorry (caractérisation + unicité ; Banzhaf #4011/#4037/#4130)` | strip-scan `Shapley.lean` = 0 real sorry ; corroboré par `LEAN_INVENTORY.md` L68 (`CooperativeGames/Shapley.lean | 0 | ...`). |
| 444 Voting | `social_choice_lean/SocialChoice/Voting.lean` + `4 sorry (open problems)` | `game_theory_lean/SocialChoice/Voting.lean` + `0 sorry` | absorption + strip-scan `Voting.lean` = 0 real sorry. |
| 445 Gale-Shapley | `2 sorry / 5 théorèmes. man_optimal + woman_pessimal OPEN (~5-8j Mathlib)` | `0 sorry. gale_shapley_stable, gale_shapley_man_optimal (via exists_isManOptimal, Lattice.lean), gale_shapley_woman_pessimal prouvés` | `GaleShapley.lean` = 0 sorry ; `Lattice.lean` = 0 **real** sorry (3 tokens sorry sont en docstrings/commentaires, strip-scan confirme) ; `exists_isManOptimal` (L841) a une vraie preuve well-founded (`classical; let W...; let P...; have hP...`), pas sorry. `LEAN_INVENTORY.md` L40 confirme `StableMarriage/GaleShapley.lean | 0 | ... man_optimal (via exists_isManOptimal), woman_pessimal`. |
| 531 FAQ example | `social_choice_lean/` | `game_theory_lean/` | `social_choice_lean/` n'a plus de modules `.lean` (absorbé) ; citation comme exemple de « preuves certifiées » désormais trompeuse. |

## §E whole-file audit (preuve)

- **Comptage des fichiers** : le file-tree (lignes ~350-367) liste `sensitivity_lean/`, `finiteness_lean/`, `conway_lean/`, `grothendieck_lean/`, `calibration_lean/`, `mathlib_examples/` — tous marqués « 0 sorry » et **vérifiés à jour** (rien à corriger).
- **Réconciliation disque ↔ prose** :
  - `ls game_theory_lean/SocialChoice/` → Arrow, Sen, Voting (+ twins `_en`) existent ✓
  - `ls social_choice_lean/SocialChoice/` → **n'existe plus** (chemins cassés dans la table) ✓ corrigé
  - strip-scan `*.lean` (méthode : strip docstrings `/-...-/` + commentaires `--`, puis pattern `:= by sorry|:= sorry|exact sorry|^\s*sorry`) :
    - `Shapley.lean` = 0, `GaleShapley.lean` = 0, `Lattice.lean` = 0 real (3 prose), `GSState.lean` = 0
    - `Arrow.lean` = 0, `Sen.lean` = 0, `Voting.lean` = 0
  - `LEAN_INVENTORY.md` L40 + L68 + L234 corroborent (StableMarriage 0 sorry man_optimal via exists_isManOptimal ; Shapley 0 sorry ; cooperative_games COMPLETE 0 sorry).
- **Autres mentions `sorry` dans le fichier** (lignes 95, 110, 113-115, 122, 128, 142-147, 350, 361-367, 403-412, 463, 466, 526-564) : **toutes exactes** (claims 0-sorry pour sensitivity/conway/grothendieck/calibration/mathlib_examples/search — vérifiés vrais). Ligne 466 Reidemeister « 2 sorry » = token-count définitionnellement cohérent (non touché — pas un drift propre).

## Notes / résiduel

- **Ligne 444 Voting** : path + count corrigés. La PR n'altère **pas** la structure lake (absorption #6058 déjà merged) — **n'entre pas en conflit** avec #6146 (qui touche RepeatedGames, pas SocialChoice).
- **CATALOG-STATUS** : inchangé (catalogue byte-identique à main, cf [catalog-pr-hygiene](.claude/rules/catalog-pr-hygiene.md)).
- **Convention FR-first** respectée (§E, [readme-french-first](.claude/rules/readme-french-first.md)).

See #3973
See #3978
