### PR TITLE
fix(probas-infer): nbformat v4.5 cell ids for Infer-3/Infer-5 (structural metadata)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
@@ -2542,7 +2542,8 @@
     "- Referencez la section 9 ci-dessus pour la syntaxe complete de `Variable.Case` vs `Variable.Switch`\n",
     "- Commencez par definir les trois probabilites de culpabilite conditionnelles (ex. jalousie -> 0.8, argent -> 0.4, personnel -> 0.6)\n",
     "- Question supplementaire : que se passe-t-il si vous ajoutez l'evidence \"arme = revolver\" comme dans la section 5 ? Le posterieur du motif change-t-il ?"
-   ]
+   ],
+   "id": "cell-be8168fa"
   },
   {
    "cell_type": "code",
@@ -2576,7 +2577,8 @@
     "\n",
     "// Question supplementaire : ajouter l'evidence arme = revolver et observer le changement\n",
     "Console.WriteLine(\"Exercice a completer : Motif du crime avec Variable.Case\");"
-   ]
+   ],
+   "id": "cell-75fd5727"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb
@@ -1634,7 +1634,8 @@
     "**Objectif** : coder le SCM (CPT via `Variable.If` comme en section 3), calculer les deux quantites, puis **mutiler l'arc `U -> X`** (`Bernoulli(1.0)` force) pour le `do()`.\n",
     "\n",
     "Les étapes (`// Étape N`) et l'indice sont dans le code ci-dessous."
-   ]
+   ],
+   "id": "cell-fa9cc32d"
   },
   {
    "cell_type": "code",
@@ -1672,7 +1673,8 @@
     "$$P(Y \\mid do(X)) = \\sum_z P(Y \\mid X, z)\\, P(z)$$\n",
     "\n",
     "**Objectif** : choisir un reseau a 3-4 noeuds avec un confondeur observe, **identifier l'ensemble d'ajustement `Z`**, appliquer la formule, et comparer au `do()` direct (les deux doivent coïncider si `Z` est valide)."
-   ]
+   ],
+   "id": "cell-7111f216"
   },
   {
    "cell_type": "code",
@@ -1709,7 +1711,8 @@
     "$$P(Y \\mid do(X)) = \\sum_m P(M=m \\mid X) \\sum_{x'} P(Y \\mid M=m, x')\\, P(x')$$\n",
     "\n",
     "**Objectif** : adapter la section 6 avec de nouvelles CPT (fumer passif, exposition professionnelle) en **preservant la structure** `X -> M -> Y` + `U -> X`, `U -> Y` (U reste non observe)."
-   ]
+   ],
+   "id": "cell-f6b3f7b1"
   },
   {
    "cell_type": "code",
@@ -1744,7 +1747,8 @@
     "**Concept** (cf. section 7) : un **renversement de Simpson** survient quand une conclusion s'inverse entre l'analyse agregee et l'analyse conditionnelle - typiquement parce qu'un confondeur `Z` favorise `X` tout en defavorisant `Y` (les patients graves, moins soignes, faussent la moyenne).\n",
     "\n",
     "**Objectif** : concevoir des CPT produisant un renversement (ex. traitement + age, ou genre + admission Berkeley 1973), puis montrer que `P(Y|X)` agrege **differere** de `P(Y|do(X))` et expliquer le mecanisme. C'est le cas ou la **conclusion naive** (agregee) est causalement **fausse** - le coeur de pourquoi l'ajustement causal importe."
-   ]
+   ],
+   "id": "cell-401fa4fc"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Scope

Add unique `id` field to **6 id-less cells** across 2 Probas/Infer notebooks to satisfy **nbformat v4.5 spec** (cell identifiers required at `nbformat_minor >= 5`).

| Notebook | Cells missing `id` | nbformat_minor |
|----------|---------------------|----------------|
| `Infer-3-Factor-Graphs.ipynb`  | 2 | 5 (already) |
| `Infer-5-Causal-Inference.ipynb` | 4 | 5 (already) |
| **Total** | **6** | |

## Why

nbformat v4.5 requires every cell to carry a unique `id`. These two .NET Interactive (Infer.NET) notebooks were minor=5 but had cells without ids — non-compliant. Register applied fleet-wide (precedent: ICT-Series #6293, Search #6292, QC-Py #6285/#6290).

## Surgical (content byte-identical)

Pure structural metadata — no source/output/execution_count/metadata change:
- Cell fingerprint `sha256([cell_type, source, outputs, execution_count, metadata])` identical before/after per notebook (verified programmatically).
- Diff is ONLY: `]` -> `],` (comma) + `"id": "cell-<8hex>"` lines.
- Trailing newline preserved (no EOF reformatting).
- `nbformat.validate()` PASSES on both.

## Deterministic id generation

`id = "cell-" + md5("<filename>-<cellIndex>")[:8]`, unique within notebook (collision-checked).

## Verification

```
Infer-3-Factor-Graphs    +2  content_same=True  trailing_nl_preserved=True
Infer-5-Causal-Inference +4  content_same=True  trailing_nl_preserved=True
TOTAL added: 6 ; nbformat.validate() PASS (both)
```

Structural metadata fix, no cell content re-execution needed (outputs/execution_count untouched).

See #2161 (notebook quality). One subject (Probas/Infer nbformat compliance), atomic.