### PR TITLE
i18n(lean,#4980): conway_cgt_lean root strip FR-seul

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/CGTTour.lean
+++ b/MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/CGTTour.lean
@@ -5,13 +5,9 @@
   Ce fichier propose une visite guidée des principaux résultats formalisés dans
   vihdzp/combinatorial-games, importé comme dépendance Lake.
 
-  ---
-  English: This file provides a curated tour of the main results formalized in
-  vihdzp/combinatorial-games, imported as a Lake dependency.
-
-  Dépôt / Repository: https://github.com/vihdzp/combinatorial-games
-  Auteurs / Authors: Violeta Hernandez Palacios (vihdzp)
-  Licence / License: Apache-2.0
+  Dépôt : https://github.com/vihdzp/combinatorial-games
+  Auteurs : Violeta Hernandez Palacios (vihdzp)
+  Licence : Apache-2.0
 
   Note historique :
   Ce dépôt a remplacé les modules CGT de Mathlib (SetTheory.Surreal,
@@ -19,35 +15,24 @@
   #28063 (août 2025) puis retirés dans la PR #35550 (février 2026). L'autrice
   (vihdzp) est la même personne qui maintenait le code CGT de Mathlib.
 
-  ---
-  English — Historical note:
-  This repository superseded Mathlib's CGT modules (SetTheory.Surreal,
-  SetTheory.PGame, SetTheory.Game, SetTheory.Nimber), which were deprecated
-  in PR #28063 (Aug 2025) and removed in PR #35550 (Feb 2026). The author
-  (vihdzp) is the same person who maintained the Mathlib CGT code.
-
   Principales contributions formalisées ici :
   1. Jeux combinatoires (IGame, Game, anniversaire, équivalence, ordre)
   2. Nombres surréels (LinearOrder, théorème de simplicité, multiplication, division)
   3. Nimbers (corps de caractéristique 2, connexion Sprague-Grundy)
   4. Jeux dyadiques et plongements ordinaux
 
-  ---
-  English — Key contributions formalized here:
-  1. Combinatorial games (IGame, Game, birthday, equivalence, ordering)
-  2. Surreal numbers (LinearOrder, simplicity theorem, multiplication, division)
-  3. Nimbers (characteristic 2 field, Sprague-Grundy connection)
-  4. Dyadic games and ordinal embeddings
+  Convention i18n #4980 (sibling pair) : cette racine est FR-seule canonique,
+  le jumeau anglais agrégateur est `CGTTour_en.lean`.
 -/
 
--- Théorie des jeux de base / Core game theory
+-- Théorie des jeux de base
 import CombinatorialGames.Game.Basic
 import CombinatorialGames.Game.Birthday
 import CombinatorialGames.Game.Order
 import CombinatorialGames.Game.Canonical
 import CombinatorialGames.Game.Player
 
--- Nombres surréels / Surreal numbers
+-- Nombres surréels
 import CombinatorialGames.Surreal.Basic
 import CombinatorialGames.Surreal.Multiplication
 import CombinatorialGames.Surreal.Division
@@ -86,31 +71,6 @@ def Game := Antisymmetrization IGame (· ≤ ·)
 ```
 
 `Game` forme un `OrderedAddCommGroup` :
-
----
-**English**
-
-The formalization is built on two layers:
-
-### IGame (pre-games)
-An `IGame` is a combinatorial game defined by its left and right option sets:
-```
-structure IGame : Type (u+1) where
-  left : Set IGame
-  right : Set IGame
-  [small_left : Small left]
-  [small_right : Small right]
-```
-This is the concrete representation where you can inspect individual moves.
-
-### Game (games up to equivalence)
-Two games `x` and `y` are equivalent (`x ≈ y`) when neither player has a
-preference -- formally `x ≤ y ∧ y ≤ x`. The quotient type:
-```
-def Game := Antisymmetrization IGame (· ≤ ·)
-```
-
-`Game` forms an `OrderedAddCommGroup`:
 -/
 #check @Game.mk                               -- IGame → Game (application du quotient)
 #check (inferInstance : AddCommGroupWithOne Game)
@@ -134,26 +94,6 @@ l'outil clé pour calculer les valeurs surréelles :
 theorem IGame.Fits.equiv_of_forall_not_fits :
     Numeric x → x.Fits y → (∀ p z ∈ x.moves p, ¬ z.Fits y) → x ≈ y
 ```
-
----
-**English**
-
-A surreal number is a numeric game quotiented by equivalence:
-```
-def Surreal := Antisymmetrization (Subtype Numeric) (· ≤ ·)
-```
-
-The surreals inherit `≤` and `<` from games, forming a **linear order**.
-They form a complete ordered field containing every ordered field as a subfield.
-
-### Simplicity Theorem
-If a numeric game `x` fits within `y` (lies between y's left and right options)
-but none of its options do, then `x ≈ y`. This is the key tool for computing
-surreal values:
-```
-theorem IGame.Fits.equiv_of_forall_not_fits :
-    Numeric x → x.Fits y → (∀ p z ∈ x.moves p, ¬ z.Fits y) → x ≈ y
-```
 -/
 #check @Surreal.mk                            -- IGame → [Numeric] → Surreal
 #check (inferInstance : LinearOrder Surreal)   -- Ordre total sur les surréels
@@ -165,14 +105,6 @@ Les surréels portent les opérations complètes d'un corps :
 - Addition (héritée du AddCommGroup de Game)
 - Multiplication (définie dans Surreal.Multiplication)
 - Division (définie dans Surreal.Division)
-
----
-**English — Surreal Arithmetic**
-
-The surreals carry full field operations:
-- Addition (inherited from Game's AddCommGroup)
-- Multiplication (defined in Surreal.Multiplication)
-- Division (defined in Surreal.Division)
 -/
 #check (inferInstance : CommRing Surreal)
 #check (inferInstance : LinearOrder Surreal)
@@ -181,23 +113,12 @@ The surreals carry full field operations:
 
 Tout rationnel dyadique se plonge dans les surréels via `Dyadic.toIGame`.
 Les surréels dyadiques sont exactement ceux d'anniversaire fini.
-
----
-**English — Dyadic Surreals**
-
-Every dyadic rational embeds into the surreals via `Dyadic.toIGame`.
-The dyadic surreals are precisely those with finite birthday.
 -/
 #check @Dyadic.toIGame    -- Plongement Rationnel dyadique → IGame
 
 /-! ### Plongement ordinal
 
 Tout ordinal se plonge dans les surréels via `NatOrdinal.toSurreal` :
-
----
-**English — Ordinal Embedding**
-
-Every ordinal embeds into the surreals via `NatOrdinal.toSurreal`:
 -/
 #check @NatOrdinal.toSurreal  -- NatOrdinal ↪o Surreal
 
@@ -219,26 +140,6 @@ Notation : `∗o` pour `Nimber.of o` (conversion depuis Ordinal).
 theorem add_def (a b : Nimber) :
     a + b = sInf {x | (∃ a' < a, a' + b = x) ∨ ∃ b' < b, a + b' = x}ᶜ
 ```
-
----
-**English**
-
-Nimbers are ordinals equipped with nim arithmetic. They arise from impartial
-games via the Sprague-Grundy theorem: every impartial game is equivalent to
-some game of nim.
-
-### Definition
-```
-Nimber = Ordinal (type synonym with nimber addition and multiplication)
-```
-Notation: `∗o` for `Nimber.of o` (cast from Ordinal).
-
-### Nim Addition
-`a + b` is the minimum excluded value (mex) from `{a' + b, a + b'}`:
-```
-theorem add_def (a b : Nimber) :
-    a + b = sInf {x | (∃ a' < a, a' + b = x) ∨ ∃ b' < b, a + b' = x}ᶜ
-```
 -/
 #check @Nimber.add_def          -- Définition de l'addition de nim par mex
 #check @Nimber.exists_of_lt_add -- Réciproque : toute valeur plus petite est atteinte
@@ -250,14 +151,6 @@ caractéristique 2** (chaque élément est son propre opposé pour l'addition).
 
 L'objectif à long terme du projet est de prouver que les nimbers sont
 algébriquement clos.
-
----
-**English — Nimber Field**
-
-Nimbers with nim addition and nim multiplication form a **field of
-characteristic 2** (every element is its own additive inverse).
-
-The long-term goal of the project is to prove nimbers are algebraically closed.
 -/
 #check (inferInstance : Field Nimber)
 
@@ -275,23 +168,6 @@ Le dépôt `combinatorial-games` représente une expansion substantielle :
 | Toolchain | v4.x (ancien) | v4.31.0-rc1 (actuel) |
 
 Référence : Conway, J.H. - *On Numbers and Games* (2001)
-
----
-**English — Key Differences with the Former Mathlib CGT**
-
-The `combinatorial-games` repo represents a substantial expansion:
-
-| Aspect | Mathlib (removed) | combinatorial-games (current) |
-|--------|-------------------|-------------------------------|
-| Games | `PGame` (basic) | `IGame` (concrete) + `Game` (quotient) |
-| Surreals | `Surreal.Basic/Dyadic/Mul` | + Division, Hahn series, Birthday, Pow |
-| Nimbers | `Nimber.Basic/Field` | + Nat, SimplestExtension |
-| Order | `PGame.Order` | Full `LinearOrder` on surreals |
-| Games lib | 8 modules | 15+ modules (Impartial, Loopy, Specific...) |
-| Toolchain | v4.x (old) | v4.31.0-rc1 (current) |
-
-Reference: Conway, J.H. - *On Numbers and Games* (2001)
-
 -/
 
 end CGTTour


### PR DESCRIPTION
## Summary

`i18n(lean,#4980)` — **conway_cgt_lean root FR-seul strip**. The canonical root
`CGTTour.lean` carried ~11 inline `--- English` / `**English**` docstring blocks
duplicated across the root docstring and all 4 section docstrings, even though
the EN twin `CGTTour_en.lean` already exists (added c.429) as a complete,
standalone EN mirror. This PR strips the redundant EN from the root → FR-seul
canonical, exactly the #4980 sibling-pair convention end-state. The lakefile
glob (`#[`CGTTour, `CGTTour_en]`) was already correct from c.429, so no glob
change here — this is a pure content strip.

### Files (1, atomic)

| File | Change | Nature |
|---|---|---|
| `CGTTour.lean` | strip all `--- English` / `**English**` blocks + EN halves of bilingual slash lines (Dépôt/Repository, etc.); add FR convention note pointing to `CGTTour_en.lean`. 298 → 173 lines (−125 EN duplication). | strip (EN already in twin) |

### What is preserved (byte-identity of code)

- **All `#check` statements** untouched (the executable content of the tour).
- **All imports** (`CombinatorialGames.*`) untouched.
- **`namespace CGTTour` / `open` / `end CGTTour`** untouched.
- **All FR prose** (root docstring + 4 sections + subsections + the comparison table).
- **Code blocks** (`structure IGame`, `def Game`, `def Surreal`, `theorem add_def`).

Only docstrings/comments changed. The EN twin `CGTTour_en.lean` is **not modified** — it already carries the full EN content (verified: imports, all 4 sections, code blocks, table).

## Pre-claims (verified firsthand)

| Claim | Status |
|---|---|
| 1 file atomic (R3) | ✓ only `CGTTour.lean` modified; twin untouched |
| EN twin already exists + complete (EN preserved) | ✓ `CGTTour_en.lean` has all imports + 4 EN sections + table (verified firsthand); strip = remove redundancy, not delete |
| `grep -c sorry` = 0 | ✓ |
| Residual "English" in root = 0 | ✓ fully FR-seul (0 matches) |
| All `#check` / imports / namespace preserved | ✓ byte-identity of code |
| **Local `lake build CGTTour` SUCCESS** | ⏳/✓ (junction to cached `CombinatorialGames` dep, verifying) |
| **ORPHAN-TRAP gate = Lean CI (conway_cgt_lean)** | ⏳ pending CI — module must still compile after strip |
| LF endings (no CRLF) | ✓ UTF-8 |
| R1 catalogue byte-identical | ✓ no catalogue touched |
| R4 `See #4980` (not `Closes`) | ✓ partial contribution to the epic |

## Convention (#4980, sibling pair, ratified 2026-07-04)

- `CGTTour.lean` = FR-seul canonical root (after this PR).
- `CGTTour_en.lean` = EN-seul twin (unchanged, complete).
- No bilingual-inline block (Option B rejected: cost 2× + FR/EN drift).

This closes the last bilingual-inline gap of conway_cgt_lean (the leaf-level
`*_en` twins + root twin were done in c.429; only the FR root still carried
the redundant inline EN).

See #4980
