### PR TITLE
docs(grothendieck,#4980): francize MayerVietorisSquare.lean canonical EN->FR (Pattern A)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare.lean
@@ -1,12 +1,12 @@
 /-
-Grothendieck Part 21 -- Mayer-Vietoris squares
+Grothendieck Partie 21 — Carrés de Mayer-Vietoris
 
-Part 20 (SheafCohomology/Basic.lean) introduced Ext-based sheaf cohomology
-groups H^n(F), the cohomology presheaf, and functoriality.
+La Partie 20 (SheafCohomology/Basic.lean) a introduit les groupes de cohomologie
+des faisceaux basés sur Ext H^n(F), le préfaisceau de cohomologie, et la fonctorialité.
 
-This module introduces **Mayer-Vietoris squares**, the geometric input for
-the Mayer-Vietoris long exact sequence in sheaf cohomology. Given a site
-(C, J), a Mayer-Vietoris square is a commutative square in C:
+Ce module introduit les **carrés de Mayer-Vietoris**, l'entrée géométrique de
+la suite exacte longue de Mayer-Vietoris en cohomologie des faisceaux. Étant donné
+un site (C, J), un carré de Mayer-Vietoris est un carré commutatif dans C :
 
   X₁ --f₁₂--> X₂
   |            |
@@ -15,29 +15,29 @@ the Mayer-Vietoris long exact sequence in sheaf cohomology. Given a site
   v            v
   X₃ --f₃₄--> X₄
 
-such that f₁₃ is a monomorphism and the square becomes a pushout in the
-category of sheaves of sets (after applying yoneda >> presheafToSheaf).
+tel que f₁₃ est un monomorphisme et le carré devient un pushout dans la
+catégorie des faisceaux d'ensembles (après application de yoneda >> presheafToSheaf).
 
-This is the abstract formulation of the classical situation where X₄ is
-covered by two open subsets X₂ and X₃ with intersection X₁.
+C'est la formulation abstraite de la situation classique où X₄ est
+recouvert par deux ouverts X₂ et X₃ d'intersection X₁.
 
-Key constructions bridged from Mathlib (`CategoryTheory.Sites.MayerVietorisSquare`):
+Constructions clés pontées depuis Mathlib (`CategoryTheory.Sites.MayerVietorisSquare`) :
 
-  - `MayerVietorisSquare` : the structure (extends Square C)
-  - `mk'` : constructor via sheaf pullback condition
-  - `mk_of_isPullback` : constructor via pullback square + covering sieve
-  - `SheafCondition` : presheaf satisfies the pullback condition
-  - `SheafCondition.ext` : injectivity of restrictions to X₄
-  - `SheafCondition.glue` : gluing sections over X₂ and X₃
-  - `sheafCondition_of_sheaf` : sheaves satisfy the condition
+  - `MayerVietorisSquare` : la structure (étend Square C)
+  - `mk'` : constructeur via condition de pullback de faisceau
+  - `mk_of_isPullback` : constructeur via carré pullback + tamis couvrant
+  - `SheafCondition` : le préfaisceau satisfait la condition de pullback
+  - `SheafCondition.ext` : injectivité des restrictions à X₄
+  - `SheafCondition.glue` : recollement de sections sur X₂ et X₃
+  - `sheafCondition_of_sheaf` : les faisceaux satisfont la condition
   - `shortComplex` : ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄]
-  - `shortComplex_exact` : the short complex is exact
-  - `shortComplex_shortExact` : it is short exact (Mono f + Epi g)
+  - `shortComplex_exact` : le court complexe est exact
+  - `shortComplex_shortExact` : il est court exact (Mono f + Epi g)
 
-This is the geometric foundation for the Mayer-Vietoris long exact
-sequence (Part 22, SheafCohomology/MayerVietoris.lean).
+C'est le fondement géométrique de la suite exacte longue de Mayer-Vietoris
+(Partie 22, SheafCohomology/MayerVietoris.lean).
 
-Epic #1646, See #2159. All `sorry`s eliminated at creation.
+Epic #1646, See #2159. Tous les `sorry` éliminés à la création.
 -/
 
 import Mathlib.CategoryTheory.Sites.MayerVietorisSquare
