### PR TITLE
fix(search,#3801): App-8 MiniZinc ASCII bars -> Plotly grouped charts (Prong-A)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
@@ -1117,287 +1117,58 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Concision du modele (lignes de code estimees)\n",
-      "--------------------------------------------------\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "N-Reines:\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Python pur ####################                                           20\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CP-SAT     ############                                                   12\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  MiniZinc   #####                                                          5\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Emploi du temps:\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Python pur ############################################################   60\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CP-SAT     #############################################                  45\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  MiniZinc   #########################                                      25\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Sudoku:\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Python pur ##################################################             50\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CP-SAT     ###################################                            35\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  MiniZinc   ####################                                           20\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "Evaluation multi-criteres (score 1-5)\n",
-      "--------------------------------------------------\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Concision:\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Python pur ##   \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CP-SAT     ###  \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  MiniZinc   #####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Lisibilite:\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Python pur ##   \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CP-SAT     ###  \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  MiniZinc   #####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Portabilite:\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Python pur #    \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CP-SAT     ##   \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  MiniZinc   #####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Integr. .NET:\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Python pur #####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CP-SAT     #####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  MiniZinc   ###  \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Performance:\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Python pur ##   \r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  CP-SAT     #####\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  MiniZinc   #### \r\n"
-     ]
+     "data": {
+      "text/html": [
+       "<h4>Concision du modele</h4><div id=\"pltConcision\"></div><h4>Evaluation multi-criteres</h4><div id=\"pltScore\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltConcision',[{\"name\":\"Python pur\",\"x\":[\"N-Reines\",\"Emploi du temps\",\"Sudoku\"],\"y\":[20,60,50],\"type\":\"bar\"},{\"name\":\"CP-SAT\",\"x\":[\"N-Reines\",\"Emploi du temps\",\"Sudoku\"],\"y\":[12,45,35],\"type\":\"bar\"},{\"name\":\"MiniZinc\",\"x\":[\"N-Reines\",\"Emploi du temps\",\"Sudoku\"],\"y\":[5,25,20],\"type\":\"bar\"}],{\"title\":{\"text\":\"Concision du modele (lignes de code estimees)\"},\"barmode\":\"group\",\"yaxis\":{\"title\":\"Lignes de code\"}});Plotly.newPlot('pltScore',[{\"name\":\"Python pur\",\"x\":[\"Concision\",\"Lisibilite\",\"Portabilite\",\"Integr. .NET\",\"Performance\"],\"y\":[2,2,1,5,2],\"type\":\"bar\"},{\"name\":\"CP-SAT\",\"x\":[\"Concision\",\"Lisibilite\",\"Portabilite\",\"Integr. .NET\",\"Performance\"],\"y\":[3,3,2,5,5],\"type\":\"bar\"},{\"name\":\"MiniZinc\",\"x\":[\"Concision\",\"Lisibilite\",\"Portabilite\",\"Integr. .NET\",\"Performance\"],\"y\":[5,5,5,3,4],\"type\":\"bar\"}],{\"title\":{\"text\":\"Evaluation multi-criteres (score 1-5)\"},\"barmode\":\"group\",\"yaxis\":{\"title\":\"Score\",\"range\":[0,5]}});</script>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "// Visualisation ASCII (remplace matplotlib) : concision et score multi-criteres.\n",
-    "static string Bar(int filled, int maxBars, char c = '#')\n",
-    "    => new string(c, filled) + new string(' ', maxBars - filled);\n",
+    "// Visualisation Plotly (remplace l'ASCII art -- EPIC #3801 Prong A) :\n",
+    "// concision du modele (lignes de code) + evaluation multi-criteres (score 1-5).\n",
+    "// Technique C548-L2 : Plotly.js via Formatter.Register (kernel builtin, aucun #r nuget).\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "using System.Text.Json;\n",
     "\n",
-    "Console.WriteLine(\"Concision du modele (lignes de code estimees)\\n\" + new string('-', 50));\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
+    "static string Trace(string name, string[] x, double[] y) =>\n",
+    "    JsonSerializer.Serialize(new Dictionary<string, object> { [\"name\"]=name, [\"x\"]=x, [\"y\"]=y, [\"type\"]=\"bar\" });\n",
+    "\n",
+    "// --- (1) Concision du modele : lignes de code estimees (grouped bars) ---\n",
     "var problems = new[] { \"N-Reines\", \"Emploi du temps\", \"Sudoku\" };\n",
-    "var linesPy = new[] { 20, 60, 50 };\n",
-    "var linesCp = new[] { 12, 45, 35 };\n",
-    "var linesMz = new[] { 5, 25, 20 };\n",
-    "int maxL = 60;\n",
-    "for (int i = 0; i < 3; i++)\n",
-    "{\n",
-    "    Console.WriteLine($\"\\n{problems[i]}:\");\n",
-    "    Console.WriteLine($\"  Python pur {Bar(linesPy[i], maxL),-62} {linesPy[i]}\");\n",
-    "    Console.WriteLine($\"  CP-SAT     {Bar(linesCp[i], maxL),-62} {linesCp[i]}\");\n",
-    "    Console.WriteLine($\"  MiniZinc   {Bar(linesMz[i], maxL),-62} {linesMz[i]}\");\n",
-    "}\n",
+    "string tConcPy = Trace(\"Python pur\", problems, new double[]{20,60,50});\n",
+    "string tConcCp = Trace(\"CP-SAT\", problems, new double[]{12,45,35});\n",
+    "string tConcMz = Trace(\"MiniZinc\", problems, new double[]{5,25,20});\n",
+    "string layoutConc = JsonSerializer.Serialize(new Dictionary<string,object>{\n",
+    "    [\"title\"]=new Dictionary<string,string>{[\"text\"]=\"Concision du modele (lignes de code estimees)\"},\n",
+    "    [\"barmode\"]=\"group\", [\"yaxis\"]=new Dictionary<string,string>{[\"title\"]=\"Lignes de code\"}});\n",
     "\n",
-    "Console.WriteLine(\"\\n\\nEvaluation multi-criteres (score 1-5)\\n\" + new string('-', 50));\n",
+    "// --- (2) Evaluation multi-criteres (score 1-5, grouped bars) ---\n",
     "var criteria = new[] { \"Concision\", \"Lisibilite\", \"Portabilite\", \"Integr. .NET\", \"Performance\" };\n",
-    "var scPy = new[] { 2, 2, 1, 5, 2 };\n",
-    "var scCp = new[] { 3, 3, 2, 5, 5 };\n",
-    "var scMz = new[] { 5, 5, 5, 3, 4 };\n",
-    "for (int i = 0; i < 5; i++)\n",
-    "{\n",
-    "    Console.WriteLine($\"\\n{criteria[i]}:\");\n",
-    "    Console.WriteLine($\"  Python pur {Bar(scPy[i], 5)}\");\n",
-    "    Console.WriteLine($\"  CP-SAT     {Bar(scCp[i], 5)}\");\n",
-    "    Console.WriteLine($\"  MiniZinc   {Bar(scMz[i], 5)}\");\n",
-    "}\n"
+    "string tScPy = Trace(\"Python pur\", criteria, new double[]{2,2,1,5,2});\n",
+    "string tScCp = Trace(\"CP-SAT\", criteria, new double[]{3,3,2,5,5});\n",
+    "string tScMz = Trace(\"MiniZinc\", criteria, new double[]{5,5,5,3,4});\n",
+    "string layoutScore = JsonSerializer.Serialize(new Dictionary<string,object>{\n",
+    "    [\"title\"]=new Dictionary<string,string>{[\"text\"]=\"Evaluation multi-criteres (score 1-5)\"},\n",
+    "    [\"barmode\"]=\"group\", [\"yaxis\"]=new Dictionary<string,object>{[\"title\"]=\"Score\",[\"range\"]=new double[]{0,5}}});\n",
+    "\n",
+    "string markup = \"<h4>Concision du modele</h4>\" +\n",
+    "    \"<div id=\\\"pltConcision\\\"></div>\" +\n",
+    "    \"<h4>Evaluation multi-criteres</h4>\" +\n",
+    "    \"<div id=\\\"pltScore\\\"></div>\" +\n",
+    "    \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "    $\"<script>Plotly.newPlot('pltConcision',[{tConcPy},{tConcCp},{tConcMz}],{layoutConc});\" +\n",
+    "    $\"Plotly.newPlot('pltScore',[{tScPy},{tScCp},{tScMz}],{layoutScore});</script>\";\n",
+    "\n",
+    "new PlotlyHtml(markup)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

App-8 (MiniZinc/CSP) cell `[18]` rendered code-concision and multi-criteria scores as **hand-built ASCII bar charts** (`Bar()` helper, explicit comment `// Visualisation ASCII (remplace matplotlib)`) while a real charting tool is installable/invocable on the worker. This is an **EPIC #3801 Prong-A** defect (workaround dégradé sans verdict SOTA).

Replaced with **real Plotly grouped bar charts** via the **C548-L2 zero-restore technique** (`Formatter.Register(typeof(PlotlyHtml), ...)` + raw Plotly.js JSON + `<script src="https://cdn.plot.ly/plotly-2.35.2.min.js">`). No `#r "nuget:"` for the charting lib -> avoids slow restore (memory `dotnet-c548-l2-zero-restore-plotly-technique`, pioneered po-2024 #6607 Infer-19).

Two charts: (1) code-line concision grouped bars {Python pur, CP-SAT, MiniZinc} x {N-Reines, Emploi du temps, Sudoku}; (2) multi-criteria scores (1-5) grouped bars {Concision, Lisibilite, Portabilite, Integr. .NET, Performance}.

## Data fidelity
Original values preserved **verbatim** (concision lines 20/60/50, 12/45/35, 5/25/20; scores incl. **CP-SAT Portabilite = 2** — matched exactly, not the near-miss 3). Visualization only.

## Real execution (C.2)
Cell re-executed via `jupyter nbconvert --execute` + `.net-csharp` kernel (dotnet-interactive 10.0.110). Committed output is the **genuine Formatter text/html** (execute_result). The kernel-injected `probeAddresses` banner was stripped per canonical hook **#6312** (rule-6 3rd exception, kernel-injected artifact — NOT a hand-edited cell output). `execution_count=11` matches the notebook sequence (idx=18 -> ec=11).

## Validation
- `validate_pr_notebooks.py` **PASS** (14 cells, `.net-csharp`)
- H.1 (no error outputs), H.3 (ec!=null), C.1 (no raise/assert/1/0) — all clean
- **Only cell `[18]` changed** — the other 13 code cells byte-identical (verified structurally + `json.dumps(indent=1, ensure_ascii=False)+newline` round-trip identity)

## SOTA verdict
**RECOVERABLE-LOCAL** — Plotly installable/invocable on the worker machine, no user action required.

`deletions > insertions` (+45/-274) = removal of the ASCII workaround (34 stream-bar outputs + `Bar()` helper), replaced by real SOTA visualization. Documented Prong-A fix, **not** a sorry/stub regression (anti-regression does not apply to a workaround cell upgraded to the real tool).

## Note for reviewer
Visual rendering QA deferred: po-2023 is a GLM lane (no vision capability, per `model-delegation.md` vision rule). The committed HTML is verified structurally (2 `Plotly.newPlot` calls, valid JSON traces, correct data). **Visual merge-gate should be confirmed by ai-01 (Opus) or a MiniMax CoursIA-2 lane.**

See #3801 (Prong-A register — partial contribution to the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)