### PR TITLE
docs(genai-audio,#5780): propagate c.445 vetted alt-texts to Audio/01-Foundation README (3 figures)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
@@ -41,7 +41,7 @@ Ce module pose les fondamentaux du traitement audio : synthèse vocale (TTS), re
 **Étape 2 — Spectrogramme.** Une transformée temps-fréquence (FFT) décompose ce signal en ses composantes spectrales : l'axe vertical devient la fréquence, l'intensité codant l'énergie. C'est la représentation qu'utilisent de nombreux modèles de speech :
 
 <p align="center">
-  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-spectrogram.webp" alt="Spectrogramme — décomposition temps-fréquence" width="420"/></a><br>
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-spectrogram.webp" alt="Analyse spectrale de l'échantillon audio — 3 panneaux empilés : Spectrogramme STFT (échelle linéaire 0-10000 Hz, magnitude dB -80→0), Spectrogramme Mel (échelle perceptuelle log 0-8192 Hz, dB -80→0) et Chromagramme (pitch class B-A-G-F-E-D-C, activation 0-1)." width="420"/></a><br>
   <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 15) : spectrogramme — décomposition temps-fréquence du même signal.</em>
 </p>
 
@@ -53,14 +53,14 @@ Ce module pose les fondamentaux du traitement audio : synthèse vocale (TTS), re
 </p>
 
 <p align="center">
-  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-mfcc2.png" alt="MFCC — carte de chaleur des coefficients" width="460"/></a><br>
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-mfcc2.png" alt="Dynamiques cepstrales — 3 panneaux empilés : MFCC statique (-500→+200) + Delta MFCC vitesse (-40→+40) + Delta-Delta MFCC accélération (-40→+40), illustrant l'évolution temporelle des coefficients cepstraux mel." width="460"/></a><br>
   <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 20, sortie 3) : MFCC en carte de chaleur — même information, vue alternative.</em>
 </p>
 
 **Étape 4 — Extraction de caractéristiques.** Aboutissement du pipeline : les descripteurs extraits (centroid spectral, RMS, ZCR…) alimentent directement les comparaisons et benchmarks des niveaux suivants :
 
 <p align="center">
-  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-features.png" alt="Extraction de caractéristiques audio" width="480"/></a><br>
+  <a href="01-3-Basic-Audio-Operations.ipynb"><img src="assets/readme/aud1-features.png" alt="Caractéristiques audio extraites (librosa) — 4 panneaux empilés : Spectral Centroid (Hz 0-8000, bleu), Spectral Bandwidth (Hz 1000-3500, vert), RMS Energy (Amplitude 0-0,15, rouge) et Zero-Crossing Rate (Rate 0-0,6, violet), sur 12 secondes d'échantillon." width="480"/></a><br>
   <em>Sortie du notebook <a href="01-3-Basic-Audio-Operations.ipynb">01-3</a> (cellule 28) : extraction des caractéristiques audio — le pipeline complet résumé.</em>
 </p>
 


### PR DESCRIPTION
## Summary

EPIC #5780 partial: propagate 3 vetted alt-text corrections from the `GenAI/Audio/01-Foundation` MANIFEST to the README in-situ. The c.445 founder audit (PR #6635, MERGED 2026-07-15) vetted these corrected alt-texts into the MANIFEST's `Alt-text (FR)` fields but **touched only the MANIFEST (+66/-12, 1 file) — the corrections were never propagated to the README `alt="..."` attributes**, which still carried the v1 short versions that omit 2/3 of the subplots. This PR closes that propagation gap.

### The defect (G.1 firsthand, origin/main = source of truth)

`gh pr view 6635 --json files` confirms #6635 modified **only** `assets/readme/MANIFEST.md` (1 file). `git show origin/main:.../01-Foundation/README.md` confirms the README still has the 3 v1 short alt-texts at L44/L56/L63. The 3 figures are over-sellers — each renders 3 (or 4) stacked subplots but the v1 alt-text described only 1:

| Line | Figure | v1 alt-text (defective) | Vetted alt-text (propagated) |
|------|--------|-------------------------|------------------------------|
| L44 | `aud1-spectrogram.webp` | « décomposition temps-fréquence » — omits Mel + Chromagramme panels | « 3 panneaux : Spectrogramme STFT + Mel + Chromagramme » |
| L56 | `aud1-mfcc2.png` | « carte de chaleur des coefficients » — omits Delta + Delta-Delta panels | « 3 panneaux : MFCC statique + Delta MFCC vitesse + Delta-Delta accélération » |
| L63 | `aud1-features.png` | generic « Extraction de caractéristiques audio » — doesn't name the 4 features | « 4 panneaux : Spectral Centroid + Bandwidth + RMS Energy + Zero-Crossing Rate » |

### Honesty-safe propagation (no vision re-judgment)

The 3 corrected alt-texts are copied **verbatim** from the c.445 MANIFEST `Alt-text (FR)` fields (MANIFEST L34 / L53 / L63), each of which was vetted by a G.1 firsthand PNG read with a `Contenu réel vérifié` section. This PR performs **no new image judgment** — it only completes the MANIFEST→README propagation that #6635 left unfinished. This avoids the ForexCarry-style file↔content inversion risk (cf c.450 / L501): the content judgment was made and documented in c.445; this PR mechanically propagates it.

### Verification

```
$ git diff --stat
 MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

$ git diff | grep -c $'\r'   # CRLF count
0   # LF-only (UTF-8 no-BOM)

$ git diff --name-only | grep -iE "CATALOG-STATUS|COURSE_CATALOG"
(none)   # R1 catalog-pr-hygiene OK — no catalogue regeneration

$ git diff | grep -nE "sk-|ghp_|AIza|password=|secret="
(none)   # secrets-hygiene OK
```

The 2 ACCURATE alt-texts (`aud1-waveform` L37, `aud1-mfcc` L51) are left untouched (c.445 verdict VRAI). The `<em>` captions are left as-is (generic but not wrong; caption enrichment is out of the vetted scope and would cross from propagation into re-authoring).

### Scope

`See #5780` (partial contribution — completes the c.445 propagation for the Audio/01-Foundation leaf; the root Audio README was already honest per the c.490 audit which states « Aucune correction d'alt-text in-situ n'est nécessaire »).

### Hygiene

- **R1 catalog-pr-hygiene** ✅ : 0 CATALOG-STATUS / COURSE_CATALOG touched, 0 catalogue regeneration
- **G.4 atomic** ✅ : 1 file, +3/-3, 1 feature (propagate 3 vetted alt-texts), 1 domain (GenAI/Audio figures)
- **L487 worktree-isolated** ✅ : new worktree `CoursIA-c468-audio-alttext` from `origin/main` (shared tree had Nash.lean WIP #6719, untouched)
- **readme-french-first** ✅ : alt-texts in French (FR-first per §E)
- **Read Body Before Any Action** ✅ : read full MANIFEST (c.445 + c.490) + README in-situ + `gh pr view 6635 --json files` + `git show origin/main:` before editing

Co-Authored-By: Claude <noreply@anthropic.com>
