### PR TITLE
fix(qc-py): nbformat v4.5 cell ids for QC-Py-02/03/09 (structural metadata)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
@@ -54,7 +54,8 @@
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-f8dab00c"
   },
   {
    "cell_type": "markdown",
@@ -69,7 +70,8 @@
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-8c9cc451"
   },
   {
    "cell_type": "markdown",
@@ -204,7 +206,8 @@
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — BasicLifecycleAlgorithm (BT 517a23f820b3..., projet 31996105)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | 0.493 | 11.761% | 33.5% | 1 |"
-   ]
+   ],
+   "id": "cell-1d10f017"
   },
   {
    "cell_type": "markdown",
@@ -295,7 +298,8 @@
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — MultiAssetAlgorithm (BT c3e7f9c329cf..., projet 31996194)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | 0.834 | 25.403% | 40.3% | 99 |"
-   ]
+   ],
+   "id": "cell-55766e0d"
   },
   {
    "cell_type": "code",
@@ -454,7 +458,8 @@
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — IndicatorsAlgorithm (BT 150fee29c7cc..., projet 31996292)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (demo) |"
-   ]
+   ],
+   "id": "cell-7d187755"
   },
   {
    "cell_type": "markdown",
@@ -625,7 +630,8 @@
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — RSIMeanReversion (BT 3b160a654712..., projet 31996392)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | 0.291 | 7.15% | 28.7% | 10 (90% WR) |"
-   ]
+   ],
+   "id": "cell-c5021626"
   },
   {
    "cell_type": "markdown",
@@ -791,7 +797,8 @@
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — TradingMethodsExample (BT 0ed23be74610..., projet 31996441)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | 0.379 | 7.14% | 21.7% | 0 |"
-   ]
+   ],
+   "id": "cell-aaf2438b"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
@@ -14,14 +14,16 @@
     "**Niveau**: Intermédiaire  \n",
     "**Prérequis**: QC-Py-01 et QC-Py-02 complétés, connaissance de pandas",
     "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
