### PR TITLE
fix(smartcontracts): nbformat v4.5 cell ids for SmartContracts Python notebooks (2 notebooks, 11 cells)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
@@ -1100,7 +1100,8 @@
     "2. Ajoutez un **plafond** : refusez (`require`) tout depot qui ferait depasser un solde individuel de 5 ETH.\n",
     "3. Redeployez le contrat, effectuez un depot valide puis un depot qui depasse le plafond ",
     "(attrapez l'exception), et lisez les evenements via `contract.events.Deposit().get_logs(...)`.\n"
-   ]
+   ],
+   "id": "cell-a50e497c"
   },
   {
    "cell_type": "code",
@@ -1124,7 +1125,8 @@
     "#   Etape 4 : lire les evenements emis via vault.events.Deposit().get_logs(from_block=0)\n",
     "\n",
     "print(\"Exercice a completer\")\n"
-   ]
+   ],
+   "id": "cell-7e00b0ce"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -1438,7 +1438,8 @@
     "concepts fondamentaux de Solana et Anchor vus dans ce notebook : derivation de PDA, ",
     "structure d'un programme Anchor, et modele de comptes Solana. Chaque enonce est suivi de ",
     "sa solution commentee.\n"
-   ]
+   ],
+   "id": "cell-e888e70e"
   },
   {
    "cell_type": "markdown",
@@ -1452,7 +1453,8 @@
     "hash des seeds soit \"hors courbe\" ed25519 -- ici simule par la condition `premier octet < 128`. ",
     "La derivation doit etre **deterministe** (memes seeds -> meme PDA) et **unique par utilisateur** ",
     "(seeds differentes -> PDAs differents).\n"
-   ]
+   ],
+   "id": "cell-e060ec01"
   },
   {
    "cell_type": "code",
@@ -1510,7 +1512,8 @@
     "seeds_bob = [b\"counter\", b\"bob_pubkey_example\"]\n",
     "pda_bob, _ = derive_pda_simulee(seeds_bob, program_id)\n",
     "print(f\"PDA bob != alice : {pda != pda_bob}\")\n"
-   ]
+   ],
+   "id": "cell-8f053f72"
   },
   {
    "cell_type": "markdown",
@@ -1523,7 +1526,8 @@
     "Un programme Anchor de sondage : `create_poll` initialise le compte `Poll` (un PDA derive de ",
     "`[b\"poll\", authority]`), et `vote` incremente le compteur du choix avec garde sur la fermeture ",
     "du sondage et la validite du choix. Le code Rust complet est presente ci-dessous.\n"
-   ]
+   ],
+   "id": "cell-0a6a741b"
   },
   {
    "cell_type": "code",
@@ -1700,7 +1704,8 @@
     "\n",
     "print(\"Exercice 2 - Programme de vote Anchor complete :\")\n",
     "print(VOTE_PROGRAM_COMPLET)\n"
-   ]
+   ],
+   "id": "cell-0ba91f97"
   },
   {
    "cell_type": "markdown",
@@ -1714,7 +1719,8 @@
     "programme Counter Anchor : `initialize` cree un compte `count = 0`, `increment`/`decrement` ",
     "verifient l'authority avant toute modification, et `decrement` protege contre l'underflow ",
     "(comme le ferait Anchor).\n"
-   ]
+   ],
+   "id": "cell-b5fa60f6"
   },
   {
    "cell_type": "code",
@@ -1780,7 +1786,8 @@
     "    program.increment(counter, \"intrus_pubkey_000\")\n",
     "except ValueError as e:\n",
     "    print(f\"Autorite invalide interceptee : {e}\")\n"
-   ]
+   ],
+   "id": "cell-0dfc58f1"
   },
   {
    "cell_type": "markdown",
@@ -1800,7 +1807,8 @@
     "\n",
     "**Indice** : reprenez le pattern de verification `authority != counter.data[\"authority\"]` deja ",
     "utilise dans `increment`/`decrement`.\n"
-   ]
+   ],
+   "id": "cell-709d9e8a"
   },
   {
    "cell_type": "code",
@@ -1824,7 +1832,8 @@
     "#   Etape 4 : scenario de test (increment jusqu'au plafond, increment de trop, reset)\n",
     "\n",
     "print(\"Exercice a completer\")\n"
-   ]
+   ],
+   "id": "cell-9c2384f2"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Adds deterministic nbformat v4.5 cell `id`s to the 2 SmartContracts **Python** notebooks whose cells lacked the `id` field required by `nbformat_minor=5` (`nbformat.validate()` fails/warns without it).

| Notebook | Cells missing id | Kernel | Sub-series |
|----------|-----------------|--------|------------|
| SC-22-Solana-Anchor.ipynb | 9 | python3 | 05-Alternative-Chains |
| SC-2-Setup-Web3py.ipynb | 2 | python3 | 00-Foundations |

**Total: 11 cell ids across 2 notebooks.**

## Method (canonical, structural-only)

Deterministic formula (convention proven across #6257/#6285/#6290/#6292/#6301/#6303/#6392/#6393):
```
id = 'cell-' + md5('<basename-with-.ipynb>:<all-cell-index-0-based>')[:8]
```
- basename **includes** the `.ipynb` extension (e.g. `SC-22-Solana-Anchor.ipynb:5`)
- index = 0-based position across **ALL** cells (code + markdown mixed), not code-only
- uniqueness guaranteed per notebook (md5 of a per-cell unique key)

Pure structural metadata. **No re-execution.** Python notebooks, so nbformat structural validation is fully authoritative.

## Anti-regression proof (content byte-identical)

- **Round-trip fidelity asserted BEFORE edit**: `json.dumps(nb, indent=1, ensure_ascii=False)` reproduces the original file byte-for-byte, with the trailing newline preserved (both notebooks keep `\n`).
- **Diff = +22/−11** = exact `2N/N` pattern (11 `"id"` lines + 11 structural comma companions `]` → `],` where the `id` key is appended as the last dict key).
- **Zero content changes**: grep of the diff for `source`/`outputs`/`execution_count`/`metadata`/`cell_type` modifications among `+`/`−` lines = empty (only the id lines and their `]`→`],` comma companions).

## Validation

- `nbformat.validate()` **2/2 PASS** (0 missing ids post-fix)
- `scripts/notebook_tools/validate_pr_notebooks.py` **2/2 PASS** (SC-22 13 cells, SC-2 10 cells)

## Collision check

`gh pr list --state open --search "SC-22 Solana"` and `"SC-2 Web3py"` — both empty. The open SmartContracts PRs (#6344/#6354 CaseStudies pip, #6342 SemanticKernel pip) touch other notebooks. Disjoint.

Part of the fleet-wide nbformat v4.5 cell-id register (post-QC/Sudoku/rl/GameTheory tranches). SmartContracts = new family (rotation).