### PR TITLE
fix(notebook,secrets,#6529): audit-extension 3 tokens (python/miniconda/windowsapps)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-21-SAETrajectoires.ipynb
@@ -164,7 +164,7 @@
       "\n",
       "Loading weights:   0%|          | 0/427 [00:00<?, ?it/s]\n",
       "Loading weights: 100%|██████████| 427/427 [00:00<00:00, 11342.99it/s]\n",
-      "C:\\Users\\MYIA\\miniconda3\\envs\\coursia-sae\\Lib\\site-packages\\torch\\nn\\modules\\module.py:1369: UserWarning: expandable_segments not supported on this platform (Triggered internally at C:\\actions-runner\\_work\\pytorch\\pytorch\\c10/cuda/CUDAAllocatorConfig.h:40.)\n",
+      "<USER_PATH>\\miniconda3\\envs\\coursia-sae\\Lib\\site-packages\\torch\\nn\\modules\\module.py:1369: UserWarning: expandable_segments not supported on this platform (Triggered internally at C:\\actions-runner\\_work\\pytorch\\pytorch\\c10/cuda/CUDAAllocatorConfig.h:40.)\n",
       "  return t.to(\n",
       "\n",
       "=> SMOKE OK : pipeline GPU rejoué en direct dans ce notebook.\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/00-Environment/Planners-0-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/00-Environment/Planners-0-Setup.ipynb
@@ -88,7 +88,7 @@
       "Systeme d'exploitation: Windows\n",
       "Version Python: 3.13.7\n",
       "Repertoire de travail: C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\00-Environment\n",
-      "Executable Python: C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\python.exe\n"
+      "Executable Python: <USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\python.exe\n"
      ]
     }
    ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
