### PR TITLE
fix(minimax,#6585): add root Minimax_en to lakefile globs (orphan build coverage)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/lakefile.lean
@@ -39,4 +39,4 @@ require mathlib from git
 
 @[default_target]
 lean_lib «Minimax» where
-  globs := #[.submodules `Minimax]
+  globs := #[.submodules `Minimax, `Minimax_en]


### PR DESCRIPTION
## Summary

Closes the **root `_en` aggregator orphan** in `minimax_lean` — EPIC #4980 i18n build coverage (#6585, 4th lake of the 6-lake rollout, per ai-01 greenlight msg-ape3lw "1-PR-per-lake").

`Minimax_en.lean` is a pure landing-doc module (imports + module docstring, **0 declarations**) that was **not type-checked by `lake build` / CI**. The lakefile glob `#[.submodules `Minimax]` enumerates children of the `Minimax/` directory but **not** the package-root sibling `Minimax_en.lean`. Result: false-green CI — a broken import/syntax in the EN root mirror would go undetected.

## Fix

Add the bare-name root `_en` to the lib's globs (precedent: `conway_cgt_lean`, #6594 decision_theory, #6597 game_theory_lean):

```lean
@[default_target]
lean_lib «Minimax» where
  globs := #[.submodules `Minimax, `Minimax_en]   -- was #[.submodules `Minimax]
```

Zero touch to any `.lean` proof/declaration file. Only `lakefile.lean` changes (+1/−1).

## Verification

- **`Minimax_en.lean` is doc-only** (0 declarations, 0 real-sorries) — it mirrors `Minimax.lean` (a default target that builds green) and re-imports the 3 nested EN siblings (`Minimax.ZeroSum_en`, `Minimax.Concavity_en`, `Minimax.SionApplication_en`), all confirmed present.
- **Local cache cold / WDAC** (per ai-01 greenlight msg-ape3lw): ai-01 takes the `lake build` gate with warm cache — "push the additive glob, my build = gate, I bounce if a `_en` fails to compile. WDAC #4551 PAS un blocker." The change is a 1-line glob addition; `Minimax_en` is doc-only so it compiles trivially once in the build graph.
- **CRLF**: 0 (`*.lean text eol=lf`).

## Scope

Single-file change (lakefile.lean, +1/−1). No existing theorem modified. See #6585 (orphan glob coverage, 6-lake finding), See #4980 (i18n convention).

## Rollout status

#6585 lakes: decision_theory (#6594 MERGED) + game_theory_lean (#6597 MERGED) + **minimax_lean (this PR)** = 3/6. Remaining: sudoku_lean, learning_theory_lean (separate PRs, anti-tunneling R6 per ai-01).