### PR TITLE
fix(search,#5081): repair Search-11-Metaheuristics-Csharp next navlink (resolves #6821 DEFERRED)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Search-11 (C#) : Metaheuristiques — Optimisation par essaim, recuit et evolution\n",
     "\n",
-    "**Navigation** : [<< Search-10 SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | [Index Part 1](../README.md) | [Search-12 A*](Search-12-AStar-And-Heuristics.ipynb) >>\n",
+    "**Navigation** : [<< Search-10 SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | [Index Part 1](../README.md) | [Search-11b Métaheuristiques (Deep)](Search-11b-Metaheuristiques-Deep.ipynb) >>\n",
     "\n",
     "**Serie** : Search / Partie 1 — Fondations (C#). Jumeau .NET du notebook Python [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb).\n",
     "\n",


### PR DESCRIPTION
## Summary

Repairs the cell0 "next >>" navlink in `Search-11-Metaheuristics-Csharp.ipynb` — the **1 link DEFERRED by #6821** (po-2026) which cited "unknown post-#5081 reading order" as the reason for leaving it untouched. This PR resolves that deferral with **README-grounded evidence**.

| | |
|---|---|
| **Old** | `[Search-12 A*](Search-12-AStar-And-Heuristics.ipynb) >>` — target **never existed** (slot-12 is now PatternDatabases; A* moved to Search-3-Informed per #6821) |
| **New** | `[Search-11b Métaheuristiques (Deep)](Search-11b-Metaheuristiques-Deep.ipynb) >>` — README-documented continuation |

## Why this is grounded (resolves the #6821 deferral)

`Part1-Foundations/README.md` line 56 canonically documents the reading order:
```
| 11 (.NET) | Search-11-Metaheuristics (C#)    | .NET (C#) | Jumeau .NET : PSO ...
| 11b (.NET)| Search-11b-Metaheuristiques-Deep | .NET (C#) | ...              ← documented continuation of 11
```
- `Search-11b-Metaheuristiques-Deep.ipynb` **exists** and is a **C# notebook** (title confirms C# / .NET) → clean same-language continuation link.
- The original "next >> A*" was pedagogically suspect regardless: A*/informed search is foundational and belongs **before** metaheuristics, not after.

## Verification (firsthand)

| Check | Result |
|-------|--------|
| target file exists (same dir, relative resolve) | yes |
| `check_notebook_navlinks.py` on this file | **0 broken** (was the last genuine break in Part1 canonical) |
| source/outputs/execution_count vs main | **IDENTICAL** (markdown-only cell0 edit) |
| JSON valid | yes |
| H.3 validate_pr_notebooks.py | **PASS** (15 cells, .net-csharp) |
| CRLF | **0** (LF preserved) |

C.2-safe: markdown-only navlink edit, no re-exec needed (cell0 is the title/navigation markdown cell).

See #5081 (renumber). See #6821 (po-2026 sibling fixes — this resolves its explicitly DEFERRED item with README evidence).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
