### PR TITLE
docs(grothendieck): fix README i18n drift (12 -> 15 _en siblings)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -8,7 +8,7 @@ Alexandre Grothendieck (1928-2014).
 - **Sorry**: **0 sorry, 0 axiom** — all 24 modules are complete at creation (Parts 1-24 merged)
 - **Build**: `lake build Grothendieck` — compiles the 24 modules (~3350 lines)
 - **Dependencies**: Mathlib 4 (via `lakefile.lean`)
-- **i18n coverage (EPIC #4980)**: extended coverage — **24 FR-canonical `.lean` modules** + **12 `_en.lean` sibling mirrors** on `main` (`Calibration_en`, `CategoryAndSites_en`, `CoverageGen_en`, `DenseTopology_en`, `LeftExact_en`, `SchemesTour_en`, `SheafHom_en`, `SitePoints_en`, `Subcanonical_en`, `ZariskiSite_en`, `SheafCohomology/Basic_en`, `SheafCohomology/Cech_en` — `_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). Option A post-#4980 on 12 modules; the 12 other modules stay FR-only at this stage of the rollout. **`README.en.md`** present (EN mirror of this file). Out-of-scope: `.lake/packages/`, vendored libs.
+- **i18n coverage (EPIC #4980)**: extended coverage — **24 `.lean` modules** + **15 `_en.lean` siblings** on `main`. Per the ratified convention (Option A: `Foo.lean` FR-canonical + `Foo_en.lean` EN mirror), 12 modules are already bilingual in Pattern A: `Calibration`, `CategoryAndSites`, `CoverageGen`, `DenseTopology`, `LeftExact`, `SchemesTour`, `SheafHom`, `SitePoints`, `Subcanonical`, `ZariskiSite`, `SheafCohomology/Basic`, `SheafCohomology/Cech`. 3 additional modules have an `_en` sibling (`ConstantSheaf`, `Conservative`, `MayerVietorisSquare`) — their FR/EN direction is being harmonized with ai-01 (convention conflict flagged); `_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable. The remaining 9 modules stay FR-only at this stage of the rollout. **`README.md`** present (FR-canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
 
 ## Purpose
 
@@ -49,10 +49,10 @@ in order by the umbrella `Grothendieck.lean`. Each module self-numbers via its h
 | 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 220 |
 | 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 88 |
 | 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Internal hom of sheaves | 140 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | — | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | — | Conservative families of points | 226 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Conservative families of points | 226 |
 | 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Sheaf cohomology (Ext-based) | 214 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | — | Mayer-Vietoris squares | 195 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Mayer-Vietoris squares | 195 |
 | 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | — | Mayer-Vietoris long exact sequence | 164 |
 | 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 123 |
 | 24 | `Grothendieck/YonedaLemma.lean` | — | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 168 |
@@ -96,7 +96,7 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - Epic #1453 (prover harness calibration)
 - Conway tribute workspace (`../conway_lean/`)
 - Lean notebook series (`../README.md`)
-- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 12 `_en.lean` siblings on `main` in this lake)
+- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 15 `_en.lean` siblings on `main` in this lake)
 - **[`README.md`](./README.md)** — FR canonical sibling of this file
 
 ## Conclusion

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -8,7 +8,7 @@ Alexandre Grothendieck (1928-2014).
 - **Sorry** : **0 sorry, 0 axiome** — les 24 modules sont complets à la création (Parties 1-24 mergées)
 - **Build** : `lake build Grothendieck` — compile les 24 modules (~3350 lignes)
 - **Dépendances** : Mathlib 4 (via `lakefile.lean`)