-   ]
+   ],
+   "id": "cell-0cfe9d95"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-8a2397fa"
   },
   {
    "cell_type": "markdown",
@@ -36,7 +38,8 @@
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-ab7ae461"
   },
   {
    "cell_type": "markdown",
@@ -85,7 +88,8 @@
     "7. Exemple complet: Multi-timeframe trend following (10 min)\n",
     "8. Conclusion (5 min)\n",
     "```"
-   ]
+   ],
+   "id": "cell-09475d45"
   },
   {
    "cell_type": "markdown",
@@ -103,7 +107,8 @@
     "### 2.2 Première récupération de données\n",
     "\n",
     "Créons un algorithme simple qui récupère 30 jours de données pour Apple (AAPL)."
-   ]
+   ],
+   "id": "cell-b86107cd"
   },
   {
    "cell_type": "code",
@@ -143,17 +148,20 @@
     "        self.Log(f\"Volume moyen: {df['volume'].mean():.0f}\")\n",
     "        self.Log(f\"Prix min: ${df['low'].min():.2f}\")\n",
     "        self.Log(f\"Prix max: ${df['high'].max():.2f}\")"
-   ]
+   ],
+   "id": "cell-96487cfb"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultats du Backtest QC Cloud**\n> \n> **Algorithme** : `DataExplorationAlgo` \n> **BT ID** : c0eea29363857469829943de0343ea94\n> **Dates tradeables** : 2516 \n> **Ordres executes** : 0 \n> **Equity finale** : $100,000.00 \n> *Note : Data exploration only (History, pandas stats)*"
+   "source": "> **Resultats du Backtest QC Cloud**\n> \n> **Algorithme** : `DataExplorationAlgo` \n> **BT ID** : c0eea29363857469829943de0343ea94\n> **Dates tradeables** : 2516 \n> **Ordres executes** : 0 \n> **Equity finale** : $100,000.00 \n> *Note : Data exploration only (History, pandas stats)*",
+   "id": "cell-e1bd263e"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultat du Backtest QC Cloud** — DataExplorationAlgo (BT c0eea293..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |"
+   "source": "> **Resultat du Backtest QC Cloud** — DataExplorationAlgo (BT c0eea293..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |",
+   "id": "cell-6137903f"
   },
   {
    "cell_type": "markdown",
@@ -207,7 +215,8 @@
     "df1 = history.loc[self.symbol1]\n",
     "df2 = history.loc[self.symbol2]\n",
     "```"
-   ]
+   ],
+   "id": "cell-73234a0f"
   },
   {
    "cell_type": "markdown",
@@ -223,12 +232,14 @@
     "| **QuoteBar** | Données de cotation (bid/ask) | bid.open, bid.close, ask.open, ask.close | Forex, Options |\n",
     "\n",
     "Pour les actions, nous utilisons principalement **TradeBar**."
-   ]
+   ],
+   "id": "cell-c36e9d4c"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultat du Backtest QC Cloud** — HistorySignaturesDemo (BT 950872b0..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |"
+   "source": "> **Resultat du Backtest QC Cloud** — HistorySignaturesDemo (BT 950872b0..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |",
+   "id": "cell-addecf85"
   },
   {
    "cell_type": "code",
@@ -285,12 +296,14 @@
     "        self.Log(f\"Low: ${latest_bar['low']:.2f}\")\n",
     "        self.Log(f\"Close: ${latest_bar['close']:.2f}\")\n",
     "        self.Log(f\"Volume: {latest_bar['volume']:.0f}\")"
-   ]
+   ],
+   "id": "cell-89dc00f2"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultats du Backtest QC Cloud**\n> \n> **Algorithme** : `HistorySignaturesDemo` \n> **BT ID** : 950872b0c8b3494db8c9a7527639eb48\n> **Dates tradeables** : 2864 \n> **Ordres executes** : 0 \n> **Equity finale** : $100,000.00 \n> *Note : Multi-signature History API demo*"
+   "source": "> **Resultats du Backtest QC Cloud**\n> \n> **Algorithme** : `HistorySignaturesDemo` \n> **BT ID** : 950872b0c8b3494db8c9a7527639eb48\n> **Dates tradeables** : 2864 \n> **Ordres executes** : 0 \n> **Equity finale** : $100,000.00 \n> *Note : Multi-signature History API demo*",
+   "id": "cell-0da119e4"
   },
   {
    "cell_type": "markdown",
@@ -307,7 +320,8 @@
     "3. **Multi-symboles**: Avec plusieurs symboles, `history.loc[symbol]` permet d'accéder aux données de chaque actif individuellement\n",
     "\n",
     "> **Best practice**: Toujours vérifier la longueur du DataFrame historique avant de l'utiliser, car les données peuvent être manquantes (IPO récente, delisting, etc.)"
-   ]
+   ],
+   "id": "cell-a27e884e"
   },
   {
    "cell_type": "markdown",
@@ -350,19 +364,22 @@
     "| **TotalReturn** | Oui | Oui (réinvestis) | Performance avec dividendes réinvestis |\n",
     "\n",
     "> **Défaut**: Si vous n'indiquez rien, QuantConnect utilise **Adjusted** (splits et dividendes ajustés)."
-   ]
+   ],
+   "id": "cell-9298f375"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultat du Backtest QC Cloud** — DataNormalizationDemo (BT 7f44566e..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | INIT_ERROR (History dataNormalizationMode KeyError) |"
+   "source": "> **Resultat du Backtest QC Cloud** — DataNormalizationDemo (BT 7f44566e..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | INIT_ERROR (History dataNormalizationMode KeyError) |",
+   "id": "cell-38bbf255"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 3.3 Comparaison Raw vs Adjusted"
-   ]
+   ],
+   "id": "cell-9d608855"
   },
   {
    "cell_type": "code",
@@ -450,12 +467,14 @@
     "        # Retour Adjusted (CORRECT)\n",
     "        return_adjusted = (df_adjusted.loc[after_split, 'close'] / df_adjusted.loc[before_split, 'close']) - 1\n",
     "        self.Log(f\"Retour avec Adjusted: {return_adjusted:.2%} (CORRECT)\")"
-   ]
+   ],
+   "id": "cell-a4e56f45"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultats du Backtest QC Cloud**\n> \n> **Algorithme** : `DataNormalizationDemo` \n> **BT ID** : 7f44566ebdc20bf19ddc9d495ce4769c\n> **Status** : Runtime Error (KeyError)\n> **Erreur** : History avec dataNormalizationMode parameter KeyError pendant Initialize\n> *Note : dataNormalizationMode parameter non disponible en mode History pendant Initialize*"
+   "source": "> **Resultats du Backtest QC Cloud**\n> \n> **Algorithme** : `DataNormalizationDemo` \n> **BT ID** : 7f44566ebdc20bf19ddc9d495ce4769c\n> **Status** : Runtime Error (KeyError)\n> **Erreur** : History avec dataNormalizationMode parameter KeyError pendant Initialize\n> *Note : dataNormalizationMode parameter non disponible en mode History pendant Initialize*",
+   "id": "cell-3240c78a"
   },
   {
    "cell_type": "markdown",
@@ -480,7 +499,8 @@
     "- Votre backtest ne reflètera pas la réalité\n",
     "\n",
     "> **Best practice**: Toujours utiliser **Adjusted** (défaut) pour le backtesting. N'utilisez Raw que si vous avez une raison académique spécifique."
-   ]
+   ],
+   "id": "cell-1bc4eb18"
   },
   {
    "cell_type": "markdown",
@@ -495,7 +515,8 @@
     "- **TotalReturn**: Votre capital devient $10,200 (dividendes automatiquement réinvestis dans les actions)\n",
     "\n",
     "C'est particulièrement pertinent pour les stratégies buy-and-hold sur actions à dividendes élevés (ex: utilities, REITs)."
-   ]
+   ],
+   "id": "cell-2b7dcf37"
   },
   {
    "cell_type": "markdown",
@@ -522,7 +543,8 @@
     "| **TickConsolidator** | Consolide des Ticks | Ultra haute fréquence |\n",
     "\n",
     "### 4.3 Exemple: Stratégie multi-timeframe"
-   ]
+   ],
+   "id": "cell-ac347f22"
   },
   {
    "cell_type": "code",
@@ -620,14 +642,16 @@
     "            if self.Portfolio.Invested:\n",
     "                self.Liquidate(self.symbol)\n",
     "                self.Log(f\"SELL: Trend weakening at {self.Time}\")"
-   ]
+   ],
+   "id": "cell-fc982e17"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — ConsolidatorByCountDemo (BT 3f54a1b5..., projet 32000820)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |"
-   ]
+   ],
+   "id": "cell-616c7cdb"
   },
   {
    "cell_type": "markdown",
@@ -656,7 +680,8 @@
     "1. **Callback DataConsolidated**: Appelé chaque fois qu'une nouvelle barre est consolidée (ex: toutes les 15 minutes)\n",
     "2. **IndicatorExtensions.Of()**: Lie un indicateur à un consolidator pour qu'il se mette à jour automatiquement\n",
     "3. **Warm-up**: Les indicateurs sur consolidators prennent plus de temps à être prêts (ex: SMA(10) sur 15-min = 150 minutes de données nécessaires)"
-   ]
+   ],
+   "id": "cell-dc52232f"
   },
   {
    "cell_type": "markdown",
@@ -665,14 +690,16 @@
     "### 4.5 Consolidators par nombre de barres\n",
     "\n",
     "Vous pouvez aussi créer des consolidators par nombre de barres au lieu de durée:"
-   ]
+   ],
+   "id": "cell-145ba283"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** — CustomDataAlgo (BT d8f6e1b4..., projet 32000870)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |"
-   ]
+   ],
+   "id": "cell-c0dd4304"
   },
   {
    "cell_type": "code",
@@ -703,7 +730,8 @@
     "        self.bar_count += 1\n",
     "        if self.bar_count <= 5:\n",
     "            self.Log(f\"Consolidated bar #{self.bar_count}: Time={bar.Time}, Close=${bar.Close:.2f}\")"
-   ]
+   ],
+   "id": "cell-db2c94e7"
   },
   {
    "cell_type": "markdown",
@@ -716,7 +744,8 @@
     "> **Ordres executes** : 0  ",
     "> **Equity finale** : $100,000.00  ",
     "> *Note : Converted Minute→Daily, 5-bar consolidator. Jan-Mar 2015.*"
-   ]
+   ],
+   "id": "cell-c915b863"
   },
   {
    "cell_type": "markdown",
@@ -732,7 +761,8 @@
     "| **Simplicité** | Un seul stream de données, plusieurs analyses |\n",
     "\n",
     "> **Use case typique**: Stratégies qui combinent tendance long terme (daily/weekly) avec timing d'entrée court terme (minute/hour)."
-   ]
+   ],
+   "id": "cell-87ae9704"
   },
   {
    "cell_type": "markdown",
@@ -767,12 +797,14 @@
     "Vous devez créer une classe héritant de `PythonData` et implémenter:\n",
     "1. **GetSource()**: URL de la source de données\n",
     "2. **Reader()**: Parser une ligne de données"
-   ]
+   ],
+   "id": "cell-94dd9755"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultat du Backtest QC Cloud** — PandasAnalysisDemo (BT e1124252..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |"
+   "source": "> **Resultat du Backtest QC Cloud** — PandasAnalysisDemo (BT e1124252..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |",
+   "id": "cell-2a13a480"
   },
   {
    "cell_type": "code",
@@ -843,12 +875,14 @@
     "        #     elif sentiment_score < 0.3 and self.Portfolio[self.btc].Invested:\n",
     "        #         self.Liquidate(self.btc)\n",
     "        pass"
-   ]
+   ],
+   "id": "cell-c87dd813"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultat du Backtest QC Cloud** — RollingAnalysisDemo (BT 7f54aaf2..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |"
+   "source": "> **Resultat du Backtest QC Cloud** — RollingAnalysisDemo (BT 7f54aaf2..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |",
+   "id": "cell-e712b64c"
   },
   {
    "cell_type": "markdown",
@@ -876,12 +910,14 @@
     "    if data.ContainsKey(USTreasuryYieldCurveRate):\n",
     "        ten_year_rate = data[USTreasuryYieldCurveRate].TenYear\n",
     "```"
-   ]
+   ],
+   "id": "cell-25ef9600"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultat du Backtest QC Cloud** — CorrelationAnalysisDemo (BT a6b3175c..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |"
+   "source": "> **Resultat du Backtest QC Cloud** — CorrelationAnalysisDemo (BT a6b3175c..., projet 32005992)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |",
+   "id": "cell-8b91c37d"
   },
   {
    "cell_type": "markdown",
@@ -897,14 +933,16 @@
     "| **Validation manuelle** | Vous devez vérifier la qualité des données |\n",
     "\n",
     "> **Best practice**: Testez votre source de custom data avec un petit backtest avant de l'utiliser en production."
-   ]
+   ],
+   "id": "cell-62eba5ca"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> **Resultat du Backtest QC Cloud** - MultiTimeframeTrendFollowing (BT 820416908df4188f3041cf6025647d2a, projet 32000959)\n>\n> | Sharpe | CAGR | MaxDD | Trades | Win Rate |\n> |--------|------|-------|--------|----------|\n> | 0.36 | 7.093% | 16.0% | 138 | 42% |\n>\n> Net Profit: +98.5% | Total Fees: $314.04 | Alpha: 0.005 | Beta: 0.328"
-   ]
+   ],
+   "id": "cell-36a914f6"
   },
   {
    "cell_type": "markdown",
@@ -921,7 +959,8 @@
     "- Analyser des corrélations\n",
     "\n",
     "### 6.2 Statistiques de base"
-   ]
+   ],
+   "id": "cell-5f4a1083"
   },
   {
    "cell_type": "code",
@@ -969,19 +1008,22 @@
     "        # Sharpe ratio (simplifié, assume risk-free rate = 0)\n",
     "        sharpe = (df['returns'].mean() / df['returns'].std()) * (252 ** 0.5)\n",
     "        self.Log(f\"Sharpe Ratio: {sharpe:.2f}\")"
-   ]
+   ],
+   "id": "cell-d1d30465"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "> **Resultats du Backtest QC Cloud**\n> \n> **Algorithme** : `PandasAnalysisDemo` \n> **BT ID** : e112425279b0a68d8e081af466988e13\n> **Dates tradeables** : 2864 \n> **Ordres executes** : 0 \n> **Equity finale** : $100,000.00 \n> *Note : SPY pandas analysis (returns, volatility, Sharpe)*"
+   "source": "> **Resultats du Backtest QC Cloud**\n> \n> **Algorithme** : `PandasAnalysisDemo` \n> **BT ID** : e112425279b0a68d8e081af466988e13\n> **Dates tradeables** : 2864 \n> **Ordres executes** : 0 \n> **Equity finale** : $100,000.00 \n> *Note : SPY pandas analysis (returns, volatility, Sharpe)*",
+   "id": "cell-bb0f1823"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 6.3 Analyse avec rolling windows"
-   ]
+   ],
+   "id": "cell-de750f6b"
   },
   {
    "cell_type": "code",
@@ -1034,7 +1076,8 @@
     "            self.Log(\"Signal: FORTE TENDANCE BAISSIÈRE (Death Cross)\")\n",
     "        else:\n",
     "            self.Log(\"Signal: TENDANCE MIXTE (Range)\")"
-   ]
+   ],
+   "id": "cell-8b9c4080"
   },
   {
    "cell_type": "markdown",
@@ -1047,7 +1090,8 @@
     "> **Ordres executes** : 0  ",
     "> **Equity finale** : $100,000.00  ",
     "> *Note : AAPL rolling SMA 20/50/200 + trend analysis*"
-   ]
+   ],
+   "id": "cell-3097d70d"
   },
   {
    "cell_type": "markdown",
@@ -1059,7 +1103,8 @@
     "- Diversification de portefeuille (chercher corrélations faibles)\n",
     "- Pair trading (chercher corrélations fortes)\n",
     "- Hedging (chercher corrélations négatives)"
-   ]
+   ],
+   "id": "cell-67e146f2"
   },
   {
    "cell_type": "code",
@@ -1112,7 +1157,8 @@
     "        self.Log(f\"SPY-TLT: {spy_tlt_corr:.2f} (Stocks-Bonds: corrélation négative = bon hedge)\")\n",
     "        self.Log(f\"SPY-GLD: {spy_gld_corr:.2f} (Stocks-Or: corrélation faible = diversification)\")\n",
     "        self.Log(f\"SPY-QQQ: {spy_qqq_corr:.2f} (S&P-Nasdaq: corrélation forte = même secteur)\")"
-   ]
+   ],
+   "id": "cell-62e5a0da"
   },
   {
    "cell_type": "markdown",
@@ -1125,7 +1171,8 @@
     "> **Ordres executes** : 0  ",
     "> **Equity finale** : $100,000.00  ",
     "> *Note : SPY/TLT/GLD/QQQ correlation matrix*"
-   ]
+   ],
+   "id": "cell-7fef4078"
   },
   {
    "cell_type": "markdown",
@@ -1169,7 +1216,8 @@
     "- **Signal**: Acheter seulement si tendance haussière sur les deux timeframes\n",
     "\n",
     "### 7.2 Implémentation complète"
-   ]
+   ],
+   "id": "cell-a9691fb9"
   },
   {
    "cell_type": "code",
@@ -1271,7 +1319,8 @@
     "        self.Log(\"\\n=== Statistiques Finales ===\")\n",
     "        self.Log(f\"Capital Final: ${self.Portfolio.TotalPortfolioValue:.2f}\")\n",
     "        self.Log(f\"Retour Total: {(self.Portfolio.TotalPortfolioValue / 100000 - 1):.2%}\")"
-   ]
+   ],
+   "id": "cell-db7e7623"
   },
   {
    "cell_type": "markdown",
@@ -1294,7 +1343,8 @@
     "- Drawdown réduit vs buy-and-hold\n",
     "\n",
     "> **Amélioration possible**: Ajouter un filtre de volatilité (ATR) pour ajuster la position size."
-   ]
+   ],
+   "id": "cell-c3cd8ea5"
   },
   {
    "cell_type": "markdown",
@@ -1394,7 +1444,8 @@
     "---\n",
     "\n",
     "**Félicitations!** Vous maîtrisez maintenant la gestion de données dans QuantConnect. C'est la fondation de toute stratégie robuste."
-   ]
+   ],
+   "id": "cell-f851b490"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
@@ -30,7 +30,8 @@
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-8bc082b0"
   },
   {
    "cell_type": "markdown",
@@ -45,7 +46,8 @@
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-e45dc705"
   },
   {
    "cell_type": "markdown",
@@ -153,7 +155,8 @@
     "| PSR | 0% |\n",
     "\n",
     "*Quick reference of all order types (market, limit, stop, MOO/MOC, LIT, SetHoldings), SPY. Classe de reference (sans OnData / sans ordre emis) : aucun trade execute. Backtest QC Cloud 2015-2024 (projet 33181748, bt 4c4734dc00a7693da39c73d1072af0b6).*"
-   ]
+   ],
+   "id": "cell-752c757d"
   },
   {
    "cell_type": "markdown",
@@ -231,7 +234,8 @@
     "| PSR | 8.0% |\n",
     "\n",
     "*Market order example (buy 50 SPY), daily resolution. Backtest QC Cloud 2015-2024 (projet 33181748, bt 43580311a0c1c0f9ef659f47f79fe5b7). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-e8e963e4"
   },
   {
    "cell_type": "markdown",
@@ -325,7 +329,8 @@
     "| PSR | 12.4% |\n",
     "\n",
     "*SetHoldings allocation (SPY 50%, QQQ 30%, Cash 20%), daily resolution. Backtest QC Cloud 2015-2024 (projet 33181748, bt 240930f7da5c59fb93f22efb8afd4c0c). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-9c85c206"
   },
   {
    "cell_type": "markdown",
@@ -400,7 +405,8 @@
     "> **Runtime Error (backtest QC Cloud, bt 94fdaf130de8f55846fcd1362d2beed3).** La strategie de reference place un limit order a -1% sous le prix, puis s'arrete, puis Runtime Error a 2015-03-20 : `'NoneType' object has no attribute 'Close'` a `data[self.spy].Close` MALGRE le guard `if not data.ContainsKey(self.spy): return` -- gotcha QC : `ContainsKey` renvoie True mais la valeur peut etre None sur certaines bars (barres auxiliaires split/dividende). Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas commitees (G.2 : aucune metrique non-verifiable). La table fabriquee d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 94fdaf130de8f55846fcd1362d2beed3).*"
-   ]
+   ],
+   "id": "cell-22b407ef"
   },
   {
    "cell_type": "code",
@@ -460,7 +466,8 @@
     "| PSR | 0% |\n",
     "\n",
     "*Order status demo (buy 100 SPY market), daily resolution. Classe de reference (sans OnData / sans ordre emis) : aucun trade execute. Backtest QC Cloud 2015-2024 (projet 33181748, bt b4bf89c7aac2170fe045a814cbe981b0).*"
-   ]
+   ],
+   "id": "cell-0511f6b7"
   },
   {
    "cell_type": "markdown",
@@ -602,7 +609,8 @@
     "| Max Drawdown | n/a |\n",
     "\n",
     "*Stop market (buy 100 SPY + 5% stop-loss), RUNTIME ERROR first bar. Runtime error des la 1re bar None : le code accede a `data[self.spy].Close` sans verifier que la bar est non-None (bug pedagogique ; corriger avec un garde `if data[self.spy] is None: return`). Backtest QC Cloud 2015-2024 (projet 33181748, bt 401f24e3ff1b74f5430ca62adc48dfbd).*"
-   ]
+   ],
+   "id": "cell-e24f3837"
   },
   {
    "cell_type": "code",
@@ -669,7 +677,8 @@
     "| PSR | 7.687% |\n",
     "\n",
     "*Breakout entry (20-day high + 0.2%), stop market order, daily resolution. Backtest QC Cloud 2015-2024 (projet 33181748, bt b20dbd603b04a0d0f9cc411777b4f24e). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-835c55ae"
   },
   {
    "cell_type": "markdown",
@@ -799,7 +808,8 @@
     "| PSR | 7.533% |\n",
     "\n",
     "*Stop-limit order (buy 100 SPY market + stop-limit sell at -5%/-5.5%), daily resolution. Backtest QC Cloud 2015-2024 (projet 33181748, bt 0f5bfc9c60a3c019bd055eb567a305f0). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-bdcc42cf"
   },
   {
    "cell_type": "markdown",
@@ -886,7 +896,8 @@
     "| PSR | 11.065% |\n",
     "\n",
     "*MOO/MOC buy Monday/sell Friday, Minute resolution, 10 trades (70% win rate). Backtest QC Cloud 2015-2024 (projet 33181748, bt 2f60ee4cacce2dbd802c6b3db6b9f1d8). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-dc52196b"
   },
   {
    "cell_type": "markdown",
@@ -962,7 +973,8 @@
     "| Probabilistic Sharpe Ratio | 8.672% |\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 8d5fc20fc6e983aa27074181a9e1a1e8). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-286a630e"
   },
   {
    "cell_type": "markdown",
@@ -1050,7 +1062,8 @@
     "> **Runtime Error (backtest QC Cloud, bt 61c83d4b9d948ac4172e011aed128170).** La strategie de reference place un limit a -2%, le met a jour a -1% apres 2 jours, l'annule apres 5, puis Runtime Error a 2015-03-20 : meme gotcha `Close None` malgre le guard `ContainsKey` (voir cellule LimitOrderExample ci-dessus). Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas commitees (G.2 : aucune metrique non-verifiable). La table fabriquee d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 61c83d4b9d948ac4172e011aed128170).*"
-   ]
+   ],
+   "id": "cell-60da6ad1"
   },
   {
    "cell_type": "code",
@@ -1111,7 +1124,8 @@
     "> Demo sans trading : la methode `CancelExamples(ticket)` n'est jamais appelee (pas de `OnData`, aucun ordre place), donc aucun ordre execute. Les differentes facons d'annuler un ordre (`ticket.Cancel()`, `Transactions.CancelOpenOrders`, `Transactions.CancelOrder`) sont illustrees dans le code mais non declenchees a l'execution.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 37bba9607b5d1621d1c7b173a173a36f). 0 ordre execute, $100,000 inchanges.*"
-   ]
+   ],
+   "id": "cell-9c6cacda"
   },
   {
    "cell_type": "markdown",
@@ -1294,7 +1308,8 @@
     "| PSR | 4.034% |\n",
     "\n",
     "*Entry + auto SL -3% + TP +5%, OCO logic, 3 trades (2W/1L, 67%), daily resolution. Backtest QC Cloud 2015-2024 (projet 33181748, bt 9ec84b6655b1bd1770b732a6e5ed5d58). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-5b683637"
   },
   {
    "cell_type": "markdown",
@@ -1399,7 +1414,8 @@
     "| PSR | 4.034% |\n",
     "\n",
     "*Bracket order OCO (entry + SL -3% + TP +5%), 3 trades (2W/1L, 67%), daily resolution. Backtest QC Cloud 2015-2024 (projet 33181748, bt 215cf9880d21274403302900d4dcf3b2). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-6e2e5bc8"
   },
   {
    "cell_type": "code",
@@ -1466,7 +1482,8 @@
     "> **Runtime Error (backtest QC Cloud, bt e966170dc9db35982cf134cf5d46018e).** La strategie de reference achete 100 SPY une seule fois (guard `order_pending`), nettoie les ordres stales via Schedule, puis Runtime Error a 2015-01-05 : `can't subtract offset-naive and offset-aware datetimes` dans `CancelStaleOrders` (`self.Time` offset-aware vs `order.CreatedTime` offset-naive) -- bug reel, non un artifice. Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas commitees (G.2 : aucune metrique non-verifiable). La table fabriquee d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt e966170dc9db35982cf134cf5d46018e).*"
-   ]
+   ],
+   "id": "cell-1cbafe11"
   },
   {
    "cell_type": "markdown",
@@ -1709,7 +1726,8 @@
     "| PSR | 0.371% |\n",
     "\n",
     "*20-day high breakout + 0.2% buffer, trailing stop 2%, TP +8% SL -3%, daily resolution. Backtest QC Cloud 2015-2024 (projet 33181748, bt 40e46344035213cff1f6608b6283e006). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-8ee1d19e"
   },
   {
    "cell_type": "code",
@@ -1795,7 +1813,8 @@
     "> **Runtime Error (backtest QC Cloud, bt 79864670e37067a4a1477a35d3888cc4).** La strategie de reference achat sur survente RSI<30 avec limit -0.5%, stop-loss -2%, take-profit +5%, puis Runtime Error a 2015-03-20 : meme gotcha `Close None` malgre le guard `ContainsKey` (le RSI n'a pas eu le temps de se declencher sur un marche haussier debut 2015). Le backtest s'arrete prematurement ; les statistiques partielles sur la periode anterieure a l'erreur ne sont pas un resultat 10y significatif et ne sont pas commitees (G.2 : aucune metrique non-verifiable). La table fabriquee d'origine (\"Q1 2023\", Sharpe 0, 0 trade) est supprimee.\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 79864670e37067a4a1477a35d3888cc4).*"
-   ]
+   ],
+   "id": "cell-3d874e55"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Add nbformat v4.5 `id` fields to cells missing them in 3 QC-Py fundamentals notebooks:
- **QC-Py-02-Platform-Fundamentals** — 7 cells missing id
- **QC-Py-03-Data-Management** — 51 cells missing id
- **QC-Py-09-Order-Types** — 19 cells missing id

