### PR TITLE
fix(infer,#3801,#6599): Infer-19 ASCII survival chart -> Plotly (Prong-A, zero-restore)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
@@ -59,10 +59,10 @@
    "id": "6cafeb7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:44.296803Z",
-     "iopub.status.busy": "2026-07-01T23:33:44.291398Z",
-     "iopub.status.idle": "2026-07-01T23:33:47.786831Z",
-     "shell.execute_reply": "2026-07-01T23:33:47.781717Z"
+     "iopub.execute_input": "2026-07-14T22:38:58.061132Z",
+     "iopub.status.busy": "2026-07-14T22:38:58.047274Z",
+     "iopub.status.idle": "2026-07-14T22:39:05.173890Z",
+     "shell.execute_reply": "2026-07-14T22:39:05.165535Z"
     }
    },
    "outputs": [
@@ -75,7 +75,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
+       "async function probeAddresses(probingAddresses) {\r\n",
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -85,10 +85,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
        "\r\n",
-       
+       "            let rootUrl = probingAddresses[i];\r\n",
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -103,7 +103,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
+       "                    body: probingAddresses[i]\r\n",
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -115,13 +115,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%12:2048/\",\"http://172.26.48.1:2048/\",\"http://fe80::4242:e8b9:6bbf:ef2c%50:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:4c49:ea51:a5f7:8b03:2048/\",\"http://2a01:e0a:9d4:f320:6d91:40d7:528:51b3:2048/\",\"http://2a01:e0a:9d4:f320:7042:4896:3da8:dc2a:2048/\",\"http://2a01:e0a:9d4:f320:c942:e5c4:12e2:6ae2:2048/\",\"http://2a01:e0a:9d4:f320:cde3:e6ed:6b4:42df:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '23188.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '1430364.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -165,13 +165,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
+       "        loadDotnetInteractiveApi();\r\n",
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
+       "    loadDotnetInteractiveApi();\r\n",
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -213,10 +213,10 @@
    "id": "444c7d04",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:47.789309Z",
-     "iopub.status.busy": "2026-07-01T23:33:47.789085Z",
-     "iopub.status.idle": "2026-07-01T23:33:48.713426Z",
-     "shell.execute_reply": "2026-07-01T23:33:48.713069Z"
+     "iopub.execute_input": "2026-07-14T22:39:05.176930Z",
+     "iopub.status.busy": "2026-07-14T22:39:05.176551Z",
+     "iopub.status.idle": "2026-07-14T22:39:06.667417Z",
+     "shell.execute_reply": "2026-07-14T22:39:06.667013Z"
     }
    },
    "outputs": [
@@ -267,10 +267,10 @@
    "id": "1dc34615",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:48.715367Z",
-     "iopub.status.busy": "2026-07-01T23:33:48.715055Z",
-     "iopub.status.idle": "2026-07-01T23:33:49.010736Z",
-     "shell.execute_reply": "2026-07-01T23:33:49.010178Z"
+     "iopub.execute_input": "2026-07-14T22:39:06.670018Z",
+     "iopub.status.busy": "2026-07-14T22:39:06.669573Z",
+     "iopub.status.idle": "2026-07-14T22:39:07.202505Z",
+     "shell.execute_reply": "2026-07-14T22:39:07.201863Z"
     }
    },
    "outputs": [
@@ -329,10 +329,10 @@
    "id": "1722c159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:49.012487Z",
-     "iopub.status.busy": "2026-07-01T23:33:49.012249Z",
-     "iopub.status.idle": "2026-07-01T23:33:51.082896Z",
-     "shell.execute_reply": "2026-07-01T23:33:51.082516Z"
+     "iopub.execute_input": "2026-07-14T22:39:07.205706Z",
+     "iopub.status.busy": "2026-07-14T22:39:07.205060Z",
+     "iopub.status.idle": "2026-07-14T22:39:10.337747Z",
+     "shell.execute_reply": "2026-07-14T22:39:10.337346Z"
     }
    },
    "outputs": [
@@ -455,10 +455,10 @@
    "id": "3358bca7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:51.084307Z",
-     "iopub.status.busy": "2026-07-01T23:33:51.084124Z",
-     "iopub.status.idle": "2026-07-01T23:33:51.274851Z",
-     "shell.execute_reply": "2026-07-01T23:33:51.271821Z"
+     "iopub.execute_input": "2026-07-14T22:39:10.340197Z",
+     "iopub.status.busy": "2026-07-14T22:39:10.339854Z",
+     "iopub.status.idle": "2026-07-14T22:39:10.839617Z",
+     "shell.execute_reply": "2026-07-14T22:39:10.838752Z"
     }
    },
    "outputs": [
@@ -526,392 +526,54 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "S(t) bayesienne (modele exponentiel) :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     0h |########################################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    60h |######################################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   120h |####################################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   180h |###################################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   240h |#################################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   300h |################################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   360h |##############################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   420h |#############################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   480h |###########################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   540h |##########################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   600h |#########################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   660h |########################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   720h |#######################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   780h |######################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   840h |#####################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   900h |####################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   960h |###################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1020h |##################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1080h |#################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1140h |################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1200h |################\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1260h |###############\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1320h |##############\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1380h |##############\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1440h |#############\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1500h |############\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1560h |############\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1620h |###########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1680h |###########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1740h |##########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1800h |##########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1860h |#########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1920h |#########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1980h |#########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2040h |########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2100h |########\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2160h |#######\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2220h |#######\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2280h |#######\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2340h |######\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2400h |######\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2460h |######\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2520h |######\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2580h |#####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2640h |#####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2700h |#####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2760h |#####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2820h |####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2880h |####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2940h |####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  3000h |####\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plt17fab564fdc943f098cb16a3590a06ab\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt17fab564fdc943f098cb16a3590a06ab',[{\"name\":\"Bayesienne (modele exponentiel)\",\"x\":[0,37.5,75,112.5,150,187.5,225,262.5,300,337.5,375,412.5,450,487.5,525,562.5,600,637.5,675,712.5,750,787.5,825,862.5,900,937.5,975,1012.5,1050,1087.5,1125,1162.5,1200,1237.5,1275,1312.5,1350,1387.5,1425,1462.5,1500,1537.5,1575,1612.5,1650,1687.5,1725,1762.5,1800,1837.5,1875,1912.5,1950,1987.5,2025,2062.5,2100,2137.5,2175,2212.5,2250,2287.5,2325,2362.5,2400,2437.5,2475,2512.5,2550,2587.5,2625,2662.5,2700,2737.5,2775,2812.5,2850,2887.5,2925,2962.5,3000],\"y\":[1,0.9707499014366825,0.9423692055293654,0.9148316601651196,0.8881118183208658,0.8621850129935085,0.8370273329225478,0.8126155990797352,0.7889273419011632,0.7659407792380303,0.7436347950030093,0.7219889184899899,0.7009833043456324,0.6805987131718751,0.6608164927392217,0.6416185597912983,0.622987382421802,0.6049059630055352,0.5873578216658814,0.5703269802615968,0.553797946876345,0.5377557007949973,0.5221856779511592,0.507073756830923,0.4924062448183519,0.47816986496865266,0.4643517431953826,0.4509393958586274,0.43792071774133895,0.4252839704015386,0.41301777088849556,0.4011110808112635,0.38955319574848063,0.3783337349885781,0.367442631589962,0.3568701227510018,0.346606740480077,0.33664330255614483,0.3269709037706838,0.3175809074421042,0.3084649371940359,0.29961486898913486,0.29102282341040664,0.28268115818217704,0.27458246092320104,0.26671954212459215,0.259085428345467,0.2516733556194912,0.24447676306567015,0.23748928669695826,0.23070475342050234,0.22411717522345134,0.21772074353855467,0.21150982378387928,0.20547895007118558,0.19962282007768775,0.1939362900760701,0.18841437011780418,0.1830522193649651,0.17784514156590972,0.17278858067030048,0.16787811657914176,0.16310946102558888,0.1584784535824533,0.15398105779246157,0.1496133574174116,0.1453715528025433,0.1412519573525194,0.13725099411553962,0.1333651924722244,0.12959118492600613,0.12592570399186642,0.12236557918036264,0.11890773407398472,0.115549183492972,0.11228703074780767,0.10911846497570565,0.106040758558482,0.10305126461928871,0.1001474145957624,0.09732671588721924],\"type\":\"scatter\",\"mode\":\"lines\"},{\"name\":\"Empirique (donnees)\",\"x\":[0,37.5,75,112.5,150,187.5,225,262.5,300,337.5,375,412.5,450,487.5,525,562.5,600,637.5,675,712.5,750,787.5,825,862.5,900,937.5,975,1012.5,1050,1087.5,1125,1162.5,1200,1237.5,1275,1312.5,1350,1387.5,1425,1462.5,1500,1537.5,1575,1612.5,1650,1687.5,1725,1762.5,1800,1837.5,1875,1912.5,1950,1987.5,2025,2062.5,2100,2137.5,2175,2212.5,2250,2287.5,2325,2362.5,2400,2437.5,2475,2512.5,2550,2587.5,2625,2662.5,2700,2737.5,2775,2812.5,2850,2887.5,2925,2962.5,3000],\"y\":[1,1,1,0.9833333333333333,0.9833333333333333,0.9833333333333333,0.9166666666666666,0.8833333333333333,0.85,0.8333333333333334,0.7666666666666667,0.75,0.7333333333333333,0.7,0.6833333333333333,0.65,0.65,0.6166666666666667,0.5333333333333333,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5,0.48333333333333334,0.45,0.45,0.45,0.45,0.45,0.43333333333333335,0.4166666666666667,0.4166666666666667,0.4,0.4,0.36666666666666664,0.3333333333333333,0.3333333333333333,0.31666666666666665,0.31666666666666665,0.31666666666666665,0.31666666666666665,0.31666666666666665,0.31666666666666665,0.3,0.3,0.2833333333333333,0.26666666666666666,0.26666666666666666,0.26666666666666666,0.21666666666666667,0.2,0.18333333333333332,0.18333333333333332,0.18333333333333332,0.16666666666666666,0.16666666666666666,0.15,0.15,0.15,0.15,0.15,0.15,0.15,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.1],\"type\":\"scatter\",\"mode\":\"lines\"}],{\"title\":{\"text\":\"Fonction de survie S(t) : bayesienne vs empirique\"},\"xaxis\":{\"title\":{\"text\":\"t (heures)\"}},\"yaxis\":{\"title\":{\"text\":\"S(t)\"},\"range\":[0,1.05]}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
+    "// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.\n",
+    "// On evite `#r \"nuget:\"` sur une charting-lib : XPlot.Plotly.Interactive / Plotly.NET\n",
+    "// pinent une vieille beta de Microsoft.DotNet.Interactive et font timeout le restore\n",
+    "// (cluster-wide). Le formatter ci-dessous emet du HTML Plotly brut, sans dependence.\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
     "// Survie predictive (forme fermee) + comparaison empirique.\n",
     "double A = lambdaPost.Shape, B = lambdaPost.Rate;\n",
     "double Sbayes(double t) => Math.Pow(B / (B + t), A);\n",
-    "\n",
-    "// Courbe empirique : fraction de durees > t.\n",
     "double Semp(double t, double[] data) => data.Count(d => d > t) / (double)data.Length;\n",
     "\n",
+    "// Tableau : S(t) bayesienne vs empirique a des horizons choisis.\n",
     "Console.WriteLine(\"=== Fonction de survie S(t) : bayesienne vs empirique ===\");\n",
     "Console.WriteLine($\"{\"t (h)\",8}  {\"S_bayes\",8}  {\"S_empir\",8}\");\n",
     "foreach (var t in new[] { 0.0, 250, 500, 1000, 1500, 2000, 3000 })\n",
     "    Console.WriteLine($\"{t,8:F0}  {Sbayes(t),8:F3}  {Semp(t, lifetimesExp),8:F3}\");\n",
     "\n",
-    "// Trace ASCII leger de S(t) bayesienne.\n",
-    "Console.WriteLine(\"\\nS(t) bayesienne (modele exponentiel) :\");\n",
-    "const int W = 50;\n",
-    "foreach (var t in Enumerable.Range(0, W + 1).Select(j => j * 3000.0 / W))\n",
-    "{\n",
-    "    int bar = (int)Math.Round(Sbayes(t) * 40);\n",
-    "    Console.WriteLine($\"{t,6:F0}h |{new string('#', bar)}\");\n",
-    "}"
+    "// Courbe continue S(t) : trace Plotly comparant le modele bayesien aux donnees empiriques.\n",
+    "int NP = 80;\n",
+    "var tGrid = Enumerable.Range(0, NP + 1).Select(j => j * 3000.0 / NP).ToArray();\n",
+    "string BuildTrace(string name, double[] ys) => System.Text.Json.JsonSerializer.Serialize(\n",
+    "    new Dictionary<string, object> { [\"name\"] = name, [\"x\"] = tGrid, [\"y\"] = ys,\n",
+    "                                     [\"type\"] = \"scatter\", [\"mode\"] = \"lines\" });\n",
+    "var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Fonction de survie S(t) : bayesienne vs empirique\\\"},\" +\n",
+    "             \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"t (heures)\\\"}},\" +\n",
+    "             \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"S(t)\\\"},\\\"range\\\":[0,1.05]}}\";\n",
+    "var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "             \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "             \"<script>Plotly.newPlot('\" + divId + \"',[\" +\n",
+    "             BuildTrace(\"Bayesienne (modele exponentiel)\", tGrid.Select(Sbayes).ToArray()) + \",\" +\n",
+    "             BuildTrace(\"Empirique (donnees)\", tGrid.Select(t => Semp(t, lifetimesExp)).ToArray()) +\n",
+    "             \"],\" + layout + \")</script>\";\n",
+    "display(new PlotlyHtml(markup));\n"
    ]
   },
   {
@@ -963,10 +625,10 @@
    "id": "d77b4a83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:51.276786Z",
-     "iopub.status.busy": "2026-07-01T23:33:51.276418Z",
-     "iopub.status.idle": "2026-07-01T23:33:51.706128Z",
-     "shell.execute_reply": "2026-07-01T23:33:51.705973Z"
+     "iopub.execute_input": "2026-07-14T22:39:10.841593Z",
+     "iopub.status.busy": "2026-07-14T22:39:10.841279Z",
+     "iopub.status.idle": "2026-07-14T22:39:11.488001Z",
+     "shell.execute_reply": "2026-07-14T22:39:11.487643Z"
     }
    },
    "outputs": [
@@ -1079,10 +741,10 @@
    "id": "71468adb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:51.707511Z",
-     "iopub.status.busy": "2026-07-01T23:33:51.707309Z",
-     "iopub.status.idle": "2026-07-01T23:33:55.095503Z",
-     "shell.execute_reply": "2026-07-01T23:33:55.095332Z"
+     "iopub.execute_input": "2026-07-14T22:39:11.490223Z",
+     "iopub.status.busy": "2026-07-14T22:39:11.489898Z",
+     "iopub.status.idle": "2026-07-14T22:39:19.431353Z",
+     "shell.execute_reply": "2026-07-14T22:39:19.430705Z"
     }
    },
    "outputs": [
@@ -1458,10 +1120,10 @@
    "id": "668036ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:55.097025Z",
-     "iopub.status.busy": "2026-07-01T23:33:55.096829Z",
-     "iopub.status.idle": "2026-07-01T23:33:55.131640Z",
-     "shell.execute_reply": "2026-07-01T23:33:55.131464Z"
+     "iopub.execute_input": "2026-07-14T22:39:19.434553Z",
+     "iopub.status.busy": "2026-07-14T22:39:19.434073Z",
+     "iopub.status.idle": "2026-07-14T22:39:19.538980Z",
+     "shell.execute_reply": "2026-07-14T22:39:19.538402Z"
     }
    },
    "outputs": [
@@ -1502,10 +1164,10 @@
    "id": "e2014207",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:55.133271Z",
-     "iopub.status.busy": "2026-07-01T23:33:55.133052Z",
-     "iopub.status.idle": "2026-07-01T23:33:55.162533Z",
-     "shell.execute_reply": "2026-07-01T23:33:55.161998Z"
+     "iopub.execute_input": "2026-07-14T22:39:19.541869Z",
+     "iopub.status.busy": "2026-07-14T22:39:19.541438Z",
+     "iopub.status.idle": "2026-07-14T22:39:19.610183Z",
+     "shell.execute_reply": "2026-07-14T22:39:19.609583Z"
     }
    },
    "outputs": [
@@ -1546,10 +1208,10 @@
    "id": "8f861db9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T23:33:55.164332Z",
-     "iopub.status.busy": "2026-07-01T23:33:55.164079Z",
-     "iopub.status.idle": "2026-07-01T23:33:55.218035Z",
-     "shell.execute_reply": "2026-07-01T23:33:55.217849Z"
+     "iopub.execute_input": "2026-07-14T22:39:19.613043Z",
+     "iopub.status.busy": "2026-07-14T22:39:19.612525Z",
+     "iopub.status.idle": "2026-07-14T22:39:19.793274Z",
+     "shell.execute_reply": "2026-07-14T22:39:19.792684Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

Pilot application of the **zero-restore Plotly technique** (C548-L2, documented on #6599) to the cleanest Prong-A case: **Infer-19-Survival-Analysis.ipynb cell[11]** — the ASCII-art survival curve `S(t)` is replaced by a real **Plotly.js chart** plotting BOTH the Bayesian model and the empirical data.

This is the first .NET notebook fixed via the technique that unblocks #6596 (Sudoku-18) + #6599 (Infer-17/18/19) cluster-wide WITHOUT needing the multi-hour kernel/stack repair.

## What changed (scope: 1 cell, 1 file)

`Infer-19-Survival-Analysis.ipynb` **cell[11]** only:
- **Kept**: the tabular output (`t / S_bayes / S_empir` at horizons 0/250/500/1000/1500/2000/3000) — legitimate tabular data.
- **Removed**: the ASCII bar chart block (`// Trace ASCII leger de S(t) bayesienne` — 50+ `Console.WriteLine` of `#` bars).
- **Added**: a real Plotly.js line chart via the kernel's built-in HTML formatter (`Formatter.Register(typeof(PlotlyHtml), delegate, "text/html")`), plotting **two scatter traces**: `Bayesienne (modele exponentiel)` + `Empirique (donnees)`.

Net diff: +85/−423 (the −423 is the committed ASCII bar output lines being replaced by one compact `display_data`).

## Why this is SOTA-OK (Prong A)

The Infer.NET engine is **genuinely exercised**, not papered over:
- `Sbayes(t) = (B/(B+t))^A` is the closed-form posterior survival function, where `A=lambdaPost.Shape`, `B=lambdaPost.Rate` come from the **real** `InferenceEngine { Algorithm = ExpectationPropagation() }` + `engine.Infer<Gamma>(lambda)` in cell[8].
- `Semp(t)` is the empirical survival fraction from `lifetimesExp`.
- The chart compares model vs data — strictly **richer** than the ASCII bar chart (1 series) it replaces.

No `#r "nuget:"` on a charting lib, so no Interactive-beta-restore hang (the cluster-wide blocker documented in C547-L1, superseded by C548-L2). The only `#r "nuget:"` in the notebook is `Microsoft.ML.Probabilistic` (cell[2]), which restores fine (plain package, no Interactive-beta pin).

## Execution proof (H.1 / C.2)

Re-executed end-to-end on po-2024 via `jupyter nbconvert --execute --kernel .net-csharp --timeout 180`:
- **EXIT=0**, no `CellExecutionError`, no timeout.
- **10/10 code cells** have non-null `execution_count`.
- **0 error outputs** in the whole notebook.
- cell[11] new output: `display_data` mime `text/html`, `Plotly.newPlot('plt...', [{"name":"Bayesienne...","x":[0,37.5,75,...],"y":[...],"type":"scatter"}, {"name":"Empirique...",...}])` — real data, unescaped HTML (validated: contains `<div id=`, `plotly-2.35.2.min.js`, both trace names, `scatter` type, NOT `&lt;`-escaped).
- `nbformat VALIDATE OK` (27 cells, code-cell IDs all present + unique).
- C.1: no `raise NotImplementedError` / `assert False` / `throw new` (exercise stubs in cells 21/23/25 untouched, retain `# TODO etudiant`).

## Conventions

- Catalogue byte-identical (no `COURSE_CATALOG.generated.*` touched).
- Atomic (1 file, 1 subject).
- `See #6599` (partial — Infer-19 is 1 of the 3 Infer notebooks in #6599; Infer-17/18 + Sudoku-18 #6596 remain).

See #3801 (SOTA axe-2), see #6599 (pattern + zero-restore technique, C548-L2), see #6596 (sibling Sudoku-18).

## Verification

```
jupyter nbconvert --to notebook --execute Infer-19-Survival-Analysis.ipynb \
  --inplace --ExecutePreprocessor.timeout=180 --ExecutePreprocessor.kernel_name=.net-csharp
# EXIT=0
# cell[11] ec=5, 10 outputs (table stream + 1 Plotly display_data text/html)
# whole notebook: 0 errors, 0 null execution_count
```

Co-Authored-By: Claude-Code <noreply@anthropic.com>
