### PR TITLE
fix(semanticweb): remove pip source-leaks in 11 SW Python notebooks (#6314)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
@@ -93,17 +93,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q rdflib"
+    "# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
@@ -98,17 +98,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q rdflib owlready2 kglab networkx matplotlib pyvis pandas"
+    "# Dependances pre-provisionnees (rdflib owlready2 kglab networkx matplotlib pyvis pandas) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
@@ -87,17 +87,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q rdflib networkx matplotlib openai anthropic python-dotenv pandas"
+    "# Dependances pre-provisionnees (rdflib networkx matplotlib openai anthropic python-dotenv pandas) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
@@ -80,18 +80,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Installation silencieuse de rdflib\n",
-    "%pip install -q rdflib"
+    "# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
@@ -53,27 +53,9 @@
      "shell.execute_reply": "2026-07-07T01:53:42.707547Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Installation silencieuse de rdflib\n",
-    "%pip install -q rdflib"
+    "# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
@@ -80,17 +80,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q rdflib"
+    "# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
@@ -81,17 +81,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q SPARQLWrapper"
+    "# Dependances pre-provisionnees (SPARQLWrapper) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
@@ -55,27 +55,9 @@
      "shell.execute_reply": "2026-07-07T01:32:36.658941Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Installation silencieuse des dependances\n",
-    "%pip install -q rdflib owlrl\n"
+    "# Dependances pre-provisionnees (rdflib owlrl) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
@@ -81,17 +81,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q owlready2"
+    "# Dependances pre-provisionnees (owlready2) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
@@ -75,17 +75,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q rdflib pyshacl"
+    "# Dependances pre-provisionnees (rdflib pyshacl) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
@@ -74,17 +74,9 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -q rdflib"
+    "# Dependances pre-provisionnees (rdflib) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.\n"
    ]
   },
   {


### PR DESCRIPTION
## What

Stop & Repair of **pip source-leak** across the **SemanticWeb Python series** (11 notebooks). All cited dependencies are pre-provisioned in `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/requirements.txt`, so the `%pip install` lines are redundant and leak pip advisory output (`[notice] A new release of pip is available` / `Note: you may need to restart the kernel`) into cell stderr. Removed at source (class C source-leak), outputs cleared, downstream byte-identical. Sibling of the coordinated `#6314` pip sweep (#6341 Search-11, #6344 CaseStudies, #6346 rl_2).

## Scope — 11 notebooks, cell[2] only (surgical splice)

| Notebook | Removed pip line | Deps (all pre-provisioned) |
|----------|------------------|----------------------------|
| SW-2b-Python-RDFBasics | `%pip install -q rdflib` | rdflib 7.6.0 |
| SW-3b-Python-GraphOperations | `%pip install -q rdflib` | rdflib |
| SW-4b-Python-SPARQL | `%pip install -q rdflib` | rdflib |
| SW-5b-Python-LinkedData | `%pip install -q SPARQLWrapper` | SPARQLWrapper 2.0.0 |
| SW-6b-Python-RDFS | `%pip install -q rdflib owlrl` | rdflib, owlrl 7.1.4 |
| SW-7b-Python-OWL | `%pip install -q owlready2` | owlready2 |
| SW-8-Python-SHACL | `%pip install -q rdflib pyshacl` | rdflib, pyshacl 0.31.0 |
| SW-9-Python-JSONLD | `%pip install -q rdflib` | rdflib |
| SW-10-Python-RDFStar | `%pip install -q rdflib` | rdflib |
| SW-11-Python-KnowledgeGraphs | `%pip install -q rdflib owlready2 kglab networkx matplotlib pyvis pandas` | all 7 |
| SW-12-Python-GraphRAG | `%pip install -q rdflib networkx matplotlib openai anthropic python-dotenv pandas` | all 7 |

Each cell[2] replaced with a French comment: `# Dependances pre-provisionnees (<deps>) : voir SemanticWeb/requirements.txt ; imports dans les cellules suivantes.` Outputs cleared, `execution_count=1` preserved (cell still runs, produces no output).

## Verification (firsthand, papermill python3 kernel, exit 0)

- `0` `%pip install` in source across all 11; `0` leak in cell[2] (pip-notice `restart the kernel` / `[notice] A new release of pip` cleared)
- All 13 cited deps importable + present in `SemanticWeb/requirements.txt` (rdflib 7.6.0, owlready2, pyshacl 0.31.0, SPARQLWrapper 2.0.0, networkx 3.6.1, owlrl 7.1.4, kglab 0.7.0, pyvis, matplotlib, pandas, openai, anthropic, dotenv)
- Papermill re-exec PROOF on 8 local-dep notebooks (SW-2b/3b/4b/6b/7b/8/9/10), `--cwd SemanticWeb/` (data/ resolution): **all `exit 0`, 0 errors, 0 stderr** — confirms deps pre-provisioned + notebooks run end-to-end WITHOUT the pip install line. owlrl RDFS inference verified correct (SW-6b: 51→148 triplets, proper type hierarchy), SPARQL queries return results (SW-4b).
- **C.3 scope**: surgical splice touches ONLY cell[2] per notebook (pip source → French comment, outputs cleared, exec_count=1 preserved). Downstream cells retained from main **byte-for-byte** (unchanged source → unchanged outputs; `git diff` shows cell[2] only). Round-trip `json.dumps(indent=1, ensure_ascii=False)` byte-identical on all 11 BEFORE edit → zero serialization churn. +22/-131.
- **Honest note on downstream outputs**: a fresh re-exec produces env-dependent output *variation* vs main's committed values (rdflib Graph set-iteration order, owlrl version formatting, trailing newlines) — this is pre-existing on main and OUT OF SCOPE for this pip-removal PR. Per c.178 splice discipline I retain main's downstream outputs rather than refresh them (refreshing would be C.3 scope-creep AND commit worker-machine env-specific values). The re-exec's role here is PROOF that deps work without pip, not output replacement.
- SW-5b (176s, network fetch), SW-11 (HermiT reasoner), SW-12 (LLM API) NOT re-exec'd (slow/network/API): deps verified importable; splice = cell[2] source only, downstream byte-for-byte from main.

## Out of scope (separate PR)

**SW-11 HermiT Java path-leak (cells 56/73/83)** — different defect class (owlready2 `sync_reasoner_hermit` echoes JVM classpath `java.exe -cp C:\ProgramData\miniconda3\envs\...`). Known latent-leak class, same as SW-13 fixed in #6269 via `debug=0` parameter. Follow-up PR will apply `debug=0` to SW-11's 3 reasoner calls. NOT touched here (G.4 atomic — 1 subject/PR).

See #6314 (pip detector), #6309 (broader probe/path-leak hygiene). Sibling of #6341/#6344/#6346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
