### PR TITLE
fix(sudoku,#3801): Sudoku-18 ASCII charts -> Plotly (Prong-A, C548-L2 zero-restore)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
@@ -58,13 +58,128 @@
    "id": "24a731fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:54.270334Z",
-     "iopub.status.busy": "2026-07-07T09:26:54.265637Z",
-     "iopub.status.idle": "2026-07-07T09:26:57.689161Z",
-     "shell.execute_reply": "2026-07-07T09:26:57.684651Z"
+     "iopub.execute_input": "2026-07-14T23:28:07.853658Z",
+     "iopub.status.busy": "2026-07-14T23:28:07.837479Z",
+     "iopub.status.idle": "2026-07-14T23:28:15.887052Z",
+     "shell.execute_reply": "2026-07-14T23:28:15.879356Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:44ae:ab2c:b59:638f:2048/\",\"http://2a01:e0a:9d4:f320:7153:b672:e4ea:ce97:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%13:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%21:2048/\",\"http://172.20.144.1:2048/\",\"http://fe80::4899:25d5:919d:5c8a%49:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '60856.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/html": [
@@ -85,7 +200,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  .NET 10.0.9\r\n"
+      "  .NET 10.0.10\r\n"
      ]
     },
     {
@@ -225,10 +340,10 @@
    "id": "00f6d107",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:57.691038Z",
-     "iopub.status.busy": "2026-07-07T09:26:57.690794Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.155295Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.155010Z"
+     "iopub.execute_input": "2026-07-14T23:28:15.889705Z",
+     "iopub.status.busy": "2026-07-14T23:28:15.889371Z",
+     "iopub.status.idle": "2026-07-14T23:28:16.999544Z",
+     "shell.execute_reply": "2026-07-14T23:28:16.998849Z"
     }
    },
    "outputs": [
@@ -400,10 +515,10 @@
    "id": "8da8f9e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.157022Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.156774Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.231022Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.230816Z"
+     "iopub.execute_input": "2026-07-14T23:28:17.003210Z",
+     "iopub.status.busy": "2026-07-14T23:28:17.002855Z",
+     "iopub.status.idle": "2026-07-14T23:28:17.143122Z",
+     "shell.execute_reply": "2026-07-14T23:28:17.142892Z"
     }
    },
    "outputs": [
@@ -411,7 +526,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtracking simple: resolu=True, 201 appels, 0.64 ms\r\n"
+      "Backtracking simple: resolu=True, 201 appels, 0.78 ms\r\n"
      ]
     }
    ],
@@ -510,10 +625,10 @@
    "id": "6b9322a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.232457Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.232240Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.357012Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.356788Z"
+     "iopub.execute_input": "2026-07-14T23:28:17.145442Z",
+     "iopub.status.busy": "2026-07-14T23:28:17.145157Z",
+     "iopub.status.idle": "2026-07-14T23:28:17.487375Z",
+     "shell.execute_reply": "2026-07-14T23:28:17.486094Z"
     }
    },
    "outputs": [
@@ -635,10 +750,10 @@
    "id": "8b60c557",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.358720Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.358474Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.530083Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.529922Z"
+     "iopub.execute_input": "2026-07-14T23:28:17.495059Z",
+     "iopub.status.busy": "2026-07-14T23:28:17.493538Z",
+     "iopub.status.idle": "2026-07-14T23:28:17.845258Z",
+     "shell.execute_reply": "2026-07-14T23:28:17.844609Z"
     }
    },
    "outputs": [
@@ -646,7 +761,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtracking MRV: resolu=True, 50 appels, 1.64 ms\r\n"
+      "Backtracking MRV: resolu=True, 50 appels, 3.52 ms\r\n"
      ]
     }
    ],
@@ -770,10 +885,10 @@
    "id": "9d2dcedb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.531739Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.531519Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.748416Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.747864Z"
+     "iopub.execute_input": "2026-07-14T23:28:17.849805Z",
+     "iopub.status.busy": "2026-07-14T23:28:17.849155Z",
+     "iopub.status.idle": "2026-07-14T23:28:18.477453Z",
+     "shell.execute_reply": "2026-07-14T23:28:18.477027Z"
     }
    },
    "outputs": [
@@ -781,7 +896,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Norvig: resolu=True, 1 appels, 4.55 ms\r\n"
+      "Norvig: resolu=True, 1 appels, 7.99 ms\r\n"
      ]
     }
    ],
