### PR TITLE
fix(smartcontracts): SC-8 kernel mismatch coursia-semanticweb -> python3

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.003007,
-     "end_time": "2026-06-08T00:51:17.034277",
+     "duration": 0.003342,
+     "end_time": "2026-07-12T02:19:13.257502+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.031270",
+     "start_time": "2026-07-12T02:19:13.254160+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "web3-setup-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002517,
-     "end_time": "2026-06-08T00:51:17.040817",
+     "duration": 0.00256,
+     "end_time": "2026-07-12T02:19:13.263776+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.038300",
+     "start_time": "2026-07-12T02:19:13.261216+00:00",
      "status": "completed"
     },
     "tags": []
@@ -64,16 +64,16 @@
    "id": "web3-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:51:17.047835Z",
-     "iopub.status.busy": "2026-06-08T00:51:17.047835Z",
-     "iopub.status.idle": "2026-06-08T00:51:17.600638Z",
-     "shell.execute_reply": "2026-06-08T00:51:17.600638Z"
+     "iopub.execute_input": "2026-07-12T02:19:13.271267Z",
+     "iopub.status.busy": "2026-07-12T02:19:13.270790Z",
+     "iopub.status.idle": "2026-07-12T02:19:14.016617Z",
+     "shell.execute_reply": "2026-07-12T02:19:14.015850Z"
     },
     "papermill": {
-     "duration": 0.557809,
-     "end_time": "2026-06-08T00:51:17.601643",
+     "duration": 0.75069,
+     "end_time": "2026-07-12T02:19:14.017186+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.043834",
+     "start_time": "2026-07-12T02:19:13.266496+00:00",
      "status": "completed"
     },
     "tags": []
@@ -143,10 +143,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.003131,
-     "end_time": "2026-06-08T00:51:17.607775",
+     "duration": 0.002276,
+     "end_time": "2026-07-12T02:19:14.021925+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.604644",
+     "start_time": "2026-07-12T02:19:14.019649+00:00",
      "status": "completed"
     },
     "tags": []
@@ -172,16 +172,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:51:17.613118Z",
-     "iopub.status.busy": "2026-06-08T00:51:17.613118Z",
-     "iopub.status.idle": "2026-06-08T00:51:17.617653Z",
-     "shell.execute_reply": "2026-06-08T00:51:17.617653Z"
+     "iopub.execute_input": "2026-07-12T02:19:14.027076Z",
+     "iopub.status.busy": "2026-07-12T02:19:14.026914Z",
+     "iopub.status.idle": "2026-07-12T02:19:14.031575Z",
+     "shell.execute_reply": "2026-07-12T02:19:14.030971Z"
     },
     "papermill": {
-     "duration": 0.009192,
-     "end_time": "2026-06-08T00:51:17.618938",
+     "duration": 0.008289,
+     "end_time": "2026-07-12T02:19:14.032342+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.609746",
+     "start_time": "2026-07-12T02:19:14.024053+00:00",
      "status": "completed"
     },
     "tags": []
@@ -256,10 +256,10 @@
    "id": "adca94a8",
    "metadata": {
     "papermill": {
-     "duration": 0.003346,
-     "end_time": "2026-06-08T00:51:17.624310",
+     "duration": 0.002649,
+     "end_time": "2026-07-12T02:19:14.037235+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.620964",
+     "start_time": "2026-07-12T02:19:14.034586+00:00",
      "status": "completed"
     },
     "tags": []
@@ -281,16 +281,16 @@
    "id": "fd4bd926",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:51:17.632030Z",
-     "iopub.status.busy": "2026-06-08T00:51:17.631029Z",
-     "iopub.status.idle": "2026-06-08T00:51:17.635020Z",
-     "shell.execute_reply": "2026-06-08T00:51:17.635020Z"
+     "iopub.execute_input": "2026-07-12T02:19:14.042999Z",
+     "iopub.status.busy": "2026-07-12T02:19:14.042806Z",
+     "iopub.status.idle": "2026-07-12T02:19:14.046333Z",
+     "shell.execute_reply": "2026-07-12T02:19:14.045795Z"
     },
     "papermill": {
-     "duration": 0.008715,
-     "end_time": "2026-06-08T00:51:17.636025",
+     "duration": 0.007371,
+     "end_time": "2026-07-12T02:19:14.047071+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.627310",
+     "start_time": "2026-07-12T02:19:14.039700+00:00",
      "status": "completed"
     },
     "tags": []
