### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to ML PythonAgentsForDataScience cluster (Lab1-7)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab8-ADK-Introduction.ipynb
@@ -998,7 +998,8 @@
     "3. H. Chase, *LangChain*, octobre 2022, `langchain.com` / `github.com/langchain-ai/langchain`. Framework modulaire open-source pour applications LLM (chaînes composables, *tools*, mémoire) — référence de l'écosystème agent Python.\n",
     "4. Google Research, *DS-STAR: A State-of-the-Art Versatile Data Science Agent*, 2025, `research.google/blog/ds-star-a-state-of-the-art-versatile-data-science-agent/`. Agent SOTA data science (paradigme planner-coder).\n",
     "5. Google Research, *MLE-STAR: A State-of-the-Art Machine Learning Engineering Agent*, 2025, `research.google/blog/mle-star-a-state-of-the-art-machine-learning-engineering-agents/`. Agent SOTA ingénierie ML (cycle d'expérimentation, Kaggle)."
-   ]
+   ],
+   "id": "cell-9fecfdf4"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
@@ -1037,7 +1037,8 @@
     "2. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (perception-raisonnement-action, outils, mémoire) — suite du Lab 8.\n",
     "3. H. Chase, *LangChain*, octobre 2022, `langchain.com`. Framework de comparaison (`create_pandas_dataframe_agent`) — suite du Lab 8.\n",
     "4. OpenBMB Team, *CodeAct / Data Interpreter*, 2024. Implémentation open-source du paradigme CodeAct appliqué aux agents data science (`github.com/OpenBMB/AgentVerse`)."
-   ]
+   ],
+   "id": "cell-c5450e2a"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab10-File-Analyzer.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab10-File-Analyzer.ipynb
@@ -814,7 +814,8 @@
    "metadata": {},
    "source": [
     "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de lab10 file analyzer. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les exercices proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
-   ]
+   ],
+   "id": "cell-b7e2c212"
   },
   {
    "cell_type": "markdown",
@@ -825,7 +826,8 @@
     "1. Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025. Article fondateur de l'agent DS-STAR (architecture multi-module : File Analyzer, planification structurée, génération/exécution de code, vérification).\n",
     "2. Google Research, *DS-STAR: A State-of-the-Art Versatile Data Science Agent*, `research.google/blog/ds-star-a-state-of-the-art-versatile-data-science-agent/`, 2025. Billet de présentation (benchmark DABStep).\n",
     "3. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM — suite des Labs 8-9."
-   ]
+   ],
+   "id": "cell-c60b2149"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
@@ -972,7 +972,8 @@
     "2. N. Shinn et al., *Reflexion: Language Agents with Verbal Reinforcement Learning*, arXiv:2303.11366, NeurIPS 2023. Auto-réflexion verbale et raffinement itératif après échec — principe de l'étape Verifier → Coder.\n",
     "3. Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025. Agent DS-STAR dont ce lab implémente la boucle cœur (suite Lab 10).\n",
     "4. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (suite Labs 8-10)."
-   ]
+   ],
+   "id": "cell-7ada47b8"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -953,7 +953,8 @@
     "2. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel de l'agent LLM modulaire de bout en bout (perception-planification-action-vérification).\n",
     "3. S. Yao et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, arXiv:2210.03629, ICLR 2023. Paradigme de la boucle raisonnement-action (suite Lab 11).\n",
     "4. N. Shinn et al., *Reflexion: Language Agents with Verbal Reinforcement Learning*, arXiv:2303.11366, NeurIPS 2023. Auto-raffinement après vérification (suite Lab 11)."
-   ]
+   ],
+   "id": "cell-44c8ee92"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab13-Web-Search-SOTA.ipynb
@@ -728,7 +728,8 @@
     "1. P. Lewis et al., *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*, arXiv:2005.11401, NeurIPS 2020. Paradigme RAG : augmenter un LLM par récupération externe de connaissances avant génération — fondement du module Web Search de ce lab.\n",
     "2. Google Research, *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*, arXiv:2506.15692, 2025. Agent MLE dont ce lab implémente le composant recherche SOTA (combinaison recherche + raffinement ciblé).\n",
     "3. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (suite Labs 8-12)."
-   ]
+   ],
+   "id": "cell-6c469afa"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb
@@ -895,7 +895,8 @@
     "- Meyes, R., Schuman, C., Sakhavi, S., et al. (2019). *Ablation Studies in Artificial Neural Networks*. arXiv:1901.08644. https://arxiv.org/abs/1901.08644\n",
     "- Guo, Q., et al. (2025). *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*. Google Research. arXiv:2506.15692. https://arxiv.org/abs/2506.15692\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
