### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to QuantConnect research cluster

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/AllWeather/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AllWeather/research.ipynb
@@ -294,7 +294,8 @@
    "metadata": {},
    "source": [
     "Définition et exécution du moteur de backtest AllWeather : simulation de la stratégie 30% SPY / 40% TLT / 15% GLD / 15% XLP sur la période historique."
-   ]
+   ],
+   "id": "cell-99971972"
   },
   {
    "cell_type": "code",
@@ -1180,7 +1181,8 @@
    "metadata": {},
    "source": [
     "Comparaison des métriques Sharpe, drawdown entre les configurations testées pour identifier la meilleure version de AllWeather."
-   ]
+   ],
+   "id": "cell-d0d21347"
   },
   {
    "cell_type": "code",
@@ -1431,7 +1433,8 @@
    "metadata": {},
    "source": [
     "Exploration de la grille de paramètres pour identifier la configuration optimale de la stratégie AllWeather."
-   ]
+   ],
+   "id": "cell-c833a38a"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FuturesTrend/research.ipynb
@@ -1074,7 +1074,8 @@
    "metadata": {},
    "source": [
     "Téléchargement de données supplémentaires (SPY, GLD, TLT, EFA, EEM, VNQ, DBC) via yfinance pour élargir l'univers de FuturesTrend."
-   ]
+   ],
+   "id": "cell-3eb31afd"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/QuantConnect/research/research_m11ef_ensemble.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_m11ef_ensemble.ipynb
@@ -22,7 +22,8 @@
     "Rebalance: monthly\n",
     "Coins: BTC, ETH, SOL, LTC\n",
     "```"
-   ]
+   ],
+   "id": "cell-70f99eb0"
   },
   {
    "cell_type": "code",
@@ -47,7 +48,8 @@
     "\n",
     "qb = QuantBook()\n",
     "print(f\"QC Cloud ready — User: {qb.UserId}\")"
-   ]
+   ],
+   "id": "cell-f4c27356"
   },
   {
    "cell_type": "code",
@@ -88,7 +90,8 @@
     "        print(f\"{symbol_str}: unavailable — {e}\")\n",
     "\n",
     "print(f\"\\nTotal coins loaded: {len(crypto_data)}\")"
-   ]
+   ],
+   "id": "cell-be855b7c"
   },
   {
    "cell_type": "code",
@@ -103,7 +106,8 @@
      ]
     }
    ],
