### PR TITLE
fix(rl): suppress user-path leaks in rl_1 cartpole (pip -q + device=cpu + Monitor + video-log mute)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
@@ -62,10 +62,10 @@
    "id": "3ffcce8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:00:41.036405Z",
-     "iopub.status.busy": "2026-06-03T15:00:41.034751Z",
-     "iopub.status.idle": "2026-06-03T15:00:42.490105Z",
-     "shell.execute_reply": "2026-06-03T15:00:42.489559Z"
+     "iopub.execute_input": "2026-07-12T07:16:53.960918Z",
+     "iopub.status.busy": "2026-07-12T07:16:53.960918Z",
+     "iopub.status.idle": "2026-07-12T07:16:57.708405Z",
+     "shell.execute_reply": "2026-07-12T07:16:57.707871Z"
     },
     "id": "gWskDE2c9WoN",
     "papermill": {
@@ -82,64 +82,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: stable-baselines3>=2.0.0a4 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from stable-baselines3[extra]>=2.0.0a4) (2.7.0)\n",
-      "Requirement already satisfied: moviepy in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (2.2.1)\n",
-      "Requirement already satisfied: gymnasium<1.3.0,>=0.29.1 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (1.2.0)\n",
-      "Requirement already satisfied: numpy<3.0,>=1.20 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (2.2.6)\n",
-      "Requirement already satisfied: torch<3.0,>=2.3 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (2.11.0+cu128)\n",
-      "Requirement already satisfied: cloudpickle in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (3.1.1)\n",
-      "Requirement already satisfied: pandas in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (3.0.3)\n",
-      "Requirement already satisfied: matplotlib in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (3.10.8)\n",
-      "Requirement already satisfied: typing-extensions>=4.3.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from gymnasium<1.3.0,>=0.29.1->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (4.15.0)\n",
-      "Requirement already satisfied: farama-notifications>=0.0.1 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from gymnasium<1.3.0,>=0.29.1->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (0.0.4)\n",
-      "Requirement already satisfied: filelock in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from torch<3.0,>=2.3->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (3.19.1)\n",
-      "Requirement already satisfied: setuptools<82 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from torch<3.0,>=2.3->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (80.10.2)\n",
-      "Requirement already satisfied: sympy>=1.13.3 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from torch<3.0,>=2.3->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (1.14.0)\n",
-      "Requirement already satisfied: networkx>=2.5.1 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from torch<3.0,>=2.3->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (3.5)\n",
-      "Requirement already satisfied: jinja2 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from torch<3.0,>=2.3->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (3.1.6)\n",
-      "Requirement already satisfied: fsspec>=0.8.5 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from torch<3.0,>=2.3->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (2026.3.0)\n",
-      "Requirement already satisfied: decorator<6.0,>=4.0.2 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from moviepy) (5.2.1)\n",
-      "Requirement already satisfied: imageio<3.0,>=2.5 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from moviepy) (2.37.0)\n",
-      "Requirement already satisfied: imageio_ffmpeg>=0.2.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from moviepy) (0.6.0)\n",
-      "Requirement already satisfied: proglog<=1.0.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from moviepy) (0.1.12)\n",
-      "Requirement already satisfied: python-dotenv>=0.10 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from moviepy) (1.2.2)\n",
-      "Requirement already satisfied: pillow<12.0,>=9.2.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from moviepy) (11.3.0)\n",
-      "Requirement already satisfied: tqdm in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from proglog<=1.0.0->moviepy) (4.67.3)\n",
-      "Requirement already satisfied: opencv-python in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from stable-baselines3[extra]>=2.0.0a4) (4.12.0.88)\n",
-      "Requirement already satisfied: pygame in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from stable-baselines3[extra]>=2.0.0a4) (2.6.1)\n",
-      "Requirement already satisfied: tensorboard>=2.9.1 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from stable-baselines3[extra]>=2.0.0a4) (2.20.0)\n",
-      "Requirement already satisfied: psutil in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from stable-baselines3[extra]>=2.0.0a4) (7.2.2)\n",
-      "Requirement already satisfied: rich in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from stable-baselines3[extra]>=2.0.0a4) (14.2.0)\n",
-      "Requirement already satisfied: ale-py>=0.9.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from stable-baselines3[extra]>=2.0.0a4) (0.11.2)\n",
-      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from sympy>=1.13.3->torch<3.0,>=2.3->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (1.3.0)\n",
-      "Requirement already satisfied: absl-py>=0.4 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from tensorboard>=2.9.1->stable-baselines3[extra]>=2.0.0a4) (2.3.1)\n",
-      "Requirement already satisfied: grpcio>=1.48.2 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from tensorboard>=2.9.1->stable-baselines3[extra]>=2.0.0a4) (1.80.0)\n",
-      "Requirement already satisfied: markdown>=2.6.8 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from tensorboard>=2.9.1->stable-baselines3[extra]>=2.0.0a4) (3.9)\n",
-      "Requirement already satisfied: packaging in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from tensorboard>=2.9.1->stable-baselines3[extra]>=2.0.0a4) (26.1)\n",
-      "Requirement already satisfied: protobuf!=4.24.0,>=3.19.6 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from tensorboard>=2.9.1->stable-baselines3[extra]>=2.0.0a4) (6.31.1)\n",
-      "Requirement already satisfied: tensorboard-data-server<0.8.0,>=0.7.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from tensorboard>=2.9.1->stable-baselines3[extra]>=2.0.0a4) (0.7.2)\n",
-      "Requirement already satisfied: werkzeug>=1.0.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from tensorboard>=2.9.1->stable-baselines3[extra]>=2.0.0a4) (3.1.1)\n",
-      "Requirement already satisfied: MarkupSafe>=2.1.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from werkzeug>=1.0.1->tensorboard>=2.9.1->stable-baselines3[extra]>=2.0.0a4) (3.0.3)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from matplotlib->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (1.3.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from matplotlib->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (0.12.1)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from matplotlib->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (4.59.2)\n",
-      "Requirement already satisfied: kiwisolver>=1.3.1 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from matplotlib->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (1.4.9)\n",
-      "Requirement already satisfied: pyparsing>=3 in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from matplotlib->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (3.2.3)\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from matplotlib->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (2.9.0.post0)\n",
-      "Requirement already satisfied: six>=1.5 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from python-dateutil>=2.7->matplotlib->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (1.17.0)\n",
-      "Requirement already satisfied: tzdata in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from pandas->stable-baselines3>=2.0.0a4->stable-baselines3[extra]>=2.0.0a4) (2025.2)\n",
-      "Requirement already satisfied: markdown-it-py>=2.2.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from rich->stable-baselines3[extra]>=2.0.0a4) (4.0.0)\n",
-      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from rich->stable-baselines3[extra]>=2.0.0a4) (2.19.2)\n",
-      "Requirement already satisfied: mdurl~=0.1 in C:\\ProgramData\\miniconda3\\Lib\\site-packages (from markdown-it-py>=2.2.0->rich->stable-baselines3[extra]>=2.0.0a4) (0.1.2)\n",
-      "Requirement already satisfied: colorama in ~\\AppData\\Roaming\\Python\\Python313\\site-packages (from tqdm->proglog<=1.0.0->moviepy) (0.4.6)\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],
    "source": [
     "# Sous Windows, on ne fait pas d'apt-get.\n",
     "# %apt-get update && apt-get install ffmpeg freeglut3-dev xvfb  # Pour la visualisation sous Linux\n",
-    "%pip install \"stable-baselines3[extra]>=2.0.0a4\" moviepy"
+    "%pip install -q \"stable-baselines3[extra]>=2.0.0a4\" moviepy\n"
    ]
   },
   {
@@ -165,10 +124,10 @@
    "id": "a2c73b9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:00:42.622789Z",
-     "iopub.status.busy": "2026-06-03T15:00:42.620418Z",
-     "iopub.status.idle": "2026-06-03T15:00:55.863595Z",
-     "shell.execute_reply": "2026-06-03T15:00:55.862710Z"
+     "iopub.execute_input": "2026-07-12T07:16:57.709952Z",
+     "iopub.status.busy": "2026-07-12T07:16:57.709434Z",
+     "iopub.status.idle": "2026-07-12T07:17:00.134581Z",
+     "shell.execute_reply": "2026-07-12T07:17:00.132563Z"
     },
     "id": "U29X1-B-AIKE",
     "papermill": {
@@ -241,10 +200,10 @@
    "id": "5fd01f77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:00:55.958613Z",
-     "iopub.status.busy": "2026-06-03T15:00:55.957647Z",
-     "iopub.status.idle": "2026-06-03T15:00:55.979523Z",
-     "shell.execute_reply": "2026-06-03T15:00:55.975276Z"
+     "iopub.execute_input": "2026-07-12T07:17:00.137595Z",
+     "iopub.status.busy": "2026-07-12T07:17:00.137595Z",
+     "iopub.status.idle": "2026-07-12T07:17:00.142968Z",
+     "shell.execute_reply": "2026-07-12T07:17:00.141961Z"
     },
     "id": "BIedd7Pz9sOs",
     "papermill": {
@@ -298,10 +257,10 @@
    "id": "de6dd33c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:00:56.178027Z",
-     "iopub.status.busy": "2026-06-03T15:00:56.177456Z",
-     "iopub.status.idle": "2026-06-03T15:00:56.189119Z",
-     "shell.execute_reply": "2026-06-03T15:00:56.184699Z"
+     "iopub.execute_input": "2026-07-12T07:17:00.145267Z",
+     "iopub.status.busy": "2026-07-12T07:17:00.145267Z",
+     "iopub.status.idle": "2026-07-12T07:17:00.148457Z",
+     "shell.execute_reply": "2026-07-12T07:17:00.148457Z"
     },
     "id": "R7tKaBFrTR0a",
     "papermill": {
@@ -354,10 +313,10 @@
    "id": "6b98e551",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:00:56.395920Z",
-     "iopub.status.busy": "2026-06-03T15:00:56.392213Z",
-     "iopub.status.idle": "2026-06-03T15:00:56.419463Z",
-     "shell.execute_reply": "2026-06-03T15:00:56.413907Z"
+     "iopub.execute_input": "2026-07-12T07:17:00.150510Z",
+     "iopub.status.busy": "2026-07-12T07:17:00.150510Z",
+     "iopub.status.idle": "2026-07-12T07:17:00.152661Z",
+     "shell.execute_reply": "2026-07-12T07:17:00.152661Z"
     },
     "id": "ROUJr675TT01",
     "papermill": {
@@ -428,10 +387,10 @@
    "id": "ae321a8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:00:56.585754Z",
-     "iopub.status.busy": "2026-06-03T15:00:56.584698Z",
-     "iopub.status.idle": "2026-06-03T15:01:03.105337Z",
-     "shell.execute_reply": "2026-06-03T15:01:03.102791Z"
+     "iopub.execute_input": "2026-07-12T07:17:00.154681Z",
+     "iopub.status.busy": "2026-07-12T07:17:00.154681Z",
+     "iopub.status.idle": "2026-07-12T07:17:01.193059Z",
+     "shell.execute_reply": "2026-07-12T07:17:01.193059Z"
     },
     "id": "pUWGZp3i9wyf",
     "papermill": {
@@ -450,20 +409,12 @@
      "text": [
       "Environnement CartPole-v1 cree, modele PPO initialise avec MlpPolicy.\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Roaming\\Python\\Python313\\site-packages\\stable_baselines3\\common\\on_policy_algorithm.py:150: UserWarning: You are trying to run PPO on the GPU, but it is primarily intended to run on the CPU when not using a CNN policy (you are using ActorCriticPolicy which should be a MlpPolicy). See https://github.com/DLR-RM/stable-baselines3/issues/1245 for more info. You can pass `device='cpu'` or `export CUDA_VISIBLE_DEVICES=` to force using the CPU.Note: The model will train, but the GPU utilization will be poor and the training might take longer than on CPU.\n",
-      "  warnings.warn(\n"
-     ]
     }
    ],
    "source": [
     "env = gym.make(\"CartPole-v1\", render_mode=\"rgb_array\")\n",
-    "model = PPO(MlpPolicy, env, verbose=0)\n",
-    "print(f\"Environnement CartPole-v1 cree, modele PPO initialise avec MlpPolicy.\")"
+    "model = PPO(MlpPolicy, env, verbose=0, device='cpu')\n",
+    "print(f\"Environnement CartPole-v1 cree, modele PPO initialise avec MlpPolicy.\")\n"
    ]
   },
   {
@@ -490,10 +441,10 @@
    "id": "dddabb38",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:01:03.150711Z",
-     "iopub.status.busy": "2026-06-03T15:01:03.150005Z",
-     "iopub.status.idle": "2026-06-03T15:01:03.160031Z",
-     "shell.execute_reply": "2026-06-03T15:01:03.158850Z"
+     "iopub.execute_input": "2026-07-12T07:17:01.193059Z",
+     "iopub.status.busy": "2026-07-12T07:17:01.193059Z",
+     "iopub.status.idle": "2026-07-12T07:17:01.198055Z",
+     "shell.execute_reply": "2026-07-12T07:17:01.198055Z"
     },
     "id": "63M8mSKR-6Zt",
     "papermill": {
@@ -568,10 +519,10 @@
    "id": "00025f2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:01:03.196899Z",
-     "iopub.status.busy": "2026-06-03T15:01:03.196533Z",
-     "iopub.status.idle": "2026-06-03T15:01:03.202253Z",
-     "shell.execute_reply": "2026-06-03T15:01:03.200941Z"
+     "iopub.execute_input": "2026-07-12T07:17:01.198055Z",
+     "iopub.status.busy": "2026-07-12T07:17:01.198055Z",
+     "iopub.status.idle": "2026-07-12T07:17:01.201778Z",
+     "shell.execute_reply": "2026-07-12T07:17:01.201778Z"
     },
     "id": "s6ZNldIR-fce",
     "papermill": {
@@ -621,10 +572,10 @@
    "id": "5f778623",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:01:03.249865Z",
-     "iopub.status.busy": "2026-06-03T15:01:03.248982Z",
-     "iopub.status.idle": "2026-06-03T15:01:26.235736Z",
-     "shell.execute_reply": "2026-06-03T15:01:26.234832Z"
+     "iopub.execute_input": "2026-07-12T07:17:01.201778Z",
+     "iopub.status.busy": "2026-07-12T07:17:01.201778Z",
+     "iopub.status.idle": "2026-07-12T07:17:01.404484Z",
+     "shell.execute_reply": "2026-07-12T07:17:01.404484Z"
     },
     "id": "xDHLMA6NFk95",
     "papermill": {
@@ -638,28 +589,21 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Roaming\\Python\\Python313\\site-packages\\stable_baselines3\\common\\evaluation.py:70: UserWarning: Evaluation environment is not wrapped with a ``Monitor`` wrapper. This may result in reporting modified episode lengths and rewards, if other wrappers happen to modify these. Consider wrapping environment first with ``Monitor`` wrapper.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mean_reward:63.52 +/- 21.19\n"
+      "mean_reward:9.52 +/- 0.66\n"
      ]
     }
    ],
    "source": [
+    "from stable_baselines3.common.monitor import Monitor\n",
     "# Nous utilisons un environnement distinct pour l’évaluation\n",
-    "eval_env = gym.make(\"CartPole-v1\", render_mode=\"rgb_array\")\n",
+    "eval_env = Monitor(gym.make(\"CartPole-v1\", render_mode=\"rgb_array\"))\n",
     "\n",
     "# Agent aléatoire, avant entraînement\n",
     "mean_reward, std_reward = evaluate_policy(model, eval_env, n_eval_episodes=100)\n",
-    "print(f\"mean_reward:{mean_reward:.2f} +/- {std_reward:.2f}\")"
+    "print(f\"mean_reward:{mean_reward:.2f} +/- {std_reward:.2f}\")\n"
    ]
   },
   {
@@ -694,10 +638,10 @@
    "id": "af265070",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:01:26.266614Z",
-     "iopub.status.busy": "2026-06-03T15:01:26.266363Z",
-     "iopub.status.idle": "2026-06-03T15:02:49.393889Z",
-     "shell.execute_reply": "2026-06-03T15:02:49.392975Z"
+     "iopub.execute_input": "2026-07-12T07:17:01.406505Z",
+     "iopub.status.busy": "2026-07-12T07:17:01.406505Z",
+     "iopub.status.idle": "2026-07-12T07:17:09.126520Z",
+     "shell.execute_reply": "2026-07-12T07:17:09.125517Z"
     },
     "id": "e4cfSXIB-pTF",
     "papermill": {
@@ -749,10 +693,10 @@
    "id": "58166ed8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:02:49.438626Z",
-     "iopub.status.busy": "2026-06-03T15:02:49.438396Z",
-     "iopub.status.idle": "2026-06-03T15:04:02.892335Z",
-     "shell.execute_reply": "2026-06-03T15:04:02.891230Z"
+     "iopub.execute_input": "2026-07-12T07:17:09.128520Z",
+     "iopub.status.busy": "2026-07-12T07:17:09.128520Z",
+     "iopub.status.idle": "2026-07-12T07:17:16.879692Z",
+     "shell.execute_reply": "2026-07-12T07:17:16.879692Z"
     },
     "id": "ygl_gVmV_QP7",
     "papermill": {
@@ -826,10 +770,10 @@
    "id": "26a4f76e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:02.953352Z",
-     "iopub.status.busy": "2026-06-03T15:04:02.952995Z",
-     "iopub.status.idle": "2026-06-03T15:04:02.957767Z",
-     "shell.execute_reply": "2026-06-03T15:04:02.956522Z"
+     "iopub.execute_input": "2026-07-12T07:17:16.881697Z",
+     "iopub.status.busy": "2026-07-12T07:17:16.881697Z",
+     "iopub.status.idle": "2026-07-12T07:17:16.883993Z",
+     "shell.execute_reply": "2026-07-12T07:17:16.883993Z"
     },
     "id": "MPyfQxD5z26J",
     "papermill": {
@@ -882,10 +826,10 @@
    "id": "7ec6a191",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:02.990591Z",
-     "iopub.status.busy": "2026-06-03T15:04:02.990203Z",
-     "iopub.status.idle": "2026-06-03T15:04:02.996425Z",
-     "shell.execute_reply": "2026-06-03T15:04:02.995318Z"
+     "iopub.execute_input": "2026-07-12T07:17:16.885998Z",
+     "iopub.status.busy": "2026-07-12T07:17:16.884998Z",
+     "iopub.status.idle": "2026-07-12T07:17:16.888877Z",
+     "shell.execute_reply": "2026-07-12T07:17:16.888877Z"
     },
     "id": "SLzXxO8VMD6N",
     "papermill": {
@@ -957,10 +901,10 @@
    "id": "55b1cd72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:03.032767Z",
-     "iopub.status.busy": "2026-06-03T15:04:03.032513Z",
-     "iopub.status.idle": "2026-06-03T15:04:03.039775Z",
-     "shell.execute_reply": "2026-06-03T15:04:03.038441Z"
+     "iopub.execute_input": "2026-07-12T07:17:16.889882Z",
+     "iopub.status.busy": "2026-07-12T07:17:16.889882Z",
+     "iopub.status.idle": "2026-07-12T07:17:16.893963Z",
+     "shell.execute_reply": "2026-07-12T07:17:16.893963Z"
     },
     "id": "Trag9dQpOIhx",
     "papermill": {
@@ -1035,10 +979,10 @@
    "id": "1e544539",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:03.073453Z",
-     "iopub.status.busy": "2026-06-03T15:04:03.073045Z",
-     "iopub.status.idle": "2026-06-03T15:04:08.974476Z",
-     "shell.execute_reply": "2026-06-03T15:04:08.973262Z"
+     "iopub.execute_input": "2026-07-12T07:17:16.894991Z",
+     "iopub.status.busy": "2026-07-12T07:17:16.894991Z",
+     "iopub.status.idle": "2026-07-12T07:17:18.871343Z",
+     "shell.execute_reply": "2026-07-12T07:17:18.871343Z"
     },
     "id": "iATu7AiyMQW2",
     "papermill": {
@@ -1050,83 +994,29 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pygame\\pkgdata.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
-      "  from pkg_resources import resource_stream, resource_exists\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saving video to D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\RL\\videos\\ppo-cartpole-step-0-to-step-500.mp4\n",
-      "MoviePy - Building video D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\RL\\videos\\ppo-cartpole-step-0-to-step-500.mp4.\n",
-      "MoviePy - Writing video D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\RL\\videos\\ppo-cartpole-step-0-to-step-500.mp4\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "frame_index:   0%|          | 0/501 [00:00<?, ?it/s, now=None]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "frame_index:  10%|▉         | 49/501 [00:00<00:00, 489.91it/s, now=None]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "frame_index:  40%|████      | 201/501 [00:00<00:00, 1095.41it/s, now=None]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "frame_index:  77%|███████▋  | 384/501 [00:00<00:00, 1428.75it/s, now=None]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "                                                                          "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MoviePy - Done !\n",
-      "MoviePy - video ready D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\RL\\videos\\ppo-cartpole-step-0-to-step-500.mp4\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "record_video(\"CartPole-v1\", model, video_length=500, prefix=\"ppo-cartpole\")"
+    "import warnings\n",
+    "import os\n",
+    "import sys\n",
+    "import proglog\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\", message=\"pkg_resources is deprecated\")\n",
+    "\n",
+    "# SB3 (print) et moviepy (proglog) affichent le chemin absolu de la vidéo\n",
+    "# enregistrée — fuite du répertoire de travail. On rend moviepy muet et on\n",
+    "# redirige stdout le temps de l'enregistrement. Le fichier .mp4 reste écrit et\n",
+    "# est affiché par show_videos() dans la cellule suivante.\n",
+    "_proglog_dbl = proglog.default_bar_logger\n",
+    "proglog.default_bar_logger = lambda logger=None: proglog.MuteProgressBarLogger()\n",
+    "_saved_stdout = sys.stdout\n",
+    "sys.stdout = open(os.devnull, \"w\")\n",
+    "try:\n",
+    "    record_video(\"CartPole-v1\", model, video_length=500, prefix=\"ppo-cartpole\")\n",
+    "finally:\n",
+    "    sys.stdout.close()\n",
+    "    sys.stdout = _saved_stdout\n",
+    "    proglog.default_bar_logger = _proglog_dbl\n"
    ]
   },
   {
@@ -1152,10 +1042,10 @@
    "id": "bbb3e432",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:09.011959Z",
-     "iopub.status.busy": "2026-06-03T15:04:09.011695Z",
-     "iopub.status.idle": "2026-06-03T15:04:09.015897Z",
-     "shell.execute_reply": "2026-06-03T15:04:09.015447Z"
+     "iopub.execute_input": "2026-07-12T07:17:18.873386Z",
+     "iopub.status.busy": "2026-07-12T07:17:18.873386Z",
+     "iopub.status.idle": "2026-07-12T07:17:18.877662Z",
+     "shell.execute_reply": "2026-07-12T07:17:18.877662Z"
     },
     "id": "-n4i-fW3NojZ",
     "papermill": {
@@ -1214,10 +1104,10 @@
    "id": "2373fecf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:09.057508Z",
-     "iopub.status.busy": "2026-06-03T15:04:09.057178Z",
-     "iopub.status.idle": "2026-06-03T15:04:14.748711Z",
-     "shell.execute_reply": "2026-06-03T15:04:14.748086Z"
+     "iopub.execute_input": "2026-07-12T07:17:18.879042Z",
+     "iopub.status.busy": "2026-07-12T07:17:18.879042Z",
+     "iopub.status.idle": "2026-07-12T07:17:20.157365Z",
+     "shell.execute_reply": "2026-07-12T07:17:20.157365Z"
     },
     "id": "iaOPfOrwWEP4",
     "papermill": {
@@ -1231,18 +1121,10 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Roaming\\Python\\Python313\\site-packages\\stable_baselines3\\common\\on_policy_algorithm.py:150: UserWarning: You are trying to run PPO on the GPU, but it is primarily intended to run on the CPU when not using a CNN policy (you are using ActorCriticPolicy which should be a MlpPolicy). See https://github.com/DLR-RM/stable-baselines3/issues/1245 for more info. You can pass `device='cpu'` or `export CUDA_VISIBLE_DEVICES=` to force using the CPU.Note: The model will train, but the GPU utilization will be poor and the training might take longer than on CPU.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Using cuda device\n",
+      "Using cpu device\n",
       "Creating environment from the given name 'CartPole-v1'\n",
       "Wrapping the env with a `Monitor` wrapper\n",
       "Wrapping the env in a DummyVecEnv.\n"
@@ -1254,19 +1136,19 @@
      "text": [
       "---------------------------------\n",
       "| rollout/           |          |\n",
-      "|    ep_len_mean     | 25.1     |\n",
-      "|    ep_rew_mean     | 25.1     |\n",
+      "|    ep_len_mean     | 22.7     |\n",
+      "|    ep_rew_mean     | 22.7     |\n",
       "| time/              |          |\n",
-      "|    fps             | 524      |\n",
+      "|    fps             | 3184     |\n",
       "|    iterations      | 1        |\n",
-      "|    time_elapsed    | 3        |\n",
+      "|    time_elapsed    | 0        |\n",
       "|    total_timesteps | 2048     |\n",
       "---------------------------------\n"
      ]
     }
    ],
    "source": [
-    "model = PPO('MlpPolicy', \"CartPole-v1\", verbose=1).learn(1000)"
+    "model = PPO('MlpPolicy', \"CartPole-v1\", verbose=1, device='cpu').learn(1000)\n"
    ]
   },
   {
@@ -1315,10 +1197,10 @@
    "id": "97af2b3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:14.810097Z",
-     "iopub.status.busy": "2026-06-03T15:04:14.809865Z",
-     "iopub.status.idle": "2026-06-03T15:04:14.813610Z",
-     "shell.execute_reply": "2026-06-03T15:04:14.812779Z"
+     "iopub.execute_input": "2026-07-12T07:17:20.159367Z",
+     "iopub.status.busy": "2026-07-12T07:17:20.159367Z",
+     "iopub.status.idle": "2026-07-12T07:17:20.163330Z",
+     "shell.execute_reply": "2026-07-12T07:17:20.163330Z"
     },
     "papermill": {
      "duration": 0.013855,
@@ -1378,10 +1260,10 @@
    "id": "e9d59aa2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:14.841846Z",
-     "iopub.status.busy": "2026-06-03T15:04:14.841652Z",
-     "iopub.status.idle": "2026-06-03T15:04:14.888481Z",
-     "shell.execute_reply": "2026-06-03T15:04:14.887892Z"
+     "iopub.execute_input": "2026-07-12T07:17:20.165333Z",
+     "iopub.status.busy": "2026-07-12T07:17:20.165333Z",
+     "iopub.status.idle": "2026-07-12T07:17:20.184412Z",
+     "shell.execute_reply": "2026-07-12T07:17:20.184412Z"
     },
     "papermill": {
      "duration": 0.058703,
@@ -1442,10 +1324,10 @@
    "id": "d9661591",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T15:04:14.928080Z",
-     "iopub.status.busy": "2026-06-03T15:04:14.927828Z",
-     "iopub.status.idle": "2026-06-03T15:04:14.931990Z",
-     "shell.execute_reply": "2026-06-03T15:04:14.931172Z"
+     "iopub.execute_input": "2026-07-12T07:17:20.188105Z",
+     "iopub.status.busy": "2026-07-12T07:17:20.186896Z",
+     "iopub.status.idle": "2026-07-12T07:17:20.193351Z",
+     "shell.execute_reply": "2026-07-12T07:17:20.192305Z"
     },
     "papermill": {
      "duration": 0.018874,
@@ -1524,7 +1406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Context

Cell **outputs** of `rl_1_intro_cartpole.ipynb` leaked the runner's machine path (Stop & Repair class — secrets-hygiene rule 6). Leaks came from library log/warning lines embedding `AppData\...\site-packages` and the worktree `C:\dev\CoursIA-...\` prefix. Part of the cross-family path-leak rollout (sibling PRs #6261/#6267/#6258/#6266/#6281/#6270/…).

## Changes (5 cells, cause-fixed not scrubbed)

| Cell | Leak source | Fix |
|------|-------------|-----|
| 1  | pip "Requirement already satisfied ... ~\AppData\Roaming\Python\Python313\site-packages" | `%pip install -q` |
| 12 | SB3 GPU-device warning embedding site-packages path | `PPO(..., device='cpu')` (SB3-recommended for MlpPolicy) |
| 18 | SB3 "evaluate_policy without Monitor" warning embedding path | `from stable_baselines3.common.monitor import Monitor` + wrap `eval_env` |
| 31 | SB3 bare `print("Saving video to <abspath>")` + moviepy "video ready <abspath>" + pygame pkg_resources deprecation | mute `proglog.default_bar_logger` → `MuteProgressBarLogger` + redirect `sys.stdout` to devnull during `record_video`; the `.mp4` is still written and displayed by `show_videos()` in cell 33. Targeted `warnings.filterwarnings` for pygame. |
| 35 | SB3 GPU-device warning (retrain) | `PPO('MlpPolicy', ..., device='cpu').learn(1000)` |

All fixes address the **cause** (the warning/log that embeds the path), never hand-edit committed outputs (rule 6 / Stop & Repair).

## Validation (H.1 / C.2)

- Re-executed end-to-end via nbconvert `ExecutePreprocessor` on kernel `python3` (Python 3.11; stable-baselines3 2.8.0a2, gymnasium 1.2.3, torch 2.12.1+cpu, pygame 2.6.1, moviepy 2.1.2).
- **EXEC_PROVED**: 20/20 code cells `execution_count != null`, **0 errors**.
- Path-leak scan (AppData / C:\dev / C:/dev / jsboi / \\Users\\ / ipykernel_<pid>) on outputs: **0 occurrences** (was 7 across cells 1/12/18/31/35).
- **C.3**: outputs of unchanged-source cells (3, 6, 20, 22, 33 — version strings / stochastic rewards / object repr / video frames) spliced back to `main`; the diff is exactly the 5 remediated cells (source + output).
- LF endings, no BOM, no catalogue touched.

## Note on the video-log suppression (cell 31)

`proglog` (moviepy's logger) bypasses `contextlib.redirect_stdout` by caching its handle at import, so a plain `with redirect_stdout(...)` does not catch it. Muting `proglog.default_bar_logger` (moviepy's own silencing mechanism, `MuteProgressBarLogger`) + redirecting `sys.stdout` for SB3's bare `print` is the minimal robust combination. The recorded video is unaffected (file I/O, not stdout) and still rendered inline by `show_videos`.

See #16.