### PR TITLE
fix(decinfer,#3801): DecInfer-6 VoI ASCII bars -> Plotly (Prong-A, 3 cells)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
@@ -2446,25 +2446,13 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Prior:          [###############...................................] 30 %\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Posterior T+:   [################################..................] 66 %  -> FORER\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Posterior T-:   [##................................................] 5 %  -> VENDRE\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plt3ffeb66eda1040068caca873f86e81ba\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt3ffeb66eda1040068caca873f86e81ba',[{\"x\":[\"Prior\",\"Posterior T\\u002B (FORER)\",\"Posterior T- (VENDRE)\"],\"y\":[0.3,0.6585365853658536,0.05084745762711864],\"type\":\"bar\",\"marker\":{\"color\":[\"#9aa0a6\",\"#2a6dba\",\"#e8743b\"]},\"text\":[\"30 %\",\"66 %\",\"5 %\"],\"textposition\":\"auto\"}],{\"title\":{\"text\":\"Impact du test sismique : P(petrole) prior vs posteriors\"},\"yaxis\":{\"title\":{\"text\":\"P(petrole)\"},\"range\":[0,1],\"tickformat\":\".0%\"},\"xaxis\":{\"title\":{\"text\":\"Croyance\"}},\"margin\":{\"l\":50,\"r\":30,\"b\":60}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -2541,9 +2529,26 @@
     "// Resume visuel\n",
     "Console.WriteLine(\"=== Visualisation de l'Impact de l'Information ===\");\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine($\"Prior:          [{new string('#', (int)(p_prior * 50))}{new string('.', 50 - (int)(p_prior * 50))}] {p_prior:P0}\");\n",
-    "Console.WriteLine($\"Posterior T+:   [{new string('#', (int)(p_pos * 50))}{new string('.', 50 - (int)(p_pos * 50))}] {p_pos:P0}  -> FORER\");\n",
-    "Console.WriteLine($\"Posterior T-:   [{new string('#', (int)(p_neg * 50))}{new string('.', 50 - (int)(p_neg * 50))}] {p_neg:P0}  -> VENDRE\");\n",
+    "{\n",
+    "    var labs = new object[] { \"Prior\", \"Posterior T+ (FORER)\", \"Posterior T- (VENDRE)\" };\n",
+    "    var probs = new object[] { p_prior, p_pos, p_neg };\n",
+    "    var colors = new object[] { \"#9aa0a6\", \"#2a6dba\", \"#e8743b\" };\n",
+    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var trace = System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> { [\"x\"] = labs, [\"y\"] = probs, [\"type\"] = \"bar\",\n",
+    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = colors },\n",
+    "                                         [\"text\"] = probs.Select(v => ((double)v).ToString(\"P0\")).ToArray(),\n",
+    "                                         [\"textposition\"] = \"auto\" });\n",
+    "    var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Impact du test sismique : P(petrole) prior vs posteriors\\\"},\" +\n",
+    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"P(petrole)\\\"},\\\"range\\\":[0,1],\\\"tickformat\\\":\\\".0%\\\"},\" +\n",
+    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Croyance\\\"}},\" +\n",
+    "                 \"\\\"margin\\\":{\\\"l\\\":50,\\\"r\\\":30,\\\"b\\\":60}}\";\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + trace + \"],\" + layout + \")</script>\";\n",
+    "    display(new PlotlyHtml(markup));\n",
+    "}\n",
+    "\n",
     "Console.WriteLine();\n",
     "Console.WriteLine(\"=> Le test change la decision : c'est pourquoi il a de la valeur !\");"
    ]
@@ -3529,28 +3534,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                 EVSI (brute)                      Cout\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                 ----------------------------------------  ----------------------------------------\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Test Rapide      [###################................] 155  [$$$................................] 50\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "IRM              [###################################] 273  [$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$] 500\r\n"
+      "                 EVSI brute / Cout / EVSI nette (EUR) - voir chart ci-dessous\r\n"
      ]
     },
     {
@@ -3561,32 +3545,29 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                 EVSI Nette                        Efficacite\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plt28231e4629914813881f156778b5c478\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt28231e4629914813881f156778b5c478',[{\"x\":[\"Test Rapide\",\"IRM\"],\"y\":[155,273],\"type\":\"bar\",\"name\":\"EVSI brute\",\"marker\":{\"color\":\"#2a6dba\"}},{\"x\":[\"Test Rapide\",\"IRM\"],\"y\":[50,500],\"type\":\"bar\",\"name\":\"Cout\",\"marker\":{\"color\":\"#9aa0a6\"}},{\"x\":[\"Test Rapide\",\"IRM\"],\"y\":[105,-227],\"type\":\"bar\",\"name\":\"EVSI nette\",\"marker\":{\"color\":\"#e8743b\"}}],{\"barmode\":\"group\",\"title\":{\"text\":\"Comparaison des tests medicaux : EVSI brute, cout, EVSI nette\"},\"yaxis\":{\"title\":{\"text\":\"EUR\"}},\"margin\":{\"l\":60,\"r\":30,\"b\":50}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "                 ----------------------------------------  ----------------------------------------\r\n"
+      "\r\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Test Rapide      [.................+++++++..........] +105  [===============....................] 44 %\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "IRM              [-----------------.................] -227  [==========================.........] 77 %\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plt24ea4895c8554175be2ee7dacf94c0d4\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt24ea4895c8554175be2ee7dacf94c0d4',[{\"x\":[\"Test Rapide\",\"IRM\"],\"y\":[43.7,76.8],\"type\":\"bar\",\"marker\":{\"color\":\"#2a6dba\"},\"text\":[43.7,76.8],\"textposition\":\"auto\"}],{\"title\":{\"text\":\"Efficacite (EVSI/EVPI) : proportion de l'info parfaite capturee (%)\"},\"yaxis\":{\"title\":{\"text\":\"Efficacite (%)\"},\"range\":[0,100]},\"margin\":{\"l\":50,\"r\":30,\"b\":50}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -3669,40 +3650,43 @@
     "double maxCout = Math.Max(coutT1, coutT2);\n",
     "int barLen = 35;\n",
     "\n",
-    "Console.WriteLine(\"                 EVSI (brute)                      Cout\");\n",
-    "Console.WriteLine(\"                 \" + new string('-', barLen + 5) + \"  \" + new string('-', barLen + 5));\n",
-    "\n",
-    "foreach (var (nom, evsi, cout, evsiNet, eff) in testsData)\n",
-    "{\n",
-    "    int evsiBar = (int)((evsi / maxEVSI) * barLen);\n",
-    "    int coutBar = (int)((cout / maxCout) * barLen);\n",
-    "    \n",
-    "    string evsiLine = $\"[{new string('#', evsiBar)}{new string('.', barLen - evsiBar)}] {evsi:F0}\";\n",
-    "    string coutLine = $\"[{new string('$', coutBar)}{new string('.', barLen - coutBar)}] {cout:F0}\";\n",
-    "    \n",
-    "    Console.WriteLine($\"{nom,-12}     {evsiLine}  {coutLine}\");\n",
-    "}\n",
-    "\n",
+    "Console.WriteLine(\"                 EVSI brute / Cout / EVSI nette (EUR) - voir chart ci-dessous\");\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine(\"                 EVSI Nette                        Efficacite\");\n",
-    "Console.WriteLine(\"                 \" + new string('-', barLen + 5) + \"  \" + new string('-', barLen + 5));\n",
-    "\n",
-    "double maxNet = Math.Max(Math.Abs(EVSI_net_T1), Math.Abs(EVSI_net_T2));\n",
-    "foreach (var (nom, evsi, cout, evsiNet, eff) in testsData)\n",
     "{\n",
-    "    // Pour EVSI nette, montrer positif/negatif\n",
-    "    string netSign = evsiNet >= 0 ? \"+\" : \"-\";\n",
-    "    int netBar = (int)((Math.Abs(evsiNet) / maxNet) * (barLen / 2));\n",
-    "    string netLine;\n",
-    "    if (evsiNet >= 0)\n",
-    "        netLine = $\"[{new string('.', barLen/2)}{new string('+', netBar)}{new string('.', barLen/2 - netBar)}] {netSign}{Math.Abs(evsiNet):F0}\";\n",
-    "    else\n",
-    "        netLine = $\"[{new string('.', barLen/2 - netBar)}{new string('-', netBar)}{new string('.', barLen/2)}] {netSign}{Math.Abs(evsiNet):F0}\";\n",
-    "    \n",
-    "    int effBar = (int)(eff * barLen);\n",
-    "    string effLine = $\"[{new string('=', effBar)}{new string('.', barLen - effBar)}] {eff:P0}\";\n",
-    "    \n",
-    "    Console.WriteLine($\"{nom,-12}     {netLine}  {effLine}\");\n",
+    "    var names = testsData.Select(t => (object)t.Item1).ToArray();\n",
+    "    var evsiBrute = testsData.Select(t => (object)Math.Round(t.Item2,0)).ToArray();\n",
+    "    var couts = testsData.Select(t => (object)Math.Round(t.Item3,0)).ToArray();\n",
+    "    var evsiNet = testsData.Select(t => (object)Math.Round(t.Item4,0)).ToArray();\n",
+    "    string tr(string n, object[] y, string c) => System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> { [\"x\"] = names, [\"y\"] = y, [\"type\"] = \"bar\", [\"name\"] = n,\n",
+    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = c } });\n",
+    "    var tEvsi = tr(\"EVSI brute\", evsiBrute, \"#2a6dba\");\n",
+    "    var tCout = tr(\"Cout\", couts, \"#9aa0a6\");\n",
+    "    var tNet = tr(\"EVSI nette\", evsiNet, \"#e8743b\");\n",
+    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var layout = \"{\\\"barmode\\\":\\\"group\\\",\\\"title\\\":{\\\"text\\\":\\\"Comparaison des tests medicaux : EVSI brute, cout, EVSI nette\\\"},\" +\n",
+    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"EUR\\\"}},\\\"margin\\\":{\\\"l\\\":60,\\\"r\\\":30,\\\"b\\\":50}}\";\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + tEvsi + \",\" + tCout + \",\" + tNet + \"],\" + layout + \")</script>\";\n",
+    "    display(new PlotlyHtml(markup));\n",
+    "}\n",
+    "Console.WriteLine();\n",
+    "{\n",
+    "    var names = testsData.Select(t => (object)t.Item1).ToArray();\n",
+    "    var effs = testsData.Select(t => (object)Math.Round(t.Item5*100,1)).ToArray();\n",
+    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var trace = System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> { [\"x\"] = names, [\"y\"] = effs, [\"type\"] = \"bar\",\n",
+    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = \"#2a6dba\" },\n",
+    "                                         [\"text\"] = effs, [\"textposition\"] = \"auto\" });\n",
+    "    var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Efficacite (EVSI/EVPI) : proportion de l'info parfaite capturee (%)\\\"},\" +\n",
+    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Efficacite (%)\\\"},\\\"range\\\":[0,100]},\" +\n",
+    "                 \"\\\"margin\\\":{\\\"l\\\":50,\\\"r\\\":30,\\\"b\\\":50}}\";\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + trace + \"],\" + layout + \")</script>\";\n",
+    "    display(new PlotlyHtml(markup));\n",
     "}\n",
     "\n",
     "Console.WriteLine();\n",
@@ -3999,67 +3983,13 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Efficacite des tests (EVSI/EVPI) :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Oracle meteo   [########################################] 100% [OK]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Test sismique  [##########################..............] 65% [OK]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Detecteur      [###############.........................] 39% [OK]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Test rapide    [#################.......................] 44% [OK]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  IRM            [##############################..........] 77% [--]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Test 95/90     [........................................] 0% [--]\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div id=\"plta4b9eadc625d4b50b85be940d010bd4f\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plta4b9eadc625d4b50b85be940d010bd4f',[{\"y\":[\"Oracle meteo\",\"Test sismique\",\"Detecteur\",\"Test rapide\",\"IRM\",\"Test 95/90\"],\"x\":[100,65,39,44,77,0],\"type\":\"bar\",\"orientation\":\"h\",\"marker\":{\"color\":[\"#2a6dba\",\"#2a6dba\",\"#2a6dba\",\"#2a6dba\",\"#e8743b\",\"#e8743b\"]},\"text\":[100,65,39,44,77,0],\"textposition\":\"auto\"}],{\"title\":{\"text\":\"Efficacite des tests (EVSI/EVPI) - bleu = rentable, orange = non rentable\"},\"xaxis\":{\"title\":{\"text\":\"Efficacite (%)\"},\"range\":[0,100]},\"yaxis\":{\"title\":{\"text\":\"Test\"}},\"margin\":{\"l\":120,\"r\":40}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -4106,19 +4036,23 @@
     "Console.WriteLine();\n",
     "\n",
     "// Visualisation en barres de l'efficacite\n",
-    "Console.WriteLine(\"Efficacite des tests (EVSI/EVPI) :\");\n",
-    "Console.WriteLine();\n",
-    "\n",
-    "int barWidth = 40;\n",
-    "foreach (var (exemple, test, evpi, evsi, eff, rentable, unite) in exemples)\n",
     "{\n",
-    "    int effBar = (int)((eff / 100.0) * barWidth);\n",
-    "    string bar = new string('#', effBar) + new string('.', barWidth - effBar);\n",
-    "    string marker = rentable.StartsWith(\"Oui\") ? \" [OK]\" : \" [--]\";\n",
-    "    Console.WriteLine($\"  {test,-14} [{bar}] {eff:F0}%{marker}\");\n",
+    "    var labels = exemples.Select(e => (object)e.Item2).ToArray();\n",
+    "    var effs = exemples.Select(e => (object)Math.Round(e.Item5,1)).ToArray();\n",
+    "    var colors = exemples.Select(e => e.Item6.StartsWith(\"Oui\") ? (object)\"#2a6dba\" : (object)\"#e8743b\").ToArray();\n",
+    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var trace = System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> { [\"y\"] = labels, [\"x\"] = effs, [\"type\"] = \"bar\", [\"orientation\"] = \"h\",\n",
+    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = colors },\n",
+    "                                         [\"text\"] = effs, [\"textposition\"] = \"auto\" });\n",
+    "    var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Efficacite des tests (EVSI/EVPI) - bleu = rentable, orange = non rentable\\\"},\" +\n",
+    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Efficacite (%)\\\"},\\\"range\\\":[0,100]},\" +\n",
+    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Test\\\"}},\\\"margin\\\":{\\\"l\\\":120,\\\"r\\\":40}}\";\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + trace + \"],\" + layout + \")</script>\";\n",
+    "    display(new PlotlyHtml(markup));\n",
     "}\n",
-    "\n",
-    "Console.WriteLine();\n",
     "Console.WriteLine(\"  Legende : # = efficacite, [OK] = rentable, [--] = non rentable\");"
    ]
   },


### PR DESCRIPTION
## SOTA Prong-A — `DecInfer-6-Value-Information` ASCII bars (3 cells) -> real Plotly figures

`See #3801` (SOTA axe-2 EPIC). A Prong-A degraded-visualization fix in the .NET value-of-information (EVSI) notebook. **Three cells** converted — one coherent subject (the value-of-information visualizations across the notebook).

### Defect (cells 35, 45, 49)
The notebook's three VoI visualizations were ASCII `[###...]` / `[$$$...]` bars:
- **cell[35]** — prior/posterior **belief bars** `[new string('#',(int)(p*50))...]` after Bayesian inference.
- **cell[45]** — medical-test **EVSI/cost comparison** ASCII bars (`#`=EVSI, `$`=cost, `+/-`=net EVSI, `=`=efficiency).
- **cell[49]** — recapitulative **efficiency bars** `[new string('#', effBar)...]` across 6 examples with `[OK]`/`[--]` markers.

ASCII bars are a degraded visualization of the EVSI story (the notebook's core point) that Plotly renders properly.

### Fix — real Plotly figures (reusing existing C548 infra)
- **cell[35]**: Plotly bar of {Prior 30 %, Posterior T+ 66 %, Posterior T- 5 %}, colored by decision (gray/blue/orange) — the impact of the seismic test is **visible**.
- **cell[45]**: two Plotly charts — a **grouped bar** (EVSI brute / Cost / EVSI nette per test) and an **efficiency bar** — replacing 4 ASCII series. Shows why Test Rapide (44 % eff) beats IRM (77 % eff) on net value despite lower efficiency.
- **cell[49]**: Plotly **horizontal bar** of efficiency across 6 examples, colored blue (rentable) / orange (non-rentable).

All three **reuse the `PlotlyHtml`/`Formatter.Register` C548-L2 infra already defined in cell[29]** (no infra duplication). The **decision text**, **inference logic**, **observation bullets**, and **summary tables** are all preserved. The Infer.NET inference cells are byte-identical.

### SOTA verdict: SOTA-OK (real Plotly figures committed)
All three committed outputs (display_data, text/html, `Plotly.newPlot`) are real Plotly figures, not workarounds.

### Environment — Rule-F repair
DecInfer-6 cell[2] `#load "FactorGraphHelper.cs"` requires the helper (which lives in the sibling `Probas/Infer/` dir) in the CWD. Re-executed with `papermill --cwd MyIA.AI.Notebooks/Probas/Infer` (same `--cwd` pattern as the Tweety env lesson) — the helper loads and Infer.NET inference runs locally. No bypass.

### Validation (real execution)
- **Full re-exec** via `papermill --kernel .net-csharp --cwd Probas/Infer`: **55/55 cells, 0 errors** (~2 min 17 s). Infer.NET belief inference + EVSI computations run to completion.
- cells 35/45/49 render 4 Plotly figures total (exec 13/16/18); all decision text + tables preserved.
- `grep` confirms **0 `new string('#'` and 0 `new string('$'`** data-bar patterns remain; the committed blob has the 4 new `Plotly.newPlot` figures.
- **Surgical splice**: only cells 35/45/49 changed (+99/−165); every other cell byte-identical to origin/main (55=55 cells, structural-integrity check). JSON valid, **CRLF = 0**. Catalogue **byte-identical to main**.

### Scope hygiene
- Catalogue **byte-identical to main** (no `COURSE_CATALOG.generated.*` touched).
- One subject (VoI ASCII bars -> Plotly in DecInfer-6), one file, 3 cells, atomic. Base fresh off `origin/main`.
- FR-first comments. Reuses existing C548 infra (no new dependency).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
