### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Probas cluster

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
@@ -3,17 +3,20 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# DecInfer-10-Thompson-Sampling : Bandits bayesiens par Infer.NET\n\n**Serie** : Programmation Probabiliste avec Infer.NET (10/10)\n**Duree estimee** : 60 minutes\n**Prerequis** : [Infer-7-Skills-IRT](../../Infer/Infer-7-Skills-IRT.ipynb) (posterior Beta), [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) (bandits, epsilon-greedy, UCB1)\n\n---\n\n## Objectifs\n\n- Modeliser un **bandit multi-bras** comme un programme probabiliste Infer.NET\n- Faire calculer au **moteur d'inference** le posterior Beta-Bernoulli de chaque bras (inference variationnelle / EP), plutot que d'appliquer la formule conjuguee a la main\n- Implementer le **Thompson Sampling** : jouer le bras dont l'echantillon posterior est le plus eleve\n- Mesurer le **regret cumule** face a epsilon-greedy et UCB1 (Prong-B : Thompson exploite l'incertitude posterior)\n- Etendre au **best-arm identification** : estimer P(bras i est le meilleur) par echantillonnage posterior\n\n## Navigation\n\n| Precedent | Suivant |\n|-----------|---------|\n| [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference](../../Infer/Infer-5-Causal-Inference.ipynb) |\n\n> **Pont inter-series** : le traitement des bandits en [DecInfer-8](DecInfer-8-Sequential.ipynb) section 8 implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (comptage des succes/echecs, formule conjuguee codee a la main). Ce notebook en est le versant **moteur** : Infer.NET calcule le posterior Beta de chaque bras par inference variationnelle, et Thompson echantillonne depuis ce posterior."
+   "source": "# DecInfer-10-Thompson-Sampling : Bandits bayesiens par Infer.NET\n\n**Serie** : Programmation Probabiliste avec Infer.NET (10/10)\n**Duree estimee** : 60 minutes\n**Prerequis** : [Infer-7-Skills-IRT](../../Infer/Infer-7-Skills-IRT.ipynb) (posterior Beta), [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) (bandits, epsilon-greedy, UCB1)\n\n---\n\n## Objectifs\n\n- Modeliser un **bandit multi-bras** comme un programme probabiliste Infer.NET\n- Faire calculer au **moteur d'inference** le posterior Beta-Bernoulli de chaque bras (inference variationnelle / EP), plutot que d'appliquer la formule conjuguee a la main\n- Implementer le **Thompson Sampling** : jouer le bras dont l'echantillon posterior est le plus eleve\n- Mesurer le **regret cumule** face a epsilon-greedy et UCB1 (Prong-B : Thompson exploite l'incertitude posterior)\n- Etendre au **best-arm identification** : estimer P(bras i est le meilleur) par echantillonnage posterior\n\n## Navigation\n\n| Precedent | Suivant |\n|-----------|---------|\n| [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference](../../Infer/Infer-5-Causal-Inference.ipynb) |\n\n> **Pont inter-series** : le traitement des bandits en [DecInfer-8](DecInfer-8-Sequential.ipynb) section 8 implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (comptage des succes/echecs, formule conjuguee codee a la main). Ce notebook en est le versant **moteur** : Infer.NET calcule le posterior Beta de chaque bras par inference variationnelle, et Thompson echantillonne depuis ce posterior.",
+   "id": "cell-065982ec"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 1. Exploration vs exploitation — pourquoi Thompson ?\n\nUn **bandit multi-bras** (Robbins, 1952) : K bras, chacun d'une recompense Bernoulli de moyenne inconnue theta_k. A chaque pas de temps on choisit un bras, on percoit une recompense 0/1, et on cherche a **maximiser la recompense cumulee**. Le dilemme :\n\n- **Exploiter** : jouer le bras qui semble le meilleur jusqu'ici.\n- **Explorer** : tester un bras peu joue pour estimer sa moyenne.\n\nTrois familles de politiques :\n\n| Politique | Strategie d'exploration |\n|-----------|------------------------|\n| **epsilon-greedy** | Avec proba epsilon, jouer un bras au hasard (exploration uniforme) |\n| **UCB1** (Auer et al., 2002) | Jouer le bras maximisant moyenne + bonus d'incertitude `sqrt(2 ln t / n_k)` |\n| **Thompson Sampling** (Thompson, 1933) | Maintenir un **posterior** sur chaque theta_k ; **echantillonner** theta_k dans son posterior ; jouer le max |\n\n**L'idee de Thompson** est subtilement bayesienne : au lieu d'explorer au hasard (epsilon-greedy) ou via un bonus frequentiste (UCB1), on quantifie l'incertitude sur chaque bras par une **distribution posterior**, et on joue proportionnellement a la probabilite que chaque bras soit le meilleur. Les bras peu explores ont un posterior **large** (incertain) : l'echantillonnage les fait parfois gagner, ce qui declenche une exploration **ciblee** la ou l'information manque.\n\n### La valeur ajoutee Infer.NET (non-doublon avec DecInfer-8)\n\nPour un bras Bernoulli de prior Beta(a, b), le posterior apres s succes et f echecs est **conjugue** : Beta(a+s, b+f). On pourrait le coder a la main (c'est l'exercice DecInfer-8 section 8). **Ce notebook ne le fait pas** : on declare le modele `theta ~ Beta ; reward ~ Bernoulli(theta)` et on laisse **Infer.NET inferer le posterior**. Pour ce cas conjugue le moteur recouvre exactement la forme analytique — mais la meme approche se generalise a des modeles **non conjugues** ou la formule fermee n'existe pas, la ou seul un moteur d'inference (EP, VMP) sait faire."
+   "source": "## 1. Exploration vs exploitation — pourquoi Thompson ?\n\nUn **bandit multi-bras** (Robbins, 1952) : K bras, chacun d'une recompense Bernoulli de moyenne inconnue theta_k. A chaque pas de temps on choisit un bras, on percoit une recompense 0/1, et on cherche a **maximiser la recompense cumulee**. Le dilemme :\n\n- **Exploiter** : jouer le bras qui semble le meilleur jusqu'ici.\n- **Explorer** : tester un bras peu joue pour estimer sa moyenne.\n\nTrois familles de politiques :\n\n| Politique | Strategie d'exploration |\n|-----------|------------------------|\n| **epsilon-greedy** | Avec proba epsilon, jouer un bras au hasard (exploration uniforme) |\n| **UCB1** (Auer et al., 2002) | Jouer le bras maximisant moyenne + bonus d'incertitude `sqrt(2 ln t / n_k)` |\n| **Thompson Sampling** (Thompson, 1933) | Maintenir un **posterior** sur chaque theta_k ; **echantillonner** theta_k dans son posterior ; jouer le max |\n\n**L'idee de Thompson** est subtilement bayesienne : au lieu d'explorer au hasard (epsilon-greedy) ou via un bonus frequentiste (UCB1), on quantifie l'incertitude sur chaque bras par une **distribution posterior**, et on joue proportionnellement a la probabilite que chaque bras soit le meilleur. Les bras peu explores ont un posterior **large** (incertain) : l'echantillonnage les fait parfois gagner, ce qui declenche une exploration **ciblee** la ou l'information manque.\n\n### La valeur ajoutee Infer.NET (non-doublon avec DecInfer-8)\n\nPour un bras Bernoulli de prior Beta(a, b), le posterior apres s succes et f echecs est **conjugue** : Beta(a+s, b+f). On pourrait le coder a la main (c'est l'exercice DecInfer-8 section 8). **Ce notebook ne le fait pas** : on declare le modele `theta ~ Beta ; reward ~ Bernoulli(theta)` et on laisse **Infer.NET inferer le posterior**. Pour ce cas conjugue le moteur recouvre exactement la forme analytique — mais la meme approche se generalise a des modeles **non conjugues** ou la formule fermee n'existe pas, la ou seul un moteur d'inference (EP, VMP) sait faire.",
+   "id": "cell-e1a1df7a"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 2. Configuration d'Infer.NET\n\nChargement du moteur d'inference probabiliste (meme `#r \"nuget\"` que toute la serie)."
+   "source": "## 2. Configuration d'Infer.NET\n\nChargement du moteur d'inference probabiliste (meme `#r \"nuget\"` que toute la serie).",
+   "id": "cell-cf83f140"
   },
   {
    "cell_type": "code",
@@ -46,12 +49,14 @@
     "using Microsoft.ML.Probabilistic.Compiler;\n",
     "Console.WriteLine(\"Infer.NET charge.\");"
    ],
