### PR TITLE
fix(prover): redirect stale SocialChoice/StableMarriage dirs to game_theory_lean (#6248)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -130,7 +130,13 @@ COOPERATIVE_GAMES_DIR = next(
 SHAPLEY_FILE = COOPERATIVE_GAMES_DIR / "CooperativeGames" / "Shapley.lean" if COOPERATIVE_GAMES_DIR.exists() else None
 BASIC_FILE = COOPERATIVE_GAMES_DIR / "CooperativeGames" / "Basic.lean" if COOPERATIVE_GAMES_DIR.exists() else None
 
+# Canonical home is game_theory_lean since the #6058 absorption merged
+# (SocialChoice/Arrow+Sen+Voting moved into game_theory_lean on
+# 2026-07-11). The legacy social_choice_lean dir survives as md-only
+# (FORMAL_STATUS/README/NOTICE) — its SocialChoice/*.lean are gone, so
+# deriving VOTING_FILE from it yields a non-existent path (#6248).
 _SOCIAL_CHOICE_CANDIDATES = [
+    _workspace_relative("GameTheory/game_theory_lean"),
     _workspace_relative("GameTheory/social_choice_lean"),
     Path(r"C:\dev\CoursIA\MyIA.AI.Notebooks\GameTheory\social_choice_lean"),
     Path(r"D:\dev\CoursIA\MyIA.AI.Notebooks\GameTheory\social_choice_lean"),
@@ -151,7 +157,13 @@ import SocialChoice.Definitions
 """
 
 # ── Stable Marriage ──
+# Canonical home is game_theory_lean since the #5904-#5913 absorption merged
+# (StableMarriage/{Definitions,GSState,GaleShapley,Lemmas,Lattice} moved into
+# game_theory_lean on 2026-07-10). The legacy stable_marriage_lean dir is
+# md-only now — deriving GSSTATE/GALESHAPLEY/LEMMAS/LATTICE_FILE from it yields
+# non-existent paths (#6248).
 _STABLE_MARRIAGE_CANDIDATES = [
+    _workspace_relative("GameTheory/game_theory_lean"),
     _workspace_relative("GameTheory/stable_marriage_lean"),
     Path(r"C:\dev\CoursIA\MyIA.AI.Notebooks\GameTheory\stable_marriage_lean"),
     Path(r"D:\CoursIA\MyIA.AI.Notebooks\GameTheory\stable_marriage_lean"),


### PR DESCRIPTION
## Summary

Fixes #6248. `prover/config.py` derived `VOTING_FILE`, `GALESHAPLEY_FILE` (and siblings `GSSTATE_FILE`, `LEMMAS_FILE`, `LATTICE_FILE`, `SMOKE_TEST_FILE`) from the `social_choice_lean` / `stable_marriage_lean` dirs — both gutted by the #4365 anti-proliferation absorption:

- **StableMarriage** absorbed into `game_theory_lean` via #5904-#5913 (merged 2026-07-10)
- **SocialChoice** (Arrow+Sen+Voting) absorbed into `game_theory_lean` via #6058 (merged 2026-07-11)

The legacy dirs survive as **md-only** (FORMAL_STATUS/README/NOTICE) — their `SocialChoice/*.lean` and `StableMarriage/*.lean` are gone. Because the dir itself still `exists()`, `SOCIAL_CHOICE_DIR` resolves to the legacy dir, but `VOTING_FILE = legacy/SocialChoice/Voting.lean` points at a **non-existent** path. **11 demo references** in `config.py` (demos 9-14 VOTING_*, 15-17 GALESHAPLEY_*, the LEMMAS/LATTICE family) are effectively dead post-absorption.

## Fix

Prepend `_workspace_relative("GameTheory/game_theory_lean")` to **both** `_SOCIAL_CHOICE_CANDIDATES` and `_STABLE_MARRIAGE_CANDIDATES`, so the canonical post-absorption home wins (the legacy entries stay as fallbacks). Two +6-line blocks.

## Verification (firsthand, G.1)

Direct import of `config.py` (mocking the heavy `agent_framework_openai` import) confirms:

```
SOCIAL_CHOICE_DIR   = .../game_theory_lean   exists=True
STABLE_MARRIAGE_DIR = .../game_theory_lean   exists=True

  OK   VOTING_FILE        exists=True
  OK   SMOKE_TEST_FILE    exists=True
  OK   GSSTATE_FILE       exists=True
  OK   GALESHAPLEY_FILE   exists=True
  OK   LEMMAS_FILE        exists=True
  OK   LATTICE_FILE       exists=True
ALL 6 FILES EXIST: True
```

Also confirmed firsthand via `git ls-tree origin/main`:
- `game_theory_lean/SocialChoice/Voting.lean` ✓ (plus Arrow, Sen, Framework, MechanismDesign, SortedListCounting, Basic, _SmokeTest + EN twins)
- `game_theory_lean/StableMarriage/{Definitions,GSState,GaleShapley,Lemmas,Lattice}.lean` ✓ (+ EN twins)
- Legacy `social_choice_lean/` / `stable_marriage_lean/` = **md-only** (no `.lean`)

## Not actually ai-01 turf (despite the issue framing)

The issue flagged this as "ai-01 turf" because `SOCIAL_CHOICE_DIR` / `STABLE_MARRIAGE_DIR` are "used as lake project roots for `lake build`". **G.1 verification contradicts that**: `git grep` across `prover/*.py` shows these DIRs are consumed **only inside `config.py`** to derive FILE paths — no `subprocess`/`lake build` call uses them as cwd. The actual `lake build` cwd (tools.py L2594 `read_build_result`) is resolved via `resolve_lake_module(self._filepath)`, which walks up from the **FILE** path to find the lake root. Redirecting the FILEs to `game_theory_lean/` will correctly resolve the `game_theory_lean` lake root — same as CooperativeGames already does. No BG-iter planning interaction.

## Workflow placement

This is **step 2** of the workflow pinned by #6249 (`test_prover_guards.test_path_constants_resolve_to_active_workspace` with `STALE_POST_ABSORPTION = {"VOTING_FILE", "GALESHAPLEY_FILE"}`):

1. #6249 (OPEN) — adds the pin, test stays green by skipping the stale set
2. **This PR** — redirect config.py so the FILEs resolve
3. Follow-up — drop the `STALE_POST_ABSORPTION` set so full existence is re-asserted

I do **not** touch `test_prover_guards.py` here (one subject per PR, catalog-pr-hygiene HARD 3). When #6249 lands and the follow-up drops the set, this PR's resolution is what makes the test pass.

## Scope

Single file, +12 lines (2 candidate-list prepends + explanatory comments). No notebook, no Lean source, no test modification. `python -c "import ast; ast.parse(...)"` syntax OK.

See #6248, #6249, #4365, #1453 (prover harness co-owned).
