### PR TITLE
ci(notebook-tools): pip-leak HIGH delta guard — fail on new !pip install leaks (See #6314)

### DIFF
--- a/.github/workflows/pip-leak-guard.yml
+++ b/.github/workflows/pip-leak-guard.yml
@@ -1,0 +1,59 @@
+name: pip-leak-guard
+
+# Durable anti-regression guard for the `!pip install` machine-path leak vector
+# (secrets-hygiene.md §6, Stop & Repair). Fails a PR only when it INTRODUCES a
+# new HIGH-severity `!pip install` occurrence vs its base ref — inherited leaks
+# (drained one-PR-per-notebook per regle C.3, See #6314) are tolerated so the
+# gate never freezes the cluster. Mirror of the #6312 probeAddresses pattern,
+# adapted: #6312 is `--apply` (auto-fix, never fails); the pip detector is
+# audit-only, so the transposable durable form is a CI HIGH-delta gate.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.ipynb'
+      - 'scripts/notebook_tools/audit_pip_install_cells.py'
+      - 'scripts/notebook_tools/pip_leak_delta.py'
+      - '.github/workflows/pip-leak-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pip-leak-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pip-leak-delta:
+    name: "!pip install HIGH delta guard (#6314)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # base ref must be reachable for the BASE scan
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: HEAD scan (PR head)
+        run: |
+          python scripts/notebook_tools/audit_pip_install_cells.py --scan-all
+          python scripts/notebook_tools/audit_pip_install_cells.py --scan-all --json > /tmp/head.json
+
+      # Swap MyIA.AI.Notebooks/ to the PR base ref, scan, then restore. head.json
+      # is already captured above, so the swap cannot contaminate the delta.
+      - name: BASE scan (PR base ref)
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }} -- MyIA.AI.Notebooks
+          python scripts/notebook_tools/audit_pip_install_cells.py --scan-all --json > /tmp/base.json
+          git checkout HEAD -- MyIA.AI.Notebooks
+
+      - name: "Fail if HIGH delta > 0 (new !pip install leaks introduced)"
+        if: github.event_name == 'pull_request'
+        run: python scripts/notebook_tools/pip_leak_delta.py /tmp/base.json /tmp/head.json