-   "execution_count": 1
+   "execution_count": 1,
+   "id": "cell-eb337d48"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "Chargement du helper de visualisation des graphes de facteurs (Graphviz)."
+   "source": "Chargement du helper de visualisation des graphes de facteurs (Graphviz).",
+   "id": "cell-45c5e1c5"
   },
   {
    "cell_type": "code",
@@ -77,12 +82,14 @@
     "Console.WriteLine(\"FactorGraphHelper charge.\");\n",
     "Console.WriteLine($\"Graphviz disponible : {FactorGraphHelper.IsGraphvizAvailable()}\");"
    ],
-   "execution_count": 2
+   "execution_count": 2,
+   "id": "cell-b0f29d4f"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 3. Le modele Beta-Bernoulli d'un bras\n\nSoit un bras de probabilite de succes inconnue `theta`. Modele :\n\n- **Prior** : `theta ~ Beta(1, 1)` (uniforme sur [0,1] — ignorance totale).\n- **Vraisemblance** : `reward_i ~ Bernoulli(theta)` pour chaque tirage observe.\n\nApres avoir observe `s` succes et `f` echecs, on demande au moteur d'inference le posterior sur `theta`. Verifions qu'Infer.NET recouvre la forme conjuguee `Beta(1+s, 1+f)` (le moteur fait le calcul, nous declarons seulement le modele)."
+   "source": "## 3. Le modele Beta-Bernoulli d'un bras\n\nSoit un bras de probabilite de succes inconnue `theta`. Modele :\n\n- **Prior** : `theta ~ Beta(1, 1)` (uniforme sur [0,1] — ignorance totale).\n- **Vraisemblance** : `reward_i ~ Bernoulli(theta)` pour chaque tirage observe.\n\nApres avoir observe `s` succes et `f` echecs, on demande au moteur d'inference le posterior sur `theta`. Verifions qu'Infer.NET recouvre la forme conjuguee `Beta(1+s, 1+f)` (le moteur fait le calcul, nous declarons seulement le modele).",
+   "id": "cell-8be332b6"
   },
   {
    "cell_type": "code",
@@ -138,12 +145,14 @@
     "Console.WriteLine($\"  Formule conjuguee   = Beta({1+succ}, {1+fail}) ; mean = {theoMean:F3}\");\n",
     "Console.WriteLine($\"  => Le moteur recouvre la forme analytique (cas conjugue favorable).\");"
    ],
