### PR TITLE
fix(gametheory): GT-11 fsolve on linear system -> np.linalg.solve (clear RuntimeWarning)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
@@ -799,10 +799,10 @@
    "id": "4fb3ab39",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T01:29:51.322688Z",
-     "iopub.status.busy": "2026-06-02T01:29:51.322308Z",
-     "iopub.status.idle": "2026-06-02T01:29:51.329055Z",
-     "shell.execute_reply": "2026-06-02T01:29:51.328548Z"
+     "iopub.execute_input": "2026-07-12T04:32:06.326152Z",
+     "iopub.status.busy": "2026-07-12T04:32:06.326152Z",
+     "iopub.status.idle": "2026-07-12T04:32:06.332073Z",
+     "shell.execute_reply": "2026-07-12T04:32:06.332073Z"
     },
     "papermill": {
      "duration": 0.012334,
@@ -834,15 +834,6 @@
       "  (c1=10, c2=30) prob=0.25: P=46.7, pi1=1161.1, pi2=361.1\n",
       "  (c1=30, c2=10) prob=0.25: P=46.7, pi1=361.1, pi2=1161.1\n",
       "  (c1=30, c2=30) prob=0.25: P=56.7, pi1=577.8, pi2=577.8\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\2051189024.py:37: RuntimeWarning: The iteration is not making good progress, as measured by the \n",
-      " improvement from the last ten iterations.\n",
-      "  solution = fsolve(equations, [30, 20])\n"
      ]
     }
    ],
@@ -876,14 +867,14 @@
     "    # a - 2*q_L - (prob_L*q_L + (1-prob_L)*q_H) - c_L = 0\n",
     "    # a - 2*q_H - (prob_L*q_L + (1-prob_L)*q_H) - c_H = 0\n",
     "    \n",
-    "    def equations(x):\n",
-    "        q_L, q_H = x\n",
-    "        E_q = prob_L * q_L + (1 - prob_L) * q_H\n",
-    "        eq1 = a - 2*q_L - E_q - c_L\n",
-    "        eq2 = a - 2*q_H - E_q - c_H\n",
-    "        return [eq1, eq2]\n",
-    "    \n",
-    "    solution = fsolve(equations, [30, 20])\n",
+    "    # Systeme lineaire issu des FOC : les conditions du premier ordre\n",
+    "    # sont lineaires en q_L, q_H. En developpant E_q = prob_L*q_L + (1-prob_L)*q_H\n",
+    "    # on obtient A @ [q_L, q_H] = b, resolu directement (solveur lineaire)\n",
+    "    # plutot que par fsolve iteratif (qui avertit de convergence sur systeme lineaire).\n",
+    "    A = np.array([[2 + prob_L,     1 - prob_L],\n",
+    "                  [prob_L,         2 + (1 - prob_L)]])\n",
+    "    b = np.array([a - c_L, a - c_H])\n",
+    "    solution = np.linalg.solve(A, b)\n",
     "    q_L, q_H = solution\n",
     "    \n",
     "    print(\"\\n\" + \"=\"*50)\n",
@@ -968,10 +959,10 @@
    "id": "12ca6cb7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T01:29:51.350751Z",
-     "iopub.status.busy": "2026-06-02T01:29:51.350540Z",
-     "iopub.status.idle": "2026-06-02T01:29:51.356136Z",
-     "shell.execute_reply": "2026-06-02T01:29:51.355696Z"
+     "iopub.execute_input": "2026-07-12T04:32:06.335078Z",
+     "iopub.status.busy": "2026-07-12T04:32:06.334079Z",
+     "iopub.status.idle": "2026-07-12T04:32:06.339509Z",
+     "shell.execute_reply": "2026-07-12T04:32:06.338987Z"
     },
     "papermill": {
      "duration": 0.010307,
@@ -1021,15 +1012,6 @@
       "    (car il anticipe un adversaire potentiellement inefficace)\n",
       "  - Le type a cout haut produit PLUS qu'avec info complete\n",
       "    (car il anticipe un adversaire potentiellement efficace)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Local\\Temp\\claude\\ipykernel_<pid>\\2051189024.py:37: RuntimeWarning: The iteration is not making good progress, as measured by the \n",
-      " improvement from the last ten iterations.\n",
-      "  solution = fsolve(equations, [30, 20])\n"
      ]
     }
    ],


