### PR TITLE
feat(lean-i18n,#6727): check_i18n_siblings order-insensitive OK-REORDERED status

### DIFF
--- a/scripts/lean/check_i18n_siblings.py
+++ b/scripts/lean/check_i18n_siblings.py
@@ -53,7 +53,6 @@ missing).
 from __future__ import annotations
 
 import argparse
-import difflib
 import re
 import sys
 from collections import Counter
@@ -213,11 +212,15 @@ def imports_fr_sibling(en_src_stripped: str, fr_module: str) -> bool:
 
 def check_pair(fr_path: Path, en_path: Path) -> tuple[str, str]:
     """Compare an FR/EN sibling pair. Returns ``(status, detail)`` where
-    ``status`` is ``"OK"`` (bodies identical after normalization),
+    ``status`` is ``"OK"`` (bodies identical after normalization, same order),
     ``"OK-CONSUMER"`` (the EN file imports the FR module and every declaration
     block it does state matches an FR block — the rest is reused via the
-    import, not missing), or ``"DRIFT"`` (detail carries a short diff or the
-    offending blocks)."""
+    import, not missing), ``"OK-REORDERED"`` (the two files declare the same
+    multiset of top-level blocks but in a different order — a legitimate
+    structural divergence, doctrine C521-L3 / #6725, not repairable at zero
+    cost because lemma order can affect elaboration), or ``"DRIFT"`` (detail
+    lists the declaration blocks unique to each side — more actionable than a
+    text diff)."""
     fr_src = fr_path.read_text(encoding="utf-8")
     en_src = en_path.read_text(encoding="utf-8")
     fr_body = normalize_body(fr_src)
@@ -242,11 +245,36 @@ def check_pair(fr_path: Path, en_path: Path) -> tuple[str, str]:
         return "DRIFT", (
             f"consumer pattern, but {len(unmatched)} EN block(s) have no FR "
             f"counterpart:\n{preview}")
-    diff = difflib.unified_diff(
-        fr_body.splitlines(), en_body.splitlines(),
-        fromfile=str(fr_path), tofile=str(en_path), lineterm="",
-    )
-    return "DRIFT", "\n".join(list(diff)[:40])
+    # Order-insensitive comparison (#6727): the two files may declare the same
+    # top-level blocks in a different order — a legitimate structural divergence
+    # (C521-L3, ConeKernel #6725) that the ordered `fr_body == en_body` check
+    # above reports as DRIFT. Reordering the EN file to match FR has already
+    # broken the build once (commit 6788d1d1f), so it is recognized as OK.
+    fr_blocks = split_decls(fr_body)
+    en_blocks = split_decls(en_body)
+    if sorted(fr_blocks) == sorted(en_blocks):
+        moved = sum(1 for a, b in zip(fr_blocks, en_blocks) if a != b)
+        return "OK-REORDERED", (
+            f"{len(fr_blocks)} declaration block(s), identical order-"
+            f"insensitive ({moved} position(s) differ in order)")
+    # Genuine drift (#6727 step 3): list the declaration blocks unique to each
+    # side — a changed/removed/added block surfaces as a counterpart pair,
+    # which is more actionable than a textual unified diff.
+    fr_counter = Counter(fr_blocks)
+    en_counter = Counter(en_blocks)
+    fr_only = list(fr_counter - en_counter)
+    en_only = list(en_counter - fr_counter)
+    parts: list[str] = []
+    if fr_only:
+        preview_fr = "\n---\n".join(
+            "\n".join(b.splitlines()[:4]) for b in fr_only[:3])
+        parts.append(f"{len(fr_only)} block(s) only in FR:\n{preview_fr}")
+    if en_only:
+        preview_en = "\n---\n".join(
+            "\n".join(b.splitlines()[:4]) for b in en_only[:3])
+        parts.append(f"{len(en_only)} block(s) only in EN:\n{preview_en}")
+    detail = "; ".join(parts) if parts else "declaration bodies differ"
+    return "DRIFT", detail
 
 
 def _excluded(path: Path) -> bool:
@@ -302,7 +330,7 @@ def main(argv: list[str] | None = None) -> int:
         print("No *_en.lean sibling files found — nothing to check.")
         return 0
 
-    passed = consumer = failed = orphan = 0
+    passed = consumer = reordered = failed = orphan = 0
     for en in sorted(en_files):
         fr = fr_sibling(en)
         if not fr.exists():
@@ -316,13 +344,17 @@ def main(argv: list[str] | None = None) -> int:
         elif status == "OK-CONSUMER":
             consumer += 1
             print(f"OK-CONSUMER  {en}  ({detail})")
+        elif status == "OK-REORDERED":
+            reordered += 1
+            print(f"OK-REORDERED  {en}  ({detail})")
         else:
             failed += 1
             print(f"DRIFT   {en}")
             print(detail)
-    total = passed + consumer + failed + orphan
+    total = passed + consumer + reordered + failed + orphan
     print(f"\n{passed}/{total} pairs byte-identical"
-          f" | {consumer} consumer-pattern | {failed} drift | {orphan} orphan")
+          f" | {consumer} consumer-pattern | {reordered} reordered"
+          f" | {failed} drift | {orphan} orphan")
     return 0 if (failed == 0 and orphan == 0) else 1
 
 

--- a/scripts/lean/tests/test_check_i18n_siblings.py
+++ b/scripts/lean/tests/test_check_i18n_siblings.py
@@ -26,6 +26,10 @@ CONWAY_DIR = (
     REPO_ROOT
     / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean" / "conway_lean" / "Conway"
 )
+CONEKERNEL_EN = (
+    REPO_ROOT / "MyIA.AI.Notebooks" / "GameTheory" / "game_theory_lean"
+    / "CooperativeGames" / "ConeKernel_en.lean"
+)
 
 
 def test_strip_comments_removes_block_line_and_docstring():
@@ -212,6 +216,60 @@ def test_consumer_pattern_still_flags_novel_en_block(tmp_path):
     assert "no FR counterpart" in detail
 
 
+def test_check_pair_reordered_blocks_ok(tmp_path):
+    # C521-L3 / ConeKernel #6727 repro: declaring the same top-level blocks in
+    # a different order (the EN port inserted a lemma at a different site) is a
+    # legitimate structural divergence, not drift — reordering to match FR has
+    # already broken the build once (commit 6788d1d1f).
+    fr = tmp_path / "Pair.lean"
+    en = tmp_path / "Pair_en.lean"
+    fr.write_text(
+        "namespace Pair\n"
+        "theorem a : True := trivial\n"
+        "theorem b : True := trivial\n"
+        "theorem c : True := trivial\n"
+        "end Pair\n",
+        encoding="utf-8",
+    )
+    en.write_text(
+        "namespace Pair_en\n"
+        "theorem a : True := trivial\n"
+        "theorem c : True := trivial\n"
+        "theorem b : True := trivial\n"
+        "end Pair_en\n",
+        encoding="utf-8",
+    )
+    status, detail = check_pair(fr, en)
+    assert status == "OK-REORDERED", detail
+    assert "3 declaration block(s)" in detail
+
+
+def test_check_pair_real_drift_lists_unique_blocks(tmp_path):
+    # A genuinely changed block is NOT OK-REORDERED; the detail lists the
+    # blocks unique to each side (the changed block appears on both sides as
+    # an old/new counterpart) — actionable diagnostic, cf #6727 step 3.
+    fr = tmp_path / "Drift.lean"
+    en = tmp_path / "Drift_en.lean"
+    fr.write_text(
+        "namespace Drift\n"
+        "theorem a : True := trivial\n"
+        "theorem b : True := trivial\n"
+        "end Drift\n",
+        encoding="utf-8",
+    )
+    en.write_text(
+        "namespace Drift_en\n"
+        "theorem a : True := trivial\n"
+        "theorem b : Nat := 1\n"
+        "end Drift_en\n",
+        encoding="utf-8",
+    )
+    status, detail = check_pair(fr, en)
+    assert status == "DRIFT"
+    assert "only in FR" in detail
+    assert "only in EN" in detail
+
+
 def test_split_decls_attribute_line_starts_block():
     body = (
         "def f : Nat := 1\n"
@@ -260,6 +318,18 @@ def test_real_conway_pairs_are_byte_identical():
         if status == "DRIFT":
             failures.append(f"DRIFT {en.name}\n{detail}")
     assert not failures, "\n".join(failures)
+
+
+def test_real_conekernel_pair_is_reordered_not_drift():
+    """ConeKernel #6727 regression guard: the EN mirror declares the same 18
+    blocks as the FR canonical in a different order (lemma inserted at a
+    different site by port #6575). Must classify as OK-REORDERED, not DRIFT."""
+    en = CONEKERNEL_EN
+    fr = fr_sibling(en)
+    if not en.is_file() or not fr.is_file():
+        return  # tree not present in this checkout; skip silently
+    status, detail = check_pair(fr, en)
+    assert status == "OK-REORDERED", detail
 
 
 def _run_direct() -> int:


### PR DESCRIPTION
## What

`scripts/lean/check_i18n_siblings.py` gains a new **`OK-REORDERED`** status, resolving the third legitimate sibling-pair divergence (after self-qualifiers #6716 and the consumer pattern #6718).

When the ordered body comparison fails, `check_pair` now compares `sorted(split_decls(...))` on both sides:
- **equal** → `OK-REORDERED` (with the count of positions whose order differs) — the FR/EN files declare the same multiset of top-level blocks in a different order;
- **unequal** → `DRIFT` listing the declaration blocks **unique to each side** (a changed/added/removed block surfaces as an old/new counterpart pair) — more actionable than the prior textual unified diff.

The unused `difflib` import is dropped; `main()` counts `OK-REORDERED` as a pass.

## Why

`CooperativeGames/ConeKernel_en.lean` declares the same 18 blocks as the FR canonical but in a different order (port #6575 inserted `separatingFunctional_none_neg` at a different site). Reordering the EN file to match FR **broke the build once** (commit `6788d1d1f`) — lemma order can affect elaboration, so it is a legitimate structural divergence (doctrine C521-L3, whitelist via #6725), not repairable drift.

## Acceptance (#6727) — verified firsthand

```
$ python scripts/lean/check_i18n_siblings.py CooperativeGames/
OK-REORDERED  .../ConeKernel_en.lean  (18 declaration block(s), identical order-insensitive (5 position(s) differ in order))

$ python scripts/lean/check_i18n_siblings.py --all   (tail)
138/141 pairs byte-identical | 2 consumer-pattern | 1 reordered | 0 drift | 0 orphan     exit=0
```
ConeKernel DRIFT → **OK-REORDERED**; full-repo drift **1 → 0**; exit code now 0 (was 1).

Tests — 3 new (reorder-OK, real-drift unique-block diagnostic, ConeKernel real-file regression guard), **22/22 PASS** in both direct and pytest modes (CI `scripts-tests.yml`):

```
PASS test_check_pair_reordered_blocks_ok
PASS test_check_pair_real_drift_lists_unique_blocks
PASS test_real_conekernel_pair_is_reordered_not_drift
...
22 tests passed
```

`pyflakes` clean (no unused imports after dropping `difflib`); `py_compile` OK. Catalogue untouched (scripts-only).

Closes #6727
See #4980