### PR TITLE
i18n(lean,#4980): Gittins/Discount canonical EN → FR (docstrings + comments)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Discount.lean
+++ b/MyIA.AI.Notebooks/Probas/decision_theory_lean/Gittins/Discount.lean
@@ -3,10 +3,10 @@ import Mathlib.Analysis.SpecificLimits.Basic
 import Mathlib.Data.Real.Basic
 
 /-!
-# Geometric Discount — Proved Identities
+# Actualisation géométrique — Identités prouvées
 
-Lemmas about geometric discounting using Mathlib's real analysis.
-These are the building blocks for the Gittins index formalization.
+Lemmas sur l'actualisation géométrique utilisant l'analyse réelle de Mathlib.
+Ce sont les briques élémentaires de la formalisation de l'indice de Gittins.
 -/
 
 namespace Gittins
@@ -14,45 +14,47 @@ namespace Gittins
 open Real
 
 /-!
-## Geometric Series
+## Série géométrique
 
-The geometric series Σ γ^n converges to 1/(1-γ) for |γ| < 1.
-Mathlib provides `tsum_geometric_of_lt_one` for this.
+La série géométrique Σ γ^n converge vers 1/(1-γ) pour |γ| < 1.
+Mathlib fournit `tsum_geometric_of_lt_one` pour cela.
 -/
 
-/-- The partial sum of a geometric series: Σ_{k=0}^{n-1} γ^k -/
+/-- La somme partielle d'une série géométrique : Σ_{k=0}^{n-1} γ^k -/
 def geometricPartialSum (γ : ℝ) (n : ℕ) : ℝ :=
   (List.range n).foldl (fun acc k => acc + γ ^ k) 0
 
 /-!
-## Foundational facts on the finite partial sum
+## Faits fondamentaux sur la somme partielle finie
 
-The infinite geometric series (`∑' n, γ^n`) is handled below via Mathlib. These
-lemmas establish the elementary identities on the *finite* partial sum
-`geometricPartialSum γ n` — the empty sum, the telescoping recurrence that builds
-it term-by-term, and the textbook closed form `(1 − γ^n)/(1 − γ)` valid for
-`γ ≠ 1`. They are the finite counterpart of `geometric_series_converges` and make
-the partial-sum definition usable (it was previously defined but unused).
+La série géométrique infinie (`∑' n, γ^n`) est traitée plus bas via Mathlib. Ces
+lemmas établissent les identités élémentaires sur la somme partielle *finie*
+`geometricPartialSum γ n` — la somme vide, la récurrence télescopique qui la
+construit terme par terme, et la forme fermée classique `(1 − γ^n)/(1 − γ)` valable
+pour `γ ≠ 1`. Ils sont le pendant fini de `geometric_series_converges` et rendent
+la définition de somme partielle utilisable (elle était précédemment définie mais
+inutilisée).
 -/
 
-/-- **Empty partial sum.** `geometricPartialSum γ 0 = 0` — summing over the empty
-    range `List.range 0 = []` yields the additive identity. -/
+/-- **Somme partielle vide.** `geometricPartialSum γ 0 = 0` — sommer sur la plage
+    vide `List.range 0 = []` donne l'identité additive. -/
 lemma geometricPartialSum_zero (γ : ℝ) : geometricPartialSum γ 0 = 0 := by
   simp [geometricPartialSum]
 
-/-- **Telescoping recurrence.** Each added term contributes `γ^n`:
-    `geometricPartialSum γ (n+1) = geometricPartialSum γ n + γ^n`. This is the
-    stepwise identity underlying the finite sum (and the induction engine for the
-    closed form below). -/
+/-- **Récurrence télescopique.** Chaque terme ajouté contribue `γ^n` :
+    `geometricPartialSum γ (n+1) = geometricPartialSum γ n + γ^n`. C'est l'identité
+    pas-à-pas sous-jacente à la somme finie (et le moteur d'induction de la forme
+    fermée ci-dessous). -/
 lemma geometricPartialSum_succ (γ : ℝ) (n : ℕ) :
     geometricPartialSum γ (n + 1) = geometricPartialSum γ n + γ ^ n := by
   simp only [geometricPartialSum, List.range_succ, List.foldl_append,
     List.foldl_cons, List.foldl_nil]
 
-/-- **Closed form of the finite partial sum** (textbook identity). For `γ ≠ 1`,
-    the partial sum `Σ_{k=0}^{n-1} γ^k` equals `(1 − γ^n) / (1 − γ)`. Proved by
-    induction on `n` using the recurrence `geometricPartialSum_succ`. This is the
-    finite analogue of `geometric_series_converges` (which takes `n → ∞`). -/
+/-- **Forme fermée de la somme partielle finie** (identité classique). Pour
+    `γ ≠ 1`, la somme partielle `Σ_{k=0}^{n-1} γ^k` vaut `(1 − γ^n) / (1 − γ)`.
+    Prouvée par récurrence sur `n` utilisant la récurrence
+    `geometricPartialSum_succ`. C'est l'analogue fini de
+    `geometric_series_converges` (qui fait tendre `n → ∞`). -/
 lemma geometricPartialSum_closed {γ : ℝ} (hγ : γ ≠ 1) (n : ℕ) :
     geometricPartialSum γ n = (1 - γ ^ n) / (1 - γ) := by
   have hdenom : (1:ℝ) - γ ≠ 0 := sub_ne_zero.mpr hγ.symm
@@ -63,19 +65,19 @@ lemma geometricPartialSum_closed {γ : ℝ} (hγ : γ ≠ 1) (n : ℕ) :
     field_simp [hdenom]
     ring
 
-/-- For 0 ≤ γ < 1, the geometric series converges.
-    This wraps Mathlib's `tsum_geometric_of_lt_one`. -/
+/-- Pour 0 ≤ γ < 1, la série géométrique converge.
+    Encapsule `tsum_geometric_of_lt_one` de Mathlib. -/
 theorem geometric_series_converges {γ : ℝ} (hγ₁ : 0 ≤ γ) (hγ₂ : γ < 1) :
     ∑' n : ℕ, γ ^ n = 1 / (1 - γ) := by
   rw [one_div]
   exact tsum_geometric_of_lt_one hγ₁ hγ₂
 
-/-- For 0 ≤ γ < 1, 1 - γ > 0. -/
+/-- Pour 0 ≤ γ < 1, 1 - γ > 0. -/
 lemma one_minus_gamma_pos {γ : ℝ} (h : γ < 1) (h₀ : 0 ≤ γ) : 0 < 1 - γ := by
   linarith
 
-/-- For 0 < γ < 1, the discounted infinite sum of a constant reward r equals r/(1-γ).
-    This is the fundamental identity used in bandit value computation. -/
+/-- Pour 0 < γ < 1, la somme infinie actualisée d'une récompense constante r vaut
+    r/(1-γ). Identité fondamentale utilisée dans le calcul de la valeur d'un bandit. -/
 theorem present_value_constant {γ r : ℝ} (hγ₁ : 0 < γ) (hγ₂ : γ < 1) (hr : 0 ≤ r) :
     ∑' n : ℕ, γ ^ n * r = r / (1 - γ) := by
   have hγ₁' : 0 ≤ γ := le_of_lt hγ₁
@@ -83,23 +85,23 @@ theorem present_value_constant {γ r : ℝ} (hγ₁ : 0 < γ) (hγ₂ : γ < 1) 
   rw [tsum_mul_right, tsum_geometric_of_lt_one hγ₁' hγ₂]
   ring
 
-/-- Discount factor closer to 1 gives higher present value.
-    If γ₁ ≤ γ₂, then Σ γ₁^n ≤ Σ γ₂^n.
+/-- Un facteur d'actualisation plus proche de 1 donne une valeur présente plus
+    élevée. Si γ₁ ≤ γ₂, alors Σ γ₁^n ≤ Σ γ₂^n.
 
-    **Proof strategy**: rewrite both tsums via the closed-form geometric
-    identity `∑' n, γ^n = 1/(1-γ)` (`geometric_series_converges`), then reduce
-    the goal to `1/(1-γ₁) ≤ 1/(1-γ₂)`. Since `γ₁ ≤ γ₂` we have
-    `1-γ₂ ≤ 1-γ₁`, and both denominators are positive (`γ₂ < 1`), so
-    `one_div_le_one_div_of_le` closes the goal. This sidesteps the missing
-    `tsum_le_tsum` on `ℝ` (not available in Mathlib v4.30.0-rc2 for bare `ℝ`
-    series) by exploiting the closed form. -/
+    **Stratégie de preuve** : réécrire les deux tsum via l'identité géométrique
+    fermée `∑' n, γ^n = 1/(1-γ)` (`geometric_series_converges`), puis ramener le
+    but à `1/(1-γ₁) ≤ 1/(1-γ₂)`. Comme `γ₁ ≤ γ₂` on a `1-γ₂ ≤ 1-γ₁`, et les deux
+    dénominateurs sont positifs (`γ₂ < 1`), donc `one_div_le_one_div_of_le` clôt le
+    but. Cela contourne l'absence de `tsum_le_tsum` sur `ℝ` (non disponible dans
+    Mathlib v4.30.0-rc2 pour les séries sur `ℝ` brut) en exploitant la forme
+    fermée. -/
 theorem discount_monotone {γ₁ γ₂ : ℝ} (h₁ : 0 ≤ γ₁) (h₂ : γ₁ ≤ γ₂) (h₃ : γ₂ < 1) :
     ∑' n : ℕ, γ₁ ^ n ≤ ∑' n : ℕ, γ₂ ^ n := by
   have hγ₁_lt : γ₁ < 1 := lt_of_le_of_lt h₂ h₃
   have hγ₂_nn : 0 ≤ γ₂ := le_trans h₁ h₂
   rw [geometric_series_converges h₁ hγ₁_lt, geometric_series_converges hγ₂_nn h₃]
-  -- Goal: 1 / (1 - γ₁) ≤ 1 / (1 - γ₂)
-  -- Since γ₁ ≤ γ₂, we have 1 - γ₂ ≤ 1 - γ₁; both denominators are positive.
+  -- But : 1 / (1 - γ₁) ≤ 1 / (1 - γ₂)
+  -- Comme γ₁ ≤ γ₂, on a 1 - γ₂ ≤ 1 - γ₁ ; les deux dénominateurs sont positifs.
   apply one_div_le_one_div_of_le
   · exact sub_pos.mpr (by linarith)  -- 0 < 1 - γ₂
   · linarith                        -- 1 - γ₂ ≤ 1 - γ₁


### PR DESCRIPTION
@@PO2023-FRENCH@@
Suite du rollout FR-canonical du sous-répertoire `Gittins` (`decision_theory_lean`), après `Gittins/Basic` (#6773, MERGED + Lean CI PASS). Le module `Gittins/Discount.lean` restait EN-canonical alors que son sibling `_en.lean` était déjà EN-mirror et le voisin `Coherence/*` déjà FR-canonical.

## Changement

Bascule EN → FR complète : **3 docstrings de module** (`/-! … -/`) + **8 docstrings d'item** (`/-- … -/`) + **commentaires inline de preuve** (`-- …`). Les formules mathématiques universelles (`Sum_n gamma^n`) et les assertions (`-- 0 < 1 - γ₂`) sont conservées telles quelles (notation maths, pas de la prose).

## Byte-identity (convention sibling-pair #4980)

Le checker canonique `check_i18n_siblings.py` **stripppe docstrings ET commentaires `--`** pour comparer le corps Lean : verdict **12/12 pairs byte-identical, 0 drift, 0 orphan, 0 unbuilt**. Seul le texte des docstrings/commentaires diffère entre `Discount.lean` (FR canonique) et `Discount_en.lean` (miroir EN) — c'est exactement la convention #4980.

## Anti-régression

- `grep sorry` = **0** (aucune preuve/lemme/theorem/tactique modifié).
- `diff --stat` : 43 insertions / 41 suppressions — cohérent avec une traduction de commentaires.
- **CI Lean (decision_theory_lean) = oracle build** pour po-2023 (pas d'olocales Mathlib locaux) ; la PR #6773 (Basic) a validé ce chemin avec Lean CI PASS.

## Méthode (leçon c.520/c.528 réappliquée)

Vérification byte-identity via le **checker canonique** (authoritatif), pas un `strip` manuel — mon hand-rolled strip bug sur `/-!` et donnait un faux DIFF, le checker canonical dit PASS. Trust the canonical tool over manual diff.

## Contexte i18n

Le lake `decision_theory_lean` : `Coherence/*` déjà FR-canonical, `Gittins/Basic` FR (#6773), `Gittins/Discount` FR (cette PR). **Résiduel** : `Gittins/GittinsTheorem.lean` (146 lignes, EN-canonical, barrières INTRINSIC — la traduction de docstrings ne touche pas les preuves) = prochain grain.

See #4980.

Co-Authored-By: Claude <noreply@anthropic.com>