### PR TITLE
fix(genai-ft): nbformat v4.5 cell ids for FT-01-Introduction-FineTuning (structural metadata)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -16,7 +16,8 @@
     "5. Evaluation avant/apres\n",
     "\n",
     "**Materiel requis** : GPU avec ~4 Go VRAM (GPT-2 = 124M params)."
-   ]
+   ],
+   "id": "cell-24754727"
   },
   {
    "cell_type": "code",
@@ -44,7 +45,8 @@
     "if torch.cuda.is_available():\n",
     "    print(f\"GPU : {torch.cuda.get_device_name(0)}\")\n",
     "    print(f\"VRAM : {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} Go\")"
-   ]
+   ],
+   "id": "cell-2853ccbc"
   },
   {
    "cell_type": "markdown",
@@ -62,7 +64,8 @@
     "| Reduction des hallucinations | Un modele specialise fait moins d'erreurs dans son domaine |\n",
     "\n",
     "**Exemple** : GPT-2 genere du texte anglais generique. Apres fine-tuning sur des textes francais du 19e siecle, il peut imiter ce style specifique."
-   ]
+   ],
+   "id": "cell-66318dab"
   },
   {
    "cell_type": "markdown",
@@ -103,7 +106,8 @@
     "ou $B \\in \\mathbb{R}^{d \\times r}$, $A \\in \\mathbb{R}^{r \\times k}$, et $r \\ll \\min(d, k)$.\n",
     "\n",
     "Le rang $r$ (typiquement 4-64) controle le compromis expressivite/efficacite."
-   ]
+   ],
+   "id": "cell-8791918c"
   },
   {
    "cell_type": "markdown",
@@ -112,7 +116,8 @@
     "## 3. Comparaison des parametres entrainables\n",
     "\n",
     "Chargeons un petit modele (GPT-2, 124M params) et comparons les trois approches."
-   ]
+   ],
+   "id": "cell-dfcac0ae"
   },
   {
    "cell_type": "code",
@@ -259,7 +264,8 @@
     "total_params = sum(p.numel() for p in model.parameters())\n",
     "print(f\"Modele : {MODEL_NAME}\")\n",
     "print(f\"Parametres totaux : {total_params:,} ({total_params/1e6:.1f}M)\")"
-   ]
+   ],
+   "id": "cell-c2fa367d"
   },
   {
    "cell_type": "code",
@@ -359,7 +365,8 @@
     "print(f\"{'Partial (2 couches)':<20} {partial_trainable:>15,} {total:>15,} {partial_trainable/total*100:>7.2f}%\")\n",
     "print(f\"{'LoRA (r=8)':<20} {lora_trainable:>15,} {total:>15,} {lora_trainable/total*100:>7.2f}%\")\n",
     "print(f\"\\nRatio LoRA/Full = {lora_trainable/full_trainable*100:.2f}%\")"
-   ]
+   ],
+   "id": "cell-de59f036"
   },
   {
    "cell_type": "markdown",
@@ -369,7 +376,8 @@
     "\n",
     "Nous allons fine-tuner GPT-2 pour generer du texte dans le style de Victor Hugo.\n",
     "Le dataset est un extrait des *Miserables* (domaine public)."
-   ]
+   ],
+   "id": "cell-2c50759f"
   },
   {
    "cell_type": "code",
@@ -431,7 +439,8 @@
     "# Creer le dataset\n",
     "train_data = Dataset.from_dict({\"text\": segments})\n",
     "print(f\"Dataset : {len(train_data)} exemples\")"
-   ]
+   ],
+   "id": "cell-09a20769"
   },
   {
    "cell_type": "code",
@@ -474,12 +483,14 @@
     "\n",
     "tokenized_dataset = train_data.map(tokenize_function, batched=True, remove_columns=[\"text\"])\n",
     "print(f\"Tokens par exemple : {len(tokenized_dataset[0]['input_ids'])}\")"
-   ]
+   ],
+   "id": "cell-8cf30c19"
   },
   {
    "cell_type": "markdown",
    "source": "Le dataset est tokenise avec un padding uniforme a 256 tokens. Chaque exemple contient les `input_ids` et les `labels` (copie des input_ids pour le causal language modeling). Nous allons maintenant configurer l'adaptateur LoRA et lancer l'entrainement.",
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-5eae637f"
   },
   {
    "cell_type": "code",
@@ -650,7 +661,8 @@
     "train_result = trainer.train()\n",
     "print(f\"\\nPerte finale : {train_result.training_loss:.4f}\")\n",
     "print(f\"Temps : {train_result.metrics['train_runtime']:.1f}s\")"
-   ]
+   ],
+   "id": "cell-565b5293"
   },
   {
    "cell_type": "markdown",
@@ -659,7 +671,8 @@
     "## 5. Evaluation avant / apres\n",
     "\n",
     "Comparons la generation du modele original vs le modele fine-tune."
-   ]
+   ],
+   "id": "cell-2fe06360"
   },
   {
    "cell_type": "code",
@@ -754,7 +767,8 @@
     "model_to_train.eval()\n",
     "finetuned_output = generate_text(model_to_train, prompt)\n",
     "print(finetuned_output)"
-   ]
+   ],
+   "id": "cell-e44b2476"
   },
   {
    "cell_type": "code",
@@ -812,7 +826,8 @@
     "\n",
     "print(\"\\nFINE-TUNE :\")\n",
     "print(generate_text(model_to_train, prompt2))"
-   ]
+   ],
+   "id": "cell-14e59cfb"
   },
   {
    "cell_type": "markdown",
@@ -821,7 +836,8 @@
     "## 6. Taille des adaptateurs LoRA\n",
     "\n",
     "Un des avantages majeurs de LoRA : les poids appris sont minuscules."
-   ]
+   ],
+   "id": "cell-dc70a9c6"
   },
   {
    "cell_type": "code",
@@ -861,14 +877,16 @@
     "print(f\"Adaptateur LoRA seul  : {adapter_size_mb:.2f} Mo\")\n",
     "print(f\"Ratio adaptateur/modele : {adapter_size_mb/model_size_mb*100:.2f}%\")\n",
     "print(f\"\\nPour deployer : il suffit du modele de base + adaptateur ({adapter_size_mb:.1f} Mo)\")"
-   ]
+   ],
+   "id": "cell-c7cfd896"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 7. Nettoyage memoire GPU"
-   ]
+   ],
+   "id": "cell-fd8f3de4"
   },
   {
    "cell_type": "code",
@@ -891,7 +909,8 @@
     "    print(f\"VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} Go\")\n",
     "else:\n",
     "    print(\"Nettoyage termine\")"
-   ]
+   ],
+   "id": "cell-94c0915a"
   },
   {
    "cell_type": "markdown",
@@ -900,7 +919,8 @@
     "## 8. Exercices\n",
     "\n",
     "Appliquez les concepts de ce notebook."
-   ]
+   ],
+   "id": "cell-f59529da"
   },
   {
    "cell_type": "code",
@@ -922,7 +942,8 @@
     "# Quel rang donne le meilleur ratio performance/taille ?\n",
     "\n",
     "print(\"Exercice a completer : comparez les rangs LoRA r=2, 8, 32\")"
-   ]
+   ],
+   "id": "cell-4102f87c"
   },
   {
    "cell_type": "code",
@@ -944,12 +965,14 @@
     "# Observez comment le style de generation change.\n",
     "\n",
     "print(\"Exercice a completer : fine-tunez sur un style different\")"
-   ]
+   ],
+   "id": "cell-f42dac6b"
   },
   {
    "cell_type": "markdown",
    "source": "### Exercice 3 : Hyperparametres d'entrainement\n\nLe *learning rate* est l'hyperparametre le plus sensible du fine-tuning. Un LR trop faible = convergence lente, un LR trop eleve = divergence et degradation du modele. Testez differentes valeurs pour trouver le point optimal.",
-   "metadata": {}
+   "metadata": {},
+   "id": "cell-70d4b526"
   },
   {
    "cell_type": "code",
@@ -971,7 +994,8 @@
     "# Que se passe-t-il avec un learning rate trop eleve ?\n",
     "\n",
     "print(\"Exercice a completer : comparez les learning rates\")"
-   ]
+   ],
+   "id": "cell-fc5cb509"
   },
   {
    "cell_type": "markdown",
@@ -992,7 +1016,8 @@
     "- Le rang $r$ controle le compromis expressivite/efficacite\n",
     "\n",
     "**Prochaines etapes** (FT-02) : LoRA sur un modele plus grand avec quantization 4-bit (QLoRA)."
-   ]
+   ],
+   "id": "cell-ebb412ad"
   }
  ],
  "metadata": {
@@ -1007,5 +1032,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Scope

Bring `FT-01-Introduction-FineTuning.ipynb` (GenAI/FineTuning, Python) to **nbformat v4.5 compliance**:
- Bump `nbformat_minor` 4 -> 5
- Add unique `id` to **25 id-less cells**

## Why

nbformat v4.5 requires every cell to carry a unique `id`. This notebook was minor=4 with no cell ids. Register applied fleet-wide (precedent: ICT-Series #6293, Search #6292, QC-Py #6285/#6290, Probas/Infer #6294).

## Surgical (content byte-identical)

Pure structural metadata — no source/output/execution_count/metadata change:
- Cell fingerprint `sha256([cell_type, source, outputs, execution_count, metadata])` **identical before/after** (verified programmatically).
- Diff is ONLY: `nbformat_minor: 4->5` + `]`->`,` (comma) + `"id": "cell-<8hex>"` lines (x25).
- `nbformat.validate()` PASSES.

## Deterministic id generation

`id = "cell-" + md5("<filename>-<cellIndex>")[:8]`, unique within notebook (collision-checked).

## Verification

```
FT-01  minor 4->5  +25 ids  content_same=True  nbformat.validate() PASS
```

Structural metadata fix, no cell content re-execution needed (outputs/execution_count untouched). FT-01 outputs untouched — this PR does NOT alter any GenAI service invocations or their results.

See #2161 (notebook quality). One subject (GenAI/FineTuning FT-01 nbformat compliance), atomic.