### PR TITLE
docs(ml-randomforest,#5780): dissolve README figure mosaic into in-situ narrative

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/README.md
@@ -14,20 +14,47 @@ Monthly model training with biweekly rebalance (every other Monday). Prediction 
 
 Le notebook [`research.ipynb`](research.ipynb) teste cinq hypothèses sur les hyperparamètres du Random Forest — nombre d'estimateurs, profondeur maximale, seuil de prédiction, taille de l'univers et fréquence d'entraînement — puis synthétise l'importance des features. Provenance détaillée : [`MANIFEST.md`](assets/readme/MANIFEST.md).
 
-<table>
-<tr>
-<td align="center"><img src="assets/readme/mrf-h1-nestimators.png" alt="H1 nombre d'estimateurs" width="420"/><br/><sub>H1 — nombre d'estimateurs</sub></td>
-<td align="center"><img src="assets/readme/mrf-h2-maxdepth.png" alt="H2 profondeur maximale" width="420"/><br/><sub>H2 — profondeur maximale des arbres</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/mrf-h3-threshold.png" alt="H3 seuil de prédiction" width="420"/><br/><sub>H3 — seuil de prédiction</sub></td>
-<td align="center"><img src="assets/readme/mrf-h4-universe.png" alt="H4 taille de l'univers" width="420"/><br/><sub>H4 — taille de l'univers d'actifs</sub></td>
-</tr>
-<tr>
-<td align="center"><img src="assets/readme/mrf-h5-trainfreq.png" alt="H5 fréquence d'entraînement" width="420"/><br/><sub>H5 — fréquence d'entraînement</sub></td>
-<td align="center"><img src="assets/readme/mrf-synthese.png" alt="Synthèse importance des features" width="420"/><br/><sub>Synthèse — importance des features</sub></td>
-</tr>
-</table>
+**H1 — Nombre d'estimateurs.** Combien d'arbres (*n_estimators*) suffit-il d'agréger pour stabiliser la prédiction ? Trop peu d'arbres, la forêt reste bruitée ; au-delà d'un certain seuil, le gain marginal s'amenuise et l'on paie un coût de calcul croissant pour un plateau de performance.
+
+<p align="center">
+  <img src="assets/readme/mrf-h1-nestimators.png" alt="H1 nombre d'estimateurs" width="460"/><br>
+  <em>H1 — performance et stabilité vs nombre d'estimateurs.</em>
+</p>
+
+**H2 — Profondeur maximale.** Jusqu'où laisser chaque arbre croître (*max_depth*) : une profondeur faible sous-ajuste (arbres trop simples pour capturer la structure), une profondeur élevée sur-ajuste (mémorisation du bruit d'entraînement). Le bon régime sépare le signal du bruit.
+
+<p align="center">
+  <img src="assets/readme/mrf-h2-maxdepth.png" alt="H2 profondeur maximale" width="460"/><br>
+  <em>H2 — compromis biais/variance vs profondeur des arbres.</em>
+</p>
+
+**H3 — Seuil de prédiction.** Une position ne s'ouvre que si la probabilité prédite de rendement 10 jours dépasse un seuil (calibré à 0.54 en production). Un seuil bas multiplie les trades (bruit, coûts), un seuil haut restreint l'univers (concentration) — la courbe trace ce compromis sélectivité/fréquence.
+
+<p align="center">
+  <img src="assets/readme/mrf-h3-threshold.png" alt="H3 seuil de prédiction" width="460"/><br>
+  <em>H3 — performance et nombre de trades vs seuil de décision.</em>
+</p>
+
+**H4 — Taille de l'univers.** Élargir l'univers au-delà des 10 large-caps de référence : plus de candidats diversifie et multiplie les opportunités, mais peut aussi diluer le signal sous un bruit croissant. La courbe montre où s'arrête le bénéfice de la diversification.
+
+<p align="center">
+  <img src="assets/readme/mrf-h4-universe.png" alt="H4 taille de l'univers" width="460"/><br>
+  <em>H4 — performance vs taille de l'univers d'actifs.</em>
+</p>
+
+**H5 — Fréquence d'entraînement.** Le modèle est ré-entraîné mensuellement par défaut. Une cadence plus courte capite un régime changeant mais sur des fenêtres plus bruitées ; plus longue, elle lisse le signal au risque de rater les ruptures de marché.
+
+<p align="center">
+  <img src="assets/readme/mrf-h5-trainfreq.png" alt="H5 fréquence d'entraînement" width="460"/><br>
+  <em>H5 — performance vs fréquence de ré-entraînement.</em>
+</p>
+
+**Synthèse — importance des features.** Parmi les 12 *features* techniques (RSI, Bollinger, MACD, momentum, volatilité, volume, ratios de prix), lesquelles pilotent réellement la prédiction ? Le classement par importance (*impurity-based*) révèle la hiérarchie effective — un diagnostic de parcimonie : peut-on dropper les features peu contributives sans dégrader le modèle ?
+
+<p align="center">
+  <img src="assets/readme/mrf-synthese.png" alt="Synthèse importance des features" width="460"/><br>
+  <em>Synthèse — classement des features par importance.</em>
+</p>
 
 ## How to Run
 


### PR DESCRIPTION
## What

`ML-RandomForest/README.md` had a `<table>` mosaic — 6 images in a 3×2 grid (H1 n_estimators, H2 max_depth, H3 threshold, H4 universe, H5 train_freq, + Synthèse feature importance). Per #5780, dissolve into in-situ narrative.

## Fix

Each hypothesis figure now sits under a bolded conceptual lead describing what the hyperparameter tests:
- **H1 — Nombre d'estimateurs**: tree count vs noise/plateau.
- **H2 — Profondeur maximale**: bias/variance vs depth.
- **H3 — Seuil de prédiction**: selectivity/frequency tradeoff (0.54 production threshold).
- **H4 — Taille de l'univers**: diversification benefit limit.
- **H5 — Fréquence d'entraînement**: cadence vs regime-sensitivity.
- **Synthèse**: feature importance ranking (12 features) as a sparseness diagnostic.

Narrative describes what each hypothesis tests; the figure shows the result. No invented numeric outcomes.

## Verification

- **img src multiset identical** (6 refs, same paths + alts).
- **`<table>` 1 → 0**.
- No CATALOG-STATUS marker in this README (consistent base/new).
- 6 figure PNGs untouched; **1 file changed**, 41 ins / 14 del; CRLF=0, no BOM.

## Scope

Markdown-only, README-only. Same #5780 pattern as #6220 (AllWeather). Fresh sub-family (QC ML-strategy — not in po-2026's active comparative-backtest cohort DualMomentum/RiskParity/TrendFollowing/AdaptiveConformalRisk).

See #5780