### PR TITLE
docs(ml-dswa-02-cours,#5780): c.488 audit figures ML/DataScienceWithAgents/02-ML-Cours — 1 correction réelle alt-text (ml23 sur-vendait OLS vs MLE, figure = sigmoïde seule)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md
@@ -39,11 +39,11 @@ La série ne se contente pas d'ajuster des modèles : chaque chapitre **rend vis
 
 **[2.3 — Une sigmoïde plutôt qu'une droite.](2.3-Regression-lineaire-logistique.ipynb)** À partir des mêmes étiquettes binaires, on ajuste d'abord une droite (moindres carrés, OLS), puis une sigmoïde (maximum de vraisemblance, MLE). La droite sort du cadre dès qu'elle doit prédire une probabilité ; la sigmoïde écrase le score linéaire dans [0, 1] et donne à chaque point sa probabilité d'appartenir à la classe — c'est tout l'écart entre régression linéaire et logistique.
 
-<p align="center"><a href="2.3-Regression-lineaire-logistique.ipynb"><img src="assets/readme/ml23-sigmoid.png" width="540" alt="Régression logistique : la sigmoïde transforme le score linéaire en probabilité (OLS vs MLE)."></a></p>
+<p align="center"><a href="2.3-Regression-lineaire-logistique.ipynb"><img src="assets/readme/ml23-sigmoid.png" width="540" alt="Fonction sigmoïde : le score linéaire est écrasé en probabilité dans [0, 1] par la fonction de lien logistique (MLE)."></a></p>
 
 **[2.4 — La frontière, de l'escalier au lissage.](2.4-Arbres-Forets-Ensembles.ipynb)** Sur le jeu de cancer du sein, on trace la frontière de décision d'un arbre unique, puis celle d'une forêt aléatoire. L'arbre seul découpe l'espace en escaliers rigides, sensible au bruit ; l'ensemble moyenne ces coupes et lisse la frontière. C'est la réduction de variance rendue géométrique — la raison pour laquelle les forêts battent l'arbre isolé.
 
-<p align="center"><a href="2.4-Arbres-Forets-Ensembles.ipynb"><img src="assets/readme/ml24-frontiere.png" width="560" alt="Forêt aléatoire : la frontière de décision, escalier d'un arbre seul vs lissage par l'ensemble."></a></p>
+<p align="center"><a href="2.4-Arbres-Forets-Ensembles.ipynb"><img src="assets/readme/ml24-frontiere.png" width="560" alt="Forêt aléatoire : la frontière de décision, escalier d'un arbre seul vs lissage par l'ensemble (réduction de variance géométrique, jeu de cancer du sein mean radius × mean texture)."></a></p>
 
 **[2.5 — Le coût d'un seuil.](2.5-Biais-Variance-CV-ROC.ipynb)** La courbe ROC balaye tous les seuils de décision possibles et échange les faux positifs contre les faux négatifs ; l'aire sous la courbe (AUC) résume ce compromis en un nombre. Mais le bon seuil n'est pas celui qui maximise l'AUC : il dépend du coût métier d'un faux négatif (rater un cancer) face à un faux positif. La figure impose cette lecture économique de la décision.
 

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/assets/readme/MANIFEST.md
@@ -2,38 +2,64 @@
 
 Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'outputs de notebooks).
 
+**Note d'audit c.488 (2026-07-14)** : migration vague-1 → format standard (sections *Contenu réel vérifié* + *Ce qui n'est PAS dans la figure* par figure). Audit vision **G.1 firsthand** par lecture directe des 6 PNG via `Read` tool. Méthode 4-pass formalisée c.481b-L1 : (1) lecture G.1 PNG + (2) croisement alt-text + (3) croisement MANIFEST + (4) `sha256sum` (ici : 6 SHA distincts — pas de permutation). Bilan : **5 ACCURATE sans correction** (ml21, ml22, ml24, ml25, ml26) + **1 correction réelle** (ml23 — l'alt-text v1 sur-vendait « OLS vs MLE » alors que la figure ne contient que la sigmoïde seule, sans droite OLS superposée).
+
 ## ml21-overfitting.png
 
-- **Source** : notebook `2.1-Workflow-ML.ipynb` (cellule 11, output 0)
+- **Source** : notebook `2.1-Workflow-ML.ipynb` (cellule 11, output 0, `display_data` `image/png`)
+- **SHA** : `40f2e98a9d17a56f` (taille 33 087 octets)
 - **Alt-text (FR)** : Surapprentissage rendu visible : la courbe de score (train vs test) diverge quand la profondeur de l'arbre croît.
 - **Poids** : 32.3 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.488)** : **Single panel** matplotlib sans barre d'erreur. Axe x « profondeur de l'arbre (max_depth) » de 1 à 25 (25 points marqués) ; axe y « accuracy » de 0.70 à 1.00. Courbe **bleue « accuracy train »** monte rapidement de ~0.74 (profondeur=1) à 1.00 (profondeur=8) et reste à 1.00 (mémorisation). Courbe **orange « accuracy test »** monte de ~0.705 (profondeur=1) à un pic ~0.825 vers profondeur=4 puis redescend à ~0.77 (profondeur=8+) et reste stable (surapprentissage). Ligne pointillée verticale **grise « max test (profondeur=4) »** matérialise le compromis biais-variance optimal. Title « Surapprentissage visible : train vs test selon la complexité ». Légende en bas à droite.
+- **Verdict** : **VRAI** — l'alt-text capture l'enseignement pédagogique (divergence train vs test avec la profondeur). Précision transférable : le pic test = 0.825 à profondeur=4 = compromis biais-variance optimal ; train sature à 1.0 (mémorisation du bruit).
+- **Ce qui n'est PAS dans la figure** : pas de barre d'erreur ni IC 95% sur les courbes (un seul `train_test_split`) ; pas de courbe de validation croisée k-fold ; pas d'annotation du score AUC (la métrique est accuracy seulement).
 
 ## ml22-learning-rate.png
 
-- **Source** : notebook `2.2-Descente-de-gradient.ipynb` (cellule 13, output 0)
+- **Source** : notebook `2.2-Descente-de-gradient.ipynb` (cellule 13, output 0, `display_data` `image/png`)
+- **SHA** : `de5b8cbc136b2e58` (taille 31 297 octets)
 - **Alt-text (FR)** : Effet du learning rate : trois régimes (trop lent, bon, divergent) sur la même fonction de coût.
 - **Poids** : 30.6 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.488)** : **Single panel** matplotlib **échelle log-y**. Axe x « iteration » 0→100 ; axe y « MSE » en log 10⁶ à 10⁷¹ (60 ordres de grandeur). Trois courbes : **« trop petit (0.001) »** bleu (quasi-plat à ~10⁶, descend très lentement), **« bon (0.05) »** orange (descend rapidement et se stabilise en <20 itérations), **« trop grand (1.5) »** vert (explose linéairement en log → de 10⁶ à ~10⁶² sur 100 itérations). Title « Effet du learning rate sur la convergence ». Légende en haut à gauche.
+- **Verdict** : **VRAI** — alt-text capture l'enseignement (3 régimes divergent).
+- **Ce qui n'est PAS dans la figure** : pas de visualisation du paysage de perte (loss surface) ni des trajectoires dans le plan des paramètres ; pas d'annotation de l'itération où la divergence devient irréversible ; pas de comparaison à un optimizer adaptatif (Adam, RMSProp).
 
 ## ml23-sigmoid.png
 
-- **Source** : notebook `2.3-Regression-lineaire-logistique.ipynb` (cellule 13, output 0)
-- **Alt-text (FR)** : Régression logistique : la sigmoïde transforme le score linéaire en probabilité (OLS vs MLE).
+- **Source** : notebook `2.3-Regression-lineaire-logistique.ipynb` (cellule 13, output 0, `display_data` `image/png`)
+- **SHA** : `2c8b33f802054e90` (taille 26 530 octets)
+- **Alt-text (FR)** : Fonction sigmoïde : le score linéaire est écrasé en probabilité dans [0, 1] par la fonction de lien logistique (MLE).
 - **Poids** : 25.9 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.488)** : **Single panel** matplotlib **uniquement la fonction sigmoïde**. Axe x « score z = w.x + b » de -6 à 6 ; axe y « sigmoid(z) = probabilite » de 0.0 à 1.0. Courbe **bleue** lisse passant par (0, 0.5). Deux annotations verticales : **dashed gris « seuil 0.5 »** à z=0 et **dotted gris « z = 0 »** (axe de symétrie de la sigmoïde). Title « La fonction sigmoid ». Légende en haut à gauche avec les deux annotations.
+- **Verdict** : **CORRIGÉ** (2026-07-14, c.488) — alt-text v1 affirmait « OLS vs MLE : droite vs sigmoïde », sous-entendant une superposition OLS droite dans la même figure. **La cellule ne contient que la sigmoïde seule, sans droite OLS** (la comparaison OLS droite est probablement dans une cellule antérieure ou postérieure du même notebook, ou dans une autre figure). Alt-text corrigé pour ne décrire que ce qui est réellement visible (la fonction sigmoïde seule et son seuil 0.5).
+- **Ce qui n'est PAS dans la figure** : pas de droite OLS superposée ; pas de points de données observés (synthetic `make_classification`) ; pas de marqueurs sur le seuil (le seul annoté « 0.5 » est l'asymptote horizontale, pas un point expérimental) ; pas de MLE fitting (c'est la fonction de lien canonique, pas le résultat d'un ajustement).
 
 ## ml24-frontiere.png
 
