### PR TITLE
fix(probas/pymc-13): sample the Community model via real pm.sample (#3801)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
@@ -1247,11 +1247,11 @@
    "source": [
     "### Demonstration PyMC : fiabilite d'annotateur par MCMC (Beta-Bernoulli)\n",
     "\n",
-    "Les modeles precedents (`Honest Worker`, `Biased Worker`, `Community`) sont **definis** dans PyMC (`with pm.Model() as ...`) mais leur inference reelle est confiee a l'EM Dawid-Skene, plus stable sur ce type de variables latentes discretes. Pour que le notebook demontre effectivement l'**echantillonnage MCMC** attendu d'une serie `PyMC-*`, nous ajoutons ici un modele simple **inferable par NUTS** : l'estimation de la fiabilite de chaque worker.\n",
+    "Les modeles precedents (`Honest Worker`, `Biased Worker`) sont **definis** dans PyMC (`with pm.Model() as ...`) mais leur inference reelle est confiee a l'EM Dawid-Skene, plus stable sur ce type de variables latentes discretes. Le modele `Community` (section 6) est, lui, echantillonne par MCMC dans sa variante a communautes connues. Pour demontrer effectivement l'**echantillonnage MCMC** attendu d'une serie `PyMC-*`, nous ajoutons ici un modele simple **inferable par NUTS** : l'estimation de la fiabilite de chaque worker.\n",
     "\n",
-    "**Modele** : pour chaque worker $w$, une fiabilite $\theta_w \\sim \\mathrm{Beta}(2, 1)$. Pour chaque paire (item, worker), on observe un indicateur de *match* (1 si le worker a donne le vrai label, 0 sinon) modense comme une Bernoulli de probabilite $\theta_w$. Les vrais labels etant connus ici (jeu de calibration), on obtient directement un vecteur d'observations `observed=`.\n",
+    "**Modele** : pour chaque worker $w$, une fiabilite $\\theta_w \\sim \\mathrm{Beta}(2, 1)$. Pour chaque paire (item, worker), on observe un indicateur de *match* (1 si le worker a donne le vrai label, 0 sinon) modense comme une Bernoulli de probabilite $\\theta_w$. Les vrais labels etant connus ici (jeu de calibration), on obtient directement un vecteur d'observations `observed=`.\n",
     "\n",
-    "Ce modele est la **version MCMC** de l'estimation bayesienne manuelle (cellule `Honest Worker complet`) : il retrouve les memes posterioris Beta, mais en utilisant `pm.sample` (NUTS) plutot que le calcul analytique `Beta(alpha + n_correct, beta + n_incorrect)`. Les deux approches sont **complementaires** : l'analytique est exacte pour ce modele conjugue, le MCMC se generalise aux modeles non-conjuges (comme Dawid-Skene, ou l'EM reste preferable).\n"
+    "Ce modele est la **version MCMC** de l'estimation bayesienne manuelle (cellule `Honest Worker complet`) : il retrouve les memes posterioris Beta, mais en utilisant `pm.sample` (NUTS) plutot que le calcul analytique `Beta(alpha + n_correct, beta + n_incorrect)`. Les deux approches sont **complementaires** : l'analytique est exacte pour ce modele conjugue, le MCMC se generalise aux modeles non-conjuges (comme Dawid-Skene, ou l'EM reste preferable)."
    ]
   },
   {
@@ -1496,10 +1496,10 @@
    "id": "dd0ab71d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-18T10:15:02.567088Z",
-     "iopub.status.busy": "2026-06-18T10:15:02.567088Z",
-     "iopub.status.idle": "2026-06-18T10:15:02.650850Z",
-     "shell.execute_reply": "2026-06-18T10:15:02.650850Z"
+     "iopub.execute_input": "2026-07-14T22:24:48.053161Z",
+     "iopub.status.busy": "2026-07-14T22:24:48.049252Z",
+     "iopub.status.idle": "2026-07-14T22:25:27.326034Z",
+     "shell.execute_reply": "2026-07-14T22:25:27.326034Z"
     },
     "papermill": {
      "duration": 0.09411,
@@ -1515,7 +1515,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Modele Community (Hierarchique) ===\n",
+      "=== Modele Community (Hierarchique, communautes connues) ===\n",
+      "\n",
       "Donnees simulees : 20 items, 3 experts, 3 spammeurs\n",
       "Worker 1 (Expert) : precision = 0.85\n",
       "Worker 2 (Expert) : precision = 0.95\n",
@@ -1526,20 +1527,136 @@
      ]
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sequential sampling (4 chains in 1 job)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "CompoundStep\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ">NUTS: [community_capacity]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      ">CategoricalGibbsMetropolis: [true_labels_sim]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Sampling 4 chains for 500 tune and 500 draw iterations (2_000 + 2_000 draws total) took 33 seconds.\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "\n",
-      "Modele Community construit.\n",
-      "(MCMC omis pour la stabilite - le modele est illustre structurellement)\n"
+      "=== Posterior des capacites par communaute ===\n",
+      "(Verite terrain : capacite expert ~0.90, spammeur ~0.55)\n",
+      "Recuperation des vrais labels : 100%\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>sd</th>\n",
+       "      <th>hdi_3%</th>\n",
+       "      <th>hdi_97%</th>\n",
+       "      <th>mcse_mean</th>\n",
+       "      <th>mcse_sd</th>\n",
+       "      <th>ess_bulk</th>\n",
+       "      <th>ess_tail</th>\n",
+       "      <th>r_hat</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>community_capacity[0]</th>\n",
+       "      <td>0.914</td>\n",
+       "      <td>0.038</td>\n",
+       "      <td>0.847</td>\n",
+       "      <td>0.979</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>1027.0</td>\n",
+       "      <td>837.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>community_capacity[1]</th>\n",
+       "      <td>0.553</td>\n",
+       "      <td>0.065</td>\n",
+       "      <td>0.436</td>\n",
+       "      <td>0.677</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>1221.0</td>\n",
+       "      <td>1199.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        mean     sd  hdi_3%  hdi_97%  mcse_mean  mcse_sd  \\\n",
+       "community_capacity[0]  0.914  0.038   0.847    0.979      0.001    0.001   \n",
+       "community_capacity[1]  0.553  0.065   0.436    0.677      0.002    0.001   \n",
+       "\n",
+       "                       ess_bulk  ess_tail  r_hat  \n",
+       "community_capacity[0]    1027.0     837.0    1.0  \n",
+       "community_capacity[1]    1221.0    1199.0    1.0  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Modele Community (Hierarchique)\n",
+    "# Modele Community (Hierarchique) - echantillonnage MCMC reel (communautes CONNUES)\n",
     "# 2 communautes : Experts (haute precision) et Spammeurs (reponses aleatoires)\n",
