### PR TITLE
feat(ci,security,#6642): banner-guard — fail PRs committing probeAddresses banner

### DIFF
--- a/.github/workflows/banner-guard.yml
+++ b/.github/workflows/banner-guard.yml
@@ -1,0 +1,65 @@
+name: banner-guard
+
+# Durable anti-regression guard for the .NET Interactive `probeAddresses` banner
+# leak vector (secrets-hygiene.md, Stop & Repair). The banner is injected by the
+# dotnet-interactive kernel into the FIRST code cell's text/html output and embeds
+# the host's network interfaces (LAN 192.168.x, Docker/WSL 172.x, and sometimes a
+# public IPv6) -- a machine-fingerprint leak committed with the notebook outputs.
+#
+# No active gate caught it until now: the pre-commit hooks are disabled and
+# pip-leak-guard.yml only inspects `!pip install` cells. This workflow closes that
+# gap by FAILING any PR that commits a banner into a main-repo notebook. The fix is
+# the canonical output-only surgical strip (Stop & Repair-compliant, NOT a hand-edit
+# of a cell output -- re-execution re-injects, so the strip is the durable form).
+#
+# Scope: main-repo notebooks only (`--exclude-submodules`). Submodules are separate
+# repos with their own CI; the Z3.Linq residual is tracked in #6633 against
+# MyIntelligenceAgency/Z3.Linq. Mirrors the #6312 probeAddresses `--apply` sweep,
+# transposed to a durable CI guard (cf pip-leak-guard.yml design note).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.ipynb'
+      - 'scripts/notebook_tools/strip_probe_banner.py'
+      - '.github/workflows/banner-guard.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - '**.ipynb'
+      - 'scripts/notebook_tools/strip_probe_banner.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: banner-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  banner-scan:
+    name: "probeAddresses banner guard (main-repo notebooks)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # Default checkout does not initialise submodules; --exclude-submodules is a
+      # belt-and-suspenders so the guard stays main-repo-only even run locally.
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: "Fail if any probeAddresses banner is committed"
+        run: |
+          if ! python scripts/notebook_tools/strip_probe_banner.py --scan-all --check --exclude-submodules; then
+            echo ""
+            echo "::error::A probeAddresses banner was committed in a notebook output -- it leaks this repo runner's / a contributor's host network interfaces."
+            echo "Fix (output-only surgical strip, Stop & Repair-compliant, NOT a hand-edit):"
+            echo "    python scripts/notebook_tools/strip_probe_banner.py --apply <path>"
+            echo "then re-commit. Re-executing a .NET notebook re-injects the banner, so run the strip after every re-exec before committing."
+            exit 1
+          fi

--- a/scripts/notebook_tools/strip_probe_banner.py
+++ b/scripts/notebook_tools/strip_probe_banner.py
@@ -385,6 +385,28 @@ def iter_notebooks(nb_root):
         yield path
 
 
+def submodule_dirs(repo_root):
+    """Absolute paths of git submodule directories declared in .gitmodules.
+
+    Used by --exclude-submodules so the CI banner-guard scans main-repo
+    notebooks only. Submodules are separate repos with their own CI (e.g. the
+    Z3.Linq notebook residual is tracked in #6633 against MyIntelligenceAgency/Z3.Linq).
+    """
+    gitmodules = os.path.join(repo_root, ".gitmodules")
+    dirs = []
+    if not os.path.isfile(gitmodules):
+        return dirs
+    with open(gitmodules, "r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped.startswith("path"):
+                _, _, rel = stripped.partition("=")
+                rel = rel.strip()
+                if rel:
+                    dirs.append(os.path.abspath(os.path.join(repo_root, rel)))
+    return dirs
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Strip the .NET Interactive probeAddresses banner from notebooks"
@@ -400,6 +422,10 @@ def main():
                        help="fix repo-wide in place")
     parser.add_argument("--check", action="store_true",
                         help="with --scan-all: exit 1 if any banner found")
+    parser.add_argument("--exclude-submodules", action="store_true",
+                        help="skip notebooks inside git submodules (main-repo only; "
+                             "used by the CI banner-guard so it stays green while a "
+                             "submodule residual is tracked in its own repo)")
     args = parser.parse_args()
 
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -417,6 +443,17 @@ def main():
         paths = [target]
     else:
         parser.error("path not found: %s" % target)
+
+    if args.exclude_submodules:
+        subs = submodule_dirs(repo_root)
+        if subs:
+            before = len(paths)
+            paths = [p for p in paths
+                     if not any(os.path.abspath(p).startswith(s + os.sep) for s in subs)]
+            excluded = before - len(paths)
+            if excluded:
+                print("(excluded %d notebook(s) inside %d submodule(s))"
+                      % (excluded, len(subs)))
 
     total_files = 0
     total_banners_found = 0


### PR DESCRIPTION
## Summary

Durable CI guard closing the **probeAddresses banner gate-gap** (#6642). The .NET Interactive kernel injects host network interfaces into a notebook's first `text/html` output; after the pre-commit hooks were disabled and given `pip-leak-guard.yml` only inspects `!pip install`, **no active gate** caught this leak. Re-executing a .NET notebook re-injects the banner, so a one-time `--apply` sweep (#6312) does not prevent regressions.

## Changes (2 files, +102)

- **`.github/workflows/banner-guard.yml`** (new) — fails any PR/push that commits a probeAddresses banner into a main-repo notebook. Absolute check (main repo is currently banner-clean). Failure message points authors to the canonical fix.
- **`scripts/notebook_tools/strip_probe_banner.py`** (+37) — additive `--exclude-submodules` flag so the guard scans **main-repo notebooks only**. Existing `--scan` / `--scan-all` / `--apply` / `--apply-all` behaviour is **unchanged** (still catches the submodule, used to find the Z3.Linq residual today).

## Why absolute (not delta like pip-leak-guard)

The main repo is already banner-clean (`--scan-all --check --exclude-submodules` = EXIT 0). Banners are **always** unwanted (they leak host IPs), so there are no inherited leaks to tolerate — an absolute guard is simpler and stricter. The author fix is the canonical **output-only surgical strip** (`strip_probe_banner.py --apply <path>`), which is Stop & Repair-compliant (NOT a hand-edit of a cell output — re-exec re-injects, so the deterministic strip is the durable form).

## Scope: main-repo only

Submodules are separate repos with their own CI. The Z3.Linq residual (`CrossSubmissionCaptureRepro.ipynb`, 9 banner lines) is tracked in **#6633** against MyIntelligenceAgency/Z3.Linq, not here.

## Verification (local)

| Command | Exit | Result |
|---|---|---|
| `--scan-all --check --exclude-submodules` | 0 | main clean, 6 submodule notebooks excluded (guard is GREEN) |
| `--scan-all --check` (unchanged) | 1 | still catches the Z3.Linq submodule notebook |
| `--help` | — | lists the new flag |
| `yaml.safe_load(banner-guard.yml)` | OK | 1 job, triggers pull_request/push/workflow_dispatch |

No notebooks re-executed, no catalogue regenerated (catalog byte-identical to main — 0 notebook touched).

## Scope / refs

`Closes #6642`. `See #6312` (founding sweep), `See #6633` (submodule residual). Mirrors `pip-leak-guard.yml` design (#6314), transposed from delta to absolute since main is clean.

CI-infra PR — ai-01 domain (workers are forbidden from `.github/workflows`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>