### PR TITLE
chore(prover,gol): retarget DEMO 62 to first p4_succ sub-goal + refresh lean-conway.yml sorry breakdown

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -8,14 +8,16 @@ name: Lean Conway CI
 # version in PR #2747 (same standalone-tactic mode, same baseline 8, now via the
 # shared lean-build.yml reusable workflow).
 #
-# Sorry profile (re-verified 2026-07-16, standalone-tactic mode, baseline=8):
-# conway has 7 real tactic sorries, ALL in HashlifeCorrectness.lean. The
-# standalone-tactic filter now also counts the Lean case-bullet form `· sorry`
-# (fixed in lean-build.yml, See #2747); the prior regex silently dropped it, so
-# CI reported 6 while the real count was 7 (1 unit of hidden slack). Prose
-# mentions ("Each sorry is a target", "Left as sorry", "remain sorry-gated")
-# are excluded by the sole-token check. Breakdown of the 7:
-#   - HashlifeCorrectness.lean: 7 (6 standalone P4/P5 + 1 case-bullet P5)
+# Sorry profile (re-verified 2026-07-16 post-#6792, standalone-tactic mode,
+# baseline=8): conway has 8 real tactic sorries, ALL in HashlifeCorrectness.lean.
+# The standalone-tactic filter also counts the Lean case-bullet form `· sorry`
+# (fixed in lean-build.yml, See #2747). Prose mentions ("Each sorry is a
+# target", "Left as sorry", "remain sorry-gated") are excluded by the
+# sole-token check. Breakdown of the 8:
+#   - HashlifeCorrectness.lean: 8 = 5 sub-goals of the p4_succ_membership
+#     decomposition (#6792: 4 mp quadrant cases + 1 mpr routing case)
+#     + 3 downstream P4-gated (p5_large_n_jump, hashlife_correctN,
+#     p5_large_n_jumpN)
 #   - HashlifeMemo.lean:        0 (discharged since #2794, Phase 3c)
 #   - Pillars.lean:             0 (discharged since #2790, scaffolding witnesses)
 # Raising this baseline requires a documented justification in the PR body.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1814,26 +1814,32 @@ DEMOS = {
     62: {
         "name": "HASHLIFE_P4_SUCC_MEMBERSHIP",
         "file": str(CONWAY_HASHLIFE_FILE) if CONWAY_HASHLIFE_FILE else "",
-        "line": 2892,
+        "line": 2904,
         "sorry_type": "sorry_replacement",
         "theorem_name": "p4_succ_membership",
         "theorem": "p4_succ_membership",
         "imports": CONWAY_HASHLIFE_IMPORTS,
         "description": (
-            "BG-prover target (hashlife nibble plan #3846, N3): residual sorry in\n"
-            "noncomputable def p4_succ_membership (declared L2855, residual sorry\n"
-            "L2892 of HashlifeCorrectness.lean). The whnf wall is already traversed\n"
-            "around L2648-2665 (node16_level_ne_two L2660 -> rw [if_neg hne2] L2663\n"
-            "-> rw [mem_toGrid_node]); what remains is the offset-matching assembly:\n"
-            "prove each `out_*.toGrid (off_*, off_*)` membership via\n"
-            "centralCorrect_mem (gate G2, merged #4812) plus the induction\n"
-            "hypothesis `centralCorrect q_* (k-1)` extracted from `_h3`, bridged\n"
-            "through evolve_half_step + evolve_add (gate G1, merged #4787).\n"
+            "BG-prover target (hashlife nibble plan #3846, N3): FIRST sub-goal of\n"
+            "the p4_succ_membership decomposition (PR #6792, 2026-07-16). The\n"
+            "former monolithic residual sorry (ex-L2892) is now 5 named\n"
+            "sub-sorries under `refine (?mp, ?mpr)`: 4 mp quadrant cases (nw\n"
+            "L2904, ne L2906, sw L2908, se L2910) + 1 mpr routing case (L2915).\n"
+            "CURRENT TARGET = nw quadrant (L2904): from hypothesis\n"
+            "`hnw : p in out_nw.toGrid (2^k, 2^k)` prove membership\n"
+            "`p in restrictGridTo (evolve (2^k) (toGrid (0,0) c)) (2^k) (2^(k+1))`\n"
+            "(note: `c` is destructured into its 16 nodes at this proof point).\n"
+            "Attack plan (also commented in-file at L2892-2897): apply\n"
+            "centralCorrect_mem_shift (G2, #4812) on q_nw extracted from `_h3`,\n"
+            "then bridge through evolve_half_step + evolve_add (G1, #4787) and\n"
+            "evolve_cone_agree (locality, #4892) to the global evolve 2^k window.\n"
             "Watch the offset arithmetic: sub-results live at scale\n"
-            "2^out_*.level while the goal is at 2^k, and the IH is at level k-1\n"
-            "versus the goal's level k. Available merged gates:\n"
-            "quad_partition_bounds (#4787), toGrid_shift_between (#4797),\n"
-            "centralCorrect_mem_shift (#4812), evolve_cone_agree (#4892).\n"
+            "2^out_nw.level while the goal is at 2^k, and the IH is at level k-1\n"
+            "versus the goal's level k. Other merged gates available:\n"
+            "quad_partition_bounds (#4787), toGrid_shift_between (#4797).\n"
+            "When the nw case is proved, re-point `line` to the next sub-sorry.\n"
+            "Harness caution (#6790): file_replace_lines build_check can\n"
+            "false-positive; only an independent lake build is proof.\n"
             "LEAN_PROJECT must be conway_lean."
         ),
         "difficulty": "hard",


### PR DESCRIPTION
## Summary

Bookkeeping post-#6792 (décomposition du sorry monolithique `p4_succ_membership` en 5 sous-buts) — deux artefacts d'infra prover/CI qui pointaient encore sur l'état d'avant :

1. **`prover/config.py` DEMO 62** : `line: 2892` (le sorry monolithique supprimé par #6792) → `line: 2904` (sous-but nw, premier des 5). Description réécrite : énumération des 5 sous-sorries (nw L2904 / ne L2906 / sw L2908 / se L2910 / mpr L2915), plan d'attaque du cas nw (`centralCorrect_mem_shift` G2 → `evolve_half_step` + `evolve_add` G1 → `evolve_cone_agree` localité), et caution harnais #6790 (`file_replace_lines` `build_check` peut false-positive — seul un `lake build` indépendant fait preuve).
2. **`.github/workflows/lean-conway.yml`** : le breakdown commenté du sorry profile était périmé (« 7 real tactic sorries », flaggé out-of-scope par po-2024 dans #6798) → 8 = 5 sous-buts p4_succ + 3 aval P4-gated (`p5_large_n_jump`, `hashlife_correctN`, `p5_large_n_jumpN`). Le `sorry-baseline: "8"` lui-même avait déjà été bumpé par #6798 — ce PR ne touche que le commentaire.

## Vérification

- Lignes des sous-sorries vérifiées firsthand sur main post-#6792 : `grep -nE "^\s+sorry\s*$"` → 2904/2906/2908/2910/2915 + 3244/3393/3422 (8 au total, tous HashlifeCorrectness.lean).
- `config.py` : `ast.parse` OK ; bloc DEMO 62 seul touché (diff 34 lignes, ASCII pur).
- `lean-conway.yml` : commentaire header uniquement — aucun changement de `jobs:`/`with:` (le YAML effectif est byte-identique).
- Aucun fichier `.lean` touché → pas de gate lake build requis ; catalogue byte-identique à main.

## Groupement §E

Les deux items sont trop petits pour des PRs dédiées (< 20 lignes chacun) et relèvent du même sujet : réconcilier l'infra prover/CI conway avec l'état post-#6792. Prochaine étape (hors PR) : relance BG prover iter sur le sous-but nw (lean-merge-discipline §2).

See #3846 (GOL S4), See #6724 (carte sorries), See #6790 (forensic harnais), See #1453 (Epic prover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
