### PR TITLE
fix(translation,#4957): resync rl.csv 1 SRC_DRIFT (rl_7 m2c3e003) 1->0

### DIFF
--- a/translations/rl/rl.csv
+++ b/translations/rl/rl.csv
@@ -6488,11 +6488,14 @@ A la fin de ce notebook, vous serez capable de :
 - Chaque agent doit apprendre une politique adaptee au comportement des autres agents, qui apprennent simultanement.
 - L'environnement devient **non-stationnaire** du point de vue d'un seul agent, ce qui complique l'apprentissage.",,,,,,,,9f70834b06664df2,,,,,,,
 MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m1b2e002,markdown,fr,bdf677c9de91e174,## 1. Installation et imports,,,,,,,,bdf677c9de91e174,,,,,,,
-MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m2c3e003,code,fr,854efb297da4e5fc,"import numpy as np
+MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m2c3e003,code,fr,10a249dc31c8aa80,"import warnings
+import numpy as np
 import matplotlib.pyplot as plt
+warnings.filterwarnings(""ignore"", message=""pkg_resources is deprecated"")  # advisory pygame import (#3436 path-leak)
 from pettingzoo.classic import tictactoe_v3
 
-print(""PettingZoo charge avec succes"")",,,,,,,,854efb297da4e5fc,,,,,,,
+print(""PettingZoo charge avec succes"")
+",,,,,,,,10a249dc31c8aa80,,,,,,,
 MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb,m3d4e004,code,fr,854efb297da4e5fc,"import numpy as np
 import matplotlib.pyplot as plt
 from pettingzoo.classic import tictactoe_v3


### PR DESCRIPTION
## Scope

Resync `translations/rl/rl.csv`: 1 `SRC_DRIFT` cell refreshed -> 0 drift. This closes the i18n drift registry to **0** (the session's i18n-cleanup effort cleared 26 anomalies across iit / gametheory / search-part4 / smartcontracts / sudoku / probas-pymc / rl).

**Cell**: `rl_7_multi_agent_rl.ipynb` cell `m2c3e003` (code, lang=fr pivot — the import-setup cell).

**Root cause of drift**: a #3436 path-leak fix added an advisory comment on the pygame import (`pkg_resources is deprecated` warning suppression). The pivot `text_fr` (the notebook's source code) gained that comment; the CSV pivot lagged.

## Fix (canonical tool)

```
python scripts/translation/extract_cells_to_csv.py \
  MyIA.AI.Notebooks/RL/rl_7_multi_agent_rl.ipynb \
  --update translations/rl/rl.csv
```

Result: `1 ligne(s) rafraîchie(s), 29 déjà in-sync, 0 ajoutée(s), 0 orpheline(s), 483 ligne(s) d'autres notebooks préservées`.

src_hash: `854efb297da4e5fc` -> `10a249dc31c8aa80`.

## Safety

- **Deposited translations**: 0 (text_en/es/ar/fa/zh/ru/pt all empty pre AND post — row tail `,,,,,,, <hash> ,,,,,,,`) -> no translation loss.
- `text_fr` is the French **pivot** (the notebook source code itself), not a deposited target-language translation.
- Only the m2c3e003 row changed; CRLF = 0.
- `check_translation_sync.py` -> `OK : 1 CSV vérifié(s), 0 drift.`
- Note: the old hash `854efb297da4e5fc` is shared by a sibling cell `m3d4e004` (identical pre-drift source). That cell is **unchanged and in-sync** (not flagged), so it legitimately retains the hash — only m2c3e003 was refreshed.

See #4957