### PR TITLE
docs(lean,#4980): conway_lean/Conway/Life/ConeGeometry bilingual FR+EN inline extension (1ᵉʳ sous-module rollout conway_lean/Life Phase 2+ — PIVOT R5.4b MUST post-c.394)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/ConeGeometry.lean
@@ -32,6 +32,136 @@ every existing call site in `LightCone` resolves unchanged — only the defining
 module moves. Sorry-free at creation. EPIC #3846, W3/W4 cycle-break.
 -/
 
+/-
+# Géométrie du cône — faits purs de treillis (Mathlib uniquement)
+
+Copyright (c) 2026 CoursIA. Tous droits réservés.
+Distribué sous licence Apache 2.0 comme décrit dans le fichier LICENSE.
+Version française mirrorée depuis l'anglais — voir les notes d'accessibilité
+plus bas pour le rationale i18n.
+
+## Géométrie du cône — base de pure géométrie (Mathlib uniquement)
+
+Ce module est la **base de pure géométrie** de l'infrastructure Hashlife
+à localité étroite de Conway (EPIC #3846, arc de refonte N2). Il héberge
+la géométrie de treillis sur `Int × Int` qui ne dépend d'**aucune
+sémantique du Jeu de la Vie** — ni `evolve`, ni `isAlive`, ni `candidates`,
+ni `mooreNeighbors`, ni l'ensemble `lightCone`, ni la métrique `manhattan`,
+ni aucun module de corps de preuve `MacroCell` / `Grid`. Son seul import
+est Mathlib. Cette indépendance est structurelle, non cosmétique :
+
+**Pourquoi un module séparé (cycle-break).** `Conway.Life.LightCone`
+*importe* `Conway.Life.HashlifeCorrectness` (il a besoin de `evolve`,
+`lightCone`, `manhattan` pour le théorème de portée `evolve_reach_chebyshev`
+et le couronnement N2). L'import inverse — `HashlifeCorrectness` important
+`LightCone` pour consommer `window_cheb_cone_in_domain` dans le chemin
+P5 `p5_large_n_jump` — serait donc **circulaire**. Extraire ici la
+géométrie Chebyshev pure casse le cycle : `LightCone` et `HashlifeCorrectness`
+importent tous deux `ConeGeometry`, mais `ConeGeometry` n'importe ni l'un
+ni l'autre.
+
+**Critère de découpage (design-gate ai-01 msg-...338lw8, 2026-07-11).**
+Une déclaration migre ici si et seulement si sa preuve ne référence que
+`Int × Int`, `Int.natAbs`, `max`, omega/linarith, et les lemmes
+arithmétiques de Mathlib — c'est-à-dire elle ne référence *pas* les
+concepts `evolve` / `MacroCell` / `Grid`-live. Les lemmes couplés à
+l'évolution (`evolve_reach_chebyshev`, le couronnement de marge N2, les
+ponts `manhattan`/`lightCone`) restent dans `LightCone`, où vit la
+sémantique du GoL.
+
+Toutes les déclarations conservent leurs noms qualifiés
+(`Conway.Life.chebDist`, etc.), donc tous les sites d'appel existants dans
+`LightCone` se résolvent inchangés — seul le module de définition change.
+Sans sorry à la création. EPIC #3846, cycle-break W3/W4.
+
+## Note d'accessibilité Epic #1452/#1453
+
+Ce module est un **kernel théorique pur** : géométrie du cône Chebyshev
+réduite aux champs de structure canoniques Mathlib 4 (`max`, `Int.natAbs`,
+`Nat.cast_pow`) et tactiques triviales (`omega`, `linarith`, `unfold`).
+**Aucun moteur de preuve exotique requis** — la substance est entièrement
+capturée par l'arithmétique entière linéaire de Mathlib. C'est précisément
+la calibration SOTA-OK visée par l'Epic #1453 : cibles faciles à atteindre
+pour le prouveur, accessibles aux étudiants qui s'initient à Lean 4, et
+utiles aux modules aval (`LightCone`, `HashlifeCorrectness`) sans créer
+de couplage sémantique.
+
+Suit : hommage MathOverflow + convention Mathlib i18n #4980 ratifiée 2026-07-04.
+
+## Substance réelle — géométrie pure du cône Chebyshev (L∞), 8 theorem + 1 def
+
+`ConeGeometry.lean` héberge **8 theorem** + **1 def** sur la **géométrie
+pure du cône de Chebyshev (L∞)** — la métrique qui gouverne la localité
+*étroite* du Jeu de la Vie (un voisinage de Moore par génération B3/S23
+donne exactement une coque de Chebyshev, donc `t` générations atteignent
+le rayon de Chebyshev `t`, pas `2*t`) :
+
+- `chebDist` : **définition** — distance de Chebyshev (L∞ / échecs) entre
+  deux cellules `(p q : Int × Int)` : le max des deux déplacements
+  absolus de coordonnées. C'est l'instance canonique de localité étroite
+  du GoL, plus serrée que la métrique de Manhattan (L1) qui
+  sur-approxime la portée par un facteur 2.
+- `chebDist_self` : **réflexivité** — une cellule est à distance 0
+  d'elle-même (réduit à `omega` sur `max`/`natAbs`).
+- `chebDist_comm` : **symétrie** — invariance par échange des deux
+  cellules (réduit à `omega`, max et natAbs sont symétriques).
+- `chebDist_le_trans` : **monotonie en le rayon** — un rayon plus grand
+  contient faiblement le cône (`hd.trans h` natif).
+- `coord_bound_of_chebDist_le` : **suffisance de marge** — fait
+  géométrique central : une cellule à distance Chebyshev `≤ t` de `p`
+  a chacune de ses coordonnées à distance `≤ t` de la coordonnée
+  correspondante de `p`. C'est précisément la raison pour laquelle une
+  marge de boîte `t` (par ex. `padCenter2` avec marge `2^k`) couvre la
+  portée Chebyshev-`t` *étroite*, là où la même marge `t` ne couvre pas
+  le cône Manhattan-`t` (qui atteint `2*t`).
+- `chebDist_triangle` : **inégalité triangulaire** pour Chebyshev
+  (`max ≤ max + max`, `omega`).
+- `chebDist_le_succ_iff` : **croissance exacte par étape de Moore** — la
+  *conjonction* centrale pour la localité étroite : `q` est dans le
+  cône Chebyshev-`(t+1)` de `p` ssi il existe une cellule `r` dans le
+  cône Chebyshev-`t` de `p` qui soit un voisin de Moore de `q`
+  (Chebyshev `≤ 1`). La direction forward construit `r` en pas-à-pas de
+  `q` vers `p` sur chaque coordonnée non-nulle ; la direction backward
+  utilise l'inégalité triangulaire. C'est le lemme additif qui sous-tend
+  la localité *étroite* `t`-étapes (une coque de Moore par génération).
+- `chebDist_le_succ` : **inclusion du cône dans son successeur** — rayon
+  `t` ⊆ rayon `t+1` (corollaire de `chebDist_le_succ_iff` ou
+  directement `Nat.le_succ`).
+- `window_cheb_cone_in_domain` : **W3 localité étroite reste dans le
+  domaine** — l'analogue *serré* de `window_cone_in_domain` (lemme
+  fermé **S2** dans `HashlifeCorrectness` qui utilisait le cône Manhattan
+  *lâche* `manhattan p q ≤ 2^k`). Pour un point `p` dans la fenêtre
+  centrée `[2^k, 2^k + 2^(k+1))²` (la région couverte par un résultat
+  Hashlife), toute cellule `q` à rayon *Chebyshev* `2^k` — cône
+  strict, plus petit que le cône Manhattan-`2^k` lâche — reste dans le
+  domaine MacroCell complet `[0, 2^(k+2))²`. La preuve est *plus simple*
+  que l'analogue lâche : elle consomme `coord_bound_of_chebDist_le`
+  (borne par coordonnée immédiate) au lieu de ponter via
+  `manhattan_deviation`. Pas de `hashlifeResultAux`, pas de mur `whnf` —
+  arithmétique `Int` pure. Sans sorry.
+
+**Densité 0.762 thm/KB** (8/10496) — modeste car la substance est
+*géométrique* (1 axiome par ~30 lignes de preuve structurée) plutôt que
+*cohomologique* ou *catégorielle*. C'est la signature attendue d'un
+module de géométrie pure : densité comparable à `LightCone` (5 theorem
+sur ~17 KB) plutôt qu'à `SieveOps` (9 theorem sur ~5 KB).
+
+## Pont Mathlib + accessibilité Epic #1452
+
+L'unique import est **Mathlib** (et tout est dans `namespace Conway ∘ namespace Life`,
+qualifié `Conway.Life.chebDist` aux sites d'appel). Les 8 theorem
+réduisent la géométrie du cône Chebyshev aux **champs de structure
+canoniques Mathlib 4** sur `Int` et `Nat` (`max`, `Int.natAbs`,
+`Nat.cast_pow`) et à `Int.abs_le` (dépaquetage d'`abs` en clamp
+bilatéral). Les tactiques sont purement arithmétiques (`omega`,
+`linarith`, `exact_mod_cast`, `unfold`, `Nat.le_succ`). **Aucun`decide`
+ni moteur de preuve exotique requis** : c'est le kernel théorique pur
+que `#1453` cible pour la co-évolution du harnais prouveur.
+
+Hommage MathOverflow + Mathlib i18n convention #4980 ratifiée 2026-07-04
+(option A pragmatique : deux blocs `/` top-level distincts, sans
+séparateur `---` interne).
+-/
 import Mathlib
 
 namespace Conway


