### PR TITLE
fix(notebook-tools): remove invalid escape sequence in scan_md_hierarchy docstring

### DIFF
--- a/scripts/notebook_tools/scan_md_hierarchy.py
+++ b/scripts/notebook_tools/scan_md_hierarchy.py
@@ -92,7 +92,7 @@ def _strip_fenced_code(cell_text):
     FENCE_RE; fence-marker lines are kept, code lines between them are blanked.
 
     A truly COLLAPSED cell (newlines stripped, the fence opener ``` glued to a
-    heading like `### Archi \`\`\` ...`) has no real fence structure: the glued
+    heading like `### Archi ``` ...`) has no real fence structure: the glued
     line does not START with ``` (FENCE_RE is anchored), so nothing is blanked
     and the glued table fragment is still detected -> correct (true positive
     preserved). See Lean-12 cell 16 FP (#3966).


### PR DESCRIPTION
## Défaut

`scripts/notebook_tools/scan_md_hierarchy.py:95` — la docstring de `_strip_fenced_code` échappait les backticks markdown avec un anti-shell (`\``). Or **le backtick n'est pas un caractère escapable en Python** → `SyntaxWarning: invalid escape sequence '\`'`, qui devient **erreur fatale** sous `-W error::SyntaxWarning` (Python 3.12+).

```python
# avant (L95) — escape invalide
heading like `### Archi \`\`\` ...`) has no real fence structure
```

Le scanner levait donc un warning à chaque import / exécution (visible dans les logs CI et à l'appel `--help`).

## Fix

Les backticks sont **littéraux** dans une string Python — on supprime les anti-shells parasites. La docstring affiche maintenant l'exemple de fence markdown proprement :

```python
# après (L95)
heading like `### Archi ``` ...`) has no real fence structure
```

## Scope (anti-G.4)

- **1 ligne** (L95, docstring uniquement). 0 ligne de code exécutable modifiée.
- Le `\n` valide de l'exemple file-tree L89 (`sensitivity_lean/\n|-- lakefile`) est **laissé tel quel** : escape valide, pas de warning, hors scope.

## Validation

| Check | Avant | Après |
|-------|-------|-------|
| `python -W error::SyntaxWarning -c "import scan_md_hierarchy"` | SyntaxError | OK |
| Détection COLLAPSED-MARKDOWN (régression) | 3/957 | 3/957 (identique) |
| Rendu docstring `help()` | backticks échappés `\`` | backticks propres `` ` `` |

Le scanner canonique de détection collapsed-markdown (#3966/#6199) reste pleinement fonctionnel — aucune régression sur les 3 notebooks résiduels qu'il flag.

Co-authored-by: Claude Opus 4.8
