### PR TITLE
docs(probas,#2876): restore French accents in Infer-10 markdown + C# comments

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
@@ -25,8 +25,8 @@
     "## Objectifs\n",
     "\n",
     "- Comprendre le probleme du surapprentissage\n",
-    "- Calculer l'evidence du modele (marginal likelihood)\n",
-    "- Utiliser le facteur de Bayes pour comparer des modeles\n",
+    "- Calculer l'evidence du modèle (marginal likelihood)\n",
+    "- Utiliser le facteur de Bayes pour comparer des modèles\n",
     "- Implementer l'Automatic Relevance Determination (ARD)\n",
     "\n",
     "---\n",
@@ -56,7 +56,7 @@
    "source": [
     "## 1. Configuration\n",
     "\n",
-    "Nous preparons l'environnement pour explorer la selection de modeles bayesienne. Cette approche permet de comparer objectivement differents modeles en calculant leur evidence marginale, implementant ainsi le rasoir d'Occam de maniere mathematique."
+    "Nous preparons l'environnement pour explorer la selection de modèles bayesienne. Cette approche permet de comparer objectivement differents modèles en calculant leur evidence marginale, implementant ainsi le rasoir d'Occam de maniere mathematique."
    ]
   },
   {
@@ -308,7 +308,7 @@
    "source": [
     "### Visualisation des graphes de facteurs\n",
     "\n",
-    "Ce notebook utilise `FactorGraphHelper.cs` pour visualiser les graphes de facteurs generes par Infer.NET. Ces graphes montrent la structure probabiliste des modeles : les noeuds representent les variables aleatoires et les observations, les facteurs (carres) representent les distributions conditionnelles.\n",
+    "Ce notebook utilise `FactorGraphHelper.cs` pour visualiser les graphes de facteurs generes par Infer.NET. Ces graphes montrent la structure probabiliste des modèles : les noeuds representent les variables aleatoires et les observations, les facteurs (carres) representent les distributions conditionnelles.\n",
     "\n",
     "Pour activer la visualisation, on configure `ShowFactorGraph = true` sur le moteur d'inference."
    ]
@@ -329,18 +329,18 @@
    "source": [
     "**Note technique : Calcul de l'evidence dans Infer.NET**\n",
     "\n",
-    "Infer.NET calcule l'evidence du modele via une astuce elegante :\n",
+    "Infer.NET calcule l'evidence du modèle via une astuce elegante :\n",
     "\n",
     "1. On introduit une variable indicatrice `evidence = Bernoulli(0.5)`\n",
-    "2. Le modele est conditionne par `Variable.If(evidence)`\n",
+    "2. Le modèle est conditionne par `Variable.If(evidence)`\n",
     "3. Apres inference, `evidence.LogOdds` donne le log de l'evidence\n",
     "\n",
-    "> **Pourquoi ca fonctionne ?** Par le theoreme de Bayes :\n",
+    "> **Pourquoi ca fonctionne ?** Par le théorème de Bayes :\n",
     "> $$P(\\text{evidence}=\\text{true}|D) \\propto P(D|\\text{evidence}=\\text{true}) \\times P(\\text{evidence}=\\text{true})$$\n",
     "> \n",
     "> Comme $P(\\text{evidence}=\\text{true}) = 0.5$, le log-odds posterieur est directement le log de l'evidence (a une constante pres).\n",
     "\n",
-    "Cette methode est specifique a Infer.NET et permet d'obtenir l'evidence sans calcul integral explicite."
+    "Cette méthode est specifique a Infer.NET et permet d'obtenir l'evidence sans calcul integral explicite."
    ]
   },
   {
@@ -361,7 +361,7 @@
     "\n",
     "### Observation\n",
     "\n",
-    "Un modele complexe peut parfaitement ajuster les donnees d'entrainement mais mal generaliser.\n",
+    "Un modèle complexe peut parfaitement ajuster les données d'entrainement mais mal generaliser.\n",
     "\n",
     "### Exemple\n",
     "\n",
@@ -369,8 +369,8 @@
     "\n",
     "### Solution bayesienne\n",
     "\n",
-    "- Les priors penalisent les modeles complexes\n",
-    "- L'evidence du modele equilibre ajustement et complexite\n",
+    "- Les priors penalisent les modèles complexes\n",
+    "- L'evidence du modèle equilibre ajustement et complexite\n",
     "- C'est le **rasoir d'Occam bayesien**"
    ]
   },
@@ -394,12 +394,12 @@
     "\n",
     "$$P(D|M) = \\int P(D|\\theta, M) P(\\theta|M) d\\theta$$\n",
     "\n",
-    "L'evidence est la probabilite des donnees sous le modele, marginalisee sur les parametres.\n",
+    "L'evidence est la probabilité des données sous le modèle, marginalisee sur les parametres.\n",
     "\n",
     "### Interpretation\n",
     "\n",
-    "- Un modele simple fait des predictions moins precises mais moins dispersees\n",
-    "- Un modele complexe fait des predictions plus precises mais plus dispersees\n",
+    "- Un modèle simple fait des predictions moins precises mais moins dispersees\n",
+    "- Un modèle complexe fait des predictions plus precises mais plus dispersees\n",
     "- L'evidence favorise le bon equilibre"
    ]
   },
@@ -873,13 +873,13 @@
     "tags": []
    },
    "source": [
-    "### Lecture du resultat\n",
+    "### Lecture du résultat\n",
     "\n",
-    "**Log evidence = -16.98** pour le modele a une gaussienne.\n",
+    "**Log evidence = -16.98** pour le modèle a une gaussienne.\n",
     "\n",
-    "Cette valeur negative est normale : c'est un logarithme de probabilite, donc toujours negatif (ou nul). Plus la valeur est proche de 0, meilleure est l'evidence.\n",
+    "Cette valeur negative est normale : c'est un logarithme de probabilité, donc toujours negatif (ou nul). Plus la valeur est proche de 0, meilleure est l'evidence.\n",
     "\n",
-    "En termes absolus, $e^{-16.98} \\approx 4.2 \\times 10^{-8}$ semble tres petit, mais c'est la **comparaison relative** entre modeles qui importe, pas la valeur absolue."
+    "En termes absolus, $e^{-16.98} \\approx 4.2 \\times 10^{-8}$ semble tres petit, mais c'est la **comparaison relative** entre modèles qui importe, pas la valeur absolue."
    ]
   },
   {
@@ -1308,13 +1308,13 @@
    "source": [
     "### Lecture du graphe de facteurs - Modele 1 gaussienne\n",
     "\n",
-    "Le graphe montre la structure du modele a une gaussienne :\n",
+    "Le graphe montre la structure du modèle a une gaussienne :\n",
     "\n",
     "- **Noeuds ovales** : variables aleatoires (`moyenne`, `precision`, `evidence1`)\n",
     "- **Noeuds carres** : facteurs (distributions conditionnelles)\n",
     "- **Noeuds gris** : observations (`obs_0` a `obs_6`)\n",
     "\n",
-    "La variable `evidence1` (Bernoulli) englobe tout le modele via `Variable.If()`. Les 7 observations partagent la meme `moyenne` et `precision`, ce qui represente l'hypothese i.i.d. (independantes et identiquement distribuees)."
+    "La variable `evidence1` (Bernoulli) englobe tout le modèle via `Variable.If()`. Les 7 observations partagent la meme `moyenne` et `precision`, ce qui represente l'hypothese i.i.d. (independantes et identiquement distribuees)."
    ]
   },
   {
@@ -1333,12 +1333,12 @@
    "source": [
     "### Implementation : Modele 2 - Melange de deux gaussiennes\n",
     "\n",
-    "Le **modele de melange** (mixture model) suppose que chaque observation provient de l'une ou l'autre de deux gaussiennes, avec une probabilite $\\pi$ pour la premiere et $1-\\pi$ pour la seconde.\n",
+    "Le **modèle de melange** (mixture model) suppose que chaque observation provient de l'une ou l'autre de deux gaussiennes, avec une probabilité $\\pi$ pour la première et $1-\\pi$ pour la seconde.\n",
     "\n",
-    "**Parametres du modele** :\n",
+    "**Parametres du modèle** :\n",
     "- $\\mu_1, \\mu_2$ : moyennes des deux composantes\n",
     "- $\\tau$ : precision commune (simplification)\n",
-    "- $\\pi$ : proportion du melange (poids de la premiere composante)\n",
+    "- $\\pi$ : proportion du melange (poids de la première composante)\n",
     "\n",
     "**Code** : Pour chaque observation, on tire d'abord `composante ~ Bernoulli(pi)`, puis on observe depuis la gaussienne correspondante.\n",
     "\n",
@@ -1811,7 +1811,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modele de melange de gaussiennes."
+    "Visualisation du graphe de facteurs du modèle de melange de gaussiennes."
    ]
   },
   {
@@ -2721,7 +2721,7 @@
    "source": [
     "### Lecture du graphe de facteurs - Modele melange\n",
     "\n",
-    "Le graphe du modele de melange est plus complexe :\n",
+    "Le graphe du modèle de melange est plus complexe :\n",
     "\n",
     "- **moyenne_a, moyenne_b** : les deux centres des composantes gaussiennes\n",
     "- **poids_mixte** : parametre Beta controlant la proportion du melange\n",
@@ -2892,7 +2892,7 @@
     "\n",
     "### Application\n",
     "\n",
-    "Determiner le nombre optimal de composantes dans un modele de melange."
+    "Determiner le nombre optimal de composantes dans un modèle de melange."
    ]
   },
   {
@@ -2909,13 +2909,13 @@
     "tags": []
    },
    "source": [
-    "### Donnees bimodales : quand le modele complexe gagne\n",
+    "### Donnees bimodales : quand le modèle complexe gagne\n",
     "\n",
-    "Les donnees precedentes etaient unimodales (autour de 15). Testons maintenant avec des donnees **clairement bimodales** : deux groupes bien separes autour de 6 et 15.\n",
+    "Les données precedentes etaient unimodales (autour de 15). Testons maintenant avec des données **clairement bimodales** : deux groupes bien separes autour de 6 et 15.\n",
     "\n",
-    "**Question** : Le modele a 2 composantes va-t-il maintenant etre prefere ?\n",
+    "**Question** : Le modèle a 2 composantes va-t-il maintenant etre prefere ?\n",
     "\n",
-    "L'algorithme compare systematiquement 1 vs 2 composantes en calculant l'evidence de chaque modele."
+    "L'algorithme compare systematiquement 1 vs 2 composantes en calculant l'evidence de chaque modèle."
    ]
   },
   {
@@ -3799,7 +3799,7 @@
     "\n",
     "Console.WriteLine($\"2 composantes : log evidence = {logEvidences[1]:F2}\");\n",
     "\n",
-    "// Meilleur modele\n",
+    "// Meilleur modèle\n",
     "int meilleur = logEvidences[0] > logEvidences[1] ? 1 : 2;\n",
     "Console.WriteLine($\"\\n=> Le modele a {meilleur} composante(s) est prefere\");"
    ]
@@ -3818,7 +3818,7 @@
     "tags": []
    },
    "source": [
-    "### Analyse des resultats : donnees bimodales\n",
+    "### Analyse des résultats : données bimodales\n",
     "\n",
     "**Donnees** : deux groupes distincts autour de 6 et 15\n",
     "\n",
@@ -3829,9 +3829,9 @@
     "\n",
     "**Difference** : log(BF) = -31.35 - (-45.89) = 14.54\n",
     "\n",
-    "Un facteur de Bayes $e^{14.54} \\approx 2 \\times 10^6$ en faveur du modele a 2 composantes constitue une evidence **decisive**.\n",
+    "Un facteur de Bayes $e^{14.54} \\approx 2 \\times 10^6$ en faveur du modèle a 2 composantes constitue une evidence **decisive**.\n",
     "\n",
-    "> **Lecon cle** : Le facteur de Bayes detecte automatiquement la structure des donnees. Il prefere le modele simple quand les donnees sont simples (section 3-4) et le modele complexe quand les donnees l'exigent (ici)."
+    "> **Lecon cle** : Le facteur de Bayes detecte automatiquement la structure des données. Il prefere le modèle simple quand les données sont simples (section 3-4) et le modèle complexe quand les données l'exigent (ici)."
    ]
   },
   {
@@ -3876,11 +3876,11 @@
     "tags": []
    },
    "source": [
-    "### Transition : de la comparaison de modeles a la selection de features\n",
+    "### Transition : de la comparaison de modèles a la selection de features\n",
     "\n",
-    "Jusqu'ici, nous avons compare des **modeles entiers** (1 vs 2 gaussiennes, lineaire vs quadratique). Mais en pratique, on veut souvent repondre a une question plus fine :\n",
+    "Jusqu'ici, nous avons compare des **modèles entiers** (1 vs 2 gaussiennes, lineaire vs quadratique). Mais en pratique, on veut souvent repondre a une question plus fine :\n",
     "\n",
-    "**Quelles features sont vraiment utiles dans mon modele ?**\n",
+    "**Quelles features sont vraiment utiles dans mon modèle ?**\n",
     "\n",
     "C'est le probleme de la **selection de variables**. L'approche bayesienne offre une solution elegante : l'**Automatic Relevance Determination** (ARD)."
    ]