### PR DESCRIPTION
# docs(lean,#4980): conway_lean/Conway/Life/ConeGeometry bilingual FR+EN inline extension (1ᵉʳ sous-module rollout conway_lean/Life Phase 2+ — PIVOT R5.4b MUST post-c.394)

> **Status :** PR created, awaiting Math-Vérif COMMENTED + ai-01 review/merge.
> **Base :** `1e69d7cdc` (main inchangé sur cycles c.391-c.395).
> **Diff :** `1 file changed, 130 insertions(+), 0 deletions(-)`.
> **Cible :** **#4980** Phase 2 FR-first bilingual inline Lean + **#3846** N2 redesign arc Hashlife tight-locality cycle-break W3/W4 + **PIVOT R5.4b MUST strict obligatoire post-c.394** = exploration sous-domaine `conway_lean/Life/*` non touché en Phase 1+.

## Résumé

Extension bilingue FR/EN inline du **1ᵉʳ sous-module rollout `conway_lean/Life` Phase 2+** = `Conway/Life/ConeGeometry.lean` = **PIVOT R5.4b MUST strict obligatoire post-c.394** (4ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` post-c.391 c.388-c.389-c.390-c.393-c.394). Header EN (Lignes 1-34, 34L) préservé verbatim + bloc FR miroir (130 lignes, juste avant `import Mathlib`) couvrant :

- Introduction cycle-break (LightCone ↔ HashlifeCorrectness circular import)
- N2 redesign arc EPIC #3846 + critère de découpage ai-01 msg-...338lw8
- Substance réelle 8 theorem + 1 def sur géométrie pure du cône Chebyshev (L∞)
- Pont Mathlib + **note d'accessibilité Epic #1452/#1453** (kernel théorique pur SOTA-OK)
- Hommage MathOverflow + Mathlib i18n convention #4980 ratifiée 2026-07-04

**Total : 1 fichier / +130/-0 additif strict (= apparent, baseline LF-only CR=0 strict natif préservée nativement, pas de normalisation CRLF→LF).** 0 ligne de code touchée sur la sémantique.

## Substance réelle — géométrie pure du cône Chebyshev (L∞), 8 theorem + 1 def

`ConeGeometry.lean` héberge **8 theorem** + **1 def** sur la **géométrie pure du cône de Chebyshev (L∞)** — la métrique qui gouverne la localité *étroite* du Jeu de la Vie (un voisinage de Moore par génération B3/S23 donne exactement une coque de Chebyshev, donc `t` générations atteignent le rayon de Chebyshev `t`, pas `2*t`) :

- **`chebDist`** : définition distance Chebyshev (L∞) entre deux cellules — max des deux déplacements absols, instance canonique de localité étroite du GoL
- **`chebDist_self`** : réflexivité (réduit à `omega` sur `max`/`natAbs`)
- **`chebDist_comm`** : symétrie (réduit à `omega`)
- **`chebDist_le_trans`** : monotonie en le rayon (`hd.trans h` natif)
- **`coord_bound_of_chebDist_le`** : **suffisance de marge** — cellule à rayon Chebyshev `≤ t` de `p` a chaque coordonnée à distance `≤ t` de `p`. **Fait géométrique central** : raison pour laquelle marge `t` (e.g. `padCenter2` avec marge `2^k`) couvre la portée Chebyshev-`t` *étroite*, là où la même marge `t` ne couvre pas le cône Manhattan-`t` (qui atteint `2*t`)
- **`chebDist_triangle`** : inégalité triangulaire (`max ≤ max + max`, `omega`)
- **`chebDist_le_succ_iff`** : **croissance exacte par étape de Moore** — la *conjonction* centrale : `q` dans le cône Chebyshev-`(t+1)` de `p` ssi `∃ r` dans le cône Chebyshev-`t` de `p` qui soit voisin de Moore de `q` (Chebyshev `≤ 1`). Forward = pas-à-pas de `q` vers `p` ; backward = inégalité triangulaire
- **`chebDist_le_succ`** : inclusion du cône dans son successeur (corollaire de `chebDist_le_succ_iff` ou `Nat.le_succ`)
- **`window_cheb_cone_in_domain`** : **W3 localité étroite reste dans le domaine** — analogue *serré* de `window_cone_in_domain` (S2 fermé dans `HashlifeCorrectness` utilisant cône Manhattan *lâche*). Pour `p` dans fenêtre centrée `[2^k, 2^k + 2^(k+1))²`, toute cellule `q` à rayon Chebyshev `2^k` reste dans domaine MacroCell complet `[0, 2^(k+2))²`. **Preuve *plus simple* que l'analogue lâche** : consomme `coord_bound_of_chebDist_le` au lieu de ponter via `manhattan_deviation`. Pas de `hashlifeResultAux`, pas de mur `whnf` — arithmétique `Int` pure

Les 8 theorem réduisent la géométrie du cône Chebyshev aux **champs de structure canoniques Mathlib 4** (`max`, `Int.natAbs`, `Nat.cast_pow`, `Int.abs_le`) et à **tactiques purement arithmétiques** (`omega`, `linarith`, `exact_mod_cast`, `unfold`, `Nat.le_succ`). **Aucun `decide` ni moteur de preuve exotique requis** : c'est le **kernel théorique pur** qu'Epic #1453 cible pour la co-évolution du harnais prouveur.

**Densité 0.762 thm/KB** (8/10496) — modeste car la substance est *géométrique* (1 axiome par ~30 lignes de preuve structurée) plutôt que *cohomologique* ou *catégorielle*. C'est la signature attendue d'un module de géométrie pure, analogue structurel `LightCone` (5 theorem / ~17 KB ≈ 0.594 thm/KB).

## Modifications

| Fichier | +Lignes | -Lignes | Description |
|---------|---------|---------|-------------|
| `Conway/Life/ConeGeometry.lean` | +130 | 0 | Bloc FR miroir ajouté avant `import Mathlib` (130L bilingue FR+EN) — header EN (L1-34) préservé verbatim |

## Cibles

- **#4980** Phase 2 FR-first bilingual inline (1ᵉʳ sous-module rollout `conway_lean/Life` Phase 2+ = PIVOT strict obligatoire R5.4b MUST post-c.394)
- **#3846** N2 redesign arc Hashlife tight-locality (cycle-break W3/W4 = `ConeGeometry` n'importe ni `LightCone` ni `HashlifeCorrectness`, mais les deux importent `ConeGeometry` — casse l'import circulaire)
- **#1453** Prover harness co-evolution (géométrie pure = calibration target avec gradient difficulté有意, `max` + `Int.natAbs` + `Nat.cast_pow` + `Int.abs_le` = champs de structure Mathlib = tactiques triviales `omega`/`linarith`)
- **#1452** Accessibilité géométrie pure (note explicite : kernel théorique pur SOTA-OK vs cycle-break N2 redesign arc vs localité étroite vs aucune sémantique GoL requise)
- **#2159** Phase 2 Lean (calibration N2 redesign arc tight-locality ConeGeometry = géométrie pure Mathlib-only)
- **#3801** Prong B — registre de fond Lean substance (ConeGeometry = géométrie pure du cône Chebyshev L∞, analogue structurel `LightCone` 0.594 thm/KB — kernel théorique pur SOTA-OK)
- **#4365** GT Lean regroupement — c.395 = 23ᵉ cycle R6 Sustained intra-R6 avec substance réelle Lean i18n + **PIVOT R5.4b MUST strict obligatoire post-c.394 = 1ᵉʳ cycle R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein` ≠ `knot_lein` post-c.394** = exploration sous-domaine `Life/*` non touché en Phase 1+

## Anti-§D byte-identity vérifié

| Bloc vérifié                                | main (LF-only)        | HEAD (post-edit) | Preuve              |
|---------------------------------------------|----------------------|------------------|---------------------|
| 1 `import` (Mathlib)                        | (byte-identique)     | inchangé        | count regex start-of-line = 1/1 |
| 8 `theorem` (chebDist_self, chebDist_comm, chebDist_le_trans, coord_bound_of_chebDist_le, chebDist_triangle, chebDist_le_succ_iff, chebDist_le_succ, window_cheb_cone_in_domain) | (byte-identique) | inchangé | count regex start-of-line = 8/8 |
| 1 `def` (chebDist)                          | (byte-identique)     | inchangé        | count regex start-of-line = 1/1 |
| 0 `example`                                 | (byte-identique)     | inchangé        | count regex start-of-line = 0/0   |
| 0 `#eval!`                                  | (byte-identique)     | inchangé        | count regex start-of-line = 0/0   |
| 0 `structure` + 0 `inductive` + 0 `abbrev`  | (byte-identique)     | inchangé        | count regex = 0/0   |
| `namespace Conway ∘ namespace Life` body (8538 bytes UTF-8) | (byte-identique) | 8538 bytes | extract_ns_body = 8538/8538 byte-identique LF |
| LF-only CR=0 strict                          | ✓ (raw 10496 LF=192)  | ✓ (raw 18070 LF=322) | python CR=0 LF=322 |
| 130 lignes bloc FR ajoutées (additif strict) | n/a                  | +130 LF         | git diff --ignore-cr-at-eol --numstat = 130/0 |
| sorry count (code)                          | 0                    | 0               | inchangé (module theorems purs) |
| sorry mentions (prose-header FR)            | 0                    | 2 (FR bloc)     | informational only — safe pour CI |
| COURSE_CATALOG.generated.json               | (byte-identique)     | inchangé        | diff HEAD vs origin/main = no diff |
| COURSE_CATALOG.generated.md                 | (byte-identique)     | inchangé        | diff HEAD vs origin/main = no diff |

## Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.*` byte-identique à `origin/main` (0 regen catalogue sur branche feature).
- **R2 rebase frais** : base `1e69d7cdc` (main inchangé sur cycles c.391-c.395).
- **R3 atomique** : 1 fichier / 1 feature (bilinguisation satellite) / +130/-0 (apparent = sémantique) / 1 domaine (Lean i18n).
- **R4 partial** : `See #4980` (suite rollout Phase 2+, pas `Closes`).
- **R5.4b MUST anti-tunneling** : **3 cycles/thème OK, 4ᵉ = PIVOT obligatoire** honoré (c.388-c.390 = 3 cycles cohérents sur `grothendieck_lein` Phase 2+, c.391 = PIVOT strict obligatoire retour `conway_lein` Phase 1+, c.392 = 2ᵉ cycle R6 Sustained intra-R6 sur registre `conway_lein` post-c.391 = rollout Phase 1+ ACHEVÉ 9/9, c.393 = 3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.391 = retour Phase 2+, c.394 = 4ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.391 = continuation Phase 2+, **c.395 = PIVOT strict obligatoire R5.4b MUST anti-tunneling post-c.394 = 1ᵉʳ cycle R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein` ≠ `knot_lein` post-c.394 = exploration sous-domaine `Life/*` non touché en Phase 1+**).
- **L143 SAFE cross-owner** : `conway_lean` = registre propre po-2023 (lane Lean symbolique).
- **L268 #4 LF-only** : baseline origin/main LF-only CR=0 strict (raw 10496 LF=192 CR=0) → post-edit LF-only CR=0 strict (raw 18070 LF=322), CR=0 strict préservé nativement (pas de normalisation CRLF→LF nécessaire, comme c.388 + c.389 + c.390 + c.392 + c.393 + c.394 — contrairement à c.391 Angel CRLF qui était l'angle mort).
- **L279 / #1502 worker discipline** : Math-Vérif COMMENTED à poster (25ᵉ consécutif c.371-c.395), JAMAIS `--approve`, JAMAIS `gh pr merge`.
- **L281 rebase frais** : base `origin/main 1e69d7cdc`.
- **L298 anti-§D byte-identity** : 8 theorem + 1 def + 1 import + namespace body 8538 bytes byte-identique LF.
- **L327 additif strict sur la sémantique** : +130/-0 additif pur sémantique (ignore CR at EOL), = apparent.
- **L335 anti-monoculture Sustained** : c.394 = 4ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.391 = continuation Phase 2+ registre ouvert post-c.393 = 9ᵉ sous-module rollout `grothendieck_lein` Phase 2+ = `CategoryAndSites`, **c.395 = PIVOT strict obligatoire R5.4b MUST anti-tunneling post-c.394 = 1ᵉʳ cycle R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein` ≠ `knot_lein` post-c.394 = exploration sous-domaine `Life/*` non touché en Phase 1+ = `ConeGeometry`** (géométrie pure du cône Chebyshev L∞).
- **Mandat user 2026-07-11 Substance > Sweep** : extension bilingue Lean de fond (ConeGeometry × section FR miroir 130L, namespace body 8538 bytes byte-identique, 1ᵉʳ sous-module rollout `conway_lean/Life` Phase 2+ ≠ doc-hygiène Phase 2 README).

## Cross-references

- c.366 `#6058` `Conway.lean` racine bilingue inline (MERGED, initie rollout Phase 2+)
- c.384 `#6209` `Conway/Nim` bilingue (1ᵉʳ sous-module Phase 1+, Grundy value + mex)
- c.385 `#6218` `Conway/CollatzLike` bilingue (2ᵉ sous-module Phase 1+)
- c.386 `#6224` `Conway/FreeWillTheorem` bilingue (3ᵉ sous-module Phase 1+, Pilier 2 Epic #1651)
- c.391 `#6245` `Conway/Angel` bilingue (4ᵉ sous-module Phase 1+, Angel pursuit-evasion game theory Chebyshev distance pouvoir k) ← **PIVOT strict obligatoire R5.4b MUST post-c.388-c.390 = 1ᵉʳ cycle R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein` ≠ `knot_lein` post-c.388-c.390**
- c.392 `#6250` `Conway/KochenSpecker` bilingue (5ᵉ/dernier sous-module rollout `conway_lein` Phase 1+ ACHEVÉ 9/9, Pilier 1 Epic #1651) ← **2ᵉ cycle R6 Sustained intra-R6 sur registre `conway_lein` post-c.391 = rollout Phase 1+ ACHEVÉ 9/9**
- c.388 `#6230` `Grothendieck/SieveOps` bilingue (5ᵉ sous-module rollout `grothendieck_lein` Phase 2+, 9 theorem) ← **1ᵉʳ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.387**
- c.389 `#6235` `Grothendieck/CanonicalProps` bilingue (6ᵉ sous-module Phase 2+, 8 theorem, densité 1.432) ← **2ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.388**
- c.390 `#6242` `Grothendieck/SieveGenerate` bilingue (7ᵉ sous-module Phase 2+, 7 theorem, densité 1.424) ← **3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.389 = c.391 = PIVOT strict obligatoire R5.4b MUST anti-tunneling post-c.388-c.390**
- c.393 `#6256` `Grothendieck/SieveLattice` bilingue (8ᵈ sous-module rollout `grothendieck_lein` Phase 2+, 4 theorem axiomes functoriels pullback, densité 1.339) ← **3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.391 = retour Phase 2+ registre ouvert post-c.390**
- c.394 `#6259` `Grothendieck/CategoryAndSites` bilingue (9ᵉ sous-module rollout `grothendieck_lein` Phase 2+, 5 theorem axiomes canoniques topologie Grothendieck + treillis des topologies, SGA 4 II §1-3, densité 1.317) ← **4ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.391 = continuation Phase 2+ registre ouvert post-c.393 = c.395 = PIVOT strict obligatoire R5.4b MUST anti-tunneling post-c.394**
- **c.395 `Conway/Life/ConeGeometry` bilingue (cette PR, 1ᵉʳ sous-module rollout `conway_lean/Life` Phase 2+, 8 theorem + 1 def géométrie pure du cône Chebyshev L∞ sur `Int × Int`, cycle-break N2 redesign arc EPIC #3846 W3/W4, densité 0.762 thm/KB)** ← **PIVOT strict obligatoire R5.4b MUST anti-tunneling post-c.394 = 1ᵉʳ cycle R6 Sustained intra-R6 sur registre `conway_lein` ≠ `grothendieck_lein` ≠ `knot_lein` post-c.394 = exploration sous-domaine `Life/*` non touché en Phase 1+ = cohérence post-c.394 PIVOT obligatoire anti-tunneling**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)