### PR TITLE
fix(symboliclearning): nbformat v4.5 cell ids for SL Python notebooks (2 notebooks, 8 cells)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -2587,7 +2587,8 @@
     "**Deux points de vigilance** :\n",
     "1. **Biais de couverture** : a chaque etape, on garde la specialisation qui couvre le *plus* de positifs. Ce greedy est rapide mais n'est pas optimal -- un choix different produirait un autre jeu de regles. C'est l'equivalent, pour les regles, du biais de simplicite absent de CBH (cf. section 9 et l'Exercice 5).\n",
     "2. **Surapprentissage** : si l'on ancre chaque regle sur un seul positif (en partant de `S0` au lieu de `G0`), on obtient 6 regles de 1 positif chacune -- une memorisation inutile. Partir de `G0` et specialiser produit des regles **generales** : c'est la difference entre apprendre un concept et recopier les donnees."
-   ]
+   ],
+   "id": "cell-c7d9cb50"
   },
   {
    "cell_type": "markdown",
@@ -2796,7 +2797,8 @@
     "**Ce qu'ajouterait le rasoir d'Occam (MDL)**. Le concept cible reel de la section 8 (`Patrons=Some OU (Patrons=Full ET Hungry=Yes)`) tient en **2 clauses / 3 conditions**. L'hypothese la plus compacte trouvee ici fait ~16 conditions -- soit ~5 fois plus. Un biais de simplicite (comme celui de **FOIL**, AIMA 19.5, ou des arbres de decision ID3/C4.5) chercherait explicitement la solution consistante **la plus courte**, au lieu de memoriser les exemples positifs sous forme de disjonctions tres specifiques.\n",
     "\n",
     "**Lien avec les exercices de reflexion (Ex4, Ex6)**. Cette mesure donne la matiere concrete pour repondre : la consistance seule est insuffisante -- il faut un **critere de selection** parmi les hypotheses consistantes, et Occam/MDL en est un. C'est aussi le pont avec la couverture sequentielle de l'Exemple guide 3, ou le tie-break \"couverture maximale\" etait une forme embryonnaire de ce biais."
-   ]
+   ],
+   "id": "cell-20649579"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-10-ActiveAutomataLearning.ipynb
@@ -2019,7 +2019,8 @@
     "dans un canal qui retourne chaque symbole correct avec probabilite `1 - epsilon`\n",
     "et le corrompt avec probabilite `epsilon`. On observe `w` *abime* et l'on cherche\n",
     "`P(w vrai appartient au langage | observation)`.\n"
-   ]
+   ],
+   "id": "cell-b2b11c8b"
   },
   {
    "cell_type": "code",
@@ -2089,7 +2090,8 @@
     "    p = forward_accept_prob(TARGET, true_w, eps)\n",
     "    note = \"certain\" if p > 0.95 else (\"penche accepte\" if p > 0.5 else \"doute\")\n",
     "    print(f\"{eps:>7.2f} | {p:>16.3f} | {note}\")\n"
-   ]
+   ],
+   "id": "cell-e26c64d8"
   },
   {
    "cell_type": "markdown",
@@ -2108,7 +2110,8 @@
     "Le vrai gain d'exactitude vient quand on dispose de **plusieurs** observations\n",
     "bruitees du meme mot (plusieurs lectures OCR, plusieurs trames audio). C'est la\n",
     "version probabiliste -- et correcte -- du vote majoritaire de l'exercice 4.\n"
-   ]
+   ],
+   "id": "cell-dfcb014a"
   },
   {
    "cell_type": "code",
@@ -2235,7 +2238,8 @@
     "ax.set_title(\"Reconnaissance probabiliste : l'evidence restaure ce que le bruit a brouille\")\n",
     "ax.set_ylim(0.70, 1.01); ax.grid(alpha=0.3); ax.legend(loc=\"lower right\")\n",
     "plt.tight_layout(); plt.show()\n"
-   ]
+   ],
+   "id": "cell-dadc71b6"
   },
   {
    "cell_type": "markdown",
@@ -2279,7 +2283,8 @@
     "`P(observe | vrai)` quelconque (2x2, lignes sommant a 1) au lieu du scalaire\n",
     "`epsilon`, puis verifiez que la coherence canal-parfait (matrice identite =\n",
     "verdict exact) tient toujours. Indice : seule la ligne `lik = ...` change.\n"
-   ]
+   ],
+   "id": "cell-71e82ee0"
   },
   {
    "cell_type": "code",
@@ -2317,7 +2322,8 @@
     "#     p = forward_accept_prob_confusion(TARGET, w, identite)\n",
     "#     assert (p is not None) and (p > 0.5) == membership_query(w)\n",
     "print(\"Exercice du pont a completer : forward avec matrice de confusion.\")\n"
-   ]
+   ],
+   "id": "cell-0e9a0c7e"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Adds missing nbformat v4.5 cell `id` fields to 2 SymbolicLearning **Python** notebooks:

| Notebook | Cells | Ids added |
|----------|-------|-----------|
| `SL-1-LogicalLearning.ipynb` | 58 | 2 |
| `SL-10-ActiveAutomataLearning.ipynb` | 45 | 6 |
| **Total** | | **8** |

## Method (canonical, proven)

Deterministic id formula (depot convention, verified empirically vs Search-5 #6292 and re-used across #6257/#6285/#6392/#6393/#6395):

```
id = 'cell-' + md5('<basename-with-.ipynb>:<all-cell-index-0-based>')[:8]
```

## Structural-only — no re-execution

Pure metadata fix. `nbformat.validate()` is structural, not execution, so no re-exec needed (per .NET Advisory #5214; these are `python3` kernels regardless). Round-trip fidelity asserted **BEFORE** edit: `json.dumps(nb, indent=1, ensure_ascii=False)` reproduces the original byte-for-byte (trailing `\n` preserved on both), so the **only** diff is the added `"id"` line + its preceding `],` comma.

## Proofs

- Diff stat: `+16/-8` = exact **2N/N** pattern (8 id lines + 8 comma companions `]`→`],`).
- Content purity: `git diff | grep -cE '"(source|outputs|execution_count|cell_type|metadata)"'` = **0** (no content touched).
- `nbformat.validate()`: **2/2 VALID** (0 missing id, 0 duplicates).
- `validate_pr_notebooks.py`: **2/2 PASS** (SL-1: 18 code cells, SL-10: 17 code cells).

## Family rotation (R6)

c.440 Sudoku .NET structural → c.441 GameTheory Python structural → c.442 Infer conclusion (markdown) → c.443 SmartContracts Python structural → **c.445 SymbolicLearning Python structural**. SymbolicLearning = family **untouched** this multi-cycle (prior SymbolicAI work was Lean i18n + SmartContracts, not SymbolicLearning). First structural-metadata item on 2026-07-14 (prior nbformat cycles were 2026-07-13).

## Collision-clean

File-level `gh pr list` check: no open PR touches `SL-1-LogicalLearning.ipynb` or `SL-10-ActiveAutomataLearning.ipynb`. (#6368 = SL **C#** probe strip, different files; #3512/#5520 = cross-repo noise / SL-1-**Csharp** twin.)

Co-Authored-By: Claude <noreply@anthropic.com>