### PR TITLE
ci(grothendieck_lean): switch sorry-counter to real mode (baseline 0) [unblocks #6208/#6202/#6197]

### DIFF
--- a/.github/workflows/lean-grothendieck.yml
+++ b/.github/workflows/lean-grothendieck.yml
@@ -7,12 +7,21 @@ name: Lean Grothendieck CI
 # Migrated to the reusable lean-build.yml per ai-01 DRY decision (option 2: matrix).
 # Behavior is identical to the former inline check-sorry + build jobs.
 #
-# Sorry profile (verified 2026-06-10, prose-header mode, baseline=0): every
-# Grothendieck module carries the boilerplate header comment "All `sorry`s
-# eliminated at creation". The raw count therefore equals the number of .lean
-# files (one header each) and is NOT a real sorry. prose-header mode filters
-# out the prose forms (`sorries`, `sorry's`) so the count reflects only
-# sorry-as-tactic. Known false-positive pattern documented in MEMORY.
+# Sorry profile (switched 2026-07-12 to `real` mode, baseline=0; was prose-header/0):
+# every Grothendieck module carries the bilingual boilerplate header "All `sorry`s
+# eliminated at creation" / "Tous les `sorry`s éliminés à la création" (i18n #4980).
+# prose-header mode filtered the possessive (`sorry's`) but still counted 3 mentions
+# on main (the bare-word prose "sorry" in roadmap/index comments), and any bilingual
+# docstring PR adding a legitimate prose "sorry" tripped the counter — #6208/#6202/#6197
+# (SheafBasics/MathlibMap/Yoneda i18n, 0 new tactic sorry) all FAILED "count (3) >
+# baseline (0)". Per lean-build.yml's guidance ("Use `real` when docstring prose
+# legitimately says 'sorry' so comment edits do not flip the raw count"), switch to
+# `real` mode: strip Lean comments (-- line + nested /- -/ block) then count
+# word-bounded `\bsorry\b`. Mirrors the prover harness `count_real_sorries`
+# (FX-6 #1453) — counts exactly compiled-tactic sorries, immune to docstring edits.
+# Real-mode baseline = 0 (firsthand counted 2026-07-12 with the exact CI awk on
+# origin/main across all 25 own .lean files: grothendieck_lean is FULLY PROVEN,
+# zero tactic `sorry`). Mirrors the knot_lean switch in #6186.
 
 on:
   push:
@@ -38,4 +47,4 @@ jobs:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
       display-name: grothendieck_lean
       sorry-baseline: "0"
-      sorry-filter-mode: prose-header
+      sorry-filter-mode: real


### PR DESCRIPTION
## Summary

Switch `grothendieck_lean` sorry-counter from `prose-header` to `real` mode (baseline stays `0`). Mirrors the `knot_lean` switch in #6186.

## Problem — 3 i18n PRs blocked by a prose false-positive

Every grothendieck module carries the bilingual boilerplate header `"All `sorry`'s eliminated at creation"` / `"Tous les `sorry`'s éliminés à la création"` (i18n #4980). Under `prose-header` mode the bare-word prose mentions still count (3 on main), so any bilingual docstring PR adding a legitimate prose `sorry` trips the counter:

| PR | lake file | CI failure | real tactic sorry added |
|----|-----------|-----------|------------------------|
| #6208 | SheafBasics.lean | `FAIL: sorry count (3) exceeds baseline (0)` | **0** (docstring only) |
| #6202 | MathlibMap.lean | `FAIL: sorry count (3) exceeds baseline (0)` | **0** (docstring only) |
| #6197 | Yoneda.lean | `FAIL: sorry count (3) exceeds baseline (0)` | **0** (docstring only) |

Verified firsthand (`git show origin/feature/...:<file> | grep -nE "sorry"`): every `sorry` occurrence is purely inside `/- ... -/` **docstring comment blocks** (the `Epic #1646 ... All sorry's eliminated` header + its FR translation). Zero actual `sorry` tactics.

## Fix

Per `lean-build.yml` guidance (*"Use `real` when docstring prose legitimately says sorry so comment edits do not flip the raw count"*), switch to `real` mode: strip Lean comments (`--` line + nested `/- -/` block) then count word-bounded `\bsorry\b`. Mirrors the prover harness `count_real_sorries` (FX-6 #1453). Immune to docstring edits.

## Real-mode baseline = 0 (firsthand counted)

Counted 2026-07-12 with the **exact CI awk** on `origin/main` across all 25 own `.lean` files of `grothendieck_lean` (excluding `.lake/`): **real tactic `sorry` total = 0**. The lake is fully proven. Baseline stays `0`.

```
REAL SORRY TOTAL = 0   (vs prose-header total = 3 on main, vs baseline 0)
```

## Scope

One-file change (`.github/workflows/lean-grothendieck.yml`): mode param + profile comment. Conway/conway_cgt lakes are **out of scope** — their failures (#6218 real build error, #6116 mathlib cache fetch) are different problems, separate PRs.

See #3801 (SOTA/prover registry), #4980 (Lean i18n epic), #6186 (knot_lean precedent).

Reassessed by po-2023: CONFIRMED prose false-positive (3 docstring PRs, 0 real sorry).