### PR TITLE
fix(infer-17,#6599): Kalman ASCII trajectory -> zero-restore Plotly (3/3, C548-L2)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
@@ -55,10 +55,10 @@
    "id": "a0e558bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:47:38.008976Z",
-     "iopub.status.busy": "2026-07-01T08:47:38.001526Z",
-     "iopub.status.idle": "2026-07-01T08:47:43.953318Z",
-     "shell.execute_reply": "2026-07-01T08:47:43.943127Z"
+     "iopub.execute_input": "2026-07-14T23:09:19.079266Z",
+     "iopub.status.busy": "2026-07-14T23:09:19.066580Z",
+     "iopub.status.idle": "2026-07-14T23:09:27.068122Z",
+     "shell.execute_reply": "2026-07-14T23:09:27.060041Z"
     }
    },
    "outputs": [
@@ -71,7 +71,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
+       "async function probeAddresses(probingAddresses) {\r\n",
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -81,10 +81,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
        "\r\n",
-       
+       "            let rootUrl = probingAddresses[i];\r\n",
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -99,7 +99,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
+       "                    body: probingAddresses[i]\r\n",
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -111,13 +111,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%12:2048/\",\"http://172.26.48.1:2048/\",\"http://fe80::4242:e8b9:6bbf:ef2c%50:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:4c49:ea51:a5f7:8b03:2048/\",\"http://2a01:e0a:9d4:f320:6d91:40d7:528:51b3:2048/\",\"http://2a01:e0a:9d4:f320:7042:4896:3da8:dc2a:2048/\",\"http://2a01:e0a:9d4:f320:c942:e5c4:12e2:6ae2:2048/\",\"http://2a01:e0a:9d4:f320:cde3:e6ed:6b4:42df:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '196332.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '1419240.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -161,13 +161,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
+       "        loadDotnetInteractiveApi();\r\n",
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
+       "    loadDotnetInteractiveApi();\r\n",
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -210,10 +210,10 @@
    "id": "309102f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:47:43.956575Z",
-     "iopub.status.busy": "2026-07-01T08:47:43.956211Z",
-     "iopub.status.idle": "2026-07-01T08:47:45.370263Z",
-     "shell.execute_reply": "2026-07-01T08:47:45.369973Z"
+     "iopub.execute_input": "2026-07-14T23:09:27.071242Z",
+     "iopub.status.busy": "2026-07-14T23:09:27.070917Z",
+     "iopub.status.idle": "2026-07-14T23:09:29.039344Z",
+     "shell.execute_reply": "2026-07-14T23:09:29.038613Z"
     }
    },
    "outputs": [
@@ -307,10 +307,10 @@
    "id": "37276c06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:47:45.371914Z",
-     "iopub.status.busy": "2026-07-01T08:47:45.371670Z",
-     "iopub.status.idle": "2026-07-01T08:47:47.686072Z",
-     "shell.execute_reply": "2026-07-01T08:47:47.685838Z"
+     "iopub.execute_input": "2026-07-14T23:09:29.041502Z",
+     "iopub.status.busy": "2026-07-14T23:09:29.041163Z",
+     "iopub.status.idle": "2026-07-14T23:09:31.705232Z",
+     "shell.execute_reply": "2026-07-14T23:09:31.704760Z"
     }
    },
    "outputs": [
@@ -401,551 +401,21 @@
    "id": "4ad73b83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:47:47.687748Z",
-     "iopub.status.busy": "2026-07-01T08:47:47.687497Z",
-     "iopub.status.idle": "2026-07-01T08:47:47.903880Z",
-     "shell.execute_reply": "2026-07-01T08:47:47.898869Z"
+     "iopub.execute_input": "2026-07-14T23:09:31.707207Z",
+     "iopub.status.busy": "2026-07-14T23:09:31.706884Z",
+     "iopub.status.idle": "2026-07-14T23:09:32.006220Z",
+     "shell.execute_reply": "2026-07-14T23:09:32.005865Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Echelle : -6,4 (gauche) -> 18,9 (droite), 60 colonnes\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  VRAI = |   OBS = .   FILT = #\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t= 0 VRAI |||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .....\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT #####  (+-1,79)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t= 2 VRAI |||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ..............\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##########  (+-1,23)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t= 4 VRAI |||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .............\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##############  (+-1,12)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t= 6 VRAI |||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT #################  (+-1,10)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t= 8 VRAI |||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .......\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=10 VRAI |||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT #################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=12 VRAI ||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=14 VRAI ||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ......................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ####################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=16 VRAI |||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ............\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=18 VRAI ||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .............................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT #######################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=20 VRAI ||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .............................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##########################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=22 VRAI |||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ....................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ############################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=24 VRAI ||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##############################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=26 VRAI |||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ...............................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ###############################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=28 VRAI |||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ...............................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT #####################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=30 VRAI ||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ####################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=32 VRAI ||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ..............................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ####################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=34 VRAI ||||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ..................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ####################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=36 VRAI |||||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .........................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT #######################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=38 VRAI ||||||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  .......................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##########################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=40 VRAI |||||||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ....................................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##############################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=42 VRAI |||||||||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ........................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT #############################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=44 VRAI ||||||||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ..................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ##########################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=46 VRAI ||||||||||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ...............................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT #############################################  (+-1,09)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "t=48 VRAI |||||||||||||||||||||||||||||||||||||||||||||||||\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     OBS  ..............................................\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     FILT ################################################  (+-1,09)\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plt79f6aff3ac724cea8bf69c4d0e28dd84\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt79f6aff3ac724cea8bf69c4d0e28dd84',[{\"name\":\"VRAI (etat cache)\",\"x\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49],\"y\":[0,-0.5130037725789927,-0.16079962952211685,-0.28892648470078214,0.10315187468075354,0.8387970896977152,0.6222931796665168,0.16339997610091583,-0.2276980642226752,-0.11557866641359185,0.789238700787506,0.5076933819881209,1.1028752356312583,1.726303194169688,2.2324937423899587,2.754722238733309,3.166531772877004,3.3494188746558926,3.9523507909205557,4.219757877015535,5.343569020241,4.864416116092874,5.0982147654281835,5.622521552848821,5.265456915400842,6.0964517997652825,6.865491113427968,7.056819155093982,7.452966012614545,7.643432471410314,8.74327944582384,9.001984224034253,8.631945832096052,9.193336783055098,9.43265524402378,9.837757690823807,10.20217002132496,10.455388425421404,10.647846623891708,10.926203517387103,11.00434154032928,11.979629584607464,11.724736820014625,11.75485619244337,11.523518862757152,12.554809326105396,12.345469548725525,12.97238526247734,14.208311868080067,14.603072831196705],\"type\":\"scatter\",\"mode\":\"lines\",\"line\":{\"color\":\"#4C72B0\"}},{\"name\":\"OBS (mesure)\",\"x\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49],\"y\":[-4.363870462542702,-3.1973772405005785,-0.437151621147165,1.4876463457198543,-0.7462107718919448,1.5980066544468032,0.8176722497830122,3.1723204577492994,-3.299439043465317,0.046301770568324296,0.3494761914248801,1.3014251794636542,0.6421305431523198,1.350166680203517,2.997590766960546,1.5910722078847859,-1.2177757308880466,2.4956869917409574,5.721652736048865,4.007431929307013,5.837771969542903,0.6220843379824972,8.870458371863284,6.07763076326419,7.2760161873274924,4.846531956290282,6.63045653663468,7.645132077437329,13.25332991981605,8.364490273207226,7.507999301909478,9.88839618169365,6.442562589833181,7.490801706270926,8.032917870317913,10.255048998495644,10.798247386070742,14.969664792556047,9.993333137440027,10.788904665775375,15.669204357276804,13.078461406838295,10.295677518308256,12.743415852394188,7.803972054398327,13.027278175489728,13.324582958699594,16.689761970026908,12.836358329145462,16.90477954665059],\"type\":\"scatter\",\"mode\":\"markers\",\"line\":{\"color\":\"#888888\"}},{\"name\":\"FILT (estimee)\",\"x\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49],\"y\":[-4.305333877176849,-3.6160340759347283,-2.22880219888395,-0.7859577768716097,-0.5678957442274216,0.3020968138430624,0.6669705950885689,1.625719229395978,0.3706744509565537,0.4851950052880341,0.6558747933202044,1.0583874684287398,1.1459461180616668,1.4175411037631893,2.0971409661814677,2.158106962628354,1.3680643284220224,1.9134851285313805,3.2537834977627442,3.6883064220977198,4.536738421128032,3.5869447939056216,5.364732098826961,5.787171084135475,6.439705479916408,6.178312942969,6.523428869198391,7.0670927673490915,9.112569079877918,9.101776857149884,8.84020521617444,9.362070147967207,8.707372941521289,8.557656239384986,8.613092310684785,9.31102965908409,9.963081464135676,11.658748929945252,11.37593403281655,11.412898632738365,12.886082405172177,13.154168994629789,12.517565202256907,12.795577312530423,11.526430272033007,12.182523903715154,12.732224024868799,14.116812644424593,13.948152362622517,15.035935744067338],\"type\":\"scatter\",\"mode\":\"lines\\u002Bmarkers\",\"line\":{\"color\":\"#DD8452\"},\"error_y\":{\"type\":\"data\",\"array\":[1.7942999178292216,1.3882831749234994,1.2290770738583017,1.1567409490789706,1.1222115150062386,1.105401696833467,1.097147366940702,1.093077893375973,1.0910677533182083,1.0900739073517887,1.0895823090058179,1.0893390888290235,1.0892187413189047,1.0891591890232288,1.0891297195942085,1.0891151364630935,1.0891079198614644,1.089104348645496,1.0891025813864808,1.0891017068364741,1.0891012740544017,1.0891010598867066,1.089100953903097,1.0891009014557564,1.0891008755015208,1.0891008626577359,1.0891008563018247,1.0891008531565212,1.0891008516000273,1.0891008508297766,1.0891008504486082,1.0891008502599822,1.089100850166638,1.0891008501204456,1.0891008500975865,1.0891008500862744,1.0891008500806767,1.0891008500779065,1.0891008500765356,1.0891008500758572,1.0891008500755215,1.0891008500753554,1.0891008500752732,1.0891008500752324,1.0891008500752124,1.0891008500752024,1.0891008500751973,1.0891008500751949,1.0891008500751937,1.0891008500751933],\"visible\":true,\"color\":\"rgba(221,132,82,0.35)\",\"thickness\":1}}],{\"title\":{\"text\":\"Filtre de Kalman : vrai etat, observations, estimation\"},\"xaxis\":{\"title\":{\"text\":\"t (pas)\"}},\"yaxis\":{\"title\":{\"text\":\"position\"}},\"showlegend\":true})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -985,25 +455,47 @@
     }
    ],
    "source": [
-    "// --- Visualisation ASCII + metriques honnetes ---\n",
-    "// Axe horizontal = position. On cale l'echelle sur l'ensemble des series.\n",
-    "double lo = Math.Min(trueState.Min(), obs.Min()) - 2;\n",
-    "double hi = Math.Max(trueState.Max(), obs.Max()) + 2;\n",
-    "int W = 60;\n",
+    "// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.\n",
+    "// (Zero `#r \"nuget:\"` sur une charting-lib : les charting libs pinent une vieille beta\n",
+    "//  de Microsoft.DotNet.Interactive et font timeout le restore, cluster-wide. Le formatter\n",
+    "//  ci-dessous emet du HTML Plotly brut, sans dependence. Cf #6599 / C548-L2.)\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
     "\n",
-    "string Bar(double v, char c) {\n",
-    "    int n = (int)Math.Round((v - lo) / (hi - lo) * W);\n",
-    "    if (n < 0) n = 0; if (n > W) n = W;\n",
-    "    return new string(c, n);\n",
-    "}\n",
+    "// --- Trajectoire : vrai etat, observations bruitees, estimation filtree ---\n",
+    "var tAxis = Enumerable.Range(0, T).Select(i => (double)i).ToArray();\n",
+    "// Ecart-type posterior a chaque pas (incertitude du filtre) -> barres d'erreur sur FILT.\n",
+    "var filtStd = filtVar.Select(v => Math.Sqrt(v)).ToArray();\n",
     "\n",
-    "Console.WriteLine($\"Echelle : {lo:F1} (gauche) -> {hi:F1} (droite), {W} colonnes\");\n",
-    "Console.WriteLine(\"  VRAI = |   OBS = .   FILT = #\");\n",
-    "for (int t = 0; t < T; t += 2) {\n",
-    "    Console.WriteLine($\"t={t,2} VRAI {Bar(trueState[t], '|')}\");\n",
-    "    Console.WriteLine($\"     OBS  {Bar(obs[t], '.')}\");\n",
-    "    Console.WriteLine($\"     FILT {Bar(filtMean[t], '#')}  (+-{Math.Sqrt(filtVar[t]):F2})\");\n",
-    "}\n",
+    "string Trace(string name, double[] y, string mode, string color) =>\n",
+    "    System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> { [\"name\"] = name, [\"x\"] = tAxis, [\"y\"] = y,\n",
+    "                                         [\"type\"] = \"scatter\", [\"mode\"] = mode,\n",
+    "                                         [\"line\"] = new { color = color } });\n",
+    "\n",
+    "var filtTrace = new Dictionary<string, object> {\n",
+    "    [\"name\"] = \"FILT (estimee)\", [\"x\"] = tAxis, [\"y\"] = filtMean,\n",
+    "    [\"type\"] = \"scatter\", [\"mode\"] = \"lines+markers\",\n",
+    "    [\"line\"] = new { color = \"#DD8452\" },\n",
+    "    [\"error_y\"] = new { type = \"data\", array = filtStd, visible = true,\n",
+    "                        color = \"rgba(221,132,82,0.35)\", thickness = 1.0 } };\n",
+    "string filtJson = System.Text.Json.JsonSerializer.Serialize(filtTrace);\n",
+    "\n",
+    "var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Filtre de Kalman : vrai etat, observations, estimation\\\"},\" +\n",
+    "             \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"t (pas)\\\"}},\" +\n",
+    "             \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"position\\\"}},\" +\n",
+    "             \"\\\"showlegend\\\":true}\";\n",
+    "var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "             \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "             \"<script>Plotly.newPlot('\" + divId + \"',[\" +\n",
+    "             Trace(\"VRAI (etat cache)\", trueState, \"lines\", \"#4C72B0\") + \",\" +\n",
+    "             Trace(\"OBS (mesure)\", obs, \"markers\", \"#888888\") + \",\" +\n",
+    "             filtJson + \"],\" + layout + \")</script>\";\n",
+    "display(new PlotlyHtml(markup));\n",
     "\n",
     "// --- Metriques : MSE filtree vs MSE brute (par rapport a la VRAIE trajectoire) ---\n",
     "double rawMSE = 0.0, filtMSE = 0.0;\n",
@@ -1092,10 +584,10 @@
    "id": "aa387393",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:47:47.905770Z",
-     "iopub.status.busy": "2026-07-01T08:47:47.905526Z",
-     "iopub.status.idle": "2026-07-01T08:47:47.991971Z",
-     "shell.execute_reply": "2026-07-01T08:47:47.991749Z"
+     "iopub.execute_input": "2026-07-14T23:09:32.008382Z",
+     "iopub.status.busy": "2026-07-14T23:09:32.008080Z",
+     "iopub.status.idle": "2026-07-14T23:09:32.087002Z",
+     "shell.execute_reply": "2026-07-14T23:09:32.086722Z"
     }
    },
    "outputs": [
@@ -1136,10 +628,10 @@
    "id": "0997e86a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:47:47.993689Z",
-     "iopub.status.busy": "2026-07-01T08:47:47.993424Z",
-     "iopub.status.idle": "2026-07-01T08:47:48.044391Z",
-     "shell.execute_reply": "2026-07-01T08:47:48.043938Z"
+     "iopub.execute_input": "2026-07-14T23:09:32.088854Z",
+     "iopub.status.busy": "2026-07-14T23:09:32.088559Z",
+     "iopub.status.idle": "2026-07-14T23:09:32.136183Z",
+     "shell.execute_reply": "2026-07-14T23:09:32.135908Z"
     }
    },
    "outputs": [
@@ -1182,10 +674,10 @@
    "id": "1ab3b005",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T08:47:48.046016Z",
-     "iopub.status.busy": "2026-07-01T08:47:48.045736Z",
-     "iopub.status.idle": "2026-07-01T08:47:48.083643Z",
-     "shell.execute_reply": "2026-07-01T08:47:48.083384Z"
+     "iopub.execute_input": "2026-07-14T23:09:32.138015Z",
+     "iopub.status.busy": "2026-07-14T23:09:32.137749Z",
+     "iopub.status.idle": "2026-07-14T23:09:32.175239Z",
+     "shell.execute_reply": "2026-07-14T23:09:32.174919Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

Third and final application of the **zero-restore Plotly technique** (C548-L2, #6607 pilot merged, #6609 twin). **Infer-17-Kalman-Filter.ipynb cell[8]** — the ASCII horizontal `Bar()` trajectory chart of the Kalman filter is replaced by a real **Plotly.js line chart** with 3 traces + posterior uncertainty bars. This completes #6599 (3/3 Infer notebooks).

## What changed (scope: 1 cell, 1 file)

`Infer-17-Kalman-Filter.ipynb` **cell[8]** only:
- **Kept**: the honest MSE metrics block (`rawMSE`/`filtMSE`/reduction d'erreur/variance post. finale) — legitimate tabular output, preserved verbatim.
- **Removed**: the ASCII horizontal bar chart (`string Bar(double v, char c)` helper + the `for t...Console.WriteLine` loop plotting VRAI `|` / OBS `.` / FILT `#` ±√filtVar over 60 columns by position).
- **Added**: a real Plotly.js line chart via `Formatter.Register(typeof(PlotlyHtml), delegate, "text/html")`: **3 scatter traces** (`VRAI (etat cache)` lines, `OBS (mesure)` markers, `FILT (estimee)` lines+markers) with `error_y` bars on FILT = the posterior std √filtVar at each step.

Net: +86/−594, 1 file, atomic. (The −594 is the 76+ ASCII stream-output lines replaced by one compact `display_data`.)

## Why this is SOTA-OK (Prong A)

The Infer.NET engine is **genuinely exercised**:
- `filtMean[]`/`filtVar[]` come from the **real online Gaussian Kalman filter** in cell[6]: latent state `x[t] ~ Gaussian(x[t-1], procVar)`, observation `y ~ Gaussian(x, obsVar)`, `Variable.GaussianFromMeanAndVariance`, inferred per-step via `InferenceEngine` (EP) in a `For{T}` block. `trueState`/`obs` are the synthetic ground-truth trajectory + noisy sensor in cell[4] (`T=50`, `obsVar=4.0`).
- The chart plots **all three trajectories continuously** (true / observed / filtered) over the full horizon — strictly richer than the ASCII bars sampled every 2 steps.
- The `error_y` band on FILT **visualizes the posterior uncertainty shrinking** as the filter converges (filtVar decreases), a genuine Kalman signature invisible in the ASCII version (which only printed ±√filtVar in the hover text).

No `#r "nuget:"` on a charting lib (same cluster-wide blocker as #6607/#6609, superseded by C548-L2 zero-restore). The only `#r "nuget:"` is `Microsoft.ML.Probabilistic` (cell[2]) which restores fine.

## Execution proof (H.1 / C.2)

Re-executed end-to-end on po-2024 via `jupyter nbconvert --execute --kernel .net-csharp --timeout 240`:
- **EXIT=0**, no CellExecutionError, no timeout.
- **7/7 code cells** execution_count non-null, **0 errors**.
- cell[8]: `display_data` mime `text/html` (4901 chars), `Plotly.newPlot('plt...', [VRAI scatter, OBS scatter, FILT scatter+error_y], ...)` — real data, unescaped HTML (validated: `has Plotly.newPlot=True`, `VRAI/OBS/FILT=True`, `error_y=True`, `not_escaped=True`, no `&lt;`, `plotly-2.35.2` CDN).
- MSE metrics preserved: `rawMSE`/`filtMSE`/`Reduction`/`Variance post. finale` stream block intact (6 lines).
- `nbformat VALIDATE OK` (18 cells, code-cell IDs all present + unique).
- C.1: no `raise NotImplementedError` / `assert False` / `1/0` / `throw new`.

## Conventions

- Catalogue byte-identical (no `COURSE_CATALOG.generated.*` touched).
- Atomic (1 file, 1 cell, 1 subject).
- `See #6599` (completes the 3/3 Infer notebooks of #6599; this is the last one — Infer-19 #6607 merged, Infer-18 #6609 in flight).

See #3801 (SOTA axe-2), see #6599 (pattern C548-L2, now 3/3 done), see #6607 (Infer-19 twin, merged), see #6609 (Infer-18 twin).

## Verification

```
jupyter nbconvert --to notebook --execute Infer-17-Kalman-Filter.ipynb \
  --inplace --ExecutePreprocessor.timeout=240 --ExecutePreprocessor.kernel_name=.net-csharp
# EXIT=0 | 7/7 code cells ec non-null | 0 errors
# cell[8]: 1 Plotly display_data text/html (VRAI/OBS/FILT + error_y) + MSE metrics stream
```

Co-Authored-By: Claude-Code <noreply@anthropic.com>
