### PR TITLE
Add: ML-4-Evaluation conclusion cell — eval workflow + explainability synthesis (C.3 markdown-only, #2651)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -2289,6 +2289,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Conclusion — ce que nous avons appris\n",
+    "\n",
+    "Ce notebook a démontré le **workflow complet d'évaluation** d'un modèle ML.NET :\n",
+    "\n",
+    "1. **Séparer entraînement / validation / test.** L'évaluation honnête exige que les métriques finales soient calculées sur un ensemble de test **jamais vu** — distinct de l'ensemble sur lequel AutoML a optimisé. Mélanger les deux revient à noter un élève sur les exercices déjà corrigés.\n",
+    "\n",
+    "2. **Le R-carré ($R^2$) comme métrique pivot.** Coefficient de détermination compris entre $-\\infty$ et $1{,}0$, $R^2$ résume en un seul nombre la part de variance expliquée par le modèle. AutoML l'optimise ; la méthode `Evaluate` le mesure sur le test set. Mais $R^2$ seul ne dit pas *pourquoi* le modèle prédit ce qu'il prédit.\n",
+    "\n",
+    "3. **Deux niveaux d'explicabilité complémentaires.**\n",
+    "   - **PFI** (Permutation Feature Importance) = vue **globale** : on permute une caractéristique et on mesure la chute de $R^2$ moyennée sur tout le jeu. Cela produit un **classement** des variables les plus déterministes. Subtilité vue plus haut : les variables catégorielles encodées en *One-Hot* apparaissent éclatées en *bits* (`vendor_id.Bit0`, `vendor_id.Bit1`…), qu'il faut regrouper mentalement.\n",
+    "   - **FCC** (Feature Contribution Calculation) = vue **locale** : elle décompose *une prédiction unique* en contributions par caractéristique (sens + intensité par rapport à la prédiction moyenne). La PFI dit « cette variable compte en moyenne » ; la FCC dit « pour *cette* prédiction, elle a tiré le score vers le haut ».\n",
+    "\n",
+    "### Et ensuite ?\n",
+    "\n",
+    "Une fois le modèle évalué et expliqué, reste à l'améliorer (cf. section précédente) puis à le déployer. Le notebook suivant ([ML-5 TimeSeries](ML-5-TimeSeries.ipynb)) aborde un régime particulier où l'ordre temporel des données change la façon d'évaluer (la validation croisée aléatoire y devient une fuite d'information)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Références\n",
     "\n",
     "1. L. Breiman, *Random Forests*, Machine Learning, 45(1):5-32, 2001. Origine de l'importance des caractéristiques par permutation (PFI).\n",


### PR DESCRIPTION
## Summary

Inserts a **conclusion markdown cell** in `ML-4-Evaluation.ipynb` (ML.Net series, .NET Interactive = po-2024 partition). The notebook previously ended on a References cell with **no recapitulative conclusion/synthesis**. Markdown-only enrichment (rule C.3 exception — outputs preserved, no re-execution needed).

## What

The conclusion synthesizes the full model-evaluation workflow, grounded on the notebook's actual sections (not invented):

1. **Train/validation/test split** — honest evaluation requires final metrics on a test set never seen, distinct from what AutoML optimized on. Mixing the two = grading a student on already-corrected exercises.
2. **R-squared (R²) as the pivot metric** — coefficient of determination (-∞ to 1.0), summarizes explained variance in one number; AutoML optimizes it, `Evaluate()` measures it on the test set. But R² alone doesn't explain *why*.
3. **Two complementary explainability levels**:
   - **PFI** (Permutation Feature Importance) = **global** view: permute a feature, measure the averaged R² drop across the whole set → produces a ranking. Subtlety shown earlier in the notebook: One-Hot-encoded categoricals appear split into bits (`vendor_id.Bit0`, `vendor_id.Bit1`…) to be mentally regrouped.
   - **FCC** (Feature Contribution Calculation) = **local** view: decomposes *one prediction* into per-feature contributions (direction + magnitude vs the mean prediction). PFI says "this variable matters on average"; FCC says "for *this* prediction, it pulled the score up".
4. **Forward pointer** to ML-5 TimeSeries — where temporal order changes how to evaluate (random CV becomes an information leak).

## Forensic verification (C.3 markdown-only)

- **40 code cells byte-identical** (source + `execution_count` + `outputs`) between `origin/main` and this branch
- Markdown cells: 45 → 46 (+1 conclusion)
- Conclusion inserted at cell index 84, **before** References (now 85)
- Total cells: 85 → 86
- `+21/-0` (pure insertion)
- H.3 validator: **0 errors**
- C.1 scan: **0 violations**
- nbformat 4.5, JSON valid

## Scope

Single notebook, single family (ML/ML.Net .NET = po-2024 partition). One subject (conclusion enrichment). No code change, no output change, no catalogue change.

See #2651 (partial — enrichment contribution, does not close the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>