### PR TITLE
docs(lean,#4980,#3978): grothendieck_lean README feuille rollout (24 modules, 12 _en siblings)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -2,6 +2,14 @@
 
 Alexandre Grothendieck (1928-2014).
 
+## Status
+
+- **Toolchain**: `leanprover/lean4:v4.31.0-rc1`
+- **Sorry**: **0 sorry, 0 axiom** — all 24 modules are complete at creation (Parts 1-24 merged)
+- **Build**: `lake build Grothendieck` — compiles the 24 modules (~3350 lines)
+- **Dependencies**: Mathlib 4 (via `lakefile.lean`)
+- **i18n coverage (EPIC #4980)**: extended coverage — **24 FR-canonical `.lean` modules** + **12 `_en.lean` sibling mirrors** on `main` (`Calibration_en`, `CategoryAndSites_en`, `CoverageGen_en`, `DenseTopology_en`, `LeftExact_en`, `SchemesTour_en`, `SheafHom_en`, `SitePoints_en`, `Subcanonical_en`, `ZariskiSite_en`, `SheafCohomology/Basic_en`, `SheafCohomology/Cech_en` — `_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). Option A post-#4980 on 12 modules; the 12 other modules stay FR-only at this stage of the rollout. **`README.en.md`** present (EN mirror of this file). Out-of-scope: `.lake/packages/`, vendored libs.
+
 ## Purpose
 
 This workspace is a **pedagogical homage** showing how Grothendieck's mathematical
@@ -22,32 +30,32 @@ The formalization spans **24 modules (Parts 1-24, ~3350 lines, 0 sorry)**, impor
 in order by the umbrella `Grothendieck.lean`. Each module self-numbers via its header
 (`Grothendieck tribute — Part N`).
 
-| Part | File | Content | Lines |
-|------|------|---------|-------|
-| 1 | `Grothendieck/CategoryAndSites.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 106 |
-| 2 | `Grothendieck/SchemesTour.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 79 |
-| 3 | `Grothendieck/ZariskiSite.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 84 |
-| 4 | `Grothendieck/MathlibMap.lean` | `#check` index of Grothendieck-related Mathlib definitions | 90 |
-| 5 | `Grothendieck/Calibration.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 80 |
-| 6 | `Grothendieck/SieveLattice.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
-| 7 | `Grothendieck/SheafBasics.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 128 |
-| 8 | `Grothendieck/SieveOps.lean` | Topology ordering, covering closure, sieve composition | 124 |
-| 9 | `Grothendieck/CoverageGen.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 148 |
-| 10 | `Grothendieck/CanonicalProps.lean` | Canonical topology, subcanonicity, representable sheaves | 133 |
-| 11 | `Grothendieck/SieveGenerate.lean` | Sieve generation identities | 128 |
-| 12 | `Grothendieck/DenseTopology.lean` | The dense topology | 131 |
-| 13 | `Grothendieck/Sheafification.lean` | Sheafification (the associated sheaf functor) | 175 |
-| 14 | `Grothendieck/LeftExact.lean` | Left exactness of sheafification | 133 |
-| 15 | `Grothendieck/SitePoints.lean` | Points of a site (fiber functors) | 220 |
-| 16 | `Grothendieck/Subcanonical.lean` | Subcanonical Grothendieck topologies | 88 |
-| 17 | `Grothendieck/SheafHom.lean` | Internal hom of sheaves | 140 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | Conservative families of points | 226 |
-| 20 | `Grothendieck/SheafCohomology/Basic.lean` | Sheaf cohomology (Ext-based) | 214 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | Mayer-Vietoris squares | 195 |
-| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | Mayer-Vietoris long exact sequence | 164 |
-| 23 | `Grothendieck/SheafCohomology/Cech.lean` | Čech cohomology | 123 |
-| 24 | `Grothendieck/YonedaLemma.lean` | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 168 |
+| Part | File | `_en` | Content | Lines |
+|------|------|-------|---------|-------|
+| 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 106 |
+| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 79 |
+| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 84 |
+| 4 | `Grothendieck/MathlibMap.lean` | — | `#check` index of Grothendieck-related Mathlib definitions | 90 |
+| 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 80 |
+| 6 | `Grothendieck/SieveLattice.lean` | — | Sieve pullback identities: `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
+| 7 | `Grothendieck/SheafBasics.lean` | — | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 128 |
+| 8 | `Grothendieck/SieveOps.lean` | — | Topology ordering, covering closure, sieve composition | 124 |
+| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 148 |
+| 10 | `Grothendieck/CanonicalProps.lean` | — | Canonical topology, subcanonicity, representable sheaves | 133 |
+| 11 | `Grothendieck/SieveGenerate.lean` | — | Sieve generation identities | 128 |
+| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | The dense topology | 131 |
+| 13 | `Grothendieck/Sheafification.lean` | — | Sheafification (the associated sheaf functor) | 175 |
+| 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Left exactness of sheafification | 133 |
+| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 220 |
+| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 88 |
+| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Internal hom of sheaves | 140 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | — | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | — | Conservative families of points | 226 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Sheaf cohomology (Ext-based) | 214 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | — | Mayer-Vietoris squares | 195 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | — | Mayer-Vietoris long exact sequence | 164 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 123 |
+| 24 | `Grothendieck/YonedaLemma.lean` | — | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 168 |
 
 The extension (Parts 6-24) was developed under Issue #2159 / Epic #1646 and is
 **complete**: all 24 modules merged, 0 `sorry`, 0 axiom added.
@@ -88,6 +96,8 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - Epic #1453 (prover harness calibration)
 - Conway tribute workspace (`../conway_lean/`)
 - Lean notebook series (`../README.md`)
+- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 12 `_en.lean` siblings on `main` in this lake)
+- **[`README.md`](./README.md)** — FR canonical sibling of this file
 
 ## Conclusion
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -2,6 +2,14 @@
 
 Alexandre Grothendieck (1928-2014).
 
+## État
+
+- **Toolchain** : `leanprover/lean4:v4.31.0-rc1`
+- **Sorry** : **0 sorry, 0 axiome** — les 24 modules sont complets à la création (Parties 1-24 mergées)
+- **Build** : `lake build Grothendieck` — compile les 24 modules (~3350 lignes)
+- **Dépendances** : Mathlib 4 (via `lakefile.lean`)
+- **Couverture i18n (EPIC #4980)** : couverture étendue — **24 modules `.lean` FR canonique** + **12 siblings `_en.lean`** miroirs EN sur `main` (`Calibration_en`, `CategoryAndSites_en`, `CoverageGen_en`, `DenseTopology_en`, `LeftExact_en`, `SchemesTour_en`, `SheafHom_en`, `SitePoints_en`, `Subcanonical_en`, `ZariskiSite_en`, `SheafCohomology/Basic_en`, `SheafCohomology/Cech_en` — namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). Option A post-#4980 sur 12 modules ; les 12 autres modules restent FR-only à ce stade du rollout. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
+
 ## Objectif
 
 Ce workspace est un **hommage pédagogique** montrant comment le langage
@@ -37,32 +45,32 @@ flowchart LR
     MM["<b>Carte Mathlib</b><br/><i>Partie 4</i><br/>index #check"] -.->|"ancre bibliothèque"| T3
 ```
 
-| Partie | Fichier | Contenu | Lignes |
-|--------|---------|---------|--------|
-| 1 | `Grothendieck/CategoryAndSites.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 106 |
-| 2 | `Grothendieck/SchemesTour.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 79 |
-| 3 | `Grothendieck/ZariskiSite.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 84 |
-| 4 | `Grothendieck/MathlibMap.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 90 |
-| 5 | `Grothendieck/Calibration.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 80 |
-| 6 | `Grothendieck/SieveLattice.lean` | Identités de pullback de cribles : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
-| 7 | `Grothendieck/SheafBasics.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 128 |
-| 8 | `Grothendieck/SieveOps.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 124 |
-| 9 | `Grothendieck/CoverageGen.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 148 |
-| 10 | `Grothendieck/CanonicalProps.lean` | Topologie canonique, sous-canoïcité, faisceaux représentables | 133 |
-| 11 | `Grothendieck/SieveGenerate.lean` | Identités de génération de cribles | 128 |
-| 12 | `Grothendieck/DenseTopology.lean` | La topologie dense | 131 |
-| 13 | `Grothendieck/Sheafification.lean` | Faisceautisation (le foncteur faisceau associé) | 175 |
-| 14 | `Grothendieck/LeftExact.lean` | Exactitude à gauche de la faisceautisation | 133 |
-| 15 | `Grothendieck/SitePoints.lean` | Points d'un site (foncteurs fibres) | 220 |
-| 16 | `Grothendieck/Subcanonical.lean` | Topologies de Grothendieck sous-canoniques | 88 |
-| 17 | `Grothendieck/SheafHom.lean` | Hom interne des faisceaux | 140 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | Familles conservatrices de points | 226 |
-| 20 | `Grothendieck/SheafCohomology/Basic.lean` | Cohomologie des faisceaux (basée sur Ext) | 214 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | Carrés de Mayer-Vietoris | 195 |
-| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | Suite exacte longue de Mayer-Vietoris | 164 |
-| 23 | `Grothendieck/SheafCohomology/Cech.lean` | Cohomologie de Čech | 123 |
-| 24 | `Grothendieck/YonedaLemma.lean` | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 168 |
+| Partie | Fichier | `_en` | Contenu | Lignes |
+|--------|---------|-------|---------|--------|
+| 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 106 |
+| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 79 |
+| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 84 |
+| 4 | `Grothendieck/MathlibMap.lean` | — | Index `#check` des définitions Mathlib liées à Grothendieck | 90 |
+| 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 80 |
+| 6 | `Grothendieck/SieveLattice.lean` | — | Identités de pullback de cribles : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone` | 88 |
+| 7 | `Grothendieck/SheafBasics.lean` | — | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 128 |
+| 8 | `Grothendieck/SieveOps.lean` | — | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 124 |
+| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 148 |
+| 10 | `Grothendieck/CanonicalProps.lean` | — | Topologie canonique, sous-canoïcité, faisceaux représentables | 133 |
+| 11 | `Grothendieck/SieveGenerate.lean` | — | Identités de génération de cribles | 128 |
+| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | La topologie dense | 131 |
+| 13 | `Grothendieck/Sheafification.lean` | — | Faisceautisation (le foncteur faisceau associé) | 175 |
+| 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Exactitude à gauche de la faisceautisation | 133 |
+| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 220 |
+| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 88 |
+| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Hom interne des faisceaux | 140 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | — | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | — | Familles conservatrices de points | 226 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Cohomologie des faisceaux (basée sur Ext) | 214 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | — | Carrés de Mayer-Vietoris | 195 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | — | Suite exacte longue de Mayer-Vietoris | 164 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 123 |
+| 24 | `Grothendieck/YonedaLemma.lean` | — | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 168 |
 
 L'extension (Parties 6-24) a été développée sous l'Issue #2159 / Epic #1646 et
 est **complète** : tous les 24 modules mergés, 0 `sorry`, 0 axiome ajouté.
@@ -103,6 +111,8 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - PR #2675 (Phases 4-6 : SieveOps + CoverageGen + CanonicalProps)
 - Epic #1453 (calibration du harnais prouveur)
 - Workspace hommage Conway (`../conway_lean/`)
+- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 12 siblings `_en.lean` sur `main` dans cette lake)
+- **[`README.en.md`](./README.en.md)** — miroir EN du présent fichier
 - Série de notebooks Lean (`../README.md`)
 
 ## Conclusion


### PR DESCRIPTION
## docs(lean,#4980,#3978): grothendieck_lean README feuille rollout

### Scope (atomic single-PR)

2 files in-place (docs-only):

- `MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md` (FR canonical, 157 → 167 LF, +10 LF)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md` (EN mirror, 123 → 133 LF, +10 LF)

`+72 / −52` net — symmetric FR + EN mirror: each adds a new `## État / ## Status` block (5 bullets), an `_en` column to the 24-module Structure table, and EPIC #4980 + cross-link entries in `## Voir aussi / ## See also`.

1 feature (i18n coverage documentation rollout), 1 domain (Lean docs). Atomic G.4 compliant.

### Constat — FR AND EN READMEs both lacked i18n coverage documentation (audit dual)

Both READMEs on `main` were **dual-stale** (textbook L400 pattern, confirmed 5ᵉ fois after c.424-c.427):

| Artifact | Before | After |
| --- | --- | --- |
| `## État / ## Status` block | **Absent** (jumps from intro → `## Objectif` / `## Purpose`) | 5 bullets: Toolchain, Sorry, Build, Dependencies, **i18n coverage** |
| Modules `_en` column | **Absent** (4-column table only) | **Added** to 24-row Structure table; `—` for FR-only modules, actual filename for the 12 modules with `_en.lean` siblings |
| EPIC #4980 reference | **Absent** in both files | Added to `## Voir aussi` (FR) + `## See also` (EN) |
| Cross-link FR ↔ EN | **Absent** (one-directional implicit) | Explicit `[`README.en.md`](./README.en.md)` in FR + `[`README.md`](./README.md)` in EN |

### Shape uniqueness — largest lake in workspace, partial rollout status

`grothendieck_lean` is **the largest lake** in the Lean workspace (24 modules, ~3350 lines, 0 sorry, 0 axiom) and has the **most `_en.lean` siblings** of any audited lake:

| Lake | FR modules | `_en` siblings | Status |
| --- | --- | --- | --- |
| `grothendieck_lean` (c.428) | 24 | **12** | **Partial rollout** (50% — option A applied to 12 of 24) |
| `conway_lean` (c.424) | 11 | 11 | Full |
| `calibration_lean` (c.425) | 3 | 3 | Full |
| `sensitivity_lean` (c.426) | 4 | 4 | Full |
| `finiteness_lean` (c.427) | 2 | 1 (Basic_en) + 1 en.md companion | Mixed patterns |

The 12 `_en.lean` siblings shipped on `main` (G.1 verified firsthand):

- `Grothendieck/Calibration_en.lean`
- `Grothendieck/CategoryAndSites_en.lean`
- `Grothendieck/CoverageGen_en.lean`
- `Grothendieck/DenseTopology_en.lean`
- `Grothendieck/LeftExact_en.lean`
- `Grothendieck/SchemesTour_en.lean`
- `Grothendieck/SheafCohomology/Basic_en.lean`
- `Grothendieck/SheafCohomology/Cech_en.lean`
- `Grothendieck/SheafHom_en.lean`
- `Grothendieck/SitePoints_en.lean`
- `Grothendieck/Subcanonical_en.lean`
- `Grothendieck/ZariskiSite_en.lean`

The 12 other modules (SieveLattice, SheafBasics, SieveOps, CanonicalProps, SieveGenerate, Sheafification, ConstantSheaf, Conservative, MayerVietorisSquare, SheafCohomology/MayerVietoris, YonedaLemma, MathlibMap) stay FR-only at this stage of the rollout. c.428 does NOT touch their language — it only documents the **actual state of `main`** (12 of 24 with `_en` siblings, 12 FR-only).

### Changes

1. **`## État` block** (FR): 5 bullets including a new **Couverture i18n (EPIC #4980)** bullet listing the 12 `_en.lean` siblings verbatim with the `SheafCohomology/` subtree (`Basic_en.lean`, `Cech_en.lean`), the `_en` namespace anti-collision pattern, and the byte-identical non-docstring content guarantee. Hors-scope: `.lake/packages/`, vendored libs.
2. **`## Status` block** (EN): mirror of the FR block in English, same 5 bullets with the sibling list verbatim.
3. **`## Structure` table** (FR + EN): add `_en` column between `Fichier / File` and `Contenu / Content`. Header becomes `| Partie | Fichier | `_en` | Contenu | Lignes |` (FR) / `| Part | File | `_en` | Content | Lines |` (EN). Values: actual filename for the 12 modules with siblings, `—` for the 12 FR-only modules.
4. **`## Voir aussi` / `## See also`**: add **EPIC #4980** reference (Option A sibling pair post-2026-07-04, 12 siblings on `main` in this lake) + cross-link `[`README.en.md`](./README.en.md)` in FR + `[`README.md`](./README.md)` in EN.

Symmetry FR/EN is exact on text structure: header + body sections mirror 1:1 across the two files.

### Verifications firsthand (G.1 verify-before-claim)

```bash
git diff --stat origin/main
```

Returns exactly **2 files** (`README.md` + `README.en.md`), `+72 / −52`. No Lean code, no notebook, no catalogue regeneration.

- **Sorry baseline** (G.1 anti-regression): `grep -c "^sorry"` over all **36** `.lean` files (24 FR + 12 EN, including `SheafCohomology/{Basic,Cech}_en.lean`) → **0/0/0/0/0/0/...** all 36 returns 0. No regression, no tactical `sorry` introduced. Baseline un-modified.
- **Encoding**: `file` → `Unicode text, UTF-8 text, with very long lines` on both READMEs — UTF-8, no BOM.
- **CRLF**: `grep -c $'\r'` → **0** on both READMEs (LF strict).
- **LF count**: FR README 157 → 167 LF (+10); EN README 123 → 133 LF (+10). Matches the `+10 LF × 2 files` of the symmetric edits: 6 LF new `## État / ## Status` block (heading + blank + 5 bullets) + 1 LF `_en` column header + 2 LF EPIC #4980 + README.en.md cross-link in `Voir aussi / See also` + 1 LF blank-line adjustment.
- **catalog-pr-hygiene R1 (L398 c.424)**: **non-binding** on this leaf — `grep -n "CATALOG-STATUS"` returns 0 hits on both READMEs. Rule "never regenerate the catalog on a feature branch" is not engaged here, so the Modules table and the i18n-coverage block can be edited freely without risk of catalogue conflict at merge.
- **No Lean code touched**: `git diff --name-only origin/main | grep "\.lean$"` returns 0. `git diff --name-only origin/main | grep "\.ipynb$"` returns 0. Only the 2 README files changed.
- **No local `lake build` required**: PR is docs-only (status / table edits + cross-links). Cold-build gate does not apply — no theorem-bearing file is touched, no namespace/import change, no risk of NUL-byte corruption (L390, L391 lessons don't bite).
- **`_en` siblings baseline verified**: `ls Grothendieck/*_en.lean Grothendieck/SheafCohomology/*_en.lean | wc -l` → **12** (10 in `Grothendieck/` + 2 in `SheafCohomology/`). Matches the i18n coverage bullet exactly.

### Pivot R6 anti-monotonie (mandat 2026-07-06)

c.427 (#6473 finiteness_lean README), c.426 (#6460 sensitivity_lean README), c.425 (#6447 calibration_lean README) and c.424 (#6442 conway_lean README) were all Lean/docs README feuilles. c.428 continues on the **same axis** but on a **5ᵉ lake distincte** (`grothendieck_lean` instead of finiteness/sensitivity/calibration/conway) — the rotation is across the lake dimension, not across the genre dimension. **Novelty** here:

- **Largest lake in workspace** (24 modules vs 11 max for conway_lean): bigger audit surface, more rows to document.
- **Partial rollout status** (12 of 24 `_en.lean` siblings): the other 12 modules stay FR-only at this stage, and c.428 explicitly documents the asymmetry via `—` in the `_en` column rather than fabricating coverage.
- **SheafCohomology subtree** (Parts 20/22/23): the `_en` column lists `SheafCohomology/Basic_en.lean` and `SheafCohomology/Cech_en.lean` with their full subtree paths — first time the EN siblings in a subdirectory of a Lean lake are documented in a README feuille.

Why **grothendieck_lean** specifically:

- **Largest `_en` sibling count** of any audited lake (12 siblings), more representative audit than a smaller leaf.
- **Largest FR module count** (24 modules): documenting the actual i18n state (12 EN + 12 FR-only) is more meaningful than documenting 100% coverage.
- **No cold-build blocker for README feuille** (docs-only): the cold-build gap that blocks ongoing sibling pairs PRs #6277/#6280/#6284/#6291 (awaiting local validation) does NOT block a docs-only audit. The 12 siblings are already shipped on `main`.
- **No concurrent PR on the same leaf**: `gh pr list --state open` filtered on `grothendieck` → 0 hits for README. The leaf is free for c.428.
- **README.en.md already shipped** (123 LF on `main`) — symmetric audit possible without gap-fill.

Why **not** `knot_lean` / other lakes:

- **knot_lean** (c.421-c.423 backlog): PRs #6429 (Reidemeister) + #6440 (Lidman) HELD par C513-L1 sorry-gate CI pathology (ai-01 décision). A README audit alone doesn't help — better revisit knot_lean once the sorry-gate fix lands.
- **examples / mathlib_examples** READMEs (0 `_en.lean`, not applicable): no i18n rollout to document.

### Links

- See #4980 (i18n Lean harmonisation — Option A sibling pair post-2026-07-04)
- See #3978 (READMEs feuilles — SymbolicAI/Lean/** included)
- See #3975 (README rollout Epic #3973 sister)
- See #1646 (Epic hommage Grothendieck)
- See #2159 (profondeur de formalisation Grothendieck)
- See #1453 (calibration du harnais prouveur — Calibration_en.lean est un input)
- See #2675 (PR Phases 4-6 : SieveOps + CoverageGen + CanonicalProps)
- See #5543 (lake fully bilingual — pattern dont `grothendieck_lean` est un déploiement partiel post-#4980)
- See #6473 (c.427 finiteness_lean README feuille — pivot précédent sur même axe)

### Lessons applied / confirmed

- **L398** (c.424): `catalog-pr-hygiene R1 not binding if markers absent`. Confirmed `grep -n "CATALOG-STATUS"` returns 0 on both READMEs → R1 is non-blocking here.
- **L399** (c.425): `gh-pr-create-backtick-mangling-shell-reparse`. PR body written via **Write tool direct** (heredoc bash échoue sur `(1)` parentheticals) to scratchpad, then `gh pr create --body-file`. **Backticks preserved verbatim** (no shell reparse).
- **L400** (c.425/c.426): `audit-dual-stale-table-modules-FR-AND-EN`. Audited both `README.md` and `README.en.md` in read-only before the edit. **Confirmée 5ᵉ fois** on c.428 (conway → calibration → sensitivity → finiteness → grothendieck).
- **L394** (c.6411): `README-feuille-forrensic-audit-by-ai01-pattern`. Worker G.1 firsthand verification: `ls _en.lean` count = 12 (10 in `Grothendieck/` + 2 in `SheafCohomology/`). No claim without disk verification.

### Cycle suivant

Lanes candidates post-c.428:

- **`knot_lean` README feuille**: 2 `_en.lean` siblings (#6429 Reidemeister + #6440 Lidman) mais les 2 PRs HELD par C513-L1 sorry-gate CI pathology. Revisiter une fois ai-01 commited à un fix sur `lean-build.yml`.
- **`grothendieck_lean` next-step sibling pairs**: 12 modules restent FR-only (SieveLattice, SheafBasics, SieveOps, CanonicalProps, SieveGenerate, Sheafification, ConstantSheaf, Conservative, MayerVietorisSquare, SheafCohomology/MayerVietoris, YonedaLemma, MathlibMap). These are blocked by cold-build gap (po-2023 PRs #6277/#6280/#6284/#6291 awaiting local validation) — drop jusqu'à unblock.
- **`examples` / `mathlib_examples` READMEs**: 0 `_en.lean` (pas applicable). Documentation bilingue hors-scope.
- **R5.4b MUST ≥1 PR/wakeup PLANCHER** — one PR per wakeup floor, never ceiling. Si le bucket easy-leaf sèche, pivot vers pool global cross-lane (cf `gh issue list --state open` cross-lane, jamais siloté par famille).

**Recommandation prochaine fenêtre**: **`knot_lean` README feuille** — revisit une fois le sorry-gate fix landed (ai-01 holds C513-L1). Or fall back to **pool global cross-lane** per proactive-coordination règle 5 (the Lean docs/README axis is reaching saturation — c.424-c.428 covered 5 lakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)