@@ -951,10 +1066,10 @@
    "id": "1724f011",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.750077Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.749849Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.910207Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.909998Z"
+     "iopub.execute_input": "2026-07-14T23:28:18.480689Z",
+     "iopub.status.busy": "2026-07-14T23:28:18.480300Z",
+     "iopub.status.idle": "2026-07-14T23:28:18.837906Z",
+     "shell.execute_reply": "2026-07-14T23:28:18.837296Z"
     }
    },
    "outputs": [
@@ -962,7 +1077,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "OR-Tools CP-SAT: resolu=True, 67.01 ms\r\n"
+      "OR-Tools CP-SAT: resolu=True, 163.26 ms\r\n"
      ]
     }
    ],
@@ -1066,10 +1181,10 @@
    "id": "b756d9ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.911599Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.911378Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.975414Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.975020Z"
+     "iopub.execute_input": "2026-07-14T23:28:18.842247Z",
+     "iopub.status.busy": "2026-07-14T23:28:18.841511Z",
+     "iopub.status.idle": "2026-07-14T23:28:19.060588Z",
+     "shell.execute_reply": "2026-07-14T23:28:19.059869Z"
     }
    },
    "outputs": [
@@ -1139,10 +1254,10 @@
    "id": "b0ae1603",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.976974Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.976580Z",
-     "iopub.status.idle": "2026-07-07T09:26:59.090623Z",
-     "shell.execute_reply": "2026-07-07T09:26:59.090364Z"
+     "iopub.execute_input": "2026-07-14T23:28:19.065019Z",
+     "iopub.status.busy": "2026-07-14T23:28:19.064252Z",
+     "iopub.status.idle": "2026-07-14T23:28:19.401526Z",
+     "shell.execute_reply": "2026-07-14T23:28:19.400533Z"
     }
    },
    "outputs": [
@@ -1315,10 +1430,10 @@
    "id": "03ad4f8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:59.092198Z",
-     "iopub.status.busy": "2026-07-07T09:26:59.091979Z",
-     "iopub.status.idle": "2026-07-07T09:26:59.212706Z",
-     "shell.execute_reply": "2026-07-07T09:26:59.212370Z"
+     "iopub.execute_input": "2026-07-14T23:28:19.406233Z",
+     "iopub.status.busy": "2026-07-14T23:28:19.405494Z",
+     "iopub.status.idle": "2026-07-14T23:28:19.720697Z",
+     "shell.execute_reply": "2026-07-14T23:28:19.720165Z"
     }
    },
    "outputs": [
@@ -1381,10 +1496,10 @@
    "id": "9d2a4ec5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:59.214274Z",
-     "iopub.status.busy": "2026-07-07T09:26:59.214056Z",
-     "iopub.status.idle": "2026-07-07T09:26:59.316069Z",
-     "shell.execute_reply": "2026-07-07T09:26:59.315852Z"
+     "iopub.execute_input": "2026-07-14T23:28:19.724683Z",
+     "iopub.status.busy": "2026-07-14T23:28:19.723938Z",
+     "iopub.status.idle": "2026-07-14T23:28:20.169527Z",
+     "shell.execute_reply": "2026-07-14T23:28:20.168550Z"
     }
    },
    "outputs": [
@@ -1467,10 +1582,10 @@
    "id": "b8f463f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:59.317579Z",
-     "iopub.status.busy": "2026-07-07T09:26:59.317373Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.095076Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.094845Z"
+     "iopub.execute_input": "2026-07-14T23:28:20.174954Z",
+     "iopub.status.busy": "2026-07-14T23:28:20.173910Z",
+     "iopub.status.idle": "2026-07-14T23:28:28.996107Z",
+     "shell.execute_reply": "2026-07-14T23:28:28.995838Z"
     }
    },
    "outputs": [
@@ -1514,10 +1629,10 @@
    "id": "a2b96f5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.096580Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.096292Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.194452Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.193880Z"
+     "iopub.execute_input": "2026-07-14T23:28:28.998677Z",
+     "iopub.status.busy": "2026-07-14T23:28:28.998072Z",
+     "iopub.status.idle": "2026-07-14T23:28:29.153721Z",
+     "shell.execute_reply": "2026-07-14T23:28:29.152995Z"
     }
    },
    "outputs": [
@@ -1547,28 +1662,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Backtracking       |           0.72    1/1 |        3322.94    0/1 |         190.16    1/1 |          58.10    1/1\r\n"
+      "Backtracking       |           3.49    1/1 |        7832.46    0/1 |         386.11    1/1 |         115.71    1/1\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BT + MRV           |           1.89    1/1 |          15.19    1/1 |          69.14    1/1 |           9.91    1/1\r\n"
+      "BT + MRV           |           2.65    1/1 |          31.45    1/1 |         171.16    1/1 |          13.39    1/1\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Norvig             |           4.79    1/1 |           3.48    1/1 |           2.35    1/1 |           3.52    1/1\r\n"
+      "Norvig             |           3.68    1/1 |           4.43    1/1 |           3.16    1/1 |           4.24    1/1\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "OR-Tools CP-SAT    |           8.18    1/1 |          15.25    1/1 |          15.91    1/1 |          15.27    1/1\r\n"
+      "OR-Tools CP-SAT    |          12.63    1/1 |          37.19    1/1 |          15.51    1/1 |          32.04    1/1\r\n"
      ]
     },
     {
@@ -1583,28 +1698,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Backtracking      :   892.98 ms/puzzle, 3/4 resolus\r\n"
+      "  Backtracking      :  2084.44 ms/puzzle, 3/4 resolus\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  BT + MRV          :    24.03 ms/puzzle, 4/4 resolus\r\n"
+      "  BT + MRV          :    54.66 ms/puzzle, 4/4 resolus\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Norvig            :     3.53 ms/puzzle, 4/4 resolus\r\n"
+      "  Norvig            :     3.88 ms/puzzle, 4/4 resolus\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  OR-Tools CP-SAT   :    13.65 ms/puzzle, 4/4 resolus\r\n"
+      "  OR-Tools CP-SAT   :    24.34 ms/puzzle, 4/4 resolus\r\n"
      ]
     }
    ],
