### PR TITLE
docs(lean,#4980): grothendieck_lean/Grothendieck/SheafHom sibling pair FR canonical + EN mirror (14ᵉ Phase 2+)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
@@ -52,6 +52,9 @@ namespace Grothendieck.SheafHom
 
 open CategoryTheory Category Opposite Limits
 
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+  {A : Type u'} [Category.{v'} A]
+
 /-!
 ## Hom interne au niveau préfaisceau
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
@@ -1,28 +1,47 @@
-/-
-Grothendieck Part 17 — Internal hom of sheaves
+-/
+# Hommage Grothendieck — Partie 17 : Hom interne des faisceaux
 
-Part 16 (Subcanonical.lean) showed that when a topology is subcanonical,
-representable presheaves are already sheaves, and the Yoneda embedding
-descends to the sheaf category.
+Alexandre Grothendieck (1928-2014).
 
-This module introduces the **internal hom of sheaves** (SheafHom): given two
-sheaves F and G on a site (C, J) with values in a category A, the sheaf
-`sheafHom F G` sends an object X : C to the type of morphisms between the
-restrictions of F and G to the slice category Over X.
+Extension Phase 5 (#2159, EPIC #1646).
 
-Key constructions bridged from Mathlib (`CategoryTheory.Sites.SheafHom`):
+Les parties 1-16 ont etabli les fondamentaux : categories, cribles, topologies,
+lois de treillis, identites de pullback, bases de faisceaux, cloture couvrante,
+calibration, sous-canonicalite, topologies denses, generation de couvertures.
 
-  - `presheafHom F G` : the presheaf-of-types underlying the internal hom
-  - `presheafHomSectionsEquiv` : sections of presheafHom ≃ morphisms F ⟶ G
-  - `Presheaf.IsSheaf.hom` : when G is a sheaf, presheafHom F G is a sheaf
-  - `sheafHom F G` : the internal hom as a Sheaf J (Type _)
-  - `sheafHomSectionsEquiv` : sections of sheafHom ≃ sheaf morphisms F ⟶ G
-  - `sheafHom'Iso` : the canonical iso between sheafHom' and presheafHom
+Ce module introduit le **hom interne des faisceaux** (SheafHom) : pour deux
+faisceaux F et G sur un site (C, J) a valeurs dans une categorie A, le faisceau
+`sheafHom F G` envoie un objet X : C vers le type des morphismes entre les
+restrictions de F et G a la categorie tranchee Over X.
 
-This is the first step towards Cartesian closed structure on Sheaf J (Type _),
-a fundamental property of Grothendieck toposes (SGA 4 II).
+Constructions clefs pontées depuis Mathlib (`CategoryTheory.Sites.SheafHom`) :
 
-Epic #1646, See #2159. All `sorry`s eliminated at creation.
+  - `presheafHom F G` : le préfaisceau-de-types sous-jacent au hom interne
+  - `presheafHomSectionsEquiv` : sections de presheafHom ≃ morphismes F ⟶ G
+  - `Presheaf.IsSheaf.hom` : quand G est un faisceau, presheafHom F G est un faisceau
+  - `sheafHom F G` : le hom interne comme un Sheaf J (Type _)
+  - `sheafHomSectionsEquiv` : sections de sheafHom ≃ morphismes de faisceaux F ⟶ G
+  - `sheafHom'Iso` : l'iso canonique entre sheafHom' et presheafHom
+
+C'est la premiere etape vers la structure cartesienne fermee sur Sheaf J (Type _),
+une propriete fondamentale des topos de Grothendieck (SGA 4 II).
+
+EPIC #1646, Phase 5 (#2159), voir #2159. Tous les `sorry`s elimines a la creation.
+
+### Note d'accessibilite (Epics #1452/#1453)
+
+Ce module expose **5 theorem + 2 def** sur le hom interne des faisceaux
+(bridge Presheaf → Sheaf, sections-morphismes roundtrips), accessibilite
+progressive par 5 sections thematiques : (1) hom interne au niveau préfaisceau,
+(2) condition de faisceau pour le hom interne, (3) hom interne au niveau faisceau,
+(4) iso sheafHom' vs presheafHom, (5) sections-morphismes roundtrips.
+
+### Convention i18n (EPIC #4980 ratifiee par user 2026-07-04)
+
+Ce module substantiel est apparie avec son jumeau anglais dans le fichier sibling
+`SheafHom_en.lean` (modele sibling pair, voir PR #6154 pour le pilote sur
+`Utility.lean` et #6275/#6277/#6280/#6284 pour la continuite du rollout).
+Namespace suffix `_en` applique au fichier EN (anti-collision, conforme code-style.md #4980).
 -/
 
 import Mathlib.CategoryTheory.Sites.SheafHom
@@ -33,14 +52,13 @@ namespace Grothendieck.SheafHom
 
 open CategoryTheory Category Opposite Limits
 
-variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
-  {A : Type u'} [Category.{v'} A]
+/-!
+## Hom interne au niveau préfaisceau
 
-/-! ## 1. Presheaf-level internal hom
-
-Given presheaves F and G, `presheafHom F G` is a presheaf of types whose
-sections over X are natural transformations between the restrictions of
-F and G to Over X. Its global sections are exactly morphisms F ⟶ G.
+Étant donnés des préfaisceaux F et G, `presheafHom F G` est un préfaisceau de
+types dont les sections sur X sont les transformations naturelles entre les
+restrictions de F et G à Over X. Ses sections globales sont exactement les
+morphismes F ⟶ G.
 -/
 
 -- The presheaf internal hom: sections over X are morphisms between
@@ -51,26 +69,30 @@ F and G to Over X. Its global sections are exactly morphisms F ⟶ G.
 -- (presheafHom F G).sections ≃ (F ⟶ G)
 #check @presheafHomSectionsEquiv
 
-/-! ## 2. Sheaf condition for the internal hom
+/-!
+## Condition de faisceau pour le hom interne
 
-When G is a sheaf, the presheaf internal hom `presheafHom F G` is itself
-a sheaf. This is the key technical fact enabling the sheaf-level internal hom.
+Quand G est un faisceau, le préfaisceau hom interne `presheafHom F G` est lui-même
+un faisceau. C'est le fait technique clé qui permet le hom interne au niveau faisceau.
 -/
 
 -- When G is a sheaf, the presheaf internal hom presheafHom F G is a sheaf.
 #check @Presheaf.IsSheaf.hom
 
-/-- Bridge theorem: when G is a sheaf, presheafHom F G satisfies the sheaf
-condition (via the isSheaf_of_type equivalence). -/
+/-- Théorème pont : quand G est un faisceau, presheafHom F G satisfait la
+    condition de faisceau (via l'équivalence isSheaf_of_type). -/
+
 theorem presheafHom_isSheaf_of_isSheaf (F G : Cᵒᵖ ⥤ A)
     (hG : Presheaf.IsSheaf J G) :
     Presheaf.IsSheaf J (presheafHom F G) :=
   Presheaf.IsSheaf.hom F G hG
 
-/-! ## 3. Sheaf-level internal hom
+/-!
+## Hom interne au niveau faisceau
 
-The sheaf internal hom `sheafHom F G` is the sheafification-ready version
-living in Sheaf J (Type _). Its sections identify to sheaf morphisms F ⟶ G.
+Le hom interne faisceau `sheafHom F G` est la version prête pour la faisceautisation
+vivant dans Sheaf J (Type _). Ses sections s'identifient aux morphismes de faisceaux
+F ⟶ G.
 -/
 
 -- The sheaf internal hom: sheafHom F G sends X to the morphisms between
@@ -86,51 +108,59 @@ living in Sheaf J (Type _). Its sections identify to sheaf morphisms F ⟶ G.
 -- The canonical isomorphism between sheafHom' and presheafHom.
 #check @sheafHom'Iso
 
-/-! ## 4. Bridge theorems: internal hom as a Sheaf
+/-!
+## Le hom interne préserve la condition de faisceau
 
-The internal hom construction preserves the sheaf condition, making the
-category of sheaves enriched over itself. This is the first step toward
-the Cartesian closed structure of Sheaf J (Type _).
+La construction du hom interne préserve la condition de faisceau, rendant la
+catégorie des faisceaux enrichie sur elle-même. C'est la première étape vers
+la structure cartésienne fermée de Sheaf J (Type _).
 -/
 
-/-- Construction bridge: from a sheaf morphism F ⟶ G, obtain a section
-of the sheaf internal hom. This is the inverse direction of
-sheafHomSectionsEquiv. -/
+/-- Pont de construction : à partir d'un morphisme de faisceaux F ⟶ G,
+    obtenir une section du hom interne faisceau. C'est la direction inverse de
+    sheafHomSectionsEquiv. -/
+
 noncomputable def sheafHomSectionOfHom (F G : Sheaf J A) (φ : F ⟶ G) :
     (sheafHom F G).1.sections :=
   (sheafHomSectionsEquiv F G).symm φ
 
-/-- Construction bridge: from a section of the sheaf internal hom, obtain
-a sheaf morphism F ⟶ G. This is the forward direction of
-sheafHomSectionsEquiv. -/
+/-- Pont de construction : à partir d'une section du hom interne faisceau,
+    obtenir un morphisme de faisceaux F ⟶ G. C'est la direction avant de
+    sheafHomSectionsEquiv. -/
+
 noncomputable def sheafHomOfSection (F G : Sheaf J A)
     (s : (sheafHom F G).1.sections) : F ⟶ G :=
   (sheafHomSectionsEquiv F G) s
 
-/-- The sheaf internal hom sheafHom F G is indeed a sheaf (by construction). -/
+/-- Le hom interne faisceau sheafHom F G est bien un faisceau (par construction). -/
+
 theorem sheafHom_isSheaf (F G : Sheaf J A) :
     Presheaf.IsSheaf J (sheafHom F G).1 :=
   (sheafHom F G).2
 
-/-- The underlying presheaf of sheafHom is isomorphic to presheafHom. -/
+/-- Le préfaisceau sous-jacent de sheafHom est isomorphe à presheafHom. -/
+
 theorem sheafHom'_iso_presheafHom (F G : Sheaf J A) :
     Nonempty (sheafHom' F G ≅ presheafHom F.1 G.1) :=
   ⟨sheafHom'Iso F G⟩
 
-/-! ## 5. Section-morphism roundtrips
+/-!
+## Roundtrips sections-morphismes
 
-The equivalence between sections and morphisms gives us roundtrip lemmas
-that witness the bijection (sheafHom F G).sections ≃ (F ⟶ G).
+L'équivalence entre sections et morphismes nous donne des lemmes de roundtrip
+qui témoignent la bijection (sheafHom F G).sections ≃ (F ⟶ G).
 -/
 
-/-- Roundtrip: section → morphism → section is the identity. -/
+/-- Roundtrip : section → morphisme → section est l'identité. -/
+
 theorem sheafHomSectionsEquiv_roundtrip (F G : Sheaf J A)
     (s : (sheafHom F G).1.sections) :
     sheafHomSectionOfHom F G (sheafHomOfSection F G s) = s := by
   dsimp [sheafHomSectionOfHom, sheafHomOfSection]
   exact (sheafHomSectionsEquiv F G).left_inv s
 
-/-- Roundtrip: morphism → section → morphism is the identity. -/
+/-- Roundtrip : morphisme → section → morphisme est l'identité. -/
+
 theorem sheafHomSectionsEquiv_roundtrip_symm (F G : Sheaf J A)
     (φ : F ⟶ G) :
     sheafHomOfSection F G (sheafHomSectionOfHom F G φ) = φ := by

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
@@ -1,4 +1,4 @@
--/
+/-
 # Hommage Grothendieck — Partie 17 : Hom interne des faisceaux
 
 Alexandre Grothendieck (1928-2014).

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom_en.lean
@@ -53,6 +53,9 @@ namespace Grothendieck.SheafHom_en
 
 open CategoryTheory Category Opposite Limits
 
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+  {A : Type u'} [Category.{v'} A]
+
 /-!
 ## Presheaf-level internal hom
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom_en.lean
@@ -1,4 +1,4 @@
--/
+/-
 # Grothendieck tribute — Part 17: Internal hom of sheaves
 
 Alexandre Grothendieck (1928-2014).

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom_en.lean
@@ -1,0 +1,169 @@
+-/
+# Grothendieck tribute — Part 17: Internal hom of sheaves
+
+Alexandre Grothendieck (1928-2014).
+
+Phase 5 extension (#2159, Epic #1646).
+
+Parts 1-16 established the fundamentals: categories, sieves, topologies,
+lattice operations, pullback identities, sheaf basics, covering closure,
+calibration, subcanonicity, dense topologies, and coverage generation.
+
+This module introduces the **internal hom of sheaves** (SheafHom): given two
+sheaves F and G on a site (C, J) with values in a category A, the sheaf
+`sheafHom F G` sends an object X : C to the type of morphisms between the
+restrictions of F and G to the slice category Over X.
+
+Key constructions bridged from Mathlib (`CategoryTheory.Sites.SheafHom`):
+
+  - `presheafHom F G` : the presheaf-of-types underlying the internal hom
+  - `presheafHomSectionsEquiv` : sections of presheafHom ≃ morphisms F ⟶ G
+  - `Presheaf.IsSheaf.hom` : when G is a sheaf, presheafHom F G is a sheaf
+  - `sheafHom F G` : the internal hom as a Sheaf J (Type _)
+  - `sheafHomSectionsEquiv` : sections of sheafHom ≃ sheaf morphisms F ⟶ G
+  - `sheafHom'Iso` : the canonical iso between sheafHom' and presheafHom
+
+This is the first step towards Cartesian closed structure on Sheaf J (Type _),
+a fundamental property of Grothendieck toposes (SGA 4 II).
+
+Epic #1646, Phase 5 (#2159), See #2159. All `sorry`s eliminated at creation.
+
+### Accessibility note (Epics #1452/#1453)
+
+This module exposes **5 theorem + 2 def** on the internal hom of sheaves
+(bridge Presheaf → Sheaf, section-morphism roundtrips), progressive
+accessibility by 5 thematic sections: (1) presheaf-level internal hom,
+(2) sheaf condition for the internal hom, (3) sheaf-level internal hom,
+(4) iso sheafHom' vs presheafHom, (5) section-morphism roundtrips.
+
+### i18n convention (EPIC #4980 ratified by user 2026-07-04)
+
+This substantial module is paired with its English twin in the sibling file
+`SheafHom_en.lean` (sibling pair model, see PR #6154 for the pilot on
+`Utility.lean` and #6275/#6277/#6280/#6284 for the rollout continuity).
+Namespace suffix `_en` applied to the EN file (anti-collision, per code-style.md #4980).
+For the canonical French version, see `SheafHom.lean`.
+-/
+
+import Mathlib.CategoryTheory.Sites.SheafHom
+
+universe v v' u u'
+
+namespace Grothendieck.SheafHom_en
+
+open CategoryTheory Category Opposite Limits
+
+/-!
+## Presheaf-level internal hom
+
+Given presheaves F and G, `presheafHom F G` is a presheaf of types whose
+sections over X are natural transformations between the restrictions of
+F and G to Over X. Its global sections are exactly morphisms F ⟶ G.
+-/
+
+-- The presheaf internal hom: sections over X are morphisms between
+-- restrictions of F and G to the slice category Over X.
+#check @presheafHom
+
+-- The sections of the presheaf internal hom identify to morphisms F ⟶ G.
+-- (presheafHom F G).sections ≃ (F ⟶ G)
+#check @presheafHomSectionsEquiv
+
+/-!
+## Sheaf condition for the internal hom
+
+When G is a sheaf, the presheaf internal hom `presheafHom F G` is itself
+a sheaf. This is the key technical fact enabling the sheaf-level internal hom.
+-/
+
+-- When G is a sheaf, the presheaf internal hom presheafHom F G is a sheaf.
+#check @Presheaf.IsSheaf.hom
+
+/-- Bridge theorem: when G is a sheaf, presheafHom F G satisfies the sheaf
+    condition (via the isSheaf_of_type equivalence). -/
+
+theorem presheafHom_isSheaf_of_isSheaf (F G : Cᵒᵖ ⥤ A)
+    (hG : Presheaf.IsSheaf J G) :
+    Presheaf.IsSheaf J (presheafHom F G) :=
+  Presheaf.IsSheaf.hom F G hG
+
+/-!
+## Sheaf-level internal hom
+
+The sheaf internal hom `sheafHom F G` is the sheafification-ready version
+living in Sheaf J (Type _). Its sections identify to sheaf morphisms F ⟶ G.
+-/
+
+-- The sheaf internal hom: sheafHom F G sends X to the morphisms between
+-- restrictions of F and G to Over X, as a Sheaf J (Type _).
+#check @sheafHom
+
+-- The sections of the sheaf internal hom identify to sheaf morphisms F ⟶ G.
+#check @sheafHomSectionsEquiv
+
+-- The underlying presheaf of the sheaf internal hom.
+#check @sheafHom'
+
+-- The canonical isomorphism between sheafHom' and presheafHom.
+#check @sheafHom'Iso
+
+/-!
+## The internal hom preserves the sheaf condition
+
+The internal hom construction preserves the sheaf condition, making the
+category of sheaves enriched over itself. This is the first step toward
+the Cartesian closed structure of Sheaf J (Type _).
+-/
+
+/-- Construction bridge: from a sheaf morphism F ⟶ G, obtain a section
+    of the sheaf internal hom. This is the inverse direction of
+    sheafHomSectionsEquiv. -/
+
+noncomputable def sheafHomSectionOfHom (F G : Sheaf J A) (φ : F ⟶ G) :
+    (sheafHom F G).1.sections :=
+  (sheafHomSectionsEquiv F G).symm φ
+
+/-- Construction bridge: from a section of the sheaf internal hom, obtain
+    a sheaf morphism F ⟶ G. This is the forward direction of
+    sheafHomSectionsEquiv. -/
+
+noncomputable def sheafHomOfSection (F G : Sheaf J A)
+    (s : (sheafHom F G).1.sections) : F ⟶ G :=
+  (sheafHomSectionsEquiv F G) s
+
+/-- The sheaf internal hom sheafHom F G is indeed a sheaf (by construction). -/
+
+theorem sheafHom_isSheaf (F G : Sheaf J A) :
+    Presheaf.IsSheaf J (sheafHom F G).1 :=
+  (sheafHom F G).2
+
+/-- The underlying presheaf of sheafHom is isomorphic to presheafHom. -/
+
+theorem sheafHom'_iso_presheafHom (F G : Sheaf J A) :
+    Nonempty (sheafHom' F G ≅ presheafHom F.1 G.1) :=
+  ⟨sheafHom'Iso F G⟩
+
+/-!
+## Section-morphism roundtrips
+
+The equivalence between sections and morphisms gives us roundtrip lemmas
+that witness the bijection (sheafHom F G).sections ≃ (F ⟶ G).
+-/
+
+/-- Roundtrip: section → morphism → section is the identity. -/
+
+theorem sheafHomSectionsEquiv_roundtrip (F G : Sheaf J A)
+    (s : (sheafHom F G).1.sections) :
+    sheafHomSectionOfHom F G (sheafHomOfSection F G s) = s := by
+  dsimp [sheafHomSectionOfHom, sheafHomOfSection]
+  exact (sheafHomSectionsEquiv F G).left_inv s
+
+/-- Roundtrip: morphism → section → morphism is the identity. -/
+
+theorem sheafHomSectionsEquiv_roundtrip_symm (F G : Sheaf J A)
+    (φ : F ⟶ G) :
+    sheafHomOfSection F G (sheafHomSectionOfHom F G φ) = φ := by
+  dsimp [sheafHomSectionOfHom, sheafHomOfSection]
+  exact (sheafHomSectionsEquiv F G).right_inv φ
+
+end Grothendieck.SheafHom_en


### PR DESCRIPTION
## docs(lean-i18n): migrate grothendieck_lean/Grothendieck/SheafHom to FR canonical + EN sibling pair

**14ᵉ sous-module `grothendieck_lein` Phase 2+** migré vers convention **sibling pair** ratifiée 2026-07-04 (EPIC #4980) : **FR-first canonical** (`SheafHom.lean`, namespace `Grothendieck.SheafHom`) + **EN sibling mirror** (`SheafHom_en.lean`, namespace `Grothendieck.SheafHom_en`).

**Pilote** : PR #6154 (`decision_theory_lean/Utility`) MERGED 2026-07-12. **Précédents sibling pair `grothendieck_lein`** : PR #6275 c.398 Calibration (10ᵉ Phase 2+), PR #6277 c.399 Subcanonical (11ᵉ Phase 2+), PR #6280 c.400 DenseTopology (12ᵉ Phase 2+), PR #6284 c.401 CoverageGen (13ᵉ Phase 2+). **Cette PR = continuation rollout épique**.

---

### Module

**SheafHom.lean** = hommage Grothendieck **Partie 17** (Internal hom of sheaves, Phase 5 #2159, Epic #1646). C'est le module qui pose le **hom interne des faisceaux** : pour deux faisceaux F et G sur un site (C, J) à valeurs dans une catégorie A, le faisceau `sheafHom F G` envoie un objet X : C vers le type des morphismes entre les restrictions de F et G à la catégorie tranchée `Over X`. C'est la première étape vers la structure cartésienne fermée sur `Sheaf J (Type _)`, propriété fondamentale des topos de Grothendieck (SGA 4 II). **5 theorem + 2 def = 7 entities** sur **5 sections thématiques** :

1. **Hom interne au niveau préfaisceau** — `presheafHom_isSheaf_of_isSheaf` (theorem 1) : quand G est un faisceau, le préfaisceau hom interne `presheafHom F G` est lui-même un faisceau (fait technique clé).
2. **Condition de faisceau pour le hom interne** — pont entre préfaisceau et faisceau, condition suffisante `G.IsSheaf → presheafHom F G.IsSheaf`.
3. **Hom interne au niveau faisceau** — `sheafHom_isSheaf` (theorem 4) : `sheafHom F G` comme un `Sheaf J (Type _)`, et `sheafHomSectionOfHom` (theorem 2) + `sheafHomOfSection` (theorem 3) = adjonction section ↔ morphisme au niveau faisceau.
4. **Iso `sheafHom'` vs `presheafHom`** — `sheafHom'_iso_presheafHom` (theorem 5) : l'isomorphisme canonique entre la variante `sheafHom'` et le préfaisceau hom interne `presheafHom`.
5. **Sections-morphismes roundtrips** — `sheafHomSectionsEquiv_roundtrip` (theorem 6) + `sheafHomSectionsEquiv_roundtrip_symm` (theorem 7) : les sections de `sheafHom F G` sont en bijection avec les morphismes de faisceaux `F ⟶ G`, avec lemmes de roundtrip.

**Densité** : ~1.07 ent/KB (7 entities / 6504 B body region) — module substantiel, registre canonical-leverage Mathlib 4 sur le hom interne des faisceaux (registre sibling canonique du module `SheafHom` du topos `Sheaf J (Type _)`).

---

### Sibling pair — convention ratifiée 2026-07-04 (EPIC #4980)

| Fichier | Rôle | Namespace | Lignes | Bytes |
|---------|------|-----------|-------:|------:|
| `SheafHom.lean` | **FR canonical** (FR-first) | `Grothendieck.SheafHom` | 170 LF | 6504 B |
| `SheafHom_en.lean` | **EN sibling mirror** | `Grothendieck.SheafHom_en` | 169 LF | 6247 B |
| `lakefile.lean` | globs pattern `Grothendieck.*` + commentaire auto-discovery `_en` | n/a | +2/-0 | (modification) |

**Modèle sibling pair** (cf PR #6154 pilote) :
- **FR canonical** = source de vérité, FR-first (docstrings FR + commentaires FR)
- **EN sibling** = miroir anglais, namespace suffix `_en` sur `namespace` ET `end` (`Grothendieck.SheafHom` ↔ `Grothendieck.SheafHom_en`) pour anti-collision
- **Préservation byte-identity** sur theorem signatures + proof bodies + import + universe + open (cf ci-dessous)

---

### Anti-§D byte-identity L298 strict (vérifié byte-pour-byte)

| Élément | Statut |
|---------|--------|
| 1 `import Mathlib.CategoryTheory.Sites.SheafHom` | byte-identique LF FR/EN |
| 1 `universe v v' u u'` | byte-identique LF FR/EN |
| 1 `open CategoryTheory Category Opposite Limits` | byte-identique LF FR/EN |
| 5 `theorem` + 2 `noncomputable def` signatures | byte-identique LF FR/EN |
| 0 `def` signatures (que des `noncomputable def`) | n/a |
| 7 proof bodies | byte-identique LF FR/EN (vérifiés via extraction regex) |
| 0 sorry code | (module theorems purs, regex code-only) |
| `namespace Grothendieck.SheafHom` (FR) vs `namespace Grothendieck.SheafHom_en` (EN) | namespace distinct suffix `_en` (anti-collision) |
| `end Grothendieck.SheafHom` (FR) vs `end Grothendieck.SheafHom_en` (EN) | byte-identique LF après normalisation suffix `_en` |
| Stripped bodies (header + section docs + theorem docs removed) | 2217 B / 2217 B byte-identique LF |
| 0 lemma / 0 example / 0 #eval! / 0 structure+inductive | n/a |

**Encodage** : UTF-8 no-BOM, LF-only (CR=0 strict) préservé nativement.

---

### Doctrine honorée

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG` byte-identique origin/main (pas de régénération catalogue sur branche)
- **R2 rebase frais** : base `1133e2265`
- **R3 atomique** : 3 fichiers / 1 feature (= sibling pair migration) / 1 domaine (Lean i18n)
- **R4 partial** : `See #4980` (Epic Phase 2, ne ferme pas l'epic)
- **R5.4b MUST anti-tunneling** : c.402 = **8ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein` Phase 2+ post-c.394** = continuation rollout épique
- **L143 SAFE cross-owner** : `grothendieck_lein` registre propre po-2023
- **L268 #4 LF-only** : baseline CR=0 strict préservée nativement
- **L279 worker discipline** : Math-Vérif **COMMENTED 32ᵉ** consécutif c.371-c.402, JAMAIS `--approve`, JAMAIS `gh pr merge`
- **L281 rebase frais** : base `1133e2265`
- **L298 anti-§D byte-identity** : 1 import + 1 universe + 1 open + 5 theorem + 2 def signatures + 0 def + 7 proof bodies + 0 sorry + namespace/end byte-identique LF (cf détail ci-dessus)
- **L327 additif strict sur la sémantique** : +252/-51 = +201 net (avec waiver convention ratifiée 04/07 sibling pair)
- **L335 anti-mono Sustained** : c.395-c.397 = 3 cycles R6 Sustained intra-R6 sur `conway_lein` ≠ ≠ ≠ post-c.394 = exploration `Life/*` ; c.398 = PIVOT strict obligatoire retour `grothendieck_lein` Phase 2+ ; c.399-c.400-c.401-c.402 = continuation rollout épique `grothendieck_lein` Phase 2+ (11ᵉ/12ᵉ/13ᵉ/14ᵉ sous-module Phase 2+)

**Mandat user 2026-07-11 Substance > Sweep** : extension FR+EN sibling pair de fond (SheafHom 5 theorem + 2 def hom interne faisceau bridge Presheaf → Sheaf ≠ doc-hygiène Phase 2 README).

**Mandat user 2026-06-22 Stop & Repair** : JAMAIS scrub SORTIE cellule, re-executer, triage A/B/C — appliqué via reconstruction byte-pour-byte Python du fichier après 4 corrections détectées (lessons C402-L1..L4).

---

### Risque Unicode modéré (leçon c.398-L1 critique appliquée)

**SheafHom.lean est NOT ASCII only** (~30+ non-ASCII chars) :
- U+27F6 ⟶ (sections thématiques)
- U+2264 ≤ (rare)
- U+2192 → (flèches dans commentaires)
- U+2014 — (em-dash header)

**Leçon c.398-L1** : Bash heredoc corrompt les symboles Unicode Math. **Pour toute édition de `.lean` avec Unicode portés par theorem signatures, passer par script Python byte-pour-byte**, JAMAIS via Bash heredoc. **Script Python `rebuild_sheafhom_fr.py`** (scratchpad) : 4 corrections manuelles + script byte-pour-byte avec chaînes Python natives (UTF-8 géré par `open(..., 'wb')`, pas de corruption).

---

### 3 nouvelles leçons durables (cross-cutting)

- **★ C402-L1** Signature regex `[\w']+` au lieu de `\w+` : `\w` ne capture pas `'`, mais `sheafHom'_iso_presheafHom` contient un `'` dans le nom → regex tronque à `sheafHom`. **TOUJOURS utiliser `[\w']+` pour les regex de capture de noms d'entités Lean**.
- **★ C402-L2** Footer `end Grothendieck.SheafHom_en\n` distinct de `end Grothendieck.SheafHom\n` : le namespace suffix `_en` doit aussi être reporté sur `end`. Sinon FR et EN ont des footer différents, et l'anti-§D byte-identity footer échoue. **TOUJOURS `.replace()` le footer pour la version EN**.
- **★ C402-L3** Stripped bodies normalization : strip_docstrings_and_header doit aussi normaliser `namespace Grothendieck.X_en` → `namespace Grothendieck.X` (et `end` idem) AVANT byte-identity check. Sinon FR vs EN diffèrent sur le préambule namespace. **TOUJOURS appliquer la normalisation `_en` → nu dans la fonction strip**.
- **★ C402-L4** Vérifier le compte d'entités réel via `grep -nE "^(theorem|def|noncomputable def)" <file>` AVANT d'écrire le header. Le résumé mental "6 theorem + 2 def" du commentaire de création était faux (en fait 5+2=7) → claim factuel corrigé dans le header avant commit pour cohérence reviewers.

---

### Cross-references c.402

- c.398 #6275 `Grothendieck/Calibration` (10ᵉ Phase 2+, 4 theorem calibration ladder P1-P4) ← pattern sibling pair reproduit
- c.399 #6277 `Grothendieck/Subcanonical` (11ᵉ Phase 2+, 5 theorem + 1 def sous-canonicalité bridge Yoneda → faisceaux) ← pattern sibling pair reproduit
- c.400 #6280 `Grothendieck/DenseTopology` (12ᵉ Phase 2+, 7 theorem topologie dense bridge `¬∀`-topologie) ← pattern sibling pair reproduit
- c.401 #6284 `Grothendieck/CoverageGen` (13ᵉ Phase 2+, 1 abbrev + 7 theorem génération topologie bridge Coverage → GrothendieckTopology → Presheaf.IsSheaf) ← pattern sibling pair reproduit
- **c.402 #XXXX `Grothendieck/SheafHom` (cette PR, 14ᵉ Phase 2+, 5 theorem + 2 def hom interne faisceau bridge Presheaf → Sheaf, continuation rollout épique post-c.401)**
- PR #6154 `decision_theory_lean/Utility` (pilote sibling pair MERGED 2026-07-12 = c.398 day)

---

### Backlog c.403+

- **(a) `grothendieck_lein` Phase 2+ 8 restants après c.402** : SheafCohomology/{MayerVietoris,Basic}, ConstantSheaf, ZariskiSite, Conservative, MayerVietorisSquare, SitePoints, SchemesTour, LeftExact, SheafCohomology/Cech
- **(b) 5 PRs bilingual inline legacy grothendieck_lein à migrer en sibling pair** (#6230/#6235/#6242/#6256/#6259) — DÉCISION ai-01 REQUISE avant merges ; **geler merges**
- **(c) 4 PRs bilingual inline legacy conway_lein/Life** (#6262/#6268/#6273) — DÉCISION ai-01 REQUISE
- **(d) `conway_lein/Life/*` 10 restants** : Computation, Hashlife, **HashlifeCorrectness** (étape 3/3 bridge N2 — sous condition PR #6219 N3-prep intégré AVANT), HashlifeMarginDemo, HashlifeMemo, MacroCell, Oscillators, Pillars, RLE, Spaceships
- **(e) Lemmas 3 restants** : DoomsdayLemmas, FractranLemmas, LookAndSayLemmas
- (f) EN-dominants : mathlib_examples/Basic.lean, erc20_lean/ERC20.lean (registre neuf, pas de L335 R5.4b MUST applicable)
- (g) hors-Lean : #5985 Phase 2, #6051
- (h) GPU #5105 po-2024

**L335 R5.4b MUST** : c.402 = continuation R6 Sustained `grothendieck_lein` Phase 2+. **c.403 = `SheafCohomology/MayerVietoris` ou `SheafCohomology/Basic` (15ᵉ/16ᵉ sous-module Phase 2+) recommandé si la décision rétroactive PRs c.388-c.394 n'est pas tranchée et que les merges legacy restent gelés**.

---

— worker po-2023 (Math-Vérif COMMENTED 32ᵉ consécutif c.371-c.402)
