### PR TITLE
fix(ict-24): restore markdown newlines in 14 collapsed cells (#3966)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-24-WorkspaceIgnition.ipynb
@@ -5,7 +5,36 @@
    "id": "445ab538",
    "metadata": {},
    "source": [
-    "# ICT-24 — WorkspaceIgnition : l'axe Global Workspace et le Gate de réconciliation IIT<->GWT sur S4*[Série ICT — Integrated Causal Trajectories, Epic #4588, strate 5.](./README.md) Part of #4588.*Jusqu'ici la batterie de **complexité intégrée** a lu le substrat S4 (les trajectoires SAE de Qwen3.5-9B-Base, cf. [ICT-21](ICT-21-SAETrajectoires.ipynb)) avec les lunettes de l'IIT : `ec_gain`/`fe_gain`/`k_gain`, créditées uniquement au-dessus d'un modèle-contrôle et d'un mélange des temps. L'article d'Anthropic [*Global Workspace*](https://www.anthropic.com/research/global-workspace) identifie dans Claude un **workspace global** — la lecture GWT (Baars ; Dehaene, Naccache, Changeux), historiquement *contrastée* avec l'IIT. Les deux lectures n'ont presque jamais été confrontées **sur le même substrat avec le même appareil**. C'est ce que fait ce notebook.> **Question fondatrice, posée en hypothèse falsifiable.** *Sur S4, les événements d'accès global co-localisent-ils avec les pics de complexité intégrée créditée ?*> - **OUI** → pont empirique : un même événement, deux lectures théoriques.> - **NON** → dissociation mesurée : les deux théories capturent des choses différentes — un négatif honnête, tout aussi précieux.## Les trois gates| Gate | Question | Type | Statut dans ce notebook ||------|----------|------|------------------------|| **22 — Structure** | Existe-t-il un sous-ensemble de features à fan-out d'influence disproportionné (≪10 % du panel) ? | Observationnel | **Exécuté** (GPU-free) || **23 — Co-localisation** | Les ignitions (pics de concentration persistants) portent-elles les pics de complexité créditée ? | Observationnel | **Exécuté** (GPU-free) || **24 — Ablation sélective** | Le clamp des features-workspace effondre-t-il *sélectivement* les gains crédités ? | **Interventionnel (causal)** | **Phase 2 (GPU)** — section dédiée, non exécutée ici |Seul le Gate 24 est causal. Les Gates 22–23 livrent un verdict observationnel **sans l'attendre**.## Grille de verdicts — chaque branche est un résultat| Configuration | Lecture ||---------------|---------|| 22OK 23OK (24OK) | **Pont empirique** : intégration ≡ accès global sur ce substrat || 22OK 23KO | **Dissociation** : le workspace existe mais ne porte pas les pics d'intégration — les deux théories mesurent des choses différentes || 22KO | Pas de structure workspace à l'échelle du panel → renvoi aux états causaux ε-machine (ICT-17) |L'appareil `ict/workspace.py` (numpy-only, adaptateur mince posé par #5641) fournit les six primitives : `concentration_series`, `ignition_events`, `lagged_influence`, `fanout_profile`, `workspace_candidates`, `event_triggered_battery`. Cette dernière **réutilise `ict.synthesis.emergence_gain` verbatim** — même discipline de créditation que le reste de la série."
+    "# ICT-24 — WorkspaceIgnition : l'axe Global Workspace et le Gate de réconciliation IIT<->GWT sur S4\n",
+    "\n",
+    "*[Série ICT — Integrated Causal Trajectories, Epic #4588, strate 5.](./README.md) Part of #4588.*\n",
+    "\n",
+    "Jusqu'ici la batterie de **complexité intégrée** a lu le substrat S4 (les trajectoires SAE de Qwen3.5-9B-Base, cf. [ICT-21](ICT-21-SAETrajectoires.ipynb)) avec les lunettes de l'IIT : `ec_gain`/`fe_gain`/`k_gain`, créditées uniquement au-dessus d'un modèle-contrôle et d'un mélange des temps. L'article d'Anthropic [*Global Workspace*](https://www.anthropic.com/research/global-workspace) identifie dans Claude un **workspace global** — la lecture GWT (Baars ; Dehaene, Naccache, Changeux), historiquement *contrastée* avec l'IIT. Les deux lectures n'ont presque jamais été confrontées **sur le même substrat avec le même appareil**. C'est ce que fait ce notebook.\n",
+    "\n",
+    "> **Question fondatrice, posée en hypothèse falsifiable.** *Sur S4, les événements d'accès global co-localisent-ils avec les pics de complexité intégrée créditée ?*\n",
+    "> - **OUI** → pont empirique : un même événement, deux lectures théoriques.\n",
+    "> - **NON** → dissociation mesurée : les deux théories capturent des choses différentes — un négatif honnête, tout aussi précieux.\n",
+    "\n",
+    "## Les trois gates\n",
+    "\n",
+    "| Gate | Question | Type | Statut dans ce notebook |\n",
+    "|------|----------|------|------------------------|\n",
+    "| **22 — Structure** | Existe-t-il un sous-ensemble de features à fan-out d'influence disproportionné (≪10 % du panel) ? | Observationnel | **Exécuté** (GPU-free) |\n",
+    "| **23 — Co-localisation** | Les ignitions (pics de concentration persistants) portent-elles les pics de complexité créditée ? | Observationnel | **Exécuté** (GPU-free) |\n",
+    "| **24 — Ablation sélective** | Le clamp des features-workspace effondre-t-il *sélectivement* les gains crédités ? | **Interventionnel (causal)** | **Phase 2 (GPU)** — section dédiée, non exécutée ici |\n",
+    "\n",
+    "Seul le Gate 24 est causal. Les Gates 22–23 livrent un verdict observationnel **sans l'attendre**.\n",
+    "\n",
+    "## Grille de verdicts — chaque branche est un résultat\n",
+    "\n",
+    "| Configuration | Lecture |\n",
+    "|---------------|---------|\n",
+    "| 22OK 23OK (24OK) | **Pont empirique** : intégration ≡ accès global sur ce substrat |\n",
+    "| 22OK 23KO | **Dissociation** : le workspace existe mais ne porte pas les pics d'intégration — les deux théories mesurent des choses différentes |\n",
+    "| 22KO | Pas de structure workspace à l'échelle du panel → renvoi aux états causaux ε-machine (ICT-17) |\n",
+    "\n",
+    "L'appareil `ict/workspace.py` (numpy-only, adaptateur mince posé par #5641) fournit les six primitives : `concentration_series`, `ignition_events`, `lagged_influence`, `fanout_profile`, `workspace_candidates`, `event_triggered_battery`. Cette dernière **réutilise `ict.synthesis.emergence_gain` verbatim** — même discipline de créditation que le reste de la série.\n",
+    "\n"
    ]
   },
   {
@@ -13,7 +42,16 @@
    "id": "3cd10ff4",
    "metadata": {},
    "source": [
-    "## Garde-fous d'honnêteté (à lire avant les résultats)Ces cinq garde-fous sont aussi dans la docstring de `ict/workspace.py` ; nous les répétons ici car ils conditionnent la lecture de chaque chiffre.1. **J-lens ≠ SAE.** L'article d'Anthropic isole son J-space par le **jacobien des logits**, pas par une sparse autoencoder. Notre route SAE (Qwen-Scope) est une opérationnalisation *parallèle* du même concept de workspace, pas une réplication de leur méthode.2. **Structurel ≠ temporel.** Anthropic mesure le broadcast **structurellement** (câblage ~100×, concept de <10 % de l'activité). L'**ignition temporelle** de Dehaene n'y est *pas* mesurée. Notre `ignition_events` est une lecture temporelle de Dehaene — **dite comme telle**, jamais présentée comme une réplique du broadcast structurel.3. **Observationnel ≠ interventionnel.** Les Gates 22–23 sont observationnels (corrélations, co-localisations). Seul le Gate 24 (clamp) est causal. Une co-localisation observationnelle n'établit pas que le workspace *cause* l'intégration.4. **Qwen ≠ Claude.** Nous travaillons sur Qwen3.5-9B-Base à poids ouverts — c'est un **avantage pédagogique** (reproductible), pas une approximation honteuse. Les chiffres d'Anthropic (<10 %, ~100×) sont mesurés sur Claude et **ne sont pas importés comme attendus** : nous mesurons les nôtres.5. **Accès ≠ phénoménal.** Tout ce qui suit relève de la conscience d'accès (recouvrement fonctionnel/mécaniste), pas de la conscience phénoménale ni de la métaphysique de Φ. Le notebook *bridge* le recouvrement, il ne le résout pas."
+    "## Garde-fous d'honnêteté (à lire avant les résultats)\n",
+    "\n",
+    "Ces cinq garde-fous sont aussi dans la docstring de `ict/workspace.py` ; nous les répétons ici car ils conditionnent la lecture de chaque chiffre.\n",
+    "\n",
+    "1. **J-lens ≠ SAE.** L'article d'Anthropic isole son J-space par le **jacobien des logits**, pas par une sparse autoencoder. Notre route SAE (Qwen-Scope) est une opérationnalisation *parallèle* du même concept de workspace, pas une réplication de leur méthode.\n",
+    "2. **Structurel ≠ temporel.** Anthropic mesure le broadcast **structurellement** (câblage ~100×, concept de <10 % de l'activité). L'**ignition temporelle** de Dehaene n'y est *pas* mesurée. Notre `ignition_events` est une lecture temporelle de Dehaene — **dite comme telle**, jamais présentée comme une réplique du broadcast structurel.\n",
+    "3. **Observationnel ≠ interventionnel.** Les Gates 22–23 sont observationnels (corrélations, co-localisations). Seul le Gate 24 (clamp) est causal. Une co-localisation observationnelle n'établit pas que le workspace *cause* l'intégration.\n",
+    "4. **Qwen ≠ Claude.** Nous travaillons sur Qwen3.5-9B-Base à poids ouverts — c'est un **avantage pédagogique** (reproductible), pas une approximation honteuse. Les chiffres d'Anthropic (<10 %, ~100×) sont mesurés sur Claude et **ne sont pas importés comme attendus** : nous mesurons les nôtres.\n",
+    "5. **Accès ≠ phénoménal.** Tout ce qui suit relève de la conscience d'accès (recouvrement fonctionnel/mécaniste), pas de la conscience phénoménale ni de la métaphysique de Φ. Le notebook *bridge* le recouvrement, il ne le résout pas.\n",
+    "\n"
    ]
   },
   {
@@ -21,7 +59,24 @@
    "id": "ced53301",
    "metadata": {},
    "source": [
-    "## Architecture : le GPU confiné, le banc numpy-only```  traces .npz (extraction GPU, #5101/ICT-21)  ──►  ict.sae_traces  ──►  panels (T,K)         [committed, GPU-free to load]                                    │                                                                          ▼                                              ict.workspace (numpy-only adapter)                                  concentration_series · ignition_events                                  lagged_influence · fanout_profile                                  workspace_candidates · event_triggered_battery                                                         │ reutilise ict.synthesis.emergence_gain                                                         ▼                                                  verdicts Gate 22 / 23```- Le torch/transformers est **confiné au pipeline d'extraction** (#5101) ; les traces reviennent en `.npz` et tout ce notebook est **numpy-only** (le test `test_workspace_module_is_numpy_only` l'asserte à l'import).- Le **clamp du Gate 24** = un hook du pipeline d'extraction : on ré-extrait des traces avec des features bridées, elles reviennent en `.npz`, et l'analyse redevient GPU-free. C'est une **phase 2** (GPU2, `CUDA_VISIBLE_DEVICES=2` strict), séparée de cette PR."
+    "## Architecture : le GPU confiné, le banc numpy-only\n",
+    "\n",
+    "```\n",
+    "  traces .npz (extraction GPU, #5101/ICT-21)  ──►  ict.sae_traces  ──►  panels (T,K)         [committed, GPU-free to load]\n",
+    "                                    │\n",
+    "                                                                          ▼\n",
+    "                                              ict.workspace (numpy-only adapter)\n",
+    "                                  concentration_series · ignition_events\n",
+    "                                  lagged_influence · fanout_profile\n",
+    "                                  workspace_candidates · event_triggered_battery\n",
+    "                                                         │ reutilise ict.synthesis.emergence_gain\n",
+    "                                                         ▼\n",
+    "                                                  verdicts Gate 22 / 23\n",
+    "```\n",
+    "\n",
+    "- Le torch/transformers est **confiné au pipeline d'extraction** (#5101) ; les traces reviennent en `.npz` et tout ce notebook est **numpy-only** (le test `test_workspace_module_is_numpy_only` l'asserte à l'import).\n",
+    "- Le **clamp du Gate 24** = un hook du pipeline d'extraction : on ré-extrait des traces avec des features bridées, elles reviennent en `.npz`, et l'analyse redevient GPU-free. C'est une **phase 2** (GPU2, `CUDA_VISIBLE_DEVICES=2` strict), séparée de cette PR.\n",
+    "\n"
    ]
   },
   {
@@ -72,7 +127,10 @@
    "id": "f0e0c3c7",
    "metadata": {},
    "source": [
-    "## Chargement des traces S4 et construction du panel $(T,K)$> **Écart de nommage assumé.** Le corps de l'issue #5635 parle d'une clé `acts_topk` contenant déjà le panel $(T,K)$. **Il n'y a pas une telle clé dans les `.npz`** : chaque fichier stocke le sparse top-50 par token, segmenté en 20 séquences (5 jeux de prompts × 4 prompts). Le panel dense $(T,K)$ est **dérivé** par `ict.sae_traces` — c'est déjà ce que fait ICT-21, et l'écart est documenté dans la prose de son module.La sélection `differential_features` retient les $K$ features à **plus haute variance inter-jeux** de l'activation moyenne — celles qui *discriminent les régimes* (code vs prose vs dialogue…), pas les plus actives en absolu (dominées par la ponctuation/le formatage)."
+    "## Chargement des traces S4 et construction du panel $(T,K)$> **Écart de nommage assumé.** Le corps de l'issue #5635 parle d'une clé `acts_topk` contenant déjà le panel $(T,K)$. **Il n'y a pas une telle clé dans les `.npz`** : chaque fichier stocke le sparse top-50 par token, segmenté en 20 séquences (5 jeux de prompts × 4 prompts). Le panel dense $(T,K)$ est **dérivé** par `ict.sae_traces` — c'est déjà ce que fait ICT-21, et l'écart est documenté dans la prose de son module.\n",
+    "\n",
+    "La sélection `differential_features` retient les $K$ features à **plus haute variance inter-jeux** de l'activation moyenne — celles qui *discriminent les régimes* (code vs prose vs dialogue…), pas les plus actives en absolu (dominées par la ponctuation/le formatage).\n",
+    "\n"
    ]
   },
   {
@@ -127,7 +185,10 @@
    "id": "3daa9f54",
    "metadata": {},
    "source": [
-    "## Sanité : un panel synthétique où hub et ignition sont *plantés*Avant de faire confiance à l'appareil sur des traces réelles, on le valide sur un panneau synthétique où **on connaît la réponse** : un AR(1) $(T,K)$ avec un **hub d'influence planté** (la feature 0 pilote les features 5/6/7 au lag 3) et des **ignitions plantées** (cycles de bursting concentré). Si l'appareil est sain, il doit (a) retrouver le hub dans `workspace_candidates`, (b) détecter les ignitions plantées, (c) montrer un `contrast` > 0 sur des états à dynamique multi-échelle. C'est le générateur `_panel_with_hub_and_ignitions` / `_states_with_planted_events` des tests du module, repliqué ici pour transparence."
+    "## Sanité : un panel synthétique où hub et ignition sont *plantés*\n",
+    "\n",
+    "Avant de faire confiance à l'appareil sur des traces réelles, on le valide sur un panneau synthétique où **on connaît la réponse** : un AR(1) $(T,K)$ avec un **hub d'influence planté** (la feature 0 pilote les features 5/6/7 au lag 3) et des **ignitions plantées** (cycles de bursting concentré). Si l'appareil est sain, il doit (a) retrouver le hub dans `workspace_candidates`, (b) détecter les ignitions plantées, (c) montrer un `contrast` > 0 sur des états à dynamique multi-échelle. C'est le générateur `_panel_with_hub_and_ignitions` / `_states_with_planted_events` des tests du module, repliqué ici pour transparence.\n",
+    "\n"
    ]
   },
   {
@@ -228,7 +289,15 @@
    "id": "0e66d083",
    "metadata": {},
    "source": [
-    "## Gate 22 — Structure : un sous-ensemble à fan-out d'influence disproportionné ?Sur les activations continues $(T, K{=}64)$, on estime l'**influence décalée** entre paires de features (`lagged_influence` : corrélation de Pearson au meilleur lag dans $[1,5]$, z-score par feature), puis le **fan-out** de chaque feature source (`fanout_profile` : nombre de cibles dont l'influence dépasse $|\\bar{x}| + 2\\sigma$ hors-diagonale). Un **hub** est une feature à fan-out anormalement élevé. `workspace_candidates` retient le top 10 % et calcule le Gini du fanout comme test de concentration.**Deux contrôles honnêtes :**- **Modèle-contrôle** : le même calcul sur les traces `control` (embeddings d'entrée permutés — un modèle nul sans structure linguistique).- **Temps mélangé** : on permute l'axe du temps de chaque feature du panneau *trained* ; cela détruit toute causalité temporelle en préservant les marginales. Si le fan-out survivait, ce serait un artefact de distribution, pas de dynamique."
+    "## Gate 22 — Structure : un sous-ensemble à fan-out d'influence disproportionné ?\n",
+    "\n",
+    "Sur les activations continues $(T, K{=}64)$, on estime l'**influence décalée** entre paires de features (`lagged_influence` : corrélation de Pearson au meilleur lag dans $[1,5]$, z-score par feature), puis le **fan-out** de chaque feature source (`fanout_profile` : nombre de cibles dont l'influence dépasse $|\\bar{x}| + 2\\sigma$ hors-diagonale). Un **hub** est une feature à fan-out anormalement élevé. `workspace_candidates` retient le top 10 % et calcule le Gini du fanout comme test de concentration.\n",
+    "\n",
+    "**Deux contrôles honnêtes :**\n",
+    "\n",
+    "- **Modèle-contrôle** : le même calcul sur les traces `control` (embeddings d'entrée permutés — un modèle nul sans structure linguistique).\n",
+    "- **Temps mélangé** : on permute l'axe du temps de chaque feature du panneau *trained* ; cela détruit toute causalité temporelle en préservant les marginales. Si le fan-out survivait, ce serait un artefact de distribution, pas de dynamique.\n",
+    "\n"
    ]
   },
   {
@@ -311,7 +380,14 @@
    "id": "27c0a64e",
    "metadata": {},
    "source": [
-    "## Gate 23 — Co-localisation : les ignitions portent-elles les pics de complexité créditée ?**C'est le gate de réconciliation.** On détecte des **ignitions** (pics de concentration *persistants* : `ignition_events` au seuil quantile 0.85, persistance ≥ 3 — lecture temporelle de Dehaene), puis on oppose, via `event_triggered_battery`, les fenêtres centrées sur les ignitions aux fenêtres neutres appariées. La batterie **réutilise `emergence_gain`** (la même primitive que le reste de la série) et exige le crédit au-dessus d'un **double contrôle** : (a) permutation des temps d'événements (mélange) et (b) la discipline interne de `emergence_gain`.Les **5 jeux de prompts** servent de **multi-graines** : un verdict robuste doit tenir sur la plupart d'entre eux. Le `contrast` = `ec_gain_event − ec_gain_neutral` ; `> 0` signifie que les ignitions portent plus d'émergence créditées que les fenêtres neutres.> **Note de support statistique.** Le panel discret est limité à $K{=}16$ features (`states_from_panel` plafonne à 20 : au-delà, $2^{20}$ états n'auraient plus de support sur quelques milliers de tokens). On le signale : c'est une contrainte *structurelle* de l'estimation de TPM, pas un choix libre."
+    "## Gate 23 — Co-localisation : les ignitions portent-elles les pics de complexité créditée ?\n",
+    "\n",
+    "**C'est le gate de réconciliation.** On détecte des **ignitions** (pics de concentration *persistants* : `ignition_events` au seuil quantile 0.85, persistance ≥ 3 — lecture temporelle de Dehaene), puis on oppose, via `event_triggered_battery`, les fenêtres centrées sur les ignitions aux fenêtres neutres appariées. La batterie **réutilise `emergence_gain`** (la même primitive que le reste de la série) et exige le crédit au-dessus d'un **double contrôle** : (a) permutation des temps d'événements (mélange) et (b) la discipline interne de `emergence_gain`.\n",
+    "\n",
+    "Les **5 jeux de prompts** servent de **multi-graines** : un verdict robuste doit tenir sur la plupart d'entre eux. Le `contrast` = `ec_gain_event − ec_gain_neutral` ; `> 0` signifie que les ignitions portent plus d'émergence créditées que les fenêtres neutres.\n",
+    "\n",
+    "> **Note de support statistique.** Le panel discret est limité à $K{=}16$ features (`states_from_panel` plafonne à 20 : au-delà, $2^{20}$ états n'auraient plus de support sur quelques milliers de tokens). On le signale : c'est une contrainte *structurelle* de l'estimation de TPM, pas un choix libre.\n",
+    "\n"
    ]
   },
   {
@@ -382,7 +458,34 @@
    "id": "907fab70",
    "metadata": {},
    "source": [
-    "## Lecture honnête des résultatsOn lit les chiffres ci-dessus sur la grille de verdicts, **sans enjoliver**.### Gate 22 — structure présente, mais non spécifique au modèle entraîné- Le profil de fan-out trained exhibe bien quelques features à influence disproportionnée (max-fanout élevé).- **Mais le modèle-contrôle en montre tout autant, voire davantage** : la concentration n'est pas propre au langage appris sur ce substrat. Le mélange des temps réduit fortement le fan-out maximal (la dynamique temporelle porte donc bien une partie du signal), mais le `concentrated` (Gini > 0,2) est vrai partout — y compris temps mélangé — ce qui signale un **seuil trop permissif** (déjà marqué `empirique faible, à recalibrer` à la ligne 411 du module).- **Verdict : 22 partiel.** Une structure d'influence temporelle existe, mais elle n'est pas *spécifique* au modèle entraîné. On ne peut pas revendiquer un workspace propre au substrat linguistique sur ce seul indice.### Gate 23 — la co-localisation n'est pas établie- Le `contrast` moyen est **proche de zéro** et sa **dispersion entre jeux est grande** (certains positifs, d'autres négatifs).- La **fraction d'événements crédités est faible** (~17 %) : l'essentiel des ignitions ne porte pas plus d'émergence créditée que les fenêtres neutres.- Le modèle-contrôle, lui, a un espace d'états ~5–6× plus fragmenté (rapporté structurellement) : sa TPM n'a pas le support statistique d'une batterie stable — c'est déjà un signal, rapporté tel quel plutôt qu'en forçant une estimation non soutenable.### Branche observée : dissociation (22 partiel, 23KO)Le workspace structurel existe partiellement, mais **il ne porte pas les pics de complexité intégrée créditée**. Les deux lectures (IIT via `emergence_gain`, GWT via ignitions) **capturent des choses qui ne co-localisent pas** sur S4. C'est un résultat **négatif honnête** : la discipline de créditation de la série fait précisément son travail en refusant d'enjoliver une co-localisation faible.**Ce qui n'est pas revendiqué.**- Ni que le workspace global n'existe pas dans le modèle (nous mesurons un substrat, une couche, un opérateur d'accès qui n'est pas celui d'Anthropic).- Ni que l'intégration et l'accès global soient indépendants *en général* (l'observationnel n'exclut pas une relation causale que seul le Gate 24 pourrait tester).- Ni que la lecture SAE égale la lecture J-lens : le fil J-lens (issue #5681) est une opérationnalisation distincte, à venir.Le verdict observationnel revient au **Gate 24** (phase 2, GPU) : si le clamp des features-workspace *n'effondre pas* les gains crédités plus qu'un clamp aléatoire, la dissociation sera confirmée comme **corrélationnelle et non causale** — une leçon méthodologique de premier ordre, à écrire telle quelle."
+    "## Lecture honnête des résultats\n",
+    "\n",
+    "On lit les chiffres ci-dessus sur la grille de verdicts, **sans enjoliver**.\n",
+    "\n",
+    "### Gate 22 — structure présente, mais non spécifique au modèle entraîné\n",
+    "\n",
+    "- Le profil de fan-out trained exhibe bien quelques features à influence disproportionnée (max-fanout élevé).\n",
+    "- **Mais le modèle-contrôle en montre tout autant, voire davantage** : la concentration n'est pas propre au langage appris sur ce substrat. Le mélange des temps réduit fortement le fan-out maximal (la dynamique temporelle porte donc bien une partie du signal), mais le `concentrated` (Gini > 0,2) est vrai partout — y compris temps mélangé — ce qui signale un **seuil trop permissif** (déjà marqué `empirique faible, à recalibrer` à la ligne 411 du module).\n",
+    "- **Verdict : 22 partiel.** Une structure d'influence temporelle existe, mais elle n'est pas *spécifique* au modèle entraîné. On ne peut pas revendiquer un workspace propre au substrat linguistique sur ce seul indice.\n",
+    "\n",
+    "### Gate 23 — la co-localisation n'est pas établie\n",
+    "\n",
+    "- Le `contrast` moyen est **proche de zéro** et sa **dispersion entre jeux est grande** (certains positifs, d'autres négatifs).\n",
+    "- La **fraction d'événements crédités est faible** (~17 %) : l'essentiel des ignitions ne porte pas plus d'émergence créditée que les fenêtres neutres.\n",
+    "- Le modèle-contrôle, lui, a un espace d'états ~5–6× plus fragmenté (rapporté structurellement) : sa TPM n'a pas le support statistique d'une batterie stable — c'est déjà un signal, rapporté tel quel plutôt qu'en forçant une estimation non soutenable.\n",
+    "\n",
+    "### Branche observée : dissociation (22 partiel, 23KO)\n",
+    "\n",
+    "Le workspace structurel existe partiellement, mais **il ne porte pas les pics de complexité intégrée créditée**. Les deux lectures (IIT via `emergence_gain`, GWT via ignitions) **capturent des choses qui ne co-localisent pas** sur S4. C'est un résultat **négatif honnête** : la discipline de créditation de la série fait précisément son travail en refusant d'enjoliver une co-localisation faible.\n",
+    "\n",
+    "**Ce qui n'est pas revendiqué.**\n",
+    "\n",
+    "- Ni que le workspace global n'existe pas dans le modèle (nous mesurons un substrat, une couche, un opérateur d'accès qui n'est pas celui d'Anthropic).\n",
+    "- Ni que l'intégration et l'accès global soient indépendants *en général* (l'observationnel n'exclut pas une relation causale que seul le Gate 24 pourrait tester).\n",
+    "- Ni que la lecture SAE égale la lecture J-lens : le fil J-lens (issue #5681) est une opérationnalisation distincte, à venir.\n",
+    "\n",
+    "Le verdict observationnel revient au **Gate 24** (phase 2, GPU) : si le clamp des features-workspace *n'effondre pas* les gains crédités plus qu'un clamp aléatoire, la dissociation sera confirmée comme **corrélationnelle et non causale** — une leçon méthodologique de premier ordre, à écrire telle quelle.\n",
+    "\n"
    ]
   },
   {
@@ -390,7 +493,12 @@
    "id": "19f2844b",
    "metadata": {},
    "source": [
-    "## Gate 24 — Ablation sélective (phase 2, GPU)Seul gate **causal**. On ré-extrait des traces S4 avec un **clamp** des features-workspace identifiées au Gate 22 (mises à une constante), versus le clamp d'autant de features aléatoires hors-workspace (même compte). Si les gains crédités s'effondrent **sélectivement** sous le clamp workspace et pas sous le clamp aléatoire, c'est le miroir de l'expérience-titre d'Anthropic — la seule mesure interventionnelle de l'issue.Ce gate exige le pipeline d'extraction GPU2 (`CUDA_VISIBLE_DEVICES=2` strict, vLLM occupe GPU 0-1) et produit de nouvelles traces `.npz` ablatées. Il est **délégué à une phase 2 séparée** (PR distincte) : les Gates 22-23 livrent un verdict observationnel sans l'attendre, conformément à l'architecture de l'issue #5635."
+    "## Gate 24 — Ablation sélective (phase 2, GPU)\n",
+    "\n",
+    "Seul gate **causal**. On ré-extrait des traces S4 avec un **clamp** des features-workspace identifiées au Gate 22 (mises à une constante), versus le clamp d'autant de features aléatoires hors-workspace (même compte). Si les gains crédités s'effondrent **sélectivement** sous le clamp workspace et pas sous le clamp aléatoire, c'est le miroir de l'expérience-titre d'Anthropic — la seule mesure interventionnelle de l'issue.\n",
+    "\n",
+    "Ce gate exige le pipeline d'extraction GPU2 (`CUDA_VISIBLE_DEVICES=2` strict, vLLM occupe GPU 0-1) et produit de nouvelles traces `.npz` ablatées. Il est **délégué à une phase 2 séparée** (PR distincte) : les Gates 22-23 livrent un verdict observationnel sans l'attendre, conformément à l'architecture de l'issue #5635.\n",
+    "\n"
    ]
   },
   {
@@ -431,7 +539,12 @@
    "id": "dc71ad94",
    "metadata": {},
    "source": [
-    "## Exercice 1 — le workspace est-il spécifique aux LLMs ?On a mesuré la concentration/ignition sur S4 (un LLM). La même batterie s'applique à un substrat non-LLM : réutiliser un panneau d'ICT-2 (Gray-Scott, S2) ou ICT-5 (réplicateur, S3) et tester si un sous-ensemble de cellules y présente un fan-out disproportionné et des ignitions.**Indices.** `# Étape 1` : charger un panneau d'activations d'un substrat morphogénétique (cf. `ict/reaction_diffusion.py`). `# Étape 2` : le formater en $(T,K)$ consommable par `concentration_series`. `# Étape 3` : comparer le Gini du fanout à celui de S4."
+    "## Exercice 1 — le workspace est-il spécifique aux LLMs ?\n",
+    "\n",
+    "On a mesuré la concentration/ignition sur S4 (un LLM). La même batterie s'applique à un substrat non-LLM : réutiliser un panneau d'ICT-2 (Gray-Scott, S2) ou ICT-5 (réplicateur, S3) et tester si un sous-ensemble de cellules y présente un fan-out disproportionné et des ignitions.\n",
+    "\n",
+    "**Indices.** `# Étape 1` : charger un panneau d'activations d'un substrat morphogénétique (cf. `ict/reaction_diffusion.py`). `# Étape 2` : le formater en $(T,K)$ consommable par `concentration_series`. `# Étape 3` : comparer le Gini du fanout à celui de S4.\n",
+    "\n"
    ]
   },
   {
@@ -470,7 +583,10 @@
    "id": "9c75c6ff",
    "metadata": {},
    "source": [
-    "## Exercice 2 — sensibilité du Gate 23 à la taille de fenêtreLe `contrast` du Gate 23 dépend du paramètre `window` (demi-largeur de la fenêtre event-triggered). Les jambes F et K de `emergence_gain` sont notoirement bruitées sur les fenêtres courtes (zlib notamment). Tester la robustesse : recalculer le `contrast` moyen trained pour `window` ∈ {6, 12, 18, 24} et tracer la courbe."
+    "## Exercice 2 — sensibilité du Gate 23 à la taille de fenêtre\n",
+    "\n",
+    "Le `contrast` du Gate 23 dépend du paramètre `window` (demi-largeur de la fenêtre event-triggered). Les jambes F et K de `emergence_gain` sont notoirement bruitées sur les fenêtres courtes (zlib notamment). Tester la robustesse : recalculer le `contrast` moyen trained pour `window` ∈ {6, 12, 18, 24} et tracer la courbe.\n",
+    "\n"
    ]
   },
   {
@@ -509,7 +625,10 @@
    "id": "0ce96197",
    "metadata": {},
    "source": [
-    "## Exercice 3 — stabilité des hubs à la taille du panelLe Gate 22 utilise $K{=}64$ features. Les hubs détectés sont-ils stables quand on change cette résolution ? Répéter `differential_features(k=K)` + `workspace_candidates` pour $K \\in \\{32, 64, 128\\}$ et mesurer le recouvrement (Jaccard) des ensembles de candidats workspace."
+    "## Exercice 3 — stabilité des hubs à la taille du panel\n",
+    "\n",
+    "Le Gate 22 utilise $K{=}64$ features. Les hubs détectés sont-ils stables quand on change cette résolution ? Répéter `differential_features(k=K)` + `workspace_candidates` pour $K \\in \\{32, 64, 128\\}$ et mesurer le recouvrement (Jaccard) des ensembles de candidats workspace.\n",
+    "\n"
    ]
   },
   {
@@ -549,7 +668,21 @@
    "id": "59faf17c",
    "metadata": {},
    "source": [
-    "## ConclusionCe notebook confronte, **sur le même substrat S4 avec le même appareil**, la lecture IIT (complexité intégrée créditée) et la lecture GWT (workspace global / ignition). Le résultat est un **négatif honnête** :- **Gate 22 (partiel)** : une structure d'influence temporelle concentrée existe, mais elle n'est pas spécifique au modèle entraîné — le contrôle la montre également, et le seuil de concentration s'avère trop permissif.- **Gate 23 (non crédité)** : les ignitions ne portent pas, de façon robuste, les pics de complexité intégrée créditée. Le contrast est proche de zéro, dispersé entre jeux, et la fraction d'événements crédités est faible.La **branche dissociation** est le verdict observationnel : sur ce substrat, cet opérateur d'accès et cette couche, les deux théories capturent des structures qui ne co-localisent pas. C'est précisément le genre de résultat que la discipline de créditation de la série est faite pour ne pas masquer.Le **Gate 24** (phase 2, GPU) tranchera la question causale : si le clamp sélectif n'effondre pas les gains, la dissociation sera confirmée comme corrélationnelle — une leçon méthodologique de premier ordre sur la différence entre *structure observable* et *mécanisme causal*.### Pont causal do-calculusL'opérateur `do` de Pearl est ici implicite : le Gate 24 **réalise** un `do(workspace = clampé)` — une intervention chirurgicale sur le graphe, contre un `do(autant de features aléatoires = clampées)`. La même armature formelle traverse la série : voir le [Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb), qui exécute l'échelle de Pearl et les trois règles sur `dowhy` (identification backdoor/front-door + estimation + réfutation), et relie cette série à Tweety-11, Infer-5 et PyMC-5."
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook confronte, **sur le même substrat S4 avec le même appareil**, la lecture IIT (complexité intégrée créditée) et la lecture GWT (workspace global / ignition). Le résultat est un **négatif honnête** :\n",
+    "\n",
+    "- **Gate 22 (partiel)** : une structure d'influence temporelle concentrée existe, mais elle n'est pas spécifique au modèle entraîné — le contrôle la montre également, et le seuil de concentration s'avère trop permissif.\n",
+    "- **Gate 23 (non crédité)** : les ignitions ne portent pas, de façon robuste, les pics de complexité intégrée créditée. Le contrast est proche de zéro, dispersé entre jeux, et la fraction d'événements crédités est faible.\n",
+    "\n",
+    "La **branche dissociation** est le verdict observationnel : sur ce substrat, cet opérateur d'accès et cette couche, les deux théories capturent des structures qui ne co-localisent pas. C'est précisément le genre de résultat que la discipline de créditation de la série est faite pour ne pas masquer.\n",
+    "\n",
+    "Le **Gate 24** (phase 2, GPU) tranchera la question causale : si le clamp sélectif n'effondre pas les gains, la dissociation sera confirmée comme corrélationnelle — une leçon méthodologique de premier ordre sur la différence entre *structure observable* et *mécanisme causal*.\n",
+    "\n",
+    "### Pont causal do-calculus\n",
+    "\n",
+    "L'opérateur `do` de Pearl est ici implicite : le Gate 24 **réalise** un `do(workspace = clampé)` — une intervention chirurgicale sur le graphe, contre un `do(autant de features aléatoires = clampées)`. La même armature formelle traverse la série : voir le [Notebook-pont — du graphe causal au do-calculus](../../Probas/DecisionTheory/Causal-Bridges/Do-Calculus-Bridge.ipynb), qui exécute l'échelle de Pearl et les trois règles sur `dowhy` (identification backdoor/front-door + estimation + réfutation), et relie cette série à Tweety-11, Infer-5 et PyMC-5.\n",
+    "\n"
    ]
   },
   {
@@ -557,7 +690,14 @@
    "id": "88dc0e55",
    "metadata": {},
    "source": [
-    "## Références- Anthropic, *Global Workspace in Claude* (2025) — [anthropic.com/research/global-workspace](https://www.anthropic.com/research/global-workspace). Opérateur d'accès = jacobien des logits ; broadcast mesuré structurellement ; preuve maîtresse = ablation sélective. IIT/Tononi absents ; claim limité à l'access-consciousness.- Baars, B. J. — *A Cognitive Theory of Consciousness* (Global Workspace Theory).- Dehaene, S., Naccache, L., Changeux, J.-P. — l'ignition temporelle (notre lecture `ignition_events`).- Jansma, K., Hoel, E. — *Engineering Emergence* (2025) — émergence causale multi-échelle, CE 2.0. Voir [ICT-5](ICT-5-CausalEmergence.ipynb).- Série ICT : [ICT-21](ICT-21-SAETrajectoires.ipynb) (substrat S4), [ICT-5](ICT-5-CausalEmergence.ipynb) (émergence causale), [ICT-Synthese](ICT-Synthese-CrossSubstrat.ipynb)."
+    "## Références\n",
+    "\n",
+    "- Anthropic, *Global Workspace in Claude* (2025) — [anthropic.com/research/global-workspace](https://www.anthropic.com/research/global-workspace). Opérateur d'accès = jacobien des logits ; broadcast mesuré structurellement ; preuve maîtresse = ablation sélective. IIT/Tononi absents ; claim limité à l'access-consciousness.\n",
+    "- Baars, B. J. — *A Cognitive Theory of Consciousness* (Global Workspace Theory).\n",
+    "- Dehaene, S., Naccache, L., Changeux, J.-P. — l'ignition temporelle (notre lecture `ignition_events`).\n",
+    "- Jansma, K., Hoel, E. — *Engineering Emergence* (2025) — émergence causale multi-échelle, CE 2.0. Voir [ICT-5](ICT-5-CausalEmergence.ipynb).\n",
+    "- Série ICT : [ICT-21](ICT-21-SAETrajectoires.ipynb) (substrat S4), [ICT-5](ICT-5-CausalEmergence.ipynb) (émergence causale), [ICT-Synthese](ICT-Synthese-CrossSubstrat.ipynb).\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
@
## What

`ICT-24-WorkspaceIgnition.ipynb` had **14 markdown cells** with all newlines stripped (collapsed-markdown defect #3966): headings, prose, GFM tables, blockquotes, ordered/bulleted lists, the ASCII architecture diagram (code fence) and inline math were glued onto single lines. As a result nbconvert/HTML rendering parsed **0 tables, 0 lists**, and the structure was illegible.

## Fix

Reconstructed each of the 14 cells canonically — inserted newlines at structural boundaries (headings `#`/`##`/`###`, GFM table rows + separator, bullets `- `, ordered `N. `, blockquotes `> `, code fence ```` ``` ````, ASCII-diagram connectors `│`/`▼`) while preserving **every character** of the original content.

## Verification (proofs)

- **Content invariant** — for each cell: `new.replace("\n","") == original.replace("\n","")` (byte-identical modulo newlines; only `\n` inserted, no character added/removed/changed).
- `scan_md_hierarchy.py` → **0/1 flagged** (was 14 collapsed cells).
- `nbformat.validate` → OK. 23 cells (9 code, 14 markdown).
- **Diff scope**: exactly the 14 markdown cells `[0,1,2,4,6,8,10,12,13,15,17,19,21,22]` changed; **0 code cells**, **0 outputs / execution_count drift**.
- CRLF = 0, no BOM, LF-only, `indent=1`.

## Scope

Markdown-only edit → **rule C.2 exception** (no kernel re-execution required; all code cells retain their committed outputs/execution_count). Same canonical collapsed-fix pattern as #6214 (HunyuanVideo), applied here to the last residual ICT-series notebook.

See #3966
@