### PR TITLE
fix(semanticweb): SW-5b-Python SPARQL cells — real data (3/4) + Wikidata retry helper (#6561)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
@@ -136,12 +136,31 @@
     "try:\n",
     "    from SPARQLWrapper import SPARQLWrapper, JSON, XML\n",
     "    import json\n",
+    "    import time\n",
+    "    from urllib.error import HTTPError\n",
     "\n",
     "    SPARQLWRAPPER_AVAILABLE = True\n",
     "    print(\"SPARQLWrapper importe.\")\n",
     "except ImportError:\n",
     "    SPARQLWRAPPER_AVAILABLE = False\n",
-    "    print(\"SPARQLWrapper non disponible. Installez avec : pip install SPARQLWrapper\")"
+    "    print(\"SPARQLWrapper non disponible. Installez avec : pip install SPARQLWrapper\")\n",
+    "\n",
+    "\n",
+    "def sparql_query_with_retry(sparql, retries=3, delay=60):\n",
+    "    \"\"\"Execute une requete SPARQL avec reessai sur HTTP 429 (limite de debit Wikidata).\n",
+    "\n",
+    "    Wikidata limite les clients anonymes/educatifs a ~1 requete / minute ; sur un\n",
+    "    429 on attend `delay` secondes puis on reessaie, jusqu'a `retries` fois.\n",
+    "    \"\"\"\n",
+    "    for attempt in range(retries + 1):\n",
+    "        try:\n",
+    "            return sparql.query().convert()\n",
+    "        except HTTPError as e:\n",
+    "            if e.code == 429 and attempt < retries:\n",
+    "                print(f\"  (limite de debit 429, nouvel essai dans {delay}s...)\")\n",
+    "                time.sleep(delay)\n",
+    "                continue\n",
+    "            raise\n"
    ]
   },
   {
@@ -400,9 +419,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur lors de la requete Wikidata : HTTPError: HTTP Error 429: Aggressively rate-limiting to 1 req / min - this rule was created during active wdqs outage (797a132)\n",
-      "L'endpoint Wikidata est peut-etre temporairement indisponible.\n",
-      "Cela n'empeche pas de continuer le notebook.\n"
+      "=== Langages de programmation recents (Wikidata) ===\n",
+      "Langage                      Annee de creation\n",
+      "---------------------------------------------\n",
+      "DJPROCODE                                 2026\n",
+      "Varphi Language                           2025\n",
+      "Fremio                                    2025\n",
+      "Pkl                                       2024\n",
+      "Jakt                                      2022\n",
+      "Delegua                                   2022\n",
+      "Mavka                                     2022\n",
+      "Carbon                                    2020\n",
+      "BQN                                       2020\n",
+      "V                                         2019\n"
      ]
     }
    ],
@@ -428,7 +457,8 @@
     "\"\"\")\n",
     "\n",
     "    try:\n",
-    "        results_wd = sparql_wd.query().convert()\n",
+    "        # sparql_query_with_retry : tolere la limite de debit 429 de Wikidata\n",
+    "        results_wd = sparql_query_with_retry(sparql_wd)\n",
     "        bindings_wd = results_wd[\"results\"][\"bindings\"]\n",
     "\n",
     "        print(f\"=== Langages de programmation recents (Wikidata) ===\")\n",
@@ -444,7 +474,7 @@
     "        print(\"L'endpoint Wikidata est peut-etre temporairement indisponible.\")\n",
     "        print(\"Cela n'empeche pas de continuer le notebook.\")\n",
     "else:\n",
