### PR TITLE
docs(translation,#4957): resync translations/README.md to 27-CSV T1 reality

### DIFF
--- a/translations/README.md
+++ b/translations/README.md
@@ -1,30 +1,78 @@
 # CSV de synchro traduction — source de vérité multilingue
 
-**Statut** : POC T1 (Epic #4957 / #1650). Arborescence des CSV source de vérité pour la synchronisation traduction des notebooks pédagogiques.
+**Statut** : T1 baseline multi-familles (Epic #4957 / #1650). Arborescence des CSV source de vérité pour la synchronisation traduction des notebooks pédagogiques. Chaque CSV capture l'extraction (`src_lang=fr`, colonne pivot `text_fr`) d'une série ; les colonnes cibles (`text_en`…`text_pt`) restent vides tant que le moteur Argumentum (T3, gated #1650 Phase 1) n'est pas branché.
 
 ## Structure
 
-```
+```text
 translations/
-├── README.md           ← ce fichier
-└── symbolicai/
-    ├── README.md
-    └── argument_analysis.csv
+├── README.md                 ← ce fichier
+├── casestudies/              ├─ gametheory/        ├─ iit/
+├── mlnet/                    ├─ planners/          ├─ probas-infer/
+├── probas-pymc/              ├─ quantconnect/      ├─ rl/
+├── search-applications/      ├─ search-part1/      ├─ search-part2/
+├── search-part3/             ├─ search-part4/      ├─ semanticweb/
+├── smartcontracts/           ├─ smt/               ├─ sudoku/
+├── symbolicai/               ├─ symboliclearning/  └─ tweety/
+├── genai/        (texte, finetuning, posttraining)
+├── genai-audio/              └── genai-image/
 ```
+
+Sous-répertoire par famille (`translations/<famille>/`), un CSV par série pédagogique. `smt/` porte deux séries (`z3-api`, `z3-linq2z3`) et `genai/` en porte trois (`texte`, `finetuning`, `posttraining`).
 
 Convention : `translations/<famille>/<série>.csv`, une ligne par cellule de notebook. Cf. `scripts/translation/README.md` pour le schéma détaillé.
 
-## Familles couverte (POC)
+## Familles couvertes (T1 baseline)
 
-- **`symbolicai/`** — Série `MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/` (16 notebooks, 395 cellules)
+**27 CSV, 21 174 cellules** au total (extraction `src_lang=fr`, comptage lignes hors en-tête). Regroupement par domaine pédagogique :
+
+| Domaine | CSV | Cellules | Série source |
+|---------|-----|---------:|--------------|
+| SymbolicAI — Tweety | `tweety/tweety.csv` | 864 | `SymbolicAI/Tweety/` |
+| SymbolicAI — SemanticWeb | `semanticweb/semanticweb.csv` | 1193 | `SymbolicAI/SemanticWeb/` |
+| SymbolicAI — Planning | `planners/planners.csv` | 1006 | `SymbolicAI/Planners/` |
+| SymbolicAI — SMT/Z3-API | `smt/z3-api.csv` | 541 | `SymbolicAI/SMT/` |
+| SymbolicAI — SMT/Z3.Linq | `smt/z3-linq2z3.csv` | 525 | `SymbolicAI/SMT/` |
+| SymbolicAI — Argument | `symbolicai/argument_analysis.csv` | 421 | `SymbolicAI/Argument_Analysis/` |
+| SymbolicLearning | `symboliclearning/symboliclearning.csv` | 738 | `SymbolicAI/SymbolicLearning/` |
+| SmartContracts | `smartcontracts/smartcontracts.csv` | 965 | `SymbolicAI/SmartContracts/` |
+| CaseStudies | `casestudies/casestudies.csv` | 149 | `CaseStudies/` |
+| Search — Part 1 | `search-part1/search-part1.csv` | 1168 | `Search/Part1-Foundations/` |
+| Search — Part 2 | `search-part2/search-part2.csv` | 784 | `Search/Part2-CSP/` |
+| Search — Part 3 | `search-part3/search-part3.csv` | 131 | `Search/Part3-Advanced/` |
+| Search — Part 4 | `search-part4/search-part4.csv` | 453 | `Search/Part4-Metaheuristics/` |
+| Search — Applications | `search-applications/search-applications.csv` | 1468 | `Search/Applications/` |
+| Probas — Infer.NET | `probas-infer/probas_infer.csv` | 940 | `Probas/` |
+| Probas — PyMC | `probas-pymc/probas_pymc.csv` | 571 | `Probas/` |
+| IIT / ICT | `iit/iit.csv` | 776 | `IIT/ICT-Series/` |
+| ML.NET | `mlnet/mlnet.csv` | 599 | `ML/` |
+| RL | `rl/rl.csv` | 513 | `RL/` |
+| Sudoku | `sudoku/sudoku.csv` | 1325 | `Sudoku/` |
+| GameTheory | `gametheory/gametheory.csv` | 1897 | `GameTheory/` |
+| GenAI — Texte | `genai/texte.csv` | 718 | `GenAI/Texte/` |
+| GenAI — FineTuning | `genai/finetuning.csv` | 161 | `GenAI/Texte/` |
+| GenAI — PostTraining | `genai/posttraining.csv` | 171 | `GenAI/Texte/` |
+| GenAI — Image | `genai-image/genai-image.csv` | 533 | `GenAI/Image/` |
+| GenAI — Audio | `genai-audio/genai-audio.csv` | 1128 | `GenAI/Audio/` |
+| QuantConnect — Python | `quantconnect/quantconnect-py.csv` | 1436 | `QuantConnect/` (QC-Py-01..41) |
+
+> Note : les séries **QuantConnect C# / QuantBooks** et **partner-course** ne sont pas couvertes par l'extraction T1 (exécution gated QC Cloud). Les sous-séries QC-Py-Cloud-* et partner-course sont en follow-up.
 
 ## Workflow (T1 → T2 → T3)
 
 | T# | Script | Statut |
 |----|--------|--------|
-| **T1** | `scripts/translation/extract_cells_to_csv.py` | **Livré** (Phase 1 INFRA, PR #5657) |
+| **T1** | `scripts/translation/extract_cells_to_csv.py` | **Livré** (Phase 1 INFRA, PR #5657) — 27 séries extraites |
 | **T2** | `scripts/translation/check_translation_sync.py` | **Livré**, CI non-bloquante `.github/workflows/translation-drift.yml` |
 | **T3** | Moteur Argumentum `datasetupdater` (8 langues) | À venir (gated #1650 Phase 1 connecteur) |
+
+Pour resynchroniser un CSV après modification du notebook source (T1, non-destructif tant que les colonnes cibles sont vides) :
+
+```bash
+python scripts/translation/extract_cells_to_csv.py --src-lang fr --repo-root . \
+  -o translations/<famille>/<série>.csv <notebooks...>
+python scripts/translation/check_translation_sync.py   # 0 anomalie attendue
+```
 
 ## Voir aussi
 


### PR DESCRIPTION
## Summary

The `translations/README.md` was frozen at the **POC state** — it listed only the `symbolicai/` pilot ("1 family, 395 cells") — while the seed wave shipped **26 more CSVs across ~18 families** (PRs #5891/#5937/#6747/#6751/#6754/#6756/#6762/#6764/#6765/#6766/#6770/#6778/#6757 + earlier). The README was ~2% of the real coverage. This resyncs it to actual disk-truth on `main` (`d2d01444a`).

Deferred since c.529 precisely because 6 seed PRs were in flight (resyncing then would have re-staled within the hour). All seeds are now **MERGED** → durable resync.

### Changes (1 file, docs-only — atomic)

- **Structure tree** rebuilt to the real 28 sub-directories. `genai/` holds 3 series (`texte`, `finetuning`, `posttraining`), `smt/` holds 2 (`z3-api`, `z3-linq2z3`).
- **"Familles couvertes" table** — 27 CSVs / **21 174 cells** total, grouped by pedagogic domain, each row citing the verified source series path.
- **Framing** updated from "POC T1" to "T1 baseline multi-familles"; target columns (`text_en`…`text_pt`) documented as empty pending the T3 Argumentum connector (gated #1650 Phase 1).
- Added the concrete resync command (`extract_cells_to_csv.py` + `check_translation_sync.py`).

## Verification (§E whole-file audit, G.1 first-hand)

| Check | Result |
|-------|--------|
| CSV inventory on fresh `main` worktree | **27 CSVs / 21 174 data rows** (row counts via `csv.reader`, excl. header) |
| Source paths cited | **G.1 corrected 4 stale paths**: `SymbolicAI/Planning/` → `Planners/`, `SymbolicLearning/` → `SymbolicAI/SymbolicLearning/`, `SmartContract/` → `SymbolicAI/SmartContracts/`, `Search/Part4/` → `Part4-Metaheuristics/` (each verified by `find`) |
| Catalogue untouched | `git diff --name-only` = `translations/README.md` only; no `CATALOG-STATUS` marker in this file |
| Scope | docs-only, 1 file (+58/−10) |

## Voir aussi

See #4957 (translation infra design). Epic #1650 (multilingual translation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)