### PR TITLE
Add: GT-2-Part2 equilibrium interpretation markdown (C.3 markdown-only, #2651)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
@@ -715,6 +715,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Interpretation -- symetrie et uniformite.** L'algorithme retrouve l'equilibre uniforme $(\\tfrac{1}{3}, \\tfrac{1}{3}, \\tfrac{1}{3})$ sans qu'on le lui indique. C'est une consequence directe de la **symetrie** de la matrice de paiement : aucune action n'est distinguable a priori, donc aucune ne peut recevoir plus de poids qu'une autre a l'equilibre. La valeur du jeu est nulle (jeu a somme nulle equitable). Le point pedagogique : la support enumeration redecouvre ce resultat par le **calcul** (resolution du systeme d'indifference), et non par un argument de symetrie injecte a la main."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "gt2b13",
    "metadata": {
     "papermill": {
@@ -804,6 +811,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Interpretation -- rupture de symetrie, Paper devient modal.** Doubler le gain de Rock contre Scissors brise la symetrie : Rock devient une menace renforcee (il bat Scissors de +2 au lieu de +1). Anticipant cela, les deux joueurs deplacent leur probabilite vers **Paper** -- l'action qui bat Rock -- qui atteint 50 %, tandis que Rock et Scissors tombent a 25 % chacun. La valeur du jeu reste nulle (le biais est symetrique entre les deux joueurs). Cet equilibre non-uniforme est exactement le genre de resultat **non evident a l'intuition** que la support enumeration revele : aucun argument heuristique simple ne dirait \"Paper 50 %\" sans resoudre le systeme."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "gt2b15",
    "metadata": {
     "papermill": {
@@ -882,6 +896,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Interpretation -- equilibre pur, support de taille 1.** Le Dilemme du Prisonnier n'a pas d'equilibre mixte interessant : son unique equilibre de Nash est la strategie pure $(\\text{Defect}, \\text{Defect})$. C'est un **support de taille 1**. L'interet ici est de montrer que la support enumeration ne se limite pas aux melanges -- elle enumere les supports de **toutes tailles**, et retrouve donc aussi les equilibres purs. La methode est **generale** : pas besoin de traiter separement le cas pur et le cas mixte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "gt2b17",
    "metadata": {
     "papermill": {
@@ -951,6 +972,15 @@
     "}\n",
     "sb.AppendLine(\">>> Melange (0.5,0.5) retrouve, valeur 0 (confirme la tranche 1).\");\n",
     "sb.ToString().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Interpretation -- equilibre mixte 2x2 sans equilibre pur.** Pile ou Face (Matching Pennies) n'a **aucun equilibre pur** (jeu a somme nulle sans point-selle en strategies pures). L'unique equilibre est le melange uniforme $(0{,}5\\,;\\,0{,}5)$ : chaque joueur rend l'autre indifferent entre ses deux actions. La support enumeration retrouve ce resultat sur le support de taille 2, **confirmant la formule close de la tranche 1**.\n",
+    "\n",
+    "Ce notebook demontre ainsi les **quatre regimes** possibles d'un equilibre de Nash melange/pur : uniforme par symetrie (RPS), non-uniforme par asymetrie (RPS biaise), pur par strategie dominante (Prisonnier), et mixte sans equilibre pur (Pile ou Face)."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Adds 4 interpretation markdown cells after the 4 Nash-equilibrium demo cells in `GameTheory-2-NormalForm-Csharp-Part2.ipynb` (Support Enumeration tranche 2). Markdown-only enrichment — **rule C.3 exception** (outputs preserved, no re-execution needed).

## What

Each demo cell (RPS, Biased RPS, Prisoner's Dilemma, Matching Pennies) printed its equilibrium via a terse `>>>` one-liner in the code output, but lacked a **markdown interpretation of the mechanism and intuition**. This PR adds that interpretation, grounded on each demo's actual output:

| Demo (cell) | Output | Interpretation added |
|---|---|---|
| RPS symmetric (#11) | `(1/3, 1/3, 1/3)`, value 0 | Uniformity = consequence of payoff symmetry; algorithm rediscovers it by calculation, not by injected symmetry argument |
| Biased RPS (#13) | `R:0.25 P:0.50 S:0.25`, value 0 | Paper becomes modal because doubling Rock-vs-Scissors strengthens Rock → both players hedge to Paper; non-obvious equilibrium surfaced by support enumeration |
| Prisoner's Dilemma (#15) | pure `(Defect, Defect)` | Pure equilibrium = support of size 1; the method enumerates supports of all sizes → handles pure AND mixed (generality) |
| Matching Pennies (#17) | `(0.5, 0.5)` | No pure equilibrium (zero-sum, no saddle); uniform mix confirms tranche-1 closed form |

The 4th cell synthesizes the **four regimes** a Nash equilibrium can take (uniform by symmetry / non-uniform by asymmetry / pure by dominance / mixed without pure).

## Forensic verification (C.3 markdown-only)

- **13 code cells byte-identical** (source + `execution_count` + `outputs`) between `origin/main` and this branch
- Markdown cells: 12 → 16 (+4 interpretation)
- Total cells: 25 → 29
- `+30/-0` (pure insertion, no deletion)
- H.3 validator: **0 errors**
- C.1 scan: **0 violations** (no `raise NotImplementedError` / `assert False` / `1/0`)
- nbformat 4.5, JSON valid

## Scope

Single notebook, single family (GameTheory non-Lean, C#/.NET = po-2024 partition). One subject (interpretation enrichment). No code change, no catalogue change, no output change.

See #2651 (partial — enrichment contribution, does not close the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>