### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to GenAI Image+Video cluster

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
@@ -2155,7 +2155,8 @@
    "metadata": {},
    "source": [
     "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de 01 3 basic image operations. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les Exemple guides proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
-   ]
+   ],
+   "id": "cell-63bd4614"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb
@@ -1891,7 +1891,8 @@
     "- Les resultats obtenus permettent de valider la comprehension\n",
     "\n",
     "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
-   ]
+   ],
+   "id": "cell-fd7fad1e"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
@@ -1468,7 +1468,8 @@
     "- Les resultats obtenus permettent de valider la comprehension\n",
     "\n",
     "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
-   ]
+   ],
+   "id": "cell-cf17aeaa"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (3 ids across 3 notebooks) to the GenAI Image + Video families — part of the v4.5 cell-id gap sweep (see #6257).

| Notebook | ids added |
|----------|-----------|
| `GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb` | 1 |
| `GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb` | 1 |
| `GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb` | 1 |

Each was **already v4.5 (`nbformat_minor=5`)** but 1 cell lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on all 3**.
- `validate_pr_notebooks.py` **PASSED** (all 3).
- `git diff --stat`: `6 insertions(+), 3 deletions(-)` = **2N/N** (3 ids × {1 separator + 1 id line}).
- `execution_count` / `outputs`: unchanged on all 3 (structural-only, no cell source touched).

See #6257.