-   "source": "# Section 3: Kelly threshold-band position sizing\ndef threshold_band_signal(close_prices, window=60):\n    \"\"\"Generate signal: long if price > rolling mean, short otherwise.\"\"\"\n    prices = pd.Series(close_prices)\n    rolling_mean = prices.rolling(window).mean()\n    signal = np.where(prices.values > rolling_mean.values, 1.0, 0.0)\n    return signal\n\ndef kelly_sleeve(close_prices, cap=0.6, window=60, fee_bps=50):\n    \"\"\"Single Kelly sleeve with threshold-band signal.\"\"\"\n    prices = pd.Series(close_prices)\n    returns = prices.pct_change().dropna().values\n\n    # Signal aligned to returns length (returns starts at index 1)\n    signal_full = threshold_band_signal(close_prices, window)\n    signal = signal_full[1:][:len(returns)]  # skip first element (no return), trim to match\n\n    # Rolling vol for Kelly sizing\n    rolling_vol = pd.Series(returns).rolling(window).std().values * np.sqrt(252)\n    rolling_vol = np.where(rolling_vol < 0.01, 0.2, rolling_vol)  # floor\n\n    # Kelly weight: cap * (signal / vol)\n    kelly_w = np.minimum(cap / rolling_vol, cap) * signal\n\n    # Net returns\n    weighted_returns = kelly_w * returns\n\n    # Fee deduction\n    fee = fee_bps / 10000\n    trades = np.abs(np.diff(np.concatenate([[0], kelly_w])))\n    fee_costs = np.concatenate([[0], trades * fee])[:len(weighted_returns)]\n    net_returns = weighted_returns - fee_costs\n\n    sharpe = np.mean(net_returns) / (np.std(net_returns) + 1e-10) * np.sqrt(252)\n    return sharpe, net_returns\n\ndef vol_targeting_sleeve(close_prices, target_vol=0.15, window=60, fee_bps=50):\n    \"\"\"Vol-targeting sleeve: scale position to maintain target volatility.\"\"\"\n    prices = pd.Series(close_prices)\n    returns = prices.pct_change().dropna().values\n\n    rolling_vol = pd.Series(returns).rolling(window).std().values * np.sqrt(252)\n    rolling_vol = np.where(rolling_vol < 0.01, 0.2, rolling_vol)\n\n    # Scale to target vol\n    scale = target_vol / rolling_vol\n    scale = np.minimum(scale, 2.0)  # cap leverage\n\n    weighted_returns = scale * returns\n\n    fee = fee_bps / 10000\n    trades = np.abs(np.diff(np.concatenate([[0], scale])))\n    fee_costs = np.concatenate([[0], trades * fee])[:len(weighted_returns)]\n    net_returns = weighted_returns - fee_costs\n\n    sharpe = np.mean(net_returns) / (np.std(net_returns) + 1e-10) * np.sqrt(252)\n    return sharpe, net_returns\n\nprint(\"Sleeve functions defined\")"
+   "source": "# Section 3: Kelly threshold-band position sizing\ndef threshold_band_signal(close_prices, window=60):\n    \"\"\"Generate signal: long if price > rolling mean, short otherwise.\"\"\"\n    prices = pd.Series(close_prices)\n    rolling_mean = prices.rolling(window).mean()\n    signal = np.where(prices.values > rolling_mean.values, 1.0, 0.0)\n    return signal\n\ndef kelly_sleeve(close_prices, cap=0.6, window=60, fee_bps=50):\n    \"\"\"Single Kelly sleeve with threshold-band signal.\"\"\"\n    prices = pd.Series(close_prices)\n    returns = prices.pct_change().dropna().values\n\n    # Signal aligned to returns length (returns starts at index 1)\n    signal_full = threshold_band_signal(close_prices, window)\n    signal = signal_full[1:][:len(returns)]  # skip first element (no return), trim to match\n\n    # Rolling vol for Kelly sizing\n    rolling_vol = pd.Series(returns).rolling(window).std().values * np.sqrt(252)\n    rolling_vol = np.where(rolling_vol < 0.01, 0.2, rolling_vol)  # floor\n\n    # Kelly weight: cap * (signal / vol)\n    kelly_w = np.minimum(cap / rolling_vol, cap) * signal\n\n    # Net returns\n    weighted_returns = kelly_w * returns\n\n    # Fee deduction\n    fee = fee_bps / 10000\n    trades = np.abs(np.diff(np.concatenate([[0], kelly_w])))\n    fee_costs = np.concatenate([[0], trades * fee])[:len(weighted_returns)]\n    net_returns = weighted_returns - fee_costs\n\n    sharpe = np.mean(net_returns) / (np.std(net_returns) + 1e-10) * np.sqrt(252)\n    return sharpe, net_returns\n\ndef vol_targeting_sleeve(close_prices, target_vol=0.15, window=60, fee_bps=50):\n    \"\"\"Vol-targeting sleeve: scale position to maintain target volatility.\"\"\"\n    prices = pd.Series(close_prices)\n    returns = prices.pct_change().dropna().values\n\n    rolling_vol = pd.Series(returns).rolling(window).std().values * np.sqrt(252)\n    rolling_vol = np.where(rolling_vol < 0.01, 0.2, rolling_vol)\n\n    # Scale to target vol\n    scale = target_vol / rolling_vol\n    scale = np.minimum(scale, 2.0)  # cap leverage\n\n    weighted_returns = scale * returns\n\n    fee = fee_bps / 10000\n    trades = np.abs(np.diff(np.concatenate([[0], scale])))\n    fee_costs = np.concatenate([[0], trades * fee])[:len(weighted_returns)]\n    net_returns = weighted_returns - fee_costs\n\n    sharpe = np.mean(net_returns) / (np.std(net_returns) + 1e-10) * np.sqrt(252)\n    return sharpe, net_returns\n\nprint(\"Sleeve functions defined\")",
+   "id": "cell-a896b9f2"
   },
   {
    "cell_type": "code",
@@ -143,7 +147,8 @@
      ]
     }
    ],