@@ -343,10 +343,10 @@
    "id": "ca6ad53a",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-06-08T00:51:17.642026",
+     "duration": 0.002208,
+     "end_time": "2026-07-12T02:19:14.051588+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.639024",
+     "start_time": "2026-07-12T02:19:14.049380+00:00",
      "status": "completed"
     },
     "tags": []
@@ -379,10 +379,10 @@
    "id": "lhfs9v9mglt",
    "metadata": {
     "papermill": {
-     "duration": 0.002488,
-     "end_time": "2026-06-08T00:51:17.646873",
+     "duration": 0.002279,
+     "end_time": "2026-07-12T02:19:14.056169+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.644385",
+     "start_time": "2026-07-12T02:19:14.053890+00:00",
      "status": "completed"
     },
     "tags": []
@@ -397,16 +397,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:51:17.654501Z",
-     "iopub.status.busy": "2026-06-08T00:51:17.653976Z",
-     "iopub.status.idle": "2026-06-08T00:51:21.720400Z",
-     "shell.execute_reply": "2026-06-08T00:51:21.720400Z"
+     "iopub.execute_input": "2026-07-12T02:19:14.061361Z",
+     "iopub.status.busy": "2026-07-12T02:19:14.061212Z",
+     "iopub.status.idle": "2026-07-12T02:19:14.418080Z",
+     "shell.execute_reply": "2026-07-12T02:19:14.417481Z"
     },
     "papermill": {
-     "duration": 4.071398,
-     "end_time": "2026-06-08T00:51:21.721634",
+     "duration": 0.360465,
+     "end_time": "2026-07-12T02:19:14.418842+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:17.650236",
+     "start_time": "2026-07-12T02:19:14.058377+00:00",
      "status": "completed"
     },
     "tags": []
@@ -416,44 +416,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: TestToken a 0x5FbDB2315678afecb367f032d93F642f64180aa3\n"
+      "Deploye: TestToken a 0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: TestToken a 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512\n"
+      "Deploye: TestToken a 0x9A676e781A523b5d0C0e43731313A708CB607508\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: SimpleAMM a 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Deploye: SimpleAMM a 0x0B306BF915C4d645ff596e518fAf3F9669b97016\n",
       "\n",
-      "Liquidite ajoutee:\n",
-      "  Reserve WETH : 100\n"
+      "Liquidite ajoutee:\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  Reserve WETH : 100\n",
       "  Reserve USDC : 200000\n",
-      "  Prix WETH    : 2000.00 USDC\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Prix WETH    : 2000.00 USDC\n",
       "\n",
       "Swap 5 WETH -> USDC:\n",
       "  USDC recu       : 9496.59\n",
@@ -724,10 +712,10 @@
    "id": "369f6928",
    "metadata": {
     "papermill": {
-     "duration": 0.003679,
-     "end_time": "2026-06-08T00:51:21.727802",
+     "duration": 0.002849,
+     "end_time": "2026-07-12T02:19:14.424961+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:21.724123",
+     "start_time": "2026-07-12T02:19:14.422112+00:00",
      "status": "completed"
     },
     "tags": []
@@ -759,10 +747,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.003497,
-     "end_time": "2026-06-08T00:51:21.733685",
+     "duration": 0.002426,
+     "end_time": "2026-07-12T02:19:14.430029+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:21.730188",
+     "start_time": "2026-07-12T02:19:14.427603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -782,16 +770,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:51:21.741416Z",
-     "iopub.status.busy": "2026-06-08T00:51:21.740399Z",
-     "iopub.status.idle": "2026-06-08T00:51:21.745420Z",
-     "shell.execute_reply": "2026-06-08T00:51:21.745420Z"
+     "iopub.execute_input": "2026-07-12T02:19:14.436130Z",
+     "iopub.status.busy": "2026-07-12T02:19:14.435925Z",
+     "iopub.status.idle": "2026-07-12T02:19:14.440318Z",
+     "shell.execute_reply": "2026-07-12T02:19:14.439801Z"
     },
     "papermill": {
-     "duration": 0.009521,
-     "end_time": "2026-06-08T00:51:21.746661",
+     "duration": 0.008536,
+     "end_time": "2026-07-12T02:19:14.440936+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:21.737140",
+     "start_time": "2026-07-12T02:19:14.432400+00:00",
      "status": "completed"
     },
     "tags": []
