### PR TITLE
fix(sota,#3801): SC-16 TenSEAL CKKS real output (was ImportError fallback)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -811,12 +811,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TenSEAL non installe.\n",
-      "Pour installer : pip install tenseal\n",
+      "CKKS AVEC TENSEAL\n",
+      "======================================================================\n",
+      "Degree du polynome : 8192\n",
+      "Scale (precision)  : 2^40\n",
       "\n",
-      "TenSEAL permet de manipuler des vecteurs chiffres avec le schema CKKS.\n",
-      "Les operations supportees incluent addition, multiplication, et produit scalaire.\n",
-      "L'erreur d'approximation est typiquement de l'ordre de 1e-6 a 1e-4.\n"
+      "v1 (clair)  : [1.5, 2.3, 4.7, 8.1]\n",
+      "v2 (clair)  : [0.5, 1.7, 3.3, 1.9]\n",
+      "\n",
+      "Addition chiffree :\n",
+      "  Resultat   : [2.0, 4.0, 8.0, 10.0]\n",
+      "  Attendu    : [2.0, 4.0, 8.0, 10.0]\n",
+      "  Erreur max : 1.28e-09\n",
+      "\n",
+      "Multiplication chiffree :\n",
+      "  Resultat   : [0.75, 3.910001, 15.510002, 15.390002]\n",
+      "  Attendu    : [0.75, 3.9099999999999997, 15.51, 15.389999999999999]\n",
+      "  Erreur max : 2.08e-06\n",
+      "\n",
+      "Produit scalaire chiffre :\n",
+      "  Resultat   : 35.560004\n",
+      "  Attendu    : 35.559999999999995\n",
+      "  Erreur     : 4.23e-06\n"
      ]
     }
    ],
@@ -958,13 +974,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TenSEAL non installe - benchmark ignore.\n",
+      "BENCHMARK CKKS (vecteur de 100 elements)\n",
+      "======================================================================\n",
+      "  Chiffrement        : 2.77 ms\n",
+      "  Addition chiffree  : 0.03 ms\n",
+      "  Multiplication     : 2.13 ms\n",
+      "  Dechiffrement      : 0.90 ms\n",
       "\n",
-      "Ordres de grandeur typiques CKKS (vecteur 100 elements) :\n",
-      "  Chiffrement       : ~1-5 ms\n",
-      "  Addition chiffree : ~0.1 ms\n",
-      "  Multiplication    : ~1-5 ms\n",
-      "  Overhead total    : ~1000x-10000x vs calcul en clair\n"
+      "  Overhead vs calcul en clair : ~1000x-10000x\n",
+      "  -> Le HE est couteux, a utiliser quand la confidentialite l'exige\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary

SC-16-Homomorphic-Encryption cells[5][6] committed the conceptual **"TenSEAL non installe" fallback** (a degraded workaround) instead of running real CKKS homomorphic encryption. The cell **source was already SOTA-correct** — real TenSEAL CKKS code (context, encrypt, homomorphic add/mul/dot, decrypt, benchmark) gated only by a `try/except ImportError` guard. The defect was environmental (TenSEAL not installed), not in the source.

## SOTA verdict — Prong A (RECOVERABLE-LOCAL)

Per [sota-not-workaround](../blob/main/.claude/rules/sota-not-workaround.md) EPIC **#3801**. TenSEAL is pip-installable. **Stop & Repair** (not a hand-edit scrub):

1. Installed `tenseal==0.3.16` (prebuilt cp313 wheel, no native build) in the `python3` (Store 3.13) kernel env — the declared kernel of all 27 SC notebooks.
2. Re-executed the **unchanged** cell source in that declared kernel.
3. Injected the genuine stdout as stream outputs. `execution_count` preserved (6, 7).

The committed output is now the **real CKKS output**, not a substitution.

## Real outputs committed

- **cell[5]**: CKKS homomorphic add `[2.0, 4.0, 8.0, 10.0]` (err 1.28e-09), mul `[0.75, 3.91, 15.51, 15.39]` (err 2.08e-06), dot product `35.56` (err 4.23e-06) — demonstrates CKKS approximate-arithmetic capability.
- **cell[6]**: benchmark — encrypt 2.77ms, add 0.03ms, mul 2.13ms, decrypt 0.90ms, **~1000x–10000x overhead** vs plaintext.

## Validation

- `nbformat.validate()` OK
- Surgical diff: **+29 / −11**, only cells[5][6] outputs changed; **source unchanged, kernelspec unchanged**
- indent=1, LF, no BOM (starts `7b 0a 22`), trailing newline
- `grep -nE "raise NotImplementedError|assert False|1/0"` = 0 (C.1)

## Scope (atomic)

Only SC-16. Note: cell[7] (Zama `concrete-python` FHE compiler) remains a **separate** conceptual fallback — different tool, heavier install; out of scope for this atomic TenSEAL PR. The Paillier cells were already SOTA-OK.

See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)