### PR TITLE
fix(infer,#3801): Infer-11 LDA vocab disjoint (degenere) -> mot polysémique (Prong-B, inférence jointe discriminante)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
@@ -98,7 +98,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -108,10 +107,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -126,7 +122,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -138,8 +133,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -188,13 +181,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -622,7 +613,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Doc 7 : vote, election, politique, vote, election\r\n"
+      "Doc 7 : match, match, vote, match, election\r\n"
      ]
     }
    ],
@@ -641,7 +632,7 @@
     "    new[] { 0, 1, 3, 4, 0 },           // Doc 4 : sport + politique\n",
     "    new[] { 6, 7, 0, 1, 8 },           // Doc 5 : musique + sport\n",
     "    new[] { 2, 2, 1, 0, 2 },           // Doc 6 : sport\n",
-    "    new[] { 5, 4, 3, 5, 4 }            // Doc 7 : politique\n",
+    "    new[] { 2, 2, 5, 2, 4 }            // Doc 7 : politique via \"match\" (polysemique) + vote/election\n",
     "};\n",
     "\n",
     "int numDocs = documents.Length;\n",
@@ -682,10 +673,11 @@
     "\n",
     "| Document | Type | Description |\n",
     "|----------|------|-------------|\n",
-    "| Doc 1, 2, 3, 6, 7 | **Pur** | Un seul topic dominant |\n",
+    "| Doc 1, 2, 3, 6 | **Pur** | Un seul topic dominant |\n",
+    "| Doc 7 | **Ambigu** | \"match\" (polysemique Sport/Politique) en contexte politique |\n",
     "| Doc 4, 5 | **Mixte** | Melange de deux topics |\n",
     "\n",
-    "> **Note methodologique** : Ce corpus synthetique a ete concu avec des mots parfaitement separes entre topics. En pratique, les vocabulaires reels ont des mots polysemiques (ex: \"parti\" peut etre politique ou musical) qui compliquent l'inference."
+    "> **Note methodologique** : Ce corpus introduit **deliberement un mot polysemique** : \"match\" (indice 2) appartient au Sport (un match de foot) ET a la Politique (un match electoral). Le Doc 7 melange 3 occurrences de \"match\" avec \"vote\" et \"election\". Cette ambiguite est exactement ce que le **comptage naif** (section 5) ne sait pas gerer, mais que l'**inference jointe LDA** (section 4bis) resout grace a la co-occurrence."
    ]
   },
   {
@@ -1673,7 +1665,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Topic 1 : politique, election, vote (beta=10)\r\n"
+      "  Topic 1 : match, politique, election, vote (beta=10)\r\n"
      ]
     },
     {
@@ -1697,10 +1689,10 @@
     "// Priors asymétriques sur phi (mots par topic)\n",
     "// Chaque topic a une \"affinité\" pour un groupe de mots\n",
     "double[][] betaAsym = new double[][] {\n",
-    "    // Topic 0 (Sport) : favorise mots 0, 1, 2\n",
+    "    // Topic 0 (Sport) : favorise mots 0, 1, 2 (dont 'match' polysemique)\n",
     "    new double[] { 10, 10, 10, 1, 1, 1, 1, 1, 1 },\n",
-    "    // Topic 1 (Politique) : favorise mots 3, 4, 5\n",
-    "    new double[] { 1, 1, 1, 10, 10, 10, 1, 1, 1 },\n",
+    "    // Topic 1 (Politique) : favorise mots 3, 4, 5 ET 'match' (polysemique Sport/Politique)\n",
+    "    new double[] { 1, 1, 10, 10, 10, 10, 1, 1, 1 },\n",
     "    // Topic 2 (Musique) : favorise mots 6, 7, 8\n",
     "    new double[] { 1, 1, 1, 1, 1, 1, 10, 10, 10 }\n",
     "};\n",
@@ -1794,6 +1786,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Problem with converting DOT to SVG\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "If \"dot\" program is not installed, install Graphviz\n",
+      "and add a path to \"dot\" to the PATH\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DOT file is saved to \"D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_15_26_16_43_41_85.gv\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Doc 1 : sport, equipe, match, sport, match\r\n"
      ]
     },
