### PR TITLE
fix(qc-py): upgrade 12 main-series notebooks to nbformat v4.5 (fix validate WARN)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
@@ -33,7 +33,8 @@
     "> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n",
     "> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n",
     "> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-ab267eee"
   },
   {
    "cell_type": "markdown",
@@ -253,14 +254,16 @@
     "| Max Drawdown | 33.600% |\n",
     "| Win Rate | 50% |\n",
     "| Capital final | $232,273.37 |"
-   ]
+   ],
+   "id": "cell-2a4cc8bc"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** (BT c80ed35291a7cb18a9305726d061e2f6, projet 31995975)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | 0.387 | 8.786% | 33.6% | 9 |"
-   ]
+   ],
+   "id": "cell-fbeebca1"
   },
   {
    "cell_type": "markdown",
@@ -792,5 +795,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -41,14 +41,16 @@
     "6. Analyse de l'Equity Curve (20 min)\n",
     "7. Rapport Complet (20 min)",
     "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-96b2cbba"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-52e57b11"
   },
   {
    "cell_type": "markdown",
@@ -63,7 +65,8 @@
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-b1deadbd"
   },
   {
    "cell_type": "markdown",
@@ -72,7 +75,8 @@
     "---\n",
     "\n",
     "## Setup et Imports"
-   ]
+   ],
+   "id": "cell-ebc2dee6"
   },
   {
    "cell_type": "code",
@@ -106,7 +110,8 @@
     "sys.path.append('../shared')\n",
     "\n",
     "print(\"Imports reussis\")"
-   ]
+   ],
+   "id": "cell-de7f5996"
   },
   {
    "cell_type": "markdown",
@@ -138,7 +143,8 @@
     "from plotting import plot_backtest_results, plot_returns_distribution\n",
     "\n",
     "print(\"Helpers importes avec succes\")"
-   ]
+   ],
+   "id": "cell-36c33c4b"
   },
   {
    "cell_type": "markdown",
@@ -152,7 +158,8 @@
     "\n",
     "Ces helpers evitent de reecrire le meme code d'analyse dans chaque projet et garantissent une presentation uniforme des resultats."
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-c3fd9543"
   },
   {
    "cell_type": "markdown",
@@ -161,7 +168,8 @@
     "### Generation de Donnees de Backtest Simulees\n",
     "\n",
     "Pour ce notebook, nous allons generer des donnees de backtest simulees representant une strategie et son benchmark. En environnement reel, ces donnees proviendraient d'un backtest QuantConnect."
-   ]
+   ],
+   "id": "cell-d016732a"
   },
   {
    "cell_type": "code",
@@ -224,7 +232,8 @@
     "print(f\"Periode: {dates[0].date()} - {dates[-1].date()}\")\n",
     "print(f\"\\nApercu:\")\n",
     "backtest_df.head()"
-   ]
+   ],
+   "id": "cell-e525e1f6"
   },
   {
    "cell_type": "markdown",
@@ -237,7 +246,8 @@
     "### 1.1 Return Metrics (10 min)\n",
     "\n",
     "Les metriques de rendement mesurent la performance absolue de la strategie."
-   ]
+   ],
+   "id": "cell-8fb0f673"
   },
   {
    "cell_type": "markdown",
@@ -251,7 +261,8 @@
     "$$\\text{Total Return} = \\frac{\\text{Final Value} - \\text{Initial Value}}{\\text{Initial Value}}$$\n",
     "\n",
     "$$\\text{CAGR} = \\left(\\frac{\\text{Final Value}}{\\text{Initial Value}}\\right)^{\\frac{1}{\\text{years}}} - 1$$"
-   ]
+   ],
+   "id": "cell-cdff5796"
   },
   {
    "cell_type": "code",
@@ -330,14 +341,16 @@
     "print(f\"{'CAGR':<25} {strategy_return_metrics['cagr']:>11.2%} {benchmark_return_metrics['cagr']:>11.2%}\")\n",
     "print(f\"{'Annualized Return':<25} {strategy_return_metrics['annualized_return']:>11.2%} {benchmark_return_metrics['annualized_return']:>11.2%}\")\n",
     "print(f\"{'Periode (annees)':<25} {strategy_return_metrics['years']:>11.2f}\")"
-   ]
+   ],
+   "id": "cell-9b7d38ea"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### Returns Journaliers, Mensuels et Annuels"
-   ]
+   ],
+   "id": "cell-3eda6c53"
   },
   {
    "cell_type": "code",
@@ -359,7 +372,8 @@
     "\n",
     "print(\"\\nReturns Annuels:\")\n",
     "print(yearly_returns)"
-   ]
+   ],
+   "id": "cell-7c75a65a"
   },
   {
    "cell_type": "markdown",
@@ -414,7 +428,8 @@
     "    plt.show()\n",
     "\n",
     "plot_monthly_returns_heatmap(strategy_returns_series, \"Strategie - Returns Mensuels (%)\")"
-   ]
+   ],
+   "id": "cell-0f1f1fb3"
   },
   {
    "cell_type": "markdown",
@@ -440,7 +455,8 @@
     "\n",
     "**Attention** : Ne pas overfiter sur des patterns saisonniers sans validation out-of-sample!"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-1f504c52"
   },
   {
    "cell_type": "markdown",
@@ -449,7 +465,8 @@
     "### 1.2 Risk-Adjusted Metrics (15 min)\n",
     "\n",
     "Les metriques ajustees au risque permettent de comparer des strategies avec des profils de risque differents."
-   ]
+   ],
+   "id": "cell-9155cd2e"
   },
   {
    "cell_type": "markdown",
@@ -471,7 +488,8 @@
     "- Sharpe 0-1 : Acceptable\n",
     "- Sharpe 1-2 : Bon\n",
     "- Sharpe > 2 : Excellent"
-   ]
+   ],
+   "id": "cell-ba85babe"
   },
   {
    "cell_type": "code",
@@ -523,7 +541,8 @@
     "\n",
     "print(f\"Sharpe Ratio Strategie:  {sharpe_strategy:.2f}\")\n",
     "print(f\"Sharpe Ratio Benchmark:  {sharpe_benchmark:.2f}\")"
-   ]
+   ],
+   "id": "cell-2b34909a"
   },
   {
    "cell_type": "markdown",
@@ -538,7 +557,8 @@
     "Ou $\\sigma_d$ est la **downside deviation** (ecart-type des returns negatifs uniquement).\n",
     "\n",
     "**Avantage**: Ne penalise pas la volatilite haussiere (les gros gains)."
-   ]
+   ],
+   "id": "cell-5da9e126"
   },
   {
    "cell_type": "code",
@@ -597,7 +617,8 @@
     "\n",
     "print(f\"Sortino Ratio Strategie:  {sortino_strategy:.2f}\")\n",
     "print(f\"Sortino Ratio Benchmark:  {sortino_benchmark:.2f}\")"
-   ]
+   ],
+   "id": "cell-ad41aac1"
   },
   {
    "cell_type": "markdown",
@@ -610,7 +631,8 @@
     "$$\\text{Calmar Ratio} = \\frac{\\text{CAGR}}{|\\text{Max Drawdown}|}$$\n",
     "\n",
     "**Interpretation**: Plus eleve = meilleur. Indique combien de rendement on obtient pour chaque unite de perte maximale potentielle."
-   ]
+   ],
+   "id": "cell-620cea09"
   },
   {
    "cell_type": "code",
@@ -669,14 +691,16 @@
     "\n",
     "print(f\"Calmar Ratio Strategie:  {calmar_strategy:.2f}\")\n",
     "print(f\"Calmar Ratio Benchmark:  {calmar_benchmark:.2f}\")"
-   ]
+   ],
+   "id": "cell-0105f986"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### Resume des Metriques Ajustees au Risque"
-   ]
+   ],
+   "id": "cell-c5a1596b"
   },
   {
    "cell_type": "code",
@@ -723,7 +747,8 @@
     "print(f\"{'Sortino Ratio':<25} {sortino_strategy:>15.2f} {sortino_benchmark:>15.2f}\")\n",
     "print(f\"{'Calmar Ratio':<25} {calmar_strategy:>15.2f} {calmar_benchmark:>15.2f}\")\n",
     "print(\"=\" * 60)"
-   ]
+   ],
+   "id": "cell-6e62f9b3"
   },
   {
    "cell_type": "markdown",
@@ -733,19 +758,22 @@
     "> - **Sharpe** > 1 : La strategie genere un bon rendement ajuste au risque total\n",
     "> - **Sortino** > Sharpe : La volatilite haussiere est superieure a la baissiere (bon signe)\n",
     "> - **Calmar** > 1 : Le CAGR est superieur au max drawdown (acceptable)"
-   ]
+   ],
+   "id": "cell-d135c220"
   },
   {
    "cell_type": "code",
    "source": "def conditional_sharpe(returns, risk_free_rate=0.02, vol_window=20):\n    \"\"\"\n    Calcule le Sharpe Ratio conditionnel par regime de volatilite.\n    \n    Args:\n        returns: Serie de returns journaliers\n        risk_free_rate: Taux sans risque annuel\n        vol_window: Fenetre de volatilite glissante (jours)\n    \n    Returns:\n        Dict avec 'high_vol_sharpe', 'low_vol_sharpe', 'threshold'\n    \"\"\"\n    # TODO etudiant : separer les returns par regime de volatilite et calculer le Sharpe\n    pass\n\n# Test (decommenter quand implemente)\n# result = conditional_sharpe(backtest_df['strategy_returns'])\n# print(f\"Seuil volatilite: {result['threshold']:.4f}\")\n# print(f\"Sharpe haute volatilite: {result['high_vol_sharpe']:.2f}\")\n# print(f\"Sharpe basse volatilite: {result['low_vol_sharpe']:.2f}\")\nprint(\"Exercice a completer\")",
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-edb47cb1"
   },
   {
    "cell_type": "markdown",
    "source": "---\n\n### Exercice 1 : Sharpe Ratio conditionnel par regime de volatilite\n\nDans cet exercice, vous allez calculer un Sharpe Ratio qui distingue les periodes de haute et basse volatilite.\n\n**Objectif** : Ecrire une fonction `conditional_sharpe` qui calcule le Sharpe Ratio separement pour les jours de haute volatilite et les jours de basse volatilite, selon un seuil defini par la mediane de la volatilite glissante (fenetre 20 jours).\n\n**Regles** :\n- Calculer la volatilite glissante 20 jours avec `returns.rolling(20).std()`\n- La mediane de cette serie est le seuil : les jours au-dessus = \"haute volatilite\", en dessous = \"basse volatilite\"\n- Calculer le Sharpe Ratio annuelise pour chaque regime (haute et basse) separement\n- Retourner un dict `{'high_vol_sharpe': float, 'low_vol_sharpe': float, 'threshold': float}`\n\n**Indices** :\n- `# Etape 1` : `rolling_vol = returns.rolling(20).std()` puis `threshold = rolling_vol.median()`\n- `# Etape 2` : Separer les returns en deux groupes : `returns[rolling_vol > threshold]` et `returns[rolling_vol <= threshold]`\n- `# Etape 3` : Appliquer la formule du Sharpe (moyenne * 252 - 0.02) / (ecart-type * sqrt(252)) a chaque groupe",
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-f588178b"
   },
   {
    "cell_type": "markdown",
@@ -761,7 +789,8 @@
     "\n",
     "> *Ancre savante -- Grossman, S. & Zhou, Z. (1993), « Optimal Investment Strategies for Controlling Drawdowns », Mathematical Finance 3(3), 241-276. Le drawdown comme mesure de risque formelle (et l'optimisation sous contrainte de drawdown maximal) y est etabli ; le Max Drawdown etudie dans cette Partie 2 en est l'avatar empirique le plus utilise.*\n",
     ""
-   ]
+   ],
+   "id": "cell-5c84ad8e"
   },
   {
    "cell_type": "code",
@@ -814,7 +843,8 @@
     "print(f\"  Jours en Drawdown: {(dd_df['drawdown_pct'] < 0).sum()} / {len(dd_df)}\")\n",
     "\n",
     "dd_df.tail()"
-   ]
+   ],
+   "id": "cell-58e5413f"
   },
   {
    "cell_type": "markdown",
@@ -837,7 +867,8 @@
     "- Max DD 15-25% : Bon pour strategies individuelles\n",
     "- Max DD > 30% : Eleve - necessite un fort appetit au risque"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-e04a7ca7"
   },
   {
    "cell_type": "code",
@@ -903,7 +934,8 @@
     "print(f\"\\nDuree Max Drawdown: {max_dd_duration} jours\")\n",
     "if dd_start and dd_end:\n",
     "    print(f\"Periode: {dd_start.date()} - {dd_end.date()}\")"
-   ]
+   ],
+   "id": "cell-8ad4bc69"
   },
   {
    "cell_type": "markdown",
@@ -928,7 +960,8 @@
     "- Diversifier sur plusieurs non-correles\n",
     "- Reduire la taille des positions pour passer les periodes difficiles"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-4dca6126"
   },
   {
    "cell_type": "markdown",
@@ -937,7 +970,8 @@
     "### 2.2 Underwater Plot (10 min)\n",
     "\n",
     "Le **Underwater Plot** visualise les periodes de drawdown et leur intensite."
-   ]
+   ],
+   "id": "cell-7c52c6fe"
   },
   {
    "cell_type": "code",
@@ -980,7 +1014,8 @@
     "    plt.show()\n",
     "\n",
     "plot_underwater(dd_df['drawdown_pct'], \"Strategie - Underwater Plot\")"
-   ]
+   ],
+   "id": "cell-b4cfeecd"
   },
   {
    "cell_type": "markdown",
@@ -989,7 +1024,8 @@
     "\n",
     "Le code ci-dessous identifie et analyse les pires episodes de drawdown de la strategie. Cette analyse permet de comprendre les conditions de marche qui ont conduit aux plus fortes pertes."
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-c3450c73"
   },
   {
    "cell_type": "code",
@@ -1036,14 +1072,16 @@
     "\n",
     "print(\"Top 5 pires drawdowns:\")\n",
     "find_top_drawdowns(dd_df['drawdown_pct'], 5)"
-   ]
+   ],
+   "id": "cell-870710c6"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **Point Cle**: L'analyse des drawdowns est cruciale pour la gestion du risque. Un max drawdown de 20% signifie qu'a un moment, un investisseur a vu son capital baisser de 20% depuis son pic - psychologiquement difficile a supporter."
-   ]
+   ],
+   "id": "cell-f6ba0311"
   },
   {
    "cell_type": "markdown",
@@ -1056,7 +1094,8 @@
     "### 3.1 Trade Statistics (10 min)\n",
     "\n",
     "Analysons les statistiques au niveau des trades individuels."
-   ]
+   ],
+   "id": "cell-7d2ebe62"
   },
   {
    "cell_type": "code",
@@ -1106,7 +1145,8 @@
     "\n",
     "print(f\"Nombre de trades: {len(trades_df)}\")\n",
     "trades_df.head(10)"
-   ]
+   ],
+   "id": "cell-e60b32db"
   },
   {
    "cell_type": "markdown",
@@ -1241,7 +1281,8 @@
     "print(f\"Max Consec. Losses:       {trade_stats['max_consec_losses']}\")\n",
     "print(f\"\\nTotal P&L:                {trade_stats['total_pnl']:.2%}\")\n",
     "print(\"=\" * 50)"
-   ]
+   ],
+   "id": "cell-1c05c0b6"
   },
   {
    "cell_type": "markdown",
@@ -1263,7 +1304,8 @@
     "\n",
     "**Limitation** : Ces statistiques sont basees sur des trades fermes. Les positions ouvertes ne sont pas comptees."
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-ff41b083"
   },
   {
    "cell_type": "markdown",
@@ -1272,7 +1314,8 @@
     "### 3.2 Trade Distribution (10 min)\n",
     "\n",
     "Visualisons la distribution des P&L et les patterns temporels."
-   ]
+   ],
+   "id": "cell-9d46e870"
   },
   {
    "cell_type": "code",
@@ -1323,7 +1366,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-7df36643"
   },
   {
    "cell_type": "markdown",
@@ -1348,19 +1392,22 @@
     "- Longues sections plates : strategie inactive ou sans signaux\n",
     "- Croissance acceleree soudaine : peut etre un outlier (chance)"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-22fcb666"
   },
   {
    "cell_type": "code",
    "source": "def analyze_trade_robustness(trades, min_loss_streak=3, last_n=20, stability_window=30, stability_threshold=0.02):\n    \"\"\"\n    Analyse la robustesse d'une serie de trades.\n    \n    Args:\n        trades: DataFrame avec colonnes 'pnl' et 'outcome'\n        min_loss_streak: Longueur minimale des series de pertes consecutives\n        last_n: Nombre de derniers trades pour le ratio gain/perte\n        stability_window: Fenetre glissante pour la stabilite\n        stability_threshold: Seuil d'ecart-type pour la stabilite\n    \n    Returns:\n        Dict avec 'loss_streaks', 'recent_ratio', 'is_stable'\n    \"\"\"\n    # TODO etudiant : implementer l'analyse de robustesse\n    return None\n\n# Test (decommenter quand implemente)\n# robustness = analyze_trade_robustness(trades_df)\n# print(f\"Series de pertes >= 3: {robustness['loss_streaks']}\")\n# print(f\"Ratio gain/perte recent: {robustness['recent_ratio']:.2f}\")\n# print(f\"Strategie stable: {robustness['is_stable']}\")\nprint(\"Exercice a completer\")",
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-8b3d670c"
   },
   {
    "cell_type": "markdown",
    "source": "---\n\n### Exercice 2 : Analyse de robustesse d'une serie de trades\n\nDans cet exercice, vous allez evaluer la robustesse d'une strategie a partir de ses trades.\n\n**Objectif** : Ecrire une fonction `analyze_trade_robustness` qui prend un DataFrame de trades (colonnes `pnl` et `outcome`) et retourne un dictionnaire avec 3 indicateurs de robustesse : (1) le nombre de series de pertes consecutives de longueur >= N, (2) le ratio gain moyen / perte moyenne sur les 20 derniers trades, (3) un booleen indiquant si la renteabilite est stable (ecart-type du P&L cumulatif glissant < seuil).\n\n**Regles** :\n- `consecutive_loss_streaks(trades, min_length=3)` : compter le nombre de sequences de pertes consecutives d'au moins `min_length` trades\n- `recent_gain_loss_ratio(trades, last_n=20)` : ratio `|mean(wins)| / |mean(losses)|` sur les `last_n` trades\n- `is_stable(trades, window=30, threshold=0.02)` : le P&L cumulatif glissant (fenetre `window`) a un ecart-type < `threshold`\n\n**Indices** :\n- `# Etape 1` : Pour les sequences consecutives, iterer sur `trades['outcome']` et compter les runs de -1\n- `# Etape 2` : Pour le ratio recent, selectionner `trades.tail(last_n)` puis separer wins/losses\n- `# Etape 3` : Pour la stabilite, calculer `trades['pnl'].rolling(window).sum().std()`",
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-f54e111e"
   },
   {
    "cell_type": "code",
@@ -1430,7 +1477,8 @@
     "\n",
     "print(\"Returns par jour de semaine:\")\n",
     "print(returns_by_day)"
-   ]
+   ],
+   "id": "cell-6b921bc8"
   },
   {
    "cell_type": "markdown",
@@ -1456,7 +1504,8 @@
     "- Ajuster la taille des positions selon le jour/mois\n",
     "- Identifier des periodes a risque eleve"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-87967969"
   },
   {
    "cell_type": "markdown",
@@ -1479,7 +1528,8 @@
     "\n",
     "> *Ancre savante -- Jensen, M. C. (1968), « The Performance of Mutual Funds in the Period 1945-1964 », The Journal of Finance 23(2), 389-416. L'alpha ajuste au risque systematique (formule ci-dessus, `alpha = Rs - (Rf + beta*(Rb-Rf))`) porte son nom (« Jensen's alpha ») ; il decompose la surperformance en celle expliquee par le beta (CAPM) et le residu (habilite/alpha).*\n",
     ""
-   ]
+   ],
+   "id": "cell-9ce8cf60"
   },
   {
    "cell_type": "code",
@@ -1558,7 +1608,8 @@
     "    print(f\"  - Alpha > 0: Surperformance ajustee au risque\")\n",
     "else:\n",
     "    print(f\"  - Alpha <= 0: Pas de surperformance ajustee au risque\")"
-   ]
+   ],
+   "id": "cell-e8368a70"
   },
   {
    "cell_type": "markdown",
@@ -1626,7 +1677,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-372baa41"
   },
   {
    "cell_type": "markdown",
@@ -1647,7 +1699,8 @@
     "\n",
     "Ces visualisations complementent les metriques numeraires (Alpha, Beta) avec une intuition visuelle."
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-bd4ce789"
   },
   {
    "cell_type": "code",
@@ -1703,7 +1756,8 @@
     "print(\"\\nInterpretation:\")\n",
     "print(\"  - IR > 0.5: Bonne generation d'alpha\")\n",
     "print(\"  - IR > 1.0: Excellente generation d'alpha\")"
-   ]
+   ],
+   "id": "cell-5b53b60c"
   },
   {
    "cell_type": "markdown",
@@ -1721,7 +1775,8 @@
     "- **IR = 0.5 - 1.0** : Bon - generation d'alpha solide\n",
     "- **IR < 0.5** : Faible - l'alpha est inconsistant ou negatif"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-9574d094"
   },
   {
    "cell_type": "markdown",
@@ -1734,7 +1789,8 @@
     "### 5.1 Acceder aux Insights dans QCAlgorithm\n",
     "\n",
     "Dans un algorithme QuantConnect, vous pouvez acceder aux metriques de backtest via l'API."
-   ]
+   ],
+   "id": "cell-65557f92"
   },
   {
    "cell_type": "code",
@@ -1815,7 +1871,8 @@
     "\n",
     "print(\"Exemple de code QCAlgorithm pour acceder aux statistiques:\")\n",
     "print(qc_example_code)"
-   ]
+   ],
+   "id": "cell-1fa386ef"
   },
   {
    "cell_type": "markdown",
@@ -1824,7 +1881,8 @@
     "### 5.2 Structure des Resultats de Backtest QuantConnect\n",
     "\n",
     "QuantConnect fournit des statistiques detaillees apres chaque backtest."
-   ]
+   ],
+   "id": "cell-fc15ca65"
   },
   {
    "cell_type": "code",
@@ -1924,7 +1982,8 @@
     "    print(f\"  {key:<25} {str(qc_backtest_stats[key]):>12}\")\n",
     "\n",
     "print(\"=\" * 60)"
-   ]
+   ],
+   "id": "cell-2dc18770"
   },
   {
    "cell_type": "markdown",
@@ -1937,7 +1996,8 @@
     "### 6.1 Simulation Monte Carlo (10 min)\n",
     "\n",
     "La **simulation Monte Carlo** permet d'estimer la distribution des resultats possibles en reshufflant les trades."
-   ]
+   ],
+   "id": "cell-d4862e3f"
   },
   {
    "cell_type": "code",
@@ -2018,7 +2078,8 @@
     "print(f\"  5e percentile:   {mc_results['dd_percentiles'][5]:.2%}\")\n",
     "print(f\"  Mediane (50e):   {mc_results['dd_percentiles'][50]:.2%}\")\n",
     "print(f\"  95e percentile:  {mc_results['dd_percentiles'][95]:.2%}\")"
-   ]
+   ],
+   "id": "cell-1002a516"
   },
   {
    "cell_type": "markdown",
@@ -2079,7 +2140,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-fec7ec6d"
   },
   {
    "cell_type": "markdown",
@@ -2097,19 +2159,22 @@
     "   - **Expectations management** : Communiquer les probabilites de performance aux investisseurs\n",
     "   - **Robustesse check** : Si les percentiles sont tres larges, la strategie est tres dependante de la sequence des returns"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-809e421d"
   },
   {
    "cell_type": "code",
    "source": "def constrained_monte_carlo(returns, n_simulations=500, initial_capital=100000, max_dd_threshold=-0.20):\n    \"\"\"\n    Simulation Monte Carlo avec contrainte de max drawdown.\n    \n    Args:\n        returns: Serie ou array de returns journaliers\n        n_simulations: Nombre de simulations a generer\n        initial_capital: Capital initial\n        max_dd_threshold: Seuil de drawdown maximal autorise (negatif, ex: -0.20)\n    \n    Returns:\n        Array des percentiles [10, 50, 90] des valeurs finales valides, ou None\n    \"\"\"\n    # TODO etudiant : implementer la simulation Monte Carlo contrainte\n    pass\n\n# Test (decommenter quand implemente)\n# result = constrained_monte_carlo(backtest_df['strategy_returns'], n_simulations=500, max_dd_threshold=-0.25)\n# if result is not None:\n#     print(f\"Percentiles (10/50/90): {result[0]:,.0f} / {result[1]:,.0f} / {result[2]:,.0f}\")\n# else:\n#     print(\"Aucune simulation valide\")\nprint(\"Exercice a completer\")",
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-d217ac22"
   },
   {
    "cell_type": "markdown",
    "source": "---\n\n### Exercice 3 : Simulation Monte Carlo avec contraintes\n\nDans cet exercice, vous allez implementer une version simplifiee de Monte Carlo qui respecte des contraintes de risque.\n\n**Objectif** : Ecrire une fonction `constrained_monte_carlo` qui genere N simulations et ne conserve que celles dont le **max drawdown ne depasse pas un seuil** donne. Retourner les percentiles des valeurs finales parmi les simulations valides.\n\n**Regles** :\n- Reshuffler les returns historiques avec remise (bootstrap)\n- Rejeter toute simulation dont le max drawdown depasse `max_dd_threshold` (en decimal, ex: -0.20)\n- Si aucune simulation valide, retourner `None`\n- Calculer les percentiles 10, 50, 90 des valeurs finales valides\n\n**Indices** :\n- `# Etape 1` : Boucler N fois, pour chaque iteration tirer `len(returns)` returns aleatoires avec `np.random.choice`\n- `# Etape 2` : Calculer l'equity curve avec `np.cumprod(1 + shuffled_returns) * initial_capital`\n- `# Etape 3` : Calculer le max drawdown de chaque simulation et filtrer\n- `# Etape 4` : Retourner `np.percentile(valid_values, [10, 50, 90])` si `len(valid_values) > 0`",
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-0c516d96"
   },
   {
    "cell_type": "markdown",
@@ -2118,7 +2183,8 @@
     "### 6.2 Rolling Statistics (10 min)\n",
     "\n",
     "Les statistiques glissantes permettent d'identifier les changements de regime."
-   ]
+   ],
+   "id": "cell-478fa840"
   },
   {
    "cell_type": "code",
@@ -2214,7 +2280,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-281f85fc"
   },
   {
    "cell_type": "markdown",
@@ -2224,7 +2291,8 @@
     "> - **Rolling Sharpe**: Identifie les periodes de bonne/mauvaise performance ajustee au risque\n",
     "> - **Rolling Volatility**: Detecte les changements de regime de volatilite\n",
     "> - **Rolling Win Rate < 50%**: Periodes difficiles necessitant peut-etre une adaptation"
-   ]
+   ],
+   "id": "cell-e71d6939"
   },
   {
    "cell_type": "markdown",
@@ -2235,7 +2303,8 @@
     "## Partie 7: Rapport Complet (20 min)\n",
     "\n",
     "### 7.1 Generer un Rapport de Backtest Complet"
-   ]
+   ],
+   "id": "cell-78212ba7"
   },
   {
    "cell_type": "code",
@@ -2393,7 +2462,8 @@
     ")\n",
     "\n",
     "print(report)"
-   ]
+   ],
+   "id": "cell-cdebfba1"
   },
   {
    "cell_type": "markdown",
@@ -2407,7 +2477,8 @@
     "\n",
     "Le workflow typique : `calculate_metrics()` → `format_backtest_summary()` → affichage."
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-3bc478a0"
   },
   {
    "cell_type": "code",
@@ -2448,7 +2519,8 @@
     "# Formater via helper\n",
     "summary_helper = format_backtest_summary(metrics_helper, \"MA Crossover (via helper)\")\n",
     "print(summary_helper)"
-   ]
+   ],
+   "id": "cell-b1b7fb29"
   },
   {
    "cell_type": "markdown",
@@ -2463,7 +2535,8 @@
     "\n",
     "C'est la fonction \"one-stop-shop\" pour un diagnostic rapide de la strategie."
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-e9890adc"
   },
   {
    "cell_type": "code",
@@ -2485,7 +2558,8 @@
     "    benchmark=backtest_df['benchmark_equity'],\n",
     "    title='MA Crossover Strategy - Backtest Results'\n",
     ")"
-   ]
+   ],
+   "id": "cell-57690b5b"
   },
   {
    "cell_type": "markdown",
@@ -2506,7 +2580,8 @@
     "    backtest_df['strategy_returns'],\n",
     "    title='MA Crossover - Returns Distribution'\n",
     ")"
-   ]
+   ],
+   "id": "cell-4b0330ea"
   },
   {
    "cell_type": "markdown",
@@ -2520,7 +2595,8 @@
     "\n",
     "Le resultat est un DataFrame avec toutes les metriques cote a cote."
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-cab279df"
   },
   {
    "cell_type": "code",
@@ -2557,7 +2633,8 @@
     "\n",
     "print(\"\\nComparaison des Strategies:\")\n",
     "print(comparison.round(4))"
-   ]
+   ],
+   "id": "cell-7da2e538"
   },
   {
    "cell_type": "markdown",
@@ -2621,7 +2698,8 @@
     "---\n",
     "\n",
     "**Notebook complete. Les metriques de backtest sont essentielles pour evaluer objectivement vos strategies.**"
-   ]
+   ],
+   "id": "cell-06619ddc"
   }
  ],
  "metadata": {
@@ -2637,5 +2715,5 @@
   "qc_reference": true
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -49,21 +49,24 @@
     "| 8 | Risk Management Models | 15 min |\n",
     "| 9 | Strategie Framework Complete | 20 min |",
     "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-38a4d388"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-09a0cf94"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-3f679e0a"
   },
   {
    "cell_type": "markdown",
@@ -78,7 +81,8 @@
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-b8064a98"
   },
   {
    "cell_type": "markdown",
@@ -117,7 +121,8 @@
     "| **Portfolio Construction** | Allocation des poids | Testable independamment |\n",
     "| **Risk Management** | Contraintes de risque | Regle de risque reutilisable |\n",
     "| **Execution** | Placement des ordres | Optimisation des couts |"
-   ]
+   ],
+   "id": "cell-41234fa7"
   },
   {
    "cell_type": "code",
@@ -143,7 +148,8 @@
     "from datetime import datetime, timedelta\n",
     "\n",
     "print(\"Imports reussis\")"
-   ]
+   ],
+   "id": "cell-afba4843"
   },
   {
    "cell_type": "markdown",
@@ -189,7 +195,8 @@
     "| `Symbol` | Symbol | L'actif concerne |\n",
     "| `Quantity` | decimal | Nombre d'actions cibles |\n",
     "| `Tag` | string | Commentaire optionnel |"
-   ]
+   ],
+   "id": "cell-03d57e7a"
   },
   {
    "cell_type": "code",
@@ -247,7 +254,8 @@
     "print(\"  - __init__(): Initialisation\")\n",
     "print(\"  - CreateTargets(): Insights -> PortfolioTargets\")\n",
     "print(\"  - OnSecuritiesChanged(): Gestion des changements d'univers\")"
-   ]
+   ],
+   "id": "cell-316f5330"
   },
   {
    "cell_type": "markdown",
@@ -266,7 +274,8 @@
     "| `NullPortfolioConstructionModel` | Ne fait rien | Desactive le composant |\n",
     "\n",
     "> *Ancre savante -- Black, F. & Litterman, R. (1991), Asset Allocation: Combining Investor Views with Market Equilibrium, The Journal of Fixed Income 1(2):7-18. DOI 10.3905/jfi.1991.408013. (Black-Litterman : combine views investisseur + equilibre de marche.)*\n"
-   ]
+   ],
+   "id": "cell-768eb949"
   },
   {
    "cell_type": "markdown",
@@ -295,7 +304,8 @@
     "- MSFT (Up): +25%\n",
     "- GOOGL (Up): +25%\n",
     "- TSLA (Down): -25%"
-   ]
+   ],
+   "id": "cell-46eb12ff"
   },
   {
    "cell_type": "code",
@@ -349,7 +359,8 @@
     "print(\"  - Direction Up -> poids positif\")\n",
     "print(\"  - Direction Down -> poids negatif (short)\")\n",
     "print(\"  - Simple et sans biais\")"
-   ]
+   ],
+   "id": "cell-a44ed851"
   },
   {
    "cell_type": "markdown",
@@ -370,7 +381,8 @@
     "> *Backtest ID: a764d2faa2e942a0feb3e552da0d3fdc*\n",
     "\n",
     "> *Ancre savante -- Bailey, D.H. & Lopez de Prado, M. (2012), The Sharpe Ratio Efficient Frontier, Journal of Risk 15(2):3-44. DOI 10.21314/JOR.2012.259. (Probabilistic Sharpe Ratio, corrige du biais de l'echantillon non-IID.)*\n"
-   ]
+   ],
+   "id": "cell-b6deefa6"
   },
   {
    "cell_type": "markdown",
@@ -432,7 +444,8 @@
     "print(\"  - timedelta(days=30)\")\n",
     "print(\"  - Expiry.EndOfMonth\")\n",
     "print(\"  - Custom lambda function\")"
-   ]
+   ],
+   "id": "cell-b52418b6"
   },
   {
    "cell_type": "markdown",
@@ -451,7 +464,8 @@
     "> *Correctif #3367 : le code de reference de la cellule precedente utilisait `EqualWeightingPortfolioConstructionModel(rebalance=Resolution.Weekly)`, or `Resolution.Weekly` n'existe pas (l'enum Resolution ne contient que Tick / Second / Minute / Hour / Daily) -- la strategie echouait a l'initialisation (Runtime Error, cf. correctif #3522). L'idiome est corrige en `Expiry.EndOfWeek` (rebalancement hebdomadaire aligne sur la fin de semaine). Le backtest aboutit desormais : metriques reelles ci-dessus obtenues par redeploiement de l'algorithme corrige sur QC Cloud (projet 33072122, 2015-2024, $100k). Les champs Sortino / Total Orders / Trades / Win Rate / Total Fees sont omis car non fournis de maniere fiable par l'API read_backtest. Pour memoire, le bloc d'origine affichait Sharpe 1.912 / CAGR 36.493% / End Equity $107938.48 -- des valeurs fabriquees et internement contradictoires (End Equity $107,938 sur 10 ans = +0.77% de CAGR, incompatible avec 36.493%).*\n",
     ">\n",
     "> *Backtest ID: 62cb1805751563f907002edd3a9fddde*"
-   ]
+   ],
+   "id": "cell-f5979b4e"
   },
   {
    "cell_type": "markdown",
@@ -478,7 +492,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-7aa96a5f"
   },
   {
    "cell_type": "markdown",
@@ -492,11 +507,12 @@
     "| Pas de biais | Ignore la magnitude attendue |\n",
     "| Robuste | Peut surponderer des signaux faibles |\n",
     "| Diversifie naturellement | Pas d'optimisation du risque |"
-   ]
+   ],
+   "id": "cell-21d1a9ec"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-fd1392df",
    "metadata": {},
    "source": [
     "---\n",
@@ -519,7 +535,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-97264684",
    "metadata": {},
    "source": [
     "# [REFERENCE QC] Exercice 1 : Equal-weight avec rebalancement conditionnel\n",
@@ -563,7 +579,8 @@
     "| MSFT | Up (+1) | 0.05 | 0.60 | 0.030 | 15% |\n",
     "| GOOGL | Up (+1) | 0.08 | 0.70 | 0.056 | 28% |\n",
     "| TSLA | Down (-1) | 0.06 | 0.55 | -0.033 | -17% |"
-   ]
+   ],
+   "id": "cell-39aa5689"
   },
   {
    "cell_type": "code",
@@ -612,7 +629,8 @@
     "print(\"  - Poids = Direction * Magnitude * Confidence\")\n",
     "print(\"  - Insights avec forte conviction -> poids plus eleves\")\n",
     "print(\"  - Permet d'exploiter la qualite des signaux\")"
-   ]
+   ],
+   "id": "cell-78b82761"
   },
   {
    "cell_type": "markdown",
@@ -636,7 +654,8 @@
     "> | Note | InsightWeighting with MomentumAlpha - no trades executed (insights likely not generated) |\n",
     ">\n",
     "> *Backtest ID: *\n"
-   ]
+   ],
+   "id": "cell-d911ec42"
   },
   {
    "cell_type": "markdown",
@@ -737,7 +756,8 @@
     "print(\"  - Direction: basee sur le signe du momentum\")\n",
     "print(\"  - Magnitude: momentum absolu normalise\")\n",
     "print(\"  - Confidence: Sharpe ratio normalise\")"
-   ]
+   ],
+   "id": "cell-c9ef4a72"
   },
   {
    "cell_type": "markdown",
@@ -751,7 +771,8 @@
     "| Signaux tous equivalents | EqualWeighting |\n",
     "| Modele ML avec probabilites | InsightWeighting |\n",
     "| Signaux discretionnaires | EqualWeighting |"
-   ]
+   ],
+   "id": "cell-d5afdf67"
   },
   {
    "cell_type": "markdown",
@@ -783,7 +804,8 @@
     "| `resolution` | Resolution | Resolution des donnees historiques |\n",
     "\n",
     "> *Ancres savantes -- Markowitz, H. (1952), Portfolio Selection, The Journal of Finance 7(1):77-91. DOI 10.1111/j.1540-6261.1952.tb01525.x (theorie moderne du portefeuille MPT, optimisation Mean-Variance) ; Sharpe, W.F. (1966), Mutual Fund Performance, The Journal of Business 39(1):119-138. DOI 10.1086/294846 (ratio de Sharpe / reward-to-variability, objectif Maximum Sharpe).*\n"
-   ]
+   ],
+   "id": "cell-c33064a3"
   },
   {
    "cell_type": "code",
@@ -842,7 +864,8 @@
     "print(\"  - rebalancingPeriod: Expiry.EndOfMonth\")\n",
     "print(\"  - portfolioBias: PortfolioBias.Long\")\n",
     "print(\"  - lookback: 60 jours\")"
-   ]
+   ],
+   "id": "cell-f55ef51f"
   },
   {
    "cell_type": "markdown",
@@ -857,7 +880,8 @@
     "> *Correctif #3367 : le bloc precedent affichait Net Profit +7.791% / End Equity $107,790.97 / Total Fees $326.83 -- mais avec **Trades = 0**, une contradiction interne (zero trade implique zero fill, zero frais, zero profit). Les valeurs etaient fabriquees.*\n",
     ">\n",
     "> *Verification QC Cloud (3 tentatives, projet 33048058) : la strategie ne s'execute pas sur la version Lean actuelle. Deux causes : (1) derive d'API -- les arguments `rebalancingPeriod` et `portfolioBias` du `MeanVarianceOptimizationPortfolioConstructionModel` ont ete supprimes des versions recentes de Lean ; (2) apres correction de l'API, le `ConstantAlphaModel` emet des `Insight` sans `magnitude`, que le modele MeanVariance refuse au runtime (\"does not accept None as Insight.magnitude\"). L'obtention de metriques reelles necessiterait de redisigner le modele Alpha (hors scope #3367, qui corrige les metriques fabriquees sans reinventer les algos). Les valeurs ci-dessus documentent la realite verifiee plutot que d'inventer des chiffres.*"
-   ]
+   ],
+   "id": "cell-c1d4d5b4"
   },
   {
    "cell_type": "markdown",
@@ -914,7 +938,8 @@
     "print(\"  - PortfolioBias.Long: Positions longues uniquement\")\n",
     "print(\"  - PortfolioBias.Short: Positions courtes uniquement\")\n",
     "print(\"  - PortfolioBias.LongShort: Les deux\")"
-   ]
+   ],
+   "id": "cell-5d91036f"
   },
   {
    "cell_type": "markdown",
@@ -929,7 +954,8 @@
     "> *Correctif #3367 : le bloc precedent affichait Net Profit +12.797% / End Equity $112,797.12 / Total Fees $209.1 -- mais avec **Trades = 0**, une contradiction interne. Les valeurs etaient fabriquees.*\n",
     ">\n",
     "> *Verification QC Cloud (projet 33048059) : meme diagnostic que MeanVarianceOptimizationExample ci-dessus -- derive d'API Lean (`rebalancingPeriod`/`portfolioBias` supprimes) et le `MeanVarianceOptimizationPortfolioConstructionModel` refuse les `Insight` sans `magnitude`. L'obtention de metriques reelles necessiterait de redisigner le modele Alpha (hors scope #3367). Realite verifiee, pas de valeurs inventees.*"
-   ]
+   ],
+   "id": "cell-4dcc72f1"
   },
   {
    "cell_type": "markdown",
@@ -943,11 +969,12 @@
     "| Base theorique solide (MPT) | Peut generer des positions concentrees |\n",
     "| Prend en compte les correlations | Plus lent (optimisation numerique) |\n",
     "| Configurable (Long/Short) | Necessite suffisamment d'historique |"
-   ]
+   ],
+   "id": "cell-9e48c711"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-5ba4e772",
    "metadata": {},
    "source": [
     "---\n",
@@ -970,7 +997,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-2eb842b7",
    "metadata": {},
    "source": [
     "# [REFERENCE QC] Exercice 2 : Mean-Variance avec contraintes sectorielles\n",
@@ -1019,7 +1046,8 @@
     "| Or (GLD) | 15% | 6.67 | 16.7% |\n",
     "\n",
     "> *Ancres savantes -- Qian, E. (2005), Risk Parity Portfolios: Efficient Portfolios Through True Diversification, PanAgora Asset Management Research (origine praticien du Risk Parity) ; Maillard, S., Roncalli, T. & Teiletche, J. (2010), The Properties of Equally Weighted Risk Contribution Portfolios, The Journal of Portfolio Management 36(4):60-70. DOI 10.3905/jpm.2010.36.4.060 (formalisation : egaliser la contribution au risque de chaque actif).*\n"
-   ]
+   ],
+   "id": "cell-8968b1c3"
   },
   {
    "cell_type": "code",
@@ -1138,7 +1166,8 @@
     "print(\"  - Poids = 1/Volatilite (normalise)\")\n",
     "print(\"  - Actifs moins volatils -> poids plus eleves\")\n",
     "print(\"  - Contribution au risque egale pour tous les actifs\")"
-   ]
+   ],
+   "id": "cell-28193fb7"
   },
   {
    "cell_type": "markdown",
@@ -1197,7 +1226,8 @@
     "print(\"  - Obligations (faible vol) -> poids eleves (~40-50%)\")\n",
     "print(\"  - Or (vol moyenne) -> poids moyens (~15-20%)\")\n",
     "print(\"  - Actions (haute vol) -> poids faibles (~20-30%)\")"
-   ]
+   ],
+   "id": "cell-b9f95688"
   },
   {
    "cell_type": "markdown",
@@ -1219,7 +1249,8 @@
     "> Le modele Risk Parity custom s'execute sur la fenetre complete 2015-2024 sans erreur mais ne genere aucun ordre : dans `CreateTargets`, le bloc `try/except: continue` autour du calcul de volatilite (`algorithm.History(...)` + `history['close'].pct_change()`) avale silencieusement chaque symbole, donc aucun target actionnable n'est jamais construit. Le caption d'origine (\"insights not generated in Q1 2023\") etait doublement faux : la fenetre est 2015-2024 (2516 dates), et la cause reelle est ce echec silencieux du PCM, non une absence d'insights.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 10708ff1d88e293034cd073a385cee1e). 0 ordre execute, $100,000 inchanges.*"
-   ]
+   ],
+   "id": "cell-fb88aced"
   },
   {
    "cell_type": "markdown",
@@ -1310,7 +1341,8 @@
     "- QQQ : 13.33% (EMA) + 30% (Trend) = **43.33%**\n",
     "- IWM : 13.33% (EMA) + 0% (Trend) = **13.33%**"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-add31add"
   },
   {
    "cell_type": "markdown",
@@ -1337,7 +1369,8 @@
     "| `VolumeWeightedAveragePriceExecutionModel` | VWAP execution | Gros ordres, minimiser impact |\n",
     "| `StandardDeviationExecutionModel` | Ordres Limit bases sur std | Reduire le slippage |\n",
     "| `NullExecutionModel` | Ne fait rien | Desactive l'execution |"
-   ]
+   ],
+   "id": "cell-3bf41b44"
   },
   {
    "cell_type": "code",
@@ -1569,7 +1602,8 @@
    ],
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-042a18f9"
   },
   {
    "cell_type": "markdown",
@@ -1580,7 +1614,8 @@
     "> **Runtime Error (backtest QC Cloud, bt 0d2d674a75f9874d5747dfee7c3b87e5).** La strategie de reference combine EMACrossAlpha + TrendStocksAlpha via CompositeAlphaModel, MultiStrategyPCM 40/60, rebalancement hebdomadaire, puis Runtime Error a 2015-04-01 : `Insight.Price(symbol, period, InsightDirection.UP, weight=None, source_model=self.name)` leve une TypeError - les alpha models du notebook utilisent des kwargs INVALIDES (`weight=`, `source_model=`). L'API QC est `Insight.Price(symbol, period, direction, magnitude=, conviction=, source=)`. Bug reel dans le code de reference (cellule EMACrossAlpha/TrendStocksAlpha), non un artifice. Le caption d'origine (\"warmup period exceeds Q1 2023\") etait faux : la fenetre est 2015-2024 (2516 dates) et l'arret vient de cette TypeError, non d'un warmup.. Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas committees (G.2 : aucune metrique non-verifiable). La table fabrique d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 0d2d674a75f9874d5747dfee7c3b87e5).*"
-   ]
+   ],
+   "id": "cell-8316bb18"
   },
   {
    "cell_type": "markdown",
@@ -1668,11 +1703,12 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-4b1f62a7"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-f83639aa",
    "metadata": {},
    "source": [
     "---\n",
@@ -1695,7 +1731,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-9b2e01e2",
    "metadata": {},
    "source": [
     "# [REFERENCE QC] Exercice 3 : Risk Parity avec contraintes\n",
@@ -1818,7 +1854,8 @@
    ],
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-19604f48"
   },
   {
    "cell_type": "markdown",
@@ -1853,7 +1890,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-235dfc3b"
   },
   {
    "cell_type": "markdown",
@@ -1907,14 +1945,16 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-3eaba914"
   },
   {
    "cell_type": "markdown",
    "source": [
     ""
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-f02d1e57"
   },
   {
    "cell_type": "code",
@@ -1961,7 +2001,8 @@
     "print(\"  - Simple et rapide\")\n",
     "print(\"  - Pas de controle sur le prix d'execution\")\n",
     "print(\"  - Peut subir du slippage sur gros volumes\")"
-   ]
+   ],
+   "id": "cell-eadf42b7"
   },
   {
    "cell_type": "markdown",
@@ -1997,7 +2038,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-ca9a8b24"
   },
   {
    "cell_type": "markdown",
@@ -2041,7 +2083,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-f916f707"
   },
   {
    "cell_type": "code",
@@ -2090,7 +2133,8 @@
     "print(\"  - Execute proportionnellement au volume du marche\")\n",
     "print(\"  - Minimise l'impact de marche\")\n",
     "print(\"  - Necessite Resolution.Minute ou plus fin\")"
-   ]
+   ],
+   "id": "cell-d9715f6e"
   },
   {
    "cell_type": "markdown",
@@ -2109,7 +2153,8 @@
     "> *Correctif #3367 : le bloc precedent affichait Sharpe 1.56 / CAGR 43.447% avec End Equity $109263.57 -- des valeurs **fabriquees et internement contradictoires** (une End Equity de $109263.57 sur 10 ans = +0.89% de CAGR, incompatible avec le CAGR de 43.447% affiche). Metriques reelles ci-dessus obtenues par redeploiement de l'algorithme verbatim sur QC Cloud (projet 33072197, 2015-2024, $100k). Les champs Sortino / Total Orders / Trades / Win Rate / Total Fees sont omis car non fournis de maniere fiable par l'API read_backtest (toujours 0 / \"-\").*\n",
     ">\n",
     "> *Backtest ID: ca4aff2968957c672d2629e2ef152e38*"
-   ]
+   ],
+   "id": "cell-fd9341a0"
   },
   {
    "cell_type": "markdown",
@@ -2169,7 +2214,8 @@
     "print(\"  - Prix Limit = Price - N * StdDev (pour achats)\")\n",
     "print(\"  - Attend des conditions favorables\")\n",
     "print(\"  - Peut ne pas etre execute si le marche s'eloigne\")"
-   ]
+   ],
+   "id": "cell-8c7a6ab8"
   },
   {
    "cell_type": "markdown",
@@ -2188,7 +2234,8 @@
     "> *Correctif #3367 : le bloc precedent affichait Sharpe 1.944 / CAGR 53.066% avec End Equity $111018.75 -- des valeurs **fabriquees et internement contradictoires** (une End Equity de $111018.75 sur 10 ans = +1.05% de CAGR, incompatible avec le CAGR de 53.066% affiche). Metriques reelles ci-dessus obtenues par redeploiement de l'algorithme verbatim sur QC Cloud (projet 33072217, 2015-2024, $100k). Les champs Sortino / Total Orders / Trades / Win Rate / Total Fees sont omis car non fournis de maniere fiable par l'API read_backtest (toujours 0 / \"-\").*\n",
     ">\n",
     "> *Backtest ID: 7208ae3f65e7bcfaf627a5b989e55d45*"
-   ]
+   ],
+   "id": "cell-85e249da"
   },
   {
    "cell_type": "markdown",
@@ -2201,7 +2248,8 @@
     "| **Immediate** | Rapide | Aucun | Eleve | Simple |\n",
     "| **VWAP** | Lent | Moyen | Faible | Moyenne |\n",
     "| **StdDev** | Variable | Eleve | Faible | Moyenne |"
-   ]
+   ],
+   "id": "cell-ce63d61d"
   },
   {
    "cell_type": "markdown",
@@ -2219,7 +2267,8 @@
     "2. Utilise **Market Orders** si le spread est acceptable\n",
     "3. Utilise **Limit Orders** si le spread est trop large\n",
     "4. Controle le **slippage maximum**"
-   ]
+   ],
+   "id": "cell-514d1bd1"
   },
   {
    "cell_type": "code",
@@ -2319,7 +2368,8 @@
     "print(\"  2. Si spread < 2x max_slippage -> Market Order\")\n",
     "print(\"  3. Sinon -> Limit Order a prix avantageux\")\n",
     "print(\"  4. Reduit le slippage sur marches peu liquides\")"
-   ]
+   ],
+   "id": "cell-55a84b33"
   },
   {
    "cell_type": "markdown",
@@ -2375,7 +2425,8 @@
     "print(\"  - Adapte le type d'ordre au marche\")\n",
     "print(\"  - Reduit les couts de transaction\")\n",
     "print(\"  - Plus efficace sur actifs moins liquides\")"
-   ]
+   ],
+   "id": "cell-598131d2"
   },
   {
    "cell_type": "markdown",
@@ -2386,7 +2437,8 @@
     "> **Runtime Error (backtest QC Cloud, bt d068e02425474a84268c99d6fd989816).** La strategie de reference utilise SmartExecutionModel (spread-aware) + EqualWeightingPCM + ConstantAlphaModel sur SPY/QQQ/IWM/VNQ/EEM en resolution Minute, puis Runtime Error a ~81% du backtest (vers 2022). Le caption d'origine (\"120920 orders, 0 filled trades, Q1 2023\") n'est PAS reproduit par l'execution verbatim : la fenetre est 2015-2024 complete (2516 dates, non Q1 2023) et le backtest tombe en erreur avant la fin. La ligne/message d'erreur exact n'est pas remonte par l'API read_backtest pour cette erreur tardive (visible sur la page de resultats QC Cloud, bt d068e024). Note : le chiffre 120920 ordres du caption d'origine n'a pas pu etre reproduit - signale au coordinateur (ai-01) qui avait marque cell 63 comme nuance (120920 suppose reel).. Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas committees (G.2 : aucune metrique non-verifiable). La table fabrique d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt d068e02425474a84268c99d6fd989816).*"
-   ]
+   ],
+   "id": "cell-d7a2d63a"
   },
   {
    "cell_type": "markdown",
@@ -2413,7 +2465,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-342ccb6c"
   },
   {
    "cell_type": "markdown",
@@ -2440,7 +2493,8 @@
     "| `MaximumSectorExposureRiskManagementModel` | Limite l'exposition par secteur |\n",
     "| `TrailingStopRiskManagementModel` | Trailing stop automatique |\n",
     "| `NullRiskManagementModel` | Desactive le risk management |"
-   ]
+   ],
+   "id": "cell-59c276b7"
   },
   {
    "cell_type": "markdown",
@@ -2506,7 +2560,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-caa32764"
   },
   {
    "cell_type": "code",
@@ -2554,7 +2609,8 @@
     "print(\"  - Surveille le drawdown de chaque position\")\n",
     "print(\"  - Si une position perd > 5% depuis son max -> liquidation\")\n",
     "print(\"  - Protection automatique contre les grosses pertes\")"
-   ]
+   ],
+   "id": "cell-64895da1"
   },
   {
    "cell_type": "markdown",
@@ -2573,7 +2629,8 @@
     "> *Correctif #3367 : le bloc precedent affichait Sharpe 5.664 / CAGR 215.072% avec End Equity $132551.14 -- des valeurs **fabriquees et internement contradictoires** (une End Equity de $132551.14 sur 10 ans = +2.86% de CAGR, incompatible avec le CAGR de 215.072% affiche). Metriques reelles ci-dessus obtenues par redeploiement de l'algorithme verbatim sur QC Cloud (projet 33072072, 2015-2024, $100k). Les champs Sortino / Total Orders / Trades / Win Rate / Total Fees sont omis car non fournis de maniere fiable par l'API read_backtest (toujours 0 / \"-\").*\n",
     ">\n",
     "> *Backtest ID: 815a39ff4580e56a821100b2f2fe5ed4*"
-   ]
+   ],
+   "id": "cell-938e6644"
   },
   {
    "cell_type": "markdown",
@@ -2634,7 +2691,8 @@
     "print(\"  - Classifie les positions par secteur\")\n",
     "print(\"  - Si un secteur depasse 20% -> reduit les positions\")\n",
     "print(\"  - Assure la diversification sectorielle\")"
-   ]
+   ],
+   "id": "cell-588d89b6"
   },
   {
    "cell_type": "markdown",
@@ -2657,7 +2715,8 @@
     "> | Total Fees | $59.62 |\n",
     ">\n",
     "> *Backtest ID: *\n"
-   ]
+   ],
+   "id": "cell-7c86a226"
   },
   {
    "cell_type": "markdown",
@@ -2770,7 +2829,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-c9496f85"
   },
   {
    "cell_type": "markdown",
@@ -2799,7 +2859,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-c236a676"
   },
   {
    "cell_type": "code",
@@ -2853,7 +2914,8 @@
     "print(\"  - Applique plusieurs regles simultanement\")\n",
     "print(\"  - Chaque regle est evaluee independamment\")\n",
     "print(\"  - Protection multi-niveaux\")"
-   ]
+   ],
+   "id": "cell-9650c622"
   },
   {
    "cell_type": "markdown",
@@ -2872,7 +2934,8 @@
     "> *Correctif #3367 : le bloc precedent affichait Sharpe 2.355 / CAGR 42.005% avec End Equity $108992.9 -- des valeurs **fabriquees et internement contradictoires** (une End Equity de $108992.9 sur 10 ans = +0.87% de CAGR, incompatible avec le CAGR de 42.005% affiche). Metriques reelles ci-dessus obtenues par redeploiement de l'algorithme verbatim sur QC Cloud (projet 33072157, 2015-2024, $100k). Les champs Sortino / Total Orders / Trades / Win Rate / Total Fees sont omis car non fournis de maniere fiable par l'API read_backtest (toujours 0 / \"-\").*\n",
     ">\n",
     "> *Backtest ID: 74b4d31aa87c2773f5be9ef32cb71a63*"
-   ]
+   ],
+   "id": "cell-65b48b70"
   },
   {
    "cell_type": "markdown",
@@ -2887,7 +2950,8 @@
     "| `MaximumSectorExposureRiskManagementModel(0.20)` | 20% | Max 20% par secteur |\n",
     "| `TrailingStopRiskManagementModel(0.03)` | 3% | Trailing stop 3% |\n",
     "| `CompositeRiskManagementModel(...)` | Multiple | Combine plusieurs models |"
-   ]
+   ],
+   "id": "cell-0aa90dc6"
   },
   {
    "cell_type": "markdown",
@@ -2906,7 +2970,8 @@
     "3. **Portfolio Construction** : Risk Parity\n",
     "4. **Execution** : Smart Execution avec controle du spread\n",
     "5. **Risk Management** : Composite (Drawdown + Sector)"
-   ]
+   ],
+   "id": "cell-1d7807a2"
   },
   {
    "cell_type": "code",
@@ -3175,7 +3240,8 @@
     "print(\"  3. Portfolio: RiskParityPortfolioConstructionFramework\")\n",
     "print(\"  4. Execution: SmartExecutionModelFramework\")\n",
     "print(\"  5. Risk: CompositeRiskManagementModel\")"
-   ]
+   ],
+   "id": "cell-ac20c615"
   },
   {
    "cell_type": "markdown",
@@ -3188,7 +3254,8 @@
     "> | Statut | Backtest non aboutissant (O(n^2) History-per-bar sur univers 30 titres) |\n",
     ">\n",
     "> *Correctif #3367 : le bloc precedent affichait un Statut \"Runtime Error\" MAIS avec des statistiques completes (Sharpe -1.137 / Sortino -1.273 / 296 trades / Win Rate 52.0%) -- une **contradiction** : un backtest en Runtime Error ne produit pas de Sharpe / Sortino / Win Rate valides. Ces statistiques etaient fabriquees. Le `FullFrameworkAlgorithm` (cellule precedente) combine `MomentumAlphaModelFramework` et `RiskParityPortfolioConstructionFramework`, qui appellent tous deux `algorithm.History(symbol, lookback)` par titre a chaque barre, sur un univers Coarse/Fine de 30 titres -- le meme pattern O(n^2) que le MomentumFramework de QC-Py-13 (verifie bloque ~9h avant arret manuel via la console QC). Ce backtest n'a deliberement **pas** ete relance ici pour ne pas bloquer le node QC ~9h. Les metriques reelles necessiteraient un redesign des modeles (indicateurs Momentum/RateOfChange enregistres en O(n)) -- hors scope #3367. Cette note documente la realite verifiee plutot que de conserver des chiffres fabriques.*"
-   ]
+   ],
+   "id": "cell-09bfe529"
   },
   {
    "cell_type": "markdown",
@@ -3229,7 +3296,8 @@
     "    | (Smart)          | --> Limit si spread large\n",
     "    +------------------+     -> Ordres\n",
     "```"
-   ]
+   ],
+   "id": "cell-c4869fd4"
   },
   {
    "cell_type": "markdown",
@@ -3286,7 +3354,8 @@
     "- Qian, E. (2005). Risk Parity Portfolios: Efficient Portfolios Through True Diversification. PanAgora Asset Management Research.\n",
     "- Sharpe, W.F. (1966). Mutual Fund Performance. The Journal of Business 39(1):119-138. DOI 10.1086/294846.\n",
     "\n"
-   ]
+   ],
+   "id": "cell-a5dcc043"
   }
  ],
  "metadata": {
@@ -3310,5 +3379,5 @@
   "qc_reference": true
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -43,14 +43,16 @@
     "5. Economic Indicators (15 min)\n",
     "6. Strategie Event-Driven: Earnings (20 min)",
     "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-e92d6044"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-37782ba9"
   },
   {
    "cell_type": "markdown",
@@ -65,7 +67,8 @@
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-2e754700"
   },
   {
    "cell_type": "markdown",
@@ -118,7 +121,8 @@
     "| **Oil Forecast** | Niveaux des reservoirs petrole | Offre/demande avant publication officielle |\n",
     "| **Tech Sentiment** | Tweets sur AAPL | Sentiment positif = acheter avant annonce |\n",
     "| **Value Investing** | Fundamentals Morningstar | Low P/E + High ROE = sous-evalue |"
-   ]
+   ],
+   "id": "cell-2947dc23"
   },
   {
    "cell_type": "code",
@@ -160,7 +164,8 @@
     "print(\"  4. Donnees CSV locales\")\n",
     "print(\"  5. Economic Indicators (macro)\")\n",
     "print(\"  6. Earnings Calendar\")"
-   ]
+   ],
+   "id": "cell-ac231b1a"
   },
   {
    "cell_type": "markdown",
@@ -193,7 +198,8 @@
     "- Fine Selection        - News feeds           - GetSource()\n",
     "                                               - Reader()\n",
     "```"
-   ]
+   ],
+   "id": "cell-c3302b2c"
   },
   {
    "cell_type": "markdown",
@@ -241,7 +247,8 @@
     "    sector = stock.AssetClassification.MorningstarSectorCode\n",
     "    market_cap = stock.MarketCap\n",
     "```"
-   ]
+   ],
+   "id": "cell-941ca100"
   },
   {
    "cell_type": "code",
@@ -347,7 +354,8 @@
     "print(\"  - FinancialStatements: TotalRevenue, NetIncome\")\n",
     "print(\"  - OperationRatios: ROE, ROA, OperationMargin\")\n",
     "print(\"  - AssetClassification: MorningstarSectorCode, MarketCap\")"
-   ]
+   ],
+   "id": "cell-0eeae957"
   },
   {
    "cell_type": "markdown",
@@ -377,7 +385,8 @@
     "> FundamentalsExplorerAlgorithm — univers uniquement, aucun trading dans OnData (squelette pedagogique). Verdict #3801 : **INTRINSIC** (0 trade verifie, 0 jour(s) boursier(s)).\n",
     "\n",
     "*Backtest QC Cloud 2015-01-01 -> 2024-12-31 (projet 33177683, bt 1526e20e4bdbcb5bf3a0b9d8780261d7) - 0 jour(s) boursier(s), Capital initial: $100,000*"
-   ]
+   ],
+   "id": "cell-69b61ede"
   },
   {
    "cell_type": "markdown",
@@ -409,7 +418,8 @@
     "```\n",
     "\n",
     "> *Ancre savante -- Graham, B. (1949), « The Intelligent Investor: A Book of Practical Counsel », Harper & Brothers, New York (1re edition 1949 ; editions revises 1954, 1959, 1965, 1973). Origine canonique de l'investissement value : le chapitre 20 formalise la **marge de securite** (margin of safety) comme concept central -- acheter un actif sensiblement en dessous de sa valeur intrinseque pour que la marge absorbe l'erreur d'estimation et les aleas defavorables. Graham y distingue aussi l'investisseur defensif de l'investisseur entreprenant et introduit l'allegorie de Mr. Market. Warren Buffett, eleve de Graham a Columbia, en a fait l'application moderne illustree par le schema ci-dessus (marge de securite + qualite de l'entreprise + detention long terme) -- les criteres P/E bas, ROE eleve et market cap liquide de la strategie Value Complete materialisent ce principe.*\n"
-   ]
+   ],
+   "id": "cell-3f1ea379"
   },
   {
    "cell_type": "code",
@@ -568,7 +578,8 @@
     "print(\"  - ROE > 15%\")\n",
     "print(\"  - Market Cap > $5B\")\n",
     "print(\"  - Exclut secteur financier\")"
-   ]
+   ],
+   "id": "cell-0a246fd2"
   },
   {
    "cell_type": "markdown",
@@ -593,7 +604,8 @@
     "> ValueInvestingStrategy — rebalance via OnSecuritiesChanged sur fenetre 90 j ; 10 ans executes (2015-2024). Verdict #3801 : **REAL** - performance reelle verifiee. Le champ totalOrders n'est pas expose de facon fiable par l'API backtest, mais la courbe d'equity confirme l'activite (CAGR +8.2%/an).\n",
     "\n",
     "*Backtest QC Cloud 2015-01-01 -> 2024-12-31 (projet 33177683, bt 10b06227dad01787dcace56d13f86534) - 2516 jour(s) boursier(s), Capital initial: $100,000*"
-   ]
+   ],
+   "id": "cell-12a21d0a"
   },
   {
    "cell_type": "markdown",
@@ -616,7 +628,8 @@
     "| `Energy` | Energie | Tres cyclique |\n",
     "| `Industrials` | Industrie | Cyclique |\n",
     "| `Technology` | Technologie | Growth, P/E eleve |"
-   ]
+   ],
+   "id": "cell-5c2474c3"
   },
   {
    "cell_type": "code",
@@ -626,7 +639,8 @@
    ],
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-8f8ca752"
   },
   {
    "cell_type": "markdown",
@@ -656,11 +670,12 @@
     "> SectorFilterExample — filtre d'univers par secteur uniquement, AddData custom commente. Verdict #3801 : **INTRINSIC** (0 trade verifie, 0 jour(s) boursier(s)).\n",
     "\n",
     "*Backtest QC Cloud 2015-01-01 -> 2024-12-31 (projet 33177683, bt 97420eec8aee6c8f111e88062c73386e) - 0 jour(s) boursier(s), Capital initial: $100,000*"
-   ]
+   ],
+   "id": "cell-48cf6f68"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-3e514b7d",
    "metadata": {},
    "source": [
     "---\n",
@@ -684,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-f24dc5f5",
    "metadata": {},
    "source": [
     "# [REFERENCE QC] Exercice 1 : Rotation sectorielle basee sur les fundamentals\n",
@@ -735,7 +750,8 @@
     "| 2.02 | Results of Operations (Earnings) | Majeur |\n",
     "| 5.02 | Departure/Appointment of Directors | Variable |\n",
     "| 5.07 | Shareholder Vote Results | Informatif |"
-   ]
+   ],
+   "id": "cell-e1b88117"
   },
   {
    "cell_type": "code",
@@ -801,7 +817,8 @@
     "print(\"  - Detection d'acquisitions (Item 2.01)\")\n",
     "print(\"  - Earnings surprises (Item 2.02)\")\n",
     "print(\"  - Changements de direction (Item 5.02)\")"
-   ]
+   ],
+   "id": "cell-1805d9d8"
   },
   {
    "cell_type": "markdown",
@@ -831,7 +848,8 @@
     "> SEC8KAlgorithm — OnData passe ; donnees SEC 8-K non connectees (souscription requise). Verdict #3801 : **INTRINSIC** (0 trade verifie, 2516 jour(s) boursier(s)).\n",
     "\n",
     "*Backtest QC Cloud 2015-01-01 -> 2024-12-31 (projet 33177683, bt 8be64c6b3d7af6d57d4904f13991e2dc) - 2516 jour(s) boursier(s), Capital initial: $100,000*"
-   ]
+   ],
+   "id": "cell-2a56b49f"
   },
   {
    "cell_type": "markdown",
@@ -938,7 +956,8 @@
       ""
      ]
     }
