### PR TITLE
fix(probas): remove !pip install pyro-ppl source-leak in Pyro_RSA_Hyperbole (sibling #6310/#6313/#6319)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb
@@ -80,10 +80,10 @@
    "id": "02427bb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-05T18:38:03.855274Z",
-     "iopub.status.busy": "2026-06-05T18:38:03.854834Z",
-     "iopub.status.idle": "2026-06-05T18:38:09.917345Z",
-     "shell.execute_reply": "2026-06-05T18:38:09.916426Z"
+     "iopub.execute_input": "2026-07-12T13:47:04.572106Z",
+     "iopub.status.busy": "2026-07-12T13:47:04.571502Z",
+     "iopub.status.idle": "2026-07-12T13:47:05.841292Z",
+     "shell.execute_reply": "2026-07-12T13:47:05.840339Z"
     },
     "papermill": {
      "duration": 6.070481,
@@ -99,37 +99,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: pyro-ppl in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (1.9.1)\n",
-      "Requirement already satisfied: numpy>=1.7 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyro-ppl) (2.4.2)\n",
-      "Requirement already satisfied: opt-einsum>=2.3.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyro-ppl) (3.4.0)\n",
-      "Requirement already satisfied: pyro-api>=0.1.1 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pyro-ppl) (0.1.2)\n",
-      "Requirement already satisfied: torch>=2.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyro-ppl) (2.11.0+cu128)\n",
-      "Requirement already satisfied: tqdm>=4.36 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pyro-ppl) (4.67.3)\n",
-      "Requirement already satisfied: filelock in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch>=2.0->pyro-ppl) (3.25.2)\n",
-      "Requirement already satisfied: typing-extensions>=4.10.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from torch>=2.0->pyro-ppl) (4.15.0)\n",
-      "Requirement already satisfied: setuptools<82 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from torch>=2.0->pyro-ppl) (80.9.0)\n",
-      "Requirement already satisfied: sympy>=1.13.3 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch>=2.0->pyro-ppl) (1.14.0)\n",
-      "Requirement already satisfied: networkx>=2.5.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch>=2.0->pyro-ppl) (3.6.1)\n",
-      "Requirement already satisfied: jinja2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch>=2.0->pyro-ppl) (3.1.6)\n",
-      "Requirement already satisfied: fsspec>=0.8.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch>=2.0->pyro-ppl) (2026.2.0)\n",
-      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from sympy>=1.13.3->torch>=2.0->pyro-ppl) (1.3.0)\n",
-      "Requirement already satisfied: colorama in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from tqdm>=4.36->pyro-ppl) (0.4.6)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from jinja2->torch>=2.0->pyro-ppl) (3.0.3)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+      "Pyro-ppl disponible: True\n"
      ]
     }
    ],
    "source": [
-    "%pip install pyro-ppl\n",
+    "# Filtre les avertissements transitifs de l'import chain (tqdm auto-detect \"IProgress not found\" -> path leak).\n",
+    "# Sans ce filtre, l'import de `pyro.distributions` declenche un tqdm.auto warning qui inclut le path utilisateur.\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore', message=r'.*IProgress not found.*')\n",
+    "warnings.filterwarnings('ignore', category=DeprecationWarning)\n",
+    "\n",
+    "# pyro-ppl doit etre pre-provisionne dans l'environnement (cf dependencies in requirements.txt).\n",
+    "# Installation conditionnelle en fallback uniquement si l'import echoue.\n",
+    "try:\n",
+    "    import pyro.distributions as _pyro_dist  # noqa: F401\n",
+    "    pyro_ok = True\n",
+    "except ImportError:\n",
+    "    import subprocess, sys as _sys\n",
+    "    subprocess.check_call([_sys.executable, '-m', 'pip', 'install', 'pyro-ppl'])\n",
+    "    import pyro.distributions as _pyro_dist  # noqa: F401\n",
+    "    pyro_ok = True\n",
+    "print(f\"Pyro-ppl disponible: {pyro_ok}\")\n",
     "\n",
     "import collections\n",
     "import functools\n",


### PR DESCRIPTION
# fix(probas): remove `!pip install pyro-ppl` source-leak in Pyro_RSA_Hyperbole (sibling #6310/#6313/#6319)

## Summary

Sibling-fix to PRs **#6310** (Search-3), **#6313** (CSP-1), **#6319** (Tweety-7b), **#6316** (Search-10), **#6317** (App-6-Minesweeper). Same defect class: machine-path leak via unconditional `%pip install` in source.

Single-notebook surgical fix on `MyIA.AI.Notebooks/Probas/Pyro_RSA_Hyperbole.ipynb` — **only cell[2] (id `02427bb4`) is modified**. All 40 other cells byte-identical to `origin/main` (sibling-fix pattern, c.462-L1).

See **#6314** (audit detector + broader rollout across other lanes/partitions).

## Sibling PRs (same defect class, other owners)

| PR | Notebook owner lane | Status |
|----|---------------------|--------|
| #6310 | Search-3 | merged |
| #6313 | CSP-1 | merged |
| #6316 | Search-10 | merged |
| #6317 | App-6-Minesweeper | merged |
| #6319 | Tweety-7b | merged |
| **#6322 (this)** | **Probas Pyro_RSA_Hyperbole** | **OPEN** |

## Defect

Cell[2] starts with `%pip install pyro-ppl` (UNCONDITIONAL_BASH) → kernel emits 17 streams of
```
Requirement already satisfied: pyro-ppl in c:\users\jsboi\appdata\local\...\site-packages (1.9.1)
```
exposing the **machine username `jsboi`** and **absolute Python install path** in cell outputs. Any subsequent kernel execution re-emits these streams, leaking machine identity on every cell run.

## Fix (Stop & Repair, no output scrubbing)

**Cause-level** (regle §6 secrets-hygiene.md): the source cell itself triggers the leak. Fix is **NOT** hand-editing the outputs (banned). Fix is replacing the unconditional `%pip install` with:

1. **pre-install warnings filter** to suppress transitive path leak from `tqdm.auto` ("IProgress not found" warning on Windows includes the install path).
2. **try/except ImportError** conditional installation as fallback (the actual defensive pattern recommended by data-science / notebook best practices).
3. `pyro-ppl doit etre pre-provisionne dans l'environnement (cf dependencies in requirements.txt).` — explicit comment that the library is expected pre-installed; the `try/except` is a graceful-fallback for portable distribution, not a primary install path.

Cell[2] source now:
```python
import warnings
warnings.filterwarnings('ignore', message=r'.*IProgress not found.*')
warnings.filterwarnings('ignore', category=DeprecationWarning)

# pyro-ppl doit etre pre-provisionne dans l'environnement (cf dependencies in requirements.txt).
# Installation conditionnelle en fallback uniquement si l'import echoue.
try:
    import pyro.distributions as _pyro_dist  # noqa: F401
    pyro_ok = True
except ImportError:
    import subprocess, sys as _sys
    subprocess.check_call([_sys.executable, '-m', 'pip', 'install', 'pyro-ppl'])
    import pyro.distributions as _pyro_dist  # noqa: F401
    pyro_ok = True
print(f"Pyro-ppl disponible: {pyro_ok}")
```

## Re-execution output (H.5 verdict: EXEC_PROVED)

Before fix (cell[2] outputs):
```
17 streams containing:
  "Requirement already satisfied: pyro-ppl in c:\\users\\jsboi\\appdata\\local\\..."
  + stderr "[notice] A new release of pip is available..."
```

After fix (cell[2] outputs):
```json
[{
  "name": "stdout",
  "output_type": "stream",
  "text": ["Pyro-ppl disponible: True\n"]
}]
```

**Single stream, no path.** `execution_count: 1`, `outputs: [...]` consistent, `metadata.execution` refreshed (`2026-07-12T13:47:04Z`).

## Preservation checks (forensic, H.5)

| Check | Pattern ref | Result |
|-------|-------------|--------|
| `cell[2].source` still a list of strings | c.414-L1 | PASS (117 items, not joined) |
| Encoding bytes LF-only (no CRLF) | c.414, c.461-L3, `.gitattributes *.ipynb text eol=lf` | PASS (CRLF=0, LF only=1586) |
| Trailing newline at EOF | c.432-L4 | PASS (`}\n` final) |
| Other 40 cells byte-identical | c.462-L1 sibling-fix | PASS |
| `ensure_ascii=False` json.dump | c.461-L3 | PASS (`\u`-prefix absent) |
| `papermill.duration: 6.070481` preserved | c.462-L1 papermill-metadata-safe | PASS (text-level surgical, no `json.dump`) |
| Catalog files unchanged | catalog-pr-hygiene R1 | PASS (worktree diff: `1 file changed, 23 insertions(+), 32 deletions(-)`) |

## Validation

```bash
$ python c464_audit_pip_native.py
# pip-install audit — partition-native (Probas) before fix
- MyIA.AI.Notebooks\Probas\Pyro_RSA_Hyperbole.ipynb cell[2] UNCONDITIONAL_BASH

# pip-install audit — after fix (partition-native)
- MyIA.AI.Notebooks\Probas\Pyro_RSA_Hyperbole.ipynb: 0 HIGH-leak cells
```

(Argument_Analysis init_agent cell[5] = real CONDITIONAL_TRY → separate sibling fix candidate, out of scope for c.464.)

## Anti-patterns interdits (banni dans cette PR)

- **No hand-editing of cell outputs** (Stop & Repair, regle §6): outputs are derived from a fresh nbconvert `--execute` re-run. Source→output provenance is preserved.
- **No mass catalogue regeneration** (catalog-pr-hygiene R1): only 1 file (notebook) modified, `COURSE_CATALOG.generated.{json,md}` and CATALOG-STATUS markers byte-identique.
- **No `json.dump` roundtrip** on the notebook (c.462-L1 papermill-metadata-safe): the surgical edit was done at text-level for `source` + `metadata.execution`. Other metadata fields (`papermill`, `tags`) byte-preserved via copy.
- **No composite scope** (G.4): 1 file, 1 cell, 1 sujet. diff = `1 file changed, 23 insertions(+), 32 deletions(-)`.

## R6 anti-monoculture disclosure

- c.462 (Tweety-7b sibling-fix) → c.463 (Argument_Analysis Phase 2 README de-spaghetti) → c.464 (THIS: Probas Pyro sibling-fix).
- Pivot post-Tweety sustained genre alternation: substantive fix → docs reorg → substantive fix.
- L429 « Substance > Sweep » honored: this is genuine code fix at source (Stop & Repair), not a sweep/mass-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
