### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Sudoku-17-LLM-Python exercise cells

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -659,6 +659,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex1-zero-shot-prompt",
    "metadata": {},
    "source": [
     "## Exercice : Optimiser le prompt zero-shot\n",
@@ -675,6 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "ex1-zero-shot-prompt-code",
    "metadata": {},
    "outputs": [
     {
@@ -1130,6 +1132,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex2-shot-comparison",
    "metadata": {},
    "source": [
     "## Exercice : Comparer zero-shot vs few-shot vs code interpreter\n",
@@ -1146,6 +1149,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "ex2-shot-comparison-code",
    "metadata": {},
    "outputs": [
     {
@@ -2176,6 +2180,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex3-llm-errors",
    "metadata": {},
    "source": [
     "## Exercice : Analyser les erreurs du LLM\n",
@@ -2192,6 +2197,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "ex3-llm-errors-code",
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Adds missing **v4.5 cell ids** to the 3 exercise pairs (markdown + code stub) of `Sudoku-17-LLM-Python.ipynb`: cells 12/13, 20/21, 37/38. This is the **last Python cluster** in the nbformat #6257 rollout, handed off by po-2024 c.454 census.

## Convention matched

This notebook uses **human-readable descriptive ids** (`intro`, `intro-llm`, `imports`, plus a few legacy uuids) — NOT a random-uuid scheme and NOT a per-notebook sequential scheme. The new ids follow the same descriptive style:
- `ex1-zero-shot-prompt` (md) / `ex1-zero-shot-prompt-code` (code) — "Optimiser le prompt zero-shot"
- `ex2-shot-comparison` (md) / `ex2-shot-comparison-code` (code) — "Comparer zero-shot vs few-shot vs code interpreter"
- `ex3-llm-errors` (md) / `ex3-llm-errors-code` (code) — "Analyser les erreurs du LLM"

Key-order convention matched to id'd siblings:
- markdown cell → `id` after `cell_type` (position 1)
- code cell → `id` after `execution_count` (position 2)

## Surgical raw-text edit (no json round-trip)

Firsthand G.1 verified the notebook is **structurally clean** (`nbformat.validate()` PASS, 0 CRLF, 0 blank-line elements — the 126-byte round-trip mismatch is just the expected 6-id growth, same model as the GameTheory-2 false-positive I debunked c.452). However, `json.dumps(indent=1)` is NOT safe here: some **already-id'd** cells have stream-outputs that omit the `name` field, and json.dumps normalizes those = **spurious churn on 3 untouched cells**.

So the edit is **raw-text surgical**: locate each target by its unique exercise heading, walk back to the cell header, insert the id line at the convention-correct position. Preserves ALL formatting.

## Verification

- `nbformat.validate()` → PASS
- **41/41 cells with unique ids** (0 missing, 0 duplicate)
- **+6/0** pure-structural (only id lines added, 0 removals) — no churn on stream-outputs or any untouched cell
- 0 CRLF
- Code stubs C.1-compliant (no voluntary errors; pure structural addition doesn't touch code)

See #6257 (nbformat v4.5 cell-id rollout).

Co-Authored-By: Claude <noreply@anthropic.com>