### PR TITLE
fix(qc-py): nbformat v4.5 cell ids for QC-Py-30/31/32 ML-Training (structural metadata)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
@@ -868,7 +868,8 @@
    "metadata": {},
    "source": [
     "### Exercice 1 : Ajouter des features de momentum au pipeline\n\nLe pipeline de features actuel inclut des returns et des statistiques rolling. Ajoutez des **features de momentum** : le momentum a 5 jours (return cumule sur 5j) et le momentum a 20 jours.\n\n**Indices** :\n- `# Indice` : Le momentum N jours = `close / close.shift(N) - 1`\n- `# Indice` : Ajoutez les colonnes `mom_5d` et `mom_20d` dans la fonction `compute_features`\n- `# Etape 1` : Calculer `mom_5d = close / close.shift(5) - 1`\n- `# Etape 2` : Calculer `mom_20d = close / close.shift(20) - 1`\n- `# Etape 3` : Verifier que les nouvelles features sont bien dans le DataFrame final"
-   ]
+   ],
+   "id": "cell-4704e3a3"
   },
   {
    "cell_type": "code",
@@ -885,7 +886,8 @@
    ],
    "source": [
     "# Exercice 1 : Features de momentum\n# TODO etudiant : Ajouter mom_5d et mom_20d au pipeline de features\n# Etape 1 : Calculer le momentum 5 jours\n# Etape 2 : Calculer le momentum 20 jours\n# Etape 3 : Verifier avec .columns\nmomentum_features = None  # TODO etudiant : remplacer par le DataFrame avec features de momentum\nprint(\"Exercice a completer : Features de momentum\")"
-   ]
+   ],
+   "id": "cell-cf48626e"
   },
   {
    "cell_type": "markdown",
@@ -1539,7 +1541,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Modifier le taux d'apprentissage et observer\n\nChangez le **learning rate** de 1e-3 a 1e-4 et observez l'impact sur la convergence. Un LR trop grand peut causer une divergence, un LR trop petit ralentit l'apprentissage.\n\n**Indices** :\n- `# Indice` : Le learning rate est passe a l'optimiseur Adam\n- `# Indice` : Relancez l'entrainement avec le nouveau LR et comparez les courbes de loss\n- `# Etape 1` : Modifier le LR dans la creation de l'optimiseur\n- `# Etape 2` : Relancer l'entrainement (meme nombre d'epochs)\n- `# Etape 3` : Comparer les courbes de loss avec le LR original"
-   ]
+   ],
+   "id": "cell-e54b3093"
   },
   {
    "cell_type": "code",
@@ -1556,7 +1559,8 @@
    ],
    "source": [
     "# Exercice 2 : Impact du learning rate\n# TODO etudiant : Tester un learning rate de 1e-4 et comparer la convergence\n# Etape 1 : Modifier le LR dans l'optimiseur Adam\n# Etape 2 : Relancer l'entrainement\n# Etape 3 : Comparer les courbes de loss\nlr_comparison = None  # TODO etudiant : remplacer par les resultats de comparaison\nprint(\"Exercice a completer : Impact du learning rate\")"
-   ]
+   ],
+   "id": "cell-1d61ab56"
   },
   {
    "cell_type": "markdown",
@@ -2286,7 +2290,8 @@
    "metadata": {},
    "source": [
     "### Exercice 3 : Implementer un early stopping simple\n\nAjoutez un mecanisme d'**early stopping** : si la validation loss ne s'amelior pas pendant 10 epochs consecutives, arretez l'entrainement.\n\n**Indices** :\n- `# Indice` : Stockez la meilleure validation loss et comptez les epochs sans amelioration\n- `# Indice` : Utilisez un compteur `patience_counter` qui s'incremente si `val_loss >= best_val_loss`\n- `# Etape 1` : Initialiser `best_val_loss = float('inf')` et `patience_counter = 0`\n- `# Etape 2` : A chaque epoch, comparer val_loss avec best_val_loss\n- `# Etape 3` : Si patience_counter >= 10, break la boucle"
-   ]
+   ],
+   "id": "cell-7db8bbae"
   },
   {
    "cell_type": "code",
@@ -2303,7 +2308,8 @@
    ],
    "source": [
     "# Exercice 3 : Early stopping\n# TODO etudiant : Implementer un early stopping avec patience=10\n# Etape 1 : Initialiser best_val_loss et patience_counter\n# Etape 2 : Comparer val_loss avec best_val_loss a chaque epoch\n# Etape 3 : Break si patience_counter >= 10\nearly_stop_epoch = None  # TODO etudiant : remplacer par le numero d'epoch de l'arret\nprint(\"Exercice a completer : Early stopping\")"
-   ]
+   ],
+   "id": "cell-dd82540f"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
@@ -905,7 +905,8 @@
    "metadata": {},
    "source": [
     "### Exercice 1 : Ajouter des features de correlation inter-actifs\n\nLe Transformer peut exploiter les relations entre actifs. Ajoutez une feature de **correlation rolling 20j** entre chaque action et SPY.\n\n**Indices** :\n- `# Indice` : Utilisez `close.pct_change().rolling(20).corr(spy_returns)`\n- `# Etape 1` : Calculer les returns de SPY comme reference\n- `# Etape 2` : Pour chaque ticker, calculer la correlation rolling 20j avec SPY\n- `# Etape 3` : Ajouter la colonne `corr_spy_20d` au DataFrame"
-   ]
+   ],
+   "id": "cell-ab2bb9c5"
   },
   {
    "cell_type": "code",
@@ -922,7 +923,8 @@
    ],
    "source": [
     "# Exercice 1 : Features de correlation inter-actifs\n# TODO etudiant : Ajouter la correlation rolling 20j avec SPY\n# Etape 1 : Calculer les returns SPY comme reference\n# Etape 2 : Calculer corr(returns_ticker, returns_spy).rolling(20)\n# Etape 3 : Ajouter au DataFrame\ncorr_features = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Features de correlation inter-actifs\")"
-   ]
+   ],
+   "id": "cell-b3d5cdef"
   },
   {
    "cell_type": "markdown",
@@ -1503,7 +1505,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Modifier le nombre de têtes d'attention\n\nChangez le **nombre de têtes d'attention** de 4 a 8 et observez l'impact sur les performances. Plus de tetes permet de capturer des patterns differents mais augmente le cout de calcul.\n\n**Indices** :\n- `# Indice` : Le parametre `nhead` est defini dans la configuration du modele\n- `# Indice` : `d_model` doit etre divisible par `nhead`\n- `# Etape 1` : Verifier que d_model est divisible par 8\n- `# Etape 2` : Modifier nhead=8 dans la configuration\n- `# Etape 3` : Relancer l'entrainement et comparer"
-   ]
+   ],
+   "id": "cell-5e739084"
   },
   {
    "cell_type": "code",
@@ -1520,7 +1523,8 @@
    ],
    "source": [
     "# Exercice 2 : Impact du nombre de tetes d'attention\n# TODO etudiant : Tester nhead=8 et comparer avec nhead=4\n# Etape 1 : Verifier d_model % 8 == 0\n# Etape 2 : Modifier nhead dans la config\n# Etape 3 : Comparer les performances\nnhead_comparison = None  # TODO etudiant : remplacer par les resultats\nprint(\"Exercice a completer : Impact du nombre de tetes d'attention\")"
-   ]
+   ],
+   "id": "cell-a0cbecac"
   },
   {
    "cell_type": "markdown",
@@ -2769,7 +2773,8 @@
    "metadata": {},
    "source": [
     "### Exercice 3 : Ajouter une metrique de Calmar Ratio au backtest\n\nLe **Calmar Ratio** = CAGR / |Max Drawdown|. Il mesure le rendement ajuste au risque de drawdown. Calculez-le pour les predictions du Transformer.\n\n**Indices** :\n- `# Indice` : CAGR = (valeur_finale / valeur_initiale)^(252/nb_jours) - 1\n- `# Indice` : Max Drawdown = min(cumulative / cummax - 1)\n- `# Etape 1` : Calculer le CAGR a partir de la courbe de portefeuille\n- `# Etape 2` : Calculer le Max Drawdown\n- `# Etape 3` : Calculer le Calmar Ratio = CAGR / |MaxDD|"
-   ]
+   ],
+   "id": "cell-1110361c"
   },
   {
    "cell_type": "code",
@@ -2786,7 +2791,8 @@
    ],
    "source": [
     "# Exercice 3 : Calmar Ratio du Transformer\n# TODO etudiant : Calculer le Calmar Ratio (CAGR / |MaxDD|) des predictions Transformer\n# Etape 1 : Calculer le CAGR\n# Etape 2 : Calculer le Max Drawdown\n# Etape 3 : Calmar = CAGR / |MaxDD|\ncalmar_ratio = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Calmar Ratio du Transformer\")"
-   ]
+   ],
+   "id": "cell-c255f730"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
@@ -610,7 +610,8 @@
    "metadata": {},
    "source": [
     "### Exercice 1 : Modifier la fonction de recompense\n\nLa recompense actuelle utilise le return net. Modifiez-la pour utiliser un **return ajuste au risque** : recompense = return - 0.5 * volatility (penalise la volatilite excessive).\n\n**Indices** :\n- `# Indice` : La recompense est calculee dans la methode `step()` de `TradingEnvironment`\n- `# Indice` : La volatilite peut etre mesuree comme l'ecart-type des N derniers returns\n- `# Etape 1` : Identifier ou la recompense est calculee dans `step()`\n- `# Etape 2` : Ajouter un terme de penalite de volatilite\n- `# Etape 3` : Observer le changement de comportement de l'agent"
-   ]
+   ],
+   "id": "cell-ac30b999"
   },
   {
    "cell_type": "code",
@@ -627,7 +628,8 @@
    ],
    "source": [
     "# Exercice 1 : Recompense ajustee au risque\n# TODO etudiant : Modifier la recompense pour penaliser la volatilite\n# Etape 1 : Identifier la recompense dans step()\n# Etape 2 : Ajouter -0.5 * vol_recente\n# Etape 3 : Comparer le comportement\nreward_adj = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Recompense ajustee au risque\")"
-   ]
+   ],
+   "id": "cell-6c6ecc9e"
   },
   {
    "cell_type": "markdown",
@@ -826,7 +828,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Implementer un epsilon schedule lineaire\n\nLe code utilise un epsilon fixe pour l'exploration. Implementez un **epsilon schedule lineaire** : epsilon passe de 1.0 a 0.01 sur les 80% premiers pas d'apprentissage.\n\n**Indices** :\n- `# Indice` : `epsilon = max(0.01, 1.0 - step / (0.8 * total_steps))`\n- `# Etape 1` : Definir total_steps et calculer le seuil de decay\n- `# Etape 2` : Implementer la formule lineaire\n- `# Etape 3` : Verifier que epsilon decroit correctement"
-   ]
+   ],
+   "id": "cell-e6c51132"
   },
   {
    "cell_type": "code",
@@ -843,7 +846,8 @@
    ],
    "source": [
     "# Exercice 2 : Epsilon schedule lineaire\n# TODO etudiant : Implementer un epsilon qui decroit lineairement de 1.0 a 0.01\n# Etape 1 : Definir total_steps = 100000 et decay_steps = 0.8 * total_steps\n# Etape 2 : epsilon = max(0.01, 1.0 - step / decay_steps)\n# Etape 3 : Verifier en affichant epsilon a differents steps\nepsilon_schedule = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Epsilon schedule lineaire\")"
-   ]
+   ],
+   "id": "cell-bb0dd230"
   },
   {
    "cell_type": "markdown",
@@ -1278,7 +1282,8 @@
    "metadata": {},
    "source": [
     "### Exercice 3 : Ajouter un taux de reussite (win rate) aux metriques\n\nCalculez le **win rate** de l'agent DQN : le pourcentage de trades (round-trips) qui sont profitables.\n\n**Indices** :\n- `# Indice` : Un trade est profitable si le return du trade > 0\n- `# Indice` : Trackez les entrees et sorties de position dans l'environnement\n- `# Etape 1` : Identifier les trades complets (achat + vente)\n- `# Etape 2` : Compter les trades profitables\n- `# Etape 3` : Calculer le pourcentage"
-   ]
+   ],
+   "id": "cell-27029b86"
   },
   {
    "cell_type": "code",
@@ -1295,7 +1300,8 @@
    ],
    "source": [
     "# Exercice 3 : Win rate de l'agent DQN\n# TODO etudiant : Calculer le pourcentage de trades profitables\n# Etape 1 : Identifier les trades complets\n# Etape 2 : Compter les trades profitables\n# Etape 3 : Win rate = profitable / total * 100\nwin_rate = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Win rate de l'agent DQN\")"
-   ]
+   ],
+   "id": "cell-d1511916"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Add nbformat v4.5 `id` fields to cells missing them in the 3 QC-Py ML-Training notebooks:
- **QC-Py-30-LSTM-Training** — 6 cells missing id
- **QC-Py-31-Transformer-Training** — 6 cells missing id
- **QC-Py-32-RL-DQN-Trading** — 6 cells missing id

