### PR TITLE
fix(semanticweb): SW-11 HermiT JVM classpath leak — owlready2 debug=0

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
@@ -2625,14 +2625,6 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    C:\\Program Files\\Microsoft\\jdk-17.0.18.8-hotspot\\bin\\java.exe -Xmx2000M -cp C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\owlready2\\hermit;C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///<temp>/ontology -Y\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -2647,14 +2639,6 @@
       "  etud_bernard est de type : ['Student']\n",
       "\n",
       "Aucune inconsistance detectee. L'ontologie est coherente.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * HermiT took 1.328338861465454 seconds\n",
-      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
     }
    ],
@@ -2672,7 +2656,7 @@
     "        # Lancer le raisonneur HermiT\n",
     "        print(\"\\nLancement du raisonneur HermiT...\")\n",
     "        with onto:\n",
-    "            owlready2.sync_reasoner_hermit(infer_property_values=True)\n",
+    "            owlready2.sync_reasoner_hermit(infer_property_values=True, debug=0)\n",
     "        print(\"Raisonnement termine.\")\n",
     "\n",
     "        # Afficher l'etat apres raisonnement\n",
@@ -3605,30 +3589,14 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    C:\\Program Files\\Microsoft\\jdk-17.0.18.8-hotspot\\bin\\java.exe -Xmx2000M -cp C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\owlready2\\hermit;C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///<temp>/ontology -Y\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Raisonnement termine.\n",
       "=== Apres raisonnement ===\n",
-      "  Types inferes pour etudiant_lefevre : ['GraduateStudent', 'Person', 'Student', 'Thing']\n",
+      "  Types inferes pour etudiant_lefevre : ['GraduateStudent', 'Student', 'Person', 'Thing']\n",
       "  -> 'Student' : correctement infere\n",
       "  -> 'Person' : correctement infere\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * HermiT took 1.0266869068145752 seconds\n",
-      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
     }
    ],
@@ -3663,7 +3631,7 @@
     "    try:\n",
     "        print(\"Lancement du raisonneur HermiT...\")\n",
     "        with onto2:\n",
-    "            owlready2.sync_reasoner_hermit(infer_property_values=True)\n",
+    "            owlready2.sync_reasoner_hermit(infer_property_values=True, debug=0)\n",
     "        print(\"Raisonnement termine.\")\n",
     "\n",
     "        # Etape 4 : Verifier les types inferes\n",
@@ -4351,14 +4319,6 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    C:\\Program Files (x86)\\Common Files\\Oracle\\Java\\java8path\\java.EXE -Xmx2000M -cp C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\owlready2\\hermit;C:\\ProgramData\\miniconda3\\envs\\coursia-ml-training\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///~/AppData/Local/Temp/tmp<tmpid>\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -4418,7 +4378,7 @@
     "            conflit.is_a.append(onto_check.Professor)\n",
     "\n",
     "        # HermiT (OWL 2 DL) sur ce world isole\n",
-    "        owlready2.sync_reasoner_hermit(check_world)\n",
+    "        owlready2.sync_reasoner_hermit(check_world, debug=0)\n",
     "        print(\"  Aucune incoherence detectee par le raisonneur (inattendu).\")\n",
     "    except owlready2.OwlReadyInconsistentOntologyError:\n",
     "        print(\"  Incoherence detectee par le raisonneur HermiT : un individu ne peut\")\n",


### PR DESCRIPTION
## What

Stop & Repair of the **owlready2/HermiT JVM classpath path-leak** in `SW-11-Python-KnowledgeGraphs.ipynb` (cells 56, 73, 83). This is the documented atomic follow-up carved out of #6348 (G.4 — different defect class than the pip source-leak). Same defect class + fix recipe as SW-13 (#6269, c.167).

## Defect — owlready2 `sync_reasoner_hermit` echoes the JVM command line

On every `sync_reasoner_hermit(...)` call, owlready2 (default `debug=1`) prints the Java launch line to **stderr**, including the full classpath with machine paths:

