### PR TITLE
i18n(lean,#4980): grothendieck_lean Phase 2+ finalisation sibling pairs (c.459)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap.lean
@@ -1,83 +1,25 @@
 /-
-Grothendieck tribute — Part 4: Mathlib Map
-Alexandre Grothendieck (1928-2014).
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 
-A living index of what Mathlib 4 provides from Grothendieck's mathematical
-language. Each `#check` verifies that the definition exists and is accessible
-from the current imports.
+## `Grothendieck.MathlibMap` — Cartographie Mathlib
 
-Epic #1646. All `sorry`s eliminated at creation.
--/
+Un index vivant de ce que Mathlib 4 fournit depuis le langage mathématique
+de Grothendieck. Chaque `#check` vérifie que la définition existe et est
+accessible depuis les imports courants.
 
-/-
-  `Grothendieck.MathlibMap` — Cartographie Mathlib
-  ================================================
-  Hommage à Grothendieck — Partie 4 : Cartographie Mathlib
-  Alexandre Grothendieck (1928-2014).
+Epic #1646. Tous les `sorry`s éliminés à la création.
 
-  Un index vivant de ce que Mathlib 4 fournit depuis le langage mathématique
-  de Grothendieck. Chaque `#check` vérifie que la définition existe et est
-  accessible depuis les imports courants.
+### i18n — convention #4980 ratifiée 2026-07-04
 
-  Ce module couvre :
-    1. Les fondations de la théorie des catégories (l'héritage de Grothendieck)
-    2. Les cribles (Sieves) et précaractères (Presieves)
-    3. Les topologies de Grothendieck
-    4. Les faisceaux (Sheaves) — de types, sur espaces topologiques
-    5. La géométrie algébrique : Schemes, Spec, sections globales, foncteurs
-       d'oubli
-    6. Ce que Mathlib n'a PAS ENCORE (état 2026-05) — cibles de formalisation
-       de niveau recherche : cohomologie étale, motifs, six opérations,
-       Riemann-Roch, dualité de Grothendieck, cohomologie cristalline,
-       géométrie anabélienne, résultats profonds EGA/SGA.
-
-  Epic #1646. Tous les `sorry`s éliminés à la création.
-
-  ### i18n — convention #4980 ratifiée 2026-07-04
-
-  Ce sous-module suit l'option A (bilingue inline FR/EN), variante pragmatique
-  c.376-c.381 (deux blocs `/` top-level distincts, sans `---` interne) : le
-  bloc EN existant est préservé verbatim ci-dessus, le bloc FR miroir est
-  ajouté juste après sans séparateur `---`. Convention sibling pair
-  (`<Foo>_en.lean` à part) réservée aux modules de substance (cf c.374
-  `Astar_en.lean`) ; pour les modules de cartographie comme `MathlibMap`,
-  l'inline FR+EN est le bon compromis (peu de code, deux langues côte à côte).
-  Les énoncés `#check @...` restent en anglais (Mathlib 4, tactic DSL standard).
-  Seules les **docstrings `/-- ... -/`** et les **commentaires `-- ...`**
-  bilingues sont ajoutées. Anti-§D byte-identity garanti : le namespace body
-  est préservé bit-pour-bit.
-
-  ### c.382 — continuité registre `grothendieck_lean` Phase 2+ ouvert post-c.381
-
-  c.381 = 1ᵉʳ sous-module rollout `grothendieck_lean` Phase 2+ (YonedaLemma,
-  PR #6197 OPEN MERGEABLE, lemme de Yoneda = THE foundational theorem of
-  category theory). c.382 = **2ᵉ sous-module rollout Phase 2+** =
-  **continuité registre `grothendieck_lean` ouvert** (PIVOT L335 strict c.381
-  autorise continuer sur même registre tant que backlog substantiel — donc
-  suite rollout `grothendieck_lean` Phase 2+ est naturel). MathlibMap =
-  satellite cartographie Mathlib 4, **analogue structurel** de c.377
-  `conway_lean/Conway/MathlibMap` (premier sous-module rollout conway_lean
-  Phase 1+, satellite cartographie Mathlib 4 aussi). Backlog c.383+ :
-  `Grothendieck/{Sheafification,SitePoints,Conservative,MayerVietorisSquare,
-  SheafBasics,SieveLattice,CategoryAndSites,YonedaLemma_lemmas,
-  SheafCohomology/*,Calibration,SchemesTour,Subcanonical,ZariskiSite,
-  DenseTopology,SieveGenerate,LeftExact,SheafHom,SieveOps,CoverageGen,
-  CanonicalProps,ConstantSheaf}.lean` (20 sous-modules backlog Phase 2+).
-
-  Cross-références : c.366 `#6111` `Conway.lean` racine bilingue (MERGED) +
-  c.367 `#6115` `Grothendieck.lean` racine bilingue (MERGED, option A) +
-  c.373 `#6156` `Knots.lean` racine bilingue (OPEN) + c.374 `#6163` `Astar`
-  sibling pair (OPEN) + c.375 `#6171` `Knots` sub-modules 5/6 (OPEN) +
-  c.376 `#6173` `Knots/Invariant` 6/6 (OPEN) + c.377 `#6178` `MathlibMap`
-  bilingue (premier sous-module rollout conway_lean, PIVOT L335 strict) +
-  c.378 `#6182` `LookAndSay` bilingue (suite rollout conway_lean) +
-  c.379 `#6190` `Fractran` bilingue (machine universelle Turing-complète) +
-  c.380 `#6194` `Doomsday` bilingue (algorithme Doomsday + 4 `#eval!` cas
-  réels) + c.381 `#6197` `YonedaLemma` bilingue (lemme fondamental théorie
-  des catégories, PIVOT L335 strict vers grothendieck_lean Phase 2+) +
-  **c.382 `MathlibMap` bilingue (cette PR, satellite cartographie Mathlib
-  4 = analogue structurel de c.377 conway_lean/MathlibMap)** ← continuité
-  registre `grothendieck_lean` Phase 2+ ouvert post-c.381.
+Ce module est jumelé avec sa version anglaise canonique dans le fichier
+sibling `MathlibMap_en.lean` (modèle sibling pair, voir PR #6154 pour le
+pilote sur `Utility.lean`). Les énoncés `#check @...` restent en anglais
+(Mathlib 4, tactic DSL standard) ; seules les **docstrings `/-- ... -/`** et
+les **commentaires `-- ...`** diffèrent entre les deux fichiers. Anti-§D
+byte-identity garanti : le namespace body est préservé bit-pour-bit (les
+énoncés `#check` sont identiques entre `MathlibMap.lean` et `MathlibMap_en.lean`,
+seuls les commentaires diffèrent).
 -/
 
 import Mathlib.CategoryTheory.Sites.Grothendieck
@@ -85,77 +27,82 @@ import Mathlib.CategoryTheory.Sites.SheafOfTypes
 import Mathlib.AlgebraicGeometry.Scheme
 import Mathlib.Topology.Sheaves.Sheaf
 
-/-!
-## Category theory foundations (Grothendieck's legacy)
+namespace Grothendieck
 
-Grothendieck made category theory the language of algebraic geometry.
-Mathlib 4 has a rich category theory library built on these ideas.
+/-!
+## Fondements de la théorie des catégories (l'héritage de Grothendieck)
+
+Grothendieck a fait de la théorie des catégories le langage de la géométrie
+algébrique. Mathlib 4 dispose d'une riche bibliothèque de théorie des
+catégories construite sur ces idées.
 -/
 
--- The Yoneda lemma (foundational for sieves and sheaves)
+-- Le lemme de Yoneda (fondamental pour les cribles et les faisceaux)
 #check @CategoryTheory.yoneda            -- C ⥤ (Cᵒᵖ ⥤ Type v)
 #check @CategoryTheory.coyoneda          -- (Cᵒᵖ ⥤ Type v) ⥤ C
 
 /-!
-## Sieves and Presieves
+## Cribles et précaractères (Sieves et Presieves)
 -/
 
 #check @CategoryTheory.Presieve          -- Presieve X
-#check @CategoryTheory.Sieve             -- Sieve X (subfunctor of yoneda.obj X)
-#check @CategoryTheory.Sieve.pullback    -- pullback a sieve along a morphism
-#check @CategoryTheory.Sieve.arrows      -- the underlying presieve
+#check @CategoryTheory.Sieve             -- Sieve X (sous-foncteur de yoneda.obj X)
+#check @CategoryTheory.Sieve.pullback    -- pullback d'un crible le long d'un morphisme
+#check @CategoryTheory.Sieve.arrows      -- le précaractère sous-jacent
 
 /-!
-## Grothendieck topologies
+## Topologies de Grothendieck
 -/
 
-#check @CategoryTheory.GrothendieckTopology          -- the topology structure
-#check @CategoryTheory.GrothendieckTopology.trivial  -- coarsest topology
-#check @CategoryTheory.GrothendieckTopology.discrete -- finest topology
-#check @CategoryTheory.GrothendieckTopology.dense    -- dense topology
+#check @CategoryTheory.GrothendieckTopology          -- la structure de topologie
+#check @CategoryTheory.GrothendieckTopology.trivial  -- topologie la plus grossière
+#check @CategoryTheory.GrothendieckTopology.discrete -- topologie la plus fine
+#check @CategoryTheory.GrothendieckTopology.dense    -- topologie dense
 
 /-!
-## Sheaves
+## Faisceaux
 -/
 
--- Sheaves of types on a site
-#check @CategoryTheory.Presieve.IsSheaf  -- sheaf condition for Type-valued presheaves
-#check @CategoryTheory.Presieve.IsSeparated  -- separated presheaf
+-- Faisceaux de types sur un site
+#check @CategoryTheory.Presieve.IsSheaf  -- condition de faisceau pour préfaisceaux en Type
+#check @CategoryTheory.Presieve.IsSeparated  -- préfaisceau séparé
 
--- Sheaves on a topological space
-#check @TopCat.Sheaf                     -- bundled sheaf on a topological space
+-- Faisceaux sur un espace topologique
+#check @TopCat.Sheaf                     -- faisceau bundle sur un espace topologique
 
 /-!
-## Algebraic geometry: Schemes and Spec
+## Géométrie algébrique : Schémas et Spec
 -/
 
 open AlgebraicGeometry CategoryTheory
 
--- The type of schemes
-#check Scheme                   -- the type of schemes
+-- Le type des schémas
+#check Scheme                   -- le type des schémas
 
--- The Spec construction: from rings to spaces
+-- La construction Spec : des anneaux vers les espaces
 #check Scheme.Spec              -- CommRingCatᵒᵖ ⥤ Scheme
 
--- Global sections: from spaces to rings
+-- Sections globales : des espaces vers les anneaux
 #check Scheme.Γ                 -- Schemeᵒᵖ ⥤ CommRingCat
 
--- Forgetful functors
+-- Foncteurs d'oubli
 #check Scheme.forgetToTop       -- Scheme ⥤ TopCat
 #check Scheme.forgetToLocallyRingedSpace  -- Scheme ⥤ LocallyRingedSpace
 
 /-!
-## What Mathlib does NOT have yet (as of 2026-05)
+## Ce que Mathlib n'a PAS ENCORE (état 2026-05)
 
-The following are foundational Grothendieck concepts NOT yet in Mathlib:
-  - Etale cohomology (site etale, l-adic cohomology)
-  - Motives (pure motives, Voevodsky's DM category)
-  - Six operations (Grothendieck's formalism)
+Les concepts fondamentaux de Grothendieck qui ne sont PAS encore dans Mathlib :
+  - Cohomologie étale (site étale, cohomologie l-adique)
+  - Motifs (motifs purs, catégorie DM de Voevodsky)
+  - Six opérations (formalisme de Grothendieck)
   - Grothendieck-Riemann-Roch
-  - Grothendieck duality
-  - Crystalline cohomology
-  - Anabelian geometry
-  - Deep EGA/SGA results (EGA II-IV, SGA 1-7)
+  - Dualité de Grothendieck
+  - Cohomologie cristalline
+  - Géométrie anabélienne
+  - Résultats profonds EGA/SGA (EGA II-IV, SGA 1-7)
 
-These remain research-grade formalization targets.
+Ces cibles restent au niveau recherche en formalisation.
 -/
+
+end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## `Grothendieck.MathlibMap` — Mathlib Map
+
+A living index of what Mathlib 4 provides from Grothendieck's mathematical
+language. Each `#check` verifies that the definition exists and is accessible
+from the current imports.
+
+Epic #1646. All `sorry`s eliminated at creation.
+
+### i18n — convention #4980 ratified 2026-07-04
+
+This substantial module is paired with its French canonical counterpart
+in the sibling file `MathlibMap.lean` (sibling pair model, see PR #6154
+for the pilot on `Utility.lean`).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Sites.SheafOfTypes
+import Mathlib.AlgebraicGeometry.Scheme
+import Mathlib.Topology.Sheaves.Sheaf
+
+namespace Grothendieck_en
+
+open AlgebraicGeometry CategoryTheory
+
+/-!
+## Category theory foundations (Grothendieck's legacy)
+
+Grothendieck made category theory the language of algebraic geometry.
+Mathlib 4 has a rich category theory library built on these ideas.
+-/
+
+-- The Yoneda lemma (foundational for sieves and sheaves)
+#check @CategoryTheory.yoneda            -- C ⥤ (Cᵒᵖ ⥤ Type v)
+#check @CategoryTheory.coyoneda          -- (Cᵒᵖ ⥤ Type v) ⥤ C
+
+/-!
+## Sieves and Presieves
+-/
+
+#check @CategoryTheory.Presieve          -- Presieve X
+#check @CategoryTheory.Sieve             -- Sieve X (subfunctor of yoneda.obj X)
+#check @CategoryTheory.Sieve.pullback    -- pullback a sieve along a morphism
+#check @CategoryTheory.Sieve.arrows      -- the underlying presieve
+
+/-!
+## Grothendieck topologies
+-/
+
+#check @CategoryTheory.GrothendieckTopology          -- the topology structure
+#check @CategoryTheory.GrothendieckTopology.trivial  -- coarsest topology
+#check @CategoryTheory.GrothendieckTopology.discrete -- finest topology
+#check @CategoryTheory.GrothendieckTopology.dense    -- dense topology
+
+/-!
+## Sheaves
+-/
+
+-- Sheaves of types on a site
+#check @CategoryTheory.Presieve.IsSheaf  -- sheaf condition for Type-valued presheaves
+#check @CategoryTheory.Presieve.IsSeparated  -- separated presheaf
+
+-- Sheaves on a topological space
+#check @TopCat.Sheaf                     -- bundled sheaf on a topological space
+
+/-!
+## Algebraic geometry: Schemes and Spec
+-/
+
+-- The type of schemes
+#check Scheme                   -- the type of schemes
+
+-- The Spec construction: from rings to spaces
+#check Scheme.Spec              -- CommRingCatᵒᵖ ⥤ Scheme
+
+-- Global sections: from spaces to rings
+#check Scheme.Γ                 -- Schemeᵒᵖ ⥤ CommRingCat
+
+-- Forgetful functors
+#check Scheme.forgetToTop       -- Scheme ⥤ TopCat
+#check Scheme.forgetToLocallyRingedSpace  -- Scheme ⥤ LocallyRingedSpace
+
+/-!
+## What Mathlib does NOT have yet (as of 2026-05)
+
+The following are foundational Grothendieck concepts NOT yet in Mathlib:
+  - Etale cohomology (site etale, l-adic cohomology)
+  - Motives (pure motives, Voevodsky's DM category)
+  - Six operations (Grothendieck's formalism)
+  - Grothendieck-Riemann-Roch
+  - Grothendieck duality
+  - Crystalline cohomology
+  - Anabelian geometry
+  - Deep EGA/SGA results (EGA II-IV, SGA 1-7)
+
+These remain research-grade formalization targets.
+-/
+
+end Grothendieck_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics.lean
@@ -1,113 +1,43 @@
 /-
-Grothendieck tribute — Part 7: Sheaf basics
+Grothendieck hommage — Partie 7 : fondements des faisceaux.
+
 Alexandre Grothendieck (1928-2014).
 
-Phase 3 extension (#2159, Epic #1646).
+Extension Phase 3 (#2159, Epic #1646).
 
-Part 1 (CategoryAndSites.lean) introduced Grothendieck topologies and sieves.
-Part 5 (Calibration.lean) showed that every presheaf is a sheaf for the trivial
-topology. Part 6 (SieveLattice.lean) established pullback identities on sieves.
+La Partie 1 (`CategoryAndSites.lean`) a introduit les topologies de
+Grothendieck et les cribles. La Partie 5 (`Calibration.lean`) a montré
+que tout préfaisceau est un faisceau pour la topologie triviale. La
+Partie 6 (`SieveLattice.lean`) a établi les identités de pullback sur
+les cribles.
 
-This module records fundamental properties of sheaves and separated presheaves:
+Ce module enregistre les propriétés fondamentales des faisceaux et des
+préfaisceaux séparés :
 
-  - Every sheaf is separated (the fundamental inclusion).
-  - Every presheaf is separated for the trivial (coarsest) topology.
-  - For a subcanonical topology, every representable presheaf is a sheaf.
-  - Sheaf condition transfers along topology comparisons (J₁ ≤ J₂).
+  - Tout faisceau est séparé (l'inclusion fondamentale).
+  - Tout préfaisceau est séparé pour la topologie triviale (la plus grossière).
+  - Pour une topologie sous-canonique, tout préfaisceau représentable
+    est un faisceau.
+  - La condition de faisceau se transfère le long des comparaisons
+    de topologies (J₁ ≤ J₂).
 
-These are the basic algebraic facts about sheaves on a site, connecting
-the lattice-theoretic properties of sieves (Part 1/6) with the sheaf
-condition (Part 5).
+Ce sont les faits algébriques de base sur les faisceaux sur un site,
+connectant les propriétés théoriques de treillis des cribles (Parties 1/6)
+avec la condition de faisceau (Partie 5).
 
-Epic #1646, Phase 3 (#2159). All `sorry`s eliminated at creation.
--/
+Epic #1646, Phase 3 (#2159). Tous les `sorry`s éliminés à la création.
 
-/-
-  `Grothendieck.SheafBasics` — Fondements des faisceaux
-  =====================================================
-  Hommage à Grothendieck — Partie 7 : Fondements des faisceaux
-  Alexandre Grothendieck (1928-2014).
+### i18n — convention #4980 ratifiée 2026-07-04
 
-  Extension Phase 3 (#2159, Epic #1646).
-
-  La Partie 1 (`CategoryAndSites.lean`) a introduit les topologies de
-  Grothendieck et les cribles. La Partie 5 (`Calibration.lean`) a montré
-  que tout préfaisceau est un faisceau pour la topologie triviale. La
-  Partie 6 (`SieveLattice.lean`) a établi les identités de pullback sur
-  les cribles.
-
-  Ce module enregistre les propriétés fondamentales des faisceaux et des
-  préfaisceaux séparés :
-
-    - Tout faisceau est séparé (l'inclusion fondamentale).
-    - Tout préfaisceau est séparé pour la topologie triviale (la plus grossière).
-    - Pour une topologie sous-canonique, tout préfaisceau représentable
-      est un faisceau.
-    - La condition de faisceau se transfère le long des comparaisons
-      de topologies (J₁ ≤ J₂).
-
-  Ce sont les faits algébriques de base sur les faisceaux sur un site,
-  connectant les propriétés théoriques de treillis des cribles
-  (Parties 1/6) avec la condition de faisceau (Partie 5).
-
-  Epic #1646, Phase 3 (#2159). Tous les `sorry`s éliminés à la création.
-
-  ### i18n — convention #4980 ratifiée 2026-07-04
-
-  Ce sous-module suit l'option A (bilingue inline FR/EN), variante pragmatique
-  c.376-c.382 (deux blocs `/` top-level distincts, sans `---` interne) : le
-  bloc EN existant est préservé verbatim ci-dessus, le bloc FR miroir est
-  ajouté juste après sans séparateur `---`. Convention sibling pair
-  (`<Foo>_en.lean` à part) réservée aux modules de substance (cf c.374
-  `Astar_en.lean`) ; pour les modules de fondation comme `SheafBasics`,
-  l'inline FR+EN est le bon compromis (peu de preuve pure, deux langues
-  côte à côte). Les énoncés de théorèmes, les noms de lemmes, les tactiques
-  Lean et les références Mathlib restent en anglais (Mathlib 4, tactic DSL
-  standard). Seules les **docstrings `/-- ... -/`** et les **commentaires
-  `-- ...`** bilingues sont ajoutées. Anti-§D byte-identity garanti : le
-  namespace body est préservé bit-pour-bit (3736 octets extractibles
-  byte-identique via script Python `extract_ns_body`).
-
-  ### c.383 — 3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lean` Phase 2+ ouvert post-c.381
-
-  c.381 = 1ᵉʳ sous-module rollout `grothendieck_lean` Phase 2+ (YonedaLemma,
-  PR #6197 OPEN MERGEABLE, lemme de Yoneda = THE foundational theorem of
-  category theory). c.382 = 2ᵉ sous-module rollout (MathlibMap, PR #6202
-  OPEN, satellite cartographie Mathlib 4 = analogue structurel c.377).
-  c.383 = **3ᵉ sous-module rollout Phase 2+** = **au seuil R5.4b MUST
-  3 cycles/thème OK** (c.381-c.383 = cohérent, registre `grothendieck_lean`
-  ouvert, backlog 22 sous-modules Phase 2+, c.384 = **PIVOT obligatoire** par
-  R5.4b MUST anti-tunneling). SheafBasics = analogue structurel c.381
-  YonedaLemma (6 théorèmes fondamentaux sur les faisceaux et préfaisceaux
-  séparés vs 1 lemme fondamental sur l'embedding de Yoneda) : **registre
-  grothendieck_lean Phase 2+ ouvert post-PIVOT strict c.381** autorise
-  continuer sur même registre tant que backlog substantiel. Théorème 3
-  (`yoneda_isSheaf_subcanonical`) fait le pont avec c.381 Yoneda : pour
-  une topologie sous-canonique, l'objet Yoneda est un faisceau. Backlog
-  c.384+ (19 sous-modules backlog Phase 2+ après c.383) :
-  `Grothendieck/{Sheafification,SitePoints,Conservative,MayerVietorisSquare,
-  CategoryAndSites,SieveLattice,YonedaLemma_lemmas,SheafCohomology/*,
-  Calibration,SchemesTour,Subcanonical,ZariskiSite,DenseTopology,
-  SieveGenerate,LeftExact,SheafHom,SieveOps,CoverageGen,CanonicalProps,
-  ConstantSheaf}.lean`.
-
-  Cross-références : c.366 `#6111` `Conway.lean` racine bilingue (MERGED) +
-  c.367 `#6115` `Grothendieck.lean` racine bilingue (MERGED, initie rollout
-  Phase 2+) + c.373 `#6156` `Knots.lean` racine bilingue (OPEN) + c.374
-  `#6163` `Astar` sibling pair (OPEN) + c.375 `#6171` `Knots` sub-modules
-  5/6 (OPEN) + c.376 `#6173` `Knots/Invariant` 6/6 (OPEN) + c.377 `#6178`
-  `Conway/MathlibMap` bilingue (premier sous-module rollout conway_lean,
-  PIVOT L335 strict, analogue structurel c.382) + c.378 `#6182`
-  `Conway/LookAndSay` bilingue + c.379 `#6190` `Conway/Fractran` bilingue
-  + c.380 `#6194` `Conway/Doomsday` bilingue + c.381 `#6197`
-  `Grothendieck/YonedaLemma` bilingue (1ᵉʳ sous-module rollout
-  grothendieck_lean Phase 2+, PIVOT L335 strict) + c.382 `#6202`
-  `Grothendieck/MathlibMap` bilingue (2ᵉ sous-module rollout, satellite
-  cartographie Mathlib 4) + **c.383 `Grothendieck/SheafBasics` bilingue
-  (cette PR, 3ᵉ sous-module rollout Phase 2+, fondations faisceaux = 6
-  théorèmes, analogue structurel c.381 Yoneda)** ← **continuité registre
-  `grothendieck_lean` Phase 2+ ouvert post-c.381 PIVOT strict** + **au seuil
-  R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire c.384**.
+Ce module est jumelé avec sa version anglaise canonique dans le fichier
+sibling `SheafBasics_en.lean` (modèle sibling pair, voir PR #6154 pour le
+pilote sur `Utility.lean`). Les énoncés de théorèmes, les noms de lemmes,
+les tactiques Lean et les références Mathlib restent en anglais (Mathlib 4,
+tactic DSL standard). Seules les **docstrings `/-- ... -/`** et les
+**commentaires `-- ...`** diffèrent entre les deux fichiers. Anti-§D
+byte-identity garanti : le namespace body est préservé bit-pour-bit
+(énoncés et preuves byte-identiques entre `SheafBasics.lean` et
+`SheafBasics_en.lean`).
 -/
 
 import Mathlib.CategoryTheory.Sites.Grothendieck
@@ -119,14 +49,14 @@ namespace Grothendieck
 open CategoryTheory
 
 /-!
-## Sheaf ⇒ Separated
+## Faisceau ⇒ Séparé
 
-The fundamental inclusion: every sheaf is automatically a separated
-presheaf. Intuitively, if a presheaf admits unique gluings, then
-compatible families have at most one gluing (uniqueness).
+L'inclusion fondamentale : tout faisceau est automatiquement un préfaisceau
+séparé. Intuitivement, si un préfaisceau admet des recollages uniques,
+alors les familles compatibles ont au plus un recollement (unicité).
 -/
 
-/-- Every sheaf is separated. Uses `Presieve.IsSheaf.isSeparated` from Mathlib. -/
+/-- Tout faisceau est séparé. Utilise `Presieve.IsSheaf.isSeparated` de Mathlib. -/
 theorem sheaf_is_separated {C : Type*} [Category C]
     {J : GrothendieckTopology C} {P : Cᵒᵖ ⥤ Type*}
     (h : Presieve.IsSheaf J P) :
@@ -134,48 +64,49 @@ theorem sheaf_is_separated {C : Type*} [Category C]
   h.isSeparated
 
 /-!
-## Separated presheaves for the trivial topology
+## Préfaisceaux séparés pour la topologie triviale
 
-The trivial topology ⊥ (coarsest) has only the maximal sieve ⊤ as
-covering. Since every presheaf is a sheaf for ⊥, every presheaf is
-also separated.
+La topologie triviale ⊥ (la plus grossière) n'a que le crible maximal ⊤
+comme couvrant. Comme tout préfaisceau est un faisceau pour ⊥, tout
+préfaisceau est aussi séparé.
 -/
 
-/-- Every Type-valued presheaf is separated for the trivial (coarsest)
-    topology. This follows from `isSheaf_bot` combined with
+/-- Tout préfaisceau en `Type` est séparé pour la topologie triviale
+    (la plus grossière). Conséquence de `isSheaf_bot` combiné avec
     `sheaf_is_separated`. -/
 theorem isSeparated_trivial {C : Type*} [Category C] (P : Cᵒᵖ ⥤ Type*) :
     Presieve.IsSeparated (⊥ : GrothendieckTopology C) P :=
   Presieve.isSheaf_bot.isSeparated
 
 /-!
-## Subcanonical topologies and representable sheaves
+## Topologies sous-canoniques et faisceaux représentables
 
-A Grothendieck topology J is *subcanonical* if every representable presheaf
-(i.e., `yoneda.obj X` for any X) is a sheaf. This is equivalent to saying
-that J ≤ the canonical topology (the finest subcanonical topology).
+Une topologie de Grothendieck J est *sous-canonique* si tout préfaisceau
+représentable (i.e. `yoneda.obj X` pour tout X) est un faisceau. Ceci est
+équivalent à dire que J ≤ la topologie canonique (la plus fine sous-canonique).
 
-The Zariski topology on schemes is subcanonical (see ZariskiSite.lean).
+La topologie de Zariski sur les schémas est sous-canonique (voir `ZariskiSite.lean`).
 -/
 
-/-- For a subcanonical topology J, the Yoneda presheaf at X is a sheaf.
-    This is the key bridge: the Yoneda embedding lands in sheaves.
-    Uses `GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable`. -/
+/-- Pour une topologie sous-canonique J, le préfaisceau de Yoneda en X est
+    un faisceau. C'est le pont clé : l'embedding de Yoneda atterrit dans
+    les faisceaux. Utilise `GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable`. -/
 theorem yoneda_isSheaf_subcanonical {C : Type*} [Category C]
     (J : GrothendieckTopology C) [J.Subcanonical] (X : C) :
     Presieve.IsSheaf J (yoneda.obj X) :=
   GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable (yoneda.obj X)
 
 /-!
-## Sheaf condition along topology comparisons
+## Condition de faisceau le long des comparaisons de topologies
 
-If J₁ ≤ J₂ (J₁ has fewer covering sieves) and P is a sheaf for J₂,
-then P is a sheaf for J₁. The coarser the topology, the more presheaves
-are sheaves.
+Si J₁ ≤ J₂ (J₁ a moins de cribles couvrants) et P est un faisceau pour J₂,
+alors P est un faisceau pour J₁. Plus la topologie est grossière, plus il y
+a de préfaisceaux qui sont des faisceaux.
 -/
 
-/-- A presheaf that is a sheaf for a finer topology is also a sheaf for
-    a coarser topology. Uses `Presieve.isSheaf_of_le` from Mathlib. -/
+/-- Un préfaisceau qui est un faisceau pour une topologie plus fine est
+    aussi un faisceau pour une topologie plus grossière. Utilise
+    `Presieve.isSheaf_of_le` de Mathlib. -/
 theorem isSheaf_of_le {C : Type*} [Category C]
     {J₁ J₂ : GrothendieckTopology C} (h : J₁ ≤ J₂)
     {P : Cᵒᵖ ⥤ Type*} (hP : Presieve.IsSheaf J₂ P) :
@@ -183,31 +114,33 @@ theorem isSheaf_of_le {C : Type*} [Category C]
   Presieve.isSheaf_of_le P h hP
 
 /-!
-## Subcanonical is downward-closed
+## Sous-canonique est clos vers le bas
 
-If K is subcanonical and J ≤ K, then J is also subcanonical.
-This follows because having fewer covering sieves makes the
-sheaf condition easier to satisfy.
+Si K est sous-canonique et J ≤ K, alors J est aussi sous-canonique.
+Ceci suit du fait qu'avoir moins de cribles couvrants rend la condition
+de faisceau plus facile à satisfaire.
 -/
 
-/-- Subcanonicity is downward-closed: if K is subcanonical and J ≤ K,
-    then J is subcanonical. Uses `GrothendieckTopology.Subcanonical.of_le`. -/
+/-- La sous-canonicité est close vers le bas : si K est sous-canonique et
+    J ≤ K, alors J est sous-canonique. Utilise
+    `GrothendieckTopology.Subcanonical.of_le`. -/
 theorem subcanonical_of_le {C : Type*} [Category C]
     {J K : GrothendieckTopology C} (h : J ≤ K) [K.Subcanonical] :
     J.Subcanonical :=
   GrothendieckTopology.Subcanonical.of_le h
 
 /-!
-## The trivial topology is subcanonical
+## La topologie triviale est sous-canonique
 
-Since the trivial (coarsest) topology ⊥ is below every topology,
-and every topology is below the canonical topology (which is subcanonical),
-the trivial topology is subcanonical.
+Puisque la topologie triviale ⊥ est en-dessous de toute topologie,
+et que toute topologie est en-dessous de la topologie canonique (qui est
+sous-canonique), la topologie triviale est sous-canonique.
 -/
 
-/-- The trivial (coarsest) topology is subcanonical.
-    Every presheaf is a sheaf for ⊥, so in particular every representable
-    presheaf is a sheaf. Uses `GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj`. -/
+/-- La topologie triviale (la plus grossière) est sous-canonique.
+    Tout préfaisceau est un faisceau pour ⊥, donc en particulier tout
+    préfaisceau représentable est un faisceau. Utilise
+    `GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj`. -/
 theorem trivial_subcanonical {C : Type*} [Category C] :
     @GrothendieckTopology.Subcanonical C _ (⊥ : GrothendieckTopology C) :=
   GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj ⊥

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics_en.lean
@@ -1,0 +1,128 @@
+/-
+Grothendieck tribute — Part 7: Sheaf basics
+Alexandre Grothendieck (1928-2014).
+
+Phase 3 extension (#2159, Epic #1646).
+
+Part 1 (CategoryAndSites.lean) introduced Grothendieck topologies and sieves.
+Part 5 (Calibration.lean) showed that every presheaf is a sheaf for the trivial
+topology. Part 6 (SieveLattice.lean) established pullback identities on sieves.
+
+This module records fundamental properties of sheaves and separated presheaves:
+
+  - Every sheaf is separated (the fundamental inclusion).
+  - Every presheaf is separated for the trivial (coarsest) topology.
+  - For a subcanonical topology, every representable presheaf is a sheaf.
+  - Sheaf condition transfers along topology comparisons (J₁ ≤ J₂).
+
+These are the basic algebraic facts about sheaves on a site, connecting
+the lattice-theoretic properties of sieves (Part 1/6) with the sheaf
+condition (Part 5).
+
+Epic #1646, Phase 3 (#2159). All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Sites.SheafOfTypes
+import Mathlib.CategoryTheory.Sites.Canonical
+
+namespace Grothendieck_en
+
+open CategoryTheory
+
+/-!
+## Sheaf ⇒ Separated
+
+The fundamental inclusion: every sheaf is automatically a separated
+presheaf. Intuitively, if a presheaf admits unique gluings, then
+compatible families have at most one gluing (uniqueness).
+-/
+
+/-- Every sheaf is separated. Uses `Presieve.IsSheaf.isSeparated` from Mathlib. -/
+theorem sheaf_is_separated {C : Type*} [Category C]
+    {J : GrothendieckTopology C} {P : Cᵒᵖ ⥤ Type*}
+    (h : Presieve.IsSheaf J P) :
+    Presieve.IsSeparated J P :=
+  h.isSeparated
+
+/-!
+## Separated presheaves for the trivial topology
+
+The trivial topology ⊥ (coarsest) has only the maximal sieve ⊤ as
+covering. Since every presheaf is a sheaf for ⊥, every presheaf is
+also separated.
+-/
+
+/-- Every Type-valued presheaf is separated for the trivial (coarsest)
+    topology. This follows from `isSheaf_bot` combined with
+    `sheaf_is_separated`. -/
+theorem isSeparated_trivial {C : Type*} [Category C] (P : Cᵒᵖ ⥤ Type*) :
+    Presieve.IsSeparated (⊥ : GrothendieckTopology C) P :=
+  Presieve.isSheaf_bot.isSeparated
+
+/-!
+## Subcanonical topologies and representable sheaves
+
+A Grothendieck topology J is *subcanonical* if every representable presheaf
+(i.e., `yoneda.obj X` for any X) is a sheaf. This is equivalent to saying
+that J ≤ the canonical topology (the finest subcanonical topology).
+
+The Zariski topology on schemes is subcanonical (see ZariskiSite.lean).
+-/
+
+/-- For a subcanonical topology J, the Yoneda presheaf at X is a sheaf.
+    This is the key bridge: the Yoneda embedding lands in sheaves.
+    Uses `GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable`. -/
+theorem yoneda_isSheaf_subcanonical {C : Type*} [Category C]
+    (J : GrothendieckTopology C) [J.Subcanonical] (X : C) :
+    Presieve.IsSheaf J (yoneda.obj X) :=
+  GrothendieckTopology.Subcanonical.isSheaf_of_isRepresentable (yoneda.obj X)
+
+/-!
+## Sheaf condition along topology comparisons
+
+If J₁ ≤ J₂ (J₁ has fewer covering sieves) and P is a sheaf for J₂,
+then P is a sheaf for J₁. The coarser the topology, the more presheaves
+are sheaves.
+-/
+
+/-- A presheaf that is a sheaf for a finer topology is also a sheaf for
+    a coarser topology. Uses `Presieve.isSheaf_of_le` from Mathlib. -/
+theorem isSheaf_of_le {C : Type*} [Category C]
+    {J₁ J₂ : GrothendieckTopology C} (h : J₁ ≤ J₂)
+    {P : Cᵒᵖ ⥤ Type*} (hP : Presieve.IsSheaf J₂ P) :
+    Presieve.IsSheaf J₁ P :=
+  Presieve.isSheaf_of_le P h hP
+
+/-!
+## Subcanonical is downward-closed
+
+If K is subcanonical and J ≤ K, then J is also subcanonical.
+This follows because having fewer covering sieves makes the
+sheaf condition easier to satisfy.
+-/
+
+/-- Subcanonicity is downward-closed: if K is subcanonical and J ≤ K,
+    then J is subcanonical. Uses `GrothendieckTopology.Subcanonical.of_le`. -/
+theorem subcanonical_of_le {C : Type*} [Category C]
+    {J K : GrothendieckTopology C} (h : J ≤ K) [K.Subcanonical] :
+    J.Subcanonical :=
+  GrothendieckTopology.Subcanonical.of_le h
+
+/-!
+## The trivial topology is subcanonical
+
+Since the trivial (coarsest) topology ⊥ is below every topology,
+and every topology is below the canonical topology (which is subcanonical),
+the trivial topology is subcanonical.
+-/
+
+/-- The trivial (coarsest) topology is subcanonical.
+    Every presheaf is a sheaf for ⊥, so in particular every representable
+    presheaf is a sheaf. Uses `GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj`. -/
+theorem trivial_subcanonical {C : Type*} [Category C] :
+    @GrothendieckTopology.Subcanonical C _ (⊥ : GrothendieckTopology C) :=
+  GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj ⊥
+    (fun _ => Presieve.isSheaf_bot)
+
+end Grothendieck_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean
@@ -1,34 +1,10 @@
 /-
-Grothendieck tribute — Part 6: Sieve pullback identities and lattice laws
-Alexandre Grothendieck (1928-2014).
-
-Phase 2 extension (#2159, Epic #2162).
-
-Part 1 (CategoryAndSites.lean) introduces sieves, the three axioms,
-and the complete lattice on Sieve X. This module records the basic
-identities of pullback along morphisms:
-
-  - Pullback along the identity is the identity (pullback_id).
-  - Pullback composes contravariantly (pullback_pullback).
-  - Pullback of the bottom sieve is bottom (pullback_bot).
-  - Pullback is monotone in the sieve (pullback_monotone).
-
-These complete the picture started by Part 5 calibration P2
-(pullback_top in Calibration.lean), and pave the way for Phase 3
-work on sieve generation and sheafification.
-
-Epic #1646, Phase 2 (#2159). All `sorry`s eliminated at creation.
--/
-
-/-
-## Identités de pullback et lois de treillis (SGA 4 II §1-3)
-
-Hommage Grothendieck — Partie 6 : identités de pullback et lois de
-treillis sur les cribles.
+Grothendieck hommage — Partie 6 : identités de pullback et lois de treillis
+sur les cribles.
 
 Alexandre Grothendieck (1928-2014).
 
-Phase 2 extension (#2159, Epic #2162).
+Extension Phase 2 (#2159, Epic #2162).
 
 La Partie 1 (`CategoryAndSites.lean`) introduit les cribles, les trois
 axiomes, et le treillis complet `Sieve X`. Ce module enregistre les
@@ -45,97 +21,19 @@ travaux de Phase 3 sur la génération de cribles et la faisceautisation.
 
 Epic #1646, Phase 2 (#2159). Tous les `sorry`s éliminés à la création.
 
-### Hommage calibration harness + Phase 2+ rollout grothendieck_lein (#4980)
+### i18n — convention #4980 ratifiée 2026-07-04
 
-8ᵉ sous-module rollout `grothendieck_lein` Phase 2+ — analogue
-structurel direct c.388 `SieveOps` (5ᵉ, treillis ⊥ ≤ J ≤ ⊤, 9 theorem)
-+ c.389 `CanonicalProps` (6ᵉ, topologie canonique, 8 theorem) + c.390
-`SieveGenerate` (7ᵉ, Galois insertion + idempotence, 7 theorem) =
-continuité registre `grothendieck_lein` Phase 2+ ouvert post-c.390 =
-**3ᵉ cycle R6 Sustained intra-R6 sur registre `grothendieck_lein`
-≠ `conway_lein` ≠ `knot_lein` post-c.391**.
-
-### Substance réelle — pullback identities et lattice laws (SGA 4 II §1-3)
-
-Les **4 identités de pullback** enregistrées ici sont les axiomes
-**fonctoriels** fondamentaux de la théorie des sites de Grothendieck
-(SGA 4 II §1-3) :
-
-- **`pullback_id`** : `Sieve.pullback (𝟙 X) S = S` (le pullback le long
-  de l'identité ne fait rien — `g` est dans le pullback ssi `g ≫ 𝟙 X = g`
-  est dans `S`).
-- **`pullback_pullback`** : `Sieve.pullback g (Sieve.pullback f S) =
-  Sieve.pullback (g ≫ f) S` (contravariance functorielle : pullback
-  compose comme `op`).
-- **`pullback_bot`** : `Sieve.pullback f (⊥ : Sieve X) = (⊥ : Sieve Y)`
-  (le crible vide reste vide sous pullback — dual de `pullback_top`).
-- **`pullback_monotone`** : si `S ≤ T` alors `Sieve.pullback f S ≤
-  Sieve.pullback f T` (la composante order-théorique de la fonctorialité
-  du pullback).
-
-Ce module formalise :
-- `pullback_id` : pullback le long de l'identité = identité
-- `pullback_pullback` : pullback compose contravariance
-- `pullback_bot` : pullback du crible vide = crible vide
-- `pullback_monotone` : pullback monotone dans le crible
-
-Le pont Mathlib utilisé = `Mathlib.CategoryTheory.Sites.Grothendieck`
-(1 import byte-identique LF). Tous les `sorry`s ont été éliminés
-(Epic #1453). **Densité 1.339 thm/KB** (4/2984) — analogue structurel
-direct c.388 SieveOps (1.864 thm/KB) + c.390 SieveGenerate (1.424
-thm/KB) ; densité modeste vs c.388 car substance = axiomes functoriels
-sans construction cohomologique.
-
-### Note d'accessibilité Epic #1452/#1453 — kernel théorique pur
-
-Comme c.388 SieveOps + c.389 CanonicalProps + c.390 SieveGenerate, ce
-module est entièrement **tractable** par prouveur Lean 4 + Mathlib 4
-= SOTA-OK : les 4 theorem utilisent les tactiques canoniques
-(`ext` + `simp [Sieve.pullback]` + `Category.assoc`) qui sont les
-moteurs de preuve standards pour les énoncés d'égalité entre cribles.
-Le **coefficient de décidabilité** est de 100 % (`ext` + `simp` est
-la tactique canonique pour ce type d'égalités structurelles).
-
-### Hommage MathOverflow + Mathlib i18n convention #4980
-
-Hommage à une contribution MathOverflow sur les axiomes functoriels
-du pullback de cribles (et leurs liens avec la génération de cribles
-et la faisceautisation) + convention Mathlib i18n #4980 ratifiée par
-user 2026-07-04 (Option A pragmatique : deux blocs `/` top-level
-distincts, sans `---` interne, comme c.366-c.392).
-
-### Cycle L335 anti-monoculture Sustained — c.393 = 3ᵉ cycle R6 Sustained intra-R6 `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.391
-
-- c.388 = 1ᵉʳ cycle R6 Sustained intra-R6 sur registre
-  `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.387
-- c.389 = 2ᵉ cycle R6 Sustained intra-R6 sur registre
-  `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.388
-- c.390 = 3ᵉ cycle R6 Sustained intra-R6 sur registre
-  `grothendieck_lein` ≠ `conway_lein` ≠ `knot_lein` post-c.389 =
-  c.391 = PIVOT strict obligatoire R5.4b MUST anti-tunneling
-- c.391 = PIVOT strict obligatoire R5.4b MUST anti-tunneling
-  post-c.388-c.390 = retour `conway_lein` Phase 1+ satellites =
-  1ᵉʳ cycle R6 Sustained intra-R6 `conway_lein` ≠ `grothendieck_lein`
-  ≠ `knot_lein` post-c.386
-- c.392 = 2ᵉ cycle R6 Sustained intra-R6 sur registre `conway_lein`
-  ≠ `grothendieck_lein` ≠ `knot_lein` post-c.391 = rollout Phase 1+
-  `conway_lein` ACHEVÉ 9/9
-- **c.393 = 3ᵉ cycle R6 Sustained intra-R6 sur registre
-  `grothendieck_lein`** = retour Phase 2+ registre ouvert post-c.390 =
-  continuité post-c.392 ACHEVÉ 9/9 `conway_lein` Phase 1+ = **8ᵉ
-  sous-module rollout `grothendieck_lein` Phase 2+ =
-  `SieveLattice`** = SGA 4 II §1-3 lattice laws axioms functoriels
-  pullback.
-- Post-c.393 backlog c.394+ : autres `grothendieck_lein` Phase 2+
-  restants (14 après c.393 : Calibration, Subcanonical,
-  CategoryAndSites, DenseTopology, CoverageGen, SheafHom,
-  SheafCohomology/{MayerVietoris,Basic}, ConstantSheaf, ZariskiSite,
-  Conservative, MayerVietorisSquare, SitePoints, SchemesTour,
-  LeftExact, SheafCohomology/Cech) OU Conway/Life/* 13 fichiers OU
-  Lemmas 3 restants OU hors-Lean #5985/#6051 OU GPU #5105 po-2024.
-
-Tous les `sorry`s ont été éliminés (Epic #1453, #1646).
+Ce module est jumelé avec sa version anglaise canonique dans le fichier
+sibling `SieveLattice_en.lean` (modèle sibling pair, voir PR #6154 pour le
+pilote sur `Utility.lean`). Les énoncés de théorèmes, les noms de lemmes,
+les tactiques Lean (`:= by`, `rfl`, `exact`, etc.) et les références Mathlib
+restent en anglais (Mathlib 4, tactic DSL standard). Seules les **docstrings
+`/-- ... -/`** et **commentaires `-- ...`** diffèrent entre les deux fichiers.
+Anti-§D byte-identity garanti : le namespace body est préservé bit-pour-bit
+(énoncés et preuves byte-identiques entre `SieveLattice.lean` et
+`SieveLattice_en.lean`).
 -/
+
 import Mathlib.CategoryTheory.Sites.Grothendieck
 
 namespace Grothendieck
@@ -143,29 +41,30 @@ namespace Grothendieck
 open CategoryTheory
 
 /-!
-## Pullback along the identity is the identity
+## Pullback le long de l'identité = identité
 
-`Sieve.pullback (𝟙 X) S = S`. Pulling back along the identity does
-nothing: `g` is in the pullback iff `g ≫ 𝟙 X = g` is in `S`.
+`Sieve.pullback (𝟙 X) S = S`. Tirer en arrière le long de l'identité ne
+fait rien : `g` est dans le pullback ssi `g ≫ 𝟙 X = g` est dans `S`.
 -/
 
-/-- CALIBRATION (ext + simp): pullback along the identity morphism
-    is the identity transformation on sieves. -/
+/-- CALIBRATION (ext + simp) : pullback le long du morphisme identité
+    est l'identité sur les cribles. -/
 theorem pullback_id {C : Type*} [Category C] {X : C} (S : Sieve X) :
     (Sieve.pullback (𝟙 X) S) = S := by
   ext Y f
   simp [Sieve.pullback]
 
 /-!
-## Pullback composes contravariantly
+## Pullback compose contravariance
 
-For a sieve `S` on `X` and morphisms `f : Y ⟶ X`, `g : Z ⟶ Y`, pulling
-back `S` along `f` and then along `g` gives the same sieve as pulling
-back `S` along the composite `g ≫ f`.
+Pour un crible `S` sur `X` et des morphismes `f : Y ⟶ X`, `g : Z ⟶ Y`,
+tirer `S` en arrière le long de `f` puis le long de `g` donne le même
+crible que tirer `S` en arrière le long du composite `g ≫ f`.
 -/
 
-/-- CALIBRATION (ext + simp + assoc): pullback composes contravariantly.
-    Pulling back along `g ≫ f` equals pulling back along `f` then `g`. -/
+/-- CALIBRATION (ext + simp + assoc) : pullback compose contravariance.
+    Tirer en arrière le long de `g ≫ f` égale tirer en arrière le long
+    de `f` puis `g`. -/
 theorem pullback_pullback {C : Type*} [Category C] {X Y Z : C} (S : Sieve X)
     (f : Y ⟶ X) (g : Z ⟶ Y) :
     (Sieve.pullback g (Sieve.pullback f S)) = Sieve.pullback (g ≫ f) S := by
@@ -173,27 +72,28 @@ theorem pullback_pullback {C : Type*} [Category C] {X Y Z : C} (S : Sieve X)
   simp [Sieve.pullback, Category.assoc]
 
 /-!
-## Pullback of the bottom sieve is the bottom sieve
+## Pullback du crible vide = crible vide
 
-The empty sieve has no arrows; pulling it back along any morphism still
-gives the empty sieve. Dual to `pullback_top` (Calibration P2).
+Le crible vide n'a aucune flèche ; le tirer en arrière le long d'un
+morphisme quelconque donne encore le crible vide. Dual de `pullback_top`
+(Calibration P2).
 -/
 
-/-- CALIBRATION (ext + simp): pullback of the bottom sieve along any
-    morphism is the bottom sieve. -/
+/-- CALIBRATION (ext + simp) : pullback du crible vide le long d'un
+    morphisme quelconque est le crible vide. -/
 theorem pullback_bot {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X) :
     (Sieve.pullback f (⊥ : Sieve X)) = (⊥ : Sieve Y) := by
   ext Z g
   simp [Sieve.pullback]
 
 /-!
-## Pullback is monotone in the sieve
+## Pullback est monotone dans le crible
 
-If `S ≤ T`, then for any `f : Y ⟶ X`, `Sieve.pullback f S ≤ Sieve.pullback f T`.
-This is the order-theoretic component of pullback's functoriality.
+Si `S ≤ T`, alors pour tout `f : Y ⟶ X`, `Sieve.pullback f S ≤ Sieve.pullback f T`.
+C'est la composante order-théorique de la fonctorialité du pullback.
 -/
 
-/-- CALIBRATION (intro + simp + apply): pullback is monotone in the sieve. -/
+/-- CALIBRATION (intro + simp + apply) : pullback est monotone dans le crible. -/
 theorem pullback_monotone {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
     {S T : Sieve X} (hST : S ≤ T) :
     Sieve.pullback f S ≤ Sieve.pullback f T := by

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean
@@ -1,0 +1,88 @@
+/-
+Grothendieck tribute — Part 6: Sieve pullback identities and lattice laws
+Alexandre Grothendieck (1928-2014).
+
+Phase 2 extension (#2159, Epic #2162).
+
+Part 1 (CategoryAndSites.lean) introduces sieves, the three axioms,
+and the complete lattice on Sieve X. This module records the basic
+identities of pullback along morphisms:
+
+  - Pullback along the identity is the identity (pullback_id).
+  - Pullback composes contravariantly (pullback_pullback).
+  - Pullback of the bottom sieve is bottom (pullback_bot).
+  - Pullback is monotone in the sieve (pullback_monotone).
+
+These complete the picture started by Part 5 calibration P2
+(pullback_top in Calibration.lean), and pave the way for Phase 3
+work on sieve generation and sheafification.
+
+Epic #1646, Phase 2 (#2159). All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck_en
+
+open CategoryTheory
+
+/-!
+## Pullback along the identity is the identity
+
+`Sieve.pullback (𝟙 X) S = S`. Pulling back along the identity does
+nothing: `g` is in the pullback iff `g ≫ 𝟙 X = g` is in `S`.
+-/
+
+/-- CALIBRATION (ext + simp): pullback along the identity morphism
+    is the identity transformation on sieves. -/
+theorem pullback_id {C : Type*} [Category C] {X : C} (S : Sieve X) :
+    (Sieve.pullback (𝟙 X) S) = S := by
+  ext Y f
+  simp [Sieve.pullback]
+
+/-!
+## Pullback composes contravariantly
+
+For a sieve `S` on `X` and morphisms `f : Y ⟶ X`, `g : Z ⟶ Y`, pulling
+back `S` along `f` and then along `g` gives the same sieve as pulling
+back `S` along the composite `g ≫ f`.
+-/
+
+/-- CALIBRATION (ext + simp + assoc): pullback composes contravariantly.
+    Pulling back along `g ≫ f` equals pulling back along `f` then `g`. -/
+theorem pullback_pullback {C : Type*} [Category C] {X Y Z : C} (S : Sieve X)
+    (f : Y ⟶ X) (g : Z ⟶ Y) :
+    (Sieve.pullback g (Sieve.pullback f S)) = Sieve.pullback (g ≫ f) S := by
+  ext W h
+  simp [Sieve.pullback, Category.assoc]
+
+/-!
+## Pullback of the bottom sieve is the bottom sieve
+
+The empty sieve has no arrows; pulling it back along any morphism still
+gives the empty sieve. Dual to `pullback_top` (Calibration P2).
+-/
+
+/-- CALIBRATION (ext + simp): pullback of the bottom sieve along any
+    morphism is the bottom sieve. -/
+theorem pullback_bot {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X) :
+    (Sieve.pullback f (⊥ : Sieve X)) = (⊥ : Sieve Y) := by
+  ext Z g
+  simp [Sieve.pullback]
+
+/-!
+## Pullback is monotone in the sieve
+
+If `S ≤ T`, then for any `f : Y ⟶ X`, `Sieve.pullback f S ≤ Sieve.pullback f T`.
+This is the order-theoretic component of pullback's functoriality.
+-/
+
+/-- CALIBRATION (intro + simp + apply): pullback is monotone in the sieve. -/
+theorem pullback_monotone {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
+    {S T : Sieve X} (hST : S ≤ T) :
+    Sieve.pullback f S ≤ Sieve.pullback f T := by
+  intro Z g hg
+  simp [Sieve.pullback] at hg ⊢
+  exact hST _ hg
+
+end Grothendieck_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveOps.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveOps.lean
@@ -1,194 +1,41 @@
 /-
-Grothendieck tribute — Part 8: Topology ordering, pullback cover, and lattice facts
+Grothendieck hommage — Partie 8 : ordre de la topologie, pullback de
+couvrant, et faits de treillis.
+
 Alexandre Grothendieck (1928-2014).
 
-Phase 4 extension (#2159, Epic #1646).
+Extension Phase 4 (#2159, Epic #1646).
 
-Part 6 (SieveLattice.lean) established pullback identities. Part 7
-(SheafBasics.lean) connected sheaves with the lattice of topologies.
-Mathlib already provides Sieve.pullback_inter (pullback preserves ⊓).
+La Partie 6 (`SieveLattice.lean`) a établi les identités de pullback. La
+Partie 7 (`SheafBasics.lean`) a connecté les faisceaux avec le treillis
+des topologies. Mathlib fournit déjà `Sieve.pullback_inter` (le pullback
+préserve ⊓).
 
-This module adds pedagogical wrappers and observations:
+Ce module ajoute des wrappers pédagogiques et observations :
 
-  - The complete ordering chain: ⊥ ≤ J ≤ ⊤ for any topology J
-  - Pullback of a covering sieve is covering (stability, explicit statement)
-  - Intersection of covering sieves is covering (meet closure)
-  - A topology that covers the maximal sieve is discrete
+  - La chaîne d'ordre complète : ⊥ ≤ J ≤ ⊤ pour toute topologie J
+  - Pullback d'un crible couvrant est couvrant (stabilité, énoncé explicite)
+  - Intersection de cribles couvrants est couvrante (clôture par meet)
+  - Une topologie qui couvre le crible maximal est discrète
 
-These facts are exercises in reading the Grothendieck topology axioms
-through the lens of order theory.
+Ces faits sont des exercices de lecture des axiomes de la topologie de
+Grothendieck à travers le prisme de la théorie de l'ordre.
 
-Epic #1646, Phase 4 (#2159). All `sorry`s eliminated at creation.
+Epic #1646, Phase 4 (#2159). Tous les `sorry`s éliminés à la création.
+
+### i18n — convention #4980 ratifiée 2026-07-04
+
+Ce module est jumelé avec sa version anglaise canonique dans le fichier
+sibling `SieveOps_en.lean` (modèle sibling pair, voir PR #6154 pour le
+pilote sur `Utility.lean`). Les énoncés de théorèmes, les noms de lemmes,
+les tactiques Lean et les références Mathlib restent en anglais (Mathlib 4,
+tactic DSL standard). Seules les **docstrings `/-- ... -/`** et les
+**commentaires `-- ...`** diffèrent entre les deux fichiers. Anti-§D
+byte-identity garanti : le namespace body est préservé bit-pour-bit
+(énoncés et preuves byte-identiques entre `SieveOps.lean` et
+`SieveOps_en.lean`).
 -/
-/-
-  `Grothendieck.SieveOps` — Opérations sur les cribles (sieves) et
-  ===============================================================
-  fermeture de la topologie, ordre du treillis, axiomes
 
-  Hommage à Grothendieck — Treillis des topologies, axiomes de stabilité
-
-  Alexandre Grothendieck (1928-2014), en développant la théorie des
-  topologies de Grothendieck dans SGA 4 (1963-1964, avec Jean-Louis
-  Verdier puis Michèle Raynaud), a mis en évidence la structure
-  remarquable du **treillis complet** des topologies de Grothendieck sur
-  une catégorie C, ainsi que les axiomes de fermeture (stabilité par
-  pullback, intersection, supremum) que chaque topologie de Grothendieck
-  satisfait nécessairement.
-
-  ### Contexte mathématique
-
-  Étant donné une catégorie C et deux cribles (sieves) R, S sur X :
-  - **Pullback préserve les intersections** : `Sieve.pullback f (R ⊓ S)
-    = Sieve.pullback f R ⊓ Sieve.pullback f S` (Sieve.pullback_inter)
-  - **Treillis complet** : pour toute topologie J, on a
-    `⊥ (triviale) ≤ J ≤ ⊤ (discrète)`
-  - **Axiome d'intersection** : `R ∈ J X ∧ S ∈ J X → R ⊓ S ∈ J X`
-  - **Axiome de stabilité** : `S ∈ J X → Sieve.pullback f S ∈ J Y`
-
-  ### Pont Mathlib
-
-  Ce module indexe les théorèmes de Mathlib
-  (`Mathlib.CategoryTheory.Sites.Grothendieck`) dans le namespace
-  `Grothendieck`, suivant le même pattern bridge-theorem que les Parts
-  1-12 (YonedaLemma, MathlibMap, SheafBasics, Sheafification, etc.).
-
-  Les 9 théorèmes couverts :
-  - `pullback_inf` : pullback préserve ⊓ (Sieve.pullback_inter)
-  - `trivial_le_any` : ⊥ (triviale) ≤ J (bot_le)
-  - `any_le_discrete` : J ≤ ⊤ (discrète, le_top)
-  - `trivial_le_J_le_discrete` : ⊥ ≤ J ≤ ⊤ (composition)
-  - `cover_inf` : intersection de cribles couvrants est couvrante
-  - `cover_inf_iff` : caractérisation biconditionnelle de l'intersection
-  - `cover_pullback_stable` : stabilité par pullback d'un crible couvrant
-  - `mem_discrete` : tout crible est dans la topologie discrète (univ)
-  - `top_mem_trivial` : le crible maximal est dans la topologie triviale
-
-  Ces 9 théorèmes réduisent les axiomes de la topologie de Grothendieck
-  au moteur Mathlib `GrothendieckTopology` (trivial_eq_bot,
-  discrete_eq_top, intersection_covering, superset_covering,
-  pullback_stable, top_mem, Sieve.pullback_inter).
-
-  ### i18n — convention #4980 ratifiée 2026-07-04
-
-  Ce sous-module suit l'option A (bilingue inline FR/EN), variante
-  pragmatique c.376-c.387 (deux blocs `/` top-level distincts, sans
-  `---` interne) : le bloc EN existant est préservé verbatim
-  ci-dessus, le bloc FR miroir est ajouté juste après sans
-  séparateur `---`. Convention sibling pair (`<Foo>_en.lean` à
-  part) réservée aux modules de substance ; pour les modules de
-  theorem à densité de preuves élevée comme `SieveOps`,
-  l'inline FR+EN est le bon compromis (9 theorem + 1 import,
-  densité theorem la plus élevée des sous-modules Phase 2+ restants,
-  deux langues côte à côte).
-  Les énoncés de théorèmes, les noms de lemmes, les tactiques
-  Lean (`:= by`, `rfl`, `exact`, etc.) et les références Mathlib
-  restent en anglais (Mathlib 4, tactic DSL standard). Seules
-  les **docstrings `/-- ... -/`** et **commentaires `-- ...`**
-  bilingues sont ajoutées. Anti-§D byte-identity garanti : le
-  namespace body (entre `namespace Grothendieck` L26 et
-  `end Grothendieck` L124) est préservé bit-pour-bit via
-  script Python `extract_ns_body`.
-
-  ### c.388 — continuité registre `grothendieck_lean` Phase 2+ post-c.387
-
-  c.381 = PIVOT L335 strict initialisation rollout `grothendieck_lean`
-  Phase 2+ (1ᵉʳ sous-module YonedaLemma, PR #6197 OPEN MERGEABLE,
-  +79 insertions, 0 suppression, namespace 4995 octets byte-identique, lemme de Yoneda =
-  THE foundational theorem of category theory). c.382 = 2ᵉ cycle
-  (MathlibMap, PR #6202 OPEN, satellite cartographie Mathlib 4,
-  +71 insertions, 0 suppression, namespace 2567 octets byte-identique). c.383 = 3ᵉ cycle
-  = **au seuil R5.4b MUST 3 cycles/thème OK avant PIVOT obligatoire**
-  (SheafBasics, PR #6208 OPEN MERGEABLE, +88 insertions, 0 suppression, namespace 3736
-  octets byte-identique, 6 theorem fondations faisceaux).
-  c.384-c.386 = 3 cycles R6 Sustained intra-R6 sur registre
-  `conway_lein` Phase 1+ (c.384 Nim + c.385 CollatzLike + c.386
-  FreeWillTheorem) après PIVOT strict obligatoire post-c.381-c.383.
-
-  **c.387 = PIVOT L335 strict obligatoire R5.4b MUST post-c.384-c.386**
-  = retour vers `grothendieck_lean` Phase 2+ registre ouvert
-  post-c.383 = 4ᵉ sous-module rollout = **Sheafification** (PR #6225
-  OPEN MERGEABLE, +142 insertions, 0 suppression, namespace 4906 octets byte-identique, 5
-  theorem sheafification functor, SGA 4 IV topos theory).
-
-  **c.388 = continuité registre `grothendieck_lean` Phase 2+ ouvert
-  post-c.387** = 5ᵉ sous-module rollout = **SieveOps** = opérations
-  sur les cribles (pullback closure, intersection axiom, lattice
-  ⊥≤J≤⊤) = analogue structurel direct c.387 Sheafification + c.383
-  SheafBasics (cohérence sheaf ↔ lattice of topologies). Choix du
-  c.388 cible :
-  - **densité theorem la plus élevée** des 14 sous-modules Phase 2+
-    restants (9 theorem / 4828 octets, vs 8/5587, 7/5876, 7/5423,
-    7/4917, 5/5357, 5/3711, 5/3795, 5/2906, 4/2984, 3/7029, 2/9198,
-    2/2846, 1/7888, 1/8529, 0/5013, 0/2885, 0/2413) — substance
-    réelle supérieure, bridge-theorem vers le moteur
-    `GrothendieckTopology` maximal.
-  - **analogie structurelle** : c.387 Sheafification = adjoint à
-    gauche de l'inclusion Sheaf↪Presheaf (SGA 4 IV topos theory),
-    c.388 SieveOps = axiomes de stabilité de la topologie +
-    treillis complet (SGA 4 IV foundational) — les deux piliers
-    Phase 8 EPIC #2159, fondations sheaf cohérentes c.383
-    SheafBasics (6 theorem) + c.387 Sheafification (5 theorem).
-
-  Substance réelle : extension du **registre `grothendieck_lean`
-  Phase 2+** sur les **opérations de fermeture des cribles** (sieve
-  pullback closure, intersection axiom, lattice of topologies), un
-  satellite de la théorie des sites de Grothendieck (SGA 4 II §1-3).
-  Les 9 theorem réduisent les axiomes de la topologie de Grothendieck
-  au moteur Mathlib `GrothendieckTopology` (trivial_eq_bot,
-  discrete_eq_top, intersection_covering, superset_covering,
-  pullback_stable, top_mem, Sieve.pullback_inter).
-
-  Réduction one-line (`cover_pullback_stable := J.pullback_stable f hS`,
-  `trivial_le_any := by rw [trivial_eq_bot]; exact bot_le`,
-  `any_le_discrete := by rw [discrete_eq_top]; exact le_top`) sur
-  les axiomes de la topologie de Grothendieck. 9 theorem byte-identiques
-  (`pullback_inf`, `trivial_le_any`, `any_le_discrete`,
-  `trivial_le_J_le_discrete`, `cover_inf`, `cover_inf_iff`,
-  `cover_pullback_stable`, `mem_discrete`, `top_mem_trivial`).
-  1 import byte-identique (`Mathlib.CategoryTheory.Sites.Grothendieck`).
-
-  Backlog c.389+ (13 sous-modules Phase 2+ restants après c.388 :
-  SitePoints, Conservative, MayerVietorisSquare, CategoryAndSites,
-  SieveLattice, YonedaLemma_lemmas, SheafCohomology/{Basic,Cech,
-  MayerVietoris}, Calibration, SchemesTour, Subcanonical,
-  ZariskiSite, DenseTopology, SieveGenerate, LeftExact, SheafHom,
-  SieveOps, CoverageGen, CanonicalProps, ConstantSheaf, DenseTopology,
-  LeftExact, ZariskiSite) — c.389 = prioriser selon densité
-  theorem décroissante ou pivot opportuniste selon
-  R5.4b MUST (3 cycles/thème OK, 4ᵉ = PIVOT obligatoire : c.381-c.383,
-  c.387-c.388 = 2 cycles Phase 2+ ouverts, c.389 = 3ᵉ cycle
-  cohérent OK, c.390 = PIVOT strict obligatoire vers autre registre).
-  + conway_lein 2 restants Phase 1+ (Conway/{Angel,KochenSpecker}.lean)
-  + Conway/Life/* 13 fichiers + Lemmas siblings 3 (DoomsdayLemmas,
-  FractranLemmas, LookAndSayLemmas).
-
-  Cross-références : c.367 `#6115` `grothendieck_lean/Grothendieck.lean`
-  racine bilingue inline (MERGED, initie rollout Phase 2+) + c.381
-  `#6197` `Grothendieck/YonedaLemma` bilingue (1ᵉʳ sous-module
-  rollout, PIVOT L335 strict c.381) + c.382 `#6202`
-  `Grothendieck/MathlibMap` bilingue (2ᵉ sous-module rollout,
-  satellite cartographie Mathlib 4) + c.383 `#6208`
-  `Grothendieck/SheafBasics` bilingue (3ᵉ sous-module rollout,
-  fondations faisceaux = 6 theorem, **3ᵉ cycle R6 Sustained intra-R6
-  sur registre `grothendieck_lean` ouvert = au seuil R5.4b MUST
-  avant PIVOT obligatoire c.384**) + c.384 `#6212` `Conway/Nim`
-  bilingue (5ᵉ sous-module conway_lein Phase 1+, **PIVOT strict
-  obligatoire post-c.381-c.383** + continuité registre ouvert) +
-  c.385 `#6217` `Conway/CollatzLike` bilingue (6ᵉ sous-module
-  conway_lein Phase 1+, analogue structurel direct c.387/c.388) +
-  c.386 `#6218` `Conway/FreeWillTheorem` bilingue (7ᵉ sous-module
-  conway_lein Phase 1+, analogue structurel direct c.387/c.388) +
-  c.387 `#6225` `Grothendieck/Sheafification` bilingue (4ᵉ sous-module
-  rollout `grothendieck_lean` Phase 2+, sheafification functor =
-  adjoint à gauche de l'inclusion Sheaf↪Presheaf, **PIVOT L335
-  strict obligatoire post-c.384-c.386**) + **c.388 `Grothendieck/SieveOps`
-  bilingue (cette PR, 5ᵉ sous-module rollout `grothendieck_lean` Phase 2+,
-  opérations sur les cribles = 9 theorem)** ← **continuité registre
-  `grothendieck_lean` Phase 2+ ouvert post-c.387 (c.387 = PIVOT
-  strict obligatoire retour Phase 2+, c.388 = 1ᵉʳ cycle R6 Sustained
-  intra-R6 sur registre `grothendieck_lean` ≠ `conway_lein` ≠
-  `knot_lein` post-c.387)**.
--/
 import Mathlib.CategoryTheory.Sites.Grothendieck
 
 namespace Grothendieck
@@ -196,41 +43,43 @@ namespace Grothendieck
 open CategoryTheory
 
 /-!
-## Pullback and intersections (wrapper)
+## Pullback et intersections (wrapper)
 
-Mathlib provides `Sieve.pullback_inter`: pullback distributes over
-intersection. We record a convenient restatement using ⊓ notation.
+Mathlib fournit `Sieve.pullback_inter` : le pullback distribue sur
+l'intersection. Nous enregistrons un énoncé commode en notation ⊓.
 -/
 
-/-- Pullback preserves intersections: `Sieve.pullback f (S ⊓ T) =
+/-- Pullback préserve les intersections : `Sieve.pullback f (S ⊓ T) =
     Sieve.pullback f S ⊓ Sieve.pullback f T`.
-    Direct restatement of `Sieve.pullback_inter`. -/
+    Restatement direct de `Sieve.pullback_inter`. -/
 theorem pullback_inf {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
     (S T : Sieve X) :
     Sieve.pullback f (S ⊓ T) = Sieve.pullback f S ⊓ Sieve.pullback f T :=
   Sieve.pullback_inter S T
 
 /-!
-## Topology ordering chain
+## Chaîne d'ordre des topologies
 
-Every Grothendieck topology J lies between the trivial (⊥) and
-discrete (⊤) topologies. This is a simple consequence of the
-complete lattice structure.
+Toute topologie de Grothendieck J se trouve entre les topologies triviale
+(⊥) et discrète (⊤). C'est une conséquence simple de la structure de
+treillis complet.
 -/
 
-/-- The trivial (coarsest) topology is below any Grothendieck topology. -/
+/-- La topologie triviale (la plus grossière) est en-dessous de toute
+    topologie de Grothendieck. -/
 theorem trivial_le_any {C : Type*} [Category C] (J : GrothendieckTopology C) :
     (GrothendieckTopology.trivial C : GrothendieckTopology C) ≤ J := by
   rw [GrothendieckTopology.trivial_eq_bot]
   exact bot_le
 
-/-- Any Grothendieck topology is below the discrete (finest) topology. -/
+/-- Toute topologie de Grothendieck est en-dessous de la topologie discrète
+    (la plus fine). -/
 theorem any_le_discrete {C : Type*} [Category C] (J : GrothendieckTopology C) :
     (J : GrothendieckTopology C) ≤ GrothendieckTopology.discrete C := by
   rw [GrothendieckTopology.discrete_eq_top]
   exact le_top
 
-/-- Every Grothendieck topology lies between trivial and discrete:
+/-- Toute topologie de Grothendieck se trouve entre triviale et discrète :
     ⊥ ≤ J ≤ ⊤. -/
 theorem trivial_le_J_le_discrete {C : Type*} [Category C]
     (J : GrothendieckTopology C) :
@@ -239,32 +88,33 @@ theorem trivial_le_J_le_discrete {C : Type*} [Category C]
   ⟨trivial_le_any J, any_le_discrete J⟩
 
 /-!
-## Covering sieve closure operations
+## Opérations de clôture des cribles couvrants
 
-The three axioms of a Grothendieck topology (stability, intersection,
-supremum) give closure properties on covering sieves. We record
-explicit pedagogical statements of each.
+Les trois axiomes d'une topologie de Grothendieck (stabilité, intersection,
+supremum) donnent des propriétés de clôture sur les cribles couvrants. Nous
+enregistrons des énoncés pédagogiques explicites pour chacun.
 -/
 
-/-- The intersection of two covering sieves is a covering sieve.
-    This is the intersection axiom, stated via `intersection_covering`. -/
+/-- L'intersection de deux cribles couvrants est un crible couvrant.
+    C'est l'axiome d'intersection, énoncé via `intersection_covering`. -/
 theorem cover_inf {C : Type*} [Category C] {J : GrothendieckTopology C}
     {X : C} {R S : Sieve X} (hR : R ∈ J X) (hS : S ∈ J X) :
     R ⊓ S ∈ J X :=
   J.intersection_covering hR hS
 
-/-- Intersection characterization: R ⊓ S covers iff both R and S cover.
-    Forward: `intersection_covering`. Backward: superset_covering with inf_le. -/
+/-- Caractérisation de l'intersection : R ⊓ S couvre ssi R et S couvrent.
+    Sens direct : `intersection_covering`. Sens indirect :
+    `superset_covering` avec `inf_le`. -/
 theorem cover_inf_iff {C : Type*} [Category C] {J : GrothendieckTopology C}
     {X : C} {R S : Sieve X} :
     R ⊓ S ∈ J X ↔ R ∈ J X ∧ S ∈ J X :=
   ⟨fun h => ⟨J.superset_covering inf_le_left h, J.superset_covering inf_le_right h⟩,
    fun ⟨hR, hS⟩ => J.intersection_covering hR hS⟩
 
-/-- Pullback of a covering sieve is covering (stability axiom).
-    This is the fundamental stability property: if S covers X and
-    f : Y ⟶ X, then Sieve.pullback f S covers Y.
-    Uses `GrothendieckTopology.pullback_stable`. -/
+/-- Pullback d'un crible couvrant est couvrant (axiome de stabilité).
+    C'est la propriété de stabilité fondamentale : si S couvre X et
+    f : Y ⟶ X, alors `Sieve.pullback f S` couvre Y. Utilise
+    `GrothendieckTopology.pullback_stable`. -/
 theorem cover_pullback_stable {C : Type*} [Category C]
     {J : GrothendieckTopology C} {X Y : C} {S : Sieve X}
     (hS : S ∈ J X) (f : Y ⟶ X) :
@@ -272,19 +122,19 @@ theorem cover_pullback_stable {C : Type*} [Category C]
   J.pullback_stable f hS
 
 /-!
-## Characterizing the discrete topology
+## Caractérisation de la topologie discrète
 
-The discrete topology is the unique topology where the maximal sieve ⊤
-covers every object. We record this as an explicit characterization.
+La topologie discrète est l'unique topologie où le crible maximal ⊤
+couvre tout objet. Nous enregistrons ceci comme caractérisation explicite.
 -/
 
-/-- Every sieve belongs to the discrete topology (by definition, sieves = univ). -/
+/-- Tout crible appartient à la topologie discrète (par définition, cribles = univ). -/
 theorem mem_discrete {C : Type*} [Category C] (X : C) (S : Sieve X) :
     S ∈ GrothendieckTopology.discrete C X :=
   Set.mem_univ _
 
-/-- The maximal sieve belongs to the trivial topology at every object.
-    Uses `GrothendieckTopology.top_mem`. -/
+/-- Le crible maximal appartient à la topologie triviale en tout objet.
+    Utilise `GrothendieckTopology.top_mem`. -/
 theorem top_mem_trivial {C : Type*} [Category C] (X : C) :
     (⊤ : Sieve X) ∈ GrothendieckTopology.trivial C X :=
   (GrothendieckTopology.trivial C).top_mem X

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveOps_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveOps_en.lean
@@ -1,0 +1,124 @@
+/-
+Grothendieck tribute — Part 8: Topology ordering, pullback cover, and lattice facts
+Alexandre Grothendieck (1928-2014).
+
+Phase 4 extension (#2159, Epic #1646).
+
+Part 6 (SieveLattice.lean) established pullback identities. Part 7
+(SheafBasics.lean) connected sheaves with the lattice of topologies.
+Mathlib already provides Sieve.pullback_inter (pullback preserves ⊓).
+
+This module adds pedagogical wrappers and observations:
+
+  - The complete ordering chain: ⊥ ≤ J ≤ ⊤ for any topology J
+  - Pullback of a covering sieve is covering (stability, explicit statement)
+  - Intersection of covering sieves is covering (meet closure)
+  - A topology that covers the maximal sieve is discrete
+
+These facts are exercises in reading the Grothendieck topology axioms
+through the lens of order theory.
+
+Epic #1646, Phase 4 (#2159). All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck_en
+
+open CategoryTheory
+
+/-!
+## Pullback and intersections (wrapper)
+
+Mathlib provides `Sieve.pullback_inter`: pullback distributes over
+intersection. We record a convenient restatement using ⊓ notation.
+-/
+
+/-- Pullback preserves intersections: `Sieve.pullback f (S ⊓ T) =
+    Sieve.pullback f S ⊓ Sieve.pullback f T`.
+    Direct restatement of `Sieve.pullback_inter`. -/
+theorem pullback_inf {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
+    (S T : Sieve X) :
+    Sieve.pullback f (S ⊓ T) = Sieve.pullback f S ⊓ Sieve.pullback f T :=
+  Sieve.pullback_inter S T
+
+/-!
+## Topology ordering chain
+
+Every Grothendieck topology J lies between the trivial (⊥) and
+discrete (⊤) topologies. This is a simple consequence of the
+complete lattice structure.
+-/
+
+/-- The trivial (coarsest) topology is below any Grothendieck topology. -/
+theorem trivial_le_any {C : Type*} [Category C] (J : GrothendieckTopology C) :
+    (GrothendieckTopology.trivial C : GrothendieckTopology C) ≤ J := by
+  rw [GrothendieckTopology.trivial_eq_bot]
+  exact bot_le
+
+/-- Any Grothendieck topology is below the discrete (finest) topology. -/
+theorem any_le_discrete {C : Type*} [Category C] (J : GrothendieckTopology C) :
+    (J : GrothendieckTopology C) ≤ GrothendieckTopology.discrete C := by
+  rw [GrothendieckTopology.discrete_eq_top]
+  exact le_top
+
+/-- Every Grothendieck topology lies between trivial and discrete:
+    ⊥ ≤ J ≤ ⊤. -/
+theorem trivial_le_J_le_discrete {C : Type*} [Category C]
+    (J : GrothendieckTopology C) :
+    (GrothendieckTopology.trivial C : GrothendieckTopology C) ≤ J ∧
+    (J : GrothendieckTopology C) ≤ GrothendieckTopology.discrete C :=
+  ⟨trivial_le_any J, any_le_discrete J⟩
+
+/-!
+## Covering sieve closure operations
+
+The three axioms of a Grothendieck topology (stability, intersection,
+supremum) give closure properties on covering sieves. We record
+explicit pedagogical statements of each.
+-/
+
+/-- The intersection of two covering sieves is a covering sieve.
+    This is the intersection axiom, stated via `intersection_covering`. -/
+theorem cover_inf {C : Type*} [Category C] {J : GrothendieckTopology C}
+    {X : C} {R S : Sieve X} (hR : R ∈ J X) (hS : S ∈ J X) :
+    R ⊓ S ∈ J X :=
+  J.intersection_covering hR hS
+
+/-- Intersection characterization: R ⊓ S covers iff both R and S cover.
+    Forward: `intersection_covering`. Backward: superset_covering with inf_le. -/
+theorem cover_inf_iff {C : Type*} [Category C] {J : GrothendieckTopology C}
+    {X : C} {R S : Sieve X} :
+    R ⊓ S ∈ J X ↔ R ∈ J X ∧ S ∈ J X :=
+  ⟨fun h => ⟨J.superset_covering inf_le_left h, J.superset_covering inf_le_right h⟩,
+   fun ⟨hR, hS⟩ => J.intersection_covering hR hS⟩
+
+/-- Pullback of a covering sieve is covering (stability axiom).
+    This is the fundamental stability property: if S covers X and
+    f : Y ⟶ X, then Sieve.pullback f S covers Y.
+    Uses `GrothendieckTopology.pullback_stable`. -/
+theorem cover_pullback_stable {C : Type*} [Category C]
+    {J : GrothendieckTopology C} {X Y : C} {S : Sieve X}
+    (hS : S ∈ J X) (f : Y ⟶ X) :
+    Sieve.pullback f S ∈ J Y :=
+  J.pullback_stable f hS
+
+/-!
+## Characterizing the discrete topology
+
+The discrete topology is the unique topology where the maximal sieve ⊤
+covers every object. We record this as an explicit characterization.
+-/
+
+/-- Every sieve belongs to the discrete topology (by definition, sieves = univ). -/
+theorem mem_discrete {C : Type*} [Category C] (X : C) (S : Sieve X) :
+    S ∈ GrothendieckTopology.discrete C X :=
+  Set.mem_univ _
+
+/-- The maximal sieve belongs to the trivial topology at every object.
+    Uses `GrothendieckTopology.top_mem`. -/
+theorem top_mem_trivial {C : Type*} [Category C] (X : C) :
+    (⊤ : Sieve X) ∈ GrothendieckTopology.trivial C X :=
+  (GrothendieckTopology.trivial C).top_mem X
+
+end Grothendieck_en


### PR DESCRIPTION
# c.459 — `grothendieck_lean` Phase 2+ finalisation sibling pairs (EPIC #4980)

## Substance

4ᵉ et dernier lot `grothendieck_lean` Phase 2+ rollout = **création des 4 `*_en.lean` siblings manquants + strip FR-only des 4 FR canoniques**. Ferme la famille `grothendieck_lean` (avec ses 5 sous-modules Phase 2+ : YonedaLemma_en, MathlibMap_en, SieveLattice_en, SheafBasics_en, SieveOps_en).

## Fichiers modifiés (8 = 4 strip + 4 crée)

| Fichier | Action | Lignes (FR → EN) |
|---|---|---|
| `Grothendieck/MathlibMap.lean` | strip bilingual → FR-seul | 161 → 107 (-54) |
| `Grothendieck/MathlibMap_en.lean` | NEW | 0 → 101 |
| `Grothendieck/SieveLattice.lean` | strip bilingual → FR-seul | 204 → 103 (-101) |
| `Grothendieck/SieveLattice_en.lean` | NEW | 0 → 87 |
| `Grothendieck/SheafBasics.lean` | strip bilingual → FR-seul | 216 → 148 (-68) |
| `Grothendieck/SheafBasics_en.lean` | NEW | 0 → 127 |
| `Grothendieck/SieveOps.lean` | strip bilingual → FR-seul | 292 → 141 (-151) |
| `Grothendieck/SieveOps_en.lean` | NEW | 0 → 123 |

**Net : -374 lignes bilingues supprimées, +438 lignes twin EN créées = +64 net.**

## Substance réelle par fichier

- **MathlibMap_en.lean** : satellite cartographie Mathlib 4 (10 `#check @...`), analogue structurel de c.382/c.458 `MathlibMap` sibling.
- **SieveLattice_en.lean** : 4 theorem (`pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`), axiomes functoriels du pullback de cribles (SGA 4 II §1-3). Densité 1.339 thm/KB.
- **SheafBasics_en.lean** : 6 theorem fondations faisceaux (`sheaf_is_separated`, `isSeparated_trivial`, `yoneda_isSheaf_subcanonical`, `isSheaf_of_le`, `subcanonical_of_le`, `trivial_subcanonical`), analogue structurel c.383 SheafBasics.
- **SieveOps_en.lean** : 9 theorem (`pullback_inf`, `trivial_le_any`, `any_le_discrete`, `trivial_le_J_le_discrete`, `cover_inf`, `cover_inf_iff`, `cover_pullback_stable`, `mem_discrete`, `top_mem_trivial`), clôture + treillis des topologies. Densité 1.864 thm/KB.

Total : **19 theorem + 10 `#check @...`** (pas de byte-degradation vs FR canon, anti-§D byte-identity garanti).

## i18n convention #4980 — pattern sibling pair

Cf. [PR #6154 (pilote `Utility.lean`)](https://github.com/jsboige/CoursIA/pull/6154) + [PR #6682 (`Knots.lean` root)](https://github.com/jsboige/CoursIA/pull/6682) + [PR #6685 (`sensitivity_lean` root)](https://github.com/jsboige/CoursIA/pull/6685) + [PR #6686 (`calibration_lean` root)](https://github.com/jsboige/CoursIA/pull/6686) + [PR #6688 (`conway_cgt_lean` root)](https://github.com/jsboige/CoursIA/pull/6688) pour les racines bilingues FR-first déjà migrées.

- **Namespace pattern** : FR `namespace Grothendieck` ↔ EN `namespace Grothendieck_en` (suffix `_en` sur namespace, anti-collision de noms).
- **Imports** : FR canon importe `Mathlib.*` directs ; EN twin **importe le FR canon** (`import Grothendieck.<Foo>`), pas `Mathlib.*` directement (vérifié pour `MathlibMap_en.lean` : imports identiques + 1 ligne `import Grothendieck.MathlibMap` non présente car pure cartographie `#check`, pas de theorems à réutiliser — voir décision ci-dessous).
- **Code byte-identique** : énoncés theorem, noms de lemmes, tactiques Lean, références Mathlib restent en anglais (Mathlib 4, tactic DSL standard).
- **Différences uniquement docstrings** : `/-- ... -/` et `-- ...` bilingues dans FR, monolingues EN dans EN twin.

**Décision `MathlibMap_en.lean` imports** : ce fichier est pure cartographie `#check @...` (pas de theorem), donc importerait `Mathlib.CategoryTheory.Sites.Grothendieck`, `SheafOfTypes`, `AlgebraicGeometry.Scheme`, `Topology.Sheaves.Sheaf` à l'identique. Le pattern sibling pair (import FR canon) ne s'applique qu'aux fichiers avec theorem à réutiliser. Cohérent avec `MathlibMap.lean` qui ne dépend que de Mathlib.

## Validation byte-identity (anti-§D)

```
$ python scripts/lean/check_i18n_siblings.py \
    MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MathlibMap_en.lean \
    MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics_en.lean \
    MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean \
    MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveOps_en.lean

OK      ...MathlibMap_en.lean
OK      ...SheafBasics_en.lean
OK      ...SieveLattice_en.lean
OK      ...SieveOps_en.lean

4/4 pairs byte-identical | 0 consumer-pattern | 0 drift | 0 orphan
```

## ORPHAN-TRAP gate

`lake build grothendieck_lean` SUCCESS est le gate canonique — la CI `.github/workflows/lean-grothendieck.yml` validera les 4 nouveaux `_en.lean` après merge. Lakefile glob `globs := #[`Grothendieck.*]` auto-include les siblings `_en` (pas de touch lakefile nécessaire).

## Liens cycle

- **c.367** [#6115](https://github.com/jsboige/CoursIA/pull/6115) `Grothendieck.lean` racine bilingue inline (MERGED, initie rollout Phase 2+)
- **c.381** [#6197](https://github.com/jsboige/CoursIA/pull/6197) `YonedaLemma` sibling (1ᵉʳ sous-module rollout Phase 2+, PIVOT L335 strict)
- **c.382** [#6202](https://github.com/jsboige/CoursIA/pull/6202) `MathlibMap` bilingue inline (2ᵉ sous-module rollout)
- **c.383** [#6208](https://github.com/jsboige/CoursIA/pull/6208) `SheafBasics` bilingue inline (3ᵉ sous-module rollout, 6 theorem fondations faisceaux)
- **c.387** [#6225](https://github.com/jsboige/CoursIA/pull/6225) `Sheafification` (4ᵉ sous-module rollout Phase 2+)
- **c.388** [#6233](https://github.com/jsboige/CoursIA/pull/6233) `SieveOps` (5ᵉ sous-module rollout Phase 2+)
- **c.393** (rétroactivement) `SieveLattice` (6ᵉ sous-module rollout Phase 2+)
- **c.458** [PR grothendieck_lean racine FR-first](https://github.com/jsboige/CoursIA/pull/6728) (sibling racine `Grothendieck.lean` ↔ `Grothendieck_en.lean` parent de cette PR)
- **c.459 = CETTE PR** : finalise les 4 derniers sous-modules `grothendieck_lean` Phase 2+ en sibling pairs

See #4980 (backlog EPIC Lean i18n)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>