### PR TITLE
fix(lean,ci): rephrase grothendieck root prose 'sorry' to filtered form (#6115 regression unblocks 5 PRs)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -38,7 +38,7 @@ Substance réelle :
 - `Grothendieck.MathlibMap` : table de correspondance entre les concepts
   formalisés ici et les modules Mathlib 4 sous-jacents.
 - `Grothendieck.Calibration` : calibration track (Epic #1453) - quelques
-  lemmes volontairement `sorry` pour gradient de difficulté du prouveur
+  lemmes volontairement laissés en `sorry`s pour le gradient de difficulté du prouveur
   multi-agent.
 - `Grothendieck.SieveLattice` : treillis des cribles sur un objet — clôtures,
   unions, intersections, relation d'inclusion.
@@ -78,7 +78,7 @@ Substance réelle :
   fidèle d'une catégorie C dans la catégorie de foncteurs [C^op, Ens],
   c_{x} ↦ Hom_C(-, x) (Grothendieck 1960, CatAlg).
 
-Tous les `sorry` ne sont pas comblés — la plupart sont des échafaudages
+Tous les `sorry`s ne sont pas comblés — la plupart sont des échafaudages
 intentionnels pour le prouveur multi-agent (cf. Epic #1453).
 
 ---
@@ -122,7 +122,7 @@ Substance (English):
 - `Grothendieck.MathlibMap`: correspondence table between the formalized
   concepts and the underlying Mathlib 4 modules.
 - `Grothendieck.Calibration`: calibration track (Epic #1453) - intentional
-  sorry as a difficulty gradient for the multi-agent prover.
+  these `sorry`s form a difficulty gradient for the multi-agent prover.
 - `Grothendieck.SieveLattice`: lattice of sieves on an object — closures,
   unions, intersections, inclusion order.
 - `Grothendieck.SieveOps`: sieve operations — inverse image, direct image,


### PR DESCRIPTION
## Problem

`grothendieck_lean` CI is RED on **every** PR pushed after 2026-07-11:
```
FAIL: sorry count (3) exceeds baseline (0)
```

Blocking: #6202, #6208, #6225, #6230, #6235 (all my i18n PRs, all UNSTABLE).

## Root cause (firsthand G.1)

PR **#6115** (grothendieck root aggregator bilingual FR+EN, merged 2026-07-11) added 3 prose mentions of \"sorry\" in comment blocks (describing scaffolding lemmas):

| Line | Text | Form |
|------|------|------|
| L41 (FR) | `lemmes volontairement \`sorry\` pour gradient...` | standalone `\`sorry\`` |
| L81 (FR) | `Tous les \`sorry\` ne sont pas comblés...` | standalone `\`sorry\`` |
| L125 (EN) | `sorry as a difficulty gradient...` | standalone `sorry` |
| L164 (EN) | `Not all \`sorry\`s are filled...` | **filtered** `\`sorry\`s` ✓ |

`lean-grothendieck.yml` uses `sorry-filter-mode: prose-header` (baseline 0), whose filter is `grep \"sorry\" | grep -viE \"sorries|sorry.s\"`. This excludes only the plural/possessive forms (`sorries`, `sorry's`, `` `sorry`s ``). The 3 standalone/backtick forms added by #6115 are **not** excluded → counted as phantom sorries → CI FAIL.

The workflow's documented design intent (lean-grothendieck.yml L10-15): *\"every Grothendieck module carries the boilerplate 'All sorry's eliminated' ... prose-header mode filters out the prose forms (sorries, sorry's) so the count reflects only sorry-as-tactic.\"* #6115's prose violated this assumption.

Baseline (0) + prose-header mode was set at #2743/#2751 (long before #6115). Pre-#6115 grothendieck PRs (e.g. #5734 merged 07-08) passed CI; post-#6115 all fail.

## Fix (comment-only, 3 lines)

Align the 3 unfiltered prose mentions to the filtered `` `sorry`s `` form (same as L164, which is already correctly excluded):

- L41: `volontairement \`sorry\`` → `volontairement laissés en \`sorry\`s`
- L81: `Tous les \`sorry\`` → `Tous les \`sorry\`s`
- L125: `sorry as a difficulty gradient` → `these \`sorry\`s form a difficulty gradient`

Meaning preserved exactly (still describes the scaffolding/difficulty-gradient purpose); only the grammatical form changes to match the filter.

## Verification

| Check | Result |
|-------|--------|
| prose-header count (`grep \"sorry\" \| grep -viE \"sorries\|sorry.s\" \| wc -l`) | **3 → 0** |
| Code body byte-identical to origin/main (nesting-aware strip) | **822 = 822 chars** ✓ |
| Block-comment delimiters balanced | ✓ |
| Real sorry count (nesting-strip `\bsorry\b`) | 0 (unchanged) |

Comment-only change (3 insertions, 3 deletions, all in comment blocks). No code, no sorry, no theorem change.

## After merge

CI re-runs on #6202/#6208/#6225/#6230/#6235 will see sorry count 0 = baseline 0 → PASS (their Lean build is already verified code-identical). This unblocks 5 PRs + all future grothendieck_lean work.

Note for reviewers: the cleaner long-term fix would be to improve the prose-header filter to catch the backtick form `` `sorry` ``, but that's a CI-infra change (ai-01 scope); this PR restores the baseline with a minimal comment-wording alignment that matches the workflow's documented intent.

See #4980 (i18n series, #6115 was part of it). No `Closes` (CI-hygiene fix, references #6115 as the regression source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)