### PR TITLE
fix(sudoku,#6596,#3801): Sudoku-18 ASCII benchmark charts -> Plotly (zero-restore C548-L2)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
@@ -58,10 +58,10 @@
    "id": "24a731fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:54.270334Z",
-     "iopub.status.busy": "2026-07-07T09:26:54.265637Z",
-     "iopub.status.idle": "2026-07-07T09:26:57.689161Z",
-     "shell.execute_reply": "2026-07-07T09:26:57.684651Z"
+     "iopub.execute_input": "2026-07-14T23:38:14.250088Z",
+     "iopub.status.busy": "2026-07-14T23:38:14.241704Z",
+     "iopub.status.idle": "2026-07-14T23:38:20.144915Z",
+     "shell.execute_reply": "2026-07-14T23:38:20.138221Z"
     }
    },
    "outputs": [
@@ -131,19 +131,12 @@
     "\n",
     "**Bibliotheques utilisees** :\n",
     "\n",
-    "| Bibliotheque | Version | Role dans ce notebook |\n",
-    "|-------------|---------|----------------------|\n",
-    "| numpy | 2.4.2 | Calculs numeriques, statistiques (medianne, moyennes) |\n",
-    "| matplotlib | - | Visualisations (barres, boxplots, radar) |\n",
-    "| ortools | - | Solveur CP-SAT industriel (4e solveur du benchmark) |\n",
-    "| time | - | Mesure des temps d'execution |\n",
+    "| Bibliotheque | Role dans ce notebook |\n",
+    "|-------------|----------------------|\n",
+    "| Google.OrTools | Solveur CP-SAT industriel (vrai moteur, meme que le twin Python) |\n",
+    "| Plotly.js (via formatter kernel) | Visualisations : barres groupees, boxplots (zero-restore C548-L2) |\n",
     "\n",
-    "**Pourquoi ces choix** :\n",
-    "- **OR-Tools CP-SAT** est le seul solveur externe necessaire. Les trois autres solveurs sont implementes en Python pur pour illustrer les algorithmes\n",
-    "- **numpy** est utilise pour les statistiques du benchmark (medianne des temps)\n",
-    "- **matplotlib** genere les graphiques comparatifs (barres, boxplots, radar)\n",
-    "\n",
-    "> **Note** : Aucune dependance lourde (pas de tensorflow, pytorch, etc.). Ce notebook reste leger et s'execute sur n'importe quel environnement Python standard."
+    "> Le twin Python (`Sudoku-18-Comparison-Python.ipynb`) produit les memes graphiques avec `matplotlib`."
    ]
   },
   {
@@ -225,10 +218,10 @@
    "id": "00f6d107",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:57.691038Z",
-     "iopub.status.busy": "2026-07-07T09:26:57.690794Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.155295Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.155010Z"
+     "iopub.execute_input": "2026-07-14T23:38:20.147293Z",
+     "iopub.status.busy": "2026-07-14T23:38:20.146970Z",
+     "iopub.status.idle": "2026-07-14T23:38:20.780828Z",
+     "shell.execute_reply": "2026-07-14T23:38:20.780271Z"
     }
    },
    "outputs": [
@@ -400,10 +393,10 @@
    "id": "8da8f9e7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.157022Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.156774Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.231022Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.230816Z"
+     "iopub.execute_input": "2026-07-14T23:38:20.782896Z",
+     "iopub.status.busy": "2026-07-14T23:38:20.782604Z",
+     "iopub.status.idle": "2026-07-14T23:38:20.876754Z",
+     "shell.execute_reply": "2026-07-14T23:38:20.876446Z"
     }
    },
    "outputs": [
@@ -510,10 +503,10 @@
    "id": "6b9322a1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.232457Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.232240Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.357012Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.356788Z"
+     "iopub.execute_input": "2026-07-14T23:38:20.879172Z",
+     "iopub.status.busy": "2026-07-14T23:38:20.878854Z",
+     "iopub.status.idle": "2026-07-14T23:38:21.052855Z",
+     "shell.execute_reply": "2026-07-14T23:38:21.052571Z"
     }
    },
    "outputs": [
@@ -635,10 +628,10 @@
    "id": "8b60c557",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.358720Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.358474Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.530083Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.529922Z"
+     "iopub.execute_input": "2026-07-14T23:38:21.055093Z",
+     "iopub.status.busy": "2026-07-14T23:38:21.054748Z",
+     "iopub.status.idle": "2026-07-14T23:38:21.290412Z",
+     "shell.execute_reply": "2026-07-14T23:38:21.289964Z"
     }
    },
    "outputs": [
@@ -770,10 +763,10 @@
    "id": "9d2dcedb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.531739Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.531519Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.748416Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.747864Z"
+     "iopub.execute_input": "2026-07-14T23:38:21.293670Z",
+     "iopub.status.busy": "2026-07-14T23:38:21.293119Z",
+     "iopub.status.idle": "2026-07-14T23:38:21.673511Z",
+     "shell.execute_reply": "2026-07-14T23:38:21.673206Z"
     }
    },
    "outputs": [
@@ -951,10 +944,10 @@
    "id": "1724f011",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.750077Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.749849Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.910207Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.909998Z"
+     "iopub.execute_input": "2026-07-14T23:38:21.675659Z",
+     "iopub.status.busy": "2026-07-14T23:38:21.675357Z",
+     "iopub.status.idle": "2026-07-14T23:38:21.889444Z",
+     "shell.execute_reply": "2026-07-14T23:38:21.889147Z"
     }
    },
    "outputs": [
@@ -1066,10 +1059,10 @@
    "id": "b756d9ab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.911599Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.911378Z",
-     "iopub.status.idle": "2026-07-07T09:26:58.975414Z",
-     "shell.execute_reply": "2026-07-07T09:26:58.975020Z"
+     "iopub.execute_input": "2026-07-14T23:38:21.891503Z",
+     "iopub.status.busy": "2026-07-14T23:38:21.891214Z",
+     "iopub.status.idle": "2026-07-14T23:38:21.991767Z",
+     "shell.execute_reply": "2026-07-14T23:38:21.991421Z"
     }
    },
    "outputs": [
@@ -1139,10 +1132,10 @@
    "id": "b0ae1603",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:58.976974Z",
-     "iopub.status.busy": "2026-07-07T09:26:58.976580Z",
-     "iopub.status.idle": "2026-07-07T09:26:59.090623Z",
-     "shell.execute_reply": "2026-07-07T09:26:59.090364Z"
+     "iopub.execute_input": "2026-07-14T23:38:21.993793Z",
+     "iopub.status.busy": "2026-07-14T23:38:21.993492Z",
+     "iopub.status.idle": "2026-07-14T23:38:22.130025Z",
+     "shell.execute_reply": "2026-07-14T23:38:22.129774Z"
     }
    },
    "outputs": [
@@ -1315,10 +1308,10 @@
    "id": "03ad4f8a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:59.092198Z",
-     "iopub.status.busy": "2026-07-07T09:26:59.091979Z",
-     "iopub.status.idle": "2026-07-07T09:26:59.212706Z",
-     "shell.execute_reply": "2026-07-07T09:26:59.212370Z"
+     "iopub.execute_input": "2026-07-14T23:38:22.131895Z",
+     "iopub.status.busy": "2026-07-14T23:38:22.131610Z",
+     "iopub.status.idle": "2026-07-14T23:38:22.298271Z",
+     "shell.execute_reply": "2026-07-14T23:38:22.298007Z"
     }
    },
    "outputs": [
@@ -1381,10 +1374,10 @@
    "id": "9d2a4ec5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:59.214274Z",
-     "iopub.status.busy": "2026-07-07T09:26:59.214056Z",
-     "iopub.status.idle": "2026-07-07T09:26:59.316069Z",
-     "shell.execute_reply": "2026-07-07T09:26:59.315852Z"
+     "iopub.execute_input": "2026-07-14T23:38:22.300221Z",
+     "iopub.status.busy": "2026-07-14T23:38:22.299936Z",
+     "iopub.status.idle": "2026-07-14T23:38:22.446921Z",
+     "shell.execute_reply": "2026-07-14T23:38:22.446605Z"
     }
    },
    "outputs": [
@@ -1467,10 +1460,10 @@
    "id": "b8f463f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:26:59.317579Z",
-     "iopub.status.busy": "2026-07-07T09:26:59.317373Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.095076Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.094845Z"
+     "iopub.execute_input": "2026-07-14T23:38:22.448663Z",
+     "iopub.status.busy": "2026-07-14T23:38:22.448374Z",
+     "iopub.status.idle": "2026-07-14T23:38:28.470363Z",
+     "shell.execute_reply": "2026-07-14T23:38:28.470046Z"
     }
    },
    "outputs": [
@@ -1514,10 +1507,10 @@
    "id": "a2b96f5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.096580Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.096292Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.194452Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.193880Z"
+     "iopub.execute_input": "2026-07-14T23:38:28.472533Z",
+     "iopub.status.busy": "2026-07-14T23:38:28.472226Z",
+     "iopub.status.idle": "2026-07-14T23:38:28.586531Z",
+     "shell.execute_reply": "2026-07-14T23:38:28.586233Z"
     }
    },
    "outputs": [
@@ -1669,10 +1662,10 @@
    "id": "d3a1fe6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.195980Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.195747Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.235913Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.235482Z"
+     "iopub.execute_input": "2026-07-14T23:38:28.588418Z",
+     "iopub.status.busy": "2026-07-14T23:38:28.588120Z",
+     "iopub.status.idle": "2026-07-14T23:38:28.637274Z",
+     "shell.execute_reply": "2026-07-14T23:38:28.636961Z"
     }
    },
    "outputs": [],
