### PR TITLE
fix(prover,#6790): interim guard hardening — fresh re-verify before preserve (item 1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -374,6 +374,63 @@ def _final_verify_is_false_negative(final_verify: dict) -> bool:
     return err_count == 0
 
 
+def _reverify_compiles_clean(filepath: str, tactic_tools) -> bool:
+    """Interim guard hardening (#6790): independent fresh re-verify of the exact
+    on-disk content before trusting a false-negative verify and PRESERVING.
+
+    The bug-1b guard ``_final_verify_is_false_negative`` detects the pattern
+    ``level_1_build == False AND error_count == 0`` and historically PRESERVED
+    the committed snapshot on that signal alone. The risk: if the
+    false-negative signal is itself misleading (the initial verify's
+    ``error_count == 0`` came from a parser/cache/manifest quirk rather than a
+    genuinely clean build), preserving leaves a *truly broken* file committed.
+    ai-01 calibration (msg-20260716T080013-ltad25): "re-verifier frais le
+    contenu exact avant de preserver" — protect the runs while (b)/(c) await.
+
+    This helper is the trust gate: it does NOT trust the false-negative
+    premise. It invalidates the verifier cache (drops stale manifest/cache
+    entries) and runs ONE independent fresh ``force=True`` build of the exact
+    on-disk content, parsed with the authoritative ``": error:"`` substring
+    contract (``_parse_lean_errors``, #6831). Returns True only if that fresh
+    build genuinely compiles with zero errors.
+
+    The caller then preserves on True (fresh build confirms the snapshot is
+    build-passing) and reverts on False (the false-negative was misleading; the
+    snapshot is truly broken). This converts "trust and preserve" into
+    "preserve only if an independent fresh build confirms".
+    """
+    from .verifier import get_verifier
+    from .tools import _parse_lean_errors  # authoritative parser (#6831)
+    from .lean_utils import resolve_lake_module
+    try:
+        verifier = get_verifier()
+        if verifier is not None:
+            type(verifier).invalidate(filepath)
+        # Re-run compile() — it already uses force=True internally, and now
+        # operates against a cache that was just invalidated above, so the
+        # build is genuinely fresh and independent of the first verify.
+        raw = tactic_tools.compile()
+        rv = json.loads(raw)
+    except Exception as _e:
+        print(f"  RE-VERIFY crashed: {_e} — conservatively revert (do NOT preserve).")
+        return False
+    fresh_errors = _parse_lean_errors(rv.get("raw_output", "") or rv.get("errors", ""))
+    fresh_ok = bool(rv.get("level_1_build", False)) and len(fresh_errors) == 0
+    if not fresh_ok:
+        print(
+            f"  RE-VERIFY FAILED: fresh independent build of the on-disk content "
+            f"reports {len(fresh_errors)} error(s) — the false-negative verify was "
+            f"MISLEADING; the snapshot is truly broken -> REVERT (#6790 hardening)."
+        )
+    else:
+        print(
+            "  RE-VERIFY PASSED: fresh independent build confirms the on-disk "
+            "content compiles clean -> the false-negative verify is confirmed, "
+            "snapshot is genuinely build-passing -> PRESERVE (#6790 hardening)."
+        )
+    return fresh_ok
+
+
 class MultiAgentSorryProver:
     """Multi-agent sorry replacement using WorkflowBuilder graph.
 
@@ -833,20 +890,38 @@ class MultiAgentSorryProver:
                 if _final_verify_is_false_negative(final_verify):
                     # Bug 1b (#6790): level_1_build=False but 0 compile errors
                     # = false-negative verify (worktree manifest warning / cache
-                    # state), on content the tool build_check had passed. Do NOT
-                    # revert — reverting here destroyed a build-passing snapshot
-                    # (DEMO 62: 5-sub-goal decomposition lost). Preserve the
-                    # committed file + structural_progress; log raw verify for
-                    # diagnosis. Treat as build-ok so the success gate below can
-                    # fire on the preserved structural progress.
+                    # state), on content the tool build_check had passed.
+                    # Interim guard hardening (msg-20260716T080013-ltad25): do
+                    # NOT trust the false-negative premise alone — re-verify the
+                    # EXACT on-disk content with an independent fresh build. If
+                    # the fresh build compiles clean, the snapshot is genuinely
+                    # build-passing -> PRESERVE (DEMO 62: 5-sub-goal decomposition
+                    # preserved). If the fresh build FAILS, the false-negative was
+                    # misleading and the snapshot is truly broken -> REVERT.
                     print(
                         f"  FINAL VERIFY INCOHERENT: level_1_build=False but 0 "
                         f"compile errors — false-negative verify (worktree "
-                        f"manifest warning / cache state), build-passing snapshot "
-                        f"PRESERVED, not reverted (#6790). Raw verify preview: "
-                        f"{final_verify_raw[:400]}"
+                        f"manifest warning / cache state). Running independent "
+                        f"fresh re-verify of the exact on-disk content before "
+                        f"deciding preserve vs revert (#6790 hardening). Raw "
+                        f"verify preview: {final_verify_raw[:400]}"
                     )
-                    final_build_ok = True
+                    if _reverify_compiles_clean(filepath, tactic_tools):
+                        # Fresh build confirms the snapshot compiles -> preserve.
+                        final_build_ok = True
+                    else:
+                        # Fresh build FAILED -> the false-negative was misleading;
+                        # the snapshot is truly broken. Revert to original (same
+                        # recovery as the genuine-build-failure branch below).
+                        print(
+                            "  REVERTING to original — independent fresh re-verify "
+                            "failed, snapshot is truly broken (#6790 hardening)."
+                        )
+                        Path(filepath).write_text(original_content, encoding="utf-8")
+                        final_sorry = original_sorry_count
+                        structural_progress = False
+                        tactic_tools._best_content = None
+                        tactic_tools._best_sorry_count = original_sorry_count
                 else:
                     print(
                         f"  FINAL VERIFY FAILED ({len(_errs)} compile errors). "

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -3049,3 +3049,124 @@ def test_parse_lean_errors_matches_authoritative_substring_contract():
     assert len(inline) == substring_count, (inline, substring_count)
     assert inline[0]["line"] is None
     assert "cannot synthesize type" in inline[0]["message"]
+
+
+def test_reverify_compiles_clean_false_on_fresh_build_failure(monkeypatch):
+    """#6790 interim guard hardening: the re-verify trust gate must return False
+    when the independent fresh build FAILS — this is the case where the
+    false-negative verify (``level_1_build=False, error_count=0``) was itself
+    MISLEADING (the snapshot is truly broken). Preserving on this signal would
+    leave a broken file committed; the gate's False forces a revert instead."""
+    import json
+    import prover.verifier as vmod
+    from prover.provers import _reverify_compiles_clean
+
+    class _BrokenVerifier:
+        @classmethod
+        def invalidate(cls, filepath):
+            pass
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _BrokenVerifier())
+
+    class _TacticTools:
+        def compile(self, check_axioms=False):
+            # Fresh build FAILS: level_1_build False + a real parseable error.
+            return json.dumps({
+                "level_1_build": False,
+                "raw_output": "Foo.lean:12:3: error: type mismatch\n",
+            })
+
+    result = _reverify_compiles_clean("dummy/path.lean", _TacticTools())
+    assert result is False, (
+        "re-verify must return False when the fresh independent build fails "
+        "(false-negative verify was misleading) -> forces revert, not preserve"
+    )
+
+
+def test_reverify_compiles_clean_true_on_fresh_build_success(monkeypatch):
+    """#6790 interim guard hardening: the re-verify trust gate must return True
+    when the independent fresh build GENUINELY compiles (level_1_build=True AND
+    zero parseable errors). This confirms the false-negative verify and permits
+    preservation of the build-passing snapshot (DEMO 62 decomposition case)."""
+    import json
+    import prover.verifier as vmod
+    from prover.provers import _reverify_compiles_clean
+
+    class _CleanVerifier:
+        @classmethod
+        def invalidate(cls, filepath):
+            pass
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _CleanVerifier())
+
+    class _TacticTools:
+        def compile(self, check_axioms=False):
+            # Fresh build PASSES: success True, no error lines in raw_output.
+            return json.dumps({
+                "level_1_build": True,
+                "raw_output": "info: invocation took 5.2s\n",
+            })
+
+    result = _reverify_compiles_clean("dummy/path.lean", _TacticTools())
+    assert result is True, (
+        "re-verify must return True when the fresh independent build compiles "
+        "clean -> confirms false-negative verify, preserves build-passing snapshot"
+    )
+
+
+def test_reverify_compiles_clean_false_on_crash(monkeypatch):
+    """#6790 hardening: if the fresh re-verify itself crashes, the gate must
+    conservatively return False (do NOT preserve on unknown state) — the prior
+    safe behavior is revert."""
+    import json
+    import prover.verifier as vmod
+    from prover.provers import _reverify_compiles_clean
+
+    class _CrashVerifier:
+        @classmethod
+        def invalidate(cls, filepath):
+            raise RuntimeError("invalidate exploded")
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: None)
+
+    class _TacticTools:
+        def compile(self, check_axioms=False):
+            raise RuntimeError("compile exploded")
+
+    # compile() raises -> the helper's except branch returns False.
+    result = _reverify_compiles_clean("dummy/path.lean", _TacticTools())
+    assert result is False, (
+        "re-verify must conservatively return False on its own crash -> revert"
+    )
+
+
+def test_reverify_compiles_clean_requires_zero_errors_even_on_success(monkeypatch):
+    """#6790 hardening: level_1_build=True ALONE is not enough — if the raw
+    output still carries a parseable error line (substring contract), the gate
+    must return False (catches a verifier that flips success=True but still
+    logs an error in raw_output). Belt-and-suspenders with the parser fix
+    #6831."""
+    import json
+    import prover.verifier as vmod
+    from prover.provers import _reverify_compiles_clean
+
+    class _Verifier:
+        @classmethod
+        def invalidate(cls, filepath):
+            pass
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _Verifier())
+
+    class _TacticTools:
+        def compile(self, check_axioms=False):
+            # level_1_build True BUT raw_output has an error line -> not clean.
+            return json.dumps({
+                "level_1_build": True,
+                "raw_output": "Bar.lean: error: cannot synthesize type\n",
+            })
+
+    result = _reverify_compiles_clean("dummy/path.lean", _TacticTools())
+    assert result is False, (
+        "re-verify must return False when level_1_build=True but raw_output "
+        "still carries a parseable error line"
+    )