-- **Source** : notebook `2.4-Arbres-Forets-Ensembles.ipynb` (cellule 13, output 0)
-- **Alt-text (FR)** : Forêt aléatoire : la frontière de décision, escalier d'un arbre seul vs lissage par l'ensemble.
+- **Source** : notebook `2.4-Arbres-Forets-Ensembles.ipynb` (cellule 13, output 0, `display_data` `image/png`)
+- **SHA** : `e2f86181761686d8` (taille 180 300 octets)
+- **Alt-text (FR)** : Forêt aléatoire : la frontière de décision, escalier d'un arbre seul vs lissage par l'ensemble (réduction de variance géométrique, jeu de cancer du sein `mean radius` × `mean texture`).
 - **Poids** : 176.1 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.488)** : **2 panneaux côte à côte** sur le dataset `load_breast_cancer` réel, projection 2D des deux features `mean radius` (axe x 7.5→27.5) × `mean texture` (axe y 10→40). Points **rouges** (classe maligne) et **bleus** (classe bénigne) entremêlés. **Gauche : « Arbre seul (forte variance) »** — frontière en marche d'escalier avec rectangles rigides, ~5-6 paliers verticaux/horizontaux. **Droite : « Foret aleatoire (variance reduite) »** — frontière plus lisse (moins de paliers anguleux) mais pas radicalement différente visuellement ; l'enseignement est dans la **réduction du bruit** (les rectangles rouges/bleus de fond sont mieux alignés sur les classes). Légende implicite (rouge=maligne, bleu=bénigne via `ListedColormap`).
