### PR TITLE
i18n(lean,#4980): lean_game_defs/Regret FR-first sibling pair

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Regret.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Regret.lean
@@ -15,20 +15,15 @@
   (non abordées ici).
 
   ---
-  English:
-  Regret Minimization and CFR Definitions in Lean 4
-  ==================================================
-
-  Defines structures for regret-based learning in games:
-  - Regret: Difference between achieved and best possible payoff
-  - RegretMatching: Strategy update rule from cumulative regrets
-  - CFR (Counterfactual Regret Minimization): Key algorithm for
-    solving imperfect-information games
-
-  Based on GameTheory-13-ImperfectInfo-CFR.ipynb
-
-  Note: These are pedagogical definitions. A full formalization would
-  require measure theory and convergence proofs (not attempted here).
+  Jumelage i18n : ce module est le FR canonique (sibling pair Pattern A,
+  ratifié par user 2026-07-04 sur EPIC #4980). Le miroir anglais vit dans
+  `Regret_en.lean` (variante reuse-FR-names : comme `Nash.lean`, `Regret.lean`
+  dépend des modules de base partagés `Basic` et `Bayesian`, donc le miroir EN
+  les importe et re-déclare ses propres définitions dans `namespace RegretEn`).
+  Le corps des définitions, signatures et tactiques est byte-identique entre
+  les deux fichiers ; seules les docstrings `/-! ... -/` (titres de section) et
+  `/-- ... -/` (docstrings de déclarations) diffèrent, FR dans ce fichier,
+  EN dans `Regret_en.lean`.
 -/
 
 import Basic
@@ -36,19 +31,10 @@ import Bayesian
 
 /-!
 ## Notions de regret
-
----
-English:
-## Regret Concepts
 -/
 
 /-- Regret instantané pour une action : de combien cette action
     aurait été meilleure que ce qui a réellement été joué.
-
-    regret(a) = u(a) - u(a_played)
-
-    English: Instantaneous regret for an action: how much better that action
-    would have been compared to what was actually played.
 
     regret(a) = u(a) - u(a_played)
 -/
@@ -57,26 +43,19 @@ def instantRegret (payoff : Fin n → Float) (played : Fin n) (action : Fin n) :
 
 /-- Regret cumulé pour chaque action sur T itérations.
     Stocké sous forme d'application de l'indice d'action vers le regret accumulé.
-    English: Cumulative regret for each action over T iterations.
-    Stored as a map from action index to accumulated regret. -/
+-/
 def CumulativeRegret (n : Nat) := Fin n → Float
 
-/-- Initialise un regret nul.
-    English: Initialize zero regret -/
+/-- Initialise un regret nul. -/
 def zeroRegret (n : Nat) : CumulativeRegret n := fun _ => 0
 
-/-- Met à jour le regret cumulé avec une nouvelle observation.
-    English: Update cumulative regret with a new observation -/
+/-- Met à jour le regret cumulé avec une nouvelle observation. -/
 def updateRegret {n : Nat} (regret : CumulativeRegret n)
     (payoff : Fin n → Float) (played : Fin n) : CumulativeRegret n :=
   fun a => regret a + instantRegret payoff played a
 
 /-!
 ## Regret matching
-
----
-English:
-## Regret Matching
 -/
 
 /-- Regret matching : convertit les regrets cumulés positifs en une stratégie.
@@ -85,13 +64,6 @@ English:
     où R+ est la partie positive du regret cumulé.
 
     Si tous les regrets sont non positifs, jouer uniformément.
-
-    English: Regret matching: convert positive cumulative regrets to a strategy.
-
-    For each action a: σ(a) = R+(a) / Σ_a' R+(a')
-    where R+ is the positive part of cumulative regret.
-
-    If all regrets are non-positive, play uniformly.
 -/
 def regretMatchingStrategy {n : Nat} (regret : CumulativeRegret n) : Fin n → Float :=
   let posRegret (a : Fin n) : Float := max 0 (regret a)
@@ -103,19 +75,10 @@ def regretMatchingStrategy {n : Nat} (regret : CumulativeRegret n) : Fin n → F
 
 /-!
 ## Regret externe (cohérence de Hannan)
-
----
-English:
-## External Regret (Hannan Consistency)
 -/
 
 /-- Regret externe : écart entre le paiement réalisé et la meilleure
     action fixe avec le recul.
-
-    R_T = max_a Σ_t u_t(a) - Σ_t u_t(a_t)
-
-    English: External regret: difference between realized payoff and best
-    fixed action in hindsight.
 
     R_T = max_a Σ_t u_t(a) - Σ_t u_t(a_t)
 -/
@@ -131,10 +94,6 @@ def externalRegret (T : Nat) (payoffs : Fin T → (Fin n → Float))
 
 /-!
 ## Regret contrefactuel
-
----
-English:
-## Counterfactual Regret
 -/
 
 /-- Regret contrefactuel pour un joueur à un ensemble d'information.
@@ -146,53 +105,31 @@ English:
     CFR(I, a) = Σ_z∈Z_I  π_{-i}(z) · (u_i(z, a) - u_i(z, σ(I)))
 
     où π_{-i} est la probabilité d'atteindre z en excluant le joueur i.
-
-    English: Counterfactual regret for a player at an information set.
-
-    The key insight of CFR: minimize counterfactual regret at each
-    information set independently, and the average strategy converges
-    to a Nash equilibrium in two-player zero-sum games.
-
-    CFR(I, a) = Σ_z∈Z_I  π_{-i}(z) · (u_i(z, a) - u_i(z, σ(I)))
-
-    where π_{-i} is the reach probability excluding player i.
 -/
 structure CounterfactualRegret where
-  /-- L'identifiant de l'ensemble d'information.
-      English: The information set identifier -/
+  /-- L'identifiant de l'ensemble d'information. -/
   infoSet : String
-  /-- Le joueur.
-      English: The player -/
+  /-- Le joueur. -/
   player : Nat
-  /-- Regret pour chaque action disponible.
-      English: Regret for each available action -/
+  /-- Regret pour chaque action disponible. -/
   actionRegrets : List (String × Float)  -- (nom_action, valeur_regret)
   deriving Repr
 
 /-!
 ## État du solveur CFR
-
----
-English:
-## CFR Solver State
 -/
 
-/-- L'état maintenu par un solveur CFR au fil des itérations.
-    English: The state maintained by a CFR solver across iterations -/
+/-- L'état maintenu par un solveur CFR au fil des itérations. -/
 structure CFRState where
-  /-- Regret contrefactuel cumulé par ensemble d'information et action.
-      English: Cumulative counterfactual regret per information set and action -/
+  /-- Regret contrefactuel cumulé par ensemble d'information et action. -/
   cumulativeRegret : List (String × List (String × Float))
-  /-- Stratégie cumulée (somme des stratégies pondérées par la probabilité d'atteinte).
-      English: Cumulative strategy (sum of strategies weighted by reach) -/
+  /-- Stratégie cumulée (somme des stratégies pondérées par la probabilité d'atteinte). -/
   strategySum : List (String × List (String × Float))
-  /-- Nombre d'itérations effectuées.
-      English: Number of iterations completed -/
+  /-- Nombre d'itérations effectuées. -/
   iterations : Nat
   deriving Repr
 
-/-- Initialise un état CFR vide.
-    English: Initialize empty CFR state -/
+/-- Initialise un état CFR vide. -/
 def initCFRState : CFRState where
   cumulativeRegret := []
   strategySum := []
@@ -200,23 +137,16 @@ def initCFRState : CFRState where
 
 /-!
 ## Notions de convergence
-
----
-English:
-## Convergence Concepts
 -/
 
-/-- Le regret moyen tend vers zéro (ε-équilibre de Nash).
-    English: Average regret approaches zero (ε-Nash equilibrium) -/
+/-- Le regret moyen tend vers zéro (ε-équilibre de Nash). -/
 def epsilonNash (ε : Float) (externalReg : Float) : Prop :=
   externalReg <= ε
 
 /-- Apprentissage sans regret : le regret externe moyen tend vers zéro.
     Les paiements et les coups sont indexés par `Nat` (horizon infini) ; le regret
     à l'horizon `t` est calculé sur le préfixe des `t` premières rondes.
-    English: No-regret learning: average external regret goes to zero.
-    Payoffs and plays are indexed by `Nat` (infinite horizon); the regret
-    at horizon `t` is computed on the prefix of the first `t` rounds. -/
+-/
 def noRegret (payoffs : Nat → (Fin n → Float))
     (played : Nat → Fin n) : Prop :=
   ∀ ε > 0, ∃ T0, ∀ t ≥ T0,
@@ -224,10 +154,6 @@ def noRegret (payoffs : Nat → (Fin n → Float))
 
 /-!
 ## Fictitious play (tiré de GT-17 Section 3)
-
----
-English:
-## Fictitious Play (from GT-17 Section 3)
 -/
 
 /-- Fictitious play : chaque joueur joue la meilleure réponse face à la
@@ -237,21 +163,11 @@ English:
     - les jeux à somme nulle à 2 joueurs
     - les jeux 2x2
     - les jeux à intérêts identiques
-
-    English: Fictitious play: each player plays best response to the
-    empirical distribution of opponent's past plays.
-
-    Brown (1951): converges to Nash equilibrium in:
-    - 2-player zero-sum games
-    - 2x2 games
-    - Games with identical interests
 -/
 structure FictitiousPlayState (n : Nat) where
-  /-- Fréquence empirique des actions de chaque joueur.
-      English: Empirical frequency of each player's actions -/
+  /-- Fréquence empirique des actions de chaque joueur. -/
   actionCounts : Fin n → (Fin m → Nat)
-  /-- Nombre de rondes jouées.
-      English: Number of rounds played -/
+  /-- Nombre de rondes jouées. -/
   rounds : Nat
   -- pas de `deriving Repr` : `actionCounts` est un type fonctionnel, non dérivable
 
@@ -259,11 +175,6 @@ structure FictitiousPlayState (n : Nat) where
 
     Conceptuellement : argmax_a Σ_{a_{-i}} empiricalDist(a_{-i}) · u_i(a, a_{-i}).
     Dans une formalisation complète, cela utiliserait l'argmax de Mathlib.
-
-    English: Best response to empirical distribution of opponent.
-
-    Conceptually: argmax_a Σ_{a_{-i}} empiricalDist(a_{-i}) · u_i(a, a_{-i}).
-    In a full formalization this would use Mathlib's argmax.
 -/
 def isBestResponseToEmpirical {m : Nat}
     (payoff : Fin 2 → (Fin 2 → Fin m) → Float)

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Regret_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/Regret_en.lean
@@ -1,0 +1,194 @@
+/-
+  Regret Minimization and CFR Definitions in Lean 4
+  ==================================================
+
+  Defines structures for regret-based learning in games:
+  - Regret: Difference between achieved and best possible payoff
+  - RegretMatching: Strategy update rule from cumulative regrets
+  - CFR (Counterfactual Regret Minimization): Key algorithm for
+    solving imperfect-information games
+
+  Based on GameTheory-13-ImperfectInfo-CFR.ipynb
+
+  Note: These are pedagogical definitions. A full formalization would
+  require measure theory and convergence proofs (not attempted here).
+
+  ---
+  i18n sibling: this module is the EN mirror of the FR canonical `Regret.lean`
+  (sibling-pair Pattern A, ratified by user on 2026-07-04, EPIC #4980). The FR
+  canonical lives in `Regret.lean` (top-level declarations, no namespace). This
+  EN mirror uses the *reuse-FR-names* variant: it `import Basic` and
+  `import Bayesian` (the FR canonical base modules that `Regret.lean` depends on)
+  and reuses their identifiers verbatim, wrapping only its own new declarations
+  in `namespace RegretEn` to avoid name collisions with the FR `Regret` module
+  when both live in the same lake. The body of definitions, signatures and
+  tactics is byte-identical between the two files; only the docstrings
+  `/-! ... -/` (section headings) and `/-- ... -/` (declaration docstrings)
+  differ — EN in this file, FR in `Regret.lean`.
+-/
+
+import Basic
+import Bayesian
+
+namespace RegretEn
+
+/-!
+## Regret Concepts
+-/
+
+/-- Instantaneous regret for an action: how much better that action
+    would have been compared to what was actually played.
+
+    regret(a) = u(a) - u(a_played)
+-/
+def instantRegret (payoff : Fin n → Float) (played : Fin n) (action : Fin n) : Float :=
+  payoff action - payoff played
+
+/-- Cumulative regret for each action over T iterations.
+    Stored as a map from action index to accumulated regret. 
+-/
+def CumulativeRegret (n : Nat) := Fin n → Float
+
+/-- Initialize zero regret -/
+def zeroRegret (n : Nat) : CumulativeRegret n := fun _ => 0
+
+/-- Update cumulative regret with a new observation -/
+def updateRegret {n : Nat} (regret : CumulativeRegret n)
+    (payoff : Fin n → Float) (played : Fin n) : CumulativeRegret n :=
+  fun a => regret a + instantRegret payoff played a
+
+/-!
+## Regret Matching
+-/
+
+/-- Regret matching: convert positive cumulative regrets to a strategy.
+
+    For each action a: σ(a) = R+(a) / Σ_a' R+(a')
+    where R+ is the positive part of cumulative regret.
+
+    If all regrets are non-positive, play uniformly.
+-/
+def regretMatchingStrategy {n : Nat} (regret : CumulativeRegret n) : Fin n → Float :=
+  let posRegret (a : Fin n) : Float := max 0 (regret a)
+  let total := (List.finRange n).foldl (fun acc a => acc + posRegret a) 0
+  if total > 0 then
+    fun a => posRegret a / total
+  else
+    fun _ => (1.0 : Float) / n.toFloat  -- uniforme
+
+/-!
+## External Regret (Hannan Consistency)
+-/
+
+/-- External regret: difference between realized payoff and best
+    fixed action in hindsight.
+
+    R_T = max_a Σ_t u_t(a) - Σ_t u_t(a_t)
+-/
+def externalRegret (T : Nat) (payoffs : Fin T → (Fin n → Float))
+    (played : Fin T → Fin n) : Float :=
+  let bestFixed := (List.finRange n).foldl
+    (fun acc a => max acc ((List.finRange T).foldl
+      (fun s t => s + payoffs t a) 0))
+    0
+  let realized := (List.finRange T).foldl
+    (fun s t => s + payoffs t (played t)) 0
+  bestFixed - realized
+
+/-!
+## Counterfactual Regret
+-/
+
+/-- Counterfactual regret for a player at an information set.
+
+    The key insight of CFR: minimize counterfactual regret at each
+    information set independently, and the average strategy converges
+    to a Nash equilibrium in two-player zero-sum games.
+
+    CFR(I, a) = Σ_z∈Z_I  π_{-i}(z) · (u_i(z, a) - u_i(z, σ(I)))
+
+    where π_{-i} is the reach probability excluding player i.
+-/
+structure CounterfactualRegret where
+  /-- The information set identifier -/
+  infoSet : String
+  /-- The player -/
+  player : Nat
+  /-- Regret for each available action -/
+  actionRegrets : List (String × Float)  -- (nom_action, valeur_regret)
+  deriving Repr
+
+/-!
+## CFR Solver State
+-/
+
+/-- The state maintained by a CFR solver across iterations -/
+structure CFRState where
+  /-- Cumulative counterfactual regret per information set and action -/
+  cumulativeRegret : List (String × List (String × Float))
+  /-- Cumulative strategy (sum of strategies weighted by reach) -/
+  strategySum : List (String × List (String × Float))
+  /-- Number of iterations completed -/
+  iterations : Nat
+  deriving Repr
+
+/-- Initialize empty CFR state -/
+def initCFRState : CFRState where
+  cumulativeRegret := []
+  strategySum := []
+  iterations := 0
+
+/-!
+## Convergence Concepts
+-/
+
+/-- Average regret approaches zero (ε-Nash equilibrium) -/
+def epsilonNash (ε : Float) (externalReg : Float) : Prop :=
+  externalReg <= ε
+
+/-- No-regret learning: average external regret goes to zero.
+    Payoffs and plays are indexed by `Nat` (infinite horizon); the regret
+    at horizon `t` is computed on the prefix of the first `t` rounds. 
+-/
+def noRegret (payoffs : Nat → (Fin n → Float))
+    (played : Nat → Fin n) : Prop :=
+  ∀ ε > 0, ∃ T0, ∀ t ≥ T0,
+    externalRegret t (fun s => payoffs s.val) (fun s => played s.val) / t.toFloat < ε
+
+/-!
+## Fictitious Play (from GT-17 Section 3)
+-/
+
+/-- Fictitious play: each player plays best response to the
+    empirical distribution of opponent's past plays.
+
+    Brown (1951): converges to Nash equilibrium in:
+    - 2-player zero-sum games
+    - 2x2 games
+    - Games with identical interests
+-/
+structure FictitiousPlayState (n : Nat) where
+  /-- Empirical frequency of each player's actions -/
+  actionCounts : Fin n → (Fin m → Nat)
+  /-- Number of rounds played -/
+  rounds : Nat
+  -- pas de `deriving Repr` : `actionCounts` est un type fonctionnel, non dérivable
+
+/-- Best response to empirical distribution of opponent.
+
+    Conceptually: argmax_a Σ_{a_{-i}} empiricalDist(a_{-i}) · u_i(a, a_{-i}).
+    In a full formalization this would use Mathlib's argmax.
+-/
+def isBestResponseToEmpirical {m : Nat}
+    (payoff : Fin 2 → (Fin 2 → Fin m) → Float)
+    (empiricalDist : Fin 2 → (Fin m → Float))
+    (player : Fin 2) (action : Fin m) : Prop :=
+  ∀ other : Fin m,
+    let expected := fun a =>
+      (List.finRange m).foldl
+        (fun acc a' => acc + empiricalDist (if player.val = 0 then 1 else 0) a' *
+                       payoff player (fun j => if j = player then a else a'))
+        0
+    expected action >= expected other
+
+end RegretEn

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lakefile.toml
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lakefile.toml
@@ -20,4 +20,5 @@ name = "LeanGameDefs"
 roots = [
   "Basic", "Nash", "Bayesian", "Combinatorial", "SocialChoice", "Regret",
   "Nash_en", "Combinatorial_en", "Basic_en", "SocialChoice_en", "Bayesian_en",
+  "Regret_en",
 ]


### PR DESCRIPTION
## Migration `Regret.lean` Option B -> Option A (sibling pair Pattern A, EPIC #4980)

5e et **dernier** module du rollout `lean_game_defs` (apres Basic #6758, Nash #6753, Combinatorial #6755, SocialChoice #6779). Partition anti-bell-storm ai-01 : `Regret_en -> po-2024` (moi), `Bayesian_en -> po-2025` (#6786). Rollout lean_game_defs maintenant **6/6 complete**.

### Substance
- **`Regret.lean` (FR canonical)** : strip des 29 blocs `"English:"` inline (Option B bilingue) -> FR-only + note "Jumelage i18n".
- **`Regret_en.lean` (NEW, EN twin)** : variante **reuse-FR-names** (comme `Nash_en`). `Regret.lean` depend de `Basic` + `Bayesian` (`import`), donc le miroir EN les importe et re-declare ses propres 13 definitions (7 defs + 3 structures + notions) dans `namespace RegretEn`. Body byte-identique, seules les docstrings `/-! ... -/` et `/-- ... -/` different EN.
- **`lakefile.toml`** : `Regret_en` ajoute aux roots (orphan-trap fix L526).

### Preuves (po-2024 via WSL elan 4.2.3, lake self-contained = pas de Mathlib)

| Verification | Resultat |
|---|---|
| `lake build LeanGameDefs` | **Build completed successfully (13 jobs), EXIT 0** — Regret (FR) + Regret_en (EN) + 9 autres targets TOUS built |
| `check_i18n_siblings.py lean_game_defs` | **5/5 pairs byte-identical**, 0 unbuilt, 0 drift, 0 orphan |
| sorry count | FR 0 / EN 0 (0 proof regression) |
| Code body FR vs EN | byte-identical (verifie par strip-comments Lean-aware) |
| Catalogue | byte-identical a main (0 churn) |
| Collision guard (`gh pr list --state all`) | 0 PR Regret concurrent (lesson c.534) |

### Note variant
Regret.lean imports `Basic` + `Bayesian` mais aucune de ses declarations ne reference un identifiant Basic/Bayesian (uniquement `Fin`/`Float`/`Nat`/`String`/`List` = Lean core). Les imports sont vestigiaux mais preserves pour byte-identity avec le FR.

See #4980. Rollout lean_game_defs complete (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
