### PR TITLE
fix(ml,#3801): ML-9 PCA redemption on multivariate-subtle anomalies (Prong-B)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
@@ -565,6 +565,166 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5e69db9f-661b-46b3-974a-62ff3bb11fd7",
+   "metadata": {},
+   "source": [
+    "### Redemption : la ou PCA est vraiment indispensable\n",
+    "\n",
+    "Le cas ci-dessus (pic de pression a **8 ecarts-types**) est **unidimensionnel** : un simple seuil sur `Pressure` seul le detecte, et la PCA n'apporte rien de plus (son AUC de 0,85 est meme *inferieure* a ce que donnerait un seuil direct sur la pression). Ou la detection d'anomalies par PCA **brille-t-elle vraiment** ?\n",
+    "\n",
+    "Sur des anomalies **multivariees subtiles** : des points ou **chaque capteur pris isolement est dans la norme**, mais dont la **combinaison** est anormale. Aucun seuil par capteur isole ne les voit ; seul le residu hors-sous-espace de la PCA les isole. C'est precisement la capacite distinctive que la demo principale (et l'[Exercice 3](#Exercice-3-:-Anomalies-subtiles-(limite-de-l'approche-PCA))) ne montrait pas — l'Exercice 3 explorait seulement des **decalages moyens reduits**, qui restent unidimensionnels.\n",
+    "\n",
+    "On reconstruit un jeu ou les trois capteurs sont **physiquement couples** en regime sain : la vibration du palier reflete a la fois la temperature et la pression, `Vibration = 0,4 * Temperature + 0,5 * Pressure`. Les points sains vivent donc sur un **plan 2D** dans l'espace 3D des capteurs ; la troisieme direction (orthogonale au plan) a une **variance quasi nulle** — c'est elle que la PCA de rang 2 laisse de cote. Les **anomalies violent ce couplage** : `Temperature` et `Pressure` restent dans leurs gammes normales, mais la `Vibration` s'ecarte de la relation predite. Ces points sortent du plan sain -> residu eleve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "0f62cba9-e76b-4be5-ad35-4bbfda158f4c",
+   "metadata": {},
+   "execution_count": 11,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Anomalies multivariees subtiles (couplage V=0.4T+0.5P brise) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  AUC PCA rank=2               : 0,945\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  AUC seuil Temperature seul   : 0,464   (|ecart| 0,443)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  AUC seuil Vibration seul      : 0,460   (|ecart| 0,646)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  AUC seuil Pressure seul       : 0,514\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Meilleur seuil univarie       : 0,646\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Avantage PCA                 : +0,299\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Redemption : anomalies MULTIVARIEES subtiles (couplage V=0.4T+0.5P brise) ===\n",
+    "// Regime sain : Vibration = 0.4*Temperature + 0.5*Pressure + bruit (les 3 capteurs\n",
+    "// sont couples -> les points sains vivent sur un plan 2D, PC3 ~ 0).\n",
+    "// Anomalies : T et P dans leurs memes marginales, MAIS Vibration = couplage + rupture.\n",
+    "var trainMv = new List<SensorData>();\n",
+    "var testMvNormal = new List<SensorData>();\n",
+    "for (int i = 0; i < 200; i++) {\n",
+    "    float T = RandUtil.NextGaussian(0f, 2.0f);\n",
+    "    float P = RandUtil.NextGaussian(0f, 0.1f);\n",
+    "    float V = 0.4f * T + 0.5f * P + RandUtil.NextGaussian(0f, 0.05f);\n",
+    "    trainMv.Add(new SensorData { Temperature = T, Pressure = P, Vibration = V });\n",
+    "}\n",
+    "for (int i = 0; i < 120; i++) {\n",
+    "    float T = RandUtil.NextGaussian(0f, 2.0f);\n",
+    "    float P = RandUtil.NextGaussian(0f, 0.1f);\n",
+    "    float V = 0.4f * T + 0.5f * P + RandUtil.NextGaussian(0f, 0.05f);\n",
+    "    testMvNormal.Add(new SensorData { Temperature = T, Pressure = P, Vibration = V });\n",
+    "}\n",
+    "var testMvAnom = new List<SensorData>();\n",
+    "for (int i = 0; i < 40; i++) {\n",
+    "    float T = RandUtil.NextGaussian(0f, 2.0f);                                  // meme marginale que le normal\n",
+    "    float P = RandUtil.NextGaussian(0f, 0.1f);                                  // meme marginale\n",
+    "    float V = 0.4f * T + 0.5f * P + RandUtil.NextGaussian(0f, 0.05f)            // couplage nominal\n",
+    "              + RandUtil.NextGaussian(0f, 1.0f);                                // + RUPTURE (couplage brise)\n",
+    "    testMvAnom.Add(new SensorData { Temperature = T, Pressure = P, Vibration = V, Label = 1.0f });\n",
+    "}\n",
+    "var testMv = testMvNormal.Concat(testMvAnom).ToList();\n",
+    "\n",
+    "// AUC = P(score_anomalie > score_normal) via Mann-Whitney sur le jeu de test.\n",
+    "static double AucMv<T>(IEnumerable<(T score, bool isAnom)> pts) where T : IComparable<T> {\n",
+    "    var a = pts.Where(p => p.isAnom).Select(p => p.score).ToList();\n",
+    "    var n = pts.Where(p => !p.isAnom).Select(p => p.score).ToList();\n",
+    "    if (a.Count == 0 || n.Count == 0) return 0.5;\n",
+    "    double wins = 0;\n",
+    "    foreach (var av in a) foreach (var nv in n) { int c = av.CompareTo(nv); if (c > 0) wins += 1; else if (c == 0) wins += 0.5; }\n",
+    "    return wins / (a.Count * (double)n.Count);\n",
+    "}\n",
+    "\n",
+    "// MEME pipeline que la demo principale : Concatenate -> RandomizedPca(rank=2).\n",
+    "var trainMvDv = mlContext.Data.LoadFromEnumerable(trainMv);\n",
+    "var testMvDv  = mlContext.Data.LoadFromEnumerable(testMv);\n",
+    "var pipeMv = mlContext.Transforms\n",
+    "    .Concatenate(\"Features\", nameof(SensorData.Temperature), nameof(SensorData.Pressure), nameof(SensorData.Vibration))\n",
+    "    .Append(mlContext.AnomalyDetection.Trainers.RandomizedPca(featureColumnName: \"Features\", rank: 2));\n",
+    "var modelMv = pipeMv.Fit(trainMvDv);\n",
+    "var scoredMv = modelMv.Transform(testMvDv);\n",
+    "var scoresMv = scoredMv.GetColumn<float>(\"Score\").ToArray();\n",
+    "var labelsMv = scoredMv.GetColumn<float>(\"Label\").ToArray();\n",
+    "double aucPcaMv = AucMv(scoresMv.Zip(labelsMv, (s, l) => (score: (double)s, isAnom: l >= 0.5f)));\n",
+    "\n",
+    "// Baselines triviales : un seuil par capteur isole (valeur signee, puis |ecart a la moyenne|).\n",
+    "double mT = trainMv.Average(x => x.Temperature);\n",
+    "double mV = trainMv.Average(x => x.Vibration);\n",
+    "double mP = trainMv.Average(x => x.Pressure);\n",
+    "double aucT    = AucMv(testMv.Select(x => (score: (double)x.Temperature, isAnom: x.Label >= 0.5f)));\n",
+    "double aucV    = AucMv(testMv.Select(x => (score: (double)x.Vibration,   isAnom: x.Label >= 0.5f)));\n",
+    "double aucP    = AucMv(testMv.Select(x => (score: (double)x.Pressure,    isAnom: x.Label >= 0.5f)));\n",
+    "double aucAbsT = AucMv(testMv.Select(x => (score: Math.Abs(x.Temperature - mT), isAnom: x.Label >= 0.5f)));\n",
+    "double aucAbsV = AucMv(testMv.Select(x => (score: Math.Abs(x.Vibration - mV),   isAnom: x.Label >= 0.5f)));\n",
+    "double bestUnivar = new[] { aucT, aucV, aucP, aucAbsT, aucAbsV }.Max();\n",
+    "\n",
+    "Console.WriteLine(\"=== Anomalies multivariees subtiles (couplage V=0.4T+0.5P brise) ===\");\n",
+    "Console.WriteLine($\"  AUC PCA rank=2               : {aucPcaMv:F3}\");\n",
+    "Console.WriteLine($\"  AUC seuil Temperature seul   : {aucT:F3}   (|ecart| {aucAbsT:F3})\");\n",
+    "Console.WriteLine($\"  AUC seuil Vibration seul      : {aucV:F3}   (|ecart| {aucAbsV:F3})\");\n",
+    "Console.WriteLine($\"  AUC seuil Pressure seul       : {aucP:F3}\");\n",
+    "Console.WriteLine($\"  Meilleur seuil univarie       : {bestUnivar:F3}\");\n",
+    "Console.WriteLine($\"  Avantage PCA                 : +{aucPcaMv - bestUnivar:F3}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bb3deac-de9f-4acc-b2b4-ee33bc314ff8",
+   "metadata": {},
+   "source": [
+    "### Interpretation : PCA bat tous les seuils univaries\n",
+    "\n",
+    "| Methode | AUC | Lecture |\n",
+    "|---------|-----|---------|\n",
+    "| Seuil `Temperature` seul | ~0,5 | aucun signal (meme marginale que le normal) |\n",
+    "| Seuil `Vibration` seul | ~0,5-0,6 | la rupture est a moyenne nulle : la Vibration drift des deux cotes |\n",
+    "| Seuil `Pressure` seul | ~0,5 | aucun signal |\n",
+    "| **PCA rank=2 (residu hors-plan)** | **~0,95** | **detecte la violation du couplage** |\n",
+    "\n",
+    "**Chaque capteur isole est a peu pres au hasard** (~0,5-0,6), parce que les anomalies ont ete construites avec les *memes distributions marginales* que le regime sain. Pourtant la PCA atteint ~0,95 : elle a appris le **plan de couplage** sain, et les points qui le violent sortent du plan (residu eleve le long de la 3e composante). C'est la capacite que **aucune methode univariee ne peut reproduire** : la detection d'anomalies par PCA est un detecteur de **structure multivariee**, pas de seuils par capteur.\n",
+    "\n",
+    "**Contraste avec la demo principale** : sur le pic de pression a 8 sigma, la PCA etait superflue (un seuil sur `Pressure` suffisait, et battait meme la PCA). Ici, la PCA est le **seul** outil qui marche. Les deux cas ensemble montrent *quand* la PCA est justifiee : non pas sur des pics unidimensionnels qu'un seuil capte, mais sur des anomalies relationnelles que seule la geometrie du sous-espace revelle. C'est le cœur de la [Lakhina et al. (2004)](#References) — detecter les anomalies qui resident dans le sous-espace residual, invisibles feature par feature."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ml9-md-23",
    "metadata": {},
    "source": [
@@ -595,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "ml9-code-25",
    "metadata": {
     "execution": {
@@ -770,7 +930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "ml9-code-28",
    "metadata": {
     "execution": {
@@ -820,7 +980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "ml9-code-30",
    "metadata": {
     "execution": {
@@ -869,7 +1029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "ml9-code-32",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## SOTA Prong-B — `ML-9 Anomaly Detection` : PCA racheté sur anomalies multivariées subtiles (chaque capteur isolé échoue, ~0,5)

`See #3801` (SOTA axe-2 EPIC, **Prong-B** : problème non-trivial qui met le moteur en valeur). Suite de `8905f8845` (BFS-vs-A*), #6701 (MGS-1 Rastrigin), #6702 (Infer-11 polysémique), #6703 (GT-14 refuge), #6706 (Planners-8 RCPSP contention), #6709 (ML-7 MF redemption).

### Defect — la PCA est superflue sur le cas principal (pic unidimensionnel)
La cellule 18 évalue `RandomizedPca(rank=2)` sur des anomalies où `Pressure ~ N(0,8 ; 0,1)` contre un régime normal `N(0 ; 0,1)` — soit **8 écarts-types** sur un seul capteur. La sortie committée :

```
AreaUnderRocCurve (AUC) : 0,8477
```

Un **seuil trivial sur `Pressure` seul** (`Pressure > 0,4`) sépare quasi-parfaitement les deux classes (séparation 8σ) : la PCA n'apporte **rien** — son AUC de 0,85 est même *inférieure* à ce que donnerait un seuil direct. Le notebook le pressent (Exercice 3, cellule 30) mais n'explore que des **décalages moyens réduits** (~1,5σ sur *tous* les capteurs), qui restent unidimensionnels. La **capacité distinctive** de la détection d'anomalies par PCA — isoler des points **marginalement normaux mais conjointement anormaux** (hors du sous-espace appris) — n'est jamais démontrée.

### Fix — appliquer le MÊME moteur à des anomalies relationnelles (couplage brisé)
- **cellules 0-21 byte-identiques** : le diagnostic honnête de la cellule 19 + l'Exercice 3 restent une bonne pédagogie (le pic 8σ *est* un cas où PCA est superflu — ne pas le masquer).
- **nouvelle cellule 22 (markdown)** : explique *pourquoi* PCA est sous-exploitée sur le cas principal, et introduit le scénario où elle est indispensable (anomalies multivariées subtiles).
- **nouvelle cellule 23 (code)** : reconstruit un jeu où les 3 capteurs sont **physiquement couplés** en régime sain (`Vibration = 0,4·Temperature + 0,5·Pressure`) → les points sains vivent sur un **plan 2D**, la 3e direction (orthogonale) a une variance quasi nulle. Les **anomalies violent ce couplage** : `Temperature` et `Pressure` sont tirées des *mêmes marginales* que le régime sain, mais la `Vibration` s'écarte de la relation prédite. On applique le **même** pipeline `Concatenate → RandomizedPca(rank=2)` et compare à la **baseline triviale** (meilleur seuil par capteur isolé).
- **nouvelle cellule 24 (markdown)** : tableau de contraste + interprétation (lien à Lakhina et al. 2004).

### Evidence — la PCA bat enfin tous les seuils univariés
La sortie de la cellule 23 (**exécution réelle** du notebook complet via papermill `--kernel .net-csharp`, RNG `seed:42` à la position correcte) :

```
=== Anomalies multivariees subtiles (couplage V=0.4T+0.5P brise) ===
  AUC PCA rank=2               : 0,945
  AUC seuil Temperature seul   : 0,464   (|ecart| 0,443)
  AUC seuil Vibration seul      : 0,460   (|ecart| 0,646)
  AUC seuil Pressure seul       : 0,514
  Meilleur seuil univarie       : 0,646
  Avantage PCA                 : +0,299
```

**Contraste net** :

| Instance | Type d'anomalie | Meilleur seuil univarie | AUC PCA | Verdict |
|----------|-----------------|------------------------|---------|---------|
| Cas principal (cellule 18) | pic Pressure 8σ (unidimensionnel) | ~1,0 (seuil Pressure) | 0,848 | PCA **superflue** (un seuil bat) |
| Couplage brisé (cellule 23) | multivariée subtile (marginales identiques) | 0,646 | **0,945** | PCA **indispensable** (+0,30) |

Sur le cas principal, **chaque capteur isolé est au hasard** (~0,46-0,51 en signé) parce que les anomalies ont été construites avec les *mêmes distributions marginales* que le régime sain — aucun seuil par capteur ne les voit. Pourtant la PCA atteint 0,945 : elle a appris le **plan de couplage** sain, et les points qui le violent sortent du plan (résidu élevé le long de la 3e composante). C'est précisément la capacité qu'**aucune méthode univariable ne peut reproduire** — la détection d'anomalies par sous-espace residual (Lakhina et al. 2004).

### SOTA verdict : SOTA-OK (vrai moteur PCA sur un vrai cas où il bat toutes les baselines univariées)
La PCA est proprement exercée sur une instance où sa capacité distinctive (résidu hors-sous-espace sur anomalies relationnelles) est **réellement nécessaire et démontrée**. On enrichit le **problème** (passer d'un pic unidimensionnel trivial à des anomalies multivariées subtiles que seule la géométrie du sous-espace révèle), exactement la doctrine Prong-B.

### Validation (real execution)
- **Full notebook re-exec** via `papermill --kernel .net-csharp` (37 cellules, ~36 s, pas de XPlot). `cellule 18` reproduit **exactement** AUC=0,8477 / DetectionRate=0,2250 → `RandomizedPca(seed:42)` déterministe, stabilité confirmée sur 2 runs (PCA 0,944 puis 0,945). La **conclusion est robuste cross-runs** (PCA ~0,94 ≫ meilleur univariable ~0,65).
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`. **C.2** : 0 cellule code à `execution_count` null ; la cellule 23 porte `execution_count: 11` et 7 outputs réels.
- **Surgical splice** : cellules **0-21 byte-identiques** à origin/main (source + outputs + exec_count + metadata, incluant la cellule 18 jouet et sa note pédagogique). Cellules origin 22-33 décalées en **25-36** (source + outputs + metadata byte-identiques ; `execution_count` +1 sur les 4 cellules code décalées = état post-insertion vrai). Seules **22** (md) + **23** (code) + **24** (md) sont nouvelles (+164 lignes). JSON valide, **CRLF = 0**, tous les `id` de cellules présents, aucun leak de chemin/secret dans les nouveaux outputs.

### Scope hygiene
- Catalogue **byte-identique à main**.
- Un sujet (ML-9 PCA redemption Prong-B), un fichier, atomique. Base fresh off `origin/main` (`0 behind / 0 ahead`). Aucune donnée extraite (synthétique, `seed:42`).
- Commentaires FR-first.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
