### PR TITLE
fix(gitignore): ignore Z3-Linq2Z3 meal-planner corpus (5500+ untracked XML in IDE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -865,3 +865,13 @@ MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/data/temp_*.owl
 _site/
 **/.quarto/
 _freeze/
+
+# Meal-planner corpus (Z3-Linq2Z3 series) — regenerable data, downloaded on demand
+# by SMT/Z3-Linq2Z3/download_meal_data.py (Ciqual ANSES 2025 + RecipeML archive.org
+# ~11k recettes + fork recipes). ~93 MB / 5500+ XML files. The notebooks + script
+# already document data/meals/ as gitignored ("il est regenere"), but the rule was
+# missing, so the corpus surfaced as 5500+ untracked files in the IDE. The `**`
+# covers both the canonical target (Z3-Linq2Z3/data/meals/) and the stale wrong-CWD
+# location (Z3/data/meals/, from the old Z3/ series name before the Z3-API/Z3-Linq2Z3
+# split). Delete the stale Z3/data/ copy locally; it is orphaned (no notebook reads it there).
+MyIA.AI.Notebooks/SymbolicAI/SMT/**/data/meals/


### PR DESCRIPTION
## Problème (signalé par le user 2026-07-14, live)

Le corpus meal-planner (RecipeML archive.org ~11k recettes + Ciqual ANSES 2025, **~93 Mo / 5502 fichiers XML**) téléchargé par [`download_meal_data.py`](MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/download_meal_data.py) apparaissait comme **5500+ fichiers untracked** dans le panneau Source Control de VSCode (l'IDE déplie le dossier untracked que git, lui, replie en une ligne `?? SMT/Z3/`).

## Diagnostic (firsthand)

- **0 fichier tracké** (`git ls-files SMT/Z3/` = 0) — jamais commité, aucun risque de perte.
- Le chemin canonique du script = `Path(__file__).parent/data/meals` = `Z3-Linq2Z3/data/meals/`, **déjà gitignoré** par un `.gitignore` local (`Z3-Linq2Z3/.gitignore:3: data/`).
- Le corpus réel siège dans **`SMT/Z3/data/meals/`** = ancien nom de série `Z3/` (avant le split `Z3/` → `Z3-API/` + `Z3-Linq2Z3/`), emplacement **orphelin sans règle d'ignore** → d'où le bruit.
- Les notebooks + le script documentent explicitement `data/meals/` comme gitignoré (« il est **régénéré** ») — la règle manquait juste pour l'emplacement stale.

## Fix

Une règle racine `MyIA.AI.Notebooks/SymbolicAI/SMT/**/data/meals/` couvrant **les deux** emplacements (canonique + stale). `git status` repasse à propre. Le corpus reste régénérable à la demande ; la copie orpheline `Z3/data/` peut être supprimée localement (aucun notebook ne la lit là).

Fix hygiène pur, réversible. Aucun code touché.