-   ]
+   ],
+   "id": "cell-89ba98d4"
   },
   {
    "cell_type": "markdown",
@@ -975,7 +994,8 @@
     "- **Complexity Analysis** : Readability scores\n",
     "\n",
     "> *Ancre savante -- Loughran, T. & McDonald, B. (2011), « When Is a Liability Not a Liability? Textual Analysis, Dictionaries, and 10-Ks », The Journal of Finance 66(1):35-65 (DOI 10.1111/j.1540-6261.2010.01625.x). Montre que les dictionnaires de sentiment generiques (notamment le Harvard IV-4) classent a tort comme negatifs pres de trois quarts des mots frequents en contexte financier (ex. « liability », « tax », « cost » n'y sont pas pejoratifs) ; les auteurs construisent donc un lexique finance-specifique (Loughran-McDonald Master Dictionary, six listes : negative, positive, uncertainty, litigious, constraining, superfluous) calibre sur un large corpus de 10-Ks 1994-2008, qu'ils relient au rendement, au volume, a la volatilite et aux fraudes. C'est la reference methodologique du NLP sur filings enseigne dans cette section 3.2 (sentiment, keyword detection, readability) -- la raison pour laquelle un lexique finance-dedie est preferable a un dictionnaire generaliste pour analyser le texte des SEC filings.*\n"
-   ]
+   ],
+   "id": "cell-135ca294"
   },
   {
    "cell_type": "markdown",
@@ -1015,7 +1035,8 @@
     "| `RemoteFile` | Fichier distant (HTTP/HTTPS) |\n",
     "| `LocalFile` | Fichier local |\n",
     "| `Rest` | API REST |"
-   ]
+   ],
+   "id": "cell-df5cdf2c"
   },
   {
    "cell_type": "code",
@@ -1148,7 +1169,8 @@
     "print(\"  2. Reader(): Parse le JSON et cree des objets\")\n",
     "print(\"\\nProprietes disponibles apres parsing:\")\n",
     "print(\"  - Title, Description, Source, URL\")"
-   ]
+   ],
+   "id": "cell-79298e17"
   },
   {
    "cell_type": "markdown",
@@ -1236,7 +1258,8 @@
       ""
      ]
     }
