### PR TITLE
fix(secrets,#1199): IBKR paper login as first-class master.env consumer

### DIFF
--- a/scripts/secrets/render_envs.py
+++ b/scripts/secrets/render_envs.py
@@ -57,6 +57,11 @@ TARGET_ENVS = [
     # Only keys present in master.env are rewritten; the prover's own
     # ZAI/LOCAL/OPENROUTER config (absent from master) is left untouched.
     REPO_ROOT / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean" / ".env",
+    # Trading paper harness: Portfolio-IBKR-Coinbase-Hybrid/paper_harness/config.py
+    # loads this .env. Centralizes the IBKR paper login (#1199) so a re-provision =
+    # edit master.env + render. The credential was lost 3x when it lived only in a
+    # per-machine .env with no canonical anchor -- master.env is now that anchor.
+    REPO_ROOT / "MyIA.AI.Notebooks" / "QuantConnect" / "projects" / "Portfolio-IBKR-Coinbase-Hybrid" / ".env",
 ]
 
 # Keys whose VALUE is a shared secret and must be synced from master.env.
@@ -90,6 +95,12 @@ SECRET_KEYS: frozenset[str] = frozenset({
     "OWUI_API_KEY", "TTS_GATEWAY_API_KEY",
     # ComfyUI client tokens (notebook client <-> service must agree)
     "COMFYUI_VIDEO_TOKEN", "COMFYUI_API_TOKEN",
+    # IBKR paper/simulated trading login (Portfolio-IBKR-Coinbase-Hybrid, #1199).
+    # A single shared credential (not per-instance) -> centralized so a re-provision
+    # is edit-master + render, never a scattered per-machine .env that gets lost.
+    # IBKR_ACCOUNT_ID stays out (it is an identifier discovered post-login, not a
+    # secret; it lives in the consumer .env as config).
+    "IBKR_USERNAME", "IBKR_PASSWORD",
     # Session
     "SECRET_KEY",
 })


### PR DESCRIPTION
## Summary

The IBKR paper/simulated trading credential (#1199) was passed by the user **three times** and lost each time — because it only ever lived in a per-machine `Portfolio-IBKR-Coinbase-Hybrid/.env` with **no canonical anchor**. This registers it in the centralized secrets pipeline so a re-provision is **one repeatable command on any machine** (`edit .secrets/master.env` + `render_envs.py`), never a scattered `.env` that vanishes.

## Changes (`scripts/secrets/render_envs.py`)

- `SECRET_KEYS += IBKR_USERNAME, IBKR_PASSWORD` — a single shared credential (not per-instance). `IBKR_ACCOUNT_ID` intentionally stays out (post-login identifier = config, not a secret).
- `TARGET_ENVS += Portfolio-IBKR-Coinbase-Hybrid/.env` — the paper harness consumer (`paper_harness/config.py`).

## Verification

```
$ python scripts/secrets/render_envs.py --check   # exit 0, "All target .env in sync, no drift"
$ python scripts/secrets/render_envs.py            # idempotent, exit 0
```

master.env + every `.env` remain **gitignored** — no secret value enters git (gitleaks scan will confirm). No behavior change for existing consumers (docker services, GenAI, Lean).

## Scope

Code-only, one file. The credential itself is provisioned out-of-band (gitignored `.secrets/master.env` on the coordinator + RooSync private DM to the harness machine) — never in this PR.

See #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)