### PR TITLE
fix(ml,#3801): ML-8 K-Means redemption on multivariate triangle clusters (Prong-B)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
@@ -672,6 +672,151 @@
   },
   {
    "cell_type": "markdown",
+   "id": "622d153e-a605-49f8-8b2c-d329d795934e",
+   "metadata": {},
+   "source": [
+    "### Redemption : la ou K-Means multivarie est vraiment indispensable\n",
+    "\n",
+    "Le jeu principal ci-dessus (3 segments Dormants / Reguliers / VIP) est **presqu'unidimensionnel** : la depense `Monetary` seule (50 / 150 / 500 EUR) separe deja les trois segments. L'[Exercice 3](#Exercice-3-:-Effet-de-la-normalisation-sur-K-Means) le reconnait (« sans normalisation, le clustering reflete surtout la depense »). Sur un tel cas, K-Means n'apporte pas grand-chose qu'un simple seuil sur `Monetary` ne donnerait pas.\n",
+    "\n",
+    "La capacite distinctive de K-Means — **combiner plusieurs features** pour separer des segments qu'aucune feature isolee ne distingue — ne s'exerce que sur un jeu ou chaque feature **prise separement chevauche** les segments. On construit donc trois segments disposes en **triangle** dans le plan (Recency, Frequency) :\n",
+    "\n",
+    "- **jeune-actif** : `Recency` bas, `Frequency` basse,\n",
+    "- **ancien-occasionnel** : `Recency` haut, `Frequency` haute,\n",
+    "- **ancien-frequent** : `Recency` bas, `Frequency` haute.\n",
+    "\n",
+    "Les deux premieres coordonnees se croisent : sur l'axe `Recency` seul, *jeune-actif* et *ancien-frequent* se chevauchent ; sur l'axe `Frequency` seul, *ancien-occasionnel* et *ancien-frequent* se chevauchent. `Monetary` est partage (bruit irrelatif). **Aucune feature isolee ne separe les trois segments** ; seul le plan (Recency, Frequency) le permet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "0f5386b2-c9fc-47c7-b2c2-2ddfc546c7af",
+   "metadata": {},
+   "execution_count": 12,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Segments en triangle (chaque feature 1-D chevauche) ===\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Recency seul (meilleur seuil 1-D)   : 0,720   (jeune-actif & ancien-frequent se chevauchent sur R)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Frequency seul (meilleur seuil 1-D) : 0,733   (ancien-occasionnel & ancien-frequent se chevauchent sur F)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Monetary seul (bruit partage)       : 0,427   (aucun signal)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Meilleure baseline 1 feature         : 0,733\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  K-Means 3D (Recency+Frequency+Mon)  : 0,993\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Avantage K-Means multivarie         : +0,260\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Redemption : 3 segments en TRIANGLE — chaque feature 1-D chevauche ===\n",
+    "// Sur le jeu principal, Monetary seul separait les segments (clustering quasi 1-D).\n",
+    "// Ici, les segments se croisent sur chaque axe isole : seul le plan (R,F) les separe.\n",
+    "var triCustomers = new List<CustomerData>();\n",
+    "var triLabels = new List<int>();\n",
+    "for (int i = 0; i < 50; i++) { triCustomers.Add(new CustomerData { Recency = RandUtil.NextGaussian(30, 9), Frequency = RandUtil.NextGaussian(30, 9), Monetary = RandUtil.NextGaussian(150, 40) }); triLabels.Add(0); } // jeune-actif\n",
+    "for (int i = 0; i < 50; i++) { triCustomers.Add(new CustomerData { Recency = RandUtil.NextGaussian(70, 9), Frequency = RandUtil.NextGaussian(70, 9), Monetary = RandUtil.NextGaussian(150, 40) }); triLabels.Add(1); } // ancien-occasionnel\n",
+    "for (int i = 0; i < 50; i++) { triCustomers.Add(new CustomerData { Recency = RandUtil.NextGaussian(30, 9), Frequency = RandUtil.NextGaussian(70, 9), Monetary = RandUtil.NextGaussian(150, 40) }); triLabels.Add(2); } // ancien-frequent\n",
+    "int[] triTruth = triLabels.ToArray();\n",
+    "\n",
+    "// Exactitude de clustering = meilleur appariement 1-a-1 entre clusters trouves et verite (6 permutations de 3 clusters).\n",
+    "static float ClusterAcc(uint[] pred, int[] truth) {\n",
+    "    var perms = new[]{ new[]{0,1,2}, new[]{0,2,1}, new[]{1,0,2}, new[]{1,2,0}, new[]{2,0,1}, new[]{2,1,0} };\n",
+    "    int n = pred.Length, best = 0;\n",
+    "    foreach (var pm in perms) { int c = 0; for (int i = 0; i < n; i++) if (pm[pred[i] - 1] == truth[i]) c++; best = Math.Max(best, c); }\n",
+    "    return (float)best / n;\n",
+    "}\n",
+    "// Baseline triviale : meilleur seuil 1-D (2 coupures -> 3 bins) sur UNE feature, contre la verite.\n",
+    "static float Best1D(float[] feat, int[] truth) {\n",
+    "    var perms = new[]{ new[]{0,1,2}, new[]{0,2,1}, new[]{1,0,2}, new[]{1,2,0}, new[]{2,0,1}, new[]{2,1,0} };\n",
+    "    float best = 0; var sorted = feat.OrderBy(v => v).ToArray();\n",
+    "    for (int ci = 0; ci < feat.Length; ci += 2) for (int cj = ci + 2; cj < feat.Length; cj += 2) {\n",
+    "        double c1 = sorted[ci], c2 = sorted[cj]; int[] bin = new int[feat.Length];\n",
+    "        for (int i = 0; i < feat.Length; i++) bin[i] = feat[i] <= c1 ? 0 : (feat[i] <= c2 ? 1 : 2);\n",
+    "        foreach (var pm in perms) { int c = 0; for (int i = 0; i < feat.Length; i++) if (pm[bin[i]] == truth[i]) c++; best = Math.Max(best, (float)c / feat.Length); }\n",
+    "    }\n",
+    "    return best;\n",
+    "}\n",
+    "\n",
+    "var triDv = mlContext.Data.LoadFromEnumerable(triCustomers);\n",
+    "var triPipe = mlContext.Transforms\n",
+    "    .Concatenate(\"Features\", nameof(CustomerData.Recency), nameof(CustomerData.Frequency), nameof(CustomerData.Monetary))\n",
+    "    .Append(mlContext.Transforms.NormalizeMinMax(\"Features\"))\n",
+    "    .Append(mlContext.Clustering.Trainers.KMeans(\"Features\", numberOfClusters: 3));\n",
+    "var triModel = triPipe.Fit(triDv);\n",
+    "var triPreds = triModel.Transform(triDv).GetColumn<uint>(\"PredictedLabel\").ToArray();\n",
+    "float accKm = ClusterAcc(triPreds, triTruth);\n",
+    "float accR = Best1D(triCustomers.Select(c => c.Recency).ToArray(), triTruth);\n",
+    "float accF = Best1D(triCustomers.Select(c => c.Frequency).ToArray(), triTruth);\n",
+    "float accM = Best1D(triCustomers.Select(c => c.Monetary).ToArray(), triTruth);\n",
+    "float best1D = Math.Max(accR, Math.Max(accF, accM));\n",
+    "\n",
+    "Console.WriteLine(\"=== Segments en triangle (chaque feature 1-D chevauche) ===\");\n",
+    "Console.WriteLine($\"  Recency seul (meilleur seuil 1-D)   : {accR:F3}   (jeune-actif & ancien-frequent se chevauchent sur R)\");\n",
+    "Console.WriteLine($\"  Frequency seul (meilleur seuil 1-D) : {accF:F3}   (ancien-occasionnel & ancien-frequent se chevauchent sur F)\");\n",
+    "Console.WriteLine($\"  Monetary seul (bruit partage)       : {accM:F3}   (aucun signal)\");\n",
+    "Console.WriteLine($\"  Meilleure baseline 1 feature         : {best1D:F3}\");\n",
+    "Console.WriteLine($\"  K-Means 3D (Recency+Frequency+Mon)  : {accKm:F3}\");\n",
+    "Console.WriteLine($\"  Avantage K-Means multivarie         : +{accKm - best1D:F3}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2044e912-b06f-4aee-a794-0cc1ab1675f1",
+   "metadata": {},
+   "source": [
+    "### Interpretation : K-Means bat tous les seuils univaries\n",
+    "\n",
+    "| Methode | Exactitude | Lecture |\n",
+    "|---------|-----------|---------|\n",
+    "| Seuil `Recency` seul | ~0,70 | separe *ancien-occasionnel* des deux autres, mais *jeune-actif* et *ancien-frequent* se chevauchent sur R |\n",
+    "| Seuil `Frequency` seul | ~0,73 | separe *jeune-actif* des deux autres, mais *ancien-occasionnel* et *ancien-frequent* se chevauchent sur F |\n",
+    "| Seuil `Monetary` seul | ~0,42 | aucun signal (Monetary est partage) |\n",
+    "| **K-Means 3D (R+F+M)** | **~0,97** | **combine les features et retrouve les 3 segments** |\n",
+    "\n",
+    "**Aucune feature isolee** ne depasse ~0,73 : chacune laisse deux segments chevauchants que seuillage 1-D ne peut separer. Pourtant K-Means atteint ~0,97 : en projetant sur les **trois** features simultanement, il exploite le fait que *jeune-actif* et *ancien-frequent* (qui se ressemblent sur `Recency`) se distinguent sur `Frequency`, et *ancien-occasionnel* et *ancien-frequent* (qui se ressemblent sur `Frequency`) se distinguent sur `Recency`. C'est precisement la capacite que **aucun seuil par feature isolee ne peut reproduire** : le clustering multivarie extrait la structure du **plan** (Recency, Frequency), pas celle d'un axe.\n",
+    "\n",
+    "**Contraste avec le jeu principal** : sur Dormants / Reguliers / VIP, `Monetary` seul separait deja tout (clustering quasi unidimensionnel). Ici, aucun axe ne suffit — K-Means est le seul outil qui marche. Les deux cas ensemble montrent *quand* K-Means est justifie : non pas sur des segments qu'un seul indicateur separe, mais sur des structures relationnelles que seule la geometrie multivariee revele."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ml8-md-27",
    "metadata": {},
    "source": [
@@ -690,7 +835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "ml8-code-28",
    "metadata": {
     "execution": {
@@ -745,7 +890,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "ml8-code-30",
    "metadata": {
     "execution": {
@@ -799,7 +944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "ml8-code-32",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## SOTA Prong-B — `ML-8 Clustering` : K-Means multivarié racheté sur segments en triangle (chaque feature 1-D chevauche)

`See #3801` (SOTA axe-2 EPIC, **Prong-B** : problème non-trivial qui met le moteur en valeur). Suite de `8905f8845` (BFS-vs-A*), #6701 (MGS-1 Rastrigin), #6702 (Infer-11 polysémique), #6703 (GT-14 refuge), #6706 (Planners-8 RCPSP contention), #6709 (ML-7 MF redemption), #6714 (ML-9 PCA redemption).

### Defect — K-Means est superflu sur les segments Monetary-driven
La cellule 18 évalue K-Means (K=3) sur 3 segments RFM : Dormants (Monetary ~50), Réguliers (~150), VIP (~500). La sortie committée :

```
AverageDistance : 0,0209
DaviesBouldinIndex : 0,394
```

Un **seuil trivial sur `Monetary` seul** (50 / 150 / 500 ≈ 5σ d'écart) sépare déjà parfaitement les trois segments. Le notebook l'avoue lui-même (Exercice 3, cellule 30) : *« Monetary (50..500 EUR) domine totalement Recency et Frequency ; sans normalisation, le clustering reflète surtout la dépense »*. Sur un tel cas quasi-unidimensionnel, K-Means n'apporte rien qu'un seuil sur une feature ne donnerait. La **capacité distinctive** de K-Means — combiner plusieurs features pour séparer des segments qu'aucune feature isolée ne distingue — n'est jamais exercée.

### Fix — appliquer le MÊME moteur à des segments en triangle (chaque axe 1-D chevauche)
- **cellules 0-25 byte-identiques** : la démo principale (métriques Davies-Bouldin, méthode du coude, prédiction) + les 3 exercices (choix de K, silhouette, normalisation) restent une bonne pédagogie sur le cas propre.
- **nouvelle cellule 26 (markdown)** : explique pourquoi K-Means est sous-exploité sur le cas Monetary-driven, et introduit le scénario multivarié (segments en triangle).
- **nouvelle cellule 27 (code)** : génère 3 segments disposés en **triangle** dans le plan (Recency, Frequency) — *jeune-actif* (R bas, F basse), *ancien-occasionnel* (R haut, F haute), *ancien-frequent* (R bas, F haute) — avec `Monetary` partagé (bruit irrélevant). Applique le **même** pipeline `Concatenate → NormalizeMinMax → KMeans(K=3)` et compare l'exactitude du clustering à la **baseline triviale** (meilleur seuil 1-D sur une seule feature).
- **nouvelle cellule 28 (markdown)** : tableau de contraste + interprétation.

### Evidence — K-Means bat enfin tous les seuils univariés
La sortie de la cellule 27 (**exécution réelle** du notebook complet via papermill `--kernel .net-csharp`, RNG `seed:42`) :

```
=== Segments en triangle (chaque feature 1-D chevauche) ===
  Recency seul (meilleur seuil 1-D)   : 0,720   (jeune-actif & ancien-frequent se chevauchent sur R)
  Frequency seul (meilleur seuil 1-D) : 0,733   (ancien-occasionnel & ancien-frequent se chevauchent sur F)
  Monetary seul (bruit partage)       : 0,427   (aucun signal)
  Meilleure baseline 1 feature        : 0,733
  K-Means 3D (Recency+Frequency+Mon) : 0,993
  Avantage K-Means multivarie        : +0,260
```

**Contraste net** :

| Instance | Structure | Meilleur seuil 1-D | K-Means 3D | Verdict |
|----------|-----------|--------------------|-----------:|---------|
| Cas principal (cellule 18) | Monetary-driven (5σ) | ~1,0 (seuil Monetary) | 0,394 (Davies-Bouldin) | K-Means **superflu** |
| Triangle (cellule 27) | chaque feature chevauche | 0,733 | **0,993** | K-Means **indispensable** (+0,26) |

Sur les segments en triangle, **chaque feature isolée plafonne à ~0,73** : `Recency` sépare *ancien-occ.* des deux autres mais laisse *jeune-actif* et *ancien-freq.* chevauchants ; `Frequency` sépare *jeune-actif* mais laisse *ancien-occ.* et *ancien-freq.* chevauchants ; `Monetary` n'a aucun signal (partagé). Pourtant K-Means atteint 0,993 : en projetant sur les **trois** features, il exploite le fait que les segments qui se ressemblent sur un axe se distinguent sur l'autre. C'est la capacité qu'**aucun seuil par feature isolée ne peut reproduire** — le clustering multivarié extrait la structure du **plan** (Recency, Frequency), pas d'un axe.

### SOTA verdict : SOTA-OK (vrai moteur K-Means sur un vrai cas multivarié où il bat les baselines univariées)
K-Means est proprement exercé sur une instance où sa capacité distinctive (combinaison multivariée de features pour séparer des segments qu'aucune feature isolée ne distingue) est **réellement nécessaire et démontrée**. On enrichit le **problème** (passer de segments 1-D-séparables à une structure en triangle exigeant le plan 2D), exactement la doctrine Prong-B.

### Validation (real execution)
- **Full notebook re-exec** via `papermill --kernel .net-csharp` (37 cellules, ~38 s, pas de XPlot). `cellule 18` reproduit **exactement** AverageDistance=0,0209 / DaviesBouldin=0,394 → déterministe `seed:42`.
- **C.1** : 0 `raise NotImplementedError`/`assert False`/`1/0`. **C.2** : 0 cellule code à `execution_count` null ; la cellule 27 porte `execution_count: 12` et 7 outputs réels.
- **Surgical splice** : cellules **0-25 byte-identiques** à origin/main (source + outputs + exec_count + metadata, incluant la cellule 18 principale, le sweep coude et la prédiction). Cellules origin 26-33 décalées en **29-36** (source + outputs + metadata byte-identiques ; `execution_count` +1 sur les 3 cellules stub d'exercice = état post-insertion vrai). Seules **26** (md) + **27** (code) + **28** (md) sont nouvelles (+148 lignes). JSON valide, **CRLF = 0**, tous les `id` de cellules présents, aucun leak de chemin/secret dans les nouveaux outputs.

### Scope hygiene
- Catalogue **byte-identique à main**.
- Un sujet (ML-8 K-Means redemption Prong-B), un fichier, atomique. Base fresh off `origin/main` (`0 behind / 0 ahead`). Aucune donnée extraite (synthétique, `seed:42`).
- Commentaires FR-first.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
