### PR TITLE
fix(qc-py-cloud): upgrade 7 notebooks to nbformat v4.5 (fix validate WARN failures)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-RiskParity-Composite.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-RiskParity-Composite.ipynb
@@ -14,7 +14,8 @@
     "\n",
     "**Approche cloud-native**: L'algorithme est execute sur QuantConnect Cloud. Les resultats sont syncs ci-dessous.",
     "\n\n> **Note de conception** : Ce notebook est un descriptif pedagogique. Le code executable se trouve dans le projet QuantConnect Cloud correspondant (voir le lien dans le notebook). L'absence d'outputs est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-145ac6ff"
   },
   {
    "cell_type": "markdown",
@@ -38,7 +39,8 @@
     "- Sous-performance quand les taux montent (TLT bear 2020-2024)\n",
     "- necessite un univers diversifie pour fonctionner\n",
     "- Leverage implicite sur les actifs low-vol"
-   ]
+   ],
+   "id": "cell-885d3cde"
   },
   {
    "cell_type": "markdown",
@@ -54,7 +56,8 @@
     "| EFA | Actions internationales | Diversification geographique |\n",
     "| EEM | Marches emergents | Growth, carry |\n",
     "| DBC | Matieres premieres | Inflation, commodity cycle |"
-   ]
+   ],
+   "id": "cell-533730fc"
   },
   {
    "cell_type": "markdown",
@@ -84,7 +87,8 @@
     "- Allocation egale parmi les candidats qualifies\n",
     "- Rebalance mensuel\n",
     "- Approche inspiree de Hurst, Ooi, Pedersen (AQR, 2014)"
-   ]
+   ],
+   "id": "cell-8ab0ca97"
   },
   {
    "cell_type": "markdown",
@@ -105,7 +109,8 @@
     "\n",
     "### Benchmark : SPY Buy & Hold\n",
     "Sur la meme periode, SPY a un CAGR ~12.8% et un MaxDD ~24%."
-   ]
+   ],
+   "id": "cell-1cabf47a"
   },
   {
    "cell_type": "markdown",
@@ -129,7 +134,8 @@
     "\n",
     "### Lecon : Le Risk Parity est un outil d'allocation, pas d'alpha\n",
     "Le risk parity excelle pour construire un portefeuille diversifie avec un bon ratio rendement/risque *ajuste pour la diversification*. Mais il ne genere pas d'alpha pur. Pour ameliorer le Sharpe, il faut combiner avec des signaux d'alpha (momentum, carry, value)."
-   ]
+   ],
+   "id": "cell-49314f73"
   },
   {
    "cell_type": "markdown",
@@ -144,7 +150,8 @@
     "# Approche : SMA200 + 6m momentum dual filter\n",
     "# Rebalance mensuel, allocation egale parmi actifs eligibles\n",
     "```"
-   ]
+   ],
+   "id": "cell-635a129c"
   },
   {
    "cell_type": "markdown",
@@ -158,7 +165,8 @@
     "4. **Universe etendu**: Ajouter des ETFs sectoriels (XLU, XLK), crypto (BTC), ou real estate (VNQ)\n",
     "\n",
     "**Reference**: Hurst, Ooi, Pedersen (2014) — \"A Century of Evidence on Trend-Following Investing\", AQR."
-   ]
+   ],
+   "id": "cell-54ec786e"
   },
   {
    "cell_type": "markdown",
@@ -251,5 +259,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-SectorRotation-Momentum.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-02-SectorRotation-Momentum.ipynb
@@ -14,7 +14,8 @@
     "\n",
     "**Approche cloud-native**: L'algorithme est execute sur QuantConnect Cloud. Les resultats sont syncs ci-dessous.",
     "\n\n> **Note de conception** : Ce notebook est un descriptif pedagogique. Le code executable se trouve dans le projet QuantConnect Cloud correspondant (voir le lien dans le notebook). L'absence d'outputs est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-c15deeff"
   },
   {
    "cell_type": "markdown",
@@ -36,7 +37,8 @@
     "- Si aucun actif ne qualifie : position defensive (T-bills)\n",
     "\n",
     "**Avantage** : Diversification跨 asset classes, pas de correlation sectorielle."
-   ]
+   ],
+   "id": "cell-8df99743"
   },
   {
    "cell_type": "markdown",
@@ -72,7 +74,8 @@
     "| GLD | Or | Inflation hedge, crisis alpha |\n",
     "| IWM | Russell 2000 | Small-cap equity |\n",
     "| SHY | Treasury 1-3y (defensif) | Cash proxy quand tendance negative |"
-   ]
+   ],
+   "id": "cell-52ca3233"
   },
   {
    "cell_type": "markdown",
@@ -108,7 +111,8 @@
     "- Allocation : Proportionnelle au score de momentum (momentum-weighted)\n",
     "- Objectif : Surponderer les actifs avec le momentum le plus fort\n",
     "- Rebalance : Mensuel"
-   ]
+   ],
+   "id": "cell-b6cddc66"
   },
   {
    "cell_type": "markdown",
@@ -129,19 +133,22 @@
     "\n",
     "### Benchmark : SPY Buy & Hold\n",
     "Sur la meme periode, SPY a un CAGR ~12.8% et un MaxDD ~24%. Le v3 ne bat pas SPY en rendement pur, mais offre un meilleur ratio rendement/risque (Sharpe 0.614 vs ~0.55 pour SPY)."
-   ]
+   ],
+   "id": "cell-55f35005"
   },
   {
    "cell_type": "markdown",
    "source": "### Exercice 1 : Double filtre tendance AQR\n\nL'approche AQR utilise un double filtre : prix > SMA200 ET momentum 6 mois > 0. Ce filtre elimine les actifs en bear market. La v3 atteint un Sharpe de 0.614 grace a ce filtre.\n\n**Objectif** : Implementez `aqr_filter(prices)` qui retourne la liste des actifs eligibles selon le double filtre. Testez avec des series simulees en bull, bear et sideways.\n\n**Indices** :\n- # Indice : Un actif en bull aura prix > SMA200 ET momentum_6m > 0.\n- # Indice : En bear market, la plupart des actifs seront exclus par le filtre.",
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-afc0213e"
   },
   {
    "cell_type": "code",
    "source": "# Exercice 2 : Double filtre tendance AQR\n# TODO etudiant : implementer aqr_filter(prices_dict) -> list des tickers eligibles\n# Indice : eligible si prix[-1] > SMA(200) ET momentum_6m > 0\n\ndef aqr_filter(prices_dict, sma_period=200, mom_period=126):\n    # TODO etudiant : pour chaque ticker, verifier les deux conditions\n    return None  # TODO etudiant : retourner la liste des eligibles\n\nresult_aqr = None  # TODO etudiant : tester avec des series simulees\nprint(\"Exercice a completer : double filtre AQR\")",
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-fe00e108"
   },
   {
    "cell_type": "markdown",
@@ -178,19 +185,22 @@
     "2. **Retournement de momentum** : Les actifs avec le momentum le plus fort sont aussi ceux qui ont le plus a perdre quand la tendance s'inverse. Le momentum-weighting maximise l'exposition au retournement.\n",
     "\n",
     "3. **Lecon : L'equal-weight est plus robuste** : Sans signal de confiance sur la persistance du momentum par actif, l'equal-weight est plus prudent et plus stable."
-   ]
+   ],
+   "id": "cell-b7feb0ae"
   },
   {
    "cell_type": "markdown",
    "source": "### Exercice 2 : Comparaison equal-weight vs momentum-weighted\n\nLa v4 (momentum-weighted) sous-performe la v3 (equal-weight) avec un Sharpe de 0.276 vs 0.614 et un MaxDD de 38.8% vs 15.5%. La ponderation par momentum concentre trop le portefeuille sur l'actif le plus chaud.\n\n**Objectif** : Simulez les poids equal-weight et momentum-weighted pour 4 actifs avec des scores de momentum differents. Calculez la concentration (indice Herfindahl-Hirschman, somme des carres des poids) pour chaque methode. Un HHI plus eleve indique une plus grande concentration.\n\n**Indices** :\n- # Indice : HHI = sum(w_i^2). Pour equal-weight avec N actifs, HHI = 1/N.\n- # Indice : Momentum-weighting normalise les scores de momentum pour sommer a 1.",
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-78496b88"
   },
   {
    "cell_type": "code",
    "source": "# Exercice 3 : Comparaison equal-weight vs momentum-weighted\n# TODO etudiant : calculer les poids equal-weight et momentum-weighted\n# TODO etudiant : calculer la concentration HHI pour chaque methode\n# Indice : HHI = sum(w_i^2), plus HHI est haut, plus c est concentre\n\ndef hhi(weights):\n    # TODO etudiant : calculer l indice Herfindahl-Hirschman\n    return None  # TODO etudiant : retourner la somme des carres\n\nmom_scores = {\"QQQ\": 0.15, \"SPY\": 0.08, \"EFA\": -0.02, \"GLD\": 0.05}\nresult_alloc = None  # TODO etudiant : comparer HHI(equal) vs HHI(momentum-weighted)\nprint(\"Exercice a completer : equal-weight vs momentum-weighted\")",
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-069aa460"
   },
   {
    "cell_type": "markdown",
@@ -229,7 +239,8 @@
     "# 3. Position defensive SHY si aucun actif ne qualifie\n",
     "# 4. Rebalance toutes les 21 jours de bourse\n",
     "```"
-   ]
+   ],
+   "id": "cell-cbbdf5a6"
   },
   {
    "cell_type": "markdown",
@@ -245,7 +256,8 @@
     "Le trend-following multi-asset surpasse le Risk Parity sur tous les metrics. La principale difference : le trend-following filtre activement les actifs en tendance negative, tandis que le Risk Parity reste expose a tous les actifs en permanence (avec une ponderation differente).\n",
     "\n",
     "**Lecon** : Un filtre de tendance actif (SMA200 + momentum) est plus efficace qu'une allocation statique basee sur la volatilite."
-   ]
+   ],
+   "id": "cell-4b03448c"
   },
   {
    "cell_type": "markdown",
@@ -262,7 +274,8 @@
     "4. **Universe etendu** : Ajouter des ETFs internationaux supplmentaires (EEM, DBC) et des ETFs alternatifs (TLT quand les taux se stabiliseront).\n",
     "\n",
     "**Reference** : Hurst, Ooi, Pedersen (2014) — \"A Century of Evidence on Trend-Following Investing\", AQR. Moskowitz, Ooi, Pedersen (2012) — \"Time Series Momentum\", Journal of Financial Economics."
-   ]
+   ],
+   "id": "cell-518b515f"
   }
  ],
  "metadata": {
@@ -277,5 +290,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb
@@ -14,7 +14,8 @@
     "\n",
     "**Approche cloud-native**: L'algorithme est execute sur QuantConnect Cloud. Les resultats sont syncs ci-dessous.",
     "\n\n> **Note de conception** : Ce notebook est un descriptif pedagogique. Le code executable se trouve dans le projet QuantConnect Cloud correspondant (voir le lien dans le notebook). L'absence d'outputs est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-23a8862a"
   },
   {
    "cell_type": "markdown",
@@ -40,7 +41,8 @@
     "Le mean reversion est conceptuellement oppose au trend following. En trend following, on achete les actifs qui montent (momentum positif). En mean reversion, on achete les actifs qui ont baisse (anticipation de rebond).\n",
     "\n",
     "**Lecon attendue** : Sur un univers d'ETFs sectoriels correles, le mean reversion genere un edge marginal (Sharpe ~0.3) mais reste inferieur au trend following multi-asset (Cloud-02, Sharpe 0.614). Le regime filter (SMA200) est crucial pour eviter d'acheter en bear market."
-   ]
+   ],
+   "id": "cell-d42ad65e"
   },
   {
    "cell_type": "markdown",
@@ -103,7 +105,8 @@
     "| Filtre regime | Prix > SMA200 |\n",
     "| Stop-loss | 8% (trailing) |\n",
     "| Rebalance | Quotidien (verification) |"
-   ]
+   ],
+   "id": "cell-16bef882"
   },
   {
    "cell_type": "markdown",
@@ -123,7 +126,8 @@
     "\n",
     "### Benchmark : SPY Buy & Hold\n",
     "Sur la meme periode, SPY a un CAGR ~12.8% et un MaxDD ~24%."
-   ]
+   ],
+   "id": "cell-55b7e4b4"
   },
   {
    "cell_type": "markdown",
@@ -157,7 +161,8 @@
     "**Pourquoi** : Le mean reversion achete par definition des actifs qui ont baisse. Un stop-loss a 8% declenche souvent sur des fluctuations normales apres l'achat, avant que le rebond ne se materialise. C'est le meme probleme que le drawdown cap dans Cloud-01 : les mecanismes de protection empechent la recuperation.\n",
     "\n",
     "Le stop-loss transforme des pertes temporaires (recoverables) en pertes permanentes."
-   ]
+   ],
+   "id": "cell-45cd0395"
   },
   {
    "cell_type": "markdown",
@@ -219,7 +224,8 @@
     "3. **Le stop-loss est contre-productif en mean reversion** : Les actifs achetes en survente ont besoin de temps pour se retourner. Le stop-loss coupe les positions avant le rebond.\n",
     "\n",
     "4. **Le mean reversion bat le Risk Parity** (Sharpe 0.307 vs 0.278) mais reste loin du Dual Momentum et du trend following multi-asset. L'edge est marginal et depend entierement du regime filter."
-   ]
+   ],
+   "id": "cell-49feff26"
   },
   {
    "cell_type": "markdown",
@@ -241,7 +247,8 @@
     "# 2. 4 positions simultanees = diversification suffisante\n",
     "# 3. Pas de stop-loss (contre-productif en mean reversion)\n",
     "```"
-   ]
+   ],
+   "id": "cell-e55371bd"
   },
   {
    "cell_type": "markdown",
@@ -258,7 +265,8 @@
     "4. **Pairs trading sectoriel** : Au lieu d'acheter un secteur en survente, acheter le secteur en survente et vendre le secteur en surachat (long/short).\n",
     "\n",
     "**Reference** : De Bondt, W. & Thaler, R. (1985) — \"Does the Stock Market Overreact?\", Journal of Finance. Jegadeesh, N. (1990) — \"Evidence of Predictable Behavior of Security Returns\", Journal of Finance."
-   ]
+   ],
+   "id": "cell-81b3e393"
   }
  ],
  "metadata": {
@@ -273,5 +281,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-RegimeSwitching.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-05-RegimeSwitching.ipynb
@@ -14,7 +14,8 @@
     "\n",
     "**Approche cloud-native**: L'algorithme est execute sur QuantConnect Cloud. Les resultats sont syncs ci-dessous.",
     "\n\n> **Note de conception** : Ce notebook est un descriptif pedagogique. Le code executable se trouve dans le projet QuantConnect Cloud correspondant (voir le lien dans le notebook). L'absence d'outputs est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-b88d51bc"
   },
   {
    "cell_type": "markdown",
@@ -35,7 +36,8 @@
     "### Tension pedagogique : complexite vs robustesse\n",
     "\n",
     "Le regime switching semble elegamment adaptatif. Mais en pratique, la detection de regime est retroactive (on identifie le regime apres qu'il a commence). La question est : un signal simple (SMA crossover) suffit-il, ou faut-il une detection plus sophistiquee (HMM, ML) ?"
-   ]
+   ],
+   "id": "cell-e5d93e4e"
   },
   {
    "cell_type": "markdown",
@@ -82,7 +84,8 @@
     "| Rebalance | Mensuel + regime change |\n",
     "\n",
     "En bear, au lieu de rester purement defensif, on cherche des opportunites de mean-reversion (RSI < 30) parmi les actifs risky, combinees avec des positions defensives."
-   ]
+   ],
+   "id": "cell-fb34e895"
   },
   {
    "cell_type": "markdown",
@@ -120,7 +123,8 @@
     "\n",
     "### Benchmark : SPY Buy & Hold\n",
     "Sur la meme periode, SPY a un CAGR ~12.8% et un MaxDD ~24%."
-   ]
+   ],
+   "id": "cell-31c07841"
   },
   {
    "cell_type": "markdown",
@@ -177,7 +181,8 @@
     "Le mean-reversion en bear market est marginalement benefique mais le stop-loss trailing (10%) coupe des positions qui auraient pu se retablir. C'est coherent avec la lecon de Cloud-04 : les mecanismes de protection sont souvent contre-productifs en mean reversion.\n",
     "\n",
     "Les ordres sont identiques (884) entre v2 et v3, suggérant que le mean-reversion ne declenche pas beaucoup de trades supplémentaires en bear."
-   ]
+   ],
+   "id": "cell-a4a7fb8d"
   },
   {
    "cell_type": "markdown",
@@ -206,7 +211,8 @@
     "4. **La combinaison regime + momentum est synergique** : le regime filter protege en bear, le momentum optimise en bull. C'est mieux que chaque signal seul.\n",
     "\n",
     "5. **Le regime switching bat le Dual Momentum** (0.622 vs 0.392) car il adapte explicitement la strategie au regime, tandis que le Dual Momentum n'a qu'un seul signal (momentum 12m)."
-   ]
+   ],
+   "id": "cell-807608c1"
   },
   {
    "cell_type": "markdown",
@@ -248,7 +254,8 @@
     "# 3. Diversification defensive (IEF+GLD, pas IEF seul)\n",
     "# 4. Rebalance mensuel + trigger sur changement de regime\n",
     "```"
-   ]
+   ],
+   "id": "cell-6e1ca767"
   },
   {
    "cell_type": "markdown",
@@ -265,7 +272,8 @@
     "4. **Machine Learning regime** : Entrainer un classificateur (Random Forest, XGBoost) sur des features de marche pour predire le regime futur.\n",
     "\n",
     "**Reference** : Hamilton, J.D. (1989) — \"A New Approach to the Economic Analysis of Nonstationary Time Series and the Business Cycle\", Econometrica. Ang, A. & Bekaert, G. (2002) — \"Regime Switches in Interest Rates\", Journal of Business & Economic Statistics."
-   ]
+   ],
+   "id": "cell-15cbf4a6"
   }
  ],
  "metadata": {
@@ -280,5 +288,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-PCA-StatArb.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-PCA-StatArb.ipynb
@@ -14,7 +14,8 @@
     "\n",
     "**Approche cloud-native** : L'algorithme est execute sur QuantConnect Cloud. Les resultats sont presentes ci-dessous.",
     "\n\n> **Note de conception** : Ce notebook est un descriptif pedagogique. Le code executable se trouve dans le projet QuantConnect Cloud correspondant (voir le lien dans le notebook). L'absence d'outputs est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-928ba74d"
   },
   {
    "cell_type": "markdown",
@@ -63,7 +64,8 @@
     "- **Stat-arb PCA** : acheter ce qui est sous-evalue par rapport aux facteurs communs\n",
     "\n",
     "Le stat-arb PCA est plus sophistique que le mean reversion simple (RSI) car il utilise un modele factoriel multivarie plutot qu'un signal univarie."
-   ]
+   ],
+   "id": "cell-a598d2bf"
   },
   {
    "cell_type": "markdown",
@@ -103,7 +105,8 @@
     "- **num_components** : Minimum 2 (pour regression multiple), maximum 6 (composantes supplementaires n'apportent peu). Le Sharpe est maximal a 3 composantes.\n",
     "- **lookback_days** : Minimum 21 (1 mois), maximum 126 (6 mois). Le Sharpe est maximise avec 126 jours de lookback.\n",
     "- **z_score_threshold** : 1.5 est le seuil optimal identifie. Un seuil plus bas genere plus de trades mais moins selectif."
-   ]
+   ],
+   "id": "cell-7ba18696"
   },
   {
    "cell_type": "markdown",
@@ -132,7 +135,8 @@
     "| **Sortino Ratio** | 0.476 |\n",
     "| **Frais totaux** | $12,424.87 |\n",
     "| **Portfolio Turnover** | 6.08% |"
-   ]
+   ],
+   "id": "cell-eec39bdc"
   },
   {
    "cell_type": "markdown",
@@ -159,7 +163,8 @@
     "L'alpha annualise de 0.5% est marginal. La majorite du rendement (12.65%) vient de l'exposition au marche (beta 0.902), pas de la capacite du modele PCA a identifier des ecarts.\n",
     "\n",
     "C'est une limitation fondamentale du stat-arb sur actions US liquides : les inefficiences de prix sont rapidement corrigees par les joueurs institutionnels, ne laissant que des traces d'alpha."
-   ]
+   ],
+   "id": "cell-8c4ea304"
   },
   {
    "cell_type": "markdown",
@@ -184,7 +189,8 @@
     "3. **MaxDD catastrophique** : 31.8%, le plus eleve de toutes les strategies. En periode de stress, les positions stat-arb aggrave les pertes au lieu de les amortir.\n",
     "\n",
     "4. **Sharpe-adjusted, le PCA stat-arb est inferieur au trend following** : Le Sector Rotation offre un Sharpe de 0.614 avec un MaxDD de 15.5%. Le PCA stat-arb offre un Sharpe de 0.399 avec un MaxDD de 31.8%. Le rendement ajuste au risque est nettement en faveur du trend following."
-   ]
+   ],
+   "id": "cell-32216e45"
   },
   {
    "cell_type": "markdown",
@@ -250,7 +256,8 @@
     "```\n",
     "\n",
     "**Note sur l'inversion des poids** : les z-scores selectionnes sont negatifs (< -1.5). Les poids sont proportionnels aux z-scores, donc negatifs. L'inversion (`-weight`) rend les positions longues. Plus le z-score est negatif, plus la position est importante."
-   ]
+   ],
+   "id": "cell-5fe7ee55"
   },
   {
    "cell_type": "markdown",
@@ -273,7 +280,8 @@
     "### 7.4 L'alpha est faible sur actions liquides\n",
     "\n",
     "Sur un univers de 100 actions US liquides, les inefficiences sont rapidement exploitees. L'alpha de 0.5% confirme que le rendement provient principalement du beta. Des univers moins liquides (small caps, marches emergents) pourraient offrir plus d'alpha."
-   ]
+   ],
+   "id": "cell-c649886b"
   },
   {
    "cell_type": "markdown",
@@ -310,7 +318,8 @@
     "5. **PCA alternative : clustering sectoriel** : Remplacer la PCA non supervisee par un clustering sectoriel explicite (GICS) pour une interpretation plus claire des facteurs.\n",
     "\n",
     "**Reference** : Avellaneda, M. & Lee, J.H. (2010) — \"Statistical Arbitrage in the US Equities Market\", Quantitative Finance. Broad, J. (2025) — *Hands-On AI Trading with Python, QuantConnect, and AWS*, Chapter 6, Example 13."
-   ]
+   ],
+   "id": "cell-35cac460"
   }
  ],
  "metadata": {
@@ -325,5 +334,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-VolTargeting.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-VolTargeting.ipynb
@@ -14,7 +14,8 @@
     "\n",
     "**Approche cloud-native**: L'algorithme est execute sur QuantConnect Cloud. Les resultats sont syncs ci-dessous.",
     "\n\n> **Note de conception** : Ce notebook est un descriptif pedagogique. Le code executable se trouve dans le projet QuantConnect Cloud correspondant (voir le lien dans le notebook). L'absence d'outputs est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-495a4eb0"
   },
   {
    "cell_type": "markdown",
@@ -49,7 +50,8 @@
     "- Le choix de la fenetre de volatilite (21, 63, 126 jours) change les resultats\n",
     "- Les caps (min/max allocation) sont cruciaux pour eviter les leviers extremes\n",
     "- Sur un seul actif (SPY), le vol targeting ne diversifie pas -- il ajuste juste l'exposition"
-   ]
+   ],
+   "id": "cell-db8d9edc"
   },
   {
    "cell_type": "markdown",
@@ -115,7 +117,8 @@
     "| Rebalance | Mensuel |\n",
     "\n",
     "Ajout d'un filtre de momentum : parmi les 4 actifs, seuls ceux avec un momentum 6 mois positif sont eligibles. Les autres sont exclus. Si aucun actif ne qualifie, 100% en IEF (defensif)."
-   ]
+   ],
+   "id": "cell-fc68e845"
   },
   {
    "cell_type": "markdown",
@@ -135,7 +138,8 @@
     "\n",
     "### Benchmark : SPY Buy & Hold\n",
     "Sur la meme periode, SPY a un CAGR ~12.8% et un MaxDD ~24%."
-   ]
+   ],
+   "id": "cell-6a0ac572"
   },
   {
    "cell_type": "markdown",
@@ -194,7 +198,8 @@
     "| v3 | 6.6% | 0.326 | 86% | 0.502 |\n",
     "\n",
     "La v2 a le beta le plus bas (0.287) et la plus faible volatilite (5.6%). La v3 offre un meilleur ratio Sortino (0.502) grace au filtre momentum qui evite les pertes pendant les bear markets."
-   ]
+   ],
+   "id": "cell-4cc038c4"
   },
   {
    "cell_type": "markdown",
@@ -226,7 +231,8 @@
     "5. **Le regime switching (Cloud-05) reste le meilleur** : Avec un signal binaire (bull/bear), le regime switching atteint un Sharpe de 0.622. Le vol targeting est plus sophistique mathematiquement mais moins performant. La lecon : un signal simple mais correct (detecter le regime) bat un mecanisme complexe (scaling continu).\n",
     "\n",
     "6. **Le single-asset vol targeting est dangereux** : La v1 (SPY seul) a un MaxDD de 38.3% avec levier. Sans diversification, le vol targeting amplifie les pertes au lieu de les reduire."
-   ]
+   ],
+   "id": "cell-54fe4784"
   },
   {
    "cell_type": "markdown",
@@ -268,7 +274,8 @@
     "# 3. Equal risk contribution = poids inverse-vol\n",
     "# 4. Momentum filter elimine les actifs en bear\n",
     "```"
-   ]
+   ],
+   "id": "cell-57f1ba5c"
   },
   {
    "cell_type": "markdown",
@@ -285,7 +292,8 @@
     "4. **Implied volatility** : Utiliser le VIX au lieu de la vol realisee pour un signal plus prospectif.\n",
     "\n",
     "**Reference** : Moreira, A. & Muir, T. (2017) -- \"Volatility-Managed Portfolios\", Journal of Finance. Harvey, C. et al. (2018) -- \"...and the Cross-Section of Expected Returns\", Review of Financial Studies."
-   ]
+   ],
+   "id": "cell-94c76fc2"
   }
  ],
  "metadata": {
@@ -300,5 +308,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-07-TemporalCNN.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-07-TemporalCNN.ipynb
@@ -14,7 +14,8 @@
     "\n",
     "**Approche cloud-native** : L'algorithme est execute sur QuantConnect Cloud. Les resultats sont presentes ci-dessous.",
     "\n\n> **Note de conception** : Ce notebook est un descriptif pedagogique. Le code executable se trouve dans le projet QuantConnect Cloud correspondant (voir le lien dans le notebook). L'absence d'outputs est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-e7618f02"
   },
   {
    "cell_type": "markdown",
@@ -47,7 +48,8 @@
     "2. **Classification 3 classes** : Au lieu de predire un prix continu, le modele classe la direction (UP/DOWN/STATIONARY). C'est plus robuste que la regression car il n'a pas besoin de predire l'amplitude exacte.\n",
     "\n",
     "3. **Entrainement hebdomadaire** : Le modele est reentraine chaque semaine avec les 500 dernieres barres quotidiennes. Cela permet au modele de s'adapter aux changements de regime."
-   ]
+   ],
+   "id": "cell-ad1da968"
   },
   {
    "cell_type": "markdown",
@@ -101,7 +103,8 @@
     "| Stationary threshold | 0.01% | Seuil pour classifier un mouvement comme stationnaire |\n",
     "| Epochs | 20 | Cycles d'entrainement par retrain |\n",
     "| Rebalance | Hebdomadaire | Retrain + prediction chaque lundi |"
-   ]
+   ],
+   "id": "cell-2db7bbf1"
   },
   {
    "cell_type": "markdown",
@@ -129,7 +132,8 @@
     "| **PSR** | 28.701 |\n",
     "| **Sortino Ratio** | N/A |\n",
     "| **Treynor Ratio** | 0.517 |"
-   ]
+   ],
+   "id": "cell-0d416f3c"
   },
   {
    "cell_type": "markdown",
@@ -157,7 +161,8 @@
     "- **Entrainement inline** : Le CNN est entraine directement dans l'algorithme QC (TensorFlow/Keras). Les performances dependent de la qualite de l'entrainement sur un nombre limite d'epochs (20) et de donnees (500 barres).\n",
     "- **Pas de validation croise** : Pas de split train/test ou de walk-forward explicite dans l'algorithme. Le reentrainement hebdomadaire sur les 500 dernieres barres est une forme implicite de validation, mais pas une garantie.\n",
     "- **Surapprentissage potentiel** : Un CNN avec 30 filtres Conv1D sur 500 echantillons peut surapprendre, surtout avec 20 epochs sans early stopping."
-   ]
+   ],
+   "id": "cell-63189329"
   },
   {
    "cell_type": "markdown",
@@ -183,7 +188,8 @@
     "3. **Beta faible (0.264)** : La strategie est largement decorrelee du marche. Le rendement ne depend pas de la direction generale du marche mais de la capacite predictive du modele.\n",
     "\n",
     "4. **Reserve** : Le univers restreint (3 actions) et l'absence de validation croisee formelle rendent ce resultat preliminaire. Une validation walk-forward multi-seed serait necessaire pour confirmer."
-   ]
+   ],
+   "id": "cell-790a615e"
   },
   {
    "cell_type": "markdown",
@@ -206,7 +212,8 @@
     "### 6.4 La confiance filtre le bruit\n",
     "\n",
     "Le seuil de confiance a 55% elimine les predictions incertaines. Un modele qui ne trade que lorsqu'il est confiant reduit le nombre de trades mais ameliore la qualite moyenne."
-   ]
+   ],
+   "id": "cell-38c953b7"
   },
   {
    "cell_type": "markdown",
@@ -243,7 +250,8 @@
     "5. **Ensemble de modeles** : Combiner les predictions de plusieurs CNN entraines avec des seeds differents pour reduire la variance des predictions.\n",
     "\n",
     "**Reference** : Broad, J. (2025) — *Hands-On AI Trading with Python, QuantConnect, and AWS*, Chapter 6, Example 14."
-   ]
+   ],
+   "id": "cell-d7318d40"
   }
  ],
  "metadata": {
@@ -258,5 +266,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Défaut

7 notebooks QC-Py-Cloud (01, 02, 04, 05, 06×2, 07) déclaraient **nbformat v4.4** mais contenaient des cellules avec une propriété `id` spurious (un champ v4.5). Cet état mixte faisait échouer `nbformat.validate` :

```
Additional properties are not allowed ('id' was unexpected)
```

La CI `notebook-validation.yml` (L43 `nbformat.validate`) attrape ceci comme **WARN** (non-bloquant, L49) à chaque run → 7 notebooks de bruit dans les logs CI.

**Root cause** : les ops normalize-source-newlines / collapsed-markdown (#5005/#5028/#5227) ont écrit des cellules avec `id=""` tout en laissant les metadata du notebook à v4.4 → état internement incohérent.

## Fix

Upgrade de chaque notebook vers **v4.5** (la norme repo — 807/922 notebooks sont v4.5 avec cell ids uniques, ex. SC-8, série GenAI). `nbformat_minor: 4 → 5` + assignation d'un id unique à chaque cell (les cells ayant déjà un id unique sont préservées ; ids manquants/vides/dupliqués → fresh `cell-<hex8>`).

## Validation

| Check | Avant | Après |
|-------|-------|-------|
| `nbformat.validate` | 7/7 FAIL | 7/7 PASS |
| WARN CI notebook-validation | 7 notebooks | 0 |

## Anti-régression (G.1)

Pour chaque notebook : `source` / `outputs` / `execution_count` / `cell_type` **byte-identical** à `origin/main` (vérifié programmatically par cell). Seuls le champ `id` et `nbformat_minor` changent. Cell counts inchangés (ex. Cloud-01 : 14/14). CRLF = 0 (LF). CATALOG generated byte-identical (0 changement de count). Aucun secret dans le diff.

## Scope (anti-G.4)

7 fichiers, **single defect class** (mixed v4.4/v4.5 state), **single series** (QC-Py-Cloud). Les 2 siblings v4.4 propres (Cloud-08, -09, qui ont 0 cell id et valident déjà) ne sont **pas** touchés — ils ne sont pas défectueux.

## Note d'honnêteté (R6)

Ceci est un fix d'**intégrité nbformat** (élimine du bruit CI WARN, forward-compatible v4.5), pas du contenu pédagogique. Aucun code/markdown modifié, pas de re-exécution (exception structure markdown C.2). Livré pour rencontrer le plancher R1 sur un pool worker self-serve vérifié saturé (3 cycles consécutifs, 3 workers confirment) — framing transparent, pas un claim de substance.

Co-authored-by: Claude Opus 4.8
