### PR TITLE
fix(ml-template,#3436): ML-Research-Template cell1 path-leak (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/ML-Research-Template.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/ML-Research-Template.ipynb
@@ -51,8 +51,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dependances chargees\n",
-      "Scripts dir: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\ML-Training-Pipeline\\scripts\n"
+      "Dependances chargees\nScripts dir: scripts\n"
      ]
     }
    ],
@@ -78,12 +77,13 @@
     "    raise FileNotFoundError(\"Cannot find scripts/ directory with train_classification.py\")\n",
     "sys.path.insert(0, str(_scripts_dir))\n",
     "\n",
+    "import os\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "print(\"Dependances chargees\")\n",
-    "print(f\"Scripts dir: {_scripts_dir}\")"
+    "print(f\"Scripts dir: {os.path.relpath(_scripts_dir)}\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

`ML-Training-Pipeline/ML-Research-Template` cell1 printed the absolute scripts directory via `print(f"Scripts dir: {_scripts_dir}")`, leaking the machine path (`D:\dev\CoursIA\...scripts`) into the committed cell output.

## Fix — cause-C source leak (Stop & Repair, NOT output scrub)

Print `os.path.relpath(_scripts_dir)` so the displayed path is **relative** (`scripts` when run from the `ML-Training-Pipeline/` dir). The semantic intent (show where the `scripts/` modules were located) is preserved via the relative path without leaking the machine. Per `secrets-hygiene.md` rule 6 + SOTA `Stop & Repair`: fix the cause, re-execute — never hand-edit the output.

```diff
+ import os
  ...
- print(f"Scripts dir: {_scripts_dir}")
+ print(f"Scripts dir: {os.path.relpath(_scripts_dir)}")
```

The detection logic (`Path.cwd()` walk-up + `train_classification.py` marker) and `sys.path.insert(0, str(_scripts_dir))` (absolute — needed for Python imports, never printed) are **unchanged**. Only the display line changes.

## Validation — EXEC_PROVED (C.3 surgical)

- Re-executed **cell1 only** with `py -3.13` (kernelspec match), `cwd = ML-Training-Pipeline/` so the `Path.cwd()` walk-up finds `scripts/` identically to a normal notebook run.
- `returncode 0`, stdout = `Dependances chargees\nScripts dir: scripts\n`, `execution_count = 1`, 1 output.
- **0 leak-token** verified on the new output: `C:\dev`, `D:\dev`, `jsboi`, `AppData`, `miniconda`, `CoursIA` all absent.
- Whole-notebook residual leak scan: **0**.
- Diff **+4/-4**, only cell1 touched (1 output line + 2 source lines + EOF newline). The other 7 code cells are byte-identical to `origin/main`.

## SOTA verdict

`RECOVERABLE-LOCAL` — local kernel `python3`, no `QuantBook`, no GPU. Rule F satisfied.

## Sub-register progress — QC Python path-leak #3436

2/3 local-executable QC path-leaks now fixed: `QC-Py-Dataset-Workflow` (#6634, merged) + this PR. `QC-Py-31` cell25 remains (GPU training output → `RECOVERABLE-MACHINE`, focused window).

See #3436