-   "execution_count": 3
+   "execution_count": 3,
+   "id": "cell-0629643f"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### 3.1 Graphe de facteurs du bras (Prong-A)\n\nLe meme modele, rendu en graphe de facteurs par Graphviz via le `FactorGraphHelper` (pattern de la serie, cf [DecInfer-3](../../Infer/Infer-3-Factor-Graphs.ipynb), [DecInfer-4](DecInfer-4-Multi-Attribute.ipynb)). Le noeud `theta` (Beta) alimente les facteurs Bernoulli des observations."
+   "source": "### 3.1 Graphe de facteurs du bras (Prong-A)\n\nLe meme modele, rendu en graphe de facteurs par Graphviz via le `FactorGraphHelper` (pattern de la serie, cf [DecInfer-3](../../Infer/Infer-3-Factor-Graphs.ipynb), [DecInfer-4](DecInfer-4-Multi-Attribute.ipynb)). Le noeud `theta` (Beta) alimente les facteurs Bernoulli des observations.",
+   "id": "cell-2a769548"
   },
   {
    "cell_type": "code",
@@ -264,12 +273,14 @@
     "Console.WriteLine(\"Modele Beta-Bernoulli : theta (Beta) -> 6 facteurs Bernoulli (un par tirage observe).\");\n",
     "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
    ],
-   "execution_count": 4
+   "execution_count": 4,
+   "id": "cell-702b3d96"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### 3.2 Convergence du posterior\n\nA mesure que les observations s'accumulent, le posterior se concentre autour de la vraie moyenne. Le moteur recalcule le posterior a chaque lot d'observations."
+   "source": "### 3.2 Convergence du posterior\n\nA mesure que les observations s'accumulent, le posterior se concentre autour de la vraie moyenne. Le moteur recalcule le posterior a chaque lot d'observations.",
+   "id": "cell-50c9bbca"
   },
   {
    "cell_type": "code",
@@ -359,12 +370,14 @@
     "}\n",
     "Console.WriteLine(\"  => Le posterior se resserre autour de la vraie moyenne quand N croit.\");"
    ],
