### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to ML AgenticDataScience cluster (Lab8-17)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb
@@ -998,7 +998,8 @@
     "3. H. Chase, *LangChain*, octobre 2022, `langchain.com` / `github.com/langchain-ai/langchain`. Framework modulaire open-source pour applications LLM (chaînes composables, *tools*, mémoire) — référence de l'écosystème agent Python.\n",
     "4. Google Research, *DS-STAR: A State-of-the-Art Versatile Data Science Agent*, 2025, `research.google/blog/ds-star-a-state-of-the-art-versatile-data-science-agent/`. Agent SOTA data science (paradigme planner-coder).\n",
     "5. Google Research, *MLE-STAR: A State-of-the-Art Machine Learning Engineering Agent*, 2025, `research.google/blog/mle-star-a-state-of-the-art-machine-learning-engineering-agents/`. Agent SOTA ingénierie ML (cycle d'expérimentation, Kaggle)."
-   ]
+   ],
+   "id": "cell-9fecfdf4"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
@@ -1037,7 +1037,8 @@
     "2. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (perception-raisonnement-action, outils, mémoire) — suite du Lab 8.\n",
     "3. H. Chase, *LangChain*, octobre 2022, `langchain.com`. Framework de comparaison (`create_pandas_dataframe_agent`) — suite du Lab 8.\n",
     "4. OpenBMB Team, *CodeAct / Data Interpreter*, 2024. Implémentation open-source du paradigme CodeAct appliqué aux agents data science (`github.com/OpenBMB/AgentVerse`)."
-   ]
+   ],
+   "id": "cell-c5450e2a"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab10-File-Analyzer.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab10-File-Analyzer.ipynb
@@ -814,7 +814,8 @@
    "metadata": {},
    "source": [
     "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de lab10 file analyzer. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les exercices proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
-   ]
+   ],
+   "id": "cell-b7e2c212"
   },
   {
    "cell_type": "markdown",
@@ -825,7 +826,8 @@
     "1. Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025. Article fondateur de l'agent DS-STAR (architecture multi-module : File Analyzer, planification structurée, génération/exécution de code, vérification).\n",
     "2. Google Research, *DS-STAR: A State-of-the-Art Versatile Data Science Agent*, `research.google/blog/ds-star-a-state-of-the-art-versatile-data-science-agent/`, 2025. Billet de présentation (benchmark DABStep).\n",
     "3. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM — suite des Labs 8-9."
-   ]
+   ],
+   "id": "cell-c60b2149"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
@@ -972,7 +972,8 @@
     "2. N. Shinn et al., *Reflexion: Language Agents with Verbal Reinforcement Learning*, arXiv:2303.11366, NeurIPS 2023. Auto-réflexion verbale et raffinement itératif après échec — principe de l'étape Verifier → Coder.\n",
     "3. Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025. Agent DS-STAR dont ce lab implémente la boucle cœur (suite Lab 10).\n",
     "4. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (suite Labs 8-10)."
-   ]
+   ],
+   "id": "cell-7ada47b8"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -953,7 +953,8 @@
     "2. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel de l'agent LLM modulaire de bout en bout (perception-planification-action-vérification).\n",
     "3. S. Yao et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, arXiv:2210.03629, ICLR 2023. Paradigme de la boucle raisonnement-action (suite Lab 11).\n",
     "4. N. Shinn et al., *Reflexion: Language Agents with Verbal Reinforcement Learning*, arXiv:2303.11366, NeurIPS 2023. Auto-raffinement après vérification (suite Lab 11)."
-   ]
+   ],
+   "id": "cell-44c8ee92"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb
@@ -728,7 +728,8 @@
     "1. P. Lewis et al., *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*, arXiv:2005.11401, NeurIPS 2020. Paradigme RAG : augmenter un LLM par récupération externe de connaissances avant génération — fondement du module Web Search de ce lab.\n",
     "2. Google Research, *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*, arXiv:2506.15692, 2025. Agent MLE dont ce lab implémente le composant recherche SOTA (combinaison recherche + raffinement ciblé).\n",
     "3. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (suite Labs 8-12)."
