### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to GenAI PostTraining cluster (PT_02-05)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_02_sft_baseline.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_02_sft_baseline.ipynb
@@ -1144,7 +1144,8 @@
     "sauter le SFT et lancer DPO directement sur le base model crée un gradient\n",
     "instable (terme `pi_ref` du loss DPO mal calibré).\n",
     ""
-   ]
+   ],
+   "id": "cell-f4c20846"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb
@@ -1346,7 +1346,8 @@
     "programmatiques sur des taches a solution unique). C'est la transition de\n",
     "l'alignement humain vers l'alignement auto-verifiable.\n",
     ""
-   ]
+   ],
+   "id": "cell-6d84ccc3"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
@@ -874,7 +874,8 @@
     "**gamable** (longueur, mots-cles) par un **verifieur exact** SymPy — eliminant\n",
     "par construction le piege n°1 (reward hacking).\n",
     ""
-   ]
+   ],
+   "id": "cell-5a73445a"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
@@ -880,7 +880,8 @@
     "Deepseek-R1 / QwQ. PT-06 (evaluation comparative) clore le parcours en comparant\n",
     "les 5 techniques de post-training vues de PT-01 a PT-05 sur un benchmark commun.\n",
     ""
-   ]
+   ],
+   "id": "cell-098249a8"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids to the 4 `GenAI/PostTraining` notebooks (1 id each) — part of the v4.5 cell-id gap sweep (see #6257). Delivered as one atomic cluster (one PR = the cohesive PostTraining family slice).

| Notebook | ids added |
|----------|-----------|
| `PT_02_sft_baseline.ipynb` | 1 |
| `PT_03_dpo_direct_preference.ipynb` | 1 |
| `PT_04_grpo_deepseek_r1.ipynb` | 1 |
| `PT_05_rlvr_verifiable_rewards.ipynb` | 1 |

Each was **already v4.5 (`nbformat_minor=5`)** but 1 cell lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on all 4**.
- `validate_pr_notebooks.py` **PASSED** (all 4).
- `git diff --stat`: `8 insertions(+), 4 deletions(-)` = **2N/N** (4 ids × {1 separator + 1 id line}).
- `execution_count` / `outputs`: unchanged on all 4 (structural-only, no cell source touched).

See #6257.