-   "source": "# Section 4: Individual sleeve backtests\nfee_levels = [0, 5, 10, 25, 50, 100]\nsleeve_results = []\n\nfor symbol, hist in crypto_data.items():\n    close = hist[\"close\"].values\n    \n    for fee in fee_levels:\n        # K60\n        sharpe_k60, rets_k60 = kelly_sleeve(close, cap=0.6, fee_bps=fee)\n        # K30\n        sharpe_k30, rets_k30 = kelly_sleeve(close, cap=0.3, fee_bps=fee)\n        # VTH\n        sharpe_vth, rets_vth = vol_targeting_sleeve(close, target_vol=0.15, fee_bps=fee)\n        \n        # Buy-and-hold baseline (round-trip fee: entry + exit)\n        bh_returns = np.diff(np.log(close))\n        bh_fee = 2 * fee / 10000  # round-trip: entry + exit\n        bh_net = bh_returns - bh_fee\n        sharpe_bh = np.mean(bh_net) / (np.std(bh_net) + 1e-10) * np.sqrt(252)\n        \n        sleeve_results.append({\n            \"coin\": symbol,\n            \"fee_bps\": fee,\n            \"sharpe_k60\": sharpe_k60,\n            \"sharpe_k30\": sharpe_k30,\n            \"sharpe_vth\": sharpe_vth,\n            \"sharpe_bh\": sharpe_bh,\n        })\n        \n        print(f\"{symbol} @ {fee}bps: K60={sharpe_k60:.3f}, K30={sharpe_k30:.3f}, \"\n              f\"VTH={sharpe_vth:.3f}, BH={sharpe_bh:.3f}\")\n\nsleeve_df = pd.DataFrame(sleeve_results)\nprint(f\"\\nTotal combos: {len(sleeve_df)}\")"
+   "source": "# Section 4: Individual sleeve backtests\nfee_levels = [0, 5, 10, 25, 50, 100]\nsleeve_results = []\n\nfor symbol, hist in crypto_data.items():\n    close = hist[\"close\"].values\n    \n    for fee in fee_levels:\n        # K60\n        sharpe_k60, rets_k60 = kelly_sleeve(close, cap=0.6, fee_bps=fee)\n        # K30\n        sharpe_k30, rets_k30 = kelly_sleeve(close, cap=0.3, fee_bps=fee)\n        # VTH\n        sharpe_vth, rets_vth = vol_targeting_sleeve(close, target_vol=0.15, fee_bps=fee)\n        \n        # Buy-and-hold baseline (round-trip fee: entry + exit)\n        bh_returns = np.diff(np.log(close))\n        bh_fee = 2 * fee / 10000  # round-trip: entry + exit\n        bh_net = bh_returns - bh_fee\n        sharpe_bh = np.mean(bh_net) / (np.std(bh_net) + 1e-10) * np.sqrt(252)\n        \n        sleeve_results.append({\n            \"coin\": symbol,\n            \"fee_bps\": fee,\n            \"sharpe_k60\": sharpe_k60,\n            \"sharpe_k30\": sharpe_k30,\n            \"sharpe_vth\": sharpe_vth,\n            \"sharpe_bh\": sharpe_bh,\n        })\n        \n        print(f\"{symbol} @ {fee}bps: K60={sharpe_k60:.3f}, K30={sharpe_k30:.3f}, \"\n              f\"VTH={sharpe_vth:.3f}, BH={sharpe_bh:.3f}\")\n\nsleeve_df = pd.DataFrame(sleeve_results)\nprint(f\"\\nTotal combos: {len(sleeve_df)}\")",
+   "id": "cell-64086bd7"
   },
   {
    "cell_type": "code",
@@ -183,7 +188,8 @@
      ]
     }
    ],
