### PR TITLE
fix(gametheory-15-csharp): restore blank lines after 25 collapsed markdown headers (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames-Csharp.ipynb
@@ -31,6 +31,7 @@
     "6. Reconnaître les **jeux convexes** (marginales croissantes ⟹ core non vide, Shapley ∈ core).\n",
     "\n",
     "### Prérequis\n",
+    "\n",
     "- Théorie des jeux en forme normale (cf. [GameTheory-2](GameTheory-2-NormalForm-Csharp.ipynb), [GameTheory-4](GameTheory-4-NashEquilibrium-Csharp.ipynb)).\n"
    ]
   },
@@ -209,12 +210,15 @@
     "## 1. Fonction caractéristique et coalitions\n",
     "\n",
     "### Définition\n",
+    "\n",
     "Un **jeu coopératif à utilité transférable** (von Neumann-Morgenstern 1944) est un couple `(N, v)` où `N = {1,…,n}` est l'ensemble des joueurs et `v : 2^N → ℝ` est la **fonction caractéristique** : `v(S)` est la valeur que la coalition `S` peut garantir seule (son « worth »). Conventions : `v(∅) = 0`, `v(S) ≥ 0` souvent.\n",
     "\n",
     "### Énumération des coalitions\n",
+    "\n",
     "L'ensemble des coalitions = le **powerset** de `N` (`2^n` coalitions). On l'énumère via les **bitmasks** de `0` à `2^n − 1`.\n",
     "\n",
     "### Propriétés\n",
+    "\n",
     "- **Superadditivité** : `v(S ∪ T) ≥ v(S) + v(T)` si `S ∩ T = ∅` (fusioner paie).\n",
     "- **Convexité** : `v(S ∪ {i}) − v(S)` **croît** avec `S` (rend les grandes coalitions stables).\n"
    ]
@@ -376,6 +380,7 @@
    "metadata": {},
    "source": [
     "### Interprétation des résultats\n",
+    "\n",
     "- **Superadditif** : oui (fusioner des coalitions disjointes ne diminue jamais la valeur — une coalition plus grosse accède à plus de gants).\n",
     "- **Non convexe** : la marginale du joueur 1 **décroît** (passer de {2} à {2,3} comme partenaires ne crée qu'une paire au maximum). Le jeu n'est pas convexe, donc on n'a **pas** la garantie que le core soit non vide (on le vérifiera plus bas).\n"
    ]
@@ -388,11 +393,13 @@
     "## 2. La valeur de Shapley\n",
     "\n",
     "### Définition (Shapley 1953)\n",
+    "\n",
     "La **valeur de Shapley** `φ_i` du joueur `i` est la **moyenne de ses contributions marginales** sur **toutes les permutations** des joueurs (modélisant tous les ordres d'arrivée équiprobables) :\n",
     "\n",
     "$$\\varphi_i = \\frac{1}{n!} \\sum_{\\pi \\in S_n} \\big[ v(\\{\\text{joueurs avant } i \\text{ dans } \\pi\\} \\cup \\{i\\}) - v(\\text{joueurs avant } i) \\big]$$\n",
     "\n",
     "### Propriétés (axiomes caractérisant Shapley)\n",
+    "\n",
     "- **Efficacité** : `Σ_i φ_i = v(N)` (tout est redistribué).\n",
     "- **Symétrie** : deux joueurs interchangeables ont même φ.\n",
     "- **Joueur nul** : si `i` ne contribue jamais (`v(S∪{i})=v(S)` ∀S), alors `φ_i = 0`.\n",
@@ -507,6 +514,7 @@
     "## 3. Indice de pouvoir de Banzhaf\n",
     "\n",
     "### Définition (Banzhaf 1965)\n",
+    "\n",
     "Dans un jeu de **vote pondéré** (chaque joueur a un poids, une coalition gagne si son poids total ≥ quota `q`), l'**indice de Banzhaf** mesure le **pouvoir de swing** d'un joueur : combien de coalitions deviennent gagnantes par son ajout.\n",
     "\n",
     "Un joueur `i` est **décisif** dans la coalition `S` (avec `i ∉ S`) si `S` perd mais `S ∪ {i}` gagne. L'indice de Banzhaf **non normalisé** :\n",