-    "    print(\"SPARQLWrapper non disponible : requete Wikidata ignoree.\")"
+    "    print(\"SPARQLWrapper non disponible : requete Wikidata ignoree.\")\n"
    ]
   },
   {
@@ -607,36 +637,39 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur : EndPointInternalError: The endpoint returned the HTTP status code 500. \n",
+      "=== Villes francaises (requete DBpedia directe + VALUES) ===\n",
+      "  Paris : 2,048,472 habitants\n",
       "\n",
-      "Response:\n",
-      "b'Virtuoso 42000 Error SQ070:SECURITY: Must have SELECT privileges on view DB.DBA.SPARQL_SINV_2 for group ID 110 (SPARQL), user ID 110 (SPARQL)\\n\\nSPARQL query:\\n#output-format:application/sparql-results+json\\n\\nPREFIX dbo: <http://dbpedia.org/ontology/>\\nPREFIX dbr: <http://dbpedia.org/resource/>\\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\\n\\nSELECT ?city ?name ?population\\nWHERE {\\n    VALUES ?city { dbr:Paris dbr:Lyon dbr:Marseille }\\n    SERVICE <http://dbpedia.org/sparql> {\\n        ?city rdfs:label ?name .\\n        ?city dbo:populationTotal ?population .\\n        FILTER (lang(?name) = \"fr\")\\n    }\\n}\\nORDER BY DESC(?population)\\n\\n'\n"
+      "Graphe local fusionne : 1 triplet(s) de population.\n"
      ]
     }
    ],
    "source": [
     "if SPARQLWRAPPER_AVAILABLE:\n",
-    "    # Federated query: combine local graph with remote endpoint\n",
+    "    # Combiner un graphe local avec un endpoint distant.\n",
+    "    # NOTE : le endpoint Virtuoso de DBpedia REJETTE les requetes federees\n",
+    "    # `SERVICE <dbpedia>` (HTTP 500, SQ070:SECURITY sur SPARQL_SINV_2). Le\n",
+    "    # pattern portable = interroger l'endpoint distant DIRECTEMENT via une\n",
+    "    # clause VALUES listant les ressources, puis fusionner le resultat dans\n",
+    "    # le graphe local. (Verdict RECOVERABLE-LOCAL, cf #3801.)\n",
     "    try:\n",
-    "        from rdflib import Graph, Namespace\n",
+    "        from rdflib import Graph, Namespace, URIRef, Literal\n",
     "        RDFLIB_AVAILABLE = True\n",
     "    except ImportError:\n",
     "        RDFLIB_AVAILABLE = False\n",
     "\n",
     "    if RDFLIB_AVAILABLE:\n",
-    "        # Create a small local graph with French city URIs\n",
+    "        # Graphe local : on declare les URIs des villes qui nous interessent.\n",
     "        g_local = Graph()\n",
     "        DBR = Namespace(\"http://dbpedia.org/resource/\")\n",
+    "        DBO = Namespace(\"http://dbpedia.org/ontology/\")\n",
     "        g_local.bind(\"dbr\", DBR)\n",
+    "        g_local.bind(\"dbo\", DBO)\n",
     "\n",
-    "        # Add some city URIs (we don't have data about them locally)\n",
-    "        cities = [DBR.Paris, DBR.Lyon, DBR.Marseille]\n",
-    "        for city in cities:\n",
-    "            # We'll query DBpedia for their populations\n",
-    "            pass\n",
-    "\n",
-    "        # Federated query: get population from DBpedia for our local cities\n",
-    "        query_federated = \"\"\"\n",
+    "        # Requete DIRECTE (non federee) sur DBpedia : VALUES epingle les\n",
+    "        # villes, aucun SERVICE => Virtuoso accepte. (DBpedia ne fournit\n",
+    "        # dbo:populationTotal que pour Paris parmi nos 3 villes.)\n",
+    "        query_direct = \"\"\"\n",
     "PREFIX dbo: <http://dbpedia.org/ontology/>\n",
     "PREFIX dbr: <http://dbpedia.org/resource/>\n",
     "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
@@ -644,32 +677,34 @@
     "SELECT ?city ?name ?population\n",
     "WHERE {\n",
     "    VALUES ?city { dbr:Paris dbr:Lyon dbr:Marseille }\n",
-    "    SERVICE <http://dbpedia.org/sparql> {\n",
-    "        ?city rdfs:label ?name .\n",
-    "        ?city dbo:populationTotal ?population .\n",
-    "        FILTER (lang(?name) = \"fr\")\n",
-    "    }\n",
+    "    ?city rdfs:label ?name .\n",
+    "    ?city dbo:populationTotal ?population .\n",
+    "    FILTER (lang(?name) = \"fr\")\n",
     "}\n",
     "ORDER BY DESC(?population)\n",
     "\"\"\"\n",
     "\n",
-    "        sparql_fed = SPARQLWrapper(\"http://dbpedia.org/sparql\")\n",
-    "        sparql_fed.setReturnFormat(JSON)\n",
-    "        sparql_fed.setQuery(query_federated)\n",
+    "        sparql_direct = SPARQLWrapper(\"http://dbpedia.org/sparql\")\n",
+    "        sparql_direct.setReturnFormat(JSON)\n",
+    "        sparql_direct.setQuery(query_direct)\n",
     "\n",
     "        try:\n",
-    "            results_fed = sparql_fed.query().convert()\n",
-    "            print(\"=== Villes francaises (requete federée) ===\")\n",
-    "            for r in results_fed[\"results\"][\"bindings\"]:\n",
+    "            results_direct = sparql_direct.query().convert()\n",
+    "            print(\"=== Villes francaises (requete DBpedia directe + VALUES) ===\")\n",
+    "            for r in results_direct[\"results\"][\"bindings\"]:\n",
     "                name = r[\"name\"][\"value\"]\n",
     "                pop = int(r[\"population\"][\"value\"])\n",
     "                print(f\"  {name} : {pop:,d} habitants\")\n",
+    "                # Fusion : on ajoute le fait distant au graphe local.\n",
+    "                city = URIRef(r[\"city\"][\"value\"])\n",
+    "                g_local.add((city, DBO.populationTotal, Literal(pop)))\n",
+    "            print(f\"\\nGraphe local fusionne : {len(g_local)} triplet(s) de population.\")\n",
     "        except Exception as e:\n",
     "            print(f\"Erreur : {e}\")\n",
     "    else:\n",
-    "        print(\"rdflib non disponible : requete federée ignoree.\")\n",
+    "        print(\"rdflib non disponible : requete ignoree.\")\n",
     "else:\n",
-    "    print(\"SPARQLWrapper non disponible : requete federée ignoree.\")"
+    "    print(\"SPARQLWrapper non disponible : requete ignoree.\")\n"
    ]
   },
   {
@@ -754,7 +789,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur : 'Document' object is not subscriptable\n"
+      "\n",
+      "Format XML (200 premiers caracteres) : <?xml version=\"1.0\" ?><sparql xmlns=\"http://www.w3.org/2005/sparql-results#\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.w3.org/2001/sw/DataAccess/rf1/result2....\n"
      ]
     }
    ],