These 3 are already `nbformat_minor=5`; they only lacked the per-cell `id` field (required by nbformat 4.5, currently `MissingIDFieldWarning`, will become a hard error in future nbformat).

## Fix (surgical)

Add `"id": "cell-<8hex>"` (deterministic MD5-based, unique within each notebook) as the **last key** of each id-less cell. The diff is minimal — only the id-addition pattern (`]` → `],` + `"id": "..."` line), nothing else touched.

## Anti-regression proof (C.2 / H.3)

Content fingerprint (`cell_type` / `source` / `outputs` / `execution_count` / `metadata` per cell) is **byte-identical before/after** on all 3 notebooks. These are **quantbooks** (`QuantBook()`) — the committed outputs are real QC Cloud results; this PR does **not** re-execute locally (structural metadata fix, exec-equivalent — same methodology and verdict as #6254 / #6257). `nbformat.validate()` PASSES on all 3 post-fix.

```
QC-Py-02  added=7  | content_fp same=True | missing_after=0 | validate PASS
QC-Py-03  added=51 | content_fp same=True | missing_after=0 | validate PASS
QC-Py-09  added=19 | content_fp same=True | missing_after=0 | validate PASS
```

## Non-collision

Same register as **#6254** (QC-Py-Cloud 7nb) and **#6257** (QC-Py main 12nb: 01/12/14/16/19/20/21/26/27/28/34/35) — **disjoint file set** (this PR = 02/03/09). Stackable, no overlap.

See #6254, #6257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
