### PR TITLE
fix(security,#6529): canonical repo-wide NuGet-ext username strip (from merged #6563 hook)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
@@ -95,14 +95,14 @@
     {
      "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll`"
+      "text/plain": ""
      },
      "metadata": {}
     },
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "Failed to load kernel extension \"KernelExtension\" from assembly C:\\Users\\jsboi\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll"
+     "text": ""
     }
    ],
    "source": [

--- a/MyIA.AI.Notebooks/ML/ML.Net/TP-prevision-ventes.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/TP-prevision-ventes.ipynb
@@ -70,9 +70,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
-      ]
+      "text/plain": [""]
      },
      "metadata": {},
      "output_type": "display_data"

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
@@ -650,9 +650,7 @@
      "output_type": "display_data",
      "metadata": {},
      "data": {
-      "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\plotly.net.interactive\\5.0.0\\lib\\netstandard2.1\\Plotly.NET.Interactive.dll`"
-      ]
+      "text/plain": [""]
      }
     },
     {

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb
@@ -73,9 +73,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\3.119.0\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
-      ]
+      "text/plain": [""]
      },
      "metadata": {},
      "output_type": "display_data"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency-Csharp.ipynb
@@ -1076,9 +1076,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
-      ]
+      "text/plain": [""]
      },
      "metadata": {},
      "output_type": "display_data"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization-Csharp.ipynb
@@ -1110,9 +1110,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\3.119.0\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
-      ]
+      "text/plain": [""]
      },
      "metadata": {},
      "output_type": "display_data"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb
@@ -61,9 +61,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
-      ]
+      "text/plain": [""]
      },
      "metadata": {},
      "output_type": "display_data"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
@@ -784,9 +784,7 @@
     },
     {
      "data": {
-      "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\skiasharp\\2.88.9\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
-      ]
+      "text/plain": [""]
      },
      "metadata": {},
      "output_type": "display_data"


### PR DESCRIPTION
## What

The single authoritative repo-wide strip of the `.NET NuGet-extension` username leak, derived from the **canonical on-main hook** (`strip_machine_paths.py`, path-based detector merged via #6563). **Notebook outputs only** — no tool churn (#6563 already landed the hook), no catalog, no `.github`.

Per coordinator dispatch (ai-01, 2026-07-14T16:19Z): one deterministic pass from the merged hook = no double-strip churn, no risk of consecrating a false-positive removal (rule-6). Ground-truth = whatever the on-main hook outputs.

## Stripped (9 leak lines / 8 notebooks)

- **ML-5-TimeSeries**: the **stream variant** `Failed to load kernel extension "KernelExtension" from assembly C:\Users\<u>\.nuget\packages\xplot.plotly.interactive\4.1.0\...\XPlot.Plotly.Interactive.dll` (stderr `text`) + its success-variant `Loading extensions from …` display_data twin.
- **TP-prevision-ventes, DecInfer-4-Multi-Attribute, App-15b-SportsScheduling, CSP-2/6/8/9-Csharp**: the `Loading extensions from C:\Users\<u>\.nuget\packages\…` success-variant display_data.

## Intentionally LEFT INTACT (no false positive)

The dotnet-interactive **tilde** variant (`~\.nuget\packages\…`) is the `%USERPROFILE%` HOME *placeholder* — no username, no PII. The path-based hook keys on the username marker, so:
- **ML-7-Recommendation** and **OR-tools-Stiegler** (tilde-only) are **untouched** (verified: not in diff).

These were the v1 over-strips flagged in review of #6562.

## Verification (firsthand)

| axis | result |
|------|--------|
| **stream variant caught** | ✓ ML-5 stderr `Failed to load … Users\<u>\.nuget` stripped (diff line) |
| **no tilde false-positive** | ✓ ML-7-Recommendation + OR-tools-Stiegler not in diff |
| `execution_count` preserved | ✓ 0 `execution_count` lines in diff |
| JSON valid | ✓ 8/8 parse, 0 null-ec |
| CRLF | ✓ 0 introduced |
| leaks = pure removals | ✓ 9/9 leak-pattern lines are `-` (removals) |
| post-strip repo-wide | ✓ `--scan-all --check` exit 0 (0 leaks) |
| scope | ✓ notebook outputs only (no tool/catalog/.github) |

## Supersedes

- **#6537** — pre-#6563 v1-hook batch (output not guaranteed to match the merged path-based detector).
- **#6562** — signature-widen approach; carried redundant tool churn + over-stripped the tilde lines.

Both are closed in favor of this single canonical pass.

See #6529. See #6563 (canonical hook, merged). Supersedes #6537, #6562.
