### PR TITLE
docs(semanticweb): correct sw12_graphrag_c18 légende fidelity (#5780)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -302,7 +302,7 @@ C'est l'anti-hallucination par excellence : un LLM ancré sur des faits RDF vér
 
 ![Graphe orienté des entités extraites par LLM, noeuds colorés par type et arêtes étiquetées](assets/readme/sw12_graphrag_c18_o0.png)
 
-*SW-12 (cellule 18) : **graphe orienté des entités extraites par LLM** (filmographie Nolan) — noeuds colorés par type d'entité (Person / Movie / Organization / Award / Genre / Concept), arêtes orientées étiquetées par la relation extraite.*
+*SW-12 (cellule 18) : **graphe orienté des entités extraites par LLM** (filmographie Nolan) — noeuds colorés par type d'entité **extrait** du texte (Person / Movie / Organization / Award — 4 types sur les 6 du vocabulaire `TYPE_MAP` ; `Genre` et `Concept` sont définis dans le mapping mais aucune entité de ce type n'apparaît dans le texte de démonstration, voir cellule 900 du notebook), arêtes orientées étiquetées par la relation extraite (`directed_by`, `starred_in`, `nominated_for`, `produced_by`, `won`, `with`).*
 
 ![Communautés détectées par modularité gloutonne (networkx) sur le graphe non-dirigé](assets/readme/sw12_graphrag_c30_o1.png)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/assets/readme/MANIFEST.md
@@ -17,7 +17,7 @@ Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'o
 ## sw12_graphrag_c18_o0.png
 
 - **Source** : notebook `SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb` (cellule 18, output 0)
-- **Alt-text (FR)** : Graphe orienté des entités extraites par LLM (filmographie Nolan) — noeuds colorés par type d'entité (Person / Movie / Organization / Award / Genre / Concept), arêtes orientées étiquetées par la relation extraite.
+- **Alt-text (FR)** : Graphe orienté des entités extraites par LLM (filmographie Nolan) — noeuds colorés par type d'entité **extrait** du texte (Person / Movie / Organization / Award — 4 types sur les 6 du vocabulaire `TYPE_MAP` ; `Genre` et `Concept` sont définis dans le mapping mais aucune entité de ce type n'est extraite du texte de démonstration, voir cellule 900 du notebook), arêtes orientées étiquetées par la relation extraite (`directed_by`, `starred_in`, `nominated_for`, `produced_by`, `won`, `with`).
 - **Poids** : 137.0 KB (PIL optimise)
 
 ## sw12_graphrag_c30_o1.png


### PR DESCRIPTION
docs(semanticweb): correct sw12_graphrag_c18 légende fidelity (#5780)

Audit visuel des 6 figures `assets/readme/` SemanticWeb par MiniMax M3 (vision-capable, différenciant vs GLM-5.1 sans vision) : **5/6 OK, 1 bug de fidélité** sur la légende `sw12_graphrag_c18_o0.png`.

## Bug constaté (audit visuel figure c.18)

Légende originale :
> noeuds colorés par type d'entité (Person / Movie / Organization / Award / Genre / Concept)

Mais la figure contient **4 catégories effectives** (Person / Movie / Organization / Award). Confirmation croisée via lecture du notebook `SW-12-Python-GraphRAG.ipynb` cellule 900 :

> `Genre` et `Concept` figurent dans le vocabulaire interne (`TYPE_MAP`) mais aucune entité de ces types n'est extraite du texte de démonstration. De même, la relation `genre_of` est définie dans `REL_MAP` mais n'apparaît pas dans les relations extraites. Les compteurs ci-dessus reflètent ce qui est réellement présent dans le graphe RDF construit (15 entités, 12 relations, 61 triplets).

Vocabulary-only ≠ entités extraites : la légende prétendait afficher 6 catégories alors que la figure n'en montre que 4.

## Fix (2 lignes)

- `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md` (L305)
- `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/assets/readme/MANIFEST.md` (L20)

Légende corrigée pour refléter **les 4 catégories effectivement visibles** dans la figure + mention explicite que `Genre`/`Concept` sont vocabulary-only + référence à la cellule 900 du notebook comme preuve vérifiable.

Bonus : liste complète des arêtes extraites (`directed_by`, `starred_in`, `nominated_for`, `produced_by`, `won`, `with`) ajoutée à la légende.

## Vérification

```bash
git diff origin/main..HEAD --stat
# 2 files changed, 2 insertions(+), 2 deletions(-)
```

```bash
python scripts/check_docs_links.py --check
# OK: No new broken links. (3903 total)
```

## Pourquoi ce fix (Substance > Sweep, L429)

Plutôt qu'un sweep cosmétique sur 33+ READMEs (catalog-pr-hygiene R1 = JAMAIS toucher catalogue sur branche), cette PR atomic :
- **1 bug réel** vérifié visuellement (la légende mentait sur le contenu de la figure)
- **2 fichiers** (+2/-2, scope minimal)
- **0 notebook modifié** (pas de re-exec Papermill requise, C.3 strict)
- **0 catalogue** touché (R1 respectée — le cron `catalog-cron.yml` régénère < 24h)
- **0 #5780 close** : contribution partielle à l'EPIC figures README (5 autres séries restent à auditer)

## Refs

- Issue #5780 (figures README — pas de galeries + légendes fidèles)
- EPIC #5654 (vague originale des figures `assets/readme/`, 42 dossiers)
- Notebook `SW-12-Python-GraphRAG.ipynb` cellule 900 (preuve vérifiable)
- R6 rotation : c.469 (figures §E substance vision) ≠ c.468 (SMT nomenclature) ≠ c.467b (SMT) ≠ c.467 (SK security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)