### PR TITLE
fix(qc-projects,#5780): c.453 audit vision fondateur 6 figures ML-XGBoost MANIFEST

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/assets/readme/MANIFEST.md
@@ -1,14 +1,162 @@
 # Manifeste des figures — ML-XGBoost
 
+> **Audit vision fondateur c.453 (MiniMax M3, 2026-07-15)** — 0/6 alt-texts ACCURATE ; 6 corrections content-driven. Tous les alt-texts d'origine étaient **TITLES-driven** (énuméraient la méthode sans rendre compte des valeurs Sharpe/MaxDD ni du verdict winner/perdant/SPY B&H sous-perf systématique). **Sous-pattern c.453 = DOUBLE-NATURE** : H1+H2 sweeps **QUASI-NULS** (écart Sharpe 0.03-0.04, paramètres inopérants) + H3+H4+H5 sweeps **DISCRIMINANTS MODESTES** (range 0.06-0.08). **Découverte majeure** : XGBoost **sous-performe SPY B&H sur TOUS les sweeps** (S range 0.508-0.593 vs SPY S=0.778), contrairement à ML-RandomForest c.452 où 4/5 winners battent SPY. **Feature importance inversée vs ML-RandomForest** : vol_20 winner ici (vs perdant dans RandomForest), bb_position perdant ici (vs winner dans RandomForest). Cf [c.453 PR body](../../../../../../../scratchpad/xgb-pr-body.md) pour le diagnostic complet G.1 + 6 attributions cell×output confirmées.
+
 Provenance de chaque figure (convention d'indexation **all-cells** du module `extract_readme_figures.py` : `cellule` = indice de cellule dans le notebook, `output` = indice de sortie de cette cellule). Sources vérifiées sur `origin/main`, extraites de [`research.ipynb`](../../research.ipynb) (notebook de recherche local).
 
-| Figure | Fichier | Dimensions | Poids | Source (cellule · output) | Sujet |
-|--------|---------|------------|-------|---------------------------|-------|
-| H1 — Learning rate | `xgb-h1-learningrate.png` | 1000×712 | 185 Ko | cellule 11 · output 4 | Learning rate (hypothèse 1) — downscale depuis 1389×989 |
-| H2 — N estimateurs | `xgb-h2-nestimators.png` | 1389×989 | 197 Ko | cellule 14 · output 4 | Nombre d'estimateurs (hypothèse 2) |
-| H3 — Seuil | `xgb-h3-threshold.png` | 1000×712 | 182 Ko | cellule 17 · output 4 | Seuil de prédiction (hypothèse 3) — downscale |
-| H4 — Max positions | `xgb-h4-maxpositions.png` | 900×640 | 174 Ko | cellule 20 · output 4 | Nombre maximum de positions (hypothèse 4) — downscale |
-| H5 — Subsample | `xgb-h5-subsample.png` | 1000×712 | 191 Ko | cellule 23 · output 4 | Subsample ratio (hypothèse 5) — downscale |
-| Synthèse | `xgb-synthese.png` | 989×790 | 43 Ko | cellule 26 · output 0 | Importance des features |
+| Figure | Fichier | Dimensions | Poids | Source (cellule · output) | Sujet (audit c.453) |
+|--------|---------|------------|-------|---------------------------|---------------------|
+| H1 — Learning rate | `xgb-h1-learningrate.png` | 1000×712 | 185 Ko | cellule 11 · output 4 | **Sweep QUASI-NUL** : 3 lr (0.01/0.03/0.1) → S=0.538/0.564/0.57, écart max 0.03, courbes superposées ; SPY B&H (S=0.778) nettement au-dessus 2.9× vs ~2.1× |
+| H2 — N estimateurs | `xgb-h2-nestimators.png` | 1389×989 | 197 Ko | cellule 14 · output 4 | **Sweep QUASI-NUL** : 3 n_est (50/100/200) → S=0.568/0.564/0.6, écart max 0.04, n_est=200 marginal winner fin 2025 ; SPY B&H toujours au-dessus |
+| H3 — Seuil | `xgb-h3-threshold.png` | 1000×712 | 182 Ko | cellule 17 · output 4 | **Sweep DISCRIMINANT MODESTE** : 3 threshold (0.0/0.001/0.01) → S=0.591/0.564/0.534, threshold=0.0 winner |
+| H4 — Max positions | `xgb-h4-maxpositions.png` | 900×640 | 174 Ko | cellule 20 · output 4 | **Sweep DISCRIMINANT MODESTE** : 3 max_pos (3/7/12) → S=0.508/0.568/0.585, max_pos=12 winner + DD=-30.62% moins creux |
+| H5 — Subsample | `xgb-h5-subsample.png` | 1000×712 | 191 Ko | cellule 23 · output 4 | **Sweep DISCRIMINANT MODESTE** : 3 subsample (0.6/0.8/1.0) → S=0.527/0.564/0.593, subsample=1.0 winner (pas de subsampling = MIEUX) |
+| Synthèse | `xgb-synthese.png` | 989×790 | 43 Ko | cellule 26 · output 0 | **Feature Importance INVERSION vs ML-RandomForest** : 22 features, **vol_20 winner ~0.122** (vs perdant 0.076 dans RandomForest), bb_position perdant ~0.018 (vs winner dans RandomForest), volume_ratio+volume_change quasi-nuls |
 
 **Total** : 6 figures, 974 Ko. **Politique** (#5654) : ≤200 Ko/fichier, downscale ≤1200 px max. H1/H3/H4/H5 (220–243 Ko natifs, denses) downscaled à 900–1000 px ; H2 passe natif après optimisation PNG (216 → 197 Ko). Arc : cinq hypothèses d'hyperparamètres XGBoost (learning rate, n estimateurs, seuil, max positions, subsample) → synthèse par importance des features.
+
+---
+
+## Verdicts détaillés par figure
+
+### H1 — Learning rate (`xgb-h1-learningrate.png`, dual-panel 1000×712)
+
+- **Haut** « H1: Learning Rate » 2018-2026, 3 courbes XGBoost :
+  - `lr=0.01` bleu : S=0.538, DD=-37.78%
+  - `lr=0.03` orange : S=0.564, DD=-37.29% (current, default)
+  - `lr=0.1` vert : S=0.57, DD=-35.81%
+  - **SPY Buy-Hold** rouge (référence externe) : S=0.778, DD=-33.72%, capital 1.0 → 2.9
+- **Bas** « Drawdowns » 2018-2026, 3 aires bleues/orange/vert + aire rose SPY
+- **Verdict** : **sweep QUASI-NUL** — écart Sharpe max 0.03 entre les 3 configs, courbes superposées sur la majeure partie de la période. Le learning_rate n'a **aucun effet discriminant** sur la perf long-terme XGBoost. **MAIS** les 3 configs XGBoost sont **nettement sous SPY B&H** (capital final ~2.1× vs 2.9×, Sharpe -25%). Verdict implicite : la stratégie XGBoost ML est **sous-performante vs benchmark**.
+
+### H2 — N estimateurs (`xgb-h2-nestimators.png`, dual-panel 1389×989)
+
+- **Haut** « H2: N Estimators » 2018-2026, 3 courbes XGBoost :
+  - `n_est=50` bleu : S=0.568, DD=-40.96%
+  - `n_est=100` orange : S=0.564, DD=-37.29% (current, default)
+  - `n_est=200` vert : S=0.6, DD=-34.85% (marginal winner fin 2025-26)
+  - **SPY Buy-Hold** rouge : S=0.778, DD=-33.72%, capital 1.0 → 2.9
+- **Bas** « Drawdowns » 2018-2026
+- **Verdict** : **sweep QUASI-NUL** — écart Sharpe max 0.04 entre les 3 configs, courbes **superposées à 2-3 pixels près** sur 2018-2026. Le verdict « n_est=200 winner S=0.6 » n'apparaît qu'en zoom sur fin 2025-26 (boost tardif). **SPY B&H toujours au-dessus** (capital final ~2.1× vs 2.9×). Verdict implicite : n_estimators est aussi inopérant sur la perf long-terme.
+
+### H3 — Seuil de prédiction (`xgb-h3-threshold.png`, dual-panel 1000×712)
+
+- **Haut** « H3: Prediction Threshold » 2018-2026, 3 courbes XGBoost :
+  - `threshold=0.0` bleu : S=0.591, DD=-36.93% (**winner**, sweet spot à 0 — aucune filter = MIEUX)
+  - `threshold=0.001` orange : S=0.564, DD=-37.29% (current, default)
+  - `threshold=0.01` vert : S=0.534, DD=-32.35% (perdant, Sharpe le plus bas)
+- **Bas** « Drawdowns » 2018-2026
+- **Verdict** : **sweep DISCRIMINANT MODESTE** — range Sharpe 0.534-0.591 (écart 0.06). threshold=0.0 winner légèrement visible fin 2024-25. **Verdict contre-intuitif** : supprimer le filtre de seuil (threshold=0) **améliore** légèrement la perf XGBoost. Mais **toutes configs encore sous SPY B&H** (~2.2× vs 2.9×).
+
+### H4 — Max positions (`xgb-h4-maxpositions.png`, dual-panel 900×640)
+
+- **Haut** « H4: Max Positions » 2018-2026, 3 courbes XGBoost :
+  - `max_pos=3` bleu : S=0.508, DD=-48.84% (perdant, DD sévère mi-2022 -49%)
+  - `max_pos=7` orange : S=0.568, DD=-41.29% (current, default)
+  - `max_pos=12` vert : S=0.585, DD=-30.62% (**winner**, + diversification → DD moins creux)
+- **Bas** « Drawdowns » 2018-2026 — on voit clairement max_pos=12 vert avec drawdown moins sévère
+- **Verdict** : **sweep DISCRIMINANT MODESTE** — range Sharpe 0.508-0.585 (écart 0.08, le plus grand des sweeps XGBoost). max_pos=12 winner en capital final + drawdown -30.62% (le moins creux des 3). **Verdict attendu** : plus de diversification améliore la perf. **Mais toutes configs sous SPY B&H** (~2.3× vs 2.9×).
+
+### H5 — Subsample ratio (`xgb-h5-subsample.png`, dual-panel 1000×712)
+
+- **Haut** « H5: Subsample Ratio » 2018-2026, 3 courbes XGBoost :
+  - `subsample=0.6` bleu : S=0.527, DD=-35.55% (perdant)
+  - `subsample=0.8` orange : S=0.564, DD=-37.29% (current, default)
+  - `subsample=1.0` vert : S=0.593, DD=-39.58% (**winner**, pas de subsampling = MIEUX)
+- **Bas** « Drawdowns » 2018-2026
+- **Verdict** : **sweep DISCRIMINANT MODESTE** — range Sharpe 0.527-0.593 (écart 0.07). subsample=1.0 winner. **Verdict contre-intuitif** : supprimer le subsampling (utiliser 100% des données par arbre) **améliore** la perf — pour XGBoost sur ces 15 tickers, le bagging n'apporte rien. **Mais toutes configs sous SPY B&H** (~2.2× vs 2.9×).
+
+### Synthèse — Feature Importance (`xgb-synthese.png`, mono-panel 989×790)
+
+- **Bar chart horizontal** « Feature Importance (GradientBoosting, moyenne sur tous les entrainements) », 22 barres bleues triées desc :
+  - **vol_20 ~0.122** winner (vs perdant 0.076 dans ML-RandomForest = **inversion spectaculaire**)
+  - **atr ~0.095** / **macd_signal ~0.088** / **atr_ratio ~0.085** (cluster volatilité+momentum top-4)
+  - **sma_ratio_10_50 ~0.078** / **price_sma50 ~0.055**
+  - **vol_5 ~0.053** / **bb_width ~0.052** / **macd ~0.053** / **macd_hist ~0.048** / **mom_20 ~0.038**
+  - **sma_ratio_5_20 ~0.034** / **mom_10 ~0.030** / **rsi ~0.026** / **price_sma20 ~0.025** / **mom_5 ~0.024**
+  - **price_sma5 ~0.023** / **stoch_d ~0.020** / **bb_position ~0.018** (vs winner 0.103 dans ML-RandomForest = **2ᵉ inversion**)
+  - **returns ~0.014** / **stoch_k ~0.010**
+  - **volume_ratio ~0.000** quasi-nul
+  - **volume_change ~0.000** quasi-nul
+- **Verdict** : **INVERSION SPECTACULAIRE vs ML-RandomForest** :
+  - vol_20 passe de perdant (mrf) à **winner** (xgb) — XGBoost exploite fortement la volatilité 20j
+  - bb_position passe de winner (mrf) à perdant (xgb) — momentum/position Bollinger marginal pour XGBoost
+  - volume_ratio quasi-nul dans les 2 cas
+  - **Hypothèse** : XGBoost gère mieux les features de **volatilité** (vol_20, atr, atr_ratio) via ses tree splits séquentiels avec shrinkage, alors que RandomForest distribue l'importance entre features de **momentum** (bb_position) et volume均等ément. Pour XGBoost : **les features de VOLATILITÉ dominent**, momentum marginal.
+
+---
+
+## Découverte majeure c.453 — XGBoost sous-performe SPY B&H systématiquement
+
+**Contrairement à ML-RandomForest c.452 où 4 winners sur 5 battent SPY**, **ML-XGBoost c.453 sous-performe SPY Buy-Hold sur TOUS les sweeps** :
+
+| Sweep | Sharpe XGBoost range | Sharpe SPY | Capital XGBoost | Capital SPY |
+|---|---|---|---|---|
+| H1 learning_rate | 0.538-0.57 | 0.778 | ~2.1× | 2.9× |
+| H2 n_estimators | 0.564-0.6 | 0.778 | ~2.1× | 2.9× |
+| H3 threshold | 0.534-0.591 | 0.778 | ~2.2× | 2.9× |
+| H4 max_positions | 0.508-0.585 | 0.778 | ~2.3× | 2.9× |
+| H5 subsample | 0.527-0.593 | 0.778 | ~2.2× | 2.9× |
+
+**Conclusion** : la stratégie XGBoost ML est **NÉGATIVEMENT valorisée** par rapport au benchmark SPY B&H sur 2018-2026. **L'algo ML XGBoost ne bat pas le simple buy-and-hold** sur la période. C'est un signal FORT contre le déploiement live de XGBoost sans amélioration substantielle (vs ML-RandomForest qui gagne 2-3× SPY avec hyperparamètres optimaux).
+
+**Hypothèses d'amélioration** (hors scope cette PR, à investiguer en suivi) :
+1. Combiner XGBoost + RandomForest (ensemble methods, déjà vu `ML-Ensemble` project)
+2. Ajouter features de régime VIX comme dans `LongShortHarvest-QC` c.451
+3. Filtrer les jours VIX>25 (cf c.451 finding : Stress S=-0.2 négatif)
+4. Backtester sur une période plus longue (2008-2026) pour vérifier la robustesse
+
+## Comparaison c.453 ML-XGBoost vs c.452 ML-RandomForest
+
+| Métrique | ML-RandomForest c.452 | ML-XGBoost c.453 |
+|---|---|---|
+| Sharpe winners | 0.841-1.118 (range 0.28) | 0.508-0.593 (range 0.085) |
+| vs SPY (S=0.778) | 4/5 winners BATTENT SPY | **0/15 configs BATTENT SPY** |
+| MaxDD winners | -30% à -41% | -30% à -49% |
+| Sweeps DISCRIMINANTS | 5/5 (range 0.6 Sharpe) | 3/5 modestes (H3+H4+H5 range 0.07) + 2/5 NULS (H1+H2 range 0.03) |
+| Feature #1 | bb_position (momentum, ~0.103) | **vol_20 (volatilité, ~0.122)** ← inversion |
+| Feature dernière significative | volume_ratio (~0.002) | **bb_position (~0.018)** ← inversion |
+| Verdict global | **Stratégie VIABLE**, 3 hyperparamètres à activer (depth=10, Universe 5, Monthly rebal) → ~3× SPY | **Stratégie NON VIABLE vs SPY**, à reconsidérer ou améliorer fondamentalement |
+
+## Cumul EPIC #5780 vague QC
+
+| Cycle | PR | Projet | Figures | Sous-pattern dominant |
+|-------|----|---------|---------|----------------------|
+| c.438 | #6541 | DualMomentum | 4 | systemic 4:4 |
+| c.447 | #6655 | AllWeather | 6 | systemic 5:1 |
+| c.448 | #6656 | EMA-Cross-Crypto | 5 | doctrinal 5:5 + dual-panel |
+| c.449 | #6661 | EMA-Cross-Index | 6 | doctrinal 6:6 + dual/triple-panel |
+| c.450 | #6668 | ForexCarry | 6 | doctrinal 6:6 + 2 ATTRIB inversées |
+| c.451 | #6671 | LongShortHarvest-QC | 6 | doctrinal 6:6 + 3 sweeps NULS (sous-pattern d) |
+| c.452 | #6674 | ML-RandomForest | 6 | doctrinal 6:6 + 5 sweeps DISCRIMINANTS (sous-pattern e) |
+| **c.453** | **this PR** | **ML-XGBoost** | **6** | **doctrinal 6:6 + 2 sweeps NULS + 3 sweeps DISCRIMINANTS modestes + inversion feature importance + sous-perf SPY systématique** |
+
+**13/16 projets QC couverts**. Reste : RiskParity (6) = ~6 figures restantes, ~1 PR.
+
+## Sous-pattern émergent c.453 — DOUBLE-NATURE NULS+DISCRIMINANTS
+
+Les 5 sweeps de ML-XGBoost montrent une **double nature** unique parmi les 8 projets QC audités :
+- **H1 (learning_rate) + H2 (n_estimators)** = sweeps **QUASI-NULS** (range Sharpe 0.03-0.04) → analogie c.451 LongShortHarvest-QC
+- **H3 (threshold) + H4 (max_positions) + H5 (subsample)** = sweeps **DISCRIMINANTS MODESTES** (range Sharpe 0.06-0.08) → analogie c.452 RandomForest (mais avec amplitudes 5-10× plus faibles)
+
+Le pipeline `extract_readme_figures.py` ne capture **aucune de ces deux nuances** : il génère dans tous les cas un alt-text générique « Courbes par sweep » qui omet à la fois la mention sweep nul vs discriminant, ET l'écart d'amplitude (modeste vs discriminant).
+
+**Cause racinaire confirmée** : alt-texts générés par **auto-extraction à partir des commentaires de cellule** (e.g. `# H1: Learning rate` → alt-text « Learning rate (hypothèse 1) »), sans lecture visuelle du PNG. Aucun des 6 alt-texts ne contient de valeur Sharpe, MaxDD, verdict winner/perdant, ni verdict SPY B&H sous-perf systématique. Corrigé c.453 par audit visuel MiniMax M3 + vérification croisée du code source des cellules.
+
+## Preuves vérifiables (G.1 firsthand)
+
+- 6/6 PNG ouverts via `Read` (vision MiniMax M3), analysés et décrits dans ce MANIFEST enrichi
+- 6/6 attributions cell×output confirmées via `python json.load(research.ipynb)` + matching `set_title()` :
+  - `xgb-h1-learningrate.png` → cell[11] out[4] ✓ (`plot_equity_curves(h1_results, title='H1: Learning Rate')`)
+  - `xgb-h2-nestimators.png` → cell[14] out[4] ✓ (`plot_equity_curves(h2_results, title='H2: N Estimators')`)
+  - `xgb-h3-threshold.png` → cell[17] out[4] ✓ (`plot_equity_curves(h3_results, title='H3: Prediction Threshold')`)
+  - `xgb-h4-maxpositions.png` → cell[20] out[4] ✓ (`plot_equity_curves(h4_results, title='H4: Max Positions')`)
+  - `xgb-h5-subsample.png` → cell[23] out[4] ✓ (`plot_equity_curves(h5_results, title='H5: Subsample Ratio')`)
+  - `xgb-synthese.png` → cell[26] out[0] ✓ (`ax.set_title('Feature Importance (GradientBoosting, moyenne sur tous les entrainements)', fontsize=13)`)
+
+## Hygiene PR (catalog-pr-hygiene)
+
+- **R1** : 1 fichier modifié (`MANIFEST.md`), 0 marqueur `CATALOG-STATUS` touché ✓
+- **R2** : rebase frais sur `origin/main` @ `a909142e6` ✓
+- **R3** : 1 sujet = audit MANIFEST ML-XGBoost (atomique) ✓
+- **R4** : `See #5780` (contribution partielle à l'epic, ne ferme pas) ✓


### PR DESCRIPTION
## Audit vision fondateur — ML-XGBoost MANIFEST

**Doctrine** : [#5780](https://github.com/jsboige/CoursIA/issues/5780) (rollout vague QC projets), [L490](~/.claude/rules/) founder-audit-pattern-sweep-figures, `model-delegation.md` vision routing MiniMax M3.

### Diagnostic G.1 firsthand (6 PNG lus via Read vision MiniMax M3)

| # | Fichier | Alt-text précédent | Verdict | Contenu réel vérifié |
|---|---------|---------------------|---------|----------------------|
| 1 | `xgb-h1-learningrate.png` | « Learning rate (hypothèse 1) — downscale depuis 1389×989 » | **TITLES-driven** (omet verdict sweep QUASI-NUL + sous-perf SPY massive) | **Dual-panel** 1000×712 « H1: Learning Rate » 2018-2026 : 3 courbes XGBoost **lr=0.01 bleu (S=0.538 DD=-37.78%) / lr=0.03 orange (S=0.564 DD=-37.29%) / lr=0.1 vert (S=0.57 DD=-35.81%)** quasi-superposées (écart Sharpe max 0.03, courbes indiscernables sauf fin 2024-25), SPY B&H rouge (S=0.778 DD=-33.72%, 1.0→2.9) **nettement au-dessus 2.9× vs ~2.1×** ; DD panel |
| 2 | `xgb-h2-nestimators.png` | « Nombre d'estimateurs (hypothèse 2) » | **TITLES-driven** (omet verdict sweep QUASI-NUL + sous-perf SPY massive) | **Dual-panel** 1389×989 « H2: N Estimators » 2018-2026 : 3 courbes XGBoost **n_est=50 bleu (S=0.568 DD=-40.96%) / n_est=100 orange (S=0.564 DD=-37.29%) / n_est=200 vert (S=0.6 DD=-34.85%)** quasi-superposées (écart Sharpe max 0.04, courbes indiscernables visuellement, le verdict « n_est=200 marginal winner S=0.6 » n'apparaît qu'en zoom fin 2025-26), SPY B&H rouge (1.0→2.9) **sépare nettement** ; DD panel |
| 3 | `xgb-h3-threshold.png` | « Seuil de prédiction (hypothèse 3) — downscale » | **TITLES-driven** (omet verdict threshold=0.0 winner S=0.591 + inversion vs intuition) | **Dual-panel** 1000×712 « H3: Prediction Threshold » 2018-2026 : 3 courbes XGBoost **threshold=0.0 bleu (S=0.591 DD=-36.93%) winner / threshold=0.001 orange (S=0.564 DD=-37.29%) current / threshold=0.01 vert (S=0.534 DD=-32.35%) perdant** — verdict **discriminant modeste** (Sharpe range 0.534-0.591, 0.06 d'écart), threshold=0.0 winner légèrement visible fin 2024-25, SPY B&H rouge |
| 4 | `xgb-h4-maxpositions.png` | « Nombre maximum de positions (hypothèse 4) — downscale » | **TITLES-driven** (omet verdict max_pos=12 winner S=0.585 + corrélation diversification) | **Dual-panel** 900×640 « H4: Max Positions » 2018-2026 : 3 courbes XGBoost **max_pos=3 bleu (S=0.508 DD=-48.84%) perdant / max_pos=7 orange (S=0.568 DD=-41.29%) current / max_pos=12 vert (S=0.585 DD=-30.62%) winner** — verdict discriminant modeste (range 0.508-0.585, 0.08 d'écart), max_pos=12 winner en capital final + drawdown -30.62% (le moins creux des 3), SPY B&H rouge toujours au-dessus |
| 5 | `xgb-h5-subsample.png` | « Subsample ratio (hypothèse 5) — downscale » | **TITLES-driven** (omet verdict subsample=1.0 winner S=0.593) | **Dual-panel** 1000×712 « H5: Subsample Ratio » 2018-2026 : 3 courbes XGBoost **subsample=0.6 bleu (S=0.527 DD=-35.55%) perdant / subsample=0.8 orange (S=0.564 DD=-37.29%) current / subsample=1.0 vert (S=0.593 DD=-39.58%) winner** — verdict discriminant modeste (range 0.527-0.593, 0.07 d'écart), subsample=1.0 winner (pas de subsampling = MIEUX, contre-intuitif), SPY B&H rouge |
| 6 | `xgb-synthese.png` | « Importance des features » | **TITLES-driven** (omet VERDICT inversion spectaculaire vs ML-RandomForest + bas de classement) | **Mono-panel bar chart horizontal** 989×790 « Feature Importance (GradientBoosting, moyenne sur tous les entrainements) » **22 barres bleues triées desc** : **vol_20 winner ~0.122** (vs perdant 0.076 dans ML-RandomForest — **inversion spectaculaire** : volume gagne pour XGBoost), **atr ~0.095** / **macd_signal ~0.088** / **atr_ratio ~0.085** (cluster volatilité+momentum top-4), **sma_ratio_10_50 ~0.078** / **price_sma50 ~0.055**, queue : **bb_position ~0.018** (vs winner dans ML-RandomForest — **2ᵉ inversion**), **stoch_k ~0.010**, **volume_ratio ~0.000** quasi-nul, **volume_change ~0.000** quasi-nul |

**Score** : **0/6 ACCURATE** — **6 corrections réelles**. Alt-texts d'origine **TITLES-driven** (énuméraient méthode sans rendre compte des verdicts Sharpe/DD ni du verdict SPY Buy-Hold systématiquement au-dessus).

### Sous-pattern identifié c.453 — DOUBLE-NATURE : 3 sweeps QUASI-NULS + 3 sweeps DISCRIMINANTS MODESTES (vs c.451 NULS / c.452 DISCRIMINANTS)

**3 observations distinctes** :

1. **H1 + H2 = sweeps QUASI-NULS (analogue c.451 LongShortHarvest-QC)** : pour `xgb-h1-learningrate.png` (3 lr 0.01/0.03/0.1) ET `xgb-h2-nestimators.png` (3 n_est 50/100/200), les courbes sont **quasi-superposées** sur 2018-2026, avec un écart Sharpe max de **0.03-0.04** seulement — **les hyperparamètres learning_rate et n_estimators sont INOPÉRANTS** sur la perf long-terme. Conséquence : la stratégie XGBoost est robuste à ces 2 paramètres (le modèle converge vers le même signal quel que soit lr/n_est). MAIS, fait majeur : **TOUTES les courbes XGBoost sont NETTEMENT SOUS SPY Buy-Hold rouge (S=0.778, 2.9×)**. Le pipeline d'auto-extraction omet cette sous-perf systématique, ce qui trompe le lecteur qui pourrait croire que la stratégie bat SPY.

2. **H3 + H4 + H5 = sweeps DISCRIMINANTS MODESTES (analogue c.452 RandomForest)** : pour `xgb-h3-threshold.png` (threshold=0.0/0.001/0.01, range S=0.534-0.591), `xgb-h4-maxpositions.png` (max_pos=3/7/12, range S=0.508-0.585), `xgb-h5-subsample.png` (subsample=0.6/0.8/1.0, range S=0.527-0.593), les courbes montrent un **verdict Sharpe discriminant modeste mais réel** (range 0.06-0.08 d'écart). Contrairement à c.452 RandomForest (range 0.4-0.6), les écarts XGBoost sont 5-10× plus faibles → **discrimination modeste**. Winners : threshold=0.0 (S=0.591), max_pos=12 (S=0.585, DD=-30.62% moins creux), subsample=1.0 (S=0.593, pas de subsampling = MIEUX, contre-intuitif). **MAIS TOUJOURS SOUS SPY B&H** (~2.0× vs SPY 2.9×).

3. **xgb-synthese.png : inversion spectaculare vs ML-RandomForest** : la 1ère feature est **vol_20 ~0.122** (vs perdant 0.076 dans ML-RandomForest = **inversion complète**). Suivi atr ~0.095, macd_signal ~0.088, atr_ratio ~0.085 (cluster volatilité+momentum), sma_ratio_10_50 ~0.078. Queue de classement : **bb_position ~0.018** (vs winner 0.103 dans ML-RandomForest = **2ᵉ inversion**), stoch_k ~0.010, **volume_ratio ~0.000** quasi-nul, **volume_change ~0.000** quasi-nul. **Hypothèse explication** : XGBoost gère mieux les features de volume (vol_20, atr, atr_ratio) via ses tree splits séquentiels avec shrinkage, alors que RandomForest distribue l'importance均等ément entre features de momentum (bb_position) et volume. Pour XGBoost : **les features de VOLATILITÉ (vol_20, atr, atr_ratio) dominent**, momentum (bb_position) marginal.

### Cause racinaire confirmée

Alt-texts d'origine générés par **auto-extraction à partir des commentaires de cellule** (e.g. `# H1: Learning rate` → alt-text « Learning rate (hypothèse 1) »), sans lecture visuelle du PNG. **Aucun des 6 alt-texts ne contient de valeur Sharpe, MaxDD ou verdict winner/perdant** — alors que **chacune des légendes des courbes matplotlib inclut le Sharpe+DD** (e.g. `lr=0.01 (S=0.538, DD=-37.78%)`). Le pipeline d'auto-extraction ne capture **pas les annotations texte in-figure**, **omet le verdict SPY B&H sous-perf systématique**, et **omet l'inversion feature importance vs ML-RandomForest**. Corrigé c.453 par audit visuel MiniMax M3 + vérification croisée du code source des cellules (`set_title()` matching, cf `.claude/rules/model-delegation.md` section vision routing).

### Découverte majeure c.453 — XGBoost sous-performe SPY B&H systématiquement

Contrairement à ML-RandomForest c.452 où **4 winners sur 5 battent SPY** (H2 depth=10 spectaculaire 2.1× SPY, H4 Universe 5 2.3× SPY), **ML-XGBoost c.453 sous-performe SPY Buy-Hold sur TOUS les sweeps** :
- H1 learning_rate : S=0.538-0.57 vs SPY S=0.778 (toutes configs perdent ~25% en Sharpe)
- H2 n_estimators : S=0.564-0.6 vs SPY S=0.778 (toutes configs perdent ~22% en Sharpe)
- H3 threshold : S=0.534-0.591 vs SPY S=0.778 (toutes configs perdent ~24% en Sharpe)
- H4 max_positions : S=0.508-0.585 vs SPY S=0.778 (toutes configs perdent ~25% en Sharpe)
- H5 subsample : S=0.527-0.593 vs SPY S=0.778 (toutes configs perdent ~24% en Sharpe)

**Capital final XGBoost ~2.0-2.2× vs SPY 2.9×** sur 2018-2026. **Conclusion** : la stratégie XGBoost ML est **NÉGATIVEMENT valorisée** par rapport au benchmark SPY B&H — l'algo ML ne bat pas le simple buy-and-hold sur la période 2018-2026. C'est un signal FORT contre le déploiement live de XGBoost sans amélioration (vs ML-RandomForest qui gagne 2-3× SPY avec hyperparamètres optimaux).

### Différence c.453 vs c.452 RandomForest

| Métrique | ML-RandomForest c.452 | ML-XGBoost c.453 |
|---|---|---|
| Sharpe winners | 0.841-1.118 (range 0.28) | 0.508-0.593 (range 0.085) |
| vs SPY (S=0.778) | 4/5 winners BATTENT SPY | **0/15 configs BATTENT SPY** |
| MaxDD winners | -30% à -41% | -30% à -48% |
| Sweeps DISCRIMINANTS | 5/5 (range 0.6 Sharpe) | 3/5 modestes (H3+H4+H5 range 0.07) + 2/5 NULS (H1+H2 range 0.03) |
| Feature #1 | bb_position (momentum) | **vol_20 (volatilité)** ← inversion |
| Verdict global | Stratégie VIABLE, **3 hyperparamètres à activer** (depth=10, Universe 5, Monthly rebal) | **Stratégie NON VIABLE vs SPY**, à reconsidérer ou améliorer |

### Preuves vérifiables

- 6/6 PNG ouverts via `Read` (vision), analysés et décrits dans le MANIFEST enrichi
- 6/6 attributions cell×output confirmées via `python json.load(research.ipynb)` + matching `set_title()` :
  - `xgb-h1-learningrate.png` → cell[11] out[4] ✓ (`plot_equity_curves(h1_results, title='H1: Learning Rate')`)
  - `xgb-h2-nestimators.png` → cell[14] out[4] ✓ (`plot_equity_curves(h2_results, title='H2: N Estimators')`)
  - `xgb-h3-threshold.png` → cell[17] out[4] ✓ (`plot_equity_curves(h3_results, title='H3: Prediction Threshold')`)
  - `xgb-h4-maxpositions.png` → cell[20] out[4] ✓ (`plot_equity_curves(h4_results, title='H4: Max Positions')`)
  - `xgb-h5-subsample.png` → cell[23] out[4] ✓ (`plot_equity_curves(h5_results, title='H5: Subsample Ratio')`)
  - `xgb-synthese.png` → cell[26] out[0] ✓ (`ax.set_title('Feature Importance (GradientBoosting, moyenne sur tous les entrainements)', fontsize=13)`)

### Cumul EPIC #5780 vague QC

| Cycle | PR | Projet | Figures | Ratio |
|-------|----|---------|---------|-------|
| c.438 | #6541 | DualMomentum | 4 | 4:4 systemic |
| c.447 | #6655 | AllWeather | 6 | 5:1 systemic |
| c.448 | #6656 | EMA-Cross-Crypto | 5 | 5:5 doctrinal |
| c.449 | #6661 | EMA-Cross-Index | 6 | 6:6 doctrinal |
| c.450 | #6668 | ForexCarry | 6 | 6:6 doctrinal + 2 ATTRIB inversées |
| c.451 | #6671 | LongShortHarvest-QC | 6 | 6:6 doctrinal + 1 FAUX alt-text + 3 sweeps NULS |
| c.452 | #6674 | ML-RandomForest | 6 | 6:6 doctrinal + 5 sweeps DISCRIMINANTS |
| **c.453** | **this PR** | **ML-XGBoost** | **6** | **6:6 doctrinal + 2 sweeps NULS + 3 sweeps DISCRIMINANTS modestes + inversion feature importance + sous-perf SPY systématique** |

13/16 projets QC couverts. Reste : RiskParity (6) = ~6 figures restantes, ~1 PR.

### Hygiene PR (catalog-pr-hygiene)

- **R1** : 1 fichier modifié (`MANIFEST.md`), 0 marqueur `CATALOG-STATUS` touché ✓
- **R2** : rebase frais sur `origin/main` @ `a909142e6` ✓
- **R3** : 1 sujet = audit MANIFEST ML-XGBoost (atomique) ✓
- **R4** : `See #5780` (contribution partielle à l'epic, ne ferme pas) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)