### PR TITLE
fix(prover,#6790): parser lake-prefix hole — kill false-negative (grain a-2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -496,9 +496,19 @@ class LeanVerifier:
 
     @staticmethod
     def _extract_errors(output: str) -> list:
-        """Extract error lines from lake build output."""
+        """Extract error lines from lake build output.
+
+        Alignment with ``prover.tools._parse_lean_errors`` (grain a-2, #6790):
+        Lake emits errors in a **lake-prefix** format with ``error:`` at the
+        START of the line -- ``error: <file>:<line>:<col>: <msg>`` -- which
+        carries NO ``": error:"`` substring.  The bare substring gate alone
+        missed that format, so the authority and the inline parser disagreed
+        (``success`` flipped via exit code, but 0 parsed errors -> false
+        negative).  Catch BOTH forms here.
+        """
         errors = []
         for line in output.split("\n"):
-            if ": error:" in line:
-                errors.append(line.strip())
+            stripped = line.strip()
+            if ": error:" in stripped or stripped.startswith("error:"):
+                errors.append(stripped)
         return errors

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -401,7 +401,6 @@ def _reverify_compiles_clean(filepath: str, tactic_tools) -> bool:
     """
     from .verifier import get_verifier
     from .tools import _parse_lean_errors  # authoritative parser (#6831)
-    from .lean_utils import resolve_lake_module
     try:
         verifier = get_verifier()
         if verifier is not None:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -118,24 +118,45 @@ def _parse_lean_errors(raw_output: str) -> list:
     ``level_1_build == False AND errors == []`` that let a non-compiling
     snapshot be preserved (DEMO 62, ``HashlifeCorrectness.lean:2940``).
 
-    This helper mirrors the authoritative substring detection so the inline
-    tools agree with ``LeanVerifier`` on what counts as an error.  Each entry
-    carries ``line`` (``int`` when a ``line:col`` is present, else ``None``)
-    and ``message`` (the text following ``": error:"``).
+    This helper mirrors the authoritative detection so the inline tools agree
+    with ``LeanVerifier`` on what counts as an error.  Each entry carries
+    ``line`` (``int`` when a ``line:col`` is present, else ``None``) and
+    ``message`` (the text following the error marker).
+
+    Grain a-2 (#6790 forensic, BG run-2/run-3, msg-20260716T084204-myaddh): the
+    real Lake output also emits errors in a **lake-prefix** format with
+    ``error:`` at the START of the line -- ``error: <file>:<line>:<col>: <msg>``
+    (e.g. ``error: Conway/Life/HashlifeCorrectness.lean:2940:79: Application
+    type mismatch``).  That format carries NO ``": error:"`` substring, so the
+    bare substring gate ``if ": error:" not in line: continue`` SKIPPED it --
+    the parser returned ``[]`` even though a real compile error existed, and
+    the false-negative ``level_1_build == False AND errors == []`` persisted
+    (the authority ``LeanVerifier`` still set ``success=False`` via the exit
+    code, hence the incoherent signature).  Fix: go **regex-first** -- try the
+    two positional regexes (standard ``<f>:<l>:<c>: error:`` and lake-prefix
+    ``error: <f>:<l>:<c>:``) on every line regardless of substring, then fall
+    back to substring / line-start detection for non-positional errors.
     """
     errors = []
     for line in raw_output.split("\n"):
-        if ": error:" not in line:
-            continue
+        # Standard positional: <file>:<line>:<col>: error: <msg>
         m = re.search(r"(\d+):(\d+): error: (.*)", line)
         if m:
             errors.append({"line": int(m.group(1)), "message": m.group(3)})
             continue
+        # Lake-prefix positional: error: <file>:<line>:<col>: <msg>  (grain a-2)
         m = re.search(r"error: .*?(\d+):(\d+): (.*)", line)
         if m:
             errors.append({"line": int(m.group(1)), "message": m.group(3)})
             continue
-        errors.append({"line": None, "message": line.split(": error:", 1)[1].strip()})
+        # Non-positional, substring form: <file>: error: <msg> (module-level)
+        if ": error:" in line:
+            errors.append({"line": None, "message": line.split(": error:", 1)[1].strip()})
+            continue
+        # Non-positional, line-start form: error: <msg> (message-only / lake-prefix no-col)
+        if line.lstrip().startswith("error: "):
+            errors.append({"line": None, "message": line.lstrip().split("error: ", 1)[1].strip()})
+            continue
     return errors
 
 def _read_lines_from_source(source: str, start: int, end: int) -> str:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -3051,6 +3051,54 @@ def test_parse_lean_errors_matches_authoritative_substring_contract():
     assert "cannot synthesize type" in inline[0]["message"]
 
 
+def test_parse_lean_errors_catches_lake_prefix_format():
+    """Grain a-2 regression (#6790 forensic, BG run-2, msg-myaddh).
+
+    The real Lake output emits errors in a **lake-prefix** format with
+    ``error:`` at the START of the line -- ``error: <file>:<line>:<col>: <msg>``
+    (verbatim from DEMO 62 run-2: ``error: Conway/Life/HashlifeCorrectness.lean:
+    2940:79: Application type mismatch``).  That format carries NO ``": error:"``
+    substring, so the bare substring gate ``if ": error:" not in line: continue``
+    SKIPPED it -> the parser returned ``[]`` even though a real compile error
+    existed -> the false-negative persisted.  This test pins the lake-prefix
+    contract so it cannot regress.
+    """
+    from prover.tools import _parse_lean_errors
+
+    # Verbatim lake-prefix error from the real BG run-2 output.
+    line = "error: Conway/Life/HashlifeCorrectness.lean:2940:79: Application type mismatch"
+    # Pin the empirical hole: this is NOT a substring-form line.
+    assert ": error:" not in line
+    assert line.lstrip().startswith("error: ")
+    # The parser must now catch it (regression: previously returned []).
+    errors = _parse_lean_errors(line + "\n")
+    assert len(errors) == 1, errors
+    assert errors[0]["line"] == 2940, errors
+    assert errors[0]["message"].endswith("Application type mismatch"), errors
+    # A mixed stream must count BOTH the lake-prefix and a standard line:col.
+    raw = (
+        "info: compiling\n"
+        f"{line}\n"
+        "Foo.lean:12:3: error: unsolved goals\n"
+    )
+    errors = _parse_lean_errors(raw)
+    assert len(errors) == 2, errors
+    assert {e["line"] for e in errors} == {2940, 12}, errors
+
+
+def test_extract_errors_catches_lake_prefix_format_authority():
+    """Grain a-2 alignment (#6790): the authoritative ``LeanVerifier.
+    _extract_errors`` must catch the lake-prefix format too, keeping parity
+    with ``_parse_lean_errors`` so the two never disagree again."""
+    from lean_server import LeanVerifier
+
+    line = "error: Conway/Life/HashlifeCorrectness.lean:2940:79: Application type mismatch"
+    assert ": error:" not in line  # pin the hole
+    extracted = LeanVerifier._extract_errors(line + "\n")
+    assert len(extracted) == 1, extracted
+    assert extracted[0].startswith("error:"), extracted
+
+
 def test_reverify_compiles_clean_false_on_fresh_build_failure(monkeypatch):
     """#6790 interim guard hardening: the re-verify trust gate must return False
     when the independent fresh build FAILS — this is the case where the


### PR DESCRIPTION
Follow-up to #6831 (bug a). The authoritative error parser still missed a whole class of real Lake errors, leaving the `level_1_build == False AND errors == []` false-negative alive.

## Root cause (grain a-2, #6790 forensic BG run-2, ai-01 msg-myaddh)

Lake emits errors in a **lake-prefix** format with `error:` at the START of the line:

```
error: Conway/Life/HashlifeCorrectness.lean:2940:79: Application type mismatch
```

That line carries NO `": error:"` substring, so the bare gate `if ": error:" not in line: continue` SKIPPED it → `_parse_lean_errors` returned `[]` even though a real compile error existed. Meanwhile `LeanVerifier` still set `success=False` via the non-zero exit code, so the two disagreed (incoherent signature), and the false-negative verify pattern that lets a non-compiling snapshot be PRESERVED persisted.

Firsthand proof of the hole (before fix):

```python
_parse_lean_errors("error: Conway/Life/HashlifeCorrectness.lean:2940:79: Application type mismatch")
# -> []   (SKIPPED)
": error:" in line  # -> False
```

## Fix

Go **regex-first** in `_parse_lean_errors`: try the two positional regexes (standard `<f>:<l>:<c>: error:` and lake-prefix `error: <f>:<l>:<c>:`) on every line regardless of substring, then fall back to substring / line-start detection for non-positional errors (module-level `<file>: error:`, message-only `error: <msg>`).

Apply the SAME gate widening to the authority `LeanVerifier._extract_errors` to keep alignment (explicit ai-01 ask).

Also drop a dead import (`resolve_lake_module`) from `_reverify_compiles_clean` — noted in ai-01 msg-6mu0ze (#6835 review).

## Verification (firsthand, this machine — `myia-po-2026:CoursIA-2`)

- **Empirical, after fix**: `_parse_lean_errors(lake_prefix_line)` → `[{'line': 2940, 'message': 'Application type mismatch'}]`; mixed stream (lake-prefix + standard `line:col` + module-level substring) → 3/3 caught; `_extract_errors` parity 1/1.
- **pytest** (`python3.14 -m pytest tests/test_prover_guards.py`):
  - New regression tests PASS: `test_parse_lean_errors_catches_lake_prefix_format`, `test_extract_errors_catches_lake_prefix_format_authority`.
  - Parser/guard cohort (8 tests incl. existing `reverify_compiles_clean_*`, `matches_authoritative_substring_contract`, `catches_module_level_no_linecol`): **8/8 PASS**.
  - Full file: **161/163 PASS**. The 2 failures are pre-existing + unrelated to this change:
    - `test_coordinator_agent_has_set_attack_plan_tool` — needs `OPENAI_API_KEY` env (credentials).
    - `test_path_constants_resolve_to_active_workspace` — stale `STALE_POST_ABSORPTION` assertion after Voting.lean #4365 absorption.
    - Both **confirmed failing identically on stashed baseline** (G.1 firsthand: `git stash` of my 4 files → same 2 fail, same `Voting.lean exists` assertion).

## Scope

4 files, +89/−11, atomic (single subject: lake-prefix parser hole + dead-import cleanup + regression tests).

See #6790, See #1453

Co-Authored-By: Claude <noreply@anthropic.com>
