### PR TITLE
Fix: remove !pip install source leaks in Search-10 (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
@@ -5,10 +5,10 @@
    "id": "51a1e954",
    "metadata": {
     "papermill": {
-     "duration": 0.010215,
-     "end_time": "2026-06-05T12:55:14.877350+00:00",
+     "duration": 0.018663,
+     "end_time": "2026-07-12T12:08:57.540117+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:14.867135+00:00",
+     "start_time": "2026-07-12T12:08:57.521454+00:00",
      "status": "completed"
     },
     "tags": []
@@ -40,10 +40,10 @@
    "id": "f88df984",
    "metadata": {
     "papermill": {
-     "duration": 0.008435,
-     "end_time": "2026-06-05T12:55:14.894794+00:00",
+     "duration": 0.019515,
+     "end_time": "2026-07-12T12:08:57.578596+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:14.886359+00:00",
+     "start_time": "2026-07-12T12:08:57.559081+00:00",
      "status": "completed"
     },
     "tags": []
@@ -78,7 +78,9 @@
     "> **Theoreme de Kleene** : Tout langage reconnu par un automate fini est regulier et reciproquement.\n",
     "\n",
     "> **Theoreme de Rabin-Scott** : NFA et DFA reconnaissent les memes langages (NFA peut etre converti en DFA).\n",
-    "\n\n> *Ancres savantes -- Kleene, S.C. (1956), Representation of Events in Nerve Nets and Finite Automata, in C.E. Shannon & J. McCarthy (eds.), Automata Studies, Annals of Mathematics Studies 34, Princeton University Press:3-42 (theoreme de Kleene : equivalence entre langages reconnus par automates finis et expressions regulieres, deja nomme ci-dessus) ; Rabin, M.O. & Scott, D. (1959), Finite Automata and Their Decision Problems, IBM Journal of Research and Development 3(2):114-125 (theoreme de Rabin-Scott : equivalence NFA/DFA, conversion non-deterministe vers deterministe — prix Turing 1976, deja nomme ci-dessus) ; Hopcroft, J.E., Motwani, R. & Ullman, J.D. (2007), Introduction to Automata Theory, Languages, and Computation (3rd ed.), Pearson (manuel de reference sur les automates finis, operations de fermeture et minimisation) ; D'Antoni, L. & Veanes, M. (2017), The Power of Symbolic Automata and Transducers, Theoretical Computer Science 719:199-211 (automates symboliques : transition etiquetee par un predicat sur un alphabet potentiellement infini, fondement theorique de l'extension avec Z3 presentee sections 3-4) ; de Moura, L. & Bjorner, N. (2008), Z3: An Efficient SMT Solver, TACAS 2008, LNCS 4963:337-340 (solveur SMT utilise comme moteur de decision des transitions symboliques).*"
+    "\n",
+    "\n",
+    "> *Ancres savantes -- Kleene, S.C. (1956), Representation of Events in Nerve Nets and Finite Automata, in C.E. Shannon & J. McCarthy (eds.), Automata Studies, Annals of Mathematics Studies 34, Princeton University Press:3-42 (theoreme de Kleene : equivalence entre langages reconnus par automates finis et expressions regulieres, deja nomme ci-dessus) ; Rabin, M.O. & Scott, D. (1959), Finite Automata and Their Decision Problems, IBM Journal of Research and Development 3(2):114-125 (theoreme de Rabin-Scott : equivalence NFA/DFA, conversion non-deterministe vers deterministe — prix Turing 1976, deja nomme ci-dessus) ; Hopcroft, J.E., Motwani, R. & Ullman, J.D. (2007), Introduction to Automata Theory, Languages, and Computation (3rd ed.), Pearson (manuel de reference sur les automates finis, operations de fermeture et minimisation) ; D'Antoni, L. & Veanes, M. (2017), The Power of Symbolic Automata and Transducers, Theoretical Computer Science 719:199-211 (automates symboliques : transition etiquetee par un predicat sur un alphabet potentiellement infini, fondement theorique de l'extension avec Z3 presentee sections 3-4) ; de Moura, L. & Bjorner, N. (2008), Z3: An Efficient SMT Solver, TACAS 2008, LNCS 4963:337-340 (solveur SMT utilise comme moteur de decision des transitions symboliques).*"
    ]
   },
   {
@@ -86,10 +88,10 @@
    "id": "df704312",
    "metadata": {
     "papermill": {
-     "duration": 0.00857,
-     "end_time": "2026-06-05T12:55:14.911973+00:00",
+     "duration": 0.021027,
+     "end_time": "2026-07-12T12:08:57.621009+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:14.903403+00:00",
+     "start_time": "2026-07-12T12:08:57.599982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -121,10 +123,10 @@
    "id": "a11db33a",
    "metadata": {
     "papermill": {
-     "duration": 0.008736,
-     "end_time": "2026-06-05T12:55:14.929531+00:00",
+     "duration": 0.017713,
+     "end_time": "2026-07-12T12:08:57.658633+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:14.920795+00:00",
+     "start_time": "2026-07-12T12:08:57.640920+00:00",
      "status": "completed"
     },
     "tags": []
@@ -152,10 +154,10 @@
    "id": "0c27f2eb",
    "metadata": {
     "papermill": {
-     "duration": 0.008519,
-     "end_time": "2026-06-05T12:55:14.947015+00:00",
+     "duration": 0.013747,
+     "end_time": "2026-07-12T12:08:57.686994+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:14.938496+00:00",
+     "start_time": "2026-07-12T12:08:57.673247+00:00",
      "status": "completed"
     },
     "tags": []
@@ -174,34 +176,24 @@
    "id": "2cced8bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:14.966557Z",
-     "iopub.status.busy": "2026-06-05T12:55:14.966162Z",
-     "iopub.status.idle": "2026-06-05T12:55:17.981887Z",
-     "shell.execute_reply": "2026-06-05T12:55:17.980884Z"
+     "iopub.execute_input": "2026-07-12T12:08:57.720406Z",
+     "iopub.status.busy": "2026-07-12T12:08:57.719831Z",
+     "iopub.status.idle": "2026-07-12T12:08:57.727319Z",
+     "shell.execute_reply": "2026-07-12T12:08:57.725736Z"
     },
     "papermill": {
-     "duration": 3.027134,
-     "end_time": "2026-06-05T12:55:17.982700+00:00",
+     "duration": 0.027113,
+     "end_time": "2026-07-12T12:08:57.728769+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:14.955566+00:00",
+     "start_time": "2026-07-12T12:08:57.701656+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Installation de automata-lib\n",
-    "!pip install -q \"automata-lib>=9.2.0\""
+    "# automata-lib (>= 9.2.0) : moteur d'automates (DFA/NFA).\n",
+    "# Dependence declaree dans requirements.txt ; import en cellule suivante."
    ]
   },
   {
@@ -209,10 +201,10 @@
    "id": "af7c2764",
    "metadata": {
     "papermill": {
-     "duration": 0.007957,
-     "end_time": "2026-06-05T12:55:17.999276+00:00",
+     "duration": 0.013871,
+     "end_time": "2026-07-12T12:08:57.756152+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:17.991319+00:00",
+     "start_time": "2026-07-12T12:08:57.742281+00:00",
      "status": "completed"
     },
     "tags": []
@@ -227,16 +219,16 @@
    "id": "e672a56d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:18.015845Z",
-     "iopub.status.busy": "2026-06-05T12:55:18.015621Z",
-     "iopub.status.idle": "2026-06-05T12:55:18.492008Z",
-     "shell.execute_reply": "2026-06-05T12:55:18.490915Z"
+     "iopub.execute_input": "2026-07-12T12:08:57.792300Z",
+     "iopub.status.busy": "2026-07-12T12:08:57.791658Z",
+     "iopub.status.idle": "2026-07-12T12:08:58.716965Z",
+     "shell.execute_reply": "2026-07-12T12:08:58.715077Z"
     },
     "papermill": {
-     "duration": 0.485926,
-     "end_time": "2026-06-05T12:55:18.492777+00:00",
+     "duration": 0.947796,
+     "end_time": "2026-07-12T12:08:58.718472+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.006851+00:00",
+     "start_time": "2026-07-12T12:08:57.770676+00:00",
      "status": "completed"
     },
     "tags": []
@@ -270,10 +262,10 @@
    "id": "tnqcmqviqe",
    "metadata": {
     "papermill": {
-     "duration": 0.007887,
-     "end_time": "2026-06-05T12:55:18.508565+00:00",
+     "duration": 0.019467,
+     "end_time": "2026-07-12T12:08:58.758210+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.500678+00:00",
+     "start_time": "2026-07-12T12:08:58.738743+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,10 +279,10 @@
    "id": "d99a4b51",
    "metadata": {
     "papermill": {
-     "duration": 0.013718,
-     "end_time": "2026-06-05T12:55:18.531803+00:00",
+     "duration": 0.019731,
+     "end_time": "2026-07-12T12:08:58.798190+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.518085+00:00",
+     "start_time": "2026-07-12T12:08:58.778459+00:00",
      "status": "completed"
     },
     "tags": []
@@ -307,16 +299,16 @@
    "id": "21805892",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:18.555387Z",
-     "iopub.status.busy": "2026-06-05T12:55:18.554843Z",
-     "iopub.status.idle": "2026-06-05T12:55:18.563694Z",
-     "shell.execute_reply": "2026-06-05T12:55:18.562488Z"
+     "iopub.execute_input": "2026-07-12T12:08:58.840922Z",
+     "iopub.status.busy": "2026-07-12T12:08:58.840056Z",
+     "iopub.status.idle": "2026-07-12T12:08:58.853990Z",
+     "shell.execute_reply": "2026-07-12T12:08:58.852436Z"
     },
     "papermill": {
-     "duration": 0.020389,
-     "end_time": "2026-06-05T12:55:18.564554+00:00",
+     "duration": 0.039107,
+     "end_time": "2026-07-12T12:08:58.855850+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.544165+00:00",
+     "start_time": "2026-07-12T12:08:58.816743+00:00",
      "status": "completed"
     },
     "tags": []
@@ -328,7 +320,7 @@
      "text": [
       "NFA pour reconnaissance de 'ab'\n",
       "\n",
-      "Etats : frozenset({'q2', 'q0', 'q1'})\n",
+      "Etats : frozenset({'q0', 'q1', 'q2'})\n",
       "Alphabet : frozenset({'a', 'b'})\n",
       "Etat initial : q0\n",
       "Etats finaux : frozenset({'q2'})\n",
@@ -384,10 +376,10 @@
    "id": "c3aqsliem1v",
    "metadata": {
     "papermill": {
-     "duration": 0.01007,
-     "end_time": "2026-06-05T12:55:18.584114+00:00",
+     "duration": 0.019373,
+     "end_time": "2026-07-12T12:08:58.895003+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.574044+00:00",
+     "start_time": "2026-07-12T12:08:58.875630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -434,10 +426,10 @@
    "id": "63ae5d03",
    "metadata": {
     "papermill": {
-     "duration": 0.010003,
-     "end_time": "2026-06-05T12:55:18.604111+00:00",
+     "duration": 0.021173,
+     "end_time": "2026-07-12T12:08:58.935338+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.594108+00:00",
+     "start_time": "2026-07-12T12:08:58.914165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -468,10 +460,10 @@
    "id": "d87da83e",
    "metadata": {
     "papermill": {
-     "duration": 0.011236,
-     "end_time": "2026-06-05T12:55:18.628963+00:00",
+     "duration": 0.025333,
+     "end_time": "2026-07-12T12:08:58.984602+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.617727+00:00",
+     "start_time": "2026-07-12T12:08:58.959269+00:00",
      "status": "completed"
     },
     "tags": []
@@ -488,16 +480,16 @@
    "id": "3856ff0a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:18.655325Z",
-     "iopub.status.busy": "2026-06-05T12:55:18.654793Z",
-     "iopub.status.idle": "2026-06-05T12:55:18.662672Z",
-     "shell.execute_reply": "2026-06-05T12:55:18.661395Z"
+     "iopub.execute_input": "2026-07-12T12:08:59.040864Z",
+     "iopub.status.busy": "2026-07-12T12:08:59.040212Z",
+     "iopub.status.idle": "2026-07-12T12:08:59.053983Z",
+     "shell.execute_reply": "2026-07-12T12:08:59.052298Z"
     },
     "papermill": {
-     "duration": 0.025523,
-     "end_time": "2026-06-05T12:55:18.663633+00:00",
+     "duration": 0.049524,
+     "end_time": "2026-07-12T12:08:59.055541+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.638110+00:00",
+     "start_time": "2026-07-12T12:08:59.006017+00:00",
      "status": "completed"
     },
     "tags": []
@@ -565,10 +557,10 @@
    "id": "3ag6zuv5opu",
    "metadata": {
     "papermill": {
-     "duration": 0.00991,
-     "end_time": "2026-06-05T12:55:18.683489+00:00",
+     "duration": 0.022404,
+     "end_time": "2026-07-12T12:08:59.106862+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.673579+00:00",
+     "start_time": "2026-07-12T12:08:59.084458+00:00",
      "status": "completed"
     },
     "tags": []
@@ -616,10 +608,10 @@
    "id": "b66ad5a6",
    "metadata": {
     "papermill": {
-     "duration": 0.011478,
-     "end_time": "2026-06-05T12:55:18.705298+00:00",
+     "duration": 0.020052,
+     "end_time": "2026-07-12T12:08:59.147699+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.693820+00:00",
+     "start_time": "2026-07-12T12:08:59.127647+00:00",
      "status": "completed"
     },
     "tags": []
@@ -651,10 +643,10 @@
    "id": "3173d8e3",
    "metadata": {
     "papermill": {
-     "duration": 0.009692,
-     "end_time": "2026-06-05T12:55:18.724352+00:00",
+     "duration": 0.020118,
+     "end_time": "2026-07-12T12:08:59.186356+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.714660+00:00",
+     "start_time": "2026-07-12T12:08:59.166238+00:00",
      "status": "completed"
     },
     "tags": []
@@ -684,16 +676,16 @@
    "id": "b81de8a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:18.746089Z",
-     "iopub.status.busy": "2026-06-05T12:55:18.745750Z",
-     "iopub.status.idle": "2026-06-05T12:55:18.751427Z",
-     "shell.execute_reply": "2026-06-05T12:55:18.750243Z"
+     "iopub.execute_input": "2026-07-12T12:08:59.228838Z",
+     "iopub.status.busy": "2026-07-12T12:08:59.228133Z",
+     "iopub.status.idle": "2026-07-12T12:08:59.236121Z",
+     "shell.execute_reply": "2026-07-12T12:08:59.234304Z"
     },
     "papermill": {
-     "duration": 0.018081,
-     "end_time": "2026-06-05T12:55:18.752346+00:00",
+     "duration": 0.030856,
+     "end_time": "2026-07-12T12:08:59.237763+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.734265+00:00",
+     "start_time": "2026-07-12T12:08:59.206907+00:00",
      "status": "completed"
     },
     "tags": []
@@ -722,10 +714,10 @@
    "id": "4db13f74",
    "metadata": {
     "papermill": {
-     "duration": 0.009531,
-     "end_time": "2026-06-05T12:55:18.771563+00:00",
+     "duration": 0.019799,
+     "end_time": "2026-07-12T12:08:59.277276+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.762032+00:00",
+     "start_time": "2026-07-12T12:08:59.257477+00:00",
      "status": "completed"
     },
     "tags": []
@@ -742,16 +734,16 @@
    "id": "e21ac97c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-12T04:09:49.938560Z",
-     "iopub.status.busy": "2026-07-12T04:09:49.938402Z",
-     "iopub.status.idle": "2026-07-12T04:09:49.942252Z",
-     "shell.execute_reply": "2026-07-12T04:09:49.941678Z"
+     "iopub.execute_input": "2026-07-12T12:08:59.322283Z",
+     "iopub.status.busy": "2026-07-12T12:08:59.321574Z",
+     "iopub.status.idle": "2026-07-12T12:08:59.331792Z",
+     "shell.execute_reply": "2026-07-12T12:08:59.329888Z"
     },
     "papermill": {
-     "duration": 0.018018,
-     "end_time": "2026-06-05T12:55:18.799171+00:00",
+     "duration": 0.034044,
+     "end_time": "2026-07-12T12:08:59.333476+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.781153+00:00",
+     "start_time": "2026-07-12T12:08:59.299432+00:00",
      "status": "completed"
     },
     "tags": []
@@ -812,10 +804,10 @@
    "id": "peg0m53fxym",
    "metadata": {
     "papermill": {
-     "duration": 0.009501,
-     "end_time": "2026-06-05T12:55:18.818220+00:00",
+     "duration": 0.032865,
+     "end_time": "2026-07-12T12:08:59.386608+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.808719+00:00",
+     "start_time": "2026-07-12T12:08:59.353743+00:00",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +838,10 @@
    "id": "bbbaef30",
    "metadata": {
     "papermill": {
-     "duration": 0.009004,
-     "end_time": "2026-06-05T12:55:18.836369+00:00",
+     "duration": 0.022206,
+     "end_time": "2026-07-12T12:08:59.433190+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.827365+00:00",
+     "start_time": "2026-07-12T12:08:59.410984+00:00",
      "status": "completed"
     },
     "tags": []
@@ -873,10 +865,10 @@
    "id": "99fd2a91",
    "metadata": {
     "papermill": {
-     "duration": 0.008743,
-     "end_time": "2026-06-05T12:55:18.854078+00:00",
+     "duration": 0.02287,
+     "end_time": "2026-07-12T12:08:59.482680+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.845335+00:00",
+     "start_time": "2026-07-12T12:08:59.459810+00:00",
      "status": "completed"
     },
     "tags": []
@@ -893,37 +885,21 @@
    "id": "90882d23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:18.873921Z",
-     "iopub.status.busy": "2026-06-05T12:55:18.873529Z",
-     "iopub.status.idle": "2026-06-05T12:55:22.800701Z",
-     "shell.execute_reply": "2026-06-05T12:55:22.799514Z"
+     "iopub.execute_input": "2026-07-12T12:08:59.525987Z",
+     "iopub.status.busy": "2026-07-12T12:08:59.525289Z",
+     "iopub.status.idle": "2026-07-12T12:09:00.762651Z",
+     "shell.execute_reply": "2026-07-12T12:09:00.761002Z"
     },
     "papermill": {
-     "duration": 3.938385,
-     "end_time": "2026-06-05T12:55:22.801614+00:00",
+     "duration": 1.260195,
+     "end_time": "2026-07-12T12:09:00.763978+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:18.863229+00:00",
+     "start_time": "2026-07-12T12:08:59.503783+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: graphviz in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (0.21)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    },
     {
      "data": {
       "image/svg+xml": [
@@ -956,7 +932,7 @@
        "<polygon fill=\"black\" stroke=\"black\" points=\"25.94,-45.03 35.94,-41.53 25.94,-38.03 25.94,-45.03\"/>\n",
        "</g>\n",
        "<!-- q_even&#45;&gt;q_even -->\n",
-       "<g id=\"edge5\" class=\"edge\">\n",
+       "<g id=\"edge3\" class=\"edge\">\n",
        "<title>q_even&#45;&gt;q_even</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M68.08,-81.88C68.67,-92.78 72.39,-101.07 79.25,-101.07 83.43,-101.07 86.45,-97.99 88.3,-93.12\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"91.72,-93.84 90.14,-83.37 84.85,-92.54 91.72,-93.84\"/>\n",
@@ -969,21 +945,21 @@
        "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"196.74\" y=\"-36.48\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">q_odd</text>\n",
        "</g>\n",
        "<!-- q_even&#45;&gt;q_odd -->\n",
-       "<g id=\"edge4\" class=\"edge\">\n",
+       "<g id=\"edge2\" class=\"edge\">\n",
        "<title>q_even&#45;&gt;q_odd</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M120.97,-41.53C130.77,-41.53 141.29,-41.53 151.25,-41.53\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"151.1,-45.03 161.1,-41.53 151.1,-38.03 151.1,-45.03\"/>\n",
        "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.79\" y=\"-44.73\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">a</text>\n",
        "</g>\n",
        "<!-- q_odd&#45;&gt;q_even -->\n",
-       "<g id=\"edge2\" class=\"edge\">\n",
+       "<g id=\"edge4\" class=\"edge\">\n",
        "<title>q_odd&#45;&gt;q_even</title>\n",
-       "<path fill=\"none\" stroke=\"black\" d=\"M164.95,-28.42C158.41,-26.18 151.46,-24.21 144.79,-23.03 139.47,-22.1 133.96,-22.11 128.51,-22.75\"/>\n",
-       "<polygon fill=\"black\" stroke=\"black\" points=\"128.13,-19.26 118.96,-24.57 129.44,-26.13 128.13,-19.26\"/>\n",
-       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.79\" y=\"-26.23\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">a</text>\n",
+       "<path fill=\"none\" stroke=\"black\" d=\"M165.6,-27.21C158.89,-24.65 151.71,-22.37 144.79,-21.03 139.16,-19.94 133.34,-20.01 127.59,-20.84\"/>\n",
+       "<polygon fill=\"black\" stroke=\"black\" points=\"127.21,-17.34 118.2,-22.92 128.72,-24.17 127.21,-17.34\"/>\n",
+       "<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"141.79\" y=\"-24.23\" font-family=\"Times New Roman,serif\" font-size=\"14.00\">a</text>\n",
        "</g>\n",
        "<!-- q_odd&#45;&gt;q_odd -->\n",
-       "<g id=\"edge3\" class=\"edge\">\n",
+       "<g id=\"edge5\" class=\"edge\">\n",
        "<title>q_odd&#45;&gt;q_odd</title>\n",
        "<path fill=\"none\" stroke=\"black\" d=\"M186.43,-74.25C186.49,-84.96 189.92,-93.48 196.74,-93.48 200.89,-93.48 203.79,-90.32 205.43,-85.42\"/>\n",
        "<polygon fill=\"black\" stroke=\"black\" points=\"208.86,-86.15 206.82,-75.75 201.93,-85.15 208.86,-86.15\"/>\n",
@@ -993,7 +969,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x2a22ac9fe00>"
+       "<graphviz.graphs.Digraph at 0x1bfd3f67e00>"
       ]
      },
      "metadata": {},
@@ -1001,7 +977,6 @@
     }
    ],
    "source": [
-    "!pip install graphviz\n",
     "try:\n",
     "    import graphviz\n",
     "    HAS_GRAPHVIZ = True\n",
@@ -1077,10 +1052,10 @@
    "id": "4gohomcq73s",
    "metadata": {
     "papermill": {
-     "duration": 0.009668,
-     "end_time": "2026-06-05T12:55:22.821064+00:00",
+     "duration": 0.014888,
+     "end_time": "2026-07-12T12:09:00.795604+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:22.811396+00:00",
+     "start_time": "2026-07-12T12:09:00.780716+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1117,10 +1092,10 @@
    "id": "df3b6fca",
    "metadata": {
     "papermill": {
-     "duration": 0.011103,
-     "end_time": "2026-06-05T12:55:22.842071+00:00",
+     "duration": 0.018019,
+     "end_time": "2026-07-12T12:09:00.830390+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:22.830968+00:00",
+     "start_time": "2026-07-12T12:09:00.812371+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1154,10 +1129,10 @@
    "id": "987f637d",
    "metadata": {
     "papermill": {
-     "duration": 0.010338,
-     "end_time": "2026-06-05T12:55:22.862917+00:00",
+     "duration": 0.015818,
+     "end_time": "2026-07-12T12:09:00.863130+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:22.852579+00:00",
+     "start_time": "2026-07-12T12:09:00.847312+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1190,10 +1165,10 @@
    "id": "2563c477",
    "metadata": {
     "papermill": {
-     "duration": 0.009941,
-     "end_time": "2026-06-05T12:55:22.882888+00:00",
+     "duration": 0.015007,
+     "end_time": "2026-07-12T12:09:00.892285+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:22.872947+00:00",
+     "start_time": "2026-07-12T12:09:00.877278+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1225,10 +1200,10 @@
    "id": "5d61895d",
    "metadata": {
     "papermill": {
-     "duration": 0.010015,
-     "end_time": "2026-06-05T12:55:22.902480+00:00",
+     "duration": 0.018731,
+     "end_time": "2026-07-12T12:09:00.927330+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:22.892465+00:00",
+     "start_time": "2026-07-12T12:09:00.908599+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1245,35 +1220,23 @@
    "id": "fbbfc1e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:22.923181Z",
-     "iopub.status.busy": "2026-06-05T12:55:22.922710Z",
-     "iopub.status.idle": "2026-06-05T12:55:25.907326Z",
-     "shell.execute_reply": "2026-06-05T12:55:25.906359Z"
+     "iopub.execute_input": "2026-07-12T12:09:00.962627Z",
+     "iopub.status.busy": "2026-07-12T12:09:00.962107Z",
+     "iopub.status.idle": "2026-07-12T12:09:00.967952Z",
+     "shell.execute_reply": "2026-07-12T12:09:00.966430Z"
     },
     "papermill": {
-     "duration": 2.996342,
-     "end_time": "2026-06-05T12:55:25.908110+00:00",
+     "duration": 0.026147,
+     "end_time": "2026-07-12T12:09:00.969188+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:22.911768+00:00",
+     "start_time": "2026-07-12T12:09:00.943041+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Z3 est deja installe (voir requirements.txt)\n",
-    "# Installation si necessaire :\n",
-    "!pip install -q \"z3-solver>=4.13\""
+    "# Z3 (z3-solver >= 4.13) deja installe (voir requirements.txt) ; import en cellule suivante."
    ]
   },
   {
@@ -1281,10 +1244,10 @@
    "id": "03677979",
    "metadata": {
     "papermill": {
-     "duration": 0.008099,
-     "end_time": "2026-06-05T12:55:25.924898+00:00",
+     "duration": 0.01572,
+     "end_time": "2026-07-12T12:09:01.000823+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:25.916799+00:00",
+     "start_time": "2026-07-12T12:09:00.985103+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1299,16 +1262,16 @@
    "id": "b4f1e65a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:25.943164Z",
-     "iopub.status.busy": "2026-06-05T12:55:25.942753Z",
-     "iopub.status.idle": "2026-06-05T12:55:25.979061Z",
-     "shell.execute_reply": "2026-06-05T12:55:25.977902Z"
+     "iopub.execute_input": "2026-07-12T12:09:01.034422Z",
+     "iopub.status.busy": "2026-07-12T12:09:01.033764Z",
+     "iopub.status.idle": "2026-07-12T12:09:01.085790Z",
+     "shell.execute_reply": "2026-07-12T12:09:01.084084Z"
     },
     "papermill": {
-     "duration": 0.046784,
-     "end_time": "2026-06-05T12:55:25.979938+00:00",
+     "duration": 0.070238,
+     "end_time": "2026-07-12T12:09:01.087149+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:25.933154+00:00",
+     "start_time": "2026-07-12T12:09:01.016911+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1347,10 +1310,10 @@
    "id": "hc0j7trot2l",
    "metadata": {
     "papermill": {
-     "duration": 0.011473,
-     "end_time": "2026-06-05T12:55:26.000948+00:00",
+     "duration": 0.01565,
+     "end_time": "2026-07-12T12:09:01.120108+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:25.989475+00:00",
+     "start_time": "2026-07-12T12:09:01.104458+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1364,10 +1327,10 @@
    "id": "ba5dc597",
    "metadata": {
     "papermill": {
-     "duration": 0.009785,
-     "end_time": "2026-06-05T12:55:26.022915+00:00",
+     "duration": 0.016079,
+     "end_time": "2026-07-12T12:09:01.151958+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.013130+00:00",
+     "start_time": "2026-07-12T12:09:01.135879+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1384,16 +1347,16 @@
    "id": "652c941e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.045525Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.045066Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.116441Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.115335Z"
+     "iopub.execute_input": "2026-07-12T12:09:01.185916Z",
+     "iopub.status.busy": "2026-07-12T12:09:01.185506Z",
+     "iopub.status.idle": "2026-07-12T12:09:01.271162Z",
+     "shell.execute_reply": "2026-07-12T12:09:01.269674Z"
     },
     "papermill": {
-     "duration": 0.084536,
-     "end_time": "2026-06-05T12:55:26.117375+00:00",
+     "duration": 0.10504,
+     "end_time": "2026-07-12T12:09:01.272606+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.032839+00:00",
+     "start_time": "2026-07-12T12:09:01.167566+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1470,10 +1433,10 @@
    "id": "6l7e34dl38m",
    "metadata": {
     "papermill": {
-     "duration": 0.009942,
-     "end_time": "2026-06-05T12:55:26.137695+00:00",
+     "duration": 0.016063,
+     "end_time": "2026-07-12T12:09:01.309410+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.127753+00:00",
+     "start_time": "2026-07-12T12:09:01.293347+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1512,10 +1475,10 @@
    "id": "da448bf1",
    "metadata": {
     "papermill": {
-     "duration": 0.010415,
-     "end_time": "2026-06-05T12:55:26.157848+00:00",
+     "duration": 0.018245,
+     "end_time": "2026-07-12T12:09:01.345786+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.147433+00:00",
+     "start_time": "2026-07-12T12:09:01.327541+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1541,10 +1504,10 @@
    "id": "8ee25e8a",
    "metadata": {
     "papermill": {
-     "duration": 0.010305,
-     "end_time": "2026-06-05T12:55:26.178257+00:00",
+     "duration": 0.016892,
+     "end_time": "2026-07-12T12:09:01.379566+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.167952+00:00",
+     "start_time": "2026-07-12T12:09:01.362674+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1561,16 +1524,16 @@
    "id": "c4b87e9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.201951Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.201440Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.212814Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.211752Z"
+     "iopub.execute_input": "2026-07-12T12:09:01.415124Z",
+     "iopub.status.busy": "2026-07-12T12:09:01.414510Z",
+     "iopub.status.idle": "2026-07-12T12:09:01.430205Z",
+     "shell.execute_reply": "2026-07-12T12:09:01.428582Z"
     },
     "papermill": {
-     "duration": 0.024466,
-     "end_time": "2026-06-05T12:55:26.213579+00:00",
+     "duration": 0.03571,
+     "end_time": "2026-07-12T12:09:01.431626+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.189113+00:00",
+     "start_time": "2026-07-12T12:09:01.395916+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1696,10 +1659,10 @@
    "id": "owzva2nr0hm",
    "metadata": {
     "papermill": {
-     "duration": 0.008975,
-     "end_time": "2026-06-05T12:55:26.232377+00:00",
+     "duration": 0.015222,
+     "end_time": "2026-07-12T12:09:01.462929+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.223402+00:00",
+     "start_time": "2026-07-12T12:09:01.447707+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1735,10 +1698,10 @@
    "id": "d9c64722",
    "metadata": {
     "papermill": {
-     "duration": 0.008222,
-     "end_time": "2026-06-05T12:55:26.248766+00:00",
+     "duration": 0.015316,
+     "end_time": "2026-07-12T12:09:01.492714+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.240544+00:00",
+     "start_time": "2026-07-12T12:09:01.477398+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1755,16 +1718,16 @@
    "id": "c2ac1857",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.266513Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.266238Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.286571Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.285585Z"
+     "iopub.execute_input": "2026-07-12T12:09:01.526929Z",
+     "iopub.status.busy": "2026-07-12T12:09:01.526350Z",
+     "iopub.status.idle": "2026-07-12T12:09:01.556601Z",
+     "shell.execute_reply": "2026-07-12T12:09:01.555152Z"
     },
     "papermill": {
-     "duration": 0.030765,
-     "end_time": "2026-06-05T12:55:26.287385+00:00",
+     "duration": 0.049863,
+     "end_time": "2026-07-12T12:09:01.557907+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.256620+00:00",
+     "start_time": "2026-07-12T12:09:01.508044+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1830,10 +1793,10 @@
    "id": "v824azj4pks",
    "metadata": {
     "papermill": {
-     "duration": 0.009359,
-     "end_time": "2026-06-05T12:55:26.306153+00:00",
+     "duration": 0.017946,
+     "end_time": "2026-07-12T12:09:01.589181+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.296794+00:00",
+     "start_time": "2026-07-12T12:09:01.571235+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1874,10 +1837,10 @@
    "id": "e1e37e51",
    "metadata": {
     "papermill": {
-     "duration": 0.009487,
-     "end_time": "2026-06-05T12:55:26.324833+00:00",
+     "duration": 0.013409,
+     "end_time": "2026-07-12T12:09:01.616070+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.315346+00:00",
+     "start_time": "2026-07-12T12:09:01.602661+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1908,10 +1871,10 @@
    "id": "ff914f72",
    "metadata": {
     "papermill": {
-     "duration": 0.009753,
-     "end_time": "2026-06-05T12:55:26.343813+00:00",
+     "duration": 0.013233,
+     "end_time": "2026-07-12T12:09:01.642692+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.334060+00:00",
+     "start_time": "2026-07-12T12:09:01.629459+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1928,16 +1891,16 @@
    "id": "decdb0db",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.366138Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.365651Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.391714Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.390672Z"
+     "iopub.execute_input": "2026-07-12T12:09:01.671549Z",
+     "iopub.status.busy": "2026-07-12T12:09:01.670944Z",
+     "iopub.status.idle": "2026-07-12T12:09:01.700034Z",
+     "shell.execute_reply": "2026-07-12T12:09:01.698617Z"
     },
     "papermill": {
-     "duration": 0.038796,
-     "end_time": "2026-06-05T12:55:26.392604+00:00",
+     "duration": 0.046073,
+     "end_time": "2026-07-12T12:09:01.701163+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.353808+00:00",
+     "start_time": "2026-07-12T12:09:01.655090+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2006,10 +1969,10 @@
    "id": "ueec18kczg",
    "metadata": {
     "papermill": {
-     "duration": 0.008924,
-     "end_time": "2026-06-05T12:55:26.410958+00:00",
+     "duration": 0.015392,
+     "end_time": "2026-07-12T12:09:01.731327+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.402034+00:00",
+     "start_time": "2026-07-12T12:09:01.715935+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2044,10 +2007,10 @@
    "id": "4c10ff02",
    "metadata": {
     "papermill": {
-     "duration": 0.008607,
-     "end_time": "2026-06-05T12:55:26.428274+00:00",
+     "duration": 0.014793,
+     "end_time": "2026-07-12T12:09:01.760958+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.419667+00:00",
+     "start_time": "2026-07-12T12:09:01.746165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2076,10 +2039,10 @@
    "id": "5156235e",
    "metadata": {
     "papermill": {
-     "duration": 0.008993,
-     "end_time": "2026-06-05T12:55:26.445945+00:00",
+     "duration": 0.018412,
+     "end_time": "2026-07-12T12:09:01.794945+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.436952+00:00",
+     "start_time": "2026-07-12T12:09:01.776533+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2103,16 +2066,16 @@
    "id": "7d113c37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.465694Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.465320Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.470095Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.469132Z"
+     "iopub.execute_input": "2026-07-12T12:09:01.829283Z",
+     "iopub.status.busy": "2026-07-12T12:09:01.828694Z",
+     "iopub.status.idle": "2026-07-12T12:09:01.836131Z",
+     "shell.execute_reply": "2026-07-12T12:09:01.834554Z"
     },
     "papermill": {
-     "duration": 0.015798,
-     "end_time": "2026-06-05T12:55:26.470913+00:00",
+     "duration": 0.026334,
+     "end_time": "2026-07-12T12:09:01.837467+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.455115+00:00",
+     "start_time": "2026-07-12T12:09:01.811133+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2142,10 +2105,10 @@
    "id": "c747e5b7",
    "metadata": {
     "papermill": {
-     "duration": 0.009989,
-     "end_time": "2026-06-05T12:55:26.490651+00:00",
+     "duration": 0.019184,
+     "end_time": "2026-07-12T12:09:01.874923+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.480662+00:00",
+     "start_time": "2026-07-12T12:09:01.855739+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2162,16 +2125,16 @@
    "id": "d0d98243",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.511822Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.511434Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.612616Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.611543Z"
+     "iopub.execute_input": "2026-07-12T12:09:01.913826Z",
+     "iopub.status.busy": "2026-07-12T12:09:01.913192Z",
+     "iopub.status.idle": "2026-07-12T12:09:02.079500Z",
+     "shell.execute_reply": "2026-07-12T12:09:02.077583Z"
     },
     "papermill": {
-     "duration": 0.11288,
-     "end_time": "2026-06-05T12:55:26.613431+00:00",
+     "duration": 0.188449,
+     "end_time": "2026-07-12T12:09:02.081052+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.500551+00:00",
+     "start_time": "2026-07-12T12:09:01.892603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2240,10 +2203,10 @@
    "id": "xb5mg2dk1tq",
    "metadata": {
     "papermill": {
-     "duration": 0.009673,
-     "end_time": "2026-06-05T12:55:26.632775+00:00",
+     "duration": 0.017429,
+     "end_time": "2026-07-12T12:09:02.114329+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.623102+00:00",
+     "start_time": "2026-07-12T12:09:02.096900+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2282,10 +2245,10 @@
    "id": "c334ff85",
    "metadata": {
     "papermill": {
-     "duration": 0.009917,
-     "end_time": "2026-06-05T12:55:26.652149+00:00",
+     "duration": 0.019145,
+     "end_time": "2026-07-12T12:09:02.152667+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.642232+00:00",
+     "start_time": "2026-07-12T12:09:02.133522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2312,10 +2275,10 @@
    "id": "90aa53eb",
    "metadata": {
     "papermill": {
-     "duration": 0.009967,
-     "end_time": "2026-06-05T12:55:26.671840+00:00",
+     "duration": 0.02013,
+     "end_time": "2026-07-12T12:09:02.192761+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.661873+00:00",
+     "start_time": "2026-07-12T12:09:02.172631+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2332,16 +2295,16 @@
    "id": "eb36b71d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.692338Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.692003Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.700342Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.699303Z"
+     "iopub.execute_input": "2026-07-12T12:09:02.237574Z",
+     "iopub.status.busy": "2026-07-12T12:09:02.236944Z",
+     "iopub.status.idle": "2026-07-12T12:09:02.252471Z",
+     "shell.execute_reply": "2026-07-12T12:09:02.250671Z"
     },
     "papermill": {
-     "duration": 0.019822,
-     "end_time": "2026-06-05T12:55:26.701202+00:00",
+     "duration": 0.041758,
+     "end_time": "2026-07-12T12:09:02.254142+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.681380+00:00",
+     "start_time": "2026-07-12T12:09:02.212384+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2432,10 +2395,10 @@
    "id": "nbg6eqhuium",
    "metadata": {
     "papermill": {
-     "duration": 0.010508,
-     "end_time": "2026-06-05T12:55:26.721704+00:00",
+     "duration": 0.018077,
+     "end_time": "2026-07-12T12:09:02.293381+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.711196+00:00",
+     "start_time": "2026-07-12T12:09:02.275304+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2469,10 +2432,10 @@
    "id": "fb30e97b",
    "metadata": {
     "papermill": {
-     "duration": 0.011009,
-     "end_time": "2026-06-05T12:55:26.743671+00:00",
+     "duration": 0.018463,
+     "end_time": "2026-07-12T12:09:02.330414+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.732662+00:00",
+     "start_time": "2026-07-12T12:09:02.311951+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2489,16 +2452,16 @@
    "id": "d828bbe6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.766304Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.765867Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.802597Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.801713Z"
+     "iopub.execute_input": "2026-07-12T12:09:02.368331Z",
+     "iopub.status.busy": "2026-07-12T12:09:02.367679Z",
+     "iopub.status.idle": "2026-07-12T12:09:02.434399Z",
+     "shell.execute_reply": "2026-07-12T12:09:02.432574Z"
     },
     "papermill": {
-     "duration": 0.049153,
-     "end_time": "2026-06-05T12:55:26.803452+00:00",
+     "duration": 0.087862,
+     "end_time": "2026-07-12T12:09:02.435835+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.754299+00:00",
+     "start_time": "2026-07-12T12:09:02.347973+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2590,10 +2553,10 @@
    "id": "7w143u0hf1d",
    "metadata": {
     "papermill": {
-     "duration": 0.00927,
-     "end_time": "2026-06-05T12:55:26.822146+00:00",
+     "duration": 0.020378,
+     "end_time": "2026-07-12T12:09:02.472682+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.812876+00:00",
+     "start_time": "2026-07-12T12:09:02.452304+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2639,10 +2602,10 @@
    "id": "926ca7ab",
    "metadata": {
     "papermill": {
-     "duration": 0.010282,
-     "end_time": "2026-06-05T12:55:26.842080+00:00",
+     "duration": 0.017795,
+     "end_time": "2026-07-12T12:09:02.510209+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.831798+00:00",
+     "start_time": "2026-07-12T12:09:02.492414+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2675,10 +2638,10 @@
    "id": "32a938e0",
    "metadata": {
     "papermill": {
-     "duration": 0.009941,
-     "end_time": "2026-06-05T12:55:26.862629+00:00",
+     "duration": 0.017546,
+     "end_time": "2026-07-12T12:09:02.543902+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.852688+00:00",
+     "start_time": "2026-07-12T12:09:02.526356+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2706,16 +2669,16 @@
    "id": "02cc8d46",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.884097Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.883711Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.888421Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.887442Z"
+     "iopub.execute_input": "2026-07-12T12:09:02.582471Z",
+     "iopub.status.busy": "2026-07-12T12:09:02.581930Z",
+     "iopub.status.idle": "2026-07-12T12:09:02.589469Z",
+     "shell.execute_reply": "2026-07-12T12:09:02.587846Z"
     },
     "papermill": {
-     "duration": 0.016592,
-     "end_time": "2026-06-05T12:55:26.889209+00:00",
+     "duration": 0.028343,
+     "end_time": "2026-07-12T12:09:02.590815+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.872617+00:00",
+     "start_time": "2026-07-12T12:09:02.562472+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2745,10 +2708,10 @@
    "id": "07fc4163",
    "metadata": {
     "papermill": {
-     "duration": 0.009786,
-     "end_time": "2026-06-05T12:55:26.908809+00:00",
+     "duration": 0.014813,
+     "end_time": "2026-07-12T12:09:02.623556+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.899023+00:00",
+     "start_time": "2026-07-12T12:09:02.608743+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2771,10 +2734,10 @@
    "id": "fa8f2b3c",
    "metadata": {
     "papermill": {
-     "duration": 0.009999,
-     "end_time": "2026-06-05T12:55:26.928422+00:00",
+     "duration": 0.015125,
+     "end_time": "2026-07-12T12:09:02.655787+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.918423+00:00",
+     "start_time": "2026-07-12T12:09:02.640662+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2791,16 +2754,16 @@
    "id": "c3415ae0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:26.950325Z",
-     "iopub.status.busy": "2026-06-05T12:55:26.949906Z",
-     "iopub.status.idle": "2026-06-05T12:55:26.980469Z",
-     "shell.execute_reply": "2026-06-05T12:55:26.979196Z"
+     "iopub.execute_input": "2026-07-12T12:09:02.689518Z",
+     "iopub.status.busy": "2026-07-12T12:09:02.689055Z",
+     "iopub.status.idle": "2026-07-12T12:09:02.724897Z",
+     "shell.execute_reply": "2026-07-12T12:09:02.723419Z"
     },
     "papermill": {
-     "duration": 0.043271,
-     "end_time": "2026-06-05T12:55:26.981409+00:00",
+     "duration": 0.053439,
+     "end_time": "2026-07-12T12:09:02.726053+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.938138+00:00",
+     "start_time": "2026-07-12T12:09:02.672614+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2820,13 +2783,7 @@
       "  Code    999 (Juste avant la plage): ✗ Invalide   | ✓ Secure\n",
       "  Code   1000 (Borne inferieure    ): ✓ Valide     | ✓ Secure\n",
       "  Code   5000 (Code moyen          ): ✓ Valide     | ✓ Secure\n",
-      "  Code   9999 (Borne superieure    ): ✓ Valide     | ✓ Secure\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Code   9999 (Borne superieure    ): ✓ Valide     | ✓ Secure\n",
       "  Code  10000 (Juste apres la plage): ✗ Invalide   | ✓ Secure\n",
       "  Code  99999 (Code trop grand     ): ✗ Invalide   | ✓ Secure\n"
      ]
@@ -2910,10 +2867,10 @@
    "id": "chxnya9igo",
    "metadata": {
     "papermill": {
-     "duration": 0.010579,
-     "end_time": "2026-06-05T12:55:27.003065+00:00",
+     "duration": 0.015775,
+     "end_time": "2026-07-12T12:09:02.756102+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:26.992486+00:00",
+     "start_time": "2026-07-12T12:09:02.740327+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2951,10 +2908,10 @@
    "id": "775df3a4",
    "metadata": {
     "papermill": {
-     "duration": 0.010799,
-     "end_time": "2026-06-05T12:55:27.024599+00:00",
+     "duration": 0.012728,
+     "end_time": "2026-07-12T12:09:02.782560+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.013800+00:00",
+     "start_time": "2026-07-12T12:09:02.769832+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2988,10 +2945,10 @@
    "id": "3c053ce6",
    "metadata": {
     "papermill": {
-     "duration": 0.010436,
-     "end_time": "2026-06-05T12:55:27.045331+00:00",
+     "duration": 0.013791,
+     "end_time": "2026-07-12T12:09:02.808999+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.034895+00:00",
+     "start_time": "2026-07-12T12:09:02.795208+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3008,16 +2965,16 @@
    "id": "891e35c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:27.067059Z",
-     "iopub.status.busy": "2026-06-05T12:55:27.066724Z",
-     "iopub.status.idle": "2026-06-05T12:55:27.103651Z",
-     "shell.execute_reply": "2026-06-05T12:55:27.102532Z"
+     "iopub.execute_input": "2026-07-12T12:09:02.842394Z",
+     "iopub.status.busy": "2026-07-12T12:09:02.841864Z",
+     "iopub.status.idle": "2026-07-12T12:09:02.883276Z",
+     "shell.execute_reply": "2026-07-12T12:09:02.881769Z"
     },
     "papermill": {
-     "duration": 0.049247,
-     "end_time": "2026-06-05T12:55:27.104692+00:00",
+     "duration": 0.061397,
+     "end_time": "2026-07-12T12:09:02.884351+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.055445+00:00",
+     "start_time": "2026-07-12T12:09:02.822954+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3043,13 +3000,7 @@
       "  Decrement 2: value=3 ✓\n",
       "  Decrement 3: value=2 ✓\n",
       "  Decrement 4: value=1 ✓\n",
-      "  Decrement 5: value=0 ✓\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Decrement 5: value=0 ✓\n",
       "  Decrement 6: value=0 ✗ Echec (invariant viole)\n",
       "  Decrement 7: value=0 ✗ Echec (invariant viole)\n"
      ]
@@ -3140,10 +3091,10 @@
    "id": "w2oc3m8p5lp",
    "metadata": {
     "papermill": {
-     "duration": 0.010366,
-     "end_time": "2026-06-05T12:55:27.125702+00:00",
+     "duration": 0.013741,
+     "end_time": "2026-07-12T12:09:02.911112+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.115336+00:00",
+     "start_time": "2026-07-12T12:09:02.897371+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3181,10 +3132,10 @@
    "id": "d12d8d9e",
    "metadata": {
     "papermill": {
-     "duration": 0.010223,
-     "end_time": "2026-06-05T12:55:27.146370+00:00",
+     "duration": 0.012498,
+     "end_time": "2026-07-12T12:09:02.938291+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.136147+00:00",
+     "start_time": "2026-07-12T12:09:02.925793+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3215,10 +3166,10 @@
    "id": "85d094b0",
    "metadata": {
     "papermill": {
-     "duration": 0.010314,
-     "end_time": "2026-06-05T12:55:27.166585+00:00",
+     "duration": 0.014927,
+     "end_time": "2026-07-12T12:09:02.967448+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.156271+00:00",
+     "start_time": "2026-07-12T12:09:02.952521+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3247,10 +3198,10 @@
    "id": "1330c777",
    "metadata": {
     "papermill": {
-     "duration": 0.009625,
-     "end_time": "2026-06-05T12:55:27.186122+00:00",
+     "duration": 0.014401,
+     "end_time": "2026-07-12T12:09:02.996853+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.176497+00:00",
+     "start_time": "2026-07-12T12:09:02.982452+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3267,16 +3218,16 @@
    "id": "c72d8872",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:27.206381Z",
-     "iopub.status.busy": "2026-06-05T12:55:27.206018Z",
-     "iopub.status.idle": "2026-06-05T12:55:27.232474Z",
-     "shell.execute_reply": "2026-06-05T12:55:27.231605Z"
+     "iopub.execute_input": "2026-07-12T12:09:03.029631Z",
+     "iopub.status.busy": "2026-07-12T12:09:03.029237Z",
+     "iopub.status.idle": "2026-07-12T12:09:03.067263Z",
+     "shell.execute_reply": "2026-07-12T12:09:03.065799Z"
     },
     "papermill": {
-     "duration": 0.0377,
-     "end_time": "2026-06-05T12:55:27.233206+00:00",
+     "duration": 0.057145,
+     "end_time": "2026-07-12T12:09:03.068356+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.195506+00:00",
+     "start_time": "2026-07-12T12:09:03.011211+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3316,7 +3267,13 @@
       "Grille Mini-Sudoku 2x2 :\n",
       "  1 2\n",
       "  2 0\n",
-      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "✓ Place (1,1)=1 : Seule valeur possible\n",
       "Grille Mini-Sudoku 2x2 :\n",
       "  1 2\n",
@@ -3428,10 +3385,10 @@
    "id": "ygg3i086qz",
    "metadata": {
     "papermill": {
-     "duration": 0.010014,
-     "end_time": "2026-06-05T12:55:27.253162+00:00",
+     "duration": 0.014548,
+     "end_time": "2026-07-12T12:09:03.095896+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.243148+00:00",
+     "start_time": "2026-07-12T12:09:03.081348+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3469,10 +3426,10 @@
    "id": "0ae6ae26",
    "metadata": {
     "papermill": {
-     "duration": 0.011932,
-     "end_time": "2026-06-05T12:55:27.275868+00:00",
+     "duration": 0.013024,
+     "end_time": "2026-07-12T12:09:03.123054+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.263936+00:00",
+     "start_time": "2026-07-12T12:09:03.110030+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3503,10 +3460,10 @@
    "id": "1188a93a",
    "metadata": {
     "papermill": {
-     "duration": 0.011865,
-     "end_time": "2026-06-05T12:55:27.299793+00:00",
+     "duration": 0.014391,
+     "end_time": "2026-07-12T12:09:03.149478+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.287928+00:00",
+     "start_time": "2026-07-12T12:09:03.135087+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3552,10 +3509,10 @@
    "id": "816404b2",
    "metadata": {
     "papermill": {
-     "duration": 0.012325,
-     "end_time": "2026-06-05T12:55:27.324149+00:00",
+     "duration": 0.011776,
+     "end_time": "2026-07-12T12:09:03.173530+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.311824+00:00",
+     "start_time": "2026-07-12T12:09:03.161754+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3606,10 +3563,10 @@
    "id": "05b6c839",
    "metadata": {
     "papermill": {
-     "duration": 0.011158,
-     "end_time": "2026-06-05T12:55:27.346968+00:00",
+     "duration": 0.012646,
+     "end_time": "2026-07-12T12:09:03.198095+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.335810+00:00",
+     "start_time": "2026-07-12T12:09:03.185449+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3630,16 +3587,16 @@
    "id": "23d36ce2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:27.371765Z",
-     "iopub.status.busy": "2026-06-05T12:55:27.371236Z",
-     "iopub.status.idle": "2026-06-05T12:55:27.393600Z",
-     "shell.execute_reply": "2026-06-05T12:55:27.392567Z"
+     "iopub.execute_input": "2026-07-12T12:09:03.224374Z",
+     "iopub.status.busy": "2026-07-12T12:09:03.223847Z",
+     "iopub.status.idle": "2026-07-12T12:09:03.252580Z",
+     "shell.execute_reply": "2026-07-12T12:09:03.251225Z"
     },
     "papermill": {
-     "duration": 0.036331,
-     "end_time": "2026-06-05T12:55:27.394447+00:00",
+     "duration": 0.043181,
+     "end_time": "2026-07-12T12:09:03.253562+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.358116+00:00",
+     "start_time": "2026-07-12T12:09:03.210381+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3649,7 +3606,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "9 accepté ? True\n",
+      "9 accepté ?"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " True\n",
       "7 accepté ? False\n",
       "-6 accepté ? True\n",
       "0 accepté ? True\n"
@@ -3713,10 +3677,10 @@
    "id": "e43nh37qe27",
    "metadata": {
     "papermill": {
-     "duration": 0.00865,
-     "end_time": "2026-06-05T12:55:27.412345+00:00",
+     "duration": 0.012395,
+     "end_time": "2026-07-12T12:09:03.277830+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.403695+00:00",
+     "start_time": "2026-07-12T12:09:03.265435+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3745,10 +3709,10 @@
    "id": "b889364c",
    "metadata": {
     "papermill": {
-     "duration": 0.008459,
-     "end_time": "2026-06-05T12:55:27.429186+00:00",
+     "duration": 0.013408,
+     "end_time": "2026-07-12T12:09:03.304390+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.420727+00:00",
+     "start_time": "2026-07-12T12:09:03.290982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3767,16 +3731,16 @@
    "id": "835259e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:27.447777Z",
-     "iopub.status.busy": "2026-06-05T12:55:27.447440Z",
-     "iopub.status.idle": "2026-06-05T12:55:27.457118Z",
-     "shell.execute_reply": "2026-06-05T12:55:27.456250Z"
+     "iopub.execute_input": "2026-07-12T12:09:03.333149Z",
+     "iopub.status.busy": "2026-07-12T12:09:03.332685Z",
+     "iopub.status.idle": "2026-07-12T12:09:03.346168Z",
+     "shell.execute_reply": "2026-07-12T12:09:03.344856Z"
     },
     "papermill": {
-     "duration": 0.020504,
-     "end_time": "2026-06-05T12:55:27.457993+00:00",
+     "duration": 0.029331,
+     "end_time": "2026-07-12T12:09:03.347290+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.437489+00:00",
+     "start_time": "2026-07-12T12:09:03.317959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3846,10 +3810,10 @@
    "id": "6z3pzi1gran",
    "metadata": {
     "papermill": {
-     "duration": 0.010475,
-     "end_time": "2026-06-05T12:55:27.478448+00:00",
+     "duration": 0.017072,
+     "end_time": "2026-07-12T12:09:03.379659+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.467973+00:00",
+     "start_time": "2026-07-12T12:09:03.362587+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3879,10 +3843,10 @@
    "id": "85877b03",
    "metadata": {
     "papermill": {
-     "duration": 0.010618,
-     "end_time": "2026-06-05T12:55:27.500477+00:00",
+     "duration": 0.014309,
+     "end_time": "2026-07-12T12:09:03.408615+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.489859+00:00",
+     "start_time": "2026-07-12T12:09:03.394306+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3904,16 +3868,16 @@
    "id": "698684fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T12:55:27.525446Z",
-     "iopub.status.busy": "2026-06-05T12:55:27.524917Z",
-     "iopub.status.idle": "2026-06-05T12:55:27.533847Z",
-     "shell.execute_reply": "2026-06-05T12:55:27.532484Z"
+     "iopub.execute_input": "2026-07-12T12:09:03.440678Z",
+     "iopub.status.busy": "2026-07-12T12:09:03.440105Z",
+     "iopub.status.idle": "2026-07-12T12:09:03.451599Z",
+     "shell.execute_reply": "2026-07-12T12:09:03.450304Z"
     },
     "papermill": {
-     "duration": 0.022905,
-     "end_time": "2026-06-05T12:55:27.534875+00:00",
+     "duration": 0.030513,
+     "end_time": "2026-07-12T12:09:03.452643+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.511970+00:00",
+     "start_time": "2026-07-12T12:09:03.422130+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3923,7 +3887,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 3 : Comparaison Fini vs Symbolique\n",
+      "Exercice 3 : Comparaison Fini vs Symbolique"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "Tache : Reconnaitre les entiers pairs entre 100 et 200\n",
       "\n",
       "1. Automate fini :\n",
@@ -3997,10 +3968,10 @@
    "id": "r3l79kx2oyk",
    "metadata": {
     "papermill": {
-     "duration": 0.011476,
-     "end_time": "2026-06-05T12:55:27.557423+00:00",
+     "duration": 0.013563,
+     "end_time": "2026-07-12T12:09:03.480140+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.545947+00:00",
+     "start_time": "2026-07-12T12:09:03.466577+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4030,10 +4001,10 @@
    "id": "b652dfd6",
    "metadata": {
     "papermill": {
-     "duration": 0.011713,
-     "end_time": "2026-06-05T12:55:27.580513+00:00",
+     "duration": 0.01352,
+     "end_time": "2026-07-12T12:09:03.506487+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.568800+00:00",
+     "start_time": "2026-07-12T12:09:03.492967+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4053,10 +4024,10 @@
    "id": "40a6ca12",
    "metadata": {
     "papermill": {
-     "duration": 0.013317,
-     "end_time": "2026-06-05T12:55:27.605731+00:00",
+     "duration": 0.013086,
+     "end_time": "2026-07-12T12:09:03.531866+00:00",
      "exception": false,
-     "start_time": "2026-06-05T12:55:27.592414+00:00",
+     "start_time": "2026-07-12T12:09:03.518780+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4082,7 +4053,16 @@
     "Cette approche ouvre des applications de **verification de proprietes** : portes codees (security system), compteurs bornes avec invariants, et meme Mini-Sudoku 2x2 comme automate symbolique.\n",
     "\n",
     "**Suite** : [Search-11 - Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Retour au sommaire](../README.md)\n",
-    "\n\n### References academiques\n\n- Kleene, S.C. (1956). Representation of Events in Nerve Nets and Finite Automata. In C.E. Shannon & J. McCarthy (eds.), Automata Studies, Annals of Mathematics Studies 34, Princeton University Press:3-42.\n- Rabin, M.O. & Scott, D. (1959). Finite Automata and Their Decision Problems. IBM Journal of Research and Development 3(2):114-125.\n- Hopcroft, J.E., Motwani, R. & Ullman, J.D. (2007). Introduction to Automata Theory, Languages, and Computation (3rd ed.). Pearson.\n- D'Antoni, L. & Veanes, M. (2017). The Power of Symbolic Automata and Transducers. Theoretical Computer Science 719:199-211.\n- de Moura, L. & Bjorner, N. (2008). Z3: An Efficient SMT Solver. TACAS 2008, LNCS 4963:337-340.\n\n"
+    "\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- Kleene, S.C. (1956). Representation of Events in Nerve Nets and Finite Automata. In C.E. Shannon & J. McCarthy (eds.), Automata Studies, Annals of Mathematics Studies 34, Princeton University Press:3-42.\n",
+    "- Rabin, M.O. & Scott, D. (1959). Finite Automata and Their Decision Problems. IBM Journal of Research and Development 3(2):114-125.\n",
+    "- Hopcroft, J.E., Motwani, R. & Ullman, J.D. (2007). Introduction to Automata Theory, Languages, and Computation (3rd ed.). Pearson.\n",
+    "- D'Antoni, L. & Veanes, M. (2017). The Power of Symbolic Automata and Transducers. Theoretical Computer Science 719:199-211.\n",
+    "- de Moura, L. & Bjorner, N. (2008). Z3: An Efficient SMT Solver. TACAS 2008, LNCS 4963:337-340.\n",
+    "\n"
    ]
   }
  ],
@@ -4106,14 +4086,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 15.681798,
-   "end_time": "2026-06-05T12:55:28.066203+00:00",
+   "duration": 10.893615,
+   "end_time": "2026-07-12T12:09:03.892329+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Search-10-SymbolicAutomata.ipynb",
-   "output_path": "Search-10-SymbolicAutomata.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb",
    "parameters": {},
-   "start_time": "2026-06-05T12:55:12.384405+00:00",
+   "start_time": "2026-07-12T12:08:52.998714+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Stop & Repair fix for **machine-path leaks via unconditional `!pip install` in SOURCE** in `Search-10-SymbolicAutomata.ipynb`. Same defect class as #6310 (Search-3) and #6313 (CSP-1); the 70 HIGH-severity cells repo-wide were surfaced by the audit detector in #6314.

### Problem

Three code cells carried unconditional `!pip install` lines in **source**. At every notebook re-execution, pip prints `Requirement already satisfied: <pkg> in c:\users\jsboi\appdata\local\programs\python\python313\lib\site-packages\...` into the committed `stdout` output stream — a machine-identifying path leak (repo is public). Scrubbing the output without removing the source line is non-durable: the leak re-appears at the next exec (secrets-hygiene rule 6 — Stop & Repair).

### Fix (Stop & Repair — cause-level)

Removed the `!pip install` lines from source (the declared dependencies already live in `requirements.txt`) and re-executed end-to-end so the pip-notice / path-leak streams are dropped from outputs.

| Cell | Before | After |
|------|--------|-------|
| 5  | `!pip install -q "automata-lib>=9.2.0"` | dependency note (import in cell 7) |
| 24 | `!pip install graphviz`                 | dropped (try/except ImportError guard KEPT) |
| 30 | `!pip install -q "z3-solver>=4.13"`     | dependency note (import in cell 32) |

## Validation (firsthand, G.1)

Re-executed via `papermill` (python3 kernel, 91/91 cells, 0 errors):

- **0 `!pip install` remaining in source** (grep)
- **0 pip-notice / path leak in outputs** — no `Requirement already satisfied`, no `site-packages`, no `AppData`, no `[notice] A new release of pip` (regex sweep of all outputs)
- exec_count `1..24` sequential; 0 null-exec non-empty code cell (C.2 / H.3)
- repo validator `scripts/notebook_tools/validate_pr_notebooks.py`: **1/1 PASS** (22 cells)
- All 3 modified cells carry `execution_count != null`

## §H.5 verdict: `EXEC_PROVED`

Outputs are real papermill execution results, not hand-edited (secrets-hygiene rule 6 — no output scrubbing). The leak is gone because the **cause** (source `!pip install`) was removed and the notebook re-executed.

## Scope / anti-régression

- 1 file, +427/-447 (output refresh from end-to-end re-exec; net source change = 3 `!pip install` lines removed + 2 dependency notes added)
- C.3: only this notebook staged (the only one whose source I modified)
- §D: 0 proof/code logic deleted — only install boilerplate; the graphviz try/except guard, all automata/z3 logic, and all exercise stubs are intact
- Object-repr address churn (`<graphviz.graphs.Digraph at 0x...>`) is non-deterministic per-exec, not a leak

## Related

- Sibling of #6310 (Search-3) and #6313 (CSP-1) — same `!pip install` source-leak class
- 70 HIGH-severity cells repo-wide surfaced by detector #6314
- See #6309 (security/hygiene register)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
