### PR TITLE
fix(search,navlinks): CSPs_Intro archive navlinks -> ../Part2-CSP (deterministic)

### DIFF
--- a/MyIA.AI.Notebooks/Search/archive/CSPs_Intro.ipynb
+++ b/MyIA.AI.Notebooks/Search/archive/CSPs_Intro.ipynb
@@ -1700,7 +1700,7 @@
     "\n",
     "La **recherche complete** (backtracking + inference) garantit de trouver une solution si elle existe, mais explose sur les grandes instances. La **recherche locale** (Min-Conflicts) est spectaculaire en vitesse (1000-queens en 0.3s) mais ne garantit ni completude ni optimalite.\n",
     "\n",
-    "**Pour approfondir** : [CSP-1 - Fondements](Part2-CSP/CSP-1-Fundamentals.ipynb) | [CSP-2 - Consistance](Part2-CSP/CSP-2-Consistency.ipynb) | [CSP-7 - Contraintes souples](Part2-CSP/CSP-7-Soft.ipynb)\n",
+    "**Pour approfondir** : [CSP-1 - Fondements](../Part2-CSP/CSP-1-Fundamentals.ipynb) | [CSP-2 - Consistance](../Part2-CSP/CSP-2-Consistency.ipynb) | [CSP-7 - Contraintes souples](../Part2-CSP/CSP-7-Soft.ipynb)\n",
     "\n",
     "**Retour au sommaire** : [Index](../../README.md)"
    ]


### PR DESCRIPTION
## Summary — navlink fix (#5081)

Fix **3 broken navlinks** in `Search/archive/CSPs_Intro.ipynb` (cell[38], "Pour approfondir" section).

## Root cause
The notebook lives in `Search/archive/` but linked to `Part2-CSP/CSP-N.ipynb` (relative path). From `Search/archive/`, that resolves to `Search/archive/Part2-CSP/...` which does **not exist** → 404. The correct relative path from the archive subdir up to `Search/Part2-CSP/` is `../Part2-CSP/CSP-N.ipynb`.

## Deterministic (#5081-safe)
Each target exists **exactly once** in the tree:
- `Search/Part2-CSP/CSP-1-Fundamentals.ipynb` ✓ (1 match)
- `Search/Part2-CSP/CSP-2-Consistency.ipynb` ✓ (1 match)
- `Search/Part2-CSP/CSP-7-Soft.ipynb` ✓ (1 match)

No ambiguity → no guessing (cf `deterministic-navlink-filter-renumbering-collateral` lesson: slug matches exactly 1 notebook; ambiguous = #5081 never guessed).

## Verification
- **Canonical checker**: `check_notebook_navlinks.py` → `OK: 0 lien cassé` (the 3 previously-broken links now resolve)
- **Markdown-only**: 0 code cells touched → no re-exec, outputs byte-identical (C.2 safe)
- **Surgical**: only cell[38] changed; other 38 cells byte-identical. Diff = +1/−1 (single navlink line)
- `validate_pr_notebooks.py` 1/1 PASS (18 cells); H.3 clean

## Context
This was the only real broken-navlink cluster in the committed tree (the 4th scan hit, `ML-2-Data&Features`, is an **external URL** `https://github.com/dotnet/...` — a false positive of the local-path resolver, not a navlink). After this fix, the committed tree has 0 genuine broken navlinks.

See #5081 (renumbering EPIC — partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)