### PR TITLE
fix(genai-texte,#6397): re-exec 10-NotebookMaker ex-pip cells [6]/[9] + stray cell-id (reduced from #6414)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb
@@ -84,7 +84,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6a10e4a",
    "metadata": {},
    "source": [
     "### Schema : conversation d'agents et etat du notebook\n",
@@ -325,10 +324,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n",
       "✅ Configuration LLM détectée dans .env :\n",
       "   - OPENAI_API_KEY       = configuree\n",
       "   - OPENAI_BASE_URL      = (API officielle)\n",
@@ -577,10 +575,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n",
       "Installation terminée. Si nécessaire, redémarrez le kernel pour activer les nouveaux packages.\n"
      ]
     }


### PR DESCRIPTION
## Reduced from #6414 per ai-01 adjudication (issuecomment-4965125090)

#6414 was HELD: its changes to 03/04/05/06/08 were a **redundant second re-exec** — those 5 files were already leak-free on `main` via **#6400** (`8731bf40b`, merged 02:48Z, 27 min before #6414's branch cut). This reduced PR keeps only the **unique value: 10-NotebookMaker**.

## Fix — 10-NotebookMaker ex-pip setup cells (EXEC_PROVED)

#6400 skipped 10-NotebookMaker. This PR completes it:

- **cell[6]** (config/widgets setup, ex-`%pip`) re-executed → clean `Configuration LLM détectée…` output. 0 `[notice]` + 0 `Python313`.
- **cell[9]** (`# Installation des packages requis`, ex-`%pip`) re-executed → clean `Installation terminée…` output.
- **Cell-index correction**: issue #6397 cited `cell[1]`, but cell[1] is a markdown mermaid diagram. The actual ex-pip setup cells are **[6]** and **[9]**.
- **Stray cell-id removed**: 10-NM was nbformat 4.2 with a lone stray `id` on cell[1] (pre-existing half-applied-hygiene inconsistency → `nbformat.validate` failed). Removed to restore 4.2 validity. Full 4.5 modernization = separate fleet rollout (#6392–#6396 pattern).

Exec env: setup cells load keys via `load_dotenv("../.env")` (gitignored, absent on fresh checkout). Exec-time env vars `OPENAI_API_KEY` (placeholder, never printed/committed) + `OPENAI_CHAT_MODEL_ID=gpt-4o` mimic `.env`. cell[6] is config-print only (no API call) → output key-value-independent and genuine. Not a scrub.

## cell[27] — pre-existing leak, OUT OF SCOPE, RECOVERABLE-USER-HAND

10-NM **cell[27]** (`run_conversation()` orchestration) output still carries a **pre-existing leak on `main`** (NOT introduced by this PR):

```
"<user_cache>\Roaming\Python\Python313\Scripts"   <- placeholder pip NEVER emits = prior incomplete hand-scrub (rule 6 falsification)
"installed in 'C:\Users\jsboi\AppData\Roaming\Python\Python313\Scripts' which is not on PATH"  <- pip PATH warning
fossil wordcloud/sgmllib3k subprocess artifacts
```

**Faithful re-exec of cell[27] requires**:
1. A valid `OPENAI_API_KEY` — cell[25] builds the `AsyncOpenAI` client; cell[27] `group_chat.invoke()` makes **real LLM calls**.
2. Navigation of **interactive cells [4]/[6]** — both have `ui_events` blocking loops (task selection + LLM config widgets) that require human interaction.

= **RECOVERABLE-USER-HAND** (credential + interaction). Cannot be done in an automated worker cycle. A dummy-key re-exec would produce a non-representative error log (losing the pedagogical orchestration output), and would still block on cell[4]'s interactive task-selection loop.

Deferred to either a user-hand re-exec (with valid key + interactive cells driven) or an orchestration-code fix (separate follow-up). Flagged for ai-01 decision.

## Validation — verdict EXEC_PROVED (for cells [6]/[9])

- ✅ Real re-execution of ex-pip setup cells [6]/[9] (python3 kernel, SK 1.43.0).
- ✅ `0 [notice]` + `0 Python313` in cells [6]/[9] outputs.
- ✅ `nbformat.validate` PASS.
- ✅ Surgical diff: only outputs of [6]/[9] changed + 1 stray-id removal (+2/−5). Source/ec/id/metadata preserved.
- ⚠️ Residual: cell[27] pre-existing leak (RECOVERABLE-USER-HAND, above).

`See #6397` (cell[27] advisory means strict leak-free not yet 100% for this file).

Supersedes #6414 (closed as redundant for 5/6 files).