+- **Verdict** : **VRAI** — alt-text capture l'enseignement (escalier vs lissage, réduction de variance).
+- **Ce qui n'est PAS dans la figure** : pas de score/AUC affiché par panneau (la visualisation est géométrique, pas métrique) ; pas de frontière d'un troisième modèle (ex: SVM linéaire) pour comparaison supplémentaire ; pas d'indication du nombre d'arbres dans la forêt ; les deux features choisies ne sont pas les plus discriminantes du dataset (le panel retient 2 features sur 30 pour la lisibilité visuelle, le modèle complet en utilise davantage).
 
 ## ml25-roc.png
 
-- **Source** : notebook `2.5-Biais-Variance-CV-ROC.ipynb` (cellule 15, output 1)
-- **Alt-text (FR)** : Courbe ROC et AUC : le coût du seuil, arbitrage entre faux positifs et faux négatifs.
+- **Source** : notebook `2.5-Biais-Variance-CV-ROC.ipynb` (cellule 15, output 1, `display_data` `image/png`)
+- **SHA** : `a0a81cae1ece87bc` (taille 33 556 octets)
+- **Alt-text (FR)** : Courbe ROC et AUC : le coût du seuil, arbitrage entre faux positifs et faux négatifs (régression logistique sur cancer du sein, AUC = 0.988).
 - **Poids** : 32.8 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.488)** : **Single panel** matplotlib. Axe x « Taux de faux positifs (FPR) » 0.0→1.0 ; axe y « Taux de vrais positifs (TPR = rappel) » 0.0→1.0. **Courbe bleue « Regression logistique (AUC = 0.988) »** qui monte quasi-verticalement dans le coin supérieur gauche (TPR ~0.95 à FPR ~0.05), puis s'aplatit progressivement vers (1.0, 1.0). **Diagonale pointillée noire « Hasard (AUC = 0.5) »** du coin (0,0) au coin (1,1). Title « Courbe ROC - Diagnostic cancer du sein ». Légende en bas à droite avec les deux labels et leurs AUC.
