### PR TITLE
fix(tools): detect_ascii_workaround excludes _output papermill artifacts

### DIFF
--- a/scripts/notebook_tools/detect_ascii_workaround.py
+++ b/scripts/notebook_tools/detect_ascii_workaround.py
@@ -342,13 +342,38 @@ def _kernel(nb: dict) -> str:
     return nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
 
 
+# Dossiers a ignorer (alignes sur la convention check_notebook_navlinks.py:SKIP_DIRS).
+SKIP_DIRS = {
+    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
+    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
+    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
+}
+
+# Artefacts papermill (gitignored mais presents en local apres exec). Sans ce
+# filtre, le detecteur flag des _output STALE : la source canonique est editee
+# (defect corrige) sans regen du _output, qui porte encore l'ancienne bar ASCII.
+# Cas firsthand : SC-17 _output cell10 `bar="#"*votes` alors que la source
+# canonique n'a plus la bar (c.597 forensic #6843). Dans ce repo les _output
+# sont des SUFFIXES de nom de fichier (*_output.ipynb), pas des dossiers.
+_OUTPUT_SUFFIX = "_output.ipynb"
+
+
+def _should_skip(rel: Path) -> bool:
+    if any(part in SKIP_DIRS for part in rel.parts):
+        return True
+    return rel.name.endswith(_OUTPUT_SUFFIX)
+
+
 def _iter_notebooks(root: Path, family: str | None):
     base = root / "MyIA.AI.Notebooks"
     if family:
         base = base / family
     if not base.exists():
         return
-    yield from sorted(base.rglob("*.ipynb"))
+    for nb in sorted(base.rglob("*.ipynb")):
+        if _should_skip(nb.relative_to(base)):
+            continue
+        yield nb
 
 
 def _human_report(results: list[dict]) -> str:

