### PR TITLE
docs(gametheory): README SocialChoice table + counts de-stale (missing C# twins)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -93,7 +93,7 @@ Poursuivez avec les jeux dynamiques : notebook 7 (formes extensives), 9 (inducti
 
 ### Expert (applications avancées et choix social, ~19h)
 
-Les notebooks 13 (CFR), 15 (jeux coopératifs, Shapley), et 16 (design de mécanismes, Arrow) ouvrent les frontières de la discipline. La sous-série [SocialChoice/](SocialChoice/) (4 notebooks) approfondit le théorème d'Arrow via Lean, SAT et Z3. Le notebook 17 (Multi-Agent RL) fait le pont avec l'apprentissage par renforcement.
+Les notebooks 13 (CFR), 15 (jeux coopératifs, Shapley), et 16 (design de mécanismes, Arrow) ouvrent les frontières de la discipline. La sous-série [SocialChoice/](SocialChoice/) (7 notebooks dont 3 twins C#) approfondit le théorème d'Arrow via Lean, SAT et Z3. Le notebook 17 (Multi-Agent RL) fait le pont avec l'apprentissage par renforcement.
 
 ### Parcours alternatifs
 
@@ -211,10 +211,12 @@ flowchart TD
 | 16 | [GameTheory-16-MechanismDesign](GameTheory-16-MechanismDesign.ipynb) | Python | Principe de révélation, VCG, matching | 65 min |
 | 16 (C#) | [GameTheory-16-MechanismDesign-Csharp](GameTheory-16-MechanismDesign-Csharp.ipynb) | .NET (C#) | Twin C# du 16 : **enchères Vickrey 1er/2nd prix + VCG (règle de Clarke) + Gale-Shapley (stable matching) + double auction** from-scratch, BCL .NET 9 (See #4956) | 50 min |
 | SC-01 | [SocialChoice/01-Arrow-Impossibility-Theorem](SocialChoice/01-Arrow-Impossibility-Theorem.ipynb) | Python | Arrow : preuve formelle vs simulation | 45 min |
+| SC-01 (C#) | [SocialChoice/01-Arrow-Impossibility-Theorem-Csharp](SocialChoice/01-Arrow-Impossibility-Theorem-Csharp.ipynb) | .NET (C#) | Twin C# du SC-01 : **théorème d'Arrow from-scratch** (BCL .NET 9, 0 NuGet), preuve déterministe par énumération des profils de préférences (See #4956) | 45 min |
 | SC-02 | [SocialChoice/02-Lean-SocialChoice-Formal](SocialChoice/02-Lean-SocialChoice-Formal.ipynb) | Lean 4 + Python | Arrow, Sen, Électeur Médian, tour Peters | 70 min |
 | SC-03 | [SocialChoice/03-Voting-Methods](SocialChoice/03-Voting-Methods.ipynb) | Python | Condorcet, Borda, Copeland, modèle Downs | 45 min |
 | SC-03 (C#) | [SocialChoice/03-Voting-Methods-Csharp](SocialChoice/03-Voting-Methods-Csharp.ipynb) | .NET (C#) | Twin C# du SC-03 : **Plurality/Borda/Copeland/Condorcet/IRV from-scratch** (BCL .NET 9, 0 NuGet), paradoxe de Condorcet (cycle A>B>C), théorème d'Arrow (violation IIA démontrée déterministement), théorème de l'électeur median (See #4956) | 45 min |
 | SC-04 | [SocialChoice/04-Computational-Aggregation-SAT-Z3](SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb) | Python | Arrow encodé en SAT + Z3, UNSAT, relaxation | 60 min |
+| SC-04 (C#) | [SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp](SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb) | .NET (C#) | Twin C# du SC-04 : **solveur SAT DPLL from-scratch** (BCL .NET 9, 0 NuGet), Arrow encodé en CNF → preuve UNSAT (See #4956) | 60 min |
 | 17 | [GameTheory-17-MultiAgent-RL](GameTheory-17-MultiAgent-RL.ipynb) | Python | NFSP, PSRO, AlphaZero intro | 55 min |
 | 17 (C#) | [GameTheory-17-MultiAgent-RL-Csharp](GameTheory-17-MultiAgent-RL-Csharp.ipynb) | .NET (C#) | Twin C# du 17 : **Self-Play naif (cycle R-P-S)**, **Fictitious Play** (BR vs frequence empirique, convergence Robinson 1951), **exploitabilite**, **NFSP table-based** (Q-values + memoire, caveat convergence G.1), **PSRO** (population + meta-Nash) from-scratch, BCL .NET 9 (See #4956) | 50 min |
 
@@ -281,7 +283,7 @@ Chaque notebook introduit un concept ou un modèle spécifique. Le tableau ci-de
 | 8c | CombinatorialGames-Python | Variantes avancées (Wythoff, Chomp), visualisations |
 | 15c | CooperativeGames-Python | Exemples avancés (Glove Game, politique française) |
 
-### Sous-série SocialChoice (4 notebooks)
+### Sous-série SocialChoice (7 notebooks dont 3 twins C#)
 
 | # | Notebook | Apport pédagogique |
 |---|----------|-------------------|
@@ -691,7 +693,7 @@ GameTheory/
 ├── GameTheory-8c-CombinatorialGames-Csharp.ipynb   #   Jumeau C# — Wythoff/Chomp/périodicité Grundy from-scratch (parité #4956)
 ├── GameTheory-15c-CooperativeGames-Python.ipynb
 ├── GameTheory-15c-CooperativeGames-Csharp.ipynb    #   Jumeau C# — Shapley (permutations) + Banzhaf + Core vide (majorité) + Mini-ONU + convexité from-scratch (parité #4956)
-├── SocialChoice/                                   # Sous-série Choix Social (4 notebooks × 2 langues, parité #4956)
+├── SocialChoice/                                   # Sous-série Choix Social (7 notebooks : 4 pères Python/Lean + 3 twins C#, parité #4956)
 │   ├── 01-Arrow-Impossibility-Theorem.ipynb
 │   ├── 01-Arrow-Impossibility-Theorem-Csharp.ipynb
 │   ├── 02-Lean-SocialChoice-Formal.ipynb


### PR DESCRIPTION
Leaf-README de-stale for `GameTheory/README.md` (EPIC #3973, subtask #3975). The SocialChoice sub-series table and prose counted **"4 notebooks"** but the directory holds **7 canonical files**: three #4956-marathon C# twins landed on disk but never surfaced in the README. (SocialChoice=7 is corroborated by line 540, which already stated "7 notebooks : SC-01 à SC-04 + 3 jumeaux C#" — three other spots were inconsistently still at 4.)

## Changes (markdown-only → no re-exec, C.2 exception)

1. **2 missing twin rows** added to the main SocialChoice table:
   - `SC-01 (C#)` — `01-Arrow-Impossibility-Theorem-Csharp` (PR #5633): théorème d'Arrow from-scratch, BCL .NET 9, 0 NuGet.
   - `SC-04 (C#)` — `04-Computational-Aggregation-SAT-Z3-Csharp` (PR #5677): solveur SAT DPLL from-scratch, Arrow encodé en CNF → UNSAT.
   - (`SC-03 (C#)` was already present.)
2. **3 stale "4 notebooks" → "7 notebooks dont 3 twins C#"** reconciled (l.96 parcours Expert, l.286 sous-série header, l.696 file-tree comment). The misleading "(4 notebooks × 2 langues)" → accurate "7 notebooks : 4 pères Python/Lean + 3 twins C#" (SC-02 Lean has no C# twin, so it was never 4×2=8).

## File-audit evidence (§E reconciliation disk ↔ prose)

```
$ ls SocialChoice/*.ipynb | grep -v _output  →  7 canonical files:
  01-Arrow + 01-Arrow-Csharp, 02-Lean, 03-Voting + 03-Voting-Csharp, 04-Computational + 04-Computational-Csharp
$ test -f <each referenced twin>             →  all 3 C# twins present (no broken links)
```
Twin-row descriptions grounded in each twin's first markdown cell (read firsthand, not fabricated).

## Catalogue handling

CATALOG-STATUS marker left **byte-identical** (catalog-pr-hygiene R1 — automation-owned). Note: the marker's hub-level `root=43` is itself behind disk (48 hub-level notebooks, +5 twins from the same marathon) — that drift is catalog-cron's job, **signaled here, not manually fixed** (per §E: "si le catalogue est faux, signaler, ne pas s'aligner"). The SocialChoice sub-count (`SocialChoice=7` in the marker) IS correct, so prose reconciliation to 7 aligns prose ↔ marker ↔ disk for that sub-series.

See #3975 (partial — one README of the #3973 leaf-READMEs rollout)