### PR TITLE
feat(lean,#3846): gridToMacroCellWithOffsetN (N3 threading builder, stacked on #6219)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -727,6 +727,27 @@ def gridToMacroCellWithOffset (g : Grid) : (Int × Int) × MacroCell :=
   let (off, lvl) := gridFrame g
   (off, MacroCell.buildFromGrid g off.1 off.2 lvl)
 
+/-- n-aware variant of `gridToMacroCellWithOffset`: builds the `MacroCell` from
+    the n-aware frame `gridFrameN n g` (padding `max 2 n`), rather than the
+    fixed-padding `gridFrame`. This is the offset/MacroCell builder the N3
+    threading of `evolveHashlifeFast` (issue #3846) substitutes in place of
+    `gridToMacroCellWithOffset` to thread the n-aware frame through the recursion
+    loop. -/
+def gridToMacroCellWithOffsetN (n : Nat) (g : Grid) : (Int × Int) × MacroCell :=
+  let (off, lvl) := gridFrameN n g
+  (off, MacroCell.buildFromGrid g off.1 off.2 lvl)
+
+/-- `gridToMacroCellWithOffsetN n g` reduces to `gridToMacroCellWithOffset g`
+    when `n ≤ 2`: since `gridFrameN n g = gridFrame g` for small `n`
+    (`gridFrameN_le_two_eq_gridFrame`), both builders feed the same offset and
+    level to `buildFromGrid`. This bridges the fixed-frame builder used by the
+    current `evolveHashlifeFast` to its n-aware variant, so the N3 threading
+    substitution is behaviorally transparent for small `n` (issue #3846). -/
+theorem gridToMacroCellWithOffsetN_le_two_eq (n : Nat) (g : Grid) (hn : n ≤ 2) :
+    gridToMacroCellWithOffsetN n g = gridToMacroCellWithOffset g := by
+  unfold gridToMacroCellWithOffsetN gridToMacroCellWithOffset
+  rw [gridFrameN_le_two_eq_gridFrame n g hn]
+
 /-- Convert a `Grid` to a `MacroCell`, discarding the offset (defaulting to
     `(0, 0)` for the round trip). For round-trip purposes, prefer
     `gridToMacroCellWithOffset`. -/


### PR DESCRIPTION
## Summary

Add the n-aware MacroCell builder `gridToMacroCellWithOffsetN` + a sorry-free bridge lemma, the offset/MacroCell constructor that the **N3 threading** of `evolveHashlifeFast` (EPIC #3846) substitutes in place of the fixed-frame `gridToMacroCellWithOffset`.

**⚠️ STACKED PR — base is #6219 (`feature/hashlife-gridframeN-reduce-3846` @ 3a1f53566), NOT `main`.** This PR depends on `gridFrameN_le_two_eq_gridFrame` provided by #6219. Merge #6219 first, then rebase this PR onto `main`.

21 insertions in 1 file (the new def + lemma only — the bridge itself is in #6219).

## Why (N3-threading grain)

`evolveHashlifeFastAux` ([Hashlife.lean L330](MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean#L330)) currently calls `gridToMacroCellWithOffset g`, which feeds the **fixed-padding** `gridFrame g` into `buildFromGrid`. N3 threading requires the **n-aware** frame `gridFrameN n g` (padding `max 2 n`) so the light-cone margin scales with `n`. This PR provides the n-aware builder `gridToMacroCellWithOffsetN n g` for that substitution, plus the lemma proving the substitution is behaviorally transparent for small `n`.

## Verification (firsthand, §B Lean PR body)

| Check | Result |
|-------|--------|
| `lake build Conway.Life.MacroCell` | **SUCCESS** (cached Mathlib `.lake`, 2947 jobs, `C:/Users/jsboi/.elan/bin/lake.exe` native, toolchain `leanprover/lean4:v4.31.0-rc1`) |
| `grep -c sorry` MacroCell.lean (strip-docstrings method) | **0 → 0** (additive def + lemma, no new sorries) |
| Diff vs #6219 head (3a1f53566) | **+21 / −0** (purely additive — only the new def + lemma) |
| Catalogue | byte-identique à `main` (no churn) |

### Build log tail

```
Build completed successfully (2947 jobs)
```

## Proof sketch

```lean
theorem gridToMacroCellWithOffsetN_le_two_eq (n : Nat) (g : Grid) (hn : n ≤ 2) :
    gridToMacroCellWithOffsetN n g = gridToMacroCellWithOffset g := by
  unfold gridToMacroCellWithOffsetN gridToMacroCellWithOffset
  rw [gridFrameN_le_two_eq_gridFrame n g hn]
```

- `unfold` exposes both bodies: `let (off, lvl) := <frame>; (off, MacroCell.buildFromGrid g off.1 off.2 lvl)`.
- `rw [gridFrameN_le_two_eq_gridFrame n g hn]` substitutes the n-aware frame `gridFrameN n g` by the fixed frame `gridFrame g` (the bridge from #6219, applied with explicit args `n g hn` so no side-goal is generated), making both sides defeq.

## Notes / résiduel

- **Stacked on #6219**: this PR does NOT compile standalone on `main` (it references `gridFrameN_le_two_eq_gridFrame`). Merge #6219 first, then rebase onto `main`.
- This PR is **additive and sorry-free**: it adds the N3-threading builder + its small-`n` bridge, it does **not** perform the threading substitution in `evolveHashlifeFastAux` itself (that behavioral change remains multi-cycle — the actual recursion modification + `p5_large_n_jumpN` closure).
- **CATALOG-STATUS**: unchanged (catalogue byte-identique à main).

See #3846
