### PR TITLE
fix(learning-theory,#6585): add root Perceptron_en + PacLearning_en to lakefile globs (orphan build coverage)

### DIFF
--- a/MyIA.AI.Notebooks/ML/learning_theory_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/ML/learning_theory_lean/lakefile.lean
@@ -38,11 +38,11 @@ require mathlib from git
 
 @[default_target]
 lean_lib «Perceptron» where
-  globs := #[.submodules `Perceptron]
+  globs := #[.submodules `Perceptron, `Perceptron_en]
 
 /-- Module `PacLearning` — théorie PAC (Valiant 1984), sample complexity classe finie.
 Frère de `Perceptron` dans le lake ML généraliste `learning_theory_lean` (cf
 `decision_theory_lean` qui mutualise Gittins + Utility + Coherence). Voir #4293. -/
 @[default_target]
 lean_lib «PacLearning» where
-  globs := #[.submodules `PacLearning]
+  globs := #[.submodules `PacLearning, `PacLearning_en]


### PR DESCRIPTION
## Summary

Last lake of EPIC #6585 (Lean i18n root-aggregator build coverage). Grain explicitly left as residual pool by po-2023 (c.484): sudoku_lean done in #6615 (OPEN); minimax #6601, decision_theory #6594, game_theory #6597 MERGED. This PR covers **learning_theory_lean**, the last confirmed remaining lake.

## Root cause (verified firsthand)

`MyIA.AI.Notebooks/ML/learning_theory_lean/lakefile.lean` declares two `lean_lib` targets:

```lean
lean_lib «Perceptron» where
  globs := #[.submodules `Perceptron]   -- covers subdir Perceptron/ only

lean_lib «PacLearning» where
  globs := #[.submodules `PacLearning]  -- covers subdir PacLearning/ only
```

`.submodules `X` covers the subdirectory recursively but **not the root sibling module `X_en`** (a root file `X_en.lean` is a distinct top-level module, not a submodule of `X`). The EN root aggregators `Perceptron_en.lean` and `PacLearning_en.lean` therefore exist on disk (added by #5752) but are **never type-checked by CI** — the CI builds green because the glob never reaches them.

## Fix

Mirror the proven merged pattern of #6601 (`globs := #[.submodules `Minimax, `Minimax_en]`):

```lean
lean_lib «Perceptron» where
  globs := #[.submodules `Perceptron, `Perceptron_en]

lean_lib «PacLearning» where
  globs := #[.submodules `PacLearning, `PacLearning_en]
```

## Build-safety (why inclusion cannot break the build)

The EN roots import only already-covered submodules:
- `Perceptron_en.lean` imports `Perceptron.Data`, `Perceptron.Perceptron`, `Perceptron.Convergence`, `Perceptron.Tightness`
- `PacLearning_en.lean` imports `PacLearning.{BernoulliMGF,Concentration,Data,Hoeffding,MGF,PacFiniteBound,Sample,SampleExpect,UnionBound}`

These submodules are covered by the existing `.submodules` globs and build fine (the FR roots `Perceptron.lean`/`PacLearning.lean` build green today). So adding the EN roots to the glob is a pure superset — once the submodules build, the EN roots build.

## Scope

1 file, +2/−2, atomic (only the two `globs` lines). No catalogue changes. `See #6585` (partial: ai-01 still to verify repeated_games_lean disposition — orphaned duplicate absorbed by game_theory #6146 per ai-01 c.482 steer, likely skip; not in this PR).

## Build verification (lean-merge-discipline)

Worker pattern (ai-01 c.482 division of labor): worker authors the trivial +N/−N glob change, **ai-01 gates the AUTHORITATIVE warm-cache `lake build`** before merge (cold Mathlib cache on worker machines makes a local 30-90min build cron-infeasible — same division that shipped #6601/#6594/#6597/#6615). `lake build` on ai-01 warm cache will build `Perceptron_en.olean` + `PacLearning_en.olean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)