### PR TITLE
fix(symbolicai): repair 20 broken nav links (Z3 #6300 rename + Planners restructure)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN-Csharp.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Planners-9-HTN (C#)\n",
     "\n",
-    "**Navigation** : [<< 8-Temporal](Planners-8-Temporal.ipynb) | [Index](../README.md) | [10-LLM-Planning >>](Planners-10-LLM-Planning.ipynb)\n",
+    "**Navigation** : [<< 8-Temporal](Planners-8-Temporal.ipynb) | [Index](../README.md) | [10-LLM-Planning >>](../04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb)\n",
     "\n",
     "**Twin C# (.NET Interactive)** de [Planners-9-HTN.ipynb](Planners-9-HTN.ipynb) — marathon **#4956** (parite .NET <-> Python).\n",
     "\n",
@@ -681,7 +681,7 @@
     "\n",
     "### Parite #4956\n",
     "\n",
-    "Twin de parite legitime : les deux langages deroulent le solveur HTN from-scratch. L'interet est la traduction du coeur recursif (decomposition + backtracking) et la confirmation sur les domaines canoniques (Logistics, Cafe). Le notebook [Planners-3-State-Space](Planners-3-State-Space.ipynb) couvre la planification state-space classique (point de contraste : HTN decompose, state-space cherche).\n",
+    "Twin de parite legitime : les deux langages deroulent le solveur HTN from-scratch. L'interet est la traduction du coeur recursif (decomposition + backtracking) et la confirmation sur les domaines canoniques (Logistics, Cafe). Le notebook [Planners-3-State-Space](../01-Foundation/Planners-3-State-Space.ipynb) couvre la planification state-space classique (point de contraste : HTN decompose, state-space cherche).\n",
     "\n",
     "---\n",
     "*Marathon #4956 (parite .NET <-> Python).*\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Z3-Python 05 — Quantificateurs et preuves formelles\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3/README.md) | [<< Z3-Python-04 Chaines](Z3-Python-04-Strings-Regex.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C# (Z3.Linq)](../Z3-Linq2Z3/README.md) | [<< Z3-Python-04 Chaines](Z3-Python-04-Strings-Regex.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Z3-Python 06 — Optimisation avancee\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C#](../Z3/README.md) | [<< Z3-Python-03 Tactiques](Z3-Python-03-Tactics.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Serie Z3 C#](../Z3-Linq2Z3/README.md) | [<< Z3-Python-03 Tactiques](Z3-Python-03-Tactics.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-07-Style-Declaratif-Linq.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Z3-Python 07 — Du style declaratif LINQ au solveur Z3 en Python\n",
     "\n",
-    "**Navigation** : [Z3-Python-06 >>](Z3-Python-06-Advanced-Optimization.ipynb) | [Index](README.md) | [Z3 C# (Z3.Linq) ->](../Z3/README.md)\n",
+    "**Navigation** : [Z3-Python-06 >>](Z3-Python-06-Advanced-Optimization.ipynb) | [Index](README.md) | [Z3 C# (Z3.Linq) ->](../Z3-Linq2Z3/README.md)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -19,7 +19,7 @@
     "\n",
     "## Positionnement\n",
     "\n",
-    "Cette serie ([Z3-Python](README.md)) utilise z3-py, le binding Python direct, en style **imperatif-symbolique** : on cree un `Solver`, on ajoute des contraintes, on appelle `check`. La serie soeur [Z3 C# (Z3.Linq)](../Z3/README.md) expose une couche **declarative** : les contraintes s'ecrivent comme des predicats LINQ, traduits automatiquement en formules SMT.\n",
+    "Cette serie ([Z3-Python](README.md)) utilise z3-py, le binding Python direct, en style **imperatif-symbolique** : on cree un `Solver`, on ajoute des contraintes, on appelle `check`. La serie soeur [Z3 C# (Z3.Linq)](../Z3-Linq2Z3/README.md) expose une couche **declarative** : les contraintes s'ecrivent comme des predicats LINQ, traduits automatiquement en formules SMT.\n",
     "\n",
     "Ce notebook fait le pont : il montre que les **deux styles expriment la meme intention declarative** (decrire le QUOI, pas le COMMENT), et comment retrouver en Python la lisibilite du DSL C# sans perdre l'acces a l'API complete."
    ]
