### PR TITLE
fix(genai-texte,#6309): scrub %pip + .env-path source-leak in 18_Semantic_Kernel_Plugins

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
@@ -85,33 +85,16 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ".env charge depuis : C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GenAI\\.env\n",
-      "semantic-kernel 1.41.3\n"
+      "semantic-kernel 1.42.0\n"
      ]
     }
    ],
    "source": [
-    "%pip install -q semantic-kernel python-dotenv\n",
-    "\n",
+    "# Dependances pre-provisionnees (semantic-kernel, python-dotenv) :\n",
+    "# voir GenAI/requirements.txt. Regle F : pas d'install runtime sur le PUBLIC repo.\n",
     "import os, re, asyncio\n",
     "from pathlib import Path\n",
     "from dotenv import load_dotenv\n",
@@ -136,9 +119,9 @@
     "        if _cand.exists():\n",
     "            _env_path = _cand; break\n",
     "if _env_path is not None:\n",
-    "    load_dotenv(_env_path); print(f\".env charge depuis : {_env_path}\")\n",
+    "    load_dotenv(_env_path); print(f\".env charge depuis : {_env_path.name}\")\n",
     "\n",
-    "print(f\"semantic-kernel {sk.__version__}\")"
+    "print(f\"semantic-kernel {sk.__version__}\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Stop & Repair of TWO source-leaks in `GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb` cell[2] (campaign #6309, MA partition — GenAI/Texte owner po-2024 per ledger #3801 entry #022).

## Defects (both in cell[2], PUBLIC repo)

1. **pip source-leak** (C460-L1): `%pip install -q semantic-kernel python-dotenv` → pip stderr `[notice] A new release of pip is available: 24.0 -> 26.1.2` + stdout `Note: you may need to restart the kernel`.
2. **.env-path source-leak** (class A env/cwd): `print(f".env charge depuis : {_env_path}")` → leaked absolute machine path `C:\dev\CoursIA-2\MyIA.AI.Notebooks\GenAI\.env` in stdout.

## Fix (Stop & Repair, secrets-hygiene rule 6)

1. **Source**: removed `%pip install` line; replaced with pre-provisioned comment (semantic-kernel, python-dotenv declared in `GenAI/requirements.txt`, regle F).
2. **Source**: fixed .env-path leak at CAUSE — `print(f".env charge depuis : {_env_path.name}")` → basename only. Durable: prints `.env` (not absolute path) on any machine where .env is found.
3. **Re-exec**: papermill 1-cell surgical (`--cwd GenAI/Texte`, `-p BATCH_MODE true`). NOT a hand-scrub.
4. **Outputs**: pip notices removed; .env-path line absent (no `GenAI/.env` on worker → conditional print skipped); `semantic-kernel 1.42.0` preserved (genuine re-exec, version drift 1.41.3→1.42.0 legitimate).

## Transparency on .env-line absence

The `.env charge depuis` line is absent from committed output because `GenAI/.env` does not exist on this worker — the `if _env_path is not None:` guard skips the print. This is **not** a hand-edit (rule 6): the source still contains the conditional print (now basename-normalized). On a machine with `.env` present, the line prints as `.env charge depuis : .env` (basename, no leak). The source fix is durable; the committed output reflects the worker environment honestly.

## Verification

- **C.3 surgical**: only `cell[2]` changed (11 other code cells byte-identical).
- **execution_count=1** preserved (original positional).
- **C.1**: no `raise NotImplementedError`/`assert False`/`1/0`.
- **C477-L1 PASS**: source→comment, pip-notice structurally impossible, re-exec real.
- **C487-L1 network-leak check**: clean (no private IPs / `fe80::` / `probeAddresses` in outputs).
- **H.3 validator**: `validate_pr_notebooks.py` 1/1 PASS (12 cells).
- **regle F**: added `semantic-kernel>=1.0.0` to `GenAI/requirements.txt` (also added by OPEN PR #6363 — identical addition auto-resolves at merge; no conflict).

## Diff stat

```
 18_Semantic_Kernel_Plugins.ipynb | 27 ++++------------------
 requirements.txt                  |  1 +
 2 files changed, 6 insertions(+), 22 deletions(-)
```
Deletions > insertions expected: removed pip-install source + leaky outputs (not code métier — anti-regression N/A).

See #6309 (pip-leak campaign, partial — 1 notebook). GenAI/Texte sweep progress: 5/13 (#6359/#6361/#6363/#6366/this). Residual: 8/12/13 = RECOVERABLE-USER-HAND (OpenRouter `client = OpenAI(api_key=...)` init in pip cell, `.env` absent locally).

Co-Authored-By: Claude-Code <noreply@anthropic.com>