### PR TITLE
i18n(lean,#4980): strip base EN block from CollatzLike.lean (FR-canonical tidy)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/CollatzLike.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/CollatzLike.lean
@@ -1,26 +1,4 @@
 /-
-Conway hommage — Collatz-like functions and undecidability
-John Horton Conway (1937-2020).
-
-Conway's 1972 paper "Unpredictable Iterations" proved that a natural
-generalization of the Collatz conjecture is undecidable. He showed that
-there exists a "Collatz-like" function (a piecewise-linear map on the
-integers with finitely many cases) whose eventual behavior (does every
-trajectory reach a particular set?) is algorithmically undecidable.
-
-This module formalizes the **accessible** parts of this result:
-1. The definition of a Collatz-like function (piecewise-linear iteration)
-2. Concrete examples with proven termination properties
-3. The connection between FRACTRAN and Collatz-like functions
-
-This is NOT the full undecidability proof (which requires arithmetization
-of Turing machines), but the computational core that motivates it.
-
-No `sorry` in this module — all results are proved via `native_decide`
-or direct computation.
--/
-
-/-
   `Conway.CollatzLike` — Fonctions de type Collatz et indécidabilité
   ===================================================================
   Hommage à Conway — Formalisation des fonctions « Collatz-like »
@@ -51,23 +29,15 @@ or direct computation.
   Aucun `sorry` dans ce module — tous les résultats sont prouvés via
   `native_decide` ou calcul direct.
 
-  ### i18n — convention #4980 ratifiée 2026-07-04
+  ### i18n — convention #4980 (sibling pair, decision 2026-07-04)
 
-  Ce sous-module suit l'option A (bilingue inline FR/EN), variante
-  pragmatique c.376-c.384 (deux blocs `/` top-level distincts, sans
-  `---` interne) : le bloc EN existant est préservé verbatim
-  ci-dessus, le bloc FR miroir est ajouté juste après sans séparateur
-  `---`. Convention sibling pair (`<Foo>_en.lean` à part) réservée aux
-  modules de substance (cf c.374 `Astar_en.lean`) ; pour les modules
-  de calibration/theorem comme `CollatzLike`, l'inline FR+EN est le bon
-  compromis (densité theorem élevée, deux langues côte à côte). Les
-  énoncés de théorèmes, les noms de lemmes, les tactiques Lean
-  (`:= by native_decide`, `simp`, `decide`, etc.) et les références
-  Mathlib restent en anglais (Mathlib 4, tactic DSL standard). Seules
-  les **docstrings `/-- ... -/`** et les **commentaires `-- ...`**
-  bilingues sont ajoutées. Anti-§D byte-identity garanti : le namespace
-  body est préservé bit-pour-bit (5992 chars extractibles byte-identique
-  via script Python `extract_ns_body`).
+  Ce fichier est **FR canonique**. Son miroir anglais vit dans le sibling
+  `CollatzLike_en.lean` (modèle sibling pair ratifié 2026-07-04, cf
+  `code-style.md` §Lean i18n, analogue `Angel.lean` / `Angel_en.lean`).
+  Les énoncés de théorèmes, les tactiques Lean, les noms de lemmes et les
+  références Mathlib restent en anglais (Mathlib 4) ; seules les docstrings
+  et les commentaires diffèrent entre les deux fichiers. Anti-§D
+  byte-identity garanti : le namespace body est préservé bit-pour-bit.
 
   ### c.385 — continuité conway_lean Phase 1+ satellites (post-c.384)
 


### PR DESCRIPTION
## CollatzLike.lean — strip base EN block (FR-canonical tidy, follow-up to #6663)

Follow-up to **#6663** (`CollatzLike_en` sibling, extract-only). The base `CollatzLike.lean` was **redundantly bilingual-inline**: it still carried the EN module docstring block while the EN mirror already lived in the sibling `CollatzLike_en.lean`. Its own FR block even documented *"inline FR+EN is the good compromise … the EN block is preserved verbatim above"* — **self-contradictory** once the sibling existed.

This is the explicit follow-up tidy flagged by ai-01 (dispatch 2026-07-15T09:40Z): *"CollatzLike_en #6663 = extract-only → strip base EN block en follow-up tidy séparé."*

## Fix (migration completion, not a convention flip)

1. **Strip the EN module-docstring block** from the base → base becomes **FR-canonical**, matching the ratified sibling-pair model (`Angel.lean` / `Angel_en.lean`).
2. **EN prose preserved verbatim** in `CollatzLike_en.lean` (no loss — verified firsthand: "Unpredictable Iterations", "algorithmically undecidable", "native_decide", "arithmetization", "Turing machines" all present in sibling).
3. **Updated the now-stale inline-convention paragraph** (it claimed "inline FR+EN is the good compromise … EN block preserved verbatim above") to a concise FR-canonical note referencing the sibling.

## Verification

| Check | Result |
|---|---|
| **Namespace body byte-identical** vs `origin/main` | ✅ 6021 chars, **0 differing lines** — comment/docstring-only change |
| sorry-tactics | ✅ **0 → 0** (the 2→1 grep delta was prose "No `sorry` in this module" in the stripped EN docstring) |
| Structure intact | ✅ `/-` opener, `import Conway.Fractran`, `namespace Conway`/`end Conway` present |
| Diff size | 9 insertions / 39 deletions (1 file) |
| Local `lake build` | ⚠️ cold (mathlib clone `fetch-pack` transient network fail, not a code issue); **comment-class change → Lean CI validates** per lean-merge-discipline / dashboard lesson "Lean CI validates comment-class ~3min". Namespace body byte-identical ⇒ mechanically cannot compile differently. |

No new file, no lakefile/glob change (orthogonal to #6678). My own property (author of #6663).

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