@@ -850,10 +838,10 @@
    "id": "f2b36324",
    "metadata": {
     "papermill": {
-     "duration": 0.003079,
-     "end_time": "2026-06-08T00:51:21.752307",
+     "duration": 0.002473,
+     "end_time": "2026-07-12T02:19:14.445821+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:21.749228",
+     "start_time": "2026-07-12T02:19:14.443348+00:00",
      "status": "completed"
     },
     "tags": []
@@ -876,16 +864,16 @@
    "id": "7cb7940a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:51:21.760206Z",
-     "iopub.status.busy": "2026-06-08T00:51:21.759201Z",
-     "iopub.status.idle": "2026-06-08T00:51:21.763298Z",
-     "shell.execute_reply": "2026-06-08T00:51:21.763298Z"
+     "iopub.execute_input": "2026-07-12T02:19:14.451853Z",
+     "iopub.status.busy": "2026-07-12T02:19:14.451670Z",
+     "iopub.status.idle": "2026-07-12T02:19:14.455364Z",
+     "shell.execute_reply": "2026-07-12T02:19:14.454849Z"
     },
     "papermill": {
-     "duration": 0.008627,
-     "end_time": "2026-06-08T00:51:21.764438",
+     "duration": 0.007536,
+     "end_time": "2026-07-12T02:19:14.456111+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:21.755811",
+     "start_time": "2026-07-12T02:19:14.448575+00:00",
      "status": "completed"
     },
     "tags": []
@@ -938,10 +926,10 @@
    "id": "109e0e13",
    "metadata": {
     "papermill": {
-     "duration": 0.001,
-     "end_time": "2026-06-08T00:51:21.768443",
+     "duration": 0.002497,
+     "end_time": "2026-07-12T02:19:14.461138+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:21.767443",
+     "start_time": "2026-07-12T02:19:14.458641+00:00",
      "status": "completed"
     },
     "tags": []
@@ -972,10 +960,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.004012,
-     "end_time": "2026-06-08T00:51:21.776628",
+     "duration": 0.002482,
+     "end_time": "2026-07-12T02:19:14.466230+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:21.772616",
+     "start_time": "2026-07-12T02:19:14.463748+00:00",
      "status": "completed"
     },
     "tags": []