-   "source": "# Section 5: Ensemble (equal-weight) and fee sweep\nensemble_results = []\n\nfor symbol, hist in crypto_data.items():\n    close = hist[\"close\"].values\n    \n    for fee in fee_levels:\n        _, rets_k60 = kelly_sleeve(close, cap=0.6, fee_bps=fee)\n        _, rets_k30 = kelly_sleeve(close, cap=0.3, fee_bps=fee)\n        _, rets_vth = vol_targeting_sleeve(close, target_vol=0.15, fee_bps=fee)\n        \n        min_len = min(len(rets_k60), len(rets_k30), len(rets_vth))\n        ensemble_rets = (rets_k60[:min_len] + rets_k30[:min_len] + rets_vth[:min_len]) / 3\n        \n        sharpe_ensemble = np.mean(ensemble_rets) / (np.std(ensemble_rets) + 1e-10) * np.sqrt(252)\n        \n        # BH baseline (round-trip fee)\n        bh_returns = np.diff(np.log(close))[:min_len]\n        bh_net = bh_returns - 2 * fee / 10000\n        sharpe_bh = np.mean(bh_net) / (np.std(bh_net) + 1e-10) * np.sqrt(252)\n        \n        ensemble_results.append({\n            \"coin\": symbol,\n            \"fee_bps\": fee,\n            \"sharpe_ensemble\": sharpe_ensemble,\n            \"sharpe_bh\": sharpe_bh,\n            \"delta_sharpe\": sharpe_ensemble - sharpe_bh,\n            \"beats_bh\": int(sharpe_ensemble > sharpe_bh),\n        })\n        \n        print(f\"{symbol} @ {fee}bps: Ensemble={sharpe_ensemble:.3f}, BH={sharpe_bh:.3f}, \"\n              f\"delta={sharpe_ensemble - sharpe_bh:+.3f}\")\n\nensemble_df = pd.DataFrame(ensemble_results)\nprint(f\"\\nTotal combos: {len(ensemble_df)}\")"
+   "source": "# Section 5: Ensemble (equal-weight) and fee sweep\nensemble_results = []\n\nfor symbol, hist in crypto_data.items():\n    close = hist[\"close\"].values\n    \n    for fee in fee_levels:\n        _, rets_k60 = kelly_sleeve(close, cap=0.6, fee_bps=fee)\n        _, rets_k30 = kelly_sleeve(close, cap=0.3, fee_bps=fee)\n        _, rets_vth = vol_targeting_sleeve(close, target_vol=0.15, fee_bps=fee)\n        \n        min_len = min(len(rets_k60), len(rets_k30), len(rets_vth))\n        ensemble_rets = (rets_k60[:min_len] + rets_k30[:min_len] + rets_vth[:min_len]) / 3\n        \n        sharpe_ensemble = np.mean(ensemble_rets) / (np.std(ensemble_rets) + 1e-10) * np.sqrt(252)\n        \n        # BH baseline (round-trip fee)\n        bh_returns = np.diff(np.log(close))[:min_len]\n        bh_net = bh_returns - 2 * fee / 10000\n        sharpe_bh = np.mean(bh_net) / (np.std(bh_net) + 1e-10) * np.sqrt(252)\n        \n        ensemble_results.append({\n            \"coin\": symbol,\n            \"fee_bps\": fee,\n            \"sharpe_ensemble\": sharpe_ensemble,\n            \"sharpe_bh\": sharpe_bh,\n            \"delta_sharpe\": sharpe_ensemble - sharpe_bh,\n            \"beats_bh\": int(sharpe_ensemble > sharpe_bh),\n        })\n        \n        print(f\"{symbol} @ {fee}bps: Ensemble={sharpe_ensemble:.3f}, BH={sharpe_bh:.3f}, \"\n              f\"delta={sharpe_ensemble - sharpe_bh:+.3f}\")\n\nensemble_df = pd.DataFrame(ensemble_results)\nprint(f\"\\nTotal combos: {len(ensemble_df)}\")",
+   "id": "cell-9a420cbf"
   },
   {
    "cell_type": "code",
@@ -250,7 +256,8 @@
     "        print(f\"  {fee:3d} bps: {wins}/{total} beats, median delta-Sharpe={med_ds:+.4f}\")\n",
     "\n",
     "print(f\"\\nLocal M11ef result: BEATS K60-vs-BH p=0.045 @50bps\")"
-   ]
+   ],
+   "id": "cell-700b25ed"
   },
   {
    "cell_type": "markdown",
@@ -293,7 +300,8 @@
     "Note: Sleeve Sharpe outputs (K60, K30, VTH) are verified nan from QC Cloud kernel.\n",
     "BH Sharpe values are reconstructed from verified endpoints (BTCUSD@0bps=0.625,\n",
     "LTCUSD@100bps=-5.801) using linear fee deduction per coin.\n"
-   ]
+   ],
+   "id": "cell-7f5f8f08"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add deterministic nbformat v4.5 cell ids (12 ids across 3 QuantConnect research notebooks) — part of the v4.5 cell-id gap sweep (see #6257).

| Notebook | ids added |
|----------|-----------|
| `QuantConnect/projects/AllWeather/research.ipynb` | 3 |
| `QuantConnect/projects/FuturesTrend/research.ipynb` | 1 |
| `QuantConnect/research/research_m11ef_ensemble.ipynb` | 8 |

Each was **already v4.5 (`nbformat_minor=5`)** but some cells lacked the required `id` field. Cell-id addition is **pure structural metadata** — no re-execution, no QuantBook/QC-Cloud needed (only the `id` field is added; `source`/`outputs`/`execution_count` unchanged).

## `research_m12_har_rv_j_minute.ipynb` intentionally excluded

This sibling notebook (10 missing ids) has **pre-existing H.3/C.2 debt on `origin/main`**: all 8 code cells have `execution_count: null` + 0 outputs (never executed). Verified pre-existing firsthand (checked out origin/main, same null-exec state). Adding ids there is byte-identical-safe, but it would make `validate_pr_notebooks.py` flag the pre-existing null-exec under this PR (the validator only checks files in the PR diff). That violation is unrelated to the nbformat sweep and warrants a **dedicated re-execution fix** (RECOVERABLE-MACHINE for a QuantConnect research notebook) in a separate PR. Flagging here so it isn't lost.

## Method (canonical convention, per #6257)

```
id = "cell-" + md5("<basename-with-.ipynb>:<all-cell-index-0based>")[:8]
```

Pure structural metadata: no re-execution, content byte-identical. Round-trip fidelity asserted BEFORE edit on each (json round-trip matched raw on all 3).

## Validation (real, post-edit)

- `nbformat.validate()` **strict PASSED on all 3**.
- `validate_pr_notebooks.py` **3/3 PASSED** (24 code cells, 0 H.3/C.2 violations).
- `git diff --stat`: `24 insertions(+), 12 deletions(-)` = **exactly 2N/N** (N=12).
- **Byte-identity proof**: stripping id lines + comma-normalizing the diff yields **0 real content changes**. `execution_count` / `outputs` / `source`: unchanged.

See #6257.
