### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Search-5-GeneticAlgorithms

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
@@ -3409,7 +3409,8 @@
    "metadata": {},
    "source": [
     "## 12. Comparaison quantitative GA vs solveurs exacts sur TSP (Prong B #3801)\n\nL'exemple resolu 1 (cellule 51) a execute l'algorithme genetique (GA) sur le **probleme du voyageur de commerce (TSP)** avec **8 villes**, obtenant une distance totale de **28.73** (route optimale par coIncidence, le GA trouve l'optimum sur ce petit exemple). Pour positionner la famille des **algorithmes genetiques** face aux **solveurs exacts** sur le meme probleme, voici une **comparaison quantitative** avec les chiffres REELS publies dans la cellule 51 (GA, PyGAD) et une nouvelle cellule de calcul exact (brute force exhaustif O(n!), limite aux petites instances).\n\n### Tableau comparatif (chiffres verifies, sources citees)\n\n| Solveur | TSP 8 villes | TSP 9 villes | TSP 10 villes | Garantie optimalite |\n|---------|--------------|--------------|---------------|---------------------|\n| **Algorithme Genetique** (`ga_tsp`, cell 51 + NEW) | 28.73, 1164 ms | 31.66, 1308 ms | 42.11, 1354 ms | Non (heuristique, depend seed) |\n| **Brute force exact** (NEW, Held-Karp DP / O(n!)) | 28.73, 9 ms | 31.66, 92 ms | 36.99, 1008 ms | Oui (exhaustif) |\n| **Gap GA / Exact** (cellule NEW) | 1.00x (optimal trouve) | 1.00x (optimal trouve) | **~1.14x (sous-optimal)** | -- |\n\n### Observations (Prong B illustre)\n\n1. **Sur petites instances (8-9 villes), le GA trouve l'optimum** par chance combinatoire : l'espace de recherche reste suffisamment petit pour que la recherche genetique converge vers la solution exacte. C'est un **cas degeneré** ou la discrimination GA/exact est invisible.\n2. **A 10 villes, le GA commence a degrader** : gap de 14% (42.11 vs 36.99) = demonstration quantitative de l'inadequation progressive du GA quand l'espace de recherche grandit exponentiellement. Le brute force exact O(n!) reste faisable (1 sec) et trouve l'optimum.\n3. **Garantie d'optimalite** : le brute force est **complet** (visite tous les chemins), le GA est **heuristique** (depend de la population initiale, du seed, des operateurs). Pour des applications critiques (logistique, circuits imprimes, planification de tournees), un solveur exact ou une heuristique de plus haute qualite (LKH, OR-Tools) est preferable.\n4. **Valeur pedagogique du GA** : illustre la **famille des methodes evolutionnistes** (population + selection + variation) applicable quand l'espace est trop grand pour l'exhaustif (TSP > 15-20 villes, O(n!) ou O(2^n n^2) intractable). Le GA brille sur des problemes ou une **bonne solution rapide** suffit (temps reel, approximative search).\n\n> **Note methodologique** : tous les chiffres GA cites proviennent de la cellule 51 (PyGAD, seed=42, pop=100, generations=300) ou de la nouvelle cellule ci-dessous. Le brute force est execute en Python pur sur les memes coordonnees de villes (8 premieres + 1, 2, 3 villes ajoutees pour 9 et 10). Aucune valeur fabriquee.\n"
-   ]
+   ],
+   "id": "cell-8cbc45fa"
   },
   {
    "cell_type": "code",
@@ -3424,14 +3425,16 @@
      "name": "stdout",
      "text": "=== Comparaison GA vs Brute Force exact sur TSP (seed=42) ===\n\n Villes   Exact dist   Exact ms    GA dist    GA ms   Gap GA/Exact\n------------------------------------------------------------------------\n      8        28.73          9      28.73     1164          1.00x\n      9        31.66        106      35.75     1539          1.13x\n     10        36.99        996      41.71     1473          1.13x\n\nObservations Prong B #3801 :\n- 8 villes  : GA = exact (28.73, optimal) ; ecart runtime GA 1164ms vs exact 9ms (~129x)\n- 9 villes  : GA = exact (31.66, optimal) ; ecart runtime GA 1539ms vs exact 106ms (~14x)\n- 10 villes : GA sous-optimal (41.71 vs 36.99, gap ~1.13x) ; runtime comparable ~1.5x\n\nConclusion : GA degenerescent sur grandes instances (n>=10). Solveurs exacts ou\nheuristiques specialisees (LKH, OR-Tools) sont preferables en production.\n"
     }
