### PR TITLE
fix(search): de-leak App-15-SportsScheduling — relabel 3 'Exercice' -> 'Exemple guide' (case 2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb
@@ -1991,9 +1991,9 @@
     "tags": []
    },
    "source": [
-    "## Exercices\n",
+    "## Exemples guides (avancés)\n",
     "\n",
-    "Les exercices suivants vous permettront d'approfondir votre compréhension de la planification sportive avec CSP."
+    "Les exemples guidés suivants approfondissent la planification sportive avec CSP : chaque exemple présente un objectif, des indices, puis la solution complète commentée (les codes qui suivent se déclarent déjà « Exemple guide »)."
    ]
   },
   {
@@ -2010,7 +2010,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Contraintes d'arbitres\n",
+    "### Exemple guide 1 : Contraintes d'arbitres\n",
     "\n",
     "Dans un championnat réel, les arbitres doivent être assignés aux matchs avec des contraintes spécifiques.\n",
     "\n",
@@ -2117,7 +2117,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Objectif d'equite des deplacements\n",
+    "### Exemple guide 2 : Objectif d'equite des deplacements\n",
     "\n",
     "L'objectif actuel minimise la distance totale, mais cela peut defavoriser certaines equipes.\n",
     "\n",
@@ -2209,7 +2209,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Contraintes de repos minimum\n",
+    "### Exemple guide 3 : Contraintes de repos minimum\n",
     "\n",
     "Les equipes professionnelles ont besoin de repos minimum entre les matchs.\n",
     "\n",


### PR DESCRIPTION
## Summary

`App-15-SportsScheduling.ipynb` second half had an **internal contradiction**: markdown titles said **"Exercice"** but the code cells that followed **self-declared "# Exemple guide"** and carried complete worked solutions. De-leaked per the **exercise-example-labeling rule case 2** (title "Exercice" + code = solution complete → relabel the title).

## The leak (content-based verdict)

| Cell | Said | Reality |
|------|------|---------|
| #37 | `## Exercices` (header) | section of resolved examples |
| #38 | `### Exercice 1 : Contraintes d'arbitres` | code #39 = `# Exemple guide 1` + **full solution** |
| #40 | `### Exercice 2 : Objectif d'equite...` | code #41 = `# Exemple guide 2` + **full solution** |
| #42 | `### Exercice 3 : Contraintes de repos minimum` | code #43 = `# Exemple guide 3` + **full solution** |

The codes **already say "Exemple guide"** — the markdown titles were simply wrong. Relabeling aligns titles with the resolved content. **Not a flip-flop** (cf incidents #1214/#1336, where *blind* Exercice↔Exemple swaps corrupted prose): here the content itself confirms the "exemple guide" intent.

## The notebook's first half is already correct

Cells #10/#18/#26 = `#### Exercice 1/2/3`, each correctly **stubbed** (code cells #11/#19/#27 have TODO markers). The **≥3-exercise convention is already satisfied** by the first half. The second half is a distinct advanced-examples section → relabeled `## Exemples guides (avancés)`.

## Changes (markdown-only, 4 cells, +5/−5)

- **cell #37**: `## Exercices` → `## Exemples guides (avancés)` + intro rewrite (explains these are guided examples with full commented solutions).
- **cells #38/#40/#42**: `### Exercice N : ...` → `### Exemple guide N : ...` (titles only).
- `Objectif`/`Indices` bodies preserved — valid pedagogical guidance for a guided example.

## §H.5 verdict: `EXEC_PROVED` (markdown-only)

- **0 code cell touched** — no re-execution needed (C.3 markdown-only exception; the 17 code cells keep their `execution_count` + outputs intact).
- `nbformat.validate` OK (45 cells).
- `validate_pr_notebooks.py` 1/1 PASS.
- Byte-format matched (trailing newline preserved, no CRLF churn).

## Why +5/−5 balanced is correct

A pure title relabel should be balanced (rename, not add/remove). The intro rewrite in cell #37 is a net-equal-length replacement. No solution content added or removed — this is a **labeling fix**, not a content change.

## Catalog hygiene (rule R1) — N/A

Does not touch `COURSE_CATALOG.*` or `CATALOG-STATUS` markers.

## Cross-references

- **#1214** (labeling rule), **#1336** (rootcause of the find-replace chaos).
- exercise-example-labeling.md (case 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)