### PR TITLE
i18n(lean,#4980): lean_game_defs/SocialChoice FR-first sibling pair (supersedes #6772/#6776)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/SocialChoice.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/SocialChoice.lean
@@ -12,82 +12,58 @@
   Inspiré de asouther4/lean-social-choice (Lean 3)
 
   ---
-  English:
-  Social Choice Theory in Lean 4
-  ==============================
-
-  Formalizes key concepts from social choice theory:
-  - Preferences and orderings
-  - Social welfare functions
-  - Arrow's axioms (Pareto, IIA, Non-dictatorship)
-  - Arrow's Impossibility Theorem (statement)
-
-  Based on GameTheory-19-Lean-SocialChoice.ipynb
-  Inspired by asouther4/lean-social-choice (Lean 3)
+  Jumelage i18n : ce module est le FR canonique (sibling pair Pattern A,
+  ratifié par user 2026-07-04 sur EPIC #4980). Le miroir anglais vit dans
+  `SocialChoice_en.lean` (variante reuse-FR-names : contrairement à `Nash.lean`
+  qui dépend du module de base partagé `Basic`, `SocialChoice.lean` est
+  autonome — aucun import, Lean core uniquement — donc le miroir EN l'est
+  aussi et re-déclare ses types dans `namespace SocialChoiceEn`). Le corps des
+  définitions, signatures, tactiques et de l'axiome `arrow_impossibility` est
+  byte-identique entre les deux fichiers ; seules les docstrings `/-! ... -/`
+  (titres de section) et `/-- ... -/` (docstrings de déclarations) diffèrent,
+  FR dans ce fichier, EN dans `SocialChoice_en.lean`.
 -/
 
 /-!
 ## Préférences
-
----
-English:
-## Preferences
 -/
 
-/-- Une relation de préférence est une relation binaire sur les alternatives.
-    English: A preference relation is a binary relation on alternatives -/
+/-- Une relation de préférence est une relation binaire sur les alternatives. -/
 structure Preference (A : Type) where
-  /-- `R x y` signifie « x est au moins aussi bon que y ».
-      English: R x y means "x is at least as good as y" -/
+  /-- `R x y` signifie « x est au moins aussi bon que y ». -/
   R : A → A → Prop
-  /-- Complétude : pour tout x, y, soit R x y soit R y x.
-      English: Completeness: for any x, y, either R x y or R y x -/
+  /-- Complétude : pour tout x, y, soit R x y soit R y x. -/
   complete : ∀ x y, R x y ∨ R y x
-  /-- Transitivité.
-      English: Transitivity -/
+  /-- Transitivité. -/
   trans : ∀ x y z, R x y → R y z → R x z
 
-/-- Préférence stricte : x est strictement préféré à y.
-    English: Strict preference: x is strictly preferred to y -/
+/-- Préférence stricte : x est strictement préféré à y. -/
 def StrictPref {A : Type} (p : Preference A) (x y : A) : Prop :=
   p.R x y ∧ ¬p.R y x
 
-/-- Indifférence : x et y sont également bons.
-    English: Indifference: x and y are equally good -/
+/-- Indifférence : x et y sont également bons. -/
 def Indifferent {A : Type} (p : Preference A) (x y : A) : Prop :=
   p.R x y ∧ p.R y x
 
 /-!
 ## Fonctions de bien-être social
-
----
-English:
-## Social Welfare Functions
 -/
 
-/-- Une fonction de bien-être social agrège les préférences individuelles en une préférence sociale.
-    English: A social welfare function aggregates individual preferences into a social preference -/
+/-- Une fonction de bien-être social agrège les préférences individuelles en une préférence sociale. -/
 structure SocialWelfareFunction (I A : Type) where
-  /-- La fonction d'agrégation.
-      English: The aggregation function -/
+  /-- La fonction d'agrégation. -/
   aggregate : (I → Preference A) → Preference A
 
 /-!
 ## Axiomes d'Arrow
-
----
-English:
-## Arrow's Axioms
 -/
 
-/-- Pareto faible : si tout le monde préfère strictement x à y, la société préfère x à y.
-    English: Weak Pareto: If everyone strictly prefers x to y, society prefers x to y -/
+/-- Pareto faible : si tout le monde préfère strictement x à y, la société préfère x à y. -/
 def WeakPareto {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
   ∀ prefs : I → Preference A, ∀ x y,
     (∀ i, StrictPref (prefs i) x y) → StrictPref (swf.aggregate prefs) x y
 
-/-- Indépendance des alternatives non pertinentes (IIA).
-    English: Independence of Irrelevant Alternatives (IIA) -/
+/-- Indépendance des alternatives non pertinentes (IIA). -/
 def IIA {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
   ∀ prefs prefs' : I → Preference A, ∀ x y,
     -- Si les préférences x vs y sont identiques dans les deux profils
@@ -96,18 +72,13 @@ def IIA {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
     -- Alors la préférence sociale sur x, y est identique
     ((swf.aggregate prefs).R x y ↔ (swf.aggregate prefs').R x y)
 
-/-- Non-dictature : aucun individu unique ne détermine la préférence sociale.
-    English: Non-dictatorship: No single individual determines the social preference -/
+/-- Non-dictature : aucun individu unique ne détermine la préférence sociale. -/
 def NonDictatorial {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
   ¬∃ d : I, ∀ prefs : I → Preference A, ∀ x y,
     StrictPref (prefs d) x y → StrictPref (swf.aggregate prefs) x y
 
 /-!
 ## Théorème d'impossibilité d'Arrow
-
----
-English:
-## Arrow's Impossibility Theorem
 -/
 
 /--
@@ -119,17 +90,6 @@ il n'existe pas de fonction de bien-être social avec ≥ 3 alternatives qui sat
 
 Note : énoncé avec des types `Fin n` explicites plutôt qu'un `Fintype` générique
 pour éviter la dépendance Mathlib. Le contenu mathématique du théorème est identique.
-
----
-English:
-Arrow's Impossibility Theorem (Statement):
-There is no social welfare function with ≥3 alternatives that satisfies:
-1. Weak Pareto
-2. Independence of Irrelevant Alternatives
-3. Non-dictatorship
-
-Note: Stated with explicit `Fin n` types instead of generic `Fintype`
-to avoid Mathlib dependency. The theorem's mathematical content is identical.
 -/
 -- La preuve complète nécessite une machinerie importante ; nous l'énonçons comme axiome
 axiom arrow_impossibility {nI nA : Nat}
@@ -142,20 +102,14 @@ axiom arrow_impossibility {nI nA : Nat}
 
 /-!
 ## Exemples
-
----
-English:
-## Examples
 -/
 
-/-- SWF dictatorial : la préférence de l'individu d devient la préférence sociale.
-    English: Dictatorship SWF: Individual d's preference becomes social preference -/
+/-- SWF dictatorial : la préférence de l'individu d devient la préférence sociale. -/
 def dictatorship {I A : Type} (d : I) : SocialWelfareFunction I A := {
   aggregate := fun prefs => prefs d
 }
 
-/-- Théorème : une dictature satisfait Pareto et IIA.
-    English: Theorem: A dictatorship satisfies Pareto and IIA -/
+/-- Théorème : une dictature satisfait Pareto et IIA. -/
 theorem dictatorship_satisfies_pareto {I A : Type} (d : I) :
     WeakPareto (dictatorship (I := I) (A := A) d) := by
   intro prefs x y h_all
@@ -168,14 +122,9 @@ theorem dictatorship_satisfies_iia {I A : Type} (d : I) :
 
 /-!
 ## Impossibilité de Sen
-
----
-English:
-## Sen's Impossibility
 -/
 
-/-- Libéralisme minimal : un individu est décisif sur au moins une paire.
-    English: Minimal Liberalism: Some individual is decisive over some pair -/
+/-- Libéralisme minimal : un individu est décisif sur au moins une paire. -/
 def MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
   ∃ i : I, ∃ x y : A,
     ∀ prefs : I → Preference A,
@@ -185,28 +134,17 @@ def MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
    aucune SWF ne peut satisfaire à la fois Pareto faible et Libéralisme minimal
    sous certaines configurations de préférences.
    (Énoncé plus faible — le théorème complet nécessite de construire
-   des profils de préférences spécifiques.)
-   English: Sen's Impossibility Theorem (Statement):
-   No SWF can satisfy both Weak Pareto and Minimal Liberalism
-   under certain preference configurations.
-   (Weaker statement — the full theorem requires constructing
-   specific preference profiles.) -/
+   des profils de préférences spécifiques.) -/
 
 /-!
 ## Représentations par utilité
-
----
-English:
-## Utility Representations
 -/
 
-/-- Une fonction d'utilité représente une préférence si `u(x) ≥ u(y)` ssi `R x y`.
-    English: A utility function represents a preference if u(x) ≥ u(y) iff R x y -/
+/-- Une fonction d'utilité représente une préférence si `u(x) ≥ u(y)` ssi `R x y`. -/
 def represents {A : Type} (u : A → Int) (p : Preference A) : Prop :=
   ∀ x y, p.R x y ↔ u x >= u y
 
-/-- Construit une préférence à partir d'une fonction d'utilité.
-    English: Create a preference from a utility function -/
+/-- Construit une préférence à partir d'une fonction d'utilité. -/
 def prefFromUtility {A : Type} (u : A → Int)
     (h_finite : ∀ x y, u x >= u y ∨ u y >= u x := by decide) : Preference A := {
   R := fun x y => u x >= u y

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/SocialChoice_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/SocialChoice_en.lean
@@ -1,0 +1,160 @@
+/-
+  Social Choice Theory in Lean 4
+  ==============================
+
+  Formalizes key concepts from social choice theory:
+  - Preferences and orderings
+  - Social welfare functions
+  - Arrow's axioms (Pareto, IIA, Non-dictatorship)
+  - Arrow's Impossibility Theorem (statement)
+
+  Based on GameTheory-19-Lean-SocialChoice.ipynb
+  Inspired by asouther4/lean-social-choice (Lean 3)
+
+  ---
+  i18n sibling: this module is the EN mirror of the FR canonical
+  `SocialChoice.lean` (sibling-pair Pattern A, ratified by user on 2026-07-04,
+  EPIC #4980). The FR canonical lives in `SocialChoice.lean` (top-level
+  declarations, no namespace). Unlike `Nash_en.lean` (which `import Basic`
+  because `Nash.lean` depends on the shared `Game2x2` base), `SocialChoice.lean`
+  is self-contained (no imports, Lean core only), so this EN mirror is likewise
+  self-contained and re-declares its types (`Preference`, `SocialWelfareFunction`,
+  ...) inside `namespace SocialChoiceEn` to avoid name collisions with the FR
+  `SocialChoice` module when both live in the same lake. The body of
+  definitions, signatures, tactics and the `arrow_impossibility` axiom is
+  byte-identical between the two files; only the docstrings `/-! ... -/`
+  (section headings) and `/-- ... -/` (declaration docstrings) differ — EN in
+  this file, FR in `SocialChoice.lean`.
+-/
+
+namespace SocialChoiceEn
+
+/-!
+## Preferences
+-/
+
+/-- A preference relation is a binary relation on alternatives. -/
+structure Preference (A : Type) where
+  /-- R x y means "x is at least as good as y" -/
+  R : A → A → Prop
+  /-- Completeness: for any x, y, either R x y or R y x -/
+  complete : ∀ x y, R x y ∨ R y x
+  /-- Transitivity -/
+  trans : ∀ x y z, R x y → R y z → R x z
+
+/-- Strict preference: x is strictly preferred to y -/
+def StrictPref {A : Type} (p : Preference A) (x y : A) : Prop :=
+  p.R x y ∧ ¬p.R y x
+
+/-- Indifference: x and y are equally good -/
+def Indifferent {A : Type} (p : Preference A) (x y : A) : Prop :=
+  p.R x y ∧ p.R y x
+
+/-!
+## Social Welfare Functions
+-/
+
+/-- A social welfare function aggregates individual preferences into a social preference -/
+structure SocialWelfareFunction (I A : Type) where
+  /-- The aggregation function -/
+  aggregate : (I → Preference A) → Preference A
+
+/-!
+## Arrow's Axioms
+-/
+
+/-- Weak Pareto: If everyone strictly prefers x to y, society prefers x to y -/
+def WeakPareto {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
+  ∀ prefs : I → Preference A, ∀ x y,
+    (∀ i, StrictPref (prefs i) x y) → StrictPref (swf.aggregate prefs) x y
+
+/-- Independence of Irrelevant Alternatives (IIA) -/
+def IIA {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
+  ∀ prefs prefs' : I → Preference A, ∀ x y,
+    -- If preferences x vs y are identical in both profiles
+    (∀ i, (prefs i).R x y ↔ (prefs' i).R x y) →
+    (∀ i, (prefs i).R y x ↔ (prefs' i).R y x) →
+    -- Then the social preference on x, y is identical
+    ((swf.aggregate prefs).R x y ↔ (swf.aggregate prefs').R x y)
+
+/-- Non-dictatorship: No single individual determines the social preference -/
+def NonDictatorial {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
+  ¬∃ d : I, ∀ prefs : I → Preference A, ∀ x y,
+    StrictPref (prefs d) x y → StrictPref (swf.aggregate prefs) x y
+
+/-!
+## Arrow's Impossibility Theorem
+-/
+
+/--
+Arrow's Impossibility Theorem (Statement):
+There is no social welfare function with ≥3 alternatives that satisfies:
+1. Weak Pareto
+2. Independence of Irrelevant Alternatives
+3. Non-dictatorship
+
+Note: Stated with explicit `Fin n` types instead of generic `Fintype`
+to avoid Mathlib dependency. The theorem's mathematical content is identical.
+-/
+-- The full proof requires substantial machinery; we state it as an axiom
+axiom arrow_impossibility {nI nA : Nat}
+    (hI : nI ≥ 2)
+    (hA : nA ≥ 3)
+    (swf : SocialWelfareFunction (Fin nI) (Fin nA))
+    (h_pareto : WeakPareto swf)
+    (h_iia : IIA swf) :
+    ¬NonDictatorial swf
+
+/-!
+## Examples
+-/
+
+/-- Dictatorship SWF: Individual d's preference becomes social preference -/
+def dictatorship {I A : Type} (d : I) : SocialWelfareFunction I A := {
+  aggregate := fun prefs => prefs d
+}
+
+/-- Theorem: A dictatorship satisfies Pareto and IIA -/
+theorem dictatorship_satisfies_pareto {I A : Type} (d : I) :
+    WeakPareto (dictatorship (I := I) (A := A) d) := by
+  intro prefs x y h_all
+  exact h_all d
+
+theorem dictatorship_satisfies_iia {I A : Type} (d : I) :
+    IIA (dictatorship (I := I) (A := A) d) := by
+  intro prefs prefs' x y h1 h2
+  exact h1 d
+
+/-!
+## Sen's Impossibility
+-/
+
+/-- Minimal Liberalism: Some individual is decisive over some pair -/
+def MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=
+  ∃ i : I, ∃ x y : A,
+    ∀ prefs : I → Preference A,
+      StrictPref (prefs i) x y → StrictPref (swf.aggregate prefs) x y
+
+/- Sen's Impossibility Theorem (Statement):
+   No SWF can satisfy both Weak Pareto and Minimal Liberalism
+   under certain preference configurations.
+   (Weaker statement — the full theorem requires constructing
+   specific preference profiles.) -/
+
+/-!
+## Utility Representations
+-/
+
+/-- A utility function represents a preference if u(x) ≥ u(y) iff R x y -/
+def represents {A : Type} (u : A → Int) (p : Preference A) : Prop :=
+  ∀ x y, p.R x y ↔ u x >= u y
+
+/-- Create a preference from a utility function -/
+def prefFromUtility {A : Type} (u : A → Int)
+    (h_finite : ∀ x y, u x >= u y ∨ u y >= u x := by decide) : Preference A := {
+  R := fun x y => u x >= u y
+  complete := h_finite
+  trans := fun x y z hxy hyz => by omega
+}
+
+end SocialChoiceEn

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lakefile.toml
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lakefile.toml
@@ -13,9 +13,10 @@ name = "LeanGameDefs"
 # an explicit root, a `*_en.lean` mirror is an orphan that Lake never builds
 # and whose compile errors stay invisible. `Nash_en` reuses the FR `Basic`
 # identifiers (reuse-FR-names variant) so it imports `Basic`, not `Basic_en`.
-# `Combinatorial_en` is self-contained (no import), so it builds standalone.
-# `Basic_en` is the English twin of `Basic` (namespace `LeanGameDefs_en`).
+# `Combinatorial_en` and `SocialChoice_en` are self-contained (no import), so
+# they build standalone. `Basic_en` is the English twin of `Basic` (namespace
+# `LeanGameDefs_en`).
 roots = [
   "Basic", "Nash", "Bayesian", "Combinatorial", "SocialChoice", "Regret",
-  "Nash_en", "Combinatorial_en", "Basic_en",
+  "Nash_en", "Combinatorial_en", "Basic_en", "SocialChoice_en",
 ]


### PR DESCRIPTION
## Summary

Re-lands the SocialChoice FR-first sibling pair (EPIC #4980, 5th lean_game_defs module after Basic #6758, Nash #6753, Combinatorial #6755). Supersedes #6772 (po-2024, first-mover 02:02Z) and #6776 (po-2025, 02:10Z): the two lanes collided, then a **double-yield race** closed both (#6772 closed at 02:19:21 designating #6776; #6776 closed at 02:19:25 yielding to #6772). GitHub refuses to reopen #6772 because its head branch was force-pushed (rebased onto fresh main) after close — hence this new PR from the same branch, same content.

## Changes (3 files)

- `SocialChoice.lean` — FR canonical: strips the Option B inline bilingual docstrings, adds the i18n Jumelage header note.
- `SocialChoice_en.lean` (new) — EN mirror, redeclare-in-namespace variant (`namespace SocialChoiceEn`, self-contained, no import).
- `lakefile.toml` — union roots (10): adds `SocialChoice_en` alongside `Basic_en` (#6758) so `lake build` actually compiles the mirror (orphan-trap doctrine, checker guard #6774).

## Verification (ai-01, local WSL, on this exact content)

- `lake build` **SUCCESS — 12 jobs**, all 10 roots incl. `SocialChoice_en` (1.8s), `Basic_en`, `Combinatorial_en`, `Nash_en`.
- `scripts/lean/check_i18n_siblings.py` : **4/4 pairs byte-identical, 0 drift, 0 orphan, 0 unbuilt**.
- `grep -c sorry` : 0 avant / 0 après (aucune preuve touchée ; l'axiome `arrow_impossibility` préexistant est inchangé, byte-identique entre FR et EN).

Credit: po-2024:CoursIA (first-mover #6772) + po-2025:CoursIA (incumbent rollout #6776) — equivalent deliverables, same variant.

See #4980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)