### PR TITLE
fix(sudoku): nbformat v4.5 cell ids for Sudoku C# series (10 notebooks, 60 cells)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -593,7 +593,8 @@
     "**Indice :**\n",
     "Parcourez chaque ligne, colonne et bloc 3x3 et vérifiez que chaque ensemble\n",
     "contient exactement les chiffres 1 à 9 sans doublon.\n"
-   ]
+   ],
+   "id": "cell-12130bab"
   },
   {
    "cell_type": "code",
@@ -616,7 +617,8 @@
     "    // contient les chiffres 1-9 sans doublon\n",
     "    return false; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-93f14df0"
   },
   {
    "cell_type": "code",
@@ -873,7 +875,8 @@
     "\n",
     "**Indice :**\n",
     "Utilisez un Stopwatch pour mesurer le temps et comptez les appels récursifs.\n"
-   ]
+   ],
+   "id": "cell-e6cd772b"
   },
   {
    "cell_type": "code",
@@ -896,7 +899,8 @@
     "    // les temps de resolution et le nombre d'appels recursifs\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-c037ef20"
   },
   {
    "cell_type": "markdown",
@@ -1017,7 +1021,8 @@
     "\n",
     "**Indice :**\n",
     "Ajoutez un compteur global et arrêtez la recherche après `maxCount` solutions trouvées.\n"
-   ]
+   ],
+   "id": "cell-77cac3cd"
   },
   {
    "cell_type": "code",
@@ -1040,7 +1045,8 @@
     "    // au lieu de s'arreter a la premiere trouvee\n",
     "    return 0; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-52072482"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -344,7 +344,8 @@
     "\n",
     "**Indice :**\n",
     "Utilisez la négation et la conjonction pour exprimer la contrainte.\n"
-   ]
+   ],
+   "id": "cell-3a69b31b"
   },
   {
    "cell_type": "code",
@@ -366,7 +367,8 @@
     "    // TODO: Construisez un BDD qui est vrai si exactement une des N variables est vraie\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-a18373c4"
   },
   {
    "cell_type": "code",
@@ -1146,7 +1148,8 @@
     "**Indice :**\n",
     "Chaque niveau du MDD représente une cellule, et chaque arc représente une valeur possible\n",
     "non encore utilisée.\n"
-   ]
+   ],
+   "id": "cell-6adc0426"
   },
   {
    "cell_type": "code",
@@ -1169,7 +1172,8 @@
     "    // ou toutes les valeurs sont différentes\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-fff6d6dd"
   },
   {
    "cell_type": "code",
@@ -1928,7 +1932,8 @@
     "\n",
     "**Indice :**\n",
     "Mesurez la taille (nombre de nœuds) et le temps de construction et de résolution.\n"
-   ]
+   ],
+   "id": "cell-ddbd1a34"
   },
   {
    "cell_type": "code",
@@ -1951,7 +1956,8 @@
     "    // et comparez les temps de construction et résolution\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-f520daf3"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -507,7 +507,8 @@
     "**Indice :**\n",
     "Identifiez les 4 types de contraintes et creez les lignes de la matrice\n",
     "pour chaque assignation (cellule, valeur) possible.\n"
-   ]
+   ],
+   "id": "cell-540beb27"
   },
   {
    "cell_type": "code",
@@ -530,7 +531,8 @@
     "    // pour un Sudoku 4x4 (chiffres 1-4, blocs 2x2)\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-c74db898"
   },
   {
    "cell_type": "markdown",
@@ -980,7 +982,8 @@
     "\n",
     "**Indice :**\n",
     "Incrémente le compteur a chaque appel récursif de la méthode de recherche.\n"
-   ]
+   ],
+   "id": "cell-710410ef"
   },
   {
    "cell_type": "code",
@@ -1003,7 +1006,8 @@
     "    // par l'algorithme Dancing Links\n",
     "    return 0; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-a99af7d9"
   },
   {
    "cell_type": "markdown",
@@ -1136,7 +1140,8 @@
     "\n",
     "**Indice :**\n",
     "Mesurez le temps et le nombre d'opérations pour chaque solveur.\n"
-   ]
+   ],
+   "id": "cell-0bbe5a5a"
   },
   {
    "cell_type": "code",
@@ -1159,7 +1164,8 @@
     "    // sur des puzzles faciles, moyens et difficiles\n",
     "    // Affichez les resultats dans un tableau\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-218b4b92"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -316,7 +316,8 @@
     "**Indice :**\n",
     "Au lieu de simplement compter le nombre total de conflits, multipliez chaque\n",
     "type par un coefficient et sommez.\n"
-   ]
+   ],
+   "id": "cell-f737f5d7"
   },
   {
    "cell_type": "code",
@@ -338,7 +339,8 @@
     "    // TODO: Calculez un score de fitness pondere selon le type de conflit\n",
     "    return 0.0; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-88ccad50"
   },
   {
    "cell_type": "code",
@@ -468,7 +470,8 @@
     "\n",
     "**Indice :**\n",
     "Choisissez une ligne aléatoire, puis deux positions dans cette ligne, et echangez-les.\n"
-   ]
+   ],
+   "id": "cell-e87abb30"
   },
   {
    "cell_type": "code",
@@ -491,7 +494,8 @@
     "    // non fixees dans cette ligne\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-6c9a0750"
   },
   {
    "cell_type": "code",
@@ -828,7 +832,8 @@
     "\n",
     "**Indice :**\n",
     "Lancez les deux solveurs avec les mêmes parametres et comparez les taux de succès.\n"
-   ]
+   ],
+   "id": "cell-65e1775f"
   },
   {
    "cell_type": "code",
@@ -851,7 +856,8 @@
     "    // et retournez le taux de succes moyen de chacune\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-fc30d0aa"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -1110,7 +1110,8 @@
     "\n",
     "**Indice :**\n",
     "Parcourez chaque unite et ignorez celles ou toutes les valeurs sont a 0.\n"
-   ]
+   ],
+   "id": "cell-421f6551"
   },
   {
    "cell_type": "code",
@@ -1132,7 +1133,8 @@
     "    // TODO: Compter les conflits uniquement dans les unites non vides\n",
     "    return 0; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-a2b7fd76"
   },
   {
    "cell_type": "code",
@@ -1436,7 +1438,8 @@
     "\n",
     "**Indice :**\n",
     "Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc.\n"
-   ]
+   ],
+   "id": "cell-2f739ce6"
   },
   {
    "cell_type": "code",
@@ -1458,7 +1461,8 @@
     "    // TODO: Echangez deux valeurs non fixees dans un meme bloc 3x3\n",
     "    return (null, (0, 0), (0, 0)); // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-97f29c0e"
   },
   {
    "cell_type": "code",
@@ -2281,7 +2285,8 @@
     "\n",
     "**Indice :**\n",
     "Pour le schema exponentiel: T = T_init * alpha^step.\n"
-   ]
+   ],
+   "id": "cell-f033d6fa"
   },
   {
    "cell_type": "code",
@@ -2303,7 +2308,8 @@
     "    // TODO: Generez la liste de temperatures selon le schema exponentiel\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-7f18fd49"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -1137,7 +1137,8 @@
     "\n",
     "**Indice :**\n",
     "Pour chaque taille, lancez le solveur sur les mêmes puzzles et comparez les résultats.\n"
-   ]
+   ],
+   "id": "cell-49c662b6"
   },
   {
    "cell_type": "code",
@@ -1159,7 +1160,8 @@
     "    // TODO: Testez differentes tailles d'essaim et mesurez les performances\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-2ac33167"
   },
   {
    "cell_type": "code",
@@ -2077,7 +2079,8 @@
     "\n",
     "**Indice :**\n",
     "Enregistrez la meilleure fitness a chaque itération et affichez avec un graphique.\n"
-   ]
+   ],
+   "id": "cell-e2a6d0af"
   },
   {
    "cell_type": "code",
@@ -2100,7 +2103,8 @@
     "    // Retournez la liste des erreurs pour tracer la courbe de convergence\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-f0a31030"
   },
   {
    "cell_type": "markdown",
@@ -2265,7 +2269,8 @@
     "\n",
     "**Indice :**\n",
     "Testez systematiquement des combinaisons de paramètres sur un ensemble de puzzles."
-   ]
+   ],
+   "id": "cell-8fc0527d"
   },
   {
    "cell_type": "code",
@@ -2288,7 +2293,8 @@
     "    // et retournez les meilleurs parametres trouves\n",
     "    return (0, 0, 0, 0); // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-5864eb59"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -465,7 +465,8 @@
     "\n",
     "**Indice :**\n",
     "Parcourez la ligne, colonne et bloc de la cellule et excluez les valeurs déjà présentées.\n"
-   ]
+   ],
+   "id": "cell-5ea23b90"
   },
   {
    "cell_type": "code",
@@ -480,7 +481,8 @@
     "    // en excluant les valeurs déjà présentées dans la ligne, colonne et bloc\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-8d50db65"
   },
   {
    "cell_type": "code",
@@ -1105,7 +1107,8 @@
     "\n",
     "**Indice :**\n",
     "Appliquez AC-3 pour réduire les domaines, puis lancez le backtracking sur les domaines réduits.\n"
-   ]
+   ],
+   "id": "cell-36d5dcd9"
   },
   {
    "cell_type": "code",
@@ -1120,7 +1123,8 @@
     "    // puis lancez le backtracking améliore sur les domaines réduits\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-1639f005"
   },
   {
    "cell_type": "code",
@@ -1567,7 +1571,8 @@
     "\n",
     "**Indice :**\n",
     "Mesurez le nombre d'appels recursifs et le temps pour chaque méthode.\n"
-   ]
+   ],
+   "id": "cell-9979ea7d"
   },
   {
    "cell_type": "code",
@@ -1582,7 +1587,8 @@
     "    // et retournez les statistiques comparatives\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-5698f05c"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
@@ -295,7 +295,8 @@
     "**Indice :**\n",
     "Pour chaque valeur 1-9, comptez dans combien de cellules d'une unité elle peut apparaitre.\n",
     "Si exactement 1, c'est un Hidden Single.\n"
-   ]
+   ],
+   "id": "cell-04772a8d"
   },
   {
    "cell_type": "code",
@@ -318,7 +319,8 @@
     "    // aller que dans une seule cellule de cette unite\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-6dca0fc6"
   },
   {
    "cell_type": "code",
@@ -771,7 +773,8 @@
     "\n",
     "**Indice :**\n",
     "Parcourez chaque unité et cherchez des paires de cellules avec les memes 2 candidats.\n"
-   ]
+   ],
+   "id": "cell-ba432058"
   },
   {
    "cell_type": "code",
@@ -794,7 +797,8 @@
     "    // Retournez la liste des paires trouvees avec leurs positions et valeurs\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-511956d9"
   },
   {
    "cell_type": "markdown",
@@ -1126,7 +1130,8 @@
     "\n",
     "**Indice :**\n",
     "Modifiez le solveur pour court-circuiter l'étape eliminate et ne garder que assign.\n"
-   ]
+   ],
+   "id": "cell-2872abc1"
   },
   {
    "cell_type": "code",
@@ -1149,7 +1154,8 @@
     "    // et comparez les temps moyens de résolution\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-3f3a84a2"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
@@ -513,7 +513,8 @@
     "\n",
     "**Indice :**\n",
     "Utilisez FindNakedSingles sur plusieurs puzzles et calculez la moyenne par difficulté.\n"
-   ]
+   ],
+   "id": "cell-23e2e0f0"
   },
   {
    "cell_type": "code",
@@ -536,7 +537,8 @@
     "    // le nombre moyen de naked singles trouves\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-825ad783"
   },
   {
    "cell_type": "code",
@@ -1147,7 +1149,8 @@
     "Parcourez chaque unité et identifiez les valeurs qui n'apparaissent que 2 fois.\n",
     "**Étape 2 :**\n",
     "Verifiez si ces 2 valeurs partagent les mêmes 2 cellules.\n"
-   ]
+   ],
+   "id": "cell-3fd11070"
   },
   {
    "cell_type": "code",
@@ -1170,7 +1173,8 @@
     "    // Retournez la liste des paires avec leurs positions et valeurs\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-9d91abb6"
   },
   {
    "cell_type": "code",
@@ -2081,7 +2085,8 @@
     "\n",
     "**Indice :**\n",
     "Utilisez HumanSolver et comptez les puzzles résolus sans atteindre le backtracking.\n"
-   ]
+   ],
+   "id": "cell-726b9950"
   },
   {
    "cell_type": "code",
@@ -2104,7 +2109,8 @@
     "    // combien sont resolus uniquement par strategies humaines\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-ea125e8b"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
@@ -449,7 +449,8 @@
     "\n",
     "**Indice :**\n",
     "Utilisez le graphe construit et comptez le degré de chaque noeud.\n"
-   ]
+   ],
+   "id": "cell-a865d9d5"
   },
   {
    "cell_type": "code",
@@ -472,7 +473,8 @@
     "    // Retournez un dictionnaire (cellule -> nombre de contraintes)\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-27d45835"
   },
   {
    "cell_type": "markdown",
@@ -671,7 +673,8 @@
     "\n",
     "**Indice :**\n",
     "Triez les variables candidats par nombre de voisins non assignes en cas d'égalité MRV.\n"
-   ]
+   ],
+   "id": "cell-24ec7457"
   },
   {
    "cell_type": "code",
@@ -694,7 +697,8 @@
     "    // En cas d'egalite, choisissez celle avec le plus de voisins non assignes\n",
     "    return (-1, -1); // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-22f93ceb"
   },
   {
    "cell_type": "code",
@@ -1303,7 +1307,8 @@
     "\n",
     "**Indice :**\n",
     "Pour chaque arête du graphe, verifiez que les deux noeuds ont des couleurs différentes.\n"
-   ]
+   ],
+   "id": "cell-711fda12"
   },
   {
    "cell_type": "code",
@@ -1326,7 +1331,8 @@
     "    // les valeurs sont differentes\n",
     "    return false; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-c053aced"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## nbformat v4.5 cell-id hygiene — Sudoku C# series (10 notebooks, 60 cells)

Adds the required `id` field to cells that declare nbformat v4.5 (`nbformat_minor=5`) but are missing it. Pure **structural metadata** fix — no re-execution, content byte-identical.

### Why

`nbformat.validate()` warns/fails on a v4.5 notebook whose cells lack `id`. The fleet-wide v4.5 cell-id register is actively in progress (po-2026 fixed QC-Cloud #6254 + QC-Py main #6257; po-2024 fixed QC-Py slices #6285/#6290; Search family #6292; ICT #6293; GenAI-FT #6296; Probas-Infer #6294). **The Sudoku C# family was unclaimed** — this PR covers it.

### Scope (10 notebooks, disjoint from open Sudoku PRs)

| Notebook | Kernel | Cells missing id |
|----------|--------|-----------------:|
| Sudoku-1-Backtracking-Csharp | .net-csharp | 6 |
| Sudoku-2-DancingLinks-Csharp | .net-csharp | 6 |
| Sudoku-3-Genetic-Csharp | .net-csharp | 6 |
| Sudoku-4-SimulatedAnnealing-Csharp | .net-csharp | 6 |
| Sudoku-5-PSO-Csharp | .net-csharp | 6 |
| Sudoku-6-AIMA-CSP-Csharp | .net-csharp | 6 |
| Sudoku-7-Norvig-Csharp | .net-csharp | 6 |
| Sudoku-8-HumanStrategies-Csharp | .net-csharp | 6 |
| Sudoku-9-GraphColoring-Csharp | .net-csharp | 6 |
| Sudoku-14-BDD-Csharp | .net-csharp | 6 |
| **Total** | | **60** |

**Collision-clean**: open Sudoku PRs target different files — #6327 (accents/probe) touches Sudoku-10/11/12/13/18-Csharp; #6380 (accents) touches Sudoku-15-Csharp. This PR targets Sudoku-1/2/3/4/5/6/7/8/9/14-Csharp only (verified disjoint via `gh pr view --json files`).

### Anti-regression (content byte-identical)

1. **Content fingerprint stable** — for every cell, all keys except `id` are identical before/after. Grep of diff for changed `source`/`outputs`/`execution_count`/`cell_type`/`metadata` lines = **EMPTY** (no content line touched).
2. **Round-trip fidelity asserted BEFORE edit** — `json.dumps(nb, indent=1, ensure_ascii=False)` reproduces the original file byte-for-byte (including trailing-newline behavior, preserved per cell); the only diff produced is the added `"id"` line + the `]`→`],` comma that precedes it. Diff decomposes exactly as 60 new id lines + 60 comma additions = **+120/−60**.
3. **`nbformat.validate()` PASS** on all 10 notebooks (0 cells missing id post-fix).
4. **Repo validator** `scripts/notebook_tools/validate_pr_notebooks.py` → **PASS**.

### Methodology

Ids are **deterministic** (`cell-<md5(basename.ipynb:all-cell-index)[:8]>`) and unique within each notebook. Verified empirically against Search-5 (#6292): cells 0-3 = exact MATCH. Matches the proven register (#6257 / #6285 / #6290 / #6292). Exec-equivalent metadata fix — no re-execution; .NET Advisory #5214 (CI cannot Papermill .NET Interactive, but `nbformat.validate` is structural, not execution).

### R6 family rotation

c.437 Lean conway i18n → c.438 .NET probe Tweety → c.439 Lean grothendieck i18n → **c.440 Sudoku .NET C# (structural metadata)**. Genuine family+register rotation (non-Lean, non-i18n). Scan c.440 found all non-Lean maintenance registers saturated (probe=DONE, accents=drained, conclusion-cell/three-exercises/C.1/execution-errors all mature, source-leak pip saturated by another worker, Lean i18n 21 open PRs); the nbformat v4.5 cell-id register was the clean structural register with unclaimed targets.