### PR TITLE
fix(translation,#4957): resync smartcontracts.csv 1 SRC_DRIFT (SC-17 tally-code) 1->0

### DIFF
--- a/translations/smartcontracts/smartcontracts.csv
+++ b/translations/smartcontracts/smartcontracts.csv
@@ -14271,7 +14271,9 @@ MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Ve
 
 Grace a la propriete additive de Paillier, on peut **additionner les bulletins chiffres**
 sans les dechiffrer. Seul le **total** est ensuite dechiffre.",,,,,,,,ac33272b4cb78f1b,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb,tally-code,code,fr,a13d2038d9cd385b,"# Addition homomorphique des bulletins
+MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb,tally-code,code,fr,e4002348447450e8,"# Addition homomorphique des bulletins
+# (SOTA Prong-A #3801 : la barre ASCII devisualisation est remplacee par un vrai
+#  graphique matplotlib ; le decompte homomorphique Paillier, lui, est inchange.)
 if PHE_AVAILABLE:
     print(""DECOMPTE HOMOMORPHIQUE"")
     print(""="" * 60)
@@ -14292,9 +14294,8 @@ if PHE_AVAILABLE:
 
     print(""RESULTATS :"")
     print(""-"" * 40)
-    for i, (candidate, votes) in enumerate(zip(candidates, results)):
-        bar = ""#"" * votes
-        print(f""  {candidate:20s} : {votes} votes  {bar}"")
+    for candidate, votes in zip(candidates, results):
+        print(f""  {candidate:20s} : {votes} votes"")
     print(f""  {'Total':20s} : {sum(results)} votes"")
     print()
 
@@ -14304,9 +14305,35 @@ if PHE_AVAILABLE:
         expected[v[""choice""]] += 1
     assert results == expected, ""Le decompte homomorphique doit correspondre au decompte manuel""
     print(""-> Verification : le decompte homomorphique correspond au decompte en clair"")
+
+    # Visualisation : repartition des voix dechiffrees (matplotlib, remplace l'ASCII).
+    # Rendu via savefig + IPython.display.Image (backend Agg headless : plt.show()
+    # n'affiche rien en sortie et emet un avertissement ; savefig garantit un PNG).
+    import matplotlib
+    matplotlib.use(""Agg"")
+    import matplotlib.pyplot as plt
+    import io
+    from IPython.display import Image, display
+
+    fig, ax = plt.subplots(figsize=(7, 3))
+    palette = [""#2980b9"", ""#27ae60"", ""#c0392b"", ""#8e44ad"", ""#d35400"", ""#16a085""]
+    ax.barh(range(len(candidates)), results, color=palette[:len(candidates)])
+    ax.set_yticks(range(len(candidates)))
+    ax.set_yticklabels(candidates)
+    ax.invert_yaxis()
+    ax.set_xlabel(""Nombre de voix"")
+    ax.set_title(""Decompte homomorphique Paillier - resultats dechiffres"")
+    ax.set_xlim(0, max(results) + 1)
+    for i, v in enumerate(results):
+        ax.text(v + 0.05, i, str(v), va=""center"", fontweight=""bold"")
+    plt.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format=""png"", dpi=110, bbox_inches=""tight"")
+    buf.seek(0)
+    display(Image(data=buf.getvalue()))
+    plt.close(fig)
 else:
-    print(""Section sautee : phe non disponible"")
-",,,,,,,,a13d2038d9cd385b,,,,,,,
+    print(""Section sautee : phe non disponible"")",,,,,,,,e4002348447450e8,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb,tally-interpretation,markdown,fr,e1daaf453bb34026,"### Interpretation
 
 Le decompte s'est fait **entierement sur des donnees chiffrees** :


### PR DESCRIPTION
## Scope

Resync `translations/smartcontracts/smartcontracts.csv`: 1 `SRC_DRIFT` cell refreshed -> 0 drift.

**Cell**: `SC-17-E2E-Verifiable-Voting.ipynb` cell `tally-code` (code, lang=fr pivot).

**Root cause of drift**: #6617 converted this cell's ASCII visualization bar to a real **matplotlib chart** (SOTA Prong-A #3801 — the comment in-cell documents it; the Paillier homomorphic tally itself is unchanged). The pivot `text_fr` (the notebook's source code) grew accordingly; the CSV pivot lagged.

## Fix (canonical tool)

```
python scripts/translation/extract_cells_to_csv.py \
  MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb \
  --update translations/smartcontracts/smartcontracts.csv
```

Result: `1 ligne(s) rafraîchie(s), 36 déjà in-sync, 0 ajoutée(s), 0 orpheline(s), 928 ligne(s) d'autres notebooks préservées`.

src_hash: `a13d2038d9cd385b` -> `e4002348447450e8`.

## Safety

- **Deposited translations**: 0 (text_en/es/ar/fa/zh/ru/pt all empty pre AND post — row tail `,,,,,,, <hash> ,,,,,,,`) -> no translation loss.
- `text_fr` is the French **pivot** (the notebook source code itself), not a deposited target-language translation.
- Only the tally-code row changed; CRLF = 0 (LF-only).
- `check_translation_sync.py` -> `OK : 1 CSV vérifié(s), 0 drift.`

See #4957