-- **Couverture i18n (EPIC #4980)** : couverture étendue — **24 modules `.lean` FR canonique** + **12 siblings `_en.lean`** miroirs EN sur `main` (`Calibration_en`, `CategoryAndSites_en`, `CoverageGen_en`, `DenseTopology_en`, `LeftExact_en`, `SchemesTour_en`, `SheafHom_en`, `SitePoints_en`, `Subcanonical_en`, `ZariskiSite_en`, `SheafCohomology/Basic_en`, `SheafCohomology/Cech_en` — namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). Option A post-#4980 sur 12 modules ; les 12 autres modules restent FR-only à ce stade du rollout. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
+- **Couverture i18n (EPIC #4980)** : couverture étendue — **24 modules `.lean`** + **15 siblings `_en.lean`** sur `main`. Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN), 12 modules sont déjà bilingues au pattern A : `Calibration`, `CategoryAndSites`, `CoverageGen`, `DenseTopology`, `LeftExact`, `SchemesTour`, `SheafHom`, `SitePoints`, `Subcanonical`, `ZariskiSite`, `SheafCohomology/Basic`, `SheafCohomology/Cech`. 3 modules additionnels ont un sibling `_en` (`ConstantSheaf`, `Conservative`, `MayerVietorisSquare`) — leur direction FR/EN est en cours d'harmonisation avec ai-01 (cf conflit de convention signalé) ; namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI. Les 9 modules restants sont FR-only à ce stade du rollout. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
 
 ## Objectif
 
@@ -64,10 +64,10 @@ flowchart LR
 | 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 220 |
 | 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 88 |
 | 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Hom interne des faisceaux | 140 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | — | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | — | Familles conservatrices de points | 226 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
+| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Familles conservatrices de points | 226 |
 | 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Cohomologie des faisceaux (basée sur Ext) | 214 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | — | Carrés de Mayer-Vietoris | 195 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Carrés de Mayer-Vietoris | 195 |
 | 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | — | Suite exacte longue de Mayer-Vietoris | 164 |
 | 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 123 |
 | 24 | `Grothendieck/YonedaLemma.lean` | — | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 168 |
@@ -111,7 +111,7 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - PR #2675 (Phases 4-6 : SieveOps + CoverageGen + CanonicalProps)
 - Epic #1453 (calibration du harnais prouveur)
 - Workspace hommage Conway (`../conway_lean/`)
-- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 12 siblings `_en.lean` sur `main` dans cette lake)
+- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 15 siblings `_en.lean` sur `main` dans cette lake)
 - **[`README.en.md`](./README.en.md)** — miroir EN du présent fichier
 - Série de notebooks Lean (`../README.md`)
 


### PR DESCRIPTION
## Summary

Fixes `grothendieck_lean/README.md` (+ `README.en.md` mirror) i18n-coverage drift: the README claimed **12 `_en.lean` siblings** while disk has **15**. Three modules that received `_en` siblings this cycle were left undocumented, leaving stale `-` entries in the structure table and an off-by-3 count.

See #4980 (partial — documentation accuracy of i18n rollout state; does not resolve the epic).

## §E whole-file audit against disk (firsthand, G.1)

| Check | Disk | README (before) | Status |
|-------|------|-----------------|--------|
| canonical `.lean` modules | **24** | 24 | ✓ matches |
| `_en.lean` siblings | **15** | 12 | **STALE by 3** |

```
$ find Grothendieck -name '*.lean' ! -name '*_en.lean' | wc -l   -> 24
$ find Grothendieck -name '*_en.lean' | wc -l                    -> 15
```

The 3 undocumented siblings, merged this cycle by a fellow agent:
- `ConstantSheaf_en.lean` (#6485) — table row 18 was `-`
- `Conservative_en.lean` (#6497) — table row 19 was `-`
- `MayerVietorisSquare_en.lean` (#6492) — table row 21 was `-`

## Convention-aware fix

**12 original `_en` siblings** follow the ratified Pattern A (`Foo.lean` FR-canonical + `Foo_en.lean` EN mirror) — verified firsthand on `Calibration`, `CategoryAndSites`, `SheafHom` (canonical FR header + `_en` EN header).

**3 newer `_en` siblings** were merged in the **inverted** pattern (canonical stays EN, `_en` contains FR). This convention conflict was flagged to ai-01 for adjudication (msg ...8a5kbc). The README therefore documents their `_en` existence **factually** (table filled, count incremented) without over-claiming "EN mirror" direction — it notes the FR/EN direction is pending harmonization. This keeps the README honest under either ruling.

## Edits (both README.md + README.en.md kept in sync)

- **L11 i18n paragraph**: `12` → `15`; restructured as "12 Pattern-A + 3 convention-pending + 9 FR-only" (24 − 15 = 9 ✓; 12 + 3 = 15 ✓)
- **Structure table rows 18 / 19 / 21**: filled `_en` sibling filenames (`ConstantSheaf_en`, `Conservative_en`, `MayerVietorisSquare_en`)
- **"Voir aussi" EPIC #4980 line (L114 / L99)**: `12` → `15`

## Why this matters

A worker reading the stale README would believe these 3 modules are FR-only and re-open a collision PR on them (exactly what po-2026 did at c.450 before this fix). Accurate fleet-wide documentation of done-work is what makes the i18n collision-guard reliable.

## Validation

- `git diff --numstat`: 5/5 per file (symmetric = no CRLF flip)
- No `*.lean` touched (pure docs) → no build/sorry concerns
- `COURSE_CATALOG.generated.*` byte-identical to main (not touched)

Co-Authored-By: Claude <noreply@anthropic.com>