--- a/scripts/notebook_tools/pip_leak_delta.py
+++ b/scripts/notebook_tools/pip_leak_delta.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Pip-leak HIGH delta guard — compare two ``audit_pip_install_cells.py`` JSON
+scans and fail if the PR introduces *new* HIGH-severity ``!pip install`` leaks.
+
+Why a delta (not an absolute ``--check`` fail)
+---------------------------------------------
+``audit_pip_install_cells.py --scan-all --check`` fails on ANY HIGH occurrence.
+The repo still carries inherited HIGH notebooks (drained one-PR-per-notebook per
+regle C.3, cf #6314 / #6310 / #6313). An absolute gate would therefore block
+every PR that touches an inherited-leak notebook for an unrelated reason and
+freeze the whole cluster — the opposite of #6312's ``strip_probe_banner.py``
+mirror, which is ``--apply`` (auto-fix, never fails).
+
+The durable, non-blocking transposition is a **delta guard**: count HIGH
+occurrences on BASE (pull-request base) and HEAD (pull-request head), fail only
+when HEAD > BASE, i.e. when the PR *introduces* new leaks. Existing leaks are
+tolerated; regressions are not.
+
+Usage
+-----
+Typically driven by ``.github/workflows/pip-leak-guard.yml`` which produces the
+two JSON files via two ``--scan-all`` runs (swapping ``MyIA.AI.Notebooks/``
+between base and head with ``git checkout``)::
+
+    python scripts/notebook_tools/audit_pip_install_cells.py --scan-all --json > head.json
+    git checkout baseref -- MyIA.AI.Notebooks
+    python scripts/notebook_tools/audit_pip_install_cells.py --scan-all --json > base.json
+    git checkout HEAD -- MyIA.AI.Notebooks
+    python scripts/notebook_tools/pip_leak_delta.py base.json head.json
+
+Standalone (local, no git): the two JSON files may be produced by any means.
+
+Exit codes: 0 = no new HIGH leaks ; 1 = HEAD introduces HIGH delta > 0 ; 2 = IO
+or JSON error.
+
+See #6314 (detector), #6309/#6312 (probeAddresses mirror pattern),
+secrets-hygiene.md §6 (Stop & Repair, source-level fix).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+HIGH_CLASSIFICATIONS = ("UNCONDITIONAL_BASH", "UNCONDITIONAL_SYS")
+
+
+def high_occurrences(data):
+    """Yield (file, cell_index, classification) for every HIGH occurrence in a
+    parsed audit-pip-install JSON document."""
+    for nb in data:
+        f = nb.get("file", "?")
+        for occ in nb.get("occurrences", []):
+            cls = occ.get("classification")
+            if cls in HIGH_CLASSIFICATIONS:
+                yield (f, occ.get("cell_index"), cls)
+
+
+def count_high(data):
+    return sum(1 for _ in high_occurrences(data))
+
+
+def high_by_file(data):
+    """map(file -> list of cell_index) for HIGH occurrences."""
+    by = {}
+    for f, idx, _ in high_occurrences(data):
+        by.setdefault(f, []).append(idx)
+    return by
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Fail if HEAD introduces new HIGH !pip install leaks vs BASE."
+    )
+    parser.add_argument("base", help="BASE JSON (audit_pip_install_cells.py --json)")
+    parser.add_argument("head", help="HEAD JSON (audit_pip_install_cells.py --json)")
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.base, encoding="utf-8") as fh:
+            base = json.load(fh)
+        with open(args.head, encoding="utf-8") as fh:
+            head = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: cannot read JSON inputs: {exc}", file=sys.stderr)
+        return 2
+
+    base_n = count_high(base)
+    head_n = count_high(head)
+    delta = head_n - base_n
+
+    print(f"pip-leak guard: BASE HIGH={base_n}  HEAD HIGH={head_n}  delta={delta:+d}")
+
+    if delta <= 0:
+        print(
+            "OK: no new HIGH leaks introduced "
+            f"(inherited {head_n} tolerated, drained one-PR-per-notebook per #6314)."
+        )
+        return 0
+
+    # Report which files gained HIGH occurrences (new or worsened).
+    base_by = high_by_file(base)
+    head_by = high_by_file(head)
+    print(
+        f"FAIL: PR introduces {delta} new HIGH-severity !pip install leak(s). "
+        "Source-level fix required (remove the !pip install line + re-execute, "
+        "cf secrets-hygiene.md §6 Stop & Repair, regle F).",
+        file=sys.stderr,
+    )
+    print("Newly-leaking / worsened notebooks:", file=sys.stderr)
+    for f, cells in sorted(head_by.items()):
+        prev = len(base_by.get(f, []))
+        if len(cells) > prev:
+            print(f"  +{len(cells) - prev}  {f}  (cells {cells})", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_pip_leak_delta.py
+++ b/scripts/notebook_tools/tests/test_pip_leak_delta.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Tests for pip_leak_delta (HIGH delta guard, See #6314).
+
+Covers:
+    * count_high / high_by_file classification wiring.
+    * delta == 0  -> exit 0 (inherited leaks tolerated).
+    * delta < 0  -> exit 0 (PR fixes leaks, encouraged).
+    * delta > 0  -> exit 1 + stderr names the newly-leaking file.
+    * malformed JSON -> exit 2.
+
+Run:
+    pytest scripts/notebook_tools/tests/test_pip_leak_delta.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent  # scripts/notebook_tools/
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import pip_leak_delta  # noqa: E402
+
+
+def _audit(nb_specs):
+    """Build a minimal audit-JSON document from (file, [classification,...])."""
+    return [
+        {
+            "file": f,
+            "total_cells": 5,
+            "code_cells": 5,
+            "occurrences": [
+                {"cell_index": i, "classification": cls, "source_preview": "..."}
+                for i, cls in enumerate(classes)
+            ],
+        }
+        for f, classes in nb_specs
+    ]
+
+
+# --- pure helpers -----------------------------------------------------------
+
+def test_count_high_only_counts_unconditional():
+    doc = _audit(
+        [
+            ("a.ipynb", ["UNCONDITIONAL_BASH", "CONDITIONAL_TRY", "NON_BASH"]),
+            ("b.ipynb", ["UNCONDITIONAL_SYS", "UNCONDITIONAL_BASH"]),
+            ("c.ipynb", ["CONDITIONAL_TRY", "NON_BASH"]),
+        ]
+    )
+    assert pip_leak_delta.count_high(doc) == 3
+
+
+def test_high_by_file_groups_cells():
+    doc = _audit([("a.ipynb", ["UNCONDITIONAL_BASH", "UNCONDITIONAL_SYS", "NON_BASH"])])
+    by = pip_leak_delta.high_by_file(doc)
+    assert by == {"a.ipynb": [0, 1]}
+
+
+# --- CLI exit codes ---------------------------------------------------------
+
+def _run(tmp_path, base_doc, head_doc):
+    base = tmp_path / "base.json"
+    head = tmp_path / "head.json"
+    base.write_text(json.dumps(base_doc), encoding="utf-8")
+    head.write_text(json.dumps(head_doc), encoding="utf-8")
+    return pip_leak_delta.main([str(base), str(head)])
+
+
+def test_delta_zero_exit_0_inherited_tolerated(capsys, tmp_path):
+    doc = _audit([("leak.ipynb", ["UNCONDITIONAL_BASH"])])
+    rc = _run(tmp_path, doc, doc)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "delta=+0" in out
+    assert "tolerated" in out
+
+
+def test_delta_negative_exit_0_fix_encouraged(capsys, tmp_path):
+    base = _audit([("a.ipynb", ["UNCONDITIONAL_BASH"]), ("b.ipynb", ["UNCONDITIONAL_BASH"])])
+    head = _audit([("a.ipynb", ["UNCONDITIONAL_BASH"])])  # b fixed
+    rc = _run(tmp_path, base, head)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "delta=-1" in out
+
+
+def test_delta_positive_exit_1_names_new_file(capsys, tmp_path):
+    base = _audit([("a.ipynb", ["UNCONDITIONAL_BASH"])])
+    head = _audit(
+        [
+            ("a.ipynb", ["UNCONDITIONAL_BASH"]),  # inherited, unchanged
+            ("new.ipynb", ["UNCONDITIONAL_BASH"]),  # NEW leak introduced
+        ]
+    )
+    rc = _run(tmp_path, base, head)
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "delta=+1" in captured.out
+    assert "new.ipynb" in captured.err
+
+
+def test_worsened_existing_file_exit_1(capsys, tmp_path):
+    base = _audit([("a.ipynb", ["UNCONDITIONAL_BASH"])])
+    head = _audit([("a.ipynb", ["UNCONDITIONAL_BASH", "UNCONDITIONAL_SYS"])])
+    rc = _run(tmp_path, base, head)
+    assert rc == 1
+    assert "a.ipynb" in capsys.readouterr().err
+
+
+def test_malformed_json_exit_2(tmp_path):
+    base = tmp_path / "base.json"
+    head = tmp_path / "head.json"
+    base.write_text("{not json", encoding="utf-8")
+    head.write_text("[]", encoding="utf-8")
+    rc = pip_leak_delta.main([str(base), str(head)])
+    assert rc == 2


### PR DESCRIPTION
## Summary

Durable anti-regression **CI guard** for the `!pip install` machine-path leak vector (secrets-hygiene.md §6, Stop & Repair). Dispatched by ai-01 (c.445): *« câbler détecteur #6314 en pre-commit/CI `--check` (mirror #6312, durabilité) »*.

Fails a PR **only when it introduces a NEW HIGH-severity `!pip install` occurrence** vs its base ref. Inherited leaks are tolerated.

## Why a delta gate, not an absolute `--check` (design decision)

`#6312` (probeAddresses mirror) is `--apply` — output-side auto-fix that **never fails**. The pip detector (`#6314`, already merged) is **audit-only** (no apply). A repo-wide `--check` would fail on the **17 inherited HIGH notebooks** and **freeze the whole cluster** (every PR touching an inherited-leak notebook for an unrelated reason would be blocked). The transposable durable form is therefore a **HIGH-delta gate**:

| | tolerated | blocked |
|---|---|---|
| inherited leaks (17, drained one-PR-per-notebook per regle C.3, See #6310/#6313) | ✅ | |
| PR that fixes a leak (delta < 0) | ✅ encouraged | |
| **PR that introduces a new `!pip install` (delta > 0)** | | ❌ **fail** |

This is the faithful "durability" intent of the `#6312` mirror, adapted to an audit-only detector.

## Files (3, atomic, +299/-0)

| File | Δ | Purpose |
|------|---|---------|
| `scripts/notebook_tools/pip_leak_delta.py` | +124 | Delta helper: compare 2 audit JSON, exit 1 if HEAD HIGH > BASE HIGH, names worsened files. |
| `scripts/notebook_tools/tests/test_pip_leak_delta.py` | +103 | 7/7 tests: delta 0 / -1 / +1, worsened existing file, malformed JSON exit 2. |
| `.github/workflows/pip-leak-guard.yml` | +72 | PR guard on `.ipynb`: HEAD scan, swap `MyIA.AI.Notebooks/` to base ref, BASE scan, fail on HIGH delta > 0. |

## §H.5 verdict: `EXEC_PROVED`

- `pytest test_pip_leak_delta.py` → **7/7 PASS**.
- `pytest test_audit_pip_install_cells.py` → **13/13 PASS** (canonical detector, no regression).
- **End-to-end local sim**: `delta=0 → exit 0` (inherited tolerated) ; injected-leak `delta=+1 → exit 1` (names `2_PromptEngineering.ipynb cell 58`), target restored after.
- `py_compile` OK, `yaml.safe_load` OK.
- Baseline on `origin/main` (`6ad49eb73`): **17 HIGH occurrences** (stable, vs the 70 at #6314 creation — drained by ~26 sibling PRs).

## How it runs

PR touching `.ipynb` (or the detector/helper/workflow) triggers:
1. HEAD scan → `head.json`.
2. `git checkout base.sha -- MyIA.AI.Notebooks` → BASE scan → `base.json` → restore.
3. `pip_leak_delta.py base.json head.json` → exit 1 if new leaks introduced.

Note: this PR touches **no `.ipynb`** → the guard does not self-trigger (no chicken-and-egg). Coverage of the new tests comes from `scripts-tests.yml` (`scripts/**` path filter).

## Anti-régression (rule D) — none

Net additive (+299/-0), no Lean/proof/code métier touched, no existing impl replaced.

## Catalog hygiene (rule R1) — N/A

Does not touch `COURSE_CATALOG.*` or `CATALOG-STATUS` markers.

## Cross-references

- `#6314` (detector `audit_pip_install_cells.py`, merged) — See, not Closes (epic ongoing).
- `#6309` / `#6312` (probeAddresses mirror pattern, `strip_probe_banner.py`).
- `secrets-hygiene.md` §6 (Stop & Repair, source-level fix triage C).
- `#6310` / `#6313` (sibling per-notebook fix precedents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)