### PR TITLE
i18n(#4980): knot_lean/Knots/MathlibPrerequisites FR-first sibling pair (Phase 0 INDEX)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/MathlibPrerequisites_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/MathlibPrerequisites_en.lean
@@ -1,27 +1,26 @@
 /-
-Knots.MathlibPrerequisites — Index des prérequis Mathlib manquants
-===================================================================
+  Knots.MathlibPrerequisites — Index of missing Mathlib infrastructure
+  =====================================================================
 
-Ce fichier documente les prérequis Mathlib nécessaires pour résoudre chaque
-sorry dans le projet knot_lean. Il sert de feuille de route pour ce qui
-devrait être construit (soit dans Mathlib, soit comme dépendances externes)
-pour formaliser les résultats de la théorie des noeuds.
+  This file documents the Mathlib prerequisites needed to resolve each sorry
+  in the knot_lean project. It serves as a roadmap for what would need to
+  be built (either in Mathlib or as external dependencies) to formalize
+  knot theory results.
 
-Epic #2874, Phase 1.
+  Epic #2874, Phase 1.
 
-Convention : organisé par tier de difficulté.
+  Convention: organized by difficulty tier.
 -/
 
 /-
-  Convention i18n (EPIC #4980, decision user 2026-07-04) : ce fichier est **FR canonique**,
-  avec son miroir anglais dans le fichier sibling `MathlibPrerequisites_en.lean` (modèle
-  sibling pair ratifié 2026-07-04, cf `code-style.md` §Lean i18n). Les énoncés de
-  théorèmes, les tactiques Lean, les noms de lemmes et les références Mathlib restent
-  en anglais (compat Mathlib 4) ; seules les docstrings de module et ce bloc
-  d'en-tête diffèrent entre les deux fichiers.
+  English mirror of `MathlibPrerequisites.lean` (FR canonical). Convention EPIC #4980
+  (decision ratified 2026-07-04, cf `code-style.md` §Lean i18n): distinct FR + EN sibling
+  files — no inline bilingual block in a single file (Option B rejected). The module
+  docstring and the theorem docstrings below differ from the FR version; the body
+  signatures, proofs and tactics remain byte-identical between the two files.
 -/
 
-namespace Knots.MathlibPrerequisites
+namespace Knots_en.MathlibPrerequisites_en
 
 /-! ## Tier 1: Accessible (Phase 2 targets, no deep prerequisites)
 
@@ -135,4 +134,4 @@ Timeline: decades
 -/
 theorem freedman_prerequisites : True := trivial
 
-end Knots.MathlibPrerequisites
+end Knots_en.MathlibPrerequisites_en


### PR DESCRIPTION
## Résumé

Pivot R5.4b MUST HORS-FAMILLE sustained (post-c.420 + c.421) : **3ᵉ satellite knot_lean migré** = `Knots/MathlibPrerequisites.lean` (138 LF, INDEX docstring des prérequis Mathlib manquants). Migration vers le modèle **sibling pair FR canonique + EN miroir** (EPIC #4980, décision user 2026-07-04).

**`Knots/MathlibPrerequisites.lean`** : module docstring FR canonique + i18n note FR.

**`Knots/MathlibPrerequisites_en.lean`** (nouveau) : miroir EN avec `namespace Knots_en.MathlibPrerequisites_en` + body byte-identique.

## Substance réelle (Phase 0 INDEX)

**Index des prérequis Mathlib manquants** (EPIC #2874 Phase 0/Phase 1) — 3ᵉ satellite du sous-dossier `Knots/*` migré (post c.420 Basic + c.421 Reidemeister) :

- **Index documentaire** : organisation par tier de difficulté (Tier 1 accessible / Tier 2 modéré / Tier 3 deep)
- **11 theorems placeholders** (`theorem foo : True := trivial`) = roadmap des prérequis Mathlib à construire pour les autres satellites (PD-codes, tricolorability, Reidemeister formal, Alexander polynomial, Jones polynomial, reidemeister theorem, Piccirillo, Lidman, Freedman)
- **Aucun `sorry` réel** (0 code-only sorry) : tous les theorems sont `True := trivial` = roadmap pure, pas de preuves à compléter
- **Référence timeline très pragmatique** : Tier 1 = Phase 2 (accessible), Tier 3 = « decades » (Piccirillo/Lidman/Freedman = effectively permanent)

**11 theorems + 0 defs + 0 sorry Phase 0** (portés verbatim, byte-identity inner body) :
- `pd_wellformed_prerequisites`, `trefoil_tricolorable_prerequisites`, `unknot_not_tricolorable_prerequisites`, `tricolorable_invariant_prerequisites` (Tier 1)
- `reidemeister_formal_prerequisites`, `alexander_polynomial_prerequisites`, `jones_polynomial_prerequisites` (Tier 2)
- `reidemeister_theorem_prerequisites`, `piccirillo_prerequisites`, `lidman_prerequisites`, `freedman_prerequisites` (Tier 3 deep)

## Preuves de progrès vérifiables (anti-§D + Lean §B)

| Critère | Mesure |
|---------|--------|
| **`grep -c sorry` avant** | 0 (INDEX = pas de sorry, juste `trivial` placeholders) |
| **`grep -c sorry` après** | 0 / 0 (FR / EN) — identiques |
| **Body byte-identity FR vs EN** | sha256 `a4925bd3c60abee20715f79707e92da4843fcd4808663da9ad6e2c476635cbe2` (113 inner lignes byte-identiques) |
| **CRLF count** | 0 / 0 (LF-only strict) |
| **Trailing newline** | OK sur les 2 fichiers (MD047) |
| **Code structure** | 11 theorem + 0 defs + 0 sorry (préservés verbatim) |
| **Size** | FR 4845 B / 138 LF ; EN 4761 B / 137 LF (différence = header FR i18n note plus long) |
| **Namespace nested single-segment** | OK (`namespace Knots.MathlibPrerequisites` × `namespace Knots_en.MathlibPrerequisites_en`) — pattern C422-L1 nouveau |
| **lakefile.lean `globs := #[.submodules \`Knots]`** | Auto-discovery inclut `_en` siblings (pas de modif lakefile) |

## i18n — convention #4980 ratifiée 2026-07-04

- **Module docstring FR** (`/- ... -/`) : design + conception + notes d'implémentation en français.
- **i18n note FR** : référence à `code-style.md §Lean i18n` + décision user 2026-07-04.
- **EN sibling** : header EN verbatim original + i18n note EN réfutant Option B (inline bilingue dans un seul fichier).
- **Énoncés de theorems, noms de lemmes, tactiques Lean, sections `/-! ##`, theorem docstrings** restent en anglais (cohérent avec c.412/c.415/c.416/c.418/c.419/c.420/c.421, compat Mathlib 4).
- **Seuls module docstring + i18n note** diffèrent entre FR et EN.

## Pattern nested namespace single-segment (C422-L1)

**Découverte c.422** : `Knots/MathlibPrerequisites.lean` utilise un **namespace nested single-segment** (`namespace Knots.MathlibPrerequisites` × `namespace Knots_en.MathlibPrerequisites_en`), différent du pattern simple de c.420/c.421 (`namespace Knots` × `namespace Knots_en`) et du pattern nested multi-segment de c.415/c.416/c.418/c.419 (`namespace Conway > Life` × `namespace Conway_en > Life_en + open × 2`).

```lean
namespace Knots.MathlibPrerequisites
  ...
end Knots.MathlibPrerequisites
```

```lean
namespace Knots_en.MathlibPrerequisites_en
  ...
end Knots_en.MathlibPrerequisites_en
```

**C422-L1** : 3 patterns namespace identifiés au sein d'EPIC #4980 :

| Pattern | Structure namespace | Exemples | Leçon |
|---------|---------------------|----------|-------|
| **simple single-level** | `namespace Foo` × `namespace Foo_en` | `Knots/Basic` c.420, `Knots/Reidemeister` c.421 | C420-L1 — mirror 1:1 namespace markers, PAS d'`open` |
| **nested multi-segment** | `namespace Foo > Bar` × `namespace Foo_en > Bar_en + open × 2` | `Conway/Life` c.415/c.416/c.418/c.419, `Conway/CGTTour` c.358 | C415-L1 — nested, nécessite `open` × 2 |
| **nested single-segment** | `namespace Knots.MathlibPrerequisites` × `namespace Knots_en.MathlibPrerequisites_en` | `Knots/MathlibPrerequisites` c.422 | C422-L1 — nested single-segment, PAS d'`open` (sub-namespace = atomic) |

**Leçon C422-L1** : le naming nested single-segment `Knots.MathlibPrerequisites` = **sous-namespace atomique** (un seul module dans l'arborescence), pas un grouping complexe. Se manipule comme `namespace Foo.enclosing.X` × `namespace Foo_en.enclosing_X_en` — PAS d'`open` × N, le namespace complet est mirroré 1:1 entre FR et EN (suffixe `_en` ajouté à chaque segment, séparés par `.`).

## Différence avec c.420/c.421 : INDEX docstring-file vs theorem-file

**Point nouveau** : `Knots/MathlibPrerequisites.lean` est un **fichier INDEX** (pas un fichier de preuves). Les 11 theorems sont des `True := trivial` placeholders = roadmap pure, jamais de preuves réelles à un terme Phase >= 5 (decades). À l'inverse :
- `Knots/Basic` c.420 : ~13 theorems + ~10 defs + #eval (fondation knot_lean)
- `Knots/Reidemeister` c.421 : 2 theorem + 2 def + 2 sorry Phase 1 (soundness + completeness)

**Sibling pair byte-identity INDEX** : la byte-identity est triviale pour un INDEX (les theorems sont triviaux), mais l'intérêt est de **standardiser** la convention sibling pair sur TOUS les fichiers `Knots/*` (foundations + theorems + INDEX) — anti-pattern « patch-case » évité (ne pas traiter différemment les INDEX vs les theorem-files).

**C422-L2** : pour les fichiers INDEX roadmap (prérequis, scope, tier), le sibling pair est **plus simple** que pour les theorem-files : pas de `sorry` réels à préserver, pas de stratégies de preuve à dupliquer entre FR/EN. La convention reste identique (module docstring FR + i18n note FR + mirror 1:1 namespace + body byte-identity) mais la substance est moindre.

## Cold-build gate (C455-1)

WSL elan absent localement → CI Lean GitHub Actions = preuve canonique du merge. Anti-§D byte-identity local = signal minimal mais ne dispense PAS de CI PASS.

## Pivot R5.4b MUST HORS-FAMILLE sustained (post-c.420 + c.421)

- c.420 = PIVOT HORS-FAMILLE conway_lein → knot_lein (1ᵉʳ satellite knot_lean = Basic.lean)
- c.421 = continuation knot_lean Phase 1 (2ᵉ satellite = Reidemeister.lean)
- **c.422 = continuation knot_lean Phase 0 INDEX** (3ᵉ satellite = MathlibPrerequisites.lean)
- Backlog knot_lean post-c.422 : 3 satellites restants (Conway 250 LF, Invariant 1778 LF, Lidman 136 LF)
- **Seuils R5.4b MUST surveillés** : 3ᵉ cycle knot_lean HORS-FAMILLE atteint → si c.423 = encore knot_lean = PIVOT obligatoire
- EPIC #2874 Phase 1 (foundations + Reidemeister + INDEX) = 3/6 satellites migrés. Phase 2+ reste à c.423+ avec pivot si 4ᵉ cycle monotonie

## Anti-patterns évités

- ✅ `Write` tool → trailing newline vérifié via Python `data += b'\n'` (C413-L1 / C280-1)
- ✅ `--body-file` (JAMAIS `--body` à cause de C403-L1 backtick stripping)
- ✅ Branch base = main local frais (R2 base-stale-14d)
- ✅ Atomique : 1 PR = 1 sibling pair (R3)
- ✅ Pas de catalogue touché (R1)
- ✅ Worker JAMAIS `gh pr merge` ou `--approve` (L143 SAFE cross-owner)
- ✅ Sections `/-! ##` et theorem docstrings en anglais (cohérent avec precedent c.412/c.413/c.414/c.415/c.416/c.418/c.419/c.420/c.421)
- ✅ Worktree isolé `D:/dev/CoursIA-c422` (sécurité R3 atomicité)
- ✅ Anti-§D byte-identity inner body préservé (sha256 identical FR↔EN)
- ✅ Branche renommée vers sujet réel `i18n/c422-mathlibprereq-4980`
- ✅ Backup `MathlibPrerequisites.lean.bak.c422` avant écriture (sécurité anti-régression)
- ✅ `Knots/MathlibPrerequisites_en.lean` (suffix `_en` ajouté à chaque segment de namespace) — pas de modif lakefile grâce à `globs := #[.submodules \`Knots]`
- ✅ Pattern nested namespace single-segment détecté (C422-L1) — pas de confusion avec simple (c.420/c.421) ou nested multi-segment (c.415-419)

🤖 Generated with [Claude Code](https://claude.com/claude-code)