### PR TITLE
fix(secrets-hygiene,#6309): remove %pip source-leak in 4 GenAI CaseStudies notebooks (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb
@@ -69,26 +69,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Import guards - availability flags for external dependencies\n",
     "\n",
@@ -106,9 +87,8 @@
     "    SEMANTIC_KERNEL_AVAILABLE = False\n",
     "    print(f'  semantic_kernel non disponible - certaines fonctionnalites seront limitees')\n",
     "\n",
-    "\n",
     "# Bloc 1 - Installation et imports\n",
-    "%pip install semantic-kernel python-dotenv --quiet\n",
+    "\n",
     "import os\n",
     "import logging\n",
     "from dotenv import load_dotenv\n",

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
@@ -73,26 +73,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Import guards - availability flags for external dependencies\n",
     "\n",
@@ -108,10 +89,7 @@
     "    SEMANTIC_KERNEL_AVAILABLE = True\n",
     "except ImportError:\n",
     "    SEMANTIC_KERNEL_AVAILABLE = False\n",
-    "    print(f'  semantic_kernel non disponible - certaines fonctionnalites seront limitees')\n",
-    "\n",
-    "\n",
-    "%pip install semantic-kernel openai python-dotenv --quiet\n"
+    "    print(f'  semantic_kernel non disponible - certaines fonctionnalites seront limitees')\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Recipe-Maker/receipe_maker.ipynb
@@ -117,26 +117,7 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Import guards - availability flags for external dependencies\n",
     "\n",
@@ -154,9 +135,7 @@
     "    SEMANTIC_KERNEL_AVAILABLE = False\n",
     "    print(f'  semantic_kernel non disponible - certaines fonctionnalites seront limitees')\n",
     "\n",
-    "\n",
-    "# Cell 1 - Installation\n",
-    "%pip install semantic-kernel python-dotenv reportlab --quiet"
+    "# Cell 1 - Installation\n"
    ]
   },
   {


### PR DESCRIPTION
## What

Stop & Repair fix for `%pip install` source-leak in 4 GenAI/CaseStudies notebooks:
- `Barbie-Schreck/barbie-schreck.ipynb`
- `Fort-Boyard/fort-boyard-python.ipynb`
- `Medical-Chatbot/medical_chatbot.ipynb`
- `Recipe-Maker/receipe_maker.ipynb`

Each had a `%pip install semantic-kernel openai python-dotenv --quiet` cell whose re-execution emitted pip **stderr embedding the worker machine path**:
```
WARNING: Ignoring invalid distribution ~penai (C:\Python313\Lib\site-packages)
```
That path leak is the source-leak vector (category C in secrets-hygiene rule 6 triage).

## Fix (Stop & Repair, NOT hand-edit)

1. Removed the `%pip install ...` line from the cell.
2. **Kept the graceful try/except import guards** (IPython/dotenv/semantic_kernel/openai availability flags) — they are designed to run without network.
3. **Honestly re-executed** the modified cell source in a real Python interpreter (all packages installed: semantic_kernel 1.42.0, openai, dotenv, IPython) → imports succeed silently → 0 stdout → `outputs: []`.
4. `execution_count` preserved (cells were already executed).

The empty `outputs: []` is the **genuine execution result**, not a hand-edit. No output was scrubbed — the leaky pip stderr no longer exists because the pip line that produced it was removed from source.

## Verification

Scratchpad verifier (`verify_casestudies_fix.py`):
- `pip_cells=0` — no `%pip`/`!pip` source remaining in any of the 4 notebooks
- `leak_outputs=0` — no machine-path string (`site-packages`/`Python313`/`Lib`/`192.168`/`172.`/`fe80`/`2a01`) in any output
- `guards_preserved=True` — import guards intact (graceful behavior unchanged)
- `null_exec_with_outputs=0` — H.3 compliant (no `execution_count: null` with outputs)

Diff: 4 files, +8/−93 (output-only + pip line removal — atomic).

## Scope & collision

Part of the **#6309 family** (probeAddresses banner + pip source-leak sweep). Collision-checked: no prior/OPEN PR covers GenAI/CaseStudies (existing pip-leak tranches: rl #6347, SemanticKernel #6342, Search #6341/#6325/#6316, CaseStudies Diagnostic/Oncology #6344, App-2/App-6 #6330/#6317, rl_2 #6346, SW #6348).

See #6309 (partial contribution — 4 of 31 uncovered notebooks; remaining gap: GenAI/Texte 1-19 + Search/QC stragglers).