-   "execution_count": 5
+   "execution_count": 5,
+   "id": "cell-5884b7f3"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 4. Reutiliser le moteur compile (problematique runtime)\n\nUn bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modele a chaque pas, Infer.NET **recompilerait** a chaque fois (~250 ms par appel). La solution : un modele a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (mesure : ~0,2 ms par re-inference).\n\nOn encapsule ce pattern dans une classe `BayesArm` : un bras dont Infer.NET calcule le posterior."
+   "source": "## 4. Reutiliser le moteur compile (problematique runtime)\n\nUn bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modele a chaque pas, Infer.NET **recompilerait** a chaque fois (~250 ms par appel). La solution : un modele a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (mesure : ~0,2 ms par re-inference).\n\nOn encapsule ce pattern dans une classe `BayesArm` : un bras dont Infer.NET calcule le posterior.",
+   "id": "cell-15063fa1"
   },
   {
    "cell_type": "code",
@@ -426,12 +439,14 @@
     "}\n",
     "Console.WriteLine(\"Classe BayesArm definie (modele masque, moteur reutilise).\");"
    ],
-   "execution_count": 6
+   "execution_count": 6,
+   "id": "cell-775a0d0a"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 5. Thompson Sampling multi-bras\n\nTrois bras de vraies moyennes `theta* = [0,2 ; 0,5 ; 0,8]` (inconnues de l'algorithme). A chaque pas de temps :\n\n1. Pour chaque bras, **Infer.NET infere** le posterior Beta.\n2. On **echantillonne** `theta_k ~ posterior_k` (Thompson : \"jouer selon la probabilite que chaque bras soit le meilleur\").\n3. On joue le bras d'echantillon maximum.\n4. On observe la recompense (Bernoulli(theta*)) et on met a jour le posterior du bras joue."
+   "source": "## 5. Thompson Sampling multi-bras\n\nTrois bras de vraies moyennes `theta* = [0,2 ; 0,5 ; 0,8]` (inconnues de l'algorithme). A chaque pas de temps :\n\n1. Pour chaque bras, **Infer.NET infere** le posterior Beta.\n2. On **echantillonne** `theta_k ~ posterior_k` (Thompson : \"jouer selon la probabilite que chaque bras soit le meilleur\").\n3. On joue le bras d'echantillon maximum.\n4. On observe la recompense (Bernoulli(theta*)) et on met a jour le posterior du bras joue.",
+   "id": "cell-5ce3ed6d"
   },
   {
    "cell_type": "code",
@@ -580,12 +595,14 @@
     "Console.WriteLine($\"Recompense totale = {totalRecompense}/{T} (optimal ~ {T*0.8:F0})\");\n",
     "Console.WriteLine($\"=> Thompson converge vers le bras 3 (le meilleur, theta*=0.8).\");"
    ],
-   "execution_count": 7
+   "execution_count": 7,
+   "id": "cell-6acb9561"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 6. Comparaison du regret cumule (Prong-B)\n\nLe **regret** mesure ce qu'on perd par rapport a jouer le bras optimal des le debut : `regret(t) = theta*_max - theta*(bras joue)`. On cumule sur T pas. On compare trois politiques, moyennées sur `N_runs` repetitions (graines differentes) :\n\n- **epsilon-greedy** (epsilon=0.1) : exploration uniforme aleatoire.\n- **UCB1** (Auer et al., 2002) : bonus d'incertitude frequentiste.\n- **Thompson** (via Infer.NET) : exploration bayesienne par echantillonnage posterior.\n\n**Hypothese (Prong-B)** : Thompson exploite l'incertitude posterior — il explore **la ou l'information manque**, pas au hasard — d'ou un regret cumule **inferieur** a epsilon-greedy."
+   "source": "## 6. Comparaison du regret cumule (Prong-B)\n\nLe **regret** mesure ce qu'on perd par rapport a jouer le bras optimal des le debut : `regret(t) = theta*_max - theta*(bras joue)`. On cumule sur T pas. On compare trois politiques, moyennées sur `N_runs` repetitions (graines differentes) :\n\n- **epsilon-greedy** (epsilon=0.1) : exploration uniforme aleatoire.\n- **UCB1** (Auer et al., 2002) : bonus d'incertitude frequentiste.\n- **Thompson** (via Infer.NET) : exploration bayesienne par echantillonnage posterior.\n\n**Hypothese (Prong-B)** : Thompson exploite l'incertitude posterior — il explore **la ou l'information manque**, pas au hasard — d'ou un regret cumule **inferieur** a epsilon-greedy.",
+   "id": "cell-6229c611"
   },
   {
    "cell_type": "code",
@@ -703,12 +720,14 @@
     "Console.WriteLine($\"=> Thompson ({regretFinal[2]:F1}) <= epsilon-greedy ({regretFinal[0]:F1}) : l exploration bayesienne\");\n",
     "Console.WriteLine($\"   ciblee par le posterior exploite l incertitude la ou l information manque (Prong-B).\");"
    ],
