### PR TITLE
fix(secrets): remove literal Qdrant API key fallback in SK-5 VectorStores

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
@@ -848,10 +848,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Erreur de connexion: [WinError 10061] Aucune connexion n’a pu être établie car l’ordinateur cible l’a expressément refusée\n",
+      "Erreur de connexion: timed out\n",
       "Continuez avec InMemoryStore pour les exemples suivants.\n"
      ]
     }
@@ -862,7 +862,7 @@
     "\n",
     "# Configuration Qdrant (depuis .env ou valeurs fournies)\n",
     "QDRANT_URL = os.getenv(\"QDRANT_URL\", \"https://qdrant.myia.io\")\n",
-    "QDRANT_API_KEY = os.getenv(\"QDRANT_API_KEY\", \"4f89edd5-90f7-4ee0-ac25-9185e9835c44\")\n",
+    "QDRANT_API_KEY = os.getenv(\"QDRANT_API_KEY\")\n",
     "\n",
     "# Connexion au client Qdrant\n",
     "qdrant_client = QdrantClient(\n",


### PR DESCRIPTION
## Security fix — literal API key fallback removed

**nb05 `05-SemanticKernel-VectorStores.ipynb` cell `ad2ec962`** had:
```python
QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", "4f89edd5-90f7-4ee0-ac25-9185e9835c44")
```
This is the **forbidden pattern** ([secrets-hygiene.md](.claude/rules/secrets-hygiene.md) rule 2: `os.getenv("KEY", "<literal-secret-as-fallback>")`) — a literal Qdrant API key committed inline as a default. Incident of record: `b34e3a05` (2026-05-14).

### Fix
Removed the default → `os.getenv("QDRANT_API_KEY")` (no literal). The `QDRANT_URL` default (`https://qdrant.myia.io`) is kept — it is a public hostname, not credentials.

### Re-execution (Stop & Repair, rule F)
Cell re-executed firsthand — `qdrant_client` was missing in the kernel so it was installed (rule F: repair, never bypass). Result: Qdrant `qdrant.myia.io` is down → `Erreur de connexion: timed out` → honest `InMemoryStore` fallback. This is the **same graceful degradation** as before (Qdrant unreachable regardless of the key value), so the change is output-neutral in behavior — the key removal does not alter observable behavior, it just stops committing a secret.

### Validation
| Check | Result |
|-------|--------|
| Literal present after fix | **0** (grep `4f89edd5` = 0) |
| Diff scope | 1 cell (`ad2ec962`), 3 ins / 3 del |
| CRLF | 0 (LF-only, binary write) |
| JSON valid | yes |
| code cells / exec_proved | 11 / 11 |
| errors | 0 |
| C.1 violation | none |

### Provenance
Found during **axe-2 SOTA audit entry #029** (GenAI/SemanticKernel, EPIC #3801). Scan of all 12 SK notebooks: **1 occurrence only** (this cell). Cluster-wide HARD rule — security transcends lane (GenAI = po-2024 native lane, but a committed literal secret is everyone's responsibility).

See #3801. No catalog changes.