@@ -504,7 +504,7 @@
     "\n",
     "**Pour aller plus loin** :\n",
     "- [Z3-Python-06 — Optimisation avancee](Z3-Python-06-Advanced-Optimization.ipynb) : `Optimize`, `maximize`/`minimize`, quand la satisfaction devient optimisation sous objectifs.\n",
-    "- [Z3 C# (Z3.Linq)](../Z3/README.md) : la serie soeur declarative, pour comparer les idiomes dans leur contexte natif.\n",
+    "- [Z3 C# (Z3.Linq)](../Z3-Linq2Z3/README.md) : la serie soeur declarative, pour comparer les idiomes dans leur contexte natif.\n",
     "- La documentation [z3-solver (pyz3)](https://z3prover.github.io/api/html/namespacez3py.html) pour l'API complete."
    ]
   }

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-08-Ordonnancement.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "\n",
     "\n",
-    "**Ce notebook montre** : (a) une heuristique gloutonne FIFO sous-optimale, (b) la modelisation Z3 avec la contrainte disjonctive `Or(... , ...)`, (c) l'optimum trouve par `Optimize.minimize`, et (d) un diagramme de Gantt comparant les deux. Il porte en Python l'exemple C# [11_Job_Shop_Scheduling](../Z3/11_Job_Shop_Scheduling.ipynb) de la serie sœur Z3.Linq."
+    "**Ce notebook montre** : (a) une heuristique gloutonne FIFO sous-optimale, (b) la modelisation Z3 avec la contrainte disjonctive `Or(... , ...)`, (c) l'optimum trouve par `Optimize.minimize`, et (d) un diagramme de Gantt comparant les deux. Il porte en Python l'exemple C# [11_Job_Shop_Scheduling](../Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb) de la serie sœur Z3.Linq."
    ]
   },
   {
@@ -809,7 +809,7 @@
     "\n",
     "\n",
     "\n",
-    "Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3/README.md) qui aborde le meme probleme via une couche declarative LINQ."
+    "Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3-Linq2Z3/README.md) qui aborde le meme probleme via une couche declarative LINQ."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-09-Enigme-Einstein.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "\n",
     "\n",
-    "C'est typiquement la ou un solveur SMT comme Z3 **fait la difference** : on decrit les 25 variables (position de chaque valeur), le domaine, les 5 contraintes de permutation (`Distinct`) et les 15 indices, et `Solver` trouve l'unique solution en **quelques millisecondes**. Ce notebook porte en Python l'exemple C# [18_Einsteins_Riddle](../Z3/18_Einsteins_Riddle.ipynb) de la serie sœur Z3.Linq."
+    "C'est typiquement la ou un solveur SMT comme Z3 **fait la difference** : on decrit les 25 variables (position de chaque valeur), le domaine, les 5 contraintes de permutation (`Distinct`) et les 15 indices, et `Solver` trouve l'unique solution en **quelques millisecondes**. Ce notebook porte en Python l'exemple C# [18_Einsteins_Riddle](../Z3-Linq2Z3/18_Einsteins_Riddle.ipynb) de la serie sœur Z3.Linq."
    ]
   },
   {
@@ -701,7 +701,7 @@
     "\n",
     "\n",
     "\n",
-    "Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3/README.md) qui aborde la meme enigme via la couche declarative LINQ."
+    "Suite logique : retour a la [serie Z3-Python](README.md), ou explorez la version C# [Z3.Linq](../Z3-Linq2Z3/README.md) qui aborde la meme enigme via la couche declarative LINQ."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-10-Cryptarithmetic.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "Ce type de puzzle est un cas canonique de **satisfaction de contraintes sur les entiers** : 8 lettres, chacune dans `{0..9}`, deux a deux distinctes, avec des tetes non nulles (S et M) et une equation lineaire positionnelle. La **propagation de contraintes** du solveur SMT resout instantanement ce que la brute force met plusieurs centaines de millisecondes a enumerer.\n",
     "\n",
-    "> Port pyz3 du notebook C# [`13_Cryptarithmetic_SMT.ipynb`](../Z3/13_Cryptarithmetic_SMT.ipynb) (Microsoft.Z3 brut). EPIC #1206, Prong B."
+    "> Port pyz3 du notebook C# [`13_Cryptarithmetic_SMT.ipynb`](../Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb) (Microsoft.Z3 brut). EPIC #1206, Prong B."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-11-Graph-Coloring.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "Le **graphe de Petersen** (10 sommets, 15 aretes) est un cas canonique : son nombre chromatique est `chi = 3` (ni biparti `chi=2`, ni trivial). La **recherche lineaire sur k** combinee a Z3 ne se contente pas de *trouver* 3 couleurs - elle **prouve** que 2 sont impossibles (`unsat`), ce qu'une heuristique gloutonne ne peut jamis affirmer.\n",
     "\n",
-    "> Port pyz3 du notebook C# [`12_Graph_Coloring_Petersen.ipynb`](../Z3/12_Graph_Coloring_Petersen.ipynb). EPIC #1206, Prong B. (La section B2 MkIte du C#, specifique au DSL Z3.Linq, n'est pas portee.)"
+    "> Port pyz3 du notebook C# [`12_Graph_Coloring_Petersen.ipynb`](../Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb). EPIC #1206, Prong B. (La section B2 MkIte du C#, specifique au DSL Z3.Linq, n'est pas portee.)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-12-Real-Arithmetic.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "Ce notebook explore les trois postures : arithmetique lineaire (solution rationnelle exacte), non-lineaire (irrationnel algebrique), et preuve d'impossibilite sur R. Aucun `float`, aucun `sqrt()` approche : tout est symbolique.\n",
     "\n",
-    "> Port pyz3 du notebook C# [`16_RealArithmetic.ipynb`](../Z3/16_RealArithmetic.ipynb). EPIC #1206, Prong B. (La section B7 Rational du C#, specifique au DSL Z3.Linq, n'est pas portee.)"
+    "> Port pyz3 du notebook C# [`16_RealArithmetic.ipynb`](../Z3-Linq2Z3/16_RealArithmetic.ipynb). EPIC #1206, Prong B. (La section B7 Rational du C#, specifique au DSL Z3.Linq, n'est pas portee.)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-13-UnsatCores.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "Pour un ingenieur qui **ecrit** la specification, UNSAT est souvent un bug de modelisation : une contrainte trop forte, ou deux contraintes incompatibles. La reponse ' impossible ' ne suffit pas - il faut savoir **lesquelles** des contraintes se contredisent. C'est le role du **noyau d'insatisfiabilite** (UNSAT core) : le sous-ensemble **minimal** de contraintes responsable du conflit. Z3 passe du diagnostic binaire au diagnostic chirurgical.\n",
     "\n",
-    "> Port pyz3 du notebook C# [`17_UnsatCores.ipynb`](../Z3/17_UnsatCores.ipynb). EPIC #1206, Prong B. (Le bloc DSL `Explain()` du C#, specifique a Z3.Linq, n'est pas porte ; l'API brute `assert_and_track` + `unsat_core` de pyz3 fait le meme travail.)"
+    "> Port pyz3 du notebook C# [`17_UnsatCores.ipynb`](../Z3-Linq2Z3/17_UnsatCores.ipynb). EPIC #1206, Prong B. (Le bloc DSL `Explain()` du C#, specifique a Z3.Linq, n'est pas porte ; l'API brute `assert_and_track` + `unsat_core` de pyz3 fait le meme travail.)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-14-BitVectors-Overflow.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "Z3 traite les entiers machines via la theorie des **bit-vectors** (`BitVec`, SMT-LIB `BV`) : un vecteur de *n* bits interprete comme un entier modulo 2^n, avec addition/multiplication/comparaisons/bit-a-bit **tous decidables**. Ce notebook demontre la capacite distinctive de cette theorie : **prouver** qu'un debordement est inevitable (ou impossible) sur le domaine machine tout entier - pas seulement le constater sur des valeurs fixes.\n",
     "\n",
-    "> Port pyz3 du notebook C# [`15_BitVectors_Overflow.ipynb`](../Z3/15_BitVectors_Overflow.ipynb). EPIC #1206, Prong B. (Le bloc DSL `[BitVecWidth(n)]` du C#, specifique a Z3.Linq, n'est pas porte ; l'API brute pyz3 `BitVec` fait le meme travail.)"
+    "> Port pyz3 du notebook C# [`15_BitVectors_Overflow.ipynb`](../Z3-Linq2Z3/15_BitVectors_Overflow.ipynb). EPIC #1206, Prong B. (Le bloc DSL `[BitVecWidth(n)]` du C#, specifique a Z3.Linq, n'est pas porte ; l'API brute pyz3 `BitVec` fait le meme travail.)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-17-Array-Theory.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-17-Array-Theory.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Z3-Python 17 — Théorie des tableaux : Select, Store et axiomes de McCarthy\n",
     "\n",
-    "**Navigation** : [Index Z3-Python](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Série Z3 C#](../Z3/README.md)\n",
+    "**Navigation** : [Index Z3-Python](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Série Z3 C#](../Z3-Linq2Z3/README.md)\n",
     "## Objectifs d'apprentissage\n",
     "\n",
     "À la fin de ce notebook, vous saurez :\n",
@@ -15,7 +15,7 @@
     "2. Énoncer et **vérifier les axiomes de McCarthy** (_read-over-write_) qui fondent la sémantique du `Store`.\n",
     "3. Résoudre des contraintes sur les **contenus** d'un tableau (tableau trié, tableau égal à un autre, permutation) sans énumérer les valeurs.\n",
     "\n",
-    "Ce notebook est le port Python (`pyz3`) du notebook C# [`04_Array_Theory`](../Z3/04_Array_Theory.ipynb) — il introduit une **théorie SMT distincte** des notebooks précédents (Booléens, arithmétique, chaînes) : la théorie des tableaux, où un tableau est vu comme une **fonction** Index → Élément.\n"
+    "Ce notebook est le port Python (`pyz3`) du notebook C# [`04_Array_Theory`](../Z3-Linq2Z3/04_Array_Theory.ipynb) — il introduit une **théorie SMT distincte** des notebooks précédents (Booléens, arithmétique, chaînes) : la théorie des tableaux, où un tableau est vu comme une **fonction** Index → Élément.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-18-Sudoku-Modes.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-18-Sudoku-Modes.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Z3-Python 18 — Sudoku 4x4 : comparaison des modes `Array` et `Constants`\n",
     "\n",
-    "**Navigation** : [Index Z3-Python](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Série Z3 C#](../Z3/README.md)\n",
+    "**Navigation** : [Index Z3-Python](README.md) | [Index SMT](../README.md) | [Index SymbolicAI](../../README.md) | [Série Z3 C#](../Z3-Linq2Z3/README.md)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -16,7 +16,7 @@
     "2. Énoncer les **contraintes canoniques** du Sudoku 4x4 (domaine `1..4`, rangées/colonnes/blocs 2x2 à valeurs distinctes) dans chaque mode.\n",
     "3. **Vérifier que les deux encodages convergent** vers une solution valide (carré latin), et comprendre pourquoi le choix d'encodage n'affecte pas la sémantique mais peut affecter la performance.\n",
     "\n",
-    "Ce notebook est le port Python (`pyz3`) du notebook C# [`03_Sudoku_Modes_Comparison`](../Z3/03_Sudoku_Modes_Comparison.ipynb). Il complète le notebook [Z3-Python-02 Sudoku](Z3-Python-02-Sudoku.ipynb) (qui résout le Sudoku dans un seul mode) en montrant que **deux modélisations équivalentes** du même problème mènent au même résultat — une leçon clé sur la séparation entre **problème** (les contraintes) et **encodage** (comment on les exprime).\n"
+    "Ce notebook est le port Python (`pyz3`) du notebook C# [`03_Sudoku_Modes_Comparison`](../Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb). Il complète le notebook [Z3-Python-02 Sudoku](Z3-Python-02-Sudoku.ipynb) (qui résout le Sudoku dans un seul mode) en montrant que **deux modélisations équivalentes** du même problème mènent au même résultat — une leçon clé sur la séparation entre **problème** (les contraintes) et **encodage** (comment on les exprime).\n"
    ]
   },
   {


### PR DESCRIPTION
Two root causes of broken markdown navigation/cross-reference links in the SymbolicAI series. All 20 targets verified to resolve on disk.

## 1. Z3 rename (#6300) collateral — 18 links, 12 Z3-API notebooks

The `Z3/` dir was renamed → `Z3-Linq2Z3/` (Linq-primary C# examples, #6300), but the `Z3-Python-*` notebooks still referenced `](../Z3/...)`. Fixed `](../Z3/` → `](../Z3-Linq2Z3/`:

| Source notebook | Cell | Links fixed |
|-----------------|------|-------------|
| Z3-Python-05-Quantifiers-Proofs | 0 | README.md |
| Z3-Python-06-Advanced-Optimization | 0 | README.md |
| Z3-Python-07-Style-Declaratif-Linq | 0,0,18 | README.md ×3 |
| Z3-Python-08-Ordonnancement | 0,19 | 11_Job_Shop_Scheduling.ipynb + README.md |
| Z3-Python-09-Enigme-Einstein | 0,17 | 18_Einsteins_Riddle.ipynb + README.md |
| Z3-Python-10-Cryptarithmetic | 0 | 13_Cryptarithmetic_SMT.ipynb |
| Z3-Python-11-Graph-Coloring | 0 | 12_Graph_Coloring_Petersen.ipynb |
| Z3-Python-12-Real-Arithmetic | 0 | 16_RealArithmetic.ipynb |
| Z3-Python-13-UnsatCores | 0 | 17_UnsatCores.ipynb |
| Z3-Python-14-BitVectors-Overflow | 0 | 15_BitVectors_Overflow.ipynb |
| Z3-Python-17-Array-Theory | 0,0 | 04_Array_Theory.ipynb + README.md |
| Z3-Python-18-Sudoku-Modes | 0,0 | 03_Sudoku_Modes_Comparison.ipynb + README.md |

The `](` prefix scopes the change to **markdown links only** — does NOT touch code-cell `#r "../Z3/..."` DLL directives (those are a separate execution concern requiring .deploy build artifacts, out of scope for this markdown PR).

## 2. Planners subdir restructure — 2 links, Planners-9-HTN-Csharp

Notebooks moved into numbered subdirs (`01-Foundation/`, `03-Advanced/`, `04-NeuroSymbolic/`), but the C# twin still used same-dir references:
- **c0**: `Planners-10-LLM-Planning.ipynb` → `../04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb`
- **c19**: `Planners-3-State-Space.ipynb` → `../01-Foundation/Planners-3-State-Space.ipynb`

(Python twin `Planners-9-HTN.ipynb` already correct — only the C# twin was stale.)

## Verification

- **Target resolution**: all 20 fixed targets verified via `os.path.exists` on resolved relative path.
- **Re-scan**: all 13 edited notebooks re-scanned → **0 broken links remaining**.
- **Byte-identity**: surgical raw-text edit (`read_bytes`→`replace`→`write_bytes`); 0 CRLF introduced (original line endings preserved).
- **JSON valid** on all 13 notebooks.
- **C.2 exception**: markdown-only (nav breadcrumbs / cross-refs), no code cells touched → no re-execution required.
- **Catalog**: byte-identical to main (no generated files touched).

See #6300