### PR TITLE
fix(search,#6309): scrub !pip install pandas source-leak in Search-3-Informed (Python) — Stop & Repair

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -59,24 +59,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: pandas in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (3.0.3)\n",
-      "Requirement already satisfied: numpy>=1.26.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2.4.4)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pandas) (2025.3)\n",
-      "Requirement already satisfied: six>=1.5 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from python-dateutil>=2.8.2->pandas) (1.17.0)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Environnement pret pour la recherche informee.\n"
      ]
     }
    ],
    "source": [
     "# Imports\n",
-    "!pip install pandas\n",
+    "# Dependances pre-provisionnees (pandas, numpy, networkx, matplotlib) : voir Search/requirements.txt\n",
     "import sys\n",
     "import time\n",
     "import heapq\n",


### PR DESCRIPTION
## Summary

Stop & Repair of a `!pip install pandas` **source-leak** (security #6309) in `Search-3-Informed.ipynb` (Python variant — the **Csharp twin is covered by #6329**, this file is not).

### Defect (leak on PUBLIC repo)

`cell[1]` `!pip install pandas` produced a committed stdout stream leaking the machine username + full Windows Store Python install path:

```
Requirement already satisfied: pandas in C:\Users\jsboi\AppData\Local\Packages\
PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\LocalCache\local-packages\
Python313\site-packages (3.0.3)
Requirement already satisfied: numpy>=1.26.0 in C:\Users\jsboi\...\site-packages (from pandas) (2.4.4)
... (5 lines, all leaking C:\Users\jsboi\...\PythonSoftwareFoundation\...)
```

## Fix — Stop & Repair (secrets-hygiene rule 6)

| Step | Action |
|------|--------|
| **Source fix (C460-L1)** | Removed `!pip install pandas` line; replaced with `# Dependances pre-provisionnees (pandas, numpy, networkx, matplotlib) : voir Search/requirements.txt` |
| **regle F** | `pandas>=2.0` already declared in `Search/requirements.txt` (line 29) — pre-provisioned, no requirements.txt change needed |
| **Re-exec (C477-L1)** | Papermill on a 1-cell temp notebook (`--cwd` Part1-Foundations for `sys.path.insert(0,'..')` → `search_helpers`, C462-L1). Honest output = single stream `Environnement pret pour la recherche informee.` |
| **Surgical (C475-L1)** | Only `cell[1]` modified (source + outputs + execution_count). 23 other code cells byte-identical to `origin/main` (timing cells 10/16/27/53 use `time.time` but don't print timing values → untouched, no churn) |

### C477-L1 proof (contrast #6342 incomplete-repair c.477)

The leaky pip-notice stream is **structurally impossible** after the fix: `!pip install pandas` is the only source of pip output; replacing it with a comment means no pip call → no pip-notice → the clean single-stream output is the **honest re-exec result**, NOT a hand-scrub. (Contrast #6342 where the pip source was removed but the stale leaky output persisted because the cell was never re-executed.)

## Validation (H.3)

- `validate_pr_notebooks.py`: **1/1 PASS** (24 code cells)
- `execution_count = 1` (not null), `outputs` = 1 coherent stream
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1)
- 0 leak in any cell output (grep `jsboi|AppData|site-packages|PythonSoftwareFoundation|Requirement already satisfied` = 0 hits)
- `git diff --stat`: `+1/-12`, 1 file (atomic, R3 OK)

## Scope

- **1 file**, **1 cell** — atomic (G.4 OK, no composite).
- Python variant only; Csharp twin `Search-3-Informed-Csharp.ipynb` covered by **#6329** (banner strip, different file, no collision).
- No catalogue regeneration (catalog-pr-hygiene R1 — catalogue byte-identical to main).

See #6309 (security sweep — partial contribution, epic remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
