### PR TITLE
i18n(lean,#4980): sensitivity_lean root FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity.lean
@@ -10,12 +10,8 @@ Théorème de sensibilité de Huang : dans l'hypercube de dimension n ≥ 1, si 
 colorie plus de la moitié des sommets, alors au moins un sommet possède au moins
 √n voisins coloriés.
 
----
-English:
-Port of mathlib4/Archive/Sensitivity.lean to standalone Lake workspace.
-Huang's sensitivity theorem: in the hypercube of dimension n >= 1, if one
-colors more than half the vertices then at least one vertex has at least
-sqrt(n) colored neighbors.
+Convention i18n #4980 (sibling pair) : cette racine est FR-seule canonique,
+le jumeau anglais agrégateur est `Sensitivity_en.lean`.
 -/
 import Sensitivity.Hypercube
 import Sensitivity.VectorSpace

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity_en.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2019 Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
+Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Reid Barton, Johan Commelin, Jesse Michael Han, Chris Hughes, Robert Y. Lewis,
+  Patrick Massot
+
+Port of mathlib4/Archive/Sensitivity.lean to standalone Lake workspace.
+Huang's sensitivity theorem: in the hypercube of dimension n >= 1, if one
+colors more than half the vertices then at least one vertex has at least
+sqrt(n) colored neighbors.
+
+i18n convention #4980 (sibling pair): this root is EN-only, the canonical
+French aggregator twin is `Sensitivity.lean`.
+-/
+import Sensitivity.Hypercube_en
+import Sensitivity.VectorSpace_en
+import Sensitivity.Operator_en
+import Sensitivity.MainTheorem_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean
@@ -16,5 +16,7 @@ lean_lib «Sensitivity» where
   -- Original authors: Reid Barton, Johan Commelin, Jesse Michael Han,
   --   Chris Hughes, Robert Y. Lewis, Patrick Massot
   -- Apache 2.0 license preserved
-  -- `globs` (not default roots) so `lake build` auto-discovers `*_en` siblings (#4980).
-  globs := #[.submodules `Sensitivity]
+  -- `.submodules `Sensitivity` covers the Sensitivity.* submodules (FR + their _en siblings);
+  -- the root `Sensitivity_en` aggregator must be globbed explicitly (bare `.submodules`
+  -- matches only submodules, not sibling root modules), pattern #6585 / #4980.
+  globs := #[.submodules `Sensitivity, `Sensitivity_en]


### PR DESCRIPTION
## Summary

`i18n(lean,#4980)` — **sensitivity_lean root FR-first sibling pair**. Closes the
last bilingual-inline gap of this lake (the canonical root `Sensitivity.lean`
carried an inline EN docstring block). Convention-pure split identical to
knot_lean #6682 (which I cross-reviewed): FR-seul canonical root + EN twin
aggregator, EN content migrated verbatim (not deleted).

### Files (3, atomic, +25/−8)

| File | Change | Nature |
|---|---|---|
| `Sensitivity.lean` | strip the `---` separator + EN docstring block; keep FR-seul canonical root docstring + 4 FR imports; add FR convention note pointing to `Sensitivity_en.lean` | migrate (EN → twin) |
| `Sensitivity_en.lean` (new) | EN-seul root sibling — pure import aggregator of the 4 `*_en` submodules | new aggregator |
| `lakefile.lean` | `globs := #[.submodules `Sensitivity, `Sensitivity_en]` + corrected comment (bare `.submodules` covers only submodules, not sibling root modules = orphan-trap) | glob-fix |

### Symmetry (FR root ↔ EN twin)

```
FR root Sensitivity.lean            EN twin Sensitivity_en.lean
  import Sensitivity.Hypercube        import Sensitivity.Hypercube_en
  import Sensitivity.VectorSpace      import Sensitivity.VectorSpace_en
  import Sensitivity.Operator         import Sensitivity.Operator_en
  import Sensitivity.MainTheorem      import Sensitivity.MainTheorem_en
```
Mirror 4 ↔ 4.

## Pre-claims (verified firsthand for merge-gate cross-check)

| Claim | Status |
|---|---|
| 3 files +25/−8 atomic (R3) | ✓ `Sensitivity.lean` strip + `Sensitivity_en.lean` new + `lakefile.lean` glob |
| `Sensitivity.lean` strip EN block → FR-seul canonical | ✓ EN content **migrated verbatim** to `Sensitivity_en.lean` (migrate, not delete → anti-regression) |
| `Sensitivity_en.lean` aggregates 4 `*_en` imports | ✓ Hypercube_en / VectorSpace_en / Operator_en / MainTheorem_en (all present on main) |
| **Symmetry** FR root 4 imports ↔ EN twin 4 imports | ✓ exact mirror |
| lakefile glob `#[.submodules `Sensitivity, `Sensitivity_en]` | ✓ pattern #6585 / #6682 (sibling root is a bare name, not `.submodules`) |
| `grep -c sorry` = 0 (root + twin + lakefile) | ✓ the root aggregator carries no proof |
| **ORPHAN-TRAP gate = Lean CI (sensitivity_lean)** | ⏳ pending CI — the new `Sensitivity_en` must compile via the glob = cold-build proof (C441-L3) |
| Collision guard: 4 leaves `*_en` MERGED | ✓ these submodules already build on main; only the root aggregator is new |
| R1 catalogue byte-identical | ✓ no catalogue touched |
| R4 `See #4980` (not `Closes`) | ✓ partial contribution to the epic |

## ORPHAN-TRAP gate

Bare `.submodules `Sensitivity`` covers `Sensitivity.*` submodules (including
the existing `Sensitivity.Hypercube_en` leaves) but **not** the sibling root
file `Sensitivity_en.lean`. Without adding `` `Sensitivity_en `` to the glob,
`lake build` would silently skip it — the EN twin would never compile, a
lurking orphan. The glob fix forces a cold-build of `Sensitivity_en` via Lean
CI: that green check is the canonical proof the split is sound (same gate as
knot_lean #6682, which passed in 2m55s).

## Convention (#4980, sibling pair, ratified 2026-07-04)

- `Sensitivity.lean` = FR-seul canonical root.
- `Sensitivity_en.lean` = EN-seul twin, pure import aggregator.
- **Byte-identity preserved**: theorem/lemma statements, tactics, lemma names,
  Mathlib references unchanged; only the docstrings/comments differ between the
  two roots (here, the roots carry no proof at all).
- No bilingual-inline block (Option B rejected: cost 2× + FR/EN drift).

See #4980
