### PR TITLE
fix(qcpy): nbformat v4.5 cell ids for QC-Py main tranche (6 notebooks, 27 cells)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -52,7 +52,8 @@
    "metadata": {},
    "source": [
     "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
-   ]
+   ],
+   "id": "cell-1e44aed1"
   },
   {
    "cell_type": "markdown",
@@ -67,7 +68,8 @@
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
-   ]
+   ],
+   "id": "cell-d9b8393c"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -881,7 +881,8 @@
     "| Probabilistic Sharpe Ratio | 3.805% |\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 73ac0abcdb02288016da3c9002b23b1f). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-e8345c07"
   },
   {
    "cell_type": "markdown",
@@ -1805,7 +1806,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
    "metadata": {},
    "source": [
     "---\n",
@@ -1824,11 +1824,11 @@
     "**Indices** :\n",
     "- # Indice : Stockez les resultats coarse dans un DataFrame, puis `.nsmallest(3, 'sharpe')` ou `.nlargest(3, 'sharpe')`\n",
     "- # Indice : Pour le niveau fine, creez un nouvel espace de recherche centre sur chaque meilleure config"
-   ]
+   ],
+   "id": "cell-c6b5adf7"
   },
   {
    "cell_type": "code",
-   "id": "",
    "metadata": {},
    "source": [
     "# Exercice 1 : Grid search personnalise (coarse-to-fine)\n",
@@ -1844,7 +1844,8 @@
     "print(\"Exercice a completer\")"
    ],
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-f20948fa"
   },
   {
    "cell_type": "markdown",
@@ -2593,7 +2594,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
    "metadata": {},
    "source": [
     "---\n",
@@ -2611,11 +2611,11 @@
     "**Indices** :\n",
     "- # Indice : Parcourez les resultats de `walk_forward_results` (variable definie ci-dessus)\n",
     "- # Indice : Protegez contre la division par zero avec `max(sharpe_IS, 1e-6)`"
-   ]
+   ],
+   "id": "cell-c271e087"
   },
   {
    "cell_type": "code",
-   "id": "",
    "metadata": {},
    "source": [
     "# Exercice 2 : Ratio d'efficacite Walk-Forward\n",
@@ -2629,7 +2629,8 @@
     "print(\"Exercice a completer\")"
    ],
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-5f4617fc"
   },
   {
    "cell_type": "markdown",
@@ -3051,7 +3052,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
    "metadata": {},
    "source": [
     "---### Exercice 3 : Penalisation de la complexiteLa validation croisee brute favorise parfois les modeles les plus complexes. L'information criterion (AIC/BIC) penalise le nombre de parametres.\n",
@@ -3059,11 +3059,11 @@
     "> *Ancre savante -- Akaike (1974), « A New Look at the Statistical Model Identification », IEEE Transactions on Automatic Control 19(6), 716-723 (AIC : critère d'information pénalisant la complexité pour la sélection de modèles).*\n",
     "\n",
     "**Objectif** : Implementer un score de fitness penalise qui combine la performance Sharpe et un terme de complexite.**Regles** :- Utilisez le resultat du grid search precedent (dictionnaire `results` avec colonnes `sharpe`, `lookback`, `hold`)- Le score penalise = `sharpe - lambda * log(n_params)` ou `n_params = lookback * hold` et `lambda = 0.05`- Affichez les 5 meilleures configurations selon ce score penalise**Indices** :- # Indice : `np.log()` pour le terme de penalisation- # Indice : Triez avec `.sort_values()` sur la colonne du score penalise"
-   ]
+   ],
+   "id": "cell-c07d0b1c"
   },
   {
    "cell_type": "code",
-   "id": "",
    "metadata": {},
    "source": [
     "# Exercice 3 : Penalisation de la complexite\n",
@@ -3078,7 +3078,8 @@
     "print(\"Exercice a completer\")"
    ],
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-e74cb843"
   },
   {
    "cell_type": "markdown",
@@ -4159,7 +4160,8 @@
     "| Probabilistic Sharpe Ratio | 11.349% |\n",
     "\n",
     "*Backtest QC Cloud 2015-2024 (projet 33177683, bt 41a1888d69fbda7bf164a04cd5761c86). Net Profit / Equity finale deduits du CAGR verifie (End = $100,000 x (1+CAGR)^10).*"
-   ]
+   ],
+   "id": "cell-33c62759"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
@@ -1072,7 +1072,8 @@
     "pivote vers l'apprentissage non-supervise (anomalies, representations) -- une\n",
     "autre reponse au « comment extraire du signal du bruit financier ».\n",
     ""
