### PR TITLE
fix(prover,#6790): clamp implicit_sorry on build-fail (grain b1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1923,7 +1923,16 @@ class TacticTools:
         text_sorry_count = count_real_sorries(content)
         build_sorry_count = _count_sorries_from_build_output(raw_output)
         sorry_count = max(text_sorry_count, build_sorry_count)
-        implicit_sorry = build_sorry_count - text_sorry_count
+        # Grain (b1) #6790 (ai-01 msg-20260716T110247): implicit_sorry counts
+        # the sorries Lake's warnings surface that the text scan missed
+        # (implicit sorry from apply?/exact?/solve_by_elim). On a FAILED build
+        # Lake never reaches the warning pass -> build_sorry_count == 0 while
+        # text_sorry_count == N -> implicit = -N (absurd negative, observed as
+        # implicit_sorry_count: -8 in BG run-3). Gate on the build outcome: 0
+        # when the build did not pass, else max(0, build - text). The reported
+        # sorry_count = max(text, build) above is already conservative-correct
+        # and is unaffected, so this only fixes the cosmetic negative.
+        implicit_sorry = 0 if not success else max(0, build_sorry_count - text_sorry_count)
 
         sorry_delta = self._original_sorry_count - sorry_count
         level_1 = success

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1621,6 +1621,56 @@ def test_build_check_or_revert_real_solve_records_zero(tmp_path, monkeypatch):
     assert tt._min_compile_sorry_count == 0
 
 
+def test_compile_implicit_sorry_clamped_on_build_failure(tmp_path, monkeypatch):
+    """Grain (b1) #6790 (ai-01 msg-20260716T110247 / T105900-ba9llf): on a FAILED
+    build, Lake never reaches the 'uses sorry' warning pass -> build_sorry_count
+    is 0 while text_sorry_count is N -> the naive ``build - text`` underflows
+    to a negative (observed as ``implicit_sorry_count: -8`` in BG run-3). The
+    clamp ``0 if not success else max(0, build - text)`` must yield 0, not -N.
+
+    sorry_count = max(text, build) is conservative-correct and unaffected, so
+    this only fixes the cosmetic negative (no consumer branches on it -- the
+    field is trace/report-only).
+    """
+    import json
+    import prover.verifier as vmod
+    import prover.tools as tmod
+
+    # File with 8 explicit sorries -> text_sorry_count = 8.
+    sorries = "theorem t : True := by sorry\n" * 8
+    fake = tmp_path / "Clamp.lean"
+    fake.write_text(sorries, encoding="utf-8")
+
+    # Build FAIL + empty raw_output (Lake exited before the warning pass) ->
+    # build_sorry_count = 0. The naive formula would give 0 - 8 = -8.
+    class _FailVerifier:
+        def verify_project_file(self, rel, force=False):
+            return {"success": False, "errors": "", "raw_output": ""}
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _FailVerifier())
+    # compile() calls resolve_lake_module(self._filepath) -- mock it so the
+    # fake path resolves without a real lake project.
+    monkeypatch.setattr(
+        tmod, "resolve_lake_module", lambda fp: (str(tmp_path), "Clamp"),
+    )
+
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=1, indentation=0,
+        indent_str="", full_file=sorries,
+    )
+    tt = TacticTools(state, str(fake), sctx)
+
+    out = json.loads(tt.compile())
+    # The regression: implicit_sorry_count must NOT be negative on build-fail.
+    assert out["implicit_sorry_count"] == 0, (
+        f"build-fail must clamp implicit_sorry to 0, not underflow to negative "
+        f"(got {out['implicit_sorry_count']}); #6790 grain b1"
+    )
+    # The conservative reported sorry_count is unaffected (text count carried).
+    assert out["sorry_count"] == 8, out
+
+
 def test_build_check_or_revert_forces_independent_build(tmp_path, monkeypatch):
     """Bug 2 (#6790 forensic): the snapshot-promotion gate must force a FRESH
     lake build, not trust a cached content-hash verdict.


### PR DESCRIPTION
Grain (b1) of the #6790 calibration sequence (ai-01 msg-20260716T110247 / T105900-ba9llf, GO decision). Observed in BG run-3: `implicit_sorry_count: -8` (absurd negative) whenever the build FAILED.

## Root cause

`implicit_sorry = build_sorry_count - text_sorry_count` (tools.py). `build_sorry_count` counts `'uses sorry'` warnings from the build log; on a FAILED build Lake never reaches the warning pass → `build_sorry_count == 0` while the file has N explicit sorries (`text_sorry_count == N`) → `implicit = 0 - N = -N`. Same build-failure class as a-2 / Run-4 crash (a broken build produces incoherent derived metrics).

## Fix (ai-01 semantics)

Gate on the build outcome:

```python
implicit_sorry = 0 if not success else max(0, build_sorry_count - text_sorry_count)
```

The reported `sorry_count = max(text, build)` (line above) is already conservative-correct and is **unaffected**, so this only fixes the cosmetic negative.

## Consumer gate (firsthand G.1, ai-01 protocol step 1)

`grep -rn 'implicit_sorry|implicit_sorry_count' prover/*.py agents/workflow/trace/config`:

- The variable `implicit_sorry` (tools.py:1939) is consumed by **(a)** the trace log string (cosmetic) and **(b)** the `implicit_sorry_count` output field of `compile()`.
- **No consumer branches on the value** (it is trace/report-only), so clamping to 0 on build-fail is cosmetic-safe — it cannot change any decision logic.
- (`lean_utils.py:1116` has a *different* local boolean `implicit_sorry`, unrelated — out of scope.)

## Verification (firsthand, this machine — `myia-po-2026:CoursIA-2`)

- **Regression test** `test_compile_implicit_sorry_clamped_on_build_failure`: mocks a FAILED build (`success=False`, empty `raw_output`) on a file with 8 explicit sorries; asserts `implicit_sorry_count == 0` (not -8) and `sorry_count == 8` (unaffected).
- **Proven to FAIL on the naive formula**: temporarily reverted to `build - text` → test failed with `got -8` (the exact run-3 value) → restored clamp → test passes. Pins the exact run-3 scenario, not a tautology.
- **Cohort** (implicit-sorry + count-sorries + parser/guard/lake-prefix): **13/13 PASS**.
- **Full file**: **164/166 PASS** (2 pre-existing unrelated: OPENAI_API_KEY env + stale STALE_POST_ABSORPTION Voting.lean #4365 — same baseline as #6845/#6846).
- LF clean; +60/−1 (11 in tools.py clamp + 50 test), atomic, 2 files.

## Sequence

Next: (b2) snapshot capture/restore `_best_content` gap (side-track investigation, separate PR), then (c) success semantics (no RESULT_SUCCESS on sorry_delta=0).

See #6790, See #1453

Co-Authored-By: Claude <noreply@anthropic.com>