```
* Owlready2 * Running HermiT...
    C:\Program Files\Microsoft\jdk-17.0.18.8-hotspot\bin\java.exe -Xmx2000M
    -cp C:\ProgramData\miniconda3\envs\coursia-ml-training\Lib\site-packages\owlready2\hermit;...
* Owlready2 * HermiT took 1.32 seconds
```

`C:\ProgramData\miniconda3\envs\coursia-ml-training\...` = worker machine install path (leak). This was **pre-existing on `main`** and latent (only appears when Java is installed on the exec machine — po-2023 has JDK 17 + Oracle Java 8).

## Fix — `debug=0` (cause-level, owlready2 official API parameter)

owlready2 `reasoning.py` prints the JVM command only in the `if debug:` block (`debug=1` is the default). Passing the **official `debug=0` parameter** suppresses this echo at its source → no JVM line → no classpath → no path leak. The reasoning behavior is **unchanged** (HermiT still runs, infers the same types/classifications); only the verbose launch-log is suppressed.

3 calls patched (all in SW-11):

| Cell | Before | After |
|------|--------|-------|
| 56 | `sync_reasoner_hermit(infer_property_values=True)` | `sync_reasoner_hermit(infer_property_values=True, debug=0)` |
| 73 | `sync_reasoner_hermit(infer_property_values=True)` | `sync_reasoner_hermit(infer_property_values=True, debug=0)` |
| 83 | `sync_reasoner_hermit(check_world)` | `sync_reasoner_hermit(check_world, debug=0)` |

## Verification (firsthand, papermill python3 kernel, --cwd SemanticWeb/, JAVA_HOME=JRE8)

- **Papermill re-exec PROOF**: `pm_exit=0`, **0 error outputs** across all 108 cells
- **`0` JVM-classpath leak in stderr across cells 56/73/83** (`ProgramData\|miniconda3\|jdk-17\|java.exe -cp\|site-packages\|Owlready2 \* Running\|HermiT took` all GONE — was 3 stderr-leak cells on main). The full leaky line removed: `C:\ProgramData\miniconda3\envs\coursia-ml-training\Lib\site-packages\owlready2\hermit;...HermiT.jar org.semanticweb.HermiT.cli.CommandLine ...`
- **HermiT reasoning functional and correct** with `debug=0` (behavior unchanged):
  - cell[56]: type listing before/after reasoning (Professor/Course/Department/GraduateStudent)
  - cell[73] (Exercice 3): `Raisonnement termine.` + `Types inferes pour etudiant_lefevre : ['GraduateStudent', 'Student', 'Person', 'Thing']` + `'Student' : correctement infere` + `'Person' : correctement infere`
  - cell[83] (Exercice 3): `Incoherence detectee par le raisonneur HermiT : un individu ne peut etre a la fois Student et Professor (classes disjointes). Resultat attendu.`
- **Env note (Rule F, honest)**: initial re-exec failed cell[73] (`WinError 2`) because `JAVA_HOME` pointed to a since-uninstalled JDK 11 (`d:\Dev\2025-Epita-Intelligence-Symbolique\jdk11\jdk-11.0.2`) and owlready2's PATH-fallback was inconsistent across the cell's `World()` reset. Re-run with `JAVA_HOME=C:\Program Files\Java\jre1.8.0_491` (system JRE, has `bin/java.exe`) → all 3 cells reason consistently + successfully. `debug=0` ensures this Java path does NOT appear in outputs (suppressed at source). The cell[73] failure was pre-existing env fragility, NOT caused by `debug=0`.
- `execution_count` coherent (17/23/27), all code cells with coherent outputs
- **Source-diff scope**: exactly 3 lines added (`debug=0` per cell), outputs cleared of leak in cells 56/73/83 only. **0** unintended source change, **0** churn on the other 105 cells (C.3-compliant surgical splice). +4/−44.

## Relationship

- **#6348** carved this out (G.4 atomic — pip source-leak vs HermiT JVM-echo = 2 distinct defect classes, 2 PRs).
- **#6269** (SW-13, c.167) = the canonical fix for this exact defect class (`debug=0` recipe).
- See #6309 (broader probe/path-leak hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