@@ -3899,14 +3899,14 @@
     "tags": []
    },
    "source": [
-    "### Generation des donnees synthetiques\n",
+    "### Generation des données synthetiques\n",
     "\n",
     "Nous creons un probleme de regression ou :\n",
     "- **Feature 1** : coefficient reel = 2.0 (pertinente)\n",
     "- **Feature 2** : coefficient reel = 0.0 (non pertinente)\n",
     "- **Feature 3** : coefficient reel = 3.0 (pertinente)\n",
     "\n",
-    "Le modele ARD devra \"decouvrir\" automatiquement que la feature 2 n'apporte aucune information predictive."
+    "Le modèle ARD devra \"decouvrir\" automatiquement que la feature 2 n'apporte aucune information predictive."
    ]
   },
   {
@@ -3996,9 +3996,9 @@
     "tags": []
    },
    "source": [
-    "### Construction du modele ARD hierarchique\n",
+    "### Construction du modèle ARD hierarchique\n",
     "\n",
-    "Le modele ARD introduit un **hyperparametre de precision** $\\alpha_f$ pour chaque feature $f$ :\n",
+    "Le modèle ARD introduit un **hyperparametre de precision** $\\alpha_f$ pour chaque feature $f$ :\n",
     "\n",
     "$$w_f \\sim \\mathcal{N}(0, \\alpha_f^{-1})$$\n",
     "\n",
@@ -4525,7 +4525,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modele ARD."
+    "Visualisation du graphe de facteurs du modèle ARD."
    ]
   },
   {
@@ -5028,7 +5028,7 @@
     "- **poids[feature]** : poids de regression, chacun avec une precision `alpha[f]` differente\n",
     "- Les poids sont couples : `poids[f] ~ N(0, 1/alpha[f])`\n",
     "\n",
-    "**Niveau donnees** :\n",
+    "**Niveau données** :\n",
     "- **x[sample, feature]** : matrice des features (observee)\n",
     "- **y[sample]** : cible (observee)\n",
     "- **noise** : precision du bruit (infere)\n",
@@ -5091,20 +5091,20 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "On genere des donnees synthetiques selon :\n",
+    "On genere des données synthetiques selon :\n",
     "\n",
     "$$y = 1.5 \\cdot x_1 + 0 \\cdot x_2 + 0 \\cdot x_3 + 2.5 \\cdot x_4 + 0 \\cdot x_5 + \\epsilon$$\n",
     "\n",
     "Seules les features 1 et 4 contribuent a la prediction. Les features 2, 3 et 5 sont du bruit.\n",
     "\n",
     "**Travail demande** :\n",
-    "1. Generez les donnees avec `nSamples = 30` et `nFeatures = 5` (seed 42)\n",
-    "2. Construisez le modele ARD hierarchique (reutilisez la structure de la section 6)\n",
+    "1. Generez les données avec `nSamples = 30` et `nFeatures = 5` (seed 42)\n",
+    "2. Construisez le modèle ARD hierarchique (reutilisez la structure de la section 6)\n",
     "3. Lancez l'inference et affichez les poids posterieurs et les valeurs alpha pour chaque feature\n",
     "4. Identifiez quelles features sont selectionnees (alpha faible = pertinente)\n",
     "5. Comparez les poids estimes avec les vrais poids : {1.5, 0.0, 0.0, 2.5, 0.0}\n",
     "\n",
-    "> **Indice** : Avec plus de features (5 vs 3) et plus de donnees (30 vs 20), les alpha des features non pertinentes devraient etre plus eleves qu'avec 3 features, car le modele a plus d'information pour distinguer le signal du bruit. Utilisez le meme prior `Gamma(1, 1)` sur les alpha et `ExpectationPropagation` pour l'inference."
+    "> **Indice** : Avec plus de features (5 vs 3) et plus de données (30 vs 20), les alpha des features non pertinentes devraient etre plus eleves qu'avec 3 features, car le modèle a plus d'information pour distinguer le signal du bruit. Utilisez le meme prior `Gamma(1, 1)` sur les alpha et `ExpectationPropagation` pour l'inference."
    ]
   },
   {
@@ -5139,14 +5139,14 @@
    "source": [
     "// Exercice : ARD avec 5 features\n",
     "\n",
-    "// TODO: Etape 1 - Generer les donnees synthetiques\n",
+    "// TODO: Etape 1 - Generer les données synthetiques\n",
     "int nSamplesARD = 30;\n",
     "int nFeaturesARD = 5;\n",
     "double[] vraisPoidsARD = { 1.5, 0.0, 0.0, 2.5, 0.0 };\n",
     "double[,] XARD = new double[nSamplesARD, nFeaturesARD];  // TODO: remplir avec Random(42)\n",
     "double[] yARD = new double[nSamplesARD];                  // TODO: calculer y = sum(w_f * x_f) + bruit\n",
     "\n",
-    "// TODO: Etape 2 - Construire le modele ARD hierarchique\n",
+    "// TODO: Etape 2 - Construire le modèle ARD hierarchique\n",
     "// Range sampleRangeARD = new Range(nSamplesARD);\n",
     "// Range featureRangeARD = new Range(nFeaturesARD);\n",
     "// VariableArray<double> alphaARD = ...  (Gamma prior par feature)\n",
@@ -5156,7 +5156,7 @@
     "\n",
     "// TODO: Etape 3 - Inference avec ExpectationPropagation\n",
     "\n",
-    "// TODO: Etape 4 - Afficher les resultats\n",
+    "// TODO: Etape 4 - Afficher les résultats\n",
     "// Console.WriteLine(\"=== Resultats ARD (5 features) ===\");\n",
     "// Pour chaque feature : afficher poids moyen, ecart-type, alpha, pertinence\n",
     "\n",
@@ -5184,7 +5184,7 @@
     "\n",
     "### Principe\n",
     "\n",
-    "Au lieu de diviser les donnees, utiliser la predictive posterieure pour evaluer le modele.\n",
+    "Au lieu de diviser les données, utiliser la predictive posterieure pour evaluer le modèle.\n",
     "\n",
     "### Leave-One-Out (LOO)\n",
     "\n",
@@ -5208,9 +5208,9 @@
     "### Algorithme Leave-One-Out bayesien\n",
     "\n",
     "Pour chaque point $i$ :\n",
-    "1. **Entrainer** le modele sur tous les points sauf $i$\n",
+    "1. **Entrainer** le modèle sur tous les points sauf $i$\n",
     "2. **Calculer** la distribution predictive posterieure\n",
-    "3. **Evaluer** la log-probabilite du point $i$ sous cette predictive\n",
+    "3. **Evaluer** la log-probabilité du point $i$ sous cette predictive\n",
     "\n",
     "La **variance predictive** combine deux sources d'incertitude :\n",
     "- L'incertitude sur la moyenne ($\\text{Var}(\\mu)$)\n",
@@ -9062,7 +9062,7 @@
     "\n",
     "for (int i = 0; i < nLOO; i++)\n",
     "{\n",
-    "    // Entrainer sur toutes les donnees sauf i\n",
+    "    // Entrainer sur toutes les données sauf i\n",
     "    Variable<double> mu = Variable.GaussianFromMeanAndPrecision(10, 0.01);\n",
     "    Variable<double> prec = Variable.GammaFromShapeAndScale(2, 0.5);\n",
     "    \n",
@@ -9112,9 +9112,9 @@
     "\n",
     "**Log predictive moyenne = -1.81**\n",
     "\n",
-    "Cette metrique mesure la capacite du modele a predire des observations non vues. Comparons avec des references :\n",
+    "Cette metrique mesure la capacite du modèle a predire des observations non vues. Comparons avec des références :\n",
     "\n",
-    "| Log predictive moyenne | Qualite du modele |\n",
+    "| Log predictive moyenne | Qualite du modèle |\n",
     "|------------------------|-------------------|\n",
     "| > -1.0 | Excellente |\n",
     "| -1.0 a -2.0 | Bonne |\n",
@@ -9123,10 +9123,10 @@
     "\n",
     "Notre valeur de -1.81 indique une **bonne** capacite predictive.\n",
     "\n",
-    "> **Avantage du LOO bayesien** : Contrairement au LOO classique, cette methode :\n",
+    "> **Avantage du LOO bayesien** : Contrairement au LOO classique, cette méthode :\n",
     "> - Utilise l'incertitude complete (pas juste une estimation ponctuelle)\n",
     "> - Tient compte de l'incertitude sur les parametres via la variance predictive\n",
-    "> - Ne necessite pas de reentrainer completement le modele (en theorie, via des approximations)"
+    "> - Ne necessite pas de reentrainer completement le modèle (en theorie, via des approximations)"
    ]
   },
   {
@@ -9143,13 +9143,13 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Selection de modele par validation croisee LOO\n",
+    "## Exercice : Selection de modèle par validation croisee LOO\n",
     "\n",
-    "Dans cette section, vous avez vu la validation Leave-One-Out pour un modele gaussien simple. L'objectif de cet exercice est d'**etendre cette approche pour comparer deux modeles** sur les memes donnees, et de verifier si le resultat LOO est coherent avec le facteur de Bayes.\n",
+    "Dans cette section, vous avez vu la validation Leave-One-Out pour un modèle gaussien simple. L'objectif de cet exercice est d'**etendre cette approche pour comparer deux modèles** sur les memes données, et de verifier si le résultat LOO est coherent avec le facteur de Bayes.\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "On considere les donnees bimodales de la section 5 :\n",
+    "On considere les données bimodales de la section 5 :\n",
     "\n",
     "```csharp\n",
     "double[] dataEx = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
@@ -9164,10 +9164,10 @@
     "**Travail demandé** :\n",
     "1. Implementez la validation LOO pour le **Modele A** (une gaussienne)\n",
     "2. Implementez la validation LOO pour le **Modele B** (melange de deux gaussiennes) - utilisez `VariationalMessagePassing`\n",
-    "3. Comparez les scores LOO totaux : quel modele est prefere ?\n",
-    "4. Comparez avec le resultat du facteur de Bayes de la section 5 : les deux methodes donnent-elles le meme gagnant ?\n",
+    "3. Comparez les scores LOO totaux : quel modèle est prefere ?\n",
+    "4. Comparez avec le résultat du facteur de Bayes de la section 5 : les deux méthodes donnent-elles le meme gagnant ?\n",
     "\n",
-    "> **Indice** : Pour le Modele B dans la boucle LOO, vous devez recreer le modele de melange complet a chaque iteration (en retirant le point i). La distribution predictive posterieure d'un melange n'est pas gaussienne -- utilisez `GetMean()` et `GetVariance()` sur le resultat `Gaussian` inferé pour chaque point laisse de cote."
+    "> **Indice** : Pour le Modele B dans la boucle LOO, vous devez recreer le modèle de melange complet a chaque iteration (en retirant le point i). La distribution predictive posterieure d'un melange n'est pas gaussienne -- utilisez `GetMean()` et `GetVariance()` sur le résultat `Gaussian` inferé pour chaque point laisse de cote."
    ]
   },
   {
@@ -9222,7 +9222,7 @@
     }
    ],
    "source": [
-    "// Exercice : Selection de modele par validation croisee LOO\n",
+    "// Exercice : Selection de modèle par validation croisee LOO\n",
     "\n",
     "double[] dataEx = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "int nEx = dataEx.Length;\n",
@@ -9241,13 +9241,13 @@
     "\n",
     "// TODO: Boucle LOO Modele B\n",
     "// Indice : pour chaque iteration, recreer le melange complet sans le point i\n",
-    "// puis inferer la posteriorie et evaluer la log-probabilite du point laisse de cote\n",
+    "// puis inferer la posteriorie et evaluer la log-probabilité du point laisse de cote\n",
     "\n",
     "Console.WriteLine($\"Modele B - LOO total : {totalLogPredB:F2}\");\n",
     "\n",
-    "// TODO: Etape 3 - Comparer les resultats\n",
+    "// TODO: Etape 3 - Comparer les résultats\n",
     "Console.WriteLine(\"\\n=== Comparaison LOO ===\");\n",
-    "// Quel modele est prefere par LOO ?\n",
+    "// Quel modèle est prefere par LOO ?\n",
     "// Est-ce coherent avec le facteur de Bayes de la section 5 (2 composantes preferees) ?\n",
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
@@ -9269,7 +9269,7 @@
    "source": [
     "## Exercice : Comparer les criteres BIC et evidence approximee\n",
     "\n",
-    "Dans les sections precedentes, nous avons utilise l'evidence exacte (marginal likelihood) calculee par Infer.NET pour comparer des modeles. En pratique, l'evidence exacte est souvent incalculable et on utilise des **approximations** comme le BIC (Bayesian Information Criterion).\n",
+    "Dans les sections precedentes, nous avons utilise l'evidence exacte (marginal likelihood) calculee par Infer.NET pour comparer des modèles. En pratique, l'evidence exacte est souvent incalculable et on utilise des **approximations** comme le BIC (Bayesian Information Criterion).\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -9277,20 +9277,20 @@
     "\n",
     "$$\\text{BIC} = -2 \\ln(\\hat{L}) + k \\ln(n)$$\n",
     "\n",
-    "ou $\\hat{L}$ est la vraisemblance maximale, $k$ le nombre de parametres et $n$ le nombre d'observations. Un BIC plus faible indique un meilleur modele.\n",
+    "ou $\\hat{L}$ est la vraisemblance maximale, $k$ le nombre de parametres et $n$ le nombre d'observations. Un BIC plus faible indique un meilleur modèle.\n",
     "\n",
-    "On reprend les donnees bimodales de la section 5 :\n",
+    "On reprend les données bimodales de la section 5 :\n",
     "```csharp\n",
     "double[] dataBIC = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "```\n",
     "\n",
     "**Travail demande** :\n",
-    "1. Pour le modele a 1 gaussienne, calculez le BIC en estimant mu et tau par maximum de vraisemblance (moyenne empirique et variance inverse)\n",
-    "2. Pour le modele a 2 gaussiennes, utilisez les posteriors Infer.NET de la section 5 comme approximation du MLE, puis calculez le BIC (k = 5 parametres : mu1, mu2, tau, poids, + 1 bruit)\n",
-    "3. Comparez les classements BIC vs facteur de Bayes : les deux methodes selectionnent-elles le meme modele ?\n",
+    "1. Pour le modèle a 1 gaussienne, calculez le BIC en estimant mu et tau par maximum de vraisemblance (moyenne empirique et variance inverse)\n",
+    "2. Pour le modèle a 2 gaussiennes, utilisez les posteriors Infer.NET de la section 5 comme approximation du MLE, puis calculez le BIC (k = 5 parametres : mu1, mu2, tau, poids, + 1 bruit)\n",
+    "3. Comparez les classements BIC vs facteur de Bayes : les deux méthodes selectionnent-elles le meme modèle ?\n",
     "4. Affichez un tableau comparatif : `| Critere | Modele 1 | Modele 2 | Gagnant |`\n",
     "\n",
-    "> **Indice** : Pour le BIC du modele a 1 gaussienne, $k=2$ (mu + tau). La log-vraisemblance se calcule en sommant `Gaussian.FromMeanAndPrecision(mu_hat, tau_hat).GetLogProb(dataBIC[i])` pour chaque point. Pour le modele a 2 gaussiennes, $k=5$ (mu1, mu2, tau, poids + variance commune). Le BIC penalise davantage les modeles complexes que le facteur de Bayes -- observez si la penalite change le gagnant."
+    "> **Indice** : Pour le BIC du modèle a 1 gaussienne, $k=2$ (mu + tau). La log-vraisemblance se calcule en sommant `Gaussian.FromMeanAndPrecision(mu_hat, tau_hat).GetLogProb(dataBIC[i])` pour chaque point. Pour le modèle a 2 gaussiennes, $k=5$ (mu1, mu2, tau, poids + variance commune). Le BIC penalise davantage les modèles complexes que le facteur de Bayes -- observez si la penalite change le gagnant."
    ]
   },
   {
@@ -9350,7 +9350,7 @@
     "double[] dataBIC = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "int nBIC = dataBIC.Length;\n",
     "\n",
-    "// TODO: Etape 1 - Calculer le BIC pour le modele a 1 gaussienne (k=2)\n",
+    "// TODO: Etape 1 - Calculer le BIC pour le modèle a 1 gaussienne (k=2)\n",
     "// Estimer mu_hat = moyenne empirique, tau_hat = 1 / variance empirique\n",
     "// Puis BIC = -2 * sum(log P(x_i | mu_hat, tau_hat)) + k * ln(n)\n",
     "double bicModele1 = 0;\n",
@@ -9363,7 +9363,7 @@
     "\n",
     "Console.WriteLine($\"Modele 1 (1 gaussienne) - BIC : {bicModele1:F2}\");\n",
     "\n",
-    "// TODO: Etape 2 - Calculer le BIC pour le modele a 2 gaussiennes (k=5)\n",
+    "// TODO: Etape 2 - Calculer le BIC pour le modèle a 2 gaussiennes (k=5)\n",
     "// Utilisez les posteriors de la section 5 ou estimez par MLE\n",
     "double bicModele2 = 0;\n",
     "\n",
@@ -9375,8 +9375,8 @@
     "\n",
     "// TODO: Etape 3 - Comparer BIC vs facteur de Bayes\n",
     "Console.WriteLine(\"\\n=== Comparaison BIC vs Facteur de Bayes ===\");\n",
-    "// Indice : Le facteur de Bayes de la section 5 favorisait le modele a 2 composantes (log BF ~ 14.5)\n",
-    "// Indice : Le BIC favorise-t-il le meme modele ? Si oui, les deux methodes sont coherentes.\n",
+    "// Indice : Le facteur de Bayes de la section 5 favorisait le modèle a 2 composantes (log BF ~ 14.5)\n",
+    "// Indice : Le BIC favorise-t-il le meme modèle ? Si oui, les deux méthodes sont coherentes.\n",
     "// Indice : Si non, expliquez pourquoi (taille d'echantillon, approximation BIC, etc.)\n",
     "\n",
     "// TODO: Etape 4 - Afficher le tableau comparatif\n",
@@ -9406,12 +9406,12 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Comparez trois modeles de regression :\n",
+    "Comparez trois modèles de regression :\n",
     "- Lineaire : y = a*x + b\n",
     "- Quadratique : y = a*x^2 + b*x + c\n",
     "- Cubique : y = a*x^3 + b*x^2 + c*x + d\n",
     "\n",
-    "Sur des donnees lineaires avec bruit."
+    "Sur des données lineaires avec bruit."
    ]
   },
   {
@@ -9430,15 +9430,15 @@
    "source": [
     "### Mise en pratique : comparaison lineaire vs quadratique\n",
     "\n",
-    "Les donnees sont generees selon $y = 2x + 1 + \\epsilon$ (relation lineaire).\n",
+    "Les données sont generees selon $y = 2x + 1 + \\epsilon$ (relation lineaire).\n",
     "\n",
     "**Modeles a comparer** :\n",
     "- **Lineaire** : $y = ax + b$ (2 parametres)\n",
     "- **Quadratique** : $y = ax^2 + bx + c$ (3 parametres)\n",
     "\n",
-    "Le modele quadratique peut representer la relation lineaire (avec $a \\approx 0$), mais paie un \"cout de complexite\" pour ce parametre inutile.\n",
+    "Le modèle quadratique peut representer la relation lineaire (avec $a \\approx 0$), mais paie un \"cout de complexite\" pour ce parametre inutile.\n",
     "\n",
-    "> **Hint** : Pour ajouter un modele cubique, il suffirait d'ajouter un terme $d \\times x^3$. Le meme raisonnement s'applique : plus de parametres = plus de penalite si ils ne sont pas necessaires."
+    "> **Hint** : Pour ajouter un modèle cubique, il suffirait d'ajouter un terme $d \\times x^3$. Le meme raisonnement s'applique : plus de parametres = plus de penalite si ils ne sont pas necessaires."
    ]
   },
   {
@@ -10266,7 +10266,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Comparaison de modeles polynomiaux\n",
+    "// Exemple guide : Comparaison de modèles polynomiaux\n",
     "\n",
     "// Donnees lineaires : y = 2*x + 1 + bruit\n",
     "double[] xPoly = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };\n",
@@ -10319,7 +10319,7 @@
     "double logEvQuad = engQuad.Infer<Bernoulli>(evQuad).LogOdds;\n",
     "Console.WriteLine($\"Modele quadratique : log evidence = {logEvQuad:F2}\");\n",
     "\n",
-    "// Meilleur modele\n",
+    "// Meilleur modèle\n",
     "string meilleurMod = logEvLin > logEvQuad ? \"Lineaire\" : \"Quadratique\";\n",
     "Console.WriteLine($\"\\n=> Le modele {meilleurMod} est prefere (rasoir d'Occam)\");"
    ]
@@ -10338,7 +10338,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modele polynomial."
+    "Visualisation du graphe de facteurs du modèle polynomial."
    ]
   },
   {
@@ -12731,7 +12731,7 @@
    "source": [
     "### Lecture du graphe de facteurs - Modele quadratique\n",
     "\n",
-    "Le graphe montre la structure du modele quadratique $y = ax^2 + bx + c$ :\n",
+    "Le graphe montre la structure du modèle quadratique $y = ax^2 + bx + c$ :\n",
     "\n",
     "- **a_quad, b_quad, c_quad** : les trois coefficients du polynome (priors Gaussiens)\n",
     "- **noise_quad** : precision du bruit d'observation (prior Gamma)\n",
@@ -12739,7 +12739,7 @@
     "- **pred_quad_i** : predictions intermediaires (combinaison des coefficients)\n",
     "- **obs_quad_i** : observations (valeurs fixees)\n",
     "\n",
-    "Comparativement au modele lineaire, ce graphe contient un parametre supplementaire (`c_quad`), ce qui augmente la complexite du modele et la \"surface\" du prior - d'ou la penalisation par le rasoir d'Occam bayesien."
+    "Comparativement au modèle lineaire, ce graphe contient un parametre supplementaire (`c_quad`), ce qui augmente la complexite du modèle et la \"surface\" du prior - d'ou la penalisation par le rasoir d'Occam bayesien."
    ]
   },
   {
@@ -12767,15 +12767,15 @@
     "\n",
     "**Facteur de Bayes** : $\\exp(-14.03 - (-20.28)) = \\exp(6.25) \\approx 518$\n",
     "\n",
-    "Le modele lineaire est **decisement** prefere (BF > 150).\n",
+    "Le modèle lineaire est **decisement** prefere (BF > 150).\n",
     "\n",
-    "**Pourquoi le modele quadratique perd-il ?**\n",
+    "**Pourquoi le modèle quadratique perd-il ?**\n",
     "\n",
     "1. **Donnees generees lineairement** : y = 2x + 1 + bruit\n",
     "2. **Coefficient quadratique inutile** : le parametre $a$ (coefficient de $x^2$) n'apporte rien\n",
     "3. **Penalite de complexite** : le prior sur $a$ \"dilue\" la vraisemblance\n",
     "\n",
-    "> **Exercice supplementaire** : Que se passerait-il si les donnees etaient generees par y = 0.1*x^2 + 2*x + 1 ? Le terme quadratique est present mais faible. Le modele lineaire pourrait encore gagner si le signal quadratique est noye dans le bruit - c'est la balance ajustement vs complexite en action."
+    "> **Exercice supplementaire** : Que se passerait-il si les données etaient generees par y = 0.1*x^2 + 2*x + 1 ? Le terme quadratique est present mais faible. Le modèle lineaire pourrait encore gagner si le signal quadratique est noye dans le bruit - c'est la balance ajustement vs complexite en action."
    ]
   },
   {
@@ -12797,14 +12797,14 @@
     "| Concept | Description |\n",
     "|---------|-------------|\n",
     "| **Evidence** | P(D\\|M) - vraisemblance marginale |\n",
-    "| **Facteur de Bayes** | Ratio d'evidences pour comparer modeles |\n",
-    "| **Rasoir d'Occam** | Preference automatique pour modeles simples |\n",
+    "| **Facteur de Bayes** | Ratio d'evidences pour comparer modèles |\n",
+    "| **Rasoir d'Occam** | Preference automatique pour modèles simples |\n",
     "| **ARD** | Selection automatique de features |\n",
-    "| **LOO-CV** | Validation sans diviser les donnees |\n",
+    "| **LOO-CV** | Validation sans diviser les données |\n",
     "\n",
     "---\n",
     "\n",
-    "## Prochaine etape\n",
+    "## Prochaine étape\n",
     "\n",
     "Dans [Infer-11-Topic-Models](Infer-11-Topic-Models.ipynb), nous explorerons :\n",
     "\n",
@@ -12844,8 +12844,8 @@
     "\n",
     "| Concept | Section | Application |\n",
     "|---------|---------|-------------|\n",
-    "| Evidence marginale $P(D\\|M)$ | 3, 5 | Comparer modeles sans validation croisee |\n",
-    "| Facteur de Bayes | 4 | Quantifier la preference pour un modele |\n",
+    "| Evidence marginale $P(D\\|M)$ | 3, 5 | Comparer modèles sans validation croisee |\n",
+    "| Facteur de Bayes | 4 | Quantifier la preference pour un modèle |\n",
     "| Rasoir d'Occam bayesien | 3-5 | Penalisation automatique de la complexite |\n",
     "| Priors hierarchiques | 6 | ARD pour selection de features |\n",
     "| Distribution predictive | 7 | LOO-CV bayesien |\n",
@@ -12876,13 +12876,13 @@
     "\n",
     "**1. Le rasoir d'Occam est automatique**\n",
     "\n",
-    "La selection de modeles bayesienne penalise naturellement la complexite. Pas besoin de criteres ad hoc comme l'AIC ou le BIC - l'evidence marginale fait le travail.\n",
+    "La selection de modèles bayesienne penalise naturellement la complexite. Pas besoin de criteres ad hoc comme l'AIC ou le BIC - l'evidence marginale fait le travail.\n",
     "\n",
     "**2. L'echelle compte**\n",
     "\n",
     "| Methode | Quand l'utiliser |\n",
     "|---------|------------------|\n",
-    "| Facteur de Bayes | Comparer 2-3 modeles distincts |\n",
+    "| Facteur de Bayes | Comparer 2-3 modèles distincts |\n",
     "| ARD | Selectionner parmi de nombreuses features |\n",
     "| LOO-CV | Evaluer la capacite predictive |\n",
     "\n",
@@ -12890,7 +12890,7 @@
     "\n",
     "Les priors vagues ($\\sigma^2 = 10$ sur les poids) penalisent moins que des priors informatifs. Un mauvais choix de prior peut fausser la comparaison.\n",
     "\n",
-    "> **Conseil pratique** : Pour une comparaison equitable, utilisez des priors de meme \"force\" (meme variance) sur les parametres comparables entre modeles."
+    "> **Conseil pratique** : Pour une comparaison equitable, utilisez des priors de meme \"force\" (meme variance) sur les parametres comparables entre modèles."
    ]
   },
   {
@@ -12911,19 +12911,19 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Vous disposez de donnees generees par `y = 2*x^2 - 3*x + 1 + bruit` :\n",
+    "Vous disposez de données generees par `y = 2*x^2 - 3*x + 1 + bruit` :\n",
     "\n",
     "```\n",
     "x = {-2, -1, 0, 1, 2, 3}\n",
     "y = {14.8, 5.9, 1.1, -0.2, 3.8, 10.1}\n",
     "```\n",
     "\n",
-    "Comparez 3 modeles de regression polynomiale :\n",
+    "Comparez 3 modèles de regression polynomiale :\n",
     "1. **Lineaire** : `y = a*x + b` (2 parametres)\n",
     "2. **Quadratique** : `y = a*x^2 + b*x + c` (3 parametres)\n",
     "3. **Cubique** : `y = a*x^3 + b*x^2 + c*x + d` (4 parametres)\n",
     "\n",
-    "Quel modele a le meilleur log evidence ? Le cubique surpasse-t-il le quadratique ?"
+    "Quel modèle a le meilleur log evidence ? Le cubique surpasse-t-il le quadratique ?"
    ]
   },
   {
@@ -12956,7 +12956,7 @@
     }
    ],
    "source": [
-    "// Exercice : Selection de modele polynomial sur donnees quadratiques\n",
+    "// Exercice : Selection de modèle polynomial sur données quadratiques\n",
     "Console.WriteLine(\"Exercice a completer : selection de modele polynomial\");\n",
     "\n",
     "// Donnees quadratiques : y = 2*x^2 - 3*x + 1 + bruit\n",
@@ -12972,10 +12972,10 @@
     "// TODO: Creer une fonction CalculLogEvidence(Vector[] features, double[] y)\n",
     "// (Reutilisez la structure de la section 8 de l'exemple guide)\n",
     "\n",
-    "// TODO: Calculer le log evidence pour chaque modele\n",
+    "// TODO: Calculer le log evidence pour chaque modèle\n",
     "\n",
     "// TODO: Afficher et comparer\n",
-    "// Quel modele gagne ? Expliquez pourquoi le cubique ne bat pas forcement le quadratique."
+    "// Quel modèle gagne ? Expliquez pourquoi le cubique ne bat pas forcement le quadratique."
    ]
   },
   {
@@ -12994,14 +12994,14 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a presente la selection de modeles bayesienne : evidence, facteur de Bayes, ARD et validation croisee LOO.\n",
+    "Ce notebook a presente la selection de modèles bayesienne : evidence, facteur de Bayes, ARD et validation croisee LOO.\n",
     "\n",
     "| Methode | Principe | Quand l'utiliser |\n",
     "|---------|----------|------------------|\n",
-    "| Evidence (marginal likelihood) | P(D\\|M) integre sur les parametres | Comparer 2-3 modeles |\n",
+    "| Evidence (marginal likelihood) | P(D\\|M) integre sur les parametres | Comparer 2-3 modèles |\n",
     "| Facteur de Bayes | Ratio des evidences, echelle de Jeffreys | Quantifier la preference |\n",
     "| ARD | Priors hierarchiques Gamma -> precision par feature | Selection automatique de features |\n",
-    "| LOO-CV | Log-probabilite predictive leave-one-out | Evaluer la capacite predictive |\n",
+    "| LOO-CV | Log-probabilité predictive leave-one-out | Evaluer la capacite predictive |\n",
     "\n",
     "| Distribution | Role |\n",
     "|--------------|------|\n",
@@ -13010,7 +13010,7 @@
     "| Gamma | Priors sur les precisions (bruit, ARD) |\n",
     "| Beta | Prior sur les proportions de melange |\n",
     "\n",
-    "> **Rasoir d'Occam bayesien** : L'evidence penalise automatiquement la complexite. Un modele plus simple avec un bon ajustement bat toujours un modele complexe dont les parametres supplementaires n'apportent rien. Cela rend la comparaison objective, sans criteres ad hoc."
+    "> **Rasoir d'Occam bayesien** : L'evidence penalise automatiquement la complexite. Un modèle plus simple avec un bon ajustement bat toujours un modèle complexe dont les parametres supplementaires n'apportent rien. Cela rend la comparaison objective, sans criteres ad hoc."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
@@ -25,8 +25,8 @@
     "## Objectifs\n",
     "\n",
     "- Comprendre le probleme du surapprentissage\n",
-    "- Calculer l'evidence du modèle (marginal likelihood)\n",
-    "- Utiliser le facteur de Bayes pour comparer des modèles\n",
+    "- Calculer l'evidence du modele (marginal likelihood)\n",
+    "- Utiliser le facteur de Bayes pour comparer des modeles\n",
     "- Implementer l'Automatic Relevance Determination (ARD)\n",
     "\n",
     "---\n",
@@ -56,7 +56,7 @@
    "source": [
     "## 1. Configuration\n",
     "\n",
-    "Nous preparons l'environnement pour explorer la selection de modèles bayesienne. Cette approche permet de comparer objectivement differents modèles en calculant leur evidence marginale, implementant ainsi le rasoir d'Occam de maniere mathematique."
+    "Nous preparons l'environnement pour explorer la selection de modeles bayesienne. Cette approche permet de comparer objectivement differents modeles en calculant leur evidence marginale, implementant ainsi le rasoir d'Occam de maniere mathematique."
    ]
   },
   {
@@ -308,7 +308,7 @@
    "source": [
     "### Visualisation des graphes de facteurs\n",
     "\n",
-    "Ce notebook utilise `FactorGraphHelper.cs` pour visualiser les graphes de facteurs generes par Infer.NET. Ces graphes montrent la structure probabiliste des modèles : les noeuds representent les variables aleatoires et les observations, les facteurs (carres) representent les distributions conditionnelles.\n",
+    "Ce notebook utilise `FactorGraphHelper.cs` pour visualiser les graphes de facteurs generes par Infer.NET. Ces graphes montrent la structure probabiliste des modeles : les noeuds representent les variables aleatoires et les observations, les facteurs (carres) representent les distributions conditionnelles.\n",
     "\n",
     "Pour activer la visualisation, on configure `ShowFactorGraph = true` sur le moteur d'inference."
    ]
@@ -329,18 +329,18 @@
    "source": [
     "**Note technique : Calcul de l'evidence dans Infer.NET**\n",
     "\n",
-    "Infer.NET calcule l'evidence du modèle via une astuce elegante :\n",
+    "Infer.NET calcule l'evidence du modele via une astuce elegante :\n",
     "\n",
     "1. On introduit une variable indicatrice `evidence = Bernoulli(0.5)`\n",
-    "2. Le modèle est conditionne par `Variable.If(evidence)`\n",
+    "2. Le modele est conditionne par `Variable.If(evidence)`\n",
     "3. Apres inference, `evidence.LogOdds` donne le log de l'evidence\n",
     "\n",
-    "> **Pourquoi ca fonctionne ?** Par le théorème de Bayes :\n",
+    "> **Pourquoi ca fonctionne ?** Par le theoreme de Bayes :\n",
     "> $$P(\\text{evidence}=\\text{true}|D) \\propto P(D|\\text{evidence}=\\text{true}) \\times P(\\text{evidence}=\\text{true})$$\n",
     "> \n",
     "> Comme $P(\\text{evidence}=\\text{true}) = 0.5$, le log-odds posterieur est directement le log de l'evidence (a une constante pres).\n",
     "\n",
-    "Cette méthode est specifique a Infer.NET et permet d'obtenir l'evidence sans calcul integral explicite."
+    "Cette methode est specifique a Infer.NET et permet d'obtenir l'evidence sans calcul integral explicite."
    ]
   },
   {
@@ -361,7 +361,7 @@
     "\n",
     "### Observation\n",
     "\n",
-    "Un modèle complexe peut parfaitement ajuster les données d'entrainement mais mal generaliser.\n",
+    "Un modele complexe peut parfaitement ajuster les donnees d'entrainement mais mal generaliser.\n",
     "\n",
     "### Exemple\n",
     "\n",
@@ -369,8 +369,8 @@
     "\n",
     "### Solution bayesienne\n",
     "\n",
-    "- Les priors penalisent les modèles complexes\n",
-    "- L'evidence du modèle equilibre ajustement et complexite\n",
+    "- Les priors penalisent les modeles complexes\n",
+    "- L'evidence du modele equilibre ajustement et complexite\n",
     "- C'est le **rasoir d'Occam bayesien**"
    ]
   },
