### PR TITLE
i18n(lean,#4980): sensitivity_lean leaves FR-seul strip (4 modules)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Hypercube.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Hypercube.lean
@@ -15,12 +15,6 @@ import Mathlib.Tactic.FinCases
 # L'hypercube pour le théorème de sensibilité de Huang
 
 Ce fichier définit l'hypercube `Q n = Fin n → Bool` et sa relation d'adjacence.
-
----
-English:
-# The hypercube for Huang's sensitivity theorem
-
-This file defines the hypercube `Q n = Fin n → Bool` and its adjacency relation.
 -/
 
 namespace Sensitivity
@@ -36,27 +30,15 @@ Notations :
 - `ℕ` désigne les entiers naturels (zéro inclus).
 - `Fin n` = {0, ⋯ , n - 1}.
 - `Bool` = {`true`, `false`}.
-
----
-English:
-### The hypercube
-
-Notations:
-- `ℕ` denotes natural numbers (including zero).
-- `Fin n` = {0, ⋯ , n - 1}.
-- `Bool` = {`true`, `false`}.
 -/
 
 
-/-- L'hypercube en dimension `n`.
-    English: The hypercube in dimension `n`. -/
+/-- L'hypercube en dimension `n`. -/
 abbrev Q (n : ℕ) :=
   Fin n → Bool
 
 /-- La projection de `Q n.succ` vers `Q n` oubliant la première valeur
-(c'est-à-dire l'image de zéro).
-    English: The projection from `Q n.succ` to `Q n` forgetting the first value
-(i.e. the image of zero). -/
+(c'est-à-dire l'image de zéro). -/
 def π {n : ℕ} : Q n.succ → Q n := fun p => p ∘ Fin.succ
 
 namespace Q
@@ -66,13 +48,11 @@ theorem ext {n} {f g : Q n} (h : ∀ x, f x = g x) : f = g := funext h
 
 variable (n : ℕ)
 
-/-- `Q 0` possède un unique élément.
-    English: `Q 0` has a unique element. -/
+/-- `Q 0` possède un unique élément. -/
 instance : Unique (Q 0) :=
   ⟨⟨fun _ => true⟩, by intro; ext x; fin_cases x⟩
 
-/-- `Q n` possède 2^n éléments.
-    English: `Q n` has 2^n elements. -/
+/-- `Q n` possède 2^n éléments. -/
 theorem card : Fintype.card (Q n) = 2 ^ n := by simp
 
 variable {n}
@@ -88,19 +68,14 @@ theorem succ_n_eq (p q : Q n.succ) : p = q ↔ p 0 = q 0 ∧ π p = π q := by
       convert congr_fun h (Fin.pred x hx)
 
 /-- La relation d'adjacence définissant la structure de graphe sur `Q n` :
-`p.adjacent q` s'il existe une arête de `p` vers `q` dans `Q n`.
-    English: The adjacency relation defining the graph structure on `Q n`:
-`p.adjacent q` if there is an edge from `p` to `q` in `Q n`. -/
+`p.adjacent q` s'il existe une arête de `p` vers `q` dans `Q n`. -/
 def adjacent {n : ℕ} (p : Q n) : Set (Q n) := { q | ∃! i, p i ≠ q i }
 
-/-- Dans `Q 0`, aucun couple de sommets n'est adjacent.
-    English: In `Q 0`, no two vertices are adjacent. -/
+/-- Dans `Q 0`, aucun couple de sommets n'est adjacent. -/
 theorem not_adjacent_zero (p q : Q 0) : q ∉ p.adjacent := by rintro ⟨v, _⟩; apply finZeroElim v
 
 /-- Si `p` et `q` dans `Q n.succ` ont des valeurs différentes en zéro, alors ils sont
-adjacents ssi leurs projections sur `Q n` sont égales.
-    English: If `p` and `q` in `Q n.succ` have different values at zero then they are adjacent
-iff their projections to `Q n` are equal. -/
+adjacents ssi leurs projections sur `Q n` sont égales. -/
 theorem adj_iff_proj_eq {p q : Q n.succ} (h₀ : p 0 ≠ q 0) : q ∈ p.adjacent ↔ π p = π q := by
   constructor
   · rintro ⟨i, _, h_uni⟩
@@ -115,9 +90,7 @@ theorem adj_iff_proj_eq {p q : Q n.succ} (h₀ : p 0 ≠ q 0) : q ∈ p.adjacent
     apply congr_fun heq
 
 /-- Si `p` et `q` dans `Q n.succ` ont la même valeur en zéro, alors ils sont adjacents
-ssi leurs projections sur `Q n` sont adjacentes.
-    English: If `p` and `q` in `Q n.succ` have the same value at zero then they are adjacent
-iff their projections to `Q n` are adjacent. -/
+ssi leurs projections sur `Q n` sont adjacentes. -/
 theorem adj_iff_proj_adj {p q : Q n.succ} (h₀ : p 0 = q 0) :
     q ∈ p.adjacent ↔ π q ∈ (π p).adjacent := by
   constructor

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/MainTheorem.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/MainTheorem.lean
@@ -17,14 +17,6 @@ import Mathlib.Tactic.FinCases
 Ce fichier prouve le théorème principal : dans l'hypercube de dimension n ≥ 1,
 si l'on colorie plus de la moitié des sommets, alors au moins un sommet possède
 au moins √n voisins coloriés.
-
----
-English:
-# Huang's sensitivity theorem (main result)
-
-This file proves the main theorem: in the hypercube of dimension n ≥ 1,
-if one colors more than half the vertices then at least one vertex has
-at least √n colored neighbors.
 -/
 
 namespace Sensitivity
@@ -49,23 +41,13 @@ variable {m : ℕ}
 ### La preuve principale
 
 Dans cette section, afin d'imposer que `n` soit strictement positif, nous l'écrivons
-sous la forme `m + 1` pour un certain entier naturel `m`.
-
----
-English:
-### The main proof
-
-In this section, in order to enforce that `n` is positive, we write it as
-`m + 1` for some natural number `m`. -/
+sous la forme `m + 1` pour un certain entier naturel `m`. -/
 
 
 open Classical in
 /-- Si une partie `H` de `Q (m+1)` a un cardinal au moins `2^m + 1`, alors le
 sous-espace de `V (m+1)` engendré par les vecteurs de base correspondants intersecte
-non trivialement l'image de `g m`.
-    English: If a subset `H` of `Q (m+1)` has cardinal at least `2^m + 1` then the
-subspace of `V (m+1)` spanned by the corresponding basis vectors non-trivially
-intersects the range of `g m`. -/
+non trivialement l'image de `g m`. -/
 theorem exists_eigenvalue (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
     ∃ y ∈ Span (e '' H) ⊓ range (g m), y ≠ 0 := by
   let W := Span (e '' H)
@@ -98,8 +80,7 @@ theorem exists_eigenvalue (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
   linarith
 
 open Classical in
-/-- **Théorème de sensibilité de Huang** également connu sous le nom de **théorème du degré de Huang**.
-    English: **Huang sensitivity theorem** also known as the **Huang degree theorem** -/
+/-- **Théorème de sensibilité de Huang** également connu sous le nom de **théorème du degré de Huang**. -/
 theorem huang_degree_theorem (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
     ∃ q, q ∈ H ∧ √(m + 1) ≤ Card H ∩ q.adjacent := by
   rcases exists_eigenvalue H hH with ⟨y, ⟨⟨y_mem_H, y_mem_g⟩, y_ne⟩⟩

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Operator.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/Operator.lean
@@ -14,13 +14,6 @@ import Sensitivity.VectorSpace
 
 Ce fichier définit les opérateurs linéaires `f` (matrice de Huang) et `g` (matrice de Knuth),
 et prouve les propriétés clés : f² = n·id, injectivité de g, et la relation d'image.
-
----
-English:
-# Linear operators for Huang's sensitivity theorem
-
-This file defines the linear operators `f` (Huang's matrix) and `g` (Knuth's matrix),
-and proves key properties: f² = n·id, injectivity of g, and the image relation.
 -/
 
 namespace Sensitivity
@@ -33,15 +26,11 @@ local notation "√" => Real.sqrt
 
 variable {n : ℕ}
 
-/-! ### L'application linéaire
-
-English: The linear map -/
+/-! ### L'application linéaire -/
 
 
 /-- L'opérateur linéaire $f_n$ correspondant à la matrice $A_n$ de Huang,
-défini inductivement comme une application ℝ-linéaire de `V n` vers `V n`.
-    English: The linear operator $f_n$ corresponding to Huang's matrix $A_n$,
-defined inductively as a ℝ-linear map from `V n` to `V n`. -/
+défini inductivement comme une application ℝ-linéaire de `V n` vers `V n`. -/
 noncomputable def f : ∀ n, V n →ₗ[ℝ] V n
   | 0 => 0
   | n + 1 =>
@@ -81,8 +70,7 @@ theorem f_matrix (p q : Q n) : |ε q (f n (e p))| = if p ∈ q.adjacent then 1 e
       simp [hp, hq, IH, duality, abs_of_nonneg ite_nonneg, Q.adj_iff_proj_eq,
         Q.adj_iff_proj_adj]
 
-/-- L'opérateur linéaire $g_m$ correspondant à la matrice $B_m$ de Knuth.
-    English: The linear operator $g_m$ corresponding to Knuth's matrix $B_m$. -/
+/-- L'opérateur linéaire $g_m$ correspondant à la matrice $B_m$ de Knuth. -/
 noncomputable def g (m : ℕ) : V m →ₗ[ℝ] V m.succ :=
   LinearMap.prod (f m + √(m + 1) • LinearMap.id) LinearMap.id
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/VectorSpace.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/Sensitivity/VectorSpace.lean
@@ -17,13 +17,6 @@ import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 
 Ce fichier définit l'espace vectoriel libre `V n` sur les sommets de l'hypercube,
 la base `e`, la base duale `ε`, et prouve les résultats de dualité et de dimension.
-
----
-English:
-# Vector space for Huang's sensitivity theorem
-
-This file defines the free vector space `V n` on vertices of the hypercube,
-the basis `e`, the dual basis `ε`, and proves duality and dimension results.
 -/
 
 namespace Sensitivity
@@ -34,13 +27,10 @@ open Function LinearMap Module Module.DualBases
 
 local notation "√" => Real.sqrt
 
-/-! ### L'espace vectoriel
-
-English: The vector space -/
+/-! ### L'espace vectoriel -/
 
 
-/-- L'espace vectoriel libre sur les sommets d'un hypercube, défini inductivement.
-    English: The free vector space on vertices of a hypercube, defined inductively. -/
+/-- L'espace vectoriel libre sur les sommets d'un hypercube, défini inductivement. -/
 def V : ℕ → Type
   | 0 => ℝ
   | n + 1 => V n × V n
@@ -67,8 +57,7 @@ instance : Module ℝ (V n) := by induction n <;> · dsimp only [V]; infer_insta
 
 end V
 
-/-- La base de `V` indexée par l'hypercube, définie inductivement.
-    English: The basis of `V` indexed by the hypercube, defined inductively. -/
+/-- La base de `V` indexée par l'hypercube, définie inductivement. -/
 noncomputable def e : ∀ {n}, Q n → V n
   | 0 => fun _ => (1 : ℝ)
   | Nat.succ _ => fun x => cond (x 0) (e (π x), 0) (0, e (π x))
@@ -77,8 +66,7 @@ noncomputable def e : ∀ {n}, Q n → V n
 theorem e_zero_apply (x : Q 0) : e x = (1 : ℝ) :=
   rfl
 
-/-- La base duale de `e`, définie inductivement.
-    English: The dual basis to `e`, defined inductively. -/
+/-- La base duale de `e`, définie inductivement. -/
 noncomputable def ε : ∀ {n : ℕ}, Q n → V n →ₗ[ℝ] ℝ
   | 0, _ => LinearMap.id
   | Nat.succ _, p =>
@@ -99,8 +87,7 @@ theorem duality (p q : Q n) : ε p (e q) = if p = q then 1 else 0 := by
         LinearMap.comp_apply, IH]
       congr 1; simp [Q.succ_n_eq, hp, hq]
 
-/-- Tout vecteur de `V n` annulé par tous les `ε p` est nul.
-    English: Any vector in `V n` annihilated by all `ε p`'s is zero. -/
+/-- Tout vecteur de `V n` annulé par tous les `ε p` est nul. -/
 theorem epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 := by
   induction n with
   | zero => dsimp [ε] at h; exact h fun _ => true
@@ -119,8 +106,7 @@ theorem epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 := by
 open Module
 
 open Classical in
-/-- `e` et `ε` sont des familles duales de vecteurs.
-    English: `e` and `ε` are dual families of vectors. -/
+/-- `e` et `ε` sont des familles duales de vecteurs. -/
 theorem dualBases_e_ε (n : ℕ) : DualBases (@e n) (@ε n) where
   eval_same := by simp [duality]
   eval_of_ne _ _ h := by simp [duality, h]


### PR DESCRIPTION
## Summary

`i18n(lean,#4980)` — **sensitivity_lean leaves FR-seul strip**. The 4 leaf
modules of this lake still carried inline bilingual docstrings
(`--- English:` sub-blocks in `/-!` section headers + `English:` lines in
`/-- -/` definitions), even though their EN twins (`*_en.lean`) already exist
as complete standalone mirrors (added when the lake went FR-first). This PR
strips the redundant EN from the FR leaves → FR-seul canonical, exactly the
#4980 sibling-pair convention end-state. Pure docstring/comment strip; the EN
content was already migrated verbatim to the twins (migrate-done, not deleted).

Companion to the root split #6685 (which made `Sensitivity.lean` FR-seul); this
closes the leaf-level gap so the whole lake is consistently FR-seul.

### Files (4, atomic, +20/−92)

| File | EN blocks stripped | Lines |
|---|---|---|
| `Sensitivity/Hypercube.lean` | 9 (2 section `/-!` blocks + 7 inline docstrings) | 151 → 124 |
| `Sensitivity/VectorSpace.lean` | 7 (1 section block + 1 variant `/-!` + 5 inline) | 146 → ~120 |
| `Sensitivity/Operator.lean` | 4 (1 section block + 1 variant `/-!` + 2 inline) | 112 → ~94 |
| `Sensitivity/MainTheorem.lean` | 4 (2 section blocks + 2 inline) | 154 → ~129 |

### What is preserved (byte-identity of code — DECISIVE proof)

Only docstrings (`/- ... -/`) and comments were edited. **The executable code
is byte-identical to main**, proven by stripping all comments then diffing:

```
for f in Hypercube VectorSpace Operator MainTheorem; do CODE IDENTICAL ✓; done
Hypercube: CODE IDENTICAL ✓   VectorSpace: CODE IDENTICAL ✓
Operator:  CODE IDENTICAL ✓   MainTheorem: CODE IDENTICAL ✓
```

Declaration counts unchanged (Hypercube 11=11, VectorSpace 14=14, Operator 7=7,
MainTheorem 2=2). Docstring block balance preserved (`/-` openers == `-/`
closers, same counts as main). The EN twins (`Hypercube_en` etc.) are
**unchanged** — verified firsthand each carries the full EN content (section
headers, all definition docstrings, code byte-identical, only namespace
`Sensitivity_en` differs).

## Pre-claims (verified firsthand)

| Claim | Status |
|---|---|
| 4 files atomic, one subject (R3) | ✓ only the 4 FR leaves; twins untouched |
| `grep -c sorry` = 0 before AND after (each leaf) | ✓ no proof touched |
| Code byte-identical to main (comment-strip diff empty) | ✓ DECISIVE |
| Docstring balance preserved (`/-` == `-/`) | ✓ all 4 leaves |
| EN twins exist + complete (EN preserved, strip = migrate-done) | ✓ verified firsthand |
| Residual "English" in leaves = 0 | ✓ (was 10/7/4/4 → 0/0/0/0) |
| **ORPHAN-TRAP gate = Lean CI (lean-sensitivity.yml)** | ⏳ pending CI — modules must still compile after strip; code byte-identical ⇒ compile identical to main |
| LF endings (no CRLF) | ✓ UTF-8 |
| R1 catalogue byte-identical | ✓ no catalogue touched |
| R4 `See #4980` (not `Closes`) | ✓ partial contribution to the epic |

## Why CI is the gate (not local build)

Local `lake build Sensitivity` is currently infeasible on this machine:
`.lake/packages/mathlib` junction → rc2 cache (`v4.30.0-rc2-54f98fd6`) but
`lean-toolchain` pins `v4.31.0-rc1` → a local build triggers a full mathlib
rebuild (same toolchain-pin-vs-cache condition as c.457 CGTTour). This mismatch
is **pre-existing on main** (not introduced by this PR — the PR is docstring-
only and touches neither `lean-toolchain` nor the junction). The CI workflow
`lean-sensitivity.yml` (→ `lean-build.yml`) builds with a consistent toolchain
+ fresh cache and gates `sorry-baseline: 0`. Since the code is byte-identical to
the (already-passing) main version, CI will pass identically. Flagging the
rc1/rc2 drift for ai-01 as a separate concern (out of scope here).

## Convention (#4980, sibling pair, ratified 2026-07-04)

- `Sensitivity/*.lean` = FR-seul canonical leaves (after this PR).
- `Sensitivity/*_en.lean` = EN-seul twins (unchanged, complete).
- No bilingual-inline block (Option B rejected: cost 2× + FR/EN drift).
- Byte-identity preserved: theorem/lemma statements, tactics, lemma names,
  Mathlib references unchanged; only docstrings/comments differ between siblings.

See #4980