+    "#\n",
+    "# Variante echantillonnee : l'appartenance de chaque worker a sa communaute est\n",
+    "# CONNUE (metadonnees d'annotation). On n'infere alors que les 2 capacites latentes\n",
+    "# + les vrais labels. La variante ou l'appartenance est AUSSI inferee est\n",
+    "# non-identifiable (label-switching) -- voir la cellule markdown suivante.\n",
     "\n",
-    "print(\"=== Modele Community (Hierarchique) ===\")\n",
+    "print(\"=== Modele Community (Hierarchique, communautes connues) ===\\n\")\n",
     "\n",
     "n_communities = 2\n",
     "\n",
@@ -1559,47 +1676,54 @@
     "labels_sim = np.zeros((n_items_sim, n_workers_sim), dtype=int)\n",
     "for i in range(n_items_sim):\n",
     "    for w in range(n_experts):\n",
-    "        if np.random.random() < expert_quality:\n",
-    "            labels_sim[i, w] = vrais_labels_sim[i]\n",
-    "        else:\n",
-    "            labels_sim[i, w] = 1 - vrais_labels_sim[i]\n",
+    "        labels_sim[i, w] = vrais_labels_sim[i] if np.random.random() < expert_quality else 1 - vrais_labels_sim[i]\n",
     "    for w in range(n_experts, n_workers_sim):\n",
-    "        if np.random.random() < spammer_quality:\n",
-    "            labels_sim[i, w] = vrais_labels_sim[i]\n",
-    "        else:\n",
-    "            labels_sim[i, w] = 1 - vrais_labels_sim[i]\n",
+    "        labels_sim[i, w] = vrais_labels_sim[i] if np.random.random() < spammer_quality else 1 - vrais_labels_sim[i]\n",
     "\n",
     "print(f\"Donnees simulees : {n_items_sim} items, {n_experts} experts, {n_spammers} spammeurs\")\n",
-    "\n",
-    "# Precision empirique par worker\n",
     "for w in range(n_workers_sim):\n",
     "    group = \"Expert\" if w < n_experts else \"Spammeur\"\n",
     "    acc = np.mean(labels_sim[:, w] == vrais_labels_sim)\n",
     "    print(f\"Worker {w+1} ({group}) : precision = {acc:.2f}\")\n",
     "\n",
-    "# Modele hierarchique avec PyMC\n",
+    "# Assignation CONNUE des workers aux communautes (3 experts = communaute 0, 3 spammeurs = 1)\n",
+    "known_community = np.array([0] * n_experts + [1] * n_spammers)\n",
+    "\n",
     "with pm.Model() as community_model:\n",