@@ -394,12 +394,12 @@
     "\n",
     "$$P(D|M) = \\int P(D|\\theta, M) P(\\theta|M) d\\theta$$\n",
     "\n",
-    "L'evidence est la probabilité des données sous le modèle, marginalisee sur les parametres.\n",
+    "L'evidence est la probabilite des donnees sous le modele, marginalisee sur les parametres.\n",
     "\n",
     "### Interpretation\n",
     "\n",
-    "- Un modèle simple fait des predictions moins precises mais moins dispersees\n",
-    "- Un modèle complexe fait des predictions plus precises mais plus dispersees\n",
+    "- Un modele simple fait des predictions moins precises mais moins dispersees\n",
+    "- Un modele complexe fait des predictions plus precises mais plus dispersees\n",
     "- L'evidence favorise le bon equilibre"
    ]
   },
@@ -873,13 +873,13 @@
     "tags": []
    },
    "source": [
-    "### Lecture du résultat\n",
+    "### Lecture du resultat\n",
     "\n",
-    "**Log evidence = -16.98** pour le modèle a une gaussienne.\n",
+    "**Log evidence = -16.98** pour le modele a une gaussienne.\n",
     "\n",
-    "Cette valeur negative est normale : c'est un logarithme de probabilité, donc toujours negatif (ou nul). Plus la valeur est proche de 0, meilleure est l'evidence.\n",
+    "Cette valeur negative est normale : c'est un logarithme de probabilite, donc toujours negatif (ou nul). Plus la valeur est proche de 0, meilleure est l'evidence.\n",
     "\n",
-    "En termes absolus, $e^{-16.98} \\approx 4.2 \\times 10^{-8}$ semble tres petit, mais c'est la **comparaison relative** entre modèles qui importe, pas la valeur absolue."
+    "En termes absolus, $e^{-16.98} \\approx 4.2 \\times 10^{-8}$ semble tres petit, mais c'est la **comparaison relative** entre modeles qui importe, pas la valeur absolue."
    ]
   },
   {
@@ -1308,13 +1308,13 @@
    "source": [
     "### Lecture du graphe de facteurs - Modele 1 gaussienne\n",
     "\n",
-    "Le graphe montre la structure du modèle a une gaussienne :\n",
+    "Le graphe montre la structure du modele a une gaussienne :\n",
     "\n",
     "- **Noeuds ovales** : variables aleatoires (`moyenne`, `precision`, `evidence1`)\n",
     "- **Noeuds carres** : facteurs (distributions conditionnelles)\n",
     "- **Noeuds gris** : observations (`obs_0` a `obs_6`)\n",
     "\n",
-    "La variable `evidence1` (Bernoulli) englobe tout le modèle via `Variable.If()`. Les 7 observations partagent la meme `moyenne` et `precision`, ce qui represente l'hypothese i.i.d. (independantes et identiquement distribuees)."
+    "La variable `evidence1` (Bernoulli) englobe tout le modele via `Variable.If()`. Les 7 observations partagent la meme `moyenne` et `precision`, ce qui represente l'hypothese i.i.d. (independantes et identiquement distribuees)."
    ]
   },
   {
@@ -1333,12 +1333,12 @@
    "source": [
     "### Implementation : Modele 2 - Melange de deux gaussiennes\n",
     "\n",
-    "Le **modèle de melange** (mixture model) suppose que chaque observation provient de l'une ou l'autre de deux gaussiennes, avec une probabilité $\\pi$ pour la première et $1-\\pi$ pour la seconde.\n",
+    "Le **modele de melange** (mixture model) suppose que chaque observation provient de l'une ou l'autre de deux gaussiennes, avec une probabilite $\\pi$ pour la premiere et $1-\\pi$ pour la seconde.\n",
     "\n",
-    "**Parametres du modèle** :\n",
+    "**Parametres du modele** :\n",
     "- $\\mu_1, \\mu_2$ : moyennes des deux composantes\n",
     "- $\\tau$ : precision commune (simplification)\n",
-    "- $\\pi$ : proportion du melange (poids de la première composante)\n",
+    "- $\\pi$ : proportion du melange (poids de la premiere composante)\n",
     "\n",
     "**Code** : Pour chaque observation, on tire d'abord `composante ~ Bernoulli(pi)`, puis on observe depuis la gaussienne correspondante.\n",
     "\n",
@@ -1811,7 +1811,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modèle de melange de gaussiennes."
+    "Visualisation du graphe de facteurs du modele de melange de gaussiennes."
    ]
   },
   {
@@ -2721,7 +2721,7 @@
    "source": [
     "### Lecture du graphe de facteurs - Modele melange\n",
     "\n",
-    "Le graphe du modèle de melange est plus complexe :\n",
+    "Le graphe du modele de melange est plus complexe :\n",
     "\n",
     "- **moyenne_a, moyenne_b** : les deux centres des composantes gaussiennes\n",
     "- **poids_mixte** : parametre Beta controlant la proportion du melange\n",
@@ -2892,7 +2892,7 @@
     "\n",
     "### Application\n",
     "\n",
-    "Determiner le nombre optimal de composantes dans un modèle de melange."
+    "Determiner le nombre optimal de composantes dans un modele de melange."
    ]
   },
   {
@@ -2909,13 +2909,13 @@
     "tags": []
    },
    "source": [
-    "### Donnees bimodales : quand le modèle complexe gagne\n",
+    "### Donnees bimodales : quand le modele complexe gagne\n",
     "\n",
-    "Les données precedentes etaient unimodales (autour de 15). Testons maintenant avec des données **clairement bimodales** : deux groupes bien separes autour de 6 et 15.\n",
+    "Les donnees precedentes etaient unimodales (autour de 15). Testons maintenant avec des donnees **clairement bimodales** : deux groupes bien separes autour de 6 et 15.\n",
     "\n",
-    "**Question** : Le modèle a 2 composantes va-t-il maintenant etre prefere ?\n",
+    "**Question** : Le modele a 2 composantes va-t-il maintenant etre prefere ?\n",
     "\n",
-    "L'algorithme compare systematiquement 1 vs 2 composantes en calculant l'evidence de chaque modèle."
+    "L'algorithme compare systematiquement 1 vs 2 composantes en calculant l'evidence de chaque modele."
    ]
   },
   {
@@ -3799,7 +3799,7 @@
     "\n",
     "Console.WriteLine($\"2 composantes : log evidence = {logEvidences[1]:F2}\");\n",
     "\n",
-    "// Meilleur modèle\n",
+    "// Meilleur modele\n",
     "int meilleur = logEvidences[0] > logEvidences[1] ? 1 : 2;\n",
     "Console.WriteLine($\"\\n=> Le modele a {meilleur} composante(s) est prefere\");"
    ]
