### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Sudoku-3-Genetic-Python

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -1789,14 +1789,16 @@
    "metadata": {},
    "source": [
     "## 7. Comparaison quantitative avec solveurs exacts (Prong B #3801)\n\nLe benchmark precedent (Section 5) a mesure les algorithmes genetiques sur 3 puzzles faciles (1/3 resolu, ~1-30s par puzzle). Pour situer les GA par rapport aux solveurs exacts, voici une **comparaison quantitative** sur les memes classes de puzzles (Easy / Hard), avec les chiffres reels publies dans les notebooks voisins.\n\n### Tableau comparatif (chiffres verifies, sources citees)\n\n| Solveur | Easy (10 puzzles) | Hard/Top11 (11 puzzles) | Garantie exactitude |\n|---------|--------------------|-------------------------|---------------------|\n| **GA Permutations** (mesure, cell 22) | 1/3 resolus, ~1-30s | non teste (gap pedagogique) | Non |\n| **Backtracking simple** (`Sudoku-1-Backtracking-Python`, cell 15) | 10/10, 1436.72 ms total, **143.67 ms moyen** | non teste dans la source | Oui (exhaustif) |\n| **OR-Tools CP-SAT** (`Sudoku-10-ORTools-Python`, cell 19) | 10/10, 145.87 ms total, **14.59 ms moyen** | 11/11, 263.65 ms total, **23.97 ms moyen** | Oui (CP) |\n| **Z3 BitVector** (`Sudoku-12-Z3-Python`, cell 14, Hard1) | non mesure sur Easy | Hard1: **68.65 ms** | Oui (SMT) |\n\n### Observations (Prong B illustre)\n\n1. **Ecart de 1 a 3 ordres de grandeur** entre GA et solveurs exacts sur les memes instances :\n   - GA Permutations Easy : ~10 000 ms (estimation d'apres cell 22)\n   - OR-Tools CP-SAT Easy : 14.59 ms moyen\n   - **Ratio GA / OR-Tools ~ 700x** sur Easy.\n2. **Taux de succes** : 1/3 (GA) vs 10/10 (Backtracking, OR-Tools) -- les GA sont **non-garantis**, les solveurs exacts sont **complets**.\n3. **Passage a l'echelle** : OR-Tools reste ~24 ms meme sur Top11 (puzzles les plus durs), GA non teste au-dela de Easy mais extrapolation pessimiste.\n4. **Valeur pedagogique des GA** : les algorithmes genetiques ne sont **pas adaptes au Sudoku** mais illustrent une famille de methodes (recherche stochastique, sans garantie) complementaire des solveurs exacts (garantis).\n\n> **Note methodologique** : tous les chiffres cites proviennent des cellules de benchmark des notebooks sources (outputs reels, ec != null, 0 erreur). Aucune valeur fabriquee.\n"
-   ]
+   ],
+   "id": "cell-74cb985c"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)\n\n### Contexte\n\nLe tableau ci-dessus compare les GA (mesure : ~1-30s par puzzle) aux solveurs exacts (~15-25 ms). Pour faire toucher du doigt le **ratio de cout**, on veut le chiffrer.\n\n### Enonce\n\nA partir des **chiffres reels** du tableau comparatif (cellule precedente) :\n\n1. Calculer le ratio `temps_GA / temps_OR-Tools` sur Easy, en utilisant :\n   - GA : le **pire cas** observe (Puzzle 3 = 29.53 s = 29530 ms, d'apres `Sudoku-3-Genetic-Python` cell 22 du notebook original).\n   - OR-Tools : le **temps moyen** sur Easy (14.59 ms).\n2. Comparer avec le ratio Backtracking / OR-Tools (143.67 / 14.59).\n3. Conclure sur la **position des GA dans la hierarchie** : efficaces / equivalentes / nettement inferieures / sans commune mesure.\n\n### Indication\n\n- `ratio_ga_ortools = temps_ga_ms / temps_ortools_ms`\n- `ratio_bt_ortools = temps_bt_moyen_ms / temps_ortools_moyen_ms`\n- Si `ratio_ga_ortools > ratio_bt_ortools * 100`, on a un ecart d'au moins 2 ordres de grandeur (Prong B demontre).\n\n### Solution (a completer par l'etudiant)\n\n```\nratio_ga_ortools = None  # TODO etudiant\nratio_bt_ortools = None  # TODO etudiant\nconclusion       = None  # TODO etudiant\n```\n"
-   ]
+   ],
+   "id": "cell-bed04ec1"
   },
   {
    "cell_type": "code",
@@ -1824,14 +1826,16 @@
       ">>> Exercice a completer : implementer compute_ratio_ga_ortools() et compute_ratio_bt_ortools()\n"
      ]
     }
-   ]
+   ],
+   "id": "cell-ad5721d2"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### References Section 7 (chiffres verifies)\n\nLes chiffres du tableau comparatif (cellule Section 7) proviennent des cellules source suivantes :\n\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb` (cell 15 : benchmark Easy 10 puzzles, 1436.72 ms total)\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb` (cell 19 : benchmark Easy + Hard/Top11)\n- `MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb` (cell 14 : comparaison Z3 Int vs BitVector sur Hard)\n\n**Verification** : tous outputs `execution_count != null`, 0 erreur, dans les notebooks sources au moment de la rédaction (2026-07-03).\n"
-   ]
+   ],
+   "id": "cell-a1a5892b"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (4 cells) to `Sudoku/Sudoku-3-Genetic-Python.ipynb` — part of the v4.5 cell-id gap sweep (see #6257).

The notebook was **already v4.5 (`nbformat_minor=5`)** but 4 cells lacked the required `id` field. Adding them makes it strictly `nbformat.validate()`-conformant.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit, so the ONLY diff is the added `"id"` line + the preceding `]`→`],` separator.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED**.
- `python scripts/notebook_tools/validate_pr_notebooks.py` **PASSED**.
- `git diff --stat`: `8 insertions(+), 4 deletions(-)` = **2N/N** (4 ids × {1 separator + 1 id line}).
- `execution_count` / `outputs`: unchanged (structural-only, no cell source touched).

See #6257.
