### PR TITLE
fix(search,#5081): repair 3 content-rename navlinks (A*/SimulatedAnnealing)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13b-TSP-Metaheuristics-CSharp.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "\u2605 Le twin Python **appelle** OR-Tools ; les autres twins C# appellent **GeneticSharp**. Ce twin **d\u00e9roule les heuristiques \u00e0 la main** (2-opt = inversion de segment, recuit simul\u00e9 = move 2-opt + crit\u00e8re de Metropolis) \u2014 la m\u00e9canique que les librairies cachent.\n",
     "\n",
-    "**Dur\u00e9e estim\u00e9e : 45 min.** Pr\u00e9requis : [`Search-4`](../../Part1-Foundations/Search-4-LocalSearch.ipynb) (recherche locale), [`Search-11`](../../Part3-Advanced/Search-11-SimulatedAnnealing.ipynb) (recuit simul\u00e9).\n"
+    "**Dur\u00e9e estim\u00e9e : 45 min.** Pr\u00e9requis : [`Search-4`](../../Part1-Foundations/Search-4-LocalSearch.ipynb) (recherche locale), [`Search-11`](../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb) (recuit simul\u00e9).\n"
    ]
   },
   {
@@ -980,7 +980,7 @@
     "\n",
     "\u2605 **Le\u00e7on** : le TSP cristallise le basculement exact \u2194 approch\u00e9. Les solveurs industriels (OR-Tools, twin Python ; GeneticSharp, autres twins C#) combinent ces briques \u00e0 grande \u00e9chelle ; ce twin les **expose individuellement** pour qu'on saisisse la m\u00e9canique de chaque heuristique.\n",
     "\n",
-    "**Lien avec les Foundations** : recherche locale \u21c4 [`Search-4`](../../Part1-Foundations/Search-4-LocalSearch.ipynb), recuit simul\u00e9 \u21c4 [`Search-11`](../../Part3-Advanced/Search-11-SimulatedAnnealing.ipynb), solveur industriel \u21c4 [`App-13-TSP-Metaheuristics`](App-13-TSP-Metaheuristics.ipynb) (twin Python).\n",
+    "**Lien avec les Foundations** : recherche locale \u21c4 [`Search-4`](../../Part1-Foundations/Search-4-LocalSearch.ipynb), recuit simul\u00e9 \u21c4 [`Search-11`](../../Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb), solveur industriel \u21c4 [`App-13-TSP-Metaheuristics`](App-13-TSP-Metaheuristics.ipynb) (twin Python).\n",
     "\n",
     "---\n",
     "*Marathon .NET \u21c4 Python #4956 \u2014 Search/Applications/Hybrid, tranche TSP / voyageur de commerce. See #4956, #3801.*\n"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
@@ -1375,7 +1375,7 @@
     "\n",
     "### Prochaines etapes\n",
     "\n",
-    "- [Search-12-AStar](Search-12-AStar-And-Heuristics.ipynb) : recherche informe avec heuristiques (cas ou l'optimalite est garantie, contrairement aux metaheuristiques).\n",
+    "- [Search-3-Informed (A*)](Search-3-Informed-Csharp.ipynb) : recherche informe avec heuristiques (cas ou l'optimalite est garantie, contrairement aux metaheuristiques).\n",
     "- [Search-5-LocalSearch](Search-4-LocalSearch.ipynb) : fondements du recuit simule et hill-climbing.\n",
     "- Applications metaheuristiques : [App-13-TSP](../Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb), [App-9-EdgeDetection](../Applications/Hybrid/App-9-EdgeDetection.ipynb).\n",
     "\n",


### PR DESCRIPTION
## Summary

EPIC **#5081** (Search-series renumber) moved/renamed foundation notebooks, breaking inbound navlinks. This PR repairs **3 links in 2 notebooks OUTSIDE the App-CSP cluster** that PR **#6809** covers (App-13b is in `Applications/Hybrid`, Search-11-Metaheuristics is in `Part1-Foundations` — disjoint from #6809's 6 `Applications/CSP` twins). No collision.

## Successors verified FIRSTHAND (not guesswork)

| Old target | Why broken | Verified successor |
|------------|-----------|--------------------|
| `Search-11-SimulatedAnnealing.ipynb` (Part3-Advanced) | never existed; recuit simulé lives in Search-11-Metaheuristics (Part1) | `Search-11-Metaheuristics-Csharp.ipynb` (confirmed: covers annealing/recuit/métaheuristique) |
| `Search-12-AStar-And-Heuristics.ipynb` | slot-12 is now PatternDatabases; A* moved to Search-3-Informed | `Search-3-Informed-Csharp.ipynb` (confirmed: covers A*/heuristique) |

## Fixes (3 links)

| Notebook | Cell | Change |
|----------|------|--------|
| `App-13b-TSP-Metaheuristics-CSharp.ipynb` | cell0 | target swap (label `` `Search-11` `` unchanged — slot number preserved, "recuit simulé" context still accurate) |
| `App-13b-TSP-Metaheuristics-CSharp.ipynb` | cell21 | target swap (same) |
| `Search-11-Metaheuristics-Csharp.ipynb` | cell27 | `[Search-12-AStar](...)` → `[Search-3-Informed (A*)](Search-3-Informed-Csharp.ipynb)` (cross-ref "recherche informée avec heuristiques") |

## DEFERRED (out of scope — flagged)

`Search-11-Metaheuristics-Csharp.ipynb` **cell0** navigation "next >>" link `[Search-12 A*]` — the post-#5081 reading order is unknown (slot-12 is now PatternDatabases). Mapping the "next in series" navlink correctly needs the EPIC #5081 reading-order; left untouched to avoid guesswork.

## Validation

- **Surgical (C.3)**: 3 ins / 3 del across 2 files. App-13b via raw-text replace (byte-identical except 2 swapped targets — original `\uXXXX` escaping preserved); Search-11 via raw `json.dumps(OrderedDict, indent=1)` matching original format.
- **C.2**: markdown-only edit → prior outputs valid (no re-exec, exception per notebook-conventions).
- **JSON valid** both files post-edit.
- **Found by**: `check_notebook_navlinks.py` (PR #6813, baseline 30 genuine broken). With #6809 (16 App-CSP) + #6819 (6 GameTheory) + this (3 Search), the genuine broken drops from 30 → ~11. Baseline regen is a #6813 follow-up post-merge.

See #5081 (renumber), #6809 (App-CSP cluster, no collision), #6813 (checker tool), #6819 (GameTheory fix).