### PR TITLE
docs(sudoku,#2876): restore French accents in Sudoku-1-Backtracking-Python cells 10 & 27

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -547,7 +547,7 @@
   {
    "cell_type": "code",
    "id": "faac36bc",
-   "source": "# EXERCICE : Verifier qu'une grille est valide\n\ndef is_valid_solution(grid: SudokuGrid) -> bool:\n    \"\"\"Verifie si une grille complete est une solution valide du Sudoku.\n\n    Args:\n        grid: Grille 9x9 censee etre complete\n\n    Returns:\n        True si la grille est une solution valide, False sinon\n    \"\"\"\n    # TODO etudiant : implementez la verification\n    # Etape 1 : Verifier qu'il n'y a pas de cases vides (0)\n    # Etape 2 : Verifier que chaque ligne contient 1-9 sans doublon\n    # Etape 3 : Verifier que chaque colonne contient 1-9 sans doublon\n    # Etape 4 : Verifier que chaque bloc 3x3 contient 1-9 sans doublon\n    return False  # TODO etudiant : remplacer par l'implementation\n\n# Test : la solution du puzzle de test doit etre valide\ngrid_check = SudokuGrid.from_string(test_puzzle)\nsolver_check = BacktrackingSolver()\nsolver_check.solve(grid_check)\nprint(f\"Solution valide (puzzle de test) : {is_valid_solution(grid_check)}\")  # True attendu\n\n# Test : le puzzle non resolu ne doit PAS etre valide\ngrid_unsolved = SudokuGrid.from_string(test_puzzle)\nprint(f\"Grille incomplete valide : {is_valid_solution(grid_unsolved)}\")  # False attendu",
+   "source": "# EXERCICE : Vérifier qu'une grille est valide\n\ndef is_valid_solution(grid: SudokuGrid) -> bool:\n    \"\"\"Vérifie si une grille complète est une solution valide du Sudoku.\n\n    Args:\n        grid: Grille 9x9 censée être complète\n\n    Returns:\n        True si la grille est une solution valide, False sinon\n    \"\"\"\n    # TODO étudiant : implémentez la vérification\n    # Étape 1 : Vérifier qu'il n'y a pas de cases vides (0)\n    # Étape 2 : Vérifier que chaque ligne contient 1-9 sans doublon\n    # Étape 3 : Vérifier que chaque colonne contient 1-9 sans doublon\n    # Étape 4 : Vérifier que chaque bloc 3x3 contient 1-9 sans doublon\n    return False  # TODO étudiant : remplacer par l'implémentation\n\n# Test : la solution du puzzle de test doit être valide\ngrid_check = SudokuGrid.from_string(test_puzzle)\nsolver_check = BacktrackingSolver()\nsolver_check.solve(grid_check)\nprint(f\"Solution valide (puzzle de test) : {is_valid_solution(grid_check)}\")  # True attendu\n\n# Test : le puzzle non résolu ne doit PAS être valide\ngrid_unsolved = SudokuGrid.from_string(test_puzzle)\nprint(f\"Grille incomplète valide : {is_valid_solution(grid_unsolved)}\")  # False attendu",
    "metadata": {},
    "execution_count": 5,
    "outputs": [
@@ -556,7 +556,7 @@
      "output_type": "stream",
      "text": [
       "Solution valide (puzzle de test) : False\n",
-      "Grille incomplete valide : False\n"
+      "Grille incomplète valide : False\n"
      ]
     }
    ]
@@ -1525,7 +1525,7 @@
     "                    best = (r, c, possible)\n",
     "                    best_count = len(possible)\n",
     "                    if best_count == 0:\n",
-    "                        return best  # Echec immediat\n",
+    "                        return best  # Échec immédiat\n",
     "\n",
     "    return best\n",
     "\n",
@@ -1533,21 +1533,21 @@
     "    \"\"\"Compte le nombre de solutions d'un puzzle Sudoku.\n",
     "\n",
     "    Args:\n",
-    "        grid: Grille a resoudre (ne doit pas etre modifiee)\n",
-    "        max_solutions: Nombre max de solutions a chercher (pour eviter les calculs infinis)\n",
+    "        grid: Grille à résoudre (ne doit pas être modifiée)\n",
+    "        max_solutions: Nombre max de solutions à chercher (pour éviter les calculs infinis)\n",
     "\n",
     "    Returns:\n",
-    "        Nombre de solutions trouvees (plafonne a max_solutions)\n",
+    "        Nombre de solutions trouvées (plafonné à max_solutions)\n",
     "    \"\"\"\n",
-    "    # TODO etudiant : adaptez le backtracking pour compter toutes les solutions\n",
-    "    # au lieu de s'arreter a la premiere.\n",
+    "    # TODO étudiant : adaptez le backtracking pour compter toutes les solutions\n",
+    "    # au lieu de s'arrêter à la première.\n",
     "    # Indications :\n",
     "    #   1. Copiez la grille avec grid.clone()\n",
-    "    #   2. Ecrivez une fonction recursive qui explore toutes les branches\n",
-    "    #   3. Quand la grille est complete, retournez 1 (une solution trouvee)\n",
-    "    #   4. Si nb_solutions >= max_solutions, arretez prematurely\n",
-    "    #   5. Apres chaque essai, remettez la case a 0 (backtrack)\n",
-    "    return 0  # TODO etudiant : remplacer par l'implementation\n",
+    "    #   2. Écrivez une fonction récursive qui explore toutes les branches\n",
+    "    #   3. Quand la grille est complète, retournez 1 (une solution trouvée)\n",
+    "    #   4. Si nb_solutions >= max_solutions, arrêtez prematurely\n",
+    "    #   5. Après chaque essai, remettez la case à 0 (backtrack)\n",
+    "    return 0  # TODO étudiant : remplacer par l'implémentation\n",
     "\n",
     "\n",
     "# Test : un bon puzzle devrait avoir exactement 1 solution\n",


### PR DESCRIPTION
Restores accented French in code-cell comments/docstrings of two exercise stubs (`is_valid_solution` cell 10, `count_solutions` cell 27) in `Sudoku-1-Backtracking-Python.ipynb`.

## Scope (code-cell accents, #2876 residual)

Continues the [#2876](https://github.com/jsboige/CoursIA/issues/2876) code-cell accent rollout on Sudoku Python notebooks (1 notebook this PR, cadence 1 PR/lane/jour per MEMORY).

## Method (4-gate, cf MEMORY accent-restoration-2876)

1. **deaccent gate**: `unicodedata.normalize("NFD")` + strip category `Mn` → `deaccent(old)==deaccent(new)` proves accent-only change. Verified per-pair (23 pairs) AND per-cell.
2. **prose/comments ONLY**: exact full-phrase replacements on comment `# ...` and docstring prose. No identifiers, signatures, f-string variable names, or code symbols touched.
3. **source type preserved**: cell[10] source stays **str** (len 1159, matches origin), cell[27] source stays **list** (65 items, matches origin) — minimal diff, no structural churn.
4. **no CRLF**: `json.dumps(indent=1, ensure_ascii=False)` + `write_bytes` (LF).

## C.2 — output regeneration (real execution proof)

- **cell[10]**: source f-string changed (`Grille incomplete valide` → `Grille incomplete valide`), so the print OUTPUT must change. Regenerated via `papermill -k python3 --cwd MyIA.AI.Notebooks/Sudoku` (full notebook executes 33/33 cells, 0 errors), then **spliced only cell[10] outputs** into the target (avoids churning other cells + avoids papermill metadata path-leak). Output now reads `Grille incomplete valide : False`.
- **cell[27]**: only comments/docstrings changed; the executable body + `print(f"Nombre de solutions: {nb}")` are byte-identical → output `Nombre de solutions: 0` unchanged, execution_count preserved at 10 (no churn).

## Residual (out of scope)

`prematurely` (indication #4) left ASCII: correcting to French "prématurément" is a **spelling change** (ment↔ly, base letters differ), not accent-only — `deaccent("prématurément")="prematurement" ≠ "prematurely"`. Out of #2876 accent-only scope.

## Coexistence with #6465

[#6465](https://github.com/jsboige/CoursIA/pull/6465) (`enrich(nbformat,#6257)`: add v4.5 cell ids to Sudoku Python cluster) touches the same notebook but **different cells** (17 & 18 are the 2 missing ids; this PR touches 10 & 27). No content overlap; both can merge independently (trivial rebase for the second).

See #2876 (partial: code-cell accents, Sudoku Python notebook 1 of N).

Co-Authored-By: Claude <noreply@anthropic.com>