### PR TITLE
feat(translation,#4957): seed SMT/Z3-Linq2Z3 CSV + unify smt/README

### DIFF
--- a/translations/smt/README.md
+++ b/translations/smt/README.md
@@ -1,16 +1,19 @@
-# CSV de synchro traduction — série SymbolicAI/SMT/Z3-API
+# CSV de synchro traduction — famille SymbolicAI/SMT
 
-**Statut** : Phase 2 rollout (Epic #4957 / #1650). Première série SMT couverte par l'infrastructure i18n.
+**Statut** : Phase 2 rollout (Epic #4957 / #1650). Famille SMT couverte par l'infrastructure i18n, deux séries indépendantes.
 
 ## Couvert
 
 | Fichier | Série | Notebooks | Cellules |
 |---------|-------|-----------|----------|
 | [`z3-api.csv`](z3-api.csv) | `SymbolicAI/SMT/Z3-API/` | 24 (`Z3-Python-01-Introduction` → `Z3-Python-24`, parité Python ⇄ C# `-Csharp`) | 541 (315 markdown + 226 code, 20 colonnes) |
+| [`z3-linq2z3.csv`](z3-linq2z3.csv) | `SymbolicAI/SMT/Z3-Linq2Z3/` | 18 (`01_Linq2Z3_Intro` → `18_Einsteins_Riddle`, C# LINQ-to-Z3 déclaratif) | 525 (323 markdown + 202 code, 20 colonnes) |
 
-**Note cross-language** : la série Z3-API est cross-language — chaque notebook Python a un jumeau .NET (`-Csharp`) via le binding `Microsoft.Z3`. Le script d'extraction prend les deux verbatim (chaque notebook est une cellule source indépendante). La traduction future T3 (moteur Argumentum) appliquera les deux langages.
+**Schéma** : 20 colonnes (#4957 §1). `src_lang=fr`, `src_hash` (sha256-16) + `text_fr` remplies ; colonnes cibles (`text_en/es/ar/...`) vides pour le moteur T3 Argumentum (#1650 Phase 1).
 
-**Note owner-floue** : SMT = SymbolicAI, partition po-2023 côté .NET (`-Csharp`) / po-2025 côté Python (cf partition language-based). L'extraction i18n est **safe cross-owner** (artefacts dérivés = CSV de cellules upstream en lecture seule, pas de modification des notebooks — cf note identique dans `translations/smartcontracts/README.md`).
+**Note cross-language** : Z3-API est parité Python ⇄ C# (`-Csharp`) via `Microsoft.Z3`. Z3-Linq2Z3 est C# natif (LINQ-to-Z3 déclaratif). Les deux CSV prennent chaque notebook verbatim (cellule source indépendante). La traduction future T3 (moteur Argumentum) appliquera les deux langages.
+
+**Note owner-floue** : SMT = SymbolicAI, partition po-2023 côté .NET (`-Csharp` + Z3-Linq2Z3) / po-2025 côté Python (Z3-API Python). L'extraction i18n est **safe cross-owner** (artefacts dérivés = CSV de cellules upstream en lecture seule, pas de modification des notebooks — cf note identique dans `translations/smartcontracts/README.md`).
 
 ## Régénération
 
@@ -19,6 +22,9 @@
 python scripts/translation/extract_cells_to_csv.py \
     MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/ \
     -o translations/smt/z3-api.csv
+python scripts/translation/extract_cells_to_csv.py \
+    MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/ \
+    -o translations/smt/z3-linq2z3.csv
 ```
 
 L'extraction est **déterministe byte-identique** (même ordre de notebooks, mêmes hash sha256-16 sur texte normalisé) — re-exécuter produit le même CSV.
@@ -26,10 +32,10 @@ L'extraction est **déterministe byte-identique** (même ordre de notebooks, mê
 ## Vérification de drift (T2)
 
 ```bash
-python scripts/translation/check_translation_sync.py translations/smt/z3-api.csv
+python scripts/translation/check_translation_sync.py translations/smt/
 ```
 
 ## Hors scope
 
-- `SymbolicAI/SMT/Z3-Linq2Z3/` (18 notebooks) — série distincte, sera un CSV séparé (`z3-linq2z3.csv`) si couverte.
-- `SymbolicAI/SMT/Z3.Linq/` — submodule vendored (hors dépôt pédagogique).
+- `SymbolicAI/SMT/Z3.Linq/` — submodule vendored (hors dépôt pédagogique, `polyglot-repro`).
+- `SymbolicAI/SMT/Automata/`, `SymbolicAI/SMT/Resharp/` — pas de notebooks pédagogiques FR-first détectés.

--- a/translations/smt/z3-linq2z3.csv
+++ b/translations/smt/z3-linq2z3.csv
@@ -1,0 +1,9311 @@
+notebook,cell_id,cell_type,src_lang,src_hash,text_fr,text_en,text_es,text_ar,text_fa,text_zh,text_ru,text_pt,hash_fr,hash_en,hash_es,hash_ar,hash_fa,hash_zh,hash_ru,hash_pt
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,bf6b6393,markdown,fr,9f58b1694a426d74,"# LINQ to Z3 - Résolution de Contraintes Déclarative
+
+**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [>> Sudoku Théorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb)
+
+## Objectifs d'apprentissage
+
+À la fin de ce notebook, vous saurez :
+1. Comprendre le concept de programmation déclarative vs impérative
+2. Utiliser Z3.Linq pour exprimer des contraintes avec la syntaxe LINQ
+3. Résoudre des problèmes de satisfaction de contraintes (CSP)
+4. Optimiser des solutions avec `Solve()` et `Optimize()`
+
+### Prérequis
+- .NET 9.0 Interactive
+- Connaissance de base de LINQ en C#
+- Notions de logique des contraintes
+
+### Durée estimée : 35-45 minutes
+
+---
+
+Ce notebook explore **Z3.Linq**, une bibliothèque qui combine le solveur SMT Z3 avec la syntaxe LINQ de C# pour exprimer des contraintes de manière déclarative.
+
+> **Contexte** : Z3.Linq est issu du travail de Ricardo Niepel (2015), enrichi par les contributions de jsboige (arrays, objets hiérarchiques, listes imbriquées, 2018-2023), puis modernisé par endjin (2022+). Le fork [MyIntelligenceAgency/Z3.Linq](https://github.com/MyIntelligenceAgency/Z3.Linq) maintient la version utilisée dans cette série.",,,,,,,,9f58b1694a426d74,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,af777fe7,code,fr,ab6444dce2e770a0,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq; using Microsoft.Z3; using System; using System.Text; using System.Diagnostics; using System.Linq;
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy fork), Microsoft.Z3, System.Linq"");",,,,,,,,ab6444dce2e770a0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,aa11516a,markdown,fr,ecbaf9fa7bdee44f,"### Qu'est-ce que Z3.Linq ?
+
+**Z3.Linq** est une bibliothèque qui combine deux technologies puissantes:
+
+1. **Z3**: Un solveur SMT (Satisfiability Modulo Theories) développé par Microsoft Research
+   - Résout des problèmes de satisfaction de contraintes
+   - Supporte les entiers, réels, tableaux, structures de données, etc.
+
+2. **LINQ (Language Integrated Query)**: Une syntaxe C# pour exprimer des requêtes de manière déclarative
+   - Permet d'écrire les contraintes Z3 avec la syntaxe familière de LINQ
+   - Les expressions lambda sont automatiquement traduites en formules SMT
+
+**Avantage principal**: Au lieu d'écrire du code impératif pour résoudre un problème, on **déclare** les contraintes et Z3 trouve une solution (si elle existe).
+
+**Cas d'usage typiques**:
+- Résolution de systèmes d'équations
+- Problèmes de planification et d'ordonnancement
+- Vérification formelle
+- Puzzles logiques (Sudoku, n-Queens, etc.)
+",,,,,,,,ecbaf9fa7bdee44f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,a1b2c3d4,markdown,fr,923ed39149f6455e,"### Architecture de la pipeline Z3.Linq
+
+Le diagramme ci-dessous illustre le chemin complet d'une contrainte LINQ jusqu'à l'objet C# résultat :
+
+```mermaid
+flowchart LR
+    L[""Lambda .Where(x => ...)""] --> V[""ExpressionVisitor""]
+    V --> E[""BoolExpr Z3""]
+    E --> S[""Solveur SMT""]
+    S -- SAT --> M[""Modèle Z3""]
+    S -- UNSAT --> N[""null""]
+    M --> T[""Objet .NET T""]
+```
+
+**Point clé** : l'`ExpressionVisitor` traduit chaque nœud de l'arbre AST C# (`BinaryExpression`, `MemberAccess`, opérateurs arithmétiques) en son équivalent Z3. C'est cette couche qui rend la déclaration de contraintes **déclarative** plutôt qu'impérative — on exprime *quoi*, pas *comment*.",,,,,,,,923ed39149f6455e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,d7e56662,markdown,fr,66d2d09e5bec5bd3,### Exemple court,,,,,,,,66d2d09e5bec5bd3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,8cd68233,code,fr,60c3ffc5562dc09b,"using Z3.Linq; 
+
+using (var ctx = new Z3Context())
+      {
+        var theorem = from t in ctx.NewTheorem<Symbols<int, int, int, int, int>>()
+              where t.X1 - t.X2 >= 1
+              where t.X1 - t.X2 <= 3
+              where t.X1 == (2 * t.X3) + t.X5
+              where t.X3 == t.X5
+              where t.X2 == 6 * t.X4
+              select t;
+var solution = theorem.Solve();
+Console.WriteLine(""X1 = {0}, X2 = {1}, X3 = {2}, X4 = {3}, X5 = {4}"", solution.X1, solution.X2, solution.X3, solution.X4, solution.X5);
+
+}",,,,,,,,60c3ffc5562dc09b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,83a2c736,markdown,fr,4de17853a7677863,"### Analyse de l'exemple
+
+**Ce que fait le code:**
+
+Le code définit un système de 5 contraintes linéaires sur 5 variables entières (X1, X2, X3, X4, X5):
+
+```
+X1 - X2 ∈ [1, 3]           (deux contraintes)
+X1 = 2·X3 + X5
+X3 = X5
+X2 = 6·X4
+```
+
+**Syntaxe LINQ To Z3:**
+- `ctx.NewTheorem<Symbols<int, int, int, int, int>>()`: Crée un théorème avec 5 variables entières
+- `where t.X1 - t.X2 >= 1`: Ajoute une contrainte (traduite en formule SMT)
+- `theorem.Solve()`: Demande à Z3 de trouver une affectation satisfaisant toutes les contraintes
+
+**Résultat attendu:**
+
+Le solveur Z3 trouve une solution (il peut y en avoir plusieurs). L'exécution ci-dessus donne par exemple :
+- Une affectation valide : X1 = 3, X2 = 0, X3 = 1, X4 = 0, X5 = 1
+
+> **Note**: Z3 est un solveur SMT (Satisfiability Modulo Theories) capable de résoudre des contraintes sur des entiers, des réels, des tableaux, etc. LINQ To Z3 offre une interface C# naturelle pour exprimer ces contraintes. Pour les fondements théoriques de la résolution SMT (DPLL(T)) et la présentation du solveur Z3 lui-même, voir de Moura & Bjørner, *Z3: An Efficient SMT Solver* (TACAS 2008) et Nieuwenhuis, Oliveras & Tinelli, *Solving SAT and SAT Modulo Theories: From an Abstract DPLL Procedure to DPLL(T)* (JACM 2006) ; la théorie des tableaux (notebook 4) et le standard SMT-LIB (notebooks 4, 10) sont ancrés dans la section Références du README.",,,,,,,,4de17853a7677863,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,9c55885b,markdown,fr,228823198868b81f,"### SAT et UNSAT — le concept fondateur d'un solveur
+
+Jusqu'ici, chaque appel à `Solve()` a renvoyé une solution. Mais la question fondamentale que tranche un solveur SMT n'est pas « quelle est la solution ? » — c'est **« une solution existe-t-elle ? »**. C'est ce que désigne le **S** de SMT : *Satisfiability*.
+
+- **SAT (satisfiable)** : il existe **au moins une** affectation des variables qui satisfait toutes les contraintes simultanément. `Solve()` renvoie alors une telle affectation.
+- **UNSAT (unsatisfiable)** : **aucune** affectation ne satisfait les contraintes — elles sont contradictoires. `Solve()` renvoie alors `null` (Z3 a *prouvé* qu'aucune solution n'existe).
+
+Cette distinction est centrale : l'une des réponses les plus utiles d'un solveur est **« c'est impossible »**, et cette réponse est une **preuve** (pas une absence de résultat). Par exemple, prouver qu'un planning est irréalisable sous certaines contraintes, ou qu'un invariant de sécurité ne peut jamais être violé. Le `(si elle existe)` de la section précédente prend ici tout son sens.
+
+L'exemple ci-dessous force un système UNSAT : la même variable ne peut pas être à la fois `> 5` **et** `< 3`.",,,,,,,,228823198868b81f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,eddd42a7,code,fr,15be1ecdbba538b6,"// Exemple : un système UNSAT (insatisfiable)
+// La variable X1 doit être à la fois > 5 ET < 3 -- contradiction, aucune solution.
+using (var ctx = new Z3Context())
+{
+    var theorem = ctx.NewTheorem<Symbols<int, int>>()
+        .Where(t => t.X1 > 5)
+        .Where(t => t.X1 < 3);
+
+    var solution = theorem.Solve();
+    Console.WriteLine($""Solve() a renvoyé : {(solution == null ? ""null  ->  le système est UNSAT (aucune affectation possible)"" : solution.ToString())}"");
+}
+",,,,,,,,15be1ecdbba538b6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,6b7e496e,markdown,fr,587cc8175a4dc1ff,"### Le problème des missionnaires et cannibales
+
+**Énoncé classique**: 3 missionnaires et 3 cannibales doivent traverser une rivière à l'aide d'une barque pouvant transporter au maximum 2 personnes. Si à un moment donné, sur l'une des deux rives, les cannibales sont plus nombreux que les missionnaires, ces derniers se font dévorer.
+
+**Objectif**: Trouver une séquence de traversées permettant à tous de passer sains et saufs.
+
+**Modélisation pour Z3.Linq:**
+- **Variables**: État de chaque rive à chaque étape (nombre de missionnaires et cannibales)
+- **Contraintes**: Capacité de la barque, sécurité des missionnaires, état initial/final
+- **Solution**: Séquence d'états satisfaisant toutes les contraintes
+
+La classe suivante encode ce problème de manière déclarative pour être résolu par Z3.
+",,,,,,,,587cc8175a4dc1ff,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,804b5ccc,markdown,fr,7f793f1c0b2cde04,### Classe de missionnaires et cannibales,,,,,,,,7f793f1c0b2cde04,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,ddea3043,markdown,fr,6ad4a78019155b55,"### Détails de la modélisation
+
+La classe `CanibalsAndMissionaries` encode le problème en trois parties:
+
+#### 1. Variables d'état
+
+| Variable | Type | Signification |
+|----------|------|---------------|
+| `Missionaries[i]` | `int[]` | Nombre de missionnaires sur la rive de départ à l'étape i |
+| `Canibals[i]` | `int[]` | Nombre de cannibales sur la rive de départ à l'étape i |
+| `Length` | `int` | Nombre total d'étapes dans le chemin |
+
+> **Note**: La rive d'arrivée se déduit par soustraction: `MissionnairesArrivée = NbMissionaries - Missionaries[i]`
+
+#### 2. Contraintes du problème
+
+**Contraintes globales:**
+- État initial: Tous les missionnaires et cannibales sont sur la rive de départ
+- État final: Tous sont sur la rive d'arrivée (0 personnes sur la rive de départ)
+
+**Contraintes de transition (modèle d'actions):**
+- Étapes paires (i % 2 == 0): La barque traverse de départ vers arrivée → perte de 1 à `SizeBoat` personnes
+- Étapes impaires (i % 2 == 1): La barque revient d'arrivée vers départ → gain de 1 à `SizeBoat` personnes
+
+**Contrainte de sécurité (invariant critique):**
+```csharp
+// Sur chaque rive, jamais plus de cannibales que de missionnaires
+// (sauf si aucun missionnaire sur la rive)
+(Missionaries[i] == 0 || Missionaries[i] >= Canibals[i])
+```
+
+#### 3. Construction du théorème avec LINQ
+
+La méthode `Create()` construit progressivement le théorème en ajoutant des clauses `Where()`:
+- Chaque appel à `Where()` ajoute une contrainte SMT
+- La boucle `for` génère des contraintes pour chaque étape du chemin
+- Z3.Linq traduit automatiquement les expressions lambda en formules logiques
+
+Cette approche **déclarative** contraste avec la programmation impérative classique: on décrit **quoi** trouver, pas **comment** le trouver.
+",,,,,,,,6ad4a78019155b55,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,0b1a1f8a,markdown,fr,5f4fca7c43bd6cfd,"###	Affirmer les contraintes
+
+L’affirmation des contraintes des arbres d’expression LINQ sur la classe d’état et l’étape suivante. On se base pour ça sur la classe Theorem de LINQ To Z3 :
+",,,,,,,,5f4fca7c43bd6cfd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,721b277f,code,fr,bcff94e978de4ba3,"public class CanibalsAndMissionaries
+{
+    
+    // Le nombre de canibales et missionaires (3 dans le problème original)
+    public int NbMissionaries { get; set; } = 3;
+    // La taille de la barque (2 dans le projet original)
+    public int SizeBoat { get; set; } = 2;
+
+    // La longueur du chemin calculé
+    private int _length;
+
+    //La propriété qui permet d'accéder à la taille du chemin dans Z3
+    public int Length
+    {
+      get => _length;
+      set
+      {
+        _length = value;
+        // Quand la longueur est déterminée par Z3, on initialise les tableaux pour pouvoir récupérer les valeurs
+        Canibals = new int[value];
+        Missionaries = new int[value];
+      }
+    }
+
+    // Un tableau contenant à chaque étape le nombre de canibales sur la berge de départ
+    public int[] Canibals { get; set; }
+    // Un tableau contenant à chaque étape le nombre de missionaires sur la berge de départ
+    public int[] Missionaries { get; set; }
+
+    /// <summary>
+    /// Une représentation lisible de la solution proposée
+    /// </summary>
+    /// <returns>une chaine de caractère ou chaque ligne est une étape du chemin</returns>
+    public override string ToString()
+    {
+      var sb = new StringBuilder();
+      for (int i = 0; i < Canibals.Length; i++)
+      {
+        sb.AppendLine($""{i + 1} - (({Missionaries[i]}M, {Canibals[i]}C, {1 - i % 2}), ({(i % 2)}, {NbMissionaries - Missionaries[i]}M, {NbMissionaries - Canibals[i]}C))"");
+      }
+
+      return sb.ToString();
+
+    }
+    
+    /// <summary>
+    /// La méthode qui permet la création du théorème associé au problème
+    /// </summary>
+    /// <param name=""context"">Le contexte Z3 qui devra interpréter les contraintes</param>
+    /// <param name=""entity"">Une valeur du problème servant de modèle pour définir les paramètres principaux</param>
+    /// <returns>Un théorème de notre environnement qui peut être filtré et résolu</returns>
+    public static Theorem<CanibalsAndMissionaries> Create(Z3Context context, CanibalsAndMissionaries entity)
+    {
+      // On créée une instance du théorème, sans contraintes, puis on va rajouter les contraintes une à une
+      var theorem = context.NewTheorem<CanibalsAndMissionaries>();
+      
+    // Contraintes globales
+      // On récupère les contraintes globales qui seront injectées sous forme de constante dans la lambda expression
+      var sizeBoat = entity.SizeBoat;
+      int nbMissionaries = entity.NbMissionaries;
+      int maxlength = entity.Length;
+
+      theorem = theorem.Where(caM => caM.NbMissionaries == nbMissionaries);
+      theorem = theorem.Where(caM => caM.SizeBoat == sizeBoat);
+      // Etat initial
+        theorem = theorem.Where(caM => caM.Missionaries[0] == caM.NbMissionaries && caM.Canibals[0] == caM.NbMissionaries);
+
+      //Modèle de transition
+      // On filtre à chaque étape selon les actions possible
+      for (int iclosure = 0; iclosure < maxlength; iclosure++)
+      {
+        var i = iclosure;
+        //Les deux rives contiennent entre 0 et 3 personnes
+        theorem = theorem.Where(caM => caM.Canibals[i] >= 0
+                                       && caM.Canibals[i] <= caM.NbMissionaries
+                                       && caM.Missionaries[i] >= 0
+                                       && caM.Missionaries[i] <= caM.NbMissionaries);
+        if (i % 2 == 0)
+        {
+          // Aux itérations paires, la rive de départ perd entre 1 et SizeBoat personnes 
+          theorem = theorem.Where(caM => caM.Canibals[i + 1] <= caM.Canibals[i]
+                                         && caM.Missionaries[i + 1] <= caM.Missionaries[i]
+                                         && caM.Canibals[i + 1] + caM.Missionaries[i + 1] - caM.Canibals[i] - caM.Missionaries[i] < 0
+                                         && caM.Canibals[i + 1] + caM.Missionaries[i + 1] - caM.Canibals[i] - caM.Missionaries[i] >= -caM.SizeBoat);
+        }
+        else
+        {
+          // Aux itérations impaires, la rive de départ gagne entre 1 et SizeBoat personnes 
+          theorem = theorem.Where(caM =>
+                                    caM.Canibals[i + 1] >= caM.Canibals[i]
+                                    && caM.Missionaries[i + 1] >= caM.Missionaries[i]
+                                    && caM.Canibals[i + 1] + caM.Missionaries[i + 1] - caM.Canibals[i] - caM.Missionaries[i] > 0
+                                    && caM.Canibals[i + 1] + caM.Missionaries[i + 1] - caM.Canibals[i] - caM.Missionaries[i] <= caM.SizeBoat);
+
+        }
+
+        //Jamais moins de missionnaire que de cannibal sur chacune des rives
+        theorem = theorem.Where(caM => (caM.Missionaries[i] == 0 || (caM.Missionaries[i] >= caM.Canibals[i]))
+                                 && (caM.Missionaries[i] == caM.NbMissionaries || ((caM.NbMissionaries - caM.Missionaries[i]) >= (caM.NbMissionaries - caM.Canibals[i]))));
+
+      }
+
+
+        // Test de but
+      // A l'arrivée, plus personne sur la rive de départ
+      theorem = theorem.Where(
+        caM => caM.Length > 0
+               && caM.Length < maxlength
+               && caM.Missionaries[caM.Length - 1] == 0
+               && caM.Canibals[caM.Length - 1] == 0
+      );
+
+
+      return theorem;
+    }
+    
+}",,,,,,,,bcff94e978de4ba3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,72f60fea,markdown,fr,ccf0ac11e0f484d7,"###	Obtenir la solution 
+LINQ To Z3 nous donne la solution sous forme d’ un objet POCO (Plain Old CLR Object) du type de paramètre générique T du théorème. 
+",,,,,,,,ccf0ac11e0f484d7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,5c3fa1be,code,fr,a100193e6bedaa11,"using System.Diagnostics;
+var stopWatch = new Stopwatch();
+      stopWatch.Start();
+      TimeSpan debutChrono;
+    // Solving Canibals & Missionaires
+      var can = new CanibalsAndMissionaries(){NbMissionaries = 3, SizeBoat = 2, Length = 30};
+
+      using (var ctx = new Z3Context())
+      {
+        var theorem = CanibalsAndMissionaries.Create(ctx, can);
+
+        debutChrono = stopWatch.Elapsed;
+
+        //Print(theorem);
+        var result = theorem.Solve();
+
+        // affichage du résultat
+        display($""Durée Cannibales et Missionaires {stopWatch.Elapsed - debutChrono}"");
+        display(result);
+
+      }
+",,,,,,,,a100193e6bedaa11,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,2f3a6f98,markdown,fr,01e970dbf43f3d68,"### Interprétation des résultats
+
+Le code ci-dessus résout le problème classique des **3 missionnaires et 3 cannibales** avec une barque de capacité 2.
+
+**Paramètres du problème:**
+- `NbMissionaries = 3`: 3 missionnaires et 3 cannibales
+- `SizeBoat = 2`: La barque peut transporter au maximum 2 personnes
+- `Length = 30`: Limite supérieure du nombre d'étapes à explorer
+
+**Sortie attendue:**
+- Un chemin solution avec le nombre d'étapes nécessaires
+- Chaque ligne au format: `(MissionnairesDépart, CannibalsDépart, Barque), (Barque, MissionnairesArrivée, CannibalesArrivée)`
+- La durée d'exécution du solveur Z3
+
+> **Note**: La méthode `Solve()` trouve **une** solution satisfaisant les contraintes, mais pas nécessairement la plus courte. Pour obtenir la solution optimale, il faut utiliser `Optimize()` (voir section suivante).
+",,,,,,,,01e970dbf43f3d68,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,b81a1e52,markdown,fr,6ae25a028bcc2861,"### Exercice 2 : Probleme de dimensionnement (n-Queens lite)
+
+Il s'agit de placer N reines sur un echiquier NxN de sorte qu'aucune ne soit sur la meme ligne, colonne ou diagonale qu'une autre.
+
+**Objectif** : Modelisez un echiquier 4x4 avec Z3.Linq. Chaque variable represente la colonne de la reine sur la ligne correspondante.
+
+**Indices** :
+- Utilisez `Symbols<int, int, int, int>` pour un echiquier 4x4
+- Contrainte 1 : toutes les colonnes differentes (Q1 != Q2 != Q3 != Q4)
+- Contrainte 2 : pas de diagonale => |Qi - Qj| != |i - j|
+- Utilisez `Math.Abs` pour la valeur absolue des differences",,,,,,,,6ae25a028bcc2861,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,26bfd605,code,fr,e16eaf1cd86a9e31,"// Exercice 2 : n-Queens 4x4 avec Z3.Linq
+// TODO etudiant : placez 4 reines sur un echiquier 4x4
+// Etape 1 : definissez un theoreme avec 4 variables (Q1, Q2, Q3, Q4)
+// Etape 2 : ajoutez les contraintes de colonnes distinctes
+// Etape 3 : ajoutez les contraintes anti-diagonales
+// Indice : Math.Abs(Qi - Qj) != Math.Abs(i - j) pour i != j
+
+// using (var ctx = new Z3Context())
+// {
+//     var theorem = from q in ctx.NewTheorem<Symbols<int, int, int, int>>()
+//         where ... // Vos contraintes de colonnes distinctes
+//         where ... // Vos contraintes anti-diagonales
+//         select q;
+//     var solution = theorem.Solve();
+//     Console.WriteLine($""Q1={solution.X1}, Q2={solution.X2}, Q3={solution.X3}, Q4={solution.X4}"");
+// }
+
+Console.WriteLine(""Exercice a completer : n-Queens 4x4 avec Z3.Linq"");",,,,,,,,e16eaf1cd86a9e31,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,5e0ad9fc,markdown,fr,d3f1b43f059f6f49,### Recherche de la solution la plus courte,,,,,,,,d3f1b43f059f6f49,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,a5c8a9da,code,fr,ada2267e9b906564,"using System.Diagnostics;
+var stopWatch = new Stopwatch();
+      stopWatch.Start();
+      TimeSpan debutChrono;
+    // Solving Canibals & Missionaires
+      var can = new CanibalsAndMissionaries(){NbMissionaries = 3, SizeBoat = 2, Length = 30};
+
+      using (var ctx = new Z3Context())
+      {
+        var theorem = CanibalsAndMissionaries.Create(ctx, can);
+
+        debutChrono = stopWatch.Elapsed;
+
+        //Print(theorem);
+        var result = theorem.Optimize(Optimization.Minimize, objMnC => objMnC.Length);
+
+        // affichage du résultat
+        display($""Durée Cannibales et Missionaires {stopWatch.Elapsed - debutChrono}"");
+        display(result);
+
+      }
+
+
+",,,,,,,,ada2267e9b906564,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,1763a6b4,markdown,fr,32155a2f90bfad7c,"### Analyse de l'optimisation
+
+**Différence entre `Solve()` et `Optimize()`:**
+
+- **`Solve()`**: Trouve **une** solution satisfaisant toutes les contraintes, sans garantie d'optimalité
+- **`Optimize(Optimization.Minimize, objMnC => objMnC.Length)`**: Trouve la solution avec la **plus petite** valeur de `Length`
+
+Dans le cas des missionnaires et cannibales, cela signifie:
+- `Solve()` peut retourner un chemin de 15 étapes alors qu'il existe un chemin de 11 étapes
+- `Optimize()` garantit de trouver le chemin le plus court possible
+
+> **Performance**: L'optimisation est plus coûteuse en temps de calcul, car le solveur doit explorer l'espace de recherche pour prouver qu'aucune solution plus courte n'existe.
+
+**Résultat attendu**: Le chemin optimal pour 3 missionnaires et 3 cannibales avec une barque de capacité 2 est de **11 étapes**.
+",,,,,,,,32155a2f90bfad7c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,2c1f373b,code,fr,092a50335aaf5191,"using System.Diagnostics;
+var stopWatch = new Stopwatch();
+      stopWatch.Start();
+      TimeSpan debutChrono;
+    // Solving Canibals & Missionaires
+      var can = new CanibalsAndMissionaries(){NbMissionaries = 30, SizeBoat = 7, Length = 100};
+
+      using (var ctx = new Z3Context())
+      {
+        var theorem = CanibalsAndMissionaries.Create(ctx, can);
+
+        debutChrono = stopWatch.Elapsed;
+
+        //Print(theorem);
+        var result = theorem.Optimize(Optimization.Minimize, objMnC => objMnC.Length);
+
+        // affichage du résultat
+        display($""Durée Cannibales et Missionaires {stopWatch.Elapsed - debutChrono}"");
+        display(result);
+
+      }
+
+
+",,,,,,,,092a50335aaf5191,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,b6cb8246,markdown,fr,edbbb37d103d211b,"### Exercice 3 : Variante du probleme - Loups, Chevres et Choux
+
+Generalisez le modele des missionnaires-cannibales pour resoudre un probleme voisin : un fermier doit traverser une riviere avec un loup, une chevre et un chou. La barque ne peut transporter que le fermier plus un seul item. Le loup mange la chevre et la chevre mange le chou s'ils restent seuls ensemble.
+
+**Objectif** : Adaptez la classe `CanibalsAndMissionaries` ou creez un nouveau modele Z3.Linq pour ce probleme.
+
+**Indices** :
+- Le fermier est toujours dans la barque (pas besoin de variable separree, il est implicite)
+- 3 items a transporter : L (loup), C (chevre), X (chou)
+- Invariant : le fermier ne peut pas laisser (L+C) ou (C+X) seuls sur une rive
+- Utilisez un codage similaire avec des tableaux pour les positions a chaque etape",,,,,,,,edbbb37d103d211b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,1ba631d6,code,fr,84e038c7d6d9b98e,"// Exercice 3 : Loups, Chevres et Choux avec Z3.Linq
+// TODO etudiant : modelisez le probleme du fermier, loup, chevre et chou
+// Etape 1 : definissez les variables d'etat (positions de chaque item par etape)
+// Etape 2 : ajoutez les contraintes de transition (1 seul item par traverse)
+// Etape 3 : ajoutez les invariants de securite (pas L+C ni C+X seuls)
+// Etape 4 : resolvez avec Optimize pour trouver le chemin le plus court
+
+// Indice : vous pouvez utiliser Symbols<int, int, int> pour 3 positions
+// ou creer une classe adaptee avec un tableau de positions
+
+// public class FarmerProblem { ... }
+// using (var ctx = new Z3Context()) { ... }
+
+Console.WriteLine(""Exercice a completer : loups, chevres et choux avec Z3.Linq"");",,,,,,,,84e038c7d6d9b98e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,af7cac81,markdown,fr,68d241d6a3e2fc3d,"## B9 - Environnements `record` positionnels (DSL `NewTheorem<PositionalRecord>`)
+
+L'environnement d'un théorème (le type `T` passe a `NewTheorem<T>`) peut etre un **record positionnel** C# -- par exemple `record Point(int X, int Y)` -- et non une `class` mutable. La reconstruction de la solution passe alors par une branche dediee du solveur ([`Theorem.cs:993-1099`](../../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993)) qui selectionne le *primary constructor* du record, evalue chaque parametre depuis le modele Z3, puis invoque `Activator.CreateInstance(t, args)` avec les valeurs positionnelles -- l'ancienne branche `Activator.CreateInstance(t)` throw sur un record sans constructeur sans parametre (un positional record n'expose que des `init`-only setters).
+
+Le mini-probleme : sur un point `(X, Y)` dans le plan, trouver le point satisfaisant `X + Y = 12` **et** `X = 2·Y` (solution unique attendue : `X = 8, Y = 4`).
+
+> **Stack : A+B** -- le raw doit gerer manuellement la reconstruction via `Model.Eval` sur chaque `IntExpr`, tandis que le DSL `NewTheorem<Point>().Where(...)` invoque la branche `ConstructFromModel` automatiquement ; l'objet rendu (`Point { X = 8, Y = 4 }`) est type C#, pas une paire de `IntNum`.
+
+**Ancre fork** : `Theorem.cs:993-1099` (branche `ConstructFromModel`), tests `Z3.Linq.Tests/RecordEnvTheoryTests.cs:18-91` (4 cas : positional standard, scalaires mixtes int+bool, trois parametres, UNSAT). La feature etait listee dans le backlog `B9` d'[#4688](https://github.com/jsboige/CoursIA/issues/4688) avec une ancre « a confirmer » -- le grep la trouve dans la branche reconstruction, **pas** dans la declaration de type (qui est du C# standard).",,,,,,,,68d241d6a3e2fc3d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,999c4775,code,fr,1642dddcb8763e73,"// B9 - Record positionnel ""deux stacks"" sur le meme probleme (X+Y=12, X=2Y).
+//   Un point (X, Y) dans le plan, soumis a 2 contraintes lineaires.
+//   Solution unique attendue : X=8, Y=4.
+
+// Un record positionnel declare au niveau de la cellule (requis par NewTheorem<T>).
+public record PointRecord(int X, int Y) { }
+
+// =====================================================================
+// BLOC DSL (Z3.Linq) : la reconstruction d'un record via primary ctor
+// =====================================================================
+{
+    using var thCtx = new Z3Context();
+    var pt = thCtx.NewTheorem<PointRecord>()
+        .Where(p => p.X + p.Y == 12)
+        .Where(p => p.X == 2 * p.Y)
+        .Solve();
+    Console.WriteLine($""[DSL] NewTheorem<PointRecord>(X+Y=12, X=2Y) : {(pt == null ? ""UNSAT"" : $""SAT -> {pt}  (X={pt.X}, Y={pt.Y})"")}"");
+    // Variante discriminante : reorder les Where -> la solution NE change PAS
+    // (le matching des params se fait par nom via l'environnement, pas par l'ordre des Where)
+    var pt2 = thCtx.NewTheorem<PointRecord>()
+        .Where(p => p.X == 2 * p.Y)
+        .Where(p => p.X + p.Y == 12)
+        .Solve();
+    Console.WriteLine($""[DSL]   (memo) Where inverse           : {(pt2 == null ? ""UNSAT"" : $""SAT -> {pt2}  (meme X, Y)"")}"");
+
+    // Variante UNSAT : X >= 0 et X < 0 -> le binding doit rendre null, pas throw
+    var unsat = thCtx.NewTheorem<PointRecord>()
+        .Where(p => p.X >= 0)
+        .Where(p => p.X < 0)
+        .Solve();
+    Console.WriteLine($""[DSL]   cas UNSAT (X>=0 et X<0)      : {(unsat == null ? ""null (UNSAT, pas d'exception)"" : ""??"")}"");
+}
+
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : meme probleme, reconstruction manuelle
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    var x = z3.MkIntConst(""X"");
+    var y = z3.MkIntConst(""Y"");
+    var solver = z3.MkSolver();
+    solver.Assert(z3.MkEq(z3.MkAdd(x, y), z3.MkInt(12)));
+    solver.Assert(z3.MkEq(x, z3.MkMul(z3.MkInt(2), y)));
+    Status st = solver.Check();
+    Console.WriteLine($""[RAW] X+Y=12, X=2Y : {st}"");
+    if (st == Status.SATISFIABLE)
+    {
+        var m = solver.Model;
+        // Reconstruction manuelle : 2 Eval + parse IntNum + construction (x, y)
+        var xv = ((IntNum)m.Eval(x, true)).Int;
+        var yv = ((IntNum)m.Eval(y, true)).Int;
+        Console.WriteLine($""[RAW]   temoin : (X={xv}, Y={yv})   (construction manuelle a partir du Model)"");
+    }
+
+    // Cas UNSAT symetrique
+    var sUn = z3.MkSolver();
+    sUn.Assert(z3.MkGe(x, z3.MkInt(0)));
+    sUn.Assert(z3.MkLt(x, z3.MkInt(0)));
+    Console.WriteLine($""[RAW]   X>=0 et X<0 : {sUn.Check()}   (aucune affectation)"");
+}",,,,,,,,1642dddcb8763e73,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,4ab72a78,markdown,fr,ee1fd8be466e3760,"### Lecture B9 - deux ecritures d'un meme record, un meme resultat
+
+Les deux ecritures resolvent **le meme systeme** (`X + Y = 12`, `X = 2·Y`) et produisent **le meme temoin** (`X = 8, Y = 4`), mais leur cout d'ecriture est asymetrique :
+
+| Aspect | Stack B (raw Microsoft.Z3) | Stack A (DSL Z3.Linq) |
+|--------|----------------------------|------------------------|
+| Variables | `MkIntConst(""X"")`, `MkIntConst(""Y"")` declaratives une a une | implicites via les proprietes `X`/`Y` du type `Point` |
+| Contraintes | `MkEq(MkAdd(x, y), MkInt(12))`, `MkEq(x, MkMul(MkInt(2), y))` | `p => p.X + p.Y == 12`, `p => p.X == 2*p.Y` en LINQ naturel |
+| Verification | `MkSolver().Assert(...).Check()` + cast `IntNum`/parse dans le Model | `.Solve()` typé C# |
+| Reconstruction | `model.Eval(x, true).ToString()` + cast manuel + reconstruction `(x, y)` a la main | un simple `Point { X = 8, Y = 4 }` -- le binding a fait le reste |
+| Surface code | ~10 lignes significatives + risque d'erreur de typage des `IntNum` | 3 lignes de contraintes |
+| Constructeur sans parametre | non requis (le raw n'instancie jamais d'objet C#) | **necessaire dans le cas d'une `class` mutable**, **interdit dans le cas d'un record** (l'ancienne branche `Activator.CreateInstance(t)` throw) |
+
+> **Ligne de contraste** : la valeur ajoutee du DSL ici n'est pas une fecondation d'expression (comme `Sum` qui replie N termes en un seul `MkAdd`), mais le **routage de reconstruction** -- la detection du type d'environnement (`class` mutable avec setter vs `record` positionnel vs type anonyme) et l'invocation de la bonne branche de [`Theorem.cs:993-1099`](../../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993). Cote raw, c'est au chercheur de coder la reconstruction -- cote DSL, elle est *incluse par defaut* dans `NewTheorem<T>()`. Les tests unitaires `RecordEnvTheoryTests` (4 cas) verifient que la branche positionnelle couvre records a 2-3 params, scalaires mixtes (int + bool), et le retour `null` sur UNSAT.",,,,,,,,ee1fd8be466e3760,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,68738069,markdown,fr,f49117462f86284b,"### Exercice 4 : record positionnel a 3 parametres (stability of constructor order)
+
+Reproduisez la demarche ci-dessus avec un record a **trois** parametres -- par exemple `record Triple(int A, int B, int C)` -- et trois contraintes scalaires (par exemple `A == 1, B == 2, C == 3`). Le solveur doit rendre un `Triple { A = 1, B = 2, C = 3 }`.
+
+**Variante discriminante** : declarez les contraintes dans un ordre different (par exemple `B == 2, C == 3, A == 1`). La solution reste-t-elle la meme ? Le matching des arguments du constructeur se fait-il par nom ou par position dans le `.Where` ?
+
+**Indice** : voir [Theorem.cs:1076](..%2F..%2FZ3.Linq%2Fsolutions%2FZ3.Linq%2FTheorem.cs#L1076) -- la reconstruction selectionne le constructeur dont tous les parametres sont dans l'environnement, puis passe les args **positionnellement**.",,,,,,,,f49117462f86284b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,851f1272,code,fr,873a5b11d9450446,"// Exercice 4 : record positionnel a 3 parametres avec Z3.Linq
+// TODO etudiant : modelisez un record Triple(int A, int B, int C) puis :
+// Etape 1 : declarez record Triple(int A, int B, int C) au niveau de la cellule
+// Etape 2 : 3 contraintes scalaires : A == 1, B == 2, C == 3
+// Etape 3 : lancez .Solve() et verifiez que vous obtenez Triple { A=1, B=2, C=3 }
+// Etape 4 (variante discriminante) : changez l'ordre des contraintes en B==2, C==3, A==1
+//           et verifiez que la solution reste la meme (le matching des params se fait par NOM, pas par ordre du Where)
+
+// Indice : la reconstruction du record (Theorem.cs:1076) selectionne le constructeur
+// dont TOUS les parametres sont satisfiables par l'environnement ; le passage des args
+// est positionnel. L'ordre de declaration des Where ne change donc pas la solution,
+// seul l'ordre des parametres du constructeur compte.
+
+Console.WriteLine(""Exercice a completer : record Triple positionnel a 3 parametres avec Z3.Linq"");",,,,,,,,873a5b11d9450446,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,2142ea44,markdown,fr,121dc8a7fafc248f,"## Conclusion et analyse comparative
+
+Ce notebook a illustré l'utilisation de **Z3.Linq** pour résoudre des problèmes de satisfaction de contraintes en combinant la puissance du solveur SMT Z3 avec la syntaxe LINQ de C#.
+
+#### Comparaison des approches
+
+| Approche | Cas simple (3M, 3C) | Cas complexe (30M, 30C) | Avantages | Limitations |
+|----------|-------------------|----------------------|-----------|-------------|
+| **Solve()** | Rapide | Rapide | Trouve une solution | Pas forcément optimale |
+| **Optimize()** | Très rapide | Plus lent | Solution optimale | Coût de calcul plus élevé |
+
+#### Points clés à retenir
+
+1. **Modélisation déclarative**: Les contraintes sont exprimées naturellement avec LINQ
+2. **Abstraction puissante**: Z3.Linq traduit automatiquement les expressions LINQ en formules SMT
+3. **Optimisation**: La méthode `Optimize()` permet de minimiser/maximiser des objectifs
+4. **Scalabilité**: Le solveur gère des instances de taille significative (30 personnes)
+
+> **Note pratique**: Pour des problèmes de grande taille, il est recommandé de fournir une borne supérieure réaliste pour `Length` afin d'éviter l'explosion combinatoire.
+
+#### Applications possibles
+
+- Planification de tâches
+- Problèmes de routage et d'allocation de ressources
+- Vérification formelle de propriétés
+- Résolution de puzzles logiques (Sudoku, n-Queens, etc.)
+
+---
+
+## Exercice : Modélisez un Problème de Planification
+
+Modélisez et résolvez un problème de planification avec Z3.Linq.
+
+### Objectifs
+Créez un solveur pour planifier des tâches sur plusieurs machines.
+
+### Instructions
+
+
+### Questions d'analyse
+1. Combien de machines sont utilisées dans la solution optimale ?
+2. Quelle est la différence entre `Solve()` et `Optimize()` pour ce problème ?
+3. Comment ajouter une contrainte ""tâches A et b ne peuvent pas être sur la même machine"" ?",,,,,,,,121dc8a7fafc248f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,c4eecb38,code,fr,e1275576fe8691fb,"// TODO: Définissez le problème de planification
+// - 5 tâches avec des durées différentes
+// - 3 machines avec des capacités différentes
+// - Contrainte : chaque tâche sur une seule machine
+// - Contrainte : capacité machine non dépassée
+// - Objectif : minimiser le temps total de complétion
+
+public class PlanningProblem
+{
+    // TODO: Propriétés du problème
+    // public int[] TaskDurations { get; set; }
+    // public int[] MachineCapacities { get; set; }
+    // public int[,] Assignment { get; set; } // tâche -> machine
+    
+}
+
+// TODO: Créez le théorème LINQ pour le problème
+// var theorem = from t in ctx.NewTheorem<PlanningProblem>()
+//     where ... // Vos contraintes
+//     select t;
+
+// TODO: Résolvez et affichez la solution
+// var solution = theorem.Optimize(...);
+
+Console.WriteLine(""Exercice a completer : modeliser un probleme de planification avec Z3.Linq"");",,,,,,,,e1275576fe8691fb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a1b2c3d4,markdown,fr,0dd4e57eb761e6c3,"# Sudoku : Théorème Explicite vs Modèle Implicite par Arrays
+
+**Navigation** : [Index SymbolicAI](../../README.md) | [Serie Z3](README.md) | [<< Introduction Linq2Z3](01_Linq2Z3_Intro.ipynb)
+
+## Objectifs d'apprentissage
+
+A la fin de ce notebook, vous saurez :
+1. Modeliser un Sudoku avec 81 proprietes explicites (approche naive)
+2. Modeliser un Sudoku avec une seule `List<int>` indexee par lambdas (approche implicite)
+3. Comprendre le mecanisme de capture de closure en C# et son role dans Z3.Linq
+4. Ajouter des indices (hints) pour resoudre un puzzle reel
+
+### Prerequis
+- .NET 9.0 Interactive
+- Avoir suivi le notebook [01_Linq2Z3_Intro](01_Linq2Z3_Intro.ipynb)
+- Connaissance de base des expressions lambda et closures en C#
+
+### Duree estimee : 40-50 minutes
+
+---
+
+Ce notebook presente la **transition pedagogique cle** entre deux approches de modelisation Sudoku avec Z3.Linq :
+
+1. **L'approche explicite** : 81 proprietes nommees (`Cell11`, `Cell12`, ..., `Cell99`), chacune contrainte individuellement. Verbeuse mais pedagogiquement claire.
+
+2. **Le modèle implicite par arrays** : une seule propriete `List<int> Cells` de 81 elements, indexes par des expressions lambda avec closures. Compacte, generalisable, et extensible.
+
+Cette transition illustre l'innovation apportee par la branche EPFdevelopment du fork Z3.Linq : la capacite d'utiliser des indexeurs de collection dans les expressions lambda traduites en formules SMT.
+
+> **Contexte** : Le modèle implicite par arrays est la base de tous les notebooks Sudoku avances de cette serie. Le comprendre en profondeur est essentiel pour la suite.",,,,,,,,0dd4e57eb761e6c3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,360fa043,markdown,fr,bee4850a4f75828d,"### Vue d'ensemble : deux strategies de modelisation du meme Sudoku
+
+```mermaid
+flowchart TB
+    P[""Grille Sudoku 9x9\n(81 cellules)""]
+    P --> E[""Approche 1 — Théorème explicite""]
+    P --> I[""Approche 2 — Modèle implicite par arrays""]
+    E --> E1[""81 proprietes nommees\nCell11, Cell12, ..., Cell99""]
+    E1 --> E2[""Contraintes ecrites une par une\nverbeux, non generalisable""]
+    I --> I1[""1 propriete List-Int Cells\nindexee par lambdas + closures""]
+    I1 --> I2[""Boucles generent les contraintes\ncompact, extensible 16x16""]
+    E2 --> Z[""Z3.Linq -> formules SMT\nsolveur Z3""]
+    I2 --> Z
+    Z --> S[""Solution (assignation valide)""]
+    style I fill:#c8f7c5
+    style I1 fill:#c8f7c5
+    style I2 fill:#c8f7c5
+    style E fill:#f7e3c5
+```
+
+Les deux approches produisent **le meme resultat**, mais le **modèle implicite** (en vert)
+est celui qui se generalise — il fonde tous les notebooks Sudoku avances de la serie.
+L'enjeu pedagogique de ce notebook est la **transition** de l'une vers l'autre.",,,,,,,,bee4850a4f75828d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,setup-markdown-intro,markdown,fr,72398f7293ab0e42,"### Configuration de l'environnement
+
+Chargement du fork Z3.Linq (`.deploy/`) et des espaces de noms nécessaires pour ce notebook.",,,,,,,,72398f7293ab0e42,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,c3d4e5f6,code,fr,c31af48ba4f9607a,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy fork), Microsoft.Z3, System.Collections.Generic, System.Linq"");",,,,,,,,c31af48ba4f9607a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d4e5f6a7,markdown,fr,5eada7bcf8b60d98,"## 1. Affichage d'une grille Sudoku
+
+Avant de modeliser le Sudoku, definissons une méthode utilitaire pour afficher une grille a partir d'une liste de 81 entiers. Cette méthode sera reutilisee tout au long du notebook.
+
+**Convention** : les cellules sont stockees dans un `List<int>` de taille 81, rangees par ligne. L'index d'une cellule à la position `(row, col)` est `row * 9 + col`.",,,,,,,,5eada7bcf8b60d98,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e5f6a7b8,code,fr,19d892827d6f627f,"void DisplaySudoku(List<int> cells, string title = ""Sudoku"") {
+    Console.WriteLine($""\n=== {title} ==="");
+    var lineSep = new string('-', 25);
+    Console.WriteLine(lineSep);
+    for (int row = 0; row < 9; row++) {
+        Console.Write(""| "");
+        for (int col = 0; col < 9; col++) {
+            var val = cells[row * 9 + col];
+            Console.Write(val == 0 ? "". "" : $""{val} "");
+            if ((col + 1) % 3 == 0) Console.Write(""| "");
+        }
+        Console.WriteLine();
+        if ((row + 1) % 3 == 0) Console.WriteLine(lineSep);
+    }
+}
+
+// Test avec une grille vide
+var emptyGrid = Enumerable.Repeat(0, 81).ToList();
+DisplaySudoku(emptyGrid, ""Grille vide (test)"");
+Console.WriteLine($""Methode DisplaySudoku prete ({emptyGrid.Count} cellules)"");",,,,,,,,19d892827d6f627f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f6a7b8c9,markdown,fr,cc30540128829acc,"## 2. Approche 1 : Théorème explicite (81 proprietes)
+
+L'approche la plus naturelle pour modeliser un Sudoku consiste a declarer **81 proprietes nommees**, une par cellule : `Cell11`, `Cell12`, ..., `Cell99`.
+
+### Principe
+
+Chaque propriete represente un entier que Z3 doit determiner. Les contraintes Sudoku se traduisent alors par :
+- **Domaine** : chaque propriete entre 1 et 9
+- **Lignes** : les 9 cellules de chaque ligne sont distinctes
+- **Colonnes** : les 9 cellules de chaque colonne sont distinctes
+- **Boites 3x3** : les 9 cellules de chaque sous-grille sont distinctes
+
+### Classe du modèle explicite
+
+Voici la classe complete. Remarquez la verbosite : 81 lignes de proprietes, chacune devant etre contrainte individuellement.",,,,,,,,cc30540128829acc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a7b8c9d0,code,fr,95b55e054f7cac56,"public class SudokuTable
+{
+    // 81 proprietes explicites - verbeux mais pedagogiquement clair
+    public int Cell11 { get; set; } public int Cell12 { get; set; } public int Cell13 { get; set; }
+    public int Cell14 { get; set; } public int Cell15 { get; set; } public int Cell16 { get; set; }
+    public int Cell17 { get; set; } public int Cell18 { get; set; } public int Cell19 { get; set; }
+    public int Cell21 { get; set; } public int Cell22 { get; set; } public int Cell23 { get; set; }
+    public int Cell24 { get; set; } public int Cell25 { get; set; } public int Cell26 { get; set; }
+    public int Cell27 { get; set; } public int Cell28 { get; set; } public int Cell29 { get; set; }
+    public int Cell31 { get; set; } public int Cell32 { get; set; } public int Cell33 { get; set; }
+    public int Cell34 { get; set; } public int Cell35 { get; set; } public int Cell36 { get; set; }
+    public int Cell37 { get; set; } public int Cell38 { get; set; } public int Cell39 { get; set; }
+    public int Cell41 { get; set; } public int Cell42 { get; set; } public int Cell43 { get; set; }
+    public int Cell44 { get; set; } public int Cell45 { get; set; } public int Cell46 { get; set; }
+    public int Cell47 { get; set; } public int Cell48 { get; set; } public int Cell49 { get; set; }
+    public int Cell51 { get; set; } public int Cell52 { get; set; } public int Cell53 { get; set; }
+    public int Cell54 { get; set; } public int Cell55 { get; set; } public int Cell56 { get; set; }
+    public int Cell57 { get; set; } public int Cell58 { get; set; } public int Cell59 { get; set; }
+    public int Cell61 { get; set; } public int Cell62 { get; set; } public int Cell63 { get; set; }
+    public int Cell64 { get; set; } public int Cell65 { get; set; } public int Cell66 { get; set; }
+    public int Cell67 { get; set; } public int Cell68 { get; set; } public int Cell69 { get; set; }
+    public int Cell71 { get; set; } public int Cell72 { get; set; } public int Cell73 { get; set; }
+    public int Cell74 { get; set; } public int Cell75 { get; set; } public int Cell76 { get; set; }
+    public int Cell77 { get; set; } public int Cell78 { get; set; } public int Cell79 { get; set; }
+    public int Cell81 { get; set; } public int Cell82 { get; set; } public int Cell83 { get; set; }
+    public int Cell84 { get; set; } public int Cell85 { get; set; } public int Cell86 { get; set; }
+    public int Cell87 { get; set; } public int Cell88 { get; set; } public int Cell89 { get; set; }
+    public int Cell91 { get; set; } public int Cell92 { get; set; } public int Cell93 { get; set; }
+    public int Cell94 { get; set; } public int Cell95 { get; set; } public int Cell96 { get; set; }
+    public int Cell97 { get; set; } public int Cell98 { get; set; } public int Cell99 { get; set; }
+}
+
+Console.WriteLine($""Classe SudokuTable definie : 81 proprietes (Cell11..Cell99)"");",,,,,,,,95b55e054f7cac56,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8c9d0e1,markdown,fr,b23b75040405831c,"### Demonstration de l'approche explicite
+
+Pour construire un théorème Sudoku avec ce modèle, il faut enumerer **explicitement** chaque cellule dans chaque contrainte. Voici un extrait montrant la structure (seule la ligne 1 et la boite haut-gauche sont illustrees pour la lisibilite).",,,,,,,,b23b75040405831c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,c9d0e1f2,code,fr,fc0ddb6e9e75665e,"var ctx = new Z3Context();
+var theorem = ctx.NewTheorem<SudokuTable>();
+
+// Extrait : contrainte de domaine sur la ligne 1 (9 des 81 necessaires)
+theorem = theorem.Where(t => t.Cell11 >= 1 && t.Cell11 <= 9);
+theorem = theorem.Where(t => t.Cell12 >= 1 && t.Cell12 <= 9);
+theorem = theorem.Where(t => t.Cell13 >= 1 && t.Cell13 <= 9);
+theorem = theorem.Where(t => t.Cell14 >= 1 && t.Cell14 <= 9);
+theorem = theorem.Where(t => t.Cell15 >= 1 && t.Cell15 <= 9);
+theorem = theorem.Where(t => t.Cell16 >= 1 && t.Cell16 <= 9);
+theorem = theorem.Where(t => t.Cell17 >= 1 && t.Cell17 <= 9);
+theorem = theorem.Where(t => t.Cell18 >= 1 && t.Cell18 <= 9);
+theorem = theorem.Where(t => t.Cell19 >= 1 && t.Cell19 <= 9);
+// ... 72 contraintes de domaine supplementaires pour les lignes 2 a 9
+
+// Contrainte de ligne 1 : les 9 cellules sont distinctes
+theorem = theorem.Where(t => Z3Methods.Distinct(
+    t.Cell11, t.Cell12, t.Cell13, t.Cell14, t.Cell15,
+    t.Cell16, t.Cell17, t.Cell18, t.Cell19));
+// ... 8 contraintes de ligne supplementaires
+
+// Contrainte de boite haut-gauche (3x3)
+theorem = theorem.Where(t => Z3Methods.Distinct(
+    t.Cell11, t.Cell12, t.Cell13,
+    t.Cell21, t.Cell22, t.Cell23,
+    t.Cell31, t.Cell32, t.Cell33));
+// ... 8 contraintes de boite supplementaires
+
+Console.WriteLine(""Approche explicite : chaque contrainte enumere les cellules par leur nom."");
+Console.WriteLine(""Pour un Sudoku complet, il faut 81 + 9 + 9 + 9 = 108 contraintes explicites."");
+Console.WriteLine(""(Ici, seules 11 contraintes sont posees pour illustration."");
+Console.WriteLine("" Ce theoreme partiel ne produit PAS une solution Sudoku valide.)"");",,,,,,,,fc0ddb6e9e75665e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d0e1f2a3,markdown,fr,834779f75205fed3,"### Limites de l'approche explicite
+
+| Aspect | Probleme |
+|--------|----------|
+| **Verbosite** | 81 proprietes + 108 contraintes a ecrire à la main |
+| **Erreur-prone** | Facile d'oublier ou de dupliquer une cellule dans une contrainte |
+| **Non generalisable** | Impossible d'adapter a un Sudoku 16x16 sans tout reecrire |
+| **Maintenance** | Ajouter un indice (hint) necessite de connaitre le nom exact de la propriete |
+| **Lisibilite** | Les contraintes de boite sont illisibles (9 noms de proprietes melanges) |
+
+> **Conclusion** : l'approche explicite est pedagogiquement utile pour comprendre ce que Z3 fait, mais elle ne passe pas a l'echelle. C'est ce qui motive le modèle implicite par arrays.",,,,,,,,834779f75205fed3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e1f2a3b4,markdown,fr,a914e42df66d36c4,"## 3. Approche 2 : Modèle implicite par arrays
+
+L'approche par arrays exploite une capacite fondamentale de Z3.Linq : la traduction d'**indexeurs de collection** (`list[i]`) en variables de decision SMT. Au lieu de 81 proprietes nommees, on utilise une seule propriete `List<int> Cells` de taille 81.
+
+### Principe cle : closures et capture de variable
+
+Quand on ecrit une boucle `for` qui genere des contraintes Z3 :
+
+```csharp
+for (int i = 0; i < 9; i++) {
+    var i1 = i;  // Copie locale OBLIGATOIRE
+    theorem = theorem.Where(s => s.Cells[i1 * 9 + j1] > 0);
+}
+```
+
+La variable `i1` est une **copie locale** qui capture la valeur de `i` a chaque iteration. Sans cette copie, toutes les expressions lambda partageraient la meme reference vers `i`, qui vaudrait 9 en sortie de boucle. C'est le mecanisme standard de closure en C#, applique ici aux expressions traduites en SMT.
+
+### Classe du modèle implicite",,,,,,,,a914e42df66d36c4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f2a3b4c5,code,fr,273975dca2219d0f,"public class SudokuArray
+{
+    public List<int> Cells { get; set; } = Enumerable.Repeat(0, 81).ToList();
+}
+
+Console.WriteLine(""Classe SudokuArray definie : 1 propriete Cells (List<int> de 81 elements)"");",,,,,,,,273975dca2219d0f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a3b4c5d6,markdown,fr,279ee73a54a15193,"### Construction du théorème avec boucles et closures
+
+Le théorème se construit en trois étapes, chacune utilisant des boucles `for` au lieu d'enumerations explicites :
+
+1. **Contraintes de domaine** : chaque cellule entre 1 et 9
+2. **Contraintes structurelles** : lignes, colonnes, boites (27 contraintes au total)
+3. **Contraintes d'indices** : les cellules pre-remplies du puzzle sont fixees
+
+**Point cle a observer** : la variable `var i1 = i;` dans chaque boucle. C'est la capture de closure. Sans elle, toutes les expressions lambda referenceraient la meme variable `i` (qui vaudrait sa valeur finale en sortie de boucle), et Z3 resoudrait un probleme incorrect.",,,,,,,,279ee73a54a15193,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b4c5d6e7,code,fr,123f296f273e8507,"var ctx2 = new Z3Context();
+var theorem2 = ctx2.NewTheorem<SudokuArray>();
+var indices = Enumerable.Range(0, 9).ToArray();
+
+// --- Etape 1 : Contraintes de domaine (1..9) ---
+for (int i = 0; i < 9; i++) {
+    for (int j = 0; j < 9; j++) {
+        var i1 = i;  // Capture de closure : copie locale obligatoire
+        var j1 = j;
+        theorem2 = theorem2.Where(s => s.Cells[i1 * 9 + j1] > 0 && s.Cells[i1 * 9 + j1] < 10);
+    }
+}
+
+// --- Etape 2a : Contraintes de lignes (9 contraintes) ---
+for (int r = 0; r < 9; r++) {
+    var r1 = r;
+    theorem2 = theorem2.Where(t => Z3Methods.Distinct(
+        indices.Select(j => t.Cells[r1 * 9 + j]).ToArray()));
+}
+
+// --- Etape 2b : Contraintes de colonnes (9 contraintes) ---
+for (int c = 0; c < 9; c++) {
+    var c1 = c;
+    theorem2 = theorem2.Where(t => Z3Methods.Distinct(
+        indices.Select(i => t.Cells[i * 9 + c1]).ToArray()));
+}
+
+// --- Etape 2c : Contraintes de boites 3x3 (9 contraintes) ---
+for (int b = 0; b < 9; b++) {
+    var b1 = b;
+    var iStart = b1 / 3;
+    var jStart = b1 % 3;
+    var idx = iStart * 3 * 9 + jStart * 3;
+    theorem2 = theorem2.Where(t => Z3Methods.Distinct(new int[] {
+        t.Cells[idx],      t.Cells[idx + 1],  t.Cells[idx + 2],
+        t.Cells[idx + 9],  t.Cells[idx + 10], t.Cells[idx + 11],
+        t.Cells[idx + 18], t.Cells[idx + 19], t.Cells[idx + 20]
+    }));
+}
+
+Console.WriteLine($""Modele implicite : 81 contraintes de domaine + 27 contraintes structurelles"");
+Console.WriteLine($""Le code est 3x plus court et generalisable a toute taille N^2 x N^2."");",,,,,,,,123f296f273e8507,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,1bc6039a,markdown,fr,2777bf3fdb60359d,"### Interprétation — La contrainte AllDifferent
+
+Les trois familles de contraintes structurelles (lignes, colonnes, boîtes) reposent toutes sur la même primitive SMT : `Z3Methods.Distinct(...)`. En programmation par contraintes, cette contrainte porte un nom canonique — **AllDifferent** — qui exprime que *toutes* les valeurs d'un ensemble doivent être deux à deux distinctes. C'est l'élément central de tout puzzle Sudoku : chaque ligne, colonne et boîte 3×3 est une instance d'AllDifferent sur 9 variables.
+
+**Décomposition de AllDifferent.** Une contrainte `AllDifferent(x₁, …, xₙ)` se décompose canoniquement en **inégalités pairwise** :
+
+$$
+\forall\, i < j,\;\; x_i \neq x_j
+$$
+
+Pour `n = 9`, cela fait `n·(n−1)/2 = 36` clauses binaires par contrainte (et autant par ligne, colonne, boîte) — une croissance en **O(n²)**. C'est pourquoi AllDifferent est exposé comme une **primitive globale** (un seul appel `Distinct`) plutôt qu'à énumérer à la main : le solveur peut alors appliquer des propagations spécialisées (par ex. *bound consistency* sur le domaine des valeurs) bien plus efficaces que sur 36 clauses `≠` isolées. `Z3Methods.Distinct` n'est donc pas du sucre syntaxique anodin — c'est un raccourci vers une structure de décision exploitée par le solveur.
+
+> **Pour aller plus loin** : la contrainte AllDifferent et ses encodages alternatifs (pairwise, channeling, propagateurs dédiés) sont un sujet central de la programmation par contraintes (réf. : *Handbook of Constraint Programming*, Rossi et al., 2006, chap. 6).",,,,,,,,2777bf3fdb60359d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,c5d6e7f8,markdown,fr,7d08b6f742acbd29,"### Résolution du Sudoku vide
+
+Sans aucune contrainte d'indice, le solveur trouve une solution valide parmi l'ensemble des Sudoku possibles.",,,,,,,,7d08b6f742acbd29,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d6e7f8a9,code,fr,9b3b3cec5419e34c,"var sw = System.Diagnostics.Stopwatch.StartNew();
+var solution = theorem2.Solve();
+sw.Stop();
+
+Console.WriteLine($""Resolution en {sw.ElapsedMilliseconds} ms"");
+DisplaySudoku(solution.Cells, ""Solution Sudoku (sans indices)"");",,,,,,,,9b3b3cec5419e34c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e7f8a9b0,markdown,fr,16271bac8b6ee15b,"### Interpretation : Sudoku vide
+
+Le solveur produit une grille Sudoku valide (chaque ligne, colonne et boite 3x3 contient les chiffres 1 a 9 exactement une fois). Ce n'est pas un Sudoku ""interessant"" (pas de puzzle a resoudre), mais il demontre que **toutes les contraintes structurelles sont correctes**.
+
+| Aspect | Valeur | Signification |
+|--------|--------|---------------|
+| Contraintes de domaine | 81 | Chaque cellule dans [1, 9] |
+| Contraintes de lignes | 9 | Une par ligne |
+| Contraintes de colonnes | 9 | Une par colonne |
+| Contraintes de boites | 9 | Une par boite 3x3 |
+| Total | 108 | Identique a l'approche explicite, mais genere par boucles |
+
+> **Note technique** : le modèle implicite genere exactement le meme ensemble de contraintes SMT que le modèle explicite. La difference est purement syntaxique (C#), pas semantique (Z3).",,,,,,,,16271bac8b6ee15b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,223a2311,markdown,fr,de6b2825c3f1cfb0,"### Précision de vocabulaire — « array » C# vs « Array » SMT
+
+Puisque nous venons d'évoquer le **niveau SMT**, il faut clarifier un point de vocabulaire qui sinon prête à confusion : le mot **« array »** dans ce notebook ne désigne **pas** la théorie des tableaux de Z3.
+
+- **Ici, « array » = `List<int>` C#.** La propriété `Cells` est une collection C#, et l'indexeur `s.Cells[i*9+j]` est un *sucre d'indexeur* que Z3.Linq traduit en **une variable de décision Z3 distincte par cellule** (81 variables au total, comme le rappelle la conclusion). Le « modèle implicite par arrays » compactifie donc le **code source C#**, pas la **représentation SMT** — d'où la note ci-dessus : les deux approches génèrent le même ensemble de contraintes.
+
+- **La théorie des tableaux SMT** (le `(Array Int Int)` de SMT-LIB, avec ses opérations `select`/`store` et les axiomes de McCarthy) est **autre chose** : là, le tableau est un *seul* symbole logique que l'on interroge par `select(arr, i)`. Cette théorie est enseignée dans le notebook [04 — Array Theory](04_Array_Theory.ipynb).
+
+Le « array » de ce notebook et l'« Array » de NB-04 sont donc deux notions différentes qui partagent un mot. Si vous cherchez à modéliser le Sudoku comme un *vrai tableau SMT* (`select`/`store`), c'est NB-04 qu'il faut voir ; la comparaison des deux modes d'encodage des collections (une variable par cellule vs un seul symbole de tableau) est elle détaillée dans le notebook [03 — Sudoku Modes Comparison](03_Sudoku_Modes_Comparison.ipynb).",,,,,,,,de6b2825c3f1cfb0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f8a9b0c1,markdown,fr,910df05352db0e36,"## 4. Résolution avec un puzzle reel (indices)
+
+La vraie puissance du modèle implicite apparait quand on ajoute des **indices** (cellules pre-remplies du puzzle). Avec l'approche explicite, ajouter un indice suppose connaitre le nom de la propriete (`Cell34`). Avec le modèle implicite, une simple boucle suffit.
+
+### Puzzle classique
+
+Nous utilisons un puzzle Sudoku classique ou `0` represente une cellule vide.",,,,,,,,910df05352db0e36,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a9b0c1d2,code,fr,6e9eeca77499cbce,"// Un puzzle Sudoku classique (0 = cellule vide)
+var puzzle = new SudokuArray {
+    Cells = new List<int> {
+        5,3,0, 0,7,0, 0,0,0,
+        6,0,0, 1,9,5, 0,0,0,
+        0,9,8, 0,0,0, 0,6,0,
+        8,0,0, 0,6,0, 0,0,3,
+        4,0,0, 8,0,3, 0,0,1,
+        7,0,0, 0,2,0, 0,0,6,
+        0,6,0, 0,0,0, 2,8,0,
+        0,0,0, 4,1,9, 0,0,5,
+        0,0,0, 0,8,0, 0,7,9
+    }
+};
+
+int givenCount = puzzle.Cells.Count(c => c != 0);
+Console.WriteLine($""Puzzle charge : {givenCount} indices sur 81 cellules"");
+DisplaySudoku(puzzle.Cells, ""Puzzle initial"");",,,,,,,,6e9eeca77499cbce,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b0c1d2e3,markdown,fr,f5ab412f276daa18,"### Construction du théorème avec indices
+
+Le théorème combine les memes contraintes structurelles que precedemment, plus une contrainte par cellule pre-remplie. Remarquez la troisieme boucle `for` : elle parcourt les 81 cellules et fixe uniquement les valeurs non-nulles.",,,,,,,,f5ab412f276daa18,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,c1d2e3f4,code,fr,e8593d9c81ff8f1f,"var ctx3 = new Z3Context();
+var puzzleTheorem = ctx3.NewTheorem<SudokuArray>();
+
+// --- Contraintes de domaine (1..9) ---
+for (int i = 0; i < 9; i++) {
+    for (int j = 0; j < 9; j++) {
+        var i1 = i; var j1 = j;
+        puzzleTheorem = puzzleTheorem.Where(s => s.Cells[i1 * 9 + j1] > 0 && s.Cells[i1 * 9 + j1] < 10);
+    }
+}
+
+// --- Contraintes de lignes ---
+for (int r = 0; r < 9; r++) {
+    var r1 = r;
+    puzzleTheorem = puzzleTheorem.Where(t => Z3Methods.Distinct(
+        indices.Select(j => t.Cells[r1 * 9 + j]).ToArray()));
+}
+
+// --- Contraintes de colonnes ---
+for (int c = 0; c < 9; c++) {
+    var c1 = c;
+    puzzleTheorem = puzzleTheorem.Where(t => Z3Methods.Distinct(
+        indices.Select(i => t.Cells[i * 9 + c1]).ToArray()));
+}
+
+// --- Contraintes de boites 3x3 ---
+for (int b = 0; b < 9; b++) {
+    var b1 = b;
+    var iStart = b1 / 3; var jStart = b1 % 3;
+    var idx = iStart * 3 * 9 + jStart * 3;
+    puzzleTheorem = puzzleTheorem.Where(t => Z3Methods.Distinct(new int[] {
+        t.Cells[idx],      t.Cells[idx + 1],  t.Cells[idx + 2],
+        t.Cells[idx + 9],  t.Cells[idx + 10], t.Cells[idx + 11],
+        t.Cells[idx + 18], t.Cells[idx + 19], t.Cells[idx + 20]
+    }));
+}
+
+// --- Contraintes d'indices : fixer les cellules pre-remplies ---
+int hintCount = 0;
+for (int i = 0; i < 81; i++) {
+    if (puzzle.Cells[i] != 0) {
+        var idx = i;
+        var val = puzzle.Cells[i];
+        puzzleTheorem = puzzleTheorem.Where(s => s.Cells[idx] == val);
+        hintCount++;
+    }
+}
+
+Console.WriteLine($""Theoreme construit : 108 contraintes structurelles + {hintCount} contraintes d'indices"");",,,,,,,,e8593d9c81ff8f1f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,solve-markdown-intro,markdown,fr,4427e16ecf49433f,"### Résolution du puzzle
+
+Le théorème est complet (contraintes structurelles + indices). Lancons la résolution.",,,,,,,,4427e16ecf49433f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d2e3f4a5,code,fr,4641461eb2db5812,"sw.Restart();
+var solved = puzzleTheorem.Solve();
+sw.Stop();
+DisplaySudoku(solved.Cells, $""Solution (en {sw.ElapsedMilliseconds} ms)"");",,,,,,,,4641461eb2db5812,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e3f4a5b6,markdown,fr,23aaccc35d251857,"### Interpretation : puzzle resolu
+
+Le solveur Z3 trouve la solution unique du puzzle en quelques millisecondes. Chaque cellule vide a ete completee de maniere a satisfaire toutes les contraintes.
+
+| Aspect | Valeur | Signification |
+|--------|--------|---------------|
+| Cellules pre-remplies | 30 | Donnees du puzzle |
+| Cellules a determiner | 51 | Trouvees par Z3 |
+| Temps de résolution | variable | Generalement < 100 ms |
+| Solutions possibles | 1 | Le puzzle a une solution unique |
+
+> **Note** : le modèle implicite rend l'ajout d'indices trivial (une boucle). Avec l'approche explicite, il faudrait ecrire 30 contraintes individuelles `Where(t => t.CellXY == val)`, en connaissant le mapping position -> nom de propriete.",,,,,,,,23aaccc35d251857,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f4a5b6c7,markdown,fr,ca020b497ee97123,"## 5. Tableau comparatif des deux approches
+
+| Aspect | Approche explicite (81 proprietes) | Modèle implicite (List<int>) |
+|--------|-------------------------------------|-------------------------------|
+| Nombre de proprietes | 81 (Cell11...Cell99) | 1 (Cells) |
+| Contraintes de domaine | 81 expressions `Where(t => t.CellXY >= 1)` | Boucle `for` 81 iterations |
+| Contraintes de ligne | 9 lambdas enumerant 9 cellules chacune | 1 boucle `for` avec `Z3Methods.Distinct` |
+| Contraintes de boite | 9 lambdas enumerant 9 cellules chacune | 1 boucle `for` avec arithmetique d'index |
+| Ajout d'indices | Copier-coller + edition manuelle | Boucle sur les cellules non-nulles |
+| Generalisable a N^2 | Non (taille fixe) | Oui (boucles parametriques) |
+| Capture de closure | Non applicable | `var i1 = i;` indispensable |
+| Code total (lignes) | ~200+ | ~50 |
+
+**Conclusion** : le modèle implicite par arrays est superieur sur tous les plans, sauf la **transparence initiale**. L'approche explicite reste utile comme étape pedagogique pour comprendre que Z3 cree bien une variable de decision par cellule.",,,,,,,,ca020b497ee97123,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,a5b6c7d8,markdown,fr,455a7ac9384569da,"## 6. Exercice 1 : Sudoku 16x16
+
+Adaptez le modèle implicite pour un **Sudoku 16x16** :
+- `Cells` contient 256 elements (16x16)
+- Domaine : chaque cellule entre 1 et 16
+- Rangees : 16 contraintes de 16 valeurs distinctes
+- Colonnes : 16 contraintes de 16 valeurs distinctes
+- Boites : 16 boites de taille 4x4
+
+**Indices** :
+- Modifier les boucles pour `n = 16` et `blockSize = 4`
+- L'arithmetique d'index pour les boites utilise `b / 4` et `b % 4` (au lieu de `b / 3` et `b % 3`)
+- L'offset entre lignes dans une boite passe de 9 a 16",,,,,,,,455a7ac9384569da,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b6c7d8e9,code,fr,f60ff758769cd331,"// Exercice : adapter le modele implicite pour un Sudoku 16x16
+// - Cells contient 256 elements (16x16)
+// - Domaine : chaque cellule entre 1 et 16
+// - Rangees : 16 contraintes de 16 valeurs distinctes
+// - Colonnes : 16 contraintes de 16 valeurs distinctes
+// - Boites : 16 boites 4x4
+// Indice : modifier les boucles pour n=16 et blockSize=4
+// L'offset entre lignes dans une boite passe de 9 a 16
+
+// TODO etudiant : implementer le theoreme pour Sudoku16
+// public class Sudoku16Array { public List<int> Cells { get; set; } = ...; }
+// var ctx16 = new Z3Context();
+// var theorem16 = ctx16.NewTheorem<Sudoku16Array>();
+// ... contraintes de domaine, lignes, colonnes, boites ...
+// var solution16 = theorem16.Solve();
+
+Console.WriteLine(""Exercice a completer : Sudoku 16x16"");",,,,,,,,f60ff758769cd331,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,c7d8e9f0,markdown,fr,b3bfa255dad5c447,"## 7. Exercice 2 : Mesurer le temps de résolution en fonction de la difficulte
+
+Generez des puzzles avec un nombre variable d'indices (de 17, le minimum theorique, a 40) et mesurez le temps de résolution par Z3.
+
+**Objectif** : comprendre comment la difficulte du puzzle (nombre d'indices) influence le temps de résolution.
+
+**Indices** :
+- Partir d'une solution complete ( utilisez le théorème sans indices)
+- Supprimer progressivement des cellules aleatoirement pour creer des puzzles de difficulte croissante
+- Chronometrer `theorem.Solve()` pour chaque puzzle
+- Afficher un tableau recapitulatif : nombre d'indices | temps (ms) | statut",,,,,,,,b3bfa255dad5c447,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,d8e9f0a1,code,fr,15df89bfa462f26c,"// Exercice : mesurer le temps de resolution pour des puzzles de difficulte croissante
+// 1. Partir d'une solution complete (theoreme sans indices)
+// 2. Supprimer progressivement des cellules (ou utiliser des puzzles connus)
+// 3. Chronometrer theorem.Solve() pour chaque niveau
+// 4. Afficher un tableau resultat : indices | temps (ms) | statut
+
+// Indice : utiliser Random pour selectionner les cellules a supprimer
+// var rng = new Random(42);
+// var cellsToRemove = Enumerable.Range(0, 81).OrderBy(_ => rng.Next()).Take(n).ToList();
+
+// TODO etudiant : implementer le benchmark
+Console.WriteLine(""Exercice a completer : benchmark difficulte"");",,,,,,,,15df89bfa462f26c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,e9f0a1b2,markdown,fr,3d52971638e17eea,"## 8. Exercice 3 : Generer plusieurs solutions
+
+Un Sudoku bien pose a une **solution unique**. Mais si le puzzle est sous-contraint (trop peu d'indices), il peut avoir plusieurs solutions. Le but de cet exercice est de trouver et denombrer ces solutions.
+
+**Objectif** : modifier le théorème pour trouver plusieurs solutions distinctes et verifier l'ununicite.
+
+**Indices** :
+- Resoudre le puzzle une premiere fois
+- Ajouter une contrainte excluant la solution trouvee : au moins une cellule doit differer
+- Re-resoudre pour trouver la solution suivante
+- Repeter jusqu'a ce qu'il n'y ait plus de solution
+- Pour exclure : `Where(s => s.Cells[0] != sol.Cells[0] || s.Cells[1] != sol.Cells[1] || ...)`",,,,,,,,3d52971638e17eea,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,f0a1b2c3,code,fr,69868c45981f4188,"// Exercice : trouver toutes les solutions d'un puzzle incomplet
+// 1. Resoudre le puzzle
+// 2. Ajouter une contrainte excluant la solution trouvee
+// 3. Re-resoudre pour trouver la solution suivante
+// 4. Compter le nombre de solutions
+// Indice : exclure = Where(s => s.Cells[0] != solution.Cells[0] || s.Cells[1] != solution.Cells[1] || ...)
+
+// TODO etudiant : implementer la recherche multi-solutions
+Console.WriteLine(""Exercice a completer : solutions multiples"");",,,,,,,,69868c45981f4188,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8-quant-intro,markdown,fr,0c30a005a99954c6,"## B8 - Quantificateurs bornes (DSL `Z3Methods.ForAll` / `Exists`)
+
+La section 3 de ce notebook **deroule à la main** les contraintes de cellule : une boucle C# emet une propriete par index (« chaque cellule dans [1,9] », les lignes/colonnes/blocs `Distinct`). C'est le pain quotidien de la modelisation par tableau - mais la boucle **grandit avec la taille** et melange la logique du modèle et la mecanique du deroulage. Le binding ajoute deux quantificateurs **bornes** : [`Z3Methods.ForAll(domaine, i => predicat)`](../Z3.Linq/solutions/Z3.Linq/Z3Methods.cs#L57) et [`Z3Methods.Exists(domaine, i => predicat)`](../Z3.Linq/solutions/Z3.Linq/Z3Methods.cs#L77). Le domaine est **evalue dans l'hote** (un `IEnumerable` C#) et le predicat est **deroule** en une conjonction (`ForAll` -> `MkAnd`) ou une disjonction (`Exists` -> `MkOr`) sur chaque element. Une seule `.Where(...)` exprime alors ce qui exigeait une boucle emettant un `.Where` par index. Ce sont des quantificateurs **finis** : pas les quantificateurs SMT sur un sort non borne (`MkForall`), mais un deroulage statique sur un index enumerable.
+
+> **Stack : A + B - pourquoi**. On modelise une **rangee** de 4 cellules (un mini-Sudoku 1D), palette `{1,2,3,4}`. Deux contraintes quantifiees : **universelle** « chaque cellule dans [1,4] » et **existentielle** « au moins une cellule vaut 4 » (le maximum apparait). Cote raw, on **deroule à la main** : une boucle construit la conjonction `MkAnd` des bornes et une autre la disjonction `MkOr` des egalites a 4. Cote DSL, les **memes** quantificateurs s'ecrivent en une ligne : `Z3Methods.ForAll(Enumerable.Range(0, N), i => ...)` et `Z3Methods.Exists(...)`. Le contraste : le systeme est **SAT** avec témoin ; puis, en reduisant les bornes a [1,3], « une cellule vaut 4 » devient **UNSAT** (aucun 4 possible sous 3) - obtenu des deux cotes sur le meme modèle.",,,,,,,,0c30a005a99954c6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8-quant-code,code,fr,8a64b8b886bf26dd,"// B8 - Quantificateurs bornes ""ForAll/Exists"" : deux stacks sur une MEME rangee de cellules.
+//   Une rangee de 4 cellules (mini-Sudoku 1D). Palette : {1,2,3,4}.
+//   Universel : chaque cellule dans [1,4].   Existentiel : au moins une cellule vaut 4 (le max apparait).
+//   SAT -> temoin ; puis bornes reduites a [1,3] + ""une cellule vaut 4"" -> UNSAT (aucun 4 possible sous 3).
+const int N = 4;
+
+// Classe au niveau cellule (requise par NewTheorem<T>) : une rangee de cellules.
+public class Row { public int[] Cells { get; set; } = new int[N]; }
+
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : universel/existentiel deroules a la main en MkAnd/MkOr
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    IntExpr[] v = new IntExpr[N];
+    for (int i = 0; i < N; i++) v[i] = z3.MkIntConst($""c{i}"");
+
+    // Universel : chaque cellule dans [1,4], DEROULE a la main en conjonction (une contrainte par index)
+    var bounds = new System.Collections.Generic.List<Microsoft.Z3.BoolExpr>();
+    for (int i = 0; i < N; i++) bounds.Add(z3.MkAnd(z3.MkGe(v[i], z3.MkInt(1)), z3.MkLe(v[i], z3.MkInt(4))));
+    Microsoft.Z3.BoolExpr forall14 = z3.MkAnd(bounds.ToArray());
+
+    // Existentiel : au moins une cellule vaut 4, DEROULE a la main en disjonction
+    var disj = new System.Collections.Generic.List<Microsoft.Z3.BoolExpr>();
+    for (int i = 0; i < N; i++) disj.Add(z3.MkEq(v[i], z3.MkInt(4)));
+    Microsoft.Z3.BoolExpr existsMax = z3.MkOr(disj.ToArray());
+
+    var sSat = z3.MkSolver();
+    sSat.Assert(forall14);
+    sSat.Assert(existsMax);
+    Status stSat = sSat.Check();
+    Console.WriteLine($""[RAW] ForAll(c dans [1,4]) & Exists(c==4) : {stSat}"");
+    if (stSat == Status.SATISFIABLE) {
+        var m = sSat.Model;
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < N; i++) { if (i > 0) sb.Append("",""); sb.Append(m.Eval(v[i], true)); }
+        Console.WriteLine($""[RAW]   temoin : [{sb}]"");
+    }
+
+    // Bornes reduites a [1,3] : ""une cellule vaut 4"" devient impossible -> UNSAT
+    var bounds13 = new System.Collections.Generic.List<Microsoft.Z3.BoolExpr>();
+    for (int i = 0; i < N; i++) bounds13.Add(z3.MkAnd(z3.MkGe(v[i], z3.MkInt(1)), z3.MkLe(v[i], z3.MkInt(3))));
+    var sUn = z3.MkSolver();
+    sUn.Assert(z3.MkAnd(bounds13.ToArray()));
+    sUn.Assert(existsMax);
+    Console.WriteLine($""[RAW] ForAll(c dans [1,3]) & Exists(c==4) : {sUn.Check()}   (aucun 4 possible sous 3)"");
+}
+
+// =====================================================================
+// BLOC DSL (Z3.Linq) : le meme universel/existentiel en une ligne sur Enumerable.Range
+// =====================================================================
+{
+    using var thCtx = new Z3Context();
+
+    var sat = thCtx.NewTheorem<Row>()
+        .Where(e => Z3Methods.ForAll(Enumerable.Range(0, N), i => e.Cells[i] >= 1 && e.Cells[i] <= 4))
+        .Where(e => Z3Methods.Exists(Enumerable.Range(0, N), i => e.Cells[i] == 4))
+        .Solve();
+    if (sat != null)
+        Console.WriteLine($""[DSL] ForAll(c dans [1,4]) & Exists(c==4) : SAT  -> [{string.Join("","", sat.Cells)}]"");
+
+    var unsat = thCtx.NewTheorem<Row>()
+        .Where(e => Z3Methods.ForAll(Enumerable.Range(0, N), i => e.Cells[i] >= 1 && e.Cells[i] <= 3))
+        .Where(e => Z3Methods.Exists(Enumerable.Range(0, N), i => e.Cells[i] == 4))
+        .Solve();
+    Console.WriteLine($""[DSL] ForAll(c dans [1,3]) & Exists(c==4) : {(unsat == null ? ""UNSAT"" : ""SAT?!"")}   (le quantificateur borne se contredit)"");
+
+    // Semantique du domaine vide : ForAll vide = vrai (vacuite), Exists vide = faux
+    var vac = thCtx.NewTheorem<Row>()
+        .Where(e => Z3Methods.ForAll(Enumerable.Empty<int>(), i => e.Cells[i] > e.Cells[i]))  // predicat faux, mais domaine vide
+        .Where(e => e.Cells[0] == 2)
+        .Solve();
+    Console.WriteLine($""[DSL] ForAll(domaine vide, predicat faux) : {(vac == null ? ""UNSAT"" : ""SAT"")}   (universel vide = vrai par vacuite)"");
+}",,,,,,,,8a64b8b886bf26dd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,b8-quant-lecture,markdown,fr,42dd45a43174a9d0,"### Lecture B8 - deux ecritures d'un quantificateur borne, un meme deroulage
+
+Les deux stacks contraignent la **meme rangee** avec les **memes quantificateurs** - universel « tout dans [1,4] », existentiel « un 4 apparait » - et donnent les **memes verdicts** : SAT avec témoin, puis UNSAT des que les bornes tombent a [1,3]. La difference est **comment** on ecrit le deroulage :
+
+| Aspect | RAW (boucle + `MkAnd`/`MkOr`) | DSL (`ForAll`/`Exists` sur `Range`) |
+|---|---|---|
+| Universel | boucle C# -> `MkAnd(bounds.ToArray())` | `Z3Methods.ForAll(Enumerable.Range(0, N), i => ...)` |
+| Existentiel | boucle C# -> `MkOr(disj.ToArray())` | `Z3Methods.Exists(Enumerable.Range(0, N), i => ...)` |
+| Taille du code | croit avec le nombre d'index (une boucle explicite) | constante : une `.Where` quel que soit `N` |
+| Domaine vide | a gerer soi-meme | `ForAll` vide = vrai, `Exists` vide = faux (vacuite classique) |
+
+> **Ligne de contraste (a retenir)** : *le raw materialise le deroulage* - une boucle C# assemble la conjonction (`MkAnd`) ou la disjonction (`MkOr`) index par index ; *le DSL le declare* - `ForAll`/`Exists` sur un `Enumerable.Range` deroulent en interne vers exactement le meme `MkAnd`/`MkOr`. **Meme deroulage, meme verdict**, mais la logique du modèle ne se noie plus dans la mecanique de la boucle. Attention : ce sont des quantificateurs **finis** (le domaine est un `IEnumerable` C# evalue dans l'hote), pas les quantificateurs SMT sur un sort non borne.
+
+**Cas d'usage** : les quantificateurs bornes sont l'idiome des **grilles et tableaux** - rangees de Sudoku, N-reines, fenetres d'ordonnancement - partout ou une contrainte s'applique « pour tout / il existe » sur un index enumerable. Ils remplacent la boucle emettant un `.Where` par index (section 3 de ce notebook). On garde le deroulage manuel quand le domaine **n'est pas statiquement enumerable** (il depend du modèle) ou quand il faut un **vrai quantificateur SMT** non borne (`MkForall`/`MkExists`), hors de portee du deroulage fini.",,,,,,,,42dd45a43174a9d0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/02_Sudoku_Theorem_vs_Array.ipynb,conclusion-cell-z3,markdown,fr,81de197076290a88,"## Conclusion
+
+Ce notebook a illustre la **transition fondamentale** entre deux paradigmes de modelisation Sudoku avec Z3.Linq :
+
+### Recapitulatif
+
+| Concept | Point cle |
+|---------|-----------|
+| **Théorème explicite** | 81 proprietes nommees, chaque contrainte enumere les cellules |
+| **Modèle implicite** | 1 `List<int>` indexee, boucles generent les contraintes |
+| **Capture de closure** | `var i1 = i;` est obligatoire pour capturer la valeur de boucle |
+| **Arithmetique d'index** | `row * 9 + col` pour l'index lineaire, `b / 3` et `b % 3` pour les boites |
+| **Ajout d'indices** | Boucle sur les cellules non-nulles, une contrainte `Where` par indice |
+
+### Pour aller plus loin
+
+- **Sudoku 16x16** (Exercice 1) : la generalisation demontre la puissance du modèle implicite
+- **Benchmark difficulte** (Exercice 2) : comprendre la complexite algorithmique du solveur
+- **Solutions multiples** (Exercice 3) : vérification d'universalite et denomination
+
+Dans les notebooks suivants de la serie Z3, le modèle implicite par arrays sera la base de toutes les modelisations avancees.
+
+---
+
+**Navigation** : [<< Introduction Linq2Z3](01_Linq2Z3_Intro.ipynb) | [Serie Z3](README.md) | [Index SymbolicAI](../../README.md)",,,,,,,,81de197076290a88,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,02bb7e6d,markdown,fr,48640cefc78d4033,"# Sudoku 4x4 : comparaison des modes `Array` et `Constants`
+
+**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | [Array Theory >>](04_Array_Theory.ipynb)
+
+## Objectif
+
+Ce notebook démontre les **deux modes de modélisation des collections** offerts par le fork `Z3.Linq`, en résolvant le **même** Sudoku 4x4 (`int[][]`) des deux façons. C'est la démonstration directe que l'enum `CollectionHandling` — historiquement du *dead code* défini mais jamais câblé — est désormais **vivante** et fonctionnelle bout-en-bout.
+
+| Mode | Modélisation Z3 | Avantage |
+|------|----------------|----------|
+| **`Array`** (défaut) | Une seule `ArrayExpr` Z3 + `Select`/`Store` (théorie des tableaux) | Compact, supporte les index symboliques, `int[][]` imbriqué |
+| **`Constants`** | Un constant Z3 par élément (`Cells_0_0`, `Cells_0_1`, …) | Modèle « un symbole = une inconnue », proche du raisonnement humain, lisible dans le solver |
+
+Les deux modes produisent une solution valide ; le choix est **pédagogique** et dépend de ce qu'on veut illustrer.",,,,,,,,48640cefc78d4033,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,bd398b0e,markdown,fr,7036f00fddb3cf4a,"### Vue d'ensemble : un meme Sudoku, deux modes d'encodage des collections
+
+```mermaid
+flowchart TB
+    G[""Meme grille Sudoku 4x4\n(int de int)""]
+    G --> M1[""Mode Array (defaut)""]
+    G --> M2[""Mode Constants""]
+    M1 --> A1[""1 seule ArrayExpr Z3\n+ Select / Store\n(theorie des tableaux)""]
+    M2 --> C1[""1 constant Z3 par cellule\nCells_0_0, Cells_0_1, ...""]
+    A1 --> S[""Solution valide\n(carre latin)""]
+    C1 --> S
+    S --> CH[""CollectionHandling\ndesormais cable bout-en-bout\n(dead code ressuscite)""]
+    style M1 fill:#c8f7c5
+    style A1 fill:#c8f7c5
+    style M2 fill:#cfe3ff
+    style C1 fill:#cfe3ff
+```
+
+Les **deux modes** resolvent le **meme** `int[][]` et convergent vers une solution valide.
+Le mode `Array` (vert) encode la grille avec une seule `ArrayExpr` ; le mode `Constants` (bleu)
+cree un symbole Z3 par cellule. C'est la demonstration directe que l'enum `CollectionHandling`
+est desormais **vivante** et fonctionnelle.",,,,,,,,7036f00fddb3cf4a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,62647528,markdown,fr,87f0d7d195b03130,"### Configuration de l'environnement
+
+Chargement du **fork Z3.Linq** (avec `CollectionHandling` câblé) depuis le sous-module local. Les DLL sont produites par le script `scripts/environment/z3-build-deploy.ps1` (décision ai-01 2026-06-13, option b).",,,,,,,,87f0d7d195b03130,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,f642f637,code,fr,6b6eef10c9fdf2fb,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Linq;
+
+Console.WriteLine($""Z3.Linq chargé. CollectionHandling disponible : {nameof(CollectionHandling.Array)}, {nameof(CollectionHandling.Constants)}"");",,,,,,,,6b6eef10c9fdf2fb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,a3cec73d,markdown,fr,82166fa0536d74eb,"### Type de grille et théorème Sudoku 4x4
+
+On définit une grille 4x4 comme un `int[][]`. Le théorème impose : chaque cellule dans `[1,4]`, chaque ligne et chaque colonne a 4 valeurs distinctes (carré latin).",,,,,,,,82166fa0536d74eb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,71f09d1d,code,fr,fbbcbc894fd60ded,"public class SudokuGrid4
+{
+    public int[][] Cells { get; set; } = new int[4][];
+    public SudokuGrid4()
+    {
+        for (int i = 0; i < 4; i++) Cells[i] = new int[4];
+    }
+}
+
+// Construit le théorème Sudoku 4x4 (sans contraintes d'indices) sur un Z3Context donné.
+// Le mode de collection est hérité du contexte (Array ou Constants).
+public static Theorem<SudokuGrid4> BuildSudoku(Z3Context ctx)
+{
+    var t = ctx.NewTheorem<SudokuGrid4>();
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+        {
+            int i1 = i, j1 = j;
+            t = t.Where(g => g.Cells[i1][j1] >= 1 && g.Cells[i1][j1] <= 4);
+        }
+    for (int r = 0; r < 4; r++)
+    {
+        int r1 = r;
+        t = t.Where(g => Z3Methods.Distinct(g.Cells[r1][0], g.Cells[r1][1], g.Cells[r1][2], g.Cells[r1][3]));
+    }
+    for (int c = 0; c < 4; c++)
+    {
+        int c1 = c;
+        t = t.Where(g => Z3Methods.Distinct(g.Cells[0][c1], g.Cells[1][c1], g.Cells[2][c1], g.Cells[3][c1]));
+    }
+    return t;
+}
+
+public static string GridToString(SudokuGrid4 g) =>
+    string.Join(""\n"", Enumerable.Range(0, 4).Select(r => string.Join("" "", g.Cells[r])));",,,,,,,,fbbcbc894fd60ded,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,1d0c2f52,markdown,fr,9e97d5502df4f1e4,"### Résolution en mode `Array` (théorie des tableaux Z3)
+
+C'est le mode par défaut. `Cells` est modélisé comme **une seule** `ArrayExpr` Z3 (avec une dimension imbriquée pour `int[][]`). L'accès `Cells[i][j]` se traduit par `Select(Select(arr, i), j)`.",,,,,,,,9e97d5502df4f1e4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,d80a1c4c,code,fr,5341c56067cd4844,"var ctxArray = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array };
+Console.WriteLine($""Mode actif : {ctxArray.DefaultCollectionHandling}"");
+
+var solArray = BuildSudoku(ctxArray).Solve();
+Console.WriteLine(""Solution (mode Array) :"");
+Console.WriteLine(GridToString(solArray));",,,,,,,,5341c56067cd4844,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,ed64899c,markdown,fr,de984f7a50bdb371,"### Résolution en mode `Constants` (un constant Z3 par cellule)
+
+Ici, `Cells` est représenté par **un constant Z3 par élément** : `Cells_0_0`, `Cells_0_1`, …, `Cells_3_3` (16 symboles). C'est le modèle classique de la librairie historique, ressuscité dans le fork. L'accès `Cells[i][j]` crée paresseusement le constant `Cells_i_j` lors de sa première utilisation.
+
+Le **même** code `BuildSudoku` est réutilisé — seule la configuration du `Z3Context` change. C'est la preuve que les deux modes coexistent proprement.",,,,,,,,de984f7a50bdb371,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,9c0b25e1,code,fr,7539aa7e08c1f8a4,"var ctxConst = new Z3Context { DefaultCollectionHandling = CollectionHandling.Constants };
+Console.WriteLine($""Mode actif : {ctxConst.DefaultCollectionHandling}"");
+
+var solConst = BuildSudoku(ctxConst).Solve();
+Console.WriteLine(""Solution (mode Constants) :"");
+Console.WriteLine(GridToString(solConst));",,,,,,,,7539aa7e08c1f8a4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,09a6e45a,markdown,fr,8968b28930242f2c,"### Vérification : les deux solutions sont des carrés latins valides
+
+Indépendamment du mode, le résultat doit satisfaire les contraintes (lignes et colonnes = permutations de 1..4).",,,,,,,,8968b28930242f2c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,734abd31,code,fr,eb6cd1c757bcccc3,"bool IsLatinSquare(SudokuGrid4 g)
+{
+    var expected = new int[] { 1, 2, 3, 4 };
+    for (int r = 0; r < 4; r++)
+        if (!g.Cells[r].OrderBy(v => v).SequenceEqual(expected)) return false;
+    for (int c = 0; c < 4; c++)
+    {
+        var col = Enumerable.Range(0, 4).Select(r => g.Cells[r][c]).OrderBy(v => v);
+        if (!col.SequenceEqual(expected)) return false;
+    }
+    return true;
+}
+
+Console.WriteLine($""Array     valide ? {IsLatinSquare(solArray)}"");
+Console.WriteLine($""Constants valide ? {IsLatinSquare(solConst)}"");",,,,,,,,eb6cd1c757bcccc3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,6782ae48,markdown,fr,cc4bfa41231be8c3,"### Interprétation : pourquoi les deux modes convergent-ils vers la même solution ?
+
+Vous aurez remarqué un fait frappant : les deux modes produisent **exactement la même grille** :
+
+```
+2 3 4 1
+3 4 1 2
+4 1 2 3
+1 2 3 4
+```
+
+Ce n'est pas une coïncidence, et ce n'est pas non plus un défaut. C'est précisément ce que doit garantir une abstraction bien conçue :
+
+| Question | Réponse |
+|----------|---------|
+| Pourquoi la même solution ? | Les deux modes résolvent le **même théorème** (mêmes contraintes LINQ), Z3 explore donc le même espace de solutions et converge vers la même solution minimale. |
+| Le mode change-t-il la sémantique ? | **Non.** `CollectionHandling` est un paramètre d'*encodage*, pas de *signification*. Le CSP (carré latin 4x4) est invariant. |
+| Que change le mode alors ? | La **représentation interne** envoyée au solver : une `ArrayExpr` (mode Array) vs 16 constantes nommées (mode Constants). |
+
+> **Leçon clé** : c'est la **preuve que le mode `Constants` est bien vivant**. Si l'enum était encore du dead code non câblé (son état historique), le mode Constants aurait soit échoué silencieusement, soit reproduit le comportement Array par défaut. Ici, il résout réellement le CSP via des symboles séparés — le chemin d'exécution est distinct, le résultat est identique par correction.",,,,,,,,cc4bfa41231be8c3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,e382c909,markdown,fr,ec31e0a86b2bf4b6,"**Indice pédagogique — quand utiliser quel mode ?**
+
+- **`Array`** : quand on veut un modèle compact ou qu'on manipule des index symboliques (ex. « existe-t-il un index `k` tel que… »). C'est aussi le seul mode qui supporte nativement le `int[][]` imbriqué via la théorie des tableaux.
+- **`Constants`** : quand on veut qu'apparaissent dans le solver des symboles nommés explicites (`Cells_2_3 = 4`), par exemple pour inspecter le modèle, pour enseigner la notion d'inconnue, ou quand la taille de la collection est fixe et petite.
+
+Les deux se valent en puissance d'expression pour les CSP statiques comme le Sudoku ; c'est une question de lisibilité et de stratégie de résolution.
+
+---
+
+## Exercices
+
+### Exercice 1 — Hint dans les deux modes
+
+Ajoutez la contrainte `g.Cells[0][0] == 2` au théorème et vérifiez que la solution la respecte **dans les deux modes**. Affichez les deux grilles.",,,,,,,,ec31e0a86b2bf4b6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,6a6cf646,code,fr,e7da736e51d887d6,"// Exercice 1 à compléter
+// Indice : reprenez BuildSudoku, ajoutez .Where(g => g.Cells[0][0] == 2), solvez dans les deux contextes.
+Console.WriteLine(""Exercice à compléter"");",,,,,,,,e7da736e51d887d6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,d7ea01c5,markdown,fr,706ddf5da4c7f5cd,"### Exercice 2 — Sudoku 9x9 en mode `Constants`
+
+Définissez un `SudokuGrid9` (9x9) et un théorème avec contraintes de lignes, colonnes **et blocs 3x3**. Résolvez-le en mode `Constants`. *Indice : un bloc partant en `(br, bc)` contient les cellules `Cells[br*3 + di][bc*3 + dj]` pour `di, dj ∈ {0,1,2}`.*",,,,,,,,706ddf5da4c7f5cd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,25c06388,code,fr,29d29d232d704a8d,"// Exercice 2 à compléter
+Console.WriteLine(""Exercice à compléter"");",,,,,,,,29d29d232d704a8d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,d7cb39e3,markdown,fr,88c0a52f47c781ca,"### Exercice 3 — Comparaison empirique des deux modes
+
+Mesurez le temps de résolution d'un Sudoku 9x9 (avec quelques indices fixés) en mode `Array` puis en mode `Constants` avec `System.Diagnostics.Stopwatch`. Que constatez-vous ? Quelle hypothèse pouvez-vous formuler sur l'impact du nombre de symboles Z3 sur le temps de résolution ?",,,,,,,,88c0a52f47c781ca,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,09a29341,code,fr,abe22a83687c39f8,"// Exercice 3 à compléter
+// Indice : var sw = System.Diagnostics.Stopwatch.StartNew(); ... sw.Stop(); sw.ElapsedMilliseconds;
+Console.WriteLine(""Exercice à compléter"");",,,,,,,,abe22a83687c39f8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/03_Sudoku_Modes_Comparison.ipynb,6e8f3582,markdown,fr,9ce8a147ec51eb6b,"---
+
+## Conclusion
+
+Ce notebook a démontré que l'enum `CollectionHandling` — historiquement du *dead code* défini mais jamais câblé dans le fork — est désormais **fonctionnelle bout-en-bout**.
+
+### Récapitulatif
+
+| Concept | Rôle dans la démonstration |
+|---------|---------------------------|
+| **`CollectionHandling.Array`** (défaut) | Le mode existant : `int[][]` modélisé comme une `ArrayExpr` Z3 + `Select`/`Store`. Anti-régression (préserve le travail hand-typed). |
+| **`CollectionHandling.Constants`** | Le mode ressuscité : un constant Z3 par élément (`Cells_i_j`). Était du dead code, maintenant câblé. |
+| **Même théorème, 2 encodages** | `BuildSudoku` est réutilisé tel quel ; seul `Z3Context.DefaultCollectionHandling` change. Preuve de l'orthogonalité mode/sémantique. |
+| **Convergence des solutions** | Les 2 modes produisent le même carré latin valide = correction de l'implémentation Constants. |
+
+### Points clés à retenir
+
+1. **L'encodage n'est pas la sémantique** : `CollectionHandling` change comment Z3 *voit* les collections, pas ce que le théorème *exprime*.
+2. **Le mode Constants expose des symboles nommés** (`Cells_2_3 = 4`) — utile pour inspecter le modèle ou enseigner la notion d'inconnue.
+3. **Le mode Array est plus compact** et supporte nativement les index symboliques et le `int[][]` imbriqué (voir [Nested Arrays 2D](05_Nested_Arrays_2D.ipynb)).
+
+### Pour aller plus loin
+
+- Le notebook [06 — Meal Planner Hierarchical](06_Meal_Planner_Modelisation.ipynb) applique la même comparaison des deux modes à un cas réel (planification de repas avec coûts).
+- Les exercices ci-dessus vous font manipuler les deux modes sur des instances plus grandes (9x9) et mesurer leur impact sur les performances.
+
+---
+
+**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | [Array Theory >>](04_Array_Theory.ipynb)",,,,,,,,9ce8a147ec51eb6b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,a1b2c3d0,markdown,fr,80909156e0b4c338,"# Théorie des Tableaux Z3 — Select, Store et Switching
+
+**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | [Nested Arrays 2D >>](05_Nested_Arrays_2D.ipynb)
+
+## Objectifs d'apprentissage
+
+À la fin de ce notebook, vous saurez :
+1. Comprendre la théorie des tableaux en logique SMT (Select, Store, axiomes de McCarthy)
+2. Utiliser `Select` via Z3.Linq pour accéder aux éléments d'un tableau symbolique
+3. Appliquer `Store` directement via l'API Microsoft.Z3 pour les mises à jour fonctionnelles
+4. Implémenter le **switching** (permutation) via des chaînes de Store
+5. Modéliser des transitions d'état avec la théorie des tableaux
+
+### Prérequis
+- Avoir complété le notebook [01 - LINQ to Z3 Intro](01_Linq2Z3_Intro.ipynb)
+- .NET 9.0 Interactive avec le package `Z3.Linq`
+- Notions de base sur les tableaux et les expressions lambda C#
+
+### Durée estimée : 40-50 minutes
+
+---
+
+Ce notebook explore la **théorie des tableaux** (Array Theory) dans Z3, une extension fondamentale de la logique SMT qui permet de raisonner sur des tableaux symboliques. Nous découvrirons les opérations **Select** (lecture) et **Store** (écriture fonctionnelle), ainsi que le **switching** qui permet de modéliser des permutations.
+
+> **Contexte** : La théorie des tableaux a été formalisée par John McCarthy (1962) avec les axiomes `select(store(a, i, v), i) = v` et `i ≠ j ⇒ select(store(a, i, v), j) = select(a, j)`. Ces axiomes sont au cœur du raisonnement sur les structures de données mutables.",,,,,,,,80909156e0b4c338,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,b2c3d4e1,code,fr,b1283f3158597e02,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy, CollectionHandling câblé), Microsoft.Z3, System.Linq"");",,,,,,,,b1283f3158597e02,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,d4e5f6a3,markdown,fr,5db9fab056b39d1a,"## 1. La théorie des tableaux en SMT
+
+La théorie des tableaux (« Array Theory ») étend la logique SMT avec deux opérations fondamentales :
+
+- **Select(a, i)** : lire l'élément à l'index `i` du tableau `a` (notation SMT-LIB : `select(a, i)`)
+- **Store(a, i, v)** : renvoyer un nouveau tableau où l'index `i` vaut `v`, sans modifier `a` (écriture fonctionnelle)
+
+### Axiomes de McCarthy
+
+$$
+\text{select}(\text{store}(a, i, v),\; i) = v
+$$
+
+$$
+i \neq j \implies \text{select}(\text{store}(a, i, v),\; j) = \text{select}(a, j)
+$$
+
+En résumé : un `Store` à l'index `i` ne modifie que la valeur à cet index ; toutes les autres positions restent inchangées.
+
+### API Z3 en C#
+
+| Concept | SMT-LIB | C# (Microsoft.Z3) | Z3.Linq |
+|---------|---------|-------------------|---------|
+| Lire un élément | `(select a i)` | `ctx.MkSelect(a, idx)` | `t.Values[idx]` (closure) |
+| Écrire un élément | `(store a i v)` | `ctx.MkStore(a, idx, val)` | Non supporté directement |
+| Créer un tableau | `(declare-const a (Array Int Int))` | `ctx.MkArrayConst(...)` | Via propriété `int[]` |
+
+### Pourquoi le switching est important
+
+Le **switching** (permutation de deux éléments) est une opération fondamentale qui se construit naturellement avec deux `Store` imbriqués :
+
+$$
+\text{swap}(a, i, j) = \text{store}(\text{store}(a, i, \text{select}(a, j)),\; j, \text{select}(a, i))
+$$
+
+Cette opération est au cœur de nombreux algorithmes : tri, permutation, planification d'actions, vérification de propriétés sur les séquences.",,,,,,,,5db9fab056b39d1a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,4d2d05a2,markdown,fr,0902bc6014963767,"### Vue d'ensemble : les axiomes de McCarthy
+
+Le diagramme ci-dessous illustre les deux axiomes fondamentaux avant de les voir en code :
+
+```mermaid
+flowchart LR
+    subgraph G [""Axiomes de McCarthy""]
+        A[""Array a""] -->|""Store(a, i, v)""| B[""Array a'""]
+        B -->|""Select(a', i)""| R1[""= v — axiome 1\nRead-after-Write""]
+        B -->|""Select(a', j≠i)""| R2[""= Select(a, j) — axiome 2\npositions non modifiées""]
+    end
+    style R1 fill:#c8f7c5
+    style R2 fill:#c8f7c5
+```
+
+**Lecture** : `Store(a, i, v)` produit un nouveau tableau `a'` identique à `a` sauf en position `i`.
+`Select(a', i)` retourne `v` (axiome 1) ; en toute autre position `j`, il retourne `Select(a, j)` (axiome 2).",,,,,,,,0902bc6014963767,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,e5f6a7b4,markdown,fr,fcdad2d019b5d7fb,"### Exemple 1 — Select via Z3.Linq
+
+Z3.Linq permet d'utiliser la notation `t.Values[idx]` dans les contraintes LINQ. Cette notation est automatiquement traduite en `MkSelect` en interne. Nous allons définir une classe avec un tableau `Values` et contraindre ses éléments.
+
+**Approche** : Définir une classe `ArrayDemo` avec un tableau `int[] Values`, puis capturer l'index dans une closure pour que Z3 puisse raisonner sur chaque position individuellement.",,,,,,,,fcdad2d019b5d7fb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,f6a7b8c5,code,fr,7d850ce05b550cc0,"// Exemple 1 : Select via Z3.Linq - contraindre les éléments d'un tableau symbolique
+public class ArrayDemo
+{
+    public int[] Values { get; set; } = new int[5];
+}
+
+using (var ctx = new Z3Context())
+{
+    int size = 5;
+    var theorem = ctx.NewTheorem<ArrayDemo>();
+
+    // Chaque élément entre 1 et 5 (inclus)
+    for (int iclosure = 0; iclosure < size; iclosure++)
+    {
+        var idx = iclosure;
+        theorem = theorem.Where(t => t.Values[idx] >= 1 && t.Values[idx] <= 5);
+    }
+
+    // Tous distincts
+    for (int i = 0; i < size; i++)
+    {
+        for (int j = i + 1; j < size; j++)
+        {
+            var ii = i;
+            var jj = j;
+            theorem = theorem.Where(t => t.Values[ii] != t.Values[jj]);
+        }
+    }
+
+    // Somme = 15 (somme des entiers 1 à 5)
+    theorem = theorem.Where(t => t.Values[0] + t.Values[1] + t.Values[2]
+                                + t.Values[3] + t.Values[4] == 15);
+
+    var result = theorem.Solve();
+
+    Console.WriteLine($""Solution trouvée : [{string.Join("", "", result.Values)}]"");
+    Console.WriteLine($""Somme = {result.Values.Sum()}"");
+    Console.WriteLine($""Distincts = {result.Values.Distinct().Count() == size}"");
+}",,,,,,,,7d850ce05b550cc0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,a7b8c9d6,markdown,fr,ecf1796016be143f,"### Interprétation 1 — Le pattern closure pour Select
+
+**Sortie obtenue** : Un tableau de 5 entiers distincts entre 1 et 5 dont la somme vaut 15 (par exemple `[1, 3, 2, 4, 5]`).
+
+| Aspect | Détail |
+|--------|---------|
+| Pattern clé | `var idx = iclosure;` capture l'index dans la closure lambda |
+| Traduction interne | `t.Values[idx]` → `ctx.MkSelect(arrayExpr, ctx.MkInt(idx))` |
+| Somme | Addition directe de 5 selects dans la contrainte LINQ |
+
+**Points clés** :
+1. La boucle `for` avec capture `iclosure` est indispensable : sans elle, toutes les closures captureraient la même valeur finale de `i`
+2. Z3.Linq traduit chaque `t.Values[idx]` en un appel `MkSelect` sur le tableau symbolique
+3. La contrainte de distinctness nécessite O(n²) clauses (ici 10 paires pour 5 éléments)
+
+> **Note technique** : La somme 1+2+3+4+5 = 15, et les 5 valeurs sont distinctes et bornées dans [1, 5]. Le seul ensemble de 5 entiers distincts de [1, 5] est précisément {1, 2, 3, 4, 5} — la contrainte de somme force donc une **permutation** de ces valeurs. Z3 explore l'espace des 5! = 120 permutations et en retourne une, ici `[1, 3, 2, 4, 5]`.
+
+> **Modes d'encodage des collections** : `int[] Values` est ici représenté via la **théorie des tableaux** Z3 — un seul `ArrayExpr` symbolique, et chaque `Values[i]` se traduit en `Select`. Z3.Linq offre une alternative, le mode **Constants** (`ctx.DefaultCollectionHandling = CollectionHandling.Constants`), qui crée un constant Z3 indépendant par élément au lieu d'un tableau symbolique. Les deux modes aboutissent à la même solution mais diffèrent dans la structure des formules SMT produites. Le notebook [03 — Sudoku Modes Comparison](03_Sudoku_Modes_Comparison.ipynb) compare les deux modes côte à côte sur un Sudoku 4x4.",,,,,,,,ecf1796016be143f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,b8c9d0e7,markdown,fr,a89db4e4aedd54d0,"## 2. L'opération Store
+
+L'opération **Store** est une écriture fonctionnelle : elle renvoie un **nouveau tableau** sans modifier l'original. C'est le pilier de la programmation fonctionnelle appliquée aux tableaux symboliques.
+
+$$
+\text{store}(a,\; i,\; v) = a' \quad \text{où} \quad a'[i] = v \;\wedge\; \forall j \neq i :\; a'[j] = a[j]
+$$
+
+**Important** : Z3.Linq ne supporte pas `Store` directement. Pour l'utiliser, il faut recourir à l'API Microsoft.Z3 de bas niveau via `new Microsoft.Z3.Context()`.",,,,,,,,a89db4e4aedd54d0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,c9d0e1f8,code,fr,54d78cc438241095,"// Exemple 2 : Store via l'API Microsoft.Z3 - vérification des axiomes de McCarthy
+using (var ctx = new Microsoft.Z3.Context())
+{
+    // Créer un tableau symbolique : Array Int -> Int
+    var array1 = ctx.MkArrayConst(ctx.MkSymbol(""a""), ctx.IntSort, ctx.IntSort);
+
+    // Store : a' = store(a, 3, 42)
+    var idx3 = ctx.MkInt(3);
+    var val42 = ctx.MkInt(42);
+    var array2 = ctx.MkStore(array1, idx3, val42);
+
+    // Axiome 1 : select(store(a, 3, 42), 3) == 42
+    var sel_at_3 = ctx.MkSelect(array2, idx3);
+    var axiom1 = ctx.MkEq(sel_at_3, val42);
+
+    // Axiome 2 : select(store(a, 3, 42), 5) == select(a, 5)
+    var idx5 = ctx.MkInt(5);
+    var sel_at_5_new = ctx.MkSelect(array2, idx5);
+    var sel_at_5_old = ctx.MkSelect(array1, idx5);
+    var axiom2 = ctx.MkEq(sel_at_5_new, sel_at_5_old);
+
+    // Vérification avec le solveur
+    var solver = ctx.MkSolver();
+
+    // Axiome 1 : le solveur doit prouver que select(store(a,3,42),3) = 42 est TOUJOURS VRAI
+    solver.Push();
+    solver.Assert(ctx.MkNot(axiom1));  // Nier l'axiome
+    var result1 = solver.Check();
+    Console.WriteLine($""Axiome 1 - select(store(a,3,42),3) == 42 : {(result1 == Status.UNSATISFIABLE ? ""TOUJOURS VRAI"" : ""PEUT ÊTRE FAUX"")}"");
+    solver.Pop();
+
+    // Axiome 2 : le solveur doit prouver que select(store(a,3,42),5) == select(a,5)
+    solver.Push();
+    solver.Assert(ctx.MkNot(axiom2));
+    var result2 = solver.Check();
+    Console.WriteLine($""Axiome 2 - i≠j → select(store(a,3,42),5) == select(a,5) : {(result2 == Status.UNSATISFIABLE ? ""TOUJOURS VRAI"" : ""PEUT ÊTRE FAUX"")}"");
+    solver.Pop();
+
+    // Store cumulé : store(store(a, 3, 42), 7, 99)
+    var idx7 = ctx.MkInt(7);
+    var val99 = ctx.MkInt(99);
+    var array3 = ctx.MkStore(array2, idx7, val99);
+
+    // Vérifier que les deux stores sont indépendants
+    var sel3_in_a3 = ctx.MkSelect(array3, idx3);  // Doit toujours valoir 42
+    var sel7_in_a3 = ctx.MkSelect(array3, idx7);  // Doit toujours valoir 99
+    var both_correct = ctx.MkAnd(ctx.MkEq(sel3_in_a3, val42), ctx.MkEq(sel7_in_a3, val99));
+
+    solver.Push();
+    solver.Assert(ctx.MkNot(both_correct));
+    var result3 = solver.Check();
+    Console.WriteLine($""Store cumulé - select(a'',3)==42 ET select(a'',7)==99 : {(result3 == Status.UNSATISFIABLE ? ""TOUJOURS VRAI"" : ""PEUT ÊTRE FAUX"")}"");
+    solver.Pop();
+
+    Console.WriteLine(""\nVérification des axiomes de McCarthy terminée : tous VALIDÉS par Z3."");
+}",,,,,,,,54d78cc438241095,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,d0e1f2a9,markdown,fr,14521e919313a9fd,"### Interprétation 2 — Vérification des axiomes de McCarthy
+
+**Sortie obtenue** : Les trois axiomes sont vérifiés comme TOUJOURS VRAI (UNSAT quand on les nie).
+
+| Axiome | Formule | Résultat |
+|--------|---------|----------|
+| Axiome 1 (write-read) | `select(store(a, 3, 42), 3) = 42` | TOUJOURS VRAI |
+| Axiome 2 (read-overwrite) | `select(store(a, 3, 42), 5) = select(a, 5)` | TOUJOURS VRAI |
+| Store cumulé | `select(store(store(a,3,42),7,99), 3) = 42` | TOUJOURS VRAI |
+
+**Points clés** :
+1. La technique de **négation + UNSAT** est la méthode standard pour prouver qu'une formule est une **tautologie** en SMT
+2. Les stores cumulatifs préservent les écritures précédentes aux indices différents (3 et 7)
+3. `new Microsoft.Z3.Context()` donne accès à l'API complète quand Z3.Linq ne suffit pas (pas de Store en LINQ)",,,,,,,,14521e919313a9fd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,6ca8f9e8,markdown,fr,1ce1e9c634b4e411,"### Deux autres briques de la théorie des tableaux SMT-LIB
+
+Les axiomes de McCarthy ci-dessus définissent `select` et `store`. La théorie des tableaux du standard SMT-LIB en compte deux autres, qui ne sont pas utilisées dans ce notebook mais qu'il faut connaître pour lire la littérature SMT :
+
+**Le tableau constant (`const`, ou `K` en SMT-LIB).** C'est un troisième constructeur, à côté de `select`/`store` : `const(v)` désigne le tableau dont **toutes** les positions contiennent la valeur `v`. En C# Microsoft.Z3, cela se crée par `ctx.MkConstArray(ctx.IntSort, ctx.MkInt(0))` — un tableau « entièrement à zéro ». C'est l'outil naturel pour exprimer un **état initial uniforme** : une grille vide (toutes cases à 0), un registre vidé, un buffer initialisé. On pourrait alors écrire l'état initial `[2, 2]` de l'exemple Missionnaires-Cannibales (cell `c5d6e7fe`) de façon plus concise comme `store(store(const(0), 0, 2), 1, 2)` — deux écritures par-dessus un fond uniforme de zéros — plutôt qu'en partant d'un tableau symbolique non interprété.
+
+**L'extensionalité.** C'est le quatrième axiome : deux tableaux `a` et `b` sont **égaux** si et seulement si ils coïncident sur tout indice —
+
+$$
+a = b \;\;\Longleftrightarrow\;\; \forall i.\; \text{select}(a, i) = \text{select}(b, i)
+$$
+
+Cet axiome est ce qui rend l'égalité entre tableaux **décidable** : écrire `ctx.MkEq(arrA, arrB)` pousse Z3 à raisonner sur l'égalité point par point (en instanciant l'axiome d'extensionalité sous le capot). Sans lui, un tableau ne serait qu'une fonction non interprétée quelconque, et `a = b` n'aurait pas de sens calculable. C'est précisément ce qui justifie l'existence d'une **théorie dédiée** des tableaux plutôt qu'un simple encodage par fonction non interprétée (`MkFuncDecl`) : la théorie fournit gratuitement ce axiome d'extensionalité, ainsi que les axiomes read-over-write, là qu'une fonction non interprétée obligerait à tout réécrire à la main.
+
+> **Pour aller plus loin** : la spécification SMT-LIB (smt-lib.org) formalise intégralement ces quatre opérations — `select`, `store`, `const`, et l'extensionalité — et la documentation Z3 (z3prover.github.io/api) détaille leurs équivalents `MkSelect`/`MkStore`/`MkConstArray`.",,,,,,,,1ce1e9c634b4e411,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,e1f2a3ba,markdown,fr,da2be806eebce994,"## 3. Switching — Permutation par double Store
+
+Le **switching** (ou swap) est la permutation de deux éléments d'un tableau. En théorie des tableaux, il se réalise par deux `Store` imbriqués :
+
+$$
+\text{swap}(a,\; i,\; j) = \text{store}\Big(\text{store}\big(a,\; i,\; \text{select}(a, j)\big),\; j,\; \text{select}(a, i)\Big)
+$$
+
+**Subtilité importante** : Z3 évalue `select(a, i)` et `select(a, j)` **avant** d'appliquer les stores. Les valeurs lues sont donc celles du tableau original `a`, pas du tableau intermédiaire.",,,,,,,,da2be806eebce994,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,f2a3b4cb,code,fr,1b729fd769d2de6d,"// Exemple 3 : Switching - permuter deux éléments d'un tableau
+using (var ctx = new Microsoft.Z3.Context())
+{
+    // Créer un tableau symbolique : Array Int -> Int
+    var arr = ctx.MkArrayConst(""a"", ctx.IntSort, ctx.IntSort);
+
+    // Initialiser le tableau avec des valeurs concrètes via Store imbriqués
+    var concrete = ctx.MkStore(ctx.MkStore(ctx.MkStore(ctx.MkStore(ctx.MkStore(
+        arr,
+        ctx.MkInt(0), ctx.MkInt(10)),
+        ctx.MkInt(1), ctx.MkInt(20)),
+        ctx.MkInt(2), ctx.MkInt(30)),
+        ctx.MkInt(3), ctx.MkInt(40)),
+        ctx.MkInt(4), ctx.MkInt(50));
+
+    // Afficher le tableau avant le swap.
+    // MkSelect renvoie une Expr symbolique : on l'évalue avec Simplify() pour
+    // réduire select(store(...), i) en la valeur concrète (axiome de McCarthy).
+    Console.Write(""Tableau avant swap  : ["");
+    for (int k = 0; k < 5; k++)
+    {
+        var val = ctx.MkSelect(concrete, ctx.MkInt(k)).Simplify();
+        Console.Write(k < 4 ? $""{val}, "" : $""{val}"");
+    }
+    Console.WriteLine(""]"");
+
+    // Effectuer le swap des indices 1 et 3
+    // swap(a, 1, 3) = store(store(a, 1, select(a, 3)), 3, select(a, 1))
+    var sel_a_1 = ctx.MkSelect(concrete, ctx.MkInt(1));  // = 20
+    var sel_a_3 = ctx.MkSelect(concrete, ctx.MkInt(3));  // = 40
+
+    var after_first_store = ctx.MkStore(concrete, ctx.MkInt(1), sel_a_3);
+    var after_swap = ctx.MkStore(after_first_store, ctx.MkInt(3), sel_a_1);
+
+    // Afficher le tableau après le swap (évaluation des selects)
+    Console.Write(""Tableau après swap  : ["");
+    for (int k = 0; k < 5; k++)
+    {
+        var val = ctx.MkSelect(after_swap, ctx.MkInt(k)).Simplify();
+        Console.Write(k < 4 ? $""{val}, "" : $""{val}"");
+    }
+    Console.WriteLine(""]"");
+
+    // Vérifier que le swap est correct
+    var val_at_1 = ctx.MkSelect(after_swap, ctx.MkInt(1)).Simplify();
+    var val_at_3 = ctx.MkSelect(after_swap, ctx.MkInt(3)).Simplify();
+    Console.WriteLine($""\nVérification : arr[1] = {val_at_1} (attendu 40), arr[3] = {val_at_3} (attendu 20)"");
+
+    // Vérifier que les autres éléments sont inchangés
+    var others_unchanged = true;
+    foreach (var k in new[] { 0, 2, 4 })
+    {
+        var before = ctx.MkSelect(concrete, ctx.MkInt(k)).Simplify();
+        var after = ctx.MkSelect(after_swap, ctx.MkInt(k)).Simplify();
+        var eq = ctx.MkEq(before, after);
+        var s = ctx.MkSolver();
+        s.Assert(ctx.MkNot(eq));
+        if (s.Check() != Status.UNSATISFIABLE)
+            others_unchanged = false;
+    }
+    Console.WriteLine($""Autres éléments inchangés : {others_unchanged}"");
+    Console.WriteLine(""Switching terminé : indices 1 et 3 permutés avec succès."");
+}",,,,,,,,1b729fd769d2de6d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,a3b4c5dc,markdown,fr,9988cc2abc3ff3ef,"### Interprétation 3 — Mécanisme du switching
+
+**Sortie obtenue** : Le tableau `[10, 20, 30, 40, 50]` devient `[10, 40, 30, 20, 50]` après permutation des indices 1 et 3.
+
+| Étape | Opération | Résultat |
+|-------|-----------|----------|
+| Initial | Tableau concret | `[10, 20, 30, 40, 50]` |
+| Store 1 | `store(a, 1, select(a, 3))` → écrit 40 à l'index 1 | `[10, 40, 30, 40, 50]` |
+| Store 2 | `store(a', 3, select(a, 1))` → écrit 20 à l'index 3 | `[10, 40, 30, 20, 50]` |
+
+**Points clés** :
+1. Les deux `select(a, 1)` et `select(a, 3)` lisent les valeurs du tableau **original** (avant tout Store)
+2. Le premier Store produit un état intermédiaire `[10, 40, 30, 40, 50]` où les deux positions ont temporairement la même valeur
+3. Le second Store corrige cet état pour produire le résultat final de la permutation
+4. Les indices non concernés (0, 2, 4) restent inchangés par l'axiome de McCarthy",,,,,,,,9988cc2abc3ff3ef,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,b4c5d6ed,markdown,fr,b440c0f7cf5bb726,"## 4. Missionnaires-Cannibales basé sur Store
+
+Dans le notebook 01, nous avons modélisé le problème des Missionnaires-Cannibales avec des **tableaux séparés** pour chaque étape. L'approche Store-based propose une alternative :
+
+| Approche | Notebook 01 (séparés) | Store-based (ceci) |
+|----------|--------------------------|---------------------|
+| Variables | `Missionaries[i]`, `Canibals[i]` (un tableau par étape) | `state` (un seul tableau, mis à jour par Store) |
+| Transitions | `state[i+1] = state[i] + delta` | `state' = store(state, ...)` |
+| Avantage | Naturel en LINQ | Plus proche de la sémantique fonctionnelle |
+| Inconvénient | Redondance entre étapes | Nécessite l'API bas niveau |
+
+Nous modélisons ici une version simplifiée du problème avec **2 missionnaires et 2 cannibales** sur **2 étapes** (un aller + un retour), en utilisant des Store pour les transitions.",,,,,,,,b440c0f7cf5bb726,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,c5d6e7fe,code,fr,27fd2cc76c3a9166,"// Exemple 4 : Missionnaires-Cannibales simplifié avec Store (2M/2C, 2 étapes)
+// État = tableau [M_left, C_left] (missionnaires et cannibales sur la rive gauche)
+// On modélise une transition élémentaire (un aller + un retour) qui FAIT PROGRESSER
+// l'état. La résolution complète [2,2] -> [0,0] est impossible en 2 étapes ; on cherche
+// donc simplement une transition valide (aller+retour) aboutissant à un état != [2,2].
+using (var ctx = new Microsoft.Z3.Context())
+{
+    var solver = ctx.MkSolver();
+
+    int N = 2;  // 2 missionnaires, 2 cannibales
+    int BOAT = 2;  // capacité barque
+
+    // État initial : [2, 2] encodé comme Store sur un tableau symbolique
+    var initState = ctx.MkArrayConst(""init"", ctx.IntSort, ctx.IntSort);
+    initState = ctx.MkStore(ctx.MkStore(initState, ctx.MkInt(0), ctx.MkInt(N)),
+                             ctx.MkInt(1), ctx.MkInt(N));
+
+    // Variables symboliques pour les deltas de la transition 1 (aller)
+    var deltaM1 = ctx.MkIntConst(""deltaM1"");  // missionnaires qui traversent
+    var deltaC1 = ctx.MkIntConst(""deltaC1"");  // cannibales qui traversent
+
+    // Contraintes sur delta1 : entre 1 et BOAT personnes
+    solver.Assert(ctx.MkGe(deltaM1, ctx.MkInt(0)));
+    solver.Assert(ctx.MkGe(deltaC1, ctx.MkInt(0)));
+    solver.Assert(ctx.MkGt(ctx.MkAdd(deltaM1, deltaC1), ctx.MkInt(0)));  // au moins 1
+    solver.Assert(ctx.MkLe(ctx.MkAdd(deltaM1, deltaC1), ctx.MkInt(BOAT)));  // max boat
+    solver.Assert(ctx.MkLe(deltaM1, ctx.MkInt(N)));
+    solver.Assert(ctx.MkLe(deltaC1, ctx.MkInt(N)));
+
+    // État après aller : state1 = store(store(init, 0, M-dM), 1, C-dC)
+    var m0 = (ArithExpr)ctx.MkSelect(initState, ctx.MkInt(0));
+    var c0 = (ArithExpr)ctx.MkSelect(initState, ctx.MkInt(1));
+    var state1 = ctx.MkStore(ctx.MkStore(initState, ctx.MkInt(0),
+        ctx.MkSub(m0, deltaM1)), ctx.MkInt(1), ctx.MkSub(c0, deltaC1));
+
+    // Sécurité après aller
+    var m1 = (ArithExpr)ctx.MkSelect(state1, ctx.MkInt(0));
+    var c1 = (ArithExpr)ctx.MkSelect(state1, ctx.MkInt(1));
+    solver.Assert(ctx.MkGe(m1, ctx.MkInt(0)));  // pas de négatif
+    solver.Assert(ctx.MkGe(c1, ctx.MkInt(0)));
+    // Si missionnaires > 0, ils doivent être >= cannibales
+    solver.Assert(ctx.MkImplies(ctx.MkGt(m1, ctx.MkInt(0)), ctx.MkGe(m1, c1)));
+    // Pareil sur la rive droite
+    var m1r = ctx.MkSub(ctx.MkInt(N), m1);
+    var c1r = ctx.MkSub(ctx.MkInt(N), c1);
+    solver.Assert(ctx.MkImplies(ctx.MkGt(m1r, ctx.MkInt(0)), ctx.MkGe(m1r, c1r)));
+
+    // Variables pour le retour (delta2 = personnes qui reviennent droite -> gauche)
+    var deltaM2 = ctx.MkIntConst(""deltaM2"");
+    var deltaC2 = ctx.MkIntConst(""deltaC2"");
+
+    solver.Assert(ctx.MkGe(deltaM2, ctx.MkInt(0)));
+    solver.Assert(ctx.MkGe(deltaC2, ctx.MkInt(0)));
+    solver.Assert(ctx.MkGt(ctx.MkAdd(deltaM2, deltaC2), ctx.MkInt(0)));
+    solver.Assert(ctx.MkLe(ctx.MkAdd(deltaM2, deltaC2), ctx.MkInt(BOAT)));
+    // Validité du retour : on ne peut ramener que des personnes réellement présentes
+    // sur la rive droite après l'aller (soit delta1 au plus).
+    solver.Assert(ctx.MkLe(deltaM2, deltaM1));
+    solver.Assert(ctx.MkLe(deltaC2, deltaC1));
+
+    // État après retour
+    var state2 = ctx.MkStore(ctx.MkStore(state1, ctx.MkInt(0),
+        ctx.MkAdd(m1, deltaM2)), ctx.MkInt(1), ctx.MkAdd(c1, deltaC2));
+
+    var m2 = (ArithExpr)ctx.MkSelect(state2, ctx.MkInt(0));
+    var c2 = (ArithExpr)ctx.MkSelect(state2, ctx.MkInt(1));
+    solver.Assert(ctx.MkGe(m2, ctx.MkInt(0)));
+    solver.Assert(ctx.MkGe(c2, ctx.MkInt(0)));
+    solver.Assert(ctx.MkLe(m2, ctx.MkInt(N)));
+    solver.Assert(ctx.MkLe(c2, ctx.MkInt(N)));
+    // Contrainte de progression : l'état final doit différer de l'état initial [N, N].
+    // Sans elle, le solveur trouve un aller-retour « sur place » (delta1 == delta2).
+    solver.Assert(ctx.MkOr(ctx.MkNot(ctx.MkEq(m2, ctx.MkInt(N))),
+                           ctx.MkNot(ctx.MkEq(c2, ctx.MkInt(N)))));
+
+    if (solver.Check() == Status.SATISFIABLE)
+    {
+        var model = solver.Model;
+        // Toutes les valeurs affichées sont évaluées contre le modèle pour obtenir
+        // des entiers concrets (les Expr symboliques non évaluées imprimeraient du SMT-LIB).
+        var dm1 = model.Eval(deltaM1);
+        var dc1 = model.Eval(deltaC1);
+        var dm2 = model.Eval(deltaM2);
+        var dc2 = model.Eval(deltaC2);
+        var m0v = model.Eval(m0);
+        var c0v = model.Eval(c0);
+        var m1v = model.Eval(m1);
+        var c1v = model.Eval(c1);
+        var m2v = model.Eval(m2);
+        var c2v = model.Eval(c2);
+
+        Console.WriteLine(""=== Missionnaires-Cannibales (2M/2C, Store-based) ==="");
+        Console.WriteLine($""État initial      : [{m0v}M, {c0v}C] sur la rive gauche"");
+        Console.WriteLine($""Aller   (delta)   : -{dm1}M, -{dc1}C"");
+        Console.WriteLine($""État après aller  : [{m1v}M, {c1v}C] sur la rive gauche"");
+        Console.WriteLine($""Retour (delta)    : +{dm2}M, +{dc2}C"");
+        Console.WriteLine($""État après retour : [{m2v}M, {c2v}C] sur la rive gauche"");
+        Console.WriteLine($""\nTransition store-based valide : [{m0v},{c0v}] -> [{m1v},{c1v}] -> [{m2v},{c2v}]."");
+        Console.WriteLine(""La résolution complète [2,2] -> [0,0] nécessite davantage d'étapes."");
+    }
+    else
+    {
+        Console.WriteLine(""UNSAT : aucune transition aller+retour ne fait progresser l'état [2,2]."");
+    }
+}",,,,,,,,27fd2cc76c3a9166,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,d6e7f8af,markdown,fr,45d90131fc716a67,"### Interprétation 4 — Store-based vs tableaux séparés
+
+**Sortie obtenue** : Une transition valide `[2,2] -> [2,0] -> [2,1]` (aller de 2 cannibales, retour d'1 cannibal). L'état final `[2,1]` diffère bien de l'état initial `[2,2]` : la transition fait progresser le problème sans violer l'invariant de sécurité sur aucune des deux rives.
+
+| Aspect | Notebook 01 (tableaux séparés) | Store-based |
+|--------|----------------------------------|-------------|
+| Encodage | `Missionaries[i]`, `Canibals[i]` | `store(store(state, 0, val), 1, val)` |
+| Transition | `state[i+1] = state[i] + delta` | `state' = store(state, idx, new_val)` |
+| API | Z3.Linq (haut niveau) | Microsoft.Z3 (bas niveau) |
+| Flexibilité | Contraintes LINQ naturelles | Accès complet à l'API Z3 |
+
+**Points clés** :
+1. L'approche Store est plus **proche de la sémantique fonctionnelle** : chaque étape est une transformation de la précédente
+2. Les invariants de sécurité sont les mêmes, mais exprimés via `MkImplies` au lieu de `Where`
+3. **Deux contraintes de correction du modèle** : (a) le retour ne peut ramener que des personnes réellement présentes sur la rive droite (`delta2 ≤ delta1`) ; (b) une contrainte de **progression** force l'état final à différer de l'état initial — sans elle, le solveur renvoie un aller-retour « sur place » (`delta1 == delta2`) techniquement SAT mais sans intérêt pédagogique
+4. Pour des problèmes à nombreuses étapes, les chaînes de Store deviennent longues mais restent correctes",,,,,,,,45d90131fc716a67,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,e37ae172,markdown,fr,c74b171d4ef78e4b,"### Exemple 4bis — Le problème complet 3M/3C via Z3.Linq (`CollectionHandling.Array`)
+
+La version Store ci-dessus ne modélise qu'**une transition** d'un problème *simplifié* (2M/2C) : elle illustre la mécanique `store`/`select`, mais ne **résout pas** le casse-tête. Passons maintenant au **problème classique complet — 3 missionnaires et 3 cannibales** — et résolvons-le **entièrement** avec le DSL Z3.Linq.
+
+L'idée : représenter toute la **trajectoire** par un champ `int[][] S`, où `S[t] = [M_gauche, C_gauche]` est l'état à l'étape `t`. Avec `DefaultCollectionHandling = CollectionHandling.Array`, le fork Z3.Linq compile ce tableau imbriqué en une **unique théorie des tableaux SMT** (un `ArrayExpr` + des `Select`) — exactement les briques `Select`/`Store` vues plus haut, mais **générées automatiquement** à partir d'expressions LINQ lisibles.
+
+Le solveur reçoit toutes les contraintes d'un coup (bornes, sécurité sur chaque rive, capacité de la barque, alternance des rives, conditions de départ et d'arrivée) et renvoie une trajectoire complète `[3,3] → … → [0,0]` si elle existe.",,,,,,,,c74b171d4ef78e4b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,2ba7fc05,code,fr,1a069bd35f88a114,"// Exemple 4bis : Missionnaires-Cannibales COMPLET (3M/3C) via le DSL Z3.Linq.
+// La trajectoire entière est un champ int[][] : S[t] = [M_gauche, C_gauche] à l'étape t.
+// CollectionHandling.Array compile ce tableau imbriqué en une théorie des tableaux Z3
+// (un ArrayExpr + des Select) - les mêmes briques que les exemples 1-4, mais générées
+// automatiquement à partir d'expressions LINQ lisibles.
+public class Crossing
+{
+    public int[][] S { get; set; } = new int[12][];
+    public Crossing() { for (int t = 0; t < 12; t++) S[t] = new int[2]; }  // init chaque ligne (cf SudokuGrid)
+}
+
+int K = 12;    // 12 états => 11 traversées
+int N = 3;     // 3 missionnaires, 3 cannibales
+int BOAT = 2;  // capacité de la barque
+
+using (var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array })
+{
+    var th = ctx.NewTheorem<Crossing>();
+
+    // Bornes + sécurité sur chaque rive, à chaque étape
+    for (int t = 0; t < K; t++)
+    {
+        int t1 = t;
+        th = th.Where(g => g.S[t1][0] >= 0 && g.S[t1][0] <= N && g.S[t1][1] >= 0 && g.S[t1][1] <= N);
+        th = th.Where(g => g.S[t1][0] == 0 || g.S[t1][0] >= g.S[t1][1]);                    // rive gauche sûre
+        th = th.Where(g => (N - g.S[t1][0]) == 0 || (N - g.S[t1][0]) >= (N - g.S[t1][1]));   // rive droite sûre
+    }
+
+    // Conditions de bord : tout le monde à gauche au départ, tout le monde traversé à l'arrivée
+    th = th.Where(g => g.S[0][0] == N && g.S[0][1] == N);
+    th = th.Where(g => g.S[K - 1][0] == 0 && g.S[K - 1][1] == 0);
+
+    // Transitions : la barque alterne avec la parité de t ; 1 à BOAT personnes par traversée
+    for (int t = 0; t < K - 1; t++)
+    {
+        int a = t, b = t + 1;
+        if (t % 2 == 0)  // aller gauche -> droite : les compteurs de gauche baissent
+        {
+            th = th.Where(g => g.S[b][0] <= g.S[a][0] && g.S[b][1] <= g.S[a][1]);
+            th = th.Where(g => (g.S[a][0] - g.S[b][0]) + (g.S[a][1] - g.S[b][1]) >= 1);
+            th = th.Where(g => (g.S[a][0] - g.S[b][0]) + (g.S[a][1] - g.S[b][1]) <= BOAT);
+        }
+        else  // retour droite -> gauche : les compteurs de gauche remontent
+        {
+            th = th.Where(g => g.S[b][0] >= g.S[a][0] && g.S[b][1] >= g.S[a][1]);
+            th = th.Where(g => (g.S[b][0] - g.S[a][0]) + (g.S[b][1] - g.S[a][1]) >= 1);
+            th = th.Where(g => (g.S[b][0] - g.S[a][0]) + (g.S[b][1] - g.S[a][1]) <= BOAT);
+        }
+    }
+
+    var sol = th.Solve();
+    if (sol == null)
+    {
+        Console.WriteLine(""UNSAT : aucune trajectoire trouvée."");
+    }
+    else
+    {
+        Console.WriteLine(""=== Plan de traversée 3M/3C (DSL Z3.Linq, CollectionHandling.Array) ==="");
+        for (int t = 0; t < K; t++)
+        {
+            int mL = sol.S[t][0], cL = sol.S[t][1];
+            Console.WriteLine($""Étape {t,2} : gauche [{mL}M,{cL}C]  droite [{N - mL}M,{N - cL}C]  ({(t % 2 == 0 ? ""barque à gauche"" : ""barque à droite"")})"");
+        }
+        Console.WriteLine($""\n{K - 1} traversées — solution optimale du problème classique 3M/3C."");
+    }
+}",,,,,,,,1a069bd35f88a114,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,3535e541,markdown,fr,21f1bc9cea6b8cb3,"### Interprétation 4bis — `int[][]` ⇒ théorie des tableaux, et la montée en puissance du DSL
+
+**Sortie obtenue** : une trajectoire complète en **11 traversées**, de `[3M,3C]` (tout à gauche) à `[0M,0C]` (tout traversé). C'est le nombre **optimal** de traversées pour le problème classique 3M/3C.
+
+**Ce que le moteur a fait** :
+1. Le champ `int[][] S` (12 états × 2 compteurs) est compilé par `CollectionHandling.Array` en **une seule variable de tableau Z3** indexée par `Select` — la même théorie des tableaux que les exemples 1 à 4, mais ici **dérivée du DSL** au lieu d'être écrite à la main.
+2. Les **contraintes structurelles** (bornes `0 ≤ · ≤ N`, sécurité `M=0 ∨ M≥C` sur chaque rive, capacité `1 ≤ Δ ≤ 2`, alternance par la parité de `t`) s'expriment toutes en **LINQ pur** — `Where(g => g.S[t][0] >= g.S[t][1])` — sans aucun `MkSelect`/`MkImplies`/`MkITE` manuel.
+3. Les conditions de bord (`S[0]=[3,3]`, `S[K-1]=[0,0]`) et le sens de traversée alterné (compteurs décroissants à l'aller, croissants au retour) suffisent à contraindre toute la trajectoire.
+
+| | Exemple 4 (Store brut) | Exemple 4bis (DSL `int[][]`) |
+|--|------------------------|-------------------------------|
+| Problème | 2M/2C, **une** transition | 3M/3C **complet**, 11 traversées |
+| API | `MkStore`/`MkSelect`/`MkImplies` à la main | `Where(...)` LINQ, théorie des tableaux générée |
+| Contraintes | ~30 appels bas niveau | une boucle `for` de `Where` lisibles |
+| Ce qu'on voit | la mécanique `store` | **la capacité du solveur** sur un vrai casse-tête |
+
+**Leçon** : la théorie des tableaux brute (`Store`/`Select`) reste indispensable pour *comprendre* ce qui se passe sous le capot ; mais dès qu'on attaque un **vrai problème de planification multi-étapes**, le DSL `CollectionHandling.Array` exprime la même chose de façon **déclarative et concise**, en laissant Z3 faire le travail. C'est le chemin **raw → LINQ** : on apprend les briques, puis on monte d'un cran d'abstraction sans rien perdre en puissance.",,,,,,,,21f1bc9cea6b8cb3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,e7f8a9b0,markdown,fr,ff9126b26f174660,"## 5. Bridge Z3 API ↔ Z3.Linq
+
+Z3.Linq offre une API de haut niveau via LINQ, mais ne supporte que **Select** (accès en lecture). Pour les opérations **Store** et **Switching**, il faut utiliser l'API Microsoft.Z3 directement.
+
+### Tableau de correspondance
+
+| Opération | Z3.Linq (LINQ) | Microsoft.Z3 (API bas niveau) |
+|-----------|----------------|------------------------------|
+| Accès élément | `t.Values[idx]` | `ctx.MkSelect(array, index)` |
+| Écriture | Non supporté | `ctx.MkStore(array, index, value)` |
+| Permutation | Non supporté | Deux `MkStore` imbriqués |
+| Création tableau | `public int[] Values { get; set; }` | `ctx.MkArrayConst(name, keySort, valSort)` |
+| Contraintes | `.Where(lambda)` | `solver.Assert(boolExpr)` |
+| Solve | `.Solve()` | `solver.Check() + solver.Model` |
+
+### Application : Tri par switching
+
+Le tri par permutation (bubble sort) est un cas d'usage naturel du switching. On effectue des swaps successifs pour transformer un tableau non trié en tableau trié. Z3 peut vérifier qu'une séquence de swaps donnée produit bien un résultat trié.",,,,,,,,ff9126b26f174660,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,f8a9b0c1,code,fr,fc3ccccc21d757fd,"// Exemple 5 : Bubble sort via switching - tri de [30, 10, 40, 20]
+// 3 swaps : (0,1), (2,3), (1,2) pour obtenir [10, 20, 30, 40]
+using (var ctx = new Microsoft.Z3.Context())
+{
+    // Tableau initial concret : [30, 10, 40, 20]
+    var a = ctx.MkArrayConst(""a"", ctx.IntSort, ctx.IntSort);
+    var s0 = ctx.MkStore(ctx.MkStore(ctx.MkStore(ctx.MkStore(a,
+        ctx.MkInt(0), ctx.MkInt(30)),
+        ctx.MkInt(1), ctx.MkInt(10)),
+        ctx.MkInt(2), ctx.MkInt(40)),
+        ctx.MkInt(3), ctx.MkInt(20));
+
+    // Affichage d'un tableau symbolique. Chaque select est réduite par Simplify()
+    // en l'entier concret correspondant (réécriture select(store(...), i) -> valeur).
+    void PrintArray(string label, ArrayExpr arr)
+    {
+        Console.Write($""{label} ["");
+        for (int k = 0; k < 4; k++)
+        {
+            var val = ctx.MkSelect(arr, ctx.MkInt(k)).Simplify();
+            Console.Write(k < 3 ? $""{val}, "" : $""{val}"");
+        }
+        Console.WriteLine(""]"");
+    }
+
+    PrintArray(""État initial  :"", s0);
+
+    // Swap 1 : indices 0 et 1 (permuter 30 et 10)
+    var s1 = ctx.MkStore(ctx.MkStore(s0,
+        ctx.MkInt(0), ctx.MkSelect(s0, ctx.MkInt(1))),
+        ctx.MkInt(1), ctx.MkSelect(s0, ctx.MkInt(0)));
+    PrintArray(""Après swap(0,1):"", s1);
+
+    // Swap 2 : indices 2 et 3 (permuter 40 et 20)
+    var s2 = ctx.MkStore(ctx.MkStore(s1,
+        ctx.MkInt(2), ctx.MkSelect(s1, ctx.MkInt(3))),
+        ctx.MkInt(3), ctx.MkSelect(s1, ctx.MkInt(2)));
+    PrintArray(""Après swap(2,3):"", s2);
+
+    // Swap 3 : indices 1 et 2 (permuter 30 et 20)
+    var s3 = ctx.MkStore(ctx.MkStore(s2,
+        ctx.MkInt(1), ctx.MkSelect(s2, ctx.MkInt(2))),
+        ctx.MkInt(2), ctx.MkSelect(s2, ctx.MkInt(1)));
+    PrintArray(""Après swap(1,2):"", s3);
+
+    // Vérifier que le résultat est trié : arr[k] <= arr[k+1]
+    var solver = ctx.MkSolver();
+    bool sorted = true;
+    for (int k = 0; k < 3; k++)
+    {
+        var v_k = (ArithExpr)ctx.MkSelect(s3, ctx.MkInt(k));
+        var v_k1 = (ArithExpr)ctx.MkSelect(s3, ctx.MkInt(k + 1));
+        var leq = ctx.MkLe(v_k, v_k1);
+        var s = ctx.MkSolver();
+        s.Assert(ctx.MkNot(leq));
+        if (s.Check() != Status.UNSATISFIABLE)
+            sorted = false;
+    }
+
+    Console.WriteLine($""\nRésultat trié : {sorted}"");
+    Console.WriteLine(""Tri par 3 switches vérifié par Z3."");
+}",,,,,,,,fc3ccccc21d757fd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,a9b0c1d2,markdown,fr,420d14f557ea7a97,"### Interprétation 5 — Tri par switching en 3 étapes
+
+**Sortie obtenue** : `[30, 10, 40, 20]` → `[10, 30, 20, 40]` → `[10, 30, 20, 40]` → `[10, 20, 30, 40]` puis vérification que le résultat est trié.
+
+| Étape | Swap | État intermédiaire |
+|-------|------|---------------------|
+| Initial | — | `[30, 10, 40, 20]` |
+| Swap 1 | indices 0, 1 | `[10, 30, 40, 20]` |
+| Swap 2 | indices 2, 3 | `[10, 30, 20, 40]` |
+| Swap 3 | indices 1, 2 | `[10, 20, 30, 40]` |
+
+**Points clés** :
+1. Chaque swap est un double Store : lire les deux valeurs, puis écrire la première à la position de la seconde et inversement
+2. La séquence de 3 swaps correspond à un **bubble sort** sur 4 éléments
+3. Z3 vérifie formellement que le résultat final est bien trié (UNSAT si on nie `arr[k] <= arr[k+1]`)",,,,,,,,420d14f557ea7a97,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,b0c1d2e3,markdown,fr,2d1cece474fbaf93,"## 6. Vérification de permutation
+
+Un problème classique en théorie des tableaux est de vérifier qu'un tableau `b` est une **permutation** d'un tableau `a`. Cela signifie que `b` contient exactement les mêmes éléments que `a`, mais potentiellement dans un ordre différent.
+
+### Contraintes de permutation
+
+Pour vérifier que `b` est une permutation de `a` (taille n) :
+1. **Bornes** : chaque élément de `b` est dans les bornes des éléments de `a`
+2. **Injectivité** : tous les éléments de `b` sont distincts
+3. **Mêmes éléments** : chaque élément de `a` apparaît dans `b` (et vice-versa)
+
+Nous utilisons ici l'approche Z3.Linq (Select uniquement) pour ce problème.",,,,,,,,2d1cece474fbaf93,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,c1d2e3f4,code,fr,628f24466aeb61ff,"// Exemple 6 : Vérification de permutation avec Z3.Linq
+// a = [1, 2, 3, 4], b = permutation de a
+public class PermutationCheck
+{
+    public int[] A { get; set; } = new int[4];  // tableau original
+    public int[] B { get; set; } = new int[4];  // permutation candidate
+}
+
+using (var ctx = new Z3Context())
+{
+    int n = 4;
+    var theorem = ctx.NewTheorem<PermutationCheck>();
+
+    // Fixer le tableau A = [1, 2, 3, 4]
+    theorem = theorem.Where(t => t.A[0] == 1 && t.A[1] == 2
+                               && t.A[2] == 3 && t.A[3] == 4);
+
+    // Contraintes sur B : éléments entre 1 et 4
+    for (int iclosure = 0; iclosure < n; iclosure++)
+    {
+        var idx = iclosure;
+        theorem = theorem.Where(t => t.B[idx] >= 1 && t.B[idx] <= 4);
+    }
+
+    // B : tous distincts
+    for (int i = 0; i < n; i++)
+    {
+        for (int j = i + 1; j < n; j++)
+        {
+            var ii = i;
+            var jj = j;
+            theorem = theorem.Where(t => t.B[ii] != t.B[jj]);
+        }
+    }
+
+    // Mêmes éléments : somme égale
+    theorem = theorem.Where(t => t.A[0] + t.A[1] + t.A[2] + t.A[3]
+                               == t.B[0] + t.B[1] + t.B[2] + t.B[3]);
+
+    // Forcer B à être différent de A (pour obtenir une vraie permutation)
+    theorem = theorem.Where(t => t.B[0] != t.A[0]);
+
+    var result = theorem.Solve();
+
+    Console.WriteLine($""A = [{string.Join("", "", result.A)}]"");
+    Console.WriteLine($""B = [{string.Join("", "", result.B)}]"");
+    Console.WriteLine($""B est une permutation de A : {result.B.OrderBy(x => x).SequenceEqual(result.A.OrderBy(x => x))}"");
+    Console.WriteLine($""Somme A = {result.A.Sum()}, Somme B = {result.B.Sum()}"");
+    Console.WriteLine(""Vérification de permutation terminée."");
+}",,,,,,,,628f24466aeb61ff,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,d2e3f4a5,markdown,fr,6049c01af45abc93,"### Interprétation 6 — Permutation via Select
+
+**Sortie obtenue** : Z3 trouve un tableau `B` qui est une permutation de `A = [1, 2, 3, 4]` avec au moins le premier élément différent.
+
+| Contrainte | Encodage | Rôle |
+|-----------|----------|------|
+| Bornes | `t.B[idx] >= 1 && t.B[idx] <= 4` | Éléments dans l'intervalle |
+| Distinctness | `t.B[ii] != t.B[jj]` (O(n²)) | Pas de doublon |
+| Somme égale | `sum(A) == sum(B)` | Conservation des éléments |
+| Différence | `t.B[0] != t.A[0]` | Force une vraie permutation |
+
+**Points clés** :
+1. La contrainte de somme égale + distinctness + bornes est suffisante pour garantir la permutation (pour des petits ensembles)
+2. Pour des ensembles plus grands, il faudrait ajouter la contrainte de produit égal ou utiliser un encodage bijectif explicite
+3. L'approche Select-only (Z3.Linq) suffit pour ce problème de vérification",,,,,,,,6049c01af45abc93,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,e3f4a5b6,markdown,fr,449f7598a3ca14a2,"### Exercice 1 : Permutation par switching
+
+**Objectif** : Trouver une séquence de switches (permutations élémentaires) qui transforme le tableau `a = [1, 2, 3, 4]` en `b = [3, 1, 4, 2]`.
+
+**Indices** :
+- Chaque switch échange deux éléments : `swap(a, i, j)`
+- Commencez par identifier quel élément de `a` doit aller à quelle position dans `b`
+- Utilisez l'API Microsoft.Z3 avec `MkStore` et `MkSelect` comme dans l'exemple 5
+- Essayez d'abord manuellement, puis vérifiez avec Z3",,,,,,,,449f7598a3ca14a2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,f4a5b6c7,code,fr,b4603dcbf22f9a7b,"// Exercice 1 : Trouver une séquence de switches pour transformer a en b
+// TODO étudiant : transformez [1, 2, 3, 4] en [3, 1, 4, 2] par switches
+// Étape 1 : initialisez le tableau a = [1, 2, 3, 4] avec des Store
+// Étape 2 : appliquez des swaps successifs
+// Étape 3 : vérifiez que le résultat est [3, 1, 4, 2]
+// Indice : commencez par swap(0, 2) pour placer le 3 en position 0
+
+// using (var ctx = new Microsoft.Z3.Context())
+// {
+//     // Votre code ici
+// }
+
+Console.WriteLine(""Exercice à compléter : permutation par switching de [1,2,3,4] vers [3,1,4,2]"");",,,,,,,,b4603dcbf22f9a7b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,a5b6c7d8,markdown,fr,778d45a344f59bb4,"### Exercice 2 : Missionnaires-Cannibales Store à partir de [3, 3]
+
+**Objectif** : En vous basant sur l'exemple 4, modélisez **une seule étape** (un aller) du problème des Missionnaires-Cannibales à partir de l'état initial `[3M, 3C]` avec une barque de capacité 2.
+
+**Indices** :
+- L'état initial est `[3, 3]` sur la rive gauche
+- L'aller fait perdre entre 1 et 2 personnes sur la rive gauche
+- L'invariant de sécurité doit être vérifié sur les deux rives
+- Utilisez `deltaM` et `deltaC` comme variables symboliques",,,,,,,,778d45a344f59bb4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,b6c7d8e9,code,fr,d176d8754af9abc9,"// Exercice 2 : Une étape aller de Missionnaires-Cannibales depuis [3, 3]
+// TODO étudiant : modélisez un aller depuis l'état [3M, 3C]
+// Étape 1 : créez l'état initial [3, 3] avec Store
+// Étape 2 : définissez deltaM et deltaC (variables symboliques)
+// Étape 3 : ajoutez les contraintes de capacité et sécurité
+// Étape 4 : trouvez une solution valide
+// Indice : deltaM + deltaC doit être entre 1 et 2
+
+// using (var ctx = new Microsoft.Z3.Context())
+// {
+//     // Votre code ici
+// }
+
+Console.WriteLine(""Exercice à compléter : une étape aller MC depuis [3,3] via Store"");",,,,,,,,d176d8754af9abc9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,c7d8e9fa,markdown,fr,38c087e60b27cbb1,"### Exercice 3 : Vérificateur de tri — Combien de switches pour trier ?
+
+**Objectif** : Déterminez si le tableau `[4, 3, 2, 1]` peut être trié en **k switches**. Montrez que :
+- k = 1 : **UNSAT** (impossible de trier en 1 seul switch)
+- k = 2 : **SAT** (possible en 2 switches)
+
+**Indices** :
+- Pour k = 1 : essayez les 6 paires possibles (0,1), (0,2), (0,3), (1,2), (1,3), (2,3) et vérifiez si l'une produit un tableau trié
+- Pour k = 2 : utilisez des variables symboliques pour les indices des 2 swaps et laissez Z3 chercher
+- Un tableau est trié si `arr[i] <= arr[i+1]` pour tout i",,,,,,,,38c087e60b27cbb1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,d8e9fa0b,code,fr,0da625cd6bad0e07,"// Exercice 3 : Peut-on trier [4, 3, 2, 1] en k switches ?
+// TODO étudiant : vérifiez si k=1 (UNSAT) et k=2 (SAT)
+// Étape 1 : créez le tableau initial [4, 3, 2, 1]
+// Étape 2 : pour k=1, testez chaque paire (i,j) et vérifiez si le résultat est trié
+// Étape 3 : pour k=2, utilisez des variables symboliques i1,j1,i2,j2
+// Étape 4 : ajoutez la contrainte de résultat trié et vérifiez SAT/UNSAT
+// Indice : pour k=2, swap(0,3) puis swap(1,2) devrait fonctionner
+
+// using (var ctx = new Microsoft.Z3.Context())
+// {
+//     // Votre code ici
+// }
+
+Console.WriteLine(""Exercice à compléter : tri de [4,3,2,1] en k switches (k=1 UNSAT, k=2 SAT)"");",,,,,,,,0da625cd6bad0e07,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/04_Array_Theory.ipynb,e9fa0b1c,markdown,fr,c76e84690047cc3a,"## Conclusion
+
+Ce notebook a exploré la **théorie des tableaux** dans Z3 à travers trois concepts fondamentaux.
+
+### Récapitulatif des concepts
+
+| Concept | Opération SMT | API C# | Utilisation clé |
+|---------|---------------|--------|----------------|
+| **Select** | `select(a, i)` | `MkSelect(a, i)` / `t.Values[i]` | Lire un élément symbolique |
+| **Store** | `store(a, i, v)` | `MkStore(a, i, v)` | Écriture fonctionnelle (immutable) |
+| **Switching** | 2x Store imbriqués | 2x `MkStore` | Permutation de deux éléments |
+
+### Comparaison des approches
+
+| Approche | Avantage | Limitation | Quand l'utiliser |
+|----------|----------|------------|----------------|
+| **Z3.Linq** | Syntaxe LINQ naturelle, closures | Pas de Store | Contraintes sur les valeurs (Select) |
+| **Microsoft.Z3 direct** | Accès complet (Store, Switch) | Plus verbeux | Transitions, permutations, vérification |
+
+### Points clés à retenir
+
+1. **Store est immuable** : chaque Store retourne un nouveau tableau, l'original est préservé
+2. **Les axiomes de McCarthy** garantissent la cohérence : `select(store(a,i,v),i)=v` et `i≠j → select(store(a,i,v),j)=select(a,j)`
+3. **Le switching** se construit naturellement avec deux Stores imbriqués, en lisant les valeurs avant l'écriture
+4. **Z3.Linq + Microsoft.Z3** se complètent : LINQ pour les contraintes de haut niveau, l'API bas niveau pour les transformations
+
+---
+
+**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Sudoku Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) | [Nested Arrays 2D >>](05_Nested_Arrays_2D.ipynb)",,,,,,,,c76e84690047cc3a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,a225c9d1,markdown,fr,e8dd1096e2c368b0,"# Tableaux Imbriqués et Grilles 2D : API Déclarative `Theorem<Grid>`
+
+**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Array Theory](04_Array_Theory.ipynb) | [Meal Planner >>](06_Meal_Planner_Modelisation.ipynb)
+
+## Objectifs d'apprentissage
+
+À la fin de ce notebook, vous saurez :
+1. Modéliser une **grille 2D** (`int[][]`) via l'API déclarative `Theorem<Grid>` du binding LINQ Z3.Linq
+2. Accéder à une cellule de façon naturelle par `g.Cells[i][j]` dans des expressions lambda
+3. Énoncer des contraintes par **ligne**, **colonne** et **bloc** sur une grille symbolique
+4. Résoudre un **Latin Square** et un **Sudoku 4x4** de manière déclarative
+5. Comparer cette approche de haut niveau avec l'API **raw** `Microsoft.Z3` (Store/Select imbriqués)
+
+### Prérequis
+- Avoir complété le notebook [04 - Array Theory](04_Array_Theory.ipynb)
+- Avoir suivi [02 - Theorem vs Array](02_Sudoku_Theorem_vs_Array.ipynb) (transition explicite/implicite pour le 1D)
+- .NET 9.0 Interactive
+
+### Durée estimée : 45-60 minutes
+
+---
+
+Ce notebook poursuit la **transition pédagogique** initiée dans le notebook 02. Là où le notebook 02 montrait comment une `List<int>` indexée remplace 81 propriétés explicites pour un Sudoku **1D**, nous montrons ici comment un tableau imbriqué `int[][]` permet de modéliser des **grilles 2D** (Latin Square, Sudoku) avec la même élégance déclarative : `g.Cells[i][j]`.
+
+> **Contexte** : la prise en charge des tableaux imbriqués `int[][]` dans `Theorem<T>` a été ajoutée au fork Z3.Linq (commit `096a638`, branche #1206) en portant le traitement des collections imbriquées depuis `Z3.LinqBinding@EPFdevelopment`. Un tableau imbriqué a le type SMT `Array Int (Array Int Int)` : `select(select(grid, i), j)` accède à la cellule `(i, j)`. Le binding LINQ traduit automatiquement `g.Cells[i][j]` vers cette chaîne de `Select`.
+
+> **Résolution du package** : cette fonctionnalité n'étant pas encore publiée sur NuGet (le paquet public `Z3.Linq` 2.0.1 ne gère qu'un seul niveau de collection), ce notebook charge le **fork local** via les DLL compilées du sous-module `Z3.Linq`. Voir la cellule de configuration ci-dessous.",,,,,,,,e8dd1096e2c368b0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,816df432,markdown,fr,f2e9b36922c7539a,"### Deux encodages canoniques d'une grille 2D en SMT
+
+Modéliser une grille 2D dans la théorie des tableaux de Z3 n'a rien d'évident : le type SMT de base est un tableau **unidimensionnel** `(Array Index Elem)`. Il existe donc **deux stratégies** pour représenter une structure bidimensionnelle, et le choix a des conséquences sur la façon dont on écrit `select` et `store`. Ce notebook utilise exclusivement la seconde — mais il est essentiel de connaître les deux pour comprendre ce que l'on choisit.
+
+#### Stratégie 1 — tableau **aplati** (*flat*), un seul niveau
+
+On encode la grille entière dans un unique tableau `(Array Int Int)`, en **linéarisant** les deux indices `(i, j)` en un seul `index = i * W + j` (où `W` est la largeur). Pour une grille 3x3, la cellule `(1, 2)` devient l'indice `1*3 + 2 = 5`.
+
+- **Lecture d'une cellule** : un seul `select` — `select(grid, i*W + j)`.
+- **Écriture d'une cellule** : un seul `store` — `store(grid, i*W + j, v)`.
+- **Avantage** : un seul niveau de tableau, arithmétique d'indices simple, économique en mémoire symbolique.
+- **Inconvénient** : il faut porter partout la formule `i*W + j`, et les contraintes « une ligne » ou « une colonne » ne se lisent plus naturellement (il faut recalculer les indices plats correspondants).
+
+#### Stratégie 2 — tableau **imbriqué** (*nested* / array of arrays), deux niveaux
+
+On encode la grille comme un tableau de lignes, chaque ligne étant elle-même un tableau : `(Array Int (Array Int Int))`. La cellule `(i, j)` s'obtient en deux `select` successifs — d'abord la ligne `i`, puis la cellule `j` dans cette ligne.
+
+- **Lecture d'une cellule** : deux `select` imbriqués — `select(select(grid, i), j)`.
+- **Écriture d'une cellule** : deux `store` imbriqués — `store(grid, i, store(select(grid, i), j, v))` (on met à jour la ligne, puis on réinsère la ligne modifiée).
+- **Avantage** : l'indexation `[i][j]` reflète directement la structure 2D, et correspond nativement au type C# `int[][]` — ce que le binding LINQ exploite pour traduire `g.Cells[i][j]`.
+- **Inconvénient** : deux niveaux de `select`/`store`, un peu plus verbeux côté API raw.
+
+| Critère | Aplati `(Array Int Int)` | Imbriqué `(Array Int (Array Int Int))` |
+|---------|--------------------------|----------------------------------------|
+| Type SMT | un niveau | deux niveaux |
+| Lecture cellule | `select(grid, i*W + j)` | `select(select(grid, i), j)` |
+| Écriture cellule | `store(grid, i*W + j, v)` | `store(grid, i, store(select(grid, i), j, v))` |
+| Mapping C# | `int[]` + arithmétique d'indices | `int[][]` (naturel) |
+| Lisibilité d'une ligne/colonne | indirecte (indices plats à recalculer) | directe (`grid[i]` = la ligne `i`) |
+
+**Pourquoi ce notebook choisit l'encodage imbriqué.** L'objectif est de manipuler la grille via l'API déclarative `Theorem<Grid>` où `Cells` est une propriété `int[][]`. L'encodage imbriqué est le miroir exact de cette structure : `g.Cells[i][j]` se traduit naturellement en `select(select(grid, i), j)`. L'encodage aplati exigerait de réécrire chaque accès `Cells[i][j]` en `flat[i*W + j]`, ce qui obscurcirait la lisibilité déclarative que ce notebook cherche justement à mettre en avant. La section 4 montre l'équivalent en API raw `Microsoft.Z3` avec ces deux `select` imbriqués.
+
+> **Remarque sur la sécurité des indices ( hors-scope pratique )**. En SMT-LIB pur, `select(arr, i)` est *non défini* pour un indice `i` en dehors du domaine de la théorie — ce qui soulève la question des accès hors-bornes. Dans ce notebook toutefois, les indices `i` et `j` sont des **constantes C#** bornées par des boucles `for` (et non des variables de décision Z3 libres) : le risque d'accès hors-domaine est donc absent du code. Cette subtilité ne devient pertinente que si l'on modélisait les *indices eux-mêmes* comme des inconnues symboliques — ce que nous ne faisons pas ici.",,,,,,,,f2e9b36922c7539a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,6c6341fa,markdown,fr,908ed6542662df44,"### Vue d'ensemble : deux stratégies d'encodage d'une grille 2D
+
+```mermaid
+flowchart TB
+    subgraph S1 [""Stratégie 1 — Flat (indice linéarisé)""]
+        G1[""Cellule (i, j)""] -->|""index = i × W + j""| A1[""Array Int-Int\n1 tableau plat""]
+    end
+    subgraph S2 [""Stratégie 2 — Nested int-int (ce notebook)""]
+        G2[""Cellule (i, j)""] -->|""ligne = tableau de W entiers""| Rows[""Array Int-Array-Int-Int\nArray de lignes""]
+        Rows -->|""Select(row_i, j)""| Elem[""Élément Grid-i-j""]
+    end
+    style A1 fill:#f0e6ff
+    style Rows fill:#c8f7c5
+    style Elem fill:#c8f7c5
+```
+
+Ce notebook utilise la **Stratégie 2** (`int[][]`) via `Theorem<Grid>` —
+plus lisible pour les contraintes ligne/colonne/bloc que l'encodage plat.",,,,,,,,908ed6542662df44,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,2bc581d3,markdown,fr,6e9f7bd96f8575e0,"### Configuration de l'environnement
+
+Chargement du **fork Z3.Linq** (avec support `int[][]`) depuis le sous-module local. Les trois DLL sont produites par `dotnet build` dans le sous-module `Z3.Linq` et déployées dans `.deploy/`. Les chemins sont **relatifs** au répertoire de ce notebook (`Z3/`), donc portables entre machines.
+
+> **Pré-requis machine (une seule fois)** : exécuter le script dédié qui compile le wrapper fork et rassemble les DLL dans `.deploy/` :
+>
+> ```powershell
+> # Windows
+> scripts/environment/z3-build-deploy.ps1
+> # Linux / macOS
+> scripts/environment/z3-build-deploy.sh
+> ```
+>
+> Ce script (décision ai-01 [DECISION COORD] 2026-06-13, option (b)) compile **uniquement** le wrapper fin `Z3.Linq.csproj` (~1.5 s), puis copie le solveur natif `Microsoft.Z3` et `MiaPlaza.ExpressionUtils` depuis le cache NuGet public à côté. Il ne recompile pas Z3 lui-même. Prérequis : clone `--recurse-submodules` + SDK .NET 8.0+. Le résultat est idempotent (relancez-le pour reconstruire).",,,,,,,,6e9f7bd96f8575e0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,12d212f2,code,fr,28e2c4aca453553b,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+",,,,,,,,28e2c4aca453553b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,7f2f5cf0,markdown,fr,2f45d1318a71d7ab,"### Imports et type de grille
+
+Nous définissons des types de grille (`Grid3` pour 3x3, `Grid4` pour 4x4) avec une propriété `Cells` de type `int[][]`. C'est ce type que `Theorem<Grid3>` (ou `<Grid4>`) rend symbolique : chaque `Cells[i][j]` devient une variable entière Z3 accessible dans les contraintes lambda.
+
+> **Important** : le binding reconstruit la solution en lisant le modèle Z3 *pour chaque cellule déjà allouée* dans l'instance de départ. Il faut donc que le type de grille **pré-alloue** le tableau `int[N][]` (chaque ligne `new int[N]`) dans son constructeur par défaut — sinon la solution renvoyée est vide. C'est pourquoi nous définissons des types `Grid3` (3x3) et `Grid4` (4x4) avec constructeurs pré-alloués, sur le modèle du `SudokuGrid` (9x9) du fork. Une fonction utilitaire `DisplayGrid` sert à afficher proprement une solution.",,,,,,,,2f45d1318a71d7ab,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,06fe93b4,code,fr,f497d122486cd120,"using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+// Grille 3x3 (Latin Square, carre magique). Constructeur par defaut PRE-ALLOUE
+// les 3 lignes de 3 cellules : necessaire pour que Theorem<Grid3> reconstruise
+// la solution (le binding lit le modele Z3 cellule par cellule sur l'instance).
+public class Grid3
+{
+    public int[][] Cells { get; set; } = new int[3][];
+    public Grid3() { for (int i = 0; i < 3; i++) Cells[i] = new int[3]; }
+}
+
+// Grille 4x4 (Sudoku 4x4, blocs 2x2). Meme principe de pre-allocation.
+public class Grid4
+{
+    public int[][] Cells { get; set; } = new int[4][];
+    public Grid4() { for (int i = 0; i < 4; i++) Cells[i] = new int[4]; }
+}
+
+// Affichage d'une grille NxN avec séparateurs de blocs (box = sqrt(N)).
+void DisplayGrid(int[][] cells, string title = ""Grille"", int box = 0)
+{
+    int n = cells.Length;
+    Console.WriteLine($""=== {title} ({n}x{n}) ==="");
+    for (int i = 0; i < n; i++)
+    {
+        var parts = new List<string>();
+        for (int j = 0; j < n; j++)
+        {
+            parts.Add(cells[i][j].ToString());
+            if (box > 0 && (j + 1) % box == 0 && j < n - 1) parts.Add(""|"");
+        }
+        Console.WriteLine(""  "" + string.Join("" "", parts));
+        if (box > 0 && (i + 1) % box == 0 && i < n - 1)
+            Console.WriteLine(""  "" + new string('-', n * 2 + (n / box - 1) * 2 - 1));
+    }
+}
+
+Console.WriteLine(""Imports OK : Z3.Linq (fork int[][]), Microsoft.Z3, System.Linq"");
+Console.WriteLine(""Type Grid defini : Cells = int[][], afficheur DisplayGrid pret"");
+",,,,,,,,f497d122486cd120,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,27d52ec0,markdown,fr,05b5be827170eaaa,"## 1. Latin Square 3x3 — l'approche déclarative `Theorem<Grid>`
+
+Un **Latin Square** d'ordre N est une grille NxN où chaque entier de 1 à N apparaît **exactement une fois par ligne et une fois par colonne**. Avec l'API déclarative, la grille entière est une seule variable symbolique `Theorem<Grid>`, et les contraintes s'expriment naturellement par des lambdas sur `g.Cells[i][j]`.
+
+| Propriété | Expression lambda |
+|-----------|-------------------|
+| Borne | `g.Cells[i][j] >= 1 && g.Cells[i][j] <= N` |
+| Ligne distincte | `Z3Methods.Distinct(g.Cells[i][0], ..., g.Cells[i][N-1])` |
+| Colonne distincte | `Z3Methods.Distinct(g.Cells[0][j], ..., g.Cells[N-1][j])` |
+
+La boucle de capture C# (`var (r, c) = (i, j)`) est essentielle : elle fige les indices dans la closure pour que chaque contrainte lambda voie les bonnes valeurs de `i` et `j`.",,,,,,,,05b5be827170eaaa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,a470ce78,code,fr,77e704703b50ff0f,"// Exemple 1 : Latin Square 3x3 via Theorem<Grid3> (lignes + colonnes distinctes)
+int N = 3;
+
+var ctx = new Z3Context();
+var theorem = ctx.NewTheorem<Grid3>();
+
+// 1. Contraintes de bornes : 1 <= Cells[i][j] <= N
+for (int i = 0; i < N; i++)
+    for (int j = 0; j < N; j++)
+    {
+        var (r, c) = (i, j);
+        theorem = theorem.Where(g => g.Cells[r][c] >= 1 && g.Cells[r][c] <= N);
+    }
+
+// 2. Lignes distinctes : chaque ligne est une permutation de 1..N
+for (int i = 0; i < N; i++)
+{
+    var r = i;
+    theorem = theorem.Where(g => Z3Methods.Distinct(
+        g.Cells[r][0], g.Cells[r][1], g.Cells[r][2]));
+}
+
+// 3. Colonnes distinctes : chaque colonne est une permutation de 1..N
+for (int j = 0; j < N; j++)
+{
+    var c = j;
+    theorem = theorem.Where(g => Z3Methods.Distinct(
+        g.Cells[0][c], g.Cells[1][c], g.Cells[2][c]));
+}
+
+// 4. Fixer la premiere ligne a [1, 2, 3] pour reduire la symetrie
+theorem = theorem.Where(g => g.Cells[0][0] == 1);
+theorem = theorem.Where(g => g.Cells[0][1] == 2);
+theorem = theorem.Where(g => g.Cells[0][2] == 3);
+
+var sw = Stopwatch.StartNew();
+var solution = theorem.Solve();
+sw.Stop();
+
+DisplayGrid(solution.Cells, $""Latin Square 3x3 (declaratif)"", box: 0);
+Console.WriteLine($""Lignes valides   : True"");
+Console.WriteLine($""Colonnes valides : True"");
+Console.WriteLine($""Temps de resolution : {sw.Elapsed.TotalMilliseconds:F1} ms"");
+",,,,,,,,77e704703b50ff0f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,349c8005,markdown,fr,173bd0e8d2fc827d,"### Interprétation 1 — Latin Square déclaratif
+
+**Sortie obtenue** : un Latin Square 3x3 avec la première ligne fixée à `[1, 2, 3]`.
+
+| Aspect | Détail |
+|--------|--------|
+| Modèle | une seule variable `Theorem<Grid>` |
+| Accès cellule | `g.Cells[i][j]` (indexation C# naturelle) |
+| Contrainte ligne | `Z3Methods.Distinct(...)` sur une ligne |
+| Contrainte colonne | `Z3Methods.Distinct(...)` sur une colonne |
+
+**Points clés** :
+1. Aucune manipulation de `ArrayExpr`, `MkSelect`, `MkStore` — le binding traduit `g.Cells[i][j]` en `select(select(grid, i), j)` automatiquement
+2. La capture `var (r, c) = (i, j)` fige les indices de boucle dans la closure (piège classique des lambdas en boucle)
+3. `Z3Methods.Distinct` est un marqueur LINQ : son corps lève `NotSupportedException` hors d'un théorème, mais le visiteur d'expressions le traduit en `distinct` SMT",,,,,,,,173bd0e8d2fc827d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,e7518785,markdown,fr,aee94c36a3833e61,"## 2. Sudoku 4x4 — le cas d'usage canonique
+
+Le Sudoku 4x4 ajoute aux contraintes du Latin Square une contrainte de **blocs 2x2** : chaque bloc doit contenir des valeurs distinctes. C'est le cas d'usage canonique des grilles 2D, et l'API déclarative le rend particulièrement lisible.
+
+| Contrainte | Encodage lambda |
+|-----------|-----------------|
+| Borne | `g.Cells[i][j] >= 1 && <= 4` |
+| Ligne | `Distinct(g.Cells[i][0..3])` |
+| Colonne | `Distinct(g.Cells[0..3][j])` |
+| Bloc 2x2 | `Distinct` des 4 cellules du bloc |
+| Indice pré-rempli | `g.Cells[i][j] == v` |
+
+Nous plaçons quelques indices (pré-remplis) et laissons Z3 compléter la grille. La grille 4x4 (et non 9x9) est choisie pour rester instantanée — la résolution d'un Sudoku 9x9 complet via `Theorem<Grid>` est possible (cf. `SudokuGridTheorem.cs`) mais demande quelques centaines de millisecondes.",,,,,,,,aee94c36a3833e61,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,da14af71,code,fr,3bb3874b22572c89,"// Exemple 2 : Sudoku 4x4 via Theorem<Grid4> (lignes + colonnes + blocs 2x2)
+int N = 4, B = 2;  // N = taille, B = cote de bloc (2 => blocs 2x2)
+
+var ctx2 = new Z3Context();
+var theorem2 = ctx2.NewTheorem<Grid4>();
+
+// Bornes : 1 <= Cells[i][j] <= 4
+for (int i = 0; i < N; i++)
+    for (int j = 0; j < N; j++)
+    {
+        var (r, c) = (i, j);
+        theorem2 = theorem2.Where(g => g.Cells[r][c] >= 1 && g.Cells[r][c] <= N);
+    }
+
+// Lignes distinctes
+for (int i = 0; i < N; i++)
+{
+    var r = i;
+    theorem2 = theorem2.Where(g => Z3Methods.Distinct(
+        g.Cells[r][0], g.Cells[r][1], g.Cells[r][2], g.Cells[r][3]));
+}
+
+// Colonnes distinctes
+for (int j = 0; j < N; j++)
+{
+    var c = j;
+    theorem2 = theorem2.Where(g => Z3Methods.Distinct(
+        g.Cells[0][c], g.Cells[1][c], g.Cells[2][c], g.Cells[3][c]));
+}
+
+// Blocs 2x2 distincts
+for (int bi = 0; bi < B; bi++)
+    for (int bj = 0; bj < B; bj++)
+    {
+        var (br, bc) = (bi, bj);
+        theorem2 = theorem2.Where(g => Z3Methods.Distinct(
+            g.Cells[br * B][bc * B],       g.Cells[br * B][bc * B + 1],
+            g.Cells[br * B + 1][bc * B],   g.Cells[br * B + 1][bc * B + 1]));
+    }
+
+// Indices pre-remplis (0 = case vide)
+// 1 _ | 3 _        1 4 | 3 2
+// _ 2 | _ _   =>   3 2 | 1 4
+// ----+----        ----+----
+// _ _ | _ 1        2 3 | 4 1
+// _ _ | 2 _        4 1 | 2 3
+int[,] clues = new int[,] {
+    { 1, 0, 3, 0 },
+    { 0, 2, 0, 0 },
+    { 0, 0, 0, 1 },
+    { 0, 0, 2, 0 }
+};
+for (int i = 0; i < N; i++)
+    for (int j = 0; j < N; j++)
+        if (clues[i, j] != 0)
+        {
+            var (r, c, v) = (i, j, clues[i, j]);
+            theorem2 = theorem2.Where(g => g.Cells[r][c] == v);
+        }
+
+var sw2 = Stopwatch.StartNew();
+var solved = theorem2.Solve();
+sw2.Stop();
+
+DisplayGrid(solved.Cells, ""Sudoku 4x4 (declaratif)"", box: B);
+Console.WriteLine($""Temps de resolution : {sw2.Elapsed.TotalMilliseconds:F1} ms"");
+",,,,,,,,3bb3874b22572c89,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,82dd425f,markdown,fr,f3d9a5e22b84b694,"### Interprétation 2 — Sudoku 4x4 déclaratif
+
+**Sortie obtenue** : le Sudoku 4x4 est résolu avec lignes, colonnes et blocs 2x2 valides.
+
+| Contrainte | Clauses | Complexité |
+|-----------|---------|------------|
+| Bornes | N² = 16 | O(N²) |
+| Lignes | N × 6 = 24 | O(N³) |
+| Colonnes | N × 6 = 24 | O(N³) |
+| Blocs | 4 × 6 = 24 | O(N³) |
+| Indices | 6 égalités | — |
+
+**Points clés** :
+1. La contrainte de bloc 2x2 se code en une seule lambda `Distinct` listant les 4 cellules du bloc — à comparer à la double-boucle nécessaire en API raw
+2. Les indices pré-remplis sont de simples égalités `g.Cells[i][j] == v`, ajoutées par `.Where()`
+3. **Scalabilité** : pour un Sudoku 9x9, `Theorem<Grid>` fonctionne (≈ 600 ms, cf. `SudokuGridTheorem.cs`) mais la construction des 729 contraintes lambda ralentit la phase de setup ; pour des grilles plus grandes, il vaut mieux se restreindre à des sous-ensembles ou utiliser l'API raw avec `MkDistinct` global",,,,,,,,f3d9a5e22b84b694,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,0abbaf32,markdown,fr,3122a72827a20c8e,"## 3. Carré magique — sommes de lignes et colonnes
+
+Un autre usage des grilles 2D est la vérification de propriétés **globales**, comme la somme de chaque ligne et colonne. Un **carré magique** d'ordre N (N impair) est une grille NxN où chaque ligne, colonne et diagonale somme à la même valeur `S = N(N²+1)/2`. L'API déclarative exprime ces sommes par accumulation de `Cells[i][j]`.
+
+> **Note** : `Z3Methods.Distinct` existe, mais il n'y a pas de sucre pour ""somme"" — on accumule les cellules dans une expression arithmétique `a + b + c` que le visiteur traduit en `MkAdd`.",,,,,,,,3122a72827a20c8e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,a43d8100,code,fr,99287055ab0c2582,"// Exemple 3 : Carre magique 3x3 via Theorem<Grid3> (sommes lignes + colonnes = 15)
+int N3 = 3;
+
+var ctx3 = new Z3Context();
+var theorem3 = ctx3.NewTheorem<Grid3>();
+
+int S = N3 * (N3 * N3 + 1) / 2;   // 15 pour N=3
+Console.WriteLine($""Somme magique pour N={N3} : S = {S}"");
+
+// Bornes : 1 <= Cells[i][j] <= N*N (=9)
+for (int i = 0; i < N3; i++)
+    for (int j = 0; j < N3; j++)
+    {
+        var (r, c) = (i, j);
+        theorem3 = theorem3.Where(g => g.Cells[r][c] >= 1 && g.Cells[r][c] <= N3 * N3);
+    }
+
+// Tous distincts (necessaire pour un carre magique normal)
+theorem3 = theorem3.Where(g => Z3Methods.Distinct(
+    g.Cells[0][0], g.Cells[0][1], g.Cells[0][2],
+    g.Cells[1][0], g.Cells[1][1], g.Cells[1][2],
+    g.Cells[2][0], g.Cells[2][1], g.Cells[2][2]));
+
+// Somme de chaque ligne = S
+for (int i = 0; i < N3; i++)
+{
+    var r = i;
+    theorem3 = theorem3.Where(g =>
+        g.Cells[r][0] + g.Cells[r][1] + g.Cells[r][2] == S);
+}
+
+// Somme de chaque colonne = S
+for (int j = 0; j < N3; j++)
+{
+    var c = j;
+    theorem3 = theorem3.Where(g =>
+        g.Cells[0][c] + g.Cells[1][c] + g.Cells[2][c] == S);
+}
+
+// Fixer le centre = 5 (propriété des carrés magiques 3x3 d'ordre impair)
+theorem3 = theorem3.Where(g => g.Cells[1][1] == 5);
+
+var sw3 = Stopwatch.StartNew();
+var magic = theorem3.Solve();
+sw3.Stop();
+
+Console.WriteLine();
+for (int i = 0; i < N3; i++)
+    Console.WriteLine($""  [{string.Join("", "", magic.Cells[i])}]  somme = {magic.Cells[i].Sum()}"");
+Console.WriteLine($""Somme magique verifiee : S = {S}"");
+Console.WriteLine($""Temps de resolution : {sw3.Elapsed.TotalMilliseconds:F1} ms"");
+",,,,,,,,99287055ab0c2582,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,cebf5ed0,markdown,fr,be4454f5e99e4754,"### Interprétation 3 — Carré magique déclaratif
+
+**Sortie obtenue** : un carré magique 3x3 où toutes les lignes et colonnes somment à 15.
+
+| Aspect | Détail |
+|--------|--------|
+| Somme ligne | `g.Cells[i][0] + g.Cells[i][1] + g.Cells[i][2] == S` |
+| Somme colonne | `g.Cells[0][j] + g.Cells[1][j] + g.Cells[2][j] == S` |
+| Distincts | `Z3Methods.Distinct` sur les 9 cellules |
+
+**Points clés** :
+1. L'accumulation arithmétique `a + b + c` est traduite par le visiteur en `MkAdd` sur les `select` imbriqués — aucun cast `ArithExpr` à gérer manuellement
+2. Fixer le centre à 5 exploite la propriété mathématique des carrés magiques d'ordre impair (le médian occupe toujours le centre)
+3. Comparé à l'API raw, la lisibilité est drastique : une contrainte de somme tient sur une ligne lisible",,,,,,,,be4454f5e99e4754,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,b3580f97,markdown,fr,a676f6181bb1ba59,"## 4. Comparaison — l'API raw `Microsoft.Z3` (Store/Select imbriqués)
+
+L'API déclarative `Theorem<Grid>` repose, en interne, sur l'API **raw** de Microsoft.Z3. Il est instructif de voir l'équivalent pour comprendre ce que le binding automatise. Voici le **même Latin Square 3x3** (lignes distinctes) codé directement avec `MkSelect` imbriqués.
+
+Un tableau imbriqué a le type SMT `Array Int (Array Int Int)`. L'accès à la cellule `(i, j)` se fait par deux `Select` imbriqués :
+
+$$
+\text{grid}[i][j] = \text{select}(\text{select}(\text{grid},\; i),\; j)
+$$
+
+| Concept | SMT-LIB | C# (Microsoft.Z3) |
+|---------|---------|-------------------|
+| Grille 2D | `(Array Int (Array Int Int))` | `ctx.MkArrayConst(""g"", ctx.IntSort, ctx.MkArraySort(ctx.IntSort, ctx.IntSort))` |
+| Lire cellule | `(select (select g i) j)` | `ctx.MkSelect((ArrayExpr)ctx.MkSelect(grid, i), j)` |
+| Écrire cellule | `(store g i (store (select g i) j v))` | `ctx.MkStore(grid, i, ctx.MkStore(row, j, v))` |",,,,,,,,a676f6181bb1ba59,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,b23bd3e1,code,fr,28118668bfc08acb,"// Comparaison : meme Latin Square 3x3 mais en API RAW Microsoft.Z3
+// (lignes distinctes uniquement, pour la lisibilite de la comparaison)
+using (var rctx = new Microsoft.Z3.Context())
+{
+    int N = 3;
+    var rowSort = rctx.MkArraySort(rctx.IntSort, rctx.IntSort);
+    var grid = rctx.MkArrayConst(""grid"", rctx.IntSort, rowSort);
+
+    var solver = rctx.MkSolver();
+
+    // Bornes + distincts par ligne : chaque MkSelect doit etre caste en ArrayExpr/ArithExpr
+    for (int i = 0; i < N; i++)
+    {
+        var row = (ArrayExpr)rctx.MkSelect(grid, rctx.MkInt(i));
+        for (int j = 0; j < N; j++)
+        {
+            var cell = (ArithExpr)rctx.MkSelect(row, rctx.MkInt(j));
+            solver.Assert(rctx.MkGe(cell, rctx.MkInt(1)));
+            solver.Assert(rctx.MkLe(cell, rctx.MkInt(N)));
+        }
+        for (int j1 = 0; j1 < N; j1++)
+            for (int j2 = j1 + 1; j2 < N; j2++)
+                solver.Assert(rctx.MkNot(rctx.MkEq(
+                    rctx.MkSelect(row, rctx.MkInt(j1)),
+                    rctx.MkSelect(row, rctx.MkInt(j2)))));
+    }
+
+    if (solver.Check() == Status.SATISFIABLE)
+    {
+        var model = solver.Model;
+        Console.WriteLine(""Latin Square 3x3 (API RAW, lignes distinctes) :"");
+        for (int i = 0; i < N; i++)
+        {
+            var row = (ArrayExpr)rctx.MkSelect(grid, rctx.MkInt(i));
+            var cells = new List<int>();
+            for (int j = 0; j < N; j++)
+            {
+                var cell = rctx.MkSelect(row, rctx.MkInt(j));
+                cells.Add(int.Parse(model.Eval(cell).ToString()));
+            }
+            Console.WriteLine($""  Ligne {i}: [{string.Join("", "", cells)}]"");
+        }
+    }
+}
+",,,,,,,,28118668bfc08acb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,17c4efb8,markdown,fr,9601742c2dd36b98,"### Interprétation 4 — Déclaratif vs Raw
+
+**Sortie obtenue** : le même type de grille 3x3 (lignes distinctes), produit par deux API différentes.
+
+| Critère | `Theorem<Grid>` (déclaratif) | API raw `Microsoft.Z3` |
+|---------|------------------------------|------------------------|
+| Accès cellule | `g.Cells[i][j]` | `MkSelect((ArrayExpr)MkSelect(grid, i), j)` |
+| Casts | aucun | `(ArrayExpr)`, `(ArithExpr)` partout |
+| Distinct | `Z3Methods.Distinct(...)` | boucle de `MkNot(MkEq(...))` par paire |
+| Modèle | `solution.Cells[i][j]` (int) | `int.Parse(model.Eval(cell).ToString())` |
+| Niveau d'abstraction | haut (LINQ) | bas (SMT direct) |
+
+**Quand utiliser quoi ?**
+1. **Déclaratif** (`Theorem<Grid>`) : prototypes pédagogiques, grilles jusqu'à 9x9, lisibilité prioritaire
+2. **Raw** (`Microsoft.Z3`) : performances critiques, grilles très larges (optimisation par `MkDistinct` global), accès fin aux tactiques du solveur",,,,,,,,9601742c2dd36b98,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,e67edd46,markdown,fr,301047f58327588d,"## 5. Raw avancé — Store imbriqué (mise à jour d'une cellule)
+
+La **mise à jour** d'une cellule `(i, j)` — opération d'écriture — n'a pas d'équivalent direct dans l'API déclarative (un théorème *décrit* une grille solution, il ne la *modifie* pas séquentiellement). C'est donc une opération strictement **raw**. Elle nécessite deux `Store` imbriqués (axiomes de McCarthy) :
+
+$$
+\text{grid}' = \text{store}(\text{grid},\; i,\; \text{store}(\text{select}(\text{grid},\; i),\; j,\; v))
+$$
+
+Cette section, conservée de l'édition précédente, montre le pattern fondamental des mises à jour de grilles (utile en vérification impérative : Sudoku incrémental, damier évolutif).",,,,,,,,301047f58327588d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,4ab059a2,code,fr,ffbc44c3f520622f,"// Exemple raw : Store imbrique - mise a jour d'une cellule dans une grille 2D
+using (var sctx = new Microsoft.Z3.Context())
+{
+    int N = 3;
+    var rowSort = sctx.MkArraySort(sctx.IntSort, sctx.IntSort);
+    var grid = sctx.MkArrayConst(""g"", sctx.IntSort, rowSort);
+
+    // Initialiser [[1,2,3],[4,5,6],[7,8,9]] par Store imbriques
+    ArrayExpr initGrid = grid;
+    int[][] initData = new int[][] { new[]{1,2,3}, new[]{4,5,6}, new[]{7,8,9} };
+    for (int i = 0; i < N; i++)
+    {
+        var row = (ArrayExpr)sctx.MkSelect(initGrid, sctx.MkInt(i));
+        ArrayExpr newRow = row;
+        for (int j = 0; j < N; j++)
+            newRow = (ArrayExpr)sctx.MkStore(newRow, sctx.MkInt(j), sctx.MkInt(initData[i][j]));
+        initGrid = (ArrayExpr)sctx.MkStore(initGrid, sctx.MkInt(i), newRow);
+    }
+
+    // Store imbrique : grid[1][2] = 99
+    var row1 = (ArrayExpr)sctx.MkSelect(initGrid, sctx.MkInt(1));
+    var updatedGrid = sctx.MkStore(initGrid, sctx.MkInt(1),
+        sctx.MkStore(row1, sctx.MkInt(2), sctx.MkInt(99)));
+
+    // Affichage des valeurs concretes : il faut un modele (Check SAT trivial,
+    // aucune contrainte) pour que model.Eval replie les Store en valeurs.
+    var dispSolver = sctx.MkSolver();
+    dispSolver.Check();   // SAT : pas de contraintes => modele trivial
+    var model = dispSolver.Model;
+    Console.WriteLine(""Apres store(grid, 1, store(row1, 2, 99)) :"");
+    for (int i = 0; i < N; i++)
+    {
+        var r = (ArrayExpr)sctx.MkSelect(updatedGrid, sctx.MkInt(i));
+        var cells = new List<int>();
+        for (int j = 0; j < N; j++)
+        {
+            var c = sctx.MkSelect(r, sctx.MkInt(j));
+            cells.Add(int.Parse(model.Eval(c).ToString()));
+        }
+        Console.WriteLine($""  [{string.Join("", "", cells)}]"");
+    }
+
+    // Verification formelle : grid'[1][2] == 99 (TOUJOURS VRAI si UNSAT sur la negation)
+    var cell12 = sctx.MkSelect((ArrayExpr)sctx.MkSelect(updatedGrid, sctx.MkInt(1)), sctx.MkInt(2));
+    var chk = sctx.MkSolver();
+    chk.Assert(sctx.MkNot(sctx.MkEq(cell12, sctx.MkInt(99))));
+    Console.WriteLine($""grid'[1][2] == 99 : {(chk.Check() == Status.UNSATISFIABLE ? ""TOUJOURS VRAI"" : ""PEUT ETRE FAUX"")}"");
+    Console.WriteLine(""Store imbrique verifie : seule la cellule (1,2) a change."");
+}
+",,,,,,,,ffbc44c3f520622f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,cfb5c945,markdown,fr,af800e60452f614a,"### Interprétation 5 — Store imbriqué
+
+**Sortie obtenue** : `[[1,2,3], [4,5,6], [7,8,9]]` devient `[[1,2,3], [4,5,99], [7,8,9]]`.
+
+| Étape | Opération | Effet |
+|-------|-----------|-------|
+| 1 | `row = select(grid, 1)` | extraire la ligne 1 |
+| 2 | `row' = store(row, 2, 99)` | mettre à jour la cellule (1,2) |
+| 3 | `grid' = store(grid, 1, row')` | réinsérer la ligne modifiée |
+
+**Points clés** :
+1. Le store imbriqué préserve la **localité** : seule la cellule ciblée est modifiée (axiome read-over-write de McCarthy)
+2. C'est le pattern fondamental pour les mises à jour impératives de grilles, hors paradigme déclaratif
+3. L'absence d'équivalent déclaratif est **fondée** : un théorème est une spécification relationnelle, pas un programme séquentiel",,,,,,,,af800e60452f614a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,e3513758,markdown,fr,b507dcf25119cc3f,"## 6. Exercices
+
+Les exercices suivants utilisent l'API déclarative `Theorem<Grid>`. Chaque stub se contente d'un `print`/`Console.WriteLine` de confirmation (convention C.1 : aucune erreur volontaire) — à vous de remplir la solution.
+
+### Exercice 1 : Latin Square avec contraintes diagonales
+
+**Objectif** : ajoutez les contraintes de **diagonales** au Latin Square 3x3 de l'exemple 1. Un Latin Square diagonal exige que chaque diagonale contienne également des valeurs distinctes.
+
+**Indices** :
+- Diagonale principale : `g.Cells[0][0]`, `g.Cells[1][1]`, `g.Cells[2][2]` doivent être distincts
+- Diagonale anti-principale : `g.Cells[0][2]`, `g.Cells[1][1]`, `g.Cells[2][0]` doivent être distincts
+- Reprenez le code de l'exemple 1 (bornes + lignes + colonnes) et ajoutez les deux `Z3Methods.Distinct` de diagonales
+- Fixez la première ligne à `[1, 2, 3]` pour réduire la symétrie",,,,,,,,b507dcf25119cc3f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,eff5dea6,code,fr,4d841a5a579baba3,"// Exercice 1 : Latin Square 3x3 avec contraintes diagonales (API declarative)
+// TODO etudiant : ajoutez les contraintes de diagonales au Latin Square
+// Etape 1 : reprenez le code de l'exemple 1 (bornes + lignes + colonnes distinctes)
+// Etape 2 : ajoutez Distinct(g.Cells[0][0], g.Cells[1][1], g.Cells[2][2])
+// Etape 3 : ajoutez Distinct(g.Cells[0][2], g.Cells[1][1], g.Cells[2][0])
+// Indice : chaque contrainte est un theorem.Where(g => Z3Methods.Distinct(...))
+
+Console.WriteLine(""Exercice a completer : Latin Square 3x3 avec diagonales distinctes"");
+",,,,,,,,4d841a5a579baba3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,5a5da616,markdown,fr,cd5661dd7ab53917,"### Exercice 2 : Sudoku 4x4 avec grille de départ différente
+
+**Objectif** : résolvez le Sudoku 4x4 avec un autre jeu d'indices, puis vérifiez que la solution satisfait toutes les contraintes (lignes, colonnes, blocs).
+
+**Indices** :
+- Reprenez la construction du théorème de l'exemple 2 (bornes + lignes + colonnes + blocs)
+- Utilisez les indices suivants (0 = vide) :
+  ```
+  _ 3 | _ _
+  _ _ | _ 2
+  ----+----
+  4 _ | _ _
+  _ _ | 1 _
+  ```
+- Ajoutez chaque indice par `theorem.Where(g => g.Cells[i][j] == v)`
+- Affichez la solution avec `DisplayGrid`",,,,,,,,cd5661dd7ab53917,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,60496222,code,fr,348e0df7571361e1,"// Exercice 2 : Sudoku 4x4 avec une autre grille de depart (API declarative)
+// TODO etudiant : construisez le theoreme et ajoutez les indices ci-dessus
+// Etape 1 : reprenez bornes + lignes + colonnes + blocs 2x2 de l'exemple 2
+// Etape 2 : ajoutez les 4 indices (Cells[0][1]==3, Cells[1][3]==2, Cells[2][0]==4, Cells[3][2]==1)
+// Etape 3 : resolvez et affichez avec DisplayGrid(..., box: 2)
+// Indice : tous les indices aboutissent a une solution unique
+
+Console.WriteLine(""Exercice a completer : Sudoku 4x4 avec autre grille de depart"");
+",,,,,,,,348e0df7571361e1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,ec68f2e2,markdown,fr,bdd3e363a4778702,"### Exercice 3 : Vérificateur de carré magique (approche déclarative)
+
+**Objectif** : vérifiez si la grille suivante est un **carré magique** (lignes, colonnes ET les deux diagonales somment à 15) en modélisant le *problème inverse* : contraindre la grille à valoir ces nombres, puis vérifier que les contraintes de somme sont satisfaites.
+
+```
+[2, 7, 6]
+[9, 5, 1]
+[4, 3, 8]
+```
+
+**Indices** :
+- Construisez un `Theorem<Grid>` et fixez chaque cellule à sa valeur (`g.Cells[i][j] == v`)
+- Ajoutez les contraintes ""somme ligne = 15"", ""somme colonne = 15"", ""somme diagonale = 15""
+- Si `Solve()` retourne une solution, la grille satisfait toutes les contraintes → c'est un carré magique
+- Variante : retirez la contrainte de diagonale et observez si le verdict change",,,,,,,,bdd3e363a4778702,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,88bfb545,code,fr,ae9207ea735f09c4,"// Exercice 3 : Verificateur de carre magique declaratif
+// TODO etudiant : verifiez si [[2,7,6],[9,5,1],[4,3,8]] est un carre magique
+// Etape 1 : fixez chaque cellule a sa valeur (9 contraintes d'egalite)
+// Etape 2 : ajoutez sommes de lignes = 15, colonnes = 15, 2 diagonales = 15
+// Etape 3 : si Solve() reussit, la grille est un carre magique valide
+// Indice : c'est bien un carre magique, toutes les contraintes doivent etre satisfiables
+
+Console.WriteLine(""Exercice a completer : verificateur de carre magique"");
+",,,,,,,,ae9207ea735f09c4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/05_Nested_Arrays_2D.ipynb,907ea954,markdown,fr,db68302cd6879efb,"## Conclusion
+
+Ce notebook a montré comment modéliser des **grilles 2D** via l'API déclarative `Theorem<Grid>` du binding LINQ Z3.Linq (support `int[][]`), en contraste avec l'API raw `Microsoft.Z3`.
+
+### Récapitulatif : déclaratif vs raw
+
+| Concept | Déclaratif `Theorem<Grid>` | Raw `Microsoft.Z3` |
+|---------|----------------------------|--------------------|
+| Grille 2D | propriété `int[][] Cells` | `MkArraySort(IntSort, MkArraySort(IntSort, IntSort))` |
+| Accès cellule | `g.Cells[i][j]` | `MkSelect((ArrayExpr)MkSelect(grid, i), j)` |
+| Distinct | `Z3Methods.Distinct(...)` | boucle de `MkNot(MkEq(...))` |
+| Mise à jour (Store) | *(non applicable)* | `MkStore(grid, i, MkStore(row, j, v))` |
+| Niveau d'abstraction | LINQ / haut | SMT / bas |
+
+### Points clés à retenir
+
+1. **`Theorem<Grid>` + `Cells[i][j]`** = grille 2D lisible, contraintes en lambdas naturelles
+2. **Capture de closure** : `var (r, c) = (i, j)` fige les indices de boucle (piège classique)
+3. **`Z3Methods.Distinct`** = sucre LINQ traduit en `distinct` SMT par le visiteur d'expressions
+4. **Raw pour les mises à jour** : le `Store` imbriqué est strictement impératif (pas d'équivalent déclaratif)
+5. **Scalabilité** : l'API déclarative excelle jusqu'à 9x9 ; au-delà, préférer l'API raw avec `MkDistinct` global ou restreindre à des sous-ensembles
+
+### Résolution du package (rappel technique)
+
+Le support `int[][]` de `Theorem<T>` n'est **pas encore publié** sur NuGet (le paquet public `Z3.Linq` 2.0.1 ne gère qu'un niveau de collection). Ce notebook charge donc le **fork local** (commit `096a638`, branche #1206) via des DLL compilées. Pour (re)générer le dossier `.deploy/`, lancez le script dédié (une fois par machine) :
+
+```powershell
+# Windows
+scripts/environment/z3-build-deploy.ps1
+# Linux / macOS
+scripts/environment/z3-build-deploy.sh
+```
+
+Ce script ne recompile **pas** Z3 : il construit uniquement le wrapper fin `Z3.Linq.csproj` (~1.5 s), puis copie le solveur natif `Microsoft.Z3` et `MiaPlaza.ExpressionUtils` depuis le cache NuGet public à côté de `Z3.Linq.dll` dans `.deploy/`. Décision ai-01 [DECISION COORD] 2026-06-13, option (b).
+
+Lorsque le fork sera publié sur NuGet (version ≥ 2.0.2 avec `int[][]`), ce notebook pourra revenir au `#r ""nuget: Z3.Linq""` standard utilisé par les notebooks 01-04.
+
+---
+
+**Navigation** : [Index SymbolicAI](../../README.md) | [Série Z3](README.md) | [<< Array Theory](04_Array_Theory.ipynb) | [Meal Planner >>](06_Meal_Planner_Modelisation.ipynb)",,,,,,,,db68302cd6879efb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,1c6a7f3f,markdown,fr,d52a6fe55036ef51,"# Notebook 06 — Meal-Planner declaratif : du modele Z3 au plan hebdomadaire visualise
+
+**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index general](../../../README.md) | [Notebook precedent (Nested Arrays)](05_Nested_Arrays_2D.ipynb)
+
+Ce notebook consolide en une seule histoire coherente la **modelisation declarative** d'un planificateur de repas avec `Z3.Linq` et l'API `Microsoft.Z3`, du menu d'un jour au plan hebdomadaire visualise. Il est organise en trois parties :
+
+- **Partie A — Modelisation declarative** : construire le probleme du menu equilibre selon plusieurs paradigmes (selection par index, enumeration, variables booleennes, theoreme hierarchique `int[][]`), et faire emerger la feature `CollectionHandling`.
+- **Partie B — Couplage hebdomadaire** : passer d'un repas a une **semaine** — matrice booleenne jours x plats, fenetre nutritionnelle par jour, variete globale, et comparaison solveur vs glouton.
+- **Partie C — Visualisation HTML** : rendre les solutions du solveur **lisibles par un humain** (cartes colorees, grilles, front de Pareto) via `display(HTML(...))`, en demontrant le decouplage solveur / presentation.
+
+Le corpus nutritionnel detaille (RecipeML x Ciqual, quantites en grammes) est prepare dans le **notebook de donnees 07** ; ici on se concentre sur la **modelisation** et sa restitution.
+
+```mermaid
+flowchart LR
+    A[""Partie A\nModele declaratif\n(index / bool / int[][])""] --> B[""Partie B\nCouplage hebdomadaire\n(fenetre kcal/jour, variete)""]
+    B --> C[""Partie C\nVisualisation HTML\n(cartes, grille, Pareto)""]
+    style A fill:#cfe3ff
+    style B fill:#ffe9c7
+    style C fill:#c8f7c5
+```
+",,,,,,,,d52a6fe55036ef51,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,324e2277,code,fr,267e18dd4f75101d,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq;
+using Microsoft.Z3;
+using Microsoft.DotNet.Interactive;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy, CollectionHandling cable), Microsoft.Z3, Microsoft.DotNet.Interactive (display/HTML), System.Linq/Text/Xml.Linq/Diagnostics"");",,,,,,,,267e18dd4f75101d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,7c3e0ddf,markdown,fr,57bddab6a8c0b4e5,"## Partie A — Modelisation declarative
+
+De la base de donnees nutritionnelle au **theoreme hierarchique** `int[][]` : on modelise le meme probleme de menu equilibre selon plusieurs paradigmes Z3 (selection par index, enumeration, variables booleennes, optimisation par dichotomie), puis on montre comment `CollectionHandling` structure un plan multi-jours en pur LINQ.",,,,,,,,57bddab6a8c0b4e5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,56283978,markdown,fr,0790540207bf0949,"---
+
+### 1. Contexte : Le théorème hiérarchique
+
+Dans les notebooks précédents, nous avons utilisé `Symbols<T1, T2, ...>` pour créer des variables Z3 plates. Le **théorème hiérarchique** generalise cette approche :
+
+- Un objet parent (ex: `Meal`) contient des references vers des objets enfants (ex: `Course`)
+- Chaque niveau de la hiérarchie possède ses propres contraintes
+- Le solveur Z3 résout le système complet de manière cohérente
+
+#### Analogie
+
+```
+Meal (contraintes globales : calories totales, budget)
+  |-- Entree (contraintes : type, taille)
+  |-- Plat principal (contraintes : proteines minimales)
+  |-- Dessert (contraintes : sucre maximal)
+```
+
+La **fusion de données** consiste a injecter des données externes (table nutritionnelle) dans les contraintes du solveur.",,,,,,,,0790540207bf0949,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,2be91470,markdown,fr,a9ca3bf706f8f56b,"### 2. Base de données nutritionnelle (data fusion)
+
+Nous definissons une base de données d'aliments avec leurs propriétés nutritionnelles. Ces données seront utilisees par le solveur pour sélectionner des combinaisons valides.",,,,,,,,a9ca3bf706f8f56b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,762ca2d8,code,fr,b974e05fd6ba4c84,"// Base de données nutritionnelle : fusion de données statiques avec le solveur
+public class FoodItem
+{
+    public string Name { get; set; }
+    public int Calories { get; set; }      // kcal par portion
+    public int Protein { get; set; }       // grammes
+    public int Carbs { get; set; }         // grammes
+    public int Fat { get; set; }           // grammes
+    public int Cost { get; set; }          // prix en centimes
+    public string Category { get; set; }   // entree, plat, dessert
+}
+
+var foodDatabase = new List<FoodItem>
+{
+    // Entrees
+    new FoodItem { Name = ""Salade verte"",    Calories = 80,  Protein = 2,  Carbs = 8,   Fat = 4,  Cost = 300, Category = ""entree"" },
+    new FoodItem { Name = ""Soupe de legumes"", Calories = 120, Protein = 4,  Carbs = 18,  Fat = 3,  Cost = 250, Category = ""entree"" },
+    new FoodItem { Name = ""Carpaccio"",        Calories = 150, Protein = 15, Carbs = 2,   Fat = 8,  Cost = 600, Category = ""entree"" },
+    // Plats principaux
+    new FoodItem { Name = ""Poulet roti"",      Calories = 350, Protein = 30, Carbs = 5,   Fat = 20, Cost = 500, Category = ""plat"" },
+    new FoodItem { Name = ""Saumon grille"",    Calories = 300, Protein = 28, Carbs = 0,   Fat = 18, Cost = 800, Category = ""plat"" },
+    new FoodItem { Name = ""Pates bolognaise"", Calories = 450, Protein = 18, Carbs = 55,  Fat = 14, Cost = 350, Category = ""plat"" },
+    new FoodItem { Name = ""Risotto"",          Calories = 400, Protein = 10, Carbs = 60,  Fat = 12, Cost = 400, Category = ""plat"" },
+    // Desserts
+    new FoodItem { Name = ""Fruit frais"",      Calories = 70,  Protein = 1,  Carbs = 15,  Fat = 0,  Cost = 200, Category = ""dessert"" },
+    new FoodItem { Name = ""Mousse au chocolat"",Calories = 250, Protein = 4,  Carbs = 28,  Fat = 14, Cost = 350, Category = ""dessert"" },
+    new FoodItem { Name = ""Yaourt nature"",    Calories = 60,  Protein = 5,  Carbs = 6,   Fat = 2,  Cost = 150, Category = ""dessert"" },
+};
+
+Console.WriteLine($""Base de données chargée : {foodDatabase.Count} aliments"");
+Console.WriteLine(string.Join(""\n"", foodDatabase.GroupBy(f => f.Category)
+    .Select(g => $""  {g.Key} : {g.Count()} items"")));",,,,,,,,b974e05fd6ba4c84,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,5d86fac1,markdown,fr,abccce53f7fc63d3,"#### Interpretation
+
+La base contient 10 aliments répartis en 3 catégories (entree, plat, dessert). Chaque aliment a des propriétés nutritionnelles et un cout. Le solveur devra sélectionner exactement **1 entree + 1 plat + 1 dessert** qui satisfont les contraintes globales.",,,,,,,,abccce53f7fc63d3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,45f22567,markdown,fr,94b247481e19d8b7,"### 3. Approche 1 : Sélection par index avec contraintes lineaires
+
+La première approche utilisé des variables entieres pour sélectionner un aliment dans chaque catégorie. Les contraintes sont exprimees lineairement en fonction de l'index.",,,,,,,,94b247481e19d8b7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,7c4fcb7e,code,fr,90e8853bc74a56b5,"// Approche index-based : chaque variable represente l'index d'un aliment
+// Les contraintes Z3.Linq doivent utiliser des expressions lineaires sur les variables
+
+var entrees = foodDatabase.Where(f => f.Category == ""entree"").ToList();
+var plats = foodDatabase.Where(f => f.Category == ""plat"").ToList();
+var desserts = foodDatabase.Where(f => f.Category == ""dessert"").ToList();
+
+using (var ctx = new Z3Context())
+{
+    // Variables : index de l'aliment choisi dans chaque catégorie
+    // Contraintes de bornes avec expressions lineaires (pattern Z3.Linq)
+    var theorem = from meal in ctx.NewTheorem<Symbols<int, int, int>>()
+        where meal.X1 >= 0 && meal.X1 - 3 <= 0   // 0 <= X1 <= 2 (3 entrees)
+        where meal.X2 >= 0 && meal.X2 - 4 <= 0   // 0 <= X2 <= 3 (4 plats)
+        where meal.X3 >= 0 && meal.X3 - 3 <= 0   // 0 <= X3 <= 2 (3 desserts)
+        select meal;
+
+    var solution = theorem.Solve();
+    
+    if (solution != null)
+    {
+        var e = entrees[solution.X1];
+        var p = plats[solution.X2];
+        var d = desserts[solution.X3];
+        int totalCal = e.Calories + p.Calories + d.Calories;
+        int totalCost = e.Cost + p.Cost + d.Cost;
+        
+        Console.WriteLine(""Menu trouve (sans contraintes nutritionnelles) :"");
+        Console.WriteLine($""  Entree  : {e.Name} ({e.Calories} kcal)"");
+        Console.WriteLine($""  Plat    : {p.Name} ({p.Calories} kcal)"");
+        Console.WriteLine($""  Dessert : {d.Name} ({d.Calories} kcal)"");
+        Console.WriteLine($""  Total   : {totalCal} kcal, {totalCost/100.0:F2} euros"");
+    }
+    else
+    {
+        Console.WriteLine(""Aucune solution trouvee"");
+    }
+}",,,,,,,,90e8853bc74a56b5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,9f7d6d3c,markdown,fr,01df6b6934e01a49,"#### Interpretation
+
+Sans contraintes nutritionnelles, le solveur trouve la première combinaison valide (index 0, 0, 0). Le résultat est trivialement la première entree, le premier plat et le premier dessert de la base. Nous devons ajouter des contraintes pour obtenir un menu équilibré.",,,,,,,,01df6b6934e01a49,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,76ee2467,markdown,fr,e142a21d6aeae50f,"### 4. Approche 2 : Contraintes nutritionnelles avec énumération
+
+La contrainte Z3.Linq fonctionne avec des expressions lineaires. Pour injecter les données nutritionnelles, nous énumérons les combinaisons possibles et posons des contraintes sur les totaux.
+
+**Strategie** : generer toutes les combinaisons possibles, puis filtrer avec Z3 sur les contraintes globales (calories, proteines, budget).",,,,,,,,e142a21d6aeae50f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,e6627bc3,code,fr,62cfe09bdcca7f04,"// Approche par énumération + filtrage Z3
+// Objectif : trouver un menu avec 600-900 kcal, >= 25g proteines, cout <= 12 euros
+
+int minCalories = 600, maxCalories = 900;
+int minProtein = 25;
+int maxCostCents = 1200; // 12 euros
+
+var validMenus = new List<string>();
+
+// Énumération des combinaisons + vérification des contraintes
+foreach (var e in entrees)
+    foreach (var p in plats)
+        foreach (var d in desserts)
+        {
+            int cal = e.Calories + p.Calories + d.Calories;
+            int prot = e.Protein + p.Protein + d.Protein;
+            int cost = e.Cost + p.Cost + d.Cost;
+            
+            if (cal >= minCalories && cal <= maxCalories 
+                && prot >= minProtein && cost <= maxCostCents)
+            {
+                validMenus.Add($""{e.Name} + {p.Name} + {d.Name} = {cal} kcal, {prot}g prot, {cost/100.0:F2} EUR"");
+            }
+        }
+
+Console.WriteLine($""Menus valides (600-900 kcal, >= 25g prot, <= 12 EUR) : {validMenus.Count}/{entrees.Count * plats.Count * desserts.Count} combinaisons"");
+Console.WriteLine();
+foreach (var menu in validMenus.Take(8))
+    Console.WriteLine($""  {menu}"");
+if (validMenus.Count > 8)
+    Console.WriteLine($""  ... et {validMenus.Count - 8} autres"");",,,,,,,,62cfe09bdcca7f04,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,24f444c7,markdown,fr,a5e456374aea4927,"#### Interpretation
+
+L'énumération exhaustive fonctionne car l'espace est petit (3 x 4 x 3 = 36 combinaisons). Pour de grands catalogues, le solveur Z3 est préférable car il explore intelligemment l'espace de recherche plutôt que de tout énumérer.",,,,,,,,a5e456374aea4927,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,b29c4a61,markdown,fr,b2cc668ad98bb35d,"### 5. Approche 3 : Modèle Z3 avec variables booléennes (sélection)
+
+Pour modéliser la sélection d'aliments directement dans Z3, nous utilisons des **variables booléennes** : chaque aliment est soit sélectionné (`true`) soit non sélectionné (`false`).
+
+#### Principe
+
+- Une variable booléenne par aliment
+- Exactement 1 entree + 1 plat + 1 dessert sélectionnés
+- Contraintes nutritionnelles sur la somme ponderee",,,,,,,,b2cc668ad98bb35d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,bb3b480c,code,fr,4ead52f07cb39973,"// Approche booléenne Z3 : chaque aliment est une variable bool
+// Avantage : le solveur explore l'espace, pas d'énumération
+
+using (var z3ctx = new Context())
+{
+    var solver = z3ctx.MkSolver();
+    
+    // Variables booléennes : une par aliment
+    var selections = foodDatabase
+        .Select((food, i) => new { Food = food, Var = (BoolExpr)z3ctx.MkConst($""sel_{i}_{food.Name}"", z3ctx.BoolSort) })
+        .ToList();
+    
+    // Contrainte 1 : exactement 1 entree sélectionnée
+    var entreeVars = selections.Where(s => s.Food.Category == ""entree"").Select(s => (BoolExpr)s.Var).ToArray();
+    solver.Add(z3ctx.MkOr(entreeVars));           // au moins 1
+    foreach (var v1 in entreeVars)                 // au plus 1 (pairwise exclusion)
+        foreach (var v2 in entreeVars)
+            if (v1 != v2)
+                solver.Add(z3ctx.MkImplies(v1, z3ctx.MkNot(v2)));
+    
+    // Contrainte 2 : exactement 1 plat sélectionné
+    var platVars = selections.Where(s => s.Food.Category == ""plat"").Select(s => (BoolExpr)s.Var).ToArray();
+    solver.Add(z3ctx.MkOr(platVars));
+    foreach (var v1 in platVars)
+        foreach (var v2 in platVars)
+            if (v1 != v2)
+                solver.Add(z3ctx.MkImplies(v1, z3ctx.MkNot(v2)));
+    
+    // Contrainte 3 : exactement 1 dessert sélectionné
+    var dessertVars = selections.Where(s => s.Food.Category == ""dessert"").Select(s => (BoolExpr)s.Var).ToArray();
+    solver.Add(z3ctx.MkOr(dessertVars));
+    foreach (var v1 in dessertVars)
+        foreach (var v2 in dessertVars)
+            if (v1 != v2)
+                solver.Add(z3ctx.MkImplies(v1, z3ctx.MkNot(v2)));
+    
+    // Contraintes nutritionnelles lineaires (implication conditionnelle)
+    IntExpr totalCal = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0), 
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Food.Calories), z3ctx.MkInt(0))));
+    
+    IntExpr totalProt = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0), 
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Food.Protein), z3ctx.MkInt(0))));
+    
+    IntExpr totalCost = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0), 
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Food.Cost), z3ctx.MkInt(0))));
+    
+    solver.Add(z3ctx.MkGe(totalCal, z3ctx.MkInt(600)));
+    solver.Add(z3ctx.MkLe(totalCal, z3ctx.MkInt(900)));
+    solver.Add(z3ctx.MkGe(totalProt, z3ctx.MkInt(25)));
+    solver.Add(z3ctx.MkLe(totalCost, z3ctx.MkInt(1200)));
+    
+    Console.WriteLine($""Contraintes : {solver.NumAssertions} assertions"");
+    
+    var result = solver.Check();
+    Console.WriteLine($""Résultat solve : {result}"");
+    
+    if (result == Status.SATISFIABLE)
+    {
+        var model = solver.Model;
+        Console.WriteLine(""\nMenu équilibré trouve :"");
+        int cal = 0, prot = 0, cost = 0;
+        foreach (var s in selections)
+        {
+            var val = model.Eval(s.Var, true);
+            if (val.BoolValue == Z3_lbool.Z3_L_TRUE)
+            {
+                Console.WriteLine($""  [{s.Food.Category}] {s.Food.Name} : {s.Food.Calories} kcal, {s.Food.Protein}g prot, {s.Food.Cost/100.0:F2} EUR"");
+                cal += s.Food.Calories;
+                prot += s.Food.Protein;
+                cost += s.Food.Cost;
+            }
+        }
+        Console.WriteLine($""  --- Total : {cal} kcal, {prot}g proteines, {cost/100.0:F2} EUR ---"");
+    }
+    else
+    {
+        Console.WriteLine(""Aucun menu ne satisfait les contraintes."");
+    }
+}",,,,,,,,4ead52f07cb39973,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,0bf4d442,markdown,fr,f5a634b93d86b704,"#### Interpretation
+
+L'approche booléenne utilisé **`MkITE` (If-Then-Else)** pour conditionnellement ajouter la contribution nutritionnelle de chaque aliment. C'est la clé technique de la **data fusion** : les données statiques (calories, proteines, cout) sont injectees dans les expressions Z3 via `MkITE`.
+
+| Technique | Role |
+|-----------|------|
+| `BoolExpr` par aliment | Sélection binaire |
+| `MkOr` + exclusion mutuelle | Exactement 1 par catégorie |
+| `MkITE(sel, valeur, 0)` | Contribution conditionnelle |
+| Somme des `MkITE` | Total nutritionnel global |",,,,,,,,f5a634b93d86b704,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,352a219e,markdown,fr,a349b621cae98e77,"### 6. Optimisation : menu le moins cher (dichotomie)
+
+Le solveur Z3 (`MkSolver`) trouve une solution satisfaisante, mais pas forcement optimale. Pour trouver le menu **le moins cher**, nous utilisons une **recherche par dichotomie** :
+
+1. On fixe une borne superieure sur le cout
+2. On demande au solveur s'il existe un menu dans ce budget
+3. Si oui, on essaie un budget plus faible ; si non, on augmente
+4. On répète jusqu'a trouver le minimum exact
+
+Cette technique (binary search on objective) est un pattern classique en optimisation par solveur SAT/SMT.",,,,,,,,a349b621cae98e77,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,7ecc5cb4,code,fr,5630c90bb3942269,"// Optimisation : trouver le menu équilibré le MOINS CHER
+// On utilisé le solver avec exploration itérative : on ajoute une contrainte
+// de cout de plus en plus strict jusqu'a ce que le probleme devienne UNSAT
+
+using (var z3ctx = new Context())
+{
+    var solver = z3ctx.MkSolver();
+    
+    // Variables booléennes
+    var selections = foodDatabase
+        .Select((food, i) => new { Food = food, Var = (BoolExpr)z3ctx.MkConst($""sel_{i}_{food.Name}"", z3ctx.BoolSort) })
+        .ToList();
+    
+    // Exactement 1 par catégorie
+    var entreeVars = selections.Where(s => s.Food.Category == ""entree"").Select(s => (BoolExpr)s.Var).ToArray();
+    solver.Add(z3ctx.MkOr(entreeVars));
+    foreach (var v1 in entreeVars)
+        foreach (var v2 in entreeVars)
+            if (!v1.Equals(v2))
+                solver.Add(z3ctx.MkImplies(v1, z3ctx.MkNot(v2)));
+    
+    var platVars = selections.Where(s => s.Food.Category == ""plat"").Select(s => (BoolExpr)s.Var).ToArray();
+    solver.Add(z3ctx.MkOr(platVars));
+    foreach (var v1 in platVars)
+        foreach (var v2 in platVars)
+            if (!v1.Equals(v2))
+                solver.Add(z3ctx.MkImplies(v1, z3ctx.MkNot(v2)));
+    
+    var dessertVars = selections.Where(s => s.Food.Category == ""dessert"").Select(s => (BoolExpr)s.Var).ToArray();
+    solver.Add(z3ctx.MkOr(dessertVars));
+    foreach (var v1 in dessertVars)
+        foreach (var v2 in dessertVars)
+            if (!v1.Equals(v2))
+                solver.Add(z3ctx.MkImplies(v1, z3ctx.MkNot(v2)));
+    
+    // Contraintes nutritionnelles
+    IntExpr totalCal = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0), 
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Food.Calories), z3ctx.MkInt(0))));
+    IntExpr totalProt = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0), 
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Food.Protein), z3ctx.MkInt(0))));
+    IntExpr totalCost = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0), 
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Food.Cost), z3ctx.MkInt(0))));
+    
+    solver.Add(z3ctx.MkGe(totalCal, z3ctx.MkInt(600)));
+    solver.Add(z3ctx.MkLe(totalCal, z3ctx.MkInt(900)));
+    solver.Add(z3ctx.MkGe(totalProt, z3ctx.MkInt(25)));
+    solver.Add(z3ctx.MkLe(totalCost, z3ctx.MkInt(1200)));
+    
+    // Recherche du cout minimum par dichotomie
+    int lo = 0, hi = 1200, bestCost = -1;
+    Status bestResult = Status.UNSATISFIABLE;
+    
+    while (lo <= hi)
+    {
+        solver.Push();
+        int mid = (lo + hi) / 2;
+        solver.Add(z3ctx.MkLe(totalCost, z3ctx.MkInt(mid)));
+        var r = solver.Check();
+        solver.Pop();
+        
+        if (r == Status.SATISFIABLE)
+        {
+            bestCost = mid;
+            bestResult = r;
+            hi = mid - 1;  // essayer moins cher
+        }
+        else
+        {
+            lo = mid + 1;  // besoin de plus de budget
+        }
+    }
+    
+    // Résoudre avec le meilleur cout trouve
+    solver.Add(z3ctx.MkLe(totalCost, z3ctx.MkInt(bestCost)));
+    var result = solver.Check();
+    Console.WriteLine($""Optimisation (dichotomie) : cout minimum = {bestCost/100.0:F2} EUR, résultat = {result}"");
+    
+    if (result == Status.SATISFIABLE)
+    {
+        var model = solver.Model;
+        Console.WriteLine(""\nMenu optimal (cout minimum) :"");
+        int cal = 0, prot = 0, cost = 0;
+        foreach (var s in selections)
+        {
+            var val = model.Eval(s.Var, true);
+            if (val.BoolValue == Z3_lbool.Z3_L_TRUE)
+            {
+                Console.WriteLine($""  [{s.Food.Category}] {s.Food.Name} : {s.Food.Calories} kcal, {s.Food.Protein}g prot, {s.Food.Cost/100.0:F2} EUR"");
+                cal += s.Food.Calories;
+                prot += s.Food.Protein;
+                cost += s.Food.Cost;
+            }
+        }
+        Console.WriteLine($""  === Total : {cal} kcal, {prot}g proteines, {cost/100.0:F2} EUR ==="");
+    }
+    else
+    {
+        Console.WriteLine(""Aucun menu optimal trouve."");
+    }
+}",,,,,,,,5630c90bb3942269,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,a8eb812f,markdown,fr,d54c0ac53b881b9a,"#### Interpretation
+
+La **dichotomie sur le cout** est un pattern classique en optimisation SAT/SMT. Plutôt que d'utiliser `MkOptimizer` (qui peut etre instable dans certains bindings), on utilisé `solver.Push()`/`solver.Pop()` pour tester différentes bornes de cout sans reconstruire le solver a chaque fois.
+
+| Aspect | Solve simple | Dichotomie |
+|--------|-------------|------------|
+| Objectif | Première solution | Solution optimale |
+| Cout | Arbitraire | Minimum garanti |
+| Appels solver | 1 | O(log(budget_max)) |
+| Stabilite | Toujours | Toujours |",,,,,,,,d54c0ac53b881b9a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,4c704316,markdown,fr,5b3f0d7233ff4a52,"---
+
+### 7. Théorème hiérarchique : plan hebdomadaire en `int[][]`
+
+Jusqu'ici, nous avons manipulé des variables **plates** : des index isolés (section 3) ou un booléen par aliment (section 5). Pour planifier **plusieurs repas simultanément** — un plan sur N jours —, l'abstraction naturelle est un **tableau imbriqué** : une ligne par jour, une colonne par créneau (entrée, plat, dessert). C'est précisément ce que le fork `Z3.Linq` résout via le **théorème hiérarchique** sur `int[][]`.
+
+Le même mécanisme qui résout une grille de Sudoku (`Cells[i][j]`, notebook 05) structure ici un plan de repas `Plan[jour][créneau]`. Les contraintes **structurelles** — catégorie imposée par créneau, non-répétition entre jours, montée en gamme — s'expriment en **pur LINQ**, sans descendre dans le Microsoft.Z3 brut.
+
+#### Modèle
+
+```
+Plan[0] = [entrée_j1, plat_j1, dessert_j1]   (indices dans foodDatabase)
+Plan[1] = [entrée_j2, plat_j2, dessert_j2]
+Plan[2] = [entrée_j3, plat_j3, dessert_j3]
+```
+
+Chaque cellule est un **entier = index d'un aliment**. Les aliments étant groupés par catégorie dans `foodDatabase` (entrées, puis plats, puis desserts), on impose des **bornes d'index** par créneau pour forcer la bonne catégorie.
+
+La cellule ci-dessous résout **deux variantes** du même modèle, pour exercer pleinement le moteur (cf. section 7.1 pour l'analyse) :
+
+- **Variante A — montée en gamme** : plats d'index strictement croissant sur la semaine, desserts non répétés d'un jour à l'autre (mode `Array` implicite).
+- **Variante B — permutation totale** : chaque colonne (entrées, plats, desserts) est servie *sans répétition* via `Z3Methods.Distinct`, en déclarant explicitement `CollectionHandling.Array`.
+",,,,,,,,5b3f0d7233ff4a52,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,90bea1fd,code,fr,adca761136e22a25,"// Théorème hiérarchique : plan de repas sur 3 jours, modélisé comme int[][] (jours x créneaux).
+// Plan[j][0] = index de l'entrée, Plan[j][1] = index du plat, Plan[j][2] = index du dessert.
+// foodDatabase est groupé par catégorie -> on calcule les bornes d'index de chaque catégorie.
+
+public class WeeklyPlan
+{
+    public int[][] Plan { get; set; } = new int[3][];
+    public WeeklyPlan() { for (int i = 0; i < 3; i++) Plan[i] = new int[3]; }
+}
+
+// Bornes d'index par catégorie (calculées depuis la base, pas codées en dur)
+int entLo = foodDatabase.FindIndex(f => f.Category == ""entree"");
+int entHi = foodDatabase.FindLastIndex(f => f.Category == ""entree"");
+int pltLo = foodDatabase.FindIndex(f => f.Category == ""plat"");
+int pltHi = foodDatabase.FindLastIndex(f => f.Category == ""plat"");
+int desLo = foodDatabase.FindIndex(f => f.Category == ""dessert"");
+int desHi = foodDatabase.FindLastIndex(f => f.Category == ""dessert"");
+Console.WriteLine($""Catégories -> entrées [{entLo},{entHi}], plats [{pltLo},{pltHi}], desserts [{desLo},{desHi}]"");
+
+// Contrainte de catégorie par créneau, factorisée (réutilisée par les deux variantes ci-dessous).
+Theorem<WeeklyPlan> WithCategoryBounds(Z3Context ctx)
+{
+    var t = ctx.NewTheorem<WeeklyPlan>();
+    for (int j = 0; j < 3; j++)
+    {
+        int jj = j;
+        t = t.Where(p => p.Plan[jj][0] >= entLo && p.Plan[jj][0] <= entHi);
+        t = t.Where(p => p.Plan[jj][1] >= pltLo && p.Plan[jj][1] <= pltHi);
+        t = t.Where(p => p.Plan[jj][2] >= desLo && p.Plan[jj][2] <= desHi);
+    }
+    return t;
+}
+
+void PrintPlan(WeeklyPlan plan)
+{
+    for (int j = 0; j < 3; j++)
+    {
+        var e = foodDatabase[plan.Plan[j][0]];
+        var pl = foodDatabase[plan.Plan[j][1]];
+        var d = foodDatabase[plan.Plan[j][2]];
+        Console.WriteLine($""Jour {j+1} : {e.Name,-18} | {pl.Name,-18} | {d.Name,-20}"");
+        Console.WriteLine($""        {e.Calories,3} + {pl.Calories,3} + {d.Calories,3} = {e.Calories+pl.Calories+d.Calories,3} kcal   ({e.Cost+pl.Cost+d.Cost,4} centimes)"");
+    }
+}
+
+// --- Variante A : montée en gamme (mode Array implicite, défaut) ---
+using (var ctx = new Z3Context())
+{
+    var theorem = WithCategoryBounds(ctx);
+
+    // Montée en gamme : plats strictement croissants sur la semaine (permutation ordonnée).
+    theorem = theorem.Where(p => p.Plan[0][1] < p.Plan[1][1]);
+    theorem = theorem.Where(p => p.Plan[1][1] < p.Plan[2][1]);
+
+    // Diversité : pas le même dessert deux jours d'affilée.
+    theorem = theorem.Where(p => p.Plan[0][2] != p.Plan[1][2]);
+    theorem = theorem.Where(p => p.Plan[1][2] != p.Plan[2][2]);
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+    var plan = theorem.Solve();
+    sw.Stop();
+
+    Console.WriteLine($""\n[A] Montée en gamme (mode Array implicite) résolue en pur LINQ int[][] : {sw.Elapsed.TotalMilliseconds:F1} ms\n"");
+    PrintPlan(plan);
+}
+
+// --- Variante B : permutation totale (mode CollectionHandling.Array EXPLICITE, Distinct cross-row) ---
+using (var ctxPerm = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array })
+{
+    var perm = WithCategoryBounds(ctxPerm);
+
+    // Permutation totale : chaque colonne (créneau) est servie sans répétition sur la semaine.
+    // Z3Methods.Distinct s'applique directement aux accès cross-row d'un int[][] (même marqueur que les
+    // colonnes d'un Sudoku, notebook 04) -> contrainte globale SMT, pas une expansion manuelle en paires.
+    perm = perm.Where(p => Z3Methods.Distinct(p.Plan[0][0], p.Plan[1][0], p.Plan[2][0])); // entrées distinctes
+    perm = perm.Where(p => Z3Methods.Distinct(p.Plan[0][1], p.Plan[1][1], p.Plan[2][1])); // plats distincts
+    perm = perm.Where(p => Z3Methods.Distinct(p.Plan[0][2], p.Plan[1][2], p.Plan[2][2])); // desserts distincts
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+    var planPerm = perm.Solve();
+    sw.Stop();
+
+    Console.WriteLine($""\n[B] Permutation totale (mode Array explicite, Distinct cross-row) résolue en : {sw.Elapsed.TotalMilliseconds:F1} ms\n"");
+    PrintPlan(planPerm);
+}
+",,,,,,,,adca761136e22a25,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,56bdbe18,markdown,fr,d921264fc03219c3,"#### Interpretation — le domaine d'élégance du théorème hiérarchique
+
+Le plan hebdomadaire est résolu en **pur LINQ** sur `int[][]` : **zéro** appel à `MkSolver`/`MkITE`/`MkOr`. C'est l'aboutissement du notebook — la même API qui résout une grille de Sudoku (notebook 05) structure un plan de repas multi-jours. Les trois familles de contraintes ci-dessous sont toutes **linéaires sur les valeurs d'index**, donc natives en LINQ :
+
+| Contrainte | Expression LINQ | Nature |
+|------------|-----------------|--------|
+| Catégorie par créneau | `p.Plan[j][k] >= lo && p.Plan[j][k] <= hi` | Bornes linéaires |
+| Montée en gamme (plats) | `p.Plan[0][1] < p.Plan[1][1]` | Ordre strict |
+| Diversité (desserts) | `p.Plan[j][2] != p.Plan[j+1][2]` | Inégalité |
+
+**Frontière honnête.** Ces contraintes portent sur la *position* des choix (les index eux-mêmes). Dès qu'on veut pondérer par un **attribut** de l'aliment — `foodDatabase[index].Calories`, un *lookup* — l'expression devient **non-linéaire** et le pur LINQ ne suffit plus. C'est exactement ce qui justifie les sections 4 à 6 (`MkITE`, énumération, dichotomie) : aucune approche n'est « meilleure » dans l'absolu, chacune a son domaine.
+
+**Leçon SMT.** Le choix de modélisation se décide sur la *nature des contraintes* :
+
+- **Structurelles** (portent sur la position/valeur des choix) → `int[][]` LINQ, concis et lisible.
+- **Pondérées** (portent sur des attributs externes des choix) → `BoolExpr` + `MkITE`.
+
+> **Corpus RecipeML + table Ciqual.** Notre `foodDatabase` compte 10 aliments — un sous-ensemble pédagogique. À l'échelle, le catalogue se construirait par **fusion de deux sources** — exactement le geste de la section 5 : **RecipeML** (standard XML de milliers de recettes) fournit la composition de chaque plat *avec les quantités* d'ingrédients — ce qui manquait, justement, aux menus de cantine bruts ; la **table Ciqual** (base de composition nutritionnelle de l'ANSES) donne, pour chaque ingrédient, ses valeurs pour 100 g. On joint les deux — quantité × composition, agrégé par recette — pour reconstituer les `Calories`/`Protein`/… de chaque plat. Sur ce volume, le solveur Z3 explore l'espace intelligemment là où l'énumération de la section 4 (coût O(n³) ici) deviendrait infaisable : un argument de plus pour la modélisation déclarative.",,,,,,,,d921264fc03219c3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,c3e73fad,markdown,fr,57d3d506301e167e,"#### 7.1 Permutation totale & mode `CollectionHandling.Array` explicite
+
+La cellule ci-dessus résout **deux variantes** du même théorème hiérarchique `int[][]` :
+
+| Aspect | Variante A (montée en gamme) | Variante B (permutation totale) |
+|--------|------------------------------|---------------------------------|
+| Plats | `Plan[j][1] < Plan[j+1][1]` (ordre strict croissant) | `Z3Methods.Distinct(Plan[0][1], Plan[1][1], Plan[2][1])` |
+| Entrées / desserts | desserts : `!=` consécutifs | les trois colonnes : `Distinct` (toute permutation) |
+| `Z3Context` | `new Z3Context()` (mode `Array` **implicite**) | `new Z3Context { DefaultCollectionHandling = CollectionHandling.Array }` (**explicite**) |
+
+**`Z3Methods.Distinct` fonctionne nativement en cross-row sur `int[][]`.** C'est le **même** marqueur LINQ que les colonnes/lignes d'un Sudoku (notebook 05) et les transitions du problème 3M/3C (notebook 04). En mode `Array`, l'accès `p.Plan[i][c]` se traduit par un `Select` imbriqué (`Select(Select(Plan, i), c)`) et `Distinct(...)` génère une seule contrainte globale `(distinct …)` — **pas** une expansion manuelle en paires `!=`. La variante B le prouve : les trois colonnes du plan sont des permutations de `{0,1,2}` (entrées), `{3,4,5,6}` (plats) et `{7,8,9}` (desserts).
+
+**Permutation totale vs montée en gamme.** La montée en gamme impose un ordre (index croissant) et implique *automatiquement* la distinction ; c'est plus contraint. La permutation totale est plus souple : n'importe quel ordre convient, la seule exigence étant que chaque aliment ne revienne pas dans sa colonne sur la semaine.
+
+**Mode `Array` explicite — symétrie avec la section 9.** Déclarer `DefaultCollectionHandling = CollectionHandling.Array` rend visible ce que la section 7 utilisait implicitement : les deux contextes sont identiques (le mode `Array` est le défaut). La section 9 démontrera la même enum sur un `Plate` **1D** (`int[]`) et comparera `Array` vs `Constants` ; ici on confirme que le DSL modélise `int[][]` comme des `ArrayExpr` Z3 imbriqués à **tous** les niveaux hiérarchiques.
+
+> **Note (.NET Interactive — submissions et capture).** Le kernel .NET Interactive compile chaque cellule en une classe `Submission#N` distincte. Une contrainte Z3.Linq qui capture une variable hôte (ici les bornes `entLo`, `entHi`, …) voit le visiteur d'expressions résoudre cette capture par réflexion sur l'objet *closure*. Historiquement, capturer une variable top-level déclarée dans une **autre** cellule levait un `ArgumentException` (le champ de la *closure* n'était pas trouvé sur la submission du `Solve()`) ; aussi les deux variantes vivent-elles ici dans **une seule cellule**. **Ce blocage est désormais résolu** : le fix fork `AssertConstraints` (PR `MyIntelligenceAgency/Z3.Linq`#3, partial-eval du corps de contrainte avant visite) replie les constantes capturées en littéraux, ce qui rend la capture cross-cell fonctionnelle — les tests xUnit du fork enchaînent plusieurs `Solve` sur `int[][]` sans souci. La **même cellule reste néanmoins le pattern recommandé** pour un notebook lisible et autonome.",,,,,,,,57d3d506301e167e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,aa1302aa,markdown,fr,95015351d812bfed,"### 8. Tableau récapitulatif des approches
+
+| Approche | Technique | Avantage | Limite |
+|----------|-----------|----------|--------|
+| Index Z3.Linq | `Symbols<int,int,int>` | Syntaxe LINQ naturelle | Contraintes index-only |
+| Énumération | Boucles C# + filtres | Simple à comprendre | Pas scalable (O(n³)) |
+| Booléenne Z3 | `BoolExpr` + `MkITE` | Data fusion native | Syntaxe bas niveau |
+| Dichotomie | `Push/Pop` + binary search | Optimisation stable | O(log n) appels solver |
+| **Hiérarchique `int[][]`** | `NewTheorem<WeeklyPlan>` + ordre strict `<` | **Structure pure LINQ, 2D** | Contraintes linéaires seulement |
+| **Permutation hiérarchique** | `CollectionHandling.Array` + `Z3Methods.Distinct` | **Contrainte globale SMT, mode explicite** | Contraintes linéaires seulement |",,,,,,,,95015351d812bfed,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,46e98e84,markdown,fr,38b9c4bc35f2e1c9,"### 9. La feature ressuscitée : `CollectionHandling` (mode Array vs Constants)
+
+Jusqu'ici, ce notebook utilisait le fork `Z3.Linq` charge depuis NuGet. Depuis le **14/06/2026**, le fork embarque une enum `CollectionHandling` qui était **définie mais jamais câblée** (dead code). Elle est désormais **vivante** : le même code LINQ peut résoudre un CSP en modélisant les collections de deux façons différentes.
+
+| Mode | Modélisation Z3 | Avantage pédagogique |
+|------|----------------|----------------------|
+| **`Array`** (défaut) | Une seule `ArrayExpr` Z3 + `Select`/`Store` (théorie des tableaux) | Compact, supporte les index symboliques |
+| **`Constants`** | Un constant Z3 par element (`TotalCal_0`, `TotalCal_1`, ...) | « un symbole = une inconnue », lisible dans le modèle |
+
+Pour illustrer concretement, modelisons une **assiette de 3 plats** (entree, plat, dessert) comme un `int[]` de couts, et resolvons un mini-théorème dans les **deux modes** avec le **même** code. C'est la preuve que `CollectionHandling` est fonctionnelle bout-en-bout.",,,,,,,,38b9c4bc35f2e1c9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,b6203e70,code,fr,e8bd77e5519f8d7c,"// Demonstration CollectionHandling : un même théorème résolu en mode Array puis Constants.
+// Plate = assiette de 3 couts (entree, plat, dessert). On impose : chaque cout dans [100, 800],
+// et les 3 couts distincts (un menu varie ne repet pas le même prix).
+
+public class Plate
+{
+    public int[] Costs { get; set; } = new int[3];
+}
+
+public static Theorem<Plate> BuildPlate(Z3Context ctx)
+{
+    var t = ctx.NewTheorem<Plate>();
+    for (int i = 0; i < 3; i++)
+    {
+        int i1 = i;
+        t = t.Where(p => p.Costs[i1] >= 100 && p.Costs[i1] <= 800);
+    }
+    // 3 couts distincts = menu varie
+    t = t.Where(p => Z3Methods.Distinct(p.Costs[0], p.Costs[1], p.Costs[2]));
+    return t;
+}
+
+var ctxArray = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array };
+var ctxConst = new Z3Context { DefaultCollectionHandling = CollectionHandling.Constants };
+
+Console.WriteLine($""Mode Array     : {ctxArray.DefaultCollectionHandling}"");
+Console.WriteLine($""Mode Constants : {ctxConst.DefaultCollectionHandling}"");
+
+var solArray = BuildPlate(ctxArray).Solve();
+var solConst = BuildPlate(ctxConst).Solve();
+
+Console.WriteLine(""\nSolution (mode Array)     : "" + string.Join("", "", solArray.Costs));
+Console.WriteLine(""Solution (mode Constants) : "" + string.Join("", "", solConst.Costs));",,,,,,,,e8bd77e5519f8d7c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,800c9569,markdown,fr,4da90231fbe25dec,"#### Interpretation — dead code ressuscite
+
+Le **même** code `BuildPlate` résout le CSP dans les deux modes. La seule différence est la configuration du `Z3Context` :
+
+- **Mode Array** : `Cells`/`Costs` est une seule `ArrayExpr` Z3. L'acces `Costs[i]` genere un `Select(arr, i)`. Compact.
+- **Mode Constants** : chaque element `Costs[i]` est un constant Z3 nomme (`Costs_0`, `Costs_1`, `Costs_2`). Si on inspectait le modèle Z3, on verrait ces 3 symboles explicites = modèle « humain ».
+
+| Aspect | Array | Constants |
+|--------|-------|-----------|
+| Symboles Z3 créés | 1 (l'array) | N (1 par element) |
+| Index symbolique | supporte | non (taille fixe) |
+| Lisibilite modèle | - | « un symbole = une inconnue » |
+
+C'est la preuve directe que l'enum `CollectionHandling` — historiquement du dead code défini mais jamais câble — est désormais **fonctionnelle bout-en-bout** (construction d'environnement → visite des contraintes → extraction du modèle) dans les deux modes.",,,,,,,,4da90231fbe25dec,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,df2afa5c,markdown,fr,00e0f47f6e17c1cd,"---
+
+## Partie B — Couplage hebdomadaire : fenetre nutritionnelle par jour et variete globale
+
+### Objectifs d'apprentissage
+
+- Modéliser un **plan de repas sur toute une semaine** comme une **matrice booléenne `int[][]`** (jours × plats), et comprendre pourquoi ce modèle diffère de la grille d'index du [notebook 06 §7](06_Meal_Planner_Modelisation.ipynb).
+- Exprimer une **fenêtre nutritionnelle par jour** (somme des kcal des plats choisis ce jour ∈ `[min, max]`) — le chaînon manquant entre la nutrition (`MkITE`, Partie A §5) et le plan multi-jours (`int[][]`, Partie A §7).
+- Imposer une **variété globale** : aucun plat servi plus d'une fois dans la semaine.
+- Démontrer pourquoi un **remplissage glouton** (« *greedy* ») jour par jour **se bloque** sur ce couplage, alors que le solveur SMT trouve une affectation globalement cohérente en quelques millisecondes.
+
+### Prérequis
+
+- [Notebook 05](05_Nested_Arrays_2D.ipynb) : tableaux imbriqués `int[][]`, `Theorem<Grid>`.
+- **Partie A §5** : variables booléennes de sélection + agrégation conditionnelle.
+- **Partie A §7** : plan hebdomadaire en grille d'index (le modèle complémentaire de celui-ci).
+- **Partie A §7** (non-repetition `Distinct` sur `int[][]`) : non-répétition `Z3Methods.Distinct` sur `int[][]`.",,,,,,,,00e0f47f6e17c1cd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,d4de98aa,markdown,fr,f2deed162fae82fa,"---
+
+### 1. Le corpus de plats
+
+Contrairement au notebook de données 07 (corpus RecipeML x Ciqual chargé et matché), nous définissons ici un corpus **inline** plus large (18 plats) pour rendre la combinatoire **non triviale** (Prong-B). Chaque plat a une catégorie (`breakfast` / `lunch` / `dinner`), un apport calorique, une teneur en protéines et un coût.
+
+> **Convention d'indices** (fixe pour ce notebook) : `breakfast` = indices `[0, 5]`, `lunch` = `[6, 11]`, `dinner` = `[12, 17]`. Les sommes des contraintes ci-dessous sont écrites explicitement sur ces plages — le DSL Z3.Linq exige des expressions linéaires **inline**, il ne suit pas les appels de méthode.",,,,,,,,f2deed162fae82fa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,e4122754,code,fr,ecb379771849fd9b,"// Corpus inline : 18 plats repartis en 3 categories, apports kcal/proteines/cout varies.
+public class Dish
+{
+    public string Name { get; set; }
+    public string Category { get; set; }   // breakfast | lunch | dinner
+    public int Kcal { get; set; }
+    public int Protein { get; set; }        // grammes
+    public int CostCents { get; set; }      // centimes d'EUR
+    public override string ToString() => $""{Name} [{Kcal}kcal, {Protein}g, {CostCents/100.0:F2}EUR]"";
+}
+
+var corpus = new List<Dish>
+{
+    // breakfast : indices 0-5, 300 a 550 kcal
+    new Dish { Name=""Porridge fruits rouges"", Category=""breakfast"", Kcal=300, Protein=12, CostCents=180 },
+    new Dish { Name=""Yaourt granola"",        Category=""breakfast"", Kcal=350, Protein=18, CostCents=220 },
+    new Dish { Name=""Oeufs brouilles"",       Category=""breakfast"", Kcal=400, Protein=22, CostCents=280 },
+    new Dish { Name=""Pancakes sirop"",        Category=""breakfast"", Kcal=450, Protein=10, CostCents=250 },
+    new Dish { Name=""Bowl acai"",             Category=""breakfast"", Kcal=500, Protein=14, CostCents=420 },
+    new Dish { Name=""English breakfast"",     Category=""breakfast"", Kcal=550, Protein=28, CostCents=550 },
+    // lunch : indices 6-11, 500 a 750 kcal
+    new Dish { Name=""Salade cesar"",          Category=""lunch"", Kcal=500, Protein=25, CostCents=650 },
+    new Dish { Name=""Wrap poulet"",           Category=""lunch"", Kcal=550, Protein=30, CostCents=580 },
+    new Dish { Name=""Quiche epinards"",       Category=""lunch"", Kcal=600, Protein=20, CostCents=520 },
+    new Dish { Name=""Buddha bowl"",           Category=""lunch"", Kcal=650, Protein=22, CostCents=700 },
+    new Dish { Name=""Burger vegetarien"",     Category=""lunch"", Kcal=700, Protein=26, CostCents=820 },
+    new Dish { Name=""Risotto champignons"",   Category=""lunch"", Kcal=750, Protein=18, CostCents=780 },
+    // dinner : indices 12-17, 600 a 850 kcal
+    new Dish { Name=""Soupe poisson pain"",    Category=""dinner"", Kcal=600, Protein=28, CostCents=450 },
+    new Dish { Name=""Pates pesto"",           Category=""dinner"", Kcal=650, Protein=20, CostCents=380 },
+    new Dish { Name=""Poulet roti legumes"",   Category=""dinner"", Kcal=700, Protein=42, CostCents=850 },
+    new Dish { Name=""Saumon riz"",            Category=""dinner"", Kcal=750, Protein=38, CostCents=980 },
+    new Dish { Name=""Curry tofu"",            Category=""dinner"", Kcal=800, Protein=30, CostCents=720 },
+    new Dish { Name=""Pizza margherita"",      Category=""dinner"", Kcal=850, Protein=32, CostCents=900 },
+};
+
+int N = corpus.Count;
+// Tableaux de valeurs constants (captures par le DSL, traites comme des litteraux a la construction de l'arbre).
+int[] kcalArr    = corpus.Select(d => d.Kcal).ToArray();
+int[] proteinArr = corpus.Select(d => d.Protein).ToArray();
+int[] costArr    = corpus.Select(d => d.CostCents).ToArray();
+Console.WriteLine($""Corpus : {N} plats | breakfast [0,5], lunch [6,11], dinner [12,17]"");",,,,,,,,ecb379771849fd9b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,71828abe,markdown,fr,9cb29e1c138fe73e,"---
+
+### 2. Le modèle : matrice booléenne jour × plat
+
+On planifie **`D = 5` jours** (lundi→vendredi). Pour chaque couple `(jour, plat)`, une variable `Sel[j][i] ∈ {0, 1}` vaut 1 si le plat `i` est servi le jour `j`. C'est une **matrice `D × N`** de booléens entiers.
+
+> **Pourquoi une matrice booléenne et non une grille d'index** (comme le `Plan[j][k]` de la Partie A §7) ? Parce que nous voulons **agréger les calories du jour** : `kcalDuJour(j) = somme sur i de (Sel[j][i] × kcal[i])`. L'expression `kcal[Plan[j][k]]` — indexer un tableau C# par une variable Z3 — **n'a pas de sens** à la résolution (l'indice est symbolique). En revanche, multiplier une sélection booléenne par une constante connue (`kcal[i]`) puis sommer est une expression **linéaire** que le solveur manipule directement.",,,,,,,,9cb29e1c138fe73e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,5aa2eb95,code,fr,72f0b4dfab31bd4c,"// Modele : matrice booleenne D x N. Sel[j][i] = 1 ssi le plat i est servi le jour j.
+int D = 5;            // lundi..vendredi
+int DAY_LO = 1500;    // fenetre kcal minimale par jour
+int DAY_HI = 1700;    // fenetre kcal maximale par jour
+
+public class WeekPlan
+{
+    public int[][] Sel { get; set; } = new int[5][];   // 5 jours x 18 plats
+    public WeekPlan() { for (int j = 0; j < 5; j++) Sel[j] = new int[18]; }
+}
+
+var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array };
+var th = ctx.NewTheorem<WeekPlan>();
+
+// (1) Domaine booleen : chaque cellule dans {0, 1}.
+for (int j = 0; j < D; j++)
+    for (int i = 0; i < N; i++)
+    {
+        int jj = j, ii = i;
+        th = th.Where(g => g.Sel[jj][ii] >= 0 && g.Sel[jj][ii] <= 1);
+    }
+
+// (2) Cardinalite par jour : exactement 1 breakfast + 1 lunch + 1 dinner (sommes inline sur les plages d'indices).
+for (int j = 0; j < D; j++)
+{
+    int jj = j;
+    th = th.Where(g => g.Sel[jj][0] + g.Sel[jj][1] + g.Sel[jj][2] + g.Sel[jj][3] + g.Sel[jj][4] + g.Sel[jj][5] == 1);   // 1 breakfast
+    th = th.Where(g => g.Sel[jj][6] + g.Sel[jj][7] + g.Sel[jj][8] + g.Sel[jj][9] + g.Sel[jj][10] + g.Sel[jj][11] == 1);   // 1 lunch
+    th = th.Where(g => g.Sel[jj][12] + g.Sel[jj][13] + g.Sel[jj][14] + g.Sel[jj][15] + g.Sel[jj][16] + g.Sel[jj][17] == 1);   // 1 dinner
+}
+Console.WriteLine($""Domaine booleen + cardinalite 1/categorie/jour poses (D={D} jours)."");",,,,,,,,72f0b4dfab31bd4c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,49bcce19,markdown,fr,58de19c5df58cbd0,"---
+
+### 3. Variété globale : aucun plat servi plus d'une fois
+
+On veut que **chaque plat apparaisse au plus une fois** dans la semaine entière. Pour le plat `i`, la somme de ses sélections sur les `D` jours est `≤ 1`. C'est l'équivalent « matriciel » du `Z3Methods.Distinct` de la Partie A §7, mais projeté sur chaque plat à travers tous les jours.",,,,,,,,58de19c5df58cbd0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,afa255f7,code,fr,5dd9008451bde724,"// (3) Variete globale : pour chaque plat i, sum_j Sel[j][i] <= 1 (au plus 1 fois dans la semaine).
+for (int i = 0; i < N; i++)
+{
+    int ii = i;
+    th = th.Where(g => g.Sel[0][ii] + g.Sel[1][ii] + g.Sel[2][ii] + g.Sel[3][ii] + g.Sel[4][ii] <= 1);
+}
+Console.WriteLine($""Variete globale posee : chacun des {N} plats <= 1x/semaine."");",,,,,,,,5dd9008451bde724,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,67325b68,markdown,fr,5e399a2eedf086af,"---
+
+### 4. La fenêtre nutritionnelle par jour (le chaînon manquant)
+
+C'est la contrainte qui transforme le problème : pour chaque jour `j`, la somme des calories des plats choisis doit tomber dans `[DAY_LO, DAY_HI]`. On l'écrit comme une **somme linéaire** de termes `Sel[j][i] × kcal[i]` — la même structure que l'agrégation `MkITE` du notebook 06 §5, mais projetée par jour sur la matrice multi-jours.
+
+| Concept | Partie A §5 (1 menu) | **Ce notebook (multi-jours)** |
+|---------|-------------------------|-------------------------------|
+| Sélection | `sel_i` (1 menu) | `Sel[j][i]` (matrice jour×plat) |
+| Agrégat nutritionnel | `sum_i MkITE(sel_i, kcal_i, 0)` | `sum_i Sel[j][i] × kcal_i` **par jour j** |
+| Fenêtre | 1 fenêtre globale | **1 fenêtre par jour** (D fenêtres couplées) |
+| Variété | (n/a) | `sum_j Sel[j][i] ≤ 1` (globale) |
+
+C'est cette multiplication des fenêtres couplées — `D` contraintes qui se partagent le même pool de plats via la variété — qui rend le glouton inopérant.",,,,,,,,5e399a2eedf086af,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,7765fb80,code,fr,876938620eca4129,"// (4) Fenetre kcal par jour : pour chaque jour j, sum_i Sel[j][i]*kcalArr[i] dans [DAY_LO, DAY_HI].
+for (int j = 0; j < D; j++)
+{
+    int jj = j;
+    th = th.Where(g => g.Sel[jj][0]*kcalArr[0] + g.Sel[jj][1]*kcalArr[1] + g.Sel[jj][2]*kcalArr[2] + g.Sel[jj][3]*kcalArr[3] + g.Sel[jj][4]*kcalArr[4] + g.Sel[jj][5]*kcalArr[5] + g.Sel[jj][6]*kcalArr[6] + g.Sel[jj][7]*kcalArr[7] + g.Sel[jj][8]*kcalArr[8] + g.Sel[jj][9]*kcalArr[9] + g.Sel[jj][10]*kcalArr[10] + g.Sel[jj][11]*kcalArr[11] + g.Sel[jj][12]*kcalArr[12] + g.Sel[jj][13]*kcalArr[13] + g.Sel[jj][14]*kcalArr[14] + g.Sel[jj][15]*kcalArr[15] + g.Sel[jj][16]*kcalArr[16] + g.Sel[jj][17]*kcalArr[17] >= DAY_LO);
+    th = th.Where(g => g.Sel[jj][0]*kcalArr[0] + g.Sel[jj][1]*kcalArr[1] + g.Sel[jj][2]*kcalArr[2] + g.Sel[jj][3]*kcalArr[3] + g.Sel[jj][4]*kcalArr[4] + g.Sel[jj][5]*kcalArr[5] + g.Sel[jj][6]*kcalArr[6] + g.Sel[jj][7]*kcalArr[7] + g.Sel[jj][8]*kcalArr[8] + g.Sel[jj][9]*kcalArr[9] + g.Sel[jj][10]*kcalArr[10] + g.Sel[jj][11]*kcalArr[11] + g.Sel[jj][12]*kcalArr[12] + g.Sel[jj][13]*kcalArr[13] + g.Sel[jj][14]*kcalArr[14] + g.Sel[jj][15]*kcalArr[15] + g.Sel[jj][16]*kcalArr[16] + g.Sel[jj][17]*kcalArr[17] <= DAY_HI);
+}
+Console.WriteLine($""Fenetre kcal/jour posee : [{DAY_LO}, {DAY_HI}] pour chacun des {D} jours."");
+
+// Resolution SMT globale.
+var sw = Stopwatch.StartNew();
+var plan = th.Solve();
+sw.Stop();
+
+Console.WriteLine($""\n=== Solution SMT (solve en {sw.Elapsed.TotalMilliseconds:F1} ms) ==="");
+for (int j = 0; j < D; j++)
+{
+    int kSum = 0; var picks = new List<string>();
+    for (int i = 0; i < N; i++)
+        if (plan.Sel[j][i] == 1) { kSum += kcalArr[i]; picks.Add($""{corpus[i].Name}({kcalArr[i]}k)""); }
+    bool inWin = kSum >= DAY_LO && kSum <= DAY_HI;
+    Console.WriteLine($""Jour {j+1} [{kSum} kcal, fenetre={inWin}] : {string.Join("" + "", picks)}"");
+}
+// Preuves post-resolution dans les sorties.
+bool allDaysInWindow = Enumerable.Range(0, D).All(j => {
+    int s = Enumerable.Range(0, N).Where(i => plan.Sel[j][i]==1).Sum(i => kcalArr[i]);
+    return s >= DAY_LO && s <= DAY_HI;
+});
+int totalDishes = Enumerable.Range(0, D).Sum(j => Enumerable.Range(0, N).Count(i => plan.Sel[j][i]==1));
+Console.WriteLine($""\nTous les jours dans la fenetre : {allDaysInWindow}"");
+Console.WriteLine($""Total plats servis : {totalDishes} (15 attendus = 5x3)"");",,,,,,,,876938620eca4129,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,24b03809,markdown,fr,bb217a455775b0f1,"---
+
+### 5. Pourquoi le glouton (*greedy*) se bloque
+
+Essayons l'approche la plus naïve : **remplir les jours l'un après l'autre**, en choisissant pour chaque jour le premier trio (breakfast+lunch+dinner) qui tombe dans la fenêtre, **sans jamais reconsidérer un choix passé**. C'est un algorithme glouton sans retour arrière.
+
+Le code ci-dessous tente exactement cela. Observez le résultat : il échoue à compléter le plan (un jour ne peut plus être rempli sans réutiliser un plat déjà consommé ni sortir de la fenêtre).",,,,,,,,bb217a455775b0f1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,99d2250d,code,fr,fe709b2c565c1862,"// Demo : glouton sans retour arriere. Remplit jour par jour avec le premier trio valide restant.
+// Montre que cette strategie LOCALE se bloque : la combinatoire couplant fenetre x variete est non compositionnelle.
+HashSet<int> usedSet = new HashSet<int>();
+var greedyPlan = new List<(int b, int l, int d)>();
+int failedAt = -1;
+for (int j = 0; j < D; j++)
+{
+    (int b, int l, int dd) choice = (-1, -1, -1); bool found = false;
+    for (int b = 0; b <= 5 && !found; b++)            // breakfast [0,5]
+    {
+        if (usedSet.Contains(b)) continue;
+        for (int l = 6; l <= 11 && !found; l++)       // lunch [6,11]
+        {
+            if (usedSet.Contains(l)) continue;
+            for (int dd = 12; dd <= 17 && !found; dd++)  // dinner [12,17]
+            {
+                if (usedSet.Contains(dd)) continue;
+                int tot = corpus[b].Kcal + corpus[l].Kcal + corpus[dd].Kcal;
+                if (tot >= DAY_LO && tot <= DAY_HI) { choice = (b, l, dd); found = true; }
+            }
+        }
+    }
+    if (!found) { failedAt = j + 1; break; }
+    usedSet.Add(choice.b); usedSet.Add(choice.l); usedSet.Add(choice.dd);
+    greedyPlan.Add(choice);
+}
+
+if (failedAt > 0)
+{
+    Console.WriteLine($""Glouton sans retour arriere : ECHEC au jour {failedAt}."");
+    Console.WriteLine(""  Aucun trio (breakfast+lunch+dinner) restant ne tombe dans la fenetre kcal."");
+    Console.WriteLine(""  Les plats aux bons apports caloriques ont deja ete consommes les jours precedents."");
+    Console.WriteLine($""  Jours remplis avant l'echec : {greedyPlan.Count}/{D}"");
+}
+else
+{
+    Console.WriteLine($""Glouton sans retour arriere : SUCCES sur ce corpus ({greedyPlan.Count}/{D} jours)."");
+    Console.WriteLine(""  La fenetre est assez large pour que l'ordre glouton tombe juste ici."");
+    Console.WriteLine(""  MAIS le couplage reste reel : resserrez [DAY_LO, DAY_HI] ou augmentez D, et le glouton"");
+    Console.WriteLine(""  se bloque la ou le solveur (section 6) continue de resoudre instantanement."");
+    foreach (var (b,l,dd) in greedyPlan)
+        Console.WriteLine($""    Jour: {corpus[b].Name} + {corpus[l].Name} + {corpus[dd].Name} = {corpus[b].Kcal+corpus[l].Kcal+corpus[dd].Kcal} kcal"");
+}
+Console.WriteLine($""\nContraste : le SMT a resolu le MEME probleme globalement en quelques ms (section 6),"");
+Console.WriteLine(""tandis que le glouton local est fragile. C'est la signature d'un CSP couple non trivial (Prong-B)."");",,,,,,,,fe709b2c565c1862,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,173fe76b,markdown,fr,ee61937885f2d442,"---
+
+### 6. Interprétation : déclaratif vs glouton sur un CSP couplé
+
+| Aspect | Glouton sans retour | Solveur SMT |
+|--------|---------------------|-------------|
+| **Stratégie** | Remplit jour par jour, premier trio valide | Propage toutes les contraintes globalement |
+| **Couplage fenêtre × variété** | Ignoré (décisions locales) | Exploité (propagation arrière) |
+| **Issue** | Fragile / se bloque dès qu'on resserre | Solution complète en ~100 ms |
+| **Coût** | Exponentiel si on ajoute du backtracking | Polynomial par propagation de contraintes |
+
+**Leçon** : la valeur d'un solveur déclaratif ne se voit pas sur un problème à un seul jour (le glouton y suffit). Elle apparaît dès que **plusieurs contraintes se partagent un même pool de ressources** (les plats) à travers **plusieurs dimensions** (les jours). C'est exactement le couplage qui rend l'ordonnancement, l'emploi du temps et la planification réels difficiles — et que le paradigme déclaratif absorbe sans changement d'approche.",,,,,,,,ee61937885f2d442,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,0c907fd0,markdown,fr,5fa292b76fbc2ed8,"---
+
+## Partie C — Visualisation HTML des solutions Z3
+
+### Objectifs d'apprentissage
+
+- Comprendre **pourquoi** le rendu d'une solution Z3 importe autant que sa résolution : un solveur n'a de valeur opérationnelle que si ses sorties sont **lisibles par un humain**
+- Utiliser l'API `display(HTML(...))` de `Microsoft.DotNet.Interactive` pour produire des **cartes HTML** (tableaux colorés, badges, barres de progression) depuis un modèle C#
+- Réutiliser les modèles des **Parties A-B** (sélection booléenne, plan `int[][]`) et **n'en changer que la couche de présentation** — le solveur reste identique
+- Produire un **front de Pareto** rendu visuellement : le solveur explore l'espace des solutions sous plusieurs bornes de budget, et le résultat est rendu comme un tableau de compromis
+
+### Prérequis
+
+- **Partie A** : pattern `int[][]`, `MkITE`, `CollectionHandling.Array`
+- **Partie A** : modèle booléen `MkITE`, théorème hiérarchique `int[][]` ; corpus RecipeML détaillé dans le notebook de données 07
+- Concepts : `XDocument`, interpolation de chaînes C#, HTML/CSS inline
+
+**Durée estimée** : 40-50 minutes",,,,,,,,5fa292b76fbc2ed8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,4feb813b,markdown,fr,ad46c1e8b1066544,"#### Vue d'ensemble : du modele Z3 a la carte lisible par un humain
+
+```mermaid
+flowchart LR
+    Z[""Solveur Z3\n(modele Parties A-B inchange)""]
+    Z --> M[""Solution brute\nbool de selection, plan int de int""]
+    M --> P[""Couche de presentation C#\n(seule partie qui change)""]
+    P --> H[""display(HTML(...))\nMicrosoft.DotNet.Interactive""]
+    H --> R[""Cartes HTML\ntableaux colores, badges,\nbarres de progression""]
+    style P fill:#c8f7c5
+    style R fill:#c8f7c5
+    style Z fill:#cfe3ff
+```
+
+Le **solveur reste identique** a celui des Parties A-B ; seule la **couche de presentation** (en vert)
+change. L'idee cle : une solution Z3 n'a de valeur operationnelle que si elle est **lisible par un humain** —
+le rendu HTML transforme une assignation brute en carte de menu interpretable.",,,,,,,,ad46c1e8b1066544,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,intro-gap,markdown,fr,c6c94d5e8ed13972,"---
+
+### Introduction : la frontière solveur / communication
+
+Les Parties A et B affichaient leurs solutions via `Console.WriteLine` sous forme de **tableaux plats alignés par espaces**. Cette représentation suffit pour debugger ou vérifier un résultat à l'écran d'un développeur. Mais en production — un menu affiché à un utilisateur, un planning imprimé, un rapport envoyé à un diététicien — **la sortie texte brute est inutilisable** :
+
+- Impossible de distinguer au premier coup d'œil une recette qui dépasse le budget d'une qui le respecte
+- Aucune signalétique visuelle pour les allergènes (pourtant critique pour la santé)
+- Aucune barre ni jauge pour comparer des quantités (calories, protéines, coût)
+- Pas de mise en page pour un plan multi-jours (lignes vs colonnes)
+
+Ce notebook introduit la brique qui manque : un **rendu HTML structuré et coloré** de la solution Z3. Le principe est simple — l'API `display(HTML(htmlString))` de `Microsoft.DotNet.Interactive` accepte n'importe quelle chaîne HTML et la rend comme une cellule `text/html` riche. On construit cette chaîne en C# pur (interpolation `$""...""` ou `StringBuilder`), en injectant les valeurs issues du modèle Z3.
+
+#### Ce que ce notebook démontre
+
+1. **Couplage faible solveur / rendu** (section 3) — on reprend *exactement* le modèle booléen de la Partie A §5 et on ne change **que la dernière ligne** : `display(HTML(RenderMenuCard(...)))` à la place de `Console.WriteLine`. Le solveur ne sait même pas qu'il est rendu en HTML.
+2. **Plan multi-jours rendu en grille** (section 4) — le `int[][]` de la Partie A §7 est projeté en une grille HTML 7 colonnes (jours en lignes), avec **détection visuelle des répétitions**.
+3. **Exploration de l'espace des solutions rendue visible** (section 5) — on lance le solveur sous une **série de budgets** (800 à 2000 centimes) et on rend le **front de Pareto kcal/coût** sous forme de tableau de compromis. C'est une montée en gamme (EPIC #3801 Prong-B) : un seul solve n'illustre pas la richesse du moteur ; une exploration paramétrique oui.
+
+> **Note technique** : `display` et `HTML` sont des helpers globaux de `Microsoft.DotNet.Interactive`. Ils ne nécessitent pas de `using` spécifique, mais on ajoutera `using Microsoft.DotNet.Interactive;` par sécurité.",,,,,,,,c6c94d5e8ed13972,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec1-title,markdown,fr,e5b6bd93530ea37b,"---
+
+### 1. Corpus RecipeML et classe de domaine
+
+On réutilise un **corpus 7-recettes inline** (même esprit que le notebook de données 07) (entrées / plats / desserts avec un mix pédagogique de coûts, protéines, allergènes). Pour éviter le piège du **verbatim string C#** (les guillemets XML doivent être doublés dans `@""...""`, sous peine de CS1003/CS1010), on construit la chaîne XML via un `StringBuilder`. Plus sûr, même résultat.
+
+La classe `Recipe` locale expose le rendu HTML consommera exactement les mêmes propriétés (`Kcal`, `Protein`, `CostCents`, `Allergens`).",,,,,,,,e5b6bd93530ea37b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec1-corpus,code,fr,d1744be8e2ea73e9,"// Construction du corpus XML via StringBuilder (evite le piege du verbatim string @""..."",
+// ou chaque guillemet XML devrait etre double sous peine de CS1003/CS1010).
+var sb = new StringBuilder();
+sb.Append(""<recipeml>"");
+Action<string, string, int, int, int, int, int, int, string, int> add =
+    (name, cat, kcal, prot, carbs, fat, cost, prep, allerg, idx) =>
+    {
+        sb.Append($""<recipe><head><title>{name}</title><category>{cat}</category></head>"");
+        sb.Append($""<nutrition kcal=\""{kcal}\"" protein=\""{prot}\"" carbs=\""{carbs}\"" fat=\""{fat}\""/>"");
+        sb.Append($""<prep time=\""{prep}\""/>"");
+        sb.Append($""<ingredients>(corpus inline)</ingredients>"");
+        sb.Append($""<allergens>{allerg}</allergens>"");
+        sb.Append($""<cost currency=\""EUR\"">{cost}</cost></recipe>"");
+    };
+add(""Salade de quinoa"",     ""entree"",  180,  6, 24,  6, 280, 15, ""none"",                0);
+add(""Veloute de potiron"",   ""entree"",  120,  4, 18,  3, 220, 20, ""lactose"",             1);
+add(""Poulet roti aux herbes"",""plat"",   520, 45,  8, 32, 850, 60, ""none"",                2);
+add(""Lasagnes bolognaise"",  ""plat"",    610, 28, 55, 30, 720, 75, ""gluten,lactose"",      3);
+add(""Tofu curry coco"",      ""plat"",    430, 22, 30, 24, 540, 35, ""none"",                4);
+add(""Brownie aux noix"",     ""dessert"", 380,  6, 42, 22, 410, 45, ""gluten,lactose,nuts"", 5);
+add(""Salade de fruits frais"",""dessert"", 90,  1, 22,  0, 180, 10, ""none"",                6);
+sb.Append(""</recipeml>"");
+string recipesXml = sb.ToString();
+
+public class Recipe
+{
+    public string Name { get; set; }
+    public string Category { get; set; }
+    public int Kcal { get; set; }
+    public int Protein { get; set; }
+    public int Carbs { get; set; }
+    public int Fat { get; set; }
+    public int CostCents { get; set; }
+    public int PrepMin { get; set; }
+    public string Allergens { get; set; }
+    public bool HasAllergen(string a) => Allergens != ""none"" && Allergens.Split(',').Contains(a);
+}
+
+var doc = XDocument.Parse(recipesXml);
+var corpus = doc.Root.Elements(""recipe"").Select(r => new Recipe
+{
+    Name = (string)r.Element(""head"").Element(""title""),
+    Category = (string)r.Element(""head"").Element(""category""),
+    Kcal = (int)r.Element(""nutrition"").Attribute(""kcal""),
+    Protein = (int)r.Element(""nutrition"").Attribute(""protein""),
+    Carbs = (int)r.Element(""nutrition"").Attribute(""carbs""),
+    Fat = (int)r.Element(""nutrition"").Attribute(""fat""),
+    CostCents = (int)r.Element(""cost""),
+    PrepMin = (int)r.Element(""prep"").Attribute(""time""),
+    Allergens = (string)r.Element(""allergens"") ?? ""none""
+}).ToList();
+
+Console.WriteLine(""Corpus parse : "" + corpus.Count + "" recettes"");
+Console.WriteLine(string.Format(""{0,-24} {1,-8} {2,4} {3,4} {4,6} {5,-18}"", ""Nom"", ""Cat"", ""kcal"", ""prot"", ""prix"", ""allergenes""));
+foreach (var rc in corpus)
+    Console.WriteLine(string.Format(""{0,-24} {1,-8} {2,4} {3,4} {4,4} c {5,-18}"", rc.Name, rc.Category, rc.Kcal, rc.Protein, rc.CostCents, rc.Allergens));",,,,,,,,d1744be8e2ea73e9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec2-title,markdown,fr,e24e29764826d95d,"---
+
+### 2. Helper de rendu HTML : cartes et grilles
+
+On définit deux helpers statiques qui prennent en entrée des **objets du domaine** (pas des expressions Z3) et retournent une **chaîne HTML**. C'est cette séparation qui rend le rendu réutilisable : le helper ne sait pas que les données viennent d'un solveur.
+
+#### `RenderMenuCard(IEnumerable<Recipe> menu, ...)`
+
+Renvoie une carte HTML stylée représentant un menu complet. Encodage visuel :
+
+- **Calories** : badge vert si 500-900 kcal (dans la cible), orange si à proximité (400-500 ou 900-1100), rouge sinon
+- **Protéines** : barre de progression proportionnelle (sur une base de 50 g)
+- **Coût** : badge vert si ≤ budget, rouge sinon
+- **Allergènes** : badge rouge avec libellé si présent, badge vert ""sans allergène"" sinon
+
+#### `RenderWeeklyGrid(int[][] plan, List<Recipe> corpus)`
+
+Renvoie une grille HTML (jours en lignes, créneaux en colonnes). Les répétitions d'une même recette à travers les jours sont **détectées** et marquées d'une couleur commune, afin de révéler visuellement une violation potentielle de variété.
+
+Le style utilise du CSS inline (pas de feuille externe) : coins arrondis, ombres légères, en-têtes colorées. Tout est dans la chaîne renvoyée — pas d'effet de bord.",,,,,,,,e24e29764826d95d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec2-helpers,code,fr,a92034069187b0c3,"// Helpers de rendu HTML : ils consomment des objets du domaine (Recipe) et renvoient une
+// chaine HTML. Aucune dependance Z3 : la couche de presentation est découplée du solveur.
+
+public static string KcalColor(int kcal)
+{
+    if (kcal >= 500 && kcal <= 900) return ""#2e7d32"";   // vert : dans la cible
+    if ((kcal >= 400 && kcal < 500) || (kcal > 900 && kcal <= 1100)) return ""#ef6c00""; // orange
+    return ""#c62828"";                                    // rouge : hors cible
+}
+
+public static string AllergenBadge(Recipe r)
+{
+    if (r.Allergens == ""none"")
+        return ""<span style='background:#2e7d32;color:white;padding:2px 8px;border-radius:8px;font-size:11px'>sans allergene</span>"";
+    var parts = r.Allergens.Split(',').Select(a => $""<span style='background:#c62828;color:white;padding:2px 8px;border-radius:8px;font-size:11px;margin-right:4px'>{a}</span>"");
+    return string.Join("""", parts);
+}
+
+public static string ProteinBar(int protein)
+{
+    int pct = Math.Min(100, protein * 100 / 50);  // base 50 g = 100 %
+    string color = protein >= 30 ? ""#2e7d32"" : ""#ef6c00"";
+    return $""<div style='background:#eee;border-radius:4px;width:90px;height:10px;display:inline-block;vertical-align:middle'>"" +
+           $""<div style='background:{color};height:10px;border-radius:4px;width:{pct}%'></div></div> "" +
+           $""<span style='font-size:11px'>{protein} g</span>"";
+}
+
+public static string RenderMenuCard(IEnumerable<Recipe> menu, string title, int budgetCents)
+{
+    var list = menu.ToList();
+    int totKcal = list.Sum(r => r.Kcal);
+    int totProt = list.Sum(r => r.Protein);
+    int totCost = list.Sum(r => r.CostCents);
+    string kcalCol = KcalColor(totKcal);
+    string costCol = totCost <= budgetCents ? ""#2e7d32"" : ""#c62828"";
+
+    var h = new StringBuilder();
+    h.Append($""<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:720px;margin:8px 0;overflow:hidden'>"");
+    h.Append($""<div style='background:#1565c0;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>{title}</div>"");
+    h.Append(""<div style='padding:8px 16px'>"");
+    h.Append(""<table style='width:100%;border-collapse:collapse;font-size:13px'>"");
+    h.Append(""<tr style='background:#f5f5f5'><th style='text-align:left;padding:6px'>Categorie</th><th style='text-align:left;padding:6px'>Recette</th><th style='padding:6px'>kcal</th><th style='padding:6px'>Proteines</th><th style='padding:6px'>Prix</th><th style='padding:6px'>Allergenes</th></tr>"");
+    foreach (var r in list)
+    {
+        string kc = KcalColor(r.Kcal);
+        h.Append($""<tr style='border-bottom:1px solid #eee'>"");
+        h.Append($""<td style='padding:6px'><span style='background:#455a64;color:white;padding:2px 8px;border-radius:8px;font-size:11px'>{r.Category}</span></td>"");
+        h.Append($""<td style='padding:6px;font-weight:600'>{r.Name}</td>"");
+        h.Append($""<td style='padding:6px;text-align:center'><span style='color:{kc};font-weight:bold'>{r.Kcal}</span></td>"");
+        h.Append($""<td style='padding:6px'>{ProteinBar(r.Protein)}</td>"");
+        h.Append($""<td style='padding:6px;text-align:center'>{r.CostCents/100.0:F2} E</td>"");
+        h.Append($""<td style='padding:6px'>{AllergenBadge(r)}</td>"");
+        h.Append(""</tr>"");
+    }
+    h.Append($""<tr style='background:#eceff1;font-weight:bold'>"");
+    h.Append($""<td colspan='2' style='padding:8px'>TOTAL</td>"");
+    h.Append($""<td style='padding:8px;text-align:center'><span style='color:{kcalCol}'>{totKcal}</span></td>"");
+    h.Append($""<td style='padding:8px'>{totProt} g</td>"");
+    h.Append($""<td style='padding:8px;text-align:center'><span style='color:{costCol}'>{totCost/100.0:F2} E / {budgetCents/100.0:F2}</span></td>"");
+    h.Append(""<td></td></tr>"");
+    h.Append(""</table></div></div>"");
+    return h.ToString();
+}
+
+public static string RenderWeeklyGrid(int[][] plan, List<Recipe> corpus)
+{
+    int days = plan.Length;
+    int slots = days > 0 ? plan[0].Length : 0;
+    // Couleur par indice de recette pour detecter les repetitions.
+    var palette = new[] { ""#e3f2fd"", ""#fff3e0"", ""#e8f5e9"", ""#fce4ec"", ""#f3e5f5"", ""#fffde7"", ""#efebe9"" };
+    var h = new StringBuilder();
+    h.Append(""<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:760px;margin:8px 0;overflow:hidden'>"");
+    h.Append(""<div style='background:#6a1b9a;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>Plan multi-jours</div>"");
+    h.Append(""<div style='padding:8px 16px'><table style='width:100%;border-collapse:collapse;font-size:13px'>"");
+    var slotNames = new[] { ""Dejeuner"", ""Diner"", ""Extra"" };
+    h.Append(""<tr style='background:#f5f5f5'><th style='padding:6px'>Jour</th>"");
+    for (int s = 0; s < slots; s++)
+        h.Append($""<th style='padding:6px'>{(s < slotNames.Length ? slotNames[s] : ""Creneau "" + (s+1))}</th>"");
+    h.Append(""</tr>"");
+    for (int d = 0; d < days; d++)
+    {
+        h.Append($""<tr>"");
+        h.Append($""<td style='padding:6px;font-weight:bold;background:#fafafa'>Jour {d+1}</td>"");
+        for (int s = 0; s < slots; s++)
+        {
+            int idx = plan[d][s];
+            var rc = corpus[idx];
+            string bg = palette[idx % palette.Length];
+            h.Append($""<td style='padding:6px;background:{bg};border:1px solid #ddd;border-radius:4px'>{rc.Name}<br/><span style='font-size:11px;color:#555'>{rc.Kcal} kcal / {rc.Category}</span></td>"");
+        }
+        h.Append(""</tr>"");
+    }
+    h.Append(""</table>"");
+    h.Append(""<div style='font-size:11px;color:#666;margin-top:6px'>Meme couleur de fond = meme recette (repetition visible).</div>"");
+    h.Append(""</div></div>"");
+    return h.ToString();
+}
+
+Console.WriteLine($""Helpers definis : RenderMenuCard, RenderWeeklyGrid, KcalColor, AllergenBadge, ProteinBar"");",,,,,,,,a92034069187b0c3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec3-title,markdown,fr,a7c3593e3f0f8288,"---
+
+### 3. Modèle booléen + rendu en carte HTML
+
+On reprend **à l'identique** le modèle booléen de la Partie A §5 : une `BoolExpr` par recette, cardinalité 1 par catégorie, agrégation nutritionnelle via `MkITE`, exclusion de l'allergène `nuts`, bornes kcal/protéines/budget. La seule différence est la **dernière ligne** : au lieu de `Console.WriteLine`, on appelle `display(HTML(RenderMenuCard(...)))`.
+
+C'est la démonstration centrale du notebook : **changer le rendu ne change pas le solveur**. Le moteur SMT reste la source de vérité ; la couche de présentation est une fonction pure des objets du domaine.",,,,,,,,a7c3593e3f0f8288,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec3-solve,code,fr,d19b62d740b4ef74,"// Modele booleen Z3 (reprend le modele booleen de la Partie A §5) : un BoolExpr par recette, agregation MkITE,
+// exclusion de l'allergene 'nuts'. Rendu final en carte HTML via display(HTML(...)).
+
+List<Recipe> solvedMenu = null;
+Status solveStatus;
+
+using (var z3ctx = new Context())
+{
+    var solver = z3ctx.MkSolver();
+    var selections = corpus
+        .Select((rc, i) => new { Recipe = rc, Index = i, Var = (BoolExpr)z3ctx.MkConst($""sel_{i}_{rc.Name}"", z3ctx.BoolSort) })
+        .ToList();
+
+    void ExactlyOne(string cat)
+    {
+        var catVars = selections.Where(s => s.Recipe.Category == cat).Select(s => (BoolExpr)s.Var).ToArray();
+        solver.Add(z3ctx.MkOr(catVars));
+        for (int a = 0; a < catVars.Length; a++)
+            for (int b = 0; b < catVars.Length; b++)
+                if (a != b) solver.Add(z3ctx.MkImplies(catVars[a], z3ctx.MkNot(catVars[b])));
+    }
+    ExactlyOne(""entree""); ExactlyOne(""plat""); ExactlyOne(""dessert"");
+
+    IntExpr totalKcal = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.Kcal), z3ctx.MkInt(0))));
+    IntExpr totalProt = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.Protein), z3ctx.MkInt(0))));
+    IntExpr totalCost = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),
+        (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.CostCents), z3ctx.MkInt(0))));
+
+    int budgetCents = 1500;
+    solver.Add(z3ctx.MkGe(totalKcal, z3ctx.MkInt(500)));
+    solver.Add(z3ctx.MkLe(totalKcal, z3ctx.MkInt(900)));
+    solver.Add(z3ctx.MkGe(totalProt, z3ctx.MkInt(30)));
+    solver.Add(z3ctx.MkLe(totalCost, z3ctx.MkInt(budgetCents)));
+
+    string bannedAllergen = ""nuts"";
+    foreach (var s in selections.Where(s => s.Recipe.HasAllergen(bannedAllergen)))
+        solver.Add(z3ctx.MkNot(s.Var));
+
+    solveStatus = solver.Check();
+    Console.WriteLine($""Resultat solve : {solveStatus}"");
+
+    if (solveStatus == Status.SATISFIABLE)
+    {
+        var model = solver.Model;
+        solvedMenu = selections.Where(s => model.Eval(s.Var, true).BoolValue == Z3_lbool.Z3_L_TRUE)
+                               .Select(s => s.Recipe).ToList();
+    }
+}
+
+if (solvedMenu != null)
+    display(HTML(RenderMenuCard(solvedMenu, ""Menu equilibre sans fruits a coque (solveur Z3)"", 1500)));
+else
+    Console.WriteLine(""Aucun menu ne satisfait les contraintes."");",,,,,,,,d19b62d740b4ef74,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec3-interp,markdown,fr,a09d801e8ebb7ffa,"#### Interpretation : ce que l'encodage couleur revele d'un coup d'oeil
+
+La carte HTML ci-dessus condense en une seule image ce que le tableau `Console.WriteLine` des Parties A-B laissait au lecteur le soin de recomposer :
+
+| Aspect | Console (Parties A-B) | Carte HTML (Partie C) |
+|--------|---------------|------------------|
+| Calories dans la cible 500-900 | à calculer mentalement | badge couleur sur le total |
+| Recette qui monte en calories | pas de signal | chiffre coloré par ligne |
+| Apport protéique | chiffre brut | barre de progression visuelle |
+| Statut d'allergène | chaîne à lire | badge rouge/vert instantané |
+| Dépassement de budget | soustraction manuelle | total coloré vs budget affiché |
+
+**Points clés** :
+
+1. **Le solveur n'a pas changé** — l'objet `solvedMenu` est une `List<Recipe>` conforme à la même définition que ci-dessus. Le rendu HTML est une **fonction pure** de cette liste.
+2. **Le badge allergène rouge** rend immédiatement visible si une recette sélectionnée contient du lactose ou du gluten — utile pour le communicant qui prépare le menu, pas seulement le diététicien qui le calcule.
+3. **L'extension est triviale** : ajouter une colonne ""temps de préparation"" consisterait à ajouter une cellule `<td>{r.PrepMin} min</td>` — sans toucher au modèle Z3.",,,,,,,,a09d801e8ebb7ffa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec4-title,markdown,fr,7e441a57c7829642,"---
+
+### 4. Plan hebdomadaire `int[][]` + grille HTML
+
+On étend au plan multi-jours de la Partie A §7 : un `int[][]` (3 jours x 2 créneaux) peuplé d'indices de recettes dans le corpus, avec contrainte de non-répétition des déjeuners via `Z3Methods.Distinct` en mode `CollectionHandling.Array`.
+
+**Rappel technique — modèle de soumission .NET Interactive**
+
+> La cellule ci-dessous regroupe **dans le même bloc** la déclaration des bornes (`entLo`, `pltLo`, etc.), la construction du théorème `Where(...)`, **et** l'appel `.Solve()`. C'est un choix de **lisibilité** : bornes et contraintes se lisent d'un seul tenant.
+>
+> **Arrière-plan** : chaque cellule `.net-csharp` compile dans un assembly dynamique distinct (une *submission* `Submission#N`). Capturer dans un lambda une variable d'une autre cellule exige une résolution *cross-submission*. Ce cas, historiquement cassant en `ArgumentException` dans le fork Z3.Linq, est **désormais résolu** : `Theorem.AssertConstraints` replie les constantes capturées en littéraux via `PartialEvaluator.PartialEval` avant la visite de l'arbre. La capture cross-cellule fonctionne — garder tout dans la même cellule reste une **recommandation de lisibilité**, plus une exigence.",,,,,,,,7e441a57c7829642,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec4-solve,code,fr,44a75e164c06685b,"// Theoreme hierarchique int[][] sur le corpus RecipeML, rendu en grille HTML.
+// Recommandation de lisibilite : bornes + Where(...) + Solve() dans la MEME cellule.
+// (La capture cross-submission est desormais supportee par le correctif AssertConstraints.)
+
+public class DayPlan
+{
+    public int[][] Sel { get; set; } = new int[3][];
+    public DayPlan() { for (int t = 0; t < 3; t++) Sel[t] = new int[2]; }
+}
+
+int entLo = corpus.FindIndex(r => r.Category == ""entree"");
+int entHi = corpus.FindLastIndex(r => r.Category == ""entree"");
+int pltLo = corpus.FindIndex(r => r.Category == ""plat"");
+int pltHi = corpus.FindLastIndex(r => r.Category == ""plat"");
+int desLo = corpus.FindIndex(r => r.Category == ""dessert"");
+int desHi = corpus.FindLastIndex(r => r.Category == ""dessert"");
+Console.WriteLine($""Bornes corpus -> entrees [{entLo},{entHi}], plats [{pltLo},{pltHi}], desserts [{desLo},{desHi}]"");
+
+DayPlan sol = null;
+using (var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array })
+{
+    var th = ctx.NewTheorem<DayPlan>();
+    for (int t = 0; t < 3; t++)
+    {
+        int tt = t;
+        th = th.Where(g => g.Sel[tt][0] >= pltLo && g.Sel[tt][0] <= pltHi);
+        th = th.Where(g => g.Sel[tt][1] >= pltLo && g.Sel[tt][1] <= pltHi);
+    }
+    th = th.Where(g => Z3Methods.Distinct(g.Sel[0][0], g.Sel[1][0], g.Sel[2][0]));
+
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+    sol = th.Solve();
+    sw.Stop();
+    Console.WriteLine($""Theoreme int[][] resolu en {sw.Elapsed.TotalMilliseconds:F1} ms (status : {(sol != null ? ""SAT"" : ""UNSAT"")})"");
+}
+
+if (sol != null)
+    display(HTML(RenderWeeklyGrid(sol.Sel, corpus)));
+else
+    Console.WriteLine(""(Aucun plan realisable avec ces bornes.)"");",,,,,,,,44a75e164c06685b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec4-interp,markdown,fr,6530694917f5fa05,"#### Interpretation : la grille rend la variété visible
+
+La grille HTML ci-dessus attribue à **chaque indice de recette** une couleur de fond stable. Sans même lire les noms, l'œil repère :
+
+- les **colonnes déjeuner** : trois couleurs différentes = contrainte `Distinct` satisfaite (aucune répétition cross-jour)
+- les **colonnes dîner** : peuvent se chevaucher (pas de contrainte `Distinct` posée ici — cf. exercice 2)
+
+| Aspect | Rôle de la couleur |
+|--------|---------------------|
+| Vérifier la non-répetition | couleurs identiques = alerte immédiate |
+| Repérer une catégorie absente | aucune cellule verte si aucun dessert |
+| Comparer visuellement la charge kcal | lecture facile des annotations par cellule |
+
+**Points clés** :
+
+1. Le solveur trouve une **permutation complète** des trois plats du corpus sur les trois déjeuners — la contrainte `Z3Methods.Distinct` accomplit un travail qu'une simple borne ne pourrait pas exprimer (non-trivialité Prong-B).
+2. Le rendu grille est **indépendant du contenu** : la même fonction `RenderWeeklyGrid` afficherait aussi bien un plan 7 jours x 3 créneaux. Seule la forme du `int[][]` change.",,,,,,,,6530694917f5fa05,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec5-title,markdown,fr,f42e82e575ae252f,"---
+
+### 5. Front de Pareto HTML : exploration de l'espace des solutions
+
+Un seul solve montre qu'il **existe** une solution. Une **série de solves sous budgets décroissants** révèle la structure du compromis kcal/coût — c'est le front de Pareto. Cette section est la montée en gamme du notebook (EPIC #3801 Prong-B) : on fait valoir la capacité du moteur à **explorer** un espace paramétrique, pas seulement à trouver un point.
+
+On boucle sur les budgets de 800 à 2000 centimes (par pas de 200), on résout à chaque fois le modèle booléen avec le même corpus, et on collecte le couple `(kcal, cost, prot)` de la solution retenue. On rend ensuite le tout comme un **tableau stylé de compromis** où chaque ligne est un point du front.",,,,,,,,f42e82e575ae252f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec5-solve,code,fr,527898559d91f0cf,"// Front de Pareto kcal/cout : on boucle sur des budgets decroissants, on resout le modele
+// booleen a chaque fois (brownie reste exclu), et on collecte (budget, kcal, cout, prot).
+// Rendu final en tableau HTML style ""compromis"".
+
+var pareto = new List<(int BudgetCents, int Kcal, int Cost, int Prot, string Desc)>();
+
+foreach (int budgetCents in new[] { 2000, 1800, 1600, 1400, 1200, 1000, 800 })
+{
+    using (var z3ctx = new Context())
+    {
+        var solver = z3ctx.MkSolver();
+        var selections = corpus
+            .Select((rc, i) => new { Recipe = rc, Var = (BoolExpr)z3ctx.MkConst($""s_{i}_{budgetCents}"", z3ctx.BoolSort) })
+            .ToList();
+
+        void ExactlyOne(string cat)
+        {
+            var cv = selections.Where(s => s.Recipe.Category == cat).Select(s => (BoolExpr)s.Var).ToArray();
+            solver.Add(z3ctx.MkOr(cv));
+            for (int a = 0; a < cv.Length; a++)
+                for (int b = 0; b < cv.Length; b++)
+                    if (a != b) solver.Add(z3ctx.MkImplies(cv[a], z3ctx.MkNot(cv[b])));
+        }
+        ExactlyOne(""entree""); ExactlyOne(""plat""); ExactlyOne(""dessert"");
+
+        IntExpr totalKcal = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),
+            (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.Kcal), z3ctx.MkInt(0))));
+        IntExpr totalProt = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),
+            (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.Protein), z3ctx.MkInt(0))));
+        IntExpr totalCost = (IntExpr)selections.Aggregate((IntExpr)z3ctx.MkInt(0),
+            (acc, s) => (IntExpr)z3ctx.MkAdd(acc, (ArithExpr)z3ctx.MkITE(s.Var, z3ctx.MkInt(s.Recipe.CostCents), z3ctx.MkInt(0))));
+
+        solver.Add(z3ctx.MkGe(totalKcal, z3ctx.MkInt(400)));
+        solver.Add(z3ctx.MkGe(totalProt, z3ctx.MkInt(20)));
+        solver.Add(z3ctx.MkLe(totalCost, z3ctx.MkInt(budgetCents)));
+        foreach (var s in selections.Where(s => s.Recipe.HasAllergen(""nuts"")))
+            solver.Add(z3ctx.MkNot(s.Var));
+
+        if (solver.Check() == Status.SATISFIABLE)
+        {
+            var model = solver.Model;
+            var chosen = selections.Where(s => model.Eval(s.Var, true).BoolValue == Z3_lbool.Z3_L_TRUE).Select(s => s.Recipe).ToList();
+            pareto.Add((budgetCents, chosen.Sum(r => r.Kcal), chosen.Sum(r => r.CostCents), chosen.Sum(r => r.Protein),
+                        string.Join("" + "", chosen.Select(r => r.Name))));
+        }
+        else
+        {
+            pareto.Add((budgetCents, -1, -1, -1, ""(IRREALISABLE)""));
+        }
+    }
+}
+
+// Rendu HTML du front de Pareto.
+int maxKcal = pareto.Where(p => p.Kcal > 0).Max(p => p.Kcal);
+var h = new StringBuilder();
+h.Append(""<div style='font-family:sans-serif;border:1px solid #ccc;border-radius:10px;box-shadow:0 2px 8px rgba(0,0,0,0.1);max-width:780px;margin:8px 0;overflow:hidden'>"");
+h.Append(""<div style='background:#00695c;color:white;padding:10px 16px;font-size:16px;font-weight:bold'>Front de Pareto : compromis kcal / cout</div>"");
+h.Append(""<div style='padding:8px 16px'><table style='width:100%;border-collapse:collapse;font-size:13px'>"");
+h.Append(""<tr style='background:#f5f5f5'><th style='padding:6px'>Budget (E)</th><th style='padding:6px'>kcal</th><th style='padding:6px'>Jauge kcal</th><th style='padding:6px'>cout reel (E)</th><th style='padding:6px'>prot (g)</th><th style='padding:6px'>menu</th></tr>"");
+foreach (var p in pareto)
+{
+    if (p.Kcal < 0)
+    {
+        h.Append($""<tr><td colspan='6' style='padding:6px;color:#c62828;font-style:italic'>Budget {p.BudgetCents/100.0:F2} E : irrealisable</td></tr>"");
+        continue;
+    }
+    int pct = maxKcal > 0 ? p.Kcal * 100 / maxKcal : 0;
+    string col = KcalColor(p.Kcal);
+    int margin = p.BudgetCents - p.Cost;
+    string marginCol = margin >= 0 ? ""#2e7d32"" : ""#c62828"";
+    h.Append(""<tr style='border-bottom:1px solid #eee'>"");
+    h.Append($""<td style='padding:6px;text-align:center'>{p.BudgetCents/100.0:F2}</td>"");
+    h.Append($""<td style='padding:6px;text-align:center;color:{col};font-weight:bold'>{p.Kcal}</td>"");
+    h.Append($""<td style='padding:6px'><div style='background:#eee;border-radius:4px;width:140px;height:10px'><div style='background:{col};height:10px;border-radius:4px;width:{pct}%'></div></div></td>"");
+    h.Append($""<td style='padding:6px;text-align:center'>{p.Cost/100.0:F2} <span style='color:{marginCol};font-size:11px'>(marge {margin/100.0:F2})</span></td>"");
+    h.Append($""<td style='padding:6px;text-align:center'>{p.Prot}</td>"");
+    h.Append($""<td style='padding:6px;font-size:12px'>{p.Desc}</td>"");
+    h.Append(""</tr>"");
+}
+h.Append(""</table>"");
+h.Append(""<div style='font-size:11px;color:#666;margin-top:6px'>Chaque ligne = une solution du solveur sous un budget different. La jauge kcal est relative au max observe.</div>"");
+h.Append(""</div></div>"");
+Console.WriteLine($""Front de Pareto : {pareto.Count} points (budgets 800 a 2000 centimes)"");
+display(HTML(h.ToString()));",,,,,,,,527898559d91f0cf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,sec5-interp,markdown,fr,3964c20954b4b523,"#### Interpretation : le solveur comme explorateur de l'espace des solutions
+
+Le tableau ci-dessus **ne montre pas une solution** mais un **spectre** : ce que le solveur peut atteindre à chaque niveau de budget. C'est l'argument opérationnel pour utiliser un moteur SMT plutôt qu'un algorithme glouton :
+
+| Observation | Lecture |
+|-------------|---------|
+| À budget élevé (20 EUR), kcal max | le solveur peut se permettre un menu consistant |
+| À budget bas, bascule vers Tofu/Salade | **rotation automatique** des recettes moins chères |
+| Palier ""irréalisable"" | le solveur prouve qu'aucun menu ne satisfait les contraintes minimales |
+
+**Points clés** :
+
+1. **Chaque ligne est un solve indépendant** — il n'y a pas d'astuce : le solveur a tourné 7 fois. Le coût calculatoire est négligeable (chaque solve prend quelques ms).
+2. **Le rendu rend la décision possible** : un décideur qui compare visuellement les jauges et les marges peut arbitrer ""je sacrifie 100 kcal pour économiser 2 EUR"" en un coup d'œil. C'est exactement la valeur d'un solveur rendu lisiblement.
+3. **Frontière avec l'optimisation** : on n'a pas **maximisé** ici (ce serait un exercice d'optimisation (maximisation) de la Partie A), on a **échantillonné**. Les deux approches sont complémentaires.",,,,,,,,3964c20954b4b523,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,recap-title,markdown,fr,9a904de33bbfe78b,"---
+
+### Tableau récapitulatif : Console (Parties A-B) vs HTML (Partie C)
+
+| Critère | `Console.WriteLine` (Parties A-B) | `display(HTML(...))` (Partie C) |
+|---------|--------------------------------|----------------------------|
+| Support | texte brut aligné par espaces | HTML riche rendu par le notebook |
+| Encodage couleur | aucun | badges, jauges, codes caloriques |
+| Détection allergène | lecture de chaîne | badge rouge/vert instantané |
+| Plan multi-jours | liste de lignes | grille colourisée, répétitions visibles |
+| Exploration paramétrique | fastidieuse | front de Pareto rendu en un bloc |
+| Effort code | un `Console.WriteLine` | un helper HTML + appel `display` |
+| Couplage au solveur | aucun | aucun (fonction pure des objets du domaine) |
+
+#### Le point fondamental
+
+Le solveur n'a **pas été modifié** entre les Parties A-B et C. Les modèles (booléen avec `MkITE`, hiérarchique `int[][]`) sont identiques. Seule la **dernière ligne** de chaque section a changé : `Console.WriteLine` est devenu `display(HTML(...))`. C'est la preuve que l'architecture est **découplée** : le solveur produit des objets du domaine, le rendu est une fonction pure de ces objets.",,,,,,,,9a904de33bbfe78b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,2a7878ad,markdown,fr,037e69737601ace7,### Exercices — Partie A : Modelisation declarative,,,,,,,,037e69737601ace7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,08151c18,markdown,fr,2c23cb4f640a7b9f,"#### Exercice 1 : Menu équilibré avec contrainte de glucides
+
+Ajoutez une contrainte sur les **glucides totaux** (entre 40g et 80g) au modèle d'optimisation (section 6). Le menu optimal doit toujours minimiser le cout, mais satisfaire cette contrainte supplementaire.
+
+**Indice** : Ajoutez un `IntExpr totalCarbs` avec le même pattern `MkITE` que `totalCal` et `totalProt`, puis ajoutez les contraintes `MkGe` / `MkLe`.",,,,,,,,2c23cb4f640a7b9f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,21080ada,code,fr,0e1dd5b072cb582a,"// Exercice 1 : ajoutez la contrainte 40g <= glucides <= 80g au modèle d'optimisation
+// Reprenez le code de la section 6 et ajoutez totalCarbs
+
+// TODO etudiant : implementer la contrainte de glucides
+// int minCarbs = 40, maxCarbs = 80;
+// IntExpr totalCarbs = ...
+// optimizer.Add(z3ctx.MkGe(totalCarbs, z3ctx.MkInt(minCarbs)));
+// optimizer.Add(z3ctx.MkLe(totalCarbs, z3ctx.MkInt(maxCarbs)));
+
+Console.WriteLine(""Exercice a completer : contrainte de glucides"");",,,,,,,,0e1dd5b072cb582a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3f97eb17,markdown,fr,4ce4bf3fea880295,"#### Exercice 2 : Planificateur de repas multi-jours
+
+Etendez le modèle pour planifier un menu sur **2 jours** (6 repas : 2 entrees, 2 plats, 2 desserts) sans répétition. Contrainte : chaque aliment ne peut etre sélectionné qu'**au maximum 1 fois**.
+
+**Etape 1** : Creez 6 groupes de variables booléennes (ou utilisez des paires jour/catégorie).
+
+**Etape 2** : Ajoutez la contrainte de non-répétition (un aliment ne peut pas etre vrai dans 2 groupes différents).
+
+**Indice** : Pour chaque aliment, la somme de ses apparitions dans les différents repas doit etre <= 1.",,,,,,,,4ce4bf3fea880295,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3b5286f9,code,fr,dc395c1187dada4a,"// Exercice 2 : planificateur multi-jours sans répétition
+
+// TODO etudiant : créer les variables pour 2 jours de menus
+// Indice : utilisez un dictionnaire (jour, catégorie) -> BoolExpr[]
+// Pour la non-répétition : pour chaque aliment, sum(apparitions) <= 1
+
+Console.WriteLine(""Exercice a completer : planificateur multi-jours"");",,,,,,,,dc395c1187dada4a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,0e611287,markdown,fr,941e5b7d814a21c8,"#### Exercice 3 : Ajout d'un plat supplementaire (boisson)
+
+Ajoutez une catégorie **""boisson""** a la base de données (3 boissons) et modifiez le modèle d'optimisation pour inclure exactement 1 boisson par repas. Verifiez que les contraintes nutritionnelles sont toujours satisfaites.
+
+**Etape 1** : Ajoutez 3 boissons a `foodDatabase`.
+
+**Etape 2** : Ajoutez le groupe ""boisson"" dans les contraintes `ExactlyOne`.
+
+**Etape 3** : Re-executez l'optimisation et comparez le nouveau menu optimal.",,,,,,,,941e5b7d814a21c8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3b1388df,code,fr,72d3498c22ea4739,"// Exercice 3 : ajout d'une catégorie boisson
+
+// TODO etudiant : ajouter 3 boissons a foodDatabase
+// Exemples : eau (0 kcal), jus d'orange (110 kcal, 25g glucides), vin (85 kcal)
+// TODO etudiant : ajouter la contrainte ExactlyOne pour la catégorie boisson
+
+Console.WriteLine(""Exercice a completer : ajout de boissons"");",,,,,,,,72d3498c22ea4739,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,36027fdb,markdown,fr,112ad15a6eab1b1c,"#### Exercice 4 : Modèle hiérarchique combiné (montée en gamme + permutation)
+
+La section 7 a montré deux variantes *séparées* du théorème `WeeklyPlan` : montée en gamme (variante A) et permutation totale (variante B). Construisez maintenant un **modèle unique** qui combine les deux familles de contraintes :
+
+- **Plats** : montée en gamme — index strictement croissant sur les 3 jours (`Plan[0][1] < Plan[1][1] < Plan[2][1]`).
+- **Entrées** ET **desserts** : permutation totale — chaque colonne servie sans répétition (`Z3Methods.Distinct(...)`).
+
+**Indice — bornes de catégorie.** Reprenez le calcul des bornes (`entLo`, `entHi`, …) avec `foodDatabase.FindIndex` / `FindLastIndex`.
+
+**Indice — lisibilité .NET Interactive.** Pour garder le notebook lisible, déclarez les bornes **dans la même cellule** que le `Solve()` qui les capture. La capture cross-cell est désormais fonctionnelle (le fix fork `AssertConstraints` lève l'ancien blocage), mais la même cellule reste le pattern le plus clair pour un exercice autonome.
+
+**Indice — `Distinct` cross-row.** `Z3Methods.Distinct(p.Plan[0][0], p.Plan[1][0], p.Plan[2][0])` s'applique directement à une colonne d'un `int[][]` (même marqueur que les lignes/colonnes d'un Sudoku, notebook 05).",,,,,,,,112ad15a6eab1b1c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,aa925fc9,code,fr,5a4622af6b032be3,"// Exercice 4 : modèle hiérarchique combiné (montée en gamme sur les plats + permutation des entrées/desserts).
+// Recommandation .NET Interactive : gardez idéalement les bornes et le Solve() dans la même cellule
+// (la capture cross-cell fonctionne désormais grâce au fix fork AssertConstraints, mais la même cellule
+// reste le pattern le plus lisible).
+
+// TODO etudiant : recalculer les bornes de categorie ici (entLo/entHi/pltLo/pltHi/desLo/desHi)
+//   via foodDatabase.FindIndex / FindLastIndex
+// TODO etudiant : construire ctx.NewTheorem<WeeklyPlan>() avec les bornes par creneau
+// TODO etudiant : plats en montee en gamme -> p.Plan[0][1] < p.Plan[1][1], p.Plan[1][1] < p.Plan[2][1]
+// TODO etudiant : entrees + desserts en permutation -> Z3Methods.Distinct(p.Plan[0][k], p.Plan[1][k], p.Plan[2][k])
+// TODO etudiant : resoudre et afficher le plan combine
+
+Console.WriteLine(""Exercice a completer : modele hierarchique combine"");",,,,,,,,5a4622af6b032be3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,899bec67,markdown,fr,a0329579ddc220f5,### Exercices — Partie B : Couplage hebdomadaire,,,,,,,,a0329579ddc220f5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,21e32d08,markdown,fr,b84b966d0c075740,#### Exercice 1 : Fenetre de proteines par jour,,,,,,,,b84b966d0c075740,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,5e05978d,code,fr,2568350f4b2565c8,"// Exercice 1 : Fenetre de proteines par jour.
+// Ajoutez une contrainte : pour chaque jour, la somme des proteines des plats choisis est >= PROTEIN_MIN (ex: 60 g).
+// Indice : meme structure que la fenetre kcal, mais avec proteinArr au lieu de kcalArr (somme inline sur les 18 plats).
+// Etape 1 : definir PROTEIN_MIN = 60.
+// Etape 2 : ajouter, pour chaque jour j, la contrainte sum_i Sel[j][i]*proteinArr[i] >= PROTEIN_MIN.
+// Etape 3 : resoudre et verifier que chaque jour atteint le seuil proteique.
+Console.WriteLine(""Exercice 1 a completer : fenetre de proteines minimale par jour."");",,,,,,,,2568350f4b2565c8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,3fa61084,markdown,fr,a11dd36a06bd259f,#### Exercice 2 : Budget hebdomadaire,,,,,,,,a11dd36a06bd259f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,1fef7778,code,fr,ab82f672c510aed9,"// Exercice 2 : Budget hebdomadaire.
+// Contraignez le cout total de la semaine : sum_{j,i} Sel[j][i] * costArr[i] <= WEEKLY_BUDGET_CENTS (ex: 3500 = 35 EUR).
+// Puis MINIMISEZ ce cout via une dichotomie sur le budget (cf. Partie A §6) et affichez le plan le moins cher.
+// Indice : la borne haute initiale est le cout du plan de la section 6 ; cherchez par dichotomie le minimum realisable.
+Console.WriteLine(""Exercice 2 a completer : budget hebdomadaire + minimisation du cout."");",,,,,,,,ab82f672c510aed9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,29e14b6a,markdown,fr,f7c0d514e8ab29ae,#### Exercice 3 : Variete renforcee sur 2 jours consecutifs,,,,,,,,f7c0d514e8ab29ae,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,6bb76295,code,fr,6033adf10d88f7f9,"// Exercice 3 : Variete renforcee sur 2 jours consecutifs.
+// En plus de la variete globale, imposez qu'un plat d'une meme categorie ne soit JAMAIS servi deux jours de suite.
+// Exemple pour le dinner : le plat du dinner du jour j et du jour j+1 doivent etre distincts.
+// Indice : pour chaque paire (j, j+1), ajouter Sel[j][i] + Sel[j+1][i] <= 1 sur la categorie cible (indices 12-17).
+Console.WriteLine(""Exercice 3 a completer : variete renforcee sur jours consecutifs."");",,,,,,,,6033adf10d88f7f9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,4889cc0f,markdown,fr,b3d4c75d1c649197,### Exercices — Partie C : Visualisation HTML,,,,,,,,b3d4c75d1c649197,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo1-title,markdown,fr,60d9e1765c251d62,"#### Exercice 1 : Badge végétarien dans la carte de menu
+
+Ajoutez à la fonction `RenderMenuCard` un **badge végétarien** global (en haut de la carte) : vert si **toutes** les recettes du menu sont végétariennes, rouge sinon. On considère comme non-végétariennes les recettes dont le nom contient `""Poulet""`, `""boeuf""` ou `""Lasagnes""`.
+
+**Indices** :
+- `# Etape 1` : écrivez un prédicat `bool IsVegetarian(Recipe r)` qui renvoie `false` si `r.Name` contient l'un des marqueurs.
+- `# Etape 2` : dans `RenderMenuCard`, calculez `bool allVeg = list.All(IsVegetarian)`.
+- `# Etape 3` : insérez dans l'en-tête de la carte un badge : vert ""100% vegetarien"" si `allVeg`, rouge ""contient de la viande"" sinon.",,,,,,,,60d9e1765c251d62,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo1-stub,code,fr,d55a567a2161ed53,"// Exercice 1 : badge vegetarien global dans RenderMenuCard.
+// TODO etudiant : modifier RenderMenuCard pour afficher un badge vegetarien en tete de carte.
+
+// Indice :
+// static bool IsVegetarian(Recipe r)
+// {
+//     string[] nonVege = { ""Poulet"", ""boeuf"", ""Lasagnes"" };
+//     return !nonVege.Any(k => r.Name.Contains(k));
+// }
+// ... dans RenderMenuCard :
+// bool allVeg = list.All(IsVegetarian);
+// h.Append($""<div style='padding:4px 16px;background:{(allVeg ? ""#e8f5e9"" : ""#ffebee"")}'>"" +
+//          $""<span style='background:{(allVeg ? ""#2e7d32"" : ""#c62828"")};color:white;padding:2px 8px;border-radius:8px;font-size:11px'>"" +
+//          $""{(allVeg ? ""100% vegetarien"" : ""contient de la viande"")}</span></div>"");
+
+Console.WriteLine(""Exercice a completer : badge vegetarien dans la carte de menu"");",,,,,,,,d55a567a2161ed53,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo2-title,markdown,fr,2d9414192712eaef,"#### Exercice 2 : Total kcal par jour dans la grille hebdomadaire
+
+Modifiez `RenderWeeklyGrid` pour ajouter une **ligne finale ""Total/jour""** qui affiche la somme des kcal de toutes les recettes de chaque journée, avec un code couleur (`KcalColor`).
+
+**Indices** :
+- `# Etape 1` : pour chaque jour `d`, calculez `int dayKcal = Enumerable.Range(0, slots).Sum(s => corpus[plan[d][s]].Kcal);`
+- `# Etape 2` : après la boucle des jours, ajoutez une ligne `<tr>` avec une cellule ""Total kcal"" et une cellule par jour contenant le total coloré.
+- `# Etape 3` : appelez `KcalColor(dayKcal)` pour la couleur du total.",,,,,,,,2d9414192712eaef,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo2-stub,code,fr,db274e88c14b0625,"// Exercice 2 : ligne ""Total kcal / jour"" dans la grille hebdomadaire.
+// TODO etudiant : modifier RenderWeeklyGrid pour ajouter une ligne de totaux par jour.
+
+// Indice :
+// h.Append(""<tr style='background:#eceff1;font-weight:bold'><td>Total kcal</td>"");
+// for (int d = 0; d < days; d++)
+// {
+//     int dayKcal = Enumerable.Range(0, slots).Sum(s => corpus[plan[d][s]].Kcal);
+//     h.Append($""<td style='text-align:center;color:{KcalColor(dayKcal)}'>{dayKcal}</td>"");
+// }
+// h.Append(""</tr>"");
+
+Console.WriteLine(""Exercice a completer : total kcal par jour dans la grille hebdomadaire"");",,,,,,,,db274e88c14b0625,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo3-title,markdown,fr,8eea6fcc39be041a,"#### Exercice 3 : Front de Pareto 2D (budget × plancher protéines) rendu en heatmap
+
+Étendez la section 5 en faisant varier **simultanément** le budget (800..2000) **et** le plancher de protéines (10..50 g). Pour chaque couple `(budget, protFloor)`, résolvez et stockez le kcal atteint. Rendez le tout comme une **heatmap HTML 2D** : lignes = budgets, colonnes = planchers protéiques, couleur de la cellule = kcal atteint (vert = haut, rouge = bas/irréalisable).
+
+**Indices** :
+- `# Etape 1` : construisez une double boucle `foreach (budget ...) foreach (protFloor ...)` qui appelle le solveur et remplit un `int[,] heatmap`.
+- `# Etape 2` : pour la couleur, normalisez le kcal sur la plage observée (`intensity = (kcal - minKcal) / (maxKcal - minKcal)`) et mappez sur un dégradé vert→jaune→rouge (utilisez `System.Drawing.Color` ou un palette CSS).
+- `# Etape 3` : générez un `<table>` HTML où chaque `<td>` a un `style='background:rgb(...)'` calculé depuis l'intensité, et contient la valeur kcal.",,,,,,,,8eea6fcc39be041a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,exo3-stub,code,fr,595ef9f7f785e755,"// Exercice 3 : heatmap 2D budget x plancher proteines (kcal atteint par cellule).
+// TODO etudiant : double boucle de solve, stockage dans int[,], rendu heatmap HTML.
+
+// Indice :
+// int[] budgets = { 800, 1000, 1200, 1400, 1600, 1800, 2000 };
+// int[] protFloors = { 10, 20, 30, 40, 50 };
+// int[,] heatmap = new int[budgets.Length, protFloors.Length];
+// ... double boucle : pour chaque (i,j), resoudre, stocker heatmap[i,j] = kcal ou -1 si UNSAT
+// ... rendu : <table> avec background calcule depuis l'intensite normalisee
+
+Console.WriteLine(""Exercice a completer : heatmap 2D du front de Pareto budget x proteines"");",,,,,,,,595ef9f7f785e755,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/06_Meal_Planner_Modelisation.ipynb,f71ae7c0,markdown,fr,ec6f3e11a538be5c,"---
+
+### Conclusion
+
+Ce notebook a parcouru la **modelisation declarative** d'un planificateur de repas de bout en bout : du menu d'un seul jour (Partie A) au plan hebdomadaire couple (Partie B), jusqu'a la restitution visuelle des solutions (Partie C). Le fil conducteur est que **le solveur est la source de verite** et que tout le reste — enumeration, couplage temporel, rendu — se decline autour de ce noyau declaratif.
+
+#### Points cles a retenir
+
+| Concept | Ou | Implementation |
+|---------|-----|----------------|
+| Selection booleenne + agregation | Partie A §5 | une `BoolExpr` par item, cardinalite, `MkITE` sur les apports |
+| Optimisation par dichotomie | Partie A §6 | recherche binaire sur le budget, borne prouvee |
+| Theoreme hierarchique `int[][]` | Partie A §7 | `NewTheorem<WeeklyPlan>`, `Z3Methods.Distinct` cross-row, pur LINQ |
+| `CollectionHandling` (Array vs Constants) | Partie A §9 | meme theoreme, deux modes d'encodage du tableau |
+| Couplage hebdomadaire | Partie B | matrice booleenne jours x plats, fenetre kcal/jour, variete globale |
+| Solveur vs glouton | Partie B | le glouton echoue la ou le solveur prouve la faisabilite |
+| Decouplage solveur / rendu | Partie C | `display(HTML(...))` = fonction pure des objets du domaine |
+| Exploration parametrique | Partie C | boucle de solves sous budgets varies -> front de Pareto rendu |
+
+#### Perspective
+
+Les techniques vues ici se generalisent a tout solveur produisant des objets structures : planification de personnel (grille par equipe), allocation de ressources (heatmap de charge), ordonnancement (frise temporelle). Le principe reste le meme : **le solveur produit des objets du domaine, le reste est une fonction pure de ces sorties.** Le corpus de donnees a l'echelle (matching RecipeML x Ciqual) est traite dans le notebook de donnees 07 ; la variante « deux stacks » (DSL `Z3.Linq` vs API brute `Microsoft.Z3`) est developpee plus loin dans la serie.
+
+**Navigation** : [Index Z3](./README.md) | [Notebook precedent (Nested Arrays)](05_Nested_Arrays_2D.ipynb)",,,,,,,,ec6f3e11a538be5c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,4a6c161c,markdown,fr,86bac8dd5eea753d,"# 07 — Données réelles & externe : Ciqual × RecipeML (couche de données, 0 Z3)
+
+> **Bloc meal-planner — notebook « Données & externe »** ([Epic #4677](https://github.com/jsboige/CoursIA/issues/4677)). Il porte à l'échelle réelle — Ciqual complet × plusieurs milliers de recettes **RecipeML** — la couche **données** du planificateur. La modélisation Z3 vit ailleurs : [06](06_Meal_Planner_Modelisation.ipynb) la pose sur un corpus jouet, [09](09_Meal_Planner_Convergence_Scale.ipynb) la résout à l'échelle sur le cache produit ici.
+
+Avant qu'un solveur SMT puisse planifier un menu, il faut **charger et préparer des données réelles**. Ce notebook **ne résout rien (0 Z3)** : son livrable est la **couche de données propre** que les notebooks de modélisation et de capstone ([08](08_Meal_Planner_Patient_Capstone.ipynb), [09](09_Meal_Planner_Convergence_Scale.ipynb)) consommeront.
+
+## Deux sources, une jointure de *data fusion*
+
+| Source | Rôle | Format | Ce qu'elle apporte |
+|--------|------|--------|--------------------|
+| **Ciqual (ANSES 2025)** | référentiel nutrition | XML | composition de 3484 aliments **par 100 g** ; noms **anglais** (`alim_nom_eng`) |
+| **RecipeML** (archive culinaire) | corpus recettes | XML auto-décrit | `<ing>` = `<amt><qty>` + `<unit>` + `<item>` — **avec les quantités** |
+
+Le corpus RecipeML porte **quoi** (les ingrédients), Ciqual porte **combien** (la nutrition). Aucune clé commune ne les relie : seul un **appariement lexical approximatif** (item anglais ↔ `alim_nom_eng`) fait le pont. C'est de la **fusion de données réelle** — pas un `join` jouet.
+
+## Le fil conducteur : trois obstacles que les corpus jouets masquaient
+
+1. **Pas de clé commune** → **appariement lexical flou** (sac-de-mots + index inversé). Section 3.
+2. **Les ingrédients ont des quantités en unités culinaires** (`2 cups`, `1 teaspoon`) → il faut **normaliser en grammes** avant toute agrégation nutritionnelle. Section 5. *C'est le point que les premières ébauches du planificateur à l'échelle escamotaient en sommant les teneurs per-100g comme si chaque ingrédient pesait 100 g.*
+3. **La couverture d'appariement est inégale** → on **gate** les recettes par qualité de match (100 % / ≥80 % / ≥50 %) pour ne livrer au solveur qu'un sous-ensemble **propre**. Sections 6-7.
+
+```mermaid
+flowchart LR
+    Q[""Ciqual ANSES 2025<br/>(XML, per-100g, EN)""]
+    R[""Archive RecipeML<br/>(XML, qty/unit/item)""]
+    Q -->|""XmlReader""| QL[""alimCompo + alim_nom_eng""]
+    R -->|""XDocument""| RL[""recettes (item, qty, unit)""]
+    RL -->|""appariement flou""| J[""item ↔ code Ciqual""]
+    RL -->|""qty×unité→grammes""| G[""masse par ingrédient""]
+    QL --> A
+    J --> A
+    G --> A[""agrégation PONDÉRÉE par la masse""]
+    A -->|""gate ≥80%""| C[""cache JSON propre""]
+    C -.->|""consommé par""| M[""08 capstone · 09 échelle""]
+    style Q fill:#f7e3c5
+    style R fill:#f7e3c5
+    style C fill:#c8e6f7
+    style M fill:#eeeeee
+```
+",,,,,,,,86bac8dd5eea753d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,e774b47c,markdown,fr,62402e8af878af34,"## Objectifs d'apprentissage
+
+- Réaliser une **jointure de data fusion** entre un corpus de recettes (RecipeML, ingrédients anglais) et une base nutritionnelle (Ciqual `alim_nom_eng`), via **rapprochement lexical flou**.
+- Parser une structure XML réelle **avec quantités** (`<amt><qty><unit>`), et comprendre pourquoi la **normalisation en grammes** est un préalable non négociable à l'agrégation nutritionnelle.
+- Mesurer la **couverture d'appariement** et **gate**r le corpus par qualité — le levier de montée en charge *piloté par la donnée*.
+
+## Prérequis
+
+- Notions LINQ-to-objects et LINQ-to-XML.
+- Aucune dépendance Z3 : ce notebook est **purement data-engineering** (0 solveur).",,,,,,,,62402e8af878af34,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,061c60b8,markdown,fr,b59a39957cf4af8d,"## 1. Données : Ciqual 2025 + archive RecipeML
+
+Les données sont volumineuses et **hors dépôt** (`data/meals/` est gitignore). Si le dossier est absent, exécutez d'abord le téléchargeur :
+
+```bash
+python download_meal_data.py --areas Ciqual RecipeML
+```
+
+Ciqual ANSES 2025 (DOI 10.57745/RDMHWY, licence etalab 2.0) est une base **normalisée en 4 fichiers** : `const` (constituants), `alim` (aliments), `compo` (compositions, ~66 Mo) et `alim_grp` (groupes). On la lit **en flux** (`XmlReader`) pour ne garder que les **constituants contraints**. L'archive RecipeML est un ensemble de fichiers XML `<recipe>` auto-décrits.",,,,,,,,b59a39957cf4af8d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,138bdfcd,code,fr,c209518c0ab67872,"// ---- dependances (0 Z3 : purement data-engineering) ----
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using System.Xml;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Globalization;
+using System.Diagnostics;
+
+var BASE = ""data/meals"";
+if (!Directory.Exists(Path.Combine(BASE, ""Ciqual"")) || !Directory.Exists(Path.Combine(BASE, ""RecipeML"")))
+    Console.WriteLine(""Donnees absentes. Lancez d'abord : python download_meal_data.py --areas Ciqual RecipeML"");
+else
+    Console.WriteLine(""Donnees presentes : "" + string.Join("", "", Directory.GetDirectories(BASE).Select(Path.GetFileName)));
+",,,,,,,,c209518c0ab67872,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,6b6e6a56,markdown,fr,8e5fdc3f4ba203e7,"## 2. Ciqual : le référentiel nutritionnel (per-100g)
+
+On lit `const` (pour repérer les 5 constituants qu'on contraindra : énergie, protéines, glucides, lipides, sel), `alim` (nom anglais de chaque aliment) et `compo` (teneurs). Les teneurs Ciqual sont **toutes par 100 g** — c'est ce qui rendra la normalisation en grammes (section 5) indispensable.",,,,,,,,8e5fdc3f4ba203e7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,b4e8ab6f,code,fr,57fcb78dd3419ee0,"// ---- Ciqual : lecture en flux, sous-ensemble des constituants contraints ----
+var sw = Stopwatch.StartNew();
+string[] WANTED = { ""Energie, Règlement"", ""Protéines, N x"", ""Glucides (g"", ""Lipides (g"", ""Sel chlorure"" };
+
+var consts = new Dictionary<string, string>();               // const_code -> nom FR
+using (var rd = XmlReader.Create(Path.Combine(BASE, ""Ciqual/const_2025_11_03.xml"")))
+{
+    string code = null, fr = null, field = null;
+    while (rd.Read())
+    {
+        if (rd.NodeType == XmlNodeType.Element) { if (rd.Name == ""CONST"") { code = fr = null; } field = rd.Name; }
+        else if (rd.NodeType == XmlNodeType.Text) { if (field == ""const_code"") code = rd.Value.Trim(); else if (field == ""const_nom_fr"") fr = rd.Value.Trim(); }
+        else if (rd.NodeType == XmlNodeType.EndElement && rd.Name == ""CONST"") { if (code != null) consts[code] = fr ?? """"; }
+    }
+}
+var chosenCodes = WANTED.Select(w => consts.First(c => c.Value.StartsWith(w.Substring(0, Math.Min(18, w.Length)))).Key).ToList();
+var codeIdx = chosenCodes.Select((c, i) => (c, i)).ToDictionary(x => x.c, x => x.i);
+int C = chosenCodes.Count;
+
+var alimEng = new Dictionary<string, string>();              // alim_code -> nom anglais
+using (var rd = XmlReader.Create(Path.Combine(BASE, ""Ciqual/alim_2025_11_03.xml"")))
+{
+    string code = null, eng = null, field = null;
+    while (rd.Read())
+    {
+        if (rd.NodeType == XmlNodeType.Element) { if (rd.Name == ""ALIM"") { code = eng = null; } field = rd.Name; }
+        else if (rd.NodeType == XmlNodeType.Text) { if (field == ""alim_code"") code = rd.Value.Trim(); else if (field == ""alim_nom_eng"") eng = rd.Value.Trim(); }
+        else if (rd.NodeType == XmlNodeType.EndElement && rd.Name == ""ALIM"") { if (code != null) alimEng[code] = eng ?? """"; }
+    }
+}
+
+decimal ParseTeneur(string s)
+{
+    if (s == null) return 0m;
+    s = s.Replace(""traces"", ""0"").Replace(""<"", "" "").Replace(""-"", ""0"").Replace("","", ""."").Trim();   // Ciqual : decimale FR + qualificatifs
+    return decimal.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d) ? d : 0m;
+}
+var alimCompo = new Dictionary<string, decimal[]>();          // alim_code -> teneurs sur les constituants choisis
+using (var rd = XmlReader.Create(Path.Combine(BASE, ""Ciqual/compo_2025_11_03.xml"")))
+{
+    string ac = null, cc = null, te = null, field = null;
+    while (rd.Read())
+    {
+        if (rd.NodeType == XmlNodeType.Element) { if (rd.Name == ""COMPO"") { ac = cc = te = null; } field = rd.Name; }
+        else if (rd.NodeType == XmlNodeType.Text)
+        {
+            if (field == ""alim_code"") ac = rd.Value.Trim();
+            else if (field == ""const_code"") cc = rd.Value.Trim();
+            else if (field == ""teneur"") te = rd.Value;
+        }
+        else if (rd.NodeType == XmlNodeType.EndElement && rd.Name == ""COMPO"")
+        {
+            if (cc != null && ac != null && codeIdx.ContainsKey(cc))
+            {
+                if (!alimCompo.TryGetValue(ac, out var v)) { v = new decimal[C]; alimCompo[ac] = v; }
+                v[codeIdx[cc]] = ParseTeneur(te);
+            }
+        }
+    }
+}
+Console.WriteLine($""Ciqual charge en {sw.Elapsed.TotalSeconds:F1}s : {consts.Count} constituants, {alimEng.Count} aliments, {alimCompo.Count} avec composition."");
+Console.WriteLine($""Constituants contraints (C={C}) :"");
+foreach (var cc in chosenCodes) Console.WriteLine($""   [{cc}] {consts[cc].Substring(0, Math.Min(48, consts[cc].Length))}"");",,,,,,,,57fcb78dd3419ee0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,9fc8a97c,markdown,fr,493c46cb2920b3cb,"## 3. La jointure de data fusion : ingrédient anglais → aliment Ciqual
+
+RecipeML est en **anglais** ; on matche donc contre `alim_nom_eng` (100 % renseigné en 2025), pas `alim_nom_fr` — **même langue des deux côtés**, la leçon de rapprochement survit sans pénalité de traduction. Un **index inversé** mot → aliments accélère la recherche : chaque ingrédient n'est comparé qu'aux aliments partageant au moins un mot (au lieu des ~3500). Sans cet index, la jointure serait quadratique.
+
+> **La normalisation *étagée* est la leçon — et la curation tue les faux positifs.** Un sac-de-mots *positionnel* naïf apparie « **White sugar** » → « **White pudding** » (les deux commencent par « white ») : faux positif classique. La correction, ci-dessous, est une petite pile de **règles métier explicables** :
+>
+> 1. **déaccentuation** + singularisation grossière + suppression des mots de préparation/qualificatifs (`chopped`, `large`, `fresh`…) ;
+> 2. **aliment primaire** = ce qui précède la 1re virgule côté Ciqual (`Sugar, white` → tête = `sugar`) ;
+> 3. **garde sur la tête-de-nom** : l'aliment candidat doit partager le **dernier mot** de l'ingrédient (le nom, pas l'adjectif) — c'est ce qui écarte « White pudding » pour « white **sugar** » ;
+> 4. **similarité de Jaccard** (recouvrement d'ensembles, seuil 0,5), départage par nom Ciqual **le plus court** (le plus primaire) ;
+> 5. petites tables de **synonymes** (`catsup`→`ketchup`, `baking soda`→`sodium bicarbonate`), de **composés** (`salt pepper`→ deux aliments) et de **modificateurs de forme** (`chili powder`→`chili`).
+>
+> Ce qui subsiste (rappel manquant, synonymes non couverts) est exactement la **matière des exercices**. Mesuré sur l'archive : couverture par occurrence ~72 % **sans faux positif** (contre ~79 % naïf mais truffé de faux positifs).",,,,,,,,493c46cb2920b3cb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,fb9c15eb,code,fr,8fef49cfd0aad5a6,"// ---- rapprochement lexical CURÉ : normalisation étagée + index inversé + garde tête-de-nom ----
+// Un sac-de-mots positionnel naïf matcherait « White sugar » -> « White pudding » (les deux
+// commencent par « white ») : faux positif. La CURATION ci-dessous -- déaccentuation, aliment
+// primaire (avant la 1re virgule côté Ciqual), garde sur la tête-de-nom, préférence au nom le
+// plus court, petites tables de synonymes / composés / modificateurs -- élimine ces faux positifs.
+
+// mots à retirer (préparation, qualificatifs, mots vides) : bruit qui masque l'aliment
+var DROP = new HashSet<string>(
+    (""chopped ground grated minced sliced diced melted softened packed sifted beaten cooked raw "" +
+     ""peeled seeded finely coarsely halved quartered cubed shredded crushed crumbled drained rinsed "" +
+     ""lightly thinly thickly cut divided fresh dried frozen canned chilled warmed uncooked prepared "" +
+     ""unbaked mashed toasted roasted boiled steamed blanched julienned trimmed cored pitted stemmed deveined "" +
+     ""large small medium extra whole ripe boneless skinless unsalted salted lean heavy light dark "" +
+     ""granulated powdered confectioners all purpose self rising active instant fine coarse "" +
+     ""of to for the with and or into pieces piece plus taste needed garnish optional about each more "" +
+     ""as in at room temperature degrees inch thick thin long your favorite good quality such other any some few several"")
+    .Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+// synonymes US/culinaire -> vocabulaire Ciqual (clé = item normalisé complet) : la couche « métier »
+var SYN = new Dictionary<string, string> {
+    [""catsup""] = ""ketchup"", [""scallion""] = ""green onion"", [""cilantro""] = ""coriander"",
+    [""cornstarch""] = ""corn starch"", [""shortening""] = ""vegetable fat"", [""baking soda""] = ""sodium bicarbonate"",
+    [""confectioner sugar""] = ""icing sugar"", [""powdered sugar""] = ""icing sugar"", [""bell pepper""] = ""sweet pepper"",
+    [""heavy cream""] = ""cream"", [""whipping cream""] = ""cream"", [""vanilla extract""] = ""vanilla"",
+    [""lemon rind""] = ""lemon zest"", [""lemon peel""] = ""lemon zest"",
+};
+// composés = deux aliments joints par un « and/or » tombé (chacun matché séparément, puis on garde le 1er)
+var COMPOUND = new Dictionary<string, string[]> {
+    [""salt pepper""] = new[] { ""salt"", ""pepper"" }, [""butter margarine""] = new[] { ""butter"", ""margarine"" },
+    [""salt black pepper""] = new[] { ""salt"", ""black pepper"" }, [""oil butter""] = new[] { ""oil"", ""butter"" },
+};
+
+string Deaccent(string s) {
+    var n = s.Normalize(NormalizationForm.FormD);
+    var sb = new StringBuilder();
+    foreach (var ch in n) if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark) sb.Append(ch);
+    return sb.ToString();
+}
+string Singular(string t) {
+    if (t.EndsWith(""ies"") && t.Length > 4) return t.Substring(0, t.Length - 3) + ""y"";
+    if (t.EndsWith(""oes"") && t.Length > 4) return t.Substring(0, t.Length - 2);
+    if (t.EndsWith(""s"") && !t.EndsWith(""ss"") && t.Length > 3) return t.Substring(0, t.Length - 1);
+    return t;
+}
+List<string> Norm(string s) {
+    s = Deaccent((s ?? """").ToLowerInvariant());
+    s = Regex.Replace(s, @""\([^)]*\)"", "" "");                 // retire les parenthèses : (19-oz)
+    s = s.Split(',')[0];                                     // aliment primaire = avant la 1re virgule
+    s = Regex.Replace(s, ""[^a-z\\s-]"", "" "").Replace(""-"", "" "");
+    var o = new List<string>();
+    foreach (var w in s.Split(' ', StringSplitOptions.RemoveEmptyEntries)) {
+        if (w.Length <= 1 || DROP.Contains(w)) continue;
+        var t = Singular(w);
+        if (t.Length > 0) o.Add(t);
+    }
+    return o;
+}
+
+// index Ciqual : (code, jeu de tokens, tête-de-nom, premier mot) sur le nom EN
+var ents = alimCompo.Keys.Where(k => alimEng.ContainsKey(k) && alimEng[k].Length > 0)
+    .Select(k => { var t = Norm(alimEng[k]); return (code: k, toks: new HashSet<string>(t),
+                   head: t.Count > 0 ? t[t.Count - 1] : """", first: t.Count > 0 ? t[0] : """"); })
+    .Where(e => e.toks.Count > 0).ToList();
+var byTok = new Dictionary<string, List<int>>();             // mot -> indices d'aliments (index inversé)
+for (int e = 0; e < ents.Count; e++)
+    foreach (var t in ents[e].toks) {
+        if (!byTok.TryGetValue(t, out var l)) { l = new List<int>(); byTok[t] = l; }
+        l.Add(e);
+    }
+double Jacc(HashSet<string> a, HashSet<string> b) {
+    if (a.Count == 0 || b.Count == 0) return 0;
+    int inter = a.Count(x => b.Contains(x));
+    return (double)inter / (a.Count + b.Count - inter);
+}
+
+// coeur : clé normalisée -> code Ciqual (garde tête-de-nom, rang jaccard puis nom le plus court, seuil 0.5)
+string MatchKey(string key) {
+    if (SYN.TryGetValue(key, out var syn)) key = string.Join("" "", Norm(syn));
+    var toks = key.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
+    if (toks.Count > 1 && (toks[toks.Count - 1] == ""powder"" || toks[toks.Count - 1] == ""extract""
+        || toks[toks.Count - 1] == ""root"") && key != ""baking powder"")
+        toks = toks.Take(toks.Count - 1).ToList();           // retire un modificateur de forme final
+    if (toks.Count == 0) return null;
+    var it = new HashSet<string>(toks);
+    var head = toks[toks.Count - 1];
+    var cand = new HashSet<int>();
+    foreach (var t in it) if (byTok.TryGetValue(t, out var l)) foreach (var e in l) cand.Add(e);
+    string best = null; double bj = 0; int bfb = 0, bnl = 0; bool has = false;
+    foreach (var e in cand) {
+        if (!ents[e].toks.Contains(head)) continue;          // garde : l'aliment partage la tête-de-nom
+        double j = Jacc(it, ents[e].toks);
+        if (j < 0.5) continue;
+        int fb = ents[e].first == head ? 1 : 0;              // bonus : l'aliment Ciqual COMMENCE par la tête
+        int nl = -ents[e].toks.Count;                        // préférer le nom le plus court (plus primaire)
+        if (!has || j > bj + 1e-9 || (Math.Abs(j - bj) < 1e-9 && (fb > bfb || (fb == bfb && nl > bnl)))) {
+            bj = j; bfb = fb; bnl = nl; best = ents[e].code; has = true;
+        }
+    }
+    return best;
+}
+var matchCache = new Dictionary<string, string>();
+string Match(string item) {                                  // surface publique : item brut -> code Ciqual
+    var key = string.Join("" "", Norm(item.Split(';')[0]));
+    if (key.Length == 0) return null;
+    if (matchCache.TryGetValue(key, out var c)) return c;
+    string code;
+    if (COMPOUND.TryGetValue(key, out var parts)) code = MatchKey(string.Join("" "", Norm(parts[0]))); // composé : 1er aliment
+    else code = MatchKey(key);
+    matchCache[key] = code;
+    return code;
+}
+
+Console.WriteLine(""Demonstration du matcheur cure sur quelques items RecipeML :"");
+foreach (var t in new[] { ""White sugar"", ""All-purpose flour"", ""Baking soda"", ""Eggs"", ""Butter"", ""Olive oil"", ""Salt pepper"" })
+{
+    var mcode = Match(t);
+    Console.WriteLine($""   '{t,-18}' -> {(mcode != null ? alimEng[mcode] : ""(aucun)"")}"");
+}
+",,,,,,,,8fef49cfd0aad5a6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,82d5c0f2,markdown,fr,52cc1f8a742cbd95,"## 4. RecipeML : parsing structuré **avec quantités**
+
+Chaque `<recipe>` porte des `<ing>` de forme `<amt><qty>…</qty><unit>…</unit></amt><item>…</item>`. On extrait le **triplet (item, quantité, unité)** — c'est la différence décisive avec l'ébauche `09`, qui ne lisait que `<item>` et ignorait la masse.
+
+`ParseQty` gère les entiers, les **fractions** (`1/2`), les **quantités mixtes** (`1 1/2`), les fractions Unicode (`½`) et prend la borne basse d'une fourchette (`2-3` → `2`). Le parsing XML est **tolérant** (certains fichiers ont des `&` nus) : on retombe sur un remplacement `& → &amp;` avant d'abandonner un fichier.",,,,,,,,52cc1f8a742cbd95,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,64ba09d6,code,fr,60832055d72b82c8,"// ---- ParseQty : quantite textuelle -> nombre (fractions, mixtes, unicode, fourchettes) ----
+double ParseQty(string s)
+{
+    if (string.IsNullOrWhiteSpace(s)) return 0;
+    s = s.Trim().Replace(""½"", ""1/2"").Replace(""¼"", ""1/4"").Replace(""¾"", ""3/4"")
+         .Replace(""⅓"", ""1/3"").Replace(""⅔"", ""2/3"");
+    int dash = s.IndexOf('-'); if (dash > 0) s = s.Substring(0, dash);           // fourchette -> borne basse
+    double total = 0; bool any = false;
+    foreach (var tok in s.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+    {
+        if (tok.Contains('/'))
+        {
+            var pr = tok.Split('/');
+            if (pr.Length == 2 && double.TryParse(pr[0], NumberStyles.Any, CultureInfo.InvariantCulture, out var a)
+                && double.TryParse(pr[1], NumberStyles.Any, CultureInfo.InvariantCulture, out var b) && b != 0)
+            { total += a / b; any = true; }
+        }
+        else if (double.TryParse(tok, NumberStyles.Any, CultureInfo.InvariantCulture, out var d)) { total += d; any = true; }
+    }
+    return any ? total : 0;
+}
+
+// ---- parsing de l'archive : liste (item, qty, unit) par recette ----
+var recipes = new List<(string title, List<string> cats, List<(string item, double qty, string unit)> ings)>();
+int skipped = 0, nIng = 0, nQty = 0, nUnit = 0;
+foreach (var f in Directory.GetFiles(Path.Combine(BASE, ""RecipeML""), ""*.xml"", SearchOption.AllDirectories))
+{
+    System.Xml.Linq.XDocument doc;
+    try { doc = System.Xml.Linq.XDocument.Load(f); }
+    catch { try { doc = System.Xml.Linq.XDocument.Parse(File.ReadAllText(f).Replace(""&"", ""&amp;"")); } catch { skipped++; continue; } }
+    var title = doc.Descendants(""title"").FirstOrDefault(x => x.Value.Trim().Length > 0)?.Value.Trim()
+                ?? Path.GetFileNameWithoutExtension(f);
+    var cats = doc.Descendants(""cat"").Select(x => x.Value.Trim()).Where(x => x.Length > 0).ToList();
+    var ings = new List<(string, double, string)>();
+    foreach (var ing in doc.Descendants(""ing""))
+    {
+        var item = ing.Element(""item"")?.Value.Trim();
+        if (string.IsNullOrEmpty(item)) continue;
+        nIng++;
+        double qty = 0; string unit = """";
+        var amt = ing.Element(""amt"");
+        if (amt != null)
+        {
+            qty = ParseQty(amt.Element(""qty"")?.Value);
+            unit = (amt.Element(""unit"")?.Value ?? """").Trim().ToLowerInvariant();
+        }
+        if (qty > 0) nQty++;
+        if (unit.Length > 0) nUnit++;
+        ings.Add((item, qty, unit));
+    }
+    if (ings.Count > 0) recipes.Add((title.Length > 44 ? title.Substring(0, 44) : title, cats, ings));
+}
+Console.WriteLine($""RecipeML : {recipes.Count} recettes, {nIng} ingredients "" +
+    $""({100.0 * nQty / Math.Max(1, nIng):F0}% avec quantite, {100.0 * nUnit / Math.Max(1, nIng):F0}% avec unite), "" +
+    $""{skipped} fichiers XML irrecuperables ignores."");
+Console.WriteLine(""Exemple de recette (item | qty | unite) :"");
+foreach (var (it, q, u) in recipes[0].ings.Take(5)) Console.WriteLine($""   {it,-38} | {q,5} | {u}"");
+",,,,,,,,60832055d72b82c8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,5e4bdd44,markdown,fr,f221e6d35b789ca7,"## 5. Normalisation quantité → grammes (le show-stopper résolu)
+
+Ciqual **ne fournit pas** de densité (74 constituants = tous des teneurs par 100 g). Le passage `(qté, unité, ingrédient) → grammes` se fait en **deux couches honnêtes** :
+
+1. **unité → millilitres (volumes) ou grammes (masses)** : une petite table fixe (`cup` = 236,6 mL, `tablespoon` = 14,8 mL, `teaspoon` = 4,93 mL, `ounce` = 28,35 g, `pound` = 453,6 g…).
+2. **millilitres → grammes** : une petite **table de densités** curée par mot-clé d'ingrédient (farine ≈ 0,53, sucre ≈ 0,85, huile ≈ 0,92, miel ≈ 1,42, eau/aqueux = 1,0 par défaut).
+3. **items comptés** (unité *vide* : `2 Eggs`, `3 Bananas`) → une table de **poids moyen par pièce** par mot-clé (œuf ≈ 50 g, banane ≈ 120 g, gousse ≈ 5 g). Indispensable sur un corpus pâtissier où les œufs abondent.
+
+Les unités **de conditionnement** restantes (`can`, `package`, `slice`…) n'ont pas de conversion fiable → masse **non calculée**. C'est une **étape de préprocessing** — et une bonne leçon de data-engineering — pas un blocage : un ingrédient apparié mais **non pesable** contribue `0` à la nutrition, honnêtement et visiblement dans les métriques (cf. exercice 2 pour élargir la couverture).",,,,,,,,f221e6d35b789ca7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,b9415167,code,fr,06f104a2fc1c9d47,"// ---- unite -> facteur (mL pour volumes, g pour masses) ; absente => non convertible ----
+var UNIT = new Dictionary<string, (double factor, bool isMass)>
+{
+    [""cup""] = (236.588, false), [""cups""] = (236.588, false),
+    [""tablespoon""] = (14.7868, false), [""tablespoons""] = (14.7868, false), [""tbsp""] = (14.7868, false), [""tbs""] = (14.7868, false),
+    [""teaspoon""] = (4.92892, false), [""teaspoons""] = (4.92892, false), [""tsp""] = (4.92892, false),
+    [""ounce""] = (28.3495, true), [""ounces""] = (28.3495, true), [""oz""] = (28.3495, true),
+    [""pound""] = (453.592, true), [""pounds""] = (453.592, true), [""lb""] = (453.592, true), [""lbs""] = (453.592, true),
+    [""gram""] = (1, true), [""grams""] = (1, true), [""g""] = (1, true), [""kg""] = (1000, true), [""kilogram""] = (1000, true),
+    [""ml""] = (1, false), [""milliliter""] = (1, false), [""millilitre""] = (1, false),
+    [""l""] = (1000, false), [""liter""] = (1000, false), [""litre""] = (1000, false),
+    [""pint""] = (473.176, false), [""pt""] = (473.176, false), [""quart""] = (946.353, false), [""qt""] = (946.353, false),
+    [""gallon""] = (3785.41, false), [""gal""] = (3785.41, false),
+    [""pinch""] = (0.36, true), [""dash""] = (0.6, false), [""stick""] = (113.0, true), [""sticks""] = (113.0, true),
+};
+// densite (g/mL) par mot-cle present dans l'item ; defaut 1.0 (eau/aqueux)
+var DENS = new (string kw, double d)[]
+{
+    (""flour"", 0.53), (""sugar"", 0.85), (""oil"", 0.92), (""butter"", 0.911), (""honey"", 1.42), (""syrup"", 1.33),
+    (""milk"", 1.03), (""cream"", 1.01), (""water"", 1.0), (""salt"", 1.22), (""rice"", 0.85), (""cocoa"", 0.52),
+    (""cornstarch"", 0.54), (""oats"", 0.41),
+};
+double Density(string itemLower) { foreach (var (kw, d) in DENS) if (itemLower.Contains(kw)) return d; return 1.0; }
+// items COMPTES (unite vide : ""2 Eggs"", ""3 Bananas"") -> poids moyen par piece, par mot-cle de tete
+var COUNT = new (string kw, double g)[]
+{
+    (""egg"", 50), (""banana"", 120), (""apple"", 180), (""onion"", 110), (""clove"", 5), (""carrot"", 60),
+    (""potato"", 150), (""tomato"", 120), (""lemon"", 60), (""lime"", 45), (""orange"", 130), (""garlic"", 5),
+    (""shallot"", 30), (""scallion"", 15), (""pepper"", 120),
+};
+double CountWeight(string itemLower) { foreach (var (kw, g) in COUNT) if (itemLower.Contains(kw)) return g; return 0; }
+
+// (qty, unite, item) -> grammes ; unite vide => item compte (table COUNT) ; unite inconnue => 0
+double ToGrams(double qty, string unit, string itemLower)
+{
+    if (qty <= 0) return 0;
+    if (unit.Length == 0) { double cw = CountWeight(itemLower); return cw > 0 ? qty * cw : 0; }  // ""2 Eggs"" -> 100 g
+    if (!UNIT.TryGetValue(unit, out var u)) return 0;                                             // ""1 can"" -> non convertible
+    return u.isMass ? qty * u.factor : qty * u.factor * Density(itemLower);
+}
+
+// demonstration
+foreach (var (q, u, it) in new[] { (2.0, ""cups"", ""white sugar""), (2.0, ""cups"", ""flour""),
+    (1.0, ""teaspoon"", ""vanilla""), (4.0, ""ounces"", ""butter""), (2.0, """", ""eggs""), (1.0, ""can"", ""crushed pineapple"") })
+    Console.WriteLine($""   {q} {(u.Length == 0 ? ""(compte)"" : u),-10} {it,-18} -> {ToGrams(q, u, it):F1} g"" +
+        (ToGrams(q, u, it) == 0 ? ""   (non convertible)"" : """"));
+",,,,,,,,06f104a2fc1c9d47,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,1fcfd65f,markdown,fr,67c338d2d7463ece,"## 6. Agrégation nutritionnelle **pondérée par la masse** + couverture par recette
+
+Pour chaque recette : on apparie chaque `item` à Ciqual (section 3), on convertit sa quantité en grammes (section 5), et on ajoute sa contribution `teneur_per_100g × grammes / 100`. C'est la correction du biais *quantity-blind* : un gâteau avec 2 tasses de farine (~250 g) ne compte plus comme 100 g.
+
+On mesure aussi la **couverture d'appariement** de chaque recette = fraction de ses ingrédients appariés à Ciqual (indépendante des quantités : c'est la qualité des **noms**). Cette couverture est le critère de gating (section 7).",,,,,,,,67c338d2d7463ece,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,8aab2456,code,fr,74181e04d0f4b6a4,"// ---- agregation ponderee + couverture par recette ----
+var built = new List<(string title, List<string> cats, decimal[] vec, double cover, int nMatch, int nItems)>();
+var mc = new Dictionary<string, string>();   // item -> code Ciqual (cache d'appariement)
+foreach (var (title, cats, ings) in recipes)
+{
+    var vec = new decimal[C];
+    int nMatch = 0;
+    foreach (var (item, qty, unit) in ings)
+    {
+        if (!mc.TryGetValue(item, out var acode)) { acode = Match(item); mc[item] = acode; }
+        if (acode == null) continue;
+        nMatch++;
+        if (!alimCompo.TryGetValue(acode, out var cv)) continue;
+        double grams = ToGrams(qty, unit, item.ToLowerInvariant());
+        if (grams <= 0) continue;                                  // apparie mais non pesable -> 0 nutrition
+        for (int k = 0; k < C; k++) vec[k] += cv[k] * (decimal)(grams / 100.0);
+    }
+    double cover = ings.Count > 0 ? (double)nMatch / ings.Count : 0;
+    built.Add((title, cats, vec, cover, nMatch, ings.Count));
+}
+int N = built.Count;
+int b100 = 0, b90 = 0, b80 = 0, b50 = 0, blo = 0; double covSum = 0;
+foreach (var r in built)
+{
+    covSum += r.cover;
+    if (r.cover >= 1.0) b100++; else if (r.cover >= 0.9) b90++; else if (r.cover >= 0.8) b80++;
+    else if (r.cover >= 0.5) b50++; else blo++;
+}
+Console.WriteLine($""Agregation : {N} recettes, couverture moyenne d'appariement = {100.0 * covSum / N:F1}%"");
+Console.WriteLine($""   couverture 100%           : {b100,5} recettes"");
+Console.WriteLine($""   couverture >=80% (solveur): {b100 + b90 + b80,5} recettes"");
+Console.WriteLine($""   couverture >=50%          : {b100 + b90 + b80 + b50,5} recettes"");
+Console.WriteLine($""   couverture  <50%          : {blo,5} recettes"");
+Console.WriteLine(""Echantillon 100% apparie (energie kJ, prot g, gluc g, lip g, sel g -- PONDERE par la masse) :"");
+foreach (var r in built.Where(x => x.cover >= 1.0 && x.vec.Any(v => v > 0)).Take(4))
+    Console.WriteLine($""   {r.title,-46} [{string.Join("", "", r.vec.Select(x => Math.Round(x, 1)))}]"");
+",,,,,,,,74181e04d0f4b6a4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,4a52d6c2,markdown,fr,915301a95b59d458,"## 7. Sous-ensembles gatés par qualité + cache JSON
+
+Le levier de **montée en charge piloté par la donnée** : plutôt qu'un plafond arbitraire (`10 → 100 → 1000`), on livre au solveur des sous-ensembles **gatés par la qualité d'appariement**. Le sous-ensemble **solveur-usable** (≥ 80 % des ingrédients appariés) est sérialisé en cache `mealplan_cache.json` — la matière première **propre** que les notebooks de modélisation ([08](08_Meal_Planner_Patient_Capstone.ipynb) capstone, [09](09_Meal_Planner_Convergence_Scale.ipynb) échelle) consommeront, sans re-parser Ciqual ni ré-apparier.
+
+> Le cache vit sous `data/meals/` (gitignore) : il est **régénéré** à l'exécution, jamais commité.",,,,,,,,915301a95b59d458,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,97771d00,code,fr,2dc1b1a9c75c01e8,"// ---- cache JSON du sous-ensemble solveur-usable (>=80% apparie) ----
+var usable = built.Where(r => r.cover >= 0.8 && r.vec.Any(v => v > 0))
+                  .Select(r => new Dictionary<string, object>
+                  {
+                      [""title""] = r.title,
+                      [""cats""] = r.cats,
+                      [""cover""] = Math.Round(r.cover, 3),
+                      [""vec""] = r.vec.Select(x => Math.Round(x, 2)).ToArray()
+                  }).ToList();
+var cachePath = Path.Combine(BASE, ""mealplan_cache.json"");
+var payload = new Dictionary<string, object>
+{
+    [""constituants""] = chosenCodes.Select(c => consts[c]).ToArray(),
+    [""n_total""] = N,
+    [""n_usable""] = usable.Count,
+    [""recipes""] = usable
+};
+File.WriteAllText(cachePath, JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = false }));
+Console.WriteLine($""Cache ecrit : {Path.GetFileName(cachePath)} -- {usable.Count} recettes solveur-usables, "" +
+    $""{new FileInfo(cachePath).Length / 1024} Ko."");
+Console.WriteLine(""Palier de montee en charge (pilote par la qualite, non par un plafond arbitraire) :"");
+Console.WriteLine($""   subset propre 100%   : {built.Count(r => r.cover >= 1.0 && r.vec.Any(v => v > 0)),5} recettes"");
+Console.WriteLine($""   subset >=80% (cache) : {usable.Count,5} recettes  <- livre au solveur"");
+Console.WriteLine($""   subset >=50%         : {built.Count(r => r.cover >= 0.5 && r.vec.Any(v => v > 0)),5} recettes"");
+Console.WriteLine(""Ce cache est la couche de donnees consommee par les notebooks 08 (capstone) et 09 (echelle)."");
+",,,,,,,,2dc1b1a9c75c01e8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,8d762fea,markdown,fr,e375661ba545e9ee,"## 8. Exercices
+
+Trois exercices de **data-engineering** (toujours 0 Z3). Ils prolongent directement les limites mesurées ci-dessus : rappel du matcheur, couverture des unités, agrégation par catégorie.",,,,,,,,e375661ba545e9ee,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,4380e68f,markdown,fr,574d8b351563a678,"### Exercice 1 — pousser le matcheur plus loin (synonymes non couverts)
+
+Le matcheur curé embarque déjà une **table de synonymes de départ** (`SYN` : `catsup`→`ketchup`, `baking soda`→`sodium bicarbonate`…). Mais la liste des **items non appariés fréquents** (à afficher : trier `mc` / `recipes` par occurrence et lister ceux sans code) révèle d'autres trous : `buttermilk`, `sherry`, `molasses`, `crisco`, `half and half`, `graham cracker`… Étendre la table `SYN` (les rediriger vers un aliment Ciqual proche), **re-appliquer** `Match`, et **re-mesurer** la couverture moyenne d'appariement (section 6) pour quantifier le gain.",,,,,,,,574d8b351563a678,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,1c09dd0f,code,fr,0d3464c111c3eb26,"// Exercice 1 : pousser le matcheur plus loin en couvrant des synonymes qui manquent.
+// Indice : reperer d'abord les items non apparies frequents, p.ex.
+//          recipes.SelectMany(r => r.ings.Select(i => i.item)).GroupBy(x => x)
+//                 .Where(g => Match(g.Key) == null).OrderByDescending(g => g.Count()).Take(20)
+//          puis ajouter des entrees a une COPIE de SYN et recomparer la couverture.
+// TODO etudiant : completer la table et re-mesurer la couverture avant/apres.
+var synonymesSup = new Dictionary<string, string>(); // ex : { [""buttermilk""]=""fermented milk"", [""molasses""]=""cane syrup"" }
+
+if (synonymesSup.Count == 0)
+    Console.WriteLine(""Exercice 1 a completer : couvrir des synonymes manquants puis re-mesurer la couverture d'appariement."");
+else
+    Console.WriteLine($""Table de {synonymesSup.Count} synonymes supplementaires prete -- reappliquer Match() et comparer."");
+",,,,,,,,0d3464c111c3eb26,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,a1b4d66d,markdown,fr,fce4c283dd8b25a9,"### Exercice 2 — étendre la couverture des unités
+
+Beaucoup d'ingrédients restent **non pesables** parce que leur unité (`can`, `package`, `clove`, `slice`, `bunch`) n'est pas dans la table `UNIT`. Ajouter des conversions plausibles (`clove` d'ail ≈ 5 g, `slice` de pain ≈ 30 g, `stick` de beurre = 113 g déjà présent), puis **compter** combien d'ingrédients gagnent une masse non nulle. Attention : certaines conversions dépendent de l'ingrédient (une « tranche » de pain ≠ une « tranche » de fromage) — documenter l'hypothèse.",,,,,,,,fce4c283dd8b25a9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,272d05ca,code,fr,ba5cadfd4c17fcf9,"// Exercice 2 : etendre la table d'unites pour rendre pesables plus d'ingredients.
+// Indice : ajouter des entrees a une copie de UNIT (clove ~5 g, slice ~30 g...) ;
+//          re-parcourir `recipes` et compter les ToGrams(...) > 0 avant/apres.
+// TODO etudiant : completer les unites supplementaires et recompter.
+var unitesSup = new Dictionary<string, (double factor, bool isMass)>(); // a completer
+
+if (unitesSup.Count == 0)
+    Console.WriteLine(""Exercice 2 a completer : ajouter des unites (clove, slice, bunch...) et recompter les ingredients pesables."");
+else
+    Console.WriteLine($""{unitesSup.Count} unites supplementaires definies -- recompter les ingredients pesables."");
+",,,,,,,,ba5cadfd4c17fcf9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,f863656b,markdown,fr,3c0b1879b7bb58cc,"### Exercice 3 — profil nutritionnel moyen par catégorie
+
+Sur le sous-ensemble solveur-usable (`usable` ou `built` filtré à `cover ≥ 0.8`), regrouper par **catégorie RecipeML** (`cats`, ex. `Cake`, `Bread`, `Soup`) et calculer le **vecteur nutritionnel moyen** de chaque catégorie. Cela révèle la structure du corpus (les desserts ressortent-ils comme attendu ?) — utile pour équilibrer un menu au notebook de modélisation.",,,,,,,,3c0b1879b7bb58cc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,7cdbe69d,code,fr,2fa7632066bd0638,"// Exercice 3 : profil nutritionnel moyen par categorie RecipeML.
+// Indice : built.Where(r => r.cover >= 0.8).SelectMany(r => r.cats.Select(c => (c, r.vec)))
+//          .GroupBy(x => x.c) puis moyenne composant par composant.
+// TODO etudiant : completer l'agregation par categorie.
+System.Collections.IEnumerable profilParCategorie = null; // remplacer par le GroupBy/Select
+
+if (profilParCategorie is null)
+    Console.WriteLine(""Exercice 3 a completer : vecteur nutritionnel moyen par categorie."");
+else
+    foreach (var row in profilParCategorie) Console.WriteLine(row);
+",,,,,,,,2fa7632066bd0638,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/07_Meal_Planner_Data_External.ipynb,7f331fa9,markdown,fr,738ea79b164f1c3a,"## Conclusion — la couche de données du bloc meal-planner
+
+Ce notebook construit la **couche de données propre** du planificateur de repas, sans jamais appeler de solveur (**0 Z3**) :
+
+- **Ciqual × RecipeML** fusionnés par **appariement lexical flou** (aucune clé commune) — la normalisation *étagée* est la leçon, ses limites sont les exercices.
+- **Quantités normalisées en grammes** (unités culinaires → mL → g via densités) — ce qui rend l'**agrégation nutritionnelle pondérée par la masse** enfin honnête, là où sommer les teneurs per-100g brutes était fictif.
+- **Sous-ensembles gatés par qualité d'appariement** (100 % / ≥80 % / ≥50 %) sérialisés en cache — le levier de **montée en charge piloté par la donnée** (des données propres de taille croissante, pas un plafond arbitraire).
+
+La leçon transverse est celle du **data-engineering** : les données réelles arrivent hétérogènes (référentiel per-100g, corpus culinaire impérial) et ne se joignent pas proprement ; il faut apparier, normaliser, et **mesurer la qualité** avant de livrer quoi que ce soit à un solveur. Ces structures typées sont la matière première des notebooks suivants du bloc meal-planner :
+
+- **Modélisation déclarative** ([06](06_Meal_Planner_Modelisation.ipynb)) — index/booléens, `MkITE`, exclusion d'allergène, théorème hiérarchique ;
+- **Capstone patient** ([08](08_Meal_Planner_Patient_Capstone.ipynb)) — théorème 4 niveaux + restrictions `Min`/`Max` ;
+- **Convergence à l'échelle** ([09](09_Meal_Planner_Convergence_Scale.ipynb)) — garder Z3 tractable quand le sous-ensemble grandit.",,,,,,,,738ea79b164f1c3a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,63d594d6,markdown,fr,a0bb19a345212e85,"# 08 — Capstone hiérarchique : du squelette `int[][]` réel aux restrictions patient (port fidèle)
+
+[< Série Z3](README.md) | Capstone MealPlanner capstone (*Part of* #4617, *See* #1206)
+
+Ce notebook est le **cœur solveur** du capstone MealPlanner. Il porte **fidèlement** la méthode
+`PlanificateurDeMenus.Create` du Demo2 d'origine
+([fork Z3.Linq, branche `EPFdevelopment`](https://github.com/MyIntelligenceAgency/Z3.LinqBinding)),
+et le construit en **deux mouvements** sur le **corpus réel** Ciqual ANSES 2025 × Recettes
+(`mealplan_cache.json`, produit par la [couche de donnees 07] — [07](07_Meal_Planner_Data_External.ipynb)) :
+
+- **Mouvement 1 — le squelette structurel `int[][]` sur les recettes reelles du cache.** Bornes de créneau par
+  rôle (entrée, plat, accompagnement…), montée en gamme, permutation totale (`Distinct` cross-row en
+  mode `CollectionHandling.Array`). C'est la **structure** hiérarchique — *quel plat à quel créneau* —
+  qui passe sans modification du corpus jouet (06) à l'échelle réelle. **Aucune nutrition** ici.
+- **Mouvement 2 — la couche nutritionnelle *fidèle* : linking de composition + restrictions patient.**
+  On ajoute ce que le squelette n'avait pas : la variable nutritionnelle **liée** au plat réellement
+  choisi (`PlatId != candidat || Comp == teneur`) et les **restrictions patient Min/Max** par
+  constituant. C'est le chaînon qui relie le corpus réel (07) au raisonnement Z3.
+
+## La hiérarchie à 4 niveaux (fidèle à la source)
+
+```
+Patient (restrictions Min/Max par constituant)
+   |
+   +-- Menu 1 .. Menu N           (un menu = un jour)
+          |
+          +-- Plat 1 .. Plat P    (un plat par créneau : ordre 1, 2, 3, ...)
+                 |
+                 +-- Denrées      (composition nutritionnelle réelle, vecteur Ciqual)
+```
+
+La nutrition d'un menu est la **somme** des compositions de ses plats ; chaque plat apporte le vecteur
+de teneurs (5 constituants Ciqual) calculé par 07. Le **patient** impose des bornes `Min`/`Max` par
+constituant (ex : énergie dans une fenêtre kJ, lipides plafonnées) — exactement la classe
+`Restriction { Min, Max }` du source.
+
+> **Note de consolidation.** Ce notebook réunit le squelette structurel à l'échelle réelle (Mouvement 1)
+> et le théorème nutritionnel fidèle (Mouvement 2), auparavant éclatés en deux notebooks. La leçon est
+> séquentielle : la *structure* passe à l'échelle sans effort, c'est l'ajout de la *nutrition fidèle*
+> (le linking) qui fait exploser l'instance et impose de **curer** un sous-ensemble (cf Mouvement 2).",,,,,,,,a0bb19a345212e85,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,38ab910e,markdown,fr,24bd3db6b12b774e,"## 0. Dependances et corpus
+
+Le notebook charge le cache `mealplan_cache.json` produit par [07(07_Meal_Planner_Data_External.ipynb)).
+Si le cache est absent : executer 07 (ou `python download_meal_data.py` puis 07). **Echec bruyant**, pas
+de corpus de substitution (regle SOTA : on raisonne sur les vraies donnees nutritionnelles).
+
+Le fork Z3.Linq est charge depuis `.deploy/` (script de build unique, cf README) — meme build que
+toute la serie, incluant le support `int[][]` et `CollectionHandling.Array`.",,,,,,,,24bd3db6b12b774e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,350f2193,code,fr,7e397bb2764dda1a,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Diagnostics;
+
+// Plat du corpus (miroir du contrat du cache 07 : recipes[].{title,cats,vec}).
+public class PlatImport {
+    public string Nom { get; set; }
+    public int Ordre { get; set; }              // creneau 1..5, derive des cats RecipeML
+    public decimal[] Compositions { get; set; } // vec[5] = [Energie kJ, Proteines, Glucides, Lipides, Sel]
+}
+
+// Cache solveur-usable produit par le notebook 07 (couche Ciqual x Recettes RecipeML).
+var CACHE = Path.Combine(""data/meals"", ""mealplan_cache.json"");
+if (!File.Exists(CACHE)) {
+    Console.WriteLine(""[CACHE ABSENT] "" + CACHE);
+    Console.WriteLine(""Executez d'abord 07 (couche de donnees) de bout en bout,"");
+    Console.WriteLine(""ou : python download_meal_data.py puis 07. Echec bruyant (regle SOTA)."");
+    throw new FileNotFoundException(CACHE);
+}
+Console.WriteLine($""Cache present : {CACHE} ({new FileInfo(CACHE).Length / 1024} Ko)"");
+
+// Derivation du creneau (Ordre 1..5) depuis les cats RecipeML (corpus anglo-saxon).
+// 1=entree/appetizer, 2=plat principal/main dish, 3=accompagnement/vegetal, 4=laitage/fromage, 5=dessert.
+// Les recettes non-categorisees (cats=['None'] ou ambigu) sont ecartees (pas de fabrication de creneau).
+int OrdreFromCats(List<string> cats) {
+    var j = string.Join("" "", cats).ToLowerInvariant();
+    if (j.Contains(""appetizer"") || j.Contains(""starter"") || j.Contains(""soup"")) return 1;
+    if (j.Contains(""main dish"") || j.Contains(""beef"") || j.Contains(""pork"") || j.Contains(""chicken"") || j.Contains(""meat"") || j.Contains(""fish"")) return 2;
+    if (j.Contains(""vegetable"") || j.Contains(""salad"") || j.Contains(""rice"") || j.Contains(""pasta"") || j.Contains(""potato"") || j.Contains(""bread"") || j.Contains(""side"")) return 3;
+    if (j.Contains(""cheese"") || j.Contains(""dairy"") || j.Contains(""yogurt"") || j.Contains(""cream"")) return 4;
+    if (j.Contains(""dessert"") || j.Contains(""cake"") || j.Contains(""cookie"") || j.Contains(""pie"") || j.Contains(""fruit"") || j.Contains(""sweet"") || j.Contains(""tart"")) return 5;
+    return 0;
+}
+
+var sw = Stopwatch.StartNew();
+var root = JsonDocument.Parse(File.ReadAllText(CACHE)).RootElement;
+var constituants = root.GetProperty(""constituants"").EnumerateArray().Select(x => x.GetString()).ToArray();
+int C = constituants.Length;
+var allPlats = new List<PlatImport>();
+foreach (var r in root.GetProperty(""recipes"").EnumerateArray()) {
+    var t = r.GetProperty(""title"").GetString().Trim();
+    var cats = r.GetProperty(""cats"").EnumerateArray().Select(x => x.GetString()).ToList();
+    int o = OrdreFromCats(cats);
+    if (o < 1) continue;   // orphan ecarte
+    allPlats.Add(new PlatImport {
+        Nom = t.Length > 44 ? t.Substring(0, 44) : t,
+        Ordre = o,
+        Compositions = r.GetProperty(""vec"").EnumerateArray().Select(x => x.GetDecimal()).ToArray()
+    });
+}
+sw.Stop();
+Console.WriteLine($""Cache charge en {sw.Elapsed.TotalSeconds:F1}s : {allPlats.Count} recettes exploitables (sur {root.GetProperty(""n_total"").GetInt32()} brutes), {C} constituants."");
+Console.WriteLine(""Constituants : "" + string.Join("" | "", constituants.Select((n, i) => $""[{i}] {n.Split(',')[0].Trim()}"")));",,,,,,,,7e397bb2764dda1a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,d0e2d48c,markdown,fr,22d504007cc9dc4f,"## Mouvement 1 — Le squelette structurel `int[][]` sur le corpus réel (plusieurs centaines de recettes)
+
+Avant la nutrition, on établit la **structure** : sélectionner, parmi le vrai catalogue de plusieurs centaines de recettes (cache 07 plats,
+un plan de 7 jours qui respecte le **rôle de chaque créneau** et la **diversité** — le tout en LINQ pur
+sur un `int[][]`. C'est le théorème hiérarchique du notebook [06](06_Meal_Planner_Modelisation.ipynb)
+(corpus jouet) porté **sans modification** à l'échelle réelle, en deux variantes : *montée en gamme* et
+*permutation totale*. Aucune teneur nutritionnelle n'intervient encore — uniquement les index de plats.",,,,,,,,22d504007cc9dc4f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,cbef5234,markdown,fr,c75122ca2c56377c,"### 1.1 Le corpus réel et sa structure en créneaux
+
+Chaque plat porte un **creneau** (`Ordre`, de 1 a 7) : entree, plat principal, accompagnement, laitage/fromage, dessert, etc. C'est cette structure qui rend le probleme *hierarchique* — un plan de repas n'est pas un sac de plats interchangeables, chaque jour doit servir **un plat par creneau, du bon type**.
+
+Pour rendre chaque creneau adressable par une **plage d'index contigue** (exactement comme les bornes de categorie `[entLo, entHi]` du notebook 06 jouet), on **trie les plats par creneau**. On se restreint aux creneaux 1 a 5 (les plus garnis), suffisants pour un plan equilibre de 7 jours.",,,,,,,,c75122ca2c56377c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,f34e9f2f,code,fr,6711f3af1ae54756,"const int Jours = 7;
+const int Creneaux = 5;   // ordres 1..5
+
+// Trie par creneau -> chaque ordre occupe une plage d'index contigue [lo[o]..hi[o]].
+var plats = allPlats.Where(p => p.Ordre >= 1 && p.Ordre <= Creneaux)
+                      .OrderBy(p => p.Ordre).ThenBy(p => p.Nom).ToList();
+
+var lo = new int[Creneaux + 1];
+var hi = new int[Creneaux + 1];
+string[] roles = { """", ""entree"", ""plat principal"", ""accompagnement"", ""laitage/fromage"", ""dessert"" };
+for (int o = 1; o <= Creneaux; o++)
+{
+    lo[o] = plats.FindIndex(p => p.Ordre == o);
+    hi[o] = plats.FindLastIndex(p => p.Ordre == o);
+    Console.WriteLine($""  creneau {o} ({roles[o],-16}) : index [{lo[o]}..{hi[o]}]  ({hi[o] - lo[o] + 1} plats)"");
+}
+Console.WriteLine($""\nTotal exploitable : {plats.Count} plats sur {Creneaux} creneaux."");
+Console.WriteLine(""\nExemples (creneau 1) : "" + string.Join("", "",
+    plats.Where(p => p.Ordre == 1).Take(4).Select(p => p.Nom.Trim())));",,,,,,,,6711f3af1ae54756,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,b7dffde0,markdown,fr,e3a77de2b1f73baf,"### 1.2 Le théorème hiérarchique `int[][]`
+
+On modelise le plan hebdomadaire comme un **tableau en escalier** `int[][]` : `Plan[j][c]` = l'index (dans la liste triee `plats`) du plat servi le jour `j` au creneau `c`. C'est la **meme structure** que le notebook 06 jouet, mais a l'echelle reelle.
+
+Les helpers sont definis dans une **classe statique** (`Menu`) : dans un noyau .NET Interactive, une classe statique **persiste d'une cellule a l'autre**, contrairement a une fonction locale. Le theoreme et les exercices la reutilisent.
+
+- `WithBounds` impose, pour chaque jour et chaque creneau, que l'index reste dans la plage du bon creneau (`Plan[j][c] in [lo[c+1], hi[c+1]]`). C'est la contrainte de categorie, exprimee une fois pour les `7 x 5 = 35` cases.
+- `PrintPlan` affiche le plan resolu en remontant des index aux noms de plats.",,,,,,,,e3a77de2b1f73baf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,df322ccc,code,fr,22e0921cbf7773a3,"// Plan hebdomadaire : 7 jours x 5 creneaux, modelise comme int[][] (jagged).
+public class WeeklyMenuPlan
+{
+    public int[][] Plan { get; set; } = new int[7][];
+    public WeeklyMenuPlan() { for (int j = 0; j < 7; j++) Plan[j] = new int[5]; }
+}
+
+// Classe statique -> persiste entre cellules. Reutilisee par le theoreme ET les exercices.
+public static class Menu
+{
+    public const int Jours = 7;
+    public const int Creneaux = 5;
+
+    // Bornes de categorie : Plan[j][c] doit indexer un plat du creneau (c+1).
+    public static Theorem<WeeklyMenuPlan> WithBounds(Z3Context ctx, int[] lo, int[] hi)
+    {
+        var t = ctx.NewTheorem<WeeklyMenuPlan>();
+        for (int j = 0; j < Jours; j++)
+        {
+            int jj = j;
+            for (int c = 0; c < Creneaux; c++)
+            {
+                int cc = c, o = c + 1;
+                int basLo = lo[o], basHi = hi[o];   // capture en constantes pour la traduction Z3
+                t = t.Where(p => p.Plan[jj][cc] >= basLo && p.Plan[jj][cc] <= basHi);
+            }
+        }
+        return t;
+    }
+
+    public static void PrintPlan(WeeklyMenuPlan plan, List<PlatImport> plats)
+    {
+        for (int j = 0; j < Jours; j++)
+        {
+            var noms = Enumerable.Range(0, Creneaux).Select(c => plats[plan.Plan[j][c]].Nom.Trim());
+            Console.WriteLine($""  Jour {j + 1} : "" + string.Join("" | "",
+                noms.Select(n => n.Length > 22 ? n.Substring(0, 22) : n)));
+        }
+    }
+}
+Console.WriteLine(""Helpers definis : WeeklyMenuPlan, Menu.WithBounds, Menu.PrintPlan."");",,,,,,,,22e0921cbf7773a3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,4540f3b2,code,fr,e5a608c0bf040999,"// --- Variante A : montee en gamme (mode Array implicite) ---
+// Pour chaque creneau, l'index du plat croit strictement au fil de la semaine :
+// une selection ordonnee, sans repetition, qui ""monte en gamme"" jour apres jour.
+using (var ctx = new Z3Context())
+{
+    var th = Menu.WithBounds(ctx, lo, hi);
+    for (int c = 0; c < Creneaux; c++)
+    {
+        int cc = c;
+        for (int j = 0; j < Jours - 1; j++)
+        {
+            int jj = j;
+            th = th.Where(p => p.Plan[jj][cc] < p.Plan[jj + 1][cc]);
+        }
+    }
+    var sw = Stopwatch.StartNew();
+    var plan = th.Solve();
+    sw.Stop();
+    Console.WriteLine($""[A] Montee en gamme resolue en {sw.Elapsed.TotalMilliseconds:F0} ms :\n"");
+    if (plan != null) Menu.PrintPlan(plan, plats); else Console.WriteLine(""  UNSAT"");
+}",,,,,,,,e5a608c0bf040999,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,e145377e,markdown,fr,b672946a6142e284,"### Interpretation — variante A
+
+La contrainte de montee en gamme (`Plan[j][c] < Plan[j+1][c]`) force, pour chaque creneau, une **suite d'index strictement croissante** sur les 7 jours. Comme les plats sont tries par creneau, cela revient a parcourir le catalogue dans l'ordre, sans jamais reservir le meme plat. Z3.Linq traduit le `int[][]` en variables entieres et resout en LINQ pur, sans expansion manuelle des paires.",,,,,,,,b672946a6142e284,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,f9db8d5c,code,fr,436192c2033f186a,"// --- Variante B : permutation totale (CollectionHandling.Array EXPLICITE, Distinct cross-row) ---
+// Chaque creneau est servi 7 fois dans la semaine, sans aucune repetition :
+// Z3Methods.Distinct s'applique directement aux acces cross-row d'un int[][]
+// (meme marqueur que les colonnes d'un Sudoku) -> une contrainte globale SMT.
+using (var ctxPerm = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array })
+{
+    var perm = Menu.WithBounds(ctxPerm, lo, hi);
+    for (int c = 0; c < Creneaux; c++)
+    {
+        int cc = c;
+        perm = perm.Where(p => Z3Methods.Distinct(
+            p.Plan[0][cc], p.Plan[1][cc], p.Plan[2][cc], p.Plan[3][cc],
+            p.Plan[4][cc], p.Plan[5][cc], p.Plan[6][cc]));
+    }
+    var sw = Stopwatch.StartNew();
+    var planPerm = perm.Solve();
+    sw.Stop();
+    Console.WriteLine($""[B] Permutation totale (Distinct cross-row) resolue en {sw.Elapsed.TotalMilliseconds:F0} ms :\n"");
+    if (planPerm != null) Menu.PrintPlan(planPerm, plats); else Console.WriteLine(""  UNSAT"");
+}",,,,,,,,436192c2033f186a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,f945ba3b,markdown,fr,15cb6de62f19a776,"### Interpretation — variante B
+
+La variante B n'impose plus d'ordre, seulement la **diversite** : chaque creneau est servi sans repetition sur la semaine. `Z3Methods.Distinct` appliquee aux acces *cross-row* d'un `int[][]` produit **une seule contrainte SMT globale** par creneau (et non `C(7,2)` inegalites deux-a-deux) — exactement le mecanisme qui modelise les colonnes d'un Sudoku.
+
+Le mode `CollectionHandling.Array` est ici **explicite** : il indique a Z3.Linq de reifier le tableau comme un tableau SMT, ce qui rend les acces cross-row adressables par `Distinct`. C'est le levier qui fait passer le `int[][]` du statut de simple structure de donnees a celui de **variable de decision hierarchique**.",,,,,,,,15cb6de62f19a776,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,a19e7e62,markdown,fr,9a9af61528125f9e,"## Mouvement 2 — La nutrition *fidèle* force la curation
+
+Le squelette structurel passe à l'échelle réelle sans effort (Z3 résout les deux variantes en quelques
+dizaines de millisecondes sur le corpus réel). On ajoute maintenant la **couche nutritionnelle fidèle** au
+Demo2 : le **linking de composition** (la variable de teneur liée au plat réellement choisi) **et** les
+**restrictions patient Min/Max** sur la somme par menu. Mais le linking, à l'échelle complète, génère
+`7 × 5 × R × C` assertions (R recettes, C constituants) — l'instance **explose**. On **cure** donc d'abord un
+sous-ensemble tractable, en préservant la **structure** du théorème (port fidèle de
+`PlanificateurDeMenus.Create`).",,,,,,,,9a9af61528125f9e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0c508613,markdown,fr,f9457410196e5dee,"### 2.1 Curation d'un sous-ensemble tractable
+
+La source pose le theoreme sur plusieurs centaines de recettes x 5 constituants x 7 menus x 5 creneaux. Le linking de
+composition genere alors `7 x 5 x R x C` (R recettes, C constituants) assertions — l'instance **explose** (c'est
+precisement le probleme de *convergence a l'echelle*, objet de [09 (convergence a l'echelle)](09_Meal_Planner_Convergence_Scale.ipynb)). Le corps de l'issue
+#4617 le prevoit : **on cure d'abord un sous-ensemble**.
+
+On reduit donc a **2 menus x 3 creneaux**, **5 candidats par creneau**, et **3 constituants cles**
+(energie kJ, proteines, lipides). Le theoreme reste **fidele dans sa structure** ; seules les
+*dimensions* sont reduites pour rester pedagogiquement lisible et resoluble en quelques secondes.",,,,,,,,f9457410196e5dee,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,3115b835,code,fr,bc276b38324cba61,"// --- Parametres du sous-ensemble cure ---
+const int NbMenus = 2;          // 2 jours
+const int NbPlats = 3;          // 3 creneaux (ordre 1, 2, 3)
+const int CandParOrdre = 5;     // 5 candidats par creneau
+
+// 3 constituants cles du cache 07 (ordre fixe : [0] Energie kJ, [1] Proteines, [3] Lipides).
+int cEnergie = 0;
+int cProt    = 1;
+int cLip     = 3;
+int[] CONST  = new[]{ cEnergie, cProt, cLip };
+string[] NOMK = new[]{ ""energie(kJ)"", ""proteines(g)"", ""lipides(g)"" };
+Console.WriteLine(""Constituants suivis :"");
+foreach (var ci in CONST) Console.WriteLine($""  [{ci}] {constituants[ci].Trim()}"");
+
+// Pool curee : CandParOrdre plats par ordre 1..NbPlats, re-indexes 0..(NbPlats*CandParOrdre-1).
+var pool = new List<PlatImport>();
+for (int o = 1; o <= NbPlats; o++)
+    pool.AddRange(allPlats.Where(p => p.Ordre == o).Take(CandParOrdre));
+Console.WriteLine($""\nPool curee : {pool.Count} plats ({NbPlats} creneaux x {CandParOrdre} candidats)"");
+
+// teneur arrondie a l'entier (arithmetique entiere Z3) ; helpers d'indexation aplatie
+int Teneur(int poolIdx, int constIdx) => (int)Math.Round(pool[poolIdx].Compositions[constIdx]);
+int Slot(int m, int p) => m * NbPlats + p;   // ligne aplatie pour le slot (menu m, creneau p)
+Console.WriteLine(""\nApercu (creneau : candidats -> energie kJ) :"");
+for (int p = 0; p < NbPlats; p++) {
+    var noms = Enumerable.Range(p*CandParOrdre, CandParOrdre)
+        .Select(i => $""{pool[i].Nom.Trim()}({Teneur(i, cEnergie)})"");
+    Console.WriteLine($""  creneau {p+1} : "" + string.Join("", "", noms));
+}",,,,,,,,bc276b38324cba61,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,cf93b03d,markdown,fr,a74cce1a06dab1e2,"### 2.2 Le modèle : 3 tableaux `int[][]`
+
+Le Demo2 d'origine modelise un **graphe d'objets** (`Menu[]` contenant `Plat[]` contenant `PlatId` +
+`Compositions[]`). Le binding Z3.Linq de la serie expose, lui, des **tableaux `int[][]`** (cf 05) :
+c'est l'encodage *index* que le fork resout en notebook. On reproduit donc la **semantique** de la
+source avec trois `int[][]` :
+
+| Tableau | Forme | Role |
+|---------|-------|------|
+| `PlatId[m][p]`  | `[NbMenus][NbPlats]`          | index (dans la pool) du plat choisi au creneau (m, p) |
+| `Comp[slot][k]` | `[NbMenus*NbPlats][3]`        | composition du plat choisi a ce slot (variable liee par disjonction) |
+| `MenuNut[m][k]` | `[NbMenus][3]`                | somme nutritionnelle du menu m (ce que le patient contraint) |
+
+`Comp` est l'**aux variable** qui resout l'impossibilite d'indexer un tableau C# par une variable Z3
+(on ne peut pas ecrire `Plats[PlatId[m][p]]`) : on la **lie** au bon plat par une disjonction
+(section 3.3), exactement la technique de la source.",,,,,,,,a74cce1a06dab1e2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,dd05ae3f,code,fr,d21828c57aae7b33,"public class PlanRepas {
+    public int[][] PlatId  { get; set; }   // [NbMenus][NbPlats]      : plat choisi par creneau
+    public int[][] Comp    { get; set; }   // [NbMenus*NbPlats][3]    : composition liee du slot
+    public int[][] MenuNut { get; set; }   // [NbMenus][3]            : somme par menu
+    public PlanRepas() {
+        PlatId  = Enumerable.Range(0, 2).Select(_ => new int[3]).ToArray();
+        Comp    = Enumerable.Range(0, 6).Select(_ => new int[3]).ToArray();
+        MenuNut = Enumerable.Range(0, 2).Select(_ => new int[3]).ToArray();
+    }
+}
+Console.WriteLine(""Modele PlanRepas defini (PlatId, Comp, MenuNut)."");
+",,,,,,,,d21828c57aae7b33,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,78ce72f9,markdown,fr,bd777ff45073bba2,"### 2.3 Le patient et ses restrictions
+
+Fidele a la classe `Patient { Restriction[] Restrictions }` du source : chaque restriction porte un
+`Min` et un `Max` par constituant (`-1` = pas de borne). Ici, le patient impose une **fenetre
+energetique** par menu et un **plafond de lipides**.",,,,,,,,bd777ff45073bba2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,12060328,code,fr,3983a26d9aa29f53,"// Restrictions patient (fidele a Restriction { Min, Max }, -1 = pas de borne), par MENU.
+// Echelle : cache 07 en kJ/100 g (Energie Ciqual) sommees sur les 3 plats du menu.
+// ( bornes rescalees de kcal -> kJ lors du rewire sur le cache 07 : x4,184 )
+int energieMin = 3347;   // ~800 kcal cumules minimum par menu
+int energieMax = 10878;  // ~2600 kcal cumules maximum par menu
+int protMin    = 30;     // proteines minimum par menu (g)
+int lipMax     = 600;    // lipides maximum par menu (g)
+Console.WriteLine($""Patient : energie in [{energieMin}, {energieMax}] kJ, proteines >= {protMin} g, lipides <= {lipMax} g (par menu)"");
+",,,,,,,,3983a26d9aa29f53,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0af45f83,markdown,fr,876193c4f558eb0c,"### 3.1 -> 3.5 Construction du theoreme (port fidele de `Create`)
+
+Les cinq familles de contraintes reproduisent `PlanificateurDeMenus.Create` (source lignes 38-101) :
+
+1. **Bornes = ordre** : `PlatId[m][p]` indexe un plat du creneau (p+1) — la source impose
+   `allPlats[rid].Ordre == p+1` ; ici la partition de la pool par ordre l'encode dans les bornes.
+2. **Variete** : `Z3Methods.Distinct(...)` sur tous les slots — *pas deux fois le meme plat*
+   (source : `Distinct` sur la grille des `PlatId`).
+3. **Linking composition** : `PlatId[m][p] != cand || Comp[slot][k] == teneur(cand, k)` — lie la
+   variable de composition au plat reellement choisi (source lignes 71-74).
+4. **Somme par menu** : `MenuNut[m][k] == somme_p Comp[slot(m,p)][k]` (source lignes 84-85).
+5. **Restrictions patient** : `Min < MenuNut[m][k] < Max` selon les bornes du patient (source lignes 90-99).",,,,,,,,876193c4f558eb0c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,75a666b7,code,fr,6b94e5943fca3d43,"var sw = Stopwatch.StartNew();
+PlanRepas sol = null;
+using (var ctx = new Z3Context { DefaultCollectionHandling = CollectionHandling.Array })
+{
+    var th = ctx.NewTheorem<PlanRepas>();
+
+    // (1) bornes = contrainte d'ordre : slot p -> candidats du creneau (p+1)
+    for (int m = 0; m < NbMenus; m++) for (int p = 0; p < NbPlats; p++) {
+        int mm = m, pp = p, lo = p * CandParOrdre, hi = p * CandParOrdre + CandParOrdre - 1;
+        th = th.Where(x => x.PlatId[mm][pp] >= lo && x.PlatId[mm][pp] <= hi);
+    }
+
+    // (2) variete : Distinct global sur les 6 slots
+    th = th.Where(x => Z3Methods.Distinct(
+        x.PlatId[0][0], x.PlatId[0][1], x.PlatId[0][2],
+        x.PlatId[1][0], x.PlatId[1][1], x.PlatId[1][2]));
+
+    // (3) linking composition : PlatId[m][p] != cand || Comp[slot][k] == teneur(cand, k)
+    for (int m = 0; m < NbMenus; m++) for (int p = 0; p < NbPlats; p++) {
+        int slot = Slot(m, p), mm = m, pp = p;
+        for (int cand = p * CandParOrdre; cand < p * CandParOrdre + CandParOrdre; cand++) {
+            int cc = cand;
+            for (int k = 0; k < CONST.Length; k++) {
+                int kk = k, val = Teneur(cand, CONST[k]);
+                th = th.Where(x => x.PlatId[mm][pp] != cc || x.Comp[slot][kk] == val);
+            }
+        }
+    }
+
+    // (4) somme par menu : MenuNut[m][k] == Comp[s0][k] + Comp[s1][k] + Comp[s2][k]
+    for (int m = 0; m < NbMenus; m++) for (int k = 0; k < CONST.Length; k++) {
+        int mm = m, kk = k, s0 = Slot(m, 0), s1 = Slot(m, 1), s2 = Slot(m, 2);
+        th = th.Where(x => x.MenuNut[mm][kk] == x.Comp[s0][kk] + x.Comp[s1][kk] + x.Comp[s2][kk]);
+    }
+
+    // (5) restrictions patient : energie in [min,max], proteines >= min, lipides <= max (par menu)
+    for (int m = 0; m < NbMenus; m++) {
+        int mm = m;
+        th = th.Where(x => x.MenuNut[mm][0] >= energieMin && x.MenuNut[mm][0] <= energieMax);
+        th = th.Where(x => x.MenuNut[mm][1] >= protMin);
+        th = th.Where(x => x.MenuNut[mm][2] <= lipMax);
+    }
+
+    sol = th.Solve();
+}
+sw.Stop();
+Console.WriteLine($""Theoreme resolu en {sw.Elapsed.TotalMilliseconds:F0} ms\n"");
+if (sol == null) {
+    Console.WriteLine(""UNSAT : aucun plan ne satisfait les restrictions du patient sur cette pool."");
+} else {
+    for (int m = 0; m < NbMenus; m++) {
+        Console.WriteLine($""== Menu {m + 1} ==  energie={sol.MenuNut[m][0]} kJ | ""
+            + $""proteines={sol.MenuNut[m][1]} g | lipides={sol.MenuNut[m][2]} g"");
+        for (int p = 0; p < NbPlats; p++) {
+            var plat = pool[sol.PlatId[m][p]];
+            Console.WriteLine($""   creneau {p + 1} : {plat.Nom.Trim(),-30} ""
+                + $""(kJ={Teneur(sol.PlatId[m][p], cEnergie)}, prot={Teneur(sol.PlatId[m][p], cProt)}, lip={Teneur(sol.PlatId[m][p], cLip)})"");
+        }
+    }
+}
+",,,,,,,,6b94e5943fca3d43,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,9f874047,markdown,fr,7b36febf63056bc6,"### 2.4 Vérification : les restrictions sont-elles vraiment respectées ?
+
+Un solveur **garantit** les contraintes par construction — mais on **verifie** independamment
+(re-calcul hors Z3) que chaque menu respecte la fenetre du patient. C'est la difference entre *croire*
+le solveur et *prouver* le resultat.",,,,,,,,7b36febf63056bc6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,369a86be,code,fr,bcd10ff436953da7,"if (sol == null) {
+    Console.WriteLine(""Pas de solution a verifier (UNSAT)."");
+} else {
+    bool ok = true;
+    for (int m = 0; m < NbMenus; m++) {
+        // re-somme directe depuis la pool (independante des variables Z3)
+        int e = 0, pr = 0, li = 0;
+        for (int p = 0; p < NbPlats; p++) {
+            e  += Teneur(sol.PlatId[m][p], cEnergie);
+            pr += Teneur(sol.PlatId[m][p], cProt);
+            li += Teneur(sol.PlatId[m][p], cLip);
+        }
+        bool eOk = e >= energieMin && e <= energieMax, pOk = pr >= protMin, lOk = li <= lipMax;
+        bool match = e == sol.MenuNut[m][0] && pr == sol.MenuNut[m][1] && li == sol.MenuNut[m][2];
+        ok &= eOk && pOk && lOk && match;
+        Console.WriteLine($""Menu {m+1} : recalc energie={e}({(eOk?""OK"":""HORS"")}), prot={pr}({(pOk?""OK"":""HORS"")}), ""
+            + $""lip={li}({(lOk?""OK"":""HORS"")}) ; coherent avec MenuNut={(match?""oui"":""NON"")}"");
+    }
+    Console.WriteLine(ok ? ""\nVERIFIE : toutes les restrictions patient sont respectees.""
+                         : ""\nINCOHERENCE detectee (a investiguer)."");
+}
+",,,,,,,,bcd10ff436953da7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,217c5e18,markdown,fr,6d3d05ea075f99da,"## Exercices
+
+Quatre exercices pour s'approprier le capstone, du squelette structurel (Mouvement 1) au théorème
+hiérarchique à restrictions patient (Mouvement 2). Les stubs s'exécutent tels quels (ils n'échouent
+pas) ; complétez le corps marqué `TODO`.",,,,,,,,6d3d05ea075f99da,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,5819459e,markdown,fr,fd3e7c5e2368ded8,"### Exercice 1 — Diversité des entrées sur jours consécutifs (structure)
+
+Renforcez le théorème structurel du **Mouvement 1** : interdisez de servir **deux fois la même entrée**
+(créneau 1) sur **deux jours consécutifs**. Repartez de `Menu.WithBounds(ctx, lo, hi)` et ajoutez la
+contrainte d'inégalité consécutive.
+
+*Indice :* pour `j` de 0 à `Jours-2`, ajoutez `p.Plan[j][0] != p.Plan[j+1][0]`.",,,,,,,,fd3e7c5e2368ded8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,b4eaccf6,code,fr,31f84064f588a87f,"// Exercice 1 — Diversite renforcee : pas deux fois la meme entree (creneau 1)
+//              sur deux jours CONSECUTIFS.
+//
+// Indice : ajoutez, pour j de 0 a Jours-2, une contrainte
+//          p.Plan[j][0] != p.Plan[j+1][0]  sur un theoreme construit avec Menu.WithBounds.
+// Etape 1 : creez un Z3Context (mode Array implicite suffit).
+// Etape 2 : partez de Menu.WithBounds(ctx, lo, hi), ajoutez la contrainte d'inegalite consecutive.
+// Etape 3 : resolvez et affichez avec Menu.PrintPlan.
+//
+// TODO etudiant : completez ci-dessous.
+Console.WriteLine(""Exercice 1 a completer : diversite des entrees sur jours consecutifs."");",,,,,,,,31f84064f588a87f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,b735bf7e,markdown,fr,534e99f960aa0020,"### Exercice 2 — Une restriction qui rend le probleme insatisfiable
+
+Le patient devient diabetique : imposez un **plafond energetique strict** par menu (ex. `energieMax = 1500`)
+et reconstruisez le theoreme. Observez si Z3 trouve encore un plan ou repond **UNSAT**, et expliquez
+*pourquoi* (quel creneau porte l'essentiel de l'energie kJ ?).
+
+*Indice* : recopiez le bloc de la section 3.5 en changeant `energieMax`, ou parametrez-le.",,,,,,,,534e99f960aa0020,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,93574677,code,fr,bde26de98254ba54,"// Exercice 2 : trouver le plafond energetique qui bascule SAT -> UNSAT.
+// TODO etudiant : reconstruire le theoreme avec un energieMax plus strict et reporter le verdict.
+int ExerciceUnsatThreshold()
+{
+    // Etape 1 : choisir un energieMax candidat (ex. 1500)
+    // Etape 2 : reconstruire le theoreme (sections 1-5 bornes/Distinct/linking/somme/restrictions)
+    //           en remplacant la borne energieMax
+    // Etape 3 : retourner le plus grand energieMax pour lequel le probleme est UNSAT (ou -1 si toujours SAT)
+    Console.WriteLine(""Exercice 2 a completer"");
+    return -1;
+}
+ExerciceUnsatThreshold();
+",,,,,,,,bde26de98254ba54,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,6bd5be84,markdown,fr,c16b609952f1456e,"### Exercice 3 — Passer a 3 menus (tractabilite)
+
+Portez `NbMenus` de 2 a **3** (3 jours). Adaptez la taille des tableaux du modele `PlanRepas`
+(`PlatId` `[3][3]`, `Comp` `[9][3]`, `MenuNut` `[3][3]`) et le `Distinct` (9 slots). Mesurez le temps
+de resolution : reste-t-il de l'ordre de la seconde ? C'est un premier pas vers [09 (convergence a l'echelle)](09_Meal_Planner_Convergence_Scale.ipynb)
+(convergence a l'echelle).
+
+*Indice* : `Z3Methods.Distinct` accepte une liste d'arguments ; enumerez les 9 `PlatId[m][p]`.",,,,,,,,c16b609952f1456e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,6b204fc2,code,fr,a1f4f77f8bf30596,"// Exercice 3 : etendre a NbMenus = 3 et mesurer le temps de resolution.
+// TODO etudiant : adapter le modele (tailles), le Distinct (9 slots) et resoudre.
+double ExerciceTroisMenus()
+{
+    // Etape 1 : definir un modele PlanRepas3 avec PlatId[3][3], Comp[9][3], MenuNut[3][3]
+    // Etape 2 : reconstruire les 5 familles de contraintes pour 3 menus
+    // Etape 3 : chronometrer Solve() et retourner le temps en millisecondes (ou -1 si UNSAT)
+    Console.WriteLine(""Exercice 3 a completer"");
+    return -1.0;
+}
+ExerciceTroisMenus();
+",,,,,,,,a1f4f77f8bf30596,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,4aebb61d,markdown,fr,ab21d82ff5c56cba,"### Exercice 4 — Ajouter un quatrieme constituant suivi
+
+Le patient surveille aussi le **sel** (`Sel chlorure de sodium`). Ajoutez ce constituant a `CONST`
+(repere par nom), etendez `Comp`/`MenuNut` a 4 colonnes, et imposez un **plafond de sel** par menu.
+Le plan reste-t-il satisfiable ?
+
+*Indice* : `constituants.Select((n,i) => (n,i)).First(x => x.n.ToLowerInvariant().Contains(""sel chlorure""))`.",,,,,,,,ab21d82ff5c56cba,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,127b8448,code,fr,61c72c1c909bb1c3,"// Exercice 4 : suivre un 4e constituant (sel) et lui imposer un plafond par menu.
+// TODO etudiant : etendre CONST a 4 elements et ajouter la restriction de sel.
+int ExerciceConstituantSel()
+{
+    // Etape 1 : reperer l'index du constituant ""Sel chlorure de sodium""
+    // Etape 2 : etendre CONST/Comp/MenuNut a 4 colonnes
+    // Etape 3 : ajouter Where(MenuNut[m][3] <= selMax) et retourner le sel max du menu 1 de la solution
+    Console.WriteLine(""Exercice 4 a completer"");
+    return 0;
+}
+ExerciceConstituantSel();
+",,,,,,,,61c72c1c909bb1c3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb,0a278a03,markdown,fr,69a08b49c26e9a52,"## Conclusion
+
+Ce notebook a porté **fidèlement** le cœur solveur du Demo2 (`PlanificateurDeMenus.Create`) en deux
+mouvements sur le **corpus réel** Ciqual × Recettes construit par
+[07 (couche de donnees)](07_Meal_Planner_Data_External.ipynb) :
+
+- **Mouvement 1 — la structure prime sur l'échelle.** Le même `int[][]` modélise un plan de 7 jours sur
+  un vrai catalogue de plusieurs centaines de plats ; c'est la *structure en créneaux* (et non le nombre de plats) qui fait
+  du problème un problème hiérarchique. Bornes de catégorie, montée en gamme et permutation totale
+  (`Distinct` cross-row, `CollectionHandling.Array`) passent **sans modification** du corpus jouet (06)
+  au réel — Z3 résout en quelques dizaines de millisecondes.
+- **Mouvement 2 — le théorème fidèle à 4 niveaux.** Patient → Menus → Plats → Denrées, avec le
+  **linking de composition** (la variable nutritionnelle liée au plat réellement choisi) et les
+  **restrictions patient Min/Max** sur la somme par menu — le chaînon nutritionnel que le squelette
+  n'avait pas. À l'échelle complète, le linking explose (un nombre eleve d'assertions) : on a **curé** un
+  sous-ensemble (2 menus, 3 créneaux, 5 candidats, 3 constituants) pour rester résoluble en quelques
+  secondes, en préservant la *structure* du théorème.
+
+La place de ce notebook dans le capstone #4617 :
+
+| Slice | Notebook | Apport |
+|-------|----------|--------|
+| A | [07](07_Meal_Planner_Data_External.ipynb) | construction du corpus (cache Ciqual x Recettes, 0 SMT) |
+| **C** | **08 (ce notebook)** | **squelette structurel réel + théorème hiérarchique à restrictions patient (port fidèle)** |
+| B+D | [09](09_Meal_Planner_Convergence_Scale.ipynb) | convergence à l'échelle réelle (RecipeML × Ciqual, trois encodages comparés) |
+
+**Vers la convergence à l'échelle** : le passage du sous-ensemble curé au corpus complet fait exploser
+le **linking** — c'est le problème de *convergence à l'échelle* que la
+[09 (convergence a l echelle)](09_Meal_Planner_Convergence_Scale.ipynb) adresse, en reformulant la contrainte
+nutritionnelle en **one-hot pseudo-booléen** (le seul encodage qui reste tractable là où la
+disjonction-liée naïve explose dès la construction).
+
+---
+
+*Série SMT / Z3.Linq — voir le [README](README.md) pour le parcours complet.*",,,,,,,,69a08b49c26e9a52,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,a6f26a1c,markdown,fr,aaf38f03f7c038b2,"# 09 — Convergence à l'échelle : l'encodage décide de la tractabilité
+
+**Clôture du bloc meal-planner (Epic #4677).** La modélisation déclarative ([06](06_Meal_Planner_Modelisation.ipynb)) a posé les modèles du planificateur sur un corpus jouet ; la couche de données ([07](07_Meal_Planner_Data_External.ipynb)) a construit le corpus réel — recettes RecipeML appariées à Ciqual ANSES 2025 **sans faux positifs** et agrégées **pondérées par la masse**. Ce notebook branche enfin le solveur sur ces données réelles, et y rencontre le problème que les corpus jouets masquaient : à l'échelle, l'encodage naïf explose dès la **construction**, l'encodage le plus **compact** (théorie des tableaux) devient **insoluble**, et seul l'encodage **one-hot pseudo-booléen** se construit instantanément et se résout.
+
+> **Stack : B (API `Microsoft.Z3` brute)** — le cœur de la leçon est l'encodage **pseudo-booléen** (`MkPBEq` / `MkPBLe` / `MkPBGe`), une famille de contraintes que le DSL Z3.Linq n'expose pas (cf. [README, « Les deux stacks »](README.md#les-deux-stacks)).
+
+> **Question de convergence.** Le problème fidèle reste-t-il *tractable* quand on remonte à l'échelle réelle (7 menus × 5 créneaux × ~2 200 recettes × constituants Ciqual) ? La puissance brute du solveur Z3 suffit-elle, ou le choix d'**encodage** décide-t-il seul de la tractabilité ?
+>
+> **Insight clé (formulation du problème).** Plus de recettes = plus de **solutions possibles**, pas plus de contraintes : des recettes supplémentaires sont des **contraintes enablantes** (elles élargissent l'espace des modèles). C'est l'encodage — pas le solveur — qui décide si cet espace est explorable.
+",,,,,,,,aaf38f03f7c038b2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,228ddea8,markdown,fr,97c027fab198618b,"## Objectifs d'apprentissage
+
+- Consommer la **couche de données** construite par le notebook 07 (cache JSON : vecteurs nutritionnels **pondérés par la masse**, appariement curé sans faux positifs).
+- Comprendre pourquoi un encodage SMT **naïf** explose dès la **construction** à l'échelle.
+- Découvrir que la **compacité d'écriture** (théorie des tableaux) n'implique pas la **résolubilité**.
+- Maîtriser l'encodage **one-hot pseudo-booléen** (`MkPBEq` / `MkPBLe` / `MkPBGe`) qui passe à l'échelle.
+
+## Prérequis
+
+- Notebooks [06](06_Meal_Planner_Modelisation.ipynb) (modélisation déclarative du menu) et [07](07_Meal_Planner_Data_External.ipynb) (couche de données Ciqual × RecipeML).
+- Notebooks [04](04_Array_Theory.ipynb) (théorie des tableaux Z3) et [14](14_Optimize_MaxSAT.ipynb) (`Optimize` / pseudo-booléen).
+",,,,,,,,97c027fab198618b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,8c05b088,markdown,fr,81d362816c1d78da,"## 1. Données : le cache solveur-usable du notebook 07
+
+Ce notebook ne refait **aucun** data-engineering : il charge `data/meals/mealplan_cache.json`, le sous-ensemble **solveur-usable** (couverture d'appariement ≥ 80 %) sérialisé par le [notebook 07](07_Meal_Planner_Data_External.ipynb). Chaque recette y porte un vecteur nutritionnel (énergie kJ, protéines, glucides, lipides, sel) agrégé **pondéré par la masse réelle des ingrédients** — le contraire du raccourci per-100g qui rendait toute somme fictive.
+
+Si le cache est absent, exécutez d'abord le notebook 07 de bout en bout (il télécharge au besoin ses sources via `python download_meal_data.py --areas Ciqual RecipeML`).
+",,,,,,,,81d362816c1d78da,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,03d5ad90,code,fr,29da10795e947bef,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Microsoft.Z3;
+using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Diagnostics;
+
+var CACHE = Path.Combine(""data/meals"", ""mealplan_cache.json"");
+Console.WriteLine(File.Exists(CACHE)
+    ? $""Cache present : {CACHE} ({new FileInfo(CACHE).Length / 1024} Ko)""
+    : ""Cache absent : executez d'abord le notebook 07 (couche de donnees) de bout en bout."");
+",,,,,,,,29da10795e947bef,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,e9001830,code,fr,457c48413ce5860b,"// ---- chargement du cache solveur-usable produit par le notebook 07 ----
+var sw = Stopwatch.StartNew();
+var doc = JsonDocument.Parse(File.ReadAllText(CACHE));
+var root = doc.RootElement;
+var constituants = root.GetProperty(""constituants"").EnumerateArray().Select(x => x.GetString()).ToArray();
+int C = constituants.Length;
+var plats = new List<(string title, decimal[] vec, List<string> cats)>();
+foreach (var r in root.GetProperty(""recipes"").EnumerateArray())
+{
+    var t = r.GetProperty(""title"").GetString().Trim();
+    plats.Add((t.Length > 40 ? t.Substring(0, 40) : t,
+               r.GetProperty(""vec"").EnumerateArray().Select(x => x.GetDecimal()).ToArray(),
+               r.GetProperty(""cats"").EnumerateArray().Select(x => x.GetString()).ToList()));
+}
+int R = plats.Count;
+sw.Stop();
+Console.WriteLine($""Cache charge en {sw.Elapsed.TotalSeconds:F1}s : R={R} recettes solveur-usables (sur {root.GetProperty(""n_total"").GetInt32()} brutes), C={C} constituants."");
+Console.WriteLine(""Quartiles par constituant (echelle : recette ENTIERE, agregation ponderee par la masse) :"");
+for (int c = 0; c < C; c++)
+{
+    var vals = plats.Select(p => p.vec[c]).OrderBy(v => v).ToList();
+    decimal P(double q) => vals[(int)(q * (vals.Count - 1))];
+    var nom = constituants[c].Length > 38 ? constituants[c].Substring(0, 38) : constituants[c];
+    Console.WriteLine($""   [{c}] {nom,-38} P25={Math.Round(P(0.25), 1),8}  mediane={Math.Round(P(0.5), 1),8}  P75={Math.Round(P(0.75), 1),8}"");
+}
+",,,,,,,,457c48413ce5860b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,355489d0,markdown,fr,ea0d2887e15b1ce5,"### Interprétation : ce que la couche 07 garantit (et ce qu'elle ne garantit pas)
+
+Le cache livre des recettes **déjà appariées** (matcheur curé du notebook 07 : `White sugar` → *Sugar, white*, et non *White pudding* — zéro faux positif toléré) et **déjà pesées** (quantités culinaires converties en grammes, agrégation pondérée par la masse). Les premières ébauches de ce notebook refaisaient ici un appariement naïf par sac-de-mots — avec ses faux positifs — et sommaient les teneurs per-100g comme si chaque ingrédient pesait 100 g : c'est exactement le travail que le notebook 07 a assaini, et qu'on ne duplique plus.
+
+Les quartiles affichés ci-dessus servent à **calibrer les bornes du théorème** (section suivante) : les vecteurs étant désormais à l'échelle de la **recette entière** (pas de la portion — RecipeML porte un `<yield>` que la couche 07 n'exploite pas encore), les fenêtres nutritionnelles par menu doivent être posées depuis ces ordres de grandeur **mesurés**, pas depuis des constantes héritées d'un autre encodage des données.
+",,,,,,,,ea0d2887e15b1ce5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,a2f8526c,code,fr,d6a30af6068fe248,"// ---- parametres du theoreme partages par les trois encodages ----
+int NMENUS = 7, NPLATS = 5;
+// valeurs entieres par constituant (kJ, g), a l'echelle de la RECETTE ENTIERE (agregation ponderee, cf. 07).
+var vint = new int[C][];
+for (int c = 0; c < C; c++) vint[c] = plats.Select(p => (int)Math.Round(p.vec[c])).ToArray();
+// restrictions patient CALIBREES sur les quartiles mesures ci-dessus : les vecteurs etant a l'echelle de la
+// recette entiere (et non per-100g), des constantes heritees d'un autre encodage n'auraient aucun sens.
+decimal Pq(int c, double q) { var v = plats.Select(p => p.vec[c]).OrderBy(x => x).ToList(); return v[(int)(q * (v.Count - 1))]; }
+int loE = NPLATS * (int)Pq(0, 0.20), hiE = NPLATS * (int)Pq(0, 0.80);   // energie/menu : bande large autour de l'IQR
+int loP = NPLATS * (int)Pq(1, 0.30);                                    // proteines/menu : plancher realiste
+int hiS = Math.Max(1, NPLATS * (int)Pq(4, 0.70));                       // sel/menu : plafond contraignant
+var restr = new (int c, int lo, int hi)[] { (0, loE, hiE), (1, loP, -1), (4, -1, hiS) };
+Console.WriteLine($""Theoreme : {NMENUS} menus x {NPLATS} plats, sur R={R} recettes (vecteurs recette entiere)."");
+Console.WriteLine($""   energie/menu in [{loE},{hiE}] kJ, proteines/menu >= {loP} g, sel/menu <= {hiS} g."");
+",,,,,,,,d6a30af6068fe248,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,ea3a8f3b,markdown,fr,20fe57b52eefbbdd,"## 3. Trois encodages du meme theoreme, trois comportements
+
+Le theoreme est fixe : **7 menus x 5 plats**, chaque plat **distinct** sur la semaine (variete), chaque
+menu dans une **fenetre nutritionnelle**. Seul l'**encodage** SMT change. On va voir trois comportements
+radicalement differents sur le **meme** corpus reel.
+
+### 3.1 Encodage naif (disjonction) -- explose des la construction
+
+L'encodage naif (celui du `Create` original) introduit une variable de nutrition par creneau et, pour
+**chaque recette**, la disjonction `creneau != r OU nutrition == ligne[r]`. Le nombre d'assertions croit
+en `menus x plats x R x constituants` : on ne mesure meme pas la resolution, juste la **construction**.",,,,,,,,20fe57b52eefbbdd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,ed45a410,code,fr,750e37fe5742b55c,"// ---- naif : sonde de temps de CONSTRUCTION (la resolution ne demarre meme pas a l'echelle) ----
+long BuildNaive(int rcap)
+{
+    using var c = new Context();
+    var so = c.MkSolver();
+    var pid = new IntExpr[NMENUS][];
+    for (int m = 0; m < NMENUS; m++) pid[m] = Enumerable.Range(0, NPLATS).Select(p => (IntExpr)c.MkIntConst($""q_{m}_{p}"")).ToArray();
+    long na = 0;
+    var swp = Stopwatch.StartNew();
+    for (int m = 0; m < NMENUS; m++)
+        for (int p = 0; p < NPLATS; p++)
+        {
+            so.Assert(c.MkAnd(c.MkGe(pid[m][p], c.MkInt(0)), c.MkLt(pid[m][p], c.MkInt(rcap))));
+            for (int rr = 0; rr < rcap; rr++)
+                foreach (var (cc, lo, hi) in restr)
+                {
+                    var nutr = (IntExpr)c.MkIntConst($""n_{m}_{p}_{cc}"");
+                    so.Assert(c.MkOr(c.MkNot(c.MkEq(pid[m][p], c.MkInt(rr))), c.MkEq(nutr, c.MkInt(vint[cc][rr]))));
+                    na++;
+                }
+        }
+    swp.Stop();
+    Console.WriteLine($""  naif R={rcap,5} : {na,8} disjonctions construites en {swp.Elapsed.TotalSeconds:F2}s (CONSTRUCTION seule, sans resolution)"");
+    return na;
+}
+foreach (var rcap in new[] { 100, 300, Math.Min(R, 1000) }) BuildNaive(rcap);
+Console.WriteLine(""  -> le cout de construction croit lineairement en R x menus x plats x contraintes :"");
+Console.WriteLine(""     a l'echelle reelle, le solveur n'a meme pas commence a chercher une solution."");",,,,,,,,750e37fe5742b55c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,2193688c,markdown,fr,58c3e88b2b75a09c,"### 3.2 Theorie des tableaux -- compacte a ecrire, mais insoluble
+
+L'encodage par **theorie des tableaux** (notebook 04) est **compact** : un `Array` par constituant
+(chaine de `Store` sur les R valeurs), un index entier par creneau, et `Select(arr, index)` pour lire la
+valeur. Le nombre de **contraintes** devient independant de R. Surprise : Z3 retourne **`unknown`** -- il
+ne sait pas resoudre les longues chaines de `Store` **symboliques**. *Compacite d'ecriture != resolubilite.*",,,,,,,,58c3e88b2b75a09c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,4ad56a35,code,fr,4ab7dc57a8498fa8,"// ---- theorie des tableaux : compact, mais Z3 -> unknown sur de longues chaines de Store symboliques ----
+{
+    using var c = new Context();
+    var so = c.MkSolver();
+    so.Set(""timeout"", (uint)15000);                                 // plafond 15s : on attend `unknown`
+    var arrs = new ArrayExpr[restr.Length];
+    for (int ci = 0; ci < restr.Length; ci++)
+    {
+        var (cc, lo, hi) = restr[ci];
+        var a = c.MkConstArray(c.IntSort, c.MkInt(0));
+        for (int r = 0; r < R; r++) a = c.MkStore(a, c.MkInt(r), c.MkInt(vint[cc][r]));    // chaine de R Store
+        arrs[ci] = a;
+    }
+    var pid = new IntExpr[NMENUS][];
+    for (int m = 0; m < NMENUS; m++) pid[m] = Enumerable.Range(0, NPLATS).Select(p => (IntExpr)c.MkIntConst($""a_{m}_{p}"")).ToArray();
+    var flat = (from m in Enumerable.Range(0, NMENUS) from p in Enumerable.Range(0, NPLATS) select pid[m][p]).ToArray();
+    foreach (var v in flat) { so.Assert(c.MkGe(v, c.MkInt(0))); so.Assert(c.MkLt(v, c.MkInt(R))); }
+    so.Assert(c.MkDistinct(flat));                                   // variete : indices distincts
+    for (int m = 0; m < NMENUS; m++)
+        for (int ci = 0; ci < restr.Length; ci++)
+        {
+            var (cc, lo, hi) = restr[ci];
+            var tot = c.MkAdd(Enumerable.Range(0, NPLATS).Select(p => (ArithExpr)c.MkSelect(arrs[ci], pid[m][p])).ToArray());
+            if (lo >= 0) so.Assert(c.MkGe(tot, c.MkInt(lo)));
+            if (hi >= 0) so.Assert(c.MkLe(tot, c.MkInt(hi)));
+        }
+    var sw2 = Stopwatch.StartNew(); var rr = so.Check(); sw2.Stop();
+    Console.WriteLine($""theorie des tableaux ({NMENUS * NPLATS} index, chaines de Store de longueur {R}) : {rr} en {sw2.Elapsed.TotalSeconds:F1}s"");
+    Console.WriteLine(""  -> compact a ECRIRE, mais insoluble : Z3 ne tranche pas les Store symboliques empiles. Compacite != resolubilite."");
+}",,,,,,,,4ab7dc57a8498fa8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,9fe99f47,markdown,fr,9cdbe363a107a0d8,"### 3.3 One-hot pseudo-booleen -- l'encodage qui passe a l'echelle
+
+L'encodage **one-hot** introduit un booleen `sel[m][p][r]` (""la recette r occupe le creneau p du menu m"").
+Trois familles de contraintes, toutes **pseudo-booleennes natives** de Z3 :
+
+- `MkPBEq(.,1)` par creneau : **exactement une** recette par creneau.
+- `MkPBLe(.,1)` par recette sur toute la semaine : chaque recette **au plus une fois** (= variete / `Distinct`).
+- `MkPBGe` / `MkPBLe` **ponderes** par menu et par constituant : la fenetre nutritionnelle devient une
+  **somme ponderee de booleens** (coefficient = valeur de la recette), traitee par le **solveur
+  pseudo-booleen** de Z3 -- pas par l'arithmetique lineaire generale.
+
+C'est cet encodage qui passe a l'echelle : les recettes sont des **contraintes enablantes**, le solveur
+trouve un modele sans enumerer. La **construction** est quasi instantanee meme a R~1000.",,,,,,,,9cdbe363a107a0d8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,178d2e41,code,fr,845977731c8d85bc,"// ---- one-hot pseudo-booleen : exactly-one + variete + bandes ponderees (MkPBGe / MkPBLe) ----
+var ctx = new Context();
+var s = ctx.MkSolver();
+var swB = Stopwatch.StartNew();
+var sel = new BoolExpr[NMENUS][][];
+for (int m = 0; m < NMENUS; m++) { sel[m] = new BoolExpr[NPLATS][]; for (int p = 0; p < NPLATS; p++) sel[m][p] = Enumerable.Range(0, R).Select(r => ctx.MkBoolConst($""s_{m}_{p}_{r}"")).ToArray(); }
+var onesR = Enumerable.Repeat(1, R).ToArray();
+for (int m = 0; m < NMENUS; m++) for (int p = 0; p < NPLATS; p++) s.Assert(ctx.MkPBEq(onesR, sel[m][p], 1));      // exactement 1 recette / creneau
+var onesMP = Enumerable.Repeat(1, NMENUS * NPLATS).ToArray();
+for (int r = 0; r < R; r++) { var col = (from m in Enumerable.Range(0, NMENUS) from p in Enumerable.Range(0, NPLATS) select sel[m][p][r]).ToArray(); s.Assert(ctx.MkPBLe(onesMP, col, 1)); }  // variete : <= 1x / semaine
+// fenetre nutritionnelle = somme ponderee de booleens (PB native), coeff = valeur de la recette
+for (int m = 0; m < NMENUS; m++) foreach (var (c, lo, hi) in restr)
+{
+    var bools = (from p in Enumerable.Range(0, NPLATS) from r in Enumerable.Range(0, R) select sel[m][p][r]).ToArray();
+    var coeffs = (from p in Enumerable.Range(0, NPLATS) from r in Enumerable.Range(0, R) select vint[c][r]).ToArray();
+    if (hi >= 0) s.Assert(ctx.MkPBLe(coeffs, bools, hi));
+    if (lo >= 0) s.Assert(ctx.MkPBGe(coeffs, bools, lo));
+}
+swB.Stop();
+var swS = Stopwatch.StartNew(); var res = s.Check(); swS.Stop();
+Console.WriteLine($""one-hot R={R} ({NMENUS * NPLATS * R} booleens) : construction {swB.Elapsed.TotalSeconds:F1}s, resolution {swS.Elapsed.TotalSeconds:F1}s -> {res}"");
+if (res == Status.SATISFIABLE)
+{
+    var mo = s.Model;
+    for (int m = 0; m < NMENUS; m++)
+    {
+        var names = new List<string>();
+        for (int p = 0; p < NPLATS; p++) for (int r = 0; r < R; r++) if (mo.Eval(sel[m][p][r], true).IsTrue) names.Add(plats[r].title);
+        Console.WriteLine($""  Menu {m + 1} : "" + string.Join(""  |  "", names.Select(n => n.Length > 18 ? n.Substring(0, 18) : n)));
+    }
+}",,,,,,,,845977731c8d85bc,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,f2a65bc2,markdown,fr,96717169fa8498f3,"### Interpretation : la compacite ne fait pas la resolubilite
+
+Trois encodages, un seul corpus :
+
+| Encodage | Taille | Comportement a R~1000 |
+|---|---|---|
+| **Naif (disjonction)** | `menus x plats x R x C` assertions | **explose a la construction** |
+| **Theorie des tableaux** | compact (R-independant) | **`unknown`** -- Store symboliques insolubles |
+| **One-hot pseudo-booleen** | `menus x plats x R` booleens | **construction quasi-immediate + resolu** |
+
+La lecon centrale : a l'echelle, **l'encodage prime sur la compacite**. L'encodage one-hot pseudo-booleen
+repond a ""plus de donnees"" par ""plus de modeles a trouver"", pas ""plus de cas a enumerer"" -- c'est la
+traduction concrete de ""les recettes sont des contraintes enablantes"".
+
+> **Nuance (jusqu'au choix de la contrainte).** Meme **au sein** du one-hot, le detail compte : exprimer la
+> fenetre nutritionnelle comme une **contrainte pseudo-booleenne native** (`MkPBGe` / `MkPBLe`, somme ponderee
+> de booleens, traitee par le solveur PB) plutot que comme une **somme d'`ITE`** routee vers l'arithmetique
+> lineaire generale change la resolution d'un facteur **~150x** (mesure lors d'une iteration precedente a ~1 000 recettes : ~0,7 s contre ~110 s).
+> Le bon outil SMT pour une somme ponderee de booleens est le solveur pseudo-booleen, pas le solveur LIA.",,,,,,,,96717169fa8498f3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,02b0fd5b,markdown,fr,8f3802b5fb0274b4,"## 4. Partitionnement par categorie : reduire R par creneau
+
+Le one-hot plat traite les cinq creneaux de chaque menu de facon identique : chacun peut tirer dans les
+**R** recettes. Or RecipeML porte `<categories><cat>` (Appetizers / Main dish / Desserts / ...). En
+affectant **un pool par creneau** -- le creneau 1 ne tire que dans les entrees, le creneau 5 que dans les
+desserts -- chaque creneau ne choisit plus que dans un **sous-ensemble** (R/creneau plus petit). Deux gains :
+
+1. **Moins de booleens** : `sum_p |pool[p]| x menus` au lieu de `menus x plats x R` -- le solveur a
+   structurellement moins de variables a poser.
+2. **Fidelite a la contrainte d'ordre** du notebook 06 (entree -> plat -> dessert) : la structure du
+   menu n'est plus emergente mais **imposee par construction**, et les menus produits sont coherents
+   (une entree, un plat, un accompagnement, un pain, un dessert) au lieu de cinq desserts.
+
+On reutilise le solveur **pseudo-booleen pondere** de la section 3.3, applique aux pools. C'est le pont
+vers un planificateur a l'echelle du corpus complet (5 215 recettes brutes, ou le one-hot plat atteindrait
+~183 000 booleens).",,,,,,,,8f3802b5fb0274b4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,1a88ab4b,code,fr,b369a7b975dc5c80,"// ---- partitionnement par categorie : un pool de recettes par creneau ----
+string[] COURSES = { ""Entree"", ""Plat principal"", ""Accompagnement"", ""Pain"", ""Dessert"" };
+var COURSE_CATS = new[]
+{
+    new HashSet<string>(StringComparer.OrdinalIgnoreCase){ ""Appetizers"",""Soups"",""Salads"",""Salad"",""Soup"" },
+    new HashSet<string>(StringComparer.OrdinalIgnoreCase){ ""Main dish"",""Meats"",""Beef"",""Poultry"",""Seafood"",""Fish"",""Pasta"",""Casseroles"",""Chili"",""Pork"",""Chicken"",""Stews"" },
+    new HashSet<string>(StringComparer.OrdinalIgnoreCase){ ""Vegetables"",""Vegetarian"",""Sauces"",""Sauce"",""Side dishes"",""Rice"",""Potatoes"" },
+    new HashSet<string>(StringComparer.OrdinalIgnoreCase){ ""Breads"",""Bread"",""Muffins"",""Rolls"",""Biscuits"" },
+    new HashSet<string>(StringComparer.OrdinalIgnoreCase){ ""Desserts"",""Cakes"",""Cake"",""Cookies"",""Chocolate"",""Fruits"",""Pies"",""Candy"",""Pastries"" },
+};
+int CourseOf(List<string> cats)                                                     // 1er <cat> reconnu gagne ; defaut = plat principal
+{
+    foreach (var cat in cats) for (int k = 0; k < 5; k++) if (COURSE_CATS[k].Contains(cat)) return k;
+    return 1;
+}
+var pool = new List<int>[5];
+for (int k = 0; k < 5; k++) pool[k] = new List<int>();
+for (int r = 0; r < R; r++) pool[CourseOf(plats[r].cats)].Add(r);                   // chaque recette -> exactement un pool
+Console.WriteLine(""Pools par creneau : "" + string.Join("", "", Enumerable.Range(0, 5).Select(k => $""{COURSES[k]}={pool[k].Count}"")));
+
+var c3 = new Context();
+var s3 = c3.MkSolver();
+var swB3 = Stopwatch.StartNew();
+// sel3[m][p][j] : dans le menu m, le creneau p prend la j-eme recette DE pool[p] -> |pool[p]| booleens / creneau
+var sel3 = new BoolExpr[NMENUS][][];
+long nb3 = 0;
+for (int m = 0; m < NMENUS; m++)
+{
+    sel3[m] = new BoolExpr[NPLATS][];
+    for (int p = 0; p < NPLATS; p++) { sel3[m][p] = Enumerable.Range(0, pool[p].Count).Select(j => c3.MkBoolConst($""c_{m}_{p}_{j}"")).ToArray(); nb3 += pool[p].Count; }
+}
+for (int m = 0; m < NMENUS; m++) for (int p = 0; p < NPLATS; p++)                   // exactement 1 recette / creneau
+    s3.Assert(c3.MkPBEq(Enumerable.Repeat(1, pool[p].Count).ToArray(), sel3[m][p], 1));
+for (int p = 0; p < NPLATS; p++) for (int j = 0; j < pool[p].Count; j++)            // variete : chaque recette <= 1x / semaine
+{
+    var col = Enumerable.Range(0, NMENUS).Select(m => sel3[m][p][j]).ToArray();
+    s3.Assert(c3.MkPBLe(Enumerable.Repeat(1, NMENUS).ToArray(), col, 1));
+}
+for (int m = 0; m < NMENUS; m++) foreach (var (c, lo, hi) in restr)                 // memes bandes PB ponderees qu'en 3.3
+{
+    var bools = (from p in Enumerable.Range(0, NPLATS) from j in Enumerable.Range(0, pool[p].Count) select sel3[m][p][j]).ToArray();
+    var coeffs = (from p in Enumerable.Range(0, NPLATS) from j in Enumerable.Range(0, pool[p].Count) select vint[c][pool[p][j]]).ToArray();
+    if (hi >= 0) s3.Assert(c3.MkPBLe(coeffs, bools, hi));
+    if (lo >= 0) s3.Assert(c3.MkPBGe(coeffs, bools, lo));
+}
+swB3.Stop();
+var swS3 = Stopwatch.StartNew(); var res3 = s3.Check(); swS3.Stop();
+Console.WriteLine($""course-onehot : {nb3} booleens (contre {NMENUS * NPLATS * R} en one-hot plat) -- construction {swB3.Elapsed.TotalSeconds:F1}s, resolution {swS3.Elapsed.TotalSeconds:F1}s -> {res3}"");
+if (res3 == Status.SATISFIABLE)
+{
+    var mo = s3.Model;
+    for (int m = 0; m < 3; m++)
+    {
+        var names = new List<string>();
+        for (int p = 0; p < NPLATS; p++) for (int j = 0; j < pool[p].Count; j++) if (mo.Eval(sel3[m][p][j], true).IsTrue) names.Add($""{COURSES[p]} : {plats[pool[p][j]].title}"");
+        Console.WriteLine($""  Menu {m + 1} -> "" + string.Join(""  |  "", names.Select(n => n.Length > 30 ? n.Substring(0, 30) : n)));
+    }
+}",,,,,,,,b369a7b975dc5c80,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,fb3cfd17,markdown,fr,3b7787ea9cd853d1,"### Interpretation : la structure imposee aide le solveur
+
+Le partitionnement divise le nombre de booleens (chaque creneau ne voit que son pool, pas tout le corpus)
+**et** garantit des menus structures -- chaque ligne ci-dessus est bien *entree / plat / accompagnement /
+pain / dessert*, la ou le one-hot plat de la section 3.3 pouvait empiler cinq desserts. La meme machinerie
+pseudo-booleenne (`MkPBEq` / `MkPBLe` / `MkPBGe`) s'applique aux pools sans changement : c'est l'espace
+d'indices qui retrecit, pas l'encodage. A l'echelle du corpus complet, on partitionnerait plus finement
+(sous-categories, equilibrage des pools) -- mais le principe ""un pool par creneau"" suffit a casser la
+croissance en `plats x R` en une croissance par pool.",,,,,,,,3b7787ea9cd853d1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,86b7989c,markdown,fr,1c95e7c68809b408,"## 5. Restriction patient : un menu vegetarien
+
+L'utilisateur a observe que les recettes sont des **contraintes enablantes** : plus de recettes = plus de
+solutions, le solveur converge plus facilement. Une **restriction patient** (regime, allergie, intolerance)
+joue le role inverse -- elle *retrecit* l'espace des solutions sans en changer la taille d'encodage. On le
+montre ici avec un **menu vegetarien** : il suffit d'interdire toute recette dont une `<cat>` RecipeML est une
+categorie viande/poisson (`Meats`, `Beef`, `Poultry`, `Seafood`, `Fish`, `Pork`, `Chicken`, `Stews`), exactement
+comme l'exclusion d'allergene -- une clause unaire `MkNot(sel...)` par booleen concerne. Aucune bande
+nutritionnelle n'est touchee : l'encodage par pools de la section 4 est reutilise tel quel, on ajoute seulement
+des contraintes negatives. Le corpus reste assez riche (pool *plat principal* a des centaines de recettes
+non carnees : `Main dish`, `Pasta`, `Casseroles`...) pour que le probleme demeure SATISFIABLE.",,,,,,,,1c95e7c68809b408,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,90c3a545,code,fr,1c85bb6625d135ab,"// ---- restriction patient : menu vegetarien (exclusion categorielle sur les memes pools qu'en section 4) ----
+var BANNED_VEG = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    { ""Meats"", ""Beef"", ""Poultry"", ""Seafood"", ""Fish"", ""Pork"", ""Chicken"", ""Stews"" };
+int nForbidden = Enumerable.Range(0, R).Count(r => plats[r].cats.Any(cc => BANNED_VEG.Contains(cc)));
+
+var c5 = new Context();
+var s5 = c5.MkSolver();
+var sel5 = new BoolExpr[NMENUS][][];                                                // meme forme que sel3 (pools)
+for (int m = 0; m < NMENUS; m++)
+{
+    sel5[m] = new BoolExpr[NPLATS][];
+    for (int p = 0; p < NPLATS; p++) sel5[m][p] = Enumerable.Range(0, pool[p].Count).Select(j => c5.MkBoolConst($""v_{m}_{p}_{j}"")).ToArray();
+}
+for (int m = 0; m < NMENUS; m++) for (int p = 0; p < NPLATS; p++)                   // exactement 1 recette / creneau
+    s5.Assert(c5.MkPBEq(Enumerable.Repeat(1, pool[p].Count).ToArray(), sel5[m][p], 1));
+for (int p = 0; p < NPLATS; p++) for (int j = 0; j < pool[p].Count; j++)            // variete : chaque recette <= 1x / semaine
+{
+    var col = Enumerable.Range(0, NMENUS).Select(m => sel5[m][p][j]).ToArray();
+    s5.Assert(c5.MkPBLe(Enumerable.Repeat(1, NMENUS).ToArray(), col, 1));
+}
+for (int m = 0; m < NMENUS; m++) foreach (var (c, lo, hi) in restr)                 // memes bandes nutritionnelles PB
+{
+    var bools = (from p in Enumerable.Range(0, NPLATS) from j in Enumerable.Range(0, pool[p].Count) select sel5[m][p][j]).ToArray();
+    var coeffs = (from p in Enumerable.Range(0, NPLATS) from j in Enumerable.Range(0, pool[p].Count) select vint[c][pool[p][j]]).ToArray();
+    if (hi >= 0) s5.Assert(c5.MkPBLe(coeffs, bools, hi));
+    if (lo >= 0) s5.Assert(c5.MkPBGe(coeffs, bools, lo));
+}
+// LA restriction : interdire toute recette viande/poisson dans chaque creneau ou elle pourrait apparaitre
+for (int m = 0; m < NMENUS; m++) for (int p = 0; p < NPLATS; p++) for (int j = 0; j < pool[p].Count; j++)
+    if (plats[pool[p][j]].cats.Any(cc => BANNED_VEG.Contains(cc))) s5.Assert(c5.MkNot(sel5[m][p][j]));
+
+var swS5 = Stopwatch.StartNew(); var res5 = s5.Check(); swS5.Stop();
+Console.WriteLine($""vegetarien : {nForbidden} recettes viande/poisson interdites -- resolution {swS5.Elapsed.TotalSeconds:F1}s -> {res5}"");
+if (res5 == Status.SATISFIABLE)
+{
+    var mo5 = s5.Model;
+    var names = new List<string>();
+    for (int p = 0; p < NPLATS; p++) for (int j = 0; j < pool[p].Count; j++) if (mo5.Eval(sel5[0][p][j], true).IsTrue) names.Add($""{COURSES[p]} : {plats[pool[p][j]].title}"");
+    Console.WriteLine(""  Menu vegetarien 1 -> "" + string.Join(""  |  "", names.Select(n => n.Length > 30 ? n.Substring(0, 30) : n)));
+}",,,,,,,,1c85bb6625d135ab,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,9bcbe3f4,markdown,fr,9ebd7eba1809d017,"## Exercices
+
+### Exercice 1 — seuil de non-satisfiabilité
+Resserrez la borne **haute d'énergie** par menu (constituant 0 ; la valeur calibrée `hiE` est affichée par la cellule des paramètres) jusqu'au seuil où le problème 7×5 devient `UNSATISFIABLE`. À partir de quelle énergie maximale cumulée le planificateur ne trouve-t-il plus de semaine valide ?
+
+*Indice :* reprenez l'encodage one-hot pseudo-booléen de la section 3.3 en faisant varier le `hi` de la bande énergie dans `{ hiE, 3 * hiE / 4, hiE / 2, hiE / 4 }`, et observez le `Status` renvoyé par `s.Check()`.
+",,,,,,,,9ebd7eba1809d017,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,518c98aa,code,fr,e55aeb619406563f,"// Exercice 1 : trouver le seuil d'energie maximale ou 7x5 devient UNSATISFIABLE.
+// Indice : reprenez l'encodage one-hot de la section 3.3 ; faites varier la borne 'hi'
+//          de la bande energie (constituant 0, ligne (0, loE, hiE) de restr) dans
+//          { hiE, 3 * hiE / 4, hiE / 2, hiE / 4 } et affichez le Status de s.Check() pour chaque valeur.
+// Etape 1 : encapsuler la section 3.3 dans une fonction SolveEnergyCap(int hi) -> Status.
+// Etape 2 : boucler sur les seuils, reperer la bascule SAT -> UNSAT.
+Console.WriteLine(""Exercice 1 a completer : seuil UNSAT de la fenetre energetique."");
+",,,,,,,,e55aeb619406563f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,6f0dbcc8,markdown,fr,12bbba268aebd412,"### Exercice 2 : plancher de glucides par menu
+Ajoutez une **borne basse** sur les glucides (constituant d'index 2) de chaque menu, sur le modele one-hot
+de la section 3.3.",,,,,,,,12bbba268aebd412,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,7231d359,code,fr,a755826cb09d8634,"// Exercice 2 : plancher de glucides par menu (constituant index 2).
+// Indice : meme patron que la bande proteines. Avec l'encodage PB pondere :
+//   var bools = (from p in Enumerable.Range(0,NPLATS) from r in Enumerable.Range(0,R) select sel[m][p][r]).ToArray();
+//   var coeffs = (from p in Enumerable.Range(0,NPLATS) from r in Enumerable.Range(0,R) select vint[2][r]).ToArray();
+//   s.Assert(ctx.MkPBGe(coeffs, bools, GLUCIDES_MIN));   // pour chaque menu m
+// Etape 1 : choisir GLUCIDES_MIN (ex. 150).
+// Etape 2 : ajouter la contrainte pour chaque menu, re-resoudre, verifier que chaque menu atteint le seuil.
+Console.WriteLine(""Exercice 2 a completer : plancher de glucides par menu."");",,,,,,,,a755826cb09d8634,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,db8747ac,markdown,fr,ec5fb331e44b8899,"### Exercice 3 : exclusion d'un allergene par mot-cle
+Interdisez toute recette dont le titre contient un mot-cle (ex. `Peanut`, `Shrimp`).",,,,,,,,ec5fb331e44b8899,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,67821526,code,fr,a4311f42e5e23e8d,"// Exercice 3 : exclure les recettes dont le titre contient un mot-cle allergene.
+// Indice :
+//   string[] bannis = { ""Peanut"", ""Shrimp"", ""Crab"" };
+//   for (int r = 0; r < R; r++)
+//       if (bannis.Any(b => plats[r].title.IndexOf(b, StringComparison.OrdinalIgnoreCase) >= 0))
+//           for (int m = 0; m < NMENUS; m++) for (int p = 0; p < NPLATS; p++) s.Assert(ctx.MkNot(sel[m][p][r]));
+// Etape 1 : pre-calculer l'ensemble des indices interdits. Etape 2 : forcer sel = false. Etape 3 : re-resoudre.
+Console.WriteLine(""Exercice 3 a completer : exclusion d'allergene par mot-cle."");",,,,,,,,a4311f42e5e23e8d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,8feee3a4,markdown,fr,8e9ae80a366cbb31,"### Exercice 4 : mesurer l'explosion
+Faites varier R (100, 300, R complet) et comparez le temps de **construction** du naif au temps
+**construction + resolution** du one-hot.",,,,,,,,8e9ae80a366cbb31,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,674905b9,code,fr,c5d0c2b48100b57f,"// Exercice 4 : tracer construction(naif) vs construction+resolution(one-hot) en fonction de R.
+// Indice : reutilisez BuildNaive(rcap) de la section 3.1 ; pour le one-hot, encapsulez la section 3.3
+//          dans une fonction SolveOneHot(int rcap) qui ne garde que les rcap premieres recettes.
+// Etape 1 : pour rcap in {100, 300, R}, mesurer les deux temps.
+// Etape 2 : observer que le naif croit en R (construction) tandis que le one-hot reste constructible.
+Console.WriteLine(""Exercice 4 a completer : mesure comparative de l'explosion."");",,,,,,,,c5d0c2b48100b57f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb,f1016fd6,markdown,fr,28d74ba97d49c886,"## Conclusion
+
+### Points clés à retenir
+
+- La **séparation données / modélisation** paie : le notebook [07](07_Meal_Planner_Data_External.ipynb) livre un cache curé (appariement sans faux positifs, agrégation pondérée par la masse) ; ce notebook n'a plus qu'à encoder et résoudre. Un solveur ne rattrape jamais des données mal jointes.
+- À l'échelle, **l'encodage prime sur la compacité** : one-hot pseudo-booléen (construit + résolu) > théorie des tableaux (compacte mais `unknown`) > naïf (explose à la construction).
+- **« Plus de données = contraintes enablantes »** : bien encodé, un gros corpus se résout sans énumération.
+- Le **partitionnement par catégorie** (section 4) réduit R par créneau **et** impose la structure du menu (entrée → dessert) : c'est le chemin vers le corpus RecipeML complet (5 215 recettes brutes).
+
+### Clôture du bloc meal-planner (Epic #4677, capstone #4617)
+
+Ce notebook clôt l'arc du planificateur de repas : [06](06_Meal_Planner_Modelisation.ipynb) pose les modèles Z3 sur un corpus jouet, [07](07_Meal_Planner_Data_External.ipynb) construit la couche de données réelle Ciqual × RecipeML, [08](08_Meal_Planner_Patient_Capstone.ipynb) pousse le théorème patient en capstone déclaratif, et ce notebook fait converger le problème fidèle à l'échelle réelle. La leçon structurante : la puissance du solveur Z3 ne compense **pas** un mauvais encodage — c'est la reformulation **one-hot pseudo-booléenne** qui fait converger le planificateur (les fenêtres nutritionnelles patient deviennent des contraintes cardinales pondérées natives `MkPBGe`/`MkPBLe`, et l'espace de recherche rétrécit aux sélecteurs booléens plutôt qu'à l'énumération disjonctive des compositions). La même leçon d'encodage vaut pour tout problème combinatoire où le corpus grossit.
+",,,,,,,,28d74ba97d49c886,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,13e003ad,markdown,fr,d891ef0b9964822d,"# 10 — Générer un témoin depuis `A & ~B` (fork Automata vivant)
+
+`<<` [06 — Meal Planner hiérarchique](06_Meal_Planner_Modelisation.ipynb) | [Sudoku-13 — Automates symboliques `>>`](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb)
+
+---
+
+## Le problème : reconnaître ne suffit pas, il faut **produire**
+
+Un moteur comme **RE#** (`System.Text.RegularExpressions`) répond à **« cette chaîne appartient-elle au langage ? »** — c'est de la *reconnaissance*. Mais beaucoup de tâches réelles demandent l'inverse : **« donne-moi une chaîne qui appartient au langage »** — c'est la *génération de témoin* (witness generation). Exemples :
+
+- générer un mot de passe **conforme à une politique** mais **évitant** les motifs faibles connus ;
+- fabriquer une entrée de **test** qui satisfait une contrainte **et** en viole une autre ;
+- produire un identifiant **valide** mais **pas encore utilisé**.
+
+Toutes ces tâches s'écrivent `A & ~B` : *« dans le langage A, mais pas dans le langage B »*.
+
+## Ce notebook
+
+On consomme le **fork `MyIntelligenceAgency/Automata`** (modernisation net8.0 de `Microsoft.Automata`, dit *AutomataDotNet*, gelé vers 2020). Le fork ajoute deux choses que ni RE# ni le paquet public ne savent faire :
+
+1. les opérateurs de **surface** `&` (intersection) et `~` (complément) **directement dans la syntaxe regex** ;
+2. la **génération de témoin sans le plafond historique de ~21 caractères** (issue #6).
+
+### Objectifs
+
+1. Manipuler l'algèbre `CharSetSolver` (BDD sur 128 caractères ASCII).
+2. Écrire `A & ~B` en surface et **générer un témoin** via `RexEngine`.
+3. Émettre la formule **SMT-LIB** correspondante (`re.inter` / `re.comp`) **et la résoudre avec Z3** pour en extraire un témoin.
+4. Comprendre **honnêtement** la portée : le fork lève le mur du témoin, **pas** l'explosion d'automate à grande échelle — voir le Sudoku-13 pour le verdict mesuré.
+
+> **Non-but** (issue #2979) : ce patch **ne remplace pas RE#** pour la reconnaissance et **ne réveille pas** `Z3.LinqBinding`. Il ajoute ce que RE# ne fait pas : *un témoin depuis la syntaxe `&`/`~`*.",,,,,,,,d891ef0b9964822d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,76086898,code,fr,9258a45c2c5606e0,"// Le fork est déployé en submodule sibling (cf scripts/environment/automata-build-deploy.ps1).
+// .deploy/ contient Microsoft.Automata.dll (pure-managed, fork net8.0) + sa dépendance System.CodeDom.
+#r ""../Automata/.deploy/System.CodeDom.dll""
+#r ""../Automata/.deploy/Microsoft.Automata.dll""
+
+using System;
+using System.Linq;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Microsoft.Automata;
+using Microsoft.Automata.Rex;
+
+Console.WriteLine(""Imports OK — fork Automata (surface &/~ + témoin non-capé) chargé."");",,,,,,,,9258a45c2c5606e0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,bbc5abdb,markdown,fr,50af6ce6b9e9ba9e,"## 1. Reconnaître vs produire — trois outils, trois rôles
+
+| Outil | Question répondue | Direction |
+|-------|-------------------|-----------|
+| **RE#** (`Regex.IsMatch`) | « *s* appartient-il à *L* ? » | reconnaissance |
+| **RexEngine** (ce notebook) | « donne-moi un *s* de *L* » | **génération de témoin** |
+| **Z3** (notebooks 01–09) | « existe-t-il un *s* satisfaisant ces contraintes ? » | résolution SMT générale |
+
+Les trois sont complémentaires. RexEngine occupe la case que RE# laisse vide : il **fabrique** un mot du langage, et — grâce au fork — depuis un langage décrit avec `&` et `~`.",,,,,,,,50af6ce6b9e9ba9e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,0839c0fe,markdown,fr,7641e018414f5eab,"## 2. L'algèbre `CharSetSolver` — des BDD sur l'alphabet
+
+Sous le capot, un langage régulier est un **automate dont les transitions sont étiquetées par des ensembles de caractères**. Ces ensembles ne sont pas stockés en clair mais comme **BDD** (*Binary Decision Diagrams*) — une représentation compacte et canonique des prédicats booléens sur les bits d'un caractère.
+
+`CharSetSolver(BitWidth.BV7)` travaille sur **7 bits = 128 caractères ASCII**. C'est l'*algèbre* partagée par tout le pipeline : convertir une regex en automate, intersecter, complémenter, tester l'appartenance. **Retenez ce mot — « algèbre partagée » — il reviendra au §6.**",,,,,,,,7641e018414f5eab,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,e45df611,code,fr,d2e2afcd1b65e75c,"// Construire un automate depuis une regex, puis tester l'appartenance.
+// API correcte : solver.Accepts(automate, chaine)  (et NON automate.Accepts).
+var solver = new CharSetSolver(BitWidth.BV7);
+
+// ""^[a-z]$"" = exactement une lettre minuscule.
+var uneMinuscule = solver.Convert(""^[a-z]$"", RegexOptions.None)
+                         .RemoveEpsilons().Determinize().Minimize();
+
+foreach (var s in new[] { ""a"", ""Z"", ""5"", ""ab"" })
+    Console.WriteLine($""  Accepts(\""{s}\"") = {solver.Accepts(uneMinuscule, s)}"");",,,,,,,,d2e2afcd1b65e75c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,3d989aa5,markdown,fr,9e40dd53627274a1,"## 3. L'opérateur de surface `&` — intersection dans la syntaxe
+
+Le fork branche `&` **en tête du parser regex** : `A&B` est analysé comme l'**intersection** des deux langages, et câblé sur `Automaton.Intersect`. Pas de manipulation manuelle d'automates : on l'écrit, c'est tout.
+
+Exemple canonique : `^[ab]$ & ^[bc]$`. Un caractère unique qui est *(a ou b)* **et** *(b ou c)* ne peut être que **`b`** — l'intersection est le singleton `{b}`.
+
+> **Pourquoi les ancres `^…$` ?** Une regex .NET non ancrée signifie *« la chaîne **contient** un tel caractère »* : `[ab]` ≡ `.*[ab].*`. Sans ancres, `[ab]&[bc]` accepterait `""ac""` (contient `a` *et* `c`). Les ancres bornent la longueur et donnent un témoin propre et lisible.",,,,,,,,9e40dd53627274a1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,0c3818be,markdown,fr,3fc9ddffe6812529,"### Pourquoi `&` et `~` marchent — la fermeture des langages réguliers
+
+Écrire `A & ~B` revient à **combiner** des langages par intersection (`&`) et complément (`~`). Cela n'a de sens que parce que les langages réguliers possèdent une propriété fondamentale : ils sont **fermés** sous ces opérations (théorème de Kleene). Concrètement, l'union (∪), l'intersection (∩) et le complément (¬) de langages réguliers sont **encore des langages réguliers** — on dit que les langages réguliers forment une **algèbre de Boole**.
+
+C'est ce fondement qui garantit que `A & ~B` reste un langage régulier, donc **représentable par un automate fini** et manipulable par les opérations `Automaton.Intersect` et `Automaton.Complement` sur lesquelles le fork câble `&` et `~`. Sans cette fermeture, intersecter ou compléter des langages pourrait produire un objet hors de portée d'un automate (impossible à représenter, donc à résoudre). Le motif vedette de ce notebook — *« dans A, mais pas dans B »* — doit donc toute son existence à ce théorème.
+
+> **Les briques d'automates appelées en code.** Dans les cellules, on voit souvent `.RemoveEpsilons().Determinize().Minimize()` après `Convert`. Ce sont les trois étapes standard de la théorie des automates :
+> - **`Determinize`** — passer d'un automate *non-déterministe* (NFA) à l'automate *déterministe* (DFA) équivalent (la construction des parties) ;
+> - **`Minimize`** — calculer le DFA *minimal* (les états équivalents fusionnés) ;
+> - **`RemoveEpsilons`** — supprimer les transitions « epsilon » (vides).
+>
+> Ces opérations rendent l'intersection et le complément **effectivement calculables** : on ne se contente pas de savoir que *le résultat existe* (fermeture), on le *construit* en pratique. Les détails algorithmiques relèvent d'un cours d'automates ; ici on consomme le résultat.",,,,,,,,3fc9ddffe6812529,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,e5f6a7b8,markdown,fr,2f3ad55d3ee68140,"### Pipeline du motif `A & ~B` — vue d'ensemble
+
+Le diagramme ci-dessous illustre comment deux expressions régulières se combinent pour produire un témoin via l'intersection et le complément :
+
+```mermaid
+flowchart TB
+    subgraph G1 [""Construction des automates""]
+        A[""Regex A""] --> DFA_A[""DFA(A)""]
+        B[""Regex B""] --> DFA_B[""DFA(B)""]
+        DFA_B --> COMP[""~DFA(B) — Complément""]
+    end
+    subgraph G2 [""Opération A & ~B""]
+        DFA_A --> INT[""DFA(A) ∩ ~DFA(B)""]
+        COMP --> INT
+    end
+    INT --> W[""Témoin w ← GenerateMember""]
+    W --> V[""Vérifié par RE#""]  
+    style W fill:#c8f7c5
+    style V fill:#c8f7c5
+```
+
+**Pourquoi ça fonctionne** : les langages réguliers sont fermés sous l'intersection (`&`) et le complément (`~`). Le résultat `A & ~B` est donc **lui-même régulier** — un automate fini existe pour le représenter, et `GenerateMember` peut en extraire un mot accepté (le témoin).",,,,,,,,2f3ad55d3ee68140,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,82374f96,code,fr,f8251f3207a85b6b,"// ""[ab] & [bc]"" ancré = le singleton {b}. On construit via le solveur et on vérifie.
+var inter = solver.Convert(""^[ab]$&^[bc]$"", RegexOptions.None)
+                  .RemoveEpsilons().Determinize().Minimize();
+
+foreach (var s in new[] { ""a"", ""b"", ""c"" })
+    Console.WriteLine($""  Accepts(\""{s}\"") = {solver.Accepts(inter, s)}"");
+
+// Génération du témoin : engine.CreateFromRegexes partage l'algèbre interne du moteur.
+var engine = new RexEngine(BitWidth.BV7);
+var interAut = engine.CreateFromRegexes(""^[ab]$&^[bc]$"");
+string temoinInter = engine.GenerateMember(interAut);
+Console.WriteLine($""  Témoin de (^[ab]$ & ^[bc]$) = \""{temoinInter}\"""");",,,,,,,,f8251f3207a85b6b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,4dabb355,markdown,fr,69ff0a00126e8e69,"## 4. L'opérateur de surface `~` — complément, et le motif `A & ~B`
+
+`~A` est le **complément** de *A* : tout ce qui n'est **pas** dans *A*. Combiné à `&`, on obtient le motif vedette **`A & ~B`** : *« dans A, mais pas dans B »*.
+
+Exemple : `^[a-z]$ & ~[aeiou]` = une lettre minuscule **qui n'est pas une voyelle** = une **consonne**.
+
+> **Précédence de `~` — un piège à connaître.** `~` se lie à l'**atome qui suit immédiatement** (une classe `[…]`, une ancre, ou un groupe `(…)`). Pour complémenter une **séquence**, il faut **parenthéser** : `~(.*motif.*)` et non `~.*motif.*` (ce dernier ne complémente que le `.` et laisse passer le motif). On exploitera cette règle au §8.",,,,,,,,69ff0a00126e8e69,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,a541f2e0,code,fr,909351a1add9ee3b,"// A & ~B : une minuscule (A) qui n'est pas une voyelle (~B) = une consonne.
+var consonne = engine.CreateFromRegexes(""^[a-z]$&~[aeiou]"");
+
+foreach (var s in new[] { ""a"", ""e"", ""t"", ""z"" })
+    Console.WriteLine($""  Accepts(\""{s}\"") = {engine.Solver.Accepts(consonne, s)}"");
+
+string temoinConsonne = engine.GenerateMember(consonne);
+Console.WriteLine($""  Témoin de (^[a-z]$ & ~[aeiou]) = \""{temoinConsonne}\"" (une consonne)"");",,,,,,,,909351a1add9ee3b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,d4128fa0,markdown,fr,1a67bfecd6fac277,"## 5. Le moteur de témoin — le chemin sûr
+
+`RexEngine.GenerateMember(automate)` effectue une **marche aléatoire** sur l'automate déterministe et renvoie un mot accepté. Deux règles d'usage :
+
+- **Construire l'automate via `engine.CreateFromRegexes(...)`** (ou `engine.Solver`), pour qu'il partage l'**algèbre** du moteur (cf §2). Le §6 montre ce qui se passe sinon.
+- Utiliser **`GenerateMember`** (marche aléatoire) et non `GenerateMemberUniformly` : ce dernier exige un automate fini et **lève une exception** sur un langage infini/bouclant.
+
+Le chemin est toujours le même :
+```csharp
+var engine = new RexEngine(BitWidth.BV7);
+var aut    = engine.CreateFromRegexes(""...&~..."");  // surface &/~
+string w   = engine.GenerateMember(aut);            // témoin
+bool ok    = engine.Solver.Accepts(aut, w);         // vérification
+```",,,,,,,,1a67bfecd6fac277,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,11e49691,code,fr,89ef1821301db943,"// Vérification systématique : tout témoin généré doit être accepté par son propre automate.
+string CheckTemoin(RexEngine eng, string regex)
+{
+    var aut = eng.CreateFromRegexes(regex);
+    string w = eng.GenerateMember(aut);
+    bool ok = eng.Solver.Accepts(aut, w);
+    return $""  regex={regex,-22} témoin=\""{w}\"" accepté={ok}"";
+}
+
+Console.WriteLine(CheckTemoin(engine, ""^[ab]$&^[bc]$""));
+Console.WriteLine(CheckTemoin(engine, ""^[a-z]$&~[aeiou]""));
+Console.WriteLine(CheckTemoin(engine, ""^[0-9]{4}$&~(.*0.*)""));  // 4 chiffres sans aucun zéro",,,,,,,,89ef1821301db943,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,f4ed7a37,markdown,fr,f8bda7f0f4090ca1,"## 6. Le piège du solveur croisé — une leçon sur l'identité d'algèbre
+
+Que se passe-t-il si on construit l'automate avec **un** `CharSetSolver` puis qu'on demande le témoin à un `RexEngine` qui en possède **un autre** ? Les BDD des deux solveurs ne partagent **aucune identité de terminal** : la descente dans l'algèbre échouerait.
+
+Le fork (#2979, étape 4) transforme cette situation en **`ArgumentException` claire et actionnable** — au lieu de l'historique `NullReferenceException` cryptique au fond de `BDDAlgebra.Choose`. **Ce n'est pas un bug, c'est une garde** : le message vous dit exactement quoi faire.
+
+> On enveloppe la démonstration dans un `try/catch` : le notebook s'exécute de bout en bout (la garde est *attendue*, pas une panne).",,,,,,,,f8bda7f0f4090ca1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,4590ac3f,code,fr,0fb116653c1ae22e,"// MAUVAIS chemin : automate bâti avec un solveur externe, témoin demandé à un autre moteur.
+var solveurExterne = new CharSetSolver(BitWidth.BV7);
+var moteur = new RexEngine(BitWidth.BV7);   // possède un solveur DIFFÉRENT
+var autExterne = solveurExterne.Convert(""[ab]+"", RegexOptions.None)
+                               .RemoveEpsilons().Determinize().Minimize();
+
+try
+{
+    string w = moteur.GenerateMember(autExterne);   // déclenche la garde
+    Console.WriteLine($""(inattendu) témoin = {w}"");
+}
+catch (ArgumentException ex)
+{
+    Console.WriteLine(""ArgumentException attendue (garde du fork) :"");
+    Console.WriteLine(""  "" + ex.Message.Split('\n')[0]);
+}
+
+// BON chemin : construire via le moteur lui-même.
+var autSafe = moteur.CreateFromRegexes(""[ab]+"");
+Console.WriteLine($""  Correction → CreateFromRegexes : témoin = \""{moteur.GenerateMember(autSafe)}\"""");",,,,,,,,0fb116653c1ae22e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,35c6807d,markdown,fr,428a15252cde397d,"## 7. Émettre la formule SMT-LIB — `re.inter` / `re.comp`
+
+Le même motif `A & ~B` se **traduit en théorie des chaînes SMT-LIB**, le langage des solveurs comme Z3. Le fork expose `RegexToSMTConverter` (rendu **public** pour ce notebook, #2979 étape 6) : il convertit une regex de surface en expression SMT, où `&` devient `re.inter` et `~` devient `re.comp`.
+
+C'est le pont entre les deux mondes du cours : la **syntaxe regex** d'ici et la **contrainte SMT** des notebooks Z3 01–09.",,,,,,,,428a15252cde397d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,527386f5,code,fr,5838019ca837105c,"var conv = new RegexToSMTConverter(BitWidth.BV7);
+
+foreach (var regex in new[] { ""[ab]&~[bc]"", ""[a-z]&~[aeiou]"" })
+{
+    Console.WriteLine($""regex   : {regex}"");
+    Console.WriteLine($""SMT-LIB : {conv.ConvertRegex(regex)}"");
+    Console.WriteLine();
+}",,,,,,,,5838019ca837105c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,9666d8f0,markdown,fr,9a966779a4e34946,"## 7b. Fermer la boucle — **résoudre** le SMT-LIB avec Z3
+
+Le §7 *émet* la formule ; mais une formule SMT-LIB n'a de valeur que si un solveur la **résout**. C'est exactement ce que font les notebooks 01–09 : on referme ici la boucle **émettre → résoudre** en injectant la sortie du convertisseur dans **Z3** (`ParseSMTLIB2String`), puis en extrayant un **témoin**.
+
+Le convertisseur émet la **théorie des chaînes SMT-LIB 2.6** (`str.to_re`, `re.range`, `re.inter`, `re.comp`, `(_ re.loop m n)`) — le dialecte que Z3 consomme réellement. La requête de témoin est `(str.in_re w R)` : *« trouve un mot complet `w` du langage `R` »*. Chaque témoin est ensuite **re-vérifié indépendamment** par RE# (`Regex.IsMatch`), comme au §8.
+
+> **Deux moteurs, un même langage.** Le §5 produit le témoin par marche aléatoire sur l'automate (chemin DFA) ; ici Z3 le produit par résolution de contraintes (chemin SMT). Les deux acceptent la **même** description `A & ~B` — et Z3, comme le fork, n'a **pas** le plafond historique de ~21 caractères (cf §9).",,,,,,,,9a966779a4e34946,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,c5a84be8,code,fr,da4e7c5d7be63150,"// Émettre ne suffit pas : on **résout** réellement le SMT-LIB produit au §7.
+// Le convertisseur (modernisé, #2979) émet la théorie des chaînes SMT-LIB 2.6 que Z3
+// consomme directement. On injecte sa sortie dans Z3 via ParseSMTLIB2String et on
+// extrait un témoin — le pendant Z3 (sans plafond) du moteur DFA des §5–§9.
+#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+using Microsoft.Z3;
+
+string ResoudreSMT(Context ctx, string regexSMT)
+{
+    // (str.in_re w R) = « w est un mot complet du langage R » (appartenance = match ancré).
+    string script =
+        ""(declare-const w String)\n"" +
+        $""(assert (str.in_re w {regexSMT}))\n"" +
+        ""(check-sat)"";
+    BoolExpr[] contraintes = ctx.ParseSMTLIB2String(script);
+    var solver = ctx.MkSolver();
+    solver.Assert(contraintes);
+    if (solver.Check() != Status.SATISFIABLE) return null;
+    var w = (SeqExpr)ctx.MkConst(""w"", ctx.StringSort);
+    return solver.Model.Eval(w, true).ToString().Trim('""');
+}
+
+using (var ctx = new Context())
+{
+    Console.WriteLine($""{Microsoft.Z3.Version.FullVersion} — résolution du SMT-LIB émis par le fork :\n"");
+
+    // (surface, vérif positive RE#, vérif négative RE#) — re-vérification indépendante.
+    var demos = new (string surface, string pos, string neg)[]
+    {
+        (""[ab]&~[bc]"",     ""^[ab]$"",   ""^[bc]$""),
+        (""[a-z]&~[aeiou]"", ""^[a-z]$"",  ""^[aeiou]$""),
+    };
+
+    foreach (var (surface, pos, neg) in demos)
+    {
+        string smt = conv.ConvertRegex(surface);     // la sortie réelle du §7
+        string temoin = ResoudreSMT(ctx, smt);
+        bool ok = temoin != null && Regex.IsMatch(temoin, pos) && !Regex.IsMatch(temoin, neg);
+        Console.WriteLine($""  {surface,-16} → témoin Z3 = \""{temoin}\""  re-vérifié(RE#)={ok}"");
+    }
+
+    // Et ça passe à l'échelle SANS le plafond ~21 : [a-z]{30} résolu par Z3.
+    string smt30 = conv.ConvertRegex(""[a-z]{30}"");
+    string t30 = ResoudreSMT(ctx, smt30);
+    Console.WriteLine($""  [a-z]{{30}}        → témoin Z3 (len={t30?.Length}) re-vérifié(RE#)={Regex.IsMatch(t30, ""^[a-z]{30}$"")}"");
+}",,,,,,,,da4e7c5d7be63150,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,veanes-z3-monadic,markdown,fr,6bc9c4691af69406,"## 7c. Quand `re.inter` tient l'echelle - la decomposition monadique
+
+Le 7b resout `A & ~B` sur de **petits** langages (un caractere, une trentaine). Mais `re.inter` **materialise l'espace croise** des langages intersectes, et cet espace **explose** quand les contraintes se chevauchent. Le notebook [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb) le mesure : l'intersection 10-way d'une ligne, emise en `re.inter` *fondu*, fait `unknown` ; la **meme** contrainte eclatee en `str.contains` par chiffre **atterrit** la grille 9x9.
+
+La theorie qui tranche est la **decomposition monadique** de Veanes (*Monadic Decomposition*, CAV 2014). Une formule a plusieurs variables est **monadiquement decomposable** si elle equivaut a une combinaison booleenne de predicats a **une seule variable**. Quand elle l'est, on remplace le produit (`re.inter`) par une **conjonction de tests independants** - sans jamais construire l'automate croise.
+
+| Forme emise | Ce que fait le solveur | Echelle |
+|-------------|------------------------|---------|
+| `re.inter` (intersection **fondue**) | materialise le produit des langages | sature des que les contraintes se chevauchent |
+| conjonction de predicats **monadiques** (`str.contains`) | tests independants, pas de produit | atterrit |
+
+> **La lecon, des deux cotes.** Ce notebook montre `A & ~B` la ou `re.inter` est **rapide** (peu de chevauchement) ; Sudoku-13 montre l'echelle ou il faut **decomposer**. Le bon critere n'est pas "" Z3 sait-il faire ? "" mais "" la conjonction est-elle monadiquement decomposable ? "". Veanes donne le verdict exact : un tous-distincts l'est (eclatable par chiffre), un ordre `x < y` ne l'est **pas** (aucune decomposition finie).",,,,,,,,6bc9c4691af69406,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,ba38e2c5,markdown,fr,c94930422a92d9d2,"## 8. Le payoff — générer un mot de passe `politique & ~faibles`
+
+Voici le motif `A & ~B` à pleine puissance, sur un cas réel : **fabriquer un mot de passe conforme à une politique tout en évitant les motifs faibles connus**.
+
+- **A** = `^[A-Za-z0-9]{8}$` — exactement 8 caractères alphanumériques ;
+- **~B₁** = `~(.*password.*)` — ne **contient pas** la sous-chaîne `password` ;
+- **~B₂** = `~(^[0-9].*$)` — ne **commence pas** par un chiffre.
+
+On note l'usage des **parenthèses** sur `~(…)` (cf §4) : on complémente bien des *séquences*, pas un seul atome. Le moteur produit des témoins variés (marche aléatoire) — chacun est un mot de passe valide selon la politique, vérifié contre les trois conditions.",,,,,,,,c94930422a92d9d2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,70e34ed8,code,fr,59703194ccf3f087,"// A & ~B1 & ~B2 : 8 alphanumériques, sans ""password"", ne commençant pas par un chiffre.
+string politique = ""^[A-Za-z0-9]{8}$&~(.*password.*)&~(^[0-9].*$)"";
+var motDePasse = engine.CreateFromRegexes(politique);
+
+// Vérificateurs indépendants (RE#) pour prouver l'honnêteté de chaque témoin.
+bool SansPassword(string s) => !s.Contains(""password"");
+bool SansChiffreInitial(string s) => s.Length > 0 && !char.IsDigit(s[0]);
+
+Console.WriteLine(""Témoins générés (chacun re-vérifié indépendamment) :"");
+for (int i = 0; i < 5; i++)
+{
+    string w = engine.GenerateMember(motDePasse);
+    bool len8 = w.Length == 8;
+    Console.WriteLine($""  \""{w}\""  len8={len8}  sansPassword={SansPassword(w)}  sansChiffreInitial={SansChiffreInitial(w)}"");
+}",,,,,,,,59703194ccf3f087,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,a7e76feb,markdown,fr,47f7d0509bf91467,"## 9. Le plafond de 21 caractères est levé (issue #6)
+
+La machinerie de témoin historique d'AutomataDotNet plafonnait en pratique vers **~21 caractères** pour les automates non triviaux (au-delà, elle explosait ou bouclait). Le fork sous net8.0 lève ce plafond : on génère ici un témoin de **30 caractères** sans difficulté.
+
+> **Honnêteté — la portée exacte.** Le fork lève le **mur du témoin** (longueur). Il ne lève **pas** le **mur de l'explosion d'automate** : intersecter des dizaines de contraintes (p. ex. les 81 cases d'un Sudoku) fait exploser le produit cartésien des états. Pour le Sudoku à l'échelle, **Z3 `Distinct` reste le résolveur de production** (~27 ms). Le verdict mesuré est au §6b du [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb). Le vrai payoff de ce notebook est la **génération de témoin générale** `A & ~B`, pas le Sudoku.",,,,,,,,47f7d0509bf91467,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,2a81aba6,code,fr,65ef77d187a8b120,"// [a-z]{30} : plus long que l'ancien plafond ~21. Mesure du temps.
+var long30 = engine.CreateFromRegexes(""^[a-z]{30}$"");
+var sw = Stopwatch.StartNew();
+string temoinLong = engine.GenerateMember(long30);
+sw.Stop();
+
+Console.WriteLine($""  témoin     = \""{temoinLong}\"""");
+Console.WriteLine($""  longueur   = {temoinLong.Length}  (ancien plafond ~21)"");
+Console.WriteLine($""  accepté    = {engine.Solver.Accepts(long30, temoinLong)}"");
+Console.WriteLine($""  temps      = {sw.Elapsed.TotalMilliseconds:F1} ms"");",,,,,,,,65ef77d187a8b120,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,cbad4641,markdown,fr,1a13cad7c96e2210,"## Exercices
+
+Trois exercices pour pratiquer le motif `A & ~B` et la génération de témoin. Les cellules sont des **squelettes à compléter** : remplacez les `// TODO etudiant` puis exécutez. Un vérificateur indépendant est fourni à chaque fois.",,,,,,,,1a13cad7c96e2210,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,078db832,markdown,fr,df5f0ddc061710f1,"### Exercice 1 — Une adresse e-mail valide mais pas `@spam.com`
+
+Générez un témoin pour le motif `A & ~B` où :
+- **A** = une adresse e-mail simple, p. ex. `^[a-z]+@[a-z]+\.[a-z]+$` ;
+- **~B** = qui **ne se termine pas** par `@spam.com` → `~(.*@spam\.com$)`.
+
+`# Indice` : pensez à **parenthéser** le `~(…)` (cf §4). `# Etape 1` : construisez l'automate via `engine.CreateFromRegexes`. `# Etape 2` : générez et vérifiez le témoin.",,,,,,,,df5f0ddc061710f1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,8d8ed423,code,fr,ac88c71ecad6b485,"// Exercice 1 : e-mail valide, mais pas @spam.com.
+// Etape 1 : composez le motif A & ~B (A = email simple, ~B = pas @spam.com).
+string motifEmail = null;  // TODO etudiant : ""^[a-z]+@[a-z]+\\.[a-z]+$&~(.*@spam\\.com$)""
+
+if (motifEmail == null)
+{
+    Console.WriteLine(""Exercice a completer : definir motifEmail (A & ~B)."");
+}
+else
+{
+    // Etape 2 : construire, generer, verifier.
+    var autEmail = engine.CreateFromRegexes(motifEmail);
+    string temoin = engine.GenerateMember(autEmail);
+    bool pasSpam = !temoin.EndsWith(""@spam.com"");
+    Console.WriteLine($""temoin=\""{temoin}\""  pasSpam={pasSpam}"");
+}",,,,,,,,ac88c71ecad6b485,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,90f7ee76,markdown,fr,e84147875d6f38e6,"### Exercice 2 — Diagnostiquer et corriger le piège du solveur croisé
+
+Le code ci-dessous **échoue** : il construit l'automate avec un `CharSetSolver` local puis demande le témoin à un `RexEngine` distinct (le piège du §6). **Diagnostiquez** l'exception attendue, puis **corrigez** en utilisant le chemin sûr.
+
+`# Indice` : relisez le §6 — l'automate doit partager l'**algèbre** du moteur. `# Etape 1` : remplacez la construction par `engine.CreateFromRegexes(...)`.",,,,,,,,e84147875d6f38e6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,9b80eed1,code,fr,361cde1e0d4916ee,"// Exercice 2 : corriger le piège du solveur croisé.
+var solveurLocal = new CharSetSolver(BitWidth.BV7);
+var moteurEx2 = new RexEngine(BitWidth.BV7);
+
+// TODO etudiant : cette construction utilise le MAUVAIS solveur. Corrigez-la.
+// Indice : Automaton<BDD> autEx2 = moteurEx2.CreateFromRegexes(""^[a-z]{5}$"");
+Automaton<BDD> autEx2 = null;  // Etape 1 : construire via moteurEx2.CreateFromRegexes(...)
+
+if (autEx2 == null)
+{
+    Console.WriteLine(""Exercice a completer : construire autEx2 via le chemin sur (cf section 6)."");
+}
+else
+{
+    string temoin = moteurEx2.GenerateMember(autEx2);
+    Console.WriteLine($""temoin=\""{temoin}\""  accepte={moteurEx2.Solver.Accepts(autEx2, temoin)}"");
+}",,,,,,,,361cde1e0d4916ee,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,0feeceac,markdown,fr,7f94284e169f9f2b,"### Exercice 3 — Un numéro de test à 10 chiffres, non déjà utilisé
+
+Classique de la génération de test : produire un identifiant **valide** mais **pas dans une liste déjà utilisée**. Motif `A & ~B` :
+- **A** = `^[0-9]{10}$` — dix chiffres ;
+- **~B** = ne commence pas par un préfixe réservé connu, p. ex. `~(^0000.*$)`.
+
+`# Indice` : même schéma qu'au §8. `# Etape 1` : composez le motif. `# Etape 2` : générez plusieurs témoins et vérifiez qu'aucun ne commence par `0000`.",,,,,,,,7f94284e169f9f2b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,e0fc9b03,code,fr,96445b0e5a779d0b,"// Exercice 3 : numero de test a 10 chiffres, ne commencant pas par 0000.
+string motifNumero = null;  // TODO etudiant : ""^[0-9]{10}$&~(^0000.*$)""
+
+if (motifNumero == null)
+{
+    Console.WriteLine(""Exercice a completer : definir motifNumero (A & ~B)."");
+}
+else
+{
+    var autNum = engine.CreateFromRegexes(motifNumero);
+    for (int i = 0; i < 3; i++)
+    {
+        string w = engine.GenerateMember(autNum);
+        Console.WriteLine($""numero=\""{w}\""  len10={w.Length == 10}  pasPrefixe0000={!w.StartsWith(""0000"")}"");
+    }
+}",,,,,,,,96445b0e5a779d0b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/10_Witness_Generation_Automata.ipynb,ccaf4bc8,markdown,fr,bbe092c9fb96dd56,"## Conclusion
+
+| Ce qu'on a vu | Outil du fork |
+|---------------|---------------|
+| Intersection `&` en surface | parser → `Automaton.Intersect` |
+| Complément `~` en surface (avec parenthésage) | parser → `Automaton.Complement` |
+| Témoin de `A & ~B` | `RexEngine.GenerateMember` (chemin partagé) |
+| Garde solveur croisé | `ArgumentException` claire (#2979 étape 4) |
+| Formule SMT-LIB | `RegexToSMTConverter` → `re.inter` / `re.comp` |
+| Témoin via Z3 (SMT) | `ParseSMTLIB2String` + `str.in_re` → `Model.Eval` |
+| Témoin > 21 caractères | plafond #6 levé sous net8.0 |
+
+### À retenir
+
+- **Reconnaître ≠ produire.** RexEngine fabrique un témoin là où RE# ne fait que tester.
+- **`A & ~B`** est le motif universel de génération sous contrainte positive/négative.
+- **`~` se lie à l'atome suivant** : parenthésez `~(…)` pour complémenter une séquence.
+- **Algèbre partagée** : construisez l'automate via le moteur (`CreateFromRegexes`).
+- **Émettre puis résoudre** : le SMT-LIB du fork est le dialecte réel de Z3 — `ParseSMTLIB2String` ferme la boucle et produit un témoin par résolution de contraintes.
+- **Portée honnête** : le fork lève le mur du témoin, pas l'explosion d'automate. À l'échelle (Sudoku 81), **Z3 reste le résolveur de production**.
+- **Décomposition monadique** (Veanes, CAV'14) : le critère théorique qui décide si `re.inter` tient l'échelle. Un tous-distincts est décomposable (éclatable par chiffre, cf 7c) ; un ordre `x < y` ne l'est pas. C'est la frontière entre "" émettre "" et "" émettre dans la bonne forme "" du [Sudoku-13](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb).
+
+> **Source du programme.** Margus Veanes, *Symbolic Automata* - [Dagstuhl Seminar 17142](https://www.dagstuhl.de/17142) (2017) : SFA sur algèbre de Boole, minimisation symbolique (POPL'14), logique M2L-str vers SFA (POPL'17), décomposition monadique (CAV'14).
+
+---
+
+`<<` [06 — Meal Planner hiérarchique](06_Meal_Planner_Modelisation.ipynb) | [Sudoku-13 — Automates symboliques `>>`](../../../Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb)",,,,,,,,bbe092c9fb96dd56,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,f4109dfc,markdown,fr,124b2dea4ecac0a2,"← [06 — Planificateur de repas hiérarchique](06_Meal_Planner_Modelisation.ipynb) | [README Z3](README.md)
+
+---
+
+# Notebook 11 — Ordonnancement d'atelier (Job Shop Scheduling) avec Z3.Linq
+
+**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md)
+
+## Objectifs d'apprentissage
+
+- Modéliser un problème d'**ordonnancement combinatoire** (Job Shop Scheduling) sous forme de CSP
+- Encoder des **contraintes de non-chevauchement disjonctives** (`||`) avec Z3.Linq
+- Comparer un heuristique glouton avec la recherche SMT exacte
+- Implémenter une **recherche linéaire** pour minimiser le makespan Cmax
+
+## Vue d'ensemble : Pipeline de résolution
+
+```mermaid
+flowchart LR
+    I[""Instance JSP\n(N jobs × M machines)""] --> G[""Heuristique gloutonne\n(FIFO)""]
+    I --> Z[""CSP Z3.Linq\n(variables + contraintes)""]
+    G --> CG[""Cmax glouton\n(sous-optimal)""]
+    Z --> BS[""Recherche linéaire\nCmax = lb, lb+1, …""]
+    BS --> CO[""Cmax optimal\n(SMT SAT)""]
+    CG --> C[""Comparaison""]
+    CO --> C
+    style CO fill:#c8f7c5
+    style CG fill:#f7d5c5
+```",,,,,,,,124b2dea4ecac0a2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,2acdaa53,code,fr,01bd8e76488ace2a,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy, OR disjonctif supporté), Microsoft.Z3, System.Linq"");",,,,,,,,01bd8e76488ace2a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,1aa6185b,markdown,fr,7c1803f334604839,"## Instance de référence : 3 jobs × 2 machines
+
+Nous utilisons l'instance suivante — chaque job suit un **itinéraire fixe** sur les machines :
+
+| Job | 1ère opération | 2ème opération | Durée totale |
+|-----|----------------|----------------|--------------|  
+| J0  | Machine A (3h) → | Machine B (2h) | 5h |
+| J1  | Machine B (2h) → | Machine A (4h) | 6h |
+| J2  | Machine A (2h) → | Machine B (3h) | 5h |
+
+**Charge totale par machine** :
+- Machine A : 3 + 4 + 2 = **9h** → borne inférieure sur Cmax
+- Machine B : 2 + 2 + 3 = **7h**
+
+> La borne inférieure théorique est **Cmax ≥ 9h**. Peut-on l'atteindre ?",,,,,,,,7c1803f334604839,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,57678a5d,code,fr,a13702b0374f3e95,"// Instance 3×2 Job Shop
+// durA[j] = durée du job j sur Machine A, durB[j] = durée sur Machine B
+// startsOnA[j] = true si le job j commence sur A
+int[] durA = { 3, 4, 2 };               // J0:3h, J1:4h, J2:2h
+int[] durB = { 2, 2, 3 };               // J0:2h, J1:2h, J2:3h
+bool[] startsOnA = { true, false, true }; // J0: A→B, J1: B→A, J2: A→B
+string[] jobNames = { ""J0"", ""J1"", ""J2"" };
+
+Console.WriteLine(""=== Instance Job Shop 3×2 ==="");
+Console.WriteLine($""{""Job"",-6} {""Itinéraire"",-24} {""Durée totale""}"");
+Console.WriteLine(new string('-', 44));
+for (int j = 0; j < 3; j++)
+{
+    string route = startsOnA[j]
+        ? $""A({durA[j]}h) → B({durB[j]}h)""
+        : $""B({durB[j]}h) → A({durA[j]}h)"";
+    Console.WriteLine($""{jobNames[j],-6} {route,-24} {durA[j]+durB[j]}h"");
+}
+int lowerBound = Math.Max(durA.Sum(), durB.Sum());
+Console.WriteLine($""\nCharge Machine A : {durA.Sum()}h | Machine B : {durB.Sum()}h"");
+Console.WriteLine($""Borne inférieure Cmax ≥ {lowerBound}h"");",,,,,,,,a13702b0374f3e95,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,98e388ca,markdown,fr,1830e0b22829bbb9,"## Approche gloutonne : ordonnancement FIFO
+
+Une heuristique simple consiste à traiter les jobs dans leur **ordre naturel** (J0 → J1 → J2), en démarrant chaque opération **dès que la machine est disponible**.
+
+**Limitation** : le glouton traite un job après l'autre sans exploiter les chevauchements possibles entre machines. Il ne *regarde pas en avant* pour éviter l'inactivité machine.",,,,,,,,1830e0b22829bbb9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,02d41766,code,fr,5e4f0f219848b0d9,"// Simulation gloutonne FIFO (ordre J0 → J1 → J2)
+int machineAvailA = 0, machineAvailB = 0;
+int[] jobFinish = new int[3];
+
+Console.WriteLine(""=== Glouton FIFO (J0 → J1 → J2) ===\n"");
+Console.WriteLine($""{""Job"",-5} {""1ère op"",-22} {""2ème op"",-22} {""Fin""}"");
+Console.WriteLine(new string('-', 55));
+
+for (int j = 0; j < 3; j++)
+{
+    int s1, s2;
+    if (startsOnA[j])  // J0, J2 : A d'abord puis B
+    {
+        s1 = machineAvailA;
+        machineAvailA = s1 + durA[j];
+        s2 = Math.Max(machineAvailA, machineAvailB);
+        machineAvailB = s2 + durB[j];
+        jobFinish[j] = s2 + durB[j];
+        Console.WriteLine($""{jobNames[j],-5} A: t={s1}..{machineAvailA,-14} B: t={s2}..{machineAvailB,-14} {jobFinish[j]}h"");
+    }
+    else               // J1 : B d'abord puis A
+    {
+        s1 = machineAvailB;
+        machineAvailB = s1 + durB[j];
+        s2 = Math.Max(machineAvailB, machineAvailA);
+        machineAvailA = s2 + durA[j];
+        jobFinish[j] = s2 + durA[j];
+        Console.WriteLine($""{jobNames[j],-5} B: t={s1}..{machineAvailB,-14} A: t={s2}..{machineAvailA,-14} {jobFinish[j]}h"");
+    }
+}
+
+int cmaxGreedy = jobFinish.Max();
+Console.WriteLine($""\nCmax glouton = {cmaxGreedy}h  (borne inf. = {lowerBound}h → écart = {cmaxGreedy - lowerBound}h)"");",,,,,,,,5e4f0f219848b0d9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,f7e22e86,markdown,fr,ee66d6de6ef59946,"## Formulation Z3.Linq : variables et contraintes
+
+Le solveur SMT travaille sur des **variables entières** représentant les instants de début :
+
+| Variable | Signification |
+|----------|---------------|
+| `S00` | Début de J0 sur Machine **A** (durée 3h) |
+| `S01` | Début de J0 sur Machine **B** (durée 2h) |
+| `S10` | Début de J1 sur Machine **A** (durée 4h) |
+| `S11` | Début de J1 sur Machine **B** (durée 2h) |
+| `S20` | Début de J2 sur Machine **A** (durée 2h) |
+| `S21` | Début de J2 sur Machine **B** (durée 3h) |
+| `Cmax` | Makespan (à minimiser) |
+
+**Contraintes disjonctives de non-chevauchement** : pour deux jobs j1 et j2 sur la même machine m :
+
+```
+S_{j1,m} ≥ S_{j2,m} + dur_{j2,m}  ∨  S_{j2,m} ≥ S_{j1,m} + dur_{j1,m}
+```
+
+En Z3.Linq : `.Where(t => t.S00 >= t.S10 + 4 || t.S10 >= t.S00 + 3)`",,,,,,,,ee66d6de6ef59946,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,9fc23825,code,fr,db22b1394aa6141f,"// Classe de variables Z3 pour le planning
+public class JobShopSchedule
+{
+    // Instants de début : S{job}{machine} (A=0, B=1)
+    public int S00 = 0; // J0 sur Machine A (durée 3h)
+    public int S01 = 0; // J0 sur Machine B (durée 2h)
+    public int S10 = 0; // J1 sur Machine A (durée 4h)
+    public int S11 = 0; // J1 sur Machine B (durée 2h)
+    public int S20 = 0; // J2 sur Machine A (durée 2h)
+    public int S21 = 0; // J2 sur Machine B (durée 3h)
+    public int Cmax = 0;
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($""  Cmax = {Cmax}h"");
+        sb.AppendLine($""  J0 : A(t={S00}..{S00+3}) → B(t={S01}..{S01+2})"");
+        sb.AppendLine($""  J1 : B(t={S11}..{S11+2}) → A(t={S10}..{S10+4})"");
+        sb.AppendLine($""  J2 : A(t={S20}..{S20+2}) → B(t={S21}..{S21+3})"");
+        return sb.ToString();
+    }
+}
+Console.WriteLine(""Classe JobShopSchedule définie (7 variables Z3 : S00, S01, S10, S11, S20, S21, Cmax)."");",,,,,,,,db22b1394aa6141f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,ac236277,markdown,fr,f3a74bd55af0eb09,"## Recherche du Cmax optimal
+
+Z3 est un solveur de **satisfaisabilité** (SMT), pas d'optimisation directe. Pour minimiser Cmax, on effectue une **recherche linéaire ascendante** depuis la borne inférieure :
+
+1. Poser `T = borne_inf` (= 9h, charge maximale d'une machine)
+2. Demander à Z3 : *Existe-t-il un planning valide avec `Cmax ≤ T` ?*
+3. Si **SAT** → T est le makespan optimal → stop
+4. Si **UNSAT** → incrémenter T et recommencer
+
+La première valeur T pour laquelle Z3 répond SAT est le makespan optimal.",,,,,,,,f3a74bd55af0eb09,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,9bef8d02,code,fr,4b735cac7fa09ab8,"// Recherche linéaire du Cmax optimal via Z3.Linq
+int upperBound = durA.Sum() + durB.Sum(); // borne triviale : 16h (tout séquentiel)
+JobShopSchedule optimalSchedule = null;
+int optimalCmax = upperBound;
+
+Console.WriteLine($""Recherche de Cmax dans [{lowerBound}, {upperBound}]..."");
+Console.WriteLine();
+
+for (int T = lowerBound; T <= upperBound; T++)
+{
+    int bound = T;
+    using (var ctx = new Z3Context())
+    {
+        var theorem = ctx.NewTheorem<JobShopSchedule>()
+            // 1. Non-négativité
+            .Where(t => t.S00 >= 0 && t.S01 >= 0 && t.S10 >= 0
+                       && t.S11 >= 0 && t.S20 >= 0 && t.S21 >= 0 && t.Cmax >= 0)
+            // 2. Précédence (routes)
+            .Where(t => t.S01 >= t.S00 + 3)  // J0 : A (durée 3) avant B
+            .Where(t => t.S10 >= t.S11 + 2)  // J1 : B (durée 2) avant A
+            .Where(t => t.S21 >= t.S20 + 2)  // J2 : A (durée 2) avant B
+            // 3. Non-chevauchement Machine A (J0:3, J1:4, J2:2)
+            .Where(t => t.S00 >= t.S10 + 4 || t.S10 >= t.S00 + 3)
+            .Where(t => t.S00 >= t.S20 + 2 || t.S20 >= t.S00 + 3)
+            .Where(t => t.S10 >= t.S20 + 2 || t.S20 >= t.S10 + 4)
+            // 4. Non-chevauchement Machine B (J0:2, J1:2, J2:3)
+            .Where(t => t.S01 >= t.S11 + 2 || t.S11 >= t.S01 + 2)
+            .Where(t => t.S01 >= t.S21 + 3 || t.S21 >= t.S01 + 2)
+            .Where(t => t.S11 >= t.S21 + 3 || t.S21 >= t.S11 + 2)
+            // 5. Borne sur le makespan
+            .Where(t => t.Cmax >= t.S00 + 3 && t.Cmax >= t.S01 + 2)
+            .Where(t => t.Cmax >= t.S10 + 4 && t.Cmax >= t.S11 + 2)
+            .Where(t => t.Cmax >= t.S20 + 2 && t.Cmax >= t.S21 + 3)
+            .Where(t => t.Cmax <= bound);
+
+        var solution = theorem.Solve();
+        if (solution != null)
+        {
+            optimalSchedule = solution;
+            optimalCmax = solution.Cmax;
+            Console.WriteLine($""T={T,2}h → SAT ✓  Cmax optimal trouvé !"");
+            break;
+        }
+        else
+        {
+            Console.WriteLine($""T={T,2}h → UNSAT  (aucun planning possible)"");
+        }
+    }
+}",,,,,,,,4b735cac7fa09ab8,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,aa467937,markdown,fr,100d67a83d1e24c3,"## Résultats : glouton vs Z3
+
+Le diagramme Gantt textuel ci-dessous utilise la convention :
+- `0` = J0, `1` = J1, `2` = J2, `.` = machine inactive
+- Chaque caractère représente 1 heure",,,,,,,,100d67a83d1e24c3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,8ae54a47,markdown,fr,7152e3dc9a45e434,"## B10 — Optimisation directe du Cmax (DSL `.Optimize(Minimize, …)`)
+
+La cellule 9 ci-dessus minimise le `Cmax` par une **recherche linéaire** : on énumère des bornes `T = 9, 10, 11, …` et on interroge Z3 jusqu'au premier SAT. C'est correct, mais c'est un **mauvais réflexe d'optimisation** : on demande à un solveur de satisfaisabilité de faire *à la main* ce qu'il sait faire *nativement*. Z3 expose depuis longtemps un objet `Optimize` (l'API `MkOptimize + AssertSoft + MkMinimize + Check`) qui trouve l'optimum **en un seul appel** — pas en N+1. Le binding Z3.Linq le rend chaînable via deux sucres LINQ : `.OrderBy(lambda)` ([`Theorem{T}.cs:142`](../Z3.Linq/solutions/Z3.Linq/Theorem{T}.cs#L142), `⇒ Optimize(Optimization.Minimize)`) et `.OrderByDescending(lambda)` ([`Theorem{T}.cs:150`](../Z3.Linq/solutions/Z3.Linq/Theorem{T}.cs#L150), `⇒ Optimize(Optimization.Maximize)`), tous deux sucres au-dessus de la même méthode `Optimize<TResult>(Optimization direction, Expression<Func<T,TResult>> lambda)` ([`Theorem{T}.cs:86`](../Z3.Linq/solutions/Z3.Linq/Theorem{T}.cs#L86)). L'instance Job Shop 3×2 sert ici de **discriminateur** : la boucle linéaire `for T = 9..16` s'exécute *jusqu'à* la borne inférieure avant SAT (ici 1 itération seulement, ce qui cache la supériorité), mais sur des instances où l'optimum est *éloigné* de la borne inférieure (5+ itérations), `.Optimize` est asymptotiquement imbattable — c'est exactement le rôle du solveur MaxSAT (qui sait que les softs sont un compromis entre préférences violées) face à la recherche linéaire.
+
+> **Stack : A + B — pourquoi**. Ce bloc juxtapose **deux écritures du même optimum** : côté DSL `.Optimize(Minimize, t => t.Cmax)`, le binding matérialise l'objet `Optimize`, y pose toutes les contraintes `.Where`, traduit la lambda en `ArithExpr`, puis appelle `MkMinimize` + `Check` ; côté raw, l'utilisateur instancie lui-même `var opt = ctx.MkOptimize()`, manipule directement `BoolExpr`/`IntExpr` et appelle `MkMinimize(cmaxExpr)`. La même instance produit le **même `Cmax` optimal = 9h** dans les deux cas — mais l'un exprime l'objectif dans le vocabulaire du modèle-objet, l'autre dans celui des termes Z3.",,,,,,,,7152e3dc9a45e434,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,eab66d1a,code,fr,82ea05c694c4bb73,"// B10 - Optimisation directe du Cmax ""deux stacks"" sur le meme Job Shop 3x2 (cellule 9)
+// Meme instance (JobShopSchedule a 7 variables : S00..S21, Cmax), memes contraintes dures,
+// memes precedents, memes non-chevauchements. La difference : au lieu d'enumerer les bornes
+// T dans une boucle lineaire, on declare l'objectif ""minimiser Cmax"" une seule fois et on
+// laisse Z3 trouver l'optimum natif en un seul Check().
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : on instancie l'Optimize, on Assert les contraintes,
+// on appelle MkMinimize(cmax) puis Check() en UNE passe.
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+
+    // Variables : memes noms que la classe DSL (la coherence est purement documentaire ici)
+    IntExpr s00 = z3.MkIntConst(""S00""), s01 = z3.MkIntConst(""S01"");
+    IntExpr s10 = z3.MkIntConst(""S10""), s11 = z3.MkIntConst(""S11"");
+    IntExpr s20 = z3.MkIntConst(""S20""), s21 = z3.MkIntConst(""S21"");
+    IntExpr cmax = z3.MkIntConst(""Cmax"");
+
+    var opt = z3.MkOptimize();
+
+    // 1. Non-negativite
+    opt.Assert(z3.MkGe(s00, z3.MkInt(0))); opt.Assert(z3.MkGe(s01, z3.MkInt(0)));
+    opt.Assert(z3.MkGe(s10, z3.MkInt(0))); opt.Assert(z3.MkGe(s11, z3.MkInt(0)));
+    opt.Assert(z3.MkGe(s20, z3.MkInt(0))); opt.Assert(z3.MkGe(s21, z3.MkInt(0)));
+
+    // 2. Precedences (routes)
+    opt.Assert(z3.MkGe(s01, z3.MkAdd(s00, z3.MkInt(3)))); // J0: A(3h) avant B
+    opt.Assert(z3.MkGe(s10, z3.MkAdd(s11, z3.MkInt(2)))); // J1: B(2h) avant A
+    opt.Assert(z3.MkGe(s21, z3.MkAdd(s20, z3.MkInt(2)))); // J2: A(2h) avant B
+
+    // 3. Non-chevauchement Machine A (J0:3, J1:4, J2:2)
+    opt.Assert(z3.MkOr(z3.MkGe(s00, z3.MkAdd(s10, z3.MkInt(4))), z3.MkGe(s10, z3.MkAdd(s00, z3.MkInt(3)))));
+    opt.Assert(z3.MkOr(z3.MkGe(s00, z3.MkAdd(s20, z3.MkInt(2))), z3.MkGe(s20, z3.MkAdd(s00, z3.MkInt(3)))));
+    opt.Assert(z3.MkOr(z3.MkGe(s10, z3.MkAdd(s20, z3.MkInt(2))), z3.MkGe(s20, z3.MkAdd(s10, z3.MkInt(4)))));
+
+    // 4. Non-chevauchement Machine B (J0:2, J1:2, J2:3)
+    opt.Assert(z3.MkOr(z3.MkGe(s01, z3.MkAdd(s11, z3.MkInt(2))), z3.MkGe(s11, z3.MkAdd(s01, z3.MkInt(2)))));
+    opt.Assert(z3.MkOr(z3.MkGe(s01, z3.MkAdd(s21, z3.MkInt(3))), z3.MkGe(s21, z3.MkAdd(s01, z3.MkInt(2)))));
+    opt.Assert(z3.MkOr(z3.MkGe(s11, z3.MkAdd(s21, z3.MkInt(3))), z3.MkGe(s21, z3.MkAdd(s11, z3.MkInt(2)))));
+
+    // 5. Definition du makespan (sans borne superieure : on cherche l'optimum)
+    opt.Assert(z3.MkGe(cmax, z3.MkAdd(s00, z3.MkInt(3))));
+    opt.Assert(z3.MkGe(cmax, z3.MkAdd(s01, z3.MkInt(2))));
+    opt.Assert(z3.MkGe(cmax, z3.MkAdd(s10, z3.MkInt(4))));
+    opt.Assert(z3.MkGe(cmax, z3.MkAdd(s11, z3.MkInt(2))));
+    opt.Assert(z3.MkGe(cmax, z3.MkAdd(s20, z3.MkInt(2))));
+    opt.Assert(z3.MkGe(cmax, z3.MkAdd(s21, z3.MkInt(3))));
+
+    // 6. Objectif : minimiser Cmax (UN SEUL appel, pas de boucle T = 9..16)
+    opt.MkMinimize(cmax);
+
+    var status = opt.Check();
+    Console.WriteLine($""[RAW] Status : {status}  (UN seul Check, pas de boucle lineaire)"");
+    if (status == Microsoft.Z3.Status.SATISFIABLE)
+    {
+        var vCmax = ((Microsoft.Z3.IntNum)opt.Model.Eval(cmax, true)).Int;
+        Console.WriteLine($""[RAW]   Cmax optimal direct = {vCmax}h  (vs recherche lineaire cellule 9 : 9h au premier SAT)"");
+        // Pour memoire : le raw access Model sur un Optimize renvoie le modele optimal,
+        // pas un modele intermediaire comme dans la boucle lineaire.
+        var vS00 = ((Microsoft.Z3.IntNum)opt.Model.Eval(s00, true)).Int;
+        Console.WriteLine($""[RAW]   Premiere variable extraite S00 = {vS00}  (le raw donne acces direct au modele)"");
+    }
+}
+Console.WriteLine();
+
+// =====================================================================
+// BLOC DSL (Z3.Linq) : .Optimize(Minimize, t => t.Cmax) sur la meme classe JobShopSchedule
+// Reutilise les contraintes deja ecrites en cellules 7-9 (memes .Where, meme classe).
+// =====================================================================
+{
+    using var ctx = new Z3Context();
+    var theorem = ctx.NewTheorem<JobShopSchedule>()
+        // Meme chaine de Where que la cellule 9, SAUF la derniere borne Cmax <= bound (supprimee : on minimise)
+        .Where(t => t.S00 >= 0 && t.S01 >= 0 && t.S10 >= 0
+                  && t.S11 >= 0 && t.S20 >= 0 && t.S21 >= 0 && t.Cmax >= 0)
+        .Where(t => t.S01 >= t.S00 + 3)   // J0 : A (3h) avant B
+        .Where(t => t.S10 >= t.S11 + 2)   // J1 : B (2h) avant A
+        .Where(t => t.S21 >= t.S20 + 2)   // J2 : A (2h) avant B
+        // Machine A
+        .Where(t => t.S00 >= t.S10 + 4 || t.S10 >= t.S00 + 3)
+        .Where(t => t.S00 >= t.S20 + 2 || t.S20 >= t.S00 + 3)
+        .Where(t => t.S10 >= t.S20 + 2 || t.S20 >= t.S10 + 4)
+        // Machine B
+        .Where(t => t.S01 >= t.S11 + 2 || t.S11 >= t.S01 + 2)
+        .Where(t => t.S01 >= t.S21 + 3 || t.S21 >= t.S01 + 2)
+        .Where(t => t.S11 >= t.S21 + 3 || t.S21 >= t.S11 + 2)
+        // Definition du makespan (pas de borne sup : on laisse Z3 minimiser)
+        .Where(t => t.Cmax >= t.S00 + 3 && t.Cmax >= t.S01 + 2)
+        .Where(t => t.Cmax >= t.S10 + 4 && t.Cmax >= t.S11 + 2)
+        .Where(t => t.Cmax >= t.S20 + 2 && t.Cmax >= t.S21 + 3);
+
+    // === ICI : l'objectif (UN SEUL appel, pas de boucle) =====================
+    // Sucre LINQ : .OrderBy(lambda) renvoie ISolveable<T> (DeferredSolvable, Theorem{T}.cs:142).
+    // Pour obtenir le T resultat (membre direct .Cmax, .S00, etc.), on appelle .Solve()
+    // (idem que pour .Solve() direct sur le Theorem). C'est le meme UN appel Check en arriere-plan.
+    ISolveable<JobShopSchedule> optimalSolveable = theorem.OrderBy(t => t.Cmax);
+    JobShopSchedule optimal = optimalSolveable?.Solve();
+
+    if (optimal != null)
+    {
+        Console.WriteLine($""[DSL] Optimize(Minimize, Cmax) : Cmax optimal = {optimal.Cmax}h  (meme verdict que RAW)"");
+        Console.WriteLine($""[DSL]   Planning derive : J0=A({optimal.S00}..{optimal.S00+3})->B({optimal.S01}..{optimal.S01+2}), J1=B({optimal.S11}..{optimal.S11+2})->A({optimal.S10}..{optimal.S10+4}), J2=A({optimal.S20}..{optimal.S20+2})->B({optimal.S21}..{optimal.S21+3})"");
+        Console.WriteLine($""[DSL]   -> appels API : 1 Check au lieu de N+1 (N etant la distance opt - borne inf)"");
+    }
+}
+Console.WriteLine();
+Console.WriteLine(""B10 OK : raw (MkOptimize + MkMinimize) et DSL (.Optimize(Minimize)) produisent le meme"");
+Console.WriteLine(""Cmax = 9h sur la meme instance, l'un en une passe optimisee, l'autre sous forme de lambda."");
+",,,,,,,,82ea05c694c4bb73,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,8dd0154b,markdown,fr,cdfc55863c6fda42,"### Lecture B10 — deux écritures du même optimum
+
+Les deux blocs résolvent **exactement la même instance** (Job Shop 3×2, mêmes variables `S00..S21`, mêmes précédences, mêmes non-chevauchements, même définition du `Cmax`) et trouvent **le même `Cmax` optimal = 9h** — l'un en une seule passe `Check()` sur un objet `Optimize`, l'autre en un appel `.OrderBy(t => t.Cmax)` chaînable. La différence n'est pas sémantique, elle est **architecturale** :
+
+| Aspect | RAW (`MkOptimize + MkMinimize + Check`) | DSL (`th.OrderBy(lambda)` / `th.Optimize(Minimize, lambda)`) |
+|---|---|---|
+| Nombre d'appels `Check()` | **1** (un seul `opt.Check()` après l'objectif) | **1** (idem, le binding matérialise l'objet `Optimize`) |
+| Forme de l'objectif | Terme Z3 explicite : `opt.MkMinimize(cmaxExpr)` | Lambda C# typée : `OrderBy(t => t.Cmax)` ⇒ `Optimize(Optimization.Minimize, t => t.Cmax)` |
+| Accès au modèle optimal | `opt.Model.Eval(...)` | Population directe de l'objet `JobShopSchedule` |
+| Sur UNSAT | `opt.Check() != SATISFIABLE` | `OrderBy(...).Solve()` retourne `null` (idem qu'un `.Solve()`) |
+| Sucre LINQ | Aucun | `.OrderBy` / `.OrderByDescending` (idem SQL) en plus de `.Optimize` direct |
+
+> **Ligne de contraste (à retenir)** : *la recherche linéaire `for T = lowerBound..upperBound` est un anti-pattern d'optimisation qui externalise au solveur SAT un travail qu'il sait faire nativement* — `.Optimize(Minimize, …)` matérialise cette capacité en une ligne, en chaînant avec `.Where` comme n'importe quel autre solveur, et le sucre LINQ `.OrderBy(...)` la rend **aussi familière** qu'un `orderby` SQL. **Même `Cmax` = 9h, deux façons de le demander** — l'une impérative et bouclée, l'autre déclarative et directe.
+
+**Cas d'usage** : on préfère le DSL `.OrderBy` (lisibilité, chaînable dans un pipeline `.Where(...).Where(...).OrderBy(...)` façon LINQ-to-SQL) ; on bascule en raw `.Optimize` quand on doit mixer **plusieurs objectifs** (un `Optimize` peut porter plusieurs `MkMinimize` / `MkMaximize`, là où le DSL `.OrderBy` est limité à un seul objectif par appel) ou **inspecter le modèle** avant l'objectif. Sur l'instance 3×2, le gain est invisible (la borne inférieure *est* l'optimum : 1 itération linéaire vs 1 passe directe) — sur des instances où l'optimum diverge de la borne basse (≥5 unités de temps), `Optimize` est asymptotiquement imbattable.",,,,,,,,cdfc55863c6fda42,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,exo4-stub-md,markdown,fr,36e41bec272a510c,"## Exercice 4 - Etendre l'instance et observer le cout de la recherche lineaire vs MkMinimize
+
+**Enonce.** Reprenez l'instance 3 x 2 (J0, J1, J2 sur Machine A puis B) et ajoutez un quatrieme job `J3 : Machine B(1h) -> Machine A(3h)`. Reconstruisez un `JobShopScheduleExt` (variables `S30`, `S31` supplementaires, plus les disjonctions Machine A et Machine B pour `J3`, et la precedence `S30 >= S31 + 1`). Appelez ensuite le DSL :
+
+```csharp
+var optimal = ctx.NewTheorem<JobShopScheduleExt>()
+    .Where(/* ... toutes les contraintes ... */)
+    .OrderBy(t => t.Cmax)
+    .Solve();
+if (optimal != null)
+    Console.WriteLine($""Cmax optimal = {optimal.Cmax}h"");
+```
+
+**Question.** Quel est le nouveau `Cmax` optimal ?
+
+**Indice.** N'oubliez pas que la *recherche lineaire* de la cellule 9 (SAT ascendant `for T = lower..upper`) coutait **un `Check()` par valeur de `T`**. Avec le seuil qui separe `Cmax = 12h` (borne Machine A avec J3 : 3+4+2+3) du `Cmax` optimal reel, combien d'appels `Check()` la boucle lineaire de la cellule 9 aurait-elle faits avant de trouver la borne, **contre combien pour `MkMinimize + Check` en une passe** ?
+",,,,,,,,36e41bec272a510c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,exo4-stub-code,code,fr,4ee9b65bbc8789e5,"// Exercice 4 - Etendre l'instance 3x2 avec J3 (B(1h) -> A(3h)) et comparer
+//               la recherche lineaire de la cellule 9 vs l'optimisation directe .OrderBy
+// TODO etudiant :
+// Etape 1 : Definir une classe JobShopScheduleExt heritant de JobShopSchedule
+//           (ou la reecrire in extenso avec S30, S31 supplementaires)
+// Etape 2 : Ajouter les contraintes :
+//           - non-negativite S30, S31
+//           - precedence .Where(t => t.S30 >= t.S31 + 1)
+//           - non-chevauchement Machine A pour (J0,J3), (J1,J3), (J2,J3)
+//           - non-chevauchement Machine B pour (J0,J3), (J1,J3), (J2,J3)
+//           - bornes makespan .Where(t => t.Cmax >= t.S30 + 3 && t.Cmax >= t.S31 + 1)
+// Etape 3 : borne Machine A avec J3 -> Cmax >= 12h (3+4+2+3)
+// Etape 4 : comparer
+//   (a) recherche lineaire .Where(t => t.Cmax <= T) pour T = 12, 13, 14, ... -> compter les appels Check()
+//   (b) optimisation directe  .OrderBy(t => t.Cmax) -> UN SEUL appel Check() renvoyant l'optimum
+// Etape 5 : afficher les deux Cmax trouves + le nombre d'appels Check() par approche
+//
+// Indice : sur cette instance, le ratio est proche de 3x en faveur de .OrderBy.
+//          Sur les instances ou l'optimum est eloigne de la borne inferieure, le ratio est nettement plus severe.
+
+Console.WriteLine(""Exercice 4 a completer : extension avec J3 + comparaison lineaire vs .OrderBy"");
+",,,,,,,,4ee9b65bbc8789e5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,4211927c,code,fr,c10f2421985ef28a,"// Comparaison et Gantt textuel
+Console.WriteLine(""=== Comparaison Glouton vs Z3 ==="");
+Console.WriteLine($""Cmax glouton : {cmaxGreedy,2}h  (sous-optimal)"");
+Console.WriteLine($""Cmax Z3      : {optimalCmax,2}h  (optimal)"");
+Console.WriteLine($""Gain         : {cmaxGreedy - optimalCmax}h ({(cmaxGreedy-optimalCmax)*100/cmaxGreedy}%)"");
+Console.WriteLine();
+
+if (optimalSchedule != null)
+{
+    Console.WriteLine(""=== Planning optimal (Z3) ==="");
+    Console.WriteLine(optimalSchedule);
+
+    int ganttLen = optimalCmax;
+    char[] gA = Enumerable.Repeat('.', ganttLen).ToArray();
+    char[] gB = Enumerable.Repeat('.', ganttLen).ToArray();
+
+    for (int t = optimalSchedule.S00; t < optimalSchedule.S00+3 && t < ganttLen; t++) gA[t]='0';
+    for (int t = optimalSchedule.S10; t < optimalSchedule.S10+4 && t < ganttLen; t++) gA[t]='1';
+    for (int t = optimalSchedule.S20; t < optimalSchedule.S20+2 && t < ganttLen; t++) gA[t]='2';
+    for (int t = optimalSchedule.S01; t < optimalSchedule.S01+2 && t < ganttLen; t++) gB[t]='0';
+    for (int t = optimalSchedule.S11; t < optimalSchedule.S11+2 && t < ganttLen; t++) gB[t]='1';
+    for (int t = optimalSchedule.S21; t < optimalSchedule.S21+3 && t < ganttLen; t++) gB[t]='2';
+
+    string ticks = string.Concat(Enumerable.Range(0, ganttLen).Select(t => (t % 10).ToString()));
+    Console.WriteLine($""  Mach. A: |{new string(gA)}|"");
+    Console.WriteLine($""  Mach. B: |{new string(gB)}|"");
+    Console.WriteLine($""  Temps:   |{ticks}|  (h)"");
+    Console.WriteLine(""  Légende: 0=J0 · 1=J1 · 2=J2 · .=inactif"");
+}",,,,,,,,c10f2421985ef28a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,9c2075f5,markdown,fr,f250e2b0212deda2,"## Exercice 1 — Ajout d'un quatrième job
+
+Étendez le modèle pour inclure un **job J3** avec l'itinéraire :
+- Machine B d'abord (durée 1h)
+- Machine A ensuite (durée 3h)
+
+**Étapes** :
+1. Ajoutez les variables `S30` (début J3 sur A) et `S31` (début J3 sur B) à une classe `JobShopScheduleExt`
+2. Ajoutez la contrainte de précédence : `S30 >= S31 + 1`
+3. Ajoutez les contraintes de non-chevauchement entre J3 et J0, J1, J2 sur chaque machine
+4. Ajoutez la borne makespan pour J3 et lancez la recherche
+
+> **Indice** : la borne inférieure sur Machine A devient 3+4+2+3=**12h**.",,,,,,,,f250e2b0212deda2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,00ba0977,code,fr,40e22bc929aa5761,"// Exercice 1 : ajout du job J3 (B(1h) → A(3h))
+// TODO etudiant :
+// Etape 1 : définir JobShopScheduleExt avec S30 (A) et S31 (B) supplémentaires
+// Etape 2 : contrainte de précédence .Where(t => t.S30 >= t.S31 + 1)
+// Etape 3 : no-overlap Machine A pour (J0,J3), (J1,J3), (J2,J3)
+// Etape 4 : no-overlap Machine B pour (J0,J3), (J1,J3), (J2,J3)
+// Etape 5 : makespan .Where(t => t.Cmax >= t.S30 + 3 && t.Cmax >= t.S31 + 1)
+// Etape 6 : recherche linéaire depuis Math.Max(durA.Sum()+3, durB.Sum()+1) = 12
+
+// public class JobShopScheduleExt { /* TODO */ }
+
+Console.WriteLine(""Exercice 1 a completer : ajout de J3 (B(1h) → A(3h))"");",,,,,,,,40e22bc929aa5761,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,e22a0128,markdown,fr,fd82a03f949e36c4,"## Exercice 2 — Contrainte d'urgence (deadline)
+
+Ajoutez une **contrainte de deadline** : le job J0, considéré urgent, doit **terminer au plus tard à l'heure 7** (les deux opérations doivent être finies avant t=7).
+
+**Étapes** :
+1. Reprenez le modèle original (3 jobs × 2 machines)
+2. Ajoutez la contrainte `S01 + 2 <= 7` (J0 finit sur Machine B avant t=7)
+3. Lancez la recherche et observez l'impact sur Cmax
+4. Discutez : quel job est retardé ? La contrainte est-elle toujours satisfaisable ?
+
+> **Indice** : une deadline peut être UNSAT si elle entre en conflit avec les contraintes de précédence ou de non-chevauchement.",,,,,,,,fd82a03f949e36c4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,2e1c0f23,code,fr,c2754bf896945ff1,"// Exercice 2 : deadline sur J0 (doit terminer avant t=7)
+// TODO etudiant :
+// 1. Reprendre le theorem du notebook avec toutes les contraintes
+// 2. Ajouter .Where(t => t.S01 + 2 <= 7)  // J0 finit sur B avant t=7
+//    ET    .Where(t => t.S01 >= 0)         // déjà inclus dans non-négativité
+// 3. Recherche linéaire depuis lowerBound, afficher le Cmax trouvé
+// 4. Commenter : quel job est poussé plus tard ? Cmax change-t-il ?
+
+Console.WriteLine(""Exercice 2 a completer : deadline J0 (fin B <= 7h)"");",,,,,,,,c2754bf896945ff1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,dc0620c7,markdown,fr,e3d44a14fdebc0ed,"## Exercice 3 — Extension à 3 machines
+
+Étendez l'instance à **3 jobs × 3 machines** en ajoutant une Machine C :
+
+| Job | 1ère op | 2ème op | 3ème op |
+|-----|---------|---------|----------|
+| J0  | A (3h) → | B (2h) → | C (1h) |
+| J1  | B (2h) → | C (2h) → | A (4h) |
+| J2  | C (1h) → | A (2h) → | B (3h) |
+
+**Étapes** :
+1. Créez `JobShopSchedule3M` avec `S0C`, `S1C`, `S2C` pour Machine C (en plus de S0A=S00, S0B=S01, etc.)
+2. Ajoutez les contraintes de précédence pour la 3ème opération de chaque job
+3. Ajoutez les contraintes de non-chevauchement sur Machine C (3 paires)
+4. Calculez la borne inférieure et lancez la recherche
+
+> **Borne inférieure** : Machine A : 3+4+2=9h, Machine B : 2+2+3=7h, Machine C : 1+2+1=4h → Cmax ≥ 9h.",,,,,,,,e3d44a14fdebc0ed,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,eea838b1,code,fr,ae38bb35b70d9aaa,"// Exercice 3 : extension 3 machines (A, B, C)
+// Routes : J0: A(3)→B(2)→C(1), J1: B(2)→C(2)→A(4), J2: C(1)→A(2)→B(3)
+// TODO etudiant :
+// Etape 1 : JobShopSchedule3M avec S00,S01,S0C, S10,S11,S1C, S20,S21,S2C, Cmax
+// Etape 2 : précédence J0: S01>=S00+3, S0C>=S01+2
+//           précédence J1: S1C>=S11+2, S10>=S1C+2
+//           précédence J2: S20>=S2C+1, S21>=S20+2
+// Etape 3 : non-chevauchement Machine C (J0,J1), (J0,J2), (J1,J2)
+// Etape 4 : recherche depuis 9h et afficher Gantt 3 machines
+
+// public class JobShopSchedule3M { /* TODO */ }
+
+Console.WriteLine(""Exercice 3 a completer : extension 3×3 (Machines A, B, C)"");",,,,,,,,ae38bb35b70d9aaa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,b5-witness-intro,markdown,fr,2c2ff4064d63e885,"## B5 - Témoin d'une quantite dérivée (DSL `Solve(inspect)` / `Eval`)
+
+Ce notebook lit le `Cmax` optimal, membre direct du type resultat. Mais une fois une solution trouvee, on veut souvent lire une quantite **dérivée** qui n'est **pas** un membre du type - la fin d'un job (`start + duree`), le temps mort d'une machine, ou un **fait relationnel** (« J1 commence-t-il bien après la fin de J0 ? »). Le `.Solve()` de base calcule un modèle Z3 puis **le jette** après avoir peuple l'objet resultat : impossible de rejouer une sous-expression. Le binding ajoute [`Theorem<T>.Solve(inspect)`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs) : un callback qui **fait ressortir le modèle vivant** via un témoin `w.Eval(lambda)`, evalue sous **le meme modèle** que celui qui a produit la solution. Le callback **n'est pas invoque** si le théorème est UNSAT (aucun modèle a temoigner).
+
+> **Stack : A + B - pourquoi**. Cote raw, le témoin est manuel : on garde le `Model`, on **re-exprime** la quantite dérivée en termes Z3 (`MkAdd(s0, d0)`) et on appelle `model.Eval(expr, true)`. Cote DSL, `Solve(w => w.Eval(x => x.S0 + d0))` evalue la **meme quantite dérivée** ecrite en lambda C# typee sur le resultat, sans jamais toucher a l'API Z3. Le contraste est la **meme valeur** (la fin de job, le makespan, le fait de non-chevauchement) obtenue des deux cotes sous le meme modèle - mais le DSL la lit dans le vocabulaire du modèle-objet, pas dans celui des termes Z3.",,,,,,,,2c2ff4064d63e885,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,b5-witness-code,code,fr,0e0c938d4f7f01f6,"// B5 - Temoin d'une quantite derivee ""Solve(inspect)"" : deux stacks sur le MEME mini-ordonnancement.
+//   Deux jobs sur une machine : J0 (duree 3), J1 (duree 2). Contraintes : S0 in [0,2], S1 >= S0+3, S1 <= 10.
+//   Quantites DERIVEES (non membres du type resultat) : fin0 = S0+3, makespan = S1+2, fait ""S1 >= fin0"".
+//   On les lit comme TEMOINS sous le meme modele qui a produit la solution - raw via Model.Eval, DSL via w.Eval.
+const int d0 = 3, d1 = 2;
+
+// Classe au niveau cellule (requise par NewTheorem<T>) : deux dates de debut.
+public class Sched { public int S0 { get; set; }  public int S1 { get; set; } }
+
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : on garde le Model et on re-exprime la quantite derivee en termes Z3
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    IntExpr s0 = z3.MkIntConst(""s0"");
+    IntExpr s1 = z3.MkIntConst(""s1"");
+    var sr = z3.MkSolver();
+    sr.Assert(z3.MkGe(s0, z3.MkInt(0)));
+    sr.Assert(z3.MkLe(s0, z3.MkInt(2)));
+    sr.Assert(z3.MkGe(s1, z3.MkAdd(s0, z3.MkInt(d0))));   // J1 apres la fin de J0
+    sr.Assert(z3.MkLe(s1, z3.MkInt(10)));
+    Status st = sr.Check();
+    Console.WriteLine($""[RAW] Check : {st}"");
+    if (st == Status.SATISFIABLE) {
+        var m = sr.Model;
+        // Quantites derivees : re-exprimees a la main en termes Z3, puis evaluees sur le modele
+        var fin0 = (IntNum)m.Eval(z3.MkAdd(s0, z3.MkInt(d0)), true);
+        var mkspan = (IntNum)m.Eval(z3.MkAdd(s1, z3.MkInt(d1)), true);
+        // Fait relationnel : S1 >= fin0 (non-chevauchement) evalue comme booleen
+        var noOverlap = m.Eval(z3.MkGe(s1, z3.MkAdd(s0, z3.MkInt(d0))), true);
+        var vs0 = (IntNum)m.Eval(s0, true);  var vs1 = (IntNum)m.Eval(s1, true);
+        Console.WriteLine($""[RAW]   modele : S0={vs0}, S1={vs1}"");
+        Console.WriteLine($""[RAW]   temoins derives : fin0={fin0}, makespan={mkspan}, (S1>=fin0)={noOverlap}"");
+    }
+}
+
+// =====================================================================
+// BLOC DSL (Z3.Linq) : le temoin sort par callback, la quantite derivee s'ecrit en lambda C# typee
+// =====================================================================
+{
+    using var thCtx = new Z3Context();
+    int wFin0 = -1, wMakespan = -1; bool wNoOverlap = false;
+    var solution = thCtx.NewTheorem<Sched>()
+        .Where(x => x.S0 >= 0)
+        .Where(x => x.S0 <= 2)
+        .Where(x => x.S1 >= x.S0 + d0)
+        .Where(x => x.S1 <= 10)
+        .Solve(w => {
+            wFin0      = w.Eval(x => x.S0 + d0);        // quantite derivee (non membre du type)
+            wMakespan  = w.Eval(x => x.S1 + d1);        // objectif derive
+            wNoOverlap = w.Eval(x => x.S1 >= x.S0 + d0); // fait relationnel booleen
+        });
+    if (solution != null) {
+        Console.WriteLine($""[DSL] Solve(inspect) : SAT  (S0={solution.S0}, S1={solution.S1})"");
+        Console.WriteLine($""[DSL]   temoins derives : fin0={wFin0}, makespan={wMakespan}, (S1>=fin0)={wNoOverlap}"");
+        Console.WriteLine($""[DSL]   -> coherence membres/derive : S0+{d0}={solution.S0 + d0} == fin0={wFin0}"");
+    }
+
+    // Le callback n'est PAS invoque sur UNSAT (aucun modele a temoigner)
+    bool invoked = false;
+    var contradiction = thCtx.NewTheorem<Sched>()
+        .Where(x => x.S0 == 1)
+        .Where(x => x.S0 == 2)   // contradictoire
+        .Solve(_ => invoked = true);
+    Console.WriteLine($""[DSL] UNSAT : solution={(contradiction == null ? ""null"" : ""?"")}, callback invoque={invoked}  (pas de temoin sans modele)"");
+}",,,,,,,,0e0c938d4f7f01f6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,b5-witness-lecture,markdown,fr,0d92846e93af5049,"### Lecture B5 - deux facons de temoigner, un meme modèle
+
+Les deux stacks resolvent le **meme mini-ordonnancement** et lisent les **memes quantites dérivées** - fin de J0, makespan, fait de non-chevauchement - **sous le meme modèle** qui a produit la solution. La difference est **comment** on rejoue une sous-expression après la résolution :
+
+| Aspect | RAW (`Model.Eval`) | DSL (`Solve(inspect)` / `w.Eval`) |
+|---|---|---|
+| Acces au modèle | Manuel : garder `sr.Model` après `Check()` | Threade dans un callback, uniquement si SAT |
+| Quantite dérivée | Re-exprimee en termes Z3 (`MkAdd(s0, MkInt(d0))`) | Lambda C# typee (`x => x.S0 + d0`) |
+| Type de retour | `Expr` a caster (`IntNum`, `BoolExpr`) | Valeur CLR directe (`int`, `bool`) |
+| Sur UNSAT | `Model` inexistant (exception si on force) | Callback **non invoque**, `Solve` renvoie `null` |
+
+> **Ligne de contraste (a retenir)** : *le raw expose le `Model` Z3 et laisse l'utilisateur re-exprimer chaque quantite dérivée en termes du solveur* ; *le DSL fait ressortir le modèle par un callback type* - `w.Eval(x => x.S0 + d0)` lit la meme dérivée dans le vocabulaire du modèle-objet, sous exactement le meme modèle, et se tait proprement sur UNSAT. **Meme modèle, meme valeur**, deux vocabulaires pour interroger la solution après coup.
+
+**Cas d'usage** : `Solve(inspect)` est l'outil des **metriques post-solution** - quand la solution optimale (le `Cmax` de ce notebook) ne suffit pas et qu'on veut lire des grandeurs dérivées (temps morts, marges, indicateurs relationnels) sans les reifier en membres du type resultat. On bascule en raw quand on a besoin d'evaluer des **termes Z3 arbitraires** hors du schema du modèle-objet (ex. une fonction non-interpretee, un tableau).",,,,,,,,0d92846e93af5049,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/11_Job_Shop_Scheduling.ipynb,bae1c09f,markdown,fr,f0aae1ad1d679b44,"## Conclusion
+
+Le **Job Shop Scheduling** est un problème NP-difficile en général. Sur notre instance 3×2 :
+
+| Approche | Cmax | Méthode |
+|----------|------|----------|
+| Glouton FIFO | 12h | Décisions locales séquentielles |
+| Z3.Linq SMT | 9h | Exploration SMT complète |
+| Borne inférieure | 9h | Charge Machine A = 3+4+2 |
+
+**Points clés** :
+- Les **contraintes disjonctives** (`||`) expriment naturellement le non-chevauchement en Z3.Linq
+- La **recherche linéaire sur Cmax** transforme l'optimisation en séquence de problèmes de satisfaisabilité
+- Pour des instances plus grandes, des solveurs spécialisés (Google OR-Tools CP-SAT, CPLEX) sont préférables
+
+**Référence** : *Garey & Johnson (1979)* — Computers and Intractability (NP-complétude du JSP général)",,,,,,,,f0aae1ad1d679b44,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,fe129563,markdown,fr,af22cec1e5874e2f,"# Notebook 12 - Coloration de graphe : le graphe de Petersen
+
+**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md) | [<< 11 Job Shop Scheduling](11_Job_Shop_Scheduling.ipynb)
+
+## Objectifs d'apprentissage
+
+- Modéliser un **problème de coloration de graphe** (graph coloring) avec Z3.Linq : une couleur par sommet, deux sommets adjacents ne partagent jamais leur couleur
+- Découvrir le **nombre chromatique** `χ(G)` — le plus petit nombre de couleurs nécessaire — par recherche linéaire (suite de requêtes SAT)
+- Confronter une **heuristique gloutonne** (first-fit) au solveur : voir où le glouton gaspille des couleurs là où Z3 trouve l'optimum
+- Travailler sur une **structure irrégulière** (un graphe, pas une grille) : le graphe de Petersen, célèbre contre-exemple de la théorie des graphes
+
+## Prérequis
+
+- Notebooks [01 (Introduction Z3.Linq)](01_Linq2Z3_Intro.ipynb) et [11 (Job Shop Scheduling)](11_Job_Shop_Scheduling.ipynb)
+- Notions de base de théorie des graphes (sommets, arêtes, adjacence)
+
+**Durée estimée** : 35-45 minutes
+
+---
+
+La **coloration de graphe** est un problème NP-difficile classique : étant donné un graphe, attribuer une couleur à chaque sommet de sorte que deux sommets reliés par une arête aient des couleurs différentes, en minimisant le nombre de couleurs. Ses applications sont nombreuses : planification d'examens (sommet = examen, arête = étudiant commun, couleur = créneau horaire), allocation de registres dans un compilateur, attribution de fréquences radio, etc.
+
+Ce notebook le démontre sur le **graphe de Petersen**, un graphe à 10 sommets et 15 arêtes, célèbre parce qu'il sert de contre-exemple à de nombreuses conjectures. Son nombre chromatique vaut `χ = 3` — mais une lecture naïve pourrait en suggérer davantage, et une heuristique gloutonne s'y trompe. C'est exactement le terrain où le solveur fait la différence.",,,,,,,,af22cec1e5874e2f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,c03d60a1,markdown,fr,a0bed3fbd4526156,"### Vue d'ensemble : du graphe à sa coloration optimale
+
+```mermaid
+flowchart LR
+    G[""Graphe de Petersen\n(10 sommets, 15 aretes)""]
+    G --> GR[""Heuristique gloutonne\nfirst-fit (ordre 0..9)""]
+    G --> Z[""Modele Z3.Linq\n1 couleur par sommet\nCi != Cj sur chaque arete""]
+    GR --> KG[""3 ou 4 couleurs\nselon l'ordre de parcours\n(aucune garantie)""]
+    Z --> RL[""Recherche lineaire\nk = 1, 2, 3, ...\npremier SAT = chi(G)""]
+    RL --> CHI[""chi(G) = 3\n(optimum PROUVE,\n2 couleurs = UNSAT)""]
+    KG --> C[""Comparaison""]
+    CHI --> C
+    style CHI fill:#c8f7c5
+    style KG fill:#f7d5c5
+```
+
+Les deux voies partent du même graphe. Le **glouton** colore les sommets dans l'ordre, sans anticiper : selon l'ordre, il trouve 3 couleurs (chanceux) ou 4 (malchanceux), **sans jamais le savoir**. Le **solveur** explore globalement l'espace des colorations, atteint `χ = 3` **et le prouve** (il démontre que 2 couleurs sont impossibles). Le payoff pédagogique : non pas « le glouton se trompe toujours », mais « le glouton ne garantit ni l'optimum ni la preuve », là où Z3 fait les deux.",,,,,,,,a0bed3fbd4526156,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,542624c9,code,fr,36a8cf47c83a3682,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy), Microsoft.Z3, System.Linq"");",,,,,,,,36a8cf47c83a3682,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,9face6d8,markdown,fr,f42d3d59939b19ed,"## 1. Le graphe de Petersen
+
+Le graphe de Petersen se construit ainsi :
+- un **pentagone externe** : les sommets `0-1-2-3-4` reliés en cycle ;
+- un **pentagramme interne** : les sommets `5-6-7-8-9` reliés en étoile (`5-7-9-6-8-5`) ;
+- cinq **rayons** reliant chaque sommet externe `i` au sommet interne `i+5`.
+
+Soit 15 arêtes au total. Ci-dessous, on encode la liste d'adjacence et un utilitaire d'affichage d'une coloration.",,,,,,,,f42d3d59939b19ed,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,d92c4e88,code,fr,979cc8e97b96a2d3,"// Graphe de Petersen : 10 sommets (0..9), 15 aretes
+int N = 10;
+var edges = new List<(int, int)>
+{
+    // Pentagone externe
+    (0,1),(1,2),(2,3),(3,4),(4,0),
+    // Rayons externe -> interne
+    (0,5),(1,6),(2,7),(3,8),(4,9),
+    // Pentagramme interne
+    (5,7),(7,9),(9,6),(6,8),(8,5)
+};
+
+// Liste d'adjacence (pour le glouton)
+var adj = Enumerable.Range(0, N).ToDictionary(v => v, v => new List<int>());
+foreach (var (a, b) in edges) { adj[a].Add(b); adj[b].Add(a); }
+
+void DisplayColoring(int[] color, string title)
+{
+    Console.WriteLine(title);
+    int k = color.Max() + 1;
+    Console.WriteLine($""  Couleurs utilisees : {k}"");
+    for (int v = 0; v < color.Length; v++)
+        Console.WriteLine($""  Sommet {v} -> couleur {color[v]}"");
+    // Verification : aucune arete monochrome
+    bool valid = edges.All(e => color[e.Item1] != color[e.Item2]);
+    Console.WriteLine($""  Coloration valide (aucune arete monochrome) : {valid}"");
+}
+
+Console.WriteLine($""Graphe de Petersen charge : {N} sommets, {edges.Count} aretes."");",,,,,,,,979cc8e97b96a2d3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,a0401663,markdown,fr,e3d401d2eb522dfa,"## 2. Approche 1 : heuristique gloutonne (first-fit)
+
+L'algorithme **first-fit** parcourt les sommets dans un ordre donné et attribue à chacun la **plus petite couleur** non encore utilisée par ses voisins déjà colorés. Simple et rapide, mais **myope** : il ne revient jamais sur une décision, et son résultat **dépend de l'ordre de parcours**.
+
+Pour le montrer, on le lance deux fois sur le **même graphe** : une fois dans l'ordre naturel `0..9`, une fois dans un ordre **défavorable**. Le degré maximal du graphe de Petersen étant 3, first-fit peut utiliser jusqu'à `Δ + 1 = 4` couleurs.",,,,,,,,e3d401d2eb522dfa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,87cf2ab6,code,fr,74bd3f2caeef3ecf,"// Coloration gloutonne first-fit selon un ordre de parcours donne
+int[] GreedyColoring(int n, Dictionary<int, List<int>> adjacency, int[] order)
+{
+    var color = Enumerable.Repeat(-1, n).ToArray();
+    foreach (int v in order)
+    {
+        var used = new HashSet<int>();
+        foreach (int w in adjacency[v])
+            if (color[w] != -1) used.Add(color[w]);
+        int c = 0;
+        while (used.Contains(c)) c++;
+        color[v] = c;
+    }
+    return color;
+}
+
+// Ordre naturel 0..9
+int[] naturalOrder = Enumerable.Range(0, N).ToArray();
+int[] greedyNatural = GreedyColoring(N, adj, naturalOrder);
+int greedyNaturalColors = greedyNatural.Max() + 1;
+DisplayColoring(greedyNatural, ""First-fit, ordre naturel 0..9 :"");
+
+Console.WriteLine();
+
+// Ordre defavorable (force la 4e couleur)
+int[] badOrder = { 4, 8, 2, 6, 5, 9, 0, 7, 1, 3 };
+int[] greedyBad = GreedyColoring(N, adj, badOrder);
+int greedyBadColors = greedyBad.Max() + 1;
+DisplayColoring(greedyBad, ""First-fit, ordre defavorable {4,8,2,6,5,9,0,7,1,3} :"");
+
+Console.WriteLine();
+Console.WriteLine($""Meme graphe, meme algorithme : {greedyNaturalColors} couleurs vs {greedyBadColors} couleurs selon l'ordre."");",,,,,,,,74bd3f2caeef3ecf,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,d71aa7f7,markdown,fr,46706f7a44ae9c10,"### Interprétation
+
+Les deux exécutions le montrent : sur le **même** graphe, first-fit donne **3 couleurs** dans l'ordre naturel mais **4** dans l'ordre défavorable. Le glouton produit toujours une coloration **valide**, mais le nombre de couleurs **dépend de l'ordre** et n'est **pas garanti minimal**. Pire : le glouton n'a aucun moyen de *savoir* si l'ordre qu'il a suivi était bon — il ne peut ni prouver qu'il est optimal, ni qu'un autre ordre ferait mieux. C'est la limite structurelle des heuristiques sans retour arrière.
+
+La question devient alors : **combien de couleurs sont réellement nécessaires ?** C'est le nombre chromatique `χ(G)`, et c'est précisément ce qu'un solveur SMT sait établir — avec une **preuve**.",,,,,,,,46706f7a44ae9c10,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,fd7581de,markdown,fr,736361ee626ea345,"## 3. Approche 2 : modélisation Z3.Linq
+
+On déclare une classe modèle avec **une variable entière par sommet** (`C0` à `C9`), représentant sa couleur. Pour un nombre de couleurs `k` fixé, les contraintes sont :
+
+1. **Domaine** : chaque couleur `Ci` est dans `[0, k)` ;
+2. **Arêtes** : pour chaque arête `(i, j)`, `Ci ≠ Cj`. On l'exprime sous forme disjonctive `(Ci < Cj || Ci > Cj)`, qui n'utilise que des opérateurs déjà éprouvés du binding ;
+3. **Brisure de symétrie** (optionnelle, accélère la recherche) : on fixe `C0 = 0`, puisque le nom des couleurs est arbitraire.
+
+En faisant **croître `k`** (1, 2, 3, …), la première valeur pour laquelle le théorème est **satisfiable** est le nombre chromatique.",,,,,,,,736361ee626ea345,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,57333767,code,fr,c823fba3ef8c2e1d,"// Modele Z3 : une couleur entiere par sommet du graphe de Petersen
+public class GraphColoring
+{
+    public int C0 = 0;
+    public int C1 = 0;
+    public int C2 = 0;
+    public int C3 = 0;
+    public int C4 = 0;
+    public int C5 = 0;
+    public int C6 = 0;
+    public int C7 = 0;
+    public int C8 = 0;
+    public int C9 = 0;
+}
+
+Console.WriteLine(""Classe modele GraphColoring definie (10 variables de couleur)."");",,,,,,,,c823fba3ef8c2e1d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,e7ee28a5,markdown,fr,201c8dff00e66af1,"## 4. Recherche du nombre chromatique
+
+On enchaîne les requêtes SAT pour `k = 1, 2, 3, …`. Pour chaque `k`, on construit un théorème dont les contraintes de domaine bornent les couleurs à `[0, k)` et dont chaque arête interdit l'égalité des deux extrémités. La **première** valeur de `k` satisfiable donne `χ(G)` et une coloration témoin.",,,,,,,,201c8dff00e66af1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,3483cd8b,code,fr,8fa78c15c5b86ec5,"// Recherche lineaire du nombre chromatique
+GraphColoring optimal = null;
+int chromatic = -1;
+
+for (int k = 1; k <= N; k++)
+{
+    int kk = k; // capture locale
+    using (var ctx = new Z3Context())
+    {
+        var theorem = ctx.NewTheorem<GraphColoring>()
+            // 1. Domaine : chaque couleur dans [0, k)
+            .Where(t => t.C0 >= 0 && t.C0 < kk && t.C1 >= 0 && t.C1 < kk
+                     && t.C2 >= 0 && t.C2 < kk && t.C3 >= 0 && t.C3 < kk
+                     && t.C4 >= 0 && t.C4 < kk && t.C5 >= 0 && t.C5 < kk
+                     && t.C6 >= 0 && t.C6 < kk && t.C7 >= 0 && t.C7 < kk
+                     && t.C8 >= 0 && t.C8 < kk && t.C9 >= 0 && t.C9 < kk)
+            // 2. Brisure de symetrie : la couleur du sommet 0 est fixee
+            .Where(t => t.C0 == 0)
+            // 3. Aretes : extremites de couleurs differentes (forme disjonctive)
+            // Pentagone externe
+            .Where(t => t.C0 < t.C1 || t.C0 > t.C1)
+            .Where(t => t.C1 < t.C2 || t.C1 > t.C2)
+            .Where(t => t.C2 < t.C3 || t.C2 > t.C3)
+            .Where(t => t.C3 < t.C4 || t.C3 > t.C4)
+            .Where(t => t.C4 < t.C0 || t.C4 > t.C0)
+            // Rayons
+            .Where(t => t.C0 < t.C5 || t.C0 > t.C5)
+            .Where(t => t.C1 < t.C6 || t.C1 > t.C6)
+            .Where(t => t.C2 < t.C7 || t.C2 > t.C7)
+            .Where(t => t.C3 < t.C8 || t.C3 > t.C8)
+            .Where(t => t.C4 < t.C9 || t.C4 > t.C9)
+            // Pentagramme interne
+            .Where(t => t.C5 < t.C7 || t.C5 > t.C7)
+            .Where(t => t.C7 < t.C9 || t.C7 > t.C9)
+            .Where(t => t.C9 < t.C6 || t.C9 > t.C6)
+            .Where(t => t.C6 < t.C8 || t.C6 > t.C8)
+            .Where(t => t.C8 < t.C5 || t.C8 > t.C5);
+
+        var sol = theorem.Solve();
+        if (sol != null)
+        {
+            optimal = sol;
+            chromatic = kk;
+            Console.WriteLine($""k = {kk} -> SAT : nombre chromatique trouve !"");
+            break;
+        }
+        else
+        {
+            Console.WriteLine($""k = {kk} -> UNSAT (impossible avec {kk} couleur(s))"");
+        }
+    }
+}
+
+Console.WriteLine();
+Console.WriteLine($""Nombre chromatique chi(Petersen) = {chromatic}"");",,,,,,,,8fa78c15c5b86ec5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,0f6d3988,markdown,fr,1e328fd9f7aa5a00,"### Interprétation : `χ = 3` prouvé
+
+La recherche établit que le graphe de Petersen **n'est pas** 2-coloriable (UNSAT pour `k = 2` — il contient des cycles impairs) mais l'est avec **3 couleurs** (SAT pour `k = 3`). C'est un résultat **prouvé**, pas estimé : pour `k = 2`, le solveur a démontré qu'aucune assignation ne satisfait toutes les arêtes ; pour `k = 3`, il exhibe une coloration témoin.
+
+L'écart avec le glouton est le cœur du propos : là où l'heuristique gaspille une couleur, le solveur atteint et **certifie** l'optimum.",,,,,,,,1e328fd9f7aa5a00,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,f5bb3769,code,fr,cf58d7ff4f7f0dc0,"// Extraction et verification de la coloration optimale
+int[] z3color = {
+    optimal.C0, optimal.C1, optimal.C2, optimal.C3, optimal.C4,
+    optimal.C5, optimal.C6, optimal.C7, optimal.C8, optimal.C9
+};
+DisplayColoring(z3color, $""Coloration optimale Z3 (chi = {chromatic}) :"");
+
+Console.WriteLine();
+Console.WriteLine(""=== Comparaison ==="");
+Console.WriteLine($""  Glouton first-fit (ordre naturel)    : {greedyNaturalColors} couleurs"");
+Console.WriteLine($""  Glouton first-fit (ordre defavorable): {greedyBadColors} couleurs"");
+Console.WriteLine($""  Z3 (optimum PROUVE)                  : {chromatic} couleurs"");
+Console.WriteLine($""  Dans le pire ordre, le glouton gaspille {greedyBadColors - chromatic} couleur(s)."");
+Console.WriteLine($""  Surtout : seul Z3 PROUVE que {chromatic} est minimal (2 couleurs = UNSAT)."");",,,,,,,,cf58d7ff4f7f0dc0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,c9588fb0,markdown,fr,e74a1fd37a3097fb,"## 5. Glouton vs solveur : ce que démontre Petersen
+
+| Critère | Glouton first-fit | Z3.Linq (recherche de `χ`) |
+|---------|-------------------|----------------------------|
+| Garantie d'optimalité | Aucune (dépend de l'ordre) | Oui (`χ` prouvé minimal) |
+| Preuve d'infaisabilité | Impossible | Oui (UNSAT pour `k < χ`) |
+| Coût | Linéaire, instantané | NP-difficile, mais trivial à cette échelle |
+| Couleurs sur Petersen | 3 (ordre favorable) **ou 4** (ordre défavorable) | 3 (optimum prouvé) |
+
+Le graphe de Petersen illustre pourquoi la coloration est un **vrai** problème combinatoire : pas de clique de taille 4 (rien ne « force » visuellement une quatrième couleur), et pourtant le first-fit **peut** y dépenser une couleur de trop selon l'ordre — sans jamais pouvoir le détecter. Le solveur, lui, raisonne globalement, **certifie** le minimum, et **prouve** qu'aucune 2-coloration n'existe — exactement la valeur ajoutée de l'approche déclarative sur une structure irrégulière.
+
+> **À retenir** : un problème dégénéré (graphe biparti, ordre favorable) ne distinguerait pas le glouton du solveur. Le choix de Petersen, structure non triviale au nombre chromatique non évident, est ce qui met la capacité du moteur en valeur.",,,,,,,,e74a1fd37a3097fb,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,a058a642,markdown,fr,58237cb8e953ff79,"## 6. Exercice 1 : forcer une quatrième couleur
+
+Ajoutez au graphe de Petersen une arête supplémentaire qui crée une **clique de taille 4** (quatre sommets tous deux à deux adjacents), puis relancez la recherche du nombre chromatique. Vérifiez que `χ` passe à 4.
+
+**Indices** :
+- Une clique de taille 4 nécessite au moins 4 couleurs (chaque sommet de la clique doit différer de tous les autres).
+- Repérez quatre sommets et ajoutez les arêtes manquantes entre eux dans une copie de la liste `edges`.
+- Réutilisez la structure de la boucle de recherche en ajoutant les `.Where(...)` correspondants.",,,,,,,,58237cb8e953ff79,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,e0b50c75,code,fr,7938f3720faed1c5,"// Exercice 1 : ajouter une arete creant une clique de taille 4, recalculer chi
+// Etape 1 : choisir 4 sommets et lister les aretes a ajouter pour qu'ils forment une clique
+// Etape 2 : construire un nouveau theoreme avec les aretes supplementaires
+// Etape 3 : relancer la recherche lineaire et verifier chi == 4
+
+// Votre code ici
+Console.WriteLine(""Exercice 1 a completer"");",,,,,,,,7938f3720faed1c5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,3fa2a6b8,markdown,fr,96734bda2b3163ae,"## 7. Exercice 2 : planification d'examens
+
+Reformulez le problème en **planification d'examens** : chaque sommet est un examen, chaque arête signifie qu'un étudiant suit les deux examens (ils ne peuvent donc pas être au même créneau), et chaque couleur est un créneau horaire. Construisez votre **propre** graphe de conflits (au moins 6 examens) et trouvez le nombre minimal de créneaux.
+
+**Indices** :
+- La modélisation est **identique** à la coloration : seul le vocabulaire change (couleur → créneau).
+- Choisissez les conflits de sorte que le glouton et le solveur diffèrent, pour illustrer le gain.
+- Affichez l'emploi du temps : pour chaque créneau, la liste des examens qui s'y déroulent.",,,,,,,,96734bda2b3163ae,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b27f4886,code,fr,5e99551fa0c6a12e,"// Exercice 2 : planification d'examens (coloration deguisee)
+// Etape 1 : definir votre graphe de conflits (sommets = examens, aretes = etudiants communs)
+// Etape 2 : trouver le nombre minimal de creneaux via la recherche lineaire
+// Etape 3 : afficher l'emploi du temps par creneau
+
+// Votre code ici
+Console.WriteLine(""Exercice 2 a completer"");",,,,,,,,5e99551fa0c6a12e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,324d754c,markdown,fr,4dccd64bd8a282d5,"## 8. Exercice 3 : compter les colorations
+
+Pour `k = 3` couleurs (sans la brisure de symétrie `C0 = 0`), **combien** de colorations valides distinctes le graphe de Petersen admet-il ? Approchez la réponse en énumérant les solutions : après chaque solution trouvée, ajoutez une contrainte qui **exclut** cette assignation précise, puis relancez, jusqu'à UNSAT.
+
+**Indices** :
+- Le nombre de 3-colorations du graphe de Petersen est `120` (avec les permutations de couleurs).
+- Pour exclure une solution `s`, ajoutez une contrainte `¬(C0 == s0 && C1 == s1 && … )`, c.-à-d. au moins une variable diffère.
+- Attention : sans brisure de symétrie, chaque coloration « géométrique » est comptée `3! = 6` fois (permutations des noms de couleurs).",,,,,,,,4dccd64bd8a282d5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,1173c67e,code,fr,b61c9d92f0a88a86,"// Exercice 3 : compter les 3-colorations en enumerant les solutions
+// Etape 1 : boucle qui resout, puis exclut la solution trouvee, jusqu'a UNSAT
+// Etape 2 : compter les solutions ; comparer a 120
+// Etape 3 : diviser par 3! = 6 pour obtenir les colorations a permutation pres
+
+// Votre code ici
+Console.WriteLine(""Exercice 3 a completer"");",,,,,,,,b61c9d92f0a88a86,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b2-ite-intro,markdown,fr,3434d18276d0be40,"## B2 - Indicateurs conditionnels (DSL ternaire `? :` -> `MkIte`)
+
+Ce notebook colore le graphe sous une contrainte **dure** : deux sommets adjacents ont des couleurs differentes. Mais une technique de modelisation fondamentale consiste a **reifier** une condition en un indicateur 0/1 - `condition ? 1 : 0` - pour la **compter** au lieu de l'interdire. On passe alors d'un « aucune arete n'est monochrome » (dur) a un « **au plus** k aretes monochromes » (souple), en **sommant** les indicateurs de conflit. C'est le bloc de base des penalites MaxSAT et de tout comptage de contraintes.
+
+Cote DSL, une telle reification n'etait pas exprimable avant le binding [B2](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L107) : un ternaire C# dans un `.Where(...)` levait `NotSupportedException` (le visiteur n'avait pas de cas `Conditional`). Le binding ajoute [`VisitConditional`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L212) qui traduit `cond ? a : b` en [`MkITE(test, ifTrue, ifFalse)`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L218) - le ternaire devient un indicateur Z3 de premiere classe.
+
+> **Stack : A + B - pourquoi**. On modelise un **triangle** (3 sommets tous adjacents) avec **2 couleurs seulement** : un 2-coloriage propre est **impossible** (un triangle exige 3 couleurs). Plutot que de constater l'insatisfiabilite, on **compte les conflits** : pour chaque arete `(u,v)`, l'indicateur de conflit est `cu == cv ? 1 : 0`. Cote raw, on reifie a la main chaque conflit en `MkITE(MkEq(cu,cv), MkInt(1), MkInt(0))` puis on somme via `MkAdd`. Cote DSL, la **meme** reification s'ecrit en ternaire C# naturel `(cu == cv ? 1 : 0)` dans le lambda. Le contraste : `somme <= 1` est **SAT** (un triangle bicolore a toujours au moins 1 conflit), `somme == 0` est **UNSAT** (preuve que le nombre chromatique depasse 2) - obtenu des deux cotes sur le meme modele.",,,,,,,,3434d18276d0be40,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b2-ite-code,code,fr,912a9f31ff4b7f53,"// B2 - Indicateurs conditionnels ""MkIte"" : deux stacks sur le MEME triangle sous-colore.
+//   Triangle : sommets A, B, C tous adjacents (aretes A-B, B-C, A-C). Palette : 2 couleurs {0, 1}.
+//   Un 2-coloriage PROPRE est impossible (triangle => chi = 3). On COMPTE les conflits au lieu de les interdire :
+//   conflit d'arete = (cu == cv ? 1 : 0). Contrainte souple : somme des conflits <= 1 (SAT) ; == 0 (UNSAT, prouve chi > 2).
+
+// Classe au niveau cellule (requise par NewTheorem<T>) : trois couleurs de sommet.
+public class TriColor2 { public int A { get; set; }  public int B { get; set; }  public int C { get; set; } }
+
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : chaque conflit reifie a la main en MkITE(cond, 1, 0)
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    IntExpr a = z3.MkIntConst(""a""), b = z3.MkIntConst(""b""), c = z3.MkIntConst(""c"");
+    var palette = new Microsoft.Z3.BoolExpr[] {
+        z3.MkGe(a, z3.MkInt(0)), z3.MkLe(a, z3.MkInt(1)),
+        z3.MkGe(b, z3.MkInt(0)), z3.MkLe(b, z3.MkInt(1)),
+        z3.MkGe(c, z3.MkInt(0)), z3.MkLe(c, z3.MkInt(1)),
+    };
+    // Indicateurs de conflit : (cu == cv ? 1 : 0) reifies en MkITE
+    ArithExpr iAB = (ArithExpr)z3.MkITE(z3.MkEq(a, b), z3.MkInt(1), z3.MkInt(0));
+    ArithExpr iBC = (ArithExpr)z3.MkITE(z3.MkEq(b, c), z3.MkInt(1), z3.MkInt(0));
+    ArithExpr iAC = (ArithExpr)z3.MkITE(z3.MkEq(a, c), z3.MkInt(1), z3.MkInt(0));
+    ArithExpr conflicts = z3.MkAdd(iAB, iBC, iAC);
+
+    // Souple : au plus 1 conflit
+    var sSoft = z3.MkSolver();
+    sSoft.Assert(palette);
+    sSoft.Assert(z3.MkLe(conflicts, z3.MkInt(1)));
+    Status stSoft = sSoft.Check();
+    Console.WriteLine($""[RAW] conflits <= 1 : {stSoft}"");
+    if (stSoft == Status.SATISFIABLE) {
+        var m = sSoft.Model;
+        var cnt = (IntNum)m.Eval(conflicts, true);
+        Console.WriteLine($""[RAW]   coloriage : A={m.Eval(a,true)}, B={m.Eval(b,true)}, C={m.Eval(c,true)}  (conflits={cnt})"");
+    }
+    // Dur : zero conflit (2-coloriage propre) -> UNSAT
+    var sHard = z3.MkSolver();
+    sHard.Assert(palette);
+    sHard.Assert(z3.MkEq(conflicts, z3.MkInt(0)));
+    Console.WriteLine($""[RAW] conflits == 0 : {sHard.Check()}   (2 couleurs ne suffisent pas pour un triangle)"");
+}
+
+// =====================================================================
+// BLOC DSL (Z3.Linq) : la meme reification en ternaire C# naturel (cond ? 1 : 0)
+// =====================================================================
+{
+    using var thCtx = new Z3Context();
+
+    // Souple : au plus 1 conflit
+    var soft = thCtx.NewTheorem<TriColor2>()
+        .Where(t => t.A >= 0).Where(t => t.A <= 1)
+        .Where(t => t.B >= 0).Where(t => t.B <= 1)
+        .Where(t => t.C >= 0).Where(t => t.C <= 1)
+        .Where(t => (t.A == t.B ? 1 : 0) + (t.B == t.C ? 1 : 0) + (t.A == t.C ? 1 : 0) <= 1)
+        .Solve();
+    if (soft != null) {
+        int cnt = (soft.A == soft.B ? 1 : 0) + (soft.B == soft.C ? 1 : 0) + (soft.A == soft.C ? 1 : 0);
+        Console.WriteLine($""[DSL] conflits <= 1 : SAT  -> A={soft.A}, B={soft.B}, C={soft.C}  (conflits={cnt})"");
+    }
+
+    // Dur : zero conflit -> UNSAT (le ternaire indicateur prouve chi > 2)
+    var hard = thCtx.NewTheorem<TriColor2>()
+        .Where(t => t.A >= 0).Where(t => t.A <= 1)
+        .Where(t => t.B >= 0).Where(t => t.B <= 1)
+        .Where(t => t.C >= 0).Where(t => t.C <= 1)
+        .Where(t => (t.A == t.B ? 1 : 0) + (t.B == t.C ? 1 : 0) + (t.A == t.C ? 1 : 0) == 0)
+        .Solve();
+    Console.WriteLine($""[DSL] conflits == 0 : {(hard == null ? ""UNSAT"" : ""SAT?!"")}   -> 2 couleurs insuffisantes, chi(triangle) = 3"");
+}",,,,,,,,912a9f31ff4b7f53,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,b2-ite-lecture,markdown,fr,b1d1d0ceee1091da,"### Lecture B2 - deux ecritures d'un indicateur, un meme comptage
+
+Les deux stacks modelisent le **meme triangle sous-colore** et comptent les **memes conflits** via des indicateurs `cu == cv ? 1 : 0`. Les deux verdicts coincident : `somme <= 1` **SAT** (un triangle bicolore a au moins un conflit) et `somme == 0` **UNSAT** (donc `chi > 2`). La difference est **comment** on ecrit l'indicateur :
+
+| Aspect | RAW (`MkITE`) | DSL (ternaire `? :`) |
+|---|---|---|
+| Reification | `MkITE(MkEq(cu,cv), MkInt(1), MkInt(0))` | `(cu == cv ? 1 : 0)` (C# idiomatique) |
+| Cast necessaire | Oui : `(ArithExpr)` pour sommer | Non : le type est inference |
+| Somme | `MkAdd(iAB, iBC, iAC)` | `+` C# natif |
+| Avant B2 | (toujours disponible en raw) | `NotSupportedException` sur le `Conditional` |
+
+> **Ligne de contraste (a retenir)** : *le raw construit l'indicateur comme un terme Z3 explicite* (`MkITE` + cast + `MkAdd`) ; *le DSL laisse ecrire l'indicateur comme un ternaire C# ordinaire* - `(cu == cv ? 1 : 0)` - que [`VisitConditional`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L212) traduit en `MkITE`. **Meme comptage de conflits**, deux notations : termes Z3 d'un cote, expression C# de l'autre. L'indicateur reifie est ce qui fait passer d'un modele **dur** (interdire) a un modele **souple** (compter et borner).
+
+**Cas d'usage** : la reification `cond ? 1 : 0` est le bloc de base des **contraintes de cardinalite** (« au plus / au moins k parmi ces conditions ») et des **penalites souples** (MaxSAT via Optimize). Dans la coloration, elle transforme le coloriage propre (dur, parfois UNSAT) en minimisation de conflits (toujours SAT). On garde le raw pour un `MkITE` dont les branches sont des **termes Z3 arbitraires** (tableaux, fonctions non-interpretees) hors du schema du modele-objet.",,,,,,,,b1d1d0ceee1091da,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/12_Graph_Coloring_Petersen.ipynb,a6e72692,markdown,fr,d855ce796287d4f5,"## Conclusion
+
+Ce notebook a transposé le paradigme déclaratif de Z3.Linq à une **structure de graphe irrégulière** — un terrain différent des grilles (Sudoku) et des ordonnancements linéaires (job shop). Trois enseignements :
+
+1. **La coloration de graphe est un CSP naturel** : une variable entière par sommet, une contrainte d'inégalité par arête. Le nombre chromatique s'obtient par une suite de requêtes SAT, exactement comme on a cherché un makespan optimal au notebook 11.
+2. **Le solveur prouve, l'heuristique devine** : sur le graphe de Petersen, le glouton first-fit donne 3 ou 4 couleurs **selon l'ordre**, sans pouvoir distinguer les deux cas ; Z3 atteint `χ = 3` **et** démontre l'infaisabilité à 2 couleurs. La preuve d'optimalité (UNSAT en dessous de `χ`) est hors de portée d'une heuristique.
+3. **Le choix de l'instance compte** : Petersen, sans clique évidente mais au nombre chromatique non trivial, met en valeur la capacité du moteur là où un graphe dégénéré ne le ferait pas.
+
+**Pour aller plus loin** : la coloration sous-tend l'allocation de registres (compilation), l'attribution de fréquences, et la planification ; les mêmes contraintes, à plus grande échelle, motivent les solveurs SAT/SMT industriels.
+
+---
+
+**Navigation** : [<< 11 Job Shop Scheduling](11_Job_Shop_Scheduling.ipynb) | [Index Z3](./README.md) | [Index SymbolicAI](../../README.md)",,,,,,,,d855ce796287d4f5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,5083685c,markdown,fr,2569fc3e90e90e61,"← [12 — Graph Coloring Petersen](12_Graph_Coloring_Petersen.ipynb) | [README Z3](README.md)
+
+---
+
+# Notebook 13 — Cryptarithmes : l'arithmétique positionnelle comme CSP
+
+**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md)
+
+## Objectifs d'apprentissage
+
+- Modéliser un **cryptarithme** (mot croisé arithmétique) comme un problème de satisfaction de contraintes sur des entiers
+- Traduire l'**arithmétique positionnelle** (base 10, retenues implicites) en contraintes linéaires que le solveur propage
+- Comprendre pourquoi un problème qu'un humain résout à la main en ~15 minutes tombe en quelques millisecondes pour Z3
+- Réutiliser le patron `Theorem<T>` de Z3.Linq avec **variables entières simples** (pas de tableaux) et la contrainte globale `Distinct`
+
+## Prérequis
+
+- Notebooks [01 (Introduction Z3.Linq)](01_Linq2Z3_Intro.ipynb) et [04 (Array Theory)](04_Array_Theory.ipynb)
+- Notions d'arithmétique positionnelle en base 10
+
+**Durée estimée** : 35-45 minutes
+
+---
+
+Un **cryptarithme** (ou alphamétique) est une équation où chaque lettre représente un chiffre distinct. Le classique absolu :
+
+```
+    S E N D
++   M O R E
+---------
+  M O N E Y
+```
+
+Chaque lettre (`S, E, N, D, M, O, R, Y`) est un chiffre de 0 à 9, **toutes différentes**, et les lettres de tête (`S` pour `SEND`, `M` pour `MORE` et `MONEY`) **ne peuvent pas valoir 0** (sinon le nombre aurait un zéro non-significatif). L'égalité arithmétique doit être vérifiée.
+
+C'est l'archétype d'un problème où la **modélisation déclarative** bat l'énumération brutale : il y a 10×9×7×6×5×4×3 ≈ 1,6 million de combinaisons à explorer naïvement pour 8 lettres distinctes, mais la propagation de contraintes du solveur en réduit l'espace drastiquement.",,,,,,,,2569fc3e90e90e61,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,860459a3,code,fr,36a8cf47c83a3682,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy), Microsoft.Z3, System.Linq"");",,,,,,,,36a8cf47c83a3682,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,639b1cbd,markdown,fr,787b9de70ff1c86b,"## Modélisation Z3.Linq
+
+Trois familles de contraintes structurent le problème :
+
+1. **Domaine** : chaque lettre ∈ `{0, ..., 9}` (8 variables entières).
+2. **Toutes différentes** : la contrainte globale `Z3Methods.Distinct(...)` impose que les 8 lettres prennent des valeurs deux à deux distinctes — c'est le cœur du problème, sans elle l'équation admettrait des solutions triviales.
+3. **Tête non nulle** : `S ≠ 0` et `M ≠ 0` (les nombres ne commencent pas par zéro).
+4. **Équation arithmétique** : en développant la notation positionnelle,
+   `SEND = 1000·S + 100·E + 10·N + D`, `MORE = 1000·M + 100·O + 10·R + E`,
+   `MONEY = 10000·M + 1000·O + 100·N + 10·E + Y`. On exige `SEND + MORE == MONEY`.
+
+Le binding Z3.Linq accepte ces expressions arithmétiques linéaires directement dans le lambda `.Where(...)` : le rewriter les traduit en assertions SMT sur la théorie des entiers (`LinearIntegerArithmetic`).",,,,,,,,787b9de70ff1c86b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,0b494b9e,code,fr,5ca9edd65362e1a4,"// Cryptarithme classique : SEND + MORE = MONEY
+public class SendMoreMoney
+{
+    public int S = 0, E = 0, N = 0, D = 0;
+    public int M = 0, O = 0, R = 0, Y = 0;
+}
+
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<SendMoreMoney>();
+
+    // (1) Domaine 0..9 pour chaque lettre
+    th = th.Where(t => t.S >= 0 && t.S <= 9 && t.E >= 0 && t.E <= 9
+                    && t.N >= 0 && t.N <= 9 && t.D >= 0 && t.D <= 9
+                    && t.M >= 0 && t.M <= 9 && t.O >= 0 && t.O <= 9
+                    && t.R >= 0 && t.R <= 9 && t.Y >= 0 && t.Y <= 9);
+
+    // (2) Les 8 lettres sont deux à deux distinctes (contrainte globale)
+    th = th.Where(t => Z3Methods.Distinct(t.S, t.E, t.N, t.D, t.M, t.O, t.R, t.Y));
+
+    // (3) Têtes non nulles (pas de zéro non-significatif)
+    th = th.Where(t => t.S > 0 && t.M > 0);
+
+    // (4) Équation arithmétique positionnelle : SEND + MORE == MONEY
+    th = th.Where(t =>
+        (1000 * t.S + 100 * t.E + 10 * t.N + t.D) +
+        (1000 * t.M + 100 * t.O + 10 * t.R + t.E) ==
+        (10000 * t.M + 1000 * t.O + 100 * t.N + 10 * t.E + t.Y));
+
+    var sol = th.Solve();
+
+    if (sol == null) {
+        Console.WriteLine(""UNSAT : aucune solution (inattendu pour ce cryptarithme)"");
+    } else {
+        int send  = 1000 * sol.S + 100 * sol.E + 10 * sol.N + sol.D;
+        int more  = 1000 * sol.M + 100 * sol.O + 10 * sol.R + sol.E;
+        int money = 10000 * sol.M + 1000 * sol.O + 100 * sol.N + 10 * sol.E + sol.Y;
+        Console.WriteLine($""  S={sol.S} E={sol.E} N={sol.N} D={sol.D}  M={sol.M} O={sol.O} R={sol.R} Y={sol.Y}"");
+        Console.WriteLine($""    {send,5}"");
+        Console.WriteLine($""  + {more,5}"");
+        Console.WriteLine($""  -------"");
+        Console.WriteLine($""  {money,5}    ({send} + {more} = {money}, vérifié = {send + more == money})"");
+    }
+}",,,,,,,,5ca9edd65362e1a4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,974557f8,markdown,fr,c72cd7d19ef7e566,"## Interprétation
+
+Z3 trouve la solution unique en quelques millisecondes :
+
+- `SEND = 9567`, `MORE = 1085`, `MONEY = 10652`
+- Vérification : `9567 + 1085 = 10652` ✓
+- Les 8 lettres sont bien distinctes : `S=9, E=5, N=6, D=7, M=1, O=0, R=8, Y=2`
+
+**Pourquoi le solveur fait la différence** (Prong-B) : la résolution humaine procède colonne par colonne en propagant les retenues (`D+E=Y ou Y+10`, etc.), ce qui demande une analyse de cas à chaque étape. Le solveur, lui, **propage globalement** toutes les contraintes simultanément : dès que `M=1` est forcé (car `SEND + MORE < 20000` implique `MONEY < 20000` donc `M=1`), le reste se déduit par réduction de domaine. Là où un humain explore ~15 minutes, Z3 explore l'arbre de recherche réduit à quelques nœuds.
+
+C'est aussi un exemple où la **contrainte globale `Distinct`** est essentielle : sans elle, l'équation arithmétique seule admettrait des solutions où deux lettres prendraient la même valeur (triviales et non-pédagogiques).",,,,,,,,c72cd7d19ef7e566,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,3a329ad6,markdown,fr,3450e5a9c8657921,"## Approche naïve vs solveur : que fait la propagation ?
+
+Pour **mesurer** l'écart (et ne pas se contenter d'une affirmation littéraire), comparons deux stratégies sur le même cryptarithme SEND + MORE = MONEY :
+
+- **Brute force** : énumérer toutes les affectations de 8 chiffres distincts pris parmi `{0..9}`, soit `P(10,8) = 10·9·8·7·6·5·4·3 = 1 814 400` candidats, et tester l'équation pour chacun.
+- **Z3** : formuler les contraintes (domaine + `Distinct` + équation) et laisser le solveur propager.
+
+La différence n'est pas tant dans le code (les deux tiennent en quelques lignes) que dans la **manière d'explorer** : la brute force teste aveuglément 1,8 million de candidats, tandis que Z3 **propage** — par exemple `SEND + MORE < 20000` force immédiatement `M = 1`, ce qui élimine d'emblée l'essentiel du domaine sans aucun essai.",,,,,,,,3450e5a9c8657921,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,a0921f7e,code,fr,cc051cbd77633df9,"using System.Diagnostics;
+
+// (1) Brute force : 8 boucles imbriquées, on saute dès que deux lettres coincident
+//     P(10,8) = 1 814 400 candidats distincts testes.
+int nbBrute = 0;
+var swBrute = Stopwatch.StartNew();
+for (int S=0; S<=9; S++)
+for (int E=0; E<=9; E++) { if (E==S) continue;
+for (int N=0; N<=9; N++) { if (N==S||N==E) continue;
+for (int D=0; D<=9; D++) { if (D==S||D==E||D==N) continue;
+for (int M=0; M<=9; M++) { if (M==S||M==E||M==N||M==D) continue;
+for (int O=0; O<=9; O++) { if (O==S||O==E||O==N||O==D||O==M) continue;
+for (int R=0; R<=9; R++) { if (R==S||R==E||R==N||R==D||R==M||R==O) continue;
+for (int Y=0; Y<=9; Y++) { if (Y==S||Y==E||Y==N||Y==D||Y==M||Y==O||Y==R) continue;
+    if (S>0 && M>0) {
+        int send  = 1000*S + 100*E + 10*N + D;
+        int more  = 1000*M + 100*O + 10*R + E;
+        int money = 10000*M + 1000*O + 100*N + 10*E + Y;
+        if (send + more == money) { nbBrute++; }
+    }
+}}}}}}}
+swBrute.Stop();
+
+// (2) Z3 : même théorème que la cellule 3, mesuré
+var swZ3 = Stopwatch.StartNew();
+int nbZ3 = 0;
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<SendMoreMoney>()
+        .Where(t => t.S>=0&&t.S<=9&&t.E>=0&&t.E<=9&&t.N>=0&&t.N<=9&&t.D>=0&&t.D<=9
+                  &&t.M>=0&&t.M<=9&&t.O>=0&&t.O<=9&&t.R>=0&&t.R<=9&&t.Y>=0&&t.Y<=9)
+        .Where(t => Z3Methods.Distinct(t.S,t.E,t.N,t.D,t.M,t.O,t.R,t.Y))
+        .Where(t => t.S>0 && t.M>0)
+        .Where(t => (1000*t.S+100*t.E+10*t.N+t.D)+(1000*t.M+100*t.O+10*t.R+t.E)
+                   ==(10000*t.M+1000*t.O+100*t.N+10*t.E+t.Y));
+    var sol = th.Solve();
+    if (sol != null) nbZ3 = 1;
+}
+swZ3.Stop();
+
+Console.WriteLine($""Brute force : {nbBrute} solution(s) en {swBrute.Elapsed.TotalMilliseconds:F1} ms  (1 814 400 candidats testes)"");
+Console.WriteLine($""Z3 solve    : {nbZ3} solution(s) en {swZ3.Elapsed.TotalMilliseconds:F1} ms  (propagation de contraintes)"");
+Console.WriteLine($"" -> meme resultat ({nbBrute==nbZ3}), strategies differentes."");",,,,,,,,cc051cbd77633df9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,5fff754d,markdown,fr,d6e60f0be07b83b5,"## Lecture du benchmark
+
+Sur ce petit cryptarithme (8 lettres), **les deux approches trouvent la même solution unique** en quelques dizaines de millisecondes — l'écart de vitesse brut reste **modeste** (même ordre de grandeur). C'est attendu : `1,8` million de candidats est un volume digérable pour une boucle C# native, et l'amorçage à froid du solveur pèse sur un petit cas. **Le vrai gain du solveur n'est donc pas la vitesse brute sur un exemple jouet**, mais trois propriétés qui apparaissent sur des instances plus lourdes : **Le vrai gain du solveur n'est donc pas la vitesse brute sur un cas jouet**, mais trois propriétés qui apparaissent sur des instances plus lourdes :
+
+1. **Modélisation déclarative** : le même patron (domaine + `Distinct` + équation) s'adapte à n'importe quel cryptarithme sans réécrire la logique de recherche — la cellule variante CROSS + ROADS = DANGER le montre (9 lettres, zéro ligne de code de parcours ajoutée).
+2. **Propagation globale** : Z3 déduit `M = 1` sans aucun essai (puisque `SEND + MORE < 20000`), puis réduit les domaines en cascade. La brute force, elle, teste aussi tous les cas `M = 0, 2, ..., 9` avant d'arriver à `M = 1`.
+3. **Passage à l'échelle** : au-delà de ~10 lettres distinctes, `P(10,k)` explose (`P(10,10) = 3,6` millions, et la combinatoire d'un cryptarithme multiplicatif ou d'une équation à 5 nombres devient vite hors de portée d'une énumération exhaustive), alors que la propagation conserve un coût quasi polynomial.
+
+C'est l'illustration concrète du **Prong-B** : un problème où le moteur SMT n'est pas réduit à un `if`, mais exerce sa capacité distinctive — **réduire un espace combinatoire par propagation de contraintes** plutôt que l'énumérer.",,,,,,,,d6e60f0be07b83b5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,b1f41954,markdown,fr,d6ba4b0c92a1faf0,"## Variante : CROSS + ROADS = DANGER
+
+Cryptarithme plus long (10 lettres distinctes), qui illustre que le même schéma de modélisation s'adapte sans changement de structure — seules les variables et l'équation diffèrent.",,,,,,,,d6ba4b0c92a1faf0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,7bf3d4d7,code,fr,32850564d4d75a65,"// Variante : CROSS + ROADS = DANGER (10 lettres distinctes)
+public class CrossRoads
+{
+    public int C = 0, R = 0, O = 0, S = 0;
+    public int A = 0, D = 0, N = 0, G = 0, E = 0;
+    // 9 lettres distinctes : C,R,O,S,A,D,N,G,E
+}
+
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<CrossRoads>();
+
+    // Domaine 0..9 pour les 9 lettres
+    th = th.Where(t => t.C >= 0 && t.C <= 9 && t.R >= 0 && t.R <= 9 && t.O >= 0 && t.O <= 9
+                    && t.S >= 0 && t.S <= 9 && t.A >= 0 && t.A <= 9 && t.D >= 0 && t.D <= 9
+                    && t.N >= 0 && t.N <= 9 && t.G >= 0 && t.G <= 9 && t.E >= 0 && t.E <= 9);
+
+    // 9 lettres deux à deux distinctes
+    th = th.Where(t => Z3Methods.Distinct(t.C, t.R, t.O, t.S, t.A, t.D, t.N, t.G, t.E));
+
+    // Têtes non nulles : C (CROSS), R (ROADS), D (DANGER)
+    th = th.Where(t => t.C > 0 && t.R > 0 && t.D > 0);
+
+    // CROSS + ROADS == DANGER
+    // CROSS = 10000·C + 1000·R + 100·O + 10·S + S
+    // ROADS = 10000·R + 1000·O + 100·A + 10·D + S
+    // DANGER = 100000·D + 10000·A + 1000·N + 100·G + 10·E + R
+    th = th.Where(t =>
+        (10000 * t.C + 1000 * t.R + 100 * t.O + 10 * t.S + t.S) +
+        (10000 * t.R + 1000 * t.O + 100 * t.A + 10 * t.D + t.S) ==
+        (100000 * t.D + 10000 * t.A + 1000 * t.N + 100 * t.G + 10 * t.E + t.R));
+
+    var sol = th.Solve();
+    if (sol == null) {
+        Console.WriteLine(""UNSAT : aucune solution pour CROSS + ROADS = DANGER"");
+    } else {
+        int cross  = 10000 * sol.C + 1000 * sol.R + 100 * sol.O + 10 * sol.S + sol.S;
+        int roads  = 10000 * sol.R + 1000 * sol.O + 100 * sol.A + 10 * sol.D + sol.S;
+        int danger = 100000 * sol.D + 10000 * sol.A + 1000 * sol.N + 100 * sol.G + 10 * sol.E + sol.R;
+        Console.WriteLine($""CROSS={cross}  ROADS={roads}  DANGER={danger}   ({cross} + {roads} = {cross + roads}, égal à DANGER = {danger} : {cross + roads == danger})"");
+    }
+}",,,,,,,,32850564d4d75a65,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,895c3f53,markdown,fr,ac65a19621f777f7,"## Exercices
+
+Les trois exercices ci-dessous vous font réutiliser le patron pour de nouveaux cryptarithmes. Chaque exercice suit le même squelette : définir la classe de variables, ajouter domaine + `Distinct` + têtes non nulles + équation, puis `Solve()`.
+
+**Rappel C.1** : les stubs ne lèvent **jamais** d'erreur — ils utilisent `Console.WriteLine(""Exercice à compléter"")`. Le notebook s'exécute de bout en bout même exercices non résolus.",,,,,,,,ac65a19621f777f7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,cd93c47d,markdown,fr,f251bc2ea2742efa,"### Exercice 1 — DONALD + GERALD = ROBERT
+
+Résolvez ce cryptarithme classique à 10 lettres (`D, O, N, A, L, G, E, R, B, T`). Têtes non nulles : `D` (DONALD), `G` (GERALD), `R` (ROBERT).
+
+**Étapes** :
+1. Définissez la classe `DonaldGerald` avec les 10 propriétés `int`.
+2. Ajoutez le domaine `0..9` pour chacune.
+3. Ajoutez `Z3Methods.Distinct(...)` sur les 10 lettres.
+4. Ajoutez les contraintes de tête non nulle (`D > 0`, `G > 0`, `R > 0`).
+5. Ajoutez l'équation positionnelle développée.",,,,,,,,f251bc2ea2742efa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,dccc6e62,code,fr,d1528694c1397d39,"// Exercice 1 : DONALD + GERALD = ROBERT
+// TODO étudiant :
+// Étape 1 : classe DonaldGerald { D, O, N, A, L, G, E, R, B, T } (int)
+// Étape 2 : domaine 0..9 pour les 10 lettres
+// Étape 3 : Z3Methods.Distinct(...) sur les 10 lettres
+// Étape 4 : têtes non nulles (D > 0, G > 0, R > 0)
+// Étape 5 : équation DONALD + GERALD == ROBERT
+//          DONALD = 100000·D + 10000·O + 1000·N + 100·A + 10·L + L
+//          GERALD = 100000·G + 10000·E + 1000·R + 100·A + 10·L + D
+//          ROBERT = 100000·R + 10000·O + 1000·B + 100·E + 10·R + T
+Console.WriteLine(""Exercice 1 à compléter : modélisez DONALD + GERALD = ROBERT avec Z3.Linq"");",,,,,,,,d1528694c1397d39,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,4d2a9983,markdown,fr,fa90f7928af4a9e6,"### Exercice 2 — Vérifier l'unicité de la solution
+
+SEND + MORE = MONEY admet une **unique** solution. Modifiez le théorème de la cellule 3 pour **compter** toutes les solutions (au lieu de s'arrêter à la première) et confirmer qu'il n'y en a qu'une.
+
+**Indice** : Z3.Linq ne fournit pas directement un itérateur de toutes les solutions. Une approche consiste à appeler `Solve()` puis à ajouter une contrainte niant la solution trouvée (`!=` sur au moins une lettre) et à re-appeler `Solve()`, jusqu'à obtenir `null` (UNSAT). Comptez les itérations.",,,,,,,,fa90f7928af4a9e6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,d9f5da75,code,fr,8047d5dd20dd8c03,"// Exercice 2 : compter toutes les solutions de SEND + MORE = MONEY
+// TODO étudiant :
+// 1. Boucle : Solve() -> si sol != null, compter++, ajouter contrainte (au moins une lettre != sol)
+// 2. Recommencer jusqu'à UNSAT (sol == null)
+// 3. Afficher le nombre total de solutions
+Console.WriteLine(""Exercice 2 à compléter : énumérez toutes les solutions de SEND + MORE = MONEY"");",,,,,,,,8047d5dd20dd8c03,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,58622724,markdown,fr,6f637d69b6cc2d2f,"### Exercice 3 — Cryptarithme avec produit (multiplication)
+
+Modélisez la multiplication : `ABC × D = DBC` où chaque lettre est un chiffre distinct, `A ≠ 0` et `D ≠ 0`. Attention : ici c'est une **multiplication** (`==`), pas une addition — l'équation est `ABC * D == DBC` (avec `ABC = 100·A + 10·B + C`).
+
+**Question subsidiaire** : ce cryptarithme admet-il une solution ? Si oui, combien ?",,,,,,,,6f637d69b6cc2d2f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,fecdfa63,code,fr,fe1b0191990f5aab,"// Exercice 3 : ABC × D = DBC (multiplication)
+// TODO étudiant :
+// 1. Classe { A, B, C, D } (int), domaine 0..9
+// 2. Distinct(A, B, C, D), têtes A > 0 et D > 0
+// 3. Équation : (100*A + 10*B + C) * D == (100*D + 10*B + C)
+Console.WriteLine(""Exercice 3 à compléter : modélisez ABC × D = DBC"");",,,,,,,,fe1b0191990f5aab,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/13_Cryptarithmetic_SMT.ipynb,a96469c8,markdown,fr,d84f83687970900e,"## Conclusion
+
+Le **cryptarithme** est le terrain idéal pour appréhender la **modélisation déclarative** d'un problème combinatoire :
+
+- Les **variables entières simples** (pas de tableaux ici) suffisent — le patron `Theorem<T>` de Z3.Linq s'applique tel quel.
+- La **contrainte globale `Distinct`** remplace élégamment l'énumération exhaustive des paires `!=` (28 paires pour 8 lettres, 45 pour 10).
+- L'**arithmétique positionnelle** se traduit en contraintes linéaires directes, sans gérer explicitement les retenues — le solveur s'en charge via la propagation.
+
+**Points clés** :
+- Un problème qu'un humain résout en ~15 minutes tombe en millisecondes : la **propagation globale** écrase l'analyse colonne-par-colonne.
+- La contrainte `Distinct` est **essentielle** — sans elle, l'équation admet des solutions triviales (lettres répétées).
+- Le même schéma (domaine + Distinct + têtes + équation) s'adapte à **tout cryptarithme**, quelle que soit sa longueur.
+
+**Référence** : *Dudeney (1924)* — ""Send More Money"", publié dans le *Strand Magazine*. Premier cryptarithme largement popularisé.",,,,,,,,d84f83687970900e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,e852f5d9,markdown,fr,ba3ff0ccc7f2fb79,"← [13 — Cryptarithmetic SMT](13_Cryptarithmetic_SMT.ipynb) | [README Z3](README.md)
+
+---
+
+# Notebook 14 — De SAT à OPT : optimisation et contraintes molles (MaxSAT)
+
+**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index général](../../../README.md)
+
+## Objectifs d'apprentissage
+
+- Passer de la **satisfiabilité** (`.Solve()` : existe-t-il *une* solution ?) à l'**optimisation** (`.Optimize()` : quelle est la *meilleure* solution selon un critère ?)
+- Modéliser le **problème du sac à dos** (0/1 knapsack) comme un théorème Z3.Linq avec un objectif à maximiser
+- Comprendre les **contraintes molles** (soft constraints) et le paradigme **MaxSAT** : maximiser le nombre de préférences satisfaites sous contraintes dures
+- Mettre en évidence le **gap** de la série : jusqu'ici tous les notebooks cherchaient une solution *quelconque* ; l'optimisation ouvre la porte à des problèmes de décision multicritères
+
+## Prérequis
+
+- Notebooks [01 (Introduction Z3.Linq)](01_Linq2Z3_Intro.ipynb) et [13 (Cryptarithmetic)](13_Cryptarithmetic_SMT.ipynb)
+- Notions d'optimisation combinatoire (sac à dos, ordonnancement)
+
+**Durée estimée** : 40-50 minutes
+
+---
+
+Les dix premiers notebooks de la série posent des problèmes de **satisfiabilité** : *existe-t-il une affectation des variables qui satisfait toutes les contraintes ?* Le solveur répond par une solution *quelconque* (la première trouvée), via `.Solve()`. C'est le cadre SAT (ou SMT, avec théories).
+
+Mais de nombreux problèmes réels ne demandent pas *une* solution, mais la **meilleure** selon un critère : minimiser un coût, maximiser une valeur, satisfaire un maximum de préférences. C'est le cadre de l'**optimisation** — et Z3 fournit un solveur d'optimisation dédié, exposé par Z3.Linq via la méthode `.Optimize()` et la syntaxe LINQ `orderby`.
+
+Ce notebook comble un **gap volontairement laissé ouvert** par les notebooks précédents : aucun n'utilisait `.Optimize()`. On le fait ici sur deux terrains — le **sac à dos** (optimisation entière simple) puis le **roulement d'affectation** (MaxSAT : contraintes dures + préférences molles).",,,,,,,,ba3ff0ccc7f2fb79,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,1e381e24,code,fr,36a8cf47c83a3682,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy), Microsoft.Z3, System.Linq"");",,,,,,,,36a8cf47c83a3682,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,3608bd6b,markdown,fr,31e34fdb4d8b420d,"## De `.Solve()` à `.Optimize()`
+
+La classe `Theorem<T>` expose, au-delà de `.Solve()`, deux points d'entrée pour l'optimisation :
+
+| API | Rôle | Équivalent LINQ |
+|-----|------|-----------------|
+| `th.Optimize(Optimization.Minimize, t => t.Cout)` | minimise l'expression donnée | `orderby t.Cost` |
+| `th.Optimize(Optimization.Maximize, t => t.Score)` | maximise l'expression donnée | `orderby t.Score descending` |
+| `th.OrderBy(t => t.Cost).Solve()` | idiomatique LINQ (minimise) | — |
+
+Le binding traduit l'expression-objectif en une assertion `maximize`/`minimize` Z3 (`ctx.MkOptimize()` + `MkMaximize`/`MkMinimize`), et le solveur explore l'espace de recherche à la recherche de l'**optimum global**, pas seulement d'une solution faisable.
+
+Concrètement, la différence se voit dans la signature : `.Solve()` renvoie `T?` (une solution ou rien si UNSAT), `.Optimize()` renvoie `T` (la meilleure solution — s'il existe au moins une solution faisable).",,,,,,,,31e34fdb4d8b420d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,2416b75e,markdown,fr,e0f9678505c3cdb3,"## Premier terrain : le sac à dos 0/1 (knapsack)
+
+Le **problème du sac à dos** est le paradigme canonique de l'optimisation combinatoire : étant donné `n` objets (chacun avec un poids `w_i` et une valeur `v_i`) et une capacité maximale `W`, choisir le sous-ensemble d'objets qui **maximise la valeur totale** sans dépasser la capacité.
+
+Modélisation Z3.Linq : une variable entière `{0,1}` par objet (`1` = pris, `0` = laissé), une contrainte linéaire sur le poids total, et un **objectif** à maximiser (la valeur totale). C'est un problème **NP-difficile**, mais sur une petite instance le solveur trouve l'optimum instantanément.",,,,,,,,e0f9678505c3cdb3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,2eb45950,code,fr,1ebd635d06a84d69,"// Sac à dos 0/1 : 5 objets, capacité 10
+// (poids, valeur) par objet
+int[] poids  = { 4, 5, 6, 3, 2 };
+int[] valeur = { 10, 15, 16, 7, 5 };
+int W = 10;
+
+public class Knapsack
+{
+    public int x0=0, x1=0, x2=0, x3=0, x4=0;  // 1 si l'objet i est pris
+}
+
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<Knapsack>();
+
+    // Domaine {0,1} pour chaque objet
+    th = th.Where(t => t.x0>=0&&t.x0<=1 && t.x1>=0&&t.x1<=1 && t.x2>=0&&t.x2<=1 && t.x3>=0&&t.x3<=1 && t.x4>=0&&t.x4<=1);
+
+    // Contrainte de capacité : poids total <= W
+    th = th.Where(t => 4*t.x0 + 5*t.x1 + 6*t.x2 + 3*t.x3 + 2*t.x4 <= W);
+
+    // Objectif : maximiser la valeur totale
+    var sol = th.Optimize(Optimization.Maximize, t => 10*t.x0 + 15*t.x1 + 16*t.x2 + 7*t.x3 + 5*t.x4);
+
+    int poidsTotal  = 4*sol.x0 + 5*sol.x1 + 6*sol.x2 + 3*sol.x3 + 2*sol.x4;
+    int valeurTotal = 10*sol.x0 + 15*sol.x1 + 16*sol.x2 + 7*sol.x3 + 5*sol.x4;
+
+    Console.WriteLine(""Objets pris (1=pris) : "" + string.Join("", "", sol.x0, sol.x1, sol.x2, sol.x3, sol.x4));
+    Console.WriteLine($""Poids total  : {poidsTotal} / {W}"");
+    Console.WriteLine($""Valeur totale: {valeurTotal}  (optimum)"");
+}",,,,,,,,1ebd635d06a84d69,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,08986c1e,markdown,fr,11d9665e16460806,"## Lecture du sac à dos
+
+Z3 trouve l'optimum en explorant l'espace des $2^5 = 32$ sous-ensembles d'objets. La solution maximise la valeur sans dépasser la capacité — c'est exactement ce que ferait une programmation dynamique, mais **sans écrire l'algorithme** : on décrit le problème (variables, domaine, contrainte, objectif), le solveur trouve l'optimum.
+
+**Verdict honnête (Prong-B)** : sur cette instance jouet, le sac à dos est trivial — une énumération exhaustive ou une DP le résout aussi vite. L'intérêt ici est **pédagogique** : introduire l'API `.Optimize()` sur un problème dont l'énoncé est familier. Le terrain où l'optimisation SMT *discrimine* vraiment apparaît dans la section suivante, avec les **contraintes molles** (MaxSAT) — là où il faut arbitrer entre des préférences conflictuelles.",,,,,,,,11d9665e16460806,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,3835d62e,markdown,fr,bfa5a2bcd23ca3b1,"## Second terrain : contraintes molles et MaxSAT (roulement d'infirmières)
+
+Le sac à dos optimise un **objectif quantitatif** (une valeur). Beaucoup de problèmes réels sont **multicritères** : on a des contraintes *dures* (qui doivent être satisfaites) et des *préférences* (qu'on aimerait satisfaire, mais qu'on peut violer au prix d'une pénalité). C'est le cadre du **MaxSAT** (satisfiabilité maximale) :
+
+- **Contraintes dures** (hard) : modélisées par `.Where(...)` — impératives.
+- **Préférences molles** (soft) : encodées dans l'**objectif** — on maximise le nombre de préférences satisfaites.
+
+Le terrain canonique est le **roulement d'affectation** (nurse rostering) : on doit staffier des gardes (contraintes dures : couverture, pas de double-garde) tout en respectant au mieux les **préférences** des employés (soft). Quand deux employés veulent le même créneau, le solveur arbitre pour **maximiser globalement** la satisfaction.
+
+Considérons 3 infirmières (A, B, C) à affecter à 3 gardes (G1, G2, G3), une infirmière par garde. Préférences : **A veut G1**, **B veut G1** aussi, **C veut G2**. Le conflit (A et B veulent G1) rend impossible de satisfaire tout le monde — c'est précisément là que MaxSAT prouve sa valeur.",,,,,,,,bfa5a2bcd23ca3b1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,757c819a,code,fr,b6ae0ea7013a1604,"// Nurse rostering (MaxSAT) : 3 infirmieres x 3 gardes, 1 infirmiere/garde.
+// Variables {0,1} : A_Gi = 1 si l'infirmiere A prend la garde Gi.
+public class NurseRoster
+{
+    public int A_G1=0, A_G2=0, A_G3=0;
+    public int B_G1=0, B_G2=0, B_G3=0;
+    public int C_G1=0, C_G2=0, C_G3=0;
+}
+
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<NurseRoster>();
+
+    // Domaine {0,1} pour les 9 variables d'affectation
+    th = th.Where(t => t.A_G1>=0&&t.A_G1<=1 && t.A_G2>=0&&t.A_G2<=1 && t.A_G3>=0&&t.A_G3<=1
+                    && t.B_G1>=0&&t.B_G1<=1 && t.B_G2>=0&&t.B_G2<=1 && t.B_G3>=0&&t.B_G3<=1
+                    && t.C_G1>=0&&t.C_G1<=1 && t.C_G2>=0&&t.C_G2<=1 && t.C_G3>=0&&t.C_G3<=1);
+
+    // HARD — couverture : exactement 1 infirmiere par garde
+    th = th.Where(t => t.A_G1 + t.B_G1 + t.C_G1 == 1);  // garde G1
+    th = th.Where(t => t.A_G2 + t.B_G2 + t.C_G2 == 1);  // garde G2
+    th = th.Where(t => t.A_G3 + t.B_G3 + t.C_G3 == 1);  // garde G3
+
+    // HARD — capacite : au plus 1 garde par infirmiere (pas de double-garde)
+    th = th.Where(t => t.A_G1 + t.A_G2 + t.A_G3 <= 1);
+    th = th.Where(t => t.B_G1 + t.B_G2 + t.B_G3 <= 1);
+    th = th.Where(t => t.C_G1 + t.C_G2 + t.C_G3 <= 1);
+
+    // SOFT — maximiser les preferences satisfaites :
+    //   A veut G1, B veut G1, C veut G2
+    var sol = th.Optimize(Optimization.Maximize,
+        t => t.A_G1 + t.B_G1 + t.C_G2);
+
+    // Infirmiere affectee a chaque garde (la premiere a 1 dans la colonne)
+    string nG1 = sol.A_G1==1?""A"":(sol.B_G1==1?""B"":""C"");
+    string nG2 = sol.A_G2==1?""A"":(sol.B_G2==1?""B"":""C"");
+    string nG3 = sol.A_G3==1?""A"":(sol.B_G3==1?""B"":""C"");
+    int prefsSatisfaites = sol.A_G1 + sol.B_G1 + sol.C_G2;
+
+    Console.WriteLine(""Affectation optimale :"");
+    Console.WriteLine($""  Garde G1 -> infirmiere {nG1}"");
+    Console.WriteLine($""  Garde G2 -> infirmiere {nG2}"");
+    Console.WriteLine($""  Garde G3 -> infirmiere {nG3}"");
+    Console.WriteLine($""Preferences satisfaites : {prefsSatisfaites} / 3  (A voulait G1, B voulait G1, C voulait G2)"");
+    Console.WriteLine(""Conflit A/B sur G1 : impossible de satisfaire les 3 -> le solveur arbitre (optimum = 2)."");
+}",,,,,,,,b6ae0ea7013a1604,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,763fbd54,markdown,fr,b1c23f3e44896881,"## Lecture : pourquoi MaxSAT fait la différence (Prong-B)
+
+L'optimum trouvé est **2 préférences sur 3** — et c'est le mieux possible. Pourquoi ? A et B veulent **toutes deux** la garde G1, or une seule infirmière peut la prendre (contrainte dure de couverture). Le solveur en donne une à A (ou B), satisfait la préférence de C sur G2, et affecte la garde restante G3 à l'infirmière dont la préférence n'a pas pu être honorée. **Aucune affectation ne peut dépasser 2 préférences satisfaites** — le solveur le prouve par optimisation globale.
+
+C'est exactement le terrain où l'optimisation SMT *discrimine* face à une approche naïve :
+
+- Un **glouton** « donner à chacun sa préférence » échoue dès la première étape (A et B en conflit sur G1) et doit reculer — sans stratégie globale, il peut aboutir à une affectation sous-optimale (1 préférence) au lieu de l'optimum (2).
+- Le **solveur d'optimisation** explore l'espace des affectations en tenant compte simultanément de **toutes** les contraintes dures et de l'objectif, et **garantit** l'optimum.
+
+Sur cette instance (3×3 = 9 variables), c'est petit. Mais le **même patron** passe à l'échelle : 30 infirmières × 30 gardes avec disponibilités, compétences et préférences pondérées devient un weighted partial MaxSAT que le solveur traite en secondes — là où un backtracking manuel explose.
+
+**Points clés** :
+- Les contraintes **dures** vont dans `.Where(...)` ; les préférences **molles** dans l'objectif `.Optimize(...)` — la distinction structurelle est explicite dans le code.
+- L'optimum est **garanti global** (le solveur explore tout l'espace, il ne s'arrête pas à la première solution faisable).
+- Quand les préférences sont **pondérées** (certaines comptent plus que d'autres), il suffit de pondérer l'objectif : `t => 3*t.A_G1 + 1*t.B_G1 + 2*t.C_G2` — weighted MaxSAT, sans changer la structure.",,,,,,,,b1c23f3e44896881,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,08cc6997,markdown,fr,d8d507498adc4306,"## B1 — Weighted MaxSAT explicite (DSL `SoftWhere`)
+
+Le pattern `.Optimize(Maximize, lambda_ponderee)` cache la **pondération dans une expression-objectif** : on construit un lambda `t => 3*t.A_G1 + 1*t.B_G1 + 2*t.C_G2` qui combine linéairement des contributions booléennes. C'est *pratique*, mais ça mélange deux choses — la **nature pondérée** de la contrainte (chaque préférence est un jugement indépendant) et la **stratégie d'agrégation** (ici une somme linéaire). Le binding Z3.Linq expose un cran plus bas via **`SoftWhere`** ([`Theorem{T}.cs:121`](../Z3.Linq/solutions/Z3.Linq/Theorem{T}.cs#L121)) : on déclare chaque préférence comme une **contrainte molle indépendante** avec son **poids** et un **groupe** optionnel (les softs d'un même groupe sont agrégés en un seul objectif par Z3), et le routage vers `MkOptimize + AssertSoft` est automatique (cf [`Theorem.cs:141-149`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L141)). Z3 minimise alors **la somme des poids des contraintes molles violées** — exactement la sémantique `MaxRes` du weighted MaxSAT canonique.
+
+> **Stack : A + B — pourquoi**. Ce bloc ouvre un **deuxième volet ""deux stacks""** : pas pour exposer une théorie Z3 cachée (BitVectors, réels, UNSAT cores), mais pour révéler l'**architecture de routage** entre `Solver` (qui ignore les softs) et `Optimize` (qui les porte via `AssertSoft`). Le DSL `SoftWhere` est l'**entrée** qui déclenche ce routage ; le raw `AssertSoft` est l'**appel Z3** qui le matérialise.",,,,,,,,d8d507498adc4306,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,a8b15506,code,fr,243e8f3861c1a5c5,"// B1 — Weighted MaxSAT ""deux stacks"" sur le meme probleme (3 infirmieres x 3 gardes)
+// Preferences : A veut G1 (poids 3), B veut G1 (poids 1), C veut G2 (poids 2)
+// Meme instance que la cellule 7 (unweighted), mais avec poids distincts.
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : on manipule l'Optimize object directement
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    var opt = z3.MkOptimize();
+
+    // Variables entieres {0,1} : A_Gi, B_Gi, C_Gi (alignement avec le pattern de NB-09)
+    var A_G1 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""A_G1"");
+    var A_G2 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""A_G2"");
+    var A_G3 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""A_G3"");
+    var B_G1 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""B_G1"");
+    var B_G2 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""B_G2"");
+    var B_G3 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""B_G3"");
+    var C_G1 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""C_G1"");
+    var C_G2 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""C_G2"");
+    var C_G3 = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""C_G3"");
+
+    // Helper : assert (v >= 0) && (v <= 1)
+    void Dom(Microsoft.Z3.ArithExpr v)
+    {
+        opt.Assert(z3.MkAnd(z3.MkGe(v, z3.MkInt(0)), z3.MkLe(v, z3.MkInt(1))));
+    }
+    Dom(A_G1); Dom(A_G2); Dom(A_G3); Dom(B_G1); Dom(B_G2); Dom(B_G3); Dom(C_G1); Dom(C_G2); Dom(C_G3);
+
+    // HARD — couverture : exactement 1 infirmiere par garde
+    opt.Assert(z3.MkEq(z3.MkAdd(A_G1, B_G1, C_G1), z3.MkInt(1)));
+    opt.Assert(z3.MkEq(z3.MkAdd(A_G2, B_G2, C_G2), z3.MkInt(1)));
+    opt.Assert(z3.MkEq(z3.MkAdd(A_G3, B_G3, C_G3), z3.MkInt(1)));
+
+    // SOFT — preferences ponderees (AssertSoft : poids = penalite si violee)
+    // La garde molle s'exprime comme ""A_Gi == 1"" — equivalente a (A_Gi != 0)
+    opt.AssertSoft(z3.MkEq(A_G1, z3.MkInt(1)), 3, ""preferences"");  // A veut G1, poids 3 (le plus fort)
+    opt.AssertSoft(z3.MkEq(B_G1, z3.MkInt(1)), 1, ""preferences"");  // B veut G1, poids 1
+    opt.AssertSoft(z3.MkEq(C_G2, z3.MkInt(1)), 2, ""preferences"");  // C veut G2, poids 2
+
+    var status = opt.Check();
+    Console.WriteLine($""[RAW] Status : {status}"");
+
+    if (status == Microsoft.Z3.Status.SATISFIABLE)
+    {
+        var m = opt.Model;
+        int vA_G1 = ((Microsoft.Z3.IntNum)m.Eval(A_G1, true)).Int;
+        int vA_G2 = ((Microsoft.Z3.IntNum)m.Eval(A_G2, true)).Int;
+        int vA_G3 = ((Microsoft.Z3.IntNum)m.Eval(A_G3, true)).Int;
+        int vB_G1 = ((Microsoft.Z3.IntNum)m.Eval(B_G1, true)).Int;
+        int vB_G2 = ((Microsoft.Z3.IntNum)m.Eval(B_G2, true)).Int;
+        int vB_G3 = ((Microsoft.Z3.IntNum)m.Eval(B_G3, true)).Int;
+        int vC_G1 = ((Microsoft.Z3.IntNum)m.Eval(C_G1, true)).Int;
+        int vC_G2 = ((Microsoft.Z3.IntNum)m.Eval(C_G2, true)).Int;
+        int vC_G3 = ((Microsoft.Z3.IntNum)m.Eval(C_G3, true)).Int;
+        var gardeG1 = vA_G1==1 ? ""A"" : (vB_G1==1 ? ""B"" : ""C"");
+        var gardeG2 = vA_G2==1 ? ""A"" : (vB_G2==1 ? ""B"" : ""C"");
+        var gardeG3 = vA_G3==1 ? ""A"" : (vB_G3==1 ? ""B"" : ""C"");
+        Console.WriteLine($""[RAW] Garde G1 -> {gardeG1}"");
+        Console.WriteLine($""[RAW] Garde G2 -> {gardeG2}"");
+        Console.WriteLine($""[RAW] Garde G3 -> {gardeG3}"");
+        Console.WriteLine(""[RAW] A obtient G1 (poids 3 satisfait) — B perd G1 (poids 1 sacrifie)"");
+    }
+}
+Console.WriteLine();
+
+public class NurseRosterB1
+{
+    public int A_G1=0, A_G2=0, A_G3=0;
+    public int B_G1=0, B_G2=0, B_G3=0;
+    public int C_G1=0, C_G2=0, C_G3=0;
+}
+
+// ============================================================
+// BLOC DSL (Z3.Linq) : SoftWhere + Solve — meme semantique
+// ============================================================
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<NurseRosterB1>();
+
+    // Domaine {0,1} pour les 9 variables d'affectation
+    th = th.Where(t => t.A_G1>=0&&t.A_G1<=1 && t.A_G2>=0&&t.A_G2<=1 && t.A_G3>=0&&t.A_G3<=1
+                    && t.B_G1>=0&&t.B_G1<=1 && t.B_G2>=0&&t.B_G2<=1 && t.B_G3>=0&&t.B_G3<=1
+                    && t.C_G1>=0&&t.C_G1<=1 && t.C_G2>=0&&t.C_G2<=1 && t.C_G3>=0&&t.C_G3<=1);
+
+    // HARD — couverture (memes contraintes qu'au-dessus)
+    th = th.Where(t => t.A_G1 + t.B_G1 + t.C_G1 == 1);
+    th = th.Where(t => t.A_G2 + t.B_G2 + t.C_G2 == 1);
+    th = th.Where(t => t.A_G3 + t.B_G3 + t.C_G3 == 1);
+
+    // SOFT — chaque preference declaree separement avec son poids
+    // Pas besoin de .Optimize() — le routage vers MkOptimize est AUTOMATIQUE
+    // des qu'une soft constraint est presente (Theorem.cs:144).
+    th = th.SoftWhere(t => t.A_G1 == 1, weight: 3);
+    th = th.SoftWhere(t => t.B_G1 == 1, weight: 1);
+    th = th.SoftWhere(t => t.C_G2 == 1, weight: 2);
+
+    var sol = th.Solve();
+
+    string nG1 = sol.A_G1==1?""A"":(sol.B_G1==1?""B"":""C"");
+    string nG2 = sol.A_G2==1?""A"":(sol.B_G2==1?""B"":""C"");
+    string nG3 = sol.A_G3==1?""A"":(sol.B_G3==1?""B"":""C"");
+
+    Console.WriteLine($""[DSL] Garde G1 -> {nG1}"");
+    Console.WriteLine($""[DSL] Garde G2 -> {nG2}"");
+    Console.WriteLine($""[DSL] Garde G3 -> {nG3}"");
+    Console.WriteLine(""[DSL] Meme verdict que le raw : A obtient G1 (poids 3) > B (poids 1)"");
+}
+Console.WriteLine();
+Console.WriteLine(""B1 OK : raw et DSL produisent la meme affectation (A sur G1), demontrant que"");
+Console.WriteLine(""SoftWhere est bien l'equivalent DSL de AssertSoft (meme routage vers MkOptimize)."");
+",,,,,,,,243e8f3861c1a5c5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,a04cb495,markdown,fr,877cec01b350cde2,"### Lecture B1 — pourquoi deux écritures du même problème
+
+Les deux blocs résolvent **exactement la même instance** (3 infirmières × 3 gardes, mêmes contraintes dures, mêmes préférences pondérées) et arrivent au **même verdict** : A obtient G1 (poids 3) — son poids bat B (poids 1). La différence n'est pas sémantique, elle est **architecturale** :
+
+| Aspect | RAW (`MkOptimize + AssertSoft`) | DSL (`th.SoftWhere + Solve`) |
+|---|---|---|
+| Qui instancie l'Optimize | L'utilisateur (`var solver = z3.MkOptimize()`) | Le binding automatiquement (Theorem.cs:144) |
+| Qui traduit la lambda `t => ...` | Pas de lambda : on construit le `BoolExpr` à la main | Le `ExpressionVisitor` du binding |
+| Visibilité des poids | Explicite : `AssertSoft(expr, weight: 3, group: ""..."")` | Explicite aussi : `SoftWhere(constraint, weight: 3)` |
+| Granularité de modification | On peut ajouter/retirer des `AssertSoft` à la volée entre `Check()` | Idem (chaque `SoftWhere` retourne un nouveau `Theorem<T>`) |
+| Verbosity | 30+ lignes de boilerplate | 3 lignes |
+
+> **Ligne de contraste (à retenir)** : *le DSL cache l'objet Optimize et déclenche le routage automatique* (cf Theorem.cs:144 `if (softConstraints.Any())`) — *le raw expose l'objet pour un contrôle direct (groupes, vérifications incrémentales)*. **Même sémantique Z3** (`AssertSoft` apparaît dans les deux), **deux niveaux d'abstraction** différents.
+
+**Cas d'usage** : on préfère le DSL `SoftWhere` par défaut (lisibilité, chaînable avec `.Where`); on bascule en raw quand on doit **inspecter le modèle entre deux assertions**, **partager un `Optimize` entre sous-problèmes**, ou **désactiver temporairement** certaines contraintes molles (le DSL `SoftWhere` ajoute toujours, jamais ne retire).",,,,,,,,877cec01b350cde2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,b3-intro-sum,markdown,fr,4fb8111170dbc63e,"## B3 — Somme variadique (DSL `Z3Methods.Sum`)
+
+Le sac à dos de la cellule 4 déroule **à la main** sa contrainte de capacité et son objectif : `4*t.x0 + 5*t.x1 + 6*t.x2 + 3*t.x3 + 2*t.x4`. Ça passe pour 5 objets ; à 20 ou 50 objets ce déroulage devient illisible et fragile (une faute de copier-coller par terme). Le visiteur Z3.Linq ne connaît nativement que le `+` **binaire** (repli pairwise `a + b`) — il n'a aucun moyen de replier une liste de longueur arbitraire. C'est le trou que comble **`Z3Methods.Sum`** ([`Z3Methods.cs:37`](../Z3.Linq/solutions/Z3.Linq/Z3Methods.cs#L37)) : une **méthode magique variadique** qui prend un `params T[]` (littéral `new[]{...}` **ou** collection matérialisée via `Select(...).ToArray()`) et se traduit en un unique `MkAdd` sur tous les termes (cf [`ExpressionVisitor.cs:482`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L482)).
+
+> **Stack : A + B — pourquoi**. Ce bloc « deux stacks » ne révèle pas une théorie Z3 cachée : `MkAdd` est **déjà** variadique côté API brute. Ce que B3 révèle, c'est le **pont d'agrégation** entre une **collection C#** et un **terme SMT unique** — le DSL `Sum` est l'**entrée LINQ** qui déclenche le repli, le raw `MkAdd(ArithExpr[])` est l'**appel Z3** qui le matérialise. Sans `Sum`, la lambda du DSL est condamnée au déroulage terme-à-terme.",,,,,,,,4fb8111170dbc63e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,b3-code-sum,code,fr,cb0f2d1d2024c59f,"// B3 — Somme variadique ""deux stacks"" sur le meme sac a dos (5 objets, capacite 10)
+// poids {4,5,6,3,2}, valeur {10,15,16,7,5} — meme instance que la cellule 4.
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : MkAdd variadique construit A LA MAIN
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    var opt = z3.MkOptimize();
+
+    int[] poidsR  = { 4, 5, 6, 3, 2 };
+    int[] valeurR = { 10, 15, 16, 7, 5 };
+    int WR = 10;
+
+    // Une variable entiere {0,1} par objet
+    var x = new Microsoft.Z3.ArithExpr[5];
+    for (int i = 0; i < 5; i++)
+    {
+        x[i] = (Microsoft.Z3.ArithExpr)z3.MkIntConst(""x"" + i);
+        opt.Assert(z3.MkAnd(z3.MkGe(x[i], z3.MkInt(0)), z3.MkLe(x[i], z3.MkInt(1))));
+    }
+
+    // Capacite : on replie A LA MAIN les 5 termes ponderes dans un tableau, puis MkAdd
+    var termesPoids = new Microsoft.Z3.ArithExpr[5];
+    for (int i = 0; i < 5; i++) termesPoids[i] = (Microsoft.Z3.ArithExpr)z3.MkMul(z3.MkInt(poidsR[i]), x[i]);
+    opt.Assert(z3.MkLe(z3.MkAdd(termesPoids), z3.MkInt(WR)));
+
+    // Objectif : maximiser la somme ponderee des valeurs (meme repli manuel)
+    var termesValeur = new Microsoft.Z3.ArithExpr[5];
+    for (int i = 0; i < 5; i++) termesValeur[i] = (Microsoft.Z3.ArithExpr)z3.MkMul(z3.MkInt(valeurR[i]), x[i]);
+    opt.MkMaximize(z3.MkAdd(termesValeur));
+
+    var status = opt.Check();
+    Console.WriteLine($""[RAW] Status : {status}"");
+    if (status == Microsoft.Z3.Status.SATISFIABLE)
+    {
+        var m = opt.Model;
+        var pris = new int[5];
+        for (int i = 0; i < 5; i++) pris[i] = ((Microsoft.Z3.IntNum)m.Eval(x[i], true)).Int;
+        int poidsTot = 0, valeurTot = 0;
+        for (int i = 0; i < 5; i++) { poidsTot += poidsR[i] * pris[i]; valeurTot += valeurR[i] * pris[i]; }
+        Console.WriteLine(""[RAW] Objets pris (1=pris) : "" + string.Join("", "", pris));
+        Console.WriteLine($""[RAW] Poids {poidsTot} / {WR} — Valeur optimale {valeurTot}"");
+    }
+}
+Console.WriteLine();
+
+public class KnapsackB3
+{
+    public int x0 = 0, x1 = 0, x2 = 0, x3 = 0, x4 = 0;  // 1 si l'objet i est pris
+}
+
+// ============================================================
+// BLOC DSL (Z3.Linq) : Z3Methods.Sum remplace le deroulage manuel
+// ============================================================
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<KnapsackB3>();
+
+    th = th.Where(t => t.x0>=0&&t.x0<=1 && t.x1>=0&&t.x1<=1 && t.x2>=0&&t.x2<=1 && t.x3>=0&&t.x3<=1 && t.x4>=0&&t.x4<=1);
+
+    // Capacite : UNE ligne — Sum replie les 5 termes ponderes en un seul MkAdd
+    th = th.Where(t => Z3Methods.Sum(new[]{ 4*t.x0, 5*t.x1, 6*t.x2, 3*t.x3, 2*t.x4 }) <= 10);
+
+    // Objectif : idem, Sum sur les valeurs
+    var sol = th.Optimize(Optimization.Maximize, t => Z3Methods.Sum(new[]{ 10*t.x0, 15*t.x1, 16*t.x2, 7*t.x3, 5*t.x4 }));
+
+    int[] prisD = { sol.x0, sol.x1, sol.x2, sol.x3, sol.x4 };
+    int poidsD  = 4*sol.x0 + 5*sol.x1 + 6*sol.x2 + 3*sol.x3 + 2*sol.x4;
+    int valeurD = 10*sol.x0 + 15*sol.x1 + 16*sol.x2 + 7*sol.x3 + 5*sol.x4;
+    Console.WriteLine(""[DSL] Objets pris (1=pris) : "" + string.Join("", "", prisD));
+    Console.WriteLine($""[DSL] Poids {poidsD} / 10 — Valeur optimale {valeurD}"");
+}
+Console.WriteLine();
+Console.WriteLine(""B3 OK : raw (MkAdd manuel sur tableau) et DSL (Z3Methods.Sum) trouvent le meme optimum."");
+Console.WriteLine(""Le DSL supprime le deroulage terme-a-terme que le + binaire du visiteur imposerait."");",,,,,,,,cb0f2d1d2024c59f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,b3-lecture-sum,markdown,fr,89df57b2c8e667b6,"### Lecture B3 — pourquoi deux écritures de la même somme
+
+Les deux blocs résolvent **le même sac à dos** (5 objets, capacité 10) et trouvent le **même optimum**. La différence tient à l'**expression de la somme pondérée** :
+
+| Aspect | RAW (`z3.MkAdd(ArithExpr[])`) | DSL (`Z3Methods.Sum(new[]{...})`) |
+|---|---|---|
+| Construction des termes | Boucle explicite `MkMul(poids[i], x[i])` dans un tableau | Directement dans la lambda `t => ...` |
+| Repli en somme | `z3.MkAdd(termes)` (API brute déjà variadique) | `Z3Methods.Sum(...)` → visiteur → `MkAdd` |
+| Longueur variable | Naturelle (on remplit le tableau) | Naturelle (`new[]{...}` littéral **ou** `Select(...).ToArray()`) |
+| Sans B3 côté DSL | — | Déroulage manuel `4*x0 + 5*x1 + ...` (le `+` du visiteur ne replie que **deux** opérandes) |
+| Lisibilité à N objets | Boilerplate `MkIntConst`/`MkMul`/`Eval` | Une ligne, même à 50 termes |
+
+> **Ligne de contraste (à retenir)** : *le `+` du visiteur ne replie que **deux** opérandes ; `Z3Methods.Sum` replie **une liste entière** en un seul `MkAdd`* — c'est le pont manquant entre une collection C# et un terme SMT. **Même sémantique Z3** (`MkAdd` dans les deux blocs), **mais le DSL supprime le déroulage manuel** que le `+` binaire imposerait.
+
+**Cas d'usage** : dès qu'une contrainte agrège un **nombre variable** de contributions (somme d'indicateurs `sum_i Sel[i]*coût[i]`, charge d'un bin, total d'une ligne Sudoku), `Sum` évite le déroulage. Sur la forme `Select(...).ToArray()`, la collection source est **évaluée dans l'hôte** (host-evaluable) puis chaque élément substitué — on peut donc sommer sur `Enumerable.Range(0, n)` sans écrire les `n` termes à la main.",,,,,,,,89df57b2c8e667b6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,bc9745e0,markdown,fr,e932f9e8de5a9bce,"## Exercices
+
+Les trois exercices vous font réutiliser l'API `.Optimize()` sur de nouvelles instances d'optimisation. Chaque exercice suit le squelette : définir la classe de variables, ajouter domaine + contraintes dures (`.Where`), puis appeler `.Optimize` avec un objectif.
+
+**Rappel C.1** : les stubs ne lèvent **jamais** d'erreur — `Console.WriteLine(""Exercice à compléter"")`. Le notebook s'exécute de bout en bout même exercices non résolus.",,,,,,,,e932f9e8de5a9bce,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,043dce7a,markdown,fr,bcff2a40d06f3cc0,"### Exercice 1 — Sac à dos avec 6 objets
+
+Reprenez le sac à dos de la cellule 4 mais avec 6 objets : poids `[6, 3, 4, 2, 5, 7]`, valeurs `[12, 5, 8, 3, 10, 14]`, capacité `W = 15`. Définissez la classe `Knapsack6` (6 variables `{0,1}`), ajoutez la contrainte de capacité, et maximisez la valeur. Quel est l'optimum ?
+
+**Indice** : il y a $2^6 = 64$ sous-ensembles — énumérable à la main, mais le solveur le trouve sans énumération explicite.",,,,,,,,bcff2a40d06f3cc0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,6d04db3c,code,fr,c4f89b766b968744,"// Exercice 1 : sac a dos 6 objets
+// TODO etudiant :
+// 1. Classe Knapsack6 { x0..x5 } (int), domaine {0,1}
+// 2. Contrainte : 6*x0 + 3*x1 + 4*x2 + 2*x3 + 5*x4 + 7*x5 <= 15
+// 3. Objectif : Optimize(Maximize, t => 12*x0 + 5*x1 + 8*x2 + 3*x3 + 10*x4 + 14*x5)
+Console.WriteLine(""Exercice 1 a completer : sac a dos 6 objets, maximiser la valeur sous capacite 15"");",,,,,,,,c4f89b766b968744,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,b1aee8fc,markdown,fr,d2c88f13de5b8b12,"### Exercice 2 — Minimisation (coût de transport)
+
+Trois entrepôts approvisionnent un client. Chaque entrepôt a un coût unitaire de livraison et une capacité : entropôt 1 (coût 4, capacité 50), entropôt 2 (coût 6, capacité 80), entropôt 3 (coût 3, capacité 30). Le client demande **100 unités**. Minimisez le **coût total** de livraison.
+
+**Étapes** : 3 variables entières (quantités, domaines `0..capacité`), contrainte `q1+q2+q3 == 100`, objectif `Optimize(Minimize, t => 4*t.q1 + 6*t.q2 + 3*t.q3)`.",,,,,,,,d2c88f13de5b8b12,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,c96bbd7c,code,fr,b3259423363602b3,"// Exercice 2 : minimisation cout de transport (LP entier)
+// TODO etudiant :
+// 1. Classe Transport { q1, q2, q3 } (int), domaines 0..50, 0..80, 0..30
+// 2. Contrainte : t.q1 + t.q2 + t.q3 == 100
+// 3. Objectif : Optimize(Minimize, t => 4*t.q1 + 6*t.q2 + 3*t.q3)
+Console.WriteLine(""Exercice 2 a completer : minimiser le cout de transport (4/6/3 par entropot, demande 100)"");",,,,,,,,b3259423363602b3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,c66633e2,markdown,fr,f6ad759ddab9a41f,"### Exercice 3 — Weighted MaxSAT (préférences pondérées)
+
+Reprenez le roulement d'infirmières de la cellule 7, mais avec des **préférences pondérées** : A veut G1 avec un poids 3, B veut G1 avec un poids 1, C veut G2 avec un poids 2. Maximisez la somme pondérée. L'affectation optimale change-t-elle par rapport à la cellule 7 (où toutes les préférences comptaient equally) ?
+
+**Question subsidiaire** : avec ces poids, quel est l'optimum pondéré, et quelle infirmière obtient G1 ?",,,,,,,,f6ad759ddab9a41f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,1958e08f,code,fr,990f8431a682026b,"// Exercice 3 : weighted MaxSAT (preferences ponderees)
+// TODO etudiant :
+// 1. Reprendre NurseRoster (9 vars {0,1}, memes contraintes dures)
+// 2. Objectif pondere : Optimize(Maximize, t => 3*t.A_G1 + 1*t.B_G1 + 2*t.C_G2)
+Console.WriteLine(""Exercice 3 a completer : weighted MaxSAT, ponderer les preferences (A=3, B=1, C=2)"");",,,,,,,,990f8431a682026b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/14_Optimize_MaxSAT.ipynb,49a0a02a,markdown,fr,06e8c9165151206d,"## Conclusion
+
+Ce notebook comble le **gap d'optimisation** de la série Z3.Linq : là où les dix premiers notebooks posaient des problèmes de *satisfiabilité* (`.Solve()`), on introduit ici l'**optimisation** (`.Optimize()`) sur deux terrains complémentaires :
+
+- **Sac à dos** (knapsack) : un objectif quantitatif à maximiser sous contrainte de capacité — l'optimisation entière la plus canonique.
+- **Roulement d'infirmières** (nurse rostering) : le paradigme **MaxSAT** — des contraintes *dures* (couverture, capacité) dans `.Where(...)`, des préférences *molles* dans l'objectif, avec conflits arbitrés globalement par le solveur.
+
+**Points clés** :
+- `.Optimize(Optimization.Maximize/Minimize, lambda)` ou la syntaxe LINQ `orderby`/`orderby descending` — le binding traduit l'objectif en assertions `maximize`/`minimize` Z3.
+- L'optimum est **garanti global** : le solveur explore l'espace complet, il ne renvoie pas la première solution faisable.
+- La distinction **dur vs mou** est explicite dans le code : `.Where(...)` pour l'impératif, l'objectif pour le souhaitable — c'est ce qui rend la modélisation MaxSAT lisible et maintenable.
+- Le **weighted MaxSAT** (préférences pondérées) s'obtient gratuitement en pondérant l'objectif, sans changer la structure du modèle.
+
+**Référence** : le MaxSAT est le cadre standard pour l'optimisation sous contraintes booléennes ; Z3 implémente les algorithmes state-of-the-art (MaxRes, OLL) pour le résoudre. Le nurse rostering en est l'application canonique en recherche opérationnelle.",,,,,,,,06e8c9165151206d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,0f8570b5,markdown,fr,286570acb2321e95,"# 15 — Théorie des bit-vectors Z3 : vérifier le débordement arithmétique
+
+> Notebook de la série **Z3 / SMT** (Track C#, [Z3.Linq](../Z3.Linq/) fork).
+> Démontre une théorie Z3 **jamais exercée** dans les 14 notebooks précédents : les
+> **bit-vectors** (`BV8/BV16/BV32/BV64`), le domaine SMT canonique pour la vérification
+> matérielle et logicielle (entiers bornés, débordement, arithmétique modulaire).
+> **Stack : B — API brute Microsoft.Z3** (`MkBV`/`MkBVAdd`/`MkBVULT`/`MkExtract`), pas le DSL Z3.Linq : la théorie des bit-vectors n'est pas exposée par le binding.
+
+## Pourquoi ce notebook
+
+Les notebooks 01-14 couvrent les entiers non bornés (`IntSort`) : Sudoku, coloration de
+graphe, cryptarithmétique, planification. Mais **aucun** ne manipule de bit-vectors — or
+c'est la théorie Z3 originelle (Z3 est né chez Microsoft Research *pour* la vérification
+de drivers et de matériel). La question que ce notebook pose, et qu'aucun entier non borné
+ne saurait formaliser :
+
+> *Pour des entiers 32 bits, l'addition `a + b` déborde-t-elle ? Et peut-on le prouver ?*
+
+L'arithmétique machine **enveloppe** (`3000000000 + 1500000000` ne donne pas `4500000000`
+en `uint32`), là où l'arithmétique mathématique ne déborde jamais. Z3 sait **raisonner
+modulo 2³²** ET **prouver** qu'un débordement se produit (ou n'en produit pas) pour des
+entrées données — exactement le service qu'un compilateur sûr ou un vérificateur de code
+attend d'un solveur SMT.
+
+**Prong-B (non-trivial)** : le cas n'est pas dégénéré. Sur des entiers non bornés,
+`a + b ≥ a` toujours (addition croissante) — l'overflow est *impossible par construction*.
+C'est précisément la **borne 32 bits** qui rend le débordement possible et sa preuve
+intéressante : la théorie BV **crée** le phénomène que l'on demande ensuite à Z3 de
+certifier. Un notebook d'entiers non bornés ne pourrait pas le faire.",,,,,,,,286570acb2321e95,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,0e36ec43,markdown,fr,ea290681485f94da,"## 1. Théorie des bit-vectors (SMT-LIB `BitVec`)
+
+Un **bit-vector** est une suite de *n* bits interprétée comme un entier modulo 2ⁿ. Z3 en
+fait une **théorie de décision** (pas une approximation) : l'addition, la multiplication,
+les comparaisons et les opérations bit-à-bit sont définies modulo 2ⁿ et décidables.
+
+| Sorte | Plage (non signé) | Usage canonique |
+|-------|-------------------|-----------------|
+| `BV8`  | 0 … 255            | octets, `char` |
+| `BV16` | 0 … 65 535         | `uint16`, ports |
+| `BV32` | 0 … 4 294 967 295  | `uint32`, pointeurs 32 bits |
+| `BV64` | 0 … 1.8 × 10¹⁹     | `uint64`, horodatages |
+
+Deux lectures coexistent pour un même motif binaire : **non signé** (`UGE/ULT` — *unsigned
+greater/less than*) et **signé** (`SGE/SLT` — interprétation complément à 2). C'est cette
+dualité qui rend les bugs d'overflow subtils : un calcul peut être correct en non signé et
+déborder en signé, ou inversement.",,,,,,,,ea290681485f94da,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,39af3d9d,code,fr,cb5b1a571926c510,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq; using Microsoft.Z3; using System; using System.Text;
+Console.OutputEncoding = Encoding.UTF8;
+
+var ctx = new Context();
+// Sorte bit-vector 32 bits (entiers modulo 2^32)
+BitVecSort bv32 = ctx.MkBitVecSort(32);
+
+// Preuve de vie du solveur sur cette théorie
+var s0 = ctx.MkSolver();
+s0.Assert(ctx.MkTrue());
+Console.WriteLine($""Z3 .NET charge sur la théorie BitVec. Trivia check : {s0.Check()}"");
+Console.WriteLine($""Sorte créée : {bv32}  (entiers modulo 2^32 = {(ulong)Math.Pow(2,32):N0})"");",,,,,,,,cb5b1a571926c510,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,38f18b97,markdown,fr,511e0af1ec1dcc3a,"## 2. Le débordement se produit (et Z3 le calcule)
+
+Additionnons deux valeurs dont la somme mathématique **dépasse 2³²**. En `uint32`,
+`3 000 000 000 + 1 500 000 000 = 4 500 000 000` mathématiquement, mais la valeur machine
+**enveloppe** (retranche 2³²).",,,,,,,,511e0af1ec1dcc3a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,1df1bce0,code,fr,9359a5c5f7318794,"// Deux valeurs dont la somme dépasse 2^32 = 4 294 967 296
+BitVecExpr a = ctx.MkBV(3000000000U, 32);   // 3 milliards : tient en uint32, dépasse Int32 signé
+BitVecExpr b = ctx.MkBV(1500000000U, 32);   // 1,5 milliard
+
+BitVecExpr somme = ctx.MkBVAdd(a, b);       // addition modulo 2^32
+
+uint va = ((BitVecNum)a).UInt;
+uint vb = ((BitVecNum)b).UInt;
+uint vs = ((BitVecNum)somme.Simplify()).UInt;   // Simplify() force l'évaluation concrète
+ulong mathematique = (ulong)va + vb;        // somme non bornée (ulong)
+
+Console.WriteLine($""  a = {va:N0}"");
+Console.WriteLine($""  b = {vb:N0}"");
+Console.WriteLine($""  a + b (mathématique)   = {mathematique:N0}"");
+Console.WriteLine($""  BV32(a + b)            = {vs:N0}   <-- valeur machine"");
+Console.WriteLine($""  Perte par enveloppe    = {mathematique - vs:N0}"");
+Console.WriteLine();
+Console.WriteLine(""-> Le débordement a BIEN eu lieu : la valeur machine n'égale pas la somme mathématique."");",,,,,,,,9359a5c5f7318794,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,2cf1612a,markdown,fr,13389f661aea72a4,"## 3. Détecter le débordement (Z3 comme vérificateur)
+
+Calculer le débordement ne suffit pas — on veut le **certifier**. Un débordement non signé
+se détecte par un test simple : après une addition `somme = a + b` de valeurs non signées,
+si `somme < a` alors le débordement **s'est produit** (car sans débordement on aurait
+toujours `somme ≥ a` puisque `b ≥ 0`). Demandons à Z3 si ce test est satisfait pour nos
+deux entrées fixes :",,,,,,,,13389f661aea72a4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,0d28951c,code,fr,31ae3e0e5acb0e1e,"// Pour a, b fixés : la condition somme < a (unsigned) est-elle vraie ?
+var solver = ctx.MkSolver();
+solver.Assert(ctx.MkBVULT(somme, a));   // somme < a  (unsigned less-than) = débordement
+Status st = solver.Check();
+
+Console.WriteLine($""Requête « somme < a » pour a=3e9, b=1.5e9 : {st}"");
+Console.WriteLine(st == Status.SATISFIABLE
+    ? ""  -> SAT : Z3 confirme que le débordement s'est produit sur ces entrées.""
+    : ""  -> inattendu (somme < a devrait être vrai ici)."");",,,,,,,,31ae3e0e5acb0e1e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,ae5a9b17,markdown,fr,7083eab66a4b2cbd,"### Démonstration par réfutation (UNSAT)
+
+Mieux : prouvons que le débordement est **inévitable** pour toute entrée assez grande.
+C'est la forme canonique d'une preuve de propriété en SMT : nier la propriété, obtenir
+UNSAT, conclure.
+
+> **Théorème** : pour tout `x, y ≥ 2³¹`, l'addition `x + y` déborde en `BV32`.
+>
+> *Pourquoi 2³¹ ?* Si `x, y ≥ 2³¹` alors `x + y ≥ 2³²` exactement — la borne de `uint32` —
+> donc l'enveloppement est inévitable. (Avec 2³⁰ ce serait faux : `2³⁰ + 2³⁰ = 2³¹ < 2³²`,
+> pas de débordement — d'où la précision du seuil.)
+
+On nie : « préconditions `x,y ≥ 2³¹` ET **pas** de débordement (`somme ≥ x`) » et on demande
+à Z3. Si UNSAT, le théorème est prouvé.",,,,,,,,7083eab66a4b2cbd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,f9989869,code,fr,612340714712396c,"// Pour x, y SYMBOLES (quelconques), prouvons : x,y >= 2^31  =>  x+y déborde
+BitVecExpr x = (BitVecExpr)ctx.MkConst(""x"", bv32);
+BitVecExpr y = (BitVecExpr)ctx.MkConst(""y"", bv32);
+BitVecExpr sxy = ctx.MkBVAdd(x, y);
+
+BoolExpr preconditions = ctx.MkAnd(
+    ctx.MkBVUGE(x, ctx.MkBV(0x80000000U, 32)),   // x >= 2^31 = 2 147 483 648
+    ctx.MkBVUGE(y, ctx.MkBV(0x80000000U, 32))    // y >= 2^31
+);
+BoolExpr pasDebord = ctx.MkBVUGE(sxy, x);          // somme >= x  = pas de débordement
+
+// Nions la propriété : preconditions ET pas de débordement
+var s2 = ctx.MkSolver();
+s2.Assert(ctx.MkAnd(preconditions, pasDebord));
+Status st2 = s2.Check();
+Console.WriteLine($""« x,y >= 2^31 ET somme >= x (pas de débord) » : {st2}"");
+Console.WriteLine(st2 == Status.UNSATISFIABLE
+    ? ""  -> UNSAT : Z3 PROUVE que pour x,y >= 2^31, le débordement est inévitable.""
+    : ""  -> SAT : contre-exemple trouvé (le théorème est faux)."");
+if (st2 == Status.SATISFIABLE) {
+    var m = s2.Model;
+    Console.WriteLine($""     Contre-exemple : x={((BitVecNum)m.ConstInterp(x)).UInt}, y={((BitVecNum)m.ConstInterp(y)).UInt}"");
+}",,,,,,,,612340714712396c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,5b4bb470,markdown,fr,08742111c9d3c18a,"## 4. Réciproque : prouver l'absence de débordement
+
+La même mécanique prouve l'**absence** de débordement sous une précondition. C'est le cas
+d'usage réel des analyseurs statiques : « si les entrées sont petites, l'addition est sûre ».
+On nie : « `p,q < 1000` ET débordement » et on attend UNSAT.",,,,,,,,08742111c9d3c18a,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,1d80672c,code,fr,0f907a864f19471c,"// Propriété : si p < 1000 ET q < 1000, alors p+q ne déborde pas (somme >= p)
+BitVecExpr p = (BitVecExpr)ctx.MkConst(""p"", bv32);
+BitVecExpr q = (BitVecExpr)ctx.MkConst(""q"", bv32);
+BitVecExpr spq = ctx.MkBVAdd(p, q);
+
+BoolExpr petites = ctx.MkAnd(
+    ctx.MkBVULT(p, ctx.MkBV(1000, 32)),
+    ctx.MkBVULT(q, ctx.MkBV(1000, 32))
+);
+BoolExpr debord = ctx.MkBVULT(spq, p);   // débordement = somme < p
+
+// Nions : petites ET débordement -> UNSAT prouve « petites => pas de débordement »
+var s3 = ctx.MkSolver();
+s3.Assert(ctx.MkAnd(petites, debord));
+Status st3 = s3.Check();
+Console.WriteLine($""« p,q < 1000 ET débordement » : {st3}"");
+Console.WriteLine(st3 == Status.UNSATISFIABLE
+    ? ""  -> UNSAT : Z3 PROUVE que pour p,q < 1000, l'addition uint32 ne déborde jamais.""
+    : ""  -> SAT : contre-exemple trouvé (improbable)."");",,,,,,,,0f907a864f19471c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,de259997,markdown,fr,29968cc18ed3bda2,"## 5. Opérations bit-à-bit et extraction de champs
+
+Les bit-vectors ne sont pas que de l'arithmétique modulaire : Z3 raisonne aussi sur les
+**opérations bit-à-bit** (ET, OU, XOR, décalages) et l'**extraction de sous-champs**
+(`MkExtract`) — la brique des analyseurs de protocoles et de formats binaires, où l'on
+isole un octet ou un drapeau dans un mot de 32 bits.",,,,,,,,29968cc18ed3bda2,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,9ce7c86b,code,fr,84becac41eb3aa45,"// Combiner arithmétique et bit-à-bit : extraction de champ
+BitVecExpr n = (BitVecExpr)ctx.MkConst(""n"", bv32);
+
+// Extraire l'octet de poids faible (bits 0-7) et l'octet suivant (bits 8-15)
+BitVecExpr octet0 = ctx.MkExtract(7, 0, n);    // bits 7..0   -> BV8
+BitVecExpr octet1 = ctx.MkExtract(15, 8, n);   // bits 15..8  -> BV8
+
+// Question : existe-t-il n NON NUL tel que octet0 == octet1 (les deux octets bas égaux) ?
+var s4 = ctx.MkSolver();
+s4.Assert(ctx.MkEq(octet0, octet1));
+s4.Assert(ctx.MkNot(ctx.MkEq(n, ctx.MkBV(0, 32))));   // forcer un témoin non trivial
+Status st4 = s4.Check();
+Console.WriteLine($""« octet bas == octet suivant » : {st4}"");
+if (st4 == Status.SATISFIABLE) {
+    var m4 = s4.Model;
+    uint vn = ((BitVecNum)m4.ConstInterp(n)).UInt;
+    uint o0 = ((BitVecNum)m4.Eval(octet0, true)).UInt;
+    uint o1 = ((BitVecNum)m4.Eval(octet1, true)).UInt;
+    Console.WriteLine($""  Témoin : n = {vn} = 0x{vn:X8}"");
+    Console.WriteLine($""    octet0 (bits 7..0)  = 0x{o0:X2}"");
+    Console.WriteLine($""    octet1 (bits 15..8) = 0x{o1:X2}"");
+}
+Console.WriteLine();
+Console.WriteLine(""-> MkExtract + égalité = raisonnement au niveau champ binaire (protocoles, formats)."");",,,,,,,,84becac41eb3aa45,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,b4-bitvecwidth-intro,markdown,fr,0d9e9a6db9c5bd2e,"## B4 - Largeur de bit-vector declarative (DSL `[BitVecWidth(n)]`)
+
+Tout le notebook jusqu'ici cable la sorte `BitVec` a la main (`ctx.MkBitVecSort(32)`, `MkBVAdd`, `MkBVULT`). Cote DSL, le binding Z3.Linq laisse **declarer la largeur par un attribut C#** - [`[BitVecWidth(n)]`](../Z3.Linq/solutions/Z3.Linq/BitVecWidthAttribute.cs#L21) sur une propriete entiere d'une classe ordinaire - et **route automatiquement** `+`/`-`/`*` vers les operateurs modulaires et les comparaisons vers l'ordre non signe ([`ExpressionVisitor.cs:120`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L120), largeur lue en [`Theorem.cs:548`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L548)). Sans cet attribut, toute variable entiere d'un theoreme Z3.Linq est un **entier mathematique non borne** - et le debordement, coeur de ce notebook, devient **inexprimable**.
+
+> **Stack : A + B - pourquoi**. Ce bloc appartient a la famille ""theorie cachee"" (comme les reels ou les UNSAT cores) : l'attribut `[BitVecWidth(n)]` **encode une semantique** (l'arithmetique modulo 2^n) qu'aucune ligne de code n'affiche - elle vit dans le type. Le raw `MkBitVecSort + MkBVAdd + MkBVULT` **materialise** cette meme semantique en appels Z3 explicites. Le contraste rend visible ce que la largeur fixe achete : le predicat `a + b < a` (debordement) est **SAT en 4 bits** mais **UNSAT sur les entiers** - meme requete, deux theories.",,,,,,,,0d9e9a6db9c5bd2e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,b4-bitvecwidth-code,code,fr,77c7c66a10448354,"// B4 - Largeur de bit-vector declarative ""[BitVecWidth(n)]"" : deux stacks sur le MEME predicat de debordement.
+// Predicat non-trivial : ""a + b < a"" avec b >= 1
+//   - SAT   sur bit-vectors 4 bits (la somme enveloppe modulo 16, sous a)   <- theorie BitVec
+//   - UNSAT sur entiers non bornes (une somme a addend positif ne decroit jamais)  <- theorie Int
+// Ce contraste EST ce que la largeur fixe achete : sans elle, le debordement est inexprimable.
+
+// Classes au niveau cellule (requises par NewTheorem<T>) : la largeur vit dans le TYPE.
+public class Reg4      { [BitVecWidth(4)] public int A { get; set; }  [BitVecWidth(4)] public int B { get; set; } }  // registres 4 bits, 0..15, mod 16
+public class PlainPair { public int A { get; set; }  public int B { get; set; } }                                    // meme forme, SANS largeur = entiers non bornes
+
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : on cable la sorte BV4 et les operateurs modulaires a la main
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    BitVecSort bv4 = z3.MkBitVecSort(4);
+    BitVecExpr ra = (BitVecExpr)z3.MkConst(""a"", bv4);
+    BitVecExpr rb = (BitVecExpr)z3.MkConst(""b"", bv4);
+
+    var sBv = z3.MkSolver();
+    sBv.Assert(z3.MkBVUGE(rb, z3.MkBV(1, 4)));                 // b >= 1        (unsigned)
+    sBv.Assert(z3.MkBVULT(z3.MkBVAdd(ra, rb), ra));            // a + b < a     (unsigned) = debordement
+    Status stBv = sBv.Check();
+    Console.WriteLine($""[RAW] BV4  : \"" a+b < a  avec b>=1 \"" -> {stBv}"");
+    if (stBv == Status.SATISFIABLE) {
+        var mBv = sBv.Model;
+        uint wa = ((BitVecNum)mBv.ConstInterp(ra)).UInt;
+        uint wb = ((BitVecNum)mBv.ConstInterp(rb)).UInt;
+        Console.WriteLine($""[RAW]   Temoin : a={wa}, b={wb} -> (a+b) mod 16 = {(wa + wb) % 16} < a={wa}   (enveloppe)"");
+    }
+
+    // Le meme predicat sur des entiers non bornes (sorte Int) : pas de debordement possible
+    var sInt = z3.MkSolver();
+    IntExpr ia = z3.MkIntConst(""a"");
+    IntExpr ib = z3.MkIntConst(""b"");
+    sInt.Assert(z3.MkGe(ia, z3.MkInt(0)));
+    sInt.Assert(z3.MkGe(ib, z3.MkInt(1)));
+    sInt.Assert(z3.MkLt(z3.MkAdd(ia, ib), ia));               // a + b < a  sur les entiers
+    Console.WriteLine($""[RAW] Int  : meme predicat sur entiers non bornes -> {sInt.Check()}   (aucun debordement)"");
+}
+
+// =====================================================================
+// BLOC DSL (Z3.Linq) : la largeur est declaree par attribut, les operateurs sont routes automatiquement
+// =====================================================================
+{
+    using var thCtx = new Z3Context();
+
+    // Stack DSL, theorie BV4 : le meme predicat de debordement, ecrit en arithmetique C# naturelle
+    var bv = thCtx.NewTheorem<Reg4>()
+        .Where(r => r.B >= 1)
+        .Where(r => r.A + r.B < r.A)      // + route vers MkBVAdd, < vers MkBVULT (Theorem.cs:548)
+        .Solve();
+    Console.WriteLine($""[DSL] Reg4 ([BitVecWidth(4)]) : predicat de debordement -> {(bv != null ? ""SAT"" : ""UNSAT"")}"");
+    if (bv != null)
+        Console.WriteLine($""[DSL]   Temoin : A={bv.A}, B={bv.B} -> (A+B) mod 16 = {(bv.A + bv.B) % 16} < A={bv.A}   (enveloppe)"");
+
+    // Meme requete SANS l'attribut = entiers non bornes : le debordement disparait
+    var noWidth = thCtx.NewTheorem<PlainPair>()
+        .Where(p => p.A >= 0)
+        .Where(p => p.B >= 1)
+        .Where(p => p.A + p.B < p.A)
+        .Solve();
+    Console.WriteLine($""[DSL] PlainPair (entiers non bornes) : meme predicat -> {(noWidth != null ? ""SAT"" : ""UNSAT"")}"");
+    Console.WriteLine(noWidth == null
+        ? ""[DSL]   -> UNSAT : sans largeur fixe, \"" a+b < a \"" est impossible. L'attribut EST la semantique.""
+        : ""[DSL]   -> inattendu."");
+}",,,,,,,,77c7c66a10448354,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,b4-bitvecwidth-lecture,markdown,fr,d62ac9120cfdc3da,"### Lecture B4 - l'attribut porte la theorie
+
+Les deux stacks posent **le meme predicat non-trivial** - `a + b < a` avec `b >= 1` - et arrivent au **meme double verdict** : **SAT** sur 4 bits (la somme enveloppe sous `a`), **UNSAT** sur les entiers non bornes (une somme a addend positif ne decroit jamais). La difference est **ou vit la largeur** :
+
+| Aspect | RAW (`MkBitVecSort + MkBV*`) | DSL (`[BitVecWidth(n)]` + `Solve`) |
+|---|---|---|
+| Declaration de la largeur | Imperative : `MkBitVecSort(4)` a chaque variable | Declarative : attribut sur la propriete |
+| Choix des operateurs | Explicite : `MkBVAdd`, `MkBVULT` (l'utilisateur sait que c'est modulaire) | Implicite : `+` et `<` routes vers les variantes BV (ExpressionVisitor.cs:120) |
+| Lisibilite du predicat | `MkBVULT(MkBVAdd(a,b), a)` | `r.A + r.B < r.A` (arithmetique C# naturelle) |
+| Risque d'erreur | Confondre `MkBVSLT` (signe) et `MkBVULT` (non signe) | Le routage non signe est fixe par le binding |
+| Sans largeur | (choix impossible a oublier) | Entier non borne : debordement inexprimable (UNSAT) |
+
+> **Ligne de contraste (a retenir)** : *le raw expose la sorte et les operateurs modulaires* (controle total : signe vs non signe, largeurs mixtes) ; *le DSL deplace la largeur dans le type* - l'attribut `[BitVecWidth(4)]` **est** la declaration que ""ces entiers sont des registres 4 bits"", et le debordement en decoule sans un seul appel Z3 ecrit a la main. **Meme theorie SMT** (`(_ BitVec 4)` dans les deux), **deux endroits ou la largeur est ecrite**.
+
+**Cas d'usage** : on prefere le DSL quand le modele a des **champs de largeur fixe naturels** (registres, octets de protocole, compteurs qui enveloppent) - la largeur devient une propriete du type, pas un parametre repete. On bascule en raw pour les **largeurs dynamiques**, l'arithmetique **signee**, ou l'`Extract`/`Concat` au niveau bit (cf section 5) que l'attribut ne couvre pas.",,,,,,,,d62ac9120cfdc3da,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,87b83359,markdown,fr,30c9cca6ce1d7797,"## 6. Ce que ce notebook a démontré
+
+Le débordement arithmétique est **impossible sur les entiers non bornés** (par construction
+`a+b ≥ a`) et **décidable sur les bit-vectors** (théorie SMT complète). Ce notebook a exercé
+la théorie `BitVec` jamais couverte par les notebooks 01-14 :
+
+- **Calcul** du débordement (`3e9 + 1.5e9` enveloppe à `205032704` en `uint32`, perte exacte de 2³²).
+- **Détection** pour des entrées fixes (`somme < a` ⟹ SAT = débordement confirmé).
+- **Preuve universelle** par réfutation (UNSAT) : pour tout `x,y ≥ 2³¹`, le débordement est inévitable.
+- **Réciproque** : preuve d'absence de débordement sous `p,q < 1000`.
+- **Bit-à-bit** : extraction de champs (`MkExtract`) et recherche de témoin.
+
+La leçon SMT : un solveur ne se limite pas à *trouver* des solutions (SAT) — il **certifie**
+des propriétés (UNSAT = preuve). C'est exactement la frontière entre « ça a l'air de
+marcher » (tests) et « c'est prouvé » (vérification formelle), et c'est le service que Z3
+rend à la vérification de code, à la cryptographie et à la conception matérielle.
+
+### Prochaines étapes
+
+- **Vers l'optimisation** : le notebook [11_Optimize_MaxSAT](14_Optimize_MaxSAT.ipynb)
+  aborde les théories d'optimisation ; un prolongement naturel serait les **UNSAT cores**
+  (quelles contraintes causent l'insatisfiabilité ?) pour le débogage de spécifications.
+- **Vers la vérification de programmes** : combiner BitVec avec les **quantificateurs**
+  pour vérifier des invariants de boucles (preuve de terminaison / correction de boucles
+  critiques sur des entiers machine).",,,,,,,,30c9cca6ce1d7797,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,68a82ebf,markdown,fr,5a48f0bd9c9e668e,"## 7. Exercices
+
+Trois exercices pour approfondir. Stubs incomplets (`return` / TODO) — le notebook
+s'exécute de bout en bout même non complété (convention C.1).",,,,,,,,5a48f0bd9c9e668e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,fffaa04c,markdown,fr,4c88944931213802,"### Exercice 1 — Débordement signé vs non signé
+
+La valeur `0xFFFFFFFF` vaut `4294967295` non signé mais `-1` signé (complément à 2).
+Construisez une addition qui **déborde en signé mais pas en non signé**.
+
+*Indice* : `MkBVSLT` (signed less-than) détecte le débordement signé ; `MkBVULT` (unsigned)
+le non signé. Choisissez `a, b` proches de `Int32.MaxValue = 2147483647`.",,,,,,,,4c88944931213802,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,966069a3,code,fr,bdd3cc72e536ef5e,"// Exercice 1 : compléter la démo signé-vs-non-signé
+void DemoSigneVsNonSigne(Context ctx) {
+    BitVecSort bv32 = ctx.MkBitVecSort(32);
+    // TODO etudiant : a, b tels que a+b déborde en SIGNE mais pas en non signé
+    // Etape 1 : choisir a, b (valeurs proches de Int32.MaxValue = 2147483647)
+    // Etape 2 : montrer que MkBVUGE(somme,a) est vrai (pas de débord non signé)
+    //           mais que MkBVSLT(somme, 0) est vrai (débord signé -> négatif)
+    Console.WriteLine(""Exercice 1 à compléter."");
+    return;
+}
+DemoSigneVsNonSigne(ctx);",,,,,,,,bdd3cc72e536ef5e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,fdb0a89f,markdown,fr,6cb98a2cc25bf850,"### Exercice 2 — Borne exacte du débordement
+
+Pour `a = b = t`, trouvez la plus grande valeur de `t` telle que `t + t` ne déborde **pas**
+en `BV32`. Vérifiez votre réponse avec Z3 (encoder `t + t < t` et chercher le seuil).
+
+*Indice* : `t + t < 2^32` ⟺ `t < 2^31`. La réponse est donc `2^31 - 1`. Encodez la propriété
+de débordement `MkBVULT(tt, t)` et vérifiez qu'elle devient SAT exactement à `t = 2^31`.",,,,,,,,6cb98a2cc25bf850,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,374244f4,code,fr,7f533d8de385062d,"// Exercice 2 : trouver la borne exacte du débordement pour a=b=t
+BitVecExpr t = (BitVecExpr)ctx.MkConst(""t"", bv32);
+BitVecExpr tt = ctx.MkBVAdd(t, t);
+// TODO etudiant : encoder « t + t déborde » (tt < t unsigned) et trouver la plus petite t SAT
+// Etape 1 : BoolExpr debord = ctx.MkBVULT(tt, t);
+// Etape 2 : solver.Check avec contrainte t >= 2^31 -> SAT ; avec t = 2^31-1 -> pas de débord
+Console.WriteLine(""Exercice 2 à compléter."");",,,,,,,,7f533d8de385062d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,2eabbc53,markdown,fr,8cb481abe08a6574,"### Exercice 3 — Multiplication et débordement
+
+L'addition déborde à partir de sommes `≥ 2³²`. La multiplication déborde bien plus tôt.
+Prouvez que `65536 * 65536` déborde en `BV32` (résultat mathématique = `2³²`, exactement
+la borne — donc enveloppement à 0).
+
+*Indice* : `MkBVMul`, puis vérifiez que le produit `< 65536` (unsigned) ou `== 0`.",,,,,,,,8cb481abe08a6574,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,885969ba,code,fr,c5d02efecc05704b,"// Exercice 3 : prouver que 65536 * 65536 déborde en BV32
+BitVecExpr m1 = ctx.MkBV(65536, 32);
+BitVecExpr m2 = ctx.MkBV(65536, 32);
+// TODO etudiant : BitVecExpr produit = ctx.MkBVMul(m1, m2);
+// Etape 1 : encoder le débordement (produit < m1 unsigned, ou produit == 0)
+// Etape 2 : solver.Assert(...) -> Check -> prouver
+Console.WriteLine(""Exercice 3 à compléter."");",,,,,,,,c5d02efecc05704b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/15_BitVectors_Overflow.ipynb,c0nc15fe,markdown,fr,bef757f94f17a316,"## Conclusion
+
+Ce notebook introduit la **théorie des bit-vectors**, dernier domaine SMT canonique non couvert par les notebooks 01-14 (limités aux entiers non bornés `IntSort`) et brique fondamentale de la **vérification matérielle et logicielle** (entiers bornés, débordement, arithmétique modulaire) :
+
+- Le débordement y est **décidable** (et non approché) : addition, multiplication, comparaisons et opérations bit-à-bit sont définies modulo 2ⁿ, Z3 en fait une théorie complète.
+- La **preuve par réfutation** est le patron canonique : nier la propriété universelle (« tout `x, y ≥ 2³¹` déborde ») et obtenir `UNSAT` certifie le théorème ; nier la sûreté (« `p, q < 1000` et débordement ») prouve la réciproque d'absence.
+- Les deux stacks convergent vers le **même prédicat non-trivial** `a + b < a` : l'API brute `MkBV*` câble la sorte à la main, le DSL `[BitVecWidth(n)]` déporte la largeur dans un attribut déclaratif — double verdict `SAT` sur 4 bits (enveloppement), `UNSAT` sur les entiers non bornés.
+
+**Points clés** :
+
+- Le débordement est **impossible par construction** sur les entiers non bornés (`a + b ≥ a`), mais **inévitable et calculable** sur les bit-vectors : c'est l'écart exact que la théorie `BitVec` capture.
+- `MkExtract` (extraction de champs) ouvre la modélisation des **formats binaires et protocoles**, où l'on isole un octet ou un drapeau dans un mot de 32 bits.
+- Le seuil `2³¹` (et non `2³⁰`) pour le théorème d'inévitabilité n'est pas anecdotique : `2³⁰ + 2³⁰ = 2³¹ < 2³²` ne déborde pas — la précision de la borne est elle-même une leçon de modélisation.
+
+**Référence** : la théorie `BitVec` est normalisée par SMT-LIB (logiques `QF_BV` et `BV`) et constitue le socle des **model checkers** matériels (STP, Boolector, Z3) pour la vérification de circuits et d'analyseurs statiques. La suite (notebook [16 — Real Arithmetic](16_RealArithmetic.ipynb)) quitte le domaine discret pour l'arithmétique des réels.",,,,,,,,bef757f94f17a316,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,629a0d75,markdown,fr,0c7a1abb892910f9,"# 16 — Arithmétique réelle Z3 : raisonner sur les irrationnels exacts
+
+> Notebook de la série **Z3 / SMT** (Track C#, [Z3.Linq](../Z3.Linq/) fork).
+> Démontre une seconde théorie Z3 **jamais exercée** dans les notebooks 01-15 : l'**arithmétique
+> réelle** (`RealSort`), après les bit-vectors (NB-15) et les entiers non bornés (01-14).
+> **Stack : B — API brute Microsoft.Z3** (`RealSort`, racines algébriques `root-obj`) : le raisonnement exact et la preuve par réfutation se font au niveau solveur, sous le DSL.
+
+## Pourquoi ce notebook
+
+Le README de la série définit Z3 comme un solveur qui « résout des systèmes de contraintes sur
+des **entiers**, des **réels**, des booléens et des tableaux ». Pourtant, après 15 notebooks,
+**aucun** n'avait manipulé de réels — tous utilisaient `IntSort` (non borné) ou `BV32` (borné,
+modulaire). Ce notebook comble ce trou : la théorie des réels.
+
+La différence n'est pas cosmétique. Un solveur d'entiers raisonne sur un ensemble **discret** ;
+un solveur de réels sur un ensemble **dense** (entre deux réels, il en existe toujours un
+autre). Et surtout : les réels incluent les **irrationnels** (√2, π, le nombre d'or). Un calcul
+numérique flottant n'en donne qu'une *approximation* (`1.4142…`). Z3, lui, raisonne sur les
+irrationnels de façon **exacte** — comme des *racines algébriques* de polynômes — et peut
+**prouver** des propriétés sur eux (existence, non-existence).
+
+**Prong-B (non-trivial)** : l'arithmétique réelle **linéaire** est décidable (Fourier-Motzkin /
+simplexe), mais l'arithmétique réelle **non-linéaire** est un terrain subtil — indécidable sur
+les entiers (dixième problème de Hilbert), mais **décidable sur les réels** (théorème de
+Tarski : la théorie des corps réels clos admet l'élimination des quantificateurs). C'est
+précisément cette décibabilité des réels, que ni les entiers ni les bit-vectors ne partagent,
+que ce notebook met en scène : trouver √2, prouver que `x² + 1 = 0` n'a pas de racine réelle.",,,,,,,,0c7a1abb892910f9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,d9925641,markdown,fr,9e08c6a47b3bf0c0,"## 1. La théorie des réels (SMT-LIB `Real`)
+
+Un **réel Z3** n'est pas un `double` machine (approximation à 15 chiffres, erreurs d'arrondi).
+C'est une valeur **exacte** :
+
+- les **rationnels** sont stockés comme couple `(numérateur, dénominateur)` — `1/3` reste `1/3`,
+  jamais `0.333…` ;
+- les **irrationnels algébriques** (√2, √3, racines de polynômes) sont représentés comme un
+  **objet racine** (`root-obj`) — la racine *k*-ième d'un polynôme à coefficients rationnels.
+
+C'est cette représentation exacte qui rend possible la **preuve** : un solveur flottant pourrait
+*calculer* `√2 ≈ 1.414` mais ne pourrait jamais *prouver* que `x² + 1 = 0` n'a pas de solution.",,,,,,,,9e08c6a47b3bf0c0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,a89a7a9c,code,fr,574a1960cbba703d,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq; using Microsoft.Z3; using System; using System.Text;
+Console.OutputEncoding = Encoding.UTF8;
+
+var ctx = new Context();
+RealSort rs = ctx.MkRealSort();
+Console.WriteLine($""Sorte réelle créée : {rs}"");
+
+// Un rationnel exact : 1/3 (stocké comme couple, pas comme 0.333...)
+var unTier = ctx.MkReal(1, 3);
+Console.WriteLine($""1/3 = {unTier}  (rationnel exact, pas 0.333...)"");",,,,,,,,574a1960cbba703d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,d3f670cb,markdown,fr,41f637a42202d3f1,"## 2. Arithmétique réelle linéaire : solution rationnelle exacte
+
+Résolvons un petit système linéaire sur les réels :
+
+```
+x + y = 1
+x − y = 3
+```
+
+La solution est `x = 2, y = −1` — rationnelle. Z3 la trouve **exactement** (pas d'arrondi).",,,,,,,,41f637a42202d3f1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,38d68702,code,fr,f7d645f352c83f8e,"RealExpr x = (RealExpr)ctx.MkConst(""x"", rs);
+RealExpr y = (RealExpr)ctx.MkConst(""y"", rs);
+
+var s1 = ctx.MkSolver();
+s1.Assert(ctx.MkEq(ctx.MkAdd(x, y), ctx.MkReal(1)));   // x + y = 1
+s1.Assert(ctx.MkEq(ctx.MkSub(x, y), ctx.MkReal(3)));   // x - y = 3
+Status st1 = s1.Check();
+
+Console.WriteLine($""Système x+y=1, x−y=3 : {st1}"");
+if (st1 == Status.SATISFIABLE) {
+    Console.WriteLine($""  x = {s1.Model.Eval(x, true)}"");
+    Console.WriteLine($""  y = {s1.Model.Eval(y, true)}"");
+}
+Console.WriteLine(""-> Solution rationnelle EXACTE (pas d'arrondi flottant)."");",,,,,,,,f7d645f352c83f8e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,35782d2b,markdown,fr,ec2a8d3d070c67d4,"## 3. Non-linéaire : trouver un irrationnel exact (√2)
+
+Ici l'arithmétique réelle révèle sa capacité distinctive. Demandons à Z3 un réel `xs` dont le
+carré vaut 2 :
+
+```
+xs² = 2
+```
+
+Un solveur flottant répondrait `xs ≈ 1.4142135…` et s'arrêterait là. Z3 répond différemment : il
+renvoie un **objet racine algébrique** — la représentation *exacte* de √2 comme racine d'un
+polynôme. √2 n'est pas rationnel (preuve classique par l'absurde), donc il **n'existe pas** de
+représentation `p/q` — mais il existe une représentation *algébrique*, et c'est celle que Z3
+manipule.",,,,,,,,ec2a8d3d070c67d4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,9c196b82,code,fr,2b9132a147a3a7ff,"// Trouver xs tel que xs^2 = 2 (l'irrationnel √2)
+RealExpr xs = (RealExpr)ctx.MkConst(""xs"", rs);
+var s2 = ctx.MkSolver();
+s2.Assert(ctx.MkEq(ctx.MkMul(xs, xs), ctx.MkReal(2)));   // xs^2 = 2
+Status st2 = s2.Check();
+
+Console.WriteLine($""« xs² = 2 » : {st2}"");
+if (st2 == Status.SATISFIABLE) {
+    var w = s2.Model.Eval(xs, true);
+    Console.WriteLine($""  xs = {w}"");
+    Console.WriteLine(""  -> Ce n'est PAS 1.4142... mais une RACINE ALGÉBRIQUE exacte."");
+    Console.WriteLine(""     (root-obj = k-ième racine d'un polynôme à coeff. rationnels)"");
+}",,,,,,,,2b9132a147a3a7ff,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,87d8e8fd,markdown,fr,6ba716b3cd79d870,"## 4. Prouver l'absence de racine réelle (UNSAT)
+
+La capacité symétrique : prouver qu'une équation **n'a pas** de solution réelle. L'exemple
+canonique :
+
+```
+xn² + 1 = 0
+```
+
+Sur les **complexes**, cela a deux solutions (`xn = ±i`). Sur les **réels**, `xn² ≥ 0` donc
+`xn² + 1 ≥ 1 > 0` — impossible. Z3 le **prouve** (UNSAT), par élimination des quantificateurs
+sur la théorie des corps réels clos (Tarski). C'est l'application directe de la technique de
+réfutation vue au notebook 15 : on asserte l'existence d'une solution, et l'UNSAT certifie
+qu'elle n'existe pas.",,,,,,,,6ba716b3cd79d870,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,aabf7f80,code,fr,aa7e2af6e2aaf7f7,"// Prouver que xn^2 + 1 = 0 n'a PAS de solution réelle
+RealExpr xn = (RealExpr)ctx.MkConst(""xn"", rs);
+var s3 = ctx.MkSolver();
+s3.Assert(ctx.MkEq(
+    ctx.MkAdd(ctx.MkMul(xn, xn), ctx.MkReal(1)),   // xn^2 + 1
+    ctx.MkReal(0)                                   // = 0
+));
+Status st3 = s3.Check();
+
+Console.WriteLine($""« xn² + 1 = 0 » sur les réels : {st3}"");
+Console.WriteLine(st3 == Status.UNSATISFIABLE
+    ? ""  -> UNSAT : Z3 PROUVE qu'il n'existe pas de racine réelle.""
+    : ""  -> inattendu (devrait être impossible sur ℝ)."");",,,,,,,,aa7e2af6e2aaf7f7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,d9272d9b,markdown,fr,b9de228f08778c7c,"## 5. Application géométrique : l'inégalité triangulaire
+
+La théorie des réels est l'outil naturel pour le **raisonnement géométrique** (distances,
+aires, inégalités). Un exemple : trois longueurs `a, b, c` forment-elles un triangle ? La
+condition nécessaire et suffisante est l'**inégalité triangulaire** : chaque côté est plus court
+que la somme des deux autres (`a + b ≥ c`, `a + c ≥ b`, `b + c ≥ a`).
+
+- `3, 4, 5` : oui (triangle rectangle pythagoricien) ;
+- `1, 2, 5` : non (`1 + 2 = 3 < 5`, le plus long côté est trop long).
+
+Z3 tranche l'un et l'autre sur les réels, exactement.",,,,,,,,b9de228f08778c7c,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,9c16a1c6,code,fr,a1afd66e8b3b6426,"// Trois longueurs forment-elles un triangle ? (inégalité triangulaire)
+BoolExpr Triangle(Context c, RealExpr a, RealExpr b, RealExpr e) {
+    return c.MkAnd(
+        c.MkGe(c.MkAdd(a, b), e),   // a + b >= e
+        c.MkGe(c.MkAdd(a, e), b),   // a + e >= b
+        c.MkGe(c.MkAdd(b, e), a)    // b + e >= a
+    );
+}
+
+// Triangle (3, 4, 5) ?
+var sA = ctx.MkSolver();
+sA.Assert(Triangle(ctx, ctx.MkReal(3), ctx.MkReal(4), ctx.MkReal(5)));
+Status stA = sA.Check();
+Console.WriteLine($""Triangle(3, 4, 5) : {stA}"");
+
+// Triangle (1, 2, 5) ?
+var sB = ctx.MkSolver();
+sB.Assert(Triangle(ctx, ctx.MkReal(1), ctx.MkReal(2), ctx.MkReal(5)));
+Status stB = sB.Check();
+Console.WriteLine($""Triangle(1, 2, 5) : {stB}"");
+Console.WriteLine(stB == Status.UNSATISFIABLE
+    ? ""  -> UNSAT : impossible (1 + 2 = 3 < 5, le plus long côté est trop long).""
+    : """");",,,,,,,,a1afd66e8b3b6426,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,b7-rational-intro,markdown,fr,3c834a76120a8883,"## B7 - Rationnels exacts (DSL `Rational`)
+
+La section 2 a montré la solution *rationnelle exacte* d'un système linéaire ; mais dès qu'on **écrit une constante** rationnelle non terminante dans une contrainte, un piège guette. Un littéral C# `1.0 / 3.0` est un `double` : stringifié, il devient `""0.3333333333333333""` = 3333333333333333/10^16, une **approximation terminante** - et `3 * x == 1` devient alors **UNSAT** (l'approximation ne se remultiplie pas exactement en 1). Le binding Z3.Linq offre [`Rational.Of(num, den)`](../Z3.Linq/solutions/Z3.Linq/Rational.cs#L56) : la fraction exacte `num/den` est portée telle quelle dans l'arbre d'expression et émise en `MkReal(""num/den"")` ([`ExpressionVisitor.cs:660`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L660)), là où un `double` nu tombe sur le chemin lossy `MkReal(Convert.ToString(...))` ([`ExpressionVisitor.cs:679`](../Z3.Linq/solutions/Z3.Linq/ExpressionVisitor.cs#L679)).
+
+> **Stack : A + B - pourquoi**. Côté raw, l'exactitude est un choix au **site d'appel** : `MkReal(1, 3)` (exact, déjà utilisé en section 2) vs `MkReal(""0.3333..."")` (lossy). Côté DSL, `Rational.Of(1,3)` **porte** la fraction exacte tandis qu'un littéral `1.0/3.0` glisse silencieusement vers le lossy - le contraste (SAT exact / UNSAT approché) rend visible ce que l'exactitude achète sur le **même prédicat** `x == 1/3` conjoint à `3x == 1`.",,,,,,,,3c834a76120a8883,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,b7-rational-code,code,fr,dd18de2505e477ba,"// B7 - Rationnels exacts ""Rational"" : deux stacks sur le MEME predicat x == 1/3 ET 3*x == 1.
+//   - EXACT (1/3 porte comme fraction) -> SATISFIABLE (3 * (1/3) == 1 exactement)
+//   - LOSSY (1/3 issu d'un double CLR)  -> UNSATISFIABLE (l'approximation ne remultiplie pas en 1)
+// Ce contraste EST ce que l'exactitude achete : la meme requete change de verdict selon l'ecriture.
+
+// Classe au niveau cellule (requise par NewTheorem<T>) : un membre reel.
+public class RealCell { public double X { get; set; } }
+
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : l'exactitude est un choix explicite au site d'appel
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    RealSort rsB = z3.MkRealSort();
+
+    // Exact : MkReal(1, 3) porte la fraction 1/3
+    RealExpr xe = (RealExpr)z3.MkConst(""xe"", rsB);
+    var sExact = z3.MkSolver();
+    sExact.Assert(z3.MkEq(xe, z3.MkReal(1, 3)));                        // x == 1/3 (exact)
+    sExact.Assert(z3.MkEq(z3.MkMul(xe, z3.MkReal(3)), z3.MkReal(1)));   // 3*x == 1
+    Console.WriteLine($""[RAW] Exact  MkReal(1,3)          : \"" x==1/3 ET 3x==1 \"" -> {sExact.Check()}"");
+
+    // Lossy : MkReal a partir de la string d'un double CLR
+    string lossy = (1.0 / 3.0).ToString(System.Globalization.CultureInfo.InvariantCulture);
+    RealExpr xl = (RealExpr)z3.MkConst(""xl"", rsB);
+    var sLossy = z3.MkSolver();
+    sLossy.Assert(z3.MkEq(xl, z3.MkReal(lossy)));                       // x == 0.3333...  (approche)
+    sLossy.Assert(z3.MkEq(z3.MkMul(xl, z3.MkReal(3)), z3.MkReal(1)));   // 3*x == 1
+    Console.WriteLine($""[RAW] Lossy  MkReal(\""{lossy}\"") : meme predicat -> {sLossy.Check()}   (approximation)"");
+}
+
+// =====================================================================
+// BLOC DSL (Z3.Linq) : Rational.Of porte l'exact ; un double nu glisse vers le lossy
+// =====================================================================
+{
+    using var thCtx = new Z3Context();
+
+    // Exact : Rational.Of(1,3) emis en MkReal(""1/3"") (ExpressionVisitor.cs:660)
+    var exact = thCtx.NewTheorem<RealCell>()
+        .Where(c => c.X == Rational.Of(1, 3))
+        .Where(c => c.X * 3.0 == 1.0)
+        .Solve();
+    Console.WriteLine($""[DSL] Rational.Of(1,3)  : predicat exact -> {(exact != null ? ""SAT"" : ""UNSAT"")}"");
+    if (exact != null)
+        Console.WriteLine($""[DSL]   Temoin : le modele Z3 tient X = 1/3 exact (remultiplie en 1)"");
+
+    // Lossy : le meme predicat avec le littéral double 1.0/3.0 (ExpressionVisitor.cs:679)
+    var approx = thCtx.NewTheorem<RealCell>()
+        .Where(c => c.X == 1.0 / 3.0)
+        .Where(c => c.X * 3.0 == 1.0)
+        .Solve();
+    Console.WriteLine($""[DSL] double 1.0/3.0     : meme predicat -> {(approx != null ? ""SAT"" : ""UNSAT"")}"");
+    Console.WriteLine(approx == null
+        ? ""[DSL]   -> UNSAT : le double stringifie n'est PAS 1/3. Rational.Of porte l'exactitude, le littéral la perd.""
+        : ""[DSL]   -> inattendu."");
+}",,,,,,,,dd18de2505e477ba,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,b7-rational-lecture,markdown,fr,dac09ac766a4b720,"### Lecture B7 - l'exactitude vit dans la constante
+
+Les deux stacks posent le **même prédicat** - `x == 1/3` conjoint à `3x == 1` - et arrivent au **même double verdict** : **SAT** quand 1/3 est exact (il se remultiplie en 1), **UNSAT** quand 1/3 vient d'un `double` (l'approximation terminante casse l'égalité). La différence est **où l'exactitude est décidée** :
+
+| Aspect | RAW (`MkReal`) | DSL (`Rational` / `double`) |
+|---|---|---|
+| Constante exacte | Explicite : `MkReal(1, 3)` (num, den) | `Rational.Of(1, 3)` porté en `MkReal(""1/3"")` |
+| Constante lossy | Explicite aussi : `MkReal(""0.333..."")` | **Implicite** : un littéral `1.0/3.0` glisse vers le lossy |
+| Où se joue le piège | Au site d'appel (`MkReal(1,3)` vs string) | Au **type** de la constante (`Rational` vs `double`) |
+| Risque | Écrire `MkReal(x.ToString())` par réflexe | Oublier `Rational.Of` et laisser un `double` nu |
+
+> **Ligne de contraste (à retenir)** : *le raw rend le choix exact/lossy visible à chaque `MkReal`* ; *le DSL déplace ce choix dans le **type** de la constante* - `Rational.Of(1,3)` **est** la déclaration « cette constante est la fraction exacte 1/3 », alors qu'un `double` nu emprunte silencieusement le chemin approché. **Même théorie des réels**, deux manières d'y injecter une constante non terminante.
+
+**Cas d'usage** : `Rational` est indispensable dès qu'une contrainte compare à une fraction non terminante (`1/3`, `2/7`, taux, ratios) - sinon le `double` intermédiaire fausse le verdict sans le moindre avertissement. Pour les décimales terminantes (`0.5`, `0.25`), le `double` suffit (leur stringification est exacte).",,,,,,,,dac09ac766a4b720,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,f1ed9e87,markdown,fr,cf436d57c6dd2eac,"## 6. Ce que ce notebook a démontré
+
+L'arithmétique réelle est la théorie qui distingue Z3 des solveurs d'entiers et des bit-vectors :
+
+- **Rationnels exacts** : `1/3` reste `1/3`, jamais arrondi (section 2).
+- **Irrationnels exacts** : √2 renvoyé comme **objet racine algébrique**, pas comme approximation
+  flottante (section 3) — la capacité distinctive que le calcul numérique ne possède pas.
+- **Preuve d'impossibilité** : `x² + 1 = 0` n'a pas de racine réelle, prouvé par UNSAT (section 4) —
+  par élimination des quantificateurs sur les corps réels clos (Tarski).
+- **Raisonnement géométrique** : l'inégalité triangulaire tranchée sur les réels (section 5).
+
+La leçon SMT, en regard du notebook 15 (bit-vectors) : chaque **théorie** de Z3 ouvre une classe
+de problèmes que les autres théories ne sauraient formaliser. Les bit-vectors capturent le
+débordement modulaire des entiers machine ; les réels capturent le **continu** et l'**exactitude
+algébrique**. C'est cette pluralité de théories — et leur combinatoire — qui fait de Z3 un
+solveur universel de vérification, du matériel (bit-vectors) à la géométrie (réels).
+
+### Prochaines étapes
+
+- **Vers les preuves** : un prolongement naturel serait les **UNSAT cores** — non plus seulement
+  *prouver* l'insatisfiabilité (sections 4-5), mais **expliquer** quelles contraintes précises
+  la causent (utile pour déboguer une spécification surcontrainte).
+- **Vers la combinaison de théories** : mélanger réels et entiers (arithmétique mixte) ou réels
+  et bit-vectors — le terrain réel des vérificateurs industriels.",,,,,,,,cf436d57c6dd2eac,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,17a87285,markdown,fr,27f3a04551a3c156,"## 7. Exercices
+
+Trois exercices pour approfondir. Stubs incomplets — le notebook s'exécute de bout en bout même
+non complété (convention C.1).",,,,,,,,27f3a04551a3c156,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,8f0843d3,markdown,fr,0e1d47ff6841baa0,"### Exercice 1 — Racine cubique de 2
+
+Trouvez un réel `c` tel que `c³ = 2` (la racine cubique de 2, irrationnelle). Observez la forme du
+témoignage renvoyé par Z3 et comparez-la à celle de √2 (section 3).
+
+*Indice* : `ctx.MkMul(c, ctx.MkMul(c, c))` pour `c³`. Le témoignage devrait être un nouvel
+`root-obj` (polynôme de degré 3).",,,,,,,,0e1d47ff6841baa0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,0d430b20,code,fr,bc4dba7ccd681443,"// Exercice 1 : trouver c tel que c^3 = 2 (racine cubique de 2)
+RealExpr c = (RealExpr)ctx.MkConst(""c"", rs);
+// TODO etudiant : encoder c^3 = 2 et afficher le témoignage
+// Etape 1 : RealExpr c3 = ctx.MkMul(c, ctx.MkMul(c, c));
+// Etape 2 : solver.Assert(ctx.MkEq(c3, ctx.MkReal(2)));
+// Etape 3 : solver.Check() + afficher le root-obj (degré 3 vs degré 2 pour √2)
+Console.WriteLine(""Exercice 1 à compléter."");",,,,,,,,bc4dba7ccd681443,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,06cf09c3,markdown,fr,5c06a2b3106fbbae,"### Exercice 2 — Discriminant et nombre de racines
+
+Pour une équation quadratique `ax² + bx + c = 0`, le **discriminant** `Δ = b² − 4ac` détermine le
+nombre de racines réelles : `Δ > 0` → deux racines, `Δ = 0` → une (double), `Δ < 0` → aucune.
+Utilisez Z3 pour vérifier que `x² − 3x + 2 = 0` a (au moins) une racine réelle, et que
+`x² + x + 1 = 0` n'en a aucune.
+
+*Indice* : assertez l'existence d'un `x` solution et observez SAT vs UNSAT. Pour `x² + x + 1`,
+le discriminant vaut `1 − 4 = −3 < 0`.",,,,,,,,5c06a2b3106fbbae,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,96ff38d6,code,fr,5e413f2d0a6053d3,"// Exercice 2 : discriminant et racines réelles
+RealExpr q = (RealExpr)ctx.MkConst(""q"", rs);
+// TODO etudiant : (a) prouver que q^2 - 3q + 2 = 0 a une racine réelle (SAT)
+//                 (b) prouver que q^2 + q + 1 = 0 n'en a aucune (UNSAT)
+// Etape 1 : encoder chaque polynôme = 0
+// Etape 2 : solver.Check() -> SAT (deux racines: 1 et 2) puis UNSAT (Δ = -3 < 0)
+Console.WriteLine(""Exercice 2 à compléter."");",,,,,,,,5e413f2d0a6053d3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,c65ddece,markdown,fr,31c22d08c9e1024e,"### Exercice 3 — Distance minimale (optimisation sur les réels)
+
+Trouvez le point `(x, y)` le plus proche de l'origine `(0, 0)` parmi ceux qui satisfont
+`x + y = 4`. Géométriquement, c'est le projeté orthogonal — la solution est `(2, 2)` à distance
+`√8`. Encodez la **minimisation** de `x² + y²` sous la contrainte `x + y = 4`.
+
+*Indice* : `ctx.MkOptimize()` puis `opt.MkMinimize(ctx.MkAdd(ctx.MkMul(x,x), ctx.MkMul(y,y)))`.
+Le minimum exact vaut `8` (atteint en `x = y = 2`).",,,,,,,,31c22d08c9e1024e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/16_RealArithmetic.ipynb,3f641d33,code,fr,fb80304af4391c4b,"// Exercice 3 : minimiser x^2 + y^2 sous x + y = 4 (point le plus proche de l'origine)
+RealExpr px = (RealExpr)ctx.MkConst(""px"", rs);
+RealExpr py = (RealExpr)ctx.MkConst(""py"", rs);
+// TODO etudiant : minimiser px^2 + py^2  sous  px + py = 4
+// Etape 1 : var opt = ctx.MkOptimize();
+// Etape 2 : opt.Assert(ctx.MkEq(ctx.MkAdd(px, py), ctx.MkReal(4)));
+// Etape 3 : opt.MkMinimize(ctx.MkAdd(ctx.MkMul(px,px), ctx.MkMul(py,py)));
+// Etape 4 : opt.Check() -> minimum exact = 8 en px = py = 2 (distance √8)
+Console.WriteLine(""Exercice 3 à compléter."");",,,,,,,,fb80304af4391c4b,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,9e82d5d8,markdown,fr,71781298ad9964a5,"# 17 — UNSAT cores Z3 : expliquer l'insatisfiabilité (le « pourquoi »)
+
+> Notebook de la série **Z3 / SMT** (Track C#, [Z3.Linq](../Z3.Linq/) fork).
+> Troisième et dernière théorie-capacité **jamais exercée** dans les notebooks 01-16 :
+> les **UNSAT cores** — non plus *décider* qu'une formule est insatisfiable, mais **expliquer
+> quelles contraintes** précisément la rendent insatisfiable.
+> **Stack : B — API brute Microsoft.Z3** (`Check(assumptions)`/`UnsatCore`) : l'extraction de core n'a pas d'équivalent dans le DSL Z3.Linq.
+
+## Pourquoi ce notebook
+
+Les notebooks 15 (bit-vectors) et 16 (réels) ont mis en scène la distinction cardinale **SAT vs
+UNSAT** : un solveur ne *trouve* pas seulement des solutions, il **certifie** leur
+impossibilité. Mais une question reste ouverte : quand Z3 répond UNSAT, **pourquoi** ?
+L'utilisateur a écrit une dizaine de contraintes ; lesquelles, précisément, se contredisent ?
+
+C'est le service de l'**UNSAT core** : parmi les contraintes (hypothèses) fournies, Z3 isole le
+**sous-ensemble minimal** qui suffit à provoquer l'insatisfiabilité. Les contraintes
+*irrelevantes* (qui ne participent pas au conflit) sont écartées du core. C'est l'outil canonique
+du **débogage de spécifications surcontraintes** : plutôt que de lire 100 contraintes à la main
+pour trouver l'incohérence, on laisse le solveur pointer les coupables.
+
+**Prong-B (non-trivial)** : le calcul d'un UNSAT core est un service algorithmique distinct de
+la simple décision SAT/UNSAT. Il repose sur la **résolution assimilable** (clauses
+apprises/`learned clauses`) et l'extraction du sous-ensemble d'hypothèses impliqué dans la
+dérivation du vide. Aucun des notebooks 01-16 ne l'exerçait — tous s'arrêtaient au verdict
+(SAT/UNSAT), jamais à l'explication.",,,,,,,,71781298ad9964a5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,6f927439,markdown,fr,db2fbc005eefe084,"## 1. Du verdict à l'explication
+
+Jusqu'ici, la série posait une question binaire :
+
+> *Ce système de contraintes a-t-il une solution ?* → **SAT** (oui, voici un témoin) ou **UNSAT**
+> (non, prouvé impossible).
+
+Mais pour un ingénieur qui **écrit** la spécification, UNSAT est souvent un *bug de
+modélisation* : il a écrit une contrainte trop forte, ou deux contraintes incompatibles. La
+réponse « impossible » ne l'aide pas à corriger. L'UNSAT core répond à la vraie question :
+
+> *Quelles contraintes, parmi celles que j'ai écrites, se contredisent ?*
+
+La mécanique : on fournit les contraintes comme des **hypothèses** (`Check(assumptions)`), et si
+le système est insatisfiable, Z3 renvoie le **core** — le sous-ensemble minimal d'hypothèses
+suffisant à prouver l'insatisfiabilité.",,,,,,,,db2fbc005eefe084,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,2dce6d43,code,fr,911cf4173f35b232,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq; using Microsoft.Z3; using System;
+Console.OutputEncoding = Encoding.UTF8;
+
+var ctx = new Context();
+
+// Rappel : un système contradictoire est UNSAT (verdict, sans explication)
+var s0 = ctx.MkSolver();
+BoolExpr a = ctx.MkBoolConst(""a"");
+BoolExpr b = ctx.MkBoolConst(""b"");
+s0.Assert(ctx.MkImplies(a, b));   // a -> b
+s0.Assert(a);                      // a
+s0.Assert(ctx.MkNot(b));           // !b   (contredit a -> b)
+Console.WriteLine($""« a->b, a, !b » : {s0.Check()}  (verdict : impossible)"");
+Console.WriteLine(""-> Z3 dit NON, mais ne dit pas (encore) POURQUOI."");",,,,,,,,911cf4173f35b232,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,fce99c54,markdown,fr,bf98f91b8cd132bd,"## 2. Le core : quelles contraintes se contredisent ?
+
+Maintenant, fournissons les contraintes comme **hypothèses** et demandons le core. Trois
+contraintes sur un entier `x` :
+
+```
+x ≥ 3     (borne inférieure)
+x ≤ 5     (borne supérieure)
+x = 10    (valeur imposée)
+```
+
+Le système est UNSAT (`x = 10` viole `x ≤ 5`). Mais **laquelle** des contraintes est coupable ?
+L'UNSAT core isole le sous-ensemble minimal conflictuel.",,,,,,,,bf98f91b8cd132bd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,cd85f9ba,code,fr,2e0ec0b2369cd947,"// Trois contraintes sur x : lesquelles se contredisent ?
+IntExpr x = ctx.MkIntConst(""x"");
+
+BoolExpr c1 = ctx.MkGe(x, ctx.MkInt(3));    // x >= 3
+BoolExpr c2 = ctx.MkLe(x, ctx.MkInt(5));    // x <= 5
+BoolExpr c3 = ctx.MkEq(x, ctx.MkInt(10));   // x = 10
+
+// On fournit les contraintes COMME HYPOTHÈSES (pas Assert dur) -> Check(assumptions)
+BoolExpr[] assumptions = new BoolExpr[]{ c1, c2, c3 };
+var s1 = ctx.MkSolver();
+Status st = s1.Check((System.Collections.Generic.IEnumerable<BoolExpr>)assumptions);
+
+Console.WriteLine($""« x>=3, x<=5, x=10 » : {st}"");
+Console.WriteLine();
+if (st == Status.UNSATISFIABLE) {
+    Console.WriteLine(""UNSAT CORE (contraintes conflictuelles, sous-ensemble MINIMAL) :"");
+    foreach (var c in s1.UnsatCore) {
+        Console.WriteLine($""  - {c}"");
+    }
+}",,,,,,,,2e0ec0b2369cd947,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,48b992d2,markdown,fr,d85ca91ac78a1556,"## 3. Le core est MINIMAL : les contraintes irrelevantes sont écartées
+
+L'observation clé : le core de la section 2 contenait **`x ≤ 5` et `x = 10`**, mais **pas**
+`x ≥ 3`. Ce n'est pas un oubli — c'est que `x ≥ 3` est **irrelevant** pour le conflit : la
+contradiction vient uniquement de la borne supérieure et de la valeur imposée. Retirer `x ≥ 3`
+ne change rien au verdict UNSAT.
+
+C'est la propriété fondamentale d'un UNSAT core : il identifie **exactement** les contraintes
+qui participent au conflit, et ignore celles qui sont compatibles (même si elles figurent dans
+le système). Pour un débogueur, c'est inestimable : sur 100 contraintes, le core peut n'en
+contenir que 2.
+
+Vérifions : le système `{x ≤ 5, x = 10}` (sans `x ≥ 3`) est-il déjà UNSAT ?",,,,,,,,d85ca91ac78a1556,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,529bb748,code,fr,04b433f1267ce442,"// Vérifions : {x<=5, x=10} SEUL (sans x>=3) est-il déjà UNSAT ?
+IntExpr y = ctx.MkIntConst(""y"");
+BoolExpr p1 = ctx.MkLe(y, ctx.MkInt(5));    // y <= 5
+BoolExpr p2 = ctx.MkEq(y, ctx.MkInt(10));   // y = 10
+
+var s2 = ctx.MkSolver();
+Status st2 = s2.Check((System.Collections.Generic.IEnumerable<BoolExpr>)(new BoolExpr[]{ p1, p2 }));
+
+Console.WriteLine($""« y<=5, y=10 » (sans y>=3) : {st2}"");
+if (st2 == Status.UNSATISFIABLE) {
+    Console.WriteLine(""-> CONFIRMÉ : la paire {x<=5, x=10} suffit au conflit."");
+    Console.WriteLine(""   Z3 avait donc raison d'EXCLURE « x>=3 » du core : elle est irrelevant."");
+}",,,,,,,,04b433f1267ce442,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,bdadc12e,markdown,fr,ae22aad08753a98f,"## 4. Application : déboguer une spécification surcontrainte
+
+Cas d'usage réel : un planificateur de réunion pose 5 contraintes et obtient UNSAT. Lequel
+relâcher ? Sans core, il faut tester les combinaisons à la main. Avec le core, Z3 pointe la
+(les) contrainte(s) coupable(s).
+
+Modélisons : une réunion doit avoir lieu à une heure `h` (entière) satisfaisant :
+
+1. `h ≥ 9` (pas avant 9h)
+2. `h ≤ 17` (pas après 17h)
+3. `h ≠ 12` (pas pendant la pause déjeuner)
+4. `h = 12` (le seul créneau libre de l'animateur)  ← contradiction avec la 3
+5. `h ≥ 9` (redondant, répète la 1)
+
+Z3 isole le conflit réel (`h ≠ 12` vs `h = 12`) et ignore les contraintes compatibles.",,,,,,,,ae22aad08753a98f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,ec039ea5,code,fr,4810edc41444ad25,"// Spécification surcontrainte : laquelle relâcher ?
+IntExpr h = ctx.MkIntConst(""h"");
+
+BoolExpr[] specs = new BoolExpr[] {
+    ctx.MkGe(h, ctx.MkInt(9)),                    // 1. h >= 9
+    ctx.MkLe(h, ctx.MkInt(17)),                   // 2. h <= 17
+    ctx.MkNot(ctx.MkEq(h, ctx.MkInt(12))),        // 3. h != 12 (pause déjeuner)
+    ctx.MkEq(h, ctx.MkInt(12)),                   // 4. h = 12 (animateur)  <-- conflit
+    ctx.MkGe(h, ctx.MkInt(9))                     // 5. h >= 9 (redondant)
+};
+
+var s3 = ctx.MkSolver();
+Status st3 = s3.Check((System.Collections.Generic.IEnumerable<BoolExpr>)specs);
+Console.WriteLine($""Spécification (5 contraintes) : {st3}"");
+Console.WriteLine();
+if (st3 == Status.UNSATISFIABLE) {
+    Console.WriteLine(""Core = les contraintes qui PARTICIPENT au conflit :"");
+    int n = 0;
+    foreach (var c in s3.UnsatCore) {
+        Console.WriteLine($""  COUPABLE : {c}"");
+        n++;
+    }
+    Console.WriteLine();
+    Console.WriteLine($""-> Sur 5 contraintes, {n} seulement sont en conflit."");
+    Console.WriteLine(""   Les autres (h>=9, h<=17, h>=9 redondant) sont COMPATIBLES -> Z3 les ignore."");
+    Console.WriteLine(""   Action : relâcher la contrainte 'h=12' (animateur) OU 'h!=12' (pause)."");
+}",,,,,,,,4810edc41444ad25,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,b6-explain-intro,markdown,fr,0536be799ee466aa,"## B6 - Cores UNSAT côté DSL (`Theorem<T>.Explain()`)
+
+Tout ce notebook lit le core par l'API brute : `solver.Check(assumptions)` puis `solver.UnsatCore`. Longtemps le DSL Z3.Linq n'avait **pas** d'équivalent - `.Solve()` réduit *tout* échec à `null` (« insatisfiable » et « le solveur n'a pas su décider » deviennent indistinguables, et le *pourquoi* est perdu). Le binding ajoute désormais une surface diagnostique **parallèle et non-cassante** : [`Theorem<T>.Explain()`](../Z3.Linq/solutions/Z3.Linq/Explanation.cs#L41) renvoie une [`Explanation`](../Z3.Linq/solutions/Z3.Linq/Explanation.cs#L41) qui distingue [`SolveStatus`](../Z3.Linq/solutions/Z3.Linq/Explanation.cs#L11) `Satisfiable` / `Unsatisfiable` / `Unknown` et, sur UNSAT, expose le **core minimal** sous forme de [`ConstraintRef`](../Z3.Linq/solutions/Z3.Linq/Explanation.cs#L29) `(Index, Expression)` - le sous-ensemble contradictoire des `.Where` durs, avec leur expression source. `.Solve()` reste inchangé.
+
+> **Stack : A + B - pourquoi**. Ce bloc corrige un cadrage vieilli du tableau A/B (« UNSAT cores = sans équivalent LINQ ») : le core UNSAT **a maintenant** une écriture DSL. Le raw `Check(assumptions) + UnsatCore` **matérialise** le mécanisme (contraintes fournies comme hypothèses traçables) ; `.Explain()` **le déclare** en LINQ, en portant en plus l'expression source de chaque coupable. Le contraste est le **même core minimal** (`{#0, #2}`, la contrainte innocente `#1` écartée) obtenu des deux côtés sur le même système.",,,,,,,,0536be799ee466aa,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,b6-explain-code,code,fr,8443fba3b716d07e,"// B6 - Cores UNSAT côté DSL ""Explain()"" : deux stacks sur le MEME systeme sur-contraint.
+//   x == 1  (contrainte #0)   |   x >= 0  (contrainte #1, INNOCENTE)   |   x == 2  (contrainte #2)
+// Le systeme est UNSAT ; le core MINIMAL est {#0, #2} : Z3 ecarte #1, non impliquee dans le conflit.
+// Le meme core minimal sort du raw (Check(assumptions)+UnsatCore) et du DSL (Explain().UnsatCore).
+
+// Classe au niveau cellule (requise par NewTheorem<T>).
+public class Cell { public int X { get; set; } }
+
+// =====================================================================
+// BLOC RAW (API brute Microsoft.Z3) : contraintes fournies comme hypotheses tracables
+// =====================================================================
+{
+    using var z3 = new Microsoft.Z3.Context();
+    IntExpr xr = z3.MkIntConst(""x"");
+    Microsoft.Z3.BoolExpr r0 = z3.MkEq(xr, z3.MkInt(1));   // #0 : x == 1
+    Microsoft.Z3.BoolExpr r1 = z3.MkGe(xr, z3.MkInt(0));   // #1 : x >= 0 (innocente)
+    Microsoft.Z3.BoolExpr r2 = z3.MkEq(xr, z3.MkInt(2));   // #2 : x == 2
+    var sr = z3.MkSolver();
+    var assumptions = new Microsoft.Z3.BoolExpr[] { r0, r1, r2 };
+    Status st = sr.Check((System.Collections.Generic.IEnumerable<Microsoft.Z3.BoolExpr>)assumptions);
+    Console.WriteLine($""[RAW] Check(assumptions) : {st}"");
+    Console.Write(""[RAW]   UnsatCore = { "");
+    foreach (var c in sr.UnsatCore) Console.Write(c + ""  "");
+    Console.WriteLine(""}   (x>=0 exclu du core)"");
+}
+
+// =====================================================================
+// BLOC DSL (Z3.Linq) : la meme explication en LINQ, avec l'expression source de chaque coupable
+// =====================================================================
+{
+    using var thCtx = new Z3Context();
+    var explanation = thCtx.NewTheorem<Cell>()
+        .Where(c => c.X == 1)   // #0
+        .Where(c => c.X >= 0)   // #1 (innocente)
+        .Where(c => c.X == 2)   // #2
+        .Explain();
+    Console.WriteLine($""[DSL] Explain().Status : {explanation.Status}"");
+    Console.WriteLine(""[DSL]   UnsatCore (core minimal) :"");
+    foreach (var cr in explanation.UnsatCore)
+        Console.WriteLine($""[DSL]     {cr}"");   // ConstraintRef.ToString() = ""#Index: Expression""
+    // Indices coupables (sans System.Linq)
+    var idx = new System.Text.StringBuilder();
+    foreach (var cr in explanation.UnsatCore) { if (idx.Length > 0) idx.Append("",""); idx.Append(cr.Index); }
+    Console.WriteLine($""[DSL]   -> indices coupables = {{{idx}}}  (#1 x>=0 exclu du core minimal)"");
+}",,,,,,,,8443fba3b716d07e,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,b6-explain-lecture,markdown,fr,9ae2595fc3a0662d,"### Lecture B6 - deux surfaces, un même core minimal
+
+Les deux stacks partent du **même système sur-contraint** (`x==1`, `x>=0`, `x==2`) et isolent le **même core minimal** `{#0, #2}` - la contrainte innocente `#1` (`x>=0`, satisfiable seule) est écartée. La différence est **ce que chaque surface rend** :
+
+| Aspect | RAW (`Check(assumptions)` + `UnsatCore`) | DSL (`Explain()`) |
+|---|---|---|
+| Verdict | `Status` (Sat/Unsat) — `Unknown` non distingué de `Unsat` par `Solve()` | `SolveStatus` : **Sat / Unsat / Unknown** explicitement distingués |
+| Core | `IEnumerable<BoolExpr>` (les termes Z3 fournis comme hypothèses) | `IReadOnlyList<ConstraintRef>` : **index + expression source** du `.Where` |
+| Traçabilité | l'utilisateur doit relier chaque BoolExpr à son intention | chaque coupable porte sa position (`#Index`) et son texte |
+| `.Solve()` | inchangé | inchangé (`Explain()` est une surface parallèle) |
+
+> **Ligne de contraste (à retenir)** : *le raw expose le mécanisme Z3 des cores* (assumptions traçables passées à `Check`) ; *le DSL en fait un diagnostic de première classe* - `Explain()` distingue les trois statuts et renvoie le core comme une liste de `ConstraintRef (Index, Expression)`, si bien qu'on sait non seulement *qu'*il y a conflit mais *quelles lignes `.Where`* le portent. Ce bloc **met à jour** le cadrage historique (« UNSAT cores : sans équivalent LINQ ») : le core a désormais une écriture DSL ; seule la *preuve par réfutation* (block-and-resolve manuel) reste l'apanage du raw.
+
+**Cas d'usage** : `Explain()` est l'outil de débogage de spécifications sur-contraintes quand on travaille déjà en DSL - on garde la lisibilité des `.Where` et on obtient le sous-ensemble coupable sans redescendre à l'API brute. On bascule en raw pour la *preuve par réfutation* (prouver l'unicité d'une solution par UNSAT du complément), que `Explain()` ne couvre pas.",,,,,,,,9ae2595fc3a0662d,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,03bd550c,markdown,fr,8adf18c20d766911,"## 5. Ce que ce notebook a démontré
+
+L'UNSAT core complète l'arc des **trois capacités** de Z3 ouvertes par les notebooks 15-17 :
+
+| Capacité | Question | Notebook |
+|----------|----------|----------|
+| **Décider (SAT)** | Une solution existe-t-elle ? | 01-14 (entiers), 15 (bit-vectors) |
+| **Prouver (UNSAT)** | L'impossibilité est-elle certifiée ? | 15, 16 (réfutation) |
+| **Expliquer (core)** | Quelles contraintes causent l'insatisfiabilité ? | **17 (ce notebook)** |
+
+Le passage du verdict à l'explication est le saut qui transforme un solveur en **outil de
+débogage de spécifications** : sur un système surcontraint, le core pointe le sous-ensemble
+minimal de contraintes coupables, écartant les contraintes *irrelevantes* (compatibles). C'est
+inestimable pour un ingénieur qui doit relâcher *la bonne* contrainte parmi des dizaines.
+
+La leçon d'arc : un solveur SMT ne se résume pas à une boîte « satisfiable ou non ». Il opère à
+trois niveaux — **trouver** (témoignage), **certifier** (preuve d'impossibilité), **expliquer**
+(core). Les trois sont des services distincts, et maîtriser Z3 c'est savoir demander le bon.
+
+### Où aller ensuite
+
+Avec les notebooks 15 (bit-vectors), 16 (réels) et 17 (UNSAT cores), la série a désormais
+exercé les théories et capacités centrales que le binding LINQ (notebooks 01-14) masquait. Les
+prolongements naturels :
+
+- **Combiner les théories** : un même problème mélangeant entiers, réels et bit-vectors (le
+  terrain réel des vérificateurs industriels — la *combinaison de théories* est elle-même un
+  sujet algorithmique, Nelson-Oppen).
+- **Les preuves formelles** (`Proof = true`) : non plus un core (sous-ensemble de contraintes),
+  mais la **dérivation complète** justifiant l'UNSAT — l'objet qu'un vérificateur externalisé
+  peut *re-vérifier* indépendamment de Z3.",,,,,,,,8adf18c20d766911,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,f7badca8,markdown,fr,a04b441b20a4d5db,"## 6. Exercices
+
+Trois exercices pour approfondir. Stubs incomplets — le notebook s'exécute de bout en bout même
+non complété (convention C.1).",,,,,,,,a04b441b20a4d5db,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,6986c552,markdown,fr,31b846089094a441,"### Exercice 1 — Core sur un conflit caché
+
+Construisez 4 contraintes sur un entier `z` telles que seules **2** d'entre elles soient en
+conflit, les 2 autres étant compatibles. Vérifiez que l'UNSAT core ne contient que les 2
+coupables (pas les 2 irrelevantes).
+
+*Indice* : par exemple `z ≥ 0`, `z ≤ 100`, `z = 50` (compatibles), `z = 200` (conflit avec
+`z ≤ 100`). Le core devrait être `{z ≤ 100, z = 200}`.",,,,,,,,31b846089094a441,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,eb01a6b8,code,fr,04da36f7c20468e5,"// Exercice 1 : core sur un conflit caché (2 coupables parmi 4)
+IntExpr z = ctx.MkIntConst(""z"");
+// TODO etudiant : 4 contraintes (2 compatibles, 2 en conflit), Check(assumptions), afficher le core
+// Etape 1 : BoolExpr[] cons = { ... };
+// Etape 2 : solver.Check((IEnumerable<BoolExpr>)cons)
+// Etape 3 : foreach (var c in solver.UnsatCore) afficher -> doit contenir seulement les 2 coupables
+Console.WriteLine(""Exercice 1 à compléter."");",,,,,,,,04da36f7c20468e5,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,f57e2578,markdown,fr,a6cf9aa2ea6358cd,"### Exercice 2 — Spécification de planning
+
+Un cours doit être programmé à un jour `j` (1=lundi … 5=vendredi) satisfaisant : (a) `j ≠ 3`
+(pas mercredi), (b) `j = 3` (seul jour libre de la salle), (c) `j ≥ 1`, (d) `j ≤ 5`. Utilisez
+l'UNSAT core pour identifier la contrainte à relâcher, puis relâchez-la et vérifiez que le
+système devient SAT.
+
+*Indice* : le core = `{j≠3, j=3}`. Après relâche de l'une des deux, `Check` doit donner SAT.",,,,,,,,a6cf9aa2ea6358cd,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,25510cbf,code,fr,fa8500d7aadfad94,"// Exercice 2 : planning, identifier puis relâcher la contrainte coupable
+IntExpr j = ctx.MkIntConst(""j"");
+// TODO etudiant : encoder (a)(b)(c)(d), obtenir le core, relâcher la coupable, re-Check -> SAT
+// Etape 1 : core = {j!=3, j=3} -> choisir laquelle relâcher
+// Etape 2 : solver.Check sur le sous-ensemble SANS la coupable -> SATISFIABLE
+Console.WriteLine(""Exercice 2 à compléter."");",,,,,,,,fa8500d7aadfad94,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,0027a15c,markdown,fr,62e651cf9652e0d7,"### Exercice 3 — Taille du core vs nombre de contraintes
+
+Générez un système de 10 contraintes sur un entier `k` dont seulement 3 sont en conflit (les 7
+autres compatibles). Mesurez la **taille du core** et comparez-la au nombre total de
+contraintes. L'UNSAT core est-il bien minimal (≤ 3) ?
+
+*Indice* : 3 contraintes mutuellement incompatibles (ex. `k=1`, `k=2`, `k=3`) + 7 contraintes
+compatibles (`k≥0`, `k≤100`, etc.). Le core doit faire exactement 3.",,,,,,,,62e651cf9652e0d7,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/17_UnsatCores.ipynb,2e2678de,code,fr,eb45cac2007ea4d9,"// Exercice 3 : core minimal parmi 10 contraintes
+IntExpr k = ctx.MkIntConst(""k"");
+// TODO etudiant : 10 contraintes (3 conflictuelles + 7 compatibles), mesurer |core|
+// Etape 1 : BoolExpr[] ten = { k==1, k==2, k==3, k>=0, k<=100, ... };
+// Etape 2 : solver.Check((IEnumerable<BoolExpr>)ten)
+// Etape 3 : compter solver.UnsatCore -> doit valoir 3 (les 3 k==n incompatibles)
+Console.WriteLine(""Exercice 3 à compléter."");",,,,,,,,eb45cac2007ea4d9,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,dc7a6d82,markdown,fr,9f1bdc8c717deb8f,"<- [17 - Unsat Cores](17_UnsatCores.ipynb) | [README Z3](README.md)
+
+---
+
+# Notebook 18 - L'enigme d'Einstein : la logique des attributs croises comme CSP
+
+**Navigation** : [Index Z3](./README.md) | [Index SymbolicAI](../../README.md) | [Index general](../../../README.md)
+
+## Objectifs d'apprentissage
+
+- Modeliser une **enigme logique a attributs croises** (le *Zebra puzzle*, dite ""enigme d'Einstein"") comme un probleme de satisfaction de contraintes sur des entiers
+- Maitriser l'**encodage par position** : pour chaque couple (attribut, valeur), une variable entiere encode la maison (0..4) ou cette valeur apparait
+- Traduire des indices **relationnels** (identite, ""a gauche de"", ""voisin de"") en contraintes lineaires et en disjonctions
+- Comprendre pourquoi un puzzle qu'un humain resout en une trentaine de minutes de deduction tombe en quelques millisecondes pour Z3
+
+## Prerequis
+
+- Notebooks [01 (Introduction Z3.Linq)](01_Linq2Z3_Intro.ipynb) et [13 (Cryptarithmetic)](13_Cryptarithmetic_SMT.ipynb)
+- Notions de logique propositionnelle et de propagation de contraintes
+
+**Duree estimee** : 40-50 minutes
+
+---
+
+L'**enigme d'Einstein** (ou *Zebra puzzle*) est un probleme de logique attribue - probablement a tort - a Albert Einstein. Cinq maisons alignees, cinq nationalites, cinq couleurs, cinq boissons, cinq cigarettes, cinq animaux. A partir de quinze indices, determiner la disposition complete et, surtout : **a qui appartient le poisson ?**
+
+L'espace de recherche est colossal : 5 attributs x 5! permutations chacun = (120)^5 de l'ordre de **2,5 milliards** de combinaisons. La resolution humaine procede par deduction pas-a-pas (remplir un tableau en propageant les indices). C'est le terrain ideal pour montrer comment un solveur SMT **propage globalement** des contraintes entrelacees plutot que d'enumerer.",,,,,,,,9f1bdc8c717deb8f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,4fd7735c,code,fr,36a8cf47c83a3682,"#r ""../Z3.Linq/.deploy/Microsoft.Z3.dll""
+#r ""../Z3.Linq/.deploy/ExpressionUtils.dll""
+#r ""../Z3.Linq/.deploy/Z3.Linq.dll""
+using Z3.Linq;
+using Microsoft.Z3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+Console.WriteLine(""Imports OK : Z3.Linq (.deploy), Microsoft.Z3, System.Linq"");",,,,,,,,36a8cf47c83a3682,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,f5973ca6,markdown,fr,d416b56309afa745,"## Modelisation : l'encodage par position
+
+L'astuce centrale consiste a **inverser le point de vue**. Au lieu de demander ""quelle couleur a la maison *k* ?"", on definit pour chaque valeur d'attribut une variable entiere egale a la **position** (numero de maison 0..4) ou elle se trouve :
+
+- `Brit`, `Swede`, `Dane`, `Norwegian`, `German` : position de chaque nationalite
+- `Red`, `Green`, `White`, `Yellow`, `Blue` : position de chaque couleur
+- `Tea`, `Coffee`, `Milk`, `Water`, `Beer` : position de chaque boisson
+- `PallMall`, `Dunhill`, `Blend`, `BlueMaster`, `Prince` : position de chaque cigarette
+- `Dog`, `Bird`, `Cat`, `Horse`, `Fish` : position de chaque animal
+
+Soit **25 variables entieres**, chacune dans `{0, 1, 2, 3, 4}`. Trois familles de contraintes :
+
+1. **Domaine** : chaque variable est dans `{0..4}` (une position valide).
+2. **Permutation** : au sein de chaque attribut, les 5 valeurs occupent des positions **deux a deux distinctes** (contrainte globale `Z3Methods.Distinct`) - chaque nationalite est dans une maison differente.
+3. **Les 15 indices** : des **egalites de position** (""le Britannique vit dans la maison rouge"" se code `Brit == Red`), des **decalages** (""la verte est juste a gauche de la blanche"" se code `Green == White - 1`), et des **adjacences** (""voisin de"" se code `|X - Y| == 1`, c'est-a-dire la disjonction `(X - Y == 1) || (Y - X == 1)`).
+
+Cet encodage transforme un puzzle de logique en un CSP sur les entiers : tous les indices deviennent des contraintes lineaires ou des disjonctions que le solveur propage.",,,,,,,,d416b56309afa745,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,fd901199,code,fr,7aa9d4a1071cc677,"// L'enigme d'Einstein : 5 maisons, 5 attributs, 15 indices.
+// Encodage par position : chaque champ = numero de maison (0..4) ou la valeur apparait.
+public class Einstein
+{
+    // Nationalites
+    public int Brit = 0, Swede = 0, Dane = 0, Norwegian = 0, German = 0;
+    // Couleurs
+    public int Red = 0, Green = 0, White = 0, Yellow = 0, Blue = 0;
+    // Boissons
+    public int Tea = 0, Coffee = 0, Milk = 0, Water = 0, Beer = 0;
+    // Cigarettes
+    public int PallMall = 0, Dunhill = 0, Blend = 0, BlueMaster = 0, Prince = 0;
+    // Animaux
+    public int Dog = 0, Bird = 0, Cat = 0, Horse = 0, Fish = 0;
+}
+
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<Einstein>();
+
+    // (1) Domaine 0..4 pour les 25 variables
+    th = th.Where(t =>
+        t.Brit>=0&&t.Brit<=4 && t.Swede>=0&&t.Swede<=4 && t.Dane>=0&&t.Dane<=4 && t.Norwegian>=0&&t.Norwegian<=4 && t.German>=0&&t.German<=4 &&
+        t.Red>=0&&t.Red<=4 && t.Green>=0&&t.Green<=4 && t.White>=0&&t.White<=4 && t.Yellow>=0&&t.Yellow<=4 && t.Blue>=0&&t.Blue<=4 &&
+        t.Tea>=0&&t.Tea<=4 && t.Coffee>=0&&t.Coffee<=4 && t.Milk>=0&&t.Milk<=4 && t.Water>=0&&t.Water<=4 && t.Beer>=0&&t.Beer<=4 &&
+        t.PallMall>=0&&t.PallMall<=4 && t.Dunhill>=0&&t.Dunhill<=4 && t.Blend>=0&&t.Blend<=4 && t.BlueMaster>=0&&t.BlueMaster<=4 && t.Prince>=0&&t.Prince<=4 &&
+        t.Dog>=0&&t.Dog<=4 && t.Bird>=0&&t.Bird<=4 && t.Cat>=0&&t.Cat<=4 && t.Horse>=0&&t.Horse<=4 && t.Fish>=0&&t.Fish<=4);
+
+    // (2) Permutation : 5 groupes Distinct (chaque attribut occupe les 5 maisons)
+    th = th.Where(t => Z3Methods.Distinct(t.Brit, t.Swede, t.Dane, t.Norwegian, t.German));
+    th = th.Where(t => Z3Methods.Distinct(t.Red, t.Green, t.White, t.Yellow, t.Blue));
+    th = th.Where(t => Z3Methods.Distinct(t.Tea, t.Coffee, t.Milk, t.Water, t.Beer));
+    th = th.Where(t => Z3Methods.Distinct(t.PallMall, t.Dunhill, t.Blend, t.BlueMaster, t.Prince));
+    th = th.Where(t => Z3Methods.Distinct(t.Dog, t.Bird, t.Cat, t.Horse, t.Fish));
+
+    // (3) Les 15 indices
+    th = th.Where(t => t.Brit == t.Red);                 // 1. Le Britannique vit dans la maison rouge
+    th = th.Where(t => t.Swede == t.Dog);                // 2. le Suedois eleve des chiens
+    th = th.Where(t => t.Dane == t.Tea);                 // 3. le Danois boit du the
+    th = th.Where(t => t.Green == t.White - 1);          // 4. la verte est juste a gauche de la blanche
+    th = th.Where(t => t.Green == t.Coffee);             // 5. le proprietaire de la verte boit du cafe
+    th = th.Where(t => t.PallMall == t.Bird);            // 6. fumeur de Pall Mall eleve des oiseaux
+    th = th.Where(t => t.Yellow == t.Dunhill);           // 7. la jaune fume du Dunhill
+    th = th.Where(t => t.Milk == 2);                     // 8. la maison du milieu boit du lait
+    th = th.Where(t => t.Norwegian == 0);                // 9. le Norvegien vit dans la 1ere maison
+    th = th.Where(t => (t.Blend - t.Cat == 1) || (t.Cat - t.Blend == 1));       // 10. Blend voisin du Chat
+    th = th.Where(t => (t.Horse - t.Dunhill == 1) || (t.Dunhill - t.Horse == 1)); // 11. Cheval voisin du Dunhill
+    th = th.Where(t => t.BlueMaster == t.Beer);          // 12. fumeur de BlueMaster boit de la biere
+    th = th.Where(t => t.German == t.Prince);            // 13. l'Allemand fume du Prince
+    th = th.Where(t => (t.Norwegian - t.Blue == 1) || (t.Blue - t.Norwegian == 1)); // 14. Norvegien voisin de la bleue
+    th = th.Where(t => (t.Blend - t.Water == 1) || (t.Water - t.Blend == 1));   // 15. Blend voisin de l'Eau
+
+    var sol = th.Solve();
+    if (sol == null) {
+        Console.WriteLine(""UNSAT : aucune solution (inattendu pour cette enigme)"");
+    } else {
+        // Inversion : pour chaque maison h, quelle valeur de chaque attribut y est ?
+        var nat  = new[]{(""Britannique"",sol.Brit),(""Suedois"",sol.Swede),(""Danois"",sol.Dane),(""Norvegien"",sol.Norwegian),(""Allemand"",sol.German)};
+        var col  = new[]{(""Rouge"",sol.Red),(""Verte"",sol.Green),(""Blanche"",sol.White),(""Jaune"",sol.Yellow),(""Bleue"",sol.Blue)};
+        var drk  = new[]{(""The"",sol.Tea),(""Cafe"",sol.Coffee),(""Lait"",sol.Milk),(""Eau"",sol.Water),(""Biere"",sol.Beer)};
+        var smk  = new[]{(""Pall Mall"",sol.PallMall),(""Dunhill"",sol.Dunhill),(""Blend"",sol.Blend),(""BlueMaster"",sol.BlueMaster),(""Prince"",sol.Prince)};
+        var pet  = new[]{(""Chien"",sol.Dog),(""Oiseau"",sol.Bird),(""Chat"",sol.Cat),(""Cheval"",sol.Horse),(""Poisson"",sol.Fish)};
+
+        string Val((string,int)[] arr, int h) => arr.First(p => p.Item2 == h).Item1;
+        Console.WriteLine($""{""Maison"",-10}{""Nationalite"",-14}{""Couleur"",-10}{""Boisson"",-10}{""Cigarette"",-14}{""Animal"",-10}"");
+        Console.WriteLine(new string('-', 68));
+        for (int h = 0; h < 5; h++) {
+            Console.WriteLine($""{h+1,-10}{Val(nat,h),-14}{Val(col,h),-10}{Val(drk,h),-10}{Val(smk,h),-14}{Val(pet,h),-10}"");
+        }
+        Console.WriteLine();
+        Console.WriteLine($"">>> Reponse : le {Val(nat, sol.Fish)} possede le Poisson (maison {sol.Fish+1})."");
+    }
+}",,,,,,,,7aa9d4a1071cc677,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,b25f2858,markdown,fr,c4e8cf0e1b7de647,"## Interpretation
+
+Z3 trouve la solution unique en quelques millisecondes :
+
+- **Maison 1** : Norvegien, Jaune, Eau, Dunhill, Chat
+- **Maison 2** : Danois, Bleue, The, Blend, Cheval
+- **Maison 3** : Britannique, Rouge, Lait, Pall Mall, Oiseau
+- **Maison 4** : Allemand, Verte, Cafe, Prince, **Poisson**
+- **Maison 5** : Suedois, Blanche, Biere, BlueMaster, Chien
+
+**Reponse : c'est l'Allemand qui possede le poisson.**
+
+**Pourquoi le solveur fait la difference** (Prong-B) : la resolution humaine procede par deduction progressive - on place le Norvegien en 1 (`Norwegian == 0`), le lait en 3 (`Milk == 2`), on deduit la bleue en 2 (voisin du Norvegien), puis on enchaine les croisements. C'est fastidieux et erreur-prone. Le solveur, lui, **propage simultanement** les 15 indices : `Norwegian == 0` et `Milk == 2` fixent deux ancres, puis les egalites de position (`Brit == Red`, `German == Prince`...) et les adjacences reduisent les domaines en cascade jusqu'a la solution unique. Aucune enumeration des 2,5 milliards de combinaisons.
+
+C'est aussi un exemple ou l'**encodage** est decisif : traduire ""voisin de"" en `|X - Y| == 1` (une disjonction lineaire) rend l'adjacence directement exploitable par le solveur, la ou une enumeration devrait tester chaque paire de positions.",,,,,,,,c4e8cf0e1b7de647,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,9e5313fd,markdown,fr,e2897b0c632ec7b4,"## Approche nave vs solveur : mesurer l'ecart
+
+Pour **mesurer** l'ecart (plutot que l'affirmer), comparons la taille de l'espace de recherche a ce que fait Z3 :
+
+- **Brute force** : enumerer toutes les permutations de chaque attribut, soit `(5!)^5 = 120^5 = 24 883 200 000` combinaisons, puis tester les 15 indices pour chacune. A raison de ~100 millions de tests par seconde en C# natif, cela represente de l'ordre de **4 minutes** de calcul - et le test des 15 indices rend chaque candidat nettement plus lent en pratique.
+- **Z3** : formuler les 25 variables + domaine + 5 `Distinct` + 15 indices, et laisser le solveur propager. La propagation fixe `Norwegian = 0` et `Milk = 2` sans aucun essai, puis reduit les domaines jusqu'a la solution unique.
+
+Mesurons egalement si la solution est **unique** : ajoutons une contrainte niant la solution trouvee (au moins un attribut different) et re-solvons. Si Z3 repond UNSAT, la solution est prouvee unique.",,,,,,,,e2897b0c632ec7b4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,8e1ce164,code,fr,0fbdd6e0b16205c1,"using System.Diagnostics;
+
+// (1) Z3 resout l'enigme complete - mesure du temps
+var sw = Stopwatch.StartNew();
+Einstein sol = null;
+using (var ctx = new Z3Context())
+{
+    var th = ctx.NewTheorem<Einstein>()
+        .Where(t => t.Brit>=0&&t.Brit<=4&&t.Swede>=0&&t.Swede<=4&&t.Dane>=0&&t.Dane<=4&&t.Norwegian>=0&&t.Norwegian<=4&&t.German>=0&&t.German<=4
+                  && t.Red>=0&&t.Red<=4&&t.Green>=0&&t.Green<=4&&t.White>=0&&t.White<=4&&t.Yellow>=0&&t.Yellow<=4&&t.Blue>=0&&t.Blue<=4
+                  && t.Tea>=0&&t.Tea<=4&&t.Coffee>=0&&t.Coffee<=4&&t.Milk>=0&&t.Milk<=4&&t.Water>=0&&t.Water<=4&&t.Beer>=0&&t.Beer<=4
+                  && t.PallMall>=0&&t.PallMall<=4&&t.Dunhill>=0&&t.Dunhill<=4&&t.Blend>=0&&t.Blend<=4&&t.BlueMaster>=0&&t.BlueMaster<=4&&t.Prince>=0&&t.Prince<=4
+                  && t.Dog>=0&&t.Dog<=4&&t.Bird>=0&&t.Bird<=4&&t.Cat>=0&&t.Cat<=4&&t.Horse>=0&&t.Horse<=4&&t.Fish>=0&&t.Fish<=4)
+        .Where(t => Z3Methods.Distinct(t.Brit,t.Swede,t.Dane,t.Norwegian,t.German))
+        .Where(t => Z3Methods.Distinct(t.Red,t.Green,t.White,t.Yellow,t.Blue))
+        .Where(t => Z3Methods.Distinct(t.Tea,t.Coffee,t.Milk,t.Water,t.Beer))
+        .Where(t => Z3Methods.Distinct(t.PallMall,t.Dunhill,t.Blend,t.BlueMaster,t.Prince))
+        .Where(t => Z3Methods.Distinct(t.Dog,t.Bird,t.Cat,t.Horse,t.Fish))
+        .Where(t => t.Brit==t.Red && t.Swede==t.Dog && t.Dane==t.Tea)
+        .Where(t => t.Green==t.White-1 && t.Green==t.Coffee)
+        .Where(t => t.PallMall==t.Bird && t.Yellow==t.Dunhill)
+        .Where(t => t.Milk==2 && t.Norwegian==0)
+        .Where(t => (t.Blend-t.Cat==1)||(t.Cat-t.Blend==1))
+        .Where(t => (t.Horse-t.Dunhill==1)||(t.Dunhill-t.Horse==1))
+        .Where(t => t.BlueMaster==t.Beer && t.German==t.Prince)
+        .Where(t => (t.Norwegian-t.Blue==1)||(t.Blue-t.Norwegian==1))
+        .Where(t => (t.Blend-t.Water==1)||(t.Water-t.Blend==1));
+    sol = th.Solve();
+}
+sw.Stop();
+
+// (2) Unicite : nie la solution trouvee, re-solve -> attend UNSAT
+bool unique = false;
+if (sol != null) {
+    using (var ctx = new Z3Context())
+    {
+        var th = ctx.NewTheorem<Einstein>()
+            .Where(t => t.Brit>=0&&t.Brit<=4&&t.Swede>=0&&t.Swede<=4&&t.Dane>=0&&t.Dane<=4&&t.Norwegian>=0&&t.Norwegian<=4&&t.German>=0&&t.German<=4
+                      && t.Red>=0&&t.Red<=4&&t.Green>=0&&t.Green<=4&&t.White>=0&&t.White<=4&&t.Yellow>=0&&t.Yellow<=4&&t.Blue>=0&&t.Blue<=4
+                      && t.Tea>=0&&t.Tea<=4&&t.Coffee>=0&&t.Coffee<=4&&t.Milk>=0&&t.Milk<=4&&t.Water>=0&&t.Water<=4&&t.Beer>=0&&t.Beer<=4
+                      && t.PallMall>=0&&t.PallMall<=4&&t.Dunhill>=0&&t.Dunhill<=4&&t.Blend>=0&&t.Blend<=4&&t.BlueMaster>=0&&t.BlueMaster<=4&&t.Prince>=0&&t.Prince<=4
+                      && t.Dog>=0&&t.Dog<=4&&t.Bird>=0&&t.Bird<=4&&t.Cat>=0&&t.Cat<=4&&t.Horse>=0&&t.Horse<=4&&t.Fish>=0&&t.Fish<=4)
+            .Where(t => Z3Methods.Distinct(t.Brit,t.Swede,t.Dane,t.Norwegian,t.German))
+            .Where(t => Z3Methods.Distinct(t.Red,t.Green,t.White,t.Yellow,t.Blue))
+            .Where(t => Z3Methods.Distinct(t.Tea,t.Coffee,t.Milk,t.Water,t.Beer))
+            .Where(t => Z3Methods.Distinct(t.PallMall,t.Dunhill,t.Blend,t.BlueMaster,t.Prince))
+            .Where(t => Z3Methods.Distinct(t.Dog,t.Bird,t.Cat,t.Horse,t.Fish))
+            .Where(t => t.Brit==t.Red && t.Swede==t.Dog && t.Dane==t.Tea)
+            .Where(t => t.Green==t.White-1 && t.Green==t.Coffee)
+            .Where(t => t.PallMall==t.Bird && t.Yellow==t.Dunhill)
+            .Where(t => t.Milk==2 && t.Norwegian==0)
+            .Where(t => (t.Blend-t.Cat==1)||(t.Cat-t.Blend==1))
+            .Where(t => (t.Horse-t.Dunhill==1)||(t.Dunhill-t.Horse==1))
+            .Where(t => t.BlueMaster==t.Beer && t.German==t.Prince)
+            .Where(t => (t.Norwegian-t.Blue==1)||(t.Blue-t.Norwegian==1))
+            .Where(t => (t.Blend-t.Water==1)||(t.Water-t.Blend==1))
+            // nie la solution trouvee en litteraux ( Britannique=2, ..., Poisson=3 ) :
+            // l'encodage DSL ne reduit pas les valeurs capturees a l'execution -> litteraux.
+            .Where(t => t.Brit!=2||t.Swede!=4||t.Dane!=1||t.Norwegian!=0||t.German!=3||
+                        t.Red!=2||t.Green!=3||t.White!=4||t.Yellow!=0||t.Blue!=1||
+                        t.Tea!=1||t.Coffee!=3||t.Milk!=2||t.Water!=0||t.Beer!=4||
+                        t.PallMall!=2||t.Dunhill!=0||t.Blend!=1||t.BlueMaster!=4||t.Prince!=3||
+                        t.Dog!=4||t.Bird!=2||t.Cat!=0||t.Horse!=1||t.Fish!=3);
+        unique = (th.Solve() == null);  // UNSAT => unique
+    }
+}
+
+long space = 120L * 120 * 120 * 120 * 120;  // (5!)^5
+Console.WriteLine($""Espace de recherche brut      : (5!)^5 = {space:N0} combinaisons"");
+Console.WriteLine($""Brute force estime (~1e8/s)    : {space/100_000_000.0:F1} s (sans compter le test des 15 indices)"");
+Console.WriteLine($""Z3 solve temps                 : {sw.Elapsed.TotalMilliseconds:F1} ms"");
+Console.WriteLine($""Solution trouvee               : {(sol != null ? ""OUI"" : ""NON"")}"");
+Console.WriteLine($""Solution unique (UNSAT si nie) : {unique}"");
+Console.WriteLine($"" -> Z3 resout en millisecondes un espace de 2,5 milliards, et prouve l'unicite sans enumeration."");",,,,,,,,0fbdd6e0b16205c1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,fb8fa6c4,markdown,fr,fbd9d5f8ed279333,"## Lecture du benchmark
+
+Sur cette enigme, l'ecart est **frappant** et non plus de ""meme ordre de grandeur"" comme sur le cryptarithme a 8 lettres :
+
+- Z3 resout les **25 variables entrelacees** en quelques **millisecondes**, alors que la brute force doit affronter **2,5 milliards** de combinaisons (soit plusieurs minutes meme a cadence elevee, et bien plus avec le test des 15 indices a chaque candidat).
+- La **propagation** fait tout le travail : `Norwegian == 0` et `Milk == 2` sont des ancres imposees par les indices 9 et 8, puis les egalites de position et les adjacences reduisent les domaines en cascade. Aucune enumeration.
+- La **preuve d'unicite** est obtenue gratuitement : il suffit d'ajouter une contrainte niant la solution trouvee, et Z3 repond UNSAT en un nouvel appel - ce qui serait, en brute force, une nouvelle exploration complete de l'espace.
+
+C'est l'illustration la plus nette du **Prong-B** : un probleme ou le moteur SMT exerce pleinement sa capacite distinctive - **reduire un espace combinatoire gigantesque par propagation de contraintes globales**, plutot que l'enumerer. La regression (un simple `if` ou une table de hachage) ne peut pas resoudre ce probleme ; le solveur SMT, si.",,,,,,,,fbd9d5f8ed279333,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,92525bdb,markdown,fr,403d9e9f9eac35b6,"## Exercices
+
+Les trois exercices ci-dessous vous font reutiliser l'encodage par position. Chaque exercice suit le meme squelette : redefinir le theoreme, ajuster les contraintes, puis `Solve()`.
+
+**Rappel C.1** : les stubs ne levent **jamais** d'erreur - ils utilisent `Console.WriteLine(""Exercice a completer"")`. Le notebook s'execute de bout en bout meme exercices non resolus.",,,,,,,,403d9e9f9eac35b6,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,4c7d538c,markdown,fr,f2b259ccf81f3731,"### Exercice 1 - Une 16e contrainte : le Chat boit de l'Eau
+
+Ajoutez l'indice supplementaire ""le proprietaire du chat boit de l'eau"" (soit `Cat == Water`) **en plus** des 15 indices existants. Le puzzle reste-t-il satisfiable ? Si non, que prouve Z3 ?
+
+**Etapes** :
+1. Reprenez le theoreme de la cellule 3 avec les 15 indices.
+2. Ajoutez une 16e contrainte `.Where(t => t.Cat == t.Water)`.
+3. Appelez `Solve()` et observez le resultat (solution ou `null`).",,,,,,,,f2b259ccf81f3731,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,75b650be,code,fr,214a0e2cc1293fc1,"// Exercice 1 : ajouter l'indice ""le Chat boit de l'Eau"" (Cat == Water)
+// TODO etudiant :
+// Etape 1 : reprendre le theoreme Einstein (domaine + 5 Distinct + 15 indices)
+// Etape 2 : ajouter .Where(t => t.Cat == t.Water)
+// Etape 3 : Solve() -> la solution reste-t-elle SAT, ou devient-elle UNSAT ?
+Console.WriteLine(""Exercice 1 a completer : ajoutez l'indice Cat == Water et testez la satisfiabilite"");",,,,,,,,214a0e2cc1293fc1,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,1e73780f,markdown,fr,a92aa5d5ae9d6875,"### Exercice 2 - Qui boit de l'Eau ? Qui eleve le Poisson ?
+
+La cellule 6 demontre l'unicite en niant la solution sur 5 attributs. Generalisez : ecrivez une boucle qui, apres avoir trouve la solution, **enumere toutes les solutions** (methode du blocage iteratif - bloquer la solution trouvee, re-solve, jusqu'a UNSAT) et affiche combien il y en a.
+
+**Indice** : a chaque iteration, ajoutez une contrainte ""au moins un attribut != solution courante"" et re-solvez. Comptez les iterations. Vous devez trouver **1** (solution unique).",,,,,,,,a92aa5d5ae9d6875,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,d9cb000f,code,fr,770d3dbbb33b21e0,"// Exercice 2 : enumerer toutes les solutions de l'enigme (boucle de blocage iteratif)
+// TODO etudiant :
+// 1. Solve() -> si sol != null, compter++, ajouter contrainte (au moins un attribut != sol)
+// 2. Recommencer jusqu'a UNSAT (sol == null)
+// 3. Afficher le nombre total de solutions (attendu : 1)
+Console.WriteLine(""Exercice 2 a completer : enumerer toutes les solutions par blocage iteratif"");",,,,,,,,770d3dbbb33b21e0,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,86789b00,markdown,fr,d48bea0e4f1ddfb4,"### Exercice 3 - Variant a 4 maisons / 4 attributs
+
+Construisez un **mini-Zebra** a 4 maisons, 4 nationalites, 4 couleurs et 4 animaux, avec 8 indices de votre choix (identites + adjacences). Definissez une nouvelle classe (par ex. `MiniZebra`) avec 16 variables entieres dans `{0..3}`, et resolvez-le.
+
+**Question subsidiaire** : votre jeu d'indices donne-t-il une solution unique ? Si non, combien de solutions Z3 trouve-t-il ?",,,,,,,,d48bea0e4f1ddfb4,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,9991065a,code,fr,67c68c83403ddae3,"// Exercice 3 : mini-Zebra a 4 maisons / 4 attributs
+// TODO etudiant :
+// 1. Classe MiniZebra { 4 nationalites, 4 couleurs, 4 animaux } (int, domaine 0..3)
+// 2. 4 groupes Distinct (4 attributs)
+// 3. 8 indices (identites + adjacences) de votre choix
+// 4. Solve() -> solution unique ?
+Console.WriteLine(""Exercice 3 a completer : modelisez un mini-Zebra a 4 maisons / 4 attributs"");",,,,,,,,67c68c83403ddae3,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/18_Einsteins_Riddle.ipynb,d8661373,markdown,fr,9a2457047f9d97f9,"## Conclusion
+
+L'**enigme d'Einstein** est le terrain le plus complet pour apprehender la modelisation d'un **puzzle de logique** comme un CSP :
+
+- L'**encodage par position** (une variable entiere par couple attribut/valeur) transforme chaque indice naturel (""le Britannique vit dans la maison rouge"", ""voisin de"") en une contrainte arithmetique simple (egalite de position, disjonction d'adjacence).
+- Les **25 variables** et les **15 indices entrelaces** forment un reseau de contraintes que le solveur **propage globalement** : deux ancres (`Norwegian == 0`, `Milk == 2`) suffisent a declencher une reduction en cascade jusqu'a la solution unique.
+- L'**unicite** se prouve gratuitement par un second appel (contrainte de negation -> UNSAT), la ou une brute force devrait re-explorer les 2,5 milliards de combinaisons.
+
+**Points cles** :
+- Un puzzle qu'un humain resout en une trentaine de minutes tombe en **millisecondes** : la propagation globale ecrase la deduction pas-a-pas.
+- L'**encodage** est decisif : ""voisin de"" devient `|X - Y| == 1`, une disjonction lineaire directement exploitable.
+- Le meme schema (domaine + `Distinct` + egalites/adjacences) s'adapte a **tout puzzle de logique a attributs croises**, quelle que soit sa taille.
+
+**Reference** : le *Zebra puzzle* publie par Michael K. Albert et [popularise par Life International (1962)](https://en.wikipedia.org/wiki/Zebra_Puzzle). L'attribution a Einstein est une legende urbaine - le puzzle est vraisemblablement de la presse americaine des annees 1960.",,,,,,,,9a2457047f9d97f9,,,,,,,


### PR DESCRIPTION
## What

Second translation CSV for the **SymbolicAI/SMT** family (Epic #4957 / #1650 Phase 0.5), completing the family started in **#6747** (Z3-API, MERGED). Covers the **Z3-Linq2Z3** series as a fr-pivot baseline.

## Coverage

| File | Series | Notebooks | Cells |
|------|--------|-----------|-------|
| `translations/smt/z3-linq2z3.csv` (new) | `SymbolicAI/SMT/Z3-Linq2Z3/` | 18 (`01_Linq2Z3_Intro` → `18_Einsteins_Riddle`, C# LINQ-to-Z3 déclaratif) | 525 (323 markdown + 202 code) |

20-column schema (#4957 §1): `src_lang=fr`, `src_hash` (sha256-16) + `text_fr` filled for all 525 rows; target-language columns empty for T3 Argumentum (#1650 Phase 1).

`translations/smt/README.md` unified into a **family README** covering both series (Z3-API 24 NB/541 cells + Z3-Linq2Z3 18 NB/525 cells), dual regen commands, family-level drift check.

## Verification (canonical tools, firsthand)

| Check | Result |
|-------|--------|
| Extractor | `525 cellules extraites de 18 notebook(s)` |
| Determinism | **byte-identical** on re-extract |
| Drift checker (T2, both CSVs) | `2 CSV vérifié(s)`, `0 drift`, `anomaly_count: 0` (IN_SYNC) |
| README consistency | both CSV files exist + referenced (4 anchors) |

## Scope (atomic — one series + the README that owns it)

- **In**: `SymbolicAI/SMT/Z3-Linq2Z3/` (18 notebooks) + the `smt/` family README unified to cover both CSVs.
- **Out of scope**: `Z3-API/` (already merged #6747); `Z3.Linq/` submodule (vendored); `Automata/`, `Resharp/` (no FR-first pedagogical notebooks).

## Notes

- **Cross-language**: Z3-Linq2Z3 is C# native (LINQ-to-Z3 déclaratif), distinct from Z3-API's Python ⇄ C# parity.
- **Partition**: Z3-Linq2Z3 is po-2023 (.NET); extraction is **safe cross-owner** (read-only meta-infrastructure, no notebook edits).
- **SMT family now fully covered** (Z3-API + Z3-Linq2Z3 = 42 notebooks / 1066 cells).

See #4957 (infra design), #1650 (translation EPIC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)