### PR TITLE
fix(datasets): manage_crypto_archive --update mixed-date TypeError + regression test

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
@@ -720,30 +720,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Updating BTC archive: appending 2024-12-30 -> 2026-06-03\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Traceback (most recent call last):\n",
-      "  File \u001b[35m\"C:\\dev\\CoursIA\\scripts\\datasets\\manage_crypto_archive.py\"\u001b[0m, line \u001b[35m207\u001b[0m, in \u001b[35m<module>\u001b[0m\n",
-      "    \u001b[31mmain\u001b[0m\u001b[1;31m()\u001b[0m\n",
-      "    \u001b[31m~~~~\u001b[0m\u001b[1;31m^^\u001b[0m\n",
-      "  File \u001b[35m\"C:\\dev\\CoursIA\\scripts\\datasets\\manage_crypto_archive.py\"\u001b[0m, line \u001b[35m199\u001b[0m, in \u001b[35mmain\u001b[0m\n",
-      "    \u001b[31mupdate_archive\u001b[0m\u001b[1;31m(args.symbol.upper(), output_dir)\u001b[0m\n",
-      "    \u001b[31m~~~~~~~~~~~~~~\u001b[0m\u001b[1;31m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\u001b[0m\n",
-      "  File \u001b[35m\"C:\\dev\\CoursIA\\scripts\\datasets\\manage_crypto_archive.py\"\u001b[0m, line \u001b[35m157\u001b[0m, in \u001b[35mupdate_archive\u001b[0m\n",
-      "    df_combined = df_combined.drop_duplicates(subset=[\"date\"]).sort_values(\"date\")\n",
-      "  File \u001b[35m\"C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\core\\frame.py\"\u001b[0m, line \u001b[35m8358\u001b[0m, in \u001b[35msort_values\u001b[0m\n",
-      "    indexer = nargsort(\n",
-      "        k, kind=kind, ascending=ascending, na_position=na_position, key=key\n",
-      "    )\n",
-      "  File \u001b[35m\"C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\core\\sorting.py\"\u001b[0m, line \u001b[35m442\u001b[0m, in \u001b[35mnargsort\u001b[0m\n",
-      "    indexer = non_nan_idx[\u001b[31mnon_nans.argsort\u001b[0m\u001b[1;31m(kind=kind)\u001b[0m]\n",
-      "                          \u001b[31m~~~~~~~~~~~~~~~~\u001b[0m\u001b[1;31m^^^^^^^^^^^\u001b[0m\n",
-      "\u001b[1;35mTypeError\u001b[0m: \u001b[35m'<' not supported between instances of 'datetime.date' and 'str'\u001b[0m\n"
+      "Updating BTC archive: appending 2024-12-30 -> 2026-07-14\n",
+      "  Updated: ..\\datasets\\crypto_archive\\BTC_USDT_archive.csv (2751 rows, +561 new)\n"
      ]
     }
    ],
@@ -779,7 +757,7 @@
      "text": [
       "Symbol   Start        End          Rows     Size      \n",
       "--------------------------------------------------\n",
-      "BTC      2019-01-01 2024-12-30 2191     178 KB\n"
+      "BTC      2019-01-01 2026-07-13 2751     220 KB\n"
      ]
     }
    ],

--- a/scripts/datasets/manage_crypto_archive.py
+++ b/scripts/datasets/manage_crypto_archive.py
@@ -154,6 +154,12 @@ def update_archive(symbol: str, output_dir: Path) -> Path | None:
         return None
 
     df_combined = pd.concat([df_old, df_new], ignore_index=True)
+    # Normalize the "date" column to a single type: pd.read_csv yields string dates from
+    # the existing archive while _download_binance_historical yields datetime.date objects,
+    # so a naive concat produces a mixed-type column that raises
+    # "TypeError: '<' not supported between instances of 'datetime.date' and 'str'" in
+    # sort_values. pd.to_datetime accepts both forms; .dt.date canonicalizes to date objects.
+    df_combined["date"] = pd.to_datetime(df_combined["date"]).dt.date
     df_combined = df_combined.drop_duplicates(subset=["date"]).sort_values("date")
 
     df_combined.to_csv(existing, index=False)

