### PR TITLE
Fix: remove %pip install source-leak in Search-11-Metaheuristics (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
@@ -58,29 +58,10 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q numpy matplotlib pandas mealpy\n",
-    "\n",
-    "import importlib, site\n",
-    "importlib.invalidate_caches()"
+    "# Dependances pre-provisionnees (numpy matplotlib pandas mealpy 3.x) : deps standards + mealpy.\n",
+    "# Aucun install requis dans le notebook ; imports directs dans les cellules suivantes."
    ]
   },
   {


### PR DESCRIPTION
## What

Stop & Repair of a **source-level pip source-leak** in `Search-11-Metaheuristics.ipynb`, fixed at the cause + papermill re-exec (NOT output-scrub). Sibling of the coordinated `#6314` pip sweep (#6310 Search-3, #6313 CSP-1, #6316 Search-10, #6317 App-6, #6319 Tweety-7b, #6322 Probas-Pyro, #6325 Search-9, #6330 App-2, #6337 App-11).

## Defect — cell[1] `%pip install` source-leak

```diff
-%pip install -q numpy matplotlib pandas mealpy
-
-import importlib, site
-importlib.invalidate_caches()
+# Dependances pre-provisionnees (numpy matplotlib pandas mealpy 3.x) : deps standards + mealpy.
+# Aucun install requis dans le notebook ; imports directs dans les cellules suivantes.
```

cell[1] ran an **unconditional `%pip install` in SOURCE**. On every re-exec, the output embedded the worker's pip notice:
```
[notice] A new release of pip is available: 25.2 -> 26.1.2
[notice] To update, run: python.exe -m pip install --upgrade pip
```
Repo is **PUBLIC** → leak of maintainer pip/pipx env topology (secrets-hygiene rule 6, triage C = source-leak). The `invalidate_caches()` after install is pointless once the install is gone — removed.

## Fix — Stop & Repair (cause-level, not output-scrub)

- Remove the `%pip install` line (all 4 deps — numpy, matplotlib, pandas, **mealpy 3.0.2** — verified importable in the worker env BEFORE re-exec, règle F).
- Replace with a dependency comment naming the 4 deps.
- Papermill re-exec end-to-end (python3 kernel, 20/20 code cells, exit 0).

## §H.5 verdict: EXEC_PROVED

Firsthand verification (papermill re-exec + regex leak-scan):
- **0 machine-path leak** in outputs (`AppData|site-packages|Python313|new release of pip|Requirement already|Defaulting to user`).
- **0 `!pip`/`%pip` install** in source.
- **exec_count sequential 1..20** (all 20 code cells executed end-to-end, 0 nulls).
- **source-diff scope = cell[1] only** (C.3 — strict scope; 19 other code cells source byte-identical).
- H.3 pre-commit: no `execution_count is None AND not outputs` cell.

## Scope check (G.4)

1 file, 1 cell, 1 sujet (pip source-leak Stop & Repair). Atomic.

## Anti-régression (rule D) — none

No Lean/proof/`sorry`. The `%pip install` removal is a source-leak fix, not a regression (deps pre-provisioned, re-exec green).

## Coordination

Sibling of the #6314 pip-sweep. `See #6314` (the pip detector), `See #6309` (broader probe/path-leak hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
