### PR TITLE
fix(prover,#6790): _parse_lean_errors accepts list input — kill run-4 AttributeError crash

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -103,7 +103,7 @@ def _count_sorries_from_build_output(raw_output: str) -> int:
 
 
 
-def _parse_lean_errors(raw_output: str) -> list:
+def _parse_lean_errors(raw_output) -> list:
     """Parse Lean/Lake error lines from build output.
 
     Root-cause fix for the metrics=0 / false-negative integrity bug (#6790):
@@ -136,7 +136,20 @@ def _parse_lean_errors(raw_output: str) -> list:
     two positional regexes (standard ``<f>:<l>:<c>: error:`` and lake-prefix
     ``error: <f>:<l>:<c>:``) on every line regardless of substring, then fall
     back to substring / line-start detection for non-positional errors.
+
+    Crash fix (#6790 forensic, BG run-4, exit 1): the preserve/revert gate
+    ``_reverify_compiles_clean`` falls back to the pre-parsed ``errors`` LIST
+    when ``raw_output`` is empty (``rv.get("raw_output", "") or
+    rv.get("errors", "")``) — a list has no ``.split`` and the resulting
+    ``AttributeError`` escaped the gate's try/except (the parse happens after
+    it) and killed the whole run, losing the trace and the [BG] postlude.
+    Normalize list/tuple input to one line per entry so every call site parses
+    identically whether it feeds raw build output or an already-split list.
     """
+    if raw_output is None:
+        raw_output = ""
+    elif isinstance(raw_output, (list, tuple)):
+        raw_output = "\n".join(str(item) for item in raw_output)
     errors = []
     for line in raw_output.split("\n"):
         # Standard positional: <file>:<line>:<col>: error: <msg>

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -3218,3 +3218,68 @@ def test_reverify_compiles_clean_requires_zero_errors_even_on_success(monkeypatc
         "re-verify must return False when level_1_build=True but raw_output "
         "still carries a parseable error line"
     )
+
+
+def test_parse_lean_errors_accepts_list_input():
+    """Crash regression (#6790 forensic, BG run-4 exit 1, provers.py:417).
+
+    ``_reverify_compiles_clean`` falls back to the pre-parsed ``errors`` LIST
+    when ``raw_output`` is empty (``rv.get("raw_output", "") or
+    rv.get("errors", "")``).  ``_parse_lean_errors`` did ``raw_output.split``
+    unconditionally -> ``AttributeError: 'list' object has no attribute
+    'split'`` -> the whole run crashed at the preserve/revert gate (trace +
+    [BG] postlude lost).  The parser must accept str, list/tuple, and None.
+    """
+    from prover.tools import _parse_lean_errors
+
+    # Verbatim error shape from the real run-4 rv["errors"] fallback.
+    err_list = [
+        "error: Conway/Life/HashlifeCorrectness.lean:2860:85: (deterministic) timeout",
+        "Foo.lean:12:3: error: unsolved goals",
+    ]
+    errors = _parse_lean_errors(err_list)  # must NOT raise AttributeError
+    assert len(errors) == 2, errors
+    assert {e["line"] for e in errors} == {2860, 12}, errors
+
+    # Tuple input parses identically to list input.
+    assert _parse_lean_errors(tuple(err_list)) == errors
+
+    # None degrades to "no errors", not a crash.
+    assert _parse_lean_errors(None) == []
+
+    # Plain-string behavior is unchanged (same two errors via a joined stream).
+    assert _parse_lean_errors("\n".join(err_list)) == errors
+
+
+def test_reverify_survives_errors_list_fallback(monkeypatch):
+    """End-to-end crash regression (#6790, BG run-4): ``_reverify_compiles_clean``
+    must survive a compile() result with NO raw_output and a LIST ``errors``
+    (the exact run-4 shape) and return False (errors present -> revert), not
+    die with AttributeError past its try/except."""
+    import json
+    import prover.verifier as vmod
+    from prover.provers import _reverify_compiles_clean
+
+    class _Verifier:
+        @classmethod
+        def invalidate(cls, filepath):
+            pass
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _Verifier())
+
+    class _TacticTools:
+        def compile(self, check_axioms=False):
+            # Run-4 shape: empty raw_output -> the `or` picks the errors LIST.
+            return json.dumps({
+                "level_1_build": False,
+                "raw_output": "",
+                "errors": [
+                    "error: Conway/Life/HashlifeCorrectness.lean:2860:85: (deterministic) timeout",
+                ],
+            })
+
+    result = _reverify_compiles_clean("dummy/path.lean", _TacticTools())
+    assert result is False, (
+        "re-verify must return False (revert) on a broken snapshot reported "
+        "via the errors-list fallback -- and must not crash with AttributeError"
+    )


### PR DESCRIPTION
## Summary

BG **run-4** (DEMO 62, GOL nw L2904) died with **exit 1** at the preserve/revert gate. Root cause (forensic ai-01 16/07, log `ai01_demo62_wt4_1784191816.log`):

```
provers.py:909 -> provers.py:417 _reverify_compiles_clean -> tools.py:127 _parse_lean_errors
AttributeError: 'list' object has no attribute 'split'
```

`_reverify_compiles_clean` falls back to the pre-parsed **errors LIST** when `raw_output` is empty (`rv.get("raw_output", "") or rv.get("errors", "")`), and `_parse_lean_errors` did `raw_output.split("\n")` unconditionally. The parse happens **after** the gate's try/except, so the exception escaped and killed the whole run — trace + [BG] postlude lost.

## Fix

Defensive normalization at the top of the **authoritative parser** (single point, all call sites covered): accept `str | list | tuple | None` — list/tuple joined one entry per line, None -> "". String behavior byte-identical (verified by the existing a-2 tests, untouched and passing).

## Tests

- `test_parse_lean_errors_accepts_list_input` — direct crash regression: verbatim run-4 errors-list shape parses (2 errors, lines {2860, 12}), tuple parity, None -> [].
- `test_reverify_survives_errors_list_fallback` — end-to-end on the exact run-4 `rv` shape (empty raw_output + errors list): returns **False (revert)**, no crash.
- Cohort `parse_lean_errors or reverify or extract_errors`: **10/10 PASS** local.

## Sequencing

Complements #6845 (grain a-2, merged): a-2 fixed *what* the parser catches, this fixes *what input types* it survives. **Unblocks BG run-5** (gated on this crash fix per run-4 forensic). Residuals (b) bookkeeping + (c) success semantics stay with po-2026.

See #6790, #1453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)