### PR TITLE
i18n(lean,#4980): strip base EN block from Fractran.lean (FR-canonical tidy)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Fractran.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Fractran.lean
@@ -1,19 +1,4 @@
 /-
-Conway's FRACTRAN — A Universal Machine
-John Horton Conway (1937-2020)
-
-FRACTRAN is arguably the simplest known universal computational model.
-A FRACTRAN program is a list of positive fractions. Given an input
-integer N, the machine finds the first fraction f such that N*f is
-an integer, replaces N with N*f, and repeats. Conway proved FRACTRAN
-is Turing-complete.
-
-Example — prime generation (Conway's 14-fraction program):
-  Starting from 2, the powers of 2 in the output are exactly 2^p
-  for each prime p: 2^2, 2^3, 2^5, 2^7, 2^11, ...
--/
-
-/-
   `Conway.Fractran` — FRACTRAN, une machine universelle
   ======================================================
   FRACTRAN est sans doute le modèle de calcul universel connu le plus
@@ -27,26 +12,14 @@ Example — prime generation (Conway's 14-fraction program):
     À partir de 2, les puissances de 2 dans la sortie sont exactement
     2^p pour chaque nombre premier p : 2^2, 2^3, 2^5, 2^7, 2^11, ...
 
-  ### i18n — convention #4980 ratifiée 2026-07-04
+  ### i18n — convention #4980 (ratifiée 2026-07-04)
 
-  Ce sous-module suit l'option A (bilingue inline FR/EN), variante pragmatique
-  c.379 (deux blocs `/` top-level distincts, sans `---` interne, analogue
-  c.376/c.377/c.378) : le bloc EN existant est préservé verbatim ci-dessus,
-  le bloc FR miroir est ajouté juste après sans séparateur `---`. Convention
-  sibling pair (`<Foo>_en.lean` à part) réservée aux modules de substance
-  (cf c.374 `Astar_en.lean`) ; pour les modules de formalisation comme
-  `Fractran`, l'inline FR+EN est le bon compromis (peu de code, deux langues
-  côte à côte).
-
-  Cross-références : c.366 `Conway.lean` racine bilingue (MERGED),
-  c.367 Grothendieck hommage (MERGED), c.373 `Knots.lean` racine bilingue,
-  c.374 `Astar.lean` sibling pair, c.375 `Knots` sub-modules bilingues,
-  c.376 `Knots/Invariant` bilingue 6/6 (saturation locale du lac `knot_lean`),
-  c.377 `Conway/MathlibMap` bilingue (premier sous-module rollout
-  `conway_lean`, PIVOT L335 strict), c.378 `Conway/LookAndSay` bilingue
-  (suite rollout `conway_lean` Phase 1+), **c.379 `Conway/Fractran`
-  bilingue (suite rollout `conway_lean` Phase 1+, machine universelle
-  Turing-complète)**.
+  Ce fichier est le **canonique français**. Le miroir anglais est le fichier
+  frère `Fractran_en.lean` (`namespace Conway_en`, `open Conway`) — modèle
+  sibling pair, cf `code-style.md` §Lean i18n et l'analogue `Angel.lean` /
+  `Angel_en.lean`. Docstrings en français ici ; le corps (signatures, defs,
+  `#eval`) reste byte-identique entre les deux fichiers. Pas de bloc bilingue
+  inline (option B rejetée).
 -/
 
 namespace Conway


### PR DESCRIPTION
## Objet

`conway_lean/Conway/Fractran.lean` portait encore un **bloc bilingue-inline redondant** : le docstring EN du module **plus** un bloc FR dont la note i18n périmée déclarait *« l'inline FR+EN est le bon compromis »* — auto-contradictoire depuis que le jumeau `Fractran_en.lean` existe sur `main` (#6690, sha `7638eb1fc`). Même classe que le tidy CollatzLike (#6695, MERGED).

## Changement (commentaire/docstring uniquement)

- **Strip** du bloc EN → base **FR-canonique**. La prose EN est préservée **verbatim** dans le frère `Fractran_en.lean` (`namespace Conway_en` + `open Conway`) — aucune perte.
- **Remplacement** de la note « inline = convention délibérée » (justification stale pré-#4980) par une note FR-canonique concise référençant `code-style.md` §Lean i18n (modèle Pattern A sibling, analogue `Angel.lean` / `Angel_en.lean`).

## Preuve (anti-régression Lean)

- Diff **+7/−34, docstring-only**.
- **Corps `namespace Conway` byte-identique** à `origin/main` (md5 `42cb2422cdfe9479adc602e5339e26f1` des deux côtés) — defs + `#eval` inchangés, ne peut pas changer la compilation.
- `sorry` **0→0**.
- Preuve de compilation = **`Lean CI (conway_lean)` cold-build in-PR** (glob `Conway.*` de #6678 couvre déjà le jumeau ; lean-merge-discipline satisfaite).

Complète la dette sibling-pair `#6190` (base-strip flaggée po-2023 c.451 / ai-01 c.516). Canon twin+strip : cf c.448 (Calibration).

`See #4980`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
