### PR TITLE
fix(security): broaden NuGet-ext hook — path-based detector + stream variant (follow-up #6536)

### DIFF
--- a/scripts/notebook_tools/strip_machine_paths.py
+++ b/scripts/notebook_tools/strip_machine_paths.py
@@ -1,22 +1,27 @@
 #!/usr/bin/env python3
-"""Strip the .NET Interactive ``Loading extensions from <NuGet cache>`` artifact
-from notebooks.
+"""Strip the .NET Interactive NuGet-cache machine-username leak from notebooks.
 
 When ``dotnet-interactive`` (the .NET kernel) processes a ``#r "nuget:..."``
-cell that ships an **interactive extension**, it injects a ``display_data``
-output whose ``data["text/plain"]`` is a single line such as::
+cell that ships an **interactive extension**, it emits **two** distinct
+kernel messages that both carry the worker's **local NuGet package cache**
+path, which embeds the machine username (``C:\\Users\\<user>\\``):
 
-    Loading extensions from `C:\\Users\\<user>\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`
+1. a ``display_data`` output whose ``data["text/plain"]`` is::
 
-The backtick-delimited path is the worker's **local NuGet package cache**, which
-embeds the machine username (``C:\\Users\\<user>\\``) — a PII-lite leak on a
-public repo (the username is the maintainer's GitHub handle / prof identity,
-correlable but not a rotatable secret, cf. ``#6443`` / ``#6529``). The message is
-**dead noise in a static notebook**: it only matters inside a live kernel
-session (it confirms an extension loaded), and it is **re-injected at every
+       Loading extensions from `C:\\Users\\<user>\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`
+
+2. a ``stream`` (stderr) output whose ``text`` is::
+
+       Failed to load kernel extension "KernelExtension" from assembly C:\\Users\\<user>\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll
+
+Both embed ``C:\\Users\\<user>\\`` — a PII-lite leak on a public repo (the
+username is the maintainer's GitHub handle / prof identity, correlable but not
+a rotatable secret, cf. ``#6443`` / ``#6529``). The messages are **dead noise
+in a static notebook**: they only matter inside a live kernel session (they
+confirm / warn about an extension load), and they are **re-injected at every
 kernel re-execution** — so, exactly like the ``probeAddresses`` banner (cf.
-``strip_probe_banner.py``, ``#6309``), re-exec does NOT fix it. The durable fix
-is to make the leak **un-committable** via this pre-commit hook.
+``strip_probe_banner.py``, ``#6309``), re-exec does NOT fix it. The durable
+fix is to make the leak **un-committable** via this pre-commit hook.
 
 This is the **category-A (kernel-injected / env-dependent)** leak family of
 rule-6 (``secrets-hygiene.md``): the username comes from the worker's
@@ -25,16 +30,27 @@ rule-6 (``secrets-hygiene.md``): the username comes from the worker's
 durable approach for category-A kernel-injected leaks (cf. ``strip_probe_banner.py``
 post-mortem).
 
+**Detection is path-based, not signature-based.** A line is a leak iff it
+carries a NuGet-cache path (``.nuget``) that embeds a **real username**
+(``C:\\Users\\<u>``, ``Users/<u>``, ``/home/<u>``). The dotnet-interactive
+**tilde** variant — ``~\\.nuget\\packages\\...`` (the ``%USERPROFILE%`` HOME
+*placeholder*, no username) — is therefore **correctly left untouched**: it
+carries no PII. Keying on the username path (not the message prefix) catches
+both kernel messages uniformly and is robust to future message rewording
+(cf. ``#6537`` review: the v1 hook keyed on ``Loading extensions from`` and
+both missed the ``stream`` ``Failed to load`` variant AND false-positive
+stripped legitimate tilde ``Loading extensions from`` lines).
+
 The strip is **output-only** — no source code is touched, ``execution_count``
 is preserved, the surrounding ``outputs: [...]`` shape is unchanged. Same
 surgical philosophy as ``strip_probe_banner.py`` / ``scrub_papermill_paths.py``:
 a text-level edit on the on-disk JSON so the rest of the file is byte-identical
 (no JSON re-serialization, no float coercion, no metadata churn).
 
-Scope (this hook): the ``Loading extensions from`` NuGet-cache message only.
-The other username-path patterns catalogued in ``#6529`` (HuggingFace-cache
-download warnings, pip ``AppData`` tracebacks, conda env paths) are Python-side
-and multi-line; they are tracked for follow-up hooks. See ``gh issue view 6529``.
+Scope (this hook): the .NET NuGet-cache kernel messages only. The other
+username-path patterns catalogued in ``#6529`` (HuggingFace-cache download
+warnings, pip ``AppData`` tracebacks, conda env paths) are Python-side and
+multi-line; they are tracked for follow-up hooks. See ``gh issue view 6529``.
 
 Usage:
     python strip_machine_paths.py --scan <path>      # dry-run, list only
@@ -52,37 +68,64 @@ import re
 import sys
 
 
-# Distinctive substring of the dotnet-interactive extension-load message. The
-# full line is ``Loading extensions from `<local-path>```; this signature is
-# specific to the ``#r "nuget:..."`` interactive-extension load (verified on
-# .NET notebooks produced by dotnet-interactive 1.0.x — 8/8 occurrences across
-# 53 username-leaking notebooks carry a user-profile path, 0 false positives).
-EXT_LOAD_SIGNATURE = "Loading extensions from"
+# Detection is **path-based**: a line is a leak iff it references the local
+# NuGet package cache (``.nuget``) AND embeds a real machine username. Two
+# dotnet-interactive kernel messages carry this payload — the ``display_data``
+# ``Loading extensions from <path>`` and the ``stream`` ``Failed to load kernel
+# extension ... from assembly <path>`` — and keying on the username path
+# (rather than the message prefix) catches both, cf. the ``#6537`` review which
+# found the v1 signature-based detector (a) missed the stream variant and
+# (b) false-positive stripped legitimate tilde lines.
+NUGET_CACHE_TOKEN = ".nuget"
 
-# A line is flagged as a leak only if it carries BOTH the signature AND a
-# user-profile / NuGet-cache path token. The path token requirement is the
-# FP guard: a hypothetical "Loading extensions from <relative-path>" without
-# a user-profile segment would not be a username leak and is left untouched.
-USER_PATH_TOKENS = (".nuget", "Users\\", "Users/", "/home/", "AppData\\")
+# Username-bearing absolute-path markers — the actual PII payload. The
+# dotnet-interactive **tilde** variant (``~\.nuget\packages\...``) is the
+# ``%USERPROFILE%`` HOME *placeholder* and carries NONE of these, so it is
+# correctly left untouched (no username = no leak).
+USERNAME_MARKERS = ("Users\\", "Users/", "/home/")
 
-# The kernel injects the message in ``data["text/plain"]`` (observed shape).
-# ``text/html`` is scanned too for robustness (future kernel versions may emit
-# it there), matching ``strip_probe_banner.py``'s defensive dual-scan.
+# Output fields that can carry the leak:
+# - ``data["text/plain"]`` / ``data["text/html"]`` for ``display_data`` /
+#   ``execute_result`` outputs (the ``Loading extensions from`` message).
+# - top-level ``text`` for ``stream`` outputs (the ``Failed to load kernel
+#   extension ... from assembly`` message lives in stderr ``text``).
 DATA_KEYS = ("text/plain", "text/html")
+STREAM_KEY = "text"
+ALL_KEYS = DATA_KEYS + (STREAM_KEY,)
 
 
 def _has_leak(text):
     """Return True if ``text`` (a str, or one element of a list) carries the
-    extension-load leak."""
+    NuGet-cache username leak. Path-based: requires BOTH the NuGet-cache
+    context token AND a username absolute-path marker (the tilde HOME
+    placeholder carries neither marker and is left untouched)."""
     if not isinstance(text, str):
         return False
-    if EXT_LOAD_SIGNATURE not in text:
+    if NUGET_CACHE_TOKEN not in text:
         return False
-    return any(tok in text for tok in USER_PATH_TOKENS)
+    return any(marker in text for marker in USERNAME_MARKERS)
+
+
+def _field_value(out, key):
+    """Return the list/str value of output field ``key``, or None.
+
+    ``data["text/plain"|"text/html"]`` for display_data/execute_result;
+    top-level ``text`` for stream outputs. (A bare ``"text"`` key is
+    stream-specific in nbformat outputs — display_data nests text under
+    ``data``, so there is no collision with ``text/plain``.)
+    """
+    if key in DATA_KEYS:
+        data = out.get("data", {})
+        if not isinstance(data, dict):
+            return None
+        return data.get(key)
+    if key == STREAM_KEY:
+        return out.get(STREAM_KEY)
+    return None
 
 
 def _output_has_leak(blob):
-    """Return True if any element of a ``data[*]`` value (list or str) leaks."""
+    """Return True if any element of a field value (list or str) leaks."""
     if isinstance(blob, list):
         return any(_has_leak(el) for el in blob)
     return _has_leak(blob)
@@ -93,6 +136,7 @@ def count_leak_lines(nb_path):
 
     Semantic is **distinct leak-bearing elements** (one per line for list-form,
     one per string output for string-form), aligned with what the strip removes.
+    Scans both ``display_data`` data keys and ``stream`` ``text``.
     """
     try:
         with open(nb_path, encoding="utf-8") as f:
@@ -104,11 +148,8 @@ def count_leak_lines(nb_path):
         if cell.get("cell_type") != "code":
             continue
         for out in cell.get("outputs", []):
-            data = out.get("data", {})
-            if not isinstance(data, dict):
-                continue
-            for key in DATA_KEYS:
-                v = data.get(key)
+            for key in ALL_KEYS:
+                v = _field_value(out, key)
                 if isinstance(v, list):
                     n += sum(1 for el in v if _has_leak(el))
                 elif _has_leak(v):
@@ -117,7 +158,11 @@ def count_leak_lines(nb_path):
 
 
 def find_leak_outputs(nb_path):
-    """Return list of ``(cell_index, output_index, data_key)`` for leak outputs."""
+    """Return list of ``(cell_index, output_index, field_key)`` for leak outputs.
+
+    ``field_key`` is one of ``text/plain`` / ``text/html`` (display_data /
+    execute_result) or ``text`` (stream).
+    """
     try:
         with open(nb_path, encoding="utf-8") as f:
             nb = json.load(f)
@@ -128,11 +173,8 @@ def find_leak_outputs(nb_path):
         if cell.get("cell_type") != "code":
             continue
         for oi, out in enumerate(cell.get("outputs", [])):
-            data = out.get("data", {})
-            if not isinstance(data, dict):
-                continue
-            for key in DATA_KEYS:
-                if _output_has_leak(data.get(key)):
+            for key in ALL_KEYS:
+                if _output_has_leak(_field_value(out, key)):
                     hits.append((ci, oi, key))
     return hits
 
@@ -214,7 +256,7 @@ def strip_in_place(nb_path):
 
     new_text = text
     fixed = 0
-    str_pat = re.compile(r'"((?:text/plain|text/html))"\s*:\s*"((?:[^"\\]|\\.)*)"')
+    str_pat = re.compile(r'"((?:text/plain|text/html|text))"\s*:\s*"((?:[^"\\]|\\.)*)"')
     elem_pat = re.compile(r'"((?:[^"\\]|\\.)*)"')
 
     # --- String-form: replace the whole "<key>": "<...>" with "<key>": "" ---
@@ -228,7 +270,7 @@ def strip_in_place(nb_path):
         outs = cell.get("outputs", [])
         if oi >= len(outs):
             continue
-        v = outs[oi].get("data", {}).get(key)
+        v = _field_value(outs[oi], key)
         if isinstance(v, str) and _has_leak(v):
             str_targets.append((key, v))
 
@@ -248,7 +290,7 @@ def strip_in_place(nb_path):
                 break
 
     # --- List-form: drop leak-bearing elements (+ trailing/preceding comma) ---
-    for key in DATA_KEYS:
+    for key in ALL_KEYS:
         blocks = _find_data_list_bounds(new_text, key)
         # Filter to blocks that contain at least one leak-bearing element.
         leak_blocks = []
@@ -321,8 +363,9 @@ def iter_notebooks(nb_root):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Strip the .NET 'Loading extensions from <NuGet cache>' "
-                    "machine-username leak from notebooks"
+        description="Strip the .NET NuGet-cache machine-username leak "
+                    "('Loading extensions from' display_data + 'Failed to load "
+                    "kernel extension' stream) from notebooks"
     )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--scan", metavar="PATH",

--- a/scripts/notebook_tools/tests/test_strip_machine_paths.py
+++ b/scripts/notebook_tools/tests/test_strip_machine_paths.py
@@ -1,14 +1,21 @@
-"""Tests for scripts/notebook_tools/strip_machine_paths.py — .NET NuGet-extension
+"""Tests for scripts/notebook_tools/strip_machine_paths.py — .NET NuGet-cache
 machine-username leak scrubber.
 
+Detection is **path-based** (NuGet-cache token + username absolute-path
+marker), so it matches BOTH dotnet-interactive kernel messages:
+- ``display_data`` ``data["text/plain"]``: "Loading extensions from <path>"
+- ``stream`` ``text``: "Failed to load kernel extension ... from assembly <path>"
+
+and leaves the **tilde** HOME-placeholder variant (``~\\.nuget\\packages\\...``)
+untouched (no username = no leak), cf. the ``#6537`` review.
+
 Tests focus on:
-- detection: the ``Loading extensions from`` signature matches only the
-  kernel-injected NuGet-cache message carrying a user-profile path, never
-  legitimate prose and never a relative path without a user-profile segment
+- detection: username NuGet path matches in BOTH messages; tilde never matches;
+  relative paths never match
 - strip safety: ``execution_count`` preserved, ``outputs`` shape stable, other
   ``data`` keys untouched, JSON stays valid
 - idempotency: re-running ``strip_in_place`` on a clean file is a no-op
-- both list-form (observed) and string-form data values
+- list-form (observed) and string-form data/stream values
 """
 
 import json
@@ -19,8 +26,10 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from strip_machine_paths import (
-    EXT_LOAD_SIGNATURE,
-    USER_PATH_TOKENS,
+    NUGET_CACHE_TOKEN,
+    USERNAME_MARKERS,
+    STREAM_KEY,
+    DATA_KEYS,
     count_leak_lines,
     find_leak_outputs,
     strip_in_place,
@@ -53,41 +62,74 @@ def _write_nb(path, cells):
     return path
 
 
-def _nuget_ext_output(data_key="text/plain", form="list"):
-    """Build a synthetic 'Loading extensions from' display_data output.
+_DISPLAY_LINE = (
+    "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\"
+    "skiasharp\\2.88.9\\interactive-extensions\\dotnet\\"
+    "SkiaSharp.DotNet.Interactive.dll`"
+)
+_STREAM_LINE = (
+    'Failed to load kernel extension "KernelExtension" from assembly '
+    "C:\\Users\\jsboi\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\"
+    "lib\\net7.0\\XPlot.Plotly.Interactive.dll"
+)
+_TILDE_DISPLAY_LINE = (
+    "Loading extensions from `~\\.nuget\\packages\\xplot.plotly.interactive\\"
+    "4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll`"
+)
+_TILDE_STREAM_LINE = (
+    'Failed to load kernel extension "KernelExtension" from assembly '
+    "~\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\"
+    "XPlot.Plotly.Interactive.dll"
+)
 
-    form='list' -> data[key] is a list[str] (the observed shape).
-    form='str'  -> data[key] is a single inline string.
-    """
-    line = ("Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\"
-            "skiasharp\\2.88.9\\interactive-extensions\\dotnet\\"
-            "SkiaSharp.DotNet.Interactive.dll`")
+
+def _display_output(line, data_key="text/plain", form="list"):
     value = [line] if form == "list" else line
-    return {"output_type": "display_data",
-            "data": {data_key: value},
+    return {"output_type": "display_data", "data": {data_key: value},
             "metadata": {}}
+
+
+def _stream_output(line, form="list"):
+    value = [line] if form == "list" else line
+    return {"output_type": "stream", "name": "stderr", "text": value}
 
 
 # ---------------------------------------------------------------------------
 # Detection
 # ---------------------------------------------------------------------------
 
-def test_has_leak_matches_nuget_cache_path():
-    line = ("Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\"
-            "plotly.net.interactive\\5.0.0\\lib\\netstandard2.1\\"
-            "Plotly.NET.Interactive.dll`")
-    assert _has_leak(line) is True
+def test_has_leak_matches_display_username_path():
+    assert _has_leak(_DISPLAY_LINE) is True
 
 
-def test_has_leak_requires_user_path_token():
-    """Signature present but no user-profile path -> NOT a leak (FP guard)."""
-    line = "Loading extensions from `./local-build/MyExt.dll`"
+def test_has_leak_matches_stream_username_path():
+    """The 'Failed to load kernel extension ... from assembly' stream variant
+    (the one the v1 signature-based hook missed, cf #6537 review)."""
+    assert _has_leak(_STREAM_LINE) is True
+
+
+def test_has_leak_requires_username_marker_not_just_nuget():
+    """Tilde HOME placeholder + NuGet cache = NOT a leak (no username)."""
+    assert _has_leak(_TILDE_DISPLAY_LINE) is False
+    assert _has_leak(_TILDE_STREAM_LINE) is False
+
+
+def test_has_leak_requires_nuget_context():
+    """Username path present but no NuGet-cache context -> not this leak
+    (avoids over-matching arbitrary C:\\Users\\x\\ paths in other outputs)."""
+    line = "Wrote output to C:\\Users\\jsboi\\Documents\\report.txt"
     assert _has_leak(line) is False
 
 
-def test_has_leak_requires_signature():
-    """User path present but no 'Loading extensions from' -> NOT this leak."""
-    line = "Cached at C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9"
+def test_has_leak_no_signature_still_matches_via_path():
+    """Path-based detection: a username NuGet path IS a leak regardless of the
+    message prefix (the v1 hook wrongly required 'Loading extensions from')."""
+    line = "Cached package at C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9"
+    assert _has_leak(line) is True
+
+
+def test_has_leak_relative_path():
+    line = "Loading extensions from `./local-build/MyExt.dll`"
     assert _has_leak(line) is False
 
 
@@ -98,8 +140,8 @@ def test_has_leak_unix_home_path():
 
 
 def test_output_has_leak_list_and_string():
-    assert _output_has_leak(["Loading extensions from `C:\\Users\\x\\.nuget\\p\\a`"]) is True
-    assert _output_has_leak("Loading extensions from `C:\\Users\\x\\.nuget\\p\\a`") is True
+    assert _output_has_leak([_DISPLAY_LINE]) is True
+    assert _output_has_leak(_STREAM_LINE) is True
     assert _output_has_leak(["ordinary text/plain line"]) is False
     assert _output_has_leak(None) is False
 
@@ -114,22 +156,61 @@ def test_legitimate_prose_not_flagged(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Count / find
+# Count / find — display_data + stream
 # ---------------------------------------------------------------------------
 
-def test_count_and_find_list_form(tmp_path):
-    out = _nuget_ext_output("text/plain", form="list")
+def test_count_and_find_display_list_form(tmp_path):
+    out = _display_output(_DISPLAY_LINE, "text/plain", form="list")
     cells = [_code(["#r \"nuget:SkiaSharp\""], outputs=[out], execution_count=3)]
     p = _write_nb(tmp_path / "a.ipynb", cells)
     assert count_leak_lines(p) == 1
     assert find_leak_outputs(p) == [(0, 0, "text/plain")]
 
 
-def test_count_string_form(tmp_path):
-    out = _nuget_ext_output("text/plain", form="str")
+def test_count_display_string_form(tmp_path):
+    out = _display_output(_DISPLAY_LINE, "text/plain", form="str")
     cells = [_code(["#r \"nuget:SkiaSharp\""], outputs=[out])]
     p = _write_nb(tmp_path / "b.ipynb", cells)
     assert count_leak_lines(p) == 1
+
+
+def test_count_and_find_stream_list_form(tmp_path):
+    """The stream 'Failed to load kernel extension' variant (ML-5-TimeSeries)."""
+    out = _stream_output(_STREAM_LINE, form="list")
+    cells = [_code(["#r \"nuget:XPlot.Plotly.Interactive\""], outputs=[out])]
+    p = _write_nb(tmp_path / "s.ipynb", cells)
+    assert count_leak_lines(p) == 1
+    assert find_leak_outputs(p) == [(0, 0, STREAM_KEY)]
+
+
+def test_count_stream_string_form(tmp_path):
+    out = _stream_output(_STREAM_LINE, form="str")
+    cells = [_code(["#r \"nuget:X\""], outputs=[out])]
+    p = _write_nb(tmp_path / "s2.ipynb", cells)
+    assert count_leak_lines(p) == 1
+
+
+def test_count_both_messages_in_one_output(tmp_path):
+    """ML-5-TimeSeries shape: display_data 'Loading' + stream 'Failed to load'
+    in the same cell. Both must be counted."""
+    cells = [_code(["#r \"nuget:XPlot.Plotly.Interactive\""], outputs=[
+        _display_output(_DISPLAY_LINE, "text/plain", form="list"),
+        _stream_output(_STREAM_LINE, form="list"),
+    ])]
+    p = _write_nb(tmp_path / "both.ipynb", cells)
+    assert count_leak_lines(p) == 2
+    assert sorted(find_leak_outputs(p)) == [(0, 0, "text/plain"), (0, 1, STREAM_KEY)]
+
+
+def test_count_zero_on_tilde_only(tmp_path):
+    """ML-7-Recommendation / OR-tools-Stiegler shape: tilde variants only -> 0."""
+    cells = [_code(["#r \"nuget:XPlot.Plotly.Interactive\""], outputs=[
+        _display_output(_TILDE_DISPLAY_LINE, "text/plain", form="list"),
+        _stream_output(_TILDE_STREAM_LINE, form="list"),
+    ])]
+    p = _write_nb(tmp_path / "tilde.ipynb", cells)
+    assert count_leak_lines(p) == 0
+    assert find_leak_outputs(p) == []
 
 
 def test_count_zero_on_clean(tmp_path):
@@ -143,44 +224,88 @@ def test_count_zero_on_clean(tmp_path):
 # Strip safety
 # ---------------------------------------------------------------------------
 
-def test_strip_list_form_preserves_execution_count_and_shape(tmp_path):
-    out = _nuget_ext_output("text/plain", form="list")
+def test_strip_display_list_form_preserves_execution_count_and_shape(tmp_path):
+    out = _display_output(_DISPLAY_LINE, "text/plain", form="list")
     cells = [_code(["#r \"nuget:SkiaSharp\""], outputs=[out], execution_count=7)]
     p = _write_nb(tmp_path / "list.ipynb", cells)
     outputs_with_leak, fixed = strip_in_place(p)
     assert outputs_with_leak == 1
     assert fixed == 1
-    # Re-parse: execution_count preserved, output still present, list shape intact
     nb = json.loads(p.read_text(encoding="utf-8"))
     cell = nb["cells"][0]
     assert cell["execution_count"] == 7
     assert len(cell["outputs"]) == 1
     data = cell["outputs"][0]["data"]
-    assert "text/plain" in data  # key preserved
-    assert isinstance(data["text/plain"], list)  # shape preserved
-    # No leak remains
+    assert "text/plain" in data
+    assert isinstance(data["text/plain"], list)
     assert count_leak_lines(p) == 0
 
 
-def test_strip_string_form(tmp_path):
-    out = _nuget_ext_output("text/plain", form="str")
+def test_strip_display_string_form(tmp_path):
+    out = _display_output(_DISPLAY_LINE, "text/plain", form="str")
     cells = [_code(["#r \"nuget:X\""], outputs=[out], execution_count=2)]
     p = _write_nb(tmp_path / "str.ipynb", cells)
     _, fixed = strip_in_place(p)
     assert fixed == 1
     nb = json.loads(p.read_text(encoding="utf-8"))
-    assert nb["cells"][0]["data"] if False else True  # placate lint
     data = nb["cells"][0]["outputs"][0]["data"]
-    assert data["text/plain"] == ""  # replaced with empty string
+    assert data["text/plain"] == ""
     assert count_leak_lines(p) == 0
 
 
+def test_strip_stream_list_form(tmp_path):
+    """Strip the 'Failed to load kernel extension' stream variant."""
+    out = _stream_output(_STREAM_LINE, form="list")
+    cells = [_code(["#r \"nuget:X\""], outputs=[out], execution_count=5)]
+    p = _write_nb(tmp_path / "stream.ipynb", cells)
+    outputs_with_leak, fixed = strip_in_place(p)
+    assert (outputs_with_leak, fixed) == (1, 1)
+    nb = json.loads(p.read_text(encoding="utf-8"))
+    cell = nb["cells"][0]
+    assert cell["execution_count"] == 5
+    assert len(cell["outputs"]) == 1
+    assert isinstance(cell["outputs"][0]["text"], list)
+    assert count_leak_lines(p) == 0
+
+
+def test_strip_stream_string_form(tmp_path):
+    out = _stream_output(_STREAM_LINE, form="str")
+    cells = [_code(["#r \"nuget:X\""], outputs=[out])]
+    p = _write_nb(tmp_path / "sstream.ipynb", cells)
+    _, fixed = strip_in_place(p)
+    assert fixed == 1
+    nb = json.loads(p.read_text(encoding="utf-8"))
+    assert nb["cells"][0]["outputs"][0]["text"] == ""
+
+
+def test_strip_both_messages_one_cell(tmp_path):
+    """ML-5-TimeSeries: both messages stripped, execution_count preserved."""
+    cells = [_code(["#r \"nuget:XPlot.Plotly.Interactive\""], outputs=[
+        _display_output(_DISPLAY_LINE, "text/plain", form="list"),
+        _stream_output(_STREAM_LINE, form="list"),
+    ], execution_count=1)]
+    p = _write_nb(tmp_path / "ml5.ipynb", cells)
+    outputs_with_leak, fixed = strip_in_place(p)
+    assert (outputs_with_leak, fixed) == (2, 2)
+    assert count_leak_lines(p) == 0
+
+
+def test_strip_does_not_touch_tilde_variants(tmp_path):
+    """Tilde display_data + stream lines must survive a strip untouched."""
+    cells = [_code(["#r \"nuget:XPlot.Plotly.Interactive\""], outputs=[
+        _display_output(_TILDE_DISPLAY_LINE, "text/plain", form="list"),
+        _stream_output(_TILDE_STREAM_LINE, form="list"),
+    ], execution_count=2)]
+    p = _write_nb(tmp_path / "tilde2.ipynb", cells)
+    before = p.read_text(encoding="utf-8")
+    outputs_with_leak, fixed = strip_in_place(p)
+    assert (outputs_with_leak, fixed) == (0, 0)
+    assert p.read_text(encoding="utf-8") == before  # byte-identical
+
+
 def test_strip_preserves_other_data_keys(tmp_path):
-    """A multi-key data dict: only the leak key is touched."""
-    leak_line = ("Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\"
-                 "x\\1.0.0\\x.dll`")
     out = {"output_type": "display_data",
-           "data": {"text/plain": [leak_line],
+           "data": {"text/plain": [_DISPLAY_LINE],
                     "text/html": ["<i>chart</i>"]},
            "metadata": {}}
     cells = [_code(["#r \"nuget:x\""], outputs=[out])]
@@ -188,16 +313,13 @@ def test_strip_preserves_other_data_keys(tmp_path):
     strip_in_place(p)
     nb = json.loads(p.read_text(encoding="utf-8"))
     data = nb["cells"][0]["outputs"][0]["data"]
-    assert data["text/html"] == ["<i>chart</i>"]  # untouched
+    assert data["text/html"] == ["<i>chart</i>"]
     assert count_leak_lines(p) == 0
 
 
 def test_strip_drops_only_leak_element_in_multiline_list(tmp_path):
-    """text/plain list with a real output line + the leak line: only leak dropped."""
-    leak_line = ("Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\"
-                 "x\\1.0.0\\x.dll`")
     out = {"output_type": "display_data",
-           "data": {"text/plain": ["Plotly chart rendered.", leak_line]},
+           "data": {"text/plain": ["Plotly chart rendered.", _DISPLAY_LINE]},
            "metadata": {}}
     cells = [_code(["#r \"nuget:x\""], outputs=[out])]
     p = _write_nb(tmp_path / "ml.ipynb", cells)
@@ -209,28 +331,42 @@ def test_strip_drops_only_leak_element_in_multiline_list(tmp_path):
     assert not any("Loading extensions from" in (l or "") for l in tp)
 
 
+def test_strip_stream_drops_only_leak_element(tmp_path):
+    """Stream text with a legit stderr line + the leak: only leak dropped."""
+    out = _stream_output("[stderr] some benign warning\n", form="str")
+    # build a list with a legit line + the leak line
+    out2 = {"output_type": "stream", "name": "stderr",
+            "text": ["[stderr] benign warning\n", _STREAM_LINE + "\n"]}
+    cells = [_code(["#r \"nuget:x\""], outputs=[out2])]
+    p = _write_nb(tmp_path / "mls.ipynb", cells)
+    _, fixed = strip_in_place(p)
+    assert fixed == 1
+    nb = json.loads(p.read_text(encoding="utf-8"))
+    txt = nb["cells"][0]["outputs"][0]["text"]
+    assert any("benign warning" in (l or "") for l in txt)
+    assert not any("Failed to load kernel extension" in (l or "") for l in txt)
+
+
 def test_strip_idempotent(tmp_path):
-    out = _nuget_ext_output("text/plain", form="list")
-    cells = [_code(["#r \"nuget:X\""], outputs=[out])]
+    cells = [_code(["#r \"nuget:X\""], outputs=[
+        _display_output(_DISPLAY_LINE, "text/plain", form="list"),
+        _stream_output(_STREAM_LINE, form="list"),
+    ])]
     p = _write_nb(tmp_path / "idem.ipynb", cells)
     strip_in_place(p)
     before = p.read_text(encoding="utf-8")
-    outputs_with_leak, fixed = strip_in_place(p)  # second pass
-    assert outputs_with_leak == 0
-    assert fixed == 0
-    assert p.read_text(encoding="utf-8") == before  # byte-identical
+    outputs_with_leak, fixed = strip_in_place(p)
+    assert (outputs_with_leak, fixed) == (0, 0)
+    assert p.read_text(encoding="utf-8") == before
 
 
 def test_strip_keeps_valid_json(tmp_path):
-    """The on-disk edit must leave valid JSON parseable by the stdlib."""
-    leak_line = ("Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\"
-                 "x\\1.0.0\\x.dll`")
-    out = {"output_type": "display_data",
-           "data": {"text/plain": [leak_line]}, "metadata": {}}
-    cells = [_code(["#r \"nuget:x\""], outputs=[out], execution_count=4)]
+    cells = [_code(["#r \"nuget:x\""], outputs=[
+        _display_output(_DISPLAY_LINE, "text/plain", form="list"),
+        _stream_output(_STREAM_LINE, form="list"),
+    ], execution_count=4)]
     p = _write_nb(tmp_path / "json.ipynb", cells)
     strip_in_place(p)
-    # Must not raise
     nb = json.loads(p.read_text(encoding="utf-8"))
     assert nb["nbformat"] == 4
 
@@ -249,8 +385,10 @@ def test_no_leak_no_change(tmp_path):
 # Constants sanity
 # ---------------------------------------------------------------------------
 
-def test_signature_and_tokens_sensible():
-    assert EXT_LOAD_SIGNATURE == "Loading extensions from"
-    assert ".nuget" in USER_PATH_TOKENS
-    assert "Users\\" in USER_PATH_TOKENS
-    assert "/home/" in USER_PATH_TOKENS
+def test_constants_sensible():
+    assert NUGET_CACHE_TOKEN == ".nuget"
+    assert "Users\\" in USERNAME_MARKERS
+    assert "Users/" in USERNAME_MARKERS
+    assert "/home/" in USERNAME_MARKERS
+    assert STREAM_KEY == "text"
+    assert "text/plain" in DATA_KEYS and "text/html" in DATA_KEYS


### PR DESCRIPTION
## Summary

Follow-up to the merged **#6536** (the v1 `strip-dotnet-nuget-ext` hook). The v1 detector keyed on the `Loading extensions from` signature + any `USER_PATH_TOKEN` (incl. `.nuget`), which had two defects surfaced by the **#6537 CHANGES_REQUESTED** forensic review:

1. **Missed the `stream` variant** — dotnet-interactive emits a *second* kernel message carrying the same `C:\Users\<u>\.nuget\packages\...` PII path, in a `stream` (stderr) output's `text` field: `Failed to load kernel extension "KernelExtension" from assembly C:\Users\<u>\.nuget\packages\...`. The v1 hook only scanned `display_data` `data[*]`, so this survived (e.g. ML-5-TimeSeries).
2. **False-positive stripped legitimate TILDE lines** — `Loading extensions from ~\.nuget\packages\...` (the `%USERPROFILE%` HOME placeholder, **no username**) matched the v1 detector (`.nuget` token) and was wrongly stripped (e.g. ML-7-Recommendation, OR-tools-Stiegler).

## Fix

**Path-based detection** (not signature-based): a line is a leak iff it carries the NuGet-cache token (`.nuget`) AND a username absolute-path marker (`Users\` / `Users/` / `/home/`). The tilde variant carries no username marker → correctly untouched. Catches both kernel messages uniformly and is robust to future message rewording.

**Stream output scanning**: the hook now inspects `stream` outputs' `text` field in addition to `display_data`/`execute_result` `data["text/plain"|"text/html"]`.

Constants renamed: `EXT_LOAD_SIGNATURE`/`USER_PATH_TOKENS` → `NUGET_CACHE_TOKEN`/`USERNAME_MARKERS`. `ALL_KEYS = DATA_KEYS + (STREAM_KEY,)`. `_field_value()` unifies data-key vs stream-text access. `strip_in_place` str_pat + list-bounds iterate `ALL_KEYS` incl. `text`.

## Verification

- **29 tests pass** (was 17): stream-variant detection+strip (list+str), tilde-variant NOT-flagged (display+stream), both-messages-one-cell (ML-5 shape), stream-only-leak-element drop, constants sanity.
- Firsthand on real notebooks: corrected hook `--scan` flags 8 notebooks / 9 username leak lines (ML-5 = 2: display + stream); ML-7 / OR-tools-Stiegler (tilde-only) = 0 flagged.
- `Scripts Tests (CPU)` CI green on the prior push (same code).

## Why a new PR (not a push to #6536)

#6536 was squash-merged at 13:36Z with the v1 detector (before this broadened fix was ready). This PR supersedes the v1 detector on `main` so the pre-commit hook stops (a) missing the stream variant and (b) false-positive stripping tilde lines on future commits. The **#6537 batch** was re-derived against this broadened detector (8 notebooks / 9 lines, tilde preserved) and is the data-side companion.

## Related

- Supersedes the v1 detector from merged **#6536**
- See **#6537** — batch cleanup re-derived against this broadened hook
- See **#6529** — 4th strip-hook (issue)
- See #6443 — PII-lite machine-path classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)