### PR TITLE
i18n(#4980): conway_lean/Conway/LookAndSayLemmas -- FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/LookAndSayLemmas.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/LookAndSayLemmas.lean
@@ -1,36 +1,43 @@
 /-
-Conway calibration track — Look-and-Say lemmas (P3: eval-vs-lemma + structural induction)
+Voie calibration Conway — lemmes Look-and-Say (P3 : éval-vs-lemme + induction structurelle)
 John Horton Conway (1937-2020).
 
-These lemmas sit on top of `Conway.LookAndSay`. They form the HARDEST rung of the
-prover co-evolution calibration ladder (Epic #1453):
+Ces lemmes se construisent par-dessus `Conway.LookAndSay`. Ils forment le BARREAU le plus
+DIFFICILE de l'échelle de calibration du harnès de co-évolution du prouveur (Epic #1453) :
 
-  - `digitsToNat_example` : closed list evaluation        -> decide / rfl       (easy)
-  - `lookAndSay_4`        : well-founded recursion result -> native_decide      (medium:
-        naive `rfl`/`decide` may not reduce the WF recursion; prover may be tempted to
-        invoke a non-existent simp lemma — exercises the phantom-id blocklist path P3)
-  - `digitsToNat_natToDigits` : round-trip over decimal digits.
-        Genuinely requires structural induction matching `natToDigits` (recursion on
-        `n / 10`), plus a `digitsToNat` append lemma. This is the strategic-decomposition
-        stress target — the Director must NOT expect a one-shot tactic.        (hard)
+  - `digitsToNat_example` : évaluation fermée d'une liste  -> decide / rfl       (facile)
+  - `lookAndSay_4`        : résultat de récursion bien fondée -> native_decide    (moyen :
+        un `rfl`/`decide` naïf peut ne pas réduire la récursion WF ; le prouveur peut être
+        tenté d'invoquer un lemme simp inexistant — exerce le chemin blocklist phantom-id P3)
+  - `digitsToNat_natToDigits` : aller-retour sur les chiffres décimaux.
+        Nécessite réellement une induction structurelle calée sur `natToDigits` (récursion sur
+        `n / 10`), plus un lemme d'append pour `digitsToNat`. C'est la cible de stress de
+        décomposition stratégique — le Directeur ne doit PAS s'attendre à une tactique unique. (dur)
 
-The proof holes in the original calibration scaffold are intentional, not regressions (Epic #1453).
+Les trous de preuve dans le échafaudage de calibration original sont intentionnels,
+pas des régressions (Epic #1453).
+
+Convention i18n (EPIC #4980, décision user 2026-07-04) : ce fichier est **FR canonique**,
+avec son miroir anglais dans le fichier sibling `LookAndSayLemmas_en.lean` (modèle sibling pair
+ratifié 2026-07-04, cf `code-style.md` §Lean i18n). Les énoncés de théorèmes, les tactiques
+Lean, les noms de lemmes et les références Mathlib restent en anglais (compat Mathlib 4) ;
+seules les docstrings de théorème et ce bloc d'en-tête diffèrent entre les deux fichiers.
 -/
 
 import Conway.LookAndSay
 
 namespace Conway
 
-/-- CALIBRATION (decide): [1,2,1,1] decodes to 1211. -/
+/-- CALIBRATION (decide) : [1,2,1,1] se décode en 1211. -/
 theorem digitsToNat_example : digitsToNat [1, 2, 1, 1] = 1211 := by
   native_decide
 
-/-- CALIBRATION (native_decide): the 5th look-and-say term (0-indexed) is 111221. -/
+/-- CALIBRATION (native_decide) : le 5e terme look-and-say (indexé depuis 0) est 111221. -/
 theorem lookAndSay_4 : lookAndSay 4 = 111221 := by
   native_decide
 
-/-- CALIBRATION (hard, structural induction): decoding the decimal digits of `n`
-    recovers `n`. Requires induction matching `natToDigits`'s recursion on `n / 10`. -/
+/-- CALIBRATION (dur, induction structurelle) : décoder les chiffres décimaux de `n`
+    retrouve `n`. Nécessite une induction calée sur la récursion de `natToDigits` sur `n / 10`. -/
 theorem digitsToNat_natToDigits (n : Nat) : digitsToNat (natToDigits n) = n := by
   have h_append : ∀ (xs : List Nat) (d : Nat),
       digitsToNat (xs ++ [d]) = digitsToNat xs * 10 + d := by

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/LookAndSayLemmas_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/LookAndSayLemmas_en.lean
@@ -1,0 +1,63 @@
+/-
+Conway calibration track — Look-and-Say lemmas (P3: eval-vs-lemma + structural induction)
+John Horton Conway (1937-2020).
+
+English mirror of `LookAndSayLemmas.lean` (FR canonical). Convention EPIC #4980
+(decision ratified 2026-07-04, cf `code-style.md` §Lean i18n): distinct FR + EN sibling
+files — no inline bilingual block in a single file (Option B rejected). The module
+docstring and the public theorem docstrings below differ from the FR version; the body
+signatures, proofs and tactics remain byte-identical between the two files.
+
+These lemmas sit on top of `Conway.LookAndSay`. They form the HARDEST rung of the
+prover co-evolution calibration ladder (Epic #1453):
+
+  - `digitsToNat_example` : closed list evaluation        -> decide / rfl       (easy)
+  - `lookAndSay_4`        : well-founded recursion result -> native_decide      (medium:
+        naive `rfl`/`decide` may not reduce the WF recursion; prover may be tempted to
+        invoke a non-existent simp lemma — exercises the phantom-id blocklist path P3)
+  - `digitsToNat_natToDigits` : round-trip over decimal digits.
+        Genuinely requires structural induction matching `natToDigits` (recursion on
+        `n / 10`), plus a `digitsToNat` append lemma. This is the strategic-decomposition
+        stress target — the Director must NOT expect a one-shot tactic.        (hard)
+
+The proof holes in the original calibration scaffold are intentional, not regressions (Epic #1453).
+-/
+
+import Conway.LookAndSay
+
+namespace Conway_en
+
+open Conway
+
+/-- CALIBRATION (decide): [1,2,1,1] decodes to 1211. -/
+theorem digitsToNat_example : digitsToNat [1, 2, 1, 1] = 1211 := by
+  native_decide
+
+/-- CALIBRATION (native_decide): the 5th look-and-say term (0-indexed) is 111221. -/
+theorem lookAndSay_4 : lookAndSay 4 = 111221 := by
+  native_decide
+
+/-- CALIBRATION (hard, structural induction): decoding the decimal digits of `n`
+    recovers `n`. Requires induction matching `natToDigits`'s recursion on `n / 10`. -/
+theorem digitsToNat_natToDigits (n : Nat) : digitsToNat (natToDigits n) = n := by
+  have h_append : ∀ (xs : List Nat) (d : Nat),
+      digitsToNat (xs ++ [d]) = digitsToNat xs * 10 + d := by
+    intro xs d
+    induction xs with
+    | nil =>
+        simp [digitsToNat]
+    | cons x xs ih =>
+        simp [digitsToNat, ih, List.length_append, Nat.pow_succ, Nat.mul_add,
+          Nat.add_assoc, Nat.add_comm, Nat.add_left_comm, Nat.mul_assoc]
+        simp [Nat.add_mul, Nat.mul_add, Nat.mul_assoc, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+  exact Nat.strongRecOn n (fun n ih => by
+    unfold natToDigits
+    by_cases hn : n = 0
+    · simp [hn, digitsToNat]
+    · simp [hn]
+      rw [h_append]
+      have hlt : n / 10 < n := Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by decide : 1 < 10)
+      rw [ih (n / 10) hlt]
+      omega)
+
+end Conway_en


### PR DESCRIPTION
## i18n(#4980): conway_lean/Conway/LookAndSayLemmas -- FR-first sibling pair

### Substance

Sibling pair FR canonique + EN mirror pour `conway_lean/Conway/LookAndSayLemmas.lean` (lemmes Look-and-Say — barreau le plus difficile de l'échelle de calibration du harnès prouveur, Epic #1453).

| Fichier | Type | Rôle |
|---------|------|------|
| `LookAndSayLemmas.lean` (FR) | modified | FR canonique — header + 3 docstrings EN->FR, corps de preuve byte-identical |
| `LookAndSayLemmas_en.lean` (EN) | new | miroir anglais — `namespace Conway_en`, `open Conway`, docstrings EN originales |

### Preuves (anti-complaisance)

- **Code byte-identical** : les énoncés de théorèmes ET le corps de preuve complet de `digitsToNat_natToDigits` (induction structurelle dure, ~20 lignes, `Nat.strongRecOn` + `omega`) sont **byte-identical** FR↔EN (vérifié `cat -A` : mêmes caractères `forall` et `middot`, mêmes tactiques). Seuls le bloc header et 3 docstrings diffèrent.
- **C404-L1 sorry count** (standalone-tactic mode, CI canonique) : **0/0**.
- **Parser-safety FR** : délimiteurs de commentaires équilibrés (4 blocs correctement appairés, 0 littéral `/-`/`-/` dans la prose — leçon tirée du bug delimiter de #6388).
- **Line-endings** : origin/main `LookAndSayLemmas.lean` était CRLF (55 CR, pré-règle) ; cette PR normalise en LF (staged blob CR=0, vérifié python byte-count) conformément à `.gitattributes *.lean text eol=lf`.

### Convention

EPIC #4980 (décision user ratifiée 2026-07-04), modèle **Option-A sibling pair** — identique à #6332 (MathlibMap) et #6388 (DoomsdayLemmas, même lake).

### Build / lakefile

- **Aucun changement de lakefile** : `lean_lib Conway where` (bare) build les siblings `_en` — prouvé par #6332/#6355 et confirmé CI-green sur #6388.
- **CI = vérificateur autoritaire** : `.github/workflows/lean-build.yml` (sorry-baseline conway_lean = 7, sorry-filter standalone-tactic). Démarche identique aux précédents conway_lean i18n.

### Pivot R6 (anti-tunneling)

c.437 = 2e PR Lean i18n conway_lean ce cycle (après #6388 DoomsdayLemmas). Pivot OFF probe/accent (drained/capped) vers Lean plate substance. Les 2 PR sont file-disjoint (DoomsdayLemmas vs LookAndSayLemmas), merge indépendant.

See #4980