### PR TITLE
docs(probas): fix post-renum prose drift — Debugging is Infer-6 not 13 (Probas/Infer README)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -162,7 +162,7 @@ flowchart TD
     class DT decision;
 ```
 
-Le socle d'inference (1-12) se suit en séquence ; le notebook **13 (Debugging)** est transversal — il compare aussi les trois algorithmes (EP/VMP/Gibbs) et sert de référence dès qu'une inférence dysfonctionne. Les notebooks **14-19 (Frontières)** prolongent le corpus bayésien (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman, détection de rupture, analyse de survie). La **théorie de la décision** — utilité espérée, EVPI, MDPs, Thompson Sampling, plus les companions Lean (indice de Gittins) — forme désormais un **arc autonome** dans [`../DecisionTheory/DecInfer/`](../DecisionTheory/DecInfer/README.md), adossé au lake [`decision_theory_lean`](../decision_theory_lean/). Le détail notebook-par-notebook figure dans les sections détaillées ci-dessous.
+Le socle d'inference (1-12) se suit en séquence ; le notebook **Debugging (6)** y joue un rôle transversal — il compare aussi les trois algorithmes (EP/VMP/Gibbs) et sert de référence dès qu'une inférence dysfonctionne. Les notebooks **14-19 (Frontières)** prolongent le corpus bayésien (causalité, processus gaussiens, modèles hiérarchiques, filtre de Kalman, détection de rupture, analyse de survie). La **théorie de la décision** — utilité espérée, EVPI, MDPs, Thompson Sampling, plus les companions Lean (indice de Gittins) — forme désormais un **arc autonome** dans [`../DecisionTheory/DecInfer/`](../DecisionTheory/DecInfer/README.md), adossé au lake [`decision_theory_lean`](../decision_theory_lean/). Le détail notebook-par-notebook figure dans les sections détaillées ci-dessous.
 
 ---
 
@@ -905,9 +905,9 @@ Pour un guide complet, voir [Infer-6-Debugging](Infer-6-Debugging.ipynb).
 | Problème | Solution |
 | --- | --- |
 | `The type 'Variable' does not contain a definition for...` | Vérifier que le namespace `MicrosoftResearch.Infer` est importé. Le notebook 1 (Setup) couvre la configuration |
-| `Inference exception: Improper distribution` | Le modèle contient une boucle causale ou une observation contradictoire. Le notebook 13 (Debugging) détaille les stratégies de diagnostic |
+| `Inference exception: Improper distribution` | Le modèle contient une boucle causale ou une observation contradictoire. Le notebook 6 (Debugging) détaille les stratégies de diagnostic |
 | `Algorithm compilation failed` | Infer.NET compile un algorithme d'inférence par reflection. Vérifier que le modèle est dans une famille supportée (conjugué). Modèles non-conjugués nécessitent EP ou VMP |
-| Performance lente sur les grands modèles | Utiliser `InferenceEngine.Compiler.ShowGeneratedSource = true` pour inspecter le code généré. Le notebook 13 compare les algorithmes EP/VMP/Gibbs |
+| Performance lente sur les grands modèles | Utiliser `InferenceEngine.Compiler.ShowGeneratedSource = true` pour inspecter le code généré. Le notebook 6 compare les algorithmes EP/VMP/Gibbs |
 | `.NET kernel non disponible` | Installer .NET Interactive : `dotnet tool install --global Microsoft.dotnet-interactive` |
 
 ### Erreur de compilation


### PR DESCRIPTION
## Post-renum prose drift — internal contradiction in Probas/Infer/README.md

After the Infer renumbering (#5081 EPIC), **Debugging** moved from Infer-13 to **Infer-6**, and Infer-13 became **Crowdsourcing**. But 3 prose references still said "notebook 13 (Debugging)".

The README was **internally inconsistent**: line 903 already pointed to `[Infer-6-Debugging]` (correct), yet lines 908 + 910 in the *same* Troubleshooting table referenced "notebook 13 (Debugging)" for the same notebook, and line 165 called "13 (Debugging)" transversal.

### Fix (3 occurrences, narrative sense preserved — not a blind find-replace)

| Line | Before | After |
|---|---|---|
| 165 | "notebook **13 (Debugging)** est transversal" | "notebook **Debugging (6)** y joue un rôle transversal" |
| 908 | "Le notebook 13 (Debugging) détaille" | "Le notebook 6 (Debugging) détaille" |
| 910 | "Le notebook 13 compare les algorithmes EP/VMP/Gibbs" | "Le notebook 6 compare les algorithmes EP/VMP/Gibbs" |

**L165 phrasing note**: a bare "13->6" swap would break the logic — the sentence says the 1-12 socle "se suit en séquence" then names 13 as transversal (out-of-sequence). Since Debugging is now 6 (in-socle), I rephrased to "Debugging (6) y joue un rôle transversal" to keep the meaning that it's a transversal reference within the socle.

### Verified

- Line 903 (`[Infer-6-Debugging]`) was already correct → now consistent with 908/910.
- Infer-13 = Crowdsourcing correctly described at L470 (untouched).
- `grep "13 (Debugging)"` = **0 remaining**.
- Disk reality: 19 notebooks, Infer-6-Debugging + Infer-13-Crowdsourcing confirmed.

Markdown-only (C.3 exception, no re-exec). Content fix (factual error + internal contradiction), not a counter resync. Prior renum-drift PRs (#5880, #5849, #5153) cleaned other occurrences; this mops up the residual 3.

`See #5081` (renum EPIC), `See #3973` (README feuilles coherence).