### PR TITLE
docs(lean,#4980,#3978): calibration_lean README i18n coverage + Modules table refresh

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.en.md
@@ -8,12 +8,15 @@ Prover calibration targets for benchmarking the multi-agent Lean prover.
 - **Sorry count**: 0 production (all 4 calibration targets proved; previous "4 sorry" claim matched docstring text inside `/-- ... -/` blocks, not actual `sorry` terms)
 - **Build**: `lake build Calibration` -- SUCCESS
 - **Dependencies**: Mathlib4
+- **i18n coverage (EPIC #4980)**: lake fully bilingual FR/EN — 3 `.lean` modules shipped as FR canonical + 3 `*_en.lean` mirror siblings on `main` (`Calibration/Doomsday_en.lean`, `Calibration/Nash_en.lean`, `Calibration/Nim_en.lean`, added by PR #5543 step 2). Convention EPIC #4980 Option A: docstrings `/-- ... -/` and `-- ...` comments differ between FR and EN, signatures and proofs remain byte-identical.
 
 ## Modules
 
-| File | sorry | Description |
-|------|-------|-------------|
-| `Calibration/Nash.lean` | 0 | Prover calibration targets (C/D/E/F) |
+| File | `_en` | sorry | Description |
+|------|-------|-------|-------------|
+| `Calibration/Doomsday.lean` | `Doomsday_en.lean` | 0 | Doomsday algorithm (day-of-week computation, anchor calendar) |
+| `Calibration/Nash.lean` | `Nash_en.lean` | 0 | Prover calibration targets on the 2×2 Prisoner's Dilemma (C/D/E/F) |
+| `Calibration/Nim.lean` | `Nim_en.lean` | 0 | Nim game theory (winning-strategy Nim-sum) |
 
 ## Calibration Targets
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
@@ -18,12 +18,15 @@ régression du prouveur.
 - **Compte de sorry** : 0 en production (les 4 cibles de calibration sont prouvées ; un ancien compte de « 4 sorry » correspondait à du texte de docstring à l'intérieur de blocs `/-- ... -/`, pas à des termes `sorry` réels)
 - **Build** : `lake build Calibration` -- SUCCESS
 - **Dépendances** : Mathlib4
+- **Couverture i18n (EPIC #4980)** : lake entièrement bilingue FR/EN — 3 modules `.lean` livrés en FR canonique + 3 siblings `*_en.lean` miroirs sur `main` (`Calibration/Doomsday_en.lean`, `Calibration/Nash_en.lean`, `Calibration/Nim_en.lean`, ajoutés par PR #5543 étape 2). Convention EPIC #4980 Option A : docstrings `/-- ... -/` et commentaires `-- ...` diffèrent entre FR et EN, signatures et preuves byte-identiques.
 
 ## Modules
 
-| Fichier | sorry | Description |
-|---------|-------|-------------|
-| `Calibration/Nash.lean` | 0 | Cibles de calibration du prouveur (C/D/E/F) |
+| Fichier | `_en` | sorry | Description |
+|---------|-------|-------|-------------|
+| `Calibration/Doomsday.lean` | `Doomsday_en.lean` | 0 | Algorithme Doomsday (calcul du jour de la semaine, anchor calendar) |
+| `Calibration/Nash.lean` | `Nash_en.lean` | 0 | Cibles de calibration du prouveur sur le Dilemme du Prisonnier 2×2 (C/D/E/F) |
+| `Calibration/Nim.lean` | `Nim_en.lean` | 0 | Théorie du jeu de Nim (stratégie gagnante Nim-somme) |
 
 ## Cibles de calibration
 


### PR DESCRIPTION
## Scope

Pivot c.425 hors conway_lean (c.424 #6442) → **calibration_lean** feuille rollout audit dual FR+EN.

**2 files in-place, +12/-6, scope atomic** : pas de modification des fichiers `.lean` du lake (convention EPIC #4980 Option A = byte-identity FR/EN préservée sur le code).

## Constat #1 — FR et EN tous les deux stale (audit dual)

Le Module table des 2 READMEs ne référence **que `Nash.lean`** — mais le dossier contient **3 modules FR + 3 siblings `_en.lean`** :

| Fichier | Sibling `_en` | sorry | Cycle |
|---------|---------------|-------|-------|
| `Calibration/Doomsday.lean` | `Doomsday_en.lean` | 0 | #2737 (FR) + #5543 (EN) |
| `Calibration/Nash.lean` | `Nash_en.lean` | 0 | Nash FR + #5543 (EN) |
| `Calibration/Nim.lean` | `Nim_en.lean` | 0 | #2737 (FR) + #5543 (EN) |

Stale depuis #2737 (avant ajout Nim/Doomsday) + #5543 (avant ajout EN siblings). PRs antérieures (#4287 prover-regression, #5112 docstrings bilingues, #3876 francisation, #5573 toolchain drift) n'ont pas mis à jour la Module table ni ajouté de bloc i18n-coverage.

## Modifications

1. **Statut block** : nouvelle ligne `**Couverture i18n (EPIC #4980)**` (FR) / `**i18n coverage (EPIC #4980)**` (EN) avec les 3 modules FR canonique + 3 siblings `*_en.lean` miroirs sur `main`, référence à PR #5543 étape 2 + convention Option A.
2. **Modules table** : colonne `_en` ajoutée + 2 lignes Doomsday/Nim précédemment absentes + ligne Nash enrichie avec mention Prisonnier 2×2.

## Verifs firsthand (G.1)

- **Inventaire** : `git ls-tree -r origin/main --name-only MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/` → 12 fichiers dont **3 _en.lean** (Doomsday_en, Nash_en, Nim_en) + README.en.md + 3 FR .lean.
- **Sorry baseline** : `grep -c "^sorry"` sur les 6 fichiers `.lean` → **0/0/0/0/0/0** (pas de régression, pas de sorry tactical introduit).
- **Encoding** : `file` → UTF-8 no BOM. `grep -c $'\r'` → 0 CRLF sur les 2 fichiers (LF strict).
- **CATALOG-STATUS** : aucun marqueur dans les 2 READMEs → **R1 catalog-pr-hygiene non-bloquant** (cf L398 c.424). Modification libre sans risque conflit catalogue au merge.
- **Worktree base** : origin/main @ d477a8634 (frais).
- **Pas de `lake build` local requis** : PR docs-only, pas de modification code Lean. Body byte-identity FR/EN garantie par construction EPIC #4980 Option A.

## Lien EPICs

- See #4980 (i18n Lean harmonisation — extension coverage)
- See #3978 (READMEs feuilles — SymbolicAI/Lean/** inclus)
- See #3973 (README ascendant — resynchronisation hierarchie)
- Refs #5543 (lake fully bilingual — lake dont on documente la couverture)
- Refs #2737 (Nim + Doomsday calibration targets — fichiers dont on reference l'existence)
- Refs #5573 (toolchain drift fix — baseline toolchain v4.31.0-rc1)

## Pivot R6 anti-monotonie

5 cycles Lean monotones consécutifs (c.417/c.420/c.421/c.422/c.423) + 1 cycle doc forensique conway_lean (c.424 #6442) → c.425 = **rotation naturelle** vers un autre lake substantive i18n-coverage (calibration_lean). Le pattern se généralise : pour chaque lake où la table Modules ne reflète pas l'existence des siblings `_en.lean`, audit dual + correction. Lakes candidats après c.425 : knot_lean (couverture #6429/#6440 en attente merge), sensitivity_lean (4 _en.lean), grothendieck_lean (12 _en.lean, mais cold-build blocker actif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