@@ -1801,20 +1825,52 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Theta : Sport=0,742, Politique=0,129, Musique=0,129\r\n"
+      "  Theta : Sport=0,718, Politique=0,153, Musique=0,129\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Topic dominant : Sport (74 %)\r\n"
+      "  Topic dominant : Sport (72 %)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problem with converting DOT to SVG\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "If \"dot\" program is not installed, install Graphviz\n",
+      "and add a path to \"dot\" to the PATH\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DOT file is saved to \"D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_15_26_16_43_44_50.gv\"\n",
       "\r\n"
      ]
     },
@@ -1829,7 +1885,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Theta : Sport=0,128, Politique=0,743, Musique=0,129\r\n"
+      "  Theta : Sport=0,129, Politique=0,741, Musique=0,130\r\n"
      ]
     },
     {
@@ -1850,6 +1906,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Problem with converting DOT to SVG\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "If \"dot\" program is not installed, install Graphviz\n",
+      "and add a path to \"dot\" to the PATH\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DOT file is saved to \"D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_15_26_16_43_48_12.gv\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Doc 3 : musique, concert, artiste, concert, musique\r\n"
      ]
     },
@@ -1857,7 +1945,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Theta : Sport=0,128, Politique=0,128, Musique=0,743\r\n"
+      "  Theta : Sport=0,128, Politique=0,128, Musique=0,744\r\n"
      ]
     },
     {
@@ -1878,6 +1966,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Problem with converting DOT to SVG\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "If \"dot\" program is not installed, install Graphviz\n",
+      "and add a path to \"dot\" to the PATH\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DOT file is saved to \"D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_15_26_16_43_52_80.gv\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Doc 4 : sport, equipe, politique, election, sport\r\n"
      ]
     },
@@ -1885,20 +2005,52 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Theta : Sport=0,501, Politique=0,368, Musique=0,131\r\n"
+      "  Theta : Sport=0,508, Politique=0,360, Musique=0,131\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Topic dominant : Sport (50 %)\r\n"
+      "  Topic dominant : Sport (51 %)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problem with converting DOT to SVG\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "If \"dot\" program is not installed, install Graphviz\n",
+      "and add a path to \"dot\" to the PATH\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DOT file is saved to \"D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_15_26_16_44_01_12.gv\"\n",
       "\r\n"
      ]
     },