-   ]
+   ],
+   "id": "cell-6c469afa"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb
@@ -895,7 +895,8 @@
     "- Meyes, R., Schuman, C., Sakhavi, S., et al. (2019). *Ablation Studies in Artificial Neural Networks*. arXiv:1901.08644. https://arxiv.org/abs/1901.08644\n",
     "- Guo, Q., et al. (2025). *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*. Google Research. arXiv:2506.15692. https://arxiv.org/abs/2506.15692\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
-   ]
+   ],
+   "id": "cell-b4e2c09f"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
@@ -808,7 +808,8 @@
    "metadata": {},
    "source": [
     "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de lab15 kaggle challenge. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les exercices proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
-   ]
+   ],
+   "id": "cell-f2cdd2f3"
   },
   {
    "cell_type": "markdown",
@@ -819,7 +820,8 @@
     "- Chan, S.P., Chowdhury, A., Chen, C., et al. (2024). *MLE-bench: Evaluating Machine Learning Agents on Machine Learning Engineering*. arXiv:2410.07095 (OpenAI). https://arxiv.org/abs/2410.07095\n",
     "- Guo, Q., et al. (2025). *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*. Google Research. arXiv:2506.15692. https://arxiv.org/abs/2506.15692\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
-   ]
+   ],
+   "id": "cell-d2566259"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb
@@ -863,7 +863,8 @@
     "- Yu, T., Zhang, R., Yang, K., et al. (2018). *Spider: A Large-Scale Human-Labeled Dataset for Complex and Cross-Domain Semantic Parsing and Text-to-SQL Task*. EMNLP 2018. arXiv:1809.08887. https://arxiv.org/abs/1809.08887\n",
     "- Chen, M., Tworek, J., Jun, H., et al. (2021). *Evaluating Large Language Models Trained on Code*. arXiv:2107.03374 (OpenAI). https://arxiv.org/abs/2107.03374\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
-   ]
+   ],
+   "id": "cell-63abe9d2"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
@@ -1000,7 +1000,8 @@
     "- Guo, Q., et al. (2025). *DS-STAR: An Automated End-to-End Data Science Agent Based on Code Generation*. arXiv:2509.21825. https://arxiv.org/abs/2509.21825\n",
     "- Ji, Z., Lee, N., Frieske, R., et al. (2023). *Survey of Hallucination in Natural Language Generation*. ACM Computing Surveys 55. arXiv:2202.03629. https://arxiv.org/abs/2202.03629\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
-   ]
+   ],
+   "id": "cell-848aa1a6"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (12 ids across 10 notebooks) to the `ML/DataScienceWithAgents/AgenticDataScience` Day-series labs (Lab8 through Lab17) — part of the v4.5 cell-id gap sweep (see #6257). Delivered as one atomic cohesive cluster (one PR = the AgenticDataScience Day4-Day7 slice).

| Lab | Day | ids added |
|-----|-----|-----------|
| Lab8-ADK-Introduction | Day4-Foundations | 1 |
| Lab9-First-ADK-Agent | Day4-Foundations | 1 |
| Lab10-File-Analyzer | Day5-DS-Star | 2 |
| Lab11-Planner-Coder-Loop | Day5-DS-Star | 1 |
| Lab12-DS-Star-Workshop | Day5-DS-Star | 1 |
| Lab13-Web-Search-SOTA | Day6-MLE-Star | 1 |
| Lab14-Ablation-Refinement | Day6-MLE-Star | 1 |
| Lab15-Kaggle-Challenge | Day6-MLE-Star | 2 |
| Lab16-Data-Science-Agent | Day7-Production | 1 |
| Lab17-Final-Project | Day7-Production | 1 |

Each was **already v4.5 (`nbformat_minor=5`)** but 1-2 cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on all 10**.
- `validate_pr_notebooks.py` **PASSED** (all 10).
- `git diff --stat`: `24 insertions(+), 12 deletions(-)` = **2N/N** (12 ids × {1 separator + 1 id line}).
- `execution_count` / `outputs`: unchanged on all 10 (structural-only, no cell source touched).

See #6257.
