### PR TITLE
feat(prover): run LSP exact?/apply? search concurrently (halve wall-clock, unblock P4 traces)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -480,8 +480,21 @@ class SearchTools:
         return json.dumps(found, indent=2, ensure_ascii=False)
 
     def _search_via_lsp(self, goal: str) -> list:
-        """Search Mathlib using Lean LSP via exact?/apply? tactics."""
+        """Search Mathlib using Lean LSP via exact?/apply? tactics.
+
+        Runs both tactics CONCURRENTLY. Each ``verifier.search_lean`` call
+        spawns a ``lake env lean --stdin`` subprocess whose cost is dominated
+        by Mathlib import elaboration (~98 s on a heavy module). Sequentially
+        that is ~196 s wall-clock — both calls routinely overrun the per-call
+        120 s timeout on complex P4/P5 goals, so the SearchAgent falls back to
+        the LLM with zero Mathlib hints (root cause of the empty-LSP traces on
+        the P4 mono-verrou). Concurrent execution collapses wall-clock to
+        ~max(single call), so at least one tactic tends to land before the
+        timeout. Suggestions stay attributed per tactic and returned in fixed
+        order (exact? first, apply? second) — no parsing or contract change.
+        """
         try:
+            from concurrent.futures import ThreadPoolExecutor
             from .verifier import get_verifier
             from .lean_utils import resolve_lake_module
             # Resolve the real Lake root + dotted module by walking up to the
@@ -493,18 +506,41 @@ class SearchTools:
             lake_root, module_name = resolve_lake_module(self._filepath)
             verifier = get_verifier(lake_root)
 
-            results = []
-            for tactic in ["exact?", "apply?"]:
-                search_result = verifier.search_lean(module_name, goal, tactic)
-                for suggestion in search_result.get("suggestions", []):
-                    results.append({
-                        "name": suggestion["tactic"][:50],
-                        "statement": suggestion["tactic"],
-                        "namespace": "Mathlib",
-                        "relevance": 0.9,
-                        "source": f"lsp_{tactic}",
-                    })
-            return results
+            tactics = ["exact?", "apply?"]
+            # Preserve display order (exact? first) regardless of completion
+            # order: a dict keyed by tactic, flattened in fixed sequence at the
+            # end.
+            by_tactic: dict = {t: [] for t in tactics}
+            with ThreadPoolExecutor(max_workers=len(tactics)) as pool:
+                future_to_tactic = {
+                    pool.submit(verifier.search_lean, module_name, goal, t): t
+                    for t in tactics
+                }
+                for fut, t in future_to_tactic.items():
+                    try:
+                        search_result = fut.result()
+                    except Exception as te:
+                        # A single tactic failing must not poison the other:
+                        # surface it and keep going so a working exact? is not
+                        # lost because apply? raised.
+                        if self._trace:
+                            self._trace.log(
+                                agent="SearchAgent", role="tool",
+                                content=f"_search_via_lsp {t} failed: "
+                                        f"{type(te).__name__}: {te}",
+                                duration_s=0.0, tool_name="search_via_lsp",
+                                tool_result="error",
+                            )
+                        continue
+                    for suggestion in search_result.get("suggestions", []):
+                        by_tactic[t].append({
+                            "name": suggestion["tactic"][:50],
+                            "statement": suggestion["tactic"],
+                            "namespace": "Mathlib",
+                            "relevance": 0.9,
+                            "source": f"lsp_{t}",
+                        })
+            return by_tactic["exact?"] + by_tactic["apply?"]
         except Exception as e:
             # Do not swallow silently: a dead LSP channel used to look identical
             # to "no lemmas found". Surface it in the trace for diagnosis.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2666,6 +2666,106 @@ def test_legacy_fallback_still_works_when_no_workspace_root(monkeypatch):
 # See #1453 follow-up to PR #6067.
 # ---------------------------------------------------------------------------
 
