### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Sudoku-4-SimulatedAnnealing-Python

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
@@ -328,7 +328,8 @@
     "\n",
     "**Indice**\n",
     "Parcourir chaque ligne/colonne/bloc et compter les doublons parmi les valeurs non nulles.\n"
-   ]
+   ],
+   "id": "cell-1f8b2328"
   },
   {
    "cell_type": "code",
@@ -351,7 +352,8 @@
     "    result = 0  # TODO etudiant\n",
     "    return result\n",
     "print(\"Exercice a completer\")\n"
-   ]
+   ],
+   "id": "cell-5b5446cb"
   },
   {
    "cell_type": "code",
@@ -527,7 +529,8 @@
     "**Indice**\n",
     "Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc,\n",
     "et echangez leurs valeurs.\n"
-   ]
+   ],
+   "id": "cell-8e341e75"
   },
   {
    "cell_type": "code",
@@ -550,7 +553,8 @@
     "    result = None  # TODO etudiant\n",
     "    return result\n",
     "print(\"Exercice a completer\")\n"
-   ]
+   ],
+   "id": "cell-6e33a250"
   },
   {
    "cell_type": "markdown",
@@ -2053,7 +2057,8 @@
     "Implementez un schema de refroidissement exponentiel: T = T_init * alpha^step\n",
     "**Étape 2**\n",
     "Lancez les benchmarks et comparez les taux de succes.\n"
-   ]
+   ],
+   "id": "cell-053d1c51"
   },
   {
    "cell_type": "code",
@@ -2076,7 +2081,8 @@
     "    result = []  # TODO etudiant\n",
     "    return result\n",
     "print(\"Exercice a completer\")\n"
-   ]
+   ],
+   "id": "cell-1facbe74"
   },
   {
    "cell_type": "code",
@@ -2696,14 +2702,16 @@
    "metadata": {},
    "source": [
     "## 11. Comparaison quantitative SA vs Backtracking (Prong B #3801)\n\nLe benchmark precedent (Section 8, cell 29) a mesure le recuit simule (SA) sur **3 puzzles faciles** (~36-51 cellules vides) avec un temps culminant a **~221 secondes** sur le puzzle 3 (51 cellules). Pour positionner SA face au solveur exact (Backtracking) sur les memes instances, voici une **comparaison quantitative** avec les chiffres reels publies dans les cellules voisines (cell 29 SA, cell 32 Backtracking).\n\n### Tableau comparatif (chiffres verifies, sources citees)\n\n| Solveur | Puzzle 1 (36 vides) | Puzzle 2 (49 vides) | Puzzle 3 (51 vides) | Garantie exactitude |\n|---------|---------------------|---------------------|---------------------|---------------------|\n| **Backtracking simple** (`SimpleBacktracking`, cell 32) | 49 appels, **1.0 ms** | 201 appels, **5.1 ms** | 295 appels, **8.6 ms** | Oui (exhaustif) |\n| **Recuit Simule** (`SimulatedAnnealingSolver`, cell 29 + cell 32) | OK, **131 ms** | OK, **10 340 ms** | OK, **207 723 ms** | Non (heuristique) |\n| **Ratio SA / BT** (cell 32 reel) | **131x** | **~2 027x** | **~24 154x** | -- |\n\n### Observations (Prong B illustre)\n\n1. **Ecart de 2 a 5 ordres de grandeur** entre SA et Backtracking sur les memes instances. Le ratio explose avec la difficulte (cellules vides) : 131x -> 2 027x -> 24 154x.\n2. **Garantie d'exactitude** : Backtracking est **complet** (trouve une solution si elle existe), SA est **non garanti** (les 3 OK ci-dessus dependent du seed et du time budget).\n3. **Cout runtime** : SA depasse la minute sur le puzzle 3 (51 vides), Backtracking reste sous les 10 ms. Pour la production, Backtracking (ou DLX) est systematiquement preferable.\n4. **Valeur pedagogique du SA** : illustre une **famille de methodes** (recherche locale + stochasticite) complementaire des solveurs exacts. Le SA brille sur des problemes ou l'espace de recherche est trop grand pour l'exhaustif et ou une solution \"proche de l'optimal\" suffit (TSP, planning, scheduling). Pour le Sudoku, ce n'est **pas** le cas : backtracking + danse-links (DLX) dominent.\n\n> **Note methodologique** : tous les chiffres cites proviennent des cellules benchmark du notebook source (outputs reels, ec != null, 0 erreur). Aucune valeur fabriquee. Le recuit simule est execute avec `T0=1.0, alpha=0.999, iterations_per_temp=100, Tmin=0.001, max_restarts=10` (cell 29).\n"
-   ]
+   ],
+   "id": "cell-29f37419"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Exercice : Estimer le ratio SA / Backtracking (Prong B reflexif)\n\n### Contexte\n\nLe tableau ci-dessus compare le recuit simule (heuristique stochastique, ~131 ms -> 208 s) au Backtracking (solveur exact, ~1 ms -> 9 ms) sur 3 puzzles Easy du meme fichier. Pour faire toucher du doigt le **ratio de cout** et sa **non-linearite avec la difficulte**, on veut le chiffrer.\n\n### Enonce\n\nA partir des **chiffres reels** du tableau comparatif (cellule precedente) :\n\n1. Calculer le ratio `temps_SA / temps_BT` pour chacun des 3 puzzles.\n2. Observer la **non-linearite** : le ratio explose-t-il lineairement avec le nombre de cellules vides, ou exponentiellement ?\n3. Conclure sur la **position du SA dans la hierarchie** : efficace / equivalentes / nettement inferieures / sans commune mesure, sur le cas Sudoku.\n\n### Indication\n\n- `ratio_puzzle_X = t_sa_X_ms / t_bt_X_ms`\n- Cellules vides : 36 -> 49 -> 51 (Puzzles 1 -> 2 -> 3)\n- Si `ratio_puzzle_3 / ratio_puzzle_1 > 10`, on a une **croissance super-lineaire** -> methode inadaptee au scaling\n- Suggestion : `conclude_prong_b()` retourne une categorie parmi `\"lineaire\"`, `\"polynomial\"`, `\"exponentiel\"`, `\"autre\"`\n\n### Solution (a completer par l'etudiant)\n\n```\nratio_puzzle_1 = None  # TODO etudiant\nratio_puzzle_2 = None  # TODO etudiant\nratio_puzzle_3 = None  # TODO etudiant\nconclusion     = None  # TODO etudiant\n```\n"
-   ]
+   ],
+   "id": "cell-7c2a3422"
   },
   {
    "cell_type": "code",
@@ -2731,14 +2739,16 @@
       ">>> Exercice a completer : implementer compute_ratio_sa_bt() et conclude_prong_b()\n"
      ]
     }