@@ -50,127 +50,127 @@ open CategoryTheory Category Opposite Limits
 
 variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
 
-/-! ## 1. The Mayer-Vietoris square structure
+/-! ## 1. La structure de carré de Mayer-Vietoris
 
-A Mayer-Vietoris square for a site (C, J) is a commutative square in C
-that becomes a pushout in the category of sheaves of sets. The structure
-extends `Square C` (with fields f₁₂, f₁₃, f₂₄, f₃₄ and condition
-f₁₂ >> f₂₄ = f₁₃ >> f₃₄) and adds:
+Un carré de Mayer-Vietoris pour un site (C, J) est un carré commutatif dans C
+qui devient un pushout dans la catégorie des faisceaux d'ensembles. La structure
+étend `Square C` (avec champs f₁₂, f₁₃, f₂₄, f₃₄ et condition
+f₁₂ >> f₂₄ = f₁₃ >> f₃₄) et ajoute :
 
-  - `mono_f₁₃` : the map X₁ ⟶ X₃ is a monomorphism
-  - `isPushout` : the square is a pushout in Sheaf J (Type v)
+  - `mono_f₁₃` : l'application X₁ ⟶ X₃ est un monomorphisme
+  - `isPushout` : le carré est un pushout dans Sheaf J (Type v)
 
-The dissymmetry (only f₁₃ is required Mono) allows the Nisnevich case
-where f₂₄ is an open immersion and f₃₄ is etale.
+La dissymétrie (seul f₁₃ est requis Mono) permet le cas Nisnevich
+où f₂₄ est une immersion ouverte et f₃₄ est étale.
 -/
 
--- A Mayer-Vietoris square: extends Square C, mono f₁₃, pushout in sheaves.
+-- Un carré de Mayer-Vietoris : étend Square C, mono f₁₃, pushout dans les faisceaux.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare
 
-/-! ## 2. Constructors
+/-! ## 2. Constructeurs
 
-Two constructors for Mayer-Vietoris squares:
+Deux constructeurs pour les carrés de Mayer-Vietoris :
 
-1. `mk'` : given a square with Mono f₁₃, if for every sheaf of types F
-   the square `sq.op.map F.val` is a pullback, then it is a MV square.
+1. `mk'` : étant donné un carré avec Mono f₁₃, si pour tout faisceau de types F
+   le carré `sq.op.map F.val` est un pullback, alors c'est un carré MV.
 
-2. `mk_of_isPullback` : given a pullback square with Mono f₂₄ and
-   Mono f₃₄, if Sieve.ofTwoArrows f₂₄ f₃₄ is J-covering on X₄,
-   then it is a MV square.
+2. `mk_of_isPullback` : étant donné un carré pullback avec Mono f₂₄ et
+   Mono f₃₄, si Sieve.ofTwoArrows f₂₄ f₃₄ est J-couvrant sur X₄,
+   alors c'est un carré MV.
 -/
 
--- Constructor: MV square from sheaf pullback condition.
+-- Constructeur : carré MV depuis condition de pullback de faisceau.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.mk'
 
--- Constructor: MV square from pullback + covering sieve.
+-- Constructeur : carré MV depuis pullback + tamis couvrant.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.mk_of_isPullback
 
-/-! ## 3. The sheaf condition
+/-! ## 3. La condition de faisceau
 
-Given a Mayer-Vietoris square S and a presheaf P : Cᵒᵖ ⥤ A,
-`S.SheafCondition P` asserts that the square `S.toSquare.op.map P`
-is a pullback square. This is the abstract sheaf condition for P
-with respect to the MV square.
+Étant donné un carré de Mayer-Vietoris S et un préfaisceau P : Cᵒᵖ ⥤ A,
+`S.SheafCondition P` affirme que le carré `S.toSquare.op.map P`
+est un carré pullback. C'est la condition de faisceau abstraite pour P
+relativement au carré MV.
 
-For presheaves of types, this is equivalent to bijectivity of the
-map `toPullbackObj P` from P(X₄) to the fiber product.
+Pour les préfaisceaux de types, cela équivaut à la bijectivité de
+l'application `toPullbackObj` de P(X₄) vers le produit fibré.
 -/
 
