### PR TITLE
i18n(lean,#4980): mathlib_examples Basic EN sibling (substance-leaf translation)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/MathLibExamples/Basic_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/MathLibExamples/Basic_en.lean
@@ -1,0 +1,24 @@
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Linarith
+-- omega est fourni par Lean core (plus de module Mathlib.Tactic.Omega depuis v4.30)
+
+/-!
+# Basic Mathlib Examples
+
+This file contains simple examples using Mathlib tactics to check that the
+installation works correctly.
+-/
+
+-- Exemple avec ring
+example (a b : ℤ) : (a + b)^2 = a^2 + 2*a*b + b^2 := by ring
+
+-- Exemple avec linarith
+example (x y : ℚ) (h1 : x ≤ 3*y) (h2 : y ≤ 1) : x ≤ 3 := by linarith
+
+-- Exemple avec omega
+example (n : ℕ) : n < n + 1 := by omega
+
+-- Exemple combiné
+example (a b c : ℤ) (h1 : a = b) (h2 : b = c) : a + a = 2 * c := by
+  rw [h1, h2]
+  ring


### PR DESCRIPTION
i18n(lean,#4980): mathlib_examples Basic EN sibling (substance-leaf translation)

mathlib_examples was 0/3 i18n (0%) per the Lean I18N inventory. Adds the
English sibling for the substance leaf Basic.lean: module docstring
translated FR -> EN, all tactical content (imports, examples, tactics)
byte-identical to the FR canonical.

Convention EPIC #4980 (ratified 2026-07-04, code-style.md §Lean i18n):
distinct FR + EN sibling files, non-docstring content strictly
byte-identical (CI drift detection basis). Verified by extraction:
  FR non-docstring lines (18) == EN non-docstring lines (18) EXACT MATCH.

Basic.lean has no namespace declaration and no local-module imports (only
external Mathlib.Tactic.{Ring,Linarith}), so Basic_en.lean mirrors the
structure 1:1 with only the module docstring translated:
  - title "# Exemples Mathlib de base" -> "# Basic Mathlib Examples"
  - body FR prose -> EN prose
Code comments (-- Exemple avec ring etc.) kept verbatim FR (they are
non-docstring comments, part of the byte-identical body, matching the
knot_lean reference where "sorry commentés" stays FR in the EN mirror).

sorry count: 0 -> 0 (no proof touched, 4 tactic examples unchanged).

Module discovery: lakefile uses default roots (`lean_lib «MathLibExamples»`
with no `globs` directive), which recursively auto-discovers *_en
submodules — same as conway_lean (default roots, 18 *_en files, no root
Conway_en.lean). Local `lake build MathLibExamples.Basic_en` reached
dependency-fetch without "unknown target" error (module IS in the graph).

BUILD VERIFICATION — honest:
mathlib_examples does not pin a mathlib tag (floating `master`), so the
local cold build cloned all deps (mathlib/plausible/batteries/...) and did
not complete in the cron window. This is glob-fix-class (single substance
leaf + default-root discovery), validated by Lean CI (~3min) per the
dashboard "Lean Glob-Fix CI Validation" lesson. Per lean-merge-discipline
"ou warm-cache ai-01". Mechanically certain: 4 tactic `example` proofs
copied verbatim + docstring-only translation. If CI build fails, fix
immediately.

Completes mathlib_examples to 1/3 i18n (Basic leaf done; root
MathLibExamples.lean is import-only pure aggregator with no docstrings —
nothing to translate).

See #4980

Co-Authored-By: Claude-Code <noreply@anthropic.com>
