### PR TITLE
fix(search,#5081): repair App-18b forward-navlink to App-19 WFC (wrong subdir)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18b-HyperparameterTuning-CSharp.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# App-18b : Optimisation d'Hyperparametres - Jumeau C#\n",
     "\n",
-    "> **Twin C#** de [`App-18-HyperparameterTuning`](App-18-HyperparameterTuning.ipynb) (Python / scikit-learn + Optuna). Navigation : [<< App-17b VRP](App-17b-VRP-Logistics-Csharp.ipynb) | [Index](../../README.md) | [App-19 WFC >>](App-19-ProceduralGeneration-WFC-Csharp.ipynb)\n",
+    "> **Twin C#** de [`App-18-HyperparameterTuning`](App-18-HyperparameterTuning.ipynb) (Python / scikit-learn + Optuna). Navigation : [<< App-17b VRP](App-17b-VRP-Logistics-Csharp.ipynb) | [Index](../../README.md) | [App-19 WFC >>](../CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb)\n",
     "\n",
     "## Objectif pedagogique\n",
     "\n",


### PR DESCRIPTION
## Summary

The **forward navigation link** in `App-18b-HyperparameterTuning-CSharp.ipynb` (cell 0) pointed to `App-19-ProceduralGeneration-WFC-Csharp.ipynb` as a same-directory relative path, but that notebook lives in `Applications/CSP/`, not `Applications/Hybrid/`. The link **404'd** (App-19 was moved to the CSP applications subfolder).

## Fix

Correct the relative path:
- Before: `](App-19-ProceduralGeneration-WFC-Csharp.ipynb)`
- After: `](../CSP/App-19-ProceduralGeneration-WFC-Csharp.ipynb)`

## Why non-ambiguous (G.9)

Exactly one `App-19-ProceduralGeneration-WFC-Csharp.ipynb` exists in the repo (verified via `find`). Path relocation (notebook moved across application subfolders, same filename), not a narrative renumbering — fix target is unambiguous. Broader renumbering tracked in #5081.

## Verification

- All 4 links in cell 0 now resolve **OK** (was 1× 404).
- Markdown-cell-only: **outputs + execution_count byte-identical**, no re-exec.
- `git diff --stat`: 1 file, 1 ins / 1 sup.

See #5081 (partial — one navlink path repair).