### PR TITLE
fix(sudoku,#6585): add root Sudoku_en to lakefile globs (orphan build coverage)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/sudoku_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/Sudoku/sudoku_lean/lakefile.lean
@@ -48,4 +48,4 @@ require mathlib from git
 
 @[default_target]
 lean_lib «Sudoku» where
-  globs := #[.submodules `Sudoku]
+  globs := #[.submodules `Sudoku, `Sudoku_en]


### PR DESCRIPTION
## Summary

Resolves the **orphan glob coverage** for `sudoku_lean`: the lakefile `globs := #[.submodules \`Sudoku]` covers the `Sudoku/` subdirectory but NOT the root sibling `Sudoku_en.lean` (the EN aggregator added in #5765). The root `_en` module is an orphan of the build graph — CI stays green but never type-checks `Sudoku_en.lean`. Same class of bug as #6585's other 5 lakes.

**Fix**: 1-line glob add, identical leaf-root pattern to the 3 merged precedents.

```diff
 @[default_target]
 lean_lib «Sudoku» where
-  globs := #[.submodules `Sudoku]
+  globs := #[.submodules `Sudoku, `Sudoku_en]
```

## Precedents (merged, same pattern)

| PR | Lake | Fix |
|----|------|-----|
| #6601 | minimax_lean | `globs := #[.submodules \`Minimax, \`Minimax_en]` |
| #6594 | decision_theory_lean | root `_en` aggregators added to globs |
| #6597 | game_theory_lean | root `_en` aggregators added to globs |

ai-01 ran warm-cache `lake build` on #6601 → BUILD_EXIT=0, `Minimax_en.olean` built, 0 sorry, doc-only. Same expected here.

## Why `Sudoku_en` is build-safe to add

`Sudoku_en.lean` (read firsthand on origin/main) is a **pure landing-doc module** — imports + module docstring, no declarations (mirrors the FR root `Sudoku.lean` exactly). Adding it to globs adds build coverage without new proofs, so the warm-cache build cannot regress (byte-identical to the FR root that already builds green).

## Build proof — division of labor (per ai-01 c.482 steer)

> "po-2026 authors trivial lakefile +N/-N; I do the AUTHORITATIVE build+merge (my warm cache gates it, not the worker's log)."

po-2023 (this PR) authored the trivial `+N/-N` glob change. The **AUTHORITATIVE `lake build Sudoku_en` warm-cache proof** is ai-01's merge-gate (cold mathlib cache on po-2023 = ~30-90min cold build = cron-infeasible; this is the explicit division of labor, not a bypass). lean-merge-discipline HARD satisfied by ai-01's warm-cache gate.

## Scope

- `See #6585` (partial — `learning_theory_lean` is the 2nd remaining lake; ai-01 c.482 steer confirmed sudoku_lean + learning_theory_lean as the 2 remaining).
- `See #4980` (i18n Lean EPIC).
- The `repeated_games_lean/RepeatedGames_en` case is **likely SKIP** per ai-01 (absorbed into game_theory_lean by #6146/#4365 = legacy duplicate, not in scope).
- Does NOT `Closes #6585` (learning_theory_lean remains).

## R6 register

Lean-infra (NOT viz) — R6 variety rotation off the ASCII→Plotly register (5 prior PRs). [CLAIMED] posted before worktree (c.483 collision lesson — 3 agents hit Sudoku-18 in 30 min when [CLAIMED] was omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)