### PR TITLE
feat(infer,#3801): Infer-11 LDA phi-matrix Plotly heatmap (Prong-A)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
@@ -3245,16 +3245,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-22T19:17:30.590172Z",
-     "iopub.status.busy": "2026-06-22T19:17:30.589647Z",
-     "iopub.status.idle": "2026-06-22T19:17:30.668442Z",
-     "shell.execute_reply": "2026-06-22T19:17:30.668442Z"
+     "iopub.execute_input": "2026-07-16T10:07:58.026892Z",
+     "iopub.status.busy": "2026-07-16T10:07:58.026611Z",
+     "iopub.status.idle": "2026-07-16T10:07:58.183879Z",
+     "shell.execute_reply": "2026-07-16T10:07:58.183733Z"
     },
     "papermill": {
-     "duration": 0.097029,
-     "end_time": "2026-06-22T19:17:30.669451",
+     "duration": 0.167186,
+     "end_time": "2026-07-16T10:07:58.183952+00:00",
      "exception": false,
-     "start_time": "2026-06-22T19:17:30.572422",
+     "start_time": "2026-07-16T10:07:58.016766+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -3384,9 +3384,24 @@
      "text": [
       "\r\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div id=\"pltPhi\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltPhi',[{\"z\":[[0.3,0.3,0.3,0.02,0.02,0.02,0.02,0.01,0.01],[0.02,0.02,0.02,0.3,0.3,0.3,0.02,0.01,0.01],[0.02,0.01,0.01,0.02,0.02,0.02,0.3,0.3,0.3]],\"x\":[\"sport\",\"equipe\",\"match\",\"politique\",\"election\",\"vote\",\"musique\",\"concert\",\"artiste\"],\"y\":[\"Sport\",\"Politique\",\"Musique\"],\"type\":\"heatmap\",\"colorscale\":\"Viridis\",\"zmin\":0,\"zmax\":0.35,\"text\":[[0.3,0.3,0.3,0.02,0.02,0.02,0.02,0.01,0.01],[0.02,0.02,0.02,0.3,0.3,0.3,0.02,0.01,0.01],[0.02,0.01,0.01,0.02,0.02,0.02,0.3,0.3,0.3]],\"texttemplate\":\"%{text:.2f}\",\"hovertemplate\":\"P(%{x} | %{y}) = %{z:.2f}\\u003Cextra\\u003E\\u003C/extra\\u003E\"}],{\"title\":{\"text\":\"Matrice phi complete : P(mot | topic)\"},\"xaxis\":{\"title\":\"Vocabulaire\",\"side\":\"bottom\"},\"yaxis\":{\"title\":\"Topic\",\"autorange\":\"reversed\"},\"margin\":{\"t\":60,\"r\":20,\"b\":60,\"l\":90},\"height\":320});</script>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "// Setup Plotly (technique C548-L2) — la clause using DOIT preceder tout autre element (CS1529).\n",
+    "using Microsoft.DotNet.Interactive.Formatting;\n",
+    "using System.IO;\n",
+    "using System.Text.Json;\n",
+    "\n",
     "// Distribution phi (mots par topic) - simulee\n",
     "\n",
     "double[,] phiSimule = {\n",
@@ -3406,19 +3421,57 @@
     "for (int k = 0; k < numTopics; k++)\n",
     "{\n",
     "    Console.WriteLine($\"Topic {k+1} ({topicNames[k]}) :\");\n",
-    "    \n",
+    "\n",
     "    // Top mots\n",
     "    var topMots = Enumerable.Range(0, vocabSize)\n",
     "        .Select(v => (mot: vocabulaire[v], prob: phiSimule[k, v]))\n",
     "        .OrderByDescending(x => x.prob)\n",
     "        .Take(3);\n",
-    "    \n",
+    "\n",
     "    foreach (var (mot, prob) in topMots)\n",
     "    {\n",
     "        Console.WriteLine($\"  {mot,-12} : {prob:F2}\");\n",
     "    }\n",
     "    Console.WriteLine();\n",
-    "}"
+    "}\n",
+    "\n",
+    "// --- Visualisation Plotly (EPIC #3801 Prong-A) : heatmap complete de la matrice phi ---\n",
+    "// Technique C548-L2 : Plotly.js via Formatter.Register (kernel builtin, aucun #r nuget).\n",
+    "// Le top-3 ASCII ci-dessus masque la structure bloc-diagonale (chaque topic \"possede\"\n",
+    "// 3 mots a 0.30) ; la heatmap de la matrice COMPLETE 3x9 la rend immediatement visible.\n",
+    "\n",
+    "record PlotlyHtml(string Markup);\n",
+    "Formatter.Register(typeof(PlotlyHtml),\n",
+    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "\n",
+    "// z = phiSimule en listes de listes (Plotly attend un tableau 2D JSON)\n",
+    "var z = new List<List<double>>();\n",
+    "for (int k = 0; k < numTopics; k++) {\n",
+    "    var row = new List<double>();\n",
+    "    for (int v = 0; v < vocabSize; v++) row.Add(phiSimule[k, v]);\n",
+    "    z.Add(row);\n",
+    "}\n",
+    "string trace = JsonSerializer.Serialize(new Dictionary<string, object> {\n",
+    "    [\"z\"] = z,\n",
+    "    [\"x\"] = vocabulaire,\n",
+    "    [\"y\"] = topicNames,\n",
+    "    [\"type\"] = \"heatmap\",\n",
+    "    [\"colorscale\"] = \"Viridis\",\n",
+    "    [\"zmin\"] = 0.0, [\"zmax\"] = 0.35,\n",
+    "    [\"text\"] = z, [\"texttemplate\"] = \"%{text:.2f}\",\n",
+    "    [\"hovertemplate\"] = \"P(%{x} | %{y}) = %{z:.2f}<extra></extra>\",\n",
+    "});\n",
+    "string layout = JsonSerializer.Serialize(new Dictionary<string, object> {\n",
+    "    [\"title\"] = new Dictionary<string, string> { [\"text\"] = \"Matrice phi complete : P(mot | topic)\" },\n",
+    "    [\"xaxis\"] = new Dictionary<string, object> { [\"title\"] = \"Vocabulaire\", [\"side\"] = \"bottom\" },\n",
+    "    [\"yaxis\"] = new Dictionary<string, object> { [\"title\"] = \"Topic\", [\"autorange\"] = \"reversed\" },\n",
+    "    [\"margin\"] = new Dictionary<string, int> { [\"t\"] = 60, [\"r\"] = 20, [\"b\"] = 60, [\"l\"] = 90 },\n",
+    "    [\"height\"] = 320,\n",
+    "});\n",
+    "string markup = \"<div id=\\\"pltPhi\\\"></div>\" +\n",
+    "    \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
+    "    $\"<script>Plotly.newPlot('pltPhi',[{trace}],{layout});</script>\";\n",
+    "new PlotlyHtml(markup)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

**SOTA Prong-A upgrade** — `Infer-11-Topic-Models.ipynb` cell32: the LDA topic→word `phi` distribution (3 topics × 9-vocab, deterministic simulated matrix) was rendered as an **ASCII top-3 list**. This PR adds a real **interactive Plotly HEATMAP of the FULL 3×9 matrix** with value labels. The ASCII list is **kept**; the heatmap adds what ASCII hides.

| Prong | Rationale |
|-------|-----------|
| **A (real SOTA tool)** | ASCII list shows only top-3 words/topic, **hiding the block-diagonal structure** (each topic owns 3 vocab words at 0.30, rest at 0.02/0.01). The full-matrix heatmap makes topic separation instantly visible. |
| **B (non-trivial problem)** | LDA topic model. (#6702 already fixed a vocab-disjointness degeneracy Prong-B here; this change is an **independent cell32 viz**, no conflict.) |

## Technique — C548-L2 (my breakthrough, EPIC #3801) — 4th application

`Formatter.Register(typeof(PlotlyHtml), (obj,w) => w.Write(markup), "text/html")` — non-generic register = **raw Plotly.js HTML via the kernel builtin**, zero extra `#r "nuget:"` (Infer.NET's `Microsoft.ML.Probabilistic` was already loaded at cell2). Pioneered Infer-19 (#6607), validated App-8 (#6826, MERGED) + Search-11b (#6837). Same CDN `plotly-2.35.2.min.js`.

## Verification (firsthand)

| Check | Result |
|-------|--------|
| Data fidelity (heatmap z vs source phiSimule) | **EXACT MATCH** — z=`[[0.3,0.3,0.3,0.02,0.02,0.02,0.02,0.01,0.01],[0.02,0.02,0.02,0.3,0.3,0.3,0.02,0.01,0.01],[0.02,0.01,0.01,0.02,0.02,0.02,0.3,0.3,0.3]]` = source matrix byte-for-byte. Block-diagonal structure now visible. |
| C.2 real re-exec | **.net-csharp + Infer.NET package restore, 28.3s, `execute_result` text/html 916 bytes, ec=11, 0 errors** |
| Determinism | `phiSimule` literal (no inference randomness in this cell) → byte-identical across runs |
| nbformat | **VALID 4.5** (strict `nbformat.validate`) |
| C.1 (voluntary errors) | **0** |
| CRLF | **0** (LF preserved) |
| H.3 `validate_pr_notebooks.py` | **PASS** (17 code cells, .net-csharp) |
| C.3 scope | **cell32 only** (base=HEAD swap; all other cells byte-identical to main, no papermill-timestamp churn). Diff +63/-10. |
| Catalog (R1) | byte-identical |

## Note on visual rendering

Heatmap renders client-side via `cdn.plot.ly/plotly-2.35.2.min.js`. **I am a BLIND lane (GLM) — visual rendering QA (does the Viridis heatmap display, are the 0.30 blocks visibly brighter than 0.02 noise, are texttemplate labels legible?) is deferred to ai-01 or a MiniMax lane.** What I verify firsthand is **data fidelity** (exact numeric match z↔phiSimule) + **structural correctness** (valid Plotly.newPlot heatmap call, execute_result text/html, real re-exec) — the textual guarantees a blind lane can honestly make (cf my forensic on #6826, L594-L1).

See #3801 (partial — SOTA Prong-A, 1 notebook). 4th C548-L2 application: Infer-19 #6607 → App-8 #6826 → Search-11b #6837 → Infer-11.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
