### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Search Metaheuristics cluster

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
@@ -16,7 +16,8 @@
     "Le deuxième ingrédient — l'opérateur de Metropolis — vit dans [`MetropolisReinsertion.cs`](https://github.com/jsboige/MetaGeneticSharp/blob/main/src/MetaGeneticSharp.Domain/Reinsertions/MetropolisReinsertion.cs). Il est installé par défaut ** uniquement** par le compound SA (via `SimulatedAnnealing.GetDefaultReinsertion()`), et n'est jamais utilisé seul. Ce notebook le **débranche** de SA et le rebranche seul sur un **GA standard** (croisement de recombinaison, pas perturbation) : que devient l'acceptation de Metropolis quand on la greffe à l'étage « survie » d'un algorithme génétique ordinaire ?\n",
     "\n",
     "La thèse est celle qui parcourt toute la Partie 4 — **composants > métaphores** (Sørensen 2015) — poussée ici jusqu'au **démontage du recuit simulé lui-même** : SA n'est pas indivisible, son opérateur de survie est réutilisable dans une autre machine. La question falsifiable : l'acceptation `exp(Δ/T)` à la réinsertion aide-t-elle un GA à échapper aux optima locaux sur un paysage multimodal ? Spoiler honnête — **non** : le verdict, rapporté ci-dessous chiffres à l'appui, est négatif, et c'est précisément ce résultat négatif qui ferme la leçon."
