### PR TITLE
fix(rl-7,#3436): filter pygame pkg_resources deprecation UserWarning path-leak (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb
@@ -88,22 +88,16 @@
      "text": [
       "PettingZoo charge avec succes\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pygame\\pkgdata.py:25: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.\n",
-      "  from pkg_resources import resource_stream, resource_exists\n"
-     ]
     }
    ],
    "source": [
+    "import warnings\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "warnings.filterwarnings(\"ignore\", message=\"pkg_resources is deprecated\")  # advisory pygame import (#3436 path-leak)\n",
     "from pettingzoo.classic import tictactoe_v3\n",
     "\n",
-    "print(\"PettingZoo charge avec succes\")"
+    "print(\"PettingZoo charge avec succes\")\n"
    ]
   },
   {


### PR DESCRIPTION
## What

`rl_7_multi_agent_rl.ipynb` **cell[2]** (pettingzoo import) leaked a machine path into committed output via a pygame advisory UserWarning. **Cause-C source leak**, fixed at the source + re-executed (Stop & Repair — not output scrubbing).

## Root cause (verified firsthand, reproduced on fresh install)

cell[2] `from pettingzoo.classic import tictactoe_v3` triggers pygame import → `pygame/pkgdata.py:25` emits:
```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/...
  from pkg_resources import resource_stream, resource_exists
```
The warning embeds the absolute user-site path `~\AppData\Roaming\Python\Python313\site-packages\pygame\pkgdata.py:25` (machine path). Same defect class as the PyMC-16 BLAS path-leak (#6623): a library UserWarning printing its own file path.

## Fix (cause-C, matches PyMC-16 pattern)

Add to cell[2] **before** the pettingzoo import:
```python
import warnings
warnings.filterwarnings("ignore", message="pkg_resources is deprecated")  # advisory pygame import (#3436 path-leak)
```
The filter suppresses the advisory (pygame still functions correctly), removing the path leak at its source. The leak cannot resurface on next exec because the warning is suppressed at emit time.

## Execution proof (EXEC_PROVED, H.1)

| Check | Result |
|-------|--------|
| Env installed (rule F) | pettingzoo 1.26.1, pygame 2.6.1, gymnasium 1.3.0 |
| Faithful re-exec | mini-notebook + `nbconvert --execute` (real kernel output), EXIT=0 |
| cell[2] execution_count | 1 (not null) |
| cell[2] outputs | 1 stream: `PettingZoo charge avec succes` (was 2: success + leak stderr) |
| Machine-path leak tokens | **0** (AppData/miniconda3/ProgramData/site-packages/pkgdata/pkg_resources is deprecated — all absent) |
| Whole-notebook residual leak scan | **0 hits** |
| C.3 surgical scope | only cell[2] source+outputs changed; 30 cells preserved; heavy training cells[15/20] untouched |
| Line endings | LF-only |

## Why surgical cell[2]-only re-exec (C.3)

The leak originates at the first pygame import (cell[2]). The heavy cells[15] `def train_iql(num_episodes=20000)` and cells[20] `evaluate_against_random(num_games=1000)` are **not modified** and their outputs are preserved byte-for-byte — only cell[2] (the import whose warning leaked) is re-executed. Rule C.3: commit only cells whose source changed.

## Scope

1 file, +4/−10. No catalogue changes. `See #3436` (path-leak family repo-wide; this PR addresses the rl_7 pygame leak specifically, does not close the meta-issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)