### PR TITLE
docs(lean,#4980,#3978): sensitivity_lean README i18n coverage + Modules table refresh

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.en.md
@@ -15,6 +15,7 @@ Complete mini-project: **0 sorry, 0 axiom** beyond Lean core axioms.
 - **Sorry**: **0** — every proof is closed
 - **Build**: `lake build Sensitivity` — SUCCESS
 - **Dependencies**: Mathlib4
+- **i18n coverage (EPIC #4980)**: lake fully bilingual FR/EN — 4 `.lean` modules shipped as FR canonical + 4 `*_en.lean` mirror siblings on `main` (`Sensitivity/Hypercube_en.lean`, `Sensitivity/VectorSpace_en.lean`, `Sensitivity/Operator_en.lean`, `Sensitivity/MainTheorem_en.lean`). Convention EPIC #4980 Option A: docstrings `/-- ... -/` and `-- ...` comments differ between FR and EN, signatures and proofs remain byte-identical.
 
 ## What it formalizes
 
@@ -40,13 +41,13 @@ interlacing theorem forces a high-degree vertex in any large induced subgraph.
 
 ## Modules
 
-| File | Lines | sorry | Content |
-|------|------:|------:|---------|
-| `Sensitivity.lean` | 1 | 0 | Root import umbrella |
-| `Sensitivity/Hypercube.lean` | 124 | 0 | Boolean hypercube `Q n`, vertices, adjacency |
-| `Sensitivity/VectorSpace.lean` | 132 | 0 | Real vector space of Boolean functions, `ℝ^{2^n}` basis |
-| `Sensitivity/Operator.lean` | 100 | 0 | Sensitivity and block-sensitivity operators |
-| `Sensitivity/MainTheorem.lean` | 131 | 0 | `exists_eigenvalue` (L51), `huang_degree_theorem` (L84) |
+| File | `_en` | Lines | sorry | Content |
+|------|-------|------:|------:|---------|
+| `Sensitivity.lean` | — | 1 | 0 | Root import umbrella |
+| `Sensitivity/Hypercube.lean` | `Hypercube_en.lean` | 124 | 0 | Boolean hypercube `Q n`, vertices, adjacency |
+| `Sensitivity/VectorSpace.lean` | `VectorSpace_en.lean` | 132 | 0 | Real vector space of Boolean functions, `ℝ^{2^n}` basis |
+| `Sensitivity/Operator.lean` | `Operator_en.lean` | 100 | 0 | Sensitivity and block-sensitivity operators |
+| `Sensitivity/MainTheorem.lean` | `MainTheorem_en.lean` | 131 | 0 | `exists_eigenvalue` (L51), `huang_degree_theorem` (L84) |
 
 ## Key results
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
@@ -15,6 +15,7 @@ Mini-projet complet : **0 sorry, 0 axiome** au-delà des axiomes du cœur de Lea
 - **Sorry** : **0** — chaque preuve est close
 - **Build** : `lake build Sensitivity` — SUCCESS
 - **Dépendances** : Mathlib4
+- **Couverture i18n (EPIC #4980)** : lake entièrement bilingue FR/EN — 4 modules `.lean` livrés en FR canonique + 4 siblings `*_en.lean` miroirs sur `main` (`Sensitivity/Hypercube_en.lean`, `Sensitivity/VectorSpace_en.lean`, `Sensitivity/Operator_en.lean`, `Sensitivity/MainTheorem_en.lean`). Convention EPIC #4980 Option A : docstrings `/-- ... -/` et commentaires `-- ...` diffèrent entre FR et EN, signatures et preuves byte-identiques.
 
 ## Ce qui est formalisé
 
@@ -81,13 +82,13 @@ flowchart TD
 
 ## Modules
 
-| Fichier | Lignes | sorry | Contenu |
-|---------|-------:|------:|---------|
-| `Sensitivity.lean` | 1 | 0 | Ombrelle d'import racine |
-| `Sensitivity/Hypercube.lean` | 124 | 0 | Hypercube booléen `Q n`, sommets, adjacence |
-| `Sensitivity/VectorSpace.lean` | 132 | 0 | Espace vectoriel réel des fonctions booléennes, base `ℝ^{2^n}` |
-| `Sensitivity/Operator.lean` | 100 | 0 | Opérateurs de sensibilité et de sensibilité par blocs |
-| `Sensitivity/MainTheorem.lean` | 131 | 0 | `exists_eigenvalue` (L51), `huang_degree_theorem` (L84) |
+| Fichier | `_en` | Lignes | sorry | Contenu |
+|---------|-------|-------:|------:|---------|
+| `Sensitivity.lean` | — | 1 | 0 | Ombrelle d'import racine |
+| `Sensitivity/Hypercube.lean` | `Hypercube_en.lean` | 124 | 0 | Hypercube booléen `Q n`, sommets, adjacence |
+| `Sensitivity/VectorSpace.lean` | `VectorSpace_en.lean` | 132 | 0 | Espace vectoriel réel des fonctions booléennes, base `ℝ^{2^n}` |
+| `Sensitivity/Operator.lean` | `Operator_en.lean` | 100 | 0 | Opérateurs de sensibilité et de sensibilité par blocs |
+| `Sensitivity/MainTheorem.lean` | `MainTheorem_en.lean` | 131 | 0 | `exists_eigenvalue` (L51), `huang_degree_theorem` (L84) |
 
 ## Résultats clés
 


### PR DESCRIPTION
## docs(lean,#4980,#3978): sensitivity_lean README i18n coverage + Modules table refresh

### Scope (atomic single-PR)

2 files in-place (docs-only):

- `MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md` (FR canonical, 152 → 153 LF, +1 LF on Status bullet)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.en.md` (EN sibling, 110 → 111 LF, +1 LF on Status bullet)

`+16 / -14` net — the Modules table grew by one column (`_en`) on each side (5 rows × 2 cells added = +10, header swap = +2 vs same row count after table rebuild on both files).

1 feature (i18n sibling-pairs coverage), 1 domain (Lean docs). Atomic G.4 compliant.

### Constat — FR and EN were BOTH stale (audit dual)

The Modules table on **both** `README.md` (FR canonical) and `README.en.md` (EN sibling) listed only the 4 FR modules (`Sensitivity.lean`, `Sensitivity/Hypercube.lean`, `Sensitivity/VectorSpace.lean`, `Sensitivity/Operator.lean`, `Sensitivity/MainTheorem.lean`) — with **no mention of the 4 `*_en.lean` siblings** that are already shipped on `main`:

| FR file | `_en` sibling on main |
| --- | --- |
| `Sensitivity/Hypercube.lean` | `Sensitivity/Hypercube_en.lean` |
| `Sensitivity/VectorSpace.lean` | `Sensitivity/VectorSpace_en.lean` |
| `Sensitivity/Operator.lean` | `Sensitivity/Operator_en.lean` |
| `Sensitivity/MainTheorem.lean` | `Sensitivity/MainTheorem_en.lean` |
| `Sensitivity.lean` (umbrella) | — (no theory of its own) |

The `_en` siblings were added (lake fully bilingual rollout, PR-style additions on this leaf) and the README tables were **never updated** to reflect them — same dual-stale pattern that c.425 (#6447 calibration_lean) fixed one cycle earlier. Cf. **L400** (c.425) — `audit-dual-stale-table-modules-FR-AND-EN`: when a leaf's FR/EN READMEs both predate the `_en` siblings, both go stale simultaneously. Always audit the **two files in read-only** before editing, never assume "only FR is stale because the EN mirrors the FR existing state".

### Changes

1. **Statut / Status block** (FR and EN): add a `Couverture i18n (EPIC #4980)` (FR) / `i18n coverage (EPIC #4980)` (EN) bullet listing **4 `.lean` modules shipped as FR canonical + 4 `*_en.lean` mirror siblings on `main`**, and a one-liner on convention EPIC #4980 Option A (docstrings `/-- ... -/` and comments `-- ...` differ between FR and EN, signatures and proofs remain byte-identical).
2. **Modules table**: add an `_en` column. For each row, the cell is the sibling filename (`Hypercube_en.lean`, etc.) or `—` for the root umbrella `Sensitivity.lean` (no theory of its own, no `_en` counterpart needed). The rest of the row content is preserved verbatim.

Symmetry FR/EN is exact — header and rows mirror 1:1 across the two files.

### Verifications firsthand (G.1 verify-before-claim)

```bash
git ls-tree -r origin/main --name-only MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/
```

Returns exactly **16 files**: `.gitignore`, `NOTICE.md`, `README.en.md`, `README.md`, `Sensitivity.lean`, the 4 FR `Sensitivity/*.lean`, the 4 EN `Sensitivity/*_en.lean`, `lake-manifest.json`, `lakefile.lean`, `lean-toolchain`. The **4 `_en.lean` siblings** are confirmed on `main`.

- **Sorry baseline** (G.1 anti-regression): `grep -c "^sorry"` over the 8 `.lean` files → **0/0/0/0/0/0/0/0**. No regression, no tactical `sorry` introduced. Baseline un-modified.
- **Encoding**: `file` → `Unicode text, UTF-8 text, with very long lines` — UTF-8, no BOM.
- **CRLF**: `grep -c $'\r'` → **0** on both files (LF strict).
- **LF count**: README.md 152 → 153 LF (+1), README.en.md 110 → 111 LF (+1) — matches the +1 bullet in each Status block.
- **catalog-pr-hygiene R1 (L398 c.424)**: **non-binding** on this leaf — `grep -n "CATALOG-STATUS"` returns 0 hits on both READMEs. Rule "never regenerate the catalog on a feature branch" is not engaged here, so the Modules table and the i18n-coverage block can be edited freely without risk of catalogue conflict at merge.
- **No Lean code touched**: `git diff --stat` confirms only the two README files changed. `lakefile.lean`, `lake-manifest.json`, `lean-toolchain` are byte-identical to `origin/main`.
- **No local `lake build` required**: PR is docs-only (status / table edits only). Cold-build gate does not apply — no theorem-bearing file is touched, no namespace/import change, no risk of NUL-byte corruption (L390, L391 lessons don't bite).

### Pivot R6 anti-monotonie (mandat 2026-07-06)

c.425 (#6447 calibration_lean README) and c.424 (#6442 conway_lean README) were both Lean/docs README feuilles. c.426 continues on the **same axis** but on a **different lake** (sensitivity_lean instead of calibration_lean / conway_lean) — the rotation is across the lake dimension, not across the genre dimension. That keeps the worker on the i18n-coverage rollout while spreading the audit across more leaves.

Why **sensitivity_lean** specifically:
- **No cold-build blocker**: sensitivity_lean builds clean (`lake build Sensitivity` — SUCCESS, 0 sorry). It is not in the `knot_lean` sorry-gate pathology (C513-L1 — `knot_lean/_en` baseline 17 vs 19, ai-01 decision) nor in the `grothendieck_lean` cold-build gap (PRs #6277/#6280/#6284/#6291 blocked).
- **No concurrent PR on the same leaf**: `gh pr list` filtered on `sensitivity` → 0 hits in `OPEN` state. The leaf is free for c.426.
- **4 `_en.lean` siblings present**: same shape as c.425 (calibration_lean = 3) and c.424 (conway_lean = 11). The dual-stale audit pattern is mechanically identical.
- **`README.en.md` already exists** (unlike `finiteness_lean`, which needs a gap-fill README.en.md first before any audit dual-stale makes sense).

Why **not** `knot_lean` README feuille next: PRs #6429 (Reidemeister) and #6440 (Lidman) are both HELD by the sorry-gate CI pathology (C513-L1) — a feuille README audit here would only describe the **current** shape, not the **i18n-coverage state**. Better to audit `sensitivity_lean` first, then revisit `knot_lean` once the sorry-gate fix lands.

### Links

- See #4980 (i18n Lean harmonisation — extension coverage)
- See #3978 (READMEs feuilles — SymbolicAI/Lean/** included)
- See #3973 (README ascendant — resynchronisation hierarchie)
- Refs #5543 (lake fully bilingual — lake dont on documente la couverture)

### Lessons applied

- **L398** (c.424): `catalog-pr-hygiene R1 not binding if markers absent`. Confirmed `grep -n "CATALOG-STATUS" <README.md>` returns 0 on both files — R1 is non-blocking here.
- **L399** (c.425): `gh-pr-create-backtick-mangling-shell-reparse`. PR body written via heredoc `cat > /tmp/c426_pr_body.md << 'EOF_PR_BODY'` (single-quoted EOF preserves backticks literally) then patched via `gh pr edit --body-file`. No backtick mangling.
- **L400** (c.425): `audit-dual-stale-table-modules-FR-AND-EN`. Audited both `README.md` and `README.en.md` in read-only before the edit. The two READMEs were stale in the **same way** (Modules table missing the `_en` siblings) — confirming the pattern generalises beyond calibration_lean.

### Cycle suivant

Lanes candidates post-c.426:
- **`finiteness_lean` README feuille**: 1 `_en.lean` on main (`Finiteness/Basic_en.lean`) but **README.en.md is MISSING** — gap-fill pre-requisite before any dual-stale audit makes sense. Different shape from c.425/c.426.
- **`knot_lean` README feuille**: 2 `_en.lean` siblings (#6429 Reidemeister + #6440 Lidman) but both HELD by C513-L1 sorry-gate CI pathology. Revisit once ai-01 commits to a fix on `lean-build.yml`.
- **`grothendieck_lean` README feuille**: 12 `_en.lean` siblings substantial, but blocked by the cold-build gap (PRs #6277/#6280/#6284/#6291 awaiting local validation). Drop until unblocked.
- **`examples` / `mathlib_examples` READMEs**: 0 `_en.lean` (i.e. not applicable). Documentation bilingue hors-scope.

Recommendation next wakeup: **finiteness_lean** — gap-fill README.en.md pre-requise, then audit dual. Different shape from c.425/c.426 (small, 1 sibling), parallelisable with another cycle's deep track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
