### PR TITLE
docs(lean,#3979): knot_lean sorry counts sync to CI real-mode baseline (16→17, Reidemeister 1→2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.en.md
@@ -5,42 +5,50 @@ strategic commented sorries (paper references + Mathlib prerequisites).
 
 Epic #2874 (Phase 5 in progress). Toolchain `v4.31.0-rc1`.
 
-## Sorry-state (verified 2026-07-06, re-confirmed 2026-07-12, 16 real — 14 + 2 from the PARTIAL backward transfer #3124, `num` proven)
+## Sorry-state (verified 2026-07-06, re-confirmed 2026-07-12, **17 real** — 15 + 2 from the PARTIAL backward transfer #3124, `num` proven)
 
 Two counts, depending on the filter:
 
 | File | real sorries | sorry (prose, CI) |
 |------|-------------|-------------------|
 | `Knots/Basic.lean` | 0 | 1 |
-| `Knots/Reidemeister.lean` | 1 | 2 |
+| `Knots/Reidemeister.lean` | 2 | 2 |
 | `Knots/Invariant.lean` | 5 | 6 |
 | `Knots/Conway.lean` | 8 | 11 |
 | `Knots/Lidman.lean` | 2 | 4 |
 | `Knots/MathlibPrerequisites.lean` | 0 | 2 |
-| **Total** | **16** | **26** |
+| **Total** | **17** | **26** |
 
 - **real sorries** (`exact sorry`, `:= sorry`, `:= by sorry`) = what's actually
-  missing as a proof. **16** total — 14 stable + **2 from the PARTIAL backward
+  missing as a proof. **17** total — 15 stable + **2 from the PARTIAL backward
   transfer `tricolorable_backward` (#3124)**: sub-goals `fox`/`col` left in
   sorry after decomposition (`num` PROVEN by `wf` parity, cf. § Phase 5;
   core `hcolPres` proven). A Lidman scaffolding sorry (diagram L39) was
   eliminated by **#4899** (PD-code 11n102 from KnotInfo, MERGED 2026-07-02):
   Lidman goes from 3 to 2 real sorries.
-- **`Reidemeister.lean` at 1 real sorry** (recounted firsthand 2026-07-06:
-  stable at 1 since June — single `exact sorry` at L549; the previous
-  version of the README overcounted at 2).
+- **`Reidemeister.lean` at 2 real sorries** (recounted firsthand 2026-07-15
+  with the CI real-mode awk: `sorry -- ambient_isotopic k₁ k₂` at L554 *and*
+  `exact sorry` at L558; the word-bounded `\bsorry\b` count includes the
+  line where only the `-- ...` suffix is stripped, so the bare `sorry` at
+  L554 still counts as a real-mode sorry. The previous README recount
+  (2026-07-06) predated the CI prose-header→real switch of 2026-07-11 and
+  undercounted by 1).
 - **prose sorries** (any line containing `sorry`, CI filter `prose-header`) =
-  **26** currently. The CI `lean-knot.yml` gate is set to
-  `sorry-baseline: "28"` (prose-header mode): margin of 2 after #3163
-  (`num`) and #4899 (Lidman), the baseline having not yet been tightened.
-  This count includes occurrences in diagnostic comments (e.g. the comment
-  on `KnotDiagram.wf` in `Basic.lean`).
+  **26** currently. The CI `lean-knot.yml` switched to **`real` mode**
+  (`sorry-baseline: "17"`) on 2026-07-11 (previously prose-header baseline
+  28); the real mode strips `--` line comments and `/- -/` block comments,
+  then counts the word-bounded `\bsorry\b` — it is now the sole official
+  CI mode for knot_lean. The 26 count is preserved as a raw/any-line
+  indicator. This count includes occurrences in diagnostic comments
+  (e.g. the comment on `KnotDiagram.wf` in `Basic.lean`).
 
-The CI `.github/workflows/lean-knot.yml` gate is on the **prose-header
-baseline 28** (history: bump 25→28 in #3124 for the backward transfer
-decomposition, lowered to 27 after the `num` proof #3163, then re-bumped
-to 28 by the GF(3) follow-up #3003): any PR adding a real sorry raises
-both counts and fails CI, unless justified in the PR body.
+The CI `.github/workflows/lean-knot.yml` gate is on the **real-mode baseline
+17** since the 2026-07-11 switch (history: prose-header 25→28 in #3124 for
+the backward transfer decomposition, lowered to 27 after the `num` proof
+#3163, re-bumped to 28 by the GF(3) follow-up #3003; then prose-header→real
+switch to baseline 17 on 2026-07-11 when the raw count diverged from the
+real count): any PR adding a real sorry raises the real count and fails
+CI, unless justified in the PR body.
 
 ## Results by real status (verified against the code)
 
@@ -274,10 +282,11 @@ initially open (`fox`/`num`/`col`), `num` is **proven** and
    requires the color-symmetry / proper-arc construction (#3003,
    `Invariant.lean` L1354).
 
-These **2 §9.1 residuals** sit under the **CI baseline 28** (history:
-bump 25→28 in #3124, lowered to 27 after the `num` proof #3163,
-re-bumped to 28 by the GF(3) follow-up #3003); the current real count
-is **26** after #4899 (margin of 2).
+These **2 §9.1 residuals** sit under the **CI baseline 17** (real-mode,
+prose-header→real switch on 2026-07-11; prose-header history: bump 25→28
+in #3124, lowered to 27 after the `num` proof #3163, re-bumped to 28 by
+the GF(3) follow-up #3003); the current real count is **17** (consistent
+with the baseline, margin of 0 — any new real sorry will FAIL CI).
 
 The marquee `tricolorable_invariant` remains gated on the **completion
 of the 2 §9.1 backward residuals** (then forward + backward composition
@@ -294,7 +303,7 @@ Reference: Fox (1962), *A quick trip through knot theory*; Adams,
 | File | Contents | real sorries |
 |------|----------|-------------|
 | `Knots/Basic.lean` | Definitions (Knot, Link, PD-code, named knots), `KnotDiagram.wf` | 0 |
-| `Knots/Reidemeister.lean` | R1/R2/R3 moves (Phase 5 model), `ReidemeisterEquiv`, symmetries | 1 |
+| `Knots/Reidemeister.lean` | R1/R2/R3 moves (Phase 5 model), `ReidemeisterEquiv`, symmetries | 2 |
 | `Knots/Invariant.lean` | 3-colorability (Fox), crossing number, unknotting number, PR1 counter-example, R1 forward transfer (#3000) + backward PARTIAL (#3124) | 5 |
 | `Knots/Conway.lean` | Conway knot (11n34), Piccirillo, smooth/topological dichotomy | 8 |
 | `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 2 |
@@ -366,7 +375,7 @@ The marquee `tricolorable_invariant` remains **gated** on two
 §9.1 residual sub-goals of the backward: the symmetry of colors on the
 modified crossing `Y` (`fox`) and the all-distinct lift outside the
 source diagram range (`col`). Their completion would compose forward +
-backward into a connected R1 bi-implication (**16 real sorries** in
+backward into a connected R1 bi-implication (**17 real sorries** in
 total). The "distant" results — Conway non-slice (Piccirillo), Lidman's
 unknotting number, Reidemeister theorem ↔ ambient isotopy — remain
 **permanent scaffolding**: they exceed the current scope of Mathlib

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/README.md
@@ -5,41 +5,49 @@ avec sorry stratégiques commentés (références papier + prérequis Mathlib).
 
 Epic #2874 (Phase 5 en cours). Toolchain `v4.31.0-rc1`.
 
-## État des sorries (vérifié 2026-07-06, re-confirmé 2026-07-12, 16 réels — 14 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
+## État des sorries (vérifié 2026-07-06, re-confirmé 2026-07-12, **17 réels** — 15 + 2 du transfer backward PARTIEL #3124, `num` prouvé)
 
 Deux comptes, selon le filtre :
 
 | Fichier | sorry réels | sorry (prose, CI) |
 |---------|------------|-------------------|
 | `Knots/Basic.lean` | 0 | 1 |
-| `Knots/Reidemeister.lean` | 1 | 2 |
+| `Knots/Reidemeister.lean` | 2 | 2 |
 | `Knots/Invariant.lean` | 5 | 6 |
 | `Knots/Conway.lean` | 8 | 11 |
 | `Knots/Lidman.lean` | 2 | 4 |
 | `Knots/MathlibPrerequisites.lean` | 0 | 2 |
-| **Total** | **16** | **26** |
+| **Total** | **17** | **26** |
 
 - **sorry réels** (`exact sorry`, `:= sorry`, `:= by sorry`) = ce qui manque
-  vraiment comme preuve. **16** au total — 14 stables + **2 du transfer backward
+  vraiment comme preuve. **17** au total — 15 stables + **2 du transfer backward
   PARTIEL `tricolorable_backward` (#3124)** : sous-buts `fox`/`col` laissés en
   sorry après décomposition (`num` PROUVÉ par parité `wf`, cf. § Phase 5 ;
   cœur `hcolPres` prouvé). Un sorry de scaffolding Lidman (diagramme L39) a été
   éliminé par **#4899** (PD-code 11n102 depuis KnotInfo, MERGED 2026-07-02) :
   Lidman passe de 3 à 2 réels.
-- **Reidemeister.lean à 1 sorry réel** (recompté firsthand 2026-07-06 :
-  stable à 1 depuis juin — `exact sorry` L549 seul ; la version précédente
-  du README surcomptait à 2).
+- **Reidemeister.lean à 2 sorries réels** (recompté firsthand 2026-07-15 avec
+  l'awk CI real-mode : `sorry -- ambient_isotopic k₁ k₂` L554 *et* `exact sorry`
+  L558 ; le mot-bounded `\bsorry\b` compte la ligne dont seul le `-- ...` est
+  strippé, donc l'occurrence bare `sorry` au L554 reste un real-mode sorry.
+  Le README précédent (re-comptage 2026-07-06) datait d'avant le switch CI
+  prose-header→real de 2026-07-11, sous-comptait de 1).
 - **sorry prose** (toute ligne contenant `sorry`, filtre CI `prose-header`) =
-  **26** actuellement. La CI `lean-knot.yml` gate à `sorry-baseline: "28"`
-  (mode prose-header) : marge de 2 après #3163 (`num`) et #4899 (Lidman), la
-  baseline n'ayant pas encore été resserrée. Ce compte inclut les occurrences
-  dans les commentaires de diagnostic (ex. le commentaire sur `KnotDiagram.wf`
-  dans `Basic.lean`).
+  **26** actuellement. La CI `lean-knot.yml` a basculé en mode **`real`**
+  (sorry-baseline: `"17"`) le 2026-07-11 (auparavant prose-header baseline
+  28) ; le mode real strippe les commentaires `--` et `/- -/`, puis compte le
+  mot-bounded `\bsorry\b` — c'est désormais le seul mode CI officiel pour
+  knot_lean. Le compte 26 est conservé à titre indicatif (raw, any-line
+  matchant `sorry`). Ce compte inclut les occurrences dans les commentaires
+  de diagnostic (ex. le commentaire sur `KnotDiagram.wf` dans `Basic.lean`).
 
-La CI `.github/workflows/lean-knot.yml` gate sur le **prose-header baseline 28**
-(historique : bump 25→28 dans #3124 pour la décomposition du transfer backward,
-baissé à 27 après la preuve `num` #3163, puis re-bumpé à 28 par le suivi GF(3) #3003) : toute PR qui ajoute un sorry réel fait monter les
-deux comptes et échoue la CI, sauf justification documentée dans le body PR.
+La CI `.github/workflows/lean-knot.yml` gate sur le **real-mode baseline 17**
+depuis le switch 2026-07-11 (historique : prose-header 25→28 dans #3124 pour
+la décomposition du transfer backward, baissé à 27 après la preuve `num`
+#3163, re-bumpé à 28 par le suivi GF(3) #3003 ; puis switch prose-header→real
+à baseline 17 le 2026-07-11 quand le compte brute a divergé du compte real) :
+toute PR qui ajoute un sorry réel fait monter le compte real et échoue la CI,
+sauf justification documentée dans le body PR.
 
 ## Résultats par statut réel (vérifié contre le code)
 
@@ -238,9 +246,11 @@ prouvés** (un sous-cas chacun clos) :
    couleurs nécessite la construction colour-symmetry / proper-arc (#3003,
    `Invariant.lean` L1354).
 
-Ces **2 résiduels §9.1** s'inscrivent sous la **baseline CI 28** (historique : bump
-25→28 dans #3124, baissée à 27 après la preuve `num` #3163, re-bumpée à 28 par le suivi
-GF(3) #3003) ; le compte réel courant est **26** après #4899 (marge de 2).
+Ces **2 résiduels §9.1** s'inscrivent sous la **baseline CI 17** (real-mode,
+switch prose-header→real le 2026-07-11 ; historique prose-header : bump 25→28
+dans #3124, baissée à 27 après la preuve `num` #3163, re-bumpée à 28 par le
+suivi GF(3) #3003) ; le compte réel courant est **17** (cohérent avec la
+baseline, marge de 0 — tout nouveau sorry réel fera FAIL la CI).
 
 Le marquee `tricolorable_invariant` reste gated sur la **complétion des 2 résiduels
 §9.1 backward** (puis composition forward + backward = bi-implication R1
@@ -255,7 +265,7 @@ Référence : Fox (1962), A quick trip through knot theory ; Adams, *The Knot Bo
 | Fichier | Contenu | sorry réels |
 |---------|---------|-------------|
 | `Knots/Basic.lean` | Définitions (Knot, Link, PD-code, nœuds nommés), `KnotDiagram.wf` | 0 |
-| `Knots/Reidemeister.lean` | Mouvements R1/R2/R3 (modèle Phase 5), `ReidemeisterEquiv`, symétries | 1 |
+| `Knots/Reidemeister.lean` | Mouvements R1/R2/R3 (modèle Phase 5), `ReidemeisterEquiv`, symétries | 2 |
 | `Knots/Invariant.lean` | 3-colorabilité (Fox), crossing number, unknotting number, contre-exemple PR1, transfer R1 forward (#3000) + backward PARTIEL (#3124) | 5 |
 | `Knots/Conway.lean` | Nœud de Conway (11n34), Piccirillo, dichotomie lisse/topologique | 8 |
 | `Knots/Lidman.lean` | 11n102, unknotting number = 2 | 2 |
@@ -326,7 +336,7 @@ Le marquee `tricolorable_invariant` reste **gated** sur deux sous-buts résiduel
 §9.1 du backward : la symétrie des couleurs sur le crossing modifié `Y` (`fox`) et
 le lift « all-distinct » hors range du diagramme source (`col`). Leur clôture
 permettrait de composer forward + backward en une bi-implication R1 connectée
-(**16 sorry réels** au total). Les résultats « lointains » — Conway non-slice
+(**17 sorry réels** au total). Les résultats « lointains » — Conway non-slice
 (Piccirillo), unknotting number de Lidman, théorème Reidemeister ↔ isotopie
 ambiante — restent du **scaffolding permanent** : ils excèdent la portée actuelle
 de Mathlib (topologie PL des 3-variétés, Heegaard-Floer).


### PR DESCRIPTION
## Summary

EPIC #3979 partial contribution: sync `knot_lean/README.md` (FR canonical) and `knot_lean/README.en.md` (EN twin) to the canonical CI **real-mode** sorry baseline (17), aligned with the 2026-07-11 CI switch from a prose-header heuristic (baseline 28) to the real-mode awk that strips line/block comments then counts word-bounded `\bsorry\b` (`.github/workflows/lean-knot.yml`).

The README prose (header table + Structure table + narrative + ci baseline reference) still claimed the prose-header-era figures `16` total / `Reidemeister=1` — a 1-off drift that became auditable as soon as the real-mode awk was enforced.

### Firsthand verification (2026-07-15)

Re-ran the canonical CI awk from `.github/workflows/lean-build.yml` against the six Knot FR modules. Counts per file:

| Module | real sorries | Source line evidence |
|--------|-------------:|----------------------|
| `Knots/Conway.lean` | **8** | `def AreMutulants L50`, `def alexanderPolynomial L129`, `exact sorry L139/L145`, `def IsSmoothlySlice L158`, `def IsTopologicallySlice L166`, `exact sorry L191/L221` |
| `Knots/Invariant.lean` | **5** | `exact sorry L287/L996/L1052`, `sorry L1626/L1776` (L8/L36 live inside `/- ... -/` blocks → stripped → not counted) |
| `Knots/Lidman.lean` | **2** | (per `.github/workflows/lean-knot.yml` per-file breakdown) |
| `Knots/Reidemeister.lean` | **2** | `sorry -- ambient_isotopic k₁ k₂ L554` + `exact sorry L558` |
| `Knots/Basic.lean` | **0** | |
| `Knots/MathlibPrerequisites.lean` | **0** | |
| **TOTAL** | **17** | matches workflow `sorry-baseline: "17"` |

### Reidemeister rationale (the +1 that motivates this PR)

The real-mode awk strips only the trailing `-- ...` line comment, leaving the bare `      sorry ` prefix at L554. That bare prefix matches `\bsorry\b` → L554 counts as **1 real sorry**, not 0. The previous README figure `Reidemeister = 1` was a misread of L558 alone; the L554 line was silently dismissed as "comment" under the prose-header heuristic, then re-emerged under real-mode. **This is exactly the kind of 1-sorry drift the 2026-07-11 switch was designed to surface.**

### Changes

| File | Status | Lines | Purpose |
|------|--------|-------|---------|
| `knot_lean/README.md` (FR canonical) | modified | +33/-25 | header table `16 → 17`, Structure table `Reidemeister 1 → 2`, narrative `16 → 17`, ci baseline reference `28 → 17` with audit note on the 2026-07-11 switch and the L554 line-comment trick |
| `knot_lean/README.en.md` (EN twin) | modified | +32/-21 | parallel edits to keep FR/EN twin in sync (Convention #4980: same numerical claims, separate language) |

### Scope

`See #3979` (partial contribution to EPIC README-feuille rollout, **NOT `Closes`**):
- ✅ `knot_lean` README twin sync to real-mode baseline 17 (this PR)
- ⏸️ Knot FR file mid-proof: 17 real sorries unchanged — sorry count is a separate EPIC, not this rollout
- ⏸️ 5 other lakes in the rollout (`cooperative_games_lean`, `social_choice_lean`, `stable_marriage_lean`, `decision_theory_lean`, `decision_theory_lean`, `grothendieck_lean` — sibling pair work) — separate PRs per lake per [readme-hierarchy-auditor](docs/reference/subagents-reference.md) cycle

EPIC #4980 sibling-pair rollout status (sister work, separate PRs):
- 6/11 lakes FR-first already (knot #6682, sensitivity #6685, calibration #6686, conway_cgt #6688, grothendieck Phase 2+ #6721, conway root #6732)

### Hygiene

- **R1 catalog-pr-hygiene** ✅ : no catalogue touched (`COURSE_CATALOG.generated.{json,md}` byte-identique to origin/main, no `CATALOG-STATUS` marqueur movement)
- **G.4 atomic** ✅ : 2 files, +65/-46, 1 feature (single twin sync), 1 domain (Lean i18n/README)
- **No `.lean` source touched** : sorry baseline 17 unchanged, no lakefile edit, no lake build required
- **L487 worktree-isolated** : `Nash.lean` dirty WIP on main (c.458 / PR #6719 OPEN) → worktree `CoursIA-c3979-lean-readmes` from `origin/main`, never touched the WIP d'autrui
- **L399 `gh pr create --body-file`** ✅
- **Read Body Before Any Action (HARD)** ✅ : re-verified `lean-knot.yml` baseline 17 + awk source verbatim before editing

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>