### PR TITLE
docs(casestudies): relocate Installation (prérequis) after Projets content (#5985 Phase 2)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -90,14 +90,6 @@ CaseStudies/
 └── requirements.txt       # Dépendances communes (9 packages)
 ```
 
-## Installation
-
-```bash
-pip install -r requirements.txt
-```
-
-Dépendances principales : numpy, pandas, matplotlib, seaborn, z3-solver, pyro-ppl, ortools
-
 ## Projets
 
 ### Diagnostic Médical
@@ -126,6 +118,14 @@ Ordonnancement de la production électrique (unit commitment) sous incertitude r
 - **Concepts** : Unit commitment NP-difficile, modèle bayésien de l'incertitude, optimisation multi-objectif, architecture en couches (filtrer > modéliser > optimiser)
 
 [Sujet](SmartGrid-Energy/subject.md) | 2 notebooks (student + solution) | ~3-4h
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+Dépendances principales : numpy, pandas, matplotlib, seaborn, z3-solver, pyro-ppl, ortools
 
 ## Acquis d'apprentissage
 


### PR DESCRIPTION
## What

Phase 2 micro-pass on `CaseStudies/README.md` per **#5985** gabarit (présenter les choses du plus saillant au plus spécifique — pyramide inversée).

The **Installation / quick-start** section sat **before** `## Projets` (the actual case-study content). Per the #5985 gabarit — `structure/contenu → quick start/prérequis → FAQ → appendices` — prereqs should come **after** the content. Moved:

- Before: `Structure → Installation → Projets`
- After: `Structure → Projets → Installation`

## Acceptance (#5985 Phase 2)

- **(a) section order saillant→spécifique**: Installation now after Projets ✓
- **(b) no tech block wedged between pedagogical blocks**: Installation (practical) cleanly grouped after content, before outcomes ✓
- **(c) reorder PUR multiset-identical**: verified `sort` diff = empty (8 ins / 8 del, pure section move, zero content change) ✓
- **(d) CATALOG-STATUS + generated blocks intact**: no `+/-` on marker lines ✓ (catalog-pr-hygiene R1)
- **(e) 1 PR per series, atomic**: one section move; deeper `Acquis d'apprentissage` reorder (objectifs earlier per gabarit) **deferred** to keep this PR atomic — separate PR if pursued ✓

## Verification

Sorted-diff empty (multiset-identical), diffstat 8 ins / 8 del, CATALOG-STATUS marker byte-identical.

New `##` order: À qui s'adresse → Pourquoi → Structure → **Projets** → **Installation** → Acquis → Concepts → Pour aller plus loin → Conclusion → FAQ → Statistiques → MCP.

See #5985
