### PR TITLE
fix(search,#3801): MGS-10 center-bias ASCII bar -> Plotly signed h-bar (Prong-A, env unlocked)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-10-CenterBias.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-10-CenterBias.ipynb
@@ -720,94 +720,33 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Signature de biais moyenne (barre = delta normalise au pire optimiseur) :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Random(control)  |######################                  | delta_moyen = 2,753\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  GA(uniform)      |                                        | delta_moyen = -0,123\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  WOA              |########################################| delta_moyen = 4,984\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  EO               |#####                                   | delta_moyen = 0,663\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  FBI              |                                        | delta_moyen = 0,001\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  DE               |                                        | delta_moyen = -2,147\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  BBPSO            |                                        | delta_moyen = -1,658\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  SA               |#############                           | delta_moyen = 1,659\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"pltddaf6a9e3cf84d5c959df2d7435d504b\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltddaf6a9e3cf84d5c959df2d7435d504b',[{\"y\":[\"WOA\",\"Random(control)\",\"SA\",\"EO\",\"FBI\",\"GA(uniform)\",\"BBPSO\",\"DE\"],\"x\":[4.984,2.753,1.659,0.663,0.001,-0.123,-1.658,-2.147],\"type\":\"bar\",\"orientation\":\"h\",\"marker\":{\"color\":[\"#2a6dba\",\"#2a6dba\",\"#2a6dba\",\"#2a6dba\",\"#2a6dba\",\"#e8743b\",\"#e8743b\",\"#e8743b\"]},\"text\":[4.984,2.753,1.659,0.663,0.001,-0.123,-1.658,-2.147],\"textposition\":\"auto\"}],{\"title\":{\"text\":\"Signature de biais moyenne par optimiseur (delta > 0 = centre, < 0 = anti-centre)\"},\"xaxis\":{\"title\":{\"text\":\"Delta moyen (objectif deplace - objectif centre)\"},\"zeroline\":true,\"zerolinewidth\":2,\"zerolinecolor\":\"#444\"},\"yaxis\":{\"title\":{\"text\":\"Optimiseur\"}},\"margin\":{\"l\":120,\"r\":40}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "\r\n",
-      "(10,45): info CS9236: La compilation nécessite la liaison de l’expression lambda au moins 100 fois. Envisagez de déclarer l’expression lambda avec des types de paramètre explicites ou, si l’appel de méthode conteneur est générique, utilisez des arguments de type explicite.\r\n",
+      "(17,45): info CS9236: La compilation nécessite la liaison de l’expression lambda au moins 100 fois. Envisagez de déclarer l’expression lambda avec des types de paramètre explicites ou, si l’appel de méthode conteneur est générique, utilisez des arguments de type explicite.\r\n",
       "\r\n"
      ]
     }
    ],
    "source": [
-    "// Tableau de synthèse : le delta (signature du biais) par fonction x optimiseur + moyenne par optimiseur.\n",
+    "// Tableau de synthese : le delta (signature du biais) par fonction x optimiseur + moyenne par optimiseur.\n",
+    "// (rendu Plotly du chart de biais en fin de cellule, technique C548-L2 : formatter HTML integre au kernel, zero NuGet charting)\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
     "var functions = rows.Select(r => r.R.Function).Distinct().ToList();\n",
     "\n",
     "Console.WriteLine(\"Delta (objectif deplace - objectif centre) : ~0 = non biaise, >0 = biaise vers le centre.\");\n",
@@ -828,15 +767,29 @@
     "    Console.WriteLine(row);\n",
     "}\n",
     "\n",
-    "// Diagramme en barres ASCII : moyenne delta normalisée au max (hiérarchie du biais d'un coup d'œil).\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Signature de biais moyenne (barre = delta normalise au pire optimiseur) :\");\n",
-    "Console.WriteLine();\n",
-    "foreach (var g in byOpt)\n",
+    "// Diagramme en barres horizontales Plotly : signature de biais moyenne par optimiseur.\n",
+    "// Contrairement a la barre ASCII (qui masquait les deltas negatifs via Math.Max(0, mean)),\n",
+    "// le chart SIGNE montre les deux sens du biais : >0 = tire vers le centre (WOA, Random),\n",
+    "// <0 = anti-centre (DE, BBPSO). La ligne zero (zeroline) separe les deux regimes.\n",
     "{\n",
-    "    double mean = g.Average(x => x.R.Delta);\n",
-    "    int barLen = maxMean <= 0 ? 0 : Math.Min(40, (int)Math.Round(40 * Math.Max(0, mean) / maxMean));\n",
-    "    Console.WriteLine(\"  \" + g.Key.PadRight(16) + \" |\" + new string('#', barLen).PadRight(40) + \"| delta_moyen = \" + mean.ToString(\"F3\"));\n",
+    "    var ordered = byOpt.OrderByDescending(g => g.Average(x => x.R.Delta)).ToList();\n",
+    "    var names = ordered.Select(g => g.Key).Select(v => (object)v).ToArray();\n",
+    "    var means = ordered.Select(g => (object)Math.Round(g.Average(x => x.R.Delta), 3)).ToArray();\n",
+    "    var colors = ordered.Select(g => g.Average(x => x.R.Delta) >= 0 ? (object)\"#2a6dba\" : (object)\"#e8743b\").ToArray();\n",
+    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var trace = System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> { [\"y\"] = names, [\"x\"] = means, [\"type\"] = \"bar\", [\"orientation\"] = \"h\",\n",
+    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = colors },\n",
+    "                                         [\"text\"] = means, [\"textposition\"] = \"auto\" });\n",
+    "    var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Signature de biais moyenne par optimiseur (delta > 0 = centre, < 0 = anti-centre)\\\"},\" +\n",
+    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Delta moyen (objectif deplace - objectif centre)\\\"},\" +\n",
+    "                 \"\\\"zeroline\\\":true,\\\"zerolinewidth\\\":2,\\\"zerolinecolor\\\":\\\"#444\\\"},\" +\n",
+    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Optimiseur\\\"}},\" +\n",
+    "                 \"\\\"margin\\\":{\\\"l\\\":120,\\\"r\\\":40}}\";\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + trace + \"],\" + layout + \")</script>\";\n",
+    "    display(new PlotlyHtml(markup));\n",
     "}\n"
    ]
   },


