### PR TITLE
fix(genai-texte,#6309): scrub %pip install source-leak in 2_PromptEngineering — Stop & Repair

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
@@ -122,42 +122,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Defaulting to user installation because normal site-packages is not writeable\n",
-      "Requirement already satisfied: openai in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (2.41.0)\n",
-      "Requirement already satisfied: tiktoken in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (0.12.0)\n",
-      "Requirement already satisfied: python-dotenv in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (1.2.2)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in c:\\python313\\lib\\site-packages (from openai) (4.9.0)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (1.9.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in c:\\python313\\lib\\site-packages (from openai) (0.28.1)\n",
-      "Requirement already satisfied: jiter<1,>=0.10.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (0.13.0)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (2.13.4)\n",
-      "Requirement already satisfied: sniffio in c:\\python313\\lib\\site-packages (from openai) (1.3.1)\n",
-      "Requirement already satisfied: tqdm>4 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (4.67.3)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.11 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (4.15.0)\n",
-      "Requirement already satisfied: regex>=2022.1.18 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from tiktoken) (2026.2.28)\n",
-      "Requirement already satisfied: requests>=2.26.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from tiktoken) (2.34.2)\n",
-      "Requirement already satisfied: idna>=2.8 in c:\\python313\\lib\\site-packages (from anyio<5,>=3.5.0->openai) (3.10)\n",
-      "Requirement already satisfied: certifi in c:\\python313\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (2025.4.26)\n",
-      "Requirement already satisfied: httpcore==1.* in c:\\python313\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\n",
-      "Requirement already satisfied: h11>=0.16 in c:\\python313\\lib\\site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\n",
-      "Requirement already satisfied: annotated-types>=0.6.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.46.4 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (2.46.4)\n",
-      "Requirement already satisfied: typing-inspection>=0.4.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.4.2)\n",
-      "Requirement already satisfied: charset_normalizer<4,>=2 in c:\\python313\\lib\\site-packages (from requests>=2.26.0->tiktoken) (3.4.2)\n",
-      "Requirement already satisfied: urllib3<3,>=1.26 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from requests>=2.26.0->tiktoken) (1.26.20)\n",
-      "Requirement already satisfied: colorama in c:\\python313\\lib\\site-packages (from tqdm>4->openai) (0.4.6)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+      "Dependances OpenAI pre-chargees avec succes.\n"
      ]
     }
    ],
@@ -166,8 +131,9 @@
     "# Cellule 1 : Installation\n",
     "# ============================\n",
     "\n",
-    "%pip install openai tiktoken python-dotenv\n",
-    "# Remarque : Aucune fin de ligne en commentaire pour éviter l'erreur\n"
+    "# Dependances pre-provisionnees (openai, tiktoken, python-dotenv) : voir GenAI/requirements.txt\n",
+    "import openai, tiktoken, dotenv\n",
+    "print(\"Dependances OpenAI pre-chargees avec succes.\")\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/requirements.txt
+++ b/MyIA.AI.Notebooks/GenAI/requirements.txt
@@ -1,5 +1,6 @@
 ﻿# GenAI CoursIA Phase 2 - Dependances Python
 openai>=1.12.0
+tiktoken>=0.7.0
 anthropic>=0.21.0
 requests>=2.31.0
 pillow>=10.0.0


### PR DESCRIPTION
## Summary

Stop & Repair of a `%pip install` **source-leak** (security #6309) in `GenAI/Texte/2_PromptEngineering.ipynb`. **0 PR OPEN touches GenAI/Texte** — no collision. GenAI/Texte = owner po-2024 (ledger #3801 entry #022).

### Defect (leak on PUBLIC repo)

`cell[3]` `%pip install openai tiktoken python-dotenv` produced committed stdout leaking username + machine Python paths:

```
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: openai in c:\users\jsboi\appdata\roaming\
python\python313\site-packages (2.41.0)
Requirement already satisfied: tiktoken in c:\users\jsboi\...\site-packages (0.12.0)
WARNING: Ignoring invalid distribution ~penai (C:\Python313\Lib\site-packages)
[notice] A new release of pip is available: 25.0.1 -> 26.1.2
```

## Fix — Stop & Repair (secrets-hygiene rule 6)

| Step | Action |
|------|--------|
| **Source fix (C460-L1)** | Removed `%pip install openai tiktoken python-dotenv` line; replaced with pre-provisioned comment + **import validation** (`import openai, tiktoken, dotenv` + print) — confirms deps are available without invoking pip |
| **regle F** | Added `tiktoken>=0.7.0` to `GenAI/requirements.txt` (was absent; openai + python-dotenv already declared). tiktoken 0.12.0 verified installed locally |
| **Re-exec (C477-L1)** | Papermill on a 1-cell temp notebook. cell[3] is install-only (no `OpenAI()` init, no API call) → safe to re-exec without API key. Honest output = single stream `Dependances OpenAI pre-chargees avec succes.` |
| **Surgical (C475-L1)** | Only `cell[3]` modified (source + outputs + execution_count). 20 other code cells byte-identical to `origin/main` (stochastic cell[45] untouched, no churn) |

### C477-L1 proof (contrast #6342 incomplete-repair c.477)

The leaky pip-notice stream is **structurally impossible** after the fix: `%pip install` is the only source of pip output; replacing it with an import validation means no pip call → no pip-notice → the clean single-stream output is the **honest re-exec result**, NOT a hand-scrub.

## Validation (H.3)

- `validate_pr_notebooks.py`: **1/1 PASS** (20 code cells)
- `execution_count = 1` (not null), `outputs` = 1 coherent stream
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1)
- 0 leak in any cell output (grep `jsboi|AppData|site-packages|PythonSoftwareFoundation|Requirement already satisfied|~penai|pip is available` = 0 hits)
- `git diff --stat`: `+5/-38`, 2 files (notebook + requirements.txt), atomic (G.4 OK)

## Scope

- **1 notebook** (`GenAI/Texte/2_PromptEngineering.ipynb`) + `GenAI/requirements.txt` (1 line added: `tiktoken>=0.7.0`).
- **0 collision**: 0 PR OPEN touches `GenAI/Texte/*.ipynb` (file-level search confirmed).
- No catalogue regeneration (catalog-pr-hygiene R1 — catalogue byte-identical to main).

## Note: remaining GenAI/Texte pip-leaks (tracked, not in scope)

7 other GenAI/Texte notebooks have the same `%pip install` defect (10_LocalLlama, 11_Quantization, 12_Test_Time_Scaling, 13_Agentic_Orchestration, 18_Semantic_Kernel_Plugins, 5_RAG_Modern, 8_Reasoning_Models — all install-only cells, safe re-exec). 6 more require OpenAI API key for re-exec (1_OpenAI_Intro, 3, 4, 6, 7, 9 — `OpenAI()` init in pip cell). This PR addresses 1 notebook atomically per G.4; the others are follow-up cycles or po-2023 (GenAI owner coordination).

See #6309 (security sweep — partial contribution, epic remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
