### PR TITLE
fix(translation,#4957,#3801): resync probas-infer + probas-pymc CSV (2 SRC_DRIFT -> 0, c.458 pivot R6)

### DIFF
--- a/translations/probas-infer/probas_infer.csv
+++ b/translations/probas-infer/probas_infer.csv
@@ -3164,21 +3164,66 @@ MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,29f5a230,mar
 
 Comparons les trois quantités : effet vrai, estimation no-pool (brute), estimation hiérarchique (pooling partiel). La rétraction doit être **visiblement plus forte** pour les classes clairsemées (faible effectif).
 ",,,,,,,,6e1e0e838bc421fa,,,,,,,
-MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,c30c821e,code,fr,3c85c7369d820bcd,"Console.WriteLine(""Classe | n  | vrai | no-pool | hierarchique | retraction"");
+MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,c30c821e,code,fr,6139a239a8cecc76,"using Microsoft.DotNet.Interactive.Formatting;
+using System.IO;
+using System.Collections.Generic;
+record PlotlyHtml(string Markup);
+Formatter.Register(typeof(PlotlyHtml),
+    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), ""text/html"");
+
+Console.WriteLine(""Classe | n  | vrai | no-pool | hierarchique | retraction"");
 Console.WriteLine(""-------|----|------|---------|--------------|----------"");
 double hierMSE = 0;
+var labels = new List<string>();
+var vraiArr = new List<double>();
+var noPoolArr = new List<double>();
+var hierArr = new List<double>();
 for (int k = 0; k < numClasses; k++) {
     double hier = thetaPost[k].GetMean();
     double shrink = noPoolEstimates[k] - hier; // >0 = tire vers mu
     double err = hier - trueClassEffects[k];
     hierMSE += err * err;
-    string bar = new string('#', (int)Math.Round(Math.Abs(shrink) * 5));
-    Console.WriteLine($""  {k}    | {countsByClass[k],2} | {trueClassEffects[k],4:F1} | {noPoolEstimates[k],7:F2} | {hier,12:F2} | {bar}"");
+    Console.WriteLine($""  {k}    | {countsByClass[k],2} | {trueClassEffects[k],4:F1} | {noPoolEstimates[k],7:F2} | {hier,12:F2} | {shrink,7:F2}"");
+    labels.Add($""cl.{k} (n={countsByClass[k]})"");
+    vraiArr.Add(trueClassEffects[k]);
+    noPoolArr.Add(noPoolEstimates[k]);
+    hierArr.Add(hier);
 }
 hierMSE /= numClasses;
 Console.WriteLine($""\nNo-pooling   MSE = {noPoolMSE:F3}"");
 Console.WriteLine($""Hierarchique MSE = {hierMSE:F3}   (amelioration {100*(1 - hierMSE/noPoolMSE):F0}%)"");
