### PR TITLE
fix(docs): repair 4 broken matching-cv links in cross-series/i18n README.en.md

### DIFF
--- a/MyIA.AI.Notebooks/cross-series/i18n/README.en.md
+++ b/MyIA.AI.Notebooks/cross-series/i18n/README.en.md
@@ -12,11 +12,11 @@ Ces projets servent donc d'**exemples-capstones** : chacun est autonome (son pro
 
 | Projet | Description | Séries mobilisées |
 | --- | --- | --- |
-| [matching-cv/](matching-cv/) | Application web Flask qui compare trois algorithmes d'appariement CV ↔ fiche de poste : mots-clés (baseline), similarité sémantique par embeddings, et appariement stable de Gale-Shapley. | GameTheory, GenAI, ML |
+| [matching-cv/](../matching-cv/) | Application web Flask qui compare trois algorithmes d'appariement CV ↔ fiche de poste : mots-clés (baseline), similarité sémantique par embeddings, et appariement stable de Gale-Shapley. | GameTheory, GenAI, ML |
 
 ## Focus — matching-cv : trois lectures d'un même problème
 
-Le projet [matching-cv/](matching-cv/) prend un problème unique — apparier des CV de consultants à des fiches de poste — et le résout de **trois façons**, chacune ancrée dans une série différente. C'est précisément ce contraste qui en fait un projet cross-séries :
+Le projet [matching-cv/](../matching-cv/) prend un problème unique — apparier des CV de consultants à des fiches de poste — et le résout de **trois façons**, chacune ancrée dans une série différente. C'est précisément ce contraste qui en fait un projet cross-séries :
 
 | Algorithme | Principe | Série d'origine |
 | --- | --- | --- |
@@ -26,7 +26,7 @@ Le projet [matching-cv/](matching-cv/) prend un problème unique — apparier de
 
 La leçon transversale est que **le « meilleur » appariement dépend du critère** : le meilleur score individuel (algorithme 2) n'est pas le même que l'appariement globalement stable au sens de Gale-Shapley (algorithme 3), où aucune paire candidat/poste n'a intérêt à se ré-apparier. Comparer les deux sur les mêmes données rend visible la différence entre *optimisation locale* et *stabilité globale*.
 
-> **Note pédagogique.** matching-cv a été produit sous orchestration automatisée comme extension d'un atelier élémentaire ; sa trace d'orchestration n'a pas été conservée. Sa valeur tient à l'**illustration** de l'intégration cross-séries plus qu'à un déroulé pas-à-pas — voir son [README dédié](matching-cv/README.md) et son [introduction](matching-cv/docs/INTRODUCTION.md) pour le détail.
+> **Note pédagogique.** matching-cv a été produit sous orchestration automatisée comme extension d'un atelier élémentaire ; sa trace d'orchestration n'a pas été conservée. Sa valeur tient à l'**illustration** de l'intégration cross-séries plus qu'à un déroulé pas-à-pas — voir son [README dédié](../matching-cv/README.md) et son [introduction](../matching-cv/docs/INTRODUCTION.md) pour le détail.
 
 ---
 


### PR DESCRIPTION
## Summary

`cross-series/i18n/README.en.md` contained 4 relative links to `matching-cv/` that resolved **inside** `i18n/` (a non-existent child) instead of the sibling `cross-series/matching-cv/` directory. `matching-cv` is a **sibling** of `i18n/`, so the links were missing the `../` parent prefix.

| Line | Before | After |
|------|--------|-------|
| 15 | `](matching-cv/)` | `](../matching-cv/)` |
| 19 | `](matching-cv/)` | `](../matching-cv/)` |
| 29 | `](matching-cv/README.md)` | `](../matching-cv/README.md)` |
| 29 | `](matching-cv/docs/INTRODUCTION.md)` | `](../matching-cv/docs/INTRODUCTION.md)` |

## Validation (§E whole-file audit)

- `scripts/check_docs_links.py` → "No broken links found." (whole file audited, not just the 4 fixed lines)
- All 3 distinct targets verified to exist: `../matching-cv/`, `../matching-cv/README.md`, `../matching-cv/docs/INTRODUCTION.md`
- 0 remaining bare `](matching-cv` refs
- Surgical diff: **+3 / −3**, 1 file, source prose unchanged
- Encoding: UTF-8 no-BOM, LF-only (no CRLF regression)

## Scope (atomic)

Only `cross-series/i18n/README.en.md`. Catalogue byte-identical to main.

See #4957 (i18n pilot epic). Not `Closes`: a link fix is partial to the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)