### PR TITLE
i18n(#4980): SheafCohomology/Cech root -- FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech.lean
@@ -1,35 +1,38 @@
 /-
-Grothendieck Part 23 -- Čech cohomology
+Grothendieck Partie 23 -- cohomologie de Čech
 
-Part 20 (SheafCohomology/Basic.lean) introduced Ext-based sheaf cohomology
-H^n(F) = Ext^n(constantSheaf ℤ, F).
+La Partie 20 (SheafCohomology/Basic.lean) a introduit la cohomologie
+des faisceaux basée sur Ext H^n(F) = Ext^n(faisceauConstant ℤ, F).
 
-This module bridges **Čech cohomology** from Mathlib
-(`CategoryTheory.Sites.SheafCohomology.Cech`). Given a family of objects
-U : ι → C in a category C with finite products, the Čech complex functor
-sends a presheaf P : Cᵒᵖ ⥤ A to the cochain complex which in degree n
-consists of the product, indexed by i : Fin (n+1) → ι, of the value of
-P on the product of the objects U (i a) for a : Fin (n+1).
+Ce module établit un pont vers la **cohomologie de Čech** de
+Mathlib (`CategoryTheory.Sites.SheafCohomology.Cech`). Étant donnée
+une famille d'objets U : ι → C dans une catégorie C
+avec produits finis, le foncteur du complexe de Čech envoie un
+préfaisceau P : Cᵒᵖ ⥤ A sur le complexe de cochaênes
+dont le degré n consiste en le produit, indexé par i : Fin (n+1) → ι,
+de la valeur de P sur le produit des objets U (i a) pour a : Fin (n+1).
 
-This is the combinatorial cochain complex associated to a covering family.
-In good situations (e.g. sheaves on a site with enough structure), the
-cohomology of this complex computes the sheaf cohomology H^n.
+Il s'agit du complexe de cochaênes combinatoire associé à une famille
+recouvrante. Dans les bonnes situations (par exemple les faisceaux sur
+un site avec suffisamment de structure), la cohomologie de ce complexe
+calcule la cohomologie des faisceaux H^n.
 
-Key constructions bridged from Mathlib:
+Constructions clés pontées depuis Mathlib :
 
   - `FormalCoproduct.cosimplicialObjectFunctor` :
-      Simplicial object in FormalCoproduct C ⟹ (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A
+      Objet simplicial dans FormalCoproduct C ⟹ (Cᵒᵖ ⥤ A) ⟹ CosimplicialObject A
   - `FormalCoproduct.cochainComplexFunctor` :
-      Simplicial object in FormalCoproduct C ⟹ (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+      Objet simplicial dans FormalCoproduct C ⟹ (Cᵒᵖ ⥤ A) ⟹ CochainComplex A ℕ
   - `cechComplexFunctor` :
-      (ι → C) ⟹ (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+      (ι → C) ⟹ (Cᵒᵖ ⥤ A) ⟹ CochainComplex A ℕ
 
-The construction goes through the category `FormalCoproduct C` (the free
-formal coproduct completion of C), where a family U : ι → C is packaged
-as a single object, and its "Čech object" is a simplicial object whose
-degree-n part is indexed by Fin (n+1) → ι.
+La construction passe par la catégorie `FormalCoproduct C` (la
+complétion par coproduits formels libres de C), oê une famille
+U : ι → C est encapsulée dans un objet unique, et son
+"objet de Čech" est un objet simpliciel dont la partie de degré n
+est indexée par Fin (n+1) → ι.
 
-Epic #1646, See #2159. All `sorry`s eliminated at creation.
+Epic #1646, Voir #2159. Tous les `sorry` éliminés à la création.
 -/
 
 import Mathlib.CategoryTheory.Sites.SheafCohomology.Cech
@@ -42,78 +45,82 @@ open CategoryTheory Category Opposite Limits
 
 variable {C : Type u} [Category.{v} C]
 
-/-! ## 1. The cosimplicial object functor
+/-! ## 1. Le foncteur en objet cosimplicial
 
-Given a simplicial object `E` in the category `FormalCoproduct C` of
-formal coproducts, `cosimplicialObjectFunctor E` is the functor
+Étant donné un objet simpliciel `E` dans la catégorie `FormalCoproduct C`
+des coproduits formels, `cosimplicialObjectFunctor E` est le foncteur
 
-  (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A
+  (Cᵒᵖ ⥤ A) ⟹ CosimplicialObject A
 
-which sends a presheaf P : Cᵒᵖ ⥤ A to the cosimplicial object obtained
-by "evaluating" P on E (using the formal-coproduct structure).
+qui envoie un préfaisceau P : Cᵒᵖ ⥤ A sur l'objet cosimpliciel
+obtenu en “evaluant” P sur E (grâce à la structure de
+coproduit formel).
 
-This is the input to the alternating-coface-map construction of the
-cochain complex.
+C'est l'entrée de la construction du complexe de cochaênes par la carte
+de coface alternée.
 -/
 
--- cosimplicialObjectFunctor: from a simplicial formal coproduct to a
--- functor (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A.
+-- cosimplicialObjectFunctor : d'un coproduit formel simpliciel vers un
+-- foncteur (Cᵒᵖ ⥤ A) ⟹ CosimplicialObject A.
 #check @CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor
 
-/-! ## 2. The cochain complex functor
+/-! ## 2. Le foncteur en complexe de cochaênes
 
-Composing `cosimplicialObjectFunctor` with the alternating coface map
-construction (`AlgebraicTopology.alternatingCofaceMapComplex`) gives
-the cochain complex functor
+En composant `cosimplicialObjectFunctor` avec la construction de la carte
+de coface alternée (`AlgebraicTopology.alternatingCofaceMapComplex`) on
+obtient le foncteur de complexe de cochaênes
 
-  (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+  (Cᵒᵖ ⥤ A) ⟹ CochainComplex A ℕ
 
-which sends a presheaf to the associated alternating cochain complex.
+qui envoie un préfaisceau sur le complexe de cochaênes alternées associé.
 -/
 
--- cochainComplexFunctor: from a simplicial formal coproduct to a
--- functor (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ.
+-- cochainComplexFunctor : d'un coproduit formel simpliciel vers un
+-- foncteur (Cᵒᵖ ⥤ A) ⟹ CochainComplex A ℕ.
 #check @CategoryTheory.Limits.FormalCoproduct.cochainComplexFunctor
 
-/-! ## 3. The Čech complex functor
+/-! ## 3. Le foncteur du complexe de Čech
 
-Given a family of objects U : ι → C in a category C with finite products,
-`cechComplexFunctor U` is the functor
+Étant donnée une famille d'objets U : ι → C dans une catégorie C
+avec produits finis, `cechComplexFunctor U` est le foncteur
 
-  (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+  (Cᵒᵖ ⥤ A) ⟹ CochainComplex A ℕ
 
-which sends a presheaf P : Cᵒᵖ ⥤ A to the Čech cochain complex. In
-degree n, this complex consists of the product, indexed by
-i : Fin (n + 1) → ι, of the value of P on the product of the objects
-U (i a) for a : Fin (n + 1).
+qui envoie un préfaisceau P : Cᵒᵖ ⥤ A sur le complexe de
+cochaênes de Čech. En degré n, ce complexe est constitué du produit,
+indexé par i : Fin (n + 1) → ι, de la valeur de P sur le produit
+des objets U (i a) pour a : Fin (n + 1).
 
-This is the classical Čech complex associated to the covering family {U j}.
+Il s'agit du complexe de Čech classique associé à la famille
+recouvrante {U j}.
 -/
 
--- cechComplexFunctor: the Čech complex functor for a family U : ι → C.
+-- cechComplexFunctor : le foncteur du complexe de Čech pour une
+-- famille U : ι → C.
 #check @CategoryTheory.cechComplexFunctor
 
-/-! ## 4. Bridge theorems
+/-! ## 4. Théorèmes ponts
 
-Bridge theorems connecting the Čech complex functor to concrete
-verification.
+Théorèmes ponts connectant le foncteur du complexe de Čech à une
+vérification concrète.
 -/
 
-/-- Bridge construction: given a family of objects U : ι → C and a
-    presheaf P : Cᵒᵖ ⥤ A (in a preadditive category with products),
-    this is the degree-n part of the Čech complex of P with respect
-    to U, as an object of A. -/
+/-- Construction pont : étant donnée une famille d'objets U : ι → C
+    et un préfaisceau P : Cᵒᵖ ⥤ A (dans une catégorie préadditive
+    avec produits), c'est la partie de degré n du complexe de Čech de P
+    par rapport à U, en tant qu'objet de A. -/
 noncomputable def cechComplexObj
     {A : Type u'} [Category.{v'} A] [HasProducts.{w} A] [Preadditive A]
     [HasFiniteProducts C] {ι : Type w} (U : ι → C)
     (P : Cᵒᵖ ⥤ A) (n : ℕ) : A :=
   ((CategoryTheory.cechComplexFunctor U).obj P).X n
 
-/-- Bridge theorem (type restatement): the Čech complex functor sends a
-    presheaf P : Cᵒᵖ ⥤ A to a cochain complex indexed by ℕ. This is the
-    type-level restatement that `cechComplexFunctor U` has source
-    `(Cᵒᵖ ⥤ A)` and target `CochainComplex A ℕ`. Marked `noncomputable`
-    because it delegates to the noncomputable Mathlib definition. -/
+/-- Théorème pont (reformulation de type) : le foncteur du complexe de
+    Čech envoie un préfaisceau P : Cᵒᵖ ⥤ A sur un complexe de
+    cochaênes indexé par ℕ. C'est la reformulation au niveau des types
+    du fait que `cechComplexFunctor U` a pour source `(Cᵒᵖ ⥤ A)` et
+    pour cible `CochainComplex A ℕ`. Marqué `noncomputable` car il
+    délègue à la définition noncomputable de Mathlib. -/
 noncomputable def cechComplexFunctor_type
     {A : Type u'} [Category.{v'} A] [HasProducts.{w} A] [Preadditive A]
     [HasFiniteProducts C] {ι : Type w} (U : ι → C) :

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech_en.lean
@@ -1,0 +1,123 @@
+/-
+Grothendieck Part 23 -- Čech cohomology
+
+Part 20 (SheafCohomology/Basic.lean) introduced Ext-based sheaf cohomology
+H^n(F) = Ext^n(constantSheaf ℤ, F).
+
+This module bridges **Čech cohomology** from Mathlib
+(`CategoryTheory.Sites.SheafCohomology.Cech`). Given a family of objects
+U : ι → C in a category C with finite products, the Čech complex functor
+sends a presheaf P : Cᵒᵖ ⥤ A to the cochain complex which in degree n
+consists of the product, indexed by i : Fin (n+1) → ι, of the value of
+P on the product of the objects U (i a) for a : Fin (n+1).
+
+This is the combinatorial cochain complex associated to a covering family.
+In good situations (e.g. sheaves on a site with enough structure), the
+cohomology of this complex computes the sheaf cohomology H^n.
+
+Key constructions bridged from Mathlib:
+
+  - `FormalCoproduct.cosimplicialObjectFunctor` :
+      Simplicial object in FormalCoproduct C ⟹ (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A
+  - `FormalCoproduct.cochainComplexFunctor` :
+      Simplicial object in FormalCoproduct C ⟹ (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+  - `cechComplexFunctor` :
+      (ι → C) ⟹ (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+
+The construction goes through the category `FormalCoproduct C` (the free
+formal coproduct completion of C), where a family U : ι → C is packaged
+as a single object, and its "Čech object" is a simplicial object whose
+degree-n part is indexed by Fin (n+1) → ι.
+
+Epic #1646, See #2159. All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.SheafCohomology.Cech
+
+universe w t v v' u u'
+
+namespace Grothendieck.SheafCohomology.Cech_en
+
+open CategoryTheory Category Opposite Limits
+
+variable {C : Type u} [Category.{v} C]
+
+/-! ## 1. The cosimplicial object functor
+
+Given a simplicial object `E` in the category `FormalCoproduct C` of
+formal coproducts, `cosimplicialObjectFunctor E` is the functor
+
+  (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A
+
+which sends a presheaf P : Cᵒᵖ ⥤ A to the cosimplicial object obtained
+by "evaluating" P on E (using the formal-coproduct structure).
+
+This is the input to the alternating-coface-map construction of the
+cochain complex.
+-/
+
+-- cosimplicialObjectFunctor: from a simplicial formal coproduct to a
+-- functor (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A.
+#check @CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor
+
+/-! ## 2. The cochain complex functor
+
+Composing `cosimplicialObjectFunctor` with the alternating coface map
+construction (`AlgebraicTopology.alternatingCofaceMapComplex`) gives
+the cochain complex functor
+
+  (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+
+which sends a presheaf to the associated alternating cochain complex.
+-/
+
+-- cochainComplexFunctor: from a simplicial formal coproduct to a
+-- functor (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ.
+#check @CategoryTheory.Limits.FormalCoproduct.cochainComplexFunctor
+
+/-! ## 3. The Čech complex functor
+
+Given a family of objects U : ι → C in a category C with finite products,
+`cechComplexFunctor U` is the functor
+
+  (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ
+
+which sends a presheaf P : Cᵒᵖ ⥤ A to the Čech cochain complex. In
+degree n, this complex consists of the product, indexed by
+i : Fin (n + 1) → ι, of the value of P on the product of the objects
+U (i a) for a : Fin (n + 1).
+
+This is the classical Čech complex associated to the covering family {U j}.
+-/
+
+-- cechComplexFunctor: the Čech complex functor for a family U : ι → C.
+#check @CategoryTheory.cechComplexFunctor
+
+/-! ## 4. Bridge theorems
+
+Bridge theorems connecting the Čech complex functor to concrete
+verification.
+-/
+
+/-- Bridge construction: given a family of objects U : ι → C and a
+    presheaf P : Cᵒᵖ ⥤ A (in a preadditive category with products),
+    this is the degree-n part of the Čech complex of P with respect
+    to U, as an object of A. -/
+noncomputable def cechComplexObj
+    {A : Type u'} [Category.{v'} A] [HasProducts.{w} A] [Preadditive A]
+    [HasFiniteProducts C] {ι : Type w} (U : ι → C)
+    (P : Cᵒᵖ ⥤ A) (n : ℕ) : A :=
+  ((CategoryTheory.cechComplexFunctor U).obj P).X n
+
+/-- Bridge theorem (type restatement): the Čech complex functor sends a
+    presheaf P : Cᵒᵖ ⥤ A to a cochain complex indexed by ℕ. This is the
+    type-level restatement that `cechComplexFunctor U` has source
+    `(Cᵒᵖ ⥤ A)` and target `CochainComplex A ℕ`. Marked `noncomputable`
+    because it delegates to the noncomputable Mathlib definition. -/
+noncomputable def cechComplexFunctor_type
+    {A : Type u'} [Category.{v'} A] [HasProducts.{w} A] [Preadditive A]
+    [HasFiniteProducts C] {ι : Type w} (U : ι → C) :
+    (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ :=
+  CategoryTheory.cechComplexFunctor U
+
+end Grothendieck.SheafCohomology.Cech_en


### PR DESCRIPTION
## i18n(#4980): SheafCohomology/Cech root -- FR-first sibling pair

### Substance

Sibling pair FR canonical + EN mirror pour `SheafCohomology/Cech.lean` (cohomologie de Cech sur les faisceaux).

| Fichier | Type | Bytes | LF | CR |
|---------|------|-------|----|----|
| `Cech.lean` (FR) | modified | 5207 | 130 | 0 |
| `Cech_en.lean` (EN) | new | 4804 | 123 | 0 |

**Anti-Section D L298** : stripped bodies **byte-identique 937/937 B** LF.

**C404-L1** awk real-mode sorry count : **0/0** (FR + EN).

### Contenu

Le module etablit un pont vers la **cohomologie de Cech** de Mathlib (`CategoryTheory.Sites.SheafCohomology.Cech`).

- 4 sections thematiques :
  1. Le foncteur en objet cosimplicial
  2. Le foncteur en complexe de cochaines
  3. Le foncteur du complexe de Cech
  4. Theoremes ponts (2 noncomputable defs)
- 3 `#check` verifiant les API Mathlib 4 sous-jacentes
- 2 `noncomputable def` (cechComplexObj, cechComplexFunctor_type) -- wrappers sur API Mathlib 4

### Reference

- EPIC #4980 (i18n Lean convention, ratifiee user 2026-07-04, Option A)
- PR #6308 (16e Phase 2+, SheafCohomology/MayerVietoris, c.406)
- PR #6304 (15e Phase 2+, SheafCohomology/Basic, c.405)
- PR #5883 (pilote sibling pair FR/EN, CooperativeGames.lean, c.349)

### Anti-Section D byte-identity on-disk

```
[OK] FR stripped: 937 B
[OK] EN stripped: 937 B
[OK] Byte-identique: True
```

Strip function :
- Strip header (jusqu'au premier `/-!`)
- Strip toutes les sections `/-! ... -/`
- Strip tous les theorem docs `/-- ... -/`
- Strip `--` comment lines
- Normalize `namespace X_en` -> `namespace X` et `end X_en` -> `end X`

### Verifications

| Check | FR | EN |
|-------|----|----|
| byte[0] = `/` | OK | OK |
| LF-only CR=0 | OK | OK |
| namespace `_en` suffix | (FR=n/a) | OK |
| def count | 2 | 2 |
| `#check` count | 3 | 3 |
| sorry count (awk real-mode) | 0 | 0 |
| stripped byte-identique | 937 B | 937 B |

🤖 Generated with [Claude Code](https://claude.com/claude-code)