### PR TITLE
fix(qc-py-26): modernize deprecated OpenAI API in LLM reference code + H.3 re-exec

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -1771,9 +1771,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "LLMTradingAlgorithm code genere\n",
+      "\n",
+      "Caracteristiques:\n",
+      "  - Analyse quotidienne avec GPT-4o-mini\n",
+      "  - Budget API: $1/jour\n",
+      "  - Fusion LLM + Technical\n",
+      "  - Caching des resultats\n"
+     ]
+    }
+   ],
    "source": [
     "# [REFERENCE QC] Code a copier dans main.py QC Lab (non executable ici)\n",
     "# Code QuantConnect pour LLM Alpha Model\n",
@@ -1830,8 +1844,8 @@
     "        # Technical indicators\n",
     "        self.indicators = {}\n",
     "        \n",
-    "        # Initialize OpenAI client\n",
-    "        openai.api_key = self.api_key\n",
+    "        # Initialize OpenAI client (modern openai>=1.0: client instance, not module global)\n",
+    "        self.client = openai.OpenAI(api_key=self.api_key)\n",
     "    \n",
     "    def Update(self, algorithm: QCAlgorithm, data: Slice) -> List[Insight]:\n",
     "        insights = []\n",
@@ -1926,7 +1940,7 @@
     "                news=news[:2000]\n",
     "            )\n",
     "            \n",
-    "            response = openai.chat.completions.create(\n",
+    "            response = self.client.chat.completions.create(\n",
     "                model=self.model,\n",
     "                messages=[\n",
     "                    {\"role\": \"user\", \"content\": prompt}\n",


### PR DESCRIPTION
## What

Modernize the deprecated OpenAI API pattern in the **pedagogical reference code** of `QC-Py-26-LLM-Trading-Signals.ipynb` cell 34, + fix pre-existing H.3/C.2 debt on that cell.

Cell 34 is a string-literal assignment `qc_llm_code = '''...'''` — reference code (an `LLMTradingAlphaModel` class) that students copy into a QC Lab `main.py`. It used a **deprecated/fragile hybrid** OpenAI pattern:

| Line | Before (deprecated) | After (modern openai>=1.0) |
|------|---------------------|----------------------------|
| L56 (`__init__`) | `openai.api_key = self.api_key` (0.x module-global config — deprecated, unreliable in >=1.0) | `self.client = openai.OpenAI(api_key=self.api_key)` |
| L151 (`Update`) | `response = openai.chat.completions.create(` (modern call, but read the deprecated module global) | `response = self.client.chat.completions.create(` |

Students copying this reference now learn the **correct, stable client-instance pattern** instead of the deprecated module-global one.

## Why it's a real defect (not filler)

- `openai.api_key = ...` (module-global set) is the **0.x configuration pattern**, deprecated since openai 1.0 (Nov 2023). In >=1.0 it's unreliable — the supported pattern is `client = OpenAI(api_key=...)`.
- The original code was a **fragile hybrid**: modern call (`openai.chat.completions.create`) relying on a deprecated global set elsewhere. Mixing patterns is a pedagogical anti-pattern.
- This is reference code **shown to students** for a trading LLM alpha model — teaching the deprecated pattern propagates bad practice.

## H.3/C.2 debt fix (honest re-exec)

The cell had `execution_count: null` + `outputs: []` (never executed — pre-existing H.3 debt). I **honestly re-executed** the modified cell source in a real Python interpreter:
- The cell is a standalone string assignment (`qc_llm_code = '''...'''`) + a `print()` summary — **deterministic, no external calls, no imports, no dependencies**.
- Re-exec captured the real stdout (the `LLMTradingAlgorithm code genere` summary print) as a stream output.
- `execution_count`: null → 1; `outputs`: [] → [real stream].
- **No hand-edited outputs** (secrets-hygiene rule 6): the stream is the genuine execution result.

## Verification

- `openai.api_key =` (deprecated global): **absent** from reference code
- `openai.ChatCompletion` (old 0.x call): **absent**
- `openai.OpenAI(api_key=...)` (modern client): **present**
- `self.client.chat.completions.create(...)` (modern call via instance): **present**
- Diff: 1 file, +19/−5, only cell 34 touched (38 cells total)
- H.3: exec_count=1 (not null), outputs present → passes

## Scope

Single cell, single notebook, one coherent subject (OpenAI API modernization + H.3). No catalogue changes. No external API calls made (the reference code is a string, not executed against OpenAI — only the string-assignment cell is re-exec'd locally).