@@ -1669,10 +1784,10 @@
    "id": "d3a1fe6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.195980Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.195747Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.235913Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.235482Z"
+     "iopub.execute_input": "2026-07-14T23:28:29.156511Z",
+     "iopub.status.busy": "2026-07-14T23:28:29.156107Z",
+     "iopub.status.idle": "2026-07-14T23:28:29.231287Z",
+     "shell.execute_reply": "2026-07-14T23:28:29.230931Z"
     }
    },
    "outputs": [],
@@ -1724,10 +1839,10 @@
    "id": "dc4ecdb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.238228Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.237839Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.310457Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.306369Z"
+     "iopub.execute_input": "2026-07-14T23:28:29.235124Z",
+     "iopub.status.busy": "2026-07-14T23:28:29.234404Z",
+     "iopub.status.idle": "2026-07-14T23:28:29.516498Z",
+     "shell.execute_reply": "2026-07-14T23:28:29.515496Z"
     }
    },
    "outputs": [
@@ -1735,179 +1850,55 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Benchmark : temps moyen (ms) - echelle log10 (1 '#' ~= 0.2 unite log)\r\n"
+      "Temps moyen (ms) par solveur et difficulte (axe Y log) :\r\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Easy]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ####      0.72 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ######      1.89 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ########      4.79 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ##########      8.18 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Medium]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         #######################   3322.94 ms  [0/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ###########     15.19 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ########      3.48 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     15.25 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Hard]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ################    190.16 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ##############     69.14 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               #######      2.35 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     15.91 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Expert]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ##############     58.10 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ##########      9.91 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ########      3.52 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     15.27 ms  [1/1]\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plt8cd77732030a467a8e84b74d823702eb\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt8cd77732030a467a8e84b74d823702eb',[{\"name\":\"Backtracking\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[3.4936,7832.4649,386.1074,115.7051],\"type\":\"bar\"},{\"name\":\"BT \\u002B MRV\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[2.6486,31.4504,171.159,13.3853],\"type\":\"bar\"},{\"name\":\"Norvig\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[3.6828,4.4299,3.1616,4.2355],\"type\":\"bar\"},{\"name\":\"OR-Tools CP-SAT\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[12.6267,37.1923,15.5138,32.0437],\"type\":\"bar\"}],{\"title\":{\"text\":\"Benchmark : temps moyen (ms) par difficulte et solveur\"},\"barmode\":\"group\",\"xaxis\":{\"title\":{\"text\":\"Difficulte\"}},\"yaxis\":{\"title\":{\"text\":\"Temps moyen (ms)\"},\"type\":\"log\"}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "// Graphique en barres groupees (rendu ASCII) : temps moyen par difficulte et solveur.\n",
-    "public static void PlotBenchmarkBarsAscii(Dictionary<string, Dictionary<string, BenchResult>> results)\n",
+    "// Graphique en barres groupees (rendu Plotly) : temps moyen par difficulte et solveur.\n",
+    "// Technique C548-L2 : formatter HTML integre au kernel (Microsoft.DotNet.Interactive.Formatting),\n",
+    "// evite `#r \"nuget:\"` sur une charting-lib (restore lent / pin vieille beta Microsoft.DotNet.Interactive).\n",
+    "// Rendu Plotly.js brut, zero dependence NuGet cote charting.\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
+    "// Barres groupees : une trace par solveur, x = difficultes, y = temps moyen (ms), axe Y log.\n",
+    "// L'echelle logarithmique (deja dans le rendu ASCII original) rend compte des ecarts d'ordres de grandeur.\n",
+    "static void PlotBenchmarkBarsPlotly(Dictionary<string, Dictionary<string, BenchResult>> results, string title)\n",
     "{\n",
     "    var diffs = new[] { \"Easy\", \"Medium\", \"Hard\", \"Expert\" };\n",
-    "    Console.WriteLine(\"Benchmark : temps moyen (ms) - echelle log10 (1 '#' ~= 0.2 unite log)\");\n",
-    "    foreach (var d in diffs)\n",
+    "    var traces = results.Keys.Select(name =>\n",
     "    {\n",
-    "        Console.WriteLine($\"\\n[{d}]\");\n",
-    "        foreach (var name in results.Keys)\n",
-    "        {\n",
-    "            double t = results[name][d].TimeAvgMs;\n",
-    "            int bars = 1;\n",
-    "            if (t > 0)\n",
-    "            {\n",
-    "                double lg = Math.Log10(t + 1e-9);\n",
-    "                bars = (int)Math.Round(Math.Max(0, lg + 1) * 5);\n",
-    "                bars = Math.Min(40, Math.Max(1, bars));\n",
-    "            }\n",
-    "            Console.WriteLine($\"  {name,-20} {new string('#', bars)} {t,9:F2} ms  [{results[name][d].Solved}/{results[name][d].Count}]\");\n",
-    "        }\n",
-    "    }\n",
+    "        var ys = diffs.Select(d => results[name][d].TimeAvgMs).ToArray();\n",
+    "        return System.Text.Json.JsonSerializer.Serialize(\n",
+    "            new Dictionary<string, object> { [\"name\"] = name, [\"x\"] = diffs, [\"y\"] = ys,\n",
+    "                                             [\"type\"] = \"bar\" });\n",
+    "    });\n",
+    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var layout = \"{\\\"title\\\":{\\\"text\\\":\" + System.Text.Json.JsonSerializer.Serialize(title) + \"},\" +\n",
+    "                 \"\\\"barmode\\\":\\\"group\\\",\" +\n",
+    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Difficulte\\\"}},\" +\n",
+    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Temps moyen (ms)\\\"},\\\"type\\\":\\\"log\\\"}}\";\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + string.Join(\",\", traces) + \"],\" + layout + \")</script>\";\n",
+    "    Console.WriteLine(\"Temps moyen (ms) par solveur et difficulte (axe Y log) :\");\n",
+    "    display(new PlotlyHtml(markup));\n",
     "}\n",
     "\n",
-    "PlotBenchmarkBarsAscii(results);\n"
+    "PlotBenchmarkBarsPlotly(results, \"Benchmark : temps moyen (ms) par difficulte et solveur\");\n"
    ]
   },
   {
@@ -1944,10 +1935,10 @@
    "id": "89517112",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.312208Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.311973Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.458058Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.453025Z"
+     "iopub.execute_input": "2026-07-14T23:28:29.519499Z",
+     "iopub.status.busy": "2026-07-14T23:28:29.519110Z",
+     "iopub.status.idle": "2026-07-14T23:28:29.679578Z",
+     "shell.execute_reply": "2026-07-14T23:28:29.678845Z"
     }
    },
    "outputs": [
@@ -1955,171 +1946,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "=== Distribution - Easy (min | mediane | max, ms) ===\r\n"
+      "Distribution des temps (boite = Q1..Q3, moustaches = min/max) :\r\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         [-|-]      0.72 |     0.72 |     0.72\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             [-|-]      1.89 |     1.89 |     1.89\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               [-|-]      4.79 |     4.79 |     4.79\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      [-|-]      8.18 |     8.18 |     8.18\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Distribution - Medium (min | mediane | max, ms) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         [-|-]   3322.94 |  3322.94 |  3322.94\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             [-|-]     15.19 |    15.19 |    15.19\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               [-|-]      3.48 |     3.48 |     3.48\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      [-|-]     15.25 |    15.25 |    15.25\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Distribution - Hard (min | mediane | max, ms) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         [-|-]    190.16 |   190.16 |   190.16\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             [-|-]     69.14 |    69.14 |    69.14\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               [-|-]      2.35 |     2.35 |     2.35\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      [-|-]     15.91 |    15.91 |    15.91\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Distribution - Expert (min | mediane | max, ms) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         [-|-]     58.10 |    58.10 |    58.10\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             [-|-]      9.91 |     9.91 |     9.91\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               [-|-]      3.52 |     3.52 |     3.52\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      [-|-]     15.27 |    15.27 |    15.27\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plt2790ffe9c7824c2bb0aa7cba74a9f670\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt2790ffe9c7824c2bb0aa7cba74a9f670',[{\"name\":\"Backtracking\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[3.4936,7832.4649,386.1074,115.7051],\"type\":\"box\"},{\"name\":\"BT \\u002B MRV\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[2.6486,31.4504,171.159,13.3853],\"type\":\"box\"},{\"name\":\"Norvig\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[3.6828,4.4299,3.1616,4.2355],\"type\":\"box\"},{\"name\":\"OR-Tools CP-SAT\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[12.6267,37.1923,15.5138,32.0437],\"type\":\"box\"}],{\"title\":{\"text\":\"Distribution des temps de resolution (ms)\"},\"boxmode\":\"group\",\"xaxis\":{\"title\":{\"text\":\"Difficulte\"}},\"yaxis\":{\"title\":{\"text\":\"Temps (ms)\"},\"type\":\"log\"}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "// Boxplots ASCII de la distribution des temps pour chaque solveur.\n",
-    "public static void PlotBoxplotsAscii(Dictionary<string, Dictionary<string, BenchResult>> results)\n",
+    "// Boxplots (rendu Plotly) de la distribution des temps pour chaque solveur, par difficulte.\n",
+    "// Une boite par solveur ; x = difficulte (un point par timing), y = temps (ms), axe Y log.\n",
+    "static void PlotBoxplotsPlotly(Dictionary<string, Dictionary<string, BenchResult>> results)\n",
     "{\n",
     "    var diffs = new[] { \"Easy\", \"Medium\", \"Hard\", \"Expert\" };\n",
-    "    foreach (var d in diffs)\n",
+    "    var traces = results.Keys.Select(name =>\n",
     "    {\n",
-    "        Console.WriteLine($\"\\n=== Distribution - {d} (min | mediane | max, ms) ===\");\n",
-    "        foreach (var name in results.Keys)\n",
-    "        {\n",
-    "            var ts = results[name][d].TimesMs;\n",
-    "            if (ts.Count == 0) { Console.WriteLine($\"  {name,-20} (no data)\"); continue; }\n",
-    "            var sorted = ts.OrderBy(x => x).ToList();\n",
-    "            double mn = sorted[0], mx = sorted[^1];\n",
-    "            double med = sorted[sorted.Count / 2];\n",
-    "            int span = (int)Math.Round(Math.Max(1, (Math.Log10(mx + 1e-9) - Math.Log10(mn + 1e-9)) * 8));\n",
-    "            string bar = \"[\" + new string('-', Math.Max(1, span / 3)) + \"|\"\n",
-    "                         + new string('-', Math.Max(1, span * 2 / 3)) + \"]\";\n",
-    "            Console.WriteLine($\"  {name,-20} {bar}  {mn,8:F2} | {med,8:F2} | {mx,8:F2}\");\n",
-    "        }\n",
-    "    }\n",
+    "        var xs = new List<string>();\n",
+    "        var ys = new List<double>();\n",
+    "        foreach (var d in diffs)\n",
+    "            foreach (var t in results[name][d].TimesMs) { xs.Add(d); ys.Add(t); }\n",
+    "        return System.Text.Json.JsonSerializer.Serialize(\n",
+    "            new Dictionary<string, object> { [\"name\"] = name, [\"x\"] = xs, [\"y\"] = ys, [\"type\"] = \"box\" });\n",
+    "    });\n",
+    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Distribution des temps de resolution (ms)\\\"},\" +\n",
+    "                 \"\\\"boxmode\\\":\\\"group\\\",\" +\n",
+    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Difficulte\\\"}},\" +\n",
+    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Temps (ms)\\\"},\\\"type\\\":\\\"log\\\"}}\";\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + string.Join(\",\", traces) + \"],\" + layout + \")</script>\";\n",
+    "    Console.WriteLine(\"Distribution des temps (boite = Q1..Q3, moustaches = min/max) :\");\n",
+    "    display(new PlotlyHtml(markup));\n",
     "}\n",
     "\n",
-    "PlotBoxplotsAscii(results);\n"
+    "PlotBoxplotsPlotly(results);\n"
    ]
   },
   {
@@ -2186,10 +2053,10 @@
    "id": "4864eb97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.460356Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.460087Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.594391Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.593761Z"
+     "iopub.execute_input": "2026-07-14T23:28:29.683104Z",
+     "iopub.status.busy": "2026-07-14T23:28:29.682341Z",
+     "iopub.status.idle": "2026-07-14T23:28:29.828858Z",
+     "shell.execute_reply": "2026-07-14T23:28:29.828533Z"
     }
    },
    "outputs": [
@@ -2197,7 +2064,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Norvig + Forward Checking: resolu=True, 1 appels, 0 coupes FC, 3.32 ms\r\n"
+      "Norvig + Forward Checking: resolu=True, 1 appels, 0 coupes FC, 2.81 ms\r\n"
      ]
     }
    ],
