### PR TITLE
docs(qc,#1621): add AdaptiveConformalRisk to comparative backtests (QC Cloud c.338, stacked on #6224)

### DIFF
--- a/docs/qc-comparative-backtests.md
+++ b/docs/qc-comparative-backtests.md
@@ -18,26 +18,26 @@
 | `1630-DualMomentum-aligned` | 33286487 | c.332 | 318 | 0.350 | 8.413 % | 14.900 % | 76.088 % ($59 745) | OK |
 | `1630-RiskParity-aligned` | 33286158 | c.332 | 309 | 0.361 | 8.303 % | 18.400 % | 74.841 % ($60 837) | OK |
 | `baseline-clone-TrendFollowing-repo-1630` | 33078355 | c.336 | 453 | 0.360 | 7.290 % | 15.000 % | 102.225 % ($83 495) | OK |
+| `1630-baseline-AdaptiveConformalRisk` | 33278416 | c.338 | 1079 | 0.449 | 11.522 % | 22.500 % | 139.392 % ($126 394) | OK |
 
-> Les métriques sont consignées après exécution du backtest c.336 (résultat brut vérifié `totalOrders > 0`).
+> Les métriques sont consignées après exécution du backtest (résultat brut vérifié `totalOrders > 0`, garde anti-exception silencieuse c.331).
 
-## Lecture comparative (3 stratégies)
+## Lecture comparative (4 stratégies)
 
-Les trois stratégies validées (DualMomentum, RiskParity, TrendFollowing) affichent un profil **modéré et cohérent** :
+Les quatre stratégies validées affichent deux profils distincts :
 
-- **Sharpe ~0.35–0.36** — rentabilité ajustée du risque modeste mais positive, sur la plage attendue pour une allocation tactique ETF multi-actifs (référence : Sharpe SPY long-terme ~0.4–0.5). Étonnamment, les trois stratégies convergent vers la même valeur de Sharpe malgré des logiques de signaux très différentes.
-- **CAGR** : DualMomentum et RiskParity ~8.3–8.4 %, TrendFollowing 7.3 % (légèrement inférieur).
-- **Drawdown 14.9–15.0 % (DualMomentum, TrendFollowing) vs 18.4 % (RiskParity)** — RiskParity paie sa diversification constante par un drawdown plus profond ; les stratégies momentum/trend contrôlent mieux le risque extrême via leurs stops.
-- **Net Profit : TrendFollowing (102.2 %, $83 495) > DualMomentum (76.1 %) > RiskParity (74.8 %)** — TrendFollowing, sur la période la plus longue (2516 jours tradeables vs 1761), surpasse en absolu tout en restant dans la même bande de Sharpe.
-- **Aucune exception silencieuse** : 309–453 ordres confirment un rebalancement actif (vs le piège 0-trade de c.331, désormais détecté par le garde).
+- **Trois stratégies tactiques (DualMomentum, RiskParity, TrendFollowing) : Sharpe ~0.35–0.36** — rentabilité ajustée du risque modeste, dans la plage attendue pour une allocation tactique ETF multi-actifs (référence : Sharpe SPY long-terme ~0.4–0.5). Étonnamment, ces trois stratégies convergent vers la même valeur de Sharpe malgré des logiques de signaux différentes.
+- **AdaptiveConformalRisk se détache : Sharpe 0.449, CAGR 11.5 %, Net +139 %** — le premier membre de la cohorte dont le Sharpe **dépasse nettement la bande de référence ~0.36**. Le Probabilistic Sharpe Ratio (2.509 %) est aussi nettement supérieur aux autres (<1 %). Ce surcroît de rentabilité s'accompagne d'un drawdown plus profond (22.5 % vs 14.9–18.4 %) — un profil risque/rendement plus agressif, caractéristique d'une stratégie à risque adaptatif (conformal risk control).
+- **Drawdown** : AdaptiveConformalRisk (22.5 %) > RiskParity (18.4 %) > DualMomentum/TrendFollowing (14.9–15.0 %). Le risque adaptatif maximise le rendement au prix d'un drawdown plus large.
+- **Net Profit : AdaptiveConformalRisk (139 %, $126 394) > TrendFollowing (102 %) > DualMomentum (76 %) > RiskParity (75 %)**.
+- **Aucune exception silencieuse** : 309–1079 ordres confirment un rebalancement actif (vs le piège 0-trade de c.331, désormais détecté par le garde).
 
-**Verdict honnête (G.2)** : NO BEATS manifesto sur les trois stratégies — performances dans la plage du benchmark (Sharpe ~0.36, pas d'alpha manifeste au-delà du buy-and-hold SPY ajusté du risque). La cohorte sert de **baseline de référence** pour comparer les stratégies suivantes (AdaptiveConformalRisk, PCAStatArbitrage) et détecter un éventuel alpha.
+**Verdict honnête (G.2)** : NO BEATS manifesto reste l'interprétation prudente pour les 3 stratégies tactiques (Sharpe ~0.36 = plage benchmark). **AdaptiveConformalRisk est un candidat alpha prometteur** (Sharpe 0.449 + PSR 2.5 % vs ~0.36 + <1 % pour le reste) mais ce verdict nécessite, avant d'être affirmé, une validation multi-seed / walk-forward (cf [pr-review-discipline.md](../.claude/rules/pr-review-discipline.md) §C) pour exclure que l'écart ne soit un artefact du régime de la période. La cohorte sert de **baseline de référence** pour les stratégies restantes (PCAStatArbitrage, robustness-c2-regime).
 
 ## Stratégies en file (cycles suivants)
 
 Backtests restants à lancer sur la cohorte, pour étendre la comparative :
 
-- `1630-baseline-AdaptiveConformalRisk` (33278416)
 - `1630-baseline-PCAStatArbitrage` (33281920)
 - `1630-robustness-c2-regime` (33280244)
 


### PR DESCRIPTION
## Summary

Extend [`docs/qc-comparative-backtests.md`](docs/qc-comparative-backtests.md) with the **AdaptiveConformalRisk** baseline, backtested via **QC Cloud** (qc-mcp-lite) on cycle c.338.

**⚠️ STACKED PR — base is #6224 (`feature/qc-comparative-backtests-doc-1621` @ 1c172ebc5), NOT `main`.** Merge #6224 first, then rebase onto `main`.

+10/−10 in 1 file (table row added, lecture section rewritten to 2 profiles, ACR removed from queue).

## The result (firsthand G.1/G.2)

Backtest `po2026-c338-AdaptiveConformalRisk-1783816355` (backtestId `3ef4ca9350324931b960eb4c31491052`, projectId 33278416, 2011 tradeable days):

| Metric | Value |
|--------|-------|
| Total Orders | **1079** (guard OK — no silent exception) |
| Sharpe Ratio | **0.449** |
| CAGR | 11.522 % |
| Max Drawdown | 22.500 % |
| Net Profit | +139.392 % ($126,394) |
| Probabilistic Sharpe | 2.509 % |

## Why notable

AdaptiveConformalRisk is the **first cohort member whose Sharpe (0.449) clearly exceeds the ~0.36 benchmark band** of the other 3 strategies (DualMomentum 0.350, RiskParity 0.361, TrendFollowing 0.360), with a higher Probabilistic Sharpe Ratio (2.5 % vs <1 %). This makes it a **promising alpha candidate** — the cohort's first signal that distinguishes from the benchmark.

**Honest caveat (G.2)**: the alpha verdict is NOT affirmed in this PR. Per [pr-review-discipline.md](.claude/rules/pr-review-discipline.md) §C, a single backtest is insufficient to claim alpha — it needs multi-seed / walk-forward validation to rule out that the gap is a period-regime artifact. The doc states this explicitly. The deeper drawdown (22.5 % vs 14.9–18.4 %) reflects the adaptive risk-control (conformal) profile trading higher return for higher risk.

## Verification

- **Silent-exception guard (c.331)**: raw payload verified `totalOrders: 1079 > 0` — active rebalancing confirmed, not a 0-trade trap.
- **Raw payload cross-checked** (c.331 lesson — don't trust wrapper extraction alone): read directly from `read_backtest` `statistics` + `totalOrders` fields.
- Catalogue: byte-identique à main (no churn — doc-only edit).
- FR-first prose (per readme-french-first).

## Notes

- Poll-loop bug from c.336 (`"Completed"` vs `"Completed."` trailing dot) fixed in the backtest driver this cycle — caught completion correctly at 50s.
- Remaining queued strategies: PCAStatArbitrage, robustness-c2-regime.

See #1621
