### PR TITLE
docs(semanticweb,#5780): correct SW-12 GraphRAG legend 6→4 entity types (README residu of #6424)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -302,7 +302,7 @@ C'est l'anti-hallucination par excellence : un LLM ancré sur des faits RDF vér
 
 ![Graphe orienté des entités extraites par LLM, noeuds colorés par type et arêtes étiquetées](assets/readme/sw12_graphrag_c18_o0.png)
 
-*SW-12 (cellule 18) : **graphe orienté des entités extraites par LLM** (filmographie Nolan) — noeuds colorés par type d'entité (Person / Movie / Organization / Award / Genre / Concept), arêtes orientées étiquetées par la relation extraite.*
+*SW-12 (cellule 18) : **graphe orienté des entités extraites par LLM** (filmographie Nolan) — noeuds colorés par type d'entité **extrait** (Person / Movie / Organization / Award ; `Genre` et `Concept` existent dans le vocabulaire `TYPE_MAP` mais aucune entité de ce type n'est extraite du texte de démonstration), arêtes orientées étiquetées par la relation extraite.*
 
 ![Communautés détectées par modularité gloutonne (networkx) sur le graphe non-dirigé](assets/readme/sw12_graphrag_c30_o1.png)
 


### PR DESCRIPTION
## Reconciliation of #6424 per ai-01 steer (msg-20260714T045732)

#6424 was **DIRTY/CONFLICTING**: after merge of **#6420** (SemanticWeb figures audit, which already corrected the `MANIFEST.md` alt-text for `sw12_graphrag_c18_o0.png` at c.469 + added a *Contenu réel vérifié* field), #6424 conflicted on the same MANIFEST.md region. This PR keeps **only the unique residual**: the **README.md** legend, which #6420 did not touch.

## Bug (fidelity, doctrine #5780) — caption over-sold vs figure

`README.md` line 305 legend for `sw12_graphrag_c18_o0.png` claimed:

> noeuds colorés par type d'entité (Person / Movie / Organization / Award / **Genre / Concept**)

But the figure shows only **4 types** — `Genre` and `Concept` exist in the notebook's `TYPE_MAP` vocabulary but **no entity of those types is extracted** from the demo text (verified via SW-12 cell 18 output / notebook cell 900: vocabulary-only ≠ extracted entities). Same finding as the #6420 MANIFEST audit (c.469).

## Fix (1 line, markdown-only)

Legend now reads: `noeuds colorés par type d'entité **extrait** (Person / Movie / Organization / Award ; Genre et Concept existent dans le vocabulaire TYPE_MAP mais aucune entité de ce type n'est extraite du texte de démonstration)`.

- Markdown-only → C.3 exception, no re-exec.
- Wording **concise and aligned** with the #6420 MANIFEST correction ("4 types effectivement visibles") for caption↔image consistency.
- Image alt-text (line 303) is generic ("par type") — no over-sell, left unchanged.

## Why not just rebase #6424

#6424's MANIFEST change is **entirely superseded** by #6420 (which did it more completely, with the *Contenu réel vérifié* provenance field). Dropping it via rebase + keeping only README = exactly this PR, on a fresh conflict-free branch from `origin/main`.

`See #5780`. Supersedes the README residu of #6424.