### PR TITLE
fix(search): de-leak Exercice 2 Search-1-StateSpace-Csharp (pre-solved -> stub)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
@@ -2883,91 +2883,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Puzzle                      n! (total)        n!/2 (accessibles)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-----------------------------------------------------------------\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8-puzzle     362880                    181440                   \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "15-puzzle    20922789888000            10461394944000           \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "24-puzzle    7034535277573963776       3517267638786981888      \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Conclusion :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "- Le nombre d'etats explose factorialement (n!)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "- Seule la moitie des etats est atteignable (parite de permutation)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "- La recherche exhaustive devient rapidement impossible\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  8-puzzle (~181K etats) : faisable en BFS avec ~1 Go de memoire\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  15-puzzle (~10^13 etats) : necessite des heuristiques (cf. Search-3)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  24-puzzle (~10^24 etats) : intractable en recherche exhaustive\r\n"
+      "Exercice 2 a completer : implementez Factorial puis le tableau n!/2.\r\n"
      ]
     }
    ],
@@ -2980,36 +2896,28 @@
     "//\n",
     "// Conclure sur la faisabilite de la recherche exhaustive.\n",
     "\n",
-    "// Liste des taquins a etudier : (nom, k, n)\n",
+    "// Liste des taquins a etudier : (nom, k, n)  -- donnee fournie.\n",
     "var puzzles = new (string name, int k, int n)[] {\n",
     "    (\"8-puzzle\",   3,  9),\n",
     "    (\"15-puzzle\",  4, 16),\n",
     "    (\"24-puzzle\",  5, 25),\n",
     "};\n",
     "\n",
-    "// Fonction factorielle iterative (evite les overflow en utilisant long).\n",
-    "static long Factorial(int n) {\n",
-    "    long f = 1;\n",
-    "    for (int i = 2; i <= n; i++) f *= i;\n",
-    "    return f;\n",
+    "// TODO (etudiant) : implementez la fonction factorielle n! -> long.\n",
+    "// Indice : boucle multiplicative ; utilisez long pour eviter l'overflow de 16! et 25!.\n",
+    "// Etape 1 : completer 'static long Factorial(int n)' ci-dessous.\n",
+    "static long Factorial(int n)\n",
+    "{\n",
+    "    // Votre code ici.\n",
+    "    return 0L;  // TODO etudiant : remplacer par le calcul de n!.\n",
     "}\n",
     "\n",
-    "Console.WriteLine($\"{\"Puzzle\",-12} {\"n! (total)\",25} {\"n!/2 (accessibles)\",25}\");\n",
-    "Console.WriteLine(new string('-', 65));\n",
-    "foreach (var p in puzzles) {\n",
-    "    long total = Factorial(p.n);\n",
-    "    long accessible = total / 2;\n",
-    "    Console.WriteLine($\"{p.name,-12} {total,-25} {accessible,-25}\");\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Conclusion :\");\n",
-    "Console.WriteLine(\"- Le nombre d'etats explose factorialement (n!)\");\n",
-    "Console.WriteLine(\"- Seule la moitie des etats est atteignable (parite de permutation)\");\n",
-    "Console.WriteLine(\"- La recherche exhaustive devient rapidement impossible\");\n",
-    "Console.WriteLine(\"  8-puzzle (~181K etats) : faisable en BFS avec ~1 Go de memoire\");\n",
-    "Console.WriteLine(\"  15-puzzle (~10^13 etats) : necessite des heuristiques (cf. Search-3)\");\n",
-    "Console.WriteLine(\"  24-puzzle (~10^24 etats) : intractable en recherche exhaustive\");"
+    "// TODO (etudiant) : pour chaque taquin, afficher n! et n!/2 dans un tableau.\n",
+    "// Indice : l'espace atteignable vaut total / 2 (parite des permutations).\n",
+    "// Etape 2 : parcourir 'puzzles', calculer Factorial(p.n) puis total / 2.\n",
+    "// Etape 3 : afficher un tableau (nom | n! | n!/2) et conclure sur la\n",
+    "//           faisabilite (8-puzzle vs 15-puzzle vs 24-puzzle, cf. Search-3).\n",
+    "Console.WriteLine(\"Exercice 2 a completer : implementez Factorial puis le tableau n!/2.\");\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

`Search-1-StateSpace-Csharp.ipynb` **cell #37** (titled **"Exercice 2"**) carried the **complete worked solution** — a student had nothing to do. De-leaked per the **exercise-example-labeling rule case 1**.

## The leak (content-based verdict, cf exercise-example-labeling.md)

| Cell | Content | Classification |
|------|---------|----------------|
| #36 (markdown) | `### Exercice 2 : Taille de l'espace d'etats...` ("**Calculez**...") | Exercise prompt |
| #37 (code) | Full solution: `Factorial` implemented + puzzles table + output loop + conclusion (25 logic lines) | **Pre-solved = LEAK** |

**Notebook pattern confirms the intent** (not a flip-flop, cf incidents #1214/#1336):
- Exercice 3 (cell 39): properly **stubbed** (41 logic lines, stub markers)
- Exercice 4 (cell 44): properly **stubbed** (9 logic lines, stub markers)
- **Exercice 2 (cell 37): pre-solved = the outlier**

Aligning Exercice 2 with its siblings per rule case 1 (title "Exercice" + code = solution complete → **stub the code**, keep the title).

## Fix

Stubbed cell 37 (C.1 compliant — no `throw new NotImplementedException`):
- **Kept**: exercise description header + data scaffolding (`puzzles` array — like the maze grid in Exercice 3).
- **Removed**: the solution (`Factorial` body + output table loop).
- **Added**: `// TODO (etudiant)` / `// Indice` / `// Etape N` markers + benign fallback (`return 0L` + `Console.WriteLine` print) so the notebook still runs end-to-end.

## §H.5 verdict: `EXEC_PROVED`

- **Re-executed cell 37 IN CONTEXT** (cells 0..37 via `.net-csharp` kernel) so `execution_count` is the natural positional value (**ec=14**, unchanged from main) and the output is real kernel stdout. The temp notebook (with banner re-injected on prior cells) is discarded — **C.3 scoped**: only cell 37 is staged.
- `validate_pr_notebooks.py` → **1/1 PASS** (17 code cells, .net-csharp).
- `nbformat.validate` OK (48 cells).
- **0 probeAddresses banner** (context exec injects it on the first code cell only, not cell 37; `strip_probe_banner.py` confirms 0).
- `0` raise NotImplementedError / `1/0` (C.1).
- Diff is surgical: **only cell 37** (source + 13 solution outputs → 1 stub output), byte-format matched (no trailing newline). `+15/−107`.

## Why deletions > insertions is correct here (rule D does not apply)

The `+15/−107` ratio is the **expected signature of a solution-leak fix** (removing a full worked solution to stub an exercise). This is **exercise-content**, not production code/proof — anti-régression rule D explicitly excludes exercise stubs (they should be stubbed). Per the labeling rule, removing the solution is the *required* fix.

## Catalog hygiene (rule R1) — N/A

Does not touch `COURSE_CATALOG.*` or `CATALOG-STATUS` markers.

## Cross-references

- **#1214** (labeling rule), **#1336** (rootcause of the find-replace chaos).
- **#6309 / #6312** (probe banner kernel-injection exception).
- exercise-example-labeling.md (case 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)