### PR TITLE
docs(probas,#3974): Probas/Infer README de-stale Domaines table + corpus counts

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -121,7 +121,7 @@ Chaque notebook inclut les références nécessaires :
 
 ### 6. Graphviz (optionnel)
 
-Pour les visualisations de factor graphs dans les notebooks 11, 14-20 :
+Pour les visualisations de factor graphs dans les notebooks 11, 14-19 :
 
 ```bash
 # Windows (chocolatey)
@@ -844,16 +844,18 @@ Infer/
 
 | Domaine | Modèles | Notebooks |
 |---------|---------|-----------|
-| Jeux vidéo | TrueSkill, ranking | 6 |
-| Éducation | IRT, DINA, compétences | 5 |
-| NLP | LDA, topics | 9 |
-| Médecine | A/B testing, diagnostic, systèmes experts | 4, 7, 17, 18, 19 |
-| Crowdsourcing | Agrégation labels | 10 |
-| Finance | Détection régimes, aversion risque, MDPs | 11, 15, 20 |
-| E-commerce | Recommandation | 12 |
-| Bioinformatique | Motif finding | 11 |
-| Planification | Diagrammes d'influence, MDPs | 17, 20 |
-| Contrôle qualité | Valeur de l'information | 18 |
+| Jeux vidéo | TrueSkill, ranking | 8 |
+| Éducation | IRT, DINA, compétences | 7 |
+| NLP | LDA, topics | 11 |
+| Médecine | Diagnostic bayésien, test A/B, analyse de survie | 4, 9, 19 |
+| Crowdsourcing | Agrégation d'annotations | 13 |
+| Finance | Détection de régimes (rupture) | 18 |
+| E-commerce | Recommandation, factorisation | 15 |
+| Bioinformatique | Motif finding (HMM, ADN) | 14 |
+| Suivi, fusion de capteurs | Filtre de Kalman | 17 |
+| Contrôle qualité | Détection de rupture (dérive de production) | 18 |
+
+> Les applications de **théorie de la décision** — MDPs, valeur de l'information (EVPI/EVSI), aversion au risque, Thompson Sampling, indice de Gittins — vivent dans l'arc autonome [`../DecisionTheory/DecInfer/`](../DecisionTheory/DecInfer/README.md).
 
 ## Sources et Références
 
@@ -950,7 +952,7 @@ Consultez le [Glossaire](Infer-Glossary.md) pour les définitions des termes tec
 
 | Série | Lien | Relation |
 | --- | --- | --- |
-| [PyMC](../PyMC/) | Même 20 modèles en Python/NUTS | Message passing (EP) vs MCMC (NUTS) |
+| [PyMC](../PyMC/) | Même 19 modèles en Python/NUTS | Message passing (EP) vs MCMC (NUTS) |
 | [Probas (parent)](../README.md) | Vue d'ensemble Probas | Contexte et parcours |
 | [ML.NET](../../ML/ML.Net/) | TP prévision de ventes | Combine ML.NET + Infer.NET |
 | [Search/CSP](../../Search/Part2-CSP/) | CSP-5 (Optimization) | Programmation par contraintes et probabilités |
@@ -968,7 +970,7 @@ Cette série vous a fait parcourir l'arc complet de la programmation probabilist
 
 ### Prochaines étapes
 
-- **Le double regard MCMC** — le port [PyMC](../PyMC/) reprend les **20 mêmes modèles** en NUTS : alterner chaque jumeau pour comparer le message passing sur graphe de facteurs (Infer.NET, EP par défaut) et l'échantillonnage MCMC (PyMC, NUTS) sur des modèles identiques.
+- **Le double regard MCMC** — le port [PyMC](../PyMC/) reprend les **19 mêmes modèles** en NUTS : alterner chaque jumeau pour comparer le message passing sur graphe de facteurs (Infer.NET, EP par défaut) et l'échantillonnage MCMC (PyMC, NUTS) sur des modèles identiques.
 - **Le capstone ML.NET** — [ML.NET](../../ML/ML.Net/) combine ML.NET et Infer.NET (TP de prévision de ventes) : une mise en pratique où l'incertitude bayésienne complète une pipeline ML classique.
 - **Les ponts latéraux** — [Search/Part2-CSP](../../Search/Part2-CSP/) (CSP-5, optimisation sous contraintes) et le [glossaire](Infer-Glossary.md) prolongent la modélisation déclarative.
 


### PR DESCRIPTION
Leaf-README de-stale for `Probas/Infer/README.md` (EPIC #3973, subtask #3974). After the DecisionTheory extraction (corpus 1-19, was 20) and the series renumbering, the README carried four stale references — exactly the §E failure mode (intro/counts fixed while a table 100 lines below was left outdated).

## Stale spots fixed (all verified against disk, §E full-file audit)

1. **"Domaines d'Application" table** (l.845) — used **pre-renumbering notebook numbers AND referenced non-existent notebook #20** (TrueSkill as #6, Recommenders as #12, Finance as "11, 15, 20", Planification as "17, 20"). The "Vue d'ensemble" table at the top is the correct current reference (1-19). Rebuilt the domain table from current numbers; removed #20 and the DecisionTheory entries (MDPs, EVPI/EVSI, aversion au risque, Gittins) which now live in the autonomous [`../DecisionTheory/DecInfer/`](../DecisionTheory/DecInfer/README.md) arc; added a pointer line.

2. **"notebooks 11, 14-20"** (Graphviz, l.124) → `14-19` (no Infer-20 on disk).
3. **"Même 20 modèles en Python/NUTS"** (PyMC bridge, l.953) → `19`.
4. **"20 mêmes modèles"** (Prochaines étapes, l.971) → `19`.

## File-audit evidence (§E reconciliation disk ↔ prose)

```
$ ls Infer-*.ipynb | grep -v _output | wc -l   →  19   (Infer 1-19)
$ ls PyMC-*.ipynb | grep -v _output | wc -l    →  19   (so "20 modèles" was stale both sides)
$ ls Infer-20*                                  →  no such file  (#20 reference was fabricated)
$ ls -d DecisionTheory/DecInfer/                →  exists (extraction done)
```
Verified topic assignments: TrueSkill=8, IRT=7, LDA=11, Recommenders=15, HMM/ADN=14, Kalman=17, ChangePoint=18, Survival=19, A/B-clinical=9.

Catalogue untouched — this file carries **no CATALOG-STATUS marker**, so there is no catalog byte-identity concern. Markdown-only edit → no re-execution (C.2 exception, prior outputs valid).

See #3974 (partial — one leaf README of the #3973 leaf-READMEs rollout)