### PR TITLE
fix(rl): nbformat v4.5 cell ids for rl_6d_sac_from_scratch (25 cells, structural metadata)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_6d_sac_from_scratch.ipynb
@@ -26,7 +26,8 @@
     "- Concepts RL de base (policy, reward, discount, on-policy vs off-policy)\n",
     "\n",
     "**Duree estimee** : 45-50 minutes"
-   ]
+   ],
+   "id": "cell-c3094261"
   },
   {
    "cell_type": "markdown",
@@ -51,14 +52,16 @@
     "4. **Twin Q-networks** : deux critiques prennent le minimum de leurs estimations, reduisant la surestimation de Q\n",
     "\n",
     "SAC est l'algorithme de reference pour les environnements a actions continues. Il est sample-efficient, robuste aux hyperparametres, et converge souvent plus vite que PPO sur ces taches."
-   ]
+   ],
+   "id": "cell-cf7f32af"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 1. Setup et imports"
-   ]
+   ],
+   "id": "cell-837311ca"
   },
   {
    "cell_type": "code",
@@ -107,7 +110,8 @@
    "metadata": {},
    "source": [
     "Nous travaillons sur **Pendulum-v1**, un environnement de controle classique avec un espace d'actions **continu** dans $[-2, 2]$. L'observation est un vecteur de dimension 3 (cos et sin de l'angle, vitesse angulaire). C'est un benchmark standard pour les algorithmes a actions continues."
-   ]
+   ],
+   "id": "cell-c24e32bd"
   },
   {
    "cell_type": "markdown",
@@ -127,14 +131,16 @@
     "- **Multi-modalite** : si plusieurs strategies sont aussi bonnes, l'agent les preserve toutes\n",
     "\n",
     "Le parametre $\\alpha$ controle le compromis exploitation/exploration. SAC propose un reglage **automatique** de $\\alpha$ (auto-tuning) en traitant $\\alpha$ comme un parametre apprenable."
-   ]
+   ],
+   "id": "cell-052cf312"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 2.1 Visualisation : entropie de differentes distributions"
-   ]
+   ],
+   "id": "cell-c1df0067"
   },
   {
    "cell_type": "code",
@@ -221,7 +227,8 @@
     "| Haute entropie | 2.0 | ~2.11 | Explore largement l'espace |\n",
     "\n",
     "**Point cle** : SAC maximise l'entropie, donc il pousse naturellement la politique vers la distribution de droite tout en maximisant la recompense. Cela produit un agent plus robuste."
-   ]
+   ],
+   "id": "cell-8acac39f"
   },
   {
    "cell_type": "markdown",
@@ -237,7 +244,8 @@
     "| **TwinQNetwork** (Critic) | Deux Q-networks $Q_{\\theta_1}, Q_{\\theta_2}$ ; on prend le minimum | Comme DQN, mais deux reseaux reduisent la surestimation |\n",
     "| **Target networks** | Copies lentes des Q-networks pour stabiliser l'apprentissage | Identique au target network de DQN |\n",
     "| **Temperature alpha** | Parametre apprenable qui controle le poids de l'entropie | Remplace le epsilon de epsilon-greedy |"
-   ]
+   ],
+   "id": "cell-fbed0978"
   },
   {
    "cell_type": "markdown",
@@ -246,7 +254,8 @@
     "### 3.1 Replay Buffer\n",
     "\n",
     "SAC est off-policy : il stocke les transitions $(s, a, r, s', done)$ dans un buffer et echantillonne des mini-lots pour l'apprentissage. Cela permet de reutiliser chaque experience plusieurs fois."
-   ]
+   ],
+   "id": "cell-8221d887"
   },
   {
    "cell_type": "code",
@@ -319,7 +328,8 @@
     "Le **log_prob** est corrige pour tenir compte du changement de variable :\n",
     "\n",
     "$$\\log \\pi(a|s) = \\log \\mu_{\\mathcal{N}}(u) - \\sum_{i=1}^{D} \\log(1 - \\tanh^2(u_i))$$"
-   ]
+   ],
+   "id": "cell-fb3b5f1c"
   },
   {
    "cell_type": "code",
@@ -345,7 +355,8 @@
    "metadata": {},
    "source": [
     "Le **reparameterization trick** (`rsample`) est essentiel : il permet aux gradients de circuler a travers l'echantillonnage stochastique, ce qui rend possible l'optimisation de la politique par descente de gradient."
-   ]
+   ],
+   "id": "cell-f7ab7d2a"
   },
   {
    "cell_type": "markdown",
@@ -354,7 +365,8 @@
     "### 3.3 Twin Q-Networks (Critic)\n",
     "\n",
     "SAC utilise **deux Q-networks** et prend le minimum de leurs estimations pour reduire la surestimation de la valeur Q. C'est le meme principe que TD3 (Twin Delayed DDPG). Chaque Q-network est un MLP simple."
-   ]
+   ],
+   "id": "cell-559b4f34"
   },
   {
    "cell_type": "code",
@@ -418,7 +430,8 @@
    "metadata": {},
    "source": [
     "L'entree du Q-network est la concatenation $[s, a]$ de l'etat et de l'action. Les deux reseaux Q1 et Q2 ont la meme architecture mais des poids independants. Lors de l'apprentissage, on utilise $\\min(Q_1, Q_2)$ comme cible pour la mise a jour du critic."
-   ]
+   ],
+   "id": "cell-b735d478"
   },
   {
    "cell_type": "markdown",
@@ -449,7 +462,8 @@
     "$$L_\\alpha = \\mathbb{E}_{a \\sim \\pi}\\left[-\\alpha (\\log \\pi(a|s) + \\bar{H})\\right]$$\n",
     "\n",
     "avec $\\bar{H} = -\\dim(\\mathcal{A})$ comme heuristique standard (entropie cible = dimension de l'espace d'actions avec un signe negatif)."
-   ]
+   ],
+   "id": "cell-0926a70f"
   },
   {
    "cell_type": "code",
@@ -593,14 +607,16 @@
     "| **Reparameterization** | `rsample()` permet les gradients a travers l'echantillonnage |\n",
     "| **Auto-alpha** | `log_alpha` est un parametre apprenable, `alpha = exp(log_alpha)` reste positif |\n",
     "| **Tanh squashing** | Les actions sont projetees dans $[-1, 1]$ puis mises a l'echelle de l'environnement |"
-   ]
+   ],
+   "id": "cell-56ecf37f"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 5. Entrainement sur Pendulum-v1"
-   ]
+   ],
+   "id": "cell-b0485c05"
   },
   {
    "cell_type": "markdown",
@@ -613,7 +629,8 @@
     "4. Repeter\n",
     "\n",
     "Nous entrainons pendant 200 episodes (rappel : scafold court, CPU-only)."
-   ]
+   ],
+   "id": "cell-ea0826c6"
   },
   {
    "cell_type": "code",
@@ -752,7 +769,8 @@
    "metadata": {},
    "source": [
     "### Interpretation : courbe d'apprentissage SAC"
-   ]
+   ],
+   "id": "cell-14b0fce8"
   },
   {
    "cell_type": "code",
@@ -821,14 +839,16 @@
     "1. SAC est **off-policy** : il reutilise les experiences passees, donc il apprend plus vite qu'A2C ou PPO\n",
     "2. La temperature alpha decroit naturellement au fil de l'entrainement (moins besoin d'explorer)\n",
     "3. Pendulum-v1 est un probleme de controle continu : impossible avec DQN pur"
-   ]
+   ],
+   "id": "cell-114ab189"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 6. Exercices"
-   ]
+   ],
+   "id": "cell-96df13bb"
   },
   {
    "cell_type": "markdown",
@@ -849,7 +869,8 @@
     "- # Etape 1 : Modifiez SACAgent pour accepter un alpha fixe (desactivez auto-tuning)\n",
     "- # Etape 2 : Dans train_sac, calculez alpha = alpha_start + (alpha_end - alpha_start) * episode / num_episodes\n",
     "- # Etape 3 : Lancez l'entrainement et comparez la courbe avec auto-tuning"
-   ]
+   ],
+   "id": "cell-e0f85535"
   },
   {
    "cell_type": "code",
@@ -912,7 +933,8 @@
     "- # Etape 1 : Creez un agent SAC avec un seul Q-network (ou ignorez Q2)\n",
     "- # Etape 2 : Entrainez sur Pendulum-v1 avec les memes hyperparametres\n",
     "- # Etape 3 : Superposez les deux courbes de reward (twin vs single)"
-   ]
+   ],
+   "id": "cell-a37b83ed"
   },
   {
    "cell_type": "code",
@@ -974,7 +996,8 @@
     "- # Etape 1 : Creez l'environnement LunarLanderContinuous-v2 (ou Pendulum avec hidden_dim modifie)\n",
     "- # Etape 2 : Initialisez un SACAgent avec les bonnes dimensions\n",
     "- # Etape 3 : Entrainez et observez si la convergence est similaire"
-   ]
+   ],
+   "id": "cell-49873c3f"
   },
   {
    "cell_type": "code",
@@ -1047,7 +1070,8 @@
     "- Actions continues (robotique, controle moteur, trading)\n",
     "- Sample efficiency importante (peu d'interactions avec l'environnement)\n",
     "- Robustesse aux hyperparametres (SAC est tolerante aux mauvais choix de lr)"
-   ]
+   ],
+   "id": "cell-2bb70d23"
   },
   {
    "cell_type": "markdown",
@@ -1093,7 +1117,8 @@
     "- Haarnoja et al. (2018) - *Soft Actor-Critic Algorithms and Applications*\n",
     "- Sutton & Barto, *Reinforcement Learning: An Introduction*, Chapter 13\n",
     "- [Spinning Up - SAC](https://spinningup.openai.com/en/latest/algorithms/sac.html)"
-   ]
+   ],
+   "id": "cell-9de85a75"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## nbformat v4.5 cell-id hygiene — RL/rl_6d_sac_from_scratch (25 cells)

