### PR TITLE
fix(qc-dataset,#3436): QC-Py-Dataset-Workflow cell1 path-leak (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
@@ -49,7 +49,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Datasets dir: C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\datasets\n"
+      "Datasets dir: ..\\datasets\n"
      ]
     }
    ],
@@ -64,7 +64,7 @@
     "DATASETS_DIR = Path(\"../datasets\")\n",
     "DATASETS_DIR.mkdir(exist_ok=True)\n",
     "\n",
-    "print(f\"Datasets dir: {DATASETS_DIR.resolve()}\")"
+    "print(f\"Datasets dir: {DATASETS_DIR}\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

`QC-Py-Dataset-Workflow` cell1 printed the absolute datasets dir via `print(f"Datasets dir: {DATASETS_DIR.resolve()}")`, leaking the machine path (`C:\dev\CoursIA\...`) into the committed cell output.

## Fix — cause-C source leak (Stop & Repair, NOT output scrub)

Drop `.resolve()` so the printed path is **relative** (`../datasets`). The semantic intent (show where datasets land) is preserved via the relative path without leaking the machine. Per `secrets-hygiene.md` rule 6 + SOTA `Stop & Repair`: fix the cause, re-execute — never hand-edit the output.

```diff
- print(f"Datasets dir: {DATASETS_DIR.resolve()}")
+ print(f"Datasets dir: {DATASETS_DIR}")
```

## Validation — EXEC_PROVED (C.3 surgical)

- Re-executed **cell1 only** with `py -3.13` (kernelspec match: Python 3.13.7; pandas+matplotlib available), `cwd = Python/` so `../datasets` resolves identically to the original run.
- `returncode 0`, stdout = `Datasets dir: ..\datasets`, `execution_count = 1`, 1 output.
- **0 leak-token** verified on the new output: `C:\dev`, `D:\dev`, `jsboi`, `AppData`, `miniconda`, `CoursIA` all absent.
- Diff **+2/-2**, only cell1 touched (1 source line + its single output line). The other 13 cells are byte-identical to `origin/main`.

## SOTA verdict

`RECOVERABLE-LOCAL` — local kernel `python3`, no `QuantBook` dependency, no GPU. Rule F satisfied (env installed, real re-exec, not a workaround).

## Scope — new sub-register for #3436

The QC Python family (kernel `python3`, local-executable, **not** QuantBook) was not covered by the existing path-leak sweeps: PyMC (po-2025), RL+SL (po-2024). A scan of 203 QC notebooks found 3 local-executable path-leaks (machine path in output); this PR fixes the most atomic one. The other 2 (`ML-Research-Template` cell1, `QC-Py-31-Transformer-Training` cell25) need cwd/GPU handling respectively and are left for focused windows.

See #3436