### PR TITLE
fix(search): Search-10 invalid escape sequence SyntaxWarning + ipykernel path leak

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
@@ -742,10 +742,10 @@
    "id": "e21ac97c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:18.792406Z",
-     "iopub.status.busy": "2026-06-05T12:55:18.792125Z",
-     "iopub.status.idle": "2026-06-05T12:55:18.798326Z",
-     "shell.execute_reply": "2026-06-05T12:55:18.797206Z"
+     "iopub.execute_input": "2026-07-12T04:09:49.938560Z",
+     "iopub.status.busy": "2026-07-12T04:09:49.938402Z",
+     "iopub.status.idle": "2026-07-12T04:09:49.942252Z",
+     "shell.execute_reply": "2026-07-12T04:09:49.941678Z"
     },
     "papermill": {
      "duration": 0.018018,
@@ -782,16 +782,6 @@
       "Note : automata-lib ne fournit pas d'operation d'union directe,\n",
       "      mais on peut construire manuellement l'automate resultant.\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<>:8: SyntaxWarning: invalid escape sequence '\\ '\n",
-      "<>:8: SyntaxWarning: invalid escape sequence '\\ '\n",
-      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\2162432086.py:8: SyntaxWarning: invalid escape sequence '\\ '\n",
-      "  print(\"3. COMPLEMENT : L^c = Σ* \\ L\")\n"
-     ]
     }
    ],
    "source": [
@@ -802,7 +792,7 @@
     "print(\"2. INTERSECTION : L1 ∩ L2\")\n",
     "print(\"   - Reconnaît les mots acceptes par L1 ET L2\")\n",
     "print()\n",
-    "print(\"3. COMPLEMENT : L^c = Σ* \\ L\")\n",
+    "print(\"3. COMPLEMENT : L^c = Σ* \\\\ L\")\n",
     "print(\"   - Reconnaît les mots NON acceptes par L\")\n",
     "print()\n",
     "print(\"4. PRODUIT (Concatenation) : L1 · L2\")\n",


### PR DESCRIPTION
## What

Fix a **Python SyntaxWarning + committed machine-path leak** in [`Search-10-SymbolicAutomata.ipynb`](MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) cell 20.

Cell 20 line 8 used a **mathematical set-difference notation** as a plain string:
```python
print("3. COMPLEMENT : L^c = Σ* \ L")   # "\ L" = invalid escape sequence
```
Python 3.12+ emits `SyntaxWarning: invalid escape sequence '\ '` at parse time, and the warning text embeds the kernel temp path: `~\AppData\Local\Temp\claude\ipykernel_<pid>\2162432086.py:8`. That **stderr was committed in the cell's outputs** — a machine-path leak (related to security epic #16), same bug-class as the `SyntaxWarning: invalid escape sequence '\leq'` fixed in Search-9 (#6260) and the matplotlib `UserWarning` path leaks (#6258, #6261).

## Fix (cause-fix, Stop & Repair — secrets-hygiene rule 6)

`"\ L"` → `"\\ L"` (escape the backslash). `\\` is a valid escape = one literal backslash, so the rendered output `Σ* \ L` is **byte-identical** to before — the set-difference notation is preserved exactly. The SyntaxWarning no longer fires, so the stderr (with its leaked path) naturally disappears on re-execution. **Not a hand-scrub of the output** — the cause is fixed and the cell re-executed; the warning+path vanish as a consequence.

## Verification (firsthand, rule F — real tool)

- **Re-executed** via `jupyter nbconvert --execute` with the **python3** kernel (Python 3.13, deps `automata-lib` + `z3 4.16.0` all present locally — rule F satisfied, no workaround).
- **Stop & Repair confirmed**: the stderr stream (carrying the SyntaxWarning + `ipykernel_<pid>` path) is **gone**; the stdout (the COMPLEMENT line) is **preserved**.
- **C.3 surgical**: only cell 20 changed (source 1 line + outputs). 6 other cells whose outputs regenerated during re-exec were **restored to main** (their source is unchanged → no re-exec staging). Diff: `5 ins / 15 del` = source fix + removed stderr block + cell-20 exec-timestamp metadata.
- `nbformat.validate`: **PASS** (91 cells).
- H.3 `notebook_tools validate`: **0 errors**, 1 warning (pre-existing LaTeX `$` false-positive in cells 3/28, also present on `main` — unrelated, not introduced here).
- **0 `SyntaxWarning`** in committed outputs (was 1), **0 `ipykernel_` path** (was 1).
- 0 `execution_count: null` (24/24 code cells executed), 0 errors, 0 C.1 violations.
- **LF-only** (CR=0), UTF-8 no BOM. No catalogue churn (catalogue byte-identical to main).

## Scope

- Single-subject (1 notebook, 1 cause-fix cell). Search family, my partition.
- Same bug-class as #6258 / #6260 / #6261 (committed warning/path-leak elimination via cause-fix + re-exec) but **distinct notebook** (no collision).
- Visual QA: N/A — this notebook has **0 image outputs** (symbolic-automata computation only), so the fix is fully deterministic and verifiable text-only.

See #16 (security: machine-path leaks in committed outputs). See #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
