### PR TITLE
docs(search): fix Part1-Foundations language-count drift (13Py/16C# -> 12Py/17C#)

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -451,7 +451,7 @@ Search/
 ├── search_helpers.py                      # Utilitaires partages
 ├── resources/                             # Images et données
 │
-├── Part1-Foundations/                     # Search Fondamental (29 notebooks : 13 Python + 16 C# — 12 jumeaux directs Search-1..11/15 + déclinaison Métaheuristiques en 4 volets)
+├── Part1-Foundations/                     # Search Fondamental (29 notebooks : 12 Python + 17 C# — 12 jumeaux directs Search-1..11/15 + Search-16 QuikGraph natif + déclinaison Métaheuristiques Search-11b en 4 volets)
 │   ├── Search-1-StateSpace.ipynb
 │   ├── Search-2-Uninformed.ipynb
 │   ├── Search-3-Informed.ipynb


### PR DESCRIPTION
## What

Single-line factual fix in `MyIA.AI.Notebooks/Search/README.md` structure tree (l.454): the directory comment claimed **`13 Python + 16 C#`** for `Part1-Foundations/`, contradicting two other paragraphs in the same file:

- Coverage table (l.346): `13 (Search-1 à Search-11, Search-15, Search-16) | Python (12) + C# natif (Search-16 QuikGraph) | 12 jumeaux C# + Search-11b (4 volets)`
- Statistics table (l.608): `29 (12 Python : Search-1 → Search-11, 15 + 17 C# : 12 jumeaux -Csharp + Search-16 QuikGraph natif + Search-11b 4 volets)`

Corrected to **`12 Python + 17 C#`** to match ground truth and the two consistent siblings.

## §E whole-file audit (disk ↔ CATALOG-STATUS ↔ prose)

The fix is +1/-1 but is **not** a drive-by — the whole Search README family was audited against disk per §E. Per-subdir `git ls-files | grep -c ipynb` (git-tracked, `_output.ipynb` excluded):

| Sub-series | Disk count | README claim | Match |
|---|---|---|---|
| Part1-Foundations | 29 | 29 | ✓ (but language split was wrong — fixed here) |
| Part2-CSP | 18 | 18 | ✓ |
| Part3-Advanced | 6 | 6 | ✓ |
| Part4-Metaheuristics | 19 | 19 | ✓ |
| Applications (CSP 26 + Hybrid 10 + Search 4) | 40 | 40 | ✓ |
| archive | 2 | 2 | ✓ |
| **Total** | **114** | **114** (pedagogical 112 + archive 2) | ✓ |

**Kernel verification (the crux of the language split).** Checked `metadata.kernelspec.name` firsthand:
- `Search-16-QuikGraph.ipynb` → `.net-csharp` (C# despite **no** `-Csharp` suffix)
- `Search-11b-Metaheuristiques-Deep{,-Part2,-Part3,-Part4}.ipynb` → all `.net-csharp` (C#, 4 volets)
- `Search-15-NetworkX.ipynb` → `python3` ✓
- `Search-1`..`Search-11` → `python3` (12 files: 11 + Search-15) ✓

So: **Python = 12** (Search-1..11 + Search-15), **C# = 17** (12 `-Csharp` twins + Search-16 + 4 Search-11b volets). The old `13 Python + 16 C#` wrongly counted the unsuffixed C# notebooks (Search-16, Search-11b) as Python. Now all three claims (l.346/454/608) agree.

## Catalog hygiene
`COURSE_CATALOG.generated.{json,md}` byte-identical to `origin/main` (not touched). `CATALOG-STATUS` marker (l.3-8) unchanged — breakdown `Part1-Foundations=29` remains correct (the error was the language sub-split, not the total).

## Scope
One README file, one line. No notebook, no code, no catalog. `See #5081` (post-renumbering prose-drift class — this count error is the same family of drift, partial).