### PR TITLE
docs(gametheory,#4365): reconcile stale cooperative_games_lean/stable_marriage_lean references (removed #6587/#5971)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/INVENTORY.md
@@ -1,5 +1,7 @@
 # Game Theory Series — Inventory & Audit Report
 
+> ⚠ **Snapshot daté (2026-04-30) — ne pas utiliser comme état courant.** Cet audit fige l'état au 2026-04-30 ; depuis lors, `cooperative_games_lean/` a été **supprimé** (rm #6587, absorbé dans `game_theory_lean/CooperativeGames/`) et `stable_marriage_lean/` également (PR #5971, absorbé dans `game_theory_lean/StableMarriage/`). Pour l'état courant des lakes Lean, voir [`LEAN_INVENTORY.md`](LEAN_INVENTORY.md).
+
 **Generated**: 2026-04-30 | **Agent**: po-2025 | **Issue**: #622
 
 ## Summary

--- a/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
+++ b/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md
@@ -7,7 +7,7 @@ Cross-directory inventory of all Lean 4 formalization projects under `GameTheory
 | Directory | Toolchain | Production sorry | Modules | Status |
 |-----------|-----------|-----------------|---------|--------|
 | `game_theory_lean` | v4.31.0-rc1 | 3 (Lattice) | CooperativeGames + StableMarriage | COMPLETE (EPIC #4365) |
-| `cooperative_games_lean` | v4.31.0-rc1 | 0 | 3 files | COMPLETE |
+| ~~`cooperative_games_lean`~~ | — | — | — | **Supprimé** (rm #6587 — absorbé dans `game_theory_lean/CooperativeGames/`) |
 | `social_choice_lean` | v4.31.0-rc1 | 0 | 7 files | COMPLETE |
 | `social_choice_lean_peters` | v4.27.0-rc1 | 0 | 1 file | Reference only |
 | `repeated_games_lean` | v4.31.0-rc1 | 0 (1 stretch) | 4 files | COMPLETE (Folk stretch) |
@@ -57,7 +57,9 @@ Note: `_GoalExtract.lean` (former prover test file) has been removed from the re
 
 ---
 
-### 2. cooperative_games_lean
+### 2. cooperative_games_lean — ⚠ **Supprimé** (rm #6587)
+
+> **Lake standalone supprimé** (commit `522c450e9`, PR #6587). Modules `Basic` / `ConeKernel` / `Shapley` (+ jumeaux `_en`) absorbés byte-identique dans [`game_theory_lean/CooperativeGames/`](game_theory_lean/CooperativeGames/) (EPIC #4365). La section ci-dessous est conservée comme trace d'audit du statut de preuve (0 sorry, préservé dans la cible). Pour l'état courant, voir [§1. game_theory_lean](#1-game_theory_lean).
 
 **Objective**: Formalize cooperative game theory (Shapley value, core).
 
@@ -231,7 +233,7 @@ Note: `_GoalExtract.lean` (former prover test file) has been removed from the re
 | Project                | Decision | Reasoning                                                      |
 |------------------------|----------|----------------------------------------------------------------|
 | game_theory_lean       | COMPLETE | 3 sorry (Lattice, Knuth lattice stretch). StableMarriage: former false statements refuted, honest `exists_isManOptimal` proved. Absorbed standalone `stable_marriage_lean/` (EPIC #4365). |
-| cooperative_games_lean | COMPLETE | 0 sorry. Bondareva-Shapley proven (#3954) via compact-slice Weierstrass; hCore bypassed without added axiom. |
+| ~~cooperative_games_lean~~ | **Supprimé** (rm #6587) | Lake standalone removed — content (0 sorry, Bondareva-Shapley #3954) absorbed byte-identique into `game_theory_lean/CooperativeGames/`. Status preserved there. |
 | social_choice_lean     | N/A      | COMPLETE (0 sorry). MechanismDesign added (#1469).             |
 | social_choice_lean_peters | N/A   | Reference only (pinned v4.27.0-rc1).                           |
 

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -305,14 +305,14 @@ La théorie des jeux n'est pas qu'un objet académique : ses résultats structur
 
 ### Pont vers les Preuves Formelles (Lean 4) — différenciant CoursIA
 
-GameTheory occupe une place à part dans la couche Lean : c'est la famille qui aligne le plus directement simulation numérique et preuve formelle. Le Niveau 3 promet de « prouver ce qu'on a calculé » ; cette série tient la promesse par **huit lakes game-théoriques en propre** — dont les sept phares cartographiés ci-dessous, plus `lean_game_defs` (types partagés) et le lake de référence externe `social_choice_lean_peters` (toolchains détaillées dans [LEAN_INVENTORY.md](LEAN_INVENTORY.md) — harmonisation Mathlib en cours, cf #4362 —, branchés sur les notebooks qui les enseignent ou les utilisent). Cartographie inter-familles :
+GameTheory occupe une place à part dans la couche Lean : c'est la famille qui aligne le plus directement simulation numérique et preuve formelle. Le Niveau 3 promet de « prouver ce qu'on a calculé » ; cette série tient la promesse par **sept lakes game-théoriques en propre** — dont les six phares cartographiés ci-dessous, plus `lean_game_defs` (types partagés) et le lake de référence externe `social_choice_lean_peters` (toolchains détaillées dans [LEAN_INVENTORY.md](LEAN_INVENTORY.md) — harmonisation Mathlib en cours, cf #4362 —, branchés sur les notebooks qui les enseignent ou les utilisent). Cartographie inter-familles :
 
 | Famille | Lake phare | Théorème | Branchement notebook |
 | --- | --- | --- | --- |
 | **GameTheory** (choix social) | `social_choice_lean` (cf. `arrow_lean`) | Théorème d'impossibilité d'Arrow + caractérisation Sen + valeur de Shapley (résolu 0 sorry) | Notebooks 16b (Arrow), Argument_Analysis |
 | **GameTheory** (équilibres) | `minimax_lean` (Sion) | Existence d'un équilibre en stratégies mixtes via point fixe (Brouwer-Sion) | GameTheory-5b-Lean-Minimax (companion natif) |
 | **GameTheory** (design) | `lean_game_defs_ext` | Vickrey (enchère au second prix = stratégie dominante), théorème de révélation | GameTheory-11b-Lean-BayesianGamesExt |
-| **GameTheory** (coopératif) | `cooperative_games_lean` (Bondareva-Shapley) | Bondareva-Shapley résolu 0 sorry (#3954), Core non-vide sous balanced | Notebooks 15-15b (coopératif, valeur de Shapley) |
+| **GameTheory** (coopératif) | `game_theory_lean` (CooperativeGames) | Bondareva-Shapley résolu 0 sorry (#3954), Core non-vide sous balanced | Notebooks 15-15b (coopératif, valeur de Shapley) |
 | **GameTheory** (matching) | `game_theory_lean` (StableMarriage) | Gale-Shapley : existence + optimalité côté proposant | Notebooks 16-2 (matching, Gale-Shapley) |
 | **GameTheory** (jeux répétés) | `repeated_games_lean` | Stratégie grim-trigger **certifiée 0 sorry** (compagnon formel GT-6c, cf #4880) ; stretch restant : théorème Folk complet (`Folk.lean`) | Notebook 6c (RepeatedGames-FolkTheorem) |
 | **GameTheory** (jeux combinatoires) | `conway_cgt_lean` | Visite guidée (`#check`) de la théorie des jeux combinatoires (Conway CGT) | Notebooks 8/8b (CombinatorialGames, Sprague-Grundy) |
@@ -333,7 +333,7 @@ flowchart LR
         L1["social_choice_lean<br/>impossibilité"]
         L2["minimax_lean<br/>Sion"]
         L3["lean_game_defs_ext<br/>Vickrey"]
-        L4["cooperative_games_lean<br/>0 sorry #3954"]
+        L4["game_theory_lean/CooperativeGames<br/>0 sorry #3954"]
         L5["game_theory_lean<br/>StableMarriage (Gale-Shapley)"]
         L6["repeated_games_lean<br/>grim_trigger"]
     end
@@ -352,6 +352,8 @@ flowchart LR
 ```
 
 Le pipeline complet relie les **notebooks** (qui motivent — Lemke-Howson, Axelrod, Folk Theorem, Gale-Shapley via `game_theory_lean`) aux **lakes** (qui prouvent — Arrow résolu 0 sorry, Bondareva-Shapley résolu 0 sorry #3954, von Neumann/Sion, Vickrey, Gale-Shapley existence et optimalité côté proposant, grim-trigger). Sans la couche Lean, ces résultats seraient des théorèmes réputés « standard » mais jamais démontrés ; avec elle, la justification est **formellement garantie** — pas seulement admise. La spécificité GameTheory : la simulation (Lemke-Howson numérique, OpenSpiel CFR, Axelrod tournois) précède la preuve, mais les deux faces du même raisonnement sont également outillées.
+
+> **Consolidation des lakes (EPIC #4365)** : les anciens lakes standalone `cooperative_games_lean/` (**Supprimé**, rm #6587 — contenu Basic/ConeKernel/Shapley préservé byte-identique sous `game_theory_lean/CooperativeGames/`) et `stable_marriage_lean/` (**Supprimé**, PR #5971 — contenu absorbé sous `game_theory_lean/StableMarriage/`) ne sont plus des projets Lake indépendants. Les sept lakes en propre actuels : `conway_cgt_lean`, `game_theory_lean` (multi-module, absorbant CooperativeGames + StableMarriage), `lean_game_defs`, `lean_game_defs_ext`, `minimax_lean`, `repeated_games_lean`, `social_choice_lean`. Statut détaillé par lake : cf [LEAN_INVENTORY.md](LEAN_INVENTORY.md).
 
 Pour aller plus loin : [EPIC #4038](https://github.com/jsboige/CoursIA/issues/4038) (Roadmap Lean — un théorème-phare par série), [hub QuantConnect ↔ `kelly_lean`](../QuantConnect/README.md) (PR #5047), [hub central P0 ↔ Lean inter-familles](../README.md) (PR #5049), [hub SymbolicAI Lean](../SymbolicAI/Lean/README.md).
 
@@ -494,7 +496,7 @@ Si l'encodage SAT d'Arrow (SC-04) semble trivial, vérifiez que le nombre de vot
 
 ### Les projets Lake Lean ne buildent pas
 
-Chaque sous-dossier Lean (`social_choice_lean/`, `cooperative_games_lean/`, `game_theory_lean/`, etc.) est un projet Lake indépendant. Pour builder :
+Chaque sous-dossier Lake (`conway_cgt_lean/`, `game_theory_lean/`, `minimax_lean/`, `repeated_games_lean/`, `social_choice_lean/`, `social_choice_lean_peters/`, `lean_game_defs/`, `lean_game_defs_ext/`) est un projet Lake indépendant. Pour builder :
 
 ```bash
 cd MyIA.AI.Notebooks/GameTheory/social_choice_lean
@@ -721,7 +723,6 @@ GameTheory/
 │   ├── strategies.py              # Tit-for-tat, hawks, doves, etc.
 │   ├── tournament.py              # Tournoi Axelrod
 │   └── visualization.py           # Animations populations
-├── cooperative_games_lean/        # Projet Lake jeux cooperatifs (Shapley + Bondareva-Shapley 0 sorry, cf #3954)
 ├── conway_cgt_lean/               # Projet Lake jeux combinatoires (Conway CGT, toolchain v4.31.0-rc1)
 ├── minimax_lean/                  # Projet Lake minimax (Sion, cf #4054)
 ├── repeated_games_lean/           # Projet Lake jeux répétés (grim trigger, cf #4880)
@@ -810,7 +811,7 @@ Cette série mobilise plusieurs couches de l'écosystème MCP du cluster, et ent
 | Mécanismes VCG, matching Gale-Shapley | [SymbolicAI/SmartContracts](../SymbolicAI/SmartContracts/README.md) | Gouvernance on-chain (DAO, vote vérifiable) ; le design de mécanismes se prolonge en smart contracts |
 | Encodage SAT/Z3 d'Arrow | [SymbolicAI/SMT/Z3-Linq2Z3](../SymbolicAI/SMT/Z3-Linq2Z3/README.md) | Outil Z3 partagé ; notebook SC-04 exploite la même API que NB-06 (witness generation Automata) |
 
-**Effet de composition** : GameTheory sert de **carrefour** entre simulation numérique (Nashpy, OpenSpiel, Z3) et formalisation (Lean 4). Toute avancée d'une série partenaire enrichit potentiellement les notebooks GameTheory — par exemple, un nouveau théorème prouvé en Lean côté SymbolicAI/Lean peut être cité depuis [LEAN_INVENTORY.md](LEAN_INVENTORY.md) ou ouvrir un nouveau side track `b`. Le pipeline complet relie les **notebooks** (qui motivent — Lemke-Howson, Axelrod, Gale-Shapley) aux **lakes** (qui prouvent — Arrow, Bondareva-Shapley, Gale-Shapley existence et optimalité côté proposant), avec **8 lakes game-théoriques en propre** (plus le lake de référence externe `social_choice_lean_peters`) et **0 sorry sur les théorèmes majeurs**.
+**Effet de composition** : GameTheory sert de **carrefour** entre simulation numérique (Nashpy, OpenSpiel, Z3) et formalisation (Lean 4). Toute avancée d'une série partenaire enrichit potentiellement les notebooks GameTheory — par exemple, un nouveau théorème prouvé en Lean côté SymbolicAI/Lean peut être cité depuis [LEAN_INVENTORY.md](LEAN_INVENTORY.md) ou ouvrir un nouveau side track `b`. Le pipeline complet relie les **notebooks** (qui motivent — Lemke-Howson, Axelrod, Gale-Shapley) aux **lakes** (qui prouvent — Arrow, Bondareva-Shapley, Gale-Shapley existence et optimalité côté proposant), avec **7 lakes game-théoriques en propre** (plus le lake de référence externe `social_choice_lean_peters`) et **0 sorry sur les théorèmes majeurs**.
 
 ## Licence
 
@@ -818,4 +819,6 @@ Voir la licence du repository principal.
 
 ---
 
-*Version 1.4.0 — Juillet 2026 (2026-07-07) — passe ascendante feuilles→hub : intégration du marathon parité C# #4956 (binômes GT-2..17 + SocialChoice), 8 lakes en propre + peters, grim-trigger certifié, comptes délégués au marqueur CATALOG-STATUS.*
+*Version 1.4.1 — Juillet 2026 (2026-07-16) — reconciliation EPIC #4365 : retrait des références aux lakes supprimés `cooperative_games_lean` (rm #6587) et `stable_marriage_lean` (PR #5971), absorbés dans `game_theory_lean` ; comptes lakes mis à jour (7 en propre + peters).*
+
+*Version 1.4.0 — Juillet 2026 (2026-07-07) — passe ascendante feuilles→hub : intégration du marathon parité C# #4956 (binômes GT-2..17 + SocialChoice), 7 lakes en propre + peters, grim-trigger certifié, comptes délégués au marqueur CATALOG-STATUS.*


### PR DESCRIPTION
## Contexte

EPIC **#4365** (consolidation des lakes Lean GameTheory). Les inventaires *courants* de GameTheory présentaient `cooperative_games_lean/` et `stable_marriage_lean/` comme des projets Lake standalone **actuels**, alors qu'ils ont été supprimés et absorbés dans `game_theory_lean/`.

Vérifié firsthand (G.1) :
- `git log --oneline 522c450e9` → `refactor(gametheory,#4365): remove legacy cooperative_games_lean lake` (PR #6587).
- `git ls-files MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/` → **vide** (idem `stable_marriage_lean/`).
- Contenu absorbé byte-identique dans `game_theory_lean/CooperativeGames/` (Basic/ConeKernel/Shapley + `_en`) et `game_theory_lean/StableMarriage/`.

## Changements (audit fichier-entier §E pour chaque fichier touché)

### `README.md` (+11/−6)
- Compte lakes : « huit lakes en propre » → « sept » aux **3** endroits (intro « Pont vers les Preuves Formelles », « Effet de composition », footer v1.4.0) ; « sept phares » → « six phares ».
- Table de cartographie inter-familles : la ligne « coopératif » pointe vers `game_theory_lean` (CooperativeGames) au lieu du lake supprimé.
- Diagramme mermaid : node `L4` → `game_theory_lean/CooperativeGames`.
- FAQ « Les projets Lake ne buildent pas » : liste exhaustive des **8** lakes actuels (7 en propre + peters) au lieu d'une liste périmée citant `cooperative_games_lean`.
- Arbre « Structure des fichiers » : ligne `cooperative_games_lean/` retirée.
- Note de consolidation (bloc `>`) ajoutée après le diagramme : liste canonique des 7 lakes en propre, citations #6587/#5971.
- Footer : ajout ligne v1.4.1 (2026-07-16).

### `LEAN_INVENTORY.md` (+5/−3)
- Summary table (ligne 10) : `cooperative_games_lean` → ligne ~~barrée~~ « Supprimé (rm #6587) ».
- Section §2 : bannière de suppression (rm #6587) en tête + pointeur vers §1 game_theory_lean. **Contenu d'audit préservé** (statut 0 sorry, lineage #3933→#3954) — trace de l'état de preuve absorbé.
- Table GO/NO-GO : `cooperative_games_lean` → « Supprimé ».

### `INVENTORY.md` (+2/−0) — snapshot daté
- **Note historique minimale** en tête (au-dessus du `Generated: 2026-04-30`) pointant vers `LEAN_INVENTORY.md` pour l'état courant.
- **Body NON réécrit** : c'est un audit daté (po-2025, issue #622). Réécrire un snapshot daté = falsifier l'historique. Touche minimale uniquement, conformément à la consigne.

## Vérifications

| Check | Résultat |
|-------|----------|
| `git ls-files` cooperative/stable | vide (suppression confirmée) |
| Lakes en propre actuels sur disque | **7** : conway_cgt_lean, game_theory_lean, lean_game_defs, lean_game_defs_ext, minimax_lean, repeated_games_lean, social_choice_lean (+ social_choice_lean_peters réf. externe) |
| Marqueur `CATALOG-STATUS` (README lines 5-10) | byte-identique (catalog-pr-hygiene R1) |
| `python scripts/check_docs_links.py --check` | **exit 0** (aucun lien cassé introduit) |
| `git diff --stat` | 3 files, +17/−10 |
| social_choice_lean (Absorbé/tombstone, toujours tracké) | intact — ne pas confondre avec les lakes pleinement supprimés |

## Follow-up noté (hors scope — PR atomique)

- `lean_game_defs/README.md:63` — node mermaid `cooperative_games_lean/<br/>Shapley · Cœur · Banzhaf` présenté comme lake courant. Découvert pendant l'audit fichier-entier §E. À corriger dans une PR dédiée (différent fichier / même sujet mais garde l'atomicité ici).
- `LEAN_INVENTORY.md` total « 39 files » utilise une convention de comptage par-lake pré-existante (non réconciliée avec les counts réels par-lake sur disque) — non touché ici (scope = refs aux lakes supprimés uniquement).

## Critères de review (§E pr-review-discipline)

Audit fichier-entier effectué sur les **3** fichiers : chaque mention de `cooperative_games_lean` / `stable_marriage_lean` vérifiée, les listes/tables/comptes à 100+ lignes de distance réconciliés (pas de « une ligne corrigée, une liste périmée 100 lignes plus bas »). Prose ajoutée en français (readme-french-first).

See #4365

Co-Authored-By: Claude <noreply@anthropic.com>