### PR TITLE
enrich(infer-6): closing synthesis markdown cell — debugging probabiliste takeaway (#2651)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
@@ -3098,6 +3098,36 @@
     "\n",
     "Console.WriteLine(\"Exercice a completer : debugging regression bayesienne\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-ac3c02c4",
+   "metadata": {},
+   "source": [
+    "## Synthese : la demarche du debuggeur probabiliste\n",
+    "\n",
+    "Les quatre exercices de fin illustrent une meme realite : en programmation probabiliste, l'erreur se manifeste rarement par un crash, mais par un posterieur **degenere** (variance quasi-nulle ou infinie) ou **non informatif**. Le reflexe du debuggeur classique -- ou est le bug dans le code -- doit ceder la place a une demarche en trois temps, dont chaque exercice isole un symptome.\n",
+    "\n",
+    "| Exercice | Piege decouvert | Ou le diagnostic le repere |\n",
+    "|----------|-----------------|----------------------------|\n",
+    "| Ex 3 (modele hierarchique) | `Gamma` de shape negatif + moyenne de population figee | shape < 0 leve une exception ; une precision de 10000 fige la moyenne |\n",
+    "| Ex 4 (regression bayesienne) | Prior trop etroit sur la pente + bruit `Gamma(0.1, 0.1)` | `DiagnosticGaussian` revele une variance nulle ; le bruit a une densite infinie en 0 |\n",
+    "\n",
+    "### Les deux familles de fautifs\n",
+    "\n",
+    "Dans toute la serie, les pannes se ramenent a deux familles :\n",
+    "\n",
+    "1. **Les priors** -- trop etroits (`GaussianFromMeanAndPrecision(0, 10000)` fige la variable), hors-support de l'observation (`ObservedValue = 100` sous un prior centre sur 0), ou invalides (`Gamma` de shape < 1, precision negative). La regle empirique reste : un `Gamma` doit avoir `shape >= 1`, et la precision d'un prior vague vaut `0.01`, pas `10000`.\n",
+    "2. **Le choix d'algorithme** -- EP pour le continu (rapide mais peut diverger), VMP pour le discret (stable mais sous-estime l'incertitude, comme on l'a mesure : variance posterieure plus etroite), Gibbs pour la validation exacte sur petits modeles. Un melange gaussien brise sous VMP peut converger sous EP.\n",
+    "\n",
+    "### Le factor graph, juge de paix\n",
+    "\n",
+    "Quand un posterieur defie l'intuition, le factor graph tranche : il revele les composantes deconnectees, les observations mal indexees (Ex 3, indice 3), et les dependances manquantes. `engine.ShowFactorGraph = true` associe au `FactorGraphHelper` n'est pas une fioriture -- c'est l'equivalent du `print` du debuggeur classique.\n",
+    "\n",
+    "### Ce quil faut emporter\n",
+    "\n",
+    "Le debugging probabiliste est avant tout un **changement de regard** : un mauvais resultat n'est pas un bug a corriger dans le code, mais un signal que le modele ou l'algorithme ne correspond pas aux hypotheses implicites des donnees. La demarche systematique -- **Support, Algorithme, Posterieurs**, validee par les fonctions `DiagnosticGaussian` / `DiagnosticGamma` / `DiagnosticBeta` -- est transferable a tous les notebooks suivants de la serie (modeles hierarchiques, series temporelles, modeles de recommandation). Gardez-la sous la main : les pannes se ressemblent, seules les distributions changent.\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

`Infer-6-Debugging.ipynb` ended abruptly on a code exercise cell (Ex 4 regression debugging), with no closing synthesis after its four exercises. It has a mid-section recap table, but nothing that closes the loop on the exercises the reader just worked through. This appends one markdown synthesis cell (C.3 markdown-only, [#2651](https://github.com/jsboige/CoursIA/issues/2651) prose mandate).

## What the cell adds (specific, not generic)

- **Metacognitive frame**: the debugging-probabiliste mindset shift — a "bad result" is a model/algorithm mismatch *signal*, not a code bug to fix.
- **Exercise-to-diagnostic table**: ties **Ex 3** (hierarchical: `Gamma` shape<0 + population mean figée par precision `10000`) and **Ex 4** (regression: prior trop étroit sur la pente + bruit `Gamma(0.1, 0.1)`) to the diagnostic that catches each (`DiagnosticGaussian` variance nulle / `Gamma` densité infinie en 0).
- **The two root-cause families**: priors mal spécifiés (too narrow, off-support, invalid shape) and mauvais choix d'algorithme (EP continu rapide/divergent, VMP discret stable/sous-estime l'incertitude, Gibbs validation exacte), restating the empiric rule `Gamma shape >= 1` and precision `~0.01`.
- **Factor-graph as judge-of-peace** (composantes déconnectées, observations mal indexées — Ex 3 indice 3).
- **Transferable triad** `Support → Algorithme → Postérieurs`, validated by the `DiagnosticGaussian` / `DiagnosticGamma` / `DiagnosticBeta` functions, pointed at the rest of the series (hierarchical, time-series, recommenders).

All references are to the notebook's own material (the exercises, the priors, the EP/VMP variance comparison measured earlier, the diagnostic functions) — no generic "Suite du traitement".

## C.3 markdown-only — no re-execution

- No code cell touched. All 17 existing code cells keep their `execution_count != null` and outputs intact (C.2 exception: markdown-only edit, previous outputs valid).
- New cell carries a deterministic nbformat v4.5 id (`cell-ac3c02c4`, formula `cell-<md5(basename:idx)[:8]>`).

## Anti-regression / validation

- Round-trip fidelity asserted on the **unmodified** notebook before append (proves zero churn on existing content): `json.dumps(indent=1, ensure_ascii=False)` reproduces the original byte-for-byte.
- Diff = **30 insertions, 0 deletions** (pure additive append).
- `nbformat.validate()` OK; `scripts/notebook_tools/validate_pr_notebooks.py` **1/1 PASS**.

## Collision check

`gh pr list --state open --search "Infer-6"` — the Probas/Infer open PRs are #6338 (probe strip Tranche A, 7 .NET notebooks) and #6379 (DecInfer probes), neither touches `Infer-6-Debugging.ipynb`. Disjoint.

See #2651 (conclusion/interpretation-cell mandate) and #3966 (visual formatting).