### PR TITLE
fix(ml,#3801): ML-7 Matrix Factorization 15 notes jouets (R2=-34) -> redemption 500 notes reelles sparse (Prong-B)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -1054,6 +1054,142 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5b023bd6-c2f6-4b91-9cfa-8af6d6f70d2d",
+   "metadata": {},
+   "source": [
+    "### Pourquoi MF echoue sur 15 notes mais reussit sur 500\n",
+    "\n",
+    "L'evaluation ci-dessus (cellule 17) donne un **R² de −34** : sur 15 notes, Matrix Factorization predit *moins bien* que la simple moyenne. Ce n'est pas un bug du moteur — c'est une limite fondamentale des facteurs latents : avec 5 utilisateurs et 3 films, la matrice utilisateur×film est **pleine** (15 cases sur 15), il n'y a **aucune structure latente a decouvrir**. Le modele sur-ajuste un exemple unique par case.\n",
+    "\n",
+    "La capacite distinctive de MF — extraire des **facteurs latents** (genres, affinites) a partir d'une matrice **sparse** (majorite de cases vides, remplissage ~10%) — ne s'exerce que sur un volume suffisant. On applique donc le **meme moteur** sur un jeu de donnees reel sparse (`product-ratings.csv` : 500 notes, 99 utilisateurs × 50 produits). Sur ce volume, les facteurs latents capturent enfin la structure, et MF **bat la baseline de la moyenne**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "b79eb0f6-266f-4d50-af9b-aff4148e4644",
+   "metadata": {},
+   "execution_count": 2,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== MF sur un jeu de donnees reel sparse (product-ratings.csv) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Notes : 500 | Utilisateurs : 99 | Produits : 50\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Baseline (moyenne = 4,21) RMSE = 0,613\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MF RMSE = 0,386 | MAE = 0,311 | R2 = 0,597\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MF bat la moyenne ? RMSE 0,386 < 0,613 => OUI\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gain relatif : 37,1% de RMSE en moins vs la baseline moyenne.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Contraste avec l'exemple jouet (cellule 17, 15 notes) : R2 = -34 (MF < moyenne).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=> Les facteurs latents de MF ne sont utiles QUE sur une matrice sparse suffisamment remplie.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Globalization;\n",
+    "using System.IO;\n",
+    "\n",
+    "// --- Redemption : le MEME moteur MF sur un jeu de donnees reel sparse ---\n",
+    "// Sur 15 notes, MF ne battait pas la moyenne (R2 = -34, sur-ajustement d'une matrice pleine).\n",
+    "// Sur 500 notes sparse (densite ~10%), les facteurs latents captent la structure.\n",
+    "public class ProdRating { public float UserID; public float ProductID; public float Rating; }\n",
+    "\n",
+    "var prodLines = File.ReadAllLines(\"product-ratings.csv\").Skip(1);\n",
+    "var prods = new List<ProdRating>();\n",
+    "foreach (var ln in prodLines)\n",
+    "{\n",
+    "    var p = ln.Split(',');\n",
+    "    prods.Add(new ProdRating {\n",
+    "        UserID = float.Parse(p[0], CultureInfo.InvariantCulture),\n",
+    "        ProductID = float.Parse(p[1], CultureInfo.InvariantCulture),\n",
+    "        Rating = float.Parse(p[2], CultureInfo.InvariantCulture) });\n",
+    "}\n",
+    "\n",
+    "var prodData = mlContext.Data.LoadFromEnumerable(prods);\n",
+    "var prodSplit = mlContext.Data.TrainTestSplit(prodData, testFraction: 0.2, seed: 42);\n",
+    "\n",
+    "// Baseline triviale : predire la note moyenne du train set sur le test set.\n",
+    "float trainMean = mlContext.Data.CreateEnumerable<ProdRating>(prodSplit.TrainSet, reuseRowObject: false)\n",
+    "    .Average(x => x.Rating);\n",
+    "var testRows = mlContext.Data.CreateEnumerable<ProdRating>(prodSplit.TestSet, reuseRowObject: false).ToList();\n",
+    "double meanRMSE = Math.Sqrt(testRows.Average(x => Math.Pow(x.Rating - trainMean, 2)));\n",
+    "\n",
+    "// Matrix Factorization (meme config que l'exemple jouet : rank 10, 20 iterations)\n",
+    "var prodPipe = mlContext.Transforms.Conversion.MapValueToKey(\"UID\", \"UserID\")\n",
+    "    .Append(mlContext.Transforms.Conversion.MapValueToKey(\"PID\", \"ProductID\"))\n",
+    "    .Append(mlContext.Recommendation().Trainers.MatrixFactorization(\n",
+    "        new MatrixFactorizationTrainer.Options {\n",
+    "            MatrixColumnIndexColumnName = \"UID\",\n",
+    "            MatrixRowIndexColumnName = \"PID\",\n",
+    "            LabelColumnName = \"Rating\",\n",
+    "            NumberOfIterations = 20,\n",
+    "            ApproximationRank = 10 }));\n",
+    "\n",
+    "var prodModel = prodPipe.Fit(prodSplit.TrainSet);\n",
+    "var prodMetrics = mlContext.Regression.Evaluate(prodModel.Transform(prodSplit.TestSet), labelColumnName: \"Rating\");\n",
+    "\n",
+    "Console.WriteLine(\"=== MF sur un jeu de donnees reel sparse (product-ratings.csv) ===\");\n",
+    "Console.WriteLine($\"Notes : {prods.Count} | Utilisateurs : {prods.Select(x => x.UserID).Distinct().Count()} | Produits : {prods.Select(x => x.ProductID).Distinct().Count()}\");\n",
+    "Console.WriteLine($\"Baseline (moyenne = {trainMean:F2}) RMSE = {meanRMSE:F3}\");\n",
+    "Console.WriteLine($\"MF RMSE = {prodMetrics.RootMeanSquaredError:F3} | MAE = {prodMetrics.MeanAbsoluteError:F3} | R2 = {prodMetrics.RSquared:F3}\");\n",
+    "Console.WriteLine($\"MF bat la moyenne ? RMSE {prodMetrics.RootMeanSquaredError:F3} < {meanRMSE:F3} => {(prodMetrics.RootMeanSquaredError < meanRMSE ? \"OUI\" : \"NON\")}\");\n",
+    "Console.WriteLine($\"Gain relatif : {(1 - prodMetrics.RootMeanSquaredError / meanRMSE) * 100:F1}% de RMSE en moins vs la baseline moyenne.\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Contraste avec l'exemple jouet (cellule 17, 15 notes) : R2 = -34 (MF < moyenne).\");\n",
+    "Console.WriteLine(\"=> Les facteurs latents de MF ne sont utiles QUE sur une matrice sparse suffisamment remplie.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "execution_count": null,
    "id": "888d16cb",
    "metadata": {


### PR DESCRIPTION
## SOTA Prong-B — `ML-7-Recommendation` : Matrix Factorization sur 15 notes jouets (R²=−34) → redemption sur 500 notes réelles sparse

`See #3801` (SOTA axe-2 EPIC, **Prong-B** : problème non-trivial qui met le moteur en valeur). Suite de `8905f8845` (BFS-vs-A*), #6701 (MGS-1 Rastrigin), #6702 (Infer-11 polysémique), #6703 (GT-14 refuge), #6706 (Planners-8 RCPSP contention).

### Defect — Matrix Factorization écrasée par la baseline « prédire la moyenne »
La cellule 17 évalue Matrix Factorization (collaborative filtering) sur **15 notes jouets** (5 utilisateurs × 3 films). La sortie committée donne :

```
=== Évaluation sur le test set ===
RMSE : 2,955
MAE : 2,564
R2 : -33,939
```

**R² = −34** signifie que MF prédit *moins bien* que prédire simplement la note moyenne globale. Le notebook l'avouait lui-même (cellule 17, note pédagogique) : *« un R2 tres negatif signifie que le modele predit moins bien qu'une simple moyenne. Cela arrive souvent avec un jeu de donnees tres petit (15 notes) »* — mais il n'honorait jamais la promesse d'un cas où MF réussit.

**Pourquoi MF échoue sur 15 notes** : 5 users × 3 films = une matrice **pleine** (15 cases sur 15). Les facteurs latents de MF n'ont **aucune structure à découvrir** — il n'y a pas de cases vides à extrapoler. Le modèle sur-ajuste un exemple unique par case. La capacité distinctive de MF (extraire des facteurs latents d'une matrice *sparse*) n'est jamais exercée.

### Fix — appliquer le MÊME moteur à un vrai jeu de données sparse
- **cellule 17 byte-identique** : son diagnostic honnête de l'échec small-data reste une bonne pédagogie (ne pas masquer le problème).
- **nouvelle cellule 18 (markdown)** : explique *pourquoi* MF échoue sur une matrice pleine mais réussit sur une matrice sparse (structure latente).
- **nouvelle cellule 19 (code)** : applique le **même** pipeline MF (même `MatrixFactorizationTrainer`, `ApproximationRank:10`, `NumberOfIterations:20`) à `product-ratings.csv` (500 notes, 99 utilisateurs × 50 produits, densité ~10 %). Compare MF à la baseline triviale « prédire la moyenne du train set ».

### Evidence — MF bat enfin la moyenne sur un vrai volume
La sortie de la cellule 19 (exécution réelle de sa source) :

```
=== MF sur un jeu de donnees reel sparse (product-ratings.csv) ===
Notes : 500 | Utilisateurs : 99 | Produits : 50
Baseline (moyenne = 4,21) RMSE = 0,613
MF RMSE = 0,386 | MAE = 0,311 | R2 = 0,597
MF bat la moyenne ? RMSE 0,386 < 0,613 => OUI
Gain relatif : 37,1% de RMSE en moins vs la baseline moyenne.
```

**Contraste net** :

| Instance | Notes | Densité | R² MF | vs baseline moyenne |
|----------|-------|---------|-------|---------------------|
| Exemple jouet (cellule 17) | 15 | 100 % (pleine) | **−33,9** | MF *écrasé* par la moyenne |
| `product-ratings.csv` (cellule 19) | 500 | ~10 % (sparse) | **+0,597** | MF bat la moyenne de 37 % RMSE |

Sur la matrice sparse, les facteurs latents capturent enfin la structure (affinités utilisateur↔produit), et MF justifie son existence — là où l'exemple jouet ne faisait que montrer qu'un modèle sophistiqué perd contre la moyenne. C'est la capacité distinctive du collaborative filtering, rendue visible.

### SOTA verdict : SOTA-OK (vrai moteur MF sur un vrai cas où il bat la baseline)
MF est proprement exercé sur une instance où sa capacité distinctive (facteurs latents sur matrice sparse) est **réellement nécessaire et démontrée** (pas de workaround, pas de cas dégénéré). On enrichit le **problème** (passer d'une matrice pleine jouet à une vraie matrice sparse), exactement la doctrine Prong-B.

### Environment — Rule-F (NuGet Microsoft.ML, exécutable localement)
- cellule 1 : `#r "nuget: Microsoft.ML, 5.0.0"` + `Microsoft.ML.Recommender, 0.23.0`. Re-exec locale via `papermill --kernel .net-csharp`. La cellule 19 utilise `float.Parse(..., CultureInfo.InvariantCulture)` (robuste au séparateur décimal français).

### Validation (real execution)
- **cellule 19 outputs** : obtenus par exécution réelle de sa **source exacte** dans un kernel ML.NET (`Microsoft.ML` + `Recommender`, `mlContext(seed:42)`, même train/test split `seed:42`) — le *prefix-probe* reproduit fidèlement le contexte d'exécution de la cellule 19 et produit ces sorties (~40 s, hors restore XPlot).
- **Reproductibilité** : MF est ~déterministe — une seconde exécution donne R²=0,592 / gain 36,7 % (vs 0,597 / 37,1 %), drift ±0,005 inhérent au SGD parallèle de ML.NET. La **conclusion est robuste cross-runs** (MF bat la moyenne, R²≈0,59, ~37 % de gain).
- **Transparence** (G.3) : le restore NuGet de `XPlot.Plotly.Interactive` (cellule 1) dépasse 5 min en papermill headless (limitation connue c.483, spécifique à ce paquet). Les sorties de la cellule 19 viennent donc de l'exécution de sa source exacte (prefix-probe), documentée honnêtement ici — elles sont régénérables par la source de la cellule 19 (C.2).
- **Surgical splice** : cellules **0-17 byte-identiques** à origin/main (incluant la cellule 17 jouet et sa note pédagogique) ; cellules origin 18-33 (Cold Start, exercices 3-6, conclusion, références) décalées en **20-35 byte-identiques** (source + outputs + exec_count). Seules **18** (md) + **19** (code) sont nouvelles (+136 lignes). JSON valide, **CRLF = 0**, tous les `id` de cellules présents.

### Scope hygiene
- Catalogue **byte-identique à main**.
- Un sujet (ML-7 MF redemption Prong-B), un fichier, atomique. Base fresh off `origin/main` (`0 behind / 0 ahead`). `product-ratings.csv` déjà suivi (aucune donnée extraite).
- Commentaires FR-first.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
