### PR TITLE
fix(prover,#6790): anti-revert guard for false-negative final-verify (bug 1b)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -341,6 +341,39 @@ def _stmt_mutation_guard(final_sorry: int, original_sorry_count: int,
     )
 
 
+def _final_verify_is_false_negative(final_verify: dict) -> bool:
+    """Bug 1b (#6790 forensic): detect an incoherent final-verify false-negative.
+
+    Founding incident (DEMO 62, conway_lean L2892, 2026-07-16, trace
+    ``ai01_demo62_wt2_1784170024.log``): the mandatory final verify reported
+    ``level_1_build=False`` with ``errors=[]`` (zero compile errors) on a
+    snapshot whose tool ``build_check`` had passed ~20 min earlier on the
+    exact same content. The blind revert at the verify site destroyed a
+    real 5-sub-goal decomposition (structural progress lost, exhumed only by
+    manual span extraction).
+
+    Root cause: ``level_1_build`` is derived from ``verifier.success`` (see
+    ``tools.py::compile``), whose parsing is sensitive to the worktree
+    ``warning: manifest out of date`` prefix / cache state — while
+    ``error_count`` is regex-parsed directly from the raw lake output. When
+    the two disagree with zero errors, NO compile error exists in the output,
+    so the build actually passed; the ``level_1_build=False`` is the
+    false-negative.
+
+    A genuine build failure always produces >=1 parseable compile error
+    (tools.py error regex), so this guard never masks a real breakage. The
+    crash-synthetic verify dict (``errors=[{"message": "final-verify
+    crashed: ..."}]``, no ``error_count``) yields err_count=1 -> not a
+    false-negative -> still reverts, preserving the prior safe behavior.
+    """
+    if final_verify.get("level_1_build", False):
+        return False  # build reported ok — not a false-negative
+    err_count = final_verify.get("error_count")
+    if err_count is None:
+        err_count = len(final_verify.get("errors", []))
+    return err_count == 0
+
+
 class MultiAgentSorryProver:
     """Multi-agent sorry replacement using WorkflowBuilder graph.
 
@@ -797,16 +830,34 @@ class MultiAgentSorryProver:
             final_build_ok = bool(final_verify.get("level_1_build", False))
             if not final_build_ok:
                 _errs = final_verify.get("errors", [])[:5]
-                print(
-                    f"  FINAL VERIFY FAILED ({len(_errs)} compile errors). "
-                    f"Reverting to original to avoid leaving the file broken."
-                )
-                Path(filepath).write_text(original_content, encoding="utf-8")
-                final_sorry = original_sorry_count
-                structural_progress = False
-                # Force-clear best snapshot so callers don't claim spurious progress
-                tactic_tools._best_content = None
-                tactic_tools._best_sorry_count = original_sorry_count
+                if _final_verify_is_false_negative(final_verify):
+                    # Bug 1b (#6790): level_1_build=False but 0 compile errors
+                    # = false-negative verify (worktree manifest warning / cache
+                    # state), on content the tool build_check had passed. Do NOT
+                    # revert — reverting here destroyed a build-passing snapshot
+                    # (DEMO 62: 5-sub-goal decomposition lost). Preserve the
+                    # committed file + structural_progress; log raw verify for
+                    # diagnosis. Treat as build-ok so the success gate below can
+                    # fire on the preserved structural progress.
+                    print(
+                        f"  FINAL VERIFY INCOHERENT: level_1_build=False but 0 "
+                        f"compile errors — false-negative verify (worktree "
+                        f"manifest warning / cache state), build-passing snapshot "
+                        f"PRESERVED, not reverted (#6790). Raw verify preview: "
+                        f"{final_verify_raw[:400]}"
+                    )
+                    final_build_ok = True
+                else:
+                    print(
+                        f"  FINAL VERIFY FAILED ({len(_errs)} compile errors). "
+                        f"Reverting to original to avoid leaving the file broken."
+                    )
+                    Path(filepath).write_text(original_content, encoding="utf-8")
+                    final_sorry = original_sorry_count
+                    structural_progress = False
+                    # Force-clear best snapshot so callers don't claim spurious progress
+                    tactic_tools._best_content = None
+                    tactic_tools._best_sorry_count = original_sorry_count
             else:
                 # Build passed — but a passing build can still hide an IMPLICIT
                 # sorry: when the agent replaces an explicit `sorry` with a search

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2835,3 +2835,82 @@ def test_latch_resolution_depth2_legacy_unchanged(tmp_path):
     project_dir, module_name = resolve_lake_module(str(depth2))
     assert Path(project_dir) == pkg_root
     assert module_name == "Conway.Doomsday"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Bug 1b (#6790 forensic) — final-verify false-negative anti-revert guard
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_final_verify_false_negative_incoherent_zero_errors():
+    """THE BUG CASE (DEMO 62): level_1_build=False but 0 compile errors on
+    build-passing content -> false-negative verify -> must NOT revert.
+
+    Before the guard, provers.py blindly reverted here, destroying a real
+    5-sub-goal decomposition whose tool build_check had passed 20 min earlier.
+    """
+    from prover.provers import _final_verify_is_false_negative
+
+    # Exact shape observed in DEMO 62: build-fail verdict from verifier.success
+    # (sensitive to the worktree "manifest out of date" warning prefix), but
+    # zero parseable compile errors in raw_output.
+    incoherent = {
+        "success": False,
+        "level_1_build": False,
+        "error_count": 0,
+        "errors": [],
+        "sorry_count": 8,
+        "raw_output": "warning: manifest out of date: git revision of dependency 'mathlib'...",
+    }
+    assert _final_verify_is_false_negative(incoherent) is True
+
+
+def test_final_verify_false_negative_via_empty_errors_no_count_field():
+    """Same incoherence expressed without an explicit error_count field — the
+    helper falls back to len(errors) and still detects the false-negative."""
+    from prover.provers import _final_verify_is_false_negative
+
+    incoherent = {"level_1_build": False, "errors": []}
+    assert _final_verify_is_false_negative(incoherent) is True
+
+
+def test_final_verify_real_failure_is_not_false_negative():
+    """A genuine build failure (>=1 parseable compile error) must still revert —
+    the guard never masks a real breakage."""
+    from prover.provers import _final_verify_is_false_negative
+
+    real_failure = {
+        "success": False,
+        "level_1_build": False,
+        "error_count": 3,
+        "errors": [
+            {"line": 29, "message": "unsolved goals"},
+            {"line": 41, "message": "type mismatch"},
+            {"line": 58, "message": "unknown identifier 'foo'"},
+        ],
+    }
+    assert _final_verify_is_false_negative(real_failure) is False
+
+
+def test_final_verify_build_ok_is_not_false_negative():
+    """A verify that reports level_1_build=True is not a false-negative (it
+    is a clean pass — the guard short-circuits and the caller skips revert)."""
+    from prover.provers import _final_verify_is_false_negative
+
+    ok = {"success": True, "level_1_build": True, "error_count": 0, "errors": []}
+    assert _final_verify_is_false_negative(ok) is False
+
+
+def test_final_verify_crash_synthetic_still_reverts():
+    """The verify-crash synthetic dict (errors=[{"message": "final-verify
+    crashed: ..."}], no error_count) must NOT be classified as a false-
+    negative — a crashed verify has unknown state and the prior safe behavior
+    (revert to original) is preserved. err_count falls back to len(errors)=1."""
+    from prover.provers import _final_verify_is_false_negative
+
+    crashed = {
+        "overall": False,
+        "level_1_build": False,
+        "errors": [{"message": "final-verify crashed: KeyError('foo')"}],
+    }
+    assert _final_verify_is_false_negative(crashed) is False


### PR DESCRIPTION
## Summary

Partial contribution to EPIC **#1453** (prover harness), dispatched by ai-01 ([DISPATCH] DM 2026-07-16T05:21Z): implement the forensic **#6790** fixes on the prover harness. This PR = **bug 1b (priority-1)**: the final-verify that fabricates false SUCCESS by reverting build-passing snapshots. Per ai-01's instruction "1 PR par fix", the other 3 fixes (build_check `file_replace_lines`, freeze-loop TacticAgent, metrics=0) are follow-up PRs.

Collides with NOTHING: this touches the harness `.py` (provers.py), while the running BG iter ai-01 on DEMO 62 works the `.lean` (as ai-01 noted in the dispatch).

### The defect (bug 1b, #6790 forensic Pathologie 1)

The mandatory final-verify in `MultiAgentSorryProver.run` (provers.py finally block) **reverted a build-passing snapshot** when it reported `level_1_build=False` with `errors=[]` (zero compile errors). This incoherent state is a **false-negative verify**, not a build failure:

- `level_1_build` is derived from `verifier.success` (`tools.py::compile`), whose parsing is sensitive to the worktree `warning: manifest out of date` prefix / cache state.
- `error_count` is regex-parsed **directly from raw lake output** (tools.py, `r".*?(\d+):\d+: error: (.*)"`).
- When the two disagree with **0 errors**, no compile error exists in the output → the build actually passed; `level_1_build=False` is the false-negative.

**Founding incident** (DEMO 62, conway_lean L2892): the tool `build_check` had promoted a 5-sub-goal decomposition (~20 min earlier: `build_check=passed, new_sorry_count=8, snapshot_updated=true`). The final verify then reported `level_1_build=False` + `errors=[]` on the **same content** → the blind revert destroyed the structural progress (the decomposition was exhumed only by manual span extraction into PR #6804). The verify's own message was self-contradictory: "FINAL VERIFY FAILED (0 compile errors)".

### The fix (anti-revert guard)

Extract `_final_verify_is_false_negative(final_verify)` pure helper + guard the revert site:

```python
if not final_build_ok:
    _errs = final_verify.get("errors", [])[:5]
    if _final_verify_is_false_negative(final_verify):
        # level_1_build=False but 0 compile errors = false-negative verify
        # (worktree manifest warning / cache state). PRESERVE the snapshot,
        # do NOT revert (#6790). Log raw verify for diagnosis.
        print(f"  FINAL VERIFY INCOHERENT: ... Raw verify preview: {final_verify_raw[:400]}")
        final_build_ok = True
    else:
        # real failure (>=1 compile error) -> revert as before
        ...revert path...
```

The helper classifies false-negative as: `level_1_build=False AND error_count==0`. A genuine build failure **always** produces ≥1 parseable compile error (tools.py error regex), so the guard **never masks a real breakage**. The verify-crash synthetic dict (`errors=[{"message": "final-verify crashed: ..."}]`, no `error_count` → `err_count=1`) is **not** classified as false-negative → prior safe revert behavior preserved.

### Repro avant / après (5 new unit tests, decision matrix)

```
$ python -m pytest tests/test_prover_guards.py -k "final_verify" -v
test_final_verify_false_negative_incoherent_zero_errors          PASSED  # THE BUG CASE
test_final_verify_false_negative_via_empty_errors_no_count_field PASSED
test_final_verify_real_failure_is_not_false_negative             PASSED
test_final_verify_build_ok_is_not_false_negative                 PASSED
test_final_verify_crash_synthetic_still_reverts                  PASSED
5 passed in 1.29s
```

| Test case | `level_1_build` | errors | → false_negative? | → action |
|---|---|---|---|---|
| **THE BUG CASE** (DEMO 62) | False | `[]` (0) | **True** | **PRESERVE** (was: revert = data loss) |
| incoherent, no error_count field | False | `[]` | True | PRESERVE |
| real failure | False | 3 errors | False | revert (unchanged) |
| build ok | True | `[]` | False | clean pass (unchanged) |
| verify crash | False | 1 synthetic | False | revert (unchanged — prior safe behavior) |

### Regression check

- **Full suite**: 151 passed, 2 failed.
- **The 2 failures are PRE-EXISTING** (verified via `git stash` on clean base — they fail identically without my change): `test_coordinator_agent_has_set_attack_plan_tool` (missing `OPENAI_API_KEY` env) + `test_path_constants_resolve_to_active_workspace` (stale `Voting.lean` test post-#4365 absorption — the test itself needs updating, unrelated to this PR).
- **Python syntax**: both files `ast.parse` OK.
- **Catalog byte-identical** (R1 — 0 catalog files touched).

### Hygiene

- **R1 catalog-pr-hygiene** ✅ : 0 CATALOG-STATUS / COURSE_CATALOG touched
- **G.4 atomic** ✅ : 2 files, 1 fix (bug 1b anti-revert guard), 1 domain (Lean prover harness)
- **L487 worktree-isolated** ✅ : worktree `CoursIA-c476-prover-bug1b` from `origin/main` @ 694ae6999 (shared tree has Nash.lean WIP #6719, untouched)
- **C524-L1 ✅** : this is harness `.py` surgery (not a BG proof iter) → tractable in worker window; the C524-L1 cron-30min interdict on BG iters does not apply.
- **Read Body Before Any Action** ✅ : read full forensic #6790 body (3 pathologies, acceptance, founding incident) + root-caused `level_1 = success` (tools.py:1865) + error regex (tools.py:1851) before designing the guard.

### Follow-ups (other #6790 fixes, separate PRs)

Per ai-01 dispatch ("1 PR par fix"): build_check `file_replace_lines` false-positive (force independent lake build as sole gate), freeze-loop TacticAgent (bound no-op turns), metrics=0 (count structural build-verified edits in iterations/attempts). Root-causing the `verifier.success` manifest-warning parser (the deeper fix, forensic acceptance checkbox 1) is also a follow-up — the guard here is robust independently of it.

### Scope

`See #6790`, `See #1453` (partial — bug 1b only).

Co-Authored-By: Claude <noreply@anthropic.com>