-   ]
+   ],
+   "id": "cell-d371f1ef"
   },
   {
    "cell_type": "markdown",
@@ -1325,7 +1348,8 @@
     "print(\"NewsAPIAlgorithm defini\")\n",
     "print(\"\\nNote: L'exemple complet necessite une cle API NewsAPI valide.\")\n",
     "print(\"Inscrivez-vous gratuitement sur https://newsapi.org/\")"
-   ]
+   ],
+   "id": "cell-57e3de36"
   },
   {
    "cell_type": "markdown",
@@ -1355,7 +1379,8 @@
     "> NewsAPIAlgorithm — OnData passe ; cle API NewsAPI requise. Verdict #3801 : **RECOVERABLE-USER-HAND** (0 trade verifie, 2516 jour(s) boursier(s)).\n",
     "\n",
     "*Backtest QC Cloud 2015-01-01 -> 2024-12-31 (projet 33177683, bt 408b70550a14c35cf4dbbab095b2e123) - 2516 jour(s) boursier(s), Capital initial: $100,000*"
-   ]
+   ],
+   "id": "cell-4d36d715"
   },
   {
    "cell_type": "markdown",
@@ -1373,7 +1398,8 @@
     "2023-02-01,2.3,3.6,4.1\n",
     "2023-03-01,2.1,3.7,3.9\n",
     "```"
-   ]
+   ],
+   "id": "cell-0b75d9d7"
   },
   {
    "cell_type": "code",
@@ -1528,7 +1554,8 @@
     "print(\"  1. Creer le fichier CSV avec vos donnees\")\n",
     "print(\"  2. Uploader dans QuantConnect (Data panel)\")\n",
     "print(\"  3. Decommentez les lignes AddData()\")"
-   ]
+   ],
+   "id": "cell-3c08e8d8"
   },
   {
    "cell_type": "markdown",
@@ -1558,11 +1585,12 @@
     "> CSVDataAlgorithm — OnData passe ; fichier CSV economique a uploader dans QC. Verdict #3801 : **RECOVERABLE-USER-HAND** (0 trade verifie, 2516 jour(s) boursier(s)).\n",
     "\n",
     "*Backtest QC Cloud 2015-01-01 -> 2024-12-31 (projet 33177683, bt 6e9675d6cf50f9a3c088cb63aca5ddcf) - 2516 jour(s) boursier(s), Capital initial: $100,000*"
-   ]
+   ],
+   "id": "cell-029f1ad4"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-288213b7",
    "metadata": {},
    "source": [
     "---\n",
@@ -1585,7 +1613,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-d9c39189",
    "metadata": {},
    "source": [
     "# [REFERENCE QC] Exercice 2 : Custom data source multi-format (CSV + JSON)\n",
@@ -1619,7 +1647,8 @@
     "| `T10Y2Y` | 10Y-2Y Spread | Yield curve, recession |\n",
     "| `VIXCLS` | VIX Close | Volatilite, stress |"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-629ba7a9"
   },
   {
    "cell_type": "code",
@@ -1629,7 +1658,8 @@
    ],
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-bbdee1d2"
   },
   {
    "cell_type": "markdown",
@@ -1659,7 +1689,8 @@
     "> YieldCurveAlgorithm — Rebalance() passe ; donnees FRED (CSV yield curve) a connecter. Verdict #3801 : **RECOVERABLE-USER-HAND** (0 trade verifie, 2516 jour(s) boursier(s)).\n",
     "\n",
     "*Backtest QC Cloud 2015-01-01 -> 2024-12-31 (projet 33177683, bt 2f3a6f14ba27e64adcd427e9da763544) - 2516 jour(s) boursier(s), Capital initial: $100,000*"
-   ]
+   ],
+   "id": "cell-82e3e27c"
   },
   {
    "cell_type": "markdown",
@@ -1685,7 +1716,8 @@
     "### Integration FRED\n",
     "\n",
     "Le Federal Reserve Economic Data (FRED) offre des milliers de series economiques. Vous pouvez les integrer via Custom Data ou des APIs tierces."
-   ]
+   ],
+   "id": "cell-2b213653"
   },
   {
    "cell_type": "code",
@@ -1785,7 +1817,8 @@
     "print(\"  - BULLISH: SPY > SMA200 et momentum positif\")\n",
     "print(\"  - BEARISH: SPY < SMA200 et momentum negatif\")\n",
     "print(\"  - NEUTRAL: conditions mixtes\")"
-   ]
+   ],
+   "id": "cell-1e7d11f2"
   },
   {
    "cell_type": "markdown",
@@ -1808,7 +1841,8 @@
     "| Probabilistic Sharpe Ratio | 6.848% |\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 70b5e8a1e5a851a7e430bcf4161fbfbe). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-44cae589"
   },
   {
    "cell_type": "markdown",
@@ -1840,7 +1874,8 @@
     "earnings_date = stock.EarningReports.BasicEPS.ReportDate\n",
     "last_eps = stock.EarningReports.BasicEPS.Value\n",
     "```"
-   ]
+   ],
+   "id": "cell-02109ee5"
   },
   {
    "cell_type": "code",
@@ -1981,7 +2016,8 @@
    ],
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-6c2e4a22"
   },
   {
    "cell_type": "markdown",
@@ -2004,7 +2040,8 @@
     "| Probabilistic Sharpe Ratio | 0.717% |\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt f782280c9fb5184328d1e7a182c7469a). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-afc2cbff"
   },
   {
    "cell_type": "markdown",
@@ -2155,7 +2192,8 @@
     "print(\"  1. Scanner les actions avec momentum >5%\")\n",
     "print(\"  2. Entrer en position (equal-weight)\")\n",
     "print(\"  3. Sortir si momentum devient negatif ou apres earnings\")"
-   ]
+   ],
+   "id": "cell-48f113e5"
   },
   {
    "cell_type": "markdown",
@@ -2170,7 +2208,8 @@
     "> **Resultat non verifiable (verdict #3801 : INTRINSIC / a diagnostiquer).** Le backtest QC Cloud de cette strategie de reference (universe Coarse, scanning de momentum quotidien sur jusqu'a 30 titres) sur 2015-2024 n'a produit AUCUNE journee negociable fiable : deux runs independants donnent `tradeableDates = 0` avec des statistiques NON-DETERMINISTES (bt 6037134b : Sharpe 0.319 / CAGR 8.585% ; bt d6cb787b : Sharpe 0.298 / CAGR 7.829%). Un backtest deterministe doit donner des resultats identiques -- ces statistiques sont donc inutilisables (probable timeout dû a l'intensite du trading quotidien sur 10 ans). La table fabriquee d'origine (\"Q1 2023\", Sharpe -1.395, CAGR -32.6%) est supprimee. Aucune metrique de substitution degradee n'est commitee a la place.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683). Aucune metrique fiable (2 runs non-deterministes, 0 tradeable dates) : bt 6037134b3942f8939906e1820ae1b067 et bt d6cb787bfac24fc3dd31d72af4022d29.*"
-   ]
+   ],
+   "id": "cell-f2e27d60"
   },
   {
    "cell_type": "markdown",
@@ -2184,7 +2223,8 @@
     "1. Detecter les earnings surprises (EPS actual vs consensus)\n",
     "2. Acheter les surprises positives, vendre les negatives\n",
     "3. Tenir pendant 60-90 jours (drift period)"
-   ]
+   ],
+   "id": "cell-70e432d8"
   },
   {
    "cell_type": "code",
@@ -2271,7 +2311,8 @@
     "print(\"  SUE = (Actual - Expected) / StdDev\")\n",
     "print(\"  SUE > 1: Positive surprise -> Buy\")\n",
     "print(\"  SUE < -1: Negative surprise -> Short\")"
-   ]
+   ],
+   "id": "cell-b7eac1ae"
   },
   {
    "cell_type": "markdown",
@@ -2301,11 +2342,12 @@
     "> PEADStrategy — aucun declencheur d'entree ; consensus earnings requis. Verdict #3801 : **INTRINSIC** (0 trade verifie, 0 jour(s) boursier(s)).\n",
     "\n",
     "*Backtest QC Cloud 2015-01-01 -> 2024-12-31 (projet 33177683, bt 527043f5d70b2538fde3af5291fc5013) - 0 jour(s) boursier(s), Capital initial: $100,000*"
-   ]
+   ],
+   "id": "cell-df77dbb0"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-2e303582",
    "metadata": {},
    "source": [
     "---\n",
@@ -2328,7 +2370,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-2fbd0560",
    "metadata": {},
    "source": [
     "# [REFERENCE QC] Exercice 3 : Strategie PEAD multi-facteurs\n",
@@ -2431,7 +2473,8 @@
     "---\n",
     "\n",
     "**Notebook complete. Vous maitrisez maintenant l'integration des Donnees Alternatives dans QuantConnect.**"
-   ]
+   ],
+   "id": "cell-0ddc4884"
   }
  ],
  "metadata": {
@@ -2455,5 +2498,5 @@
   "qc_reference": true
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
@@ -43,7 +43,8 @@
     "6. Strategie Complete (20 min)\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-05397242"
   },
   {
    "cell_type": "markdown",
@@ -53,7 +54,8 @@
     "> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n",
     "> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n",
     "> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-b943d72a"
   },
   {
    "cell_type": "markdown",
@@ -72,7 +74,8 @@
     "> \n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-02002850"
   },
   {
    "cell_type": "markdown",
@@ -81,7 +84,8 @@
     "---\n",
     "\n",
     "## Setup et Imports"
-   ]
+   ],
+   "id": "cell-592fe79f"
   },
   {
    "cell_type": "code",
@@ -118,7 +122,8 @@
     "%matplotlib inline\n",
     "\n",
     "print(\"Imports de base reussis\")"
-   ]
+   ],
+   "id": "cell-c9ade2cb"
   },
   {
    "cell_type": "code",
@@ -160,7 +165,8 @@
     "    print(f\"XGBoost importe avec succes (version {xgb.__version__})\")\n",
     "except ImportError:\n",
     "    print(\"XGBoost non installe. Executez: pip install xgboost\")"
-   ]
+   ],
+   "id": "cell-85a3ed7f"
   },
   {
    "cell_type": "markdown",
@@ -190,7 +196,8 @@
     "- Sauvegarde/chargement des modèles entraînés\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-b4319c2f"
   },
   {
    "cell_type": "markdown",
@@ -230,7 +237,8 @@
     "| **Overfitting** | Memorise le passe | Regularisation, validation robuste |\n",
     "| **Class Imbalance** | Plus de Up que Down (ou inverse) | Class weights, resampling |\n",
     "| **Lookahead Bias** | Utiliser le futur | TimeSeriesSplit strict |"
-   ]
+   ],
+   "id": "cell-0dc32160"
   },
   {
    "cell_type": "code",
@@ -363,7 +371,8 @@
     "\n",
     "print(f\"Donnees generees: {len(df)} jours\")\n",
     "print(f\"Periode: {df.index[0].date()} a {df.index[-1].date()}\")"
-   ]
+   ],
+   "id": "cell-8f43eb5d"
   },
   {
    "cell_type": "code",
@@ -412,7 +421,8 @@
     "print(f\"\\nDistribution des labels:\")\n",
     "print(f\"  Down (0): {(y == 0).sum()} ({(y == 0).mean()*100:.1f}%)\")\n",
     "print(f\"  Up (1):   {(y == 1).sum()} ({(y == 1).mean()*100:.1f}%)\")"
-   ]
+   ],
+   "id": "cell-c4982d23"
   },
   {
    "cell_type": "markdown",
@@ -440,7 +450,8 @@
     "- Cette information guide le choix des métriques (accuracy vs precision/recall)\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-82cca644"
   },
   {
    "cell_type": "code",
@@ -492,11 +503,12 @@
     ")\n",
     "\n",
     "print(\"\\nNormalisation appliquee (StandardScaler)\")"
-   ]
+   ],
+   "id": "cell-22cfd0b1"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-3c168820",
    "metadata": {},
    "source": [
     "---\n",
@@ -519,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-83ead0f1",
    "metadata": {},
    "source": [
     "# Exercice 1 : Methodes de labeling\n",
@@ -562,7 +574,8 @@
     "- Standardisation facilite la comparaison des coefficients\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-03cfb86a"
   },
   {
    "cell_type": "markdown",
@@ -611,7 +624,8 @@
     "| `max_features` | Features par split | 'sqrt' ou 0.3-0.7 |\n",
     "\n",
     "> *Ancre savante -- Breiman, L. (2001), « Random Forests », Machine Learning 45(1):5-32 (DOI 10.1023/A:1010933404324). Introduit les Random Forests : un ensemble d'arbres de decision construits chacun sur un bootstrap sample (tirage avec remise) de l'echantillon, avec une selection aleatoire d'un sous-ensemble de variables a chaque split (feature subsampling). Ces deux sources d'alea decorrelent les arbres, et l'agregation par **vote majoritaire** (schema d'architecture ci-dessus) reduit la variance sans augmenter le biais -- le remede au sur-apprentissage dont souffrent les arbres individuels.*\n"
-   ]
+   ],
+   "id": "cell-06bad63a"
   },
   {
    "cell_type": "code",
@@ -657,7 +671,8 @@
     "print(f\"  min_samples_leaf: {rf_model.min_samples_leaf}\")\n",
     "print(f\"  max_features: {rf_model.max_features}\")\n",
     "print(f\"  class_weight: {rf_model.class_weight}\")"
-   ]
+   ],
+   "id": "cell-db7292b8"
   },
   {
    "cell_type": "code",
@@ -781,7 +796,8 @@
     "\n",
     "print(\"\\n\" + \"=\"*60)\n",
     "print(f\"Mean CV Accuracy: {np.mean(cv_scores):.4f} (+/- {np.std(cv_scores):.4f})\")"
-   ]
+   ],
+   "id": "cell-b9dc6e94"
   },
   {
    "cell_type": "markdown",
@@ -809,7 +825,8 @@
     "- Std élevée = modèle instable selon la période\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-eb693ef2"
   },
   {
    "cell_type": "code",
@@ -858,7 +875,8 @@
     "    print(f\"ROC AUC:   {auc:.4f}\")\n",
     "except:\n",
     "    pass"
-   ]
+   ],
+   "id": "cell-939d643a"
   },
   {
    "cell_type": "markdown",
@@ -886,7 +904,8 @@
     "- Ces probabilités peuvent être utilisées pour le position sizing\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-b2af234a"
   },
   {
    "cell_type": "code",
@@ -954,11 +973,12 @@
     "ax.set_title('Random Forest - Feature Importance', fontsize=14, fontweight='bold')\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-4a7ae421"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-2bf3fbc7",
    "metadata": {},
    "source": [
     "---\n",
@@ -981,7 +1001,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-550df7fe",
    "metadata": {},
    "source": [
     "# Exercice 2 : Permutation importance vs Gini\n",
@@ -1025,7 +1045,8 @@
     "- Guider la création de nouvelles features\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-93011d2c"
   },
   {
    "cell_type": "markdown",
@@ -1072,7 +1093,8 @@
     "| `reg_lambda` | Regularisation L2 | 1-10 |\n",
     "\n",
     "> *Ancres savantes -- Friedman, J. H. (2001), « Greedy Function Approximation: A Gradient Boosting Machine », The Annals of Statistics 29(5):1189-1232 (1999 Reitz Lecture, DOI 10.1214/aos/1013203451) -- Gradient Boosting (MART) : au lieu d'agreger des arbres independants (bagging, Random Forest), on les construit **sequentiellement** en ajustant chaque nouvel arbre au gradient des residus du precedent -- le schema « corrige les erreurs du precedent » ci-dessus. La regularisation L1/L2 et le learning_rate en font le principe de base enseigne dans cette Partie 3. Chen, T. & Guestrin, C. (2016), « XGBoost: A Scalable Tree Boosting System », Proceedings of the 22nd ACM SIGKDD (KDD '16):785-794 (arXiv:1603.02754, DOI 10.1145/2939672.2939785) -- XGBoost : implementation optimisee du gradient boosting (objectif regularise, split finding sparsity-aware, cache-aware et out-of-core) qui en a fait le standard de fait du ML tabulaire, demontre dans cette Partie 3 (early stopping, gestion native des NaN, comparaison vs RF).*\n"
-   ]
+   ],
+   "id": "cell-ae12d386"
   },
   {
    "cell_type": "code",
@@ -1123,7 +1145,8 @@
     "print(f\"  learning_rate: {xgb_model.learning_rate}\")\n",
     "print(f\"  subsample: {xgb_model.subsample}\")\n",
     "print(f\"  colsample_bytree: {xgb_model.colsample_bytree}\")"
-   ]
+   ],
+   "id": "cell-a8626122"
   },
   {
    "cell_type": "code",
@@ -1179,7 +1202,8 @@
     "\n",
     "print(f\"\\nEntrainement termine.\")\n",
     "print(f\"Meilleur nombre d'iterations: {xgb_model.best_iteration if hasattr(xgb_model, 'best_iteration') else 'N/A'}\")"
-   ]
+   ],
+   "id": "cell-e3476901"
   },
   {
    "cell_type": "markdown",
@@ -1207,7 +1231,8 @@
     "- `subsample=0.8`, `colsample_bytree=0.8` : régularisation par sous-échantillonnage\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-64baee02"
   },
   {
    "cell_type": "code",
@@ -1259,7 +1284,8 @@
     "    print(f\"ROC AUC:   {auc:.4f}\")\n",
     "except:\n",
     "    pass"
-   ]
+   ],
+   "id": "cell-ca61093e"
   },
   {
    "cell_type": "markdown",
@@ -1287,7 +1313,8 @@
     "- Comparer avec la baseline (0.5) pour évaluer l'avantage\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-ecb62ac1"
   },
   {
    "cell_type": "code",
@@ -1369,7 +1396,8 @@
     "plt.suptitle('Comparaison Feature Importance', fontsize=16, fontweight='bold')\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-ec6e6613"
   },
   {
    "cell_type": "markdown",
@@ -1397,7 +1425,8 @@
     "- SMA Ratio : indicateur de tendance\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-de6af7d0"
   },
   {
    "cell_type": "code",
@@ -1490,11 +1519,12 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-20879c31"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-08163737",
    "metadata": {},
    "source": [
     "---\n",
@@ -1517,7 +1547,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-b74fea28",
    "metadata": {},
    "source": [
     "# Exercice 3 : Benchmark RF vs XGBoost\n",
@@ -1559,7 +1589,8 @@
     "- F1 Score pour un équilibre entre les deux\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-87caaed6"
   },
   {
    "cell_type": "markdown",
@@ -1593,7 +1624,8 @@
     "- FP (Faux Positif) = Achat suivi de baisse = PERTE\n",
     "- Une Precision de 55% peut etre profitable si gain > perte\n",
     "```"
-   ]
+   ],
+   "id": "cell-81444f55"
   },
   {
    "cell_type": "code",
@@ -1717,7 +1749,8 @@
     "# Appliquer aux deux modeles\n",
     "rf_metrics = detailed_classification_metrics(y_test, rf_predictions, rf_proba, \"Random Forest\")\n",
     "xgb_metrics = detailed_classification_metrics(y_test, xgb_predictions, xgb_proba, \"XGBoost\")"
-   ]
+   ],
+   "id": "cell-1a64bffe"
   },
   {
    "cell_type": "markdown",
@@ -1753,7 +1786,8 @@
     "   - AUC > 0.7 indique un bon pouvoir discriminant\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-7fa1b7cc"
   },
   {
    "cell_type": "code",
@@ -1816,7 +1850,8 @@
     "plt.suptitle('Matrices de Confusion', fontsize=16, fontweight='bold')\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-b6752ebe"
   },
   {
    "cell_type": "markdown",
@@ -1848,7 +1883,8 @@
     "- Un modèle avec moins de FP mais plus de FN peut être préférable (moins de trades gagnants mais plus fiables)\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-ee4b2ef7"
   },
   {
    "cell_type": "code",
@@ -1901,7 +1937,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-567cdda3"
   },
   {
    "cell_type": "markdown",
@@ -1932,7 +1969,8 @@
     "---\n",
     "\n",
     "> *Ancre savante -- Fawcett, T. (2006), « An introduction to ROC analysis », Pattern Recognition Letters 27(8):861-874 (DOI 10.1016/j.patrec.2005.10.010). Reference pedagogique standard pour les courbes ROC en machine learning : formalise le **False Positive Rate** (axe X = 1 - specificite) et le **True Positive Rate** (axe Y = sensibilite/recall), l'aire sous la courbe (AUC) comme mesure d'independance du seuil, et la lecture de la courbe (coin superieur gauche = classifieur ideal AUC = 1.0, diagonale = classifieur aleatoire AUC = 0.5). Les courbes ROC ont pour origine la theorie de la detection du signal (Egan 1975, Swets 1973) ; Fawcett 2006 en est l'introduction canonique adoptee par la communaute ML/data mining, illustree par les courbes RF vs XGBoost ci-dessus.*\n"
-   ]
+   ],
+   "id": "cell-9257c1ee"
   },
   {
    "cell_type": "markdown",
@@ -1954,7 +1992,8 @@
     "```\n",
     "\n",
     "> *Ancre savante -- Pardo, R. (2008), « The Evaluation and Optimization of Trading Strategies », 2e edition, Wiley Trading (ISBN 978-0-470-12801-5). Reference canonique de la **Walk-Forward Analysis** : au lieu d'un simple split train/test statique, on optimise le modele sur une fenetre, le teste sur la periode suivante (out-of-sample), puis on decale la fenetre (expanding ou sliding window, schema ci-dessus) et on reitere. Seule une strategy qui reste profitable sur les fenetres out-of-sample successives est jugee robuste -- le controle contre le sur-ajustement a une periode historique unique, enseigne dans cette section 4.2.*\n"
-   ]
+   ],
+   "id": "cell-2a658201"
   },
   {
    "cell_type": "code",
@@ -2120,7 +2159,8 @@
     "print(f\"  Accuracy:  {wf_results['overall_accuracy']:.4f}\")\n",
     "print(f\"  Precision: {wf_results['overall_precision']:.4f}\")\n",
     "print(f\"  F1 Score:  {wf_results['overall_f1']:.4f}\")"
-   ]
+   ],
+   "id": "cell-40961aa4"
   },
   {
    "cell_type": "markdown",
@@ -2149,7 +2189,8 @@
     "- Comparaison folds vs global : stabilité ou variabilité\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-38204ae2"
   },
   {
    "cell_type": "code",
@@ -2215,7 +2256,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-aedad305"
   },
   {
    "cell_type": "markdown",
@@ -2244,7 +2286,8 @@
     "- Chutes temporaires → périodes de transition de régime\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-dffdad01"
   },
   {
    "cell_type": "markdown",
@@ -2271,7 +2314,8 @@
     "model_bytes = self.ObjectStore.ReadBytes(\"model/rf_classifier\")\n",
     "model = pickle.loads(model_bytes)\n",
     "```"
-   ]
+   ],
+   "id": "cell-fedf518b"
   },
   {
    "cell_type": "code",
@@ -2520,7 +2564,8 @@
     "\n",
     "print(\"ObjectStore pour Persistence des Modeles:\")\n",
     "print(objectstore_code)"
-   ]
+   ],
+   "id": "cell-5ed7969d"
   },
   {
    "cell_type": "markdown",
@@ -2529,7 +2574,8 @@
     "### 5.2 ML Classification Alpha Model\n",
     "\n",
     "Creeons un Alpha Model qui utilise un classificateur ML pour generer des Insights."
-   ]
+   ],
+   "id": "cell-fd71a72f"
   },
   {
    "cell_type": "code",
@@ -3159,7 +3205,8 @@
     "\n",
     "print(\"MLClassificationAlphaModel:\")\n",
     "print(ml_alpha_code)"
-   ]
+   ],
+   "id": "cell-b002f428"
   },
   {
    "cell_type": "markdown",
@@ -3202,7 +3249,8 @@
     "                  v\n",
     "           Execution\n",
     "```"
-   ]
+   ],
+   "id": "cell-2d0194f3"
   },
   {
    "cell_type": "code",
@@ -3657,7 +3705,8 @@
     "\n",
     "print(\"MLDirectionPredictionStrategy Complete:\")\n",
     "print(complete_strategy_code)"
-   ]
+   ],
+   "id": "cell-981bfb4e"
   },
   {
    "cell_type": "markdown",
@@ -3694,7 +3743,8 @@
     "**Important** : Ce code doit être copié dans un fichier `main.py` de QC Lab, pas exécuté dans ce notebook.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-2959fd01"
   },
   {
    "cell_type": "code",
@@ -3786,7 +3836,8 @@
     "    print(f\"\\n{category}:\")\n",
     "    for key, value in details.items():\n",
     "        print(f\"  - {key}: {value}\")"
-   ]
+   ],
+   "id": "cell-86e958b7"
   },
   {
    "cell_type": "markdown",
@@ -3820,7 +3871,8 @@
     "   - Position sizing dynamique selon la confiance du modèle\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-d5c99d66"
   },
   {
    "cell_type": "code",
@@ -3903,7 +3955,8 @@
     "    print(f\"  Installation: {dep['install']}\")\n",
     "    print(f\"  Usage: {dep['usage']}\")\n",
     "    print(f\"  Note: {dep['note']}\")"
-   ]
+   ],
+   "id": "cell-81eeaaba"
   },
   {
    "cell_type": "markdown",
@@ -3998,7 +4051,8 @@
     "- Fawcett, T. (2006). *An introduction to ROC analysis*. Pattern Recognition Letters, 27(8), 861-874. https://doi.org/10.1016/j.patrec.2005.10.010\n",
     "\n",
     "- Pardo, R. (2008). *The Evaluation and Optimization of Trading Strategies* (2nd ed.). Wiley. ISBN 978-0-470-12801-5\n"
-   ]
+   ],
+   "id": "cell-5ad3109f"
   }
  ],
  "metadata": {
@@ -4021,5 +4075,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
@@ -45,14 +45,16 @@
     "\n",
     "---",
     "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-477cba79"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-f753a705"
   },
   {
    "cell_type": "markdown",
@@ -67,7 +69,8 @@
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-a9ee5e88"
   },
   {
    "cell_type": "markdown",
@@ -119,7 +122,8 @@
     "                                           Signal Trading\n",
     "                                           (Long si > threshold)\n",
     "```"
-   ]
+   ],
+   "id": "cell-0b1689ee"
   },
   {
    "cell_type": "code",
@@ -159,7 +163,8 @@
     "\n",
     "print(\"\\nImports reussis!\")\n",
     "print(\"Ce notebook couvre la Regression ML pour la prediction de prix.\")"
-   ]
+   ],
+   "id": "cell-6eaf0e32"
   },
   {
    "cell_type": "markdown",
@@ -190,7 +195,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-e637849f"
   },
   {
    "cell_type": "code",
@@ -303,7 +309,8 @@
     "print(f\"\\nTarget: 'target_return' (rendement 5 jours)\")\n",
     "print(f\"  Mean: {df['target_return'].mean()*100:.3f}%\")\n",
     "print(f\"  Std: {df['target_return'].std()*100:.3f}%\")"
-   ]
+   ],
+   "id": "cell-5b4b6795"
   },
   {
    "cell_type": "markdown",
@@ -342,7 +349,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-02644ef6"
   },
   {
    "cell_type": "code",
@@ -388,11 +396,12 @@
     "X_test_scaled = pd.DataFrame(scaler.transform(X_test), columns=feature_cols, index=X_test.index)\n",
     "\n",
     "print(\"\\nStandardisation appliquee (fit sur train, transform sur test)\")"
-   ]
+   ],
+   "id": "cell-e2a9fd79"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-d2d75872",
    "metadata": {},
    "source": [
     "---\n",
@@ -415,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-587894b6",
    "metadata": {},
    "source": [
     "# Exercice 1 : Classification vs Regression\n",
@@ -469,7 +478,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-c5f64f6a"
   },
   {
    "cell_type": "markdown",
@@ -510,7 +520,8 @@
     "```\n",
     "\n",
     "> *Ancres savantes -- Hoerl, A. E. & Kennard, R. W. (1970), « Ridge Regression: Biased Estimation for Nonorthogonal Problems », Technometrics 12(1):55-67 (DOI 10.1080/00401706.1970.10488634) -- Ridge regression : introduit la penalite L2 (terme lambda*||beta||^2) qui reserre les coefficients vers zero sans jamais les annuler, contre le sur-apprentissage en presence de colinearite ; la table de regularisation ci-dessus l'illustre comme le cas L2 de la famille. Tibshirani, R. (1996), « Regression Shrinkage and Selection via the Lasso », Journal of the Royal Statistical Society Series B 58(1):267-288 (DOI 10.1111/j.2517-6161.1996.tb02080.x) -- Lasso : la penalite L1 (lambda*||beta||_1) produit une parcimonie exacte (coefficients ramenes a zero), c'est-a-dire une selection de variables automatique, que Ridge ne permet pas. Zou, H. & Hastie, T. (2005), « Regularization and Variable Selection via the Elastic Net », JRSS-B 67(2):301-320 -- Elastic Net : combine les penalites L1 et L2 pour recuperer la selection de variables du Lasso tout en stabilisant les groupes de variables correlees (ou le Lasso pur en selectionne une sur N au hasard), d'ou le compromis ridge-lasso enseigne dans cette Partie 2.*\n"
-   ]
+   ],
+   "id": "cell-643057ee"
   },
   {
    "cell_type": "markdown",
@@ -552,7 +563,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-a6348286"
   },
   {
    "cell_type": "code",
@@ -620,7 +632,8 @@
     "# Meilleur alpha\n",
     "best_ridge_alpha = ridge_df.loc[ridge_df['test_rmse'].idxmin(), 'alpha']\n",
     "print(f\"\\nMeilleur alpha: {best_ridge_alpha}\")"
-   ]
+   ],
+   "id": "cell-f8c74d56"
   },
   {
    "cell_type": "markdown",
@@ -662,7 +675,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-e63fb82a"
   },
   {
    "cell_type": "code",
@@ -716,7 +730,8 @@
     "for feat, coef in zip(feature_cols, best_lasso.coef_):\n",
     "    if coef != 0:\n",
     "        print(f\"  {feat}: {coef:.6f}\")"
-   ]
+   ],
+   "id": "cell-48c2984b"
   },
   {
    "cell_type": "markdown",
@@ -756,7 +771,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-8c7935bd"
   },
   {
    "cell_type": "code",
@@ -830,7 +846,8 @@
     "print(\"  - l1_ratio=0 -> Ridge (pure L2)\")\n",
     "print(\"  - l1_ratio=1 -> Lasso (pure L1)\")\n",
     "print(\"  - l1_ratio=0.5 -> Mix equilibre\")"
-   ]
+   ],
+   "id": "cell-1f416521"
   },
   {
    "cell_type": "markdown",
@@ -873,7 +890,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-b95f9954"
   },
   {
    "cell_type": "code",
@@ -943,11 +961,12 @@
     "print(\"  - Ridge: tous les coefficients non-nuls (shrinkage)\")\n",
     "print(\"  - Lasso: certains coefficients a 0 (feature selection)\")\n",
     "print(\"  - ElasticNet: compromis entre les deux\")"
-   ]
+   ],
+   "id": "cell-c99f4c8d"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-78b2d13b",
    "metadata": {},
    "source": [
     "---\n",
@@ -970,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-78f168ba",
    "metadata": {},
    "source": [
     "# Exercice 2 : Alpha optimal par GridSearchCV\n",
@@ -1021,7 +1040,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-96adfceb"
   },
   {
    "cell_type": "markdown",
@@ -1056,7 +1076,8 @@
     "```\n",
     "\n",
     "> *Ancres savantes -- Breiman, L. (2001), « Random Forests », Machine Learning 45(1):5-32 (DOI 10.1023/A:1010933404324) -- Random Forest : generalise le bagging (Bootstrap AGGregatING) en ajoutant une selection aleatoire d'un sous-ensemble de variables a chaque split (feature subsampling), decorrelant les arbres et reduisant la variance par moyenne -- le schema de bootstrap du « Random Forest Regressor » ci-dessus materialise ce principe. Friedman, J. H. (2001), « Greedy Function Approximation: A Gradient Boosting Machine », The Annals of Statistics 29(5):1189-1232 (1999 Reitz Lecture, DOI 10.1214/aos/1013203451) -- Gradient Boosting (MART) : au lieu d'agreger des arbres independants (bagging), on les construit sequentiellement en ajustant chaque nouvel arbre au gradient des residus du precedent, minimisant une fonction de perte additive -- le principe recursif sur les residus enseigne dans cette Partie 3. Chen, T. & Guestrin, C. (2016), « XGBoost: A Scalable Tree Boosting System », Proceedings of the 22nd ACM SIGKDD (KDD '16):785-794 (arXiv:1603.02754, DOI 10.1145/2939672.2939785) -- XGBoost : implementation optimisee du gradient boosting (objectif regularise, split finding sparsity-aware, cache-aware et out-of-core) qui en a fait le standard de fait du tabular ML et dont l'usage via sklearn/xgboost est demontre dans cette Partie 3.*\n"
-   ]
+   ],
+   "id": "cell-8d612b05"
   },
   {
    "cell_type": "markdown",
@@ -1090,7 +1111,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-a6c6c78d"
   },
   {
    "cell_type": "code",
@@ -1175,7 +1197,8 @@
     "best_rf_idx = rf_df['test_rmse'].idxmin()\n",
     "best_rf_params = rf_params[best_rf_idx]\n",
     "print(f\"\\nMeilleurs parametres: {best_rf_params}\")"
-   ]
+   ],
+   "id": "cell-019a0d7e"
   },
   {
    "cell_type": "markdown",
@@ -1219,7 +1242,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-ddb12270"
   },
   {
    "cell_type": "code",
@@ -1285,7 +1309,8 @@
     "plt.gca().invert_yaxis()\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-5c18cdc5"
   },
   {
    "cell_type": "markdown",
@@ -1319,7 +1344,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-37a1204b"
   },
   {
    "cell_type": "code",
@@ -1403,7 +1429,8 @@
     "best_gb_idx = gb_df['test_rmse'].idxmin()\n",
     "best_gb_params = gb_params[best_gb_idx]\n",
     "print(f\"\\nMeilleurs parametres: {best_gb_params}\")"
-   ]
+   ],
+   "id": "cell-58c1105a"
   },
   {
    "cell_type": "markdown",
@@ -1443,7 +1470,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-bef3c51c"
   },
   {
    "cell_type": "code",
@@ -1525,11 +1553,12 @@
     "else:\n",
     "    print(\"XGBoost non disponible.\")\n",
     "    print(\"Installer avec: pip install xgboost\")"
-   ]
+   ],
+   "id": "cell-e4a25741"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-b544a236",
    "metadata": {},
    "source": [
     "---\n",
@@ -1553,7 +1582,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-3043a76d",
    "metadata": {},
    "source": [
     "# Exercice 3 : Stacking de regressieurs\n",
@@ -1603,7 +1632,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-e5cdf49f"
   },
   {
    "cell_type": "markdown",
@@ -1634,7 +1664,8 @@
     "### Importance du Scaling\n",
     "\n",
     "**SVR necessite IMPERATIVEMENT des features standardisees**. Sans scaling, les performances sont tres degradees."
-   ]
+   ],
+   "id": "cell-5be2b9d6"
   },
   {
    "cell_type": "markdown",
@@ -1668,7 +1699,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-2007da8e"
   },
   {
    "cell_type": "code",
@@ -1723,7 +1755,8 @@
     "print(f\"   RMSE sans scaling: {rmse_no_scale:.6f}\")\n",
     "print(f\"   RMSE avec scaling: {rmse_scaled:.6f}\")\n",
     "print(f\"   Amelioration: {(rmse_no_scale - rmse_scaled) / rmse_no_scale * 100:.1f}%\")"
-   ]
+   ],
+   "id": "cell-e188db69"
   },
   {
    "cell_type": "markdown",
@@ -1761,7 +1794,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-27e2765e"
   },
   {
    "cell_type": "code",
@@ -1836,7 +1870,8 @@
     "best_svr_idx = svr_df['test_rmse'].idxmin()\n",
     "best_svr_config = svr_configs[best_svr_idx]\n",
     "print(f\"\\nMeilleure config: {best_svr_config}\")"
-   ]
+   ],
+   "id": "cell-a7f2ddb4"
   },
   {
    "cell_type": "markdown",
@@ -1870,7 +1905,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-a905f5f4"
   },
   {
    "cell_type": "code",
@@ -1949,7 +1985,8 @@
     "\n",
     "print(\"Code SVR pour QuantConnect:\")\n",
     "print(svr_qc_code)"
-   ]
+   ],
+   "id": "cell-076d828e"
   },
   {
    "cell_type": "markdown",
@@ -1992,7 +2029,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-6bea9b2d"
   },
   {
    "cell_type": "markdown",
@@ -2019,7 +2057,8 @@
     "| **Direction Accuracy** | % de predictions avec la bonne direction | Cruciale pour PnL |\n",
     "| **Correlation** | Correlation Pearson/Spearman avec y | Qualite du ranking |\n",
     "| **IC (Information Coefficient)** | Correlation avec les rendements futurs | Standard en quant |"
-   ]
+   ],
+   "id": "cell-35ff5e9d"
   },
   {
    "cell_type": "markdown",
@@ -2051,7 +2090,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-341bd712"
   },
   {
    "cell_type": "code",
@@ -2151,7 +2191,8 @@
     "print(\"COMPARAISON DE TOUS LES MODELES\")\n",
     "print(\"=\"*80)\n",
     "print(metrics_df.to_string(index=False))"
-   ]
+   ],
+   "id": "cell-c8223e50"
   },
   {
    "cell_type": "markdown",
@@ -2183,7 +2224,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-4f6df42f"
   },
   {
    "cell_type": "code",
@@ -2258,7 +2300,8 @@
     "print(\"\\nNote importante:\")\n",
     "print(\"  La Direction Accuracy est souvent plus importante que le RMSE pour le trading.\")\n",
     "print(\"  Un modele peut avoir un bon RMSE mais predire la mauvaise direction.\")"
-   ]
+   ],
+   "id": "cell-9293236f"
   },
   {
    "cell_type": "markdown",
@@ -2292,7 +2335,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-6fe4f269"
   },
   {
    "cell_type": "code",
@@ -2353,7 +2397,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-77a4f9da"
   },
   {
    "cell_type": "markdown",
@@ -2385,7 +2430,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-5cbfaf10"
   },
   {
    "cell_type": "markdown",
@@ -2422,7 +2468,8 @@
     "| **Proportionnel** | Proportionnel a la prediction | size = k * abs(y_pred) |\n",
     "| **Confiance** | Base sur la confiance du modele | size = k * confidence |\n",
     "| **Kelly** | Optimisation Kelly | size = edge / variance |"
-   ]
+   ],
+   "id": "cell-691005cf"
   },
   {
    "cell_type": "markdown",
@@ -2459,7 +2506,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-18494cb4"
   },
   {
    "cell_type": "code",
@@ -2644,7 +2692,8 @@
     "\n",
     "print(\"RegressionAlphaModel pour QuantConnect:\")\n",
     "print(qc_regression_alpha_code)"
-   ]
+   ],
+   "id": "cell-1175db5e"
   },
   {
    "cell_type": "markdown",
@@ -2683,7 +2732,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-f209b78e"
   },
   {
    "cell_type": "code",
@@ -2788,7 +2838,8 @@
     "    trading_df[col] = trading_df[col].apply(lambda x: f\"{x*100:.2f}%\")\n",
     "\n",
     "print(trading_df.to_string(index=False))"
-   ]
+   ],
+   "id": "cell-4663da06"
   },
   {
    "cell_type": "markdown",
@@ -2822,7 +2873,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-90de093f"
   },
   {
    "cell_type": "code",
@@ -2861,7 +2913,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-40adc94f"
   },
   {
    "cell_type": "markdown",
@@ -2895,7 +2948,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-8d6d553b"
   },
   {
    "cell_type": "markdown",
@@ -2935,7 +2989,8 @@
     "Risk Management\n",
     "(5% max drawdown per position)\n",
     "```"
-   ]
+   ],
+   "id": "cell-e369f80b"
   },
   {
    "cell_type": "markdown",
@@ -2971,7 +3026,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-d3fa5232"
   },
   {
    "cell_type": "code",
@@ -3301,7 +3357,8 @@
     "print(\"  5. Position Sizing: Proportionnel a magnitude\")\n",
     "print(\"  6. Retraining: Tous les 30 jours\")\n",
     "print(\"=\"*60)"
-   ]
+   ],
+   "id": "cell-536b4934"
   },
   {
    "cell_type": "markdown",
@@ -3339,7 +3396,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-3a3357e2"
   },
   {
    "cell_type": "code",
@@ -3387,7 +3445,8 @@
     "])\n",
     "\n",
     "print(recommendations.to_string(index=False))"
-   ]
+   ],
+   "id": "cell-f006d7cf"
   },
   {
    "cell_type": "markdown",
@@ -3416,7 +3475,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-8d0f73c1"
   },
   {
    "cell_type": "markdown",
@@ -3525,7 +3585,8 @@
     "---\n",
     "\n",
     "**Notebook complete. Vous maitrisez maintenant la regression ML pour la prediction de prix.**"
-   ]
+   ],
+   "id": "cell-78220165"
   }
  ],
  "metadata": {
@@ -3549,5 +3610,5 @@
   "qc_reference": true
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
@@ -50,14 +50,16 @@
     "\n",
     "> *Ancres savantes -- les methodes enseignees dans ce notebook reposent sur une litterature classique : Markowitz (1952, Modern Portfolio Theory / Mean-Variance), Black & Litterman (1992, views-implied returns), Ledoit & Wolf (2004, covariance shrinkage), Lopez de Prado (2016, Hierarchical Risk Parity), Sharpe (1966, ratio de Sharpe). La section **References** a la fin du notebook donne les citations completes.*\n",
     ""
-   ]
+   ],
+   "id": "cell-b52fc7f2"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-9ba0121b"
   },
   {
    "cell_type": "markdown",
@@ -72,7 +74,8 @@
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-50833649"
   },
   {
    "cell_type": "markdown",
@@ -116,7 +119,8 @@
     "         v\n",
     "   Poids Optimaux\n",
     "```"
-   ]
+   ],
+   "id": "cell-af214507"
   },
   {
    "cell_type": "code",
@@ -157,7 +161,8 @@
     "\n",
     "print(\"Imports reussis!\")\n",
     "print(\"Ce notebook couvre l'optimisation de portefeuille avec ML.\")"
-   ]
+   ],
+   "id": "cell-37d70440"
   },
   {
    "cell_type": "markdown",
@@ -183,7 +188,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-555fa480"
   },
   {
    "cell_type": "code",
@@ -279,7 +285,8 @@
     "print(f\"Donnees generees: {len(prices)} jours, {len(prices.columns)} actifs\")\n",
     "print(f\"\\nApercu des prix:\")\n",
     "print(prices.head())"
-   ]
+   ],
+   "id": "cell-eb2aa7eb"
   },
   {
    "cell_type": "markdown",
@@ -303,7 +310,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-e785dd2b"
   },
   {
    "cell_type": "code",
@@ -331,7 +339,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-74166d8a"
   },
   {
    "cell_type": "markdown",
@@ -353,7 +362,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-bf3d72f4"
   },
   {
    "cell_type": "markdown",
@@ -393,7 +403,8 @@
     "\n",
     "> *Ancres savantes -- Markowitz, H. (1952), « Portfolio Selection », The Journal of Finance 7(1), 77-91 (formalisation du compromis rendement/variance et de la frontiere efficiente, Nobel 1990). Sharpe, W. F. (1966), « Mutual Fund Performance », Journal of Business 39(1), 119-138 (le ratio maximise ci-dessus porte son nom ; origine « reward-to-variability »).*\n",
     ""
-   ]
+   ],
+   "id": "cell-dc1f7bac"
   },
   {
    "cell_type": "code",
@@ -495,7 +506,8 @@
     "print(f\"\\nVolatilites annualisees:\")\n",
     "for i, asset in enumerate(returns.columns):\n",
     "    print(f\"  {asset}: {np.sqrt(cov_matrix[i,i]):.2%}\")"
-   ]
+   ],
+   "id": "cell-60fd7b9a"
   },
   {
    "cell_type": "markdown",
@@ -516,7 +528,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-1ae60254"
   },
   {
    "cell_type": "code",
@@ -657,7 +670,8 @@
     "print(f\"\\n  Rendement: {portfolio_return(msr_weights, expected_returns):.2%}\")\n",
     "print(f\"  Volatilite: {portfolio_volatility(msr_weights, cov_matrix):.2%}\")\n",
     "print(f\"  Sharpe: {portfolio_sharpe(msr_weights, expected_returns, cov_matrix):.2f}\")"
-   ]
+   ],
+   "id": "cell-6dfacda5"
   },
   {
    "cell_type": "markdown",
@@ -680,7 +694,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-ebdb432d"
   },
   {
    "cell_type": "code",
@@ -766,7 +781,8 @@
     "frontier = efficient_frontier(expected_returns, cov_matrix, num_portfolios=50)\n",
     "\n",
     "print(f\"Frontiere efficiente calculee: {len(frontier)} portefeuilles\")"
-   ]
+   ],
+   "id": "cell-6579f5ff"
   },
   {
    "cell_type": "markdown",
@@ -787,7 +803,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-025396ba"
   },
   {
    "cell_type": "code",
@@ -843,11 +860,12 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-6e673b14"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-859ae736",
    "metadata": {},
    "source": [
     "---\n",
@@ -871,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-eb59457d",
    "metadata": {},
    "source": [
     "# Exercice 1 : Frontiere efficiente contrainte\n",
@@ -911,7 +929,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-02a30ce6"
   },
   {
    "cell_type": "markdown",
@@ -925,7 +944,8 @@
     "| **Matrice mal conditionnee** | Avec peu de donnees, la covariance est mal estimee | Poids extremes |\n",
     "| **Sensibilite aux inputs** | Petits changements -> grands changements de poids | Turnover eleve |\n",
     "| **In-sample overfitting** | Optimise sur le passe, pas le futur | Sous-performance out-of-sample |"
-   ]
+   ],
+   "id": "cell-f6ca44fe"
   },
   {
    "cell_type": "markdown",
@@ -953,7 +973,8 @@
     "\n",
     "> *Ancre savante -- Ledoit, O. & Wolf, M. (2004), « A well-conditioned estimator for large-dimensional covariance matrices », Journal of Multivariate Analysis 88(2), 365-411. L'estimateur de shrinkage `Sigma_shrunk = (1-alpha)*Sigma_sample + alpha*Sigma_target` enseigne ci-dessus est leur formulation ; le coefficient alpha optimal minimise l'erreur de Stein (MSE de Frobenius).*\n",
     ""
-   ]
+   ],
+   "id": "cell-fe25404a"
   },
   {
    "cell_type": "code",
@@ -1016,7 +1037,8 @@
     "print(f\"  Sample: {cond_sample:.1f}\")\n",
     "print(f\"  Shrunk: {cond_shrunk:.1f}\")\n",
     "print(f\"  Reduction: {(1 - cond_shrunk/cond_sample)*100:.1f}%\")"
-   ]
+   ],
+   "id": "cell-bbeef2a6"
   },
   {
    "cell_type": "markdown",
@@ -1039,7 +1061,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-bbafcf54"
   },
   {
    "cell_type": "code",
@@ -1110,11 +1133,12 @@
     "print(\"-\" * 45)\n",
     "for i, asset in enumerate(returns.columns):\n",
     "    print(f\"{asset:<12} {msr_sample[i]:>9.1%} {msr_shrunk[i]:>9.1%} {msr_shrunk[i]-msr_sample[i]:>9.1%}\")"
-   ]
+   ],
+   "id": "cell-2714ac87"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-079ea202",
    "metadata": {},
    "source": [
     "---\n",
@@ -1137,7 +1161,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-ff1aa386",
    "metadata": {},
    "source": [
     "# Exercice 2 : Estimateurs de covariance\n",
@@ -1175,7 +1199,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-2befcb31"
   },
   {
    "cell_type": "markdown",
@@ -1202,7 +1227,8 @@
     "- RSI                Neural Net\n",
     "- Valuation\n",
     "```"
-   ]
+   ],
+   "id": "cell-93474db1"
   },
   {
    "cell_type": "code",
@@ -1296,7 +1322,8 @@
     "print(features_df.columns.tolist())\n",
     "print(f\"\\nApercu:\")\n",
     "print(features_df.head())"
-   ]
+   ],
+   "id": "cell-e9533e8a"
   },
   {
    "cell_type": "markdown",
@@ -1317,7 +1344,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-8c62114f"
   },
   {
    "cell_type": "code",
@@ -1430,7 +1458,8 @@
     "\n",
     "print(f\"\\nFeature Importance:\")\n",
     "print(importance.to_string(index=False))"
-   ]
+   ],
+   "id": "cell-659ff66f"
   },
   {
    "cell_type": "markdown",
@@ -1453,7 +1482,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-691e728d"
   },
   {
    "cell_type": "code",
@@ -1494,7 +1524,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-78ab742e"
   },
   {
    "cell_type": "markdown",
@@ -1517,7 +1548,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-601e5f40"
   },
   {
    "cell_type": "markdown",
@@ -1553,7 +1585,8 @@
     "\n",
     "> *Ancre savante -- Black, F. & Litterman, R. (1992), « Global Portfolio Optimization », Financial Analysts Journal 48(5), 28-43. Le modele combine un prior d'equilibre de marche `pi = delta*Sigma*w_mkt` avec les vues de l'investisseur via une mise a jour bayesienne (formule posterieure ci-dessus) -- d'ou des rendements posterieurs plus stables que l'optimisation naive.*\n",
     ""
-   ]
+   ],
+   "id": "cell-5fa6bf72"
   },
   {
    "cell_type": "code",
@@ -1672,7 +1705,8 @@
     "print(\"Vues ML (Q):\")\n",
     "for i, asset in enumerate(assets):\n",
     "    print(f\"  {asset}: {Q[i]:.2%} (incertitude: {np.sqrt(omega[i,i]):.2%})\")"
-   ]
+   ],
+   "id": "cell-61e86269"
   },
   {
    "cell_type": "markdown",
@@ -1696,7 +1730,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-d9ddb250"
   },
   {
    "cell_type": "code",
@@ -1766,7 +1801,8 @@
     "print(f\"\\n  Rendement attendu: {portfolio_return(bl_weights, posterior_returns):.2%}\")\n",
     "print(f\"  Volatilite: {portfolio_volatility(bl_weights, cov_shrunk):.2%}\")\n",
     "print(f\"  Sharpe: {portfolio_sharpe(bl_weights, posterior_returns, cov_shrunk):.2f}\")"
-   ]
+   ],
+   "id": "cell-bc4e4e64"
   },
   {
    "cell_type": "markdown",
@@ -1789,7 +1825,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-31eb3251"
   },
   {
    "cell_type": "code",
@@ -1845,11 +1882,12 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-77bd4921"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-b9cd08ec",
    "metadata": {},
    "source": [
     "---\n",
@@ -1874,7 +1912,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-9b160ee2",
    "metadata": {},
    "source": [
     "# Exercice 3 : Backtest comparatif d'allocations\n",
@@ -1912,7 +1950,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-83a92290"
   },
   {
    "cell_type": "markdown",
@@ -1951,7 +1990,8 @@
     "\n",
     "> *Ancre savante -- Lopez de Prado, M. (2016), « Building Diversified Portfolios that Outperform Out-of-Sample », The Journal of Portfolio Management 42(4), 59-69 (SSRN 2708678). HRP (clustering hierarchique + quasi-diagonalisation + bisection recursive) y est introduit precisement pour eviter l'inversion instable de la matrice de covariance qui plombe le Mean-Variance.*\n",
     ""
-   ]
+   ],
+   "id": "cell-ec952a7a"
   },
   {
    "cell_type": "code",
@@ -2093,7 +2133,8 @@
     "print(f\"\\n  Rendement attendu: {portfolio_return(hrp_weights, expected_returns):.2%}\")\n",
     "print(f\"  Volatilite: {portfolio_volatility(hrp_weights, cov_shrunk):.2%}\")\n",
     "print(f\"  Sharpe: {portfolio_sharpe(hrp_weights, expected_returns, cov_shrunk):.2f}\")"
-   ]
+   ],
+   "id": "cell-e84f083d"
   },
   {
    "cell_type": "markdown",
@@ -2116,7 +2157,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-fcc33df1"
   },
   {
    "cell_type": "code",
@@ -2166,7 +2208,8 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
-   ]
+   ],
+   "id": "cell-f22c841d"
   },
   {
    "cell_type": "markdown",
@@ -2179,7 +2222,8 @@
     "### ML-Enhanced Portfolio Construction Model\n",
     "\n",
     "Integrons les techniques vues dans un **Portfolio Construction Model** QuantConnect."
-   ]
+   ],
+   "id": "cell-1ba95036"
   },
   {
    "cell_type": "code",
@@ -2393,7 +2437,8 @@
     "print(\"  - Expected Returns: Random Forest (optionnel)\")\n",
     "print(\"  - Optimisation: Mean-Variance ou HRP\")\n",
     "print(\"  - Contraintes: Max 25% par actif\")"
-   ]
+   ],
+   "id": "cell-f12c88ab"
   },
   {
    "cell_type": "markdown",
@@ -2423,7 +2468,8 @@
     "              v\n",
     "Execution (Immediate)\n",
     "```"
-   ]
+   ],
+   "id": "cell-284c46ed"
   },
   {
    "cell_type": "code",
@@ -2606,7 +2652,8 @@
     "print(\"\\n5. Execution:\")\n",
     "print(\"   - Immediate Market Orders\")\n",
     "print(\"   - Rebalancement: Mensuel\")"
-   ]
+   ],
+   "id": "cell-1eb832ca"
   },
   {
    "cell_type": "markdown",
@@ -2630,7 +2677,8 @@
     "\n",
     "---"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-0d60cfe0"
   },
   {
    "cell_type": "code",
@@ -2672,7 +2720,8 @@
     "})\n",
     "\n",
     "print(methods_comparison.to_string(index=False))"
-   ]
+   ],
+   "id": "cell-c8bc524c"
   },
   {
    "cell_type": "markdown",
@@ -2732,7 +2781,8 @@
     "---\n",
     "\n",
     "**Notebook complete. Vous maitrisez maintenant l'optimisation de portefeuille avec ML.**"
-   ]
+   ],
+   "id": "cell-e369de77"
   }
  ],
  "metadata": {
@@ -2748,5 +2798,5 @@
   "qc_reference": true
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -45,14 +45,16 @@
     "| 5 | Systeme Hybride LLM + Indicateurs | 15 min |\n",
     "| 6 | Integration QuantConnect | 15 min |",
     "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-b1db72be"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-5401d92d"
   },
   {
    "cell_type": "markdown",
@@ -67,7 +69,8 @@
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-b2d87854"
   },
   {
    "cell_type": "markdown",
@@ -114,7 +117,8 @@
     "| Generalisation zero-shot | Hallucinations possibles |\n",
     "| Mise a jour des connaissances | Knowledge cutoff |\n",
     "| Multi-tache sans retraining | Non deterministe |"
-   ]
+   ],
+   "id": "cell-f5b25118"
   },
   {
    "cell_type": "code",
@@ -161,7 +165,8 @@
     "print(f\"Anthropic disponible: {ANTHROPIC_AVAILABLE}\")\n",
     "print(\"\\nNote: Ce notebook necessite des cles API valides pour les appels reels.\")\n",
     "print(\"Les exemples utilisent des reponses simulees si les APIs ne sont pas configurees.\")"
-   ]
+   ],
+   "id": "cell-497228b7"
   },
   {
    "cell_type": "markdown",
@@ -218,7 +223,8 @@
     "print(f\"  Anthropic Key: {'configuree' if config.anthropic_api_key else 'Non configuree'}\")\n",
     "print(f\"  OpenAI Model: {config.openai_model}\")\n",
     "print(f\"  Claude Model: {config.claude_model}\")"
-   ]
+   ],
+   "id": "cell-e26a2bda"
   },
   {
    "cell_type": "markdown",
@@ -251,7 +257,8 @@
     "  Output: 100K * 30 * $0.60/1M = $1.80\n",
     "  Total: ~$3.40/mois\n",
     "```"
-   ]
+   ],
+   "id": "cell-79f7c9b7"
   },
   {
    "cell_type": "code",
@@ -336,11 +343,12 @@
     "    tracker.record_usage('gpt-4o-mini', input_tokens=500, output_tokens=200)\n",
     "\n",
     "print(tracker.report('gpt-4o-mini'))"
-   ]
+   ],
+   "id": "cell-8f196758"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-c4f261ac",
    "metadata": {},
    "source": [
     "---\n",
@@ -365,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-f3ce82c0",
    "metadata": {},
    "source": [
     "# Exercice 1 : Estimation couts API\n",
@@ -387,7 +395,8 @@
    "metadata": {},
    "source": [
     "### Exercice 1 : Estimation du cout mensuel d'une strategie multi-actifs\n\nEstimez le **cout mensuel** d'une strategie LLM analysant 10 actifs avec 3 appels API par jour. L'objectif est de determiner si l'approche est economiquement viable.\n\n**Indices** :\n- `# Indice` : Calculez `nb_appels = 10 actifs * 3 appels/jour * 22 jours/mois`\n- `# Etape 1` : Definir le cout par appel API (ex: $0.01 pour GPT-4o-mini)\n- `# Etape 2` : Calculer le nombre d'appels mensuel\n- `# Etape 3` : Calculer le cout total mensuel"
-   ]
+   ],
+   "id": "cell-d3193b5d"
   },
   {
    "cell_type": "code",
@@ -404,7 +413,8 @@
    ],
    "source": [
     "# Exercice 1 : Cout mensuel API multi-actifs\n# TODO etudiant : Estimer le cout mensuel d'une strategie LLM sur 10 actifs\n# Etape 1 : cout_par_appel = 0.01  # USD (GPT-4o-mini estimate)\n# Etape 2 : appels_mensuel = 10 * 3 * 22\n# Etape 3 : cout_total = appels_mensuel * cout_par_appel\ncout_mensuel = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Cout mensuel API multi-actifs\")"
-   ]
+   ],
+   "id": "cell-135ccd50"
   },
   {
    "cell_type": "markdown",
@@ -445,7 +455,8 @@
     "[INPUT]\n",
     "{texte a analyser}\n",
     "```"
-   ]
+   ],
+   "id": "cell-13cf9256"
   },
   {
    "cell_type": "code",
@@ -598,7 +609,8 @@
     ")\n",
     "print(f\"\\nExemple de prompt formate ({len(example_prompt)} caracteres):\")\n",
     "print(example_prompt[:500] + \"...\")"
-   ]
+   ],
+   "id": "cell-dad153f2"
   },
   {
    "cell_type": "markdown",
@@ -631,7 +643,8 @@
     "    v\n",
     "Trading Signal\n",
     "```"
-   ]
+   ],
+   "id": "cell-695b822b"
   },
   {
    "cell_type": "code",
@@ -803,7 +816,8 @@
     "# Initialiser client\n",
     "llm_client = LLMClient(config)\n",
     "print(\"LLM Client initialise\")"
-   ]
+   ],
+   "id": "cell-f7c2f006"
   },
   {
    "cell_type": "markdown",
@@ -973,11 +987,12 @@
     "# Aggreger\n",
     "agg_signal, agg_conf = analyzer.aggregate_signals(results)\n",
     "print(f\"\\nSignal Agrege: {agg_signal:.2f} (confiance: {agg_conf:.2f})\")"
-   ]
+   ],
+   "id": "cell-611367e6"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-c6cf3fd7",
    "metadata": {},
    "source": [
     "---\n",
@@ -1001,7 +1016,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-5f783234",
    "metadata": {},
    "source": [
     "# Exercice 2 : Prompt engineering compare\n",
@@ -1023,7 +1038,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Prompt personnalise pour l'analyse de results d'entreprise\n\nCreez un **prompt specifique** pour analyser les results d'entreprise (earnings). Le prompt doit demander au LLM d'evaluer le sentiment et la confiance.\n\n**Indices** :\n- `# Indice` : Utilisez un template avec des placeholders `{company}`, `{quarter}`, `{eps_actual}`, `{eps_estimate}`\n- `# Etape 1` : Definir le template de prompt\n- `# Etape 2` : Inclure les consignes : sentiment (bullish/bearish/neutral), confiance (0-1), raison principale\n- `# Etape 3` : Tester le template avec des valeurs exemples"
-   ]
+   ],
+   "id": "cell-e84bb559"
   },
   {
    "cell_type": "code",
@@ -1040,7 +1056,8 @@
    ],
    "source": [
     "# Exercice 2 : Prompt d'analyse de results d'entreprise\n# TODO etudiant : Creer un prompt pour analyser les earnings\n# Etape 1 : Definir le template avec placeholders\n# Etape 2 : Inclure consignes (sentiment, confiance, raison)\n# Etape 3 : Tester avec des valeurs exemples\nearnings_prompt = None  # TODO etudiant : remplacer par le template\nprint(\"Exercice a completer : Prompt d'analyse de results d'entreprise\")"
-   ]
+   ],
+   "id": "cell-f10d87fa"
   },
   {
    "cell_type": "markdown",
@@ -1064,7 +1081,8 @@
     "\n",
     "> *Ancre savante -- Chain-of-Thought prompting.* Le raisonnement etape par etape explicitement demande dans le prompt (chain-of-thought) a ete formalise par Wei et al. (2022), *Chain-of-Thought Prompting Elicits Reasoning in Large Language Models*, NeurIPS, arXiv:2201.11903.\n",
     ""
-   ]
+   ],
+   "id": "cell-ef7234b7"
   },
   {
    "cell_type": "code",
@@ -1229,7 +1247,8 @@
     "    print(f\"  Position Size: {decision.get('position_size', 'N/A')}\")\n",
     "else:\n",
     "    print(f\"\\nResultat brut: {json.dumps(cot_result, indent=2)[:500]}...\")"
-   ]
+   ],
+   "id": "cell-f6dfba9f"
   },
   {
    "cell_type": "markdown",
@@ -1269,7 +1288,8 @@
     "| Latence | Haute | Faible | Moyenne |\n",
     "| Cout | Eleve | Faible | Modere |\n",
     "| Robustesse | Moyenne | Moyenne | Haute |"
-   ]
+   ],
+   "id": "cell-f38fd3f3"
   },
   {
    "cell_type": "code",
@@ -1506,14 +1526,16 @@
     "print(f\"  Fused Signal: {hybrid_signal.fused_signal:.2f}\")\n",
     "print(f\"  Direction: {hybrid_signal.final_direction}\")\n",
     "print(f\"  Position Size: {hybrid_signal.position_size:.1%}\")"
-   ]
+   ],
+   "id": "cell-7e6df23f"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 3 : Impact du desaccord entre signaux LLM et techniques\n\nAnalysez l'impact sur le **position sizing** quand le signal LLM et le signal technique sont en desaccord (ex: LLM bullish mais RSI en surachat).\n\n**Indices** :\n- `# Indice` : Simulez 10 scenarios de desaccord avec differentes combinaisons de signaux\n- `# Etape 1` : Creer une liste de scenarios (LLM bullish/bearish) x (technique bullish/bearish)\n- `# Etape 2` : Definir une regle de position sizing pour chaque cas\n- `# Etape 3` : Afficher un tableau recapitulatif des tailles de position"
-   ]
+   ],
+   "id": "cell-f75769bc"
   },
   {
    "cell_type": "code",
@@ -1530,7 +1552,8 @@
    ],
    "source": [
     "# Exercice 3 : Desaccord signaux LLM vs techniques\n# TODO etudiant : Analyser l'impact du desaccord LLM/technique sur le position sizing\n# Etape 1 : Creer 4 scenarios (LLM+/Tech+, LLM+/Tech-, LLM-/Tech+, LLM-/Tech-)\n# Etape 2 : Attribuer une taille de position a chaque scenario\n# Etape 3 : Afficher le tableau recapitulatif\nposition_sizing_table = None  # TODO etudiant : remplacer par le tableau\nprint(\"Exercice a completer : Desaccord signaux LLM vs techniques\")"
-   ]
+   ],
+   "id": "cell-b7d8e4e7"
   },
   {
    "cell_type": "markdown",
@@ -1669,11 +1692,12 @@
     "    demo_signals.append(signal)\n",
     "\n",
     "visualize_hybrid_signals(demo_signals)"
-   ]
+   ],
+   "id": "cell-54aa8a87"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-03dde241",
    "metadata": {},
    "source": [
     "---\n",
@@ -1697,7 +1721,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-19a79b4c",
    "metadata": {},
    "source": [
     "# Exercice 3 : Systeme de vote LLM\n",
@@ -1742,7 +1766,8 @@
     "        v\n",
     "Alpha Model Insights\n",
     "```"
-   ]
+   ],
+   "id": "cell-091e8f62"
   },
   {
    "cell_type": "code",
@@ -2043,7 +2068,8 @@
     "print(\"  - Budget API: $1/jour\")\n",
     "print(\"  - Fusion LLM + Technical\")\n",
     "print(\"  - Caching des resultats\")"
-   ]
+   ],
+   "id": "cell-179f3b53"
   },
   {
    "cell_type": "markdown",
@@ -2152,7 +2178,8 @@
     "print(\"  - GPT-4o-mini: ~$3-5/mois\")\n",
     "print(\"  - GPT-4o: ~$15-25/mois\")\n",
     "print(\"  - Claude 3.5 Sonnet: ~$20-30/mois\")"
-   ]
+   ],
+   "id": "cell-33a88029"
   },
   {
    "cell_type": "markdown",
@@ -2202,7 +2229,8 @@
     "---\n",
     "\n",
     "**Notebook complete. Vous maitrisez maintenant l'integration des LLMs pour le trading.**"
-   ]
+   ],
+   "id": "cell-ec437b8f"
   }
  ],
  "metadata": {
@@ -2218,5 +2246,5 @@
   "qc_reference": true
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -45,14 +45,16 @@
     "| 5 | Multi-Strategy Orchestration | 10 min |\n",
     "| 6 | Checklist et Best Practices | 10 min |",
     "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-e8d2bd2e"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-613fd687"
   },
   {
    "cell_type": "markdown",
@@ -67,7 +69,8 @@
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-18bfe679"
   },
   {
    "cell_type": "markdown",
@@ -115,7 +118,8 @@
     "| Pas de monitoring | Pertes non detectees | Alertes automatiques |\n",
     "| Position sizing agressif | Drawdown fatal | Kelly fractional (25-50%) |\n",
     "| Pas de stop-loss | Pertes illimitees | Hardcoded max loss |"
-   ]
+   ],
+   "id": "cell-8f858d1f"
   },
   {
    "cell_type": "code",
@@ -159,7 +163,8 @@
     "print(\"=\"*50)\n",
     "print(\"\\nCe notebook couvre le deploiement en production.\")\n",
     "print(\"Les exemples de code sont destines a QuantConnect.\")"
-   ]
+   ],
+   "id": "cell-29810366"
   },
   {
    "cell_type": "markdown",
@@ -192,7 +197,8 @@
     "| Paper -> Live | 2+ semaines paper, metrics stables |\n",
     "| Live -> Paused | Drawdown > seuil, anomalie detectee |\n",
     "| Paused -> Live | Cause identifiee, fix valide |"
-   ]
+   ],
+   "id": "cell-347b3391"
   },
   {
    "cell_type": "code",
@@ -381,11 +387,12 @@
     "\n",
     "# Paper -> Live\n",
     "manager.transition(\"MomentumML\", AlgorithmState.LIVE)"
-   ]
+   ],
+   "id": "cell-d69d643a"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-cb0dc0c9",
    "metadata": {},
    "source": [
     "---\n",
@@ -409,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-10b1aa7f",
    "metadata": {},
    "source": [
     "# Exercice 1 : Pipeline validation pre-deploiement\n",
@@ -431,7 +438,8 @@
    "metadata": {},
    "source": [
     "### Exercice 1 : Criteres de transition personnalises\n\nAjoutez un critere de transition entre paper trading et live trading : le **backtest return** doit depasser 15% ET le **Max Drawdown** doit rester sous 20%.\n\n**Indices** :\n- `# Indice` : Utilisez les metriques `backtest_return` et `max_drawdown` du LifecycleManager\n- `# Etape 1` : Definir les seuils (return > 15%, drawdown < 20%)\n- `# Etape 2` : Ajouter les conditions dans la methode de transition\n- `# Etape 3` : Logger le resultat de chaque condition"
-   ]
+   ],
+   "id": "cell-a58c0a99"
   },
   {
    "cell_type": "code",
@@ -448,7 +456,8 @@
    ],
    "source": [
     "# Exercice 1 : Criteres de transition paper-to-live\n# TODO etudiant : Ajouter des criteres de transition (return>15%, MaxDD<20%)\n# Etape 1 : Definir les seuils\n# Etape 2 : Verifier chaque condition\n# Etape 3 : Logger le resultat\ntransition_result = None  # TODO etudiant : remplacer par le resultat\nprint(\"Exercice a completer : Criteres de transition paper-to-live\")"
-   ]
+   ],
+   "id": "cell-c2a44cbb"
   },
   {
    "cell_type": "markdown",
@@ -469,7 +478,8 @@
     "| **Errors** | Gestion des exceptions |\n",
     "\n",
     "### Configuration QuantConnect Paper Trading"
-   ]
+   ],
+   "id": "cell-f7340496"
   },
   {
    "cell_type": "code",
@@ -670,7 +680,8 @@
     "print(\"  - Weekly backtest comparison\")\n",
     "print(\"  - Slippage and fill time tracking\")\n",
     "print(\"  - Automatic alerts on anomalies\")"
-   ]
+   ],
+   "id": "cell-7e5e472c"
   },
   {
    "cell_type": "markdown",
@@ -681,7 +692,8 @@
     ">\n",
     "> Ce template illustre le **comportement attendu en live / paper trading** : logging detaille (`LogTrade`), rapports quotidiens et hebdomadaires (`DailyReport`, `WeeklyComparison`), tracking du slippage et du temps de fill (`OnOrderEvent`), alertes sur drawdown et deviation de performance (`Notify.Sms` / `Notify.Email`). Il s'agit d'une **structure de deploiement**, NON d'une performance issue d'un backtest reel."
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-1d5b1e3a"
   },
   {
    "cell_type": "markdown",
@@ -851,11 +863,12 @@
     "paper_metrics.slippage_bps = list(np.random.uniform(1, 8, 12))\n",
     "\n",
     "print(paper_metrics.report())"
-   ]
+   ],
+   "id": "cell-27ed258b"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-b3b8951d",
    "metadata": {},
    "source": [
     "---\n",
@@ -878,7 +891,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-10f9f8eb",
    "metadata": {},
    "source": [
     "# Exercice 2 : Validateur de configuration live\n",
@@ -900,7 +913,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Ratio Sharpe paper vs backtest\n\nCalculez le **ratio de Sharpe** entre le paper trading et le backtest. Un ratio proche de 1.0 indique une bonne coherence. Un ratio < 0.5 signale un probleme de deploiement.\n\n**Indices** :\n- `# Indice` : Ratio = `paper_sharpe / backtest_sharpe`\n- `# Etape 1` : Extraire le Sharpe du paper trading\n- `# Etape 2` : Extraire le Sharpe du backtest\n- `# Etape 3` : Calculer le ratio et interpreter"
-   ]
+   ],
+   "id": "cell-e0e38754"
   },
   {
    "cell_type": "code",
@@ -917,7 +931,8 @@
    ],
    "source": [
     "# Exercice 2 : Ratio Sharpe paper vs backtest\n# TODO etudiant : Calculer le ratio paper_sharpe / backtest_sharpe\n# Etape 1 : paper_sharpe = extraire des metriques paper\n# Etape 2 : backtest_sharpe = extraire des metriques backtest\n# Etape 3 : ratio = paper_sharpe / backtest_sharpe\nsharpe_ratio = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Ratio Sharpe paper vs backtest\")"
-   ]
+   ],
+   "id": "cell-af05a88b"
   },
   {
    "cell_type": "markdown",
@@ -938,7 +953,8 @@
     "| Bitfinex | Crypto | $0 | Variable |\n",
     "\n",
     "### Configuration Interactive Brokers"
-   ]
+   ],
+   "id": "cell-56fabec9"
   },
   {
    "cell_type": "code",
@@ -1101,12 +1117,14 @@
     "print(\"  - Max 10% total drawdown\")\n",
     "print(\"  - Max 20 trades per day\")\n",
     "print(\"  - Auto-liquidation on breach\")"
-   ]
+   ],
+   "id": "cell-0130e4bd"
   },
   {
    "cell_type": "markdown",
    "source": "> **Resultat du backtest QC Cloud** - `LiveTradingAlgorithm` (periode 2023-01-01 a 2023-03-31, $100k initial)\n>\n> | Metrique | Valeur |\n> |----------|--------|\n> | Statut | COMPLETED |\n> | Ordres | 0 |\n> | Sharpe | 0 |\n> | Net Profit | 0% |\n> | End Equity | $100,000 |\n>\n> **Note** : Risk manager skeleton - aucune logique de trading, reset quotidien uniquement. Le framework de risque (position sizing, daily loss limit, trade limit) est en place mais ne genere pas de signaux.",
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-228b61fb"
   },
   {
    "cell_type": "markdown",
@@ -1144,7 +1162,8 @@
     "| **Critical** | Drawdown >10%, errors | SMS + Email + Halt |\n",
     "| **Warning** | Deviation >50%, slippage | Email |\n",
     "| **Info** | Daily report, trades | Log |"
-   ]
+   ],
+   "id": "cell-bfe955e5"
   },
   {
    "cell_type": "code",
@@ -1308,11 +1327,12 @@
     "monitor.record_metric('drawdown', -0.12)  # Critical\n",
     "\n",
     "print(f\"\\nTotal alerts: {len(monitor.alerts)}\")"
-   ]
+   ],
+   "id": "cell-52f46ecd"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-23f14c47",
    "metadata": {},
    "source": [
     "---\n",
@@ -1336,7 +1356,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-a5c6cbfb",
    "metadata": {},
    "source": [
     "# Exercice 3 : Allocateur multi-strategies\n",
@@ -1390,7 +1410,8 @@
     "> **Ancrage théorique — allocation de capital multi-stratégies.**\n",
     "> La ligne **Risk Parity** renvoie au *risk budgeting* où chaque stratégie reçoit un poids inversement proportionnel à sa contribution de risque, formalisé par Maillard, Roncalli & Teiletche (2010) *The Properties of Equally Weighted Risk Contribution Portfolios*, Journal of Portfolio Management 36(4):60–70 — le portefeuille de *parité de risque* équilibre les contributions de risque plutôt que les capitaux.\n",
     "> La ligne **Kelly** renvoie au *critère de Kelly* (Kelly 1956 *A New Interpretation of Information Rate*, Bell System Technical Journal 35:917–926), qui maximise le taux de croissance attendu du log-capital et donne la fraction optimale à risquer par stratégie — théoriquement optimal sous hypothèses fortes (probabilités connues, fonction d'utilité logarithmique), d'où le qualificatif « optimal théorique » et l'usage prudent « agressif » en pratique.\n"
-   ]
+   ],
+   "id": "cell-dec33e15"
   },
   {
    "cell_type": "code",
@@ -1581,14 +1602,16 @@
     "    allocs = orchestrator.compute_allocations()\n",
     "    for name, alloc in allocs.items():\n",
     "        print(f\"  {name}: {alloc:.1%}\")"
-   ]
+   ],
+   "id": "cell-9accec70"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 3 : Allocation avec contrainte de correlation\n\nAjoutez une **contrainte de correlation** a l'orchestrateur multi-strategies : si deux strategies ont une correlation > 0.7, reduisez l'allocation de la moins performante.\n\n**Indices** :\n- `# Indice` : Calculez la correlation entre les returns des strategies\n- `# Etape 1` : Simuler les returns de 3 strategies\n- `# Etape 2` : Calculer la matrice de correlation\n- `# Etape 3` : Reduire l'allocation des strategies correllees"
-   ]
+   ],
+   "id": "cell-467d75f2"
   },
   {
    "cell_type": "code",
@@ -1605,7 +1628,8 @@
    ],
    "source": [
     "# Exercice 3 : Allocation avec contrainte de correlation\n# TODO etudiant : Reduire l'allocation des strategies trop correllees (>0.7)\n# Etape 1 : Simuler les returns de 3 strategies\n# Etape 2 : Calculer la matrice de correlation\n# Etape 3 : Reduire l'allocation si corr > 0.7\nadjusted_allocations = None  # TODO etudiant : remplacer par les allocations\nprint(\"Exercice a completer : Allocation avec contrainte de correlation\")"
-   ]
+   ],
+   "id": "cell-fbde7235"
   },
   {
    "cell_type": "markdown",
@@ -1616,7 +1640,8 @@
     "## Partie 6 : Checklist et Best Practices (10 min)\n",
     "\n",
     "### Pre-Deployment Checklist"
-   ]
+   ],
+   "id": "cell-9b6364c2"
   },
   {
    "cell_type": "code",
@@ -1825,7 +1850,8 @@
     "checklist.check(\"Infra\", \"API keys\", True)\n",
     "\n",
     "print(checklist.report())"
-   ]
+   ],
+   "id": "cell-a578b259"
   },
   {
    "cell_type": "markdown",
@@ -1932,7 +1958,8 @@
     "\"\"\"\n",
     "\n",
     "print(best_practices)"
-   ]
+   ],
+   "id": "cell-9865d106"
   },
   {
    "cell_type": "markdown",
@@ -1981,7 +2008,8 @@
     "**Felicitations ! Vous avez complete la serie QuantConnect AI Trading.**\n",
     "\n",
     "*Bonne chance dans vos strategies de trading algorithmique !*"
-   ]
+   ],
+   "id": "cell-e5e5bd1c"
   }
  ],
  "metadata": {
@@ -1997,5 +2025,5 @@
   "qc_reference": true
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -46,7 +46,8 @@
     "| 6 | Analyse par Regime | 5 min |\n",
     "\n",
     "> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-92d5ecf7"
   },
   {
    "cell_type": "markdown",
@@ -56,7 +57,8 @@
     "> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n",
     "> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n",
     "> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-5d52f80a"
   },
   {
    "cell_type": "markdown",
@@ -129,7 +131,8 @@
     "---\n",
     "\n",
     "**Felicitations !** Vous avez appris a detecter les regimes de marche et a construire une strategie adaptative. Cette approche peut etre appliquee a de nombreuses autres strategies pour les rendre plus robustes."
-   ]
+   ],
+   "id": "cell-acd4dc7c"
   },
   {
    "cell_type": "code",
@@ -382,7 +385,8 @@
     "print(\"  - Stop-loss trailing -10%\")\n",
     "print(\"  - Rebalancement mensuel + trigger regime\")\n",
     "print(\"\\\\nCopiez ce code dans main.py de votre projet QC Lab.\")"
-   ]
+   ],
+   "id": "cell-a70ee805"
   },
   {
    "cell_type": "markdown",
@@ -403,7 +407,8 @@
     ">\n",
     "> *Backtest QC Cloud 2015-2024 (projet 33177683, bt 97a99ceb9a70b6a18e27b3408c24029c). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
    ],
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-bef966d0"
   },
   {
    "cell_type": "markdown",
@@ -416,7 +421,8 @@
     "### Code de reference pour QC Lab\n",
     "\n",
     "Voici le code complet a copier dans `main.py` de votre projet QuantConnect. Ce code implemente la strategie RegimeSwitching avec toutes les fonctionnalites decrites dans ce notebook."
-   ]
+   ],
+   "id": "cell-41ddcfa6"
   },
   {
    "cell_type": "code",
@@ -611,14 +617,16 @@
     "print(\"Setup complet : {} jours, {} cellules pretes\".format(n_days, len(df)))\n",
     "print(\"Regimes : {}\".format(regimes_sma.value_counts().to_dict()))\n",
     "print(\"Meilleur seuil RSI: {} (Sharpe={:.3f})\".format(best_rsi[0], best_rsi[1]['sharpe']))"
-   ]
+   ],
+   "id": "cell-46d40b7f"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 1 : Calcul du Sortino Ratio par regime\n\nLe Sharpe Ratio penalise la volatilite haussiere et baissiere. Calculez le **Sortino Ratio** pour chaque regime, qui ne penalise que la volatilite baissiere.\n\n**Indices** :\n- `# Indice` : Le Sortino Ratio = mean(returns) / std(returns[returns < 0]) * sqrt(252)\n- `# Indice` : Filtrez les returns negatifs avec `returns[returns < 0]`\n- `# Etape 1` : Extraire les returns par regime\n- `# Etape 2` : Calculer le downside deviation par regime\n- `# Etape 3` : Calculer et afficher le Sortino Ratio par regime"
-   ]
+   ],
+   "id": "cell-8e19f411"
   },
   {
    "cell_type": "code",
@@ -635,14 +643,16 @@
    ],
    "source": [
     "# Exercice 3 : Sortino Ratio par regime\n# TODO etudiant : Calculer le Sortino Ratio (downside deviation) pour chaque regime\n# Etape 1 : Extraire les returns par regime\n# Etape 2 : Calculer le downside deviation (std des returns negatifs)\n# Etape 3 : Calculer Sortino = mean(return) / downside_dev * sqrt(252)\nsortino_by_regime = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Sortino Ratio par regime\")"
-   ]
+   ],
+   "id": "cell-513c85fc"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 2 : Ajouter un regime CRISIS au detecteur\n\nLe detecteur actuel utilise 3 regimes. Ajoutez un **4eme regime CRISIS** declenche quand le drawdown depasse -15% ET la volatilite rolling est au-dessus de la moyenne + 2 ecarts-types.\n\n**Indices** :\n- `# Indice` : Calculez le drawdown comme `(price / cummax - 1)`\n- `# Indice` : Calculez la volatilite rolling 20j annualisee\n- `# Etape 1` : Calculer le drawdown quotidien\n- `# Etape 2` : Calculer la volatilite rolling 20j\n- `# Etape 3` : Ajouter la condition CRISIS a la classification"
-   ]
+   ],
+   "id": "cell-800df3f0"
   },
   {
    "cell_type": "code",
@@ -659,14 +669,16 @@
    ],
    "source": [
     "# Exercice 2 : Detecteur de regime CRISIS\n# TODO etudiant : Ajouter un regime CRISIS quand drawdown < -15% ET vol > mean + 2*std\n# Etape 1 : Calculer le drawdown quotidien\n# Etape 2 : Calculer la volatilite rolling 20j\n# Etape 3 : Ajouter la condition CRISIS\nregime_crisis = None  # TODO etudiant : remplacer par la serie de regimes avec CRISIS\nprint(\"Exercice a completer : Detecteur de regime CRISIS\")"
-   ]
+   ],
+   "id": "cell-c6c64c5a"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 3 : Calcul de la volatilite par regime\n\nCalculez la **volatilite annualisee** des returns journaliers pour chaque regime (BULL, BEAR, NEUTRAL). Cela permet de verifier que la classification capture bien des regimes de volatilite distincts.\n\n**Indices** :\n- `# Indice` : Groupez les returns par regime avec `.groupby(regimes)` puis calculez `.std() * sqrt(252)`\n- `# Etape 1` : Calculer les returns journaliers\n- `# Etape 2` : Grouper par regime et calculer l'ecart-type\n- `# Etape 3` : Annualiser et afficher"
-   ]
+   ],
+   "id": "cell-207829f9"
   },
   {
    "cell_type": "code",
@@ -683,7 +695,8 @@
    ],
    "source": [
     "# Exercice 1 : Volatilite par regime\n# TODO etudiant : Calculer la volatilite annualisee des returns par regime\n# Etape 1 : Calculer les returns journaliers (pct_change)\n# Etape 2 : Grouper par regime avec .groupby()\n# Etape 3 : Annualiser (std * sqrt(252)) et afficher\nvol_by_regime = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Volatilite par regime\")"
-   ]
+   ],
+   "id": "cell-4befb25c"
   },
   {
    "cell_type": "code",
@@ -754,7 +767,8 @@
     "print(\"  - Le momentum en bull capture les trends haussiers\")\n",
     "print(\"  - L'allocation defensive en bear protege le capital\")\n",
     "print(\"  - Le mean-reversion en sideways ajoute de l'alpha\")"
-   ]
+   ],
+   "id": "cell-79adee84"
   },
   {
    "cell_type": "markdown",
@@ -777,7 +791,8 @@
     "3. La performance globale depend de la **distribution des regimes** sur la periode\n",
     "\n",
     "> **Note technique** : Pour une analyse plus complete, on peut calculer la performance \"regime-adjusted\" : normaliser la performance par le temps passe dans chaque regime. Cela permet de comparer des strategies sur differentes periodes."
-   ]
+   ],
+   "id": "cell-ec0fceb3"
   },
   {
    "cell_type": "code",
@@ -864,11 +879,12 @@
     "print(f\"  Total regimes: {len(regimes_sma)}\")\n",
     "print(f\"  Warmup period: {warmup} jours\")\n",
     "print(f\"  Periode d'analyse: {len(prices_all) - warmup} jours ({(len(prices_all) - warmup)/252:.1f} ans)\")"
-   ]
+   ],
+   "id": "cell-77828c4d"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-464af4c5",
    "metadata": {},
    "source": [
     "---\n",
@@ -891,7 +907,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-47c61562",
    "metadata": {},
    "source": [
     "# Exercice 3 : Performance par regime\n",
@@ -932,7 +948,8 @@
     "- **Return moyen par regime** : Performance annualisee par regime\n",
     "- **Drawdown par regime** : Risque maximal par regime\n",
     "- **Stabilite** : Variance de la performance dans le temps"
-   ]
+   ],
+   "id": "cell-64a2cb0d"
   },
   {
    "cell_type": "code",
@@ -1004,7 +1021,8 @@
     "print(f\"  Meilleur Sharpe: {best_rsi[1]['sharpe']:.3f} (RSI<{best_rsi[0]})\")\n",
     "print(f\"  CAGR correspondant: {best_rsi[1]['cagr']:.1%}\")\n",
     "print(f\"  Max DD correspondant: {best_rsi[1]['max_dd']:.1%}\")"
-   ]
+   ],
+   "id": "cell-7db4ae23"
   },
   {
    "cell_type": "markdown",
@@ -1026,7 +1044,8 @@
     "3. Il est preferable de choisir un seuil **robuste** (performance stable) plutot qu'optimal\n",
     "\n",
     "> **Note technique** : Pour une implementation en production, utiliser **walk-forward optimization** : optimiser sur une periode, tester sur la periode suivante, et repeter. Cela evite l'overfitting et simule les conditions reelles de trading."
-   ]
+   ],
+   "id": "cell-bf7f42ba"
   },
   {
    "cell_type": "code",
@@ -1143,7 +1162,8 @@
     "\n",
     "best_rsi = max(results_rsi.items(), key=lambda x: x[1]['sharpe'])\n",
     "print(f\"\\\\nMeilleur seuil RSI: {best_rsi[0]} (Sharpe={best_rsi[1]['sharpe']:.3f})\")"
-   ]
+   ],
+   "id": "cell-396154ea"
   },
   {
    "cell_type": "markdown",
@@ -1176,7 +1196,8 @@
     "- Calculer Sharpe, CAGR, Max Drawdown\n",
     "- Selectionner la combinaison avec le meilleur Sharpe\n",
     "- Verifier la robustesse (pas d'overfitting)"
-   ]
+   ],
+   "id": "cell-99088f11"
   },
   {
    "cell_type": "code",
@@ -1243,11 +1264,12 @@
     "print(f\"  Jours avec SPY > 0 : {(signals['SPY'] > 0).sum()} ({(signals['SPY'] > 0).sum() / len(signals) * 100:.1f}%)\")\n",
     "print(f\"  Jours avec GLD > 0 : {(signals['GLD'] > 0).sum()} ({(signals['GLD'] > 0).sum() / len(signals) * 100:.1f}%)\")\n",
     "print(f\"  Jours avec IEF > 0 : {(signals['IEF'] > 0).sum()} ({(signals['IEF'] > 0).sum() / len(signals) * 100:.1f}%)\")"
-   ]
+   ],
+   "id": "cell-d97d9515"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-683ba458",
    "metadata": {},
    "source": [
     "---\n",
@@ -1270,7 +1292,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-e00482a3",
    "metadata": {},
    "source": [
     "# Exercice 2 : Rotation adaptative trend/mean-reversion\n",
@@ -1307,7 +1329,8 @@
     "3. Le mean-reversion en sideways ajoute de l'alpha mais augmente le risque\n",
     "\n",
     "> **Note technique** : Cette implementation est simplifiee. La version complete (voir `projects/RegimeSwitching/main.py`) inclut le rebalancement mensuel, le stop-loss trailing, et la gestion des transitions de regime."
-   ]
+   ],
+   "id": "cell-85a2b37d"
   },
   {
    "cell_type": "code",
@@ -1438,7 +1461,8 @@
     "print(signals.tail(10))\n",
     "print(f\"\\\\nAllocation moyenne :\")\n",
     "print(signals.mean())"
-   ]
+   ],
+   "id": "cell-9fa80b6e"
   },
   {
    "cell_type": "markdown",
@@ -1473,7 +1497,8 @@
     "- **Allocation bull** : 70/30 (peut etre optimise : 60/40, 80/20)\n",
     "- **Frequence rebalancement** : Mensuel + trigger sur changement de regime\n",
     "- **Stop-loss** : Trailing stop a -10% sur les positions equities"
-   ]
+   ],
+   "id": "cell-3f5009f8"
   },
   {
    "cell_type": "code",
@@ -1541,7 +1566,8 @@
     "print(\"\\\\nSignaux RSI :\")\n",
     "print(f\"  Signaux oversold (RSI < 30) : {len(oversold_dates)}\")\n",
     "print(f\"  Signaux overbought (RSI > 70) : {len(overbought_dates)}\")"
-   ]
+   ],
+   "id": "cell-7a6f812b"
   },
   {
    "cell_type": "markdown",
@@ -1563,7 +1589,8 @@
     "3. Le RSI doit etre combine avec le **regime de marche** pour etre efficace\n",
     "\n",
     "> **Note technique** : Le RSI(14) est standard, mais on peut ajuster la periode. RSI(7) est plus reactif mais plus bruite, RSI(21) est plus lent mais plus fiable."
-   ]
+   ],
+   "id": "cell-2aae7727"
   },
   {
    "cell_type": "code",
@@ -1640,11 +1667,12 @@
     "print(f\"  Max : {rsi.max():.1f}\")\n",
     "print(f\"  Jours oversold (< 30) : {(rsi < 30).sum()}\")\n",
     "print(f\"  Jours overbought (> 70) : {(rsi > 70).sum()}\")"
-   ]
+   ],
+   "id": "cell-b36d07a6"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-7a7446ff",
    "metadata": {},
    "source": [
     "---\n",
@@ -1669,7 +1697,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-466ebecf",
    "metadata": {},
    "source": [
     "# Exercice 1 : Detecteur multi-indicateurs\n",
@@ -1716,7 +1744,8 @@
     "1. On est en regime defensif (bear/sideways)\n",
     "2. On utilise des positions reduites (30% max)\n",
     "3. On a un stop-loss strict"
-   ]
+   ],
+   "id": "cell-3ab41c06"
   },
   {
    "cell_type": "code",
@@ -1787,7 +1816,8 @@
     "print(f\"  Pourcentage en bull : {(regimes_sma == 'bull').sum() / len(regimes_sma) * 100:.1f}%\")\n",
     "print(f\"  Pourcentage en bear : {(regimes_sma == 'bear').sum() / len(regimes_sma) * 100:.1f}%\")\n",
     "print(f\"  Pourcentage en sideways : {(regimes_sma == 'sideways').sum() / len(regimes_sma) * 100:.1f}%\")"
-   ]
+   ],
+   "id": "cell-5406948a"
   },
   {
    "cell_type": "markdown",
@@ -1810,7 +1840,8 @@
     "3. La distribution des regimes depend de la periode etudiee (marche haussier vs baissier)\n",
     "\n",
     "> **Note technique** : Les periodes SMA (50/200) sont standards mais peuvent etre ajustees. SMA50 represente environ 3 mois de trading, SMA200 environ 10 mois."
-   ]
+   ],
+   "id": "cell-f3ff2e89"
   },
   {
    "cell_type": "code",
@@ -1888,7 +1919,8 @@
     "print(regimes_sma.tail(10))\n",
     "print(f\"\\\\nDistribution :\")\n",
     "print(regimes_sma.value_counts())"
-   ]
+   ],
+   "id": "cell-fddff02d"
   },
   {
    "cell_type": "markdown",
@@ -1929,7 +1961,8 @@
     "```\n",
     "\n",
     "Cette logique est **simple, robuste et eprouvee**. Elle evite les whipsaws (faux signaux) en exigeant que TANT le prix que SMA50 soient du meme cote de SMA200."
-   ]
+   ],
+   "id": "cell-61efddaa"
   },
   {
    "cell_type": "code",
@@ -2008,7 +2041,8 @@
     "\n",
     "print(\"\\\\nDistribution des regimes detectes :\")\n",
     "print(df['regime'].value_counts())"
-   ]
+   ],
+   "id": "cell-9be00605"
   },
   {
    "cell_type": "markdown",
@@ -2031,7 +2065,8 @@
     "3. Le nombre de jours dans chaque regime depend de la periode etudiee\n",
     "\n",
     "> **Note technique** : Cette approche SMA50/SMA200 est simple mais efficace. Des methodes plus avancees existent (HMM, modeles de Markov, ML), mais cette approche est robuste et interpretable."
-   ]
+   ],
+   "id": "cell-d7b4484d"
   },
   {
    "cell_type": "code",
@@ -2088,7 +2123,8 @@
     "\n",
     "print(\"Exemple de donnees avec 3 regimes :\")\n",
     "print(df.tail())"
-   ]
+   ],
+   "id": "cell-1bc30fec"
   },
   {
    "cell_type": "markdown",
@@ -2128,7 +2164,8 @@
     "| **Risque** | Le drawdown maximal depend du regime |\n",
     "| **Allocation** | L'optimale differe selon le regime (100% equity en bull vs 0% en bear) |\n",
     "| **Psychologie** | Les investisseurs se comportent differemment selon le regime |"
-   ]
+   ],
+   "id": "cell-9d00c42a"
   },
   {
    "cell_type": "code",
@@ -2169,7 +2206,8 @@
     "print(\"=\"*60)\n",
     "print(\"\\nCe notebook explore la detection de regimes de marche\")\n",
     "print(\"et la construction de strategies adaptatives.\")"
-   ]
+   ],
+   "id": "cell-69682792"
   },
   {
    "cell_type": "markdown",
@@ -2206,7 +2244,8 @@
     "- **Buy & Hold** : Excellent en bull, desastreux en bear\n",
     "\n",
     "**Solution** : Adapter la strategie au regime actuel du marche."
-   ]
+   ],
+   "id": "cell-8630c61b"
   }
  ],
  "metadata": {
@@ -2222,5 +2261,5 @@
   "qc_reference": true
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
@@ -16,7 +16,8 @@
     "\n",
     "> **References** : Haarnoja et al. (2018) \"Soft Actor-Critic\", Mnih et al. (2016)\n",
     "> \"Asynchronous Methods for Deep RL\", Hands-On AI Trading, chap. 12-13."
-   ]
+   ],
+   "id": "cell-87b6aa76"
   },
   {
    "cell_type": "markdown",
@@ -31,7 +32,8 @@
     "> 3. **A2C** : Synchronous advantage actor-critic\n",
     "> 4. **Benchmark** : Entrainement 100K steps, comparaison DQN/PPO/SAC/A2C\n",
     "> 5. **Synthese** : Tableau comparatif et recommandations"
-   ]
+   ],
+   "id": "cell-d53c996e"
   },
   {
    "cell_type": "markdown",
@@ -40,7 +42,8 @@
     "---\n",
     "\n",
     "## Partie 1 : Positionnement dans le paysage RL (10 min)"
-   ]
+   ],
+   "id": "cell-240a0379"
   },
   {
    "cell_type": "markdown",
@@ -69,7 +72,8 @@
     "- Moins stable que PPO mais plus rapide a converger\n",
     "\n",
     "> *Ancre savante -- Sutton, R.S. & Barto, A.G. (2018), Reinforcement Learning: An Introduction (2nd ed.), MIT Press, ISBN 978-0-262-03924-6. (Manuel de reference du RL : formalise la taxonomie value-based vs policy-gradient et on-policy vs off-policy utilisee ici pour positionner DQN/PPO/A2C/SAC ; source canonique des concepts de politique, fonction de valeur, avantage et equation de Bellman.)*\n"
-   ]
+   ],
+   "id": "cell-2da29a53"
   },
   {
    "cell_type": "markdown",
@@ -78,7 +82,8 @@
     "---\n",
     "\n",
     "## Partie 2 : Environnement et Configuration (5 min)"
-   ]
+   ],
+   "id": "cell-27552a7a"
   },
   {
    "cell_type": "code",
@@ -127,7 +132,8 @@
     "if torch.cuda.is_available():\n",
     "    torch.cuda.manual_seed(SEED)\n",
     "print(f\"Seed: {SEED}\")"
-   ]
+   ],
+   "id": "cell-c9a26acf"
   },
   {
    "cell_type": "markdown",
@@ -136,7 +142,8 @@
     "### Telechargement des donnees et environnement\n",
     "\n",
     "Nous reutilisons le meme environnement que QC-Py-32 et QC-Py-33 pour une comparaison equitable."
-   ]
+   ],
+   "id": "cell-45473868"
   },
   {
    "cell_type": "code",
@@ -289,7 +296,8 @@
     "print(f\"Tickers valides: {len(valid_tickers)}/{len(TRADE_TICKERS)}\")\n",
     "print(f\"Periode: {close_prices.index[0].strftime('%Y-%m-%d')} au {close_prices.index[-1].strftime('%Y-%m-%d')}\")\n",
     "print(f\"Jours de bourse: {len(close_prices)}\")"
-   ]
+   ],
+   "id": "cell-b17db46d"
   },
   {
    "cell_type": "code",
@@ -442,11 +450,12 @@
     "\n",
     "print(f\"Environnement: {N_ASSETS} actifs, STATE_DIM={STATE_DIM}, ACTION_DIM={ACTION_DIM}\")\n",
     "print(f\"Train: {train_env.total_steps} steps, Val: {val_env.total_steps} steps\")"
-   ]
+   ],
+   "id": "cell-2ed6fd3b"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-74009362",
    "metadata": {},
    "source": [
     "---\n",
@@ -469,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-c5363160",
    "metadata": {},
    "source": [
     "# Exercice 1 : Environnement avec couts de transaction\n",
@@ -493,7 +502,8 @@
     "---\n",
     "\n",
     "## Partie 3 : SAC Discret (20 min)"
-   ]
+   ],
+   "id": "cell-9d7555ea"
   },
   {
    "cell_type": "markdown",
@@ -516,7 +526,8 @@
     "- **Replay buffer** : Stocke les transitions pour reutilisation\n",
     "\n",
     "> *Ancres savantes -- Haarnoja, T., Zhou, A., Abbeel, P. & Levine, S. (2018), Soft Actor-Critic: Off-Policy Maximum Entropy Deep Reinforcement Learning with a Stochastic Actor, ICML 2018 (arXiv:1801.01290) (algorithme SAC : actor-critic off-policy maximisant recompense ET entropie, double Q-network + target smoothing + temperature alpha auto-adaptable) ; Haarnoja, T., Zhou, A., Hartikainen, K. et al. (2018), Soft Actor-Critic Algorithms and Applications (arXiv:1812.05905) (cadre du RL a entropie maximale, justification theorique de la regularisation par l'entropie et de l'exploration automatique).)*\n"
-   ]
+   ],
+   "id": "cell-30098feb"
   },
   {
    "cell_type": "code",
@@ -696,14 +707,16 @@
     "sac_agent = SACDiscreteAgent(STATE_DIM, ACTION_DIM, hidden_dim=128)\n",
     "n_params_sac = sum(p.numel() for p in list(sac_agent.q1.parameters()) + list(sac_agent.q2.parameters()) + list(sac_agent.policy.parameters()) + list(sac_agent.policy_head.parameters()))\n",
     "print(f\"SAC Discret: {n_params_sac:,} parametres, alpha={sac_agent.alpha:.3f}\")"
-   ]
+   ],
+   "id": "cell-c8ebcce2"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 1 : Analyser l'impact de la taille du buffer SAC\n\nLe **replay buffer** du SAC stocke les experiences passees. Testez deux tailles : 25K (petit) vs 100K (grand) et observez l'impact sur la stabilite.\n\n**Indices** :\n- `# Indice` : La taille est le parametre `capacity` du ReplayBuffer\n- `# Etape 1` : Modifier capacity=25000 et executer\n- `# Etape 2` : Modifier capacity=100000 et executer\n- `# Etape 3` : Comparer les courbes d'eval Sharpe"
-   ]
+   ],
+   "id": "cell-810a68e1"
   },
   {
    "cell_type": "code",
@@ -720,7 +733,8 @@
    ],
    "source": [
     "# Exercice 1 : Impact de la taille du replay buffer SAC\n# TODO etudiant : Tester capacity=25000 vs 100000\n# Etape 1 : Entrainer avec petit buffer\n# Etape 2 : Entrainer avec grand buffer\n# Etape 3 : Comparer les Sharpe ratios\nbuffer_comparison = None  # TODO etudiant : remplacer par les resultats\nprint(\"Exercice a completer : Impact de la taille du replay buffer SAC\")"
-   ]
+   ],
+   "id": "cell-cc6d5659"
   },
   {
    "cell_type": "markdown",
@@ -729,7 +743,8 @@
     "---\n",
     "\n",
     "## Partie 4 : A2C - Advantage Actor-Critic (15 min)"
-   ]
+   ],
+   "id": "cell-4b7ac8b8"
   },
   {
    "cell_type": "markdown",
@@ -748,7 +763,8 @@
     "- N steps returns au lieu de GAE\n",
     "\n",
     "> *Ancres savantes -- Mnih, V., Puigdomenech Badia, A., Mirza, M. et al. (2016), Asynchronous Methods for Deep Reinforcement Learning, ICML 2016 (arXiv:1602.01783) (A3C = acteurs-asynchrones ; A2C en est la variante synchrone deterministe decrite ici, sans parallelisme) ; Sutton, R.S., McAllester, D., Singh, S. & Mansour, Y. (2000), Policy Gradient Methods for Reinforcement Learning with Function Approximation, NeurIPS 2000 (cadre des methodes policy-gradient avec approximateur de fonction, fondement de l'acteur et de l'usage de l'avantage A(s,a) = R - V(s) comme signal).)*\n"
-   ]
+   ],
+   "id": "cell-5134a332"
   },
   {
    "cell_type": "code",
@@ -855,11 +871,12 @@
     "a2c_agent = A2CAgent(STATE_DIM, ACTION_DIM, hidden_dim=128)\n",
     "n_params_a2c = sum(p.numel() for p in list(a2c_agent.shared.parameters()) + list(a2c_agent.actor_head.parameters()) + list(a2c_agent.critic_head.parameters()))\n",
     "print(f\"A2C: {n_params_a2c:,} parametres, n_steps={a2c_agent.n_steps}\")"
-   ]
+   ],
+   "id": "cell-a1375de0"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-17069d1b",
    "metadata": {},
    "source": [
     "---\n",
@@ -882,7 +899,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-1d01d08c",
    "metadata": {},
    "source": [
     "# Exercice 2 : A2C entropy bonus\n",
@@ -904,7 +921,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Modifier le facteur de discount gamma\n\nLe **facteur de discount gamma** determine l'horizon temporel de l'agent. Testez gamma=0.9 (court terme) vs gamma=0.995 (long terme).\n\n**Indices** :\n- `# Indice` : `gamma` est utilise dans le calcul des returns dans A2C\n- `# Etape 1` : Localiser le parametre gamma dans A2CAgent\n- `# Etape 2` : Tester gamma=0.9 et gamma=0.995\n- `# Etape 3` : Comparer les performances"
-   ]
+   ],
+   "id": "cell-d357580b"
   },
   {
    "cell_type": "code",
@@ -921,7 +939,8 @@
    ],
    "source": [
     "# Exercice 2 : Impact du facteur de discount gamma\n# TODO etudiant : Tester gamma=0.9 vs gamma=0.995 sur A2C\n# Etape 1 : Localiser gamma dans A2CAgent\n# Etape 2 : Tester les deux valeurs\n# Etape 3 : Comparer les courbes de reward\ngamma_comparison = None  # TODO etudiant : remplacer par les resultats\nprint(\"Exercice a completer : Impact du facteur de discount gamma\")"
-   ]
+   ],
+   "id": "cell-82eb8d0e"
   },
   {
    "cell_type": "markdown",
@@ -930,7 +949,8 @@
     "---\n",
     "\n",
     "## Partie 5 : Benchmark 100K Steps (30 min)"
-   ]
+   ],
+   "id": "cell-9269b3f0"
   },
   {
    "cell_type": "markdown",
@@ -941,7 +961,8 @@
     "Les deux agents sont entraines sur le meme environnement pendant 100K steps chacun.\n",
     "Ce nombre reduit (vs 200K pour PPO) permet une comparaison rapide.\n",
     "Une evaluation walk-forward est effectuee tous les 25K steps."
-   ]
+   ],
+   "id": "cell-a49d6781"
   },
   {
    "cell_type": "code",
@@ -991,14 +1012,16 @@
     "    return action\n",
     "\n",
     "print(\"Fonctions d'evaluation definies.\")"
-   ]
+   ],
+   "id": "cell-6bb69d7d"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 3 : Tableau comparatif SAC vs A2C vs DQN vs PPO\n\nCreez un **tableau comparatif** des 4 algorithmes RL (DQN, PPO, SAC, A2C) avec les metriques : Sharpe, Return total, Max Drawdown, Nombre de trades.\n\n**Indices** :\n- `# Indice` : Reutilisez les resultats des notebooks QC-Py-32 et QC-Py-33 si disponibles\n- `# Indice` : Utilisez `pd.DataFrame()` pour construire le tableau\n- `# Etape 1` : Collecter les metriques de chaque algorithme\n- `# Etape 2` : Construire le DataFrame\n- `# Etape 3` : Afficher le tableau formatte"
-   ]
+   ],
+   "id": "cell-ead4003d"
   },
   {
    "cell_type": "code",
@@ -1015,7 +1038,8 @@
    ],
    "source": [
     "# Exercice 3 : Tableau comparatif des 4 algorithmes RL\n# TODO etudiant : Construire un tableau comparatif SAC vs A2C vs DQN vs PPO\n# Etape 1 : Collecter les metriques (Sharpe, Return, MaxDD, Trades)\n# Etape 2 : Construire un DataFrame\n# Etape 3 : Afficher le tableau formatte\ncomparison_table = None  # TODO etudiant : remplacer par le tableau\nprint(\"Exercice a completer : Tableau comparatif des algorithmes RL\")"
-   ]
+   ],
+   "id": "cell-da4e1451"
   },
   {
    "cell_type": "code",
@@ -1124,7 +1148,8 @@
     "\n",
     "sac_time = time.time() - sac_start\n",
     "print(f\"SAC termine: {sac_time/60:.1f} min, best_sharpe={best_sac_sharpe:.3f}\")"
-   ]
+   ],
+   "id": "cell-fd080527"
   },
   {
    "cell_type": "code",
@@ -1246,7 +1271,8 @@
     "\n",
     "a2c_time = time.time() - a2c_start\n",
     "print(f\"A2C termine: {a2c_time/60:.1f} min, best_sharpe={best_a2c_sharpe:.3f}\")"
-   ]
+   ],
+   "id": "cell-1ec1db07"
   },
   {
    "cell_type": "markdown",
@@ -1261,7 +1287,8 @@
     "La temperature alpha de SAC devrait converger vers une valeur stable si l'entropie\n",
     "de la politique est suffisante. L'entropie A2C peut diminuer plus rapidement\n",
     "car il n'y a pas de regularisation explicite."
-   ]
+   ],
+   "id": "cell-9e29fee0"
   },
   {
    "cell_type": "code",
@@ -1332,11 +1359,12 @@
     "plt.savefig(\"sac_a2c_training.png\", dpi=150, bbox_inches=\"tight\")\n",
     "plt.show()\n",
     "print(\"Courbes sauvegardees dans sac_a2c_training.png\")"
-   ]
+   ],
+   "id": "cell-aa6e5d5e"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-4051469b",
    "metadata": {},
    "source": [
     "---\n",
@@ -1359,7 +1387,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-70702d7d",
    "metadata": {},
    "source": [
     "# Exercice 3 : Benchmark DQN/PPO/SAC/A2C\n",
@@ -1383,7 +1411,8 @@
     "---\n",
     "\n",
     "## Partie 6 : Synthese et Comparaison Quadri-Algorithmes (10 min)"
-   ]
+   ],
+   "id": "cell-d13097eb"
   },
   {
    "cell_type": "markdown",
@@ -1393,7 +1422,8 @@
     "\n",
     "Nous evaluons SAC et A2C sur le set de validation complet et comparons avec les\n",
     "resultats de DQN (QC-Py-32) et PPO (QC-Py-33)."
-   ]
+   ],
+   "id": "cell-ed0b882d"
   },
   {
    "cell_type": "code",
@@ -1465,7 +1495,8 @@
     "print(f\"\\nClassement par Sharpe:\")\n",
     "for rank, (name, sharpe) in enumerate(sorted_agents, 1):\n",
     "    print(f\"  {rank}. {name}: {sharpe:+.3f}\")"
-   ]
+   ],
+   "id": "cell-6f889674"
   },
   {
    "cell_type": "code",
@@ -1535,7 +1566,8 @@
     "plt.savefig(\"sac_a2c_backtest.png\", dpi=150, bbox_inches=\"tight\")\n",
     "plt.show()\n",
     "print(\"Backtest sauvegarde dans sac_a2c_backtest.png\")"
-   ]
+   ],
+   "id": "cell-92a89e3d"
   },
   {
    "cell_type": "markdown",
@@ -1544,7 +1576,8 @@
     "---\n",
     "\n",
     "## Conclusion : Quelle methode RL pour le trading ?"
-   ]
+   ],
+   "id": "cell-63daf20a"
   },
   {
    "cell_type": "markdown",
@@ -1588,7 +1621,8 @@
     "- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press. ISBN 978-0-262-03924-6.\n",
     "- Sutton, R.S., McAllester, D., Singh, S. & Mansour, Y. (2000). Policy Gradient Methods for Reinforcement Learning with Function Approximation. NeurIPS 2000.\n",
     "\n"
-   ]
+   ],
+   "id": "cell-a5538d6a"
   }
  ],
  "metadata": {
@@ -1611,5 +1645,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
@@ -30,7 +30,8 @@
     "- Python : numpy, pandas, matplotlib\n",
     "\n",
     "### Duree estimee : 90 minutes"
-   ]
+   ],
+   "id": "cell-923e9a79"
   },
   {
    "cell_type": "code",
@@ -68,7 +69,8 @@
     "print(\"Imports charges avec succes.\")\n",
     "print(f\"NumPy version: {np.__version__}\")\n",
     "print(f\"Pandas version: {pd.__version__}\")"
-   ]
+   ],
+   "id": "cell-b665dec5"
   },
   {
    "cell_type": "markdown",
@@ -97,7 +99,8 @@
     "> et simulons un proxy obligataire via une serie synthetique correlee negativement.\n",
     "\n",
     "> *Ancre savante -- Markowitz, H. (1952), Portfolio Selection, The Journal of Finance 7(2):77-91 (DOI 10.1111/j.1540-6261.1952.tb01525.x). (Theorie moderne du portefeuille / Modern Portfolio Theory : allocation optimale des poids par minimisation de la variance pour un rendement cible donne, formalisation moyenne-variance. C'est la reference a \"l'optimisation de portefeuille classique (Markowski)\" que le RL vient completer en apprenant la politique par interaction au lieu de resoudre le probleme quadratique.)*\n"
-   ]
+   ],
+   "id": "cell-1fd2dd8b"
   },
   {
    "cell_type": "code",
@@ -286,7 +289,8 @@
     "print(f\"  Pas    : {env.n_steps} jours (~1 an de bourse)\")\n",
     "print(f\"  Actifs : SPY (equity) + TLT synthetique (obligations)\")\n",
     "print(f\"  Cout transaction : 10 bps de turnover\")"
-   ]
+   ],
+   "id": "cell-167e78bd"
   },
   {
    "cell_type": "markdown",
@@ -306,7 +310,8 @@
     "\n",
     "> **Note** : L'espace d'etat est discretise intentionnellement pour le Q-learning\n",
     "> tabulaire. En pratique, on utiliserait un espace continu avec DQN ou PPO."
-   ]
+   ],
+   "id": "cell-a945b9ee"
   },
   {
    "cell_type": "code",
@@ -373,11 +378,12 @@
     "print(f\"  Valeur finale : {env.portfolio_value:,.0f} $\")\n",
     "print(f\"  Sharpe ratio  : {sharpe_random:.3f}\")\n",
     "print(f\"  Max drawdown  : {maxdd_random:.2%}\")"
-   ]
+   ],
+   "id": "cell-b4db1b97"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-1cec015d",
    "metadata": {},
    "source": [
     "---\n",
@@ -400,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-9ddb47e1",
    "metadata": {},
    "source": [
     "# Exercice 2 : Reward avec penalite drawdown\n",
@@ -422,7 +428,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Implementer le Maximum Drawdown\n\nImplementez une fonction `compute_max_drawdown(equity_curve)` qui calcule le **drawdown maximum** a partir d'une serie de valeurs de portefeuille.\n\n**Indices** :\n- `# Indice` : Le drawdown = `(equity - cummax) / cummax` ou cummax est le maximum cumulatif\n- `# Etape 1` : Calculer le cummax de l'equity curve\n- `# Etape 2` : Calculer le drawdown a chaque pas\n- `# Etape 3` : Retourner le minimum du drawdown (la plus grosse perte)"
-   ]
+   ],
+   "id": "cell-d168c026"
   },
   {
    "cell_type": "code",
@@ -439,7 +446,8 @@
    ],
    "source": [
     "# Exercice 1 : Maximum Drawdown\n# TODO etudiant : Implementer compute_max_drawdown(equity_curve)\n# Etape 1 : Calculer cummax = equity.cummax()\n# Etape 2 : drawdown = (equity - cummax) / cummax\n# Etape 3 : Retourner drawdown.min()\ndef compute_max_drawdown(equity_curve):  # TODO etudiant : completer l'implementation\n    pass\nprint(\"Exercice a completer : Maximum Drawdown\")"
-   ]
+   ],
+   "id": "cell-78aecd33"
   },
   {
    "cell_type": "markdown",
@@ -467,7 +475,8 @@
     "- $\\epsilon$ decay de 1.0 a 0.05 sur les episodes\n",
     "\n",
     "> *Ancre savante -- Sutton, R.S. & Barto, A.G. (2018), Reinforcement Learning: An Introduction (2nd ed.), MIT Press, ISBN 978-0-262-03924-6. (Manuel de reference du RL : formalise le dilemme exploration/exploitation, la politique epsilon-greedy et son decay, et la taxonomie on-policy vs off-policy utilisee pour opposer SARSA et Q-learning dans l'exercice 3. Source canonique des concepts de reward, d'etat, d'action et de politique manipules dans tout le notebook.)*\n"
-   ]
+   ],
+   "id": "cell-dfafe4ed"
   },
   {
    "cell_type": "code",
@@ -686,11 +695,12 @@
     "        marker = \" <--\" \n",
     "        print(f\"{regime_names[regime]:>8}/{vol_names[vol]:>9} | \" +\n",
     "              \" | \".join(f\"{v:+.3f}{marker if i == best_a else '':>4}\" for i, v in enumerate(q_vals)))"
-   ]
+   ],
+   "id": "cell-d8221aa1"
   },
   {
    "cell_type": "markdown",
-   "id": "",
+   "id": "cell-85d0336b",
    "metadata": {},
    "source": [
     "---\n",
@@ -715,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "id": "",
+   "id": "cell-765460a6",
    "metadata": {},
    "source": [
     "# Exercice 3 : SARSA on-policy\n",
@@ -737,7 +747,8 @@
    "metadata": {},
    "source": [
     "### Exercice 4 : Politique epsilon-greedy avec decay\n\nAjoutez un **epsilon decay** a l'agent Q-learning tabulaire : epsilon commence a 1.0 et decroit vers 0.01 apres chaque episode.\n\n**Indices** :\n- `# Indice` : Apres chaque episode, `epsilon = max(0.01, epsilon * decay_rate)`\n- `# Indice` : Un decay_rate de 0.995 est un bon point de depart\n- `# Etape 1` : Ajouter epsilon et decay_rate comme parametres\n- `# Etape 2` : Implementer le decay apres chaque episode\n- `# Etape 3` : Observer l'amelioration de la convergence"
-   ]
+   ],
+   "id": "cell-d871d27b"
   },
   {
    "cell_type": "code",
@@ -754,7 +765,8 @@
    ],
    "source": [
     "# Exercice 2 : Epsilon-greedy avec decay\n# TODO etudiant : Ajouter un epsilon decroissant au Q-learning tabulaire\n# Etape 1 : Ajouter epsilon=1.0 et decay_rate=0.995 comme parametres\n# Etape 2 : epsilon = max(0.01, epsilon * decay_rate) apres chaque episode\n# Etape 3 : Comparer la convergence\nepsilon_decay_result = None  # TODO etudiant : remplacer par les resultats\nprint(\"Exercice a completer : Epsilon-greedy avec decay\")"
-   ]
+   ],
+   "id": "cell-bc803fa8"
   },
   {
    "cell_type": "markdown",
@@ -791,7 +803,8 @@
     "- Watkins, C.J.C.H. (1989). Learning from Delayed Rewards. PhD thesis, University of Cambridge.\n",
     "- Watkins, C.J.C.H. & Dayan, P. (1992). Q-learning. Machine Learning, 8(3-4):279-292.\n",
     "\n"
-   ]
+   ],
+   "id": "cell-3a3d1664"
   },
   {
    "cell_type": "code",
@@ -830,7 +843,8 @@
     "print(\"Exercice a completer -- implementez un agent DQN pour N actifs\")\n",
     "print(\"Inspirez-vous de QC-Py-32 (DQN Dueling) et de la classe PortfolioEnv ci-dessus.\")\n",
     "print(\"Tickers QC disponibles : SPY, QQQ, AAPL, GOOGL, IWM\")"
-   ]
+   ],
+   "id": "cell-6ccd45cd"
   }
  ],
  "metadata": {
@@ -845,5 +859,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## nbformat v4.5 normalization — QC-Py main pedagogical series (12 notebooks)

Companion to po-2024 **#6254** (which covered the QC-Py-Cloud subset, 7 notebooks). This PR covers the **QC-Py main series** (the pedagogical curriculum), the other large coherent subset of the same defect class.

### Defect (firsthand)
12 QC-Py main-series notebooks declared `nbformat: 4.2` or `4.4` but already carried cell `id` fields (a v4.5 property). `nbformat.validate` warns/fails:
- v4.4 notebooks with spurious `id`: `Additional properties are not allowed (id was unexpected)`
- cells with empty/duplicate `id`: `DuplicateCellId` / ` does not match ^[a-zA-Z0-9-_]+`

| Notebook | before | cells | ids added |
|----------|--------|-------|-----------|
| QC-Py-01-Setup | 4.2 | 26 | 3 |
| QC-Py-12-Backtesting-Analysis | 4.4 | 84 | 78 |
| QC-Py-14-Portfolio-Construction-Execution | 4.4 | 82 | 75 |
| QC-Py-16-Alternative-Data | 4.4 | 53 | 49 |
| QC-Py-19-ML-Supervised-Classification | 4.2 | 60 | 60 |
| QC-Py-20-ML-Regression-Prediction | 4.4 | 67 | 67 |
| QC-Py-21-Portfolio-Optimization-ML | 4.4 | 56 | 56 |
| QC-Py-26-LLM-Trading-Signals | 4.4 | 38 | 34 |
| QC-Py-27-Production-Deployment | 4.4 | 36 | 34 |
| QC-Py-28-Market-Regime-Detection | 4.2 | 45 | 45 |
| QC-Py-34-RL-SAC-A2C-Trading | 4.4 | 40 | 40 |
| QC-Py-35-RL-Portfolio-Construction | 4.2 | 18 | 18 |

### Fix
1. `nbformat_minor` → 5 (4.2/4.4 → 4.5)
2. Assign deterministic unique `id` (`cell-<md5(path#index)[:8]>`) to every cell missing one; dedupe collisions; append at end of cell object (matches #6254 convention, minimal diff).

### PURE metadata — no content change
Verified per-notebook: **0 source/output/metadata modification** (`src_same=True nbmeta_same=True` for all 12). Only the nbformat version field + new `id` fields are added. No C.2 re-exec needed (structural metadata, not cell content).

### Validation
| Check | Result |
|-------|--------|
| `nbformat.validate` | **PASS** all 12 |
| Cell ids unique & non-empty | all 12 |
| source/outputs preserved | all 12 |
| notebook metadata (kernelspec etc.) preserved | all 12 |
| CRLF | 0 (LF-only, binary write) |
| JSON indent | 1 (repo norm) |

### Scope / R6
CI-integrity à-côté (eliminates `nbformat.validate` WARN), 1/lane/jour cap respected (po-2025 did 0 à-côté in c.411/c.412 — both substance). Different register from c.411 (PyMC audit) / c.412 (SK audit + secrets). No collision: po-2024 #6254 = QC-Py-Cloud only; this = QC-Py main series only.

### Residual (out of scope, noted honestly)
A separate defect class exists: some QC-Py notebooks already at v4.5 carry **empty `id: ""`** (QC-Py-15/17/18/22/23/24/25/40) — different fix (fill empty ids, not version bump). Not in this PR's scope.

No catalog changes (CATALOG-STATUS markers untouched). See #6254 for the sibling Cloud-subset fix.