### PR TITLE
fix(search,#5081): repair Search-15 prev-navlink to Search-14 (wrong subdir)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Search-15 : Theorie des Graphes avec NetworkX (C#)\n",
     "\n",
-    "**Navigation** : [<< 14-WeightedAstar](Search-14-WeightedAstar-Csharp.ipynb) | [Index](../README.md) | [16-QuikGraph >>](Search-16-QuikGraph.ipynb)\n",
+    "**Navigation** : [<< 14-WeightedAstar](../Part3-Advanced/Search-14-WeightedAstar-Csharp.ipynb) | [Index](../README.md) | [16-QuikGraph >>](Search-16-QuikGraph.ipynb)\n",
     "\n",
     "**Twin C# (.NET Interactive)** de [Search-15-NetworkX.ipynb](Search-15-NetworkX.ipynb) — marathon **#4956** (parite .NET <-> Python).\n",
     "\n",


### PR DESCRIPTION
## Summary

The **previous-notebook navigation link** in `Search-15-NetworkX-Csharp.ipynb` (cell 0, navigation bar) pointed to `Search-14-WeightedAstar-Csharp.ipynb` as a **same-directory** relative path, but that notebook lives in `Part3-Advanced/`, not `Part1-Foundations/`. The link **404'd**.

`Search-14-WeightedAstar-Csharp` was moved to Part3-Advanced during the Search series restructuring; the navlink was not updated to reflect the new location.

## Fix

Correct the relative path:
- Before: `](Search-14-WeightedAstar-Csharp.ipynb)`
- After: `](../Part3-Advanced/Search-14-WeightedAstar-Csharp.ipynb)`

This matches the established cross-Part convention (the `Search-3-Informed-Csharp` link in cell 19 already uses `../Part1-Foundations/...`). The forward link to `Search-16-QuikGraph` stays same-directory (correct — it IS in Part1-Foundations).

## Why this one is non-ambiguous (G.9)

Exactly **one** `Search-14-WeightedAstar-Csharp.ipynb` exists in the repo (verified via `find`). This is a **path relocation** (notebook moved across subdirs, same filename), not a narrative renumbering — so the fix target is unambiguous and does not require guessing. The broader Search renumbering epic is tracked in #5081.

## Verification

- Re-scan of all `.ipynb` links in the notebook: **all 3 links in cell 0 now resolve OK** (were 1× 404).
- Markdown-cell-only edit: **outputs and execution_count byte-identical** (verified programmatically), no re-execution needed.
- `git diff --stat`: 1 file, 1 ins / 1 sup (surgical).

See #5081 (partial — one navlink path repair).