### PR TITLE
fix(prover,#3846): DEMO 62 sorry line 2734 -> 2892 (post-N3 drift)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1814,15 +1814,15 @@ DEMOS = {
     62: {
         "name": "HASHLIFE_P4_SUCC_MEMBERSHIP",
         "file": str(CONWAY_HASHLIFE_FILE) if CONWAY_HASHLIFE_FILE else "",
-        "line": 2734,
+        "line": 2892,
         "sorry_type": "sorry_replacement",
         "theorem_name": "p4_succ_membership",
         "theorem": "p4_succ_membership",
         "imports": CONWAY_HASHLIFE_IMPORTS,
         "description": (
             "BG-prover target (hashlife nibble plan #3846, N3): residual sorry in\n"
-            "noncomputable def p4_succ_membership (declared L2697, residual sorry\n"
-            "L2734 of HashlifeCorrectness.lean). The whnf wall is already traversed\n"
+            "noncomputable def p4_succ_membership (declared L2855, residual sorry\n"
+            "L2892 of HashlifeCorrectness.lean). The whnf wall is already traversed\n"
             "around L2648-2665 (node16_level_ne_two L2660 -> rw [if_neg hne2] L2663\n"
             "-> rw [mem_toGrid_node]); what remains is the offset-matching assembly:\n"
             "prove each `out_*.toGrid (off_*, off_*)` membership via\n"


### PR DESCRIPTION
## Substance

`prover/config.py` DEMO 62 (`HASHLIFE_P4_SUCC_MEMBERSHIP`) pointed at L2734, but `HashlifeCorrectness.lean` grew ~158 lines with the N3 merges (#6730/#6731/#6732/#6733/#6735). Effect observed firsthand on a BG iter tonight (ai-01, isolated worktree from origin/main `4bef1919c`):

- AutoFix: `Configured line 2734 has no sorry. Using closest sorry at line 2709`
- FX-5 guard: `RESULT_SKIPPED reason=true_placeholder_goal` — L2709 is a degenerate `True`-goal placeholder, so the run refused upstream and **never reached the real `p4_succ_membership` obligation**.

## Fix

`"line": 2734` → `2892` + description refs (declared L2697→L2855). Ground truth from `lake build Conway.Life.HashlifeCorrectness` (SUCCESS, 8498 jobs, warm worktree): 4 `declaration uses sorry` warnings at L2855/L3218/L3368/L3396 — `p4_succ_membership` declared **L2855**, its residual `sorry` at **L2892** (grep-verified).

## Scope

1 file, +3/−3, config-only (no prover logic, no Lean file touched). A relaunched BG iter on the corrected line is running now (targets L2892, no AutoFix drift, no refusal).

See #3846, See #6724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)