### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to GameTheory-4c-NashExistence

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
@@ -2898,7 +2898,8 @@
      "name": "stdout",
      "text": "Exercice 2 a completer : dynamique alternee vs simultanee.\r\n"
     }
-   ]
+   ],
+   "id": "cell-c8d54e45"
   },
   {
    "cell_type": "code",
@@ -2933,7 +2934,8 @@
      "name": "stdout",
      "text": "Exercice 3 a completer : verificateur d'hypothese de Brouwer.\r\n"
     }
-   ]
+   ],
+   "id": "cell-5bd6f76c"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (2 ids) to `GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb` — the freshly-added Nash existence exercises notebook (see commit `578865bb4`, "GT-4c Nash exercises"). Part of the v4.5 cell-id gap sweep (see #6257).

| Notebook | ids added |
|----------|-----------|
| `GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb` | 2 |

Already v4.5 (`nbformat_minor=5`) but 2 cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit.

## Note: GameTheory-2-NormalForm-Csharp-Part2 intentionally NOT touched

This sibling notebook (4 missing ids) has **non-standard .NET source serialization** (CRLF `\r\n` + blank-line source elements, round-trip mismatch of 72 bytes) — the `.NET notebook newline source corruption` pattern (#5005). Forcing ids onto it would mask the corruption with a larger-than-expected diff. Skipped per canonical round-trip-fidelity gate; warrants a dedicated investigation.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED**.
- `validate_pr_notebooks.py` **PASSED**.
- `git diff --stat`: `4 insertions(+), 2 deletions(-)` = **2N/N**.
- `execution_count` / `outputs`: unchanged (structural-only).

See #6257.
