### PR TITLE
i18n(c426,#4980): Conway/Life/MacroCell FR-first sibling pair (14e sibling conway_lein)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell_en.lean
@@ -46,17 +46,18 @@ import Conway.Life
 
 
 /-
-  Convention i18n (EPIC #4980, décision user 2026-07-04) : ce fichier est **FR canonique**,
-  avec son miroir anglais dans le fichier sibling `MacroCell_en.lean` (modèle sibling
-  pair ratifié 2026-07-04, cf `code-style.md` paragraphe Lean i18n). Les énoncés de
-  théorèmes, les tactiques Lean, les noms de lemmes et les références Mathlib restent en
-  anglais (compatibilité Mathlib 4) ; seules les docstrings de module et ce bloc d'en-tête
-  diffèrent entre les deux fichiers.
+  English mirror of `MacroCell.lean` (FR canonical). Convention EPIC #4980
+  (decision ratified 2026-07-04, cf `code-style.md` paragraphe Lean i18n): distinct FR + EN sibling
+  files - no inline bilingual block in a single file (Option B rejected). The module
+  docstring above mirrors the FR copyright + FR-orbit description; the body signatures,
+  proofs and tactics remain byte-identical between the two files.
 -/
 
-namespace Conway
+namespace Conway_en
 
-namespace Life
+open Conway_en
+
+namespace Life_en
 
 /-! ## The quadtree data structure -/
 
@@ -72,7 +73,7 @@ inductive MacroCell where
   -- proofs in `Conway.Life.HashlifeMemo` rely on.
   deriving DecidableEq, Repr, Inhabited
 
-namespace MacroCell
+namespace MacroCell_en
 
 /-- The level of a `MacroCell`: 0 for `leaf`, `1 + nw.level` for `node`.
     By construction, a well-formed `MacroCell` has all four subtrees at the
@@ -135,7 +136,7 @@ def toCellsAux (r0 c0 : Int) : MacroCell -> List (Int × Int)
 def toGrid (offset : Int × Int) (c : MacroCell) : Grid :=
   sortDedup (c.toCellsAux offset.1 offset.2)
 
-end MacroCell
+end MacroCell_en
 
 /-! ## Conversion: Grid -> MacroCell
 
@@ -153,7 +154,7 @@ The construction is straightforward but a little tedious:
    appropriate quadrant.
 -/
 
-namespace MacroCell
+namespace MacroCell_en
 
 /-- Smallest `n` such that `2 ^ n >= k`. -/
 def ceilLog2 (k : Nat) : Nat :=
@@ -346,7 +347,7 @@ theorem mem_toCellsAux_shift {c : MacroCell} {r0 c0 : Int} {p : Int × Int} :
     refine ⟨(p.1 - r0, p.2 - c0), hq, ?_⟩
     ext <;> omega
 
-end MacroCell
+end MacroCell_en
 
 /-! ## High-level Grid -> MacroCell
 
@@ -801,5 +802,5 @@ small canonical patterns of `Conway.Life`. -/
   let (off, mc) := gridToMacroCellWithOffset toad
   (off, mc.level, mc.toGrid off == toad)
 
-end Life
-end Conway
+end Life_en
+end Conway_en


### PR DESCRIPTION
## Résumé

**14ᵉ sibling `conway_lein` migré** = `Conway/Life/MacroCell.lean` (805 LF canonique + 806 LF EN sibling). Migration vers le modèle **sibling pair FR canonique + EN miroir** (EPIC #4980, décision user 2026-07-04).

**`Conway/Life/MacroCell.lean`** (FR canonique) : header EN mono-lingual préservé + i18n note FR + structure nested triple-segment `Conway > Life > MacroCell` (avec **2ᵉ sous-namespace MacroCell re-ouvert** pour la section "Conversion: Grid -> MacroCell").

**`Conway/Life/MacroCell_en.lean`** (nouveau) : header EN verbatim + i18n note EN + namespace mirror `Conway_en > Life_en > MacroCell_en × 2 + open Conway_en` + body byte-identique.

## Substance réelle (quadtree + Hashlife)

**Quadtree MacroCell** : représentation efficace d'une région carrée de la grille Game of Life :
- `leaf b` : cellule individuelle (vivante `b = true` ou morte `b = false`)
- `node nw ne sw se` : bloc 2×2 de sous-arbres (niveau n+1 couvre 2^(n+1) × 2^(n+1))
- `DecidableEq` dérivé (et non `BEq`) pour que l'instance `BEq` soit `LawfulBEq` (requis par les preuves du cache de mémoïsation dans `Conway.Life.HashlifeMemo`)

**Algorithme Hashlife (Gosper 1984)** : la fonction de transition sur les MacroCells peut être calculée récursivement et mémoïsée, donnant un speedup exponentiel sur les patterns à structure répétitive. Ce module est la **fondation** sur laquelle `Conway.Life.HashlifeMemo` et `Conway.Life.HashlifeCorrectness` construisent leurs preuves de mémoïsation.

**Fonctions clés** :
- `level` : niveau d'un MacroCell (0 pour `leaf`, 1 + max des sous-arbres pour `node`)
- `size` : taille 2^level
- `toCellsAux` : conversion MacroCell → liste de cellules
- `toGrid` : conversion MacroCell → Grid canonique
- `ceilLog2` : logarithme base 2 par excès
- `buildFromGrid` : construction depuis une Grid
- `gridToMacroCellWithOffset` : variante avec offset (pour le thread de padding)

**Substance LeAN portée verbatim** : 41 symbols (definitions, theorems, lemmas + eval) + 2 namespace MacroCell re-ouverts (quadtree data structure L66-L126 + conversion Grid L145+). 0 sorry code-only (Epic #1453, #1651 honorés). 2 `#eval` (beehive + toad pattern tests).

## Preuves de progrès vérifiables (anti-§D + Lean §B)

| Critère | Mesure |
|---------|--------|
| **`grep -c sorry` avant** | 0 |
| **`grep -c sorry` après** | 0 / 0 (FR / EN) — identiques (code-only) |
| **Body byte-identity FR vs EN** | sha256 `6c390a54...` (740 stripped inner lignes, exclude les markers `namespace`/`end` Conway/Life/MacroCell + `_en` swap) |
| **CRLF count** | 0 / 0 (LF-only strict L268) |
| **Trailing newline** | OK sur les 2 fichiers (MD047 C280-1) |
| **Code structure** | 41 symbols préservés verbatim (definitions + theorems + lemmas + #eval) |
| **Size** | FR 34269 B / 805 LF ; EN 34232 B / 806 LF (1 LF de plus pour `open Conway_en`) |
| **Namespace nested triple-segment + re-opened sub** | OK (`namespace Conway > Life > MacroCell × 2` × `namespace Conway_en > Life_en > MacroCell_en × 2 + open Conway_en`) — pattern (b') **C426-L1** (variante de (b) C415-L1) |
| **lakefile.lean `lean_lib «Conway»`** | Inchangé (auto-discovery Lean `lake build` compile les `_en` siblings sans modif, cf precedent des 13 fichiers `_en` déjà mergés) |
| **Imports verbatim FR/EN** | `import Conway.Life` présent dans les 2 fichiers (assert post-write) |
| **Pattern nested multi-segment (b') C426-L1** | Namespace nested `Conway > Life` + sous-namespace `MacroCell` re-ouvert 2 fois (quadtree data + Grid conversion). Différent de c.425 KochenSpecker (nested `Conway > KochenSpecker` simple) — gère le cas où le même sous-namespace est rouvert dans le même outer namespace |

## i18n — convention #4980 ratifiée 2026-07-04

- **Module docstring mono-lingual EN** : le fichier source avait un header EN (copyright Apache 2.0 + abstract EN L1-L46), **PAS de bloc bilingue FR+EN** pré-existant (différent de c.425 KochenSpecker). Conséquence = pas de préservation de traduction FR legacy.
- **i18n note FR** (ajoutée après les imports) : référence à `code-style.md §Lean i18n` + décision user 2026-07-04 + modèle sibling pair.
- **EN sibling** : header EN verbatim original + i18n note EN réfutant Option B (inline bilingue dans un seul fichier).
- **Énoncés de theorems, noms de lemmas, tactiques Lean, sections `/-! ##`, theorem docstrings** restent en anglais (cohérent avec c.412-c.425, compat Mathlib 4).
- **Seuls i18n note + namespace markers + `open` statement** diffèrent entre FR et EN.

## Pattern namespace nested triple-segment (b') **C426-L1** (nouveau)

`Conway/Life/MacroCell.lean` utilise un **namespace nested triple-segment** avec **sous-namespace re-ouvert** : `Conway > Life > MacroCell × 2` (2ᵉ ouverture pour "Conversion: Grid -> MacroCell"). Différent de c.425 KochenSpecker qui avait un sous-namespace simple.

```lean
namespace Conway

namespace Life

namespace MacroCell
  -- quadtree data structure
end MacroCell

namespace MacroCell
  -- conversion: Grid -> MacroCell
end MacroCell

end Life
end Conway
```

```lean
namespace Conway_en

open Conway_en

namespace Life_en

namespace MacroCell_en
  -- quadtree data structure
end MacroCell_en

namespace MacroCell_en
  -- conversion: Grid -> MacroCell
end MacroCell_en

end Life_en
end Conway_en
```

**C426-L1** : `Conway/Life/MacroCell.lean` est le **14ᵉ sibling** du sous-dossier `Conway/*` migré sous EPIC #4980. Le pattern **nested triple-segment avec sous-namespace re-ouvert** est une variante du pattern (b) C415-L1 — détecté pour la 1ère fois dans ce rollout.

## Différence avec c.412-c.425 satellites `Conway/*`

| Satellite | LF | Sorry | Pattern namespace |
|-----------|-----|-------|-------------------|
| `HashlifeMarginDemo` (c.412) | 89 | 0 | (b) nested multi-segment |
| `FractranLemmas` (c.413) | 153 | 0 | (b) nested multi-segment |
| `Angel` (c.414) | 277 | 0 | (b) nested multi-segment |
| `Spaceships` (c.415) | 169 | 0 | (b) nested multi-segment (1ᵉʳ) |
| `Oscillators` (c.416) | 119 | 0 | (b) nested multi-segment |
| `HashlifeMemo` (c.418) | 247 | 0 | (b) nested multi-segment |
| `Conway/Life` (c.419) | 178 | 0 | (b) nested multi-segment (root aggregator) |
| `GridCanonical` (c.423) | 271 | 0 | (b) nested multi-segment |
| **`MacroCell` (c.426)** | **805** | **0** | **(b') nested triple-segment + re-opened sub** |
| `KochenSpecker` (c.425) | 374 | 0 | (b) nested multi-segment (KS theorem) |

**Substance Free Will Theorem / Game of Life** : `Conway/Life/MacroCell.lean` est l'**un des modules les plus fondamentaux** du sous-dossier `Conway/Life/` — il définit la **structure de données centrale** (quadtree) sur laquelle Hashlife (Gosper 1984) s'appuie pour obtenir son speedup exponentiel. Sans ce quadtree, l'algorithme Hashlife ne pourrait pas être formalisé en Lean.

## Cold-build gate (C455-1)

WSL elan absent localement → CI Lean GitHub Actions = preuve canonique du merge. Anti-§D byte-identity local = signal minimal mais ne dispense PAS de CI PASS. Le CI Lean conway (`lean-conway.yml` workflow) utilise `sorry-baseline: "7"` (toutes dans HashlifeCorrectness.lean). MacroCell a 0 sorry, donc bien sous la baseline.

## Anti-§D byte-identity (L298) préservé

sha256 `6c390a542e36b10920114e23f0e62bee89fbc7d781b57845d4b9e36898317a5f` calculé sur 740 stripped inner lignes (excluant tous les `namespace Conway(_en)?/Life(_en)?/MacroCell(_en)?` et `end Conway(_en)?/Life(_en)?/MacroCell(_en)?` markers) — identique FR↔EN. Preuve que le compositor a correctement préservé le contenu substantif (signatures, lemmas, théorèmes, tactiques, commentaires `--`).

## Anti-patterns évités

- ✅ `Write` tool → trailing newline vérifié via Python `data += b'\n'` (C413-L1 / C280-1)
- ✅ `--body-file` (JAMAIS `--body` à cause de C403-L1 backtick stripping)
- ✅ Branch base = main local frais (R2 base-stale-14d)
- ✅ Atomique : 1 PR = 1 sibling pair (R3) : 1 file modified + 1 file added
- ✅ Pas de catalogue touché (R1, #2632)
- ✅ Worker JAMAIS `gh pr merge` ou `--approve` (L143 SAFE cross-owner, #1502)
- ✅ Sections `/-! ##` et theorem docstrings en anglais (cohérent avec c.412-c.425)
- ✅ Worktree isolé `D:/dev/CoursIA-c426` (sécurité R3 atomicité)
- ✅ Anti-§D byte-identity inner body préservé (sha256 `6c390a54…` identique FR↔EN, 740 stripped inner lignes)
- ✅ Branche nommée vers sujet réel `i18n/c426-macrocell-4980`
- ✅ Backup `MacroCell.lean.bak.c426` avant écriture (sécurité anti-régression)
- ✅ `Conway/Life/MacroCell_en.lean` (suffix `_en` ajouté à chaque segment de namespace) — pas de modif lakefile
- ✅ Pattern (b') nested triple-segment + re-opened sub détecté — C426-L1 nouvelle variante
- ✅ gh auth switch -u jsboige ONLY pour push (jamais de merge/close d'autrui = L143 SAFE)
- ✅ Imports préservés verbatim `import Conway.Life` dans les DEUX fichiers (assert post-write)
- ✅ Module docstring mono-lingual EN (pas de bloc bilingue pré-existant dans ce fichier) — pas de destruction de contenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
