### PR TITLE
fix(smt,#5081): repair 2 Z3-Linq2Z3 Intro navlinks (../../ -> ../ typo)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb
@@ -1149,7 +1149,7 @@
    "source": [
     "## B9 - Environnements `record` positionnels (DSL `NewTheorem<PositionalRecord>`)\n",
     "\n",
-    "L'environnement d'un théorème (le type `T` passe a `NewTheorem<T>`) peut etre un **record positionnel** C# -- par exemple `record Point(int X, int Y)` -- et non une `class` mutable. La reconstruction de la solution passe alors par une branche dediee du solveur ([`Theorem.cs:993-1099`](../../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993)) qui selectionne le *primary constructor* du record, evalue chaque parametre depuis le modele Z3, puis invoque `Activator.CreateInstance(t, args)` avec les valeurs positionnelles -- l'ancienne branche `Activator.CreateInstance(t)` throw sur un record sans constructeur sans parametre (un positional record n'expose que des `init`-only setters).\n",
+    "L'environnement d'un théorème (le type `T` passe a `NewTheorem<T>`) peut etre un **record positionnel** C# -- par exemple `record Point(int X, int Y)` -- et non une `class` mutable. La reconstruction de la solution passe alors par une branche dediee du solveur ([`Theorem.cs:993-1099`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993)) qui selectionne le *primary constructor* du record, evalue chaque parametre depuis le modele Z3, puis invoque `Activator.CreateInstance(t, args)` avec les valeurs positionnelles -- l'ancienne branche `Activator.CreateInstance(t)` throw sur un record sans constructeur sans parametre (un positional record n'expose que des `init`-only setters).\n",
     "\n",
     "Le mini-probleme : sur un point `(X, Y)` dans le plan, trouver le point satisfaisant `X + Y = 12` **et** `X = 2·Y` (solution unique attendue : `X = 8, Y = 4`).\n",
     "\n",
@@ -1295,7 +1295,7 @@
     "| Surface code | ~10 lignes significatives + risque d'erreur de typage des `IntNum` | 3 lignes de contraintes |\n",
     "| Constructeur sans parametre | non requis (le raw n'instancie jamais d'objet C#) | **necessaire dans le cas d'une `class` mutable**, **interdit dans le cas d'un record** (l'ancienne branche `Activator.CreateInstance(t)` throw) |\n",
     "\n",
-    "> **Ligne de contraste** : la valeur ajoutee du DSL ici n'est pas une fecondation d'expression (comme `Sum` qui replie N termes en un seul `MkAdd`), mais le **routage de reconstruction** -- la detection du type d'environnement (`class` mutable avec setter vs `record` positionnel vs type anonyme) et l'invocation de la bonne branche de [`Theorem.cs:993-1099`](../../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993). Cote raw, c'est au chercheur de coder la reconstruction -- cote DSL, elle est *incluse par defaut* dans `NewTheorem<T>()`. Les tests unitaires `RecordEnvTheoryTests` (4 cas) verifient que la branche positionnelle couvre records a 2-3 params, scalaires mixtes (int + bool), et le retour `null` sur UNSAT."
+    "> **Ligne de contraste** : la valeur ajoutee du DSL ici n'est pas une fecondation d'expression (comme `Sum` qui replie N termes en un seul `MkAdd`), mais le **routage de reconstruction** -- la detection du type d'environnement (`class` mutable avec setter vs `record` positionnel vs type anonyme) et l'invocation de la bonne branche de [`Theorem.cs:993-1099`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993). Cote raw, c'est au chercheur de coder la reconstruction -- cote DSL, elle est *incluse par defaut* dans `NewTheorem<T>()`. Les tests unitaires `RecordEnvTheoryTests` (4 cas) verifient que la branche positionnelle couvre records a 2-3 params, scalaires mixtes (int + bool), et le retour `null` sur UNSAT."
    ]
   },
   {


### PR DESCRIPTION
## Summary

`01_Linq2Z3_Intro.ipynb` had two Z3.Linq submodule deep-links with an extra parent-dir component (`../../Z3.Linq` instead of `../Z3.Linq`), so they resolved to `SymbolicAI/Z3.Linq` (does not exist) instead of `SymbolicAI/SMT/Z3.Linq` (the actual Z3.Linq submodule). The other **26 Z3-Linq2Z3 notebooks all use the correct single `../Z3.Linq`** path (78 occurrences repo-wide vs exactly 2 typo occurrences, both in Intro).

## Fix (2 links)

| Cell | Change |
|------|--------|
| cell25 | `[`Theorem.cs:993-1099`](../../Z3.Linq/...)` → `[...](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993)` |
| cell27 | same |

Post-fix the links resolve INTO the Z3.Linq submodule (valid on GitHub, consistent with the 26 sibling notebooks).

## Validation

- **Surgical (C.3)**: raw-text replace, 2 ins / 2 del, 1 file, byte-identical elsewhere.
- **C.2**: markdown-only → prior outputs valid (no re-exec).
- **JSON valid** post-edit.
- **Verified firsthand**: 78 repo-wide `../Z3.Linq/solutions` (canonical) vs 2 `../../Z3.Linq/solutions` (typo, Intro only).
- **Found by**: `check_notebook_navlinks.py` (PR #6813, baseline 30 genuine broken).

With #6809 (16 App-CSP) + #6819 (6 GameTheory) + #6821 (3 Search) + this (2 Z3), the genuine-broken baseline drops from 30 → ~3 (1 deferred Search navigation + 2 .claude/rules).

See #5081, #6813 (checker), #6809/#6819/#6821 (sibling navlink fixes, no collision).