+
+# ---------------------------------------------------------------------------
+# _search_via_lsp concurrency (c.343, #1453) — the SearchAgent runs exact?
+# and apply? in parallel to halve wall-clock. Each search_lean call is a
+# `lake env lean --stdin` subprocess dominated by Mathlib import elaboration
+# (~98 s); the old sequential loop was ~196 s and routinely overran the
+# 120 s per-call timeout on heavy modules, returning zero suggestions. The
+# tests pin: both tactics fire, order is preserved (exact? then apply?), and
+# one tactic failing does not poison the other.
+# ---------------------------------------------------------------------------
+
+def _build_search_tools(monkeypatch, tactic_results, calls):
+    """Build a SearchTools whose verifier.search_lean records calls and
+    returns per-tactic results. ``tactic_results`` maps tactic -> suggestions
+    list (or Exception instance to raise)."""
+    import prover.verifier as vmod
+    import prover.lean_utils as lu
+    from prover.state import ProofState
+    from prover.tools import SearchTools
+
+    class _FakeVerifier:
+        def search_lean(self, module_name, goal, tactic):
+            calls.append((tactic, module_name, goal))
+            res = tactic_results.get(tactic, [])
+            if isinstance(res, Exception):
+                raise res
+            return {"success": len(res) > 0, "suggestions": res,
+                    "tactic_used": tactic, "goal": goal[:200], "raw_output": ""}
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _FakeVerifier())
+    monkeypatch.setattr(lu, "resolve_lake_module",
+                        lambda fp: ("/fake/lake_root", "Fake.Module"))
+    return SearchTools(ProofState(theorem_statement="t"), filepath="/fake/Fake/Module.lean")
+
+
+def test_search_via_lsp_runs_both_tactics_and_preserves_order(monkeypatch):
+    """exact? and apply? both execute; suggestions return exact?-first."""
+    calls = []
+    tools = _build_search_tools(monkeypatch, {
+        "exact?": [{"tactic": "exact le_one"}, {"tactic": "exact le_two"}],
+        "apply?": [{"tactic": "apply le_three"}],
+    }, calls)
+
+    results = tools._search_via_lsp("0 ≤ n")
+
+    tactics_called = [c[0] for c in calls]
+    assert set(tactics_called) == {"exact?", "apply?"}, (
+        f"both tactics must fire, got {tactics_called}"
+    )
+    # Fixed order: exact? suggestions before apply? suggestions, regardless
+    # of which subprocess finished first.
+    sources = [r["source"] for r in results]
+    assert sources == ["lsp_exact?", "lsp_exact?", "lsp_apply?"], (
+        f"order must be exact?-first then apply?, got {sources}"
+    )
+    assert [r["statement"] for r in results] == [
+        "exact le_one", "exact le_two", "apply le_three"], (
+        "suggestion statements must map through unchanged"
+    )
+
+
+def test_search_via_lsp_resilient_to_one_tactic_failing(monkeypatch):
+    """If apply? raises, exact? suggestions still return (no poisoning)."""
+    calls = []
+    tools = _build_search_tools(monkeypatch, {
+        "exact?": [{"tactic": "exact survived"}],
+        "apply?": RuntimeError("apply? subprocess crashed"),
+    }, calls)
+
+    results = tools._search_via_lsp("goal")
+
+    assert [r["statement"] for r in results] == ["exact survived"], (
+        "exact? result must survive an apply? failure"
+    )
+    assert {c[0] for c in calls} == {"exact?", "apply?"}, (
+        "both tactics must have been attempted"
+    )
+
+
+def test_search_via_lsp_empty_when_verifier_unavailable(monkeypatch):
+    """A dead verifier channel returns [] (logged), never propagates."""
+    import prover.verifier as vmod
+    import prover.lean_utils as lu
+    from prover.state import ProofState
+    from prover.tools import SearchTools
+
+    def _boom(*a, **k):
+        raise FileNotFoundError("lean not on PATH")
+
+    monkeypatch.setattr(vmod, "get_verifier", _boom)
+    monkeypatch.setattr(lu, "resolve_lake_module",
+                        lambda fp: ("/fake/lake_root", "Fake.Module"))
+    tools = SearchTools(ProofState(theorem_statement="t"),
+                        filepath="/fake/Fake/Module.lean")
+
+    assert tools._search_via_lsp("goal") == [], (
+        "verifier failure must degrade to empty, not raise"
+    )
+
+
 def test_latch_uses_resolve_lake_module_for_depth3_files(tmp_path):
     """Latch code path must call resolve_lake_module() on the file path so
     `project_dir` lands on the directory holding the lakefile and the relative


### PR DESCRIPTION
## What

Makes the SearchAgent's Mathlib LSP search (`_search_via_lsp`) run `exact?` and `apply?` **concurrently** instead of sequentially, halving wall-clock so at least one tactic lands before the per-call 120 s timeout on heavy modules.

## Why (firsthand)

Each `verifier.search_lean` call spawns a `lake env lean --stdin` subprocess whose cost is dominated by **Mathlib import elaboration** (~98 s on a heavy module — measured firsthand, c.318). The old loop ran `exact?` then `apply?` **sequentially**:

```
for tactic in ["exact?", "apply?"]:
    search_result = verifier.search_lean(module_name, goal, tactic)  # ~98 s each
```

→ ~196 s wall-clock. Both calls routinely overrun the **120 s per-call timeout** (`subprocess.run(timeout=120)` in `lean_server.py:424`) on complex P4/P5 goals → both return empty → the SearchAgent falls back to the LLM with **zero Mathlib hints**. This is the root cause of the empty-LSP traces on the **P4 mono-verrou** (`p4_succ_membership` L2789), the single sorry blocking the entire Hashlife N3/W3 track (#3846).

## Change (additive, local to `_search_via_lsp` in `tools.py`)

| Aspect | Before | After |
|--------|--------|-------|
| Execution | sequential loop | `ThreadPoolExecutor(max_workers=2)`, both tactics submitted together |
| Wall-clock | ~196 s (sum) | ~max(single) (~98–120 s) |
| Order | exact? then apply? | **unchanged** — results flattened in fixed order regardless of completion |
| Failure | outer `try` short-circuits the whole call on one exception | each future's exception logged; **surviving tactic's results kept** (no poisoning) |
| `verifier.search_lean` contract | — | **unchanged** (one tactic/call, same parsing, same attribution) — no verifier/test-protocol churn |

The concurrency choice (vs stdin-batching both tactics in one subprocess) is deliberate: it needs **no output-parsing change**, preserves per-tactic attribution exactly, and keeps `search_lean`'s contract intact (ai-01 owns the verifier test protocol). Wall-clock halving is the same.

## Tests (`test_prover_guards.py`)

- `test_search_via_lsp_runs_both_tactics_and_preserves_order` — both fire; suggestions return exact?-first then apply?-second regardless of completion order.
- `test_search_via_lsp_resilient_to_one_tactic_failing` — `apply?` raising does not lose `exact?` results.
- `test_search_via_lsp_empty_when_verifier_unavailable` — dead verifier channel degrades to `[]` (logged), never raises.

A `_build_search_tools` helper mocks `get_verifier` + `resolve_lake_module` (follows the existing `monkeypatch.setattr(vmod, "get_verifier", …)` pattern, cf `_patch_verifier_and_reverify`).

## Verification

- **148/148 pass** locally on the stacked base (143 pre-existing + 2 from #6249 + 3 new).
- 3 new tests isolated: 3/3 pass.
- No Lean build impact (harness Python only).

## Stacking

Stacked on **#6249** (both touch `test_prover_guards.py`; this branch's base = #6249's branch). Merge #6249 first, then this rebases onto main cleanly. The stacked diff vs #6249 is exactly this PR's scope: `tools.py` (concurrent impl) + 3 tests, 149 insertions / 13 deletions, single commit.

See #1453 (prover harness co-owned). Directly attacks the bottleneck blocking #3846 (Hashlife P4/P5).
