### PR TITLE
fix(security): strip machine-path pip stderr from GenAI/Image/04-3-Production-Integration

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb
@@ -65,81 +65,12 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Defaulting to user installation because normal site-packages is not writeable\n",
-      "Requirement already satisfied: pandas in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.0.2)\n",
-      "Requirement already satisfied: matplotlib in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.10.3)\n",
-      "Requirement already satisfied: seaborn in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (0.13.2)\n",
-      "Requirement already satisfied: ipywidgets in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (8.1.5)\n",
-      "Requirement already satisfied: pillow in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (12.1.1)\n",
-      "Requirement already satisfied: requests in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (2.34.2)\n",
-      "Requirement already satisfied: python-dotenv in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (1.2.2)\n",
-      "Requirement already satisfied: openai in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (2.43.0)\n",
-      "Requirement already satisfied: numpy>=1.26.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2.4.3)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2025.2)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (1.3.2)\n",
-      "Requirement already satisfied: cycler>=0.10 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (0.12.1)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (4.58.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.3.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (1.4.8)\n",
-      "Requirement already satisfied: packaging>=20.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (24.2)\n",
-      "Requirement already satisfied: pyparsing>=2.3.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (3.2.3)\n",
-      "Requirement already satisfied: comm>=0.1.3 in c:\\python313\\lib\\site-packages (from ipywidgets) (0.2.2)\n",
-      "Requirement already satisfied: ipython>=6.1.0 in c:\\python313\\lib\\site-packages (from ipywidgets) (9.2.0)\n",
-      "Requirement already satisfied: traitlets>=4.3.1 in c:\\python313\\lib\\site-packages (from ipywidgets) (5.14.3)\n",
-      "Requirement already satisfied: widgetsnbextension~=4.0.12 in c:\\python313\\lib\\site-packages (from ipywidgets) (4.0.14)\n",
-      "Requirement already satisfied: jupyterlab-widgets~=3.0.12 in c:\\python313\\lib\\site-packages (from ipywidgets) (3.0.15)\n",
-      "Requirement already satisfied: charset_normalizer<4,>=2 in c:\\python313\\lib\\site-packages (from requests) (3.4.2)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in c:\\python313\\lib\\site-packages (from requests) (3.10)\n",
-      "Requirement already satisfied: urllib3<3,>=1.26 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from requests) (1.26.20)\n",
-      "Requirement already satisfied: certifi>=2023.5.7 in c:\\python313\\lib\\site-packages (from requests) (2025.4.26)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in c:\\python313\\lib\\site-packages (from openai) (4.9.0)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (1.9.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in c:\\python313\\lib\\site-packages (from openai) (0.28.1)\n",
-      "Requirement already satisfied: jiter<1,>=0.10.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (0.13.0)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (2.13.4)\n",
-      "Requirement already satisfied: sniffio in c:\\python313\\lib\\site-packages (from openai) (1.3.1)\n",
-      "Requirement already satisfied: tqdm>4 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (4.67.3)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.11 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (4.15.0)\n",
-      "Requirement already satisfied: httpcore==1.* in c:\\python313\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\n",
-      "Requirement already satisfied: h11>=0.16 in c:\\python313\\lib\\site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\n",
-      "Requirement already satisfied: colorama in c:\\python313\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.4.6)\n",
-      "Requirement already satisfied: decorator in c:\\python313\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (5.2.1)\n",
-      "Requirement already satisfied: ipython-pygments-lexers in c:\\python313\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (1.1.1)\n",
-      "Requirement already satisfied: jedi>=0.16 in c:\\python313\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.19.2)\n",
-      "Requirement already satisfied: matplotlib-inline in c:\\python313\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.1.7)\n",
-      "Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in c:\\python313\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (3.0.51)\n",
-      "Requirement already satisfied: pygments>=2.4.0 in c:\\python313\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (2.19.1)\n",
-      "Requirement already satisfied: stack_data in c:\\python313\\lib\\site-packages (from ipython>=6.1.0->ipywidgets) (0.6.3)\n",
-      "Requirement already satisfied: annotated-types>=0.6.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.46.4 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (2.46.4)\n",
-      "Requirement already satisfied: typing-inspection>=0.4.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.4.2)\n",
-      "Requirement already satisfied: six>=1.5 in c:\\python313\\lib\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n",
-      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in c:\\python313\\lib\\site-packages (from jedi>=0.16->ipython>=6.1.0->ipywidgets) (0.8.4)\n",
-      "Requirement already satisfied: wcwidth in c:\\python313\\lib\\site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets) (0.2.13)\n",
-      "Requirement already satisfied: executing>=1.2.0 in c:\\python313\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (2.2.0)\n",
-      "Requirement already satisfied: asttokens>=2.1.0 in c:\\python313\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (3.0.0)\n",
-      "Requirement already satisfied: pure-eval in c:\\python313\\lib\\site-packages (from stack_data->ipython>=6.1.0->ipywidgets) (0.2.3)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!pip install pandas matplotlib seaborn ipywidgets pillow requests python-dotenv openai"
+    "# Dependances : voir requirements.txt (pandas, matplotlib, seaborn,\n",
+    "# ipywidgets, pillow, requests, python-dotenv, openai). L'environnement\n",
+    "# doit etre pre-installe (regle F) — pas d'appel pip dans le notebook\n",
+    "# commite."
    ]
   },
   {


### PR DESCRIPTION
## Summary

`GenAI/Image/04-Applications/04-3-Production-Integration.ipynb` cell[1] ran `!pip install pandas matplotlib seaborn ipywidgets pillow requests python-dotenv openai`. The committed stderr outputs baked the **worker machine path** into the repo:

> "Defaulting to user installation because normal site-packages is not writeable. Requirement already satisfied: pandas in `c:\users\jsboi\appdata\roaming\...`"
> "WARNING: Ignoring invalid distribution ~penai (`C:\Python313\Lib\site-packages`)"

Same leak-vector class as **Search-3 (#6310)** and **CSP-1 (#6313)**.

## Fix (regle F — env pre-provisioned, not shell-out pip)

Cell[1] becomes a requirements-pointer comment; the path-leaking pip stderr outputs are removed (the cell no longer executes pip → produces no output).

## Verification — repo validator H.3 PASS (10/10 cells)

| Check | Result |
|-------|--------|
| `!pip install` in source | **0** (was 1) |
| "requirement already satisfied" / "site-packages" in outputs | **0** (was 2 leak outputs) |
| execution_count | 1-11 intact, **0** null-on-non-empty (H.3) |
| nbformat validate | OK |
| diff scope | surgical **+5/-74**, single cell (cell[1]) |
| source logic deleted | none (pip shell-out only, no computation) |

## Scope

Single notebook, single cell. No cross-family churn. `See #6309` (path-leak / probeAddresses EPIC) — not `Closes` since the EPIC spans many notebooks and the pre-commit hook (#6312) is the durable fix.