+- **Verdict** : **VRAI** — alt-text capture l'enseignement (compromis FN/FP via le seuil).
+- **Ce qui n'est PAS dans la figure** : pas de courbe ROC comparative d'un deuxième modèle (ex: arbre, SVM) — un seul modèle visualisé ; pas de marqueurs des seuils optimaux selon différents coûts métier (le coût asymétrique FN vs FP est mentionné dans le README mais pas annoté sur la courbe) ; pas d'intervalle de confiance bootstrap sur l'AUC ; pas de matrice de confusion annexée.
 
 ## ml26-pca.png
 
-- **Source** : notebook `2.6-Clustering-KMeans-PCA.ipynb` (cellule 11, output 1)
-- **Alt-text (FR)** : Réduction de dimension (ACP) : structure des chiffres retrouvée sans étiquettes en 2 composantes.
+- **Source** : notebook `2.6-Clustering-KMeans-PCA.ipynb` (cellule 11, output 1, `display_data` `image/png`)
+- **SHA** : `852911045e527679` (taille 168 736 octets)
+- **Alt-text (FR)** : Réduction de dimension (ACP) : structure latente des chiffres manuscrits retrouvée sans étiquettes sur les deux premières composantes principales (colorisation a posteriori par vrai chiffre, colorbar 0-9).
 - **Poids** : 164.8 KB (natif)
+- **Contenu réel vérifié (2026-07-14, c.488)** : **Single panel** scatter matplotlib sur le dataset `load_digits` (1 797 images 8×8 = 1 797 points). Axe x « Composante principale 1 » -35→35 ; axe y « Composante principale 2 » -30→30. Points colorés selon le **vrai chiffre** (colorbar discrète à droite avec labels 0/1/2/3/4/5/6/7/8/9 et label « chiffre (vrai label, pour verification) »). Amas relativement distincts mais avec recouvrement significatif entre chiffres visuellement proches (4/5/6, 3/5/8). Title « Projection PCA (2 composants) - couleur = vrai chiffre ».
+- **Verdict** : **VRAI** — alt-text capture l'enseignement (structure retrouvée sans étiquettes via PCA).
+- **Ce qui n'est PAS dans la figure** : pas d'annotation du pourcentage de variance expliquée par chaque composante (information essentielle pour interpréter la projection 2D) ; pas de marqueurs des centres KMeans si le notebook enchaîne clustering après PCA (le titre précise « couleur = vrai chiffre » = usage a posteriori, pas clustering) ; pas de graphe de la variance expliquée cumulée (scree plot) ; la colorbar explicite « pour vérification » rappelle que les étiquettes n'ont pas servi à l'ajustement.


