### PR TITLE
feat(translation,#4957): resync SmartContracts CSV (11 new + 3 drift + 2 orphans)

### DIFF
--- a/translations/smartcontracts/smartcontracts.csv
+++ b/translations/smartcontracts/smartcontracts.csv
@@ -7450,13 +7450,19 @@ MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Stan
 | Cas typique | Monnaie, governance | Art, collectibles | Jeux video, DeFi |
 
 **Note technique** : ERC-1155 utilise `safeTransferFrom` avec un callback `onERC1155Received` pour empecher les transferts vers des contrats qui ne savent pas gerer les tokens (securite supplementaire par rapport a ERC-721).",,,,,,,,5d1d9bc2ebf161da,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,eabd7d0a,markdown,fr,1665dec571861c28,"### Exercice 1 : Multi-Token ERC-1155
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,eabd7d0a,markdown,fr,01a0197cd7cba739,"### 7.1. Exercice 1 : Multi-Token (ERC-1155 simplifie)
 
 Implementez un contrat `SimpleMultiToken` gerant plusieurs types de tokens dans un seul contrat, inspire du standard ERC-1155 vu ci-dessus.
 
 **Objectif** : Comprendre comment un seul contrat peut gerer a la fois des tokens fongibles et non-fongibles via des identifiants.
 
-**Indice** : Contrairement a ERC-20 (un seul mapping `address => uint256`) et ERC-721 (`uint256 => address`), ERC-1155 utilise un mapping a deux dimensions `tokenId => owner => amount`.",,,,,,,,1665dec571861c28,,,,,,,
+**Indice 1 (structure de donnees)** : Contrairement a ERC-20 (un seul mapping `address => uint256`) et ERC-721 (`uint256 => address`), ERC-1155 utilise un mapping a deux dimensions `tokenId => owner => amount`. Pour `balanceOfBatch`, faites un `require(ids.length == accounts.length)` au debut, puis retournez un tableau dynamique de meme longueur.
+
+**Indice 2 (evenements et conformite)** : Emettez un evenement `TransferSingle(operator, from, to, id, value)` apres chaque mutation de solde (mint, burn, transfer). Cet evenement est ce que les indexeurs (OpenSea, etc.) écoutent pour mettre a jour les inventaires. Pour rester compatible ERC-1155, ne melangez jamais FT et NFT dans le meme `tokenId`.
+
+**Indice 3 (securite et pieges)** : Dans `safeTransferFrom`, verifiez `from != address(0)` et `to != address(0)` au debut (un mint doit utiliser `from = address(0)` explicitement). Attention au cas `amount == 0` : convention ERC-1155 = accepter sans effet (emettre quand meme l'evenement). Pour les batch, faites toutes les verifications AVANT d'appliquer les mutations, sinon une transaction partiellement valide peut bloquer le batch entier.
+
+L'implementation complete tient en ~80 lignes de Solidity (hors interface).",,,,,,,,01a0197cd7cba739,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,4cc9d1d0,code,fr,9f54ace4638c27b4,"# Exercice 1 : Multi-Token (ERC-1155 simplifie)
 # TODO etudiant : implementer un contrat SimpleMultiToken gerant plusieurs types de tokens
 # Indice : utilisez mapping(uint256 => mapping(address => uint256)) pour les soldes
@@ -7651,10 +7657,19 @@ MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Stan
 MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,cell-11,markdown,fr,6034c598a87ceb3a,"---
 
 ## 5. Exemples guidés",,,,,,,,6034c598a87ceb3a,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,cell-12,markdown,fr,8f88ef8daa184200,"### Exercice 2 : Token avec plafond
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,cell-12,markdown,fr,f42455df571e9b7b,"### 7.2. Exercice 2 : Token avec plafond (ERC-20 capped)
 
-Creez un ERC-20 avec un supply maximum (capped).",,,,,,,,8f88ef8daa184200,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,697f96cc,markdown,fr,824c9ac92af194be,"**Indice :** Le mecanisme de cap repose sur un `require()` dans la fonction `mint()` qui verifie que `_totalSupply + amount <= cap`. Utilisez `immutable` pour le cap (fixe a la construction). Les fonctions ERC-20 (`transfer`, `approve`, `transferFrom`) sont identiques a `SimpleERC20` -- vous pouvez reutiliser le meme code.",,,,,,,,824c9ac92af194be,,,,,,,
+Creez un contrat `CappedToken` qui herite de `IERC20` et impose un supply maximum fixe a la construction (cap).
+
+**Objectif** : Comprendre comment limiter la quantite totale de tokens qui peuvent etre crees via `mint`, tout en preservant l'interface ERC-20 standard.
+
+**Indice 1 (variable immutable)** : Le `cap` doit etre declare `uint256 public immutable cap;` car il est fixe a la construction et ne change jamais. Dans le `constructor`, prenez `_cap` en argument, verifiez `_cap > 0` avec `require`, puis assignez `cap = _cap`. Un immutable est plus gas-efficient qu'un storage variable pour les valeurs constantes apres deploy.
+
+**Indice 2 (logique de mint)** : Le coeur du mecanisme est `require(_totalSupply + amount <= cap, ""CappedToken: cap exceeded"");` AU DEBUT de `mint()`. Ensuite, `_totalSupply += amount; _balances[to] += amount; emit Transfer(address(0), to, amount);`. La verification overflow est importante : `_totalSupply + amount` peut overflow si `amount` est proche de `2^256`, mais en pratique avec un cap raisonnable, ce n'est pas un probleme. Pour une securite maximale, utilisez OpenZeppelin `Math.max` ou `unchecked` block.
+
+**Indice 3 (fonctions a reutiliser)** : Les fonctions `transfer`, `approve`, `transferFrom`, `allowance`, `balanceOf`, `totalSupply` sont identiques a `SimpleERC20` vu precedemment (section 1). Vous pouvez copier-coller ces implementations telles quelles -- le cap n'affecte que `mint`. Pensez a emettre `event Transfer(address(0), to, amount)` dans `mint` (convention ERC-20 pour signaler une creation) et `event Transfer(from, address(0), amount)` si vous implementez un `burn` optionnel.
+
+Une fois deploye, testez : `capped.functions.mint(addr1, cap).transact(...)` doit reussir, mais `capped.functions.mint(addr2, 1).transact(...)` apres doit echouer avec ""cap exceeded"".",,,,,,,,f42455df571e9b7b,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,cell-13,code,fr,d7878bfa7c1d80cf,"# Exercice 2 : Token avec plafond
 EXERCICE_CAPPED = '''
 // SPDX-License-Identifier: MIT
@@ -7691,15 +7706,19 @@ contract CappedToken is IERC20 {
 # cappedtoken, receipt = compile_and_deploy(w3, EXERCICE_CAPPED, deployer)
 # print(f""Deploye a: {cappedtoken.address}"")
 print(""Exercice a completer"")",,,,,,,,d7878bfa7c1d80cf,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,cell-14,markdown,fr,2d850afea6b6745c,"### Exercice 3 : NFT avec enumeration
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,cell-14,markdown,fr,42b6f769c4226c59,"### 7.3. Exercice 3 : NFT avec enumeration (ERC-721 enumerable)
 
-Creez un NFT qui permet d'enumerer tous les tokens.",,,,,,,,2d850afea6b6745c,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,17355d13,markdown,fr,eb9e8a0a2da690c7,"**Indice :** Un NFT enumerable necessite de maintenir trois structures en parallele :
-- `_ownedTokens[owner]` : liste des tokenIds possedes par un proprietaire
-- `_ownedTokensIndex[tokenId]` : position d'un token dans la liste de son proprietaire
-- `_allTokens` : liste globale de tous les tokenIds existants
+Creez un contrat `EnumerableNFT` qui permet d'enumerer tous les tokens existants et les tokens d'un proprietaire donne, en plus des operations ERC-721 de base.
 
-Pensez a mettre a jour ces trois structures dans `_mint()` et a gerer les retraits/insertions lors d'un transfert. Reutilisez le pattern de la fonction `_mint()` de `SimpleNFT` vu precedemment.",,,,,,,,eb9e8a0a2da690c7,,,,,,,
+**Objectif** : Comprendre comment maintenir des index secondaires (listes inversees) en parallele du mapping `_owners`, pour permettre des fonctions comme `tokenByIndex(i)` ou `tokenOfOwnerByIndex(owner, i)` qui sont impossibles avec uniquement `mapping(uint256 => address)`.
+
+**Indice 1 (les 3 structures paralleles)** : Pour enumerer, vous devez maintenir trois structures en parallele : `_ownedTokens[owner]` (liste des tokenIds possedes), `_ownedTokensIndex[tokenId]` (position inverse dans la liste du proprietaire), `_allTokens` (liste globale), et `_allTokensIndex[tokenId]` (position inverse dans la liste globale). Chaque structure consomme du storage mais permet un acces en O(1) aux fonctions d'enumeration. Le pattern ""swap-and-pop"" est preferable a `delete array[i]` pour eviter de laisser des trous.
+
+**Indice 2 (fonction _mint atomique)** : Dans `_mint(to, tokenId)`, faites TOUTES les operations dans l'ordre suivant : (1) `_owners[tokenId] = to;` (2) `_ownedTokensIndex[tokenId] = _ownedTokens[to].length;` (3) `_ownedTokens[to].push(tokenId);` (4) `_allTokensIndex[tokenId] = _allTokens.length;` (5) `_allTokens.push(tokenId);` Si vous oubliez une etape, les fonctions d'enumeration retourneront des valeurs incorrectes ou revert. L'ordre des push AVANT l'assignation de l'index est crucial pour la coherence.
+
+**Indice 3 (transfert et burn optionnels)** : Pour implementer `_transfer(from, to, tokenId)` (et `_burn(tokenId)`) avec enumeration, vous devez mettre a jour les 4 structures : retirer le token de la liste de `from` (swap avec le dernier + pop + maj de l'index inverse), ajouter a la liste de `to` (push + maj de l'index), et gerer `_allTokens` si c'est un burn. Le swap-and-pop preserve l'ordre des autres elements. Cette complexite supplementaire est la raison pour laquelle ERC-721 standard n'inclut PAS l'enumeration par defaut (optionnel via extension ERC721Enumerable d'OpenZeppelin).
+
+Test : deployez, mint 5 NFTs avec `_mint(deployer, i)` pour i in [1..5], puis verifiez `totalSupply() == 5`, `tokenByIndex(0) == 1`, `tokenOfOwnerByIndex(deployer, 0) == 1`.",,,,,,,,42b6f769c4226c59,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb,cell-15,code,fr,72eff5878c558cf8,"# Exercice 3 : NFT avec enumeration
 EXERCICE_ENUMERABLE = '''
 // SPDX-License-Identifier: MIT
@@ -21988,3 +22007,236 @@ Ce projet capstone a permis de consolider l'ensemble des competences developpees
 L'integration de ces composants illustre un principe central de la securite blockchain : la separation entre privacy (protection du contenu individuel via chiffrement) et verifiability (preuve publique de correction via ZKP). Le modele de state machine du contrat, combine au typage fort du chiffrement homomorphique et aux commitment schemes, forme une architecture ou chaque couche apporte une garantie complementaire. Ce pattern de composition de primitives cryptographiques se retrouve dans les systemes de vote reels (comme les implementations basées sur MACI ou Semaphore) et dans les protocoles DeFi avances utilisant des preuves a divulgation nulle pour la conformite reglementaire.
 
 Les perspectives d'approfondissement incluent l'utilisation de zk-SNARKs (Groth16, PLONK) pour des preuves plus succinctes et verificables on-chain a cout reduit, l'implementation d'un mecanisme de seuil de dechiffrement (threshold decryption) pour eliminer le point de confiance unique de l'autorite de decompte, et le deploiement sur un L2 (Base, Arbitrum) pour beneficier de couts de transaction negligeables tout en heritant de la securite d'Ethereum.",,,,,,,,14891c00ef554477,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb,cell-a50e497c,markdown,fr,5bb905b1fcaf9f5d,"---
+
+### Exercice (a completer) : Evenements et plafond de depot
+
+En vous inspirant de l'exemple guide ci-dessus, faites evoluer le contrat `Vault` :
+
+1. Ajoutez deux **evenements** Solidity `Deposit(address indexed compte, uint256 montant)` et `Withdrawal(address indexed compte, uint256 montant)`, et emettez-les dans `deposit()` et `withdraw()`.
+2. Ajoutez un **plafond** : refusez (`require`) tout depot qui ferait depasser un solde individuel de 5 ETH.
+3. Redeployez le contrat, effectuez un depot valide puis un depot qui depasse le plafond (attrapez l'exception), et lisez les evenements via `contract.events.Deposit().get_logs(...)`.
+",,,,,,,,5bb905b1fcaf9f5d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb,cell-7e00b0ce,code,fr,3ad7a666b43ec2c4,"# Exercice : Evenements et plafond de depot sur le contrat Vault
+# TODO etudiant :
+#   Etape 1 : copier VAULT_SOL et ajouter les evenements Deposit / Withdrawal + le plafond (require <= 5 ETH)
+#   Etape 2 : recompiler et redeployer avec compile_and_deploy(w3, VAULT_PLAFOND_SOL, deployer)
+#   Etape 3 : tester un depot valide, puis un depot au-dela du plafond (try/except)
+#   Etape 4 : lire les evenements emis via vault.events.Deposit().get_logs(from_block=0)
+
+print(""Exercice a completer"")
+",,,,,,,,3ad7a666b43ec2c4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-e888e70e,markdown,fr,2df3a16fb1455e78,"---
+
+## 7. Contributions etudiantes -- exemples guides
+
+Les trois exemples ci-dessous, contribues par un groupe d'etudiants, illustrent les concepts fondamentaux de Solana et Anchor vus dans ce notebook : derivation de PDA, structure d'un programme Anchor, et modele de comptes Solana. Chaque enonce est suivi de sa solution commentee.
+",,,,,,,,2df3a16fb1455e78,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-e060ec01,markdown,fr,3d80fc1f7986491c,"### Exemple guide 1 : Simulation Python de la derivation d'un PDA
+
+_Exemple contribue par le groupe **Mehdi Azouz, Ryad Gazenay & Hani Bouzida** (PR #2189)._
+
+Un PDA (Program Derived Address) est obtenu en cherchant un *bump* (255 -> 0) tel que le hash des seeds soit ""hors courbe"" ed25519 -- ici simule par la condition `premier octet < 128`. La derivation doit etre **deterministe** (memes seeds -> meme PDA) et **unique par utilisateur** (seeds differentes -> PDAs differents).
+",,,,,,,,3d80fc1f7986491c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-8f053f72,code,fr,317fa1ec9ca05170,"# Exercice 1 : Simulation Python de derivation PDA
+import hashlib
+
+def derive_pda_simulee(seeds: list, program_id: str) -> tuple:
+    """"""
+    Simule la derivation d'un PDA Solana en Python.
+
+    Convention simplifiee : on cherche le premier bump (255..0) tel que
+    SHA256(b"""".join(seeds) + program_id.encode() + bytes([bump]))
+    produise un hash dont le premier octet (int) est < 128
+    (simule ""hors courbe ed25519"").
+
+    Args:
+        seeds     : liste de bytes (ex: [b""counter"", b""alice_pubkey""])
+        program_id: identifiant du programme (str)
+
+    Returns:
+        (pda_address: str, bump: int) ou (None, None) si aucun bump trouve
+    """"""
+    seeds_bytes = b"""".join(seeds)
+    for bump in range(255, -1, -1):
+        data = seeds_bytes + program_id.encode() + bytes([bump])
+        h = hashlib.sha256(data).hexdigest()
+        if int(h[:2], 16) < 128:
+            return h, bump
+    return None, None
+
+# --- Tests ---
+seeds_alice = [b""counter"", b""alice_pubkey_example""]
+program_id  = ""MyCounter1111111111111111111111111""
+
+pda, bump = derive_pda_simulee(seeds_alice, program_id)
+print(f""PDA alice        : {pda[:16]}..."")
+print(f""Bump             : {bump}"")
+pda2, _ = derive_pda_simulee(seeds_alice, program_id)
+print(f""Deterministe     : {pda == pda2}"")
+seeds_bob = [b""counter"", b""bob_pubkey_example""]
+pda_bob, _ = derive_pda_simulee(seeds_bob, program_id)
+print(f""PDA bob != alice : {pda != pda_bob}"")
+",,,,,,,,317fa1ec9ca05170,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-0a6a741b,markdown,fr,9ebba955e8e5b18f,"### Exemple guide 2 : Programme Anchor de vote complet
+
+_Exemple contribue par le groupe **Mehdi Azouz, Ryad Gazenay & Hani Bouzida** (PR #2189)._
+
+Un programme Anchor de sondage : `create_poll` initialise le compte `Poll` (un PDA derive de `[b""poll"", authority]`), et `vote` incremente le compteur du choix avec garde sur la fermeture du sondage et la validite du choix. Le code Rust complet est presente ci-dessous.
+",,,,,,,,9ebba955e8e5b18f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-0ba91f97,code,fr,df4b65b9f0d91ec8,"# Exercice 2 : Programme Anchor de Vote complete (Rust)
+
+VOTE_PROGRAM_COMPLET = '''
+use anchor_lang::prelude::*;
+
+declare_id!(""Vote1111111111111111111111111111111111111"");
+
+#[program]
+pub mod voting {
+    use super::*;
+
+    pub fn create_poll(
+        ctx: Context<CreatePoll>,
+        question: String,
+        option_a: String,
+        option_b: String,
+    ) -> Result<()> {
+        let poll = &mut ctx.accounts.poll;
+        poll.question  = question;
+        poll.option_a  = option_a;
+        poll.option_b  = option_b;
+        poll.votes_a   = 0;
+        poll.votes_b   = 0;
+        poll.authority = ctx.accounts.authority.key();
+        poll.is_open   = true;
+        Ok(())
+    }
+
+    pub fn vote(ctx: Context<CastVote>, choice: u8) -> Result<()> {
+        let poll = &mut ctx.accounts.poll;
+        require!(poll.is_open, PollError::PollClosed);
+        match choice {
+            0 => poll.votes_a += 1,
+            1 => poll.votes_b += 1,
+            _ => return err!(PollError::InvalidChoice),
+        }
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct CreatePoll<\'info> {
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + Poll::INIT_SPACE,
+        seeds = [b""poll"", authority.key().as_ref()],
+        bump
+    )]
+    pub poll: Account<\'info, Poll>,
+    #[account(mut)]
+    pub authority: Signer<\'info>,
+    pub system_program: Program<\'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct CastVote<\'info> {
+    #[account(mut, seeds = [b""poll"", authority.key().as_ref()], bump)]
+    pub poll: Account<\'info, Poll>,
+    pub authority: Signer<\'info>,
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct Poll {
+    pub authority: Pubkey,
+    #[max_len(200)] pub question: String,
+    #[max_len(100)] pub option_a: String,
+    #[max_len(100)] pub option_b: String,
+    pub votes_a: u64,
+    pub votes_b: u64,
+    pub is_open: bool,
+}
+
+#[error_code]
+pub enum PollError {
+    #[msg(""Le sondage est ferme"")] PollClosed,
+    #[msg(""Choix invalide : 0 ou 1 uniquement"")] InvalidChoice,
+}
+'''
+
+print(""Exercice 2 - Programme de vote Anchor complete :"")
+print(VOTE_PROGRAM_COMPLET)
+",,,,,,,,df4b65b9f0d91ec8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-b5fa60f6,markdown,fr,568e06d080ade4be,"### Exemple guide 3 : Modeliser un Counter Solana en Python
+
+_Exemple contribue par le groupe **Mehdi Azouz, Ryad Gazenay & Hani Bouzida** (PR #2189)._
+
+Pour valider la comprehension du **modele de comptes Solana**, on modelise en Python pur le programme Counter Anchor : `initialize` cree un compte `count = 0`, `increment`/`decrement` verifient l'authority avant toute modification, et `decrement` protege contre l'underflow (comme le ferait Anchor).
+",,,,,,,,568e06d080ade4be,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-0dfc58f1,code,fr,185ba3c6deee95b9,"# Exercice 3 : Modeliser un Counter Solana en Python
+
+class SolanaAccount:
+    """"""Simule un compte Solana (programme owner + donnees)""""""
+    def __init__(self, owner: str, data: dict):
+        self.owner = owner
+        self.data = data
+
+class CounterProgram:
+    """"""Simule le programme Counter Anchor.""""""
+    PROGRAM_ID = ""Counter1111111111111111111111111111""
+
+    def initialize(self, authority: str) -> SolanaAccount:
+        return SolanaAccount(
+            owner=self.PROGRAM_ID,
+            data={""authority"": authority, ""count"": 0}
+        )
+
+    def increment(self, counter: SolanaAccount, authority: str) -> None:
+        if authority != counter.data[""authority""]:
+            raise ValueError(""Autorite invalide"")
+        counter.data[""count""] += 1
+
+    def decrement(self, counter: SolanaAccount, authority: str) -> None:
+        if authority != counter.data[""authority""]:
+            raise ValueError(""Autorite invalide"")
+        if counter.data[""count""] == 0:
+            raise ValueError(""Underflow"")
+        counter.data[""count""] -= 1
+
+# --- Tests ---
+program = CounterProgram()
+alice = ""alice_pubkey_111111""
+
+counter = program.initialize(alice)
+print(f""Initialise  : count = {counter.data['count']}"")   # attendu : 0
+program.increment(counter, alice)
+print(f""Increment   : count = {counter.data['count']}"")   # attendu : 1
+program.increment(counter, alice)
+print(f""Increment   : count = {counter.data['count']}"")   # attendu : 2
+program.decrement(counter, alice)
+print(f""Decrement   : count = {counter.data['count']}"")   # attendu : 1
+try:
+    program.increment(counter, ""intrus_pubkey_000"")
+except ValueError as e:
+    print(f""Autorite invalide interceptee : {e}"")
+",,,,,,,,185ba3c6deee95b9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-709d9e8a,markdown,fr,0a469d5319aec590,"### Exercice (a completer) : Etendre le Counter avec un plafond et un reset
+
+A votre tour ! En vous inspirant de l'exemple guide 3, faites evoluer la classe `CounterProgram` :
+
+1. Ajoutez une borne `MAX_COUNT = 10` : `increment` doit lever une exception (interceptee) si l'on depasse le plafond.
+2. Ajoutez une methode `reset(counter, authority)` qui remet `count` a 0 -- **seule** l'authority du compte peut la declencher.
+3. Ecrivez un petit scenario de test qui incremente jusqu'au plafond, tente un increment de trop (try/except), puis effectue un reset.
+
+**Indice** : reprenez le pattern de verification `authority != counter.data[""authority""]` deja utilise dans `increment`/`decrement`.
+",,,,,,,,0a469d5319aec590,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb,cell-9c2384f2,code,fr,37226fe67df4720b,"# Exercice : etendre CounterProgram avec MAX_COUNT (plafond) et reset(counter, authority)
+# TODO etudiant :
+#   Etape 1 : sous-classer ou modifier CounterProgram avec MAX_COUNT = 10
+#   Etape 2 : increment leve une exception (interceptee) si count atteindrait le plafond
+#   Etape 3 : reset(counter, authority) remet count a 0, reserve a l'authority
+#   Etape 4 : scenario de test (increment jusqu'au plafond, increment de trop, reset)
+
+print(""Exercice a completer"")
+",,,,,,,,37226fe67df4720b,,,,,,,


### PR DESCRIPTION
## Summary

`translations/smartcontracts/smartcontracts.csv` had drifted from the source notebooks since its Phase 2 seed (**#5808**): new cells were added to SC-2 and SC-22, SC-7 exercise headers were renumbered, and two SC-7 hint cells were removed. This PR resyncs the CSV to current source state.

## What changed

All verified firsthand (composite key `notebook + cell_id`, since `cell_id` is not unique across notebooks in this series):

**11 ADDED rows** (new notebook content registered):
- `SC-2-Setup-Web3py` (2): "Evenements et plafond de depot" exercise + its markdown header
- `SC-22-Solana-Anchor` (9): 3 "Exemple guide" markdown (PDA derivation, Anchor vote program, Counter modelling) + exercises 1/2/3 + Counter `MAX_COUNT` extension + "Contributions etudiantes" section header

**3 DRIFTED rows refreshed** (SC-7 exercise headers renumbered `### Exercice N` → `### 7.N. Exercice N` + parenthetical clarification):
- `eabd7d0a` — Multi-Token ERC-1155 → **7.1.** Multi-Token (ERC-1155 simplifie)
- `cell-12` — Token avec plafond → **7.2.** Token avec plafond (ERC-20 capped)
- `cell-14` — NFT avec enumeration → **7.3.** NFT avec enumeration (ERC-721 enumerable)

All translation columns empty (T1 pivot phase only).

**2 ORPHAN rows removed** (verified deleted firsthand — 0 hits in current SC-7):
- `SC-7 697f96cc` + `17355d13` — "Indice" hint cells dropped in a refactor

## Verification

| Check | Result |
|-------|--------|
| `check_translation_sync.py` anomalies | **5 → 0** |
| Diff scope | 1 file, +264/-12 |
| CRLF convention | LF-only preserved |
| Catalogue (`COURSE_CATALOG.generated.*`) | byte-identical to main |
| Orphan deletion grounded | firsthand (text grep 0 hits in SC-7) |

Resync via the `--update` in-place mode (now MERGED **#6514**): refreshes only drifted rows + registers new cells, preserves in-sync rows byte-identical (unlike full re-extract which causes CRLF churn). Orphans removed surgically by composite key (`--update` preserves orphans for human decision by design).

## Related

- See #4957 — translation-CSV sync infra
- See #1650 — multilingual translation epic