### PR TITLE
fix(semanticweb): SW-13 HermiT classpath leak — owlready2 debug=0 (latent-leak fix)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -1079,17 +1079,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Démarrage du raisonnement HermiT...\n",
-      "⚠ HermiT n'est pas disponible (Java manquant?): [WinError 2] Le fichier spécifié est introuvable\n",
-      "  HermiT nécessite Java Runtime Environment (JRE)\n"
+      "Démarrage du raisonnement HermiT...\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpb75_2nmr\n"
+      "✓ Temps HermiT (via OWLReady2): 1.1480 secondes\n",
+      "\n",
+      "--- Types inférés pour Margherita ---\n",
+      "  Classes directes: [pizza.VegetarianPizza]\n",
+      "\n",
+      "✓ Total triples (HermiT): 43\n"
      ]
     }
    ],
@@ -1103,7 +1105,11 @@
     "        # sync_reasoner() utilise HermiT par défaut\n",
     "        # Nécessite Java d'installé\n",
     "        with onto:\n",
-    "            sync_reasoner()\n",
+    "            # debug=0 supprime l'echo par owlready2 de la commande Java\n",
+    "            # complete (classpath incluant le chemin d'install machine\n",
+    "            # C:\\\\Users\\\\...\\\\site-packages\\\\owlready2\\\\hermit ; ...).\n",
+    "            # secrets-hygiene regle 6 : fix cause-level, pas de scrub.\n",
+    "            sync_reasoner(debug=0)\n",
     "        \n",
     "        time_hermit = time.time() - start\n",
     "        \n",
@@ -2376,8 +2382,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "HermiT (DL) indisponible dans cet environnement (FileNotFoundError).\n",
-      "  -> Le raisonneur Java ne s'execute pas ici ; partie DL non evaluee.\n",
+      "HermiT (DL) : INCOHERENCE detectee -> 'tomate' ne peut etre a la fois Vegetal et Animal (classes disjointes). Resultat attendu.\n",
       "\n",
       "owlrl (RL) : materialisation effectuee (5 -> 126 triples), AUCUNE exception levee.\n",
       "Le profil RL materialise les triples mais ne rejette pas l'incoherence comme le ferait un raisonneur DL complet.\n",
@@ -2386,14 +2391,6 @@
       "  - DL (HermiT)  : valide la coherence logique (detecte les contradictions).\n",
       "  - RL (owlrl)   : materialise rapidement la cloture, mais tolere l'incoherence.\n",
       "  => DL pour la validation logique, RL pour la materialisation rapide.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpj73iqoft\n"
      ]
     }
    ],
@@ -2424,7 +2421,9 @@
     "        tomate.is_a.append(Animal)\n",
     "\n",
     "    try:\n",
-    "        sync_reasoner_hermit(world)\n",
+    "        # debug=0 : empeche owlready2 d'echoer la commande Java (classpath\n",
+    "        # = chemin d'install machine C:\\\\Users\\\\...\\\\owlready2\\\\hermit).\n",
+    "        sync_reasoner_hermit(world, debug=0)\n",
     "        print(\"HermiT (DL) : aucune incoherence detectee (inattendu).\")\n",
     "    except OwlReadyInconsistentOntologyError:\n",
     "        print(\"HermiT (DL) : INCOHERENCE detectee -> 'tomate' ne peut etre \"\n",
@@ -2620,13 +2619,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "HermiT (DL) indisponible dans cet environnement (FileNotFoundError).\n",
+      "HermiT (DL) : pizza1 classifiee comme MeatPizza ? True\n",
       "owlrl (RL)  : pizza1 classifiee comme MeatPizza ? True\n",
       "\n",
       "| Profil       | Classification automatique pizza1 -> MeatPizza ? |\n",
       "|--------------|---------------------------------------------------|\n",
       "| RL (owlrl)   | True\n",
-      "| DL (HermiT)  | non execute (HermiT indispo)\n",
+      "| DL (HermiT)  | True\n",
       "\n",
       "Note : contrairement a une idee repandue, owlrl implemente la regle cls-svf1 d'OWL 2 RL,\n",
       "ce qui lui permet ICI de deriver la classification via someValuesFrom (equivalentClass + restriction).\n",
@@ -2635,27 +2634,23 @@
       "\n",
       "============================================================\n",
       "Contraste reel : BigFamily = (hasChild min 2)\n",
-      "============================================================\n",
-      "HermiT (DL) indisponible (FileNotFoundError).\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HermiT (DL) : parent classifie BigFamily ? True\n",
       "owlrl (RL)  : parent classifie BigFamily ? False\n",
       "\n",
       "| Profil       | Classification parent -> BigFamily (min 2) ? |\n",
       "|--------------|-----------------------------------------------|\n",
       "| RL (owlrl)   | False\n",
-      "| DL (HermiT)  | non execute\n",
+      "| DL (HermiT)  | True\n",
       "\n",
       "=> Ici la difference est nette : seule la logique DL (HermiT) classifie par cardinalite minimale ;\n",
       "   le profil RL ne supporte pas min-cardinality en position de super-classe.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpqiflsfi9\n",
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpq3yei2bp\n"
      ]
     }
    ],
@@ -2692,7 +2687,9 @@
     "            pizza1 = Pizza(\"pizza1\")\n",
     "            pizza1.hasTopping.append(topping1)\n",
     "\n",
-    "        sync_reasoner_hermit(world)\n",
+    "        # debug=0 : empeche owlready2 d'echoer la commande Java (classpath\n",
+    "        # = chemin d'install machine C:\\\\Users\\\\...\\\\owlready2\\\\hermit).\n",
+    "        sync_reasoner_hermit(world, debug=0)\n",
     "        meatpizza_dl = MeatPizza in pizza1.is_a\n",
     "        print(f\"HermiT (DL) : pizza1 classifiee comme MeatPizza ? {meatpizza_dl}\")\n",
     "    except Exception as e:\n",
