### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Sudoku-10-ORTools-Csharp

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -406,7 +406,8 @@
     "\n",
     "**Indice :**\n",
     "Parcourez les contraintes de ligne, colonne, bloc et cellule et comptez-les.\n"
-   ]
+   ],
+   "id": "cell-e6193129"
   },
   {
    "cell_type": "code",
@@ -429,7 +430,8 @@
     "    // dans le modèle OR-Tools pour ce puzzle\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-5a67c251"
   },
   {
    "cell_type": "code",
@@ -717,7 +719,8 @@
     "\n",
     "**Indice :**\n",
     "Créez le modèle, fixez les variables aux valeurs de la solution, et vérifiez la faisabilité.\n"
-   ]
+   ],
+   "id": "cell-6d82acb0"
   },
   {
    "cell_type": "code",
@@ -740,7 +743,8 @@
     "    // et vérifiez que toutes les contraintes sont satisfaites\n",
     "    return false; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-6dfc572f"
   },
   {
    "cell_type": "markdown",
@@ -1149,7 +1153,8 @@
     "\n",
     "**Indice :**\n",
     "Ajoutez une contrainte AllDifferent pour chaque diagonale de la grille.\n"
-   ]
+   ],
+   "id": "cell-a0a951cd"
   },
   {
    "cell_type": "code",
@@ -1172,7 +1177,8 @@
     "    // et résolvez le puzzle\n",
     "    return null; // TODO etudiant\n",
     "}\n"
-   ]
+   ],
+   "id": "cell-021396d7"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (6 ids) to `Sudoku/Sudoku-10-ORTools-Csharp.ipynb` — part of the v4.5 cell-id gap sweep (see #6257). Completes the Sudoku family coverage (the last C# cluster in the series; Python siblings covered by #6465).

| Notebook | ids added |
|----------|-----------|
| `Sudoku/Sudoku-10-ORTools-Csharp.ipynb` | 6 |

Already v4.5 (`nbformat_minor=5`) but 6 cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit (json round-trip matched raw on this notebook, so no surgical raw-text fallback was needed — contrast with the .NET bootstrap-whitespace notebooks that require it).

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED**.
- `validate_pr_notebooks.py` **PASSED**.
- `git diff --stat`: `12 insertions(+), 6 deletions(-)` = **exactly 2N/N** (N=6).
- **Byte-identity proof**: stripping id lines + comma-normalizing the diff yields **0 real content changes**. `execution_count` / `outputs` / `source`: unchanged.

See #6257.
