### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to ML cluster (ML.Net + NumPy)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb
@@ -403,7 +403,8 @@
     "1. C. R. Harris et al., *Array programming with NumPy*, Nature, 585(7825):357-362, 2020. doi:10.1038/s41586-020-2649-2. Article de référence décrivant l'objet `ndarray`, l'écosystème de tableaux N-dimensionnels et les fondations de la data science Python.\n",
     "2. S. van der Walt, S. C. Colbert, G. Varoquaux, *The NumPy Array: A Structure for Efficient Numerical Computation*, Computing in Science & Engineering, 13(2):22-30, 2011. Architecture interne de `ndarray` et principes de vectorisation.\n",
     "3. T. E. Oliphant, *A Guide to NumPy*, Trelgol Publishing, 2006. Référence technique historique sur NumPy (première édition)."
-   ]
+   ],
+   "id": "cell-a4c4a43f"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -2304,7 +2304,8 @@
     "### Et ensuite ?\n",
     "\n",
     "Une fois le modèle évalué et expliqué, reste à l'améliorer (cf. section précédente) puis à le déployer. Le notebook suivant ([ML-5 TimeSeries](ML-5-TimeSeries.ipynb)) aborde un régime particulier où l'ordre temporel des données change la façon d'évaluer (la validation croisée aléatoire y devient une fuite d'information)."
-   ]
+   ],
+   "id": "cell-1b95a742"
   },
   {
    "cell_type": "markdown",
@@ -2317,7 +2318,8 @@
     "3. T. Fawcett, *An Introduction to ROC Analysis*, Pattern Recognition Letters, 27(8):861-874, 2006. Courbe ROC et aire sous la courbe (AUC).\n",
     "4. T. Hastie, R. Tibshirani, J. Friedman, *The Elements of Statistical Learning*, Springer, 2009. Métriques d'évaluation et théorie de l'apprentissage statistique.\n",
     "5. A. R. Ahmed et al., *Hands-On Machine Learning with ML.NET*, Packt, 2019. Référence appliquée pour l'écosystème ML.NET (API `Evaluate`, `PermutationFeatureImportance`, `CrossValidate`)."
-   ]
+   ],
+   "id": "cell-b14f7bd2"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (3 ids across 2 notebooks) to the `ML` family — part of the v4.5 cell-id gap sweep (see #6257). Covers ML.Net (Evaluation) + the PythonForDataScience NumPy intro.

| Notebook | ids added |
|----------|-----------|
| `ML/ML.Net/ML-4-Evaluation.ipynb` | 2 |
| `ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb` | 1 |

Each was **already v4.5 (`nbformat_minor=5`)** but 1-2 cells lacked the required `id` field.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit (json round-trip matched raw on both).

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on both**.
- `validate_pr_notebooks.py` **PASSED** (both).
- `git diff --stat`: `6 insertions(+), 3 deletions(-)` = **exactly 2N/N** (N=3).
- **Byte-identity proof**: stripping id lines + comma-normalizing the diff yields **0 real content changes**. `execution_count` / `outputs` / `source`: unchanged.

See #6257.