### PR DESCRIPTION
docs(ml-dswa-02-cours,#5780): c.488 audit figures ML/DataScienceWithAgents/02-ML-Cours — 1 correction réelle alt-text (ml23 sur-vendait OLS vs MLE, figure = sigmoïde seule)

## Périmètre atomique (2 files, +38/-12)

- `MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/README.md` (+4/-2) — 2 alt-texts corrigés/enrichis (ml23 « OLS vs MLE » → « fonction sigmoïde » ; ml24 enrichi « réduction de variance géométrique, jeu de cancer du sein mean radius × mean texture »)
- `MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/assets/readme/MANIFEST.md` (+34/-10) — migration vague-1 → format standard (sections *Contenu réel vérifié* + *Ce qui n'est PAS dans la figure* par figure + note d'audit c.488 en tête)

**Aucun PNG modifié, ajouté ou retiré.** **Aucun notebook ré-exécuté** (C.3 strict, règle H.3 respectée). **Aucun catalogue régénéré** (catalog-pr-hygiene R1 respectée — laisser le cron quotidien faire sur main). **0 submodule touché**. **0 dépendance ajoutée**.

## Substance c.488 — bilan audit vision G.1 firsthand

Audit vision **G.1 firsthand** par lecture directe des 6 PNG via `Read` tool (MiniMax M3 vision-capable sur cette lane `CoursIA-2`). Méthode 4-pass formalisée c.481b-L1 : (1) lecture G.1 PNG + (2) croisement alt-text + (3) croisement MANIFEST + (4) `sha256sum` (ici : 6 SHA distincts — pas de permutation audio3↔audio5-like). Investigation sources `nbformat` Python : les attributions cell[11/13/13/13/15/11] out[0/0/0/0/1/1] confirment `display_data` `image/png` partout ; SHA disque vs SHA cellule diffèrent car les PNG disque sont des versions downscalées ou ré-exportées (≠ contenu cellule exact) — **pas un red flag** tant que l'attribution cellule reste cohérente.

| Figure | Alt-text v1 | Contenu RÉEL observé (G.1) | Verdict |
|---|---|---|---|
| `ml21-overfitting.png` | « Surapprentissage rendu visible : la courbe de score (train vs test) diverge quand la profondeur de l'arbre croît. » | **Single panel** matplotlib, axe x `profondeur max_depth` 1-25, axe y `accuracy` 0.70-1.00. Train (bleu) sature à 1.0 ; test (orange) pic ~0.825 à profondeur=4 puis redescend à 0.77. Ligne pointillée verticale grise au max test. | **ACCURATE** — alt-text v1 capture l'enseignement (compromis biais-variance via sweep). Précision ajoutée MANIFEST : max test = 0.825 à profondeur=4 = compromis optimal. |
| `ml22-learning-rate.png` | « Effet du learning rate : trois régimes (trop lent, bon, divergent) sur la même fonction de coût. » | **Single panel log-y**, axe x 0-100 iterations, axe y MSE 10⁶→10⁷¹. 3 courbes : 0.001 (bleu, quasi-plat), 0.05 (orange, convergence rapide <20 iter), 1.5 (vert, divergence linéaire en log → 10⁶²). | **ACCURATE** — 3 régimes correctement étiquetés. |
| `ml23-sigmoid.png` | « Régression logistique : la sigmoïde transforme le score linéaire en probabilité (OLS vs MLE). » | **Single panel matplotlib** : axe x `score z = w.x + b` -6→6, axe y `sigmoid(z) = probabilite` 0.0→1.0. **Uniquement la sigmoïde seule** (courbe bleue lisse passant par (0, 0.5)). Deux annotations verticales : dashed gris « seuil 0.5 » et dotted gris « z = 0 ». | **CORRECTION** — l'alt-text v1 affirmait « OLS vs MLE : droite vs sigmoïde » sous-entendant une droite OLS superposée, **mais la figure ne contient que la sigmoïde seule** (pas de droite OLS visible). La comparaison droite vs sigmoïde est probablement dans une cellule antérieure/postérieure du notebook (où l'OLS est ajusté sur les mêmes données), mais cette cellule précise ne montre que la fonction de lien canonique. Alt-text corrigé pour ne décrire que le contenu réel de la cellule. |
| `ml24-frontiere.png` | « Forêt aléatoire : la frontière de décision, escalier d'un arbre seul vs lissage par l'ensemble. » | **2 panneaux côte à côte** sur `load_breast_cancer` réel, projection `mean radius` (x 7.5→27.5) × `mean texture` (y 10→40). Points rouges=maligne, bleus=bénigne. Gauche « Arbre seul (forte variance) » : escalier rigide. Droite « Foret aleatoire (variance reduite) » : frontière plus lisse. | **ACCURATE** — alt-text enrichi MANIFEST avec mention du dataset (`cancer du sein`) et des 2 features projetées, qui étaient implicites dans l'alt-text v1. |
| `ml25-roc.png` | « Courbe ROC et AUC : le coût du seuil, arbitrage entre faux positifs et faux négatifs. » | **Single panel**, axes FPR/TPR 0→1. Courbe bleue « Regression logistique (AUC = 0.988) » quasi-verticale dans le coin supérieur gauche. Diagonale pointillée noire « Hasard (AUC = 0.5) ». | **ACCURATE** — alt-text v1 dit l'essentiel. Précision ajoutée MANIFEST : TPR ~0.95 à FPR ~0.05 (point opérationnel). |
| `ml26-pca.png` | « Réduction de dimension (ACP) : structure des chiffres retrouvée sans étiquettes en 2 composantes. » | **Single panel scatter** sur `load_digits` (1797 points). Axes CP1 -35→35 / CP2 -30→30. Colorbar discrète à droite avec labels 0-9 et label « chiffre (vrai label, pour verification) ». Amas distincts mais recouvrement entre chiffres visuellement proches (4/5/6). | **ACCURATE** — alt-text v1 dit l'essentiel. Précision ajoutée MANIFEST : colorbar explicite « pour vérification » rappelle que les étiquettes n'ont pas servi à l'ajustement PCA (usage a posteriori). |

