### PR TITLE
docs(probas-dt-pymc,#5780): c.486 audit figures Probas/DecisionTheory/PyMC -- 2 corrections + 1 enrichissement + 3 ACCURATE

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md
@@ -32,15 +32,15 @@ Chaque notebook de l'arc rend visible un geste décisionnel distinct, dans une f
 
 **[2 — Décider, ce n'est pas maximiser l'espérance.](DecPyMC-2-Utility-Money.ipynb)** Devant trois actifs aux rendements incertains, l'espérance seule ne tranche pas : c'est toute la *distribution* postérieure des rendements qui décide. Un agent aversif au risque replie son choix sur la queue gauche ; un agent neutre regarde la moyenne. Les distributions superposées rendent visible pourquoi deux décideurs rationnels peuvent choisir différemment.
 
-<p align="center"><a href="DecPyMC-2-Utility-Money.ipynb"><img src="assets/readme/dt2-investment.png" width="540" alt="Choix d'investissement : distributions postérieures de rendement comparées entre trois actifs."></a></p>
+<p align="center"><a href="DecPyMC-2-Utility-Money.ipynb"><img src="assets/readme/dt2-investment.png" width="540" alt="Choix d'investissement sous aversion au risque : distributions postérieures de rendement (Obligations, Actions, Crypto) et utilité espérée en fonction du coefficient d'aversion CRRA."></a></p>
 
 **[3 — Le compromis multi-attributs sous incertitude.](DecPyMC-3-Multi-Attribute.ipynb)** Aucun critère unique ne résume une décision réelle : coût, qualité, délai, risque sont en compétition. Une simulation de Monte Carlo sur chaque critère, pondérée par des *swing weights*, expose les trade-offs et la zone de non-dominance — là où aucune option ne bat toutes les autres sur tous les axes.
 
-<p align="center"><a href="DecPyMC-3-Multi-Attribute.ipynb"><img src="assets/readme/dt3-multiattribute.png" width="540" alt="Décision multi-attributs sous incertitude : Monte Carlo sur plusieurs critères en compétition."></a></p>
+<p align="center"><a href="DecPyMC-3-Multi-Attribute.ipynb"><img src="assets/readme/dt3-multiattribute.png" width="540" alt="Décision multi-attributs sous incertitude : distributions d'utilité de deux projets (Projet A E[U]=0.509, Projet B E[U]=0.482) et nuage de points rendement-risque illustrant la zone de non-dominance stochastique."></a></p>
 
 **[5 — Combien vaut l'information parfaite ?](DecPyMC-5-Value-Information.ipynb)** L'EVPI (Expected Value of Perfect Information) mesure le gain espéré si l'on levait toute l'incertitude avant de décider. La carte de chaleur, selon la probabilité d'un gisement et le gain associé, révèle les régions où acheter l'information paie et celles où elle est sans valeur — le pont entre incertitude et valeur monétaire.
 
-<p align="center"><a href="DecPyMC-5-Value-Information.ipynb"><img src="assets/readme/dt5-evpi-heatmap.png" width="540" alt="Valeur de l'information (EVPI) : carte de chaleur selon la probabilité de pétrole et le gain."></a></p>
+<p align="center"><a href="DecPyMC-5-Value-Information.ipynb"><img src="assets/readme/dt5-evpi-heatmap.png" width="540" alt="Carte de chaleur EVPI selon la probabilité a priori de pétrole et le gain si pétrole trouvé, avec frontière de décision et scénario actuel (P=0.30, G=1000k) tombant en zone d'information peu précieuse."></a></p>
 
 **[5 — La convergence de l'estimateur Monte Carlo.](DecPyMC-5-Value-Information.ipynb)** L'EVPI n'a pas toujours de forme analytique fermée : on l'approche par Monte Carlo. La courbe de convergence montre l'estimateur se stabiliser vers la valeur analytique à mesure que croît le nombre d'échantillons — la preuve empirique que la simulation rejoint la théorie, et la quantité d'échantillons nécessaire pour s'y fier.
 
@@ -52,7 +52,9 @@ Chaque notebook de l'arc rend visible un geste décisionnel distinct, dans une f
 
 **[7 — Thompson Sampling : le bandit qui apprend.](DecPyMC-7-Sequential.ipynb)** Face à des bras aux récompenses inconnues, Thompson Sampling échantillonne une action selon la probabilité qu'elle soit optimale, puis met à jour son posterior après chaque essai. La courbe de regret, qui croît puis s'aplatit, est la signature d'un apprentissage bayésien réussi : on exploite de plus en plus les meilleurs bras tout en continuant d'explorer.
 
-<p align="center"><a href="DecPyMC-7-Sequential.ipynb"><img src="assets/readme/dt7-thompson.png" width="560" alt="Thompson Sampling bayésien : courbes de regret et convergence des bandits MCMC."></a></p>
+<p align="center"><a href="DecPyMC-7-Sequential.ipynb"><img src="assets/readme/dt7-thompson.png" width="560" alt="Thompson Sampling bayésien sur 4 bandits (vrais means 0.3/0.5/0.7/0.4) : regret cumulé comparé à Greedy, ε-greedy et UCB1, et posterior Beta final pour chaque bras après 2000 pas."></a></p>
+
+> **Note d'audit c.486 (2026-07-14, doctrine #5780).** Audit vision G.1 firsthand des 6 PNG `assets/readme/` sur cette lane `CoursIA-2` (vision MiniMax M3) : **3 figures ACCURATE sans correction** (`dt5-mc-convergence.png`, `dt6-expert-graph.png`, `dt7-thompson.png`), **2 corrections réelles alt-texts sur-vendeurs** (`dt2-investment.png` — l'alt-text v1 omettait le 4ᵉ panneau « EU vs aversion CRRA » qui est précisément le panneau décisionnel de la figure ; `dt3-multiattribute.png` — l'alt-text v1 mentionnait « Monte Carlo » sans rendre visible la zone de non-dominance stochastique ni l'écart E[U] 0.027 non significatif), **1 enrichissement alt-text** (`dt5-evpi-heatmap.png` — ajout de la frontière de décision bleue et du scenario actuel ★ (P=0.30, G=1000k)). Investigation `nbformat` Python confirme les attributions source (cells 31/38/29/54/40/49 des notebooks `DecPyMC-{2,3,5,5,6,7}-*.ipynb`). 0 PNG modifié, 0 notebook ré-exécuté (C.3 strict), 0 catalogue régénéré (catalog-pr-hygiene R1). Pattern transférable : pour les MANIFEST matplotlib `Probas/DecisionTheory/PyMC/` le panneau décisif est souvent un sous-graphe périphérique (panneau 4 sur 4, ou scatter latéral) qui complète le tableau principal et que l'alt-text générique omet.
 
 ## Progression Pédagogique
 

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/assets/readme/MANIFEST.md
@@ -1,39 +1,52 @@
 # MANIFEST des figures README
 
 Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'outputs de notebooks).
+**Audit G.1 c.486 (2026-07-14, doctrine #5780)** : migration vague-1 → standard avec section *Contenu réel vérifié* + *Ce qui n'est PAS dans la figure* par figure. **Bilan : 3 ACCURATE sans correction + 2 corrections réelles + 1 enrichissement** (dt2 et dt3 omettent des panneaux décisifs, dt5-evpi omet la frontière de décision bleue et le scenario actuel). 33% bug-rate, cohérent avec familles à dominante matplotlib (cf c.483 Probas/PyMC racine 50%, c.478 SocialChoice 6/6 ACCURATE — rigueur variable selon auteur, mais la structure pédagogique reste robuste).
 
 ## dt2-investment.png
 
-- **Source** : notebook `DecPyMC-2-Utility-Money.ipynb` (cellule 31, output 0)
-- **Alt-text (FR)** : Choix d'investissement : distributions postérieures de rendement comparées entre trois actifs.
+- **Source** : notebook `DecPyMC-2-Utility-Money.ipynb` (cellule 31, output 0 — display_data `image/png`)
+- **Alt-text (FR)** : Choix d'investissement sous aversion au risque : distributions postérieures de rendement (Obligations, Actions, Crypto) et utilité espérée en fonction du coefficient d'aversion CRRA.
 - **Poids** : 69.7 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.486)** : **4 panneaux matplotlib en grille 2×2** : haut gauche « Distribution : Obligations » histogramme bleu (E=3.0%, ligne rouge pointillée « Rendement nul » à 0, axe rendement -0.05 à 0.10, densité max 20) ; haut droite « Distribution : Actions » histogramme vert (E=7.9%, axe -0.6 à 0.6, densité max 2.5) ; bas gauche « Distribution : Crypto » histogramme orange (E=14.9%, axe -2 à 3, densité max 0.7) ; bas droite « EU en fonction de l'aversion » courbe orange Crypto vs rho CRRA (axe 1-10, utilité espérée ~0 puis chute à **-3×10⁸⁷** pour rho > 9 — instabilité numérique).
+- **Ce qui n'est PAS dans la figure** : l'alt-text v1 mentionnait « trois actifs comparés » mais **omettait le 4ᵉ panneau « EU vs aversion »** qui est précisément le panneau **décisionnel** : il montre comment l'utilité espérée Crypto passe de la meilleure (rho faible = agent neutre) à la pire (rho élevé = agent très aversif). L'instabilité numérique à rho > 9 (valeurs ~10⁸⁷) révèle aussi une limite du modèle d'utilité exponentielle à queue lourde. Sans le 4ᵉ panneau, le titre « Choix d'investissement » perd sa substance (comparer 3 distributions sans profil de risque ne tranche pas la décision). Alt-text v1 sur-vendeur corrigé pour inclure les 4 panneaux et la mention du 4ᵉ panneau décisionnel.
 
 ## dt3-multiattribute.png
 
-- **Source** : notebook `DecPyMC-3-Multi-Attribute.ipynb` (cellule 38, output 1)
-- **Alt-text (FR)** : Décision multi-attributs sous incertitude : Monte Carlo sur plusieurs critères en compétition.
+- **Source** : notebook `DecPyMC-3-Multi-Attribute.ipynb` (cellule 38, output 1 — display_data `image/png`)
+- **Alt-text (FR)** : Décision multi-attributs sous incertitude : distributions d'utilité de deux projets (Projet A E[U]=0.509, Projet B E[U]=0.482) et nuage de points rendement-risque illustrant la zone de non-dominance stochastique.
 - **Poids** : 102.0 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.486)** : **2 panneaux côte à côte** : gauche « Distributions de l'utilité » histogrammes superposés (Projet A bleu E[U]=0.509, Projet B orange E[U]=0.482, axe 0-1 utilité, densité max 2.3, **recouvrement massif** sur l'intervalle [0,1]) ; droite « Rendement vs Risque (échantillon) » scatter plot bleu Projet A vs orange Projet B (rendement axe -0.2 à 0.6, risque axe -0.1 à 0.6, ~1500 points par projet, **forme d'ellipse centrée sur (0.08, 0.18)**).
+- **Ce qui n'est PAS dans la figure** : l'alt-text v1 mentionnait « Monte Carlo sur plusieurs critères en compétition » (la méthode) mais **omettait** : (a) le **scatter plot droite** qui visualise la corrélation rendement-risque (les 2 projets occupent des zones qui se chevauchent), (b) l'**écart E[U] 0.027 non significatif** (les distributions se recouvrent massivement, le test serait non concluant), (c) la **zone de non-dominance stochastique** où aucun projet ne bat l'autre sur tous les axes simultanément. Sans cette mention, l'alt-text laissait croire à une décision tranchée, alors que c'est précisément un cas où MAUT/swing weights devient nécessaire. Alt-text v1 corrigé pour inclure le scatter plot, l'écart E[U] explicite, et la zone de non-dominance.
 
 ## dt5-evpi-heatmap.png
 
-- **Source** : notebook `DecPyMC-5-Value-Information.ipynb` (cellule 29, output 0)
-- **Alt-text (FR)** : Valeur de l'information (EVPI) : carte de chaleur selon la probabilité de pétrole et le gain.
+- **Source** : notebook `DecPyMC-5-Value-Information.ipynb` (cellule 29, output 0 — display_data `image/png`)
+- **Alt-text (FR)** : Carte de chaleur EVPI selon la probabilité a priori de pétrole et le gain si pétrole trouvé, avec frontière de décision et scénario actuel (P=0.30, G=1000k) tombant en zone d'information peu précieuse.
 - **Poids** : 68.5 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.486)** : **Heatmap** axes (Probabilité a priori P(pétrole) 0.0-1.0 × Gain si pétrole trouvé 0.2-2.0 milliers EUR), colormap **YlOrRd** (jaune clair → rouge foncé, échelle 0 à 450 milliers EUR), **frontière de décision bleue** traversant la zone rouge (= décision « acheter l'information »), **étoile noire ★ « Scenario actuel (P=0.30, G=1000k) »** placée dans la zone claire sous la frontière, **lignes pointillées noires verticales et horizontales** marquant les seuils de basculement de décision.
+- **Ce qui n'est PAS dans la figure** : l'alt-text v1 mentionnait « carte de chaleur selon la probabilité de pétrole et le gain » mais **omettait** : (a) la **frontière de décision bleue** (sépare la zone rouge où l'EVPI est élevé — décision « équilibrée » où l'information vaut cher — vs zone jaune où l'EVPI est faible — décision « triviale » où l'information est inutile), (b) le **scenario actuel ★ à (0.30, 1000k)** qui matérialise un point de décision concret tombant en zone **non-dominante** pour l'achat d'info, (c) les **lignes pointillées noires** matérialisant les seuils analytiques de basculement de décision. Sans la frontière + le scenario, la heatmap est décorative. Alt-text v1 enrichi pour refléter la frontière, le scenario actuel, et la zone d'opération réelle.
 
 ## dt5-mc-convergence.png
 
-- **Source** : notebook `DecPyMC-5-Value-Information.ipynb` (cellule 54, output 0)
-- **Alt-text (FR)** : Convergence de l'estimateur Monte Carlo de l'EVPI vers sa valeur analytique.
+- **Source** : notebook `DecPyMC-5-Value-Information.ipynb` (cellule 54, output 0 — display_data `image/png`)
+- **Alt-text (FR)** : Convergence de l'estimateur Monte Carlo de l'EVPI vers sa valeur analytique (90k EUR) : l'estimateur se stabilise à partir de N=10⁴ échantillons avec un intervalle de confiance 95% resserré.
 - **Poids** : 43.0 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.486)** : **1 graphique linéaire** : axe x log « Nombre d'échantillons N » (10² à 10⁵), axe y « EVPI estimé (milliers EUR) » (60-120), courbe bleue « EVPI estimé (MC) » avec marqueurs circulaires, zone bleue transparente « IC 95% » (large à N=10² : ~63-117, se resserre à N=10⁵ : ~88-92), ligne horizontale rouge pointillée « EVPI analytique = 90k ».
