### PR TITLE
Fix: remove %pip install source-leak in Search-11-Metaheuristics (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
@@ -58,26 +58,10 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q numpy matplotlib pandas mealpy\n",
+    "# Dependencies pre-provisionnees (numpy matplotlib pandas mealpy) : voir requirements.txt.\n",
+    "# Aucun install requis dans le notebook ; import et invalidation des caches ci-dessous.\n",
     "\n",
     "import importlib, site\n",
     "importlib.invalidate_caches()"


### PR DESCRIPTION
## Summary

`fix(search):` remove `%pip install` source-leak in **Search-11-Metaheuristics** (Stop & Repair, coordinated #6314 pip-sweep, MA Search partition).

cell[1] ran `%pip install -q numpy matplotlib pandas mealpy` **unconditionally in SOURCE**. On every re-exec, the output embedded pip boot notice: `[notice] A new release of pip is available: 25.2 -> 26.1.2 ... python.exe -m pip --upgrade pip`. Repo is **PUBLIC** → env-hygiene anti-pattern + potential path leak vector.

## Fix — Stop & Repair (cause-level, not output-scrub)

- Remove the `%pip install -q ...` line (all 4 deps — numpy, matplotlib, pandas, mealpy — pre-provisioned in `requirements.txt`, verified installed locally, règle F).
- Keep the real code: `import importlib, site` + `importlib.invalidate_caches()`.
- Add dependency comment naming the 4 deps + requirements.txt pointer.
- Papermill re-exec end-to-end (51/51 cells, exit 0).

## §H.5 verdict: EXEC_PROVED

Firsthand verification (papermill re-exec + regex leak-scan incl. metadata):
- **0 leak finding** in the notebook JSON (no `site-packages`, `AppData`, `Python313`, `~penai`, `Defaulting to user installation`, `Requirement already satisfied`, `new release of pip`, `python.exe -m pip`).
- **metadata.papermill.output_path = basename** (`s11_exec_tmp.ipynb`) — applied preventively per lesson C472-L1 (short papermill output_path).
- **exec_count sequential 1..20** (all 20 code cells executed end-to-end).
- **source-diff scope = cell[1] only** (C.3 — strict scope; 19 other code cells source byte-identical).
- H.3 pre-commit: no `execution_count is None AND not outputs` cell.

## Scope check (G.4)

1 file, 1 cell, 1 sujet. Atomic.

## Anti-régression (rule D) — none

No Lean/proof/`sorry`. Source-leak fix, not regression (deps pre-provisioned, re-exec green).

## Catalog (R1) — N/A

## Coordination

Sibling of the #6314 pip-sweep: #6310 (Search-3), #6313 (CSP-1), #6316 (Search-10), #6317 (App-6), #6319 (Tweety-7b), #6322 (Probas-Pyro), #6324 (Argument_Analysis), #6330 (App-2), #6337 (App-11).

See #6314 (the pip detector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
