### PR TITLE
fix(sl-8,#3436): disable pip version-check notice path-leak (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP.ipynb
@@ -136,20 +136,11 @@
      "text": [
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 23.0.1 -> 26.1.2\n",
-      "[notice] To update, run: ~\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip\n"
-     ]
     }
    ],
    "source": [
     "# Installation silencieuse de rdflib\n",
-    "%pip install -q rdflib"
+    "%pip install -q --disable-pip-version-check rdflib"
    ]
   },
   {


### PR DESCRIPTION
fix(sl-8,#3436): disable pip version-check notice path-leak (Stop & Repair)

cell[3] `%pip install -q rdflib` emitted the pip-upgrade notice embedding
the machine user path: `[notice] To update, run: ~\AppData\Local\Programs\Python\Python310\python.exe -m pip install --upgrade pip`.

Cause fix (Stop & Repair, not output scrub): add `--disable-pip-version-check`
to the install line. Re-exec cell[3] via nbconvert --execute (real kernel output),
verified leak-free (no AppData/site-packages/Python310/python.exe tokens; only the
benign `Note: you may need to restart the kernel...` advisory remains).

Surgical C.3: only cell[3] source + outputs changed, 62/62 cells byte-identical
to origin/main. EXEC_PROVED (ec=1, 1 output).

See #3436

Co-Authored-By: Claude-Code <noreply@anthropic.com>
