### PR TITLE
i18n(lean,#4980): grothendieck_lean/LeftExact sibling pair FR canonical + EN mirror

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/LeftExact.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/LeftExact.lean
@@ -1,29 +1,29 @@
 /-
-Grothendieck tribute — Part 14: Left exactness of sheafification
+Hommage Grothendieck — Partie 14 : Exactitude à gauche de la faisceautisation
 Alexandre Grothendieck (1928-2014).
 
-Phase 8 extension (#2159, Epic #1646).
+Extension Phase 8 (#2159, Epic #1646).
 
-Part 13 (Sheafification.lean) introduced the sheafification functor and its
-universal property: `presheafToSheaf ⊣ sheafToPresheaf`.
+La Partie 13 (Sheafification.lean) a introduit le foncteur de faisceautisation
+et sa propriété universelle : `presheafToSheaf ⊣ sheafToPresheaf`.
 
-This module records the **exactness properties** of sheafification, following
-Mathlib's `CategoryTheory.Sites.LeftExact`:
+Ce module enregistre les **propriétés d'exactitude** de la faisceautisation,
+à la suite de `CategoryTheory.Sites.LeftExact` de Mathlib :
 
-  - Sheafification preserves finite limits (it is left exact).
-  - The plus construction preserves finite limits.
-  - Categories of sheaves inherit exactness properties from the target:
-    they are finitary extensive, adhesive, and balanced.
+  - La faisceautisation préserve les limites finies (elle est exacte à gauche).
+  - La construction plus préserve les limites finies.
+  - Les catégories de faisceaux héritent des propriétés d'exactitude de la
+    catégorie cible : elles sont finitairement extensives, adhésives et équilibrées.
 
-These are all instances (typeclass resolution), so our bridge theorems
-simply re-expose them in the `Grothendieck` namespace with doc strings
-explaining their significance.
+Ce sont toutes des instances (résolution par classe de types), donc nos théorèmes
+ponts les ré-exposent simplement dans l'espace de noms `Grothendieck` avec des
+docstrings expliquant leur signification.
 
-Universe note: same as Part 13 — `Type (max u v)` for presheaves on
-`C : Type u` with `[Category.{v} C]`, via `HasSheafify J (Type (max u v))`
-from LeftExact.lean.
+Note d'univers : comme la Partie 13 — `Type (max u v)` pour les préfaisceaux sur
+`C : Type u` avec `[Category.{v} C]`, via `HasSheafify J (Type (max u v))`
+de LeftExact.lean.
 
-Epic #1646, Phase 8 (#2159). All `sorry`s eliminated at creation.
+Epic #1646, Phase 8 (#2159). Tous les `sorry`s éliminés à la création.
 -/
 
 import Mathlib.CategoryTheory.Sites.Grothendieck
@@ -39,92 +39,93 @@ open CategoryTheory
 open CategoryTheory.Limits
 
 /-!
-## The plus construction preserves finite limits
+## La construction plus préserve les limites finies
 
-The "plus construction" `P ↦ P⁺` is the first step of sheafification.
-Applying it twice gives the sheafification. That `plusFunctor` preserves
-finite limits is the technical heart of left exactness: it means the
-construction respects products, equalizers, and pullbacks.
+La « construction plus » `P ↦ P⁺` est la première étape de la faisceautisation.
+L'appliquer deux fois donne la faisceautisation. Que `plusFunctor` préserve les
+limites finies est le cœur technique de l'exactitude à gauche : cela signifie
+que la construction respecte les produits, les égaliseurs et les pullbacks.
 
-For `Type (max u v)`-valued presheaves, all the required instances
-(`HasFiniteLimits`, `PreservesFiniteLimits (forget)`, etc.) are
-provided by Mathlib's type-theoretic machinery.
+Pour les préfaisceaux à valeurs dans `Type (max u v)`, toutes les instances
+requises (`HasFiniteLimits`, `PreservesFiniteLimits (forget)`, etc.) sont
+fournies par la machinerie de théorie des types de Mathlib.
 -/
 
-/-- The plus construction `J.plusFunctor` preserves finite limits
-    for Type-valued presheaves. This is the key intermediate result:
-    sheafification = plus ∘ plus, so if plus preserves finite limits,
-    so does sheafification.
-    Uses `preserveFiniteLimits_plusFunctor` from Mathlib's LeftExact. -/
+/-- La construction plus `J.plusFunctor` préserve les limites finies
+    pour les préfaisceaux à valeurs dans Type. C'est le résultat intermédiaire
+    clé : la faisceautisation = plus ∘ plus, donc si plus préserve les limites
+    finies, la faisceautisation aussi.
+    Utilise `preserveFiniteLimits_plusFunctor` du LeftExact de Mathlib. -/
 instance plus_preserves_finite_limits {C : Type u} [Category.{v} C]
     (J : GrothendieckTopology C) :
     PreservesFiniteLimits (J.plusFunctor (Type (max u v))) :=
   inferInstance
 
 /-!
-## presheafToSheaf preserves finite limits
+## presheafToSheaf préserve les limites finies
 
-The concrete sheafification functor `presheafToSheaf` (which goes from
-presheaves to sheaves, unlike `sheafification` which is the endofunctor
-on presheaves) also preserves finite limits.
+Le foncteur concret de faisceautisation `presheafToSheaf` (qui va des
+préfaisceaux aux faisceaux, contrairement à `sheafification` qui est
+l'endofoncteur sur les préfaisceaux) préserve lui aussi les limites finies.
 -/
 
-/-- The concrete sheafification functor `presheafToSheaf` preserves
-    finite limits. This is the version stated for the functor landing
-    in the category of sheaves (rather than the endofunctor on presheaves).
-    Uses `presheafToSheaf_preservesFiniteLimits` from Mathlib. -/
+/-- Le foncteur concret de faisceautisation `presheafToSheaf` préserve
+    les limites finies. C'est la version énoncée pour le foncteur atterrissant
+    dans la catégorie des faisceaux (plutôt que l'endofoncteur sur les préfaisceaux).
+    Utilise `presheafToSheaf_preservesFiniteLimits` de Mathlib. -/
 instance presheaf_to_sheaf_left_exact {C : Type u} [Category.{v} C]
     (J : GrothendieckTopology C) :
     PreservesFiniteLimits (presheafToSheaf J (Type (max u v))) :=
   inferInstance
 
 /-!
-## Categories of sheaves are finitary extensive
+## Les catégories de faisceaux sont finitairement extensives
 
-A category is **finitary extensive** when pullbacks along coproduct
-inclusions exist and the fibration structure is well-behaved. Since
-sheafification is a left exact localization, the category of sheaves
-inherits finitary extensivity from the target category.
+Une catégorie est **finitairement extensive** lorsque les pullbacks le long des
+inclusions de coproduits existent et la structure de fibration est bien élevée.
+Puisque la faisceautisation est une localisation exacte à gauche, la catégorie
+des faisceaux hérite de l'extensivité finitaire de la catégorie cible.
 
-For `Type`-valued sheaves, this means finite coproducts in `Sheaf J`
-behave like disjoint unions with well-behaved pullbacks.
+Pour les faisceaux à valeurs dans `Type`, cela signifie que les coproduits finis
+dans `Sheaf J` se comportent comme des unions disjointes avec des pullbacks
+bien élevés.
 -/
 
-/-- The category of Type-valued sheaves on a site is finitary extensive.
-    This follows from the reflective localization given by sheafification.
-    Uses `SheafOfTypes.finitary_extensive` from Mathlib. -/
+/-- La catégorie des faisceaux à valeurs dans Type sur un site est finitairement
+    extensive. Cela découle de la localisation réflexe donnée par la faisceautisation.
+    Utilise `SheafOfTypes.finitary_extensive` de Mathlib. -/
 instance sheaf_finitary_extensive {C : Type u} [Category.{v} C]
     (J : GrothendieckTopology C) :
     FinitaryExtensive (Sheaf J (Type (max u v))) :=
   inferInstance
 
 /-!
-## Categories of sheaves are adhesive
+## Les catégories de faisceaux sont adhésives
 
-A category is **adhesive** if it has pullbacks, pushouts along
-monomorphisms, and van Kampen colimits. Categories of sheaves on a site
-inherit adhesivity from the target via the reflective localization.
+Une catégorie est **adhésive** si elle a des pullbacks, des pushouts le long
+de monomorphismes, et des colimites de van Kampen. Les catégories de faisceaux
+sur un site héritent de l'adhésivité de la cible via la localisation réflexe.
 -/
 
-/-- The category of Type-valued sheaves on a site is adhesive.
-    Uses `SheafOfTypes.adhesive` from Mathlib. -/
+/-- La catégorie des faisceaux à valeurs dans Type sur un site est adhésive.
+    Utilise `SheafOfTypes.adhesive` de Mathlib. -/
 instance sheaf_adhesive {C : Type u} [Category.{v} C]
     (J : GrothendieckTopology C) :
     Adhesive (Sheaf J (Type (max u v))) :=
   inferInstance
 
 /-!
-## Categories of sheaves are balanced
+## Les catégories de faisceaux sont équilibrées
 
-A category is **balanced** if every morphism that is both monic and epic
-is already an isomorphism. For categories of sheaves of types, this
-means a sheaf morphism that is injective and surjective on sections
-is necessarily an isomorphism.
+Une catégorie est **équilibrée** si tout morphisme à la fois monique et épique
+est déjà un isomorphisme. Pour les catégories de faisceaux de types, cela
+signifie qu'un morphisme de faisceaux qui est injectif et surjectif sur les
+sections est nécessairement un isomorphisme.
 -/
 
-/-- The category of Type-valued sheaves on a site is balanced.
-    A morphism that is both monic and epic is an isomorphism.
-    Uses `SheafOfTypes.balanced` from Mathlib. -/
+/-- La catégorie des faisceaux à valeurs dans Type sur un site est équilibrée.
+    Un morphisme à la fois monique et épique est un isomorphisme.
+    Utilise `SheafOfTypes.balanced` de Mathlib. -/
 instance sheaf_balanced {C : Type u} [Category.{v} C]
     (J : GrothendieckTopology C) :
     Balanced (Sheaf J (Type (max u v))) :=

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/LeftExact_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/LeftExact_en.lean
@@ -1,0 +1,139 @@
+/-
+Grothendieck tribute — Part 14: Left exactness of sheafification (English mirror)
+Alexandre Grothendieck (1928-2014).
+
+Phase 8 extension (#2159, Epic #1646).
+
+Part 13 (Sheafification.lean) introduced the sheafification functor and its
+universal property: `presheafToSheaf ⊣ sheafToPresheaf`.
+
+This module records the **exactness properties** of sheafification, following
+Mathlib's `CategoryTheory.Sites.LeftExact`:
+
+  - Sheafification preserves finite limits (it is left exact).
+  - The plus construction preserves finite limits.
+  - Categories of sheaves inherit exactness properties from the target:
+    they are finitary extensive, adhesive, and balanced.
+
+These are all instances (typeclass resolution), so our bridge theorems
+simply re-expose them in the `Grothendieck_en` namespace with doc strings
+explaining their significance.
+
+Universe note: same as Part 13 — `Type (max u v)` for presheaves on
+`C : Type u` with `[Category.{v} C]`, via `HasSheafify J (Type (max u v))`
+from LeftExact.lean.
+
+Epic #1646, Phase 8 (#2159). All `sorry`s eliminated at creation.
+
+i18n convention (EPIC #4980 ratified by user 2026-07-04, see code-style.md Lean i18n):
+This substantial module is paired with its French canonical counterpart in the sibling
+file `LeftExact.lean` (sibling pair model, see PR #6275 for the pilot on `Calibration.lean`
+and #6197/#6208/#6230/#6235/#6256/#6259 for the broader rollout). Namespace suffix `_en`
+applied to this EN file (anti-collision, conforms to code-style.md #4980).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Sites.SheafOfTypes
+import Mathlib.CategoryTheory.Sites.Sheafification
+import Mathlib.CategoryTheory.Sites.LeftExact
+
+universe v u
+
+namespace Grothendieck_en
+
+open CategoryTheory
+open CategoryTheory.Limits
+
+/-!
+## The plus construction preserves finite limits
+
+The "plus construction" `P ↦ P⁺` is the first step of sheafification.
+Applying it twice gives the sheafification. That `plusFunctor` preserves
+finite limits is the technical heart of left exactness: it means the
+construction respects products, equalizers, and pullbacks.
+
+For `Type (max u v)`-valued presheaves, all the required instances
+(`HasFiniteLimits`, `PreservesFiniteLimits (forget)`, etc.) are
+provided by Mathlib's type-theoretic machinery.
+-/
+
+/-- The plus construction `J.plusFunctor` preserves finite limits
+    for Type-valued presheaves. This is the key intermediate result:
+    sheafification = plus ∘ plus, so if plus preserves finite limits,
+    so does sheafification.
+    Uses `preserveFiniteLimits_plusFunctor` from Mathlib's LeftExact. -/
+instance plus_preserves_finite_limits {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) :
+    PreservesFiniteLimits (J.plusFunctor (Type (max u v))) :=
+  inferInstance
+
+/-!
+## presheafToSheaf preserves finite limits
+
+The concrete sheafification functor `presheafToSheaf` (which goes from
+presheaves to sheaves, unlike `sheafification` which is the endofunctor
+on presheaves) also preserves finite limits.
+-/
+
+/-- The concrete sheafification functor `presheafToSheaf` preserves
+    finite limits. This is the version stated for the functor landing
+    in the category of sheaves (rather than the endofunctor on presheaves).
+    Uses `presheafToSheaf_preservesFiniteLimits` from Mathlib. -/
+instance presheaf_to_sheaf_left_exact {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) :
+    PreservesFiniteLimits (presheafToSheaf J (Type (max u v))) :=
+  inferInstance
+
+/-!
+## Categories of sheaves are finitary extensive
+
+A category is **finitary extensive** when pullbacks along coproduct
+inclusions exist and the fibration structure is well-behaved. Since
+sheafification is a left exact localization, the category of sheaves
+inherits finitary extensivity from the target category.
+
+For `Type`-valued sheaves, this means finite coproducts in `Sheaf J`
+behave like disjoint unions with well-behaved pullbacks.
+-/
+
+/-- The category of Type-valued sheaves on a site is finitary extensive.
+    This follows from the reflective localization given by sheafification.
+    Uses `SheafOfTypes.finitary_extensive` from Mathlib. -/
+instance sheaf_finitary_extensive {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) :
+    FinitaryExtensive (Sheaf J (Type (max u v))) :=
+  inferInstance
+
+/-!
+## Categories of sheaves are adhesive
+
+A category is **adhesive** if it has pullbacks, pushouts along
+monomorphisms, and van Kampen colimits. Categories of sheaves on a site
+inherit adhesivity from the target via the reflective localization.
+-/
+
+/-- The category of Type-valued sheaves on a site is adhesive.
+    Uses `SheafOfTypes.adhesive` from Mathlib. -/
+instance sheaf_adhesive {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) :
+    Adhesive (Sheaf J (Type (max u v))) :=
+  inferInstance
+
+/-!
+## Categories of sheaves are balanced
+
+A category is **balanced** if every morphism that is both monic and epic
+is already an isomorphism. For categories of sheaves of types, this
+means a sheaf morphism that is injective and surjective on sections
+is necessarily an isomorphism.
+-/
+
+/-- The category of Type-valued sheaves on a site is balanced.
+    A morphism that is both monic and epic is an isomorphism.
+    Uses `SheafOfTypes.balanced` from Mathlib. -/
+instance sheaf_balanced {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) :
+    Balanced (Sheaf J (Type (max u v))) :=
+  inferInstance
+
+end Grothendieck_en


### PR DESCRIPTION
## EPIC #4980 — Lean i18n (Option A sibling pair, ratified convention 2026-07-04)

Migrates `grothendieck_lean/Grothendieck/LeftExact.lean` (Part 14: left exactness of sheafification) to **FR-canonical docstrings** + **EN sibling** (`LeftExact_en.lean`, namespace `Grothendieck_en`), following the Option A pattern ratified in `code-style.md` and piloted by #6275 (`Calibration`).

## Forensic §B/§D — code byte-identity (no #6304-class risk)

The file is **5 pure `inferInstance` typeclass re-exposures** — no theorems, no proofs, no tactics, **no `variable` declarations** (the #6304 bug class cannot occur). Verified firsthand:

| Check | Result |
|-------|--------|
| FR code-identity vs EN (namespace-normalized) | ✅ True |
| FR code-identity vs **compiled origin/main baseline** | ✅ True |
| EN code-identity vs **compiled origin/main baseline** | ✅ True |
| Block-comment balance `/-`/`-/` | ✅ 11/11, final_depth=0 |
| Real `sorry` (code, real mode) | ✅ 0 |
| Bare-`sorry`-in-prose (CI #6115 bug class) | ✅ 0 (used `` `sorry`s `` safe plural) |
| CRLF | ✅ 0 |

**Because the code is byte-identical to the compiled baseline, `lake build` cannot break** — only docstrings/comments differ. CI will confirm (`Lean CI (grothendieck_lean)`, ~2min).

## Scope

- `LeftExact.lean`: docstrings/comments EN→FR (code unchanged). Module docstring + 5 section docstrings + 5 instance docstrings translated.
- `LeftExact_en.lean`: new EN mirror (original EN content), namespace `Grothendieck_en`, i18n-convention note added.
- Imports: all Mathlib (no internal `import Grothendieck.X` to suffix) — unchanged.
- **No lakefile change**: `globs := #[`Grothendieck.*]` auto-discovers `_en` siblings (same as merged `Calibration_en` #6275).

## Diff

`+202/-62`, 2 files (1 modified, 1 new). Atomic, single subject.

See #4980. Part of the grothendieck_lean i18n rollout (siblings: #6275 Calibration ✓, #6277 Subcanonical, #6280 DenseTopology, #6284 CoverageGen, #6291 SheafHom, #6304 SheafCohomology/Basic).

Co-Authored-By: Claude-Code <noreply@anthropic.com>