### PR TITLE
fix(genai): replace deprecated pkg_resources in SK-09 to stop ipykernel leak (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
@@ -181,14 +181,6 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_40812\\1193808625.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html\n",
-      "  import pkg_resources\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -199,8 +191,11 @@
    ],
    "source": [
     "# On peut vérifier la version\n",
-    "import pkg_resources\n",
-    "print(\"pythonnet version :\", pkg_resources.get_distribution(\"pythonnet\").version)\n",
+    "# importlib.metadata remplace pkg_resources (deprecie depuis setuptools 67) :\n",
+    "# import pkg_resources emet un DeprecationWarning dont la traceback fuite le chemin\n",
+    "# temporaire du kernel (ipykernel_<pid>\\<hash>.py) dans les sorties commitees.\n",
+    "from importlib.metadata import version as _pkg_version\n",
+    "print(\"pythonnet version :\", _pkg_version(\"pythonnet\"))\n",
     "print(\"Installation pythonnet : OK\")"
    ]
   },


### PR DESCRIPTION
## Summary

Fixes a committed **ipykernel path-leak** in `GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb` (cell 4). Part of EPIC **#3801** (path-leak defect class). Sibling to **#6261** (Search-4), **#6266** (SW-13 cProfile), **#6281** (01-3 FigureCanvasAgg).

## Defect

Cell 4 used `import pkg_resources` to read the pythonnet version. `pkg_resources` (deprecated since setuptools 67) emits a `DeprecationWarning` whose traceback embeds the kernel temp path:

```
C:\Users\jsboi\AppData\Local\Temp\ipykernel_40812\1193808625.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
```

This leaked `C:\Users\<user>\AppData\Local\Temp\ipykernel_<pid>\...` into the committed cell-4 **stderr** output.

## Fix (cause-level — secrets-hygiene règle 6)

Replace the deprecated `pkg_resources.get_distribution(\"pythonnet\").version` with `importlib.metadata.version(\"pythonnet\")` — the **modern, non-deprecated API** the warning itself recommends. No `pkg_resources` import → no DeprecationWarning → no path leak. This is strictly better than a `warnings.filterwarnings` suppression (uses the replacement API, not a mask).

## Verification (firsthand)

c4 is self-contained (a pythonnet version check — no prior-cell variable dependencies; cells 0-2 are markdown, cell 3 is `%pip install`). The fixed c4 source was **re-executed standalone in a real Python subprocess**:

```
$ python c4_source.py 1>stdout.txt 2>stderr.txt
exit: 0
--- stdout ---
pythonnet version : 3.0.5
Installation pythonnet : OK
--- stderr ---   (0 bytes — no DeprecationWarning, no leak)
```

The captured real stdout was spliced into cell 4's output (list-format, byte-identical content to the original stdout output). The leak stderr stream is removed.

**Full-notebook re-exec is blocked** by the umbrella `MyIA.AI.Notebooks.csproj` build failing with 223 unrelated errors in `CoursIA-OwlAdapter` (missing `RDFResource`/`OWLOntology` — a separate pre-existing build break, not this PR's scope). Cell 4 sits **before** the DLL-loading cell (c8) and has no DLL dependency, so a standalone re-exec of c4 is sufficient and honest (real Python output, not hand-edited).

| Check | Result |
|-------|--------|
| ipykernel leaks before | 1 (cell 4 stderr) |
| ipykernel leaks after | **0** |
| c4 stdout byte-identical to origin/main | yes |
| `raise NotImplementedError` / `assert False` / `1/0` | 0 (C.1 OK) |
| code cells with `execution_count: null` | 0 (C.2 intact) |

**Surgical splice**: final notebook differs from `origin/main` by **cell 4 source** (+importlib.metadata fix) + **cell 4 outputs** (stderr leak stream removed; stdout byte-identical) only. `git diff --stat`: +5/−10. All other cells untouched.

## Scope

1 file, 1 cell. pythonnet already installed locally (règle F: `pip install pythonnet`, `import clr` OK). No Lean, no catalog touch, no README. Base 0 commits behind `origin/main`.

## Note for reviewer

The umbrella `.csproj` build break (OwlAdapter) is out of scope — flagging it here for a separate issue if not already tracked. It blocks full re-exec of CLR-interop notebooks on this machine.

See #3801, #6261, #6266, #6281.