### PR TITLE
feat(lean-i18n,#4980): sibling byte-identity checker (scripts/lean/check_i18n_siblings.py)

### DIFF
--- a/scripts/lean/check_i18n_siblings.py
+++ b/scripts/lean/check_i18n_siblings.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Check Lean i18n sibling-pair body byte-identity (EPIC #4980).
+
+Convention #4980 (ratified 2026-07-04, cf ``.claude/rules/code-style.md`` §Lean
+i18n): a French-canonical ``Foo.lean`` may have an English mirror ``Foo_en.lean``.
+Only the **docstrings** (``/-- ... -/``, ``/- ... -/``) and **comments**
+(``-- ...``) differ between the two files; the code **body** — signatures,
+``def`` / ``structure`` / ``inductive``, theorem statements, proofs, tactics,
+``#eval`` — stays **byte-identical**, modulo the lines that legitimately differ:
+``import`` (the ``_en`` file imports its FR sibling and/or Mathlib differently),
+``open`` (the ``_en`` file opens the FR namespace), ``namespace`` / ``end`` (the
+``_en`` file suffixes the namespace with ``_en``). The two validated i18n
+variants (lesson C565-L1) are both accepted: *reuse-FR-names* (the EN file does
+``open <FRnamespace>`` and reuses the FR identifiers verbatim — conway_lean) and
+*prefixed-suffix* (the EN file refers to ``_en``-suffixed entities such as
+``TUGame_en`` — game_theory_lean); the trailing ``_en`` on identifiers is
+collapsed symmetrically so genuine body content still compares byte-for-byte.
+
+This is the reusable form of the ad-hoc ``normalize_body()`` that the #4980
+rollout has been re-writing by hand for every pair (cf the conway_lean sibling
+pairs, forensic notes "byte-identity N/N"). It does **NOT** compile Lean — use
+``lake build`` for that, per ``.claude/rules/lean-merge-discipline.md``; it only
+proves that the FR and EN bodies have not drifted apart.
+
+Usage
+-----
+    python scripts/lean/check_i18n_siblings.py PATH [PATH ...]
+    python scripts/lean/check_i18n_siblings.py --all
+
+``PATH`` may be a directory (scanned recursively for ``*_en.lean``) or a single
+``*_en.lean`` file. ``--all`` scans the whole repository, skipping vendored /
+out-of-scope trees (``.lake/``, ``_peters/``, ``reference_docs/``, ...).
+
+Exit code ``0`` if every discovered pair matches (or none is found), ``1`` on any
+body drift or on an orphan ``_en`` file (a ``*_en.lean`` whose FR sibling is
+missing).
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+# Trees out of scope for the #4980 convention (vendored Mathlib, external lakes,
+# third-party fixtures) — cf code-style.md §Lean i18n "Hors scope".
+EXCLUDE_PARTS = frozenset(
+    {".lake", "_peters", "reference_docs", "agent_tests", ".git", ".claude",
+     "node_modules", "foundry-lib"}
+)
+
+# Lines that legitimately differ between an FR canonical and its EN mirror.
+_STRUCTURAL_LINE = re.compile(r"^\s*(import|open|namespace|end)\b")
+
+# The `_en` anti-collision suffix the convention adds to namespaced identifiers
+# in the EN mirror. Two validated i18n variants exist (lesson C565-L1):
+#   * reuse-FR-names  — the EN file does `open <FRnamespace>` and references the
+#     FR identifiers verbatim (conway_lean); no `_en` suffix in the body.
+#   * prefixed-suffix — the EN file defines `_en`-suffixed entities and refers to
+#     them with the suffix (game_theory_lean: `TUGame` ↔ `TUGame_en`).
+# Collapsing a trailing `_en` on identifiers (applied to BOTH files, so it is
+# symmetric) makes the two variants compare equal on genuine body content while
+# still surfacing any real divergence.
+_EN_SUFFIX = re.compile(r"\b(\w+)_en\b")
+
+
+def strip_comments(src: str) -> str:
+    """Remove Lean block comments (``/- -/`` and ``/-- -/`` docstrings,
+    nesting-aware) and ``-- ...`` line comments, while leaving string literals
+    untouched. Newlines are preserved so line structure survives."""
+    out: list[str] = []
+    i, n = 0, len(src)
+    depth = 0        # block-comment nesting depth
+    in_str = False
+    while i < n:
+        c = src[i]
+        pair = src[i:i + 2]
+        if depth > 0:                       # inside a (possibly nested) block comment
+            if pair == "/-":
+                depth += 1
+                i += 2
+            elif pair == "-/":
+                depth -= 1
+                i += 2
+            else:
+                if c == "\n":
+                    out.append("\n")        # keep line breaks from multi-line comments
+                i += 1
+            continue
+        if in_str:                          # inside a "..." string literal
+            out.append(c)
+            if c == "\\" and i + 1 < n:     # escaped char — copy verbatim
+                out.append(src[i + 1])
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+            i += 1
+            continue
+        # normal code
+        if c == '"':
+            in_str = True
+            out.append(c)
+            i += 1
+        elif pair == "/-":
+            depth += 1
+            i += 2
+        elif pair == "--":
+            j = src.find("\n", i)           # line comment → drop to end of line
+            if j == -1:
+                break
+            i = j                           # leave the newline for the next iteration
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def normalize_body(src: str) -> str:
+    """Reduce a ``.lean`` source to its comparable code body: strip comments /
+    docstrings, drop ``import`` / ``open`` / ``namespace`` / ``end`` lines and
+    blank lines, and trim trailing whitespace (indentation is preserved, as Lean
+    tactic blocks are indentation-sensitive)."""
+    stripped = strip_comments(src)
+    kept: list[str] = []
+    for line in stripped.splitlines():
+        if _STRUCTURAL_LINE.match(line):
+            continue
+        trimmed = line.rstrip()
+        if trimmed.strip() == "":
+            continue
+        kept.append(trimmed)
+    return _EN_SUFFIX.sub(r"\1", "\n".join(kept) + "\n")
+
+
+def check_pair(fr_path: Path, en_path: Path) -> tuple[bool, str]:
+    """Return ``(ok, diff)``: whether the FR and EN bodies match after
+    normalization, and a short unified diff when they do not."""
+    fr_body = normalize_body(fr_path.read_text(encoding="utf-8"))
+    en_body = normalize_body(en_path.read_text(encoding="utf-8"))
+    if fr_body == en_body:
+        return True, ""
+    diff = difflib.unified_diff(
+        fr_body.splitlines(), en_body.splitlines(),
+        fromfile=str(fr_path), tofile=str(en_path), lineterm="",
+    )
+    return False, "\n".join(list(diff)[:40])
+
+
+def _excluded(path: Path) -> bool:
+    return any(part in EXCLUDE_PARTS for part in path.parts)
+
+
+def find_en_files(paths: list[Path]) -> list[Path]:
+    """Collect ``*_en.lean`` files from the given files/directories, skipping
+    out-of-scope trees and de-duplicating."""
+    found: list[Path] = []
+    seen: set[Path] = set()
+    for raw in paths:
+        p = Path(raw)
+        candidates: list[Path]
+        if p.is_file():
+            candidates = [p] if p.name.endswith("_en.lean") else []
+        elif p.is_dir():
+            candidates = sorted(p.rglob("*_en.lean"))
+        else:
+            print(f"warning: path not found: {p}", file=sys.stderr)
+            candidates = []
+        for f in candidates:
+            rf = f.resolve()
+            if _excluded(f) or rf in seen:
+                continue
+            seen.add(rf)
+            found.append(f)
+    return found
+
+
+def fr_sibling(en_path: Path) -> Path:
+    """``Foo_en.lean`` → ``Foo.lean`` in the same directory."""
+    return en_path.with_name(en_path.name[: -len("_en.lean")] + ".lean")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("paths", nargs="*", help="files or directories to scan")
+    parser.add_argument("--all", action="store_true",
+                        help="scan the whole repository")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if args.all:
+        scan_paths = [repo_root]
+    elif args.paths:
+        scan_paths = [Path(p) for p in args.paths]
+    else:
+        parser.error("provide PATH(s) or --all")
+
+    en_files = find_en_files(scan_paths)
+    if not en_files:
+        print("No *_en.lean sibling files found — nothing to check.")
+        return 0
+
+    passed = failed = orphan = 0
+    for en in sorted(en_files):
+        fr = fr_sibling(en)
+        rel = en
+        if not fr.exists():
+            orphan += 1
+            print(f"ORPHAN  {rel}  (no FR sibling {fr.name})")
+            continue
+        ok, diff = check_pair(fr, en)
+        if ok:
+            passed += 1
+            print(f"OK      {rel}")
+        else:
+            failed += 1
+            print(f"DRIFT   {rel}")
+            print(diff)
+    total = passed + failed + orphan
+    print(f"\n{passed}/{total} pairs byte-identical"
+          f" | {failed} drift | {orphan} orphan")
+    return 0 if (failed == 0 and orphan == 0) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lean/tests/test_check_i18n_siblings.py
+++ b/scripts/lean/tests/test_check_i18n_siblings.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Tests for check_i18n_siblings.py (Lean i18n #4980 sibling byte-identity).
+
+Dual-mode: runnable directly (``python scripts/lean/tests/test_check_i18n_siblings.py``)
+or under pytest (auto-collected by scripts-tests.yml on any ``scripts/**`` change).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_i18n_siblings import (  # noqa: E402
+    check_pair,
+    find_en_files,
+    fr_sibling,
+    normalize_body,
+    strip_comments,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONWAY_DIR = (
+    REPO_ROOT
+    / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean" / "conway_lean" / "Conway"
+)
+
+
+def test_strip_comments_removes_block_line_and_docstring():
+    src = (
+        '/-- doc -/\n'
+        'def f := 1 -- trailing comment\n'
+        '/- multi\nline block -/\n'
+        'def g := 2\n'
+    )
+    out = strip_comments(src)
+    assert "doc" not in out
+    assert "trailing comment" not in out
+    assert "multi" not in out and "block" not in out
+    assert "def f := 1" in out
+    assert "def g := 2" in out
+
+
+def test_strip_comments_nested_block():
+    src = "/- outer /- inner -/ still outer -/def h := 3\n"
+    out = strip_comments(src)
+    assert "outer" not in out and "inner" not in out
+    assert "def h := 3" in out
+
+
+def test_strip_comments_preserves_string_with_double_dash():
+    # A "--" inside a string literal must NOT be treated as a line comment.
+    src = 'def s := "a -- b"\ndef t := 4\n'
+    out = strip_comments(src)
+    assert '"a -- b"' in out
+    assert "def t := 4" in out
+
+
+def test_normalize_drops_structural_lines():
+    fr = (
+        "import Mathlib.Data.List.Basic\n"
+        "namespace Conway\n"
+        "def f (n : Nat) := n + 1\n"
+        "end Conway\n"
+    )
+    en = (
+        "import Conway.Foo\n"
+        "namespace Conway_en\n"
+        "open Conway\n"
+        "def f (n : Nat) := n + 1\n"
+        "end Conway_en\n"
+    )
+    assert normalize_body(fr) == normalize_body(en)
+
+
+def test_normalize_ignores_docstring_language():
+    fr = "/-- Additionne un. -/\ndef f (n : Nat) := n + 1\n"
+    en = "/-- Adds one. -/\ndef f (n : Nat) := n + 1\n"
+    assert normalize_body(fr) == normalize_body(en)
+
+
+def test_normalize_preserves_indentation_drift():
+    # Tactic-block indentation is meaningful; a real indentation change must show.
+    a = "theorem t : True := by\n  trivial\n"
+    b = "theorem t : True := by\n    trivial\n"
+    assert normalize_body(a) != normalize_body(b)
+
+
+def test_normalize_collapses_en_suffix_variant():
+    # prefixed-suffix variant (game_theory_lean): EN refers to `_en`-suffixed
+    # entities; body must still compare equal to the FR canonical.
+    fr = "def Efficiency (G : TUGame N) : Prop := G.v = 0\n"
+    en = "def Efficiency (G : TUGame_en N) : Prop := G.v = 0\n"
+    assert normalize_body(fr) == normalize_body(en)
+
+
+def test_normalize_en_suffix_does_not_mask_real_drift():
+    fr = "def f (G : TUGame N) : Nat := 42\n"
+    en = "def f (G : TUGame_en N) : Nat := 43\n"
+    assert normalize_body(fr) != normalize_body(en)
+
+
+def test_check_pair_matching(tmp_path):
+    fr = tmp_path / "Foo.lean"
+    en = tmp_path / "Foo_en.lean"
+    fr.write_text(
+        "/-- Le module français. -/\n"
+        "namespace Conway\n"
+        "def answer : Nat := 42\n"
+        "end Conway\n",
+        encoding="utf-8",
+    )
+    en.write_text(
+        "/-- The English mirror. -/\n"
+        "import Conway.Foo\n"
+        "namespace Conway_en\n"
+        "open Conway\n"
+        "def answer : Nat := 42\n"
+        "end Conway_en\n",
+        encoding="utf-8",
+    )
+    ok, diff = check_pair(fr, en)
+    assert ok, diff
+
+
+def test_check_pair_drift_detected(tmp_path):
+    fr = tmp_path / "Bar.lean"
+    en = tmp_path / "Bar_en.lean"
+    fr.write_text("namespace Conway\ndef answer : Nat := 42\nend Conway\n",
+                  encoding="utf-8")
+    en.write_text("namespace Conway_en\ndef answer : Nat := 43\nend Conway_en\n",
+                  encoding="utf-8")
+    ok, diff = check_pair(fr, en)
+    assert not ok
+    assert "42" in diff and "43" in diff
+
+
+def test_fr_sibling_naming(tmp_path):
+    en = tmp_path / "Widget_en.lean"
+    assert fr_sibling(en).name == "Widget.lean"
+
+
+def test_find_en_files_skips_excluded(tmp_path):
+    good = tmp_path / "Good_en.lean"
+    good.write_text("x", encoding="utf-8")
+    lake = tmp_path / ".lake" / "packages" / "Vendored_en.lean"
+    lake.parent.mkdir(parents=True)
+    lake.write_text("x", encoding="utf-8")
+    found = {p.name for p in find_en_files([tmp_path])}
+    assert "Good_en.lean" in found
+    assert "Vendored_en.lean" not in found
+
+
+def test_real_conway_pairs_are_byte_identical():
+    """The merged conway_lean rollout must stay clean — regression guard."""
+    if not CONWAY_DIR.is_dir():
+        return  # tree not present in this checkout; skip silently
+    en_files = find_en_files([CONWAY_DIR])
+    assert en_files, "expected conway_lean *_en.lean pairs to exist"
+    failures = []
+    for en in en_files:
+        fr = fr_sibling(en)
+        if not fr.exists():
+            failures.append(f"ORPHAN {en.name}")
+            continue
+        ok, diff = check_pair(fr, en)
+        if not ok:
+            failures.append(f"DRIFT {en.name}\n{diff}")
+    assert not failures, "\n".join(failures)
+
+
+def _run_direct() -> int:
+    import tempfile
+
+    passed = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        argcount = fn.__code__.co_argcount
+        try:
+            if argcount == 0:
+                fn()
+            else:
+                with tempfile.TemporaryDirectory() as d:
+                    fn(Path(d))
+            print(f"PASS {name}")
+            passed += 1
+        except AssertionError as exc:
+            print(f"FAIL {name}: {exc}")
+            return 1
+    print(f"\n{passed} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_direct())


### PR DESCRIPTION
## Summary

Reusable checker for the **Lean i18n #4980** sibling convention (ratified 2026-07-04, cf `.claude/rules/code-style.md` §Lean i18n). A French-canonical `Foo.lean` and its English mirror `Foo_en.lean` must differ **only** in docstrings/comments, staying **byte-identical** in the code body modulo the convention's legitimate divergences.

Until now, every FR/EN pair has been proven byte-identical by hand-writing a throwaway `normalize_body()` Python snippet per pair (po-2024 c.515 "13/13", po-2023 c.456 "12/12 defs byte-id", …). This ships that logic once, as a scanner.

`scripts/lean/check_i18n_siblings.py`:
- **Normalizes** a `.lean` source to its comparable body: strip block/line comments + docstrings (nesting-aware, string-literal-safe), drop `import`/`open`/`namespace`/`end` lines and blanks, preserve indentation (tactic blocks are indentation-sensitive).
- **Collapses the `_en` anti-collision suffix** symmetrically, so BOTH validated i18n variants (lesson C565-L1) pass: *reuse-FR-names* (`open <FRnamespace>`, identifiers verbatim — conway_lean) and *prefixed-suffix* (`TUGame` ↔ `TUGame_en` — game_theory_lean).
- **Scans** a file, a directory (recursive), or `--all` (repo-wide, skipping `.lake/`, `_peters/`, vendored, worktrees); prints a unified diff on drift; exit `1` on any body drift or orphan `_en` (an `_en` file whose FR sibling is missing).
- **Stdlib-only**, no Lean compile — that stays `lake build` (cf `lean-merge-discipline.md`). This is a fast *drift* guard, not a compiler.

## Validation

- **22/22** `conway_lean/Conway` pairs (incl. `Life/`) PASS — 0 drift, 0 orphan (regression guard test).
- **Repo-wide `--all`** surfaces **3 real content-drift pairs + 1 orphan**, all in the EN-dominant lakes still on the #4980 backlog:
  - `game_theory_lean/SocialChoice/Arrow_en` — qualifier divergence `_root_.is_strictly_best` (FR) vs `SocialChoice.is_strictly_best` (EN)
  - `game_theory_lean/CooperativeGames/ConeKernel_en` — EN has an extra `lemma separatingFunctional_none_neg` absent from FR
  - `game_theory_lean/StableMarriage/Lattice_en` — FR has `Matching.joinSpouse`/`meetSpouse` defs absent from EN
  - `repeated_games_lean/RepeatedGames_en.lean` — orphan (no `RepeatedGames.lean` FR canonical)
  
  These are **genuine drift** the manual per-pair checks missed at scale, not tool false-positives — surfaced here as a signal for the #4980 backlog, **not fixed in this PR** (reconciling FR/EN drift is Lean work owned by the lake, out of scope for this tooling PR).
- **13 tests** (`scripts/lean/tests/test_check_i18n_siblings.py`) — dual-mode (direct `python …` or pytest); auto-collected by `scripts-tests.yml` on this `scripts/**` change.

## Scope

Adds 2 files, `scripts/**` only. No notebook, no catalogue, no workflow touched. `See #4980`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)