--- The sheaf condition: the presheaf sees a pullback square.
+-- La condition de faisceau : le préfaisceau voit un carré pullback.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition
 
--- The canonical map from P(X₄) to the fiber product.
+-- L'application canonique de P(X₄) vers le produit fibré.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toPullbackObj
 
--- Sheaf condition iff toPullbackObj is bijective (Type-valued presheaves).
+-- Condition de faisceau ssi toPullbackObj est bijective (préfaisceaux à valeurs Type).
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_iff_bijective_toPullbackObj
 
-/-! ## 4. Consequences of the sheaf condition
+/-! ## 4. Conséquences de la condition de faisceau
 
-When S.SheafCondition P holds for a Type-valued presheaf P:
+Quand S.SheafCondition P tient pour un préfaisceau à valeurs Type P :
 
-  - `ext` : if two elements of P(X₄) agree on X₂ and X₃, they are equal
-    (injectivity of restrictions)
+  - `ext` : si deux éléments de P(X₄) coïncident sur X₂ et X₃, ils sont égaux
+    (injectivité des restrictions)
 
-  - `glue` : given matching sections u : P(X₂) and v : P(X₃) that agree
-    on X₁, there exists a glued section glue u v huv : P(X₄)
+  - `glue` : étant données des sections compatibles u : P(X₂) et v : P(X₃) qui coïncident
+    sur X₁, il existe une section recollée glue u v huv : P(X₄)
 
-  - `map_f₂₄_op_glue` : the restriction of glue to X₂ is u
-  - `map_f₃₄_op_glue` : the restriction of glue to X₃ is v
+  - `map_f₂₄_op_glue` : la restriction de glue à X₂ est u
+  - `map_f₃₄_op_glue` : la restriction de glue à X₃ est v
 -/
 
--- Injectivity: two sections agreeing on X₂ and X₃ are equal.
+-- Injectivité : deux sections coïncidant sur X₂ et X₃ sont égales.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.ext
 
--- Gluing: matching sections over X₂ and X₃ glue to a section over X₄.
+-- Recollement : des sections compatibles sur X₂ et X₃ se recollent en une section sur X₄.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.glue
 
--- Restriction of glued section to X₂ is the original.
+-- La restriction de la section recollée à X₂ est l'originale.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.map_f₂₄_op_glue
 
--- Restriction of glued section to X₃ is the original.
+-- La restriction de la section recollée à X₃ est l'originale.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.SheafCondition.map_f₃₄_op_glue
 
-/-! ## 5. Sheaves satisfy the sheaf condition
+/-! ## 5. Les faisceaux satisfont la condition de faisceau
 
-Every sheaf (of types) satisfies the Mayer-Vietoris sheaf condition.
-This is the key fact that makes MV squares useful: the pullback
-condition is automatic for sheaves.
+Tout faisceau (de types) satisfait la condition de faisceau de Mayer-Vietoris.
+C'est le fait clé qui rend les carrés MV utiles : la condition de pullback
+est automatique pour les faisceaux.
 -/
 
--- Every sheaf satisfies the MV sheaf condition.
+-- Tout faisceau satisfait la condition de faisceau MV.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_of_sheaf
 
-/-! ## 6. The associated short complex
+/-! ## 6. Le court complexe associé
 
-Given a MV square S, there is an associated short complex of abelian sheaves:
+Étant donné un carré MV S, il y a un court complexe associé de faisceaux abéliens :
 
   ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄]
 
-where ℤ[X] denotes the free abelian sheaf on yoneda.obj X, the left map
-is the difference (f₁₂ - f₁₃), and the right map is the sum (f₂₄ + f₃₄).
+où ℤ[X] dénote le faisceau abélien libre sur yoneda.obj X, l'application à gauche
+est la différence (f₁₂ - f₁₃), et l'application à droite est la somme (f₂₄ + f₃₄).
 
-This short complex is short exact (Mono f + Epi g + Exact), which is
-the input for the Mayer-Vietoris long exact sequence in sheaf cohomology.
+Ce court complexe est court exact (Mono f + Epi g + Exact), ce qui est
+l'entrée de la suite exacte longue de Mayer-Vietoris en cohomologie des faisceaux.
 -/
 
