### PR TITLE
fix(prover,#6790): force independent lake build in build_check gate (bug 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1085,7 +1085,19 @@ class TacticTools:
             verifier = get_verifier(project_dir)
             subdir = Path(self._filepath).parent.name
             relative_path = f"{subdir}/{Path(self._filepath).name}"
-            result = verifier.verify_project_file(relative_path)
+            # Bug 2 (#6790 forensic): force an INDEPENDENT fresh lake build as the
+            # sole snapshot-promotion gate. verify_project_file() caches results by
+            # content hash; without force=True, re-writing content X (e.g. after a
+            # prior compile() cached hash(X) => success) returns the STALE cached
+            # result with NO fresh build. That cached "success" is a CLAIM, not a
+            # proof — and in a worktree/copy-cache scenario where the dependency
+            # manifest drifts ("manifest out of date"), the cached verdict can be
+            # wrong, promoting _last_build_ok_content on an un-verified basis
+            # (DEMO 62: file_replace_lines build_check="passed" was a cache hit,
+            # not a fresh build). compile() already passes force=True (tools.py
+            # 1763/1843); the structural-edit gate must be equally authoritative
+            # — the snapshot it promotes is what the finally-block commits.
+            result = verifier.verify_project_file(relative_path, force=True)
         except Exception as e:
             # Verifier itself blew up — revert defensively and surface the error.
             Path(self._filepath).write_text(original_content, encoding="utf-8")

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1589,6 +1589,58 @@ def test_build_check_or_revert_real_solve_records_zero(tmp_path, monkeypatch):
     assert tt._min_compile_sorry_count == 0
 
 
+def test_build_check_or_revert_forces_independent_build(tmp_path, monkeypatch):
+    """Bug 2 (#6790 forensic): the snapshot-promotion gate must force a FRESH
+    lake build, not trust a cached content-hash verdict.
+
+    DEMO 62: file_replace_lines reported build_check="passed" on a cache hit
+    (hash(X) was cached by an earlier compile()), so _last_build_ok_content
+    was promoted with NO fresh build — the "passed" was a CLAIM, not a proof.
+    In a worktree/copy-cache scenario with dependency-manifest drift, that
+    stale cache can be wrong. compile() already passes force=True; the
+    structural-edit gate (_build_check_or_revert, shared by file_replace_lines
+    / file_insert_lines / file_replace_sorry) must be equally authoritative.
+
+    This test asserts the fix by recording the force kwarg the gate actually
+    passes to verify_project_file: before the fix it was False (cache trusted),
+    after the fix it must be True (independent fresh build).
+    """
+    import prover.verifier as vmod
+
+    proved = (
+        "import Mathlib.Tactic\n"
+        "theorem t : True := by\n"
+        "  trivial\n"
+    )
+    fake = tmp_path / "ForceGate.lean"
+    fake.write_text(proved, encoding="utf-8")
+
+    force_seen = []
+
+    class _RecordingFakeVerifier:
+        def verify_project_file(self, rel, force=False):
+            force_seen.append(force)
+            return {"success": True, "errors": "", "raw_output": "ok"}
+
+    monkeypatch.setattr(
+        vmod, "get_verifier", lambda *a, **k: _RecordingFakeVerifier())
+
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=3, indentation=2,
+        indent_str="  ", full_file=proved,
+    )
+    tt = TacticTools(state, str(fake), sctx)
+
+    original = proved.replace("  trivial\n", "  sorry\n")
+    assert tt._build_check_or_revert(original, "test") is None
+    assert force_seen == [True], (
+        f"_build_check_or_revert must call verify_project_file(force=True) so "
+        f"the snapshot-promotion gate is an INDEPENDENT fresh lake build, not "
+        f"a cached content-hash claim (got force={force_seen})"
+    )
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # FX-6 (#1453) — statement-mutation false success. Founding incident
 # (Reidemeister.lean L545, 2026-07-02, trace


### PR DESCRIPTION
## Summary

2nd fix in the sequenced **#6790** dispatch (msg-sl8sj8, after bug 1b = PR #6811). The dispatch ordered: \"bug 1b EN PREMIER, ensuite dans l'ordre : build_check `file_replace_lines` false-positive (un `passed` d'outil = claim, pas preuve — le fix doit forcer un lake build indépendant comme seul gate), freeze-loop, metrics=0\". This PR = **bug 2**.

Per ai-01's \"1 PR par fix\" instruction, freeze-loop + metrics=0 are separate follow-up PRs.

### The defect (bug 2, #6790 dispatch)

