### PR TITLE
enrich(rl): interpretation cells for rl_4 multi-armed bandits comparison section

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb
@@ -1236,6 +1236,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f06ef340",
+   "metadata": {},
+   "source": [
+    "### Lecture des resultats : que regarder ?\n",
+    "\n",
+    "L'evaluation ci-dessus a lance chaque strategie sur **50 graines aleatoires** independantes (pour lisser la variance inherente a un tirage Bernoulli). Les variables `mean_rewards` et `mean_regret` contiennent desormais les trajectoires moyennes. Les trois sorties suivantes se lisent ensemble :\n",
+    "\n",
+    "- **Figure 1 (gauche)** trace la recompense cumulee moyenne : une bonne strategie se rapproche de la droite \"Optimal\". **Figure 1 (droite)** trace le regret cumule, grandeur la plus discriminante car elle soustrait l'effet du hasard. Une pente **lineaire** signale une strategie qui n'apprend pas (Random) ; une pente **sous-lineaire** qui s'aplatit signale une strategie qui converge.\n",
+    "- **Figure 2** mesure un signal plus fin : la frequence a laquelle chaque agent tire le *meilleur* bras. C'est le diagnostic de convergence — une strategie peut afficher un regret correct tout en selectionnant le meilleur bras trop tard.\n",
+    "- Le **tableau recapitulatif** quantifie le regret final et le rattache a son **type asymptotique** (lineaire, sous-lineaire borne, $O(\\log T)$).\n",
+    "\n",
+    "> **Astuce de lecture** : comparez d'abord les *pentes* du regret (Figure 1 droite) avant les valeurs finales du tableau — le type de croissance en dit plus sur la strategie qu'un seul nombre isole.\n",
+    ""
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
    "id": "77729da1",
@@ -1418,6 +1435,19 @@
     "    print(f\"| {name:<15} | {final_regret:>9.1f}   | {pct_optimal:>7.1f}%   | {regret_types[name]:<21} |\")\n",
     "\n",
     "print(\"+-----------------+-------------+-------------+-----------------------+\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33756095",
+   "metadata": {},
+   "source": [
+    "### Un paradoxe apparent : Greedy bat UCB ?\n",
+    "\n",
+    "Le benchmark ci-dessus laisse une impression etrange : **Greedy gagne** (regret final le plus bas), tandis qu'UCB — repute asymptotiquement optimal — finit en mauvaise position. Faut-il en conclure que la theorie d'UCB est vide ? **Non** : ce resultat s'explique par le `n_warmup=10` genereux de notre Greedy, qui beneficie de 100 tirages d'initialisation gratuits pour identifier le meilleur bras avant meme de commencer a exploiter.\n",
+    "\n",
+    "La cellule suivante mene le test decisif : on relance la comparaison sur **plusieurs horizons** $T$ (de 1 000 a 30 000 pas) en reduisant cet avantage (warmup=1). C'est la que la *robustesse* d'UCB — exploration principée sans phase d'initialisation — doit apparaitre, et ou le Greedy trop confiant peut s'effondrer en se bloquant sur un bras sous-optimal.\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Summary

`rl_4_multi_armed_bandits` §5 "Comparaison et analyse" enchaînait **5 cellules code consécutives** (run multi-seeds → Figure 1 → Figure 2 → tableau → sweep Prong-B) sans markdown reliant le calcul aux visualisations. Le lecteur passait de *"Evaluation sur 50 seeds terminee"* directement à deux figures + un tableau, puis à un sweep dont le motif n'était annoncé nulle part.

## Changes (+30 / −0, markdown-only)

Deux cellules d'interprétation françaises (ASCII accent-free, conformes au style du notebook) :

1. **`### Lecture des resultats : que regarder ?`** — après le run (cell 28→29). Explique le protocole 50-seeds (`mean_rewards`/`mean_regret`), ce que chaque sortie révèle (pente linéaire = n'apprend pas, sous-linéaire = converge ; diagnostic de convergence du meilleur bras ; type asymptotique du regret). Se termine par une astuce de lecture (comparer les *pentes* avant les valeurs finales).

2. **`### Un paradoxe apparent : Greedy bat UCB ?`** — avant le sweep (cell 32→33). Pose le paradoxe (Greedy gagne à T=2000 alors qu'UCB est réputé optimal), l'explique (artefact du `n_warmup=10`), et motive le test de robustesse qui suit (warmup réduit, multi-horizons). Prépare la lecture de la cellule d'interprétation existante sur la robustesse Greedy vs UCB.

## Anti-regression proof

- **Diff purement additif** : `+30 insertions, 0 deletions`. Aucune cellule existante modifiée.
- **21 cellules code inchangées** : `execution_count` 1→21 intactes, **outputs préservés** (21/21).
- **Dispense re-exec (C.2 exception)** : ajout markdown uniquement → outputs précédents valides.
- `nbformat.validate()` **PASS** (nbformat 4.5).
- Repo validator `validate_pr_notebooks.py` **21/21 PASS**, 0 violation H.3.
- C.1 OK (pas de code ajouté, pas de stub).

## Why this is substance (not nbformat/doc à-côté)

Rotation R6 off the nbformat register (7 cycles consécutifs Search/IIT/Probas/GenAI-FT/QC-Cloud/RL/QC-Py). Enrichissement = « série notebook » (plat principal R6), pas nettoyage structural. Famille RL = variété (non touchée précédemment). Markdown-only = exécutable CPU sans re-exec, pas vision-dépendant.

## Test plan

- [x] `nbformat.validate()` PASS
- [x] Repo validator 21/21 PASS
- [x] Diff purement additif (+30/−0)
- [x] Code cells outputs + exec_count préservés
- [ ] Relecture pédagogique ai-01 (les 2 cellules lisent-elles correctement avant les figures ?)

See related pedagogy convention: notebook-conventions (interprétation APRES la cellule de code interprétée — respecté : MD-A précède les figures qu'elle décrit, MD-B précède le sweep qu'elle cadre).