-   "execution_count": 8
+   "execution_count": 8,
+   "id": "cell-f341dab0"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 7. Extension — best-arm identification\n\nLe regret mesure la **performance** (cumul de recompenses). Une autre question : **identifier** le meilleur bras avec une garantie probabiliste. Thompson fournit naturellement `P(bras i est le meilleur)` : on echantillonne plusieurs fois les posteriors simultanement et on compte la frequence a laquelle chaque bras gagne. Quand cette probabilite depasse un seuil (ex. 0,95), on peut declarer le gagnant."
+   "source": "## 7. Extension — best-arm identification\n\nLe regret mesure la **performance** (cumul de recompenses). Une autre question : **identifier** le meilleur bras avec une garantie probabiliste. Thompson fournit naturellement `P(bras i est le meilleur)` : on echantillonne plusieurs fois les posteriors simultanement et on compte la frequence a laquelle chaque bras gagne. Quand cette probabilite depasse un seuil (ex. 0,95), on peut declarer le gagnant.",
+   "id": "cell-5da4782f"
   },
   {
    "cell_type": "code",
@@ -789,22 +808,26 @@
     "Console.WriteLine($\"=> Bras declare meilleur : bras {best+1} (theta*={vraiB[best]}).\");\n",
     "Console.WriteLine($\"   Si P > 0.95, on peut arreter : identification du meilleur bras avec confiance.\");"
    ],
-   "execution_count": 9
+   "execution_count": 9,
+   "id": "cell-211f6ecf"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 8. Limites honnetes\n\n- **Cas conjugue favorable** : pour un bandit Bernoulli, le posterior Beta est analytique. L'apport d'Infer.NET n'est pas la (le moteur recouvre la formule fermee) mais dans la **generalisation** a des modeles non conjugues (ex. bras Gaussiennes de variance inconnue, effets contextuels) ou seule l'inference approchee (EP/VMP) sait calculer le posterior.\n- **Cout d'inference** : chaque pas de Thompson requiert `K` inferences posteriors. Grace au modele masque reutilise (~0,2 ms/call), cela reste negligeable pour `K` petit et `T` modere. Pour un grand `K` (centaines de bras) ou un modele lourd, l'overhead devient un facteur — c'est la ou un posterior conjugue code a la main (cf DecInfer-8 section 8) garde sa place.\n- **Non-stationnarite** : si les vraies `theta*` changent au cours du temps, le posterior Beta s'accumule indefiniment et devient trop confident. Il faut alors introduire un **facteur d'oubli** (sliding window, discount) — voir exercice 2."
+   "source": "## 8. Limites honnetes\n\n- **Cas conjugue favorable** : pour un bandit Bernoulli, le posterior Beta est analytique. L'apport d'Infer.NET n'est pas la (le moteur recouvre la formule fermee) mais dans la **generalisation** a des modeles non conjugues (ex. bras Gaussiennes de variance inconnue, effets contextuels) ou seule l'inference approchee (EP/VMP) sait calculer le posterior.\n- **Cout d'inference** : chaque pas de Thompson requiert `K` inferences posteriors. Grace au modele masque reutilise (~0,2 ms/call), cela reste negligeable pour `K` petit et `T` modere. Pour un grand `K` (centaines de bras) ou un modele lourd, l'overhead devient un facteur — c'est la ou un posterior conjugue code a la main (cf DecInfer-8 section 8) garde sa place.\n- **Non-stationnarite** : si les vraies `theta*` changent au cours du temps, le posterior Beta s'accumule indefiniment et devient trop confident. Il faut alors introduire un **facteur d'oubli** (sliding window, discount) — voir exercice 2.",
+   "id": "cell-71669703"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 9. Exercices\n\nTrois exercices pour aller plus loin. Chaque stub s'execute sans erreur ; completez le code entre les `// TODO`.\n\n| # | Exercice | Concept |\n|---|----------|---------|\n| 1 | Ajouter un 4e bras et observer la convergence | Thompson sur K=4 |\n| 2 | Bandit non-stationnaire (facteur d'oubli) | Adaptation au changement |\n| 3 | Prior informatif Beta(50, 50) | Impact du prior sur l'exploration |"
+   "source": "## 9. Exercices\n\nTrois exercices pour aller plus loin. Chaque stub s'execute sans erreur ; completez le code entre les `// TODO`.\n\n| # | Exercice | Concept |\n|---|----------|---------|\n| 1 | Ajouter un 4e bras et observer la convergence | Thompson sur K=4 |\n| 2 | Bandit non-stationnaire (facteur d'oubli) | Adaptation au changement |\n| 3 | Prior informatif Beta(50, 50) | Impact du prior sur l'exploration |",
+   "id": "cell-c1d6e31d"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Exercice 1 — Ajouter un 4e bras et observer la convergence\n\nThompson Sampling se generalise de 3 a **K** bras. Ajoutez un 4e bras de vraie\nmoyenne 0,65 et relancez la boucle de selection. Observez comment le choix bascule\nde bras en bras puis se stabilise sur le meilleur des 4.\n\n**Objectif.** Etendre le modele a 4 bras et verifier que Thompson identifie le meilleur.\n\n**Indices.**\n- Etendez `vraiTheta` a 4 valeurs (par ex. `[0.3, 0.5, 0.7, 0.65]`).\n- Mettez `K = 4` et construisez 4 `BayesArm`, comme en section 5.\n- Reportez les tirages par bras et la recompense totale cumulee."
+   "source": "### Exercice 1 — Ajouter un 4e bras et observer la convergence\n\nThompson Sampling se generalise de 3 a **K** bras. Ajoutez un 4e bras de vraie\nmoyenne 0,65 et relancez la boucle de selection. Observez comment le choix bascule\nde bras en bras puis se stabilise sur le meilleur des 4.\n\n**Objectif.** Etendre le modele a 4 bras et verifier que Thompson identifie le meilleur.\n\n**Indices.**\n- Etendez `vraiTheta` a 4 valeurs (par ex. `[0.3, 0.5, 0.7, 0.65]`).\n- Mettez `K = 4` et construisez 4 `BayesArm`, comme en section 5.\n- Reportez les tirages par bras et la recompense totale cumulee.",
+   "id": "cell-84e0024e"
   },
   {
    "cell_type": "code",
@@ -827,12 +850,14 @@
     "// Etape 3 : reporter les tirages par bras et la recompense totale\n",
     "Console.WriteLine(\"Exercice 1 a completer : Thompson sur 4 bras (K=4).\");"
    ],