@@ -2287,10 +2154,10 @@
    "id": "80d91159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.597046Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.596418Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.748566Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.748382Z"
+     "iopub.execute_input": "2026-07-14T23:28:29.831572Z",
+     "iopub.status.busy": "2026-07-14T23:28:29.831167Z",
+     "iopub.status.idle": "2026-07-14T23:28:30.124915Z",
+     "shell.execute_reply": "2026-07-14T23:28:30.124421Z"
     }
    },
    "outputs": [
@@ -2298,7 +2165,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Simulated Annealing: resolu=True, 1275 iterations, 212 acceptees, 9.12 ms\r\n"
+      "Simulated Annealing: resolu=True, 1275 iterations, 212 acceptees, 20.95 ms\r\n"
      ]
     }
    ],
@@ -2460,10 +2327,10 @@
    "id": "8642cf81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.750610Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.750229Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.810165Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.809578Z"
+     "iopub.execute_input": "2026-07-14T23:28:30.127253Z",
+     "iopub.status.busy": "2026-07-14T23:28:30.126889Z",
+     "iopub.status.idle": "2026-07-14T23:28:30.325941Z",
+     "shell.execute_reply": "2026-07-14T23:28:30.325545Z"
     }
    },
    "outputs": [
@@ -2506,10 +2373,10 @@
    "id": "e692ea3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.812330Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.811815Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.021654Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.021358Z"
+     "iopub.execute_input": "2026-07-14T23:28:30.329319Z",
+     "iopub.status.busy": "2026-07-14T23:28:30.328651Z",
+     "iopub.status.idle": "2026-07-14T23:28:48.230139Z",
+     "shell.execute_reply": "2026-07-14T23:28:48.229704Z"
     }
    },
    "outputs": [
@@ -2551,10 +2418,10 @@
    "id": "a091a298",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.023534Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.023178Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.066840Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.058747Z"
+     "iopub.execute_input": "2026-07-14T23:28:48.233719Z",
+     "iopub.status.busy": "2026-07-14T23:28:48.233028Z",
+     "iopub.status.idle": "2026-07-14T23:28:48.289860Z",
+     "shell.execute_reply": "2026-07-14T23:28:48.289590Z"
     }
    },
    "outputs": [
@@ -2562,208 +2429,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Benchmark : temps moyen (ms) - echelle log10 (1 '#' ~= 0.2 unite log)\r\n"
+      "Temps moyen (ms) par solveur et difficulte (axe Y log) :\r\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Easy]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ##      0.28 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ####      0.75 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ######      1.67 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     15.37 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig + FC          ######      1.69 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Simulated Annealing  ##########      8.90 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Medium]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         #######################   3639.56 ms  [0/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             #############     48.36 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               #######      2.47 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     16.01 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig + FC          ######      1.84 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Simulated Annealing  ######################   3000.35 ms  [0/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Hard]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         #################    225.28 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ##############     72.60 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ######      1.81 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     17.16 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig + FC          #####      1.14 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Simulated Annealing  ######################   3000.10 ms  [0/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Expert]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ##############     66.97 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             #########      7.35 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               #######      2.19 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     16.03 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig + FC          ######      1.40 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Simulated Annealing  ######################   3000.34 ms  [0/1]\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plt3a6a72ec861b489d92b26a0434766c7e\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt3a6a72ec861b489d92b26a0434766c7e',[{\"name\":\"Backtracking\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[0.3442,7814.165,431.8713,149.2263],\"type\":\"bar\"},{\"name\":\"BT \\u002B MRV\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[1.4592,17.6287,153.6973,33.444],\"type\":\"bar\"},{\"name\":\"Norvig\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[6.3333,6.9867,4.7064,5.8296],\"type\":\"bar\"},{\"name\":\"OR-Tools CP-SAT\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[29.5115,44.7413,32.1908,30.9639],\"type\":\"bar\"},{\"name\":\"Norvig \\u002B FC\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[4.1007,6.043,3.809,4.3287],\"type\":\"bar\"},{\"name\":\"Simulated Annealing\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[20.0105,3000.139,3000.1708,3000.1319],\"type\":\"bar\"}],{\"title\":{\"text\":\"Benchmark etendu : Norvig\\u002BFC \\u002B recuit simule (Prong B #3801)\"},\"barmode\":\"group\",\"xaxis\":{\"title\":{\"text\":\"Difficulte\"}},\"yaxis\":{\"title\":{\"text\":\"Temps moyen (ms)\"},\"type\":\"log\"}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -2775,8 +2451,8 @@
     }
    ],
    "source": [
-    "// Graphique etendu (ASCII) : Norvig+FC + Simulated Annealing (Prong B #3801)\n",
-    "PlotBenchmarkBarsAscii(resultsExtended);\n",
+    "// Graphique etendu (Plotly) : Norvig+FC + Simulated Annealing (Prong B #3801)\n",
+    "PlotBenchmarkBarsPlotly(resultsExtended, \"Benchmark etendu : Norvig+FC + recuit simule (Prong B #3801)\");\n",
     "Console.WriteLine(\"\\n(Prong B #3801 : le recuit simule n'a aucune garantie de convergence)\");\n"
    ]
   },