The `build_check` gate that promotes `_last_build_ok_content` — i.e. the snapshot the finally-block commits — called `verify_project_file()` **without `force=True`** (tools.py:1088). `LeanVerifier` caches build results by **content hash** (lean_server.py:173), so re-writing content X after a prior `compile()` cached `hash(X) → success` returns the **stale cached verdict with NO fresh lake build**. The tool's `build_check="passed"` was a **CLAIM, not a proof**.

In a worktree/copy-cache scenario where the dependency manifest drifts (`warning: manifest out of date`), the cached verdict can be wrong — promoting `_last_build_ok_content` on an un-verified basis. DEMO 62 locus: `file_replace_lines` reported `build_check=passed` on a cache hit, not a fresh build.

### The fix (force independent fresh build)

```python
# tools.py _build_check_or_revert, line 1088:
result = verifier.verify_project_file(relative_path, force=True)   # was: (relative_path)
```

`force=True` makes `verify_project_file` skip the content-hash cache and run `_run_lake_build` fresh (lean_server.py:181-189) — an **independent lake build as the sole gate**, exactly what `compile()` already does (tools.py:1763 and 1843).

`_build_check_or_revert` is the shared gate for all 3 structural-edit tools (`file_replace_lines`, `file_insert_lines`, `file_replace_sorry` → tools.py:1424/1538/1719), so all three snapshot-promotion paths are now backed by a fresh build.

**Out of scope** (intentionally not force=True): the two other force-less callers `read_build_result` (2634) and `read_build_errors` (2714) are read-only diagnostics that surface build state to the agent — they do NOT promote snapshots, so the cache is acceptable there (informational reads).

### Repro avant / après (1 new unit test)

```
$ python -m pytest tests/test_prover_guards.py -k build_check_or_revert -v
test_build_check_or_revert_counts_implicit_sorry         PASSED
test_build_check_or_revert_real_solve_records_zero       PASSED
test_build_check_or_revert_forces_independent_build      PASSED  # NEW — asserts force=True
3 passed
```

The new test uses a **recording fake verifier** that captures the `force` kwarg `_build_check_or_revert` passes to `verify_project_file`, and asserts `force == True`. Before the fix it was `False` (cache trusted); after, `True` (independent fresh build).

### Regression check

- **Full suite**: 147 passed, 2 failed.
- **The 2 failures are PRE-EXISTING** (verified identical on clean base last cycle during bug 1b via `git stash`): `test_coordinator_agent_has_set_attack_plan_tool` (missing `OPENAI_API_KEY` env) + `test_path_constants_resolve_to_active_workspace` (stale `Voting.lean` test post-#4365 absorption). NOT caused by this change.
- **Python syntax**: both files `ast.parse` OK.
- **Catalog byte-identical** (R1 — 0 catalog files touched).

### Composes with bug 1b (independent code paths)

| Fix | File | Code path | PR |
|---|---|---|---|
| bug 1b | provers.py | finally-block revert site (false-negative verify) | #6811 |
| bug 2 | tools.py | `_build_check_or_revert` snapshot-promotion gate (cached claim) | this PR |

Different files, different mechanisms — merge cleanly together. bug 1b guards the *final* verify; bug 2 hardens the *per-edit* build_check. Together they close the two paths by which a stale/cached verdict could persist an un-verified snapshot.

### Hygiene

- **R1 catalog-pr-hygiene** ✅ : 0 CATALOG-STATUS / COURSE_CATALOG touched
- **G.4 atomic** ✅ : 2 files, 1 fix (force=True gate + test), 1 domain (Lean prover harness)
- **L487 worktree-isolated** ✅ : worktree `CoursIA-c477-prover-bug2-buildcheck` from `origin/main` @ 5fbb59740 (shared tree has Nash.lean WIP #6719, untouched)
- **C524-L1 ✅** : harness `.py` surgery (not a BG proof iter) → tractable in worker window; C524-L1 cron-30min interdict on BG iters does not apply.
- **Read Body Before Any Action** ✅ : re-read #6790 dispatch sequence + root-caused the content-hash cache (lean_server.py:132-189) + audited all 5 `verify_project_file` callers (3 force-less; 2 are read-only diagnostics → out of scope) before designing the fix.

### Follow-ups (remaining #6790 fixes, separate PRs)

Per ai-01 dispatch \"1 PR par fix\": freeze-loop TacticAgent (bound no-op turns), metrics=0 (count structural build-verified edits in iterations/attempts). I'll continue with the next in-sequence item if the window allows, else next cycle.

### Scope

`See #6790`, `See #1453` (partial — bug 2 only).

Co-Authored-By: Claude <noreply@anthropic.com>