### PR TITLE
feat(genai): ancrage semantic-fleet en submodule (base reconciliee stable-from-v0343)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,7 @@
 [submodule "MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argumentum"]
 	path = MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argumentum
 	url = https://github.com/ArgumentumGames/Argumentum
+[submodule "MyIA.AI.Notebooks/GenAI/SemanticKernel/semantic-fleet"]
+	path = MyIA.AI.Notebooks/GenAI/SemanticKernel/semantic-fleet
+	url = https://github.com/MyIntelligenceAgency/semantic-fleet.git
+	branch = stable-from-v0343


### PR DESCRIPTION
## Semantic-fleet — Axe 1 : ancrage submodule (base reconciliee)

Ancre `semantic-fleet` (fork SK multi-connecteurs, #1210) comme **submodule CoursIA** sous `MyIA.AI.Notebooks/GenAI/SemanticKernel/semantic-fleet`.

### Cible du pin
`MyIntelligenceAgency/semantic-fleet@cac5abc` — branche `stable-from-v0343` (branch-tracking).

### Base reconciliee (ledger #6405)
`stable-from-v0343` = base **v0.34.3** (`ed647c4`, release propre et authoritative) **+ 1 commit additif** greffant les 8 fichiers genuine presents seulement sur le `main` post-incident (mai-2025) :
- `model_tester/{api_utils,transparent_model_test}.py`
- `tools/verification/vetting/{multi_connector_vetting_test_fixed,run_vetting_tests}.py`
- `dotnet/notebooks/test-packages/{Program.cs,test-packages.csproj}`
- `semantic-fleet.sln`, `expressions.txt` (allowlist secret-scan)

**Sans** les 14 artefacts cruft du filter-branch (`clean_git_history*.ps1`, `*_STATUS_REPORT.md`, zip results). **Aucun force push, aucune reecriture d'historique** : commit strictement additif sur base release.

`dotnet/notebooks/config/settings.json` **non greffe** : le `config/.gitignore` restaure (v0.34.3) l'ignore volontairement (champ ApiKey) — hygiene correcte, ce qui reconcilie aussi le count "8" du ledger.

### Verification
- Tree-diff v0.34.3 (300 fichiers) <-> main (264) : seuls `.gitignore` + `README.md` different sur les fichiers communs ; tout `dotnet/`, `src/` + 5 notebooks byte-identiques (le code reconstitue EST le code release).
- Secret-scan de la branche greffee : CLEAN (seul `sk-demo-key-for-testing` placeholder + allowlist `expressions.txt`, attendus).

### Sequence
Axe 1 (ce PR) -> Axe 2 (upgrade SK) -> Axe 3 (pivot claudish) -> Axe 6 (notebook) -> Axe 7 (bench prover). Axe 4 (module radix) DONE #5672.

See #1210, #6405.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)