--- The short complex ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄].
+-- Le court complexe ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄].
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex
 
--- The short complex is exact.
+-- Le court complexe est exact.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex_exact
 
--- The short complex is short exact (Mono f + Epi g + Exact).
+-- Le court complexe est court exact (Mono f + Epi g + Exact).
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex_shortExact
 
-/-! ## 7. Bridge theorems
+/-! ## 7. Théorèmes ponts
 
-Bridge theorems connecting Mayer-Vietoris squares to concrete verification.
+Théorèmes ponts connectant les carrés de Mayer-Vietoris à la vérification concrète.
 -/
 
-/-- Bridge theorem: every sheaf of types satisfies the Mayer-Vietoris
-    sheaf condition for a given MV square S. This means the pullback
-    diagram is automatic for sheaves. -/
+/-- Théorème pont : tout faisceau de types satisfait la condition de faisceau
+    de Mayer-Vietoris pour un carré MV donné S. Cela signifie que le diagramme
+    de pullback est automatique pour les faisceaux. -/
 theorem sheaf_satisfies_MV_condition
     [HasWeakSheafify J (Type v)]
     (S : J.MayerVietorisSquare)
@@ -178,9 +178,9 @@ theorem sheaf_satisfies_MV_condition
     S.SheafCondition F.obj :=
   CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_of_sheaf S F
 
-/-- Bridge theorem: given a Mayer-Vietoris square S and a presheaf P
-    satisfying the sheaf condition, matching sections over X₂ and X₃
-    that agree on X₁ can be glued into a section over X₄. -/
+/-- Théorème pont : étant donné un carré de Mayer-Vietoris S et un préfaisceau P
+    satisfaisant la condition de faisceau, des sections compatibles sur X₂ et X₃
+    qui coïncident sur X₁ peuvent être recollées en une section sur X₄. -/
 noncomputable def glue_sections
     [HasWeakSheafify J (Type v)]
     (S : J.MayerVietorisSquare)


### PR DESCRIPTION
## What

Francize the **canonical** `MayerVietorisSquare.lean` EN→FR, completing ai-01's Lean i18n adjudication (2026-07-14): "francize Conservative 226L + MayerVietoris 195L" (Conservative = #6543). grothendieck is the FR-canonical target; Pattern A (#4980) confirmed. The canonical was entirely EN; this translates the prose to FR.

## Translation scope (prose ONLY)

- Module docstring (incl. the commutative-square ASCII diagram, preserved verbatim) → FR
- 7 section headers + bodies (`/-! ## … -/`) → FR
- Line comments (`-- …`) → FR
- Theorem/def docstrings (`/-- … -/`) → FR
- Mathlib symbol names + ASCII square art kept verbatim

## Code is byte-identical (anti-regression verified)

Stripped all prose (`/- … -/` + `--`) from origin/main and the francized file, then diffed:

```
CODE IDENTICAL: 0 code lines changed (only prose translated FR).
sorry: origin/main 0 → francized 0
diff: 1 file, +86/−86 (prose lines only)
```

Unchanged: `import`, `universe`, `namespace Grothendieck.MayerVietorisSquare`, `open`, `variable`, all `#check` targets, theorem signatures, `noncomputable def` body, the tactic/proof bodies. **No proof, no signature, no tactic touched.**

## Why this compiles identically (merge gate)

Lean ignores docstrings and comments, so a prose-only translation has **zero** compile impact — the francized module compiles exactly as the EN original did (builds on `main`). Local `lake build` is disk-constrained here (C: ~35G vs Mathlib cold-build peak ~18G; shared `.mathlib-cache` v4.30 vs lakefile v4.31.0-rc1). Relying on **CI fresh-clone + glob `Grothendieck.*` orphan-trap** as merge gate, per coordinator guidance.

## Scope boundaries

- Canonical **only**. The `_en` sibling is untouched per ai-01 ("KEEP the _en").
- **No EN→EN byte-copy** (interdit) — genuine EN→FR translation.
- Completes ai-01's named grain for grothendieck francization (Conservative #6543 + this).

See #4980