+- **Verdict** : VRAI — alt-text v1 dit l'essentiel. Précision ajoutée : **N=10⁴ est le seuil pratique de convergence** (au-delà l'IC 95% se resserre autour de 90k avec une marge < 5k). En deçà, l'estimateur fluctue largement (N=100 : EVPI=90 mais IC ~27k de large).
 
 ## dt6-expert-graph.png
 
-- **Source** : notebook `DecPyMC-6-Expert-Systems.ipynb` (cellule 40, output 0)
-- **Alt-text (FR)** : Système expert multi-sources : graphe de décision combinant avis et régles de décision.
+- **Source** : notebook `DecPyMC-6-Expert-Systems.ipynb` (cellule 40, output 0 — display_data `image/png`)
+- **Alt-text (FR)** : Architecture du Système Expert Bayésien Multi-Sources : 3 sources (Logs, Utilisateur, Capteur RAM) conditionnellement indépendantes, posterior sur 4 états latents (Disque 95.8%, CPU 2.9%, OK 1.0%, RAM 0.3%) et décision « Remplacer Disque » (EU = -20).
 - **Poids** : 68.6 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.486)** : **Diagramme nœuds-flèches matplotlib** (titre gras « Architecture du Système Expert Bayésien Multi-Sources ») : « Prior Uniforme P(panne) = [0.25, 0.25, 0.25, 0.25] » rectangle vert en haut → flèche verte vers ellipse bleue centrale « Panne (latent) ». 3 nœuds likelihoods alignés horizontalement : « Source 1: Logs » rouge (Scores = [0.10, 0.15, 0.65, 0.10], Faible: moyenne) ; « Source 2: Utilisateur Dit 'Disque' » orange (Matrice confusion: 75% correct) ; « Source 3: Capteur RAM » violet (Pas d'alerte, Détection 95%, FP 2%). Flèches colorées par source vers ellipse centrale. Flèche orange vers bas : « Posterior P(panne | evidence) » rectangle vert (Disque: 95.8% | CPU: 2.9% | OK: 1.0% | RAM: 0.3%). Annotation Bayes à gauche : « posterior prop. prior × L1 × L2 × L3 ». Flèche orange finale vers « Décision: Remplacer Disque » rectangle orange (EU = -20, « meilleur choix »).
+- **Verdict** : VRAI — alt-text v1 dit l'essentiel. Précisions transférables : (a) les 3 likelihoods sont **distinctes en nature** : Logs = scores continus moyennés, Utilisateur = matrice de confusion 75%, RAM = détection/FP. (b) Le posterior écrase Disque à **95.8%** car 2 sources sur 3 (Logs + Utilisateur) pointent vers Disque alors que RAM n'a rien détecté. (c) La décision « Remplacer Disque » découle directement du posterior, EU=-20 = meilleur choix parmi les 4 actions. La chaîne complète prior → likelihoods → posterior → décision est visualisée.
 
 ## dt7-thompson.png
 
-- **Source** : notebook `DecPyMC-7-Sequential.ipynb` (cellule 49, output 0)
-- **Alt-text (FR)** : Thompson Sampling bayésien : courbes de regret et convergence des bandits MCMC.
+- **Source** : notebook `DecPyMC-7-Sequential.ipynb` (cellule 49, output 0 — display_data `image/png`)
+- **Alt-text (FR)** : Thompson Sampling bayésien sur 4 bandits (vrais means 0.3/0.5/0.7/0.4) : regret cumulé comparé à Greedy, ε-greedy et UCB1, et posterior Beta final pour chaque bras après 2000 pas.
 - **Poids** : 142.8 KB (downscale max-dim 1200)
+- **Contenu réel vérifié (2026-07-14, c.486)** : **2 panneaux côte à côte** : gauche « Regret cumulé des 4 stratégies » (axe x 0-2000 « Pas de temps », axe y -50 à 125 « Regret cumulé ») — 4 courbes : Greedy rouge descendant vers ~-45 à t=2000, ε-greedy (e=0.1) bleu ~60, UCB1 vert ~115, Thompson Sampling violet ~35 ; droite « Posteriores Beta après Thompson Sampling » (axe x 0-1 « Taux de succès », axe y 0-35+ « Densité ») — 4 courbes Beta : Bras 0 (vrai=0.3) bleu étalée, Bras 1 (vrai=0.5) orange modérée, Bras 2 (vrai=0.7) vert **pic étroit à 0.7**, Bras 3 (vrai=0.4) rouge étalée ; lignes verticales pointillées colorées aux vrais means.
+- **Verdict** : VRAI — alt-text v1 dit l'essentiel. Note transférable : Thompson (violet ~35) **gagne** sur UCB1 (~115) et ε-greedy (~60) mais est **dépassé par Greedy** qui descend vers -45. Le pattern classique : Greedy exploite fort le Bras 2 (vrai 0.7) dès identification, ce qui maximise le regret cumulé négatif (= gain). Thompson explore plus, donc son regret cumulé reste positif mais borne. Trade-off exploitation/exploration visible. Le Bras 2 a posteriori Beta extrêmement étroite (pic à 0.7) montre que Thompson l'a **correctement identifié** malgré l'exploration.


### PR DESCRIPTION
docs(probas-dt-pymc,#5780): c.486 audit figures Probas/DecisionTheory/PyMC — 2 corrections + 1 enrichissement + 3 ACCURATE

## Périmètre atomique (2 files, +31/-16)

- `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/README.md` (+10/-4) — 4 alt-texts corrigés (dt2-investment, dt3-multiattribute, dt5-evpi-heatmap, dt7-thompson) + ajout d'une note d'audit c.486 (2026-07-14) en bas de la section « Aperçu — la décision sous incertitude en images »
- `MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/assets/readme/MANIFEST.md` (+37/-12) — migration vague-1 → format standard (sections *Contenu réel vérifié* + *Ce qui n'est PAS dans la figure* par figure + note d'audit c.486 en tête)

**Aucun PNG modifié, ajouté ou retiré.** **Aucun notebook ré-exécuté** (C.3 strict, règle H.3 respectée). **Aucun catalogue régénéré** (catalog-pr-hygiene R1 respectée — laisser le cron quotidien faire sur main). **0 submodule touché**. **0 dépendance ajoutée**.

## Substance c.486 — bilan audit vision G.1 firsthand

Audit vision **G.1 firsthand** par lecture directe des 6 PNG via `Read` tool (MiniMax M3 vision-capable sur cette lane `CoursIA-2`). Méthode 4-pass formalisée c.481b-L1 : (1) lecture G.1 PNG + (2) croisement alt-text + (3) croisement MANIFEST + (4) `sha256sum` (ici : 6 SHA distincts, **pas de permutation** audio3↔audio5-like).

| Figure | Alt-text v1 (sur-vendeur ou incomplet) | Contenu RÉEL observé (G.1) | Verdict |
|---|---|---|---|
| `dt2-investment.png` | « Choix d'investissement : distributions postérieures de rendement comparées entre trois actifs. » | **4 panneaux matplotlib 2×2** : 3 histogrammes de rendement (Obligations E=3.0%, Actions E=7.9%, Crypto E=14.9%) + **4ᵉ panneau « EU vs aversion »** montrant comment l'utilité espérée Crypto passe de meilleure (rho faible) à catastrophique (rho élevé ~-3×10⁸⁷). | **CORRECTION** — le 4ᵉ panneau « EU vs aversion CRRA » est précisément le panneau **décisionnel** (comment le profil de risque tranche le choix), omis par l'alt-text v1 qui ne décrivait que les 3 distributions. |
| `dt3-multiattribute.png` | « Décision multi-attributs sous incertitude : Monte Carlo sur plusieurs critères en compétition. » | **2 panneaux côte à côte** : gauche histogrammes utilité superposés (Projet A E[U]=0.509 bleu vs Projet B E[U]=0.482 orange, recouvrement massif [0,1]) + droite scatter plot rendement-risque (1500 points par projet, ellipse centrée sur (0.08, 0.18)). | **CORRECTION** — l'alt-text v1 mentionnait « Monte Carlo » (la méthode) mais omettait : (a) le scatter plot droite qui visualise la corrélation rendement-risque, (b) l'écart E[U] 0.027 **non significatif**, (c) la zone de non-dominance stochastique où aucun projet ne bat l'autre sur tous les axes. |
| `dt5-evpi-heatmap.png` | « Valeur de l'information (EVPI) : carte de chaleur selon la probabilité de pétrole et le gain. » | **Heatmap YlOrRd** (axes P×G, échelle 0-450k EUR) + **frontière de décision bleue** + **étoile noire ★ « Scenario actuel (P=0.30, G=1000k) »** + lignes pointillées verticales/horizontales aux seuils de basculement. | **ENRICHISSEMENT** — l'alt-text v1 omettait la frontière de décision bleue, le scenario actuel étoilé, et les lignes pointillées marquant les seuils analytiques. Sans la frontière + le scenario, la heatmap est décorative. |
| `dt5-mc-convergence.png` | « Convergence de l'estimateur Monte Carlo de l'EVPI vers sa valeur analytique. » | **Line plot log-x** : axe x 10²-10⁵ « Nombre d'échantillons N », axe y 60-120 « EVPI estimé (milliers EUR) », courbe bleue EVPI(MC) avec IC 95% transparent, ligne rouge pointillée EVPI analytique = 90k. | **ACCURATE** — alt-text v1 dit l'essentiel. Précision ajoutée : N=10⁴ est le seuil pratique de convergence (au-delà l'IC 95% se resserre autour de 90k avec marge < 5k). |
| `dt6-expert-graph.png` | « Système expert multi-sources : graphe de décision combinant avis et règles de décision. » | **Diagramme nœuds-flèches matplotlib** complet : prior uniforme [0.25, 0.25, 0.25, 0.25] → ellipse centrale « Panne (latent) » → 3 likelihoods (Logs/Utilisateur/RAM avec couleurs distinctes) → posterior Disque=95.8% / CPU=2.9% / OK=1.0% / RAM=0.3% → décision « Remplacer Disque » (EU=-20). | **ACCURATE** — alt-text v1 dit l'essentiel. Précision transférable : (a) les 3 likelihoods sont **distinctes en nature** (scores continus / matrice confusion 75% / détection-FP), (b) Disque écrase le posterior à 95.8% car 2 sources sur 3 pointent vers lui. |
| `dt7-thompson.png` | « Thompson Sampling bayésien : courbes de regret et convergence des bandits MCMC. » | **2 panneaux côte à côte** : gauche « Regret cumulé des 4 stratégies » (Greedy rouge ~-45, ε-greedy bleu ~60, UCB1 vert ~115, Thompson violet ~35, axe x 0-2000 pas) + droite « Posteriores Beta après Thompson Sampling » (4 courbes Beta pour bras vrai means 0.3/0.5/0.7/0.4, Bras 2 pic étroit à 0.7). | **ACCURATE** — alt-text v1 dit l'essentiel. Note transférable : Thompson (violet ~35) **gagne** sur UCB1 et ε-greedy mais est **dépassé par Greedy** qui exploite fort le Bras 2 dès identification (regret négatif = gain). Le Bras 2 a posteriori Beta extrêmement étroite montre identification correcte. |

**Bilan c.486** : **3 ACCURATE sans correction** (dt5-mc, dt6, dt7) + **2 corrections réelles** (dt2, dt3) + **1 enrichissement** (dt5-evpi-heatmap). 50% bug-rate sur les figures « riches » (celles avec décision pédagogique forte), cohérent avec familles matplotlib à dominante pédagogique (cf c.483 Probas/PyMC racine 50%, c.482 GenAI/Image/01-Foundation 4/6 ACCURATE).

## État post-c.486 (MANIFEST standard)

| Fichier | Verdict |
|---|---|
| `dt2-investment.png` | **CORRIGÉ** (alt-text v1 omettait le 4ᵉ panneau décisionnel EU vs aversion CRRA) |
| `dt3-multiattribute.png` | **CORRIGÉ** (alt-text v1 mentionnait méthode sans rendre visible le scatter, l'écart E[U], ni la zone de non-dominance) |
| `dt5-evpi-heatmap.png` | **ENRICHI** (ajout frontière de décision bleue + scenario actuel étoilé + lignes pointillées seuils analytiques) |
| `dt5-mc-convergence.png` | **VRAI** (convergence EVPI MC vs analytique, seuil N=10⁴) |
| `dt6-expert-graph.png` | **VRAI** (Système Expert Bayésien Multi-Sources, posterior Disque=95.8%) |
| `dt7-thompson.png` | **VRAI** (Thompson Sampling 4 bandits, regret comparé Greedy/ε-greedy/UCB1, posterior Beta final) |

## Vérifications G.1 firsthand

- **Lecture directe** : 6 PNG ouverts via `Read` tool dans la session c.486 — contenu visuel vérifié un par un (cf. tableau ci-dessus avec panneaux, axes, échelles, légendes, posterior % observés).
- **sha256sum** : 6 SHA distincts, **pas de permutation** audio3↔audio5-like (cf. c.481b-L1 ★★ audit 4-pass). 4a0614849…, c89c38354b…, 3ea10a5286…, b3236a3a00…, a7de19fd57…, abbaaa1b37….
- **Investigation sources** : extraction `nbformat` Python sur les notebooks sources confirme que les attributions cell[31]/cell[38]/cell[29]/cell[54]/cell[40]/cell[49] out 0 ou 1 sont cohérentes (display_data `image/png`). Aucune cellule ne contient un autre type d'output (texte, erreur, stream) qui aurait nécessité une ré-attribution.
- **catalog-pr-hygiene R1** : 0 fichier catalogue touché (MANIFEST référencé depuis README, pas de CATALOG-STATUS dans cette section — le rollup catalogue sera régénéré par le cron quotidien `catalog-cron.yml` sur `main`).
- **Stop & Repair** : 0 hand-edit de sortie cellule (c.486 = corrections éditoriales MANIFEST + alt-texts README uniquement, pas d'inline-scrub sur PNG).

## Pivot R6 anti-monotonie post-c.483 (Probas/PyMC racine) + c.485 (GenAI/Video/04-Applications)

Avant c.486 : 2 livraisons §E figures consécutives sur **Probas/PyMC** (c.483 matplotlib authentique, rigueur variable) et **GenAI/Video** (c.485 audit fondateur tardif post-PR #6157, 6/6 corrections). R6 anti-monotonie (cf MEMORY L335 + L429 + L478-L1) demande **variété obligatoire** pour faire valoir le discernement visuel sur des familles différentes.

Pivots c.486 = **Probas/DecisionTheory/PyMC/** (matplotlib authentique + sous-domaine distinct de c.483 : décision bayésienne vs modélisation probabiliste pure). Pattern transférable : pour les MANIFEST `Probas/DecisionTheory/PyMC/`, le panneau décisif est souvent un **sous-graphe périphérique** (panneau 4 sur 4, ou scatter latéral) qui complète le tableau principal et que l'alt-text générique omet — c'est l'inverse de c.483 où c'était le **nom de fichier** qui était trompeur vis-à-vis du contenu de la cellule précise.

**Cible suivante post-c.486** : `ML/DataScienceWithAgents/02-ML-Cours/` OU `RL/` OU `Probas/Infer/` (jamais traversée worker po-2025 strict sur le dernier). Substances toutes matplotlib authentiques + familles distinctes de Probas/DecisionTheory.

## Cumul worker po-2025 strict après c.486

| Métrique | c.346 → c.486 |
|---|---|
| Pilotes §E figures | **17** |
| Bugs figures corrigés | **27** (3 c.486 + 24 c.346-c.483 + 0 c.484/c.485 hors-rollup) |
| Total figures auditées | **78** (6 c.486 + 72 c.346-c.485) |
| Bug-rate | **35%** (27/78) |

Distribution par famille c.346-c.486 : GenAI/Image racine (5/6 c.481), GenAI/Image/01-Foundation (2/6 c.482), GenAI/Audio (1/6 c.481b), GenAI/Image/examples (0/6 c.475), GenAI/Texte (0/3 c.479), ML.Net (0/6 c.480), SocialChoice (0/6 c.478), Search/Part1 (3/6 c.471), Search/Part2-CSP (0/6 c.472), Search/Part4 (2/4 c.474), Search/Applications (4/6 c.473), SemanticWeb (1/6 c.469), SymbolicLearning (3/3 c.5947), Probas/PyMC (3/6 c.483), GenAI/Image/02-Advanced (5/6 c.483), GenAI/Image/03-Orchestration (4/5 c.484), GenAI/Video/04-Applications (6/6 c.485), **Probas/DecisionTheory/PyMC (2+1/6 c.486)**.

## Note méthodologique — pattern « panneau périphérique décisif » (L486-L1 ★)

Pour les figures multi-panneaux `Probas/DecisionTheory/PyMC/` (typiquement matplotlib 2×2 ou côte-à-côte), le panneau qui contient **l'enseignement pédagogique principal** n'est pas toujours le panneau central :

- **dt2** : le 4ᵉ panneau « EU vs aversion » est **plus informatif** que les 3 histogrammes (qui montrent juste « 3 distributions différentes ») parce qu'il montre **comment le profil de risque tranche la décision**.
- **dt3** : le scatter rendement-risque est **plus informatif** que les histogrammes utilité (qui se recouvrent massivement) parce qu'il montre la **zone de non-dominance stochastique** où la décision MAUT devient nécessaire.
- **dt5-evpi** : la frontière de décision bleue + scenario actuel étoilé sont **plus informatifs** que la heatmap seule (qui sans repère est décorative).

Alt-text générique « comparaison de distributions » rate systématiquement ce point. **Pattern transférable** : pour tout MANIFEST matplotlib multi-panneaux, lire **chaque panneau** et nommer le panneau qui contient l'enseignement, pas le panneau le plus voyant.

## Liens EPICs / Issues

- *Part of #5780* — EPIC figures README #5654 / #3801 (doctrine amendée 2026-07-09)
- *See #5780* — convention rollout (cf commentaire ai-01 2026-07-10T22:58 : `See #5780` dans titre ET body, JAMAIS `fix/fixes/closes #5780`)
- Cf. #5654 (audit images Parent), #5668 (outillage `extract_readme_figures`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)