@@ -3818,7 +3818,7 @@
     "tags": []
    },
    "source": [
-    "### Analyse des résultats : données bimodales\n",
+    "### Analyse des resultats : donnees bimodales\n",
     "\n",
     "**Donnees** : deux groupes distincts autour de 6 et 15\n",
     "\n",
@@ -3829,9 +3829,9 @@
     "\n",
     "**Difference** : log(BF) = -31.35 - (-45.89) = 14.54\n",
     "\n",
-    "Un facteur de Bayes $e^{14.54} \\approx 2 \\times 10^6$ en faveur du modèle a 2 composantes constitue une evidence **decisive**.\n",
+    "Un facteur de Bayes $e^{14.54} \\approx 2 \\times 10^6$ en faveur du modele a 2 composantes constitue une evidence **decisive**.\n",
     "\n",
-    "> **Lecon cle** : Le facteur de Bayes detecte automatiquement la structure des données. Il prefere le modèle simple quand les données sont simples (section 3-4) et le modèle complexe quand les données l'exigent (ici)."
+    "> **Lecon cle** : Le facteur de Bayes detecte automatiquement la structure des donnees. Il prefere le modele simple quand les donnees sont simples (section 3-4) et le modele complexe quand les donnees l'exigent (ici)."
    ]
   },
   {
@@ -3876,11 +3876,11 @@
     "tags": []
    },
    "source": [
-    "### Transition : de la comparaison de modèles a la selection de features\n",
+    "### Transition : de la comparaison de modeles a la selection de features\n",
     "\n",
-    "Jusqu'ici, nous avons compare des **modèles entiers** (1 vs 2 gaussiennes, lineaire vs quadratique). Mais en pratique, on veut souvent repondre a une question plus fine :\n",
+    "Jusqu'ici, nous avons compare des **modeles entiers** (1 vs 2 gaussiennes, lineaire vs quadratique). Mais en pratique, on veut souvent repondre a une question plus fine :\n",
     "\n",
-    "**Quelles features sont vraiment utiles dans mon modèle ?**\n",
+    "**Quelles features sont vraiment utiles dans mon modele ?**\n",
     "\n",
     "C'est le probleme de la **selection de variables**. L'approche bayesienne offre une solution elegante : l'**Automatic Relevance Determination** (ARD)."
    ]
