### PR TITLE
fix(grothendieck,#4980): namespace root-only suffix on 3 _en siblings (Pattern A)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Conservative_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Conservative_en.lean
@@ -46,7 +46,7 @@ import Mathlib.CategoryTheory.Sites.Point.Conservative
 
 universe v v' u u' w
 
-namespace Grothendieck_en.Conservative_en
+namespace Grothendieck_en.Conservative
 
 open CategoryTheory Category Opposite Limits
 
@@ -232,4 +232,4 @@ noncomputable def skyscraper_adjunction_bridge {A : Type u'} [Category.{v'} A]
     Φ.sheafFiber (A := A) ⊣ Φ.skyscraperSheafFunctor :=
   Φ.skyscraperSheafAdjunction
 
-end Grothendieck_en.Conservative_en
+end Grothendieck_en.Conservative

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/ConstantSheaf_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/ConstantSheaf_en.lean
@@ -38,7 +38,7 @@ import Mathlib.CategoryTheory.Sites.ConstantSheaf
 
 universe v v' u u'
 
-namespace Grothendieck_en.ConstantSheaf_en
+namespace Grothendieck_en.ConstantSheaf
 
 open CategoryTheory Category Opposite Limits Functor Sheaf Adjunction
 
@@ -191,4 +191,4 @@ theorem isConstant_congr_bridge [HasWeakSheafify J D]
     Sheaf.IsConstant J G := by
   exact CategoryTheory.Sheaf.isConstant_congr J i
 
-end Grothendieck_en.ConstantSheaf_en
+end Grothendieck_en.ConstantSheaf

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
@@ -53,7 +53,7 @@ import Mathlib.CategoryTheory.Sites.MayerVietorisSquare
 
 universe w v v' u u'
 
-namespace Grothendieck_en.MayerVietorisSquare_en
+namespace Grothendieck_en.MayerVietorisSquare
 
 open CategoryTheory Category Opposite Limits
 
@@ -201,4 +201,4 @@ noncomputable def glue_sections
     P.obj (op S.X₄) :=
   CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.glue h u v huv
 
-end Grothendieck_en.MayerVietorisSquare_en
+end Grothendieck_en.MayerVietorisSquare


### PR DESCRIPTION
## What

Fix the **namespace suffix convention** on the 3 grothendieck EN-mirror siblings added by #6485 / #6492 / #6497. They used a double-suffix namespace `Grothendieck_en.<Module>_en` (e.g. `Grothendieck_en.Conservative_en`), which violates the ratified Lean i18n **Pattern A** (#4980, `code-style.md` §Lean i18n, template #6429 knot `Reidemeister_en`): the `_en` suffix belongs on the **ROOT segment only** (`Grothendieck_en`), not on every leaf module.

## Change

Rename the `namespace` declaration + matching `end` line in all 3 files:

| File | Before | After |
|------|--------|-------|
| `Conservative_en.lean` | `Grothendieck_en.Conservative_en` | `Grothendieck_en.Conservative` |
| `ConstantSheaf_en.lean` | `Grothendieck_en.ConstantSheaf_en` | `Grothendieck_en.ConstantSheaf` |
| `MayerVietorisSquare_en.lean` | `Grothendieck_en.MayerVietorisSquare_en` | `Grothendieck_en.MayerVietorisSquare` |

This is the **namespace-suffix half** of ai-01's Lean i18n adjudication (2026-07-14). The **francization of the canonicals EN→FR** (Conservative.lean 226L, MayerVietorisSquare.lean 195L) is a separate follow-up PR — this PR touches only the namespace line, scope kept atomic (one-subject-per-PR).

## Verification

- **Diff**: 3 files, `+6/−6` — only the `namespace`/`end` lines, bodies byte-identical.
- **sorry**: `0 → 0` (these are `#check` + bridge-theorem files delegating to Mathlib lemmas; no proofs touched).
- **Orphan-trap**: `grep -rn "Conservative_en\|ConstantSheaf_en\|MayerVietorisSquare_en" --include="*.lean"` across `grothendieck_lean/` (excl `.lake`) = **0 hits** → no external reference to the old double-suffix names. The lakefile glob `globs := #[`Grothendieck.*]` builds the `_en` submodules, so any missed reference fails the build in CI (orphan-trap covered).
- **Local lake build**: attempted, **disk-constrained** — C: has 35G free, a Mathlib cold-build peaks ~18G and the shared `.mathlib-cache` is `v4.30.0-rc2` while the lakefile pins `v4.31.0-rc1` (no usable warm cache to junction). Relying on **CI fresh-clone + glob orphan-trap** as merge gate per coordinator guidance.
- **Structural correctness argument**: the canonical `Grothendieck.Conservative` (identical body, FR/EN prose swapped) builds on `main`; a namespace *name* is not a semantic compile dependency, so the `_en` sibling compiles identically.

See #4980
