### PR TITLE
docs(sudoku,#3975): correct _output count in editorial note (gitignored, not committed)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -9,7 +9,7 @@ maturity: PRODUCTION=30, BETA=5, ALPHA=1
 
 > **Note éditoriale (counts)** : Le marqueur `CATALOG-STATUS` ci-dessus est autoritatif pour le compte agrégé (36 notebooks canoniques). Pour la **décomposition langagière par kernel** (`metadata.kernelspec.language`), ce README reste autoritatif car la granularité kernel n'est pas dans le marqueur agrégé ; elle est documentée ici par lecture directe des kernelspecs au 10/07/2026 :
 >
-> **17 C# + 18 Python + 1 Lean 4 = 36 notebooks canoniques ✓** (44 fichiers `*.ipynb` au total sur disque = 36 canoniques + 8 `_output.ipynb` artefacts Papermill commités couvrant 8 notebooks Python : Choco 11, Infer 15, NN 16, LLM 17, DancingLinks 2, Genetic 3, PSO 5, GraphColoring 9).
+> **17 C# + 18 Python + 1 Lean 4 = 36 notebooks canoniques ✓** (36 fichiers `*.ipynb` canoniques au total dans le dépôt — les artefacts Papermill `_output.ipynb` sont gitignored, locaux à la machine d'exécution et non commités).
 >
 > Sudoku est un cas de **mixité JUMEAUX C#/Python dominante** (14 paires strictes 1-14 + 1 paradigme-comparable 15 Infer.NET/NumPyro + 1 benchmark 18, soit 16 entrées à 2 langages) avec **1 companion Lean natif intra-hub** (`Sudoku-19-Lean-Propagation.ipynb`, lake `sudoku_lean` 0-sorry). C'est une **variante L392 #4** : contrairement à QC (#5917) où Lean est isolé dans une sous-série dédiée `kelly_lean/`, et contrairement à ML (#5915) / Probas (#5916) où la mixité kernel est intra-série, ici la mixité jumeaux domine largement et le notebook tiers (Lean) est intra-hub sans sous-série dédiée.
 >


### PR DESCRIPTION
## §E fichier-entier audit — Sudoku feuille README (#3975, owner po-2025:CoursIA-2)

Part of the README feuille rollout steered by ai-01 (non-viz durable substance, R6-rotation away from path-leak/ASCII-viz registers).

## Drift found (firsthand, origin/main)

The authoritative kernel-breakdown editorial note (L12) claimed:
> "44 fichiers `.ipynb` au total sur disque = 36 canoniques + **8 `_output.ipynb` artefacts Papermill commités** couvrant 8 notebooks Python : Choco 11, Infer 15, NN 16, LLM 17, DancingLinks 2, Genetic 3, PSO 5, GraphColoring 9"

**Disk truth:**
- `git ls-files 'MyIA.AI.Notebooks/Sudoku/*.ipynb'` = **36** canonical notebooks tracked (17 C# + 18 Python + 1 Lean). All README counts verify correct.
- `git check-ignore` confirms `*_output.ipynb` are **GITIGNORED** — local Papermill artifacts, **NOT committed**. `git ls-files '*_output'` returns empty for Sudoku.
- So "8 commités" is wrong on **two counts**: the number (4 local, not 8) AND the claim (they are not committed at all). The listed notebooks NN/LLM/DancingLinks/Genetic/GraphColoring do not have committed outputs.

## Fix

State the durable truth: 36 canonical tracked notebooks; `_output.ipynb` are gitignored local execution artifacts, not committed. Removes the machine-dependent local-file count from the authoritative note.

## §E fichier-entier verification (not just the corrected line)

| Audit point | Result |
|---|---|
| Canonical count (36) | ✓ disk = 36 tracked |
| Kernel split (17 C# + 18 Python + 1 Lean) | ✓ filename-suffix count matches |
| Pair count (16 mirror) | ✓ notebooks 1-15 + 18 = 16 two-language pairs |
| Structure tree (L615-700) | ✓ lists all 36, `comm -3` tree↔disk = empty diff |
| #3969 grilles / #3921 SC-13 fuzzing drivers | ✓ reflected (21 grep hits) |
| "18 solveurs" (L780) | ✓ defensible (18 Python notebooks) |
| CATALOG-STATUS marker (L3-8) | untouched (auto-regenerated by catalog-cron) |
| Catalogue | byte-identical to main (catalog-pr-hygiene R1) |

Only L12 was drifted; the rest of the 811-line README is accurate. Editorial prose is hand-maintained (`grep` of catalog scripts emits no "Note éditoriale"/"mixité JUMEAUX" prose; precedent #6496/#5923 hand-edited this block) — safe to edit, not silently reverted by cron.

See #3975 See #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)