### PR TITLE
Fix: remove %pip install source-leak in App-9-EdgeDetection (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
@@ -130,17 +130,10 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install pygad deap scipy matplotlib numpy -q"
+    "# Dependencies pre-provisionnees (pygad deap scipy matplotlib numpy) : voir Search/requirements.txt.\n",
+    "# Aucun install requis dans le notebook ; imports directs dans les cellules suivantes."
    ]
   },
   {


### PR DESCRIPTION
## Summary

`fix(search):` remove `%pip install` source-leak in **App-9-EdgeDetection** (Stop & Repair, coordinated #6314 pip-sweep, MA Search partition). **Last Search-partition residual** of the #6314 sweep.

cell[3] ran `%pip install pygad deap scipy matplotlib numpy -q` **unconditionally in SOURCE**. On every re-exec, the output embedded pip boot notice: `Note: you may need to restart the kernel to use updated packages.` Repo is **PUBLIC**. #6287 scrubbed the OUTPUT (merged) but left the SOURCE leak — this fixes the cause (C460-L1: source-level removal, not output-scrub).

## Fix — Stop & Repair (cause-level)

- Remove the `%pip install -q ...` line (all 5 deps — pygad, deap, scipy, matplotlib, numpy — pre-provisioned in `MyIA.AI.Notebooks/Search/requirements.txt`, verified installed locally, règle F).
- Replace with a dependency comment naming the 5 deps + requirements.txt pointer.
- Papermill re-exec **44/44 cells green, exit 0** — proves the notebook runs end-to-end without the pip line.

## §H.5 verdict: EXEC_PROVED

Firsthand verification:
- **0 leak finding** in the notebook JSON (no `restart the kernel`, `site-packages`, `AppData`, `Python3xx`, `~penai`, `Requirement already`, `new release of pip`).
- **cell[3]**: exec=1, outputs=0 (comment cell — consistent, comments produce no output).
- **source-diff scope = cell[3] only** (C.3 — +3/-10). **Surgical edit per C475-L1**: App-9 uses pygad/deap (stochastic genetic algorithms), so papermill full re-exec would churn GA outputs (random trajectories/convergence). Re-exec was used as PROOF the notebook is green; its output was DISCARDED. The committed version is a surgical edit of origin/main's blob (`json.dumps indent=1 ensure_ascii=False` round-trip byte-identical verified), preserving all other cells byte-identical.
- exec_counts preserved on all cells except the edited cell[3] (now a no-output comment, exec=1).
- metadata.papermill normalized to basename (C472-L1).

## Scope check (G.4)

1 file, 1 cell, 1 sujet. Atomic.

## Anti-régression (rule D) — none

No Lean/proof/`sorry`. Source-leak fix, not regression (deps pre-provisioned, re-exec green).

## Catalog (R1) — N/A

## Coordination

Sibling of the #6314 pip-sweep: #6310 (Search-3), #6313 (CSP-1), #6316 (Search-10), #6317 (App-6), #6319 (Tweety-7b), #6322 (Probas-Pyro), #6324 (Argument_Analysis), #6325 (Search-9), #6330 (App-2), #6337 (App-11), #6341 (Search-11). This App-9 fix closes the Search-partition residuals of the sweep.

See #6314 (the pip detector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