-",,,,,,,,3c85c7369d820bcd,,,,,,,
+
+// Bar chart Plotly groupe : vrai / no-pool / hierarchique par classe.
+// Le pooling hierarchique retracte chaque estimation de classe vers la moyenne de groupe (mu) :
+// les classes a faible effectif (n petit) sont les plus retractees -- c'est tout l'interet du modele
+// hierarchique (regularisation adaptee a l'incertitude). La barre 'hierarchique' se rapproche du
+// centre du au retrait la ou 'no-pool' suit bruyamment l'echantillon.
+{
+    var xs = labels.Select(v => (object)v).ToArray();
+    var tVrai = System.Text.Json.JsonSerializer.Serialize(
+        new Dictionary<string, object> { [""x""] = xs, [""y""] = vraiArr.Select(v => (object)Math.Round(v,2)).ToArray(),
+                                         [""type""] = ""bar"", [""name""] = ""vrai"",
+                                         [""marker""] = new Dictionary<string,object>{ [""color""] = ""#444"" } });
+    var tNoPool = System.Text.Json.JsonSerializer.Serialize(
+        new Dictionary<string, object> { [""x""] = xs, [""y""] = noPoolArr.Select(v => (object)Math.Round(v,2)).ToArray(),
+                                         [""type""] = ""bar"", [""name""] = ""no-pool"",
+                                         [""marker""] = new Dictionary<string,object>{ [""color""] = ""#e8743b"" } });
+    var tHier = System.Text.Json.JsonSerializer.Serialize(
+        new Dictionary<string, object> { [""x""] = xs, [""y""] = hierArr.Select(v => (object)Math.Round(v,2)).ToArray(),
+                                         [""type""] = ""bar"", [""name""] = ""hierarchique"",
+                                         [""marker""] = new Dictionary<string,object>{ [""color""] = ""#2a6dba"" } });
+    var divId = ""plt"" + Guid.NewGuid().ToString(""N"");
+    var layout = ""{\""barmode\"":\""group\"",\""title\"":{\""text\"":\""Modele hierarchique : retraction des effets de classe vers mu "" +
+                 ""(le pooling retracte surtout les classes a faible effectif)\""},"" +
+                 ""\""xaxis\"":{\""title\"":{\""text\"":\""Classe (effectif n)\""}},"" +
+                 ""\""yaxis\"":{\""title\"":{\""text\"":\""Effet estime\""}},"" +
+                 ""\""margin\"":{\""l\"":50,\""r\"":30,\""b\"":90}}"";
+    var markup = ""<div id=\"""" + divId + ""\""></div>"" +
+                 ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
+                 ""<script>Plotly.newPlot('"" + divId + ""',["" + tVrai + "","" + tNoPool + "","" + tHier + ""],"" + layout + "")</script>"";
+    display(new PlotlyHtml(markup));
+}
+",,,,,,,,6139a239a8cecc76,,,,,,,
 MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb,958f5f00,markdown,fr,232ba6b71e9e2af7,"### Lecture du résultat
 
 L'**erreur quadratique moyenne de récupération** (MSE) chute avec le pooling partiel (hierarchique < no-pooling) : les trois classes clairsemées (effectif 1 ou 2) voient leur estimateur **rétracter** vers la moyenne de population `mu`, ce qui les arrache au bruit de leur (trop) petite mesure. La classe 7 (un seul élève) en est l'illustration la plus nette : sa moyenne brute est fortement bruitée, et le modèle la ramène près de `mu` — bien plus proche de l'effet vrai.

--- a/translations/probas-pymc/probas_pymc.csv
+++ b/translations/probas-pymc/probas_pymc.csv
@@ -1518,18 +1518,46 @@ print(f""Divergences NUTS (non centre) = {div_noncentered}  (cible : 0)"")",,,,,
 MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb,08d92b72,markdown,fr,b4572f04350cbc25,"## Pooling partiel vs no pooling -- la retraction en action
 
 Comparons les trois quantites : effet vrai, estimation no-pool (brute), estimation hierarchique (pooling partiel). La retraction doit etre **visiblement plus forte** pour les classes clairsemees (faible effectif).",,,,,,,,b4572f04350cbc25,,,,,,,
-MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb,ec3a0f75,code,fr,ee2d9fbea5e04fe8,"hier_mean = idata.posterior[""theta""].mean(dim=(""chain"", ""draw"")).values
+MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb,ec3a0f75,code,fr,d58c34d41e560b52,"hier_mean = idata.posterior[""theta""].mean(dim=(""chain"", ""draw"")).values
 hier_mse = np.mean((hier_mean - true_class_effects) ** 2)
 
-print(""Classe | n  | vrai  | no-pool | hierarchique | retraction"")
-print(""-------|----|-------|---------|--------------|----------"")
+print(""Classe | n  | vrai  | no-pool | hierarchique | retraction (|no-pool - hier|)"")
+print(""-------|----|-------|---------|--------------|--------------------------"")
 for c in range(num_classes):
     shrink = no_pool[c] - hier_mean[c]   # >0 = tire vers mu
-    bar = ""#"" * round(abs(shrink) * 5)
-    sign = ""+"" if shrink >= 0 else ""-""
-    print(f""  {c}    | {counts_by_class[c]:2d} | {true_class_effects[c]:.1f}   | {no_pool[c]:7.2f} | {hier_mean[c]:12.2f} | {sign}{bar}"")
+    print(f""  {c}    | {counts_by_class[c]:2d} | {true_class_effects[c]:.1f}   | {no_pool[c]:7.2f} | {hier_mean[c]:12.2f} | {abs(shrink):+.2f}"")
 print(f""\nNo-pooling     MSE = {no_pool_mse:.3f}"")
-print(f""Hierarchique   MSE = {hier_mse:.3f}   (amelioration {100*(1 - hier_mse/no_pool_mse):.0f}%)"")",,,,,,,,ee2d9fbea5e04fe8,,,,,,,
+print(f""Hierarchique   MSE = {hier_mse:.3f}   (amelioration {100*(1 - hier_mse/no_pool_mse):.0f}%)"")
+
+# Dumbbell : vrai (◆) / no-pool (●) / hierarchique (▲) par classe,
+# colore par effectif n -- la retraction (hier tire vers mu) doit etre
+# visiblement plus forte pour les classes clairsemees (n faible).
+import matplotlib.pyplot as plt
+classes = np.arange(num_classes)
+ns = np.array([counts_by_class[c] for c in classes], dtype=float)
+nc = (ns - ns.min()) / (ns.max() - ns.min() + 1e-12)  # 0=sparse .. 1=opaque
+fig, ax = plt.subplots(figsize=(8, 1.0 + 0.45 * num_classes))
+for c in classes:
+    vals = [float(true_class_effects[c]), float(no_pool[c]), float(hier_mean[c])]
+    lo, hi = min(vals), max(vals)
+    col = plt.cm.viridis(nc[c])
+    ax.plot([lo, hi], [c, c], color=col, lw=4, alpha=0.55, zorder=1)
+    ax.scatter(float(true_class_effects[c]), c, marker=""D"", s=90,
+               color=""black"", zorder=5, label=""vrai"" if c == 0 else None)
+    ax.scatter(float(no_pool[c]), c, marker=""o"", s=80,
+               color=col, edgecolor=""black"", zorder=5, label=""no-pool"" if c == 0 else None)
+    ax.scatter(float(hier_mean[c]), c, marker=""^"", s=95,
+               color=""white"", edgecolor=col, linewidth=2.2, zorder=5,
+               label=""hierarchique"" if c == 0 else None)
+ax.set_yticks(classes)
+ax.set_yticklabels([f""classe {c} (n={counts_by_class[c]})"" for c in classes])
+ax.set_xlabel(""effet estime"")
+ax.set_title(""Retraction hierarchique : le pooling partiel tire les classes\nclairsemees (n faible, jaune) vers la moyenne de population mu"")
+ax.legend(loc=""lower right"", framealpha=0.9)
+ax.invert_yaxis()
+plt.tight_layout()
+plt.show()
+",,,,,,,,d58c34d41e560b52,,,,,,,
 MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb,fa01d255,markdown,fr,53e8a4a5f346eca7,"### Lecture du resultat
 
 L'**erreur quadratique moyenne de recuperation** (MSE) chute avec le pooling partiel (hierarchique < no-pooling) : les classes clairsemees (effectif 1 ou 2) voient leur estimateur **retracter** vers la moyenne de population `mu`, ce qui les arrache au bruit de leur (trop) petite mesure. La classe a un seul eleve en est l'illustration la plus nette : sa moyenne brute est fortement bruitee, et le modele la ramene pres de `mu` -- bien plus proche de l'effet vrai.


### PR DESCRIPTION
## c.458 — resync probas-infer + probas-pymc CSV (2 SRC_DRIFT → 0, post-#3801 Prong-A cluster)

### Substance

Resync `translations/probas-infer/probas_infer.csv` et `translations/probas-pymc/probas_pymc.csv` pour éliminer les **2 SRC_DRIFT récurrent(e)s** apparus post-substance cluster EPIC #3801 Prong-A/B du 2026-07-15. Pattern canon **c.438/439/440 `--update` mode** rafraîchi ciblé.

**Note pivot R6 anti-monotonie** : post-c.457 (3ᵉ cycle conway_lean consécutif c.451/c.456/c.457), c.458 pivote cross-famille vers translation backlog. Grain = le dernier résidu de la vague c.440 post-batch-wave EPIC #3801 sur la famille Probas.

### Changement (2 fichiers, R3 atomique strict)

| Fichier | Δ drift | Δ lignes | Structure |
|---------|---------|----------|-----------|
| `translations/probas-infer/probas_infer.csv` | 1 SRC_DRIFT → 0 | +50/-3, **941 cell_ids uniques** (0 doublon) | Rafraîchit cell `c30c821e` (Infer-12-Modeles-Hierarchiques) — nouvelle infra PlotlyHtml + Formatter.Register backportée, hashes pivot rafraîchis |
| `translations/probas-pymc/probas_pymc.csv` | 1 SRC_DRIFT → 0 | +34/-8, **572 cell_ids uniques** (0 doublon) | Rafraîchit cell `ec3a0f75` (PyMC-12-Modeles-Hierarchiques, == cell[8]) post-#6659 matplotlib dumbbell shrink |

**Total** : 2 files +84/-11, < 3000L, 1 sujet (translation resync post-substance-cluster), bien sous le seuil R3.

### Origine du drift (G.1 firsthand vérifié)

EPIC **#3801** cluster wave du 2026-07-15 a backporté l'infra **C548-L2 canon** (`record PlotlyHtml` + `Formatter.Register(typeof(PlotlyHtml), (obj,writer) => ..., "text/html")`) sur les 2 notebooks substance :
- **Infer-12 cell c30c821e** : rewrite avec nouvelles `using Microsoft.DotNet.Interactive.Formatting; using System.IO;`, infra PlotlyHtml, variables `labels/vraiArr/noPoolArr/hierArr` collection pour Plotly dumbbell downstream. Hash `3c85c7369d820bcd` → `6139a239a8cecc76`.
- **PyMC-12 cell ec3a0f75 (= cell[8])** : post-**PR #6659** `fix(probas,#3801): PyMC-12 cell[8] shrinkage ASCII bar -> matplotlib dumbbell (Prong-A)` (MERGED 07:32:29Z aujourd'hui). Hash `ee2d9fbea5e04fe8` → `d58c34d41e560b52`.

**Cause canon** : EPIC #3801 substance cluster ne re-run PAS systématiquement la T2 (translation CSV sync) après modification d'une cellule code avec `text_en` à retraduire — uniquement les PRs `feature/translation` manuels post-cluster-wave re-flaggent le drift. C'est la **3ème ré-occurrence du pattern** post-#3801 (cf #6604 iit → #6638, #6660 rl, #6646 Sudoku, #6651 search-part4 ; #6586 ML-7 ; etc.).

### Vérifications anti-régression

- **R3 atomique strict** : 2 files, 1 sujet (translation resync), +84/-11 < 3000L. 0 composite.
- **R1 catalog-pr-hygiene** : `git status` filtered = vide côté catalogue. `COURSE_CATALOG.generated.{json,md}` byte-identique à `origin/main`. Pas de marqueur `CATALOG-STATUS` touché.
- **L268 LF-only** : `python -c` CR=0 byte-level sur les 2 CSV (904343B / 501692B).
- **Conservation T3** (cf c.438 doc) : `--update` mode préserve **920 lignes d'autres notebooks** dans probas-infer + **548 lignes d'autres notebooks** dans probas-pymc. Cellules targets = `text_en` UNIQUE rafraîchies (champ FR pivot seulement).
- **Pas de doublon cell_ids** : `csv.reader` + `Counter` → 0 doublon (941/572 uniques).
- **G.1 firsthand** : `python scripts/translation/check_translation_sync.py translations/probas-{infer,pymc}/*.csv --check` = **0 drift** sur les 2 CSV post-extra `extract_cells_to_csv.py --update`.
- **`See #4957`** (pas `Closes` — l'EPIC #4957 T2 inclut la surveillance continue, clôture au gel de la T3 traduction).
- **`See #3801`** (cause racine) : cross-référence informative.
- **Pas de cross-domain spill** : 2 CSV dans `translations/probas-{infer,pymc}/` uniquement.

### Comparaison avec c.440 (cette PR ≠ clone c.440)

c.440 (PR #6519) = T1b gros backfill : 61 refresh + 16 ajoutées + 1820 in-sync + 5 ORPHAN (1902 lignes/55 nb) en gametheory. **c.458** est un resync **chirurgical** (2 cellules, deux familles soeurs Probas) post-substance-cluster EPIC #3801. **Pas de doublonnage** avec c.440 (gametheory), c.439 (Sudoku), c.438 (Argument_Analysis).

### Comparaison avec c.440-style précédent Probas

- **c.440 #6639 Probas/Infer CSV (54 SRC_DRIFT -> 0)** MERGED 14:34:06Z 2026-07-15.
- **c.440 #6649 probas-pymc.csv 5 cells SRC_DRIFT 5->0** MERGED 14:48:23Z 2026-07-15.
- **c.458** = re-drift **post-ces 2 merges** : la substance Prong-A cluster EPIC #3801 (#6659 matplotlib dumbbell PyMC-12 cell[8], backport PlotlyHtml Infer-12) a re-modifié les cellules **après** les 2 merges c.440. C'est un drift de **substance post-fix**, pas un résidu pré-fix.

### c.438 canon appliqué (cf MEMORY.md C438-L1)

- **`--update <csv>`** mode = merge (préserve T3) + rafraîchit champs pivot (`src_hash`, `text_fr`, `hash_fr`, `src_lang`, `cell_type`) pour les notebooks en input. 0 écrasement.
- **Conservation ORPHAN_ROW** : aucune ligne d'un autre notebook touchée.
- **Pas de `csv.writer` Windows `\r\n`** : `extract_cells_to_csv.py` ouvre le fichier destination en mode texte + write direct (cf C438-L1 sur la conversion post-write).

### Cycle worker discipline

| Aspect | Application |
|--------|-------------|
| **Worker = po-2023** | Pivot R6 cross-famille (post-3 conway_lean) ; author = jsboige self-bot = mon auth principal |
| **gh auth** | `myia-po-2023` token worker, pas de `gh auth switch`/merge (lesson #1502) |
| **--body-file** (C403-L1) | Body via fichier, pas `--body` inline (backtick stripping) |
| **--cwd excluded** | N/A (PR main-repo) |
| **L515-L1 ★★** | Cron worker 30 min staggered, PAS de `ScheduleWakeup` (source unique wakeup = `CronCreate` interne / Task Scheduler externe) |

### Suite logique (post-merge c.458)

- **#3801 substance cluster Prong-A/B wave COMPLETE** : 11 PRs MERGED + 2 self-bot po-2023 OPEN. c.458 résout le re-drift translation collatéral sans rouvrir le substance.
- **Dette c.451-L1 ★ restante** (post-c.457-L1 ★ réduction 3→2) : Nim sibling pair c.518 + FreeWillTheorem strip = 2 PRs canon c.448 restantes. Pas c.458 (R6 cross-famille prioritaire).
- **#6659 + #6694/#6696/#6698/#6700 Vision-Gated** : easing policy #6704 forensic per-PR + spot-check suffit pour les PRs Plotly CDN (pas round-trip MiniMax).
- **Cron `01dd6122` next fire** : `:21`/`:51` per L291-3 pattern → c.459.

### Refs

- `See #4957` (EPIC T2 surveillance continue traductions CSV)
- `See #3801` (cause racine = substance cluster EPIC axe-2 SOTA)
- `See #6659` (PyMC-12 cell[8] matplotlib dumbbell Prong-A — cause spécifique du re-drift pymc)
- `See #6639` (c.440 Probas/Infer resync précédent — preuve du 1er passage puis re-drift)
- `See #6649` (c.440 probas-pymc resync précédent — preuve du 1er passage puis re-drift)
- `See c.438` (canon `--update` mode + conservation T3)
- `See c.439` (Sudoku resync --update validé canon)
- `See c.440` (gametheory resync --update validé canon)
- `See c.457` (conway_lean cycle précédent — pivot R6 post-3 cycles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
