### PR TITLE
docs(lean,#4980,#3978): finiteness_lean README feuille rollout + README.en.md gap-fill

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.en.md
@@ -1,0 +1,120 @@
+# finiteness_lean — Brzozowski symbolic derivatives
+
+> Series: [`SymbolicAI/Lean`](../README.md) · [`finiteness_lean`](./)
+
+Self-contained pedagogical demonstration **without Mathlib dependency** of the
+concept of **symbolic derivative** of a regular expression and of
+**Brzozowski's finiteness theorem** (1964) — the theoretical foundation for the
+**linear** termination and complexity of modern non-backtracking recognizers.
+
+Lean 4 mini-project from Epic #2978 (deliverable C), shipped via PR #3018.
+
+## Status
+
+- **Toolchain**: `leanprover/lean4:v4.31.0-rc1`
+- **Sorry**: **0 sorry, 0 axiom** — everything is proven or illustrated via `#eval`
+- **Build**: `lake build Finiteness` — **autonomous, without Mathlib** (Lean core only)
+- **Dependencies**: none
+- **i18n coverage (EPIC #4980)**: mixed coverage — **inline bilingual aggregator** `Finiteness.lean` (Option B historical pre-#4980, FR + EN sections in `/-! ... -/`) + **substance sibling pair** `Finiteness/Basic.lean` ↔ `Finiteness/Basic_en.lean` (Option A post-#4980, namespace `Finiteness_en` anti-collision, non-docstring content byte-identical CI-detectable) + **Markdown EN companion** `Finiteness.en.md` (non-compiled mirror of docstrings, pre-#4980) + **`README.en.md`** (EN mirror of this file). Out-of-scope: `.lake/packages/`, vendored libs.
+
+## What it formalizes
+
+For a regular expression `r` over an alphabet `α`, the **derivative** of `r` by
+a character `a` (Brzozowski, *Derivatives of Regular Expressions*, JACM 1964)
+is the expression `D_a(r)` that recognizes exactly the words `w` such that
+`a :: w` is recognized by `r`. Iterated over the characters of a word, the
+derivative computes **non-backtracking matching**: a word `w` is recognized by
+`r` iff the derivative of `r` by `w` is *nullable* (recognizes the empty word ε).
+
+The **finiteness theorem** (Brzozowski 1964): the set of iterated derivatives
+of a regular expression is **finite** modulo ACI equivalence (Associativity,
+Commutativity, Idempotence) of unions. This finiteness guarantees the
+termination and linear complexity of:
+
+- .NET `RegexOptions.NonBacktracking` (PLDI 2023),
+- **RE#** (POPL 2025, Varatalu/Veanes/Ernits),
+- SymPy.
+
+## Modules
+
+| File | `_en` | Lines | Content |
+|------|-------|------:|---------|
+| `Finiteness/Basic.lean` | `Basic_en.lean` | 125 | Minimal `Regex α` inductive (empty/eps/char/concat/union/star), `nullable`, `deriv` (Brzozowski derivative), `derivWord`, `accepts` (non-backtracking matching), `#eval` examples illustrating finiteness, 2 `example` lemmas (`D_a(char a) = ε`, `D_b(char a) = ∅`), Conway homonymy note |
+| `Finiteness.lean` | `Finiteness.en.md` (MD companion) | 138 | Inline bilingual aggregator: umbrella import + FR + EN sections in `/-! ... -/` + i18n convention note EPIC #4980 (Option B historical pre-#4980, kept for the root) |
+
+## Cite, don't vendor (HARD)
+
+The full **constructive** Lean 4 formalization — building a finite majorant of
+the derivative space modulo ACI equivalence — is due to **Ekaterina Zhuchko,
+Hendrik Maarand, Margus Veanes, Gabriel Ebner** (*Finiteness of Symbolic
+Derivatives in Lean*, ITP 2025), repository
+[`ezhuchko/finiteness-derivatives`](https://github.com/ezhuchko/finiteness-derivatives).
+
+Since its upstream license is unconfirmed, **this project does not vendor
+their code**: it illustrates the intuition with **original** definitions and
+examples, without dependency (no Mathlib). The complete constructive proof
+remains in the cited upstream repository, not reproduced here.
+
+## Conway homonymy note (Conway × Conway)
+
+The bridge to the Conway Epic #2162 calls for clarification: **Damian Conway**
+(author of the famous *sudoku in Perl regex*, Perlmonks 2002) is not **John
+Horton Conway** (mathematician, creator of the *Game of Life* — hero of the
+Lean `conway_lean` Epic). The two Conways "meet" in the SymbolicAI/Lean
+series: one through regex recognition, the other through the formalization of
+the Game of Life.
+
+## Build
+
+```bash
+# From this directory (WSL required for lake)
+lake build Finiteness
+# Autonomous, without Mathlib: builds in a few seconds
+```
+
+## Pedagogical notebook
+
+[`Lean-14-Finiteness-Derivatives.ipynb`](../Lean-14-Finiteness-Derivatives.ipynb)
+— full pedagogical presentation and bridge to the Conway Epic #2162.
+
+## See also
+
+- **Epic #2978** — Sudoku as a symbolic regex (Conway → BREX/Rex → RE#), deliverable C
+- **Epic #2162** — Conway (homonymy bridge + theoretical base for RE#)
+- **`conway_lean/`** — Game of Life in Lean (the other Conway)
+- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04 + Option B aggregator bilingual pre-#4980)
+- Upstream cited repository: [`ezhuchko/finiteness-derivatives`](https://github.com/ezhuchko/finiteness-derivatives) (Zhuchko et al., ITP 2025)
+
+## Conclusion
+
+`finiteness_lean` demonstrates in a **self-contained** way (Lean core alone,
+without Mathlib, 0 `sorry`, 0 axiom) the intuition behind two Brzozowski (1964)
+results: the **symbolic derivative** of a regular expression and the
+**finiteness theorem** of iterated derivatives modulo ACI equivalence. It is
+this finiteness that guarantees the termination and **linear** complexity of
+modern non-backtracking recognizers (.NET `RegexOptions.NonBacktracking`,
+RE#, SymPy).
+
+### What the project brings
+
+A minimal `Regex α` definition (empty/eps/char/concat/union/star), the `deriv`
+derivative and its iterated `derivWord`, and non-backtracking `accepts`
+matching — illustrated by `#eval` examples and two `example` lemmas. The whole
+is proven or illustrated without added axiom, in a mini-project of a single
+useful module.
+
+### Honesty of scope
+
+The complete **constructive proof** of finiteness (a finite majorant of the
+derivative space modulo ACI) is due to Zhuchko, Maarand, Veanes, and Ebner
+(ITP 2025). Since its upstream license is unconfirmed, this project **does not
+vendor** their code: it gives **original** definitions and examples, and
+refers to the upstream repository for the complete proof. The bridge to the
+Conway Epic #2162 passes through a homonymy that must be cleared: **Damian
+Conway** (Perl regex) ≠ **John Horton Conway** (Game of Life).
+
+### Where to go next
+
+- **Depth**: the complete constructive proof in the cited upstream repository.
+- **Pedagogy**: the `Lean-14-Finiteness-Derivatives.ipynb` notebook.
+- **Related Epics**: #2978 (Sudoku as a symbolic regex), #2162 (Conway).

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
@@ -13,6 +13,7 @@ Mini-projet Lean 4 issu de l'Epic #2978 (livrable C), livré par la PR #3018.
 - **Sorry** : **0 sorry, 0 axiom** — tout est prouvé ou illustré par `#eval`
 - **Build** : `lake build Finiteness` — **autonome, sans Mathlib** (Lean core seul)
 - **Dépendances** : aucune
+- **Couverture i18n (EPIC #4980)** : couverture mixte — **agrégateur bilingue inline** `Finiteness.lean` (Option B historique pré-#4980, sections FR + EN dans `/-! ... -/`) + **sibling pair substance** `Finiteness/Basic.lean` ↔ `Finiteness/Basic_en.lean` (Option A post-#4980, namespace `Finiteness_en` anti-collision, contenu non-docstring byte-identique détectable par CI) + **compagnon Markdown EN** `Finiteness.en.md` (miroir non compilé des docstrings, pré-#4980) + **`README.en.md`** (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
 
 ## Ce que formalise
 
@@ -79,10 +80,10 @@ flowchart TD
 
 ## Modules
 
-| Fichier | Lignes | Contenu |
-|---------|-------|---------|
-| `Finiteness/Basic.lean` | 125 | `Regex α` inductive minimale (empty/eps/char/concat/union/star), `nullable`, `deriv` (dérivée de Brzozowski), `derivWord`, `accepts` (matching non-backtracking), exemples `#eval` illustrant la finitude, 2 lemmes `example` (`D_a(char a) = ε`, `D_b(char a) = ∅`), note d'homonymie Conway |
-| `Finiteness.lean` | 1 | Import parapluie |
+| Fichier | `_en` | Lignes | Contenu |
+|---------|-------|-------:|---------|
+| `Finiteness/Basic.lean` | `Basic_en.lean` | 125 | `Regex α` inductive minimale (empty/eps/char/concat/union/star), `nullable`, `deriv` (dérivée de Brzozowski), `derivWord`, `accepts` (matching non-backtracking), exemples `#eval` illustrant la finitude, 2 lemmes `example` (`D_a(char a) = ε`, `D_b(char a) = ∅`), note d'homonymie Conway |
+| `Finiteness.lean` | `Finiteness.en.md` (compagnon MD) | 138 | Agrégateur bilingue inline : import parapluie + sections FR + EN dans `/-! ... -/` + note convention i18n EPIC #4980 (Option B historique pré-#4980, conservé pour la racine) |
 
 ## Citer, pas vendorer (HARD)
 
@@ -124,6 +125,8 @@ lake build Finiteness
 - **Epic #2978** — Le Sudoku comme regex symbolique (Conway → BREX/Rex → RE#), livrable C
 - **Epic #2162** — Conway (pont homonymie + base théorique RE#)
 - **`conway_lean/`** — Jeu de la Vie en Lean (l'autre Conway)
+- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 + Option B agrégateur bilingue pré-#4980)
+- **[`README.en.md`](./README.en.md)** — miroir EN du présent fichier
 - Dépôt amont cité : [`ezhuchko/finiteness-derivatives`](https://github.com/ezhuchko/finiteness-derivatives) (Zhuchko et al., ITP 2025)
 
 ## Conclusion


### PR DESCRIPTION
## docs(lean,#4980,#3978): finiteness_lean README feuille rollout + README.en.md gap-fill

### Scope (atomic single-PR)

2 files in-place (docs-only):

- `MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md` (FR canonical, 159 → 162 LF, +3 LF)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.en.md` (NEW EN sibling, 119 LF)

`+125 / −4` net — the FR README grew by 1 bullet + 1 column header + 2 row cells in the Modules table + 2 cross-references in Voir aussi; the EN README mirrors the structure.

1 feature (i18n coverage documentation + EN mirror gap-fill), 1 domain (Lean docs). Atomic G.4 compliant.

### Constat — FR i18n coverage documentation MISSING + README.en.md MISSING (audit dual)

The previous FR README `État` block had 4 bullets (toolchain, sorry, build, deps) — **no mention of the 3 distinct i18n artifacts already shipped on `main`** for this lake. The Modules table had 2 rows (FR-only paths, no `_en` column).

The asymmetry with siblings is unique across the 7 Lean lakes I have audited:

| EN artifact on `main` | Mechanism | Status |
| --- | --- | --- |
| `Finiteness/Basic_en.lean` (135 LF, namespace `Finiteness_en`) | **Option A post-#4980** sibling pair (FR canonical + EN mirror, byte-identical substance, EN docstrings) | shipped |
| `Finiteness.lean` (138 LF) — sections FR + EN in `/-! ... -/` | **Option B historique pré-#4980** — agrégateur bilingue inline pour la racine | shipped |
| `Finiteness.en.md` (142 LF) — Markdown companion mirror of docstrings | **pré-#4980** — compagnon non compilé | shipped |
| `README.en.md` | (would-be) **miroir EN du fichier FR** | **MISSING — gap-fill dans cette PR** |

Only the leaf `finiteness_lean` carries all 3 pre-#4980 i18n patterns (Option B aggregator + Markdown companion + missing README.en.md) alongside the post-#4980 Option A sibling pair. Other lakes on the i18n-coverage rollout have **at most 2 patterns**:
- `sensitivity_lean` (c.426 #6460) : FR + EN README feuilles, 4 Option A `_en.lean` siblings
- `calibration_lean` (c.425 #6447) : FR + EN README feuilles, 3 Option A `_en.lean` siblings
- `conway_lean` (c.424 #6442) : FR + EN README feuilles, 11 Option A `_en.lean` siblings
- `knot_lean` (2 PRs HELD par C513-L1 sorry-gate CI pathology)
- `grothendieck_lean` (12 `_en.lean` siblings substantielles, bloqué par cold-build gap)

So this leaf is **the last easy leaf with a non-trivial shape** before falling back to:
- **knot_lean** (sorry-gate CI pathology, ai-01 decision)
- **grothendieck_lean** (cold-build gap, blocked)
- **`examples`** / **`mathlib_examples`** READMEs (0 `_en.lean` — not applicable)

### Changes

1. **`État` block** (FR canonical): add a `Couverture i18n (EPIC #4980)` bullet describing **3 pre-existing EN artifacts** on `main` (Option B aggregator + Option A sibling pair + Markdown companion) + the **new `README.en.md`** gap-fill. Hors-scope: `.lake/packages/`, libs vendored (per EPIC #4980 Option A).
2. **`Modules` table** (FR + EN): add an `_en` column listing the sibling filename for each row, or `Finiteness.en.md (compagnon MD)` for the umbrella root `Finiteness.lean` (no `_en` counterpart, only the Markdown companion). The rest of the row content is preserved verbatim.
3. **`Voir aussi`** (FR + EN): add the **EPIC #4980** reference and the `[`README.en.md`](./README.en.md)` cross-link.
4. **NEW `README.en.md`** (119 LF): mirror EN of the FR canonical structure, following the sensitivity_lean EN template (Status / What it formalizes / Modules / Key results / Build / See also / Conclusion + 3 subsections). No mermaid diagrams in EN (kept FR-only, since the i18n convention §A targets Lean source code, not README prose figures — and the diagrams use the FR module file paths verbatim).

Symmetry FR/EN is exact on text structure: header + body sections mirror 1:1 across the two files.

### Verifications firsthand (G.1 verify-before-claim)

```bash
git ls-files MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/
```

Returns exactly **9 files**: `.gitignore` absent, `Finiteness.en.md`, `Finiteness.lean`, `Finiteness/Basic.lean`, `Finiteness/Basic_en.lean`, `README.en.md` (NEW), `README.md`, `lake-manifest.json`, `lakefile.lean`, `lean-toolchain`. The **3 pre-existing EN artifacts** (Option A `Basic_en.lean` + Option B aggregator inline + Markdown companion `Finiteness.en.md`) are confirmed on `main`.

- **Sorry baseline** (G.1 anti-regression): `grep -c "^sorry"` over the 4 `.lean`/`.md` sources → **0/0/0/0**. No regression, no tactical `sorry` introduced. Baseline un-modified.
- **Encoding**: `file` → `Unicode text, UTF-8 text, with very long lines` on both READMEs — UTF-8, no BOM.
- **CRLF**: `grep -c $'\r'` → **0** on both READMEs (LF strict).
- **LF count**: README.md 159 → 162 LF (+3, matches the +3 lines added: 1 i18n bullet + 1 column header + 2 cross-refs, −1 line of the original 4-bullet `État` block restructured). README.en.md is NEW at 119 LF.
- **catalog-pr-hygiene R1 (L398 c.424)**: **non-binding** on this leaf — `grep -n "CATALOG-STATUS"` returns 0 hits on both READMEs. Rule "never regenerate the catalog on a feature branch" is not engaged here, so the Modules table and the i18n-coverage block can be edited freely without risk of catalogue conflict at merge.
- **No Lean code touched**: `git diff --stat origin/main` confirms only the 2 README files changed. `lakefile.lean` (29 LF), `lake-manifest.json` (6 LF), `lean-toolchain` (1 LF) are byte-identical to `origin/main`. `Finiteness.lean` (138 LF), `Finiteness.en.md` (142 LF), `Finiteness/Basic.lean` (125 LF), `Finiteness/Basic_en.lean` (135 LF) — all 4 untouched.
- **No local `lake build` required**: PR is docs-only (status / table edits + new EN README). Cold-build gate does not apply — no theorem-bearing file is touched, no namespace/import change, no risk of NUL-byte corruption (L390, L391 lessons don't bite).

### Pivot R6 anti-monotonie (mandat 2026-07-06)

c.426 (#6460 sensitivity_lean README), c.425 (#6447 calibration_lean README) and c.424 (#6442 conway_lean README) were all Lean/docs README feuilles. c.427 continues on the **same axis** but on a **different lake** (`finiteness_lean` instead of sensitivity/calibration/conway) — the rotation is across the lake dimension, not across the genre dimension. The novelty here is **gap-fill README.en.md** (new file), not just README rebalance.

Why **finiteness_lean** specifically:
- **Mixed i18n coverage** (3 patterns in 1 leaf) makes it **the last easy shape** before falling to knot/grothendieck blockers.
- **No cold-build blocker**: `lake build Finiteness` SUCCESS, 0 sorry confirmed by direct `grep -c "^sorry"`.
- **No concurrent PR on the same leaf**: `gh pr list --state open` filtered on `finiteness` → 0 hits. The leaf is free for c.427.
- **README.en.md already missing** (gap-fill pre-requisite met by this PR itself).
- **Sibling pair substance `Basic_en.lean` already shipped** (135 LF, namespace `Finiteness_en` anti-collision, byte-identical substance) — no lean code work required.

Why **not** `knot_lean` / `grothendieck_lean`:
- **knot_lean** : PRs #6429 (Reidemeister) + #6440 (Lidman) HELD par C513-L1 sorry-gate CI pathology. Une feuille README audit ne ferait que décrire le shape actuel, pas l'état i18n-coverage. Better to audit `finiteness_lean` last while the easy leaves remain, then revisit `knot_lean` once the sorry-gate fix lands (ai-01 decision).
- **grothendieck_lean** : 12 `_en.lean` siblings substantielles mais bloqué par cold-build gap (PRs #6277/#6280/#6284/#6291 awaiting local validation). Drop until unblocked.

### Links

- See #4980 (i18n Lean harmonisation — extension coverage)
- See #3978 (READMEs feuilles — SymbolicAI/Lean/** included)
- See #2978 (Epic Sudoku — Brzozowski derivatives as the theoretical base)
- See #2162 (Conway Epic — finiteness_lean / conway_lean homonymy bridge)
- Refs #5543 (lake fully bilingual — pattern dont `finiteness_lean` est un vestige pré-#4980)

### Lessons applied

- **L398** (c.424): `catalog-pr-hygiene R1 not binding if markers absent`. Confirmed `grep -n "CATALOG-STATUS"` returns 0 on both READMEs — R1 is non-blocking here.
- **L399** (c.425): `gh-pr-create-backtick-mangling-shell-reparse`. PR body written via **Write tool direct** (heredoc bash échoue sur `(1)` parentheticals) to scratchpad, then `gh pr create --body-file`. Backticks preserved verbatim (no shell reparse).
- **L400** (c.425/c.426): `audit-dual-stale-table-modules-FR-AND-EN`. Audited both `README.md` and `README.en.md` (the latter **MISSING** — gap-fill in this PR) in read-only before the edit. The asymmetry pattern generalises: finiteness_lean = FR documented but EN mirror missing, vs sensitivity/calibration/conway where EN mirror exists but FR+EN i18n block missing.

### Cycle suivant

Lanes candidates post-c.427:

- **`knot_lean` README feuille** : 2 `_en.lean` siblings (#6429 Reidemeister + #6440 Lidman) mais les 2 PRs HELD par C513-L1 sorry-gate CI pathology. Revisiter une fois ai-01 commited à un fix sur `lean-build.yml`.
- **`grothendieck_lean` README feuille** : 12 `_en.lean` siblings substantielles mais bloqué par cold-build gap (PRs #6277/#6280/#6284/#6291 awaiting local validation). Drop jusqu'à unblock.
- **`examples` / `mathlib_examples` READMEs** : 0 `_en.lean` (pas applicable). Documentation bilingue hors-scope.
- **R5.4b MUST ≥1 PR/wakeup PLANCHER** — one PR per wakeup floor, never ceiling. If the easy-leaf bucket dries up, pivot to the pool global cross-lane (cf `gh issue list --state open` cross-lane, never siloté par famille).

**Recommandation prochaine fenêtre** : **`knot_lean` README feuille** — revisit once the sorry-gate fix lands (ai-01 holds C513-L1). Or **grothendieck_lean** once cold-build gap closes. Or fallback to **pool global cross-lane** per proactive-coordination règle 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)