### PR TITLE
fix(search): nbformat v4.5 cell ids for Search-5/7/8-Csharp + Search-12 (109 cells)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
@@ -24,7 +24,8 @@
     "- Search-4-LocalSearch (notion de paysage d'optimisation)\n",
     "\n",
     "### Durée estimée : ~1h"
-   ]
+   ],
+   "id": "cell-ea82750b"
   },
   {
    "cell_type": "markdown",
@@ -39,7 +40,8 @@
     "3. **Mutation** — perturbation aléatoire, source de diversité et d'exploration.\n",
     "\n",
     "**Pourquoi les AG ?** Ils excellent sur les espaces de recherche vastes, non-différentiables, multimodaux — là où le gradient est inutilisable (Search-4 a montré les limites du hill-climbing sur les paysages accidentés)."
-   ]
+   ],
+   "id": "cell-78d21e5d"
   },
   {
    "cell_type": "markdown",
@@ -59,7 +61,8 @@
     "### 2.2 Opérateurs\n",
     "\n",
     "Classe GA **générique** paramétrée par le type de gène : `record` immutable pour l'individu + délégués pour chaque opérateur (pattern établi par les jumeaux Search-6/13/14-Csharp)."
-   ]
+   ],
+   "id": "cell-e2091fc1"
   },
   {
    "cell_type": "code",
@@ -248,7 +251,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-fdca2a4b"
   },
   {
    "cell_type": "markdown",
@@ -259,7 +263,8 @@
     "- **Sélection roulette** : probabilité proportionnelle au fitness ; **tournoi** : meilleur de k tirés au hasard.\n",
     "- **Crossover 1-point** : un point de coupure aléatoire.\n",
     "- **Mutation bit-flip** : chaque bit inversé avec probabilité `mutationRate`."
-   ]
+   ],
+   "id": "cell-4815cdce"
   },
   {
    "cell_type": "code",
@@ -307,7 +312,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-363f0417"
   },
   {
    "cell_type": "markdown",
@@ -316,7 +322,8 @@
     "## 3. AG from-scratch : OneMax (~10 min)\n",
     "\n",
     "**OneMax** = maximiser la somme des bits d'un chromosome binaire. Solution optimale triviale (tous les bits à 1), ce qui rend la **convergence** (et non le résultat) l'objet d'étude : un GA sain converge en un nombre de générations prévisible."
-   ]
+   ],
+   "id": "cell-df39f534"
   },
   {
    "cell_type": "code",
@@ -368,7 +375,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-88127a6d"
   },
   {
    "cell_type": "markdown",
@@ -381,7 +389,8 @@
     "$$f(\\mathbf{x}) = 10d + \\sum_{i=1}^{d} \\left[ x_i^2 - 10\\cos(2\\pi x_i) \\right]$$\n",
     "\n",
     "On réutilise **la même classe `GeneticAlgorithm<T>`** avec des opérateurs réels (crossover arithmétique + mutation gaussienne). Le Python appelle ça DEAP (§4) ou PyGAD (§5) ; en .NET on le code en ~20 lignes, ce qui **démystifie** le framework."
-   ]
+   ],
+   "id": "cell-9cf00647"
   },
   {
    "cell_type": "code",
@@ -465,7 +474,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-eaed0471"
   },
   {
    "cell_type": "markdown",
@@ -476,7 +486,8 @@
     "### 5.1 Élitisme\n",
     "\n",
     "L'**élitisme** préserve les N meilleurs individus d'une génération à la suivante. Il garantit que le meilleur jamais trouvé ne se dégrade jamais — au prix d'un risque accru de convergence prématurée."
-   ]
+   ],
+   "id": "cell-7d516ae4"
   },
   {
    "cell_type": "code",
@@ -520,7 +531,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-0ab1d10a"
   },
   {
    "cell_type": "markdown",
@@ -529,7 +541,8 @@
     "### 5.2 Taux de mutation adaptatif\n",
     "\n",
     "Plutôt qu'un taux fixe, on le fait **décroître** avec les générations : forte exploration au début, raffinement à la fin."
-   ]
+   ],
+   "id": "cell-a24080e6"
   },
   {
    "cell_type": "code",
@@ -574,7 +587,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-36594784"
   },
   {
    "cell_type": "markdown",
@@ -596,7 +610,8 @@
     "**Exercice 2 — Effet de la taille de population.** Faites varier `PopulationSize` ∈ {20, 50, 100, 200} sur Rastrigin (mêmes générations). Affichez (table texte) le meilleur f(x) final. Y a-t-il un rendement décroissant ?\n",
     "\n",
     "**Exercice 3 — Mutation adaptative.** Modifiez `GeneticAlgorithm<T>.Run` pour que le taux de mutation passe à `AdaptiveRate(g, generations)` à chaque génération. Relancez OneMax. Comparez la trajectoire de convergence au taux fixe 0.01."
-   ]
+   ],
+   "id": "cell-dbb056a3"
   },
   {
    "cell_type": "code",
@@ -726,7 +741,8 @@
     "- Holland, J.H. (1975). *Adaptation in Natural and Artificial Systems*.\n",
     "- Goldberg, D.E. (1989). *Genetic Algorithms in Search, Optimization and Machine Learning*.\n",
     "- Jumeau Python : [Search-5-GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb) (DEAP + PyGAD)."
-   ]
+   ],
+   "id": "cell-69ee585e"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
@@ -25,7 +25,8 @@
     "> **Jumeau .NET** du notebook Python [Search-7-MCTS-And-Beyond.ipynb](Search-7-MCTS-And-Beyond.ipynb). Meme pedagogie, implementation C# idiome. Les graphiques matplotlib sont remplaces par des tables texte (le kernel .NET Interactive fuiterait des chemins ScottPlot/SkiaSharp, verdict INTRINSIC #3436).\n",
     "\n",
     "### Duree estimee : 90 minutes\n"
