### PR TITLE
docs(quantconnect): fix research-notebook count drift in hub summary (2 -> 17)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -244,7 +244,7 @@ python -m ipykernel install --user --name=quantconnect --display-name "Python (Q
 
 ## Résumé de la Progression
 
-**Total cours linéaire** : **29 notebooks Python** (QC-Py-01 à QC-Py-28 + le 23b, ~33 heures de contenu) + **24 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, **15** Cloud strategies QC-Py-Cloud-01..09, training QC-Py-30..32, dataset workflow), plus 2 notebooks de recherche utilitaires (`research_*.ipynb`).
+**Total cours linéaire** : **29 notebooks Python** (QC-Py-01 à QC-Py-28 + le 23b, ~33 heures de contenu) + **24 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, **15** Cloud strategies QC-Py-Cloud-01..09, training QC-Py-30..32, dataset workflow), plus **17 notebooks de recherche** standalone (`research_*.ipynb`, détaillés dans [research/README.md](research/README.md)).
 
 **Répartition cours linéaire (Phases 1-8)** :
 - **18 notebooks non-ML** (Fondations, Universe, Trading Avancé, Framework, Alternative Data) : ~18h


### PR DESCRIPTION
## What

The `QuantConnect/README.md` hub "Résumé de la Progression" claimed **"2 notebooks de recherche utilitaires (`research_*.ipynb`)"**, but the `research/` directory contains **17 standalone research notebooks**, each already documented in [`research/README.md`](MyIA.AI.Notebooks/QuantConnect/research/README.md). This updates the stale count and links the canonical research README.

## Why it is drift (not a counting scheme)

Unlike the SocialChoice "4 topics vs 7 files" dual-scheme (deliberate), this is a plain stale count: the research/ subdirectory grew from ~2 utility notebooks to **17** substantive research notebooks (m12 HAR-RV/realized-vol series ×5, RL series ×6, composite-ff/mom ×2, btc-ml, quality-lowvol, risk-parity, vrp-putwrite) and the hub summary never caught up. A reader of the hub "Résumé" would miss 15 research notebooks.

## File-entier audit (rule E) — QuantConnect/README.md vs fresh origin/main `8da7aab01`

Reconciled **disk ↔ prose** for every numeric claim in the hub:

| Claim (line) | Prose | Disk (fresh `origin/main`) | Verdict |
|---|---|---|---|
| L51 "`Python/` 53 notebooks" | 53 | 53 QC-Py-*.ipynb | OK |
| L247 "29 cours linéaire (01-28 + 23b)" | 29 | 29 (01-28 + 23b) | OK |
| L247 "24 compléments" | 24 | 3 training (30-32) + 3 RL (33-35) + 2 paper (40-41) + 15 Cloud + 1 Dataset-Workflow = 24 | OK |
| L247 "15 Cloud strategies" | 15 | 15 (Cloud-01×2 … Cloud-06×2, 07, 08, 09) | OK |
| Phases 1-8 headers (4/4/4/3/3/3/4/4) | 29 | sum = 29 | OK |
| **L247 "2 notebooks de recherche utilitaires"** | **2** | **17 `research_*.ipynb`** | **DRIFT — fixed** |

Arithmetic: 29 (cours) + 24 (compléments) = 53 ✓. The single drift is the research count.

## Scope

- 1 file, +1/−1, markdown-only (prose summary line).
- **Catalogue byte-identical to `main`** — `COURSE_CATALOG.generated.*` and `CATALOG-STATUS` markers untouched (catalog-pr-hygiene).
- No notebook touched, no re-exec needed (pure docs).

## Verification

```
$ git diff --stat
 MyIA.AI.Notebooks/QuantConnect/README.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
$ ls MyIA.AI.Notebooks/QuantConnect/research/*.ipynb | wc -l
17
$ ls MyIA.AI.Notebooks/QuantConnect/research/README.md   # link target exists
```

Same pattern as po-2023 #6494 (Search Part1 language-count 13→12) / #6496 (Sudoku pair-count off-by-one): a single-line factual count correction from a file-entier §E audit.

See #3973 (README resync EPIC), #4959 (READMEs intermédiaires P0). Partial contribution — EPIC remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)