### PR TITLE
feat(lean,#2874): add figureEight_not_tricolorable via decide (Path-B witness)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -980,6 +980,22 @@ theorem unknot_not_tricolorable : ¬ Knot.isTricolorable unknot := by
   obtain ⟨i, j, hne⟩ := htwocolors
   exact hne (this i j)
 
+/-! ## 4b. La figure-eight n'est PAS tricolorable
+
+La figure-eight (4₁) possède 4 croisements et un déterminant égal à 5 ; elle
+n'est donc PAS 3-coloriable au sens de Fox. Sous **Path B** (conjonction
+d'arc-égalité `c₂ = c₄`), c'est le témoin de distinction canonique : le modèle
+permissif antérieur laissait passer une tricoloration parasite `(0,0,0,1,0,0,1,2)`
+(README §Path B), que la contrainte d'arc exclut désormais.
+
+Preuve par énumération finie (`decide`) : l'espace des coloriages `Fin 8 → TriColor`
+(3⁸ = 6561) est parcouru, et pour chacun la conjonction d'arc-égalité + Fox aux 4
+croisements est réfutée — soit l'arc-continuité casse, soit Fox force le monochrome
+(contrredisant « ≥ 2 couleurs »). Témoin de non-régression Path B (#2874). -/
+theorem figureEight_not_tricolorable : ¬ Knot.isTricolorable figureEight := by
+  unfold Knot.isTricolorable IsTricolorable IsTriColoring figureEight
+  decide
+
 /-! ## 5. Corollary: the trefoil is not the unknot
 
 Since tricolorability is an invariant, and the trefoil has it

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -943,6 +943,22 @@ theorem unknot_not_tricolorable : ¬ Knot.isTricolorable unknot := by
   obtain ⟨i, j, hne⟩ := htwocolors
   exact hne (this i j)
 
+/-! ## 4b. The figure-eight is NOT tricolorable
+
+The figure-eight (4_1) has 4 crossings and determinant 5, so it is NOT
+3-colorable in the Fox sense. Under **Path B** (the `c₂ = c₄` over-strand
+continuity conjunct), this is the canonical distinguishing witness: the earlier
+permissive model admitted a spurious tricoloring `(0,0,0,1,0,0,1,2)` (README
+§Path B), which the arc constraint now excludes.
+
+Proof by finite enumeration (`decide`): the coloring space `Fin 8 → TriColor`
+(3⁸ = 6561) is exhausted, and for each the arc-continuity + Fox conjunction at
+all 4 crossings is refuted — either arc-continuity breaks, or Fox forces
+monochrome (contradicting "≥ 2 colors"). Path-B non-regression witness (#2874). -/
+theorem figureEight_not_tricolorable : ¬ Knot.isTricolorable figureEight := by
+  unfold Knot.isTricolorable IsTricolorable IsTriColoring figureEight
+  decide
+
 /-! ## 5. Corollary: the trefoil is not the unknot
 
 Since tricolorability is an invariant, and the trefoil has it


### PR DESCRIPTION
## Summary

Adds a **new** theorem `figureEight_not_tricolorable` to both FR `Invariant.lean` and EN twin `Invariant_en.lean` (knot_lean), proving the figure-eight knot (4₁) is **NOT** Fox-tricolorable under the Path-B arc-respecting model.

This is the **canonical distinguishing witness** for Path-B (#3003): the figure-eight has determinant 5 and is classically non-3-colorable. The earlier permissive edge-model admitted a spurious tricoloring `(0,0,0,1,0,0,1,2)` that the `c₂ = c₄` over-strand-continuity conjunct now excludes (README §Path B). It mirrors `unknot_not_tricolorable` (L966 FR / L929 EN) as a non-regression guard that the invariant genuinely distinguishes trefoil (tricolorable) from figure-eight (not) — not just from the unknot.

## Proof

Finite enumeration via `decide` — the coloring space `Fin 8 → TriColor` (3⁸ = 6561) is exhausted; for each, the arc-continuity + Fox conjunction at all 4 crossings is refuted (either arc-continuity breaks, or Fox forces monochrome, contradicting "≥ 2 colors"). Zero sorry, zero proof-obligation.

```lean
theorem figureEight_not_tricolorable : ¬ Knot.isTricolorable figureEight := by
  unfold Knot.isTricolorable IsTricolorable IsTriColoring figureEight
  decide
```

## Anti-regression §D

- **Sorries unchanged**: FR=EN=3 real proof-sorries (README-def: `:= by sorry`/`:= sorry`/`exact sorry`); **0 added** (this theorem uses `decide`, no sorry).
- **i18n sibling check**: `1/1 pairs byte-identical | 0 drift | 0 orphan` (FR/EN theorem code identical modulo docstrings).
- **No existing proof touched** — purely additive (new theorem after `unknot_not_tricolorable`).

## Namespace resolution (EN twin verified)

The EN mirror resolves safely (the #6716 trap is avoided): `figureEight` is defined under `namespace Knots_en` in `Basic_en.lean` L169; `IsTriColoring`/`IsTricolorable`/`Knot.isTricolorable` all present in `Invariant_en.lean` (L175/181/185); `trefoil_tricolorable` (L275 EN) uses the same `unfold` pattern.

## ⚠️ Local lake build NOT validated (CI is the gate)

**Honest caveat**: local `lake build Knots.Invariant` on po-2026 did **not** complete this cycle — 3 failure modes: cold-build timeout, OOM/access-violation crashes (`3221226505`/`3221225477`) under parallel Mathlib rebuild, and timeout at 98% (2894/2948). Junctioning the worktree `.lake` → shared warm `.lake` did **not** propagate lake-DB trust → cold rebuild → OOM/timeout. **CI `lean-knot.yml` is the authoritative gate.**

Possible CI failure modes + response:
1. `Fintype (Fin 8 → TriColor)` / `Decidable` synthesis fails → add instances or `native_decide`.
2. `decide` finds a counterexample → figure-eight IS tricolorable under Path-B → contradicts README claim (a real finding to report, PR closed with diagnosis).
3. `decide` compile-time too long → switch to `native_decide` or a manual finite case-bash.

Greenlit by ai-01 (DM thread msg-2z6062): "arc-coloring test cases via `decide` (enumeration finie, zero sorry, zero proof-obligation)... Exactement la bonne voie."

See #2874 (Knot Epic, Phase 5). Not `Closes`: a single witness theorem is partial to the Epic (the marquee `tricolorable_invariant` remains gated on the 2 research-level §9.1 backward residuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)