### PR TITLE
fix(csp-1): remove redundant !pip install leaking machine path in output

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -2190,8 +2190,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Defaulting to user installation because normal site-packages is not writeable\n",
-      "Requirement already satisfied: python-constraint in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (1.4.0)\n",
       "python-constraint importe avec succes.\n"
      ]
     }
@@ -2199,7 +2197,6 @@
    "source": [
     "# Installation si necessaire\n",
     "import sys\n",
-    "!{sys.executable} -m pip install python-constraint\n",
     "try:\n",
     "    from constraint import Problem, AllDifferentConstraint\n",
     "    print(\"python-constraint importe avec succes.\")\n",
@@ -2447,22 +2444,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Defaulting to user installation because normal site-packages is not writeable\n",
-      "Requirement already satisfied: matplotlib in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (3.10.8)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (1.3.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (0.12.1)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (4.62.1)\n",
-      "Requirement already satisfied: kiwisolver>=1.3.1 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (1.5.0)\n",
-      "Requirement already satisfied: numpy>=1.23 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (2.4.4)\n",
-      "Requirement already satisfied: packaging>=20.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (26.0)\n",
-      "Requirement already satisfied: pillow>=8 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (12.2.0)\n",
-      "Requirement already satisfied: pyparsing>=3 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (3.3.2)\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from matplotlib) (2.9.0.post0)\n",
-      "Requirement already satisfied: six>=1.5 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from python-dateutil>=2.7->matplotlib) (1.17.0)\n",
       "Probleme des 4-Reines (python-constraint)\n",
       "=============================================\n",
       "Nombre de solutions : 2\n",
-      "Temps               : 1.17 ms\n",
+      "Temps               : 0.77 ms\n",
       "\n",
       "Solutions :\n",
       "  Solution 1 : lignes = [2, 0, 3, 1]\n",
@@ -2481,7 +2466,6 @@
     }
    ],
    "source": [
-    "!{sys.executable} -m pip install matplotlib\n",
     "import matplotlib.pyplot as plt\n",
     "# 4-Reines avec python-constraint\n",
     "n = 4\n",


### PR DESCRIPTION
## Summary

`CSP-1-Fundamentals` cell[50] and cell[57] each began with an unconditional `!{sys.executable} -m pip install <pkg>`. On any machine where the package is already installed, this prints `Defaulting to user installation because normal site-packages is not writeable / Requirement already satisfied: <pkg> in C:\Users\jsboi\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.13_...\site-packages` into the committed cell output — a **machine-path leak** (regle [secrets-hygiene](.claude/rules/secrets-hygiene.md) §6).

Cell[57] was the worse offender: matplotlib's `!pip install` transitively printed ~14 `Requirement already satisfied` lines (matplotlib + contourpy + cycler + fonttools + kiwisolver + numpy + packaging + pillow + pyparsing + python-dateutil + six), each carrying the machine path.

## Root cause & fix (Stop & Repair, triage C = source-leak)

The leak's *source* is the `!pip install` line itself. Per [sota-not-workaround](.claude/rules/sota-not-workaround.md) Stop & Repair + [secrets-hygiene](.claude/rules/secrets-hygiene.md) §6, the honest fix is **correct the cause + re-execute**, not hand-edit the output.

- **cell[50]** (`python-constraint`): removed the leading `!pip install`. The cell **already** had a robust `try/except ImportError → subprocess.check_call(install)` fallback, so the unconditional `!pip install` was **redundant** AND leaky. With it gone, the install is now **truly conditional** (only triggers if the import fails) — strictly better than before. Output → `python-constraint importe avec succes.`
- **cell[57]** (`matplotlib`): removed the leading `!pip install`. matplotlib is part of the project env (imported two lines below; regle F). Output → the 4-Reines solutions table (clean).

`python-constraint` (1.4.0) and `matplotlib` (3.10.8) verified present in the env before removing the installs.

## Anti-regression + surgical proof

- **Surgical inject** (method #3115/#3436): only cells 50 and 57 touched. Full notebook re-executed in order (so kernel state for cell[57]'s `Problem()` is correct), then ONLY cells 50/57's source+outputs+exec_count injected into the original — every other cell byte-identical to main.
- Diff = **+2/−18**: −2 source lines (the two `!pip install`), −16 leaked output lines, +2 clean output lines.
- **0 path-leak remaining** across all 75 cells (`grep` for `C:\Users`, `AppData\Local\Temp`, `site-packages is not writeable` = 0).
- 29/29 code cells `execution_count` set, 0 errors. C.2 honored (committed WITH outputs). H.3 honored. `nbformat.validate()` PASS.
- Repo validator `validate_pr_notebooks.py` **29/29 PASS**.

## Why this PR (R6 variety)

Same `!pip install` source-leak class as #6310 (Search-3), different sub-series (Search/Part2-CSP vs Part1-Foundations). CPU-local Python, no GPU/API/vision needed. Distinct register from the forensic-review cycles (c.428-429) and nbformat work.

## Test plan

- [x] `nbformat.validate()` PASS
- [x] Repo validator 29/29 PASS
- [x] 0 path-leak (full-notebook scan)
- [x] 29/29 code cells exec_count set, 0 errors
- [x] Diff surgical (+2/−18, cells 50 & 57 only)
- [ ] Relecture ai-01 (le retrait du `!pip install` redondant en cell[50] est-il OK ? — oui, le try/except conditionnel subsiste, l'install devient strictement conditionnelle au lieu d'inconditionnelle)