### PR DESCRIPTION
## Defect (firsthand)

`GameTheory-11-BayesianGames.ipynb` cell18 `solve_cournot_bayesian` solved the Bayesian Cournot equilibrium with `scipy.optimize.fsolve(equations, [30, 20])`. The first-order conditions are **linear** in `q_L, q_H` (expand `E_q = prob_L*q_L + (1-prob_L)*q_H`), so fsolve — an iterative root-finder — is the wrong tool and reliably emits on every run:

```
RuntimeWarning: The iteration is not making good progress, as measured by the improvement from the last ten iterations.
  solution = fsolve(equations, [30, 20])
```

This was committed in stderr of **cell18** and **cell21** (cell21 calls the function; the warning attributes to cell18 L37), and the warning text leaked a machine path (ipykernel temp dir).

## Root cause — why a better guess doesn't work

Tested 8 initial guesses (`[30,20]`, `[25,25]`, `[32,22]`, `[30,22]`, `[35,25]`, `[28,18]`, `[20,15]`, `[40,30]`): **all converge to the correct solution AND all emit the same RuntimeWarning**. The warning is intrinsic to fsolve iterating on a linear system, not a bad guess. The correct fix is the direct linear solver the system actually is.

## Fix

Replace the residual `equations` closure + `fsolve` call with the direct linear system, derived from the same FOCs (kept in preceding comments):

```python
A = np.array([[2 + prob_L,     1 - prob_L],
              [prob_L,         2 + (1 - prob_L)]])
b = np.array([a - c_L, a - c_H])
solution = np.linalg.solve(A, b)
```

`numpy` already imported as `np` in cell1. Direct method → no iteration → cannot emit a convergence warning. This is the SOTA-appropriate tool (direct linear solver) vs the degraded approach (iterative root-finder spuriously warning) — sota-not-workaround Prong A.

## Verification (H.1, firsthand)

- **Solution exactly preserved**: `q(c_L)=31.67`, `q(c_H)=21.67` — identical to the fsolve result (linear system, unique root; confirmed analytically: `2.5*q_L+0.5*q_H=90`, `0.5*q_L+2.5*q_H=70` → unique solution).
- `nbconvert --execute --inplace`: **0 errors, 0 stderr streams** (fsolve warning GONE from cell18 AND cell21). zmq kernel-launcher warning did NOT leak into committed outputs.
- **C.3 surgical splice**: only cell18 source changed; outputs changed only on cell18 and cell21 (the warning cells). Downstream `np.random` cells (25/28) are **byte-identical to `origin/main`** — verified empirically that neither fsolve nor `linalg.solve` consumes `np.random` state (seeded draws `0.3745, 0.9507, 0.7320` identical in all cases), so no collateral drift committed.
- 48/48 cells preserved; `nbformat` VALID; LF preserved (CRLF=0). Diff: 16 ins / 34 del.

## Scope

1 file, 1 cell source (cell18), 1 defect class (numerical-solver warning + path leak). Single-subject. `See #1453` not applicable (notebook numerical-hygiene, not prover).

## R6 note

Different defect class from the ongoing warning-pollution sweep (po-2024/po-2025: matplotlib/escape subtypes): this is a **numerical-solver convergence** warning in game theory, fixed by switching to the mathematically-correct direct solver. po-2024 explicitly skipped this one as "même famille" — it is in fact a distinct cause (scipy fsolve, not matplotlib/escape).

Co-Authored-By: Claude <noreply@anthropic.com>