@@ -783,11 +819,14 @@
     "        print(f\"Format JSON : {result_json}\")\n",
     "\n",
     "        result_xml = sparql_xml.query().convert()\n",
-    "        print(f\"\\nFormat XML (first 200 chars) : {result_xml[:200]}...\")\n",
+    "        # result_xml est un Document DOM (xml.dom.minidom), pas une chaine :\n",
+    "        # on le serialise avec .toxml() avant de le decouper.\n",
+    "        xml_str = result_xml.toxml()\n",
+    "        print(f\"\\nFormat XML (200 premiers caracteres) : {xml_str[:200]}...\")\n",
     "    except Exception as e:\n",
     "        print(f\"Erreur : {e}\")\n",
     "else:\n",
-    "    print(\"SPARQLWrapper non disponible : comparaison formats ignoree.\")"
+    "    print(\"SPARQLWrapper non disponible : comparaison ignoree.\")\n"
    ]
   },
   {
@@ -1165,7 +1204,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur : HTTP Error 429: Aggressively rate-limiting to 1 req / min - this rule was created during active wdqs outage (797a132)\n"
+      "  (limite de debit 429, nouvel essai dans 60s...)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (limite de debit 429, nouvel essai dans 60s...)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  (limite de debit 429, nouvel essai dans 60s...)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Erreur : HTTPError: HTTP Error 429: Aggressively rate-limiting to 1 req / min - this rule was created during active wdqs outage (797a132)\n",
+      "L'endpoint Wikidata est peut-etre temporairement indisponible.\n"
      ]
     }
    ],
@@ -1196,15 +1257,22 @@
     "\"\"\")\n",
     "\n",
     "    try:\n",
-    "        time.sleep(60)\n",
-    "        results_uni = sparql_uni.query().convert()\n",
-    "        print(\"=== Top 10 universites francaises ===\")\n",
-    "        for r in results_uni[\"results\"][\"bindings\"]:\n",
-    "            print(f\"  {r['universityLabel']['value']} : {r['students']['value']} etudiants\")\n",
+    "        # sparql_query_with_retry : tolere la limite de debit 429 de Wikidata\n",
+    "        results_uni = sparql_query_with_retry(sparql_uni)\n",
+    "        bindings_uni = results_uni[\"results\"][\"bindings\"]\n",
+    "\n",
+    "        print(f\"=== Top 10 universites francaises (Wikidata) ===\")\n",
+    "        print(f\"{'Universite':<40s} {'Etudiants':>12s}\")\n",
+    "        print(\"-\" * 52)\n",
+    "        for r in bindings_uni:\n",
+    "            name = r[\"universityLabel\"][\"value\"]\n",
+    "            students = int(r[\"students\"][\"value\"])\n",
+    "            print(f\"{name:<40s} {students:>12,d}\")\n",
     "    except Exception as e:\n",