@@ -3899,14 +3899,14 @@
     "tags": []
    },
    "source": [
-    "### Generation des données synthetiques\n",
+    "### Generation des donnees synthetiques\n",
     "\n",
     "Nous creons un probleme de regression ou :\n",
     "- **Feature 1** : coefficient reel = 2.0 (pertinente)\n",
     "- **Feature 2** : coefficient reel = 0.0 (non pertinente)\n",
     "- **Feature 3** : coefficient reel = 3.0 (pertinente)\n",
     "\n",
-    "Le modèle ARD devra \"decouvrir\" automatiquement que la feature 2 n'apporte aucune information predictive."
+    "Le modele ARD devra \"decouvrir\" automatiquement que la feature 2 n'apporte aucune information predictive."
    ]
   },
   {
@@ -3996,9 +3996,9 @@
     "tags": []
    },
    "source": [
-    "### Construction du modèle ARD hierarchique\n",
+    "### Construction du modele ARD hierarchique\n",
     "\n",
-    "Le modèle ARD introduit un **hyperparametre de precision** $\\alpha_f$ pour chaque feature $f$ :\n",
+    "Le modele ARD introduit un **hyperparametre de precision** $\\alpha_f$ pour chaque feature $f$ :\n",
     "\n",
     "$$w_f \\sim \\mathcal{N}(0, \\alpha_f^{-1})$$\n",
     "\n",
@@ -4525,7 +4525,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modèle ARD."
+    "Visualisation du graphe de facteurs du modele ARD."
    ]
   },
   {
@@ -5028,7 +5028,7 @@
     "- **poids[feature]** : poids de regression, chacun avec une precision `alpha[f]` differente\n",
     "- Les poids sont couples : `poids[f] ~ N(0, 1/alpha[f])`\n",
     "\n",
-    "**Niveau données** :\n",
+    "**Niveau donnees** :\n",
     "- **x[sample, feature]** : matrice des features (observee)\n",
     "- **y[sample]** : cible (observee)\n",
     "- **noise** : precision du bruit (infere)\n",
@@ -5091,20 +5091,20 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "On genere des données synthetiques selon :\n",
+    "On genere des donnees synthetiques selon :\n",
     "\n",
     "$$y = 1.5 \\cdot x_1 + 0 \\cdot x_2 + 0 \\cdot x_3 + 2.5 \\cdot x_4 + 0 \\cdot x_5 + \\epsilon$$\n",
     "\n",
     "Seules les features 1 et 4 contribuent a la prediction. Les features 2, 3 et 5 sont du bruit.\n",
     "\n",
     "**Travail demande** :\n",
-    "1. Generez les données avec `nSamples = 30` et `nFeatures = 5` (seed 42)\n",
-    "2. Construisez le modèle ARD hierarchique (reutilisez la structure de la section 6)\n",
+    "1. Generez les donnees avec `nSamples = 30` et `nFeatures = 5` (seed 42)\n",
+    "2. Construisez le modele ARD hierarchique (reutilisez la structure de la section 6)\n",
     "3. Lancez l'inference et affichez les poids posterieurs et les valeurs alpha pour chaque feature\n",
     "4. Identifiez quelles features sont selectionnees (alpha faible = pertinente)\n",
     "5. Comparez les poids estimes avec les vrais poids : {1.5, 0.0, 0.0, 2.5, 0.0}\n",
     "\n",
-    "> **Indice** : Avec plus de features (5 vs 3) et plus de données (30 vs 20), les alpha des features non pertinentes devraient etre plus eleves qu'avec 3 features, car le modèle a plus d'information pour distinguer le signal du bruit. Utilisez le meme prior `Gamma(1, 1)` sur les alpha et `ExpectationPropagation` pour l'inference."
+    "> **Indice** : Avec plus de features (5 vs 3) et plus de donnees (30 vs 20), les alpha des features non pertinentes devraient etre plus eleves qu'avec 3 features, car le modele a plus d'information pour distinguer le signal du bruit. Utilisez le meme prior `Gamma(1, 1)` sur les alpha et `ExpectationPropagation` pour l'inference."
    ]
   },
   {
@@ -5139,14 +5139,14 @@
    "source": [
     "// Exercice : ARD avec 5 features\n",
     "\n",
-    "// TODO: Etape 1 - Generer les données synthetiques\n",
+    "// TODO: Etape 1 - Generer les donnees synthetiques\n",
     "int nSamplesARD = 30;\n",
     "int nFeaturesARD = 5;\n",
     "double[] vraisPoidsARD = { 1.5, 0.0, 0.0, 2.5, 0.0 };\n",
     "double[,] XARD = new double[nSamplesARD, nFeaturesARD];  // TODO: remplir avec Random(42)\n",
     "double[] yARD = new double[nSamplesARD];                  // TODO: calculer y = sum(w_f * x_f) + bruit\n",
     "\n",
-    "// TODO: Etape 2 - Construire le modèle ARD hierarchique\n",
+    "// TODO: Etape 2 - Construire le modele ARD hierarchique\n",
     "// Range sampleRangeARD = new Range(nSamplesARD);\n",
     "// Range featureRangeARD = new Range(nFeaturesARD);\n",
     "// VariableArray<double> alphaARD = ...  (Gamma prior par feature)\n",
@@ -5156,7 +5156,7 @@
     "\n",
     "// TODO: Etape 3 - Inference avec ExpectationPropagation\n",
     "\n",
-    "// TODO: Etape 4 - Afficher les résultats\n",
+    "// TODO: Etape 4 - Afficher les resultats\n",
     "// Console.WriteLine(\"=== Resultats ARD (5 features) ===\");\n",
     "// Pour chaque feature : afficher poids moyen, ecart-type, alpha, pertinence\n",
     "\n",
@@ -5184,7 +5184,7 @@
     "\n",
     "### Principe\n",
     "\n",
-    "Au lieu de diviser les données, utiliser la predictive posterieure pour evaluer le modèle.\n",
+    "Au lieu de diviser les donnees, utiliser la predictive posterieure pour evaluer le modele.\n",
     "\n",
     "### Leave-One-Out (LOO)\n",
     "\n",
@@ -5208,9 +5208,9 @@
     "### Algorithme Leave-One-Out bayesien\n",
     "\n",
     "Pour chaque point $i$ :\n",
-    "1. **Entrainer** le modèle sur tous les points sauf $i$\n",
+    "1. **Entrainer** le modele sur tous les points sauf $i$\n",
     "2. **Calculer** la distribution predictive posterieure\n",
-    "3. **Evaluer** la log-probabilité du point $i$ sous cette predictive\n",
+    "3. **Evaluer** la log-probabilite du point $i$ sous cette predictive\n",
     "\n",
     "La **variance predictive** combine deux sources d'incertitude :\n",
     "- L'incertitude sur la moyenne ($\\text{Var}(\\mu)$)\n",
@@ -9062,7 +9062,7 @@
     "\n",
     "for (int i = 0; i < nLOO; i++)\n",
     "{\n",
-    "    // Entrainer sur toutes les données sauf i\n",
+    "    // Entrainer sur toutes les donnees sauf i\n",
     "    Variable<double> mu = Variable.GaussianFromMeanAndPrecision(10, 0.01);\n",
     "    Variable<double> prec = Variable.GammaFromShapeAndScale(2, 0.5);\n",
     "    \n",
@@ -9112,9 +9112,9 @@
     "\n",
     "**Log predictive moyenne = -1.81**\n",
     "\n",
-    "Cette metrique mesure la capacite du modèle a predire des observations non vues. Comparons avec des références :\n",
+    "Cette metrique mesure la capacite du modele a predire des observations non vues. Comparons avec des references :\n",
     "\n",
-    "| Log predictive moyenne | Qualite du modèle |\n",
+    "| Log predictive moyenne | Qualite du modele |\n",
     "|------------------------|-------------------|\n",
     "| > -1.0 | Excellente |\n",
     "| -1.0 a -2.0 | Bonne |\n",
@@ -9123,10 +9123,10 @@
     "\n",
     "Notre valeur de -1.81 indique une **bonne** capacite predictive.\n",
     "\n",
-    "> **Avantage du LOO bayesien** : Contrairement au LOO classique, cette méthode :\n",
+    "> **Avantage du LOO bayesien** : Contrairement au LOO classique, cette methode :\n",
     "> - Utilise l'incertitude complete (pas juste une estimation ponctuelle)\n",
     "> - Tient compte de l'incertitude sur les parametres via la variance predictive\n",
-    "> - Ne necessite pas de reentrainer completement le modèle (en theorie, via des approximations)"
+    "> - Ne necessite pas de reentrainer completement le modele (en theorie, via des approximations)"
    ]
   },
   {
@@ -9143,13 +9143,13 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Selection de modèle par validation croisee LOO\n",
+    "## Exercice : Selection de modele par validation croisee LOO\n",
     "\n",
-    "Dans cette section, vous avez vu la validation Leave-One-Out pour un modèle gaussien simple. L'objectif de cet exercice est d'**etendre cette approche pour comparer deux modèles** sur les memes données, et de verifier si le résultat LOO est coherent avec le facteur de Bayes.\n",
+    "Dans cette section, vous avez vu la validation Leave-One-Out pour un modele gaussien simple. L'objectif de cet exercice est d'**etendre cette approche pour comparer deux modeles** sur les memes donnees, et de verifier si le resultat LOO est coherent avec le facteur de Bayes.\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "On considere les données bimodales de la section 5 :\n",
+    "On considere les donnees bimodales de la section 5 :\n",
     "\n",
     "```csharp\n",
     "double[] dataEx = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
@@ -9164,10 +9164,10 @@
     "**Travail demandé** :\n",
     "1. Implementez la validation LOO pour le **Modele A** (une gaussienne)\n",
     "2. Implementez la validation LOO pour le **Modele B** (melange de deux gaussiennes) - utilisez `VariationalMessagePassing`\n",
-    "3. Comparez les scores LOO totaux : quel modèle est prefere ?\n",
-    "4. Comparez avec le résultat du facteur de Bayes de la section 5 : les deux méthodes donnent-elles le meme gagnant ?\n",
+    "3. Comparez les scores LOO totaux : quel modele est prefere ?\n",
+    "4. Comparez avec le resultat du facteur de Bayes de la section 5 : les deux methodes donnent-elles le meme gagnant ?\n",
     "\n",
-    "> **Indice** : Pour le Modele B dans la boucle LOO, vous devez recreer le modèle de melange complet a chaque iteration (en retirant le point i). La distribution predictive posterieure d'un melange n'est pas gaussienne -- utilisez `GetMean()` et `GetVariance()` sur le résultat `Gaussian` inferé pour chaque point laisse de cote."
+    "> **Indice** : Pour le Modele B dans la boucle LOO, vous devez recreer le modele de melange complet a chaque iteration (en retirant le point i). La distribution predictive posterieure d'un melange n'est pas gaussienne -- utilisez `GetMean()` et `GetVariance()` sur le resultat `Gaussian` inferé pour chaque point laisse de cote."
    ]
   },
   {
@@ -9222,7 +9222,7 @@
     }
    ],
    "source": [
-    "// Exercice : Selection de modèle par validation croisee LOO\n",
+    "// Exercice : Selection de modele par validation croisee LOO\n",
     "\n",
     "double[] dataEx = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "int nEx = dataEx.Length;\n",
@@ -9241,13 +9241,13 @@
     "\n",
     "// TODO: Boucle LOO Modele B\n",
     "// Indice : pour chaque iteration, recreer le melange complet sans le point i\n",
-    "// puis inferer la posteriorie et evaluer la log-probabilité du point laisse de cote\n",
+    "// puis inferer la posteriorie et evaluer la log-probabilite du point laisse de cote\n",
     "\n",
     "Console.WriteLine($\"Modele B - LOO total : {totalLogPredB:F2}\");\n",
     "\n",
-    "// TODO: Etape 3 - Comparer les résultats\n",
+    "// TODO: Etape 3 - Comparer les resultats\n",
     "Console.WriteLine(\"\\n=== Comparaison LOO ===\");\n",
-    "// Quel modèle est prefere par LOO ?\n",
+    "// Quel modele est prefere par LOO ?\n",
     "// Est-ce coherent avec le facteur de Bayes de la section 5 (2 composantes preferees) ?\n",
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
@@ -9269,7 +9269,7 @@
    "source": [
     "## Exercice : Comparer les criteres BIC et evidence approximee\n",
     "\n",
-    "Dans les sections precedentes, nous avons utilise l'evidence exacte (marginal likelihood) calculee par Infer.NET pour comparer des modèles. En pratique, l'evidence exacte est souvent incalculable et on utilise des **approximations** comme le BIC (Bayesian Information Criterion).\n",
+    "Dans les sections precedentes, nous avons utilise l'evidence exacte (marginal likelihood) calculee par Infer.NET pour comparer des modeles. En pratique, l'evidence exacte est souvent incalculable et on utilise des **approximations** comme le BIC (Bayesian Information Criterion).\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -9277,20 +9277,20 @@
     "\n",
     "$$\\text{BIC} = -2 \\ln(\\hat{L}) + k \\ln(n)$$\n",
     "\n",
-    "ou $\\hat{L}$ est la vraisemblance maximale, $k$ le nombre de parametres et $n$ le nombre d'observations. Un BIC plus faible indique un meilleur modèle.\n",
+    "ou $\\hat{L}$ est la vraisemblance maximale, $k$ le nombre de parametres et $n$ le nombre d'observations. Un BIC plus faible indique un meilleur modele.\n",
     "\n",
-    "On reprend les données bimodales de la section 5 :\n",
+    "On reprend les donnees bimodales de la section 5 :\n",
     "```csharp\n",
     "double[] dataBIC = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "```\n",
     "\n",
     "**Travail demande** :\n",
-    "1. Pour le modèle a 1 gaussienne, calculez le BIC en estimant mu et tau par maximum de vraisemblance (moyenne empirique et variance inverse)\n",
-    "2. Pour le modèle a 2 gaussiennes, utilisez les posteriors Infer.NET de la section 5 comme approximation du MLE, puis calculez le BIC (k = 5 parametres : mu1, mu2, tau, poids, + 1 bruit)\n",
-    "3. Comparez les classements BIC vs facteur de Bayes : les deux méthodes selectionnent-elles le meme modèle ?\n",
+    "1. Pour le modele a 1 gaussienne, calculez le BIC en estimant mu et tau par maximum de vraisemblance (moyenne empirique et variance inverse)\n",
+    "2. Pour le modele a 2 gaussiennes, utilisez les posteriors Infer.NET de la section 5 comme approximation du MLE, puis calculez le BIC (k = 5 parametres : mu1, mu2, tau, poids, + 1 bruit)\n",
+    "3. Comparez les classements BIC vs facteur de Bayes : les deux methodes selectionnent-elles le meme modele ?\n",
     "4. Affichez un tableau comparatif : `| Critere | Modele 1 | Modele 2 | Gagnant |`\n",
     "\n",
-    "> **Indice** : Pour le BIC du modèle a 1 gaussienne, $k=2$ (mu + tau). La log-vraisemblance se calcule en sommant `Gaussian.FromMeanAndPrecision(mu_hat, tau_hat).GetLogProb(dataBIC[i])` pour chaque point. Pour le modèle a 2 gaussiennes, $k=5$ (mu1, mu2, tau, poids + variance commune). Le BIC penalise davantage les modèles complexes que le facteur de Bayes -- observez si la penalite change le gagnant."
+    "> **Indice** : Pour le BIC du modele a 1 gaussienne, $k=2$ (mu + tau). La log-vraisemblance se calcule en sommant `Gaussian.FromMeanAndPrecision(mu_hat, tau_hat).GetLogProb(dataBIC[i])` pour chaque point. Pour le modele a 2 gaussiennes, $k=5$ (mu1, mu2, tau, poids + variance commune). Le BIC penalise davantage les modeles complexes que le facteur de Bayes -- observez si la penalite change le gagnant."
    ]
   },
   {
@@ -9350,7 +9350,7 @@
     "double[] dataBIC = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "int nBIC = dataBIC.Length;\n",
     "\n",
-    "// TODO: Etape 1 - Calculer le BIC pour le modèle a 1 gaussienne (k=2)\n",
+    "// TODO: Etape 1 - Calculer le BIC pour le modele a 1 gaussienne (k=2)\n",
     "// Estimer mu_hat = moyenne empirique, tau_hat = 1 / variance empirique\n",
     "// Puis BIC = -2 * sum(log P(x_i | mu_hat, tau_hat)) + k * ln(n)\n",
     "double bicModele1 = 0;\n",
@@ -9363,7 +9363,7 @@
     "\n",
     "Console.WriteLine($\"Modele 1 (1 gaussienne) - BIC : {bicModele1:F2}\");\n",
     "\n",
-    "// TODO: Etape 2 - Calculer le BIC pour le modèle a 2 gaussiennes (k=5)\n",
+    "// TODO: Etape 2 - Calculer le BIC pour le modele a 2 gaussiennes (k=5)\n",
     "// Utilisez les posteriors de la section 5 ou estimez par MLE\n",
     "double bicModele2 = 0;\n",
     "\n",
@@ -9375,8 +9375,8 @@
     "\n",
     "// TODO: Etape 3 - Comparer BIC vs facteur de Bayes\n",
     "Console.WriteLine(\"\\n=== Comparaison BIC vs Facteur de Bayes ===\");\n",
-    "// Indice : Le facteur de Bayes de la section 5 favorisait le modèle a 2 composantes (log BF ~ 14.5)\n",
-    "// Indice : Le BIC favorise-t-il le meme modèle ? Si oui, les deux méthodes sont coherentes.\n",
+    "// Indice : Le facteur de Bayes de la section 5 favorisait le modele a 2 composantes (log BF ~ 14.5)\n",
+    "// Indice : Le BIC favorise-t-il le meme modele ? Si oui, les deux methodes sont coherentes.\n",
     "// Indice : Si non, expliquez pourquoi (taille d'echantillon, approximation BIC, etc.)\n",
     "\n",
     "// TODO: Etape 4 - Afficher le tableau comparatif\n",
@@ -9406,12 +9406,12 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Comparez trois modèles de regression :\n",
+    "Comparez trois modeles de regression :\n",
     "- Lineaire : y = a*x + b\n",
     "- Quadratique : y = a*x^2 + b*x + c\n",
     "- Cubique : y = a*x^3 + b*x^2 + c*x + d\n",
     "\n",
-    "Sur des données lineaires avec bruit."
+    "Sur des donnees lineaires avec bruit."
    ]
   },
   {
@@ -9430,15 +9430,15 @@
    "source": [
     "### Mise en pratique : comparaison lineaire vs quadratique\n",
     "\n",
-    "Les données sont generees selon $y = 2x + 1 + \\epsilon$ (relation lineaire).\n",
+    "Les donnees sont generees selon $y = 2x + 1 + \\epsilon$ (relation lineaire).\n",
     "\n",
     "**Modeles a comparer** :\n",
     "- **Lineaire** : $y = ax + b$ (2 parametres)\n",
     "- **Quadratique** : $y = ax^2 + bx + c$ (3 parametres)\n",
     "\n",
-    "Le modèle quadratique peut representer la relation lineaire (avec $a \\approx 0$), mais paie un \"cout de complexite\" pour ce parametre inutile.\n",
+    "Le modele quadratique peut representer la relation lineaire (avec $a \\approx 0$), mais paie un \"cout de complexite\" pour ce parametre inutile.\n",
     "\n",
-    "> **Hint** : Pour ajouter un modèle cubique, il suffirait d'ajouter un terme $d \\times x^3$. Le meme raisonnement s'applique : plus de parametres = plus de penalite si ils ne sont pas necessaires."
+    "> **Hint** : Pour ajouter un modele cubique, il suffirait d'ajouter un terme $d \\times x^3$. Le meme raisonnement s'applique : plus de parametres = plus de penalite si ils ne sont pas necessaires."
    ]
   },
   {
@@ -10266,7 +10266,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Comparaison de modèles polynomiaux\n",
+    "// Exemple guide : Comparaison de modeles polynomiaux\n",
     "\n",
     "// Donnees lineaires : y = 2*x + 1 + bruit\n",
     "double[] xPoly = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };\n",
@@ -10319,7 +10319,7 @@
     "double logEvQuad = engQuad.Infer<Bernoulli>(evQuad).LogOdds;\n",
     "Console.WriteLine($\"Modele quadratique : log evidence = {logEvQuad:F2}\");\n",
     "\n",
-    "// Meilleur modèle\n",
+    "// Meilleur modele\n",
     "string meilleurMod = logEvLin > logEvQuad ? \"Lineaire\" : \"Quadratique\";\n",
     "Console.WriteLine($\"\\n=> Le modele {meilleurMod} est prefere (rasoir d'Occam)\");"
    ]
@@ -10338,7 +10338,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modèle polynomial."
+    "Visualisation du graphe de facteurs du modele polynomial."
    ]
   },
   {
@@ -12731,7 +12731,7 @@
    "source": [
     "### Lecture du graphe de facteurs - Modele quadratique\n",
     "\n",
-    "Le graphe montre la structure du modèle quadratique $y = ax^2 + bx + c$ :\n",
+    "Le graphe montre la structure du modele quadratique $y = ax^2 + bx + c$ :\n",
     "\n",
     "- **a_quad, b_quad, c_quad** : les trois coefficients du polynome (priors Gaussiens)\n",
     "- **noise_quad** : precision du bruit d'observation (prior Gamma)\n",
@@ -12739,7 +12739,7 @@
     "- **pred_quad_i** : predictions intermediaires (combinaison des coefficients)\n",
     "- **obs_quad_i** : observations (valeurs fixees)\n",
     "\n",
-    "Comparativement au modèle lineaire, ce graphe contient un parametre supplementaire (`c_quad`), ce qui augmente la complexite du modèle et la \"surface\" du prior - d'ou la penalisation par le rasoir d'Occam bayesien."
+    "Comparativement au modele lineaire, ce graphe contient un parametre supplementaire (`c_quad`), ce qui augmente la complexite du modele et la \"surface\" du prior - d'ou la penalisation par le rasoir d'Occam bayesien."
    ]
   },
   {
@@ -12767,15 +12767,15 @@
     "\n",
     "**Facteur de Bayes** : $\\exp(-14.03 - (-20.28)) = \\exp(6.25) \\approx 518$\n",
     "\n",
-    "Le modèle lineaire est **decisement** prefere (BF > 150).\n",
+    "Le modele lineaire est **decisement** prefere (BF > 150).\n",
     "\n",
-    "**Pourquoi le modèle quadratique perd-il ?**\n",
+    "**Pourquoi le modele quadratique perd-il ?**\n",
     "\n",
     "1. **Donnees generees lineairement** : y = 2x + 1 + bruit\n",
     "2. **Coefficient quadratique inutile** : le parametre $a$ (coefficient de $x^2$) n'apporte rien\n",
     "3. **Penalite de complexite** : le prior sur $a$ \"dilue\" la vraisemblance\n",
     "\n",
-    "> **Exercice supplementaire** : Que se passerait-il si les données etaient generees par y = 0.1*x^2 + 2*x + 1 ? Le terme quadratique est present mais faible. Le modèle lineaire pourrait encore gagner si le signal quadratique est noye dans le bruit - c'est la balance ajustement vs complexite en action."
+    "> **Exercice supplementaire** : Que se passerait-il si les donnees etaient generees par y = 0.1*x^2 + 2*x + 1 ? Le terme quadratique est present mais faible. Le modele lineaire pourrait encore gagner si le signal quadratique est noye dans le bruit - c'est la balance ajustement vs complexite en action."
    ]
   },
   {
@@ -12797,14 +12797,14 @@
     "| Concept | Description |\n",
     "|---------|-------------|\n",
     "| **Evidence** | P(D\\|M) - vraisemblance marginale |\n",
-    "| **Facteur de Bayes** | Ratio d'evidences pour comparer modèles |\n",
-    "| **Rasoir d'Occam** | Preference automatique pour modèles simples |\n",
+    "| **Facteur de Bayes** | Ratio d'evidences pour comparer modeles |\n",
+    "| **Rasoir d'Occam** | Preference automatique pour modeles simples |\n",
     "| **ARD** | Selection automatique de features |\n",
-    "| **LOO-CV** | Validation sans diviser les données |\n",
+    "| **LOO-CV** | Validation sans diviser les donnees |\n",
     "\n",
     "---\n",
     "\n",
-    "## Prochaine étape\n",
+    "## Prochaine etape\n",
     "\n",
     "Dans [Infer-11-Topic-Models](Infer-11-Topic-Models.ipynb), nous explorerons :\n",
     "\n",
@@ -12844,8 +12844,8 @@
     "\n",
     "| Concept | Section | Application |\n",
     "|---------|---------|-------------|\n",
-    "| Evidence marginale $P(D\\|M)$ | 3, 5 | Comparer modèles sans validation croisee |\n",
-    "| Facteur de Bayes | 4 | Quantifier la preference pour un modèle |\n",
+    "| Evidence marginale $P(D\\|M)$ | 3, 5 | Comparer modeles sans validation croisee |\n",
+    "| Facteur de Bayes | 4 | Quantifier la preference pour un modele |\n",
     "| Rasoir d'Occam bayesien | 3-5 | Penalisation automatique de la complexite |\n",
     "| Priors hierarchiques | 6 | ARD pour selection de features |\n",
     "| Distribution predictive | 7 | LOO-CV bayesien |\n",
@@ -12876,13 +12876,13 @@
     "\n",
     "**1. Le rasoir d'Occam est automatique**\n",
     "\n",
-    "La selection de modèles bayesienne penalise naturellement la complexite. Pas besoin de criteres ad hoc comme l'AIC ou le BIC - l'evidence marginale fait le travail.\n",
+    "La selection de modeles bayesienne penalise naturellement la complexite. Pas besoin de criteres ad hoc comme l'AIC ou le BIC - l'evidence marginale fait le travail.\n",
     "\n",
     "**2. L'echelle compte**\n",
     "\n",
     "| Methode | Quand l'utiliser |\n",
     "|---------|------------------|\n",
-    "| Facteur de Bayes | Comparer 2-3 modèles distincts |\n",
+    "| Facteur de Bayes | Comparer 2-3 modeles distincts |\n",
     "| ARD | Selectionner parmi de nombreuses features |\n",
     "| LOO-CV | Evaluer la capacite predictive |\n",
     "\n",
@@ -12890,7 +12890,7 @@
     "\n",
     "Les priors vagues ($\\sigma^2 = 10$ sur les poids) penalisent moins que des priors informatifs. Un mauvais choix de prior peut fausser la comparaison.\n",
     "\n",
-    "> **Conseil pratique** : Pour une comparaison equitable, utilisez des priors de meme \"force\" (meme variance) sur les parametres comparables entre modèles."
+    "> **Conseil pratique** : Pour une comparaison equitable, utilisez des priors de meme \"force\" (meme variance) sur les parametres comparables entre modeles."
    ]
   },
   {
@@ -12911,19 +12911,19 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Vous disposez de données generees par `y = 2*x^2 - 3*x + 1 + bruit` :\n",
+    "Vous disposez de donnees generees par `y = 2*x^2 - 3*x + 1 + bruit` :\n",
     "\n",
     "```\n",
     "x = {-2, -1, 0, 1, 2, 3}\n",
     "y = {14.8, 5.9, 1.1, -0.2, 3.8, 10.1}\n",
     "```\n",
     "\n",
-    "Comparez 3 modèles de regression polynomiale :\n",
+    "Comparez 3 modeles de regression polynomiale :\n",
     "1. **Lineaire** : `y = a*x + b` (2 parametres)\n",
     "2. **Quadratique** : `y = a*x^2 + b*x + c` (3 parametres)\n",
     "3. **Cubique** : `y = a*x^3 + b*x^2 + c*x + d` (4 parametres)\n",
     "\n",
-    "Quel modèle a le meilleur log evidence ? Le cubique surpasse-t-il le quadratique ?"
+    "Quel modele a le meilleur log evidence ? Le cubique surpasse-t-il le quadratique ?"
    ]
   },
   {
@@ -12956,7 +12956,7 @@
     }
    ],
    "source": [
-    "// Exercice : Selection de modèle polynomial sur données quadratiques\n",
+    "// Exercice : Selection de modele polynomial sur donnees quadratiques\n",
     "Console.WriteLine(\"Exercice a completer : selection de modele polynomial\");\n",
     "\n",
     "// Donnees quadratiques : y = 2*x^2 - 3*x + 1 + bruit\n",
@@ -12972,10 +12972,10 @@
     "// TODO: Creer une fonction CalculLogEvidence(Vector[] features, double[] y)\n",
     "// (Reutilisez la structure de la section 8 de l'exemple guide)\n",
     "\n",
-    "// TODO: Calculer le log evidence pour chaque modèle\n",
+    "// TODO: Calculer le log evidence pour chaque modele\n",
     "\n",
     "// TODO: Afficher et comparer\n",
-    "// Quel modèle gagne ? Expliquez pourquoi le cubique ne bat pas forcement le quadratique."
+    "// Quel modele gagne ? Expliquez pourquoi le cubique ne bat pas forcement le quadratique."
    ]
   },
   {
@@ -12994,14 +12994,14 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a presente la selection de modèles bayesienne : evidence, facteur de Bayes, ARD et validation croisee LOO.\n",
+    "Ce notebook a presente la selection de modeles bayesienne : evidence, facteur de Bayes, ARD et validation croisee LOO.\n",
     "\n",
     "| Methode | Principe | Quand l'utiliser |\n",
     "|---------|----------|------------------|\n",
-    "| Evidence (marginal likelihood) | P(D\\|M) integre sur les parametres | Comparer 2-3 modèles |\n",
+    "| Evidence (marginal likelihood) | P(D\\|M) integre sur les parametres | Comparer 2-3 modeles |\n",
     "| Facteur de Bayes | Ratio des evidences, echelle de Jeffreys | Quantifier la preference |\n",
     "| ARD | Priors hierarchiques Gamma -> precision par feature | Selection automatique de features |\n",
-    "| LOO-CV | Log-probabilité predictive leave-one-out | Evaluer la capacite predictive |\n",
+    "| LOO-CV | Log-probabilite predictive leave-one-out | Evaluer la capacite predictive |\n",
     "\n",
     "| Distribution | Role |\n",
     "|--------------|------|\n",
@@ -13010,7 +13010,7 @@
     "| Gamma | Priors sur les precisions (bruit, ARD) |\n",
     "| Beta | Prior sur les proportions de melange |\n",
     "\n",
-    "> **Rasoir d'Occam bayesien** : L'evidence penalise automatiquement la complexite. Un modèle plus simple avec un bon ajustement bat toujours un modèle complexe dont les parametres supplementaires n'apportent rien. Cela rend la comparaison objective, sans criteres ad hoc."
+    "> **Rasoir d'Occam bayesien** : L'evidence penalise automatiquement la complexite. Un modele plus simple avec un bon ajustement bat toujours un modele complexe dont les parametres supplementaires n'apportent rien. Cela rend la comparaison objective, sans criteres ad hoc."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
@@ -14,9 +14,9 @@
     "tags": []
    },
    "source": [
-    "# Infer-10-Model-Selection : Selection et Comparaison de Modeles\n",
+    "# Infer-10-Model-Sélection : Sélection et Comparaison de Modèles\n",
     "\n",
-    "**Serie** : Programmation Probabiliste avec Infer.NET (10/20)  \n",
+    "**Série** : Programmation Probabiliste avec Infer.NET (10/20)  \n",
     "**Duree estimee** : 45 minutes  \n",
     "**Prerequis** : Infer-9-Classification\n",
     "\n",
@@ -25,8 +25,8 @@
     "## Objectifs\n",
     "\n",
     "- Comprendre le probleme du surapprentissage\n",
-    "- Calculer l'evidence du modele (marginal likelihood)\n",
-    "- Utiliser le facteur de Bayes pour comparer des modeles\n",
+    "- Calculer l'evidence du modèle (marginal likelihood)\n",
+    "- Utiliser le facteur de Bayes pour comparer des modèles\n",
     "- Implementer l'Automatic Relevance Determination (ARD)\n",
     "\n",
     "---\n",
@@ -56,7 +56,7 @@
    "source": [
     "## 1. Configuration\n",
     "\n",
-    "Nous preparons l'environnement pour explorer la selection de modeles bayesienne. Cette approche permet de comparer objectivement differents modeles en calculant leur evidence marginale, implementant ainsi le rasoir d'Occam de maniere mathematique."
+    "Nous preparons l'environnement pour explorer la selection de modèles bayesienne. Cette approche permet de comparer objectivement differents modèles en calculant leur evidence marginale, implementant ainsi le rasoir d'Occam de maniere mathematique."
    ]
   },
   {
@@ -308,7 +308,7 @@
    "source": [
     "### Visualisation des graphes de facteurs\n",
     "\n",
-    "Ce notebook utilise `FactorGraphHelper.cs` pour visualiser les graphes de facteurs generes par Infer.NET. Ces graphes montrent la structure probabiliste des modeles : les noeuds representent les variables aleatoires et les observations, les facteurs (carres) representent les distributions conditionnelles.\n",
+    "Ce notebook utilise `FactorGraphHelper.cs` pour visualiser les graphes de facteurs generes par Infer.NET. Ces graphes montrent la structure probabiliste des modèles : les noeuds representent les variables aleatoires et les observations, les facteurs (carres) representent les distributions conditionnelles.\n",
     "\n",
     "Pour activer la visualisation, on configure `ShowFactorGraph = true` sur le moteur d'inference."
    ]
@@ -329,18 +329,18 @@
    "source": [
     "**Note technique : Calcul de l'evidence dans Infer.NET**\n",
     "\n",
-    "Infer.NET calcule l'evidence du modele via une astuce elegante :\n",
+    "Infer.NET calcule l'evidence du modèle via une astuce elegante :\n",
     "\n",
     "1. On introduit une variable indicatrice `evidence = Bernoulli(0.5)`\n",
-    "2. Le modele est conditionne par `Variable.If(evidence)`\n",
+    "2. Le modèle est conditionne par `Variable.If(evidence)`\n",
     "3. Apres inference, `evidence.LogOdds` donne le log de l'evidence\n",
     "\n",
-    "> **Pourquoi ca fonctionne ?** Par le theoreme de Bayes :\n",
+    "> **Pourquoi ca fonctionne ?** Par le théorème de Bayes :\n",
     "> $$P(\\text{evidence}=\\text{true}|D) \\propto P(D|\\text{evidence}=\\text{true}) \\times P(\\text{evidence}=\\text{true})$$\n",
     "> \n",
     "> Comme $P(\\text{evidence}=\\text{true}) = 0.5$, le log-odds posterieur est directement le log de l'evidence (a une constante pres).\n",
     "\n",
-    "Cette methode est specifique a Infer.NET et permet d'obtenir l'evidence sans calcul integral explicite."
+    "Cette méthode est specifique a Infer.NET et permet d'obtenir l'evidence sans calcul integral explicite."
    ]
   },
   {
@@ -361,7 +361,7 @@
     "\n",
     "### Observation\n",
     "\n",
-    "Un modele complexe peut parfaitement ajuster les donnees d'entrainement mais mal generaliser.\n",
+    "Un modèle complexe peut parfaitement ajuster les données d'entrainement mais mal generaliser.\n",
     "\n",
     "### Exemple\n",
     "\n",
@@ -369,8 +369,8 @@
     "\n",
     "### Solution bayesienne\n",
     "\n",
-    "- Les priors penalisent les modeles complexes\n",
-    "- L'evidence du modele equilibre ajustement et complexite\n",
+    "- Les priors penalisent les modèles complexes\n",
+    "- L'evidence du modèle equilibre ajustement et complexite\n",
     "- C'est le **rasoir d'Occam bayesien**"
    ]
   },
