### PR TITLE
feat(security,#16): audit_exposed_services.py — tier WebUI login natif probe tool

### DIFF
--- a/scripts/security/audit_exposed_services.py
+++ b/scripts/security/audit_exposed_services.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Audit publicly-exposed `*.myia.io` services for authentication state.
+
+Distinguishes three categories of debt (audit c.442, 2026-07-14):
+
+- **AUTH-OK**     : auth UI (login form or token gate) PRESENT, auth API
+                    (endpoints behind same gate) also PRESENT.
+- **API-LEAK**    : auth UI PRESENT (login form, 302 redirect), but API
+                    endpoints (e.g. Gradio `/sdapi/*`) respond WITHOUT auth.
+                    User can hit backend via API bypass.
+- **ORPHELIN-START** : reverse-proxy (IIS) responds 502/504 because no
+                    backend Docker container is running, BUT the
+                    `docker-compose.yml` exists. Compose-no-start.
+- **ORPHELIN-DNS**    : DNS resolves + reverse-proxy routes, but NO
+                    `docker-compose.yml` exists for the service. DNS-only
+                    ghost subdomain.
+
+Usage:
+    python audit_exposed_services.py                  # run full probe
+    python audit_exposed_services.py --json out.json  # machine-readable output
+    python audit_exposed_services.py --md report.md   # markdown report
+
+Sourced from issue #16 (sécurisation services IA exposés publiquement).
+First audit run by po-2023, cycle c.442, 2026-07-14T~14:00Z.
+Pattern mirror: scripts/notebook_tools/scan_md_hierarchy.py (render-agnostic,
+machine-readable summary line per finding, plus human report).
+"""
+
+import argparse
+import json
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+from typing import Dict, List, Optional, Tuple
+
+# Tier WebUI login natif — full set of exposed services to probe.
+# Each tier entry: (subdomain, compose_dir, auth_endpoint_probe)
+#   compose_dir: relative to docker-configurations/services/, or None if no compose.
+#   auth_endpoint_probe: URL to test for API auth, or None if not applicable.
+DEFAULT_TIER = [
+    # (subdomain, expected_compose, api_endpoint_probe)
+    ("stable-diffusion-webui-forge.myia.io", "forge-turbo", "/sdapi/v1/options"),
+    ("sdnext.myia.io", "sdnext", None),
+    ("micro.text-generation-webui.myia.io", None, None),
+    ("mini.text-generation-webui.myia.io", None, None),
+    ("medium.text-generation-webui.myia.io", None, None),
+    ("large.text-generation-webui.myia.io", None, None),
+]
+
+DEFAULT_TIMEOUT = 5.0
+DEFAULT_USER_AGENT = "CoursIA-AuditExposedServices/1.0 (po-2023, #16)"
+
+
+def dns_resolves(host: str) -> Tuple[bool, Optional[str]]:
+    """Return (resolves, ip) for the given hostname."""
+    try:
+        ip = socket.gethostbyname(host)
+        return True, ip
+    except (socket.gaierror, socket.herror):
+        return False, None
+
+
+def http_probe(url: str, timeout: float = DEFAULT_TIMEOUT) -> Tuple[int, Dict[str, str]]:
+    """Return (status_code, headers_dict) for the given URL (HEAD first, GET fallback)."""
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("User-Agent", DEFAULT_USER_AGENT)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, dict(resp.headers)
+    except urllib.error.HTTPError as e:
+        return e.code, dict(e.headers or {})
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return 0, {"error": str(e)}
+
+
+def compose_exists(compose_dir: Optional[str], repo_root: str = ".") -> bool:
+    """Check if docker-compose.yml exists for the given service directory."""
+    if not compose_dir:
+        return False
+    import os
+    path = os.path.join(repo_root, "docker-configurations", "services", compose_dir, "docker-compose.yml")
+    return os.path.isfile(path)
+
+
+def container_running(compose_dir: Optional[str]) -> bool:
+    """Check if a Docker container matching the compose service name is running."""
+    if not compose_dir:
+        return False
+    try:
+        out = subprocess.run(
+            ["docker", "ps", "--filter", f"name={compose_dir}", "--format", "{{.Names}}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return compose_dir in out.stdout
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def probe_api_auth(api_endpoint: Optional[str], port: int = 1111, timeout: float = DEFAULT_TIMEOUT) -> str:
+    """Test API auth on a known local port (proxy bypass).
+
+    Returns one of: 'OPEN' (no auth), 'PROTECTED' (401/403), 'N/A' (no probe configured).
+    """
+    if not api_endpoint:
+        return "N/A"
+    url = f"http://localhost:{port}{api_endpoint}"
+    code, _ = http_probe(url, timeout=timeout)
+    if code in (401, 403):
+        return "PROTECTED"
+    if code == 200:
+        return "OPEN"
+    return f"ERR({code})"
+
+
+def classify_subdomain(subdomain: str, compose_dir: Optional[str], api_endpoint: Optional[str],
+                       local_port: int = 1111) -> Dict[str, object]:
+    """Run all probes and return a single finding dict."""
+    resolves, ip = dns_resolves(subdomain)
+    http_code, headers = http_probe(f"https://{subdomain}", timeout=DEFAULT_TIMEOUT)
+    compose = compose_exists(compose_dir)
+    container = container_running(compose_dir)
+    api_auth = probe_api_auth(api_endpoint, port=local_port)
+
+    if not resolves:
+        category = "NO-DNS"
+    elif not compose and not container:
+        category = "ORPHELIN-DNS"
+    elif compose and not container:
+        category = "ORPHELIN-START"
+    elif container and api_auth == "OPEN":
+        # Substance: backend is up, but its API endpoints accept unauthenticated
+        # requests. The UI may be protected (login form) but the API surface
+        # is the actual attack vector. Flag API-LEAK regardless of the external
+        # proxy state (502 just means the proxy is misconfigured too, but the
+        # backend substance is the leak).
+        category = "API-LEAK"
+    elif container and api_auth == "PROTECTED":
+        category = "AUTH-OK"
+    else:
+        category = "UNCLEAR"
+
+    return {
+        "subdomain": subdomain,
+        "category": category,
+        "dns_resolves": resolves,
+        "dns_ip": ip,
+        "http_external": http_code,
+        "compose_exists": compose,
+        "container_running": container,
+        "api_auth": api_auth,
+        "redirect": headers.get("Location", ""),
+        "server": headers.get("Server", ""),
+    }
+
+
+def run_audit(tier: List[Tuple[str, Optional[str], Optional[str]]] = None,
+              local_port: int = 1111) -> List[Dict[str, object]]:
+    """Run the full audit and return list of findings."""
+    if tier is None:
+        tier = DEFAULT_TIER
+    findings = []
+    for subdomain, compose_dir, api_endpoint in tier:
+        f = classify_subdomain(subdomain, compose_dir, api_endpoint, local_port=local_port)
+        findings.append(f)
+    return findings
+
+
+def render_markdown(findings: List[Dict[str, object]], tier_name: str = "tier WebUI login natif") -> str:
+    """Render a markdown audit report (mirror c.442 layout)."""
+    lines = [
+        f"# Audit `*.myia.io` — {tier_name}",
+        "",
+        f"Date: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}",
+        f"Source: issue #16 (sécurisation services IA exposés publiquement)",
+        "",
+        "## Résultats",
+        "",
+        "| Subdomain | DNS | HTTP ext. | Backend | Auth UI | Auth API | Catégorie |",
+        "|-----------|-----|-----------|---------|---------|----------|-----------|",
+    ]
+    for f in findings:
+        dns = "OK" if f["dns_resolves"] else "FAIL"
+        compose = f["compose_exists"] and f["container_running"]
+        backend = "running" if f["container_running"] else (
+            "compose-only" if f["compose_exists"] else "absent"
+        )
+        auth_ui = (
+            "OK" if f["redirect"].endswith("/login")
+            else ("n/a" if not f["container_running"] else "?")
+        )
+        lines.append(
+            f"| `{f['subdomain']}` | {dns} | {f['http_external']} | {backend} | {auth_ui} | "
+            f"{f['api_auth']} | **{f['category']}** |"
+        )
+    lines.extend([
+        "",
+        "## Légende catégories",
+        "",
+        "- **AUTH-OK** : auth UI et API présentes, service sécurisé.",
+        "- **API-LEAK** : auth UI (login) présente mais endpoints API ouverts sans auth.",
+        "- **ORPHELIN-START** : compose existe mais container pas démarré (502 via reverse-proxy).",
+        "- **ORPHELIN-DNS** : DNS résout + reverse-proxy route, mais aucun compose file (ghost).",
+        "- **NO-DNS** : subdomain ne résout pas (DNS-only ghost, pas d'IIS).",
+        "",
+        "## Sourced from",
+        "",
+        "Issue #16 — po-2023, cycle c.442, 2026-07-14T~14:00Z. Mirror de `scripts/notebook_tools/scan_md_hierarchy.py`.",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit `*.myia.io` services for auth state.")
+    parser.add_argument("--json", metavar="PATH", help="Write JSON findings to PATH")
+    parser.add_argument("--md", metavar="PATH", help="Write markdown report to PATH")
+    parser.add_argument("--local-port", type=int, default=1111,
+                        help="Local backend port for API auth probe (default: 1111, forge-turbo)")
+    parser.add_argument("--quiet", action="store_true", help="Suppress stdout output")
+    args = parser.parse_args(argv)
+
+    findings = run_audit(local_port=args.local_port)
+
+    if not args.quiet:
+        # Compact stdout summary
+        for f in findings:
+            print(f"  {f['subdomain']:50s} → {f['category']:15s} (HTTP={f['http_external']}, "
+                  f"container={f['container_running']}, api_auth={f['api_auth']})")
+
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as fp:
+            json.dump(findings, fp, indent=2, ensure_ascii=False)
+        if not args.quiet:
+            print(f"\nJSON written to {args.json}")
+
+    if args.md:
+        with open(args.md, "w", encoding="utf-8") as fp:
+            fp.write(render_markdown(findings))
+        if not args.quiet:
+            print(f"Markdown written to {args.md}")
+
+    # Exit non-zero if any API-LEAK or ORPHELIN found (P0/P1 actions required)
+    critical = [f for f in findings if f["category"] in ("API-LEAK", "ORPHELIN-START", "ORPHELIN-DNS")]
+    return 1 if critical else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_audit_exposed_services.py
+++ b/scripts/tests/test_audit_exposed_services.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Tests for audit_exposed_services.py — round-trip output-content asserts (L498).
+
+Per L498, REDACT-class tooling MUST have a round-trip OUTPUT-content test,
+not just detection boolean. For audit_exposed_services.py, the analog is:
+classify_subdomain must classify correctly across all 5 categories (output
+content) AND helpers (dns_resolves, compose_exists, container_running,
+probe_api_auth, http_probe) must return the right SHAPE (boolean-like).
+
+Pattern mirror: scripts/notebook_tools/tests/test_strip_machine_paths.py
+(detection + non-overlap + round-trip output).
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Mirror the import style from test_strip_machine_paths.py
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_SECURITY = REPO_ROOT / "scripts" / "security"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from security.audit_exposed_services import (  # noqa: E402
+    DEFAULT_TIER,
+    classify_subdomain,
+    compose_exists,
+    container_running,
+    dns_resolves,
+    http_probe,
+    probe_api_auth,
+    render_markdown,
+    run_audit,
+)
+
+
+# --- helpers: mock fixtures ---
+
+def _no_dns(_host: str):
+    return (False, None)
+
+
+def _dns_ok(_host: str):
+    return (True, "82.66.89.184")
+
+
+def _http_ok(url, timeout=5.0):
+    return (200, {"Server": "Gradio", "Location": "/login"})
+
+
+def _http_502(url, timeout=5.0):
+    return (502, {"Server": "Microsoft-IIS/10.0", "Location": ""})
+
+
+def _http_401(url, timeout=5.0):
+    return (401, {"Server": "Gradio"})
+
+
+def _container_running(compose_dir):
+    return True
+
+
+def _compose_yes(compose_dir, repo_root="."):
+    return True
+
+
+def _compose_no(compose_dir, repo_root="."):
+    return False
+
+
+# --- DNS helper ---
+
+def test_dns_resolves_returns_tuple_false():
+    # Script catches (socket.gaierror, herror) — both inherit from OSError.
+    # Use a proper gaierror to verify the handler.
+    with mock.patch("socket.gethostbyname", side_effect=socket.gaierror("no DNS")):
+        resolves, ip = dns_resolves("does-not-exist.invalid")
+    assert resolves is False
+    assert ip is None
+
+
+def test_dns_resolves_returns_tuple_true():
+    with mock.patch("socket.gethostbyname", return_value="10.0.0.1"):
+        resolves, ip = dns_resolves("ok.example")
+    assert resolves is True
+    assert ip == "10.0.0.1"
+
+
+# --- HTTP probe ---
+
+def test_http_probe_200_returns_status():
+    with mock.patch("urllib.request.urlopen") as m:
+        m.return_value.__enter__.return_value.status = 200
+        m.return_value.__enter__.return_value.headers = {"Server": "IIS"}
+        code, headers = http_probe("https://example.com")
+    assert code == 200
+    assert headers["Server"] == "IIS"
+
+
+# --- compose_exists ---
+
+def test_compose_exists_none_returns_false(tmp_path):
+    assert compose_exists(None, repo_root=str(tmp_path)) is False
+
+
+def test_compose_exists_real_present(tmp_path):
+    compose_dir = tmp_path / "docker-configurations" / "services" / "forge-turbo"
+    compose_dir.mkdir(parents=True)
+    (compose_dir / "docker-compose.yml").write_text("services: {}\n")
+    assert compose_exists("forge-turbo", repo_root=str(tmp_path)) is True
+
+
+def test_compose_exists_real_absent(tmp_path):
+    assert compose_exists("nonexistent", repo_root=str(tmp_path)) is False
+
+
+# --- container_running ---
+
+def test_container_running_no_compose_returns_false():
+    assert container_running(None) is False
+
+
+def test_container_running_docker_not_found():
+    with mock.patch("subprocess.run", side_effect=FileNotFoundError):
+        assert container_running("forge-turbo") is False
+
+
+def test_container_running_match_in_output():
+    out = "forge-turbo\n" * 3
+    fake_result = mock.Mock(stdout=out)
+    with mock.patch("subprocess.run", return_value=fake_result):
+        assert container_running("forge-turbo") is True
+
+
+# --- probe_api_auth ---
+
+def test_probe_api_auth_n_a_when_none():
+    assert probe_api_auth(None) == "N/A"
+
+
+def test_probe_api_auth_protected_on_401():
+    with mock.patch(
+        "security.audit_exposed_services.http_probe", return_value=(401, {})
+    ):
+        assert probe_api_auth("/sdapi/v1/options") == "PROTECTED"
+
+
+def test_probe_api_auth_open_on_200():
+    with mock.patch(
+        "security.audit_exposed_services.http_probe", return_value=(200, {})
+    ):
+        assert probe_api_auth("/sdapi/v1/options") == "OPEN"
+
+
+def test_probe_api_auth_err_on_unexpected():
+    with mock.patch(
+        "security.audit_exposed_services.http_probe", return_value=(500, {})
+    ):
+        assert probe_api_auth("/sdapi/v1/options") == "ERR(500)"
+
+
+# --- classify_subdomain: round-trip OUTPUT-content (L498) ---
+# The substance: a finding dict is the audit's "output content". Per L498,
+# tests MUST assert on the output data, not just on detection booleans.
+
+def test_classify_no_dns_when_dns_fails():
+    with mock.patch("security.audit_exposed_services.dns_resolves", _no_dns):
+        f = classify_subdomain("ghost.invalid", "ghost", None)
+    assert f["category"] == "NO-DNS"
+    assert f["dns_resolves"] is False
+    assert f["dns_ip"] is None
+
+
+def test_classify_orphelin_dns_dns_resolves_but_no_compose():
+    with mock.patch("security.audit_exposed_services.dns_resolves", _dns_ok), \
+         mock.patch("security.audit_exposed_services.http_probe", _http_ok), \
+         mock.patch("security.audit_exposed_services.compose_exists", _compose_no), \
+         mock.patch("security.audit_exposed_services.container_running", lambda c: False):
+        f = classify_subdomain("ghost.text-gen.myia.io", "ghost-text", None)
+    assert f["category"] == "ORPHELIN-DNS"
+    assert f["dns_resolves"] is True
+    assert f["compose_exists"] is False
+    assert f["container_running"] is False
+
+
+def test_classify_orphelin_start_compose_but_container_not_running():
+    with mock.patch("security.audit_exposed_services.dns_resolves", _dns_ok), \
+         mock.patch("security.audit_exposed_services.http_probe", _http_502), \
+         mock.patch("security.audit_exposed_services.compose_exists", _compose_yes), \
+         mock.patch("security.audit_exposed_services.container_running", lambda c: False):
+        f = classify_subdomain("forge.myia.io", "forge-turbo", "/sdapi/v1/options")
+    assert f["category"] == "ORPHELIN-START"
+    assert f["compose_exists"] is True
+    assert f["container_running"] is False
+    assert f["http_external"] == 502  # substance: 502 reverse-proxy response
+
+
+def test_classify_api_leak_when_container_up_but_api_open():
+    with mock.patch("security.audit_exposed_services.dns_resolves", _dns_ok), \
+         mock.patch("security.audit_exposed_services.http_probe", _http_ok), \
+         mock.patch("security.audit_exposed_services.compose_exists", _compose_yes), \
+         mock.patch("security.audit_exposed_services.container_running", _container_running), \
+         mock.patch("security.audit_exposed_services.probe_api_auth", return_value="OPEN"):
+        f = classify_subdomain("forge.myia.io", "forge-turbo", "/sdapi/v1/options")
+    assert f["category"] == "API-LEAK"
+    assert f["api_auth"] == "OPEN"
+    assert f["container_running"] is True
+    assert f["redirect"].endswith("/login")  # UI has login, but API leaks
+
+
+def test_classify_auth_ok_when_container_up_and_api_protected():
+    with mock.patch("security.audit_exposed_services.dns_resolves", _dns_ok), \
+         mock.patch("security.audit_exposed_services.http_probe", _http_ok), \
+         mock.patch("security.audit_exposed_services.compose_exists", _compose_yes), \
+         mock.patch("security.audit_exposed_services.container_running", _container_running), \
+         mock.patch("security.audit_exposed_services.probe_api_auth", return_value="PROTECTED"):
+        f = classify_subdomain("forge.myia.io", "forge-turbo", "/sdapi/v1/options")
+    assert f["category"] == "AUTH-OK"
+    assert f["api_auth"] == "PROTECTED"
+    assert f["container_running"] is True
+
+
+# --- run_audit (integration-shaped) ---
+
+def test_run_audit_returns_list_of_findings():
+    fake_findings = [
+        {"subdomain": "a", "category": "ORPHELIN-START", "dns_resolves": True, "dns_ip": "1.2.3.4",
+         "http_external": 502, "compose_exists": True, "container_running": False,
+         "api_auth": "N/A", "redirect": "", "server": ""},
+    ]
+    with mock.patch("security.audit_exposed_services.classify_subdomain", return_value=fake_findings[0]):
+        out = run_audit(tier=[("a.myia.io", "a", None)])
+    assert isinstance(out, list)
+    assert len(out) == 1
+    assert out[0]["category"] == "ORPHELIN-START"
+
+
+# --- render_markdown round-trip ---
+
+def test_render_markdown_contains_table_and_categories():
+    findings = [
+        {"subdomain": "a.myia.io", "category": "AUTH-OK", "dns_resolves": True, "dns_ip": "1.2.3.4",
+         "http_external": 200, "compose_exists": True, "container_running": True,
+         "api_auth": "PROTECTED", "redirect": "/login", "server": "Gradio"},
+        {"subdomain": "b.myia.io", "category": "API-LEAK", "dns_resolves": True, "dns_ip": "1.2.3.4",
+         "http_external": 200, "compose_exists": True, "container_running": True,
+         "api_auth": "OPEN", "redirect": "/login", "server": "Gradio"},
+    ]
+    md = render_markdown(findings)
+    assert "# Audit `*.myia.io`" in md
+    assert "| Subdomain |" in md
+    assert "`a.myia.io`" in md
+    assert "**AUTH-OK**" in md
+    assert "**API-LEAK**" in md
+    assert "## Légende catégories" in md
+
+
+# --- DEFAULT_TIER smoke check ---
+
+def test_default_tier_covers_forge_sdnext_and_text_gen():
+    """Smoke test: ensure DEFAULT_TIER covers forge-turbo + sdnext + 4x text-gen."""
+    subdomains = [entry[0] for entry in DEFAULT_TIER]
+    assert "stable-diffusion-webui-forge.myia.io" in subdomains
+    assert "sdnext.myia.io" in subdomains
+    text_gen = [s for s in subdomains if "text-generation-webui.myia.io" in s]
+    assert len(text_gen) == 4  # micro/mini/medium/large


### PR DESCRIPTION
## feat(security,#16): audit_exposed_services.py — tier WebUI login natif probe (round-trip output tests, L498)

### Context

Suite commentaire ai-01 du 2026-07-12T00:30Z (cycle ~160) qui m'a piloté sur l'inventaire auth par service `*.myia.io`. Mon audit précédent a couvert mcp-tools + embeddings (résolus ambigus) + clarification statut idle-stopped des 5 backends. Reste **tier WebUI login natif** (Stable Diffusion Forge / SDNext / Text Generation WebUI) non couvert exhaustivement.

**Pivot R6** : post-c.441 Lean infra → c.442 Security/outillage = alternance propre (cf mandat user 2026-07-06).

### Change

Single-script deliverable `scripts/security/audit_exposed_services.py` (251 LF) + tests `scripts/tests/test_audit_exposed_services.py` (272 LF, 21 tests).

**Five-category debt classification** (substantive — the script's job is to TELL THE TRUTH about auth state):

| Category | Substance | Remediation |
|---|---|---|
| **AUTH-OK** | auth UI (login form, 302 redirect) AND auth API endpoints present | none — secured |
| **API-LEAK** | auth UI PRESENT (login form) but API endpoints (e.g. Gradio `/sdapi/*`) respond WITHOUT auth → user can hit backend via API bypass | configure backend auth |
| **ORPHELIN-START** | reverse-proxy (IIS) responds 502/504 because no backend Docker container is running, BUT `docker-compose.yml` exists | `docker compose up -d` |
| **ORPHELIN-DNS** | DNS resolves + reverse-proxy routes, but NO `docker-compose.yml` exists | cleanup DNS or provision compose |
| **NO-DNS** | subdomain does not resolve | cleanup DNS-only ghost |

**Audit mode** : `urllib.request` (stdlib only, no extra deps) + `subprocess.run` for `docker ps` + `socket.gethostbyname` for DNS. Exit code = 1 if any P0/P1 (API-LEAK, ORPHELIN-*) found, 0 otherwise — CI-gateable.

### Empirical probe (post-apply, 6/6 tier WebUI)

Run c.442, 2026-07-14T~19:49Z. Output of `python scripts/security/audit_exposed_services.py`:

```
  stable-diffusion-webui-forge.myia.io               → ORPHELIN-START  (HTTP=502, container=False, api_auth=ERR(0))
  sdnext.myia.io                                     → ORPHELIN-START  (HTTP=502, container=False, api_auth=N/A)
  micro.text-generation-webui.myia.io                → ORPHELIN-DNS    (HTTP=0, container=False, api_auth=N/A)
  mini.text-generation-webui.myia.io                 → ORPHELIN-DNS    (HTTP=0, container=False, api_auth=N/A)
  medium.text-generation-webui.myia.io               → ORPHELIN-DNS    (HTTP=0, container=False, api_auth=N/A)
  large.text-generation-webui.myia.io                → ORPHELIN-DNS    (HTTP=0, container=False, api_auth=N/A)
```

**Finding** : 2× ORPHELIN-START (forge-turbo, sdnext — compose file exists, container not started, IIS 502) + 4× ORPHELIN-DNS (text-gen micro/mini/medium/large — DNS resolves but no compose file). NO AUTH-OK or API-LEAK detected = pas d'exposition auth-API-by-bypass détectée (cohérent avec l'inventaire ui-only).

**P0 actions** :
- `docker compose up -d forge-turbo` + `sdnext` (cleanup ORPHELIN-START → bring backend up)
- Triage : les 4 text-gen DNS entries sont-elles voulu-telles ou à supprimer ? (PR ou issue fille selon décision user)

### Tests (L498 NEW doctrine)

L498 : privacy/audit-class tooling MUST have round-trip **output-content** tests, not just detection boolean. The script's outputs ARE the substance (finding dict + markdown table), so:

- 5× `test_classify_<category>` : each of NO-DNS / ORPHELIN-DNS / ORPHELIN-START / API-LEAK / AUTH-OK — assertion on **finding dict content** (category, dns_resolves, http_external, api_auth, container_running), not just on detection
- 4× `test_probe_api_auth_<state>` : N/A / PROTECTED / OPEN / ERR(N) — assert on the returned classification string
- 3× `test_dns_resolves_*` + `test_http_probe_*` + `test_compose_exists_*` + `test_container_running_*` : helper-shape tests
- `test_render_markdown_contains_table_and_categories` : L498 round-trip on markdown rendered table — assert **specific content** (subdomain markers `a.myia.io`, `b.myia.io`; category markers `**AUTH-OK**`, `**API-LEAK**`; legend section) NOT just non-empty
- `test_run_audit_returns_list_of_findings` + `test_default_tier_covers_forge_sdnext_and_text_gen` : integration smoke

**21/21 PASS** (round-trip on substance, not detection).

### Validation

- `pytest scripts/tests/test_audit_exposed_services.py -v` : **21/21 PASS** in 0.23s
- `pytest scripts/tests/` (full repo test suite, regression check) : **1311 passed, 18 skipped** (1290 baseline + 21 new tests, 0 regressions)
- Script end-to-end execution : **6/6 findings rendered**, exit 1 (P0/P1 criticals detected)
- Branch rebase to current `origin/main` : **0 conflicts**, `mergeable=MERGEABLE` after force-push

### Files

- `scripts/security/audit_exposed_services.py` (NEW, 251 LF)
- `scripts/tests/test_audit_exposed_services.py` (NEW, 272 LF)

Total : 2 files changed, +523/-0.

### See #16

Partial contribution to EPIC #16 — this PR delivers the **tier WebUI login natif** audit tool. Remaining tiers (API-token services : Whisper / TTS / MusicGen / Demucs / MCP Tools / SK Agents / Embeddings / Qdrant / Search) will need their own probe tools or a generalized audit. Out of scope for this PR — separate follow-up issues to be opened once tier WebUI debt is resolved (forge-turbo + sdnext bringup, text-gen triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>