### PR TITLE
fix(genai-texte,#6397): re-exec 6 SK ex-pip setup cells — Stop&Repair leak-free (EXEC_PROVED)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
@@ -75,23 +75,13 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n",
       "Configuration chargee:\n",
       "  - API Key: OK\n",
       "  - Modele: gpt-4o\n",
       "semantic-kernel installe.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.0\n",
-      "[notice] To update, run: <user_cache>\\Local\\Programs\\Python\\Python313\\python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb
@@ -107,24 +107,8 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.0\n",
-      "[notice] To update, run: <user_cache>\\Local\\Programs\\Python\\Python313\\python.exe -m pip install --upgrade pip\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
      "text": [
       "Configuration: API Key OK\n",
       "Imports OK\n"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
@@ -77,21 +77,11 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n",
       "Configuration: API Key OK\n",
       "Dependances installees\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.0\n",
-      "[notice] To update, run: <user_cache>\\Local\\Programs\\Python\\Python313\\python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb
@@ -76,24 +76,8 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.0\n",
-      "[notice] To update, run: <user_cache>\\Local\\Programs\\Python\\Python313\\python.exe -m pip install --upgrade pip\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
      "text": [
       "Process Framework - Demo conceptuelle\n"
      ]

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
@@ -77,20 +77,10 @@
    },
    "outputs": [
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n",
       "MCP SDK installe\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.2 -> 26.0\n",
-      "[notice] To update, run: <user_cache>\\Local\\Programs\\Python\\Python313\\python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb
@@ -84,7 +84,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6a10e4a",
    "metadata": {},
    "source": [
     "### Schema : conversation d'agents et etat du notebook\n",
@@ -325,10 +324,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n",
       "✅ Configuration LLM détectée dans .env :\n",
       "   - OPENAI_API_KEY       = configuree\n",
       "   - OPENAI_BASE_URL      = (API officielle)\n",
@@ -577,10 +575,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n",
       "Installation terminée. Si nécessaire, redémarrez le kernel pour activer les nouveaux packages.\n"
      ]
     }


### PR DESCRIPTION
## Context — completes #6342 Stop&Repair gap (#6397)

PR #6342 (merged `a2c7ffa7`) removed redundant `%pip install` source lines from 14 SemanticKernel notebooks. po-2024's forensic review found the Stop&Repair **incomplete for 6/14 files**: the pip source line was removed but the stale pip-`[notice]` output was **not regenerated** → committed `outputs` inconsistent with source (falsified exec state, secrets-hygiene rule 6) + `Python313` install-path + pip-version fingerprint in a PUBLIC repo.

ai-01 merged #6342 over the explicit "hold merge" review (batch-merge miss). This PR tracks the completion fix.

## Fix — re-execute the ex-pip setup cell (Stop & Repair)

Source `%pip` lines already removed by #6342; only stale OUTPUT remained. Fix = re-execute each setup cell, regenerating clean output. **No source change, no output scrubbing** (secrets-hygiene rule 6 — Stop & Repair, not hand-edit).

### Ex-pip setup cells re-executed (0 `[notice]` + 0 `Python313`)

| Notebook | cell | new clean output |
|---|---|---|
| 03-SemanticKernel-Agents | [1] | `Configuration chargee: API Key OK, Modele: gpt-4o, semantic-kernel installe.` |
| 04-SemanticKernel-Filters-Observability | [2] | `Configuration: API Key OK / Imports OK` |
| 05-SemanticKernel-VectorStores | [1] | `Configuration: API Key OK / Dependances installees` |
| 06-SemanticKernel-ProcessFramework | [1] | `Process Framework - Demo conceptuelle` |
| 08-SemanticKernel-MCP | [1] | `MCP SDK installe` |
| 10-SemanticKernel-NotebookMaker | [6] + [9] | `Configuration LLM detectee...` / `Installation terminee...` |

**Cell-index correction**: issue #6397 cited `10-NotebookMaker cell[1]`, but cell[1] is a markdown cell (mermaid diagram). The actual ex-pip setup cells are **[6]** (config/widgets setup) and **[9]** (`# Installation des packages requis`). Both cleaned.

### Exec env (honest disclosure)

Setup cells load API keys via `load_dotenv("../.env")`. The committed `.env` is **gitignored** (user secrets), absent on fresh checkout. To regenerate the intended "working config" outputs faithfully, exec-time env vars `OPENAI_API_KEY` (placeholder `sk-dummy-exec-no-leak`, **never printed nor committed**) + `OPENAI_CHAT_MODEL_ID=gpt-4o` were provided, mimicking what `.env` provides.

- **No setup cell makes an API call** (construction / config-print only).
- Printed output is **key-value-independent** (cells print `OK` / `configuree`, never the key).
- Outputs are **genuine** (real execution of the current source). Not scrubbing.

Rule F: `semantic-kernel` 1.43.0 + `python-dotenv` already in the `python3` kernel; `ipywidgets` + `jupyter_ui_poll` installed (needed by 10-NM cell[6]).

### 10-NotebookMaker — stray cell-id removed (validity fix)

10-NotebookMaker was nbformat **4.2** with a lone stray `id` on cell[1] (pre-existing half-applied-hygiene inconsistency) → `nbformat.validate` failed. Removed the stray id to restore 4.2 consistency. Full 4.5 modernization (the active fleet rollout, #6392-#6396 pattern) is a **separate** PR.

## Advisory — out of scope, distinct leak class (like #6397's 07-MultiModal)

**10-NotebookMaker cell[27]** (multi-agent orchestration runner `run_conversation()`, 49KB output) contains subprocess pip-install artifacts (`wordcloud`/`sgmllib3k` + `Python313\Scripts` paths). This is a **different leak class** — not an ex-pip setup cell, but orchestration subprocess output. Critically, **re-executing cell[27] would REGENERATE the leak** (the orchestration subp-`pip install`s in the user env). The real fix is an orchestration code change (install in a venv / don't echo subprocess pip output) → **separate follow-up**. Analogous to the issue's 07-MultiModal advisory.

## Validation — verdict EXEC_PROVED

- ✅ Real re-execution of all 7 ex-pip setup cells (python3 kernel, SK 1.43.0).
- ✅ `0 [notice]` + `0 Python313` in all ex-pip setup cell outputs (grep-verified).
- ✅ `nbformat.validate` 6/6 PASS.
- ✅ `validate_pr_notebooks.py` 6/6 PASS (53 code cells).
- ✅ Surgical diff: only `outputs` changed (5 insertions, 70 deletions = pip-notice text removed); source/ec/id/metadata preserved. 10-NM: +1 stray-id removal.
- ⚠️ Residual: 10-NM cell[27] orchestration-subprocess pip artifacts (advisory above, follow-up).

`See #6397` (not `Closes` — cell[27] advisory means strict "0 Python313 in all outputs of file 10" not yet met; the 6 ex-pip setup cells are fully resolved).