-   ]
+   ],
+   "id": "cell-02cf00de"
   },
   {
    "cell_type": "code",
@@ -157,7 +158,8 @@
    ],
    "source": [
     "// Cellule 1 : Environnement + interface du jeu (somme nulle)\nusing System.Diagnostics;\nusing System.Globalization;\n\n// Contrat commun a tous les jeux a deux joueurs, somme nulle, tour a tour.\n// TAction est fixe a int (TicTacToe = indice 0-8, Nim = 1-3, Connect-4 = colonne 0-6).\npublic interface IJeuSommeNulle<TEtat>\n{\n    TEtat EtatInitial();\n    string Joueur(TEtat etat);                  // \"MAX\" ou \"MIN\"\n    List<int> Actions(TEtat etat);\n    TEtat Resultat(TEtat etat, int action);\n    bool EstTerminal(TEtat etat);\n    double Utilite(TEtat etat, string joueur);  // +1 victoire, -1 defaite, 0 nul\n}\n\nConsole.WriteLine(\"Environnement pret pour MCTS (C# / .NET Interactive).\");"
-   ]
+   ],
+   "id": "cell-72246cc9"
   },
   {
    "cell_type": "markdown",
@@ -182,7 +184,8 @@
     "MCTS permet d'explorer intelligemment sans fonction d'evaluation experte !\n",
     "\n",
     "> *Ancres savantes -- von Neumann (1928),Zur Theorie der Gesellschaftsspiele, Math. Annalen 100:295-320 (theoreme minimax) ; Kocsis & Szepesvari (2006), Bandit Based Monte-Carlo Planning, ECML, LNCS 4212:282-293 (UCT = MCTS + UCB1) ; Silver et al. (2016), Mastering the game of Go with deep neural networks and tree search, Nature 529:484-489 (AlphaGo) ; Silver et al. (2017), Mastering the game of Go without human knowledge, Nature 550:354-359 (AlphaGo Zero) ; Browne et al. (2012), A Survey of Monte Carlo Tree Search Methods, IEEE TCIAIG 4(1):1-43.*\n"
-   ]
+   ],
+   "id": "cell-86c3a6f4"
   },
   {
    "cell_type": "markdown",
@@ -207,7 +210,8 @@
     "- **W/N** : Taux de victoire (exploitation)\n",
     "- **c * sqrt(...)** : Terme d'exploration (c = 1.41 = sqrt(2) typiquement)\n",
     "- **N** : Nombre de visites du noeud ; **N_parent** : visites du parent\n"
-   ]
+   ],
+   "id": "cell-a9ab6457"
   },
   {
    "cell_type": "code",
@@ -237,14 +241,16 @@
    ],
    "source": [
     "// Cellule 4 : Noeud de l'arbre MCTS (UCB1, selection, expansion)\npublic class NoeudMCTS<TEtat>\n{\n    public TEtat Etat { get; }\n    public NoeudMCTS<TEtat>? Parent { get; }\n    public int Action { get; }                         // coup qui a mene a cet etat (-1 = racine)\n    public Dictionary<int, NoeudMCTS<TEtat>> Enfants { get; } = new();\n    public int Visites { get; set; } = 0;\n    public double Victoires { get; set; } = 0.0;\n    public List<int>? ActionsNonExplorees { get; set; } // lazy a la premiere expansion\n\n    public NoeudMCTS(TEtat etat, NoeudMCTS<TEtat>? parent = null, int action = -1)\n    { Etat = etat; Parent = parent; Action = action; }\n\n    // Convention UCT \"moved-into\" : Victoires/Visites est du point de vue du joueur qui a\n    // DECIDE le coup vers ce noeud (voir Backpropagation dans MCTS<T>). Tous les enfants\n    // d'un meme parent etant evalues du point de vue de ce parent, MeilleurEnfantUcb1\n    // (max) selectionne bien le meilleur coup pour le joueur qui decide.\n\n    // Score UCB1 : exploitation (W/N) + exploration (c * sqrt(ln(N_parent)/N))\n    public double Ucb1(double c = 1.41)\n    {\n        if (Visites == 0) return double.PositiveInfinity;\n        double exploitation = Victoires / Visites;\n        double exploration = c * Math.Sqrt(Math.Log(Parent!.Visites) / Visites);\n        return exploitation + exploration;\n    }\n\n    public NoeudMCTS<TEtat> MeilleurEnfantUcb1(double c = 1.41)\n        => Enfants.Values.MaxBy(n => n.Ucb1(c))!;\n\n    public NoeudMCTS<TEtat> MeilleurEnfantVisites()\n        => Enfants.Values.MaxBy(n => n.Visites)!;\n\n    public bool EstFullyExpanded(IJeuSommeNulle<TEtat> jeu)\n    {\n        ActionsNonExplorees ??= jeu.Actions(Etat);\n        return ActionsNonExplorees.Count == 0;\n    }\n\n    public bool EstTerminal(IJeuSommeNulle<TEtat> jeu) => jeu.EstTerminal(Etat);\n}\n\nConsole.WriteLine(\"Classe NoeudMCTS<T> definie (UCB1, selection, expansion).\");"
-   ]
+   ],
+   "id": "cell-0615afb3"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Implementation de la classe MCTS avec selection UCB1, expansion, simulation (rollout aleatoire) et retropropagation."
-   ]
+   ],
+   "id": "cell-bb81de6f"
   },
   {
    "cell_type": "code",
@@ -270,14 +276,16 @@
    ],
    "source": [
     "// Cellule 6 : MCTS<T> -- selection (UCB1), expansion, simulation (rollout), backpropagation\npublic class MCTS<TEtat>\n{\n    private readonly IJeuSommeNulle<TEtat> _jeu;\n    private readonly double _c;\n    private readonly Random _rng;\n    public Dictionary<string, int> Stats { get; } = new() { [\"selections\"]=0, [\"expansions\"]=0, [\"simulations\"]=0, [\"backprops\"]=0 };\n\n    public MCTS(IJeuSommeNulle<TEtat> jeu, double c = 1.41, int? seed = null)\n    { _jeu = jeu; _c = c; _rng = seed.HasValue ? new Random(seed.Value) : new Random(); }\n\n    // Execute MCTS depuis l'etat donne ; retourne (meilleure action, valeur estimee).\n    public (int Action, double Valeur) Recherche(TEtat etat, int iterations = 1000)\n    {\n        var racine = new NoeudMCTS<TEtat>(etat);\n        for (int i = 0; i < iterations; i++)\n        {\n            var noeud = Selection(racine);\n            double resultat = Simulation(noeud);\n            Backpropagation(noeud, resultat);\n        }\n        var meilleur = racine.MeilleurEnfantVisites();\n        double valeur = meilleur.Visites > 0 ? meilleur.Victoires / meilleur.Visites : 0;\n        return (meilleur.Action, valeur);\n    }\n\n    // Variante qui expose aussi le nombre de visites du coup choisi (sert au benchmark de c).\n    public (int Action, int Visites) RechercheAvecVisites(TEtat etat, int iterations)\n    {\n        var racine = new NoeudMCTS<TEtat>(etat);\n        for (int i = 0; i < iterations; i++)\n        {\n            var noeud = Selection(racine);\n            double resultat = Simulation(noeud);\n            Backpropagation(noeud, resultat);\n        }\n        var meilleur = racine.MeilleurEnfantVisites();\n        return (meilleur.Action, meilleur.Visites);\n    }\n\n    private NoeudMCTS<TEtat> Selection(NoeudMCTS<TEtat> noeud)\n    {\n        Stats[\"selections\"]++;\n        while (!noeud.EstTerminal(_jeu))\n        {\n            if (!noeud.EstFullyExpanded(_jeu)) return Expansion(noeud);\n            noeud = noeud.MeilleurEnfantUcb1(_c);\n        }\n        return noeud;\n    }\n\n    private NoeudMCTS<TEtat> Expansion(NoeudMCTS<TEtat> noeud)\n    {\n        Stats[\"expansions\"]++;\n        noeud.ActionsNonExplorees ??= _jeu.Actions(noeud.Etat);\n        int idx = noeud.ActionsNonExplorees.Count - 1;\n        int action = noeud.ActionsNonExplorees[idx];     // pop (dernier element)\n        noeud.ActionsNonExplorees.RemoveAt(idx);\n        TEtat nouvelEtat = _jeu.Resultat(noeud.Etat, action);\n        var enfant = new NoeudMCTS<TEtat>(nouvelEtat, noeud, action);\n        noeud.Enfants[action] = enfant;\n        return enfant;\n    }\n\n    // Rollout aleatoire depuis le noeud jusqu'a un etat terminal.\n    private double Simulation(NoeudMCTS<TEtat> noeud)\n    {\n        Stats[\"simulations\"]++;\n        TEtat etat = noeud.Etat;\n        // Le joueur MAX = celui qui devait jouer a l'etat parent (ou MAX a la racine).\n        string joueurMaxOriginal = noeud.Parent != null ? _jeu.Joueur(noeud.Parent.Etat) : \"MAX\";\n        while (!_jeu.EstTerminal(etat))\n        {\n            var actions = _jeu.Actions(etat);\n            int action = actions[_rng.Next(actions.Count)];\n            etat = _jeu.Resultat(etat, action);\n        }\n        return _jeu.Utilite(etat, joueurMaxOriginal);\n    }\n\n    private void Backpropagation(NoeudMCTS<TEtat>? noeud, double resultat)\n    {\n        Stats[\"backprops\"]++;\n        // Convention UCT \"moved-into\" : on stocke a chaque noeud la valeur du point de vue\n        // du joueur QUI A DECIDE le coup vers ce noeud (le joueur de l'etat parent).\n        // Ainsi tous les enfants d'un meme parent sont evalues du meme point de vue,\n        // et max(UCB1) selectionne bien le meilleur coup pour le joueur qui decide.\n        while (noeud != null)\n        {\n            noeud.Visites++;\n            string decideur = noeud.Parent != null ? _jeu.Joueur(noeud.Parent.Etat) : _jeu.Joueur(noeud.Etat);\n            if (decideur == \"MAX\") noeud.Victoires += resultat;\n            else noeud.Victoires += -resultat;\n            noeud = noeud.Parent;\n        }\n    }\n}\n\nConsole.WriteLine(\"Classe MCTS<T> definie (selection, expansion, simulation, backpropagation).\");"
-   ]
+   ],
+   "id": "cell-fd4246b3"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Maintenant que nous avons la structure de noeud, nous pouvons implementer l'algorithme **MCTS complet** qui utilise ces noeuds pour construire l'arbre de recherche."
-   ]
+   ],
+   "id": "cell-594a226a"
   },
   {
    "cell_type": "markdown",
@@ -286,7 +294,8 @@
     "## 3. Test sur Tic-Tac-Toe\n",
     "\n",
     "Comparons MCTS avec Minimax sur le jeu de Morpion.\n"
-   ]
+   ],
+   "id": "cell-1d7eea9d"
   },
   {
    "cell_type": "code",
@@ -310,7 +319,8 @@
    ],
    "source": [
     "// Cellule 9 : Tic-Tac-Toe (implementation du jeu) + premier test MCTS\npublic sealed class EtatTTT\n{\n    public char[] Grille { get; }\n    public char Joueur { get; }   // 'X' ou 'O' (celui qui doit jouer)\n    public EtatTTT(char[] grille, char joueur) { Grille = grille; Joueur = joueur; }\n}\n\npublic class TicTacToe : IJeuSommeNulle<EtatTTT>\n{\n    private static readonly int[][] Lignes = new[] {\n        new[] {0,1,2}, new[] {3,4,5}, new[] {6,7,8},   // lignes\n        new[] {0,3,6}, new[] {1,4,7}, new[] {2,5,8},   // colonnes\n        new[] {0,4,8}, new[] {2,4,6}                    // diagonales\n    };\n\n    public EtatTTT EtatInitial() => new(Enumerable.Repeat(' ', 9).ToArray(), 'X');\n    public string Joueur(EtatTTT e) => e.Joueur == 'X' ? \"MAX\" : \"MIN\";\n    public List<int> Actions(EtatTTT e) => Enumerable.Range(0,9).Where(i => e.Grille[i] == ' ').ToList();\n    public EtatTTT Resultat(EtatTTT e, int a)\n    {\n        char[] g = (char[])e.Grille.Clone();\n        g[a] = e.Joueur;\n        return new EtatTTT(g, e.Joueur == 'X' ? 'O' : 'X');\n    }\n    public bool EstTerminal(EtatTTT e)\n    {\n        foreach (var l in Lignes)\n            if (e.Grille[l[0]] != ' ' && e.Grille[l[0]] == e.Grille[l[1]] && e.Grille[l[1]] == e.Grille[l[2]])\n                return true;\n        return !e.Grille.Contains(' ');\n    }\n    public double Utilite(EtatTTT e, string joueur)\n    {\n        foreach (var l in Lignes)\n            if (e.Grille[l[0]] != ' ' && e.Grille[l[0]] == e.Grille[l[1]] && e.Grille[l[1]] == e.Grille[l[2]])\n            {\n                string gagnant = e.Grille[l[0]] == 'X' ? \"MAX\" : \"MIN\";\n                return gagnant == joueur ? 1.0 : -1.0;\n            }\n        return 0.0;\n    }\n}\n\n// Test MCTS sur Tic-Tac-Toe (etat initial vide)\nvar jeu = new TicTacToe();\nvar mcts = new MCTS<EtatTTT>(jeu, seed: 42);\nvar sw = Stopwatch.StartNew();\nvar (action, valeur) = mcts.Recherche(jeu.EtatInitial(), iterations: 1000);\nsw.Stop();\nConsole.WriteLine($\"MCTS (1000 iterations) : action={action}, valeur={valeur:F3}, temps={sw.Elapsed.TotalSeconds:F3}s\");\nConsole.WriteLine($\"Stats : selections={mcts.Stats[\"selections\"]}, expansions={mcts.Stats[\"expansions\"]}, simulations={mcts.Stats[\"simulations\"]}, backprops={mcts.Stats[\"backprops\"]}\");"
-   ]
+   ],
+   "id": "cell-cbcc8cd7"
   },
   {
    "cell_type": "markdown",
@@ -332,7 +342,8 @@
     "2. **Valeur proche de 0** : Au Morpion, le resultat optimal est 0 (match nul), donc une valeur faible indique une bonne estimation.\n",
     "3. **Action strategique** : Un coin ou le centre sont les meilleurs premiers coups au Morpion.\n",
     "4. **Determinisme** : avec une graine fixee (`seed: 42`), la sortie est reproductible ; sans graine, elle varie legerement d'une execution a l'autre.\n"
-   ]
+   ],
+   "id": "cell-6fe27d2b"
   },
   {
    "cell_type": "markdown",
@@ -341,7 +352,8 @@
     "## 4. Comparaison MCTS vs Minimax\n",
     "\n",
     "Comparons les deux approches sur differents criteres.\n"
-   ]
+   ],
+   "id": "cell-5ece8bac"
   },
   {
    "cell_type": "code",
@@ -400,7 +412,8 @@
    ],
    "source": [
     "// Cellule 12 : Minimax (pour comparaison) + benchmark text-table Minimax vs MCTS\npublic static class RechercheAdversariale\n{\n    // Minimax exact (explore tout l'arbre) -- optimal mais exponentiel.\n    public static (double Valeur, int? Action) Minimax<TEtat>(IJeuSommeNulle<TEtat> jeu, TEtat etat, string joueurMax = \"MAX\")\n    {\n        if (jeu.EstTerminal(etat)) return (jeu.Utilite(etat, joueurMax), null);\n        var actions = jeu.Actions(etat);\n        if (jeu.Joueur(etat) == joueurMax)\n        {\n            double bestV = double.NegativeInfinity; int? bestA = null;\n            foreach (var a in actions)\n            {\n                var (v, _) = Minimax(jeu, jeu.Resultat(etat, a), joueurMax);\n                if (v > bestV) { bestV = v; bestA = a; }\n            }\n            return (bestV, bestA);\n        }\n        else\n        {\n            double bestV = double.PositiveInfinity; int? bestA = null;\n            foreach (var a in actions)\n            {\n                var (v, _) = Minimax(jeu, jeu.Resultat(etat, a), joueurMax);\n                if (v < bestV) { bestV = v; bestA = a; }\n            }\n            return (bestV, bestA);\n        }\n    }\n}\n\n// Benchmark : Minimax vs MCTS a differents budgets d'iterations\nConsole.WriteLine($\"{\"Algorithme\",-16}{\"Temps (s)\",12}{\"Valeur\",10}{\"Action\",8}\");\nConsole.WriteLine(new string('-', 46));\nvar sw = Stopwatch.StartNew();\nvar (vMm, aMm) = RechercheAdversariale.Minimax(jeu, jeu.EtatInitial());\nsw.Stop();\nConsole.WriteLine($\"{\"Minimax\",-16}{sw.Elapsed.TotalSeconds,12:F4}{vMm,10:F2}{aMm,8}\");\nforeach (int nIter in new[] { 100, 500, 1000, 5000 })\n{\n    var m = new MCTS<EtatTTT>(jeu, seed: 42);\n    sw.Restart();\n    var (action, valeur) = m.Recherche(jeu.EtatInitial(), nIter);\n    sw.Stop();\n    Console.WriteLine($\"{\"MCTS (\"+nIter+\")\",-16}{sw.Elapsed.TotalSeconds,12:F4}{valeur,10:F2}{action,8}\");\n}"
-   ]
+   ],
+   "id": "cell-386c7ab1"
   },
   {
    "cell_type": "markdown",
@@ -417,7 +430,8 @@
     "4. **Variabilite des actions** : les actions choisies varient selon le budget, montrant que le nombre d'iterations influence la stabilite du choix.\n",
     "\n",
     "> **Note technique** : La valeur de Minimax (0) est exacte car l'algorithme explore tout l'arbre de jeu du Morpion. La valeur MCTS est une estimation probabiliste qui converge vers 0 avec plus d'iterations.\n"
-   ]
+   ],
+   "id": "cell-961c0211"
   },
   {
    "cell_type": "markdown",
@@ -439,7 +453,8 @@
     "- Jeux sans bonne fonction d'evaluation\n",
     "- Situations avec contrainte de temps variable\n",
     "- Jeux avec hasard (backgammon, poker)\n"
-   ]
+   ],
+   "id": "cell-6d1c1a6e"
   },
   {
    "cell_type": "markdown",
@@ -459,7 +474,8 @@
     "- **Algos inclus** : MCTS, AlphaZero, CFR, etc.\n",
     "\n",
     "> **Note .NET** : OpenSpiel est une librairie C++/Python (installation `pip install open-spiel`, Linux/WSL). Il n'existe pas d'equivalent .NET direct ; en C# on reimplemente la logique de jeu (comme nous le faisons ici avec `IJeuSommeNulle<T>`) ou on consomme des moteurs natifs via P/Invoke. La cellule suivante montre l'equivalent conceptuel de l'API OpenSpiel en C#.\n"
-   ]
+   ],
+   "id": "cell-1f123cb6"
   },
   {
    "cell_type": "code",
@@ -505,7 +521,8 @@
    ],
    "source": [
     "// Cellule 16 : Equivalent conceptuel de l'API OpenSpiel en C#\n// OpenSpiel (pyspiel) est C++/Python uniquement. En .NET on reimplemente le jeu\n// derriere une interface normalisee (c'est exactement IJeuSommeNulle<TEtat> ci-dessus).\n// On reutilise donc notre TicTacToe + MCTS pour montrer le meme usage qu'OpenSpiel.\n\nvar openspielEquivalent = new TicTacToe();\nvar bot = new MCTS<EtatTTT>(openspielEquivalent, c: 1.41, seed: 42);\nvar etat0 = openspielEquivalent.EtatInitial();\nvar (actionOS, _) = bot.Recherche(etat0, iterations: 1000);\nConsole.WriteLine($\"Jeu charge        : tic_tac_toe()  (via TicTacToe : IJeuSommeNulle<EtatTTT>)\");\nConsole.WriteLine($\"Etat initial      : grille vide, X a jouer\");\nConsole.WriteLine($\"Action MCTSBot    : {actionOS}  (1000 simulations, c=sqrt(2))\");\nConsole.WriteLine($\"\\nOpenSpiel .NET : pas de port officiel. L'interface IJeuSommeNulle<T> normalise\");\nConsole.WriteLine($\"  la meme separation jeu / algorithme qu'OpenSpiel (state, actions, resultat, terminal, utilite).\");"
-   ]
+   ],
+   "id": "cell-005cd9cb"
   },
   {
    "cell_type": "markdown",
@@ -518,7 +535,8 @@
     "2. **Pas de port .NET officiel** : OpenSpiel est C++/Python ; en C# on reimplemente la logique (comme ici) ou on invoque un moteur natif.\n",
     "3. **Coherence avec MCTS manuel** : le bot joue un coup fort (coin/centre), comme le `MCTSBot` d'OpenSpiel.\n",
     "4. **Separation jeu / algorithme** : c'est le pattern cle -- ajouter un nouveau jeu (Connect-4, Hex...) se reduit a implementer 6 methodes.\n"
-   ]
+   ],
+   "id": "cell-c7e28f9a"
   },
   {
    "cell_type": "markdown",
@@ -548,7 +566,8 @@
     "3. Entrainer le reseau sur les positions et resultats\n",
     "4. Repeter jusqu'a convergence\n",
     "```\n"
-   ]
+   ],
+   "id": "cell-de66a51a"
   },
   {
    "cell_type": "code",
@@ -565,7 +584,8 @@
    ],
    "source": [
     "// Cellule 19 : Sketch conceptuel d'un AlphaZero simplifie (C#)\n// En pratique, policy_value_fn serait un reseau de neurones (PyTorch/TensorFlow/.NET).\n// Ici : une fonction factice qui simule (probas, valeur) pour illustrer l'integration MCTS.\n\n// Signature d'une evaluation reseau : (probas par action, valeur de la position)\npublic delegate (Dictionary<int,double> Probs, double Value) PolicyValueFn<TEtat>(TEtat etat);\n\npublic class AlphaZeroMCTS<TEtat>\n{\n    private readonly IJeuSommeNulle<TEtat> _jeu;\n    private readonly PolicyValueFn<TEtat> _policyValue;\n    private readonly double _c;\n    public AlphaZeroMCTS(IJeuSommeNulle<TEtat> jeu, PolicyValueFn<TEtat> policyValue, double c = 1.41)\n    { _jeu = jeu; _policyValue = policyValue; _c = c; }\n\n    // MCTS guide par le reseau : l'expansion utilise les probas policy,\n    // et la simulation est remplacee par l'evaluation value (pas de rollout aleatoire).\n    public NoeudMCTS<TEtat> Recherche(TEtat etat, int iterations = 100)\n    {\n        var racine = new NoeudMCTS<TEtat>(etat);\n        for (int i = 0; i < iterations; i++)\n        {\n            var noeud = racine;\n            // Selection (comme MCTS classique, via UCB1)\n            while (noeud.Enfants.Count > 0 && noeud.EstFullyExpanded(_jeu) && !_jeu.EstTerminal(noeud.Etat))\n                noeud = noeud.MeilleurEnfantUcb1(_c);\n            // Evaluation par le reseau\n            double value;\n            if (_jeu.EstTerminal(noeud.Etat))\n                value = _jeu.Utilite(noeud.Etat, \"MAX\");\n            else\n            {\n                var (probs, v) = _policyValue(noeud.Etat);\n                value = v;\n                // Expansion avec les probabilites du policy network\n                foreach (var a in _jeu.Actions(noeud.Etat))\n                    noeud.Enfants[a] = new NoeudMCTS<TEtat>(_jeu.Resultat(noeud.Etat, a), noeud, a);\n            }\n            // Backpropagation (comme MCTS classique ; Victoires est un setter public)\n            while (noeud != null)\n            {\n                noeud.Visites++;\n                if (_jeu.Joueur(noeud.Etat) == \"MAX\") noeud.Victoires += value;\n                else noeud.Victoires += -value;\n                noeud = noeud.Parent;\n            }\n        }\n        return racine;\n    }\n}\n\nConsole.WriteLine(\"Sketch AlphaZeroMCTS<T> defini (policy network + value network, pas de rollout aleatoire).\");"
-   ]
+   ],
+   "id": "cell-646f16f4"
   },
   {
    "cell_type": "markdown",
@@ -585,7 +605,8 @@
     "2. **Policy network** : guide l'expansion en donnant des probabilites pour chaque action.\n",
     "3. **Auto-apprentissage** : le reseau s'entraine sur les parties generees par MCTS (auto-play sans donnees humaines).\n",
     "4. **Generalisation** : la meme architecture fonctionne pour Go, Echecs, Shogi.\n"
-   ]
+   ],
+   "id": "cell-a906ede1"
   },
   {
    "cell_type": "markdown",
@@ -609,7 +630,8 @@
     "- **Leaf parallelisation** : simulations en parallele\n",
     "- **Root parallelisation** : plusieurs arbres en parallele\n",
     "- **Tree parallelisation** : acces concurrent a l'arbre\n"
-   ]
+   ],
+   "id": "cell-01aa139b"
   },
   {
    "cell_type": "code",
@@ -633,7 +655,8 @@
    ],
    "source": [
     "// Cellule 22 : Root parallelization en C# (Parallel.ForEach / LINQ)\n// Contrairement a multiprocessing.Pool (Python), le TPL (.NET) fonctionne dans un notebook.\npublic static class MCTSParallel\n{\n    // Root parallelization : nWorkers arbres MCTS independants, vote majoritaire.\n    public static int Recherche<TEtat>(IJeuSommeNulle<TEtat> jeu, TEtat etat, int totalIterations, int nWorkers, int seed = 42)\n    {\n        int perWorker = Math.Max(1, totalIterations / nWorkers);\n        var actions = new int[nWorkers];\n        Parallel.For(0, nWorkers, w =>\n        {\n            var m = new MCTS<TEtat>(jeu, seed: seed + w);\n            actions[w] = m.Recherche(etat, perWorker).Action;\n        });\n        // Vote majoritaire\n        return actions.GroupBy(a => a).OrderByDescending(g => g.Count()).First().Key;\n    }\n}\n\nvar jeuP = new TicTacToe();\nvar sw = Stopwatch.StartNew();\nint coupVote = MCTSParallel.Recherche(jeuP, jeuP.EtatInitial(), totalIterations: 1000, nWorkers: 4, seed: 42);\nsw.Stop();\nConsole.WriteLine($\"Root parallelization (4 workers x 250 iter) -> action = {coupVote}, temps = {sw.Elapsed.TotalSeconds:F3}s\");\nConsole.WriteLine(\"Chaque worker construit son propre arbre ; le vote majoritaire reduit la variance.\");"
-   ]
+   ],
+   "id": "cell-69708bf7"
   },
   {
    "cell_type": "markdown",
@@ -653,7 +676,8 @@
     "2. **Scalabilite** : avec 4 coeurs, on fait ~4x plus d'iterations dans le meme temps.\n",
     "3. **Vote majoritaire** : reduit la variance en combinant plusieurs estimations.\n",
     "4. **Alternative** : tree parallelization (acces concurrent a un arbre partage avec lock) -- plus complexe mais meilleure convergence.\n"
-   ]
+   ],
+   "id": "cell-2404bf16"
   },
   {
    "cell_type": "markdown",
@@ -680,7 +704,8 @@
     "\n",
     "### Exercice 5 : Time management\n",
     "Implementez une gestion du temps adaptive pour MCTS.\n"
-   ]
+   ],
+   "id": "cell-2e6fabb4"
   },
   {
    "cell_type": "markdown",
@@ -689,7 +714,8 @@
     "### Exemple resolu : Analyse de convergence MCTS\n",
     "\n",
     "La convergence est une propriete fondamentale de MCTS : plus on augmente le nombre d'iterations, plus la decision se rapproche de l'optimal. L'exemple ci-dessous mesure cette convergence sur TicTacToe en comparant l'action choisie par MCTS a l'action optimale Minimax (verite terrain). La table montre le taux de choix optimal, la valeur estimee moyenne et le temps moyen, pour des budgets croissants.\n"
-   ]
+   ],
+   "id": "cell-4727b4cf"
   },
   {
    "cell_type": "code",
@@ -770,7 +796,8 @@
    ],
    "source": [
     "// Exemple resolu : Analyse de convergence MCTS (table texte au lieu de matplotlib)\n// Pour chaque budget d'iterations, on repete N fois et on mesure le taux de choix\n// de l'action optimale (ref Minimax), la valeur estimee moyenne et le temps moyen.\nstatic List<(int Iter, double TauxOpt, double ValeurMoy, double TempsMoy)> AnalyserConvergence<TEtat>(\n    IJeuSommeNulle<TEtat> jeu, TEtat etat, IEnumerable<int> iterList, int repetitions = 20, int seed = 42)\n{\n    var (_, actionOptNull) = RechercheAdversariale.Minimax(jeu, etat);\n    int actionOpt = actionOptNull ?? jeu.Actions(etat)[0];\n    var rng = new Random(seed);\n    var res = new List<(int, double, double, double)>();\n    foreach (int nIter in iterList)\n    {\n        int optCount = 0;\n        double sv = 0, st = 0;\n        for (int r = 0; r < repetitions; r++)\n        {\n            var mcts = new MCTS<TEtat>(jeu, seed: rng.Next());\n            var sw = Stopwatch.StartNew();\n            var (action, valeur) = mcts.Recherche(etat, nIter);\n            sw.Stop();\n            if (action == actionOpt) optCount++;\n            sv += valeur; st += sw.Elapsed.TotalSeconds;\n        }\n        res.Add((nIter, optCount * 100.0 / repetitions, sv / repetitions, st / repetitions));\n    }\n    return res;\n}\n\nvar iterList = new[] { 10, 50, 100, 500, 1000, 2000 };\nvar conv = AnalyserConvergence(jeu, jeu.EtatInitial(), iterList, repetitions: 20);\nConsole.WriteLine($\"{\"Iterations\",12}{\"Taux optimal (%)\",18}{\"Valeur moyenne\",16}{\"Temps moyen (s)\",16}\");\nConsole.WriteLine(new string('-', 62));\nforeach (var (it, taux, vmoy, tmoy) in conv)\n    Console.WriteLine($\"{it,12}{taux,18:F1}{vmoy,16:F3}{tmoy,16:F4}\");\nConsole.WriteLine(\"\\nRemarque : depuis la grille vide, plusieurs premiers coups du Morpion sont\");\nConsole.WriteLine(\"tous optimaux (valeur 0). Le taux compare a UNE action de reference (Minimax).\");"
-   ]
+   ],
+   "id": "cell-ca9a8638"
   },
   {
    "cell_type": "markdown",
@@ -779,7 +806,8 @@
     "### Exemple resolu : MCTS sur le jeu de Nim\n",
     "\n",
     "Le jeu de **Nim** est un cas ideal pour comprendre MCTS : l'espace d'etats est petit et la strategie optimale est connue mathematiquement (laisser un multiple de 4 allumettes a l'adversaire). L'exemple ci-dessous montre la **convergence** de MCTS vers cette strategie en fonction du budget d'iterations, puis compare ses performances contre un joueur optimal. On observe que MCTS decouvre l'action optimale (prendre 3 depuis n=15) des 1000 iterations, avec une valeur estimee qui converge vers la victoire (0,64 -> 0,96).\n"
-   ]
+   ],
+   "id": "cell-e331ec8e"
   },
   {
    "cell_type": "code",
@@ -861,7 +889,8 @@
    ],
    "source": [
     "// Exemple resolu : MCTS sur le jeu de Nim\npublic sealed class EtatNim { public int Restantes; public char Joueur; public EtatNim(int r, char j){Restantes=r;Joueur=j;} }\n\npublic class NimGame : IJeuSommeNulle<EtatNim>\n{\n    private readonly int _n0;\n    public NimGame(int nAllumettes = 15) => _n0 = nAllumettes;\n    public EtatNim EtatInitial() => new(_n0, 'X');\n    public string Joueur(EtatNim e) => e.Joueur == 'X' ? \"MAX\" : \"MIN\";\n    public List<int> Actions(EtatNim e) => new[] { 1, 2, 3 }.Where(k => k <= e.Restantes).ToList();\n    public EtatNim Resultat(EtatNim e, int a) => new(e.Restantes - a, e.Joueur == 'X' ? 'O' : 'X');\n    public bool EstTerminal(EtatNim e) => e.Restantes == 0;\n    public double Utilite(EtatNim e, string joueur)\n    {\n        // e = (0, joueur qui doit jouer) -> il ne peut pas jouer -> l'autre a pris la derniere -> l'autre GAGNE\n        string gagnant = e.Joueur == 'O' ? \"MAX\" : \"MIN\";\n        return gagnant == joueur ? 1.0 : -1.0;\n    }\n}\n\nstatic int StrategieOptimaleNim(EtatNim etat)\n{\n    int reste = etat.Restantes % 4;\n    return reste > 0 ? reste : 1;   // laisser un multiple de 4 a l'adversaire\n}\n\nvar jeuNim = new NimGame(15);\n// Budget eleve pour l'action initiale : MCTS doit explorer assez pour decouvrir la parite (n%%4).\nConsole.WriteLine(\"--- Action initiale : MCTS a budgets croissants ---\");\nint actionOptNim = StrategieOptimaleNim(jeuNim.EtatInitial());\nConsole.WriteLine($\"Nim(15) - Strategie optimale : prendre {actionOptNim} (laisser un multiple de 4)\\n\");\nforeach (int nIter in new[] { 1000, 5000, 10000 })\n{\n    var (a, v) = new MCTS<EtatNim>(jeuNim, seed: 42).Recherche(jeuNim.EtatInitial(), nIter);\n    Console.WriteLine($\"  MCTS({nIter,5} iter) : prendre {a}, valeur={v:F3}  {(a == actionOptNim ? \"<< OPTIMAL\" : \"\")}\");\n}\nConsole.WriteLine();\n// Tournoi : MCTS(500) vs strategie optimale, 50 parties (MCTS joue 1er puis 2nd)\nint victoiresMcts = 0, nulles = 0, nParties = 50;\nfor (int i = 0; i < nParties; i++)\n{\n    var etat = jeuNim.EtatInitial();\n    string mctsJoueur = i % 2 == 0 ? \"MAX\" : \"MIN\";\n    while (!jeuNim.EstTerminal(etat))\n    {\n        int a;\n        if (jeuNim.Joueur(etat) == mctsJoueur)\n            a = new MCTS<EtatNim>(jeuNim, seed: 1000 + i).Recherche(etat, 500).Action;\n        else\n            a = StrategieOptimaleNim(etat);\n        etat = jeuNim.Resultat(etat, a);\n    }\n    double u = jeuNim.Utilite(etat, mctsJoueur);\n    if (u > 0) victoiresMcts++; else if (u == 0) nulles++;\n}\nConsole.WriteLine($\"\\nTournoi MCTS(500 iter) vs Strategie optimale ({nParties} parties) :\");\nConsole.WriteLine($\"  Victoires MCTS              : {victoiresMcts}/{nParties}\");\nConsole.WriteLine($\"  Nulles                      : {nulles}/{nParties}\");\nConsole.WriteLine($\"  Victoires strategie optimale: {nParties - victoiresMcts - nulles}/{nParties}\");"
-   ]
+   ],
+   "id": "cell-23b47a77"
   },
   {
    "cell_type": "markdown",
@@ -870,7 +899,8 @@
     "### Exercice 2 : Rollout intelligent\n",
     "\n",
     "Implementez un rollout guide par heuristiques au lieu d'un choix purement aleatoire. Evaluez les actions candidates avec une fonction heuristique et choisissez l'action avec le meilleur score (avec un peu d'aleatoire). Pour TicTacToe, privilegiez le centre et les coins.\n"
-   ]
+   ],
+   "id": "cell-f3bd048d"
   },
   {
    "cell_type": "code",
@@ -887,7 +917,8 @@
    ],
    "source": [
     "// Exercice 2 : Rollout intelligent (stub a completer)\n// Indice : derivez de MCTS<T> et surchargez la methode de selection d'action pendant\n// le rollout. Pour TicTacToe, une heuristique simple = score(centre=3, coin=2, bord=1).\npublic class MCTSRolloutHeuristique<TEtat> : MCTS<TEtat>\n{\n    public MCTSRolloutHeuristique(IJeuSommeNulle<TEtat> jeu, double c = 1.41, int? seed = null)\n        : base(jeu, c, seed) { }\n\n    // TODO etudiant : remplacer le rollout aleatoire par un rollout guide.\n    // 1. Definir une fonction heuristique Heuristique(etat) -> score par action.\n    //    Ex TicTacToe : centre (action 4) = 3, coins (0,2,6,8) = 2, bords = 1.\n    // 2. Avec probabilite epsilon, jouer aleatoire (exploration) ; sinon jouer le meilleur score.\n    // 3. Mesurer la convergence plus rapide vs rollout purement aleatoire.\n    public double HeuristiqueExample(TEtat etat, int action)\n    {\n        // TODO etudiant : implementer l'heuristique selon le jeu.\n        return 0.0;  // placeholder : retour neutre (a completer)\n    }\n}\nConsole.WriteLine(\"Exercice 2 : stub pret -- derivez MCTS<T> et implementez le rolloutheuristique.\");"
-   ]
+   ],
+   "id": "cell-6228a2c5"
   },
   {
    "cell_type": "markdown",
@@ -896,7 +927,8 @@
     "### Exercice 3 : MCTS vs Alpha-Beta sur Connect Four\n",
     "\n",
     "Comparez les deux algorithmes sur le jeu de Puissance 4. Implementez Connect Four (ou reutilisez du notebook Search-6), faites jouer MCTS vs Alpha-Beta sur plusieurs parties et analysez : taux de victoire, temps, qualite des coups. Alpha-Beta devrait etre plus fort avec une bonne profondeur.\n"
-   ]
+   ],
+   "id": "cell-20536fde"
   },
   {
    "cell_type": "code",
@@ -913,7 +945,8 @@
    ],
    "source": [
     "// Exercice 3 : MCTS vs Alpha-Beta sur Connect Four (stub a completer)\n// Indice : Connect Four = grille 6x7, gravite (le jeton tombe en bas de la colonne).\n// 1. Implementer une classe ConnectFour : IJeuSommeNulle<EtatC4>.\n//    - EtatC4 = { char[42] Grille, char Joueur }\n//    - Actions = colonnes non pleines (0-6)\n//    - Resultat : trouver la 1ere case vide en partant du bas dans la colonne\n//    - EstTerminal : alignement de 4 (H, V, 2 diagonales) ou grille pleine\n// 2. Ajouter Alpha-Beta (Minimax + elagage) -- reutilisable depuis Search-6-Csharp.\n// 3. Tournoi MCTS(iter) vs AlphaBeta(prof) sur N parties.\npublic sealed class EtatC4 { /* TODO etudiant */ }\npublic class ConnectFour : IJeuSommeNulle<EtatC4>\n{\n    public EtatC4 EtatInitial() => default!;   // TODO etudiant\n    public string Joueur(EtatC4 e) => \"MAX\";    // TODO etudiant\n    public List<int> Actions(EtatC4 e) => new();// TODO etudiant\n    public EtatC4 Resultat(EtatC4 e, int a) => default!;  // TODO etudiant\n    public bool EstTerminal(EtatC4 e) => true;  // TODO etudiant\n    public double Utilite(EtatC4 e, string j) => 0.0;     // TODO etudiant\n}\nConsole.WriteLine(\"Exercice 3 : stub ConnectFour pret -- implementez les 6 methodes de l'interface.\");"
-   ]
+   ],
+   "id": "cell-2ea5954a"
   },
   {
    "cell_type": "markdown",
@@ -922,7 +955,8 @@
     "### Exercice 4 : Extension RAVE\n",
     "\n",
     "Implementez l'extension RAVE (Rapid Action Value Estimation) pour accelerer la convergence de MCTS. RAVE utilise l'heuristique \"all moves as first\" : un coup est evalue meme s'il est joue plus tard dans la partie. La formule est `Q_RAVE = (1-beta) * Q_MCTS + beta * Q_RAVE`. Modifiez la classe `NoeudMCTS<T>` pour stocker les stats RAVE.\n"
-   ]
+   ],
+   "id": "cell-926ab925"
   },
   {
    "cell_type": "code",
@@ -948,7 +982,8 @@
    ],
    "source": [
     "// Exercice 4 : Extension RAVE (stub a completer)\n// Indice : ajouter a NoeudMCTS<T> deux compteurs par action globale (pas seulement par noeud).\npublic class NoeudRAVE<TEtat> : NoeudMCTS<TEtat>\n{\n    public Dictionary<int, int> RaveVisites = new();   // TODO etudiant : remplir pendant la backprop\n    public Dictionary<int, double> RaveVictoires = new();\n    public NoeudRAVE(TEtat etat, NoeudMCTS<TEtat>? parent = null, int action = -1)\n        : base(etat, parent, action) { }\n\n    // TODO etudiant : surcharger Ucb1 pour melanger Q_MCTS et Q_RAVE.\n    // Q_RAVE = (1-beta) * (Victoires/Visites) + beta * (RaveVictoires[a]/RaveVisites[a])\n    // avec beta decroissant avec le nombre de visites.\n    public double Ucb1Rave(double c = 1.41, double beta = 0.5)\n    {\n        // TODO etudiant : implementer la formule RAVE\n        return Ucb1(c);   // placeholder = UCB1 classique (a completer)\n    }\n}\nConsole.WriteLine(\"Exercice 4 : stub NoeudRAVE<T> pret -- ajoutez les stats RAVE et la formule beta.\");"
-   ]
+   ],
+   "id": "cell-303e493b"
   },
   {
    "cell_type": "markdown",
@@ -957,7 +992,8 @@
     "### Exercice 5 : Time management\n",
     "\n",
     "Implementez une gestion du temps adaptive pour MCTS. Allouez plus de temps aux positions critiques, utilisez moins de temps quand le coup est evident, et detectez les positions \"faciles\" (victoire probable). Utilisez la variance des evaluations pour detecter l'incertitude.\n"
-   ]
+   ],
+   "id": "cell-cb2f66d3"
   },
   {
    "cell_type": "code",
@@ -974,7 +1010,8 @@
    ],
    "source": [
     "// Exercice 5 : Time management adaptive (stub a completer)\n// Indice : au lieu d'un budget fixe d'iterations, allouer un budget variable selon :\n//  - la variance des valeurs estimees des enfants (haute variance = incertain = + d'iterations)\n//  - la presence d'un coup ecrasant (un enfant >> les autres = coup evident = - d'iterations)\npublic static class TimeManagement\n{\n    // TODO etudiant : retourner un nombre d'iterations adapte a la position.\n    public static int BudgetAdaptatif<TEtat>(IJeuSommeNulle<TEtat> jeu, TEtat etat, int budgetMax)\n    {\n        // 1. Lancer un pre-MCTS court (budgetMax/10 iter) pour estimer la variance.\n        // 2. Si variance faible (coup evident) -> retourner budgetMax/4.\n        // 3. Si variance elevee (position critique) -> retourner budgetMax.\n        return budgetMax;   // placeholder = budget fixe (a completer)\n    }\n}\nConsole.WriteLine(\"Exercice 5 : stub TimeManagement pret -- implementez le budget adaptatif.\");"
-   ]
+   ],
+   "id": "cell-08f8c30e"
   },
   {
    "cell_type": "markdown",
@@ -985,7 +1022,8 @@
     "L'exemple ci-dessous benchmark differentes valeurs du parametre d'exploration `c` de MCTS. On joue des parties MCTS contre un joueur aleatoire, puis on compare les taux de victoire, temps d'execution et visites moyennes pour `c = 0.5, 1.0, 1.41, 2.0`.\n",
     "\n",
     "Observez comment la valeur de `c` influence le compromis entre exploration et exploitation.\n"
-   ]
+   ],
+   "id": "cell-c8cdb716"
   },
   {
    "cell_type": "code",
@@ -1037,7 +1075,8 @@
    ],
    "source": [
     "// Exemple : Benchmark du parametre d'exploration c\n// Pour chaque c, on joue N parties MCTS(c) contre un joueur aleatoire, et on mesure\n// le taux de victoire, le temps moyen et les visites moyennes du coup choisi.\nstatic (double TauxVictoire, double TempsMoy, double VisitesMoy) JouerPartieMctsVsRandom<TEtat>(\n    IJeuSommeNulle<TEtat> jeu, MCTS<TEtat> mcts, int iterations, int seed)\n{\n    var rng = new Random(seed);\n    var etat = jeu.EtatInitial();\n    var visites = new List<int>();\n    bool tourMcts = true;\n    while (!jeu.EstTerminal(etat))\n    {\n        int a;\n        if (tourMcts)\n        {\n            var (act, vis) = mcts.RechercheAvecVisites(etat, iterations);\n            a = act; visites.Add(vis);\n        }\n        else\n        {\n            var acts = jeu.Actions(etat);\n            a = acts[rng.Next(acts.Count)];\n        }\n        etat = jeu.Resultat(etat, a);\n        tourMcts = !tourMcts;\n    }\n    double res = jeu.Utilite(etat, \"MAX\");\n    double visMoy = visites.Count > 0 ? visites.Average() : 0.0;\n    return (res, 0.0, visMoy);\n}\n\nConsole.WriteLine($\"{\"c\",6}{\"Taux victoire (%)\",20}{\"Temps moyen (s)\",18}{\"Visites moyennes\",18}\");\nConsole.WriteLine(new string('-', 62));\nforeach (double c in new[] { 0.5, 1.0, 1.41, 2.0 })\n{\n    int victoires = 0; double sommeTemps = 0, sommeVisites = 0;\n    int parties = 12;\n    for (int p = 0; p < parties; p++)\n    {\n        var mcts = new MCTS<EtatTTT>(jeu, c: c, seed: 500 + p);\n        var sw = Stopwatch.StartNew();\n        var (res, _, visMoy) = JouerPartieMctsVsRandom(jeu, mcts, iterations: 1000, seed: 900 + p);\n        sw.Stop();\n        if (res > 0) victoires++;\n        sommeTemps += sw.Elapsed.TotalSeconds;\n        sommeVisites += visMoy;\n    }\n    Console.WriteLine($\"{c,6}{victoires * 100.0 / parties,20:F1}{sommeTemps / parties,18:F4}{sommeVisites / parties,18:F1}\");\n}"
-   ]
+   ],
+   "id": "cell-29fcfd83"
   },
   {
    "cell_type": "markdown",
@@ -1065,7 +1104,8 @@
     "- Pour `Resultat`, les jetons tombent : trouver la premiere case vide dans la colonne en partant du bas\n",
     "- Pour `EstTerminal`, verifiez les 4 directions : horizontal, vertical, et les deux diagonales\n",
     "- Le nombre de positions au Connect-4 est d'environ 4.5 trillions, MCTS est donc particulierement pertinent\n"
-   ]
+   ],
+   "id": "cell-77b6a797"
   },
   {
    "cell_type": "code",
@@ -1082,7 +1122,8 @@
    ],
    "source": [
     "// Exercice : MCTS sur Connect-4 (la classe ConnectFour est declaree en Exercice 3).\n// Une fois les 6 methodes implementees, decommentez le tournoi ci-dessous.\n// var jeuC4 = new ConnectFour();\n// var mctsC4 = new MCTS<EtatC4>(jeuC4, seed: 42);\n// var (a4, v4) = mctsC4.Recherche(jeuC4.EtatInitial(), iterations: 2000);\n// Console.WriteLine($\"Connect-4 - MCTS(2000) : colonne={a4}, valeur={v4:F3}\");\nConsole.WriteLine(\"Exercice Connect-4 : completez ConnectFour (Exercice 3) puis decommentez le tournoi.\");"
-   ]
+   ],
+   "id": "cell-978ca3d9"
   },
   {
    "cell_type": "markdown",
@@ -1123,7 +1164,8 @@
     "- Silver, D., Huang, A., Maddison, C.J. et al. (2016). Mastering the game of Go with deep neural networks and tree search. Nature 529:484-489.\n",
     "- Silver, D., Schrittwieser, J., Simonyan, K. et al. (2017). Mastering the game of Go without human knowledge. Nature 550:354-359.\n",
     "- Browne, C.B., Powley, E., Whitehouse, D. et al. (2012). A Survey of Monte Carlo Tree Search Methods. IEEE TCIAIG 4(1):1-43.\n"
-   ]
+   ],
+   "id": "cell-36fe9466"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb
@@ -13,7 +13,8 @@
     "Donald Knuth a inventé l'**Algorithme X** (résolution de la couverture exacte par backtracking) et la structure de données **Dancing Links (DLX)** qui le rend redoutablement efficace. Cette structure exploite une idée géniale : supprimer et restaurer un nœud d'une liste doublement chaînée circulaire sont des opérations **symétriques** en O(1), ce qui accélère dramatiquement le backtracking.\n",
     "\n",
     "Nous allons : (1) définir la couverture exacte, (2) implanter l'Algorithme X naïf, (3) présenter la structure Dancing Links, (4) implanter DLX en C#, (5) l'appliquer au pavage, (6) comparer ses performances au backtracking classique."
