### PR TITLE
feat(notebook-tools): add check_notebook_navlinks.py — .ipynb navlink checker (#5081)

### DIFF
--- a/scripts/notebook_tools/check_notebook_navlinks.py
+++ b/scripts/notebook_tools/check_notebook_navlinks.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Check for broken notebook navigation links (`.ipynb` relative links) across the repository.
+
+Sibling of ``scripts/check_docs_links.py``: that tool scans markdown documentation
+(``CLAUDE.md``, ``docs/``, READMEs) for broken relative links; THIS tool scans the
+**markdown cells of ``.ipynb`` notebooks** for broken relative links to other notebooks
+(the cell-0 "Navigation" prev/next bars and in-body prerequisite links).
+
+Motivation: after a series reorganization that moves notebooks into subdirectories
+(see EPIC #5081 — narrative renumbering), relative navlinks like
+``[<< 14-WeightedAstar](Search-14-WeightedAstar-Csharp.ipynb)`` silently break when the
+target moved to another subdir (e.g. ``Part3-Advanced/``). ``check_docs_links.py`` cannot
+catch these because it never opens ``.ipynb`` files. This tool closes that gap.
+
+A link is reported broken when the target ``.ipynb`` (resolved relative to the source
+notebook's own directory) does not exist on disk. HTTP(S) links are skipped.
+
+Usage:
+    python scripts/notebook_tools/check_notebook_navlinks.py            # scan all notebooks
+    python scripts/notebook_tools/check_notebook_navlinks.py Search/    # scan one family
+    python scripts/notebook_tools/check_notebook_navlinks.py --quiet    # minimal output
+    python scripts/notebook_tools/check_notebook_navlinks.py --strict   # exit 1 if broken
+
+Exit codes:
+    0 = no broken navlinks (or report-only mode)
+    1 = broken navlinks found AND --strict set
+    2 = error during execution
+
+NOTE: as of EPIC #5081, several Search/ notebooks carry pre-existing broken navlinks
+that reference notebooks renamed during the Part1-4 reorganization. Those require the
+renumbering map to resolve (pedagogical judgment, not a mechanical path fix) and are
+tracked in #5081. This tool is therefore NOT yet wired to blocking CI; run it on demand
+to surface drift, and adopt ``--strict`` in CI once the renumbering settles.
+"""
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ROOT = REPO_ROOT / "MyIA.AI.Notebooks"
+
+# Markdown link to a .ipynb target: [label](target.ipynb)
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+\.ipynb)\)")
+
+# Directories / path fragments to skip (non-pedagogical, generated, or legacy)
+SKIP_FRAGMENTS = (
+    "_output",
+    ".lake",
+    "_lean",
+    "/.ipynb_checkpoints",
+    "/archive/",
+    "partner-course",
+    "MetaGeneticSharp",
+)
+
+
+@dataclass(frozen=True)
+class BrokenNavlink:
+    notebook: str   # repo-relative path of the source notebook
+    cell: int       # cell index containing the broken link
+    target: str     # the raw (unresolvable) link target
+
+    def __str__(self) -> str:
+        return f"{self.notebook} [cell {self.cell}] -> {self.target}"
+
+
+def _should_skip(path: Path) -> bool:
+    posix = path.as_posix()
+    return any(frag in posix for frag in SKIP_FRAGMENTS)
+
+
+def find_notebook_files(roots: list[Path]) -> list[Path]:
+    """Return sorted .ipynb files under the given roots, skipping generated/legacy dirs."""
+    files: list[Path] = []
+    for root in roots:
+        if root.is_file() and root.suffix == ".ipynb":
+            if not _should_skip(root):
+                files.append(root)
+        else:
+            for nb in sorted(root.rglob("*.ipynb")):
+                if not _should_skip(nb):
+                    files.append(nb)
+    # De-duplicate while preserving order
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for f in files:
+        if f not in seen:
+            seen.add(f)
+            unique.append(f)
+    return unique
+
+
+def iter_navlinks(nb_path: Path):
+    """Yield (cell_index, target) for each markdown link to a .ipynb in the notebook."""
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    for ci, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "markdown":
+            continue
+        src = "".join(cell.get("source", []))
+        for m in LINK_RE.finditer(src):
+            target = m.group(1)
+            if target.startswith(("http://", "https://")):
+                continue
+            yield ci, target
+
+
+def check_navlink(target: str, nb_path: Path) -> bool:
+    """Return True if the target .ipynb resolves relative to the notebook's directory."""
+    resolved = (nb_path.parent / target).resolve()
+    return resolved.exists()
+
+
+def scan(roots: list[Path]) -> list[BrokenNavlink]:
+    """Scan notebooks under roots; return the list of broken navlinks."""
+    broken: list[BrokenNavlink] = []
+    for nb in find_notebook_files(roots):
+        rel = nb.relative_to(REPO_ROOT).as_posix() if nb.is_absolute() else nb.as_posix()
+        for ci, target in iter_navlinks(nb):
+            if not check_navlink(target, nb):
+                broken.append(BrokenNavlink(rel, ci, target))
+    return sorted(broken, key=lambda b: (b.notebook, b.cell, b.target))
+
+
+def format_report(broken: list[BrokenNavlink], quiet: bool = False) -> str:
+    if not broken:
+        return "OK: 0 broken notebook navlink(s)." if not quiet else ""
+    lines = [f"BROKEN notebook navlinks: {len(broken)}"]
+    if not quiet:
+        for b in broken:
+            lines.append(f"  {b}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("roots", nargs="*", default=[str(DEFAULT_ROOT)],
+                        help="Notebook file or directory to scan (default: MyIA.AI.Notebooks/). "
+                             "Paths are relative to repo root and may omit the "
+                             "'MyIA.AI.Notebooks/' prefix (e.g. 'Search/' or 'GameTheory/').")
+    parser.add_argument("--strict", action="store_true",
+                        help="Exit 1 if any broken navlink is found (for opt-in CI).")
+    parser.add_argument("--quiet", action="store_true", help="Minimal output (count only).")
+    args = parser.parse_args(argv)
+
+    roots: list[Path] = []
+    for r in args.roots:
+        p = Path(r)
+        if not p.is_absolute():
+            # Allow shorthand: 'Search/' -> 'MyIA.AI.Notebooks/Search'
+            candidate = REPO_ROOT / p
+            if not candidate.exists():
+                candidate = DEFAULT_ROOT / p
+            p = candidate
+        roots.append(p)
+
+    try:
+        broken = scan(roots)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"ERROR during scan: {exc}", file=sys.stderr)
+        return 2
+
+    report = format_report(broken, quiet=args.quiet)
+    if report:
+        print(report)
+    if broken and args.strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_check_notebook_navlinks.py
+++ b/scripts/notebook_tools/tests/test_check_notebook_navlinks.py
@@ -1,0 +1,114 @@
+"""Tests for scripts/notebook_tools/check_notebook_navlinks.py — notebook navlink checker.
+
+Validates:
+- Detects broken relative .ipynb navlinks (0 false negatives)
+- Accepts valid relative navlinks (0 false positives)
+- Skips HTTP links
+- Resolves relative to the source notebook's directory (not repo root)
+- --strict exit code semantics
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import check_notebook_navlinks as cnn
+
+
+def _make_nb(*cells):
+    """Build a minimal notebook from (cell_type, source_lines) tuples."""
+    return {
+        "cells": [
+            {"cell_type": ct, "source": src if isinstance(src, list) else [src], "metadata": {}, "outputs": [] if ct == "code" else None}
+            for ct, src in cells
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+@pytest.fixture
+def nb_tree(tmp_path: Path):
+    """Create a fake notebook family: Search-1 exists, Search-2 exists in a subdir,
+    Search-3 does NOT exist (broken target)."""
+    nb_good = tmp_path / "Search-1-Real.ipynb"
+    nb_subdir = tmp_path / "Sub" / "Search-2-Real.ipynb"
+    nb_missing_target = tmp_path / "Search-9-Real.ipynb"  # the source with broken links
+    for p in (nb_good, nb_subdir, nb_missing_target):
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(_make_nb(("markdown", "# title"))), encoding="utf-8")
+
+    # Notebook in tmp_path root: links to existing (same dir), existing (subdir), missing, http
+    src = tmp_path / "Src.ipynb"
+    src.write_text(json.dumps(_make_nb(
+        ("markdown", "**Nav**: [next](Search-1-Real.ipynb) | "
+                     "[sub](Sub/Search-2-Real.ipynb) | "
+                     "[broken](Search-999-Missing.ipynb) | "
+                     "[web](https://example.com/x.ipynb)"),
+    )), encoding="utf-8")
+    return tmp_path
+
+
+def test_detects_broken_navlink(nb_tree, monkeypatch):
+    monkeypatch.setattr(cnn, "REPO_ROOT", nb_tree)
+    broken = cnn.scan([nb_tree])
+    targets = {b.target for b in broken}
+    assert "Search-999-Missing.ipynb" in targets, "must detect the missing target"
+
+
+def test_accepts_valid_navlinks(nb_tree, monkeypatch):
+    monkeypatch.setattr(cnn, "REPO_ROOT", nb_tree)
+    broken = cnn.scan([nb_tree])
+    targets = {b.target for b in broken}
+    assert "Search-1-Real.ipynb" not in targets, "same-dir valid link must NOT be flagged"
+    assert "Sub/Search-2-Real.ipynb" not in targets, "subdir valid link must NOT be flagged"
+
+
+def test_skips_http_links(nb_tree, monkeypatch):
+    monkeypatch.setattr(cnn, "REPO_ROOT", nb_tree)
+    broken = cnn.scan([nb_tree])
+    targets = {b.target for b in broken}
+    assert not any(t.startswith("http") for t in targets), "HTTP links must be skipped"
+
+
+def test_only_one_broken(nb_tree, monkeypatch):
+    monkeypatch.setattr(cnn, "REPO_ROOT", nb_tree)
+    broken = cnn.scan([nb_tree])
+    assert len(broken) == 1, f"expected exactly 1 broken navlink, got {len(broken)}"
+
+
+def test_strict_exit_code(nb_tree, monkeypatch):
+    monkeypatch.setattr(cnn, "REPO_ROOT", nb_tree)
+    # With a broken link present, --strict must exit 1
+    assert cnn.main([str(nb_tree), "--strict", "--quiet"]) == 1
+
+
+def test_strict_clean_exit_code(nb_tree, monkeypatch):
+    monkeypatch.setattr(cnn, "REPO_ROOT", nb_tree)
+    # Scanning only the notebook with no broken link (the good one's dir has no broken refs)
+    clean = nb_tree / "Clean.ipynb"
+    clean.write_text(json.dumps(_make_nb(("markdown", "[ok](Search-1-Real.ipynb)"))), encoding="utf-8")
+    assert cnn.main([str(clean), "--strict", "--quiet"]) == 0
+
+
+def test_report_format_empty(monkeypatch):
+    assert cnn.format_report([], quiet=False) == "OK: 0 broken notebook navlink(s)."
+    assert cnn.format_report([], quiet=True) == ""
+
+
+def test_resolves_relative_to_notebook_dir(nb_tree, monkeypatch):
+    """A navlink in Sub/Search-2-Real.ipynb pointing to ../Search-1-Real.ipynb must resolve."""
+    monkeypatch.setattr(cnn, "REPO_ROOT", nb_tree)
+    sub_nb = nb_tree / "Sub" / "Search-2-Real.ipynb"
+    sub_nb.write_text(json.dumps(_make_nb(
+        ("markdown", "[parent](../Search-1-Real.ipynb) | [broken-sib](Search-888.ipynb)"),
+    )), encoding="utf-8")
+    broken = cnn.scan([nb_tree / "Sub"])
+    targets = {b.target for b in broken}
+    assert "../Search-1-Real.ipynb" not in targets, "relative ../ must resolve to parent dir"
+    assert "Search-888.ipynb" in targets


### PR DESCRIPTION
## Summary

Adds `scripts/notebook_tools/check_notebook_navlinks.py` — a validation tool that detects **broken relative navigation links inside `.ipynb` notebook markdown cells**. This fills a real gap: `scripts/check_docs_links.py` scans markdown documentation only (`CLAUDE.md`, `docs/`, READMEs) and cannot see the cell-0 "Navigation" prev/next bars or in-body prerequisite links that break when notebooks are reorganized into subdirectories (EPIC **#5081**).

## Why

After the Part1-4 reorganization (#5081), notebooks moved into subdirs but their relative navlinks (`[<< 14-WeightedAstar](Search-14-WeightedAstar-Csharp.ipynb)`) silently broke when the target moved to another subdir (e.g. `Part3-Advanced/`). The path-drift subset is being fixed (#6801 Search-15, #6802 App-18b — both LGTM'd by me this cycle), but **no existing tool detects these defects**. This tool closes that gap and makes future reorgs verifiable.

## What it does

Scans `.ipynb` markdown cells for `[label](target.ipynb)` links, resolves each target relative to the **source notebook's own directory**, reports targets that do not exist on disk. HTTP links skipped. Skips `_output/.lake/archive/checkpoints/partner-course/MetaGeneticSharp`.

Modes: default (report, exit 0) · `--strict` (exit 1 if broken, opt-in CI) · `--quiet` (count only) · family shorthand (`Search/` -> `MyIA.AI.Notebooks/Search`).

## Validation

- **Repo scan**: surfaces **20 pre-existing broken navlinks, all in `Search/`** (EPIC #5081 renumbering — they reference *renamed* targets like `Search-9-ConstraintSatisfaction` -> now `Search-9-LinearProgramming`; these need the renumbering map, not a path fix, and are tracked in my [inventory comment on #5081](https://github.com/jsboige/CoursIA/issues/5081#issuecomment-4988420573)).
- **My partition** (GameTheory/Sudoku/ML.Net/Probas-Infer): **0 broken** (clean).
- **8 unit tests PASS** (detect broken, accept valid same-dir + subdir, skip HTTP, resolve relative-to-nb-dir including `../`, `--strict` exit codes 0/1, report format).
- **Full `scripts/notebook_tools/tests/` suite: 2151 passed** — no regression.
- CRLF 0, UTF-8 no-BOM.

## Scope

2 new files, +292 lines (1 tool + 1 test). Atomic, scripts-only, no notebook/catalog touch. Per CLAUDE.md tool mandate ("validation tools go in `scripts/notebook_tools/`").

**NOT wired to blocking CI**: the 20 Search/ breaks are pre-existing #5081 work. `--strict` can be adopted in CI once the renumbering settles (then it guards against future regressions).

See #5081.

## Test plan

- [x] `pytest scripts/notebook_tools/tests/test_check_notebook_navlinks.py` -> 8 passed
- [x] Full suite `pytest scripts/notebook_tools/tests/` -> 2151 passed
- [x] Repo scan reproduces the 20 known Search/ breaks; partition scan clean
- [x] `--strict` exits 1 on broken, 0 on clean

Co-Authored-By: Claude-Code <noreply@anthropic.com>