### PR TITLE
fix(genai): suppress ipykernel path-leak in 01-3-Basic-Image-Operations (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
@@ -243,6 +243,13 @@
     "import numpy as np\n",
     "import matplotlib\n",
     "matplotlib.use('Agg')  # Headless backend for Papermill\n",
+    "import warnings\n",
+    "# Agg est non-interactif par conception sous Papermill ; plt.show() emet un\n",
+    "# UserWarning (« FigureCanvasAgg is non-interactive ») dont la traceback\n",
+    "# incorpore le chemin temporaire du kernel (ipykernel_<pid>\\<hash>.py),\n",
+    "# ce qui fuite le chemin utilisateur local dans les sorties commitees.\n",
+    "# On supprime a la cause (secrets-hygiene regle 6 : fixer + re-executer).\n",
+    "warnings.filterwarnings(\"ignore\", message=\"FigureCanvasAgg is non-interactive\")\n",
     "import matplotlib.pyplot as plt\n",
     "from matplotlib.gridspec import GridSpec\n",
     "import logging\n",
@@ -367,17 +374,15 @@
       "   📐 Dimensions: 800x600\n",
       "   🎨 Mode: RGB\n",
       "   📦 Format: JPEG\n",
-      "   💾 Taille mémoire: ~1406.2 KB\n",
-      "\n",
-      "✅ Image de base chargée et analysée\n"
+      "   💾 Taille mémoire: ~1406.2 KB\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_43332\\2868962829.py:79: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
-      "  plt.show()\n"
+      "\n",
+      "✅ Image de base chargée et analysée\n"
      ]
     }
    ],
@@ -536,14 +541,6 @@
       "\n",
       "✅ 8 transformations effectuées\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_43332\\2356990642.py:75: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
-      "  plt.show()\n"
-     ]
     }
    ],
    "source": [
@@ -671,7 +668,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "f1dbe798",
    "metadata": {
     "execution": {
@@ -695,26 +692,31 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "🎨 FILTRES ET EFFETS"
+      "🎨 FILTRES ET EFFETS\n",
+      "==================================================\n",
+      "\n",
+      "1️⃣ Blur (Flou)\n",
+      "   ✅ Blur basique et Gaussian Blur appliqués\n",
+      "\n",
+      "2️⃣ Sharpen (Augmentation netteté)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "==================================================\n",
-      "\n",
-      "1️⃣ Blur (Flou)\n",
-      "   ✅ Blur basique et Gaussian Blur appliqués\n",
-      "\n",
-      "2️⃣ Sharpen (Augmentation netteté)\n",
       "   ✅ Sharpen et UnsharpMask appliqués\n",
       "\n",
       "3️⃣ Edge Detection (Détection contours)\n",
       "   ✅ Find Edges et Edge Enhance appliqués\n",
       "\n",
-      "4️⃣ Contour et Emboss (Relief)\n",
+      "4️⃣ Contour et Emboss (Relief)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "   ✅ Contour et Emboss appliqués\n",
       "\n",
       "5️⃣ Ajustements (Brightness, Contrast, Color)\n",
@@ -727,14 +729,6 @@
      "text": [
       "\n",
       "✅ 14 filtres/effets appliqués\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_43332\\1974090558.py:87: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown\n",
-      "  plt.show()\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary

Fixes a committed **ipykernel path-leak** in `GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb`. Part of EPIC **#3801** (axis-2 SOTA / path-leak defect class). Sibling to **#6261** (Search-4) and **#6266** (SW-13 cProfile) — same defect class, same cause-level fix method.

## Defect

Cell 4 (matplotlib config) already sets `matplotlib.use('Agg')` for headless Papermill execution, but `plt.show()` under the Agg backend emits a benign `UserWarning`:

```
C:\Users\jsboi\AppData\Local\Temp\ipykernel_43332\2868962829.py:79: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
  plt.show()
```

The warning traceback embeds the **kernel temp path** (`ipykernel_<pid>\<hash>.py` under `C:\Users\<user>\AppData\Local\Temp\`), leaking the local user path into **committed outputs** (cells 6, 8, 12 — the image-loading, transform, and filter display cells).

## Fix (cause-level — secrets-hygiene règle 6 / Stop & Repair)

Insert `warnings.filterwarnings(\"ignore\", message=\"FigureCanvasAgg is non-interactive\")` right after `matplotlib.use('Agg')` in cell 4, with an explanatory comment. The warning is purely informational (Agg **cannot** show interactively — expected under headless execution), so suppressing it is legitimate — not hiding a real error. **No output is hand-edited**: the cause is fixed and the notebook is **re-executed** so the leak lines are gone from the regenerated outputs.

## Verification (firsthand, §D notebook PR)

```
python -m papermill 01-3...ipynb OUT --kernel python3 --cwd <dir> --execution-timeout 240
→ 31/31 cells executed, 0 errors, 11s
```

| Check | Result |
|-------|--------|
| ipykernel leaks before | 3 (cells 6, 8, 12) |
| ipykernel leaks after | **0** |
| `grep -nE "raise NotImplementedError\|assert False\|1/0"` | 0 (C.1 OK) |
| code cells with `execution_count: null` | 0 (C.2 intact) |
| residual `C:\Users\...\Temp` in any output | 0 |
| `raise NotImplementedError` / `1/0` | none |

**Surgical splice** (SW-13 c.166 method — avoids papermill str→list source-normalization churn): the final notebook differs from `origin/main` by **cell 4 source** (the +7-line fix) + **cells 6/8/12 outputs** (regenerated, warning lines removed) only. `git diff --stat`: +26/−32. Source type normalization (papermill str→list) explicitly avoided — origin/main source types preserved.

**Local-runnable (RECOVERABLE-LOCAL, règle F)**: PIL + requests + matplotlib + numpy, public `picsum.photos` test image (no API key), `create_test_image` synthetic fallback if offline. No GenAI service / GPU / QC Cloud needed.

## Scope

1 file, 1 notebook. No Lean, no catalog touch, no README. Base 0 commits behind `origin/main` (catalog-pr-hygiene HARD 2).

See #3801, #6261, #6266, #3436 (path-leak umbrella CLOSED, defect class still surfacing).