--- a/scripts/tests/test_manage_crypto_archive.py
+++ b/scripts/tests/test_manage_crypto_archive.py
@@ -1,0 +1,103 @@
+"""Tests for scripts/datasets/manage_crypto_archive.py
+
+Covers: update_archive mixed-date-type handling.
+
+Regression test: pd.read_csv yields string dates from the existing archive while
+_download_binance_historical yields datetime.date objects, so a naive concat produced a
+mixed-type "date" column that raised
+"TypeError: '<' not supported between instances of 'datetime.date' and 'str'" in sort_values.
+The fix normalizes the column with pd.to_datetime(...).dt.date before dedup/sort.
+
+Pure computation on CPU. The network download is monkeypatched (no yfinance/network needed).
+"""
+
+import sys
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Add scripts/datasets to sys.path so we can import the module by file.
+_datasets = str(Path(__file__).resolve().parent.parent / "datasets")
+if _datasets not in sys.path:
+    sys.path.insert(0, _datasets)
+
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "manage_crypto_archive", Path(_datasets) / "manage_crypto_archive.py"
+)
+mca = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mca)
+
+
+def _mock_new_rows():
+    """Mimic _download_binance_historical output: date column as datetime.date objects."""
+    return pd.DataFrame(
+        {
+            "date": [date(2024, 12, 30), date(2024, 12, 31), date(2025, 1, 1)],
+            "open": [94800, 95100, 95300],
+            "high": [95500, 95800, 96000],
+            "low": [94000, 94500, 94700],
+            "close": [95200, 95300, 95700],
+            "volume": [1.2e9, 1.0e9, 1.1e9],
+        }
+    )
+
+
+def _write_old_archive(path: Path):
+    """Mimic an existing archive as read back by pd.read_csv: string dates."""
+    pd.DataFrame(
+        {
+            "date": ["2024-12-28", "2024-12-29", "2024-12-30"],
+            "open": [95000, 95500, 94800],
+            "high": [96000, 96500, 95500],
+            "low": [94500, 95000, 94000],
+            "close": [95500, 94800, 95200],
+            "volume": [1.0e9, 1.1e9, 1.2e9],
+        }
+    ).to_csv(path, index=False)
+
+
+class TestUpdateArchiveMixedDateTypes:
+    """update_archive must merge CSV-read string dates with downloaded date objects."""
+
+    def test_update_succeeds_with_mixed_types(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mca, "_download_binance_historical",
+                            lambda symbol, start, end: _mock_new_rows())
+        archive = tmp_path / "BTC_USDT_archive.csv"
+        _write_old_archive(archive)
+
+        # Before the fix this raised TypeError in sort_values.
+        result = mca.update_archive("BTC", tmp_path)
+        assert result == archive
+
+        df = pd.read_csv(archive)
+        # 3 old + 3 new - 1 overlap (2024-12-30)
+        assert len(df) == 5
+
+    def test_update_dedups_overlap_and_sorts(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mca, "_download_binance_historical",
+                            lambda symbol, start, end: _mock_new_rows())
+        archive = tmp_path / "BTC_USDT_archive.csv"
+        _write_old_archive(archive)
+
+        mca.update_archive("BTC", tmp_path)
+        df = pd.read_csv(archive)
+
+        dates = pd.to_datetime(df["date"]).tolist()
+        assert dates == sorted(dates), "dates must be sorted ascending"
+        assert (df["date"].astype(str) == "2024-12-30").sum() == 1, "overlap must be deduped"
+
+    def test_update_no_new_data(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mca, "_download_binance_historical",
+                            lambda symbol, start, end: pd.DataFrame())
+        archive = tmp_path / "BTC_USDT_archive.csv"
+        _write_old_archive(archive)
+
+        assert mca.update_archive("BTC", tmp_path) is None
+
+    def test_update_missing_archive(self, tmp_path):
+        # No existing CSV -> graceful None, no exception.
+        assert mca.update_archive("BTC", tmp_path) is None


### PR DESCRIPTION
## Summary

Fixes a `TypeError: '<' not supported between instances of 'datetime.date' and 'str'` in `scripts/datasets/manage_crypto_archive.py` `update_archive` (the `--update` path was broken). Adds a regression test.

## Root cause

`update_archive` concatenates an existing CSV archive with freshly-downloaded rows:
- `df_old = pd.read_csv(existing)` → `date` column is **strings** (CSV has no type info)
- `df_new = _download_binance_historical(...)` → `date` column is **`datetime.date` objects** (line 98: `pd.to_datetime(...).dt.date`)
- `pd.concat([df_old, df_new])` → **mixed-type** `date` column
- `.sort_values("date")` → `TypeError` (can't compare `date` < `str`)

`build_archive` and `list_archives` are unaffected (single-source and all-string paths respectively), so the bug is localized to `update_archive`.

## Fix (1 line + comment)

Normalize the concatenated `date` column before dedup/sort:
```python
df_combined["date"] = pd.to_datetime(df_combined["date"]).dt.date
```
`pd.to_datetime` accepts both string and date-object forms → single-type column → clean sort. Output CSV still serializes back to strings (unchanged).

## Verification (H.1 — real + unit)

**Regression test** `scripts/tests/test_manage_crypto_archive.py` (4 tests, all pass):
- Monkeypatches `_download_binance_historical` (no yfinance/network needed)
- Reproduces the mixed-type concat, asserts `update_archive` succeeds
- Asserts overlap dedup (3+4-1=5 rows) + ascending sort
- Asserts empty-download and missing-archive edge cases return `None` gracefully

**Real-data re-exec** (the H.1 proof): `QC-Py-Dataset-Workflow.ipynb` cells exercising the script regenerated from actual script runs:
- **c18** (`--update`): was a committed `TypeError` traceback → now succeeds (`2191 -> 2751 rows, +561 new`)
- **c19** (`--list`): updated to reflect the new archive state (`2751 rows, 220 KB`, end `2026-07-13`)
- c9 (build) unchanged — identical `2191 rows` output, not invalidated by the fix
- No machine-path leak: outputs use relative `..\datasets` paths (matching c9's committed style). Archive data is gitignored (not committed).

`validate_pr_notebooks.py` PASS (14 cells). Catalog byte-identical to main.

## Scope

Atomic, single subject (the script bug + its test + the notebook outputs it invalidated). C.1 clean. The notebook output update is limited to the two cells (c18/c19) directly invalidated by the script fix (the traceback was the visible symptom); no other cells touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)