### PR TITLE
fix(probas): PyMC-17 cell[5] stale markdown — describe matplotlib plot, not removed ASCII

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
@@ -186,10 +186,11 @@
    "source": [
     "## 3. Visualisation : trajectoire vraie, observations brutes, estimation filtree\n",
     "\n",
-    "Le graphe ASCII ci-dessous aligne, a chaque pas de temps (un pas sur deux pour la\n",
-    "lisibilite), les trois series. Les **observations** (`.`) oscillent fortement autour de\n",
-    "la vraie trajectoire (`|`) a cause du capteur bruite ($R = 4$). L'**estimation filtree**\n",
-    "(`#`, esperance du posterieur) lisse ce bruit et suit fidelement la trajectoire cachee.\n"
+    "Le graphique ci-dessous trace, a chaque pas de temps, les trois series : **etat vrai**\n",
+    "(trait noir), **observations** (points gris, bruit du capteur $R = 4$) et **estimation\n",
+    "filtree** (trait bleu, esperance du posterieur). La **bande bleue** ($\\pm 1$ ecart-type,\n",
+    "$\\sqrt{\\text{filtVar}}$) montre l'incertitude residuelle : elle se resserre au fur et a\n",
+    "mesure que le filtre corrige le bruit."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Follow-up to #6834 (PyMC-17 Kalman ASCII -> matplotlib, merged): the intro markdown `cell[5]` still described the **removed ASCII chart** — char codes `|`/`.`/`#`, « un pas sur deux pour la lisibilité » — and did not mention the new **±1σ `fill_between` band**. A student reading cell[5] then cell[6] saw a description that does not match the figure (§B-3 pedagogical coherence, flagged non-blocking in the #6834 forensic by po-2024, with a ready FR drop-in).

## Change

Applied the drop-in: the paragraph now describes the matplotlib time-vs-position plot — état vrai (trait noir), observations (points gris, $R=4$), estimation filtrée (trait bleu) et bande ±1σ ($\sqrt{\text{filtVar}}$) qui se resserre.

## Safety

- **Markdown-only** : 1 cell source, 0 code cells, outputs + execution_count byte-identical (C.2 exception markdown).
- Catalog byte-identical (no generated files touched).

See #3801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)