### PR TITLE
fix(gametheory-8c,#3801): Sprague-Grundy ASCII bars -> zero-restore Plotly (C548-L2, new family)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
@@ -52,10 +52,10 @@
    "id": "fe275b6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:00.309595Z",
-     "iopub.status.busy": "2026-07-07T09:15:00.302601Z",
-     "iopub.status.idle": "2026-07-07T09:15:02.019936Z",
-     "shell.execute_reply": "2026-07-07T09:15:02.014639Z"
+     "iopub.execute_input": "2026-07-14T23:40:06.513112Z",
+     "iopub.status.busy": "2026-07-14T23:40:06.503965Z",
+     "iopub.status.idle": "2026-07-14T23:40:08.811856Z",
+     "shell.execute_reply": "2026-07-14T23:40:08.805795Z"
     }
    },
    "outputs": [
@@ -68,7 +68,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
+       "async function probeAddresses(probingAddresses) {\r\n",
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -78,10 +78,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
        "\r\n",
-       
+       "            let rootUrl = probingAddresses[i];\r\n",
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -96,7 +96,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
+       "                    body: probingAddresses[i]\r\n",
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -108,13 +108,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%12:2048/\",\"http://172.26.48.1:2048/\",\"http://fe80::4242:e8b9:6bbf:ef2c%50:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:4c49:ea51:a5f7:8b03:2048/\",\"http://2a01:e0a:9d4:f320:6d91:40d7:528:51b3:2048/\",\"http://2a01:e0a:9d4:f320:7042:4896:3da8:dc2a:2048/\",\"http://2a01:e0a:9d4:f320:c942:e5c4:12e2:6ae2:2048/\",\"http://2a01:e0a:9d4:f320:cde3:e6ed:6b4:42df:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '41804.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '1448228.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -158,13 +158,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
+       "        loadDotnetInteractiveApi();\r\n",
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
+       "    loadDotnetInteractiveApi();\r\n",
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -226,10 +226,10 @@
    "id": "c670abf7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:02.021544Z",
-     "iopub.status.busy": "2026-07-07T09:15:02.021329Z",
-     "iopub.status.idle": "2026-07-07T09:15:02.298671Z",
-     "shell.execute_reply": "2026-07-07T09:15:02.298321Z"
+     "iopub.execute_input": "2026-07-14T23:40:08.814280Z",
+     "iopub.status.busy": "2026-07-14T23:40:08.813979Z",
+     "iopub.status.idle": "2026-07-14T23:40:09.189507Z",
+     "shell.execute_reply": "2026-07-14T23:40:09.189232Z"
     }
    },
    "outputs": [
@@ -297,10 +297,10 @@
    "id": "dd6fa408",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:02.299994Z",
-     "iopub.status.busy": "2026-07-07T09:15:02.299799Z",
-     "iopub.status.idle": "2026-07-07T09:15:02.622419Z",
-     "shell.execute_reply": "2026-07-07T09:15:02.622040Z"
+     "iopub.execute_input": "2026-07-14T23:40:09.191505Z",
+     "iopub.status.busy": "2026-07-14T23:40:09.191174Z",
+     "iopub.status.idle": "2026-07-14T23:40:09.597413Z",
+     "shell.execute_reply": "2026-07-14T23:40:09.597149Z"
     }
    },
    "outputs": [
@@ -464,13 +464,22 @@
    "id": "539733c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:02.623867Z",
-     "iopub.status.busy": "2026-07-07T09:15:02.623667Z",
-     "iopub.status.idle": "2026-07-07T09:15:02.694589Z",
-     "shell.execute_reply": "2026-07-07T09:15:02.691047Z"
+     "iopub.execute_input": "2026-07-14T23:40:09.599138Z",
+     "iopub.status.busy": "2026-07-14T23:40:09.598874Z",
+     "iopub.status.idle": "2026-07-14T23:40:09.998749Z",
+     "shell.execute_reply": "2026-07-14T23:40:09.998475Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"plt5466d2671264460096490882d1a3b954\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt5466d2671264460096490882d1a3b954',[{\"name\":\"G(n) (Grundy)\",\"x\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34],\"y\":[0,1,0,1,2,3,2,0,1,0,1,2,3,2,0,1,0,1,2,3,2,0,1,0,1,2,3,2,0,1,0,1,2,3,2],\"type\":\"bar\",\"marker\":{\"color\":[\"#4C72B0\",\"#4C72B0\",\"#4C72B0\",\"#4C72B0\",\"#4C72B0\",\"#4C72B0\",\"#4C72B0\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\",\"#888888\"]}}],{\"title\":{\"text\":\"Sequence de Grundy du jeu de soustraction S({1,3,4})\"},\"xaxis\":{\"title\":{\"text\":\"n (taille du tas)\"}},\"yaxis\":{\"title\":{\"text\":\"G(n)\"}},\"shapes\":[{\"type\":\"line\",\"x0\":0,\"x1\":0,\"y0\":0,\"y1\":1,\"yref\":\"paper\",\"line\":{\"color\":\"#C44E52\",\"width\":1.5,\"dash\":\"dash\"}},{\"type\":\"line\",\"x0\":7,\"x1\":7,\"y0\":0,\"y1\":1,\"yref\":\"paper\",\"line\":{\"color\":\"#4C72B0\",\"width\":1.5,\"dash\":\"dash\"}}],\"showlegend\":false,\"annotations\":[{\"x\":0,\"y\":1,\"yref\":\"paper\",\"text\":\"fin pre-periode\",\"showarrow\":false,\"xanchor\":\"left\",\"font\":{\"color\":\"#C44E52\",\"size\":10}},{\"x\":7,\"y\":0.95,\"yref\":\"paper\",\"text\":\"fin 1ere periode\",\"showarrow\":false,\"xanchor\":\"left\",\"font\":{\"color\":\"#4C72B0\",\"size\":10}}]})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -482,296 +491,66 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  0 |  <- fin pre-periode\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  1 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  2 |\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  3 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  4 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  5 |###\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  6 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  7 |  <- fin 1ere periode\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  8 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  9 |\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 10 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 11 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 12 |###\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 13 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 14 |\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 15 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 16 |\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 17 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 18 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 19 |###\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 20 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 21 |\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 22 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 23 |\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 24 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 25 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 26 |###\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 27 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 28 |\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 29 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 30 |\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 31 |#\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 32 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 33 |###\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 34 |##\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Pre-periode: 0, Periode: 7\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "Motif periodique: [0, 1, 0, 1, 2, 3, 2]\r\n"
      ]
     }
    ],
    "source": [
-    "// Visualisation ASCII de la periodicite (matplotlib -> barres ASCII)\n",
+    "// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.\n",
+    "// (Zero `#r \"nuget:\"` sur une charting-lib : les charting libs pinent une vieille beta\n",
+    "//  de Microsoft.DotNet.Interactive et font timeout le restore, cluster-wide. Le formatter\n",
+    "//  ci-dessous emet du HTML Plotly brut, sans dependence. Cf #3801 / C548-L2.)\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
+    "// Visualisation de la sequence de Grundy (valeurs G(n)) et de sa structure periodique.\n",
     "var moves = new HashSet<int> { 1, 3, 4 };\n",
     "var (pre, period, seq) = FindPeriodicity(moves, maxN: 100);\n",
-    "\n",
-    "Console.WriteLine($\"Jeu de soustraction S({{1,3,4}}) - Periode = {period}, Pre-periode = {pre}\");\n",
-    "Console.WriteLine();\n",
     "int show = Math.Min(35, seq.Count);\n",
-    "for (int i = 0; i < show; i++)\n",
-    "{\n",
-    "    string bar = new string('#', seq[i]);\n",
-    "    string marker = \"\";\n",
-    "    if (i == pre) marker += \"  <- fin pre-periode\";\n",
-    "    if (i == pre + period) marker += \"  <- fin 1ere periode\";\n",
-    "    Console.WriteLine($\"{i,3} |{bar}{marker}\");\n",
-    "}\n",
+    "\n",
+    "var xIdx = Enumerable.Range(0, show).Select(i => (double)i).ToArray();\n",
+    "var yGrundy = seq.GetRange(0, show).Select(v => (double)v).ToArray();\n",
+    "\n",
+    "// Couleur : rouge pour la pre-periode, bleu pour la premiere periode, gris pour la suite.\n",
+    "var barColors = Enumerable.Range(0, show).Select(i =>\n",
+    "    i < pre ? \"#C44E52\"\n",
+    "    : i < pre + period ? \"#4C72B0\"\n",
+    "    : \"#888888\").ToArray();\n",
+    "\n",
+    "var barTrace = new Dictionary<string, object> {\n",
+    "    [\"name\"] = \"G(n) (Grundy)\", [\"x\"] = xIdx, [\"y\"] = yGrundy, [\"type\"] = \"bar\",\n",
+    "    [\"marker\"] = new { color = barColors } };\n",
+    "string barJson = System.Text.Json.JsonSerializer.Serialize(barTrace);\n",
+    "\n",
+    "// Lignes verticales marquant la fin de pre-periode et la fin de la premiere periode.\n",
+    "string ShapeLine(double x0, string color) =>\n",
+    "    $\"{{\\\"type\\\":\\\"line\\\",\\\"x0\\\":{x0},\\\"x1\\\":{x0},\\\"y0\\\":0,\\\"y1\\\":1,\\\"yref\\\":\\\"paper\\\",\" +\n",
+    "    $\"\\\"line\\\":{{\\\"color\\\":\\\"{color}\\\",\\\"width\\\":1.5,\\\"dash\\\":\\\"dash\\\"}}}}\";\n",
+    "string shapes = \"[\" + ShapeLine(pre, \"#C44E52\") + \",\" + ShapeLine(pre + period, \"#4C72B0\") + \"]\";\n",
+    "\n",
+    "var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Sequence de Grundy du jeu de soustraction S({1,3,4})\\\"},\" +\n",
+    "             \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"n (taille du tas)\\\"}},\" +\n",
+    "             \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"G(n)\\\"}},\" +\n",
+    "             \"\\\"shapes\\\":\" + shapes + \",\" +\n",
+    "             \"\\\"showlegend\\\":false,\" +\n",
+    "             \"\\\"annotations\\\":[\" +\n",
+    "             \"{\\\"x\\\":\" + pre + \",\\\"y\\\":1,\\\"yref\\\":\\\"paper\\\",\\\"text\\\":\\\"fin pre-periode\\\",\" +\n",
+    "               \"\\\"showarrow\\\":false,\\\"xanchor\\\":\\\"left\\\",\\\"font\\\":{\\\"color\\\":\\\"#C44E52\\\",\\\"size\\\":10}},\" +\n",
+    "             \"{\\\"x\\\":\" + (pre + period) + \",\\\"y\\\":0.95,\\\"yref\\\":\\\"paper\\\",\\\"text\\\":\\\"fin 1ere periode\\\",\" +\n",
+    "               \"\\\"showarrow\\\":false,\\\"xanchor\\\":\\\"left\\\",\\\"font\\\":{\\\"color\\\":\\\"#4C72B0\\\",\\\"size\\\":10}}\" +\n",
+    "             \"]}\";\n",
+    "var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "             \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "             \"<script>Plotly.newPlot('\" + divId + \"',[\" + barJson + \"],\" + layout + \")</script>\";\n",
+    "display(new PlotlyHtml(markup));\n",
+    "\n",
     "var onePeriod = seq.GetRange(pre, period);\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine($\"Pre-periode: {pre}, Periode: {period}\");\n",
-    "Console.WriteLine($\"Motif periodique: [{string.Join(\", \", onePeriod)}]\");"
+    "Console.WriteLine($\"Jeu de soustraction S({{1,3,4}}) - Periode = {period}, Pre-periode = {pre}\");\n",
+    "Console.WriteLine($\"Motif periodique: [{string.Join(\", \", onePeriod)}]\");\n"
    ]
   },
   {
@@ -803,10 +582,10 @@
    "id": "2fc0a5bf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:02.696250Z",
-     "iopub.status.busy": "2026-07-07T09:15:02.696030Z",
-     "iopub.status.idle": "2026-07-07T09:15:02.803033Z",
-     "shell.execute_reply": "2026-07-07T09:15:02.802767Z"
+     "iopub.execute_input": "2026-07-14T23:40:10.000903Z",
+     "iopub.status.busy": "2026-07-14T23:40:10.000575Z",
+     "iopub.status.idle": "2026-07-14T23:40:10.134642Z",
+     "shell.execute_reply": "2026-07-14T23:40:10.134061Z"
     }
    },
    "outputs": [
@@ -982,10 +761,10 @@
    "id": "89992316",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:02.804672Z",
-     "iopub.status.busy": "2026-07-07T09:15:02.804480Z",
-     "iopub.status.idle": "2026-07-07T09:15:02.949291Z",
-     "shell.execute_reply": "2026-07-07T09:15:02.874289Z"
+     "iopub.execute_input": "2026-07-14T23:40:10.137528Z",
+     "iopub.status.busy": "2026-07-14T23:40:10.136928Z",
+     "iopub.status.idle": "2026-07-14T23:40:10.464751Z",
+     "shell.execute_reply": "2026-07-14T23:40:10.308766Z"
     }
    },
    "outputs": [
@@ -3472,10 +3251,10 @@
    "id": "040d79f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:02.951206Z",
-     "iopub.status.busy": "2026-07-07T09:15:02.950978Z",
-     "iopub.status.idle": "2026-07-07T09:15:03.026182Z",
-     "shell.execute_reply": "2026-07-07T09:15:03.025637Z"
+     "iopub.execute_input": "2026-07-14T23:40:10.467333Z",
+     "iopub.status.busy": "2026-07-14T23:40:10.466973Z",
+     "iopub.status.idle": "2026-07-14T23:40:10.570598Z",
+     "shell.execute_reply": "2026-07-14T23:40:10.570163Z"
     }
    },
    "outputs": [
@@ -3575,10 +3354,10 @@
    "id": "ba0a403e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:03.027942Z",
-     "iopub.status.busy": "2026-07-07T09:15:03.027682Z",
-     "iopub.status.idle": "2026-07-07T09:15:03.100149Z",
-     "shell.execute_reply": "2026-07-07T09:15:03.099705Z"
+     "iopub.execute_input": "2026-07-14T23:40:10.573158Z",
+     "iopub.status.busy": "2026-07-14T23:40:10.572812Z",
+     "iopub.status.idle": "2026-07-14T23:40:10.694813Z",
+     "shell.execute_reply": "2026-07-14T23:40:10.694438Z"
     }
    },
    "outputs": [
@@ -3654,10 +3433,10 @@
    "id": "45e3d6eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:03.101561Z",
-     "iopub.status.busy": "2026-07-07T09:15:03.101347Z",
-     "iopub.status.idle": "2026-07-07T09:15:03.263099Z",
-     "shell.execute_reply": "2026-07-07T09:15:03.262838Z"
+     "iopub.execute_input": "2026-07-14T23:40:10.697315Z",
+     "iopub.status.busy": "2026-07-14T23:40:10.696913Z",
+     "iopub.status.idle": "2026-07-14T23:40:10.900797Z",
+     "shell.execute_reply": "2026-07-14T23:40:10.899870Z"
     }
    },
    "outputs": [
@@ -3835,10 +3614,10 @@
    "id": "46553128",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:03.264595Z",
-     "iopub.status.busy": "2026-07-07T09:15:03.264377Z",
-     "iopub.status.idle": "2026-07-07T09:15:03.316500Z",
-     "shell.execute_reply": "2026-07-07T09:15:03.316280Z"
+     "iopub.execute_input": "2026-07-14T23:40:10.903504Z",
+     "iopub.status.busy": "2026-07-14T23:40:10.903027Z",
+     "iopub.status.idle": "2026-07-14T23:40:10.998308Z",
+     "shell.execute_reply": "2026-07-14T23:40:10.997748Z"
     }
    },
    "outputs": [
@@ -3909,10 +3688,10 @@
    "id": "db7d14b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:03.318140Z",
-     "iopub.status.busy": "2026-07-07T09:15:03.317889Z",
-     "iopub.status.idle": "2026-07-07T09:15:03.456525Z",
-     "shell.execute_reply": "2026-07-07T09:15:03.440914Z"
+     "iopub.execute_input": "2026-07-14T23:40:11.001422Z",
+     "iopub.status.busy": "2026-07-14T23:40:11.000907Z",
+     "iopub.status.idle": "2026-07-14T23:40:11.194184Z",
+     "shell.execute_reply": "2026-07-14T23:40:11.170587Z"
     }
    },
    "outputs": [
@@ -4701,10 +4480,10 @@
    "id": "a2afeacf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:03.459822Z",
-     "iopub.status.busy": "2026-07-07T09:15:03.459297Z",
-     "iopub.status.idle": "2026-07-07T09:15:03.679045Z",
-     "shell.execute_reply": "2026-07-07T09:15:03.678724Z"
+     "iopub.execute_input": "2026-07-14T23:40:11.196530Z",
+     "iopub.status.busy": "2026-07-14T23:40:11.196172Z",
+     "iopub.status.idle": "2026-07-14T23:40:11.366610Z",
+     "shell.execute_reply": "2026-07-14T23:40:11.366128Z"
     }
    },
    "outputs": [
@@ -4897,10 +4676,10 @@
    "id": "832e5520",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:03.682151Z",
-     "iopub.status.busy": "2026-07-07T09:15:03.681434Z",
-     "iopub.status.idle": "2026-07-07T09:15:03.799755Z",
-     "shell.execute_reply": "2026-07-07T09:15:03.791294Z"
+     "iopub.execute_input": "2026-07-14T23:40:11.369279Z",
+     "iopub.status.busy": "2026-07-14T23:40:11.368767Z",
+     "iopub.status.idle": "2026-07-14T23:40:11.487848Z",
+     "shell.execute_reply": "2026-07-14T23:40:11.476156Z"
     }
    },
    "outputs": [
@@ -5239,10 +5018,10 @@
    "id": "14fb6c95",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T09:15:03.801779Z",
-     "iopub.status.busy": "2026-07-07T09:15:03.801517Z",
-     "iopub.status.idle": "2026-07-07T09:15:03.853046Z",
-     "shell.execute_reply": "2026-07-07T09:15:03.852782Z"
+     "iopub.execute_input": "2026-07-14T23:40:11.489761Z",
+     "iopub.status.busy": "2026-07-14T23:40:11.489485Z",
+     "iopub.status.idle": "2026-07-14T23:40:11.535404Z",
+     "shell.execute_reply": "2026-07-14T23:40:11.535096Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
## Summary

Application of the **zero-restore Plotly technique** (C548-L2) to a **new family** (GameTheory .NET) beyond the Infer pilot. **GameTheory-8c-CombinatorialGames-Csharp.ipynb cell[8]** — the ASCII horizontal `#`-bar chart of the Sprague-Grundy sequence is replaced by a real **Plotly.js bar chart** with period-structure coloring + markers. The cell comment self-documented the degradation: *« Visualisation ASCII de la periodicite (matplotlib -> barres ASCII) »*.

## What changed (scope: 1 cell, 1 file)

`GameTheory-8c-CombinatorialGames-Csharp.ipynb` **cell[8]** only:
- **Kept**: the text summary (`Periode = 7, Pre-periode = 0`, `Motif periodique: [0, 1, 0, 1, 2, 3, 2]`) — legitimate tabular output of the real CGT result.
- **Removed**: the ASCII bar loop (`string bar = new string('#', seq[i])` over 35 lines, one `Console.WriteLine` per `n`, with `marker` strings for pre-period/period end).
- **Added**: a real Plotly.js bar chart via `Formatter.Register(typeof(PlotlyHtml), delegate, "text/html")`: bar trace `G(n)` over n=0..34, **colored by region** (red = pre-period, blue = first period, gray = after), + dashed vertical `shapes` lines + annotations marking **"fin pre-periode"** and **"fin 1ere periode"**.

Net: +125/−346, 1 file, atomic. (The −346 = the ~35 ASCII stream-output lines replaced by one compact `display_data`.)

## Why this is SOTA-OK (Prong A)

The combinatorial-game-theory engine is **genuinely exercised**:
- `seq` is the **Sprague-Grundy sequence** of the subtraction game S({1,3,4}) — `G(n)` computed via `GrundySubtraction` (cell[4]: `mex`, nim-sum, the real Grundy recurrence) and the periodicity detected via `FindPeriodicity` (cell[6], **Guy 1996 theorem** on ultimately-periodic Grundy sequences of finite subtraction games).
- The chart plots the **real** sequence `seq` returned by `FindPeriodicity(moves, maxN: 100)` — the period structure (red/blue/gray regions + the two vertical markers) is computed from the genuine `pre`/`period` values, not hardcoded.
- **Strictly richer** than the ASCII version: the ASCII bars only showed bar-length-by-n with a trailing text marker; the Plotly version makes the periodic structure visually obvious (colored regions + aligned markers).

No `#r "nuget:"` on a charting lib (same cluster-wide blocker as #6599 Infer, superseded by C548-L2 zero-restore). This notebook has no `#r "nuget:"` at all — `Microsoft.DotNet.Interactive.Formatting` is kernel-built-in.

## Prong B (non-trivial problem)

The periodicity detection of a subtraction game's Grundy sequence is a **genuine CGT algorithm** (not a degenerate case): S({1,3,4}) has a non-trivial period (7) with motif `[0,1,0,1,2,3,2]`, and the pre-period/period decomposition is a real computational result. The chart makes this structure legible.

## Execution proof (H.1 / C.2)

Re-executed end-to-end on po-2024 via `jupyter nbconvert --execute --kernel .net-csharp --timeout 360`:
- **EXIT=0**, no CellExecutionError, no timeout.
- **14/14 code cells** execution_count non-null, **0 errors**.
- cell[8]: `display_data` mime `text/html` (1455 chars), `Plotly.newPlot('plt...', [{"name":"G(n) (Grundy)","type":"bar",...}])` with `shapes` (2 vertical period lines) + `annotations` — real data, unescaped HTML (validated: `Plotly.newPlot=True`, `type bar=True`, `shapes=True`, `annotations=True`, `not_escaped=True`, no `&lt;`, `plotly-2.35.2` CDN).
- Text summary preserved: 2 stream outputs (`Periode = 7, Pre-periode = 0`, `Motif periodique: [0, 1, 0, 1, 2, 3, 2]`).
- `nbformat VALIDATE OK` (31 cells, code-cell IDs all present + unique).
- C.1: no `raise NotImplementedError` / `assert False` / `1/0` / `throw new` (exercise stubs in cells 20/28 untouched, retain `// TODO etudiant`).

## Conventions

- Catalogue byte-identical (no `COURSE_CATALOG.generated.*` touched).
- Atomic (1 file, 1 cell, 1 subject).
- Collision-preempt: `gh pr list --state all --search GameTheory-8c` = 0 OPEN (30 historical MERGED/CLOSED).

See #3801 (SOTA axe-2), see #6599 (pattern C548-L2, Infer pilot).

## Verification

```
jupyter nbconvert --to notebook --execute GameTheory-8c-CombinatorialGames-Csharp.ipynb \
  --inplace --ExecutePreprocessor.timeout=360 --ExecutePreprocessor.kernel_name=.net-csharp
# EXIT=0 | 14/14 code cells ec non-null | 0 errors
# cell[8]: 1 Plotly display_data text/html (G(n) bar + period shapes/annotations) + text summary stream
```

Co-Authored-By: Claude-Code <noreply@anthropic.com>
