### PR TITLE
i18n(conway): sibling pair HashlifeMemo + HashlifeMemo_en (EPIC #4980, c.418)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMemo_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMemo_en.lean
@@ -1,65 +1,64 @@
 /-
-Copyright (c) 2026 CoursIA. Tous droits reserves.
-Distribue sous licence Apache 2.0 comme decrit dans le fichier LICENSE.
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 
-## HashlifeMemo — Hashlife memoise, prouve correct (Phase 3c)
+## HashlifeMemo — Memoized Hashlife, proven correct (Phase 3c)
 
-Ce module implemente la couche de memoisation qui rend `hashlifeResult`
-faisable sur les temoins communautaires piliers (OTCA 35K gen, UnitCell
-4096 gen, Gemini 33M gen, CPU 1M gen). Sans memoisation, l'algorithme
-recursif de Hashlife dans `Conway.Life.Hashlife` est `9^k` au pire cas
-(chacun des 13 appels subnode engendre d'autres appels jusqu'au cas de
-base niveau 2). Avec memoisation (l'astuce canonique de Gosper : cacher
-les resultats des sous-arbres identiques), le nombre de sous-arbres
-distincts explores sur des patterns realistes tombe a quelques millions,
-dans le budget de `native_decide`.
+This module implements the memoization layer that makes `hashlifeResult`
+tractable on community pillar witnesses (OTCA 35K gen, UnitCell 4096 gen,
+Gemini 33M gen, CPU 1M gen). Without memoization, the recursive Hashlife
+algorithm in `Conway.Life.Hashlife` is `9^k` in the worst case (each of
+13 subnode calls spawns further calls until the level-2 base case). With
+memoization (the canonical Gosper trick: cache results for identical
+subtrees), distinct subtrees explored on realistic patterns drop to a few
+million, within `native_decide` budget.
 
-### Conception
+### Design
 
-- **Cache** : `Std.HashMap (Nat x MacroCell) MacroCell`, cle =
-  `(fuel, cell)`. Le fuel fait partie de la cle car `hashlifeResultAux`
-  est reellement dependant du fuel (ses branches de repli dependent de
-  l'epuisement du fuel), donc cacher par cellule seule serait incorrect
-  sur des cellules mal formees.
-- **`Hashable MacroCell`** : un hash structurel 64-bit du contenu
-  (`MacroCell.contentHash`). `BEq` provient du `DecidableEq` derive
-  (done loyal), ce dont les preuves de correction du cache ont besoin.
-- **Correction fusionnee** : au lieu de definir la fonction memoisee puis
-  la prouver correcte par une induction separee, chaque fonction renvoie
-  un sous-type conditionnant la valeur, le cache final, une preuve que
-  la valeur egale la reference non memoisee, et une preuve que le cache
-  reste correct (`CacheOK`). Chaque appel recursif porte sa propre preuve,
-  donc aucune induction globale sur l'arbre de recursion a 13 appels
-  n'est requise. Les preuves sont de type `Prop` et completement effacees
-  a l'execution.
+- **Cache**: `Std.HashMap (Nat × MacroCell) MacroCell`, keyed by
+  `(fuel, cell)`. The fuel is part of the key because
+  `hashlifeResultAux` is genuinely fuel-dependent (its fallback arms
+  depend on whether fuel is exhausted), so caching by cell alone would
+  be unsound on malformed cells.
+- **`Hashable MacroCell`**: a structural 64-bit content hash
+  (`MacroCell.contentHash`). `BEq` comes from the derived `DecidableEq`
+  (hence lawful), which is what the cache-correctness proofs need.
+- **Fused correctness**: instead of defining the memoized function and
+  then proving it correct by a separate induction, each function returns
+  a subtype packaging the value, the final cache, a proof that the value
+  equals the unmemoized reference, and a proof that the cache stays
+  correct (`CacheOK`). Every recursive call carries its own proof, so no
+  global induction over the 13-call recursion tree is ever needed. The
+  proofs are `Prop`-valued and fully erased at runtime.
 
-### Notes d'implementation
+### Implementation notes
 
-- La branche bien formee `node`-de-`node`s deploie ses 16 petits-enfants
-  (`a1..a4, b1..b4, c1..c4, d1..d4`) **sans** alias de motif (`c@(...)`) :
-  les fvars alias sont syntaxiquement opaques a `rw`/`simp`, ce qui
-  casserait le lemme d'unfold `hashlifeResultAux_succ_node` ci-dessous.
-- Les branches mal formees dont le calcul de `level` est bloque (par ex.
-  `1 + (1 + w1.level)` avec `w1` neutre) renvoient l'expression `ite`
-  verbatim de la branche de repli de `hashlifeResultAux` pour que `rfl`
-  ferme l'obligation de preuve par unfold definitionnel.
+- The well-formed `node`-of-`node`s arm spells out its 16 grandchildren
+  (`a1..a4, b1..b4, c1..c4, d1..d4`) **without** a pattern alias
+  (`c@(...)`): alias fvars are syntactically opaque to `rw`/`simp`, which
+  would break the unfold lemma `hashlifeResultAux_succ_node` below.
+- The malformed arms whose `level` computation is stuck (e.g.
+  `1 + (1 + w1.level)` with `w1` neutral) return the *verbatim* `ite`
+  expression from `hashlifeResultAux`'s fallback arm so that `rfl`
+  closes the proof obligation by definitional unfolding.
 -/
 
 /-
-  Convention i18n (EPIC #4980, decision user 2026-07-04) : ce fichier est **FR canonique**,
-  avec son miroir anglais dans le fichier sibling `HashlifeMemo_en.lean` (modele sibling
-  pair ratifie 2026-07-04, cf `code-style.md` §Lean i18n). Les enonces de theoremes,
-  les tactiques Lean, les noms de lemmes et les references Mathlib restent en anglais
-  (compat Mathlib 4) ; seules les docstrings de module et ce bloc d'en-tete different
-  entre les deux fichiers.
+  English mirror of `HashlifeMemo.lean` (FR canonical). Convention EPIC #4980
+  (decision ratified 2026-07-04, cf `code-style.md` §Lean i18n): distinct FR + EN sibling
+  files — no inline bilingual block in a single file (Option B rejected). The module
+  docstring and the public theorem docstrings below differ from the FR version; the body
+  signatures, proofs and tactics remain byte-identical between the two files.
 -/
 
 import Conway.Life.MacroCell
 import Conway.Life.Hashlife
 import Std.Data.HashMap
 
-namespace Conway
-namespace Life
+namespace Conway_en
+open Conway
+namespace Life_en
+open Life
 
 open MacroCell
 
@@ -355,5 +354,5 @@ kernel-checked theorems above). -/
 #eval evolveHashlifeFastMemo 4 blinker_h == evolve 4 blinker_h        -- true
 #eval evolveHashlifeFastMemo 3 toad == evolve 3 toad                  -- true
 
-end Life
-end Conway
+end Life_en
+end Conway_en


### PR DESCRIPTION
## Résumé

Migration `Conway/Life/HashlifeMemo` vers le modèle **sibling pair FR canonique + EN miroir** (EPIC #4980, décision user 2026-07-04). **9ᵉ sibling pair** du backlog mono-lingual conway_lean, **4ᵉ nested namespace** `Conway > Life` × `Conway_en > Life_en` post c.412 / c.415 / c.416.

**`Conway/Life/HashlifeMemo.lean`** : module docstring FR canonique + i18n note FR.

**`Conway/Life/HashlifeMemo_en.lean`** (nouveau) : miroir EN avec `namespace Conway_en` + `open Conway` + `namespace Life_en` + `open Life` + body byte-identique.

## Substance réelle (Phase 3c)

**Couche de mémoïsation Hashlife** qui rend `hashlifeResult` faisable sur témoins communautaires piliers (OTCA 35K gen, UnitCell 4096 gen, Gemini 33M gen, CPU 1M gen) :

- **Cache** : `Std.HashMap (Nat × MacroCell) MacroCell` clé = `(fuel, cell)`.
- **`Hashable MacroCell`** : hash structurel 64-bit (`MacroCell.contentHash`).
- **Correction fusionnée** : chaque appel renvoie sous-type contenant valeur + cache final + preuve que valeur = référence non mémoisée + preuve `CacheOK`. Pas d'induction globale sur l'arbre de récursion 13-appels.

**8 theorem + 1 private theorem + 2 def + 1 instance + 4 #eval** (portés verbatim, byte-identity inner body) :
- `cacheOK_empty`, `CacheOK.insert`, `hashlifeResultAux_succ_node` (privé)
- `hashlifeResultMemo_correct` (FR/EN), `evolveHashlifeFastMemo_eq_evolveHashlifeFast` (bridge Phase 3b→3c)
- `evolveHashlifeFastMemo_empty` (utilisé par `Conway.Life.Pillars`)

## Preuves de progrès vérifiables (anti-§D + Lean §B)

| Critère | Mesure |
|---------|--------|
| **`grep -c sorry`** avant | 0 |
| **`grep -c sorry`** après | 0 / 0 (FR / EN) |
| **Body byte-identity FR vs EN** | sha256 `6ba76120a7a93ae09fdc5af225d0fbceb656ae07d8ff7717172222f15cab4bab` (295 inner lignes byte-identiques) |
| **CRLF count** | 0 / 0 (LF-only strict) |
| **Trailing newline** | OK sur les 2 fichiers |
| **Code structure** | 8 theorems + 2 defs + 1 instance + 4 #eval (préservés) |
| **Size** | FR 16732 B / 359 LF ; EN 16570 B / 358 LF |
| **Namespace imbriqué** | OK (`Conway > Life` × `Conway_en > Life_en` + open × 2) |

## i18n — convention #4980 ratifiée 2026-07-04

- **Module docstring FR** (`/-- ... -/`) : design + conception + notes d'implémentation.
- **i18n note FR** : référence à `code-style.md §Lean i18n` + décision user 2026-07-04.
- **EN sibling** : docstring EN équivalente + i18n note EN réfutant Option B (inline bilingue dans un seul fichier).
- **Énoncés de theorems, noms de lemmes, tactiques Lean, sections `/-! ##`, theorem docstrings** restent en anglais (cohérent avec c.412 / c.415 / c.416, compat Mathlib 4).
- **Seuls module docstring + i18n note** diffèrent entre FR et EN.

## Pattern namespace imbriqué (c.412/c.415/c.416 confirmés c.418)

Le namespace `Conway.Life` est défini par deux `namespace` consécutifs dans le source. Le miroir EN utilise **deux namespaces différents + deux `open`** :

```lean
namespace Conway        -- FR canonique
namespace Life
  ...
end Life
end Conway
```

```lean
namespace Conway_en     -- EN mirror
open Conway
namespace Life_en
open Life
  ...
end Life_en
end Conway_en
```

C'est le pattern canonique pour `Conway/Life/*.lean` — applicable aux 10 fichiers restants dans ce sous-dossier (Computation, ConeGeometry, GridCanonical, Hashlife, HashlifeCorrectness, LightCone, MacroCell, Pillars déjà migré par po-2026 #6412, RLE).

## Cold-build gate (C455-1)

WSL elan absent localement → CI Lean GitHub Actions = preuve canonique du merge. Anti-§D byte-identity local = signal minimal mais ne dispense PAS de CI PASS.

## Backlog c.418 (registration)

`Conway/Life/HashlifeMemo.lean` (359 LF rebuilt, 348 LF original) = **9ᵉ sibling pair** du backlog EPIC #4980 sur `conway_lean` Phase 1+, après :

- c.408 `Conway/MathlibMap` (10 #check, 90 LF, sorry 0/0) — `#6332`
- c.412 `Conway/Life/HashlifeMarginDemo` (1 def + 11 #eval + 6 inline, sorry 0/0) — `#6355`
- c.413 `Conway/FractranLemmas` (8 theorem, sorry 0/0) — `#6398` MERGED 2026-07-14
- c.414 `Conway/Angel` (4 theorem + 1 anchor, sorry 0/0) — `#6399`
- c.415 `Conway/Life/Spaceships` (3 theorem + 3 def, sorry 0/0) — `#6401`
- c.416 `Conway/Life/Oscillators` (7 theorems, sorry 0/0) — `#6407`
- c.417 `Conway/Life/Pillars` (po-2026, triple nested) — `#6412`

## Backlog restant c.419+

**Sibling pair candidates mono-linguaux** (10 restants dans `Conway/Life/`) :
- `Computation 194, ConeGeometry 322, GridCanonical 285, Hashlife 543, HashlifeCorrectness 3397=split, LightCone 477, MacroCell 794, RLE 342`
- `Conway/{KochenSpecker 363, Life 224}.lean`

**Bilingual inline legacy exclus** (6 fichiers, conservés en l'état) :
- `Conway/{CollatzLike, Doomsday, Fractran, FreeWillTheorem, LookAndSay, Nim}.lean`

## Anti-patterns évités

- ✅ `Write` tool → trailing newline vérifié via Python `data += b'\n'` (C413-L1 / C280-1)
- ✅ `--body-file` (JAMAIS `--body` à cause de C403-L1 backtick stripping)
- ✅ branch base = main local frais (R2 base-stale-14d)
- ✅ Atomique : 1 PR = 1 sibling pair (R3)
- ✅ Pas de catalogue touché (R1)
- ✅ Worker JAMAIS `gh pr merge` ou `--approve` (L143 SAFE cross-owner)
- ✅ Sections `/-! ##` et theorem docstrings en anglais (cohérent avec precedent c.412/c.413/c.414/c.415/c.416)
- ✅ Worktree isolé `D:/dev/CoursIA-c418` (sécurité R3 atomicité)
- ✅ Anti-§D byte-identity inner body préservé (sha256 identical FR↔EN)
- ✅ R5.4b MUST pivot : c.418 = 4ᵉ en arc conway_lean/Life mono-theme, signaler pivot post-c.418

🤖 Generated with [Claude Code](https://claude.com/claude-code)