### PR TITLE
fix(gametheory,#2876): restore FR accents in GT-3 C# code comments

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
@@ -418,7 +418,7 @@
     }
    ],
    "source": [
-    "// Cellule 3 — Swaps de rangs (transformations elementaires)\n",
+    "// Cellule 3 — Swaps de rangs (transformations élémentaires)\n",
     "static int[] SwapRanks(int[] payoffs, int rank1, int rank2)\n",
     "{\n",
     "    var r = (int[])payoffs.Clone();\n",
@@ -438,7 +438,7 @@
     "\n",
     "// Demonstration : un swap sur le Dilemme du Prisonnier\n",
     "var pd = ClassicGames[\"Prisoner's Dilemma\"];\n",
-    "var pdR34 = ApplyRowSwap(pd, 3, 4);   // echange Reward<->Temptation cote Ligne\n",
+    "var pdR34 = ApplyRowSwap(pd, 3, 4);   // échange Reward<->Temptation côté Ligne\n",
     "$\"PD original          : {pd}\".Display();\n",
     "$\"PD apres swap Row 3-4: {pdR34}  (Row devient {string.Join(\",\", pdR34.Row)})\".Display();\n",
     "\"Les 3 swaps adjacents possibles : (1,2), (2,3), (3,4) — par joueur.\".Display();\n"
@@ -748,7 +748,7 @@
     }
    ],
    "source": [
-    "// Cellule 6 — Equilibres de Nash purs (best response)\n",
+    "// Cellule 6 — Équilibres de Nash purs (best response)\n",
     "static List<(int i, int j)> FindPureNash(OrdinalGame g)\n",
     "{\n",
     "    var A = g.RowMatrix();   // A[i,j] = gain Ligne\n",
@@ -757,8 +757,8 @@
     "    for (int i = 0; i < 2; i++)\n",
     "    for (int j = 0; j < 2; j++)\n",
     "    {\n",
-    "        bool rowBR = A[i, j] >= A[1 - i, j];   // Ligne best-response a Colonne=j\n",
-    "        bool colBR = B[i, j] >= B[i, 1 - j];   // Colonne best-response a Ligne=i\n",
+    "        bool rowBR = A[i, j] >= A[1 - i, j];   // Ligne best-response à Colonne=j\n",
+    "        bool colBR = B[i, j] >= B[i, 1 - j];   // Colonne best-response à Ligne=i\n",
     "        if (rowBR && colBR) eq.Add((i, j));\n",
     "    }\n",
     "    return eq;\n",
@@ -889,9 +889,9 @@
     "}\n",
     "sb7.ToString().Display();\n",
     "\n",
-    "// Bar chart Plotly : nombre de jeux par nombre d'equilibres de Nash purs.\n",
-    "// Le recensement exhaustif des 576 jeux 2x2 revele la distribution des nombres\n",
-    "// d'equilibres (0, 1, 2, ...) -- la majorite des jeux a 0 ou 1 equilibre pur.\n",
+    "// Bar chart Plotly : nombre de jeux par nombre d'équilibres de Nash purs.\n",
+    "// Le recensement exhaustif des 576 jeux 2x2 révèle la distribution des nombres\n",
+    "// d'équilibres (0, 1, 2, ...) -- la majorité des jeux à 0 ou 1 équilibre pur.\n",
     "{\n",
     "    var ordered = histogram.OrderBy(x => x.Key).ToList();\n",
     "    var keys = ordered.Select(kv => kv.Key.ToString()).Select(v => (object)v).ToArray();\n",
@@ -978,7 +978,7 @@
     }
    ],
    "source": [
-    "// Cellule 8 — Connexite du graphe des swaps (BFS flood-fill depuis 1 noeud)\n",
+    "// Cellule 8 — Connexité du graphe des swaps (BFS flood-fill depuis 1 nœud)\n",
     "static int ReachableCount(OrdinalGame start)\n",
     "{\n",
     "    var swaps = new[] { (1,2), (2,3), (3,4) };\n",
@@ -1175,11 +1175,11 @@
     }
    ],
    "source": [
-    "// Cellule 10 — Exercice 1 (a completer) : voisinage de swap\n",
-    "// TODO etudiant : implementer ExploreSwapNeighbors(game) -> liste de voisins classes\n",
-    "// Etape 1 : iterer sur swaps [(1,2), (2,3), (3,4)].\n",
-    "// Etape 2 : pour chaque swap, calculer le voisin Row et le voisin Col.\n",
-    "// Etape 3 : pour chaque voisin, compter les Nash purs via FindPureNash.\n",
+    "// Cellule 10 — Exercice 1 (à compléter) : voisinage de swap\n",
+    "// TODO étudiant : implémenter ExploreSwapNeighbors(game) -> liste de voisins classés\n",
+    "// Étape 1 : itérer sur swaps [(1,2), (2,3), (3,4)].\n",
+    "// Étape 2 : pour chaque swap, calculer le voisin Row et le voisin Col.\n",
+    "// Étape 3 : pour chaque voisin, compter les Nash purs via FindPureNash.\n",
     "public List<(OrdinalGame neighbor, string swap, int nashCount)> ExploreSwapNeighbors(OrdinalGame g)\n",
     "{\n",
     "    // TODO etudiant\n",
@@ -1242,10 +1242,10 @@
     }
    ],
    "source": [
-    "// Cellule 11 — Exercice 2 (a completer) : jeux sans Nash pur\n",
-    "// TODO etudiant : denombrer les jeux sans Nash pur et identifier les proches de Matching Pennies\n",
-    "// Etape 1 : filtrer allGames pour FindPureNash == 0.\n",
-    "// Etape 2 : calculer SwapDistance vs Matching Pennies pour chaque jeu sans Nash.\n",
+    "// Cellule 11 — Exercice 2 (à compléter) : jeux sans Nash pur\n",
+    "// TODO étudiant : dénombrer les jeux sans Nash pur et identifier les proches de Matching Pennies\n",
+    "// Étape 1 : filtrer allGames pour FindPureNash == 0.\n",
+    "// Étape 2 : calculer SwapDistance vs Matching Pennies pour chaque jeu sans Nash.\n",
     "public int CountNoNashGames()\n",
     "{\n",
     "    // TODO etudiant\n",
@@ -1308,10 +1308,10 @@
     }
    ],
    "source": [
-    "// Cellule 12 — Exercice 3 (a completer) : equivalence par renommage\n",
-    "// TODO etudiant : compter les classes d'equivalence sous echange Ligne<->Colonne\n",
-    "// Etape 1 : definir la transposee (swap des roles : Row<->Col + reindexation des cellules).\n",
-    "// Etape 2 : regrouper les 576 jeux en classes (un representant canonique par classe).\n",
+    "// Cellule 12 — Exercice 3 (à compléter) : équivalence par renommage\n",
+    "// TODO étudiant : compter les classes d'équivalence sous échange Ligne<->Colonne\n",
+    "// Étape 1 : définir la transposée (swap des rôles : Row<->Col + réindexation des cellules).\n",
+    "// Étape 2 : regrouper les 576 jeux en classes (un représentant canonique par classe).\n",
     "public int CountPlayerSwapClasses()\n",
     "{\n",
     "    // TODO etudiant\n",


### PR DESCRIPTION
## Summary

`GameTheory-3-Topology2x2-Csharp.ipynb` carried **systematic accent stripping in its code COMMENT lines** (Étape, étudiant, implémenter, définir, transposée, rôles, Connexité, Équilibres, etc.). Restored **22 comment lines** across cells 3, 6, 7, 8, 22, 24, 26 (including the 3 exercise-cell instruction stubs — stub logic untouched).

Found deterministically via `detect_accent_stripping.py` (**#6806**, po-2024 c.590 LGTM). My partition (GameTheory .NET), different family from recent Sudoku accent work (R6 variety).

## Scope — code COMMENT lines only (C.2-safe)

| Touched | Skipped (residual) |
|---------|--------------------|
| 22 `//` comment lines (cells 3,6,7,8,22,24,26) | `.Display()`/`display()` strings (would change outputs) |
| — | executable code / stub logic |

**C.2-safe**: comments do not affect execution → outputs + execution_count preserved → **no re-exec needed** (#6796/#6722 precedent for comment-only changes).

## Verification (firsthand)

| Check | Result |
|-------|--------|
| outputs/execution_count signature vs main | **IDENTICAL** (programmatic) |
| nbformat | VALID |
| C.1 (raise/NotImpl/assert/1-0) | **0** |
| CRLF | **0** (LF preserved) |
| H.3 validate_pr_notebooks.py | **PASS** (12 code cells, .net-csharp) |
| git diff | +22/-22 symmetric |

## Broader coordination finding

`detect_accent_stripping.py` (#6806) reports **3311 systematic accent strippings across 70 GameTheory notebooks**. This PR is ONE notebook of a **family-scale sweep** that should be done tool-driven + .NET re-exec (for the display-string residuals). The markdown cells in GT-3 already have accents; the stripping is concentrated in code comments + display strings.

Display strings in GT-3 (e.g. `"OrdinalGame defini. Validation : ... enforcee."`) remain stripped — fixing them needs .NET re-exec to update outputs honestly (Stop & Repair). Documented as residual for a follow-up re-exec scope.

See #2876 (partial — 1 notebook, comment-scope). See #6806 (audit tool).

Co-Authored-By: Claude-Code <noreply@anthropic.com>