@@ -66,7 +66,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\python.exe\n"
+      "<USER_PATH>\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\python.exe\n"
      ]
     },
     {

--- a/scripts/notebook_tools/strip_machine_paths.py
+++ b/scripts/notebook_tools/strip_machine_paths.py
@@ -8,8 +8,8 @@ the sanctioned durable approach for category-A kernel-injected leaks (cf.
 ``strip_probe_banner.py`` post-mortem); contrast with category-C
 (source-leak), which must be fixed at the source.
 
-Five runtime-category tokens cover the observed kernel-injected leaks, each
-with the runtime that injects them:
+Eight runtime-category tokens cover the observed kernel-injected leaks,
+each with the runtime that injects them:
 
 ==== ============================================ ===========================
 cat  cache / context token                        runtime
@@ -36,6 +36,22 @@ conda   ``.conda\\envs``                           conda env (e.g.
 hf      ``.cache\\huggingface`` / ``.cache/huggingface``  HF transformers/datasets
             download warnings (``local_dir_use_symlinks is deprecated``,
             symlink-cache system warning, etc.)
+
+python  ``AppData\\Local\\Programs``               user-local Python interpreter
+            install (``python.exe`` shebang / ``sys.executable`` printouts
+            via ``sysconfig`` ``get_paths`` / ``pip --version`` output
+            warnings). REDACT: keep ``\\Python\\Python313\\python.exe``.
+
+miniconda    ``miniconda3\\envs``                  miniconda-managed env warning
+            stderr (``miniconda3/envs/<env>/lib/python3.X/...`` torch /
+            triton warnings). Distinct from ``.conda\\envs`` (the
+            ``conda`` token above) — different install layout (Conda vs
+            miniconda). REDACT: keep ``\\envs\\<env>\\Lib\\site-packages``.
+
+windowsapps  ``Microsoft\\WindowsApps``           WindowsApps Python launcher
+            (``py.exe`` resolution from Microsoft Store install:
+            ``PythonSoftwareFoundation.Python.3.13_<id>\\python.exe``).
+            REDACT: keep the launcher filename.
 
 other   ``AppData\\Local\\Temp`` (without ipykernel)     python-side ephemeral
             file prints (``Audio cree: ...\\Temp\\test_audio.mp3``,
@@ -136,6 +152,28 @@ MACHINE_PATH_TOKENS = (
     ("hf", ".cache\\huggingface"),  # forward-slash variant is detected by the
                                     # same token pair because cache tokens are
                                     # substring-matched, not slash-strict
+    ("python", "AppData\\Local\\Programs"),  # user-local Python interpreter
+                                              # install (``python.exe`` shebang
+                                              # / sys.executable printouts);
+                                              # missed by ``pip``/``ipykernel``
+                                              # because no ``\Roaming\Python``
+                                              # or ``\Temp\ipykernel`` segment.
+                                              # REDACT strategy: keep the
+                                              # ``\Python\Python313\python.exe``
+                                              # trailing leaf (pedagogy).
+    ("miniconda", "miniconda3\\envs"),  # conda env warning stderr (NOT
+                                        # ``.conda\envs`` which is the
+                                        # ``conda`` token above — distinct
+                                        # install layout). REDACT: keep
+                                        # ``\envs\<env>\Lib\site-packages``
+                                        # trailing path.
+    ("windowsapps", "Microsoft\\WindowsApps"),  # WindowsApps Python launcher
+                                                # (``PythonSoftwareFoundation.
+                                                # Python.3.13_*.exe`` —
+                                                # `py.exe` resolution from the
+                                                # Microsoft Store install).
+                                                # REDACT: keep the launcher
+                                                # filename.
     ("other", "AppData\\Local\\Temp"),  # generic %TEMP% prints (catches
                                         # both ipykernel-pid and bare temp
                                         # files; ipykernel category above is
@@ -700,10 +738,13 @@ def main():
     global ACTIVE_CATEGORIES
     parser = argparse.ArgumentParser(
         description="Strip machine-username path leaks from notebook outputs. "
-                    "Covers 5 runtime-category leaks: nuget (dotnet-interactive), "
+                    "Covers 8 runtime-category leaks: nuget (dotnet-interactive), "
                     "pip (CPython AppData\\Roaming\\Python), ipykernel (per-cell "
-                    "temp file warnings), conda (env path warnings), hf "
-                    "(HuggingFace cache warnings). Path-based detection."
+                    "temp file warnings), conda (.conda\\envs), hf (HuggingFace "
+                    "cache warnings), python (user-local interpreter under "
+                    "AppData\\Local\\Programs), miniconda (conda envs under "
+                    "miniconda3\\envs), windowsapps (Microsoft Store Python "
+                    "launcher). Path-based detection."
     )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--scan", metavar="PATH",

--- a/scripts/notebook_tools/tests/test_strip_machine_paths.py
+++ b/scripts/notebook_tools/tests/test_strip_machine_paths.py
@@ -456,20 +456,49 @@ _HF_LINE = (
 )
 _OTHER_LINE = "C:\\Users\\jsboi\\AppData\\Local\\Temp\\test_audio.mp3"
 
+# c.441 c.7e — audit-extension follow-up: 3 new tokens (python / miniconda /
+# windowsapps) catch 3 source-nb leaks the 6-token taxonomy missed. Each
+# fixture mirrors a real source-nb leak line observed in:
+# - Planners-0-Setup (AppData\\Local\\Programs user-local Python install)
+# - ICT-21-SAETrajectoires (miniconda3\\envs\\coursia-sae torch warning)
+# - Tweety-7b-Ranking-Probabilistic (Microsoft\\WindowsApps Python launcher)
+_PYTHON_LINE = (
+    "C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\python.exe"
+)
+_MINICONDA_LINE = (
+    "C:\\Users\\MYIA\\miniconda3\\envs\\coursia-sae\\Lib\\site-packages\\"
+    "torch\\nn\\modules\\module.py"
+)
+_WINDOWSAPPS_LINE = (
+    "C:\\Users\\jsboi\\AppData\\Local\\Microsoft\\WindowsApps\\"
+    "PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\python.exe"
+)
+
 
 def test_machine_path_tokens_canonical():
-    """The category taxonomy MUST be exactly the 6 listed in C534-L1.
+    """The category taxonomy MUST be exactly the 9 listed in C534-L1 + the
+    audit-extension follow-up (c.441 c.7e — python / miniconda / windowsapps
+    tokens added to catch 3 source-nb leaks missed by the 6-token taxonomy).
 
     Order matters for ``_first_matching_label`` (first hit wins): nuget →
-    pip → ipykernel → conda → hf → other. The hf token (``.cache\\huggingface``)
-    overlaps the ``other`` token (``AppData\\Local\\Temp``) **not at all**;
-    what can happen is a single line matching pip THEN hf (because
-    ``huggingface_hub`` lives under ``AppData\\Roaming\\Python\\site-packages``),
-    and we want the more specific pip label to win (it is more diagnostic
-    for the source machine — same env-name, same Python interpreter).
+    pip → ipykernel → conda → hf → python → miniconda → windowsapps → other.
+    The hf token (``.cache\\huggingface``) overlaps the ``other`` token
+    (``AppData\\Local\\Temp``) **not at all**; what can happen is a single
+    line matching pip THEN hf (because ``huggingface_hub`` lives under
+    ``AppData\\Roaming\\Python\\site-packages``), and we want the more
+    specific pip label to win (it is more diagnostic for the source
+    machine — same env-name, same Python interpreter).
+
+    python / miniconda / windowsapps are interleaved between hf and other
+    because they're more specific than ``other`` (``AppData\\Local\\Temp``)
+    and distinct from conda / pip (different runtime layout, no token
+    overlap with the more-specific tokens above them).
     """
     labels = [label for label, _ in MACHINE_PATH_TOKENS]
-    assert labels == ["nuget", "pip", "ipykernel", "conda", "hf", "other"]
+    assert labels == [
+        "nuget", "pip", "ipykernel", "conda", "hf",
+        "python", "miniconda", "windowsapps", "other",
+    ]
     # Backwards-compat surface preserved.
     assert MACHINE_PATH_TOKENS[0] == ("nuget", NUGET_CACHE_TOKEN)
 
@@ -540,6 +569,57 @@ def test_redact_line_per_category():
         # The stable placeholder MUST appear at least once (the username
         # was successfully redacted to the placeholder form).
         assert "<USER_PATH>" in redacted, (line, redacted)
+
+
+def test_redact_line_per_category_audit_extension_3_tokens():
+    """L498 (round-trip output-content test) for the 3 audit-extension tokens
+    added in c.441 c.7e. Each new token (python / miniconda / windowsapps)
+    must REDACT the username prefix to <USER_PATH>\\, drop the username
+    segment, and preserve the runtime-distinct trailing leaf (the pedagogy
+    part).
+
+    L498 doctrine: REDACT privacy tooling must have a round-trip OUTPUT
+    test (not just a detection boolean). The v1 detection-only test would
+    have silently passed even if ``_redact_line`` re-emitted the original
+    line verbatim — a falsified coverage.
+    """
+    cases = [
+        # (leak_line, runtime_segment_to_preserve)
+        (_PYTHON_LINE, "Python\\Python313\\python.exe"),
+        (_MINICONDA_LINE, "envs\\coursia-sae\\Lib\\site-packages\\torch"),
+        (_WINDOWSAPPS_LINE,
+         "PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\python.exe"),
+    ]
+    for line, runtime_segment in cases:
+        redacted = _redact_line(line)
+        # No username / ``Users\\`` payload survives.
+        assert "jsboi" not in redacted, (line, redacted)
+        assert "MYIA" not in redacted, (line, redacted)
+        assert "Users\\" not in redacted, (line, redacted)
+        # Placeholder MUST appear (REDACT happened, not DROP).
+        assert "<USER_PATH>" in redacted, (line, redacted)
+        # Runtime segment MUST survive (pedagogy — which Python install,
+        # which env, which launcher).
+        assert runtime_segment in redacted, (line, redacted, runtime_segment)
+
+
+def test_has_leak_per_token_audit_extension_3_tokens():
+    """Detection picks up the 3 new tokens AND these are not double-counted
+    by any of the pre-existing 6 categories (no token overlap).
+    """
+    # python token — ``AppData\\Local\\Programs`` (NOT ``Roaming\\Python``
+    # which would be the pip token, NOT ``Local\\Temp`` which is other).
+    assert _has_leak(_PYTHON_LINE) is True
+    # miniconda token — ``miniconda3\\envs`` (NOT ``.conda\\envs`` which is
+    # the conda token; C534-L1 / c.441 c.5 distinction preserved).
+    assert _has_leak(_MINICONDA_LINE) is True
+    # windowsapps token — ``Microsoft\\WindowsApps``.
+    assert _has_leak(_WINDOWSAPPS_LINE) is True
+    # Label resolution per first-matching-token: each new token produces
+    # its own label (NOT pip / conda / other — proving non-overlap).
+    assert _first_matching_label(_PYTHON_LINE) == "python"
+    assert _first_matching_label(_MINICONDA_LINE) == "miniconda"
+    assert _first_matching_label(_WINDOWSAPPS_LINE) == "windowsapps"
 
 
 def test_redact_line_unix_home_path():


### PR DESCRIPTION
## fix(notebook,secrets,#6529): audit-extension 3 tokens (python/miniconda/windowsapps)

### Context

C534-L1 multi-runtime path-based detector (6 tokens, #6574) covered nuget / pip / ipykernel / conda / hf / other. C538-L1 follow-up audit (po-2024 c.534 + po-2026 c.441 c.5) found 3 additional source-nb leaks the 6-token taxonomy missed because the runtime context-tokens they embed are not in the taxonomy:

- **Planners-0-Setup cell[2]**: `C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\python.exe` (user-local Python interpreter install)
- **ICT-21-SAETrajectoires cell[5]**: `C:\\Users\\MYIA\\miniconda3\\envs\\coursia-sae\\Lib\\site-packages\\torch\\nn\modules\module.py` (miniconda3 env warning)
- **Tweety-7b-Ranking-Probabilistic cell[1]**: `C:\\Users\\jsboi\\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\python.exe` (Microsoft Store Python launcher)

### Change

Add 3 new `MACHINE_PATH_TOKENS` entries between `hf` and `other` (order matters for `_first_matching_label` first-hit-wins; new tokens are more specific than `other` but distinct from the more-specific tokens above them):

| Token | Cache context | Runtime |
| --- | --- | --- |
| `python` | `AppData\\Local\\Programs` | user-local CPython install |
| `miniconda` | `miniconda3\\envs` | miniconda env warning (distinct from `conda`'s `.conda\envs`) |
| `windowsapps` | `Microsoft\\WindowsApps` | MS Store Python launcher |

### Tests (L498 NEW doctrine)

L498: REDACT privacy tooling must have a round-trip **output-content** test, not just detection boolean. v1 detection-only tests would have falsely passed even if `_redact_line` re-emitted the original line verbatim — a falsified coverage.

- `test_machine_path_tokens_canonical`: updated 6 → 9 entries, asserts order `[nuget, pip, ipykernel, conda, hf, python, miniconda, windowsapps, other]`
- `test_redact_line_per_category_audit_extension_3_tokens`: 3 REDACT cases asserting **username/`Users\\` GONE** + **`<USER_PATH>` APPEARS** + **runtime segment PRESERVED** (C534-L1 REDACT, not DROP)
- `test_has_leak_per_token_audit_extension_3_tokens`: detection + non-overlap (each new token's `_first_matching_label` returns its own label, not pip / conda / other — proving no double-counting)

### Empirical probe (3 spot-checks, post-apply)

REDACT strategy (C534-L1): username segment GONE, runtime segment PRESERVED.

```
ICT-21-SAETrajectoires cell[5]:
  C:\\Users\\MYIA\\miniconda3\\envs\\coursia-sae\\Lib\\site-packages\\torch\nn\modules\module.py:1369: UserWarning: expandable_segments not supported on this platform (Triggered internally at C:\\actions-runner\_work\pytorch\pytorch\c10/cuda/CUDAAllocatorConfig.h:40.)
  ->
  <USER_PATH>\\miniconda3\\envs\\coursia-sae\\Lib\\site-packages\\torch\nn\modules\module.py:1369: UserWarning: ...

Planners-0-Setup cell[2]:
  Executable Python: C:\\Users\\jsboi\\AppData\\Local\\Programs\\Python\\Python313\\python.exe
  ->
  Executable Python: <USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\python.exe

Tweety-7b-Ranking-Probabilistic cell[1]:
  C:\\Users\\jsboi\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\python.exe
  ->
  <USER_PATH>\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\python.exe
```

NB: Planners-0-Setup cell[18] has a benign `jsboige/coursia-fast-downward` DockerHub reference (not a Windows path, `jsboige` ≠ `jsboi`) that is correctly left untouched.

### Validation

- `--scan-all`: 23 nb × 60 leaks (pre-PR baseline) → **26 nb × 63 leaks** (post-PR) = +3 nb, +3 leaks caught
- `--apply-all`: 26 nb × 63 leak lines fixed, 0 skipped
- `--scan-all --check`: **0 nb × 0 leaks, exit 0** (acceptance gate)
- `pytest scripts/notebook_tools/tests/test_strip_machine_paths.py`: **52/52 PASS** (49 baseline + 3 new)
- `pytest scripts/notebook_tools/tests/`: **2139/2139 PASS** (2136 baseline + 3 new)
- `pytest --tb=short` (full repo): **4657 PASS, 19 skipped, 4 xfailed, 9 warnings** (torch UserWarning, unrelated)

### See #6529

Partial contribution to #6529 (audit-extension follow-up — Option B doctrine continued from #6574 / c.441 c.7b). The 3 new tokens extend the multi-runtime taxonomy. No new doctrine: C534-L1 REDACT vs DROP strategy applies identically (python / miniconda / windowsapps all keep the runtime-distinct trailing leaf, drop the username prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