All 3 are already `nbformat_minor=5`; they only lacked the per-cell `id` field (required by nbformat 4.5, currently `MissingIDFieldWarning`, will become a hard error in future nbformat).

## Fix (surgical)

Add `"id": "cell-<8hex>"` (deterministic MD5-based, unique within each notebook) as the **last key** of each id-less cell. Minimal diff — only the id-addition pattern (`]` → `],` + `"id": "..."` line).

## Anti-regression proof (C.2 / H.3)

Content fingerprint (`cell_type` / `source` / `outputs` / `execution_count` / `metadata`) is **byte-identical before/after** on all 3 notebooks. These are **quantbooks** — outputs are real QC Cloud results; this PR does **not** re-execute locally (structural metadata fix, exec-equivalent per #6254 / #6257 / #6285). `nbformat.validate()` PASSES on all 3.

```
QC-Py-30  added=6 | content_same=True | validate PASS
QC-Py-31  added=6 | content_same=True | validate PASS
QC-Py-32  added=6 | content_same=True | validate PASS
```

## Non-collision

Disjoint slice from **#6254** (Cloud 7nb), **#6257** (main 12nb), **#6285** (02/03/09). This PR = the ML-Training thematic suite (LSTM / Transformer / RL-DQN). Stackable, no overlap.

See #6254, #6257, #6285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