-   ]
+   ],
+   "id": "cell-b885e5a5"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
@@ -727,7 +727,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "",
    "metadata": {},
    "source": [
     "---\n",
@@ -746,11 +745,11 @@
     "**Indices** :\n",
     "- # Indice : `deviation = abs(paper - backtest) / abs(backtest)`\n",
     "- # Indice : Assignez un niveau par metrique puis prenez le max"
-   ]
+   ],
+   "id": "cell-b1789bc4"
   },
   {
    "cell_type": "code",
-   "id": "",
    "metadata": {},
    "source": [
     "# Exercice 3 : Alerte deviation backtest vs paper\n",
@@ -765,7 +764,8 @@
     "print(\"Exercice a completer\")"
    ],
    "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "id": "cell-3b06c9e8"
   },
   {
    "cell_type": "code",
@@ -842,7 +842,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Rapport de slippage estimation\n\nCreez une fonction qui estime le **slippage moyen** a partir d'une liste de trades paper vs prix mid. Le slippage est la difference entre le prix d'execution et le prix mid au moment de l'ordre.\n\n**Indices** :\n- `# Indice` : `slippage = |fill_price - mid_price| / mid_price`\n- `# Etape 1` : Simuler une liste de trades avec prix mid et prix fill\n- `# Etape 2` : Calculer le slippage pour chaque trade\n- `# Etape 3` : Afficher le slippage moyen et la distribution"
-   ]
+   ],
+   "id": "cell-524823e6"
   },
   {
    "cell_type": "code",
@@ -859,7 +860,8 @@
    ],
    "source": [
     "# Exercice 1 : Estimation du slippage\n# TODO etudiant : Calculer le slippage moyen a partir de trades simules\n# Etape 1 : Simuler 20 trades (prix mid + prix fill)\n# Etape 2 : Calculer slippage = |fill - mid| / mid\n# Etape 3 : Afficher slippage moyen en bps\navg_slippage_bps = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Estimation du slippage\")"
-   ]
+   ],
+   "id": "cell-6de74393"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
@@ -184,7 +184,8 @@
    "metadata": {},
    "source": [
     "### Exercice 1 : Calcul du taux de remplissage des ordres\n\nEn paper trading IBKR, certains ordres limites ne sont pas remplis. Calculez le **fill rate** : pourcentage d'ordres soumis qui ont ete reellement executes.\n\n**Indices** :\n- `# Indice` : fill_rate = ordres_executes / ordres_soumis * 100\n- `# Etape 1` : Simuler une liste d'ordres avec statut (filled/pending/cancelled)\n- `# Etape 2` : Compter les ordres filled\n- `# Etape 3` : Calculer et afficher le fill rate"
-   ]
+   ],
+   "id": "cell-bbb6c4f5"
   },
   {
    "cell_type": "code",
@@ -201,7 +202,8 @@
    ],
    "source": [
     "# Exercice 1 : Taux de remplissage des ordres\n# TODO etudiant : Calculer le fill rate a partir d'ordres simules\n# Etape 1 : Simuler 50 ordres avec statuts aleatoires\n# Etape 2 : Compter les ordres filled\n# Etape 3 : fill_rate = filled / total * 100\nfill_rate = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Taux de remplissage des ordres\")"
-   ]
+   ],
+   "id": "cell-4534527c"
   },
   {
    "cell_type": "markdown",
@@ -483,7 +485,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Estimation des couts de transaction IBKR\n\nEstimez les **couts de transaction mensuels** pour une strategie SP500 momentum avec IBKR : frais de commission ($0.005/action), frais SEC, et slippage estime.\n\n**Indices** :\n- `# Indice` : IBKR commission = $0.005 par action, minimum $1.00\n- `# Indice` : Estimez 4 trades par semaine, 100 actions par trade\n- `# Etape 1` : Calculer le cout par trade (commission + SEC fee)\n- `# Etape 2` : Multiplier par le nombre de trades mensuel\n- `# Etape 3` : Ajouter le slippage estime (5 bps par trade)"
-   ]
+   ],
+   "id": "cell-92173279"
   },
   {
    "cell_type": "code",
@@ -500,7 +503,8 @@
    ],
    "source": [
     "# Exercice 2 : Couts de transaction IBKR\n# TODO etudiant : Estimer les couts mensuels de transaction\n# Etape 1 : Cout par trade = max($1.00, 100 * $0.005) + SEC fee\n# Etape 2 : Trades/mois = 4/semaine * 4 semaines = 16\n# Etape 3 : Ajouter slippage 5 bps * valeur_trade * nb_trades\nmonthly_costs = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Couts de transaction IBKR\")"
-   ]
+   ],
+   "id": "cell-97108a87"
   },
   {
    "cell_type": "markdown",
@@ -794,7 +798,8 @@
    "metadata": {},
    "source": [
     "### Exercice 3 : Checklist de validation paper-to-live\n\nCreez une **checklist de validation** avant de passer du paper trading au live trading avec IBKR. Chaque item doit avoir un seuil quantitatif.\n\n**Indices** :\n- `# Indice` : Inspirez-vous de la checklist du notebook QC-Py-27\n- `# Etape 1` : Lister les metriques cles (Sharpe, Drawdown, Fill Rate, Slippage)\n- `# Etape 2` : Definir un seuil pour chaque metrique\n- `# Etape 3` : Creer un DataFrame avec les items et les seuils"
-   ]
+   ],
+   "id": "cell-f95b38df"
   },
   {
    "cell_type": "code",
@@ -811,7 +816,8 @@
    ],
    "source": [
     "# Exercice 3 : Checklist paper-to-live IBKR\n# TODO etudiant : Creer une checklist de validation avec seuils quantitatifs\n# Etape 1 : Lister les metriques cles (Sharpe, MaxDD, FillRate, Slippage)\n# Etape 2 : Definir des seuils (Sharpe>1, MaxDD<15%, FillRate>90%, Slippage<10bps)\n# Etape 3 : Creer un DataFrame checklist\nchecklist = None  # TODO etudiant : remplacer par le DataFrame\nprint(\"Exercice a completer : Checklist paper-to-live IBKR\")"
-   ]
+   ],
+   "id": "cell-841e3f06"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
@@ -262,7 +262,8 @@
    "metadata": {},
    "source": [
     "### Exercice 1 : Calculer les returns et statistiques de base\n\nChargez les donnees SPY et calculez les **returns journaliers**, la **moyenne**, l'**ecart-type** et le **Sharpe Ratio** annuelise.\n\n**Indices** :\n- `# Indice` : `returns = df['Close'].pct_change()`\n- `# Indice` : Sharpe annualise = `mean(returns) / std(returns) * sqrt(252)`\n- `# Etape 1` : Charger le CSV et calculer les returns\n- `# Etape 2` : Calculer mean et std des returns\n- `# Etape 3` : Calculer le Sharpe Ratio annualise"
-   ]
+   ],
+   "id": "cell-87e25f44"
   },
   {
    "cell_type": "code",
@@ -279,7 +280,8 @@
    ],
    "source": [
     "# Exercice 1 : Returns et Sharpe Ratio de SPY\n# TODO etudiant : Calculer returns journaliers et Sharpe Ratio annualise\n# Etape 1 : returns = spy['Close'].pct_change()\n# Etape 2 : mean_ret = returns.mean(), std_ret = returns.std()\n# Etape 3 : sharpe = mean_ret / std_ret * np.sqrt(252)\nsharpe_spy = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Returns et Sharpe Ratio de SPY\")"
-   ]
+   ],
+   "id": "cell-16b5096d"
   },
   {
    "cell_type": "code",
@@ -510,7 +512,8 @@
    "metadata": {},
    "source": [
     "### Exercice 2 : Calculer la correlation BTC vs SPY\n\nCalculez la **correlation rolling 30 jours** entre les returns de BTC et SPY. Une correlation elevee reduit l'interet de la diversification.\n\n**Indices** :\n- `# Indice` : Mergez les deux DataFrames sur la date, puis calculez `returns.rolling(30).corr()`\n- `# Etape 1` : Calculer les returns pour SPY et BTC\n- `# Etape 2` : Merger les returns sur la colonne date\n- `# Etape 3` : Calculer la correlation rolling 30j"
-   ]
+   ],
+   "id": "cell-9c53cd52"
   },
   {
    "cell_type": "code",
@@ -527,7 +530,8 @@
    ],
    "source": [
     "# Exercice 2 : Correlation BTC vs SPY\n# TODO etudiant : Calculer la correlation rolling 30 jours entre BTC et SPY\n# Etape 1 : Returns SPY et BTC\n# Etape 2 : Merger sur la date\n# Etape 3 : Correlation rolling 30j\ncorr_rolling = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Correlation BTC vs SPY\")"
-   ]
+   ],
+   "id": "cell-bdadbfe7"
   },
   {
    "cell_type": "code",
@@ -789,7 +793,8 @@
    "metadata": {},
    "source": [
     "### Exercice 3 : Ajouter ETH a l'archive et calculer la beta\n\nTelechargez les donnees **ETH** et ajoutez-les a l'archive crypto. Calculez ensuite la **beta de BTC par rapport a ETH** (sensibilite du prix BTC aux mouvements d'ETH).\n\n**Indices** :\n- `# Indice` : Beta = covariance(BTC, ETH) / variance(ETH)\n- `# Indice` : Utilisez `np.cov()` ou `.cov()` de pandas\n- `# Etape 1` : Telecharger ETH avec le script manage_crypto_archive.py\n- `# Etape 2` : Calculer les returns de BTC et ETH\n- `# Etape 3` : Calculer beta = cov(BTC,ETH) / var(ETH)"
-   ]
+   ],
+   "id": "cell-3a5f1ab1"
   },
   {
    "cell_type": "code",
@@ -806,7 +811,8 @@
    ],
    "source": [
     "# Exercice 3 : Beta de BTC par rapport a ETH\n# TODO etudiant : Telecharger ETH et calculer la beta BTC/ETH\n# Etape 1 : Telecharger les donnees ETH\n# Etape 2 : Calculer les returns BTC et ETH\n# Etape 3 : Beta = cov(btc_ret, eth_ret) / var(eth_ret)\nbeta_btc_eth = None  # TODO etudiant : remplacer par le calcul\nprint(\"Exercice a completer : Beta de BTC par rapport a ETH\")"
-   ]
+   ],
+   "id": "cell-6b9fef92"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## nbformat v4.5 cell-id hygiene — QuantConnect/Python main-series (27 cells)

