### PR TITLE
fix(prover,#6790): authoritative error parser — kill metrics=0 false-negative (bug a)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -102,6 +102,42 @@ def _count_sorries_from_build_output(raw_output: str) -> int:
     return count
 
 
+
+def _parse_lean_errors(raw_output: str) -> list:
+    """Parse Lean/Lake error lines from build output.
+
+    Root-cause fix for the metrics=0 / false-negative integrity bug (#6790):
+    the inline parsers anchored on ``<digits>:<digits>: error:`` (a per-line
+    ``line:col`` position) and therefore MISSED every error that carries no
+    per-line position -- module-level errors (``foo.lean: error: ...``),
+    message-only errors, and multi-line continuations.  An authoritative
+    ``LeanVerifier._extract_errors`` (``agent_tests/lean_server.py``) detects
+    the same class with the bare substring ``": error:"`` and flips
+    ``success`` to ``False``; the inline parsers returned ``error_count == 0``
+    for those very lines, producing the false-negative
+    ``level_1_build == False AND errors == []`` that let a non-compiling
+    snapshot be preserved (DEMO 62, ``HashlifeCorrectness.lean:2940``).
+
+    This helper mirrors the authoritative substring detection so the inline
+    tools agree with ``LeanVerifier`` on what counts as an error.  Each entry
+    carries ``line`` (``int`` when a ``line:col`` is present, else ``None``)
+    and ``message`` (the text following ``": error:"``).
+    """
+    errors = []
+    for line in raw_output.split("\n"):
+        if ": error:" not in line:
+            continue
+        m = re.search(r"(\d+):(\d+): error: (.*)", line)
+        if m:
+            errors.append({"line": int(m.group(1)), "message": m.group(3)})
+            continue
+        m = re.search(r"error: .*?(\d+):(\d+): (.*)", line)
+        if m:
+            errors.append({"line": int(m.group(1)), "message": m.group(3)})
+            continue
+        errors.append({"line": None, "message": line.split(": error:", 1)[1].strip()})
+    return errors
+
 def _read_lines_from_source(source: str, start: int, end: int) -> str:
     """Read lines [start, end] (1-based inclusive) from a string source."""
     lines = source.split("\n")
@@ -1131,27 +1167,21 @@ class TacticTools:
         # replacement might still be valid if no new syntax errors were introduced.
         raw_output = result.get("raw_output", "") or result.get("errors", "")
         non_sorry_errors = []
-        for line in raw_output.split("\n"):
-            if "error:" not in line:
+        skip_patterns = [
+            "declaration uses `sorry`",
+            "uses `sorry`",
+            "Some required targets logged failures",
+            "Lean exited with code 1",
+            "error: build failed",
+            "compiled configuration is invalid",
+        ]
+        for err in _parse_lean_errors(raw_output):  # #6790: authoritative parser
+            msg = err["message"]
+            if any(skip in msg for skip in skip_patterns):
                 continue
-            skip_patterns = [
-                "declaration uses `sorry`",
-                "uses `sorry`",
-                "Some required targets logged failures",
-                "Lean exited with code 1",
-                "error: build failed",
-                "compiled configuration is invalid",
-            ]
-            if any(skip in line for skip in skip_patterns):
+            if "unsolved goals" in msg:
                 continue
-            m = re.match(r".*?(\d+):\d+: error: (.*)", line)
-            if not m:
-                m = re.match(r"error: .*?(\d+):\d+: (.*)", line)
-            if m:
-                msg = m.group(2)
-                if "unsolved goals" in msg:
-                    continue
-                non_sorry_errors.append({"line": int(m.group(1)), "message": msg})
+            non_sorry_errors.append({"line": err["line"], "message": msg})
 
         # If only sorry-related errors, accept the replacement (don't revert)
         if not non_sorry_errors:
@@ -1202,13 +1232,7 @@ class TacticTools:
         # Build failed with real errors — revert to original.
         Path(self._filepath).write_text(original_content, encoding="utf-8")
         raw_output = result.get("raw_output", "") or result.get("errors", "")
-        errors = []
-        for line in raw_output.split("\n"):
-            m = re.match(r".*?(\d+):\d+: error: (.*)", line)
-            if not m:
-                m = re.match(r"error: .*?(\d+):\d+: (.*)", line)
-            if m:
-                errors.append({"line": int(m.group(1)), "message": m.group(2)})
+        errors = _parse_lean_errors(raw_output)  # #6790: authoritative parser
 
         if self._trace:
             self._trace.log(
@@ -1859,13 +1883,7 @@ class TacticTools:
         success = result.get("success", False)
         cached = result.get("cached", False)
 
-        errors = []
-        for line in raw_output.split("\n"):
-            m = re.match(r".*?(\d+):\d+: error: (.*)", line)
-            if not m:
-                m = re.match(r"error: .*?(\d+):\d+: (.*)", line)
-            if m:
-                errors.append({"line": int(m.group(1)), "message": m.group(2)})
+        errors = _parse_lean_errors(raw_output)  # #6790: authoritative parser
 
         content = Path(self._filepath).read_text(encoding="utf-8")
         text_sorry_count = count_real_sorries(content)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2998,3 +2998,54 @@ def test_final_verify_crash_synthetic_still_reverts():
         "errors": [{"message": "final-verify crashed: KeyError('foo')"}],
     }
     assert _final_verify_is_false_negative(crashed) is False
+
+
+def test_parse_lean_errors_catches_module_level_no_linecol():
+    """Regression for the metrics=0 / false-negative integrity bug (#6790).
+
+    The legacy inline parsers anchored on ``<digits>:<digits>: error:`` and
+    therefore MISSED module-level errors that carry no per-line ``line:col``
+    position (``foo.lean: error: type mismatch``).  An authoritative
+    ``LeanVerifier._extract_errors`` detects the same class via the
+    ``": error:"`` substring and sets ``success=False``; the inline parsers
+    returned ``error_count == 0`` for those very lines -> the false-negative
+    ``level_1_build == False AND errors == []`` that let DEMO 62 preserve a
+    non-compiling ``HashlifeCorrectness.lean:2940`` snapshot.
+    ``_parse_lean_errors`` mirrors the authoritative substring detection.
+    """
+    from prover.tools import _parse_lean_errors
+
+    # Module-level error with NO line:col position — the false-negative case.
+    raw = (
+        "info: ...\n"
+        "HashlifeCorrectness.lean: error: type mismatch\n"
+        "  term\n"
+        "Foo.lean:12:3: error: unsolved goals\n"
+    )
+    errors = _parse_lean_errors(raw)
+    assert len(errors) == 2, errors
+    # Module-level error is now captured (line=None), not dropped.
+    module_level = [e for e in errors if e["line"] is None]
+    assert len(module_level) == 1, module_level
+    assert "type mismatch" in module_level[0]["message"]
+    # line:col error still parsed correctly.
+    positioned = [e for e in errors if e["line"] == 12]
+    assert len(positioned) == 1 and "unsolved goals" in positioned[0]["message"]
+
+
+def test_parse_lean_errors_matches_authoritative_substring_contract():
+    """The whole point of #6790: where the authoritative verifier sees an
+    error (``": error:"`` substring -> ``success=False``), the inline tool
+    must agree (``len(errors) > 0``), not return the false-negative 0.
+    This test pins the substring contract shared with
+    ``LeanVerifier._extract_errors`` (``agent_tests/lean_server.py``)."""
+    from prover.tools import _parse_lean_errors
+
+    raw = "MyMod.lean: error: cannot synthesize type\n"
+    # Authoritative substring contract: any line containing ": error:" is one.
+    substring_count = sum(1 for line in raw.split("\n") if ": error:" in line)
+    assert substring_count == 1
+    inline = _parse_lean_errors(raw)
+    assert len(inline) == substring_count, (inline, substring_count)
+    assert inline[0]["line"] is None
+    assert "cannot synthesize type" in inline[0]["message"]


### PR DESCRIPTION
## Summary

Root-cause fix for the remaining prover integrity bug (EPIC #1453 / #6790). ai-01's live-test (msg-ucuczi) revealed that bug-1b's guard (#6811) MIS-FIRED in production: it **preserved a non-compiling snapshot** (`HashlifeCorrectness.lean:2940:79` type-mismatch) because the inline error parser reported `error_count == 0` — a **false negative**. There WAS a real error; the parser just missed it.

### Root cause (verified firsthand, G.1)

The 3 inline parsers in [`prover/tools.py`](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py) anchored on a per-line `line:col` position:

```python
m = re.match(r".*?(\d+):\d+: error: (.*)", line)   # requires <digits>:<digits> before "error:"
```

Errors **without** a per-line position never matched:
- **module-level**: `foo.lean: error: type mismatch`
- **message-only** / multi-line continuations

Meanwhile the authoritative `LeanVerifier._extract_errors` ([`agent_tests/lean_server.py:498`](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py)) detects the same class via the bare substring `": error:"` and flips `success=False`. Divergence → `level_1_build == False AND errors == []` → bug-1b guard read it as "build not attempted" → **preserved the broken snapshot**.

Empirically confirmed: a `foo.lean: error: ...` line has `": error:" in line == True` (authoritative: 1 error) but `re.match(r".*?(\d+):\d+: error:", line) is None` (inline: 0 errors).

## Changes

- **New shared helper `_parse_lean_errors(raw_output)`** — mirrors the authoritative `": error:"` substring detection; falls back to `line=None` when no `line:col` present.
- **Wired into all 3 inline sites**:
  - `non_sorry_errors` (build_check revert gate) — preserves `skip_patterns` + `"unsolved goals"` filtering, now applied to the parsed `message`
  - `file_insert_lines` revert `errors`
  - **final-verify `errors`** — THE critical false-negative source (site c)

## Verification (re-launched post-last-commit)

| Check | Result |
|-------|--------|
| `git diff --stat` coherent | 2 files, +102/-33 (helper ~40 + 3 site conversions) |
| AST parse | OK |
| Line endings preserved (LF) | CRLF 0 (write_text had flipped to CRLF — normalized back to match HEAD) |
| Cohort `-k "error or parse or build_check or final_verify or false_negative"` | **14/14 PASS** |
| Full suite `test_prover_guards.py` | **155 PASS**, 2 fail |
| 2 failures pre-existing on HEAD? | **YES** — confirmed via `git stash` + re-run on clean HEAD |

### 2 pre-existing failures (NOT regressions, confirmed on HEAD)
1. `test_coordinator_agent_has_set_attack_plan_tool` — `openai.OpenAIError: Missing credentials` (needs `OPENAI_API_KEY` env, environmental)
2. `test_path_constants_resolve_to_active_workspace` — `Voting.lean` now exists (#4365 absorption); stale `STALE_POST_ABSORPTION` entry, unrelated to error parsing

### New regression tests
- `test_parse_lean_errors_catches_module_level_no_linecol` — the false-negative case: module-level error now captured (`line=None`), not dropped
- `test_parse_lean_errors_matches_authoritative_substring_contract` — pins the `": error:"` substring contract shared with `LeanVerifier._extract_errors`

## Scope

Strictly the error-parsing defect (bug **a** in ai-01's msg-ucuczi decomposition). Does NOT touch:
- bug **b** (snapshot bookkeeping) — separate
- bug **c** (success semantics) — separate; this PR makes its diagnostics visible
- bug 3 (freeze-loop) — deferred, full-window behavioral change

Per ai-01 calibration: **parser first** (it conditions both the guard and the diagnostics) → interim guard hardening → freeze-loop.

See #6790, See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)