@@ -388,18 +388,18 @@
     "tags": []
    },
    "source": [
-    "## 3. Evidence du Modele (Marginal Likelihood)\n",
+    "## 3. Evidence du Modèle (Marginal Likelihood)\n",
     "\n",
-    "### Definition\n",
+    "### Définition\n",
     "\n",
     "$$P(D|M) = \\int P(D|\\theta, M) P(\\theta|M) d\\theta$$\n",
     "\n",
-    "L'evidence est la probabilite des donnees sous le modele, marginalisee sur les parametres.\n",
+    "L'evidence est la probabilité des données sous le modèle, marginalisee sur les parametres.\n",
     "\n",
     "### Interpretation\n",
     "\n",
-    "- Un modele simple fait des predictions moins precises mais moins dispersees\n",
-    "- Un modele complexe fait des predictions plus precises mais plus dispersees\n",
+    "- Un modèle simple fait des predictions moins precises mais moins dispersees\n",
+    "- Un modèle complexe fait des predictions plus precises mais plus dispersees\n",
     "- L'evidence favorise le bon equilibre"
    ]
   },
@@ -830,7 +830,7 @@
    "source": [
     "// Calcul de l'evidence avec Infer.NET\n",
     "\n",
-    "// Donnees\n",
+    "// Données\n",
     "double[] observations = { 13, 15, 17, 14, 16, 15, 18 };\n",
     "int n = observations.Length;\n",
     "\n",
@@ -873,13 +873,13 @@
     "tags": []
    },
    "source": [
-    "### Lecture du resultat\n",
+    "### Lecture du résultat\n",
     "\n",
-    "**Log evidence = -16.98** pour le modele a une gaussienne.\n",
+    "**Log evidence = -16.98** pour le modèle a une gaussienne.\n",
     "\n",
-    "Cette valeur negative est normale : c'est un logarithme de probabilite, donc toujours negatif (ou nul). Plus la valeur est proche de 0, meilleure est l'evidence.\n",
+    "Cette valeur negative est normale : c'est un logarithme de probabilité, donc toujours negatif (ou nul). Plus la valeur est proche de 0, meilleure est l'evidence.\n",
     "\n",
-    "En termes absolus, $e^{-16.98} \\approx 4.2 \\times 10^{-8}$ semble tres petit, mais c'est la **comparaison relative** entre modeles qui importe, pas la valeur absolue."
+    "En termes absolus, $e^{-16.98} \\approx 4.2 \\times 10^{-8}$ semble tres petit, mais c'est la **comparaison relative** entre modèles qui importe, pas la valeur absolue."
    ]
   },
   {
@@ -1288,7 +1288,7 @@
     }
    ],
    "source": [
-    "// Visualisation du graphe de facteurs - Modele 1 gaussienne\n",
+    "// Visualisation du graphe de facteurs - Modèle 1 gaussienne\n",
     "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
    ]
   },
@@ -1306,15 +1306,15 @@
     "tags": []
    },
    "source": [
-    "### Lecture du graphe de facteurs - Modele 1 gaussienne\n",
+    "### Lecture du graphe de facteurs - Modèle 1 gaussienne\n",
     "\n",
-    "Le graphe montre la structure du modele a une gaussienne :\n",
+    "Le graphe montre la structure du modèle a une gaussienne :\n",
     "\n",
     "- **Noeuds ovales** : variables aleatoires (`moyenne`, `precision`, `evidence1`)\n",
     "- **Noeuds carres** : facteurs (distributions conditionnelles)\n",
     "- **Noeuds gris** : observations (`obs_0` a `obs_6`)\n",
     "\n",
-    "La variable `evidence1` (Bernoulli) englobe tout le modele via `Variable.If()`. Les 7 observations partagent la meme `moyenne` et `precision`, ce qui represente l'hypothese i.i.d. (independantes et identiquement distribuees)."
+    "La variable `evidence1` (Bernoulli) englobe tout le modèle via `Variable.If()`. Les 7 observations partagent la meme `moyenne` et `precision`, ce qui represente l'hypothese i.i.d. (independantes et identiquement distribuees)."
    ]
   },
   {
@@ -1331,14 +1331,14 @@
     "tags": []
    },
    "source": [
-    "### Implementation : Modele 2 - Melange de deux gaussiennes\n",
+    "### Implementation : Modèle 2 - Melange de deux gaussiennes\n",
     "\n",
-    "Le **modele de melange** (mixture model) suppose que chaque observation provient de l'une ou l'autre de deux gaussiennes, avec une probabilite $\\pi$ pour la premiere et $1-\\pi$ pour la seconde.\n",
+    "Le **modèle de melange** (mixture model) suppose que chaque observation provient de l'une ou l'autre de deux gaussiennes, avec une probabilité $\\pi$ pour la première et $1-\\pi$ pour la seconde.\n",
     "\n",
-    "**Parametres du modele** :\n",
+    "**Parametres du modèle** :\n",
     "- $\\mu_1, \\mu_2$ : moyennes des deux composantes\n",
     "- $\\tau$ : precision commune (simplification)\n",
-    "- $\\pi$ : proportion du melange (poids de la premiere composante)\n",
+    "- $\\pi$ : proportion du melange (poids de la première composante)\n",
     "\n",
     "**Code** : Pour chaque observation, on tire d'abord `composante ~ Bernoulli(pi)`, puis on observe depuis la gaussienne correspondante.\n",
     "\n",
@@ -1811,7 +1811,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modele de melange de gaussiennes."
+    "Visualisation du graphe de facteurs du modèle de melange de gaussiennes."
    ]
   },
   {
@@ -2701,7 +2701,7 @@
     }
    ],
    "source": [
-    "// Visualisation du graphe de facteurs - Modele melange\n",
+    "// Visualisation du graphe de facteurs - Modèle melange\n",
     "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
    ]
   },
@@ -2719,9 +2719,9 @@
     "tags": []
    },
    "source": [
-    "### Lecture du graphe de facteurs - Modele melange\n",
+    "### Lecture du graphe de facteurs - Modèle melange\n",
     "\n",
-    "Le graphe du modele de melange est plus complexe :\n",
+    "Le graphe du modèle de melange est plus complexe :\n",
     "\n",
     "- **moyenne_a, moyenne_b** : les deux centres des composantes gaussiennes\n",
     "- **poids_mixte** : parametre Beta controlant la proportion du melange\n",
@@ -2747,7 +2747,7 @@
    "source": [
     "## 4. Facteur de Bayes\n",
     "\n",
-    "### Definition\n",
+    "### Définition\n",
     "\n",
     "$$BF_{12} = \\frac{P(D|M_1)}{P(D|M_2)} = \\exp(\\log E_1 - \\log E_2)$$\n",
     "\n",
@@ -2888,11 +2888,11 @@
     "tags": []
    },
    "source": [
-    "## 5. Selection du Nombre de Composantes\n",
+    "## 5. Sélection du Nombre de Composantes\n",
     "\n",
     "### Application\n",
     "\n",
-    "Determiner le nombre optimal de composantes dans un modele de melange."
+    "Determiner le nombre optimal de composantes dans un modèle de melange."
    ]
   },
   {
@@ -2909,13 +2909,13 @@
     "tags": []
    },
    "source": [
-    "### Donnees bimodales : quand le modele complexe gagne\n",
+    "### Données bimodales : quand le modèle complexe gagne\n",
     "\n",
-    "Les donnees precedentes etaient unimodales (autour de 15). Testons maintenant avec des donnees **clairement bimodales** : deux groupes bien separes autour de 6 et 15.\n",
+    "Les données precedentes etaient unimodales (autour de 15). Testons maintenant avec des données **clairement bimodales** : deux groupes bien separes autour de 6 et 15.\n",
     "\n",
-    "**Question** : Le modele a 2 composantes va-t-il maintenant etre prefere ?\n",
+    "**Question** : Le modèle a 2 composantes va-t-il maintenant etre prefere ?\n",
     "\n",
-    "L'algorithme compare systematiquement 1 vs 2 composantes en calculant l'evidence de chaque modele."
+    "L'algorithme compare systematiquement 1 vs 2 composantes en calculant l'evidence de chaque modèle."
    ]
   },
   {
@@ -3743,7 +3743,7 @@
     }
    ],
    "source": [
-    "// Donnees bimodales\n",
+    "// Données bimodales\n",
     "double[] dataBimodal = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "int nBi = dataBimodal.Length;\n",
     "\n",
@@ -3799,7 +3799,7 @@
     "\n",
     "Console.WriteLine($\"2 composantes : log evidence = {logEvidences[1]:F2}\");\n",
     "\n",
-    "// Meilleur modele\n",
+    "// Meilleur modèle\n",
     "int meilleur = logEvidences[0] > logEvidences[1] ? 1 : 2;\n",
     "Console.WriteLine($\"\\n=> Le modele a {meilleur} composante(s) est prefere\");"
    ]
@@ -3818,20 +3818,20 @@
     "tags": []
    },
    "source": [
-    "### Analyse des resultats : donnees bimodales\n",
+    "### Analyse des résultats : données bimodales\n",
     "\n",
-    "**Donnees** : deux groupes distincts autour de 6 et 15\n",
+    "**Données** : deux groupes distincts autour de 6 et 15\n",
     "\n",
-    "| Modele | Log evidence | Interpretation |\n",
+    "| Modèle | Log evidence | Interpretation |\n",
     "|--------|--------------|----------------|\n",
     "| 1 composante | -45.89 | Mal adapte (moyenne ~10.5 ne represente aucun groupe) |\n",
     "| 2 composantes | -31.35 | Bien adapte (capture les deux modes) |\n",
     "\n",
     "**Difference** : log(BF) = -31.35 - (-45.89) = 14.54\n",
     "\n",
-    "Un facteur de Bayes $e^{14.54} \\approx 2 \\times 10^6$ en faveur du modele a 2 composantes constitue une evidence **decisive**.\n",
+    "Un facteur de Bayes $e^{14.54} \\approx 2 \\times 10^6$ en faveur du modèle a 2 composantes constitue une evidence **decisive**.\n",
     "\n",
-    "> **Lecon cle** : Le facteur de Bayes detecte automatiquement la structure des donnees. Il prefere le modele simple quand les donnees sont simples (section 3-4) et le modele complexe quand les donnees l'exigent (ici)."
+    "> **Lecon cle** : Le facteur de Bayes detecte automatiquement la structure des données. Il prefere le modèle simple quand les données sont simples (section 3-4) et le modèle complexe quand les données l'exigent (ici)."
    ]
   },
   {
@@ -3854,7 +3854,7 @@
     "\n",
     "ARD utilise des priors hierarchiques pour determiner automatiquement quelles features sont pertinentes.\n",
     "\n",
-    "### Modele\n",
+    "### Modèle\n",
     "\n",
     "$$\\alpha_f \\sim \\text{Gamma}(a, b)$$\n",
     "$$w_f \\sim \\mathcal{N}(0, \\alpha_f^{-1})$$\n",
@@ -3876,11 +3876,11 @@
     "tags": []
    },
    "source": [
-    "### Transition : de la comparaison de modeles a la selection de features\n",
+    "### Transition : de la comparaison de modèles a la selection de features\n",
     "\n",
-    "Jusqu'ici, nous avons compare des **modeles entiers** (1 vs 2 gaussiennes, lineaire vs quadratique). Mais en pratique, on veut souvent repondre a une question plus fine :\n",
+    "Jusqu'ici, nous avons compare des **modèles entiers** (1 vs 2 gaussiennes, lineaire vs quadratique). Mais en pratique, on veut souvent repondre a une question plus fine :\n",
     "\n",
-    "**Quelles features sont vraiment utiles dans mon modele ?**\n",
+    "**Quelles features sont vraiment utiles dans mon modèle ?**\n",
     "\n",
     "C'est le probleme de la **selection de variables**. L'approche bayesienne offre une solution elegante : l'**Automatic Relevance Determination** (ARD)."
    ]
@@ -3899,14 +3899,14 @@
     "tags": []
    },
    "source": [
-    "### Generation des donnees synthetiques\n",
+    "### Generation des données synthetiques\n",
     "\n",
     "Nous creons un probleme de regression ou :\n",
     "- **Feature 1** : coefficient reel = 2.0 (pertinente)\n",
     "- **Feature 2** : coefficient reel = 0.0 (non pertinente)\n",
     "- **Feature 3** : coefficient reel = 3.0 (pertinente)\n",
     "\n",
-    "Le modele ARD devra \"decouvrir\" automatiquement que la feature 2 n'apporte aucune information predictive."
+    "Le modèle ARD devra \"decouvrir\" automatiquement que la feature 2 n'apporte aucune information predictive."
    ]
   },
   {
@@ -3958,7 +3958,7 @@
    "source": [
     "// ARD pour regression\n",
     "\n",
-    "// Donnees : y = 2*x1 + 0*x2 + 3*x3 + bruit\n",
+    "// Données : y = 2*x1 + 0*x2 + 3*x3 + bruit\n",
     "// x2 est une feature non pertinente\n",
     "int nSamples = 20;\n",
     "int nFeatures = 3;\n",
@@ -3996,9 +3996,9 @@
     "tags": []
    },
    "source": [
-    "### Construction du modele ARD hierarchique\n",
+    "### Construction du modèle ARD hierarchique\n",
     "\n",
-    "Le modele ARD introduit un **hyperparametre de precision** $\\alpha_f$ pour chaque feature $f$ :\n",
+    "Le modèle ARD introduit un **hyperparametre de precision** $\\alpha_f$ pour chaque feature $f$ :\n",
     "\n",
     "$$w_f \\sim \\mathcal{N}(0, \\alpha_f^{-1})$$\n",
     "\n",
@@ -4456,7 +4456,7 @@
     }
    ],
    "source": [
-    "// Modele ARD\n",
+    "// Modèle ARD\n",
     "Range sampleRange = new Range(nSamples).Named(\"sample\");\n",
     "Range featureRange = new Range(nFeatures).Named(\"feature\");\n",
     "\n",
@@ -4474,7 +4474,7 @@
     "// Bruit de l'observation\n",
     "Variable<double> noisePrecision = Variable.GammaFromShapeAndScale(2, 1).Named(\"noise\");\n",
     "\n",
-    "// Donnees\n",
+    "// Données\n",
     "VariableArray2D<double> xVar = Variable.Array<double>(sampleRange, featureRange).Named(\"x\");\n",
     "VariableArray<double> yVar = Variable.Array<double>(sampleRange).Named(\"y\");\n",
     "\n",
@@ -4525,7 +4525,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modele ARD."
+    "Visualisation du graphe de facteurs du modèle ARD."
    ]
   },
   {
@@ -4998,7 +4998,7 @@
     }
    ],
    "source": [
-    "// Visualisation du graphe de facteurs - Modele ARD\n",
+    "// Visualisation du graphe de facteurs - Modèle ARD\n",
     "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
    ]
   },