6 notebooks in `MyIA.AI.Notebooks/QuantConnect/Python/` declare `nbformat_minor=5` (v4.5) but had **27 cells** with invalid cell-id status (missing key OR empty string, both invalid in nbformat v4.5):

| Notebook | Cells | missing id | empty id "" |
|----------|-------|-----------:|-------------:|
| QC-Py-11-Technical-Indicators | 49 | 2 | 0 |
| QC-Py-15-Parameter-Optimization | 78 | 2 | 6 |
| QC-Py-23b-PatchTST-iTransformer | 28 | 1 | 0 |
| QC-Py-40-PaperTrading-Binance | 23 | 2 | 2 |
| QC-Py-41-PaperTrading-IBKR | 28 | 6 | 0 |
| QC-Py-Dataset-Workflow | 23 | 6 | 0 |

Empty-string `"id": ""` is invalid in nbformat v4.5 (id must be non-empty + unique). This was missed by the previous scan which only counted `'id' not in c`; the v2 script counts BOTH missing-key AND empty-string as needing a fix (catches 8 extra cells: QC-Py-15 +6, QC-Py-40 +2).

### Anti-regression (content byte-identical, 3-way proof)
1. Content fingerprint (all non-id keys) stable per cell.
2. **json round-trip fidelity asserted BEFORE edit** — `json.dumps(indent=1, ensure_ascii=False)` reproduces the original byte-for-byte (trailing-newline preserved). Only diff = new id lines + preceding comma + removal of empty `"id": ""` lines. **Diff = +54/-35**.
3. `nbformat.validate()` PASS on all 6 notebooks.

Repo validator `validate_pr_notebooks.py` → **6/6 PASS (101 code cells)**. H.3 clean: 0 cells with `execution_count=None & no outputs`. Structural metadata fix only, no re-execution needed.

### Scope (disjoint slice)

QC-Py main-series tranche not covered by prior nbformat work:
- #6285 covered QC-Py-02/03/09
- #6290 covered QC-Py-30/31/32 (ML-Training)
- #6298 covered QC-Py-Cloud-08/09

This PR completes the QC-Py main-series sweep. See #3973 umbrella + #3974 milestone.

Ids deterministic: `cell-<md5(nbname:idx)[:8]>`, unique within notebook.

### Proven register

Same methodology as #6292 (Search 109 cells), #6293 (IIT 7 cells), #6294 (Probas/Infer 6 cells), #6296 (GenAI/FT 25 cells), #6298 (QC-Cloud 25 cells), #6301 (RL 25 cells). Family rotation: Search → IIT → Probas → GenAI-FT → QC-Cloud → RL → **QC-Py main**.

Refs #3973 (umbrella), See #3974 (milestone tranche)