### PR TITLE
i18n(lean,#4980): erc20_lean ERC20 root FR-first sibling pair + glob

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/ERC20_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/ERC20_en.lean
@@ -1,0 +1,3 @@
+import ERC20.State_en
+import ERC20.Ops_en
+import ERC20.Invariant_en

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean/lakefile.lean
@@ -33,4 +33,4 @@ require mathlib from git
 
 @[default_target]
 lean_lib «ERC20» where
-  globs := #[.submodules `ERC20]
+  globs := #[.submodules `ERC20, `ERC20_en]


### PR DESCRIPTION
i18n(lean,#4980): erc20_lean ERC20 root FR-first sibling pair + glob

erc20_lean was 3/5 i18n (60%) — the 3 leaf siblings (State_en/Ops_en/
Invariant_en) existed but the ROOT aggregator ERC20.lean had no EN twin.
Completes the lake to 4/4 user files (root + 3 leaves), matching the
reference lake learning_theory_lean (95%), which declares root _en
siblings (Perceptron_en.lean, PacLearning_en.lean) AND lists them in
the glob: globs := #[.submodules `Perceptron, `Perceptron_en]

Two atomic changes (1 subject = erc20_lean root sibling):
1. ERC20_en.lean (new): 3-line import aggregator
     import ERC20.State_en / Ops_en / Invariant_en
   All 3 imported modules exist on main and compile (leaf siblings). Pure
   re-export, no docstrings (same as FR root ERC20.lean which is import-only).
2. lakefile.lean: glob `ERC20` -> `ERC20, ERC20_en` so lake builds the new
   root module (without this, `lake build ERC20_en` = "unknown target").
   Mirrors the merged Perceptron glob precedent byte-for-byte.

Byte-identity: ERC20_en.lean non-docstring content = 3 imports, differing
from FR root ONLY by the mandated `_en` suffix (code-style.md Lean i18n:
"import Foo.Bar <-> import Foo.Bar_en"). FR root has no docstrings, nothing
else to translate.

sorry count: 0 -> 0 (no proof touched, anti-regression clean).

BUILD VERIFICATION — honest:
Local `lake build` not completed in cron window: mathlib v4.31.0-rc1 cold
build (~15-30min) exceeds the 30min budget; `lake exe cache get` built the
cache exe but the RC Azure cache yielded no warm oleans (reached [164/211]
Batteries dep at 280s timeout). This change is glob-fix-class (glob token
addition + import-only root) per the dashboard "Lean Glob-Fix CI
Validation" pattern — CI validates such changes in ~3min without
warm-cache. Per lean-merge-discipline "ou warm-cache ai-01", build
verification deferred to Lean CI + ai-01. Mechanically certain: import
aggregation of existing-compiling modules + glob mirror of MERGED
Perceptron precedent. If CI build fails, will fix immediately.

See #4980

Co-Authored-By: Claude-Code <noreply@anthropic.com>
