### PR TITLE
i18n(lean,#4980): lean_game_defs/Nash FR-first sibling pair + root Nash_en

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Nash_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Nash_en.lean
@@ -1,79 +1,84 @@
 /-
-  Définitions de l'équilibre de Nash en Lean 4
-  ============================================
+  Nash Equilibrium Definitions in Lean 4
+  ======================================
 
-  Définit l'équilibre de Nash et les notions associées :
-  - Meilleure réponse
-  - Équilibre de Nash en stratégies pures
-  - Équilibre de Nash en stratégies mixtes
-  - Dominance stricte
+  Defines Nash equilibrium and related concepts:
+  - Best response
+  - Pure Nash equilibrium
+  - Mixed Nash equilibrium
+  - Strict dominance
 
-  Basé sur GameTheory-16-Lean-Definitions.ipynb
+  Based on GameTheory-16-Lean-Definitions.ipynb
 
   ---
-  Jumelage i18n : ce module est le FR canonique (sibling pair Pattern A,
-  ratifié par user 2026-07-04 sur EPIC #4980). Le miroir anglais vit dans
-  `Nash_en.lean` (variante reuse-FR-names : il importe le FR canonique
-  `Basic` et réutilise ses identifiants, en enveloppant ses propres
-  déclarations dans `namespace NashEn`). Le corps des définitions, signatures
-  et tactiques est byte-identique entre les deux fichiers ; seules les
-  docstrings `/-! ... -/` (titres de section) et `/-- ... -/` (docstrings de
-  déclarations) diffèrent, FR dans ce fichier, EN dans `Nash_en.lean`.
+  i18n sibling: this module is the EN mirror of the FR canonical `Nash.lean`
+  (sibling-pair Pattern A, ratified by user on 2026-07-04, EPIC #4980). The FR
+  canonical lives in `Nash.lean` (top-level declarations, no namespace). This
+  EN mirror uses the *reuse-FR-names* variant: it `import Basic` (the FR
+  canonical base module) and reuses the FR identifiers (`Game2x2`,
+  `expectedPayoff1`, `expectedPayoff2`) verbatim, wrapping only its own new
+  declarations in `namespace NashEn` to avoid name collisions with the FR
+  `Nash` module when both live in the same lake. The body of definitions,
+  signatures and tactics is byte-identical between the two files; only the
+  docstrings `/-! ... -/` (section headings) and `/-- ... -/` (declaration
+  docstrings) differ — EN in this file, FR in `Nash.lean`.
 -/
 
 import Basic
 
+namespace NashEn
+
 /-!
-## Meilleure réponse
+## Best Response
 -/
 
-/-- Le joueur 1 joue une meilleure réponse face à `s2`. -/
+/-- Player 1 plays a best response to `s2`. -/
 def isBestResponse1 (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) : Prop :=
   ∀ s1' : Fin 2 → Float,
     expectedPayoff1 g s1 s2 >= expectedPayoff1 g s1' s2
 
-/-- Le joueur 2 joue une meilleure réponse face à `s1`. -/
+/-- Player 2 plays a best response to `s1`. -/
 def isBestResponse2 (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) : Prop :=
   ∀ s2' : Fin 2 → Float,
     expectedPayoff2 g s1 s2 >= expectedPayoff2 g s1 s2'
 
 /-!
-## Équilibre de Nash
+## Nash Equilibrium
 -/
 
-/-- Équilibre de Nash en stratégies mixtes : chaque joueur joue une meilleure réponse. -/
+/-- Nash equilibrium in mixed strategies: each player plays a best response. -/
 def isNashEquilibrium (g : Game2x2) (s1 : Fin 2 → Float) (s2 : Fin 2 → Float) : Prop :=
   isBestResponse1 g s1 s2 ∧ isBestResponse2 g s1 s2
 
-/-- Équilibre de Nash en stratégies pures pour les jeux 2x2. -/
+/-- Nash equilibrium in pure strategies for 2x2 games. -/
 def isPureNashEquilibrium (g : Game2x2) (a1 : Fin 2) (a2 : Fin 2) : Prop :=
-  -- Le joueur 1 ne peut pas améliorer en changeant d'action
+  -- Player 1 cannot improve by changing action
   (∀ a1' : Fin 2, g.payoff1 a1 a2 >= g.payoff1 a1' a2) ∧
-  -- Le joueur 2 ne peut pas améliorer en changeant d'action
+  -- Player 2 cannot improve by changing action
   (∀ a2' : Fin 2, g.payoff2 a1 a2 >= g.payoff2 a1 a2')
 
 /-!
 ## Dominance
 -/
 
-/-- L'action `a` domine strictement l'action `a'` pour le joueur 1. -/
+/-- Action `a` strictly dominates action `a'` for player 1. -/
 def strictlyDominates1 (g : Game2x2) (a a' : Fin 2) : Prop :=
   ∀ a2 : Fin 2, g.payoff1 a a2 > g.payoff1 a' a2
 
-/-- L'action `a` domine faiblement l'action `a'` pour le joueur 1. -/
+/-- Action `a` weakly dominates action `a'` for player 1. -/
 def weaklyDominates1 (g : Game2x2) (a a' : Fin 2) : Prop :=
   (∀ a2 : Fin 2, g.payoff1 a a2 >= g.payoff1 a' a2) ∧
   (∃ a2 : Fin 2, g.payoff1 a a2 > g.payoff1 a' a2)
 
-/-- L'action `a` domine strictement l'action `a'` pour le joueur 2. -/
+/-- Action `a` strictly dominates action `a'` for player 2. -/
 def strictlyDominates2 (g : Game2x2) (a a' : Fin 2) : Prop :=
   ∀ a1 : Fin 2, g.payoff2 a1 a > g.payoff2 a1 a'
 
 /-!
-## Jeux classiques
+## Classic Games
 -/
 
-/-- Dilemme du prisonnier : C=0 (Coopérer), D=1 (Trahir). -/
+/-- Prisoner's Dilemma: C=0 (Cooperate), D=1 (Defect). -/
 def prisonersDilemma : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
@@ -91,14 +96,14 @@ def prisonersDilemma : Game2x2 := {
     | _, _ => 0
 }
 
-/-- Jeu de la poule (Chicken) : Céder=0, Foncer=1. -/
+/-- Chicken Game: Yield=0, Charge=1. -/
 def chickenGame : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
     | 0, 0 => 3  -- (Yield, Yield)
     | 0, 1 => 2  -- (Yield, Charge)
     | 1, 0 => 4  -- (Charge, Yield)
-    | 1, 1 => 0  -- (Charge, Charge) - collision !
+    | 1, 1 => 0  -- (Charge, Charge) - crash!
     | _, _ => 0
   payoff2 := fun i j =>
     match i.val, j.val with
@@ -109,7 +114,7 @@ def chickenGame : Game2x2 := {
     | _, _ => 0
 }
 
-/-- Chasse au cerf (Stag Hunt) : Cerf=0, Lièvre=1. -/
+/-- Stag Hunt: Stag=0, Hare=1. -/
 def stagHunt : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
@@ -127,7 +132,7 @@ def stagHunt : Game2x2 := {
     | _, _ => 0
 }
 
-/-- Matching Pennies (jeu à somme nulle) : Pile=0, Face=1. -/
+/-- Matching Pennies (zero-sum): Heads=0, Tails=1. -/
 def matchingPennies : Game2x2 := {
   payoff1 := fun i j =>
     match i.val, j.val with
@@ -146,7 +151,7 @@ def matchingPennies : Game2x2 := {
 }
 
 /-!
-## Noms d'actions
+## Action Names
 -/
 
 def Cooperer : Fin 2 := ⟨0, by omega⟩
@@ -157,3 +162,5 @@ def Cerf : Fin 2 := ⟨0, by omega⟩
 def Lievre : Fin 2 := ⟨1, by omega⟩
 def Pile : Fin 2 := ⟨0, by omega⟩
 def Face : Fin 2 := ⟨1, by omega⟩
+
+end NashEn

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lakefile.toml
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lakefile.toml
@@ -8,4 +8,12 @@ defaultTargets = ["LeanGameDefs"]
 
 [[lean_lib]]
 name = "LeanGameDefs"
-roots = ["Basic", "Nash", "Bayesian", "Combinatorial", "SocialChoice", "Regret"]
+# Roots include the `_en` i18n siblings (EPIC #4980 sibling-pair Pattern A) so
+# that `lake build` (the CI verification path) actually compiles them — without
+# an explicit root, a `*_en.lean` mirror is an orphan that Lake never builds
+# and whose compile errors stay invisible. `Nash_en` reuses the FR `Basic`
+# identifiers (reuse-FR-names variant) so it imports `Basic`, not `Basic_en`.
+roots = [
+  "Basic", "Nash", "Bayesian", "Combinatorial", "SocialChoice", "Regret",
+  "Nash_en",
+]


### PR DESCRIPTION
## Summary

Strip the inline English from the FR canonical `Nash.lean` and add the EN mirror `Nash_en.lean` (sibling-pair Pattern A, ratified by user 2026-07-04 on EPIC **#4980**). Second module of the `lean_game_defs` i18n rollout (after `Basic`, #6749).

**Substance**: Nash equilibrium theory in Lean 4 — best response (`isBestResponse1/2`), pure & mixed Nash equilibrium (`isNashEquilibrium`, `isPureNashEquilibrium`), strict & weak dominance (`strictlyDominates1/2`, `weaklyDominates1`), four classic games (`prisonersDilemma`, `chickenGame`, `stagHunt`, `matchingPennies`), action-name constants. 12 declarations.

## Variant — reuse-FR-names

`Nash_en` imports the FR canonical `Basic` and reuses its identifiers (`Game2x2`, `expectedPayoff1`, `expectedPayoff2`) verbatim, then wraps its own declarations in `namespace NashEn` to avoid name collisions with the FR `Nash` module when both live in the same lake. This variant (validated by #4980, cf `conway_lean`) works on current `main` without depending on the not-yet-merged `Basic_en` (#6749).

The body (signatures, tactics, classic-game payoff matrices, action-name defs) is **byte-identical** between the two files; only docstrings (`/-! … -/` section headings, `/-- … -/` declaration docstrings) and French inline comments differ — FR in `Nash.lean`, EN in `Nash_en.lean`.

## Validation (lean-merge-discipline: lake build SUCCESS local)

- `scripts/lean/check_i18n_siblings.py Nash_en.lean` → **OK 1/1 pairs byte-identical | 0 consumer-pattern | 0 drift | 0 orphan**.
- `lake -R build` (toolchain `leanprover/lean4:v4.31.0-rc1`, core-Lean-only, no Mathlib) → **Build completed successfully (9 jobs)**, including **`Built Nash_en`** and the recompiled stripped `Nash`.
- sorry count 0/0 (baseline 0 respected, no regression).

## Orphan-trap fix (harness)

Add `Nash_en` to the `LeanGameDefs` roots. Without an explicit root, a `*_en.lean` mirror is an orphan Lake never builds, so its compile errors stay invisible to CI (`lake build` builds roots + transitive imports only; `Basic_en`/`Nash_en` are neither). Now `lake build` builds `Nash_en` (9 jobs, was 8) and CI verifies the sibling actually compiles.

## Caveat for #6749

`#6749` (Basic sibling pair) did NOT add `Basic_en` to the roots, so its `Basic_en.lean` is currently an orphan that CI does not build — its compilation is unverified by CI (my c.520 claim that "the common stem makes CI compile both" was wrong: Lake roots match exact module names, not stems). When #6749 merges, `Basic_en` should be added to the roots the same way. Flagging here so it is not lost.

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)