### PR TITLE
Add: Infer-16 conclusion cell — Sparse GP synthesis (C.3 markdown-only, #2651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
@@ -1055,6 +1055,27 @@
    "id": "81601e3e",
    "metadata": {},
    "source": "### GP vs BPM (Infer-9)\n\n| Aspect | BPM (Infer-9) | GP (Infer-16) |\n|--------|---------------|---------------|\n| Paramètre | Vecteur de poids $\\mathbf{w}$ | Fonction $f$ |\n| Frontière | Hyperplan (linéaire) | Courbe quelconque |\n| Donut | **Échec** | **Succès** |\n| Coût | Linéaire en $n$ | $O(nm^2)$ (sparse) |\n| Quand l'utiliser | Données linéairement séparables | Frontières non linéaires |\n\n### Distributions utilisées\n\n| Distribution | Rôle |\n|--------------|------|\n| `SparseGP` | Prior et posterior sur la fonction $f$ |\n| `Gaussian` | Score bruité (probit) + marginal posterior en chaque point |\n| `Bernoulli` | (Implicite) prediction de classe via `NormalCdf` |\n\n> **Leçon** : le GP est l'outil naturel quand la frontière de décision est non linéaire ET qu'on veut une **incertitude calibrée**. Pour un cas linéaire, le BPM (Infer-9) reste plus simple et plus rapide. Le processus gaussien n'est pas un remplacement universel — c'est un **complément** qui étend la boîte à outils bayésienne au non-linéaire, au prix d'un noyau à choisir et d'un basis à calibrer.\n\n### Ponts dans la série\n\n- **Pont hiérarchique** ([Infer-12-Modeles-Hierarchiques](Infer-12-Modeles-Hierarchiques.ipynb)) : la longueur d'échelle $\\ell$ du noyau RBF est un hyperparamètre ; un GP qui apprendrait une longueur par groupe d'inputs est, structurellement, un modèle hiérarchique sur ces hyperparamètres. Ce notebook, en restant à $\\ell$ fixée, montre d'abord le mécanisme bayésien avant d'envisager sa généralisation hiérarchique.\n- **Suivant** ([Infer-17-Kalman-Filter](Infer-17-Kalman-Filter.ipynb)) : le GP est le pendant **statique** (covariance dans l'espace des entrées) du modèle d'état markovien (covariance dans le temps). Tous deux sont résolus exactement par EP dans la famille gaussienne — Kalman est le GP temporel, en quelque sorte."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion — ce que nous avons appris\n",
+    "\n",
+    "Ce notebook a prolongé la **Bayes Point Machine** d'Infer-9 (frontière linéaire) en un **Processus Gaussien** capable de tracer une frontière **non-linéaire** — illustrée ici par la classification du *donut*, qu'aucun hyperplan ne peut séparer.\n",
+    "\n",
+    "### Trois idées à retenir\n",
+    "\n",
+    "1. **Le GP modélise une fonction, pas un vecteur de poids.** Là où la BPM apprend un hyperplan $\\mathbf{w} \\cdot \\mathbf{x} = 0$, le GP infère une fonction $f(\\mathbf{x})$ dont seul le signe sert à la classification. C'est ce passage « du paramétrique au non-paramétrique » qui débloque les frontières courbes.\n",
+    "\n",
+    "2. **L'incertitude est un produit dérivé du GP, pas un accessoire.** La prédiction au centre du donut ($E[f] < 0$) est confiante (`false`) ; à mi-rayon, l'incertitude est maximale — exactement là où l'information d'entraînement est la plus pauvre. Un classifieur déterministe ne saurait pas dire « je ne sais pas » ; le GP le quantifie.\n",
+    "\n",
+    "3. **L'approximation sparse rend le GP abordable.** Un GP full coûte $O(n^3)$ (inversion d'une matrice $n \\times n$). Le **sparse** ramène ce coût à $O(nm^2)$ en remplaçant le jeu complet d'inputs par un petit **basis set** de $m$ points induiseurs. Sur le donun — structure globale — $m = 4$ points suffisent : la perte de précision est négligeable face au gain de coût. Le sparse n'est pas une approximation brutale : c'est un **continu** contrôlé par $m$, qui redonne le GP full quand $m = n$.\n",
+    "\n",
+    "### Et ensuite ?\n",
+    "\n",
+    "Le GP ouvre la voie aux **modèles hiérarchiques** (Infer-12) où plusieurs groupes partagent un prior commun, et aux **mélangees de Gaussiennes** (Infer-2) pour la densité. Pour les très grands jeux de données, l'approximation sparse est indispensable — c'est elle qui rend le GP utilisable en pratique."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Appends a **conclusion markdown cell** to `Infer-16-Sparse-Gaussian-Process.ipynb` (Infer.NET probabilistic programming, po-2024 owner-lane). The notebook previously ended on a GP-vs-BPM comparison table inside the exercise section, with **no recapitulative conclusion**. Markdown-only enrichment (rule C.3 exception — outputs preserved, no re-execution needed).

## What

The conclusion synthesizes three takeaways, each grounded on the notebook's actual demonstrations (not invented):

1. **GP models a function f(x), not a weight vector** — the move from parametric (Infer-9 BPM hyperplan) to non-parametric unlocks curved boundaries; the donut classification demonstrates a frontier no hyperplan can separate.
2. **Uncertainty is a first-class output** — confident prediction (`false`) at the donut center where E[f]<0; maximal uncertainty at mid-radius where training information is poorest. A deterministic classifier cannot say "I don't know"; the GP quantifies it.
3. **The sparse approximation makes the GP affordable** — full GP costs O(n³); sparse reduces to O(nm²) via a small basis set of m inducing points. For the donut's global structure, m=4 points suffice — sparse is a continuum controlled by m (gives back full GP when m=n).

Closes with a forward pointer to Infer-12 (hierarchical models) and Infer-2 (Gaussian mixtures).

## Forensic verification (C.3 markdown-only)

- **12 code cells byte-identical** (source + `execution_count` + `outputs`) between `origin/main` and this branch
- Markdown cells: 18 → 19 (+1 conclusion)
- Total cells: 30 → 31
- `+21/-0` (pure insertion)
- H.3 validator: **0 errors**
- C.1 scan: **0 violations**
- nbformat 4.5, JSON valid

## Scope

Single notebook, single family (Probas/Infer .NET = po-2024 partition). One subject (conclusion enrichment). No code change, no output change, no catalogue change.

See #2651 (partial — enrichment contribution, does not close the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>