### PR TITLE
docs(tweety,#3975): reconcile C# count in two table-coverage notes (18/12 vs stale 16/14)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -177,11 +177,11 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 11 | [Tweety-11-Causal](Tweety-11-Causal.ipynb) | Raisonnement causal : do-calculus, interventions, contrefactuels | 50 min  | Python |
 | 11c | [Tweety-11-Causal-Csharp](Tweety-11-Causal-Csharp.ipynb) | Twin C# moteur causal booléen from-scratch (do-operator, contrefactuel) | 35 min  | C# PROD |
 
-**Durée totale estimée** : ~13h (Python) + ~7h (C#/.NET). Le tableau ci-dessus couvre les **29 notebooks principaux** (12 Python + 16 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
+**Durée totale estimée** : ~13h (Python) + ~7h (C#/.NET). Le tableau ci-dessus couvre les **31 notebooks principaux** (12 Python + 18 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
 
 ## En quoi chaque notebook est unique
 
-Chaque notebook introduit un concept ou cadre théorique spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun — couvrant les **27 notebooks principaux** (12 Python + 14 C#/.NET + 1 Lean companion) :
+Chaque notebook introduit un concept ou cadre théorique spécifique. Le tableau ci-dessous résume en une ligne l'apport pédagogique de chacun — couvrant les **25 notebooks principaux** (12 Python + 12 C#/.NET + 1 Lean companion) :
 
 | #  | Notebook                      | Concept clé enseigné                                                    |
 |----|-------------------------------|--------------------------------------------------------------------------|


### PR DESCRIPTION
## §E fichier-entier audit — Tweety feuille README (#3975)

Continues the README feuille rollout (#3975, owner po-2025:CoursIA-2). Two table-coverage prose notes had drifted C# counts, verified firsthand by row-counting each table.

## Drift found

| Note | Claimed | Actual (row count) | Disk truth |
|---|---|---|---|
| **Timing table (L180)** "Le tableau ci-dessus couvre…" | 29 notebooks (12 Py + **16** C# + 1 Lean) | 31 rows = **18** C# + 13 non-C# | 31 canonical (18 C# + 12 Py + 1 Lean) |
| **Uniqueness table (L184)** "Le tableau ci-dessous résume…" | 27 notebooks (12 Py + **14** C# + 1 Lean) | 25 rows = **12** C# + 13 non-C# | — (table is a subset) |

The two tables genuinely differ in size (timing table lists all 31 notebooks; uniqueness table lists 25 — it omits some C# extensions). So the two totals being different is **correct**; what was wrong was the **C# count in each** (16 vs 18, and 14 vs 12).

## Fix (content-based, not blind re-derivation)

- L180: `29 (12 Python + 16 C# + 1 Lean)` → `31 (12 Python + **18** C# + 1 Lean)`
- L184: `27 (12 Python + 14 C# + 1 Lean)` → `25 (12 Python + **12** C# + 1 Lean)`

## §E fichier-entier verification

| Point | Result |
|---|---|
| Disk canonical count | 31 (`git ls-files`, 18 `-Csharp` + 12 Python + 1 Lean) ✓ matches timing-table rows |
| Timing table row count | 31 notebook link-rows (18 C# + 13 non-C#) ✓ |
| Uniqueness table row count | 25 data rows (12 C# + 13 non-C#) ✓ (awk count) |
| L66 "13 notebooks" Python block | ✓ correct (12 Python + 1 Lean = 13) |
| CATALOG-STATUS marker (32 vs disk 31) | untouched — catalog-cron's job (R1), self-heals |
| Catalogue | byte-identical to main |
| Editorial prose | hand-written (catalog scripts emit none of this prose; precedent #5411/#5365) |

See #3975 See #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)