### PR TITLE
fix(search-3): remove !pip install leaking machine path in committed output

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -40,10 +40,10 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-09T22:53:52.348604Z",
-     "iopub.status.busy": "2026-07-09T22:53:52.348455Z",
-     "iopub.status.idle": "2026-07-09T22:53:53.992710Z",
-     "shell.execute_reply": "2026-07-09T22:53:53.992195Z"
+     "iopub.execute_input": "2026-07-12T11:24:32.433609Z",
+     "iopub.status.busy": "2026-07-12T11:24:32.433165Z",
+     "iopub.status.idle": "2026-07-12T11:24:33.159157Z",
+     "shell.execute_reply": "2026-07-12T11:24:33.158623Z"
     },
     "papermill": {
      "duration": 1.656798,
@@ -59,24 +59,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: pandas in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (3.0.3)\n",
-      "Requirement already satisfied: numpy>=1.26.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2.4.4)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2025.3)\n",
-      "Requirement already satisfied: six>=1.5 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Environnement pret pour la recherche informee.\n"
      ]
     }
    ],
    "source": [
     "# Imports\n",
-    "!pip install pandas\n",
     "import sys\n",
     "import time\n",
     "import heapq\n",


### PR DESCRIPTION
## Summary

`Search-3-Informed` cell[1] started with `!pip install pandas`. On any machine where pandas is already installed, this prints `Requirement already satisfied: pandas in C:\Users\jsboi\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.13_...\site-packages` into the committed cell output — a **machine-path leak** in the notebook output (regle [secrets-hygiene](.claude/rules/secrets-hygiene.md) §6).

## Root cause & fix (Stop & Repair, not output-scrubbing)

The leak's *source* is the `!pip install pandas` line itself. Per the triage in [sota-not-workaround](.claude/rules/sota-not-workaround.md) Stop & Repair (and [secrets-hygiene](.claude/rules/secrets-hygiene.md) §6 triage C = source-leak), the honest fix is **correct the cause + re-execute**, not hand-edit the output:

- **Removed** the `!pip install pandas` line. pandas is part of the project env (the cell imports it via `import pandas as pd` two lines below; CoursIA notebooks assume the env is installed — regle F). The `!pip install` was inherited boilerplate, not pedagogically load-bearing.
- **Re-executed** cell[1] via `nbconvert --execute` (python3 kernel, cwd = Part1-Foundations so `sys.path.insert(0,'..')` resolves `search_helpers`). Output is now just `Environnement pret pour la recherche informee.` — no path.

## Anti-regression proof

- **Surgical inject** (method #3115/#3436): only cell[1] touched. Diff = **+4/−16**, not a full-notebook regeneration.
- Source diff = exactly **−1 line** (`!pip install pandas`). No import, no pedagogical code, no other cell's source changed.
- The remaining −11 lines = the removed `Requirement already satisfied: pandas in C:\Users\...` output block (the leak itself). +4 lines = regenerated `iopub`/`execute_reply` metadata timestamps on cell[1] only.
- **24/24 code cells** `execution_count` 1..24, **0 errors**, **0 path-leak remaining** (`grep "C:\Users\jsboi"` = 0).
- C.2 honored: notebook committed WITH outputs. H.3 honored. `nbformat.validate()` PASS.
- Repo validator `validate_pr_notebooks.py` **24/24 PASS**.

## Scope note (C.3)

This is the only cell modified; the re-exec was confined to cell[1] via surgical inject (original notebook + executed cell[1]), so outputs of cells 2–24 are preserved byte-for-byte from main — no collateral output churn.

## Why this PR (R6 variety)

Rotation off the forensic-review genre (c.428 #6304 build-break, c.429 #6284 repo-destroyer) and off the nbformat register. Path-leak fix-and-reexec = substance in my Python turf (CPU-local, no GPU/API/vision needed), a distinct register from nbformat/enrichment/Lean.

## Test plan

- [x] `nbformat.validate()` PASS
- [x] Repo validator 24/24 PASS
- [x] 0 path-leak (`grep C:\Users\jsboi` = 0)
- [x] 24/24 cells exec_count set, 0 errors
- [x] Diff surgical (+4/−16, cell[1] only)
- [ ] Relecture ai-01 (le retrait du `!pip install` est-il OK pédagogiquement ? — oui, pandas est importé juste après, l'env est pré-supposé regle F)