-   ]
+   ],
+   "id": "cell-06f1f2df"
   },
   {
    "cell_type": "markdown",
@@ -28,7 +29,8 @@
     "On représente le problème par une **matrice binaire** $A$ ($m$ lignes × $n$ colonnes) où $A[i,j] = 1$ si $j \\in S_i$. Une couverture exacte = un ensemble de lignes dont la somme colonne par colonne vaut exactement 1 partout.\n",
     "\n",
     "Le problème est **NP-complet** : aucune méthode polynomiale connue. Applications : Sudoku, pavage de polyominos, planning de personnel, résolution de casse-têtes (N-reines, pentominoes)."
-   ]
+   ],
+   "id": "cell-1b86e886"
   },
   {
    "cell_type": "code",
@@ -214,7 +216,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-ff274a3d"
   },
   {
    "cell_type": "markdown",
@@ -235,7 +238,8 @@
     "   - Si échec, annuler et essayer la ligne suivante.\n",
     "\n",
     "La version **naïve** recopie la matrice à chaque étape (coûteuse). Dancing Links (section 3) fera tout en O(1)."
-   ]
+   ],
+   "id": "cell-9dcab047"
   },
   {
    "cell_type": "code",
@@ -328,7 +332,8 @@
       "\r\n"
      ]
     }