### PR DESCRIPTION
## Summary

ai-01 calibration (msg-20260716T080013-ltad25): **item (1) — durcissement interim guard (re-verify frais du contenu exact avant preserve) — PRIORITAIRE car il protège les runs pendant que (b)/(c) attendent**. This is the P0 for this cycle.

### Problem

The bug-1b guard `_final_verify_is_false_negative` ([`provers.py:344`](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py)) detects `level_1_build == False AND error_count == 0` and **PRESERVED** the committed snapshot on that signal alone. The risk: if the false-negative signal is *itself misleading* (the initial verify's `error_count == 0` came from a parser/cache/manifest quirk rather than a genuinely clean build), preserving leaves a **truly broken** file committed.

The parser fix **#6831** closed one source (the anchored-regex blind spot), but the cache/manifest source remains — so the guard can still be fooled into preserving broken content.

## Fix

Convert "trust the false-negative premise and preserve" into "preserve only if an independent fresh build confirms". New helper `_reverify_compiles_clean(filepath, tactic_tools)`:

1. **invalidates** the verifier cache (drops stale manifest/cache entries)
2. runs ONE fresh `compile()` (`force=True` internally, cache just cleared)
3. parses `raw_output` with the authoritative `_parse_lean_errors` substring contract (#6831)
4. returns `True` **only if** `level_1_build=True` AND zero parseable errors
5. **conservatively returns `False` on its own crash** (do NOT preserve unknown state)

The preserve site ([`provers.py:890`](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py)) now gates on it:
- fresh build **confirms** → **PRESERVE** (DEMO 62 decomposition case preserved)
- fresh build **FAILS** → the false-negative was misleading → **REVERT** to original (same recovery as the genuine-build-failure branch), and clears the best snapshot so callers cannot claim spurious progress

## Verification (re-launched post-last-commit)

| Check | Result |
|-------|--------|
| `git diff --stat` coherent | 2 files, +206/-10 (helper ~60 + preserve-site gate + 4 tests) |
| AST parse | OK |
| Line endings (LF preserved) | CRLF 0 (write_text flipped CRLF on test file — normalized back) |
| Cohort `-k "reverify or parse or false_negative or final_verify"` | **11/11 PASS** |
| Full suite | **159 PASS** (+4 new), 2 fail |
| 2 failures pre-existing? | **YES** — identical to prior cycles: `OPENAI_API_KEY` env + `Voting.lean` #4365 path-constant staleness |

### 4 new regression tests
- `test_reverify_compiles_clean_false_on_fresh_build_failure` — the misleading-false-negative case → False → forces revert (the exact bug this fixes)
- `test_reverify_compiles_clean_true_on_fresh_build_success` — fresh build compiles → True → confirms preserve (DEMO 62 case)
- `test_reverify_compiles_clean_false_on_crash` — re-verify itself crashes → conservatively False → revert
- `test_reverify_compiles_clean_requires_zero_errors_even_on_success` — belt-and-suspenders: `level_1_build=True` but raw_output still has an error line → False

## Scope

Strictly the guard hardening (**item 1** of ai-01's 4-item sequence). Does NOT touch (b) snapshot bookkeeping, (c) PARTIAL/STRUCTURAL semantics, bug 3 freeze-loop (full-window). Composes with #6811/#6814/#6824/#6831 (distinct code path: provers.py preserve site).

See #6790, See #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)