### PR TITLE
i18n(#4980): migrate knot_lean Conway_en + Lidman_en to _en import graph

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Conway_en.lean
@@ -33,10 +33,10 @@
   remain byte-identical between the two files (anti-§D byte-identity invariant).
 -/
 
-import Knots.Basic
-import Knots.Invariant
+import Knots.Basic_en
+import Knots.Invariant_en
 
-open Knots
+open Knots_en
 
 namespace Knots_en
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Lidman_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Lidman_en.lean
@@ -24,8 +24,8 @@
   - Némethi's algorithm for computing HF of plumbed manifolds
 -/
 
-import Knots.Basic
-import Knots.Invariant
+import Knots.Basic_en
+import Knots.Invariant_en
 
 /-
   English mirror of `Lidman.lean` (FR canonical). Convention EPIC #4980
@@ -35,7 +35,7 @@ import Knots.Invariant
   signatures, proofs and tactics remain byte-identical between the two files.
 -/
 
-open Knots
+open Knots_en
 
 namespace Knots_en
 


### PR DESCRIPTION
## Summary

Migrates `Conway_en.lean` + `Lidman_en.lean` (knot_lean) from the **transitional** FR-import graph + `open Knots` to the clean **_en import graph**, now that `Invariant_en.lean` exists (#6581). This is the second half of ai-01's greenlit Invariant_en follow-up (DM msg-...dv0kt2): _"Then migrate Conway_en + Lidman_en to `import Knots.Invariant_en` + `open Knots_en` (drops the transitional `open Knots`)."_ Kept atomic (only the 2 migrated files) so the import-switch can be gated separately from the Invariant_en add.

## Change (3 lines per file, body untouched)

```diff
- import Knots.Basic        # FR canonical
- import Knots.Invariant    # FR canonical
+ import Knots.Basic_en
+ import Knots.Invariant_en

- open Knots                # transitional, opens FR namespace
+ open Knots_en
```

Applied identically to both `Conway_en.lean` and `Lidman_en.lean`. The body (signatures, proofs, tactics, sorry) is **byte-identical** — only the 3 import/open lines per file change. Bare names (`KnotDiagram`, `ReidmeisterEquiv`, `IsTricolorable`, …) now resolve via the _en graph (`Basic_en` → `Reidemeister_en` → `Invariant_en`, all in `namespace Knots_en`) instead of the FR `Knots` namespace.

## Stacking

This PR is **stacked on #6581** (base = `feature/i18n-invariant-en-4980`) so the `_en` import graph resolves for both the local build verification and CI. After #6581 merges, retarget this PR's base to `main` (or rebase onto main) — the diff stays atomic (only the 2 migrated files, since `Invariant_en.lean` will then be on main).

## Verification (lean-merge-discipline HARD)

- **`lake build Knots.Conway_en` + `Knots.Lidman_en` LOCAL SUCCESS** — C:/invEn shallow worktree (MAX_PATH-safe), rc1, 319 jobs, exit 0.
- **tactical `sorry` unchanged** (anti-regression):
  - `Conway_en` = 8 (= FR canonical `Conway.lean` = 8) — 0 new, 0 removed
  - `Lidman_en` = 2 (= FR canonical `Lidman.lean` = 2) — 0 new, 0 removed
- **diff**: 2 files, 6 insertions, 6 deletions (import/open lines only).
- **LF endings** (byte-verified CRLF=0).

## Out of scope (separate follow-up)

`Conway_en.lean`'s module docstring is currently **FR** (the "inverted pattern" — `Conway.lean` canonical is EN-headed, `Conway_en` carries the FR translation; cf the grothendieck c.450 adjudication). Restoring `Conway_en`'s header to EN (or francizing the canonical) is a **separate** docstring/francization concern, NOT this import-switch. Flagged to ai-01 for a follow-up.

See #4980 (Lean i18n EPIC, Pattern A). Not `Closes` — the epic tranche is partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
