### PR TITLE
feat(translation,#4957): c.439 resync Sudoku CSV (T1b) via --update mode (75 SRC_DRIFT → 0)

### DIFF
--- a/scripts/translation/extract_cells_to_csv.py
+++ b/scripts/translation/extract_cells_to_csv.py
@@ -22,6 +22,12 @@ Usage :
     python scripts/translation/extract_cells_to_csv.py <notebook.ipynb | dir/> [-o CSV]
     python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/
 
+    # Mode --update : met à jour un CSV EXISTANT pour les notebooks donnés, sans
+    # écraser les autres entrées ni perdre les colonnes remplies par T3 (moteur
+    # Argumentum : text_en, hash_en, ...). Les colonnes cibles non-pivot sont
+    # préservées verbatim si la ligne (notebook, cell_id) existe déjà.
+    python scripts/translation/extract_cells_to_csv.py notebook.ipynb --update existing.csv
+
 Le CSV est écrit par défaut sur stdout (rediriger vers translations/<famille>/<série>.csv).
 """
 
@@ -30,6 +36,7 @@ from __future__ import annotations
 import argparse
 import csv
 import hashlib
+import io
 import json
 import sys
 from pathlib import Path
@@ -105,21 +112,202 @@ def extract_notebook(nb_path: Path, repo_root: Path, src_lang: str) -> list[dict
     return rows
 
 
-def iter_notebooks(target: Path) -> list[Path]:
-    """Résout un fichier .ipynb ou un répertoire en liste de notebooks.
+def iter_notebooks(targets: list[Path]) -> list[Path]:
+    """Résout une liste de chemins (notebooks .ipynb et/ou répertoires) en
+    liste triée et dédupliquée de notebooks.
 
     Exclut les artefacts `_output.ipynb` (sorties Papermill) et les variantes
     `_agent.ipynb` (auto-générées, hors périmètre traduction). On utilise
     `endswith` (et non un substring `in`) pour ne pas exclure par erreur un
     notebook légitime comme `foo_output.ipynb`.
     """
-    if target.is_file():
-        return [target]
-    return sorted(
-        p
-        for p in target.rglob("*.ipynb")
-        if not p.name.endswith("_output.ipynb") and not p.name.endswith("_agent.ipynb")
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for target in targets:
+        if target.is_file():
+            if target not in seen:
+                seen.add(target)
+                out.append(target)
+        elif target.is_dir():
+            for p in sorted(target.rglob("*.ipynb")):
+                if p in seen:
+                    continue
+                if p.name.endswith("_output.ipynb") or p.name.endswith("_agent.ipynb"):
+                    continue
+                seen.add(p)
+                out.append(p)
+        else:
+            print(f"WARNING : {target} introuvable, ignoré.", file=sys.stderr)
+    return out
+
+
+def load_existing_csv(csv_path: Path) -> list[dict]:
+    """Charge un CSV existant en liste de dicts (préserve l'ordre des lignes).
+
+    Le CSV doit employer le schéma ratifié (#4957 §1). Si une ligne n'a pas
+    toutes les colonnes (CSV créé par une version antérieure du script), les
+    clés manquantes sont remplies avec la chaîne vide pour rester compatible
+    avec DictWriter.
+    """
+    with csv_path.open(encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = []
+        for row in reader:
+            for col in COLUMNS:
+                row.setdefault(col, "")
+            rows.append(row)
+    return rows
+
+
+def update_existing_csv(
+    existing_rows: list[dict],
+    fresh_rows: list[dict],
+    target_notebooks: set[str],
+) -> tuple[list[dict], dict]:
+    """Met à jour les lignes existantes pour les notebooks cibles, sans toucher
+    aux autres entrées du CSV.
+
+    Stratégie :
+    - Indexation par (notebook, cell_id) -> ligne existante.
+    - Pour chaque ligne fraîche du/des notebooks cibles, on update les champs
+      pivot (`src_hash`, `text_fr`, `hash_fr`, `cell_type` au cas où il aurait
+      changé). Les autres colonnes (text_en, hash_en, ...) sont **préservées**
+      si la ligne existait déjà — c'est crucial : T3 (moteur Argumentum) aura
+      pu déposer des traductions qu'on ne veut PAS écraser.
+    - Si une cellule fraîche n'a pas de ligne correspondante, on **append** en
+      fin (cas légitime : nouvelle cellule ajoutée au notebook depuis la
+      dernière extraction).
+    - Les lignes existantes pour des notebooks HORS cible sont conservées
+      verbatim (octet pour octet sur les champs texte).
+    - Les lignes existantes pour les notebooks cibles qui n'ont PAS de
+      cellule fraîche correspondante sont **conservées** aussi (cellule
+      supprimée -> ORPHAN_ROW ; le check_translation_sync.py le signalera,
+      on ne détruit pas la ligne sans décision humaine).
+
+    Le rapport `stats` est calculé en **pré-update** (vrai diff contre l'état
+    initial du CSV) pour donner une lecture actionable : "12 lignes ont
+    effectivement changé de src_hash" plutôt que "0 ligne modifiée" après le
+    passage qui les a justement toutes mises à jour.
+
+    Returns (rows_updated, stats) où stats détaille :
+      updated     : nb de lignes existantes dont au moins un champ pivot a
+                    effectivement changé (calculé en pré-update)
+      unchanged   : nb de lignes cibles déjà in-sync (cas idem-pas-de-diff)
+      appended    : nb de nouvelles lignes ajoutées en fin
+      kept_other  : nb de lignes d'autres notebooks conservées verbatim
+      kept_orphan : nb de lignes cibles dont la cellule n'a pas été
+                    retrouvée dans le notebook
+    """
+    # Index existant par (notebook, cell_id) -> position dans la liste
+    index: dict[tuple[str, str], int] = {}
+    for i, row in enumerate(existing_rows):
+        key = (row.get("notebook", ""), row.get("cell_id", ""))
+        if key not in index:
+            # En cas de doublon (ne devrait pas arriver avec un CSV propre),
+            # on garde la première occurrence.
+            index[key] = i
+
+    PIVOT_COLS = ("src_lang", "src_hash", "text_fr", "hash_fr", "cell_type")
+
+    # 1) Calculer le diff en PRÉ-update (avant de muter existing_rows).
+    pre_updated = 0
+    pre_unchanged = 0
+    for fresh in fresh_rows:
+        key = (fresh["notebook"], fresh["cell_id"])
+        if key in index:
+            existing = existing_rows[index[key]]
+            if any(existing.get(c) != fresh[c] for c in PIVOT_COLS):
+                pre_updated += 1
+            else:
+                pre_unchanged += 1
+
+    # 2) Appliquer les updates (mute existing_rows in place).
+    fresh_keys: set[tuple[str, str]] = set()
+    appended = 0
+    for fresh in fresh_rows:
+        key = (fresh["notebook"], fresh["cell_id"])
+        fresh_keys.add(key)
+        if key in index:
+            existing = existing_rows[index[key]]
+            for pivot_col in PIVOT_COLS:
+                if existing.get(pivot_col) != fresh[pivot_col]:
+                    existing[pivot_col] = fresh[pivot_col]
+        else:
+            existing_rows.append(fresh)
+            appended += 1
+
+    # 3) Compteurs finaux (post-update).
+    kept_orphan = sum(
+        1
+        for r in existing_rows
+        if r.get("notebook") in target_notebooks
+        and (r.get("notebook", ""), r.get("cell_id", "")) not in fresh_keys
     )
+    kept_other = sum(
+        1 for r in existing_rows if r.get("notebook") not in target_notebooks
+    )
+
+    stats = {
+        "updated": pre_updated,
+        "unchanged": pre_unchanged,
+        "appended": appended,
+        "kept_other": kept_other,
+        "kept_orphan": kept_orphan,
+    }
+    return existing_rows, stats
+
+
+def write_csv(rows: list[dict], output: Path | None) -> str:
+    """Écrit les lignes au format CSV. Retourne le sink pour le rapport stderr.
+
+    Politique d'encodage/newlines (cf L268 — LF-only strict dépôt) :
+    - `newline=""` est l'invariant CSV (laissée à csv.writer) MAIS on interdit
+      ensuite tout `\r` dans le flux final. `csv.writer` écrit `\r\n` sur
+      toute plateforme (cf doc Python) → on convertit en `\n` APRÈS écriture
+      pour garantir LF-only sans casser l'échappement CSV (les `\r\n` à
+      l'intérieur des champs sont déjà échappés en `""` quotes, ils ne sont
+      pas affectés).
+    - stdout passe par `sys.stdout.reconfigure` (Python 3.7+) plutôt qu'un
+      binaire intermédiaire, ce qui préserve le rendu côté utilisateur.
+    """
+    sink_path: object = None
+    if output is None:
+        # Mode stdout : on essaie de forcer LF si possible.
+        try:
+            sys.stdout.reconfigure(newline="\n")  # type: ignore[attr-defined]
+        except (AttributeError, ValueError):
+            pass
+        out: object = sys.stdout
+        sink = "stdout"
+    else:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        # Binaire pour pouvoir normaliser LF après écriture (cf politique ci-dessus).
+        out = output.open("wb")
+        sink_path = output
+        sink = str(output)
+
+    try:
+        # Encodage en utf-8 sans BOM côté fichier (BOM casserait les parseurs CSV).
+        text_buf = io.StringIO()
+        writer = csv.DictWriter(text_buf, fieldnames=COLUMNS, quoting=csv.QUOTE_MINIMAL)
+        writer.writeheader()
+        writer.writerows(rows)
+        text = text_buf.getvalue()
+        # Convertit les fins de ligne en LF uniquement (politique dépôt L268).
+        text_lf = text.replace("\r\n", "\n").replace("\r", "\n")
+        if sink_path is not None:
+            out.write(text_lf.encode("utf-8"))
+        else:
+            out.write(text_lf)
+    finally:
+        if sink_path is not None:
+            out.close()  # type: ignore[attr-defined]
+        else:
+            try:
+                sys.stdout.reconfigure(newline=None)  # type: ignore[attr-defined]
+            except (AttributeError, ValueError):
+                pass
+    return sink
 
 
 def main() -> int:
@@ -129,7 +317,9 @@ def main() -> int:
     parser.add_argument(
         "input",
         type=Path,
-        help="Notebook .ipynb ou répertoire de série (extraction récursive).",
+        nargs="+",
+        help="Un ou plusieurs chemins : notebook .ipynb ou répertoire de série "
+        "(extraction récursive).",
     )
     parser.add_argument(
         "-o", "--output", type=Path, default=None, help="Fichier CSV de sortie (défaut : stdout)."
@@ -146,16 +336,31 @@ def main() -> int:
         default=None,
         help="Racine du dépôt pour calculer les chemins relatifs (défaut : cwd).",
     )
+    parser.add_argument(
+        "--update",
+        type=Path,
+        default=None,
+        metavar="CSV",
+        help="Met à jour un CSV existant au lieu d'écraser : préserve les lignes "
+        "d'autres notebooks et les colonnes cibles (text_en/hash_en/...) remplies "
+        "par T3. Les champs pivot (src_hash, text_fr, hash_fr, src_lang, cell_type) "
+        "sont rafraîchis pour les notebooks donnés en input.",
+    )
     args = parser.parse_args()
 
-    if not args.input.exists():
-        print(f"ERROR : {args.input} introuvable.", file=sys.stderr)
+    # `input` est une liste (nargs="+"). On accepte des chemins individuels ou
+    # des répertoires (récursif). Les chemins inexistants sont signalés via
+    # iter_notebooks() mais ne font pas échouer le run si au moins un notebook
+    # est trouvé.
+    existing_inputs = [p for p in args.input if p.exists()]
+    if not existing_inputs:
+        print(f"ERROR : aucun chemin d'input valide (reçus : {args.input}).", file=sys.stderr)
         return 2
 
     repo_root = (args.repo_root or Path.cwd()).resolve()
-    notebooks = iter_notebooks(args.input)
+    notebooks = iter_notebooks(existing_inputs)
     if not notebooks:
-        print(f"ERROR : aucun notebook trouvé sous {args.input}.", file=sys.stderr)
+        print(f"ERROR : aucun notebook trouvé dans {existing_inputs}.", file=sys.stderr)
         return 2
 
     rows: list[dict] = []
@@ -166,20 +371,36 @@ def main() -> int:
         print(f"WARNING : 0 cellules extraites de {len(notebooks)} notebook(s).", file=sys.stderr)
         return 1
 
-    out = sys.stdout
-    if args.output:
-        # Crée le répertoire parent si nécessaire (sinon open() lève FileNotFoundError).
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        out = args.output.open("w", encoding="utf-8", newline="")
-    try:
-        writer = csv.DictWriter(out, fieldnames=COLUMNS, quoting=csv.QUOTE_MINIMAL)
-        writer.writeheader()
-        writer.writerows(rows)
-    finally:
-        if args.output:
-            out.close()
+    if args.update is not None:
+        # Mode --update : on charge le CSV existant et on merge en préservant
+        # les autres entrées / colonnes cibles.
+        if not args.update.exists():
+            print(f"ERROR : --update CSV introuvable : {args.update}", file=sys.stderr)
+            return 2
+        existing = load_existing_csv(args.update)
+        target_notebooks = {row["notebook"] for row in rows}
+        updated_rows, stats = update_existing_csv(existing, rows, target_notebooks)
+        sink = write_csv(updated_rows, args.update)
+        print(
+            f"OK (--update) : {stats['updated']} ligne(s) rafraîchie(s), "
+            f"{stats['unchanged']} déjà in-sync, "
+            f"{stats['appended']} ajoutée(s), "
+            f"{stats['kept_orphan']} orpheline(s) "
+            f"potentielle(s), {stats['kept_other']} ligne(s) d'autres notebooks "
+            f"préservées -> {sink}",
+            file=sys.stderr,
+        )
+        if stats["kept_orphan"] > 0:
+            print(
+                f"WARNING : {stats['kept_orphan']} ligne(s) du CSV cible n'ont "
+                f"pas de cellule correspondante dans le notebook (cellules "
+                f"supprimées ?). Le check_translation_sync.py les signalera en "
+                f"ORPHAN_ROW.",
+                file=sys.stderr,
+            )
+        return 0
 
-    sink = str(args.output) if args.output else "stdout"
+    sink = write_csv(rows, args.output)
     print(
         f"OK : {len(rows)} cellules extraites de {len(notebooks)} notebook(s) -> {sink}",
         file=sys.stderr,

--- a/translations/sudoku/sudoku.csv
+++ b/translations/sudoku/sudoku.csv
@@ -1068,33 +1068,33 @@ Apres avoir resolu un Sudoku avec le backtracking, il est essentiel de verifier 
 - Utilisez `set(range(1, 10))` comme reference pour comparer chaque ligne/colonne/bloc
 - Pour acceder au bloc 3x3 : `box_row, box_col = 3 * (i // 3), 3 * (j // 3)`
 - La fonction retourne `True` si **toutes** les contraintes sont respectees, `False` sinon",,,,,,,,cda529c76030ee3f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb,faac36bc,code,fr,5f05fe47dadca6e4,"# EXERCICE : Verifier qu'une grille est valide
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb,faac36bc,code,fr,ab23c8e798bbb9ee,"# EXERCICE : Vérifier qu'une grille est valide
 
 def is_valid_solution(grid: SudokuGrid) -> bool:
-    """"""Verifie si une grille complete est une solution valide du Sudoku.
+    """"""Vérifie si une grille complète est une solution valide du Sudoku.
 
     Args:
-        grid: Grille 9x9 censee etre complete
+        grid: Grille 9x9 censée être complète
 
     Returns:
         True si la grille est une solution valide, False sinon
     """"""
-    # TODO etudiant : implementez la verification
-    # Etape 1 : Verifier qu'il n'y a pas de cases vides (0)
-    # Etape 2 : Verifier que chaque ligne contient 1-9 sans doublon
-    # Etape 3 : Verifier que chaque colonne contient 1-9 sans doublon
-    # Etape 4 : Verifier que chaque bloc 3x3 contient 1-9 sans doublon
-    return False  # TODO etudiant : remplacer par l'implementation
+    # TODO étudiant : implémentez la vérification
+    # Étape 1 : Vérifier qu'il n'y a pas de cases vides (0)
+    # Étape 2 : Vérifier que chaque ligne contient 1-9 sans doublon
+    # Étape 3 : Vérifier que chaque colonne contient 1-9 sans doublon
+    # Étape 4 : Vérifier que chaque bloc 3x3 contient 1-9 sans doublon
+    return False  # TODO étudiant : remplacer par l'implémentation
 
-# Test : la solution du puzzle de test doit etre valide
+# Test : la solution du puzzle de test doit être valide
 grid_check = SudokuGrid.from_string(test_puzzle)
 solver_check = BacktrackingSolver()
 solver_check.solve(grid_check)
 print(f""Solution valide (puzzle de test) : {is_valid_solution(grid_check)}"")  # True attendu
 
-# Test : le puzzle non resolu ne doit PAS etre valide
+# Test : le puzzle non résolu ne doit PAS être valide
 grid_unsolved = SudokuGrid.from_string(test_puzzle)
-print(f""Grille incomplete valide : {is_valid_solution(grid_unsolved)}"")  # False attendu",,,,,,,,5f05fe47dadca6e4,,,,,,,
+print(f""Grille incomplète valide : {is_valid_solution(grid_unsolved)}"")  # False attendu",,,,,,,,ab23c8e798bbb9ee,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb,939ee8ed,markdown,fr,2a328f3d752c7ca8,"## 3. Chargement des puzzles depuis fichier
 
 Les puzzles Sudoku sont stockés dans des fichiers texte, un puzzle par ligne (81 caractères représentant la grille ligne par ligne).
@@ -1502,7 +1502,7 @@ L'idee est de modifier l'algorithme de backtracking pour **ne pas s'arreter** ap
 
 - Un puzzle bien forme (1 seule solution) retourne `1`
 - Un puzzle mal forme (trous importants) peut retourner `2` ou plus",,,,,,,,489798e0af1bba91,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb,lni75htlvgp,code,fr,a75bde99de737067,"# EXERCICE : Compter le nombre de solutions
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb,lni75htlvgp,code,fr,1a75fd1cb4588159,"# EXERCICE : Compter le nombre de solutions
 
 def get_possible_values(grid: SudokuGrid, row: int, col: int) -> List[int]:
     """"""Retourne les valeurs possibles pour une case.""""""
@@ -1538,7 +1538,7 @@ def find_mrv_empty(grid: SudokuGrid) -> Optional[Tuple[int, int, List[int]]]:
                     best = (r, c, possible)
                     best_count = len(possible)
                     if best_count == 0:
-                        return best  # Echec immediat
+                        return best  # Échec immédiat
 
     return best
 
@@ -1546,27 +1546,27 @@ def count_solutions(grid: SudokuGrid, max_solutions: int = 2) -> int:
     """"""Compte le nombre de solutions d'un puzzle Sudoku.
 
     Args:
-        grid: Grille a resoudre (ne doit pas etre modifiee)
-        max_solutions: Nombre max de solutions a chercher (pour eviter les calculs infinis)
+        grid: Grille à résoudre (ne doit pas être modifiée)
+        max_solutions: Nombre max de solutions à chercher (pour éviter les calculs infinis)
 
     Returns:
-        Nombre de solutions trouvees (plafonne a max_solutions)
+        Nombre de solutions trouvées (plafonné à max_solutions)
     """"""
-    # TODO etudiant : adaptez le backtracking pour compter toutes les solutions
-    # au lieu de s'arreter a la premiere.
+    # TODO étudiant : adaptez le backtracking pour compter toutes les solutions
+    # au lieu de s'arrêter à la première.
     # Indications :
     #   1. Copiez la grille avec grid.clone()
-    #   2. Ecrivez une fonction recursive qui explore toutes les branches
-    #   3. Quand la grille est complete, retournez 1 (une solution trouvee)
-    #   4. Si nb_solutions >= max_solutions, arretez prematurely
-    #   5. Apres chaque essai, remettez la case a 0 (backtrack)
-    return 0  # TODO etudiant : remplacer par l'implementation
+    #   2. Écrivez une fonction récursive qui explore toutes les branches
+    #   3. Quand la grille est complète, retournez 1 (une solution trouvée)
+    #   4. Si nb_solutions >= max_solutions, arrêtez prematurely
+    #   5. Après chaque essai, remettez la case à 0 (backtrack)
+    return 0  # TODO étudiant : remplacer par l'implémentation
 
 
 # Test : un bon puzzle devrait avoir exactement 1 solution
 grid_to_count = SudokuGrid.from_string(easy_puzzles[0])
 nb = count_solutions(grid_to_count)
-print(f""Nombre de solutions: {nb}"")  # Doit afficher 1",,,,,,,,a75bde99de737067,,,,,,,
+print(f""Nombre de solutions: {nb}"")  # Doit afficher 1",,,,,,,,1a75fd1cb4588159,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb,319f7451,markdown,fr,991e1aaef6cf4733,"### Test de validation sur puzzle mal formé
 
 Pour vérifier que `count_solutions` explore bien toutes les branches (et ne s'arrête pas à la première solution), on le teste sur un **puzzle mal formé** : une grille très peu remplie qui admet **plusieurs solutions valides**.
@@ -1643,23 +1643,23 @@ Ce notebook a explore l'algorithme de backtracking pour la resolution de Sudoku,
 L'heuristique MRV illustre le principe ""fail-first"" fondamental en recherche : en traitant d'abord les variables les plus contraintes, on detecte les impasses plus tot et on elague massivement l'arbre de recherche. Cette lecon s'applique au-dela du Sudoku a tous les problemes de satisfaction de contraintes. Les exercices proposes (comptage de solutions, placements valides sur une colonne) approfondissent la maitrise du backtracking et de ses variantes.
 
 Le notebook suivant, [Sudoku-2-DancingLinks-Python](Sudoku-2-DancingLinks-Python.ipynb), aborde une approche radicalement differente : la reformulation du Sudoku comme probleme de couverture exacte, resolue par l'algorithme X de Knuth et la technique des Dancing Links (DLX).",,,,,,,,769286f29d486113,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,9987f17e,markdown,fr,f795d63208a65ba6,"# Sudoku-10 : Resolution avec OR-Tools (C#)
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,9987f17e,markdown,fr,9af2edcce3da94ff,"# Sudoku-10 : Résolution avec OR-Tools (C#)
 
 **Navigation** : [<< Sudoku-9 Graph Coloring C#](Sudoku-9-GraphColoring-Csharp.ipynb) | [Index](README.md) | [Sudoku-11 Choco C# >>](Sudoku-11-Choco-Csharp.ipynb)
 
 ## Objectifs d'apprentissage
 
-A la fin de ce notebook, vous saurez :
-1. Comprendre les differences entre les solveurs CSP, CP-SAT et MIP d'OR-Tools
-2. Implementer un solveur de contraintes pour le Sudoku avec `CpModel` et `AddAllDifferent`
-3. Utiliser la programmation lineaire mixte (MIP) avec une formulation 3D binaire
-4. Comparer les performances de differentes approches de resolution de contraintes
+À la fin de ce notebook, vous saurez :
+1. Comprendre les différences entre les solveurs CSP, CP-SAT et MIP d'OR-Tools
+2. Implémenter un solveur de contraintes pour le Sudoku avec `CpModel` et `AddAllDifferent`
+3. Utiliser la programmation linéaire mixte (MIP) avec une formulation 3D binaire
+4. Comparer les performances de différentes approches de résolution de contraintes
 
-### Prerequis
-- [Sudoku-1-Backtracking-Csharp](Sudoku-1-Backtracking-Csharp.ipynb) - resolution de base
+### Prérequis
+- [Sudoku-1-Backtracking-Csharp](Sudoku-1-Backtracking-Csharp.ipynb) - résolution de base
 - Notions de programmation par contraintes (variables, domaines, contraintes)
 
-### Duree estimee : 50 minutes
+### Durée estimée : 50 minutes
 
 **Voir aussi** : [CSP-1-Fondamentaux](../Search/Part2-CSP/CSP-1-Fundamentals.ipynb) pour les bases de CSP
 
@@ -1667,24 +1667,24 @@ A la fin de ce notebook, vous saurez :
 
 ## Introduction
 
-Google OR-Tools est une suite de logiciels d'optimisation developpee par Google. Elle permet de resoudre des problemes complexes d'optimisation combinatoire tels que la satisfaction de contraintes (CSP), la programmation lineaire (LP), la programmation lineaire mixte (MIP), et bien plus. Dans ce projet, nous nous concentrerons sur la resolution de Sudokus en utilisant differentes techniques fournies par OR-Tools.
+Google OR-Tools est une suite de logiciels d'optimisation développée par Google. Elle permet de résoudre des problèmes complexes d'optimisation combinatoire tels que la satisfaction de contraintes (CSP), la programmation linéaire (LP), la programmation linéaire mixte (MIP), et bien plus. Dans ce projet, nous nous concentrerons sur la résolution de Sudokus en utilisant différentes techniques fournies par OR-Tools.
 
 ### Types de Solveurs
 
 1. **Solveur de Satisfaction de Contraintes (CSP)** :
-   Ce solveur utilise des techniques de propagation de contraintes et de recherche pour trouver des solutions qui satisfont toutes les contraintes specifiees. En CSP, les utilisateurs declarent les contraintes sur les solutions faisables pour un ensemble de variables de decision.
+   Ce solveur utilise des techniques de propagation de contraintes et de recherche pour trouver des solutions qui satisfont toutes les contraintes spécifiées. En CSP, les utilisateurs déclarent les contraintes sur les solutions faisables pour un ensemble de variables de décision.
 
-2. **Solveur de Programmation Lineaire Mixte (MIP)** :
-   Ce solveur combine la programmation lineaire avec des variables entieres pour resoudre des problemes d'optimisation.
+2. **Solveur de Programmation Linéaire Mixte (MIP)** :
+   Ce solveur combine la programmation linéaire avec des variables entières pour résoudre des problèmes d'optimisation.
 
 3. **Solveur de Satisfaction de Contraintes SAT (CP-SAT)** :
-   Ce solveur est base sur un noyau SAT, utilisant des techniques avancees pour resoudre les problemes de satisfaction de contraintes.
+   Ce solveur est basé sur un noyau SAT, utilisant des techniques avancées pour résoudre les problèmes de satisfaction de contraintes.
 
 ## Installation de OR-Tools
 
-Pour utiliser OR-Tools avec C#, nous devons d'abord installer la bibliotheque.
+Pour utiliser OR-Tools avec C#, nous devons d'abord installer la bibliothèque.
 
-### Installation de OR-Tools",,,,,,,,f795d63208a65ba6,,,,,,,
+### Installation de OR-Tools",,,,,,,,9af2edcce3da94ff,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,1c9378fb,code,fr,49a460551bc67eb6,"#r ""nuget: Google.OrTools""",,,,,,,,49a460551bc67eb6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,58f7ac86,markdown,fr,03bf47fc69a84cef,"## Importation des Classes de Base
 
@@ -1797,20 +1797,20 @@ var mediumSudoku = SudokuHelper.GetSudokus(SudokuDifficulty.Medium).First();
 SudokuHelper.SolveSudoku(mediumSudoku, solver);
 var hardSudoku = SudokuHelper.GetSudokus(SudokuDifficulty.Hard).First();
 SudokuHelper.SolveSudoku(hardSudoku, solver);",,,,,,,,3360ce85b893072c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,b91e7533,markdown,fr,63eb012e79ad0768,"#### Interpretation des resultats du solveur CP
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,b91e7533,markdown,fr,2912cdcadb8cc899,"#### Interprétation des résultats du solveur CP
 
-Les trois Sudokus (facile, moyen, difficile) ont ete resolus avec succes par le solveur CP classique (0 erreur residuelle dans chaque cas), comme le montre la sortie reelle de la cellule `56a5b954` ci-dessus :
+Les trois Sudokus (facile, moyen, difficile) ont été résolus avec succès par le solveur CP classique (0 erreur résiduelle dans chaque cas), comme le montre la sortie réelle de la cellule `56a5b954` ci-dessus :
 
-| Difficulte | Statut | Temps observe (sortie reelle) |
+| Difficulté | Statut | Temps observé (sortie réelle) |
 |------------|--------|--------------------------------|
-| Facile | Resolu | 62,15 ms |
-| Moyen | Resolu | 5,21 ms |
-| Difficile | Resolu | 2,59 ms |
+| Facile | Résolu | 62,15 ms |
+| Moyen | Résolu | 5,21 ms |
+| Difficile | Résolu | 2,59 ms |
 
-**Points cles** :
-1. Le solveur CP classique resout tous les niveaux de difficulte sans erreur (0 erreur residuelle pour les trois cas).
-2. A cette echelle (tous les temps observes sont inferieurs a 65 ms), le temps **ne crot pas** avec la difficulte nominale : ici le puzzle facile est le plus lent (62,15 ms, premier appel paient le cout de chauffe du solveur : JIT .NET + initialisation de `OrToolsCPSolver`) et le puzzle difficile est le plus rapide (2,59 ms). La duree depend surtout de la grille particuliere plutot que de son etiquette de difficulte.
-3. L'approche CSP est bien adaptee au Sudoku grace aux contraintes `AllDifferent` (lignes, colonnes, regions 3x3).",,,,,,,,63eb012e79ad0768,,,,,,,
+**Points clés** :
+1. Le solveur CP classique résout tous les niveaux de difficulté sans erreur (0 erreur résiduelle pour les trois cas).
+2. À cette échelle (tous les temps observés sont inférieurs à 65 ms), le temps **ne croît pas** avec la difficulté nominale : ici le puzzle facile est le plus lent (62,15 ms, premier appel paient le coût de chauffe du solveur : JIT .NET + initialisation de `OrToolsCPSolver`) et le puzzle difficile est le plus rapide (2,59 ms). La durée dépend surtout de la grille particulière plutôt que de son étiquette de difficulté.
+3. L'approche CSP est bien adaptée au Sudoku grâce aux contraintes `AllDifferent` (lignes, colonnes, régions 3x3).",,,,,,,,2912cdcadb8cc899,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,fde6b5cb,markdown,fr,3773afaadaf01cb4,"### Solveur par contraintes SAT
 
 Le solveur de satisfaction de contraintes SAT (CP-SAT) d'OR-Tools est un outil puissant basé sur un noyau SAT, utilisant des techniques avancées pour résoudre les problèmes de satisfaction de contraintes. Le SAT (Satisfiability Testing) est le problème de décision qui consiste à déterminer si une formule booléenne peut être satisfaite. En d'autres termes, il s'agit de vérifier s'il existe une attribution des variables qui rend la formule vraie.
@@ -1927,24 +1927,24 @@ public class OrToolsSatSolver : ISudokuSolver
 
 Console.WriteLine(""Classe OrToolsSatSolver definie."");
 ",,,,,,,,3de605ff0ec3a37c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,6420602b,markdown,fr,0f3bfef59b4d7928,"### Interpretation : Implementation du solveur CP-SAT
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,6420602b,markdown,fr,8322206fb66151e1,"### Interprétation : Implémentation du solveur CP-SAT
 
-Le code presente une implementation moderne du solveur CP-SAT d'OR-Tools pour le Sudoku.
+Le code présente une implémentation moderne du solveur CP-SAT d'OR-Tools pour le Sudoku.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
-| Namespace | `Google.OrTools.Sat` | Solveur CP-SAT (different du CSP classique) |
+| Namespace | `Google.OrTools.Sat` | Solveur CP-SAT (différent du CSP classique) |
 | Variables | `IntVar` domaine [1,9] | Une variable par cellule (81 variables totales) |
-| Contraintes | `AddAllDifferent` | Unicite sur lignes, colonnes, regions 3x3 |
-| Methode | `Solve()` | Resolution avec propagation SAT |
+| Contraintes | `AddAllDifferent` | Unicité sur lignes, colonnes, régions 3x3 |
+| Méthode | `Solve()` | Résolution avec propagation SAT |
 
-**Points cles** :
+**Points clés** :
 1. **CP-SAT vs CSP** : CP-SAT utilise un moteur SAT moderne avec apprentissage de clauses (CDCL)
-2. **Modelisation compacte** : 81 variables entieres contre 729 variables binaires pour MIP
-3. **Performance** : Generalement plus rapide que CSP classique sur les problemes difficiles
-4. **Statuts de retour** : `Feasible` ou `Optimal` indiquent une solution trouvee
+2. **Modélisation compacte** : 81 variables entières contre 729 variables binaires pour MIP
+3. **Performance** : Généralement plus rapide que CSP classique sur les problèmes difficiles
+4. **Statuts de retour** : `Feasible` ou `Optimal` indiquent une solution trouvée
 
-> **Note technique** : CP-SAT est le solveur recommande pour les nouveaux projets de satisfaction de contraintes chez Google OR-Tools. Il combine la propagation de contraintes classiques avec des techniques SAT modernes.",,,,,,,,0f3bfef59b4d7928,,,,,,,
+> **Note technique** : CP-SAT est le solveur recommandé pour les nouveaux projets de satisfaction de contraintes chez Google OR-Tools. Il combine la propagation de contraintes classiques avec des techniques SAT modernes.",,,,,,,,8322206fb66151e1,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,f323f146,markdown,fr,70f51cad7f06f6ea,"### Solveur MIP (Mixed-Integer Programming)
 
 L'algorithme de programmation linéaire mixte (MIP) combine la programmation linéaire et les variables entières pour résoudre des problèmes d'optimisation. En MIP, certaines variables de décision sont contraintes à être des entiers, ce qui est particulièrement utile pour modéliser des problèmes où les décisions sont binaires ou doivent prendre des valeurs discrètes.
@@ -2089,24 +2089,24 @@ public class OrToolsMIPSolver : ISudokuSolver
 
 Console.WriteLine(""Classe OrToolsMIPSolver definie."");
 ",,,,,,,,400da0362fed3a50,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,baeebaf0,markdown,fr,80a40383c879bbc4,"### Interpretation : Implementation du solveur MIP
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,baeebaf0,markdown,fr,896ad1607fdfb5c9,"### Interprétation : Implémentation du solveur MIP
 
-Le code presente une implementation de la programmation lineaire mixte (MIP) pour le Sudoku, utilisant une formulation 3D binaire.
+Le code présente une implémentation de la programmation linéaire mixte (MIP) pour le Sudoku, utilisant une formulation 3D binaire.
 
 | Aspect | Valeur | Signification |
 |--------|--------|---------------|
-| Namespace | `Google.OrTools.LinearSolver` | Solveur MIP (different de CSP/SAT) |
+| Namespace | `Google.OrTools.LinearSolver` | Solveur MIP (différent de CSP/SAT) |
 | Variables | `Variable[9,9,9]` binaires | 729 variables (une par cellule/valeur possible) |
-| Contraintes | Sommes == 1 | Une valeur par cellule, une occurrence par ligne/colonne/region |
-| Methode | `Solve()` | Resolution par branch-and-bound + relaxation lineaire |
+| Contraintes | Sommes == 1 | Une valeur par cellule, une occurrence par ligne/colonne/région |
+| Méthode | `Solve()` | Résolution par branch-and-bound + relaxation linéaire |
 
-**Points cles** :
+**Points clés** :
 1. **Formulation binaire 3D** : `cells[i,j,k] = 1` signifie que la cellule (i,j) contient la valeur k
-2. **Contrainte d'unicite par cellule** : Somme sur k de `cells[i,j,k] == 1` pour tout (i,j)
-3. **Contraintes d'unicite par ligne/colonne/region** : Pour chaque valeur k, une seule occurrence
-4. **Extraction de la solution** : Trouver l'indice k ou `cells[i,j,k] == 1`
+2. **Contrainte d'unicité par cellule** : Somme sur k de `cells[i,j,k] == 1` pour tout (i,j)
+3. **Contraintes d'unicité par ligne/colonne/région** : Pour chaque valeur k, une seule occurrence
+4. **Extraction de la solution** : Trouver l'indice k où `cells[i,j,k] == 1`
 
-> **Note technique** : Cette formulation MIP est moins efficace pour le Sudoku (729 variables vs 81 pour CSP/SAT), mais elle generalise bien aux problemes d'optimisation avec une fonction objectif (ex: minimiser le nombre de changements par rapport a une grille initiale).",,,,,,,,80a40383c879bbc4,,,,,,,
+> **Note technique** : Cette formulation MIP est moins efficace pour le Sudoku (729 variables vs 81 pour CSP/SAT), mais elle généralise bien aux problèmes d'optimisation avec une fonction objectif (ex: minimiser le nombre de changements par rapport à une grille initiale).",,,,,,,,896ad1607fdfb5c9,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,f42e724a,markdown,fr,07ced59e02e2e71a,"## Comparaison des Performances des Solveurs
 
 Nous allons tester nos solveurs implémentés sur des grilles de Sudoku de différentes difficultés : Facile, Moyen et Difficile. Nous mesurerons également le temps de résolution et vérifierons la validité des solutions trouvées. 
@@ -2190,47 +2190,47 @@ foreach (var solverType in mipSolverTypes)
 var results = SudokuHelper.TestSolvers(solvers);
 SudokuHelper.DisplayResults(results);
 ",,,,,,,,f70b2168fe3287e0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,7ca6fb47,markdown,fr,f27edca587014db0,"### Interpretation des resultats de performance
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,7ca6fb47,markdown,fr,3087280a8a16c2c5,"### Interprétation des résultats de performance
 
-> **Note de lecture** : la cellule de benchmark ci-dessus a bien ete executee (`execution_count: 9` dans le notebook), mais seule la premiere ligne de la sortie (`Running tests...`) a ete preservee a l'enregistrement. Le tableau complet produit par `DisplayResults(results)` (8 solveurs x 3 niveaux de difficulte x N puzzles = plusieurs centaines de lignes) n'a pas ete capture dans le champ `outputs` de la cellule, vraisemblablement parce que le runner `.NET Interactive` tronque les sorties dont la taille depasse un certain seuil. L'etat reel au moment de l'execution est donc : **benchmark reellement execute, sortie complete perdue a la capture**, et non « benchmark non execute ».
+> **Note de lecture** : la cellule de benchmark ci-dessus a bien été exécutée (`exécution_count: 9` dans le notebook), mais seule la première ligne de la sortie (`Running tests...`) a été préservée à l'enregistrement. Le tableau complet produit par `DisplayResults(results)` (8 solveurs x 3 niveaux de difficulté x N puzzles = plusieurs centaines de lignes) n'a pas été capturée dans le champ `outputs` de la cellule, vraisemblablement parce que le runner `.NET Interactive` tronque les sorties dont la taille dépasse un certain seuil. L'état réel au moment de l'exécution est donc : **benchmark réellement exécuté, sortie complète perdue à la capture**, et non « benchmark non exécuté ».
 >
-> Les observations ci-dessous refletent le **comportement qualitatif observe** sur des instances similaires (et les chiffres reels que la cellule `56a5b954` ci-dessus, qui capture integralement sa sortie, permet de corroborer pour la strategie `OrToolsCPSolver`) :
+> Les observations ci-dessous reflètent le **comportement qualitatif observé** sur des instances similaires (et les chiffres réels que la cellule `56a5b954` ci-dessus, qui capture intégralement sa sortie, permet de corroborer pour la stratégie `OrToolsCPSolver`) :
 
 | Aspect | Observation | Signification |
 |--------|-------------|---------------|
-| Solveurs CP | Performances variables selon la strategie (cf `56a5b954`) | Le choix du DecisionBuilder impacte significativement la resolution |
-| Solveur CP-SAT | Generalement plus rapide sur problemes difficiles | La modelisation SAT offre une meilleure propagation des contraintes |
-| Solveurs MIP | Temps de resolution plus eleves | La formulation 3D binaire introduit plus de variables (729 vs 81) |
+| Solveurs CP | Performances variables selon la stratégie (cf `56a5b954`) | Le choix du DecisionBuilder impacte significativement la résolution |
+| Solveur CP-SAT | Généralement plus rapide sur problèmes difficiles | La modélisation SAT offre une meilleure propagation des contraintes |
+| Solveurs MIP | Temps de résolution plus élevés | La formulation 3D binaire introduit plus de variables (729 vs 81) |
 
-**Points cles** :
-1. **CP-SAT** est generalement le plus efficace pour les Sudoku difficiles grace a son moteur SAT moderne (apprentissage de clauses CDCL).
-2. **Le parametrage** des solveurs CP (strategie de selection de variables) influence notablement les performances : cf `56a5b954` ci-dessus, ou `OrToolsCPSolver` resout trois difficultes avec des temps tres differents (62,15 / 5,21 / 2,59 ms sur easy / medium / hard) selon la grille particuliere, independamment de l'etiquette de difficulte.
-3. **MIP** est moins adapte ici car la formulation binaire 3D augmente considerablement la taille du probleme (729 variables vs 81 pour CSP/SAT) ; il brille quand une fonction objectif est requise (ex : minimiser le nombre de changements par rapport a une grille initiale).
+**Points clés** :
+1. **CP-SAT** est généralement le plus efficace pour les Sudoku difficiles grâce à son moteur SAT moderne (apprentissage de clauses CDCL).
+2. **Le paramétrage** des solveurs CP (stratégie de sélection de variables) influence notablement les performances : cf `56a5b954` ci-dessus, où `OrToolsCPSolver` résout trois difficultés avec des temps très différents (62,15 / 5,21 / 2,59 ms sur easy / medium / hard) selon la grille particulière, indépendamment de l'étiquette de difficulté.
+3. **MIP** est moins adapté ici car la formulation binaire 3D augmente considérablement la taille du problème (729 variables vs 81 pour CSP/SAT) ; il brille quand une fonction objectif est requise (ex : minimiser le nombre de changements par rapport à une grille initiale).
 
-> **Note methodologique** : pour recuperer le tableau complet du benchmark 8 solveurs, il faudrait (a) executer `18307c5b` dans une session .NET Interactive interactive (VS Code ou Jupyter Lab) et copier la sortie vers le presse-papier, ou (b) instrumenter `SudokuHelper.DisplayResults` pour ecrire dans un fichier plutot que sur stdout. Cette amelioration est **hors scope** de la PR Phase 2 #4940 (P2 prose consacrante) et pourra etre traitee dans un suivi dedie.
+> **Note méthodologique** : pour récupérer le tableau complet du benchmark 8 solveurs, il faudrait (a) exécuter `18307c5b` dans une session .NET Interactive interactive (VS Code ou Jupyter Lab) et copier la sortie vers le presse-papier, ou (b) instrumenter `SudokuHelper.DisplayResults` pour écrire dans un fichier plutôt que sur stdout. Cette amélioration est **hors scope** de la PR Phase 2 #4940 (P2 prose consacrante) et pourra être traitée dans un suivi dédié.
 >
-> **Note technique** : Pour les problemes de satisfaction de contraintes pures comme le Sudoku, CP-SAT est souvent preferable aux solveurs MIP.",,,,,,,,f27edca587014db0,,,,,,,
+> **Note technique** : Pour les problèmes de satisfaction de contraintes pures comme le Sudoku, CP-SAT est souvent préférable aux solveurs MIP.",,,,,,,,3087280a8a16c2c5,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,3f30ed8a,markdown,fr,50b465e8e39fec87,"### Conclusion Générale
 
 Les résultats des tests de performance montrent une distinction claire entre les solveurs simples plus efficaces sur les problèmes simples et et les solveurs plus sophistiqués qui passent devant sur les problèmes plus difficiles.
 
 Une observation clé de cette analyse est l'importance de la paramétrisation des solveurs. Les différents types de solveurs MIP et les stratégies de sélection de variables et de valeurs des solveurs CP peuvent considérablement influencer les performances. Par conséquent, il est crucial de sélectionner et de paramétrer les solveurs en fonction de la nature spécifique du problème à résoudre.",,,,,,,,50b465e8e39fec87,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,52003c86,markdown,fr,b1d1bbd58e8a598e,"## Exercices
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,52003c86,markdown,fr,6f5b5ac0f9b0c7d9,"## Exercices
 
-### Exercice 1 : Comparaison des strategies de selection de variables
+### Exercice 1 : Comparaison des stratégies de sélection de variables
 
-Le solveur CP d'OR-Tools permet de parametrer la strategie de selection des variables (`VariableSelectionStrategy`) et des valeurs (`ValueSelectionStrategy`). Ces choix ont un impact significatif sur les performances.
+Le solveur CP d'OR-Tools permet de paramétrer la stratégie de sélection des variables (`VariableSelectionStrategy`) et des valeurs (`ValueSelectionStrategy`). Ces choix ont un impact significatif sur les performances.
 
-**Objectif** : Comparer differentes combinaisons de strategies et mesurer leur impact sur les temps de resolution.
+**Objectif** : Comparer différentes combinaisons de stratégies et mesurer leur impact sur les temps de résolution.
 
 **Indices** :
-1. Boucle imbriquee sur `varStrategies` et `valStrategies`
-2. Pour chaque combinaison, creer un `OrToolsCPSolver` avec les deux strategies
-3. Mesurer le temps moyen de resolution sur 3 puzzles difficiles
-4. Les strategies `CHOOSE_MIN_SIZE*` selectionnent la variable avec le domaine le plus restreint (similaire a MRV) : generalement plus performantes
+1. Boucle imbriquée sur `varStrategies` et `valStrategies`
+2. Pour chaque combinaison, créer un `OrToolsCPSolver` avec les deux stratégies
+3. Mesurer le temps moyen de résolution sur 3 puzzles difficiles
+4. Les stratégies `CHOOSE_MIN_SIZE*` sélectionnent la variable avec le domaine le plus restreint (similaire à MRV) : généralement plus performantes
 
-**Verification** : Affichez les resultats tries par temps croissant.",,,,,,,,b1d1bbd58e8a598e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,328eaa59,code,fr,4c06bbfc6eb389a7,"// Exemple guide 1 : Comparaison des strategies de selection de variables OR-Tools
+**Vérification** : Affichez les résultats triés par temps croissant.",,,,,,,,6f5b5ac0f9b0c7d9,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,328eaa59,code,fr,809db8c554f9653b,"// Exemple guide 1 : Comparaison des stratégies de sélection de variables OR-Tools
 using System.Diagnostics;
 using System.Linq;
 
@@ -2252,33 +2252,33 @@ var valStrategies = new (string Name, int Strategy)[]
 
 var hardPuzzles3 = SudokuHelper.GetSudokus(SudokuDifficulty.Hard).Take(3).ToList();
 
-// TODO : Creer une boucle imbriquee sur varStrategies et valStrategies
+// TODO : Créer une boucle imbriquée sur varStrategies et valStrategies
 // Pour chaque combinaison (varStrat, valStrat) :
 //   var solver = new OrToolsCPSolver
 //   {
 //       VariableSelectionStrategy = varStrat.Strategy,
 //       ValueSelectionStrategy = valStrat.Strategy
 //   };
-//   Mesurer le temps moyen sur hardPuzzles3 et stocker le resultat
+//   Mesurer le temps moyen sur hardPuzzles3 et stocker le résultat
 
-// TODO : Afficher les resultats tries par temps croissant
+// TODO : Afficher les résultats tries par temps croissant
 
 Console.WriteLine(""Exercice a completer"");
-",,,,,,,,4c06bbfc6eb389a7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,7d56706f,markdown,fr,4944ecd8498ba0d8,"### Exercice 2 : Implémenter le Sudoku X (avec diagonales)
+",,,,,,,,809db8c554f9653b,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,7d56706f,markdown,fr,441417387d1e2ba8,"### Exercice 2 : Implémenter le Sudoku X (avec diagonales)
 
-Le **Sudoku X** est une variante ou les deux diagonales principales doivent contenir tous les chiffres 1-9.
+Le **Sudoku X** est une variante où les deux diagonales principales doivent contenir tous les chiffres 1-9.
 
-**Objectif** : Creer `SudokuXCPSATSolver` en ajoutant des contraintes de diagonale au solveur CP-SAT.
+**Objectif** : Créer `SudokuXCPSATSolver` en ajoutant des contraintes de diagonale au solveur CP-SAT.
 
 **Indices** :
-1. Creer un `CpModel` et les variables comme dans `OrToolsSatSolver`
-2. La diagonale principale : cellules `grid[i, i]` pour i de 0 a 8
-3. L'anti-diagonale : cellules `grid[i, 8-i]` pour i de 0 a 8
+1. Créer un `CpModel` et les variables comme dans `OrToolsSatSolver`
+2. La diagonale principale : cellules `grid[i, i]` pour i de 0 à 8
+3. L'anti-diagonale : cellules `grid[i, 8-i]` pour i de 0 à 8
 4. Utiliser `model.AddAllDifferent()` sur chaque diagonale
 
-> La plupart des puzzles Sudoku normaux n'ont pas de solution valide avec contraintes de diagonale. Verifiez le fonctionnement sans diagonales d'abord.",,,,,,,,4944ecd8498ba0d8,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,f4f6b873,code,fr,8918bf9d08ccb86e,"// EXERCICE 2 : Sudoku X avec contraintes de diagonale (CP-SAT)
+> La plupart des puzzles Sudoku normaux n'ont pas de solution valide avec contraintes de diagonale. Vérifiez le fonctionnement sans diagonales d'abord.",,,,,,,,441417387d1e2ba8,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,f4f6b873,code,fr,186f380db3444c77,"// EXERCICE 2 : Sudoku X avec contraintes de diagonale (CP-SAT)
 using Google.OrTools.Sat;
 
 public class SudokuXCPSATSolver : ISudokuSolver
@@ -2290,7 +2290,7 @@ public class SudokuXCPSATSolver : ISudokuSolver
         var model = new CpModel();
         var grid = new SatIntVar[Dimension, Dimension];
 
-        // Creer les variables
+        // Créer les variables
         for (int i = 0; i < Dimension; i++)
             for (int j = 0; j < Dimension; j++)
             {
@@ -2309,24 +2309,24 @@ public class SudokuXCPSATSolver : ISudokuSolver
         // model.AddAllDifferent(antiDiag);
 
         Console.WriteLine(""Exercice a completer"");
-        return inputGrid; // TODO etudiant : retourner la grille resolue par CP-SAT
+        return inputGrid; // TODO etudiant : retourner la grille résolue par CP-SAT
     }
 }
 
 Console.WriteLine(""TODO : Implementez SudokuXCPSATSolver avec les contraintes de diagonale"");
-",,,,,,,,8918bf9d08ccb86e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,a439535d,markdown,fr,bb48de26232df284,"### Exercice 3 : Comparer CSP, CP-SAT et MIP sur un puzzle difficile
+",,,,,,,,186f380db3444c77,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,a439535d,markdown,fr,b0b211aee7a279da,"### Exercice 3 : Comparer CSP, CP-SAT et MIP sur un puzzle difficile
 
-Le notebook presente trois approches OR-Tools : CSP classique, CP-SAT, et MIP. Analysez leurs differences de performance.
+Le notebook présente trois approches OR-Tools : CSP classique, CP-SAT, et MIP. Analysez leurs différences de performance.
 
-**Objectif** : Comparer les trois solveurs sur un puzzle difficile et analyser pourquoi leurs performances different.
+**Objectif** : Comparer les trois solveurs sur un puzzle difficile et analyser pourquoi leurs performances différent.
 
 **Indices** :
-1. Creer les trois solveurs : `OrToolsCPSolver`, `OrToolsSatSolver`, `OrToolsMIPSolver`
-2. Chronometrer la resolution pour chaque solveur sur le meme puzzle difficile
-3. CP-SAT est generalement le plus rapide (CDCL, apprentissage de clauses)
-4. MIP est plus lent : formulation binaire 3D avec 729 variables vs 81 pour CSP/SAT",,,,,,,,bb48de26232df284,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,cfc8e85e,code,fr,ebef973ff661c480,"// Exemple guide 3 : Comparaison CSP vs CP-SAT vs MIP
+1. Créer les trois solveurs : `OrToolsCPSolver`, `OrToolsSatSolver`, `OrToolsMIPSolver`
+2. Chronométrer la résolution pour chaque solveur sur le même puzzle difficile
+3. CP-SAT est généralement le plus rapide (CDCL, apprentissage de clauses)
+4. MIP est plus lent : formulation binaire 3D avec 729 variables vs 81 pour CSP/SAT",,,,,,,,b0b211aee7a279da,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,cfc8e85e,code,fr,5a8e251db47177d9,"// Exemple guide 3 : Comparaison CSP vs CP-SAT vs MIP
 using System.Diagnostics;
 
 var hardPuzzle1 = SudokuHelper.GetSudokus(SudokuDifficulty.Hard).First();
@@ -2334,7 +2334,7 @@ Console.WriteLine(""Puzzle difficile :"");
 Console.WriteLine(hardPuzzle1);
 Console.WriteLine();
 
-// TODO : Tester les trois solveurs et mesurer le temps de resolution
+// TODO : Tester les trois solveurs et mesurer le temps de résolution
 // var solversToCompare = new (string Name, ISudokuSolver Solver)[]
 // {
 //     (""CSP Classique"", new OrToolsCPSolver()),
@@ -2352,23 +2352,23 @@ Console.WriteLine();
 //     Console.WriteLine($""{name,-20} | {sw.ElapsedMilliseconds,-12} | OK"");
 // }
 
-Console.WriteLine(""TODO : Implementez la comparaison CSP vs CP-SAT vs MIP"");",,,,,,,,ebef973ff661c480,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,571a5cef,markdown,fr,79008668aeb96079,"## Exercice : Solveur OR-Tools pour le probleme des N-Reines
+Console.WriteLine(""TODO : Implementez la comparaison CSP vs CP-SAT vs MIP"");",,,,,,,,5a8e251db47177d9,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,571a5cef,markdown,fr,062d8e4deb0235d0,"## Exercice : Solveur OR-Tools pour le problème des N-Reines
 
-### Enonce
+### Énoncé
 
-Le probleme des N-Reines demande de placer N reines sur un echiquier N×N sans qu'aucune ne s'attaque. Implementez un solveur CP-SAT pour ce probleme en adaptant la modelisation du Sudoku :
+Le problème des N-Reines demande de placer N reines sur un échiquier N×N sans qu'aucune ne s'attaque. Implémentez un solveur CP-SAT pour ce problème en adaptant la modélisation du Sudoku :
 
-1. Creez N variables entiere `queen[i]` representant la colonne de la reine de la ligne i (domaine 0..N-1)
-2. Ajoutez les contraintes d'unicite pour les colonnes (AllDifferent sur `queen`)
-3. Ajoutez les contraintes de diagonales : les reines ne doivent pas etre sur la meme diagonale
+1. Créez N variables entière `queen[i]` représentant la colonne de la reine de la ligne i (domaine 0..N-1)
+2. Ajoutez les contraintes d'unicité pour les colonnes (AllDifferent sur `queen`)
+3. Ajoutez les contraintes de diagonales : les reines ne doivent pas être sur la même diagonale
 4. Comptez le nombre de solutions pour N=8 (attendu : 92)
 
 **Indice :**
 
-Pour les diagonales, deux reines aux positions (i, queen[i]) et (j, queen[j]) sont en conflit si `queen[i] - queen[j] == i - j` (diagonale principale) ou `queen[i] - queen[j] == j - i` (diagonale secondaire). Ces contraintes peuvent s'exprimer avec `model.Add(queen[i] - queen[j] != i - j)` pour tous les couples (i, j).",,,,,,,,79008668aeb96079,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,78048935,code,fr,1c83c4dceb550e6b,"// EXERCICE : Probleme des N-Reines avec OR-Tools CP-SAT
-// TODO: Implementez un solveur pour compter les solutions du probleme des N-Reines
+Pour les diagonales, deux reines aux positions (i, queen[i]) et (j, queen[j]) sont en conflit si `queen[i] - queen[j] == i - j` (diagonale principale) ou `queen[i] - queen[j] == j - i` (diagonale secondaire). Ces contraintes peuvent s'exprimer avec `model.Add(queen[i] - queen[j] != i - j)` pour tous les couples (i, j).",,,,,,,,062d8e4deb0235d0,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,78048935,code,fr,bc62d332637bd62a,"// EXERCICE : Problème des N-Reines avec OR-Tools CP-SAT
+// TODO: Implémentez un solveur pour compter les solutions du problème des N-Reines
 
 using Google.OrTools.Sat;
 
@@ -2385,12 +2385,12 @@ public class NQueensCPSATSolver
     {
         var model = new CpModel();
 
-        // TODO: Creer les variables queen[i] pour chaque ligne i (domaine 0..N-1)
+        // TODO: Créer les variables queen[i] pour chaque ligne i (domaine 0..N-1)
         // var queens = new IntVar[N];
         // for (int i = 0; i < N; i++)
         //     queens[i] = model.NewIntVar(0, N - 1, $""queen_{i}"");
 
-        // TODO: Contrainte de colonnes : toutes les reines dans des colonnes differentes
+        // TODO: Contrainte de colonnes : toutes les reines dans des colonnes différentes
         // model.AddAllDifferent(queens);
 
         // TODO: Contraintes de diagonales
@@ -2402,33 +2402,33 @@ public class NQueensCPSATSolver
         // Classe CpSolverSolutionCallback pour enumerer toutes les solutions
 
         Console.WriteLine(""Exercice a completer"");
-        return 0; // TODO etudiant : retourner le nombre de solutions trouvees
+        return 0; // TODO etudiant : retourner le nombre de solutions trouvées
     }
 }
 
-// Test de votre implementation
+// Test de votre implémentation
 int N = 8;
 var nQueens = new NQueensCPSATSolver(N);
 // int solutions = nQueens.CountSolutions();
 // Console.WriteLine($""Nombre de solutions pour {N}-Reines : {solutions}"");
 // Console.WriteLine($""Attendu : 92"");
 Console.WriteLine($""TODO: Implementez NQueensCPSATSolver.CountSolutions() pour le probleme des {N}-Reines"");
-",,,,,,,,1c83c4dceb550e6b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,f3c72f85,markdown,fr,2db8f582e545dd8e,"### A retenir
+",,,,,,,,bc62d332637bd62a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,f3c72f85,markdown,fr,1fd91357bc58335e,"### À retenir
 
-OR-Tools propose **trois paradigmes** pour modeliser Sudoku :
+OR-Tools propose **trois paradigmes** pour modéliser Sudoku :
 
-| Paradigme | Variables | Solveur | Temps observe (sortie reelle `56a5b954`) |
+| Paradigme | Variables | Solveur | Temps observé (sortie réelle `56a5b954`) |
 |-----------|-----------|---------|------------------------------------------|
 | **CSP classique** | 81 IntVar | ConstraintSolver | 2,59 - 62,15 ms (selon la grille) |
 | **CP-SAT** | 81 IntVar | SAT + CDCL | Le plus rapide (canonique) |
 | **MIP** | 729 binaires | Branch-and-bound | Le plus lourd (729 variables) |
 
-**Points cles** :
-1. **CP-SAT** (Google) est le solveur recommande pour les nouveaux projets CSP : apprentissage de clauses (CDCL), performance optimale.
-2. La **strategie de selection** (CHOOSE_MIN_SIZE = analogie MRV) impacte significativement les performances du solveur CP. Les chiffres ci-dessus (cellule `56a5b954`) le demontrent : sur un meme solveur `OrToolsCPSolver`, les temps varient d'un facteur ~24 entre les trois difficultes (62,15 / 5,21 / 2,59 ms), principalement a cause du cout de chauffe JIT lors du premier appel.
-3. Le MIP (729 variables binaires 3D) est surdimensionne pour Sudoku sans fonction objectif : il brille quand une optimisation est requise.
-4. La modelisation **N-Reines** (N=8, 92 solutions) generalise les memes techniques CSP.",,,,,,,,2db8f582e545dd8e,,,,,,,
+**Points clés** :
+1. **CP-SAT** (Google) est le solveur recommandé pour les nouveaux projets CSP : apprentissage de clauses (CDCL), performance optimale.
+2. La **stratégie de sélection** (CHOOSE_MIN_SIZE = analogie MRV) impacte significativement les performances du solveur CP. Les chiffres ci-dessus (cellule `56a5b954`) le démontrent : sur un même solveur `OrToolsCPSolver`, les temps varient d'un facteur ~24 entre les trois difficultés (62,15 / 5,21 / 2,59 ms), principalement à cause du coût de chauffe JIT lors du premier appel.
+3. Le MIP (729 variables binaires 3D) est surdimensionné pour Sudoku sans fonction objectif : il brille quand une optimisation est requise.
+4. La modélisation **N-Reines** (N=8, 92 solutions) généralise les mêmes techniques CSP.",,,,,,,,1fd91357bc58335e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,4b8e695f,markdown,fr,423169cb29a19105,"---
 
 **Navigation** : [<< Sudoku-9 Graph Coloring C#](Sudoku-9-GraphColoring-Csharp.ipynb) | [Index](README.md) | [Sudoku-11 Choco C# >>](Sudoku-11-Choco-Csharp.ipynb)
@@ -4759,7 +4759,7 @@ Console.WriteLine(""Classe Z3IntSolverSimple definie (solveur Z3 avec entiers)""
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,demo-int-md,markdown,fr,50d285be24a5c46f,"#### Démonstration : résoudre une vraie grille avec l'encodage entier
 
 Avant de comparer les performances, vérifions que le solveur produit bien une grille valide. On charge une grille *facile*, on l'affiche (les `0` marquent les cases à remplir), puis on la résout avec `Z3IntSolverSimple`. La sortie montre la grille de départ, la grille complète, et le nombre d'erreurs restantes : `0` confirme une solution correcte.",,,,,,,,50d285be24a5c46f,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,demo-int-code,code,fr,cc201ad96fbe3697,"// Demonstration : charger une grille reelle, la resoudre et comparer avant / apres.
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,demo-int-code,code,fr,977449ed9abe5814,"// Demonstration : charger une grille réelle, la résoudre et comparer avant / après.
 var puzzleDemo = SudokuHelper.GetSudokus(SudokuDifficulty.Easy)[0];
 Console.WriteLine(""Grille initiale (les 0 sont les cases a remplir) :"");
 Console.WriteLine(puzzleDemo);
@@ -4767,7 +4767,7 @@ Console.WriteLine(puzzleDemo);
 var solvedInt = new Z3IntSolverSimple().Solve(puzzleDemo);
 Console.WriteLine(""Grille resolue par Z3IntSolverSimple :"");
 Console.WriteLine(solvedInt);
-Console.WriteLine($""Nombre d'erreurs restantes (0 = grille valide) : {solvedInt.NbErrors(puzzleDemo)}"");",,,,,,,,cc201ad96fbe3697,,,,,,,
+Console.WriteLine($""Nombre d'erreurs restantes (0 = grille valide) : {solvedInt.NbErrors(puzzleDemo)}"");",,,,,,,,977449ed9abe5814,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,dbdb820e,markdown,fr,8b8fbe1a2d843ebd,"### 2. Utilisation de vecteurs de bits
 
 Nous allons maintenant explorer une autre piste d'amélioration en utilisant des vecteurs de bits pour représenter les cellules du Sudoku. Cette approche peut réduire la taille des variables et améliorer les performances du solver.
@@ -4954,7 +4954,7 @@ Console.WriteLine(""Classe Z3BitVectorSolverSimple definie (solveur Z3 BitVector
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,demo-bv-md,markdown,fr,aea46e4c72c55de1,"#### Démonstration : la même grille avec l'encodage en vecteurs de bits
 
 L'encodage précédent représente chaque case par un entier ; celui-ci la représente par un **vecteur de bits** de 4 bits. On résout la même grille facile pour vérifier que ce second encodage aboutit lui aussi à une solution valide.",,,,,,,,aea46e4c72c55de1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,demo-bv-code,code,fr,86160b61063fd9e8,"// Demonstration : le meme puzzle, resolu cette fois par l'encodage en vecteurs de bits.
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,demo-bv-code,code,fr,7645a5be6d9ded84,"// Demonstration : le même puzzle, résolu cette fois par l'encodage en vecteurs de bits.
 var puzzleDemoBv = SudokuHelper.GetSudokus(SudokuDifficulty.Easy)[0];
 Console.WriteLine(""Grille initiale :"");
 Console.WriteLine(puzzleDemoBv);
@@ -4962,7 +4962,7 @@ Console.WriteLine(puzzleDemoBv);
 var solvedBv = new Z3BitVectorSolverSimple().Solve(puzzleDemoBv);
 Console.WriteLine(""Grille resolue par Z3BitVectorSolverSimple :"");
 Console.WriteLine(solvedBv);
-Console.WriteLine($""Nombre d'erreurs restantes (0 = grille valide) : {solvedBv.NbErrors(puzzleDemoBv)}"");",,,,,,,,86160b61063fd9e8,,,,,,,
+Console.WriteLine($""Nombre d'erreurs restantes (0 = grille valide) : {solvedBv.NbErrors(puzzleDemoBv)}"");",,,,,,,,7645a5be6d9ded84,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,326bf677,markdown,fr,d4cd652b1e180279,"### 4. Utilisation de l'API de substitution avec vecteurs de bits
 
 Nous allons implémenter une classe utilisant l'API de substitution. Cette approche peut améliorer les performances en réutilisant les contraintes génériques et en substituant uniquement les valeurs spécifiques à la grille de Sudoku en cours de résolution.
@@ -5097,10 +5097,10 @@ Console.WriteLine(""Classe Z3BitSub_Tactic definie (solveur Z3 avec tactiques)""
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,008967cc,markdown,fr,b38563af9f9d71b7,"### 6. Comparaison des solveurs
 
 Pour comparer les différentes implémentations de solveurs, nous utiliserons une approche similaire à celle de notre notebook OR-Tools. Nous évaluerons les performances de chaque solver sur des puzzles de Sudoku de différentes difficultés (Facile, Moyen, Difficile).",,,,,,,,b38563af9f9d71b7,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,9d27fc52,code,fr,7e9632b285be516a,"// Comparaison des quatre encodages Z3 sur des grilles reelles.
-// Budget borne pour un temps d'execution raisonnable : 3 grilles par difficulte, 3 s max par grille.
-// Les grilles ""Hard"" (top95) peuvent depasser ce budget pour certains encodages : un depassement
-// (statut ""Timeout"" / ""Disqualified"") est alors un resultat en soi, pas une erreur.
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,9d27fc52,code,fr,cc787dd83eded4f6,"// Comparaison des quatre encodages Z3 sur des grilles réelles.
+// Budget borne pour un temps d'exécution raisonnable : 3 grilles par difficulté, 3 s max par grille.
+// Les grilles ""Hard"" (top95) peuvent dépasser ce budget pour certains encodages : un dépassement
+// (statut ""Timeout"" / ""Disqualified"") est alors un résultat en soi, pas une erreur.
 var solvers = new List<(string Name, ISudokuSolver Solver)>
 {
     (""Z3 Int Solver Simple"", new Z3IntSolverSimple()),
@@ -5111,13 +5111,13 @@ var solvers = new List<(string Name, ISudokuSolver Solver)>
 
 var results = SudokuHelper.TestSolvers(solvers, numberOfSudokus: 3, timeLimitMilliseconds: 3000);
 
-// Tableau texte des resultats (committe dans le notebook ; les graphiques Plotly ci-dessous sont interactifs).
+// Tableau texte des résultats (committe dans le notebook ; les graphiques Plotly ci-dessous sont interactifs).
 Console.WriteLine(String.Format(""{0,-36} {1,-10} {2,12} {3,8}  {4}"", ""Encodage"", ""Difficulte"", ""Temps (ms)"", ""Resolus"", ""Statut""));
 Console.WriteLine(new string('-', 84));
 foreach (var r in results)
     Console.WriteLine(String.Format(""{0,-36} {1,-10} {2,12:F1} {3,8}  {4}"", r.SolverName, r.Difficulty, r.Time, r.SolvedCount, r.Status));
 
-SudokuHelper.DisplayResults(results);",,,,,,,,7e9632b285be516a,,,,,,,
+SudokuHelper.DisplayResults(results);",,,,,,,,cc787dd83eded4f6,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,8af4bf6c,markdown,fr,a70c0e27ccc96ceb,"### Interprétation des résultats
 
 La cellule précédente lance le banc d'essai comparatif (`TestSolvers` + `DisplayResults`) sur trois niveaux de difficulté, avec un budget borné (3 grilles par difficulté, 3 s max par grille) afin que la comparaison tienne dans un temps raisonnable. Le tableau texte capture les temps de résolution réels ; les graphiques Plotly, eux, restent interactifs et ne sont pas sérialisés dans le notebook.
@@ -5164,7 +5164,7 @@ Le **Sudoku X** est une variante où les deux diagonales principales doivent ég
 4. `ctx` et `CellVariables` sont accessibles statiquement depuis la classe de base
 
 **Vérification** : Vérifiez d'abord avec `EnforceDiagonals = false` (comportement identique au solveur de base).",,,,,,,,614cf0acc378ced3,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,bb6ac47c,code,fr,fa95066564448387,"// Exercice 1 : Sudoku X avec contraintes de diagonale (Z3 BitVector)
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,bb6ac47c,code,fr,65f097eca0130f64,"// Exercice 1 : Sudoku X avec contraintes de diagonale (Z3 BitVector)
 using Microsoft.Z3;
 
 public class SudokuXZ3Solver : Z3BitVectorSolverBase
@@ -5191,7 +5191,7 @@ public class SudokuXZ3Solver : Z3BitVectorSolverBase
             // solver.Assert(ctx.MkDistinct(antiDiag));
         }
 
-        // TODO : Ajouter les contraintes du puzzle et resoudre
+        // TODO : Ajouter les contraintes du puzzle et résoudre
         // solver.Assert(GetPuzzleConstraints(grid));
         // if (solver.Check() == Status.SATISFIABLE) { ... extraire la solution ... }
 
@@ -5199,7 +5199,7 @@ public class SudokuXZ3Solver : Z3BitVectorSolverBase
     }
 }
 
-Console.WriteLine(""TODO : Implementez SudokuXZ3Solver avec les contraintes de diagonale"");",,,,,,,,fa95066564448387,,,,,,,
+Console.WriteLine(""TODO : Implementez SudokuXZ3Solver avec les contraintes de diagonale"");",,,,,,,,65f097eca0130f64,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,713807d9,markdown,fr,e3ea155c0e189264,"### Exercice 2 : Vérifier l'unicité d'une solution avec Z3
 
 Z3 permet de chercher toutes les solutions en ajoutant progressivement des contraintes d'exclusion.
@@ -5214,14 +5214,14 @@ Z3 permet de chercher toutes les solutions en ajoutant progressivement des contr
 4. Technique appelée ""exclusion de modèle"" (model blocking)
 
 **Vérification** : Testez sur un puzzle facile (solution unique attendue).",,,,,,,,e3ea155c0e189264,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,5e3f4e98,code,fr,5fa1fb689d97520c,"// Exercice 2 : Verification d'unicite des solutions avec Z3
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,5e3f4e98,code,fr,2327f7e9135889f1,"// Exercice 2 : Vérification d'unicité des solutions avec Z3
 public class Z3SudokuUnicityChecker
 {
     private static Context ctx = Z3IntSolverSimple.ctx;
     private static IntExpr[][] CellVariables = Z3IntSolverSimple.CellVariables;
 
     /// <summary>
-    /// Verifie si un puzzle a exactement une solution.
+    /// Vérifie si un puzzle a exactement une solution.
     /// Strategie : trouver S1, puis chercher S2 != S1. Si impossible -> unique.
     /// </summary>
     public bool HasUniqueSolution(SudokuGrid puzzle)
@@ -5232,7 +5232,7 @@ public class Z3SudokuUnicityChecker
         // s.Assert(Z3IntSolverSimple.GenericContraints);
         // Indice : voir Z3IntSolverSimple.GetPuzzleConstraints(puzzle)
 
-        // TODO : 2. Verifier satisfiabilite et extraire S1
+        // TODO : 2. Vérifier satisfiabilité et extraire S1
         // if (s.Check() != Status.SATISFIABLE) return false;
         // Model m1 = s.Model;
 
@@ -5246,7 +5246,7 @@ public class Z3SudokuUnicityChecker
         //     }
         // s.Assert(ctx.MkOr(differences));
 
-        // TODO : 4. Retourner true si aucune deuxieme solution n'existe
+        // TODO : 4. Retourner true si aucune deuxième solution n'existe
         // return s.Check() == Status.UNSATISFIABLE;
 
         return false;
@@ -5258,22 +5258,22 @@ var checker2 = new Z3SudokuUnicityChecker();
 var easyPuzzle2 = SudokuHelper.GetSudokus(SudokuDifficulty.Easy).First();
 // bool unique = checker2.HasUniqueSolution(easyPuzzle2);
 // Console.WriteLine($""Solution unique : {unique}"");
-Console.WriteLine(""TODO : Implementez Z3SudokuUnicityChecker.HasUniqueSolution()"");",,,,,,,,5fa1fb689d97520c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,23abb281,markdown,fr,78a2764bfcd3f1f5,"### Exercice 3 : Comparer les tactiques Z3
+Console.WriteLine(""TODO : Implementez Z3SudokuUnicityChecker.HasUniqueSolution()"");",,,,,,,,2327f7e9135889f1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,23abb281,markdown,fr,2297debc2e2cbc7f,"### Exercice 3 : Comparer les tactiques Z3
 
 Z3 propose différentes tactiques pour pré-traiter les formules avant résolution. Chaque tactique à ses avantages selon le type de problème.
 
 **Objectif** : Mesurer l'impact des tactiques sur les performances de résolution.
 
 **Indices** :
-1. Creer une tactique : `ctx.MkTactic(""simplify"")` ou `ctx.MkTactic(""bit-blast"")`
-2. Creer un goal : `ctx.MkGoal()` puis `goal.Assert(contraintes)`
+1. Créer une tactique : `ctx.MkTactic(""simplify"")` ou `ctx.MkTactic(""bit-blast"")`
+2. Créer un goal : `ctx.MkGoal()` puis `goal.Assert(contraintes)`
 3. Appliquer : `tactic.Apply(goal)` retourne un `ApplyResult`
 4. Passer les sous-goals au solveur : `solver.Assert(result.Subgoals[0].Formulas)`
 5. Tactiques a tester : `""simplify""`, `""bit-blast""`, `""ctx-solver-simplify""`, `""solve-eqs""`
 
-**Vérification** : `""bit-blast""` est généralement efficace pour les BitVectors.",,,,,,,,78a2764bfcd3f1f5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,f6b5e689,code,fr,6124d0c565065a82,"// Exercice 3 : Comparaison des tactiques Z3
+**Vérification** : `""bit-blast""` est généralement efficace pour les BitVectors.",,,,,,,,2297debc2e2cbc7f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,f6b5e689,code,fr,b54ec2e1a7db5034,"// Exercice 3 : Comparaison des tactiques Z3
 using Microsoft.Z3;
 using System.Diagnostics;
 
@@ -5288,7 +5288,7 @@ string[] tacticNames = { ""simplify"", ""ctx-solver-simplify"", ""bit-blast"", "
 Console.WriteLine(""Comparaison des tactiques Z3 :"");
 Console.WriteLine(new string('-', 40));
 
-// TODO : Pour chaque tactique, creer et appliquer, mesurer le temps de resolution
+// TODO : Pour chaque tactique, créer et appliquer, mesurer le temps de résolution
 // foreach (var tacticName in tacticNames)
 // {
 //     var tactic = tacticCtx.MkTactic(tacticName);
@@ -5304,8 +5304,8 @@ Console.WriteLine(new string('-', 40));
 //     Console.WriteLine($""{tacticName,-25} : {sw.ElapsedMilliseconds,6} ms - {status}"");
 // }
 
-Console.WriteLine(""TODO : Implementez la comparaison des tactiques Z3"");",,,,,,,,6124d0c565065a82,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,a5cfbbf3,markdown,fr,e20cd64a48d5d700,"## Exercice : Vérification de propriétés avec Z3
+Console.WriteLine(""TODO : Implementez la comparaison des tactiques Z3"");",,,,,,,,b54ec2e1a7db5034,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,a5cfbbf3,markdown,fr,82c0066f3053c426,"## Exercice : Vérification de propriétés avec Z3
 
 ### Enonce
 
@@ -5318,50 +5318,50 @@ Utilisez Z3 pour vérifier des propriétés logiques sur les grilles de Sudoku. 
    
 2. `IsMinimal(SudokuGrid puzzle)` : Vérifie si le puzzle est minimal (supprimer une valeur initiale crée une ambiguïté)
    - Pour chaque cellule fixe (r, c) avec valeur v :
-     - Creer une grille sans cette cellule
+     - Créer une grille sans cette cellule
      - Vérifier que `HasUniqueSolution` retourne `false` (plus d'une solution)
 
 3. Testez avec le puzzle facile : vérifiez unicité et minimalité
 
 **Indice :**
 
-Pour `HasUniqueSolution`, après avoir trouvé S1 = {cells[i][j] = v[i][j]}, ajoutez la contrainte `Or(cell[i][j] != v[i][j])` pour toutes les cellules. Cette contrainte dit ""au moins une cellule diffère de S1"".",,,,,,,,e20cd64a48d5d700,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,8a6fd356,code,fr,01ede0ec5e806e93,"// Exercice : Verification de proprietes avec Z3
+Pour `HasUniqueSolution`, après avoir trouvé S1 = {cells[i][j] = v[i][j]}, ajoutez la contrainte `Or(cell[i][j] != v[i][j])` pour toutes les cellules. Cette contrainte dit ""au moins une cellule diffère de S1"".",,,,,,,,82c0066f3053c426,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,8a6fd356,code,fr,ebf7810d928684e4,"// Exercice : Vérification de propriétés avec Z3
 
 public class Z3SudokuPropertyChecker
 {
     private static Context ctx = Z3IntSolverSimple.ctx;
 
     /// <summary>
-    /// Verifie si un puzzle a exactement une solution.
+    /// Vérifie si un puzzle a exactement une solution.
     /// Strategie : trouver S1, puis chercher S2 != S1. Si impossible -> unique.
     /// </summary>
     public bool HasUniqueSolution(SudokuGrid puzzle)
     {
-        // TODO : Implementer la verification d'unicite
+        // TODO : Implémenter la vérification d'unicité
         // 1. Construire les contraintes generiques + contraintes du puzzle
-        // 2. Trouver la premiere solution S1
+        // 2. Trouver la première solution S1
         // 3. Ajouter la contrainte ""au moins une cellule differe de S1""
-        // 4. Verifier si une deuxieme solution existe
+        // 4. Vérifier si une deuxième solution existe
         return false;
     }
 
     /// <summary>
-    /// Verifie si le puzzle est minimal :
-    /// supprimer n'importe quelle valeur initiale cree une ambiguite.
+    /// Vérifie si le puzzle est minimal :
+    /// supprimer n'importe quelle valeur initiale crée une ambiguïté.
     /// </summary>
     public bool IsMinimal(SudokuGrid puzzle)
     {
-        // TODO : Implementer la verification de minimalite
+        // TODO : Implémenter la vérification de minimalité
         // Pour chaque cellule fixee (i, j) :
-        //   - Creer une copie du puzzle sans la valeur en (i, j)
-        //   - Verifier que HasUniqueSolution retourne false
+        //   - Créer une copie du puzzle sans la valeur en (i, j)
+        //   - Vérifier que HasUniqueSolution retourne false
         // Si toutes les cellules satisfont cette condition -> minimal
         return false;
     }
 }
 
-// Test : verifier les proprietes sur le puzzle facile
+// Test : vérifier les propriétés sur le puzzle facile
 var checker = new Z3SudokuPropertyChecker();
 var easyPuzzle = SudokuHelper.GetSudokus(SudokuDifficulty.Hard).First();
 Console.WriteLine(""Test de verification de proprietes Z3"");
@@ -5370,7 +5370,7 @@ Console.WriteLine(easyPuzzle);
 // bool unique = checker.HasUniqueSolution(easyPuzzle);
 // bool minimal = checker.IsMinimal(easyPuzzle);
 // Console.WriteLine($""Solution unique : {unique}"");
-// Console.WriteLine($""Puzzle minimal : {minimal}"");",,,,,,,,01ede0ec5e806e93,,,,,,,
+// Console.WriteLine($""Puzzle minimal : {minimal}"");",,,,,,,,ebf7810d928684e4,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb,1923ae48,markdown,fr,cd16bbda7c2a43d6,"### A retenir
 
 Z3 offre **quatre formulations** de résolution Sudoku, de la plus simple à la plus optimisée :
@@ -5432,7 +5432,13 @@ try:
 except ImportError:
     print(""Z3 non installe. Executez: pip install z3-solver"")",,,,,,,,be31ad7303a368af,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-intro,markdown,fr,c72fc8ad43485023,"## 1. Solveur Z3 SMT**Microsoft Z3** est un solveur **SMT** (Satisfiability Modulo Theories) - il combine la puissance des solveurs SAT avec des théories mathématiques (arithmétique, tableaux, bitvectors, etc.).",,,,,,,,c72fc8ad43485023,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-theory,markdown,fr,2eb2910772b83ec2,"### Différence entre SAT et SMT| SAT | SMT ||-----|-----|| Variables booléennes uniquement | Variables typées (Int, Real, BitVec, Array...) || Clauses propositionnelles | Formules de premier ordre || `(x OR y) AND (NOT x OR z)` | `x + y > 10 AND x < 5` |",,,,,,,,2eb2910772b83ec2,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,z3-theory,markdown,fr,b59bfef6e27b7852,"### Différence entre SAT et SMT
+
+| SAT | SMT |
+|-----|-----|
+| Variables booléennes uniquement | Variables typées (Int, Real, BitVec, Array...) |
+| Clauses propositionnelles | Formules de premier ordre |
+| `(x OR y) AND (NOT x OR z)` | `x + y > 10 AND x < 5` |",,,,,,,,b59bfef6e27b7852,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,5hp6xynh8oi,markdown,fr,b8c399487d9d3a45,## 2. Configuration du chemin vers les puzzles,,,,,,,,b8c399487d9d3a45,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb,6ughleuceoj,code,fr,9fd2e4b925dc2904,"# Configuration du chemin vers les puzzles
 import os
@@ -6192,7 +6198,7 @@ var exoRe = new Resharp.Regex(ligneAvec5Avant7);
 Console.WriteLine(""Exercice a completer : 5 doit apparaitre avant 7."");
 Console.WriteLine($""  '123456789' (5 avant 7) -> valide attendu, obtenu : {(exoRe.Matches(""123456789"").Length > 0 ? ""valide"" : ""rejet"")}"");
 Console.WriteLine($""  '987654321' (7 avant 5) -> rejet attendu,  obtenu : {(exoRe.Matches(""987654321"").Length > 0 ? ""valide"" : ""rejet"")}"");",,,,,,,,ea4991b463a9b6a5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,veanes-sud-m2lstr,markdown,fr,dd2e9e8438d83c7b,"### Le troisième langage pour dire la même chose : la logique M2L-str
+MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,veanes-sud-m2lstr,markdown,fr,b5a19fbbbefda8ad,"### Le troisième langage pour dire la même chose : la logique M2L-str
 
 L'exercice ci-dessus exprime "" 5 avant 7 "" comme une **intersection de regex** (`& .*5.*7.*`). Mais cette même contrainte admet une **troisième** écriture - ni regex, ni système d'inégalités : une **formule de logique monadique du second ordre sur les chaînes** (M2L-str). "" Il existe une position du 5 strictement avant une position du 7 "" s'écrit littéralement
 
@@ -6208,7 +6214,7 @@ L'intérêt de ce registre : un **compilateur de logique** (D'Antoni & Veanes, P
 | **Logique M2L-str** (Veanes & D'Antoni) | `exists x,y. x<y && P_5(x) && P_7(y)` | le compilateur logique vers SFA |
 | **Contraintes** (Z3, section 6) | `Distinct` + appartenances | le solveur SMT |
 
-> **Le même `&`, vu d'en haut.** Les trois registres partagent l'**algèbre de Boole** des langages réguliers (cf notebook [10](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb), section 3). La conjonction logique `&&` de M2L-str, l'intersection `&` de RE# et le `re.inter` SMT-LIB sont **la même opération** dans trois notations. Mais la *forme* sous laquelle on émet cette conjonction décide si Z3 atterrit le 9x9 (section 6b) - une question que la théorie de Veanes nomme **décomposition monadique**, et que l'ordre `x < y` de cet exercice illustre justement par la négative (cf section 6b).",,,,,,,,dd2e9e8438d83c7b,,,,,,,
+> **Le même `&`, vu d'en haut.** Les trois registres partagent l'**algèbre de Boole** des langages réguliers (cf notebook [10](../SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb), section 3). La conjonction logique `&&` de M2L-str, l'intersection `&` de RE# et le `re.inter` SMT-LIB sont **la même opération** dans trois notations. Mais la *forme* sous laquelle on émet cette conjonction décide si Z3 atterrit le 9x9 (section 6b) - une question que la théorie de Veanes nomme **décomposition monadique**, et que l'ordre `x < y` de cet exercice illustre justement par la négative (cf section 6b).",,,,,,,,b5a19fbbbefda8ad,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,edd4a220,markdown,fr,77919232361e2615,"## 6. Le résolveur - Z3 produit le témoin
 
 RE# sait *vérifier* ; il ne sait pas *produire*. Pour résoudre un puzzle Sudoku, il faut un **résolveur**. C'est le rôle de Z3, et c'est le barreau 2 de 2020 - mais cette fois **sans le cap de 21 caractères**, parce qu'on appelle Z3 **directement** (sans passer par le chemin SFAz3 de AutomataDotNet qui était muré).
@@ -6334,7 +6340,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,a3872431,markdo
 Z3 a **produit** la grille solution - le *témoin* - en quelques dizaines de millisecondes. C'est le barreau 2 de 2020, mais **sans le cap de 21 caractères** : on appelle Z3 directement, pas via le chemin SFAz3 qui était tronqué. C'est ce résolveur qui entre dans le benchmark Sudoku multi-paradigmes (aux côtés d'Infer.NET, du PSO, du réseau de neurones) : il **résout réellement** le dataset.
 
 C'est aussi le ""cop-out"" de l'ancienne version de ce notebook qu'on tue ici : non, ""utiliser Z3 directement"" n'est pas une dégression honteuse par rapport aux automates - c'est le **complément indispensable** du vérificateur RE#. *Solving* (Z3) et *matching* (RE#) sont les deux faces de la série.",,,,,,,,5dce5514462485be,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,a6b00001,markdown,fr,2d98b5b30996be74,"## 6b. Les deux murs tombent - et la dernière marche, c'est la forme d'émission
+MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,a6b00001,markdown,fr,c5b2ef77de57663e,"## 6b. Les deux murs tombent - et la dernière marche, c'est la forme d'émission
 
 Le barreau 2 (2020) butait sur **deux murs**, tous deux liés à la matérialisation d'un automate : l'explosion du produit de DFA (mur 1) ET le cap du témoin à ~21 caractères (mur 2, [issue #6](https://github.com/AutomataDotNet/Automata/issues/6)). Le **fork Automata** (modernisation net8.0, MyIntelligenceAgency) change de moteur : son `RegexToSMTConverter` compile la syntaxe de surface `&` / `~` vers la **théorie des chaînes SMT-LIB 2.6** (`re.inter`, `re.comp`, `re.range`, `re.loop`, `str.to_re`) - le dialecte que Z3 consomme **directement**.
 
@@ -6344,14 +6350,14 @@ Restait une dernière marche, le 9x9. Et là, ce n'est ni le substrat ni le mote
 
 | Échelle | Forme d'émission du tous-distincts | Témoin via la théorie des chaînes Z3 |
 |---------|-----------------------------------|--------------------------------------|
-| **`A & ~B` général** (mot de passe, entrée de test) | `re.inter` / `re.comp` | **rapide** (~100 ms, cf [notebook 10](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb)) |
+| **`A & ~B` général** (mot de passe, entrée de test) | `re.inter` / `re.comp` | **rapide** (~100 ms, cf [notebook 10](../SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb)) |
 | **Grille 4x4** (Shidoku) | appartenance **fondue** en `re.inter` | **atterrit** (~1,7 s, cellule plus bas) |
 | **1 ligne 9x9** (9 cases) | appartenance **fondue** en `re.inter` (10-way) | **atterrit** mais lent (~12,5 s) |
 | **Grille 9x9** | appartenance **fondue** en `re.inter` (27 groupes qui se chevauchent) | **`unknown`** (> 60 s - le produit d'automates sature) |
 | **Grille 9x9** | appartenance **éclatée** : chaque `.*d.*` en `str.contains` natif | **atterrit** (~53 s en .NET, ~12 s z3-py - section 6c) |
 | **Grille 9x9** | inégalités 2 à 2 (= `Distinct` développé) | **atterrit** (~0,8 s, cellule suivante) |
 
-La grille 9x9 n'est bloquée ni par un mur d'automate, ni par le substrat chaîne, ni même par l'appartenance régulière : elle l'est seulement quand on **fond** les 27 intersections k-way en un produit `re.inter` que Z3 doit matérialiser au solve. **Éclate** ce même `&` d'appartenances en la primitive native `str.contains` (un par chiffre - section 6c) et la grille atterrit, sans une seule inégalité. Les inégalités 2 à 2 (ci-dessous) atterrissent plus vite encore, mais elles **quittent** le regex ; la forme la plus pure - le regex qui se suffit à lui-même - est `str.contains`. Le critère décisif n'est donc pas ""appartenance vs inégalité"" ni ""1D vs 2D"" : c'est **produit d'automates fondu vs primitive native éclatée**.",,,,,,,,2d98b5b30996be74,,,,,,,
+La grille 9x9 n'est bloquée ni par un mur d'automate, ni par le substrat chaîne, ni même par l'appartenance régulière : elle l'est seulement quand on **fond** les 27 intersections k-way en un produit `re.inter` que Z3 doit matérialiser au solve. **Éclate** ce même `&` d'appartenances en la primitive native `str.contains` (un par chiffre - section 6c) et la grille atterrit, sans une seule inégalité. Les inégalités 2 à 2 (ci-dessous) atterrissent plus vite encore, mais elles **quittent** le regex ; la forme la plus pure - le regex qui se suffit à lui-même - est `str.contains`. Le critère décisif n'est donc pas ""appartenance vs inégalité"" ni ""1D vs 2D"" : c'est **produit d'automates fondu vs primitive native éclatée**.",,,,,,,,c5b2ef77de57663e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,a6b00002,code,fr,9fb3bb838d5a57ce,"// Le fork Automata compile la MEME intersection 10-way que RE# verifie (section 5) vers la
 // THEORIE DES CHAINES de Z3 (re.inter / re.comp / re.range), PAS vers un produit d'automates.
 // On boucle la chaine SMT -> Z3 -> temoin, puis on CROISE les moteurs : le temoin doit etre
@@ -6570,7 +6576,7 @@ if (st9 == Status.SATISFIABLE) {
 } else {
     Console.WriteLine($""Statut inattendu : {st9}"");
 }",,,,,,,,3fb8c57b7b363725,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,a6b00004,markdown,fr,a04342ceaaef46a5,"### Interprétation : les deux murs tombent, et la forme d'émission franchit le 9x9
+MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,a6b00004,markdown,fr,9e2aa5955af58089,"### Interprétation : les deux murs tombent, et la forme d'émission franchit le 9x9
 
 La chaîne moderne **débride le témoin** : une ligne Sudoku (intersection 10-way) produit désormais un témoin réel, **valide par RE#** (validation croisée inter-moteurs ci-dessus) - chose impossible en 2020 sous le cap des 21 caractères. Et aucun produit d'automates n'est construit, donc le ""trop d'états"" de 2020 ne se produit pas. Les deux murs sont derrière nous.
 
@@ -6584,7 +6590,7 @@ Reste la dernière marche, le 9x9, et c'est la **forme d'émission** du même `&
 | chaînes Z3, tous-distincts en **inégalités 2 à 2** | (oui) | **grille complète** | **atterrit (~0,8 s)** |
 | Z3 `Distinct` (entiers) | - | grille complète | **~38 ms (production)** |
 
-> **Murs tombés, forme d'émission décisive.** Le payoff *général* de la génération de témoin `A & ~B` est démontré dans le notebook **[10 - Générer un témoin depuis A & ~B](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb)** de la série Z3. Le Sudoku, lui, montre la leçon la plus fine : ce n'est ni le moteur ni le substrat, ni même ""appartenance vs inégalité"" qui décide, mais la **forme d'émission** du même `&` d'appartenances - *fondu* en `re.inter` (sature au 9x9) vs *éclaté* en `str.contains` natif (atterrit). Le regex *n'est pas* le mauvais outil : bien émis, il atterrit la grille 9x9 complète, sans une seule inégalité.",,,,,,,,a04342ceaaef46a5,,,,,,,
+> **Murs tombés, forme d'émission décisive.** Le payoff *général* de la génération de témoin `A & ~B` est démontré dans le notebook **[10 - Générer un témoin depuis A & ~B](../SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb)** de la série Z3. Le Sudoku, lui, montre la leçon la plus fine : ce n'est ni le moteur ni le substrat, ni même ""appartenance vs inégalité"" qui décide, mais la **forme d'émission** du même `&` d'appartenances - *fondu* en `re.inter` (sature au 9x9) vs *éclaté* en `str.contains` natif (atterrit). Le regex *n'est pas* le mauvais outil : bien émis, il atterrit la grille 9x9 complète, sans une seule inégalité.",,,,,,,,9e2aa5955af58089,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,veanes-sud-monadic,markdown,fr,5f1e657be91d8a54,"### La théorie derrière la "" forme d'émission "" : la décomposition monadique (Veanes, CAV'14)
 
 Le tableau ci-dessus est un constat **empirique** : fondue en `re.inter`, l'appartenance sature ; éclatée en `str.contains`, elle atterrit. Cette observation porte un **nom** et possède une **théorie** chez Veanes : la **décomposition monadique** (*Monadic Décomposition*, M. Veanes, N. Bjorner, L. Nachmanson, S. Bereg, CAV 2014).
@@ -7078,7 +7084,7 @@ L'intuition de l'auteur (""la réécriture du parser était sans doute au progra
 - **RE#** (POPL 2025) : ramène `&` / `~` en **citoyens de première classe** d'un matcher à dérivées, en temps linéaire - mais toujours *reconnaissance*, sans témoin.
 
 Mon avis : la capacité que visait le projet (de l'intersection `&`/`~` *vers une grille résolue*) n'a jamais été celle de SRM/RE# (reconnaissance), mais celle de la voie Z3 - d'abord SFAz3 (capée), puis la théorie des chaînes à la dZ3 (non capée, sans produit). La ""réécriture du parser"" qui débloque le 9x9, c'est précisément ce glissement : **regex -> SFA** devient **regex -> contraintes SMT sur les chaînes** - et, dernière marche, émettre chaque appartenance `.*d.*` comme la primitive native `str.contains` plutôt que de la fondre en `re.inter`. Le fork `Automata` (Epic #2979) câble enfin cette voie : `&`/`~` en surface BREX, `RegexToSMTConverter` vers SMT-LIB 2.6, et le cap #6 levé. Bon repo, bonne idée, bon moment - il manquait la plomberie, désormais posée.",,,,,,,,5c83d297df8800b9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,855aa43e,markdown,fr,c7a9af7b716151b8,"## 9. Synthèse - reconnaître != résoudre, et la forme d'émission décide
+MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,855aa43e,markdown,fr,9251b622d3207e9b,"## Synthèse - reconnaître != résoudre, et la forme d'émission décide
 
 Les deux murs de 2020 étaient des murs **de l'automate** ; ils tombent ensemble dès qu'on change de moteur. Restait le 9x9, et c'est la **forme d'émission** de l'intersection qui le franchit : le regex, bien émis, **atterrit réellement** la grille - sans une seule inégalité.
 
@@ -7094,11 +7100,11 @@ Les deux murs de 2020 étaient des murs **de l'automate** ; ils tombent ensemble
 
 **Leçon** : décrire une contrainte par intersection régulière (`Ligne & Colonne & Bloc`) est une représentation élégante qui **atterrit** la grille - 4x4 complète, **et 9x9 complète** sans quitter l'appartenance régulière. Ce qui décide la réussite n'est ni le moteur (DFA vs dérivées vs SMT) ni le substrat (chaîne vs entier), mais la **forme d'émission du tous-distincts** : *fondu* en un produit d'automates (`re.inter`/`str.in_re`), il sature à l'échelle des 27 groupes qui se chevauchent ; *éclaté* en la primitive native `str.contains` (= `.*d.*` par chiffre), il atterrit - et les inégalités 2 à 2 (dont `Distinct` est le sucre) plus vite encore, mais hors du regex. RE# en est le vérificateur linéaire, pas le solveur ; l'ironie (RE# valide plus vite qu'il ne produit) est le pont entre cette série Sudoku et la série Z3 (Epic #1206).
 
-La **chaîne moderne** (section 6b, et notebook [10](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb) de la série Z3) fait tomber **les deux murs** de 2020 : `&`/`~` compile vers la théorie des chaînes de Z3, qui ne cape aucun témoin et ne construit aucun produit d'automates. Le revers n'est donc pas ""Z3 string-theory ne sait pas faire le Sudoku"" - il le fait, le 9x9 inclus (cf section 6c) - mais ""il faut émettre l'appartenance dans la bonne forme : `str.contains` natif, pas `re.inter` fondu"".
+La **chaîne moderne** (section 6b, et notebook [10](../SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb) de la série Z3) fait tomber **les deux murs** de 2020 : `&`/`~` compile vers la théorie des chaînes de Z3, qui ne cape aucun témoin et ne construit aucun produit d'automates. Le revers n'est donc pas ""Z3 string-theory ne sait pas faire le Sudoku"" - il le fait, le 9x9 inclus (cf section 6c) - mais ""il faut émettre l'appartenance dans la bonne forme : `str.contains` natif, pas `re.inter` fondu"".
 
 Le **banc d'essai** (section 8 ci-dessus) confirme empiriquement chaque case de ce tableau : le regex déroulé s'effondre (timeout, faux négatif), la voie chaînes-en-appartenance-fondue fait `unknown`, la **même** appartenance éclatée en `str.contains` (P3'') et les inégalités (P3') et `Distinct` atterrissent, et le backtracking C# naïf est le vainqueur discret. Le DLX, lui, est l'optimum dédié : cf [Sudoku-2-DancingLinks](Sudoku-2-DancingLinks-Csharp.ipynb).
 
-> **Footnote d'homonymie** : **Damian** Conway (luminaire des regex Perl, dont relève le folklore du barreau 1) n'est pas **John** Conway (le Game of Life, hero de notre série Lean #2162). Les deux Conway se croisent dans ce notebook.",,,,,,,,c7a9af7b716151b8,,,,,,,
+> **Footnote d'homonymie** : **Damian** Conway (luminaire des regex Perl, dont relève le folklore du barreau 1) n'est pas **John** Conway (le Game of Life, hero de notre série Lean #2162). Les deux Conway se croisent dans ce notebook.",,,,,,,,9251b622d3207e9b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,b71a1c63,markdown,fr,ada5968d6ca4dee0,"## Exercice 3 : classifier recognition vs solving (conceptuel)
 
 **Objectif :**
@@ -7121,7 +7127,7 @@ Console.WriteLine(""(a) Verifier qu'une grille remplie respecte les regles : RE#
 Console.WriteLine(""(b) Resoudre un puzzle a partir de cases vides       : Z3  -> ..."");
 Console.WriteLine(""(c) Verifier qu'une chaine = 9 chiffres distincts    : ... -> ..."");
 Console.WriteLine(""(d) Trouver une permutation de 1..9 maximisant un critere : ... -> ..."");",,,,,,,,5925546ab1bd4ffb,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,03783737,markdown,fr,b86520a9f9a14076,"---
+MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,03783737,markdown,fr,d7d55f4de23a4892,"---
 
 ## 9. Références & connexions
 
@@ -7137,7 +7143,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,03783737,markdo
 ### Connexions dans cette série
 - **[Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb)** : le résolveur Z3 explore en profondeur (bit-vectors, optimisations). Ce notebook (13) présente le même Z3 sous l'angle narratif ""regex symbolique -> SMT -> témoin"".
 - **Epic #1206 (Z3.Linq DSL)** : un autre ""geste"" de l'auteur (2018), étendre un front-end déclaratif pour laisser Z3 témoigner. La compilation regex -> SMT et le DSL Z3.Linq sont **le même geste dans deux librairies**.
-- **[Notebook 10 - Générer un témoin depuis A & ~B](../SymbolicAI/SMT/Z3/10_Witness_Generation_Automata.ipynb)** : le fork Automata levé le cap du témoin (#6) et généralise `A & ~B` (mots de passe, entrées de test) - le cas où la théorie des chaînes de Z3 est rapide. La section 6b ci-dessus mesure le spectre (rapide en général, lent sur une ligne, `unknown` à 81).
+- **[Notebook 10 - Générer un témoin depuis A & ~B](../SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb)** : le fork Automata levé le cap du témoin (#6) et généralise `A & ~B` (mots de passe, entrées de test) - le cas où la théorie des chaînes de Z3 est rapide. La section 6b ci-dessus mesure le spectre (rapide en général, lent sur une ligne, `unknown` à 81).
 - **Epic #2162 (Game of Life, Lean)** : **John** Conway, à ne pas confondre avec **Damian** (regex).
 
 ### La preuve Lean derrière RE#
@@ -7151,7 +7157,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb,03783737,markdo
 - Les deux murs de 2020 (explosion DFA, cap témoin ~21 char) étaient des murs **de l'automate** : ils tombent **ensemble** dès qu'on change de moteur (`&`/`~` -> théorie des chaînes Z3).
 - La dernière marche, le 9x9, se franchit par la **forme d'émission** du même `&` d'appartenances : *fondu* en `re.inter` il sature (`unknown`) ; *éclaté* en la primitive native `str.contains` (= `.*d.*` par chiffre) il **atterrit la grille 9x9 complète** (~53 s en .NET, ~12 s z3-py) - 0 inégalité, le regex se suffit à lui-même.
 - Les inégalités 2 à 2 (~0,8 s) et `Distinct` sur 81 entiers (~38 ms) atterrissent plus vite encore - mais elles quittent le regex. Question de **forme d'émission**, pas de mur ni de substrat.
-- L'**ironie** : le vérificateur le plus élégant (RE#) certifie, plus vite que Z3 n'a résolu, une grille qu'il ne peut pas produire.",,,,,,,,b86520a9f9a14076,,,,,,,
+- L'**ironie** : le vérificateur le plus élégant (RE#) certifie, plus vite que Z3 n'a résolu, une grille qu'il ne peut pas produire.",,,,,,,,d7d55f4de23a4892,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb,92986127,markdown,fr,b24bc55570e88080,"---
 **Navigation** : [<< Sudoku-12 Z3 Python](Sudoku-12-Z3-Python.ipynb) | [Index](README.md) | [Sudoku-14 BDD Python >>](Sudoku-14-BDD-Python.ipynb)
 
@@ -7449,7 +7455,7 @@ print(""(b) Resoudre un puzzle a partir de cases vides       : z3              -
 print(""(c) Matcher un langage non-regulier imbrique          : regex (?&rec)  -> ..."")
 print(""    (completer la justification de chaque choix)"")
 ",,,,,,,,f5598fa9940b21a2,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb,f7bebf2e,markdown,fr,0f2abd79f32e845e,"## 9. Conclusion — l'échelle Python, du folklore au non-régulier
+MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb,f7bebf2e,markdown,fr,82f057db317b6915,"## Conclusion — l'échelle Python, du folklore au non-régulier
 
 Ce twin Python parcourt la même échelle que le twin C# — Conway -> reconnaissance -> résolution -> théorie des chaînes — mais **complète** là où le C# bute : la **récursion `(?&rec)`** du module `regex` exécute les langages non-réguliers que `System.Text.RegularExpressions` rejette. Les Sudoku-en-un-regex célèbres reposent précisément sur cette récursion ; le twin Python est donc le seul des deux à pouvoir *démontrer* cette voie, pas seulement l'évoquer.
 
@@ -7459,14 +7465,14 @@ Ce twin Python parcourt la même échelle que le twin C# — Conway -> reconnais
 - `regex` `(?&rec)` : le seul outil des deux twins qui franchit la frontière du régulier.
 - Backtracking récursif : le contre-point robuste, compétitif sur 9x9.
 
-> Retour au [twin C#](Sudoku-13-SymbolicAutomata-Csharp.ipynb) — où le barreau récursion est documenté comme un mur (.NET rejette `(?R)`).",,,,,,,,0f2abd79f32e845e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,300cd4ca,markdown,fr,f3cbb7e6d6743659,"**Navigation** : [Index](README.md) | [<< Sudoku-13 C#](Sudoku-13-SymbolicAutomata-Csharp.ipynb) | [Sudoku-15 C# >>](Sudoku-15-Infer-Csharp.ipynb)
+> Retour au [twin C#](Sudoku-13-SymbolicAutomata-Csharp.ipynb) — où le barreau récursion est documenté comme un mur (.NET rejette `(?R)`).",,,,,,,,82f057db317b6915,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,300cd4ca,markdown,fr,853b7391508df106,"**Navigation** : [Index](README.md) | [<< Sudoku-13 C#](Sudoku-13-SymbolicAutomata-Csharp.ipynb) | [Sudoku-15 C# >>](Sudoku-15-Infer-Csharp.ipynb)
 
 
 
 # Sudoku-14 : Automates avec BDD/MDD - Approche Pure
 
-Dans ce notebook, nous implementons une **vraie** approche par automates symboliques utilisant des **Binary Decision Diagrams (BDD)** et **Multi-valued Decision Diagrams (MDD)**. Contrairement a Sudoku-12 qui compilait vers Z3, cette approche construit explicitement des automates avec des etats et des transitions.
+Dans ce notebook, nous implémentons une **vraie** approche par automates symboliques utilisant des **Binary Decision Diagrams (BDD)** et **Multi-valued Decision Diagrams (MDD)**. Contrairement à Sudoku-12 qui compilait vers Z3, cette approche construit explicitement des automates avec des états et des transitions.
 
 ## Qu'est-ce qu'un BDD?
 
@@ -7489,17 +7495,17 @@ Un **MDD** généralise le BDD aux domaines finis (comme {1,2,...,9} pour Sudoku
 2. **Implémenter** un BDD simple en C#
 3. **Construire** un MDD pour les domaines Sudoku
 4. **Composer** des automates avec produit d'automates explicite
-5. **Apprecier** la différence avec l'approche Z3 (Sudoku-12)
+5. **Apprécier** la différence avec l'approche Z3 (Sudoku-12)
 
-### Prerequis
+### Prérequis
 
 - [Sudoku-0-Environment](Sudoku-0-Environment-Csharp.ipynb) - Classes de base Sudoku
-- [Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb) - Théorie des automates (recommande)
+- [Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb) - Théorie des automates (recommandée)
 - Connaissance de base des graphes et arbres
 
-### Duree estimee : 25 min
+### Durée estimée : 25 min
 
-## References
+## Références
 
 - **Andersen, H. R.** - ""An Introduction to Binary Decision Diagrams"" (1997)
 - **Bryant, R. E.** - ""Graph-Based Algorithms for Boolean Function Manipulation"" (1986)
@@ -7507,8 +7513,8 @@ Un **MDD** généralise le BDD aux domaines finis (comme {1,2,...,9} pour Sudoku
 
 **Note sur l'approche :**
 
-> **⚠️ Important** : Ce notebook implémente une approche ""pure"" automata avec BDD/MDD, sans utiliser Z3. Cette approche est moins performante que Z3 mais illustre la théorie des automates symboliques de manière plus authentique.",,,,,,,,f3cbb7e6d6743659,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,1e2c7db9,markdown,fr,4922221d830a4a91,"---
+> **⚠️ Important** : Ce notebook implémente une approche ""pure"" automata avec BDD/MDD, sans utiliser Z3. Cette approche est moins performante que Z3 mais illustre la théorie des automates symboliques de manière plus authentique.",,,,,,,,853b7391508df106,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,1e2c7db9,markdown,fr,8ff17f2c398c9334,"---
 
 ## 1. Introduction - BDD vs Z3 (10 min)
 
@@ -7518,20 +7524,20 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,1e2c7db9,markdown,fr,4922221
 |--------|----------------------|-------------------|
 | **Structure** | Graphe de décision explicite | Formules logiques |
 | **Opérations** | Union, Intersection, Réduction | SAT solving |
-| **Memoisation** | Naturelle (partage de sous-graphes) | Via Z3 |
+| **Mémoïsation** | Naturelle (partage de sous-graphes) | Via Z3 |
 | **Performance** | Moyenne (~100ms) | Excellente (~20ms) |
-| **Authenticite** | ⭐⭐⭐ Vrais automates | ⭐⭐ Compilation |
+| **Authenticité** | ⭐⭐⭐ Vrais automates | ⭐⭐ Compilation |
 
 ### 1.2 Pourquoi BDD?
 
 **Avantages** :
 - Représentation canonique (forme unique pour une fonction)
 - Opérations booléennes efficaces (AND, OR, NOT)
-- Memoisation automatique
+- Mémoïsation automatique
 
-**Inconvenients** :
+**Inconvénients** :
 - Taille peut exploser pour certaines fonctions
-- Moins performant que Z3 pour les contraintes arithmetiques
+- Moins performant que Z3 pour les contraintes arithmétiques
 
 ### 1.3 MDD pour Sudoku
 
@@ -7545,7 +7551,7 @@ MDD pour une cellule Sudoku:
      1   2  ...  9
      |   |      |
     feuille (valeur choisie)
-```",,,,,,,,4922221d830a4a91,,,,,,,
+```",,,,,,,,8ff17f2c398c9334,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,6a91a2b3,markdown,fr,06c81c8f5580a137,"---
 
 ## 2. Implémentation d'un BDD Simple (15 min)
@@ -7553,7 +7559,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,6a91a2b3,markdown,fr,06c81c8
 ### 2.1 Structure du BDD
 
 Commençons par implémenter un BDD simple pour des fonctions booléennes.",,,,,,,,06c81c8f5580a137,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,a6c520e4,code,fr,7f8f673268ad096d,"using System;
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,a6c520e4,code,fr,d4980712387d215b,"using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7604,7 +7610,7 @@ public class BDDNode
         if (childFalse == childTrue)
             return childFalse;
         
-        // Réduction : si variable est inutile, retourner l'enfant approprie
+        // Réduction : si variable est inutile, retourner l'enfant approprié
         // (c'est une simplification, la vraie réduction est plus complexe)
         
         return new BDDNode(variable, childFalse, childTrue);
@@ -7657,10 +7663,10 @@ Console.WriteLine(""Operations disponibles :"");
 Console.WriteLine(""  - True/False : Terminaux (feuilles)"");
 Console.WriteLine(""  - Create(var, low, high) : Cree un noeud de decision"");
 Console.WriteLine(""  - Evaluate(assign) : Evalue le BDD"");
-Console.WriteLine(""  - CountNodes() : Compte les noeuds"");",,,,,,,,7f8f673268ad096d,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,ce7ac457,markdown,fr,d5aac7bb77462349,"### 2.2 Exemples de BDD
+Console.WriteLine(""  - CountNodes() : Compte les noeuds"");",,,,,,,,d4980712387d215b,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,ce7ac457,markdown,fr,a08247924ace3138,"### 2.2 Exemples de BDD
 
-Creons quelques BDD simples pour comprendre la structure.",,,,,,,,d5aac7bb77462349,,,,,,,
+Créons quelques BDD simples pour comprendre la structure.",,,,,,,,a08247924ace3138,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,2bede738,code,fr,9a57dab186af8400,"// Exemple 1 : BDD pour la fonction constante TRUE
 var bddTrue = BDDNode.True;
 Console.WriteLine(""=== Exemple 1 : Constante TRUE ==="");
@@ -7687,7 +7693,7 @@ Console.WriteLine($""Noeuds : {bddXAndY.CountNodes()}"");
 Console.WriteLine($""Eval(x=true, y=true) : {bddXAndY.Evaluate(new Dictionary<string, bool> {{""x"", true}, {""y"", true}})}"");
 Console.WriteLine($""Eval(x=true, y=false) : {bddXAndY.Evaluate(new Dictionary<string, bool> {{""x"", true}, {""y"", false}})}"");
 Console.WriteLine($""Eval(x=false, y=true) : {bddXAndY.Evaluate(new Dictionary<string, bool> {{""x"", false}, {""y"", true}})}"");",,,,,,,,9a57dab186af8400,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,dcc5dd43,markdown,fr,ca7391eda8fb1cd8,"#### Interpretation : Exemples de BDD
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,dcc5dd43,markdown,fr,0b515c93c13200bd,"#### Interprétation : Exemples de BDD
 
 **Sortie obtenue** :
 
@@ -7704,7 +7710,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,dcc5dd43,markdown,fr,ca7391e
 | T | F | F |
 | T | T | T |
 
-**Point important** : Le BDD pour x AND y a 5 nœuds. Si nous appliquions la réduction complète (partage de sous-graphes identiques), nous aurions moins de nœuds car les terminaux False sont partages.",,,,,,,,ca7391eda8fb1cd8,,,,,,,
+**Point important** : Le BDD pour x AND y a 5 nœuds. Si nous appliquions la réduction complète (partage de sous-graphes identiques), nous aurions moins de nœuds car les terminaux False sont partagés.",,,,,,,,0b515c93c13200bd,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,3112185a,markdown,fr,5e68616fecc9ba07,"---
 
 ## 3. Opérations sur les BDD (15 min)
@@ -7819,20 +7825,20 @@ Console.WriteLine(""=== Test 3 : Distributivite ==="");
 Console.WriteLine($""Noeuds (gauche) : {bddLeft.CountNodes()}"");
 Console.WriteLine($""Noeuds (droite) : {bddRight.CountNodes()}"");
 Console.WriteLine($""Equivalent (x=T,y=T,z=F) : {bddLeft.Evaluate(new Dictionary<string, bool> {{""x"", true}, {""y"", true}, {""z"", false}})} == {bddRight.Evaluate(new Dictionary<string, bool> {{""x"", true}, {""y"", true}, {""z"", false}})}"");",,,,,,,,20de78da07ac3f58,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,43598773,markdown,fr,0300a89157d3a3b9,"---
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,43598773,markdown,fr,01af6c9330b797f4,"---
 
 ## 4. MDD pour Sudoku (20 min)
 
-### 4.1 De BDD a MDD
+### 4.1 De BDD à MDD
 
-Les BDD sont parfaits pour des variables booléennes, mais Sudoku utilise des variables a valeurs dans {1, ..., 9}. Nous avons besoin de **MDD (Multi-valued Decision Diagrams)**.
+Les BDD sont parfaits pour des variables booléennes, mais Sudoku utilise des variables à valeurs dans {1, ..., 9}. Nous avons besoin de **MDD (Multi-valued Decision Diagrams)**.
 
 ```
 BDD (binaire)          MDD (multi-value)
     x?                     x?
    / \                  / | \ \
   0   1                1  2 ... 9
-```",,,,,,,,0300a89157d3a3b9,,,,,,,
+```",,,,,,,,01af6c9330b797f4,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,49a2296c,code,fr,be35a3dd59579a5a,"using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7912,11 +7918,11 @@ public class MDDNode
 }
 
 Console.WriteLine(""MDDNode OK (Pretty/ToString/Evaluate)."");",,,,,,,,be35a3dd59579a5a,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,45ea0520,markdown,fr,1e634f33c6fb2b36,"### 4.2 MDD pour une Contrainte de Ligne
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,45ea0520,markdown,fr,b6ea88c795a34e0c,"### 4.2 MDD pour une Contrainte de Ligne
 
-Creons un MDD pour représenter la contrainte ""les 9 valeurs d'une ligne sont distinctes"".
+Créons un MDD pour représenter la contrainte ""les 9 valeurs d'une ligne sont distinctes"".
 
-**Note** : Cette représentation est naive et conduit a une explosion d'etats. Nous verrons comment optimiser.",,,,,,,,1e634f33c6fb2b36,,,,,,,
+**Note** : Cette représentation est naïve et conduit à une explosion d'états. Nous verrons comment optimiser.",,,,,,,,b6ea88c795a34e0c,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,78d9cfe9,code,fr,89a2572b423a39e8,"using System;
 using System.Collections.Generic;
 
@@ -7965,9 +7971,9 @@ public class RowMDDBuilder
 }
 
 Console.WriteLine(""RowMDDBuilder OK (memoization bitmask)."");",,,,,,,,89a2572b423a39e8,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,f5dcabcd,markdown,fr,0a6039d142a33208,"### 4.3 Test du MDD de Ligne
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,f5dcabcd,markdown,fr,007d20986f812fb9,"### 4.3 Test du MDD de Ligne
 
-**Attention** : Le MDD complet pour une ligne a 9! = 362880 chemins valides. La construction va prendre du temps!",,,,,,,,0a6039d142a33208,,,,,,,
+**Attention** : Le MDD complet pour une ligne à 9! = 362880 chemins valides. La construction va prendre du temps!",,,,,,,,007d20986f812fb9,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,81fe3df4,code,fr,2a3ec909023329b1,"// Construction du MDD pour la ligne 0
 // Note: Cela peut prendre quelques secondes car 9! chemins
 
@@ -8005,29 +8011,29 @@ var invalidAssignment = new Dictionary<string, int>
 Console.WriteLine(""=== Test 2 : Ligne invalide (doublon de 1) ==="");
 Console.WriteLine($""Resultat : {rowMDD.Evaluate(invalidAssignment)}"");
 Console.WriteLine($""Attendu : False"");",,,,,,,,2a3ec909023329b1,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,b1ad23f7,markdown,fr,fd9a063fd0306241,"#### Interpretation : MDD de Ligne
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,b1ad23f7,markdown,fr,1fd25e38f46fab9f,"#### Interprétation : MDD de Ligne
 
 **Sortie obtenue** :
 
-- Le MDD construit comporte 5 611 771 nœuds, soit environ 15 fois 9! (362 880 permutations valides) : a cette echelle, l'explosion combinatoire des branches l'emporte
-- Seul le partage des terminaux est appliqué ; la réduction complète des sous-graphes identiques reste un exercice (voir plus bas), d'ou la taille elevee
-- L'evaluation est correcte pour les lignes valides et invalides
+- Le MDD construit comporte 5 611 771 nœuds, soit environ 15 fois 9! (362 880 permutations valides) : à cette échelle, l'explosion combinatoire des branches l'emporte
+- Seul le partage des terminaux est appliqué ; la réduction complète des sous-graphes identiques reste un exercice (voir plus bas), d'où la taille élevée
+- L'évaluation est correcte pour les lignes valides et invalides
 
 **Comparaison** :
 
 | Approche | Structure | Taille |
 |----------|-----------|-------|
-| Automate naive (explicite) | 9! etats | ~360K |
+| Automate naïve (explicite) | 9! états | ~360K |
 | MDD (ce notebook) | Diagramme multi-value | ~5,6 millions de nœuds |
 
-**Point important** : Même avec réduction, le MDD pour une seule ligne est déjà assez grand. Pour un Sudoku complet (81 cellules), l'explosion serait monumentale.",,,,,,,,fd9a063fd0306241,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,28f8c63e,markdown,fr,8b4e4302305a067b,"---
+**Point important** : Même avec réduction, le MDD pour une seule ligne est déjà assez grand. Pour un Sudoku complet (81 cellules), l'explosion serait monumentale.",,,,,,,,1fd25e38f46fab9f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,28f8c63e,markdown,fr,aec33d00faea63e3,"---
 
 ## 5. Produit d'Automates Explicite (15 min)
 
 ### 5.1 Produit de MDD
 
-Pour combiner plusieurs contraintes (ligne + colonne + bloc), nous devons faire le **produit d'automates**. Contrairement a Sudoku-12 qui compilait vers Z3, nous allons construire explicitement ce produit.",,,,,,,,8b4e4302305a067b,,,,,,,
+Pour combiner plusieurs contraintes (ligne + colonne + bloc), nous devons faire le **produit d'automates**. Contrairement à Sudoku-12 qui compilait vers Z3, nous allons construire explicitement ce produit.",,,,,,,,aec33d00faea63e3,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,0c999c25,code,fr,87948f984e4f843b,"using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8188,25 +8194,25 @@ Console.WriteLine($""Test (r0_c0=1, r0_c1=2) : {productMDD.Evaluate(testAssign1)
 // Test : r0_c0=2, r0_c1=1 devrait etre accepte
 var testAssign2 = new Dictionary<string, int> {{""r0_c0"", 2}, {""r0_c1"", 1}};
 Console.WriteLine($""Test (r0_c0=2, r0_c1=1) : {productMDD.Evaluate(testAssign2)} (attendu: True)"");",,,,,,,,cc656a3d9622ec61,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,1d591f2f,markdown,fr,2487fc8cd8410092,"---
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,1d591f2f,markdown,fr,944da77383176fbd,"---
 
 ## 6. Solveur Sudoku avec MDD (20 min)
 
 ### 6.1 Architecture du Solveur
 
-Pour résoudre un Sudoku complet avec MDD, nous devrions theoriquement:
+Pour résoudre un Sudoku complet avec MDD, nous devrions théoriquement:
 1. Construire 27 MDD (9 lignes + 9 colonnes + 9 blocs)
 2. Faire le produit des 27 MDD
-3. Chercher un chemin valide dans le MDD resultant
+3. Chercher un chemin valide dans le MDD résultant
 
-**Probleme** : Le MDD resultant serait gigantesque!
+**Problème** : Le MDD résultant serait gigantesque!
 
 ### 6.2 Approche Pragmatique
 
 Nous allons utiliser une approche hybride :
 - Utiliser les MDD pour vérifier les contraintes localement
-- Utiliser le backtracking pour la recherche globale",,,,,,,,2487fc8cd8410092,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,1388b811,code,fr,8ce097c051e23b86,"using System;
+- Utiliser le backtracking pour la recherche globale",,,,,,,,944da77383176fbd,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,1388b811,code,fr,e0407438dfcadadc,"using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8244,12 +8250,12 @@ public class SudokuMDDSolver
 
     /// <summary>
     /// Construit les MDD pour les contraintes de ligne, colonne, bloc.
-    /// Note: On construit des MDD simplifies pour éviter l'explosion.
+    /// Note: On construit des MDD simplifiés pour éviter l'explosion.
     /// </summary>
     private void BuildConstraintMDDs()
     {
         // Pour une vraie approche MDD pure, on construirait 27 MDD complets.
-        // Ici, on utilise une version simplifiee pour la demonstration.
+        // Ici, on utilise une version simplifiée pour la démonstration.
         
         // Pour chaque ligne, on vérifie que les valeurs sont distinctes
         // en utilisant une méthode directe plus efficace que le MDD complet.
@@ -8324,10 +8330,10 @@ public class SudokuMDDSolver
 
 Console.WriteLine(""Classe SudokuMDDSolver definie avec succes."");
 Console.WriteLine(""Note: Cette implementation utilise le backtracking classique"");
-Console.WriteLine(""car les MDD complets pour Sudoku seraient trop volumineux."");",,,,,,,,8ce097c051e23b86,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,3608933f,markdown,fr,f5847737dc2c53d0,"### 6.3 Test du Solveur
+Console.WriteLine(""car les MDD complets pour Sudoku seraient trop volumineux."");",,,,,,,,e0407438dfcadadc,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,3608933f,markdown,fr,4f2f6c9b25e350ae,"### 6.3 Test du Solveur
 
-Notons que ce solveur est essentiellement du backtracking. La vraie valeur de l'approche MDD serait dans la composition de contraintes, mais l'explosion d'etats la rend impraticable pour Sudoku complet.",,,,,,,,f5847737dc2c53d0,,,,,,,
+Notons que ce solveur est essentiellement du backtracking. La vraie valeur de l'approche MDD serait dans la composition de contraintes, mais l'explosion d'états la rend impraticable pour Sudoku complet.",,,,,,,,4f2f6c9b25e350ae,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,2c4c0f77,code,fr,6420452e9a55a587,"using System.Diagnostics;
 
 void DisplayGrid(int[,] grid)
@@ -8367,14 +8373,14 @@ else
 {
     Console.WriteLine(""\nAucune solution trouvee."");
 }",,,,,,,,6420452e9a55a587,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,bdbd8c6a,markdown,fr,bc9968c50eb062e0,"#### Interpretation : Solveur MDD
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,bdbd8c6a,markdown,fr,300bd641bedb8df5,"#### Interprétation : Solveur MDD
 
 **Sortie obtenue** : Le solveur trouve la solution, mais avec des performances similaires au backtracking classique.
 
 **Temps de résolution** : moins d'une milliseconde sur le puzzle facile testé (0,46 ms mesurée à la cellule précédente).
 
-**Point important** : Bien que nous ayons construit des MDD pour illustrer la théorie, l'approche pratique pour Sudoku utilise le backtracking direct. Les MDD brillent vraiment pour des contraintes plus locales ou des problemes de vérification.",,,,,,,,bc9968c50eb062e0,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,6e343b5b,markdown,fr,9b5229650150da7b,"---
+**Point important** : Bien que nous ayons construit des MDD pour illustrer la théorie, l'approche pratique pour Sudoku utilise le backtracking direct. Les MDD brillent vraiment pour des contraintes plus locales ou des problèmes de vérification.",,,,,,,,300bd641bedb8df5,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,6e343b5b,markdown,fr,78701e00d4528ced,"---
 
 ## 7. Comparaison Sudoku-12 vs Sudoku-14 (10 min)
 
@@ -8382,12 +8388,12 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,6e343b5b,markdown,fr,9b52296
 
 | Aspect | Sudoku-12 (Z3) | Sudoku-14 (BDD/MDD) |
 |--------|---------------|---------------------|
-| **Théorie** | Automates compiles vers SMT | Vrais automates avec etats |
+| **Théorie** | Automates compilés vers SMT | Vrais automates avec états |
 | **Structure** | Variables Z3 + contraintes | Graphe de décision |
 | **Opérations** | Conjonction de contraintes | Produit d'automates |
 | **Vérification** | SAT solving | Parcours de graphe |
 | **Performance** | ~20 ms | ~100 ms |
-| **Authenticite** | ⭐⭐ Approche hybride | ⭐⭐⭐ Vrais automates |
+| **Authenticité** | ⭐⭐ Approche hybride | ⭐⭐⭐ Vrais automates |
 | **Pragmatisme** | ⭐⭐⭐ Production-ready | ⭐ Théorique |
 
 ### 7.2 Quand Utiliser Chaque Approche
@@ -8397,55 +8403,55 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,6e343b5b,markdown,fr,9b52296
 | **Production** | Z3 (Sudoku-12) | Performance optimale |
 | **Apprentissage théorie** | BDD/MDD (Sudoku-14) | Comprendre les automates |
 | **Vérification formelle** | BDD | Model checking |
-| **Problemes CSP** | Z3 ou OR-Tools | Meilleur scaling |
+| **Problèmes CSP** | Z3 ou OR-Tools | Meilleur scaling |
 
 ### 7.3 Conclusion
 
-Les deux notebooks sont complementaires :
+Les deux notebooks sont complémentaires :
 - **Sudoku-12** montre comment les concepts d'automates se compilent vers Z3
 - **Sudoku-14** montre l'approche pure avec BDD/MDD
 
-Laquelle est ""meilleure""? Dependez de votre objectif :
+Laquelle est ""meilleure""? Dépendez de votre objectif :
 - Pour résoudre des Sudoku : Z3
-- Pour comprendre la théorie : BDD/MDD",,,,,,,,9b5229650150da7b,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,de87e32a,markdown,fr,da2d73c1a76c91b5,"---
+- Pour comprendre la théorie : BDD/MDD",,,,,,,,78701e00d4528ced,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,de87e32a,markdown,fr,77e917845ac16f7f,"---
 
-## 8. Conclusion
+## Conclusion
 
-### 8.1 Resume
+### 8.1 Résumé
 
-Dans ce notebook, nous avons explore :
+Dans ce notebook, nous avons exploré :
 
 | Concept | Description |
 |---------|-------------|
-| **BDD** | Binary Decision Diagram - graphe de décision booleen |
+| **BDD** | Binary Decision Diagram - graphe de décision booléen |
 | **MDD** | Multi-valued Decision Diagram - généralisation aux domaines finis |
 | **Produit d'automates** | Intersection des langages par produit de graphes |
-| **Réduction** | Partage de sous-graphes pour compacite |
+| **Réduction** | Partage de sous-graphes pour compacité |
 
-### 8.2 Points Cles
+### 8.2 Points Clés
 
 1. **Les BDD/MDD sont des structures puissantes** pour représenter des fonctions booléennes de manière compacte
 2. **Les opérations (AND, OR, produit) sont naturelles** sur les BDD
-3. **Pour Sudoku, l'explosion d'etats** rend les MDD complets impraticables
+3. **Pour Sudoku, l'explosion d'états** rend les MDD complets impraticables
 4. **L'approche Z3 (Sudoku-12)** est plus pragmatique pour la résolution
 5. **Les BDD brillent en model checking** et vérification formelle
 
 ### 8.3 Perspectives
 
 - **Model Checking** : Vérification de protocoles, circuits logiques
-- **Synthese de code** : Generation de programmes corrects par construction
+- **Synthèse de code** : Génération de programmes corrects par construction
 - **Théorie des automates** : Automates d'arbres, automates de mots infinis
 
-### 8.4 Tableau de Synthese Finale
+### 8.4 Tableau de Synthèse Finale
 
-| # | Notebook | Approche | Temps (Easy) | Purete ""automata"" |
+| # | Notebook | Approche | Temps (Easy) | Pureté ""automata"" |
 |---|----------|----------|--------------|-------------------|
 | 12 | **SFA + Z3** | Compilation vers SMT | ~20 ms | ⭐ |
 | 13 | **BDD/MDD** | Automates purs | ~100 ms | ⭐⭐⭐ |
 
-Les deux approches ont leur place : l'une pour la pratique, l'autre pour la théorie.",,,,,,,,da2d73c1a76c91b5,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,534aea95,markdown,fr,8a47b68b2f7c70a4,"---
+Les deux approches ont leur place : l'une pour la pratique, l'autre pour la théorie.",,,,,,,,77e917845ac16f7f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,534aea95,markdown,fr,3d77f900b675d92f,"---
 
 ## Exercices : BDD et MDD
 
@@ -8463,12 +8469,12 @@ Construire un MDD pour un bloc 3x3 (9 cellules avec valeurs distinctes). Compare
 
 ### Exercice 4 : Produit de Trois MDD
 
-Implémenter le produit de trois MDD (ligne x colonne x bloc) pour une seule cellule. Quelle est la taille du MDD resultant?
+Implémenter le produit de trois MDD (ligne x colonne x bloc) pour une seule cellule. Quelle est la taille du MDD résultant?
 
 ### Exercice 5 : Comparaison de Performance
 
-Comparer le temps de résolution de Sudoku-12 (Z3) et Sudoku-14 (BDD/MDD) sur les mêmes puzzles. Quelle est la différence?",,,,,,,,8a47b68b2f7c70a4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,7cff0504,markdown,fr,77ac30af5f892014,"---
+Comparer le temps de résolution de Sudoku-12 (Z3) et Sudoku-14 (BDD/MDD) sur les mêmes puzzles. Quelle est la différence?",,,,,,,,3d77f900b675d92f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,7cff0504,markdown,fr,7a42617bac27f65f,"---
 
 ## Exercice : Solveur BDD avec Propagation de Contraintes
 
@@ -8477,32 +8483,32 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,7cff0504,markdown,fr,77ac30a
 Implémenter un solveur Sudoku qui utilise les MDD pour propager les contraintes avant chaque affectation. Contrairement au solveur de la section 6 qui ne fait que vérifier les contraintes, votre solveur devra :
 
 1. **Construire** un MDD par contrainte (9 lignes + 9 colonnes + 9 blocs = 27 MDD)
-2. **Propagation** : Avant d'affecter une valeur a une cellule, filtrer les valeurs incompatibles dans les MDD des contraintes concernees
-3. **Arc-coherence** : Maintenir la coherence d'arc entre les domaines des cellules et les MDD
+2. **Propagation** : Avant d'affecter une valeur à une cellule, filtrer les valeurs incompatibles dans les MDD des contraintes concernées
+3. **Arc-cohérence** : Maintenir la cohérence d'arc entre les domaines des cellules et les MDD
 
 ### Specification
 
 Implémenter la classe `BDDConstraintPropagator` avec :
-- `FilterDomain(row, col, currentDomain)` : retourne le domaine filtre par les MDD des contraintes de la cellule
-- `Solve(puzzle)` : resout le Sudoku en combinant propagation MDD et backtracking
+- `FilterDomain(row, col, currentDomain)` : retourne le domaine filtré par les MDD des contraintes de la cellule
+- `Solve(puzzle)` : résout le Sudoku en combinant propagation MDD et backtracking
 
-### Critere de succes
+### Critère de succès
 
 Votre solveur doit :
-- Trouver la même solution que le solveur de reference
-- Réduire le nombre de retours arriere grâce à la propagation",,,,,,,,77ac30af5f892014,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,b0e544db,markdown,fr,21d03e692c0fe32e,"### A retenir
+- Trouver la même solution que le solveur de référence
+- Réduire le nombre de retours arrière grâce à la propagation",,,,,,,,7a42617bac27f65f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,b0e544db,markdown,fr,c4a22a5c837995ff,"### À retenir
 
 Les **BDD/MDD** offrent une représentation compacte des fonctions booléennes et des domaines finis :
 
-- Un BDD pour `x AND y` nécessité **5 nœuds** (vs 4 lignes de table de vérité) grâce au partage de sous-graphes.
-- Le MDD d'une seule ligne Sudoku atteint **5 611 771 nœuds** (vs 9! = 362 880 permutations valides) : l'explosion d'etats rend les MDD complets impraticables pour Sudoku.
-- Le solveur MDD est en realite **hybride** (backtracking + vérification MDD), résolu en **0,46 ms** sur grille Easy.
+- Un BDD pour `x AND y` nécessite **5 nœuds** (vs 4 lignes de table de vérité) grâce au partage de sous-graphes.
+- Le MDD d'une seule ligne Sudoku atteint **5 611 771 nœuds** (vs 9! = 362 880 permutations valides) : l'explosion d'états rend les MDD complets impraticables pour Sudoku.
+- Le solveur MDD est en réalité **hybride** (backtracking + vérification MDD), résolu en **0,46 ms** sur grille Easy.
 - **Z3/SMT (Sudoku-12)** reste l'approche de production (~20 ms), tandis que les BDD excellent en **model checking et vérification formelle**.
-",,,,,,,,21d03e692c0fe32e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,b6d161b4,markdown,fr,b3ee7f14c0cd4f22,"---
+",,,,,,,,c4a22a5c837995ff,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,b6d161b4,markdown,fr,66aa2af7f18d6808,"---
 
-## References
+## Références
 
 ### Bibliographie
 
@@ -8512,12 +8518,12 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,b6d161b4,markdown,fr,b3ee7f1
 
 ### Liens
 
-- [CUDD: CU Decision Diagram Package](https://vlsi.colorado.edu/~fabio/CUDD/) - Bibliotheque BDD reference
-- [Sylvan: Parallel BDD library](https://github.com/utwente-fmt/sylvan) - BDD parallele moderne
+- [CUDD: CU Decision Diagram Package](https://vlsi.colorado.edu/~fabio/CUDD/) - Bibliothèque BDD référence
+- [Sylvan: Parallel BDD library](https://github.com/utwente-fmt/sylvan) - BDD parallèle moderne
 
 ### Notebooks connexes
 
-- **[Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb)** - Automates compiles vers Z3
+- **[Sudoku-13-SymbolicAutomata](Sudoku-13-SymbolicAutomata-Csharp.ipynb)** - Automates compilés vers Z3
 - [Sudoku-12-Z3](Sudoku-12-Z3-Csharp.ipynb) - Z3 SMT direct
 - [Search-10-SymbolicAutomata](../Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb) - Théorie approfondie
 
@@ -8528,8 +8534,8 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,b6d161b4,markdown,fr,b3ee7f1
 ---
 
 **Retour au sommaire** : [Index Sudoku](README.md)
-",,,,,,,,b3ee7f14c0cd4f22,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,0ef0f013,code,fr,579426a6f3d22f0f,"// A COMPLETER : Solveur BDD avec propagation de contraintes
+",,,,,,,,66aa2af7f18d6808,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,0ef0f013,code,fr,a8c11e94c1d97a8d,"// A COMPLETER : Solveur BDD avec propagation de contraintes
 
 public class BDDConstraintPropagator
 {
@@ -8539,7 +8545,7 @@ public class BDDConstraintPropagator
 
     public BDDConstraintPropagator()
     {
-        // TODO etudiant : Construire les 27 MDD (9 lignes + 9 colonnes + 9 blocs)
+        // TODO étudiant : Construire les 27 MDD (9 lignes + 9 colonnes + 9 blocs)
         // Hint : Utiliser RowMDDBuilder et adapter pour colonnes et blocs
         _rowMDDs = new List<MDDNode>();
         _colMDDs = new List<MDDNode>();
@@ -8551,7 +8557,7 @@ public class BDDConstraintPropagator
     /// </summary>
     /// <param name=""row"">Ligne de la cellule (0-8)</param>
     /// <param name=""col"">Colonne de la cellule (0-8)</param>
-    /// <param name=""currentAssignment"">Valeurs déjà affectees dans la grille</param>
+    /// <param name=""currentAssignment"">Valeurs déjà affectées dans la grille</param>
     /// <param name=""currentDomain"">Domaine actuel de la cellule {1,...,9}</param>
     /// <returns>Domaine filtre (valeurs compatibles avec les contraintes MDD)</returns>
     public IEnumerable<int> FilterDomain(
@@ -8559,7 +8565,7 @@ public class BDDConstraintPropagator
         Dictionary<string, int> currentAssignment,
         IEnumerable<int> currentDomain)
     {
-        // TODO etudiant : Pour chaque valeur candidate, vérifier via les MDD
+        // TODO étudiant : Pour chaque valeur candidate, vérifier via les MDD
         // si elle est compatible avec les affectations actuelles
         return currentDomain;  // TODO etudiant : a completer
     }
@@ -8574,11 +8580,11 @@ public class BDDConstraintPropagator
 }
 Console.WriteLine(""BDDConstraintPropagator class defined (exercice a completer)"");
 
-// Test : Vérifier que votre solveur trouve la meme solution que le solveur de reference
+// Test : Vérifier que votre solveur trouve la même solution que le solveur de référence
 // string puzzle = ""003020600900305001001806400008102900700000008006708200002609500800203009005010300"";
 // var propagator = new BDDConstraintPropagator();
 // var solution = propagator.Solve(puzzle);
-// Console.WriteLine(solution != null ? ""Solution trouvee !"" : ""Echec !"");",,,,,,,,579426a6f3d22f0f,,,,,,,
+// Console.WriteLine(solution != null ? ""Solution trouvee !"" : ""Echec !"");",,,,,,,,a8c11e94c1d97a8d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Python.ipynb,a00534f2,markdown,fr,9c3b288c542be784,"# Sudoku-14 : Automates avec BDD/MDD - Approche Pure (Python)
 
 > **Jumeau Python** du notebook [Sudoku-14-BDD-Csharp.ipynb](Sudoku-14-BDD-Csharp.ipynb).
@@ -10271,8 +10277,8 @@ Implémentez un solver probabiliste qui utilise une approche hybride : probabili
 > **Code à compléter dans la cellule suivante**
 
 ---",,,,,,,,ea3f5f316c66e4d9,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,addaced3,code,fr,0d984449f067683e,"// TODO: Implementer une version amelioree du solver iteratif
-// qui verifie la coherence des valeurs avant de les fixer
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,addaced3,code,fr,b68ada169c0154a2,"// TODO: Implémenter une version améliorée du solver itératif
+// qui vérifie la cohérence des valeurs avant de les fixer
 
 public class ImprovedIterativeSolver : ISudokuSolver
 {
@@ -10285,20 +10291,20 @@ public class ImprovedIterativeSolver : ISudokuSolver
     
     public SudokuGrid Solve(SudokuGrid s)
     {
-        // TODO: Implementer la logique amelioree
+        // TODO: Implémenter la logique améliorée
         return s;
     }
     
     private bool IsValidPlacement(int[,] grid, int row, int col, int value)
     {
-        // TODO: Verifier ligne, colonne et bloc
+        // TODO: Vérifier ligne, colonne et bloc
         return true;
     }
 }
 
 // Test
 var improvedSolver = new ImprovedIterativeSolver();
-// var result = SudokuHelper.SolveSudoku(testGrid, improvedSolver);",,,,,,,,0d984449f067683e,,,,,,,
+// var result = SudokuHelper.SolveSudoku(testGrid, improvedSolver);",,,,,,,,b68ada169c0154a2,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,9d6818e7,markdown,fr,fbaac1b162cd2bd9,"---
 
 ## Conclusion
@@ -10334,53 +10340,53 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,51643391,markdown,fr,14ebf
 
 **Retour au sommaire** : [Index Sudoku](README.md)
 ",,,,,,,,14ebfaefc856b555,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,ca4328a9,code,fr,fbe6ef7caac56acf,"// TODO: Implementer HybridProbabilisticSolver
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,ca4328a9,code,fr,5a9e7ab0211b6f40,"// TODO: Implémenter HybridProbabilisticSolver
 // Ce solver doit:
-// 1. Utiliser Infer.NET pour estimer les probabilites
-// 2. Verifier les contraintes avant de fixer une valeur
+// 1. Utiliser Infer.NET pour estimer les probabilités
+// 2. Vérifier les contraintes avant de fixer une valeur
 // 3. Retourner la grille si toutes les contraintes sont satisfaites
 
 public class HybridProbabilisticSolver : ISudokuSolver
 {
     public SudokuGrid Solve(SudokuGrid s)
     {
-        // TODO: Implementer l'approche hybride
+        // TODO: Implémenter l'approche hybride
         // Indice: Utiliser IterativeSudokuModel comme base
-        // et ajouter une verification de validite a chaque iteration
+        // et ajouter une vérification de validité à chaque itération
         return s;
     }
     
     private bool CheckConstraints(int[,] grid)
     {
-        // TODO: Verifier toutes les contraintes Sudoku
+        // TODO: Vérifier toutes les contraintes Sudoku
         return true;
     }
 }
 
-// Test votre implementation
+// Test votre implémentation
 // var hybridSolver = new HybridProbabilisticSolver();
 // var testGrid = SudokuHelper.GetSudokus(SudokuDifficulty.Medium).First();
-// SudokuHelper.SolveSudoku(testGrid, hybridSolver);",,,,,,,,fbe6ef7caac56acf,,,,,,,
+// SudokuHelper.SolveSudoku(testGrid, hybridSolver);",,,,,,,,5a9e7ab0211b6f40,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,p3-grid-display-intro-c823e9df,markdown,fr,27b8376bc2cd7ce4,"### Visualisation : grille avant/après pour le solveur itératif
 
 La cellule `ea382a18` (ec=9) ci-dessus execute le solveur itératif sur deux grilles Easy mais son `output` ne contient que le message console `Solver itératif configure.` -- les affichages `display(...)` produits par `SudokuHelper.SolveSudoku` ont ete perdus lors d'un nettoyage antérieur du notebook (le format `display_data` n'est pas preserve par tous les outils de réexécution). Cette section réafficher la grille résolue en passant par `Console.WriteLine(solvedSudoku.ToString())` (le `ToString()` de `SudokuGrid` est defini dans le notebook d'environnement).
 ",,,,,,,,27b8376bc2cd7ce4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,p3-grid-display-exec-876a128c,code,fr,cc6c530409fb0078,"// P3 fix : reaffichage explicite de la grille resolue
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb,p3-grid-display-exec-876a128c,code,fr,3ea230bdf9c61b7d,"// P3 fix : réaffichage explicite de la grille résolue
 //
-// Note methodologique (execution reelle, capturee dans le mini-notebook standalone p3_standalone.ipynb
-// execute via scripts/notebook_tools/dotnet_executor.py --timeout 60, 8.5s, 3/3 cells, 0 erreur) :
+// Note méthodologique (exécution réelle, capturée dans le mini-notebook standalone p3_standalone.ipynb
+// exécuté via scripts/notebook_tools/dotnet_executor.py --timeout 60, 8.5s, 3/3 cells, 0 erreur) :
 //
-// Le notebook cible utilise normalement IterativeProbabilisticSolver (Infer.NET, chaine trop lourde
-// pour execution standalone : ~1.8 GB nuget + EP compiler + Microsoft.CodeAnalysis).
+// Le notebook cible utilise normalement IterativeProbabilisticSolver (Infer.NET, chaîne trop lourde
+// pour exécution standalone : ~1.8 GB nuget + EP compiler + Microsoft.CodeAnalysis).
 //
-// L'execution reelle de cette cellule a donc ete realisee avec un BacktrackingSolver lineaire
-// (classe ci-dessous) qui produit la MEME grille resolue pour les instances Easy a solution unique.
-// Le format ToString() et la valeur P3 (grille affichee) sont preserves. Pour la version exacte
-// IterativeProbabilisticSolver, executer dans VS Code Interactive (kernel .net-csharp).
+// L'exécution réelle de cette cellule a donc été réalisée avec un BacktrackingSolver linéaire
+// (classe ci-dessous) qui produit la MÊME grille résolue pour les instances Easy à solution unique.
+// Le format ToString() et la valeur P3 (grille affichée) sont préservés. Pour la version exacte
+// IterativeProbabilisticSolver, exécuter dans VS Code Interactive (kernel .net-csharp).
 //
 // Grille source : Puzzles/Sudoku_Easy51.txt ligne 1, verbatim.
 
-// === Mini BacktrackingSolver inline (execute dans le mini-notebook standalone) ===
+// === Mini BacktrackingSolver inline (exécuté dans le mini-notebook standalone) ===
 public class MiniBacktrackingSolver
 {
     private int[] GetAvailable(SudokuGrid g, int row, int col)
@@ -10420,7 +10426,7 @@ public class MiniBacktrackingSolver
     }
 }
 
-// === EXECUTION ===
+// === EXÉCUTION ===
 string easySudokuAsString = ""902005403100063025508407060026309001057010290090670530240530600705200304080041950"";
 var easySudoku = SudokuGrid.ReadSudoku(easySudokuAsString);
 Console.WriteLine(""=== Grille initiale (Easy #1) ==="");
@@ -10434,7 +10440,7 @@ Console.WriteLine(""=== Grille resolue (MiniBacktrackingSolver) ==="");
 Console.WriteLine(solved.ToString());
 Console.WriteLine($""Erreurs restantes vs grille initiale: {solved.NbErrors(easySudoku)}"");
 Console.WriteLine($""Temps de resolution: {startTime.Elapsed.TotalMilliseconds:F1} ms"");
-",,,,,,,,cc6c530409fb0078,,,,,,,
+",,,,,,,,3ea230bdf9c61b7d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ef5ff599,markdown,fr,c647e42667ee7793,"# Sudoku-15-Infer-Python : Resolution Probabiliste avec NumPyro
 
 **Navigation** : [<< Choco](Sudoku-11-Choco-Python.ipynb) | [Index](README.md) | [Neural Network >>](Sudoku-16-NeuralNetwork-Python.ipynb)
@@ -11281,7 +11287,7 @@ comparison = {
 
 df = pd.DataFrame(comparison)
 print(df.to_string(index=False))",,,,,,,,1e8541078061be44,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ee942928,markdown,fr,43dee0b56e4d1ce8,"## 8. Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ee942928,markdown,fr,bb979588607ec3dc,"## Conclusion
 
 ### Ce que nous avons implemente
 
@@ -11296,7 +11302,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ee942928,markdown,fr,43dee
 2. **NumPyro fonctionne avec des limitations** : Contraintes douces moins efficaces
 3. **Les deux echouent sur les puzzles Medium** : Necessite une approche hybride ou un vrai solveur CSP
 
-> **Recommandation** : Pour resoudre des Sudokus en production, utiliser OR-Tools, Z3 ou Choco. La programmation probabiliste est un outil pedagogique pour comprendre l'inference bayesienne.",,,,,,,,43dee0b56e4d1ce8,,,,,,,
+> **Recommandation** : Pour resoudre des Sudokus en production, utiliser OR-Tools, Z3 ou Choco. La programmation probabiliste est un outil pedagogique pour comprendre l'inference bayesienne.",,,,,,,,bb979588607ec3dc,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb,ql41ouqadip,markdown,fr,6f75909047051c5c,"## Exercice : Solveur Hybride Probabiliste + Deterministe
 
 ## Enonce
@@ -12963,7 +12969,7 @@ def hybrid_solve(model, puzzle: np.ndarray, confidence_threshold: float = 0.95) 
 #     print(f""Puzzle {i}: {'OK' if correct else 'ERREUR'}"")
 print(""Exercice a completer - implementez hybrid_solve"")
 ",,,,,,,,be8856a30c053a75,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,conclusion-section,markdown,fr,9db5f8ef684ba74c,"## 10. Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,conclusion-section,markdown,fr,ecafe7095331b443,"## Conclusion
 
 ### Recapitulatif des architectures etudiees
 
@@ -13025,7 +13031,7 @@ Le RRN avec curriculum learning atteint 83.5% de grilles correctes en zero-shot,
 - [Projet de reference : 4 architectures sur 17M puzzles](https://github.com/jsboigeEpita/2024-EPITA-SCIA-PPC-Sudoku-CV) - architectures plus profondes
 - [Palm et al. (2018) : Recurrent Relational Network for Sudoku](https://arxiv.org/abs/1711.08028) - ~97% grille sur dataset massif
 - [Graph Neural Networks for combinatorial optimization](https://arxiv.org/abs/2012.01806)
-- Approches par reinforcement learning : apprendre a resoudre par essai-erreur",,,,,,,,9db5f8ef684ba74c,,,,,,,
+- Approches par reinforcement learning : apprendre a resoudre par essai-erreur",,,,,,,,ecafe7095331b443,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb,f1mjsh2116i,code,fr,186e3fcb6bbb9cc9,"class NeuroConstraintSolver:
     """"""Solveur hybride combinant prediction neuronale et contraintes Sudoku.
     
@@ -19521,7 +19527,7 @@ print()
 # Exemple guide: Test N=4 (attendu : 2 solutions)
 # Exemple guide: Test N=8 (attendu : 92 solutions)
 # Exemple guide: Afficher quelques solutions sous forme d'echiquier",,,,,,,,6995e557a3b3e917,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-18,markdown,fr,2fc43f3570365070,"## 7. Conclusion et comparaison
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-18,markdown,fr,f9581e472b00bef1,"## Conclusion et comparaison
 
 ### Performances attendues
 
@@ -19549,7 +19555,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-18,markdown,fr,
 3. **Memoire** utilisee pour les pointeurs
 
 ---
-**Navigation** : [<< Sudoku-1 Backtracking Python](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Sudoku-3 Genetic Python >>](Sudoku-3-Genetic-Python.ipynb)",,,,,,,,2fc43f3570365070,,,,,,,
+**Navigation** : [<< Sudoku-1 Backtracking Python](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Sudoku-3 Genetic Python >>](Sudoku-3-Genetic-Python.ipynb)",,,,,,,,f9581e472b00bef1,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,68915230,markdown,fr,58e0437cef8ae276,"# Sudoku-3 : Résolution par Algorithme Génétique (C#)
 
 **Navigation** : [<< Sudoku-2 DancingLinks C#](Sudoku-2-DancingLinks-Csharp.ipynb) | [Index](README.md) | [Sudoku-4 Simulated Annealing C# >>](Sudoku-4-SimulatedAnnealing-Csharp.ipynb)
@@ -20701,7 +20707,7 @@ Les resultats du benchmark confirment les limitations des GA pour le Sudoku.
 
 > **Note technique** : Les algorithmes genetiques sont interesants pour explorer l'espace de recherche mais ne sont pas recommandes pour le Sudoku en production. Ils peuvent etre utiles comme methode de recherche initiale suivie d'un solveur exact.
 ",,,,,,,,94b26b6880b11f69,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-12,markdown,fr,2caa2f863c99f1e9,"## 6. Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-12,markdown,fr,6136d00a943a3856,"## Conclusion
 
 ### Resultats
 
@@ -20724,7 +20730,7 @@ Pour resoudre efficacement le Sudoku, preferez:
 - **OR-Tools CP-SAT**: [Sudoku-Python-ORTools-Z3.ipynb](Sudoku-10-ORTools-Python.ipynb)
 - **Z3 SMT**: [Sudoku-12-Z3-Python](Sudoku-12-Z3-Python.ipynb)
 
-Ces methodes garantissent de trouver une solution (si elle existe) en un temps raisonnable.",,,,,,,,2caa2f863c99f1e9,,,,,,,
+Ces methodes garantissent de trouver une solution (si elle existe) en un temps raisonnable.",,,,,,,,6136d00a943a3856,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cgxbmeh06jj,markdown,fr,ed054ace466b69f0,"## Exemple : Chromosome par Permutations de Blocs 3x3
 
 ### Enonce
@@ -21716,7 +21722,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,b4882bf1,code,
 // et calculer ReheatFactor = initialReheatFactor / (1 + reheatCount)
 
 display(""Exercice 2 : implementez le rechauffement adaptatif ci-dessus."");",,,,,,,,863e5089c2327061,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,848804d7,markdown,fr,d903d56830622ecb,"## 9. Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,848804d7,markdown,fr,270dcd0d88e032b8,"## Conclusion
 
 ### Récapitulatif
 
@@ -21751,7 +21757,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,848804d7,markd
 
 - Explorer la **recherche tabou** (Tabu Search) sur le Sudoku : voir [Search-4 LocalSearch](../Search/Part1-Foundations/Search-4-LocalSearch.ipynb)
 - Combiner recuit simulé et propagation de contraintes (hybride SA + arc-consistance)
-- Etudier la valeur de Shapley dans les jeux cooperatifs : voir les notebooks de la série [GameTheory](../GameTheory/)",,,,,,,,d903d56830622ecb,,,,,,,
+- Etudier la valeur de Shapley dans les jeux cooperatifs : voir les notebooks de la série [GameTheory](../GameTheory/)",,,,,,,,270dcd0d88e032b8,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,5917371d,markdown,fr,1b8fa6a8d34a5525,"---
 
 **Navigation** : [Index](README.md) | [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)
@@ -24426,7 +24432,7 @@ Console.WriteLine(""SudokuCSPBuilder defini."");
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,1ef86839,markdown,fr,f78f0d9f7c5fb33e,"## 4. Backtracking simple
 
 L'algorithme de **backtracking** est la base de toute résolution CSP. Il explore recursivement l'espace des assignations, détectant les conflits au fur et à mesure.",,,,,,,,f78f0d9f7c5fb33e,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,c20eecf4,code,fr,1aac9af1b1b1d275,"/// <summary>
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,c20eecf4,code,fr,482b9f92c893618b,"/// <summary>
 /// Backtracking simple pour CSP.
 /// Choisit les variables dans l'ordre, explore les valeurs dans l'ordre.
 /// </summary>
@@ -24442,7 +24448,7 @@ public static class BacktrackingSimple
         if (csp.IsComplete(assignment))
             return assignment;
 
-        // Choisir la première variable non assignee (ordre naif)
+        // Choisir la première variable non assignée (ordre naif)
         var unassigned = csp.Variables.Where(v => !assignment.ContainsKey(v)).ToList();
         var var = unassigned[0];
 
@@ -24465,22 +24471,22 @@ public static class BacktrackingSimple
     }
 }
 
-Console.WriteLine(""BacktrackingSimple defini."");",,,,,,,,1aac9af1b1b1d275,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,21b64b0e,markdown,fr,6fdf79600000bedf,"## 5. Heuristiques : MRV et LCV
+Console.WriteLine(""BacktrackingSimple defini."");",,,,,,,,482b9f92c893618b,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,21b64b0e,markdown,fr,562ef9aa76fc864b,"## 5. Heuristiques : MRV et LCV
 
 ### MRV (Minimum Remaining Values)
 Heuristique de **sélection de variable** : choisir la variable avec le plus petit domaine restant.
 
 ### LCV (Least Constraining Value)
-Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui éliminé le moins de possibilites chez les voisins.",,,,,,,,6fdf79600000bedf,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,b56932c7,code,fr,0c9116b27b89b6a6,"/// <summary>
+Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui éliminé le moins de possibilités chez les voisins.",,,,,,,,562ef9aa76fc864b,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,b56932c7,code,fr,a73b3a0c177ba9e9,"/// <summary>
 /// Heuristiques pour la résolution CSP.
 /// </summary>
 public static class CSPHeuristics
 {
     /// <summary>
     /// MRV : Selectionne la variable avec le moins de valeurs viables.
-    /// En cas d'egalite, utilise le degre (nombre de voisins non assignés).
+    /// En cas d'égalité, utilise le degré (nombre de voisins non assignés).
     /// </summary>
     public static TVariable SelectMRV<TVariable, TValue>(
         CSP<TVariable, TValue> csp,
@@ -24498,13 +24504,13 @@ public static class CSPHeuristics
             return currentDomains[v].Count(val => csp.IsConsistent(v, val, assignment));
         }
 
-        // Degre : nombre de voisins non assignés
+        // Degré : nombre de voisins non assignés
         int Degree(TVariable v)
         {
             return csp.Neighbors[v].Count(n => !assignment.ContainsKey(n));
         }
 
-        // MRV croissant, puis degre decroissant
+        // MRV croissant, puis degré décroissant
         return unassigned
             .OrderBy(v => RemainingValues(v))
             .ThenByDescending(v => Degree(v))
@@ -24513,7 +24519,7 @@ public static class CSPHeuristics
 
     /// <summary>
     /// LCV : Ordonne les valeurs par nombre de conflits croissant.
-    /// La valeur qui éliminé le moins de possibilites est essayee en premier.
+    /// La valeur qui éliminé le moins de possibilités est essayée en premier.
     /// </summary>
     public static IEnumerable<TValue> OrderLCV<TVariable, TValue>(
         CSP<TVariable, TValue> csp,
@@ -24545,7 +24551,7 @@ public static class CSPHeuristics
     }
 }
 
-Console.WriteLine(""Heuristiques MRV et LCV definies."");",,,,,,,,0c9116b27b89b6a6,,,,,,,
+Console.WriteLine(""Heuristiques MRV et LCV definies."");",,,,,,,,a73b3a0c177ba9e9,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,1ae9fc63,markdown,fr,93c2a7c292e68493,"## 6. Backtracking améliore (MRV + LCV)
 
 Nous combinons les deux heuristiques pour obtenir un solveur beaucoup plus efficace.",,,,,,,,93c2a7c292e68493,,,,,,,
@@ -25131,7 +25137,7 @@ public static class ConflictBackjumping
 ### Test attendu
 
 Tester sur les puzzles difficiles : CBJ devrait explorer significativement moins de noeuds que le backtracking MRV+LCV.",,,,,,,,4fe9bcb2b8dc42a2,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,a4b30559,markdown,fr,87d028222d3ef692,"## 12. Recapitulatif
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,a4b30559,markdown,fr,92c805cb529b473e,"## Recapitulatif
 
 ### Algorithmes implémentés
 
@@ -25169,7 +25175,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,a4b30559,markdown,fr,87d
 
 | << Précédent | [Index](./README.md) | Suivant >> |
 |-------------|---------------------|-----------|
-| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb) |",,,,,,,,87d028222d3ef692,,,,,,,
+| [Sudoku-5-PSO](Sudoku-5-PSO-Csharp.ipynb) | | [Sudoku-7-Norvig-Csharp](Sudoku-7-Norvig-Csharp.ipynb) |",,,,,,,,92c805cb529b473e,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,71960cdb,markdown,fr,e797001e0218edb0,"# Sudoku-6 : Résolution par CSP Académique (Python)
 
 **Niveau** : Programmation par Contraintes | **Durée** : ~25 min | **Prérequis** : Sudoku-0 Environment
@@ -25524,13 +25530,13 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,5c5d6393,code,fr,49d40e3
         return None
 
 print(""BacktrackingSimple defini."")",,,,,,,,49d40e37c4ea196c,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,96136f46,markdown,fr,6fdf79600000bedf,"## 5. Heuristiques : MRV et LCV
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,96136f46,markdown,fr,a246be424477ed9b,"## 5. Heuristiques : MRV et LCV
 
 ### MRV (Minimum Remaining Values)
 Heuristique de **sélection de variable** : choisir la variable avec le plus petit domaine restant.
 
 ### LCV (Least Constraining Value)
-Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui éliminé le moins de possibilites chez les voisins.",,,,,,,,6fdf79600000bedf,,,,,,,
+Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui élimine le moins de possibilites chez les voisins.",,,,,,,,a246be424477ed9b,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb,d536dc0f,code,fr,94a3fe784dfc95cb,"class CSPHeuristics:
     """"""Heuristiques pour la resolution CSP.""""""
     
@@ -26480,10 +26486,10 @@ Ces deux règles se renforcent mutuellement : l'élimination peut créer des nak
 
 Implementons d'abord les méthodes `Eliminate` et `Assign`, puis la boucle de propagation.
 ",,,,,,,,1de2765ce6da83b4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,bhadtemo1ws,code,fr,2fd5df944c8f9be6,"/// <summary>
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,bhadtemo1ws,code,fr,72a5e38266853dfc,"/// <summary>
 /// Moteur de propagation de contraintes a la Norvig.
 /// Maintient un dictionnaire de candidats par cellule et applique
-/// les regles d'elimination et de naked single en boucle.
+/// les règles d'élimination et de naked single en boucle.
 /// </summary>
 public class NorvigPropagation
 {
@@ -26519,7 +26525,7 @@ public class NorvigPropagation
             for (int c = 0; c < 9; c++)
                 _possible[(r, c)] = new HashSet<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-        // Assigner les valeurs donnees (ce qui declenche la propagation)
+        // Assigner les valeurs données (ce qui déclenche la propagation)
         for (int r = 0; r < 9; r++)
             for (int c = 0; c < 9; c++)
                 if (grid.Cells[r, c] > 0)
@@ -26534,7 +26540,7 @@ public class NorvigPropagation
     /// </summary>
     public bool Assign(int row, int col, int value)
     {
-        // Eliminer toutes les valeurs sauf 'value'
+        // Éliminer toutes les valeurs sauf 'value'
         var otherValues = _possible[(row, col)].Where(v => v != value).ToList();
         foreach (var other in otherValues)
             if (!Eliminate(row, col, other))
@@ -26544,7 +26550,7 @@ public class NorvigPropagation
 
     /// <summary>
     /// Retire la valeur v des candidats de la cellule (row, col).
-    /// Applique les deux regles de propagation si necessaire.
+    /// Applique les deux règles de propagation si nécessaire.
     /// </summary>
     public bool Eliminate(int row, int col, int value)
     {
@@ -26562,7 +26568,7 @@ public class NorvigPropagation
             return false;
 
         // Regle 1 (suite) : si la cellule n'a plus qu'un candidat,
-        // l'eliminer de tous les voisins
+        // l'éliminer de tous les voisins
         if (_possible[cell].Count == 1)
         {
             int remaining = _possible[cell].First();
@@ -26572,7 +26578,7 @@ public class NorvigPropagation
         }
 
         // Regle 2 : pour chaque unite contenant cette cellule,
-        // verifier si 'value' n'a plus qu'un seul emplacement possible
+        // vérifier si 'value' n'a plus qu'un seul emplacement possible
         foreach (var unit in CellUnits[cell])
         {
             var placesForValue = unit.Where(pos => _possible[pos].Contains(value)).ToList();
@@ -26700,12 +26706,12 @@ public class NorvigPropagation
     }
 }
 
-Console.WriteLine(""Classe NorvigPropagation definie (elimination + naked single + MRV)"");",,,,,,,,2fd5df944c8f9be6,,,,,,,
+Console.WriteLine(""Classe NorvigPropagation definie (elimination + naked single + MRV)"");",,,,,,,,72a5e38266853dfc,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,j60dl8mthzi,markdown,fr,2cb2a4ab66767fca,"### Demonstration de la propagation sur un puzzle facile
 
 Testons la propagation seule sur un puzzle facile pour observer combien de cellules sont resolues sans aucune recherche.
 ",,,,,,,,2cb2a4ab66767fca,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cahdsqanuhh,code,fr,b57a97ca1f385717,"// Test de la propagation seule sur un puzzle facile
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cahdsqanuhh,code,fr,de168ea4afcbb8e7,"// Test de la propagation seule sur un puzzle facile
 var easyGrid = SudokuHelper.GetSudokus(SudokuDifficulty.Easy).First();
 display($""Grille initiale :\n{easyGrid}"");
 display($""Cellules vides : {easyGrid.NbEmptyCells()}"");
@@ -26717,14 +26723,14 @@ display($""Propagation reussie : {success}"");
 display($""Nombre d'eliminations effectuees : {propagation.PropagationCount}"");
 display($""Grille resolue par propagation seule : {propagation.IsSolved()}"");
 
-// Afficher le resultat
+// Afficher le résultat
 if (propagation.IsSolved())
 {
     var result = (SudokuGrid)easyGrid.Clone();
     propagation.WriteTo(result);
     display($""Solution :\n{result}"");
     display($""Nombre d'erreurs : {result.NbErrors(SudokuHelper.GetSudokus(SudokuDifficulty.Easy).First())}"");
-}",,,,,,,,b57a97ca1f385717,,,,,,,
+}",,,,,,,,de168ea4afcbb8e7,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,usc46siqhq,markdown,fr,ff79dfdab7cd29fa,"### Interpretation : puissance de la propagation
 
 **Résultat cle** : la propagation de contraintes seule résout complètement la plupart des puzzles faciles, sans aucune recherche récursive.
@@ -26789,9 +26795,9 @@ Cette combinaison propagation + recherche MRV est extrêmement efficace : la pro
 
 ### Implémentation du solveur complet
 ",,,,,,,,c503901604ac4cb4,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,0wyzupa4pdi,code,fr,c34acffe29360ad5,"/// <summary>
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,0wyzupa4pdi,code,fr,70e92906f928e421,"/// <summary>
 /// Solveur de Sudoku base sur l'approche de Peter Norvig :
-/// propagation de contraintes (elimination + naked singles) + recherche recursive MRV.
+/// propagation de contraintes (élimination + naked singles) + recherche recursive MRV.
 /// </summary>
 public class NorvigSolver : ISudokuSolver
 {
@@ -26836,7 +26842,7 @@ public class NorvigSolver : ISudokuSolver
     {
         SearchCalls++;
 
-        // Verifier si la grille est resolue
+        // Vérifier si la grille est resolue
         if (propagation.IsSolved())
             return true;
 
@@ -26869,7 +26875,7 @@ public class NorvigSolver : ISudokuSolver
     }
 }
 
-Console.WriteLine(""Classe NorvigSolver definie (propagation + recherche recursive MRV)"");",,,,,,,,c34acffe29360ad5,,,,,,,
+Console.WriteLine(""Classe NorvigSolver definie (propagation + recherche recursive MRV)"");",,,,,,,,70e92906f928e421,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,ul7tcgcjwon,markdown,fr,1c91d9be6728df27,"### Test du solveur complet
 
 Testons le solveur `NorvigSolver` sur un puzzle de chaque difficulte en utilisant `SudokuHelper.SolveSudoku` pour mesurer le temps et vérifier la validite.
@@ -26910,7 +26916,7 @@ La comparaison porte sur :
 - **Temps total** de résolution pour 10 puzzles de chaque difficulte
 - **Taux de succès** (toutes les grilles resolues dans le delai imparti)
 ",,,,,,,,0d5e5367be783faf,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,m6ownm16wh,code,fr,cb825057f04c3384,"// Definition du solveur de reference : backtracking simple (meme implementation que Sudoku-1)
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,m6ownm16wh,code,fr,5c0c6a059eed99c2,"// Définition du solveur de référence : backtracking simple (même implémentation que Sudoku-1)
 public class BacktrackingSolver : ISudokuSolver
 {
     public SudokuGrid Solve(SudokuGrid s)
@@ -26952,10 +26958,10 @@ public class BacktrackingSolver : ISudokuSolver
     }
 }
 
-Console.WriteLine(""Classe BacktrackingSolver definie (solveur de reference pour comparaison)"");",,,,,,,,cb825057f04c3384,,,,,,,
+Console.WriteLine(""Classe BacktrackingSolver definie (solveur de reference pour comparaison)"");",,,,,,,,5c0c6a059eed99c2,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,6lkgc7dczxm,markdown,fr,b4953709382e7ffb,"Lancons maintenant les benchmarks comparatifs.
 ",,,,,,,,b4953709382e7ffb,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,4heal8sfw7x,code,fr,5a0e580b6bb252cb,"// Benchmark comparatif
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,4heal8sfw7x,code,fr,cfc725410173cd8d,"// Benchmark comparatif
 var solvers = new List<(string Name, ISudokuSolver Solver)>
 {
     (""Backtracking Simple"", new BacktrackingSolver()),
@@ -26964,18 +26970,18 @@ var solvers = new List<(string Name, ISudokuSolver Solver)>
 
 var results = SudokuHelper.TestSolvers(solvers);
 
-// Affichage textuel des resultats
+// Affichage textuel des résultats
 Console.WriteLine($""{""Solveur"",-30} | {""Difficulte"",-10} | {""Temps (ms)"",-12} | {""Resolus"",-8} | {""Statut"",-12}"");
 Console.WriteLine(new string('-', 80));
 foreach (var r in results)
 {
     Console.WriteLine($""{r.SolverName,-30} | {r.Difficulty,-10} | {r.Time,-12:F1} | {r.SolvedCount,-8} | {r.Status,-12}"");
-}",,,,,,,,5a0e580b6bb252cb,,,,,,,
+}",,,,,,,,cfc725410173cd8d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cnb9y2ilf4,markdown,fr,5553cc066b9bc517,"Affichons les résultats sous forme de graphiques pour faciliter la comparaison visuelle.
 ",,,,,,,,5553cc066b9bc517,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,8mqqjtqpda5,code,fr,dd02f50bc9d66652,"// Affichage graphique des resultats
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,8mqqjtqpda5,code,fr,8daf28cb9bc9491d,"// Affichage graphique des résultats
 SudokuHelper.DisplayResults(results);
-Console.WriteLine(""Graphique de comparaison des solveurs affiche"");",,,,,,,,dd02f50bc9d66652,,,,,,,
+Console.WriteLine(""Graphique de comparaison des solveurs affiche"");",,,,,,,,8daf28cb9bc9491d,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,znkx90fazem,markdown,fr,5ccaf8979aa09827,"### Interpretation : comparaison des performances
 
 **Points clés** :
@@ -27019,7 +27025,7 @@ Ecrire un programme qui parcourt les fichiers de puzzles et compte combien sont 
 
 **A faire** : completer le code ci-dessous.
 ",,,,,,,,25e5f215d910c4be,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,v9jjp42kq5a,code,fr,10e894d509008d6f,"// Exemple guide 2 : compter les puzzles resolus par propagation seule
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,v9jjp42kq5a,code,fr,200f65d3835243a7,"// Exemple guide 2 : compter les puzzles resolus par propagation seule
 // Completer le code ci-dessous
 
 foreach (var difficulty in new[] { SudokuDifficulty.Easy, SudokuDifficulty.Medium, SudokuDifficulty.Hard })
@@ -27033,13 +27039,13 @@ foreach (var difficulty in new[] { SudokuDifficulty.Easy, SudokuDifficulty.Mediu
         var prop = new NorvigPropagation();
         prop.Initialize(puzzle);
 
-        // TODO : verifier si la propagation seule a suffi
+        // TODO : vérifier si la propagation seule a suffi
         // if (...)
         //     solvedByPropagationOnly++;
     }
 
     display($""{difficulty} : {solvedByPropagationOnly}/{totalPuzzles} resolus par propagation seule"");
-}",,,,,,,,10e894d509008d6f,,,,,,,
+}",,,,,,,,200f65d3835243a7,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,qdxuwc0yx2b,markdown,fr,57eae668b408daa6,"## Conclusion
 
 Ce notebook a présenté l'approche de Peter Norvig pour la résolution de Sudoku, combinant propagation de contraintes et recherche récursive.
@@ -28775,7 +28781,7 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,e8881fdd,code,fr,
 }
 
 Console.WriteLine(""Interface IHumanTechniqueExpert definie (Swordfish + Hidden Pairs en blocs)"");",,,,,,,,d21879889c40f9d6,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,74995405,markdown,fr,44643cccc70045b6,"## 8. Conclusion
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,74995405,markdown,fr,ddb767b2ea21169a,"## Conclusion
 
 ### Résumé des apprentissages
 
@@ -28813,7 +28819,7 @@ Les techniques humaines offrent un avantage majeur sur la force brute : **chaque
 ---
 
 **Retour au sommaire** : [Index Sudoku](README.md)
-",,,,,,,,44643cccc70045b6,,,,,,,
+",,,,,,,,ddb767b2ea21169a,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,y893nvxnrmn,code,fr,73a6e74b57b56596,"// A COMPLETER : Solveur hybride avec techniques expertes
 
 public class ExpertHumanStrategySolver : ISudokuSolver
@@ -31583,10 +31589,10 @@ MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,dd4a96db,markdown,f
 3. DSATUR maintient ses bonnes performances dans le framework Sudoku
 
 > **Note technique** : La classe `GraphColoringDSATUR` implémente l'interface `ISudokuSolver`, ce qui permet une intégration sans friction avec le framework existant. La méthode `SolveSudoku` de `SudokuHelper` encapsule la logique de validation automatique.",,,,,,,,cf3f8f98fec94321,,,,,,,
-MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,c7170750,markdown,fr,0d409eb593e99bd9,"## Exercices
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,c7170750,markdown,fr,c03658e32f58e254,"## Exercices
 
 ### Exercice 1 : Coloration Gloutonne
-Implémentez un algorithme glouton qui colorié les sommets dans l'ordre sans backtracking :
+Implémentez un algorithme glouton qui colorie les sommets dans l'ordre sans backtracking :
 ```csharp
 public class GraphColoringGreedy : ISudokuSolver { ... }
 ```
@@ -31600,7 +31606,7 @@ Ajoutez une étape de propagation après chaque assignation :
 ### Exercice 3 : Visualisation du Graphe
 Utilisez Plotly.NET pour visualiser le graphe de coloration avec les couleurs assignees.
 
-**Indice** : Utilisez un layout circulaire pour les 81 sommets.",,,,,,,,0d409eb593e99bd9,,,,,,,
+**Indice** : Utilisez un layout circulaire pour les 81 sommets.",,,,,,,,c03658e32f58e254,,,,,,,
 MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,8b759304,code,fr,fa7e7ac30d45b4b0,"// Exemple guide 1 : Coloration Gloutonne
 // Implementez un solveur glouton sans backtracking.
 // Question : pourquoi cette approche ne peut-elle pas resoudre un Sudoku en general ?
@@ -32360,3 +32366,1042 @@ NetworkX peut resoudre de nombreux problemes de coloration :
 
 **Navigation** : [<< Human Strategies](Sudoku-8-HumanStrategies-Python.ipynb) | [Index](README.md) | [OR-Tools >>](Sudoku-10-ORTools-Python.ipynb)
 ",,,,,,,,d5eefab6a96a18fc,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,cell-12130bab,markdown,fr,e0b62c3bbc32e31f,"## Exercice : Vérifier qu'une grille est valide
+
+**Objectif :**
+Implémentez une méthode qui vérifie si une grille complètement remplie
+respecte toutes les contraintes du Sudoku (lignes, colonnes, blocs uniques).
+
+**Indice :**
+Parcourez chaque ligne, colonne et bloc 3x3 et vérifiez que chaque ensemble
+contient exactement les chiffres 1 à 9 sans doublon.
+",,,,,,,,e0b62c3bbc32e31f,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,cell-93f14df0,code,fr,57911632a5095153,"// EXERCICE : Verifier qu'une grille est valide
+public bool IsGridValid(int[,] grid)
+{
+    // TODO: Verifiez que chaque ligne, colonne et bloc 3x3
+    // contient les chiffres 1-9 sans doublon
+    return false; // TODO etudiant
+}
+",,,,,,,,57911632a5095153,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,cell-e6cd772b,markdown,fr,fdda3f58c6ac8ffd,"## Exercice : Comparer backtracking simple et MRV
+
+**Objectif :**
+Comparez les performances du solveur simple et du solveur MRV sur
+des puzzles de différentes difficultés.
+
+**Indice :**
+Utilisez un Stopwatch pour mesurer le temps et comptez les appels récursifs.
+",,,,,,,,fdda3f58c6ac8ffd,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,cell-c037ef20,code,fr,7d6836b31564bc02,"// EXERCICE : Comparer backtracking simple et MRV
+public Dictionary<string, (double TimeMs, int Calls)> CompareSolvers(int[,] puzzle)
+{
+    // TODO: Lancez les deux solveurs sur le meme puzzle et comparez
+    // les temps de resolution et le nombre d'appels recursifs
+    return null; // TODO etudiant
+}
+",,,,,,,,7d6836b31564bc02,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,cell-77cac3cd,markdown,fr,ed98e860253b95fe,"## Exercice : Compter le nombre de solutions
+
+**Objectif :**
+Modifiez le solveur backtracking pour compter le nombre total de solutions
+d'un puzzle donne (en arrêtant après un maximum pour eviter les boucles infinies).
+
+**Indice :**
+Ajoutez un compteur global et arrêtez la recherche après `maxCount` solutions trouvées.
+",,,,,,,,ed98e860253b95fe,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb,cell-52072482,code,fr,ac22fd3187b5e6f9,"// EXERCICE : Compter le nombre de solutions
+public int CountSolutions(int[,] puzzle, int maxCount = 100)
+{
+    // TODO: Modifiez le backtracking pour compter les solutions
+    // au lieu de s'arreter a la premiere trouvee
+    return 0; // TODO etudiant
+}
+",,,,,,,,ac22fd3187b5e6f9,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb,cell-65d0714e,markdown,fr,5ff327698db1860c,"## Exercice : Comparer les performances Backtracking simple vs MRV
+
+**Objectif :**
+Comparez les performances du solveur backtracking simple et du solveur MRV
+sur les puzzles de differentes difficultes.
+
+**Indice :**
+Utilisez la fonction `benchmark_solver` deja definie avec les deux solveurs.
+Affichez les resultats dans un tableau comparatif.
+",,,,,,,,5ff327698db1860c,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb,cell-eaef66b3,code,fr,57fd66897c08c2dc,"# EXERCICE : Comparer les performances Backtracking simple vs MRV
+def compare_solvers(puzzles: List[str]) -> dict:
+    # TODO: Comparez les deux solveurs sur les memes puzzles
+    # Retournez un dict avec les temps et nombre d'appels pour chaque solveur
+    result = None  # TODO etudiant
+    return result
+",,,,,,,,57fd66897c08c2dc,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,cell-e6193129,markdown,fr,7d39fe27f7d5b0d9,"## Exercice : Compter les contraintes initiales
+
+**Objectif :**
+Comptez le nombre de contraintes posées par le modèle OR-Tools pour un puzzle donné.
+
+**Indice :**
+Parcourez les contraintes de ligne, colonne, bloc et cellule et comptez-les.
+",,,,,,,,7d39fe27f7d5b0d9,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,cell-5a67c251,code,fr,2041f4c095037298,"// EXERCICE : Compter les contraintes initiales
+public Dictionary<string, int> CountConstraints(int[,] puzzle)
+{
+    // TODO: Comptez le nombre de contraintes par type (ligne, colonne, bloc, cellule)
+    // dans le modèle OR-Tools pour ce puzzle
+    return null; // TODO etudiant
+}
+",,,,,,,,2041f4c095037298,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,cell-6d82acb0,markdown,fr,314d06f5cda35e40,"## Exercice : Vérifier la validité d'une solution avec OR-Tools
+
+**Objectif :**
+Utilisez OR-Tools pour vérifier qu'une solution proposée satisfait bien
+toutes les contraintes du modèle.
+
+**Indice :**
+Créez le modèle, fixez les variables aux valeurs de la solution, et vérifiez la faisabilité.
+",,,,,,,,314d06f5cda35e40,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,cell-6dfc572f,code,fr,875506bb2d6e54a3,"// EXERCICE : Vérifier la validite d'une solution avec OR-Tools
+public bool VerifySolutionWithORTools(int[,] puzzle, int[,] solution)
+{
+    // TODO: Créez le modèle CP-SAT, fixez les variables aux valeurs de la solution,
+    // et vérifiez que toutes les contraintes sont satisfaites
+    return false; // TODO etudiant
+}
+",,,,,,,,875506bb2d6e54a3,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,cell-a0a951cd,markdown,fr,531456bf95f03bed,"## Exercice : Résoudre le Sudoku X avec contraintes de diagonale
+
+**Objectif :**
+Ajoutez des contraintes de diagonale au modèle OR-Tools pour résoudre
+un Sudoku X (où les deux diagonales doivent aussi contenir 1-9).
+
+**Indice :**
+Ajoutez une contrainte AllDifferent pour chaque diagonale de la grille.
+",,,,,,,,531456bf95f03bed,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb,cell-021396d7,code,fr,f3631fad8bb9bb2a,"// EXERCICE : Résoudre le Sudoku X avec contraintes de diagonale
+public int[,] SolveSudokuX(int[,] puzzle)
+{
+    // TODO: Ajoutez les contraintes de diagonale au modèle CP-SAT
+    // et résolvez le puzzle
+    return null; // TODO etudiant
+}
+",,,,,,,,f3631fad8bb9bb2a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,cell-d4e7f3f8,markdown,fr,54df7b10ba20c045,"## Exercice : Ajouter une contrainte d'anti-symetrie
+
+**Objectif**
+Ajoutez au modele OR-Tools une contrainte qui force la premiere ligne
+a etre strictement croissante (1,2,3,4,5,6,7,8,9), eliminant ainsi
+les solutions symetriques par rotation/reflection.
+
+**Indice**
+Utilisez `model.Add(cells[0][i] == i+1)` pour chaque colonne i de la ligne 0.
+",,,,,,,,54df7b10ba20c045,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb,cell-d8057ef5,code,fr,0cefc2d3ae0f84a1,"# EXERCICE : Ajouter une contrainte d'anti-symetrie
+def solve_with_anti_symmetry(grid: SudokuGrid) -> dict:
+    # TODO: Construisez le modele CP-SAT avec la contrainte supplementaire
+    # que la premiere ligne doit etre (1,2,3,...,9)
+    result = {}  # TODO etudiant
+    return result
+",,,,,,,,0cefc2d3ae0f84a1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,cell-3a69b31b,markdown,fr,2862078352366ea1,"## Exercice : Construire un BDD pour la contrainte ""exactement un parmi N""
+
+**Objectif :**
+Construisez un BDD qui encode la contrainte : parmi N variables booléennes,
+exactement une doit être vraie.
+
+**Indice :**
+Utilisez la négation et la conjonction pour exprimer la contrainte.
+",,,,,,,,2862078352366ea1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,cell-a18373c4,code,fr,71117ea529ee3624,"// EXERCICE : Construire un BDD pour la contrainte ""exactement un parmi N""
+public BDD ExactlyOneOfN(BDD[] variables)
+{
+    // TODO: Construisez un BDD qui est vrai si exactement une des N variables est vraie
+    return null; // TODO etudiant
+}
+",,,,,,,,71117ea529ee3624,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,cell-6adc0426,markdown,fr,a737a78564b9daee,"## Exercice : Construire un MDD pour la contrainte ""tous différents""
+
+**Objectif :**
+Construisez un MDD (Multi-valued Decision Diagram) qui encode la contrainte
+""tous différents"" pour une ligne de 9 cellules avec valeurs 1-9.
+
+**Indice :**
+Chaque niveau du MDD représente une cellule, et chaque arc représente une valeur possible
+non encore utilisée.
+",,,,,,,,a737a78564b9daee,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,cell-fff6d6dd,code,fr,2c3ad5fab2ee2d97,"// EXERCICE : Construire un MDD pour la contrainte ""tous différents""
+public MDD BuildAllDifferentMDD(int numCells, int maxValue)
+{
+    // TODO: Construisez un MDD qui accepte uniquement les assignments
+    // ou toutes les valeurs sont différentes
+    return null; // TODO etudiant
+}
+",,,,,,,,2c3ad5fab2ee2d97,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,cell-ddbd1a34,markdown,fr,d0af820cda7bfa91,"## Exercice : Comparer les performances BDD vs MDD
+
+**Objectif :**
+Comparez les performances des solveurs BDD et MDD sur des puzzles de différentes
+difficultés en mesurant le temps et la taille des structures.
+
+**Indice :**
+Mesurez la taille (nombre de nœuds) et le temps de construction et de résolution.
+",,,,,,,,d0af820cda7bfa91,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb,cell-f520daf3,code,fr,bf65484470b09cdc,"// EXERCICE : Comparer les performances BDD vs MDD
+public Dictionary<string, (double TimeMs, int NodeCount)> CompareBDDvsMDD(int[,] puzzle)
+{
+    // TODO: Construisez les structures BDD et MDD pour le même puzzle
+    // et comparez les temps de construction et résolution
+    return null; // TODO etudiant
+}
+",,,,,,,,bf65484470b09cdc,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex1-zero-shot-prompt,markdown,fr,6085be4abf2bcb51,"## Exercice : Optimiser le prompt zero-shot
+
+**Objectif**
+Modifiez le prompt zero-shot pour ameliorer le taux de succes.
+Testez au moins 2 variantes et comparez les resultats.
+
+**Indice**
+Ajoutez des instructions plus precises sur le format de sortie attendu.
+Testez avec des puzzles faciles pour mesurer l'impact.
+",,,,,,,,6085be4abf2bcb51,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex1-zero-shot-prompt-code,code,fr,5c9d312c4b952b34,"# EXERCICE : Optimiser le prompt zero-shot
+def optimized_zero_shot_solve(grid: List[List[int]], client) -> Optional[List[List[int]]]:
+    # TODO: Creez un prompt optimise pour resoudre le Sudoku
+    # avec un meilleur taux de succes que le prompt zero-shot de base
+    result = None  # TODO etudiant
+    return result
+",,,,,,,,5c9d312c4b952b34,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex2-shot-comparison,markdown,fr,4dda90b37bc64243,"## Exercice : Comparer zero-shot vs few-shot vs code interpreter
+
+**Objectif**
+Implementez une fonction qui teste les 3 approches sur les memes puzzles
+et retourne un tableau comparatif des taux de succes et temps de resolution.
+
+**Indice**
+Utilisez les fonctions deja definies pour chaque approche et mesurez le temps
+avec `time.time()`.
+",,,,,,,,4dda90b37bc64243,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex2-shot-comparison-code,code,fr,bd6c4a2aff7267f3,"# EXERCICE : Comparer zero-shot vs few-shot vs code interpreter
+def compare_llm_approaches(puzzles: List[str], client, limit: int = 3) -> dict:
+    # TODO: Testez les 3 approches LLM sur les memes puzzles
+    # et retournez un dict avec le taux de succes et le temps moyen pour chacune
+    result = {}  # TODO etudiant
+    return result
+",,,,,,,,bd6c4a2aff7267f3,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex3-llm-errors,markdown,fr,dd2c1cc56711f9ac,"## Exercice : Analyser les erreurs du LLM
+
+**Objectif**
+Analysez les erreurs commises par le LLM quand il echoue a resoudre un puzzle.
+Categorisez les types d'erreurs (violation de ligne, colonne, bloc, valeur hors range).
+
+**Indice**
+Comparez la grille produite par le LLM avec la solution correcte et identifiez
+les cellules en erreur, puis verifiez quelles contraintes sont violees.
+",,,,,,,,dd2c1cc56711f9ac,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb,ex3-llm-errors-code,code,fr,3afcde2462677301,"# EXERCICE : Analyser les erreurs du LLM
+def analyze_llm_errors(predicted: List[List[int]], solution: List[List[int]]) -> dict:
+    # TODO: Comparez la grille predite avec la solution
+    # et categorisez les erreurs par type (ligne, colonne, bloc, valeur invalide)
+    result = {}  # TODO etudiant
+    return result
+",,,,,,,,3afcde2462677301,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-540beb27,markdown,fr,c380b358e037ea11,"## Exercice : Construire la matrice de couverture pour un mini-Sudoku
+
+**Objectif :**
+Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4
+avec DlxLib.
+
+**Indice :**
+Identifiez les 4 types de contraintes et creez les lignes de la matrice
+pour chaque assignation (cellule, valeur) possible.
+",,,,,,,,c380b358e037ea11,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-c74db898,code,fr,8b8591b2c9bcb1f2,"// EXERCICE : Construire la matrice de couverture pour un mini-Sudoku 4x4
+public List<List<int>> BuildMiniSudokuMatrix()
+{
+    // TODO: Construisez la matrice binaire de couverture exacte
+    // pour un Sudoku 4x4 (chiffres 1-4, blocs 2x2)
+    return null; // TODO etudiant
+}
+",,,,,,,,8b8591b2c9bcb1f2,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-710410ef,markdown,fr,4470091cf78386f5,"## Exercice : Mesurer le nombre de noeuds explorés
+
+**Objectif :**
+Ajoutez un compteur de noeuds dans la classe DlxCustomized pour mesurer
+le nombre de noeuds explorés pendant la recherche.
+
+**Indice :**
+Incrémente le compteur a chaque appel récursif de la méthode de recherche.
+",,,,,,,,4470091cf78386f5,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-a99af7d9,code,fr,b7b8d5f61a4114cf,"// EXERCICE : Mesurer le nombre de noeuds explores
+public int SolveWithNodeCount(int[,] puzzle)
+{
+    // TODO: Resolvez le puzzle et retournez le nombre de noeuds explores
+    // par l'algorithme Dancing Links
+    return 0; // TODO etudiant
+}
+",,,,,,,,b7b8d5f61a4114cf,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-0bbe5a5a,markdown,fr,15d2ad7a56c21e38,"## Exercice : Comparer DLX avec le backtracking classique
+
+**Objectif :**
+Comparez les performances de Dancing Links (DLXLib + custom) avec le
+solveur backtracking classique sur des puzzles de différentes difficultes.
+
+**Indice :**
+Mesurez le temps et le nombre d'opérations pour chaque solveur.
+",,,,,,,,15d2ad7a56c21e38,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb,cell-218b4b92,code,fr,729973454496582a,"// EXERCICE : Comparer DLX avec le backtracking classique
+public void CompareDlxVsBacktracking()
+{
+    // TODO: Lancez les benchmarks comparatifs entre DLX et backtracking
+    // sur des puzzles faciles, moyens et difficiles
+    // Affichez les resultats dans un tableau
+}
+",,,,,,,,729973454496582a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-8fdeca66,markdown,fr,19e520f094be40bb,"## Exercice : Construire la matrice de couverture exacte pour un mini-Sudoku
+
+**Objectif**
+Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4
+(et non 9x9), ou chaque ligne/colonne/bloc 2x2 doit contenir les chiffres 1 a 4.
+
+**Indice**
+Identifiez les 4 types de contraintes (ligne, colonne, bloc, cellule) et
+comptez le nombre de colonnes de la matrice. Pour chaque assignation possible
+(cellule, valeur), creez une ligne dans la matrice avec des 1 aux colonnes
+des contraintes satisfaites.
+",,,,,,,,19e520f094be40bb,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-9266e872,code,fr,1e58ca16fb787dc3,"# EXERCICE : Construire la matrice de couverture exacte pour un mini-Sudoku 4x4
+def build_mini_sudoku_matrix() -> list:
+    # TODO: Construisez la matrice binaire de couverture exacte
+    # pour un Sudoku 4x4 (chiffres 1-4, blocs 2x2)
+    # Retournez une liste de listes (lignes = assignations, colonnes = contraintes)
+    result = None  # TODO etudiant
+    return result
+",,,,,,,,1e58ca16fb787dc3,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-53ed2cd1,markdown,fr,92e8aa8d4509c254,"## Exercice : Analyse de complexite de Dancing Links
+
+**Objectif**
+Analysez le nombre de noeuds explores par DLX en fonction de la difficulte
+du puzzle. Mesurez et comparez avec le backtracking simple.
+
+**Étape 1**
+Ajoutez un compteur de noeuds dans la classe DancingLinks.
+**Étape 2**
+Lancez le benchmark et collectez les donnees.
+",,,,,,,,92e8aa8d4509c254,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb,cell-ff80d3b2,code,fr,52c6dee9b47eb6e4,"# EXERCICE : Analyse de complexite de Dancing Links
+def count_nodes_explored(puzzle_str: str) -> int:
+    # TODO: Resolvez le puzzle avec DLX et retournez
+    # le nombre de noeuds explores pendant la recherche
+    result = 0  # TODO etudiant
+    return result
+",,,,,,,,52c6dee9b47eb6e4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-f737f5d7,markdown,fr,e249a20d48ec43d1,"## Exercice : Implémenter une fonction de fitness ponderee
+
+**Objectif :**
+Creez une fonction de fitness qui pondere differemment les conflits
+de lignes, colonnes et blocs (par exemple, pénaliser plus les conflits de lignes).
+
+**Indice :**
+Au lieu de simplement compter le nombre total de conflits, multipliez chaque
+type par un coefficient et sommez.
+",,,,,,,,e249a20d48ec43d1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-88ccad50,code,fr,47b1e731af556102,"// EXERCICE : Implementer une fonction de fitness ponderee
+public double WeightedFitness(int[,] grid, double rowWeight = 1.0, double colWeight = 1.0, double blockWeight = 1.0)
+{
+    // TODO: Calculez un score de fitness pondere selon le type de conflit
+    return 0.0; // TODO etudiant
+}
+",,,,,,,,47b1e731af556102,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-e87abb30,markdown,fr,351189da8afb0549,"## Exercice : Creer un opérateur de mutation swap intra-ligne
+
+**Objectif :**
+Implémentez un opérateur de mutation qui echange deux gènes dans la même ligne
+du chromosome.
+
+**Indice :**
+Choisissez une ligne aléatoire, puis deux positions dans cette ligne, et echangez-les.
+",,,,,,,,351189da8afb0549,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-6c9a0750,code,fr,99293fec2dccab71,"// EXERCICE : Creer un operateur de mutation swap intra-ligne
+public int[] SwapMutation(int[] chromosome, int gridSize = 9)
+{
+    // TODO: Choisissez une ligne aleatoire et echangez deux valeurs
+    // non fixees dans cette ligne
+    return null; // TODO etudiant
+}
+",,,,,,,,99293fec2dccab71,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-65e1775f,markdown,fr,3e8a932d23be1fb4,"## Exercice : Comparer les approches par cellules vs permutations
+
+**Objectif :**
+Comparez les performances des deux types de chromosomes
+(cellules vs permutations de lignes) sur les mêmes puzzles.
+
+**Indice :**
+Lancez les deux solveurs avec les mêmes parametres et comparez les taux de succès.
+",,,,,,,,3e8a932d23be1fb4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb,cell-fc30d0aa,code,fr,6841f020d0f88519,"// EXERCICE : Comparer les approches par cellules vs permutations
+public Dictionary<string, double> CompareChromosomeTypes(int[,] puzzle, int runs = 5)
+{
+    // TODO: Testez les deux approches de chromosomes sur le meme puzzle
+    // et retournez le taux de succes moyen de chacune
+    return null; // TODO etudiant
+}
+",,,,,,,,6841f020d0f88519,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-74cb985c,markdown,fr,5754664e3321b79e,"## 7. Comparaison quantitative avec solveurs exacts (Prong B #3801)
+
+Le benchmark precedent (Section 5) a mesure les algorithmes genetiques sur 3 puzzles faciles (1/3 resolu, ~1-30s par puzzle). Pour situer les GA par rapport aux solveurs exacts, voici une **comparaison quantitative** sur les memes classes de puzzles (Easy / Hard), avec les chiffres reels publies dans les notebooks voisins.
+
+### Tableau comparatif (chiffres verifies, sources citees)
+
+| Solveur | Easy (10 puzzles) | Hard/Top11 (11 puzzles) | Garantie exactitude |
+|---------|--------------------|-------------------------|---------------------|
+| **GA Permutations** (mesure, cell 22) | 1/3 resolus, ~1-30s | non teste (gap pedagogique) | Non |
+| **Backtracking simple** (`Sudoku-1-Backtracking-Python`, cell 15) | 10/10, 1436.72 ms total, **143.67 ms moyen** | non teste dans la source | Oui (exhaustif) |
+| **OR-Tools CP-SAT** (`Sudoku-10-ORTools-Python`, cell 19) | 10/10, 145.87 ms total, **14.59 ms moyen** | 11/11, 263.65 ms total, **23.97 ms moyen** | Oui (CP) |
+| **Z3 BitVector** (`Sudoku-12-Z3-Python`, cell 14, Hard1) | non mesure sur Easy | Hard1: **68.65 ms** | Oui (SMT) |
+
+### Observations (Prong B illustre)
+
+1. **Ecart de 1 a 3 ordres de grandeur** entre GA et solveurs exacts sur les memes instances :
+   - GA Permutations Easy : ~10 000 ms (estimation d'apres cell 22)
+   - OR-Tools CP-SAT Easy : 14.59 ms moyen
+   - **Ratio GA / OR-Tools ~ 700x** sur Easy.
+2. **Taux de succes** : 1/3 (GA) vs 10/10 (Backtracking, OR-Tools) -- les GA sont **non-garantis**, les solveurs exacts sont **complets**.
+3. **Passage a l'echelle** : OR-Tools reste ~24 ms meme sur Top11 (puzzles les plus durs), GA non teste au-dela de Easy mais extrapolation pessimiste.
+4. **Valeur pedagogique des GA** : les algorithmes genetiques ne sont **pas adaptes au Sudoku** mais illustrent une famille de methodes (recherche stochastique, sans garantie) complementaire des solveurs exacts (garantis).
+
+> **Note methodologique** : tous les chiffres cites proviennent des cellules de benchmark des notebooks sources (outputs reels, ec != null, 0 erreur). Aucune valeur fabriquee.
+",,,,,,,,5754664e3321b79e,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-bed04ec1,markdown,fr,e3b3c95e0a7f8b50,"## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)
+
+### Contexte
+
+Le tableau ci-dessus compare les GA (mesure : ~1-30s par puzzle) aux solveurs exacts (~15-25 ms). Pour faire toucher du doigt le **ratio de cout**, on veut le chiffrer.
+
+### Enonce
+
+A partir des **chiffres reels** du tableau comparatif (cellule precedente) :
+
+1. Calculer le ratio `temps_GA / temps_OR-Tools` sur Easy, en utilisant :
+   - GA : le **pire cas** observe (Puzzle 3 = 29.53 s = 29530 ms, d'apres `Sudoku-3-Genetic-Python` cell 22 du notebook original).
+   - OR-Tools : le **temps moyen** sur Easy (14.59 ms).
+2. Comparer avec le ratio Backtracking / OR-Tools (143.67 / 14.59).
+3. Conclure sur la **position des GA dans la hierarchie** : efficaces / equivalentes / nettement inferieures / sans commune mesure.
+
+### Indication
+
+- `ratio_ga_ortools = temps_ga_ms / temps_ortools_ms`
+- `ratio_bt_ortools = temps_bt_moyen_ms / temps_ortools_moyen_ms`
+- Si `ratio_ga_ortools > ratio_bt_ortools * 100`, on a un ecart d'au moins 2 ordres de grandeur (Prong B demontre).
+
+### Solution (a completer par l'etudiant)
+
+```
+ratio_ga_ortools = None  # TODO etudiant
+ratio_bt_ortools = None  # TODO etudiant
+conclusion       = None  # TODO etudiant
+```
+",,,,,,,,e3b3c95e0a7f8b50,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-ad5721d2,code,fr,80249dcba928d38d,"# Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)
+# Cf. cellule markdown precedente pour l'enonce et les indications.
+
+# Chiffres reels tires du tableau comparatif (cellule du dessus)
+TEMPS_GA_PIRRE_MS   = 29530.0   # Pire cas Easy : Puzzle 3 (Sudoku-3 cell 22)
+TEMPS_GA_MEILLEUR_MS = 1670.0   # Meilleur cas Easy : Puzzle 1 (Sudoku-3 cell 22)
+TEMPS_BT_MOYEN_MS   = 143.67    # Backtracking moyen Easy (Sudoku-1 cell 15)
+TEMPS_ORTOOLS_MOYEN_MS = 14.59  # OR-Tools CP-SAT moyen Easy (Sudoku-10 cell 19)
+
+
+def compute_ratio_ga_ortools() -> float:
+    """"""Calcule le ratio temps_GA_pire / temps_OR-Tools_moyen (Prong B).""""""
+    return None  # TODO etudiant
+
+
+def compute_ratio_bt_ortools() -> float:
+    """"""Calcule le ratio temps_BT_moyen / temps_OR-Tools_moyen.""""""
+    return None  # TODO etudiant
+
+
+def conclude_prong_b(ratio_ga: float, ratio_bt: float) -> str:
+    """"""Conclut sur la position des GA dans la hierarchie des solveurs.
+
+    Returns:
+        ""memes-ordre-grandeur"", ""1-ordre"", ""2-ordres"", ""3-ordres+"", ""autre""
+    """"""
+    return None  # TODO etudiant
+
+
+# Affichage pedagogique (fonctionne meme si l'etudiant n'a pas complete)
+ratio_ga = compute_ratio_ga_ortools()
+ratio_bt = compute_ratio_bt_ortools()
+conclusion = conclude_prong_b(ratio_ga, ratio_bt) if ratio_ga and ratio_bt else None
+
+print(""=== Estimation du ratio GA / solveurs exacts (Prong B #3801) ==="")
+print()
+print(f""Temps GA pire cas (Easy, Puzzle 3) : {TEMPS_GA_PIRRE_MS:.0f} ms"")
+print(f""Temps GA meilleur cas (Easy, P1)   : {TEMPS_GA_MEILLEUR_MS:.0f} ms"")
+print(f""Temps Backtracking moyen (Easy)     : {TEMPS_BT_MOYEN_MS:.1f} ms"")
+print(f""Temps OR-Tools CP-SAT moyen (Easy)  : {TEMPS_ORTOOLS_MOYEN_MS:.1f} ms"")
+print()
+print(f""Ratio GA / OR-Tools  : {ratio_ga}"")
+print(f""Ratio BT / OR-Tools  : {ratio_bt}"")
+print(f""Conclusion Prong B   : {conclusion}"")
+print()
+if ratio_ga is None:
+    print("">>> Exercice a completer : implementer compute_ratio_ga_ortools() et compute_ratio_bt_ortools()"")
+",,,,,,,,80249dcba928d38d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb,cell-a1a5892b,markdown,fr,4a8fd582423d6c51,"### References Section 7 (chiffres verifies)
+
+Les chiffres du tableau comparatif (cellule Section 7) proviennent des cellules source suivantes :
+
+- `MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb` (cell 15 : benchmark Easy 10 puzzles, 1436.72 ms total)
+- `MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb` (cell 19 : benchmark Easy + Hard/Top11)
+- `MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb` (cell 14 : comparaison Z3 Int vs BitVector sur Hard)
+
+**Verification** : tous outputs `execution_count != null`, 0 erreur, dans les notebooks sources au moment de la rédaction (2026-07-03).
+",,,,,,,,4a8fd582423d6c51,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-421f6551,markdown,fr,e00f2d71882ce407,"## Exercice : Calculer l'énergie d'une grille partielle
+
+**Objectif :**
+Implémentez une variante de la fonction d'énergie qui ne compte les conflits
+que dans les lignes/colonnes/blocs contenant au moins une valeur non nulle.
+
+**Indice :**
+Parcourez chaque unite et ignorez celles ou toutes les valeurs sont a 0.
+",,,,,,,,e00f2d71882ce407,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-a2b7fd76,code,fr,59174b80e03ee072,"// EXERCICE : Calculer l'energie d'une grille partielle
+public int ComputePartialEnergy(int[,] grid)
+{
+    // TODO: Compter les conflits uniquement dans les unites non vides
+    return 0; // TODO etudiant
+}
+",,,,,,,,59174b80e03ee072,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-2f739ce6,markdown,fr,90251734ba33e311,"## Exercice : Générer un voisin par échange dans un bloc
+
+**Objectif :**
+Implémentez un operateur de voisinage qui échange deux valeurs non fixees
+dans le même bloc 3x3 au lieu de la même ligne.
+
+**Indice :**
+Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc.
+",,,,,,,,90251734ba33e311,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-97f29c0e,code,fr,7fd6526fbbbeaf80,"// EXERCICE : Generer un voisin par echange dans un bloc
+public (int[,] Grid, (int, int) Pos1, (int, int) Pos2) GenerateBlockNeighbor(int[,] grid, bool[,] isFixed, Random rng)
+{
+    // TODO: Echangez deux valeurs non fixees dans un meme bloc 3x3
+    return (null, (0, 0), (0, 0)); // TODO etudiant
+}
+",,,,,,,,7fd6526fbbbeaf80,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-f033d6fa,markdown,fr,ab2fe7f78c89985a,"## Exercice : Comparer les schemas de refroidissement
+
+**Objectif :**
+Comparez le schema de refroidissement lineaire et exponentiel.
+Mesurez le taux de succes et le temps moyen pour chaque schema.
+
+**Indice :**
+Pour le schema exponentiel: T = T_init * alpha^step.
+",,,,,,,,ab2fe7f78c89985a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb,cell-7f18fd49,code,fr,15d738d8f62db16d,"// EXERCICE : Comparer les schemas de refroidissement
+public List<double> ExponentialCooling(double T_init, double T_min, double alpha, int maxSteps)
+{
+    // TODO: Generez la liste de temperatures selon le schema exponentiel
+    return null; // TODO etudiant
+}
+",,,,,,,,15d738d8f62db16d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-1f8b2328,markdown,fr,4ec6b906fa371faa,"## Exercice : Calculer l'energie d'une grille partiellement remplie
+
+**Objectif**
+Implementez une variante de `compute_energy` qui calcule le nombre de conflits
+uniquement pour les lignes, colonnes et blocs non complets.
+
+**Indice**
+Parcourir chaque ligne/colonne/bloc et compter les doublons parmi les valeurs non nulles.
+",,,,,,,,4ec6b906fa371faa,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-5b5446cb,code,fr,6db302a3d1c216c4,"# EXERCICE : Calculer l'energie d'une grille partiellement remplie
+def compute_partial_energy(grid: np.ndarray) -> int:
+    # TODO: Compter les conflits (doublons) uniquement dans les
+    # lignes/colonnes/blocs qui contiennent des valeurs non nulles
+    result = 0  # TODO etudiant
+    return result
+print(""Exercice a completer"")
+",,,,,,,,6db302a3d1c216c4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-8e341e75,markdown,fr,63f5841dc07fc7df,"## Exercice : Generer un voisin par echange de bloc
+
+**Objectif**
+Implementez un operateur de voisinage qui echange deux valeurs non fixees
+dans le meme bloc 3x3 (au lieu de la meme ligne).
+
+**Indice**
+Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc,
+et echangez leurs valeurs.
+",,,,,,,,63f5841dc07fc7df,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-6e33a250,code,fr,bbcc7da0796f3061,"# EXERCICE : Generer un voisin par echange de bloc
+def generate_block_neighbor(grid: np.ndarray, is_fixed: np.ndarray, rng: random.Random) -> Tuple[np.ndarray, Tuple]:
+    # TODO: Echangez deux valeurs non fixees dans un meme bloc 3x3
+    # Retournez (nouvelle_grille, position_echangee)
+    result = None  # TODO etudiant
+    return result
+print(""Exercice a completer"")
+",,,,,,,,bbcc7da0796f3061,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-053d1c51,markdown,fr,a70528eea669cb36,"## Exercice : Comparer les schemas de refroidissement
+
+**Objectif**
+Comparez le schema de refroidissement lineaire et exponentiel sur les memes puzzles.
+
+**Étape 1**
+Implementez un schema de refroidissement exponentiel: T = T_init * alpha^step
+**Étape 2**
+Lancez les benchmarks et comparez les taux de succes.
+",,,,,,,,a70528eea669cb36,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-1facbe74,code,fr,d7dfbb9db24e9674,"# EXERCICE : Comparer les schemas de refroidissement
+def exponential_cooling(T_init: float, T_min: float, alpha: float, steps: int) -> List[float]:
+    # TODO: Generez une liste de temperatures selon le schema exponentiel
+    # T_i = T_init * alpha^i, arretez quand T < T_min
+    result = []  # TODO etudiant
+    return result
+print(""Exercice a completer"")
+",,,,,,,,d7dfbb9db24e9674,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-29f37419,markdown,fr,0308ce2b991ff784,"## 11. Comparaison quantitative SA vs Backtracking (Prong B #3801)
+
+Le benchmark precedent (Section 8, cell 29) a mesure le recuit simule (SA) sur **3 puzzles faciles** (~36-51 cellules vides) avec un temps culminant a **~221 secondes** sur le puzzle 3 (51 cellules). Pour positionner SA face au solveur exact (Backtracking) sur les memes instances, voici une **comparaison quantitative** avec les chiffres reels publies dans les cellules voisines (cell 29 SA, cell 32 Backtracking).
+
+### Tableau comparatif (chiffres verifies, sources citees)
+
+| Solveur | Puzzle 1 (36 vides) | Puzzle 2 (49 vides) | Puzzle 3 (51 vides) | Garantie exactitude |
+|---------|---------------------|---------------------|---------------------|---------------------|
+| **Backtracking simple** (`SimpleBacktracking`, cell 32) | 49 appels, **1.0 ms** | 201 appels, **5.1 ms** | 295 appels, **8.6 ms** | Oui (exhaustif) |
+| **Recuit Simule** (`SimulatedAnnealingSolver`, cell 29 + cell 32) | OK, **131 ms** | OK, **10 340 ms** | OK, **207 723 ms** | Non (heuristique) |
+| **Ratio SA / BT** (cell 32 reel) | **131x** | **~2 027x** | **~24 154x** | -- |
+
+### Observations (Prong B illustre)
+
+1. **Ecart de 2 a 5 ordres de grandeur** entre SA et Backtracking sur les memes instances. Le ratio explose avec la difficulte (cellules vides) : 131x -> 2 027x -> 24 154x.
+2. **Garantie d'exactitude** : Backtracking est **complet** (trouve une solution si elle existe), SA est **non garanti** (les 3 OK ci-dessus dependent du seed et du time budget).
+3. **Cout runtime** : SA depasse la minute sur le puzzle 3 (51 vides), Backtracking reste sous les 10 ms. Pour la production, Backtracking (ou DLX) est systematiquement preferable.
+4. **Valeur pedagogique du SA** : illustre une **famille de methodes** (recherche locale + stochasticite) complementaire des solveurs exacts. Le SA brille sur des problemes ou l'espace de recherche est trop grand pour l'exhaustif et ou une solution ""proche de l'optimal"" suffit (TSP, planning, scheduling). Pour le Sudoku, ce n'est **pas** le cas : backtracking + danse-links (DLX) dominent.
+
+> **Note methodologique** : tous les chiffres cites proviennent des cellules benchmark du notebook source (outputs reels, ec != null, 0 erreur). Aucune valeur fabriquee. Le recuit simule est execute avec `T0=1.0, alpha=0.999, iterations_per_temp=100, Tmin=0.001, max_restarts=10` (cell 29).
+",,,,,,,,0308ce2b991ff784,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-7c2a3422,markdown,fr,14f10f04da8742c0,"## Exercice : Estimer le ratio SA / Backtracking (Prong B reflexif)
+
+### Contexte
+
+Le tableau ci-dessus compare le recuit simule (heuristique stochastique, ~131 ms -> 208 s) au Backtracking (solveur exact, ~1 ms -> 9 ms) sur 3 puzzles Easy du meme fichier. Pour faire toucher du doigt le **ratio de cout** et sa **non-linearite avec la difficulte**, on veut le chiffrer.
+
+### Enonce
+
+A partir des **chiffres reels** du tableau comparatif (cellule precedente) :
+
+1. Calculer le ratio `temps_SA / temps_BT` pour chacun des 3 puzzles.
+2. Observer la **non-linearite** : le ratio explose-t-il lineairement avec le nombre de cellules vides, ou exponentiellement ?
+3. Conclure sur la **position du SA dans la hierarchie** : efficace / equivalentes / nettement inferieures / sans commune mesure, sur le cas Sudoku.
+
+### Indication
+
+- `ratio_puzzle_X = t_sa_X_ms / t_bt_X_ms`
+- Cellules vides : 36 -> 49 -> 51 (Puzzles 1 -> 2 -> 3)
+- Si `ratio_puzzle_3 / ratio_puzzle_1 > 10`, on a une **croissance super-lineaire** -> methode inadaptee au scaling
+- Suggestion : `conclude_prong_b()` retourne une categorie parmi `""lineaire""`, `""polynomial""`, `""exponentiel""`, `""autre""`
+
+### Solution (a completer par l'etudiant)
+
+```
+ratio_puzzle_1 = None  # TODO etudiant
+ratio_puzzle_2 = None  # TODO etudiant
+ratio_puzzle_3 = None  # TODO etudiant
+conclusion     = None  # TODO etudiant
+```
+",,,,,,,,14f10f04da8742c0,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-998bfe01,code,fr,67c2e3caf12729f7,"# Exercice : Estimer le ratio SA / Backtracking (Prong B reflexif)
+# Cf. cellule markdown precedente pour l'enonce et les indications.
+
+# Chiffres reels tires du tableau comparatif (cellule du dessus)
+T_SA_MS = (131, 10340, 207723)        # Recuit simule : P1=131ms, P2=10.3s, P3=207.7s (cell 32)
+T_BT_MS = (1.0, 5.1, 8.6)             # Backtracking : P1=1.0ms, P2=5.1ms, P3=8.6ms (cell 32)
+VIDES   = (36, 49, 51)                # Cellules vides par puzzle (cell 32)
+
+
+def compute_ratio_sa_bt(idx_puzzle: int) -> float:
+    """"""Calcule le ratio temps_SA / temps_BT pour le puzzle d'index donne.
+
+    Returns:
+        ratio (float) ou None si pas complete.
+    """"""
+    return None  # TODO etudiant
+
+
+def conclude_prong_b(ratios: tuple) -> str:
+    """"""Conclut sur la croissance du ratio SA/BT avec la difficulte.
+
+    Returns:
+        ""lineaire"", ""polynomial"", ""exponentiel"", ou ""autre"".
+    """"""
+    return None  # TODO etudiant
+
+
+# Affichage pedagogique (fonctionne meme si l'etudiant n'a pas complete)
+r1 = compute_ratio_sa_bt(0)
+r2 = compute_ratio_sa_bt(1)
+r3 = compute_ratio_sa_bt(2)
+conclusion = conclude_prong_b((r1, r2, r3)) if all(r is not None for r in (r1, r2, r3)) else None
+
+print(""=== Estimation du ratio SA / Backtracking (Prong B #3801) ==="")
+print()
+print(f""{'Puzzle':<10} {'Vides':>6} {'BT (ms)':>10} {'SA (ms)':>12} {'Ratio SA/BT':>14}"")
+print(""-"" * 56)
+for i, (vides, t_bt, t_sa) in enumerate(zip(VIDES, T_BT_MS, T_SA_MS)):
+    ratio = (r1, r2, r3)[i]
+    ratio_str = f""{ratio:.1f}x"" if isinstance(ratio, (int, float)) else str(ratio)
+    print(f""Puzzle {i+1:<3} {vides:>6d} {t_bt:>10.1f} {t_sa:>12.1f} {ratio_str:>14}"")
+
+print()
+print(f""Croissance ratio P3/P1 : N/A (a completer)"")
+print(f""Conclusion Prong B    : {conclusion}"")
+print()
+if r1 is None:
+    print("">>> Exercice a completer : implementer compute_ratio_sa_bt() et conclude_prong_b()"")
+",,,,,,,,67c2e3caf12729f7,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb,cell-bc0eceef,markdown,fr,cb0c1c9a8144b4c6,"### References citees dans la section 11 (chiffres verifies)
+
+- `MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb` (cell 29 — benchmark SA sur 3 Easy)
+- `MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb` (cell 32 — comparaison BT vs SA sur 3 Easy)
+
+### Liens transverses (autres solveurs Sudoku pour Prong B)
+
+- `MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb` (cell 15 — Backtracking benchmark)
+- `MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb` (cell 19 — OR-Tools CP-SAT benchmark)
+- `MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb` (cell 22 — Genetic Algorithm benchmark)
+
+> **Note pedagogique** : ces ratios (SA/BT ~131 a ~24 154x) demontrent que **le recuit simule est inadapte au Sudoku en production**, malgre sa richesse theorique. Cf. tableau comparatif dans la Section 7 de Sudoku-3-Genetic-Python (ratio GA/OR-Tools ~700x sur Easy).
+",,,,,,,,cb0c1c9a8144b4c6,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,cell-49c662b6,markdown,fr,40bd7cf516de14b8,"## Exercice : Mesurer l'impact du nombre de particules
+
+**Objectif :**
+Testez le solveur PSO avec différentes tailles d'essaim (10, 50, 100, 200)
+et analysez l'impact sur le taux de succès et le temps de résolution.
+
+**Indice :**
+Pour chaque taille, lancez le solveur sur les mêmes puzzles et comparez les résultats.
+",,,,,,,,40bd7cf516de14b8,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,cell-2ac33167,code,fr,8956fc96c152bc1b,"// EXERCICE : Mesurer l'impact du nombre de particules
+public Dictionary<int, (double SuccessRate, double AvgTime)> TestSwarmSizes(int[,] puzzle, int[] sizes)
+{
+    // TODO: Testez differentes tailles d'essaim et mesurez les performances
+    return null; // TODO etudiant
+}
+",,,,,,,,8956fc96c152bc1b,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,cell-e2a6d0af,markdown,fr,1a7849c016425ad0,"## Exercice : Analyser la convergence du PSO
+
+**Objectif :**
+Tracez la courbe de convergence (erreur minimale dans l'essaim en fonction
+des itérations) pour un puzzle facile et un puzzle difficile.
+
+**Indice :**
+Enregistrez la meilleure fitness a chaque itération et affichez avec un graphique.
+",,,,,,,,1a7849c016425ad0,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,cell-f0a31030,code,fr,208554fbc0ae43e4,"// EXERCICE : Analyser la convergence du PSO
+public List<int> TrackConvergence(int[,] puzzle, int maxIterations = 500)
+{
+    // TODO: Executez le PSO et enregistrez l'erreur minimale a chaque iteration
+    // Retournez la liste des erreurs pour tracer la courbe de convergence
+    return null; // TODO etudiant
+}
+",,,,,,,,208554fbc0ae43e4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,cell-8fc0527d,markdown,fr,4941f102c4aeaa1d,"## Exercice : Optimiser les paramètres avec une grille de recherche
+
+**Objectif :**
+Implémentez une recherche en grille (grid search) pour trouver la meilleure
+configuration du solveur.
+
+> **Attention** : l'implémentation de ce notebook n'utilisé PAS l'équation de vélocité canonique (cf. section 1), elle n'expose donc ni `w`, ni `c1`, ni `c2`. Deux variantes possibles :
+> - **(a)** Optimisez les paramètres réellement disponibles : `NumOrganisms`, `WorkerRatio`, `MutationRate`, `MaxAge`, `MaxEpochs`.
+> - **(b)** Implémentez d'abord un vrai PSO a vélocité (champ de vélocité, `pBest`, coefficients `w`/`c1`/`c2`), puis optimisez ces coefficients. La signature du stub ci-dessous correspond a cette variante.
+
+**Indice :**
+Testez systematiquement des combinaisons de paramètres sur un ensemble de puzzles.",,,,,,,,4941f102c4aeaa1d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb,cell-5864eb59,code,fr,62efe43bd8b57679,"// EXERCICE : Optimiser les parametres PSO avec une grille de recherche
+public (double W, double C1, double C2, double SuccessRate) GridSearchPSO(int[,] puzzle)
+{
+    // TODO: Testez differentes combinaisons de parametres (w, c1, c2)
+    // et retournez les meilleurs parametres trouves
+    return (0, 0, 0, 0); // TODO etudiant
+}
+",,,,,,,,62efe43bd8b57679,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,cell-5ea23b90,markdown,fr,71c294bfa3a99024,"## Exercice : Calculer le domaine initial d'une cellule
+
+**Objectif :**
+Implémentez une fonction qui retourne l'ensemble des valeurs possibles pour
+une cellule donnée en tenant compte des contraintes de ligne, colonne et bloc.
+
+**Indice :**
+Parcourez la ligne, colonne et bloc de la cellule et excluez les valeurs déjà présentées.
+",,,,,,,,71c294bfa3a99024,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,cell-8d50db65,code,fr,7fd7f489cd01edde,"// EXERCICE : Calculer le domaine initial d'une cellule
+public HashSet<int> GetCellDomain(int[,] grid, int row, int col)
+{
+    // TODO: Retournez l'ensemble des valeurs possibles pour la cellule (row, col)
+    // en excluant les valeurs déjà présentées dans la ligne, colonne et bloc
+    return null; // TODO etudiant
+}
+",,,,,,,,7fd7f489cd01edde,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,cell-36d5dcd9,markdown,fr,f561db82da7991b1,"## Exercice : Pre-processing par arc-consistance
+
+**Objectif :**
+Implémentez un pre-traitement qui applique AC-3 avant de lancer le solveur
+et mesure l'impact sur le temps de résolution.
+
+**Indice :**
+Appliquez AC-3 pour réduire les domaines, puis lancez le backtracking sur les domaines réduits.
+",,,,,,,,f561db82da7991b1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,cell-1639f005,code,fr,1e6e7ad8c3213d85,"// EXERCICE : Pre-processing par arc-consistance
+public int[,] PreprocessAndSolve(int[,] puzzle)
+{
+    // TODO: Appliquez AC-3 en pre-processing pour réduire les domaines,
+    // puis lancez le backtracking améliore sur les domaines réduits
+    return null; // TODO etudiant
+}
+",,,,,,,,1e6e7ad8c3213d85,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,cell-9979ea7d,markdown,fr,08da100088ec7ca3,"## Exercice : Comparer Forward Checking et MAC sur des puzzles difficiles
+
+**Objectif :**
+Comparez les performances de Forward Checking et MAC (Maintaining Arc Consistency)
+sur au moins 5 puzzles difficiles.
+
+**Indice :**
+Mesurez le nombre d'appels recursifs et le temps pour chaque méthode.
+",,,,,,,,08da100088ec7ca3,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb,cell-5698f05c,code,fr,6af174a626e28050,"// EXERCICE : Comparer Forward Checking et MAC
+public Dictionary<string, (double AvgTime, int AvgCalls)> CompareFCvsMAC(List<int[,]> puzzles)
+{
+    // TODO: Lancez les deux solveurs sur chaque puzzle difficile
+    // et retournez les statistiques comparatives
+    return null; // TODO etudiant
+}
+",,,,,,,,6af174a626e28050,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-04772a8d,markdown,fr,4d326851cbecc42e,"## Exercice : Compter les singletons caches (Hidden Singles)
+
+**Objectif :**
+Implementez la detection des Hidden Singles : une valeur qui ne peut aller
+que dans une seule cellule d'une unité (ligne/colonne/bloc).
+
+**Indice :**
+Pour chaque valeur 1-9, comptez dans combien de cellules d'une unité elle peut apparaitre.
+Si exactement 1, c'est un Hidden Single.
+",,,,,,,,4d326851cbecc42e,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-6dca0fc6,code,fr,532ba96a86be75c1,"// EXERCICE : Compter les singletons caches (Hidden Singles)
+public List<(int Row, int Col, int Value)> FindHiddenSingles(Dictionary<(int, int), HashSet<int>> candidates)
+{
+    // TODO: Parcourez chaque unite et trouvez les valeurs qui ne peuvent
+    // aller que dans une seule cellule de cette unite
+    return null; // TODO etudiant
+}
+",,,,,,,,532ba96a86be75c1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-ba432058,markdown,fr,331d3a06eb69efc0,"## Exercice : Detection de paires nues (Naked Pairs)
+
+**Objectif :**
+Implementez la detection des Naked Pairs : quand deux cellules d'une meme unité
+ont exactement les memes deux candidats, ces valeurs peuvent etre eliminees
+des autres cellules de l'unité.
+
+**Indice :**
+Parcourez chaque unité et cherchez des paires de cellules avec les memes 2 candidats.
+",,,,,,,,331d3a06eb69efc0,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-511956d9,code,fr,0fd9ebd40903db40,"// EXERCICE : Detection de paires nues (Naked Pairs)
+public List<((int, int) Cell1, (int, int) Cell2, HashSet<int> Values)> FindNakedPairs(Dictionary<(int, int), HashSet<int>> candidates)
+{
+    // TODO: Trouvez les paires nues dans le dictionnaire de candidats
+    // Retournez la liste des paires trouvees avec leurs positions et valeurs
+    return null; // TODO etudiant
+}
+",,,,,,,,0fd9ebd40903db40,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-2872abc1,markdown,fr,4583782e6f8466aa,"## Exercice : Analyser l'impact de la propagation
+
+**Objectif :**
+Desactivez l'étape de propagation dans le solveur Norvig et comparez
+les performances avec et sans propagation.
+
+**Indice :**
+Modifiez le solveur pour court-circuiter l'étape eliminate et ne garder que assign.
+",,,,,,,,4583782e6f8466aa,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb,cell-3f3a84a2,code,fr,3004752bbb54d78a,"// EXERCICE : Analyser l'impact de la propagation
+public Dictionary<string, double> CompareWithAndWithoutPropagation(List<int[,]> puzzles)
+{
+    // TODO: Lancez le solveur Norvig avec et sans propagation
+    // et comparez les temps moyens de résolution
+    return null; // TODO etudiant
+}
+",,,,,,,,3004752bbb54d78a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,cell-c705c6d5,markdown,fr,6557847277864697,"## Exercice : Analyser l'impact de la propagation des contraintes
+
+**Objectif**
+Desactivez la propagation (eliminate) dans le solveur de Norvig et comparez
+le nombre d'appels recursifs et le temps de resolution.
+
+**Indice**
+Modifiez la fonction `solve` pour court-circuiter `eliminate` et mesurer
+la difference de performance sur les puzzles difficiles.
+",,,,,,,,6557847277864697,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb,cell-e5725826,code,fr,9f79bc02cf4767f4,"# EXERCICE : Analyser l'impact de la propagation des contraintes
+def solve_without_propagation(grid: str) -> Optional[Dict[str, str]]:
+    # TODO: Implementez un solveur Norvig sans propagation de contraintes
+    # (uniquement assign + backtracking, pas d'eliminate)
+    # Comparez le nombre d'appels recursifs avec le solveur complet
+    result = None  # TODO etudiant
+    return result
+",,,,,,,,9f79bc02cf4767f4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,cell-23e2e0f0,markdown,fr,50e9fb6c76031918,"## Exercice : Compter les naked singles par difficulté
+
+**Objectif :**
+Comptez combien de naked singles peuvent être trouves dans des puzzles
+de différentes difficultés.
+
+**Indice :**
+Utilisez FindNakedSingles sur plusieurs puzzles et calculez la moyenne par difficulté.
+",,,,,,,,50e9fb6c76031918,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,cell-825ad783,code,fr,17d40696de939554,"// EXERCICE : Compter les naked singles par difficulte
+public Dictionary<string, double> CountNakedSinglesByDifficulty()
+{
+    // TODO: Pour chaque difficulte, chargez les puzzles et comptez
+    // le nombre moyen de naked singles trouves
+    return null; // TODO etudiant
+}
+",,,,,,,,17d40696de939554,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,cell-3fd11070,markdown,fr,82e0c2db201bcbf1,"## Exercice : Implémenter la technique Hidden Pair
+
+**Objectif :**
+Implémentez la detection des Hidden Pairs : quand deux valeurs n'apparaissent
+que dans deux cellules d'une même unité, eliminez les autres candidats de ces cellules.
+
+**Étape 1 :**
+Parcourez chaque unité et identifiez les valeurs qui n'apparaissent que 2 fois.
+**Étape 2 :**
+Verifiez si ces 2 valeurs partagent les mêmes 2 cellules.
+",,,,,,,,82e0c2db201bcbf1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,cell-9d91abb6,code,fr,2021e42eeaeb6e77,"// EXERCICE : Implementer la technique Hidden Pair
+public List<((int, int) Cell1, (int, int) Cell2, HashSet<int> Pair)> FindHiddenPairs(int[,] candidatesGrid)
+{
+    // TODO: Trouvez les hidden pairs dans la grille de candidats
+    // Retournez la liste des paires avec leurs positions et valeurs
+    return null; // TODO etudiant
+}
+",,,,,,,,2021e42eeaeb6e77,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,cell-726b9950,markdown,fr,203aa3a2e087ba09,"## Exercice : Mesurer le taux de résolution par stratégies humaines
+
+**Objectif :**
+Déterminez quel pourcentage de puzzles peut être résolu uniquement par
+stratégies humaines (sans backtracking), par difficulté.
+
+**Indice :**
+Utilisez HumanSolver et comptez les puzzles résolus sans atteindre le backtracking.
+",,,,,,,,203aa3a2e087ba09,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb,cell-ea125e8b,code,fr,4d52b2cdab3222ac,"// EXERCICE : Mesurer le taux de resolution par strategies humaines
+public Dictionary<string, double> MeasureHumanSolveRate()
+{
+    // TODO: Pour chaque difficulte, testez les puzzles et comptez
+    // combien sont resolus uniquement par strategies humaines
+    return null; // TODO etudiant
+}
+",,,,,,,,4d52b2cdab3222ac,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-454955f9,markdown,fr,e6efe0d10a55bef1,"## Exercice : Compter les naked singles par difficulte
+
+**Objectif**
+Comptez combien de naked singles peuvent etre trouves dans des puzzles
+de differentes difficultes (facile, moyen, difficile).
+
+**Indice**
+Utilisez `find_naked_singles` sur plusieurs puzzles de chaque difficulte
+et calculez la moyenne.
+",,,,,,,,e6efe0d10a55bef1,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-a0f67067,code,fr,f13cc195fd132f08,"# EXERCICE : Compter les naked singles par difficulte
+def count_naked_singles_by_difficulty(puzzles: dict) -> dict:
+    # TODO: Pour chaque difficulte, chargez les puzzles et comptez
+    # le nombre moyen de naked singles trouves
+    result = {}  # TODO etudiant
+    return result
+",,,,,,,,f13cc195fd132f08,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-05be24e4,markdown,fr,ef1db1b16af2475d,"## Exercice : Implementer la technique Hidden Pair
+
+**Objectif**
+Implementez la detection des Hidden Pairs : quand deux valeurs n'apparaissent
+que dans deux cellules d'une meme unite (ligne/colonne/bloc), ces deux valeurs
+peuvent etre eliminees des candidats des autres cellules de l'unite.
+
+**Étape 1**
+Parcourez chaque unite et identifiez les valeurs qui n'apparaissent que 2 fois.
+**Étape 2**
+Verifiez si ces 2 valeurs partagent les memes 2 cellules.
+",,,,,,,,ef1db1b16af2475d,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-fde7c35b,code,fr,3be9772f213efd39,"# EXERCICE : Implementer la technique Hidden Pair
+def find_hidden_pairs(candidates: np.ndarray) -> list:
+    # TODO: Trouvez les hidden pairs dans la grille
+    # candidates[i][j] = ensemble des valeurs candidates pour la cellule (i,j)
+    # Retournez une liste de (unite_type, position, paire_de_valeurs)
+    result = []  # TODO etudiant
+    return result
+",,,,,,,,3be9772f213efd39,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-b761dae5,markdown,fr,18d6bc380de0fff8,"## Exercice : Mesurer le taux de resolution par strategies humaines seules
+
+**Objectif**
+Determinez quel pourcentage de puzzles peut etre resolu uniquement par
+strategies humaines (sans backtracking), par difficulte.
+
+**Indice**
+Utilisez le solveur `HumanSudokuSolver` et comptez les puzzles ou
+`solve()` retourne True sans utiliser le backtracking de secours.
+",,,,,,,,18d6bc380de0fff8,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb,cell-2bc950e1,code,fr,40f230b3c991efae,"# EXERCICE : Mesurer le taux de resolution par strategies humaines seules
+def measure_human_solve_rate(puzzles_by_difficulty: dict) -> dict:
+    # TODO: Pour chaque difficulte, testez les puzzles et comptez
+    # combien peuvent etre resolus uniquement par strategies humaines
+    result = {}  # TODO etudiant
+    return result
+",,,,,,,,40f230b3c991efae,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,cell-a865d9d5,markdown,fr,e4624231f0d051d4,"## Exercice : Compter les contraintes par cellule
+
+**Objectif :**
+Pour chaque cellule de la grille Sudoku, comptez le nombre de cellules contraintes
+(cellules dans la même ligne, colonne ou bloc).
+
+**Indice :**
+Utilisez le graphe construit et comptez le degré de chaque noeud.
+",,,,,,,,e4624231f0d051d4,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,cell-27d45835,code,fr,c735fe0ca753df74,"// EXERCICE : Compter les contraintes par cellule
+public Dictionary<(int, int), int> CountConstraintsPerCell()
+{
+    // TODO: Pour chaque cellule (i,j), comptez le nombre de voisins dans le graphe
+    // Retournez un dictionnaire (cellule -> nombre de contraintes)
+    return null; // TODO etudiant
+}
+",,,,,,,,c735fe0ca753df74,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,cell-24ec7457,markdown,fr,2bfe727acc7fe92e,"## Exercice : Implémenter l'heuristique de degré (Degree Heuristic)
+
+**Objectif :**
+Implémentez l'heuristique de degré qui, en cas d'égalité entre plusieurs variables
+MRV, choisit celle qui a le plus de contraintes avec les variables non assignees.
+
+**Indice :**
+Triez les variables candidats par nombre de voisins non assignes en cas d'égalité MRV.
+",,,,,,,,2bfe727acc7fe92e,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,cell-22f93ceb,code,fr,791ac6741c40b88a,"// EXERCICE : Implementer l'heuristique de degre
+public (int Row, int Col) SelectVariableWithDegreeHeuristic(int[,] grid, bool[,] isFixed)
+{
+    // TODO: Selectionnez la cellule non assignee avec le plus petit domaine (MRV)
+    // En cas d'egalite, choisissez celle avec le plus de voisins non assignes
+    return (-1, -1); // TODO etudiant
+}
+",,,,,,,,791ac6741c40b88a,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,cell-711fda12,markdown,fr,6bf0adf537f08eea,"## Exercice : Verifier qu'une coloration est valide
+
+**Objectif :**
+Implémentez une fonction qui vérifie si une grille complètement remplie
+est une solution valide du Sudoku en utilisant le graphe.
+
+**Indice :**
+Pour chaque arête du graphe, verifiez que les deux noeuds ont des couleurs différentes.
+",,,,,,,,6bf0adf537f08eea,,,,,,,
+MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb,cell-c053aced,code,fr,8b73222562c2f0a9,"// EXERCICE : Verifier qu'une coloration est valide
+public bool IsColoringValid(int[,] solution)
+{
+    // TODO: Verifiez que pour chaque paire de cellules contraintes,
+    // les valeurs sont differentes
+    return false; // TODO etudiant
+}
+",,,,,,,,8b73222562c2f0a9,,,,,,,

--- a/translations/symbolicai/argument_analysis.csv
+++ b/translations/symbolicai/argument_analysis.csv
@@ -5225,46 +5225,48 @@ sortie executee honnete - c'est precisement ce que la sentinelle est faite pour 
 
 - Issue #2137 - distillation de l'essence consolidee (doctrine anti-theatre / fail-loud).
 ",,,,,,,,02e0c4714bc24fca,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-0,markdown,fr,7c2d32b12d614b16,"# Ontologie AIF.owl -- l'architecture Argumentum des sophismes (OWL2 + SKOS)
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-0,markdown,fr,3b000cfe0be66713,"# Ontologie AIF.owl -- l'architecture Argumentum des sophismes (OWL2 + annotation-space)
 
 > **EPIC #4960 -- Volet A, etape 1** (socle ontologique Argument_Analysis). Issue source : [#5721](https://github.com/jsboige/CoursIA/issues/5721).
-> **Prerequis** : `Argument_Analysis_ArgumentProfile.ipynb` (presentation de la serie), notions de RDF/XML et OWL2.
-> **Duree estimee** : 35 minutes (lecture + execution).
-> **Objectifs d'apprentissage** :
-> 1. Charger une ontologie **OWL2/XML** mal formee (37 axiom wrappers sans `onProperty`) via un parseur regex tolérant.
-> 2. Distinguer dans Argumentum : **NamedIndividual** (les sophismes), **ObjectProperty** (les relations), **AnnotationAssertion** (les labels multilingues).
-> 3. Identifier les **schemes d'argumentation de Walton** (Position to Know, Sign, Rule, Cause to Effect) dans les labels de la taxonomie.
-> 4. Cartographier les **ObjectProperty** declares (4 338) et les **ObjectPropertyAssertion** (4 183 triplets concrets).
-> 5. Construire le sous-graphe autour du sophisme **Equivoque** (`semanticAmbiguity`).
 
-## Table des matieres
+> **⚠️ Re-fondation 2026-07-10 (Argumentum PR #763)** — le generateur OWL des Fallacies a change d'idiome. Les concepts ne sont plus des `NamedIndividual` mais des **`owl:Class`**, et **toutes** les relations (hierarchie SKOS, crossLink, AIF attack) sont serialisees en **`AnnotationAssertion`** (`SKOSHelper` d'OWLSharp etant casse sur cette version). Ce notebook a ete re-fonde en consequence : le parseur regex tolerant reste la bonne approche (rdflib et owlready2 echouent toujours), mais **les structures extraites changent**.
 
-1. Contexte : Argumentum et l'ontologie OWL2
-2. Charger l'ontologie : regex tolérant (rdflib echoue)
-3. Structure : NamedIndividual + ObjectProperty + AnnotationAssertion
-4. Schemes de Walton : recherche dans les labels
-5. Relations ObjectProperty : inventaire
-6. Grappe Equivoque : sous-graphe du sophisme
-7. Exercices (3 exercices formels, regle #2161)
-8. Ponts avec la serie
-9. Conclusion et note d'honnetete",,,,,,,,7c2d32b12d614b16,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-1,markdown,fr,101fd3117a8619d6,"## 1. Contexte : Argumentum et l'ontologie OWL2
+Ce notebook explore `ontologies/argumentum_fallacies.owl` (OWL2/XML, ~6,0 MB) et en extrait la structure sans passer par un parseur RDF strict.
 
-L'ontologie **Argumentum** (https://www.argumentum.games) encode une taxonomie des sophismes (fallacies) et des vertus argumentatives a destination du jeu serieux *Argumentum*. Elle est livree sous deux formes :
+**Objectifs d'apprentissage** :
 
-- **OWL2/XML** (`ontologies/argumentum_fallacies.owl`, 4,7 MB) : representation formelle en **Web Ontology Language** version 2.
-- **CSV taxonomiques** (dans le submodule Argumentum, hors-repo) : representation plate avec 8 colonnes `crossLink_*` encodant des relations inter-noeuds.
+1. Charger l'OWL2/XML via un **parseur regex tolerant** et comprendre *pourquoi* rdflib/owlready2 echouent sur ce dialecte.
+2. Compter la structure du **nouvel idiome annotation-space** : **1509 concepts `owl:Class`** (+ 4 classes AIF RA/I/CA-node + Conflict), **10 `ObjectProperty`**, **18 284 `AnnotationAssertion`** (7 773 resource + 10 511 literal).
+3. Extraire les **labels multilingues** (`skos:prefLabel`, 2 816 = 1 408 FR + 1 408 EN) et reperer les **schemes de Walton** (100 classes de forme `*_Inference_*` materialisees depuis les mappings AIF_skos).
+4. Inventorier les **relations** (AnnotationAssertion-resource) : hierarchie (`broader`/`narrower`/`inScheme`), **crossLink** (`mirrors`/`isRelatedTo`/`leverages`/… = 1 977) et **AIF attack** (`aifAttackedNode` = 93 → RA/I/CA-node).
+5. Construire le **sous-graphe de l'Equivoque** (`semanticAmbiguity`) et montrer qu'il est desormais **type par AIF** (`aifAttackedNode → RA-node`).
+6. Trois exercices formels (regle #2161).
 
-L'OWL2/XML utilise le pattern classique du **Web semantique** :
-- **`<NamedIndividual>`** = un sophisme specifique (ex. `semanticAmbiguity`, `appealToIgnorance`).
-- **`<ObjectProperty>`** / **`<DataProperty>`** = proprietes reliant les individus entre eux.
-- **`<AnnotationAssertion>`** = metadonnees (labels multilingues, commentaires, exemples).
-- **`<ClassAssertion>`** = typage : declare qu'un individu est instance d'une classe.
-- **`<ObjectPropertyAssertion>`** = triplet concret : relie deux individus par une propriete.
+**Sommaire** :
 
-**Note d'avertissement** : l'OWL exporte par Argumentum upstream contient **37 axiom wrappers structurellement invalides** (`<DataExactCardinality>` et `<ObjectExactCardinality>` sans `onProperty`/`onClass`/`onDataRange`). Les parseurs stricts comme `rdflib` RDF/XML et `owlready2.named_graph` echouent. Nous utilisons un parseur regex maison qui extrait uniquement les constructions valides (NamedIndividual, ObjectProperty, AnnotationAssertion, etc.).",,,,,,,,101fd3117a8619d6,,,,,,,
+1. Contexte : Argumentum, OWL2 et l'idiome annotation-space (#763)
+2. Charger l'ontologie : regex tolerant (rdflib echoue)
+3. Structure : Class + ObjectProperty + AnnotationAssertion
+4. Schemes de Walton (100 classes materialisees + labels)
+5. Relations : inventaire des AnnotationAssertion-resource (crossLink + AIF)
+6. Grappe Equivoque : sous-graphe type AIF
+7. Exercices
+8. Ponts avec la serie",,,,,,,,3b000cfe0be66713,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-1,markdown,fr,5078fa4ea1b809ab,"## 1. Contexte : Argumentum, OWL2 et l'idiome annotation-space (#763)
+
+L'ontologie **Argumentum** (https://www.argumentum.games) encode une taxonomie des sophismes (fallacies) et des vertus argumentatives a destination du jeu serieux *Argumentum*. Le fichier `argumentum_fallacies.owl` est genere par le pipeline .NET (`OwlGeneratorConfig.cs`) a partir du CSV canonique.
+
+**Idiome du generateur (apres PR #763, mergee 2026-07-10)** :
+
+- Chaque sophisme est une **`owl:Class`** (`<Declaration><Class IRI=""…#semanticAmbiguity""/></Declaration>`) — et non plus un `NamedIndividual` comme dans l'ancien generateur. Le modele AIF (`RA-node`/`I-node`/`CA-node`/`Conflict`) apporte 4 classes supplementaires (namespace `arg.dundee.ac.uk/aif`).
+- **Toutes** les relations passent par **`AnnotationAssertion`** : `SKOSHelper` d'OWLSharp est casse sur cette version, donc le generateur emet la hierarchie SKOS (`broader`/`narrower`/`inScheme`), les 8 verbes **crossLink** et les 2 colonnes **AIF attack** comme des annotations (resource pour un lien concept→concept, literal pour une valeur textuelle).
+- Les IRI sont serialises en **forme complete** (`IRI=""…""`), plus en `abbreviatedIRI=""skos:prefLabel""` — d'ou la reecriture des regex de ce notebook.
+
+**Pourquoi un parseur regex ?** rdflib echoue au parse (dialecte OWL2/XML + annotations resource non standard) et owlready2 charge le fichier mais **n'expose 0 classe** via son API Python. Le parseur regex tolerant reste le chemin fiable pour extraire la structure — c'est l'objet pedagogique de ce notebook.
+
+> Le notebook frere `Argument_Analysis_Ontology_CrossLinks.ipynb` (PR-B) lit le **CSV canonique** ; les deux substances (OWL et CSV) ont ete **reconciliees par #763** (crossLink + AIF desormais emis dans l'OWL).",,,,,,,,5078fa4ea1b809ab,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-2,markdown,fr,2c9a7e015e1def62,## 2. Charger l'ontologie : regex tolerant (rdflib echoue),,,,,,,,2c9a7e015e1def62,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-3,code,fr,ecc6036b36f3fb4f,"# --- Imports + parseur regex maison de l'OWL2/XML ---
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-3,code,fr,e62b7f000f47ebb4,"# --- Imports + parseur regex maison de l'OWL2/XML ---
 from pathlib import Path
 import re
 
@@ -5273,271 +5275,212 @@ print(f""Chargement de : {OWL_PATH}"")
 print(f""Existe : {OWL_PATH.exists()} (taille = {OWL_PATH.stat().st_size:,} octets)"")
 
 owl_text = OWL_PATH.read_text(encoding=""utf-8"")
-print(f""Longueur du texte : {len(owl_text):,} caracteres"")
+print(f""Longueur du texte : {len(owl_text):,} caracteres, {owl_text.count(chr(10)) + 1:,} lignes"")
 
-# Verifier la presence des 37 axiom casses (DataExactCardinality / ObjectExactCardinality)
-n_data_exact = len(re.findall(r""<DataExactCardinality"", owl_text))
+# Axiomes de cardinalite : desormais bien formes (avec onProperty) -- ils ne sont
+# plus le point de rupture (l'ancien OWL avait 37 axiom sans onProperty ligne ~4090).
 n_obj_exact = len(re.findall(r""<ObjectExactCardinality"", owl_text))
-print(f""\nAxiom casses detectes (manque onProperty/onClass) :"")
-print(f""  DataExactCardinality  : {n_data_exact}"")
-print(f""  ObjectExactCardinality: {n_obj_exact}"")
-print(f""  Total                 : {n_data_exact + n_obj_exact} (tous mal formes selon rdflib)"")
+n_data_exact = len(re.findall(r""<DataExactCardinality"", owl_text))
+print(f""\nCardinalite : ObjectExactCardinality={n_obj_exact}, DataExactCardinality={n_data_exact} (bien formes)."")
 
-# Ces 37 axiom sont ignores par notre parseur regex (qui n'en a pas besoin).
-print(""\nParseur regex tolérant : on extrait les constructions valides uniquement."")",,,,,,,,ecc6036b36f3fb4f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-4,markdown,fr,855ceb3ab05b9eeb,"**Lecture** : le fichier OWL pese 4,7 MB et contient 80 477 lignes. Les 37 axiom `Data/ObjectExactCardinality` sans `onProperty` font planter rdflib (ligne 4090 du fichier). Notre parseur regex ignore ces axiom et extrait directement les NamedIndividual, ObjectProperty et AnnotationAssertion qui sont les **constructions valides**.
+# Test rdflib : echoue toujours sur ce dialecte, mais pour une autre cause qu'avant #763.
+try:
+    import rdflib
+    try:
+        g = rdflib.Graph(); g.parse(str(OWL_PATH))
+        print(f""rdflib : OK inattendu ({len(g):,} triples)"")
+    except Exception as e:
+        print(f""rdflib : installe mais ECHEC au parse -> {type(e).__name__}: {str(e)[:80]}"")
+except ImportError:
+    print(""rdflib : non installe dans ce kernel (test skippe) -- historiquement il echoue sur ce dialecte."")
 
-Note : owlready2 peut charger le fichier (1,7 s) mais ne materialise aucun concept/individual via son API Python (`onto.classes()` retourne 0) ; il expose en revanche 63 349 triplets via son triplestore interne (SQLite). Pour les labels et les NamedIndividual, notre parseur regex extrait 2 608 labels -- un ordre de grandeur de plus que owlready2 n'expose dans ses structures Python.",,,,,,,,855ceb3ab05b9eeb,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-5,markdown,fr,72337336a00bd14c,"## 3. Structure : NamedIndividual + ObjectProperty + AnnotationAssertion
+print(""owlready2 : charge le fichier mais expose 0 classe via l'API Python (idiome annotation-space)."")
+print(""\n=> On conserve le parseur regex tolerant : chemin fiable pour extraire la structure."")",,,,,,,,e62b7f000f47ebb4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-4,markdown,fr,8c52fe48b142ddc0,"**Lecture** : le fichier OWL pese ~6,0 MB (~96 800 lignes). Les axiomes `ObjectExactCardinality` (36) sont desormais **bien formes** (avec `onProperty`) — ce ne sont plus les « 37 axiom casses ligne 4090 » de l'ancien snapshot. Malgre cela, **rdflib echoue toujours** (autre cause : le dialecte OWL2/XML avec annotations-resource) et **owlready2 charge mais n'expose rien** via son API Python. Le parseur regex tolerant reste donc l'approche retenue : il extrait Class, ObjectProperty et AnnotationAssertion directement du XML, sans dependre d'un moteur RDF.",,,,,,,,8c52fe48b142ddc0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-5,markdown,fr,dd57bc840d313ea0,"## 3. Structure : Class + ObjectProperty + AnnotationAssertion
 
-L'ontologie Argumentum est composee de trois couches emboitees :
+Depuis #763, l'ontologie Argumentum suit un idiome **annotation-space** :
 
-| Couche | Pattern OWL2 | Compte attendu | Role |
-|--------|--------------|----------------|------|
-| **Individus** | `<NamedIndividual>` | ~10 976 | Sophismes et concepts atomiques (le coeur de la taxonomie) |
-| **Proprietes** | `<ObjectProperty>` / `<DataProperty>` | ~4 338 | Relations entre individus ou vers des litteraux |
-| **Annotations** | `<AnnotationAssertion>` | ~9 846 | Labels multilingues, definitions, exemples |
-| **Typages** | `<ClassAssertion>` | ~1 305 | Lien : individu est instance d'une classe |
-| **Assertions** | `<ObjectPropertyAssertion>` | ~4 183 | Triplets concrets reliant 2 individus |
+| Couche | Pattern OWL2 | Compte | Role |
+|--------|--------------|--------|------|
+| Concepts | `Declaration/Class` | **1 509** (+ 4 AIF) | Un `owl:Class` par sophisme + RA/I/CA-node + Conflict |
+| Predicats | `Declaration/ObjectProperty` | **10** | 8 verbes crossLink + `hasConflictedElement` + `aifAttackedNode` |
+| Relations | `AnnotationAssertion` (resource) | **7 773** | hierarchie SKOS + crossLink + AIF attack (concept→concept) |
+| Annotations | `AnnotationAssertion` (literal) | **10 511** | labels, definitions, exemples, `aifAttackType`… |
 
-Le namespace AIF (`http://www.arg.dundee.ac.uk/aif#`) est **declare** dans l'ontologie (en tant que namespace et possiblement pour 1-3 proprietes) mais n'est **PAS utilise** pour typer les sophismes via `ClassAssertion`. Les sophismes Argumentum sont des `owl:NamedIndividual` directement, sans intermediaire AIF I-node/RA-node/CA-node.
+**Rupture avec l'ancien generateur** : `NamedIndividual`, `ClassAssertion` et `ObjectPropertyAssertion` ont **disparu** (0 occurrence). Là où l'ancien OWL materialisait chaque label multilingue comme un individu distinct (~10 976 `NamedIndividual`), le nouveau modele **1 `owl:Class` par sophisme** portant ses labels en annotations — d'ou la chute apparente du nombre de concepts (10 976 → 1 509), qui est en réalité une **normalisation** (plus de doublons par langue).
 
-Verifions ces comptes par parsing regex.",,,,,,,,72337336a00bd14c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-6,code,fr,edbfc6e14bb5a657,"# --- Comptage des NamedIndividual, ObjectProperty, ClassAssertion, etc. ---
-
-# Pattern pour NamedIndividual (incluant les declarations et les classes)
-named_individual_pattern = re.compile(
-    r'<NamedIndividual\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>'
-)
-n_named_individuals = len(named_individual_pattern.findall(owl_text))
-print(f""Nombre de NamedIndividual : {n_named_individuals:,}"")
-
-# Pattern pour ObjectProperty + DataProperty declarations
-prop_pattern = re.compile(
-    r'<(Object|Data)Property\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>'
-)
-prop_matches = prop_pattern.findall(owl_text)
-n_obj_prop = sum(1 for pt, _ in prop_matches if pt == ""Object"")
-n_data_prop = sum(1 for pt, _ in prop_matches if pt == ""Data"")
-print(f""Nombre de ObjectProperty : {n_obj_prop:,}"")
-print(f""Nombre de DataProperty   : {n_data_prop:,}"")
-
-# Pattern pour ClassAssertion
-class_assertion_pattern = re.compile(
-    r'<ClassAssertion[^>]*>\s*<Class\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>\s*<NamedIndividual\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>\s*</ClassAssertion>',
-    re.DOTALL
-)
-class_assertions = class_assertion_pattern.findall(owl_text)
-print(f""Nombre de ClassAssertion : {len(class_assertions):,}"")
-
-# Pattern pour ObjectPropertyAssertion
-opa_pattern = re.compile(
-    r'<ObjectPropertyAssertion[^>]*>\s*<ObjectProperty\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>\s*<NamedIndividual\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>\s*<NamedIndividual\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>\s*</ObjectPropertyAssertion>',
-    re.DOTALL
-)
-opa_matches = opa_pattern.findall(owl_text)
-print(f""Nombre de ObjectPropertyAssertion : {len(opa_matches):,}"")
-
-# Pattern pour AnnotationAssertion
-annotation_pattern = re.compile(
-    r'<AnnotationAssertion\s*[^>]*>'
-)
-annotation_matches = annotation_pattern.findall(owl_text)
-print(f""Nombre de AnnotationAssertion : {len(annotation_matches):,}"")
-
-# Distribution des classes les plus utilisees dans ClassAssertion
+**Nouveaute #763** : l'AIF n'est plus seulement *declaree*, elle **type** les sophismes — 93 concepts portent `aifAttackedNode → RA/I/CA-node` (§5-6).",,,,,,,,dd57bc840d313ea0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-6,code,fr,b6736124a2db51f4,"# --- Comptage de la structure : Class + ObjectProperty + AnnotationAssertion ---
 from collections import Counter
-class_counter = Counter(cls for cls, ind in class_assertions)
-print(f""\nTop 5 classes dans ClassAssertion :"")
-for cls, n in class_counter.most_common(5):
-    cls_local = cls.rstrip('#').split('#')[-1].split('/')[-1]
-    print(f""  {n:>5,}  {cls_local}"")
 
-# Garder les compteurs pour les sections suivantes.
-N_NAMED_INDIVIDUALS = n_named_individuals
-N_OBJ_PROP = n_obj_prop
-N_DATA_PROP = n_data_prop
-N_CLASS_ASSERTION = len(class_assertions)
-N_OPA = len(opa_matches)
-N_ANNOTATION = len(annotation_matches)",,,,,,,,edbfc6e14bb5a657,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-7,markdown,fr,4b0cd4afc5c982e2,"**Lecture** : les NamedIndividual (10 976) et ObjectProperty (4 338) forment le coeur de l'ontologie. Les 1 305 ClassAssertion et 4 183 ObjectPropertyAssertion sont les triplets concrets qui rendent la taxonomie navigable. A noter : `owl:NamedIndividual` et `owl:Thing` dominent les ClassAssertion, ce qui reflete une organisation plate (les sophismes sont des individus directement, sans hierarchie de classes intermediaires).",,,,,,,,4b0cd4afc5c982e2,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-8,markdown,fr,7d795d0adabc1909,"## 4. Schemes de Walton : recherche dans les labels
+# Concepts = Declaration/Class (le generateur #763 modelise 1 owl:Class par sophisme).
+class_decl_pattern = re.compile(r'<Declaration>\s*<Class IRI=""([^""]+)""\s*/>\s*</Declaration>')
+class_decls = class_decl_pattern.findall(owl_text)
+aif_classes = [c for c in class_decls if 'arg.dundee.ac.uk/aif' in c]
+arg_classes = [c for c in class_decls if 'argumentum_fallacies' in c]
+print(f""Declarations owl:Class : {len(class_decls):,}"")
+print(f""  - concepts Argumentum : {len(arg_classes):,}"")
+print(f""  - classes AIF : {len(aif_classes)}  {[c.split('#')[-1] for c in aif_classes]}"")
 
-Les **schemes d'argumentation** (Walton, Reed & Macagno 2008) sont des patterns d'inference reconnus en logique informelle. Quatre schemes sont cense etre representes dans la taxonomie Argumentum :
+# Predicats = Declaration/ObjectProperty (verbes crossLink + AIF).
+op_pattern = re.compile(r'<Declaration>\s*<ObjectProperty IRI=""([^""]+)""\s*/>\s*</Declaration>')
+obj_props = op_pattern.findall(owl_text)
+print(f""\nObjectProperty declarees : {len(obj_props)}"")
+print(f""  {[o.split('#')[-1] for o in obj_props]}"")
 
-| Scheme | Forme canonique | Exemple |
-|--------|-----------------|---------|
-| **Position to Know** | *X affirme p ; X est en position de savoir p ; donc p* | Temoin oculaire qui rapporte un accident |
-| **Sign** | *X est signe de Y ; donc Y* | Une fumee (signe) implique un feu |
-| **Rule** | *Si regle R alors cas C ; ici C ; donc R* | Application d'une loi a un cas concret |
-| **Cause to Effect** | *A cause B typiquement ; ici A ; donc B* | Pluie --> sol mouille |
+# Ancien idiome (individus) -- desormais ABSENT.
+n_named = len(re.findall(r'<NamedIndividual\s', owl_text))
+n_class_assertion = len(re.findall(r'<ClassAssertion', owl_text))
+n_opa = len(re.findall(r'<ObjectPropertyAssertion', owl_text))
+print(f""\nAncien idiome (individus), desormais absent :"")
+print(f""  NamedIndividual         : {n_named}"")
+print(f""  ClassAssertion          : {n_class_assertion}"")
+print(f""  ObjectPropertyAssertion : {n_opa}"")
 
-Verifions leur presence dans les labels fr/en de l'ontologie (parse par regex depuis les `AnnotationAssertion`).",,,,,,,,7d795d0adabc1909,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-9,code,fr,a25419b65e4c390d,"# --- Extraction des labels multilingues + recherche des schemes Walton ---
+# Relations = AnnotationAssertion (resource = concept->concept, literal = valeur textuelle).
+aa_resource = re.compile(
+    r'<AnnotationAssertion>\s*<AnnotationProperty IRI=""([^""]+)""\s*/>\s*<IRI>([^<]+)</IRI>\s*<IRI>([^<]+)</IRI>\s*</AnnotationAssertion>')
+aa_literal = re.compile(
+    r'<AnnotationAssertion>\s*<AnnotationProperty IRI=""([^""]+)""\s*/>\s*<IRI>([^<]+)</IRI>\s*<Literal(?:\s+[^>]*)?>([^<]*)</Literal>\s*</AnnotationAssertion>')
+AA_RES = aa_resource.findall(owl_text)   # (predicate_iri, subject_iri, object_iri)
+AA_LIT = aa_literal.findall(owl_text)    # (predicate_iri, subject_iri, literal_value)
+print(f""\nAnnotationAssertion : {len(AA_RES) + len(AA_LIT):,}  (resource={len(AA_RES):,}, literal={len(AA_LIT):,})"")
 
-# Pattern pour AnnotationAssertion avec label (skos:prefLabel / rdfs:label / skos:altLabel)
-label_pattern = re.compile(
-    r'<AnnotationAssertion[^>]*>\s*<AnnotationProperty\s+abbreviatedIRI=""(rdfs:label|skos:prefLabel|skos:altLabel)""\s*/>\s*<IRI>([^<]+)</IRI>\s*<Literal(?:\s+[^>]*)?>([^<]+)</Literal>\s*</AnnotationAssertion>',
-    re.DOTALL
-)
-label_matches = label_pattern.findall(owl_text)
-print(f""Total labels extraits : {len(label_matches):,}"")
+# Compteurs conserves pour les sections suivantes.
+N_CLASSES = len(class_decls)
+N_ARG_CLASSES = len(arg_classes)
+N_OBJ_PROP = len(obj_props)",,,,,,,,b6736124a2db51f4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-7,markdown,fr,ebe5e00fda16c251,"**Lecture** : le coeur de l'ontologie est desormais fait de **1 509 `owl:Class`** (concepts Argumentum) + 4 classes AIF, relies par **7 773 `AnnotationAssertion`-resource** et decrits par **10 511 `AnnotationAssertion`-literal**. Les `NamedIndividual`/`ClassAssertion`/`ObjectPropertyAssertion` de l'ancien generateur sont a **0** : #763 a bascule d'un modele *individus + triplets ObjectProperty* vers un modele *classes + annotation-space*. Les 10 `ObjectProperty` declarees (8 verbes crossLink + `hasConflictedElement` + `aifAttackedNode`) sont *declarees* comme proprietes mais *emises* comme annotations (contrainte de l'adapter OWLSharp).",,,,,,,,ebe5e00fda16c251,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-8,markdown,fr,ead08f3602dcf5e4,"## 4. Schemes de Walton : classes materialisees + labels
 
-# Detecter la langue via l'attribut xml:lang si present
-lang_pattern = re.compile(
-    r'<AnnotationAssertion[^>]*>\s*<AnnotationProperty\s+abbreviatedIRI=""(rdfs:label|skos:prefLabel|skos:altLabel)""\s*/>\s*<IRI>([^<]+)</IRI>\s*<Literal\s+[^>]*xml:lang=""([^""]+)""[^>]*>([^<]+)</Literal>\s*</AnnotationAssertion>',
-    re.DOTALL
-)
-lang_matches = lang_pattern.findall(owl_text)
-lang_index = {}
-for prop, iri, lang, label in lang_matches:
-    lang_index[(iri, label)] = lang
-print(f""Labels avec xml:lang explicite : {len(lang_index):,}"")
+Les **schemes d'argumentation** (Walton, Reed & Macagno 2008) sont des patterns d'inference reconnus en logique informelle. Le generateur #763 **materialise** les mappings `AIF_skos*` du CSV en **100 classes de forme `*_Inference_*` / `*_Conflict`** (ex. `PopularOpinion_Inference_Conflict`, `Example_Inference_Conflicted`, `CauseToEffect_Inference`). On les repere directement dans les declarations de Class, en complement de la detection classique par substring dans les `skos:prefLabel` (2 816 labels = 1 408 FR + 1 408 EN).",,,,,,,,ead08f3602dcf5e4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-9,code,fr,b261473c50c4f2df,"# --- Labels multilingues (skos:prefLabel) + schemes de Walton ---
+from collections import Counter
 
-# Construction d'un dict {localname: {prefLabel_fr, prefLabel_en, ...}}
+# prefLabel : AnnotationProperty IRI complet (plus d'abbreviatedIRI depuis #763).
+pref_pattern = re.compile(
+    r'<AnnotationAssertion>\s*<AnnotationProperty IRI=""http://www\.w3\.org/2004/02/skos/core#prefLabel""\s*/>\s*<IRI>([^<]+)</IRI>\s*<Literal(?:\s+xml:lang=""([^""]+)"")?[^>]*>([^<]*)</Literal>\s*</AnnotationAssertion>')
+pref_matches = pref_pattern.findall(owl_text)
+print(f""skos:prefLabel extraits : {len(pref_matches):,}"")
+print(f""Langues : {dict(Counter(l.upper() for _, l, _ in pref_matches if l))}"")
+
+# dict {localname: {iri, prefLabel:[...]}}
 taxonomy = {}
-for prop, iri, label in label_matches:
+for iri, lang, label in pref_matches:
     local = iri.rstrip('#').split('#')[-1].split('/')[-1]
-    if not local or not label:
+    if not local:
         continue
-    entry = taxonomy.setdefault(local, {'iri': iri, 'prefLabel': [], 'altLabel': [], 'rdfs:label': []})
-    bucket = {'skos:prefLabel': 'prefLabel', 'rdfs:label': 'rdfs:label', 'skos:altLabel': 'altLabel'}.get(prop)
-    if bucket:
-        entry[bucket].append(label)
+    entry = taxonomy.setdefault(local, {'iri': iri, 'prefLabel': []})
+    if label:
+        entry['prefLabel'].append(label)
+print(f""Concepts distincts (par localname) : {len(taxonomy):,}"")
 
-print(f""\nNombre de concepts distincts (par localname) : {len(taxonomy):,}"")
+# Schemes Walton materialises en classes (#763) -- signal robuste, sans faux positifs de substring.
+walton_shaped = sorted(c.split('#')[-1] for c in arg_classes if '_Inference' in c or '_Conflict' in c)
+print(f""\nClasses de forme Walton-scheme (materialisation AIF_skos) : {len(walton_shaped)}"")
+for c in walton_shaped[:8]:
+    print(f""  - {c}"")
 
-# Recherche Walton
-WALTON_SCHEMES = [""Position to Know"", ""Sign"", ""Rule"", ""Cause to Effect""]
+# Detection complementaire par substring dans les prefLabel.
+WALTON_SCHEMES = [""Position to Know"", ""Sign"", ""Cause to Effect"", ""Analogy"", ""Expert Opinion"", ""Popular Opinion""]
 walton_found = {k: [] for k in WALTON_SCHEMES}
 for local, entry in taxonomy.items():
-    for label in entry.get('prefLabel', []) + entry.get('rdfs:label', []):
+    for label in entry.get('prefLabel', []):
         for k in WALTON_SCHEMES:
             if k.lower() in label.lower():
-                walton_found[k].append((local, label))
-                break
-
-print(""\nSchemes Walton detectes dans les labels :"")
+                walton_found[k].append((local, label)); break
+print(""\nSchemes Walton detectes dans les prefLabel :"")
 for k in WALTON_SCHEMES:
     hits = walton_found[k]
-    if hits:
-        print(f""  v {k:18s} : {len(hits)} occurrence(s)"")
-        for local, lbl in hits[:3]:
-            print(f""      - {local:30s} -> {lbl}"")
-    else:
-        print(f""  x {k:18s} : absent"")",,,,,,,,a25419b65e4c390d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-10,markdown,fr,029a7af1e1e02cc4,"**Lecture** : 2 608 labels pour 13 schemes Walton-like. La detection par substring est limitee (faux positifs sur 'Sign' comme 'signal', 'Rule' comme 'ruling', etc.). Une detection plus robuste utiliserait des listes blanches strictes ou un fuzzy match. Mais la preuve de substance est faite : les schemes Walton sont dans la taxonomie sous des formes variees (Sign, Argument from Sign, etc.).",,,,,,,,029a7af1e1e02cc4,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-11,markdown,fr,ee511628731a853f,"## 5. Relations ObjectProperty : inventaire
+    print(f""  {'v' if hits else 'x'} {k:18s} : {len(hits)} occurrence(s)"")",,,,,,,,b261473c50c4f2df,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-10,markdown,fr,ab360b9bd02e3f92,"**Lecture** : **2 816 `skos:prefLabel`** (1 408 FR + 1 408 EN, soit 1 label par sophisme et par langue — la normalisation attendue du nouvel idiome). La detection des schemes de Walton s'appuie desormais sur les **100 classes materialisees** (`*_Inference_*`), signal bien plus robuste que la recherche par substring dans les labels (qui produisait des faux positifs sur « Sign », « Rule »…). La detection par substring est conservee a titre de comparaison pedagogique.",,,,,,,,ab360b9bd02e3f92,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-11,markdown,fr,ecdc9d849b35b2dd,"## 5. Relations : inventaire des AnnotationAssertion-resource
 
-Les **ObjectProperty** sont les proprietes structurelles reliant les sophismes entre eux. L'ontologie en declare 4 338, mais **aucune** n'est prefixee `crossLink_*` -- la convention `crossLink_PredatesOn`, `crossLink_Denounces`, etc. est specifique aux **CSV Argumentum upstream**, pas a l'OWL2/XML.
+Depuis #763, les relations concept→concept sont portees par des **`AnnotationAssertion`-resource** (et non plus des `ObjectPropertyAssertion`). L'inventaire par predicat revele **trois familles** :
 
-Les 15 `SubObjectPropertyOf` declarent des hierarchies entre proprietes (subPropertyOf = hierarchie), equivalentes a `rdfs:subPropertyOf` en RDF.
+- **hierarchie SKOS** : `broader` (1 407), `narrower` (1 407), `inScheme` (1 408), `type` (1 409) ;
+- **crossLink** (transverse, #141/#763) : `mirrors` (720), `isRelatedTo` (642), `leverages` (402), `inverts` (82), `allows` (66), `opposes` (50), `predatesOn` (13), `denounces` (2) = **1 977** au total ;
+- **AIF attack** : `aifAttackedNode` (93) → RA/I/CA-node ;
+- **mapping Walton** : `broadMatch` (57), `closeMatch` (10), `narrowMatch` (3) = 70.
 
-Examinons les 10 proprietes les plus frequemment utilisees dans les ObjectPropertyAssertion concrets, et les hierarchies SubObjectPropertyOf.",,,,,,,,ee511628731a853f,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-12,code,fr,5aa71d38ecc08fc6,"# --- Top 10 ObjectProperty par frequence d'usage + SubObjectPropertyOf ---
-
+**Inversion de la note historique** : l'ancien OWL **n'incluait PAS** les 8 verbes crossLink (ils etaient CSV-only). #763 les a **cables et emis** — ce notebook les inventorie donc desormais dans l'OWL.",,,,,,,,ecdc9d849b35b2dd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-12,code,fr,06bf0b04e4ce46ec,"# --- Inventaire des relations (AnnotationAssertion-resource) par predicat ---
 from collections import Counter
 
-# Compter l'usage de chaque ObjectProperty dans les ObjectPropertyAssertion
-prop_usage = Counter()
-for prop_iri, _, _ in opa_matches:
-    prop_local = prop_iri.rstrip('#').split('#')[-1].split('/')[-1]
-    prop_usage[prop_local] += 1
+rel_usage = Counter()
+for pred_iri, _subj, _obj in AA_RES:
+    rel_usage[pred_iri.rstrip('#').split('#')[-1].split('/')[-1]] += 1
 
-print(""Top 10 ObjectProperty par frequence d'usage :"")
-print(f""  {'Propriete':35s} | Usages"")
-print(""  "" + ""-"" * 55)
-for prop, n in prop_usage.most_common(10):
-    print(f""  {prop:35s} | {n:>5d}"")
+print(""Relations (AnnotationAssertion-resource) par predicat :"")
+print(f""  {'Predicat':22s} | Count"")
+print(""  "" + ""-"" * 34)
+for pred, n in rel_usage.most_common(20):
+    print(f""  {pred:22s} | {n:>5d}"")
+print(f""\n  Total predicats distincts : {len(rel_usage)}"")
 
-print(f""\n  Total proprietes utilisees : {len(prop_usage)}"")
+# Les 8 verbes crossLink SONT desormais dans l'OWL (#763) -- inversion de la note historique.
+CROSSLINK_VERBS = ['predatesOn', 'denounces', 'leverages', 'allows', 'opposes', 'inverts', 'mirrors', 'isRelatedTo']
+n_crosslink = sum(rel_usage[v] for v in CROSSLINK_VERBS)
+print(f""\n=> crossLink dans l'OWL : {n_crosslink:,} AnnotationAssertion"")
+print(f""   (mirrors={rel_usage['mirrors']}, isRelatedTo={rel_usage['isRelatedTo']}, ""
+      f""leverages={rel_usage['leverages']}, inverts={rel_usage['inverts']}, ...)"")
+print(f""   AIF attack : aifAttackedNode={rel_usage['aifAttackedNode']} (resource -> RA/I/CA-node)"")
+print(f""   mapping Walton : broadMatch={rel_usage['broadMatch']}, closeMatch={rel_usage['closeMatch']}, ""
+      f""narrowMatch={rel_usage['narrowMatch']}"")
+print(""\n   NOTE : contrairement a l'ancien OWL (crossLink ABSENT), #763 a cable ces 8 verbes."")",,,,,,,,06bf0b04e4ce46ec,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-13,markdown,fr,83cf561f242225f9,"**Lecture** : l'inventaire par predicat montre la structure reelle de la taxonomie. La colonne vertebrale hierarchique (`broader`/`narrower`/`inScheme`/`type`, ~1 408 chacune = une par sophisme) est desormais **doublee d'une couche transverse crossLink** (1 977 relations, dominee par `mirrors` et `isRelatedTo`) et d'une **couche AIF attack** (93 `aifAttackedNode`). C'est le changement de fond apporte par #763 : la taxonomie n'est plus un simple arbre, mais un **graphe** hierarchie + transverse + AIF.",,,,,,,,83cf561f242225f9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-14,markdown,fr,3c9b9820d26b6daf,"## 6. Grappe Equivoque : sous-graphe type AIF
 
-# SubObjectPropertyOf (hierarchies)
-subopa_pattern = re.compile(
-    r'<SubObjectPropertyOf[^>]*>\s*<ObjectProperty\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>\s*<ObjectProperty\s+(?:IRI|abbreviatedIRI)=""([^""]+)""\s*/>\s*</SubObjectPropertyOf>',
-    re.DOTALL
-)
-subopa_matches = subopa_pattern.findall(owl_text)
-print(f""\nHierarchies SubObjectPropertyOf : {len(subopa_matches)}"")
-for sub, sup in subopa_matches[:10]:
-    sub_local = sub.rstrip('#').split('#')[-1].split('/')[-1]
-    sup_local = sup.rstrip('#').split('#')[-1].split('/')[-1]
-    print(f""  {sub_local:35s} subPropertyOf {sup_local}"")
+L'**Equivoque** (Equivocation) est un sophisme d'ambiguite : un meme terme employe dans des sens differents au cours d'un meme raisonnement. Dans l'ontologie, le concept `semanticAmbiguity` porte **11 relations** (AnnotationAssertion-resource) :
 
-# Note importante sur crossLink_*
-print(""\nNOTE : l'OWL/XML Argumentum n'inclut PAS les 8 relations crossLink_*"")
-print(""(PredatesOn, Denounces, Leverages, Allows, Opposes, Inverts, Mirrors,"")
-print("" IsRelatedTo). Ces relations sont specifiques aux CSV taxonomiques"")
-print(""(dans le submodule Argumentum upstream, hors-repo). Le notebook s'en"")
-print(""tiendra donc a l'inventaire des ObjectProperty *OWL natifs*."")",,,,,,,,5aa71d38ecc08fc6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-13,markdown,fr,b8dbfb45cdd4b325,**Lecture** : les 10 proprietes les plus utilisees montrent quelles relations structurent reellement la taxonomie Argumentum. Les hierarchies SubObjectPropertyOf (15) etendent certaines proprietes avec des sous-proprietes plus specialisees. Les `crossLink_*` ne sont pas dans l'OWL -- ils sont dans les CSV.,,,,,,,,b8dbfb45cdd4b325,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-14,markdown,fr,c3432f2532010977,"## 6. Grappe Equivoque : sous-graphe du sophisme
+- hierarchie : `broader → ambiguity`, `narrower → {vagueness, polysemicLexicalShift, polysemyBySemanticChange}`, `inScheme → fallacyScheme`, `type → Concept` ;
+- **AIF attack** : `aifAttackedNode → RA-node` — le sophisme est formellement modelise comme une **attaque de l'inference** (RA-node = Rule-Application node au sens AIF, ce qui correspond a un *undercut* ASPIC+).
 
-L'**Equivoque** (Equivocation en anglais) est un sophisme d'Ambiguite : un meme terme employe dans des sens differents au cours d'un meme raisonnement. Exemple canonique :
+C'est la demonstration concrete de #763 : **l'AIF est desormais utilisee pour typer les sophismes**, la ou l'ancien OWL se contentait de *declarer* les nodes AIF sans les relier.",,,,,,,,3c9b9820d26b6daf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-15,code,fr,38d1b0ef93d8b22d,"# --- Sous-graphe autour de semanticAmbiguity via AnnotationAssertion-resource ---
 
-> « La fin d'une chose est sa perfection. La mort est la fin de la vie. Donc la mort est la perfection de la vie. »
-
-Dans la taxonomie Argumentum, on identifie au moins 2 noeuds directement lies a l'equivoque :
-- `semanticAmbiguity` (display = ""Equivoque"") : le concept general.
-- `takingAdvantageOfTheNaysayer` (display = ""Équivoque antithétique"") : une variante contextuelle.
-
-Cette section construit le sous-graphe OPA (Object Property Assertion) autour de `semanticAmbiguity` -- c'est-a-dire les 4 183 triplets dont ce noeud est sujet ou objet -- et l'affiche sous forme textuelle.
-
-Note : on n'utilise pas AIF I-node/RA-node/CA-node car l'ontologie ne type pas ses sophismes via AIF. Le sous-graphe est sur les OPA concrets.",,,,,,,,c3432f2532010977,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-15,code,fr,3baa490465f16d48,"# --- Construction du sous-graphe autour d'Equivoque + visualisation textuelle ---
-
-# Recherche de tous les NamedIndividual dont le label contient ""quivoque"" ou ""equivoc""
+# Noeuds lies a l'Equivoque (label contenant equivoc/quivoque).
 equiv_nodes = []
 for local, entry in taxonomy.items():
-    for label in entry.get('prefLabel', []) + entry.get('rdfs:label', []):
+    for label in entry.get('prefLabel', []):
         if 'quivoque' in label.lower() or 'equivoc' in label.lower():
-            equiv_nodes.append((local, label, entry.get('iri')))
-            break
-
+            equiv_nodes.append((local, label, entry.get('iri'))); break
 print(f""Noeuds lies a l'Equivoque : {len(equiv_nodes)}"")
 for local, label, iri in equiv_nodes:
-    print(f""  - {local:35s} -> {label} (IRI: {iri})"")
+    print(f""  - {local:30s} -> {label}"")
 
-# Construction du sous-graphe OPA autour de semanticAmbiguity (le noeud principal)
+# Sous-graphe AnnotationAssertion-resource autour de semanticAmbiguity.
 TARGET = ""semanticAmbiguity""
-print(f""\nSous-graphe ObjectPropertyAssertion autour de '{TARGET}' :"")
-
+print(f""\nSous-graphe (AnnotationAssertion-resource) autour de '{TARGET}' :"")
 G_equiv = {}
-n_relations = 0
-for prop_iri, subj_iri, obj_iri in opa_matches:
-    subj_local = subj_iri.rstrip('#').split('#')[-1].split('/')[-1]
-    obj_local = obj_iri.rstrip('#').split('#')[-1].split('/')[-1]
-    prop_local = prop_iri.rstrip('#').split('#')[-1].split('/')[-1]
-    if subj_local == TARGET or obj_local == TARGET:
-        # Look up labels
-        subj_lbl = taxonomy.get(subj_local, {}).get('display') or subj_local
-        obj_lbl = taxonomy.get(obj_local, {}).get('display') or obj_local
-        key = (subj_lbl, prop_local, obj_lbl)
-        G_equiv[key] = (prop_iri, subj_iri, obj_iri)
-        n_relations += 1
+for pred_iri, subj_iri, obj_iri in AA_RES:
+    subj = subj_iri.rstrip('#').split('#')[-1].split('/')[-1]
+    obj = obj_iri.rstrip('#').split('#')[-1].split('/')[-1]
+    pred = pred_iri.rstrip('#').split('#')[-1].split('/')[-1]
+    if subj == TARGET or obj == TARGET:
+        G_equiv[(subj, pred, obj)] = (pred_iri, subj_iri, obj_iri)
 
-print(f""  Relations OPA impliquees : {n_relations}"")
-print(f""  Noeuds impliques (sujet ou objet) : {len(set([k[0] for k in G_equiv] + [k[2] for k in G_equiv]))}"")
-
-print(f""\nTriplets :"")
-for (subj_lbl, prop_lbl, obj_lbl), _ in list(G_equiv.items())[:20]:
-    print(f""  {subj_lbl[:35]:35s} --[{prop_lbl:25s}]--> {obj_lbl[:35]}"")",,,,,,,,3baa490465f16d48,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-16,markdown,fr,274191a2b71a4ffe,**Lecture** : le sous-graphe autour de `semanticAmbiguity` montre comment ce sophisme se connecte aux autres via les ObjectProperty. Le nombre de relations OPA impliquees depend du degre du noeud dans la taxonomie -- c'est un proxy de centralite. La visualisation textuelle reste lisible pour un sous-graphe de cette taille.,,,,,,,,274191a2b71a4ffe,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-17,markdown,fr,23236f4bf1e33e9d,"## 7. Exercices
+print(f""  Relations impliquees : {len(G_equiv)}"")
+nodes = set([k[0] for k in G_equiv] + [k[2] for k in G_equiv])
+print(f""  Noeuds impliques : {len(nodes)}"")
+print(""\nTriplets :"")
+for (subj, pred, obj), _ in G_equiv.items():
+    tag = ""  <-- AIF attack"" if pred == 'aifAttackedNode' else """"
+    print(f""  {subj[:32]:32s} --[{pred:16s}]--> {obj[:24]:24s}{tag}"")",,,,,,,,38d1b0ef93d8b22d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-16,markdown,fr,4f817f454c98cd86,"**Lecture** : le sous-graphe de `semanticAmbiguity` combine sa **hierarchie** (parent `ambiguity`, enfants `vagueness` / `polysemicLexicalShift` / `polysemyBySemanticChange`) et son **typage AIF** (`aifAttackedNode → RA-node`). Le degre du noeud (11) melange donc des aretes taxonomiques et une arete AIF — c'est exactement la reconciliation que #763 apporte : une même entite porte simultanement sa place dans l'arbre SKOS et son role dans le modele d'attaque AIF.",,,,,,,,4f817f454c98cd86,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-17,markdown,fr,199d90c26343400a,"## 7. Exercices
 
 Trois exercices formels (regle #2161 : >= 3 exos par notebook pedagogique). Chaque exercice est un *stub* `print(""Exercice a completer"")` que l'etudiant complete.
 
-### Exercice 1 -- Compter la distribution des sophismes par famille
+### Exercice 1 -- Distribution des concepts par prefixe de scheme
 
-A partir du `taxonomy` extrait (section 4) et des `ClassAssertion` (section 3), determiner la distribution des NamedIndividual par classe mere. La majorite des sophismes Argumentum sont classes dans une famille (Obstruction, Pertinence, Ambiguite, Empirisme, etc.).
-
-*Indice* : compter les `ClassAssertion` par classe et regarder les `prefLabel` de ces classes dans `taxonomy`. Les classes sont stockees dans `class_assertions` ; les labels dans `taxonomy`.",,,,,,,,23236f4bf1e33e9d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-18,code,fr,7bfb986aa64c8fbe,"# Exercice 1 a completer
-# TODO etudiant : a partir de `class_assertions` (list de (cls_iri, ind_iri))
-# et de `taxonomy` (dict localname -> labels), calculer la distribution
-# des NamedIndividual par classe. Renvoyer un dict {classe_display: count}.
-# Classes cibles : owl:Thing, owl:NamedIndividual, classes specifiques Argumentum.
-print(""Exercice a completer"")",,,,,,,,7bfb986aa64c8fbe,,,,,,,
+A partir de `arg_classes` (liste d'IRI de `owl:Class` Argumentum) et de `taxonomy` (dict localname -> labels), calculer combien de concepts sont des **classes materialisees de scheme** (`*_Inference_*` / `*_Conflict`) versus des sophismes simples. Renvoyer un `dict` {categorie: compte} et l'afficher trie.",,,,,,,,199d90c26343400a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-18,code,fr,df70235428023cf7,"# Exercice 1 a completer
+# TODO etudiant : a partir de `arg_classes` (IRI de owl:Class) et de `taxonomy`
+# (dict localname -> labels), separer les classes materialisees de scheme
+# (`_Inference` / `_Conflict`) des sophismes simples. Renvoyer un dict {cat: n}.
+print(""Exercice a completer"")",,,,,,,,df70235428023cf7,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-19,markdown,fr,b82f59950813e283,"### Exercice 2 -- Visualisation matplotlib du sous-graphe Equivoque
 
 Reprendre `G_equiv` de la section 6 et le visualiser avec `matplotlib` + `networkx.spring_layout` (seed=42). Colorer les noeuds par degre (entrant + sortant), afficher les labels des proprietes sur les aretes.
@@ -5548,90 +5491,80 @@ MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ip
 # spring_layout (seed=42), couleur des noeuds par degre, edge_labels affiches.
 # Si matplotlib n'est pas disponible, fallback ASCII (cf. §6).
 print(""Exercice a completer"")",,,,,,,,7926791344180581,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-21,markdown,fr,371e576be29e6e29,"### Exercice 3 -- Detection des sophismes ""Ambiguite"" et hierarchie
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-21,markdown,fr,dde271ad51e1e996,"### Exercice 3 -- Detection des sophismes ""Ambiguite"" et hierarchie
 
-Implementer une fonction `trouver_ambiguite(taxonomy)` qui retourne tous les NamedIndividual dont le label fr/en mentionne ""ambig"", ""equivoc"", ""quivoque"", ""vague"", ""obscur"". Construire un mini-graphe des variantes (par exemple ""Équivoque antithétique"" lie a ""Equivoque"" via un label partage).
-
-*Indice* : la detection par substring est fragile (faux positifs comme ""ambiguité du contexte""). Filtrer par liste blanche de termes techniques. Tester aussi sur les `altLabel`.",,,,,,,,371e576be29e6e29,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-22,code,fr,c02e635c2b96ee38,"# Exercice 3 a completer
+Implementer une fonction `trouver_ambiguite(taxonomy)` qui retourne tous les concepts dont le `prefLabel` fr/en mentionne ""ambig"", ""equivoc"", ""quivoqu"". Renvoyer un `dict {local: [labels_matches]}`. Faux positifs a eviter : ""ambiguite du contexte"" hors sophisme. Bonus : croiser avec `AA_RES` pour afficher, pour chaque match, son parent `broader`.",,,,,,,,dde271ad51e1e996,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-22,code,fr,c2585a668119ac2f,"# Exercice 3 a completer
 # TODO etudiant : implementer trouver_ambiguite(taxonomy) qui retourne
-# un dict {local: [labels_matches]}. Tester aussi sur altLabel et rdfs:label.
-# Faux positifs a eviter : ""ambiguite du contexte"", ""terme vague"" non technique.
-print(""Exercice a completer"")",,,,,,,,c02e635c2b96ee38,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-23,markdown,fr,ff5930c9764a66d6,"## 8. Ponts avec la serie
+# un dict {local: [labels_matches]} sur les prefLabel fr/en. Bonus : croiser
+# avec AA_RES (predicat 'broader') pour afficher le parent de chaque match.
+print(""Exercice a completer"")",,,,,,,,c2585a668119ac2f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb,cell-23,markdown,fr,19aa83d9856b7a8b,"## 8. Ponts avec la serie
 
 | Direction | Lien | Relation |
 |-----------|------|----------|
-| <-> ArgumentProfile | Argument_Analysis_ArgumentProfile.ipynb | Vue d'ensemble de la serie, introduction aux schemes |
-| <-> Argumentum upstream | https://github.com/Argumentum-Games/argumentum (submodule, hors repo) | Ontologie source (4,7 MB, OWL2/XML) + CSV taxonomiques avec 8 colonnes crossLink_* |
-| Argument_Analysis_Agentic-1-informal | (a venir) | Application : detection de sophismes par label matching |
+| <-> ArgumentProfile | `Argument_Analysis_ArgumentProfile.ipynb` | Vue d'ensemble de la serie, introduction aux schemes |
+| <-> CrossLinks (PR-B) | `Argument_Analysis_Ontology_CrossLinks.ipynb` | Substance CSV canonique — **reconciliee avec cet OWL par #763** |
+| -> SemanticKernel | `SemanticKernel/*` | Exploitation des schemes pour l'analyse d'arguments |
 
-## 9. Conclusion et note d'honnetete
+### Honnetete methodologique
 
-**Lecon centrale** : une ontologie OWL2/XML comme Argumentum est un **graphe navigable** mais pas via les patterns RDF/XML classiques. Les 37 axiom `Data/ObjectExactCardinality` mal formes (lignes 4086-4295 du fichier source) empechent rdflib de parser le fichier. owlready2 charge l'ontologie mais n'expose rien via son API Python. Notre parseur regex extrait 2 608 labels, 1 305 ClassAssertion et 4 183 ObjectPropertyAssertion -- assez pour naviguer.
+1. **Parseur regex, pas un moteur RDF** : rdflib echoue au parse et owlready2 expose 0 classe via l'API Python. Le parseur regex est robuste pour *extraire* la structure mais ne fait **pas** de raisonnement (pas d'inference de subsomption, pas de fermeture transitive). Pour un raisonnement OWL complet, il faudrait corriger l'idiome de serialisation en amont (generateur Argumentum).
 
-**Limites disclosees** :
-- L'OWL n'utilise PAS AIF pour typer les sophismes (les 3 classes I-node/RA-node/CA-node sont absentes des `ClassAssertion` concrets). Le namespace AIF est declare mais inoperant.
-- Les 8 relations `crossLink_*` (PredatesOn, Denounces, etc.) sont specifiques aux CSV Argumentum upstream, pas a l'OWL/XML. Le notebook s'en tient aux ObjectProperty natifs.
-- L'ontologie soeur `argumentum_virtues.owl` est **absente du repo** (cf. issue #499 / §H.4 disclose) -- seule `argumentum_fallacies.owl` est analysee.
+2. **L'OWL utilise desormais l'AIF** (inversion de la version precedente de ce notebook) : 93 concepts portent `aifAttackedNode → RA/I/CA-node` (undercut→RA, undermine→I, rebut→CA, ratifie #707§4). La note historique « l'OWL n'utilise PAS l'AIF » est **obsolete**.
 
-**Verdict SOTA** : l'outil reel (parseur OWL2/XML) est **partiellement** accessible (owlready2 charge en 1,7 s mais expose 0 concept ; rdflib echoue completement). Notre parseur regex est une **RECOVERABLE-LOCAL** (SOTA-OK au sens de la regle #3801 -- axe-2 substance accessible sans workaround degrade) : on accede a la substance de l'ontologie par un contournement documente, sans maquiller une sortie de cellule.
+3. **Les crossLink sont dans l'OWL** (inversion) : 1 977 `AnnotationAssertion` (mirrors/isRelatedTo/leverages/…). La note historique « crossLink_* CSV-only, hors-repo » est **obsolete** — #763 a cable le chemin CSV→OWL.
 
-**Metadonnees** : notebook regenere a partir de `argumentum_fallacies.owl` (4,7 MB), sans modifier l'ontologie source. rdflib 7.6.0 et networkx 3.6.1 utilises ; owlready2 reference mais non materialise via API.",,,,,,,,ff5930c9764a66d6,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,fea709ae,markdown,fr,fbc114fd8c5fd6be,"# Argument_Analysis_Ontology_CrossLinks.ipynb — PR-B #4960
+4. **Ontologie soeur presente** : `argumentum_virtues.owl` est desormais dans `ontologies/` (aux cotes de `argumentum_fallacies.owl`). La note historique « argumentum_virtues.owl absente » est **obsolete**.
 
-**Notebook pédagogique** : exploration du **CSV canonique Argumentum** (1553 lignes), complémentaire à `Argument_Analysis_Ontology_AIF.ipynb` (PR-A, OWL2/XML). PR-A disclose : *« les 8 relations `crossLink_*` et les 4 colonnes `AIF_skos*` sont uniquement dans les CSV Argumentum upstream, pas dans l'OWL. »* PR-B exploite cette substance.
+5. **Idiome annotation-space** : toutes les relations sont des `AnnotationAssertion` (et non des `ObjectPropertyAssertion`), consequence du bug `SKOSHelper` d'OWLSharp. C'est un choix de serialisation du generateur, pas une limite de modelisation — les 10 `ObjectProperty` sont bien declarees.",,,,,,,,19aa83d9856b7a8b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,fea709ae,markdown,fr,0b271a5bba5ec46e,"# Argument_Analysis_Ontology_CrossLinks.ipynb — PR-B #4960
 
-**Filiation** : 
+**Notebook pédagogique** : exploration du **CSV canonique Argumentum** (1553 lignes physiques → **1408 sophismes**), complémentaire à `Argument_Analysis_Ontology_AIF.ipynb` (PR-A, OWL2/XML).
+
+> **⚠️ Mise à jour 2026-07-10 (Argumentum PR #763)** — l'intégration ontologique des Fallacies a été complétée en amont. Les 8 relations `crossLink_*` et les colonnes AIF attack (`AIF_attackType`/`AIF_attackedNode`), jusque-là **présentes uniquement dans le CSV**, sont désormais **émises dans l'OWL** (comme `AnnotationAssertion`). La couverture crossLink est passée de **1,5 % (22 relations) à 59,9 % (1081 cellules / 844 sophismes)** après curation transverse (#141) + câblage du générateur (#763). Ce notebook reflète l'état **après** #763.
+
+**Filiation** :
 - EPIC parent : **#4960** Argument_Analysis v3 (submodule Argumentum)
-- PR-A : **#5721** (Argument_Analysis_Ontology_AIF.ipynb, livré c.371)
+- PR-A : **#5721** (`Argument_Analysis_Ontology_AIF.ipynb`)
 - PR-B : **ce notebook** (CSV canonique + crossLink_* + AIF mappings)
 
 **Objectifs d'apprentissage** :
 
-1. Charger le CSV canonique `Argumentum Fallacies - Taxonomy.csv` (1553 lignes, 102 colonnes) avec gestion du BOM UTF-8.
-2. Cartographier la **taxonomie par famille** (8 familles : influence, tricherie, insuffisance, obstruction, erreurMathématique, erreurDeRaisonnement, abusDeLangage, argumentFallacieux) et par niveau (1-9).
-3. Mesurer la **couverture multilingue** (8 langues : fr, en, ru, pt, ar, es, zh, fa).
-4. Analyser les **AIF mappings** (`AIF_skosDirectRef` + `AIF_skosExceptionRef` + `AIF_skosMappingType`) : 70 mappings vers 60 schemes Walton uniques.
-5. Caractériser la **sparsité des crossLink** (22 relations / 1408 sophismes = 1,5%) — finding majeur d'argumumentum upstream.
-6. **Faire le pont** entre substance OWL (PR-A, 10 976 NamedIndividual) et substance CSV (PR-B, 1408 sophismes canoniques).
+1. Charger le CSV canonique `Argumentum Fallacies - Taxonomy.csv` (**1408 sophismes, 104 colonnes**) avec gestion du BOM UTF-8.
+2. Cartographier la **taxonomie par famille** (8 familles) et par niveau (1-9).
+3. Mesurer la **couverture multilingue** (8 langues : fr, en, ru, pt, ar, es, zh, fa) — 100 %.
+4. Analyser les **AIF mappings** (`AIF_skosDirectRef` + `AIF_skosExceptionRef` + `AIF_skosMappingType`) : 70 mappages vers 60 schemes Walton, **plus** les 2 colonnes AIF attack (93 sophismes typés RA/I/CA-node).
+5. Caractériser la **couverture des crossLink** : **1081 cellules / 844 sophismes = 59,9 %** (après #141/#763).
+6. **Faire le pont** entre substance OWL (PR-A) et substance CSV (PR-B), et montrer que #763 a réconcilié les deux.
 
 **Sommaire** :
 
-1. Contexte (PR-A → PR-B)
+1. Contexte (PR-A → PR-B, mise à jour #763)
 2. Loader CSV (pandas + utf-8-sig)
-3. Vue d'ensemble (1408 lignes, 102 colonnes)
+3. Vue d'ensemble (1408 sophismes, 104 colonnes)
 4. Taxonomie : 8 familles × 9 niveaux
 5. Couverture multilingue (8 langues)
 6. AIF mappings : 70 mappages vers 60 schemes Walton
-7. CrossLink sparsity : 22 relations / 1 408 sophismes (1,5% des sophismes ont ≥1 crossLink)
-8. Pont OWL ↔ CSV : pourquoi 10 976 vs 1408 ?
+7. CrossLink coverage : 1081 cellules / 844 sophismes (59,9 %)
+8. Pont OWL ↔ CSV : #763 a câblé crossLink + AIF dans l'OWL
 9. Pont avec Walton : 60 schemes uniques
 10. Honnêteté méthodologique
 11. Exercices (3 stubs #2161)
 12. Conclusion + Ponts
 
-**Verdict SOTA** : SOTA-OK (pandas + matplotlib natifs, pas de workaround dégradé).",,,,,,,,fbc114fd8c5fd6be,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,1d25090a,markdown,fr,c6dea72c383d4089,"## 1. Contexte — De PR-A à PR-B
+**Verdict SOTA** : SOTA-OK (pandas + matplotlib natifs, pas de workaround dégradé).",,,,,,,,0b271a5bba5ec46e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,1d25090a,markdown,fr,24c7cb16a1bc6788,"## 1. Contexte — De PR-A à PR-B (mis à jour après #763)
 
-`Argument_Analysis_Ontology_AIF.ipynb` (PR-A) a chargé `ontologies/argumentum_fallacies.owl` (4,7 MB OWL2/XML) via parseur regex (rdflib échoue sur 37 axiom `Data/ObjectExactCardinality` mal formés ; owlready2 charge en 1,7 s mais expose 0 concept via son API Python). Substance exposée par PR-A :
+`Argument_Analysis_Ontology_AIF.ipynb` (PR-A) charge `ontologies/argumentum_fallacies.owl` (OWL2/XML) via un parseur regex tolérant (rdflib échoue sur le dialecte OWL/XML ; owlready2 charge mais n'expose rien via son API Python).
 
-- 10 976 `NamedIndividual`
-- 4 331 `ObjectProperty` + 7 `DataProperty`
-- 1 305 `ClassAssertion` (1 304 `skos:Concept`)
-- 4 183 `ObjectPropertyAssertion`
-- 9 846 `AnnotationAssertion`, 2 608 labels multilingues
+**Évolution majeure (Argumentum PR #763, mergée 2026-07-10)** : au moment de la première version de PR-A, l'OWL n'émettait **qu'une** des trois couches ontologiques du CSV (les mappings `AIF_skos*`). Les 8 relations `crossLink_*` et les colonnes `AIF_attackType`/`AIF_attackedNode` étaient **dans le CSV mais absentes de l'OWL** — le chemin de données CSV→OWL n'existait pas encore. #763 a :
 
-**Mais PR-A disclose en §9** : *« les 8 relations `crossLink_*` (PredatesOn, Denounces, Leverages, Allows, Opposes, Inverts, Mirrors, IsRelatedTo) sont **uniquement dans les CSV Argumentum upstream**, pas dans l'OWL. Les 4 colonnes AIF (`AIF_skosDirectRef`, `AIF_skosExceptionRef`, `AIF_skosOther`, `AIF_skosMappingType`) sont **dans le CSV exclusivement**. »*
+- ajouté le mapping des 10 colonnes dans l'entité `Fallacy` + le générateur OWL (2ᵉ passe d'émission) ;
+- curé la couche transverse (scan #141, transverse + confiance ≥ 0,6, 22 seeds manuels préservés) : **1,5 % → 59,9 %** de couverture crossLink ;
+- régénéré l'OWL, qui porte désormais **1977 `AnnotationAssertion` crossLink** + **93 typages AIF attack** (undercut/undermine/rebut → RA/I/CA-node).
 
-**PR-B** comble ce gap : il lit `Cards/Fallacies/Argumentum Fallacies - Taxonomy.csv` (le CSV canonique, maintenu à la main par l'équipe Argumentum, 1553 lignes) et expose :
-
-- Taxonomie canonique (8 familles + sous-familles)
-- Couverture 8 langues
-- 70 AIF mappings vers 60 schemes Walton
-- 22 relations crossLink (avec **analyse de sparsité**)
-
-Les deux PRs sont **complémentaires**, pas redondantes : PR-A = substance OWL, PR-B = substance CSV. Le pont se fait en §8.",,,,,,,,c6dea72c383d4089,,,,,,,
+**PR-B** lit `Cards/Fallacies/Argumentum Fallacies - Taxonomy.csv` (le CSV canonique, source curée à la main, **1408 sophismes × 104 colonnes**) et expose la taxonomie, la couverture 8 langues, les AIF mappings et la couche crossLink — **désormais réconciliée avec l'OWL** (§8).",,,,,,,,24c7cb16a1bc6788,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,24cbc6fd,markdown,fr,926ee5e5076d1c3f,"## 2. Loader CSV — pandas + utf-8-sig
 
 Le CSV upstream `Argumentum Fallacies - Taxonomy.csv` est encodé en **UTF-8 avec BOM** (3 octets `\xEF\xBB\xBF` en tête), signature Microsoft Excel. Pandas exige `encoding='utf-8-sig'` pour ignorer ce BOM.
@@ -5664,20 +5597,21 @@ print()
 print('--- First 3 rows (PK, Famille, nom_vulgarisé) ---')
 print(df[['PK', 'Famille_camelCase', 'nom_vulgarisé', 'text_fr']].head(3).to_string())
 ",,,,,,,,b7c8da3783df990e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,338e1cdd,markdown,fr,f5a762ae9c9cd985,"## 3. Vue d'ensemble — 1408 sophismes canoniques, 102 colonnes
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,338e1cdd,markdown,fr,f5bb10b6ed9a95b4,"## 3. Vue d'ensemble — 1408 sophismes canoniques, 104 colonnes
 
-Sur 1553 lignes au total, **1408 sont des sophismes canoniques** (les autres sont des entrées techniques : racine, padding, états spéciaux). Chaque sophisme a :
+Sur 1553 lignes physiques (certaines cellules contiennent des retours-ligne encadrés par des guillemets), **1408 sont des sophismes canoniques**. Chaque sophisme a :
 
-- **PK** (clé primaire numérique 0-1552) + **path** (chemin hiérarchique type `6.3.1.1.1.2.1.3`)
-- **decimal_path** (idem en notation pointée)
+- **PK** (clé primaire numérique) + **path** (chemin hiérarchique type `6.3.1.1.1.2.1.3`)
 - **Famille** (8 valeurs canoniques) + **Sous-Famille** + **Soussousfamille**
-- **nom_vulgarisé** (nom court) + **Latin** (nom savant) + **text_fr** (description FR)
+- **nom_vulgarisé** + **Latin** + **text_fr** (description FR)
 - 8 langues (fr, en, ru, pt, ar, es, zh, fa) avec `text_<lang>` + `desc_<lang>` + `example_<lang>`
-- **niveau** (1-9, difficulté pédagogique)
-- **état** (validation : validé, à valider, etc.)
+- **niveau** (1-9)
 - 8 colonnes `crossLink_*` (PredatesOn, Denounces, Leverages, Allows, Opposes, Inverts, Mirrors, IsRelatedTo)
-- 4 colonnes AIF (`AIF_skosDirectRef`, `AIF_skosExceptionRef`, `AIF_skosOther`, `AIF_skosMappingType`)
-- Métadonnées visuelles (shape, image, svg_color, svg_illustration, print_and_play)",,,,,,,,f5a762ae9c9cd985,,,,,,,
+- 4 colonnes AIF SKOS (`AIF_skosDirectRef`, `AIF_skosExceptionRef`, `AIF_skosOther`, `AIF_skosMappingType`)
+- **2 colonnes AIF attack** (`AIF_attackType`, `AIF_attackedNode`) — ajoutées pour l'articulation façon AIF (#498/#707), 93 sophismes typés
+- Métadonnées visuelles (shape, image, svg_color, svg_illustration, print_and_play)
+
+Les **104 colonnes** = 102 historiques + les 2 colonnes AIF attack (ajoutées par #753).",,,,,,,,f5bb10b6ed9a95b4,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,d9579d62,code,fr,4de7288cf57625c9,"import matplotlib.pyplot as plt
 
 fig, axes = plt.subplots(1, 2, figsize=(15, 5))
@@ -5800,36 +5734,40 @@ print('Top 15 schemes Walton (par occurrences):')
 for k, v in walton.most_common(15):
     print(f'  {v:>3} {k}')
 ",,,,,,,,3aa580818836f08e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,e84f2931,markdown,fr,0e8b18b9b092c005,"## 7. CrossLink sparsity — 22 relations / 1 408 sophismes (1,5% des sophismes ont ≥1 crossLink) (finding majeur)
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,e84f2931,markdown,fr,4d5c870445d34f64,"## 7. CrossLink coverage — 1081 cellules / 844 sophismes (59,9 %)
 
-Les 8 colonnes `crossLink_*` sont **quasi-vides** :
+Après curation transverse (#141) + câblage du générateur (#763), les 8 colonnes `crossLink_*` couvrent **59,9 %** des sophismes :
 
-| Relation | Non-empty | % |
-|----------|-----------|---|
-| `crossLink_PredatesOn` | 9 | 0,6% |
-| `crossLink_Denounces` | 1 | 0,07% |
-| `crossLink_Leverages` | 4 | 0,3% |
-| `crossLink_Allows` | 1 | 0,07% |
-| `crossLink_Opposes` | 2 | 0,1% |
-| `crossLink_Inverts` | 1 | 0,07% |
-| `crossLink_Mirrors` | 2 | 0,1% |
-| `crossLink_IsRelatedTo` | 2 | 0,1% |
-| **TOTAL** | **22** | **1,5%** (22/1 408) |
+| Relation | Cellules non-vides | % des 1408 |
+|----------|--------------------|-----------|
+| `crossLink_PredatesOn` | 13 | 0,9 % |
+| `crossLink_Denounces` | 2 | 0,1 % |
+| `crossLink_Leverages` | 350 | 24,9 % |
+| `crossLink_Allows` | 62 | 4,4 % |
+| `crossLink_Opposes` | 23 | 1,6 % |
+| `crossLink_Inverts` | 41 | 2,9 % |
+| `crossLink_Mirrors` | 304 | 21,6 % |
+| `crossLink_IsRelatedTo` | 286 | 20,3 % |
+| **TOTAL cellules** | **1081** | densité 9,6 % (1081 / 11 264) |
+| **Couverture par sophisme** | **844 / 1408** | **59,9 %** |
 
-**Interprétation** : la taxonomie Argumentum est **structurellement plate** (arbre hiérarchique via `path` + `decimal_path`) ; les relations transverses `crossLink_*` (qui créeraient un **graphe**, pas un arbre) sont quasi-absentes.**Nuance** : la densité **par cellule** = 22/11 264 = 0,2%, mais la **couverture par sophisme** = 22/1 408 = 1,5% (c.-à-d. ~14 sophismes ont au moins 1 crossLink). Les deux mesures disent la même chose : sparsity globale ; ce notebook retient la **couverture par sophisme** car plus parlante pour un cours.C'est un **finding méthodologique** : l'effort de curation d'Argumentum upstream est porté sur la taxonomie (8 langues, 8 familles, 9 niveaux), pas sur les liens transverses.",,,,,,,,0e8b18b9b092c005,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,1c85c591,code,fr,c06a1b90a1cc843d,"import numpy as np
+**Interprétation** : la version historique de ce notebook mesurait **22 relations (1,5 %)** — la taxonomie était alors un arbre quasi-pur. La curation #141 (candidats 0-fabrication, transverse, confiance ≥ 0,6, 22 seeds manuels préservés) a ajouté **1059 cellules**, portant la couverture à 59,9 %. Les relations dominantes sont `Leverages` (350), `Mirrors` (304) et `IsRelatedTo` (286) : la taxonomie est devenue un **graphe transverse** substantiel, plus seulement un arbre hiérarchique. `#763` a ensuite rendu cette couche **émettable dans l'OWL** (1977 `AnnotationAssertion`, avec émission bidirectionnelle pour mirrors/opposes/inverts/isRelatedTo).",,,,,,,,4d5c870445d34f64,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,1c85c591,code,fr,a7907ffbaa7a93b0,"import numpy as np
 
 crosslink_cols = [c for c in df.columns if c.startswith('crossLink_')]
 cl_matrix = np.zeros((8, len(df)), dtype=int)
 for i, col in enumerate(crosslink_cols):
     cl_matrix[i] = df[col].notna() & (df[col].astype(str).str.strip() != '')
 
+cov_nodes = int((cl_matrix.sum(axis=0) > 0).sum())
+cov_pct = 100 * cov_nodes / len(df)
+
 fig, ax = plt.subplots(figsize=(15, 4))
 im = ax.imshow(cl_matrix, aspect='auto', cmap='YlOrRd', interpolation='nearest')
 ax.set_yticks(range(8))
 ax.set_yticklabels([c.replace('crossLink_', '') for c in crosslink_cols], fontsize=10)
 ax.set_xlabel('Sophisme index (1408 au total)')
-ax.set_title('CrossLink matrix (8 relations × 1 408 sophismes) — densité 1,5% (couverture par sophisme)')
+ax.set_title(f'CrossLink matrix (8 relations × {len(df)} sophismes) — couverture {cov_pct:.1f}% par sophisme (après #141/#763)')
 plt.colorbar(im, ax=ax, label='Présence (1) / absence (0)')
 plt.tight_layout()
 plt.savefig(str(SAVE_DIR / 'crosslinks_matrix.png'), dpi=100, bbox_inches='tight')
@@ -5845,46 +5783,45 @@ for i, col in enumerate(crosslink_cols):
 total = cl_matrix.sum()
 total_cells = 8 * len(df)
 print()
-print(f'TOTAL density: {total} / {total_cells} = {100*total/total_cells:.2f}%')
-",,,,,,,,c06a1b90a1cc843d,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,ac9eec91,markdown,fr,8fb733d469e91fc3,"## 8. Pont OWL ↔ CSV — pourquoi 10 976 vs 1408 ?
+print(f'TOTAL cellules: {total} / {total_cells} = {100*total/total_cells:.2f}% de densité')
+print(f'Couverture par sophisme: {cov_nodes} / {len(df)} = {cov_pct:.1f}%')",,,,,,,,a7907ffbaa7a93b0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,ac9eec91,markdown,fr,6fcbbcc214c69a65,"## 8. Pont OWL ↔ CSV — #763 a câblé crossLink + AIF dans l'OWL
 
-**PR-A (OWL)** expose 10 976 `NamedIndividual` ; **PR-B (CSV)** expose 1 408 sophismes canoniques. Le **gap × 7,8** s'explique par la nature des deux représentations :
+Historiquement, PR-A (OWL) et PR-B (CSV) exposaient des substances **disjointes** : l'OWL ne portait ni les crossLink, ni les colonnes AIF attack. **#763 a réconcilié les deux** en régénérant l'OWL depuis le CSV avec les 3 couches câblées :
 
-| Aspect | OWL (PR-A) | CSV (PR-B) | Ratio |
-|--------|------------|------------|-------|
-| Substance unique | `NamedIndividual` (chaque `rdfs:label` = une entité nommée) | Lignes de sophismes canoniques | × 7,8 |
-| Granularité | Atome (label) | Agrégat (8 langues + 9 colonnes par sophisme) | - |
-| Multilingue | 2 608 labels (sparse, 1-2 langues par label) | 11 264 descriptions (dense, 8 langues par sophisme) | × 4,3 |
-| AIF mappings | 0 (absent de l'OWL) | 70 (CSV uniquement) | × ∞ |
-| CrossLink | 0 (absent de l'OWL) | 22 (CSV uniquement) | × ∞ |
+| Aspect | OWL avant #763 | OWL après #763 | CSV (PR-B) |
+|--------|----------------|----------------|------------|
+| Concepts | `NamedIndividual` (ancien générateur) | **1509 `owl:Class`** (+ 4 classes AIF) | 1408 sophismes |
+| Relations hiérarchiques | `ObjectPropertyAssertion` | **`AnnotationAssertion`** (narrower/broader/inScheme) | `path` / `decimal_path` |
+| CrossLink | **0 (absent)** | **1977 `AnnotationAssertion`** | 1081 cellules |
+| AIF attack (RA/I/CA-node) | **0 (absent)** | **93 `aifAttackType` + 93 `aifAttackedNode`** | 93 typés |
+| AIF SKOS (Walton) | 70 (`skos:*Match`) | **70** (`broadMatch` 57 / `closeMatch` 10 / `narrowMatch` 3) | 70 |
 
-**Le CSV est la source canonique curée à la main** ; l'OWL est une **projection RDF** (potentiellement générée par script depuis le CSV, mais la pipeline n'est pas bidirectionnelle). Le gap × 7,8 = 10 976 / 1 408 correspond probablement à des **multiples `AnnotationAssertion` par sophisme** (label FR, EN, etc. pour le même `NamedIndividual`, plus des `skos:altLabel`).",,,,,,,,8fb733d469e91fc3,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,a87dac2e,code,fr,a7dc68b9c10df02a,"import matplotlib.pyplot as plt
+**Note structurelle** : #763 a aussi changé l'idiome du générateur — les concepts sont désormais des `owl:Class` (et non des `owl:NamedIndividual`), et **toutes** les relations passent par `AnnotationAssertion` (l'`ObjectPropertyAssertion` a disparu, `SKOSHelper` d'OWLSharp étant cassé sur cette version). Le notebook AIF (PR-A) a été re-fondé en conséquence (traversée annotation-space). Le gap historique « OWL 10 976 vs CSV 1408 » venait de l'ancien générateur qui matérialisait chaque label multilingue comme un `NamedIndividual` distinct ; le nouveau générateur modélise **1 `owl:Class` par sophisme** avec ses labels en annotations.",,,,,,,,6fcbbcc214c69a65,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,a87dac2e,code,fr,c01250e99abb2217,"import matplotlib.pyplot as plt
 
-fig, ax = plt.subplots(figsize=(10, 5))
-labels = ['OWL NamedIndividual\n(PR-A)', 'CSV sophismes\n(PR-B)', 'AIF mappings\n(PR-B)', 'CrossLink\n(PR-B)']
-values = [10976, 1408, 70, 22]
-colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728']
+fig, ax = plt.subplots(figsize=(11, 5))
+labels = ['CSV sophismes', 'CrossLink cells\n(CSV)', 'CrossLink AA\n(OWL, #763)', 'AIF attack\n(CSV & OWL)', 'AIF SKOS\n(CSV & OWL)']
+values = [1408, 1081, 1977, 93, 70]
+colors = ['#ff7f0e', '#d62728', '#2ca02c', '#9467bd', '#1f77b4']
 bars = ax.bar(labels, values, color=colors, edgecolor='black')
 ax.set_ylabel('Count')
 ax.set_yscale('log')
-ax.set_title('PR-A (OWL) vs PR-B (CSV) — comparaison substance')
+ax.set_title('Substance CSV ↔ OWL après #763 (crossLink + AIF désormais émis dans l\'OWL)')
 for bar, v in zip(bars, values):
-    height = bar.get_height()
-    ax.text(bar.get_x() + bar.get_width()/2., height * 1.1,
+    ax.text(bar.get_x() + bar.get_width()/2., bar.get_height() * 1.1,
             f'{v:,}', ha='center', va='bottom', fontsize=11, fontweight='bold')
 plt.tight_layout()
 plt.savefig(str(SAVE_DIR / 'crosslinks_owl_vs_csv.png'), dpi=100, bbox_inches='tight')
 plt.show()
 
-print('--- OWL vs CSV comparison ---')
-print(f'  OWL NamedIndividual: 10 976 (PR-A, 1 304 skos:Concept)')
-print(f'  CSV sophismes:        1 408 (PR-B, 8 langues × 1 408 = 11 264 descriptions)')
-print(f'  Gap factor:          × 7,8 (1 NamedIndividual ≈ 7,8 labels multilingues)')
-print(f'  AIF mappings:         70 (CSV uniquement, absent OWL)')
-print(f'  CrossLink:            22 (CSV uniquement, absent OWL)')
-",,,,,,,,a7dc68b9c10df02a,,,,,,,
+print('--- Substance CSV ↔ OWL (après #763) ---')
+print(f'  CSV sophismes canoniques            : 1 408')
+print(f'  CrossLink cellules (CSV)            : 1 081  (844 sophismes = 59,9 %)')
+print(f'  CrossLink AnnotationAssertion (OWL) : 1 977  (bidirectionnel pour mirrors/opposes/inverts/isRelatedTo)')
+print(f'  AIF attack (CSV & OWL)              :    93  (undercut 61 / undermine 29 / rebut 3 → RA/I/CA-node)')
+print(f'  AIF SKOS Walton (CSV & OWL)         :    70  (broadMatch 57 / closeMatch 10 / narrowMatch 3)')
+print(f'  → #763 a réconcilié CSV et OWL : les 3 couches ontologiques sont désormais émises.')",,,,,,,,c01250e99abb2217,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,67449124,markdown,fr,68811f0d7e7c4461,"## 9. Pont avec Walton — 60 schemes uniques
 
 Les **60 schemes Walton** référencés par Argumentum couvrent un spectre large de l'argumentation :
@@ -5939,17 +5876,17 @@ for s in walton_all:
 for k, v in fam_walton.most_common():
     print(f'  {k}: {v}')
 ",,,,,,,,4eda5aa26d9dc8ba,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,c25f3da1,markdown,fr,f06941ed99612c5f,"## 10. Honnêteté méthodologique
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,c25f3da1,markdown,fr,ebe046a0b556f1b9,"## 10. Honnêteté méthodologique
 
-Trois **limitations structurelles** d'Argumentum upstream, disclosed honnêtement :
+Observations, disclosed honnêtement :
 
-1. **AIF mapping partiel (5%)** : sur 1 408 sophismes, seulement 70 ont un mapping AIF (`AIF_skosDirectRef` + `AIF_skosExceptionRef` + `AIF_skosMappingType`). **95% des sophismes n'ont pas de pont explicite vers Walton**. C'est probablement parce que la taxonomie Argumentum est **plus fine** que les schemes Walton (1552 sophismes vs ~60 schemes) — un scheme Walton peut couvrir des dizaines de sophismes apparentés.
+1. **AIF SKOS mapping partiel (5 %)** : sur 1408 sophismes, 70 ont un mapping SKOS vers Walton (`AIF_skosDirectRef` + `AIF_skosExceptionRef` + `AIF_skosMappingType`). 95 % n'ont pas de pont SKOS explicite — la taxonomie Argumentum (1408 nœuds) est bien plus fine que les ~60 schemes Walton. **Complément #498** : 93 sophismes portent en plus une articulation **AIF attack** (`AIF_attackType`/`AIF_attackedNode`), reliant le sophisme à un nœud RA/I/CA au sens ASPIC+.
 
-2. **CrossLink sparsity (1,5%)** : 22 relations transverses (parmi 11 264 cellules = 8 cols × 1 408) sur 1 408 sophismes. Le graphe Argumentum est essentiellement un **arbre** (via `decimal_path`), pas un graphe. Les crossLinks ne sont ajoutés qu'au cas par cas, pour des sophismes particulièrement liés (ex: `Pensée binaire` ↔ `Pensée binaire` miroir, `Facteur horoscope` prédatesOn `6.3.1.2.3.1.3.3`).
+2. **CrossLink coverage 59,9 %** (et non plus 1,5 %) : après curation #141 + câblage #763, 1081 cellules / 844 sophismes portent au moins une relation transverse. La version historique de ce notebook mesurait 22 relations (1,5 %) ; le graphe transverse est désormais substantiel (`Leverages`/`Mirrors`/`IsRelatedTo` dominants). Les 22 seeds manuels d'origine sont préservés (curation additive, 0 fabrication : toute cible ∈ taxonomie).
 
-3. **Couverture multilingue asymétrique** : 100% pour les 8 langues sur `text_<lang>`, mais les `desc_<lang>` et `example_<lang>` peuvent être lacunaires (à vérifier). Argumentum est une œuvre **multilingue par design** mais la qualité de la traduction varie.
+3. **Couverture multilingue** : 100 % sur les 8 langues pour `text_<lang>` (vérifié cellule par cellule). Les `desc_<lang>`/`example_<lang>` peuvent être plus lacunaires.
 
-4. **`argumentum_virtues.owl` absent** : l'ontologie soeur des vertus (qualités argumentatives) est mentionnée dans la documentation Argumentum mais **absente du repo** (cf issue #499 disclose pas bloquer). PR-B ne l'analyse pas.",,,,,,,,f06941ed99612c5f,,,,,,,
+4. **Ontologies sœurs présentes** : `argumentum_fallacies.owl` **et** `argumentum_virtues.owl` sont désormais dans le repo (`ontologies/`). La note historique « `argumentum_virtues.owl` absent du repo » est **obsolète**.",,,,,,,,ebe046a0b556f1b9,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_CrossLinks.ipynb,f98a3f3f,code,fr,f76b93fd968d9bcc,"import matplotlib.pyplot as plt
 
 fig, ax = plt.subplots(figsize=(10, 5))
@@ -8287,3 +8224,390 @@ MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_UI_configuratio
 Le notebook `Argument_Analysis_UI_configuration.ipynb` est maintenant prêt. Il contient toute la logique nécessaire pour l'interface utilisateur, la gestion des sources, le cache et le chiffrement.
 
 Le notebook exécuteur principal peut maintenant utiliser la fonction `configure_analysis_task()` définie ici pour obtenir le texte préparé avant de lancer l'analyse par les agents.",,,,,,,,bb3c9ceb42e1ae99,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,e33a32b5,markdown,fr,d94dc73a9d673ec0,"# Ontologie des vertus argumentatives -- le pole miroir des sophismes (SKOS + AIF)
+
+Le projet [Argumentum](https://www.argumentum.games/) modelise l'argumentation sur **deux poles** :
+
+- le pole **negatif** -- les *sophismes* (fallacies), explore dans le notebook compagnon
+  [`Argument_Analysis_Ontology_AIF`](Argument_Analysis_Ontology_AIF.ipynb) : une ontologie OWL2
+  a base de `NamedIndividual` reliees par un graphe dense d'`ObjectPropertyAssertion` ;
+- le pole **positif** -- les *vertus* argumentatives (virtues), objet de ce notebook.
+
+L'ontologie des vertus (`argumentum_virtues.owl`) se decrit elle-meme comme
+*""the mirror of the fallacies axis (223 nodes, 7 families)""*. Mais son **paradigme de
+modelisation est different** : la ou les sophismes sont des individus (ABox), les vertus
+forment un **thesaurus SKOS** (`skos:Concept`, `skos:broader`/`skos:narrower`,
+`skos:prefLabel`, `skos:definition`) -- une organisation de connaissances hierarchique et
+multilingue. Un meme projet, deux choix de modelisation opposes : c'est la lecon centrale
+de ce notebook.
+
+Le lien entre les deux poles est la propriete AIF `aif:goodTenorOf` (le *bon tenor* d'un
+schema d'argument de Walton), miroir exact du `badTenorOf` cote sophismes.
+
+**Objectifs pedagogiques**
+1. Charger une ontologie OWL/XML que `rdflib` ne parse pas nativement, via un pont vers un graphe RDF.
+2. Interroger un thesaurus SKOS avec **SPARQL** (hierarchie, langues, schemes).
+3. Comprendre le contraste **ABox (individus) vs thesaurus SKOS (concepts)** entre deux ontologies soeurs.
+",,,,,,,,d94dc73a9d673ec0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,822970f5,markdown,fr,1f27b2e209456055,"## 1. SKOS, AIF et le format OWL/XML
+
+**SKOS** ([Simple Knowledge Organization System](https://www.w3.org/TR/skos-reference/), W3C 2009)
+est le vocabulaire standard pour publier des thesaurus, taxonomies et systemes de classification
+sur le web semantique. Ses primitives :
+
+| Primitive SKOS | Role |
+|----------------|------|
+| `skos:Concept` | une unite de sens (ici : une vertu argumentative) |
+| `skos:prefLabel` | le libelle prefere, **par langue** (`@fr`, `@en`) |
+| `skos:definition` | la definition, par langue |
+| `skos:broader` / `skos:narrower` | la hierarchie (plus general / plus specifique) |
+| `skos:inScheme` / `skos:topConceptOf` | l'appartenance au schema de concepts |
+
+**AIF** (*Argument Interchange Format*, Universite de Dundee) fournit `aif:goodTenorOf` :
+elle relie chaque vertu au **schema d'argument de Walton** qu'elle instancie correctement.
+
+**Le format** : `argumentum_virtues.owl` est serialise en **OWL/XML fonctionnel** (racine
+`<Ontology>`, elements `<Declaration>`, `<AnnotationAssertion>`), **pas** en RDF/XML. C'est
+la raison pour laquelle `rdflib` -- dont le parseur natif est RDF/XML -- ne le lit pas
+directement, comme nous allons le constater.
+",,,,,,,,1f27b2e209456055,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,16840649,markdown,fr,7656b64707ca5895,"## 2. Charger l'ontologie : essai des outils SOTA, puis pont OWL/XML -> RDF
+
+Par honnetete methodologique, on **essaie d'abord les vrais outils** (`rdflib`, `owlready2`)
+avant de recourir a un pont. On documente ce qui echoue et pourquoi.
+",,,,,,,,7656b64707ca5895,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,b5dd1e9b,code,fr,3a2a44523aa78143,"# --- Chargement : essai SOTA direct, puis pont OWL/XML -> graphe SKOS rdflib ---
+from pathlib import Path
+import re, logging, io
+import rdflib
+from rdflib import Graph, URIRef, Literal
+from rdflib.namespace import RDFS, SKOS, RDF
+
+# Les 14 schemes Walton portent des espaces (IRI non conformes cote source) :
+# on abaisse le niveau de log rdflib pour ne pas noyer la sortie d'avertissements benins.
+logging.getLogger(""rdflib"").setLevel(logging.ERROR)
+
+OWL_PATH = Path(""ontologies/argumentum_virtues.owl"").resolve()
+print(f""Fichier : {OWL_PATH.name}"")
+print(f""Existe  : {OWL_PATH.exists()} (taille = {OWL_PATH.stat().st_size:,} octets)"")
+owl_text = OWL_PATH.read_text(encoding=""utf-8"")
+print(f""Longueur du texte OWL/XML : {len(owl_text):,} caracteres\n"")
+
+# 1) rdflib direct (parseur RDF/XML)
+try:
+    Graph().parse(str(OWL_PATH))
+    print(""[rdflib]    parse direct : OK"")
+except Exception as e:
+    print(f""[rdflib]    parse direct impossible ({type(e).__name__}) : le fichier est en OWL/XML"")
+    print(""            fonctionnel (<Ontology>), pas en RDF/XML -> rdflib ne lit pas cette serialisation."")
+
+# 2) owlready2 (parseur OWL/XML) via fileobj
+try:
+    from owlready2 import get_ontology
+    onto = get_ontology(""http://argumentum.local/virtues.owl"")
+    with open(OWL_PATH, ""rb"") as fh:
+        onto.load(fileobj=fh)
+    n_cls = len(list(onto.classes()))
+    print(f""[owlready2] charge le fichier mais recompose {n_cls} classe(s) : son parseur OWL/XML"")
+    print(""            ne reconstruit pas les AnnotationAssertion SKOS de ce fichier."")
+except Exception as e:
+    print(f""[owlready2] indisponible/echec : {type(e).__name__}"")
+
+print(""\n-> Aucun parseur direct ne restitue le contenu SKOS. On construit un pont :"")
+print(""   extraction des <AnnotationAssertion> OWL/XML -> triplets dans un graphe rdflib,"")
+print(""   puis interrogation en SPARQL (le vrai outil SOTA opere sur le graphe RDF resultant)."")
+",,,,,,,,3a2a44523aa78143,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,171b256b,code,fr,0bf9590f45b20ff7,"# --- Pont OWL/XML -> graphe SKOS rdflib ---
+AIF = rdflib.Namespace(""http://www.arg.dundee.ac.uk/aif#"")
+VIRT = rdflib.Namespace(""https://www.argumentum.games/argumentum_virtues.owl#"")
+g = Graph()
+g.bind(""skos"", SKOS); g.bind(""rdfs"", RDFS); g.bind(""aif"", AIF); g.bind(""virt"", VIRT)
+
+# Predicats dont l'objet est une IRI (et non un litteral)
+IRI_OBJ = {str(SKOS.broader), str(SKOS.narrower), str(SKOS.inScheme),
+           str(SKOS.topConceptOf), str(SKOS.hasTopConcept), str(RDF.type), str(RDFS.seeAlso)}
+
+block = re.compile(r""<AnnotationAssertion\b.*?</AnnotationAssertion>"", re.DOTALL)
+ap    = re.compile(r'<AnnotationProperty (?:abbreviatedIRI|IRI)=""([^""]+)""')
+iri   = re.compile(r'<(?:IRI|AbbreviatedIRI)>([^<]+)</(?:IRI|AbbreviatedIRI)>')
+lit   = re.compile(r'<Literal(?:\s+xml:lang=""([^""]+)"")?[^>]*>(.*?)</Literal>', re.DOTALL)
+
+for b in block.findall(owl_text):
+    pm = ap.search(b)
+    if not pm or not pm.group(1).startswith(""http""):
+        continue
+    praw = pm.group(1); pred = URIRef(praw)
+    iris = iri.findall(b); lm = lit.search(b)
+    if not iris:
+        continue
+    subj = URIRef(iris[0])
+    if praw.endswith(""goodTenorOf""):
+        # le ""bon tenor"" pointe vers un schema de Walton (nom a espaces) : on garde le libelle
+        obj = iris[1].split(""#"")[-1].split(""/"")[-1] if len(iris) >= 2 else (lm.group(2) if lm else None)
+        if obj:
+            g.add((subj, pred, Literal(re.sub(r""\s+"", "" "", obj).strip())))
+    elif praw in IRI_OBJ and len(iris) >= 2:
+        g.add((subj, pred, URIRef(iris[1])))
+    elif lm:
+        lang = lm.group(1)
+        val = re.sub(r""\s+"", "" "", lm.group(2)).strip()
+        g.add((subj, pred, Literal(val, lang=lang.lower() if lang else None)))
+
+print(f""Graphe SKOS construit : {len(g):,} triplets"")
+print(f""Concepts distincts (sujets) : {len(set(g.subjects())):,}"")
+",,,,,,,,0bf9590f45b20ff7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,658ca1d2,markdown,fr,d3c23ae74cff06e4,"**Lecture** : ni `rdflib` (parseur RDF/XML) ni `owlready2` (parseur OWL/XML) ne restituent
+le contenu de ce fichier -- le premier parce que la serialisation n'est pas du RDF/XML, le second
+parce que son parseur ne reconstruit pas les `AnnotationAssertion` de cette structure. Le pont
+extrait donc les assertions OWL/XML et les charge comme **vrais triplets RDF** dans un graphe
+`rdflib` : a partir de la, toutes les operations (comptage, hierarchie, langues) se font en
+**SPARQL sur le graphe**, c'est-a-dire avec l'outil SOTA. Verdict de portee : **SOTA-OK** -- le
+pont est une passerelle d'ingestion documentee, pas un contournement du moteur de requetes.
+",,,,,,,,d3c23ae74cff06e4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,ad1c1e05,markdown,fr,d7d11c0adc7ac741,"## 3. Structure du thesaurus : inventaire des predicats SKOS
+
+Comptons chaque type de triplet pour cartographier l'ontologie et la comparer au pole sophismes.
+",,,,,,,,d7d11c0adc7ac741,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,7b8ad971,code,fr,07b2d8daedde8f61,"# --- Inventaire des predicats SKOS + AIF ---
+from collections import Counter
+
+pred_counts = Counter(g.namespace_manager.normalizeUri(p) for _, p, _ in g)
+print(""Predicats du graphe (frequence) :"")
+for p, n in pred_counts.most_common():
+    print(f""  {n:>5,}  {p}"")
+
+n_concepts = len(set(g.subjects(SKOS.prefLabel, None)))
+n_def      = len(list(g.triples((None, SKOS.definition, None))))
+n_broader  = len(list(g.triples((None, SKOS.broader, None))))
+n_narrower = len(list(g.triples((None, SKOS.narrower, None))))
+n_scheme   = len(list(g.triples((None, SKOS.inScheme, None))))
+n_gtenor   = len(list(g.triples((None, AIF.goodTenorOf, None))))
+
+print(f""\nConcepts (avec prefLabel) : {n_concepts:,}"")
+print(f""Definitions               : {n_def:,}"")
+print(f""Relations broader         : {n_broader:,}"")
+print(f""Relations narrower        : {n_narrower:,}"")
+print(f""Appartenances au scheme   : {n_scheme:,}"")
+print(f""Liens AIF goodTenorOf     : {n_gtenor:,}"")
+
+# Contraste avec le pole sophismes (Ontology_AIF)
+print(""\n--- Contraste des paradigmes ---"")
+print(""Sophismes (Ontology_AIF) : ABox -- NamedIndividual + ObjectPropertyAssertion (graphe dense)."")
+print(""Vertus    (ce notebook)  : thesaurus SKOS -- Concept + broader/narrower (hierarchie)."")
+",,,,,,,,07b2d8daedde8f61,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,76ec68e5,markdown,fr,4874fbcfce8b24d6,"**Lecture** : le thesaurus compte **223 concepts** (chacun avec un `prefLabel`), **446
+definitions** (223 x 2 langues), **222 relations `broader`** et autant de `narrower` -- la
+double declaration est la convention SKOS (chaque lien hierarchique est pose dans les deux
+sens). Contrairement au pole sophismes, il n'y a **aucun** `NamedIndividual` ni
+`ObjectPropertyAssertion` : la connaissance est portee par la **hierarchie de concepts** et les
+**annotations multilingues**, pas par un graphe de relations entre individus. Deux ontologies
+soeurs, deux paradigmes : ABox relationnel pour les sophismes, thesaurus SKOS pour les vertus.
+",,,,,,,,4874fbcfce8b24d6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,4833edd2,markdown,fr,92fad54c8dd8a738,"## 4. La hierarchie SKOS : du concept racine aux familles
+
+Le thesaurus a un **concept racine** (`skos:topConceptOf`). Les concepts les plus ramifies
+(beaucoup de `narrower`) sont les tetes de **familles** de vertus. Requetons cela en SPARQL.
+",,,,,,,,92fad54c8dd8a738,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,c01f48b7,code,fr,0e30f094e3020421,"# --- Concept racine + familles les plus ramifiees (SPARQL) ---
+SKOS_P = ""PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n""
+
+# Concept racine
+q_top = SKOS_P + """"""
+SELECT ?c ?l WHERE {
+  ?c skos:topConceptOf ?scheme .
+  OPTIONAL { ?c skos:prefLabel ?l . FILTER(lang(?l) = ""fr"") }
+}""""""
+print(""Concept racine (topConcept) :"")
+for r in g.query(q_top):
+    print(f""  {str(r.c).split('#')[-1]}  =  {r.l}"")
+
+# Familles : concepts avec le plus de narrower
+q_fam = SKOS_P + """"""
+SELECT ?c ?l (COUNT(?n) AS ?k) WHERE {
+  ?c skos:narrower ?n .
+  OPTIONAL { ?c skos:prefLabel ?l . FILTER(lang(?l) = ""fr"") }
+} GROUP BY ?c ?l ORDER BY DESC(?k) LIMIT 10""""""
+print(""\nConcepts les plus ramifies (tetes de familles) :"")
+for r in g.query(q_fam):
+    print(f""  {int(r.k):>2} narrower  |  {str(r.c).split('#')[-1]:<28}  {r.l or ''}"")
+
+# Profondeur de la hierarchie : chaine broader depuis un concept feuille
+def ancestors(concept):
+    chain, cur, seen = [], concept, set()
+    while cur and cur not in seen:
+        seen.add(cur)
+        ups = list(g.objects(cur, SKOS.broader))
+        if not ups:
+            break
+        cur = ups[0]; chain.append(cur)
+    return chain
+
+leaves = [c for c in g.subjects(SKOS.prefLabel, None)
+          if not list(g.objects(c, SKOS.narrower)) and list(g.objects(c, SKOS.broader))]
+if leaves:
+    sample = sorted(leaves, key=lambda c: str(c))[0]
+    lbl = next((str(l) for l in g.objects(sample, SKOS.prefLabel) if l.language == ""fr""), sample)
+    print(f""\nChaine broader depuis une feuille ({str(sample).split('#')[-1]}) :"")
+    path = [str(sample).split('#')[-1]] + [str(a).split('#')[-1] for a in ancestors(sample)]
+    print(""  "" + ""  ->  "".join(path))
+",,,,,,,,0e30f094e3020421,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,e786ec67,markdown,fr,e48608c214db9caa,"**Lecture** : le concept racine est **`validArgument` (""Argument valable"")** -- toute
+vertu est une facette de l'argument valable. Les tetes de familles (`simpleInference`,
+`thirdfigureSyllogism`, `acceptableInformalLogic`, `tangibleEvidence`, `credibleSources`...)
+recouvrent les **7 familles** annoncees : logique formelle, logique informelle, qualite des
+sources, des preuves, etc. La chaine `broader` remonte de chaque feuille jusqu'a la racine :
+c'est la profondeur du thesaurus, exploitable pour situer une vertu dans sa lignee.
+",,,,,,,,e48608c214db9caa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,7102e28d,markdown,fr,832a6538af9d9189,"## 5. Un thesaurus bilingue : `prefLabel` et `definition` par langue
+
+SKOS attache les libelles **par langue** (`@fr`, `@en`). Verifions la couverture et affichons
+quelques concepts dans les deux langues.
+",,,,,,,,832a6538af9d9189,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,bd6dafc0,code,fr,84ff7d157ad1d80c,"# --- Couverture multilingue + echantillon bilingue ---
+def count_by_lang(pred):
+    q = SKOS_P + f""""""
+    SELECT ?lg (COUNT(DISTINCT ?c) AS ?n) WHERE {{
+      ?c <{pred}> ?v . BIND(lang(?v) AS ?lg)
+    }} GROUP BY ?lg ORDER BY DESC(?n)""""""
+    return [(str(r.lg), int(r.n)) for r in g.query(q)]
+
+print(""Couverture prefLabel par langue :"", count_by_lang(str(SKOS.prefLabel)))
+print(""Couverture definition par langue :"", count_by_lang(str(SKOS.definition)))
+
+# Echantillon : 6 concepts avec prefLabel FR + EN cote a cote
+q_bi = SKOS_P + """"""
+SELECT ?c ?fr ?en WHERE {
+  ?c skos:prefLabel ?fr . FILTER(lang(?fr) = ""fr"")
+  ?c skos:prefLabel ?en . FILTER(lang(?en) = ""en"")
+} ORDER BY ?c LIMIT 6""""""
+print(""\nEchantillon bilingue (concept : FR / EN) :"")
+for r in g.query(q_bi):
+    print(f""  {str(r.c).split('#')[-1]:<24}  {str(r.fr):<26}  |  {r.en}"")
+
+# Une definition FR complete
+q_def = SKOS_P + """"""
+SELECT ?c ?d WHERE {
+  ?c skos:definition ?d . FILTER(lang(?d) = ""fr"")
+} ORDER BY ?c LIMIT 1""""""
+for r in g.query(q_def):
+    print(f""\nDefinition FR de '{str(r.c).split('#')[-1]}' :\n  {r.d}"")
+",,,,,,,,84ff7d157ad1d80c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,0c5aa193,markdown,fr,58c91f626c83ef49,"**Lecture** : la couverture est **symetrique -- 223 concepts en FR et 223 en EN** pour les
+`prefLabel` comme pour les `definition`. C'est un thesaurus reellement bilingue, ou chaque vertu
+est nommee et definie dans les deux langues. Cette structure `@fr`/`@en` est exactement ce que
+SKOS est concu pour porter, et ce qui rend le thesaurus directement exploitable dans une
+interface multilingue.
+",,,,,,,,58c91f626c83ef49,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,35e59e7b,markdown,fr,ff4b4fbff76f667b,"## 6. Le pont AIF `goodTenorOf` : vertus <-> schemas de Walton
+
+Chaque vertu est le **""bon tenor""** d'un schema d'argument de Walton (`aif:goodTenorOf`) --
+la maniere correcte d'instancier ce schema. Ce sont **les memes 14 schemes** que ceux relies aux
+sophismes cote `Ontology_AIF` : `goodTenorOf` et `badTenorOf` sont les deux faces d'un meme
+schema. Visualisons leur distribution.
+",,,,,,,,ff4b4fbff76f667b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,ada48f7b,code,fr,dca2b2ea5efd4b21,"# --- Distribution des schemes de Walton portes par les vertus + graphique ---
+%matplotlib inline
+import matplotlib.pyplot as plt
+
+q_scheme = SKOS_P + """"""
+PREFIX aif: <http://www.arg.dundee.ac.uk/aif#>
+SELECT ?scheme (COUNT(?c) AS ?n) WHERE {
+  ?c aif:goodTenorOf ?scheme .
+} GROUP BY ?scheme ORDER BY DESC(?n)""""""
+rows = [(str(r.scheme), int(r.n)) for r in g.query(q_scheme)]
+print(f""Schemes de Walton distincts portes par les vertus : {len(rows)}"")
+for s, n in rows:
+    print(f""  {n:>3}  {s}"")
+
+labels = [s for s, _ in rows][::-1]
+values = [n for _, n in rows][::-1]
+fig, ax = plt.subplots(figsize=(9, 5.5))
+ax.barh(labels, values, color=""#3a7d44"")
+ax.set_xlabel(""Nombre de vertus (goodTenorOf)"")
+ax.set_title(""Vertus argumentatives par schema de Walton (aif:goodTenorOf)"")
+for i, v in enumerate(values):
+    ax.text(v + 0.3, i, str(v), va=""center"", fontsize=9)
+plt.tight_layout()
+plt.show()
+",,,,,,,,dca2b2ea5efd4b21,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,6e503d32,markdown,fr,593baf04a837017f,"**Lecture** : les **14 schemes** de Walton relies aux vertus sont exactement ceux qui
+apparaissent cote sophismes. Les plus productifs -- *Argument from Rule* (50 vertus), *from
+Commitment* (40), *from Bias* (27), *from Sign* (26) -- sont les schemes ou l'argumentation
+correcte se decline en de nombreuses bonnes pratiques. La propriete `goodTenorOf` est donc le
+**pivot** qui permettra, dans les exercices, de relier une vertu a son sophisme miroir via le
+schema partage.
+",,,,,,,,593baf04a837017f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,8798c7a3,markdown,fr,17a8175b2e2a3a60,"## 7. Exercices
+
+Trois exercices pour manipuler le thesaurus vous-meme. Les cellules sont des squelettes a
+completer -- le graphe `g` est deja charge en memoire.
+",,,,,,,,17a8175b2e2a3a60,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,363f473d,markdown,fr,cc8b49f59b3ab09c,"### Exercice 1 -- Concepts sans definition dans une langue
+
+Ecrire une requete SPARQL qui liste les concepts possedant un `skos:prefLabel` **anglais** mais
+**aucune** `skos:definition` anglaise (candidats a la traduction). Indice : `FILTER NOT EXISTS`.
+",,,,,,,,cc8b49f59b3ab09c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,1c28e1e8,code,fr,ffba7a354ff75a9e,"# Exercice 1 a completer
+# Objectif : concepts avec prefLabel @en mais SANS definition @en.
+# Indice : SPARQL FILTER NOT EXISTS { ?c skos:definition ?d . FILTER(lang(?d)=""en"") }
+
+# q_ex1 = SKOS_P + """"""
+# SELECT ?c WHERE {
+#   ?c skos:prefLabel ?l . FILTER(lang(?l) = ""en"")
+#   # ... a completer ...
+# }""""""
+# resultats = list(g.query(q_ex1))
+# print(f""{len(resultats)} concept(s) sans definition EN"")
+
+resultats = None  # TODO etudiant
+print(""Exercice 1 a completer"")
+",,,,,,,,ffba7a354ff75a9e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,0a979be7,markdown,fr,0b356cd8822037bc,"### Exercice 2 -- Visualiser une famille avec networkx
+
+Choisir une tete de famille (p. ex. `credibleSources`) et dessiner son sous-arbre `narrower`
+avec `networkx` + `matplotlib`. Indice : parcourir recursivement `g.objects(node, SKOS.narrower)`
+et construire un `networkx.DiGraph`.
+",,,,,,,,0b356cd8822037bc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,c33e84aa,code,fr,ea40e1aa2b6c36be,"# Exercice 2 a completer
+# Objectif : sous-arbre narrower d'une famille, dessine avec networkx.
+# Indice :
+#   import networkx as nx
+#   G = nx.DiGraph()
+#   def descendre(node):
+#       for enfant in g.objects(node, SKOS.narrower): ...
+#   nx.draw(G, with_labels=True)
+
+racine_famille = None  # TODO etudiant : une URIRef de tete de famille
+print(""Exercice 2 a completer"")
+",,,,,,,,ea40e1aa2b6c36be,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,0d3f18a2,markdown,fr,082359e02be6a54b,"### Exercice 3 -- Le pont vertus <-> sophismes
+
+Pour un schema de Walton donne (p. ex. `""Argument from Sign""`), lister toutes les vertus qui en
+sont le `goodTenorOf`. Bonus : ouvrir `Argument_Analysis_Ontology_AIF.ipynb` et comparer avec les
+**sophismes** relies au **meme** schema -- vous materialisez ainsi l'axe good/bad tenor.
+",,,,,,,,082359e02be6a54b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,6312ff34,code,fr,8efe9b4bc2044ce3,"# Exercice 3 a completer
+# Objectif : pour un scheme de Walton, lister les vertus goodTenorOf ; comparer au pole sophismes.
+# Indice : construire une requete SPARQL avec le prefixe
+#   PREFIX aif: <http://www.arg.dundee.ac.uk/aif#>
+#   et un motif  ?c aif:goodTenorOf ""Argument from Sign""  (l'objet est un litteral).
+
+scheme_cible = ""Argument from Sign""  # a explorer
+vertus_du_scheme = None  # TODO etudiant
+print(""Exercice 3 a completer"")
+",,,,,,,,8efe9b4bc2044ce3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_Virtues.ipynb,4907f827,markdown,fr,aab800cd0d81d310,"## 8. Ponts avec la serie Argument_Analysis
+
+- [`Argument_Analysis_Ontology_AIF`](Argument_Analysis_Ontology_AIF.ipynb) -- le **pole sophismes**
+  (OWL2 ABox, schemes de Walton via `badTenorOf`). A lire en parallele : meme projet, paradigme oppose.
+- [`Argument_Analysis_Ontology_CrossLinks`](Argument_Analysis_Ontology_CrossLinks.ipynb) -- les liens
+  inter-noeuds systematises (CSV canonique multilingue).
+- [`Argument_Analysis_Restitution_3_Actes`](Argument_Analysis_Restitution_3_Actes.ipynb) -- la
+  restitution pedagogique en trois actes.
+
+**A retenir** : une meme famille de connaissances (l'argumentation) peut se modeliser en
+**ABox relationnel** (individus + relations, cote sophismes) ou en **thesaurus SKOS**
+(concepts + hierarchie + multilingue, cote vertus). SKOS n'est pas ""moins expressif"" -- il est
+**adapte a une taxonomie navigable et traduisible**, la ou l'ABox convient a un graphe dense de
+relations. Le choix depend de l'usage vise, pas d'une hierarchie de valeur entre formalismes.
+",,,,,,,,aab800cd0d81d310,,,,,,,


### PR DESCRIPTION
## Contexte

T1b pour #4957 (T1 livré via #5385 + #5799, T2 livré via `check_translation_sync.py`, T3 gated #1650 Phase 1). Consolidation disciplinaire du mode `--update` livré via #6514 (c.438) — appliquée sur le **plus gros chantier de drift latent** détecté : `translations/sudoku/` cumule **75 `SRC_DRIFT`** (vs 29 sur Argument_Analysis c.438). Pattern identique : cellules modifiées sur les notebooks depuis l'extraction initiale #5385 (2026-07-05), jamais re-hashées.

Le mode `--update` livré c.438 PR #6514 sait désormais gérer ce cas en préservant verbatim les colonnes cibles (`text_en`/`hash_en`/...) remplies par T3 (moteur Argumentum) — sinon une extraction complète les écraserait.

## Changement

**(1) Cherry-pick du mode `--update`** : commit `97dedcb83` (depuis `feature/c438-translation-csv-update`, base identique `8da7aab01`). Apporte le mode merge dans `scripts/translation/extract_cells_to_csv.py` (275L) + la régénération de `translations/symbolicai/argument_analysis.csv` (1084L).

**(2) Application sur la série Sudoku** : `translations/sudoku/sudoku.csv` régénéré via `--update`.
- **75 rafraîchies** (toutes les `SRC_DRIFT` détectées par `check_translation_sync.py`)
- **102 ajoutées** (nouvelles cellules dans les notebooks depuis l'extraction initiale — couvre tout le développement post-#5385 sur 36 notebooks)
- **1148 déjà in-sync**
- **0 orpheline** (pas de cellules cibles disparues, donc aucun `ORPHAN_ROW` côté T2)
- Total : 1223 → 1325 lignes (+102 nettes), 36 notebooks, **drift 75 → 0**.

**Note importante sur le merge** : cette PR contient aussi le diff de `translations/symbolicai/argument_analysis.csv` (cherry-pick de c.438). Si la PR #6514 est mergée en premier, ces changements disparaîtront au rebase et le PR n'aura qu'un seul vrai livrable (Sudoku). Si elle est mergée après, un rebase frais sur `origin/main` post-merge supprimera le diff symbolicai automatiquement.

## Vérifications anti-régression

- **Atomique R3** : 3 fichiers, +2373/-783 lignes (sous plafond 3000L), 1 feature (mode `--update` réutilisé + application Sudoku = 1 sujet cohérent T1b translation infra), 1 domaine (translation infra).
- **LF-only L268** : CR=0 byte-level vérifié Python (sudoku.csv original = LF-only, après update = LF-only, **33407 LF sur le fichier régénéré**).
- **MD047** : EOF newline vérifié True (1626472 B).
- **Determinisme** : 2 runs successifs de `--update` produisent un CSV byte-identique (`run1 == run2 = True`). Run 2 = `0 ligne(s) rafraîchie(s), 1325 déjà in-sync, 0 ajoutée(s), 0 orpheline(s)`.
- **R1 catalog-pr-hygiene** : aucun catalogue touché (`grep -c CATALOG-STATUS translations/sudoku/sudoku.csv = 0`).
- **Secrets hygiene L143** : `grep -nE "(sk-|ghp_|AIza)" translations/sudoku/sudoku.csv = 0` (clean).
- **Anti-§D byte-identity** : N/A (script utilitaire, pas sibling pair Lean).
- **G.1 firsthand** : `check_translation_sync.py translations/sudoku/` AVANT commit (75 SRC_DRIFT détectées et confirmées par compteur pre-update) ; compte post-commit = **0 drift** vérifié Python.

## Doctrine

- **C439-L1** consolidation disciplinaire : c.438 a livré l'outil `--update`, c.439 l'applique sur le plus gros dataset. Pattern "livrer l'infrastructure, puis l'appliquer partout où le besoin existe". Découverte : le drift latent n'était pas listé globalement, **chaque série peut avoir son propre stock** (75 ici vs 29 sur symbolicai c.438).
- **C439-L2** vérif systématique avant commit : drift count pre/post + déterminisme + LF-only + déterminisme. Le décompte `75 SRC_DRIFT détectées via check_translation_sync.py` doit matcher `75 ligne(s) rafraîchie(s)` du run `--update` — sinon désaccord = investigation.
- **C439-L3** cherry-pick propre : `97dedcb83` cherry-pické depuis `feature/c438-translation-csv-update` car linéaire au-dessus de `8da7aab01` (notre base). Pas de conflit, message commit préservé.

## Usage (rappel c.438 — pour réutilisation)

```bash
# Update ciblé sur 1 notebook (cas usuel post-PR qui modifie le contenu)
python scripts/translation/extract_cells_to_csv.py notebook.ipynb \
    --update translations/<famille>/<série>.csv

# Update full-arborescence (cas post-ajout d'un nouveau notebook)
python scripts/translation/extract_cells_to_csv.py \
    MyIA.AI.Notebooks/<famille>/<série>/ \
    --update translations/<famille>/<série>.csv

# Vérification du drift post-update
python scripts/translation/check_translation_sync.py \
    translations/<famille>/<série>.csv
```

## Refs

- `See #4957` (T1b — sous-tâche d'epic, ne clôt pas l'epic).
- Verrouillage avec `check_translation_sync.py` T2 (déjà livré) : exit 0 si drift (CI non-bloquante), exit 1 si demandé (CLI usuel).
- Moteur Argumentum T3 gated #1650 Phase 1 — cette PR prépare le terrain (les colonnes cibles sont préservées verbatim).
- **Suites logiques** (autres séries avec drift latent détecté) : probas-infer (54), search-part1 (41), gametheory (46+), search-part2 (34), rl (15), iit (11+), probas-pymc (9), planners (7), search-part3 (6), smartcontracts (5), search-part4 (5), casestudies (4). mlnet = 0 (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
