### PR TITLE
fix(qc-mlpipeline): replace hardcoded MYIA python path with sys.executable (source-leak + portability)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/launch_ai01_track_b.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/launch_ai01_track_b.py
@@ -26,7 +26,11 @@ os.environ["CUDA_VISIBLE_DEVICES"] = "2"
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 DATA_DIR = ROOT.parent / "datasets" / "yfinance"
-PYTHON = r"C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe"
+# Use the interpreter that launched this driver (must be the coursia-ml-training
+# conda env, since the spawned train_*.py scripts import torch / CUDA). Hardcoding
+# an absolute C:\Users\<user>\... path leaked the worker username and broke on
+# any machine where miniconda is not at that exact path (forks, CI, other cluster nodes).
+PYTHON = sys.executable
 
 ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
 OUT_DIR = ROOT / "outputs" / f"ai01_track_b_{ts}"

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/run_m8_overnight_sota.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/run_m8_overnight_sota.py
@@ -34,7 +34,11 @@ PIPELINE = SCRIPTS.parent
 RESULTS = PIPELINE / "results" / "m8_sota_overnight"
 RESULTS.mkdir(parents=True, exist_ok=True)
 OVERALL = RESULTS / "_overall.log"
-PYTHON = r"C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe"
+# Use the interpreter that launched this driver (must be the coursia-ml-training
+# conda env, since the spawned train_*.py scripts import torch / CUDA). Hardcoding
+# an absolute C:\Users\<user>\... path leaked the worker username and broke on
+# any machine where miniconda is not at that exact path (forks, CI, other cluster nodes).
+PYTHON = sys.executable
 DATA_DIR = (PIPELINE.parent / "datasets" / "yfinance" / "crypto_panier").as_posix()
 
 # Per-script capability profile:


### PR DESCRIPTION
## What

Replace hardcoded absolute machine path `C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe` with the portable `sys.executable` in **2 ML-Training-Pipeline driver scripts** (`launch_ai01_track_b.py`, `run_m8_overnight_sota.py`). Same defect class as #6372 (po-2024 c.428), which fixed 2 stragglers in top-level `scripts/` — but missed these 2 in the nested `ML-Training-Pipeline/scripts/` subfolder.

## Defect — 2-en-1 (source-leak + portability)

`PYTHON = r"C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe"` :

1. **Source-leak (SECURITY)**: `MYIA` = worker machine username (ai-01), exposed in committed source on a public repo. Same class as the `jsboi` leaks fixed in #6341/#6362/#6364/#6366/#6367/#6372.
2. **Portability defect**: the absolute path only resolves on a machine where miniconda is installed at exactly `C:\Users\MYIA\miniconda3\`. Breaks on any fork, CI runner, or other cluster node where the repo isn't cloned under that exact user.

## Fix — `sys.executable` (portable, zero-leak)

```python
PYTHON = sys.executable
```

Both scripts already `import sys`. `sys.executable` returns the interpreter currently running the driver — which **is** the `coursia-ml-training` conda env, since the spawned `train_*.py` children import `torch` / CUDA (they fail outside that env). This is the standard portable pattern for a Python launcher that spawns children in its own env. If the driver is ever launched from the wrong env, the child fails with a clear `ImportError: torch` rather than an obscure `FileNotFoundError: C:\Users\MYIA\...`.

## Validation (firsthand, mechanical)

| Check | Result |
|-------|--------|
| `py_compile` 2 scripts | SUCCESS (syntax valid) |
| `sys.executable` resolves | yes (real Python path) |
| diff | 2 files, **+10/-2** surgical (3 comment lines + `sys.executable` each) |
| CRLF | 0 |
| residual hardcoded `C:\Users\` in `.py` source | **0** (exhaustive `git grep` on `*.py`; remaining matches = docstrings/path-detection logic in `scrub_papermill_paths.py` + `lean4-kernel-wrapper.py`, legitimate) |
| no notebook re-exec needed | `.py` scripts (H.3 N/A) |

## G.1 anti-collision

`gh pr list` + file-overlap matrix checked firsthand: **0 open PRs touch `ML-Training-Pipeline/scripts/`**. po-2024 #6372 (c.428) fixed `scripts/sudoku/finetune.py` + `scripts/genai-stack/validate_all_notebooks.py` (top-level `scripts/`) — this PR covers the **nested** `ML-Training-Pipeline/scripts/` stragglers that scan missed.

## Relationship

- Same defect class as **#6372** (po-2024 c.428, merged-pending), #6362, #6364, #6366, #6367.
- See #6309 (security sweep tracker, partial partition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