-   "execution_count": 10
+   "execution_count": 10,
+   "id": "cell-eb45673d"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Exercice 2 — Bandit non-stationnaire (facteur d'oubli)\n\nJusqu'ici les vraies moyennes sont fixes. En pratique elles peuvent **changer** : ici\nla meilleure bascule a `t = 100`. Implantez un **facteur d'oubli** : a chaque pas, ne\ngardez qu'une fraction des observations passees afin que le posterior s'adapte au\nchangement de regime.\n\n**Objectif.** Ajouter l'oubli au posterior et comparer le regret avec et sans oubli.\n\n**Indices.**\n- Modifiez `BayesArm.Observe` pour decaler/oublier les observations, ou ajoutez une\n  methode `Forget(double gamma)`.\n- Definissez `theta*(t)` qui change a mi-parcours (ex. le bras 1 devient meilleur apres `t=100`).\n- Comparez le regret avec et sans oubli sur la sequence non-stationnaire."
+   "source": "### Exercice 2 — Bandit non-stationnaire (facteur d'oubli)\n\nJusqu'ici les vraies moyennes sont fixes. En pratique elles peuvent **changer** : ici\nla meilleure bascule a `t = 100`. Implantez un **facteur d'oubli** : a chaque pas, ne\ngardez qu'une fraction des observations passees afin que le posterior s'adapte au\nchangement de regime.\n\n**Objectif.** Ajouter l'oubli au posterior et comparer le regret avec et sans oubli.\n\n**Indices.**\n- Modifiez `BayesArm.Observe` pour decaler/oublier les observations, ou ajoutez une\n  methode `Forget(double gamma)`.\n- Definissez `theta*(t)` qui change a mi-parcours (ex. le bras 1 devient meilleur apres `t=100`).\n- Comparez le regret avec et sans oubli sur la sequence non-stationnaire.",
+   "id": "cell-b2a05fe7"
   },
   {
    "cell_type": "code",
@@ -855,12 +880,14 @@
     "// Etape 3 : comparer le regret avec et sans oubli sur la sequence non-stationnaire\n",
     "Console.WriteLine(\"Exercice 2 a completer : bandit non-stationnaire avec facteur d oubli.\");"
    ],
