### PR TITLE
docs(smt,#3975): SMT feuille Z3-API count-drift 16->24 + twins orientation (§E audit)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/README.md
@@ -44,7 +44,7 @@ Le saut **SAT → SMT** : plutôt que d'encoder un problème en variables boolé
 | Série | Langage / Binding | Style | Notebooks | Statut |
 |-------|-------------------|-------|-----------|--------|
 | [**Z3-Linq2Z3/**](Z3-Linq2Z3/README.md) | C# .NET 9 / **Z3.Linq** | Déclaratif borné : on traduit des expressions LINQ en formules SMT — avec bascule sur l'API .NET brute `Microsoft.Z3` quand la démonstration l'exige (notebooks `09`, `15`-`17`) | 18 (`01` -> `18`) | PRODUCTION / BETA |
-| [**Z3-API/**](Z3-API/README.md) | Python / **z3-py** | Impératif complet : accès à l'API intégrale du solveur | 16 (`01`->`14`, `17`, `18`) | PRODUCTION |
+| [**Z3-API/**](Z3-API/README.md) | Python / **z3-py** (+ 6 twins C# parité `Microsoft.Z3`) | Impératif complet : accès à l'API intégrale du solveur | 24 (18 Python `01`->`18` + 6 twins C# `01ᶜˢ`->`06ᶜˢ`) | PRODUCTION |
 
 ### Z3.Linq (C#) — la porte d'entrée déclarative
 
@@ -53,6 +53,8 @@ Le saut **SAT → SMT** : plutôt que d'encoder un problème en variables boolé
 ### z3-py (Python) — l'API complète
 
 `z3-py` n'impose aucune couche déclarative restrictive : tactiques (`simplify`, `Then`, `OrElse`), théories `BitVec` et `Array`, `Optimize`, quantificateurs, `SolverFor(...)` spécialisés. C'est l'outil de référence pour aller au-delà de la modélisation introductive et explorer les ressorts internes du solveur.
+
+> **Parité .NET** : depuis le regroupement des séries par techno d'API (#6404, Schéma A #6300), la série `Z3-API/` héberge aussi **6 jumeaux C#** (`Z3-Python-01`…`06-Csharp`) qui rejouent les mêmes problèmes via le binding `Microsoft.Z3` brut — miroir direct des notebooks Python, pour comparer l'API impérative pyz3 et l'API .NET déclarative. Voir le [README de la série](Z3-API/README.md) (table twins `01ᶜˢ`-`06ᶜˢ`).
 
 ## Quelle série choisir ?
 
@@ -83,7 +85,7 @@ La thèse est puissante et honnêtement présentée : il n'existe pas de « bon 
 ### Prochaines étapes
 
 - **Z3 en C# déclaratif (Z3.Linq)** : la série [Z3-Linq2Z3/](Z3-Linq2Z3/README.md) (18 notebooks, .NET 9) est la porte d'entrée idéale si vous venez de l'écosystème .NET — patron `Theorem<T>`, théorie des tableaux, planificateur de repas à l'échelle réelle (bloc 06→09 sur corpus RecipeML × Ciqual), ordonnancement, coloration, cryptarithmes, MaxSAT, puis bit-vectors, réels exacts et UNSAT cores via l'API brute.
-- **Z3 en Python (z3-py)** : la série [Z3-API/](Z3-API/README.md) (16 notebooks) ouvre l'API complète — tactiques, `BitVec`/`Array`/`String`, quantificateurs, preuve par réfutation, optimisation Pareto/MaxSAT.
+- **Z3 en Python (z3-py)** : la série [Z3-API/](Z3-API/README.md) (24 notebooks : 18 Python + 6 twins C# parité `Microsoft.Z3`) ouvre l'API complète — tactiques, `BitVec`/`Array`/`String`, quantificateurs, preuve par réfutation, optimisation Pareto/MaxSAT.
 - **Z3 parmi d'autres paradigmes** : la [série Sudoku](../../Sudoku/README.md) compare Z3 à une dizaine d'autres approches algorithmiques (backtracking, DLX, métaheuristiques, inférence probabiliste, réseaux de neurones) sur un même problème NP-complet — le terrain idéal pour situer la résolution SMT dans le spectre des solveurs.
 - **Programmation par contraintes industrielle** : la série [Search / CSP](../../Search/README.md) généralise la modélisation par contraintes (OR-Tools CP-SAT) à une famille plus large de problèmes d'optimisation et d'ordonnancement, avec un solveur complémentaire de Z3.
 


### PR DESCRIPTION
## §E file-wide audit — `SymbolicAI/SMT/README.md` (feuille)

`See #3975` (feuille README reconciliation EPIC). Partial contribution — this feuille only.

### Drift found (only one)

The feuille's Z3-API row was **stale**: claimed `16 (`01`->`14`, `17`, `18`)`, but the series composition changed (notebooks `15`-`16` added + **6 C# twins** hosted in `Z3-API/` since the **#6404** Schéma-A rename, parent #6300). The child `Z3-API/README.md` was already correct (`18 notebooks` + twins table); only the feuille count drifted.

### Disk truth (verified firsthand, G.1)

```
Z3-API/      24 files = 18 Python (Z3-Python-01..-18) + 6 C# twins (-Csharp on 01..06)
Z3-Linq2Z3/  18 files
```

### Changes (+4 / -2, 1 file)

1. **Table row** (l.47): `16 (`01`->`14`, `17`, `18`)` -> `24 (18 Python `01`->`18` + 6 twins C# `01ᶜˢ`->`06ᶜˢ`)` + binding col notes `(+ 6 twins C# parité `Microsoft.Z3`)`.
2. **`### z3-py` subsection** (l.55): added a `> **Parité .NET**` orientation note — the dedicated subsection previously omitted the C# twins entirely (a real feature since #6404); this completes its orientation job (distinct from the table summary row and the forward-looking conclusion).
3. **Conclusion prose** (l.86): `(16 notebooks)` -> `(24 notebooks : 18 Python + 6 twins C# parité `Microsoft.Z3`)`.

### File-wide §E audit (rest of the feuille = clean)

| Check | Result |
|-------|--------|
| Mermaid fence balance | 2 (balanced) |
| Internal links resolve | `Z3-Linq2Z3/README.md`, `Z3-API/README.md`, `../../Sudoku/README.md`, `../../Search/README.md`, `../README.md` — all OK |
| External URLs | `Z3Prover/z3`, `endjin/Z3.Linq` — both valid |
| `CATALOG-STATUS` markers | 0 (no catalog byte-identity concern) |
| Z3-Linq2Z3 count | 18 (matches disk) |
| CRLF | 0 (clean) |

### Scope hygiene

- Catalogue **byte-identical to main** (no `COURSE_CATALOG.generated.*` touched).
- FR-first (prose additions in French, per `readme-french-first`).
- Atomic: one feuille, one subject (Z3-API count + twins reconciliation post-#6404).
- Base fresh: `0 behind / 1 ahead` origin/main.

Co-Authored-By: Claude-Code <noreply@anthropic.com>