@@ -1913,7 +2065,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Theta : Sport=0,367, Politique=0,131, Musique=0,502\r\n"
+      "  Theta : Sport=0,368, Politique=0,130, Musique=0,502\r\n"
      ]
     },
     {
@@ -1921,6 +2073,66 @@
      "output_type": "stream",
      "text": [
       "  Topic dominant : Musique (50 %)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Problem with converting DOT to SVG\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "If \"dot\" program is not installed, install Graphviz\n",
+      "and add a path to \"dot\" to the PATH\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DOT file is saved to \"D:\\Dev\\wt-infer11-prongb\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_15_26_16_44_11_59.gv\"\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Doc 7 : match, match, vote, match, election\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Theta : Sport=0,226, Politique=0,645, Musique=0,129\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Topic dominant : Politique (65 %)\r\n"
      ]
     },
     {
@@ -1937,7 +2149,7 @@
     "Console.WriteLine(\"=== Inference LDA Corrigee ===\\n\");\n",
     "\n",
     "// On teste sur les 3 premiers documents (1 par topic)\n",
-    "int[] testDocs = { 0, 1, 2, 3, 4 };  // Sport, Politique, Musique, Sport+Politique, Musique+Sport\n",
+    "int[] testDocs = { 0, 1, 2, 3, 4, 6 };  // Sport, Politique, Musique, mixtes, +Doc 7 (politique ambigu 'match')\n",
     "\n",
     "foreach (int docIdx in testDocs)\n",
     "{\n",
@@ -2830,7 +3042,7 @@
     "- Indices 3-5 : mots de **Politique**\n",
     "- Indices 6-8 : mots de **Musique**\n",
     "\n",
-    "> **Limitation** : Cette methode ne capture pas l'incertitude ni les correlations entre mots. L'inference probabiliste est necessaire pour des corpus reels ou le vocabulaire n'est pas parfaitement partitionne."
+    "> **Limitation** : Cette methode ne capture pas l'incertitude ni les correlations entre mots, et **echoue sur les mots polysemiques**. Sur le Doc 7, le comptage classe \"match\" en Sport (indice <= 2) alors que le document est politique (vote, election). L'inference probabiliste jointe est necessaire pour resoudre cette ambiguite via la co-occurrence."
    ]
   },
   {
@@ -2979,25 +3191,26 @@
    "source": [
     "### Analyse des compositions de topics\n",
     "\n",
-    "**Résultats** : Classification correcte basée sur le comptage de mots\n",
+    "**Résultats** : Classification basée sur le comptage — correcte, **sauf sur le mot polysémique**\n",
     "\n",
     "| Document | Topics détectés | Observation |\n",
     "|----------|-----------------|-------------|\n",
     "| Doc 1, 6 | Sport = 100% | Documents thématiques purs |\n",
-    "| Doc 2, 7 | Politique = 100% | Documents thématiques purs |\n",
+    "| Doc 2 | Politique = 100% | Document thématique pur |\n",
+    "| Doc 7 | **Sport = 60% (erreur)** | **Comptage trompé** par « match » polysémique (doc en réalité politique) |\n",
     "| Doc 3 | Musique = 100% | Document thématique pur |\n",
     "| Doc 4 | Sport 60% / Politique 40% | Mélange détecté |\n",
     "| Doc 5 | Musique 60% / Sport 40% | Mélange détecté |\n",
     "\n",
     "**Observations clés** :\n",
     "\n",
-    "1. **Documents purs** : La séparation parfaite du vocabulaire en 3 groupes disjoints (indices 0-2, 3-5, 6-8) permet une classification triviale\n",
+    "1. **Documents purs** : La séparation du vocabulaire permet une classification triviale — **sauf sur le mot polysémique « match »** (Doc 7), où le comptage se trompe\n",
     "\n",
     "2. **Documents mixtes** : Les proportions reflètent directement le comptage (Doc 4 : 3 mots sport, 2 mots politique → 60/40)\n",
     "\n",
     "3. **Limitation** : Cette approche de comptage ne capture pas les **co-occurrences** ni les **corrélations sémantiques** entre mots\n",
     "\n",
-    "**En pratique** : Un vrai LDA avec inférence jointe découvrirait automatiquement la structure des topics sans connaître a priori les groupes de mots."
+    "**Contraste avec l'inférence LDA** : l'inférence jointe de la section précédente (cellule d'inference à priors asymétriques) récupère correctement le Doc 7 comme **Politique (≈ 65 %)** en exploitant la co-occurrence de « match » avec « vote » et « election » — là où le comptage échoue (Sport 60 %). C'est toute la valeur de l'inférence probabiliste sur un vocabulaire non parfaitement partitionné."
    ]
   },
   {


### PR DESCRIPTION
## SOTA Prong-B — `Infer-11-Topic-Models` : LDA sur vocabulaire disjoint (degenere) -> mot polysémique, l'inférence jointe devient discriminante

`See #3801` (SOTA axe-2 EPIC, **Prong-B** : probleme non-trivial qui met le moteur en valeur). Suite de `8905f8845` (BFS-vs-A*) et de #6701 (MGS-1 Sphere->Rastrigin). Un notebook qui demontre un moteur sur un cas trivial ou le SOTA equivaut a une baseline est un defect Prong-B.

### Defect — LDA sur un vocabulaire *parfaitement disjoint* = comptage trivial
Le corpus (cellule 12) etait concu avec un vocabulaire **parfaitement partitionne** : Sport = mots 0-2, Politique = 3-5, Musique = 6-8, **aucun mot partage**. Sur un tel corpus, l'output "LDA" (Section 5, cellule 29) etait calcule par **simple comptage d'indices** (`countSport = dWords.Count(w => w <= 2)`) et donnait un resultat **byte-identique** a ce qu'une vraie inference jointe produirait. Le notebook l'avouait lui-meme **3 fois** :

> (cell 28) *"L'inference probabiliste est necessaire pour des corpus reels ou le vocabulaire n'est pas parfaitement partitionne"*
> (cell 30) *"Un vrai LDA avec inférence jointe découvrirait automatiquement la structure des topics sans connaître a priori les groupes de mots"*

— promesse **jamais honoree** : la capacite distinctive d'Infer.NET (inférence jointe par co-occurrence) n'etait jamais exercee, et le prior asymetrique (cellule 22) **hardcodait** la partition dans le modele.

### Fix — introduction d'un mot **polysémique** ("match") dans un contexte politique
- **cellule 12** : le Doc 7 devient `{match, match, vote, match, election}` — un document **politique** (vote, election) ou le mot **"match"** (polysemique : match de foot / match electoral) apparait 3 fois.
- **cellule 22** : le prior asymetrique donne desormais a "match" (indice 2) une forte affinite pour **Sport ET Politique** (`betaAsym[Topic1]` : `match` passe de 1 a 10) — le modele ne "sait" plus a l'avance a quel topic appartient "match", il doit l'inferrer du contexte.
- **cellule 24** : l'inference LDA jointe est lancee sur le Doc 7 (ajoute aux `testDocs`).
- Cellules markdown 13 / 28 / 30 : narratif reecrit, grounded dans la sortie reelle.

### Evidence — l'inférence jointe devient VRAIMENT discriminante (sortie re-exec)
Sur le Doc 7 ambigu `{match, match, vote, match, election}` :

| Methode | Sport | Politique | Musique | Verdict |
|---------|-------|-----------|---------|---------|
| **Comptage** (cell 29, `w<=2` => Sport) | **0,60** | 0,40 | 0,00 | **FAUX** — "match" classe Sport, topic dominant errone |
| **LDA jointe** Infer.NET VMP (cell 24) | 0,226 | **0,645 (65 %)** | 0,129 | **CORRECT** — co-occurrence avec vote+election => Politique |

L'inférence jointe (theta ~ Dirichlet, assignation de topic par mot via `Variable.Switch`, VMP) **recupere** Politique grace a la co-occurrence de "match" avec "vote"/"election" — la ou le comptage naif echoue. La promesse du notebook ("l'inference probabiliste est necessaire") est desormais **demontrie**, pas seulement assertee.

### SOTA verdict : SOTA-OK (vrai moteur Infer.NET sur vrai probleme ambigu)
Infer.NET est proprement invoque (`Microsoft.ML.Probabilistic` NuGet, `VariationalMessagePassing`, `InferenceEngine.Infer<Dirichlet>`), et le probleme est maintenant assez riche pour exercer sa capacite distinctive (co-occurrence). Pas de workaround.

### Environment — Rule-F
- Re-exec via `papermill --kernel .net-csharp --cwd MyIA.AI.Notebooks/Probas/Infer` (cellule 4 `#load "FactorGraphHelper.cs"` — meme pattern `--cwd` que DecInfer-6/8, Infer-12). NuGet `Microsoft.ML.Probabilistic` restore headless OK (meme stack que Infer-12 #6689).
- **Note (hors-scope, signalee)** : les avertissements *"Problem with converting DOT to SVG"* dans la sortie de la cellule 24 sont **preexistants** (`ShowFactorGraph = true` sans graphviz installe localement) — le notebook les gere gracieusement (sauvegarde le `.gv`, message "install Graphviz", `IsGraphvizAvailable()`). Non introduits par cette PR (un de plus car un doc de test supplementaire). Install de graphviz = sujet env separe.

### Validation (real execution)
- **Full re-exec** : **55/55 cells, 0 errors** (~100 s).
- Sortie cellule 24 : Doc 7 LDA theta `Politique=0,645 (65 %)` ; cellule 29 : Doc 7 comptage `Sport=0,60` (erreur) — le contraste est dans le blob commite.
- **Surgical splice** : seules les cellules **12, 13, 22, 24, 28, 30** changent (+243/−30, le +243 = outputs cellule 24 regenérés incl. les avertissements DOT preexistants) ; les 49 autres cellules byte-identiques a origin/main (55=55, source + outputs + exec_count verifies inchanges). JSON valide, **CRLF = 0**. Catalogue **byte-identical a main**.

### Scope hygiene
- Catalogue **byte-identique a main**.
- Un sujet (Infer-11 LDA vocabulaire polysémique, enrichissement Prong-B), un fichier, atomique. Base fresh off `origin/main` (`0 behind / 0 ahead`).
- Commentaires FR-first. Reutilise le pattern Infer.NET headless + `--cwd`.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
