### PR TITLE
fix(gametheory): nbformat v4.5 cell ids for GameTheory Python series (4 notebooks, 8 cells)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
@@ -1889,7 +1889,8 @@
     "- **Etape 3** : Comparer avec le resultat en information complete\n",
     "\n",
     "*Indice* : Un prix bas peut etre un signal credible de force (le faible ne peut pas imiter)."
-   ]
+   ],
+   "id": "cell-2aa0ebcd"
   },
   {
    "cell_type": "code",
@@ -1914,7 +1915,8 @@
     "    return {\"equilibrium_signal\": None, \"entrant_enters\": None}  # TODO etudiant\n",
     "\n",
     "print(\"Exercice a completer\")"
-   ]
+   ],
+   "id": "cell-d5ed0e02"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
@@ -1687,7 +1687,8 @@
     "- **Etape 3** : Analyser si la reputation (TFT) est un avantage ou un cout\n",
     "\n",
     "*Indice* : En finitude connue, backward induction predit toujours defect. La reputation change-t-elle cela ?"
-   ]
+   ],
+   "id": "cell-53398827"
   },
   {
    "cell_type": "code",
@@ -1712,7 +1713,8 @@
     "    return {\"tft_payoff\": 0, \"myopic_payoff\": 0, \"history\": []}  # TODO etudiant\n",
     "\n",
     "print(\"Exercice a completer\")"
-   ]
+   ],
+   "id": "cell-7f3d611b"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
@@ -7218,7 +7218,8 @@
     "\n",
     "*Indice* : La solution analytique de Kuhn Poker (1930) est connu. Joueur 1 avec K mise toujours.\n",
     "Joueur 1 avec Q check toujours. Joueur 1 avec J mise avec probabilite alpha."
-   ]
+   ],
+   "id": "cell-7b58d7e5"
   },
   {
    "cell_type": "code",
@@ -7243,7 +7244,8 @@
     "    return {\"strategy\": {}, \"converged\": False}  # TODO etudiant\n",
     "\n",
     "print(\"Exercice a completer\")"
-   ]
+   ],
+   "id": "cell-bce43bec"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
@@ -1806,7 +1806,8 @@
     "- **Etape 3** : Calculer le temps de capture et verifier qu'il est fini quand v_p > v_e\n",
     "\n",
     "*Indice* : La strategie optimale de P est de se diriger directement vers E (ligne droite)."
-   ]
+   ],
+   "id": "cell-d25fbf6f"
   },
   {
    "cell_type": "code",
@@ -1831,7 +1832,8 @@
     "    return {\"capture_time\": None, \"trajectory\": []}  # TODO etudiant\n",
     "\n",
     "print(\"Exercice a completer\")"
-   ]
+   ],
+   "id": "cell-1bdf5de7"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Adds deterministic nbformat v4.5 cell `id`s to the 4 GameTheory **Python** notebooks whose cells lacked the `id` field required by `nbformat_minor=5` (`nbformat.validate()` fails/warns without it).

| Notebook | Cells missing id | Kernel |
|----------|-----------------|--------|
| GameTheory-10-ForwardInduction-SPE.ipynb | 2 | python3 |
| GameTheory-12-ReputationGames.ipynb | 2 | python3 |
| GameTheory-13-ImperfectInfo-CFR.ipynb | 2 | gametheory-wsl |
| GameTheory-14-DifferentialGames.ipynb | 2 | python3 |

**Total: 8 cell ids across 4 notebooks.**

## Method (canonical, structural-only)

Deterministic formula (convention proven across #6257/#6285/#6290/#6292/#6301/#6303/#6392):
```
id = 'cell-' + md5('<basename-with-.ipynb>:<all-cell-index-0-based>')[:8]
```
- basename **includes** the `.ipynb` extension (e.g. `GameTheory-10-ForwardInduction-SPE.ipynb:5`)
- index = 0-based position across **ALL** cells (code + markdown mixed), not code-only
- uniqueness guaranteed per notebook (md5 of a per-cell unique key)

Pure structural metadata. **No re-execution.** These are Python notebooks (not .NET), so nbformat structural validation is fully authoritative.

## Anti-regression proof (content byte-identical)

- **Round-trip fidelity asserted BEFORE edit**: `json.dumps(nb, indent=1, ensure_ascii=False)` reproduces the original file byte-for-byte, with the trailing newline preserved per-notebook (GT-10/GT-12 keep `\n`; GT-13/GT-14 have no trailing `\n`).
- **Diff = +16/−8** = exact `2N/N` pattern (8 `"id"` lines + 8 structural comma companions `]` → `],` where the `id` key is appended as the last dict key).
- **Zero content changes**: grep of the diff for `source`/`outputs`/`execution_count`/`metadata`/`cell_type` modifications among `+`/`−` lines = empty (only the id lines and their `]`→`],` comma companions).

## Validation

- `nbformat.validate()` **4/4 PASS** (0 missing ids post-fix)
- `scripts/notebook_tools/validate_pr_notebooks.py` **4/4 PASS**

## Collision check

`gh pr list --state open --search "GameTheory-10/12/13/14"` — the open GameTheory PRs are all `.NET` probe strips (#6335/#6336 Tranche A/B), GT-2-Part2 (#6381), GT-5-csharp accents (#6176), and RepeatedGames lake absorb (#6146). None touch these 4 **Python** notebooks for cell ids. Disjoint.

Part of the fleet-wide nbformat v4.5 cell-id register (post-QC/Sudoku/rl tranches).