### PR TITLE
fix(search,#5081): repair Search/Applications/CSP prerequisite navlinks post-renumber

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11b-Picross-CSharp.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "Le twin Python **appelle** CP-SAT et constate un speedup de plusieurs millions ; ce twin **d\u00e9roule** l'algorithme de propagation qui produit ce speedup, rendant la m\u00e9canique explicite.\n",
     "\n",
-    "**Dur\u00e9e estim\u00e9e : 40 min.** Pr\u00e9requis : [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb) (CSP).\n"
+    "**Dur\u00e9e estim\u00e9e : 40 min.** Pr\u00e9requis : [`Search-9`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb) (CSP).\n"
    ]
   },
   {
@@ -1073,7 +1073,7 @@
     "\n",
     "\u2605 **Le\u00e7on** : la propagation de contraintes (d\u00e9duction locale it\u00e9r\u00e9e) transforme un probl\u00e8me exponentiel en probl\u00e8me polynomial \u2014 c'est exactement ce que CP-SAT industrialise, et dont le \u00ab speedup spectaculaire \u00bb du twin Python n'est que la manifestation mesur\u00e9e.\n",
     "\n",
-    "**Lien avec les Foundations** : CSP \u21c4 [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb), propagation \u21c4 [`Search-9` \u00a7consistance arc](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb), CP-SAT \u21c4 [`App-11-Picross`](App-11-Picross.ipynb) (twin Python, solveur industriel).\n",
+    "**Lien avec les Foundations** : CSP \u21c4 [`Search-9`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), propagation \u21c4 [`Search-9` \u00a7consistance arc](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), CP-SAT \u21c4 [`App-11-Picross`](App-11-Picross.ipynb) (twin Python, solveur industriel).\n",
     "\n",
     "---\n",
     "*Marathon .NET \u21c4 Python #4956 \u2014 Search/Applications, tranche Picross / nonogrammes. See #4956, #3801.*\n"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-1b-NQueens-CSharp.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "Le twin Python **appelle** un solveur ; ce twin **d\u00e9roule** les algorithmes. Les deux se compl\u00e8tent : on voit ici *ce que fait* CP-SAT sous le capot (propagation, \u00e9num\u00e9ration, brisure de sym\u00e9trie).\n",
     "\n",
-    "**Dur\u00e9e estim\u00e9e : 35 min.** Pr\u00e9requis : [`Search-1`](../../Part1-Foundations/Search-1-UninformedSearch.ipynb), [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb) (CSP).\n"
+    "**Dur\u00e9e estim\u00e9e : 35 min.** Pr\u00e9requis : [`Search-1`](../../Part1-Foundations/Search-1-StateSpace-Csharp.ipynb), [`Search-9`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb) (CSP).\n"
    ]
   },
   {
@@ -600,7 +600,7 @@
     "\n",
     "id\u00e9e radicalement diff\u00e9rente : on part d'une affectation **al\u00e9atoire** (une reine par colonne, ligne al\u00e9atoire), puis on **r\u00e9pare**. \u00c0 chaque it\u00e9ration, on choisit une colonne en conflit et on d\u00e9place sa reine vers la ligne qui **minimise** le nombre de conflits. Pas de retour arri\u00e8re : c'est une **marche** dans l'espace des configurations.\n",
     "\n",
-    "C'est l'anc\u00eatre des m\u00e9taheuristiques (proche du hill-climbing stochastique, cf [`Search-11`](../../Part3-Advanced/Search-11-Metaheuristics.ipynb))."
+    "C'est l'anc\u00eatre des m\u00e9taheuristiques (proche du hill-climbing stochastique, cf [`Search-11`](../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb))."
    ]
   },
   {
@@ -1297,7 +1297,7 @@
     "- **Min-Conflicts** = la recherche locale qui passe \u00e0 l'\u00e9chelle (le \u00ab miracle \u00bb N = 1000) ;\n",
     "- **\u00c9num\u00e9ration + brisure de sym\u00e9trie D4** = le comptage exact des solutions fondamentales (12 pour N = 8).\n",
     "\n",
-    "**Lien avec les Foundations** : backtracking \u21c4 [`Search-1`](../../Part1-Foundations/Search-1-UninformedSearch.ipynb) (DFS), CSP \u21c4 [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb), Min-Conflicts \u21c4 [`Search-11`](../../Part3-Advanced/Search-11-Metaheuristics.ipynb) (m\u00e9taheuristiques), CP-SAT \u21c4 [`App-1-NQueens`](App-1-NQueens.ipynb) (twin Python, solveur industriel).\n",
+    "**Lien avec les Foundations** : backtracking \u21c4 [`Search-1`](../../Part1-Foundations/Search-1-StateSpace-Csharp.ipynb) (DFS), CSP \u21c4 [`Search-9`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), Min-Conflicts \u21c4 [`Search-11`](../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb) (m\u00e9taheuristiques), CP-SAT \u21c4 [`App-1-NQueens`](App-1-NQueens.ipynb) (twin Python, solveur industriel).\n",
     "\n",
     "### Pour aller plus loin\n",
     "- Ajouter la **propagation AC-3** (arc-consistency) avant le backtracking.\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-20b-SudokuBenchmark-CSharp.ipynb
@@ -946,7 +946,7 @@
     "### Ponts inter-series\n",
     "\n",
     "- **Dancing Links / couverture exacte** : cf. la formalisation DLX dans la serie Search et l'algorithme X de Knuth (cf. App-11 Picross pour une autre application de DLX) ;\n",
-    "- **AC-3 / propagation de contraintes** : cf. [Partie 2 (CSP)](../../../Part2-CSP/README.md) pour la theorie de la consistance d'arc ;\n",
+    "- **AC-3 / propagation de contraintes** : cf. [Partie 2 (CSP)](../../Part2-CSP/README.md) pour la theorie de la consistance d'arc ;\n",
     "- **App-20 Python** : la version originale avec la stdlib Python donne les memes nombres d'appels.\n",
     "\n",
     "### Prochaines etapes\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2b-GraphColoring-CSharp.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "Le twin Python **appelle** networkx (graphes) et CP-SAT (optimum) ; ce twin **d\u00e9roule** les heuristiques et le branch-and-bound. \u2605 **Am\u00e9lioration p\u00e9dagogique** : utilisation de **graphes canoniques \u00e0 \u03c7 connu** (Petersen=3, K4=4, Mycielski-4 triangle-free \u03c7=4) plut\u00f4t qu'un graphe ad hoc \u2014 on peut **v\u00e9rifier** que chaque heuristique atteint (ou non) l'optimum.\n",
     "\n",
-    "**Dur\u00e9e estim\u00e9e : 40 min.** Pr\u00e9requis : [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb) (CSP).\n"
+    "**Dur\u00e9e estim\u00e9e : 40 min.** Pr\u00e9requis : [`Search-9`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb) (CSP).\n"
    ]
   },
   {
@@ -1281,7 +1281,7 @@
     "\n",
     "\u2605 **Le\u00e7on paradoxe** : les graphes de **Mycielski** (triangle-free, \u03c7 arbitrairement grand) montrent que la complexit\u00e9 chromatique **ne se r\u00e9duit pas** \u00e0 la densit\u00e9 de triangles \u2014 un r\u00e9sultat fondamental que la sortie du notebook rend tangible.\n",
     "\n",
-    "**Lien avec les Foundations** : CSP \u21c4 [`Search-9`](../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb), backtracking \u21c4 [`Search-1`](../../Part1-Foundations/Search-1-UninformedSearch.ipynb), CP-SAT \u21c4 [`App-2-GraphColoring`](App-2-GraphColoring.ipynb) (twin Python, solveur industriel).\n",
+    "**Lien avec les Foundations** : CSP \u21c4 [`Search-9`](../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb), backtracking \u21c4 [`Search-1`](../../Part1-Foundations/Search-1-StateSpace-Csharp.ipynb), CP-SAT \u21c4 [`App-2-GraphColoring`](App-2-GraphColoring.ipynb) (twin Python, solveur industriel).\n",
     "\n",
     "---\n",
     "*Marathon .NET \u21c4 Python #4956 \u2014 Search/Applications, tranche coloration de graphes. See #4956, #3801.*\n"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
@@ -532,7 +532,7 @@
     "2. **Pour chaque cours**, parcourir les creneaux et salles dans l'ordre, et affecter au premier creneau+salle disponible (sans conflit salle ni enseignant)\n",
     "3. **Pas de backtracking** : si echec, le cours reste non place\n",
     "\n",
-    "C'est la version sequentielle de l'algorithme MRV deja vu dans [CSP-1-NQueens-CSharp](../../Part2-CSP/CSP-1-NQueens-CSharp.ipynb) et [CSP-3-Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb)."
+    "C'est la version sequentielle de l'algorithme MRV deja vu dans [CSP-1-NQueens-CSharp](App-1b-NQueens-CSharp.ipynb) et [CSP-3-Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb)."
    ]
   },
   {
@@ -1860,7 +1860,7 @@
     "\n",
     "### References\n",
     "\n",
-    "- [CSP-1-NQueens-CSharp](../../Part2-CSP/CSP-1-NQueens-CSharp.ipynb) — backtracking + MRV\n",
+    "- [CSP-1-NQueens-CSharp](App-1b-NQueens-CSharp.ipynb) — backtracking + MRV\n",
     "- [CSP-3-Advanced](../../Part2-CSP/CSP-3-Advanced.ipynb) — propagation de contraintes\n",
     "- [App-4-JobShopScheduling.ipynb](App-4-JobShopScheduling.ipynb) — jumeau Python avec OR-Tools\n",
     "- [App-4b-JobShopScheduling-CSharp.ipynb](App-4b-JobShopScheduling-CSharp.ipynb) — jumeau C# App-4b (dispatching + B&B)\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb
@@ -2660,7 +2660,7 @@
     "### Ponts inter-series\n",
     "\n",
     "- **Theorie de l'information** : cf. serie Search et la formalisation de l'entropie (Cover & Thomas) ;\n",
-    "- **CSP** : cf. [Partie 2 (CSP)](../../../Part2-CSP/README.md) pour les domaines, la propagation et la consistence ;\n",
+    "- **CSP** : cf. [Partie 2 (CSP)](../../Part2-CSP/README.md) pour les domaines, la propagation et la consistence ;\n",
     "- **App-7 Python** : la version originale avec `numpy`/`matplotlib` donne les memes resultats deterministes.\n",
     "\n",
     "### Prochaines etapes\n",


### PR DESCRIPTION
## Summary

Partial contribution to EPIC **#5081** (Search-series renumber): the renumber moved/renamed several foundation notebooks, breaking 16 inbound prerequisite navlinks across 6 `Search/Applications/CSP` C# twin notebooks. This PR repairs that atomic cluster (the CSP-Applications family).

### The 16 broken links + their canonical targets (each verified by content read)

| Broken target | Why broken | Correct target |
|---|---|---|
| `../../Part2-CSP/Search-9-ConstraintSatisfaction.ipynb` | CSP content moved to `CSP-1-Fundamentals` (Search-9 never existed in Part2-CSP) | `../../Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb` (C# twin prereq) |
| `../../Part1-Foundations/Search-1-UninformedSearch.ipynb` | renamed to `Search-1-StateSpace` | `../../Part1-Foundations/Search-1-StateSpace-Csharp.ipynb` |
| `../../Part3-Advanced/Search-11-Metaheuristics.ipynb` | moved Part3-Advanced -> Part1-Foundations | `../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb` |
| `../../Part2-CSP/CSP-1-NQueens-CSharp.ipynb` | no such file; NQueens MRV+backtracking lives in App-1b | `App-1b-NQueens-CSharp.ipynb` (same dir) |
| `../../../Part2-CSP/README.md` | wrong depth (Applications/CSP is 2 levels, not 3) | `../../Part2-CSP/README.md` |

### Files (6, atomic - 1 family, 1 feature: post-renumber navlink repair)

| Notebook | Links fixed |
|---|---|
| App-11b-Picross-CSharp.ipynb | 3 |
| App-1b-NQueens-CSharp.ipynb | 6 |
| App-20b-SudokuBenchmark-CSharp.ipynb | 1 |
| App-2b-GraphColoring-CSharp.ipynb | 3 |
| App-5-Timetabling-CSharp.ipynb | 2 |
| App-7b-Wordle-CSharp.ipynb | 1 |

### Verification

- **0 broken navlinks** post-fix across the whole CSP dir (162 links re-checked, markdown [text](url) resolution against disk).
- **Byte-identity preserved**: applied via raw byte replacement - navlink paths are ASCII, so they appear literally regardless of the file's \uXXXX-escaping convention. Only the 11 changed JSON source-array lines differ; zero structural JSON fields (execution_count/outputs/id/metadata/cell_type) touched.
- **No re-execution needed** (C.3 markdown-source-only exemption - only prose navlink URLs changed, no code-cell source).
- **Label text preserved** (e.g. [Search-9], [CSP-1-NQueens]): students know the concept names; only the URL target needed correcting.
- **Catalog byte-identical** (R1 - 0 catalog files touched).

### Hygiene

- **R1 catalog-pr-hygiene**: 0 CATALOG-STATUS / COURSE_CATALOG touched
- **G.4 atomic**: 6 files, 1 feature (post-renumber navlink repair), 1 family (Search/Applications/CSP)
- **L487 worktree-isolated**: worktree CoursIA-c476-search-csp-navlinks from origin/main @ 694ae6999 (shared tree has Nash.lean WIP #6719, untouched)
- **Read Body Before Any Action**: read #5081 renumber scope + verified each target exists on disk + pedagogical content-match before editing

### Scope

`See #5081` (partial - fixes the CSP-Applications cluster atomically; remaining broken links in other Search sub-dirs to be addressed in follow-up PRs).

Co-Authored-By: Claude <noreply@anthropic.com>