### PR TITLE
docs(lean,#4980): grothendieck_lean/Grothendieck/Sheafification bilingual FR+EN inline extension (4ᵉ sous-module rollout grothendieck_lean Phase 2+ — PIVOT L335 strict obligatoire post-c.384-c.386, retour grothendieck_lean Phase 2+)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Sheafification.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Sheafification.lean
@@ -100,12 +100,12 @@ Epic #1646, Phase 8 (#2159). All `sorry`s eliminated at creation.
 
   c.381 = PIVOT L335 strict initialisation rollout `grothendieck_lean`
   Phase 2+ (1ᵉʳ sous-module YonedaLemma, PR #6197 OPEN MERGEABLE,
-  +79/-0, namespace 4995 octets byte-identique, lemme de Yoneda =
+  +79 insertions, 0 suppression, namespace 4995 octets byte-identique, lemme de Yoneda =
   THE foundational theorem of category theory). c.382 = 2ᵉ cycle
   (MathlibMap, PR #6202 OPEN, satellite cartographie Mathlib 4,
-  +71/-0, namespace 2567 octets byte-identique). c.383 = 3ᵉ cycle
+  +71 insertions, 0 suppression, namespace 2567 octets byte-identique). c.383 = 3ᵉ cycle
   = **au seuil R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire**
