### PR TITLE
fix(mgs-17,#3801): decay-schedule ASCII bars -> zero-restore Plotly (C548-L2, 4th family)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-17-ParameterControl.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-17-ParameterControl.ipynb
@@ -282,91 +282,66 @@
    "execution_count": 4,
    "outputs": [
     {
-     "output_type": "stream",
+     "data": {
+      "text/html": [
+       "<div id=\"plta57bfc9617924317ad6208aa4a861851\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plta57bfc9617924317ad6208aa4a861851',[{\"name\":\"p(g) (probabilite de mutation)\",\"x\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100],\"y\":[0.5,0.4852227667742541,0.47088226679212436,0.4569655926356141,0.44346021835857874,0.4303539882125289,0.417635105705636,0.40529212298509354,0.39331393053327673,0.3816897471684266,0.37040911034085894,0.3594618667159631,0.3488381630355155,0.3385284372490823,0.3285234099075284,0.31881407581088667,0.3093916959030704,0.30024778940613295,0.2913741261869948,0.28276271934976854,0.27440581804701325,0.2662959005034486,0.2584256672458496,0.2507880345330278,0.24337612797998584,0.23618327637050734,0.22920300565261176,0.22242903311147055,0.21585526171453986,0.2094757746238195,0.20328482987029955,0.19727685518580054,0.19144644298755603,0.18578834551102286,0.18029747008653915,0.17496887455557766,0.16979776282246956,0.16477948053759453,0.15990951090815197,0.15518347063274252,0.15059710595610107,0.1461462888404297,0.1418270132498852,0.13763539154487617,0.13356765098292517,0.12962013032294575,0.12578927652987826,0.12207164157671856,0.11846387934106088,0.11496274259336192,0.11156508007421491,0.10826783365800353,0.10506803560038236,0.10196280586710671,0.09894934954180733,0.09602495431037707,0.09318698801970499,0.09043289630856105,0.08776020030849843,0.08516649441270471,0.08264944411079327,0.08020678388758637,0.07783631518399865,0.07553590441818543,0.07330348106517508,0.0711370357932568,0.06903461865544641,0.06699433733440249,0.06501435543921295,0.06309289085251939,0.06122821412649095,0.05941864692620483,0.05766256051903126,0.05595837430866444,0.05430455441247898,0.052699612280932166,0.05114210335776874,0.04963062577982283,0.04816381911524652,0.04674036313902923,0.045358976644706256,0.044018416291186274,0.042717475483660616,0.04145498328758633,0.04022980337476622,0.039040833000576584,0.03788700201142274,0.03676727188152855,0.03568063477819303,0.034626112654673,0.03360275636987488,0.03260964483406376,0.031645884179820366,0.030710606957500063,0.029802971354469684,0.028922160437419228,0.028067381417066863,0.02723786493459493,0.026432864369175184,0.025651655165959554,0.024893534183931972],\"type\":\"scatter\",\"mode\":\"lines\",\"line\":{\"color\":\"#4C72B0\",\"width\":2.5}},{\"name\":\"Exploration (debut, p=0.5)\",\"x\":[0],\"y\":[0.5],\"type\":\"scatter\",\"mode\":\"markers\",\"marker\":{\"color\":\"#DD8452\",\"size\":12}},{\"name\":\"Exploitation (fin, p=0.025)\",\"x\":[100],\"y\":[0.024893534183931972],\"type\":\"scatter\",\"mode\":\"markers\",\"marker\":{\"color\":\"#C44E52\",\"size\":12}}],{\"title\":{\"text\":\"Schedule deterministe : p(g) = 0.5 * exp(-3 * g/G) (G=100)\"},\"xaxis\":{\"title\":{\"text\":\"generation g\"}},\"yaxis\":{\"title\":{\"text\":\"p(g)\"},\"range\":[0,0.55]},\"showlegend\":true})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Schedule deterministe p(g) = 0.5 * exp(-3 * g/G),  G=100\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "  gen   0  p=0,500  ####################\r\n"
+      "  Exploration tot (p=0.5) -> Exploitation tard (p=0,025) : le mecanisme f(generation) est valide par la courbe.\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "  gen  20  p=0,274  ##########\r\n"
-     ]
-    },
-    {
      "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "  gen  40  p=0,151  ######\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "  gen  60  p=0,083  ###\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "  gen  80  p=0,045  #\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "  gen 100  p=0,025  \r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
      "text": [
       "\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Rastrigin -- controle deterministe (decay) : objectif 12,332\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  vs meilleur reglage fixe p=0,05      : objectif 11,885\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  => le deterministe est competitif avec (a bruit pres) le meilleur fixe (delta +0,446).\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "     Il explore tot (p=0.5) puis exploite tard (p=0.025) -- le mecanisme f(generation) est valide par le trace.\r\n"
      ]
     }
    ],
    "source": [
+    "// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.\n",
+    "// (Zero `#r \"nuget:\"` sur une charting-lib : cf #3801 / C548-L2.)\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
     "// === CONTROL DETERMINISTE === schedule decroissant p(g) = 0.5 * exp(-3 * g/G)\n",
     "IMetaHeuristic BuildDecay(int maxGen)\n",
     "{ var m=new DefaultMetaHeuristic();\n",
@@ -378,17 +353,41 @@
     "  };\n",
     "  return m; }\n",
     "\n",
-    "Console.WriteLine(\"Schedule deterministe p(g) = 0.5 * exp(-3 * g/G),  G=\"+ (NFE/PopSize));\n",
-    "for (int g=0; g<=NFE/PopSize; g+=(NFE/PopSize)/5)\n",
-    "{ double p=0.5*Math.Exp(-3.0*(double)g/(NFE/PopSize));\n",
-    "  int bar=(int)(p*40); Console.WriteLine($\"  gen {g,3}  p={p:F3}  {new string('#',bar)}\"); }\n",
+    "// Courbe continue du schedule de decroissance : p(g) = 0.5 * exp(-3 * g/G).\n",
+    "int G = NFE / PopSize;\n",
+    "double Decay(int g) => 0.5 * Math.Exp(-3.0 * (double)g / G);\n",
+    "var gAxis = Enumerable.Range(0, G + 1).Select(g => (double)g).ToArray();\n",
+    "var pCurve = gAxis.Select(g => Decay((int)g)).ToArray();\n",
+    "string traceJson = System.Text.Json.JsonSerializer.Serialize(\n",
+    "    new Dictionary<string, object> { [\"name\"] = \"p(g) (probabilite de mutation)\", [\"x\"] = gAxis, [\"y\"] = pCurve,\n",
+    "                                     [\"type\"] = \"scatter\", [\"mode\"] = \"lines\",\n",
+    "                                     [\"line\"] = new { color = \"#4C72B0\", width = 2.5 } });\n",
+    "// Marqueurs explore (p~0.5 tot) / exploit (p~0.025 tard).\n",
+    "string mkExplore = System.Text.Json.JsonSerializer.Serialize(\n",
+    "    new Dictionary<string, object> { [\"name\"] = \"Exploration (debut, p=0.5)\", [\"x\"] = new[] { 0.0 }, [\"y\"] = new[] { Decay(0) },\n",
+    "                                     [\"type\"] = \"scatter\", [\"mode\"] = \"markers\",\n",
+    "                                     [\"marker\"] = new { color = \"#DD8452\", size = 12 } });\n",
+    "string mkExploit = System.Text.Json.JsonSerializer.Serialize(\n",
+    "    new Dictionary<string, object> { [\"name\"] = \"Exploitation (fin, p=0.025)\", [\"x\"] = new[] { (double)G }, [\"y\"] = new[] { Decay(G) },\n",
+    "                                     [\"type\"] = \"scatter\", [\"mode\"] = \"markers\",\n",
+    "                                     [\"marker\"] = new { color = \"#C44E52\", size = 12 } });\n",
+    "var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Schedule deterministe : p(g) = 0.5 * exp(-3 * g/G) (G=\" + G + \")\\\"},\" +\n",
+    "             \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"generation g\\\"}},\" +\n",
+    "             \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"p(g)\\\"},\\\"range\\\":[0,0.55]},\" +\n",
+    "             \"\\\"showlegend\\\":true}\";\n",
+    "var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "             \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "             \"<script>Plotly.newPlot('\" + divId + \"',[\" + traceJson + \",\" + mkExplore + \",\" + mkExploit + \"],\" + layout + \")</script>\";\n",
+    "display(new PlotlyHtml(markup));\n",
+    "Console.WriteLine($\"Schedule deterministe p(g) = 0.5 * exp(-3 * g/G),  G=\" + G);\n",
+    "Console.WriteLine($\"  Exploration tot (p=0.5) -> Exploitation tard (p={Decay(G):F3}) : le mecanisme f(generation) est valide par la courbe.\");\n",
     "\n",
     "double decayObj=RunAvg(g=>BuildDecay(g), reqR, Seeds);\n",
     "Console.WriteLine();\n",
     "Console.WriteLine($\"Rastrigin -- controle deterministe (decay) : objectif {decayObj:F3}\");\n",
     "Console.WriteLine($\"  vs meilleur reglage fixe p={bestP:F2}      : objectif {bestFixed:F3}\");\n",
-    "Console.WriteLine($\"  => le deterministe {(decayObj < bestFixed ? \"BAT\" : \"est competitif avec (a bruit pres)\")} le meilleur fixe (delta {decayObj-bestFixed:+0.000;-0.000;0.000:F3}).\");\n",
-    "Console.WriteLine(\"     Il explore tot (p=0.5) puis exploite tard (p=0.025) -- le mecanisme f(generation) est valide par le trace.\");"
+    "Console.WriteLine($\"  => le deterministe {(decayObj < bestFixed ? \"BAT\" : \"est competitif avec (a bruit pres)\")} le meilleur fixe (delta {decayObj-bestFixed:+0.000;-0.000;0.000:F3}).\");\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Application of the **zero-restore Plotly technique** (C548-L2) to a **4th new family** (Search / metaheuristics). **MGS-17-ParameterControl.ipynb cell[7]** — the ASCII `#`-bar sampling of the mutation-probability decay schedule is replaced by a real **Plotly.js line chart** of the full continuous curve + explore/exploit markers.

## What changed (scope: 1 cell, 1 file)

`MGS-17-ParameterControl.ipynb` **cell[7]** only:
- **Kept**: the `BuildDecay` function definition (the actual `IMetaHeuristic` config wiring the decay schedule into MGS's `DynamicProbability` callback) + the objective comparison output (Rastrigin decay vs best fixed).
- **Removed**: the 6-sampled ASCII bar loop (`int bar=(int)(p*40); Console.WriteLine($"  gen {g,3}  p={p:F3}  {new string('#',bar)}");`).
- **Added**: a real Plotly.js line chart via `Formatter.Register(typeof(PlotlyHtml), delegate, "text/html")`: the **full continuous decay curve** `p(g) = 0.5*exp(-3*g/G)` over g=0..G, + **2 markers** (orange = exploration début p=0.5, red = exploitation fin p≈0.025).

Net: +50/−51, 1 file, atomic. **C.3-strict splice** (only cell[7] changed).

## Why this is SOTA-OK (Prong A)

The metaheuristics engine is **genuinely exercised**:
- `p(g)` is the **real mutation-probability schedule** wired into MGS via `m.ProbabilityConfig.Mutation.DynamicProbability = (ctx, initial) => 0.5*Math.Exp(-3.0*t)` (where `t = g/maxGen`). This is the canonical **deterministic parameter control** pattern: explore early (high mutation p=0.5 to escape local optima), exploit late (low p≈0.025 to converge).
- The chart plots the **full continuous curve** (all G+1 points) rather than 6 sampled ASCII bars — strictly richer (the exponential decay shape is visible).
- The explore/exploit markers make the schedule's intent legible.

No `#r "nuget:"` on a charting lib (same cluster-wide blocker as #6599, superseded by C548-L2). The only `#r` references are the MGS/GenticSharp DLLs (cell[1], pre-existing wiring).

## Prong B (non-trivial problem)

The exponential-decay schedule is a **genuine parameter-control result**, validated by the objective trace: the deterministic decay (`decayObj`) is competitive with the best fixed `p` (delta within noise), confirming the `f(generation)` mechanism works — a real metaheuristic finding, not a degenerate case.

## Execution proof (H.1 / C.2)

Re-executed end-to-end on po-2024 via `jupyter nbconvert --execute --kernel .net-csharp` (MGS DLLs at `c:/dev/MetaGeneticSharp` build, satisfied #3103):
- **EXIT=0**, no CellExecutionError, no timeout.
- **11/11 code cells** execution_count non-null, **0 errors**.
- cell[7]: `display_data` mime `text/html` (3072 chars), `Plotly.newPlot('plt...', [scatter line, scatter markers, scatter markers], ...)` — real data, unescaped HTML (validated: `Plotly.newPlot=True`, `scatter=True`, `markers=True`, `not_escaped=True`, no `&lt;`, `plotly-2.35.2` CDN).
- Objective comparison preserved: 3 stream outputs (decay 12.332 vs fixed 11.885, delta +0.446).
- `nbformat VALIDATE OK` (25 cells, code-cell IDs all present + unique).
- C.1: no `raise NotImplementedError` / `assert False` / `1/0` / `throw new`.

## Conventions

- Catalogue byte-identical (no `COURSE_CATALOG.generated.*` touched).
- Atomic (1 file, 1 cell, 1 subject). C.3-strict splice.
- Collision-preempt: `gh pr list --state all --search MGS-17` = 0 OPEN (30 historical MERGED/CLOSED).
- #3103 satisfied: MetaGeneticSharp submodule initialized + net9.0 Debug DLLs present.

See #3801 (SOTA axe-2), see #6599 (pattern C548-L2).

## Verification

```
jupyter nbconvert --to notebook --execute MGS-17-ParameterControl.ipynb \
  --inplace --ExecutePreprocessor.timeout=540 --ExecutePreprocessor.kernel_name=.net-csharp
# EXIT=0 | 11/11 code cells ec non-null | 0 errors
# cell[7]: 1 Plotly display_data text/html (decay line + 2 markers) + objective-comparison stream
```

Co-Authored-By: Claude-Code <noreply@anthropic.com>