-    "        print(f\"Erreur : {e}\")\n",
+    "        print(f\"Erreur : {type(e).__name__}: {e}\")\n",
+    "        print(\"L'endpoint Wikidata est peut-etre temporairement indisponible.\")\n",
     "else:\n",
-    "    print(\"SPARQLWrapper non disponible : exercice 1 ignore.\")"
+    "    print(\"SPARQLWrapper non disponible : exercice ignore.\")\n"
    ]
   },
   {


### PR DESCRIPTION
## What

Python twin of **#6561** (po-2025 partition; C# half = **#6568** by po-2023). Fixes 4 error-output cells in `SW-5b-Python-LinkedData.ipynb` with **3 distinct failure modes** (firsthand — NOT async like the C# twin; SPARQLWrapper is synchronous).

## Diagnosis + fixes (firsthand)

| Cell | Old output (error) | Root cause | Fix |
|------|--------------------|------------|-----|
| **11** | `HTTPError 429: Aggressively rate-limiting` (Wikidata) | no backoff on Wikidata's ~1 req/min anon limit | new `sparql_query_with_retry()` helper (catch `urllib HTTPError 429`, sleep 60s, retry ×3) |
| **16** | `HTTP 500 Virtuoso SQ070:SECURITY` (DBpedia) | DBpedia Virtuoso **rejects federated `SERVICE`** queries | redesign to **direct DBpedia query + `VALUES`** + local-fuse into rdflib Graph (SOTA-correct portable pattern) |
| **19** | `'Document' object is not subscriptable` | XML DOM `Document` sliced as string | `result_xml.toxml()[:200]` (serialize DOM first) |
| **29** | `HTTPError 429` (Wikidata) | same rate-limit as cell 11 | call the retry helper |

## Re-execution (papermill, python3, live endpoints)

- **cell[11]**: ✅ **REAL DATA** — 10 programming languages ≥2010 (DJPROCODE 2026, Varphi 2025, …). 0 error.
- **cell[16]**: ✅ **REAL DATA** — `Paris : 2,048,472 habitants` + `Graphe local fusionné : 1 triplet`. 0 error (was Virtuoso 500).
- **cell[19]**: ✅ **REAL DATA** — JSON `{'boolean': False}` + XML serialized via `.toxml()`. 0 error (was Document-not-subscriptable).
- **cell[29]**: ⚠️ retry helper applied (correct fix) but **Wikidata was in active WDGS degraded-outage mode** during exec — its own 429 message reads *"this rule was created during active wdqs outage (797a132)"*. Cell 11 (first Wikidata query) succeeded; cell 29 (2nd consecutive query) was hard-blocked for 5+ min even after 3×60s retries, and my IP entered a multi-minute cooldown. **Verdict RECOVERABLE**: cell 11 + an isolated standalone test both prove the universities query succeeds when Wikidata isn't rate-limiting; re-exec cell 29 when WDGS recovers — **source fix already in place, no further edit needed**.

## Verification

- Source guards: `def sparql_query_with_retry`, retry calls in 11/29, `query_direct` (16), `toxml()` (19) — all present.
- Outputs surgically injected (no papermill metadata churn); `1 file +113/-45`; comment/prose French; **no catalogue touched**.
- Uncontested: po-2023 #6568 touched only `SW-5-CSharp-LinkedData.ipynb` (C# twin) — no file overlap.

## SOTA verdicts (per `sota-not-workaround.md`)

- cell[16] DBpedia federated `SERVICE` → **RECOVERABLE-LOCAL** (real endpoint, query redesign avoids the rejected pattern).
- cell[11]/[29] Wikidata 429 → retry helper = correct; cell 29 blocked by transient **active WDGS outage** (Wikidata's own status message), not a code defect.

## Note for ai-01 / po-2023

Keeping `See #6561` (not `Closes`) — cell 29 will need one re-exec after Wikidata WDGS clears to swap its transient-429 output for real university data (no source change). When that lands, the issue can close.

---
_Lane: myia-po-2025 / CoursIA (worker cycle c.459). Atomic single-subject PR; catalogue byte-identical to `origin/main`. Based on origin/main 2addfbf86 (git fetch env-broken this worktree — SW-5b is independent of the recent .NET merges #6563/#6567/#6568, near-zero conflict risk)._