-   "execution_count": 11
+   "execution_count": 11,
+   "id": "cell-1a9f9028"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Exercice 3 — Prior informatif Beta(50, 50) vs uniforme\n\nUn prior `Beta(50, 50)` exprime une forte conviction que theta vaut environ 0,5 ; un\nprior `Beta(1, 1)` est uniforme (sans information a priori). Comparez le regret des\ndeux : un prior informatif reduit-il l'exploration prematuree ?\n\n**Objectif.** Mesurer l'impact du prior sur la vitesse de convergence de Thompson.\n\n**Indices.**\n- `BayesArm` accepte des parametres `priorA` / `priorB`.\n- Creez deux jeux de bras — l'un avec `Beta(1,1)`, l'autre avec `Beta(50,50)` — et\n  mesurez le regret de chacun.\n- Interpretez : dans quels cas un prior informatif aide-t-il, et quand nuit-il ?"
+   "source": "### Exercice 3 — Prior informatif Beta(50, 50) vs uniforme\n\nUn prior `Beta(50, 50)` exprime une forte conviction que theta vaut environ 0,5 ; un\nprior `Beta(1, 1)` est uniforme (sans information a priori). Comparez le regret des\ndeux : un prior informatif reduit-il l'exploration prematuree ?\n\n**Objectif.** Mesurer l'impact du prior sur la vitesse de convergence de Thompson.\n\n**Indices.**\n- `BayesArm` accepte des parametres `priorA` / `priorB`.\n- Creez deux jeux de bras — l'un avec `Beta(1,1)`, l'autre avec `Beta(50,50)` — et\n  mesurez le regret de chacun.\n- Interpretez : dans quels cas un prior informatif aide-t-il, et quand nuit-il ?",
+   "id": "cell-02023ecc"
   },
   {
    "cell_type": "code",
@@ -883,12 +910,14 @@
     "// Etape 3 : comparer les regrets et interpreter (quand un prior informatif aide/nuit)\n",
     "Console.WriteLine(\"Exercice 3 a completer : impact du prior informatif Beta(50,50) sur Thompson.\");"
    ],