-   ]
+   ],
+   "id": "cell-b4e2c09f"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
@@ -808,7 +808,8 @@
    "metadata": {},
    "source": [
     "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de lab15 kaggle challenge. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les exercices proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
-   ]
+   ],
+   "id": "cell-f2cdd2f3"
   },
   {
    "cell_type": "markdown",
@@ -819,7 +820,8 @@
     "- Chan, S.P., Chowdhury, A., Chen, C., et al. (2024). *MLE-bench: Evaluating Machine Learning Agents on Machine Learning Engineering*. arXiv:2410.07095 (OpenAI). https://arxiv.org/abs/2410.07095\n",
     "- Guo, Q., et al. (2025). *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*. Google Research. arXiv:2506.15692. https://arxiv.org/abs/2506.15692\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
-   ]
+   ],
+   "id": "cell-d2566259"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab16-Data-Science-Agent.ipynb
@@ -863,7 +863,8 @@
     "- Yu, T., Zhang, R., Yang, K., et al. (2018). *Spider: A Large-Scale Human-Labeled Dataset for Complex and Cross-Domain Semantic Parsing and Text-to-SQL Task*. EMNLP 2018. arXiv:1809.08887. https://arxiv.org/abs/1809.08887\n",
     "- Chen, M., Tworek, J., Jun, H., et al. (2021). *Evaluating Large Language Models Trained on Code*. arXiv:2107.03374 (OpenAI). https://arxiv.org/abs/2107.03374\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
-   ]
+   ],
+   "id": "cell-63abe9d2"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
@@ -1000,7 +1000,8 @@
     "- Guo, Q., et al. (2025). *DS-STAR: An Automated End-to-End Data Science Agent Based on Code Generation*. arXiv:2509.21825. https://arxiv.org/abs/2509.21825\n",
     "- Ji, Z., Lee, N., Frieske, R., et al. (2023). *Survey of Hallucination in Natural Language Generation*. ACM Computing Surveys 55. arXiv:2202.03629. https://arxiv.org/abs/2202.03629\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
-   ]
+   ],
+   "id": "cell-848aa1a6"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day1/Labs/Lab1-PythonForDataScience.ipynb
@@ -931,7 +931,8 @@
     "- Pedregosa, F., Varoquaux, G., Gramfort, A., et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12, pp. 2825-2830. arXiv:1201.0490. https://arxiv.org/abs/1201.0490\n",
     "- McKinney, W. (2010). *Data Structures for Statistical Computing in Python*. SciPy 2010 proceedings, pp. 51-56.\n",
     "- Harris, C.R., Millman, K.J., et al. (2020). *Array programming with NumPy*. Nature 585, pp. 357-362."
-   ]
+   ],
+   "id": "cell-99ebb962"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
@@ -546,7 +546,8 @@
     "\n",
     "1. LangChain, *LangChain Expression Language (LCEL)*, 2023, `python.langchain.com/docs/concepts/lcel`. Syntaxe déclarative de composition de chaînes via l'opérateur tube `|` ; chaque composant implémente l'interface `Runnable` (*batch*, asynchrone, *streaming*). Primitive centrale de ce laboratoire (`extraction_prompt | llm`).\n",
     "2. H. Chase, *LangChain*, octobre 2022, `github.com/langchain-ai/langchain`. Framework modulaire open-source pour applications LLM — chaînes composables, *tools*, mémoire. Référence bibliographique détaillée au Lab 8 (ADK Introduction).\n"
-   ]
+   ],
+   "id": "cell-4eb0b399"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/Lab3-CV-Screening.ipynb
@@ -506,7 +506,8 @@
     "\n",
     "1. T. B. Brown, B. Mann, N. Ryder, et al., *Language Models are Few-Shot Learners*, Advances in Neural Information Processing Systems (NeurIPS) 33, 2020, pp. 1877-1901, arXiv:2005.14165. Article fondateur de GPT-3 établissant le paradigme du *prompting* et de l'*in-context learning* : un même modèle accomplit des tâches variées (dont l'extraction structurée) sans *fine-tuning*, uniquement par instruction. Concept central de ce laboratoire.\n",
     "2. LangChain, *LangChain Expression Language (LCEL)*, 2023, `python.langchain.com/docs/concepts/lcel`. Syntaxe de composition de chaînes (`prompt | llm`) utilisée pour assembler l'agent de recrutement — primitive détaillée au Lab 2.\n"
