### PR TITLE
feat(translation,#4957): resync Search/Part1 CSV (43 SRC_DRIFT -> 0)

### DIFF
--- a/translations/search-part1/search-part1.csv
+++ b/translations/search-part1/search-part1.csv
@@ -769,7 +769,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb,125e
 - L'espace atteignable est donc $n!/2$ etats.
 
 Conclusions attendues : la recherche exhaustive devient rapidement impossible meme avec les algorithmes les plus performants, d'ou l'interet des **heuristiques** et de la recherche informee (cf. Search-3).",,,,,,,,3cc5efaf4fcca7f2,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb,e8a9131f,code,fr,9285b6e77a24afaa,"// Exercice 2 : Taille de l'espace d'etats des taquins.
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb,e8a9131f,code,fr,d61e2dc604ece7fe,"// Exercice 2 : Taille de l'espace d'etats des taquins.
 //
 // Pour chaque puzzle, calculer la taille de l'espace d'etats :
 //   - n!   : nombre total de permutations (factorielle)
@@ -777,36 +777,29 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb,e8a9
 //
 // Conclure sur la faisabilite de la recherche exhaustive.
 
-// Liste des taquins a etudier : (nom, k, n)
+// Liste des taquins a etudier : (nom, k, n)  -- donnee fournie.
 var puzzles = new (string name, int k, int n)[] {
     (""8-puzzle"",   3,  9),
     (""15-puzzle"",  4, 16),
     (""24-puzzle"",  5, 25),
 };
 
-// Fonction factorielle iterative (evite les overflow en utilisant long).
-static long Factorial(int n) {
-    long f = 1;
-    for (int i = 2; i <= n; i++) f *= i;
-    return f;
+// TODO (etudiant) : implementez la fonction factorielle n! -> long.
+// Indice : boucle multiplicative ; utilisez long pour eviter l'overflow de 16! et 25!.
+// Etape 1 : completer 'static long Factorial(int n)' ci-dessous.
+static long Factorial(int n)
+{
+    // Votre code ici.
+    return 0L;  // TODO etudiant : remplacer par le calcul de n!.
 }
 
-Console.WriteLine($""{""Puzzle"",-12} {""n! (total)"",25} {""n!/2 (accessibles)"",25}"");
-Console.WriteLine(new string('-', 65));
-foreach (var p in puzzles) {
-    long total = Factorial(p.n);
-    long accessible = total / 2;
-    Console.WriteLine($""{p.name,-12} {total,-25} {accessible,-25}"");
-}
-
-Console.WriteLine();
-Console.WriteLine(""Conclusion :"");
-Console.WriteLine(""- Le nombre d'etats explose factorialement (n!)"");
-Console.WriteLine(""- Seule la moitie des etats est atteignable (parite de permutation)"");
-Console.WriteLine(""- La recherche exhaustive devient rapidement impossible"");
-Console.WriteLine(""  8-puzzle (~181K etats) : faisable en BFS avec ~1 Go de memoire"");
-Console.WriteLine(""  15-puzzle (~10^13 etats) : necessite des heuristiques (cf. Search-3)"");
-Console.WriteLine(""  24-puzzle (~10^24 etats) : intractable en recherche exhaustive"");",,,,,,,,9285b6e77a24afaa,,,,,,,
+// TODO (etudiant) : pour chaque taquin, afficher n! et n!/2 dans un tableau.
+// Indice : l'espace atteignable vaut total / 2 (parite des permutations).
+// Etape 2 : parcourir 'puzzles', calculer Factorial(p.n) puis total / 2.
+// Etape 3 : afficher un tableau (nom | n! | n!/2) et conclure sur la
+//           faisabilite (8-puzzle vs 15-puzzle vs 24-puzzle, cf. Search-3).
+Console.WriteLine(""Exercice 2 a completer : implementez Factorial puis le tableau n!/2."");
+",,,,,,,,d61e2dc604ece7fe,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb,854a6a88,markdown,fr,169fc999d3eb0a71,"### Exercice 3 : Labyrinthe comme probleme de recherche
 
 **Tache** : Modelisez un labyrinthe en `MazeProblem` (sous-classe de `SearchProblem`) et resolvez-le par BFS.
@@ -3091,8 +3084,8 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,0c27
 ### 2.1 Installation et importation
 
 La librairie `automata-lib` permet de manipuler facilement des automates finis en Python.",,,,,,,,c96764f637a59ff8,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,2cced8bf,code,fr,e206501b360c61af,"# Installation de automata-lib
-!pip install -q ""automata-lib>=9.2.0""",,,,,,,,e206501b360c61af,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,2cced8bf,code,fr,07817e5ab988b9d2,"# automata-lib (>= 9.2.0) : moteur d'automates (DFA/NFA).
+# Dependence declaree dans requirements.txt ; import en cellule suivante.",,,,,,,,07817e5ab988b9d2,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,af7c2764,markdown,fr,e4d0e3844191f15d,Suite de l'implementation.,,,,,,,,e4d0e3844191f15d,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,e672a56d,code,fr,0d2031f5239917fb,"import sys
 sys.path.insert(0, '..')
@@ -3306,14 +3299,14 @@ print(""Exercice a completer : NFA pour mots se terminant par 'ba'"")",,,,,,,,39
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,4db13f74,markdown,fr,4ff04ca68ef39a8d,"### 2.4 Operations sur les automates
 
 Les automates (et les langages reguliers) supportent plusieurs operations classiques.",,,,,,,,4ff04ca68ef39a8d,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,e21ac97c,code,fr,f3a8f8dd51e2a22a,"print(""Operations sur les automates\n"")
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,e21ac97c,code,fr,b38e6886bd259df8,"print(""Operations sur les automates\n"")
 print(""1. UNION : L1 ∪ L2"")
 print(""   - Reconnaît les mots acceptes par L1 OU L2"")
 print()
 print(""2. INTERSECTION : L1 ∩ L2"")
 print(""   - Reconnaît les mots acceptes par L1 ET L2"")
 print()
-print(""3. COMPLEMENT : L^c = Σ* \ L"")
+print(""3. COMPLEMENT : L^c = Σ* \\ L"")
 print(""   - Reconnaît les mots NON acceptes par L"")
 print()
 print(""4. PRODUIT (Concatenation) : L1 · L2"")
@@ -3325,7 +3318,7 @@ print(""   - Reconnaît les repetitions (y compris mot vide)"")
 # Exemple avec automata-lib
 print(""\nExemple : Union avec automata-lib"")
 print(""Note : automata-lib ne fournit pas d'operation d'union directe,"")
-print(""      mais on peut construire manuellement l'automate resultant."")",,,,,,,,f3a8f8dd51e2a22a,,,,,,,
+print(""      mais on peut construire manuellement l'automate resultant."")",,,,,,,,b38e6886bd259df8,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,peg0m53fxym,markdown,fr,1a485ede943e719c,"### Interprétation : Opérations sur les Automates
 
 **Résultat obtenu** : Présentation des 5 opérations fondamentales sur les automates et les langages.
@@ -3359,8 +3352,7 @@ La limitation principale d'`automata-lib` (et des automates finis en general) es
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,99fd2a91,markdown,fr,74bec704b82c65c2,"### 2.6 Visualisation d'automates
 
 Visualisons nos automates avec graphviz.",,,,,,,,74bec704b82c65c2,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,90882d23,code,fr,06a84748b729c71f,"!pip install graphviz
-try:
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,90882d23,code,fr,5eb03553c9a21226,"try:
     import graphviz
     HAS_GRAPHVIZ = True
 except ImportError:
@@ -3427,7 +3419,7 @@ elif not HAS_GRAPHVIZ:
     print(""       | ^       "")
     print(""       b |       "")
     print(""       v |       "")
-    print(""     q_even (final)"")",,,,,,,,06a84748b729c71f,,,,,,,
+    print(""     q_even (final)"")",,,,,,,,5eb03553c9a21226,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,4gohomcq73s,markdown,fr,642e247ac8ab6199,"### Interpretation : Configuration Graphviz
 
 **Resultat obtenu** : Graphviz (package Python) et l'executable systeme `dot` sont disponibles : le DFA est rendu sous forme d'image vectorielle (SVG) ci-dessus, avec ses etats (`q_even`, `q_odd`) et ses transitions (`a`, `b`).
@@ -3516,9 +3508,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,2563
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,5d61895d,markdown,fr,cd992e5e7fde4ad4,"## 4. Automates Symboliques avec Z3
 
 ### 4.1 Installation de Z3",,,,,,,,cd992e5e7fde4ad4,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,fbbfc1e0,code,fr,86134d476482a691,"# Z3 est deja installe (voir requirements.txt)
-# Installation si necessaire :
-!pip install -q ""z3-solver>=4.13""",,,,,,,,86134d476482a691,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,fbbfc1e0,code,fr,c87394543ac74350,# Z3 (z3-solver >= 4.13) deja installe (voir requirements.txt) ; import en cellule suivante.,,,,,,,,c87394543ac74350,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,03677979,markdown,fr,1de91880942b7d8f,Verification des resultats.,,,,,,,,1de91880942b7d8f,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb,b4f1e65a,code,fr,3e4e7f006e7e4c55,"from z3 import *
 
@@ -4931,7 +4921,7 @@ Cette approche ouvre des applications de **verification de proprietes** : portes
 - de Moura, L. & Bjorner, N. (2008). Z3: An Efficient SMT Solver. TACAS 2008, LNCS 4963:337-340.
 
 ",,,,,,,,2b67a6dac7181bb2,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb,434b7647,markdown,fr,631ca93ed5b3328c,"# Search-11 (C#) : Metaheuristiques — Optimisation par essaim, recuit et evolution
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb,434b7647,markdown,fr,e68f4b2595d8f4ff,"# Search-11 (C#) : Metaheuristiques — Optimisation par essaim, recuit et evolution
 
 **Navigation** : [<< Search-10 SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | [Index Part 1](../README.md) | [Search-12 A*](Search-12-AStar-And-Heuristics.ipynb) >>
 
@@ -4939,10 +4929,10 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
 
 **Duree estimee** : ~1h30
 
-**Prerequis** : [Search-5-LocalSearch](Search-5-LocalSearch.ipynb) (recuit simule, hill-climbing), notions d'algebre lineaire et de C# / .NET.
+**Prerequis** : [Search-5-LocalSearch](Search-4-LocalSearch.ipynb) (recuit simule, hill-climbing), notions d'algebre lineaire et de C# / .NET.
 
 **Pourquoi un jumeau C# ?** Le notebook Python original s'appuie sur la librairie **`mealpy`** (PSO, ABC, SA, BRO, GWO, WOA, GA, DE) et `numpy`/`matplotlib` pour comparer des metaheuristiques sur des fonctions de benchmark. Ce jumeau reimplemente les **algorithmes majeurs depuis zero** en **C# .NET 9 (BCL seule, 0 NuGet)** : essaim particulaire (PSO), recuit simule (SA), algorithme genetique (GA). Les fonctions de benchmark (Sphere, Rastrigin, Rosenbrock, Ackley) sont codees explicitement, ainsi que la convergence, l'analyse de parametres et un exemple d'optimisation de profit. Les graphiques `matplotlib` sont remplaces par des tables et traces ASCII. Les deux notebooks derivent les memes optima (f=0 sur les benchmarks, profit max sur l'exemple entreprise).
-",,,,,,,,631ca93ed5b3328c,,,,,,,
+",,,,,,,,e68f4b2595d8f4ff,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb,ac53d855,markdown,fr,a4a6222ed1188e2d,"## 1. Introduction aux metaheuristiques
 
 Une **metaheuristique** est une strategie d'optimisation generique qui guide une recherche dans un espace de solutions trop vaste pour une exploration exhaustive. Contrairement aux methodes exactes (programmation lineaire, branch-and-bound), elle ne garantit pas l'optimalite mais trouve de bonnes solutions en temps raisonnable sur des problemes reels (dimension elevee, multimodalite, non-differentiabilite).
@@ -5495,7 +5485,7 @@ static double Schwefel(double[] x)
 double fitSchwefel = 0.0;  // TODO etudiant : optimiser Schwefel dim=10 avec PSO, bornes [-500,500]
 Console.WriteLine($""Exercice 3 a completer : Schwefel(420.9687,...)={Schwefel(Enumerable.Repeat(420.9687,5).ToArray()):F4} (attendu ~0), optimiser en dim=10 : {fitSchwefel} (a completer)."");
 ",,,,,,,,cc9e76b0b8b11d0f,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb,7efb4dec,markdown,fr,c615b9dfd0876b90,"## 10. Conclusion et resume
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb,7efb4dec,markdown,fr,daa8a73f4e770acd,"## Conclusion et resume
 
 Ce jumeau C# a reimplemente, sans aucune librairie externe, les metaheuristiques majeures du notebook Python `mealpy` :
 
@@ -5522,13 +5512,13 @@ Les **valeurs numeriques exactes** (fitness finale, temps) different C# vs Pytho
 ### Prochaines etapes
 
 - [Search-12-AStar](Search-12-AStar-And-Heuristics.ipynb) : recherche informe avec heuristiques (cas ou l'optimalite est garantie, contrairement aux metaheuristiques).
-- [Search-5-LocalSearch](Search-5-LocalSearch.ipynb) : fondements du recuit simule et hill-climbing.
-- Applications metaheuristiques : [App-13-TSP](../Applications/CSP/App-13-TSP-Metaheuristics.ipynb), [App-9-EdgeDetection](../Applications/CSP/App-9-EdgeDetection.ipynb).
+- [Search-5-LocalSearch](Search-4-LocalSearch.ipynb) : fondements du recuit simule et hill-climbing.
+- Applications metaheuristiques : [App-13-TSP](../Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb), [App-9-EdgeDetection](../Applications/Hybrid/App-9-EdgeDetection.ipynb).
 
 ---
 
 *Part of #4956 (marathon parite .NET <-> Python).*
-",,,,,,,,c615b9dfd0876b90,,,,,,,
+",,,,,,,,daa8a73f4e770acd,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb,nav-header,markdown,fr,598a5ff1b0266ed0,"# Search-11-Metaheuristiques : Optimisation avec MEALPy
 
 **Navigation** : [<< Recherche locale](Search-4-LocalSearch.ipynb) | [Index](../README.md) | [App-1-NQueens >>](../Applications/CSP/App-1-NQueens.ipynb)
@@ -5551,10 +5541,8 @@ A la fin de ce notebook, vous saurez :
 - Notions de base en optimisation (fonction objectif, minimiseur)
 
 ### Duree estimee : 1h30",,,,,,,,598a5ff1b0266ed0,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb,install-deps,code,fr,d4c18c03130bf73d,"%pip install -q numpy matplotlib pandas mealpy
-
-import importlib, site
-importlib.invalidate_caches()",,,,,,,,d4c18c03130bf73d,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb,install-deps,code,fr,c76b6ac117300714,"# Dependances pre-provisionnees (numpy matplotlib pandas mealpy 3.x) : deps standards + mealpy.
+# Aucun install requis dans le notebook ; imports directs dans les cellules suivantes.",,,,,,,,c76b6ac117300714,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb,d24fe342,markdown,fr,984441c7cbed825a,"### Import des bibliotheques
 
 Chargement des outils pour la comparaison des metaheuristiques.",,,,,,,,984441c7cbed825a,,,,,,,
@@ -9018,7 +9006,7 @@ def exercice_3_flot_pipelines():
 # - Appeler exercice_3_flot_pipelines()
 # - Afficher : ""Flot max : X unités/jour, arêtes saturées : N""
 ",,,,,,,,3aee67c61460756d,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb,fffe7b3b,markdown,fr,587b141d45937adc,"## 11. Conclusion
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb,fffe7b3b,markdown,fr,6d0ef4104adf9e70,"## Conclusion
 
 Ce notebook a couvert les **briques algorithmiques essentielles** de NetworkX :
 
@@ -9049,7 +9037,7 @@ Ce notebook a couvert les **briques algorithmiques essentielles** de NetworkX :
 
 **Référence** : [Documentation officielle NetworkX](https://networkx.org/documentation/stable/)
 
-**Livrable équivalent C#/.NET** : voir [issue #5082](https://github.com/jsboige/CoursIA/issues/5082) pour la parité Python ⇄ .NET avec **QuikGraph** (successeur maintenu de QuickGraph, NuGet) sous .NET Interactive.",,,,,,,,587b141d45937adc,,,,,,,
+**Livrable équivalent C#/.NET** : voir [issue #5082](https://github.com/jsboige/CoursIA/issues/5082) pour la parité Python ⇄ .NET avec **QuikGraph** (successeur maintenu de QuickGraph, NuGet) sous .NET Interactive.",,,,,,,,6d0ef4104adf9e70,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX.ipynb,9aa250ae,code,fr,59d2947c3a284c79,"# Cellule de fermeture — vérifie que tout est en ordre
 import networkx as nx
 import matplotlib.pyplot as plt
@@ -9838,7 +9826,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,d596
 
 Avant d'implémenter les algorithmes, nous définissons les **structures de données communes** : un noeud d'arbre de recherche (avec parent, action, coût cumule, profondeur), une classe abstraite `Problem`, et sa specialisation `GraphProblem` pour cheminer dans un graphe pondéré. Le tout reproduit fidelement la hierarchie Python `Node` / `Problem` / `GraphProblem` du notebook source.
 ",,,,,,,,6aeb9cad8aa60e1c,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,54b75d08,code,fr,d154e29c925e7a86,"// Imports + structures communes (Node, Problem, GraphProblem, SearchResult) + graphe France.
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,54b75d08,code,fr,3303bcb9f3e7c9b5,"// Imports + structures communes (Node, Problem, GraphProblem, SearchResult) + graphe France.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -9945,25 +9933,25 @@ public sealed class SearchResult {
     }
 }
 
-// Carte des villes francaises (12 villes, 18 routes, distances en km).
+// Carte des villes francaises (13 villes, 20 routes, distances en km).
 var franceGraph = new Dictionary<string, Dictionary<string, double>> {
     [""Bordeaux""]   = new() { [""Paris""] = 585, [""Toulouse""] = 245, [""Nantes""] = 350 },
     [""Paris""]      = new() { [""Bordeaux""] = 585, [""Lille""] = 225, [""Strasbourg""] = 490, [""Lyon""] = 465, [""Nantes""] = 385 },
     [""Lille""]      = new() { [""Paris""] = 225, [""Rennes""] = 510 },
-    [""Rennes""]     = new() { [""Lille""] = 510, [""Paris""] = 385, [""Nantes""] = 110, [""Brest""] = 245 },
+    [""Rennes""]     = new() { [""Lille""] = 510, [""Nantes""] = 110, [""Brest""] = 245 },
     [""Brest""]      = new() { [""Rennes""] = 245 },
     [""Nantes""]     = new() { [""Rennes""] = 110, [""Paris""] = 385, [""Bordeaux""] = 350, [""Toulouse""] = 590 },
     [""Strasbourg""] = new() { [""Paris""] = 490, [""Lyon""] = 490 },
     [""Lyon""]       = new() { [""Paris""] = 465, [""Strasbourg""] = 490, [""Marseille""] = 315, [""Toulouse""] = 535, [""Grenoble""] = 115 },
     [""Grenoble""]   = new() { [""Lyon""] = 115, [""Marseille""] = 305 },
-    [""Marseille""]  = new() { [""Lyon""] = 315, [""Grenoble""] = 305, [""Toulouse""] = 405, [""Nice""] = 200 },
+    [""Marseille""]  = new() { [""Lyon""] = 315, [""Grenoble""] = 305, [""Toulouse""] = 405, [""Nice""] = 200, [""Montpellier""] = 165 },
     [""Toulouse""]   = new() { [""Bordeaux""] = 245, [""Nantes""] = 590, [""Marseille""] = 405, [""Lyon""] = 535, [""Montpellier""] = 245 },
     [""Montpellier""] = new() { [""Toulouse""] = 245, [""Marseille""] = 165 },
     [""Nice""]       = new() { [""Marseille""] = 200 },
 };
 
-Console.WriteLine($""Carte chargee : {franceGraph.Count} villes"");",,,,,,,,d154e29c925e7a86,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,381f2230,markdown,fr,c5b018c426614fc5,"### Interpretation : cadre de recherche
+Console.WriteLine($""Carte chargee : {franceGraph.Count} villes"");",,,,,,,,3303bcb9f3e7c9b5,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,381f2230,markdown,fr,ca9dd365a8580342,"### Interpretation : cadre de recherche
 
 Trois structures fondamentales, exactement comme dans le notebook Python :
 
@@ -9971,8 +9959,8 @@ Trois structures fondamentales, exactement comme dans le notebook Python :
 - **`Problem`** : classe abstraite (équivalent C# du pattern ABC Python) ; `GraphProblem` la spécialise pour un graphe pondéré dont les arêtes sont les actions et les poids sont les coûts d'etape.
 - **`SearchResult`** : agrège le résultat d'une recherche : chemin, coût, statistiques d'exploration et de génération, taille maximale de la frontière, temps ecoule.
 
-Le graphe des villes françaises contient 12 villes et 18 routes bidirectionnelles (les distances sont en km). L'**invariant clé** est que les coûts sont asymetriques uniquement par accident d'arrondi : sur la carte source, chaque arête est declaree dans les deux sens avec la même valeur, ce qui rend UCS et BFS comparables sur un terrain ou ils ne divergent pas toujours -- sauf cas explicite (Bordeaux -> Strasbourg via Paris-Lyon 1050 km vs via Toulouse-Marseille-Lyon 1165 km, ou BFS choisira le plus court en nombre de sauts, pas en coût).
-",,,,,,,,c5b018c426614fc5,,,,,,,
+Le graphe des villes françaises contient **13 villes et 20 routes bidirectionnelles** (les distances sont en km) : chaque arête est déclarée dans les deux sens avec la même valeur. Les coûts étant tous >= 100 km et assez homogènes, le plus court en sauts coïncide *souvent* avec le moins coûteux — mais pas toujours : la **Section 6** montre un trajet piège (**Paris -> Rennes**) où BFS et UCS divergent de 240 km à nombre de sauts égal.
+",,,,,,,,ca9dd365a8580342,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,24ebba9f,markdown,fr,2fa52f2654e9f069,"---
 
 ## 2. Recherche en Largeur (BFS -- Breadth-First Search)
@@ -10039,14 +10027,14 @@ var resultBFS = BFS(problemBS, verbose: true);
 resultBFS.Display();
 Console.WriteLine($""\nOrdre d'exploration : {string.Join("" -> "", resultBFS.ExploredOrder)}"");
 ",,,,,,,,28d2f277801dd557,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,0d6f4013,markdown,fr,b30f2913ddb812ee,"### Interpretation : BFS sur les villes françaises
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,0d6f4013,markdown,fr,065c08480042e68c,"### Interpretation : BFS sur les villes françaises
 
 BFS exploré **tous les voisins de la racine**, puis tous les voisins de ces voisins, etc. Sur Bordeaux -> Strasbourg, on observe l'ordre caracteristique : Bordeaux -> Paris/Toulouse/Nantes, puis Lyon/Lille/..., Strasbourg est atteinte en **3 sauts** (Bordeaux -> Paris -> Lyon -> Strasbourg ou Bordeaux -> Paris -> Strasbourg) -- BFS garantit que c'est **le plus court en nombre d'actions**.
 
 **Coût total** : sur ce trajet, BFS a choisi Bordeaux -> Paris -> Strasbourg (585 + 490 = 1075 km). Mais le chemin **Bordeaux -> Toulouse -> Marseille -> Lyon -> Strasbourg** (245 + 405 + 315 + 490 = **1455 km**) est en 4 sauts donc jamais considere par BFS -- même s'il etait moins cher, ce n'est pas le cas ici.
 
-> **Cas ou BFS diverge d'UCS** : si l'arête Toulouse -> Marseille coutait **beaucoup moins** (par exemple 100 km au lieu de 405), BFS continuerait a preferer Bordeaux -> Paris -> Strasbourg (3 sauts) tandis qu'UCS pourrait preferer un chemin plus long en sauts mais moins coûteux en km. C'est precisement ce qu'on observe dans la **Section 4 (Exercice 2)**.
-",,,,,,,,b30f2913ddb812ee,,,,,,,
+> **Cas ou BFS diverge d'UCS** : si l'arête Toulouse -> Marseille coutait **beaucoup moins** (par exemple 100 km au lieu de 405), BFS continuerait a preferer Bordeaux -> Paris -> Strasbourg (3 sauts) tandis qu'UCS pourrait preferer un chemin plus long en sauts mais moins coûteux en km. C'est precisement ce que l'**Exercice 2** vous fera construire (Montpellier -> Lyon), et ce que la **Section 6** démontre sur le trajet piège **Paris -> Rennes**.
+",,,,,,,,065c08480042e68c,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,9a724fa9,markdown,fr,f27e39ecfbd409f1,"---
 
 ## 3. Recherche en Profondeur (DFS -- Depth-First Search)
@@ -10225,19 +10213,19 @@ Sur Bordeaux -> Strasbourg, UCS confirme le chemin de BFS : **Bordeaux -> Paris 
 
 **Coût temps/espace** : UCS exploré les noeuds par ordre de coût croissant. Sur un graphe ou toutes les arêtes valent 1 (cas BFS), UCS degeneré en BFS. Sur un graphe fortement pondéré, UCS exploré typiquement beaucoup plus de noeuds que BFS pour le même probleme, car il doit explorer tous les chemins partiels dont le coût est inférieur au coût optimal.
 ",,,,,,,,ac79a724399754cf,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,62213596,markdown,fr,29bc00fd73fbaf5d,"### Exercice 2 : Analyser l'écart de coût entre BFS et UCS
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,62213596,markdown,fr,34688e3b513e211d,"### Exercice 2 : Analyser l'écart de coût entre BFS et UCS
 
-**Enonce** : choisissez un trajet ou BFS et UCS donnent **un coût différent**. Le candidat naturel est **Rennes -> Nice** (4 ou 5 sauts selon le chemin, avec des poids interessants).
+**Enonce** : choisissez un trajet ou BFS et UCS donnent **un coût différent**. Le candidat naturel est **Montpellier -> Lyon** : deux chemins en 2 sauts existent, avec des coûts très différents selon les arêtes empruntées.
 
 **Indices** :
-1. `var problem6 = new GraphProblem(""Rennes"", ""Nice"", franceGraph);`
+1. `var problem6 = new GraphProblem(""Montpellier"", ""Lyon"", franceGraph);`
 2. Lancez `BFS(problem6)` et `UCS(problem6)` puis comparez `result.Cost`.
 3. Affichez les deux chemins et expliquez pourquoi UCS est strictement meilleur (ou pas).
-",,,,,,,,29bc00fd73fbaf5d,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,6f60e28f,code,fr,dfb9582b2a9e46a6,"// Exercice 2 : Analyser l'ecart de cout entre BFS et UCS.
+",,,,,,,,34688e3b513e211d,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,6f60e28f,code,fr,f2f0a896545f15d7,"// Exercice 2 : Analyser l'ecart de cout entre BFS et UCS.
 // TODO etudiant : choisissez un trajet ou BFS et UCS divergent.
-string depart = null;   // TODO etudiant : remplacer (ex: ""Rennes"")
-string arrivee = null;  // TODO etudiant : remplacer (ex: ""Nice"")
+string depart = null;   // TODO etudiant : remplacer (ex: ""Montpellier"")
+string arrivee = null;  // TODO etudiant : remplacer (ex: ""Lyon"")
 
 // TODO etudiant : executez BFS et UCS sur ce trajet.
 // var problem6 = new GraphProblem(depart, arrivee, franceGraph);
@@ -10248,7 +10236,7 @@ string arrivee = null;  // TODO etudiant : remplacer (ex: ""Nice"")
 
 // TODO etudiant : expliquez en commentaire pourquoi les couts divergent.
 Console.WriteLine(""Exercice a completer"");
-",,,,,,,,dfb9582b2a9e46a6,,,,,,,
+",,,,,,,,f2f0a896545f15d7,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,ca40058a,markdown,fr,0db299ebb8bf563b,"---
 
 ## 5. Recherche en Profondeur ITÉRÉE (IDDFS -- Iterative Deepening DFS)
@@ -10327,18 +10315,19 @@ IDDFS termine quand une DLS atteint le but. Sur Bordeaux -> Strasbourg (but a pr
 
 **Avantage clé** : la mémoire utilisée par DLS(k) est O(b*k), donc au pire O(b*d) -- bien meilleur que BFS (O(b^d)). Le compromis : un facteur de re-exploration borne par `b/(b-1)` sur un arbre regulier, donc asymptotiquement équivalent a BFS en temps.
 ",,,,,,,,78f86d2cfbd54922,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,8113874c,markdown,fr,4829613fc812052b,"---
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,8113874c,markdown,fr,97aa96ce064dc4fd,"---
 
 ## 6. Comparaison synthetique sur plusieurs problemes
 
-Executons les quatre algorithmes sur les 4 trajets emblematiques du notebook Python : Bordeaux -> Strasbourg, Rennes -> Nice, Lille -> Toulouse, Nantes -> Marseille. Nous comparons coût, nombre de noeuds explorés et generees.
-",,,,,,,,4829613fc812052b,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,6cb1fbf2,code,fr,fe56d255f1cbd795,"// Comparaison complete sur 4 trajets.
+Exécutons les quatre algorithmes sur les 4 trajets emblématiques du notebook Python — Bordeaux -> Strasbourg, Rennes -> Nice, Lille -> Toulouse, Nantes -> Marseille — plus un **cinquième trajet piège, Paris -> Rennes**, où deux chemins de 2 sauts ont des coûts très différents. Nous comparons coût, nombre de nœuds explorés et générés.
+",,,,,,,,97aa96ce064dc4fd,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,6cb1fbf2,code,fr,4ddc51489cff0fc3,"// Comparaison complete sur 5 trajets (dont le trajet piege Paris -> Rennes).
 var testCases = new (string start, string goal)[] {
     (""Bordeaux"", ""Strasbourg""),
     (""Rennes"", ""Nice""),
     (""Lille"", ""Toulouse""),
     (""Nantes"", ""Marseille""),
+    (""Paris"", ""Rennes""),
 };
 
 var allResults = new List<(string start, string goal, Dictionary<string, SearchResult> results)>();
@@ -10366,13 +10355,14 @@ foreach (var (start, goal) in testCases) {
     }
     allResults.Add((start, goal, results));
 }
-",,,,,,,,fe56d255f1cbd795,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,30620c41,markdown,fr,6e31203205fcdfb1,"### Interpretation : tableau comparatif
+",,,,,,,,4ddc51489cff0fc3,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,30620c41,markdown,fr,77ff39d7299228d3,"### Interpretation : tableau comparatif
 
 On observe les patterns classiques :
 
-- **BFS et UCS** trouvent **toujours** le même chemin sur les 4 trajets (la carte source a tous ses coûts >= 100 km, donc le plus court en sauts coïncide souvent avec le moins coûteux). Si vous modifiez une arête pour la rendre « piege », UCS divergera.
-- **DFS** trouve un chemin (la carte est acyclique et finie, donc DFS termine), mais pas necessairement le moins coûteux. Sur Lille -> Toulouse par exemple, DFS peut preferer Lille -> Paris -> ... -> Toulouse via un long detour.
+- **Sur les 4 trajets classiques, BFS et UCS coïncident** : les coûts de la carte sont tous >= 100 km et assez homogènes, donc le plus court en sauts y est aussi le moins coûteux.
+- **Le cinquième trajet, Paris -> Rennes, est le piège qui les sépare** : deux chemins en 2 sauts existent, et BFS — aveugle aux coûts — retourne Paris -> Lille -> Rennes (**735 km**) parce que Lille sort de la file avant Nantes, tandis qu'UCS garantit Paris -> Nantes -> Rennes (**495 km**), soit **240 km de moins à nombre de sauts égal**. BFS retourne *un* chemin optimal en sauts (lequel dépend de l'ordre d'exploration de la frontière), UCS retourne *le* chemin optimal en coût — même trajet piège que dans le notebook Python.
+- **DFS** trouve un chemin (le graphe est fini et la liste des explorés évite les boucles, donc DFS termine), mais pas nécessairement le moins coûteux. Sur Lille -> Toulouse par exemple, DFS peut preferer Lille -> Paris -> ... -> Toulouse via un long detour.
 - **IDDFS** exploré plus de noeuds que BFS (overhead de re-exploration) mais trouve la même solution en nombre de sauts.
 
 **Regle pratique** :
@@ -10383,7 +10373,7 @@ On observe les patterns classiques :
 | Trouver le plus court en sauts, graphe petit | BFS |
 | Trouver n'importe quel chemin, mémoire limitee | DFS |
 | Combiner complétude + faible mémoire | IDDFS |
-",,,,,,,,6e31203205fcdfb1,,,,,,,
+",,,,,,,,77ff39d7299228d3,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,f83fbaf5,code,fr,f50312d04b47888a,"// Tableau recapitulatif des proprietes theoriques.
 Console.WriteLine(""\nTableau recapitulatif des proprietes theoriques"");
 Console.WriteLine(""="" + new string('=', 90));
@@ -10399,15 +10389,15 @@ foreach (var row in rows)
     Console.WriteLine($""{row.algo,-12} {row.complete,-12} {row.optimal,-15} {row.time,-22} {row.space,-18} {row.front,-10}"");
 Console.WriteLine(""\n* Optimal uniquement si tous les couts d'action sont identiques."");
 ",,,,,,,,f50312d04b47888a,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,7bdc029c,markdown,fr,92d6b67b1f10574b,"### Exercice 3 : Comparaison experimentale personnalisee
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,7bdc029c,markdown,fr,524b10ecffd94a0d,"### Exercice 3 : Comparaison experimentale personnalisee
 
-**Enonce** : choisissez un trajet **non couvert** par les 4 cas ci-dessus (par exemple **Grenoble -> Lille** ou **Montpellier -> Rennes**) et executez les quatre algorithmes. Construisez un tableau comparatif.
+**Enonce** : choisissez un trajet **non couvert** par les 5 cas ci-dessus (par exemple **Grenoble -> Lille** ou **Montpellier -> Rennes**) et executez les quatre algorithmes. Construisez un tableau comparatif.
 
 **Indices** :
 1. `var problemC = new GraphProblem(depart, arrivee, franceGraph);`
 2. `BFS(problemC)` / `DFS(problemC)` / `UCS(problemC)` / `IDDFS(problemC, maxDepth: 15)`.
 3. Affichez pour chacun : chemin, coût, noeuds explorés, noeuds générés, temps.
-",,,,,,,,92d6b67b1f10574b,,,,,,,
+",,,,,,,,524b10ecffd94a0d,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,19b46fd7,code,fr,1419f8129a129d5a,"// Exercice 3 : Comparaison experimentale personnalisee.
 // TODO etudiant : choisissez un trajet personnel.
 string depart = null;    // TODO etudiant : remplacer (ex: ""Grenoble"")
@@ -10607,12 +10597,12 @@ foreach (var m in memLog)
 Console.WriteLine($""\nBFS (Rennes -> Nice) : {resBfsRN.NodesExpanded} noeuds explores, frontiere max = {resBfsRN.MaxFrontierSize}"");
 Console.WriteLine($""IDS memoire cumulee : {(memLog.Count > 0 ? memLog[^1].explored : 0)} noeuds explores, pic pile = {(memLog.Count > 0 ? memLog[^1].stackMax : 0)}"");
 ",,,,,,,,c89ea89f3a402d38,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,e21f1159,markdown,fr,c472e7957a433798,"### Interpretation : IDS vs BFS en mémoire
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,e21f1159,markdown,fr,60cf936c0c4da642,"### Interpretation : IDS vs BFS en mémoire
 
 IDS exploré en profondeur limitee croissante, sa mémoire (taille de la pile) reste **lineaire en la profondeur courante**. BFS, lui, stocke **tous les noeuds d'un niveau** et la mémoire grandit **exponentiellement** avec la profondeur.
 
-Sur Rennes -> Nice (le trajet le plus long du notebook), on observe : pic de pile IDS = O(d) ~= 5 noeuds, contre frontière BFS ~= 12 noeuds sur un niveau intermediaire. Pour des arbres plus profonds (profondeur 20+), l'écart devient dramatique : IDS devient imbattable.
-",,,,,,,,c472e7957a433798,,,,,,,
+Sur Rennes -> Nice (le trajet le plus long du notebook), le graphe est trop petit pour que l'avantage soit visible : pic de pile IDS = 5 nœuds contre frontière BFS max = 4 nœuds — IDS « paie » ici ses ré-explorations sans rien gagner en mémoire. C'est normal : la mémoire d'IDS croît en $O(bd)$ et celle de BFS en $O(b^d)$. Sur un arbre de branchement $b = 10$ et profondeur $d = 10$, IDS stockerait ~100 nœuds là où BFS en stockerait ~10 milliards : pour des espaces d'états réels (profondeur 20+), IDS devient imbattable.
+",,,,,,,,60cf936c0c4da642,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed-Csharp.ipynb,0482eddd,markdown,fr,24c1879c521f31fd,"---
 
 ## 8. Resume et perspectives
@@ -12491,19 +12481,19 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,5b90e3
 Nous réutilisons le **même graphe pondéré** que le jumeau Search-2-Csharp (13 villes, distances routières en km). Pour la recherche informée, nous ajoutons une **heuristique** $h(n)$ = distance à vol d'oiseau entre la ville courante et le but, calculée par la **formule de Haversine** sur les coordonnées lat/lon.
 
 **Pourquoi Haversine est admissible** : à vol d'oiseau (arc de grand cercle), la distance est toujours **inférieure ou égale** à la distance routière réelle (qui suit des arcs de cercle déformés par le réseau). Donc $h(n) \leq h^*(n)$ pour toute ville — la condition d'admissibilité.",,,,,,,,2c761989fd420c0b,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,5f020aaf,code,fr,1fb6cd82bae7d43a,"// Graphe des villes francaises (13 villes, reutilise du jumeau Search-2-Csharp)
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,5f020aaf,code,fr,e4d47e2a785ce047,"// Graphe des villes francaises (13 villes, reutilise du jumeau Search-2-Csharp)
 // + coordonnees lat/lon + heuristique Haversine.
 var franceGraph = new Dictionary<string, Dictionary<string, double>> {
     [""Bordeaux""]    = new() { [""Paris""] = 585, [""Toulouse""] = 245, [""Nantes""] = 350 },
     [""Paris""]       = new() { [""Bordeaux""] = 585, [""Lille""] = 225, [""Strasbourg""] = 490, [""Lyon""] = 465, [""Nantes""] = 385 },
     [""Lille""]       = new() { [""Paris""] = 225, [""Rennes""] = 510 },
-    [""Rennes""]      = new() { [""Lille""] = 510, [""Paris""] = 385, [""Nantes""] = 110, [""Brest""] = 245 },
+    [""Rennes""]      = new() { [""Lille""] = 510, [""Nantes""] = 110, [""Brest""] = 245 },
     [""Brest""]       = new() { [""Rennes""] = 245 },
     [""Nantes""]      = new() { [""Rennes""] = 110, [""Paris""] = 385, [""Bordeaux""] = 350, [""Toulouse""] = 590 },
     [""Strasbourg""]  = new() { [""Paris""] = 490, [""Lyon""] = 490 },
     [""Lyon""]        = new() { [""Paris""] = 465, [""Strasbourg""] = 490, [""Marseille""] = 315, [""Toulouse""] = 535, [""Grenoble""] = 115 },
     [""Grenoble""]    = new() { [""Lyon""] = 115, [""Marseille""] = 305 },
-    [""Marseille""]   = new() { [""Lyon""] = 315, [""Grenoble""] = 305, [""Toulouse""] = 405, [""Nice""] = 200 },
+    [""Marseille""]   = new() { [""Lyon""] = 315, [""Grenoble""] = 305, [""Toulouse""] = 405, [""Nice""] = 200, [""Montpellier""] = 165 },
     [""Toulouse""]    = new() { [""Bordeaux""] = 245, [""Nantes""] = 590, [""Marseille""] = 405, [""Lyon""] = 535, [""Montpellier""] = 245 },
     [""Montpellier""] = new() { [""Toulouse""] = 245, [""Marseille""] = 165 },
     [""Nice""]        = new() { [""Marseille""] = 200 },
@@ -12552,7 +12542,7 @@ Console.WriteLine();
 Console.WriteLine(""Heuristique h(n) = Haversine vers Toulouse (vol d'oiseau, admissible) :"");
 foreach (var v in new[] { ""Lille"", ""Paris"", ""Rennes"", ""Nantes"", ""Bordeaux"", ""Toulouse"" }) {
     Console.WriteLine($""  {v,-12} h = {hLilleToulouse(v),6:F0} km"");
-}",,,,,,,,1fb6cd82bae7d43a,,,,,,,
+}",,,,,,,,e4d47e2a785ce047,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,4ef05065,markdown,fr,530934f46d8a8d67,"### Interprétation : l'heuristique guide vers le but
 
 La colonne $h(n)$ décroît à mesure qu'on se rapproche géographiquement de Toulouse. **Lille** (~830 km à vol d'oiseau) et **Brest** (lointain) ont un $h$ élevé ; **Bordeaux** (~245 km) et surtout **Toulouse** ($h = 0$) ont un $h$ faible. C'est ce gradient que les algorithmes informés vont exploiter.
@@ -13045,8 +13035,8 @@ void GrillePondereeAStar() {
 }
 
 GrillePondereeAStar();",,,,,,,,0ba9c5500afc73c8,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,1f226681,markdown,fr,bd3acaa3f4acdf23,"---
-## 8. Conclusion
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,1f226681,markdown,fr,17489bf3955e9f25,"---
+## Conclusion
 
 ### Concepts clés
 
@@ -13083,7 +13073,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,1f2266
 
 **Navigation** : [<< Recherche non informée (Search-2 C#)](Search-2-Uninformed-Csharp.ipynb) | [Index série Search](../README.md) | [Recherche locale (Search-4 C#) >>](Search-4-LocalSearch-Csharp.ipynb)
 
-*Port C# / .NET 9.0 du notebook Python Search-3-Informed — Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956) (parité .NET ⇄ Python des séries).*",,,,,,,,bd3acaa3f4acdf23,,,,,,,
+*Port C# / .NET 9.0 du notebook Python Search-3-Informed — Epic [#4956](https://github.com/jsboige/CoursIA/issues/4956) (parité .NET ⇄ Python des séries).*",,,,,,,,17489bf3955e9f25,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,nav-header,markdown,fr,6baffe8ddf47a645,"# Search-3-Informed : Algorithmes de Recherche Informée
 
 **Navigation** : [<< Recherche non informée](Search-2-Uninformed.ipynb) | [Index](../README.md) | [Recherche locale >>](Search-4-LocalSearch.ipynb)
@@ -13103,8 +13093,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,nav-header,ma
 
 ### Durée estimée : 50 minutes
 ",,,,,,,,6baffe8ddf47a645,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,imports,code,fr,bf328c15afc066b5,"# Imports
-!pip install pandas
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,imports,code,fr,a39de7bc9067cbfd,"# Imports
 import sys
 import time
 import heapq
@@ -13127,7 +13116,7 @@ warnings.filterwarnings('ignore')
 sys.path.insert(0, '..')
 from search_helpers import benchmark_table, plot_benchmark
 
-print(""Environnement pret pour la recherche informee."")",,,,,,,,bf328c15afc066b5,,,,,,,
+print(""Environnement pret pour la recherche informee."")",,,,,,,,a39de7bc9067cbfd,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,intro-section,markdown,fr,0b09c0fcce81cc8e,"## 1. Introduction : Qu'est-ce que la recherche informée ?
 
 ### Recherche non informée vs informée
@@ -14927,7 +14916,7 @@ goal_w = (5, 7)
 
 print(""Exercice 5 : implementez les TODO ci-dessus."")
 ",,,,,,,,ad59a804b622e013,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,conclusion-section,markdown,fr,3d696ec9560dce3e,"## 10. Conclusion
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,conclusion-section,markdown,fr,681e7c4b7bdea1a0,"## Conclusion
 
 ### Concepts clés
 
@@ -14964,7 +14953,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,conclusion-se
 ---
 
 **Navigation** : [<< Recherche non informée](Search-2-Uninformed.ipynb) | [Index](../README.md) | [Recherche locale >>](Search-4-LocalSearch.ipynb)
-",,,,,,,,3d696ec9560dce3e,,,,,,,
+",,,,,,,,681e7c4b7bdea1a0,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb,nav-footer,markdown,fr,2a1ce9ee883c6de5,"## Conclusion et perspectives
 
 Ce notebook a présenté les algorithmes de recherche informée, qui utilisent des connaissances spécifiques du problème (heuristiques) pour guider l'exploration. L'efficacité de ces algorithmes dépend crucialement de la qualité de l'heuristique.
@@ -15494,7 +15483,7 @@ A la fin de ce notebook, vous saurez :
 - Notions de base en probabilites (pour Simulated Annealing)
 
 ### Duree estimee : 45 minutes",,,,,,,,d7fe309d0d88ac65,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb,imports,code,fr,d541419b71b4490f,"# Imports
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb,imports,code,fr,5530bb3dfa15cb60,"# Imports
 import sys
 import time
 import math
@@ -15505,6 +15494,10 @@ from copy import deepcopy
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
+import warnings
+# Filtrer les avertissements matplotlib non-actionnables dont le formateur
+# fuite le chemin temporaire du kernel (~\AppData\Local\Temp\ipykernel_<pid>\...).
+warnings.filterwarnings('ignore', message='set_ticklabels.*', category=UserWarning)
 
 %matplotlib inline
 
@@ -15516,7 +15509,7 @@ from search_helpers import draw_fitness_landscape, benchmark_table, plot_benchma
 random.seed(42)
 np.random.seed(42)
 
-print(""Environnement pret."")",,,,,,,,d541419b71b4490f,,,,,,,
+print(""Environnement pret."")",,,,,,,,5530bb3dfa15cb60,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb,section-1-intro,markdown,fr,f85734c644f4cdd2,"## 1. Introduction a la recherche locale (~5 min)
 
 ### De la recherche systematique a la recherche locale
@@ -19214,7 +19207,7 @@ contraste qu'entre A\* (optimal, Partie 1) et les métaheuristiques (approché, 
   l'optimalité garantie pour gagner en scalabilité ;
 - **EPIC [#4956](https://github.com/jsboige/CoursIA/issues/4956)** : parité `.NET ⇄ Python` des
   séries de notebooks.",,,,,,,,da6f91e0e3adc040,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,nav-header,markdown,fr,c353611aae7bb15d,"# Search-6-AdversarialSearch : Recherche Adversariale
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,nav-header,markdown,fr,5a1d8f848d10f933,"# Search-6-AdversarialSearch : Recherche Adversariale
 
 **Navigation** : [<< Recherche informee](Search-3-Informed.ipynb) | [Index](../README.md) | [MCTS >>](Search-7-MCTS-And-Beyond.ipynb)
 
@@ -19228,11 +19221,12 @@ A la fin de ce notebook, vous saurez :
 5. **Utiliser** les tables de transposition pour optimiser la recherche
 
 ### Prerequis
+
 - Notebooks Search-1 (StateSpace) et Search-2 (DFS/BFS)
 - Notebook Search-3 (heuristiques)
 - Bases de Python : recursivite, classes
 
-### Duree estimee : 60 minutes",,,,,,,,c353611aae7bb15d,,,,,,,
+### Duree estimee : 60 minutes",,,,,,,,5a1d8f848d10f933,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,imports,code,fr,a4baf326d070e0ef,"# Imports
 import sys
 import time
@@ -19809,25 +19803,31 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,ecf5
 4. **Tous les algorithmes retournent la meme valeur** : l'optimisation ne change pas le resultat, seulement la vitesse
 
 > **Note technique** : La table de transposition montre 1565 hits pour 3010 misses, indiquant que ~34% des etats ont ete rencontres precedemment. Ce taux augmente avec la profondeur de recherche.",,,,,,,,af86d847e6933673,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,exercices-section,markdown,fr,9c317cbd16a06271,"## Exercices
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,exercices-section,markdown,fr,3e3a7f79c1a33239,"## Exercices
 
 ### Exercice 1 : Connect Four
+
 Implementez une classe `ConnectFour` heritant de `JeuSommeNulle` pour le jeu Puissance 4 (grille 6x7, 4 alignes pour gagner).
 
 ### Exercice 2 : Ordonnancement des coups
+
 Ameliorez Alpha-Beta en ordonnant les coups par potentiel decroissant (coups au centre d'abord).
 
 ### Exercice 3 : Recherche de Quiescence
+
 Implementez une recherche de quiescence pour eviter l'effet d'horizon.
 
 ### Exercice 4 : Zobrist Hashing
+
 Implementez le Zobrist hashing pour optimiser les tables de transposition.
 
 ### Exercice 5 : Negamax
+
 Implementez l'algorithme Negamax, une formulation simplifiee de Minimax ou les deux joueurs maximisent de leur propre point de vue. Ajoutez l'elagage Alpha-Beta a votre implementation.
 
 ### Exercice 6 : Tournoi algorithmique
-Creez un framework de tournoi automatique entre differents algorithmes (aleatoire, Minimax, Alpha-Beta) et analysez les resultats statistiquement.",,,,,,,,9c317cbd16a06271,,,,,,,
+
+Creez un framework de tournoi automatique entre differents algorithmes (aleatoire, Minimax, Alpha-Beta) et analysez les resultats statistiquement.",,,,,,,,3e3a7f79c1a33239,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,o8n7ldilw8,code,fr,367e749499f74900,"# Exercice 1 : Connect Four
 # Exercice: Implementez la classe ConnectFour heritant de JeuSommeNulle
 # - Grille 6 lignes x 7 colonnes
@@ -20012,7 +20012,7 @@ def tournoi_round_robin(jeu, strategies, parties_par_paire=6):
 
 print(""Exercice a completer"")",,,,,,,,da3fe81ba5bbe029,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,882136fd,markdown,fr,cb3f91d54eee30e5,---,,,,,,,,cb3f91d54eee30e5,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,conclusion-section,markdown,fr,35ed849dfd8925dd,"## 8. Synthese
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,conclusion-section,markdown,fr,2343d7b785b3267b,"## Synthese
 
 ### Resume des techniques
 
@@ -20047,7 +20047,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb,conc
 - Zobrist, A.L. (1970). A New Hashing Method with Application for Game Playing. ICCV Report 88, University of Wisconsin.
 - Korf, R.E. (1985). Depth-first Iterative-Deepening: An Optimal Admissible Tree Search. Artificial Intelligence 27(1):97-109.
 
-",,,,,,,,35ed849dfd8925dd,,,,,,,
+",,,,,,,,2343d7b785b3267b,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,nav-header,markdown,fr,5bff1de83d5b4be6,"# Search-7-MCTS-And-Beyond : Monte Carlo Tree Search et Extensions
 
 **Navigation** : [<< Recherche adversariale](Search-6-AdversarialSearch.ipynb) | [Index](../README.md) | [Dancing Links >>](Search-8-DancingLinks.ipynb)
@@ -20124,17 +20124,17 @@ UCB1 = W/N + c * sqrt(ln(N_parent) / N)
 - **c * sqrt(...)** : Terme d'exploration (c = 1.41 typiquement)
 - **N** : Nombre de visites du noeud
 - **N_parent** : Nombre de visites du parent",,,,,,,,6d76092412d8b1b1,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,mcts-node-class,code,fr,7d6a875f527a5ca0,"class NoeudMCTS:
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,mcts-node-class,code,fr,4d1671e73a50a9e3,"class NoeudMCTS:
     """"""Noeud de l'arbre MCTS.""""""
     
     def __init__(self, etat: Any, parent=None, action=None):
         self.etat = etat
         self.parent = parent
-        self.action = action  # Action qui a mene a cet etat
+        self.action = action  # Action qui a mené a cet etat
         self.enfants = {}     # action -> NoeudMCTS
         self.visites = 0
         self.victoires = 0.0
-        self.actions_non_explorees = None  # Initialise lors de la premiere expansion
+        self.actions_non_explorees = None  # Initialise lors de la première expansion
     
     def ucb1(self, c: float = 1.41) -> float:
         """"""Calcul du score UCB1.""""""
@@ -20162,14 +20162,14 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,mcts-n
     def est_terminal(self, jeu) -> bool:
         return jeu.est_terminal(self.etat)
 print(""Classe NoeudMCTS definie (UCB1, selection, expansion)"")
-",,,,,,,,7d6a875f527a5ca0,,,,,,,
+",,,,,,,,4d1671e73a50a9e3,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,79692fea,markdown,fr,d9d9f9ce641d2201,"Implementation de la classe MCTS avec selection UCB1, expansion, simulation et retropropagation.",,,,,,,,d9d9f9ce641d2201,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,mcts-algorithm,code,fr,39f65917c09e6ebf,"class MCTS:
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,mcts-algorithm,code,fr,5d43ed0f1a60586a,"class MCTS:
     """"""Implementation de Monte Carlo Tree Search.""""""
     
     def __init__(self, jeu, c: float = 1.41):
         self.jeu = jeu
-        self.c = c  # Parametre d'exploration
+        self.c = c  # Paramètre d'exploration
         self.stats = {'selections': 0, 'expansions': 0, 'simulations': 0, 'backprops': 0}
     
     def recherche(self, etat: Any, iterations: int = 1000) -> Tuple[Any, float]:
@@ -20237,7 +20237,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,mcts-a
         while noeud is not None:
             noeud.visites += 1
             
-            # Le resultat depend du point de vue du joueur a ce noeud
+            # Le résultat dépend du point de vue du joueur a ce noeud
             if self.jeu.joueur(noeud.etat) == 'MAX':
                 noeud.victoires += resultat
             else:
@@ -20245,13 +20245,13 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,mcts-a
             
             noeud = noeud.parent
 print(""Classe MCTS definie (selection, expansion, simulation, backpropagation)"")
-",,,,,,,,39f65917c09e6ebf,,,,,,,
+",,,,,,,,5d43ed0f1a60586a,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,ng2kq8fnyml,markdown,fr,1ec9a6ee4a41fff3,"Maintenant que nous avons la structure de nœud, nous pouvons implémenter l'algorithme **MCTS complet** qui utilise ces nœuds pour construire l'arbre de recherche.
 ",,,,,,,,1ec9a6ee4a41fff3,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,test-mcts-section,markdown,fr,29644a19611c0a09,"## 3. Test sur Tic-Tac-Toe
 
 Comparons MCTS avec Minimax sur le jeu de Morpion.",,,,,,,,29644a19611c0a09,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,tictactoe-class,code,fr,463362318edfdb38,"# Reutilisation de la classe TicTacToe du notebook precedent
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,tictactoe-class,code,fr,3fc21b40be3ba2bb,"# Réutilisation de la classe TicTacToe du notebook précédent
 from abc import ABC, abstractmethod
 
 class JeuSommeNulle(ABC):
@@ -20314,7 +20314,7 @@ action, valeur = mcts.recherche(jeu.etat_initial(), iterations=1000)
 temps = time.time() - start
 
 print(f""MCTS (1000 iterations): action={action}, valeur={valeur:.3f}, temps={temps:.3f}s"")
-print(f""Stats: {mcts.stats}"")",,,,,,,,463362318edfdb38,,,,,,,
+print(f""Stats: {mcts.stats}"")",,,,,,,,3fc21b40be3ba2bb,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,e103e3fc,markdown,fr,f983705c8899599d,"### Interpretation : Premiers resultats MCTS
 
 **Sortie obtenue** : MCTS avec 1000 iterations a selectionne l'action 8 (coin inferieur-droit) avec une valeur estimee de 0.086, en 0.080 seconde.
@@ -20770,11 +20770,11 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,f14e37
 Le jeu de **Nim** est un cas ideal pour comprendre MCTS : l'espace d'etats est petit et la strategie optimale est connue mathematiquement (laisser un multiple de 4 allumettes a l'adversaire). L'exemple ci-dessous montre comment MCTS peut decouvrir cette strategie par simulation, et compare ses performances contre un joueur optimal.
 
 Observez comment le taux de victoire de MCTS varie en fonction du nombre d'iterations et du fait que MCTS joue en premier ou en second.",,,,,,,,008914b585003361,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,883gmdiqt1x,code,fr,bd977f2c0dd88199,"# Exemple resolu : MCTS sur le jeu de Nim
-# Le jeu de Nim est un cas ideal pour MCTS : espace petit, strategie optimale connue.
-# Regles: N allumettes au depart, chaque joueur prend 1, 2 ou 3 allumettes.
-# Le joueur qui prend la derniere allumette GAGNE (variante normale).
-# Strategie optimale: laisser un multiple de 4 a l'adversaire.
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,883gmdiqt1x,code,fr,b3297e72a42c7eb6,"# Exemple resolu : MCTS sur le jeu de Nim
+# Le jeu de Nim est un cas idéal pour MCTS : espace petit, stratégie optimale connue.
+# Règles: N allumettes au depart, chaque joueur prend 1, 2 ou 3 allumettes.
+# Le joueur qui prend la dernière allumette GAGNE (variante normale).
+# Stratégie optimale: laisser un multiple de 4 a l'adversaire.
 
 class NimGame(JeuSommeNulle):
     """"""Jeu de Nim : N allumettes, prendre 1-3, le dernier a jouer gagne.""""""
@@ -20801,8 +20801,8 @@ class NimGame(JeuSommeNulle):
         return etat[0] == 0
 
     def utilite(self, etat, joueur):
-        # etat = (0, joueur_qui_doit_jouer) -> il ne peut pas jouer -> l'autre a pris la derniere -> l'autre GAGNE
-        # Le joueur qui vient de jouer (pas celui dont c'est le tour) a pris la derniere allumette -> il GAGNE
+        # etat = (0, joueur_qui_doit_jouer) -> il ne peut pas jouer -> l'autre a pris la dernière -> l'autre GAGNE
+        # Le joueur qui vient de jouer (pas celui dont c'est le tour) a pris la dernière allumette -> il GAGNE
         gagnant = 'MAX' if etat[1] == 'O' else 'MIN'
         return 1 if gagnant == joueur else -1
 
@@ -20816,10 +20816,10 @@ def strategie_optimale_nim(etat):
     reste = n % 4
     return reste if reste > 0 else 1
 
-# --- Test : MCTS vs strategie optimale sur Nim ---
+# --- Test : MCTS vs stratégie optimale sur Nim ---
 jeu_nim = NimGame(n_allumettes=15)
 
-# Verifier que MCTS decouvre la strategie optimale
+# Vérifier que MCTS découvre la stratégie optimale
 mcts_nim = MCTS(jeu_nim)
 action_nim, valeur_nim = mcts_nim.recherche(jeu_nim.etat_initial(), iterations=2000)
 action_opt = strategie_optimale_nim(jeu_nim.etat_initial())
@@ -20827,7 +20827,7 @@ print(f""Nim(15) - MCTS(2000 iter): prendre {action_nim}, valeur={valeur_nim:.3f
 print(f""Nim(15) - Strategie optimale: prendre {action_opt}"")
 print(f""Optimal atteint: {action_nim == action_opt}"")
 
-# Tournoi : MCTS vs strategie optimale sur 50 parties
+# Tournoi : MCTS vs stratégie optimale sur 50 parties
 victoires_mcts = 0
 nulles = 0
 n_parties = 50
@@ -20853,13 +20853,13 @@ for i in range(n_parties):
 print(f""\nTournoi MCTS(500 iter) vs Strategie optimale ({n_parties} parties):"")
 print(f""  Victoires MCTS: {victoires_mcts}/{n_parties}"")
 print(f""  Nulles: {nulles}/{n_parties}"")
-print(f""  Victoires strategie optimale: {n_parties - victoires_mcts - nulles}/{n_parties}"")",,,,,,,,bd977f2c0dd88199,,,,,,,
+print(f""  Victoires strategie optimale: {n_parties - victoires_mcts - nulles}/{n_parties}"")",,,,,,,,b3297e72a42c7eb6,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,843a15ef,markdown,fr,ceb89637aa149e26,"### Exercice 2 : Rollout intelligent
 
 Implementez un rollout guide par heuristiques au lieu d'un choix purement aleatoire. Evaluez les actions candidates avec une fonction heuristique et choisissez l'action avec le meilleur score (avec un peu d'aleatoire). Pour TicTacToe, privilegiez le centre et les coins.",,,,,,,,ceb89637aa149e26,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,2e230a8b,code,fr,3084c701f951ab40,"# Exercice 2 : Rollout intelligent
-# TODO: Implementez un rollout guide par heuristiques
-# - Evaluer les actions candidates avec une fonction heuristique
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,2e230a8b,code,fr,6448b381b3524576,"# Exercice 2 : Rollout intelligent
+# TODO: Implémentez un rollout guide par heuristiques
+# - Évaluer les actions candidates avec une fonction heuristique
 # - Choisir l'action avec le meilleur score (avec un peu d'aleatoire)
 # Indice: pour TicTacToe, privilegier le centre et les coins
 
@@ -20868,7 +20868,7 @@ class MCTSSmartRollout(MCTS):
     
     def _simulation(self, noeud):
         """"""Simulation avec choix heuristique au lieu d'aleatoire.""""""
-        # TODO: Implementer le rollout intelligent
+        # TODO: Implémenter le rollout intelligent
         # Utiliser une fonction heuristique pour guider les choix
         pass
 
@@ -20879,41 +20879,41 @@ def heuristique_tictactoe(etat, jeu):
     pass
 
 
-# --- Test (decommentez apres avoir complete l'exercice ci-dessus) ---
+# --- Test (décommentez après avoir complete l'exercice ci-dessus) ---
 # print(""Exercice a completer - voir les indices ci-dessus"")
 
-print(""Exercice charge - completez le code puis decommentez les tests."")",,,,,,,,3084c701f951ab40,,,,,,,
+print(""Exercice charge - completez le code puis decommentez les tests."")",,,,,,,,6448b381b3524576,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,3ff76cc9,markdown,fr,cccddfd0a565f836,"### Exercice 3 : MCTS vs Alpha-Beta sur Connect Four
 
 Comparez les deux algorithmes sur le jeu de Puissance 4. Implementez Connect Four (ou reutilisez du notebook Search-6), faites jouer MCTS vs Alpha-Beta sur plusieurs parties et analysez : taux de victoire, temps, qualite des coups. Alpha-Beta devrait etre plus fort avec une bonne profondeur.",,,,,,,,cccddfd0a565f836,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,2ae95cd2,code,fr,e7adc5e2553d84f4,"# Exercice 3 : MCTS vs Alpha-Beta sur Connect Four
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,2ae95cd2,code,fr,f68590f4e4785b5d,"# Exercice 3 : MCTS vs Alpha-Beta sur Connect Four
 # TODO: Comparez les deux algorithmes sur Puissance 4
-# - Implementer Connect Four (ou reutiliser du notebook Search-6)
+# - Implémenter Connect Four (ou réutiliser du notebook Search-6)
 # - Faire jouer MCTS vs Alpha-Beta sur plusieurs parties
 # - Analyser: taux de victoire, temps, qualite des coups
-# Indice: Alpha-Beta devrait etre plus fort avec une bonne profondeur
+# Indice: Alpha-Beta devrait être plus fort avec une bonne profondeur
 
 def tournoi_mcts_vs_alphabeta(jeu, mcts_iterations=1000, alpha_beta_depth=6, parties=20):
     """"""
     Organise un tournoi entre MCTS et Alpha-Beta.
     Retourne les statistiques de victoire.
     """"""
-    # TODO: Implementer le tournoi
+    # TODO: Implémenter le tournoi
     # Alterner qui commence (MAX = MCTS ou Alpha-Beta)
     pass
 
 
-# --- Test (decommentez apres avoir complete l'exercice ci-dessus) ---
+# --- Test (décommentez après avoir complete l'exercice ci-dessus) ---
 # print(""Exercice a completer - voir les indices ci-dessus"")
 
-print(""Exercice charge - completez le code puis decommentez les tests."")",,,,,,,,e7adc5e2553d84f4,,,,,,,
+print(""Exercice charge - completez le code puis decommentez les tests."")",,,,,,,,f68590f4e4785b5d,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,27185f48,markdown,fr,7439665a6edcd12c,"### Exercice 4 : Extension RAVE
 
 Implementez l'extension RAVE (Rapid Action Value Estimation) pour accelerer la convergence de MCTS. RAVE utilise l'heuristique ""all moves as first"" : un coup est evalue meme s'il est joue plus tard dans la partie. La formule est `Q_RAVE = (1-beta) * Q_MCTS + beta * Q_RAVE`. Modifiez la classe NoeudMCTS pour stocker les stats RAVE.",,,,,,,,7439665a6edcd12c,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,924f80a7,code,fr,4e1b9d2a885be8be,"# Exercice 4 : Extension RAVE
-# TODO: Implementez RAVE (Rapid Action Value Estimation)
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,924f80a7,code,fr,101b77c4f2506e39,"# Exercice 4 : Extension RAVE
+# TODO: Implémentez RAVE (Rapid Action Value Estimation)
 # - RAVE utilise l'heuristique ""all moves as first""
-# - Un coup est evalue meme s'il est joue plus tard
+# - Un coup est évalué même s'il est joue plus tard
 # - Formule: Q_RAVE = (1-beta) * Q_MCTS + beta * Q_RAVE
 # Indice: modifier la classe NoeudMCTS pour stocker les stats RAVE
 
@@ -20928,7 +20928,7 @@ class NoeudRAVE(NoeudMCTS):
     
     def valeur_rave(self, beta):
         """"""Calcule la valeur combinee MCTS + RAVE.""""""
-        # TODO: Implementer la formule RAVE
+        # TODO: Implémenter la formule RAVE
         pass
 
 class MCTSRAVE(MCTS):
@@ -20940,15 +20940,15 @@ class MCTSRAVE(MCTS):
         pass
 
 
-# --- Test (decommentez apres avoir complete l'exercice ci-dessus) ---
+# --- Test (décommentez après avoir complete l'exercice ci-dessus) ---
 # print(""Exercice a completer - voir les indices ci-dessus"")
 
-print(""Exercice charge - completez le code puis decommentez les tests."")",,,,,,,,4e1b9d2a885be8be,,,,,,,
+print(""Exercice charge - completez le code puis decommentez les tests."")",,,,,,,,101b77c4f2506e39,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,be1570de,markdown,fr,78fb19edcc5a4dae,"### Exercice 5 : Time management
 
 Implementez une gestion du temps adaptive pour MCTS. Allouez plus de temps aux positions critiques, utilisez moins de temps quand le coup est evident, et detectez les positions ""faciles"" (victoire probable). Utilisez la variance des evaluations pour detecter l'incertitude.",,,,,,,,78fb19edcc5a4dae,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,7393021e,code,fr,939f9ca93631f567,"# Exercice 5 : Time management
-# TODO: Implementez une gestion du temps adaptive pour MCTS
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,7393021e,code,fr,48e6899033023f81,"# Exercice 5 : Time management
+# TODO: Implémentez une gestion du temps adaptive pour MCTS
 # - Allouer plus de temps aux positions critiques
 # - Utiliser moins de temps quand le coup est evident
 # - Detecter les positions ""faciles"" (victoire probable)
@@ -20962,7 +20962,7 @@ class MCTSTimeManaged(MCTS):
         MCTS avec gestion adaptive du temps.
         Arrete quand: temps ecoule OU confidence suffisante.
         """"""
-        # TODO: Implementer la logique adaptive
+        # TODO: Implémenter la logique adaptive
         # 1. Si variance des evaluations faible, arreter plus tot
         # 2. Si victoire probable (valeur > 0.9), arreter
         # 3. Sinon, utiliser tout le temps
@@ -20974,20 +20974,20 @@ class MCTSTimeManaged(MCTS):
         pass
 
 
-# --- Test (decommentez apres avoir complete l'exercice ci-dessus) ---
+# --- Test (décommentez après avoir complete l'exercice ci-dessus) ---
 # print(""Exercice a completer - voir les indices ci-dessus"")
 
-print(""Exercice charge - completez le code puis decommentez les tests."")",,,,,,,,939f9ca93631f567,,,,,,,
+print(""Exercice charge - completez le code puis decommentez les tests."")",,,,,,,,48e6899033023f81,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,5db5e6a2,markdown,fr,a66d362845455504,"### Exemple : Parametre d'exploration c
 
 L'exemple ci-dessous montre comment benchmark differentes valeurs du parametre d'exploration `c` de MCTS. Le code implemente des fonctions auxiliaires pour jouer des parties MCTS contre un joueur aleatoire, puis compare les taux de victoire, temps d'execution et visites moyennes pour `c = 0.5, 1.0, 1.41, 2.0`.
 
 Observez comment la valeur de `c` influence le compromis entre exploration et exploitation.",,,,,,,,a66d362845455504,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,41im4gza0gh,code,fr,54c7f703686037cc,"# Exemple : Benchmark du parametre d'exploration c
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,41im4gza0gh,code,fr,54103371dfbdd119,"# Exemple : Benchmark du paramètre d'exploration c
 # Test des differentes valeurs de c et mesure de l'impact sur les performances
 # - c = 0.5 : exploitation dominante
-# - c = 1.0 : equilibre
-# - c = 1.41 : valeur theorique (sqrt(2))
+# - c = 1.0 : équilibre
+# - c = 1.41 : valeur théorique (sqrt(2))
 # - c = 2.0 : exploration dominante
 
 def mcts_coup_avec_visites(mcts, etat, iterations):
@@ -21062,7 +21062,7 @@ def benchmark_parametre_c(jeu, valeurs_c, iterations=1000, parties=10):
 
 df_c = benchmark_parametre_c(TicTacToe(), [0.5, 1.0, 1.41, 2.0], iterations=1000)
 df_c.index.name = 'c'
-display(df_c)",,,,,,,,54c7f703686037cc,,,,,,,
+display(df_c)",,,,,,,,54103371dfbdd119,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,d4785a8a,markdown,fr,ef2de2626b05b531,"---
 
 ### Exercice : MCTS sur le jeu de Connect-4
@@ -21090,8 +21090,8 @@ Implementez le jeu de **Connect-4** (Puissance 4) et testez l'algorithme MCTS de
 - Pour la methode `resultat`, les jetons tombent : trouver la premiere case vide dans la colonne en partant du bas
 - Pour `est_terminal`, verifiez les 4 directions : horizontal, vertical, et les deux diagonales
 - Le nombre de positions au Connect-4 est d'environ 4.5 trillions, MCTS est donc particulierement pertinent",,,,,,,,ef2de2626b05b531,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,d66a3ffa,code,fr,52d7129434b3efbc,"# Exercice : MCTS sur le jeu de Connect-4
-# TODO: Implementez la classe ConnectFour et testez MCTS dessus
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,d66a3ffa,code,fr,b54eba756d78dacd,"# Exercice : MCTS sur le jeu de Connect-4
+# TODO: Implémentez la classe ConnectFour et testez MCTS dessus
 
 class ConnectFour(JeuSommeNulle):
     """"""Jeu de Connect-4 (Puissance 4) : grille 6x7, aligner 4 jetons pour gagner.""""""
@@ -21118,8 +21118,8 @@ class ConnectFour(JeuSommeNulle):
         pass
 
     def est_terminal(self, etat):
-        # TODO: Verifier s'il y a un alignement de 4 (ou grille pleine)
-        # Verifier dans les 4 directions : horizontal, vertical, diagonales
+        # TODO: Vérifier s'il y a un alignement de 4 (ou grille pleine)
+        # Vérifier dans les 4 directions : horizontal, vertical, diagonales
         pass
 
     def utilite(self, etat, joueur):
@@ -21127,7 +21127,7 @@ class ConnectFour(JeuSommeNulle):
         pass
 
 
-# --- Tests (decommentez apres avoir complete) ---
+# --- Tests (décommentez après avoir complete) ---
 # jeu_cf = ConnectFour()
 # mcts_cf = MCTS(jeu_cf)
 # action_cf, valeur_cf = mcts_cf.recherche(jeu_cf.etat_initial(), iterations=1000)
@@ -21141,8 +21141,8 @@ class ConnectFour(JeuSommeNulle):
 #     t = time.time() - t0
 #     print(f""  {n_iter:5d} iter -> colonne={a}, valeur={v:.3f}, temps={t:.3f}s"")
 
-print(""Exercice charge - completez la classe ConnectFour puis decommentez les tests."")",,,,,,,,52d7129434b3efbc,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,conclusion-section,markdown,fr,2788d6f84bbf60c0,"## 8. Synthese
+print(""Exercice charge - completez la classe ConnectFour puis decommentez les tests."")",,,,,,,,b54eba756d78dacd,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,conclusion-section,markdown,fr,d12cb75fa9538af2,"## Synthese
 
 ### Resume des approches
 
@@ -21179,7 +21179,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,conclu
 - Silver, D., Schrittwieser, J., Simonyan, K. et al. (2017). Mastering the game of Go without human knowledge. Nature 550:354-359.
 - Browne, C.B., Powley, E., Whitehouse, D. et al. (2012). A Survey of Monte Carlo Tree Search Methods. IEEE Transactions on Computational Intelligence and AI in Games 4(1):1-43.
 
-",,,,,,,,2788d6f84bbf60c0,,,,,,,
+",,,,,,,,d12cb75fa9538af2,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb,l1i6cpxssef,markdown,fr,bd1ecd17b885fd1b,"# Search-8-DancingLinks : L'algorithme X et Dancing Links de Knuth
 
 **Navigation** : [<< Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)
@@ -23270,7 +23270,7 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipy
 var solverMO = Solver.CreateSolver(""GLOP"");
 // TODO étudiant : optimisation multi-objectif
 ""Exercice à compléter — voir l'énoncé ci-dessus."".Display();",,,,,,,,18c36d79fedbd8d7,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb,s9c20,markdown,fr,1b1ee1480dec9ea0,"## 6. Conclusion
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb,s9c20,markdown,fr,b0601561e973eaef,"## Conclusion
 
 Ce notebook a présenté la **programmation linéaire en C#/.NET** avec Google OrTools — le pendant du notebook Python/PuLP.
 
@@ -23305,7 +23305,7 @@ Ce notebook a présenté la **programmation linéaire en C#/.NET** avec Google O
 
 ---
 
-*First tranche du twin .NET⇄Python (#4956, marathon). Sections suivantes à venir : transport, multi-dépôts, multi-objectif, comparaison PL vs PLNE approfondie.*",,,,,,,,1b1ee1480dec9ea0,,,,,,,
+*First tranche du twin .NET⇄Python (#4956, marathon). Sections suivantes à venir : transport, multi-dépôts, multi-objectif, comparaison PL vs PLNE approfondie.*",,,,,,,,b0601561e973eaef,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,2bb61f44,markdown,fr,bc56ef43968d9771,"# Search-9-LinearProgramming : Programmation Lineaire et Simplexe
 
 **Navigation** : [<< DancingLinks](Search-8-DancingLinks.ipynb) | [Index](../README.md) | [SymbolicAutomata >>](Search-10-SymbolicAutomata.ipynb)
@@ -23439,7 +23439,7 @@ Une entreprise fabrique deux produits **P1** et **P2** :
   - $x_1 + 2x_2 \leq 4$ (heures machine)
   - $2x_1 + x_2 \leq 5$ (heures main d'oeuvre)
   - $x_1, x_2 \geq 0$ (non-negativite)",,,,,,,,4da61ff2a173f879,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,c4727644,code,fr,87ffc819ac277719,"# Visualisation geometrique du probleme de production
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,c4727644,code,fr,f4274800309dee05,"# Visualisation geometrique du probleme de production
 fig, ax = plt.subplots(figsize=(10, 8))
 
 # Domaine de tracage
@@ -23452,8 +23452,8 @@ y1 = (4 - x) / 2
 y2 = 5 - 2*x
 
 # Tracer les contraintes
-ax.plot(x, y1, 'b-', linewidth=2, label='Contrainte machine: $x_1 + 2x_2 \leq 4$')
-ax.plot(x, y2, 'r-', linewidth=2, label='Contrainte MO: $2x_1 + x_2 \leq 5$')
+ax.plot(x, y1, 'b-', linewidth=2, label=r'Contrainte machine: $x_1 + 2x_2 \leq 4$')
+ax.plot(x, y2, 'r-', linewidth=2, label=r'Contrainte MO: $2x_1 + x_2 \leq 5$')
 
 # Region admissible (intersection des contraintes)
 y_feasible = np.minimum(y1, y2)
@@ -23502,7 +23502,7 @@ print(""  (0, 0)   : Profit = 3*0 + 2*0 = 0"")
 print(""  (0, 2)   : Profit = 3*0 + 2*2 = 4"")
 print(""  (1, 1.5) : Profit = 3*1 + 2*1.5 = 6  <- OPTIMAL"")
 print(""  (2.5, 0) : Profit = 3*2.5 + 2*0 = 7.5 (viole contrainte machine!)"")
-print(""\nSolution correcte : x1=1, x2=1.5, Profit = 6"")",,,,,,,,87ffc819ac277719,,,,,,,
+print(""\nSolution correcte : x1=1, x2=1.5, Profit = 6"")",,,,,,,,f4274800309dee05,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,9cc19398,markdown,fr,e25d6cb3c841d4fb,"### Interpretation : Visualisation geometrique
 
 **Composantes de la visualisation** :
@@ -23534,12 +23534,12 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,9082
 - Analyser les resultats (valeur optimale, variables, sensibilite)
 
 **Solver CBC** (Coin-OR Branch and Cut) est inclus par defaut et ne necessite pas d'installation supplementaire.",,,,,,,,ebaf2194b4580a1a,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,c2b2753d,code,fr,1036798f49a70c8e,"# Installation de PuLP
-!pip install -q pulp
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,c2b2753d,code,fr,fa2de4a6ded3e121,"# PuLP (pulp >= 2.8.0) : solveur de programmation lineaire (CBC, HiGHS).
+# Dependence declaree dans requirements.txt ; import et verification en cellule suivante.
 
 import sys
 print(f""Python {sys.version}"")
-print(""\nInstallation de PuLP terminee."")",,,,,,,,1036798f49a70c8e,,,,,,,
+print(""\nPuLP pret a etre importe (voir cellule suivante)."")",,,,,,,,fa2de4a6ded3e121,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,1eeb5c79,markdown,fr,db2e6b57cf3300f4,Import de PuLP et verification,,,,,,,,db2e6b57cf3300f4,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,7e8fe8a8,code,fr,28c4d7627a369322,"# Import de PuLP et verification
 import pulp
@@ -24356,12 +24356,11 @@ Chaque employe ne peut faire qu'une seule tache, et chaque tache doit etre effec
 **Question** : Minimiser le temps total d'execution.
 
 **Indice** : Utiliser des variables binaires $x_{ij} \in \{0, 1\}$.",,,,,,,,f72270959bb1d096,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,bc02ee52,code,fr,f11a3860596ff8c8,"# Exercice 1 : Probleme d'affectation
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,bc02ee52,code,fr,764ef827c1baf9d9,"# Exercice 1 : Probleme d'affectation
 print(""Exercice 1 : Probleme d'affectation"")
 print(""="" * 50)
 
-# Solution complete
-# 1. Definir les donnees (employes, taches, temps)
+# Donnees fournies (temps de realisation en heures).
 employes = ['E1', 'E2', 'E3', 'E4']
 taches = ['T1', 'T2', 'T3', 'T4']
 temps = {
@@ -24370,34 +24369,17 @@ temps = {
     ('E3', 'T1'): 3, ('E3', 'T2'): 2, ('E3', 'T3'): 6, ('E3', 'T4'): 1,
     ('E4', 'T1'): 4, ('E4', 'T2'): 3, ('E4', 'T3'): 5, ('E4', 'T4'): 2,
 }
-capacite = [1, 1 , 1, 1]
-# 2. Creer le probleme LpProblem
-prob_tache = pulp.LpProblem(""Probleme d'affectation"", pulp.LpMinimize)
-# 3. Definir les variables binaires x_ij
-x = pulp.LpVariable.dicts('x', [(e, t) for e in employes for t in taches], 
-                           cat='Binary')
-# 4. Fonction objectif (minimiser le temps)
-prob_tache += pulp.lpSum(temps[(i, j)] * x[(i, j)] 
-                               for i in employes for j in taches), ""temps_Total""
-# 5. Contraintes (chaque employe 1 tache, chaque tache 1 employe)
-for j in taches:
-    prob_tache += pulp.lpSum(x[(i, j)] for i in employes) == 1, f""Capacite{j}""
-for i in employes:
-    prob_tache += pulp.lpSum(x[(i, j)] for j in taches) == 1, f""Demande{i}""
 
-# 6. Resolution et affichage
+# TODO etudiant : construire et resoudre le probleme d'affectation avec PuLP.
+# Etape 1 : creer le LpProblem en minimisation du temps total.
+# Etape 2 : definir les variables binaires x_ij (1 si l'employe i est affecte a la tache j).
+# Etape 3 : ecrire la fonction objectif (somme des temps * x_ij).
+# Etape 4 : ajouter les contraintes (chaque employe a exactement 1 tache, chaque tache a exactement 1 employe).
+# Etape 5 : resoudre puis afficher le temps total minimal et l'affectation employee.
 
-prob_tache.solve()
-
-print(f""Statut : {pulp.LpStatus[prob_tache.status]}"")
-print(f""Temps total minimal : {pulp.value(prob_tache.objective):.2f} heures\n"")
-print(""Affectation des taches :"")
-for i in employes:
-    for j in taches:
-        if pulp.value(x[(i, j)]) > 0.5:
-            print(f""  {i} affecte a {j} (temps = {temps[(i, j)]} heures)"")                   
-
-",,,,,,,,f11a3860596ff8c8,,,,,,,
+result = None  # TODO etudiant : remplacer par la solution PuLP
+print(""Exercice 1 a completer : construire le modele d'affectation"")
+",,,,,,,,764ef827c1baf9d9,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,bee62bc2,markdown,fr,02d76a2c90bc2b2c,"### Exemple guide 2 : Probleme de planification de production
 
 **Enonce** :
@@ -24416,19 +24398,11 @@ Une usine produit 3 produits (P1, P2, P3) sur une periode de 1 mois. Chaque prod
 2. Resoudre avec PuLP
 3. Quel est le profit maximal ?
 4. Quelles sont les ressources critiques (bottlenecks) ?",,,,,,,,02d76a2c90bc2b2c,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,9c1e3f1f,code,fr,3c11fd0ce2ff20e1,"# Exercice 2 : Planification de production
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,9c1e3f1f,code,fr,d437c44c9069a7dd,"# Exercice 2 : Planification de production
 print(""Exercice 2 : Planification de production"")
 print(""="" * 50)
 
-# Solution complete
-# 1. Creer le probleme LpProblem
-# 2. Definir les variables (P1, P2, P3)
-# 3. Fonction objectif (maximiser le profit)
-# 4. Contraintes de ressources
-# 5. Contraintes de demande (min et max)
-# 6. Resolution et affichage
-
-# Indice : utiliser des dictionnaires pour les donnees
+# Donnees fournies.
 produits = ['P1', 'P2', 'P3']
 profit = {'P1': 5, 'P2': 7, 'P3': 8}
 ressources = {
@@ -24440,43 +24414,18 @@ capacite = (100, 120, 80)
 demande_min = {'P1': 10, 'P2': 15, 'P3': 5}
 demande_max = {'P1': 50, 'P2': 40, 'P3': 30}
 
-prob_profit = pulp.LpProblem(""Profit"", pulp.LpMaximize)
-xA = pulp.LpVariable('xA', lowBound=0, cat='Continuous')
-xB = pulp.LpVariable('xB', lowBound=0, cat='Continuous')
-xC = pulp.LpVariable('xC', lowBound=0, cat='Continuous')
+# Indice : utiliser des dictionnaires pour les donnees.
+# TODO etudiant : construire et resoudre le probleme de planification avec PuLP.
+# Etape 1 : creer le LpProblem en maximisation du profit.
+# Etape 2 : definir les variables xA, xB, xC >= 0 (unites produites de chaque produit).
+# Etape 3 : ecrire la fonction objectif (profit = 5*xA + 7*xB + 8*xC).
+# Etape 4 : ajouter les contraintes de demande (min et max) pour chaque produit.
+# Etape 5 : ajouter les contraintes de ressources (3 ressources, capacites 100/120/80).
+# Etape 6 : resoudre puis afficher les quantites a produire et le profit maximal.
 
-prob_profit += xA*5 + xB *7 + xC*8
-
-# Contraintes de demande min
-prob_profit += xA >= 10, ""demande_min_P1""
-prob_profit += xB >= 15, ""demande_min_P2""
-prob_profit += xC >= 5,  ""demande_min_P3""
-
-# Contraintes de demande max
-prob_profit += xA <= 50, ""demande_max_P1""
-prob_profit += xB <= 40, ""demande_max_P2""
-prob_profit += xC <= 30, ""demande_max_P3""
-
-# Contraintes de ressources
-prob_profit += xA*2 + xB*1              <= 100, ""ressource_R1""
-prob_profit += xA   + xB*3 + xC*2      <= 120, ""ressource_R2""
-prob_profit +=        xB*1 + xC*4      <= 80,  ""ressource_R3""
-
-
-prob_profit.solve()
-
-# Affichage des resultats
-print(""Quantites a produire :"")
-print(f""  P1 : {pulp.value(xA):.2f} unites"")
-print(f""  P2 : {pulp.value(xB):.2f} unites"")
-print(f""  P3 : {pulp.value(xC):.2f} unites"")   
-print()
-print(f""Profit maximal : {pulp.value(prob_profit.objective):.2f} euros\n"")
-print(""\nAnalyse des ressources :"")
-for name, constraint in prob_profit.constraints.items():
-    slack = constraint.value()  # 0 = critique, >0 = marge disponible
-    print(f""  {name}: slack = {slack:.2f} {'<-- CRITIQUE' if abs(slack) < 1e-6 else ''}"")
-",,,,,,,,3c11fd0ce2ff20e1,,,,,,,
+result = None  # TODO etudiant : remplacer par la solution PuLP
+print(""Exercice 2 a completer : construire le modele de planification"")
+",,,,,,,,d437c44c9069a7dd,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,4ce08494,markdown,fr,4edb4a0dced67634,"### Exemple : Analyse de sensibilite
 
 **Enonce** :
@@ -24726,3 +24675,2005 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb,1243
 **Series connexes** :
 - [Sudoku-10-ORTools-Python](../../Sudoku/Sudoku-10-ORTools-Python.ipynb) - Constraint Programming
 - [App-10-Portfolio](../Applications/Hybrid/App-10-Portfolio.ipynb) - PL pour la finance",,,,,,,,eea860c8cac44f28,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,a1b2rennes,markdown,fr,f023e5e2084149e9,"### Le piège Greedy : Rennes → Paris (miroir du piège BFS de Search-2)
+
+Le couple **Lille → Toulouse** ci-dessus diverge déjà (~14 %), mais le piège le plus net se voit sur **Rennes → Paris** : c'est le **miroir exact** du trajet **Paris → Rennes** étudié dans le jumeau *Search-2-Uninformed-Csharp* (où BFS préférait Lille et UCS préférait Nantes).
+
+Depuis Rennes, l'heuristique $h(n)$ = distance à vol d'oiseau vers Paris est **plus faible pour Lille** que pour Nantes (Lille est plus proche de Paris). Greedy Best-First, qui ne regarde que $h(n)$, **file vers Lille** — exactement comme le faisait BFS (qui ne regarde que le nombre de sauts). Mais l'arête Rennes → Lille coûte **510 km**, cher. A*, qui équilibre $f = g + h$, **résiste à l'attraction de Lille** et trouve l'optimum via Nantes — comme UCS le faisait sur le même graphe.
+
+> **Lien pedagogique** (Prong B, Epic #3801) : sur le **même graphe** et la **même paire de villes**, la recherche *non informée* (BFS vs UCS) et la recherche *informée* (Greedy vs A*) tombent dans le **même piège géographique** — Lille vs Nantes. BFS et Greedy sont toutes deux « myopes » (l'une au saut, l'autre à la flèche géométrique) ; UCS et A* intègrent le coût réel et évitent le piège.
+",,,,,,,,f023e5e2084149e9,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb,c3d4rennes,code,fr,47efe0f0779cf9fc,"// Le piège Greedy sur Rennes -> Paris (miroir du piège BFS Paris->Rennes du Search-2-Csharp, See #5872).
+var problemRP = new GraphProblem(""Rennes"", ""Paris"", franceGraph);
+Func<string, double> hRennesParis = MakeH(""Paris"");
+
+Console.WriteLine(""Greedy Best-First : Rennes -> Paris"");
+Console.WriteLine(new string('=', 60));
+var resultGreedyRP = GreedyBestFirst(problemRP, hRennesParis, verbose: true);
+Console.WriteLine();
+resultGreedyRP.Display();
+Console.WriteLine();
+
+Console.WriteLine(""A* : Rennes -> Paris"");
+Console.WriteLine(new string('=', 60));
+var resultAStarRP = AStar(problemRP, hRennesParis, verbose: true);
+Console.WriteLine();
+resultAStarRP.Display();
+Console.WriteLine();
+
+// Comparaison cote a cote : Greedy vs A* sur Rennes -> Paris.
+var frRP = CultureInfo.GetCultureInfo(""fr-FR"");
+Console.WriteLine(""Comparaison : Greedy vs A* sur Rennes -> Paris"");
+Console.WriteLine(new string('=', 70));
+Console.WriteLine($""{""Algorithme"",-10} {""Chemin"",-42} {""Cout"",8} {""Sauts"",6} {""Noeuds"",8}"");
+Console.WriteLine(new string('-', 70));
+foreach (var r in new[] { resultGreedyRP, resultAStarRP }) {
+    string chemin = string.Join("" -> "", r.PathStates);
+    if (chemin.Length > 40) chemin = chemin.Substring(0, 37) + ""..."";
+    Console.WriteLine($""{r.Algorithm,-10} {chemin,-42} {r.Cost.ToString(""F0"", frRP),8} {r.SolutionNode.Depth,6} {r.NodesExpanded,8}"");
+}
+Console.WriteLine();
+double diffRP = resultGreedyRP.Cost - resultAStarRP.Cost;
+double pctRP = diffRP / resultAStarRP.Cost * 100.0;
+if (diffRP > 0.5) {
+    Console.WriteLine($""Greedy a trouve un chemin {diffRP.ToString(""F0"", frRP)} km plus long ({pctRP.ToString(""F1"", frRP)}% de surcout)."");
+    Console.WriteLine(""-> Comme BFS sur Paris->Rennes (Search-2), Greedy file vers Lille ; A* (comme UCS) trouve l'optimum via Nantes."");
+} else {
+    Console.WriteLine(""Ici Greedy coincide avec A* (pas de divergence sur ce couple)."");
+}
+",,,,,,,,47efe0f0779cf9fc,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-ea82750b,markdown,fr,5167328680cc84f0,"# Search-5-GeneticAlgorithms-Csharp : Algorithmes Génétiques en C#
+
+**Navigation** : [<< Search-4 (Local Search)](Search-4-LocalSearch.ipynb) | [↑ Série Search (C#)](../README.md) | [Search-6 (Adversarial Search) >>](Search-6-AdversarialSearch.ipynb)
+
+**Jumeau .NET** du notebook Python [Search-5-GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb). Port C# from-scratch (EPIC [#4956](https://github.com/jsboige/CoursIA/issues/4956), prong A [#3801](https://github.com/jsboige/CoursIA/issues/3801) — algorithme pur, aucun framework GA externe : .NET n'ayant pas de framework GA dominant, l'implémentation from-scratch **est** la leçon). Tables texte via `.Display()` (verdict #3436 INTRINSIC : path-leaks SkiaSharp intrinsèques au kernel .NET Interactive).
+
+## Objectifs d'apprentissage
+
+1. **Encoder** un chromosome (binaire OneMax, réel Rastrigin) en C#
+2. **Implémenter** sélection (roulette, tournoi), crossover (1-point, arithmétique), mutation (bit-flip, gaussienne)
+3. **Assembler** une classe `GeneticAlgorithm<TChromosome>` générique réutilisable
+4. **Étudier** la convergence sur OneMax + l'optimisation continue sur Rastrigin
+5. **Mesurer** l'effet de l'élitisme et d'un taux de mutation adaptatif
+
+### Prérequis
+
+- .NET 9.0 + kernel `.net-csharp`
+- Search-4-LocalSearch (notion de paysage d'optimisation)
+
+### Durée estimée : ~1h",,,,,,,,5167328680cc84f0,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-78d21e5d,markdown,fr,6225d93dd81ecde2,"## 1. Introduction (~5 min)
+
+Un **algorithme génétique (GA)** est une métaheuristique d'optimisation inspirée de l'évolution naturelle. Une **population** de **chromosomes** (solutions candidates) évolue sur plusieurs **générations** via :
+
+1. **Sélection** — les individus les plus *aptes* (fitness élevé) ont plus de descendants.
+2. **Crossover** (croisement) — deux parents produisent des enfants combinant leurs gènes.
+3. **Mutation** — perturbation aléatoire, source de diversité et d'exploration.
+
+**Pourquoi les AG ?** Ils excellent sur les espaces de recherche vastes, non-différentiables, multimodaux — là où le gradient est inutilisable (Search-4 a montré les limites du hill-climbing sur les paysages accidentés).",,,,,,,,6225d93dd81ecde2,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-e2091fc1,markdown,fr,df9fd0d2cb7542b5,"## 2. Composants d'un AG (~10 min)
+
+### 2.1 Encodage du chromosome
+
+Le choix de l'encodage conditionne tout. Deux cas canoniques :
+
+| Problème | Encodage | Chromosome C# |
+|----------|----------|---------------|
+| OneMax (maximiser la somme de bits) | binaire | `bool[]` |
+| Rastrigin (minimiser f(x)) | réel | `double[]` |
+
+### 2.2 Opérateurs
+
+Classe GA **générique** paramétrée par le type de gène : `record` immutable pour l'individu + délégués pour chaque opérateur (pattern établi par les jumeaux Search-6/13/14-Csharp).",,,,,,,,df9fd0d2cb7542b5,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-fdca2a4b,code,fr,e879425951c2a9c9,"using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+// Individu : chromosome + fitness calculé
+public record Individu<T>(T Chromosome, double Fitness);
+
+// GA générique : l'utilisateur fournit fitness + 4 opérateurs (délégués)
+public class GeneticAlgorithm<T>
+{
+    private readonly Random _rng;
+    private readonly Func<T,double> _fitness;
+    private readonly Func<Random,T> _randomIndiv;
+    private readonly Func<Random,T,T,(T,T)> _crossover;
+    private readonly Func<Random,T,double,T> _mutate;
+    private readonly Func<Random,Individu<T>[],int> _select;
+    public int PopulationSize { get; }
+    public double MutationRate { get; set; }
+    public bool Elitism { get; set; }
+    public int EliteCount { get; set; } = 1;
+    public List<double> HistoryBest { get; } = new();
+    public List<double> HistoryAvg { get; } = new();
+
+    public GeneticAlgorithm(Func<T,double> fitness, Func<Random,T> randomIndiv,
+        Func<Random,T,T,(T,T)> crossover, Func<Random,T,double,T> mutate,
+        Func<Random,Individu<T>[],int> select,
+        int populationSize, double mutationRate, int seed = 42)
+    { _rng=new(seed); _fitness=fitness; _randomIndiv=randomIndiv; _crossover=crossover;
+      _mutate=mutate; _select=select; PopulationSize=populationSize; MutationRate=mutationRate; }
+
+    public Individu<T>[] Run(int generations)
+    {
+        var pop = Enumerable.Range(0, PopulationSize).Select(_=>Eval(_randomIndiv(_rng))).ToArray();
+        Record(pop);
+        for (int g=0; g<generations; g++) {
+            var next = new List<Individu<T>>();
+            if (Elitism) next.AddRange(pop.OrderByDescending(p=>p.Fitness).Take(EliteCount));
+            while (next.Count < PopulationSize) {
+                int i1=_select(_rng,pop), i2=_select(_rng,pop);
+                var (c1,c2)=_crossover(_rng, pop[i1].Chromosome, pop[i2].Chromosome);
+                next.Add(Eval(_mutate(_rng, c1, MutationRate)));
+                if (next.Count<PopulationSize) next.Add(Eval(_mutate(_rng, c2, MutationRate)));
+            }
+            pop = next.ToArray(); Record(pop);
+        }
+        return pop;
+    }
+    private Individu<T> Eval(T chrom) => new(chrom, _fitness(chrom));
+    private void Record(Individu<T>[] pop) { HistoryBest.Add(pop.Max(p=>p.Fitness)); HistoryAvg.Add(pop.Average(p=>p.Fitness)); }
+}
+
+var sb = new StringBuilder();
+sb.AppendLine(""Classe GeneticAlgorithm<T> chargée — opérateurs (sélection/crossover/mutation) = délégués."");
+sb.ToString().Display();",,,,,,,,e879425951c2a9c9,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-4815cdce,markdown,fr,f50258d86a152cf2,"#### Opérateurs binaires (OneMax)
+
+- **Sélection roulette** : probabilité proportionnelle au fitness ; **tournoi** : meilleur de k tirés au hasard.
+- **Crossover 1-point** : un point de coupure aléatoire.
+- **Mutation bit-flip** : chaque bit inversé avec probabilité `mutationRate`.",,,,,,,,f50258d86a152cf2,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-363f0417,code,fr,006d66b678d0b5b4,"// Opérateurs binaire (OneMax)
+double OneMax(bool[] c) => c.Count(b=>b);
+bool[] RandomBits(Random r) => Enumerable.Range(0,20).Select(_=>r.NextDouble()<0.5).ToArray();
+(bool[],bool[]) Crossover1P(Random r, bool[] a, bool[] b) {
+    int pt = r.Next(1, a.Length);
+    return (a.Take(pt).Concat(b.Skip(pt)).ToArray(), b.Take(pt).Concat(a.Skip(pt)).ToArray());
+}
+bool[] MutateBitFlip(Random r, bool[] c, double rate) {
+    var m=(bool[])c.Clone();
+    for (int i=0;i<m.Length;i++) if (r.NextDouble()<rate) m[i]=!m[i];
+    return m;
+}
+int Roulette(Random r, Individu<bool[]>[] pop) {
+    double min=pop.Min(p=>p.Fitness);
+    double[] w=pop.Select(p=>p.Fitness-min+1e-9).ToArray();
+    double total=w.Sum(), pick=r.NextDouble()*total, acc=0;
+    for (int i=0;i<w.Length;i++){ acc+=w[i]; if(acc>=pick) return i; }
+    return w.Length-1;
+}
+int Tournament(Random r, Individu<bool[]>[] pop, int k=3) {
+    int best=r.Next(pop.Length);
+    for (int i=1;i<k;i++){ int c=r.Next(pop.Length); if(pop[c].Fitness>pop[best].Fitness) best=c; }
+    return best;
+}
+
+var sb = new StringBuilder();
+sb.AppendLine(""Opérateurs binaires (OneMax) chargés :"");
+sb.AppendLine(""  OneMax, RandomBits(L=20), Crossover1P, MutateBitFlip, Roulette, Tournament(k=3)"");
+sb.ToString().Display();",,,,,,,,006d66b678d0b5b4,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-df39f534,markdown,fr,583e58ca6e4ee89a,"## 3. AG from-scratch : OneMax (~10 min)
+
+**OneMax** = maximiser la somme des bits d'un chromosome binaire. Solution optimale triviale (tous les bits à 1), ce qui rend la **convergence** (et non le résultat) l'objet d'étude : un GA sain converge en un nombre de générations prévisible.",,,,,,,,583e58ca6e4ee89a,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-88127a6d,code,fr,08770fec507d60f6,"// OneMax : exécution + convergence (table texte)
+var ga = new GeneticAlgorithm<bool[]>(OneMax, RandomBits, Crossover1P, MutateBitFlip, Roulette,
+            populationSize:100, mutationRate:0.01, seed:42);
+var sw = Stopwatch.StartNew();
+var final = ga.Run(generations:40);
+sw.Stop();
+var best = final.OrderByDescending(p=>p.Fitness).First();
+
+var sb = new StringBuilder();
+sb.AppendLine(""=== OneMax GA (pop=100, 40 générations, taux mutation 0.01) ==="");
+sb.AppendLine($""Meilleur fitness final : {best.Fitness}/20"");
+sb.AppendLine($""Temps : {sw.Elapsed.TotalMilliseconds:F1} ms"");
+sb.AppendLine();
+sb.AppendLine(""Génération | Best | Moyenne"");
+sb.AppendLine(""-----------|------|--------"");
+foreach (var g in new[]{0,5,10,20,30,40})
+    sb.AppendLine($""{g,10} | {ga.HistoryBest[g],4:F0} | {ga.HistoryAvg[g],6:F2}"");
+sb.AppendLine();
+if (best.Fitness >= 19) sb.AppendLine(""Convergence : OneMax résolu (>= 19/20). GA from-scratch fonctionnel."");
+else sb.AppendLine($""Convergence partielle : {best.Fitness}/20 (augmenter générations)."");
+sb.ToString().Display();",,,,,,,,08770fec507d60f6,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-9cf00647,markdown,fr,4b5869d214a3b8ac,"## 4. Optimisation continue : Rastrigin (~8 min)
+
+**Rastrigin** est la fonction-test classique : fortement multimodale (des milliers d'optima locaux), minimum global 0 en x=0. C'est l'anti-OneMax : le gradient mène aux pièges locaux, le GA doit donc **explorer**.
+
+$$f(\mathbf{x}) = 10d + \sum_{i=1}^{d} \left[ x_i^2 - 10\cos(2\pi x_i) \right]$$
+
+On réutilise **la même classe `GeneticAlgorithm<T>`** avec des opérateurs réels (crossover arithmétique + mutation gaussienne). Le Python appelle ça DEAP (§4) ou PyGAD (§5) ; en .NET on le code en ~20 lignes, ce qui **démystifie** le framework.",,,,,,,,4b5869d214a3b8ac,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-eaed0471,code,fr,1a90ee66786d1514,"// Rastrigin : opérateurs réels + exécution
+double Rastrigin(double[] x) {
+    double s = 10.0*x.Length;
+    for (int i=0;i<x.Length;i++) s += x[i]*x[i] - 10.0*Math.Cos(2*Math.PI*x[i]);
+    return s;
+}
+double NegRastrigin(double[] x) => -Rastrigin(x);
+double[] RandomReal(Random r) => Enumerable.Range(0,5).Select(_=>r.NextDouble()*10.24-5.12).ToArray();
+(double[],double[]) CrossoverArith(Random r, double[] a, double[] b) {
+    double alpha=r.NextDouble();
+    return (a.Zip(b,(x,y)=>alpha*x+(1-alpha)*y).ToArray(), a.Zip(b,(x,y)=>(1-alpha)*x+alpha*y).ToArray());
+}
+double[] MutateGauss(Random r, double[] c, double rate, double sigma=0.5) {
+    var m=(double[])c.Clone();
+    for (int i=0;i<m.Length;i++) if (r.NextDouble()<rate)
+        m[i] += sigma*(r.NextDouble()+r.NextDouble()+r.NextDouble()-1.5);
+    for (int i=0;i<m.Length;i++) m[i]=Math.Max(-5.12, Math.Min(5.12, m[i]));
+    return m;
+}
+int RouletteReal(Random r, Individu<double[]>[] pop) {
+    double min=pop.Min(p=>p.Fitness);
+    double[] w=pop.Select(p=>p.Fitness-min+1e-9).ToArray();
+    double total=w.Sum(), pick=r.NextDouble()*total, acc=0;
+    for (int i=0;i<w.Length;i++){ acc+=w[i]; if(acc>=pick) return i; }
+    return w.Length-1;
+}
+
+var gaR = new GeneticAlgorithm<double[]>(NegRastrigin, RandomReal, CrossoverArith,
+            (rng,c,rate)=>MutateGauss(rng,c,rate,0.5), RouletteReal,
+            populationSize:200, mutationRate:0.1, seed:7);
+var swR = Stopwatch.StartNew();
+var finalR = gaR.Run(generations:100);
+swR.Stop();
+var bestR = finalR.OrderByDescending(p=>p.Fitness).First();
+double fRastrigin = Rastrigin(bestR.Chromosome);
+
+var sb = new StringBuilder();
+sb.AppendLine(""=== Rastrigin GA (d=5, pop=200, 100 générations) ==="");
+sb.AppendLine($""Meilleur f(x) trouvé : {fRastrigin:F4}  (optimum global = 0.0000)"");
+sb.AppendLine($""Temps : {swR.Elapsed.TotalMilliseconds:F1} ms"");
+sb.AppendLine();
+sb.AppendLine(""Génération | f(x) meilleur | Moyenne fitness"");
+sb.AppendLine(""-----------|---------------|----------------"");
+foreach (var g in new[]{0,20,40,60,80,100})
+    sb.AppendLine($""{g,10} | {-gaR.HistoryBest[g],13:F4} | {gaR.HistoryAvg[g],14:F2}"");
+sb.AppendLine();
+string verdict = fRastrigin<1.0 ? ""Très proche de l'optimum global (< 1.0)."" :
+                 fRastrigin<5.0 ? ""Bon résultat (< 5.0) — optimum local évité."" :
+                                  ""Piégé dans un optimum local (Rastrigin est dur)."";
+sb.AppendLine($""Verdict : {verdict}"");
+sb.AppendLine(""Rastrigin illustre le rôle-clé de la MUTATION (exploration) vs OneMax (exploitation)."");
+sb.ToString().Display();",,,,,,,,1a90ee66786d1514,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-7d516ae4,markdown,fr,885959f0c76dd4d6,"## 5. Concepts avancés (~6 min)
+
+### 5.1 Élitisme
+
+L'**élitisme** préserve les N meilleurs individus d'une génération à la suivante. Il garantit que le meilleur jamais trouvé ne se dégrade jamais — au prix d'un risque accru de convergence prématurée.",,,,,,,,885959f0c76dd4d6,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-0ab1d10a,code,fr,93f4efa84223a02d,"// Effet de l'élitisme sur OneMax
+var sb = new StringBuilder();
+sb.AppendLine(""=== Élitisme : avec vs sans (OneMax, 30 générations) ==="");
+sb.AppendLine();
+sb.AppendLine(""Config        | Best final | Génération convergence (>=19)"");
+sb.AppendLine(""-------------|------------|------------------------------"");
+foreach (var (elite, label) in new[] { (false,""Sans élite  ""), (true,""Avec élite "") }) {
+    int convGen = -1;
+    var g = new GeneticAlgorithm<bool[]>(OneMax, RandomBits, Crossover1P, MutateBitFlip, Roulette,
+              populationSize:100, mutationRate:0.01, seed:42){ Elitism=elite, EliteCount=1 };
+    g.Run(30);
+    for (int i=0;i<g.HistoryBest.Count;i++) if (g.HistoryBest[i]>=19){ convGen=i; break; }
+    sb.AppendLine($""{label} | {g.HistoryBest.Last(),10:F0} | {convGen}"");
+}
+sb.AppendLine();
+sb.AppendLine(""L'élitisme accélère la convergence mais peut réduire la diversité."");
+sb.AppendLine(""Compromis exploration/exploitation : pas de 'bon' réglage universel (No-Free-Lunch)."");
+sb.ToString().Display();",,,,,,,,93f4efa84223a02d,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-a24080e6,markdown,fr,b34e368910ea072a,"### 5.2 Taux de mutation adaptatif
+
+Plutôt qu'un taux fixe, on le fait **décroître** avec les générations : forte exploration au début, raffinement à la fin.",,,,,,,,b34e368910ea072a,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-36594784,code,fr,13e0ac86ebbed344,"// Taux de mutation adaptatif : décroissance linéaire
+double AdaptiveRate(int gen, int maxGen, double rMax=0.1, double rMin=0.001) {
+    double t = (double)gen/maxGen;
+    return rMax - (rMax-rMin)*t;
+}
+var sb = new StringBuilder();
+sb.AppendLine(""=== Taux de mutation adaptatif (décroissance linéaire) ==="");
+sb.AppendLine();
+sb.AppendLine(""Génération | Taux mutation"");
+sb.AppendLine(""-----------|--------------"");
+foreach (var g in new[]{0,25,50,75,100})
+    sb.AppendLine($""{g,10} | {AdaptiveRate(g,100),12:F4}"");
+sb.AppendLine();
+sb.AppendLine(""Intuition : on explore largement au début (~0.1), on raffine à la fin (~0.001)."");
+sb.AppendLine(""Exercice 3 : branchez AdaptiveRate dans GeneticAlgorithm.Run (voir ci-dessous)."");
+sb.ToString().Display();",,,,,,,,13e0ac86ebbed344,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-dbb056a3,markdown,fr,193a84a4059488c4,"## Synthèse et lien avec les Applications
+
+Les GA de cette feuille sont la **brique** derrière plusieurs notebooks d'application :
+- **App-13 TSP-Metaheuristiques** : GA + 2-opt sur le voyageur de commerce.
+- **App-17 VRP-Logistics** : optimisation de tournées de livraison.
+- **App-18 HyperparameterTuning** : GA pour explorer l'espace d'hyperparamètres.
+
+Le pattern `GeneticAlgorithm<T>` générique est conçu pour être **réutilisé** : il suffit de fournir fitness + 4 opérateurs adaptés au problème.
+
+## Exercices
+
+**Exercice 1 — Tournoi vs roulette.** Remplacez la sélection roulette par le tournoi (`Tournament`, k=3) sur OneMax. Comparez la génération de convergence (>=19). Quelle sélection converge plus vite ? Pourquoi ?
+
+**Exercice 2 — Effet de la taille de population.** Faites varier `PopulationSize` ∈ {20, 50, 100, 200} sur Rastrigin (mêmes générations). Affichez (table texte) le meilleur f(x) final. Y a-t-il un rendement décroissant ?
+
+**Exercice 3 — Mutation adaptative.** Modifiez `GeneticAlgorithm<T>.Run` pour que le taux de mutation passe à `AdaptiveRate(g, generations)` à chaque génération. Relancez OneMax. Comparez la trajectoire de convergence au taux fixe 0.01.",,,,,,,,193a84a4059488c4,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb,cell-69ee585e,markdown,fr,eaa4622427096ed2,"---
+
+## Conclusion
+
+Vous avez implémenté **from-scratch** un algorithme génétique générique en C#, validé sur deux problèmes-test opposés (OneMax binaire, Rastrigin continu), et étudié deux leviers-clés (élitisme, mutation adaptatif). Leçon centrale : un GA n'est pas une boîte noire — c'est **sélection + crossover + mutation** assemblés sur une population, et .NET n'a pas besoin de framework GA pour l'enseigner.
+
+**Navigation** : [<< Search-4 Local Search](Search-4-LocalSearch.ipynb) | [↑ Série Search (C#)](../README.md) | [Search-6 Adversarial Search >>](Search-6-AdversarialSearch.ipynb)
+
+### Références
+
+- Holland, J.H. (1975). *Adaptation in Natural and Artificial Systems*.
+- Goldberg, D.E. (1989). *Genetic Algorithms in Search, Optimization and Machine Learning*.
+- Jumeau Python : [Search-5-GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb) (DEAP + PyGAD).",,,,,,,,eaa4622427096ed2,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb,cell-8cbc45fa,markdown,fr,cfcf21dd16579eb2,"## 12. Comparaison quantitative GA vs solveurs exacts sur TSP (Prong B #3801)
+
+L'exemple resolu 1 (cellule 51) a execute l'algorithme genetique (GA) sur le **probleme du voyageur de commerce (TSP)** avec **8 villes**, obtenant une distance totale de **28.73** (route optimale par coIncidence, le GA trouve l'optimum sur ce petit exemple). Pour positionner la famille des **algorithmes genetiques** face aux **solveurs exacts** sur le meme probleme, voici une **comparaison quantitative** avec les chiffres REELS publies dans la cellule 51 (GA, PyGAD) et une nouvelle cellule de calcul exact (brute force exhaustif O(n!), limite aux petites instances).
+
+### Tableau comparatif (chiffres verifies, sources citees)
+
+| Solveur | TSP 8 villes | TSP 9 villes | TSP 10 villes | Garantie optimalite |
+|---------|--------------|--------------|---------------|---------------------|
+| **Algorithme Genetique** (`ga_tsp`, cell 51 + NEW) | 28.73, 1164 ms | 31.66, 1308 ms | 42.11, 1354 ms | Non (heuristique, depend seed) |
+| **Brute force exact** (NEW, Held-Karp DP / O(n!)) | 28.73, 9 ms | 31.66, 92 ms | 36.99, 1008 ms | Oui (exhaustif) |
+| **Gap GA / Exact** (cellule NEW) | 1.00x (optimal trouve) | 1.00x (optimal trouve) | **~1.14x (sous-optimal)** | -- |
+
+### Observations (Prong B illustre)
+
+1. **Sur petites instances (8-9 villes), le GA trouve l'optimum** par chance combinatoire : l'espace de recherche reste suffisamment petit pour que la recherche genetique converge vers la solution exacte. C'est un **cas degeneré** ou la discrimination GA/exact est invisible.
+2. **A 10 villes, le GA commence a degrader** : gap de 14% (42.11 vs 36.99) = demonstration quantitative de l'inadequation progressive du GA quand l'espace de recherche grandit exponentiellement. Le brute force exact O(n!) reste faisable (1 sec) et trouve l'optimum.
+3. **Garantie d'optimalite** : le brute force est **complet** (visite tous les chemins), le GA est **heuristique** (depend de la population initiale, du seed, des operateurs). Pour des applications critiques (logistique, circuits imprimes, planification de tournees), un solveur exact ou une heuristique de plus haute qualite (LKH, OR-Tools) est preferable.
+4. **Valeur pedagogique du GA** : illustre la **famille des methodes evolutionnistes** (population + selection + variation) applicable quand l'espace est trop grand pour l'exhaustif (TSP > 15-20 villes, O(n!) ou O(2^n n^2) intractable). Le GA brille sur des problemes ou une **bonne solution rapide** suffit (temps reel, approximative search).
+
+> **Note methodologique** : tous les chiffres GA cites proviennent de la cellule 51 (PyGAD, seed=42, pop=100, generations=300) ou de la nouvelle cellule ci-dessous. Le brute force est execute en Python pur sur les memes coordonnees de villes (8 premieres + 1, 2, 3 villes ajoutees pour 9 et 10). Aucune valeur fabriquee.
+",,,,,,,,cfcf21dd16579eb2,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb,cell-d5ef7329,code,fr,c07fd05c49cb1a6f,"# Comparaison quantitative GA vs solveurs exacts sur TSP (Prong B #3801)
+# Cf. cellule markdown precedente pour le contexte et le tableau comparatif.
+# Chiffres GA de la cellule 51 (PyGAD TSP 8 villes, seed=42, pop=100, gen=300).
+# Meme coordonnees de villes que cell 51, etendues pour 9 et 10 villes.
+
+import numpy as np
+import time
+from itertools import permutations
+
+# Coordonnees de base (8 villes, identiques a cell 51)
+BASE_CITIES = np.array([
+    [0, 0], [1, 5], [5, 2], [7, 8],
+    [8, 1], [3, 6], [6, 5], [2, 3]
+], dtype=float)
+
+
+def gen_cities(n_cities: int) -> np.ndarray:
+    """"""Genere n_cities en concatenant BASE_CITIES + duplique decalee.""""""
+    if n_cities <= len(BASE_CITIES):
+        return BASE_CITIES[:n_cities]
+    extra_needed = n_cities - len(BASE_CITIES)
+    extras = [BASE_CITIES + np.array([k * 10, k * 5]) for k in range(1, extra_needed + 1)]
+    return np.concatenate([BASE_CITIES] + extras, axis=0)[:n_cities]
+
+
+def brute_tsp(cities: np.ndarray) -> tuple:
+    """"""Solveur exact TSP par brute force exhaustif (O(n!)). Returns (best_dist, elapsed_ms).""""""
+    n = len(cities)
+    diffs = cities[:, None, :] - cities[None, :, :]
+    DM = np.sqrt((diffs ** 2).sum(axis=2))
+    best = float(""inf"")
+    t0 = time.perf_counter()
+    for perm in permutations(range(1, n)):
+        route = (0,) + perm
+        d = sum(DM[route[i], route[(i + 1) % n]] for i in range(n))
+        if d < best:
+            best = d
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    return best, elapsed_ms
+
+
+# Resultats GA (cell 51 + simulation dans la cellule NEW : seed=42, pop=100, gen=300)
+# Source: cf cellule 51 pour 8 villes (28.73). 9 et 10 : re-execution pour coherence.
+import pygad
+
+def ga_tsp_replicate(cities: np.ndarray, n_gen: int = 300, pop: int = 100, seed: int = 42) -> tuple:
+    """"""Replique la cellule 51 pour 9 et 10 villes (memes hyperparametres).""""""
+    n = len(cities)
+    diffs = cities[:, None, :] - cities[None, :, :]
+    DM = np.sqrt((diffs ** 2).sum(axis=2))
+
+    def fitness(ga_inst, sol, _):
+        r = np.asarray(sol, dtype=int)
+        return -DM[r, np.roll(r, -1)].sum()
+
+    def pmx(parents, sz, _ga):
+        out = np.empty(sz, dtype=int)
+        for k in range(sz[0]):
+            p1, p2 = (
+                parents[np.random.randint(0, len(parents))].astype(int),
+                parents[np.random.randint(0, len(parents))].astype(int),
+            )
+            cx1, cx2 = sorted(np.random.choice(sz[1], 2, replace=False))
+            child = np.full(sz[1], -1, dtype=int)
+            child[cx1:cx2 + 1] = p1[cx1:cx2 + 1]
+            mapping = {int(p1[i]): int(p2[i]) for i in range(cx1, cx2 + 1)}
+            seg = set(int(x) for x in child[cx1:cx2 + 1])
+            for i in range(sz[1]):
+                if cx1 <= i <= cx2:
+                    continue
+                v = int(p2[i])
+                for _ in range(sz[1]):
+                    if v not in seg:
+                        break
+                    v = mapping[v]
+                child[i] = v
+            out[k] = child
+        return out
+
+    init_pop = [list(np.random.permutation(n)) for _ in range(pop)]
+    t0 = time.perf_counter()
+    ga = pygad.GA(
+        num_generations=n_gen,
+        num_parents_mating=20,
+        fitness_func=fitness,
+        initial_population=init_pop,
+        parent_selection_type=""tournament"",
+        K_tournament=3,
+        crossover_type=pmx,
+        mutation_type=""swap"",
+        mutation_percent_genes=30,
+        keep_elitism=1,
+        random_seed=seed,
+        suppress_warnings=True,
+        save_solutions=False,
+        save_best_solutions=False,
+    )
+    ga.run()
+    _, bf, _ = ga.best_solution()
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    return -bf, elapsed_ms
+
+
+# Calcul sur 3 instances (8, 9, 10 villes)
+np.random.seed(42)
+results = []
+for n in [8, 9, 10]:
+    cities = gen_cities(n)
+    # Brute force exact
+    exact_dist, exact_ms = brute_tsp(cities)
+    # GA (replique pour 9 et 10 ; pour 8 on garde la valeur cell 51)
+    if n == 8:
+        ga_dist, ga_ms = 28.73, 1164.0  # cell 51 verbatim
+    else:
+        ga_dist, ga_ms = ga_tsp_replicate(cities)
+    gap = ga_dist / exact_dist
+    results.append((n, exact_dist, exact_ms, ga_dist, ga_ms, gap))
+
+# Affichage pedagogique
+print(""=== Comparaison GA vs Brute Force exact sur TSP (seed=42) ==="")
+print()
+print(f""{'Villes':>7} {'Exact dist':>12} {'Exact ms':>10} {'GA dist':>10} {'GA ms':>8} {'Gap GA/Exact':>14}"")
+print(""-"" * 72)
+for n, ed, em, gd, gm, gap in results:
+    print(f""{n:>7d} {ed:>12.2f} {em:>10.0f} {gd:>10.2f} {gm:>8.0f} {gap:>13.2f}x"")
+
+print()
+print(""Observations Prong B #3801 :"")
+print(""- 8 villes  : GA = exact (28.73, optimal) ; ecart runtime GA 1164ms vs exact 9ms (~129x)"")
+print(""- 9 villes  : GA = exact (31.66, optimal) ; ecart runtime GA 1308ms vs exact 92ms (~14x)"")
+print(""- 10 villes : GA sous-optimal (42.11 vs 36.99, gap ~1.14x) ; runtime comparable ~1.3x"")
+print()
+print(""Conclusion : GA degenerescent sur grandes instances (n>=10). Solveurs exacts ou"")
+print(""heuristiques specialisees (LKH, OR-Tools) sont preferables en production."")
+",,,,,,,,c07fd05c49cb1a6f,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb,cell-5cf504d4,markdown,fr,8a1190b6471b3322,"## Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)
+
+### Contexte
+
+Le tableau ci-dessus compare l'algorithme genetique (heuristique, ~1.1-1.4 sec) au brute force exact (solveur exhaustif, 9-1008 ms) sur 3 instances TSP de 8, 9 et 10 villes. Pour faire toucher du doigt le **ratio de cout** et sa **non-linearite avec la taille de l'instance**, on veut le chiffrer.
+
+### Enonce
+
+A partir des **chiffres reels** du tableau comparatif (cellule precedente) :
+
+1. Calculer le ratio `temps_GA / temps_exact` pour chacune des 3 instances (8, 9, 10 villes).
+2. Calculer le ratio `qualite_GA / qualite_exact` (gap) : observe-t-on une degradation lineaire, polynomiale ou autre ?
+3. Conclure sur la **position du GA dans la hierarchie** : efficace / equivalente / nettement inferieure / sans commune mesure, sur le cas TSP.
+
+### Indication
+
+- `ratio_runtime_X = t_ga_X_ms / t_exact_X_ms`
+- `gap_X = dist_ga_X / dist_exact_X` (1.0 = optimal, >1.0 = sous-optimal)
+- Si `gap_10 / gap_8 > 1.10`, on a une **degradation visible** -> methode inadaptee au scaling
+- Suggestion : `conclude_prong_b(runtime_ratios, gaps)` retourne une categorie parmi `""lineaire""`, `""polynomial""`, `""exponentiel""`, `""autre""`
+
+### Solution (a completer par l'etudiant)
+
+```
+ratio_runtime_8  = None  # TODO etudiant
+ratio_runtime_9  = None  # TODO etudiant
+ratio_runtime_10 = None  # TODO etudiant
+gap_8, gap_9, gap_10 = None, None, None  # TODO etudiant
+conclusion = None  # TODO etudiant
+```
+",,,,,,,,8a1190b6471b3322,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb,cell-a7df56f9,code,fr,45a5f71a50bcb9aa,"# Exercice : Estimer le ratio GA / solveur-exact (Prong B reflexif)
+# Cf. cellule markdown precedente pour l'enonce et les indications.
+
+# Chiffres reels tires du tableau comparatif (cellule du dessus)
+EXACT_DIST = (28.73, 31.66, 36.99)   # Brute force exact (NEW, cell 72) : 8 / 9 / 10 villes
+EXACT_MS   = (9, 106, 996)           # Runtime exact (cell 72 reel) : 8 / 9 / 10 villes
+GA_DIST    = (28.73, 35.75, 41.71)   # GA (cell 51 verbatim + cell 72 reel) : 8 / 9 / 10 villes
+GA_MS      = (1164, 1539, 1473)      # Runtime GA (cell 72 reel) : 8 / 9 / 10 villes
+N_VILLES   = (8, 9, 10)
+
+
+def compute_ratio_runtime(idx: int) -> float:
+    """"""Calcule le ratio temps_GA / temps_exact pour l'instance d'index donne.
+
+    Returns:
+        ratio (float) ou None si pas complete.
+    """"""
+    return None  # TODO etudiant
+
+
+def compute_gap(idx: int) -> float:
+    """"""Calcule le gap qualite dist_GA / dist_exact pour l'instance d'index donne.
+
+    Returns:
+        gap (float, 1.0 = optimal) ou None si pas complete.
+    """"""
+    return None  # TODO etudiant
+
+
+def conclude_prong_b(runtime_ratios: tuple, gaps: tuple) -> str:
+    """"""Conclut sur la croissance du ratio et du gap avec la taille de l'instance.
+
+    Returns:
+        ""lineaire"", ""polynomial"", ""exponentiel"", ou ""autre"".
+    """"""
+    return None  # TODO etudiant
+
+
+# Affichage pedagogique (fonctionne meme si l'etudiant n'a pas complete)
+r1, r2, r3 = (compute_ratio_runtime(i) for i in range(3))
+g1, g2, g3 = (compute_gap(i) for i in range(3))
+all_present = all(v is not None for v in (r1, r2, r3, g1, g2, g3))
+conclusion = conclude_prong_b((r1, r2, r3), (g1, g2, g3)) if all_present else None
+
+print(""=== Estimation du ratio GA / solveur-exact (Prong B #3801) ==="")
+print()
+print(f""{'Villes':>7} {'Runtime GA ms':>14} {'Runtime Exact ms':>17} {'Ratio GA/Exact':>16} {'Gap GA/Exact':>14}"")
+print(""-"" * 78)
+for i, (n, gm, em, gd, ed) in enumerate(zip(N_VILLES, GA_MS, EXACT_MS, GA_DIST, EXACT_DIST)):
+    r = (r1, r2, r3)[i]
+    g = (g1, g2, g3)[i]
+    r_str = f""{r:.1f}x"" if isinstance(r, (int, float)) else str(r)
+    g_str = f""{g:.2f}x"" if isinstance(g, (int, float)) else str(g)
+    print(f""{n:>7d} {gm:>14.0f} {em:>17.0f} {r_str:>16} {g_str:>14}"")
+
+print()
+print(f""Gap croissance 10 vs 8 : N/A (a completer)"")
+print(f""Conclusion Prong B     : {conclusion}"")
+print()
+if r1 is None:
+    print("">>> Exercice a completer : implementer compute_ratio_runtime(), compute_gap() et conclude_prong_b()"")
+",,,,,,,,45a5f71a50bcb9aa,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb,cell-4d2aa687,markdown,fr,1655050a54611479,"### References citees dans la section 12 (chiffres verifies)
+
+- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (cell 51 — exemple resolu TSP 8 villes, GA via PyGAD)
+- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb` (NEW — brute force exact + GA replicate pour 9 et 10 villes)
+
+### Liens transverses (autres solveurs pour Prong B)
+
+- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb` (LP relaxation + branch-and-bound)
+- `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb` (MEALPy : PSO, ABC, SA, BRO)
+- `MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb` (CSP/OR-Tools Choco)
+
+> **Note pedagogique** : les ratios GA/exact (gap 1.0x a 8-9 villes puis 1.14x a 10 villes) demontrent que **l'algorithme genetique devient sous-optimal quand l'espace de recherche grandit**, malgre sa richesse theorique. Cf. Section 7 de `Sudoku-3-Genetic-Python.ipynb` (ratio GA/OR-Tools ~700x sur Easy) et Section 11 de `Sudoku-4-SimulatedAnnealing-Python.ipynb` (ratio SA/Backtracking ~24 154x sur Easy) pour des demonstrations equivalentes sur d'autres solveurs heuristiques vs exacts.
+",,,,,,,,1655050a54611479,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-02cf00de,markdown,fr,26b4672d2d029db1,"# Search-7-MCTS-And-Beyond (C#) : Monte Carlo Tree Search et Extensions
+
+**Navigation** : [<< Recherche adversariale (C#)](Search-6-AdversarialSearch-Csharp.ipynb) | [Index](../README.md) | [Version Python](Search-7-MCTS-And-Beyond.ipynb) | [Dancing Links >>](Search-8-DancingLinks.ipynb)
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous saurez :
+1. **Comprendre** les limites de Minimax et pourquoi MCTS a revolutionne les jeux
+2. **Implementer** l'algorithme MCTS avec UCB1 en C#
+3. **Comparer** MCTS vs Minimax sur differents types de jeux
+4. **Explorer** les approches hybrides (AlphaGo, AlphaZero)
+5. **Jouer** avec le parametre d'exploration et la convergence
+
+### Prerequis
+- Notebook Search-6-Csharp (AdversarialSearch, Minimax, Alpha-Beta)
+- Bases de probabilites et statistiques
+- Bases de C# : classes, generiques, LINQ
+
+> **Jumeau .NET** du notebook Python [Search-7-MCTS-And-Beyond.ipynb](Search-7-MCTS-And-Beyond.ipynb). Meme pedagogie, implementation C# idiome. Les graphiques matplotlib sont remplaces par des tables texte (le kernel .NET Interactive fuiterait des chemins ScottPlot/SkiaSharp, verdict INTRINSIC #3436).
+
+### Duree estimee : 90 minutes
+",,,,,,,,26b4672d2d029db1,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-72246cc9,code,fr,5fd028f74c048b56,"// Cellule 1 : Environnement + interface du jeu (somme nulle)
+using System.Diagnostics;
+using System.Globalization;
+
+// Contrat commun a tous les jeux a deux joueurs, somme nulle, tour a tour.
+// TAction est fixe a int (TicTacToe = indice 0-8, Nim = 1-3, Connect-4 = colonne 0-6).
+public interface IJeuSommeNulle<TEtat>
+{
+    TEtat EtatInitial();
+    string Joueur(TEtat etat);                  // ""MAX"" ou ""MIN""
+    List<int> Actions(TEtat etat);
+    TEtat Resultat(TEtat etat, int action);
+    bool EstTerminal(TEtat etat);
+    double Utilite(TEtat etat, string joueur);  // +1 victoire, -1 defaite, 0 nul
+}
+
+Console.WriteLine(""Environnement pret pour MCTS (C# / .NET Interactive)."");",,,,,,,,5fd028f74c048b56,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-86c3a6f4,markdown,fr,1e25a455fbe08769,"## 1. Limites de Minimax
+
+### Pourquoi Minimax ne suffit pas
+
+L'algorithme Minimax avec Alpha-Beta fonctionne bien pour les jeux simples, mais rencontre des limites :
+
+1. **Explosion combinatoire** : Aux echecs, meme avec Alpha-Beta, on ne peut explorer que 6-8 demi-coups en profondeur
+2. **Fonction d'evaluation** : Necessite une expertise humaine pour concevoir une bonne heuristique
+3. **Horizon effect** : Des evenements importants au-dela de la profondeur sont ignores
+
+### La revolution AlphaGo (2016)
+
+AlphaGo a battu Lee Sedol (champion du monde de Go) en utilisant :
+- **MCTS** pour la recherche
+- **Reseaux de neurones** pour l'evaluation (policy + value networks)
+
+MCTS permet d'explorer intelligemment sans fonction d'evaluation experte !
+
+> *Ancres savantes -- von Neumann (1928),Zur Theorie der Gesellschaftsspiele, Math. Annalen 100:295-320 (theoreme minimax) ; Kocsis & Szepesvari (2006), Bandit Based Monte-Carlo Planning, ECML, LNCS 4212:282-293 (UCT = MCTS + UCB1) ; Silver et al. (2016), Mastering the game of Go with deep neural networks and tree search, Nature 529:484-489 (AlphaGo) ; Silver et al. (2017), Mastering the game of Go without human knowledge, Nature 550:354-359 (AlphaGo Zero) ; Browne et al. (2012), A Survey of Monte Carlo Tree Search Methods, IEEE TCIAIG 4(1):1-43.*
+",,,,,,,,1e25a455fbe08769,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-a9ab6457,markdown,fr,15235c654be47722,"## 2. L'Algorithme MCTS
+
+### Principe
+
+**Monte Carlo Tree Search** construit progressivement un arbre de recherche en :
+1. **Selection** : Traverser l'arbre avec UCB1 pour equilibrer exploration/exploitation
+2. **Expansion** : Ajouter un nouveau noeud a l'arbre
+3. **Simulation** : Jouer une partie aleatoire jusqu'a la fin (rollout)
+4. **Backpropagation** : Remonter le resultat dans l'arbre
+
+### UCB1 (Upper Confidence Bound)
+
+```
+UCB1 = W/N + c * sqrt(ln(N_parent) / N)
+```
+
+- **W/N** : Taux de victoire (exploitation)
+- **c * sqrt(...)** : Terme d'exploration (c = 1.41 = sqrt(2) typiquement)
+- **N** : Nombre de visites du noeud ; **N_parent** : visites du parent
+",,,,,,,,15235c654be47722,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-0615afb3,code,fr,005336b8a75ba77f,"// Cellule 4 : Noeud de l'arbre MCTS (UCB1, selection, expansion)
+public class NoeudMCTS<TEtat>
+{
+    public TEtat Etat { get; }
+    public NoeudMCTS<TEtat>? Parent { get; }
+    public int Action { get; }                         // coup qui a mene a cet etat (-1 = racine)
+    public Dictionary<int, NoeudMCTS<TEtat>> Enfants { get; } = new();
+    public int Visites { get; set; } = 0;
+    public double Victoires { get; set; } = 0.0;
+    public List<int>? ActionsNonExplorees { get; set; } // lazy a la premiere expansion
+
+    public NoeudMCTS(TEtat etat, NoeudMCTS<TEtat>? parent = null, int action = -1)
+    { Etat = etat; Parent = parent; Action = action; }
+
+    // Convention UCT ""moved-into"" : Victoires/Visites est du point de vue du joueur qui a
+    // DECIDE le coup vers ce noeud (voir Backpropagation dans MCTS<T>). Tous les enfants
+    // d'un meme parent etant evalues du point de vue de ce parent, MeilleurEnfantUcb1
+    // (max) selectionne bien le meilleur coup pour le joueur qui decide.
+
+    // Score UCB1 : exploitation (W/N) + exploration (c * sqrt(ln(N_parent)/N))
+    public double Ucb1(double c = 1.41)
+    {
+        if (Visites == 0) return double.PositiveInfinity;
+        double exploitation = Victoires / Visites;
+        double exploration = c * Math.Sqrt(Math.Log(Parent!.Visites) / Visites);
+        return exploitation + exploration;
+    }
+
+    public NoeudMCTS<TEtat> MeilleurEnfantUcb1(double c = 1.41)
+        => Enfants.Values.MaxBy(n => n.Ucb1(c))!;
+
+    public NoeudMCTS<TEtat> MeilleurEnfantVisites()
+        => Enfants.Values.MaxBy(n => n.Visites)!;
+
+    public bool EstFullyExpanded(IJeuSommeNulle<TEtat> jeu)
+    {
+        ActionsNonExplorees ??= jeu.Actions(Etat);
+        return ActionsNonExplorees.Count == 0;
+    }
+
+    public bool EstTerminal(IJeuSommeNulle<TEtat> jeu) => jeu.EstTerminal(Etat);
+}
+
+Console.WriteLine(""Classe NoeudMCTS<T> definie (UCB1, selection, expansion)."");",,,,,,,,005336b8a75ba77f,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-bb81de6f,markdown,fr,c1b308c8f4ee1efc,"Implementation de la classe MCTS avec selection UCB1, expansion, simulation (rollout aleatoire) et retropropagation.",,,,,,,,c1b308c8f4ee1efc,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-fd4246b3,code,fr,819d8fc1624c0e40,"// Cellule 6 : MCTS<T> -- selection (UCB1), expansion, simulation (rollout), backpropagation
+public class MCTS<TEtat>
+{
+    private readonly IJeuSommeNulle<TEtat> _jeu;
+    private readonly double _c;
+    private readonly Random _rng;
+    public Dictionary<string, int> Stats { get; } = new() { [""selections""]=0, [""expansions""]=0, [""simulations""]=0, [""backprops""]=0 };
+
+    public MCTS(IJeuSommeNulle<TEtat> jeu, double c = 1.41, int? seed = null)
+    { _jeu = jeu; _c = c; _rng = seed.HasValue ? new Random(seed.Value) : new Random(); }
+
+    // Execute MCTS depuis l'etat donne ; retourne (meilleure action, valeur estimee).
+    public (int Action, double Valeur) Recherche(TEtat etat, int iterations = 1000)
+    {
+        var racine = new NoeudMCTS<TEtat>(etat);
+        for (int i = 0; i < iterations; i++)
+        {
+            var noeud = Selection(racine);
+            double resultat = Simulation(noeud);
+            Backpropagation(noeud, resultat);
+        }
+        var meilleur = racine.MeilleurEnfantVisites();
+        double valeur = meilleur.Visites > 0 ? meilleur.Victoires / meilleur.Visites : 0;
+        return (meilleur.Action, valeur);
+    }
+
+    // Variante qui expose aussi le nombre de visites du coup choisi (sert au benchmark de c).
+    public (int Action, int Visites) RechercheAvecVisites(TEtat etat, int iterations)
+    {
+        var racine = new NoeudMCTS<TEtat>(etat);
+        for (int i = 0; i < iterations; i++)
+        {
+            var noeud = Selection(racine);
+            double resultat = Simulation(noeud);
+            Backpropagation(noeud, resultat);
+        }
+        var meilleur = racine.MeilleurEnfantVisites();
+        return (meilleur.Action, meilleur.Visites);
+    }
+
+    private NoeudMCTS<TEtat> Selection(NoeudMCTS<TEtat> noeud)
+    {
+        Stats[""selections""]++;
+        while (!noeud.EstTerminal(_jeu))
+        {
+            if (!noeud.EstFullyExpanded(_jeu)) return Expansion(noeud);
+            noeud = noeud.MeilleurEnfantUcb1(_c);
+        }
+        return noeud;
+    }
+
+    private NoeudMCTS<TEtat> Expansion(NoeudMCTS<TEtat> noeud)
+    {
+        Stats[""expansions""]++;
+        noeud.ActionsNonExplorees ??= _jeu.Actions(noeud.Etat);
+        int idx = noeud.ActionsNonExplorees.Count - 1;
+        int action = noeud.ActionsNonExplorees[idx];     // pop (dernier element)
+        noeud.ActionsNonExplorees.RemoveAt(idx);
+        TEtat nouvelEtat = _jeu.Resultat(noeud.Etat, action);
+        var enfant = new NoeudMCTS<TEtat>(nouvelEtat, noeud, action);
+        noeud.Enfants[action] = enfant;
+        return enfant;
+    }
+
+    // Rollout aleatoire depuis le noeud jusqu'a un etat terminal.
+    private double Simulation(NoeudMCTS<TEtat> noeud)
+    {
+        Stats[""simulations""]++;
+        TEtat etat = noeud.Etat;
+        // Le joueur MAX = celui qui devait jouer a l'etat parent (ou MAX a la racine).
+        string joueurMaxOriginal = noeud.Parent != null ? _jeu.Joueur(noeud.Parent.Etat) : ""MAX"";
+        while (!_jeu.EstTerminal(etat))
+        {
+            var actions = _jeu.Actions(etat);
+            int action = actions[_rng.Next(actions.Count)];
+            etat = _jeu.Resultat(etat, action);
+        }
+        return _jeu.Utilite(etat, joueurMaxOriginal);
+    }
+
+    private void Backpropagation(NoeudMCTS<TEtat>? noeud, double resultat)
+    {
+        Stats[""backprops""]++;
+        // Convention UCT ""moved-into"" : on stocke a chaque noeud la valeur du point de vue
+        // du joueur QUI A DECIDE le coup vers ce noeud (le joueur de l'etat parent).
+        // Ainsi tous les enfants d'un meme parent sont evalues du meme point de vue,
+        // et max(UCB1) selectionne bien le meilleur coup pour le joueur qui decide.
+        while (noeud != null)
+        {
+            noeud.Visites++;
+            string decideur = noeud.Parent != null ? _jeu.Joueur(noeud.Parent.Etat) : _jeu.Joueur(noeud.Etat);
+            if (decideur == ""MAX"") noeud.Victoires += resultat;
+            else noeud.Victoires += -resultat;
+            noeud = noeud.Parent;
+        }
+    }
+}
+
+Console.WriteLine(""Classe MCTS<T> definie (selection, expansion, simulation, backpropagation)."");",,,,,,,,819d8fc1624c0e40,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-594a226a,markdown,fr,f915c4fbca824725,"Maintenant que nous avons la structure de noeud, nous pouvons implementer l'algorithme **MCTS complet** qui utilise ces noeuds pour construire l'arbre de recherche.",,,,,,,,f915c4fbca824725,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-1d7eea9d,markdown,fr,29644a19611c0a09,"## 3. Test sur Tic-Tac-Toe
+
+Comparons MCTS avec Minimax sur le jeu de Morpion.
+",,,,,,,,29644a19611c0a09,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-cbcc8cd7,code,fr,9797b0cda25cb4a0,"// Cellule 9 : Tic-Tac-Toe (implementation du jeu) + premier test MCTS
+public sealed class EtatTTT
+{
+    public char[] Grille { get; }
+    public char Joueur { get; }   // 'X' ou 'O' (celui qui doit jouer)
+    public EtatTTT(char[] grille, char joueur) { Grille = grille; Joueur = joueur; }
+}
+
+public class TicTacToe : IJeuSommeNulle<EtatTTT>
+{
+    private static readonly int[][] Lignes = new[] {
+        new[] {0,1,2}, new[] {3,4,5}, new[] {6,7,8},   // lignes
+        new[] {0,3,6}, new[] {1,4,7}, new[] {2,5,8},   // colonnes
+        new[] {0,4,8}, new[] {2,4,6}                    // diagonales
+    };
+
+    public EtatTTT EtatInitial() => new(Enumerable.Repeat(' ', 9).ToArray(), 'X');
+    public string Joueur(EtatTTT e) => e.Joueur == 'X' ? ""MAX"" : ""MIN"";
+    public List<int> Actions(EtatTTT e) => Enumerable.Range(0,9).Where(i => e.Grille[i] == ' ').ToList();
+    public EtatTTT Resultat(EtatTTT e, int a)
+    {
+        char[] g = (char[])e.Grille.Clone();
+        g[a] = e.Joueur;
+        return new EtatTTT(g, e.Joueur == 'X' ? 'O' : 'X');
+    }
+    public bool EstTerminal(EtatTTT e)
+    {
+        foreach (var l in Lignes)
+            if (e.Grille[l[0]] != ' ' && e.Grille[l[0]] == e.Grille[l[1]] && e.Grille[l[1]] == e.Grille[l[2]])
+                return true;
+        return !e.Grille.Contains(' ');
+    }
+    public double Utilite(EtatTTT e, string joueur)
+    {
+        foreach (var l in Lignes)
+            if (e.Grille[l[0]] != ' ' && e.Grille[l[0]] == e.Grille[l[1]] && e.Grille[l[1]] == e.Grille[l[2]])
+            {
+                string gagnant = e.Grille[l[0]] == 'X' ? ""MAX"" : ""MIN"";
+                return gagnant == joueur ? 1.0 : -1.0;
+            }
+        return 0.0;
+    }
+}
+
+// Test MCTS sur Tic-Tac-Toe (etat initial vide)
+var jeu = new TicTacToe();
+var mcts = new MCTS<EtatTTT>(jeu, seed: 42);
+var sw = Stopwatch.StartNew();
+var (action, valeur) = mcts.Recherche(jeu.EtatInitial(), iterations: 1000);
+sw.Stop();
+Console.WriteLine($""MCTS (1000 iterations) : action={action}, valeur={valeur:F3}, temps={sw.Elapsed.TotalSeconds:F3}s"");
+Console.WriteLine($""Stats : selections={mcts.Stats[""selections""]}, expansions={mcts.Stats[""expansions""]}, simulations={mcts.Stats[""simulations""]}, backprops={mcts.Stats[""backprops""]}"");",,,,,,,,9797b0cda25cb4a0,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-6fe27d2b,markdown,fr,fb68dddad5272281,"### Interpretation : Premiers resultats MCTS
+
+La sortie ci-dessus montre la decision de MCTS apres 1000 iterations depuis la grille vide.
+
+| Aspect | Signification |
+|--------|---------------|
+| **Action choisie** | Indice 0-8 ; un coin (0/2/6/8) ou le centre (4) sont les premiers coups strategiques au Morpion |
+| **Valeur estimee** | Taux de victoire moyen des rollouts ; proche de 0 car le Morpion est un match nul entre joueurs competents |
+| **Temps d'execution** | Tres rapide : MCTS n'explore qu'une partie de l'arbre (vs Minimax qui explore tout) |
+| **Stats equilibrees** | selections = expansions = simulations = backprops = une iteration MCTS complete |
+
+**Points cles** :
+1. **Vitesse** : MCTS est nettement plus rapide que Minimax car il n'explore qu'une partie de l'arbre (comparaison chiffree en section 4).
+2. **Valeur proche de 0** : Au Morpion, le resultat optimal est 0 (match nul), donc une valeur faible indique une bonne estimation.
+3. **Action strategique** : Un coin ou le centre sont les meilleurs premiers coups au Morpion.
+4. **Determinisme** : avec une graine fixee (`seed: 42`), la sortie est reproductible ; sans graine, elle varie legerement d'une execution a l'autre.
+",,,,,,,,fb68dddad5272281,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-5ece8bac,markdown,fr,0ae2d6f13fb4da4a,"## 4. Comparaison MCTS vs Minimax
+
+Comparons les deux approches sur differents criteres.
+",,,,,,,,0ae2d6f13fb4da4a,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-386c7ab1,code,fr,e47edaaae18188ea,"// Cellule 12 : Minimax (pour comparaison) + benchmark text-table Minimax vs MCTS
+public static class RechercheAdversariale
+{
+    // Minimax exact (explore tout l'arbre) -- optimal mais exponentiel.
+    public static (double Valeur, int? Action) Minimax<TEtat>(IJeuSommeNulle<TEtat> jeu, TEtat etat, string joueurMax = ""MAX"")
+    {
+        if (jeu.EstTerminal(etat)) return (jeu.Utilite(etat, joueurMax), null);
+        var actions = jeu.Actions(etat);
+        if (jeu.Joueur(etat) == joueurMax)
+        {
+            double bestV = double.NegativeInfinity; int? bestA = null;
+            foreach (var a in actions)
+            {
+                var (v, _) = Minimax(jeu, jeu.Resultat(etat, a), joueurMax);
+                if (v > bestV) { bestV = v; bestA = a; }
+            }
+            return (bestV, bestA);
+        }
+        else
+        {
+            double bestV = double.PositiveInfinity; int? bestA = null;
+            foreach (var a in actions)
+            {
+                var (v, _) = Minimax(jeu, jeu.Resultat(etat, a), joueurMax);
+                if (v < bestV) { bestV = v; bestA = a; }
+            }
+            return (bestV, bestA);
+        }
+    }
+}
+
+// Benchmark : Minimax vs MCTS a differents budgets d'iterations
+Console.WriteLine($""{""Algorithme"",-16}{""Temps (s)"",12}{""Valeur"",10}{""Action"",8}"");
+Console.WriteLine(new string('-', 46));
+var sw = Stopwatch.StartNew();
+var (vMm, aMm) = RechercheAdversariale.Minimax(jeu, jeu.EtatInitial());
+sw.Stop();
+Console.WriteLine($""{""Minimax"",-16}{sw.Elapsed.TotalSeconds,12:F4}{vMm,10:F2}{aMm,8}"");
+foreach (int nIter in new[] { 100, 500, 1000, 5000 })
+{
+    var m = new MCTS<EtatTTT>(jeu, seed: 42);
+    sw.Restart();
+    var (action, valeur) = m.Recherche(jeu.EtatInitial(), nIter);
+    sw.Stop();
+    Console.WriteLine($""{""MCTS (""+nIter+"")"",-16}{sw.Elapsed.TotalSeconds,12:F4}{valeur,10:F2}{action,8}"");
+}",,,,,,,,e47edaaae18188ea,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-961c0211,markdown,fr,cea6040ddd112bc3,"### Interpretation : Comparaison MCTS vs Minimax
+
+La table ci-dessus compare Minimax (exploration complete, exact) a MCTS a 4 budgets d'iterations.
+
+**Points cles** (a lire sur la sortie reelle ci-dessus) :
+1. **Avantage vitesse critique** : MCTS meme a faible budget est considerablement plus rapide que Minimax, qui explore tout l'arbre du Morpion (~26 000 positionslegales avant elagage terminal).
+2. **Convergence progressive** : plus d'iterations rapprochent la valeur MCTS de 0 (la valeur optimale donnee par Minimax).
+3. **Stabilite tardive** : a 5000 iterations, la valeur estimee MCTS est tres proche de l'optimal (0).
+4. **Variabilite des actions** : les actions choisies varient selon le budget, montrant que le nombre d'iterations influence la stabilite du choix.
+
+> **Note technique** : La valeur de Minimax (0) est exacte car l'algorithme explore tout l'arbre de jeu du Morpion. La valeur MCTS est une estimation probabiliste qui converge vers 0 avec plus d'iterations.
+",,,,,,,,cea6040ddd112bc3,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-6d1c1a6e,markdown,fr,d7e6cab2e9162f41,"### Analyse des resultats
+
+| Critere | Minimax | MCTS |
+|---------|---------|------|
+| **Garantie d'optimalite** | Oui (si arbre complet) | Non (probabiliste) |
+| **Fonction d'evaluation** | Necessaire (pour la profondeur) | Non necessaire |
+| **Complexite** | O(b^d) | O(n * d) ou n = iterations |
+| **Parallellisable** | Difficile | Tres facile |
+| **Jeux a grand facteur de branchement** | Impraticable | Adapte |
+
+### Quand utiliser MCTS ?
+
+- Jeux avec grand espace d'etat (Go, Hex)
+- Jeux sans bonne fonction d'evaluation
+- Situations avec contrainte de temps variable
+- Jeux avec hasard (backgammon, poker)
+",,,,,,,,d7e6cab2e9162f41,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-1f123cb6,markdown,fr,93f7fb11c9a1c558,"## 5. OpenSpiel -- Framework de Jeux
+
+### Presentation
+
+**OpenSpiel** est un framework open-source de DeepMind pour la recherche en IA sur les jeux.
+
+### Caracteristiques
+
+- **40+ jeux** : Echecs, Go, Hex, Poker, Hanabi, etc.
+- **Multi-agent** : jeux a N joueurs
+- **Information imparfaite** : Poker, Hanabi
+- **Algos inclus** : MCTS, AlphaZero, CFR, etc.
+
+> **Note .NET** : OpenSpiel est une librairie C++/Python (installation `pip install open-spiel`, Linux/WSL). Il n'existe pas d'equivalent .NET direct ; en C# on reimplemente la logique de jeu (comme nous le faisons ici avec `IJeuSommeNulle<T>`) ou on consomme des moteurs natifs via P/Invoke. La cellule suivante montre l'equivalent conceptuel de l'API OpenSpiel en C#.
+",,,,,,,,93f7fb11c9a1c558,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-005cd9cb,code,fr,5e20a82384adf436,"// Cellule 16 : Equivalent conceptuel de l'API OpenSpiel en C#
+// OpenSpiel (pyspiel) est C++/Python uniquement. En .NET on reimplemente le jeu
+// derriere une interface normalisee (c'est exactement IJeuSommeNulle<TEtat> ci-dessus).
+// On reutilise donc notre TicTacToe + MCTS pour montrer le meme usage qu'OpenSpiel.
+
+var openspielEquivalent = new TicTacToe();
+var bot = new MCTS<EtatTTT>(openspielEquivalent, c: 1.41, seed: 42);
+var etat0 = openspielEquivalent.EtatInitial();
+var (actionOS, _) = bot.Recherche(etat0, iterations: 1000);
+Console.WriteLine($""Jeu charge        : tic_tac_toe()  (via TicTacToe : IJeuSommeNulle<EtatTTT>)"");
+Console.WriteLine($""Etat initial      : grille vide, X a jouer"");
+Console.WriteLine($""Action MCTSBot    : {actionOS}  (1000 simulations, c=sqrt(2))"");
+Console.WriteLine($""\nOpenSpiel .NET : pas de port officiel. L'interface IJeuSommeNulle<T> normalise"");
+Console.WriteLine($""  la meme separation jeu / algorithme qu'OpenSpiel (state, actions, resultat, terminal, utilite)."");",,,,,,,,5e20a82384adf436,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-c7e28f9a,markdown,fr,1f67b2143597f95c,"### Interpretation : OpenSpiel et la normalisation des jeux
+
+**Points cles** :
+1. **Interface normalisee** : `IJeuSommeNulle<T>` joue le role de l'API `pyspiel` -- n'importe quel jeu a deux joueurs l'implemente et beneficie immediatement de MCTS, Minimax, etc.
+2. **Pas de port .NET officiel** : OpenSpiel est C++/Python ; en C# on reimplemente la logique (comme ici) ou on invoque un moteur natif.
+3. **Coherence avec MCTS manuel** : le bot joue un coup fort (coin/centre), comme le `MCTSBot` d'OpenSpiel.
+4. **Separation jeu / algorithme** : c'est le pattern cle -- ajouter un nouveau jeu (Connect-4, Hex...) se reduit a implementer 6 methodes.
+",,,,,,,,1f67b2143597f95c,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-de66a51a,markdown,fr,36db6b04d313fb74,"## 6. AlphaGo et AlphaZero
+
+### Architecture AlphaGo (2016)
+
+AlphaGo combine MCTS avec des reseaux de neurones :
+1. **Policy Network** : predit la probabilite de chaque coup
+2. **Value Network** : evalue la position
+3. **MCTS** : guide la recherche avec les predictions des reseaux
+
+### AlphaZero (2017)
+
+AlphaZero simplifie et generalise l'approche :
+- **Auto-apprentissage** : pas de donnees humaines
+- **Reseau unique** : policy + value ensemble
+- **Universel** : fonctionne pour Go, Echecs, Shogi
+
+### Principe de l'apprentissage
+
+```
+1. Initialiser le reseau aleatoirement
+2. Jouer des parties contre soi-meme avec MCTS
+3. Entrainer le reseau sur les positions et resultats
+4. Repeter jusqu'a convergence
+```
+",,,,,,,,36db6b04d313fb74,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-646f16f4,code,fr,0a7652ac4b11f4d6,"// Cellule 19 : Sketch conceptuel d'un AlphaZero simplifie (C#)
+// En pratique, policy_value_fn serait un reseau de neurones (PyTorch/TensorFlow/.NET).
+// Ici : une fonction factice qui simule (probas, valeur) pour illustrer l'integration MCTS.
+
+// Signature d'une evaluation reseau : (probas par action, valeur de la position)
+public delegate (Dictionary<int,double> Probs, double Value) PolicyValueFn<TEtat>(TEtat etat);
+
+public class AlphaZeroMCTS<TEtat>
+{
+    private readonly IJeuSommeNulle<TEtat> _jeu;
+    private readonly PolicyValueFn<TEtat> _policyValue;
+    private readonly double _c;
+    public AlphaZeroMCTS(IJeuSommeNulle<TEtat> jeu, PolicyValueFn<TEtat> policyValue, double c = 1.41)
+    { _jeu = jeu; _policyValue = policyValue; _c = c; }
+
+    // MCTS guide par le reseau : l'expansion utilise les probas policy,
+    // et la simulation est remplacee par l'evaluation value (pas de rollout aleatoire).
+    public NoeudMCTS<TEtat> Recherche(TEtat etat, int iterations = 100)
+    {
+        var racine = new NoeudMCTS<TEtat>(etat);
+        for (int i = 0; i < iterations; i++)
+        {
+            var noeud = racine;
+            // Selection (comme MCTS classique, via UCB1)
+            while (noeud.Enfants.Count > 0 && noeud.EstFullyExpanded(_jeu) && !_jeu.EstTerminal(noeud.Etat))
+                noeud = noeud.MeilleurEnfantUcb1(_c);
+            // Evaluation par le reseau
+            double value;
+            if (_jeu.EstTerminal(noeud.Etat))
+                value = _jeu.Utilite(noeud.Etat, ""MAX"");
+            else
+            {
+                var (probs, v) = _policyValue(noeud.Etat);
+                value = v;
+                // Expansion avec les probabilites du policy network
+                foreach (var a in _jeu.Actions(noeud.Etat))
+                    noeud.Enfants[a] = new NoeudMCTS<TEtat>(_jeu.Resultat(noeud.Etat, a), noeud, a);
+            }
+            // Backpropagation (comme MCTS classique ; Victoires est un setter public)
+            while (noeud != null)
+            {
+                noeud.Visites++;
+                if (_jeu.Joueur(noeud.Etat) == ""MAX"") noeud.Victoires += value;
+                else noeud.Victoires += -value;
+                noeud = noeud.Parent;
+            }
+        }
+        return racine;
+    }
+}
+
+Console.WriteLine(""Sketch AlphaZeroMCTS<T> defini (policy network + value network, pas de rollout aleatoire)."");",,,,,,,,0a7652ac4b11f4d6,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-a906ede1,markdown,fr,58100b47a968d321,"### Interpretation : Concept AlphaZero et integration reseau/MCTS
+
+| Aspect | Implementation | Signification |
+|--------|----------------|---------------|
+| **Policy/Value** | `PolicyValueFn<T>` delegate | Simule un reseau (a remplacer par PyTorch/TensorFlow/.NET) |
+| **Integration MCTS** | Selection + Expansion guidee | MCTS utilise les probabilites du policy network |
+| **Backpropagation** | Valeur reseau (pas rollout) | Plus efficace que les rollouts aleatoires |
+| **Architecture** | Reseau unique (policy+value) | Simplification d'AlphaZero vs AlphaGo (2016) |
+
+**Points cles** :
+1. **Remplacement du rollout** : AlphaZero remplace les simulations aleatoires par l'evaluation directe du value network.
+2. **Policy network** : guide l'expansion en donnant des probabilites pour chaque action.
+3. **Auto-apprentissage** : le reseau s'entraine sur les parties generees par MCTS (auto-play sans donnees humaines).
+4. **Generalisation** : la meme architecture fonctionne pour Go, Echecs, Shogi.
+",,,,,,,,58100b47a968d321,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-01aa139b,markdown,fr,f1ca36b8c7b2319a,"## 7. Extensions Avancees
+
+### RAVE (Rapid Action Value Estimation)
+
+RAVE utilise l'heuristique ""all moves as first"" pour accelerer l'apprentissage : un coup est evalue meme s'il est joue plus tard dans la partie. Acceleration significative dans les premiers stades.
+
+### UCT (UCB applied to Trees)
+
+UCT est le nom original de l'algorithme MCTS avec UCB1. Variantes :
+- **UCB1-Tuned** : ajuste le parametre d'exploration
+- **UCB-V** : utilise la variance des recompenses
+
+### Parallelisation
+
+MCTS se parallellise facilement :
+- **Leaf parallelisation** : simulations en parallele
+- **Root parallelisation** : plusieurs arbres en parallele
+- **Tree parallelisation** : acces concurrent a l'arbre
+",,,,,,,,f1ca36b8c7b2319a,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-69708bf7,code,fr,4be5631817cc8516,"// Cellule 22 : Root parallelization en C# (Parallel.ForEach / LINQ)
+// Contrairement a multiprocessing.Pool (Python), le TPL (.NET) fonctionne dans un notebook.
+public static class MCTSParallel
+{
+    // Root parallelization : nWorkers arbres MCTS independants, vote majoritaire.
+    public static int Recherche<TEtat>(IJeuSommeNulle<TEtat> jeu, TEtat etat, int totalIterations, int nWorkers, int seed = 42)
+    {
+        int perWorker = Math.Max(1, totalIterations / nWorkers);
+        var actions = new int[nWorkers];
+        Parallel.For(0, nWorkers, w =>
+        {
+            var m = new MCTS<TEtat>(jeu, seed: seed + w);
+            actions[w] = m.Recherche(etat, perWorker).Action;
+        });
+        // Vote majoritaire
+        return actions.GroupBy(a => a).OrderByDescending(g => g.Count()).First().Key;
+    }
+}
+
+var jeuP = new TicTacToe();
+var sw = Stopwatch.StartNew();
+int coupVote = MCTSParallel.Recherche(jeuP, jeuP.EtatInitial(), totalIterations: 1000, nWorkers: 4, seed: 42);
+sw.Stop();
+Console.WriteLine($""Root parallelization (4 workers x 250 iter) -> action = {coupVote}, temps = {sw.Elapsed.TotalSeconds:F3}s"");
+Console.WriteLine(""Chaque worker construit son propre arbre ; le vote majoritaire reduit la variance."");",,,,,,,,4be5631817cc8516,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-2404bf16,markdown,fr,8e790d8cdead4270,"### Interpretation : Parallelisation de MCTS
+
+| Aspect | Implementation | Signification |
+|--------|----------------|---------------|
+| **Type** | Root parallelization | Plusieurs arbres MCTS independants en parallele |
+| **Workers** | 4 (configurable) | Chaque worker execute un MCTS complet |
+| **Vote** | `GroupBy().OrderByDescending(Count)` | L'action la plus choisie parmi les workers gagne |
+| **API .NET** | `Parallel.For` / TPL | Fonctionne dans un notebook (contrairement au `multiprocessing` Python) |
+
+**Points cles** :
+1. **Root parallelization** : chaque worker construit son propre arbre MCTS independant, puis on vote.
+2. **Scalabilite** : avec 4 coeurs, on fait ~4x plus d'iterations dans le meme temps.
+3. **Vote majoritaire** : reduit la variance en combinant plusieurs estimations.
+4. **Alternative** : tree parallelization (acces concurrent a un arbre partage avec lock) -- plus complexe mais meilleure convergence.
+",,,,,,,,8e790d8cdead4270,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-2e6fabb4,markdown,fr,7267fcd1ec50ac69,"## Exemples et Exercices
+
+Les deux premiers items sont des **exemples completement resolus** qui servent de modeles. Les exercices 2 a 5 sont des stubs a completer (C# `// TODO`, sans lancer d'exception -- le notebook doit s'executer de bout en bout).
+
+### Exemple resolu 1 : Analyse de convergence MCTS
+Mesurez comment la qualite des decisions MCTS evolue avec le nombre d'iterations.
+
+### Exemple resolu 2 : MCTS sur le jeu de Nim
+Verifiez que MCTS decouvre la strategie optimale connue du Nim (laisser un multiple de 4).
+
+### Exercice 2 : Rollout intelligent
+Implementez un rollout guide par heuristiques au lieu d'un choix purement aleatoire.
+
+### Exercice 3 : MCTS vs Alpha-Beta sur Connect Four
+Comparez les deux algorithmes sur le jeu de Puissance 4.
+
+### Exercice 4 : Extension RAVE
+Implementez l'extension RAVE pour accelerer la convergence.
+
+### Exercice 5 : Time management
+Implementez une gestion du temps adaptive pour MCTS.
+",,,,,,,,7267fcd1ec50ac69,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-4727b4cf,markdown,fr,c479525ab06c3a40,"### Exemple resolu : Analyse de convergence MCTS
+
+La convergence est une propriete fondamentale de MCTS : plus on augmente le nombre d'iterations, plus la decision se rapproche de l'optimal. L'exemple ci-dessous mesure cette convergence sur TicTacToe en comparant l'action choisie par MCTS a l'action optimale Minimax (verite terrain). La table montre le taux de choix optimal, la valeur estimee moyenne et le temps moyen, pour des budgets croissants.
+",,,,,,,,c479525ab06c3a40,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-ca9a8638,code,fr,12f7b85c8b7a6061,"// Exemple resolu : Analyse de convergence MCTS (table texte au lieu de matplotlib)
+// Pour chaque budget d'iterations, on repete N fois et on mesure le taux de choix
+// de l'action optimale (ref Minimax), la valeur estimee moyenne et le temps moyen.
+static List<(int Iter, double TauxOpt, double ValeurMoy, double TempsMoy)> AnalyserConvergence<TEtat>(
+    IJeuSommeNulle<TEtat> jeu, TEtat etat, IEnumerable<int> iterList, int repetitions = 20, int seed = 42)
+{
+    var (_, actionOptNull) = RechercheAdversariale.Minimax(jeu, etat);
+    int actionOpt = actionOptNull ?? jeu.Actions(etat)[0];
+    var rng = new Random(seed);
+    var res = new List<(int, double, double, double)>();
+    foreach (int nIter in iterList)
+    {
+        int optCount = 0;
+        double sv = 0, st = 0;
+        for (int r = 0; r < repetitions; r++)
+        {
+            var mcts = new MCTS<TEtat>(jeu, seed: rng.Next());
+            var sw = Stopwatch.StartNew();
+            var (action, valeur) = mcts.Recherche(etat, nIter);
+            sw.Stop();
+            if (action == actionOpt) optCount++;
+            sv += valeur; st += sw.Elapsed.TotalSeconds;
+        }
+        res.Add((nIter, optCount * 100.0 / repetitions, sv / repetitions, st / repetitions));
+    }
+    return res;
+}
+
+var iterList = new[] { 10, 50, 100, 500, 1000, 2000 };
+var conv = AnalyserConvergence(jeu, jeu.EtatInitial(), iterList, repetitions: 20);
+Console.WriteLine($""{""Iterations"",12}{""Taux optimal (%)"",18}{""Valeur moyenne"",16}{""Temps moyen (s)"",16}"");
+Console.WriteLine(new string('-', 62));
+foreach (var (it, taux, vmoy, tmoy) in conv)
+    Console.WriteLine($""{it,12}{taux,18:F1}{vmoy,16:F3}{tmoy,16:F4}"");
+Console.WriteLine(""\nRemarque : depuis la grille vide, plusieurs premiers coups du Morpion sont"");
+Console.WriteLine(""tous optimaux (valeur 0). Le taux compare a UNE action de reference (Minimax)."");",,,,,,,,12f7b85c8b7a6061,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-e331ec8e,markdown,fr,f5a6cd34db855119,"### Exemple resolu : MCTS sur le jeu de Nim
+
+Le jeu de **Nim** est un cas ideal pour comprendre MCTS : l'espace d'etats est petit et la strategie optimale est connue mathematiquement (laisser un multiple de 4 allumettes a l'adversaire). L'exemple ci-dessous montre la **convergence** de MCTS vers cette strategie en fonction du budget d'iterations, puis compare ses performances contre un joueur optimal. On observe que MCTS decouvre l'action optimale (prendre 3 depuis n=15) des 1000 iterations, avec une valeur estimee qui converge vers la victoire (0,64 -> 0,96).
+",,,,,,,,f5a6cd34db855119,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-23b47a77,code,fr,5b7667794dc1a656,"// Exemple resolu : MCTS sur le jeu de Nim
+public sealed class EtatNim { public int Restantes; public char Joueur; public EtatNim(int r, char j){Restantes=r;Joueur=j;} }
+
+public class NimGame : IJeuSommeNulle<EtatNim>
+{
+    private readonly int _n0;
+    public NimGame(int nAllumettes = 15) => _n0 = nAllumettes;
+    public EtatNim EtatInitial() => new(_n0, 'X');
+    public string Joueur(EtatNim e) => e.Joueur == 'X' ? ""MAX"" : ""MIN"";
+    public List<int> Actions(EtatNim e) => new[] { 1, 2, 3 }.Where(k => k <= e.Restantes).ToList();
+    public EtatNim Resultat(EtatNim e, int a) => new(e.Restantes - a, e.Joueur == 'X' ? 'O' : 'X');
+    public bool EstTerminal(EtatNim e) => e.Restantes == 0;
+    public double Utilite(EtatNim e, string joueur)
+    {
+        // e = (0, joueur qui doit jouer) -> il ne peut pas jouer -> l'autre a pris la derniere -> l'autre GAGNE
+        string gagnant = e.Joueur == 'O' ? ""MAX"" : ""MIN"";
+        return gagnant == joueur ? 1.0 : -1.0;
+    }
+}
+
+static int StrategieOptimaleNim(EtatNim etat)
+{
+    int reste = etat.Restantes % 4;
+    return reste > 0 ? reste : 1;   // laisser un multiple de 4 a l'adversaire
+}
+
+var jeuNim = new NimGame(15);
+// Budget eleve pour l'action initiale : MCTS doit explorer assez pour decouvrir la parite (n%%4).
+Console.WriteLine(""--- Action initiale : MCTS a budgets croissants ---"");
+int actionOptNim = StrategieOptimaleNim(jeuNim.EtatInitial());
+Console.WriteLine($""Nim(15) - Strategie optimale : prendre {actionOptNim} (laisser un multiple de 4)\n"");
+foreach (int nIter in new[] { 1000, 5000, 10000 })
+{
+    var (a, v) = new MCTS<EtatNim>(jeuNim, seed: 42).Recherche(jeuNim.EtatInitial(), nIter);
+    Console.WriteLine($""  MCTS({nIter,5} iter) : prendre {a}, valeur={v:F3}  {(a == actionOptNim ? ""<< OPTIMAL"" : """")}"");
+}
+Console.WriteLine();
+// Tournoi : MCTS(500) vs strategie optimale, 50 parties (MCTS joue 1er puis 2nd)
+int victoiresMcts = 0, nulles = 0, nParties = 50;
+for (int i = 0; i < nParties; i++)
+{
+    var etat = jeuNim.EtatInitial();
+    string mctsJoueur = i % 2 == 0 ? ""MAX"" : ""MIN"";
+    while (!jeuNim.EstTerminal(etat))
+    {
+        int a;
+        if (jeuNim.Joueur(etat) == mctsJoueur)
+            a = new MCTS<EtatNim>(jeuNim, seed: 1000 + i).Recherche(etat, 500).Action;
+        else
+            a = StrategieOptimaleNim(etat);
+        etat = jeuNim.Resultat(etat, a);
+    }
+    double u = jeuNim.Utilite(etat, mctsJoueur);
+    if (u > 0) victoiresMcts++; else if (u == 0) nulles++;
+}
+Console.WriteLine($""\nTournoi MCTS(500 iter) vs Strategie optimale ({nParties} parties) :"");
+Console.WriteLine($""  Victoires MCTS              : {victoiresMcts}/{nParties}"");
+Console.WriteLine($""  Nulles                      : {nulles}/{nParties}"");
+Console.WriteLine($""  Victoires strategie optimale: {nParties - victoiresMcts - nulles}/{nParties}"");",,,,,,,,5b7667794dc1a656,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-f3bd048d,markdown,fr,ceb89637aa149e26,"### Exercice 2 : Rollout intelligent
+
+Implementez un rollout guide par heuristiques au lieu d'un choix purement aleatoire. Evaluez les actions candidates avec une fonction heuristique et choisissez l'action avec le meilleur score (avec un peu d'aleatoire). Pour TicTacToe, privilegiez le centre et les coins.
+",,,,,,,,ceb89637aa149e26,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-6228a2c5,code,fr,ec54459e35a5e110,"// Exercice 2 : Rollout intelligent (stub a completer)
+// Indice : derivez de MCTS<T> et surchargez la methode de selection d'action pendant
+// le rollout. Pour TicTacToe, une heuristique simple = score(centre=3, coin=2, bord=1).
+public class MCTSRolloutHeuristique<TEtat> : MCTS<TEtat>
+{
+    public MCTSRolloutHeuristique(IJeuSommeNulle<TEtat> jeu, double c = 1.41, int? seed = null)
+        : base(jeu, c, seed) { }
+
+    // TODO etudiant : remplacer le rollout aleatoire par un rollout guide.
+    // 1. Definir une fonction heuristique Heuristique(etat) -> score par action.
+    //    Ex TicTacToe : centre (action 4) = 3, coins (0,2,6,8) = 2, bords = 1.
+    // 2. Avec probabilite epsilon, jouer aleatoire (exploration) ; sinon jouer le meilleur score.
+    // 3. Mesurer la convergence plus rapide vs rollout purement aleatoire.
+    public double HeuristiqueExample(TEtat etat, int action)
+    {
+        // TODO etudiant : implementer l'heuristique selon le jeu.
+        return 0.0;  // placeholder : retour neutre (a completer)
+    }
+}
+Console.WriteLine(""Exercice 2 : stub pret -- derivez MCTS<T> et implementez le rolloutheuristique."");",,,,,,,,ec54459e35a5e110,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-20536fde,markdown,fr,cccddfd0a565f836,"### Exercice 3 : MCTS vs Alpha-Beta sur Connect Four
+
+Comparez les deux algorithmes sur le jeu de Puissance 4. Implementez Connect Four (ou reutilisez du notebook Search-6), faites jouer MCTS vs Alpha-Beta sur plusieurs parties et analysez : taux de victoire, temps, qualite des coups. Alpha-Beta devrait etre plus fort avec une bonne profondeur.
+",,,,,,,,cccddfd0a565f836,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-2ea5954a,code,fr,a52850ec2194f3bd,"// Exercice 3 : MCTS vs Alpha-Beta sur Connect Four (stub a completer)
+// Indice : Connect Four = grille 6x7, gravite (le jeton tombe en bas de la colonne).
+// 1. Implementer une classe ConnectFour : IJeuSommeNulle<EtatC4>.
+//    - EtatC4 = { char[42] Grille, char Joueur }
+//    - Actions = colonnes non pleines (0-6)
+//    - Resultat : trouver la 1ere case vide en partant du bas dans la colonne
+//    - EstTerminal : alignement de 4 (H, V, 2 diagonales) ou grille pleine
+// 2. Ajouter Alpha-Beta (Minimax + elagage) -- reutilisable depuis Search-6-Csharp.
+// 3. Tournoi MCTS(iter) vs AlphaBeta(prof) sur N parties.
+public sealed class EtatC4 { /* TODO etudiant */ }
+public class ConnectFour : IJeuSommeNulle<EtatC4>
+{
+    public EtatC4 EtatInitial() => default!;   // TODO etudiant
+    public string Joueur(EtatC4 e) => ""MAX"";    // TODO etudiant
+    public List<int> Actions(EtatC4 e) => new();// TODO etudiant
+    public EtatC4 Resultat(EtatC4 e, int a) => default!;  // TODO etudiant
+    public bool EstTerminal(EtatC4 e) => true;  // TODO etudiant
+    public double Utilite(EtatC4 e, string j) => 0.0;     // TODO etudiant
+}
+Console.WriteLine(""Exercice 3 : stub ConnectFour pret -- implementez les 6 methodes de l'interface."");",,,,,,,,a52850ec2194f3bd,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-926ab925,markdown,fr,6954ff34a602a62f,"### Exercice 4 : Extension RAVE
+
+Implementez l'extension RAVE (Rapid Action Value Estimation) pour accelerer la convergence de MCTS. RAVE utilise l'heuristique ""all moves as first"" : un coup est evalue meme s'il est joue plus tard dans la partie. La formule est `Q_RAVE = (1-beta) * Q_MCTS + beta * Q_RAVE`. Modifiez la classe `NoeudMCTS<T>` pour stocker les stats RAVE.
+",,,,,,,,6954ff34a602a62f,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-303e493b,code,fr,5a5c62c9c6626620,"// Exercice 4 : Extension RAVE (stub a completer)
+// Indice : ajouter a NoeudMCTS<T> deux compteurs par action globale (pas seulement par noeud).
+public class NoeudRAVE<TEtat> : NoeudMCTS<TEtat>
+{
+    public Dictionary<int, int> RaveVisites = new();   // TODO etudiant : remplir pendant la backprop
+    public Dictionary<int, double> RaveVictoires = new();
+    public NoeudRAVE(TEtat etat, NoeudMCTS<TEtat>? parent = null, int action = -1)
+        : base(etat, parent, action) { }
+
+    // TODO etudiant : surcharger Ucb1 pour melanger Q_MCTS et Q_RAVE.
+    // Q_RAVE = (1-beta) * (Victoires/Visites) + beta * (RaveVictoires[a]/RaveVisites[a])
+    // avec beta decroissant avec le nombre de visites.
+    public double Ucb1Rave(double c = 1.41, double beta = 0.5)
+    {
+        // TODO etudiant : implementer la formule RAVE
+        return Ucb1(c);   // placeholder = UCB1 classique (a completer)
+    }
+}
+Console.WriteLine(""Exercice 4 : stub NoeudRAVE<T> pret -- ajoutez les stats RAVE et la formule beta."");",,,,,,,,5a5c62c9c6626620,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-cb2f66d3,markdown,fr,78fb19edcc5a4dae,"### Exercice 5 : Time management
+
+Implementez une gestion du temps adaptive pour MCTS. Allouez plus de temps aux positions critiques, utilisez moins de temps quand le coup est evident, et detectez les positions ""faciles"" (victoire probable). Utilisez la variance des evaluations pour detecter l'incertitude.
+",,,,,,,,78fb19edcc5a4dae,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-08f8c30e,code,fr,e9382eb07af6d23a,"// Exercice 5 : Time management adaptive (stub a completer)
+// Indice : au lieu d'un budget fixe d'iterations, allouer un budget variable selon :
+//  - la variance des valeurs estimees des enfants (haute variance = incertain = + d'iterations)
+//  - la presence d'un coup ecrasant (un enfant >> les autres = coup evident = - d'iterations)
+public static class TimeManagement
+{
+    // TODO etudiant : retourner un nombre d'iterations adapte a la position.
+    public static int BudgetAdaptatif<TEtat>(IJeuSommeNulle<TEtat> jeu, TEtat etat, int budgetMax)
+    {
+        // 1. Lancer un pre-MCTS court (budgetMax/10 iter) pour estimer la variance.
+        // 2. Si variance faible (coup evident) -> retourner budgetMax/4.
+        // 3. Si variance elevee (position critique) -> retourner budgetMax.
+        return budgetMax;   // placeholder = budget fixe (a completer)
+    }
+}
+Console.WriteLine(""Exercice 5 : stub TimeManagement pret -- implementez le budget adaptatif."");",,,,,,,,e9382eb07af6d23a,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-c8cdb716,markdown,fr,0c1c85ba2074b518,"### Exemple : Parametre d'exploration c
+
+L'exemple ci-dessous benchmark differentes valeurs du parametre d'exploration `c` de MCTS. On joue des parties MCTS contre un joueur aleatoire, puis on compare les taux de victoire, temps d'execution et visites moyennes pour `c = 0.5, 1.0, 1.41, 2.0`.
+
+Observez comment la valeur de `c` influence le compromis entre exploration et exploitation.
+",,,,,,,,0c1c85ba2074b518,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-29fcfd83,code,fr,96e06816dccb689c,"// Exemple : Benchmark du parametre d'exploration c
+// Pour chaque c, on joue N parties MCTS(c) contre un joueur aleatoire, et on mesure
+// le taux de victoire, le temps moyen et les visites moyennes du coup choisi.
+static (double TauxVictoire, double TempsMoy, double VisitesMoy) JouerPartieMctsVsRandom<TEtat>(
+    IJeuSommeNulle<TEtat> jeu, MCTS<TEtat> mcts, int iterations, int seed)
+{
+    var rng = new Random(seed);
+    var etat = jeu.EtatInitial();
+    var visites = new List<int>();
+    bool tourMcts = true;
+    while (!jeu.EstTerminal(etat))
+    {
+        int a;
+        if (tourMcts)
+        {
+            var (act, vis) = mcts.RechercheAvecVisites(etat, iterations);
+            a = act; visites.Add(vis);
+        }
+        else
+        {
+            var acts = jeu.Actions(etat);
+            a = acts[rng.Next(acts.Count)];
+        }
+        etat = jeu.Resultat(etat, a);
+        tourMcts = !tourMcts;
+    }
+    double res = jeu.Utilite(etat, ""MAX"");
+    double visMoy = visites.Count > 0 ? visites.Average() : 0.0;
+    return (res, 0.0, visMoy);
+}
+
+Console.WriteLine($""{""c"",6}{""Taux victoire (%)"",20}{""Temps moyen (s)"",18}{""Visites moyennes"",18}"");
+Console.WriteLine(new string('-', 62));
+foreach (double c in new[] { 0.5, 1.0, 1.41, 2.0 })
+{
+    int victoires = 0; double sommeTemps = 0, sommeVisites = 0;
+    int parties = 12;
+    for (int p = 0; p < parties; p++)
+    {
+        var mcts = new MCTS<EtatTTT>(jeu, c: c, seed: 500 + p);
+        var sw = Stopwatch.StartNew();
+        var (res, _, visMoy) = JouerPartieMctsVsRandom(jeu, mcts, iterations: 1000, seed: 900 + p);
+        sw.Stop();
+        if (res > 0) victoires++;
+        sommeTemps += sw.Elapsed.TotalSeconds;
+        sommeVisites += visMoy;
+    }
+    Console.WriteLine($""{c,6}{victoires * 100.0 / parties,20:F1}{sommeTemps / parties,18:F4}{sommeVisites / parties,18:F1}"");
+}",,,,,,,,96e06816dccb689c,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-77b6a797,markdown,fr,bc9bf26025c3b39b,"---
+
+### Exercice : MCTS sur le jeu de Connect-4
+
+Implementez le jeu de **Connect-4** (Puissance 4) et testez l'algorithme MCTS dessus (voir stub Exercice 3).
+
+**Regles du Connect-4** :
+- Grille de 6 lignes x 7 colonnes
+- Deux joueurs (X et O) placent tour a tour un jeton dans une colonne
+- Le jeton tombe dans la case vide la plus basse de la colonne
+- Le premier joueur a aligner 4 jetons (H, V, ou diagonale) gagne
+- Si la grille est pleine sans alignement, c'est un match nul
+
+**Contraintes** :
+- L'etat sera represente par une classe `EtatC4` (grille `char[42]`, joueur courant)
+- Les actions sont les indices de colonnes valides (0 a 6)
+- Le facteur de branchement est 7 (vs 9 au Tic-Tac-Toe), l'arbre est beaucoup plus grand
+
+**Indices** :
+- Pour `Resultat`, les jetons tombent : trouver la premiere case vide dans la colonne en partant du bas
+- Pour `EstTerminal`, verifiez les 4 directions : horizontal, vertical, et les deux diagonales
+- Le nombre de positions au Connect-4 est d'environ 4.5 trillions, MCTS est donc particulierement pertinent
+",,,,,,,,bc9bf26025c3b39b,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-978ca3d9,code,fr,c2e6b0401f684206,"// Exercice : MCTS sur Connect-4 (la classe ConnectFour est declaree en Exercice 3).
+// Une fois les 6 methodes implementees, decommentez le tournoi ci-dessous.
+// var jeuC4 = new ConnectFour();
+// var mctsC4 = new MCTS<EtatC4>(jeuC4, seed: 42);
+// var (a4, v4) = mctsC4.Recherche(jeuC4.EtatInitial(), iterations: 2000);
+// Console.WriteLine($""Connect-4 - MCTS(2000) : colonne={a4}, valeur={v4:F3}"");
+Console.WriteLine(""Exercice Connect-4 : completez ConnectFour (Exercice 3) puis decommentez le tournoi."");",,,,,,,,c2e6b0401f684206,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb,cell-36fe9466,markdown,fr,5c204dc23daf31aa,"## Synthese
+
+### Resume des approches
+
+| Approche | Force | Faiblesse |
+|----------|-------|----------|
+| **Minimax + Alpha-Beta** | Optimal si arbre complet | Explosion combinatoire |
+| **MCTS pur** | Pas de fonction d'evaluation | Convergence lente |
+| **MCTS + Heuristiques** | Rapide, bon compromis | Heuristiques necessaires |
+| **AlphaZero** | Auto-apprentissage | Ressources enormes |
+
+### Quand utiliser quoi ?
+
+- **Jeux simples** (Tic-Tac-Toe, petits puzzles) : Minimax
+- **Jeux moyens** (Connect Four, Othello) : Alpha-Beta + heuristiques
+- **Jeux complexes** (Go, Hex) : MCTS + reseaux de neurones
+- **Jeux a information imparfaite** (Poker, Hanabi) : CFR + deep learning
+
+### Pour aller plus loin
+
+- **MuZero** : apprend les regles du jeu (model-based)
+- **AlphaFold** : applications hors jeux (biologie)
+- **Expert Iteration** : combinaison expert/apprenti
+
+---
+
+**Navigation** : [<< Recherche adversariale (C#)](Search-6-AdversarialSearch-Csharp.ipynb) | [Index](../README.md) | [Version Python](Search-7-MCTS-And-Beyond.ipynb) | [Dancing Links >>](Search-8-DancingLinks.ipynb)
+
+### References academiques
+
+- von Neumann, J. (1928). Zur Theorie der Gesellschaftsspiele. Mathematische Annalen 100:295-320.
+- Kocsis, L. & Szepesvari, C. (2006). Bandit Based Monte-Carlo Planning. ECML 2006, LNCS 4212:282-293.
+- Silver, D., Huang, A., Maddison, C.J. et al. (2016). Mastering the game of Go with deep neural networks and tree search. Nature 529:484-489.
+- Silver, D., Schrittwieser, J., Simonyan, K. et al. (2017). Mastering the game of Go without human knowledge. Nature 550:354-359.
+- Browne, C.B., Powley, E., Whitehouse, D. et al. (2012). A Survey of Monte Carlo Tree Search Methods. IEEE TCIAIG 4(1):1-43.
+",,,,,,,,5c204dc23daf31aa,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-06f1f2df,markdown,fr,be59d360a238067d,"# Search-8-DancingLinks-Csharp : L'algorithme X et Dancing Links de Knuth en C#
+
+**Navigation** : [<< Search-7 (MCTS)](Search-7-MCTS-And-Beyond.ipynb) | [↑ Série Search (C#)](../README.md) | [Search-9 (Linear Programming) >>](Search-9-LinearProgramming.ipynb)
+
+**Jumeau .NET** du notebook Python [Search-8-DancingLinks](Search-8-DancingLinks.ipynb). Port C# from-scratch (EPIC [#4956](https://github.com/jsboige/CoursIA/issues/4956), prong A [#3801](https://github.com/jsboige/CoursIA/issues/3801) — algorithme pur : .NET n'a pas de bibliothèque DLX dominante, l'implémentation from-scratch **est** la leçon pédagogique).
+
+Donald Knuth a inventé l'**Algorithme X** (résolution de la couverture exacte par backtracking) et la structure de données **Dancing Links (DLX)** qui le rend redoutablement efficace. Cette structure exploite une idée géniale : supprimer et restaurer un nœud d'une liste doublement chaînée circulaire sont des opérations **symétriques** en O(1), ce qui accélère dramatiquement le backtracking.
+
+Nous allons : (1) définir la couverture exacte, (2) implanter l'Algorithme X naïf, (3) présenter la structure Dancing Links, (4) implanter DLX en C#, (5) l'appliquer au pavage, (6) comparer ses performances au backtracking classique.",,,,,,,,be59d360a238067d,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-1b86e886,markdown,fr,c6812a3c842df24c,"## 1. Le problème de couverture exacte (~15 min)
+
+### Définition formelle
+
+Soit un univers $U = \{1, 2, \dots, n\}$ et une collection $\mathcal{S} = \{S_1, S_2, \dots, S_m\}$ de sous-ensembles de $U$. Trouver une **couverture exacte** = un sous-ensemble $\mathcal{S}^* \subseteq \mathcal{S}$ tel que chaque élément de $U$ est contenu dans **exactement un** $S_i \in \mathcal{S}^*$.
+
+On représente le problème par une **matrice binaire** $A$ ($m$ lignes × $n$ colonnes) où $A[i,j] = 1$ si $j \in S_i$. Une couverture exacte = un ensemble de lignes dont la somme colonne par colonne vaut exactement 1 partout.
+
+Le problème est **NP-complet** : aucune méthode polynomiale connue. Applications : Sudoku, pavage de polyominos, planning de personnel, résolution de casse-têtes (N-reines, pentominoes).",,,,,,,,c6812a3c842df24c,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-ff274a3d,code,fr,6f3cd48b16e6b9e5,"using System.Text;
+
+// Exemple canonique : Univers U = {1,2,3,4,5,6,7}
+// S1={1,4,7}, S2={1,4}, S3={4,5,7}, S4={3,5,6}, S5={2,3,6,7}, S6={2,7}
+// Solution attendue : {S2, S4, S6} car S2∪S4∪S6 = {1,4}∪{3,5,6}∪{2,7} = U
+int[,] matrix = {
+    { 1, 0, 0, 1, 0, 0, 1 },  // S1
+    { 1, 0, 0, 1, 0, 0, 0 },  // S2
+    { 0, 0, 0, 1, 1, 0, 1 },  // S3
+    { 0, 0, 1, 0, 1, 1, 0 },  // S4
+    { 0, 1, 1, 0, 0, 1, 1 },  // S5
+    { 0, 1, 0, 0, 0, 0, 1 },  // S6
+};
+string[] rowNames = { ""S1"", ""S2"", ""S3"", ""S4"", ""S5"", ""S6"" };
+int nRows = matrix.GetLength(0), nCols = matrix.GetLength(1);
+
+var sb = new StringBuilder();
+sb.AppendLine(""=== Couverture exacte : exemple canonique ==="");
+sb.AppendLine($""Univers U = {{1,2,3,4,5,6,7}}  (n={nCols} éléments, m={nRows} sous-ensembles)"");
+sb.AppendLine();
+sb.AppendLine(""Matrice binaire :"");
+sb.AppendLine(""      1 2 3 4 5 6 7"");
+for (int i = 0; i < nRows; i++)
+{
+    var row = new StringBuilder();
+    for (int j = 0; j < nCols; j++) row.Append(matrix[i, j] == 1 ? "" 1"" : "" ."");
+    sb.AppendLine($""  {rowNames[i]} {row}"");
+}
+sb.AppendLine();
+// Vérification de la solution {S2, S4, S6} = indices 1, 3, 5
+int[] solRows = { 1, 3, 5 };
+int[] coverCount = new int[nCols];
+foreach (var r in solRows)
+    for (int j = 0; j < nCols; j++) coverCount[j] += matrix[r, j];
+bool isExact = coverCount.All(c => c == 1);
+sb.AppendLine($""Solution proposée : {{S2, S4, S6}}"");
+sb.AppendLine($""Couverture par colonne : [{string.Join("", "", coverCount)}]"");
+sb.AppendLine($""Couverture exacte ? {(isExact ? ""OUI"" : ""NON"")}  (chaque colonne == 1)"");
+sb.ToString().Display();",,,,,,,,6f3cd48b16e6b9e5,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-9dcab047,markdown,fr,55f0ae461d4c0cce,"## 2. L'Algorithme X de Knuth (~15 min)
+
+### Principe
+
+L'Algorithme X est une procédure récursive de backtracking :
+
+1. Si la matrice est vide → **solution trouvée**.
+2. Choisir une colonne $c$ (idéalement avec le moins de 1 — heuristique).
+3. Pour chaque ligne $r$ ayant un 1 dans $c$ :
+   - Inclure $r$ dans la solution partielle.
+   - Éliminer toutes les colonnes conflictuelles (celles où $r$ a un 1) et toutes les lignes qui touchent ces colonnes.
+   - Récursion sur la matrice réduite.
+   - Si échec, annuler et essayer la ligne suivante.
+
+La version **naïve** recopie la matrice à chaque étape (coûteuse). Dancing Links (section 3) fera tout en O(1).",,,,,,,,55f0ae461d4c0cce,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-f4ca5d48,code,fr,d1d0ee31c9976e30,"// Algorithme X naïf (recopie la matrice — référence pédagogique)
+
+static List<int>? AlgorithmXNaive(int[,] matrix)
+{
+    int nRows = matrix.GetLength(0), nCols = matrix.GetLength(1);
+    var rowIdx = Enumerable.Range(0, nRows).ToList();
+    var sol = new List<int>();
+    bool Solve(int[,] m, List<int> rows, List<int> solution)
+    {
+        int nc = m.GetLength(1);
+        if (nc == 0) return true;  // matrice vide = solution
+        // Heuristique : colonne avec le minimum de 1
+        int bestCol = -1, minCount = int.MaxValue;
+        for (int j = 0; j < nc; j++)
+        {
+            int cnt = 0;
+            for (int i = 0; i < m.GetLength(0); i++) cnt += m[i, j];
+            if (cnt == 0) return false;  // colonne sans 1 = impossible
+            if (cnt < minCount) { minCount = cnt; bestCol = j; }
+        }
+        for (int i = 0; i < m.GetLength(0); i++)
+        {
+            if (m[i, bestCol] != 1) continue;
+            // Colonnes à couvrir = celles où la ligne i a un 1
+            var colsToCover = new List<int>();
+            for (int j = 0; j < nc; j++) if (m[i, j] == 1) colsToCover.Add(j);
+            // Lignes à garder = celles sans 1 sur aucune colonne conflictuelle
+            var rowsToKeep = new List<int>();
+            for (int i2 = 0; i2 < m.GetLength(0); i2++)
+            {
+                bool keep = true;
+                foreach (var cc in colsToCover) if (m[i2, cc] == 1) { keep = false; break; }
+                if (keep) rowsToKeep.Add(i2);
+            }
+            // Construire la matrice réduite
+            var newRows = rowsToKeep.Select(r => rows[r]).ToList();
+            var keptCols = Enumerable.Range(0, nc).Where(j => !colsToCover.Contains(j)).ToList();
+            int[,] reduced = new int[rowsToKeep.Count, keptCols.Count];
+            for (int a = 0; a < rowsToKeep.Count; a++)
+                for (int b = 0; b < keptCols.Count; b++)
+                    reduced[a, b] = m[rowsToKeep[a], keptCols[b]];
+            solution.Add(rows[i]);
+            if (Solve(reduced, newRows, solution)) return true;
+            solution.RemoveAt(solution.Count - 1);
+        }
+        return false;
+    }
+    return Solve(matrix, rowIdx, sol) ? sol : null;
+}
+
+var sw = System.Diagnostics.Stopwatch.StartNew();
+var naiveSol = AlgorithmXNaive(matrix);
+sw.Stop();
+var sb2 = new StringBuilder();
+sb2.AppendLine(""=== Algorithme X naïf (réduction de matrice) ==="");
+if (naiveSol != null)
+{
+    sb2.AppendLine($""Solution trouvée : [{string.Join("", "", naiveSol.Select(r => rowNames[r]))}]"");
+    sb2.AppendLine(""Solution attendue : [S2, S4, S6]"");
+}
+else sb2.AppendLine(""Aucune solution trouvée."");
+sb2.AppendLine($""Temps : {sw.Elapsed.TotalMilliseconds:F3} ms"");
+sb2.ToString().Display();",,,,,,,,d1d0ee31c9976e30,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-2c878d7e,markdown,fr,bf905dcb9a0a5796,"### Exercice 1 : Implémenter l'heuristique MRV pour le choix de colonne
+
+L'heuristique **MRV (Minimum Remaining Values)** choisit la colonne avec le **moins de 1** strictement positif. C'est elle que l'Algorithme X utilise implicitement ci-dessus. Isolez-la dans une fonction dédiée — elle retourne l'index de la colonne optimale, ou `-1` si une colonne n'a aucun 1 (échec).
+
+**Indices** : `# Etape 1` compter les 1 par colonne · `# Etape 2` détecter une colonne à 0 → retourner -1 · `# Etape 3` retourner l'index du minimum strictement positif.",,,,,,,,bf905dcb9a0a5796,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-dc9038d6,code,fr,ae8298547c14f3be,"static int ChooseColumnMrv(int[,] m)
+{
+    // TODO etudiant : implementer l'heuristique MRV
+    // Etape 1 : compter les 1 par colonne
+    // Etape 2 : si une colonne a 0 choix, retourner -1
+    // Etape 3 : trouver la colonne avec le minimum positif
+    return -1;  // TODO etudiant : remplacer par l'implementation
+}
+
+""Exercice a completer : heuristique MRV pour le choix de colonne"".Display();",,,,,,,,ae8298547c14f3be,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-04042d4f,markdown,fr,3c0b3bd884dc83d4,"### Exercice 2 : Vérifier une solution de couverture exacte
+
+Étant donnée une matrice binaire et une liste d'indices de lignes, écrire une fonction `IsExactCover` qui retourne `true` ssi ces lignes forment une couverture exacte (chaque colonne est couverte exactement une fois).
+
+**Indices** : `# Etape 1` extraire et sommer les lignes sélectionnées · `# Etape 2` vérifier que chaque colonne vaut exactement 1.",,,,,,,,3c0b3bd884dc83d4,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-9d80f4c1,code,fr,b7ff9e74718c7801,"static bool IsExactCover(int[,] m, List<int> solutionRows)
+{
+    // TODO etudiant : implementer la verification
+    // Etape 1 : extraire les lignes de la solution
+    // Etape 2 : sommer les colonnes
+    // Etape 3 : verifier que chaque colonne a exactement un 1
+    return false;  // TODO etudiant : remplacer par la verification
+}
+
+""Exercice a completer : verification d'une couverture exacte"".Display();",,,,,,,,b7ff9e74718c7801,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-47dced75,markdown,fr,820acd4269e73906,"## 3. Dancing Links — la structure de données (~20 min)
+
+### L'idée géniale de Knuth
+
+Dancing Links repose sur un fait trivial mais puissant des **listes doublement chaînées circulaires** :
+
+```
+// Supprimer un nœud X de sa liste (horizontale) :
+X.R.L = X.L;
+X.L.R = X.R;
+
+// Restaurer X exactement (opération inverse, O(1)) :
+X.L.R = X;
+X.R.L = X;
+```
+
+Comme chaque nœud « connaît » ses voisins, **supprimer puis restaurer est symétrique**. Pas besoin de pile de undo, pas de recopie : le backtracking devient quasiment gratuit.
+
+On organise la matrice binaire comme un **réseau toroïdal** de nœuds :
+- Chaque **1** de la matrice = un `DataNode`.
+- Chaque **colonne** a un `ColumnNode` (tête) qui compte ses 1 (`size`).
+- Un `Header` (racine « ROOT ») chaîne toutes les `ColumnNode`.
+- Chaque nœud a **4 pointeurs** : `L` (left), `R` (right), `U` (up), `D` (down), plus `C` (sa colonne).
+- Toutes les listes sont **circulaires** (le dernier pointe vers le premier).
+
+**Opération `cover(c)`** : retire la colonne `c` de la liste des colonnes, puis retire chaque ligne qui contient un 1 dans `c` (en parcourant les autres colonnes de cette ligne et en les détachant verticalement). **`uncover(c)`** fait exactement l'inverse, dans l'ordre inverse — crucial pour restaurer l'état.",,,,,,,,820acd4269e73906,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-7217a145,code,fr,4b0cdad11beabaa7,"// Structure de données Dancing Links (implémentation C# from-scratch)
+
+public class DlxNode
+{
+    public string Name = """";     // nom de la colonne (pour ColumnNode)
+    public int Size;             // nombre de 1 dans la colonne (ColumnNode seulement)
+    public int RowIndex = -1;    // index de ligne (DataNode seulement)
+    public DlxNode L, R, U, D, C;  // 4 pointeurs + colonne
+    public bool IsColumn => RowIndex == -1 && C == this;
+}
+
+static DlxNode MakeColumn(string name)
+{
+    var c = new DlxNode { Name = name };
+    c.L = c.R = c.U = c.D = c.C = c;  // circulaire sur soi-même
+    return c;
+}
+
+static DlxNode MakeDataNode(DlxNode column, int rowIndex)
+{
+    var n = new DlxNode { C = column, RowIndex = rowIndex };
+    n.L = n.R = n.U = n.D = n;
+    return n;
+}
+
+// cover : détache la colonne et toutes ses lignes conflictuelles
+static void Cover(DlxNode column)
+{
+    column.L.R = column.R;
+    column.R.L = column.L;
+    for (var i = column.D; i != column; i = i.D)
+        for (var j = i.R; j != i; j = j.R)
+        {
+            j.D.U = j.U;
+            j.U.D = j.D;
+            j.C.Size--;
+        }
+}
+
+// uncover : restaure exactement (ordre inverse — crucial)
+static void Uncover(DlxNode column)
+{
+    for (var i = column.U; i != column; i = i.U)
+        for (var j = i.L; j != i; j = j.L)
+        {
+            j.C.Size++;
+            j.D.U = j;
+            j.U.D = j;
+        }
+    column.L.R = column;
+    column.R.L = column;
+}
+
+// Construction de la structure toroïdale depuis une matrice binaire
+static DlxNode BuildDlxStructure(int[,] matrix, out List<DlxNode> rowHeads)
+{
+    int nRows = matrix.GetLength(0), nCols = matrix.GetLength(1);
+    var header = MakeColumn(""ROOT"");
+    var columns = new DlxNode[nCols];
+    var prevCol = header;
+    for (int j = 0; j < nCols; j++)
+    {
+        columns[j] = MakeColumn(j.ToString());
+        columns[j].L = prevCol;
+        prevCol.R = columns[j];
+        prevCol = columns[j];
+    }
+    header.L = columns[nCols - 1];
+    columns[nCols - 1].R = header;
+    rowHeads = new List<DlxNode>();
+    for (int r = 0; r < nRows; r++)
+    {
+        DlxNode firstInRow = null, prevInRow = null;
+        for (int j = 0; j < nCols; j++)
+        {
+            if (matrix[r, j] != 1) continue;
+            var node = MakeDataNode(columns[j], r);
+            // insertion verticale en bas de la colonne
+            node.U = columns[j].U;
+            node.D = columns[j];
+            columns[j].U.D = node;
+            columns[j].U = node;
+            columns[j].Size++;
+            // chaînage horizontal
+            if (firstInRow == null) firstInRow = node;
+            if (prevInRow != null) { node.L = prevInRow; prevInRow.R = node; }
+            prevInRow = node;
+        }
+        if (firstInRow != null) { firstInRow.L = prevInRow; prevInRow.R = firstInRow; rowHeads.Add(firstInRow); }
+    }
+    return header;
+}
+
+""Classes Dancing Links (DlxNode) + Cover/Uncover + BuildDlxStructure definies."".Display();",,,,,,,,4b0cdad11beabaa7,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-295ec0ac,markdown,fr,eeb2546273da841c,"## 4. Implémentation DLX (~25 min)
+
+L'algorithme DLX = l'Algorithme X **opérant sur la structure Dancing Links**. À chaque étape :
+
+1. Si `header.R == header` → plus de colonnes → **solution trouvée**.
+2. Choisir la colonne `c` de `size` minimum (heuristique S — équivalente à MRV).
+3. `cover(c)`.
+4. Pour chaque nœud `r` dans la colonne `c` (descendre) :
+   - Ajouter `r` à la solution.
+   - `cover` de chaque colonne touchée par la ligne de `r`.
+   - Récursion. Si succès → retour vrai.
+   - Sinon : `uncover` dans l'ordre inverse, retirer `r` de la solution.
+5. `uncover(c)` et retourner faux.
+
+La magie : `cover`/`uncover` sont O(1) par nœud, donc le backtracking ne recopie **aucune matrice**.",,,,,,,,eeb2546273da841c,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-9352e61e,code,fr,1d543c235d393dd3,"// Algorithme X avec Dancing Links (DLX) — récursif, heuristique S
+static bool Search(DlxNode header, List<DlxNode> solution)
+{
+    if (header.R == header) return true;  // plus de colonnes = solution
+    // Choisir la colonne avec le minimum de 1 (heuristique S)
+    DlxNode c = null;
+    int minSize = int.MaxValue;
+    for (var j = header.R; j != header; j = j.R)
+        if (j.Size < minSize) { minSize = j.Size; c = j; }
+    if (minSize == 0) return false;  // colonne vide = cul-de-sac
+    Cover(c);
+    for (var r = c.D; r != c; r = r.D)
+    {
+        solution.Add(r);
+        for (var j = r.R; j != r; j = j.R) Cover(j.C);
+        if (Search(header, solution)) return true;
+        // backtrack
+        solution.RemoveAt(solution.Count - 1);
+        for (var j = r.L; j != r; j = j.L) Uncover(j.C);
+    }
+    Uncover(c);
+    return false;
+}
+
+static List<int>? SolveDlx(int[,] matrix)
+{
+    var header = BuildDlxStructure(matrix, out _);
+    var sol = new List<DlxNode>();
+    if (Search(header, sol)) return sol.Select(n => n.RowIndex).ToList();
+    return null;
+}
+
+var swDlx = System.Diagnostics.Stopwatch.StartNew();
+var dlxSol = SolveDlx(matrix);
+swDlx.Stop();
+var sb3 = new StringBuilder();
+sb3.AppendLine(""=== Algorithme X avec Dancing Links (DLX) ==="");
+if (dlxSol != null)
+{
+    sb3.AppendLine($""Solution DLX : [{string.Join("", "", dlxSol.Select(r => rowNames[r]))}]"");
+    sb3.AppendLine(""Solution attendue : [S2, S4, S6]"");
+    sb3.AppendLine($""Vérification : {(dlxSol.Count == 3 && dlxSol.Contains(1) && dlxSol.Contains(3) && dlxSol.Contains(5) ? ""CORRECT"" : ""?"" )}"");
+}
+else sb3.AppendLine(""Aucune solution trouvée."");
+sb3.AppendLine($""Temps : {swDlx.Elapsed.TotalMilliseconds:F3} ms"");
+sb3.ToString().Display();",,,,,,,,1d543c235d393dd3,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-55cbf259,markdown,fr,c0ddd1571f1e26b6,"### Exercice 3 : Compter toutes les solutions
+
+La fonction `SolveDlx` ci-dessus s'arrête à la **première** solution. Écrivez `CountAllSolutions` qui compte **toutes** les couvertures exactes d'une matrice. Indice : la structure `Cover`/`Uncover` symétrique permet d'énumérer sans dupliquer ni Corrompre l'état.
+
+**Indices** : `# Etape 1` construire la structure DLX · `# Etape 2` modifier `Search` pour qu'au cas de base (`header.R == header`) elle incrémente un compteur et continue au lieu de retourner vrai · `# Etape 3` retourner le total.",,,,,,,,c0ddd1571f1e26b6,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-3155e942,code,fr,690205eca426b761,"static int CountAllSolutions(int[,] matrix)
+{
+    // TODO etudiant : compter toutes les solutions
+    // Etape 1 : construire la structure DLX avec BuildDlxStructure
+    // Etape 2 : modifier Search pour compter au lieu de s'arreter a la premiere
+    // Etape 3 : lancer la recherche exhaustive et retourner le compteur
+    return 0;  // TODO etudiant : remplacer par le vrai comptage
+}
+
+""Exercice a completer : comptage de toutes les solutions"".Display();",,,,,,,,690205eca426b761,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-04881c35,markdown,fr,e01b092de963628a,"## 5. Application — Pavage de polyominos (~10 min)
+
+Le **pavage** est l'application vedette de DLX : paver une grille avec des formes (polyominos) revient à une couverture exacte.
+
+- **Colonnes** = une par case de la grille (chaque case doit être couverte exactement une fois).
+- **Lignes** = un **placement** (forme + position + rotation) : la ligne a un 1 dans la case occupée par chaque cellule du placement.
+
+Résoudre la couverture exacte = trouver un jeu de placements non conflictuels couvrant toute la grille.
+
+### Exemple : grille 3×2 pavée par des triominos
+
+Deux formes : le triomino **I** (3 cases en ligne) et le triomino **L**. Construisons la matrice et résolvons-la avec DLX.",,,,,,,,e01b092de963628a,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-c989a575,code,fr,cf7fcc7aad915c7e,"// Pavage d'une grille 3×2 par deux triominos (I vertical, L)
+// Représentation : cellule (ligne, col) → index = ligne * largeur + col
+
+static (int[,], List<string>) BuildTilingMatrix(int gridW, int gridH, Dictionary<string, List<(int,int)>> polyominos)
+{
+    var placements = new List<(string name, List<(int r,int c)> cells)>();
+    foreach (var (polyName, shape) in polyominos)
+    {
+        // Normaliser la forme
+        int minR = shape.Min(p => p.Item1), minC = shape.Min(p => p.Item2);
+        var norm = shape.Select(p => (p.Item1 - minR, p.Item2 - minC)).ToList();
+        int sh = norm.Max(p => p.Item1) + 1, sw = norm.Max(p => p.Item2) + 1;
+        // Essayer les 4 rotations
+        var current = norm;
+        int ch = sh, cw = sw;
+        for (int rot = 0; rot < 4; rot++)
+        {
+            // Essayer chaque position dans la grille
+            for (int sr = 0; sr <= gridH - ch; sr++)
+                for (int sc = 0; sc <= gridW - cw; sc++)
+                {
+                    var cells = current.Select(p => (p.Item1 + sr, p.Item2 + sc)).ToList();
+                    if (cells.All(p => p.Item1 >= 0 && p.Item1 < gridH && p.Item2 >= 0 && p.Item2 < gridW))
+                        placements.Add((polyName, cells));
+                }
+            // Rotation 90° : (r,c) -> (c, ch-1-r)
+            var rot2 = current.Select(p => (p.Item2, ch - 1 - p.Item1)).ToList();
+            current = rot2;
+            (ch, cw) = (cw, ch);  // les dimensions s'échangeant
+        }
+    }
+    int nConstraints = gridW * gridH;
+    int[,] m = new int[placements.Count, nConstraints];
+    var labels = new List<string>();
+    for (int i = 0; i < placements.Count; i++)
+    {
+        foreach (var (r, c) in placements[i].cells)
+            m[i, r * gridW + c] = 1;
+        labels.Add($""{placements[i].name}@{string.Join(""|"", placements[i].cells.Select(p => $""{p.r},{p.c}""))}"");
+    }
+    return (m, labels);
+}
+
+var triominos = new Dictionary<string, List<(int,int)>>
+{
+    [""I""] = new() { (0,0), (1,0), (2,0) },  // vertical (3×1)
+    [""L""] = new() { (0,0), (1,0), (1,1) },  // forme L
+};
+
+var (mTiling, labels) = BuildTilingMatrix(2, 3, triominos);  // grille 2×3
+var tilingSol = SolveDlx(mTiling);
+var sb4 = new StringBuilder();
+sb4.AppendLine(""=== Pavage d'une grille 2×3 par des triominos ==="");
+sb4.AppendLine($""Matrice : {mTiling.GetLength(0)} placements × {mTiling.GetLength(1)} cases-contraintes"");
+if (tilingSol != null)
+{
+    sb4.AppendLine($""Solution : {tilingSol.Count} placements"");
+    foreach (var idx in tilingSol) sb4.AppendLine($""  - {labels[idx]}"");
+}
+else sb4.AppendLine(""Aucun pavage exact trouvé."");
+sb4.ToString().Display();",,,,,,,,cf7fcc7aad915c7e,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-872d20ce,markdown,fr,a0f67c091bc899a9,"## 6. Comparaison de performances DLX vs backtracking (~10 min)
+
+Comparons DLX à un **backtracking classique** (sans la structure Dancing Links, qui re-teste la cohérence à chaque pas) sur une instance de pavage plus large. L'écart illustre pourquoi la structure de données — pas seulement l'algorithme — compte en pratique.",,,,,,,,a0f67c091bc899a9,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-d0d3a232,code,fr,a4446e5f056d7cff,"// Backtracking classique sur couverture exacte (référence naive pour la comparaison)
+static bool BacktrackExactCover(int[,] m, List<int> partial, ref int bestCount, HashSet<int> coveredCols)
+{
+    int nCols = m.GetLength(1);
+    if (coveredCols.Count == nCols) { bestCount++; return true; }
+    // Trouver la première colonne non couverte
+    int targetCol = -1;
+    for (int j = 0; j < nCols; j++) if (!coveredCols.Contains(j)) { targetCol = j; break; }
+    for (int r = 0; r < m.GetLength(0); r++)
+    {
+        if (m[r, targetCol] != 1) continue;
+        // Vérifier la compatibilité (pas de chevauchement)
+        bool ok = true;
+        for (int j = 0; j < nCols; j++) if (m[r, j] == 1 && coveredCols.Contains(j)) { ok = false; break; }
+        if (!ok) continue;
+        var newCols = new List<int>();
+        for (int j = 0; j < nCols; j++) if (m[r, j] == 1) { coveredCols.Add(j); newCols.Add(j); }
+        partial.Add(r);
+        if (BacktrackExactCover(m, partial, ref bestCount, coveredCols)) { /* on ne stoppe pas pour mesure */ }
+        partial.RemoveAt(partial.Count - 1);
+        foreach (var j in newCols) coveredCols.Remove(j);
+    }
+    return false;
+}
+
+// Comparaison sur un pavage 3×3 (instance plus large)
+var (mBig, labelsBig) = BuildTilingMatrix(3, 3, triominos);
+
+var swBt = System.Diagnostics.Stopwatch.StartNew();
+int btCount = 0;
+BacktrackExactCover(mBig, new List<int>(), ref btCount, new HashSet<int>());
+swBt.Stop();
+
+var swD = System.Diagnostics.Stopwatch.StartNew();
+var bigSol = SolveDlx(mBig);
+swD.Stop();
+
+var sb5 = new StringBuilder();
+sb5.AppendLine(""=== Comparaison DLX vs backtracking classique (pavage 3×3) ==="");
+sb5.AppendLine($""Taille de la matrice : {mBig.GetLength(0)} placements × {mBig.GetLength(1)} contraintes"");
+sb5.AppendLine($""DLX              : {swD.Elapsed.TotalMilliseconds:F3} ms  → {(bigSol != null ? ""solution trouvée"" : ""pas de solution"")}"");
+sb5.AppendLine($""Backtracking     : {swBt.Elapsed.TotalMilliseconds:F3} ms"");
+sb5.AppendLine();
+sb5.AppendLine(""DLX évite la recopie de matrice (cover/uncover O(1) par nœud),"");
+sb5.AppendLine(""tandis que le backtracking classique re-vérifie la compatibilité à chaque pas."");
+sb5.ToString().Display();",,,,,,,,a4446e5f056d7cff,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-bb36d206,markdown,fr,b8a46616c502ecf5,"## 7. Exemple guidé + Exercice 4
+
+### Exemple guidé : instance simple
+
+Revenons à l'exemple canonique (section 1). La matrice 6×7 admet une unique couverture exacte `{S2, S4, S6}`. Les deux solveurs (`AlgorithmXNaive` et `SolveDlx`) la retrouvent — DLX sans jamais recopier la matrice.
+
+### Exercice 4 : Pavage d'une grille 3×5 avec des trominos
+
+**Énoncé** : On souhaite paver une grille 3×5 (15 cases) avec 5 triominos. Modifiez le dictionnaire `triominos` et la taille de grille dans la cellule de pavage pour résoudre ce problème. Combien de pavages distincts existe-t-il ?",,,,,,,,b8a46616c502ecf5,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-e1ae1531,code,fr,a51a8a9aea9918a4,"// Exercice 4 : Pavage d'une grille 3×5 avec des triominos
+// TODO etudiant : adapter BuildTilingMatrix(5, 3, ...) avec les bonnes formes
+// puis compter le nombre de pavages distincts (utiliser CountAllSolutions de l'exercice 3).
+""Exercice a completer : pavage d'une grille 3×5 avec des triominos"".Display();",,,,,,,,a51a8a9aea9918a4,,,,,,,
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks-Csharp.ipynb,cell-209c0192,markdown,fr,aee6ecf5f64531c1,"---
+
+## Conclusion
+
+Vous avez implémenté **from-scratch** l'Algorithme X de Knuth avec la structure **Dancing Links (DLX)** en C#, validé sur l'exemple canonique de couverture exacte et appliqué au pavage de polyominos. Leçon centrale : la performance d'un algorithme de backtracking ne dépend pas que de la stratégie de recherche, mais surtout de la **structure de données** — la symétrie cover/uncover en O(1) est ce qui rend DLX si efficace sur les problèmes NP-complets à grande matrice creuse (Sudoku, N-reines, pentominoes).
+
+**Verdict #3801 (prong A — SOTA-OK)** : .NET n'a pas de bibliothèque DLX dominante (contrairement à Python où on pourrait importer un solveur) ; l'implémentation from-scratch de la structure toroïdale et des opérations cover/uncover **est** la leçon pédagogique. Les sorties texte passent par `StringBuilder.Display()` plutôt qu'une lib de plotting — en exécution papermill headless, `Console.WriteLine` est avalé, `.Display()` capture `text/plain` (verdict intrinsèque #3436, cohérent avec le twin GA).
+
+**Navigation** : [<< Search-7 MCTS](Search-7-MCTS-And-Beyond.ipynb) | [↑ Série Search (C#)](../README.md) | [Search-9 Linear Programming >>](Search-9-LinearProgramming.ipynb)",,,,,,,,aee6ecf5f64531c1,,,,,,,


### PR DESCRIPTION
## Summary

`Search/Part1-Foundations` source notebooks drifted (**43 SRC_DRIFT**) vs the translation CSV. Source markdown changes (accents FR, content expansion in Search-1/2/10/11/15 — Python + C# twins) were not propagated to the FR-pivot CSV.

Resynced via `extract_cells_to_csv.py --update` (#6514 incremental merge mode) → **43 drift → 0**.

## Method

`extract_cells_to_csv.py MyIA.AI.Notebooks/Search/Part1-Foundations --update translations/search-part1/search-part1.csv --repo-root .`

Incremental merge refreshes drifted source rows (FR pivot + `src_hash`) while preserving existing translations and in-sync rows.

**Result**: 43 refreshed, 87 new (content expansion in Search series source), 1038 in-sync, 0 orphan.

## Verification (firsthand, G.1)

| Check | Before | After |
|-------|--------|-------|
| `check_translation_sync` drift | 43 SRC_DRIFT | **0** |
| CSV integrity | — | 1169 rows / 21 cols / **0 malformed** |
| CRLF byte count | — | **0** (LF-only) |
| Scope | — | 1 file (CSV only) — no notebooks / catalog touched |
| Full-repo regression | — | search-part1 = 0 (others untouched) |

CSV-only change → C.2/H.3 N/A.

See #4957.

## Honest R6 note

My accessible substance lanes are genuinely drained this cycle (verified firsthand 4 ways): Lean i18n knot = all 6 files claimed/done (Lidman #6440, Conway #6476, Invariant CLAIMED, Basic/MathlibPrerequisites/Reidemeister done); grothendieck drained (c.454); Lean toolchain broken locally (lake build FAIL, ai-01 repairing); nav-links = 0 broken in ML/Probas/GenAI/Sudoku/GameTheory/IIT/QC; figures #5780 = vision-required (GLM lane excluded); QC catalog drained; Lean prover = 0 sorry viable (Gittins/Folk INTRINSIC). search-part1 translation is the cleanest **uncontested** executable grain — different family (Search) from c.455 (Probas/Infer).