-   ]
+   ],
+   "id": "cell-f4ca5d48"
   },
   {
    "cell_type": "markdown",
@@ -339,7 +344,8 @@
     "L'heuristique **MRV (Minimum Remaining Values)** choisit la colonne avec le **moins de 1** strictement positif. C'est elle que l'Algorithme X utilise implicitement ci-dessus. Isolez-la dans une fonction dédiée — elle retourne l'index de la colonne optimale, ou `-1` si une colonne n'a aucun 1 (échec).\n",
     "\n",
     "**Indices** : `# Etape 1` compter les 1 par colonne · `# Etape 2` détecter une colonne à 0 → retourner -1 · `# Etape 3` retourner l'index du minimum strictement positif."
-   ]
+   ],
+   "id": "cell-2c878d7e"
   },
   {
    "cell_type": "code",
@@ -367,7 +373,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-dc9038d6"
   },
   {
    "cell_type": "markdown",
@@ -378,7 +385,8 @@
     "Étant donnée une matrice binaire et une liste d'indices de lignes, écrire une fonction `IsExactCover` qui retourne `true` ssi ces lignes forment une couverture exacte (chaque colonne est couverte exactement une fois).\n",
     "\n",
     "**Indices** : `# Etape 1` extraire et sommer les lignes sélectionnées · `# Etape 2` vérifier que chaque colonne vaut exactement 1."
-   ]
+   ],
+   "id": "cell-04042d4f"
   },
   {
    "cell_type": "code",
@@ -406,7 +414,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-9d80f4c1"
   },
   {
    "cell_type": "markdown",
@@ -438,7 +447,8 @@
     "- Toutes les listes sont **circulaires** (le dernier pointe vers le premier).\n",
     "\n",
     "**Opération `cover(c)`** : retire la colonne `c` de la liste des colonnes, puis retire chaque ligne qui contient un 1 dans `c` (en parcourant les autres colonnes de cette ligne et en les détachant verticalement). **`uncover(c)`** fait exactement l'inverse, dans l'ordre inverse — crucial pour restaurer l'état."
-   ]
+   ],
+   "id": "cell-47dced75"
   },
   {
    "cell_type": "code",
@@ -550,7 +560,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-7217a145"
   },
   {
    "cell_type": "markdown",
@@ -571,7 +582,8 @@
     "5. `uncover(c)` et retourner faux.\n",
     "\n",
     "La magie : `cover`/`uncover` sont O(1) par nœud, donc le backtracking ne recopie **aucune matrice**."
-   ]
+   ],
+   "id": "cell-295ec0ac"
   },
   {
    "cell_type": "code",
@@ -648,7 +660,8 @@
       "\r\n"
      ]
     }
