### PR TITLE
docs(sudoku): fix off-by-one pair count in editorial reconciliation note (17->16 entrées)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -11,7 +11,7 @@ maturity: PRODUCTION=30, BETA=5, ALPHA=1
 >
 > **17 C# + 18 Python + 1 Lean 4 = 36 notebooks canoniques ✓** (44 fichiers `*.ipynb` au total sur disque = 36 canoniques + 8 `_output.ipynb` artefacts Papermill commités couvrant 8 notebooks Python : Choco 11, Infer 15, NN 16, LLM 17, DancingLinks 2, Genetic 3, PSO 5, GraphColoring 9).
 >
-> Sudoku est un cas de **mixité JUMEAUX C#/Python dominante** (15 paires strictes 1-14 + 1 paradigme-comparable 15 Infer.NET/NumPyro + 1 benchmark 18, soit 17 entrées à 2 langages) avec **1 companion Lean natif intra-hub** (`Sudoku-19-Lean-Propagation.ipynb`, lake `sudoku_lean` 0-sorry). C'est une **variante L392 #4** : contrairement à QC (#5917) où Lean est isolé dans une sous-série dédiée `kelly_lean/`, et contrairement à ML (#5915) / Probas (#5916) où la mixité kernel est intra-série, ici la mixité jumeaux domine largement et le notebook tiers (Lean) est intra-hub sans sous-série dédiée.
+> Sudoku est un cas de **mixité JUMEAUX C#/Python dominante** (14 paires strictes 1-14 + 1 paradigme-comparable 15 Infer.NET/NumPyro + 1 benchmark 18, soit 16 entrées à 2 langages) avec **1 companion Lean natif intra-hub** (`Sudoku-19-Lean-Propagation.ipynb`, lake `sudoku_lean` 0-sorry). C'est une **variante L392 #4** : contrairement à QC (#5917) où Lean est isolé dans une sous-série dédiée `kelly_lean/`, et contrairement à ML (#5915) / Probas (#5916) où la mixité kernel est intra-série, ici la mixité jumeaux domine largement et le notebook tiers (Lean) est intra-hub sans sous-série dédiée.
 >
 > Les counts obsolètes `16 notebooks Python` (L605) et `16 solveurs` (L770) ont été réconciliés sur la valeur disk-truth de **18 notebooks Python canoniques** dans cette PR.
 >


### PR DESCRIPTION
## What

Single-line factual fix in `MyIA.AI.Notebooks/Sudoku/README.md` line 14 — the **"Note éditoriale (counts)"** blockquote (itself added by a prior PR to reconcile counts) stated:

> "15 paires strictes 1-14 + 1 paradigme-comparable 15 Infer.NET/NumPyro + 1 benchmark 18, soit **17 entrées** à 2 langages"

This contradicts three other paragraphs in the same file:
- Intro (l.22): "**16 paires miroir** C#/Python (notebooks 1 à 15 et le benchmark 18)"
- Structure (l.615): "16 paires miroir C#/Python"
- Conclusion (l.789): "(**16 paires miroir**, du backtracking au benchmark comparatif)"

And contains an arithmetic impossibility: notebooks **1-14 = 14 pairs**, not 15.

Corrected to: "**14 paires strictes 1-14** + 1 paradigme-comparable 15 + 1 benchmark 18, soit **16 entrées** à 2 langages".

## §E whole-file audit (disk ↔ prose)

The fix is +1/-1 but the whole Sudoku README was audited. Disk pair-verification (C# and Python both present):

| Notebook | C# | Python | |
|---|---|---|---|
| Sudoku-0 | ✓ | ✗ | C#-only |
| Sudoku-1..14 | ✓ | ✓ | **14 strict pairs** |
| Sudoku-15 | ✓ | ✓ | 1 paradigm-comparable (Infer.NET ⇄ NumPyro) |
| Sudoku-16 | ✗ | ✓ | Python-only |
| Sudoku-17 | ✗ | ✓ | Python-only |
| Sudoku-18 | ✓ | ✓ | 1 benchmark |
| Sudoku-19 | — | — | Lean companion |

**Dual-language pairs = 14 + 1 + 1 = 16** ✓. Language split reconciles: 16 pairs → 16 C# + 16 Python, + Sudoku-0 C# = 17 C#, + Sudoku-16/17 Python = 18 Python, + Sudoku-19 Lean = 1. **17 C# + 18 Python + 1 Lean = 36** (l.12, unchanged, correct).

Post-fix, all pair counts agree: l.14 (16), l.22 (16), l.615 (16), l.789 (16).

## Catalog hygiene
`COURSE_CATALOG.generated.{json,md}` byte-identical to `origin/main`. `CATALOG-STATUS` marker (l.3-8) unchanged (`pedagogical_count: 36` correct).

## Scope
One README file, one line. Companion to #6494 (Search README count drift) — same §E content-drift audit pattern (cf po-2025 #6471), different family. `See #5081` (post-renumbering prose-drift class, partial).