### PR TITLE
fix(scripts): replace hardcoded machine paths with portable equivalents (source-leak + portability)

### DIFF
--- a/scripts/genai-stack/validate_all_notebooks.py
+++ b/scripts/genai-stack/validate_all_notebooks.py
@@ -11,6 +11,7 @@ Categories: Environment, Texte, Audio, Video, Image, all
 import os
 import sys
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -63,7 +64,7 @@ def execute_notebook(notebook_path: Path, timeout: int = 300) -> Tuple[bool, str
     env["BATCH_MODE"] = "true"
 
     # Output temporaire
-    output_path = Path("C:\\Users\\jsboi\\AppData\\Local\\Temp\\temp_output.ipynb")
+    output_path = Path(tempfile.gettempdir()) / "temp_output.ipynb"
 
     cmd = [
         sys.executable, "-m", "papermill",

--- a/scripts/sudoku/finetune.py
+++ b/scripts/sudoku/finetune.py
@@ -77,7 +77,7 @@ def load_diverse_200k():
 
 def load_kaggle_1m(max_puzzles=None):
     """Load Kaggle 1M dataset (easy/medium, ~34 givens)."""
-    path = 'C:/Users/jsboi/.cache/kagglehub/datasets/bryanpark/sudoku/versions/3/sudoku.csv'
+    path = os.path.expanduser('~/.cache/kagglehub/datasets/bryanpark/sudoku/versions/3/sudoku.csv')
     if not os.path.exists(path):
         print(f"  Kaggle 1M not found at {path}")
         return None, None


### PR DESCRIPTION
## Summary

Replaces 2 hardcoded absolute user paths (`C:/Users/jsboi/...`) in production scripts with portable equivalents. Source-leak fix (username + cache topology exposed on a public repo) + portability defect (broke on any non-`jsboi` machine). Genuinely distinct register from the probeAddresses OUTPUT-strip work — this is the SOURCE-side hardcoded-path family (#6341/#6362/#6364).

## Problem

Two active production scripts hardcoded the maintainer's absolute home path:

- `scripts/sudoku/finetune.py:80` — Kaggle 1M dataset cache path `'C:/Users/jsboi/.cache/kagglehub/...'`
- `scripts/genai-stack/validate_all_notebooks.py:66` — papermill temp output `Path("C:\\Users\\jsboi\\AppData\\Local\\Temp\\temp_output.ipynb")`

On a public repo this leaks the maintainer's username + cache/temp topology. It is also a **portability defect**: the scripts break (Kaggle load fails silently → returns `None, None`; papermill writes to a non-existent temp dir) on any machine whose user isn't `jsboi` — e.g. CI runners, other cluster machines, student forks.

Same defect class as the source-leak PRs already shipped this session (#6341 Search-11, #6342 SemanticKernel, #6362 Tweety-10 `#r` path, #6364 MGS `#r` paths, #6366/#6367 GenAI `%pip`), but a **distinct vector**: hardcoded paths in `.py` script source (not notebook `#r`/`%pip` cells, not kernel-injected probe output).

## This PR

| File | Line | Before | After |
|------|------|--------|-------|
| `scripts/sudoku/finetune.py` | 80 | `'C:/Users/jsboi/.cache/kagglehub/...'` | `os.path.expanduser('~/.cache/kagglehub/...')` |
| `scripts/genai-stack/validate_all_notebooks.py` | 66 | `Path("C:\\Users\\jsboi\\AppData\\Local\\Temp\\temp_output.ipynb")` | `Path(tempfile.gettempdir()) / "temp_output.ipynb"` (+ `import tempfile`) |

Both fixes use canonical Python portable patterns:
- `os.path.expanduser('~')` resolves to the current user's home (`C:\Users\<user>` on Windows, `/home/<user>` on Linux). `os` already imported.
- `tempfile.gettempdir()` returns the OS temp dir (`C:\Users\<user>\AppData\Local\Temp` on Windows, `/tmp` on Linux).

## Validation

- `python -m py_compile` **SUCCESS** on both files (no syntax errors).
- Functional check: `os.path.expanduser('~/.cache/kagglehub/...')` + `Path(tempfile.gettempdir()) / "temp_output.ipynb"` resolve correctly to the current user's home/temp — **portable** (source no longer hardcodes the username; resolves dynamically per machine).
- `git diff --numstat`: `3 add / 2 del` across 2 files, **CRLF=0**, surgical (only the 2 path lines + 1 import, no collateral).
- No notebook re-exec needed (`.py` scripts, not notebooks; H.3 not applicable).
- Behavior preserved exactly on the maintainer's machine (same resolved paths); fixed on every other machine.

## Scope

2 production `.py` scripts. Collision-checked: 0 open PRs touch either file (`gh pr list --json files` filtered). Atomic single subject (hardcoded machine paths → portable).

See #6309 (source-leak family, same epic). Not `Closes` — partial contribution to the broader machine-path-leak cleanup.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
