### PR TITLE
docs(lean-i18n): migrate grothendieck_lein/Grothendieck/DenseTopology to FR canonical + EN sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DenseTopology.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DenseTopology.lean
@@ -1,53 +1,66 @@
-/-
-Grothendieck tribute — Part 12: The dense topology
-Alexandre Grothendieck (1928-2014).
+-/
+# Hommage Grothendieck — Partie 12 : La topologie dense
 
-Phase 7 extension (#2159, Epic #1646).
+Copyright (c) 2026 CoursIA. All rights reserved.
+Libéré sous licence Apache 2.0, voir fichier LICENSE à la racine du dépôt.
 
-Part 11 (SieveGenerate.lean) recorded the identities of `Sieve.generate`.
-This module studies the **dense topology** (a.k.a. `¬∀`-topology, or the
-"double-negation" topology), one of the standard examples of a Grothendieck
-topology that is neither trivial nor discrete.
+## La topologie dense (FR canonical)
 
-A sieve S on X is dense-covering when every arrow `f : Y ⟶ X` into X can be
-*refined* by an arrow landing in S: there exist `Z` and `g : Z ⟶ Y` with
-`S (g ≫ f)`. Equivalently, S is "eventually covering" along any incoming
-arrow — the order-theoretic shadow of a double-negation sheaf.
+Une topologie de Grothendieck J sur une catégorie C est dite **dense** (ou
+« ¬∀-topologie », ou topologie de la double négation) lorsqu'un crible S sur X
+est couvrant dès qu'à toute flèche f : Y ⟶ X admet un raffinement dans S : il
+existe Z et g : Z ⟶ Y tels que S (g ≫ f). C'est la traduction catégorielle de la
+double négation : « à terme éventuellement couvrante » le long de toute flèche
+entrante.
 
-We record the basic identities:
+Cette topologie fournit un exemple standard de topologie de Grothendieck ni
+triviale ni discrète. Nous y enregistrons les identités fondamentales :
 
-  - The maximal sieve is dense-covering at every object.
-  - The dense topology lies between the trivial and discrete topologies.
-  - The explicit membership characterization (`dense_covering`).
-  - Pullback stability: dense-covering is stable under base change.
+  - Le crible maximal est dense-couvrant en tout objet.
+  - La topologie dense est comprise entre les topologies triviale et discrète.
+  - La caractérisation d'appartenance explicite (`dense_covering`).
+  - La stabilité par pullback : dense-couvrant est stable par changement de base.
 
-A naming subtlety worth flagging for learners: in Mathlib, `C` is an
-*explicit* parameter of `GrothendieckTopology.trivial` and `.discrete` but
-an *implicit* one of `.dense` (they live in different `variable` blocks of
-the Mathlib source). Hence we write `trivial C` and `discrete C` but bare
-`dense` (letting Lean infer `C`); writing `dense C` would instead apply the
-topology to `C` as an object via the `DFunLike` coercion.
+Une subtilité de nommage à signaler : dans Mathlib, `C` est un paramètre
+*explicite* de `GrothendieckTopology.trivial` et `.discrete` mais *implicite*
+de `.dense` (les déclarations `variable` diffèrent dans la source Mathlib). On
+écrit donc `trivial C` et `discrete C` mais `dense` nu (Lean infère `C`) ;
+écrire `dense C` appliquerait plutôt la topologie à `C` comme objet via la
+coercion `DFunLike`.
 
-Epic #1646, Phase 7 (#2159). All `sorry`s eliminated at creation.
+### Note d'accessibilité (Epics #1452/#1453)
+
+Ce module expose **7 theorem** sur la **topologie dense** (treillis complet des
+topologies de Grothendieck), accessibilité progressive par 4 sections
+thématiques : (1) crible maximal dense-couvrant, (2) ordre trivial/dense/discret,
+(3) caractérisation d'appartenance explicite, (4) stabilité par pullback.
+
+### Convention i18n (EPIC #4980 ratifiée par user 2026-07-04)
+
+Ce module substantiel est apparié avec son jumeau anglais dans le fichier sibling
+`DenseTopology_en.lean` (modèle sibling pair, voir PR #6154 pour le pilote sur
+`Utility.lean`).
 -/
 
 import Mathlib.CategoryTheory.Sites.Grothendieck
 
-namespace Grothendieck
+namespace Grothendieck.DenseTopology
 
 open CategoryTheory
 
 /-!
-## The maximal sieve is dense-covering
+## 1. Le crible maximal est dense-couvrant
 
-Every arrow `f : Y ⟶ X` is refined by itself via the identity: `g := 𝟙 Y`
-gives `⊤ (𝟙 Y ≫ f)`. So the maximal sieve covers for the dense topology at
-every object — this is the identity axiom of a Grothendieck topology,
-specialized to the dense topology.
+Toute flèche f : Y ⟶ X est raffinée par elle-même via l'identité :
+g := 𝟙 Y donne ⊤ (𝟙 Y ≫ f). Donc le crible maximal couvre pour la
+topologie dense en tout objet — c'est l'axiome d'identité d'une topologie
+de Grothendieck, spécialisé à la topologie dense.
 -/
 
-/-- The maximal sieve is dense-covering at every object.
-    Unfolds `dense_covering` and witnesses the refinement via `𝟙`. -/
+
+/-- Le crible maximal est dense-couvrant en tout objet.
+    Déplie `dense_covering` et témoigne du raffinement via 𝟙. -/
+
 theorem dense_top_mem {C : Type*} [Category C] (X : C) :
     (⊤ : Sieve X) ∈ GrothendieckTopology.dense X := by
   rw [GrothendieckTopology.dense_covering]
@@ -55,33 +68,37 @@ theorem dense_top_mem {C : Type*} [Category C] (X : C) :
   exact ⟨Y, 𝟙 Y, trivial⟩
 
 /-!
-## The dense topology lies between trivial and discrete
+## 2. La topologie dense est comprise entre triviale et discrète
 
-The trivial (coarsest) topology is below the dense topology, and the dense
-topology is below the discrete (finest) topology. These follow directly from
-the complete lattice structure on `GrothendieckTopology C`.
+La topologie triviale (la plus grossière) est en-dessous de la topologie dense,
+et la topologie dense est en-dessous de la topologie discrète (la plus fine).
+Cela découle directement de la structure de treillis complet sur
+`GrothendieckTopology C`.
 
-Note that `dense` carries `C` implicitly (unlike `trivial`/`discrete`), so
-it is written without an explicit argument here — Lean infers it from the
-expected type.
+Notez que `dense` porte `C` implicitement (contrairement à `trivial`/`discrete`),
+d'où on l'écrit sans argument explicite ici — Lean l'infère du type attendu.
 -/
 
-/-- The trivial topology is below the dense topology. -/
+
+/-- La topologie triviale est en-dessous de la topologie dense. -/
+
 theorem trivial_le_dense {C : Type*} [Category C] :
     (GrothendieckTopology.trivial C : GrothendieckTopology C) ≤
       GrothendieckTopology.dense := by
   rw [GrothendieckTopology.trivial_eq_bot]
   exact bot_le
 
-/-- The dense topology is below the discrete topology. -/
+/-- La topologie dense est en-dessous de la topologie discrète. -/
+
 theorem dense_le_discrete {C : Type*} [Category C] :
     (GrothendieckTopology.dense : GrothendieckTopology C) ≤
       GrothendieckTopology.discrete C := by
   rw [GrothendieckTopology.discrete_eq_top]
   exact le_top
 
-/-- Every dense topology lies between trivial and discrete:
+/-- Toute topologie dense est comprise entre triviale et discrète :
     ⊥ ≤ dense ≤ ⊤. -/
+
 theorem trivial_le_dense_le_discrete {C : Type*} [Category C] :
     (GrothendieckTopology.trivial C : GrothendieckTopology C) ≤
       GrothendieckTopology.dense ∧
@@ -90,42 +107,48 @@ theorem trivial_le_dense_le_discrete {C : Type*} [Category C] :
   ⟨trivial_le_dense, dense_le_discrete⟩
 
 /-!
-## Explicit membership characterization
+## 3. Caractérisation d'appartenance explicite
 
-A sieve `S` is dense-covering exactly when every incoming arrow can be
-refined into `S`. This is the definitional `dense_covering` iff,
-repackaged as forward and backward directions for readability.
+Un crible S est dense-couvrant si et seulement si toute flèche entrante admet
+un raffinement dans S. C'est l'équivalence définitionnelle `dense_covering`,
+reconditionnée en directions aller et retour pour la lisibilité.
 -/
 
-/-- If every incoming arrow `f : Y ⟶ X` can be refined into `S`, then `S`
-    is dense-covering. Forward direction is definitional (`Iff.rfl`). -/
+
+/-- Si toute flèche entrante f : Y ⟶ X admet un raffinement dans S, alors S
+    est dense-couvrant. La direction aller est définitionnelle (`Iff.rfl`). -/
+
 theorem mem_dense_of_refines {C : Type*} [Category C] {X : C} {S : Sieve X}
     (h : ∀ {Y : C} (f : Y ⟶ X), ∃ (Z : _) (g : Z ⟶ Y), S.arrows (g ≫ f)) :
     S ∈ GrothendieckTopology.dense X := by
   rw [GrothendieckTopology.dense_covering]
   exact h
 
-/-- A dense-covering sieve refines every incoming arrow `f : Y ⟶ X`.
-    Backward direction of `dense_covering`, made into a usable lemma. -/
+/-- Un crible dense-couvrant raffine toute flèche entrante f : Y ⟶ X.
+    Direction retour de `dense_covering`, mise en lemme exploitable. -/
+
 theorem dense_refines_of_mem {C : Type*} [Category C] {X : C} {S : Sieve X}
     (hS : S ∈ GrothendieckTopology.dense X) {Y : C} (f : Y ⟶ X) :
     ∃ (Z : _) (g : Z ⟶ Y), S.arrows (g ≫ f) :=
   GrothendieckTopology.dense_covering.mp hS f
 
 /-!
-## Pullback stability
+## 4. Stabilité par pullback
 
-Dense-covering is stable under pullback: if `S` is dense-covering on `X` and
-`f : Y ⟶ X`, then `Sieve.pullback f S` is dense-covering on `Y`. This is the
-stability axiom of the Grothendieck topology, specialized to `dense`.
+La propriété dense-couvrant est stable par pullback : si S est dense-couvrant
+sur X et f : Y ⟶ X, alors `Sieve.pullback f S` est dense-couvrant sur Y.
+C'est l'axiome de stabilité d'une topologie de Grothendieck, spécialisé à
+`dense`.
 -/
 
-/-- The pullback of a dense-covering sieve is dense-covering.
-    This is `GrothendieckTopology.pullback_stable` applied to the dense
-    topology. Note `dense` is written without an explicit `C` argument. -/
+
+/-- Le pullback d'un crible dense-couvrant est dense-couvrant.
+    C'est `GrothendieckTopology.pullback_stable` appliqué à la topologie dense.
+    Notez que `dense` s'écrit sans argument explicite `C`. -/
+
 theorem dense_pullback_stable {C : Type*} [Category C] {X Y : C}
     {S : Sieve X} (hS : S ∈ GrothendieckTopology.dense X) (f : Y ⟶ X) :
     Sieve.pullback f S ∈ GrothendieckTopology.dense Y :=
   GrothendieckTopology.dense.pullback_stable f hS
 
-end Grothendieck
+end Grothendieck.DenseTopology

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DenseTopology.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DenseTopology.lean
@@ -1,4 +1,5 @@
--/
+/-
+
 # Hommage Grothendieck — Partie 12 : La topologie dense
 
 Copyright (c) 2026 CoursIA. All rights reserved.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DenseTopology_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DenseTopology_en.lean
@@ -1,4 +1,5 @@
--/
+/-
+
 # Grothendieck tribute — Part 12: The dense topology
 
 Copyright (c) 2026 CoursIA. All rights reserved.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DenseTopology_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/DenseTopology_en.lean
@@ -1,0 +1,128 @@
+-/
+# Grothendieck tribute — Part 12: The dense topology
+
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under the Apache 2.0 license, see LICENSE file at the repository root.
+
+## The dense topology (EN sibling mirror)
+
+This module is the English-language mirror of `DenseTopology.lean` (FR canonical).
+Per the EPIC #4980 convention (ratified by user 2026-07-04), the FR-first file is
+the canonical source; this sibling carries the same theorems, signatures, and proof
+bodies, with English documentation. Anti-§D byte-identity (L298) holds: every
+`theorem` signature, `def`, `import`, `open`, and proof body is BYTE-IDENTICAL to
+the FR canonical — only the docstrings and headers differ. The namespace
+suffix is `Grothendieck.DenseTopology_en` to avoid collisions.
+
+For the canonical French version, see `DenseTopology.lean`.
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.DenseTopology_en
+
+open CategoryTheory
+
+/-!
+## 1. The maximal sieve is dense-covering
+
+Every arrow `f : Y ⟶ X` is refined by itself via the identity: `g := 𝟙 Y`
+gives `⊤ (𝟙 Y ≫ f)`. So the maximal sieve covers for the dense topology at
+every object — this is the identity axiom of a Grothendieck topology,
+specialized to the dense topology.
+-/
+
+
+/-- The maximal sieve is dense-covering at every object.
+    Unfolds `dense_covering` and witnesses the refinement via 𝟙. -/
+
+theorem dense_top_mem {C : Type*} [Category C] (X : C) :
+    (⊤ : Sieve X) ∈ GrothendieckTopology.dense X := by
+  rw [GrothendieckTopology.dense_covering]
+  intro Y _f
+  exact ⟨Y, 𝟙 Y, trivial⟩
+
+/-!
+## 2. The dense topology lies between trivial and discrete
+
+The trivial (coarsest) topology is below the dense topology, and the dense
+topology is below the discrete (finest) topology. These follow directly from
+the complete lattice structure on `GrothendieckTopology C`.
+
+Note that `dense` carries `C` implicitly (unlike `trivial`/`discrete`), so
+it is written without an explicit argument here — Lean infers it from the
+expected type.
+-/
+
+
+/-- The trivial topology is below the dense topology. -/
+
+theorem trivial_le_dense {C : Type*} [Category C] :
+    (GrothendieckTopology.trivial C : GrothendieckTopology C) ≤
+      GrothendieckTopology.dense := by
+  rw [GrothendieckTopology.trivial_eq_bot]
+  exact bot_le
+
+/-- The dense topology is below the discrete topology. -/
+
+theorem dense_le_discrete {C : Type*} [Category C] :
+    (GrothendieckTopology.dense : GrothendieckTopology C) ≤
+      GrothendieckTopology.discrete C := by
+  rw [GrothendieckTopology.discrete_eq_top]
+  exact le_top
+
+/-- Every dense topology lies between trivial and discrete:
+    ⊥ ≤ dense ≤ ⊤. -/
+
+theorem trivial_le_dense_le_discrete {C : Type*} [Category C] :
+    (GrothendieckTopology.trivial C : GrothendieckTopology C) ≤
+      GrothendieckTopology.dense ∧
+    (GrothendieckTopology.dense : GrothendieckTopology C) ≤
+      GrothendieckTopology.discrete C :=
+  ⟨trivial_le_dense, dense_le_discrete⟩
+
+/-!
+## 3. Explicit membership characterization
+
+A sieve `S` is dense-covering exactly when every incoming arrow can be
+refined into `S`. This is the definitional `dense_covering` iff,
+repackaged as forward and backward directions for readability.
+-/
+
+
+/-- If every incoming arrow `f : Y ⟶ X` can be refined into `S`, then `S`
+    is dense-covering. Forward direction is definitional (`Iff.rfl`). -/
+
+theorem mem_dense_of_refines {C : Type*} [Category C] {X : C} {S : Sieve X}
+    (h : ∀ {Y : C} (f : Y ⟶ X), ∃ (Z : _) (g : Z ⟶ Y), S.arrows (g ≫ f)) :
+    S ∈ GrothendieckTopology.dense X := by
+  rw [GrothendieckTopology.dense_covering]
+  exact h
+
+/-- A dense-covering sieve refines every incoming arrow `f : Y ⟶ X`.
+    Backward direction of `dense_covering`, made into a usable lemma. -/
+
+theorem dense_refines_of_mem {C : Type*} [Category C] {X : C} {S : Sieve X}
+    (hS : S ∈ GrothendieckTopology.dense X) {Y : C} (f : Y ⟶ X) :
+    ∃ (Z : _) (g : Z ⟶ Y), S.arrows (g ≫ f) :=
+  GrothendieckTopology.dense_covering.mp hS f
+
+/-!
+## 4. Pullback stability
+
+Dense-covering is stable under pullback: if `S` is dense-covering on `X` and
+`f : Y ⟶ X`, then `Sieve.pullback f S` is dense-covering on `Y`. This is the
+stability axiom of the Grothendieck topology, specialized to `dense`.
+-/
+
+
+/-- The pullback of a dense-covering sieve is dense-covering.
+    This is `GrothendieckTopology.pullback_stable` applied to the dense
+    topology. Note `dense` is written without an explicit `C` argument. -/
+
+theorem dense_pullback_stable {C : Type*} [Category C] {X Y : C}
+    {S : Sieve X} (hS : S ∈ GrothendieckTopology.dense X) (f : Y ⟶ X) :
+    Sieve.pullback f S ∈ GrothendieckTopology.dense Y :=
+  GrothendieckTopology.dense.pullback_stable f hS
+
+end Grothendieck.DenseTopology_en


### PR DESCRIPTION
## docs(lean-i18n): migrate grothendieck_lein/Grothendieck/DenseTopology to FR canonical + EN sibling pair

**12ᵉ sous-module `grothendieck_lein` Phase 2+** migré vers convention **sibling pair** ratifiée 2026-07-04 (EPIC #4980) : **FR-first canonical** (`DenseTopology.lean`, namespace `Grothendieck.DenseTopology`) + **EN sibling mirror** (`DenseTopology_en.lean`, namespace `Grothendieck.DenseTopology_en`).

**Pilote** : PR #6154 (`decision_theory_lean/Utility`) MERGED 2026-07-12 = c.398 day. **Précédents sibling pair `grothendieck_lein`** : PR #6275 c.398 Calibration (10ᵉ Phase 2+), PR #6277 c.399 Subcanonical (11ᵉ Phase 2+). **Cette PR = continuation rollout épique**.

---

### Module

**DenseTopology.lean** = hommage Grothendieck **Partie 12** (la topologie dense, ou `¬∀`-topologie, ou topologie de la double négation). C'est une des topologies de Grothendieck standard, ni triviale ni discrète. **7 theorem** sur **4 sections thématiques** :

1. **Crible maximal dense-couvrant** — `dense_top_mem` : démontre que tout crible maximal est dense-couvrant via le témoin `𝟙 Y`.
2. **Ordre trivial/dense/discret** — `trivial_le_dense`, `dense_le_discrete`, `trivial_le_dense_le_discrete` : la topologie dense est comprise entre triviale (coarsest) et discrète (finest), via le complete lattice `GrothendieckTopology C`.
3. **Caractérisation d'appartenance explicite** — `mem_dense_of_refines`, `dense_refines_of_mem` : forward/backward de `dense_covering` (définitionnelle `Iff.rfl`).
4. **Stabilité par pullback** — `dense_pullback_stable` : `Sieve.pullback f S` reste dense-couvrant si `S` l'est, via `GrothendieckTopology.pullback_stable`.

**Densité** : 1.291 thm/KB (7 theorem / 5423 B origin) — module substantiel, registre canonical-leverage Mathlib 4.

**Subtilité de nommage** (note pédagogique dans le header FR) : `dense` est *implicite* en `C` dans Mathlib (contrairement à `trivial C` et `discrete C` qui sont *explicites*) ; écrire `dense C` appliquerait la topologie à `C` comme objet via `DFunLike`.

---

### Sibling pair — convention ratifiée 2026-07-04 (EPIC #4980)

| Fichier | Rôle | Namespace | Lignes | Bytes |
|---------|------|-----------|-------:|------:|
| `DenseTopology.lean` | **FR canonical** (FR-first) | `Grothendieck.DenseTopology` | 154 LF | 6237 B |
| `DenseTopology_en.lean` | **EN sibling mirror** | `Grothendieck.DenseTopology_en` | 128 LF | 4827 B |
| `lakefile.lean` | auto-discovery `Grothendieck.*` glob pattern | n/a | +2/-1 | (modification) |

**Modèle sibling pair** (cf PR #6154 pilote) :
- **FR canonical** = source de vérité, FR-first (docstrings FR + commentaires FR)
- **EN sibling** = miroir anglais, namespace suffix `_en` pour anti-collision imports
- **Préservation byte-identity** sur theorem signatures + proof bodies + import + open + universe (cf ci-dessous)

---

### Anti-§D byte-identity L298 strict (vérifié byte-pour-byte)

| Élément | Statut |
|---------|--------|
| 1 `import Mathlib.CategoryTheory.Sites.Grothendieck` | byte-identique LF FR/EN |
| 0 `universe` (DenseTopology n'a pas `universe v u`) | n/a |
| 1 `open CategoryTheory` | byte-identique LF FR/EN |
| 7 `theorem` signatures | byte-identique LF FR/EN |
| 0 `def` signatures | n/a |
| 7 proof bodies | byte-identique LF FR/EN (vérifiés via extraction regex) |
| 0 sorry code | (module theorems purs) |
| `namespace Grothendieck.DenseTopology` (FR) vs `namespace Grothendieck.DenseTopology_en` (EN) | suffix distinct |
| `end Grothendieck.DenseTopology` (FR) vs `end Grothendieck.DenseTopology_en` (EN) | suffix distinct |
| 0 lemma / 0 example / 0 #eval! / 0 structure+inductive+abbrev | n/a |

**Encodage** : UTF-8 no-BOM, LF-only (CR=0 strict) préservé nativement.

---

### Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG` byte-identique origin/main (pas de régénération catalogue sur branche)
- **R2 rebase frais** : base `1e69d7cdc`
- **R3 atomique** : 3 fichiers / 1 feature (= sibling pair migration) / 1 domaine (Lean i18n)
- **R4 partial** : `See #4980` (Epic Phase 2, ne ferme pas l'epic)
- **R5.4b MUST anti-tunneling** : c.400 = **6ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` Phase 2+ post-c.394** = continuation rollout épique
- **L143 SAFE cross-owner** : `grothendieck_lein` registre propre po-2023
- **L268 #4 LF-only** : baseline CR=0 strict préservée nativement (origin/main 5423 B LF=131 CR=0 → 6237 B LF=154 CR=0 FR / 4827 B LF=128 CR=0 EN)
- **L279 worker discipline** : Math-Vérif **COMMENTED 30ᵉ** consécutif c.371-c.400, JAMAIS `--approve`, JAMAIS `gh pr merge`
- **L281 rebase frais** : base `1e69d7cdc`
- **L298 anti-§D byte-identity** : 1 import + 0 universe + 1 open + 7 theorem signatures + 0 def signatures + 7 proof bodies BYTE-IDENTIQUE LF vs original main (cf détail ci-dessus)
- **L327 additif strict sur la sémantique** : +211/-58 (avec waiver convention ratifiée 04/07 sibling pair)
- **L335 anti-mono Sustained** : c.395-c.397 = 3 cycles R6 Sustained intra-R6 sur `conway_lein` ≠ ≠ ≠ post-c.394 = exploration `Life/*` ; c.398 = PIVOT strict obligatoire retour `grothendieck_lein` Phase 2+ ; c.399 = continuation rollout épique `grothendieck_lein` Phase 2+ (11ᵉ sous-module Subcanonical) ; **c.400 = continuation rollout épique `grothendieck_lein` Phase 2+ (12ᵉ sous-module DenseTopology)**

**Mandat user 2026-07-11 Substance > Sweep** : extension FR+EN sibling pair de fond (DenseTopology 7 theorem topologie dense GROTHENDIECK ≠ doc-hygiène Phase 2 README).

**Mandat user 2026-06-22 Stop & Repair** : JAMAIS scrub SORTIE cellule, re-executer, triage A/B/C — appliqué via reconstruction byte-pour-byte Python du fichier après 5 erreurs détectées (parenthèse manquante, regex sur sous-pattern, comptage `open` dupliqué, comptage `theorem` prefix collision, typo `grothendieck_lein` vs `grothendieck_lean`).

---

### Risque Unicode élevé (leçon c.398-L1 critique)

**DenseTopology.lean est NOT ASCII only** (147 non-ASCII chars vs 0 pour c.399 Subcanonical) :
- U+27F6 ⟶ (long arrow, 11 occurrences dans theorem signatures)
- U+2264 ≤ (6), U+226B ≫ (4) — ordre treillis
- U+2208 ∈ (5) — `GrothendieckTopology.dense X`
- U+1D7D9 𝟙 (4) — `𝟙 Y` dans preuve
- U+22A4 ⊤ (3), U+22A5 ⊥ (1) — tamis max/min
- U+2200 ∀ (2), U+2203 ∃ (2) — quantificateurs
- U+27E8/U+27E9 ⟨⟩ (2 each) — pairs dans preuves
- U+00AC ¬ (1), U+2227 ∧ (1), U+2014 — (4) em-dash header

**Leçon c.398-L1** : Bash heredoc corrompt les symboles Unicode Math (`Y ⟶ X` U+27F6 → `Y ⟒ X` U+207E). **Pour toute édition de `.lean` avec Unicode portés par theorem signatures, passer par script Python byte-pour-byte**, JAMAIS via Bash heredoc. **Script Python `rebuild_dense_fr.py`** (scratchpad) : 5 corrections manuelles + script byte-pour-byte avec chaînes Python natives (UTF-8 géré par `open(..., 'wb')`, pas de corruption).

---

### Cross-references c.400

- c.398 #6275 `Grothendieck/Calibration` (10ᵉ Phase 2+, 4 theorem calibration ladder P1-P4) ← pattern sibling pair reproduit
- c.399 #6277 `Grothendieck/Subcanonical` (11ᵉ Phase 2+, 5 theorem + 1 def sous-canonicalité bridge Yoneda → faisceaux) ← pattern sibling pair reproduit
- **c.400 #XXXX `Grothendieck/DenseTopology` (cette PR, 12ᵉ Phase 2+, 7 theorem topologie dense bridge ¬∀-topologie, densité 1.291 thm/KB, continuation rollout épique post-c.399)**
- PR #6154 `decision_theory_lean/Utility` (pilote sibling pair MERGED 2026-07-12 = c.398 day)

---

### Backlog c.401+

- **(a) `grothendieck_lein` Phase 2+ 10 restants après c.400** : CoverageGen, SheafHom, SheafCohomology/{MayerVietoris,Basic}, ConstantSheaf, ZariskiSite, Conservative, MayerVietorisSquare, SitePoints, SchemesTour, LeftExact, SheafCohomology/Cech
- **(b) 5 PRs bilingual inline legacy grothendieck_lein à migrer en sibling pair** (#6230/#6235/#6242/#6256/#6259) — DÉCISION ai-01 REQUISE avant merges ; **geler merges**
- **(c) 4 PRs bilingual inline legacy conway_lein/Life** (#6262/#6268/#6273) — DÉCISION ai-01 REQUISE
- **(d) `conway_lein/Life/*` 10 restants** : Computation, Hashlife, **HashlifeCorrectness** (étape 3/3 bridge N2 — sous condition PR #6219 N3-prep intégré AVANT), HashlifeMarginDemo, HashlifeMemo, MacroCell, Oscillators, Pillars, RLE, Spaceships
- **(e) Lemmas 3 restants** : DoomsdayLemmas, FractranLemmas, LookAndSayLemmas
- (f) EN-dominants : mathlib_examples/Basic.lean, erc20_lean/ERC20.lean (registre neuf, pas de L335 R5.4b MUST applicable)
- (g) hors-Lean : #5985 Phase 2, #6051
- (h) GPU #5105 po-2024

**L335 R5.4b MUST** : c.400 = continuation R6 Sustained `grothendieck_lein` Phase 2+. **c.401 = `CoverageGen` (13ᵉ sous-module Phase 2+) recommandé si la décision rétroactive PRs c.388-c.394 n'est pas tranchée et que les merges legacy restent gelés**.

---

— worker po-2023 (Math-Vérif COMMENTED 30ᵉ consécutif c.371-c.400)