### PR TITLE
fix(prover,#1453): normalize best_sorry sentinel in result JSON (FX-10)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -893,6 +893,12 @@ class MultiAgentSorryProver:
         trace_name = f"multi_{demo['name']}_{self.provider}"
         self.trace.save(trace_name)
 
+        # FX-10 (#1453 forensic): normalize the never-updated best_sorry_count
+        # sentinel (999, tools.py:681) -- see the autonomous path for rationale.
+        _raw_best = tactic_tools.best_sorry_count
+        _best_reported = (_raw_best if _raw_best is not None and _raw_best < 900
+                          else min(original_sorry_count, final_sorry))
+
         return {
             "success": success,
             "proof": state.final_proof,
@@ -912,7 +918,7 @@ class MultiAgentSorryProver:
             "total_s": round(total_s, 1),
             "config": f"multi-{self.provider}",
             "sorry_evolution": f"{original_sorry_count} -> {final_sorry}",
-            "best_sorry": tactic_tools.best_sorry_count,
+            "best_sorry": _best_reported,
             # P6 (#1453 forensic): surface the structural-progress flag so a
             # build-OK / sorry_delta==0 outcome ("proof restructured", e.g. one
             # sorry decomposed into N compiling sub-sorries) is distinguishable
@@ -1741,6 +1747,16 @@ class AutonomousProver:
         trace_name = f"auto_{demo['name']}_{self.provider}"
         self.trace.save(trace_name)
 
+        # FX-10 (#1453 forensic): _best_sorry_count defaults to 999 (tools.py:681)
+        # and is only lowered on a build-verified improvement. With 0 verified
+        # tactics it stays 999, polluting forensic stats (analyze_traces reads it
+        # as a real count). When unset, report the session floor min(original,
+        # final) -- never the sentinel. Verified: autonomous_*_HashlifeCorrectness_L2536
+        # (sorry 4->4, iter 3, best_sorry 999 -> should report 4).
+        _raw_best = tactic_tools.best_sorry_count
+        _best_reported = (_raw_best if _raw_best is not None and _raw_best < 900
+                          else min(original_sorry_count, final_sorry))
+
         return {
             "success": success,
             "proof": state.final_proof,
@@ -1749,7 +1765,7 @@ class AutonomousProver:
             "total_s": round(total_s, 1),
             "config": self.config_label,
             "sorry_evolution": f"{original_sorry_count} -> {final_sorry}",
-            "best_sorry": tactic_tools.best_sorry_count,
+            "best_sorry": _best_reported,
             # P6 (#1453 forensic): same flag as MultiAgentSorryProver — already
             # computed by _autonomous_success_gate, now surfaced so a build-OK /
             # sorry_delta>=0 "proof restructured" outcome is distinguishable


### PR DESCRIPTION
fix(prover,#1453): normalize best_sorry sentinel in result JSON (FX-10)

tactic_tools._best_sorry_count defaults to 999 (tools.py:681) and is only
lowered on a build-verified improvement (tools.py:1168/1434/1546/1728). When a
session makes zero build-verified progress, it stays 999 -- and that 999 is
reported verbatim in the result JSON's best_sorry field (both paths: multi
provers.py:915, autonomous provers.py:1752), polluting forensic stats
(analyze_traces.py reads best_sorry as a real sorry count).

Live case (verified firsthand, 2026-07-06): autonomous_custom_HashlifeCorrectness_L2536
(mistral) -- sorry 4->4, 3 iterations, 0 verified tactics, best_sorry reported
999 (absurd: the file never had 999 sorries). Two older traces (2026-05-24) show
the same pattern (Lattice_L145, CALIBRATION_CONWAY_NIM_SUM_SELF).

Fix (FX-10, +18/-2, both prover paths): at result assembly, when the sentinel is
still unset (>= 900, i.e. never build-verified), report the session floor
min(original_sorry_count, final_sorry) -- the best-known state -- never the
sentinel. The internal restore-best logic is untouched (999 > any real sorry
count, so the existing `best_sorry_count < final_sorry` guard stays correct).

Verified: py_compile OK; normalization logic unit-tested across 5 cases
(L2536 999->4, progress preserved, regression->floor, best-wins, None->fallback).

See #1453

Co-Authored-By: Claude <noreply@anthropic.com>
