### PR TITLE
fix(sl2): raw-string docstring to clear SyntaxWarning invalid-escape

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -45,10 +45,10 @@
    "id": "a0468061",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.129319Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.129057Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.146231Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.144074Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.252020Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.251021Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.260675Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.260675Z"
     },
     "papermill": {
      "duration": 0.030442,
@@ -145,10 +145,10 @@
    "id": "5569731d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.189551Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.189371Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.197637Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.196588Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.262733Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.262733Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.267983Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.267983Z"
     },
     "papermill": {
      "duration": 0.018361,
@@ -319,10 +319,10 @@
    "id": "945eff3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.233362Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.233199Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.241379Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.240737Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.269988Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.268989Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.276471Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.276471Z"
     },
     "papermill": {
      "duration": 0.012701,
@@ -501,10 +501,10 @@
    "id": "58666a2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.266911Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.266711Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.272748Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.272204Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.277475Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.277475Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.282633Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.282633Z"
     },
     "papermill": {
      "duration": 0.01059,
@@ -611,10 +611,10 @@
    "id": "2804a17a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.301801Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.301055Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.312822Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.311411Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.283883Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.283883Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.288888Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.288888Z"
     },
     "papermill": {
      "duration": 0.028207,
@@ -775,10 +775,10 @@
    "id": "1b6b6247",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.352997Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.352772Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.364440Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.362367Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.290146Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.290146Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.295152Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.295152Z"
     },
     "papermill": {
      "duration": 0.018043,
@@ -947,10 +947,10 @@
    "id": "750b1f6e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.417624Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.417100Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.436965Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.436410Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.297165Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.297165Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.308009Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.308009Z"
     },
     "papermill": {
      "duration": 0.028562,
@@ -988,16 +988,6 @@
       "  1. ArithmeticUnknown(z) => Simplify(1*(0+z), (z))\n",
       "  2. ArithmeticUnknown(v) => Simplify(1*v, v)\n",
       "  3. ArithmeticUnknown(w) => Simplify(0+w, w)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<>:141: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "<>:141: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "~\\AppData\\Local\\Temp\\ipykernel_<pid>\\2657864012.py:141: SyntaxWarning: invalid escape sequence '\\*'\n",
-      "  Le pattern \"1*(0+z)\" devient la regex r\"1\\*\\(0\\+(\\w+)\\)\" : chaque\n"
      ]
     }
    ],
@@ -1140,7 +1130,7 @@
     "        return rule\n",
     "    \n",
     "    def _match_learned(self, rule: LearnedRule, expr: str) -> str | None:\n",
-    "        \"\"\"Matche un pattern appris contre l'expression (unification simple).\n",
+    "        r\"\"\"Matche un pattern appris contre l'expression (unification simple).\n",
     "\n",
     "        Le pattern \"1*(0+z)\" devient la regex r\"1\\*\\(0\\+(\\w+)\\)\" : chaque\n",
     "        variable declaree dans la precondition capture un sous-terme, et le\n",
