### PR TITLE
fix(nbformat,#6257): register v4.5 cell ids for Probas DecInfer + Search MGS-19 (49 cells)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
@@ -2,21 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "d4675418",
    "metadata": {},
    "source": "# DecInfer-10-Thompson-Sampling : Bandits bayesiens par Infer.NET\n\n**Serie** : Programmation Probabiliste avec Infer.NET (10/10)\n**Duree estimee** : 60 minutes\n**Prerequis** : [Infer-7-Skills-IRT](../../Infer/Infer-7-Skills-IRT.ipynb) (posterior Beta), [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) (bandits, epsilon-greedy, UCB1)\n\n---\n\n## Objectifs\n\n- Modeliser un **bandit multi-bras** comme un programme probabiliste Infer.NET\n- Faire calculer au **moteur d'inference** le posterior Beta-Bernoulli de chaque bras (inference variationnelle / EP), plutot que d'appliquer la formule conjuguee a la main\n- Implementer le **Thompson Sampling** : jouer le bras dont l'echantillon posterior est le plus eleve\n- Mesurer le **regret cumule** face a epsilon-greedy et UCB1 (Prong-B : Thompson exploite l'incertitude posterior)\n- Etendre au **best-arm identification** : estimer P(bras i est le meilleur) par echantillonnage posterior\n\n## Navigation\n\n| Precedent | Suivant |\n|-----------|---------|\n| [DecInfer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference](../../Infer/Infer-5-Causal-Inference.ipynb) |\n\n> **Pont inter-series** : le traitement des bandits en [DecInfer-8](DecInfer-8-Sequential.ipynb) section 8 implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (comptage des succes/echecs, formule conjuguee codee a la main). Ce notebook en est le versant **moteur** : Infer.NET calcule le posterior Beta de chaque bras par inference variationnelle, et Thompson echantillonne depuis ce posterior."
   },
   {
    "cell_type": "markdown",
+   "id": "b679a1ad",
    "metadata": {},
    "source": "## 1. Exploration vs exploitation — pourquoi Thompson ?\n\nUn **bandit multi-bras** (Robbins, 1952) : K bras, chacun d'une recompense Bernoulli de moyenne inconnue theta_k. A chaque pas de temps on choisit un bras, on percoit une recompense 0/1, et on cherche a **maximiser la recompense cumulee**. Le dilemme :\n\n- **Exploiter** : jouer le bras qui semble le meilleur jusqu'ici.\n- **Explorer** : tester un bras peu joue pour estimer sa moyenne.\n\nTrois familles de politiques :\n\n| Politique | Strategie d'exploration |\n|-----------|------------------------|\n| **epsilon-greedy** | Avec proba epsilon, jouer un bras au hasard (exploration uniforme) |\n| **UCB1** (Auer et al., 2002) | Jouer le bras maximisant moyenne + bonus d'incertitude `sqrt(2 ln t / n_k)` |\n| **Thompson Sampling** (Thompson, 1933) | Maintenir un **posterior** sur chaque theta_k ; **echantillonner** theta_k dans son posterior ; jouer le max |\n\n**L'idee de Thompson** est subtilement bayesienne : au lieu d'explorer au hasard (epsilon-greedy) ou via un bonus frequentiste (UCB1), on quantifie l'incertitude sur chaque bras par une **distribution posterior**, et on joue proportionnellement a la probabilite que chaque bras soit le meilleur. Les bras peu explores ont un posterior **large** (incertain) : l'echantillonnage les fait parfois gagner, ce qui declenche une exploration **ciblee** la ou l'information manque.\n\n### La valeur ajoutee Infer.NET (non-doublon avec DecInfer-8)\n\nPour un bras Bernoulli de prior Beta(a, b), le posterior apres s succes et f echecs est **conjugue** : Beta(a+s, b+f). On pourrait le coder a la main (c'est l'exercice DecInfer-8 section 8). **Ce notebook ne le fait pas** : on declare le modele `theta ~ Beta ; reward ~ Bernoulli(theta)` et on laisse **Infer.NET inferer le posterior**. Pour ce cas conjugue le moteur recouvre exactement la forme analytique — mais la meme approche se generalise a des modeles **non conjugues** ou la formule fermee n'existe pas, la ou seul un moteur d'inference (EP, VMP) sait faire."
   },
   {
    "cell_type": "markdown",
+   "id": "dfe9adea",
    "metadata": {},
    "source": "## 2. Configuration d'Infer.NET\n\nChargement du moteur d'inference probabiliste (meme `#r \"nuget\"` que toute la serie)."
   },
   {
    "cell_type": "code",
+   "id": "d3dfd228",
    "metadata": {},
    "outputs": [
     {
@@ -50,11 +54,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "264569cc",
    "metadata": {},
    "source": "Chargement du helper de visualisation des graphes de facteurs (Graphviz)."
   },
   {
    "cell_type": "code",
+   "id": "760cc0de",
    "metadata": {},
    "outputs": [
     {
@@ -81,11 +87,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "da7d0f2d",
    "metadata": {},
    "source": "## 3. Le modele Beta-Bernoulli d'un bras\n\nSoit un bras de probabilite de succes inconnue `theta`. Modele :\n\n- **Prior** : `theta ~ Beta(1, 1)` (uniforme sur [0,1] — ignorance totale).\n- **Vraisemblance** : `reward_i ~ Bernoulli(theta)` pour chaque tirage observe.\n\nApres avoir observe `s` succes et `f` echecs, on demande au moteur d'inference le posterior sur `theta`. Verifions qu'Infer.NET recouvre la forme conjuguee `Beta(1+s, 1+f)` (le moteur fait le calcul, nous declarons seulement le modele)."
   },
   {
    "cell_type": "code",
+   "id": "b1bd97ee",
    "metadata": {},
    "outputs": [
     {
@@ -142,11 +150,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3b45babd",
    "metadata": {},
    "source": "### 3.1 Graphe de facteurs du bras (Prong-A)\n\nLe meme modele, rendu en graphe de facteurs par Graphviz via le `FactorGraphHelper` (pattern de la serie, cf [DecInfer-3](../../Infer/Infer-3-Factor-Graphs.ipynb), [DecInfer-4](DecInfer-4-Multi-Attribute.ipynb)). Le noeud `theta` (Beta) alimente les facteurs Bernoulli des observations."
   },
   {
    "cell_type": "code",
+   "id": "afcce2f0",
    "metadata": {},
    "outputs": [
     {
@@ -268,11 +278,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0dd46912",
    "metadata": {},
    "source": "### 3.2 Convergence du posterior\n\nA mesure que les observations s'accumulent, le posterior se concentre autour de la vraie moyenne. Le moteur recalcule le posterior a chaque lot d'observations."
   },
   {
    "cell_type": "code",
+   "id": "bbd6ead0",
    "metadata": {},
    "outputs": [
     {
@@ -363,11 +375,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "af42b71d",
    "metadata": {},
    "source": "## 4. Reutiliser le moteur compile (problematique runtime)\n\nUn bandit reel rejoue des centaines de fois, et le posterior de chaque bras evolue a chaque recompense. Si l'on reconstruisait le modele a chaque pas, Infer.NET **recompilerait** a chaque fois (~250 ms par appel). La solution : un modele a **taille fixe** `MAX` ou un **masque** `mask[i]` dit quelles cases de `obs[i]` sont de vraies observations. On compile une fois, puis on met seulement a jour `ObservedValue` des tableaux : Infer.NET **reutilise** le code compile (mesure : ~0,2 ms par re-inference).\n\nOn encapsule ce pattern dans une classe `BayesArm` : un bras dont Infer.NET calcule le posterior."
   },
   {
    "cell_type": "code",
+   "id": "f869880f",
    "metadata": {},
    "outputs": [
     {
@@ -430,11 +444,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "493299c1",
    "metadata": {},
    "source": "## 5. Thompson Sampling multi-bras\n\nTrois bras de vraies moyennes `theta* = [0,2 ; 0,5 ; 0,8]` (inconnues de l'algorithme). A chaque pas de temps :\n\n1. Pour chaque bras, **Infer.NET infere** le posterior Beta.\n2. On **echantillonne** `theta_k ~ posterior_k` (Thompson : \"jouer selon la probabilite que chaque bras soit le meilleur\").\n3. On joue le bras d'echantillon maximum.\n4. On observe la recompense (Bernoulli(theta*)) et on met a jour le posterior du bras joue."
   },
   {
    "cell_type": "code",
+   "id": "040fc8ed",
    "metadata": {},
    "outputs": [
     {
@@ -584,11 +600,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e2a5b778",
    "metadata": {},
    "source": "## 6. Comparaison du regret cumule (Prong-B)\n\nLe **regret** mesure ce qu'on perd par rapport a jouer le bras optimal des le debut : `regret(t) = theta*_max - theta*(bras joue)`. On cumule sur T pas. On compare trois politiques, moyennées sur `N_runs` repetitions (graines differentes) :\n\n- **epsilon-greedy** (epsilon=0.1) : exploration uniforme aleatoire.\n- **UCB1** (Auer et al., 2002) : bonus d'incertitude frequentiste.\n- **Thompson** (via Infer.NET) : exploration bayesienne par echantillonnage posterior.\n\n**Hypothese (Prong-B)** : Thompson exploite l'incertitude posterior — il explore **la ou l'information manque**, pas au hasard — d'ou un regret cumule **inferieur** a epsilon-greedy."
   },
   {
    "cell_type": "code",
+   "id": "161f1c9d",
    "metadata": {},
    "outputs": [
     {
@@ -707,11 +725,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "068b2f33",
    "metadata": {},
    "source": "## 7. Extension — best-arm identification\n\nLe regret mesure la **performance** (cumul de recompenses). Une autre question : **identifier** le meilleur bras avec une garantie probabiliste. Thompson fournit naturellement `P(bras i est le meilleur)` : on echantillonne plusieurs fois les posteriors simultanement et on compte la frequence a laquelle chaque bras gagne. Quand cette probabilite depasse un seuil (ex. 0,95), on peut declarer le gagnant."
   },
   {
    "cell_type": "code",
+   "id": "4e5c18fd",
    "metadata": {},
    "outputs": [
     {
@@ -793,21 +813,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a3b88954",
    "metadata": {},
    "source": "## 8. Limites honnetes\n\n- **Cas conjugue favorable** : pour un bandit Bernoulli, le posterior Beta est analytique. L'apport d'Infer.NET n'est pas la (le moteur recouvre la formule fermee) mais dans la **generalisation** a des modeles non conjugues (ex. bras Gaussiennes de variance inconnue, effets contextuels) ou seule l'inference approchee (EP/VMP) sait calculer le posterior.\n- **Cout d'inference** : chaque pas de Thompson requiert `K` inferences posteriors. Grace au modele masque reutilise (~0,2 ms/call), cela reste negligeable pour `K` petit et `T` modere. Pour un grand `K` (centaines de bras) ou un modele lourd, l'overhead devient un facteur — c'est la ou un posterior conjugue code a la main (cf DecInfer-8 section 8) garde sa place.\n- **Non-stationnarite** : si les vraies `theta*` changent au cours du temps, le posterior Beta s'accumule indefiniment et devient trop confident. Il faut alors introduire un **facteur d'oubli** (sliding window, discount) — voir exercice 2."
   },
   {
    "cell_type": "markdown",
+   "id": "de6dfd20",
    "metadata": {},
    "source": "## 9. Exercices\n\nTrois exercices pour aller plus loin. Chaque stub s'execute sans erreur ; completez le code entre les `// TODO`.\n\n| # | Exercice | Concept |\n|---|----------|---------|\n| 1 | Ajouter un 4e bras et observer la convergence | Thompson sur K=4 |\n| 2 | Bandit non-stationnaire (facteur d'oubli) | Adaptation au changement |\n| 3 | Prior informatif Beta(50, 50) | Impact du prior sur l'exploration |"
   },
   {
    "cell_type": "markdown",
+   "id": "e9bae203",
    "metadata": {},
    "source": "### Exercice 1 — Ajouter un 4e bras et observer la convergence\n\nThompson Sampling se generalise de 3 a **K** bras. Ajoutez un 4e bras de vraie\nmoyenne 0,65 et relancez la boucle de selection. Observez comment le choix bascule\nde bras en bras puis se stabilise sur le meilleur des 4.\n\n**Objectif.** Etendre le modele a 4 bras et verifier que Thompson identifie le meilleur.\n\n**Indices.**\n- Etendez `vraiTheta` a 4 valeurs (par ex. `[0.3, 0.5, 0.7, 0.65]`).\n- Mettez `K = 4` et construisez 4 `BayesArm`, comme en section 5.\n- Reportez les tirages par bras et la recompense totale cumulee."
   },
   {
    "cell_type": "code",
+   "id": "ac9bc9aa",
    "metadata": {},
    "outputs": [
     {
@@ -831,11 +855,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5a4ecabf",
    "metadata": {},
    "source": "### Exercice 2 — Bandit non-stationnaire (facteur d'oubli)\n\nJusqu'ici les vraies moyennes sont fixes. En pratique elles peuvent **changer** : ici\nla meilleure bascule a `t = 100`. Implantez un **facteur d'oubli** : a chaque pas, ne\ngardez qu'une fraction des observations passees afin que le posterior s'adapte au\nchangement de regime.\n\n**Objectif.** Ajouter l'oubli au posterior et comparer le regret avec et sans oubli.\n\n**Indices.**\n- Modifiez `BayesArm.Observe` pour decaler/oublier les observations, ou ajoutez une\n  methode `Forget(double gamma)`.\n- Definissez `theta*(t)` qui change a mi-parcours (ex. le bras 1 devient meilleur apres `t=100`).\n- Comparez le regret avec et sans oubli sur la sequence non-stationnaire."
   },
   {
    "cell_type": "code",
+   "id": "bc274e33",
    "metadata": {},
    "outputs": [
     {
@@ -859,11 +885,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fe723f27",
    "metadata": {},
    "source": "### Exercice 3 — Prior informatif Beta(50, 50) vs uniforme\n\nUn prior `Beta(50, 50)` exprime une forte conviction que theta vaut environ 0,5 ; un\nprior `Beta(1, 1)` est uniforme (sans information a priori). Comparez le regret des\ndeux : un prior informatif reduit-il l'exploration prematuree ?\n\n**Objectif.** Mesurer l'impact du prior sur la vitesse de convergence de Thompson.\n\n**Indices.**\n- `BayesArm` accepte des parametres `priorA` / `priorB`.\n- Creez deux jeux de bras — l'un avec `Beta(1,1)`, l'autre avec `Beta(50,50)` — et\n  mesurez le regret de chacun.\n- Interpretez : dans quels cas un prior informatif aide-t-il, et quand nuit-il ?"
   },
   {
    "cell_type": "code",
+   "id": "d39609cb",
    "metadata": {},
    "outputs": [
     {
@@ -887,6 +915,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fe03db02",
    "metadata": {},
    "source": "## 10. Synthese\n\n| Politique | Exploration | Calcul du posterior | Origine |\n|-----------|-------------|---------------------|---------|\n| **epsilon-greedy** | uniforme (proba epsilon) | aucun (moyenne empirique) | frequentiste |\n| **UCB1** | bonus d'incertitude `sqrt(2 ln t / n_k)` | aucun (moyenne empirique) | Auer et al. 2002 |\n| **Thompson** | echantillonnage posterior | **Infer.NET (EP/VMP)** | Thompson 1933 |\n\n### Ce qu'il faut retenir\n\n- **Thompson Sampling = jouer selon la probabilite que chaque bras soit le meilleur**, quantifiee par un posterior. Les bras incertains (posterior large) sont naturellement explores.\n- **Le moteur Infer.NET calcule le posterior** (section 3) : on declare `theta ~ Beta ; reward ~ Bernoulli(theta)` et le moteur infere `Beta(1+s, 1+f)`. Pour ce cas conjugue il recouvre la forme analytique ; l'interet est la **generalisation** aux modeles non conjugues.\n- **Prong-B PROVEN** : le regret cumule de Thompson est **inferieur** a epsilon-greedy (section 6) — l'exploration bayesienne ciblee par le posterior exploite l'incertitude la ou l'information manque, au lieu d'explorer au hasard. Le probleme n'est pas degenerere : la selection depend visiblement des posteriors.\n\n### Ponts\n\n- **DecInfer-8 section 8** : implemente epsilon-greedy, UCB1 et un exercice de Thompson **manuel** (formule conjuguee codee a la main). Ce notebook en est le versant **moteur**.\n- **DecInfer-8 section 10bis** : les belief-state updates en Infer.NET pour les POMDPs — meme idee d'inference posterior sequentielle, dans un cadre partiellement observable.\n- **References** : Thompson, W. R. (1933) *On the likelihood that one unknown probability exceeds another* ; Auer, P., Cesa-Bianchi, N. & Fischer, P. (2002) *Finite-time analysis of the multiarmed bandit problem* ; Russo, D., Van Roy, D., Kazerouni, A., Osband, I. & Wen, Z. (2018) *A Tutorial on Thompson Sampling*.\n\n---\n\n[<- Infer-8-Sequential](DecInfer-8-Sequential.ipynb) | [Infer-5-Causal-Inference ->](../../Infer/Infer-5-Causal-Inference.ipynb) | [Retour a la serie](README.md)"
   }

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
@@ -4488,6 +4488,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "de9da620",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
@@ -1058,6 +1058,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "17310ebe",
    "metadata": {},
    "source": [
     "## Conclusion — ce que nous avons appris\n",

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-19-MetropolisReinsertion.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "cb8a32e5",
    "metadata": {},
    "source": [
     "# MGS-19 — Recuit simulé décomposé : l'opérateur de Metropolis isolé\n",
@@ -20,6 +21,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a4c33786",
    "metadata": {},
    "source": [
     "## Le critère de Metropolis et son double habitat\n",
@@ -33,6 +35,7 @@
   },
   {
    "cell_type": "code",
+   "id": "50ba3bde",
    "metadata": {},
    "execution_count": 1,
    "outputs": [
@@ -103,6 +106,7 @@
   },
   {
    "cell_type": "code",
+   "id": "f99f87ea",
    "metadata": {},
    "execution_count": 2,
    "outputs": [
@@ -178,6 +182,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "db095130",
    "metadata": {},
    "source": [
     "## Méthode\n",
@@ -197,6 +202,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d36441b8",
    "metadata": {},
    "source": [
     "## Partie A — le témoin neutre : Sphere (unimodale)\n",
@@ -206,6 +212,7 @@
   },
   {
    "cell_type": "code",
+   "id": "32ff68fb",
    "metadata": {},
    "execution_count": 3,
    "outputs": [
@@ -284,6 +291,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5fc9996d",
    "metadata": {},
    "source": [
     "**Lecture (G.9).** Sur Sphere, le contrôle greedy et les `Metropolis` froid/moyen résolvent la fonction (objectif ≈ 0,01) : il n'y a pas de montée utile à accepter — c'est le **témoin neutre attendu**. Le réglage **chaud** dégrade pourtant nettement (≈ 0,10, soit ~8× le contrôle) : à force d'accepter des montées inutiles, il injecte du bruit dans une convergence facile. Leçon provisoire : sur un paysage unimodal, l'annealing ne sert à rien et trop d'annealing nuit. Le paysage multimodal dira si cela s'inverse."
@@ -291,6 +299,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b0c54087",
    "metadata": {},
    "source": [
     "## Partie B — le paysage discriminant : Rastrigin (fortement multimodale)\n",
@@ -300,6 +309,7 @@
   },
   {
    "cell_type": "code",
+   "id": "805c34d7",
    "metadata": {},
    "execution_count": 4,
    "outputs": [
@@ -367,6 +377,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ddd72432",
    "metadata": {},
    "source": [
     "**Lecture honnête (résultat négatif).** Le verdict **réfute** l'hypothèse d'évasion : sur Rastrigin, aucun réglage Metropolis n'améliore le contrôle greedy pairwise (1,19) — le froid (1,62) et le chaud (1,77) le dégradent nettement, le moyen (1,23) est dans le bruit. Accepter des enfants moins bons à la réinsertion n'aide pas le GA à franchir les cols ; cela l'écarte des bons bassins, et le réglage le plus chaud (le plus d'annealing) est le **pire**.\n",
@@ -376,6 +387,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6256bd9b",
    "metadata": {},
    "source": [
     "## Partie C — second multimodal : Ackley (puits central + rides fines)\n",
@@ -385,6 +397,7 @@
   },
   {
    "cell_type": "code",
+   "id": "2ace5c82",
    "metadata": {},
    "execution_count": 5,
    "outputs": [
@@ -452,6 +465,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2c890cbf",
    "metadata": {},
    "source": [
     "**Lecture.** Même verdict qu'en Rastrigin : le Metropolis froid (2,46) est dans le bruit du contrôle greedy (2,74) — pas d'amélioration fiable ; le moyen (2,92) et surtout le chaud (4,32) dégradent. La géométrie différente d'Ackley ne renverse pas la conclusion : l'acceptation annealée détachée du couplage SA n'aide pas."
@@ -459,6 +473,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4ca815db",
    "metadata": {},
    "source": [
     "## Partie D — la signature de température et la limite frozen\n",
@@ -468,6 +483,7 @@
   },
   {
    "cell_type": "code",
+   "id": "341a2308",
    "metadata": {},
    "execution_count": 6,
    "outputs": [
@@ -624,6 +640,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5a936221",
    "metadata": {},
    "source": [
     "## Synthèse — un opérateur démonté, un bénéfice qui ne voyage pas\n",
@@ -641,6 +658,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dcef00a6",
    "metadata": {},
    "source": [
     "## Exercices\n",


### PR DESCRIPTION
## Summary

Registers missing nbformat v4.5 cell `id` fields (deterministic 8-hex) for 4 notebooks with structural gaps. Surgical id-only injection: **0 deletions**, content byte-identical to `origin/main`.

| Notebook | Family | Cells with id added |
|----------|--------|---------------------|
| DecInfer-10-Thompson-Sampling | Probas/Decision | 29 |
| MGS-19-MetropolisReinsertion | Search/Metaheuristics | 18 |
| DecInfer-6-Value-Information | Probas/Decision | 1 |
| Infer-16-Sparse-Gaussian-Process | Probas/Infer | 1 |
| **Total** | | **49** |

## Convention (#6257)

`id` = 8-hex random, inserted immediately after `cell_type` (minimal-diff canonical-early position; consistent across markdown + code cells regardless of the notebooks' original non-standard key ordering).

## Verification (H.5 forensic)

- **Diff preflight**: `git diff --shortstat` = 4 files, **49 insertions(+), 0 deletions** — purely `+   "id": "xxxxxxxx",` lines.
- **nbformat.validate()**: OK on all 4 notebooks.
- **Canonical validator** `scripts/notebook_tools/validate_pr_notebooks.py`: **3/3 PASS** (40 code cells). DecInfer-10 skipped by a validator quirk; verified healthy firsthand — 12/12 code cells have `execution_count` 1-12 + non-empty outputs (unchanged vs `origin/main`).
- **Content fingerprint**: per-cell SHA-256 (content minus `id`) identical before/after.
- **No CRLF** introduced; original trailing-newline state preserved per file (3 with `\n`, MGS-19 without).

## Verdict

`STRUCTURAL_ONLY` — id registration metadata only; no source / output / execution_count change. No notebook re-execution required (no source touched).

See #6257