### PR TITLE
fix(lean-i18n,#4980,#6775): root Basic_en in mathlib_examples lake (orphan-trap)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lakefile.lean
@@ -12,4 +12,9 @@ require mathlib from git
 
 @[default_target]
 lean_lib «MathLibExamples» where
-  -- add any library configuration options here
+  -- Convention i18n #4980: globs build FR root + EN sibling (orphan-trap guard).
+  -- Without an explicit `globs`, Lake roots the lib at `MathLibExamples.lean`
+  -- only, so `Basic_en.lean` is never compiled (the FR root imports `Basic`,
+  -- not `Basic_en`). Verified by `scripts/lean/check_i18n_siblings.py --all`
+  -- post-#6774. Pattern: sudoku_lean, minimax_lean, learning_theory_lean.
+  globs := #[.submodules `MathLibExamples] -- includes Basic + Basic_en


### PR DESCRIPTION
# fix(lean-i18n,#4980,#6775): root Basic_en in mathlib_examples lake (orphan-trap)

## Substance

The `mathlib_examples` lake was building **only** the bare lib root
``MathLibExamples`` (= transitive imports starting at `MathLibExamples.lean`),
which pulled `Basic` (FR, imported by the FR root) but **never** `Basic_en`
(EN twin, no FR import points to it). Root-cause mirror of the
`L521c-L1 ★` ORPHAN-TRAP lesson (PR #6752 Nash UNSTABLE, c.520): in the
i18n sibling-pair convention #4980, the lakefile's `lean_lib` declaration
**must** explicitly glob the `_en` twin or Lake treats it as an orphan,
and a green Lean CI on `lake build` is a **false pass** — `Basic_en` errors
stay invisible because Lake never compiles it.

| Aspect | Valeur |
|--------|--------|
| Files modified | 1 (mathlib_examples/lakefile.lean) |
| Lines | +6 / -1 = 7 net |
| Source lines (declare) | bare `lean_lib «MathLibExamples»` |
| Source lines (after) | `globs := #[.submodules \`MathLibExamples]` |
| Catalog touched | 0 (R1) |
| Notebook touched | 0 |
| Lint/LF | UTF-8 no-BOM |

## Reproduction (orphaned `Basic_en`, pre-fix)

```text
$ python scripts/lean/check_i18n_siblings.py --all | tail -1
148/150 pairs byte-identical | 2 consumer-pattern | 0 drift | 0 orphan | 1 unbuilt

$ python scripts/lean/check_i18n_siblings.py --all \
    | grep UNBUILT
UNBUILT  MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/MathLibExamples/Basic_en.lean
         module `MathLibExamples.Basic_en` absent from lakefile.lean roots/globs
         -> never compiled by `lake build` (a green Lean CI is a false pass)
```

## Fix (1 line, standard sibling-globs pattern)

Add the pattern already adopted by **sudoku_lean** (PR #6569, c.494),
**minimax_lean** (PR #6613, c.491), **learning_theory_lean** (PR #6651,
c.501):

```diff
 @[default_target]
 lean_lib «MathLibExamples» where
-  -- add any library configuration options here
+  -- Convention i18n #4980: globs build FR root + EN sibling (orphan-trap guard).
+  -- Pattern: sudoku_lean, minimax_lean, learning_theory_lean.
+  globs := #[.submodules `MathLibExamples] -- includes Basic + Basic_en
```

`.submodules \`MathLibExamples` matches the root and every nested
`.lean` submodule — `Basic.lean` AND `Basic_en.lean` in this case —
without requiring an explicit ``Basic_en`` glob reference (which would
fail anyway since `Basic_en` is a submodule, not a top-level sibling).

## Verification (post-fix)

```text
$ python scripts/lean/check_i18n_siblings.py --all | tail -1
148/150 pairs byte-identical | 2 consumer-pattern | 0 drift | 0 orphan | 0 unbuilt
```

`Basic_en.lean` byte-identity unchanged (`MathLibExamples/Basic_en.lean`,
OK). The orphan-trap guard in #6774 (the same `check_i18n_siblings.py`)
now returns 0 unbuilt on main — lake build SUCCESS is no longer a
false pass.

## lake build verification (deferred to CI, per #6771 infra note)

Per issue #6775 + lean-merge-discipline: `lake build MathLibExamples`
would require a full Mathlib4 cold build (~minutes-to-OOM on po-2026
per #6771 — same env issue). This PR ships the lakefile-only fix and
**relies on CI** (`lean-game-defs.yml` analogue + the `lean_ci.yml`
reusable workflow with `project-path: mathlib_examples`) for the
`lake build` SUCCESS verification. This is consistent with how
#6753 / #6755 / #6758 handled the same scope: lakefile-only fix,
CI-only build, no local Mathlib4 rebuild.

The risk surface is minimal: `Basic_en.lean` is byte-identical to
`Basic.lean` (same imports `Mathlib.Tactic.Ring`, `Mathlib.Tactic.Linarith`,
same tactics `ring`/`linarith`/`omega`, only docstrings differ), and
`Basic.lean` is already green on main. The only failure mode is a
transitive-import gap, which CI will catch.

## Convention respect

| Aspect | Convention | Statut |
|--------|-----------|--------|
| Atomic | G.4 (1 file, ≤3000L, 1 sujet) | ✅ |
| R1 catalog | no catalog touched | ✅ |
| R2 rebase frais | origin/main frais (HEAD c0e220971) | ✅ |
| R3 un seul livrable | 1 PR = 1 fix = 1 lakefile | ✅ |
| R4 Closes/See | full résolution = **Closes #6775** | ✅ |
| L268 UTF-8 no-BOM | L268 #4 LF-only | ✅ |
| L516-L1 namespace resolution | `Basic_en` (submodule, not separate lib) | ✅ — `.submodules` matche |
| L516c-L1 strip+twin atomique | first-class twin already created 2026-07-15; this PR closes the orphan-trap on the LAKE side | ✅ |
| L521c-L1 ★ NEW c.521 ORPHAN-TRAP | leçon acquise c.520 sur #6752 Nash UNSTABLE appliquée ici ; lakefile roots must include _en OR `.submodules` | ✅ |
| L468-L1 DURCIE verify | `git diff --stat` + `check_i18n_siblings.py --all` re-run firsthand | ✅ |
| L506-L1 ★ R6 anti-monotonie | pas un nouveau sibling pair (3ᵉ Lean cycle consécutif = c.521 NO-NEW-PR + c.522 pivot → ce cycle fix infrastructure ORPHAN-TRAP unique, *debt* sur l'#4980 rollout existant, pas *substance* nouveau module) | ✅ |

## Cross-références

- **#6775** (issue pilote : `MathLibExamples/Basic_en is an unbuilt orphan`)
- **#6774** (PR `orphan-trap guard` parent — `check_i18n_siblings.py` UNBUILT check)
- **#6771** (infra : po-2026 Lake cold-rebuild OOM/timeout — motive CI-only lake build)
- **#6773** (PR Gittins/Basic canonical EN → FR — sibling-pair Pattern A precedent dans le meme cycle)
- **#6753** (PR jsboige Nash reuse-FR-names, MERGED — precedent closest pour ce fix)
- **#6755** (PR Combinatorial, MERGED — reference pour orphan-trap resolve = `roots += ["Foo_en"]`)
- **#6758** (PR Basic, MERGED — wrappant, antérieur à ce pattern)
- **#6749** (moi c.520 Basic OPEN MERGEABLE, MERGED — namespace `BasicEn`)
- **#6752** (moi c.520 Nash UNSTABLE superseded) — leçon ORPHAN-TRAP découverte c.521
- **L521c-L1** ★ NEW c.521 ORPHAN-TRAP gate
- **L516c-L1** ★★ strip+twin atomique
- **L516-L1** ★★★ namespace anti-collision
- **EPIC #4980** (convention sibling pair, Mandat 2026-07-04)

## Suite logique (R6 anti-monotonie, c.524+)

3 cycles NO-NEW-PR authentique c.519-522 + ce 4ᵉ cycle = fix ORPHAN-TRAP debt
sur l'#4980 rollout existant (pas *substance* nouveau Lean module). 
c.524+ **OBLIGATOIREMENT** pivot R6 out-of-Lean out-of-doc-figures, sinon
L506-L1 violation 5ᵉ consécutif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
