### PR TITLE
fix(decinfer,#3801): DecInfer-8 sequential belief ASCII bar -> Plotly evolution (Prong-A)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
@@ -3886,21 +3886,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Bon       ) = 95,9 % ############################\r\n"
+      "  P(Bon       ) = 95,9 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Degrade   ) = 3,9 % #\r\n"
+      "  P(Degrade   ) = 3,9 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Defaillant) = 0,2 % \r\n"
+      "  P(Defaillant) = 0,2 %\r\n"
      ]
     },
     {
@@ -4012,21 +4012,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Bon       ) = 29,6 % ########\r\n"
+      "  P(Bon       ) = 29,6 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Degrade   ) = 52,7 % ###############\r\n"
+      "  P(Degrade   ) = 52,7 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Defaillant) = 17,7 % #####\r\n"
+      "  P(Defaillant) = 17,7 %\r\n"
      ]
     },
     {
@@ -4138,21 +4138,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Bon       ) = 2,2 % \r\n"
+      "  P(Bon       ) = 2,2 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Degrade   ) = 55,8 % ################\r\n"
+      "  P(Degrade   ) = 55,8 %\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  P(Defaillant) = 42,0 % ############\r\n"
+      "  P(Defaillant) = 42,0 %\r\n"
      ]
     },
     {
@@ -4198,6 +4198,15 @@
      ]
     },
     {
+     "data": {
+      "text/html": [
+       "<div id=\"pltcf4a3ac128b84f66863cecac3b4ff904\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltcf4a3ac128b84f66863cecac3b4ff904',[{\"x\":[\"Prior\",\"t=1 (Normal)\",\"t=2 (Anormal)\",\"t=3 (Anormal)\"],\"y\":[0.95,0.959,0.296,0.022],\"type\":\"bar\",\"name\":\"Bon\",\"marker\":{\"color\":\"#2a6dba\"}},{\"x\":[\"Prior\",\"t=1 (Normal)\",\"t=2 (Anormal)\",\"t=3 (Anormal)\"],\"y\":[0.04,0.039,0.527,0.558],\"type\":\"bar\",\"name\":\"Degrade\",\"marker\":{\"color\":\"#e8743b\"}},{\"x\":[\"Prior\",\"t=1 (Normal)\",\"t=2 (Anormal)\",\"t=3 (Anormal)\"],\"y\":[0.01,0.002,0.177,0.42],\"type\":\"bar\",\"name\":\"Defaillant\",\"marker\":{\"color\":\"#c5392f\"}}],{\"barmode\":\"group\",\"title\":{\"text\":\"Evolution des croyances (maintenance predictive) : le belief bascule avec les anomalies\"},\"xaxis\":{\"title\":{\"text\":\"Pas de temps (observation)\"}},\"yaxis\":{\"title\":{\"text\":\"Probabilite de l etat\"},\"range\":[0,1],\"tickformat\":\".0%\"},\"margin\":{\"l\":50,\"r\":30,\"b\":70}})</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -4231,6 +4240,15 @@
     "// Belief State Updates avec Infer.NET : Maintenance Predictive\n",
     "\n",
     "using Microsoft.ML.Probabilistic.Math;\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "using System.Collections.Generic;\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
+    "// Historique des croyances pour la visualisation (Prior + chaque pas de temps)\n",
+    "var beliefHist = new List<(string Label, double[] Probs)>();\n",
     "\n",
     "Console.WriteLine(\"=== Belief State Updates avec Infer.NET ===\\n\");\n",
     "Console.WriteLine(\"Scenario : Maintenance predictive d'un systeme\\n\");\n",
@@ -4275,6 +4293,7 @@
     "Console.WriteLine(\"Belief initial :\");\n",
     "for (int e = 0; e < nEtats; e++)\n",
     "    Console.WriteLine($\"  P({etatsNom[e]}) = {belief[e]:P1}\");\n",
+    "beliefHist.Add((\"Prior\", belief.ToArray()));\n",
     "Console.WriteLine();\n",
     "\n",
     "// Boucle de mise a jour\n",
@@ -4322,11 +4341,13 @@
     "    \n",
     "    Console.WriteLine($\"Observation : {(obs == 0 ? \"Normal\" : \"Anormal\")}\");\n",
     "    Console.WriteLine(\"Apres correction (Bayes via Infer.NET) :\");\n",
+    "    double[] probsArr = new double[nEtats];\n",
     "    for (int e = 0; e < nEtats; e++)\n",
     "    {\n",
-    "        string bar = new string('#', (int)(probs[e] * 30));\n",
-    "        Console.WriteLine($\"  P({etatsNom[e],-10}) = {probs[e]:P1} {bar}\");\n",
+    "        probsArr[e] = probs[e];\n",
+    "        Console.WriteLine($\"  P({etatsNom[e],-10}) = {probs[e]:P1}\");\n",
     "    }\n",
+    "    beliefHist.Add(($\"t={t + 1} ({(obs == 0 ? \"Normal\" : \"Anormal\")})\", probsArr));\n",
     "    \n",
     "    // 3. Decision basee sur le belief\n",
     "    double[] EU = new double[3];\n",
@@ -4348,6 +4369,29 @@
     "    // Note: GetProbs() retourne un Vector, on copie manuellement\n",
     "    for (int e = 0; e < nEtats; e++)\n",
     "        belief[e] = probs[e];\n",
+    "}\n",
+    "\n",
+    "// Visualisation Plotly : evolution des croyances (Prior + chaque pas de temps).\n",
+    "// Les observations \"Anormal\" successives font chuter P(Bon) et monter P(Defaillant)\n",
+    "// -- la decision bascule de Continuer vers Maintenance puis Remplacer.\n",
+    "{\n",
+    "    var labels = beliefHist.Select(b => (object)b.Label).ToArray();\n",
+    "    string tr(string name, int ei, string color) => System.Text.Json.JsonSerializer.Serialize(\n",
+    "        new Dictionary<string, object> { [\"x\"] = labels, [\"y\"] = beliefHist.Select(b => (object)Math.Round(b.Probs[ei],3)).ToArray(),\n",
+    "                                         [\"type\"] = \"bar\", [\"name\"] = name,\n",
+    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = color } });\n",
+    "    var tBon = tr(\"Bon\", 0, \"#2a6dba\");\n",
+    "    var tDeg = tr(\"Degrade\", 1, \"#e8743b\");\n",
+    "    var tDef = tr(\"Defaillant\", 2, \"#c5392f\");\n",
+    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
+    "    var layout = \"{\\\"barmode\\\":\\\"group\\\",\\\"title\\\":{\\\"text\\\":\\\"Evolution des croyances (maintenance predictive) : le belief bascule avec les anomalies\\\"},\" +\n",
+    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Pas de temps (observation)\\\"}},\" +\n",
+    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Probabilite de l etat\\\"},\\\"range\\\":[0,1],\\\"tickformat\\\":\\\".0%\\\"},\" +\n",
+    "                 \"\\\"margin\\\":{\\\"l\\\":50,\\\"r\\\":30,\\\"b\\\":70}}\";\n",
+    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
+    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + tBon + \",\" + tDeg + \",\" + tDef + \"],\" + layout + \")</script>\";\n",
+    "    display(new PlotlyHtml(markup));\n",
     "}\n",
     "\n",
     "Console.WriteLine(\"=== Resume ===\");\n",