-    "    # Distribution sur les communautes\n",
-    "    p_community = pm.Dirichlet(\"p_community\", a=np.ones(n_communities))\n",
-    "    \n",
-    "    # Capacite par communaute\n",
+    "    # Niveau hierarchique : capacite partagee par communaute\n",
     "    community_capacity = pm.Beta(\"community_capacity\", alpha=2, beta=1,\n",
     "                                 shape=n_communities)\n",
-    "    \n",
-    "    # Assignation des workers aux communautes\n",
-    "    worker_community = pm.Categorical(\"worker_community\",\n",
-    "                                      p=p_community, shape=n_workers_sim)\n",
-    "    \n",
-    "    # Capacite individuelle = capacite de la communaute du worker\n",
-    "    worker_capacity = pm.Deterministic(\"worker_capacity\",\n",
-    "                                       community_capacity[worker_community])\n",
-    "    \n",
-    "    # Vrais labels\n",
+    "    # Capacite d'un worker = capacite de sa communaute (appartenance connue)\n",
+    "    worker_capacity = community_capacity[known_community]\n",
+    "    # Vrais labels latents des items\n",
     "    true_labels_sim = pm.Categorical(\"true_labels_sim\",\n",
     "                                     p=np.ones(2) / 2, shape=n_items_sim)\n",
+    "    # Likelihood : P(label observe=1) = capacite si vrai label=1, sinon (1 - capacite)\n",
+    "    p_obs = pm.math.switch(true_labels_sim[None, :] > 0,\n",
+    "                           worker_capacity[:, None],\n",
+    "                           1 - worker_capacity[:, None])\n",
+    "    pm.Bernoulli(\"obs_labels\", p=p_obs, observed=labels_sim.T)\n",
+    "    # Echantillonnage mixte : NUTS (continu) + CategoricalGibbs (discret).\n",
+    "    # 4 chaines pour un diagnostic de convergence robuste (recommandation ArviZ).\n",
+    "    # compute_convergence_checks=False : on diagnostique nous-meme (az.summary\n",
+    "    # sur les parametres continus ci-dessous) ; le check interne de pm.sample\n",
+    "    # produit un r_hat NaN sur le label discret (variance inter-chaines nulle),\n",
+    "    # sans que cela reflete un probleme de convergence.\n",
+    "    step_c = pm.NUTS(vars=[community_capacity], target_accept=0.95)\n",
+    "    step_t = pm.CategoricalGibbsMetropolis(vars=[true_labels_sim])\n",
+    "    trace_community = pm.sample(500, tune=500, chains=4, cores=1,\n",
+    "                                step=[step_c, step_t],\n",
+    "                                random_seed=42, progressbar=False,\n",
+    "                                compute_convergence_checks=False)\n",
     "\n",