-   "execution_count": 12
+   "execution_count": 12,
+   "id": "cell-c31e1ca9"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 10. Synthese\n\n| Politique | Exploration | Calcul du posterior | Origine |\n|-----------|-------------|---------------------|---------|\n| **epsilon-greedy** | uniforme (proba epsilon) | aucun (moyenne empirique) | frequentiste |\n| **UCB1** | bonus d'incertitude `sqrt(2 ln t / n_k)` | aucun (moyenne empirique) | Auer et al. 2002 |\n| **Thompson** | echantillonnage posterior | **Infer.NET (EP/VMP)** | Thompson 1933 |\n\n### Ce qu'il faut retenir\n\n- **Thompson Sampling = jouer selon la probabilite que chaque bras soit le meilleur**, quantifiee par un posterior. Les bras incertains (posterior large) sont naturellement explores.\n- **Le moteur Infer.NET calcule le posterior** (section 3) : on declare `theta ~ Beta ; reward ~ Bernoulli(theta)` et le moteur infere `Beta(1+s, 1+f)`. Pour ce cas conjugue il recouvre la forme analytique ; l'interet est la **generalisation** aux modeles non conjugues.\n- **Prong-B PROVEN** : le regret cumule de Thompson est **inferieur** a epsilon-greedy (section 6) — l'exploration bayesienne ciblee par le posterior exploite l'incertitude la ou l'information manque, au lieu d'explorer au hasard. Le probleme n'est pas degenerere : la selection depend visiblement des posteriors.\n\n### Ponts\n\n- **DecInfer-8 section 8** : implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (formule conjuguee codee a la main). Ce notebook en est le versant **moteur**.\n- **DecInfer-8 section 10bis** : les belief-state updates en Infer.NET pour les POMDPs — meme idee d'inference posterior sequentielle, dans un cadre partiellement observable.\n- **References** : Thompson, W. R. (1933) *On the likelihood that one unknown probability exceeds another* ; Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002) *Finite-time analysis of the multiarmed bandit problem* ; Russo, D., Van Roy, D., Kazerouni, A., Osband, I. & Wen, Z. (2018) *A Tutorial on Thompson Sampling*.\n\n---\n\n[<- Infer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference ->](../../Infer/Infer-5-Causal-Inference.ipynb) | [Retour a la serie](README.md)"
+   "source": "## 10. Synthese\n\n| Politique | Exploration | Calcul du posterior | Origine |\n|-----------|-------------|---------------------|---------|\n| **epsilon-greedy** | uniforme (proba epsilon) | aucun (moyenne empirique) | frequentiste |\n| **UCB1** | bonus d'incertitude `sqrt(2 ln t / n_k)` | aucun (moyenne empirique) | Auer et al. 2002 |\n| **Thompson** | echantillonnage posterior | **Infer.NET (EP/VMP)** | Thompson 1933 |\n\n### Ce qu'il faut retenir\n\n- **Thompson Sampling = jouer selon la probabilite que chaque bras soit le meilleur**, quantifiee par un posterior. Les bras incertains (posterior large) sont naturellement explores.\n- **Le moteur Infer.NET calcule le posterior** (section 3) : on declare `theta ~ Beta ; reward ~ Bernoulli(theta)` et le moteur infere `Beta(1+s, 1+f)`. Pour ce cas conjugue il recouvre la forme analytique ; l'interet est la **generalisation** aux modeles non conjugues.\n- **Prong-B PROVEN** : le regret cumule de Thompson est **inferieur** a epsilon-greedy (section 6) — l'exploration bayesienne ciblee par le posterior exploite l'incertitude la ou l'information manque, au lieu d'explorer au hasard. Le probleme n'est pas degenerere : la selection depend visiblement des posteriors.\n\n### Ponts\n\n- **DecInfer-8 section 8** : implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (formule conjuguee codee a la main). Ce notebook en est le versant **moteur**.\n- **DecInfer-8 section 10bis** : les belief-state updates en Infer.NET pour les POMDPs — meme idee d'inference posterior sequentielle, dans un cadre partiellement observable.\n- **References** : Thompson, W. R. (1933) *On the likelihood that one unknown probability exceeds another* ; Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002) *Finite-time analysis of the multiarmed bandit problem* ; Russo, D., Van Roy, D., Kazerouni, A., Osband, I. & Wen, Z. (2018) *A Tutorial on Thompson Sampling*.\n\n---\n\n[<- Infer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference ->](../../Infer/Infer-5-Causal-Inference.ipynb) | [Retour a la serie](README.md)",
+   "id": "cell-4b9a1107"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
@@ -4524,7 +4524,8 @@
     "\n",
     "> **A retenir** : dans tout probleme de decision sous incertitude, se demander *quelle information pourrait changer ma decision, et a quel prix* est le reflexe fondamental que la VoI formalise. Le calcul est bayesien ; l'intuition est economique.\n",
     ""
-   ]
+   ],
+   "id": "cell-e557a1e0"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
@@ -1075,7 +1075,8 @@
     "### Et ensuite ?\n",
     "\n",
     "Le GP ouvre la voie aux **modèles hiérarchiques** (Infer-12) où plusieurs groupes partagent un prior commun, et aux **mélangees de Gaussiennes** (Infer-2) pour la densité. Pour les très grands jeux de données, l'approximation sparse est indispensable — c'est elle qui rend le GP utilisable en pratique."
-   ]
+   ],
+   "id": "cell-076f7eaf"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (31 ids across 3 notebooks) to the `Probas` family — part of the v4.5 cell-id gap sweep (see #6257). Covers the DecisionTheory/DecInfer sub-series + Infer-16.

| Notebook | ids added |
|----------|-----------|
| `Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb` | 1 |
| `Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb` | 29 |
| `Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb` | 1 |

Each was **already v4.5 (`nbformat_minor=5`)** but some cells lacked the required `id` field. DecInfer-10 (Thompson Sampling) is a substantial notebook hence 29 missing ids.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on all 3**.
- `validate_pr_notebooks.py` **PASSED** (all 3).
- `git diff --stat`: `62 insertions(+), 31 deletions(-)` = **exactly 2N/N** (N=31).
- **Byte-identity proof**: stripping id lines + comma-normalizing the diff yields **0 real content changes** (every `-` line is either a separator or a comma-addition matching a `+` line). `execution_count` / `outputs` / `source`: unchanged.
- Uniqueness: all 31 ids distinct within each notebook (md5-collision-free).

See #6257.
