### PR TITLE
docs(lean,#3979): fix knot_lean README stale sorry counts (Structure table + Conclusion)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.en.md
@@ -5,7 +5,7 @@ strategic commented sorries (paper references + Mathlib prerequisites).
 
 Epic #2874 (Phase 5 in progress). Toolchain `v4.31.0-rc1`.
 
-## Sorry-state (verified 2026-07-06, 16 real — 14 + 2 from the PARTIAL backward transfer #3124, `num` proven)
+## Sorry-state (verified 2026-07-06, re-confirmed 2026-07-12, 16 real — 14 + 2 from the PARTIAL backward transfer #3124, `num` proven)
 
 Two counts, depending on the filter:
 
@@ -294,8 +294,8 @@ Reference: Fox (1962), *A quick trip through knot theory*; Adams,
 | File | Contents | real sorries |
 |------|----------|-------------|
 | `Knots/Basic.lean` | Definitions (Knot, Link, PD-code, named knots), `KnotDiagram.wf` | 0 |
-| `Knots/Reidemeister.lean` | R1/R2/R3 moves (Phase 5 model), `ReidemeisterEquiv`, symmetries | 2 |
-| `Knots/Invariant.lean` | 3-colorability (Fox), crossing number, unknotting number, PR1 counter-example, R1 forward transfer (#3000) + backward PARTIAL (#3124) | 6 |
+| `Knots/Reidemeister.lean` | R1/R2/R3 moves (Phase 5 model), `ReidemeisterEquiv`, symmetries | 1 |
+| `Knots/Invariant.lean` | 3-colorability (Fox), crossing number, unknotting number, PR1 counter-example, R1 forward transfer (#3000) + backward PARTIAL (#3124) | 5 |
 | `Knots/Conway.lean` | Conway knot (11n34), Piccirillo, smooth/topological dichotomy | 8 |
 | `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 2 |
 | `Knots/MathlibPrerequisites.lean` | Index of missing Mathlib prerequisites by tier | 0 |
@@ -366,7 +366,7 @@ The marquee `tricolorable_invariant` remains **gated** on two
 §9.1 residual sub-goals of the backward: the symmetry of colors on the
 modified crossing `Y` (`fox`) and the all-distinct lift outside the
 source diagram range (`col`). Their completion would compose forward +
-backward into a connected R1 bi-implication (**17 real sorries** in
+backward into a connected R1 bi-implication (**16 real sorries** in
 total). The "distant" results — Conway non-slice (Piccirillo), Lidman's
 unknotting number, Reidemeister theorem ↔ ambient isotopy — remain
 **permanent scaffolding**: they exceed the current scope of Mathlib

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
@@ -5,7 +5,7 @@ avec sorry stratégiques commentés (références papier + prérequis Mathlib).
 
 Epic #2874 (Phase 5 en cours). Toolchain `v4.31.0-rc1`.
 
-## État des sorries (vérifié 2026-07-06, 16 réels — 14 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
+## État des sorries (vérifié 2026-07-06, re-confirmé 2026-07-12, 16 réels — 14 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
 
 Deux comptes, selon le filtre :
 
@@ -255,8 +255,8 @@ Référence : Fox (1962), A quick trip through knot theory ; Adams, *The Knot Bo
 | Fichier | Contenu | sorry réels |
 |---------|---------|-------------|
 | `Knots/Basic.lean` | Définitions (Knot, Link, PD-code, nœuds nommés), `KnotDiagram.wf` | 0 |
-| `Knots/Reidemeister.lean` | Mouvements R1/R2/R3 (modèle Phase 5), `ReidemeisterEquiv`, symétries | 2 |
-| `Knots/Invariant.lean` | 3-colorabilité (Fox), crossing number, unknotting number, contre-exemple PR1, transfer R1 forward (#3000) + backward PARTIEL (#3124) | 6 |
+| `Knots/Reidemeister.lean` | Mouvements R1/R2/R3 (modèle Phase 5), `ReidemeisterEquiv`, symétries | 1 |
+| `Knots/Invariant.lean` | 3-colorabilité (Fox), crossing number, unknotting number, contre-exemple PR1, transfer R1 forward (#3000) + backward PARTIEL (#3124) | 5 |
 | `Knots/Conway.lean` | Nœud de Conway (11n34), Piccirillo, dichotomie lisse/topologique | 8 |
 | `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 2 |
 | `Knots/MathlibPrerequisites.lean` | Index des prérequis Mathlib manquants par tier | 0 |
@@ -326,7 +326,7 @@ Le marquee `tricolorable_invariant` reste **gated** sur deux sous-buts résiduel
 §9.1 du backward : la symétrie des couleurs sur le crossing modifié `Y` (`fox`) et
 le lift « all-distinct » hors range du diagramme source (`col`). Leur clôture
 permettrait de composer forward + backward en une bi-implication R1 connectée
-(**17 sorry réels** au total). Les résultats « lointains » — Conway non-slice
+(**16 sorry réels** au total). Les résultats « lointains » — Conway non-slice
 (Piccirillo), unknotting number de Lidman, théorème Reidemeister ↔ isotopie
 ambiante — restent du **scaffolding permanent** : ils excèdent la portée actuelle
 de Mathlib (topologie PL des 3-variétés, Heegaard-Floer).


### PR DESCRIPTION
## What

§E whole-file audit of the `knot_lean` README (FR primary + EN golden sibling), part of [#3979](https://github.com/jsboige/CoursIA/issues/3979) (READMEs feuilles — Knot / Grothendieck / Lean math).

## Finding

The README's **authoritative top table** (L8, "16 réels") and its **L29 correction note** ("Reidemeister stable à 1 depuis juin") were contradicted **230 lines down** by the **Structure table** (L258-259: Reidemeister=2, Invariant=6) and the **Conclusion** ("17 sorry réels"). Those two sections had not been refreshed when the sorry counts moved.

## Firsthand recount (2026-07-12)

Strip-docstring + strip-comment scan against the actual `.lean` source (the reliable method, `.lake` excluded):

| File | real sorry |
|------|------------|
| `Knots/Basic.lean` | 0 |
| `Knots/Reidemeister.lean` | **1** (Structure table said 2) |
| `Knots/Invariant.lean` | **5** (Structure table said 6) |
| `Knots/Conway.lean` | 8 |
| `Knots/Lidman.lean` | 2 |
| `Knots/MathlibPrerequisites.lean` | 0 |
| **Total** | **16** |

This matches the top table and the L29 note exactly. The Structure table + Conclusion figure were the stale outliers.

## Fix

6 edits (identical content FR + EN):
- Structure table: Reidemeister `2 -> 1`, Invariant `6 -> 5`.
- Conclusion "verrou" section: `17 sorry réels` -> `16 sorry réels`.
- Header date: appended "re-confirmed 2026-07-12".

## Checks

- No code change, no catalogue churn (byte-identical), markdown-only (C.2 exec exception).
- LF-only (CR = 0 verified in diff).
- One-subject: `knot_lean` README only. The other Lean-math READMEs in #3979's scope (Grothendieck) are a separate PR.

See #3979
See #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
