### PR TITLE
docs(csp,#2876): restore French accents in CSP-1-Fundamentals-Csharp comments + markdown

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -143,9 +143,9 @@
    "source": [
     "// Configuration IKVM 8.15.0 pour Choco-solver -- recette #4711 (IkvmCopyMerge recursif)\n",
     "// Leve \"Could not locate ikvm home path\" : IKVM 8.15 lit AppContext[\"IKVM.Home\"], pas la variable\n",
-    "// d environnement. On assemble le home complet (fusion image arch-independante any/any + native\n",
+    "// d'environnement. On assemble le home complet (fusion image arch-indépendante any/any + native\n",
     "// win-x64) via copie RECURSIVE (la copie plate rate les sous-dossiers lib/ et tzdb.dat), AVANT\n",
-    "// tout premier appel Java (l init JVM se declenche au premier type java.*, cellule suivante).\n",
+    "// tout premier appel Java (l'init JVM se declenche au premier type java.*, cellule suivante).\n",
     "// See #4667, See #3801, See #4956.\n",
     "#r \"nuget: IKVM, 8.15.0\"\n",
     "#r \"nuget: IKVM.Image, 8.15.0\"\n",
@@ -330,9 +330,9 @@
    "source": [
     "---\n",
     "\n",
-    "## 3. Exemple : coloration de carte de l Australie (~8 min)\n",
+    "## 3. Exemple : coloration de carte de l'Australie (~8 min)\n",
     "\n",
-    "Le probleme classique de coloration de carte consiste a colorier les regions de sorte que deux regions adjacentes n aient jamais la meme couleur. C est l exemple canonique du livre AIMA (Russell & Norvig), applique a la carte de l Australie avec ses 7 etats/territoires.\n",
+    "Le probleme classique de coloration de carte consiste a colorier les regions de sorte que deux regions adjacentes n aient jamais la meme couleur. C est l exemple canonique du livre AIMA (Russell & Norvig), applique a la carte de l'Australie avec ses 7 etats/territoires.\n",
     "\n",
     "### Modelisation CSP\n",
     "\n",
@@ -430,7 +430,7 @@
     }
    ],
    "source": [
-    "// Coloration de l Australie : variables, domaines, voisins, contrainte binaire\n",
+    "// Coloration de l'Australie : variables, domaines, voisins, contrainte binaire\n",
     "var australiaVars = new List<string> { \"WA\", \"NT\", \"SA\", \"Q\", \"NSW\", \"V\", \"T\" };\n",
     "\n",
     "var australiaDomains = new Dictionary<string, List<object>>();\n",
@@ -595,7 +595,7 @@
    "id": "72e0ef68",
    "metadata": {},
    "source": [
-    "**Interpretation** : le graphe de contraintes de l Australie a 7 noeuds et 9 aretes. SA (Australie-Méridionale) est le noeud le plus contraint (5 voisins) -- c est lui qui elimine le plus de combinaisons. T (Tasmanie) est isolee : n importe quelle couleur lui convient.\n",
+    "**Interpretation** : le graphe de contraintes de l'Australie a 7 noeuds et 9 aretes. SA (Australie-Méridionale) est le noeud le plus contraint (5 voisins) -- c est lui qui elimine le plus de combinaisons. T (Tasmanie) est isolee : n importe quelle couleur lui convient.\n",
     "\n",
     "**Points cles** :\n",
     "1. SA est adjacent a presque tous les etats continentaux : c est la variable la plus contrainte\n",
@@ -677,7 +677,7 @@
    ],
    "source": [
     "// Brute force : enumerer toutes les combinaisons et filtrer\n",
-    "// Sert de reference pour mesurer l apport du backtracking\n",
+    "// Sert de référence pour mesurer l'apport du backtracking\n",
     "using System.Diagnostics;\n",
     "\n",
     "var colors = new List<object> { \"Rouge\", \"Vert\", \"Bleu\" };\n",
@@ -759,8 +759,8 @@
    ],
    "source": [
     "// Backtracking simple pour CSP binaire (C#)\n",
-    "// Choisit les variables dans l ordre de csp.Variables.\n",
-    "// Explore les valeurs dans l ordre du domaine.\n",
+    "// Choisit les variables dans l'ordre de csp.Variables.\n",
+    "// Explore les valeurs dans l'ordre du domaine.\n",
     "Dictionary<string, object> Backtrack(CSP csp, Dictionary<string, object> assignment) {\n",
     "    if (csp.IsComplete(assignment)) return new Dictionary<string, object>(assignment);\n",
     "    var unassigned = csp.Variables.FindAll(v => !assignment.ContainsKey(v));\n",
@@ -777,7 +777,7 @@
     "    return null;\n",
     "}\n",
     "\n",
-    "// Compteur manuel d assignations (la classe CSP expose NAssigns via propriete)\n",
+    "// Compteur manuel d'assignations (la classe CSP expose NAssigns via propriété)\n",
     "int CountAssigns(CSP csp, Dictionary<string, object> assignment, ref int count) {\n",
     "    if (csp.IsComplete(assignment)) return count;\n",
     "    var unassigned = csp.Variables.FindAll(v => !assignment.ContainsKey(v));\n",
@@ -873,7 +873,7 @@
    ],
    "source": [
     "// Heuristique MRV : choisir la variable avec le moins de valeurs viables.\n",
-    "// En cas d egalite, departage par degree (nombre de voisins non assignes, ordre decroissant).\n",
+    "// En cas d'égalité, départage par degree (nombre de voisins non assignes, ordre decroissant).\n",
     "string SelectMRV(CSP csp, Dictionary<string, object> assignment) {\n",
     "    var unassigned = csp.Variables.FindAll(v => !assignment.ContainsKey(v));\n",
     "    return unassigned\n",
@@ -999,7 +999,7 @@
    ],
    "source": [
     "// Heuristique LCV : trier les valeurs par nombre de conflits croissant\n",
-    "// (la moins contraignante d abord -- \"succeed-first\")\n",
+    "// (la moins contraignante d'abord -- \"succeed-first\")\n",
     "List<object> OrderLCV(CSP csp, string var, Dictionary<string, object> assignment) {\n",
     "    return csp.Domains[var]\n",
     "        .OrderBy(val => {\n",
@@ -1140,7 +1140,7 @@
     }
    ],
    "source": [
-    "// Comparaison des variantes sur la coloration de l Australie\n",
+    "// Comparaison des variantes sur la coloration de l'Australie\n",
     "var variants = new (string name, bool mrv, bool lcv)[] {\n",
     "    (\"Backtracking simple\", false, false),\n",
     "    (\"+ MRV\",              true,  false),\n",
@@ -1185,7 +1185,7 @@
     "2. L effet des heuristiques est **instance-dependant** : nul ou negatif sur une instance facile, il devient dramatique sur des instances plus dures (cf. les 8-Reines ci-dessous : 876 -> 572 avec MRV)\n",
     "3. Conclusion honnete : aucune heuristique n est monotonement benefique, il faut mesurer et non presupposer une amelioration\n",
     "\n",
-    "> **Regle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais son surcout n est pas amorti sur les instances faciles comme la coloration de l Australie."
+    "> **Regle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais son surcout n est pas amorti sur les instances faciles comme la coloration de l'Australie."
    ]
   },
   {
@@ -1285,7 +1285,7 @@
     }
    ],
    "source": [
-    "// Coloration de l Australie avec Choco-solver 4.10.17\n",
+    "// Coloration de l'Australie avec Choco-solver 4.10.17\n",
     "// Comparaison directe avec notre implementation manuelle\n",
     "var chocModel = new Model(\"Coloration Australie - Choco 4.10.17\");\n",
     "\n",
@@ -1329,7 +1329,7 @@
    "id": "d2d3ac0d",
    "metadata": {},
    "source": [
-    "**Interpretation** : Choco-solver resout la coloration de l Australie en moins de 10 ms avec 6 lignes de modelisation declaratives.\n",
+    "**Interpretation** : Choco-solver resout la coloration de l'Australie en moins de 10 ms avec 6 lignes de modelisation declaratives.\n",
     "\n",
     "| Aspect | Implementation manuelle C# | Choco-solver 4.10.17 |\n",
     "|--------|---------------------------|----------------------|\n",
@@ -1556,7 +1556,7 @@
     "var queenModel = new Model($\"N-Reines (n={n})\");\n",
     "var queens = new IntVar[n];\n",
     "for (int c = 0; c < n; c++) {\n",
-    "    // Cast explicite (string) pour eviter l ambiguite entre intVar(int,int) et intVar(int,int,bool)\n",
+    "    // Cast explicite (string) pour éviter l'ambiguïté entre intVar(int,int) et intVar(int,int,bool)\n",
     "    queens[c] = queenModel.intVar(c.ToString(), 0, n - 1);\n",
     "}\n",
     "\n",
@@ -1564,13 +1564,13 @@
     "queenModel.allDifferent(queens).post();\n",
     "\n",
     "// Diagonales : pour chaque paire (i,j), creer une IntVar auxiliaire pour la diff/somme,\n",
-    "// puis la comparer a la constante. Choco 4.10.17 surcharge `arithm(IntVar,String,IntVar,String,IntVar)`\n",
-    "// pas forcement portee par l IKVM Java->.NET ; on utilise des contraintes separees qui sont\n",
+    "// puis la comparer à la constante. Choco 4.10.17 surcharge `arithm(IntVar,String,IntVar,String,IntVar)`\n",
+    "// pas forcement portee par l'IKVM Java->.NET ; on utilise des contraintes separees qui sont\n",
     "// bien supportees : arithm(var, \"op\", var) + arithm(IntVarResult, \"op\", int).\n",
     "for (int i = 0; i < n; i++) {\n",
     "    for (int j = i + 1; j < n; j++) {\n",
     "        // Diagonale descendante : q_i - q_j != i - j\n",
-    "        // Cast explicite (string) sur le nom pour eviter l ambiguite intVar(int,int,bool)\n",
+    "        // Cast explicite (string) sur le nom pour éviter l'ambiguïté intVar(int,int,bool)\n",
     "        var diff = queenModel.intVar($\"d_{i}_{j}\", -(n - 1), n - 1);\n",
     "        queenModel.scalar(new IntVar[] { queens[i], queens[j] }, new int[] { 1, -1 }, \"=\", diff).post();\n",
     "        int diagDown = i - j;\n",
@@ -1700,7 +1700,7 @@
    ],
    "source": [
     "// Exercice 1 : 4-Reines avec backtracking manuel C#\n",
-    "// A COMPLETER par l etudiant\n",
+    "// A COMPLETER par l'étudiant\n",
     "// Indice : utilisez la classe CSP et BacktrackImproved definies plus haut.\n",
     "// Modelisation : 4 variables (colonnes), domaine {0,1,2,3} (lignes),\n",
     "// contrainte = reine sur (c1, r1) et (c2, r2) ne s attaquent pas.\n",
@@ -1745,7 +1745,7 @@
    ],
    "source": [
     "// Exercice 2 : comparer MRV sur les 4-Reines\n",
-    "// A COMPLETER par l etudiant\n",
+    "// A COMPLETER par l'étudiant\n",
     "// Indice : mesurez assignations et temps pour 3 variantes :\n",
     "//   1) Manuel sans MRV : BacktrackImproved(csp, ..., useMRV=false, useLCV=false)\n",
     "//   2) Manuel avec MRV : BacktrackImproved(csp, ..., useMRV=true,  useLCV=false)\n",
@@ -1802,7 +1802,7 @@
    ],
    "source": [
     "// Exercice 3 : SEND + MORE = MONEY avec Choco-solver\n",
-    "// A COMPLETER par l etudiant\n",
+    "// A COMPLETER par l'étudiant\n",
     "// Indice :\n",
     "//   - 8 IntVar (s,e,n,d,m,o,r,y), domaine 0..9\n",
     "//   - model.allDifferent(new IntVar[] {s,e,n,d,m,o,r,y}).post()\n",


### PR DESCRIPTION
## Summary

Restore French accents + elision apostrophes in the `//` comments and markdown prose of `Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb` (23 lines). Part of the #2876 French-accent restoration register.

| Scope | Lines | Examples |
|-------|-------|----------|
| `//` C# comments | 18 | `de l Australie` → `de l'Australie`, `Sert de reference` → `Sert de référence`, `d egalite` → `d'égalité`, `l etudiant` → `l'étudiant` |
| Markdown prose | 5 | `coloration de carte de l Australie` → `de l'Australie` |

`degree` kept ASCII (English technical term used in the C# code).

## Scope discipline (Stop & Repair honored)

**Only `//` comment lines and markdown cell source were modified.** No code strings (`Console.WriteLine(...)`) and no committed cell outputs were touched. C# re-execution is currently blocked locally (`JAVA_HOME` broken — tracked [ASK USER] blocker), so any executed-source change that would require output regeneration is explicitly out of scope. Comments and markdown are not executed, so no re-exec is needed and existing outputs stay consistent with their source.

Verification: `git diff` filtered for `Console.WriteLine` / `"text":` / `output_type` / `execution_count` lines → **0 matches** (no code/output touched).

## Method (per #2876 4-gate)

- Accent-only pairs verified by `deaccent(old) == deaccent(new)` (unicodedata NFD + strip Mn).
- Elision pairs (space → apostrophe) verified pairwise as valid French elisions (`l'` / `d'`), applied only on `//`-prefixed comment lines or markdown (never code).
- `nbformat.validate()` PASS. `validate_pr_notebooks.py` PASS. C.1 scan clean (no `raise NotImplementedError` / `assert False` / `1/0`).

See #2876.
