### PR TITLE
i18n(lean,#4980): calibration_lean root FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration.lean
@@ -8,16 +8,8 @@
 
   Difficulté cible : 3-10 itérations du prouveur (zone de Goldilocks).
 
-  ---
-  English:
-  Calibration targets for the multi-agent Lean prover (Epic #1452).
-
-  Each theorem exercises a specific harness path:
-  - P1: no-progress detection (stuck agents)
-  - P2: distant-error diagnosis
-  - P3: phantom-identifier blocklist (searches for nonexistent Mathlib lemmas)
-
-  Target difficulty: 3-10 prover iterations (Goldilocks zone).
+  Convention i18n #4980 (sibling pair) : cette racine est FR-seule canonique,
+  le jumeau anglais agrégateur est `Calibration_en.lean`.
 -/
 import Calibration.Nash
 import Calibration.Nim

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/Calibration_en.lean
@@ -1,0 +1,16 @@
+/-
+  Calibration targets for the multi-agent Lean prover (Epic #1452).
+
+  Each theorem exercises a specific harness path:
+  - P1: no-progress detection (stuck agents)
+  - P2: distant-error diagnosis
+  - P3: phantom-identifier blocklist (searches for nonexistent Mathlib lemmas)
+
+  Target difficulty: 3-10 prover iterations (Goldilocks zone).
+
+  i18n convention #4980 (sibling pair): this root is EN-only, the canonical
+  French aggregator twin is `Calibration.lean`.
+-/
+import Calibration.Nash_en
+import Calibration.Nim_en
+import Calibration.Doomsday_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.lean
@@ -12,8 +12,10 @@ require mathlib from git
 
 @[default_target]
 lean_lib «Calibration» where
-  -- `globs` (not default roots) so `lake build` auto-discovers `*_en` siblings (#4980).
-  globs := #[.submodules `Calibration]
+  -- `.submodules `Calibration` covers the Calibration.* submodules (FR + their _en siblings);
+  -- the root `Calibration_en` aggregator must be globbed explicitly (bare `.submodules`
+  -- matches only submodules, not sibling root modules), pattern #6585 / #4980.
+  globs := #[.submodules `Calibration, `Calibration_en]
   -- Calibration targets for multi-agent Lean prover (Epic #1452).
   -- Each theorem is a self-contained proof challenge designed to exercise
   -- specific harness paths (P1/P2/P3 from Epic #1453).


### PR DESCRIPTION
## Summary

`i18n(lean,#4980)` — **calibration_lean root FR-first sibling pair**. Closes the
last bilingual-inline gap of this lake (the canonical root `Calibration.lean`
carried an inline EN docstring block). Convention-pure split identical to
knot_lean #6682 and sensitivity_lean #6685: FR-seul canonical root + EN twin
aggregator, EN content migrated verbatim (not deleted).

### Files (3, atomic, +22/−12)

| File | Change | Nature |
|---|---|---|
| `Calibration.lean` | strip the `---` separator + EN docstring block; keep FR-seul canonical root docstring + 3 FR imports; add FR convention note pointing to `Calibration_en.lean` | migrate (EN → twin) |
| `Calibration_en.lean` (new) | EN-seul root sibling — pure import aggregator of the 3 `*_en` submodules | new aggregator |
| `lakefile.lean` | `globs := #[.submodules `Calibration, `Calibration_en]` + corrected comment (bare `.submodules` covers only submodules, not sibling root modules = orphan-trap) | glob-fix |

### Symmetry (FR root ↔ EN twin)

```
FR root Calibration.lean            EN twin Calibration_en.lean
  import Calibration.Nash             import Calibration.Nash_en
  import Calibration.Nim              import Calibration.Nim_en
  import Calibration.Doomsday         import Calibration.Doomsday_en
```
Mirror 3 ↔ 3.

## Pre-claims (verified firsthand for merge-gate cross-check)

| Claim | Status |
|---|---|
| 3 files +22/−12 atomic (R3) | ✓ `Calibration.lean` strip + `Calibration_en.lean` new + `lakefile.lean` glob |
| `Calibration.lean` strip EN block → FR-seul canonical | ✓ EN content **migrated verbatim** to `Calibration_en.lean` (migrate, not delete → anti-regression) |
| `Calibration_en.lean` aggregates 3 `*_en` imports | ✓ Nash_en / Nim_en / Doomsday_en (all present on main) |
| **Symmetry** FR root 3 imports ↔ EN twin 3 imports | ✓ exact mirror |
| lakefile glob `#[.submodules `Calibration, `Calibration_en]` | ✓ pattern #6585 / #6682 / #6685 (sibling root is a bare name, not `.submodules`) |
| `grep -c sorry` = 0 (root + twin + lakefile) | ✓ the root aggregator carries no proof |
| **ORPHAN-TRAP gate = Lean CI (calibration_lean)** | ⏳ pending CI — the new `Calibration_en` must compile via the glob = cold-build proof (C441-L3) |
| Collision guard: 3 leaves `*_en` MERGED | ✓ these submodules already build on main; only the root aggregator is new |
| R1 catalogue byte-identical | ✓ no catalogue touched |
| R4 `See #4980` (not `Closes`) | ✓ partial contribution to the epic |

## ORPHAN-TRAP gate

Bare `.submodules `Calibration`` covers `Calibration.*` submodules (including
the existing `Calibration.Nash_en` leaves) but **not** the sibling root file
`Calibration_en.lean`. Without adding `` `Calibration_en `` to the glob,
`lake build` would silently skip it — the EN twin would never compile, a
lurking orphan. The glob fix forces a cold-build of `Calibration_en` via Lean
CI: that green check is the canonical proof the split is sound (same gate as
knot_lean #6682 / sensitivity_lean #6685).

## Convention (#4980, sibling pair, ratified 2026-07-04)

- `Calibration.lean` = FR-seul canonical root.
- `Calibration_en.lean` = EN-seul twin, pure import aggregator.
- **Byte-identity preserved**: theorem/lemma statements, tactics, lemma names,
  Mathlib references unchanged; only the docstrings/comments differ between the
  two roots (here, the roots carry no proof at all).
- No bilingual-inline block (Option B rejected: cost 2× + FR/EN drift).

See #4980
