### PR TITLE
feat(lean,gol): materialize nw steps 1-2 (wave-1 facts) in p4_succ_membership (BG run-3 verified)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1814,7 +1814,7 @@ DEMOS = {
     62: {
         "name": "HASHLIFE_P4_SUCC_MEMBERSHIP",
         "file": str(CONWAY_HASHLIFE_FILE) if CONWAY_HASHLIFE_FILE else "",
-        "line": 2904,
+        "line": 2929,
         "sorry_type": "sorry_replacement",
         "theorem_name": "p4_succ_membership",
         "theorem": "p4_succ_membership",
@@ -1824,8 +1824,8 @@ DEMOS = {
             "the p4_succ_membership decomposition (PR #6792, 2026-07-16). The\n"
             "former monolithic residual sorry (ex-L2892) is now 5 named\n"
             "sub-sorries under `refine (?mp, ?mpr)`: 4 mp quadrant cases (nw\n"
-            "L2904, ne L2906, sw L2908, se L2910) + 1 mpr routing case (L2915).\n"
-            "CURRENT TARGET = nw quadrant (L2904): from hypothesis\n"
+            "L2929, ne L2932, sw L2934, se L2936) + 1 mpr routing case (L2941).\n"
+            "CURRENT TARGET = nw quadrant (L2929): from hypothesis\n"
             "`hnw : p in out_nw.toGrid (2^k, 2^k)` prove membership\n"
             "`p in restrictGridTo (evolve (2^k) (toGrid (0,0) c)) (2^k) (2^(k+1))`\n"
             "(note: `c` is destructured into its 16 nodes at this proof point).\n"
@@ -1850,6 +1850,15 @@ DEMOS = {
             "first using hk1 : 1 <= k (Nat.sub_add_cancel / omega-driven\n"
             "`show`/`convert`) BEFORE the .mp application. Fixing that one\n"
             "conversion is likely all that separates the nw case from closing.\n"
+            "IN-FILE PROGRESS (BG run-3 2026-07-16, independently build-verified):\n"
+            "steps 1-2 are now MATERIALIZED IN-FILE above the nw sorry — hfacts\n"
+            "is destructured into 32 named components (hnw_nw_l..hse_se_w) and\n"
+            "the 4 wave-1 result facts hn1/r1, hn2/r2, hn4/r4, hn5/r5 are\n"
+            "established via node_wf_level_of_four + wave1_result_facts. DO NOT\n"
+            "re-derive them. REMAINING = steps 3-7: apply p4_wave2_ih_step on\n"
+            "(r1, r2, r4, r5) to obtain hcc_nw, then the hk1 rewrite above,\n"
+            "then centralCorrect_mem_shift .mp and the evolve_half_step +\n"
+            "evolve_cone_agree bridge to the goal window.\n"
             "When the nw case is proved, re-point `line` to the next sub-sorry.\n"
             "Harness caution (#6790): file_replace_lines build_check can\n"
             "false-positive; only an independent lake build is proof.\n"

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2901,7 +2901,33 @@ noncomputable def p4_succ_membership
     rcases hlhs with hnw | hne | hsw | hse
     · -- nw quadrant: p ∈ out_nw.toGrid (2^k, 2^k)
       -- goal: p ∈ restrictGridTo (evolve (2^k) (toGrid (0,0) <c destructuré en nodes>)) (2^k) (2^(k+1))
+      -- Step 1: destructure the 32-conjunct grandchild facts into hg1..hg32.
+      obtain ⟨hnw_nw_l, hnw_nw_w, hnw_ne_l, hnw_ne_w, hnw_sw_l, hnw_sw_w, hnw_se_l, hnw_se_w,
+              hne_nw_l, hne_nw_w, hne_ne_l, hne_ne_w, hne_sw_l, hne_sw_w, hne_se_l, hne_se_w,
+              hsw_nw_l, hsw_nw_w, hsw_ne_l, hsw_ne_w, hsw_sw_l, hsw_sw_w, hsw_se_l, hsw_se_w,
+              hse_nw_l, hse_nw_w, hse_ne_l, hse_ne_w, hse_sw_l, hse_sw_w, hse_se_l, hse_se_w⟩ := hfacts
+      -- Step 2: build 9 wave-1 result facts (level + cellWf) via node_wf_level_of_four + wave1_result_facts.
+      -- n1 = node nw_nw nw_ne nw_sw nw_se
+      have hn1 := node_wf_level_of_four hnw_nw_l hnw_ne_l hnw_sw_l hnw_se_l
+                                        hnw_nw_w hnw_ne_w hnw_sw_w hnw_se_w
+      have r1 := wave1_result_facts k hk1 (node nw_nw nw_ne nw_sw nw_se) hn1.2 hn1.1
+      -- n2 = node nw_ne ne_nw nw_se ne_sw
+      have hn2 := node_wf_level_of_four hnw_ne_l hne_nw_l hnw_se_l hne_sw_l
+                                        hnw_ne_w hne_nw_w hnw_se_w hne_sw_w
+      have r2 := wave1_result_facts k hk1 (node nw_ne ne_nw nw_se ne_sw) hn2.2 hn2.1
+      -- n4 = node nw_sw nw_se sw_nw sw_ne
+      have hn4 := node_wf_level_of_four hnw_sw_l hnw_se_l hsw_nw_l hsw_ne_l
+                                        hnw_sw_w hnw_se_w hsw_nw_w hsw_ne_w
+      have r4 := wave1_result_facts k hk1 (node nw_sw nw_se sw_nw sw_ne) hn4.2 hn4.1
+      -- n5 = node nw_se ne_sw sw_ne se_nw
+      have hn5 := node_wf_level_of_four hnw_se_l hne_sw_l hsw_ne_l hse_nw_l
+                                        hnw_se_w hne_sw_w hsw_ne_w hse_nw_w
+      have r5 := wave1_result_facts k hk1 (node nw_se ne_sw sw_ne se_nw) hn5.2 hn5.1
+      -- With r1, r2, r4, r5 we can now (step 3) apply p4_wave2_ih_step to get
+      -- centralCorrect (node r1_result r2_result r4_result r5_result) (k-1).
+      -- Left as sorry pending steps 3-7 (evolve_half_step + evolve_cone_agree assembly).
       sorry
+
     · -- ne quadrant: p ∈ out_ne.toGrid (2^k, 2^k + 2^level)
       sorry
     · -- sw quadrant: p ∈ out_sw.toGrid (2^k + 2^level, 2^k)


### PR DESCRIPTION
## Summary

BG prover **run-3** (DEMO 62, 2026-07-16, first run after the #6831 parser fix) produced **build-verified structural progress** on the **nw quadrant** sub-goal of `p4_succ_membership` (`HashlifeCorrectness.lean`). This PR promotes the preserved snapshot from the wtprover worktree to main, so the progress is shared with po-2026's manual track and the next BG run starts from it.

- **Step 1 in-file**: `hfacts` destructured into its 32 named grandchild components (`hnw_nw_l` .. `hse_se_w`).
- **Step 2 in-file**: the 4 wave-1 result facts `hn1/r1`, `hn2/r2`, `hn4/r4`, `hn5/r5` established via `node_wf_level_of_four` + `wave1_result_facts`.
- Remaining `sorry` explicitly scoped in-comment to steps 3-7 (`p4_wave2_ih_step` + the `k-1+2 = k+1` rewrite via `hk1` + `centralCorrect_mem_shift .mp` + `evolve_half_step`/`evolve_cone_agree` bridge).
- **DEMO 62 re-pointed** (`prover/config.py`): sub-sorry lines shifted by the +26 insertions (nw L2929, ne L2932, sw L2934, se L2936, mpr L2941) + description records the in-file progress so the next run does NOT re-derive steps 1-2. AST OK.

## Proof gates (pr-review-discipline §B)

1. **`grep -c sorry`**: 58 → 59 textual — the +1 is the word 'sorry' inside a new `--` comment. **Standalone-tactic sorries UNCHANGED 8 → 8** (CI `lean-conway.yml` baseline `8`, mode `standalone-tactic`, unaffected by comment prose).
2. **`lake build Conway.Life.HashlifeCorrectness`: SUCCESS** — independent post-run build by ai-01 (NOT the harness's own claim): 8498 jobs, exit 0, WSL wtprover warm cache. Harness final-verify had reported an incoherent `level_1_build=False ∧ errors=[]` — traced to a residual parser hole (lake-prefix `error: file:line:col:` format missed by the `": error:"` substring gate, forensic grain sent to po-2026); the independent build proves the snapshot is genuinely build-passing.
3. **No new axioms**: additions are `obtain`/`have` steps inside an existing proof + comments; no new declarations, no signature changes.
4. **Not a prover refactor** — config.py change is the DEMO 62 line re-point + description note only, required to keep the BG loop aimed at the right line after the insertion shift.

See #6724, See #1453, See #3846, See #6790

🤖 Generated with [Claude Code](https://claude.com/claude-code)