### PR TITLE
fix(lean,#4980): SocialChoice/Arrow_en qualifier drift — _root_.is_strictly_best (FR canonical alignment)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/Arrow_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/SocialChoice/Arrow_en.lean
@@ -105,8 +105,8 @@ lemma is_extremal.is_strictly_best {R : σ → σ → Prop} {b : σ} {X : Finset
   | Or.inr hworst => absurd hworst h
 
 lemma is_extremal.is_strictly_worst {R : σ → σ → Prop} {b : σ} {X : Finset σ}
-    (hextr : is_extremal R b X) (h : ¬SocialChoice_en.is_strictly_best R b X) :
-    SocialChoice_en.is_strictly_worst R b X :=
+    (hextr : is_extremal R b X) (h : ¬_root_.is_strictly_best R b X) :
+    _root_.is_strictly_worst R b X :=
   match hextr with
   | Or.inl hbest => absurd hbest h
   | Or.inr hworst => hworst


### PR DESCRIPTION
## i18n drift fix — `game_theory_lean/SocialChoice/Arrow_en.lean` qualifier divergence (FR canonical alignment)

`See #4980` (EPIC i18n, axe-1). Grain from **ai-01 drift audit** (issuecomment-4983575301) posted this cycle: `check_i18n_siblings.py` (#6711) found `Arrow_en.lean` qualifier drift vs the FR canonical `Arrow.lean`.

### The drift
| Line | FR canonical (`Arrow.lean`) | EN mirror (`Arrow_en.lean`) before |
|------|------------------------------|-------------------------------------|
| L52-53 | `_root_.is_strictly_best` / `_root_.is_strictly_worst` | `SocialChoice_en.is_strictly_best` / `SocialChoice_en.is_strictly_worst` |

Both qualifiers resolve the **same top-level definition** (`is_strictly_best` is defined at top-level in both files, before `namespace SocialChoice`/`SocialChoice_en`). They are semantically equivalent — but the FR canonical convention (#4980, ratified 2026-07-04) is `_root_.` for top-level defs, and consistency between siblings is the goal of the checker (#6711).

### Direction: FR canonical
Align EN to FR → use `_root_.is_strictly_best/worst`. Surgical `+2/-2` (L108-109 only — the EN lemma `is_extremal.is_strictly_worst` hypothesis/conclusion). Namespace body otherwise byte-identical to FR modulo docstrings (verified by checker below).

### Acceptance (per ai-01 audit)
1. **`check_i18n_siblings.py` PASS** ✓ firsthand (worktree):
   ```
   OK      Arrow_en.lean
   1/1 pairs byte-identical | 0 drift | 0 orphan
   ```
2. **`lake build` SUCCESS** → gate = Lean CI `game_theory_lean` (push triggers CI; cold-build ~8min incompatible with local cron, cf known structural blocker — CI is the authoritative gate, as for #6707/#6710/#6712). `_root_.` is a valid top-level resolver (used identically in the FR canonical that already builds green), so no name-resolution risk.

### Scope hygiene
- **1 file**, `+2/-2`, atomic (R3 << 3000L). `See #4980` (epic, partial — 1 of 4 drifts in the audit; 3 remain: StableMarriage/Lattice_en, CooperativeGames/ConeKernel_en, repeated_games/RepeatedGames_en orphan).
- **LF-only** (CR=0, verified byte-level). Catalogue byte-identical (CI-guarded).
- **Context-ownership**: po-2026 diagnosed the namespace-qualifier trap family on FreeWillTheorem (c.457 → #6705 MERGED). Same class of subtle Lean namespace-resolution issue, here as a pure qualifier alignment.

Co-Authored-By: Claude <noreply@anthropic.com>
