### PR TITLE
enrich(nbformat,#6257): add v4.5 cell ids to Sudoku-15-Infer + Sudoku-12-Z3 (C#)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
@@ -775,6 +775,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "add29da2",
    "metadata": {},
    "source": [
     "## Exercice : Résoudre un Killer Sudoku avec contrainte de somme\n",
@@ -789,6 +790,7 @@
   },
   {
    "cell_type": "code",
+   "id": "71c3588f",
    "execution_count": 6,
    "metadata": {
     "execution": {
@@ -1189,6 +1191,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d0583d20",
    "metadata": {},
    "source": [
     "## Exercice : Compter le nombre de solutions avec Z3\n",
@@ -1205,6 +1208,7 @@
   },
   {
    "cell_type": "code",
+   "id": "37a27e98",
    "execution_count": 11,
    "metadata": {
     "execution": {
@@ -1445,6 +1449,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "940a7420",
    "metadata": {},
    "source": [
     "## Exercice : Coloration de graphe avec Z3\n",
@@ -1460,6 +1465,7 @@
   },
   {
    "cell_type": "code",
+   "id": "55ada6cd",
    "execution_count": 13,
    "metadata": {
     "execution": {
@@ -1910,5 +1916,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -306,6 +306,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "145b8d51",
    "metadata": {},
    "source": [
     "## Exercice : Compter les candidats possibles par case\n",
@@ -320,6 +321,7 @@
   },
   {
    "cell_type": "code",
+   "id": "ec7b6e3a",
    "execution_count": 1,
    "metadata": {},
    "outputs": [
@@ -1550,6 +1552,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b2520e9c",
    "metadata": {},
    "source": [
     "## Exercice : Vérifier la reproductibilité du solver\n",
@@ -1564,6 +1567,7 @@
   },
   {
    "cell_type": "code",
+   "id": "34ad96ff",
    "execution_count": 1,
    "metadata": {},
    "outputs": [
@@ -3190,6 +3194,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "26a3ccc1",
    "metadata": {},
    "source": [
     "## Exercice : Comparer les trois solveurs Infer.NET\n",
@@ -3204,6 +3209,7 @@
   },
   {
    "cell_type": "code",
+   "id": "e01ffa84",
    "execution_count": 1,
    "metadata": {},
    "outputs": [
@@ -41068,5 +41074,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

These 2 Sudoku C# notebooks were **omitted from the series-wide migration** (#6392 covered 10 Sudoku C# notebooks). They each carried **6 missing-id exercise-cell pairs** (12 total): the exercise markdown/code stubs (`## Exercice` + `// EXERCICE`) were added in an exercise-enrichment pass *after* the #6392 migration, without backfilling cell ids.

Follows the canonical fleet-wide v4.5 cell-id migration (#6498 / #6392 / #6797 / #6810 pattern). My partition (Sudoku .NET C#). Different register from recent accent work (R6 variety).

## What changed

| Notebook | Cells | Ids added | nbformat_minor |
|----------|------:|----------:|:--------------:|
| `Sudoku-15-Infer-Csharp.ipynb` | 47 | 6 | 2 → 5 |
| `Sudoku-12-Z3-Csharp.ipynb` | 38 | 6 | 2 → 5 |

**Id scheme**: `md5(basename:index)[:8]` (8-hex, deterministic, matches the existing `#6392` id format — no `cell-` prefix, e.g. `7e4e8300`).

## Verification (firsthand)

| Check | Result |
|-------|--------|
| source/outputs/execution_count vs main | **byte-identical** (programmatic) |
| nbformat.validate() strict | **PASS** (both) |
| all code/markdown cells have `id` | **yes** (47 / 38, all unique) |
| nbformat churn | +14/-2 (12 id lines + 2 nbformat_minor) — **id-only**, no source/output churn |
| H.3 validate_pr_notebooks.py | **PASS** (16 + 15 cells, .net-csharp) |
| C.1 (raise/NotImpl/assert/1-0) | **0** |
| CRLF | **0** (LF preserved) |

C.2-safe: id-only change → no re-exec needed (0 source/output churn, precedent #6797/#6810).

See #6257 (partial — 2 residual Sudoku C# notebooks). See #6392 (Sudoku C# series base migration).

Co-Authored-By: Claude-Code <noreply@anthropic.com>