### PR TITLE
docs(lean,#4980): SchemesTour FR mirror block (inline i18n, grothendieck)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SchemesTour.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SchemesTour.lean
@@ -12,6 +12,35 @@ Mathlib 4 formalizes schemes as `AlgebraicGeometry.Scheme`, extending
 Epic #1646. All `sorry`s eliminated at creation.
 -/
 
+/-
+  `Grothendieck.SchemesTour` — Schémas (Partie 2)
+  =================================================
+
+  Hommage à Alexandre Grothendieck (1928-2014).
+
+  L'idée la plus transformante de Grothendieck : remplacer les variétés
+  par des *schémas* — des espaces annelés en anneaux locaux qui sont
+  localement affines (isomorphes à Spec R pour un anneau commutatif R).
+  Ce cadre unifie l'arithmétique et la géométrie.
+
+  Mathlib 4 formalise les schémas comme `AlgebraicGeometry.Scheme`, qui
+  étend `LocallyRingedSpace` par la condition d'affinité locale.
+
+  Ce module parcourt :
+    - Le type `Scheme` et sa structure de catégorie, avec ses foncteurs
+      d'oubli vers les espaces topologiques et les espaces annelés en
+      anneaux locaux.
+    - La construction Spec, qui associe à chaque anneau commutatif un
+      schéma affine ; Spec est l'adjoint à gauche du foncteur de sections
+      globales Γ.
+    - Les propriétés de base : un isomorphisme de schémas induit un
+      homéomorphisme des espaces sous-jacents.
+    - L'adjonction Spec Γ, cœur de la géométrie algébrique : pour les
+      schémas affines, Spec et Γ sont des équivalences inverses.
+
+  Epic #1646. Tous les `sorry`s éliminés à la création.
+-/
+
 import Mathlib.AlgebraicGeometry.Scheme
 
 namespace Grothendieck


### PR DESCRIPTION
## Scope

Add a **FR mirror comment block** (Option A inline, convention EPIC #4980) to `grothendieck_lean/Grothendieck/SchemesTour.lean`, immediately after the EN header block. Same pattern as merged #6242 (SieveGenerate), #6256 (SieveLattice), #6259 (CategoryTheory).

The module was **EN-only** (Grothendieck tribute Part 2: schemes). The FR block mirrors the tribute + the schemes concept (replace varieties by locally-affine locally-ringed spaces) + the module walkthrough (Scheme type, Spec functor as left adjoint to Γ, Spec-Γ adjunction = heart of algebraic geometry).

## Build-equivalence RIGOROUSLY proven (comment-only change)

Comment-only changes are build-equivalent when the code is byte-identical via nesting-aware comment extraction (cf cluster pattern "Lean Comment-Only Build"). Verified programmatically:

| Check | Result |
|-------|--------|
| Delimiter balance `/-` and `-/` | 8/8 → **9/9** (exactly one balanced block added) |
| FR prose stray `/-` or `-/` literal | **none** (asserted: `fr_block.count('/-')==1`, `count('-/')==1`, inner prose clean) |
| Code-identity (strip comments nesting-aware, non-blank code lines) | **byte-identical** — 17 lines before == 17 after, sha256 `a73a25e0f289f873` identical |
| Diff | **+29 lines, 0 deletions, 1 file** (purely additive comment block) |

This is the rigorous safeguard documented after incidents #6218/#6234/#6242 (FR prose with stray `/-`/`-/` literals unbalanced comment nesting and broke the build). Here the balance + code-identity are proven BEFORE push.

## CI

grothendieck CI runs in `real` sorry-mode (#6223, merged 2026-07-12) — strips comments/docstrings BEFORE counting `\bsorry\b`. FR prose mentions of "sorry" do not affect the count. Local `lake build Grothendieck.SchemesTour` launched in WSL for empirical confirmation.

## See

- #4980 (Lean i18n convention, ratified user 2026-07-04).
- Merged precedent: #6242 (SieveGenerate inline FR), #6256 (SieveLattice), #6259 (CategoryTheory).
- One subject (SchemesTour FR i18n), atomic.