### PR TITLE
fix(gametheory,#6585): build root _en aggregators in game_theory_lean (orphan glob coverage)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean
@@ -68,7 +68,7 @@ require mathlib from git
 -- cold builds remain unaffected. See #6140.
 @[default_target]
 lean_lib StableMarriage where
-  globs := #[`StableMarriage.*]
+  globs := #[`StableMarriage.*, `StableMarriage_en]
   moreLeanArgs := #["--tstack=8192"]
 
 @[default_target]
@@ -84,4 +84,4 @@ lean_lib RepeatedGames where
   -- Repeated Games Library for Lean 4
   -- Includes: stage game (Prisoner's Dilemma), discounting, grim trigger
   -- Theorem phare: grim_trigger_sustains_iff (one-shot deviation principle)
-  globs := #[`RepeatedGames.*]
+  globs := #[`RepeatedGames.*, `RepeatedGames_en]


### PR DESCRIPTION
## Summary

Closes the **root `_en` aggregator orphan** in `game_theory_lean` (EPIC #4980 i18n build coverage, pilot extended from #6585/#6594 decision_theory_lean).

Two English-mirror root aggregators — `StableMarriage_en.lean` (added #6468) and `RepeatedGames_en.lean` (added #6491) — are pure landing-doc modules (imports + module docstring, **0 declarations**) that were **not type-checked by `lake build` / CI**. The lakefile glob `<Lib>.*` covers the submodule subtree but **not** the root sibling `<Lib>_en` (package-root module). Result: false-green CI — a broken import/syntax error in those EN root files would go undetected.

## Fix

Add the bare-name root `_en` to the 2 libs that have a root `_en` file (precedent: `conway_cgt_lean`, #6594 decision_theory_lean):

```lean
@[default_target]
lean_lib StableMarriage where
  globs := #[`StableMarriage.*, `StableMarriage_en]   -- was #[`StableMarriage.*]
  moreLeanArgs := #["--tstack=8192"]

@[default_target]
lean_lib RepeatedGames where
  globs := #[`RepeatedGames.*, `RepeatedGames_en]      -- was #[`RepeatedGames.*]
```

`CooperativeGames_en.lean` / `SocialChoice_en.lean` root files do **not** exist (those libs use nested `_en` only) → no orphan for them, no change.

Zero touch to any `.lean` proof/declaration file. Only `lakefile.lean` changes (+2/−2).

## Verification (local, lean-merge-discipline HARD)

- **`lake build StableMarriage_en RepeatedGames_en` SUCCESS** — both oleans now built (were MISSING pre-fix, confirmed firsthand). game_theory_lean cache warm (8113 mathlib oleans, `lake exe cache get` works — not WDAC-blocked).
- **sorry before/after**: the 2 root `_en` files are doc-only (0 declarations) → 0 proof-sorries before and after. FR roots also 0.
- **Note on `RepeatedGames/Folk_en.lean:106` `sorry`**: this is the **pre-existing #4880 Folk-theorem stretch sorry** (tolerated, documented in FORMAL_STATUS). It now surfaces in the CI build log as a warning — this is *exactly the coverage gap #6585 closes*: previously RepeatedGames_en (and its transitive deps via the aggregator) were not in the build graph, so the sorry-gate CI was blind to the EN mirror. #6585 does not introduce or remove any sorry; it adds build coverage.
- **CRLF**: 0 (`*.lean text eol=lf`).

## Collision check

- My PR #6587 (#4365 legacy-rm) touches `game_theory_lean/README.md` but **NOT `lakefile.lean`** → no same-file collision. Verified firsthand.
- The root `_en` files exist on `main` (merged via #6468/#6491 this morning); this PR only changes how they're built.

## Scope

Single-file change (lakefile.lean, +2/−2, 2 glob entries). No existing theorem modified. See #6585 (orphan glob coverage, 6-lake finding), See #4980 (i18n convention). 2 of the 6 affected lakes now fixed (#6594 decision_theory + this). Remaining: sudoku_lean (cache cold), minimax_lean, learning_theory_lean.