### PR DESCRIPTION
## SOTA Prong-A — `DecInfer-8-Sequential` ASCII belief bar -> real Plotly grouped evolution chart

`See #3801` (SOTA axe-2 EPIC). A Prong-A degraded-visualization fix in the .NET sequential-decision (predictive maintenance) notebook. This completes the Probas/DecisionTheory Prong-A sweep.

### Defect (cell[49])
Cell[49] runs the **Infer.NET sequential belief update** (predictive maintenance: Bon → Dégradé → Défaillant over 3 time-steps with a vibration sensor). At each time-step it printed the posterior with an **ASCII bar** `new string('#', (int)(probs[e] * 30))` per state. The belief *evolution* across time-steps — the whole pedagogical point — was invisible (each step's bars printed separately, no comparison).

### Fix — real Plotly grouped EVOLUTION chart (C548-L2 zero-restore)
- **cell[49]**: the posterior at each step is now collected into a history, and after the loop a **grouped bar chart** renders the **belief evolution** across `Prior → t1 (Normal) → t2 (Anormal) → t3 (Anormal)`, with **3 series** (Bon blue / Dégradé orange / Défaillant red). The collapse of P(Bon) and rise of P(Défaillant) as anomalies accumulate is now **visible** — the decision flip `Continuer → Maintenance → Remplacer` becomes visually obvious. (Touches Prong-B richness too: this exercises the sequential-inference engine, not a degenerate single-shot case.)

All **Infer.NET inference** (transition/observation model, `Variable.Case`, `InferenceEngine`), the **per-step decision text**, **expected utilities**, and the **summary** are **preserved byte-for-byte** — only the ASCII bar lines were replaced. C548-L2 infra (`record PlotlyHtml` + `Formatter.Register` + raw Plotly.js, no NuGet charting) is defined inline in cell[49].

### SOTA verdict: SOTA-OK (real Plotly figure committed)
The committed output (display_data, text/html, `Plotly.newPlot`) is a real Plotly grouped evolution chart, not a workaround.

### Environment — Rule-F (re-exec via `--cwd`)
DecInfer-8 cell[2] `#load "FactorGraphHelper.cs"` (helper in sibling `Probas/Infer/` dir) needs that dir in CWD. Re-executed with `papermill --cwd MyIA.AI.Notebooks/Probas/Infer` (same proven pattern as DecInfer-6 #6694). No bypass.

### Validation (real execution)
- **Full re-exec** via `papermill --kernel .net-csharp --cwd Probas/Infer`: **55/55 cells, 0 errors** (~1 min). Infer.NET sequential belief inference runs to completion.
- cell[49] renders its Plotly evolution figure (exec 13); all decision text + EUs + summary preserved (verified: "Belief initial", "Pas de temps", "Decision :", "Continuer/Maintenance/Remplacer", "Resume" all present).
- `grep` confirms **0 `new string('#'`** data-bar patterns remain; 1 `Plotly.newPlot` figure present in the committed blob.
- **Surgical splice**: only cell[49] changed (+55/−11); every other cell byte-identical to origin/main (55=55 cells, structural-integrity check). JSON valid, **CRLF = 0**. Catalogue **byte-identical to main**.

### Scope hygiene
- Catalogue **byte-identical to main** (no `COURSE_CATALOG.generated.*` touched).
- One subject (sequential-belief ASCII bar -> Plotly evolution in DecInfer-8), one file, atomic. Base fresh off `origin/main` (`0 behind / 1 ahead`).
- FR-first comments. Reuses the proven `.NET`-headless re-exec capability.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
