### PR TITLE
recover(lean,#3846): re-land gridToMacroCellWithOffsetN N3 bridge (orphaned by concurrent-merge race, #6231)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -727,6 +727,27 @@ def gridToMacroCellWithOffset (g : Grid) : (Int × Int) × MacroCell :=
   let (off, lvl) := gridFrame g
   (off, MacroCell.buildFromGrid g off.1 off.2 lvl)
 
+/-- n-aware variant of `gridToMacroCellWithOffset`: builds the `MacroCell` from
+    the n-aware frame `gridFrameN n g` (padding `max 2 n`), rather than the
+    fixed-padding `gridFrame`. This is the offset/MacroCell builder the N3
+    threading of `evolveHashlifeFast` (issue #3846) substitutes in place of
+    `gridToMacroCellWithOffset` to thread the n-aware frame through the recursion
+    loop. -/
+def gridToMacroCellWithOffsetN (n : Nat) (g : Grid) : (Int × Int) × MacroCell :=
+  let (off, lvl) := gridFrameN n g
+  (off, MacroCell.buildFromGrid g off.1 off.2 lvl)
+
+/-- `gridToMacroCellWithOffsetN n g` reduces to `gridToMacroCellWithOffset g`
+    when `n ≤ 2`: since `gridFrameN n g = gridFrame g` for small `n`
+    (`gridFrameN_le_two_eq_gridFrame`), both builders feed the same offset and
+    level to `buildFromGrid`. This bridges the fixed-frame builder used by the
+    current `evolveHashlifeFast` to its n-aware variant, so the N3 threading
+    substitution is behaviorally transparent for small `n` (issue #3846). -/
+theorem gridToMacroCellWithOffsetN_le_two_eq (n : Nat) (g : Grid) (hn : n ≤ 2) :
+    gridToMacroCellWithOffsetN n g = gridToMacroCellWithOffset g := by
+  unfold gridToMacroCellWithOffsetN gridToMacroCellWithOffset
+  rw [gridFrameN_le_two_eq_gridFrame n g hn]
+
 /-- Convert a `Grid` to a `MacroCell`, discarding the offset (defaulting to
     `(0, 0)` for the round trip). For round-trip purposes, prefer
     `gridToMacroCellWithOffset`. -/


### PR DESCRIPTION
## Recovery of orphaned merge #6231

**Incident (firsthand-verified):** #6231 was squash-merged (mergeCommit `44da893f`) at 10:17 during a high-throughput batch, but a concurrent-merge race dropped its squash commit — GitHub still shows #6231 as MERGED, yet `git merge-base --is-ancestor 44da893f origin/main` = false and `git grep gridToMacroCellWithOffsetN` = **0** in main. Content genuinely absent. (G.1 / leçon C452-L1: verify content-presence, not just the MERGED label.)

**Impact:** blocks po-2026's N3-threading main track — `evolveHashlifeFast` needs `gridToMacroCellWithOffsetN` + `gridToMacroCellWithOffsetN_le_two_eq` to thread the n-aware frame (#3846).

**This PR:** cherry-picks the original squash `44da893f` onto current main. Additive (+21/-0) to `MacroCell.lean` — def + lemma, **0 new sorries** (verified in original + re-verified by cold-build here). Content re-introduced (grep = 5).

Cold-build gated (lean-merge §1). See #6231. Part of the orphan-recovery for the concurrent-merge-race incident (2026-07-12).