### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Sudoku-8-HumanStrategies-Python

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -518,7 +518,8 @@
     "**Indice**\n",
     "Utilisez `find_naked_singles` sur plusieurs puzzles de chaque difficulte\n",
     "et calculez la moyenne.\n"
-   ]
+   ],
+   "id": "cell-454955f9"
   },
   {
    "cell_type": "code",
@@ -540,7 +541,8 @@
     "    # le nombre moyen de naked singles trouves\n",
     "    result = {}  # TODO etudiant\n",
     "    return result\n"
-   ]
+   ],
+   "id": "cell-a0f67067"
   },
   {
    "cell_type": "markdown",
@@ -889,7 +891,8 @@
     "Parcourez chaque unite et identifiez les valeurs qui n'apparaissent que 2 fois.\n",
     "**Étape 2**\n",
     "Verifiez si ces 2 valeurs partagent les memes 2 cellules.\n"
-   ]
+   ],
+   "id": "cell-05be24e4"
   },
   {
    "cell_type": "code",
@@ -912,7 +915,8 @@
     "    # Retournez une liste de (unite_type, position, paire_de_valeurs)\n",
     "    result = []  # TODO etudiant\n",
     "    return result\n"
-   ]
+   ],
+   "id": "cell-fde7c35b"
   },
   {
    "cell_type": "markdown",
@@ -1579,7 +1583,8 @@
     "**Indice**\n",
     "Utilisez le solveur `HumanSudokuSolver` et comptez les puzzles ou\n",
     "`solve()` retourne True sans utiliser le backtracking de secours.\n"
-   ]
+   ],
+   "id": "cell-b761dae5"
   },
   {
    "cell_type": "code",
@@ -1601,7 +1606,8 @@
     "    # combien peuvent etre resolus uniquement par strategies humaines\n",
     "    result = {}  # TODO etudiant\n",
     "    return result\n"
-   ]
+   ],
+   "id": "cell-2bc950e1"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (6 cells) to `Sudoku/Sudoku-8-HumanStrategies-Python.ipynb` — part of the v4.5 cell-id gap sweep (see #6257). This was the last Sudoku-family notebook in the gap (Sudoku-2/#6423, Sudoku-3/#6422, Sudoku-4/#6406 already delivered).

The notebook was **already v4.5 (`nbformat_minor=5`)** but 6 of its 52 cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED**.
- `validate_pr_notebooks.py` **PASSED**.
- `git diff --stat`: `12 insertions(+), 6 deletions(-)` = **2N/N** (6 ids × {1 separator + 1 id line}).
- `execution_count` / `outputs`: unchanged (structural-only, no cell source touched).

See #6257.
