### PR TITLE
fix(security,#6312): strip probeAddresses banner from 7 .NET notebooks (repo-wide sweep)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
@@ -68,7 +68,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -78,10 +78,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -96,7 +96,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -108,8 +108,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%12:2048/\",\"http://172.26.48.1:2048/\",\"http://fe80::4242:e8b9:6bbf:ef2c%50:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:4c49:ea51:a5f7:8b03:2048/\",\"http://2a01:e0a:9d4:f320:6d91:40d7:528:51b3:2048/\",\"http://2a01:e0a:9d4:f320:7042:4896:3da8:dc2a:2048/\",\"http://2a01:e0a:9d4:f320:c942:e5c4:12e2:6ae2:2048/\",\"http://2a01:e0a:9d4:f320:cde3:e6ed:6b4:42df:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -158,13 +158,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb
@@ -147,7 +147,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -157,10 +157,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -175,7 +175,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -187,8 +187,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.105:2048/\", \"http://172.21.208.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -237,13 +237,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
@@ -71,7 +71,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -81,10 +81,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -99,7 +99,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -111,8 +111,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%12:2048/\",\"http://172.26.48.1:2048/\",\"http://fe80::4242:e8b9:6bbf:ef2c%50:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:4c49:ea51:a5f7:8b03:2048/\",\"http://2a01:e0a:9d4:f320:6d91:40d7:528:51b3:2048/\",\"http://2a01:e0a:9d4:f320:7042:4896:3da8:dc2a:2048/\",\"http://2a01:e0a:9d4:f320:c942:e5c4:12e2:6ae2:2048/\",\"http://2a01:e0a:9d4:f320:cde3:e6ed:6b4:42df:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -161,13 +161,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
@@ -84,7 +84,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -94,10 +94,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -112,7 +112,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -124,8 +124,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%12:2048/\",\"http://172.26.48.1:2048/\",\"http://fe80::4242:e8b9:6bbf:ef2c%50:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:4c49:ea51:a5f7:8b03:2048/\",\"http://2a01:e0a:9d4:f320:6d91:40d7:528:51b3:2048/\",\"http://2a01:e0a:9d4:f320:7042:4896:3da8:dc2a:2048/\",\"http://2a01:e0a:9d4:f320:c942:e5c4:12e2:6ae2:2048/\",\"http://2a01:e0a:9d4:f320:cde3:e6ed:6b4:42df:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -174,13 +174,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
@@ -75,7 +75,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -85,10 +85,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -103,7 +103,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -115,8 +115,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%12:2048/\",\"http://172.26.48.1:2048/\",\"http://fe80::4242:e8b9:6bbf:ef2c%50:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:4c49:ea51:a5f7:8b03:2048/\",\"http://2a01:e0a:9d4:f320:6d91:40d7:528:51b3:2048/\",\"http://2a01:e0a:9d4:f320:7042:4896:3da8:dc2a:2048/\",\"http://2a01:e0a:9d4:f320:c942:e5c4:12e2:6ae2:2048/\",\"http://2a01:e0a:9d4:f320:cde3:e6ed:6b4:42df:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -165,13 +165,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
@@ -46,7 +46,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -56,10 +56,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -74,7 +74,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -86,8 +86,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:44ae:ab2c:b59:638f:2048/\",\"http://2a01:e0a:9d4:f320:7153:b672:e4ea:ce97:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%13:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%21:2048/\",\"http://172.20.144.1:2048/\",\"http://fe80::4899:25d5:919d:5c8a%49:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -136,13 +136,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
@@ -74,7 +74,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -84,10 +84,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -102,7 +102,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -114,8 +114,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:e752:1064:583e:9fb4:2048/\",\"http://2a01:e0a:9d4:f320:44ae:ab2c:b59:638f:2048/\",\"http://2a01:e0a:9d4:f320:7153:b672:e4ea:ce97:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%13:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3b5c:d316:6200:c69%21:2048/\",\"http://172.20.144.1:2048/\",\"http://fe80::4899:25d5:919d:5c8a%49:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -164,13 +164,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",


### PR DESCRIPTION
## Summary
The .NET Interactive kernel injects a `probeAddresses` `display_data` output in the first code cell, embedding the executing host's network interfaces (LAN `192.168.x`, Docker/WSL bridge `172.x`, localhost) into committed notebook JSON. On a public repo this leaks the maintainer's host addresses. 7 notebooks re-acquired the banner via recent Prong-A re-execs (6 last cycle) + DecInfer-7 (#6626).

## Fix
Ran the canonical deterministic strip `scripts/notebook_tools/strip_probe_banner.py --apply-all` (#6312).

- **Output-only, surgical text-level**: `execution_count` and all source preserved, byte-identity elsewhere.
- **Verified**: `--scan-all --check` exits 0 for the main repo; `git diff` shows **0** `execution_count`/`source` changes (63/63 balanced output-array edits).
- **Not a hand-edit**: the cause (kernel injection) cannot be fixed by re-exec — re-exec re-injects the banner — so the sanctioned scripted strip is the compliant remediation (Stop & Repair exception for the canonical tool).

## Scope note
`Z3.Linq/solutions/polyglot-repro/CrossSubmissionCaptureRepro.ipynb` lives in the **Z3.Linq submodule** (`MyIntelligenceAgency/Z3.Linq`) and is **excluded** — it needs a separate PR against that repo (tracked follow-up).

## Files (7)
GameTheory-8c, DecInfer-7, Infer-17, Infer-18, Infer-19, App-7b-Wordle, Sudoku-18.

See #6312 (canonical strip), #6309 (post-mortem), regression of #2727/#2733.

Credit: po-2025 correctly flagged the banner re-injection on #6626 — this sweep addresses it comprehensively rather than only that one notebook.

Co-Authored-By: Claude Opus 4.8 (1M context)