### PR TITLE
docs(search): fix Part1-Foundations stale Applications count (22 -> 40)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -16,7 +16,7 @@ Trois extensions complètent le panorama. La couverture exacte et les Dancing Li
 
 ## Pourquoi cette partie
 
-Cette partie est l'alphabet de toute la série : la formalisation en espace d'états, le backtracking et les heuristiques qu'on y construit sont réutilisés tels quels par la programmation par contraintes (Partie 2) et par les 22 notebooks d'application. Mais son véritable enseignement est un réflexe d'ingénieur : chaque algorithme y est présenté comme un compromis — complétude contre mémoire, garantie contre temps de calcul, exploration contre exploitation — et jamais comme une recette. C'est ce réflexe, plus que tel ou tel algorithme, qui distingue celui qui applique une bibliothèque de celui qui choisit une stratégie.
+Cette partie est l'alphabet de toute la série : la formalisation en espace d'états, le backtracking et les heuristiques qu'on y construit sont réutilisés tels quels par la programmation par contraintes (Partie 2) et par les 40 notebooks d'application. Mais son véritable enseignement est un réflexe d'ingénieur : chaque algorithme y est présenté comme un compromis — complétude contre mémoire, garantie contre temps de calcul, exploration contre exploitation — et jamais comme une recette. C'est ce réflexe, plus que tel ou tel algorithme, qui distingue celui qui applique une bibliothèque de celui qui choisit une stratégie.
 
 ## Objectifs d'apprentissage
 
@@ -165,7 +165,7 @@ Le véritable enseignement, au-delà du catalogue d'algorithmes, est un **réfle
 ### Prochaines étapes
 
 - **La programmation par contraintes** : la suite naturelle est la [Partie 2 (CSP)](../Part2-CSP/README.md), qui réutilise le backtracking et les heuristiques de cette partie pour propager des contraintes plutôt que d'énumérer — la réduction de l'espace de recherche y devient systématique plutôt qu'heuristique.
-- **Les applications** : les [22 notebooks d'application](../Applications/README.md) (détection de contours, TSP, VRP, optimisation de portefeuille, hyperparameter tuning) mobilisent directement les métaheuristiques et la recherche locale vues ici sur des problèmes réels.
+- **Les applications** : les [40 notebooks d'application](../Applications/README.md) (détection de contours, TSP, VRP, optimisation de portefeuille, hyperparameter tuning) mobilisent directement les métaheuristiques et la recherche locale vues ici sur des problèmes réels.
 - **Les ponts vers les autres séries** : les Dancing Links irriguent [Sudoku](../../Sudoku/README.md), Minimax et MCTS se prolongent dans [GameTheory](../../GameTheory/README.md) (OpenSpiel) puis [RL](../../RL/README.md) (politiques apprises), et les prédicats Z3 de Search-10 ouvrent sur [SymbolicAI](../../SymbolicAI/README.md). Reprendre un de ces ponts après avoir posé les fondations de la recherche donne aux primitives une nouvelle profondeur.
 - **La série dans son ensemble** : le [sommaire Search](../README.md) cartographie les quatre parties et les applications — celle-ci est le socle commun.
 


### PR DESCRIPTION
## Summary

Fixes a stale cross-reference count in `Search/Part1-Foundations/README.md`: it says **"les 22 notebooks d'application"** (L19, L168) pointing to `../Applications/README.md`, but the Applications sub-series has grown to **40 notebooks**.

See #3973 (partial — documentation accuracy; does not resolve the epic).

## §E whole-file audit against disk (firsthand, G.1)

| Check | Disk | Part1 README (before) | Canonical Applications/README | Status |
|-------|------|----------------------|-------------------------------|--------|
| Part1 count claims | — | "22 notebooks" ×2 (L19, L168) | — | both are cross-refs to Applications |
| Applications notebooks | **40** | (referenced as "22") | **"40 notebooks" (L3, L5)** ✓ | Part1 ref stale by +18 |

```
$ find Search/Applications -name '*.ipynb' ! -path '*/.ipynb_checkpoints/*' | wc -l  -> 40
  (App-1..App-20, most with a -CSharp twin = 20 Python mains + 20 Csharp twins)
```

**Disambiguation (G.1 — avoided a false positive):** the "22" refers to the **Applications/** directory, NOT to Part1-Foundations itself. Confirmed by reading L168's link target: `les [22 notebooks d'application](../Applications/README.md)`. Part1-Foundations itself has 29 `.ipynb` (17 Python + 12 Csharp twins) — a different count that the README does not claim.

## Fix

`22` → `40` in both cross-references (L19 + L168), aligning Part1 with:
- the **canonical** `Applications/README.md` (already says "40 notebooks"), and
- **disk** (40 `.ipynb`).

## Validation

- `git diff --numstat`: 2/2 (symmetric = no CRLF flip)
- No `*.lean` touched (pure docs) → no build/sorry concerns
- No `.en.md` mirror for Part1-Foundations → 1 file only
- Collision guard: open PR #6513 touches only `assets/readme/MANIFEST.md` (alt-text/cell-ref), NOT README.md prose → no collision
- `COURSE_CATALOG.generated.*` not touched

Co-Authored-By: Claude <noreply@anthropic.com>