### PR TITLE
i18n(#4980): conway_lean/Conway/DoomsdayLemmas -- FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas.lean
@@ -1,45 +1,51 @@
 /-
-Conway calibration track — Doomsday lemmas (P2: closed-eval vs. case-decomposition)
+Voie calibration Conway — lemmes Doomsday (P2 : évaluation fermée vs décomposition par cas)
 John Horton Conway (1937-2020).
 
-These lemmas sit on top of `Conway.Doomsday` (the day-of-week algorithm). They form
-a HARNESS CALIBRATION ladder for the prover co-evolution Epic (#1453):
+Ces lemmes se construisent par-dessus `Conway.Doomsday` (l'algorithme du jour de la semaine).
+Ils forment une échelle de CALIBRATION DU HARNÈS pour l'Epic de co-évolution du prouveur (#1453) :
 
   - `isLeapYear_2000` / `isLeapYear_1900` / `isLeapYear_2024`
-        : closed boolean evaluations            -> decide / native_decide   (easy)
+        : évaluations booléennes fermées            -> decide / native_decide   (facile)
   - `dayOfWeek_conway_death`
-        : the homage — Conway died Sat 2020-04-11; closed eval over the algorithm
-        : naive `rfl` may stall on `%`-arithmetic -> decide / native_decide  (easy-med)
+        : l'hommage — Conway est décédé le sam. 2020-04-11 ; évaluation fermée de l'algorithme
+        : un `rfl` naïf peut caler sur l'arithmétique `%` -> decide / native_decide  (facile-moyen)
   - `dayOfWeek_add_seven`
-        : NOT closed (free `d`); a naive `decide` fails because `d` is a variable.
-          The Director must DECOMPOSE: `cases d <;> rfl`.                    (medium)
+        : NON fermé (`d` libre) ; un `decide` naïf échoue car `d` est une variable.
+          Le Directeur doit DÉCOMPOSER : `cases d <;> rfl`.                    (moyen)
 
-All `sorry`s have been eliminated (Epic #1453, #1651).
+Tous les `sorry` ont été éliminés (Epic #1453, #1651).
+
+Convention i18n (EPIC #4980, décision user 2026-07-04) : ce fichier est **FR canonique**,
+avec son miroir anglais dans le fichier sibling `DoomsdayLemmas_en.lean` (modèle sibling pair
+ratifié 2026-07-04, cf `code-style.md` §Lean i18n). Les énoncés de théorèmes, les tactiques
+Lean, les noms de lemmes et les références Mathlib restent en anglais (compat Mathlib 4) ;
+seules les docstrings de théorème et ce bloc d'en-tête diffèrent entre les deux fichiers.
 -/
 
 import Conway.Doomsday
 
 namespace Conway
 
-/-- CALIBRATION (decide): 2000 is a leap year (divisible by 400). -/
+/-- CALIBRATION (decide) : 2000 est bissextile (divisible par 400). -/
 theorem isLeapYear_2000 : isLeapYear 2000 = true := by
   native_decide
 
-/-- CALIBRATION (decide): 1900 is NOT a leap year (divisible by 100, not 400). -/
+/-- CALIBRATION (decide) : 1900 n'est PAS bissextile (divisible par 100, pas par 400). -/
 theorem isLeapYear_1900 : isLeapYear 1900 = false := by
   native_decide
 
-/-- CALIBRATION (decide): 2024 is a leap year. -/
+/-- CALIBRATION (decide) : 2024 est bissextile. -/
 theorem isLeapYear_2024 : isLeapYear 2024 = true := by
   native_decide
 
-/-- HOMAGE + CALIBRATION: John Conway passed away on Saturday, April 11, 2020.
-    Closed evaluation of the Doomsday algorithm. -/
+/-- HOMMAGE + CALIBRATION : John Conway est décédé le samedi 11 avril 2020.
+    Évaluation fermée de l'algorithme Doomsday. -/
 theorem dayOfWeek_conway_death : dayOfWeek 2020 4 11 = DayOfWeek.saturday := by
   native_decide
 
-/-- CALIBRATION (case-decomposition): adding a full week is the identity.
-    A naive `decide` fails (`d` is free); requires `cases d`. -/
+/-- CALIBRATION (décomposition par cas) : ajouter une semaine complète est l'identité.
+    Un `decide` naïf échoue (`d` est libre) ; nécessite `cases d`. -/
 theorem dayOfWeek_add_seven (d : DayOfWeek) : DayOfWeek.add d 7 = d := by
   cases d <;> rfl
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas_en.lean
@@ -1,0 +1,54 @@
+/-
+Conway calibration track — Doomsday lemmas (P2: closed-eval vs. case-decomposition)
+John Horton Conway (1937-2020).
+
+English mirror of `DoomsdayLemmas.lean` (FR canonical). Convention EPIC #4980
+(decision ratified 2026-07-04, cf `code-style.md` §Lean i18n): distinct FR + EN sibling
+files — no inline bilingual block in a single file (Option B rejected). The module
+docstring and the public theorem docstrings below differ from the FR version; the body
+signatures, proofs and tactics remain byte-identical between the two files.
+
+These lemmas sit on top of `Conway.Doomsday` (the day-of-week algorithm). They form
+a HARNESS CALIBRATION ladder for the prover co-evolution Epic (#1453):
+
+  - `isLeapYear_2000` / `isLeapYear_1900` / `isLeapYear_2024`
+        : closed boolean evaluations            -> decide / native_decide   (easy)
+  - `dayOfWeek_conway_death`
+        : the homage — Conway died Sat 2020-04-11; closed eval over the algorithm
+        : naive `rfl` may stall on `%`-arithmetic -> decide / native_decide  (easy-med)
+  - `dayOfWeek_add_seven`
+        : NOT closed (free `d`); a naive `decide` fails because `d` is a variable.
+          The Director must DECOMPOSE: `cases d <;> rfl`.                    (medium)
+
+All `sorry`s have been eliminated (Epic #1453, #1651).
+-/
+
+import Conway.Doomsday
+
+namespace Conway_en
+
+open Conway
+
+/-- CALIBRATION (decide): 2000 is a leap year (divisible by 400). -/
+theorem isLeapYear_2000 : isLeapYear 2000 = true := by
+  native_decide
+
+/-- CALIBRATION (decide): 1900 is NOT a leap year (divisible by 100, not 400). -/
+theorem isLeapYear_1900 : isLeapYear 1900 = false := by
+  native_decide
+
+/-- CALIBRATION (decide): 2024 is a leap year. -/
+theorem isLeapYear_2024 : isLeapYear 2024 = true := by
+  native_decide
+
+/-- HOMAGE + CALIBRATION: John Conway passed away on Saturday, April 11, 2020.
+    Closed evaluation of the Doomsday algorithm. -/
+theorem dayOfWeek_conway_death : dayOfWeek 2020 4 11 = DayOfWeek.saturday := by
+  native_decide
+
+/-- CALIBRATION (case-decomposition): adding a full week is the identity.
+    A naive `decide` fails (`d` is free); requires `cases d`. -/
+theorem dayOfWeek_add_seven (d : DayOfWeek) : DayOfWeek.add d 7 = d := by
+  cases d <;> rfl
+
+end Conway_en


### PR DESCRIPTION
## i18n(#4980): conway_lean/Conway/DoomsdayLemmas -- FR-first sibling pair

### Substance

Sibling pair FR canonique + EN mirror pour `conway_lean/Conway/DoomsdayLemmas.lean` (lemmes Doomsday — calibration du harnès prouveur, hommage Conway).

| Fichier | Type | Rôle |
|---------|------|------|
| `DoomsdayLemmas.lean` (FR) | modified | FR canonique — header + 5 docstrings EN->FR, code byte-identical |
| `DoomsdayLemmas_en.lean` (EN) | new | miroir anglais — `namespace Conway_en`, `open Conway`, docstrings EN originales |

### Preuves (anti-complaisance)

- **Code byte-identical** : les lignes `import`/`namespace`/`theorem`/`native_decide`/`cases d <;> rfl`/`end` sont **identiques octet-par-octet** entre FR et EN, et entre FR et origin/main (LF-normalisé, vérifié par `diff` sur code-only). Seuls les blocs de commentaires (`/- ... -/` header + 5 docstrings `/-- ... -/`) diffèrent.
- **C404-L1 sorry count** (standalone-tactic mode, CI canonique) : **0/0** (les 5 théorèmes restent `native_decide` / `cases d <;> rfl`).
- **Parser-safety FR** : délimiteurs de commentaires équilibrés (6 blocs `/- ... -/` correctement appairés, 0 fermeture prématurée). Le bug `lean-i18n-fr-block-delimiter-literal-bug` (littéral `-/` dans la prose qui ferme prématurément le bloc) a été **détecté et corrigé** avant push (la note de convention ne cite plus la notation littérale `/- ... -/`).

### Convention

EPIC #4980 (décision user ratifiée 2026-07-04), modèle **Option-A sibling pair** :
- FR canonique `Foo.lean` + EN miroir `Foo_en.lean` (pas de bloc bilingue inline — Option B rejetée).
- EN sibling : `namespace Foo_en`, `open Foo`, imports identiques.
- Énoncés de théorèmes, tactiques, noms de lemmes, références Mathlib **restent en anglais** (compat Mathlib 4). Seules les docstrings diffèrent.

### Build / lakefile

- **Aucun changement de lakefile** : `lean_lib «Conway» where` (bare, no globs) découvre et build les siblings `_en` — prouvé par le précédent MERGED **#6332** (MathlibMap sibling pair, CI-green, pas de touch lakefile) et **#6355**.
- **CI = vérificateur autoritaire** : `.github/workflows/lean-build.yml` tourne `lake exe cache get || true` + `lake -R build` (sorry-baseline conway_lean = 7, sorry-filter standalone-tactic). Cold-Mathlib build local impraticable en cycle 30 min — précédent #6332 s'appuie sur code-identity + CI (pas de log lake-build local dans le body), démarche identique ici.

### Pivot R6 (anti-tunneling)

c.437 = pivot OFF probe-register (DRAINED pour notebooks trackés c.434) et accents-register (capped 1/lane/jour, c.432 SW-2 livré) vers **Lean i18n** = plat principal substance (#4980 Lean plate). Rotation famille .NET/probe -> Lean.

See #4980