-   ]
+   ],
+   "id": "cell-d5ef7329"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)\n\n### Contexte\n\nLe tableau ci-dessus compare l'algorithme genetique (heuristique, ~1.1-1.4 sec) au brute force exact (solveur exhaustif, 9-1008 ms) sur 3 instances TSP de 8, 9 et 10 villes. Pour faire toucher du doigt le **ratio de cout** et sa **non-linearite avec la taille de l'instance**, on veut le chiffrer.\n\n### Enonce\n\nA partir des **chiffres reels** du tableau comparatif (cellule precedente) :\n\n1. Calculer le ratio `temps_GA / temps_exact` pour chacune des 3 instances (8, 9, 10 villes).\n2. Calculer le ratio `qualite_GA / qualite_exact` (gap) : observe-t-on une degradation lineaire, polynomiale ou autre ?\n3. Conclure sur la **position du GA dans la hierarchie** : efficace / equivalente / nettement inferieure / sans commune mesure, sur le cas TSP.\n\n### Indication\n\n- `ratio_runtime_X = t_ga_X_ms / t_exact_X_ms`\n- `gap_X = dist_ga_X / dist_exact_X` (1.0 = optimal, >1.0 = sous-optimal)\n- Si `gap_10 / gap_8 > 1.10`, on a une **degradation visible** -> methode inadaptee au scaling\n- Suggestion : `conclude_prong_b(runtime_ratios, gaps)` retourne une categorie parmi `\"lineaire\"`, `\"polynomial\"`, `\"exponentiel\"`, `\"autre\"`\n\n### Solution (a completer par l'etudiant)\n\n```\nratio_runtime_8  = None  # TODO etudiant\nratio_runtime_9  = None  # TODO etudiant\nratio_runtime_10 = None  # TODO etudiant\ngap_8, gap_9, gap_10 = None, None, None  # TODO etudiant\nconclusion = None  # TODO etudiant\n```\n"
-   ]
+   ],
+   "id": "cell-5cf504d4"
   },
   {
    "cell_type": "code",
@@ -3444,14 +3447,16 @@
      "name": "stdout",
      "text": "=== Estimation du ratio GA / solveur-exact (Prong B #3801) ===\n\n Villes  Runtime GA ms  Runtime Exact ms   Ratio GA/Exact   Gap GA/Exact\n------------------------------------------------------------------------------\n      8           1164                 9             None           None\n      9           1539               106             None           None\n     10           1473               996             None           None\n\nGap croissance 10 vs 8 : N/A (a completer)\nConclusion Prong B     : None\n\n>>> Exercice a completer : implementer compute_ratio_runtime(), compute_gap() et conclude_prong_b()\n"
     }
-   ]
+   ],
+   "id": "cell-a7df56f9"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### References citees dans la section 12 (chiffres verifies)\n\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (cell 51 — exemple resolu TSP 8 villes, GA via PyGAD)\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (NEW — brute force exact + GA replicate pour 9 et 10 villes)\n\n### Liens transverses (autres solveurs pour Prong B)\n\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb` (LP relaxation + branch-and-bound)\n- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb` (MEALPy : PSO, ABC, SA, BRO)\n- `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb` (CSP/OR-Tools Choco)\n\n> **Note pedagogique** : les ratios GA/exact (gap 1.0x a 8-9 villes puis 1.14x a 10 villes) demontrent que **l'algorithme genetique devient sous-optimal quand l'espace de recherche grandit**, malgre sa richesse theorique. Cf. Section 7 de `Sudoku-3-Genetic-Python.ipynb` (ratio GA/OR-Tools ~700x sur Easy) et Section 11 de `Sudoku-4-SimulatedAnnealing-Python.ipynb` (ratio SA/Backtracking ~24 154x sur Easy) pour des demonstrations equivalentes sur d'autres solveurs heuristiques vs exacts.\n"
-   ]
+   ],
+   "id": "cell-4d2aa687"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (5 cells) to `Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` — part of the v4.5 cell-id gap sweep (see #6257).

The notebook was **already v4.5 (`nbformat_minor=5`)** but 5 cells lacked the required `id` field. Adding them makes it strictly `nbformat.validate()`-conformant.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit (`json.dumps(nb, indent=1, ensure_ascii=False)` + preserved trailing newline reproduces the original byte-for-byte), so the ONLY diff is the added `"id"` line + the preceding `]`→`],` separator.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED**.
- `python scripts/notebook_tools/validate_pr_notebooks.py` **PASSED**.
- `git diff --stat`: `10 insertions(+), 5 deletions(-)` = **2N/N** (5 ids × {1 separator + 1 id line}).
- `execution_count` / `outputs`: unchanged (structural-only, no cell source touched).

See #6257.
