### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Sudoku Python cluster

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -921,7 +921,8 @@
     "**Indice :**\n",
     "Utilisez la fonction `benchmark_solver` deja definie avec les deux solveurs.\n",
     "Affichez les resultats dans un tableau comparatif.\n"
-   ]
+   ],
+   "id": "cell-65d0714e"
   },
   {
    "cell_type": "code",
@@ -943,7 +944,8 @@
     "    # Retournez un dict avec les temps et nombre d'appels pour chaque solveur\n",
     "    result = None  # TODO etudiant\n",
     "    return result\n"
-   ]
+   ],
+   "id": "cell-eaef66b3"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -767,7 +767,8 @@
     "\n",
     "**Indice**\n",
     "Utilisez `model.Add(cells[0][i] == i+1)` pour chaque colonne i de la ligne 0.\n"
-   ]
+   ],
+   "id": "cell-d4e7f3f8"
   },
   {
    "cell_type": "code",
@@ -789,7 +790,8 @@
     "    # que la premiere ligne doit etre (1,2,3,...,9)\n",
     "    result = {}  # TODO etudiant\n",
     "    return result\n"
-   ]
+   ],
+   "id": "cell-d8057ef5"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
@@ -653,7 +653,8 @@
     "**Indice**\n",
     "Modifiez la fonction `solve` pour court-circuiter `eliminate` et mesurer\n",
     "la difference de performance sur les puzzles difficiles.\n"
-   ]
+   ],
+   "id": "cell-c705c6d5"
   },
   {
    "cell_type": "code",
@@ -676,7 +677,8 @@
     "    # Comparez le nombre d'appels recursifs avec le solveur complet\n",
     "    result = None  # TODO etudiant\n",
     "    return result\n"
-   ]
+   ],
+   "id": "cell-e5725826"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (6 ids across 3 notebooks) to the Sudoku Python series — part of the v4.5 cell-id gap sweep (see #6257). Continues the established series pattern (#6422 / #6423 / #6425 / #6406).

| Notebook | ids added |
|----------|-----------|
| `Sudoku/Sudoku-1-Backtracking-Python.ipynb` | 2 |
| `Sudoku/Sudoku-7-Norvig-Python.ipynb` | 2 |
| `Sudoku/Sudoku-10-ORTools-Python.ipynb` | 2 |

Each was **already v4.5 (`nbformat_minor=5`)** but a few cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on all 3**.
- `validate_pr_notebooks.py` **PASSED** (all 3).
- `git diff --stat`: `12 insertions(+), 6 deletions(-)` = **2N/N**.
- `execution_count` / `outputs`: unchanged (structural-only).

See #6257.
