### PR TITLE
feat(search,#3801): Search-11b-Part3 ABC limit-sweep Plotly chart (Prong-A)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part3.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part3.ipynb
@@ -675,16 +675,16 @@
    "id": "d8358eeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T04:55:56.998269Z",
-     "iopub.status.busy": "2026-07-06T04:55:56.998099Z",
-     "iopub.status.idle": "2026-07-06T04:55:57.167667Z",
-     "shell.execute_reply": "2026-07-06T04:55:57.167517Z"
+     "iopub.execute_input": "2026-07-16T08:20:37.232645Z",
+     "iopub.status.busy": "2026-07-16T08:20:37.232421Z",
+     "iopub.status.idle": "2026-07-16T08:20:37.829066Z",
+     "shell.execute_reply": "2026-07-16T08:20:37.829192Z"
     },
     "papermill": {
-     "duration": 0.173284,
-     "end_time": "2026-07-06T04:55:57.167736",
+     "duration": 0.601942,
+     "end_time": "2026-07-16T08:20:37.829276+00:00",
      "exception": false,
-     "start_time": "2026-07-06T04:55:56.994452",
+     "start_time": "2026-07-16T08:20:37.227334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -773,15 +773,33 @@
      "text": [
       "le temps d'explorer la vallee avant abandon — limite de l'intuition naive.\r\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"pltLimitSweep\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltLimitSweep',[{\"x\":[\"5\",\"20\",\"50\",\"100\",\"200\"],\"y\":[34.38066986048842,2.8502668016306707,0.8981649929870109,1.1260534975010452,0.5517182108962033],\"error_y\":{\"type\":\"data\",\"array\":[15.116392944568139,1.7174925797043974,0.9974498129878254,1.0273226163927474,0.4900358933022671],\"visible\":true,\"color\":\"#888888\",\"thickness\":1.5},\"type\":\"scatter\",\"mode\":\"lines\\u002Bmarkers\",\"name\":\"f moyen\",\"line\":{\"color\":\"#264653\",\"width\":2},\"marker\":{\"size\":9,\"color\":\"#2a9d8f\"}}],{\"title\":{\"text\":\"Qualite ABC vs limit (Rosenbrock dim=10, moy sur 3 seeds)\"},\"xaxis\":{\"title\":\"limit (budget d\\u0027essai avant abandon d\\u0027une source)\"},\"yaxis\":{\"title\":\"f moyen (plus bas = mieux)\",\"type\":\"log\"},\"margin\":{\"t\":60,\"r\":20,\"b\":60,\"l\":70},\"showlegend\":false,\"height\":400});</script>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "// Setup Plotly (technique C548-L2) — la clause using DOIT preceder tout autre element (CS1529).\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "using System.Text.Json;\n",
+    "\n",
     "// Sweep du parametre limit sur Rosenbrock.\n",
     "Console.WriteLine(\"Effet de 'limit' sur la qualite finale (Rosenbrock, dim=10, moyenne sur 3 seeds) :\");\n",
     "Console.WriteLine(\"  limit | f moyen       | std\");\n",
     "Console.WriteLine(\"  ------|---------------|----------\");\n",
     "\n",
     "int[] limits = { 5, 20, 50, 100, 200 };\n",
+    "var limArr = new List<int>();\n",
+    "var meanArr = new List<double>();\n",
+    "var stdArr = new List<double>();\n",
     "foreach (int lim in limits) {\n",
     "    var fs = new List<double>();\n",
     "    foreach (int seed in new[] { 1, 7, 42 }) {\n",
@@ -791,12 +809,48 @@
     "    }\n",
     "    double mean = fs.Average();\n",
     "    double std = Math.Sqrt(fs.Select(v => (v - mean) * (v - mean)).Average());\n",
+    "    limArr.Add(lim); meanArr.Add(mean); stdArr.Add(std);\n",
     "    Console.WriteLine($\"  {lim,5}  | {FI(mean, \"F6\"),13} | {FI(std, \"F6\")}\");\n",
     "}\n",
     "Console.WriteLine();\n",
     "Console.WriteLine(\"Lecture : limit=5 (abandon agressif) casse la convergence (f>>0, bruit).\");\n",
     "Console.WriteLine(\"Sur Rosenbrock, un limit GRAND (abandon rare) est meilleur : les sources ont\");\n",
-    "Console.WriteLine(\"le temps d'explorer la vallee avant abandon — limite de l'intuition naive.\");\n"
+    "Console.WriteLine(\"le temps d'explorer la vallee avant abandon — limite de l'intuition naive.\");\n",
+    "\n",
+    "// --- Visualisation Plotly (EPIC #3801 Prong-A) : f moyen +- std vs limit ---\n",
+    "// Technique C548-L2 : Plotly.js via Formatter.Register (kernel builtin, aucun #r nuget).\n",
+    "// Les barres d'erreur (std, 3 seeds) sont INVISIBLES dans le tableau ASCII ci-dessus ;\n",
+    "// le graphique les rend apparentes : limit=5 est a la fois mauvais ET bruite.\n",
+    "\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
+    "string[] xLabels = limArr.Select(l => l.ToString()).ToArray();\n",
+    "string trace = JsonSerializer.Serialize(new Dictionary<string, object> {\n",
+    "    [\"x\"] = xLabels,\n",
+    "    [\"y\"] = meanArr,\n",
+    "    [\"error_y\"] = new Dictionary<string, object> {\n",
+    "        [\"type\"] = \"data\", [\"array\"] = stdArr, [\"visible\"] = true, [\"color\"] = \"#888888\", [\"thickness\"] = 1.5\n",
+    "    },\n",
+    "    [\"type\"] = \"scatter\",\n",
+    "    [\"mode\"] = \"lines+markers\",\n",
+    "    [\"name\"] = \"f moyen\",\n",
+    "    [\"line\"] = new Dictionary<string, object> { [\"color\"] = \"#264653\", [\"width\"] = 2 },\n",
+    "    [\"marker\"] = new Dictionary<string, object> { [\"size\"] = 9, [\"color\"] = \"#2a9d8f\" },\n",
+    "});\n",
+    "string layout = JsonSerializer.Serialize(new Dictionary<string, object> {\n",
+    "    [\"title\"] = new Dictionary<string, string> { [\"text\"] = \"Qualite ABC vs limit (Rosenbrock dim=10, moy sur 3 seeds)\" },\n",
+    "    [\"xaxis\"] = new Dictionary<string, object> { [\"title\"] = \"limit (budget d'essai avant abandon d'une source)\" },\n",
+    "    [\"yaxis\"] = new Dictionary<string, object> { [\"title\"] = \"f moyen (plus bas = mieux)\", [\"type\"] = \"log\" },\n",
+    "    [\"margin\"] = new Dictionary<string, int> { [\"t\"] = 60, [\"r\"] = 20, [\"b\"] = 60, [\"l\"] = 70 },\n",
+    "    [\"showlegend\"] = false,\n",
+    "    [\"height\"] = 400,\n",
+    "});\n",
+    "string markup = \"<div id=\\\"pltLimitSweep\\\"></div>\" +\n",
+    "    \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "    $\"<script>Plotly.newPlot('pltLimitSweep',[{trace}],{layout});</script>\";\n",
+    "new PlotlyHtml(markup)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

**SOTA Prong-A upgrade** — `Search-11b-Metaheuristiques-Deep-Part3.ipynb` cell15: the ABC `limit` parameter sweep (Rosenbrock dim=10, 3 seeds) was rendered as an **ASCII table**. This PR adds a real **interactive Plotly line chart with error bands (std)** next to it, via my C548-L2 technique. The ASCII table is **kept** (raw numbers are pedagogically useful); the chart adds what ASCII cannot show.

| Prong | Rationale |
|-------|-----------|
| **A (real SOTA tool)** | ASCII table = degraded. The **error bands (std, 3 seeds)** were **INVISIBLE** in ASCII. The chart makes variance pedagogically visible — `limit=5` is visibly both **noisy** (large band) **and bad** (high mean). |
| **B (non-trivial problem)** | ABC metaheuristic (Karaboga 2005) on Rosenbrock (narrow valley) dim=10, 5 budget levels × 3 seeds. The finding ("large `limit` is better — counter-intuitive") is exactly what a chart with bands makes visible. |

## Technique — C548-L2 (my breakthrough, EPIC #3801)

`Formatter.Register(typeof(PlotlyHtml), (obj,w) => w.Write(markup), "text/html")` — non-generic register = **raw Plotly.js HTML via the kernel builtin**, **zero `#r "nuget:"`** (no package restore, no cold-download hang). Pioneered in Infer-19 (#6607), validated on App-8 (#6826, MERGED). Clean greenfield here (Plotly not previously loaded in this notebook).

```csharp
record PlotlyHtml(string Markup);
Formatter.Register(typeof(PlotlyHtml),
    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), "text/html");
// trace: scatter lines+markers with error_y { type:data, array:stdArr }
// layout: log Y axis (f spans 0.55 → 34.38), title in FR
new PlotlyHtml("<div id='pltLimitSweep'></div>" + plotlyScriptCDN + Plotly.newPlot(...))
```

## Verification (firsthand)

| Check | Result |
|-------|--------|
| Data fidelity (chart vs ASCII table) | **EXACT MATCH** — chart `y=[34.38, 2.85, 0.898, 1.126, 0.552]` = ASCII f-moyen; chart `error_y.array=[15.12, 1.72, 1.00, 1.03, 0.49]` = ASCII std. Real computed data, not fabricated. |
| C.2 real re-exec | **.net-csharp kernel, 9.5s, `execute_result` text/html (886-byte Plotly markup), ec=6, 0 errors** |
| Determinism | Seeded `Random(1/7/42)` → byte-identical across runs |
| nbformat | **VALID 4.5** (strict `nbformat.validate`) |
| C.1 (voluntary errors) | **0** |
| CRLF | **0** (LF preserved) |
| H.3 `validate_pr_notebooks.py` | **PASS** (9 code cells, .net-csharp) |
| C.3 scope | **cell15 only** (base=HEAD swap; 23 unchanged cells byte-identical to main, no papermill-timestamp churn). Diff +63/-9. |
| Catalog (R1) | byte-identical (no CATALOG-STATUS touched) |

## Note on visual rendering

The Plotly chart loads client-side via `cdn.plot.ly/plotly-2.35.2.min.js` (same CDN as App-8 #6826, MERGED). **I am a BLIND lane (GLM) — visual rendering QA (does the chart display correctly, are the log-axis + error bands legible?) is deferred to ai-01 or a MiniMax lane.** What I verify firsthand is **data fidelity** (exact numeric match chart↔ASCII) + **structural correctness** (valid Plotly.newPlot call, execute_result text/html, real re-exec) — the textual guarantees a blind lane can honestly make (cf my forensic on #6826).

See #3801 (partial — SOTA Prong-A, 1 notebook). Pattern: App-8 #6826, Infer-19 #6607.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
