### PR TITLE
i18n(lean,#4980): Gittins/Basic canonical EN → FR (docstrings only)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Basic.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Basic.lean
@@ -1,36 +1,38 @@
 import Mathlib.Data.Real.Basic
 
 /-!
-# Basic Definitions — Multi-Armed Bandits
+# Définitions de base — Bandits Manchots (Multi-Armed Bandits)
 
-Core types for the bandit problem: arms, instances, policies, and value functions.
-Means and discount factors are carried on `ℝ` (not `Float`) so that order laws are
-reflexive — a bandit mean is a real number, never a `NaN`. Sampled reward histories
-stay `Float` (empirical quantities); the two notions are deliberately distinct.
+Types fondamentaux du problème du bandit : bras, instances, politiques et fonctions
+de valeur. Les moyennes et facteurs d'actualisation sont portés par `ℝ` (et non
+`Float`) afin que les lois d'ordre soient réflexives — une moyenne de bandit est un
+nombre réel, jamais un `NaN`. Les historiques de récompenses échantillonnées
+restent en `Float` (quantités empiriques) ; les deux notions sont délibérément
+distinctes.
 -/
 
 namespace Gittins
 
-/-- A bandit arm characterized by its true mean reward. -/
+/-- Un bras de bandit, caractérisé par sa récompense moyenne réelle. -/
 structure BanditArm where
   name : String
   trueMean : ℝ
 
-/-- A bandit instance: a collection of arms with a discount factor. -/
+/-- Une instance de bandit : une collection de bras avec un facteur d'actualisation. -/
 structure BanditInstance where
   arms : Array BanditArm
   discount : ℝ  -- gamma in (0, 1)
 
-/-- A policy maps each time step to the index of the arm to pull. -/
+/-- Une politique associe à chaque pas de temps l'indice du bras à tirer. -/
 def Policy := Nat → Nat
 
-/-- A reward history for a single arm. -/
+/-- Un historique de récompenses pour un seul bras. -/
 def RewardHistory := List Float
 
-/-- Number of times an arm has been pulled. -/
+/-- Nombre de fois qu'un bras a été tiré. -/
 def pullCount (history : RewardHistory) : Nat := history.length
 
-/-- Empirical mean from a reward history. Returns 0 for empty history. -/
+/-- Moyenne empirique d'un historique de récompenses. Vaut 0 pour un historique vide. -/
 def empiricalMean (history : RewardHistory) : Float :=
   match history with
   | [] => 0.0


### PR DESCRIPTION
@@PO2023-FRENCH@@
Bascule FR-canonical du module `decision_theory_lean/Gittins/Basic.lean` (EPIC #4980). Le canonical restait EN alors que son sibling `_en.lean` (PR #5571) et le module voisin `Coherence/Basic.lean` étaient déjà FR-canonical.

## Changement

Les **7 docstrings** (1 module `/-! … -/` + 6 items `/-- … -/`) sont traduites EN → FR. **Aucune modification des énoncés Lean** (signatures, `structure`, `def`, namespace, commentaire inline `-- gamma in (0,1)`).

Exemple :
- Module : `# Basic Definitions — Multi-Armed Bandits` → `# Définitions de base — Bandits Manchots (Multi-Armed Bandits)`
- `/-- A bandit arm characterized by its true mean reward. -/` → `/-- Un bras de bandit, caractérisé par sa récompense moyenne réelle. -/`

## Byte-identity (convention sibling-pair #4980)

`check_i18n_siblings.py` verdict : **12/12 pairs byte-identical, 0 drift, 0 orphan**. La seule diff structurelle entre `Basic.lean` (FR canonique) et `Basic_en.lean` (miroir EN) est le namespace suffixé (`Gittins` vs `Gittins_en`) — exactement la convention attendue. Strip-docstrings comparison : énoncés Lean byte-identical.

## Anti-régression

- `grep sorry` = **0** (aucune preuve touchée, aucune tactique modifiée).
- `diff --stat` : 14 insertions / 12 suppressions — cohérent avec une traduction de docstrings (reformulation FR).
- CI Lean build = oracle (po-2023 n'a pas les olocales Mathlib locaux) ; les docstrings sont neutres pour la compilation.

## Contexte i18n

Convention Lean ratifiée (ai-01 2026-07-04, #4980) : docstrings FR par défaut dans les `*.lean` own, miroir EN optionnel via sibling `_en.lean`. Le lake `decision_theory_lean` avait `Coherence/*` déjà FR-canonical mais `Gittins/Basic.lean` oublié EN — cette PR comble ce gap. Pattern identique aux PRs #6352 (LeftExact), #5546 (Argumentation).

See #4980.

Co-Authored-By: Claude <noreply@anthropic.com>