--- a/scripts/tests/test_detect_ascii_workaround.py
+++ b/scripts/tests/test_detect_ascii_workaround.py
@@ -1,0 +1,71 @@
+"""Tests for scripts/notebook_tools/detect_ascii_workaround.py — Prong-A ASCII detector.
+
+Validates the artifact filter (c.598, fix to c.597 forensic finding #6843):
+- _output papermill artifacts (filename suffix *_output.ipynb in this repo) are EXCLUDED
+- canonical source is still scanned
+- the documented SC-17 stale-artifact case firsthand: source has no bar, _output does
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from notebook_tools.detect_ascii_workaround import SKIP_DIRS, _should_skip, _iter_notebooks
+
+
+class TestSkipDirs:
+    """The artifact filter — prevents stale _output false positives."""
+
+    def test_should_skip_output_filename_suffix(self):
+        """A *_output.ipynb filename (papermill artifact) is flagged for skip.
+
+        In this repo, _output artifacts are filename SUFFIXES, not directories
+        (158 *_output.ipynb files, 0 _output/ dirs). This is the actual SC-17
+        stale-artifact case from c.597.
+        """
+        rel = Path("SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting_output.ipynb")
+        assert _should_skip(rel) is True
+
+    def test_should_not_skip_canonical_source(self):
+        """The canonical source (no _output suffix) is NOT skipped."""
+        rel = Path("SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb")
+        assert _should_skip(rel) is False
+
+    def test_should_skip_dir_segments(self):
+        """A path under a SKIP_DIR (e.g. .lake) is also skipped."""
+        rel = Path("SomeFam/.lake/build/nb.ipynb")
+        assert _should_skip(rel) is True
+
+    def test_skip_dirs_align_with_navlink_convention(self):
+        """SKIP_DIRS mirrors check_notebook_navlinks.py:SKIP_DIRS (repo convention)."""
+        expected = {
+            ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
+            ".ipynb_checkpoints", ".pytest_cache", "worktrees", "foundry-lib",
+        }
+        assert expected.issubset(SKIP_DIRS), f"missing: {expected - SKIP_DIRS}"
+
+    @pytest.mark.parametrize("skip_dir", sorted(SKIP_DIRS))
+    def test_each_skip_dir_caught_in_path(self, skip_dir):
+        """Any SKIP_DIR appearing as a path segment triggers skip."""
+        rel = Path(f"some/prefix/{skip_dir}/nb.ipynb")
+        assert _should_skip(rel) is True, f"{skip_dir} not caught"
+
+
+class TestIterNotebooksExcludesOutput:
+    """The walk does not yield *_output.ipynb artifacts."""
+
+    def test_no_output_artifacts_in_walk(self, tmp_path):
+        """A tree with canonical + _output twin yields ONLY canonical."""
+        nb_root = tmp_path / "MyIA.AI.Notebooks" / "Fam"
+        nb_root.mkdir(parents=True)
+        canonical = nb_root / "Nb.ipynb"
+        artifact = nb_root / "Nb_output.ipynb"
+        canonical.write_text('{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}', encoding="utf-8")
+        artifact.write_text('{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}', encoding="utf-8")
+
+        walked = [p.name for p in _iter_notebooks(tmp_path, family="Fam")]
+        assert walked == ["Nb.ipynb"], f"_output artifact leaked into walk: {walked}"
+

--- a/scripts/tests/test_detect_ascii_workaround.py
+++ b/scripts/tests/test_detect_ascii_workaround.py
@@ -11,9 +11,15 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Convention siblings (test_notebook_tools_pure.py, test_execute_qcpy_docker.py) :
+# inserer scripts/notebook_tools/ et importer le module directement. Importer
+# `notebook_tools.detect_ascii_workaround` (package-style) enregistrerait le
+# REPERTOIRE comme namespace package `notebook_tools` dans sys.modules, masquant
+# le module notebook_tools.py pour les autres tests de la session pytest
+# (ImportError "unknown location" en CI Scripts Tests).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "notebook_tools"))
 
-from notebook_tools.detect_ascii_workaround import SKIP_DIRS, _should_skip, _iter_notebooks
+from detect_ascii_workaround import SKIP_DIRS, _should_skip, _iter_notebooks
 
 
 class TestSkipDirs:


### PR DESCRIPTION
## Summary

Implements the fix I flagged in my c.597 forensic review of #6843 (`detect_ascii_workaround.py`). The detector scanned `*_output.ipynb` papermill artifacts and flagged **STALE** outputs whose canonical source had already been fixed.

| File | Change |
|------|--------|
| `scripts/notebook_tools/detect_ascii_workaround.py` | Add `_should_skip()` filter to `_iter_notebooks()` — skip SKIP_DIRS path segments (`.lake`, `.ipynb_checkpoints`, …) AND `*_output.ipynb` filename suffix. +26/-1. |
| `scripts/tests/test_detect_ascii_workaround.py` | NEW — 15 regression tests pinning the filter behavior. |

## The bug (c.597 forensic finding, firsthand)

`SC-17-E2E-Verifiable-Voting_output.ipynb` cell10 carries `bar = "#" * votes` — but the **canonical** `SC-17-E2E-Verifiable-Voting.ipynb` does **not** have the bar. The `_output` is a stale artifact (source edited, output not regenerated). The detector flagged the stale artifact as a defect.

## G.1 correction during this PR (verify-before-claiming)

My first attempt copied the `SKIP_DIRS` path-segment filter verbatim from the sibling `check_notebook_navlinks.py`. My own regression test (`test_should_skip_output_artifact`) **caught that it didn't work**: in this repo `_output` artifacts are **filename suffixes** (`*_output.ipynb`), not directory segments —

```
158 *_output.ipynb files, 0 _output/ dirs   (verified firsthand)
```

So checking `rel.parts` (directory segments) never matched. The fix now checks **both**: the filename suffix (`rel.name.endswith("_output.ipynb")`) AND the SKIP_DIRS path segments. My initial "Test 1 passed" was misleading (the artifact wasn't in the fresh worktree at all); the parameterized test forced the real verification.

## Scope note (honest severity)

`*_output.ipynb` files are **gitignored** (`git check-ignore` matches; 0 tracked). So there is **no CI `--check` false-positive on committed files** — severity is lower than the c.597 review speculated. The fix still matters for **local worker runs** where papermill drops `_output` next to the canonical notebook and a worker running the detector by hand gets misled.

## Verification (firsthand)

| Check | Result |
|-------|--------|
| Functional: `SC-17..._output.ipynb` skipped | **True** |
| Functional: canonical `SC-17....ipynb` skipped | **False** (scanned) |
| `.lake` path segment skipped | **True** |
| `python -m pytest test_detect_ascii_workaround.py` | **15 passed** (incl. parametrized per-SKIP_DIR) |
| AST | **OK** (both files) |
| CRLF | **0** (both files) |
| Diff scope | tool +26/-1, NEW test file |

See #6843 (the tool, MERGED), c.597 forensic review (https://github.com/jsboige/CoursIA/pull/6843#issuecomment-4990918321).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
