### PR TITLE
fix(lean,#6419): move require mathlib last in conway_cgt_lean/lakefile.lean

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.lean
@@ -27,11 +27,11 @@ package «conway_cgt» where
     ⟨`autoImplicit, false⟩
   ]
 
-require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git"
-
 require CombinatorialGames from git
   "https://github.com/vihdzp/combinatorial-games.git"
+
+require mathlib from git
+  "https://github.com/leanprover-community/mathlib4.git"
 
 @[default_target]
 lean_lib «CGTTour» where


### PR DESCRIPTION
## Résumé

**Fix `conway_cgt_lean/lakefile.lean`** : réordonnancer `require mathlib` **en dernier** (après `require CombinatorialGames`), conformément au diagnostic Lake émis sur le build cassé.

**Substance** : modification de 3 lignes (1 bloc `require mathlib` déplacé de la position L30-L32 vers L34-L36, après `require CombinatorialGames`). Aucun autre fichier touché.

**Closes #6419** — bug ouvert 2026-07-14 par ai-01, racines identifiées (CombinatorialGames pins transitifs `Batteries/Aesop/Plausible` qui préemptent mathlib via l'ordre de déclaration).

## Diagnostic du problème (preuves)

Le diagnostic Lake de l'échec build sur `main @ 67dbbd05` (run 28633292323, 2026-07-03) et sur la branche PR #6116 @ `80c2c10a` (run 29301240161, 2026-07-14) est explicite :

```
Some mismatched dependencies come transitively from other packages in your lakefile.
Try putting `require mathlib` last in your lakefile so that Mathlib's versions take precedence, then run `lake update`.
error: mathlib: failed to fetch cache
Some required targets logged failures:
- Batteries.Data.Nat.Basic
- Plausible.Testable
- Aesop.Builder.Forward
```

**Root cause** : `conway_cgt_lean` déclare
1. `require mathlib` d'abord (mathlib résout ses versions de transitives Batteries/Aesop/Plausible),
2. puis `require CombinatorialGames` (qui transitivement pin des révisions **différentes** de ces mêmes libs).

Lake applique le **pin transitif le plus tardif** = CombinatorialGames gagne → mathlib voit des transitive-pins incompatibles avec ses propres résolutions → `mathlib: failed to fetch cache`.

**Fix Lake-explicit** : mettre `require mathlib` **en dernier** = ses transitive-pins priment → résolutions cohérentes.

## Preuve de progrès vérifiable (anti-§D + Lean §B)

| Critère | Mesure |
|---------|--------|
| **`lakefile.lean` diff minimal** | `+3 / -3` lignes (1 bloc `require mathlib` déplacé), aucun autre fichier touché |
| **LF-only strict (L268)** | LF (CR=0), `lean-toolchain` inchangé (`leanprover/lean4:v4.31.0-rc1`) |
| **Pas de touche au code Lean source** | Aucun `*.lean` modifié, uniquement `lakefile.lean` (config build Lake) |
| **Pas de sorry / pas de preuve touchée** | `grep -c sorry` conway_cgt_lean : 0 → 0 (invariant) |
| **Branche en rebased fresh** | Créée directement depuis `origin/main` @ `d477a8634` (2026-07-11) |
| **Commit message** | `fix(lean,#6419): move require mathlib last ...` (conventionnel, scope Lean, ref issue) |
| **Worktree isolé** | `D:/dev/CoursIA-c427` (sécurité R3 atomique + L143 SAFE cross-owner) |
| **Closes #6419** | PR résout intégralement l'issue (1-ligne dans 1 fichier), `Closes #X` valide per R4 |

## Acceptation

| Acceptance #6419 | Preuve / Statut |
|------------------|-----------------|
| `lake build` SUCCESS local (cold build ~20-60 min) | **DELEGATED to po-2026** : po-2023 (this worker) n'a pas d'env Lean local (WSL elan absent, C455-1 cold-build gate non disponible localement). Cible : dispatcher po-2026 pour build log complet, OU attendre `Lean CI (conway_cgt_lean)=pass` via GitHub Actions sur cette PR (proof canonique per C455-1) |
| `Lean CI (conway_cgt_lean)=pass` sur cette PR | **À vérifier post-push** (CI Lean GitHub Actions = proof canonique par défaut) |
| Post-fix, #6116 (CGTTour_en sibling) passe le gate | **Indirect** : ce fix débloque le gate pour toute PR touchant conway_cgt_lean, y compris #6116 |

## Refs croisées

- **#6419** (issue résolue) — `Closes`
- **#6116** (débloqué indirectement) — mentionné dans le body, pas dans le titre
- **#4980** (i18n EPIC) — context global Lean i18n sibling pair rollout
- **#4362** (Lean infra EPIC) — context Lean build infra ensemble
- **PRs c.412-c.426** (sibling pair conway_lean précédents) — pattern cohérent avec cet infra fix

## Anti-patterns évités

- ✅ Pas de force push, pas de direct main push (L143 SAFE)
- ✅ Branch `fix/6419-conway-cgt-lean-mathlib-order` (nommée vers sujet réel)
- ✅ Worktree isolé `D:/dev/CoursIA-c427` (sécurité R3 atomique)
- ✅ `git auth switch -u jsboige` ONLY for push, restore `jsboigeEpita` after (C492-L2)
- ✅ `--body-file` (JAMAIS `--body`, C403-L1 anti-backtick stripping)
- ✅ Pas de `Closes #X` partiel (R4) — issue entièrement résolue par 1-ligne, `Closes #6419` valide
- ✅ Acceptance local-build honestly framed as delegated (po-2023 sans env Lean local), CI Lean GitHub Actions = proof canonique per C455-1
- ✅ Cross-référence à C513-L1 pathology (lean-build.yml scan inclut `_en` siblings) — celui-ci est un fix distinct, infra lake-spécifique, pas shared CI

## Note pour le reviewer (`lean-merge-discipline.md` regle 1)

**`lake build` SUCCESS local OBLIGATOIRE avant merge** (incident 2026-05-10 merge #866 sur claim non-vérifié → revert #885, 1 cycle perdu). Le claim « lake build SUCCESS Xs » dans le body PR n'est PAS suffisant. **Pas d'env Lean local sur po-2023** : dispatcher **po-2026** avec build log complet + `grep -c sorry` avant/après (invariant 0/0) + diff sur defs partagées (1 fichier lakefile.lean, pas de defs de code Lean).

**Alternative acceptable** : `Lean CI (conway_cgt_lean)=pass` sur GitHub Actions = proof canonique per `C455-1 cold-build gate` (WSL elan absent localement → CI Lean = preuve canonique du merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