@@ -5016,7 +5016,7 @@
     "tags": []
    },
    "source": [
-    "### Lecture du graphe de facteurs - Modele ARD hierarchique\n",
+    "### Lecture du graphe de facteurs - Modèle ARD hierarchique\n",
     "\n",
     "Le graphe ARD illustre la structure hierarchique a deux niveaux :\n",
     "\n",
@@ -5028,7 +5028,7 @@
     "- **poids[feature]** : poids de regression, chacun avec une precision `alpha[f]` differente\n",
     "- Les poids sont couples : `poids[f] ~ N(0, 1/alpha[f])`\n",
     "\n",
-    "**Niveau donnees** :\n",
+    "**Niveau données** :\n",
     "- **x[sample, feature]** : matrice des features (observee)\n",
     "- **y[sample]** : cible (observee)\n",
     "- **noise** : precision du bruit (infere)\n",
@@ -5091,20 +5091,20 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "On genere des donnees synthetiques selon :\n",
+    "On genere des données synthetiques selon :\n",
     "\n",
     "$$y = 1.5 \\cdot x_1 + 0 \\cdot x_2 + 0 \\cdot x_3 + 2.5 \\cdot x_4 + 0 \\cdot x_5 + \\epsilon$$\n",
     "\n",
     "Seules les features 1 et 4 contribuent a la prediction. Les features 2, 3 et 5 sont du bruit.\n",
     "\n",
     "**Travail demande** :\n",
-    "1. Generez les donnees avec `nSamples = 30` et `nFeatures = 5` (seed 42)\n",
-    "2. Construisez le modele ARD hierarchique (reutilisez la structure de la section 6)\n",
+    "1. Generez les données avec `nSamples = 30` et `nFeatures = 5` (seed 42)\n",
+    "2. Construisez le modèle ARD hierarchique (reutilisez la structure de la section 6)\n",
     "3. Lancez l'inference et affichez les poids posterieurs et les valeurs alpha pour chaque feature\n",
     "4. Identifiez quelles features sont selectionnees (alpha faible = pertinente)\n",
     "5. Comparez les poids estimes avec les vrais poids : {1.5, 0.0, 0.0, 2.5, 0.0}\n",
     "\n",
-    "> **Indice** : Avec plus de features (5 vs 3) et plus de donnees (30 vs 20), les alpha des features non pertinentes devraient etre plus eleves qu'avec 3 features, car le modele a plus d'information pour distinguer le signal du bruit. Utilisez le meme prior `Gamma(1, 1)` sur les alpha et `ExpectationPropagation` pour l'inference."
+    "> **Indice** : Avec plus de features (5 vs 3) et plus de données (30 vs 20), les alpha des features non pertinentes devraient etre plus eleves qu'avec 3 features, car le modèle a plus d'information pour distinguer le signal du bruit. Utilisez le meme prior `Gamma(1, 1)` sur les alpha et `ExpectationPropagation` pour l'inference."
    ]
   },
   {
@@ -5139,14 +5139,14 @@
    "source": [
     "// Exercice : ARD avec 5 features\n",
     "\n",
-    "// TODO: Etape 1 - Generer les donnees synthetiques\n",
+    "// TODO: Étape 1 - Generer les données synthetiques\n",
     "int nSamplesARD = 30;\n",
     "int nFeaturesARD = 5;\n",
     "double[] vraisPoidsARD = { 1.5, 0.0, 0.0, 2.5, 0.0 };\n",
     "double[,] XARD = new double[nSamplesARD, nFeaturesARD];  // TODO: remplir avec Random(42)\n",
     "double[] yARD = new double[nSamplesARD];                  // TODO: calculer y = sum(w_f * x_f) + bruit\n",
     "\n",
-    "// TODO: Etape 2 - Construire le modele ARD hierarchique\n",
+    "// TODO: Étape 2 - Construire le modèle ARD hierarchique\n",
     "// Range sampleRangeARD = new Range(nSamplesARD);\n",
     "// Range featureRangeARD = new Range(nFeaturesARD);\n",
     "// VariableArray<double> alphaARD = ...  (Gamma prior par feature)\n",
@@ -5154,13 +5154,13 @@
     "// Variable<double> noiseARD = ...      (Gamma prior sur bruit)\n",
     "// Relation: y = sum(poids[f] * x[f])\n",
     "\n",
-    "// TODO: Etape 3 - Inference avec ExpectationPropagation\n",
+    "// TODO: Étape 3 - Inference avec ExpectationPropagation\n",
     "\n",
-    "// TODO: Etape 4 - Afficher les resultats\n",
-    "// Console.WriteLine(\"=== Resultats ARD (5 features) ===\");\n",
+    "// TODO: Étape 4 - Afficher les résultats\n",
+    "// Console.WriteLine(\"=== Résultats ARD (5 features) ===\");\n",
     "// Pour chaque feature : afficher poids moyen, ecart-type, alpha, pertinence\n",
     "\n",
-    "// TODO: Etape 5 - Comparer avec les vrais poids et conclure\n",
+    "// TODO: Étape 5 - Comparer avec les vrais poids et conclure\n",
     "// Quelles features ont ete correctement identifiees comme pertinentes/non pertinentes ?\n",
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
@@ -5184,7 +5184,7 @@
     "\n",
     "### Principe\n",
     "\n",
-    "Au lieu de diviser les donnees, utiliser la predictive posterieure pour evaluer le modele.\n",
+    "Au lieu de diviser les données, utiliser la predictive posterieure pour evaluer le modèle.\n",
     "\n",
     "### Leave-One-Out (LOO)\n",
     "\n",
@@ -5208,9 +5208,9 @@
     "### Algorithme Leave-One-Out bayesien\n",
     "\n",
     "Pour chaque point $i$ :\n",
-    "1. **Entrainer** le modele sur tous les points sauf $i$\n",
+    "1. **Entrainer** le modèle sur tous les points sauf $i$\n",
     "2. **Calculer** la distribution predictive posterieure\n",
-    "3. **Evaluer** la log-probabilite du point $i$ sous cette predictive\n",
+    "3. **Evaluer** la log-probabilité du point $i$ sous cette predictive\n",
     "\n",
     "La **variance predictive** combine deux sources d'incertitude :\n",
     "- L'incertitude sur la moyenne ($\\text{Var}(\\mu)$)\n",
@@ -9062,7 +9062,7 @@
     "\n",
     "for (int i = 0; i < nLOO; i++)\n",
     "{\n",
-    "    // Entrainer sur toutes les donnees sauf i\n",
+    "    // Entrainer sur toutes les données sauf i\n",
     "    Variable<double> mu = Variable.GaussianFromMeanAndPrecision(10, 0.01);\n",
     "    Variable<double> prec = Variable.GammaFromShapeAndScale(2, 0.5);\n",
     "    \n",
@@ -9081,7 +9081,7 @@
     "    Gaussian muPost = eng.Infer<Gaussian>(mu);\n",
     "    Gamma precPost = eng.Infer<Gamma>(prec);\n",
     "    \n",
-    "    // Probabilite predictive pour le point i\n",
+    "    // Probabilité predictive pour le point i\n",
     "    double predMean = muPost.GetMean();\n",
     "    double predVar = muPost.GetVariance() + 1.0 / precPost.GetMean();\n",
     "    \n",
@@ -9112,9 +9112,9 @@
     "\n",
     "**Log predictive moyenne = -1.81**\n",
     "\n",
-    "Cette metrique mesure la capacite du modele a predire des observations non vues. Comparons avec des references :\n",
+    "Cette metrique mesure la capacite du modèle a predire des observations non vues. Comparons avec des références :\n",
     "\n",
-    "| Log predictive moyenne | Qualite du modele |\n",
+    "| Log predictive moyenne | Qualite du modèle |\n",
     "|------------------------|-------------------|\n",
     "| > -1.0 | Excellente |\n",
     "| -1.0 a -2.0 | Bonne |\n",
@@ -9123,10 +9123,10 @@
     "\n",
     "Notre valeur de -1.81 indique une **bonne** capacite predictive.\n",
     "\n",
-    "> **Avantage du LOO bayesien** : Contrairement au LOO classique, cette methode :\n",
+    "> **Avantage du LOO bayesien** : Contrairement au LOO classique, cette méthode :\n",
     "> - Utilise l'incertitude complete (pas juste une estimation ponctuelle)\n",
     "> - Tient compte de l'incertitude sur les parametres via la variance predictive\n",
-    "> - Ne necessite pas de reentrainer completement le modele (en theorie, via des approximations)"
+    "> - Ne necessite pas de reentrainer completement le modèle (en theorie, via des approximations)"
    ]
   },
   {
@@ -9143,31 +9143,31 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Selection de modele par validation croisee LOO\n",
+    "## Exercice : Sélection de modèle par validation croisee LOO\n",
     "\n",
-    "Dans cette section, vous avez vu la validation Leave-One-Out pour un modele gaussien simple. L'objectif de cet exercice est d'**etendre cette approche pour comparer deux modeles** sur les memes donnees, et de verifier si le resultat LOO est coherent avec le facteur de Bayes.\n",
+    "Dans cette section, vous avez vu la validation Leave-One-Out pour un modèle gaussien simple. L'objectif de cet exercice est d'**etendre cette approche pour comparer deux modèles** sur les memes données, et de verifier si le résultat LOO est coherent avec le facteur de Bayes.\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "On considere les donnees bimodales de la section 5 :\n",
+    "On considere les données bimodales de la section 5 :\n",
     "\n",
     "```csharp\n",
     "double[] dataEx = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "```\n",
     "\n",
-    "**Modele A** : Une seule gaussienne $y \\sim \\mathcal{N}(\\mu, \\tau^{-1})$ avec priors :\n",
+    "**Modèle A** : Une seule gaussienne $y \\sim \\mathcal{N}(\\mu, \\tau^{-1})$ avec priors :\n",
     "- $\\mu \\sim \\mathcal{N}(10, 100)$ (moyenne vague)\n",
     "- $\\tau \\sim \\text{Gamma}(2, 0.5)$\n",
     "\n",
-    "**Modele B** : Melange de deux gaussiennes (meme structure que la section 5).\n",
+    "**Modèle B** : Melange de deux gaussiennes (meme structure que la section 5).\n",
     "\n",
     "**Travail demandé** :\n",
-    "1. Implementez la validation LOO pour le **Modele A** (une gaussienne)\n",
-    "2. Implementez la validation LOO pour le **Modele B** (melange de deux gaussiennes) - utilisez `VariationalMessagePassing`\n",
-    "3. Comparez les scores LOO totaux : quel modele est prefere ?\n",
-    "4. Comparez avec le resultat du facteur de Bayes de la section 5 : les deux methodes donnent-elles le meme gagnant ?\n",
+    "1. Implementez la validation LOO pour le **Modèle A** (une gaussienne)\n",
+    "2. Implementez la validation LOO pour le **Modèle B** (melange de deux gaussiennes) - utilisez `VariationalMessagePassing`\n",
+    "3. Comparez les scores LOO totaux : quel modèle est prefere ?\n",
+    "4. Comparez avec le résultat du facteur de Bayes de la section 5 : les deux méthodes donnent-elles le meme gagnant ?\n",
     "\n",
-    "> **Indice** : Pour le Modele B dans la boucle LOO, vous devez recreer le modele de melange complet a chaque iteration (en retirant le point i). La distribution predictive posterieure d'un melange n'est pas gaussienne -- utilisez `GetMean()` et `GetVariance()` sur le resultat `Gaussian` inferé pour chaque point laisse de cote."
+    "> **Indice** : Pour le Modèle B dans la boucle LOO, vous devez recreer le modèle de melange complet a chaque iteration (en retirant le point i). La distribution predictive posterieure d'un melange n'est pas gaussienne -- utilisez `GetMean()` et `GetVariance()` sur le résultat `Gaussian` inferé pour chaque point laisse de cote."
    ]
   },
   {
@@ -9222,32 +9222,32 @@
     }
    ],
    "source": [
-    "// Exercice : Selection de modele par validation croisee LOO\n",
+    "// Exercice : Sélection de modèle par validation croisee LOO\n",
     "\n",
     "double[] dataEx = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "int nEx = dataEx.Length;\n",
     "\n",
-    "// TODO: Etape 1 - Implementer LOO pour le Modele A (1 gaussienne)\n",
+    "// TODO: Étape 1 - Implementer LOO pour le Modèle A (1 gaussienne)\n",
     "// Pour chaque point i, entrainer sur dataEx sans le point i, calculer log P(dataEx[i])\n",
     "double totalLogPredA = 0;\n",
     "\n",
-    "// TODO: Boucle LOO Modele A\n",
+    "// TODO: Boucle LOO Modèle A\n",
     "\n",
     "Console.WriteLine($\"Modele A - LOO total : {totalLogPredA:F2}\");\n",
     "\n",
-    "// TODO: Etape 2 - Implementer LOO pour le Modele B (melange 2 gaussiennes)\n",
+    "// TODO: Étape 2 - Implementer LOO pour le Modèle B (melange 2 gaussiennes)\n",
     "// Utilisez VariationalMessagePassing pour la stabilite\n",
     "double totalLogPredB = 0;\n",
     "\n",
-    "// TODO: Boucle LOO Modele B\n",
+    "// TODO: Boucle LOO Modèle B\n",
     "// Indice : pour chaque iteration, recreer le melange complet sans le point i\n",
-    "// puis inferer la posteriorie et evaluer la log-probabilite du point laisse de cote\n",
+    "// puis inferer la posteriorie et evaluer la log-probabilité du point laisse de cote\n",
     "\n",
     "Console.WriteLine($\"Modele B - LOO total : {totalLogPredB:F2}\");\n",
     "\n",
-    "// TODO: Etape 3 - Comparer les resultats\n",
+    "// TODO: Étape 3 - Comparer les résultats\n",
     "Console.WriteLine(\"\\n=== Comparaison LOO ===\");\n",
-    "// Quel modele est prefere par LOO ?\n",
+    "// Quel modèle est prefere par LOO ?\n",
     "// Est-ce coherent avec le facteur de Bayes de la section 5 (2 composantes preferees) ?\n",
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
@@ -9269,7 +9269,7 @@
    "source": [
     "## Exercice : Comparer les criteres BIC et evidence approximee\n",
     "\n",
-    "Dans les sections precedentes, nous avons utilise l'evidence exacte (marginal likelihood) calculee par Infer.NET pour comparer des modeles. En pratique, l'evidence exacte est souvent incalculable et on utilise des **approximations** comme le BIC (Bayesian Information Criterion).\n",
+    "Dans les sections precedentes, nous avons utilise l'evidence exacte (marginal likelihood) calculee par Infer.NET pour comparer des modèles. En pratique, l'evidence exacte est souvent incalculable et on utilise des **approximations** comme le BIC (Bayesian Information Criterion).\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -9277,20 +9277,20 @@
     "\n",
     "$$\\text{BIC} = -2 \\ln(\\hat{L}) + k \\ln(n)$$\n",
     "\n",
-    "ou $\\hat{L}$ est la vraisemblance maximale, $k$ le nombre de parametres et $n$ le nombre d'observations. Un BIC plus faible indique un meilleur modele.\n",
+    "ou $\\hat{L}$ est la vraisemblance maximale, $k$ le nombre de parametres et $n$ le nombre d'observations. Un BIC plus faible indique un meilleur modèle.\n",
     "\n",
-    "On reprend les donnees bimodales de la section 5 :\n",
+    "On reprend les données bimodales de la section 5 :\n",
     "```csharp\n",
     "double[] dataBIC = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "```\n",
     "\n",
     "**Travail demande** :\n",
-    "1. Pour le modele a 1 gaussienne, calculez le BIC en estimant mu et tau par maximum de vraisemblance (moyenne empirique et variance inverse)\n",
-    "2. Pour le modele a 2 gaussiennes, utilisez les posteriors Infer.NET de la section 5 comme approximation du MLE, puis calculez le BIC (k = 5 parametres : mu1, mu2, tau, poids, + 1 bruit)\n",
-    "3. Comparez les classements BIC vs facteur de Bayes : les deux methodes selectionnent-elles le meme modele ?\n",
-    "4. Affichez un tableau comparatif : `| Critere | Modele 1 | Modele 2 | Gagnant |`\n",
+    "1. Pour le modèle a 1 gaussienne, calculez le BIC en estimant mu et tau par maximum de vraisemblance (moyenne empirique et variance inverse)\n",
+    "2. Pour le modèle a 2 gaussiennes, utilisez les posteriors Infer.NET de la section 5 comme approximation du MLE, puis calculez le BIC (k = 5 parametres : mu1, mu2, tau, poids, + 1 bruit)\n",
+    "3. Comparez les classements BIC vs facteur de Bayes : les deux méthodes selectionnent-elles le meme modèle ?\n",
+    "4. Affichez un tableau comparatif : `| Critere | Modèle 1 | Modèle 2 | Gagnant |`\n",
     "\n",
-    "> **Indice** : Pour le BIC du modele a 1 gaussienne, $k=2$ (mu + tau). La log-vraisemblance se calcule en sommant `Gaussian.FromMeanAndPrecision(mu_hat, tau_hat).GetLogProb(dataBIC[i])` pour chaque point. Pour le modele a 2 gaussiennes, $k=5$ (mu1, mu2, tau, poids + variance commune). Le BIC penalise davantage les modeles complexes que le facteur de Bayes -- observez si la penalite change le gagnant."
+    "> **Indice** : Pour le BIC du modèle a 1 gaussienne, $k=2$ (mu + tau). La log-vraisemblance se calcule en sommant `Gaussian.FromMeanAndPrecision(mu_hat, tau_hat).GetLogProb(dataBIC[i])` pour chaque point. Pour le modèle a 2 gaussiennes, $k=5$ (mu1, mu2, tau, poids + variance commune). Le BIC penalise davantage les modèles complexes que le facteur de Bayes -- observez si la penalite change le gagnant."
    ]
   },
   {
@@ -9350,7 +9350,7 @@
     "double[] dataBIC = { 5, 6, 7, 5.5, 6.5, 15, 16, 17, 14, 15.5, 16.5, 6, 15 };\n",
     "int nBIC = dataBIC.Length;\n",
     "\n",
-    "// TODO: Etape 1 - Calculer le BIC pour le modele a 1 gaussienne (k=2)\n",
+    "// TODO: Étape 1 - Calculer le BIC pour le modèle a 1 gaussienne (k=2)\n",
     "// Estimer mu_hat = moyenne empirique, tau_hat = 1 / variance empirique\n",
     "// Puis BIC = -2 * sum(log P(x_i | mu_hat, tau_hat)) + k * ln(n)\n",
     "double bicModele1 = 0;\n",
@@ -9363,7 +9363,7 @@
     "\n",
     "Console.WriteLine($\"Modele 1 (1 gaussienne) - BIC : {bicModele1:F2}\");\n",
     "\n",
-    "// TODO: Etape 2 - Calculer le BIC pour le modele a 2 gaussiennes (k=5)\n",
+    "// TODO: Étape 2 - Calculer le BIC pour le modèle a 2 gaussiennes (k=5)\n",
     "// Utilisez les posteriors de la section 5 ou estimez par MLE\n",
     "double bicModele2 = 0;\n",
     "\n",
@@ -9373,17 +9373,17 @@
     "\n",
     "Console.WriteLine($\"Modele 2 (2 gaussiennes) - BIC : {bicModele2:F2}\");\n",
     "\n",
-    "// TODO: Etape 3 - Comparer BIC vs facteur de Bayes\n",
+    "// TODO: Étape 3 - Comparer BIC vs facteur de Bayes\n",
     "Console.WriteLine(\"\\n=== Comparaison BIC vs Facteur de Bayes ===\");\n",
-    "// Indice : Le facteur de Bayes de la section 5 favorisait le modele a 2 composantes (log BF ~ 14.5)\n",
-    "// Indice : Le BIC favorise-t-il le meme modele ? Si oui, les deux methodes sont coherentes.\n",
+    "// Indice : Le facteur de Bayes de la section 5 favorisait le modèle a 2 composantes (log BF ~ 14.5)\n",
+    "// Indice : Le BIC favorise-t-il le meme modèle ? Si oui, les deux méthodes sont coherentes.\n",
     "// Indice : Si non, expliquez pourquoi (taille d'echantillon, approximation BIC, etc.)\n",
     "\n",
-    "// TODO: Etape 4 - Afficher le tableau comparatif\n",
-    "// | Critere              | Modele 1 | Modele 2 | Gagnant    |\n",
+    "// TODO: Étape 4 - Afficher le tableau comparatif\n",
+    "// | Critere              | Modèle 1 | Modèle 2 | Gagnant    |\n",
     "// |----------------------|----------|----------|------------|\n",
     "// | BIC (plus petit=mieux)| ...     | ...      | ...        |\n",
-    "// | log Evidence          | -45.89  | -31.35   | Modele 2   |\n",
+    "// | log Evidence          | -45.89  | -31.35   | Modèle 2   |\n",
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
    ]
@@ -9406,12 +9406,12 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Comparez trois modeles de regression :\n",
+    "Comparez trois modèles de regression :\n",
     "- Lineaire : y = a*x + b\n",
     "- Quadratique : y = a*x^2 + b*x + c\n",
     "- Cubique : y = a*x^3 + b*x^2 + c*x + d\n",
     "\n",
-    "Sur des donnees lineaires avec bruit."
+    "Sur des données lineaires avec bruit."
    ]
   },
   {
@@ -9430,15 +9430,15 @@
    "source": [
     "### Mise en pratique : comparaison lineaire vs quadratique\n",
     "\n",
-    "Les donnees sont generees selon $y = 2x + 1 + \\epsilon$ (relation lineaire).\n",
+    "Les données sont generees selon $y = 2x + 1 + \\epsilon$ (relation lineaire).\n",
     "\n",
-    "**Modeles a comparer** :\n",
+    "**Modèles a comparer** :\n",
     "- **Lineaire** : $y = ax + b$ (2 parametres)\n",
     "- **Quadratique** : $y = ax^2 + bx + c$ (3 parametres)\n",
     "\n",
-    "Le modele quadratique peut representer la relation lineaire (avec $a \\approx 0$), mais paie un \"cout de complexite\" pour ce parametre inutile.\n",
+    "Le modèle quadratique peut representer la relation lineaire (avec $a \\approx 0$), mais paie un \"cout de complexite\" pour ce parametre inutile.\n",
     "\n",
-    "> **Hint** : Pour ajouter un modele cubique, il suffirait d'ajouter un terme $d \\times x^3$. Le meme raisonnement s'applique : plus de parametres = plus de penalite si ils ne sont pas necessaires."
+    "> **Hint** : Pour ajouter un modèle cubique, il suffirait d'ajouter un terme $d \\times x^3$. Le meme raisonnement s'applique : plus de parametres = plus de penalite si ils ne sont pas necessaires."
    ]
   },
   {
@@ -10266,9 +10266,9 @@
     }
    ],
    "source": [
-    "// Exemple guide : Comparaison de modeles polynomiaux\n",
+    "// Exemple guide : Comparaison de modèles polynomiaux\n",
     "\n",
-    "// Donnees lineaires : y = 2*x + 1 + bruit\n",
+    "// Données lineaires : y = 2*x + 1 + bruit\n",
     "double[] xPoly = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };\n",
     "double[] yPoly = { 1.2, 3.1, 4.8, 7.2, 8.9, 11.1, 13.0, 14.8, 17.2, 19.1 };\n",
     "int nPoly = xPoly.Length;\n",
@@ -10276,7 +10276,7 @@
     "Console.WriteLine(\"=== Comparaison de Modeles Polynomiaux ===\");\n",
     "Console.WriteLine(\"Vraie relation : y = 2*x + 1\\n\");\n",
     "\n",
-    "// Modele lineaire\n",
+    "// Modèle lineaire\n",
     "Variable<bool> evLin = Variable.Bernoulli(0.5).Named(\"evidence_lin\");\n",
     "using (Variable.If(evLin))\n",
     "{\n",
@@ -10297,7 +10297,7 @@
     "double logEvLin = engLin.Infer<Bernoulli>(evLin).LogOdds;\n",
     "Console.WriteLine($\"Modele lineaire : log evidence = {logEvLin:F2}\");\n",
     "\n",
-    "// Modele quadratique\n",
+    "// Modèle quadratique\n",
     "Variable<bool> evQuad = Variable.Bernoulli(0.5).Named(\"evidence_quad\");\n",
     "using (Variable.If(evQuad))\n",
     "{\n",
@@ -10319,7 +10319,7 @@
     "double logEvQuad = engQuad.Infer<Bernoulli>(evQuad).LogOdds;\n",
     "Console.WriteLine($\"Modele quadratique : log evidence = {logEvQuad:F2}\");\n",
     "\n",
-    "// Meilleur modele\n",
+    "// Meilleur modèle\n",
     "string meilleurMod = logEvLin > logEvQuad ? \"Lineaire\" : \"Quadratique\";\n",
     "Console.WriteLine($\"\\n=> Le modele {meilleurMod} est prefere (rasoir d'Occam)\");"
    ]
@@ -10338,7 +10338,7 @@
     "tags": []
    },
    "source": [
-    "Visualisation du graphe de facteurs du modele polynomial."
+    "Visualisation du graphe de facteurs du modèle polynomial."
    ]
   },
   {
@@ -12711,7 +12711,7 @@
     }
    ],
    "source": [
-    "// Visualisation du graphe de facteurs - Modele quadratique (dernier compile)\n",
+    "// Visualisation du graphe de facteurs - Modèle quadratique (dernier compile)\n",
     "display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()));"
    ]
   },
@@ -12729,9 +12729,9 @@
     "tags": []
    },
    "source": [
-    "### Lecture du graphe de facteurs - Modele quadratique\n",
+    "### Lecture du graphe de facteurs - Modèle quadratique\n",
     "\n",
-    "Le graphe montre la structure du modele quadratique $y = ax^2 + bx + c$ :\n",
+    "Le graphe montre la structure du modèle quadratique $y = ax^2 + bx + c$ :\n",
     "\n",
     "- **a_quad, b_quad, c_quad** : les trois coefficients du polynome (priors Gaussiens)\n",
     "- **noise_quad** : precision du bruit d'observation (prior Gamma)\n",
@@ -12739,7 +12739,7 @@
     "- **pred_quad_i** : predictions intermediaires (combinaison des coefficients)\n",
     "- **obs_quad_i** : observations (valeurs fixees)\n",
     "\n",
-    "Comparativement au modele lineaire, ce graphe contient un parametre supplementaire (`c_quad`), ce qui augmente la complexite du modele et la \"surface\" du prior - d'ou la penalisation par le rasoir d'Occam bayesien."
+    "Comparativement au modèle lineaire, ce graphe contient un parametre supplementaire (`c_quad`), ce qui augmente la complexite du modèle et la \"surface\" du prior - d'ou la penalisation par le rasoir d'Occam bayesien."
    ]
   },
   {
@@ -12758,24 +12758,24 @@
    "source": [
     "### Analyse de l'exercice polynomes\n",
     "\n",
-    "**Resultats** :\n",
+    "**Résultats** :\n",
     "\n",
-    "| Modele | Parametres | Log evidence |\n",
+    "| Modèle | Parametres | Log evidence |\n",
     "|--------|------------|--------------|\n",
     "| Lineaire | a, b (2) | -14.03 |\n",
     "| Quadratique | a, b, c (3) | -20.28 |\n",
     "\n",
     "**Facteur de Bayes** : $\\exp(-14.03 - (-20.28)) = \\exp(6.25) \\approx 518$\n",
     "\n",
-    "Le modele lineaire est **decisement** prefere (BF > 150).\n",
+    "Le modèle lineaire est **decisement** prefere (BF > 150).\n",
     "\n",
-    "**Pourquoi le modele quadratique perd-il ?**\n",
+    "**Pourquoi le modèle quadratique perd-il ?**\n",
     "\n",
-    "1. **Donnees generees lineairement** : y = 2x + 1 + bruit\n",
+    "1. **Données generees lineairement** : y = 2x + 1 + bruit\n",
     "2. **Coefficient quadratique inutile** : le parametre $a$ (coefficient de $x^2$) n'apporte rien\n",
     "3. **Penalite de complexite** : le prior sur $a$ \"dilue\" la vraisemblance\n",
     "\n",
-    "> **Exercice supplementaire** : Que se passerait-il si les donnees etaient generees par y = 0.1*x^2 + 2*x + 1 ? Le terme quadratique est present mais faible. Le modele lineaire pourrait encore gagner si le signal quadratique est noye dans le bruit - c'est la balance ajustement vs complexite en action."
+    "> **Exercice supplementaire** : Que se passerait-il si les données etaient generees par y = 0.1*x^2 + 2*x + 1 ? Le terme quadratique est present mais faible. Le modèle lineaire pourrait encore gagner si le signal quadratique est noye dans le bruit - c'est la balance ajustement vs complexite en action."
    ]
   },
   {
@@ -12797,14 +12797,14 @@
     "| Concept | Description |\n",
     "|---------|-------------|\n",
     "| **Evidence** | P(D\\|M) - vraisemblance marginale |\n",
-    "| **Facteur de Bayes** | Ratio d'evidences pour comparer modeles |\n",
-    "| **Rasoir d'Occam** | Preference automatique pour modeles simples |\n",
-    "| **ARD** | Selection automatique de features |\n",
-    "| **LOO-CV** | Validation sans diviser les donnees |\n",
+    "| **Facteur de Bayes** | Ratio d'evidences pour comparer modèles |\n",
+    "| **Rasoir d'Occam** | Preference automatique pour modèles simples |\n",
+    "| **ARD** | Sélection automatique de features |\n",
+    "| **LOO-CV** | Validation sans diviser les données |\n",
     "\n",
     "---\n",
     "\n",
-    "## Prochaine etape\n",
+    "## Prochaine étape\n",
     "\n",
     "Dans [Infer-11-Topic-Models](Infer-11-Topic-Models.ipynb), nous explorerons :\n",
     "\n",
@@ -12836,7 +12836,7 @@
     "| Distribution | Role | Parametres typiques |\n",
     "|--------------|------|---------------------|\n",
     "| `Bernoulli(0.5)` | Variable indicatrice pour calcul d'evidence | p=0.5 (prior non informatif) |\n",
-    "| `GaussianFromMeanAndPrecision` | Modele d'observation | mean~15, precision~1 |\n",
+    "| `GaussianFromMeanAndPrecision` | Modèle d'observation | mean~15, precision~1 |\n",
     "| `GammaFromShapeAndScale` | Prior sur precision | shape=2, scale=0.5 |\n",
     "| `Beta(1,1)` | Prior sur proportion de melange | Prior uniforme sur [0,1] |\n",
     "\n",
@@ -12844,16 +12844,16 @@
     "\n",
     "| Concept | Section | Application |\n",
     "|---------|---------|-------------|\n",
-    "| Evidence marginale $P(D\\|M)$ | 3, 5 | Comparer modeles sans validation croisee |\n",
-    "| Facteur de Bayes | 4 | Quantifier la preference pour un modele |\n",
+    "| Evidence marginale $P(D\\|M)$ | 3, 5 | Comparer modèles sans validation croisee |\n",
+    "| Facteur de Bayes | 4 | Quantifier la preference pour un modèle |\n",
     "| Rasoir d'Occam bayesien | 3-5 | Penalisation automatique de la complexite |\n",
     "| Priors hierarchiques | 6 | ARD pour selection de features |\n",
     "| Distribution predictive | 7 | LOO-CV bayesien |\n",
     "\n",
     "### Applications pratiques\n",
     "\n",
-    "- **Selection du nombre de composantes** : Clustering avec nombre de clusters inconnu\n",
-    "- **Selection de features** : Regression avec beaucoup de covariables\n",
+    "- **Sélection du nombre de composantes** : Clustering avec nombre de clusters inconnu\n",
+    "- **Sélection de features** : Regression avec beaucoup de covariables\n",
     "- **Choix d'architecture** : Reseaux bayesiens avec structure variable\n",
     "- **Comparaison de familles** : Lineaire vs non-lineaire, parametrique vs non-parametrique"
    ]
@@ -12876,13 +12876,13 @@
     "\n",
     "**1. Le rasoir d'Occam est automatique**\n",
     "\n",
-    "La selection de modeles bayesienne penalise naturellement la complexite. Pas besoin de criteres ad hoc comme l'AIC ou le BIC - l'evidence marginale fait le travail.\n",
+    "La selection de modèles bayesienne penalise naturellement la complexite. Pas besoin de criteres ad hoc comme l'AIC ou le BIC - l'evidence marginale fait le travail.\n",
     "\n",
     "**2. L'echelle compte**\n",
     "\n",
-    "| Methode | Quand l'utiliser |\n",
+    "| Méthode | Quand l'utiliser |\n",
     "|---------|------------------|\n",
-    "| Facteur de Bayes | Comparer 2-3 modeles distincts |\n",
+    "| Facteur de Bayes | Comparer 2-3 modèles distincts |\n",
     "| ARD | Selectionner parmi de nombreuses features |\n",
     "| LOO-CV | Evaluer la capacite predictive |\n",
     "\n",
@@ -12890,7 +12890,7 @@
     "\n",
     "Les priors vagues ($\\sigma^2 = 10$ sur les poids) penalisent moins que des priors informatifs. Un mauvais choix de prior peut fausser la comparaison.\n",
     "\n",
-    "> **Conseil pratique** : Pour une comparaison equitable, utilisez des priors de meme \"force\" (meme variance) sur les parametres comparables entre modeles."
+    "> **Conseil pratique** : Pour une comparaison equitable, utilisez des priors de meme \"force\" (meme variance) sur les parametres comparables entre modèles."
    ]
   },
   {
@@ -12907,23 +12907,23 @@
     "tags": []
    },
    "source": [
-    "## 10. Exercice : Trouver le Meilleur Modele pour des Donnees Quadratiques\n",
+    "## 10. Exercice : Trouver le Meilleur Modèle pour des Données Quadratiques\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "Vous disposez de donnees generees par `y = 2*x^2 - 3*x + 1 + bruit` :\n",
+    "Vous disposez de données generees par `y = 2*x^2 - 3*x + 1 + bruit` :\n",
     "\n",
     "```\n",
     "x = {-2, -1, 0, 1, 2, 3}\n",
     "y = {14.8, 5.9, 1.1, -0.2, 3.8, 10.1}\n",
     "```\n",
     "\n",
-    "Comparez 3 modeles de regression polynomiale :\n",
+    "Comparez 3 modèles de regression polynomiale :\n",
     "1. **Lineaire** : `y = a*x + b` (2 parametres)\n",
     "2. **Quadratique** : `y = a*x^2 + b*x + c` (3 parametres)\n",
     "3. **Cubique** : `y = a*x^3 + b*x^2 + c*x + d` (4 parametres)\n",
     "\n",
-    "Quel modele a le meilleur log evidence ? Le cubique surpasse-t-il le quadratique ?"
+    "Quel modèle a le meilleur log evidence ? Le cubique surpasse-t-il le quadratique ?"
    ]
   },
   {
@@ -12956,10 +12956,10 @@
     }
    ],
    "source": [
-    "// Exercice : Selection de modele polynomial sur donnees quadratiques\n",
+    "// Exercice : Sélection de modèle polynomial sur données quadratiques\n",
     "Console.WriteLine(\"Exercice a completer : selection de modele polynomial\");\n",
     "\n",
-    "// Donnees quadratiques : y = 2*x^2 - 3*x + 1 + bruit\n",
+    "// Données quadratiques : y = 2*x^2 - 3*x + 1 + bruit\n",
     "double[] xData = { -2, -1, 0, 1, 2, 3 };\n",
     "double[] yData = { 14.8, 5.9, 1.1, -0.2, 3.8, 10.1 };\n",
     "\n",
@@ -12972,10 +12972,10 @@
     "// TODO: Creer une fonction CalculLogEvidence(Vector[] features, double[] y)\n",
     "// (Reutilisez la structure de la section 8 de l'exemple guide)\n",
     "\n",
-    "// TODO: Calculer le log evidence pour chaque modele\n",
+    "// TODO: Calculer le log evidence pour chaque modèle\n",
     "\n",
     "// TODO: Afficher et comparer\n",
-    "// Quel modele gagne ? Expliquez pourquoi le cubique ne bat pas forcement le quadratique."
+    "// Quel modèle gagne ? Expliquez pourquoi le cubique ne bat pas forcement le quadratique."
    ]
   },
   {
@@ -12994,14 +12994,14 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a presente la selection de modeles bayesienne : evidence, facteur de Bayes, ARD et validation croisee LOO.\n",
+    "Ce notebook a presente la selection de modèles bayesienne : evidence, facteur de Bayes, ARD et validation croisee LOO.\n",
     "\n",
-    "| Methode | Principe | Quand l'utiliser |\n",
+    "| Méthode | Principe | Quand l'utiliser |\n",
     "|---------|----------|------------------|\n",
-    "| Evidence (marginal likelihood) | P(D\\|M) integre sur les parametres | Comparer 2-3 modeles |\n",
+    "| Evidence (marginal likelihood) | P(D\\|M) integre sur les parametres | Comparer 2-3 modèles |\n",
     "| Facteur de Bayes | Ratio des evidences, echelle de Jeffreys | Quantifier la preference |\n",
-    "| ARD | Priors hierarchiques Gamma -> precision par feature | Selection automatique de features |\n",
-    "| LOO-CV | Log-probabilite predictive leave-one-out | Evaluer la capacite predictive |\n",
+    "| ARD | Priors hierarchiques Gamma -> precision par feature | Sélection automatique de features |\n",
+    "| LOO-CV | Log-probabilité predictive leave-one-out | Evaluer la capacite predictive |\n",
     "\n",
     "| Distribution | Role |\n",
     "|--------------|------|\n",
@@ -13010,7 +13010,7 @@
     "| Gamma | Priors sur les precisions (bruit, ARD) |\n",
     "| Beta | Prior sur les proportions de melange |\n",
     "\n",
-    "> **Rasoir d'Occam bayesien** : L'evidence penalise automatiquement la complexite. Un modele plus simple avec un bon ajustement bat toujours un modele complexe dont les parametres supplementaires n'apportent rien. Cela rend la comparaison objective, sans criteres ad hoc."
+    "> **Rasoir d'Occam bayesien** : L'evidence penalise automatiquement la complexite. Un modèle plus simple avec un bon ajustement bat toujours un modèle complexe dont les parametres supplementaires n'apportent rien. Cela rend la comparaison objective, sans criteres ad hoc."
    ]
   }
  ],