-   ]
+   ],
+   "id": "cell-47fd9648"
   },
   {
    "cell_type": "markdown",
@@ -29,7 +30,8 @@
     "Dans SA, ce critère est **couplé** à une perturbation : l'enfant est un voisin gaussien du parent. On l'isole ici en gardant un **croisement de recombinaison standard** (`UniformCrossover`) : l'enfant est un recombinant de deux parents, pas un clone perturbé. Le critère de Metropolis s'applique alors à la **survie** : à chaque paire parent/enfant, on accepte l'enfant (même moins bon) avec la probabilité d'annealing. C'est un hybride « GA + survie annealée », distinct du recuit complet.\n",
     "\n",
     "> **Pourquoi le contrôle `FitnessBasedPairwiseReinsertion`.** `MetropolisReinsertion` apparie parent[i] ↔ enfant[i] (pairwise). Pour isoler *l'effet du critère d'acceptation*, le bon contrôle est donc un **pairwise greedy** — `FitnessBasedPairwiseReinsertion` (réutilisé par le compound FBI) — qui garde simplement le meilleur de chaque paire. Même appariement, même croisement/mutation/sélection : **seule la règle d'acceptation change**. La réinsertion `FitnessBasedElitistReinsertion` (défaut du GA) opère elle un **μ+λ global** (top-N sur parents ∪ enfants) : schéma de sélection différent, on la tient pour référence de contexte, pas pour contrôle de l'opérateur."
-   ]
+   ],
+   "id": "cell-a166fcdb"
   },
   {
    "cell_type": "code",
@@ -99,7 +101,8 @@
     "Console.WriteLine(\"  MetropolisReinsertion           (pairwise + annealing, compound SA) : \" + typeof(MetropolisReinsertion).Name);\n",
     "Console.WriteLine(\"  SimulatedAnnealing               (compound complet)            : \" + typeof(SimulatedAnnealing).Name);\n",
     "Console.WriteLine(\"  MetaGeneticAlgorithm .Reinsertion settable       : \" + typeof(MetaGeneticAlgorithm).Name);"
-   ]
+   ],
+   "id": "cell-b0567f0b"
   },
   {
    "cell_type": "code",
@@ -174,7 +177,8 @@
     "double smoke = -MakeGAWithReinsertion(Pairwise)(new OptimizerRequest(new SphereFitness(), KnownFunctionsBounds.For(typeof(SphereFitness)), dim, NFE));\n",
     "Console.WriteLine($\"Setup OK. PopSize={PopSize}, NFE={NFE} (gens={NFE/PopSize}), dim={dim}, seeds={string.Join(\", \",seeds)}.\");\n",
     "Console.WriteLine($\"Smoke GA+Pairwise/Sphere objectif={smoke:F3} (proche 0 = OK).\");"
-   ]
+   ],
+   "id": "cell-efd8ffc4"
   },
   {
    "cell_type": "markdown",
@@ -193,7 +197,8 @@
     "| `FitnessBasedElitistReinsertion` | μ+λ global | top-N | référence contexte |\n",
     "\n",
     "Les trois `Metropolis` partagent le **même appariement** que le contrôle `Pairwise` ; la différence est uniquement la règle d'acceptation (greedy → annealing). C'est cette comparaison qui isole l'opérateur. Le banc est seedé (`FastRandomRandomization.ResetSeed` avant chaque course) : les chiffres sont reproduisibles."
-   ]
+   ],
+   "id": "cell-3ac2858f"
   },
   {
    "cell_type": "markdown",
@@ -202,7 +207,8 @@
     "## Partie A — le témoin neutre : Sphere (unimodale)\n",
     "\n",
     "Sur Sphere (unimodale, lisse), tout déplacement qui n'améliore pas la fitness est une **montée** inutile : il n'y a pas d'optimum local à franchir. La prédiction de la théorie : l'acceptation de Metropolis n'a rien à accepter d'utile — accepter une montée ne fait que bruiter la convergence. Les `Metropolis` froid/moyen doivent donc **égaliser** le contrôle greedy, et le réglage chaud (beaucoup d'annealing) le dégrader (beaucoup de bruit). C'est notre témoin neutre : un problème où l'opérateur, par construction, **ne peut pas** aider."
-   ]
+   ],
+   "id": "cell-ca8cb9f4"
   },
   {
    "cell_type": "code",
@@ -280,14 +286,16 @@
     "    Console.WriteLine($\"{\"Elitist global (reference)\",-32}|{RunAvg(MakeGAWithReinsertion(Elitist), fit),10:F3}\");\n",
     "}\n",
     "RunBanc(new SphereFitness(), \"Sphere\");"
-   ]
+   ],
+   "id": "cell-5ec92d70"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "**Lecture (G.9).** Sur Sphere, le contrôle greedy et les `Metropolis` froid/moyen résolvent la fonction (objectif ≈ 0,01) : il n'y a pas de montée utile à accepter — c'est le **témoin neutre attendu**. Le réglage **chaud** dégrade pourtant nettement (≈ 0,10, soit ~8× le contrôle) : à force d'accepter des montées inutiles, il injecte du bruit dans une convergence facile. Leçon provisoire : sur un paysage unimodal, l'annealing ne sert à rien et trop d'annealing nuit. Le paysage multimodal dira si cela s'inverse."
-   ]
+   ],
+   "id": "cell-595cea55"
   },
   {
    "cell_type": "markdown",
@@ -296,7 +304,8 @@
     "## Partie B — le paysage discriminant : Rastrigin (fortement multimodale)\n",
     "\n",
     "Rastrigin ($\\sum [x_i^2 - 10\\cos(2\\pi x_i)] + 10n$) est une forêt régulière d'optima locaux séparés par des montées de fitness. Hypothèse naturelle à éprouver : un GA greedy pairwise se fige dans le premier bassin rencontré, tandis qu'un GA à survie annealée accepte, tant que T est chaud, des enfants moins bons — donc maintient la diversité et pourrait franchir les cols entre bassins. La question n'est pas de savoir si Rastrigin est résolu (à NFE = 5000 en dimension 5, aucun des opérateurs ne l'annule) mais **quel critère d'acceptation atteint le meilleur bassin**. Le tableau ci-dessous tranche — et il tranche **contre** l'hypothèse."
-   ]
+   ],
+   "id": "cell-2b76d735"
   },
   {
    "cell_type": "code",
@@ -363,7 +372,8 @@
    ],
    "source": [
     "RunBanc(new RastriginFitness(), \"Rastrigin\");"
-   ]
+   ],
+   "id": "cell-35497f89"
   },
   {
    "cell_type": "markdown",
@@ -372,7 +382,8 @@
     "**Lecture honnête (résultat négatif).** Le verdict **réfute** l'hypothèse d'évasion : sur Rastrigin, aucun réglage Metropolis n'améliore le contrôle greedy pairwise (1,19) — le froid (1,62) et le chaud (1,77) le dégradent nettement, le moyen (1,23) est dans le bruit. Accepter des enfants moins bons à la réinsertion n'aide pas le GA à franchir les cols ; cela l'écarte des bons bassins, et le réglage le plus chaud (le plus d'annealing) est le **pire**.\n",
     "\n",
     "**Pourquoi l'évasion échoue.** L'explication la plus naturelle tient à la sémantique du « voisin ». Dans SA, l'enfant est un **voisin** du parent (perturbation gaussienne isotrope) : accepter un voisin moins bon a le sens d'une exploration du voisinage. Ici l'enfant est un **recombinant** de deux parents (mosaïque par gène via `UniformCrossover`) : il n'est le voisin ni de l'un ni de l'autre. Accepter un recombinant moins bon n'est donc pas une exploration de voisinage — c'est du bruit injecté à la survie. Le bénéfice du recuit réside dans le **couplage** perturbation+acceptation, pas dans l'acceptation seule. (L'élitiste global μ+λ, référence 0,39, gagne encore : la sélection globale top-N est plus exploitative que tout schéma pairwise — mais ce n'est pas l'objet ; l'objet est la comparaison Metropolis-vs-Pairwise à appariement constant, et elle est négative.)"
-   ]
+   ],
+   "id": "cell-59a7ba9a"
   },
   {
    "cell_type": "markdown",
@@ -381,7 +392,8 @@
     "## Partie C — second multimodal : Ackley (puits central + rides fines)\n",
     "\n",
     "Ackley est l'autre paysage multimodal canonique : un grand puits central entouré de rides cosinus à période fine. On y reporte le même banc pour vérifier si le verdict négatif de Rastrigin se confirme ou si Ackley, à la géométrie différente (large puits plutôt que forêt régulière), répond autrement."
-   ]
+   ],
+   "id": "cell-669b0c7c"
   },
   {
    "cell_type": "code",
@@ -448,14 +460,16 @@
    ],
    "source": [
     "RunBanc(new AckleyFitness(), \"Ackley\");"
-   ]
+   ],
+   "id": "cell-8eed3bd0"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "**Lecture.** Même verdict qu'en Rastrigin : le Metropolis froid (2,46) est dans le bruit du contrôle greedy (2,74) — pas d'amélioration fiable ; le moyen (2,92) et surtout le chaud (4,32) dégradent. La géométrie différente d'Ackley ne renverse pas la conclusion : l'acceptation annealée détachée du couplage SA n'aide pas."
-   ]
+   ],
+   "id": "cell-3a23996f"
   },
   {
    "cell_type": "markdown",
@@ -464,7 +478,8 @@
     "## Partie D — la signature de température et la limite frozen\n",
     "\n",
     "L'effet de `MetropolisReinsertion` est piloté par le schedule $T_k = T_0 \\alpha^k$. On le trace sur 100 générations (= NFE/PopSize) : on voit le spectre `chaud persistant → gélification rapide`. La **limite frozen** ($T \\to 0$) est l'autre vérification de cohérence : quand T gèle, le critère `exp(Δ/T)` devient 0 pour toute montée — la **règle** d'acceptation dégénère en greedy. On la vérifie sur le témoin lisse Sphere : là, même si l'opérateur consomme un tirage RNG par évaluation (et diverge donc de la trajectoire du contrôle), la convergence lisse ramène les deux au même lieu. (Sur un paysage rude comme Rastrigin, la divergence de trajectoire domine et l'égalité numérique n'a plus de sens — d'où le choix du témoin lisse.)"
-   ]
+   ],
+   "id": "cell-717dde0a"
   },
   {
    "cell_type": "code",
@@ -620,7 +635,8 @@
     "Console.WriteLine($\"  Metropolis frozen = {frozenSphere:F4}\");\n",
     "Console.WriteLine($\"  Pairwise greedy   = {pairSphere:F4}\");\n",
     "Console.WriteLine($\"  Ecart |frozen - pairwise| = {Math.Abs(frozenSphere-pairSphere):F4} (proche = regle greedy confirmee ; residu = divergence trajectoire RNG).\");"
-   ]
+   ],
+   "id": "cell-88454e6e"
   },
   {
    "cell_type": "markdown",
@@ -637,7 +653,8 @@
     "3. **Le bénéfice du recuit est dans le couplage, pas dans l'acceptation seule.** SA marche parce que la perturbation propose un **voisin** du courant et l'acceptation anneale entre voisins ; les deux sont conjointement accordés. Détacher l'acceptation et la brancher sur un croisement de recombinaison (l'enfant = mosaïque de deux parents, pas un voisin) brise cette sémantique. C'est la leçon « composants > métaphores » dans sa forme la plus exigeante : on PEUT démonter SA, l'opérateur isolé FONCTIONNE sur le vrai moteur — mais il ne porte pas, à lui seul, le bénéfice du tout. Le tout est plus que la somme des pièces, et c'est précisément en démontant qu'on le prouve (écho de la synergie conditionnelle de MGS-11/14 : la composition n'est magique ni assemblée ni désassemblée).\n",
     "\n",
     "Le prolongement naturel n'en reste pas moins la **composition** : ayant isolé `MetropolisReinsertion`, on peut le recombiner ailleurs qu'en survie brute de GA — par exemple l'injecter comme étage d'exploration dans une île d'un archipel (MGS-4/11), où la diversité qu'il entretient pourrait payer autrement. L'opérateur, démonté, reste une brique disponible ; ce notebook dit seulement *où* il ne suffit pas."
-   ]
+   ],
+   "id": "cell-01e138dd"
   },
   {
    "cell_type": "markdown",
@@ -663,7 +680,8 @@
     "| Critère d'acceptation de Metropolis (recuit simulé) | Metropolis, N., Rosenbluth, A. W., Rosenbluth, M. N., Teller, A. H., & Teller, E. (1953) — « Equation of State Calculations by Fast Computing Machines », *Journal of Chemical Physics* 21(6). |\n",
     "| Recuit simulé en optimisation | Kirkpatrick, S., Gelatt, C. D., & Vecchi, M. P. (1983) — « Optimization by Simulated Annealing », *Science* 220(4598). |\n",
     "| Métaheuristiques = composants (pas métaphores) | Sørensen, K. (2015) — « Metaheuristics—the metaphor exposed », *Intl. Trans. in Operational Research* 22(1). doi:10.1111/itor.12001 |"
-   ]
+   ],
+   "id": "cell-f6fa769c"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb
@@ -986,7 +986,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Exercice 1 — Sensibilite a la tolerance tau\n\nLe taux de reussite depend du **rayon d'acceptation** `tau`. Re-tabulez les 4 methodes\nx 4 zooms pour `tau` dans `{ 0.03, 0.06, 0.12 }` et observez comment la **hierarchie des\nmethodes** bouge selon qu'on est strict ou tolerant.\n\n**Objectif.** Mesurer la sensibilite d'une metaheuristique au rayon de reussite.\n\n**Indices.**\n- Parametrez `Hit`/`Rate` pour accepter `tau` en argument, puis re-affichez la table de la section 4.\n- Un `tau` petit = critere strict (peu de methodes reussissent) ; un `tau` grand = tolerant.\n- Une methode robuste garde une hierarchie stable quand `tau` varie."
+   "source": "### Exercice 1 — Sensibilite a la tolerance tau\n\nLe taux de reussite depend du **rayon d'acceptation** `tau`. Re-tabulez les 4 methodes\nx 4 zooms pour `tau` dans `{ 0.03, 0.06, 0.12 }` et observez comment la **hierarchie des\nmethodes** bouge selon qu'on est strict ou tolerant.\n\n**Objectif.** Mesurer la sensibilite d'une metaheuristique au rayon de reussite.\n\n**Indices.**\n- Parametrez `Hit`/`Rate` pour accepter `tau` en argument, puis re-affichez la table de la section 4.\n- Un `tau` petit = critere strict (peu de methodes reussissent) ; un `tau` grand = tolerant.\n- Une methode robuste garde une hierarchie stable quand `tau` varie.",
+   "id": "cell-148b672c"
   },
   {
    "cell_type": "code",
@@ -1038,7 +1039,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Exercice 2 — Ajouter une baseline « hill-climber »\n\nAjoutez une **5e ligne** au tableau : un *hill-climber* (montee de gradient stochastique).\nDepart aleatoire, petits pas `(u, v) ± epsilon`, on garde le pas s'il monte. Meme budget\n`NFE = Pop * Gens` que les metaheuristiques. Ou se classe-t-il face a GA/PSO/WOA/EO ?\n\n**Objectif.** Comparer une recherche locale gloutonne aux metaheuristiques populationnelles.\n\n**Indices.**\n- 1 seul point courant, `NFE = Pop * Gens` evaluations, pas `epsilon ~ 0.05`, clamp `[0,1]`.\n- Un hill-climber est vite piege dans un optimum local sur un relief multimodal comme l'Everest.\n- C'est precisement ce qui justifie les metaheuristiques populationnelles (diversite)."
+   "source": "### Exercice 2 — Ajouter une baseline « hill-climber »\n\nAjoutez une **5e ligne** au tableau : un *hill-climber* (montee de gradient stochastique).\nDepart aleatoire, petits pas `(u, v) ± epsilon`, on garde le pas s'il monte. Meme budget\n`NFE = Pop * Gens` que les metaheuristiques. Ou se classe-t-il face a GA/PSO/WOA/EO ?\n\n**Objectif.** Comparer une recherche locale gloutonne aux metaheuristiques populationnelles.\n\n**Indices.**\n- 1 seul point courant, `NFE = Pop * Gens` evaluations, pas `epsilon ~ 0.05`, clamp `[0,1]`.\n- Un hill-climber est vite piege dans un optimum local sur un relief multimodal comme l'Everest.\n- C'est precisement ce qui justifie les metaheuristiques populationnelles (diversite).",
+   "id": "cell-315f2b63"
   },
   {
    "cell_type": "code",
@@ -1091,7 +1093,8 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Exercice 3 — Taux de reussite vs budget NFE\n\nFaites varier le **budget** `NFE` (par ex. `Pop * Gens` dans `{ 200, 450, 900, 1800 }`)\npour la WOA sur `everestRegion` et tracez (en ASCII ou en colonne) le taux de reussite\ncorrespondant. Le scaling est-il lineaire, sous-lineaire, ou a seuil ?\n\n**Objectif.** Etudier la convergence d'une metaheuristique en fonction du budget.\n\n**Indices.**\n- Ajustez `Gens = nfe / Pop` (gardez `Pop` fixe), relancez `Rate(everestRegion, ...)`.\n- Un seuil (`NFE` minimal pour atteindre le sommet) est plus informatif qu'une pente lineaire.\n- Comparez la forme de la courbe WOA a celle d'un hill-climber (exercice 2)."
+   "source": "### Exercice 3 — Taux de reussite vs budget NFE\n\nFaites varier le **budget** `NFE` (par ex. `Pop * Gens` dans `{ 200, 450, 900, 1800 }`)\npour la WOA sur `everestRegion` et tracez (en ASCII ou en colonne) le taux de reussite\ncorrespondant. Le scaling est-il lineaire, sous-lineaire, ou a seuil ?\n\n**Objectif.** Etudier la convergence d'une metaheuristique en fonction du budget.\n\n**Indices.**\n- Ajustez `Gens = nfe / Pop` (gardez `Pop` fixe), relancez `Rate(everestRegion, ...)`.\n- Un seuil (`NFE` minimal pour atteindre le sommet) est plus informatif qu'une pente lineaire.\n- Comparez la forme de la courbe WOA a celle d'un hill-climber (exercice 2).",
+   "id": "cell-ff527908"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (21 ids across 2 notebooks) to the `Search` Part4-Metaheuristics series — part of the v4.5 cell-id gap sweep (see #6257).

| Notebook | ids added |
|----------|-----------|
| `Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb` | 18 |
| `Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb` | 3 |

Each was **already v4.5 (`nbformat_minor=5`)** but some cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each.

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on both**.
- `validate_pr_notebooks.py` **PASSED** (both).
- `git diff --stat`: `42 insertions(+), 21 deletions(-)` = **exactly 2N/N** (N=21).
- **Byte-identity proof**: stripping id lines + comma-normalizing the diff yields **0 real content changes**. `execution_count` / `outputs` / `source`: unchanged.

See #6257.
