### PR TITLE
docs(qc,#1621): verify BTC-ML status — deployed (29318876) + real OOS backtest metrics

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/README.md
@@ -1,25 +1,48 @@
 # BTC-ML
 
 **Asset class:** Crypto (BTC)
-**Cloud project ID:** None (local only)
+**Cloud project ID:** 29318876 (deployed on QC Cloud)
 
 ## Description
 
-Machine learning strategy on Bitcoin using lagged returns, volatility, and volume features with sklearn classifiers.
+Machine learning strategy on Bitcoin using sklearn `RandomForestClassifier` over
+trend/momentum features (SMA, RSI, EMA 10/20/50/200, ADX, ATR, annualized
+volatility) with strict walk-forward feature construction, periodic retraining
+(60-day interval, 2-year lookback), probabilistic position sizing, volatility
+filter, and risk management (stop-loss -8%, take-profit +15%). Strict train/OOS
+split: training 2017-2020, out-of-sample backtest 2021-2026 (no overlap).
 
 ## How to Run
 
 **Lean CLI:** `lean backtest "MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML"`
-**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+**QC Cloud:** Deployed (project 29318876). Verified via backtest po2026-verify-btc-ml-oos-2021-2026 (2026-07-15): BuildSuccess, 0 compile errors.
 
 ## Backtest Metrics
 
+Verified out-of-sample backtest (2021-01-01 to 2026-03-01, Binance cash, USDT):
+
 | Metric | Value |
 |--------|-------|
-| Method | ML classifier |
-| Universe | BTCUSD |
+| Method | RandomForestClassifier (n=50, depth=4, leaf=10) |
+| Universe | BTCUSDT (Binance, daily) |
 | Rebalance | Daily |
+| Sharpe ratio | 0.057 |
+| Probabilistic Sharpe | 1.520% |
+| Compounding annual return | 3.692% |
+| Max drawdown | 15.400% |
+| Total net profit | +20.612% (USDT 20,612 on 100k) |
+| Total orders | 13 |
+| Tradeable days | 1886 |
+
+The low Sharpe (0.057) and near-zero Probabilistic Sharpe (1.52%) indicate the
+strategy's edge over this OOS window is statistically indistinguishable from
+noise — i.e. **NO BEATS** vs buy-and-hold BTC over the same period. Honest
+verdict: the strategy runs cleanly and is correctly structured (no compile
+errors, no data leakage), but does not demonstrate alpha. Suitable as a
+pedagogical reference for ML-strategy scaffolding, not as a live alpha source.
 
 ## Files
 
-- main.py - Strategy
+- main.py - Strategy (`MyEnhancedCryptoMlAlgorithm`)
+- research.ipynb - Research notebook
+- quantbook.ipynb - QuantBook exploration


### PR DESCRIPTION
docs(qc,#1621): verify BTC-ML status — deployed (29318876) + real OOS backtest metrics

The BTC-ML README claimed "Cloud project ID: None (local only)" and "QC Cloud:
Not yet deployed" — but project 29318876 exists on QC Cloud with matching
371-line main.py (BuildSuccess, 0 compile errors, verified firsthand via MCP).
README also had no backtest metrics. This is one of the 82 "Vivant best-guess,
non vérifié" entries flagged TODO in docs/qc/qc-strategies-status.md (#1621
Phase 5 PR-D followup) — verifying its real status is the residual executable
QC work after the docs-saturation noted c.368.

Verified via backtest po2026-verify-btc-ml-oos-2021-2026 (2026-07-15):
- Sharpe 0.057, Probabilistic Sharpe 1.52%, CAGR 3.692%, MaxDD 15.4%
- Total net profit +20.612% (USDT 20,612 on 100k), 13 orders, 1886 tradeable days
- OOS window 2021-01-01 to 2026-03-01, Binance cash, no overlap with 2017-2020 train

Honest verdict documented in-README: low Sharpe + near-zero PSR = edge
indistinguishable from noise over this window = NO BEATS vs buy-and-hold BTC.
Strategy is correctly structured (no data leakage, strict walk-forward features,
periodic retraining) and runs cleanly — a valid pedagogical ML-strategy
scaffold, not an alpha source.

Also corrects the README description (features are SMA/RSI/EMA/ADX/ATR/vol, not
"lagged returns + volume" as previously stated).

Backtest announced; single backtest well within fleet rate-limit (10/min).
Catalogue unchanged (byte-identical to main). See #1621.

Co-Authored-By: Claude <noreply@anthropic.com>