`rl_6d_sac_from_scratch.ipynb` declares `nbformat_minor=5` (v4.5) but had **25/38 cells** missing the required `id` field (the other 13 already carried one). This PR adds the missing ids.

### Anti-regression (content byte-identical, 3-way proof)
1. Content fingerprint (all non-id keys) stable per cell.
2. **json round-trip fidelity asserted BEFORE edit** — `json.dumps(indent=1, ensure_ascii=False)` reproduces the original byte-for-byte (trailing-newline preserved), so the only diff is the new id line + the preceding comma. Diff = **+50/−25** = 25 new id lines + 25 `]`→`],`. No content churn.
3. `nbformat.validate()` PASS (38/38 cells have id).

Repo validator `validate_pr_notebooks.py` → **PASS (12 code cells)**. H.3 sanity: 0 cells with `execution_count=None & no outputs`. Exec-equivalent metadata fix, no re-execution.

### Scope
Disjoint slice — RL family (Python), unclaimed. po-2024 covered Probas/Infer (#6294) + GenAI/FT (#6296); po-2026 covered QC-Cloud (#6254/#6257/#6298); I covered Search (#6292) + IIT (#6293) prior cycles. Same proven register/methodology. See #6292, #6293, #6257, #6285, #6290.

Ids deterministic: `cell-<md5(nbname:idx)[:8]>`, unique within the notebook.
