### PR TITLE
fix(prover,#6790): sync remaining_iterations on every AgentExecutor hop (bug 4 metrics=0)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -234,6 +234,20 @@ class AgentExecutor(Executor):
         # Forensic evidence: Demo16 CYCLE78, iter_cap fired at [+3213.3s]
         # while Director was the designated next_agent, 2→2 no progress.
         msg.iteration += 1
+        # metrics=0 (#6790 bug 4, completes FX-9): mirror the per-traversal
+        # iteration into state.remaining_iterations on EVERY hop, not just in
+        # DiagnosisExecutor.handle (the earlier sole sync site). When a run
+        # ends via an AgentExecutor hard-cap (iteration_cap / delta0_stagnation
+        # / build_fail_streak below) it yields BEFORE reaching DiagnosisExecutor,
+        # so remaining_iterations kept its init value (max_iterations) and the
+        # result computed ``iterations = max_iterations - max_iterations = 0``
+        # even though msg.iteration had advanced (forensic: ai-01 BG iter
+        # DEMO 62, 33 min of work, RESULT_ITERATIONS 0). The cap logic below
+        # keys on msg.iteration directly, so syncing the reporting field here
+        # is inert to the cap and only fixes the reported count.
+        if self._state and msg.max_iterations > 0:
+            self._state.remaining_iterations = max(
+                0, msg.max_iterations - msg.iteration)
         _director_budget_remaining = (
             self._state
             and hasattr(self._state, '_has_director')

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1140,6 +1140,38 @@ def test_delta0_hardcap_yields_and_skips_agent():
     agent.run.assert_not_awaited()  # no compute wasted past the cap
 
 
+def test_hardcap_yield_syncs_remaining_iterations():
+    """metrics=0 (#6790 bug 4): a run that ends via an AgentExecutor hard-cap
+    (here delta0_stagnation) yields BEFORE reaching DiagnosisExecutor, which
+    was previously the sole site syncing state.remaining_iterations. The result
+    then computed ``iterations = max_iterations - max_iterations = 0`` even
+    though msg.iteration had advanced. The fix mirrors the sync into
+    AgentExecutor.handle on every hop; this test asserts the field is no longer
+    stale after a hard-cap yield."""
+    from prover.workflow import (
+        AgentExecutor, ProofMessage, DELTA0_STAGNATION_HARDCAP,
+    )
+
+    state = ProofState(theorem_statement="t")
+    # Simulate the init that prove_sorry sets (provers.py:504): budget=10.
+    state.remaining_iterations = 10
+    state.consecutive_delta0_compiles = DELTA0_STAGNATION_HARDCAP
+    agent = _stagnation_agent()
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x", max_iterations=10)
+    ctx = _run_handle(ex, msg)
+
+    ctx.yield_output.assert_awaited_once()          # hard-cap fired
+    agent.run.assert_not_awaited()                  # no work past the cap
+    # One iteration consumed (msg.iteration 0 -> 1 inside handle), so the
+    # reporting field must reflect 10 - 1 = 9, NOT the stale init 10.
+    assert state.remaining_iterations == 9, (
+        f"expected remaining_iterations synced to 9 after one consumed "
+        f"iteration, got {state.remaining_iterations} (metrics=0 regression: "
+        f"hard-cap-ending runs would report iterations=0)"
+    )
+
+
 def test_delta0_below_hardcap_runs_agent_normally():
     """One short of the cap, the run continues — the agent executes as usual."""
     from prover.workflow import (


### PR DESCRIPTION
## Summary

4th fix in the ai-01-dispatched prover-harness sequence (#6790, EPIC #1453, forensic DEMO 62): **bug 4 — metrics=0** (the run reported `RESULT_ITERATIONS 0 / ATTEMPTS 0` on 33 min of real work).

Bugs 1b (`#6811` MERGED) + 2 (`#6814` MERGED) closed both integrity paths (destructive revert + stale-cache promotion). This PR + freeze-loop (bug 3, deferred) are **run-quality**, not integrity.

## Root cause (firsthand G.1)

`state.remaining_iterations` was synced in **one place only**: `DiagnosisExecutor.handle` (`workflow.py:1294`). When a run ended via an **AgentExecutor hard-cap** (`iteration_cap` / `delta0_stagnation` / `build_fail_streak`), the message yielded via `ctx.yield_output(msg); return` *before* reaching `DiagnosisExecutor` → `remaining_iterations` kept its init value (`max_iterations`, set at `provers.py:504`).

The result then computed:
```
iterations = max(0, max_iterations - remaining_iterations)
           = max(0, max_iterations - max_iterations)
           = 0
```
even though `msg.iteration` had advanced. **Forensic**: ai-01 BG iter DEMO 62 (nw L2904), 33 min of real work, `RESULT_ITERATIONS 0`.

This **completes FX-9** (`#1453`), which correctly switched the result to `max(0, max_iterations - remaining_iterations)` but relied on a sync site too narrow to cover hard-cap-ending runs.

## Fix

Mirror the sync into `AgentExecutor.handle` right after `msg.iteration += 1` (`workflow.py:236`), so `remaining_iterations` is in sync on **every** hop regardless of which path ends the run. Mirrors `DiagnosisExecutor`'s logic verbatim (`if self._state and msg.max_iterations > 0: self._state.remaining_iterations = max(0, max_iterations - msg.iteration)`).

The cap logic below keys on `msg.iteration` directly (`_over_cap = msg.max_iterations and msg.iteration > msg.max_iterations`), **not** on `remaining_iterations` → the sync is inert to the cap and only fixes the reported count.

## Note on `ATTEMPTS=0`

That field (`len(state.tactic_history)`) was **honest** for the DEMO 62 run — the freeze-loop (bug 3) submitted no compilable tactics, so the empty history is accurate, not a bug. This PR fixes the `iterations` undercount only. (Bug 3 freeze-loop remains deferred: behavioral loop-control change needing workflow-graph no-action-turn detection, full-window focus.)

## Validation

| Check | Result |
|-------|--------|
| New test `test_hardcap_yield_syncs_remaining_iterations` | PASS (delta0 hard-cap yield → remaining_iterations synced 10→9, not stale 10) |
| Hardcap cohort (delta0 + fail_streak + build_check + new) | 12/12 PASS |
| Full `test_prover_guards.py` | **153 passed, 2 failed** |
| The 2 failures | pre-existing, identical to baseline, UNRELATED to this change: `test_coordinator_agent_has_set_attack_plan_tool`, `test_path_constants_resolve_to_active_workspace` (Voting.lean #4365 stale-post-absorption) |
| Diff scope | 2 files, +46/-0 (pure addition, 0 deletions = no existing logic removed) |
| Collision scan (`gh pr list --state all --search ...`) | 0 hit |
| Composes with bug 1b (#6811) + bug 2 (#6814) | yes — distinct code paths (workflow.py handle vs tools.py vs provers.py) |

See #6790, See #1453