@@ -611,6 +619,7 @@
    "metadata": {},
    "source": [
     "### Interprétation : poids ≠ pouvoir\n",
+    "\n",
     "Dans le vote `[50, 49, 1]` (quota 50), l'indice de Banzhaf vaut **β = (3, 1, 1)** :\n",
     "- **A50** est décisif dans **3** coalitions (`{}`→`{A50}`, `{B49}`→`{A50,B49}`, `{C1}`→`{A50,C1}`) → β = 3.\n",
     "- **B49** est décisif dans **1** coalition (`{C1}`→`{B49,C1}` = 50 ≥ 50) → β = 1.\n",
@@ -627,6 +636,7 @@
     "## 4. Le core\n",
     "\n",
     "### Définition\n",
+    "\n",
     "Le **core** (Gillies 1959) est l'ensemble des **imputations** `x = (x_1,…,x_n)` que **aucune coalition ne peut bloquer** :\n",
     "- **Efficacité** : `Σ_i x_i = v(N)` (tout est distribué).\n",
     "- **Rationalité coalitionnelle** : `Σ_{i∈S} x_i ≥ v(S)` pour **toute** coalition `S`.\n",
@@ -634,9 +644,11 @@
     "Une coalition `S` pour laquelle `Σ_{i∈S} x_i < v(S)` peut **bloquer** `x` (elle obtient moins seule qu'en se séparable). Le core = répartitions **stables** (non bloquables).\n",
     "\n",
     "### Non-vacuité\n",
+    "\n",
     "Le core peut être **vide** (aucune répartition stable). Le **théorème de Bondareva-Shapley** : le core est non vide ssi le jeu est **équilibré**. Une condition suffisante : le jeu est **convexe** (alors Shapley ∈ core).\n",
     "\n",
     "### Test pratique\n",
+    "\n",
     "Pour un petit jeu, on teste la non-vacuité en cherchant une imputation `x` efficace satisfaisant toutes les inégalités `Σ_{i∈S} x_i ≥ v(S)`. C'est un **programme linéaire** (feasibility). On l'illustre ici par vérification directe de candidats (Shapley, imputation extrêmale).\n"
    ]
   },
@@ -724,6 +736,7 @@
    "metadata": {},
    "source": [
     "### Interprétation : core du glove game\n",
+    "\n",
     "Le core du glove game est **non vide** et contient les imputations où `x_{L1} ≥ 1` contraint — en fait `x = (1, 0, 0)` est stable : L1 prend tout, et R2/R3 seuls valent 0 donc ne peuvent bloquer. Le Shapley `(2/3, 1/6, 1/6)` **n'est pas** dans le core (la coalition {L1, R2} vaut 1 mais ne reçoit que 2/3 + 1/6 = 5/6 < 1 → bloque). C'est un exemple où **Shapley ∉ core** car le jeu n'est **pas convexe**.\n"
    ]
   },
@@ -735,6 +748,7 @@
     "## 5. Jeux convexes : Shapley ∈ core\n",
     "\n",
     "### Théorème (Shapley 1971)\n",
+    "\n",
     "Si le jeu est **convexe** (marginales croissantes : `v(S ∪ {i}) − v(S)` croît avec `S ⊆ T`), alors :\n",
     "1. Le **core est non vide**.\n",
     "2. La **valeur de Shapley est dans le core** (Shapley est une répartition stable).\n",
@@ -742,6 +756,7 @@
     "C'est le cas « idéal » où équité (Shapley) et stabilité (core) coïncident.\n",
     "\n",
     "### Exemple : le jeu d'aéroport\n",
+    "\n",
     "Coût de construction d'une piste dont chaque joueur `i` a besoin d'une longueur `ℓ_i`. Le coût d'une coalition `S` = `max_{i∈S} ℓ_i` (la plus grande longueur requise). Ce jeu de coût est **concave** (dual du convexe) : les économies d'échelle sont décroissantes. La répartition Shapley des coûts est dans le core.\n"
    ]
   },
@@ -825,6 +840,7 @@
    "metadata": {},
    "source": [
     "### Interprétation : tarification Shapley de l'aéroport\n",
+    "\n",
     "La valeur de Shapley répartit le coût **par tranches d'usage marginal** : le petit avion (1000m) partage la première tranche avec tous, le gros (6000m) paie seul la dernière. C'est la base de la **tarification équitable des coûts communs** (aéroports, réseaux, projets jointifs). Le caractère concave du jeu de coût garantit la stabilité (personne ne paie plus que sa longueur seule → pas de blocage).\n"
    ]
   },
@@ -903,6 +919,7 @@
    "metadata": {},
    "source": [
     "### Interprétation du tableau comparatif\n",
+    "\n",
     "La convexité (ou concavité d'un jeu de coût) est la condition clé : elle **garantit** que la répartition équitable (Shapley) est aussi **stable** (dans le core). Hors convexité, équité et stabilité divergent — c'est le cœur de la difficulté des jeux coopératifs non convexes (négociation, externalités).\n"
    ]
   },
