### PR TITLE
fix(csp,#3436): print cwd basename not abs path in CSP-6/CSP-9 cell[1] (Stop & Repair)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization-Csharp.ipynb
@@ -48,7 +48,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cwd = D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part2-CSP\r\n"
+      "cwd = Part2-CSP\r\n"
      ]
     }
    ],
@@ -72,7 +72,7 @@
     "}\n",
     "var cspDir = FindCspDir();\n",
     "Directory.SetCurrentDirectory(cspDir);\n",
-    "Console.WriteLine($\"cwd = {cspDir}\");\n"
+    "Console.WriteLine($\"cwd = {Path.GetFileName(cspDir)}\");  // #3436 basename\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed-Csharp.ipynb
@@ -32,7 +32,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Repertoire courant : d:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part2-CSP\r\n"
+      "Repertoire courant : Part2-CSP\r\n"
      ]
     },
     {
@@ -52,7 +52,7 @@
     "using System.IO;\n",
     "\n",
     "Console.WriteLine(\".NET Version : \" + Environment.Version);\n",
-    "Console.WriteLine(\"Repertoire courant : \" + Directory.GetCurrentDirectory());\n",
+    "Console.WriteLine(\"Repertoire courant : \" + Path.GetFileName(Directory.GetCurrentDirectory()));  // #3436 basename\n",
     "Console.WriteLine(\"Environnement DisCSP pret (System.* imports)\");\n"
    ]
   },


### PR DESCRIPTION
## #3436 cause-C source-leak — CSP-6 / CSP-9 cell[1] cwd print (Stop & Repair)

`cell[1]` (setup/env-verification cell) printed the **absolute machine cwd path** to stdout — a cause-C source-leak (code that prints the path), not a papermill-metadata or probe-banner leak.

| Notebook | cell[1] leaked output (before) |
|---|---|
| CSP-6-Hybridization-Csharp | `cwd = D:\dev\CoursIA-2\MyIA.AI.Notebooks\Search\Part2-CSP` |
| CSP-9-Distributed-Csharp | `Repertoire courant : d:\dev\CoursIA-2\MyIA.AI.Notebooks\Search\Part2-CSP` |

## Fix (cause-C source, Stop & Repair — NOT output scrubbing)

Print the **basename** via `Path.GetFileName(...)` instead of the absolute path:

- **CSP-6**: `Console.WriteLine($"cwd = {Path.GetFileName(cspDir)}");` — the functional `Directory.SetCurrentDirectory(cspDir)` is **unchanged**, so the cwd is still correctly set for subsequent cells; only the *displayed* value is the basename.
- **CSP-9**: `Console.WriteLine("Repertoire courant : " + Path.GetFileName(Directory.GetCurrentDirectory()));`

## Verification

| Check | Result |
|---|---|
| Re-executed cell[1] on local `.net-csharp` kernel (rule F) | OK — produces `cwd = Part2-CSP` / `Repertoire courant : Part2-CSP` |
| cell[1] `execution_count` preserved | `= 1` (both) |
| Repo-wide path-leak scan of both notebooks | **0 leak** (was 1 per notebook) |
| Diff size | 4 insertions / 4 deletions (2 lines/notebook: 1 source + 1 output) |

## Why byte-surgical output update, not full `nbconvert --execute`

Tested `nbconvert --execute` on CSP-9 with the source fix: it **churns cell[13]** (ScottPlot `#r nuget` visualization cell) and **introduces a NEW leak** there — `Loading extensions from C:\Users\jsboi\.nuget\packages\skiasharp\...` (SkiaSharp DotNet-Interactive extension-loading banner). The committed cell[13] does **not** leak today; a full re-exec would regress it. The committed output for cell[1] is set to exactly what the **re-executed corrected source** prints when the notebook runs in its own directory (the standard kernel-cwd case) — a transcript of a real re-execution, not a redaction. This is Stop & Repair (cause fixed + re-executed), distinct from the banned scrub-without-source-fix.

See #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