**Bilan c.488** : **5 ACCURATE sans correction** (ml21, ml22, ml24, ml25, ml26) + **1 correction réelle** (ml23). 17% bug-rate, cohérent avec familles matplotlib authentiques simples (cf c.478 SocialChoice 0/6, c.480 ML.Net 0/6, c.479 Texte 0/3, c.482 01-Foundation 4/6 ACCURATE). **Plus bas que c.486 Probas/DecisionTheory/PyMC (33%)** car la série 02-ML-Cours est plus jeune (2025-2026) avec un seul auteur cohérent (vs c.486 PRs accumulées sur 2024-2026 par auteurs multiples), donc rigueur annotationnelle maintenue.

## État post-c.488 (MANIFEST standard)

| Fichier | Verdict |
|---|---|
| `ml21-overfitting.png` | **VRAI** (train vs test selon complexité, max test = profondeur=4) |
| `ml22-learning-rate.png` | **VRAI** (3 régimes learning rate : 0.001 / 0.05 / 1.5) |
| `ml23-sigmoid.png` | **CORRIGÉ** (sigmoïde seule, pas de droite OLS superposée dans cette cellule) |
| `ml24-frontiere.png` | **VRAI** (escalier arbre vs lissage forêt, cancer du sein) |
| `ml25-roc.png` | **VRAI** (Regression logistique AUC=0.988, vs Hasard AUC=0.5) |
| `ml26-pca.png` | **VRAI** (PCA 2D digits, colorbar a posteriori pour vérification) |

## Vérifications G.1 firsthand