-   ]
+   ],
+   "id": "cell-998bfe01"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### References citees dans la section 11 (chiffres verifies)\n\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb` (cell 29 — benchmark SA sur 3 Easy)\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb` (cell 32 — comparaison BT vs SA sur 3 Easy)\n\n### Liens transverses (autres solveurs Sudoku pour Prong B)\n\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb` (cell 15 — Backtracking benchmark)\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb` (cell 19 — OR-Tools CP-SAT benchmark)\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb` (cell 22 — Genetic Algorithm benchmark)\n\n> **Note pedagogique** : ces ratios (SA/BT ~131 a ~24 154x) demontrent que **le recuit simule est inadapte au Sudoku en production**, malgre sa richesse theorique. Cf. tableau comparatif dans la Section 7 de Sudoku-3-Genetic-Python (ratio GA/OR-Tools ~700x sur Easy).\n"
-   ]
+   ],
+   "id": "cell-bc0eceef"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (10 cells) to `Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb`, closing part of the v4.5 cell-id gap (see #6257).

This notebook was **already v4.5 (`nbformat_minor=5`)** but 10 of its 19 cells lacked the required `id` field. Adding the ids makes it strictly `nbformat.validate()`-conformant (the strict schema check that fails for v4.5 notebooks missing ids).

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata:
- **No re-execution** — only the `id` field is added per cell.
- **Content byte-identical** — round-trip fidelity asserted BEFORE edit (`json.dumps(nb, indent=1, ensure_ascii=False)` + preserved trailing newline reproduces the original byte-for-byte), so the ONLY diff is the added `"id"` line + the preceding `]`→`],` separator.
- **No version bump needed** — notebook was already v4.5; adding `id` is schema-valid at minor=5. (Contrast: adding ids to a pre-v4.2 notebook would also require a `nbformat_minor` bump.)

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED** — the v4.5 schema accepts the cell ids.
- `python scripts/notebook_tools/validate_pr_notebooks.py` **PASSED** (19 cells, 0 errors).
- `git diff --stat`: `20 insertions(+), 10 deletions(-)` = exactly the **2N/N** pattern (10 ids × {1 separator-comma edit + 1 id line}).
- Diff purity: all 10 deletions are `]` separator tokens; **0 value-content changes** (verified by grepping non-separator deletions → empty).
- `execution_count` / `outputs`: **unchanged** (structural-only edit, no cell source touched).

See #6257 (epic register; partial delivery of the v4.5 cell-id hygiene sweep).
