### PR TITLE
fix(genai,secrets): mask Claudish BASE_URL host in env-print cell (rule-6 source-leak)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb
@@ -341,7 +341,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  ANTHROPIC_BASE_URL       = http://192.168.0.46:3000\n",
+      "  ANTHROPIC_BASE_URL       = http://<hote masque>:3000\n",
       "  CLAUDISH_BASE_URL        = (non definie)\n",
       "  ANTHROPIC_MODEL          = (non definie)\n",
       "  ANTHROPIC_AUTH_TOKEN     = <masque, 0 caracteres>\n"
@@ -350,14 +350,22 @@
    ],
    "source": [
     "# Verifier quelles env vars sont deja positionnees (NE PAS afficher les valeurs completes)\n",
+    "from urllib.parse import urlparse\n",
+    "\n",
     "for var in (\"ANTHROPIC_BASE_URL\", \"CLAUDISH_BASE_URL\", \"ANTHROPIC_MODEL\", \"ANTHROPIC_AUTH_TOKEN\"):\n",
     "    val = os.environ.get(var)\n",
     "    if val is None:\n",
     "        print(f\"  {var:24s} = (non definie)\")\n",
     "    elif \"TOKEN\" in var or \"KEY\" in var:\n",
     "        print(f\"  {var:24s} = <masque, {len(val)} caracteres>\")\n",
+    "    elif \"://\" in val:\n",
+    "        # Masquer l hote dans les URLs : evite de fuiter l adresse LAN du gateway Claudish.\n",
+    "        # On garde le port (debug) mais jamais l hote (PII machine).\n",
+    "        u = urlparse(val)\n",
+    "        port = f\":{u.port}\" if u.port else \"\"\n",
+    "        print(f\"  {var:24s} = {u.scheme}://<hote masque>{port}\")\n",
     "    else:\n",
-    "        print(f\"  {var:24s} = {val}\")"
+    "        print(f\"  {var:24s} = {val}\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Cell 11 of [`01-claude-code-via-claudish.ipynb`](MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/notebooks/01-claude-code-via-claudish.ipynb) printed `ANTHROPIC_BASE_URL` **raw** (`http://192.168.0.46:3000`) in its `else` branch — leaking the Claudish gateway's **LAN address**.

The cell already masked `TOKEN`/`KEY` vars and carried the comment *`NE PAS afficher les valeurs completes`*, but the URL-host path was missed (only the literal-values intent was implemented for secrets, not for the BASE_URL host).

## Fix (rule-6 source-leak category C → Stop & Repair §6)

Added an `elif "://" in val:` branch that masks the host via `urlparse` → `<hote masque>`, keeping the **port** for debugging:

```
ANTHROPIC_BASE_URL       = http://192.168.0.46:3000   # BEFORE (LAN IP leaked)
ANTHROPIC_BASE_URL       = http://<hote masque>:3000  # AFTER  (host gone, port kept)
```

Then **RE-EXEC cell 11** (not a hand-scrub of the committed output): `ANTHROPIC_BASE_URL` is set in my env, so the masking branch **is exercised** → the spliced output proves `http://<hote masque>:3000`. Cell 11 is standalone env-printing (deps: `import os` only); cells 5/8 (real API calls) untouched.

## Validation (H.1 / C.2 / C.3)
- **Source-identity**: only cell 11 source + cell 11 outputs change (1 cell, +11/−3).
- **nbformat.validate**: PASS (strict).
- **Re-exec proof**: masking branch exercised (var SET) → `<hote masque>` in output, 0 IPv4 remaining.
- **LF-only**: `write_bytes` (0 CRLF, avoids Path.write_text newline-translation on Windows).
- **exec_count**: preserved at 4 (isolated cell re-exec, not a full-notebook re-run).
- **Verify-gate** (c.455): `git show HEAD:file` confirms blob has `hote masque` ×2, 0 `192.168.0.46`.

## Context
PII-lite LAN address (private range) — cf #6443 precedent (RECOVERABLE-USER-HAND, priorité basse). This one is **RECOVERABLE-LOCAL** (source-fix + re-exec, no user action). See secrets-hygiene rule 6 / EPIC #2874.

`See #2874` (partial — one leak among the #2876/#6443 family, not closing the EPIC).