### PR TITLE
fix(lean,conway): pin mathlib @ v4.31.0-rc1 in lakefile

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean
@@ -7,8 +7,13 @@ package «conway» where
     ⟨`autoImplicit, false⟩
   ]
 
+-- Pin explicite v4.31.0-rc1 (harmonisation #4362) : sans `@`, lake resout la
+-- require sur `master` par defaut alors que lake-manifest.json est epingle sur
+-- v4.31.0-rc1 (rev d568c8c0) -> warning `manifest out of date: git revision of
+-- dependency 'mathlib' changed` a CHAQUE lake build (bruit dans les logs du
+-- prover BG, et un `lake update` accidentel sauterait sur master).
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.31.0-rc1"
 
 @[default_target]
 lean_lib «Conway» where


### PR DESCRIPTION
## Summary

Pin explicite `@ "v4.31.0-rc1"` sur la require mathlib du lakefile `conway_lean` — elimine le warning `manifest out of date: git revision of dependency 'mathlib' changed` emis a CHAQUE `lake build`.

## Root cause (investigation forensic run-5 BG prover)

`require mathlib from git "url"` **sans** `@ "tag"` → lake resout la dependance sur `master` par defaut, alors que `lake-manifest.json` est epingle sur `v4.31.0-rc1` (rev `d568c8c0`). Le mismatch declenche le warning a chaque build, sur **tous** les arbres (main tree, wtprover, worktrees CI) — verifie : les 9 HEADs de `.lake/packages` matchent le manifest, ce n'est PAS une corruption d'arbre.

Risque au-dela du bruit : un `lake update` accidentel sauterait mathlib sur `master` (breaking vs v4.31.0-rc1).

Note forensic : ce warning n'est **pas** la cause du freeze-loop `level_1_build=False` du prover BG (run-5 compile 6.4s EXIT=0 AVEC le warning — hypothese falsifiee ; la semantique exit-code/parse des verifies in-run reste la piste ouverte, grain po-2026).

## Preuves

- **wtprover (arbre jetable)** : pin teste → warning elimine, `lake build` EXIT=0.
- **Main tree (cette branche)** : `lake build` full WSL → `Build completed successfully (8545 jobs)`, exit 0, log tail :
  ```
  ✔ [8543/8545] Built Conway.Life.LightCone_en (172s)
  ✔ [8544/8545] Built Conway.Life.LightCone (178s)
  Build completed successfully (8545 jobs).
  ```
- **grep -c sorry avant/apres** : 0/0 (lakefile-only, aucun fichier de preuve touche).
- **Proof integrity** : aucun module Lean modifie — diff = 1 fichier lakefile.lean, +6/-1.

## Rollout flotte (See #4362)

Scan des lakes own : 5 autres lakes ont le meme pattern (manifest pinne v4.31.0-rc1 / SHA, lakefile non pinne) — `calibration_lean`, `grothendieck_lean`, `mathlib_examples`, `sensitivity_lean`, `repeated_games_lean`. Table postee sur #4362 pour rollout par la lane Lean ; cette PR = pilote conway_lean (le lake du prover BG, ou le bruit gene le plus).

See #4362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)