### PR TITLE
fix(security): scrub MiniZinc CLI machine-path source-leak in App-8 (#6309)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
@@ -110,17 +110,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Package minizinc disponible (version 0.10.0)\n",
-      "CLI minizinc disponible : ~\\AppData\\Local\\Programs\\MiniZinc\\minizinc.EXE\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OR-Tools CP-SAT disponible pour les comparaisons.\n",
-      "\n",
-      "Imports OK\n"
+      "Package minizinc disponible (version 0.10.0)\nCLI minizinc disponible : minizinc.EXE (dans le PATH)\nOR-Tools CP-SAT disponible pour les comparaisons.\n\nImports OK\n"
      ]
     }
    ],
@@ -131,6 +121,7 @@
     "import textwrap\n",
     "import subprocess\n",
     "import shutil\n",
+    "import os\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
@@ -147,7 +138,8 @@
     "    print(\"Les modeles seront affiches mais pas executes via l'API Python.\")\n",
     "\n",
     "if MINIZINC_CLI_AVAILABLE:\n",
-    "    print(f\"CLI minizinc disponible : {shutil.which('minizinc')}\")\n",
+    "    _cli = shutil.which('minizinc')\n",
+    "    print(f\"CLI minizinc disponible : {os.path.basename(_cli)} (dans le PATH)\")\n",
     "else:\n",
     "    print(\"CLI minizinc non trouvee dans le PATH.\")\n",
     "    print(\"Les modeles seront affiches a titre illustratif.\")\n",
@@ -161,7 +153,7 @@
     "except ImportError:\n",
     "    print(\"OR-Tools non installe (pip install ortools).\")\n",
     "\n",
-    "print(\"\\nImports OK\")"
+    "print(\"\\nImports OK\")\n"
    ]
   },
   {


### PR DESCRIPTION
## What

Stop & Repair of a **source-leak (class C)** in `App-8-MiniZinc.ipynb` cell[2]. The cell printed the full machine path of the MiniZinc CLI to committed stdout via `shutil.which('minizinc')`:

```
CLI minizinc disponible : ~\AppData\Local\Programs\MiniZinc\minizinc.EXE
```

This is a worker-machine install path (leak). Sibling of the coordinated security sweep #6309, but a **distinct leak class** from the pip source-leaks (#6314) and probeAddresses banner (#6309): here the *notebook's own code* prints the path, not a library echo or pip notice.

## Fix — source-level (secrets-hygiene rule 6, class C)

Print the **basename** instead of the absolute path:

```python
if MINIZINC_CLI_AVAILABLE:
    _cli = shutil.which('minizinc')
    print(f"CLI minizinc disponible : {os.path.basename(_cli)} (dans le PATH)")
```

New honest output: `CLI minizinc disponible : minizinc.EXE (dans le PATH)` — leak-free, availability info preserved for pedagogy. Added `import os`.

## Re-exec — regle F (Stop & Repair, C477-L1)

MiniZinc CLI **is present on the worker machine** at `~/AppData/Local/Programs/MiniZinc/minizinc.EXE` (just not in PATH). Added the dir to PATH and re-executed cell[2]'s logic to capture the genuine output (package version, CLI basename, OR-Tools availability). This is a real re-exec with the tool properly available — **not a hand-scrub** of the committed output.

## C.3 scope — surgical cell[2]-only edit (C475-L1)

The notebook has **timing-dependent cells** (cells 4, 15, 35 use `time.time` and emit `ms` measurements), so a full papermill re-exec would churn those timing values across many cells (C.3 violation). Applied the surgical method: loaded `origin/main` blob (json.dumps indent=1 round-trip **byte-identical** verified, sha `4ff918730495`), edited **only** cell[2] (source + outputs + exec_count), preserved all 46 other cells byte-identical.

## Verification

| Check | Result |
|-------|--------|
| cells changed vs main | exactly `[2]` |
| new cell[2] machine-path leak | **0** (was: `~\AppData\Local\Programs\MiniZinc\minizinc.EXE`) |
| round-trip byte-identical pre-edit | sha main = rt = `4ff918730495` |
| exec_count | 1 |
| metadata path-leak (C472-L1) | none |
| H.3 validate | 0 errors (1 pre-existing warning, also on main — not a regression) |
| diff | +5/-13, 1 file |

See #6309
