### PR TITLE
docs(lean,#4980): MayerVietoris FR mirror block (inline i18n, v2 re-do of #6308)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris.lean
@@ -32,6 +32,43 @@ condition (Part 21) to the cohomological consequence (this part).
 Epic #1646, See #2159. All `sorry`s eliminated at creation.
 -/
 
+/-
+  Bloc miroir FR (convention i18n EPIC #4980, Option A inline)
+  =============================================================
+
+  Hommage a Grothendieck -- Partie 22 : suite exacte longue de Mayer-Vietoris
+  en cohomologie des faisceaux.
+
+  La Partie 21 (MayerVietorisSquare.lean) a introduit les carres de
+  Mayer-Vietoris : l'entree geometrique (un carre pushout de faisceaux) et
+  le complexe court exact de faisceaux abeliens libres associe.
+
+  Ce module fait le pont avec la **suite exacte longue de Mayer-Vietoris**
+  en cohomologie des faisceaux depuis Mathlib
+  (CategoryTheory.Sites.SheafCohomology.MayerVietoris).
+
+  Etant donne un carre de Mayer-Vietoris S pour un site (C, J) et un
+  faisceau abelien F, il existe une suite exacte longue :
+
+    ... -> H^n(X_4, F) -> H^n(X_2, F) (+) H^n(X_3, F) -> H^n(X_1, F) -> H^(n+1)(X_4, F) -> ...
+
+  ou X_1 = intersection, X_2/X_3 = ouverts du recouvrement, X_4 = espace
+  recouvert.
+
+  Constructions cles recuperees de Mathlib :
+
+    - toBiprod : somme des restrictions H^n(X_4) -> H^n(X_2) (+) H^n(X_3)
+    - fromBiprod : difference des restrictions H^n(X_2) (+) H^n(X_3) -> H^n(X_1)
+    - toBiprod_fromBiprod : la composition est nulle
+    - delta : homomorphisme de connexion H^{n_0}(X_1) -> H^{n_1}(X_4) (n_1 = n_0 + 1)
+    - sequence : la suite exacte longue complete (ComposableArrows AddCommGrp 5)
+    - sequence_exact : la suite est exacte
+    - delta_toBiprod : delta >> toBiprod = 0
+    - fromBiprod_delta : fromBiprod >> delta = 0
+
+  EPIC #1646. Tous les sorry elimines a la creation.
+-/
+
 import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
 
 universe w v u


### PR DESCRIPTION
## Scope

Add a **FR mirror comment block** (Option A inline, convention EPIC #4980) to `grothendieck_lean/Grothendieck/SheafCohomology/MayerVietoris.lean`, after the EN header. Same proven pattern as merged **#6242** (SieveGenerate) and **#6306** (SchemesTour).

This is a **clean re-do of #6308** (which was closed: the FR-canonical migration produced UTF-8 corrupted files via a `byte & ~0x80` tooling bug — ₀→NUL, ₁→0x01, etc. — caught by forensic §H.4 from po-2025).

## Approach change vs #6308

#6308 attempted FR-canonical migration (rewrite the EN file to FR + add EN sibling). That path triggered a UTF-8 corruption bug in my tooling. This v2 uses the **inline FR block** pattern instead: the baseline EN file stays **byte-identical** (only a comment block is added after the header), which eliminates the corruption risk entirely.

## 4 safeguards proven (lessons c.408/c.410)

| Check | Result |
|-------|--------|
| Delimiter balance `/-` / `-/` | 11/11 -> **12/12** (exactly one balanced block added) |
| FR prose stray `/-` or `-/` literal | **none** (asserted programmatically) |
| Code-identity vs origin/main | **byte-identical** — 43 == 43 non-blank code lines (sha256 match) |
| UTF-8 integrity (c.410 new check) | **NUL=0, decodes clean** — FR prose is ASCII-only (`X_1`, `n_0`) so the subscript byte-corruption class cannot occur |
| git file type | **TEXT** (not `Bin`) — contrast with corrupted #6308 which git saw as binary |

Diff: **+37 lines, 0 deletions, 1 file** (purely additive ASCII comment block).

## CI

grothendieck CI runs in `real` sorry-mode (#6223) — strips comments before counting `\bsorry\b`. FR prose mentions of "sorry" ("Tous les sorry elimines a la creation") do not affect the count. Local `lake build Grothendieck.SheafCohomology.MayerVietoris` launched in WSL for empirical confirmation.

## See

- #4980 (Lean i18n convention).
- Merged precedent: #6242 (SieveGenerate), #6306 (SchemesTour) — same inline FR block pattern.
- Supersedes closed #6308 (corrupted). One subject (MayerVietoris FR i18n), atomic.