-   ]
+   ],
+   "id": "cell-5702efc2"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
@@ -999,7 +999,8 @@
     "1. CrowdFlower, *Data Science Report*, 2016 ; vulgarisé par G. Press, *Cleaning Big Data: Most Time-Consuming, Least Enjoyable Data Science Task, Survey Says*, Forbes, 23 mars 2016. Enquête établissant la règle des 80/20 : ~80% du temps des data scientists consacré à la préparation/nettoyage des données. Concept central de l'introduction de ce laboratoire.\n",
     "2. J. W. Tukey, *Exploratory Data Analysis*, Addison-Wesley, Reading, MA, 1977. Ouvrage fondateur de l'analyse exploratoire de données ; introduit le *box-plot* et la règle des bornes à 1,5×IQR pour la détection de valeurs aberrantes (Exercice 2).\n",
     "3. W. McKinney, *Data Structures for Statistical Computing in Python*, Proc. SciPy 2010, pp. 51-56. Sous-jacent aux manipulations `DataFrame` de ce laboratoire (pandas) — référence détaillée au Lab 1.3.\n"
-   ]
+   ],
+   "id": "cell-875c3aa4"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
@@ -828,7 +828,8 @@
     "2. T. Fawcett, *An Introduction to ROC Analysis*, Pattern Recognition Letters 27(8), 2006, pp. 861-874. Référence canonique de la courbe ROC et de l'AUC (Exercice 4).\n",
     "3. F. Pedregosa et al., *Scikit-learn: Machine Learning in Python*, JMLR 12, 2011, pp. 2825-2830. Implémentation `LogisticRegression` / `roc_curve` / `train_test_split` — référence détaillée au Lab 1.\n",
     "4. J. W. Tukey, *Exploratory Data Analysis*, Addison-Wesley, 1977. Cadre de l'EDA (Étape 2) — référence détaillée au Lab 4.\n"
-   ]
+   ],
+   "id": "cell-d1c9f249"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
@@ -578,7 +578,8 @@
     "1. S. Yao, J. Zhao, D. Yu, et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, ICLR 2023, arXiv:2210.03629. Paradigme Reasoning+Acting (boucle Pensée → Action → Observation) implémenté par `create_react_agent` (Étape 4) — concept central de ce laboratoire.\n",
     "2. T. Schick, J. Dwivedi-Yu, R. Dessì, et al., *Toolformer: Language Models Can Teach Themselves to Use Tools*, NeurIPS 2023, arXiv:2302.04761. Fondement académique des LLMs *tool-augmented* (décider/quand/arguments d'un appel d'outil) sous-jacent au décorateur `@tool` (Étape 2).\n",
     "3. H. Chase, *LangChain*, 2022 ; LangGraph, `langchain-ai/langgraph`. Framework d'orchestration d'agents (graphe d'états) utilisé tout au long du laboratoire — référence bibliographique détaillée au Lab 8.\n"
-   ]
+   ],
+   "id": "cell-7ecacbd6"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
@@ -803,7 +803,8 @@
     "2. S. Yao et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, ICLR 2023, arXiv:2210.03629. Boucle Pensée→Action→Observation sous-jacente à l'itération de l'agent — détaillée au Lab 6.\n",
     "3. Google Research, *DS-STAR: A State-of-the-Art Versatile Data Science Agent*, 2025. Agent data-science SOTA — référence détaillée au Lab 10.\n",
     "4. H. Chase, *LangChain*, 2022 ; `langchain_experimental`. Implémentation de `create_pandas_dataframe_agent` / `PythonREPLTool` — référence bibliographique détaillée au Lab 8.\n"
-   ]
+   ],
+   "id": "cell-68fc25a0"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (7 ids across 7 notebooks) to the `ML/DataScienceWithAgents/PythonAgentsForDataScience` Day-series labs (Lab1 through Lab7) — part of the v4.5 cell-id gap sweep (see #6257). Together with #6450 (AgenticDataScience Day4-Day7), this **drains the full ML/DataScienceWithAgents gap**.

| Lab | Day | ids added |
|-----|-----|-----------|
| Lab1-PythonForDataScience | Day1 | 1 |
| Lab2-RFP-Analysis | Day2 | 1 |
| Lab3-CV-Screening | Day2 | 1 |
| Lab4-DataWrangling | Day3 | 1 |
| Lab5-Viz-ML | Day3 | 1 |
| Lab6-First-Agent | Day3 | 1 |
| Lab7-Data-Analysis-Agent | Day3 | 1 |

Each was **already v4.5 (`nbformat_minor=5`)** but 1 cell lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on all 7**.
- `validate_pr_notebooks.py` **PASSED** (all 7).
- `git diff --stat`: `14 insertions(+), 7 deletions(-)` = **2N/N** (7 ids × {1 separator + 1 id line}).
- `execution_count` / `outputs`: unchanged on all 7 (structural-only, no cell source touched).

See #6257.
