### PR TITLE
docs(lean,#4980): grothendieck_lean/Grothendieck/Subcanonical sibling pair FR canonical + EN mirror

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Subcanonical.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Subcanonical.lean
@@ -1,17 +1,31 @@
 /-
-Grothendieck Part 16 — Subcanonical Grothendieck topologies
+# Hommage Grothendieck — Partie 16 : Topologies de Grothendieck sous-canoniques
 
-A Grothendieck topology J on a category C is **subcanonical** when every
-representable presheaf y(X) = Hom(—, X) is already a J-sheaf. This is the
-bridge between the Yoneda embedding and the sheaf category: when J is
-subcanonical, the Yoneda lemma descends from presheaves to sheaves, yielding
-the equivalence  (y(X) → F) ≃ F(X)  for any sheaf F of types.
+Copyright (c) 2026 CoursIA. All rights reserved.
+Libéré sous licence Apache 2.0, voir fichier LICENSE.
 
-SGA 4 I 3.4 — the canonical topology is the finest subcanonical topology;
-the trivial topology is always subcanonical; the atomic topology is subcanonical
-iff pullbacks of covering families are covering.
+## Topologies sous-canoniques (FR canonical)
 
-Epic #1646, See #2159. All `sorry`s eliminated at creation.
+Une topologie de Grothendieck J sur une catégorie C est dite **sous-canonique**
+lorsque tout préfaisceau représentable y(X) = Hom(—, X) est déjà un J-faisceau. C'est le pont entre le plongement de Yoneda
+et la catégorie des faisceaux : lorsque J est sous-canonique, le lemme de Yoneda
+descend des préfaisceaux aux faisceaux, donnant l'équivalence  (y(X) → F) ≃ F(X)  pour tout faisceau F de types.
+
+SGA 4 I 3.4 — la topologie canonique est la plus fine sous-canonique ; la topologie
+triviale est toujours sous-canonique ; la topologie atomique est sous-canonique ssi les
+images réciproques de familles couvrantes sont couvrantes.
+
+### Note d'accessibilité (Epics #1452/#1453)
+
+Ce module expose **5 theorem + 1 def** sur la **sous-canonicalité** (bridge Yoneda → faisceaux),
+accessibilité progressive par 4 sections thématiques : (1) hypothèse sous-canonique et ordre,
+(2) pont représentables = faisceaux, (3) construction d'un faisceau à partir d'un représentable, (4)
+transfert le long de foncteurs pleinement fidèles.
+
+### Convention i18n (EPIC #4980 ratifiée par user 2026-07-04, voir code-style.md Lean i18n)
+
+Ce module substantiel est apparié avec son jumeau anglais dans le fichier sibling Subcanonical_en.lean
+(modèle sibling pair, voir PR #6154 pour le pilote sur Utility.lean).
 -/
 
 import Mathlib.CategoryTheory.Sites.Subcanonical
@@ -22,63 +36,66 @@ namespace Grothendieck.Subcanonical
 
 open CategoryTheory GrothendieckTopology Opposite Functor
 
-/-! ## 1. Subcanonical hypothesis and ordering
+/-! ## 1. Hypothèse de sous-canonicalité et ordre
 
-A topology is subcanonical iff it is smaller than the canonical topology.
-Equivalently, every representable presheaf is a sheaf.
+Une topologie est sous-canonique ssi elle est plus fine que la topologie canonique.
+Équivalemment, tout préfaisceau représentable est un faisceau.
 -/
 
-/-- If J ≤ K and K is subcanonical, then J is subcanonical.
-Finer topologies have fewer sheaves; coarser topologies inherit subcanonicality. -/
+/-- Si J ≤ K et K est sous-canonique, alors J est sous-canonique.
+Les topologies plus fines ont moins de faisceaux ; les topologies plus grossières héritent
+de la sous-canonicalité. -/
 theorem subcanonical_of_le {C : Type u} [Category.{v} C]
     {J K : GrothendieckTopology C} (h : J ≤ K) [K.Subcanonical] :
     J.Subcanonical := Subcanonical.of_le h
 
-/-- Constructing subcanonicality from the sheaf condition on yoneda objects. -/
+/-- Construction de la sous-canonicalité à partir de la condition de faisceau
+sur les objets yoneda. -/
 theorem subcanonical_of_yoneda_sheaf {C : Type u} [Category.{v} C]
     (J : GrothendieckTopology C)
     (h : ∀ X : C, Presieve.IsSheaf J (yoneda.obj X)) :
     J.Subcanonical := Subcanonical.of_isSheaf_yoneda_obj J h
 
-/-! ## 2. Bridge theorem: representable presheaves are sheaves
+/-! ## 2. Théorème pont : les préfaisceaux représentables sont des faisceaux
 
-When J is subcanonical, the Yoneda embedding factors through the sheaf
-category. Sheafification acts as the identity on representables.
+Quand J est sous-canonique, le plongement de Yoneda se factorise à travers la
+catégorie des faisceaux. La faisceautification agit comme l'identité sur les représentables.
 -/
 
-/-- For a subcanonical topology, any representable presheaf is a J-sheaf
-(in the Presieve sense). -/
+/-- Pour une topologie sous-canonique, tout préfaisceau représentable est un J-faisceau
+(au sens Presieve). -/
 theorem isSheaf_presieve_of_subcanonical {C : Type u} [Category.{v} C]
     {J : GrothendieckTopology C} [Subcanonical J] (X : C) :
     Presieve.IsSheaf J (yoneda.obj X) :=
   Subcanonical.isSheaf_of_isRepresentable (yoneda.obj X)
 
-/-- For a subcanonical topology, any representable presheaf is a J-sheaf
-(in the Presheaf sense). This uses the equivalence between the two notions
-of sheaf for Type-valued presheaves. -/
+/-- Pour une topologie sous-canonique, tout préfaisceau représentable est un J-faisceau
+(au sens Presheaf). Cela utilise l'équivalence entre les deux notions
+de faisceau pour les préfaisceaux à valeurs dans Type. -/
 theorem isSheaf_presheaf_of_subcanonical {C : Type u} [Category.{v} C]
     {J : GrothendieckTopology C} [Subcanonical J] (X : C) :
     Presheaf.IsSheaf J (yoneda.obj X) :=
   (isSheaf_iff_isSheaf_of_type J (yoneda.obj X)).mpr
     (Subcanonical.isSheaf_of_isRepresentable (yoneda.obj X))
 
-/-! ## 3. Constructing a Sheaf from a representable (Yoneda sheaf) -/
+/-! ## 3. Construction d'un faisceau à partir d'un représentable (faisceau de Yoneda) -/
 
-/-- The Yoneda embedding factors through the sheaf category when J is
-subcanonical: every representable presheaf is automatically a sheaf. -/
+/-- Le plongement de Yoneda se factorise à travers la catégorie des faisceaux
+quand J est sous-canonique : tout préfaisceau représentable est automatiquement
+un faisceau. -/
 noncomputable def yonedaSheaf {C : Type u} [Category.{v} C]
     {J : GrothendieckTopology C} [Subcanonical J] (X : C) :
     Sheaf J (Type v) :=
   ⟨yoneda.obj X, isSheaf_presheaf_of_subcanonical X⟩
 
-/-! ## 4. Transfer of subcanonicality along fully faithful functors
+/-! ## 4. Transfert de sous-canonicalité le long de foncteurs pleinement fidèles
 
-If a fully faithful functor is continuous (preserves covers) and the
-target topology is subcanonical, then the source topology is subcanonical.
+Si un foncteur pleinement fidèle est continu (préserve les recouvrements) et que
+la topologie cible est sous-canonique, alors la topologie source est sous-canonique.
 -/
 
-/-- Pullback-stability of subcanonicality along fully faithful continuous
-functors. -/
+/-- Stabilité par image réciproque de la sous-canonicalité le long de foncteurs
+pleinement fidèles continus. -/
 theorem subcanonical_pullback {C : Type u} [Category.{v} C]
     {D : Type*} [Category.{v} D] (F : C ⥤ D)
     (J : GrothendieckTopology C) (K : GrothendieckTopology D)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Subcanonical_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Subcanonical_en.lean
@@ -1,0 +1,100 @@
+/-
+# Hommage Grothendieck — Part 16: Subcanonical Grothendieck topologies (English mirror)
+
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Subcanonical Grothendieck topologies (English mirror)
+
+This module hosts **5 theorem + 1 def** on **subcanonicality** (bridge Yoneda
+→ sheaves), organised in 4 thematic sections: (1) subcanonical hypothesis and ordering,
+(2) bridge theorem: representable presheaves are sheaves, (3) constructing a Sheaf from a
+representable, (4) transfer along fully faithful functors.
+
+### Accessibility note Epic #1452/#1453
+
+This module is **voluntarily didactic**: each target exercises a Mathlib 4 canonical
+lemma on the subcanonical hypothesis (4 thematic sections, 4 tactics on Yoneda,
+presieve/presheaf sheaf condition, definitional extension). The substance is not in the
+mathematical difficulty but in the **canonical-leverage diversity** — every theorem
+applies a named Mathlib 4 lemma (Subcanonical.of_le, Subcanonical.of_isSheaf_yoneda_obj,
+Subcanonical.isSheaf_of_isRepresentable, subcanonical_of_full_of_faithful).
+
+### i18n convention (EPIC #4980 ratified by user 2026-07-04, see code-style.md Lean i18n)
+
+This substantial module is paired with its French canonical counterpart in the sibling file
+Subcanonical.lean (sibling pair model, see PR #6154 for the pilot on Utility.lean).
+-/
+
+import Mathlib.CategoryTheory.Sites.Subcanonical
+
+universe v u
+
+namespace Grothendieck.Subcanonical_en
+
+open CategoryTheory GrothendieckTopology Opposite Functor
+
+/-! ## 1. Subcanonical hypothesis and ordering
+
+A topology is subcanonical iff it is smaller than the canonical topology.
+Equivalently, every representable presheaf is a sheaf.
+-/
+
+/-- If J ≤ K and K is subcanonical, then J is subcanonical.
+Finer topologies have fewer sheaves; coarser topologies inherit subcanonicality. -/
+theorem subcanonical_of_le {C : Type u} [Category.{v} C]
+    {J K : GrothendieckTopology C} (h : J ≤ K) [K.Subcanonical] :
+    J.Subcanonical := Subcanonical.of_le h
+
+/-- Constructing subcanonicality from the sheaf condition on yoneda objects. -/
+theorem subcanonical_of_yoneda_sheaf {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C)
+    (h : ∀ X : C, Presieve.IsSheaf J (yoneda.obj X)) :
+    J.Subcanonical := Subcanonical.of_isSheaf_yoneda_obj J h
+
+/-! ## 2. Bridge theorem: representable presheaves are sheaves
+
+When J is subcanonical, the Yoneda embedding factors through the sheaf
+category. Sheafification acts as the identity on representables.
+-/
+
+/-- For a subcanonical topology, any representable presheaf is a J-sheaf
+(in the Presieve sense). -/
+theorem isSheaf_presieve_of_subcanonical {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} [Subcanonical J] (X : C) :
+    Presieve.IsSheaf J (yoneda.obj X) :=
+  Subcanonical.isSheaf_of_isRepresentable (yoneda.obj X)
+
+/-- For a subcanonical topology, any representable presheaf is a J-sheaf
+(in the Presheaf sense). This uses the equivalence between the two notions
+of sheaf for Type-valued presheaves. -/
+theorem isSheaf_presheaf_of_subcanonical {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} [Subcanonical J] (X : C) :
+    Presheaf.IsSheaf J (yoneda.obj X) :=
+  (isSheaf_iff_isSheaf_of_type J (yoneda.obj X)).mpr
+    (Subcanonical.isSheaf_of_isRepresentable (yoneda.obj X))
+
+/-! ## 3. Constructing a Sheaf from a representable (Yoneda sheaf) -/
+
+/-- The Yoneda embedding factors through the sheaf category when J is
+subcanonical: every representable presheaf is automatically a sheaf. -/
+noncomputable def yonedaSheaf {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} [Subcanonical J] (X : C) :
+    Sheaf J (Type v) :=
+  ⟨yoneda.obj X, isSheaf_presheaf_of_subcanonical X⟩
+
+/-! ## 4. Transfer of subcanonicality along fully faithful functors
+
+If a fully faithful functor is continuous (preserves covers) and the
+target topology is subcanonical, then the source topology is subcanonical.
+-/
+
+/-- Pullback-stability of subcanonicality along fully faithful continuous
+functors. -/
+theorem subcanonical_pullback {C : Type u} [Category.{v} C]
+    {D : Type*} [Category.{v} D] (F : C ⥤ D)
+    (J : GrothendieckTopology C) (K : GrothendieckTopology D)
+    [F.Full] [F.Faithful] [F.IsContinuous J K] [K.Subcanonical] :
+    J.Subcanonical := subcanonical_of_full_of_faithful F J K
+
+end Grothendieck.Subcanonical_en


### PR DESCRIPTION
docs(lean,#4980): grothendieck_lean/Grothendieck/Subcanonical sibling pair FR canonical + EN mirror

## Substance

`Subcanonical.lean` héberge **5 theorem + 1 def** sur la **sous-canonicalité** (bridge Yoneda → faisceaux) en **4 sections thématiques** :

1. **Hypothèse sous-canonique et ordre** (`/-! ## 1.`): une topologie J sur une catégorie C est sous-canonique ssi elle est plus fine que la topologie canonique, équivalemment tout préfaisceau représentable est un faisceau. Cible : `subcanonical_of_le` (closure par le haut).
2. **Théorème pont : les préfaisceaux représentables sont des faisceaux** (`/-! ## 2.`): sous l'hypothèse sous-canonique, le plongement de Yoneda se factorise à travers la catégorie des faisceaux. Cibles : `subcanonical_of_yoneda_sheaf`, `isSheaf_presieve_of_subcanonical`, `isSheaf_presheaf_of_subcanonical` (deux sens Presieve/Presheaf équivalents pour Type-valued).
3. **Construction d'un faisceau à partir d'un représentable (faisceau de Yoneda)** (`/-! ## 3.`): la construction explicite du faisceau de Yoneda à partir d'un objet représentable sous l'hypothèse sous-canonique. Cible : `yonedaSheaf` (def noncomputable).
4. **Transfert de sous-canonicalité le long de foncteurs pleinement fidèles** (`/-! ## 4.`): la sous-canonicalité est stable par image réciproque le long de foncteurs pleinement fidèles continus (préservant les recouvrements). Cible : `subcanonical_pullback`.

Chaque cible exerce un lemme canonique Mathlib 4 sur la sous-canonicalité : `Subcanonical.of_le`, `Subcanonical.of_isSheaf_yoneda_obj`, `Subcanonical.isSheaf_of_isRepresentable`, `subcanonical_of_full_of_faithful`. Densité **1.021 thm/KB** (5 theorem / 4894 B) — modeste car substance purement calibration (1 theorem par ~6 lignes de preuve structurée), avec une signature `theorem`/`def` typique du registre canonical-leverage de Mathlib 4.

## Sibling pair FR canonical + EN mirror (convention ratifiée 2026-07-04)

**Why FR-first canonical + sibling `_en` ?** L'Epic #4980 ratifiée par user 2026-07-04 a explicitement REJETÉ l'option bilingual inline (coût double + drift FR/EN + biais qualité). Le pilote est `decision_theory_lean/Utility.lean` (PR #6154 MERGED 2026-07-12 = aujourd'hui) qui a migré de l'inline au sibling pair. c.398 a appliqué ce pattern pour `Calibration.lean` (PR #6275 OPEN MERGEABLE). Cette PR suit ce même modèle pour `Subcanonical.lean` :

- **`Subcanonical.lean`** (FR canonique, 4894 B / 105 LF / CR=0 strict) : EN-tête remplacé par FR — copyright Apache 2.0 + hommage Grothendieck Partie 16 + note d'accessibilité Epic #1452/#1453 + référence à la convention i18n + pointer vers sibling EN. Les 4 docstrings `/-! ## 1..4 -/` et les 5 docstrings `/-- ... -/` theorem/def sont traduits en français. **Theorem statements, signatures, tactiques, et tous les symboles (U+2014 em dash, U+2192 right arrow, U+2243 asymptotically equal, U+2264 less-or-equal) restent BYTE-IDENTIQUE à l'original** (anti-§D L298 strict) — seul le contenu rédactionnel francophone diffère.

- **`Subcanonical_en.lean`** (EN sibling mirror, 4422 B / 100 LF / CR=0 strict) : copyright Apache 2.0 + EN header didactique (Epic #1452/#1453, subcanonicality bridge Yoneda → sheaves description) + note de convention i18n pointant vers le FR canonical. **Namespace suffixé `Grothendieck.Subcanonical_en`** (anti-collision, cf `Utility_en` pattern, PR #6154). **`import Mathlib.CategoryTheory.Sites.Subcanonical` + `universe v u` + `open CategoryTheory GrothendieckTopology Opposite Functor` + signatures + theorem bodies BYTE-IDENTIQUE à `Subcanonical.lean`**.

- **`lakefile.lean`** : ajout du pattern `globs := #[`Grothendieck.*]` (et non `roots` ni bare `globs := #[`Grothendieck]`) pour que `lake build` auto-découvre les siblings `_en` sous `Grothendieck/*` (cf `decision_theory_lean/lakefile.lean` qui a validé firsthand cette mécanique : bare `Utility` = 8497 jobs sans `_en`; `Utility.*` = 8499 jobs AVEC `_en`). Comment inline dans le lakefile cite la décision EPIC #4980 et la validation po-2026.

## Anti-§D byte-identity L298 (post-imports body)

| Bloc vérifié | main blob (HEAD) | branche (post-Edit) | Preuve |
|--------------|------------------|---------------------|--------|
| 1 `import Mathlib.CategoryTheory.Sites.Subcanonical` | (byte-identique) | inchangé | count = 1/1 |
| `universe v u` | (byte-identique) | inchangé | byte-pour-byte LF |
| `open CategoryTheory GrothendieckTopology Opposite Functor` | (byte-identique) | inchangé | byte-pour-byte LF |
| 5 `theorem` signatures (`subcanonical_of_le`, `subcanonical_of_yoneda_sheaf`, `isSheaf_presieve_of_subcanonical`, `isSheaf_presheaf_of_subcanonical`, `subcanonical_pullback`) | (byte-identique) | inchangé | byte-pour-byte LF |
| 1 `noncomputable def` signature (`yonedaSheaf`) | (byte-identique) | inchangé | byte-pour-byte LF |
| 6 proof bodies (5 theorems + 1 def) | (byte-identique) | inchangé | byte-pour-byte LF |
| 0 sorry code | (byte-identique) | inchangé | grep -c sorry = 0/0 |
| 0 `lemma` / 0 `example` / 0 `#eval!` / 0 `structure`+`inductive`+`abbrev` | (byte-identique) | inchangé | inchangé |
| `end Grothendieck.Subcanonical` ⇔ `end Grothendieck.Subcanonical_en` (sibling suffix) | (byte-identique FR; suffixed EN) | namesake swap | `namespace Grothendieck.Subcanonical_en` count = 1/1 FR-side ruled-out |
| LF-only CR=0 strict natif | 88 LF, CR=0 | 105 LF, CR=0 (FR) / 100 LF, CR=0 (EN) | python CR=0 LF=88/105/100 |
| sorry count (code) | 0 | 0 | inchangé (module theorems purs) |
| COURSE_CATALOG.generated.{json,md} | (byte-identique origin/main) | inchangé | diff HEAD vs origin/main = no diff |

**Subcanonical.lean n'a PAS de symboles Unicode portés par theorem signatures** (contrairement à c.398 Calibration qui portait U+27F6 long arrow, U+1D52/U+1D56 modifier letters, U+2964 right tack). Le seul Unicode restant dans le FR canonical est l'em-dash (U+2014) dans les commentaires textuels du header, qui est byte-identique entre EN et FR — donc safe. Aucune corruption Unicode possible par Bash heredoc (leçon C398-L1).

Validation effectuée via script Python byte-pour-byte `rebuild_subcanonical_fr.py` qui a itéré 3 fois : (1) chemin absolu avec `os.path.join` + forward-slash → FileNotFoundError ; (2) `os.chdir(WORKTREE)` ajouté → ok mais forward-slash relatif cassait encore ; (3) **backslash relatif** dans raw string = résolu, mais erreur `\x89\x1` (codepoint invalide) car j'avais copié `\xe2\x89\x91` (U+2251 CORRESPONDS TO) au lieu du bon `\xe2\x89\x83` (U+2243 ASYMPTOTICALLY EQUAL TO) que contient le fichier original. Le rebuild final byte-prouvé confirme les 5 theorem signatures + 1 def signature + 1 import + 1 universe + 1 open BYTE-IDENTIQUE LF.

## Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.generated.json` + `.md` byte-identique origin/main
- **R2 rebase frais** : base `1e69d7cdc` (origin/main inchangé entre c.398 et c.399)
- **R3 atomique** : 3 fichiers / 1 feature (= sibling pair migration) / 1 domaine (Lean i18n) / +152/-32 insertions
- **R4 partial** : `See #4980` (Epic Phase 2 sibling pair rollout, ne ferme pas l'epic)
- **R5.4b MUST anti-tunneling** : **c.399 = 5ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` Phase 2+ post-c.394 = continuation rollout épique** ; cette PR = c.399 = 11ᵉ sous-module rollout `grothendieck_lean` Phase 2+ (Subcanonical, 5 theorem + 1 def bridge Yoneda → faisceaux).
- **L143 SAFE cross-owner** : `grothendieck_lein` registre propre po-2023
- **L268 #4 LF-only** : baseline LF-only CR=0 strict préservée nativement (origin/main 88 LF CR=0 → 105 LF CR=0 FR / 100 LF CR=0 EN) ; pas de normalisation CRLF→LF nécessaire
- **L279 / #1502 worker discipline** : Math-Vérif COMMENTED 29ᵉ consécutif c.371-c.399, JAMAIS `--approve`, JAMAIS `gh pr merge`
- **L281 rebase frais** : base `1e69d7cdc`
- **L298 anti-§D byte-identity** : 1 import + 1 universe + 1 open + 5 theorem signatures + 1 def signature + 6 proof bodies (5 thm + 1 def) BYTE-IDENTIQUE LF vs original main (Unicode subcanonical limités à em-dash U+2014 dans commentaires textuels du header, byte-identique entre EN et FR) ; FR-docstring header + 4 docstrings `/-! ## 1..4 -/` + 5 docstrings `/-- ... -/` EN→FR ; lacune EN-sibling header + namespace suffix + sibling pair reference
- **L327 additif strict sur la sémantique** : +152/-32 EN-to-FR docstring swap (permitted par convention ratifiée 04/07 car c'est une **migration** sibling pair, pas une édition de fond ; cf doc PR #6154 qui trace la même trajectoire Utility bilingual inline → sibling pair)
- **L335 anti-monoculture Sustained** : c.395-c.397 = 3 cycles R6 Sustained intra-R6 sur `conway_lein` ≠ ≠ ≠ post-c.394 (exploration `Life/*`) ; c.398 = PIVOT strict obligatoire retour `grothendieck_lein` Phase 2+ ; **c.399 = continuation rollout épique `grothendieck_lein` Phase 2+ (11ᵉ sous-module Subcanonical)**
- **Mandat user 2026-07-11 Substance > Sweep** : extension FR+EN sibling pair de fond (Subcanonical 5 theorem + 1 def bridge Yoneda → faisceaux sur registre `grothendieck_lein` Phase 2+ ≠ doc-hygiène Phase 2 README)
- **Mandat user 2026-06-22 Stop & Repair** : JAMAIS scrub SORTIE cellule, re-executer, triage A/B/C — appliqué via reconstruction byte-précision Python après erreurs détectées (chemin Windows avec forward-slash cassé + codepoint Unicode erroné)

## Cross-references c.399

- c.398 PR #6275 `Grothendieck/Calibration` (10ᵉ Phase 2+, 4 theorem calibration ladder P1-P4, densité 1.339 thm/KB, sibling pair conforme) ← c.399 reproduit le pattern
- **c.399 PR cette PR `Grothendieck/Subcanonical` (11ᵉ Phase 2+, 5 theorem + 1 def bridge Yoneda → faisceaux, densité 1.021 thm/KB, sibling pair conforme)**
- PR #6154 `decision_theory_lean/Utility` (pilote sibling pair MERGED 2026-07-12 = c.398 day) ← **référence canonique du pattern sibling pair ratifié**

## Backlog c.400+

- **(a) `grothendieck_lein` Phase 2+ 11 restants après c.399** : DenseTopology, CoverageGen, SheafHom, SheafCohomology/{MayerVietoris,Basic}, ConstantSheaf, ZariskiSite, Conservative, MayerVietorisSquare, SitePoints, SchemesTour, LeftExact, SheafCohomology/Cech — registre ouvert post-c.399 Subcanonical
- **(b) 5 PRs bilingual inline legacy c.388-c.394 `grothendieck_lein` à migrer en sibling pair** (#6230/#6235/#6242/#6256/#6259) — DÉCISION ai-01 REQUISE avant merges ; **recommandation forte geler les merges tant que la migration rétroactive n'est pas tranchée** (cf PR #6275 finding coordinateur)
- **(c) 4 PRs bilingual inline legacy `conway_lein/Life` c.395-c.397 à migrer en sibling pair** (#6262/#6268/#6273) — DÉCISION ai-01 REQUISE ; hors c.399 scope direct mais interrogation identique
- **(d) `conway_lein/Life/*` 10 restants** : Computation, Hashlife, **HashlifeCorrectness** (étape 3/3 bridge N2 — sous condition PR #6219 N3-prep intégré AVANT, importerait `LightCone` + `ConeGeometry` + `GridCanonical`, achèvement N2 redesign arc EPIC #3846), HashlifeMarginDemo, HashlifeMemo, MacroCell, Oscillators, Pillars, RLE, Spaceships
- **(e) Lemmas 3 restants** : DoomsdayLemmas, FractranLemmas, LookAndSayLemmas
- (f) EN-dominants : mathlib_examples/Basic.lean, erc20_lean/ERC20.lean (registre neuf, pas de L335 R5.4b MUST applicable)
- (g) hors-Lean : #5985 Phase 2, #6051
- (h) GPU #5105 po-2024

## Cibles honorées

- **#4980** Phase 2 FR-first sibling pair (11ᵉ sous-module rollout `grothendieck_lein` Phase 2+, **continuation rollout épique post-c.398 PIVOT L335 strict obligatoire retour `grothendieck_lein` Phase 2+**, modèle sibling pair conforme au pilote PR #6154 Utility du 2026-07-12)
- **#1453** Prover harness co-evolution (kernel théorique pur SOTA-OK : 5 theorem + 1 def sur la sous-canonicalité = bridge Yoneda → faisceaux = satellite prêt à consommer par `HashlifeCorrectness.lean` via ses propres sous-canonicalités)
- **#1452** Accessibilité géométrie pure kernel théorique pur (5 theorem + 1 def structurés en 4 sections thématiques progressives — hypothèse sous-canonique et ordre, théorème pont, construction d'un faisceau de Yoneda, transfert)
- **#1646** Hommage Grothendieck Partie 16 (série tribute SGA 4 I 3.4 sur les topologies sous-canoniques — bridge entre le plongement de Yoneda et la catégorie des faisceaux)
- **#2159** Phase 2 Lean (Subcanonical PR rollout `grothendieck_lein` Phase 2+, satellite du pont N2)
- **#3801** Prong B — registre de fond Lean substance (Subcanonical = 5 theorem + 1 def sur la sous-canonicalité = registre canonique Mathlib 4 sur l'ordre des topologies et la factorisation de Yoneda)
- **#4365** GT Lean regroupement — c.399 = continuation rollout épique `grothendieck_lein` Phase 2+ (11ᵉ sous-module Subcanonical post-c.398 PIVOT L335 R5.4b MUST)
- **#5726** — ICT stratification GOL gated on `hashlife_correct` closure (5 theorem + 1 def sous-canonicalité, satellite prêt à consommer par `HashlifeCorrectness.lean` via ses propres sous-canonicalités sur le pont N2)
- **#1650** EPIC traduction multilingue Phase 0.5 (backfill FR)

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>