-   ]
+   ],
+   "id": "cell-9352e61e"
   },
   {
    "cell_type": "markdown",
@@ -659,7 +672,8 @@
     "La fonction `SolveDlx` ci-dessus s'arrête à la **première** solution. Écrivez `CountAllSolutions` qui compte **toutes** les couvertures exactes d'une matrice. Indice : la structure `Cover`/`Uncover` symétrique permet d'énumérer sans dupliquer ni Corrompre l'état.\n",
     "\n",
     "**Indices** : `# Etape 1` construire la structure DLX · `# Etape 2` modifier `Search` pour qu'au cas de base (`header.R == header`) elle incrémente un compteur et continue au lieu de retourner vrai · `# Etape 3` retourner le total."
-   ]
+   ],
+   "id": "cell-55cbf259"
   },
   {
    "cell_type": "code",
@@ -687,7 +701,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-3155e942"
   },
   {
    "cell_type": "markdown",
@@ -705,7 +720,8 @@
     "### Exemple : grille 3×2 pavée par des triominos\n",
     "\n",
     "Deux formes : le triomino **I** (3 cases en ligne) et le triomino **L**. Construisons la matrice et résolvons-la avec DLX."
-   ]
+   ],
+   "id": "cell-04881c35"
   },
   {
    "cell_type": "code",
@@ -788,7 +804,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-c989a575"
   },
   {
    "cell_type": "markdown",
@@ -797,7 +814,8 @@
     "## 6. Comparaison de performances DLX vs backtracking (~10 min)\n",
     "\n",
     "Comparons DLX à un **backtracking classique** (sans la structure Dancing Links, qui re-teste la cohérence à chaque pas) sur une instance de pavage plus large. L'écart illustre pourquoi la structure de données — pas seulement l'algorithme — compte en pratique."
-   ]
+   ],
+   "id": "cell-872d20ce"
   },
   {
    "cell_type": "code",
@@ -867,7 +885,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-d0d3a232"
   },
   {
    "cell_type": "markdown",
@@ -882,7 +901,8 @@
     "### Exercice 4 : Pavage d'une grille 3×5 avec des trominos\n",
     "\n",
     "**Énoncé** : On souhaite paver une grille 3×5 (15 cases) avec 5 triominos. Modifiez le dictionnaire `triominos` et la taille de grille dans la cellule de pavage pour résoudre ce problème. Combien de pavages distincts existe-t-il ?"
-   ]
+   ],
+   "id": "cell-bb36d206"
   },
   {
    "cell_type": "code",
@@ -904,7 +924,8 @@
      "metadata": {},
      "output_type": "display_data"
     }
