### PR TITLE
i18n(#4980): conway_lean/Conway/Life/Spaceships FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Spaceships_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Spaceships_en.lean
@@ -1,44 +1,43 @@
 /-
-Copyright (c) 2026 CoursIA. Tous droits reserves.
-Distribue sous licence Apache 2.0 comme decrit dans le fichier LICENSE.
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 
-## Jeu de la Vie de Conway — Vaisseaux spatiaux (spaceships)
+## Conway's Game of Life — Spaceships
 
-Vaisseaux Leger, Moyen et Lourd (LWSS, MWSS, HWSS).
-Vaisseaux de periode 4, chacun translatant de 2 cellules horizontalement par periode.
+Lightweight, Middleweight, and Heavyweight Spaceships (LWSS, MWSS, HWSS).
+Period-4 spaceships, each translating 2 cells horizontally per period.
 
-Decouverts au debut de l'histoire du Jeu de la Vie (Conway,
-Guy, Berlekamp ; Cambridge 1970), ils sont parmi les vaisseaux
-spatiaux les plus communs dans la nature. Avec le planeur (glider),
-ils forment la famille des vaisseaux de periode 4 et deplacement 2
-de la regle B3/S23.
+These were discovered early in the history of the Game of Life (Conway,
+Guy, Berlekamp; Cambridge 1970) and are among the most common
+naturally-occurring spaceships. Together with the glider they form the
+family of period-4 displacement-2 spaceships of the B3/S23 rule.
 
