### PR TITLE
docs(smt): Z3-Python count 6->16 in parent SMT README (§E audit-fichier-entier)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
@@ -44,7 +44,7 @@ Le saut **SAT → SMT** : plutôt que d'encoder un problème en variables boolé
 | Série | Langage / Binding | Style | Notebooks | Statut |
 |-------|-------------------|-------|-----------|--------|
 | [**Z3/**](Z3/README.md) | C# .NET 9 / **Z3.Linq** | Déclaratif borné : on traduit des expressions LINQ en formules SMT — avec bascule sur l'API .NET brute `Microsoft.Z3` quand la démonstration l'exige (notebooks `09`, `15`-`17`) | 18 (`01` -> `18`) | PRODUCTION / BETA |
-| [**Z3-Python/**](Z3-Python/README.md) | Python / **z3-py** | Impératif complet : accès à l'API intégrale du solveur | 6 (`01` -> `06`, série complète) | PRODUCTION |
+| [**Z3-Python/**](Z3-Python/README.md) | Python / **z3-py** | Impératif complet : accès à l'API intégrale du solveur | 16 (`01`->`14`, `17`, `18`) | PRODUCTION |
 
 ### Z3.Linq (C#) — la porte d'entrée déclarative
 
@@ -83,7 +83,7 @@ La thèse est puissante et honnêtement présentée : il n'existe pas de « bon 
 ### Prochaines étapes
 
 - **Z3 en C# déclaratif (Z3.Linq)** : la série [Z3/](Z3/README.md) (18 notebooks, .NET 9) est la porte d'entrée idéale si vous venez de l'écosystème .NET — patron `Theorem<T>`, théorie des tableaux, planificateur de repas à l'échelle réelle (bloc 06→09 sur corpus RecipeML × Ciqual), ordonnancement, coloration, cryptarithmes, MaxSAT, puis bit-vectors, réels exacts et UNSAT cores via l'API brute.
-- **Z3 en Python (z3-py)** : la série [Z3-Python/](Z3-Python/README.md) (6 notebooks) ouvre l'API complète — tactiques, `BitVec`/`Array`/`String`, quantificateurs, preuve par réfutation, optimisation Pareto/MaxSAT.
+- **Z3 en Python (z3-py)** : la série [Z3-Python/](Z3-Python/README.md) (16 notebooks) ouvre l'API complète — tactiques, `BitVec`/`Array`/`String`, quantificateurs, preuve par réfutation, optimisation Pareto/MaxSAT.
 - **Z3 parmi d'autres paradigmes** : la [série Sudoku](../../Sudoku/README.md) compare Z3 à une dizaine d'autres approches algorithmiques (backtracking, DLX, métaheuristiques, inférence probabiliste, réseaux de neurones) sur un même problème NP-complet — le terrain idéal pour situer la résolution SMT dans le spectre des solveurs.
 - **Programmation par contraintes industrielle** : la série [Search / CSP](../../Search/README.md) généralise la modélisation par contraintes (OR-Tools CP-SAT) à une famille plus large de problèmes d'optimisation et d'ordonnancement, avec un solveur complémentaire de Z3.
 


### PR DESCRIPTION
## What

§E README-accuracy fix: the parent `SymbolicAI/SMT/README.md` claimed Z3-Python was **"6 notebooks (`01` -> `06`, série complète)"** — badly stale. Disk has **16 Python notebooks** (`01-14`, `17`, `18`). The "série complète" claim is also false (the series is actively growing; PR #6299, CLEAN/mergeable, adds `-15`/`-16`).

## §E audit-fichier-entier (all counts reconciled disk ↔ prose)

Firsthand `git ls-files` + full-file read:

| Location | Before | After | Disk truth |
|---|---|---|---|
| L47 table (Z3-Python) | `6 ("série complète")` | `16 (01->14, 17, 18)` | 16 Python ✓ |
| L86 Prochaines étapes (Z3-Python) | `(6 notebooks)` | `(16 notebooks)` | 16 ✓ |
| L46 table (Z3 C#) | `18 (01 -> 18)` | unchanged | 18 ✓ already correct |
| L85 Prochaines étapes (Z3 C#) | `(18 notebooks)` | unchanged | 18 ✓ already correct |
| L51 C# raw-API notebooks (`09`,`15`,`16`,`17`) | — | unchanged | all present on disk ✓ |

Only Z3-Python was drifted (2 lines). Z3 C# counts were already accurate. No other pinned notebook counts in the file ("dizaine d'autres approches" L66/L87 is qualitative, not a pinned count).

## Scope

- **Single file**, 2 lines, output-only prose fix.
- **No CATALOG-STATUS marker** in this file (catalog-pr-hygiene R1 N/A).
- **Collision-safe**: PR #6299 touches the *child* `Z3-Python/README.md`, not this parent — no overlap.

## Verification

```
$ git diff --stat
 MyIA.AI.Notebooks/SymbolicAI/SMT/README.md | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

## Dependency note for ai-01 (merge-gate)

PR **#6299** (pending merge) brings Z3-Python to **18** notebooks and reconciles the *child* `Z3-Python/README.md` ("14"→"18", adds table rows 15-18), but does **not** touch this parent. When #6299 merges, bump L47 + L86 here to `18` (I reconciled to current-main truth = 16 to avoid claiming notebooks `15`/`16` that aren't on `main` yet). Suggested merge order: #6299 first, then this PR rebased with the 16→18 bump; or merge this at 16 now and fold the parent bump into #6299.

See #1206 (Z3-Python tail Epic).
