### PR TITLE
fix(genai-texte,#3436): disable pip version-check notice leak in 12_Test_Time_Scaling (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "04ad8197",
    "metadata": {
     "execution": {
@@ -109,15 +109,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 24.0 -> 26.1.2\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -144,7 +135,7 @@
    ],
    "source": [
     "# Installation des dependances\n",
-    "%pip install -q openai python-dotenv\n",
+    "%pip install -q --disable-pip-version-check openai python-dotenv\n",
     "\n",
     "import os\n",
     "from pathlib import Path\n",


### PR DESCRIPTION
fix(genai-texte,#3436): disable pip version-check notice leak in 12_Test_Time_Scaling (Stop & Repair)

cell[3] `%pip install -q openai python-dotenv` emitted the pip-upgrade notice
`[notice] To update, run: python.exe -m pip install --upgrade pip` (leak-class
token). Same cause-C class as SL-8 (#6631, c.490).

Cause fix (Stop & Repair, not output scrub): add `--disable-pip-version-check`
to the install line. Re-exec'd cell[3] via nbconvert --execute (real kernel,
cwd=GenAI/Texte so the .env loader finds GenAI/.env). Verified leak-free: the
version-notice output removed; only benign outputs remain:
- `Note: you may need to restart the kernel...`
- `.env charge depuis : GenAI/.env` (downstream preserved)
- `FAST_MODEL (bon marche) = meta-llama/llama-3.3-70b-instruct` (downstream preserved)

cell[3] makes no API call (OpenAI client object creation only, key not
validated until a call), so no API key was needed for the faithful re-exec.

Surgical C.3: only cell[3] source + outputs changed, 31/31 cells byte-identical
to origin/main. .env is gitignored (not staged, not committed). EXEC_PROVED.

See #3436

Co-Authored-By: Claude-Code <noreply@anthropic.com>