@@ -2762,7 +2759,8 @@
     "            child2 = Person(\"child2\")\n",
     "            parent.hasChild = [child1, child2]\n",
     "            AllDifferent([child1, child2])\n",
-    "        sync_reasoner_hermit(world2)\n",
+    "        # debug=0 : empeche owlready2 d'echoer la commande Java (classpath machine).\n",
+    "        sync_reasoner_hermit(world2, debug=0)\n",
     "        bigfamily_dl = BigFamily in parent.is_a\n",
     "        print(f\"HermiT (DL) : parent classifie BigFamily ? {bigfamily_dl}\")\n",
     "    except Exception as e:\n",


### PR DESCRIPTION
## Summary

Fixes a latent classpath leak in `SW-13-Python-Reasoners.ipynb` cells 30, 63, 67 (HermiT reasoner demos via owlready2). When HermiT runs, owlready2 echoes the full JVM command — including `_HERMIT_CLASSPATH`, which is the machine's `site-packages/owlready2/hermit` install path — to stderr. This is the latent leak surfaced (but not fixed) in PR #6266 (c.166).

## Leak — latent on `main`, re-emerges with Java installed

`owlready2/reasoning.py` prints the assembled `java` command whenever `debug=1` (the default for both `sync_reasoner` and `sync_reasoner_hermit`):

```python
if debug:
    print("* Owlready2 * Running HermiT...", file=sys.stderr)
    print("    %s" % " ".join(command), file=sys.stderr)   # <- L187 / L299
```

`command` = `[JAVA_EXE, "-Xmx1000M", "-cp", _HERMIT_CLASSPATH, ...]`, and `_HERMIT_CLASSPATH` resolves to:

```
C:\Users\jsboi\AppData\Roaming\Python\Python313\site-packages\owlready2\hermit;...
```

A machine-username path (`C:\Users\jsboi\...`) in a committed cell output — violates secrets-hygiene rule 6.

**Why latent on `main`**: the last committed execution of these cells ran on a machine *without* Java, so they committed the clean "HermiT indisponible (Java manquant)" stub (no leak). The leak re-emerges on any machine with Java installed (e.g. po-2023 now). Confirmed firsthand: `inspect.getsource(owlready2.reasoning)` shows L187/L299 are the **only** classpath prints, both inside the `if debug:` block.

## Fix — cause-level `debug=0` (not output scrubbing)

Pass `debug=0` to all four reasoner calls. This is owlready2's official API knob for suppressing verbose command echo — the legitimate cause-level fix (secrets-hygiene rule 6: fix the cause + re-execute, never hand-scrub output).

| Cell | Call (before → after) |
|------|----------------------|
| 30 | `sync_reasoner()` → `sync_reasoner(debug=0)` |
| 63 | `sync_reasoner_hermit(world)` → `sync_reasoner_hermit(world, debug=0)` |
| 67 (MeatPizza block) | `sync_reasoner_hermit(world)` → `sync_reasoner_hermit(world, debug=0)` |
| 67 (BigFamily/cardinality block) | `sync_reasoner_hermit(world2)` → `sync_reasoner_hermit(world2, debug=0)` |

## Verification (rule H.1 — EXEC_PROVED)

- **Papermill re-exec SUCCESS**: 88 cells, 26s, kernel `python3`, `--cwd` = notebook dir. **0 errors.**
- **0 code cells with `execution_count: null`** post-exec.
- **cells 30/63/67 leak-free**: 0 occurrences of `ipykernel`, `AppData`, `jsboi`, `site-packages`, no `C:\` drive-letter paths in any output.
- **HermiT actually ran** (not the stub): cell 30 "Temps HermiT 1.1480s / 43 triples", cell 63 "INCOHERENCE detectee → 'tomate' Vegetal+Animal disjointes", cell 67 "pizza1 classifiee comme MeatPizza ? True" + "parent classifie BigFamily ? True" (cardinality reasoning). Real DL results preserved.
- **No `raise NotImplementedError` / `assert False` / `1/0`** introduced (C.1).

## Scope — surgical splice (rule C.3)

Papermill re-execution regenerated outputs for 16 cells, but only cells 30/63/67 had a source change. The other cells' output churn is **ephemeral and NOT committed** (timing, rdflib hash-randomized set-ordering, Python/matplotlib version strings). The committed notebook = `origin/main` base + cells 30/63/67 (source patch + re-executed outputs) only. **85/88 cells byte-identical to `origin/main`.**

## Output semantics note (pre-existing env-dependence, not a regression)

On `main` these cells committed the "Java manquant" stub. After this PR they commit the **nominal** case (HermiT functional), which is pedagogically what the notebook is meant to demonstrate. The code's existing `try/except (FileNotFoundError, OSError)` and `if java_path:` guards retain graceful degradation — a re-execution on a Java-less machine still yields the stub. This env-dependence **pre-existed** this PR (the stub itself was env-dependent). Documented so reviewers aren't surprised that a Java-less re-exec differs.

## Verdict

- SOTA: **RECOVERABLE-LOCAL done** (owlready2 official `debug=0` knob).
- H.1: **EXEC_PROVED** (Papermill 88 cells, 0 errors, HermiT results real).
- C.2: outputs regenerated, reproducible by source (modulo the pre-existing Java env-dependence).
- C.3: only the 3 modified cells' outputs staged.

Concludes the c.165-166 ipykernel/path-leak defect-class series for SW-13 (sister to #6261 Search-4 matplotlib, #6266 SW-13 cProfile). See #2876 (output-hygiene epic context).