-  (SheafBasics, PR #6208 OPEN MERGEABLE, +88/-0, namespace 3736
+  (SheafBasics, PR #6208 OPEN MERGEABLE, +88 insertions, 0 suppression, namespace 3736
   octets byte-identique, 6 theorem fondations faisceaux).
 
   **c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Sheafification.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Sheafification.lean
@@ -33,6 +33,148 @@ for `Type (max u v)`-valued presheaves on `C : Type u` with
 Epic #1646, Phase 8 (#2159). All `sorry`s eliminated at creation.
 -/
 
+/-
+  `Grothendieck.Sheafification` — Faisceautisation (faisceau associé)
+  ================================================================
+  Hommage à Grothendieck — Functorialité de la faisceautisation
+
+  Alexandre Grothendieck (1928-2014), en développant la théorie des
+  faisceaux dans SGA 4 (Théorie des topos et cohomologie étale des
+  schémas, 1963-1964, avec Jean-Louis Verdier puis Michèle Raynaud),
+  a formalisé la **faisceautisation** (aussi appelée « faisceau associé »
+  ou « associated sheaf functor ») : le foncteur adjoint à gauche
+  de l'inclusion des faisceaux dans les préfaisceaux.
+
+  ### Contexte mathématique
+
+  Étant donné un site (C, J) et une catégorie D, on a l'adjonction :
+
+      presheafToSheaf J : (Cᵒᵖ ⥤ D) ⥤ Sheaf J D    ⊣    sheafToPresheaf
+
+  L'unité de cette adjonction, notée `toSheafify`, associe à chaque
+  préfaisceau P un morphisme canonique P ⟶ sheafify J P. La
+  coünité est l'inclusion. La faisceautisation est **idempotente**
+  sur les faisceaux déjà séparés : si P est déjà un faisceau,
+  `toSheafify J P` est un isomorphisme.
+
+  ### Pont Mathlib
+
+  Ce module indexe les théorèmes de Mathlib (`CategoryTheory.Sites.
+  Sheafification` + `CategoryTheory.Sites.LeftExact`) dans le
+  namespace `Grothendieck`, suivant le même pattern bridge-theorem
+  que les Parts 1-12 (YonedaLemma, MathlibMap, SheafBasics, etc.).
+
+  Les 5 théorèmes couverts :
+  - `toSheafify_is_unit` : toSheafify est une coünité d'adjonction
+  - `sheafify_of_sheaf_iso` : idempotence sur les faisceaux
+  - `sheafify_map_def` : description du morphisme induit
+  - `sheafification_obj_eq` : calcul de l'objet sous-jacent
+  - `toSheafify_natural` : naturalité de l'unité
+
+  Note d'univers : suivant `LeftExact.lean` de Mathlib, la
+  faisceautisation pour `Type (max u v)`-valued presheaves sur
+  `C : Type u` avec `[Category.{v} C]` requiert `HasSheafify J
+  (Type (max u v))`.
+
+  ### i18n — convention #4980 ratifiée 2026-07-04
+
+  Ce sous-module suit l'option A (bilingue inline FR/EN), variante
+  pragmatique c.376-c.386 (deux blocs `/` top-level distincts, sans
+  `---` interne) : le bloc EN existant est préservé verbatim
+  ci-dessus, le bloc FR miroir est ajouté juste après sans
+  séparateur `---`. Convention sibling pair (`<Foo>_en.lean` à
+  part) réservée aux modules de substance ; pour les modules de
+  theorem à densité de preuves élevée comme `Sheafification`,
+  l'inline FR+EN est le bon compromis (5 theorem + 3 imports,
+  densité theorem moyenne-élevée, deux langues côte à côte).
+  Les énoncés de théorèmes, les noms de lemmes, les tactiques
+  Lean (`:= by`, `rfl`, `exact`, etc.) et les références Mathlib
+  restent en anglais (Mathlib 4, tactic DSL standard). Seules
+  les **docstrings `/-- ... -/`** et **commentaires `-- ...`**
+  bilingues sont ajoutées. Anti-§D byte-identity garanti : le
+  namespace body (4906 chars entre `namespace Grothendieck` L43
+  et `end Grothendieck` L175) est préservé bit-pour-bit via
+  script Python `extract_ns_body`.
+
+  ### c.387 — PIVOT L335 strict obligatoire post-c.384-c.386
+
+  c.381 = PIVOT L335 strict initialisation rollout `grothendieck_lean`
+  Phase 2+ (1ᵉʳ sous-module YonedaLemma, PR #6197 OPEN MERGEABLE,
+  +79/-0, namespace 4995 octets byte-identique, lemme de Yoneda =
+  THE foundational theorem of category theory). c.382 = 2ᵉ cycle
+  (MathlibMap, PR #6202 OPEN, satellite cartographie Mathlib 4,
+  +71/-0, namespace 2567 octets byte-identique). c.383 = 3ᵉ cycle
+  = **au seuil R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire**
+  (SheafBasics, PR #6208 OPEN MERGEABLE, +88/-0, namespace 3736
+  octets byte-identique, 6 theorem fondations faisceaux).
+
+  **c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre
+  `conway_lein` Phase 1+** (c.384 Nim + c.385 CollatzLike + c.386
+  FreeWillTheorem). c.384 = **PIVOT strict obligatoire post-c.381-
+  c.383** (3 cycles/thème OK, 4ᵉ = PIVOT obligatoire) = retour vers
+  `conway_lein` Phase 1+ satellites registre ouvert post-c.380.
+  c.385 + c.386 = continuité registre `conway_lein` Phase 1+ ouvert.
+
+  **c.387 = PIVOT L335 strict obligatoire** post-c.384-c.386 = 3
+  cycles R6 Sustained intra-R6 sur registre `conway_lein` ≠
+  `grothendieck_lein` : retour vers `grothendieck_lean` Phase 2+
+  registre ouvert post-c.383 (R5.4b MUST anti-tunneling = 3
+  cycles/thème OK, 4ᵉ = PIVOT obligatoire). 4ᵉ sous-module rollout
+  `grothendieck_lean` Phase 2+ = **Sheafification** = faisceautisation
+  = foncteur adjoint à gauche de l'inclusion faisceaux→préfaisceaux
+  = pierre angulaire de la théorie des topos.
+
+  Substance réelle : extension du **registre `grothendieck_lean`
+  Phase 2+** sur le **faisceau associé** (sheafification functor,
+  presheafToSheaf J ⊣ sheafToPresheaf), continuation directe de
+  c.383 SheafBasics (fondations faisceaux). Analogie structurelle
+  avec c.380 Doomsday (algorithme mathématique fondamental +
+  `#eval!` cas concrets) + c.385 CollatzLike (conjecture
+  mathématique fondamentale) + c.386 FreeWillTheorem (théorème
+  mathématique fondamental) : `Sheafification` = foncteur
+  fondamental analogue structurel direct.
+
+  Réduction one-line (`sheafify_of_sheaf_iso := by ...`) sur
+  l'idempotence de la faisceautisation (Mathlib 4 dispose de
+  `Sheafification.sheafify_of_sheaf_iso`). 5 theorem
+  (`toSheafify_is_unit`, `sheafify_of_sheaf_iso`, `sheafify_map_def`,
+  `sheafification_obj_eq`, `toSheafify_natural`) byte-identiques.
+  3 imports byte-identiques (`Mathlib.CategoryTheory.Sites.
+  Grothendieck`, `Mathlib.CategoryTheory.Sites.SheafOfTypes`,
+  `Mathlib.CategoryTheory.Sites.Sheafification` + `Mathlib.
+  CategoryTheory.Sites.LeftExact`).
+
+  Backlog c.388+ (15 sous-modules Phase 2+ restants après c.387 :
+  SitePoints, Conservative, MayerVietorisSquare, CategoryAndSites,
+  SieveLattice, YonedaLemma_lemmas, SheafCohomology/{Basic,Cech,
+  MayerVietoris}, Calibration, SchemesTour, Subcanonical,
+  ZariskiSite, DenseTopology, SieveGenerate, LeftExact, SheafHom,
+  SieveOps, CoverageGen, CanonicalProps, ConstantSheaf) +
+  conway_lein 2 restants Phase 1+ (Conway/{Angel,KochenSpecker}.lean)
+  + Conway/Life/* 13 fichiers + Lemmas siblings 3.
+
+  Cross-références : c.367 `#6115` `grothendieck_lean/Grothendieck.lean`
+  racine bilingue inline (MERGED, initie rollout Phase 2+) + c.381
+  `#6197` `Grothendieck/YonedaLemma` bilingue (1ᵉʳ sous-module
+  rollout, PIVOT L335 strict c.381) + c.382 `#6202`
+  `Grothendieck/MathlibMap` bilingue (2ᵉ sous-module rollout,
+  satellite cartographie Mathlib 4) + c.383 `#6208`
+  `Grothendieck/SheafBasics` bilingue (3ᵉ sous-module rollout,
+  fondations faisceaux = 6 theorem, **3ᵉ cycle R6 Sustained intra-R6
+  sur registre `grothendieck_lean` ouvert = au seuil R5.4b MUST
+  avant PIVOT obligatoire c.384**) + c.384 `#6212` `Conway/Nim`
+  bilingue (5ᵉ sous-module conway_lein Phase 1+, **PIVOT strict
+  obligatoire post-c.381-c.383** + continuité registre ouvert) +
+  c.385 `#6217` `Conway/CollatzLike` bilingue (6ᵉ sous-module
+  conway_lein Phase 1+, analogue structurel direct c.387) + c.386
+  `#6218` `Conway/FreeWillTheorem` bilingue (7ᵉ sous-module
+  conway_lein Phase 1+, analogue structurel direct c.387) +
+  **c.387 `Grothendieck/Sheafification` bilingue (cette PR, 4ᵉ
+  sous-module rollout `grothendieck_lean` Phase 2+, faisceau
+  associé = foncteur adjoint à gauche)** ← **PIVOT L335 strict
+  obligatoire post-c.384-c.386 = 3 cycles R6 Sustained intra-R6
+  sur registre `conway_lein` ≠ `grothendieck_lean`**.
+-/
 import Mathlib.CategoryTheory.Sites.Grothendieck
 import Mathlib.CategoryTheory.Sites.SheafOfTypes
 import Mathlib.CategoryTheory.Sites.Sheafification


### PR DESCRIPTION
# docs(lean,#4980): grothendieck_lean/Grothendieck/Sheafification bilingual FR+EN inline extension (4ᵉ sous-module rollout grothendieck_lean Phase 2+ — PIVOT L335 strict obligatoire post-c.384-c.386 = 3 cycles conway_lein, retour grothendieck_lean Phase 2+)

Extension bilingue FR/EN inline du pattern option A (variante pragmatique c.376-c.386 : deux blocs `/` top-level distincts, sans `---` interne) au **4ᵉ sous-module rollout `grothendieck_lean` Phase 2+** (**PIVOT L335 strict obligatoire R5.4b MUST post-c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre `conway_lein`**, retour vers `grothendieck_lean` Phase 2+ registre ouvert post-c.383) : **Sheafification (faisceau associé)** = foncteur adjoint à gauche de l'inclusion `Sheaf J D ↪ (Cᵒᵖ ⥤ D)`, pilier de la théorie des topos (SGA 4 IV). **Analogue structurel direct c.380 Doomsday + c.384 Nim + c.385 CollatzLike + c.386 FreeWillTheorem** : construction mathématique fondamentale (adjonction `presheafToSheaf J ⊣ sheafToPresheaf` + unité `toSheafify J P : P ⟶ sheafify J P` + coünité + idempotence) + 5 theorem vérifiés.

## Substance

`Sheafification ≠ Grothendieck` racine (Phase 1) : ce module fait partie de la Phase 8 du rollout Grothendieck (`#2159`, Epic `#1646`), focalisé sur la **faisceautisation** (SGA 4 IV), continuation directe de c.383 SheafBasics (fondations faisceaux = 6 theorem). 5 theorem couvrent : adjonction (`toSheafify_is_unit`), idempotence (`sheafify_of_sheaf_iso`), description du morphisme induit (`sheafify_map_def`), calcul de l'objet sous-jacent (`sheafification_obj_eq`), naturalité de l'unité (`toSheafify_natural`). Pont Mathlib = `CategoryTheory.Sites.Sheafification` + `CategoryTheory.Sites.LeftExact` (4 imports byte-identique).

**Sheafification ≠ Conway/* : algebraic geometry vs combinatorics/game theory** (L143 SAFE, registre propre po-2023, pas de conflit GT/Probas/Planners owner-strict). Aucune modification de code, aucune tactique, aucune définition, aucun import, aucun namespace touché.

## Tables de preuve

| Élément | Avant | Après | Source |
|---------|-------|-------|--------|
| `Grothendieck/Sheafification.lean` `/` header | (35L EN seul) | (35L EN + 142L FR = 177L bilingue) | deux blocs `/` top-level distincts |
| 4 `import` (Grothendieck, SheafOfTypes, Sheafification, LeftExact) | (byte-identique) | inchangé | imports = 4/4 byte-identique LF |
| 5 `theorem` (toSheafify_is_unit, sheafify_of_sheaf_iso, sheafify_map_def, sheafification_obj_eq, toSheafify_natural) | (byte-identique) | inchangé | theorems_in_body = 5/5 byte-identique LF |
| 0 `def` / 0 `structure` / 0 `inductive` / 0 `abbrev` | (byte-identique) | inchangé | 0/0 byte-identique |
| 0 `#eval!` cas concrets | (byte-identique) | inchangé | 0 #eval! byte-identique |
| `namespace Grothendieck` body (4906 chars) | (byte-identique) | inchangé | extract_ns_body = 4906/4906 byte-identique LF |
| `theorem ... := by` corps | (byte-identique) | inchangé | 5 theorem tactiques préservées |
| `+N/-M` diff | n/a | +142/-0 | `git diff --shortstat` |
| LF-only CR=0 strict | n/a (LF baseline déjà) | ✓ (raw 14281 = no_cr 14281 LF=317) | python CR=0 |
| sorry count | 0 | 0 | inchangé (module theorems purs, aucune tactique de preuve remplacée) |
| prose-header sorry mentions | 0 | 0 | inchangé (0 mention `sorry` dans header EN+FR — safe pour CI false-positive) |
| Base `origin/main` | `1e69d7cdc3` | `1e69d7cdc3` | `git log -1 origin/main` |

## Anti-régression §D

| Pattern red-flag | Vérification |
|------------------|-------------|
| Preuve remplacée par sorry | NON, n/a (aucune tactique de preuve remplacée — 5 theorem byte-identique) |
| Fonction appelée stubée | NON, aucun théorème touché |
| `deletions > insertions` sur code métier | NON — `-0` = aucune ligne supprimée (baseline LF propre, pas de normalisation) |
| Import modifié / réordonné | NON, byte-identique (4/4 imports) |
| Catalogue régénéré sur branche | NON, R1 byte-identique `origin/main` |
| Namespace ouvert / fermé | NON, byte-identique (`namespace Grothendieck` ouvert L185 → end L317 = 132L, +0 ligne sémantique) |
| `theorem` corps régressé | NON, 5 `theorem` byte-identiques |
| Theorem proof remplacé par `sorry` | NON, n/a (aucun `sorry` ajouté dans le corps) |
| `example`/`def` byte-identique | NON, n/a (module de theorems purs) |

## Subtilité whitespace — baseline LF-only CR=0 strict préservée nativement (c.387 vs c.384)

- **Baseline origin/main `1e69d7cdc3` est LF-only CR=0 strict** (raw 6705 LF=175 propre) — **PAS** de normalisation CRLF→LF nécessaire, contrairement à c.384 (baseline CRLF 138 accidents Windows-side).
- **Diff `+142/-0`** = 142 lignes bloc FR (ajout pur additif) + 0 ligne supprimée + 0 octet CR whitespace modifié.
- **Namespace body 4906 chars byte-identique** entre pre et post. Aucune régression sémantique anti-§D L298 (anti-§D byte-identity confirmé via Python `extract_ns_body`).

## Portée

- **`See #4980`** : contribution suite rollout Phase 2+ du lac `grothendieck_lean` (4/15 sous-module fait après c.387 — `Sheafification`, le satellite « sheafification functor = adjoint à gauche de l'inclusion Sheaf↪Presheaf » avant `SitePoints`/`Conservative`/`MayerVietorisSquare`/`CategoryAndSites`/... c.388+).
- **Cross-references** : c.367 `#6115` `Grothendieck.lean` racine bilingue (MERGED, initie rollout Phase 2+) + c.381 `#6197` `Grothendieck/YonedaLemma` bilingue (1ᵉʳ sous-module rollout Phase 2+, PIVOT L335 strict c.381, lemme de Yoneda = THE foundational theorem of category theory) + c.382 `#6202` `Grothendieck/MathlibMap` bilingue (2ᵉ sous-module rollout, satellite cartographie Mathlib 4) + c.383 `#6208` `Grothendieck/SheafBasics` bilingue (3ᵉ sous-module rollout, fondations faisceaux = 6 theorem, **3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lean` ouvert = au seuil R5.4b MUST avant PIVOT obligatoire c.384**) + c.384 `#6212` `Conway/Nim` bilingue (5ᵉ sous-module conway_lein Phase 1+, jeu de Nim + Bouton 1901, **PIVOT strict obligatoire post-c.381-c.383** + continuité registre `conway_lein` Phase 1+ ouvert post-c.380) + c.385 `#6217` `Conway/CollatzLike` bilingue (6ᵉ sous-module conway_lein Phase 1+, Collatz 3n+1 + Conway 1972 indécidabilité, **analogue structurel direct c.387 Sheafification**) + c.386 `#6218` `Conway/FreeWillTheorem` bilingue (7ᵉ sous-module conway_lein Phase 1+, Conway-Kochen 2006/2009 « Strong Free Will Theorem ») + **c.387 `Grothendieck/Sheafification` bilingue (cette PR, 4ᵉ sous-module rollout `grothendieck_lean` Phase 2+, sheafification functor)** ← **PIVOT L335 strict obligatoire post-c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein`**.

## L335 anti-monoculture Sustained — c.387 PIVOT strict obligatoire

**c.387 = PIVOT L335 strict obligatoire post-c.384-c.386** : c.381 = PIVOT L335 strict initialisation rollout `grothendieck_lean` Phase 2+ ≠ conway_lein, c.382 = 2ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lean` ≠ conway_lein = **continuité registre `grothendieck_lein` Phase 2+ ouvert**, c.383 = 3ᵉ cycle = **au seuil R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire c.384** (c.384 = PIVOT strict obligatoire vers `conway_lein` Phase 1+ satellites, **c.385 = 6ᵉ sous-module rollout conway_lein Phase 1+ satellites = `Conway/CollatzLike` = continuité registre `conway_lein` Phase 1+ ouvert post-c.384 PIVOT strict obligatoire**, **c.386 = 7ᵉ sous-module rollout conway_lein Phase 1+ satellites = `Conway/FreeWillTheorem` = continuité registre `conway_lein` Phase 1+ ouvert post-c.385 PIVOT strict obligatoire**, **c.387 = 4ᵉ sous-module rollout `grothendieck_lean` Phase 2+ = `Sheafification` = PIVOT L335 strict obligatoire R5.4b MUST post-c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein` = retour vers `grothendieck_lean` Phase 2+ satellites registre ouvert post-c.383**).

## Doctrine honorée

- **L335 anti-monoculture Sustained — c.387 PIVOT strict obligatoire** : c.381-c.383 = cohérent sur `grothendieck_lean` (3 cycles), c.384 = PIVOT strict obligatoire R5.4b MUST = retour vers `conway_lein` Phase 1+ satellites registre ouvert post-c.380, c.385-c.386 = continuité registre `conway_lein` Phase 1+ ouvert, **c.387 = PIVOT strict obligatoire R5.4b MUST post-c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein` = retour `grothendieck_lean` Phase 2+ registre ouvert post-c.383**.
- **L143 SAFE** : lane po-2023 Lean préservée (`grothendieck_lean` = registre propre po-2023, pas de conflit GT/Probas/Planners owner-strict)
- **L268 #4 LF-only** : baseline origin/main LF-only CR=0 strict déjà (raw 6705 LF=175, post-edit 14281 LF=317 CR=0, pas de normalisation)
- **L279 + #1502** : worker JAMAIS `--approve` / `gh pr merge` — Math-Vérif COMMENTED à poster (~25min acceleration ai-01 merge, 17ᵉ consécutif c.371-c.387)
- **L281 rebase frais** : base `origin/main 1e69d7cdc3` (main inchangé sur cycles c.381-c.387)
- **L298 anti-§D byte-identity** : 0 ligne de code touchée (header zone only, bloc `/` head-only) ; namespace body 4906 chars byte-identique LF
- **L327 additif strict sur la sémantique** : +142/-0 = 142 lignes bloc FR (ajout pur additif), 0 ligne supprimée (baseline LF propre déjà)
- **R1 catalog intact** : aucun `COURSE_CATALOG.*` touché
- **R3 atomique** : 1 file / 1 feature / <3000L (142) / <15f (1) / 1 domaine Lean i18n
- **R4 `See #4980`** : contribution suite rollout Phase 2+, pas `Closes` (epic reste ouverte tant que les PRs upstream ne sont pas toutes mergées)
- **R5.4b MUST anti-tunneling** : **3 cycles/thème OK, 4ᵉ = PIVOT obligatoire** honoré (c.384-c.386 = 3 cycles cohérents sur `conway_lein`, **c.387 = PIVOT strict obligatoire** vers `grothendieck_lean` Phase 2+ registre ouvert post-c.383)
- **Mandat user 2026-07-11 Substance > Sweep** : extension bilingue Lean de fond (Sheafification × section FR miroir 142L, 0 code touched sur la sémantique, baseline LF propre préservée, 4/15 sous-modules `grothendieck_lean` rollout Phase 2+ ≠ doc-hygiène Phase 2 README)

## Suggestion ai-01

Merci de valider :

1. `lake build grothendieck_lean` SUCCESS sur ai-01 §1 pre-merge (confirme que `Grothendieck/Sheafification.lean` compile sans collision et que le 4 imports + 5 `theorem` sont préservés byte-identique LF).
2. CI Linux Lake build / Sorry check / Proof integrity SUCCESS (aucun de cassé — fichier docstring + 4 imports + 5 theorem inchangés).
3. Convention option A bilingue FR+EN inline #4980 respectée : section EN préservée verbatim (lignes 1-35) + bloc français miroir (lignes 36-177, deux blocs `/` top-level distincts, sans `---` interne) + référence croisée c.367 `Grothendieck.lean` racine bilingue (MERGED, initie rollout Phase 2+) + convention ratifiée 2026-07-04.
4. **c.387 = PIVOT L335 strict obligatoire post-c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lean`** : c.381 = PIVOT L335 strict, c.382 = 2ᵉ cycle continuité registre ouvert, c.383 = 3ᵉ = au seuil (registre `grothendieck_lean` ≠ conway_lein ≠ knot_lean, substance réelle = fondations sheaf cohérente avec c.381 Yoneda (lemme de Yoneda = THE foundational theorem) + c.382 MathlibMap (satellite cartographie Mathlib 4) + c.383 SheafBasics (fondations faisceaux = 6 theorem), backlog 22 sous-modules autorise c.381-c.383, **c.384 = PIVOT strict obligatoire** par R5.4b MUST = retour vers `conway_lein` Phase 1+ satellites registre ouvert post-c.380, **c.385 = 6ᵉ sous-module rollout `CollatzLike` = continuité registre `conway_lein` Phase 1+ ouvert post-c.384**, **c.386 = 7ᵉ sous-module rollout `FreeWillTheorem` = continuité registre `conway_lein` Phase 1+ ouvert post-c.385 PIVOT strict obligatoire**, **c.387 = 4ᵉ sous-module rollout `grothendieck_lean` Phase 2+ = `Sheafification` = PIVOT L335 strict obligatoire R5.4b MUST post-c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein` = retour `grothendieck_lean` Phase 2+ registre ouvert post-c.383**).
5. Diff `+142/-0` additif strict sur la sémantique : aucun code de production touché (le module reste bit-pour-bit sémantiquement identique à `origin/main` hors zone header — namespace body 4906 chars byte-identique LF, 4 imports byte-identique, 5 theorem byte-identique). Le diff est purement additif : 142 lignes bloc FR miroir ajoutées, 0 ligne supprimée, 0 octet CR whitespace modifié (baseline LF-only CR=0 strict déjà, pas de normalisation nécessaire, contrairement à c.384 baseline CRLF 138 accidents).