-   ]
+   ],
+   "id": "cell-e1ae1531"
   },
   {
    "cell_type": "markdown",
@@ -919,7 +940,8 @@
     "**Verdict #3801 (prong A — SOTA-OK)** : .NET n'a pas de bibliothèque DLX dominante (contrairement à Python où on pourrait importer un solveur) ; l'implémentation from-scratch de la structure toroïdale et des opérations cover/uncover **est** la leçon pédagogique. Les sorties texte passent par `StringBuilder.Display()` plutôt qu'une lib de plotting — en exécution papermill headless, `Console.WriteLine` est avalé, `.Display()` capture `text/plain` (verdict intrinsèque #3436, cohérent avec le twin GA).\n",
     "\n",
     "**Navigation** : [<< Search-7 MCTS](Search-7-MCTS-And-Beyond.ipynb) | [↑ Série Search (C#)](../README.md) | [Search-9 Linear Programming >>](Search-9-LinearProgramming.ipynb)"
-   ]
+   ],
+   "id": "cell-209c0192"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part3-Advanced/Search-12-PatternDatabases.ipynb
@@ -33,7 +33,8 @@
     "données de motifs**. Ce notebook construit d'abord une PDB simple (concept), puis\n",
     "la **PDB additive** qui est, quarante ans après Korf, la référence absolue du\n",
     "15-puzzle."
