### PR TITLE
i18n(lean,#4980,#4365): add StableMarriage_en sibling pair (root aggregator)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/StableMarriage_en.lean
@@ -1,0 +1,42 @@
+/-
+  GameTheory.StableMarriage — root aggregator (EPIC #4365 phase 4)
+  ================================================================
+
+  This module groups together the 5 sub-modules absorbed from the former
+  `stable_marriage_lean/StableMarriage/` (now removed):
+
+  - `StableMarriage.Definitions`      (absorbed c.300)
+  - `StableMarriage.GSState`          (c.301)
+  - `StableMarriage.Lemmas`           (c.302/c.303)
+  - `StableMarriage.GaleShapley`      (c.304)
+  - `StableMarriage.Lattice`          (c.305)
+
+  Removal of the `stable_marriage_lean/` checkout is effective
+  (EPIC #4365 phase 4; anti-regression 4-step protocol respected:
+  content entirely preserved here, lake build SUCCESS, 0 net `sorry`
+  introduced). Prose/CI/inventory refs updated to game_theory_lean.
+
+  i18n convention (EPIC #4980 ratified by user 2026-07-04): the
+  sub-modules `.lean` and their `_en.lean` siblings (namespace
+  `<Name>_en`) are auto-discovered by the lakefile's
+  `globs := #[`StableMarriage.*]`. The CI drift-detection sees both languages.
+
+  Convention i18n (EPIC #4980, user decision 2026-07-04): this file is the
+  **English mirror** of the FR-canonical root aggregator `StableMarriage.lean`,
+  following the **sibling pair model** ratified by user on 2026-07-04
+  (see `code-style.md` §Lean i18n, line 35; Option B rejected: double cost +
+  FR/EN drift + quality bias). The FR-canonical aggregator is byte-identical
+  on the import block (root aggregator is imports-only); only the docstring
+  differs between the two siblings.
+-/
+
+import StableMarriage.Definitions
+import StableMarriage.Definitions_en
+import StableMarriage.GSState
+import StableMarriage.GSState_en
+import StableMarriage.Lemmas
+import StableMarriage.Lemmas_en
+import StableMarriage.Lattice
+import StableMarriage.Lattice_en
+import StableMarriage.GaleShapley
+import StableMarriage.GaleShapley_en


### PR DESCRIPTION
## Résumé

**Sibling pair root aggregator conway_lean → game_theory_lean PIVOT R6 anti-monotonie** : `GameTheory/game_theory_lean/StableMarriage.lean` (FR canonical 1388 B/33 LF) → ajout de `StableMarriage_en.lean` (EN sibling 1868 B/42 LF) selon la convention EPIC #4980 ratifiée 2026-07-04 (sibling pair `Foo.lean`/`Foo_en.lean`, namespace suffix `_en`).

**Substance** : ajout de **1 fichier**, **0 fichier modifié**. Pattern **root aggregator** (imports-only, pas de `namespace` block). Precedent : PR #6175 (CooperativeGames.lean + CooperativeGames_en.lean, même pattern, c.357).

## Diagnostic du problème (G.1 firsthand)

Le fichier `StableMarriage.lean` est un root aggregator (imports-only, sans namespace/end markers) :
- **L1-L23** : header `/-/...-/` copyright + module docstring FR (mono-lingual FR, **PAS de bilingual inline legacy**)
- **L25-L34** : bloc d'imports (10 imports : 5 `Foo` + 5 `Foo_en` siblings)
- **Pas de `namespace StableMarriage`** : c'est un agrégateur au root du lake (cf `globs := #[`StableMarriage.*]` dans lakefile)

État actuel : aucun sibling EN. Convention EPIC #4980 veut un sibling `_en.lean` distinct, pas de bloc bilingue inline (Option B rejetée 2026-07-04).

**Distinction critique** vs `SocialChoice.lean` (109L) :
- `StableMarriage.lean` (33L) = **mono-lingual FR canonique** → eligible sibling pair
- `SocialChoice.lean` (109L) = **bilingual inline legacy** → EXCLU per C414-L2 filter

## Preuve de progrès vérifiable (anti-§D + Lean §B)

| Critère | Mesure |
|---------|--------|
| **`git diff --stat` strict** | `+42 / -0` lignes (1 fichier nouveau, 0 fichier modifié) |
| **Anti-§D byte-identity** | **N/A root aggregator** : pas de `namespace`/`end` markers, pas de theorem signatures — invariant ne s'applique pas aux fichiers imports-only |
| **Structural mirror import-block** | FR sha256 `1690e55f…` ≡ EN sha256 `1690e55f…` (PASS) — 10 imports byte-identiques entre siblings |
| **LF-only strict (L268)** | LF (CR=0, CRLF=0) sur FR ET EN, confirmé Python `data.count(b'\r')` |
| **Trailing newline (MD047)** | EN file ends with `\n` (1868 B divisible OK) |
| **Sorry code-only invariant** | FR: 0 sorry, EN: 0 sorry code-only (regex `(?:^|\s\|:=\|by)\s*sorry(?:\s\|$\|\})`) |
| **Pattern reconnu** | **Root aggregator** (imports-only, distinct des patterns C415-L1 nested / C420-L1 simple / C426-L1 nested-triple / C422-L1 nested-single) |
| **i18n note EN** | Ajouté L24-L30 (7 lignes) — référence EPIC #4980 + `code-style.md` §Lean i18n |
| **Header preservation** | FR canonical `StableMarriage.lean` (33L) PRESERVED byte-identique (mono-lingual FR, pas de bilingual legacy) |
| **Branche en rebase frais** | Créée depuis `origin/main` @ `d477a8634` (2026-07-14) |
| **Worktree isolé** | `D:/dev/CoursIA-c429` (sécurité R3 atomique + L143 SAFE cross-owner) |
| **Commit message** | `i18n(lean,#4980,#4365): add StableMarriage_en sibling pair (root aggregator conway_lean → game_theory_lean PIVOT R6)` |
| **`lakefile.lean` modification** | **AUCUNE** — `globs := #[`StableMarriage.*]` auto-discovery sibling `_en.lean` (C502-L2 precedent, identique c.420/c.421/c.422) |
| **`--body-file` strict** | JAMAIS `--body` (C403-L1 anti-backtick stripping) |

## Preuve du contenu préservé

Import-block sha256 byte-identique FR ↔ EN sur les 10 imports (sibling root aggregator re-export pattern) :

```
FR import-block sha256: 1690e55fb01f2ac9ebc2af9637defff5fb1ea38e0c7a0ab095824c668a5cbd02
EN import-block sha256: 1690e55fb01f2ac9ebc2af9637defff5fb1ea38e0c7a0ab095824c668a5cbd02
Structural mirror: PASS
```

L'invariant 0 sorry code-only est préservé FR ↔ EN (le seul `sorry` substring est dans le docstring du FR canonical).

**Note méthodologique** : l'anti-§D byte-identity (L298) vise les fichiers avec `namespace`/`end` markers + theorem signatures + proof bodies. Les root aggregators (imports-only, sans namespace) sont des **import-mirrors** : leur substance = liste d'imports, qui doit être byte-identique entre siblings. Le structural mirror ci-dessus vérifie exactement cet invariant pour les root aggregators.

## Acceptation

| Critère | Statut |
|---------|--------|
| Anti-§D byte-identity (adapté root aggregator) | ✓ structural mirror import-block sha256 identique |
| LF-only strict | ✓ (CR=0 sur les 2 fichiers) |
| MD047 trailing newline | ✓ |
| 0 sorry invariant FR↔EN | ✓ |
| Branch rebase frais `origin/main` @ `d477a8634` | ✓ |
| `lakefile.lean` non touché | ✓ (`globs := #[`StableMarriage.*]` auto-discovery, C502-L2) |
| `lake build SUCCESS` local | **DELEGATED to po-2026** : po-2023 sans env Lean WSL local (cf `lean-merge-discipline.md` regle 1) ; CI Lean GitHub Actions = proof canonique per `C455-1 cold-build gate` |
| Lean CI GitHub Actions post-push | **À vérifier post-push** (proof canonique du merge per C455-1) |

## Refs croisées

- **EPIC #4980** — convention i18n sibling pair (ratifiée 2026-07-04, addendum mécanisme FR/EN inclus)
- **EPIC #4365** — Lean infra (anti-proliferation GameTheory 6->2, regroupement lakes cohesifs)
- **PR #6175** — CooperativeGames.lean + CooperativeGames_en.lean precedent (root aggregator pattern, c.357)
- **PR #6457** — c.427 lakefile.lean fix (`#6419` Lake require order — débloque game_theory_lean build)
- **PR #6454** — c.426 MacroCell (14ᵉ sibling conway_lein, pattern (b'))
- **PR #6464** — c.428 Hashlife (15ᵉ sibling conway_lein, pattern (b))
- **#6116** — CGTTour_en débloqué par c.427 lakefile fix

## Anti-patterns évités

- ✅ Pas de force push, pas de direct main push (L143 SAFE)
- ✅ Branch `i18n/c429-stablemarriage-4980` (nommée vers sujet réel)
- ✅ Worktree isolé `D:/dev/CoursIA-c429` (sécurité R3 atomique)
- ✅ `git auth switch -u jsboige` ONLY for push, restore `jsboigeEpita` after (C492-L2)
- ✅ `--body-file` (JAMAIS `--body`, C403-L1 anti-backtick stripping)
- ✅ Pas de `Closes #X` partiel (R4) — issue EPIC ouverte, `See #4980` plus approprié ; PR ajoute un sibling, l'EPIC reste ouverte pour les autres siblings
- ✅ Header FR canonical `StableMarriage.lean` (33L, mono-lingual FR docstring) PRESERVED verbatim
- ✅ Pas de bloc bilingue inline dans le sibling EN (Option B rejetée 2026-07-04)
- ✅ LF-only + MD047 trailing newline vérifiés Python byte-level
- ✅ Pas de code Lean source touché (uniquement ajout fichier sibling EN)
- ✅ Pas de lakefile.lean modifié (C502-L2 : `globs := #[`StableMarriage.*]` auto-discovery `_en.lean`)

## Pivot R6 anti-monotonie (mandat user 2026-07-06)

c.426-c.428 = 3 cycles conway_lean (MacroCell, lakefile fix, Hashlife). **R6 anti-monotonie** : c.429 PIVOTE vers **`game_theory_lean`** (autre famille Lean) tout en restant sur EPIC #4980 i18n. Variété R5.4b MUST respectée.

Justification du choix `StableMarriage.lean` :
- **Éligibilité** : mono-lingual FR canonical (PAS bilingual inline legacy comme `SocialChoice.lean`, EXCLU per C414-L2)
- **Taille modeste** : 33L, import-block simple
- **Lakfile pattern éprouvé** : `globs := #[`StableMarriage.*]` auto-discovery `*_en.lean` siblings (5 sub-modules déjà migrés : `Definitions`, `GSState`, `Lemmas`, `Lattice`, `GaleShapley`)
- **EPIC #4365** : continuation directe du regroupement lakes cohesifs GameTheory

## Note pour le reviewer (`lean-merge-discipline.md` regle 1)

**`lake build SUCCESS` local OBLIGATOIRE avant merge** (incident 2026-05-10 merge #866 sur claim non-vérifié → revert #885, 1 cycle perdu). Le claim « lake build SUCCESS Xs » dans le body PR n'est PAS suffisant. **Pas d'env Lean local sur po-2023** : dispatcher **po-2026** avec build log complet + `grep -c sorry` avant/après (invariant 0/0) + diff sur import-block (sha256 byte-identique FR↔EN, 0 code Lean source touchée).

**Alternative acceptable** : `Lean CI (game_theory_lean)=pass` sur GitHub Actions = proof canonique per `C455-1 cold-build gate` (WSL elan absent localement → CI Lean = preuve canonique du merge).

## Note technique Pattern root aggregator

Ce sibling utilise le **pattern root aggregator** (imports-only, sans `namespace` block), distinct des 4 patterns catalog previously :
- **(a) simple single-level** (c.420-c.424 knot_lein satellites) — `namespace Foo` × `Foo_en` mais appliqué à des sub-modules avec namespace
- **(b) nested multi-segment** (c.415-c.419, c.425, c.428 conway_lein) — `Conway > Life` × `Conway_en > Life_en`
- **(b') nested triple-segment + re-ouvert** (c.426 MacroCell)
- **(c) nested single-segment INDEX** (c.422 MathlibPrerequisites)

**Pattern root aggregator** (PR #6175 CooperativeGames precedent + c.429 StableMarriage) :
- **Pas de namespace** : agrégateur au root du lake
- **Substance = import-block** : la liste des imports des sub-modules
- **Mirror pattern** : FR canonical importe `Foo` modules, EN sibling importe `Foo` modules aussi (même structure car root aggregator re-export les deux namespaces `Foo` et `Foo_en` via les sous-modules)
- **Docstring differs** : seul le docstring change entre FR et EN, byte-identity porte sur le bloc d'imports uniquement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
