### PR TITLE
fix(validate,#6803): H.1 advisory for *_archive.ipynb research snapshots (option 1)

### DIFF
--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -57,6 +57,18 @@ ALLOW_NULL_EXEC_COUNT_KERNELS = {"lean4", "lean4-wsl", "lean"}
 # H.3 is advisory-only for these — they can only be executed via QC Cloud.
 QC_CLOUD_PATHS = ("QuantConnect/Python", "QuantConnect/projects")
 
+# Research-exploration archive snapshots (path suffix). An `*_archive.ipynb` is
+# a frozen log of exploratory iteration; its error outputs (KeyError/NameError
+# from cells run out of order, a missing data field, ...) are a RECORD of what
+# happened, not a bug to fix — the live counterpart (`research.ipynb`) carries
+# the clean run. The H.1 error-output check is ADVISORY for these so a future
+# nbformat pass / enrichment does not re-trip on the deliberate snapshot. C.1
+# (no intentional-error source) and H.3 (execution_count != null) stay enforced
+# — an archive was still executed and must not embed forbidden patterns. Scope
+# is deliberately tight (path suffix) so only explicit archives opt out. See
+# #6803.
+ARCHIVE_NOTEBOOK_SUFFIX = "_archive.ipynb"
+
 # Kernels that render errors as TEXT, not as output_type=="error" (#5151).
 # Lean via lean4_jupyter/alectryon embeds the compiler's own message severity
 # in the cell output (text/plain + text/html). A `severity: error` message is
@@ -165,6 +177,9 @@ def validate_notebook(nb_path: Path) -> dict:
     # kernel/runtime). Covers .NET, Lean, QC Cloud, qc_reference templates.
     qc_cloud = _is_qc_cloud(rel_path, data)
     ci_reexec_skipped = any(k in kernel for k in SKIP_EXEC_KERNELS) or qc_cloud
+    # Research archive snapshot: error outputs are a deliberate record, not a
+    # bug (#6803). H.1 is advisory; H.3 + C.1 still enforced below.
+    is_archive = rel_path.replace("\\", "/").endswith(ARCHIVE_NOTEBOOK_SUFFIX)
     # "A null execution_count is tolerated" — STRICTER than ci_reexec_skipped.
     # Only where local execution is ALSO impossible (QC Cloud needs QuantBook;
     # Lean kept advisory for now — own rendering subtleties, out of #5214).
@@ -241,6 +256,11 @@ def validate_notebook(nb_path: Path) -> dict:
                 if ci_reexec_skipped:
                     result["errors"].append(
                         f"cell {i}: has error output — {ename} (advisory, QC Cloud)"
+                    )
+                elif is_archive:
+                    result["errors"].append(
+                        f"cell {i}: has error output — {ename} "
+                        f"(advisory, research archive snapshot — See #6803)"
                     )
                 else:
                     result["passed"] = False


### PR DESCRIPTION
## What

`research_archive.ipynb` (partner-course Crypto-MultiCanal) carries **13 error outputs** (KeyError x7, NameError x6) that are a frozen record of exploratory research iteration — not a bug. The live counterpart `research.ipynb` holds the clean run. The H.1 gate (`no error outputs`) was blocking this deliberate snapshot, surfaced when #6797 added cell-ids over it.

Implements **option 1 of #6803** (recommended by ai-01): a tight path-suffix carve-out so the blocking H.1 check becomes **advisory** for `*_archive.ipynb` only.

## Change (`scripts/notebook_tools/validate_pr_notebooks.py`, +20/-0)

- New module constant `ARCHIVE_NOTEBOOK_SUFFIX = "_archive.ipynb"` with a comment documenting the snapshot convention.
- New `is_archive` predicate in `validate_notebook`.
- New `elif is_archive:` advisory branch in the H.1 error-output loop — errors are reported (non-fatal) with `(advisory, research archive snapshot — See #6803)`.
- **Purely additive** — no existing branch changed. C.1 (no `raise NotImplementedError`/`assert False`/`1/0` source) and H.3 (`execution_count != null`) stay fully enforced: an archive was still executed and must not embed forbidden patterns.

## Why option 1 (not 2 re-exec / 3 delete)

- The 13 errors are **pre-existing on main** (anterior to #6797, which added 0 source/output churn).
- Archives are by convention frozen logs; the systemic note of #6803 asks for this exclusion so the gate can later become **required** without re-tripping legitimate snapshots.
- Options 2 (QC Cloud re-exec) and 3 (delete) are **owner decisions** (po-2025:CoursIA-2) left open by this PR.

## Scope

Exactly **1 file** repo-wide matches `*_archive.ipynb` (`git ls-files`). The suffix is tight; a non-archive notebook with the same error output still fails (verified).

## Validation (local, python3)

| Case | Before | After |
|------|--------|-------|
| `research_archive.ipynb` (13 errors) | FAIL (blocking) | **PASS**, 13 advisory msgs, verdict `EXEC_PROVED` |
| `research.ipynb` (live, clean) | PASS | PASS, 0 errors (no regression) |
| temp non-archive + error output | FAIL | **FAIL** (still blocking — no over-relaxation) |
| temp `*_archive.ipynb` + error output | FAIL | PASS (suffix triggers advisory) |

AST parse OK. No notebook re-execution involved (script-only change).

See #6803 (option 1 of 3; does not decide options 2/3). See #6257, #6797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)