### PR DESCRIPTION
## SOTA Prong-A — `MGS-10-CenterBias` ASCII bias bar -> real Plotly signed h-bar (env unlocked via Rule-F)

`See #3801` (SOTA axe-2 EPIC). A Prong-A degraded-visualization fix in the .NET metaheuristic center-bias notebook.

### Defect (cell[8])
Cell[8] shows the mean center-bias **delta** per optimizer with an **ASCII bar** `new string('#', barLen)` where `barLen = Math.Round(40 * Math.Max(0, mean) / maxMean)`. The `Math.Max(0, mean)` **masks anti-center bias** — every negative-delta optimizer renders as an empty bar, hiding half the signal.

### Fix — real Plotly SIGNED horizontal bar chart (C548-L2 zero-restore)
- **cell[8]**: a **signed horizontal bar chart** (`orientation=h`, color split: blue `>=0` center-bias / orange `<0` anti-center) with a **zero-line** (`zeroline`) separating the two regimes. Both directions of bias are now **visible**: center-bias (WOA `4.984`, Random `2.753`, SA `1.659`) **and** anti-center (DE `-2.147`, BBPSO `-1.658`, GA `-0.123`), which the ASCII `Max(0,…)` had erased.

The **text table** (Optimiseur × Function × moyenne) and the Kudela-2022 protocol framing are **preserved**. Uses the **C548-L2 zero-restore technique** (`record PlotlyHtml` + `Formatter.Register` + raw Plotly.js, no NuGet charting) defined inline in cell[8].

### SOTA verdict: SOTA-OK (real Plotly figure committed)
The committed output (display_data, text/html, `Plotly.newPlot`) is a real Plotly signed bar chart, not a workaround.

### Environment — Rule-F repair (env unlocked LOCALLY)
MGS-10 cell[1] `#r`-references Debug DLLs from the external **MetaGeneticSharp** fork at `c:/dev/MetaGeneticSharp/`, which were absent on this machine (previously logged as RECOVERABLE-MACHINE). Per the "repair, never bypass" rule, the fork was **cloned + built** (`git clone` + `git submodule update --init GeneticSharp` + `dotnet build MetaGeneticSharp.sln -c Debug` → **0 errors**, net9.0). The notebook now re-executes locally — verdict upgraded **RECOVERABLE-MACHINE → RECOVERABLE-LOCAL** (proven executable on this machine).

### Validation (real execution)
- **Full re-exec** via `papermill --kernel .net-csharp`: **19/19 cells, 0 errors** (~57 s). MetaGeneticSharp benchmark runs to completion (8 optimizers × 3 functions × shifted/centered).
- cell[8] renders its Plotly signed figure (exec 5); the delta table is preserved.
- `grep` confirms **0 `new string('#'` data-bar patterns remain**; 1 `Plotly.newPlot` figure present in the committed blob.
- **Surgical splice**: only cell[8] changed (+39/−86); every other cell byte-identical to origin/main (19=19 cells, structural-integrity check). JSON valid, **CRLF = 0**. Catalogue **byte-identical to main**.

### Scope hygiene
- Catalogue **byte-identical to main** (no `COURSE_CATALOG.generated.*` touched).
- One subject (center-bias ASCII bar -> Plotly signed h-bar in MGS-10), one file, atomic. Base fresh off `origin/main` (`0 behind / 1 ahead`).
- FR-first comments. MetaGeneticSharp build is a machine-local dev dependency at `c:/dev/` (not in repo), matching the notebook's existing `#r` contract.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