### PR DESCRIPTION
Epic #2876 (restore French accents). See #2876.

## Scope
`Infer-10-Model-Selection.ipynb` (`.net-csharp` kernel, Probas/Infer family): **111 source lines accented across 42 cells** (`+111/-111` clean 1-for-1).

Conservative bare-word pairs: `modele`->`modèle`, `methode`->`méthode`, `donnees`->`données`, `resultat`->`résultat`, `etape`, `theoreme`, `definition`, `reference`, `probabilite`, `esperance`, `premiere`, `theorique`, `regle`, `caractere`, etc. English-ambiguous words (`different`/`complete`/`declare`) and no-ops (`exemple` needs no accent) skipped.

## Method (4-gate deaccent #2876 + c.456 comment-only filter)
- **Safe lines ONLY**: markdown cells + C# `//` comment lines. 0 executable code line, 0 identifier, 0 C# string literal touched.
- Surgical **raw-text** replacement (json.dumps round-trip churns papermill metadata -73B on this .NET notebook, leçon c.119).
- Word-boundary regex; deaccent verified.

## Validation
- `nbformat.validate` PASS
- **Comment-only invariant PASS** (0 non-comment code line changed)
- **outputs/execution_count invariant PASS** (0 output touched -> no re-exec needed; existing outputs valid, C.2 markdown+comment-only exception). JAVA_HOME broken does not block (no code re-exec).
- LF-only PASS, catalog byte-identical (0 generated file touched)
- `validate_pr_notebooks.py` repo-wide: All notebooks passed

## R6 note
Fresh family rotation (Probas/Infer — untouched this sequence; prior cycles were Lean/Sudoku/Search/GameTheory). Accents #2876 = active EPIC with residual ("code-cell → 22 notebooks"). Two HARD rules tension (no-idle/deliver-PR vs nettoyage cap): c.454 was a count-**correctness** fix (substance), this is the day's single nettoyage item. Documented for coordinator review.

See #2876