### PR TITLE
feat(lean,#6727): teach check_i18n_siblings.py order-insensitive comparison (OK-REORDERED)

### DIFF
--- a/scripts/lean/check_i18n_siblings.py
+++ b/scripts/lean/check_i18n_siblings.py
@@ -211,29 +211,70 @@ def imports_fr_sibling(en_src_stripped: str, fr_module: str) -> bool:
     )
 
 
+def _drift_detail(fr_blocks: list[str], en_blocks: list[str],
+                  fr_path: Path, en_path: Path) -> str:
+    """Actionable DRIFT detail: list blocks unique to each side rather than a
+    noisy unified diff. Used when the ordered AND sorted comparisons both fail.
+    """
+    fr_counter = Counter(fr_blocks)
+    en_counter = Counter(en_blocks)
+    only_en: list[str] = []
+    for blk, n in en_counter.items():
+        if fr_counter[blk] >= n:
+            fr_counter[blk] -= n
+        else:
+            only_en.append(blk)
+    only_fr = list(fr_counter.elements())
+    parts: list[str] = []
+    if only_en:
+        parts.append(f"{len(only_en)} block(s) only in EN:")
+        parts.append("\n---\n".join(
+            "\n".join(b.splitlines()[:6]) for b in only_en[:3]))
+    if only_fr:
+        parts.append(f"{len(only_fr)} block(s) only in FR:")
+        parts.append("\n---\n".join(
+            "\n".join(b.splitlines()[:6]) for b in only_fr[:3]))
+    if not parts:
+        # Blocks match by multiset but full-body diff still failed (line-level
+        # noise inside a block): fall back to the unified diff for diagnostic.
+        diff = difflib.unified_diff(
+            fr_blocks, en_blocks,
+            fromfile=str(fr_path), tofile=str(en_path), lineterm="",
+        )
+        return "\n".join(list(diff)[:40])
+    return "\n".join(parts)
+
+
 def check_pair(fr_path: Path, en_path: Path) -> tuple[str, str]:
     """Compare an FR/EN sibling pair. Returns ``(status, detail)`` where
     ``status`` is ``"OK"`` (bodies identical after normalization),
     ``"OK-CONSUMER"`` (the EN file imports the FR module and every declaration
-    block it does state matches an FR block — the rest is reused via the
-    import, not missing), or ``"DRIFT"`` (detail carries a short diff or the
-    offending blocks)."""
+    block it does state must match an FR block — the rest is reused via the
+    import, not missing),
+    ``"OK-REORDERED"`` (FR and EN share the same multiset of declaration
+    blocks but in a different order — legitimate per ConeKernel / C521-L3; the
+    detail reports how many blocks moved), or
+    ``"DRIFT"`` (detail lists the blocks unique to each side)."""
     fr_src = fr_path.read_text(encoding="utf-8")
     en_src = en_path.read_text(encoding="utf-8")
     fr_body = normalize_body(fr_src)
     en_body = normalize_body(en_src)
     if fr_body == en_body:
         return "OK", ""
+    fr_blocks = split_decls(fr_body)
+    en_blocks = split_decls(en_body)
     if imports_fr_sibling(strip_comments(en_src), fr_path.stem):
-        fr_blocks = Counter(split_decls(fr_body))
+        # Consumer pattern: each EN-stated block must match an FR block (the
+        # rest is legitimately reused via the import).
+        fr_counter = Counter(fr_blocks)
         unmatched: list[str] = []
-        for blk in split_decls(en_body):
-            if fr_blocks[blk] > 0:
-                fr_blocks[blk] -= 1
+        for blk in en_blocks:
+            if fr_counter[blk] > 0:
+                fr_counter[blk] -= 1
             else:
                 unmatched.append(blk)
         if not unmatched:
-            reused = sum(fr_blocks.values())
+            reused = sum(fr_counter.values())
             return "OK-CONSUMER", (
                 f"{reused} FR declaration block(s) reused via import; "
                 "all EN-stated blocks match FR")
@@ -242,11 +283,16 @@ def check_pair(fr_path: Path, en_path: Path) -> tuple[str, str]:
         return "DRIFT", (
             f"consumer pattern, but {len(unmatched)} EN block(s) have no FR "
             f"counterpart:\n{preview}")
-    diff = difflib.unified_diff(
-        fr_body.splitlines(), en_body.splitlines(),
-        fromfile=str(fr_path), tofile=str(en_path), lineterm="",
-    )
-    return "DRIFT", "\n".join(list(diff)[:40])
+    # Third pattern (C521-L3 / #6727): same multiset of blocks, different
+    # order — legitimate when a lemma is declared at the site where it is
+    # first used rather than after a sibling lemma. Whitelisted via #6725
+    # (ConeKernel / ConeKernel_en).
+    if sorted(fr_blocks) == sorted(en_blocks) and fr_blocks != en_blocks:
+        moves = sum(1 for a, b in zip(fr_blocks, en_blocks) if a != b)
+        return "OK-REORDERED", (
+            f"{len(fr_blocks)} blocks shared, {moves} position(s) moved; "
+            "same multiset, order differs (legitimate, see C521-L3)")
+    return "DRIFT", _drift_detail(fr_blocks, en_blocks, fr_path, en_path)
 
 
 def _excluded(path: Path) -> bool:
@@ -302,7 +348,7 @@ def main(argv: list[str] | None = None) -> int:
         print("No *_en.lean sibling files found — nothing to check.")
         return 0
 
-    passed = consumer = failed = orphan = 0
+    passed = consumer = reordered = failed = orphan = 0
     for en in sorted(en_files):
         fr = fr_sibling(en)
         if not fr.exists():
@@ -316,13 +362,17 @@ def main(argv: list[str] | None = None) -> int:
         elif status == "OK-CONSUMER":
             consumer += 1
             print(f"OK-CONSUMER  {en}  ({detail})")
+        elif status == "OK-REORDERED":
+            reordered += 1
+            print(f"OK-REORDERED  {en}  ({detail})")
         else:
             failed += 1
             print(f"DRIFT   {en}")
             print(detail)
-    total = passed + consumer + failed + orphan
+    total = passed + consumer + reordered + failed + orphan
     print(f"\n{passed}/{total} pairs byte-identical"
-          f" | {consumer} consumer-pattern | {failed} drift | {orphan} orphan")
+          f" | {consumer} consumer-pattern | {reordered} reordered"
+          f" | {failed} drift | {orphan} orphan")
     return 0 if (failed == 0 and orphan == 0) else 1
 
 

--- a/scripts/lean/tests/test_check_i18n_siblings.py
+++ b/scripts/lean/tests/test_check_i18n_siblings.py
@@ -233,6 +233,102 @@ def test_fr_sibling_naming(tmp_path):
     assert fr_sibling(en).name == "Widget.lean"
 
 
+def test_check_pair_reorder_reports_ok_reordered(tmp_path):
+    """#6727 / C521-L3: same multiset of declaration blocks, different order
+    is legitimate (e.g. lemma declared at first-use site rather than after a
+    sibling). The checker must report ``OK-REORDERED`` instead of DRIFT.
+    """
+    fr = tmp_path / "Reorder.lean"
+    en = tmp_path / "Reorder_en.lean"
+    fr.write_text(
+        "namespace Game\n"
+        "def a : Nat := 1\n"
+        "def b : Nat := 2\n"
+        "def c : Nat := 3\n"
+        "end Game\n",
+        encoding="utf-8",
+    )
+    # EN declares in a different order (c, a, b) but same blocks.
+    en.write_text(
+        "namespace Game\n"
+        "def c : Nat := 3\n"
+        "def a : Nat := 1\n"
+        "def b : Nat := 2\n"
+        "end Game\n",
+        encoding="utf-8",
+    )
+    status, detail = check_pair(fr, en)
+    assert status == "OK-REORDERED", detail
+    assert "3 blocks shared" in detail
+    assert "legitimate" in detail
+
+
+def test_check_pair_reordered_does_not_mask_real_drift(tmp_path):
+    """If the multisets differ, ``OK-REORDERED`` must NOT trigger — the
+    status stays ``DRIFT`` and the detail lists the unique blocks."""
+    fr = tmp_path / "Mixed.lean"
+    en = tmp_path / "Mixed_en.lean"
+    fr.write_text(
+        "namespace Mixed\n"
+        "def a : Nat := 1\n"
+        "def b : Nat := 2\n"
+        "end Mixed\n",
+        encoding="utf-8",
+    )
+    en.write_text(
+        "namespace Mixed\n"
+        "def a : Nat := 1\n"
+        "def c : Nat := 3\n"
+        "end Mixed\n",
+        encoding="utf-8",
+    )
+    status, detail = check_pair(fr, en)
+    assert status == "DRIFT"
+    assert "only in EN" in detail or "only in FR" in detail
+
+
+def test_real_conekernel_pair_is_ok():
+    """Regression guard for the ConeKernel / #6725 merge: the checker must
+    keep reporting the pair as OK (bodies already byte-identical at
+    normalize_body level after the C521-L3 reorder fixes). Skips silently if
+    the file is not present in the checkout.
+    """
+    en = (REPO_ROOT
+          / "MyIA.AI.Notebooks" / "GameTheory" / "game_theory_lean"
+          / "CooperativeGames" / "ConeKernel_en.lean")
+    fr = en.with_name("ConeKernel.lean")
+    if not en.exists() or not fr.exists():
+        return  # tree not present in this checkout; skip silently
+    status, detail = check_pair(fr, en)
+    assert status == "OK", detail
+
+
+def test_real_repo_scan_has_no_orphan_drift():
+    """Sanity sweep across the merged rollout: every discoverable pair must
+    resolve to OK / OK-CONSUMER / OK-REORDERED — no DRIFT, no ORPHAN. Catches
+    regressions in the byte-identity invariant for all 6 lakes."""
+    from check_i18n_siblings import find_en_files
+    scan_roots = [
+        REPO_ROOT / "MyIA.AI.Notebooks" / "SymbolicAI" / "Lean",
+        REPO_ROOT / "MyIA.AI.Notebooks" / "GameTheory" / "game_theory_lean",
+    ]
+    en_files: list[Path] = []
+    for r in scan_roots:
+        if r.is_dir():
+            en_files.extend(find_en_files([r]))
+    assert en_files, "expected at least one *_en.lean in the rollout trees"
+    failures: list[str] = []
+    for en in en_files:
+        fr = fr_sibling(en)
+        if not fr.exists():
+            failures.append(f"ORPHAN {en.name}")
+            continue
+        status, detail = check_pair(fr, en)
+        if status not in ("OK", "OK-CONSUMER", "OK-REORDERED"):
+            failures.append(f"{status} {en.name}\n{detail}")
+    assert not failures, "\n".join(failures)
+
+
 def test_find_en_files_skips_excluded(tmp_path):
     good = tmp_path / "Good_en.lean"
     good.write_text("x", encoding="utf-8")


### PR DESCRIPTION
# feat(lean,#6727): teach check_i18n_siblings.py order-insensitive comparison

**See #6727** — third legitimate sibling-pair pattern (C521-L3 / #6725) needs explicit OK-REORDERED status instead of DRIFT.

## Contexte (EPIC #4980)

Le checker `scripts/lean/check_i18n_siblings.py` (#6711, durci #6718) compare les paires FR/EN par corps normalisé **ordonné**. Or #6725 (C521-L3 doctrine) a whitelisté un troisième pattern légitime : même multiset de blocs de déclarations mais ordre différent (un lemme déclaré au site de première utilisation plutôt qu'après un sibling).

**Vérification firsthand (c.462)** : la paire `ConeKernel.lean` / `ConeKernel_en.lean` est désormais **déjà byte-identique au niveau `normalize_body`** après le fix #6725 — donc le statut reste `OK`. Le nouveau code `OK-REORDERED` est **forward-looking** : il activera pour toute future paire où la merge du EN aurait laissé les blocs réordonnés.

## Changements (atomique, 1 PR = 1 sujet)

1. **`scripts/lean/check_i18n_siblings.py`** (+58/-10 net)
   - **Nouveau helper** `_drift_detail()` : remplace le diff unifié sur les bodies par un diff **multiset** des blocs — liste les blocs *uniques à chaque côté* (plus actionnable que le diff textuel quand le multiset diffère), fallback sur le diff unifié si les multisets matchent (drift intra-bloc).
   - **Nouveau statut `OK-REORDERED`** dans `check_pair()` : quand `fr_body != en_body` mais `sorted(fr_blocks) == sorted(en_blocks)`. Detail rapporte `N blocks shared, M positions moved` et la doctrine (`legitimate, see C521-L3`).
   - `main()` compte `reordered` séparément ; exit code reste 0 sur `OK-REORDERED` (légitime).
   - Docstring du `check_pair` mise à jour : 4 statuts (OK / OK-CONSUMER / **OK-REORDERED** / DRIFT) au lieu de 3.

2. **`scripts/lean/tests/test_check_i18n_siblings.py`** (+96/-0)
   - `test_check_pair_reorder_reports_ok_reordered` : repro synthétique (a/b/c → c/a/b) → `OK-REORDERED` avec detail `3 blocks shared`.
   - `test_check_pair_reordered_does_not_mask_real_drift` : multiset différent → reste `DRIFT`, detail liste les blocs uniques (pas de faux négatif).
   - `test_real_conekernel_pair_is_ok` : regression guard post-#6725 — la pair reste `OK` (le multiset match + bodies byte-identical).
   - `test_real_repo_scan_has_no_orphan_drift` : sweep des 2 rollout trees (SymbolicAI/Lean + GameTheory/game_theory_lean) — tous les statuts ∈ {OK, OK-CONSUMER, OK-REORDERED}, échoue si DRIFT ou ORPHAN apparaît.

## Anti-régression

- `check_i18n_siblings.py --all` après modif : **140/142 byte-identical | 2 consumer-pattern | 0 reordered | 0 drift | 0 orphan** (exit 0, vert). Avant la modif : **24/24 conway_lean + autres lakes clean** — pas de regression observée ; la logique existante reste prioritaire (`OK` > `OK-CONSUMER` > `OK-REORDERED` > `DRIFT`).
- Aucune modif de fichiers `.lean` (vérifier git diff : 0 .lean touched).
- Aucun import FR modifié.
- Code de production préservé : les seuils de comparaison ordonnée restent la première passe ; `OK-REORDERED` ne s'active que quand l'ordonnée a échoué.

## Vérification

- **Direct** : `python scripts/lean/tests/test_check_i18n_siblings.py` → **23/23 tests PASS** (4 nouveaux + 19 anciens).
- **Pytest** (CI scripts-tests.yml) : `python -m pytest scripts/lean/tests/test_check_i18n_siblings.py -q` → **23 passed in 0.43s**.
- **Full repo scan** : `python scripts/lean/check_i18n_siblings.py --all` → exit 0, 0 drift, 0 orphan.

## Fichiers

| File | Change | Lines |
|------|--------|-------|
| `scripts/lean/check_i18n_siblings.py` | OK-REORDERED status + multiset DRIFT detail | +58/-10 |
| `scripts/lean/tests/test_check_i18n_siblings.py` | 4 new tests + 1 repo-sweep guard | +96/-0 |

Total : 1 PR = 1 sujet (checker enhancement), 2 fichiers, +154/-10, ≤ 3000 lignes (G.4 OK), 1 domaine (Lean i18n tooling), atomic.

## Anti-patterns évités

- **Pas de workaround dégradé** : nouvelle branche de détection explicite, pas de skip silencieux du sort.
- **Pas de bloc bilingue inline** (rappel convention EPIC #4980) : pas de modif `.lean`.
- **Pas de catalog regen** : aucun fichier catalogue touché (`COURSE_CATALOG.generated.*` byte-identique à origin/main, cf catalog-pr-hygiene R1).
- **Pas de force push** : base `e6a2db8ab` = origin/main à jour (R2 OK, vérifié post-fetch).
- **Pas de double-claim** : aucun dashboard accessible (L500 session isolation confirmée), aucun claim posé sur INTERCOM par cette PR.
- **Pas de merge** : L278/L279 worker JAMAIS merge own PR → en attente review/merge ai-01.

## Liens

- #6727 — issue source (3rd pattern FP, target enhancement)
- #6725 — precedent merge ConeKernel whitelist documentation (C521-L3 doctrine)
- #6718 — checker precedent hardening (self-qualifier + consumer-pattern)
- #6711 — checker original (1ʳᵉ fondation byte-identity checker)
- #4980 — EPIC Lean i18n parent
- L504 ★ — lesson root-twin-glob-pattern (cyclic: ce fix renforce aussi la lisibilité du rapport checker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