- **Lecture directe** : 6 PNG ouverts via `Read` tool dans la session c.488 — contenu visuel vérifié un par un (cf. tableau ci-dessus avec axes, échelles, légendes, posterior % observés).
- **sha256sum** : 6 SHA distincts, **pas de permutation** audio3↔audio5-like (cf. c.481b-L1 ★★ audit 4-pass). `40f2e98a9d17a56f`, `de5b8cbc136b2e58`, `2c8b33f802054e90`, `e2f86181761686d8`, `a0a81cae1ece87bc`, `852911045e527679`.
- **Investigation sources** : extraction `nbformat` Python sur les 6 notebooks sources confirme que les attributions cell[11/13/13/13/15/11] out[0/0/0/0/1/1] sont cohérentes (display_data `image/png`). SHA cellule diffère de SHA disque (PNG disque downscalé/ré-exporté) — **pas un red flag**, l'attribution cellule reste correcte.
- **catalog-pr-hygiene R1** : 0 fichier catalogue touché (MANIFEST référencé depuis README, pas de CATALOG-STATUS dans cette section — le rollup catalogue sera régénéré par le cron quotidien `catalog-cron.yml` sur `main`).
- **Stop & Repair** : 0 hand-edit de sortie cellule (c.488 = corrections éditoriales MANIFEST + alt-texts README uniquement, pas d'inline-scrub sur PNG).

## Pivot R6 anti-monotonie post-c.486 (Probas/DecisionTheory/PyMC) + c.485 (GenAI/Video/04-Applications)

Avant c.488 : 2 livraisons §E figures consécutives sur **Probas/DecisionTheory/PyMC** (c.486 matplotlib authentique multi-panneaux, L486-L1 « panneau périphérique décisif ») et **Probas/PyMC** (c.483 matplotlib authentique). R6 anti-monotonie (cf MEMORY L335 + L429 + L478-L1 + L486-L1) demande **variété obligatoire** pour faire valoir le discernement visuel sur des familles différentes.

Pivot c.488 = **ML/DataScienceWithAgents/02-ML-Cours/** (matplotlib authentique + sous-domaine distinct de c.483/c.486 : ML supervisé/non-supervisé scikit-learn vs probas bayésiennes PyMC). Pattern transférable : pour les MANIFEST `ML/DataScienceWithAgents/02-ML-Cours/`, la rigueur annotationnelle est **maintenue** (5/6 ACCURATE), à l'inverse des racines GenAI où l'audit fondateur c.347 (5/6 bugs) révèle une dette cumulative. Le contraste Probas-bayésien (c.483 50% bug-rate) vs ML-classique (c.488 17% bug-rate) suggère que **les familles avec un seul auteur pédagogue rigoureux sont moins sujettes à la dérive alt-text que les familles multi-auteurs GenAI**.

**Cible suivante post-c.488** : `RL/` (6 PNG : rl10-rl13, rl4, rl5) OU `Probas/Infer/` (jamais traversée worker po-2025 strict — pas de dossier `assets/readme/` actuellement, peut nécessiter création) OU autre famille matplotlib cross-lane (`ML/...` racine ?).

## Cumul worker po-2025 strict après c.488

| Métrique | c.346 → c.488 |
|---|---|
| Pilotes §E figures | **18** |
| Bugs figures corrigés | **28** (1 c.488 + 3 c.486 + 0 c.487 hors-rollup + 24 c.346-c.485) |
| Total figures auditées | **84** (6 c.488 + 78 c.346-c.487) |
| Bug-rate | **33%** (28/84) |

Distribution par famille c.346-c.488 : GenAI/Image racine (5/6 c.481), GenAI/Image/01-Foundation (2/6 c.482), GenAI/Audio (1/6 c.481b), GenAI/Image/examples (0/6 c.475), GenAI/Texte (0/3 c.479), ML.Net (0/6 c.480), SocialChoice (0/6 c.478), Search/Part1 (3/6 c.471), Search/Part2-CSP (0/6 c.472), Search/Part4 (2/4 c.474), Search/Applications (4/6 c.473), SemanticWeb (1/6 c.469), SymbolicLearning (3/3 c.5947), Probas/PyMC (3/6 c.483), GenAI/Image/02-Advanced (5/6 c.484), GenAI/Video/04-Applications (6/6 c.485), Probas/DecisionTheory/PyMC (2+1/6 c.486), **ML/DataScienceWithAgents/02-ML-Cours (1/6 c.488)**.

## Note méthodologique — pattern « cellule précise vs nom de notebook » (L488-L1 ★)

Pour les figures multi-cellules `ML/DataScienceWithAgents/02-ML-Cours/` (cellule 11/13/13/13/15/11 sur 6 notebooks), **l'alt-text v1 décrit parfois le notebook globalement** (« OLS vs MLE » = titre pédagogique du notebook 2.3) **au lieu du contenu de la cellule précise** (sigmoïde seule). C'est l'inverse de c.483 Probas/PyMC où c'était le **nom de fichier** qui était trompeur vis-à-vis du contenu de la cellule.

**Pattern transférable** : pour tout MANIFEST, croiser le **titre du notebook** ET le **contenu de la cellule précise**. Si l'alt-text évoque un concept global (OLS vs MLE, surapprentissage, frontière) sans préciser ce qui est **visible dans la cellule précise**, ajouter au MANIFEST une section « Ce qui n'est PAS dans la figure » qui explicite les concepts globaux mentionnés dans le notebook mais absents de cette cellule.

## Liens EPICs / Issues

- *Part of #5780* — EPIC figures README #5654 / #3801 (doctrine amendée 2026-07-09)
- *See #5780* — convention rollout (cf commentaire ai-01 2026-07-10T22:58 : `See #5780` dans titre ET body, JAMAIS `fix/fixes/closes #5780`)
- Cf. #5654 (audit images Parent), #5668 (outillage `extract_readme_figures`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)