### PR TITLE
feat(lean,#3846): gridFrameN_le_two_eq_gridFrame reduction bridge (N3-prep, sorry-free)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -688,6 +688,39 @@ theorem gridFrameN_contains_g (n : Nat) (g : Grid) (p : Int × Int) (hp : p ∈ 
     unfold MacroCell.inRegion
     refine ⟨?_, ?_, ?_, ?_⟩ <;> omega
 
+/-- `gridFrameN n g` reduces to `gridFrame g` when `n ≤ 2`: the n-aware padding
+    `max 2 n` equals the fixed padding `2`, so both frames coincide. This is the
+    reduction bridge showing `gridFrameN` strictly generalizes `gridFrame` — it
+    lets existing `gridFrame`-based results transfer to the n-aware frame for
+    small `n` (N3 threading, issue #3846). -/
+theorem gridFrameN_le_two_eq_gridFrame (n : Nat) (g : Grid) (hn : n ≤ 2) :
+    gridFrameN n g = gridFrame g := by
+  have hpad : max 2 n = 2 := by omega
+  cases g with
+  | nil => rfl
+  | cons p₀ ps =>
+    -- Establish non-negativity of the row/col spans directly (no `set` aliases,
+    -- so `omega` connects these facts to the goal terms `gridRowMin _` etc.).
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
+      gridColMin_le_gridColMax _ (List.cons_ne_nil _ _)
+    simp only [gridFrameN, gridFrame, hpad, Nat.cast_two]
+    -- Both frames now have padding 2; the only residual difference is
+    -- `+ 1 + 2*2` (gridFrameN) vs `+ 5` (gridFrame) in the height/width, a
+    -- pure Int arithmetic identity. The offset pair `(r0, c0)` matches by `rfl`.
+    -- Close the offset pair `(r0, c0)` by `Prod.ext` + `rfl` (no `congr` on the
+    -- subtraction, which would over-decompose). The level equality reduces to
+    -- the height/width `toNat` identities `(x + 1 + 2*2).toNat = (x + 5).toNat`,
+    -- which `omega` closes using the non-negativity facts above.
+    refine Prod.ext ?_ ?_
+    · rfl
+    · have hH : (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 1 + 2 * 2).toNat
+                  = (gridRowMax (p₀ :: ps) - gridRowMin (p₀ :: ps) + 5).toNat := by omega
+      have hW : (gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 1 + 2 * 2).toNat
+                  = (gridColMax (p₀ :: ps) - gridColMin (p₀ :: ps) + 5).toNat := by omega
+      rw [hH, hW]
+
 /-- Convert a `Grid` to a `MacroCell`, returning the chosen offset so that
     `MacroCell.toGrid offset (gridToMacroCell g) = g`. -/
 def gridToMacroCellWithOffset (g : Grid) : (Int × Int) × MacroCell :=


### PR DESCRIPTION
## Summary

Add a **sorry-free** reduction bridge `gridFrameN_le_two_eq_gridFrame` to [`Conway/Life/MacroCell.lean`](MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean): `gridFrameN n g = gridFrame g` when `n ≤ 2`. This is the additive, sorry-free first grain toward **N3 threading** (EPIC #3846, Hashlife correctness P5 redesign).

33 insertions in 1 file. No existing proof touched.

## Why (N3-prep grain)

N3 threading needs to reason about the n-aware `gridFrameN` inside the `evolveHashlifeFast` loop, toward closing the named sorry `p5_large_n_jumpN` ([HashlifeCorrectness.lean](MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean), P4-gated ∀n non-vacuous). This bridge proves `gridFrameN` strictly generalizes `gridFrame` — the n-aware padding `max 2 n` collapses to the fixed padding `2` for small `n`, so existing `gridFrame`-based results (`box_assez_grand` etc.) transfer to the n-aware frame.

## Verification (firsthand, §B Lean PR body)

| Check | Result |
|-------|--------|
| `lake build Conway.Life.MacroCell` | **SUCCESS** (11s, cached Mathlib `.lake`, 2947 jobs, `C:/Users/jsboi/.elan/bin/lake.exe` native, toolchain `leanprover/lean4:v4.31.0-rc1`) |
| `grep -c sorry` MacroCell.lean (strip-docstrings method) | **0 → 0** (additive lemma, no new sorries) |
| Diff | **+33 / −0** (purely additive, no existing code modified) |
| Catalogue | byte-identique à `main` (no churn — `git checkout origin/main -- COURSE_CATALOG.*` not needed, branch untouched catalog) |

### Build log tail (proof of compile)

```
⚠ [2947/2947] Built Conway.Life.MacroCell (11s)
Build completed successfully (2947 jobs)
```

(The two `unusedSimpArgs` linter warnings at L311/L314 are **pre-existing**, not from this change.)

## Proof sketch

```lean
theorem gridFrameN_le_two_eq_gridFrame (n : Nat) (g : Grid) (hn : n ≤ 2) :
    gridFrameN n g = gridFrame g := by
  have hpad : max 2 n = 2 := by omega
  cases g with
  | nil => rfl
  | cons p₀ ps =>
    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
      gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
    have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
      gridColMin_le_gridColMax _ (List.cons_ne_nil _ _)
    simp only [gridFrameN, gridFrame, hpad, Nat.cast_two]
    refine Prod.ext ?_ ?_
    · rfl
    · have hH : ... + 1 + 2 * 2).toNat = ... + 5).toNat := by omega
      have hW : ... := by omega
      rw [hH, hW]
```

- `hpad : max 2 n = 2` — omega from `hn`.
- `simp only [gridFrameN, gridFrame, hpad, Nat.cast_two]` — unfolds both frames, normalizes the `↑2` Nat-cast to `(2 : Int)`.
- `Prod.ext` — splits the offset pair `(r0, c0)` (closed by `rfl`, defeq on `↑2 = (2:Int)`) from the level field.
- Level reduces to two `toNat` arithmetic identities `(x + 1 + 2*2).toNat = (x + 5).toNat`, closed by `omega` from `gridRowMin_le_gridRowMax` / `gridColMin_le_gridColMax`.

The `Nat.cast_two` simp lemma was the key fix: the goal retains `↑2` (Nat→Int cast) while the `have` elaborates `(↑2 : ℤ)` to `(2:Int)`, so `rw` pattern-matching fails without normalizing the cast first.

## Notes / résiduel

- This PR is **additive and sorry-free**: it adds infrastructure (the reduction bridge), it does **not** close any sorry. The actual N3-threading work (closing `p5_large_n_jumpN` via `gridFrameN` in the `evolveHashlifeFast` loop) remains multi-cycle research — this PR is the bounded grain that unblocks it.
- Does **not** alter lake structure or touch `HashlifeCorrectness.lean` (where the sorries live). No conflict with concurrent Lean PRs.
- **CATALOG-STATUS**: unchanged (catalogue byte-identique à main, cf [catalog-pr-hygiene](.claude/rules/catalog-pr-hygiene.md)).

See #3846
