### PR TITLE
i18n(#4980): conway_lean GridCanonical FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
@@ -151,28 +151,14 @@ sans séparateur `---` interne).
 -/
 
 /-
-Copyright (c) 2026 CoursIA. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
+## Convention i18n (EPIC #4980, Option A)
 
-## Canonical grid forms — the `sortDedup` specification
-
-Every grid manipulated by the Life engine is a `sortDedup` image:
-`step`, `evolve (n+1)`, `shift` and `MacroCell.toGrid` all post-compose
-with `sortDedup`, and `restrictGridTo` is a `filter` of such an image.
-This module proves that `sortDedup` outputs are **canonical** — lex-sorted
-and duplicate-free — and that canonical lists are **rigid**: determined by
-their membership predicate alone (`Canonical.ext`).
-
-This is the bridge that turns the list-equality goals of the Hashlife
-correctness theorems (P4/P5, `HashlifeCorrectness.lean`) into pointwise
-membership goals, where the actual combinatorics of the B3/S23 rule and
-the macrocell recursion can be argued cell by cell.
-
-The order theory is elementary: `lexLe` (reflexive closure of `lexLt`)
-is total, transitive and antisymmetric on `Int × Int`, all by `omega`
-after unfolding to linear integer arithmetic.
-
-This module is fully proven (no `sorry`).
+Convention ratifiée par user 2026-07-04 (cf `code-style.md` §Lean i18n) :
+fichier **FR canonique** + sibling **EN** dans `GridCanonical_en.lean`.
+Seules les **docstrings `/-- ... -/`** et les **commentaires `-- ...`**
+diffèrent entre les deux fichiers. **Préservation byte-identity** sur
+le reste (signatures, preuves, tactiques) — vérifiable par diff.
+Pas de bloc bilingue inline dans un même fichier (Option B rejeté).
 -/
 
 import Conway.Life

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Canonical grid forms — the `sortDedup` specification (Conway's Game of Life)
+
+English mirror of `GridCanonical.lean` (FR canonical). Convention EPIC #4980
+(decision ratified 2026-07-04, cf `code-style.md` §Lean i18n): distinct FR + EN sibling
+files — no inline bilingual block in a single file (Option B rejected). The module
+docstring and the theorem docstrings below differ from the FR version; the body
+signatures, proofs and tactics remain byte-identical between the two files.
+
+This file is the **canonical-grid-form** leaf of the `conway_lean` lake, sibling-paired
+with `GridCanonical.lean` (FR canonical) per EPIC #4980 Option A. The module proves that
+`sortDedup` outputs are **canonical** (lex-sorted and duplicate-free) and that canonical
+lists are **rigid** — exactly the bridge that turns the list-equality goals of the
+Hashlife correctness theorems (`HashlifeCorrectness.lean`, P4/P5) into pointwise
+membership goals, where the actual combinatorics of the B3/S23 rule and the macrocell
+recursion can be argued cell by cell. The level-2 namespace `Conway > Life` is mirrored
+as `Conway_en > Life_en` (level-2 sibling pattern, see `LightCone_en.lean` c.421).
+-/
+
+import Conway.Life
+
+namespace Conway_en
+namespace Life_en
+
+/-! ## The lexicographic comparator: order axioms -/
+
+/-- `lexLt` in terms of linear integer arithmetic. -/
+theorem lexLt_iff {a b : Int × Int} :
+    lexLt a b = true ↔ a.1 < b.1 ∨ (a.1 = b.1 ∧ a.2 < b.2) := by
+  unfold lexLt
+  split_ifs <;> simp <;> omega
+
+/-- `lexLe` in terms of linear integer arithmetic. -/
+theorem lexLe_iff {a b : Int × Int} :
+    lexLe a b = true ↔ a.1 < b.1 ∨ (a.1 = b.1 ∧ a.2 ≤ b.2) := by
+  simp only [lexLe, Bool.or_eq_true, lexLt_iff, beq_iff_eq, Prod.ext_iff]
+  omega
+
+/-- `lexLe` is total — the hypothesis `List.pairwise_mergeSort` needs. -/
+theorem lexLe_total (a b : Int × Int) : (lexLe a b || lexLe b a) = true := by
+  simp only [Bool.or_eq_true, lexLe_iff]
+  omega
+
+/-- `lexLe` is transitive. -/
+theorem lexLe_trans (a b c : Int × Int)
+    (hab : lexLe a b = true) (hbc : lexLe b c = true) : lexLe a c = true := by
+  simp only [lexLe_iff] at *
+  omega
+
+/-- `lexLe` is antisymmetric — what makes sorted Nodup lists rigid. -/
+theorem lexLe_antisymm (a b : Int × Int)
+    (hab : lexLe a b = true) (hba : lexLe b a = true) : a = b := by
+  simp only [lexLe_iff] at hab hba
+  rw [Prod.ext_iff]
+  omega
+
+/-! ## Canonical grids -/
+
+/-- A grid in canonical form: lexicographically sorted and duplicate-free.
+    Invariant of every `sortDedup` image, preserved by `filter`. -/
+def Canonical (g : Grid) : Prop :=
+  g.Pairwise (fun a b => lexLe a b = true) ∧ g.Nodup
+
+/-- `sortDedup` always produces a canonical grid: sortedness comes from
+    `pairwise_mergeSort` (using totality and transitivity of `lexLe`) and
+    survives `dedup` because `dedup` yields a sublist; freedom from
+    duplicates is `nodup_dedup`. -/
+theorem canonical_sortDedup (l : List (Int × Int)) : Canonical (sortDedup l) := by
+  unfold sortDedup
+  exact ⟨List.Pairwise.sublist (List.dedup_sublist _)
+          (List.pairwise_mergeSort lexLe_trans lexLe_total l),
+        List.nodup_dedup _⟩
+
+/-- Filtering preserves canonical form (`filter` yields a sublist). -/
+theorem Canonical.filter {g : Grid} (h : Canonical g) (q : (Int × Int) → Bool) :
+    Canonical (g.filter q) :=
+  ⟨List.Pairwise.sublist List.filter_sublist h.1,
+   List.Nodup.sublist List.filter_sublist h.2⟩
+
+/-- **Rigidity of canonical grids**: two canonical grids with the same
+    members are equal as lists. Same-membership gives a permutation
+    (`perm_ext_iff_of_nodup`), and a permutation between two lex-sorted
+    lists is the identity by antisymmetry (`Perm.eq_of_pairwise`). -/
+theorem Canonical.ext {g₁ g₂ : Grid} (h₁ : Canonical g₁) (h₂ : Canonical g₂)
+    (h : ∀ p, p ∈ g₁ ↔ p ∈ g₂) : g₁ = g₂ :=
+  List.Perm.eq_of_pairwise (fun a b _ _ hab hba => lexLe_antisymm a b hab hba)
+    h₁.1 h₂.1 ((List.perm_ext_iff_of_nodup h₁.2 h₂.2).mpr h)
+
+/-- The workhorse corollary: two `sortDedup` images are equal **iff** their
+    input lists have the same members. List equality of canonical grids is
+    exactly set equality. -/
+theorem sortDedup_eq_sortDedup_iff {l₁ l₂ : List (Int × Int)} :
+    sortDedup l₁ = sortDedup l₂ ↔ ∀ p, p ∈ l₁ ↔ p ∈ l₂ := by
+  constructor
+  · intro h p
+    rw [← mem_sortDedup (l := l₁), h, mem_sortDedup]
+  · intro h
+    exact Canonical.ext (canonical_sortDedup _) (canonical_sortDedup _)
+      (fun p => by rw [mem_sortDedup, mem_sortDedup]; exact h p)
+
+/-! ## Canonicity of the Life-engine grids -/
+
+/-- `step` produces canonical grids. -/
+theorem canonical_step (g : Grid) : Canonical (step g) :=
+  canonical_sortDedup _
+
+/-- `evolve n` produces canonical grids for `n ≥ 1` (for `n = 0` the
+    output is the input, which need not be canonical). -/
+theorem canonical_evolve_of_pos {n : Nat} (hn : 0 < n) (g : Grid) :
+    Canonical (evolve n g) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  rw [evolve_succ]
+  exact canonical_step _
+
+/-- `shift` produces canonical grids. -/
+theorem canonical_shift (v : Int × Int) (g : Grid) : Canonical (shift v g) :=
+  canonical_sortDedup _
+
+/-- Membership in a `step` image, unfolded to the rule: `p` is in `step g`
+    iff it is a candidate and `aliveNext` accepts it. -/
+theorem mem_step_iff {g : Grid} {p : Int × Int} :
+    p ∈ step g ↔ p ∈ candidates g ∧ aliveNext g p = true := by
+  unfold step
+  rw [mem_sortDedup, List.mem_filter]
+
+end Life_en
+end Conway_en


### PR DESCRIPTION
## Livrable

c.423 — 12ᵉ sibling `_en` conway_lean (après ConeGeometry, LightCone, Pillars, RLE, …).

### Fichiers

- **FR canonical** [GridCanonical.lean](MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean) : 285 → 271 LF. Retire le bloc bilingue inline EN legacy (L153-L176) et le remplace par une **note i18n courte** enveloppée dans `/- ... -/` (l'erreur de mon Edit précédent où la note était à l'extérieur du bloc `/-` a été corrigée — cf L395 vigilance transcription artifact).
- **EN sibling** [GridCanonical_en.lean](MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean) : 130 LF nouveau. Niveau 2 namespace mirror `Conway_en > Life_en` (pattern c.421 LightCone_en).

### Substance préservée — 13 theorem + 1 def

Sur la **canonicité structurelle des grilles** (lex-sortie + sans-doublons), maintenue par les opérations fondamentales du moteur Life : `lexLt_iff`, `lexLe_iff`, `lexLe_total`, `lexLe_trans`, `lexLe_antisymm`, `Canonical` (def), `canonical_sortDedup`, `Canonical.filter`, `Canonical.ext`, `sortDedup_eq_sortDedup_iff`, `canonical_step`, `canonical_evolve_of_pos`, `canonical_shift`, `mem_step_iff`. C'est le **pont** qui transforme les objectifs d'égalité de listes P4/P5 de `HashlifeCorrectness.lean` en objectifs d'appartenance cellulaire.

### Vérifications

- **Byte-identity corps** : 2402 chars matchent exactement après strip des commentaires + normalisation des namespaces (`Conway_en` → `Conway`, `Life_en` → `Life`). Vérifié script Python.
- **`grep -c sorry`** : 0/0 (le seul match FR est la mention prose « aucun `sorry` » dans la docstring).
- **Lean 4.32.0 syntax parse** OK sur les deux fichiers : la seule erreur visible est `unknown module prefix 'Conway'` (chemin d'import standard quand on invoque lean directement, identique à Pillars.lean c.417 — le compileur canonique est `lake build Conway.Life.GridCanonical` côté CI/main).
- **CRLF** : 0/0 (LF strict).
- **lakefile/lean-toolchain/lake-manifest** : non touchés (rien à `git checkout origin/main`).

### Convention EPIC #4980 Option A

Modèle sibling-pair : FR canonique + EN sibling `<File>_en.lean`. Suffixe `_en` sur le namespace (`Conway` ↔ `Conway_en`, `Life` ↔ `Life_en`) et sur les imports. Énoncés de theorems/lemmes, tactiques Lean, noms de lemmes restent en anglais. Seules les docstrings `/-- ... -/` et commentaires `-- ...` diffèrent. **Préservation byte-identity** sur le reste — vérifiable par diff.

See #4980

### Anti-régression

- Pas de remplacement de preuve par `sorry` (deletions < insertions : 22 < 138).
- Pas de regeneration de catalogue (cf R1 catalog-pr-hygiene — cours #2632).
- Pas de force push, pas de push direct sur `main` (cf git-workflow Règle A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)