### PR TITLE
docs(smt,#6300): normalize stale papermill paths to basename post-rename

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
@@ -897,8 +897,8 @@
    "end_time": "2026-06-13T00:08:01.570183+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-01-Introduction.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-01-Introduction_output.ipynb",
+   "input_path": "Z3-Python-01-Introduction.ipynb",
+   "output_path": "Z3-Python-01-Introduction_output.ipynb",
    "parameters": {},
    "start_time": "2026-06-13T00:07:56.540983+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
@@ -724,8 +724,8 @@
    "end_time": "2026-06-13T00:07:44.740658+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-02-Sudoku.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Z3-Python/Z3-Python-02-Sudoku_output.ipynb",
+   "input_path": "Z3-Python-02-Sudoku.ipynb",
+   "output_path": "Z3-Python-02-Sudoku_output.ipynb",
    "parameters": {},
    "start_time": "2026-06-13T00:07:29.272981+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
## Post-#6404 rename residue — `metadata.papermill` path normalization

`See #6300` (SMT nomenclature reconciliation; parent of the #6404 Schéma-A rename). Partial contribution.

### Finding

After the **#6404** rename (`Z3-Python/` -> `SMT/Z3-API/`), **2 notebooks** still carried `metadata.papermill.input_path` / `output_path` pointing at the **OLD** pre-rename location `SymbolicAI/Z3-Python/...`. The other 16 Python notebooks + 6 C# twins have no `papermill` metadata (already clean).

Verified repo-wide: the only stale **path** references to the old names are these 2 metadata fossils. All other `SMT/Z3` / `Z3-Python` grep hits are generic prose terms (solver name), not paths — correctly left untouched.

### Fix

Normalized the 2 stale paths to **basename** — explicitly a tolerated manual normalization per **secrets-hygiene rule 6** (`metadata.papermill.input/output_path` au basename). No re-exec needed (metadata-only, not a cell-output edit; not a source-cell change).

| Notebook | input_path / output_path |
|----------|--------------------------|
| Z3-Python-01-Introduction | `.../SymbolicAI/Z3-Python/Z3-Python-01-Introduction[_output].ipynb` -> basename |
| Z3-Python-02-Sudoku | `.../SymbolicAI/Z3-Python/Z3-Python-02-Sudoku[_output].ipynb` -> basename |

### Hygiene / scope

- **Surgical raw-byte edit**: only the 2 path strings per notebook changed (`+4 / -4`, 2 files); rest byte-identical (no JSON re-serialization -> no duration/timestamp churn, no ASCII-escaping of accented cell content). Duration preserved (5.03s, 15.47s).
- **JSON validity**: re-parsed OK after edit. **CRLF = 0**.
- **Catalogue byte-identical to main** (no `COURSE_CATALOG.generated.*` touched).
- **Verify-gate**: `git show HEAD:<nb>` confirms 0 stale `SymbolicAI/Z3-Python/` refs in both committed blobs.
- Atomic: one subject (post-rename papermill path normalization). Base fresh (`0 behind / 1 ahead`).

Co-Authored-By: Claude-Code <noreply@anthropic.com>