### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to 1.3-Analyse_de_Donnees_avec_Pandas

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb
@@ -496,7 +496,8 @@
     "- Les resultats obtenus permettent de valider la comprehension\n",
     "\n",
     "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
-   ]
+   ],
+   "id": "cell-ced13a1a"
   },
   {
    "cell_type": "markdown",
@@ -507,7 +508,8 @@
     "1. W. McKinney, *Data Structures for Statistical Computing in Python*, Proceedings of the 9th Python in Science Conference (SciPy 2010), pp. 51-56, 2010. Article fondateur de Pandas : structures `Series` et `DataFrame`, conçues pour le calcul statistique sur données étiquetées.\n",
     "2. W. McKinney, *Python for Data Analysis: Data Wrangling with Pandas, NumPy, and Jupyter*, O'Reilly Media, 3e édition, 2022. Référence livresque canonique sur l'usage pratique de Pandas (`groupby`, indexation, nettoyage).\n",
     "3. T. Wes McKinney, *pandas: a Foundational Python Library for Data Analysis and Statistics*, 2011. Notes techniques complémentaires sur l'architecture interne de Pandas."
-   ]
+   ],
+   "id": "cell-042df0dd"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (2 cells) to `ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.3-Analyse_de_Donnees_avec_Pandas.ipynb` — part of the v4.5 cell-id gap sweep (see #6257).

The notebook was **already v4.5 (`nbformat_minor=5`)** but 2 cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED**.
- `validate_pr_notebooks.py` **PASSED**.
- `git diff --stat`: `4 insertions(+), 2 deletions(-)` = **2N/N**.
- `execution_count` / `outputs`: unchanged (structural-only).

See #6257.