@@ -1724,190 +1717,67 @@
    "id": "dc4ecdb4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.238228Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.237839Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.310457Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.306369Z"
+     "iopub.execute_input": "2026-07-14T23:38:28.639428Z",
+     "iopub.status.busy": "2026-07-14T23:38:28.639111Z",
+     "iopub.status.idle": "2026-07-14T23:38:28.816888Z",
+     "shell.execute_reply": "2026-07-14T23:38:28.816626Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Benchmark : temps moyen (ms) - echelle log10 (1 '#' ~= 0.2 unite log)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Easy]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ####      0.72 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ######      1.89 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ########      4.79 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ##########      8.18 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Medium]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         #######################   3322.94 ms  [0/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ###########     15.19 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ########      3.48 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     15.25 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Hard]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ################    190.16 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ##############     69.14 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               #######      2.35 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     15.91 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Expert]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ##############     58.10 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ##########      9.91 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ########      3.52 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     15.27 ms  [1/1]\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"bars64faea80924d4085b8a1a9f4cc7a96d7\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('bars64faea80924d4085b8a1a9f4cc7a96d7',[{\"name\":\"Backtracking\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[1.1497,5344.4039,312.4795,94.6131],\"type\":\"bar\",\"marker\":{\"color\":\"#2c3e50\"}},{\"name\":\"BT \\u002B MRV\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[1.696,20.9271,107.5862,10.3472],\"type\":\"bar\",\"marker\":{\"color\":\"#2980b9\"}},{\"name\":\"Norvig\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[3.5499,2.7467,2.023,2.4348],\"type\":\"bar\",\"marker\":{\"color\":\"#27ae60\"}},{\"name\":\"OR-Tools CP-SAT\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[19.4363,15.7861,16.3763,14.9413],\"type\":\"bar\",\"marker\":{\"color\":\"#c0392b\"}}],{\"title\":{\"text\":\"Benchmark : temps moyen (ms) par solveur et difficulte\"},\"xaxis\":{\"title\":{\"text\":\"Difficulte\"}},\"yaxis\":{\"title\":{\"text\":\"Temps moyen (ms)\"},\"type\":\"log\"},\"barmode\":\"group\"})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "// Graphique en barres groupees (rendu ASCII) : temps moyen par difficulte et solveur.\n",
-    "public static void PlotBenchmarkBarsAscii(Dictionary<string, Dictionary<string, BenchResult>> results)\n",
+    "// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.\n",
+    "// Zero-restore (C548-L2, #3801) : on evite `#r \"nuget:\"` sur une charting-lib.\n",
+    "// XPlot.Plotly.Interactive / Plotly.NET pinent une vieille beta de Microsoft.DotNet.Interactive\n",
+    "// et font timeout le restore (cluster-wide, C547-L1). Le formatter emet du HTML Plotly brut.\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
+    "// Graphique en barres groupees : temps moyen par difficulte et solveur (rendu Plotly).\n",
+    "public static void PlotBenchmarkBars(Dictionary<string, Dictionary<string, BenchResult>> results)\n",
     "{\n",
     "    var diffs = new[] { \"Easy\", \"Medium\", \"Hard\", \"Expert\" };\n",
-    "    Console.WriteLine(\"Benchmark : temps moyen (ms) - echelle log10 (1 '#' ~= 0.2 unite log)\");\n",
-    "    foreach (var d in diffs)\n",
+    "    var solvers = results.Keys.ToList();\n",
+    "    var palette = new[] { \"#2c3e50\", \"#2980b9\", \"#27ae60\", \"#c0392b\", \"#8e44ad\", \"#d35400\" };\n",
+    "    var traces = new List<string>();\n",
+    "    for (int si = 0; si < solvers.Count; si++)\n",
     "    {\n",
-    "        Console.WriteLine($\"\\n[{d}]\");\n",
-    "        foreach (var name in results.Keys)\n",
-    "        {\n",
-    "            double t = results[name][d].TimeAvgMs;\n",
-    "            int bars = 1;\n",
-    "            if (t > 0)\n",
-    "            {\n",
-    "                double lg = Math.Log10(t + 1e-9);\n",
-    "                bars = (int)Math.Round(Math.Max(0, lg + 1) * 5);\n",
-    "                bars = Math.Min(40, Math.Max(1, bars));\n",
-    "            }\n",
-    "            Console.WriteLine($\"  {name,-20} {new string('#', bars)} {t,9:F2} ms  [{results[name][d].Solved}/{results[name][d].Count}]\");\n",
-    "        }\n",
+    "        var name = solvers[si];\n",
+    "        var ys = diffs.Select(d => results[name].ContainsKey(d) && results[name][d].Count > 0\n",
+    "                                   ? results[name][d].TimeAvgMs : double.NaN).ToArray();\n",
+    "        traces.Add(System.Text.Json.JsonSerializer.Serialize(\n",
+    "            new Dictionary<string, object> {\n",
+    "                [\"name\"] = name, [\"x\"] = diffs, [\"y\"] = ys, [\"type\"] = \"bar\",\n",
+    "                [\"marker\"] = new Dictionary<string, object> { [\"color\"] = palette[si % palette.Length] }\n",
+    "            }));\n",
     "    }\n",
+    "    var divId = \"bars\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var layout = System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> {\n",
+    "            [\"title\"] = new Dictionary<string, object> { [\"text\"] = \"Benchmark : temps moyen (ms) par solveur et difficulte\" },\n",
+    "            [\"xaxis\"] = new Dictionary<string, object> { [\"title\"] = new Dictionary<string, object> { [\"text\"] = \"Difficulte\" } },\n",
+    "            [\"yaxis\"] = new Dictionary<string, object> { [\"title\"] = new Dictionary<string, object> { [\"text\"] = \"Temps moyen (ms)\" }, [\"type\"] = \"log\" },\n",
+    "            [\"barmode\"] = \"group\"\n",
+    "        });\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + string.Join(\",\", traces) + \"],\" + layout + \")</script>\";\n",
+    "    display(new PlotlyHtml(markup));\n",
     "}\n",
     "\n",
-    "PlotBenchmarkBarsAscii(results);\n"
+    "PlotBenchmarkBars(results);"
    ]
   },
   {
@@ -1944,182 +1814,67 @@
    "id": "89517112",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.312208Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.311973Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.458058Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.453025Z"
+     "iopub.execute_input": "2026-07-14T23:38:28.818664Z",
+     "iopub.status.busy": "2026-07-14T23:38:28.818402Z",
+     "iopub.status.idle": "2026-07-14T23:38:28.957496Z",
+     "shell.execute_reply": "2026-07-14T23:38:28.956760Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Distribution - Easy (min | mediane | max, ms) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         [-|-]      0.72 |     0.72 |     0.72\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             [-|-]      1.89 |     1.89 |     1.89\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               [-|-]      4.79 |     4.79 |     4.79\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      [-|-]      8.18 |     8.18 |     8.18\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Distribution - Medium (min | mediane | max, ms) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         [-|-]   3322.94 |  3322.94 |  3322.94\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             [-|-]     15.19 |    15.19 |    15.19\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               [-|-]      3.48 |     3.48 |     3.48\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      [-|-]     15.25 |    15.25 |    15.25\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Distribution - Hard (min | mediane | max, ms) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         [-|-]    190.16 |   190.16 |   190.16\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             [-|-]     69.14 |    69.14 |    69.14\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               [-|-]      2.35 |     2.35 |     2.35\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      [-|-]     15.91 |    15.91 |    15.91\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Distribution - Expert (min | mediane | max, ms) ===\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         [-|-]     58.10 |    58.10 |    58.10\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             [-|-]      9.91 |     9.91 |     9.91\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               [-|-]      3.52 |     3.52 |     3.52\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      [-|-]     15.27 |    15.27 |    15.27\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"box8a6dcd8331c4484f9adc7029bbac4b9e\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('box8a6dcd8331c4484f9adc7029bbac4b9e',[{\"name\":\"Easy\",\"x\":[\"Backtracking\",\"BT \\u002B MRV\",\"Norvig\",\"OR-Tools CP-SAT\"],\"y\":[1.1497,1.696,3.5499,19.4363],\"type\":\"box\",\"marker\":{\"color\":\"#27ae60\"}},{\"name\":\"Medium\",\"x\":[\"Backtracking\",\"BT \\u002B MRV\",\"Norvig\",\"OR-Tools CP-SAT\"],\"y\":[5344.4039,20.9271,2.7467,15.7861],\"type\":\"box\",\"marker\":{\"color\":\"#2980b9\"}},{\"name\":\"Hard\",\"x\":[\"Backtracking\",\"BT \\u002B MRV\",\"Norvig\",\"OR-Tools CP-SAT\"],\"y\":[312.4795,107.5862,2.023,16.3763],\"type\":\"box\",\"marker\":{\"color\":\"#e67e22\"}},{\"name\":\"Expert\",\"x\":[\"Backtracking\",\"BT \\u002B MRV\",\"Norvig\",\"OR-Tools CP-SAT\"],\"y\":[94.6131,10.3472,2.4348,14.9413],\"type\":\"box\",\"marker\":{\"color\":\"#c0392b\"}}],{\"title\":{\"text\":\"Distribution des temps de resolution par solveur\"},\"yaxis\":{\"title\":{\"text\":\"Temps (ms)\"},\"type\":\"log\"},\"boxmode\":\"group\"})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "// Boxplots ASCII de la distribution des temps pour chaque solveur.\n",
-    "public static void PlotBoxplotsAscii(Dictionary<string, Dictionary<string, BenchResult>> results)\n",
+    "// Boxplots : distribution des temps par solveur et difficulte (rendu Plotly).\n",
+    "public static void PlotBoxplots(Dictionary<string, Dictionary<string, BenchResult>> results)\n",
     "{\n",
     "    var diffs = new[] { \"Easy\", \"Medium\", \"Hard\", \"Expert\" };\n",
+    "    var solvers = results.Keys.ToList();\n",
+    "    var palette = new Dictionary<string, string> {\n",
+    "        [\"Easy\"] = \"#27ae60\", [\"Medium\"] = \"#2980b9\",\n",
+    "        [\"Hard\"] = \"#e67e22\", [\"Expert\"] = \"#c0392b\"\n",
+    "    };\n",
+    "    var traces = new List<string>();\n",
     "    foreach (var d in diffs)\n",
     "    {\n",
-    "        Console.WriteLine($\"\\n=== Distribution - {d} (min | mediane | max, ms) ===\");\n",
-    "        foreach (var name in results.Keys)\n",
+    "        var xs = new List<string>();\n",
+    "        var ys = new List<double>();\n",
+    "        foreach (var name in solvers)\n",
     "        {\n",
+    "            if (!results[name].ContainsKey(d)) continue;\n",
     "            var ts = results[name][d].TimesMs;\n",
-    "            if (ts.Count == 0) { Console.WriteLine($\"  {name,-20} (no data)\"); continue; }\n",
-    "            var sorted = ts.OrderBy(x => x).ToList();\n",
-    "            double mn = sorted[0], mx = sorted[^1];\n",
-    "            double med = sorted[sorted.Count / 2];\n",
-    "            int span = (int)Math.Round(Math.Max(1, (Math.Log10(mx + 1e-9) - Math.Log10(mn + 1e-9)) * 8));\n",
-    "            string bar = \"[\" + new string('-', Math.Max(1, span / 3)) + \"|\"\n",
-    "                         + new string('-', Math.Max(1, span * 2 / 3)) + \"]\";\n",
-    "            Console.WriteLine($\"  {name,-20} {bar}  {mn,8:F2} | {med,8:F2} | {mx,8:F2}\");\n",
+    "            if (ts.Count == 0) continue;\n",
+    "            xs.AddRange(ts.Select(_ => name));\n",
+    "            ys.AddRange(ts);\n",
     "        }\n",
+    "        if (xs.Count == 0) continue;\n",
+    "        traces.Add(System.Text.Json.JsonSerializer.Serialize(\n",
+    "            new Dictionary<string, object> {\n",
+    "                [\"name\"] = d, [\"x\"] = xs, [\"y\"] = ys, [\"type\"] = \"box\",\n",
+    "                [\"marker\"] = new Dictionary<string, object> { [\"color\"] = palette[d] }\n",
+    "            }));\n",
     "    }\n",
+    "    var divId = \"box\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var layout = System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> {\n",
+    "            [\"title\"] = new Dictionary<string, object> { [\"text\"] = \"Distribution des temps de resolution par solveur\" },\n",
+    "            [\"yaxis\"] = new Dictionary<string, object> { [\"title\"] = new Dictionary<string, object> { [\"text\"] = \"Temps (ms)\" }, [\"type\"] = \"log\" },\n",
+    "            [\"boxmode\"] = \"group\"\n",
+    "        });\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + string.Join(\",\", traces) + \"],\" + layout + \")</script>\";\n",
+    "    display(new PlotlyHtml(markup));\n",
     "}\n",
     "\n",
-    "PlotBoxplotsAscii(results);\n"
+    "PlotBoxplots(results);"
    ]
   },
   {
@@ -2186,10 +1941,10 @@
    "id": "4864eb97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.460356Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.460087Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.594391Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.593761Z"
+     "iopub.execute_input": "2026-07-14T23:38:28.959645Z",
+     "iopub.status.busy": "2026-07-14T23:38:28.959342Z",
+     "iopub.status.idle": "2026-07-14T23:38:29.099765Z",
+     "shell.execute_reply": "2026-07-14T23:38:29.099459Z"
     }
    },
    "outputs": [
@@ -2287,10 +2042,10 @@
    "id": "80d91159",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.597046Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.596418Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.748566Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.748382Z"
+     "iopub.execute_input": "2026-07-14T23:38:29.102183Z",
+     "iopub.status.busy": "2026-07-14T23:38:29.101773Z",
+     "iopub.status.idle": "2026-07-14T23:38:29.321154Z",
+     "shell.execute_reply": "2026-07-14T23:38:29.320787Z"
     }
    },
    "outputs": [
@@ -2460,10 +2215,10 @@
    "id": "8642cf81",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.750610Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.750229Z",
-     "iopub.status.idle": "2026-07-07T09:27:03.810165Z",
-     "shell.execute_reply": "2026-07-07T09:27:03.809578Z"
+     "iopub.execute_input": "2026-07-14T23:38:29.323661Z",
+     "iopub.status.busy": "2026-07-14T23:38:29.323186Z",
+     "iopub.status.idle": "2026-07-14T23:38:29.397577Z",
+     "shell.execute_reply": "2026-07-14T23:38:29.397312Z"
     }
    },
    "outputs": [
@@ -2506,10 +2261,10 @@
    "id": "e692ea3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:03.812330Z",
-     "iopub.status.busy": "2026-07-07T09:27:03.811815Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.021654Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.021358Z"
+     "iopub.execute_input": "2026-07-14T23:38:29.399723Z",
+     "iopub.status.busy": "2026-07-14T23:38:29.399293Z",
+     "iopub.status.idle": "2026-07-14T23:38:45.467680Z",
+     "shell.execute_reply": "2026-07-14T23:38:45.467243Z"
     }
    },
    "outputs": [
@@ -2551,219 +2306,21 @@
    "id": "a091a298",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.023534Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.023178Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.066840Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.058747Z"
+     "iopub.execute_input": "2026-07-14T23:38:45.469668Z",
+     "iopub.status.busy": "2026-07-14T23:38:45.469374Z",
+     "iopub.status.idle": "2026-07-14T23:38:45.604415Z",
+     "shell.execute_reply": "2026-07-14T23:38:45.604135Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Benchmark : temps moyen (ms) - echelle log10 (1 '#' ~= 0.2 unite log)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Easy]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ##      0.28 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ####      0.75 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ######      1.67 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     15.37 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig + FC          ######      1.69 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Simulated Annealing  ##########      8.90 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Medium]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         #######################   3639.56 ms  [0/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             #############     48.36 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               #######      2.47 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     16.01 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig + FC          ######      1.84 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Simulated Annealing  ######################   3000.35 ms  [0/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Hard]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         #################    225.28 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             ##############     72.60 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               ######      1.81 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     17.16 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig + FC          #####      1.14 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Simulated Annealing  ######################   3000.10 ms  [0/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[Expert]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Backtracking         ##############     66.97 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BT + MRV             #########      7.35 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig               #######      2.19 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  OR-Tools CP-SAT      ###########     16.03 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Norvig + FC          ######      1.40 ms  [1/1]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Simulated Annealing  ######################   3000.34 ms  [0/1]\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"bars57721963a11946acb7ef84547bbdf01b\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('bars57721963a11946acb7ef84547bbdf01b',[{\"name\":\"Backtracking\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[0.3609,6076.4949,317.6591,90.1171],\"type\":\"bar\",\"marker\":{\"color\":\"#2c3e50\"}},{\"name\":\"BT \\u002B MRV\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[0.8132,11.6476,92.4642,11.9978],\"type\":\"bar\",\"marker\":{\"color\":\"#2980b9\"}},{\"name\":\"Norvig\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[2.1597,3.2469,2.7162,3.0443],\"type\":\"bar\",\"marker\":{\"color\":\"#27ae60\"}},{\"name\":\"OR-Tools CP-SAT\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[22.6693,15.261,16.004,15.5674],\"type\":\"bar\",\"marker\":{\"color\":\"#c0392b\"}},{\"name\":\"Norvig \\u002B FC\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[2.0143,3.0197,1.9761,2.5122],\"type\":\"bar\",\"marker\":{\"color\":\"#8e44ad\"}},{\"name\":\"Simulated Annealing\",\"x\":[\"Easy\",\"Medium\",\"Hard\",\"Expert\"],\"y\":[10.5769,3009.1154,3000.5745,3292.1061],\"type\":\"bar\",\"marker\":{\"color\":\"#d35400\"}}],{\"title\":{\"text\":\"Benchmark : temps moyen (ms) par solveur et difficulte\"},\"xaxis\":{\"title\":{\"text\":\"Difficulte\"}},\"yaxis\":{\"title\":{\"text\":\"Temps moyen (ms)\"},\"type\":\"log\"},\"barmode\":\"group\"})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -2775,9 +2332,9 @@
     }
    ],
    "source": [
-    "// Graphique etendu (ASCII) : Norvig+FC + Simulated Annealing (Prong B #3801)\n",
-    "PlotBenchmarkBarsAscii(resultsExtended);\n",
-    "Console.WriteLine(\"\\n(Prong B #3801 : le recuit simule n'a aucune garantie de convergence)\");\n"
+    "// Graphique etendu : Norvig+FC + Simulated Annealing (Prong B #3801)\n",
+    "PlotBenchmarkBars(resultsExtended);\n",
+    "Console.WriteLine(\"\\n(Prong B #3801 : le recuit simule n'a aucune garantie de convergence)\");"
    ]
   },
   {
@@ -2859,10 +2416,10 @@
    "id": "7c230215",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.068695Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.068450Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.101209Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.100905Z"
+     "iopub.execute_input": "2026-07-14T23:38:45.606912Z",
+     "iopub.status.busy": "2026-07-14T23:38:45.606533Z",
+     "iopub.status.idle": "2026-07-14T23:38:45.658679Z",
+     "shell.execute_reply": "2026-07-14T23:38:45.658204Z"
     }
    },
    "outputs": [
@@ -2914,10 +2471,10 @@
    "id": "7af6d43b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.102648Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.102430Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.138789Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.138200Z"
+     "iopub.execute_input": "2026-07-14T23:38:45.661169Z",
+     "iopub.status.busy": "2026-07-14T23:38:45.660622Z",
+     "iopub.status.idle": "2026-07-14T23:38:45.721687Z",
+     "shell.execute_reply": "2026-07-14T23:38:45.721365Z"
     }
    },
    "outputs": [
@@ -2962,10 +2519,10 @@
    "id": "461a17c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.140255Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.139888Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.199781Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.199384Z"
+     "iopub.execute_input": "2026-07-14T23:38:45.723570Z",
+     "iopub.status.busy": "2026-07-14T23:38:45.723260Z",
+     "iopub.status.idle": "2026-07-14T23:38:45.804584Z",
+     "shell.execute_reply": "2026-07-14T23:38:45.804031Z"
     }
    },
    "outputs": [
@@ -3027,10 +2584,10 @@
    "id": "2d0e1768",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:27:17.201467Z",
-     "iopub.status.busy": "2026-07-07T09:27:17.201248Z",
-     "iopub.status.idle": "2026-07-07T09:27:17.234510Z",
-     "shell.execute_reply": "2026-07-07T09:27:17.234040Z"
+     "iopub.execute_input": "2026-07-14T23:38:45.807053Z",
+     "iopub.status.busy": "2026-07-14T23:38:45.806668Z",
+     "iopub.status.idle": "2026-07-14T23:38:45.855007Z",
+     "shell.execute_reply": "2026-07-14T23:38:45.854693Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

SOTA axe-2 Prong-A fix (#6596): replace 3 ASCII-art benchmark charts in `Sudoku-18-Comparison-Csharp.ipynb` with real **Plotly.js charts** via the **zero-restore C548-L2 technique** (the kernel's built-in HTML formatter — no `#r "nuget:"` on a charting lib). The OR-Tools/backtracking/Norvig solvers run for real; only the rendering was degraded.

**This supersedes the issue's literal proposal** (`#r "nuget: XPlot.Plotly.Interactive, 4.1.0"`): that beta-restore times out headless cluster-wide (C547-L1, po-2024/po-2023 confirmed). ai-01's C548-L2 insight — proven on #6607 (Infer-19, MERGED) — sidesteps the restore entirely with `record PlotlyHtml + Formatter.Register(typeof(PlotlyHtml), ..., "text/html")`. Picked up per ai-01's c.482 dispatch bell.

**Cells edited** (pure visualization swap, NO solver/computation change):

| Cell | id | Before | After |
|------|----|--------|-------|
| `[39]` | `dc4ecdb4` | `PlotBenchmarkBarsAscii` — `#`-bars (log10 scale) via `Console.WriteLine` | `PlotBenchmarkBars` — Plotly grouped bars (x=difficulty, traces per solver), log-Y axis |
| `[42]` | `89517112` | `PlotBoxplotsAscii` — `[---\|---]` ASCII boxplots | `PlotBoxplots` — Plotly grouped boxes (y=TimesMs per solver, color by difficulty), log-Y |
| `[55]` | `a091a298` | `PlotBenchmarkBarsAscii(resultsExtended)` call | `PlotBenchmarkBars(resultsExtended)` (Prong-B note kept) |
| `[3]` | `466f92a0` | markdown deps table (claimed `numpy/matplotlib` — wrong for a .NET nb) | accurate deps: Google.OrTools + Plotly.js via formatter |

cell[64] (exercise stub, intentionally ASCII for students) left intact — out of scope per the issue.

## SOTA verdict (#3801)

**RECOVERABLE-LOCAL → fixed** via C548-L2 (supersedes po-2023's earlier RECOVERABLE-MACHINE "kernel-repair" verdict on this grain). The real tool (Plotly.js) is invokable through the kernel's HTML formatter; no NuGet restore on a charting lib needed.

## Execution proof (H.1 / C.2)

Re-executed end-to-end on po-2024 via `jupyter nbconvert --execute --kernel .net-csharp` — **EXIT=0, 43s** (the solver benchmarks run fast; the .NET headless blocker does NOT apply here because plain `#r "nuget: Google.OrTools"` restores fine — only the charting-lib beta pin hangs).

- cell[39] ec=15: real `Plotly.newPlot` HTML output with genuine benchmark data (Backtracking Easy=1.15ms / Medium=5344ms / Hard=312ms / Expert=94ms — solvers genuinely exercised).
- cell[42] ec=16: real Plotly box output (distribution of TimesMs per solver × difficulty).
- cell[55] ec=21: real Plotly grouped bars (extended results incl. Norvig+FC + Simulated Annealing).
- **0 errors, 0 null-exec** across all 25 code cells (C.2 holds, H.3 clean).
- **C.1**: no voluntary errors in edited cells.

## Surgical scope (C.3) — cleaner than the #6602 pattern

Source-changed: **exactly [3]md, [39], [42], [55]**. Outputs/ec-changed: **only [39], [42], [55]** (unchanged-source cells' stochastic solver-timing outputs + .NET banner were surgically reverted to `origin/main`). `cell[2]` (`#r nuget` setup) byte-identical. Metadata + nbformat identical. Catalog byte-identical (single-file PR).

## Scope

Single notebook, +200/−643 (the −643 is the verbose ASCII-bar `Console.WriteLine` output blocks replaced by compact Plotly HTML). Base fresh on `origin/main` (`c4bce3d8e`).

Closes #6596. See #3801 (SOTA axe-2, .NET Prong-A). Sibling: #6607 (Infer-19, the C548-L2 pilot). #6599 (Infer-17/18) covered by #6609/#6610.

**Co-Authored-By:** Claude <noreply@anthropic.com>
