### PR TITLE
fix(genai-texte,#6309): scrub %pip install source-leak in 5_RAG_Modern — Stop & Repair

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -89,24 +89,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
-      "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+      "Dépendances RAG pré-chargées avec succès.\n"
      ]
     }
    ],
    "source": [
-    "# Installation des dépendances\n",
-    "%pip install openai tiktoken python-dotenv scikit-learn numpy pandas requests beautifulsoup4 lxml -q"
+    "# Dépendances pré-provisionnées (openai, tiktoken, python-dotenv, scikit-learn, numpy, pandas, requests, beautifulsoup4, lxml) : voir GenAI/requirements.txt\n",
+    "import openai, tiktoken, dotenv, sklearn, numpy, pandas, requests, bs4, lxml\n",
+    "print(\"Dépendances RAG pré-chargées avec succès.\")"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/requirements.txt
+++ b/MyIA.AI.Notebooks/GenAI/requirements.txt
@@ -1,7 +1,11 @@
 ﻿# GenAI CoursIA Phase 2 - Dependances Python
 openai>=1.12.0
+tiktoken>=0.7.0
 anthropic>=0.21.0
 requests>=2.31.0
+scikit-learn>=1.3.0
+beautifulsoup4>=4.12.0
+lxml>=5.0.0
 pillow>=10.0.0
 numpy>=1.24.0
 pandas>=2.0.0


### PR DESCRIPTION
## Summary

Stop & Repair of a `%pip install` **source-leak** (security #6309) in `GenAI/Texte/5_RAG_Modern.ipynb`. **0 collision** (only #6359 touches GenAI/Texte, different file). GenAI/Texte = owner po-2024 (ledger #3801 entry #022). Continues the GenAI/Texte pip-leak sweep started in #6359 (c.484).

### Defect (leak on PUBLIC repo)

`cell[2]` `%pip install openai tiktoken python-dotenv scikit-learn numpy pandas requests beautifulsoup4 lxml -q` produced committed stdout:

```
Note: you may need to restart the kernel to use updated packages.
WARNING: Ignoring invalid distribution ~penai (C:\Python313\Lib\site-packages)
[notice] A new release of pip is available: 25.0.1 -> 26.1.2
```

## Fix — Stop & Repair (secrets-hygiene rule 6)

| Step | Action |
|------|--------|
| **Source fix (C460-L1)** | Removed `%pip install` line; replaced with pre-provisioned comment + **import validation** (`import openai, tiktoken, dotenv, sklearn, numpy, pandas, requests, bs4, lxml` + print) — confirms deps without invoking pip |
| **regle F** | Added to `GenAI/requirements.txt`: `tiktoken>=0.7.0`, `scikit-learn>=1.3.0`, `beautifulsoup4>=4.12.0`, `lxml>=5.0.0` (were absent). All deps verified installed locally |
| **Re-exec (C477-L1)** | Papermill 1-cell isolation. cell[2] is install-only (no `OpenAI()` init, no API call) → safe re-exec without API key. Honest output = single stream `Dépendances RAG pré-chargées avec succès.` |
| **Surgical (C475-L1)** | Only `cell[2]` modified. 18 other code cells byte-identical to `origin/main` (no churn) |

### C477-L1 proof (contrast #6342 incomplete-repair c.477)

The leaky pip-notice stream is **structurally impossible** after the fix: `%pip install` is the only source of pip output; replacing it with import validation means no pip call → no pip-notice → the clean single-stream output is the **honest re-exec result**, NOT a hand-scrub.

## Validation (H.3)

- `validate_pr_notebooks.py`: **1/1 PASS** (19 code cells)
- `execution_count = 1`, `outputs` = 1 coherent stream
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1)
- 0 leak in any cell output (grep `jsboi|AppData|site-packages|PythonSoftwareFoundation|~penai|pip is available|restart the kernel` = 0 hits)
- `git diff --stat`: `+8/-14`, 2 files, atomic (G.4 OK)

## Scope & collision note

- **1 notebook** (`GenAI/Texte/5_RAG_Modern.ipynb`) + `GenAI/requirements.txt` (4 lines added).
- **0 collision** with #6359 (different notebook file). The `tiktoken>=0.7.0` requirements.txt line is also added by #6359 with identical content → git auto-resolves the identical add at merge.
- No catalogue regeneration (catalog-pr-hygiene R1).

## GenAI/Texte sweep progress

| Notebook | Status |
|----------|--------|
| 2_PromptEngineering | #6359 (c.484) |
| **5_RAG_Modern** | **#6360 (this PR, c.485)** |
| 10_LocalLlama, 11_Quantization, 12_Test_Time_Scaling, 13_Agentic_Orchestration, 18_Semantic_Kernel_Plugins, 8_Reasoning_Models | safe candidates (install-only), follow-up cycles |
| 1_OpenAI_Intro, 3, 4, 6, 7, 9 | RECOVERABLE-USER-HAND (`OpenAI()` init in pip cell, .env absent locally) |

See #6309 (security sweep — partial contribution, epic remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