-    "print(\"\\nModele Community construit.\")\n",
-    "print(\"(MCMC omis pour la stabilite - le modele est illustre structurellement)\")"
+    "print(\"\\n=== Posterior des capacites par communaute ===\")\n",
+    "print(\"(Verite terrain : capacite expert ~0.90, spammeur ~0.55)\")\n",
+    "# Recuperation des vrais labels (mode du posterior)\n",
+    "tl_mean = (trace_community.posterior[\"true_labels_sim\"]\n",
+    "           .mean(dim=(\"chain\", \"draw\")) > 0.5).astype(int).values\n",
+    "acc_labels = np.mean(tl_mean == vrais_labels_sim)\n",
+    "print(f\"Recuperation des vrais labels : {acc_labels:.0%}\")\n",
+    "az.summary(trace_community, var_names=[\"community_capacity\"])"
    ]
   },
   {
@@ -1616,7 +1740,7 @@
     "tags": []
    },
    "source": [
-    "### Structure hierarchique du modele Community\n",
+    "### Structure hierarchique et identifiabilite\n",
     "\n",
     "Le modele Community introduit un niveau de hierarchie supplementaire :\n",
     "\n",
@@ -1628,7 +1752,13 @@
     "\n",
     "**Niveau 4 (Labels)** : comme le modele Honest Worker mais avec $\\theta_{z_j}$\n",
     "\n",
-    "Ce modele partage l'information entre workers d'une meme communaute, ce qui est utile quand on a peu de donnees par worker."
+    "Ce modele partage l'information entre workers d'une meme communaute, ce qui est utile quand on a peu de donnees par worker.\n",
+    "\n",
+    "### Pourquoi on echantillonne la variante a communautes CONNUES\n",
+    "\n",
+    "La cellule precedente echantillonne la variante ou l'appartenance $z_j$ de chaque worker est **connue** (metadonnees d'annotation) : on n'infere que les capacites $\\theta_k$ et les vrais labels. Le resultat est net : les deux capacites sont recuperees (expert $0.91$ vs spammeur $0.55$, proches des verites terrain $0.90$ et $0.55$), avec une convergence propre ($\\hat{R} = 1.0$, $\\mathrm{ESS} > 1000$) et une recuperation parfaite des vrais labels.\n",
+    "\n",
+    "La variante **complete** -- ou l'appartenance $z_j$ est *aussi* inferee -- souffre d'un probleme de **non-identifiabilite par label-switching** : avec deux communautes symetriques, rien ne distingue la configuration (experts = groupe 0, spammeurs = groupe 1) de la configuration permutee. Un echantillonnage direct (CompoundStep : NUTS sur les capacites + Gibbs sur $z_j$ et les labels) traduit cette ambiguite -- sur ce meme jeu de donnees il produit $\\hat{R} \\approx 1.8$ et les deux capacites s'effondrent vers une valeur identique ($\\approx 0.51$). Resoudre cette non-identifiabilite demande soit plus de donnees par worker, soit des priors informatifs, soit une parametrisation contrainte (par exemple ordonner $\\theta_0 > \\theta_1$). La variante a communautes connues evite le piege tout en illustrant le partage d'information hierarchique au coeur du modele."
    ]
   },
   {


### PR DESCRIPTION
## Summary

PyMC-13-Crowdsourcing cell 30 defined the hierarchical Community model (`with pm.Model()`) but **never sampled it** (`print("(MCMC omis pour la stabilite)")`), and the model had **no likelihood** — only a prior spec. In a `PyMC-*` notebook that is a **Prong-A SOTA defect** (defined-but-not-sampled). The stated reason ("stabilite") was incomplete — the real cause is deeper and more instructive.

This PR makes cell 30 a genuine `pm.sample` demonstration, grounded in a firsthand convergence diagnostic.

## Root cause (verified firsthand)

The **full** Community model — inferring worker→community assignment `z_j` AND capacities AND true labels — is **non-identifiable**: label-switching on two symmetric communities. A direct CompoundStep sample (NUTS on capacities + CategoricalGibbs on `z_j` and labels) collapses both capacities to ~0.51 with **r_hat ≈ 1.8**. That is why MCMC was omitted — but the notebook never said so.

## Fix

Sample the **identified** variant: community membership is **known** (annotation metadata), so the model infers only the 2 community capacities + true labels. This converges cleanly:

| param | posterior mean | ground truth | r_hat | ESS_bulk |
|---|---|---|---|---|
| community_capacity[0] (expert) | **0.914** | ~0.90 | 1.0 | 1027 |
| community_capacity[1] (spammer) | **0.553** | ~0.55 | 1.0 | 1221 |

0 divergences, **100% true-label recovery**. CompoundStep (NUTS + CategoricalGibbsMetropolis), 4 chains x 500 draws.

## Cells changed (3)

- **cell 27 (md)**: drop `Community` from the "defined-but-not-sampled" list (it is now sampled).
- **cell 30 (code)**: real `pm.sample` on the identified model - likelihood `pm.Bernoulli(observed=labels_sim.T)`, 4-chain CompoundStep, `compute_convergence_checks=False` (avoids a spurious r_hat NaN on the discrete label; we diagnose via `az.summary` on the continuous params instead). Real outputs injected.
- **cell 31 (md)**: honest identified-vs-full explanation grounded in the convergence test - the full model's label-switching (r_hat approx 1.8, capacities collapse) is an **intrinsic** non-identifiability, and the identified variant avoids it while still illustrating hierarchical information-sharing.

No downstream cells depend on cell-30 outputs (verified: cell 33 uses the original `labels`/`n_items`, cell 36 is self-contained).

## Validation

- **EXEC_PROVED**: papermill end-to-end, **16/16 cells, 0 errors**, 55-60s, kernel `pymc18-jsboi` (pymc 5.28.5).
- **C.1**: 0 voluntary errors (`raise NotImplementedError`/`assert False`/`1/0`) - confirmed by grep across all 43 cells.
- **C.2**: cell 30 `execution_count=13`, real outputs; no cell with null exec_count; **no machine-path leak** in outputs.
- **SOTA verdict**: `SOTA-OK` - real `pm.sample` on the genuine Community hierarchical model; the non-identifiable full variant is documented honestly (INTRINSIC), not hidden.

See #3801

Co-Authored-By: Claude-Code <noreply@anthropic.com>