@@ -916,6 +933,7 @@
     "> Stubs à compléter (jamais `throw` : le notebook s'exécute end-to-end, règle C.1).\n",
     "\n",
     "### Exercice 1 — Jeu de vote pondéré (Conseil de l'UE)\n",
+    "\n",
     "Construire un jeu de vote pondéré représentant le Conseil de l'UE (poids des grands pays) et calculer les indices de Banzhaf. Qui a le plus de pouvoir relatif ?\n"
    ]
   },
@@ -954,6 +972,7 @@
    "metadata": {},
    "source": [
     "### Exercice 2 — Bankruptcy game\n",
+    "\n",
     "Trois créanciers réclament 100, 200, 300 ; l'actif disponible est 350. Modéliser comme jeu coopératif (`v(S) = max(0, actif − somme des réclamations hors S)`) et calculer Shapley. Comparer à la règle proportionnelle.\n"
    ]
   },
@@ -991,6 +1010,7 @@
    "metadata": {},
    "source": [
     "### Exercice 3 — Core vide\n",
+    "\n",
     "Construire un jeu à 3 joueurs dont le core est **vide** (ex: jeu non équilibré) et le vérifier (aucune imputation stable).\n"
    ]
   },
@@ -1029,6 +1049,7 @@
    "metadata": {},
    "source": [
     "### Exercice 4 — Nucleolus\n",
+    "\n",
     "Le **nucleolus** est la répartition qui minimise lexicographiquement le vecteur des excès (mécontentement max des coalitions). L'implémenter (avancé) et comparer à Shapley sur le glove game.\n"
    ]
   },
@@ -1066,6 +1087,7 @@
    "metadata": {},
    "source": [
     "### Exercice 5 — Convexité et core\n",
+    "\n",
     "Montrer (par énumération) que pour un jeu convexe à 3 joueurs, la valeur de Shapley satisfait toutes les inégalités du core.\n"
    ]
   },
@@ -1105,6 +1127,7 @@
     "## 8. Résumé\n",
     "\n",
     "### Points clés\n",
+    "\n",
     "- **Jeu coopératif** `(N, v)` : `v(S)` = valeur d'une coalition.\n",
     "- **Shapley** : répartition équitable (contribution marginale moyenne, 4 axiomes).\n",
     "- **Banzhaf** : pouvoir de swing (poids ≠ pouvoir).\n",
@@ -1112,9 +1135,11 @@
     "- **Convexité** ⟹ core non vide **et** Shapley ∈ core (équité + stabilité).\n",
     "\n",
     "### Leçon centrale\n",
+    "\n",
     "La théorie coopérative sépare **équité** (Shapley) et **stabilité** (core). Elles coïncident pour les jeux convexes ; sinon, il faut choisir — ou chercher d'autres solutions (nucleolus, valeur de Nash).\n",
     "\n",
     "### Prochaine étape\n",
+    "\n",
     "- [GameTheory-16 (Choix social / Mechanism Design)](GameTheory-16-MechanismDesign-Csharp.ipynb) : agrégation des préférences et conception d'enchères.\n",
     "\n",
     "---\n",


### PR DESCRIPTION
## What

Restores blank lines after **25 collapsed markdown headers** in `GameTheory-15-CooperativeGames-Csharp.ipynb` (cooperative game theory: Shapley value, Banzhaf power index, core, VCG).

A collapsed header = a markdown header line (`### Définition`) immediately followed by content with no blank line between — hurts markdown rendering and readability. Fixed instances include: `### Prérequis`, `### Définition` (Shapley/Banzhaf/core), `### Énumération des coalitions`, `### Propriétés`, `### Interprétation`, `### Non-vacuité`, `### Test pratique`, and the Shapley/Banzhaf axiom blocks.

## Verification

- **Markdown-only (C.2-exempt)**: 0 code cell source diffs (byte-identical vs HEAD, 13 code cells preserved) so existing `execution_count`/`outputs` intact (markdown-only edit per C.2 exception).
- **Diff**: 26 ins / 1 del (25 blank-line insertions + 1 JSON trailing-element reformat).
- **LF-only** (CR=0, L268 #4).
- **nbformat valid**, 34 cells preserved.
- **Post-fix scan**: 0 residual collapsed headers (was 25).

## Scope

- Campaign **#3966** (po-2025 lead): markdown header aeration. Same pattern as #6188 / #6189 / #6203 / #6204 / #6206 (Search-6 c.431).
- Scan rigor **C431-L1** applied: markdown cells only — excluded Python `#` comments in code cells (the FP source that inflated earlier scans).
- Single-subject (1 file, markdown-only).
- Distinct sub-genre from accent fixes (structural whitespace vs diacritics).

See #3966 (markdown aeration campaign).