@@ -2859,10 +2535,10 @@
    "id": "7c230215",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.068695Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.068450Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.101209Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.100905Z"
+     "iopub.execute_input": "2026-07-14T23:28:48.292586Z",
+     "iopub.status.busy": "2026-07-14T23:28:48.292120Z",
+     "iopub.status.idle": "2026-07-14T23:28:48.354345Z",
+     "shell.execute_reply": "2026-07-14T23:28:48.353799Z"
     }
    },
    "outputs": [
@@ -2914,10 +2590,10 @@
    "id": "7af6d43b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.102648Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.102430Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.138789Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.138200Z"
+     "iopub.execute_input": "2026-07-14T23:28:48.356946Z",
+     "iopub.status.busy": "2026-07-14T23:28:48.356584Z",
+     "iopub.status.idle": "2026-07-14T23:28:48.411112Z",
+     "shell.execute_reply": "2026-07-14T23:28:48.411575Z"
     }
    },
    "outputs": [
@@ -2962,10 +2638,10 @@
    "id": "461a17c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.140255Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.139888Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.199781Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.199384Z"
+     "iopub.execute_input": "2026-07-14T23:28:48.415163Z",
+     "iopub.status.busy": "2026-07-14T23:28:48.414351Z",
+     "iopub.status.idle": "2026-07-14T23:28:48.496330Z",
+     "shell.execute_reply": "2026-07-14T23:28:48.495827Z"
     }
    },
    "outputs": [
@@ -3027,10 +2703,10 @@
    "id": "2d0e1768",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.201467Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.201248Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.234510Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.234040Z"
+     "iopub.execute_input": "2026-07-14T23:28:48.498611Z",
+     "iopub.status.busy": "2026-07-14T23:28:48.498347Z",
+     "iopub.status.idle": "2026-07-14T23:28:48.543119Z",
+     "shell.execute_reply": "2026-07-14T23:28:48.542684Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

Resolves the **SOTA Prong-A degradation** in `Sudoku-18-Comparison-Csharp.ipynb`: 3 chart cells rendered benchmark results as ASCII-art (`########`, `[---|---]`) instead of real plotting. Replaced with real **Plotly.js** rendering.

Addresses ai-01's `[DISPATCH→inbox / BELL]` (2026-07-14T23:06Z): the .NET-chart C547-L1 blocker is solved by po-2024's **C548-L2 zero-restore technique** (kernel-builtin `Formatter.Register`, no `#r "nuget:"` for the charting lib).

## Cells changed (3, surgical — C.3 verified)

| Cell | id | Before | After |
|------|----|--------|-------|
| cell[39] | `dc4ecdb4` | `PlotBenchmarkBarsAscii` (`#` log10 bars) | `PlotBenchmarkBarsPlotly` grouped bars (solver × difficulty, **log Y**), + `PlotlyHtml` formatter registration |
| cell[42] | `89517112` | `PlotBoxplotsAscii` (`[---|---]`) | `PlotBoxplotsPlotly` boxplots (per-solver distribution, **log Y**) |
| cell[55] | `a091a298` | `PlotBenchmarkBarsAscii(resultsExtended)` | `PlotBenchmarkBarsPlotly(resultsExtended)` (Norvig+FC + Simulated Annealing) |

Per-cell source diff confirmed: **exactly 3 cells changed source** (no other source edits). The rest of the diff is execution-metadata timestamps + regenerated outputs from the full re-exec (legitimate per C.2, since I modified source cells).

## Technique — C548-L2 (cluster-wide, matches po-2024 #6607 Infer-19)

```csharp
using Microsoft.DotNet.Interactive.Formatting;
record PlotlyHtml(string Markup);
Formatter.Register(typeof(PlotlyHtml),
    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), "text/html");
```
Emits raw Plotly.js (hand-built `Plotly.newPlot` JSON via `System.Text.Json`). **Avoids `#r "nuget: XPlot.Plotly.Interactive"`** — which pins an old beta of `Microsoft.DotNet.Interactive` and times out the restore (the exact issue #6596 flagged). The solver's `#r "nuget: Google.OrTools"` (cell[2]) stays — it's the real CP-SAT engine, and it now restores fast (see below).

## Verdict SOTA: SOTA-OK (real chart rendering, real data)

Real Plotly output verified with **real benchmark data**:
- **Grouped bars (cell[39])**: 4 solver traces × 4 difficulties. e.g. Backtracking `[3.49, 7832.46, 386.11, 115.71]` ms (Medium = slow peak, the discrimination point cell[40] teaches), Norvig `[3.68, 4.43, 3.16, 4.24]` (fast/flat), OR-Tools CP-SAT `[12.63, 37.19, 15.51, 32.04]`.
- **Boxplots (cell[42])**: 4 solver traces, log Y. Note: the benchmark uses `maxPuzzles=1` per difficulty, so each (solver,difficulty) box has 1 sample — a **pre-existing data limitation** (the ASCII original rendered the same single-sample data), faithfully represented, not a regression.
- **Extended bars (cell[55])**: 6 traces including Norvig+FC + Simulated Annealing (Prong-B #3801).

## Execution proof (C.2 / H.1 / H.3)

- **Re-exec PROVED end-to-end**: `jupyter nbconvert --to notebook --execute --inplace` via `.net-csharp` kernel, **53s, EXIT=0**.
- **0 errors** across all 68 cells (25 code).
- **0 null-exec code cells** (all `execution_count != null`).
- **C.1 clean**: 0 `NotImplementedError`/`assert False`/`1/0`/`throw NotImplementedException`.
- **RECOVERABLE-MACHINE blocker RESOLVED**: #6596 documented the OrTools `#r "nuget:"` restore as >10min headless (c.477) → not cron-feasible on po-2023. **Firsthand re-probe today**: cached `Google.OrTools` (9.11/9.15) restores in **28s**, full notebook re-exec **53s**. The wall was a flaky instance; the env is now ready.

## Closes #6596

The issue's title-scoped deliverable (Sudoku-18 ASCII charts → real plotting) is **fully resolved**. The Prong-B **Sudoku-14 BDD/MDD borderline** mentioned in #6596's body is a separate coordinator-decision item (not a worker deliverable) — **not in scope** here.

See #3801 (SOTA EPIC, axe-2 Prong-A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)