@@ -1272,10 +1262,10 @@
    "id": "1bf94123",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.463783Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.463592Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.470546Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.469343Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.309403Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.309403Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.314530Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.314530Z"
     },
     "papermill": {
      "duration": 0.012726,
@@ -1446,10 +1436,10 @@
    "id": "9649140c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.499292Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.499123Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.506367Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.505651Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.316535Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.315535Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.321528Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.321528Z"
     },
     "papermill": {
      "duration": 0.013154,
@@ -1670,10 +1660,10 @@
    "id": "d8492780",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.588866Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.588273Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.611134Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.609553Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.323533Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.322533Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.328547Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.328547Z"
     },
     "papermill": {
      "duration": 0.038266,
@@ -1836,10 +1826,10 @@
    "id": "sl2-ex1-variation-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.633412Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.633138Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.638197Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.637021Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.329561Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.329561Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.332606Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.332606Z"
     },
     "papermill": {
      "duration": 0.013039,
@@ -1900,10 +1890,10 @@
    "id": "5835c6f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.662569Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.662400Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.671113Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.670312Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.333874Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.333874Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.339925Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.339925Z"
     },
     "papermill": {
      "duration": 0.013759,
@@ -2089,10 +2079,10 @@
    "id": "d4d1535a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.697473Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.697132Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.725994Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.725037Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.340930Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.340930Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.359715Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.359715Z"
     },
     "papermill": {
      "duration": 0.035562,
@@ -2108,14 +2098,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ebl_without : 0 regle apprise (base KB seule)"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "ebl_without : 0 regle apprise (base KB seule)\n",
       "ebl_with    : 3 regles apprises\n",
       "\n",
       "Corpus : 100 expressions (34 profondes, 33 shallow, 33 nomatch)\n",
@@ -2134,8 +2117,8 @@
       "  nomatch    |      0 |      0 |    +0\n",
       "\n",
       "=== Metrique secondaire : temps wall-clock (mediane sur 20 runs) ===\n",
-      "  Sans EBL :   218.5 us\n",
-      "  Avec EBL :   492.0 us\n",
+      "  Sans EBL :   147.8 us\n",
+      "  Avec EBL :   336.3 us\n",
       "  Ratio (sans/avec) : 0.44x\n",
       "  NB : bruite par la charge CPU ; le classement wall-clock peut DIFFERER\n",
       "       du classement en etapes -- voir l'interpretation ci-dessous.\n",
@@ -2327,10 +2310,10 @@
    "id": "da5d87a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.761750Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.761560Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.765365Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.764563Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.361780Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.361780Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.364802Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.364802Z"
     },
     "papermill": {
      "duration": 0.012391,
@@ -2404,10 +2387,10 @@
    "id": "d254f41d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T09:36:25.797837Z",
-     "iopub.status.busy": "2026-06-18T09:36:25.797595Z",
-     "iopub.status.idle": "2026-06-18T09:36:25.803820Z",
-     "shell.execute_reply": "2026-06-18T09:36:25.802290Z"
+     "iopub.execute_input": "2026-07-12T04:00:33.365993Z",
+     "iopub.status.busy": "2026-07-12T04:00:33.365993Z",
+     "iopub.status.idle": "2026-07-12T04:00:33.369115Z",
+     "shell.execute_reply": "2026-07-12T04:00:33.369115Z"
     },
     "papermill": {
      "duration": 0.016553,
@@ -2548,7 +2531,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Defect (firsthand)

`SL-2-KnowledgeBasedLearning.ipynb` cell17 `_match_learned` had a regex literal embedded inside a **non-raw** triple-quoted docstring. Python 3.12+ treats the backslashes as invalid escape sequences and commits a `SyntaxWarning` to stderr on every execution:

```
SyntaxWarning: invalid escape sequence '\*'
```

This will escalate to `SyntaxError` in a future Python version. The warning was committed in the notebook's cell17 stderr output.

## Fix

Prefix the docstring opener with `r` so the embedded regex is raw text:

```diff
-        """Matche un pattern appris contre l'expression (unification simple).
+        r"""Matche un pattern appris contre l'expression (unification simple).
```

Same validated defect class as:
- **#6260** (Search-9 raw-string `\leq` fix)
- **#6258** (GT-8c matplotlib cause-fix)

i.e. committed stderr warning pollution in a Python-kernel notebook, fixed **at the source** and re-executed — not hand-scrubbed (per secrets-hygiene rule 6 / Stop & Repair).

## Verification (H.1, firsthand)

- `jupyter nbconvert --to notebook --execute --inplace --kernel python3` → **SUCCESS** (113310 bytes)
- **0 error outputs** across the whole notebook
- **0 stderr streams remaining** (the SyntaxWarning block is gone)
- cell17 stderr: **NONE (clean)**; execution_count = 7
- zmq/Proactor kernel-launcher warning did **NOT** leak into committed outputs
- Deterministic EBL outputs preserved:
  - `ArithmeticUnknown(z) => Simplify(1*(0+z), (z))`
  - EBL speedup metric rendered
  - `nationality -> language : True` determination
  - `d/dx(sin(x))` chain rule
- **Source diff surgical**: exactly 1 cell (cell17), 1 line (+`r` prefix); 44/44 cells preserved, 0 source content destroyed (anti-regression §D clean)
- LF line endings preserved (matches `origin/main`); CRLF introduced by nbconvert normalized before commit

## Scope

Notebook hygiene only. `See #1453` not applicable (not prover BUILD-FAIL).