-   ]
+   ],
+   "id": "cell-b69788eb"
   },
   {
    "cell_type": "markdown",
@@ -43,7 +44,8 @@
     "\n",
     "État = tuple de 16 entiers (cellules en row-major), `0` = case vide. But = tuiles\n",
     "1..15 en ordre, vide en bas à droite."
-   ]
+   ],
+   "id": "cell-0e4b6589"
   },
   {
    "cell_type": "code",
@@ -85,14 +87,16 @@
     "\n",
     "assert len(successors(GOAL)) == 2  # le coin bas-droit a 2 voisins\n",
     "print(\"OK : le but a\", len(successors(GOAL)), \"successeurs\")"
-   ]
+   ],
+   "id": "cell-faa5473a"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 3. Heuristique de Manhattan (référence, vu en Search-3)"
-   ]
+   ],
+   "id": "cell-15266b30"
   },
   {
    "cell_type": "code",
@@ -121,7 +125,8 @@
     "\n",
     "assert manhattan(GOAL) == 0\n",
     "print(\"Manhattan(but) =\", manhattan(GOAL))"
-   ]
+   ],
+   "id": "cell-2eff1d4b"
   },
   {
    "cell_type": "markdown",
@@ -132,7 +137,8 @@
     "On brouille le but par une marche aléatoire longue (90-130 pas), ce qui produit\n",
     "des instances *réalistement difficiles* (optimal typiquement ~38-46 coups) — bien\n",
     "plus coût à résoudre que les instances jouets où Manhattan est instantané."
-   ]
+   ],
+   "id": "cell-ab365b47"
   },
   {
    "cell_type": "code",
@@ -163,7 +169,8 @@
     "INST = scramble(GOAL, 100, seed=11)\n",
     "print(\"Instance de démo :\", INST)\n",
     "print(\"Manhattan =\", manhattan(INST), \"(borne inférieure ; l'optimal est nettement supérieur)\")"
-   ]
+   ],
+   "id": "cell-73d47a5f"
   },
   {
    "cell_type": "markdown",
@@ -186,7 +193,8 @@
     "**Fonction de rang.** Pour stocker la table dans un tableau compact, on *range*\n",
     "chaque état abstrait vers un entier : rang de permutation des positions du motif\n",
     "`P(16,k)`, multiplié par le nombre de cellules restantes pour le vide."
-   ]
+   ],
+   "id": "cell-f4577a77"
   },
   {
    "cell_type": "code",
@@ -238,7 +246,8 @@
     "        seen[rk] = (pos, blank)\n",
     "print(f\"Injectivité du rang : {len(seen)} états abstraits testés, {collisions} collision (attendu 0)\")\n",
     "assert collisions == 0"
-   ]
+   ],
+   "id": "cell-480b43c8"
   },
   {
    "cell_type": "markdown",
@@ -250,7 +259,8 @@
     "distances optimales depuis le but abstrait. Cette PDB unique couvre 5 tuiles ;\n",
     "elle servira de briques, puis la **PDB additive** (section 7) en combinera\n",
     "plusieurs pour couvrir les 15 tuiles."
-   ]
+   ],
+   "id": "cell-28a5c873"
   },
   {
    "cell_type": "code",
@@ -300,7 +310,8 @@
     "PDB5, n5 = build_pdb(PATTERN)\n",
     "print(f\"PDB simple ({len(PATTERN)} tuiles) : {n5:,} états en {time.time()-t0:.1f}s, \"\n",
     "      f\"distance max = {int(PDB5[PDB5<255].max())}\")"
-   ]
+   ],
+   "id": "cell-138d881a"
   },
   {
    "cell_type": "markdown",
@@ -322,7 +333,8 @@
     "On utilise une partition **4-4-4-3** (les groupes couvrent les 15 tuiles). Le BFS\n",
     "devient un **0-1 BFS** : déplacer une tuile du groupe coûte 1, déplacer la case\n",
     "vide à travers un joker coûte 0."
-   ]
+   ],
+   "id": "cell-ebf444e1"
   },
   {
    "cell_type": "code",
@@ -376,7 +388,8 @@
     "print(f\"PDB additives (4-4-4-3) construites en {time.time()-t0:.1f}s\")\n",
     "for g, (tbl, ns) in zip(GROUPS, ADDITIVE):\n",
     "    print(f\"  groupe {g}: {ns:,} états, dist max = {int(tbl[tbl<255].max())}\")"
-   ]
+   ],
+   "id": "cell-c66a73a7"
   },
   {
    "cell_type": "markdown",
@@ -388,7 +401,8 @@
     "itératifs sur `f = g + h`, recherche en profondeur. On compte les **nœuds\n",
     "explorés** (métrique du coût de recherche). On l'introduit avant l'heuristique\n",
     "additive car il sert à sa vérification d'admissibilité ci-après."
-   ]
+   ],
+   "id": "cell-69af6593"
   },
   {
    "cell_type": "code",
@@ -434,7 +448,8 @@
     "easy = scramble(GOAL, 8, seed=1)\n",
     "sm, _ = ida_star(easy, manhattan)\n",
     "print(f\"Sanity : instance facile optimal={sm} (Manhattan résout bien)\")"
-   ]
+   ],
+   "id": "cell-633a8f06"
   },
   {
    "cell_type": "markdown",
@@ -446,7 +461,8 @@
     "sur un échantillon d'instances résolues à l'optimum (via Manhattan, elle-même\n",
     "admissible), `h_additive(s) ≤ optimal(s)` doit toujours tenir. On vérifie aussi la\n",
     "convergence (même optimum) sur une instance facile."
-   ]
+   ],
+   "id": "cell-484927d5"
   },
   {
    "cell_type": "code",
@@ -487,7 +503,8 @@
     "# Dominance vs Manhattan sur une instance\n",
     "print(f\"Sur l'instance de démo : Manhattan={manhattan(INST)}, h_additive={h_additive(INST)} \"\n",
     "      f\"(additive >= Manhattan attendu)\")"
-   ]
+   ],
+   "id": "cell-5ccf0cf3"
   },
   {
    "cell_type": "markdown",
@@ -501,7 +518,8 @@
     "l'heuristique. Sur les instances les plus dures, Manhattan frappe la limite\n",
     "(20M nœuds) tandis que la PDB additive en explore **un ordre de grandeur moins**\n",
     "et termine."
-   ]
+   ],
+   "id": "cell-48fd0855"
   },
   {
    "cell_type": "code",
@@ -550,14 +568,16 @@
     "          f\"additive: {na_s} ({ta:6.1f}s) | speedup x{speedup:6.1f}\")\n",
     "\n",
     "bench = rows"
-   ]
+   ],
+   "id": "cell-4cf2ee63"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 10. Visualisation : la PDB additive comprime l'arbre de recherche"
-   ]
+   ],
+   "id": "cell-e423da18"
   },
   {
    "cell_type": "code",
@@ -591,7 +611,8 @@
     "        ax.annotate(f'{int(r.get_height()):,}', (r.get_x()+r.get_width()/2, r.get_height()),\n",
     "                    ha='center', va='bottom', fontsize=7)\n",
     "plt.tight_layout(); plt.show()"
-   ]
+   ],
+   "id": "cell-228ee245"
   },
   {
    "cell_type": "markdown",
@@ -608,7 +629,8 @@
     "- **Généralité.** La même technique résout le Rubik's Cube (Korf 1997), la Tour de\n",
     "  Hanoï, tout puzzle de permutation. C'est l'archétype du compromis\n",
     "  *mémoire contre qualité d'heuristique*."
-   ]
+   ],
+   "id": "cell-0b79209d"
   },
   {
    "cell_type": "markdown",
@@ -625,7 +647,8 @@
     "Remplacez la partition 4-4-4-3 par **6-6-3** (Korf & Felner 2002). Combien d'états\n",
     "par PDB (`P(16,6)×10`, `P(16,3)×13`) ? Mesurez le speedup supplémentaire sur les\n",
     "instances du banc d'essai. Attention au temps de construction des groupes de 6."
-   ]
+   ],
+   "id": "cell-932b57b3"
   },
   {
    "cell_type": "code",
@@ -645,7 +668,8 @@
     "def h_additive_663(state):\n",
     "    # Indice : somme des lookups sur GROUPS_663.\n",
     "    pass  # TODO etudiant"
-   ]
+   ],
+   "id": "cell-f9e3f29a"
   },
   {
    "cell_type": "markdown",
@@ -658,7 +682,8 @@
     "transformation `reflect(state)`, vérifiez qu'elle préserve la résolubilité et que\n",
     "`h_additive(state) == h_additive(reflect(state))`. En déduire une seconde PDB\n",
     "*gratuite* et combinez-la par `max`."
-   ]
+   ],
+   "id": "cell-5328983f"
   },
   {
    "cell_type": "code",
@@ -675,7 +700,8 @@
     "    pass  # TODO etudiant\n",
     "\n",
     "# Indice : vérifiez reflect(reflect(s)) == s et h_additive(s) == h_additive(reflect(s))."
-   ]
+   ],
+   "id": "cell-5f194e47"
   },
   {
    "cell_type": "markdown",
@@ -687,7 +713,8 @@
     "seules les PDB additives rendent la résolution optimale envisageable. Adaptez ce\n",
     "notebook (25 cellules, partition 6-6-6-7) et résolvez une instance. Que\n",
     "constatez-vous sur le rapport construction/qualité ?"
-   ]
+   ],
+   "id": "cell-ca1ae9c2"
   },
   {
    "cell_type": "code",
@@ -700,7 +727,8 @@
     "# et la partition. Étape 1 : redéfinissez GOAL24 et neighbors pour N=5.\n",
     "# Étape 2 : attention à l'explosion de P(25, k) — restez sur des groupes <= 6.\n",
     "pass  # TODO etudiant"
-   ]
+   ],
+   "id": "cell-12a65b8b"
   },
   {
    "cell_type": "markdown",
@@ -748,7 +776,8 @@
     "\n",
     "← [Search-3 — Recherche informée](../Part1-Foundations/Search-3-Informed.ipynb)\n",
     "| ↑ [Search (racine)](../README.md) | [Partie 4 — Métaheuristiques →](../Part4-Metaheuristics/README.md)"
-   ]
+   ],
+   "id": "cell-58db3f04"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## nbformat v4.5 cell-id hygiene — Search series (4 notebooks, 109 cells)

