### PR TITLE
recover(prover): re-land concurrent LSP exact?/apply? search (orphaned by concurrent-merge race, #6252)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -480,8 +480,21 @@ class SearchTools:
         return json.dumps(found, indent=2, ensure_ascii=False)
 
     def _search_via_lsp(self, goal: str) -> list:
-        """Search Mathlib using Lean LSP via exact?/apply? tactics."""
+        """Search Mathlib using Lean LSP via exact?/apply? tactics.
+
+        Runs both tactics CONCURRENTLY. Each ``verifier.search_lean`` call
+        spawns a ``lake env lean --stdin`` subprocess whose cost is dominated
+        by Mathlib import elaboration (~98 s on a heavy module). Sequentially
+        that is ~196 s wall-clock — both calls routinely overrun the per-call
+        120 s timeout on complex P4/P5 goals, so the SearchAgent falls back to
+        the LLM with zero Mathlib hints (root cause of the empty-LSP traces on
+        the P4 mono-verrou). Concurrent execution collapses wall-clock to
+        ~max(single call), so at least one tactic tends to land before the
+        timeout. Suggestions stay attributed per tactic and returned in fixed
+        order (exact? first, apply? second) — no parsing or contract change.
+        """
         try:
+            from concurrent.futures import ThreadPoolExecutor
             from .verifier import get_verifier
             from .lean_utils import resolve_lake_module
             # Resolve the real Lake root + dotted module by walking up to the
@@ -493,18 +506,41 @@ class SearchTools:
             lake_root, module_name = resolve_lake_module(self._filepath)
             verifier = get_verifier(lake_root)
 
-            results = []
-            for tactic in ["exact?", "apply?"]:
-                search_result = verifier.search_lean(module_name, goal, tactic)
-                for suggestion in search_result.get("suggestions", []):
-                    results.append({
-                        "name": suggestion["tactic"][:50],
-                        "statement": suggestion["tactic"],
-                        "namespace": "Mathlib",
-                        "relevance": 0.9,
-                        "source": f"lsp_{tactic}",
-                    })
-            return results
+            tactics = ["exact?", "apply?"]
+            # Preserve display order (exact? first) regardless of completion
+            # order: a dict keyed by tactic, flattened in fixed sequence at the
+            # end.
+            by_tactic: dict = {t: [] for t in tactics}
+            with ThreadPoolExecutor(max_workers=len(tactics)) as pool:
+                future_to_tactic = {
+                    pool.submit(verifier.search_lean, module_name, goal, t): t
+                    for t in tactics
+                }
+                for fut, t in future_to_tactic.items():
+                    try:
+                        search_result = fut.result()
+                    except Exception as te:
+                        # A single tactic failing must not poison the other:
+                        # surface it and keep going so a working exact? is not
+                        # lost because apply? raised.
+                        if self._trace:
+                            self._trace.log(
+                                agent="SearchAgent", role="tool",
+                                content=f"_search_via_lsp {t} failed: "
+                                        f"{type(te).__name__}: {te}",
+                                duration_s=0.0, tool_name="search_via_lsp",
+                                tool_result="error",
+                            )
+                        continue
+                    for suggestion in search_result.get("suggestions", []):
+                        by_tactic[t].append({
+                            "name": suggestion["tactic"][:50],
+                            "statement": suggestion["tactic"],
+                            "namespace": "Mathlib",
+                            "relevance": 0.9,
+                            "source": f"lsp_{t}",
+                        })
+            return by_tactic["exact?"] + by_tactic["apply?"]
         except Exception as e:
             # Do not swallow silently: a dead LSP channel used to look identical
             # to "no lemmas found". Surface it in the trace for diagnosis.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2666,6 +2666,106 @@ def test_legacy_fallback_still_works_when_no_workspace_root(monkeypatch):
 # See #1453 follow-up to PR #6067.
 # ---------------------------------------------------------------------------
 
+
+# ---------------------------------------------------------------------------
+# _search_via_lsp concurrency (c.343, #1453) — the SearchAgent runs exact?
+# and apply? in parallel to halve wall-clock. Each search_lean call is a
+# `lake env lean --stdin` subprocess dominated by Mathlib import elaboration
+# (~98 s); the old sequential loop was ~196 s and routinely overran the
+# 120 s per-call timeout on heavy modules, returning zero suggestions. The
+# tests pin: both tactics fire, order is preserved (exact? then apply?), and
+# one tactic failing does not poison the other.
+# ---------------------------------------------------------------------------
+
+def _build_search_tools(monkeypatch, tactic_results, calls):
+    """Build a SearchTools whose verifier.search_lean records calls and
+    returns per-tactic results. ``tactic_results`` maps tactic -> suggestions
+    list (or Exception instance to raise)."""
+    import prover.verifier as vmod
+    import prover.lean_utils as lu
+    from prover.state import ProofState
+    from prover.tools import SearchTools
+
+    class _FakeVerifier:
+        def search_lean(self, module_name, goal, tactic):
+            calls.append((tactic, module_name, goal))
+            res = tactic_results.get(tactic, [])
+            if isinstance(res, Exception):
+                raise res
+            return {"success": len(res) > 0, "suggestions": res,
+                    "tactic_used": tactic, "goal": goal[:200], "raw_output": ""}
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _FakeVerifier())
+    monkeypatch.setattr(lu, "resolve_lake_module",
+                        lambda fp: ("/fake/lake_root", "Fake.Module"))
+    return SearchTools(ProofState(theorem_statement="t"), filepath="/fake/Fake/Module.lean")
+
+
+def test_search_via_lsp_runs_both_tactics_and_preserves_order(monkeypatch):
+    """exact? and apply? both execute; suggestions return exact?-first."""
+    calls = []
+    tools = _build_search_tools(monkeypatch, {
+        "exact?": [{"tactic": "exact le_one"}, {"tactic": "exact le_two"}],
+        "apply?": [{"tactic": "apply le_three"}],
+    }, calls)
+
+    results = tools._search_via_lsp("0 ≤ n")
+
+    tactics_called = [c[0] for c in calls]
+    assert set(tactics_called) == {"exact?", "apply?"}, (
+        f"both tactics must fire, got {tactics_called}"
+    )
+    # Fixed order: exact? suggestions before apply? suggestions, regardless
+    # of which subprocess finished first.
+    sources = [r["source"] for r in results]
+    assert sources == ["lsp_exact?", "lsp_exact?", "lsp_apply?"], (
+        f"order must be exact?-first then apply?, got {sources}"
+    )
+    assert [r["statement"] for r in results] == [
+        "exact le_one", "exact le_two", "apply le_three"], (
+        "suggestion statements must map through unchanged"
+    )
+
+
+def test_search_via_lsp_resilient_to_one_tactic_failing(monkeypatch):
+    """If apply? raises, exact? suggestions still return (no poisoning)."""
+    calls = []
+    tools = _build_search_tools(monkeypatch, {
+        "exact?": [{"tactic": "exact survived"}],
+        "apply?": RuntimeError("apply? subprocess crashed"),
+    }, calls)
+
+    results = tools._search_via_lsp("goal")
+
+    assert [r["statement"] for r in results] == ["exact survived"], (
+        "exact? result must survive an apply? failure"
+    )
+    assert {c[0] for c in calls} == {"exact?", "apply?"}, (
+        "both tactics must have been attempted"
+    )
+
+
+def test_search_via_lsp_empty_when_verifier_unavailable(monkeypatch):
+    """A dead verifier channel returns [] (logged), never propagates."""
+    import prover.verifier as vmod
+    import prover.lean_utils as lu
+    from prover.state import ProofState
+    from prover.tools import SearchTools
+
+    def _boom(*a, **k):
+        raise FileNotFoundError("lean not on PATH")
+
+    monkeypatch.setattr(vmod, "get_verifier", _boom)
+    monkeypatch.setattr(lu, "resolve_lake_module",
+                        lambda fp: ("/fake/lake_root", "Fake.Module"))
+    tools = SearchTools(ProofState(theorem_statement="t"),
+                        filepath="/fake/Fake/Module.lean")
+
+    assert tools._search_via_lsp("goal") == [], (
+        "verifier failure must degrade to empty, not raise"
+    )
+
+
 def test_latch_uses_resolve_lake_module_for_depth3_files(tmp_path):
     """Latch code path must call resolve_lake_module() on the file path so
     `project_dir` lands on the directory holding the lakefile and the relative


### PR DESCRIPTION
## Recovery of orphaned merge #6252

**Incident (firsthand-verified):** #6252 squash-merged (`f603355f`) at 09:51 in the high-throughput batch, but a concurrent-merge race dropped the squash — GitHub shows MERGED, yet `merge-base --is-ancestor f603355f origin/main` = false and `grep ThreadPoolExecutor prover/tools.py` in main = **0**. Content genuinely absent.

**This PR:** cherry-picks the original squash onto current main. Cleanly stacks on #6249 (in main). Re-introduces concurrent `exact?`/`apply?` in `SearchAgent._search_via_lsp` via `ThreadPoolExecutor` (+149/-13, tools.py + test_prover_guards.py). Collapses sequential ~196s → ~max(single call) so at least one tactic lands before the 120s timeout — directly attacks the empty-LSP traces on the P4 mono-verrou (Hashlife N3/W3, #3846/#1453).

See #6252, See #1453. Orphan-recovery for the concurrent-merge-race incident (2026-07-12).