@@ -997,16 +985,16 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:51:21.786430Z",
-     "iopub.status.busy": "2026-06-08T00:51:21.786430Z",
-     "iopub.status.idle": "2026-06-08T00:51:25.308972Z",
-     "shell.execute_reply": "2026-06-08T00:51:25.307967Z"
+     "iopub.execute_input": "2026-07-12T02:19:14.472074Z",
+     "iopub.status.busy": "2026-07-12T02:19:14.471887Z",
+     "iopub.status.idle": "2026-07-12T02:19:14.734547Z",
+     "shell.execute_reply": "2026-07-12T02:19:14.733702Z"
     },
     "papermill": {
-     "duration": 3.526853,
-     "end_time": "2026-06-08T00:51:25.308972",
+     "duration": 0.266603,
+     "end_time": "2026-07-12T02:19:14.735282+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:21.782119",
+     "start_time": "2026-07-12T02:19:14.468679+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1016,14 +1004,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: TestToken a 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6\n"
+      "Deploye: TestToken a 0x59b670e9fA9D0A427751Af201D676719a970857b\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: SimpleLending a 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318\n"
+      "Deploye: SimpleLending a 0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1\n"
      ]
     },
     {
@@ -1234,10 +1222,10 @@
    "id": "e06f11c6",
    "metadata": {
     "papermill": {
-     "duration": 0.002891,
-     "end_time": "2026-06-08T00:51:25.315863",
+     "duration": 0.003058,
+     "end_time": "2026-07-12T02:19:14.741705+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:25.312972",
+     "start_time": "2026-07-12T02:19:14.738647+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1258,16 +1246,16 @@
    "id": "07e4e023",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:51:25.322953Z",
-     "iopub.status.busy": "2026-06-08T00:51:25.322953Z",
-     "iopub.status.idle": "2026-06-08T00:51:25.326044Z",
-     "shell.execute_reply": "2026-06-08T00:51:25.326044Z"
+     "iopub.execute_input": "2026-07-12T02:19:14.750464Z",
+     "iopub.status.busy": "2026-07-12T02:19:14.750220Z",
+     "iopub.status.idle": "2026-07-12T02:19:14.755077Z",
+     "shell.execute_reply": "2026-07-12T02:19:14.754286Z"
     },
     "papermill": {
-     "duration": 0.008011,
-     "end_time": "2026-06-08T00:51:25.327057",
+     "duration": 0.01074,
+     "end_time": "2026-07-12T02:19:14.755678+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:25.319046",
+     "start_time": "2026-07-12T02:19:14.744938+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1315,10 +1303,10 @@
    "id": "b162cadb",
    "metadata": {
     "papermill": {
-     "duration": 0.00336,
-     "end_time": "2026-06-08T00:51:25.333429",
+     "duration": 0.003441,
+     "end_time": "2026-07-12T02:19:14.762388+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:25.330069",
+     "start_time": "2026-07-12T02:19:14.758947+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1354,10 +1342,10 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.003018,
-     "end_time": "2026-06-08T00:51:25.379086",
+     "duration": 0.003385,
+     "end_time": "2026-07-12T02:19:14.769069+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:25.376068",
+     "start_time": "2026-07-12T02:19:14.765684+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1390,10 +1378,10 @@
    "id": "ce0c139e",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-06-08T00:51:25.385069",
+     "duration": 0.003392,
+     "end_time": "2026-07-12T02:19:14.775792+00:00",
      "exception": false,
-     "start_time": "2026-06-08T00:51:25.382068",
+     "start_time": "2026-07-12T02:19:14.772400+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1407,9 +1395,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (CoursIA SemanticWeb)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "coursia-semanticweb"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1421,18 +1409,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 9.641838,
-   "end_time": "2026-06-08T00:51:25.620845",
+   "duration": 3.698738,
+   "end_time": "2026-07-12T02:19:15.121944+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "SC-8-DeFi-Primitives.ipynb",
-   "output_path": "SC-8-DeFi-Primitives.ipynb",
+   "output_path": "sc8_out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-08T00:51:15.979007",
+   "start_time": "2026-07-12T02:19:11.423206+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Défaut

`SC-8-DeFi-Primitives.ipynb` déclarait le kernel **`coursia-semanticweb`** (display « Python (CoursIA SemanticWeb) ») mais n'importe **aucun** module semanticweb : seuls `web3`, `solcx`, `math`.

Or `web3` (7.16.0) et `solcx` sont **disponibles dans le kernel `python3` standard** (vérifié). Le kernel `coursia-semanticweb` imposait donc une **dépendance inutile** aux étudiants (env conda `coursia-semanticweb` avec rdflib/owlreadyz, overkill pour SC-8). Tous les autres notebooks `SC-0`..`SC-17` utilisent `python3`. Probable copier-coller d'un notebook SemanticWeb à la création.

## Fix

`kernelspec` : `coursia-semanticweb` → `python3` (display « Python 3 »), aligné sur la convention SC-0..17.

## Validation (C.2 — Stop & Repair, vrai outil SOTA)

**Re-exécution complète** avec kernel `python3` contre un node **anvil local** (Foundry, chain 31337) via papermill — pas un workaround, le vrai outil SmartContracts (`~/.foundry/bin/anvil` déjà installé) :

| Check | Résultat |
|-------|----------|
| Cellules exécutées | 8/8 (`execution_count` 1..8) |
| Erreurs | 0 |
| Deploys | TestToken + SimpleLending déployés (anvil real) |
| Lending Pool | « Safe », Health Factor 1.7000 |
| H.3 pre-commit | PASS (0 cell code non-exécutée) |

Outputs régénérés (addresses de deploy différentes du commit précédent car l'état anvil est éphémère, mais le scénario pédagogique est identique).

## Anti-régression (G.1)

- **Code source + markdown byte-identical** à `origin/main` (vérifié programmatically : `oc==fc`, `om==fm`, 23 cells == 23 cells).
- Seuls `kernelspec` + `outputs` + `papermill metadata` ont changé.
- **Aucun secret** dans le diff (les `0x...` sont des addresses de contrats anvil locales, pas des clés).
- CRLF = 0 (ré-écrit en LF via `write_bytes`, cohérent repo).

## Scope (anti-G.4)

Single file, single concern (kernel metadata + re-exec).

Co-authored-by: Claude Opus 4.8
