### PR TITLE
Fix: remove pip install source-leaks in CaseStudies Diagnostic-Medical + Oncology-Planning (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
@@ -63,42 +63,10 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: numpy in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (2.4.2)\n",
-      "Requirement already satisfied: pandas in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.0.2)\n",
-      "Requirement already satisfied: matplotlib in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.10.8)\n",
-      "Requirement already satisfied: seaborn in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (0.13.2)\n",
-      "Requirement already satisfied: z3-solver in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (4.16.0.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2026.1)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (1.3.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (0.12.1)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (4.61.1)\n",
-      "Requirement already satisfied: kiwisolver>=1.3.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (1.4.9)\n",
-      "Requirement already satisfied: packaging>=20.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from matplotlib) (25.0)\n",
-      "Requirement already satisfied: pillow>=8 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (12.1.1)\n",
-      "Requirement already satisfied: pyparsing>=3 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (3.3.2)\n",
-      "Requirement already satisfied: six>=1.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Installation des dépendances requises\n",
-    "%pip install numpy pandas matplotlib seaborn z3-solver"
+    "# Dependances pre-provisionnees (numpy pandas matplotlib seaborn z3-solver).\n",
+    "# Aucun install requis : voir CaseStudies/requirements.txt ; imports directs en cellule suivante."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
@@ -63,42 +63,10 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: numpy in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (2.3.4)\n",
-      "Requirement already satisfied: pandas in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (3.0.1)\n",
-      "Requirement already satisfied: matplotlib in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (3.10.8)\n",
-      "Requirement already satisfied: seaborn in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (0.13.2)\n",
-      "Requirement already satisfied: z3-solver in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (4.16.0.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from pandas) (2025.2)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from matplotlib) (1.3.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from matplotlib) (0.12.1)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from matplotlib) (4.61.1)\n",
-      "Requirement already satisfied: kiwisolver>=1.3.1 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from matplotlib) (1.4.9)\n",
-      "Requirement already satisfied: packaging>=20.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from matplotlib) (25.0)\n",
-      "Requirement already satisfied: pillow>=8 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from matplotlib) (11.3.0)\n",
-      "Requirement already satisfied: pyparsing>=3 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from matplotlib) (3.3.2)\n",
-      "Requirement already satisfied: six>=1.5 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 24.0 -> 26.0.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Installation des dépendances requises\n",
-    "%pip install numpy pandas matplotlib seaborn z3-solver"
+    "# Dependances pre-provisionnees (numpy pandas matplotlib seaborn z3-solver).\n",
+    "# Aucun install requis : voir CaseStudies/requirements.txt ; imports directs en cellule suivante."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
@@ -63,59 +63,10 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: rdflib in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (7.6.0)\n",
-      "Requirement already satisfied: ortools in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (9.15.6755)\n",
-      "Requirement already satisfied: pyro-ppl in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (1.9.1)\n",
-      "Requirement already satisfied: torch in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (2.11.0+cu128)\n",
-      "Requirement already satisfied: pandas in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.0.2)\n",
-      "Requirement already satisfied: matplotlib in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.10.8)\n",
-      "Requirement already satisfied: seaborn in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (0.13.2)\n",
-      "Requirement already satisfied: pyparsing<4,>=2.1.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from rdflib) (3.3.2)\n",
-      "Requirement already satisfied: absl-py>=2.0.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (2.4.0)\n",
-      "Requirement already satisfied: numpy>=2.0.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (2.4.2)\n",
-      "Requirement already satisfied: protobuf<6.34,>=6.33.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (6.33.5)\n",
-      "Requirement already satisfied: typing-extensions>=4.12 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from ortools) (4.15.0)\n",
-      "Requirement already satisfied: immutabledict>=3.0.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (4.3.1)\n",
-      "Requirement already satisfied: opt-einsum>=2.3.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyro-ppl) (3.4.0)\n",
-      "Requirement already satisfied: pyro-api>=0.1.1 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pyro-ppl) (0.1.2)\n",
-      "Requirement already satisfied: tqdm>=4.36 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pyro-ppl) (4.67.3)\n",
-      "Requirement already satisfied: filelock in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (3.25.2)\n",
-      "Requirement already satisfied: setuptools<82 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from torch) (80.9.0)\n",
-      "Requirement already satisfied: sympy>=1.13.3 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (1.14.0)\n",
-      "Requirement already satisfied: networkx>=2.5.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (3.6.1)\n",
-      "Requirement already satisfied: jinja2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (3.1.6)\n",
-      "Requirement already satisfied: fsspec>=0.8.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (2026.2.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2026.1)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (1.3.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (0.12.1)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (4.61.1)\n",
-      "Requirement already satisfied: kiwisolver>=1.3.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (1.4.9)\n",
-      "Requirement already satisfied: packaging>=20.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from matplotlib) (25.0)\n",
-      "Requirement already satisfied: pillow>=8 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (12.1.1)\n",
-      "Requirement already satisfied: six>=1.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n",
-      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from sympy>=1.13.3->torch) (1.3.0)\n",
-      "Requirement already satisfied: colorama in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from tqdm>=4.36->pyro-ppl) (0.4.6)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from jinja2->torch) (3.0.3)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!pip install rdflib ortools pyro-ppl torch pandas matplotlib seaborn"
+    "# Dependances pre-provisionnees (rdflib ortools pyro-ppl torch pandas matplotlib seaborn).\n",
+    "# Aucun install requis : voir CaseStudies/requirements.txt ; imports directs en cellule suivante."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
@@ -63,59 +63,10 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: rdflib in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (7.6.0)\n",
-      "Requirement already satisfied: ortools in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (9.15.6755)\n",
-      "Requirement already satisfied: pyro-ppl in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (1.9.1)\n",
-      "Requirement already satisfied: torch in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (2.11.0+cu128)\n",
-      "Requirement already satisfied: pandas in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.0.2)\n",
-      "Requirement already satisfied: matplotlib in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (3.10.8)\n",
-      "Requirement already satisfied: seaborn in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (0.13.2)\n",
-      "Requirement already satisfied: pyparsing<4,>=2.1.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from rdflib) (3.3.2)\n",
-      "Requirement already satisfied: absl-py>=2.0.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (2.4.0)\n",
-      "Requirement already satisfied: numpy>=2.0.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (2.4.2)\n",
-      "Requirement already satisfied: protobuf<6.34,>=6.33.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (6.33.5)\n",
-      "Requirement already satisfied: typing-extensions>=4.12 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from ortools) (4.15.0)\n",
-      "Requirement already satisfied: immutabledict>=3.0.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (4.3.1)\n",
-      "Requirement already satisfied: opt-einsum>=2.3.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pyro-ppl) (3.4.0)\n",
-      "Requirement already satisfied: pyro-api>=0.1.1 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pyro-ppl) (0.1.2)\n",
-      "Requirement already satisfied: tqdm>=4.36 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pyro-ppl) (4.67.3)\n",
-      "Requirement already satisfied: filelock in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (3.25.2)\n",
-      "Requirement already satisfied: setuptools<82 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from torch) (80.9.0)\n",
-      "Requirement already satisfied: sympy>=1.13.3 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (1.14.0)\n",
-      "Requirement already satisfied: networkx>=2.5.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (3.6.1)\n",
-      "Requirement already satisfied: jinja2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (3.1.6)\n",
-      "Requirement already satisfied: fsspec>=0.8.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from torch) (2026.2.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas) (2026.1)\n",
-      "Requirement already satisfied: contourpy>=1.0.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (1.3.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (0.12.1)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (4.61.1)\n",
-      "Requirement already satisfied: kiwisolver>=1.3.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (1.4.9)\n",
-      "Requirement already satisfied: packaging>=20.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from matplotlib) (25.0)\n",
-      "Requirement already satisfied: pillow>=8 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from matplotlib) (12.1.1)\n",
-      "Requirement already satisfied: six>=1.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n",
-      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from sympy>=1.13.3->torch) (1.3.0)\n",
-      "Requirement already satisfied: colorama in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from tqdm>=4.36->pyro-ppl) (0.4.6)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from jinja2->torch) (3.0.3)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!pip install rdflib ortools pyro-ppl torch pandas matplotlib seaborn"
+    "# Dependances pre-provisionnees (rdflib ortools pyro-ppl torch pandas matplotlib seaborn).\n",
+    "# Aucun install requis : voir CaseStudies/requirements.txt ; imports directs en cellule suivante."
    ]
   },
   {


### PR DESCRIPTION
## What

Stop & Repair of **source-level `%pip`/`!pip install` source-leaks** in the **CaseStudies** family (4 notebooks: 2 CaseStudies × {solution, student}). Fixed at the cause + papermill re-exec (NOT output-scrub). Sibling of the coordinated `#6314` pip sweep.

| Notebook | pip cell | deps installed | 
|----------|----------|----------------|
| CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb | cell[1] | numpy pandas matplotlib seaborn z3-solver |
| CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb | cell[1] | numpy pandas matplotlib seaborn z3-solver |
| CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb | cell[2] | rdflib ortools pyro-ppl torch pandas matplotlib seaborn |
| CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb | cell[2] | rdflib ortools pyro-ppl torch pandas matplotlib seaborn |

## Defect — `%pip`/`!pip install` source-leak

Each notebook ran an **unconditional `%pip`/`!pip install` in SOURCE**. On every re-exec, the output embedded the worker's machine install paths:
```
Requirement already satisfied: numpy in c:\users\jsboi\appdata\roaming\python\python313\site-packages (2.4.2)
Requirement already satisfied: ortools in c:\users\jsboi\appdata\roaming\python\python313\site-packages (9.15.6755)
...
```
Repo is **PUBLIC** → leak of maintainer env topology (secrets-hygiene rule 6, triage C = source-leak). Same defect class as #6310/#6313/#6316/#6317/#6325/#6330/#6337/#6341.

## Fix — Stop & Repair (cause-level, not output-scrub)

- Remove the `%pip`/`!pip install` line in each (all deps pre-provisioned in `MyIA.AI.Notebooks/CaseStudies/requirements.txt` — numpy, pandas, matplotlib, seaborn, z3-solver, ortools, rdflib, pyro-ppl, torch; all 9 verified importable in the worker env BEFORE re-exec, règle F).
- Replace with a dependency comment naming the deps + requirements.txt pointer.
- Papermill re-exec end-to-end (python3 kernel, all code cells, exit 0) as PROOF; **surgical splice commit** (main bytes + changed-cell only) → minimal diff per the papermill-metadata-duration-churn lesson (full re-exec upd `metadata.papermill.duration` on every cell).

## §H.5 verdict: EXEC_PROVED

Firsthand verification (per notebook, post-splice):
- **exec_count sequential** (1..16 solution / 1..13 student for Diagnostic; 1..N Oncology), **0 nulls**.
- **0 machine-path leak** in outputs (`AppData|site-packages|n2kfra8p0|new release of pip|Requirement already|Defaulting to user`).
- **0 `!pip`/`%pip install`** in source.
- **0 error-type outputs**.
- H.3 pre-commit: no `execution_count is None AND not outputs` cell.

## Scope check (G.4)

4 files, 1 cell each, 1 sujet (pip source-leak Stop & Repair, one CaseStudies family). Atomic.

## Anti-régression (rule D) — none

No Lean/proof/`sorry`. The `pip install` removal is a source-leak fix, not a regression (deps pre-provisioned, re-exec green).

## Coordination

Sibling of the `#6314` pip-sweep. `See #6314` (the pip detector), `See #6309` (broader probe/path-leak hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
