### PR TITLE
fix(gametheory-5-csharp): re-execute 3 exercise stubs (C.2 — commit with outputs)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax-Csharp.ipynb
@@ -1175,7 +1175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "e3e9ab03",
    "metadata": {
     "execution": {
@@ -1193,7 +1193,17 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 1 a completer : matrice Blotto(5,3) puis appelez SolveMatrixGame(ex1Matrix)."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": "// Exercice 1 : Colonel Blotto avec 5 soldats et 3 champs de bataille (B impair, non degenere)\n// Construire la matrice (C(7,2)=21 strategies), resoudre via SolveMatrixGame, afficher v et sigma.\n// Indice 1 : reutilisez BlottoStrategies(5, 3) + BlottoPayoff pour remplir la matrice.\n// Indice 2 : par symetrie A = -A^T, donc v=0 ; mais la strategie mixte n'est PAS uniforme.\n// Indice 3 : combien de strategies pures (sur 21) recoivent une probabilite > 0 dans sigma ?\n// TODO etudiant : remplacer la matrice 1x1 ci-dessous par votre matrice Blotto(5, 3).\ndouble[,] ex1Matrix = new double[,] { { 0 } };\ndisplay(\"Exercice 1 a completer : matrice Blotto(5,3) puis appelez SolveMatrixGame(ex1Matrix).\");"
   },
   {
@@ -1204,7 +1214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "748cd741",
    "metadata": {
     "execution": {
@@ -1222,7 +1232,17 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 2 a completer : votre matrice 3x3 -> SolveMatrixGame -> verification."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": "// Exercice 2 : Verification du theoreme minimax sur un jeu 3x3 personnalise\n// Etape 1 : remplacer la matrice 1x1 ci-dessous par votre matrice 3x3 (sans point-selle).\n// Etape 2 : appeler SolveMatrixGame(ex2Matrix) pour obtenir sigma, tau, v.\n// Etape 3 : verifier que sigma*Matrice*tau == v (a 1e-9 pres) ET que le resultat est non trivial.\n// Indice 1 : dimensions obligatoires : double[,] ex2Matrix = new double[3,3] { ... };\n// Indice 2 : utiliser SolveAndShow(new ZeroSumGame(ex2Matrix, ...)) pour afficher le detail.\n// Indice 3 : la verification de dualite est dans la cellule 6 (VerifyDuality) si besoin.\n// TODO etudiant : remplacer la matrice 1x1 ci-dessous par votre matrice 3x3.\ndouble[,] ex2Matrix = new double[,] { { 0 } };\ndisplay(\"Exercice 2 a completer : votre matrice 3x3 -> SolveMatrixGame -> verification.\");"
   },
   {
@@ -1233,7 +1253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "b663ecf7",
    "metadata": {
     "execution": {
@@ -1251,7 +1271,17 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Exercice 3 a completer : matrice 3x3 avec point-selle -> AnalyzePure."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": "// Exercice 3 : Construire un jeu 3x3 AVEC un point-selle en strategies pures\n// Indice 1 : un point-selle A[i,j] = max de la colonne j ET min de la ligne i.\n// Indice 2 : dimensions obligatoires : double[,] ex3Matrix = new double[3,3] { ... };\n// Indice 3 : passer votre matrice a AnalyzePure pour verifier que maximin == minimax.\n// TODO etudiant : remplacer la matrice 1x1 ci-dessous par votre matrice 3x3 avec point-selle.\ndouble[,] ex3Matrix = new double[,] { { 0 } };\ndisplay(\"Exercice 3 a completer : matrice 3x3 avec point-selle -> AnalyzePure.\");"
   },
   {


### PR DESCRIPTION
## Summary

Fix a **C.2 violation** (notebooks commit WITH their outputs) in [`GameTheory-5-ZeroSum-Minimax-Csharp.ipynb`](MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax-Csharp.ipynb): the 3 exercise stubs (cells 21/23/25) were committed with `execution_count: null` and `outputs: []`. The stubs are C.1-conformant (display placeholders, no `throw`/`NotImplementedException`) — they had simply never been run.

1 file, +36/−6 (surgical: exec/outs only on 3 cells).

## The defect (firsthand G.1)

Found by scanning the GameTheory family for execution health (`.ipynb` cells with `execution_count: null` + non-empty source). GameTheory-5 had exactly 3 such cells — the §9 Exercises section:

| Cell | Exercise | Before | After |
|------|----------|--------|-------|
| 21 | Colonel Blotto (5 soldats, 3 champs) | exec=null, outs=0 | exec=10, outs=1 |
| 23 | Théorème minimax sur jeu 3x3 | exec=null, outs=0 | exec=11, outs=1 |
| 25 | Jeu 3x3 avec point-selle | exec=null, outs=0 | exec=12, outs=1 |

The stubs use the correct C.1 pattern (`double[,] ex1Matrix = new double[,] { { 0 } }; display("Exercice 1 a completer...");`) — they just needed execution.

## Verification (firsthand, rule F — real tool)

- **Re-executed** via `.NET Interactive` kernel (`jupyter nbconvert --execute --kernel .net-csharp`, `microsoft.dotnet-interactive 1.0.712001`) — real tool, no fabricated output. Exit 0, kernel started/executed/shut down cleanly.
- **Surgical scope (C.3)**: updated ONLY `execution_count` + `outputs` on cells 21/23/25. Verified **0 source cells changed** (byte-level: the original string-form `source` field is preserved — avoided nbconvert's `string → list-of-lines` serialization churn that would have touched markdown cells 20/22/24).
- `validate_pr_notebooks` H.3: **1/1 PASS** (12 cells checked).
- C.1 re-check: **0 violations** (no `throw new NotImplementedException`, no `raise NotImplementedError`).
- CRLF=0 (LF-only, UTF-8 no BOM); no catalogue churn (catalogue byte-identique à main).

## Notes

- **No collision with #6176**: that PR is markdown-prose only (FR accents, #2876) and touches different cells; this PR touches only the 3 exercise code cells' execution state. Sequential rebase resolves cleanly if both converge.
- R6 variety: .NET/C# family (fresh — no .NET grain in c.327-336, which were Lean/QC/tooling/Python).
