### PR TITLE
fix(lean-ci): exclude *_en.lean i18n siblings from sorry scan (C513-L1)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -74,7 +74,15 @@ jobs:
         BASELINE="${{ inputs.sorry-baseline }}"
         echo "=== Sorry inventory for ${{ inputs.display-name }} (mode: $MODE, baseline: $BASELINE) ==="
         SORRY_TOTAL=0
-        for f in $(find . -name '*.lean' -not -path './.lake/*'); do
+        # Exclude i18n English siblings `*_en.lean` from the sorry scan: they are
+        # byte-identical mirrors of their FR counterpart (only docstrings/comments
+        # differ, and `real` mode strips comments before counting), so their sorries
+        # are DUPLICATES of the FR file's, not new debt. Counting both double-inflates
+        # the total above baseline (e.g. knot_lean: Reidemeister.lean(2) +
+        # Reidemeister_en.lean(2) => 19 > baseline 17, a false FAIL — C513-L1, #6429).
+        # FR<->EN divergence is caught separately by the i18n drift CI, so nothing is
+        # hidden. This exclusion only ever LOWERS a count, never breaks a green lake.
+        for f in $(find . -name '*.lean' ! -name '*_en.lean' -not -path './.lake/*'); do
           if [ -f "$f" ]; then
             case "$MODE" in
               raw)


### PR DESCRIPTION
## Problème (C513-L1)

Le sorry-scan du workflow réutilisable `lean-build.yml` énumère `find . -name '*.lean'` — **incluant les jumeaux i18n anglais `*_en.lean`**. Or un `_en.lean` est un miroir **byte-identique** de son homologue FR (drift-CI l'impose ; seuls docstrings/commentaires diffèrent, que le mode `real` strippe avant comptage). Ses `sorry` sont donc des **doublons** de ceux du fichier FR, **pas de la dette nouvelle**. Compter les deux gonfle le total au-dessus de la baseline → **FAIL fallacieux** pour tout lake ayant un jumeau `_en` porteur de sorries Phase-1.

**Cas concret — knot_lean** : `Reidemeister.lean`(2) + `Reidemeister_en.lean`(2) ⇒ 19 > baseline 17 ⇒ FAIL parasite qui **bloque le rollout `_en`** (#6429, #6440, #6476). Avec l'exclusion, le scan ne compte que le fichier FR canonique : Conway(8)+Invariant(5)+Lidman(2)+Reidemeister(2) = **17 = baseline**. ✅

## Fix (1 ligne)

```diff
- for f in $(find . -name '*.lean' -not -path './.lake/*'); do
+ for f in $(find . -name '*.lean' ! -name '*_en.lean' -not -path './.lake/*'); do
```

## Sûreté (prouvée sur les 118 `_en.lean`, 20 lakes)

- **117/118** ont un sibling FR exact ; le 1 restant (`repeated_games_lean/RepeatedGames_en.lean`) est un root-aggregator imports-only (0 sorry tactique).
- L'exclusion **ne fait jamais que baisser** un compte ⇒ elle peut rendre vert un false-FAIL mais **ne casse jamais un lake actuellement vert**.
- La divergence FR↔EN est captée par le **drift-CI i18n séparé** ⇒ aucun vrai sorry introduit dans un `_en` n'est masqué.

## Portée
Débloque le rollout knot `_en` (#6429/#6440/#6476) et tout futur sibling `_en` porteur de sorries Phase-1. Aucun changement de baseline requis (17 reste correct, désormais atteint).

See #6429