### PR TITLE
fix(semantic-fleet-radix): correct dead upstream URL in README

### DIFF
--- a/tools/semantic-fleet-radix/README.md
+++ b/tools/semantic-fleet-radix/README.md
@@ -1,7 +1,7 @@
 # SemanticFleet.Radix
 
 Standalone .NET module extracted from
-[semantic-fleet](https://github.com/SemanticFlow/SemanticFlow) v0.34.3 to
+[semantic-fleet](https://github.com/MyIntelligenceAgency/semantic-fleet) v0.34.3 to
 implement **Axis 4 (radix-tree signature matching)** of
 [Epic #1210](https://github.com/jsboige/CoursIA/issues/1210).
 


### PR DESCRIPTION
## Problem

The README of `tools/semantic-fleet-radix` (landed by #5672, Epic #1210 Axis 4) links its "semantic-fleet" upstream provenance to `https://github.com/SemanticFlow/SemanticFlow` — which **404s** (org/repo does not exist).

## Fix

Point it to the real upstream: `https://github.com/MyIntelligenceAgency/semantic-fleet` (MyIA org).

## Verification (firsthand)

- `gh api repos/SemanticFlow/SemanticFlow` -> **404 Not Found**
- `gh api repos/MyIntelligenceAgency/semantic-fleet` -> exists (not archived, `v0.34.3` tag present)
- `gh search code "SimpleMatchPromptSettings repo:MyIntelligenceAgency/semantic-fleet"` -> confirms `dotnet/src/Connectors/Connectors.AI.MultiConnector/MultiTextCompletionSettings.cs` holds the exact baseline the module extracts from

So the module's code provenance is genuine; only the README hyperlink was garbled. One-line doc fix, no code/catalogue/notebook change.

See #1210

🤖 Generated with [Claude Code](https://claude.com/claude-code)