-Convention de coordonnees (heritee de `Conway.Life`) :
-- Chaque cellule est une paire `(row, col) : Int × Int`.
-- Les motifs sont stockes en `List (Int × Int)` dans l'ordre
-  lexicographique trie (row d'abord, puis col) pour que `step`
-  produise une liste dans le meme ordre, permettant a
-  `native_decide` de verifier l'egalite par comparaison structurelle.
-- Un deplacement `(dr, dc)` translate chaque cellule de `dr` lignes
-  et `dc` colonnes. Les vaisseaux ci-dessous vont vers l'est :
-  `dr = 0`, `dc = 2`.
+Coordinate convention (inherited from `Conway.Life`):
+- Each cell is a pair `(row, col) : Int × Int`.
+- Patterns are stored as `List (Int × Int)` in sorted lexicographic order
+  (row first, then column) so that `step` produces a list in the same
+  order, enabling `native_decide` to verify equality by structural
+  comparison.
+- A displacement `(dr, dc)` shifts every cell by `dr` rows and `dc`
+  columns. The spaceships below are east-bound: `dr = 0`, `dc = 2`.
 
-Ce module est entierement prouve (aucun gap).
+This module is fully proven (no gaps).
 -/
 
 /-
-  Convention i18n (EPIC #4980, decision user 2026-07-04) : ce fichier est **FR canonique**,
-  avec son miroir anglais dans le fichier sibling `Spaceships_en.lean` (modele sibling
-  pair ratifie 2026-07-04, cf `code-style.md` §Lean i18n). Les enonces de theoremes,
-  les tactiques Lean, les noms de lemmes et les references Mathlib restent en anglais
-  (compat Mathlib 4) ; seules les docstrings de theoreme et ce bloc d'en-tete different
-  entre les deux fichiers.
+  English mirror of `Spaceships.lean` (FR canonical). Convention EPIC #4980
+  (decision ratified 2026-07-04, cf `code-style.md` §Lean i18n): distinct FR + EN sibling
+  files — no inline bilingual block in a single file (Option B rejected). The module
+  docstring and the public theorem docstrings below differ from the FR version; the body
+  signatures, proofs and tactics remain byte-identical between the two files.
 -/
 
 import Conway.Life
 
-namespace Conway
-namespace Life
+namespace Conway_en
+open Conway
+namespace Life_en
+open Life
 
 /-! ## Lightweight Spaceship (LWSS)
 
@@ -135,5 +134,5 @@ def hwss : Grid :=
 /-- The HWSS is a spaceship of period 4 and displacement `(0, 2)`. -/
 theorem hwss_spaceship : isSpaceship hwss 4 (0, 2) = true := by native_decide
 
-end Life
-end Conway
+end Life_en
+end Conway_en


### PR DESCRIPTION
## Résumé

Migration `Conway/Life/Spaceships` vers le modèle **sibling pair FR canonique + EN miroir** (EPIC #4980, décision user 2026-07-04). Premier sibling pair avec **namespace imbriqué** `Conway > Life` (vs c.408/c.412/c.413/c.414 qui étaient namespace simple).

**`Conway/Life/Spaceships.lean`** : module docstring FR canonique + i18n note FR.

**`Conway/Life/Spaceships_en.lean`** (nouveau) : miroir EN avec `namespace Conway_en` + `open Conway` + `namespace Life_en` + `open Life` + body byte-identique.

## Substance réelle

**Spaceships (vaisseaux spatiaux) du Jeu de la Vie** : LWSS/MWSS/HWSS — période 4, déplacement 2 cellules par période, direction est (`dr=0, dc=2`). Découverts au début de l'histoire du Jeu de la Vie (Conway, Guy, Berlekamp ; Cambridge 1970). Avec le planeur (glider), ils forment la famille standard des vaisseaux de période 4 et déplacement 2 de la règle **B3/S23**.

Convention de coordonnées : chaque cellule est une paire `(row, col) : Int × Int`. Motifs stockés en `List (Int × Int)` lexicographiquement triés pour que `step` produise une liste dans le même ordre, permettant à `native_decide` de vérifier l'égalité par comparaison structurelle.

**3 theorem + 3 defs + 12 `#eval`** :
- `lwss_spaceship` (`native_decide`) — 9 cellules, 4 lignes
- `mwss_spaceship` (`native_decide`) — 11 cellules, 5 lignes
- `hwss_spaceship` (`native_decide`) — 13 cellules, 5 lignes

## Preuves de progrès vérifiables (anti-§D + Lean §B)

| Critère | Mesure |
|---------|--------|
| **`grep -c sorry`** avant | 0 |
| **`grep -c sorry`** après | 0 / 0 (FR / EN) |
| **Body byte-identity FR vs EN** | sha256 `1589884375e2a0…` (96 inner lignes byte-identiques) |
| **CRLF count** | 0 / 0 (LF-only strict) |
| **Trailing newline** | OK sur les 2 fichiers |
| **Code structure** | 3 theorems + 3 defs + 12 #eval (préservés) |
| **Size** | FR 3873 B / 139 LF ; EN 3776 B / 138 LF |
| **Namespace imbriqué** | OK (`Conway > Life` × `Conway_en > Life_en` + open × 2) |

## i18n — convention #4980 ratifiée 2026-07-04

- **Module docstring FR** (`/-- ... -/`) : hommage Conway en français.
- **i18n note FR** : référence à `code-style.md §Lean i18n` + décision user 2026-07-04.
- **EN sibling** : docstring EN équivalente + i18n note EN réfutant Option B (inline bilingue dans un seul fichier).
- **Énoncés de theorems, noms de lemmes, tactiques Lean, sections `/-! ##`** restent en anglais (cohérent avec c.412 HashlifeMarginDemo et c.413 FractranLemmas, compat Mathlib 4).
- **Docstrings de theorems** conservées en anglais (cohérent avec precedent sibling pairs c.408/412/413/414).

## Pattern namespace imbriqué (C415-L1)

Le namespace `Conway.Life` est défini par deux `namespace` consécutifs dans le source. Le miroir EN doit utiliser **deux namespaces différents + deux `open`** :

```lean
namespace Conway        -- FR canonique
namespace Life
  ...
end Life
end Conway
```

```lean
namespace Conway_en     -- EN mirror
open Conway
namespace Life_en
open Life
  ...
end Life_en
end Conway_en
```

C'est le pattern canonique pour `Conway/Life/*.lean` — applicable aux 12 fichiers restants dans ce sous-dossier (Computation, ConeGeometry, GridCanonical, Hashlife, HashlifeCorrectness, HashlifeMemo, LightCone, MacroCell, Oscillators, Pillars, RLE).

## Backlog c.415 (registration)

`Conway/Life/Spaceships.lean` (139 LF rebuilt, 128 LF original) = **7ᵉ sibling pair** du backlog EPIC #4980 sur `conway_lean` Phase 1+, après :

- c.408 `Conway/MathlibMap` (10 #check, 90 LF, stripped 433/433 B LF, sorry 0/0)
- c.412 `Conway/Life/HashlifeMarginDemo` (1 def + 11 #eval + 6 inline, 79 LF, stripped 550/550 B LF, sorry 0/0) — `#6355`
- c.413 `Conway/FractranLemmas` (8 theorem, 67 LF, stripped 274/274 B, sorry 0/0) — `#6398`
- c.414 `Conway/Angel` (4 theorem + 1 anchor, 77 LF, sorry 0/0) — `#6399` (en attente merge ai-01)
- c.500 `Conway/DoomsdayLemmas` (5 theorem, 40 LF) — antérieur
- c.501 `Conway/LookAndSayLemmas` (4 theorem, 52 LF) — antérieur

## Backlog restant c.416+

**Sibling pair candidates mono-linguaux** (13 restants) :
- `Conway/{KochenSpecker 363, Life 224}.lean`
- `Conway/Life/{Computation 194, ConeGeometry 322, GridCanonical 285, Hashlife 543, HashlifeCorrectness 3397=split, HashlifeMemo 348, LightCone 477, MacroCell 794, Oscillators 201, Pillars 234, RLE 342}.lean`

**Bilingual inline legacy exclus** (6 fichiers, conservés en l'état) :
- `Conway/{CollatzLike, Doomsday, Fractran, FreeWillTheorem, LookAndSay, Nim}.lean`

## Anti-patterns évités

- ✅ `Write` tool → trailing newline vérifié via Python `data += b'\n'` (C413-L1 / C280-1)
- ✅ `--body-file` (JAMAIS `--body` à cause de C403-L1 backtick stripping)
- ✅ branch base = main local frais (R2 base-stale-14d)
- ✅ Atomique : 1 PR = 1 sibling pair (R3)
- ✅ Pas de catalogue touché (R1)
- ✅ Worker JAMAIS `gh pr merge` ou `--approve` (L143 SAFE cross-owner)
- ✅ Sections `/-! ##` et theorem docstrings en anglais (cohérent avec precedent c.412/c.413 — module docstring et i18n note sont les seuls endroits où FR/EN diffèrent au niveau du module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
