### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to SymbolicAI cluster

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-7b-Examples.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-7b-Examples.ipynb
@@ -2378,7 +2378,8 @@
     "\n",
     "**Indice** : Utilisez une comprehension de liste pour filtrer les succes, puis\n",
     "`sum() / len()` pour les moyennes. Gerez le cas ou la liste est vide.\n"
-   ]
+   ],
+   "id": "cell-c817b869"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
@@ -2613,7 +2613,8 @@
     "construisez un graphe RDF complet et serialisez-le en Turtle.\n",
     "\n",
     "**Indices** : utilisez `NamespaceMap`, `UriFactory`, et `CompressingTurtleWriter`."
-   ]
+   ],
+   "id": "cell-01751f78"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
@@ -967,7 +967,8 @@
      "name": "stdout",
      "text": "Exercice 2 a completer : RBL robuste au bruit (nTrials=10) -> False.\r\n"
     }
-   ]
+   ],
+   "id": "cell-67d68a8d"
   },
   {
    "cell_type": "code",
@@ -997,7 +998,8 @@
      "name": "stdout",
      "text": "Exercice 3 a completer : seuil de desapprentissage (N=5) -> 1 regle(s) conservee(s).\r\n"
     }
-   ]
+   ],
+   "id": "cell-711161da"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
@@ -941,7 +941,8 @@
      "name": "stdout",
      "text": "Exercice 2 a completer : profondeur de la clause bottom (depth 1 vs 3).\r\n"
     }
-   ]
+   ],
+   "id": "cell-d79cad6e"
   },
   {
    "cell_type": "code",
@@ -976,7 +977,8 @@
      "name": "stdout",
      "text": "Exercice 3 a completer : tolerance au bruit (k=1 negatif autorise).\r\n"
     }
-   ]
+   ],
+   "id": "cell-5b05ed18"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (6 ids across 4 notebooks) to the `SymbolicAI` family — part of the v4.5 cell-id gap sweep (see #6257). Drains the remaining SymbolicAI gaps (Lean, SemanticWeb, SymbolicLearning sub-series).

| Notebook | ids added |
|----------|-----------|
| `SymbolicAI/Lean/Lean-7b-Examples.ipynb` | 1 |
| `SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb` | 1 |
| `SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb` | 2 |
| `SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb` | 2 |

Each was **already v4.5 (`nbformat_minor=5`)** but 1-2 cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on all 4**.
- `validate_pr_notebooks.py` **PASSED** (all 4).
- `git diff --stat`: `12 insertions(+), 6 deletions(-)` = **2N/N**.
- `execution_count` / `outputs`: unchanged (structural-only).

See #6257.