Adds the required `id` field to cells that declare nbformat v4.5 (`nbformat_minor=5`) but are missing it. Pure **structural metadata** fix — no re-execution, content byte-identical.

### Why
`nbformat.validate()` warns/fails on a v4.5 notebook whose cells lack `id`. A fleet scan found **54 such defects across non-QC Python families**; po-2026 already fixed QC-Cloud (#6254) and QC-Py main (#6257), po-2024 is fixing QC-Py slices (#6285, #6290). The **Search family was unclaimed** — this PR covers it.

### Scope (4 notebooks, disjoint from QC PRs)
| Notebook | Kernel | Cells missing id |
|----------|--------|-----------------:|
| Search-5-GeneticAlgorithms-**Csharp** | .net-csharp | 16 / 19 |
| Search-7-MCTS-And-Beyond-**Csharp** | .net-csharp | 42 / 42 |
| Search-8-DancingLinks-**Csharp** | .net-csharp | 22 / 22 |
| Search-12-PatternDatabases (Python) | python3 | 29 / 29 |
| **Total** | | **109** |

### Anti-regression (3-way proof, content untouched)
1. **Content fingerprint stable** — for every cell, the JSON of all keys except `id` is identical before/after.
2. **Round-trip fidelity asserted BEFORE edit** — `json.dumps(nb, indent=1, ensure_ascii=False)` reproduces the original file byte-for-byte (including trailing-newline behavior), so the only diff produced is the added `"id"` line + the comma that precedes it. The diff is **+218/−109**, which decomposes exactly as 109 new id lines + 109 `]`→`],` comma additions (C# notebooks store French accents as raw UTF-8; `ensure_ascii=False` preserves them, avoiding the L3966 churn trap).
3. **`nbformat.validate()` PASS** on all 4 notebooks.

The repo validator `scripts/notebook_tools/validate_pr_notebooks.py` → **4/4 passed (48 code cells)**. H.3 sanity: 0 cells with `execution_count=None & no outputs`.

### Methodology
Ids are deterministic (`cell-<md5(nbname:idx)[:8]>`) and unique within each notebook. Matches the proven register (#6257 / #6285 / #6290). Exec-equivalent metadata fix — no re-execution; .NET Advisory #5214 (CI cannot Papermill .NET Interactive, but `nbformat.validate` is structural, not execution).

See #6254, #6257, #6285, #6290 (sibling nbformat hygiene PRs).
