### PR TITLE
fix(smt,#6300): repair 5 stale Z3-rename cross-family refs (Sudoku + scripts/environment)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/index.qmd
+++ b/MyIA.AI.Notebooks/Sudoku/index.qmd
@@ -75,12 +75,12 @@ jupyter kernelspec list             # vérifier la présence de .net-csharp
 
 - **README de série** : [Sudoku/README.md](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Sudoku/README.md) — table des matières détaillée et arc narratif.
 - **Catalogue** : `COURSE_CATALOG.generated.md` — inventaire exhaustif avec statuts, kernels, prérequis.
-- **Séries connexes** : [Search](../Search/index.qmd) (CSP et métaheuristiques, fondements algorithmiques), [GameTheory](../GameTheory/index.qmd) (jeux combinatoires), [SMT/Z3 (README)](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md) (Z3, le solveur du Sudoku-12).
+- **Séries connexes** : [Search](../Search/index.qmd) (CSP et métaheuristiques, fondements algorithmiques), [GameTheory](../GameTheory/index.qmd) (jeux combinatoires), [SMT/Z3 (README)](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/README.md) (Z3, le solveur du Sudoku-12).
 
 ## Pour aller plus loin
 
 Une fois les 19 approches comparées, les prolongements naturels sont :
 
 1. **Vers la preuve formelle** : Sudoku-19 (Lean 4) ouvre la série SymbolicAI/Lean — la propagation devient un théorème.
-2. **Vers les solveurs SMT** : [SMT/Z3 (README)](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/README.md) — Z3, le moteur du Sudoku-12, appliqué à l'ordonnancement, la cryptarithmétique, les bit-vectors.
+2. **Vers les solveurs SMT** : [SMT/Z3 (README)](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/README.md) — Z3, le moteur du Sudoku-12, appliqué à l'ordonnancement, la cryptarithmétique, les bit-vectors.
 3. **Vers la théorie des jeux** : [GameTheory](../GameTheory/index.qmd) — d'autres espaces combinatoires, d'autres critères d'optimalité.

--- a/scripts/environment/automata-build-deploy.ps1
+++ b/scripts/environment/automata-build-deploy.ps1
@@ -14,10 +14,10 @@
 #   (System.CodeDom) from the NuGet cache is all that the notebook #r path-loads need.
 #
 # Result: a fresh checkout with --recurse-submodules + .NET SDK can run notebook
-#   06_Witness_Generation_Automata self-contained (no publish account, offline-friendly).
+#   10_Witness_Generation_Automata self-contained (no publish account, offline-friendly).
 #
 # Mirrors scripts/environment/z3-build-deploy.ps1 (Z3.Linq fork). See #2979 step 6.
-# See: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/06_Witness_Generation_Automata.ipynb (cell 1)
+# See: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb (cell 1)
 
 param(
     # Path to the Automata submodule (auto-detected relative to this script).

--- a/scripts/environment/z3-build-deploy.ps1
+++ b/scripts/environment/z3-build-deploy.ps1
@@ -14,10 +14,10 @@
 #   ExpressionUtils.dll from the NuGet cache alongside it.
 #
 # Result: a fresh checkout with --recurse-submodules + .NET SDK can run every
-# SMT/Z3 notebook self-contained (no publish account, offline-friendly).
+# SMT/Z3-Linq2Z3 notebook self-contained (no publish account, offline-friendly).
 #
 # Decision: ai-01 [DECISION COORD] 2026-06-13, option (b) refined.
-# See: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/04_Nested_Arrays_2D.ipynb (cell 1)
+# See: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb (cell 1)
 
 param(
     # Path to the Z3.Linq submodule (auto-detected relative to this script).

--- a/scripts/environment/z3-build-deploy.sh
+++ b/scripts/environment/z3-build-deploy.sh
@@ -13,10 +13,10 @@
 # ExpressionUtils.dll from the NuGet cache alongside it.
 #
 # Result: a fresh checkout with --recurse-submodules + .NET SDK runs every
-# SMT/Z3 notebook self-contained.
+# SMT/Z3-Linq2Z3 notebook self-contained.
 #
 # Decision: ai-01 [DECISION COORD] 2026-06-13, option (b) refined.
-# See: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3/04_Nested_Arrays_2D.ipynb (cell 1)
+# See: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb (cell 1)
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Post-#6404 rename (`Z3/` → `Z3-Linq2Z3/`, `Z3-Python/` → `Z3-API/`) + #6552 (repaired 20 broken nav-links intra-SymbolicAI), **5 stale `SMT/Z3/` refs survived** in cross-family files that #6552's scope missed. All point to targets that were double-renamed (directory rename + file renumber).

## The 5 stale refs (4 files)

| File:line | Stale ref | New path (verified exists) |
|---|---|---|
| `Sudoku/index.qmd:78` | `SMT/Z3/README.md` | `SMT/Z3-Linq2Z3/README.md` |
| `Sudoku/index.qmd:85` | `SMT/Z3/README.md` | `SMT/Z3-Linq2Z3/README.md` |
| `scripts/environment/automata-build-deploy.ps1:20` | `SMT/Z3/06_Witness_Generation_Automata.ipynb` | `SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb` (renumber 06→10) |
| `scripts/environment/z3-build-deploy.ps1:20` | `SMT/Z3/04_Nested_Arrays_2D.ipynb` | `SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb` (renumber 04→05) |
| `scripts/environment/z3-build-deploy.sh:19` | `SMT/Z3/04_Nested_Arrays_2D.ipynb` | `SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb` |

The two script files also had a prose mention of the old notebook number (e.g. `06_Witness_Generation_Automata` / `SMT/Z3 notebook`) on the line above — harmonized to the new number/name for consistency (the comment points to the same notebook via the `(cell 1)` reference).

## Why these are not po-2025's turf

po-2025 owns the Z3 series itself. These 5 stale refs are in **Sudoku** (`index.qmd`) and **scripts/environment** (build-deploy scripts) — cross-family files pointing INTO the renamed Z3 dirs. #6552 (po-2025) correctly scoped its nav-link repair to intra-SymbolicAI and missed these cross-family incoming refs.

## Verification (firsthand)

- **All 3 new-path targets verified to EXIST** on `origin/main` (`git ls-tree`): `Z3-Linq2Z3/README.md`, `Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb`, `Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb`.
- **Exhaustive repo scan post-fix**: `git grep -nE 'SMT/Z3/|SMT/Z3-Python/'` → **0 stale refs remaining**.
- **`check_docs_links.py`**: 3920 links scanned, **0 broken** (EXIT=0).
- **Catalogue byte-identical** to `origin/main` (catalog-guard CI clean).
- **LF endings** (byte-verified CRLF=0; `*.sh text eol=lf` in .gitattributes, .ps1/.qmd were already LF).

## Scope

4 files, +8/−8, link/path correction only. No source code, no notebooks, no re-execution needed (markdown/comments only). Atomic — single defect class (post-rename stale cross-family refs).

See #6300 (ai-01 greenlit Schéma A rename, owner po-2025). Not `Closes` — the rename epic's cross-family cleanup is incremental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)