### PR TITLE
feat(lean-i18n,#4980): orphan-trap guard — flag _en siblings lake build never compiles

### DIFF
--- a/scripts/lean/check_i18n_siblings.py
+++ b/scripts/lean/check_i18n_siblings.py
@@ -47,8 +47,11 @@ Usage
 out-of-scope trees (``.lake/``, ``_peters/``, ``reference_docs/``, ...).
 
 Exit code ``0`` if every discovered pair matches (or none is found), ``1`` on any
-body drift or on an orphan ``_en`` file (a ``*_en.lean`` whose FR sibling is
-missing).
+body drift, on an orphan ``_en`` file (a ``*_en.lean`` whose FR sibling is
+missing), or on an *unbuilt* ``_en`` file (a ``*_en.lean`` whose module is
+neither an explicit lake root nor covered by a parent glob, so ``lake build``
+never compiles it and a green ``Lean CI`` is a false pass for it — the #6749
+orphan-trap, which the body comparison alone cannot catch).
 """
 from __future__ import annotations
 
@@ -323,6 +326,96 @@ def fr_sibling(en_path: Path) -> Path:
     return en_path.with_name(en_path.name[: -len("_en.lean")] + ".lean")
 
 
+# --- Orphan-trap guard: an `_en` mirror that `lake build` never compiles (#6749)
+# A `*_en.lean` whose module is neither an explicit lake root nor covered by a
+# parent glob is never built — so a green ``Lean CI (<lake>)`` is a FALSE PASS
+# for that sibling (the job only cold-builds the declared roots/globs, and Lake
+# matches roots by EXACT module name, not stem). This guard reproduces the
+# by-hand roots-array check that gated the #6752 / #6749 / #6753 duplicates,
+# which the ``OK``/``DRIFT`` body comparison alone cannot catch: bodies can be
+# byte-identical while the mirror silently sits outside the build.
+_LAKEFILE_NAMES = ("lakefile.toml", "lakefile.lean")
+
+# `.lean` glob tokens inside `globs := #[...]` / `roots := #[...]`:
+#   `Foo          → exact        Foo
+#   `Foo_en       → exact        Foo_en
+#   `Foo.*  `Foo.+ → glob-prefix Foo   (Foo and its submodules)
+#   .submodules `Foo / .andSubmodules `Foo → glob-prefix Foo
+_LEAN_BACKTICK = re.compile(
+    r"(?P<sub>\.submodules\s+|\.andSubmodules\s+)?"
+    r"`(?P<name>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)"
+    r"(?P<glob>\.\*|\.\+)?"
+)
+_LEAN_LIB = re.compile(r"lean_lib\s+«?([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)»?")
+# `.toml` arrays: roots = [ "A", "B" ]  /  globs = [ "A.*" ]
+_TOML_ARRAY = re.compile(r"\b(?:roots|globs)\s*=\s*\[(.*?)\]", re.DOTALL)
+
+
+def lake_targets(lakefile: Path) -> tuple[set[str], set[str]]:
+    """Parse a lakefile into ``(exact, glob_prefixes)`` — the modules Lake will
+    compile. ``exact`` are single modules (``Foo``, ``Foo_en``); each entry of
+    ``glob_prefixes`` is a parent whose subtree is globbed (``Foo`` from
+    ``Foo.*`` / ``.submodules `Foo``). Returns empty sets when nothing parses,
+    so the caller can conservatively skip rather than false-flag."""
+    exact: set[str] = set()
+    globs: set[str] = set()
+    text = lakefile.read_text(encoding="utf-8", errors="replace")
+    if lakefile.name == "lakefile.toml":
+        # Drop `#` comments, then read quoted entries of roots/globs arrays.
+        text = re.sub(r"#[^\n]*", "", text)
+        for arr in _TOML_ARRAY.finditer(text):
+            for m in re.finditer(r'"([^"]+)"', arr.group(1)):
+                name = m.group(1)
+                if name.endswith((".*", ".+")):
+                    globs.add(name[:-2])
+                else:
+                    exact.add(name)
+    else:
+        # `.lean`: strip comments first (doc comments quote example globs, e.g.
+        # conway_cgt_lean's ``globs := #[`Foo, `Foo_en]`` in prose).
+        code = strip_comments(text)
+        for m in _LEAN_LIB.finditer(code):
+            exact.add(m.group(1))  # a lib with no globs roots at its own name
+        for m in _LEAN_BACKTICK.finditer(code):
+            if m.group("sub") or m.group("glob"):
+                globs.add(m.group("name"))
+            else:
+                exact.add(m.group("name"))
+    return exact, globs
+
+
+def enclosing_lake(en_path: Path, repo_root: Path) -> Path | None:
+    """Nearest ancestor directory (up to ``repo_root``) holding a lakefile."""
+    for d in [en_path.parent, *en_path.parents]:
+        for name in _LAKEFILE_NAMES:
+            if (d / name).is_file():
+                return d / name
+        if d == repo_root:
+            break
+    return None
+
+
+def check_en_built(en_path: Path, repo_root: Path) -> tuple[bool | None, str]:
+    """Is ``en_path``'s module compiled by its lake? ``(True, "")`` when a root
+    or glob covers it, ``(False, reason)`` when it is an orphan Lake never
+    builds (the #6749 trap), ``(None, reason)`` when undeterminable (no lakefile
+    / unparsable) — the caller skips those rather than false-flag."""
+    en_path = en_path.resolve()
+    lakefile = enclosing_lake(en_path, repo_root)
+    if lakefile is None:
+        return None, "no enclosing lakefile"
+    exact, globs = lake_targets(lakefile)
+    if not exact and not globs:
+        return None, f"no roots/globs parsed from {lakefile.name}"
+    module = ".".join(en_path.relative_to(lakefile.parent).with_suffix("").parts)
+    if module in exact or any(
+            module == g or module.startswith(g + ".") for g in globs):
+        return True, ""
+    return False, (
+        f"module `{module}` absent from {lakefile.name} roots/globs "
+        "-> never compiled by `lake build` (a green Lean CI is a false pass)")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("paths", nargs="*", help="files or directories to scan")
@@ -343,13 +436,21 @@ def main(argv: list[str] | None = None) -> int:
         print("No *_en.lean sibling files found — nothing to check.")
         return 0
 
-    passed = consumer = failed = orphan = 0
+    passed = consumer = failed = orphan = unbuilt = 0
     for en in sorted(en_files):
         fr = fr_sibling(en)
         if not fr.exists():
             orphan += 1
             print(f"ORPHAN  {en}  (no FR sibling {fr.name})")
             continue
+        # Orphan-trap guard (#6749): flag an `_en` mirror Lake never compiles.
+        # Orthogonal to the body check below — a pair can be byte-identical yet
+        # sit outside the build, which is exactly the failure CI misses.
+        built, why = check_en_built(en, repo_root)
+        if built is False:
+            unbuilt += 1
+            print(f"UNBUILT {en}")
+            print(f"        {why}")
         status, detail = check_pair(fr, en)
         if status == "OK":
             passed += 1
@@ -363,8 +464,9 @@ def main(argv: list[str] | None = None) -> int:
             print(detail)
     total = passed + consumer + failed + orphan
     print(f"\n{passed}/{total} pairs byte-identical"
-          f" | {consumer} consumer-pattern | {failed} drift | {orphan} orphan")
-    return 0 if (failed == 0 and orphan == 0) else 1
+          f" | {consumer} consumer-pattern | {failed} drift | {orphan} orphan"
+          f" | {unbuilt} unbuilt")
+    return 0 if (failed == 0 and orphan == 0 and unbuilt == 0) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/lean/tests/test_check_i18n_siblings.py
+++ b/scripts/lean/tests/test_check_i18n_siblings.py
@@ -13,10 +13,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_i18n_siblings import (  # noqa: E402
     _drift_detail,
+    check_en_built,
     check_pair,
+    enclosing_lake,
     find_en_files,
     fr_sibling,
     imports_fr_sibling,
+    lake_targets,
     normalize_body,
     split_decls,
     strip_comments,
@@ -379,6 +382,103 @@ def test_real_conway_pairs_are_byte_identical():
         if status == "DRIFT":
             failures.append(f"DRIFT {en.name}\n{detail}")
     assert not failures, "\n".join(failures)
+
+
+# --- Orphan-trap guard (#6749): an `_en` mirror `lake build` never compiles ---
+
+
+def test_lake_targets_toml_roots(tmp_path):
+    """`.toml` `roots = [...]` → exact names; a `"Foo.*"` entry → glob prefix."""
+    lf = tmp_path / "lakefile.toml"
+    lf.write_text(
+        '# comment with roots = ["ignored"] in prose\n'
+        '[[lean_lib]]\nname = "L"\n'
+        'roots = [\n  "Basic", "Nash",\n  "Nash_en",\n]\n'
+        'globs = ["Extra.*"]\n',
+        encoding="utf-8",
+    )
+    exact, globs = lake_targets(lf)
+    assert exact == {"Basic", "Nash", "Nash_en"}
+    assert globs == {"Extra"}
+
+
+def test_lake_targets_lean_globs(tmp_path):
+    """`.lean` backtick tokens: bare → exact, `.*` / `.submodules` → glob-prefix;
+    doc-comment example globs are stripped and must not leak into the sets."""
+    lf = tmp_path / "lakefile.lean"
+    lf.write_text(
+        "import Lake\nopen Lake DSL\n"
+        "-- doc: `globs := #[`Ghost, `Ghost_en]` appears only in prose\n"
+        "lean_lib «Foo» where\n"
+        "  globs := #[.submodules `Foo, `Foo_en]\n"
+        "lean_lib «Bar» where\n"
+        "  globs := #[`Bar.*]\n",
+        encoding="utf-8",
+    )
+    exact, globs = lake_targets(lf)
+    assert "Foo_en" in exact and "Foo" in exact and "Bar" in exact
+    assert "Foo" in globs and "Bar" in globs
+    assert "Ghost" not in exact and "Ghost_en" not in exact  # comment stripped
+
+
+def test_check_en_built_flags_orphan_toml(tmp_path):
+    """The #6749 trap: a root-level `_en` absent from `roots` is UNBUILT."""
+    lake = tmp_path / "mylake"
+    lake.mkdir()
+    (lake / "lakefile.toml").write_text(
+        '[[lean_lib]]\nname = "L"\nroots = ["Basic", "Nash", "Nash_en"]\n',
+        encoding="utf-8",
+    )
+    (lake / "Basic_en.lean").write_text("-- orphan\n", encoding="utf-8")
+    built, why = check_en_built(lake / "Basic_en.lean", tmp_path)
+    assert built is False
+    assert "Basic_en" in why and "never compiled" in why
+
+
+def test_check_en_built_passes_when_in_roots(tmp_path):
+    """A root-level `_en` explicitly listed in `roots` is built (no flag)."""
+    lake = tmp_path / "mylake"
+    lake.mkdir()
+    (lake / "lakefile.toml").write_text(
+        '[[lean_lib]]\nname = "L"\nroots = ["Nash", "Nash_en"]\n',
+        encoding="utf-8",
+    )
+    (lake / "Nash_en.lean").write_text("-- covered\n", encoding="utf-8")
+    built, why = check_en_built(lake / "Nash_en.lean", tmp_path)
+    assert built is True and why == ""
+
+
+def test_check_en_built_glob_covers_submodule(tmp_path):
+    """A submodule `_en` under a `.submodules`/`.*` parent glob is built — the
+    guard must NOT flag it (matches game_theory_lean `RepeatedGames.*`)."""
+    lake = tmp_path / "glake"
+    (lake / "Foo").mkdir(parents=True)
+    (lake / "lakefile.lean").write_text(
+        "lean_lib «Foo» where\n  globs := #[.submodules `Foo]\n",
+        encoding="utf-8",
+    )
+    (lake / "Foo" / "Bar_en.lean").write_text("-- sub\n", encoding="utf-8")
+    built, _ = check_en_built(lake / "Foo" / "Bar_en.lean", tmp_path)
+    assert built is True
+
+
+def test_check_en_built_skips_without_lakefile(tmp_path):
+    """No enclosing lakefile → undeterminable → skip (None), never false-flag."""
+    (tmp_path / "Loose_en.lean").write_text("-- x\n", encoding="utf-8")
+    built, why = check_en_built(tmp_path / "Loose_en.lean", tmp_path)
+    assert built is None
+    assert "lakefile" in why
+
+
+def test_enclosing_lake_walks_up_to_nearest(tmp_path):
+    """`enclosing_lake` returns the nearest ancestor lakefile, stopping at root."""
+    lake = tmp_path / "l"
+    (lake / "sub").mkdir(parents=True)
+    lf = lake / "lakefile.lean"
+    lf.write_text("lean_lib «L» where\n", encoding="utf-8")
+    found = enclosing_lake(lake / "sub" / "X_en.lean", tmp_path)
+    assert found == lf
+    assert enclosing_lake(tmp_path / "Nowhere_en.lean", tmp_path) is None
 
 
 def _run_direct() -> int:


### PR DESCRIPTION
## Summary

`scripts/lean/check_i18n_siblings.py` proves an EN mirror `Foo_en.lean` has not **drifted** from its FR sibling (`OK`/`DRIFT` body byte-identity). It could not see the other #4980 failure mode: an `_en` mirror that sits **outside the lake build**. When `Foo_en`'s module is neither an explicit lakefile root nor covered by a parent glob, `lake build` never compiles it — so a green `Lean CI (<lake>)` is a **false pass** for that sibling. This is the **#6749 orphan-trap** (`Basic_en`), which the rollout gated **by hand** this cycle on the #6752 / #6749 / #6753 duplicates.

This PR codifies that manual gate.

## What it adds

- **`check_en_built(en_path, repo_root)`** — finds the enclosing lakefile, parses its targets, computes the `_en` module relative to the lake dir, and returns:
  - `(True, "")` when an exact root or a parent glob covers it,
  - `(False, reason)` when it is an orphan Lake never builds → **`UNBUILT`**, exit 1,
  - `(None, reason)` when undeterminable (no lakefile / unparsable) → **skip**, never false-flag.
- **`lake_targets(lakefile)`** — parses both formats: `.toml` `roots`/`globs` arrays; `.lean` `globs := #[...]` backtick tokens (bare → exact, `` `Foo.* ``/`.submodules `Foo` → glob-prefix) + `lean_lib` names. Comments are stripped first so doc-comment example globs don't leak in.
- Orthogonal to the body check — a pair can be byte-identical **yet** unbuilt (both lines print). Summary gains `| N unbuilt`; exit 1 on any `UNBUILT`.

## It already caught a live one

Running `--all` on `main` surfaced **one real orphan already merged**:

```
UNBUILT  MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/MathLibExamples/Basic_en.lean
         module `MathLibExamples.Basic_en` absent from lakefile.lean roots/globs
         -> never compiled by `lake build` (a green Lean CI is a false pass)
```

The lake declares a bare `lean_lib «MathLibExamples»` (no `globs`), so Lake builds only the root + its FR imports; `Basic_en` (added 2026-07-15) is never reached. Verified true-positive: the FR root `MathLibExamples.lean` imports `MathLibExamples.Basic`, never `Basic_en`. **Tracked as a separate Lean-lane follow-up** (1-line glob fix `globs := #[.submodules \`MathLibExamples]` + `lake build` verify) rather than folded here, per lean-merge-discipline (no unverified build-graph change in a tooling PR).

## Validation

- `--all` on `main`: `146/148 byte-identical | 2 consumer | 0 drift | 0 orphan | 1 unbuilt` — the `1 unbuilt` is the real orphan above; **zero false positives** across the 148 legitimately-built pairs (submodule `_en` under a `.*` glob stays covered).
- **+7 tests** (toml/lean target parse with comment-strip, orphan flag, in-roots pass, submodule-glob coverage, no-lakefile skip, enclosing-lake walk-up). Full suite **30/30 green** (auto-collected by `scripts-tests.yml`).

Pure-Python tooling; touches no notebooks, no catalogue, no workflows.

See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)