### PR TITLE
docs(#5780,#5654): harmonize 3 MANIFEST.md H1 titles (Galerie→Manifeste, doctrine corrigée)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md
@@ -1,4 +1,4 @@
-# Galerie README — Audio 01-Foundation (bases speech & audio)
+# Manifeste des figures — GenAI/Audio/01-Foundation (bases speech & audio)
 
 Provenance de chaque figure (convention `extract_readme_figures.py` L132 : index ALL-CELLS).
 Toutes les figures sont extraites des **outputs déjà committés** des notebooks (C.3 — aucune re-exécution).

--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md
@@ -1,4 +1,4 @@
-# Galerie README — Video 01-Foundation (bases vidéo & compréhension)
+# Manifeste des figures — GenAI/Video/01-Foundation (bases vidéo & compréhension)
 
 Provenance de chaque figure (convention `extract_readme_figures.py` L132 : index ALL-CELLS).
 Toutes les figures sont extraites des **outputs déjà committés** des notebooks (C.3 — aucune re-exécution).

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/assets/readme/MANIFEST.md
@@ -1,4 +1,4 @@
-# Galerie README — Pipeline d'entraînement ML
+# Manifeste des figures — QuantConnect/ML-Training-Pipeline
 
 Provenance de chaque figure (convention `extract_readme_figures.py` L132 : index ALL-CELLS, markdown + code).
 Toutes les figures sont extraites des **outputs déjà committés** des notebooks de recherche (C.3 — aucune re-exécution).


### PR DESCRIPTION
## Résumé

Harmonisation terminologique de 3 titres H1 legacy `# Galerie README — ...` vers `# Manifeste des figures — <chemin>` dans 3 fichiers `MANIFEST.md`, conformément à la **convention de nomenclature** déjà utilisée par 11+ autres MANIFESTs du dépôt (cf `SymbolicLearning`, `Search/Part1-Foundations`, `ICT-Series`, `Probas/...`, etc.).

**Substance** : 3 fichiers modifiés, +3/-3 lignes. **Aucune autre modification** du contenu (provenances, tableaux de figures, notes d'audit G.1, légendes, etc., tous préservés byte-identiques).

## Périmètre des modifications

| Fichier | Avant | Après |
|---------|-------|-------|
| `MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md` | `# Galerie README — Audio 01-Foundation (bases speech & audio)` | `# Manifeste des figures — GenAI/Audio/01-Foundation (bases speech & audio)` |
| `MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md` | `# Galerie README — Video 01-Foundation (bases vidéo & compréhension)` | `# Manifeste des figures — GenAI/Video/01-Foundation (bases vidéo & compréhension)` |
| `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/assets/readme/MANIFEST.md` | `# Galerie README — Pipeline d'entraînement ML` | `# Manifeste des figures — QuantConnect/ML-Training-Pipeline` |

## Vérification anti-régression (anti-§D byte-identity)

```bash
# Avant commit
$ grep -rln "^# Galerie README" --include="MANIFEST.md" MyIA.AI.Notebooks/
MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/assets/readme/MANIFEST.md
MyIA.AI.Notebooks/GenAI/Video/01-Foundation/assets/readme/MANIFEST.md
MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/assets/readme/MANIFEST.md

# Après commit (vérification post-fix)
$ grep -rln "^# Galerie README" --include="MANIFEST.md" MyIA.AI.Notebooks/
0 résultats — PASS
```

Le **contenu** de chaque MANIFEST est strictement préservé : seule la ligne H1 (1ère ligne de chaque fichier) est modifiée, ce qui correspond exactement à +1/-1 ligne par fichier dans `git diff --stat` (3 fichiers, +3/-3 lignes au total).

## Pourquoi cette harmonisation (doctrine corrigée #5780)

L'EPIC **#5780** (figures README — doctrine corrigée, post-incident `GenAI/Image/assets/readme/workflow-orchestration.png` avec 3 blocs plats labellisés) a établi la règle :

> **Pas de section `## Galerie` cosmétique**. Légende = ce que l'image **MONTRE**, choisir figure distinctive ou renoncer.

Dans ce cadre, **le terme `Galerie` lui-même est devenu inadapté** : un MANIFEST n'est pas une galerie (collection ornementale) mais un **inventaire traçable** (provenance + cellule + output + dimensions + alt-text). Le terme `Manifeste des figures` reflète mieux le rôle fonctionnel du fichier : table de correspondance **outputs notebooks ↔ assets README**.

**Convention cible** : `# Manifeste des figures — <chemin-du-module>` (avec chemin explicite `GenAI/Audio/01-Foundation`, `GenAI/Video/01-Foundation`, `QuantConnect/ML-Training-Pipeline` pour désambiguïser par rapport au titre affiché dans la mosaïque de tête du README).

## Preuves vérifiables

| Critère | Mesure |
|---------|--------|
| **`git diff --stat` strict** | `+3 / -3` lignes sur 3 fichiers (chirurgical) |
| **Anti-régression contenu** | Body byte-identique — seule la ligne H1 diffère (vérifié par `git diff` ligne par ligne) |
| **0 `Galerie` H1 restante** | `grep -rln "^# Galerie README"` post-fix = 0 résultat |
| **LF-only strict (L268)** | CR=0 sur les 3 fichiers, confirmé `python open(..., 'rb').read().count(b'\r')` |
| **MD047 trailing newline** | `endswith(b'\n')` = True sur les 3 fichiers (cf `python` vérif) |
| **Aucune section `## Galerie`** | `grep -nE "^## Galerie"` = 0 match sur les 3 fichiers (déjà alignés avec doctrine #5780) |
| **Branch rebase frais** | Créée depuis `origin/main @ 6ad27bc3e` (2026-07-14 docs gametheory #6483) |
| **Worktree isolé** | `D:/dev/CoursIA-c434` (sécurité R3 atomique + L143 SAFE cross-owner) |
| **Scope atomique** | 1 sujet = 1 PR (cosmétique docs, R3 + §A) ; 3 fichiers = 1 logique = 1 livraison |
| **Aucune régénération catalogue** | Pas de `COURSE_CATALOG.generated.json` ni de marqueurs `CATALOG-STATUS` touchés (catalog-pr-hygiene R1 respecté) |
| **Aucun notebook modifié** | Aucun `.ipynb` ni cellule touchée (C.2/C.3 préservés) |
| **Aucun code source** | Uniquement H1 markdown, pas de code |

## Refs croisées

- **EPIC #5780** — figures README, doctrine corrigée (post-incident `workflow-orchestration.png` blocs plats) ; rollout déjà livré sur `SymbolicLearning/README.md` + `Search/*` + `ICT-Series` + `Probas/*` par c.351/c.353/c.396.
- **PR #6483** — `docs(gametheory,#2876): restore French accents + v4.5 cell ids in GameTheory-2-Part2` (commit `6ad27bc3e`, base de la branche)
- **EPIC #5654** — bornes P1 figures README (`≤200 KB/fichier`, `≤1200 px max-dim`) ; respectées par les 3 MANIFESTs harmonisés
- **C403-L1** — `--body-file` strict (JAMAIS `--body`, anti-backtick stripping)
- **C350-L1** — intitulé ≠ contenu, vérifié G.1 firsthand par audit myia-po-2023 (cf MANIFEST Video §Audit G.1, 6/6 VRAI)
- **catalog-pr-hygiene R1-R4** — aucune régénération catalogue sur branche ; rebase frais ; atomique ; `See #5780` (contribution partielle à l'EPIC, non-résolution entière)
- **L298 anti-§D byte-identity** — body byte-identique préservé sur les 3 fichiers (vérifié `git diff` ligne-par-ligne : seule L1 diffère)

## Anti-patterns évités

- ✅ Pas de force push, pas de direct main push (L143 SAFE)
- ✅ Branch `docs/c5780-manifest-terminology` (nommée vers sujet réel)
- ✅ Worktree isolé `D:/dev/CoursIA-c434` (sécurité R3 atomique)
- ✅ `--body-file` (JAMAIS `--body`, C403-L1 anti-backtick stripping)
- ✅ `See #5780` (l'EPIC reste ouverte, contribution partielle ne ferme rien — R4)
- ✅ Aucune régénération catalogue (catalog-pr-hygiene R1)
- ✅ Aucune ré-exécution Papermill (C.3 — seul H1 markdown touché, aucun notebook)
- ✅ Body byte-identique préservé (anti-§D L298 : seule L1 diffère)
- ✅ LF-only + MD047 vérifiés Python byte-level sur les 3 fichiers
- ✅ Pas de main track monotone — c.434 = PIVOT hors-famille post-c.433 (R5.4b MUST + R6 anti-monotonie)

## Pivot R6 anti-monotonie (mandat user 2026-07-06) + R5.4b MUST (mandat user 2026-05-23)

**c.431 + c.432 + c.433 = 3 satellites pattern (c) intra-famille grothendieck_lean** (ConstantSheaf + MayerVietorisSquare + Conservative). **R5.4b MUST 3 cycles/thème consommés — c.434 = PIVOT obligatoire hors-famille.**

Justification du choix cosmétique `MANIFEST.md` H1 rename :
- **Hors-famille Lean** (R6 anti-monotonie : pas un 4ᵉ satellite grothendieck_lean)
- **Owner-free** (pas de claim cross-owner, conforme L143 SAFE)
- **Scope atomique** (R3 : 1 sujet = 1 PR, +3/-3 lignes sur 3 fichiers)
- **Nettoyage/doc plafonné à 1 item/lane/jour** acceptable (cf proactive-coordination règle 6 — 3 MANIFESTs rename = 1 lot cohérent `MANIFEST-terminology`)
- **Doctrine #5780 alignée** : harmonisation terminologique avec 11+ autres MANIFESTs du dépôt déjà convertis
- **Faible risque de régression** : changement H1 uniquement, body préservé byte-identique
- **Issue EPIC ouverte** : `See #5780` (R4 — contribution partielle, EPIC reste ouverte pour les autres MANIFESTs legacy éventuels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)