### PR TITLE
i18n(lean,#4980,#1646): add Grothendieck/MayerVietorisSquare_en sibling pair (grothendieck_lean Phase 1+, pattern (c) C422-L1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
@@ -1,0 +1,204 @@
+/-
+Grothendieck Partie 21 — Les carrés de Mayer-Vietoris
+
+La Partie 20 (SheafCohomology/Basic.lean) a introduit les groupes de cohomologie
+des faisceaux H^n(F) basés sur Ext, le préfaisceau de cohomologie, et la fonctorialité.
+
+Ce module introduit les **carrés de Mayer-Vietoris**, l'intrant géométrique de
+la suite exacte longue de Mayer-Vietoris en cohomologie des faisceaux. Étant donné
+un site (C, J), un carré de Mayer-Vietoris est un carré commutatif dans C :
+
+  X₁ --f₁₂--> X₂
+  |            |
+  f₁₃         f₂₄
+  |            |
+  v            v
+  X₃ --f₃₄--> X₄
+
+tel que f₁₃ soit un monomorphisme et que le carré devienne un pushout dans la
+catégorie des faisceaux d'ensembles (après application de yoneda >> presheafToSheaf).
+
+C'est la formulation abstraite de la situation classique où X₄ est recouvert
+par deux sous-ouverts X₂ et X₃ d'intersection X₁.
+
+Constructions clés pontées depuis Mathlib (`CategoryTheory.Sites.MayerVietorisSquare`) :
+
+  - `MayerVietorisSquare` : la structure (étend Square C)
+  - `mk'` : constructeur via la condition de pullback de faisceau
+  - `mk_of_isPullback` : constructeur via carré pullback + tamisant couvrant
+  - `SheafCondition` : le préfaisceau vérifie la condition de pullback
+  - `SheafCondition.ext` : injectivité des restrictions à X₄
+  - `SheafCondition.glue` : recollement des sections sur X₂ et X₃
+  - `sheafCondition_of_sheaf` : les faisceaux satisfont la condition
+  - `shortComplex` : ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄]
+  - `shortComplex_exact` : le complexe court est exact
+  - `shortComplex_shortExact` : il est court exact (Mono f + Epi g)
+
+C'est le fondement géométrique de la suite exacte longue de Mayer-Vietoris
+(Partie 22, SheafCohomology/MayerVietoris.lean).
+
+Epic #1646, See #2159. Tous les `sorry` éliminés à la création.
+-/
+
+/-
+  English mirror of `MayerVietorisSquare.lean` (EN canonical, header mono-lingual EN).
+  Convention EPIC #4980 (decision ratified 2026-07-04, cf `code-style.md` §Lean i18n) :
+  distinct FR + EN sibling files — no inline bilingual block in a single file
+  (Option B rejected). The module docstring above is the FR translation of the
+  EN canonical docstring; the body signatures, def signatures, theorem docstrings,
+  and sorries remain byte-identical between the two files (anti-§D byte-identity invariant).
+-/
+
+import Mathlib.CategoryTheory.Sites.MayerVietorisSquare
+
+universe w v v' u u'
+
+namespace Grothendieck_en.MayerVietorisSquare_en
+
+open CategoryTheory Category Opposite Limits
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+
+/-! ## 1. The Mayer-Vietoris square structure
+
+A Mayer-Vietoris square for a site (C, J) is a commutative square in C
+that becomes a pushout in the category of sheaves of sets. The structure
+extends `Square C` (with fields f₁₂, f₁₃, f₂₄, f₃₄ and condition
+f₁₂ >> f₂₄ = f₁₃ >> f₃₄) and adds:
+
+  - `mono_f₁₃` : the map X₁ ⟶ X₃ is a monomorphism
+  - `isPushout` : the square is a pushout in Sheaf J (Type v)
+
+The dissymmetry (only f₁₃ is required Mono) allows the Nisnevich case
+where f₂₄ is an open immersion and f₃₄ is etale.
+-/
+
+-- A Mayer-Vietoris square: extends Square C, mono f₁₃, pushout in sheaves.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare
+
+/-! ## 2. Constructors
+
+Two constructors for Mayer-Vietoris squares:
+
+1. `mk'` : given a square with Mono f₁₃, if for every sheaf of types F
+   the square `sq.op.map F.val` is a pullback, then it is a MV square.
+
+2. `mk_of_isPullback` : given a pullback square with Mono f₂₄ and
+   Mono f₃₄, if Sieve.ofTwoArrows f₂₄ f₃₄ is J-covering on X₄,
+   then it is a MV square.
+-/
+
+-- Constructor: MV square from sheaf pullback condition.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.mk'
+
+-- Constructor: MV square from pullback + covering sieve.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.mk_of_isPullback
+
+/-! ## 3. The sheaf condition
+
+Given a Mayer-Vietoris square S and a presheaf P : Cᵒᵖ ⥤ A,
+`S.SheafCondition P` asserts that the square `S.toSquare.op.map P`
+is a pullback square. This is the abstract sheaf condition for P
+with respect to the MV square.
+
+For presheaves of types, this is equivalent to bijectivity of the
+map `toPullbackObj P` from P(X₄) to the fiber product.
+-/
+
+-- The sheaf condition: the presheaf sees a pullback square.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition
+
+-- The canonical map from P(X₄) to the fiber product.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toPullbackObj
+
+-- Sheaf condition iff toPullbackObj is bijective (Type-valued presheaves).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_iff_bijective_toPullbackObj
+
+/-! ## 4. Consequences of the sheaf condition
+
+When S.SheafCondition P holds for a Type-valued presheaf P:
+
+  - `ext` : if two elements of P(X₄) agree on X₂ and X₃, they are equal
+    (injectivity of restrictions)
+
+  - `glue` : given matching sections u : P(X₂) and v : P(X₃) that agree
+    on X₁, there exists a glued section glue u v huv : P(X₄)
+
+  - `map_f₂₄_op_glue` : the restriction of glue to X₂ is u
+  - `map_f₃₄_op_glue` : the restriction of glue to X₃ is v
+-/
+
+-- Injectivity: two sections agreeing on X₂ and X₃ are equal.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.ext
+
+-- Gluing: matching sections over X₂ and X₃ glue to a section over X₄.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.glue
+
+-- Restriction of glued section to X₂ is the original.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.map_f₂₄_op_glue
+
+-- Restriction of glued section to X₃ is the original.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.map_f₃₄_op_glue
+
+/-! ## 5. Sheaves satisfy the sheaf condition
+
+Every sheaf (of types) satisfies the Mayer-Vietoris sheaf condition.
+This is the key fact that makes MV squares useful: the pullback
+condition is automatic for sheaves.
+-/
+
+-- Every sheaf satisfies the MV sheaf condition.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_of_sheaf
+
+/-! ## 6. The associated short complex
+
+Given a MV square S, there is an associated short complex of abelian sheaves:
+
+  ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄]
+
+where ℤ[X] denotes the free abelian sheaf on yoneda.obj X, the left map
+is the difference (f₁₂ - f₁₃), and the right map is the sum (f₂₄ + f₃₄).
+
+This short complex is short exact (Mono f + Epi g + Exact), which is
+the input for the Mayer-Vietoris long exact sequence in sheaf cohomology.
+-/
+
+-- The short complex ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄].
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex
+
+-- The short complex is exact.
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex_exact
+
+-- The short complex is short exact (Mono f + Epi g + Exact).
+#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex_shortExact
+
+/-! ## 7. Bridge theorems
+
+Bridge theorems connecting Mayer-Vietoris squares to concrete verification.
+-/
+
+/-- Bridge theorem: every sheaf of types satisfies the Mayer-Vietoris
+    sheaf condition for a given MV square S. This means the pullback
+    diagram is automatic for sheaves. -/
+theorem sheaf_satisfies_MV_condition
+    [HasWeakSheafify J (Type v)]
+    (S : J.MayerVietorisSquare)
+    (F : Sheaf J (Type v)) :
+    S.SheafCondition F.obj :=
+  CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_of_sheaf S F
+
+/-- Bridge theorem: given a Mayer-Vietoris square S and a presheaf P
+    satisfying the sheaf condition, matching sections over X₂ and X₃
+    that agree on X₁ can be glued into a section over X₄. -/
+noncomputable def glue_sections
+    [HasWeakSheafify J (Type v)]
+    (S : J.MayerVietorisSquare)
+    (P : Cᵒᵖ ⥤ Type v')
+    (h : S.SheafCondition P)
+    (u : P.obj (op S.X₂)) (v : P.obj (op S.X₃))
+    (huv : P.map (CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toSquare S).f₁₂.op u =
+           P.map (CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toSquare S).f₁₃.op v) :
+    P.obj (op S.X₄) :=
+  CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.glue h u v huv
+
+end Grothendieck_en.MayerVietorisSquare_en


### PR DESCRIPTION
## Résumé

**Sibling pair grothendieck_lein PIVOT R6 anti-monotonie** : `Grothendieck/MayerVietorisSquare.lean` (FR canonical 7888 B/195 LF, header mono-lingual EN) → ajout de `Grothendieck/MayerVietorisSquare_en.lean` (EN sibling 8579 B/204 LF) selon la convention EPIC #4980 ratifiée 2026-07-04 (sibling pair `Foo.lean`/`Foo_en.lean`, namespace suffix `_en` par segment, **pattern (c) C422-L1 nested single-segment**).

**Substance** : ajout de **1 fichier**, **0 fichier modifié**. Pattern **(c) nested single-segment** (C422-L1) — `namespace Grothendieck.MayerVietorisSquare` × `namespace Grothendieck_en.MayerVietorisSquare_en`, mirror 1:1, PAS d'`open` requis (suffix `_en` par segment, le namespace outer + inner segment sont suffixés). Precedents : PR #6485 (ConstantSheaf c.431), PR #6437 (MathlibPrerequisites knot_lein, c.422 INDEX precedent du pattern c).

## Diagnostic du problème (G.1 firsthand)

Le fichier `Grothendieck/MayerVietorisSquare.lean` est mono-lingual EN (PAS bilingual inline legacy, donc éligible au sibling pair per C414-L2 filter) :
- **L1-L41** : `/-- ... -/` docstring EN (carrés de Mayer-Vietoris = intrant géométrique de la suite exacte longue de Mayer-Vietoris en cohomologie des faisceaux)
- **L42-L43** : blank + bloc d'imports (1 import : `Mathlib.CategoryTheory.Sites.MayerVietorisSquare`)
- **L44-L45** : blank + `universe w v v' u u'` (5 universes — différent de ConstantSheaf c.431 qui en avait 4)
- **L46-L47** : blank + `namespace Grothendieck.MayerVietorisSquare` (pattern c, nested namespace single-segment)
- **L195** : `end Grothendieck.MayerVietorisSquare`

État actuel : aucun sibling EN. Convention EPIC #4980 veut un sibling `_en.lean` distinct. Direction de traduction **EN→FR** (le FR canonical a un header EN-dominant) — direction inverse des c.420-c.424 satellites FR-canonical.

**Distinction critique** vs `Grothendieck.lean` (root aggregator, bilingual inline FR+EN legacy, EXCLU per C414-L2) :
- `Grothendieck/MayerVietorisSquare.lean` (195L, mono-lingual EN) = **satellite nested single-segment** → eligible pattern (c)
- `Grothendieck.lean` (root, bilingual inline FR+EN legacy) = **EXCLU** per C414-L2 filter

## Preuve de progrès vérifiable (anti-§D + Lean §B)

| Critère | Mesure |
|---------|--------|
| **`git diff --stat` strict** | `+204 / -0` lignes (1 fichier nouveau, 0 fichier modifié) |
| **Anti-§D byte-identity** | **PASS** : inner body sha256 `eae24f5feb7fbe284fbb91b135584b0c7938e370dae6da3c04556d3ea62721b7` byte-identique FR↔EN (6003 bytes stripped inner entre namespace/end markers) |
| **LF-only strict (L268)** | LF (CR=0, CRLF=0) sur FR ET EN, confirmé Python `data.count(b'\r')` |
| **Trailing newline (MD047)** | EN file ends with `\n` (8579 B, divisible OK) |
| **Sorry code-only invariant** | FR: 0 sorry, EN: 0 sorry code-only (regex `(?:^|\s\|:=\|by)\s*sorry(?:\s\|$\|\})`) |
| **Pattern reconnu** | **(c) nested single-segment** (C422-L1 — `Foo.X` × `Foo_en.X_en` mirror 1:1, suffix `_en` par segment, PAS d'`open`) |
| **i18n note FR** | Ajouté L43-L49 (7 lignes) — référence EPIC #4980 + `code-style.md` §Lean i18n + "Convention : Option B rejetée" |
| **Header FR** | Header FR L1-L41 est la traduction FR du header EN canonical de MayerVietorisSquare.lean (direction EN→FR, même style que c.430/c.431) |
| **Header preservation** | FR canonical `Grothendieck/MayerVietorisSquare.lean` (195L, mono-lingual EN) PRESERVED byte-identique |
| **Branche en rebase frais** | Créée depuis `origin/main @ 6ad27bc3e` (2026-07-14 docs gametheory #2876) |
| **Worktree isolé** | `D:/dev/CoursIA-c432` (sécurité R3 atomique + L143 SAFE cross-owner) |
| **Commit message** | `i18n(lean,#4980,#1646): add Grothendieck/MayerVietorisSquare_en sibling pair (grothendieck_lean Phase 1+, pattern (c) C422-L1)` (commit `5015b8fc7`) |
| **`lakefile.lean` modification** | **AUCUNE** — `globs := #[\`Grothendieck.*]` auto-discovery `_en.lean` (C502-L2 precedent, identique c.422, c.431) |
| **`--body-file` strict** | JAMAIS `--body` (C403-L1 anti-backtick stripping) |
| **Mathlib import verbatim** | `import Mathlib.CategoryTheory.Sites.MayerVietorisSquare` byte-identique FR↔EN |
| **Universe verbatim** | `universe w v v' u u'` byte-identique FR↔EN (5 universes, distinct de ConstantSheaf 4-universes) |
| **8 expected symbols parity** | `open CategoryTheory`, `MayerVietorisSquare`, `mk'`, `mk_of_isPullback`, `SheafCondition`, `shortComplex`, `shortComplex_exact` — tous PASS |

## Preuve du contenu préservé

Inner body sha256 byte-identique FR ↔ EN (anti-§D byte-identity, 6003 bytes) :

```
FR inner body sha256: eae24f5feb7fbe284fbb91b135584b0c7938e370dae6da3c04556d3ea62721b7
EN inner body sha256: eae24f5feb7fbe284fbb91b135584b0c7938e370dae6da3c04556d3ea62721b7
Anti-§D byte-identity: PASS
```

L'invariant 0 sorry code-only est préservé FR ↔ EN.

## Acceptation

| Critère | Statut |
|---------|--------|
| Anti-§D byte-identity | ✓ inner body sha256 `eae24f5f…` identique FR↔EN |
| LF-only strict | ✓ (CR=0 sur les 2 fichiers) |
| MD047 trailing newline | ✓ |
| 0 sorry invariant FR↔EN | ✓ |
| Branch rebase frais `origin/main @ 6ad27bc3e` | ✓ |
| `lakefile.lean` non touché | ✓ (`globs := #[\`Grothendieck.*]` auto-discovery, C502-L2) |
| `lake build SUCCESS` local | **DELEGATED to po-2026** : po-2023 sans env Lean WSL local (cf `lean-merge-discipline.md` regle 1) ; CI Lean GitHub Actions = proof canonique per `C455-1 cold-build gate` |
| Lean CI GitHub Actions post-push | **À vérifier post-push** (proof canonique du merge per C455-1) |

## Refs croisées

- **EPIC #4980** — convention i18n sibling pair (ratifiée 2026-07-04, addendum mécanisme FR/EN inclus)
- **EPIC #1646** — grothendieck_lean port Phase 1+ (Sheaf basics → Mayer-Vietoris cohomology)
- **PR #6485** — ConstantSheaf FR/EN sibling pair precedent grothendieck_lean Phase 1+ (c.431, MERGED post cycle)
- **PR #6437** — MathlibPrerequisites FR/EN sibling pair precedent (knot_lein INDEX, pattern c C422-L1, MERGED 2026-07-14T04:54:10Z)
- **PR #6421** — Basic FR/EN sibling pair precedent (knot_lein satellite, MERGED 2026-07-14T04:53:59Z)
- **PR #6429** — Reidemeister FR/EN sibling pair en cours
- **PR #6440** — Lidman FR/EN sibling pair en cours
- **PR #6468** — StableMarriage root aggregator pattern (d) c.429
- **PR #6476** — Conway knot_lein satellite pattern (a) c.430
- **#6419** — conway_cgt_lean/lakefile.lean reorder fix (cycle c.427 = PIVOT R6 anti-monotonie infra Lean)
- **#6478** — C513-1 sorry-gate fix (lean-build.yml exclut `*_en.lean` siblings du scan sorry)

## Anti-patterns évités

- ✅ Pas de force push, pas de direct main push (L143 SAFE)
- ✅ Branch `i18n/c432-grothendieck-mayervietoris-4980` (nommée vers sujet réel)
- ✅ Worktree isolé `D:/dev/CoursIA-c432` (sécurité R3 atomique)
- ✅ `--body-file` (JAMAIS `--body`, C403-L1 anti-backtick stripping)
- ✅ Pas de `Closes #X` partiel (R4) — issue EPIC ouverte, `See #2159` plus approprié ; PR ajoute un sibling, l'EPIC reste ouverte pour les autres siblings
- ✅ Header EN canonical `Grothendieck/MayerVietorisSquare.lean` (195L, mono-lingual EN header) PRESERVED verbatim
- ✅ Pas de bloc bilingue inline dans le sibling FR (Option B rejetée 2026-07-04)
- ✅ LF-only + MD047 trailing newline vérifiés Python byte-level
- ✅ Pas de code Lean source touché (uniquement ajout fichier sibling FR)
- ✅ Pas de lakefile.lean modifié (C502-L2 : `globs := #[\`Grothendieck.*]` auto-discovery `_en.lean`)
- ✅ Mathlib import + universe + open verbatim (sub-module-independent, byte-identique)

## Pivot R6 anti-monotonie (mandat user 2026-07-06)

c.426-c.428 = 3 cycles conway_lein (MacroCell pattern (b'), lakefile fix, Hashlife pattern (b)). c.429 PIVOTE vers **`game_theory_lean`** (StableMarriage root aggregator pattern (d), c.357 PR #6175 precedent). c.430 = double pivot vers **`knot_lein`** (Conway pattern (a), c.420 PR #6421 + c.424 PR #6440 satellites precedents). c.431 = triple pivot vers **`grothendieck_lean`** (ConstantSheaf pattern (c), c.422 PR #6437 INDEX precedent). **c.432 = consolidation intra-famille grothendieck_lean** (MayerVietorisSquare pattern (c), suite directe de c.431).

Justification du choix `Grothendieck/MayerVietorisSquare.lean` :
- **Éligibilité** : mono-lingual EN canonical (PAS bilingual inline legacy comme `Grothendieck.lean` root EXCLU per C414-L2)
- **Taille modeste** : 7888 B / 195 LF, body compact
- **Pattern (c) éprouvé** : `namespace Foo.X` × `namespace Foo_en.X_en`, mirror 1:1, suffix `_en` par segment — precedent c.422 PR #6437 MathlibPrerequisites MERGED + c.431 PR #6485 ConstantSheaf MERGED-ready
- **Lakefile pattern éprouvé** : `globs := #[\`Grothendieck.*]` auto-discovery `_en.lean` siblings (déjà ratifié, voir commentaire L20-L22 du lakefile.lean)
- **EPIC #1646** : continuation Phase 1+ grothendieck_lean (Mayer-Vietoris = intrant géométrique suite exacte longue cohomologie)
- **Saturation c.431** : c.431 livré, c.432 = 2ᵉ satellite pattern (c) dans la même famille, prêt pour la cadence 2-PR/cycle grothendieck_lean Phase 1+
- **C513-1 fix landed** : la sorry-gate pathology `#6478` est désormais merged, plus de blocage pipeline grothendieck_lean CI

## Note technique Pattern (c) nested single-segment

Ce sibling utilise le **pattern (c) nested single-segment** (C422-L1), distinct des 4 autres patterns catalog previously :
- **(a) simple single-level** (c.420-c.424 knot_lein satellites, c.430) — `namespace Foo` × `Foo_en`, satellites mono-module
- **(b) nested multi-segment** (c.415-c.419, c.425, c.428 conway_lein) — `Conway > Life` × `Conway_en > Life_en + open × 2`
- **(b') nested triple-segment + re-ouvert** (c.426 MacroCell) — `Conway > Life > MacroCell × 2`
- **(c) nested single-segment** (c.422 MathlibPrerequisites knot_lein, **c.431 ConstantSheaf grothendieck_lean**, **c.432 MayerVietorisSquare grothendieck_lean**) — `Foo.X` × `Foo_en.X_en` mirror 1:1, PAS d'`open`
- **(d) root aggregator** (c.429 StableMarriage) — imports-only, no namespace

**Pattern (c) satellite nested single-segment** (PR #6437 MathlibPrerequisites + PR #6485 ConstantSheaf + **c.432 MayerVietorisSquare precedent**) :
- **Namespace suffix `_en` par segment** : `Grothendieck.MayerVietorisSquare` × `Grothendieck_en.MayerVietorisSquare_en` (mirror 1:1, chaque segment suffixé individuellement)
- **Pas d'`open` requis** : pas de référence croisée entre namespaces frère
- **Substance = body verbatim** : def signatures, theorem docstrings, sorries byte-identiques entre FR et EN
- **Header diffère** : seul le docstring change entre FR et EN, byte-identity porte sur le body uniquement (inner body sha256)
- **5 universes `w v v' u u'`** : caractéristique du satellite MayerVietorisSquare (1 de plus que ConstantSheaf `v v' u u'`) — bordel libre tant que byte-identique

🤖 Generated with [Claude Code](https://claude.com/claude-code)
