### PR TITLE
feat(i18n,#4957): seed GenAI/FineTuning translation CSV (Phase 0.5)

### DIFF
--- a/translations/genai-finetuning/README.md
+++ b/translations/genai-finetuning/README.md
@@ -1,0 +1,40 @@
+# CSV de synchro traduction — série GenAI/FineTuning
+
+**Statut** : Phase 0.5 backfill (Epic #4957 / #1650). Série `GenAI/FineTuning/` couverte par l'infrastructure i18n.
+
+## Couvert
+
+| Fichier | Série | Notebooks | Cellules |
+|---------|-------|-----------|----------|
+| [`genai-finetuning.csv`](genai-finetuning.csv) | `GenAI/FineTuning/` (5 notebooks : Introduction, QLoRA, SFT, RLHF/DPO, Model Merging & Routing) | 5 | 161 (21 colonnes) |
+
+Répartition : 71 cellules `code` + 90 cellules `markdown` (prose pédagogique FR). Pivot `src_lang = fr` pour les 161 cellules (Phase 0.5, cf [#readme-french-first](../../.claude/rules/readme-french-first.md)). Les colonnes cibles T3 (`text_en`/`hash_en`/…/`text_pt`/`hash_pt`) restent vides en attente du run moteur Argumentum (gated #1650 Phase 1).
+
+**Note owner-lane** : l'extraction i18n est **safe owner-lane** (artefacts dérivés = CSV de cellules upstream, pas de modification de code des notebooks). Cette série est distincte de `translations/genai-casestudies/` (cas d'usage agentiques) et couvre la chaîne d'entraînement/post-entraînement des LLM.
+
+**Périmètre fonctionnel** : la série parcourt le fine-tuning de bout en bout — introduction aux stratégies (FT-01), quantification QLoRA 4-bit (FT-02), supervised fine-tuning sur dataset instruct (FT-03), alignement par préférences RLHF/DPO (FT-04), fusion de modèles et routing MoE (FT-05). Python (kernel `python3`), appels aux frameworks ML (transformers, peft, trl, bitsandbytes).
+
+## Régénération
+
+```bash
+# Depuis la racine du dépôt :
+python scripts/translation/extract_cells_to_csv.py \
+    MyIA.AI.Notebooks/GenAI/FineTuning/ \
+    -o translations/genai-finetuning/genai-finetuning.csv
+```
+
+L'extraction est **déterministe byte-identique** (même ordre de notebooks, mêmes hash sha256-16 sur texte normalisé) — re-exécuter produit le même CSV (vérifié : SHA256 `9ca37363f0…` reproductible).
+
+## Vérification de drift (T2)
+
+```bash
+python scripts/translation/check_translation_sync.py translations/genai-finetuning/genai-finetuning.csv
+# -> 0 anomalie (intégrité src_hash == hash_fr sur les 161 cellules)
+```
+
+## Voir aussi
+
+- Issue #4957 — design infrastructure T1→T2→T3
+- Epic #1650 — traduction multilingue du dépôt
+- [`translations/README.md`](../README.md) — arborescence globale des CSV
+- `scripts/translation/README.md` — schéma détaillé des colonnes

--- a/translations/genai-finetuning/genai-finetuning.csv
+++ b/translations/genai-finetuning/genai-finetuning.csv
@@ -1,0 +1,2689 @@
+notebook,cell_id,cell_type,src_lang,src_hash,text_fr,text_en,text_es,text_ar,text_fa,text_zh,text_ru,text_pt,hash_fr,hash_en,hash_es,hash_ar,hash_fa,hash_zh,hash_ru,hash_pt
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-24754727,markdown,fr,36226898e92d0980,"# FT-01 : Introduction au Fine-Tuning
+
+**Objectif** : Comprendre les trois approches de fine-tuning (complet, partiel, LoRA) et mettre en pratique LoRA sur un petit modele de texte.
+
+**Plan** :
+1. Pourquoi fine-tuner ?
+2. Full Fine-Tuning vs Partial vs LoRA
+3. Comparaison des parametres entrainables
+4. LoRA en pratique : fine-tuning de GPT-2 sur un style litteraire
+5. Evaluation avant/apres
+
+**Materiel requis** : GPU avec ~4 Go VRAM (GPT-2 = 124M params).",,,,,,,,36226898e92d0980,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-2853ccbc,code,fr,253239aabdbd5220,"import torch
+import os
+import gc
+
+print(f""PyTorch {torch.__version__}"")
+print(f""CUDA disponible : {torch.cuda.is_available()}"")
+if torch.cuda.is_available():
+    print(f""GPU : {torch.cuda.get_device_name(0)}"")
+    print(f""VRAM : {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} Go"")",,,,,,,,253239aabdbd5220,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-66318dab,markdown,fr,b70148073983373e,"## 1. Pourquoi fine-tuner ?
+
+Les modeles pre-entraines (foundation models) sont capables de taches generales, mais manquent de specialisation :
+
+| Cas d'usage | Pourquoi fine-tuner ? |
+|-------------|----------------------|
+| Style d'ecriture specifique | Le modele generique ne maitrise pas un style particulier |
+| Domaine technique (medical, juridique) | Le vocabulaire et les schemas de raisonnement different |
+| Tache structuree (classification, extraction) | Le format de sortie n'est pas naturel pour le modele |
+| Reduction des hallucinations | Un modele specialise fait moins d'erreurs dans son domaine |
+
+**Exemple** : GPT-2 genere du texte anglais generique. Apres fine-tuning sur des textes francais du 19e siecle, il peut imiter ce style specifique.",,,,,,,,b70148073983373e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-8791918c,markdown,fr,1c6ee56d1aa722a0,"## 2. Trois approches de fine-tuning
+
+### 2a. Full Fine-Tuning
+
+Tous les parametres du modele sont mis a jour.
+
+- **Avantage** : Performance maximale, le modele s'adapte completement
+- **Inconvenient** : Tres couteux en GPU (VRAM = modeles + gradients + optimizer states, souvent 3-4x la taille du modele)
+- **Usage** : Modeles petits (<1B) ou budgets GPU importants
+
+### 2b. Partial Fine-Tuning (Feature Extraction)
+
+On gele les couches inferieures et n'entraine que les dernieres.
+
+- **Avantage** : Moins de parametres a entrainer, plus rapide
+- **Inconvenient** : Adaptation limitee, pas de modification des representations profondes
+- **Usage** : Quand le domaine d'application est proche du pre-entrainement
+
+### 2c. LoRA (Low-Rank Adaptation)
+
+On injecte de petites matrices de rang faible ($A \times B$) a cote des poids originaux, et on n'entraine que ces matrices.
+
+- **Avantage** : Tres peu de parametres entrainables (0.1-1% du modele), stockage minimal
+- **Inconvenient** : Performances legerement inferieures au full fine-tuning sur des taches complexes
+- **Usage** : Standard industriel actuel, surtout pour modeles >3B
+
+### Formulation mathematique de LoRA
+
+Pour un poids pre-entraine $W \in \mathbb{R}^{d \times k}$ :
+
+$$h = Wx + \Delta W x = Wx + BAx$$
+
+ou $B \in \mathbb{R}^{d \times r}$, $A \in \mathbb{R}^{r \times k}$, et $r \ll \min(d, k)$.
+
+Le rang $r$ (typiquement 4-64) controle le compromis expressivite/efficacite.",,,,,,,,1c6ee56d1aa722a0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-dfcac0ae,markdown,fr,fb5a3d6267cde188,"## 3. Comparaison des parametres entrainables
+
+Chargeons un petit modele (GPT-2, 124M params) et comparons les trois approches.",,,,,,,,fb5a3d6267cde188,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-c2fa367d,code,fr,0732db71d1edb62a,"from transformers import AutoModelForCausalLM, AutoTokenizer
+
+MODEL_NAME = ""openai-community/gpt2""  # 124M params
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+tokenizer.pad_token = tokenizer.eos_token
+
+model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+total_params = sum(p.numel() for p in model.parameters())
+print(f""Modele : {MODEL_NAME}"")
+print(f""Parametres totaux : {total_params:,} ({total_params/1e6:.1f}M)"")",,,,,,,,0732db71d1edb62a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-de59f036,code,fr,b6f1d543a7a02de8,"def count_trainable(model):
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total = sum(p.numel() for p in model.parameters())
+    return trainable, total
+
+def freeze_all(model):
+    for p in model.parameters():
+        p.requires_grad = False
+
+def unfreeze_last_n_layers(model, n):
+    freeze_all(model)
+    for block in model.transformer.h[-n:]:
+        for p in block.parameters():
+            p.requires_grad = True
+    for p in model.lm_head.parameters():
+        p.requires_grad = True
+
+# Approche 1 : Full fine-tuning
+for p in model.parameters():
+    p.requires_grad = True
+full_trainable, total = count_trainable(model)
+
+# Approche 2 : Partial (2 dernieres couches + lm_head)
+unfreeze_last_n_layers(model, 2)
+partial_trainable, _ = count_trainable(model)
+
+# Approche 3 : LoRA
+from peft import LoraConfig, get_peft_model
+
+lora_config = LoraConfig(
+    r=8,
+    lora_alpha=16,
+    target_modules=[""c_attn""],  # Attention projections dans GPT-2
+    lora_dropout=0.05,
+    bias=""none"",
+    task_type=""CAUSAL_LM"",
+)
+
+# Recharger le modele propre pour LoRA
+model_lora = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+model_lora = get_peft_model(model_lora, lora_config)
+lora_trainable, _ = count_trainable(model_lora)
+
+print(f""{'Approche':<20} {'Entrainables':>15} {'Total':>15} {'%':>8}"")
+print(f""{'-'*20} {'-'*15} {'-'*15} {'-'*8}"")
+print(f""{'Full Fine-Tuning':<20} {full_trainable:>15,} {total:>15,} {100.0:>7.2f}%"")
+print(f""{'Partial (2 couches)':<20} {partial_trainable:>15,} {total:>15,} {partial_trainable/total*100:>7.2f}%"")
+print(f""{'LoRA (r=8)':<20} {lora_trainable:>15,} {total:>15,} {lora_trainable/total*100:>7.2f}%"")
+print(f""\nRatio LoRA/Full = {lora_trainable/full_trainable*100:.2f}%"")",,,,,,,,b6f1d543a7a02de8,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-2c50759f,markdown,fr,e3f48c7241820058,"## 4. LoRA en pratique : Fine-tuning sur un style litteraire
+
+Nous allons fine-tuner GPT-2 pour generer du texte dans le style de Victor Hugo.
+Le dataset est un extrait des *Miserables* (domaine public).",,,,,,,,e3f48c7241820058,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-09a20769,code,fr,0f43b1e3f12bedeb,"from datasets import Dataset
+
+# Extrait des Miserables (Victor Hugo, domaine public)
+miserables_text = """"""Cosette, enentrant dans la vieille maison de la rue de l'Homme-Arme, 
+n'avait pas pu quitter la main du vieuxhomme. Cosette regardait la chambre 
+obscure, et la figure ridée de son bienfaiteur, et cette figure ridée était 
+l'immense figure de la misere humaine.
+
+Jean Valjean etait devenu le bonhomme de la maison. Il avait pris l'habitude 
+de descendre a la cave pour rapporter du vin, et de monter au grenier pour 
+rapporter du bois. Cosette trouvait que monsieur Jean avait les mains pleines 
+de bienfaits.
+
+La nuit, quand tout dormait dans la maison, Jean Valjean restait eveille. 
+Il songeait aux annees de bagne, aux chaines, aux coups de fouet, a cette 
+longue montee vers la lumiere. Cosette dormait, et il la regardait dormir.
+
+Les rues de Paris etaient sombres en ce temps-la. Les reverberes jetaient 
+des taches de lumiere jaune sur les pavés mouilles. Jean Valjean marchait 
+vite, comme un homme qui fuit quelque chose, ou qui cherche quelqu'un.
+
+Marius l'observait de loin. Ce jeune homme pale, aux yeux brillants de 
+passion, voyait Cosette chaque soir au Luxembourg. Il n'osait lui parler. 
+L'amour est timide, meme pour les coeurs les plus courageux.
+
+La barricade s'elevait dans la rue de la Grange-aux-Belles. Les jeunes 
+hommes avaient pris les pavés et construit un mur de pierres. Enjolras, 
+beau comme un dieu, commandait avec une autorite naturelle. Grantaire, 
+ivre et fidele, le suivait partout.
+
+Gavroche passait entre les balles comme un oiseau. Ce gamin de Paris, 
+nenfant abandonne devenu enfant de la patrie, ramassait les cartouches 
+des soldats morts pour les rapporter aux insurgés. Son chant retentissait 
+dans la nuit, clair et courageux.""""""
+
+# Decouper en segments d'entrainement
+segments = [s.strip() for s in miserables_text.split(""\n\n"") if s.strip()]
+print(f""Segments d'entrainement : {len(segments)}"")
+print(f""Exemple : {segments[0][:100]}..."")
+
+# Creer le dataset
+train_data = Dataset.from_dict({""text"": segments})
+print(f""Dataset : {len(train_data)} exemples"")",,,,,,,,0f43b1e3f12bedeb,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-8cf30c19,code,fr,e81510bc91afa4ec,"# Tokenisation
+def tokenize_function(examples):
+    result = tokenizer(
+        examples[""text""],
+        truncation=True,
+        max_length=256,
+        padding=""max_length"",
+    )
+    result[""labels""] = result[""input_ids""].copy()
+    return result
+
+tokenized_dataset = train_data.map(tokenize_function, batched=True, remove_columns=[""text""])
+print(f""Tokens par exemple : {len(tokenized_dataset[0]['input_ids'])}"")",,,,,,,,e81510bc91afa4ec,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-5eae637f,markdown,fr,37d5e47f71bf8eac,Le dataset est tokenise avec un padding uniforme a 256 tokens. Chaque exemple contient les `input_ids` et les `labels` (copie des input_ids pour le causal language modeling). Nous allons maintenant configurer l'adaptateur LoRA et lancer l'entrainement.,,,,,,,,37d5e47f71bf8eac,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-565b5293,code,fr,aedd3c0b2272a940,"from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling
+
+# Configuration LoRA
+lora_config = LoraConfig(
+    r=8,
+    lora_alpha=16,
+    target_modules=[""c_attn""],
+    lora_dropout=0.05,
+    bias=""none"",
+    task_type=""CAUSAL_LM"",
+)
+
+model_to_train = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+model_to_train = get_peft_model(model_to_train, lora_config)
+model_to_train.print_trainable_parameters()
+
+# Arguments d'entrainement
+training_args = TrainingArguments(
+    output_dir=""./temp_ft01_output"",
+    num_train_epochs=10,
+    per_device_train_batch_size=2,
+    learning_rate=5e-4,
+    weight_decay=0.01,
+    logging_steps=5,
+    save_strategy=""no"",
+    report_to=""none"",
+    fp16=torch.cuda.is_available(),
+    seed=42,
+)
+
+data_collator = DataCollatorForLanguageModeling(
+    tokenizer=tokenizer,
+    mlm=False,
+)
+
+trainer = Trainer(
+    model=model_to_train,
+    args=training_args,
+    train_dataset=tokenized_dataset,
+    data_collator=data_collator,
+)
+
+print(f""\nEntrainement en cours..."")
+train_result = trainer.train()
+print(f""\nPerte finale : {train_result.training_loss:.4f}"")
+print(f""Temps : {train_result.metrics['train_runtime']:.1f}s"")",,,,,,,,aedd3c0b2272a940,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-2fe06360,markdown,fr,2a6d9cbb59c6fa2c,"## 5. Evaluation avant / apres
+
+Comparons la generation du modele original vs le modele fine-tune.",,,,,,,,2a6d9cbb59c6fa2c,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-e44b2476,code,fr,4b48dbb5dc3ec629,"# Modele original (recharger)
+model_original = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+model_original.eval()
+
+def generate_text(model, prompt, max_new_tokens=80, temperature=0.8):
+    inputs = tokenizer(prompt, return_tensors=""pt"")
+    if torch.cuda.is_available():
+        inputs = {k: v.to(model.device) for k, v in inputs.items()}
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            do_sample=True,
+            top_p=0.9,
+            pad_token_id=tokenizer.eos_token_id,
+        )
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+prompt = ""Dans les rues sombres de Paris,""
+
+print(""="" * 60)
+print(""GENERATION ORIGINALE (GPT-2 pre-entraine)"")
+print(""="" * 60)
+original_output = generate_text(model_original, prompt)
+print(original_output)
+
+print(""\n"" + ""="" * 60)
+print(""GENERATION APRES LoRA (fine-tune style Hugo)"")
+print(""="" * 60)
+model_to_train.eval()
+finetuned_output = generate_text(model_to_train, prompt)
+print(finetuned_output)",,,,,,,,4b48dbb5dc3ec629,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-14e59cfb,code,fr,ea276b0c447bc964,"# Second prompt pour comparer
+prompt2 = ""Jean Valjean marchait dans la nuit""
+
+print(""="" * 60)
+print(f""Prompt : \""{prompt2}\"""")
+print(""="" * 60)
+
+print(""\nORIGINAL :"")
+print(generate_text(model_original, prompt2))
+
+print(""\nFINE-TUNE :"")
+print(generate_text(model_to_train, prompt2))",,,,,,,,ea276b0c447bc964,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-dc70a9c6,markdown,fr,d7c536b8f859c29e,"## 6. Taille des adaptateurs LoRA
+
+Un des avantages majeurs de LoRA : les poids appris sont minuscules.",,,,,,,,d7c536b8f859c29e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-c7cfd896,code,fr,5781cee3dc5eb0da,"import tempfile
+
+# Sauvegarder l'adaptateur LoRA
+adapter_dir = os.path.join(tempfile.gettempdir(), ""ft01_lora_adapter"")
+model_to_train.save_pretrained(adapter_dir)
+
+# Taille totale du modele original vs adaptateur
+adapter_size = sum(
+    os.path.getsize(os.path.join(adapter_dir, f))
+    for f in os.listdir(adapter_dir)
+    if f.endswith("".safetensors"") or f.endswith("".bin"")
+)
+
+model_size_mb = total_params * 4 / 1e6  # float32
+adapter_size_mb = adapter_size / 1e6
+
+print(f""Modele complet (GPT-2) : {model_size_mb:.1f} Mo"")
+print(f""Adaptateur LoRA seul  : {adapter_size_mb:.2f} Mo"")
+print(f""Ratio adaptateur/modele : {adapter_size_mb/model_size_mb*100:.2f}%"")
+print(f""\nPour deployer : il suffit du modele de base + adaptateur ({adapter_size_mb:.1f} Mo)"")",,,,,,,,5781cee3dc5eb0da,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-fd8f3de4,markdown,fr,6248b1bb3bda8737,## 7. Nettoyage memoire GPU,,,,,,,,6248b1bb3bda8737,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-94c0915a,code,fr,2718db4d40bafc80,"del model_original, model_to_train, trainer
+gc.collect()
+if torch.cuda.is_available():
+    torch.cuda.empty_cache()
+    print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} Go"")
+else:
+    print(""Nettoyage termine"")",,,,,,,,2718db4d40bafc80,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-f59529da,markdown,fr,59b534a87270ae75,"## 8. Exercices
+
+Appliquez les concepts de ce notebook.",,,,,,,,59b534a87270ae75,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-4102f87c,code,fr,40a3b60642fa742e,"# Exercice 1 : Exploration du rang LoRA
+# TODO etudiant : Creez 3 configurations LoRA avec r=2, r=8, r=32
+# et comparez le nombre de parametres entrainables pour chacune.
+# Quel rang donne le meilleur ratio performance/taille ?
+
+print(""Exercice a completer : comparez les rangs LoRA r=2, 8, 32"")",,,,,,,,40a3b60642fa742e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-f42dac6b,code,fr,165be5bb72fe6930,"# Exercice 2 : Fine-tuning sur un autre style
+# TODO etudiant : Remplacez le dataset des Miserables par un extrait
+# d'un autre auteur (ex: Baudelaire, Verlaine) et relancez l'entrainement.
+# Observez comment le style de generation change.
+
+print(""Exercice a completer : fine-tunez sur un style different"")",,,,,,,,165be5bb72fe6930,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-70d4b526,markdown,fr,4947fe82d8347d29,"### Exercice 3 : Hyperparametres d'entrainement
+
+Le *learning rate* est l'hyperparametre le plus sensible du fine-tuning. Un LR trop faible = convergence lente, un LR trop eleve = divergence et degradation du modele. Testez differentes valeurs pour trouver le point optimal.",,,,,,,,4947fe82d8347d29,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-fc5cb509,code,fr,4daa1488050f4257,"# Exercice 3 : Impact du learning rate
+# TODO etudiant : Entrainnez avec learning_rate = 1e-5, 5e-4, 1e-3.
+# Observez la perte finale et la qualite de generation.
+# Que se passe-t-il avec un learning rate trop eleve ?
+
+print(""Exercice a completer : comparez les learning rates"")",,,,,,,,4daa1488050f4257,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb,cell-ebb412ad,markdown,fr,439fb82b66a76fcb,"## Resume
+
+| Approche | Params entrainables | VRAM requise | Stockage adaptateur |
+|----------|--------------------:|-------------:|--------------------:|
+| Full Fine-Tuning | 100% | 3-4x taille modele | Modele complet |
+| Partial (2 couches) | ~5-15% | ~1.5x taille modele | Couches modifiees |
+| **LoRA (r=8)** | **~0.5%** | **~1.1x taille modele** | **~2-5 Mo** |
+
+**Points cles** :
+- LoRA decompose la mise a jour en matrices de bas rang $B \times A$ ou $r \ll d, k$
+- Seuls ~0.5% des parametres sont entraines, mais la qualite reste proche du full fine-tuning
+- Les adaptateurs sont portables : un seul modele de base + N adaptateurs pour N taches
+- Le rang $r$ controle le compromis expressivite/efficacite
+
+**Prochaines etapes** (FT-02) : LoRA sur un modele plus grand avec quantization 4-bit (QLoRA).",,,,,,,,439fb82b66a76fcb,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,b4fb8592,markdown,fr,58c7534b298b25ba,"# FT-02 : QLoRA — Fine-Tuning avec Quantization
+
+**Objectif** : Comprendre la quantization 4-bit (NF4) et l'approche QLoRA qui combine quantization + LoRA pour fine-tuner des modeles jusqu'a 7B params sur un GPU consumer.
+
+**Plan** :
+1. Le probleme memoire des grands modeles
+2. Quantization : de FP16 a NF4
+3. BitsAndBytesConfig en pratique
+4. QLoRA : quantized base + LoRA adapters
+5. Entrainement QLoRA sur OPT-1.3B
+6. Comparaison LoRA vs QLoRA
+7. Exercices
+
+**Prerequis** : FT-01 (Introduction au Fine-Tuning) — LoRA, rang, adaptateurs.
+
+**Materiel requis** : GPU avec ~8 Go VRAM (QLoRA OPT-1.3B 4-bit = ~2 Go).",,,,,,,,58c7534b298b25ba,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,482ed3ca,code,fr,31bb8dcfa3cec04b,"import torch
+import os
+import gc
+import time
+
+print(f""PyTorch {torch.__version__}"")
+print(f""CUDA : {torch.cuda.is_available()}"")
+if torch.cuda.is_available():
+    print(f""GPU : {torch.cuda.get_device_name(0)}"")
+    vram_total = torch.cuda.get_device_properties(0).total_memory / 1e9
+    vram_free = torch.cuda.mem_get_info()[0] / 1e9
+    print(f""VRAM totale : {vram_total:.1f} Go | Libre : {vram_free:.1f} Go"")",,,,,,,,31bb8dcfa3cec04b,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,f42fdf42,markdown,fr,ce3717a4980c5882,"## 1. Le probleme memoire des grands modeles
+
+Fine-tuner un modele de langue necessite de stocker en VRAM :
+
+| Composant | Taille approximative |
+|-----------|---------------------|
+| Poids du modele (FP16) | 2 bytes/param |
+| Gradients | 2 bytes/param |
+| Etats de l'optimiseur (AdamW) | 8 bytes/param (m + v) |
+| Activations (forward pass) | Variable, souvent 1-2x modele |
+
+**Total pour full fine-tuning** : ~12-16 bytes par parametre.
+
+| Modele | Params | Full FT (FP16) | LoRA (FP16) | QLoRA (4-bit) |
+|--------|--------|---------------|-------------|---------------|
+| GPT-2 | 124M | ~2 Go | ~0.5 Go | ~0.3 Go |
+| OPT-1.3B | 1.3B | ~20 Go | ~5 Go | ~2 Go |
+| Llama-7B | 7B | ~112 Go | ~28 Go | ~6 Go |
+
+LoRA reduit les gradients et l'optimiseur (seuls les adaptateurs sont entraines), mais les **poids du modele restent en FP16**.
+
+**QLoRA** va plus loin : il **quantize les poids du modele en 4-bit** tout en gardant les calculs en precision superieure.",,,,,,,,ce3717a4980c5882,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,6dd153f7,markdown,fr,75938d79649f2040,"## 2. Quantization : de FP16 a NF4
+
+### 2a. Principe de la quantization
+
+La quantization reduit la precision des poids pour diminuer l'empreinte memoire :
+
+```
+FP32 (32 bits) → FP16 (16 bits) → INT8 (8 bits) → NF4 (4 bits)
+4 bytes/param    2 bytes/param    1 byte/param    0.5 bytes/param
+```
+
+### 2b. Pourquoi NF4 et pas un simple INT4 ?
+
+Les poids des reseaux de neurones suivent une distribution **approximativement normale** (centree sur 0). Un encodage lineaire INT4 gaspille des valeurs possibles :
+
+- **INT4** : valeurs uniformement reparties sur [-8, 7] → regions denses de la distribution mal representees
+- **NF4 (NormalFloat 4)** : valeurs optimisees pour une distribution normale → chaque quantile represente une fraction egale de la distribution
+
+NF4 = le format optimal theorique pour les poids de reseaux de neurones (Dettmers et al., 2023).
+
+### 2c. Double quantization
+
+QLoRA applique aussi une **double quantization** : les constantes de quantization (scaling factors) sont elles-memes quantizees en FP8, economisant ~0.37 bits/param supplementaire.",,,,,,,,75938d79649f2040,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,181e3df5,markdown,fr,9ca91c48d293fcb3,"## 3. BitsAndBytesConfig en pratique
+
+La bibliotheque `bitsandbytes` integre la quantization directement dans le chargement du modele via `transformers`.",,,,,,,,9ca91c48d293fcb3,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,58f8f7ff,code,fr,b1b8e8d4c5f260f1,"from transformers import BitsAndBytesConfig
+
+# Configuration QLoRA : quantization 4-bit NF4
+bnb_config = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type=""nf4"",             # NormalFloat 4 (optimal pour poids)
+    bnb_4bit_compute_dtype=torch.float16,   # Calculs en FP16 pour stabilite numerique
+    bnb_4bit_use_double_quant=True,         # Double quantization des scaling factors
+)
+
+print(""BitsAndBytesConfig QLoRA :"")
+print(f""  Quantization : 4-bit NF4"")
+print(f""  Compute dtype : float16"")
+print(f""  Double quant : True"")",,,,,,,,b1b8e8d4c5f260f1,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,1c745d40,code,fr,4610db9bb7117f8a,"# Mesurer la VRAM avant chargement
+if torch.cuda.is_available():
+    torch.cuda.reset_peak_memory_stats()
+    vram_before = torch.cuda.memory_allocated() / 1e9
+else:
+    vram_before = 0
+
+print(f""VRAM avant chargement : {vram_before:.2f} Go"")",,,,,,,,4610db9bb7117f8a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,872b697a,markdown,fr,10fe44e11d2e9cd5,"## 4. QLoRA : quantized base + LoRA adapters
+
+Chargeons OPT-1.3B en 4-bit et comparons avec le chargement FP16 classique.",,,,,,,,10fe44e11d2e9cd5,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,c18d2f35,code,fr,987ed8bcd8ae989b,"from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+
+MODEL_NAME = ""facebook/opt-1.3b""  # 1.3B params
+
+# Charger en 4-bit (QLoRA)
+model_4bit = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME,
+    quantization_config=bnb_config,
+    device_map=""auto"",
+)
+
+# Preparer le modele pour l'entrainement en mode quantize
+model_4bit = prepare_model_for_kbit_training(model_4bit)
+
+# Statistiques memoire
+if torch.cuda.is_available():
+    vram_4bit = torch.cuda.max_memory_allocated() / 1e9
+else:
+    vram_4bit = 0
+
+total_params = sum(p.numel() for p in model_4bit.parameters())
+print(f""Modele : {MODEL_NAME}"")
+print(f""Params totaux : {total_params:,} ({total_params/1e9:.2f}B)"")
+print(f""VRAM apres chargement 4-bit : {vram_4bit:.2f} Go"")
+print(f""Theorie 4-bit : {total_params * 0.5 / 1e9:.2f} Go (poids seuls)"")",,,,,,,,987ed8bcd8ae989b,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,8bcb791f,code,fr,4d27609302498283,"# Ajouter les adaptateurs LoRA sur le modele quantize
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    target_modules=[""q_proj"", ""v_proj""],  # Attention query/value dans OPT
+    lora_dropout=0.05,
+    bias=""none"",
+    task_type=""CAUSAL_LM"",
+)
+
+model_qlora = get_peft_model(model_4bit, lora_config)
+model_qlora.print_trainable_parameters()
+
+trainable = sum(p.numel() for p in model_qlora.parameters() if p.requires_grad)
+total = sum(p.numel() for p in model_qlora.parameters())
+print(f""\nParams entrainables : {trainable:,} ({trainable/total*100:.2f}%)"")",,,,,,,,4d27609302498283,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,464aab75,markdown,fr,1ce287d1e69f2d35,"### Tokenisation du modele
+
+Le modele OPT-1.3B est maintenant charge en 4-bit avec les adaptateurs LoRA configures (r=16, target q_proj/v_proj). Chargeons le tokenizer associe pour preparer le dataset d'entrainement.",,,,,,,,1ce287d1e69f2d35,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,a0b80355,code,fr,eb0b8741da2602cf,"# Tokenizer
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+tokenizer.pad_token = tokenizer.eos_token
+print(f""Tokenizer : vocabulaire = {tokenizer.vocab_size:,} tokens"")",,,,,,,,eb0b8741da2602cf,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,1fb4824c,markdown,fr,c5849ed6cfcf4937,"## 5. Entrainement QLoRA sur OPT-1.3B
+
+Fine-tunons OPT-1.3B sur du texte francais litteraire, le meme type de dataset que FT-01.",,,,,,,,c5849ed6cfcf4937,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ce505cf2,code,fr,1e5bc967ca72a52e,"from datasets import Dataset
+
+# Extrait elargi — texte francais classique (domaine public)
+training_texts = [
+    ""Cosette regardait la chambre obscure, et la figure ridee de son bienfaiteur. ""
+    ""Cette figure ridee etait l'immense figure de la misere humaine. Jean Valjean ""
+    ""avait pris l'habitude de descendre a la cave pour rapporter du vin."",
+
+    ""La nuit, quand tout dormait dans la maison, Jean Valjean restait eveille. ""
+    ""Il songeait aux annees de bagne, aux chaines, aux coups de fouet, a cette ""
+    ""longue montee vers la lumiere. Cosette dormait, et il la regardait dormir."",
+
+    ""Les rues de Paris etaient sombres en ce temps-la. Les reverberes jetaient ""
+    ""des taches de lumiere jaune sur les paves mouilles. Jean Valjean marchait ""
+    ""vite, comme un homme qui fuit quelque chose."",
+
+    ""Marius l'observait de loin. Ce jeune homme pale, aux yeux brillants de ""
+    ""passion, voyait Cosette chaque soir au Luxembourg. Il n'osait lui parler. ""
+    ""L'amour est timide, meme pour les coeurs les plus courageux."",
+
+    ""La barricade s'elevait dans la rue. Les jeunes hommes avaient pris les ""
+    ""paves et construit un mur de pierres. Enjolras commandait avec une ""
+    ""autorite naturelle. Grantaire, ivre et fidele, le suivait partout."",
+
+    ""Gavroche passait entre les balles comme un oiseau. Ce gamin de Paris, ""
+    ""nenfant abandonne devenu enfant de la patrie, ramassait les cartouches ""
+    ""des soldats morts pour les rapporter aux insurges."",
+
+    ""Eponine errait dans les rues, le coeur lourd d'un amour sans espoir. ""
+    ""Elle avait vu Marius regarder Cosette, et elle avait compris que son ""
+    ""propre amour ne serait jamais partage."",
+
+    ""Javet suivait la piste avec une tenacite implacable. Cet homme de loi ""
+    ""ne connaissait ni pitié ni doute. Pour lui, Jean Valjean resterait ""
+    ""toujours le forcat 24601, quelles que soient ses actions."",
+
+    ""Le jardin du Luxembourg etait paisible en ce matin de printemps. ""
+    ""Les marronniers etaient en fleur, et les enfants jouaient sur le sable. ""
+    ""Cosette lisait sur un banc, attendant celui qui ne viendrait pas."",
+
+    ""Les Thenardier comptaient leur butin dans l'arriere-salle de l'auberge. ""
+    ""Monsieur Thenardier calculait, madame Thenardier injuriait. La cupidite ""
+    ""etait leur religion, l'argent leur seul dieu."",
+]
+
+train_data = Dataset.from_dict({""text"": training_texts})
+print(f""Dataset : {len(train_data)} exemples"")
+print(f""Moyenne caracteres/exemple : {sum(len(t) for t in training_texts) / len(training_texts):.0f}"")",,,,,,,,1e5bc967ca72a52e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,9dce8a5a,markdown,fr,72f33e4893aa8139,Le dataset contient 10 extraits de texte francais classique (moyenne 200 caracteres par extrait). Ces segments sont plus courts que dans FT-01 pour s'adapter au contexte limite d'OPT-1.3B. La prochaine etape est la tokenisation avec un padding uniforme.,,,,,,,,72f33e4893aa8139,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,fabaa57e,code,fr,629b538887f154b3,"# Tokenisation
+def tokenize_function(examples):
+    result = tokenizer(
+        examples[""text""],
+        truncation=True,
+        max_length=256,
+        padding=""max_length"",
+    )
+    result[""labels""] = result[""input_ids""].copy()
+    return result
+
+tokenized_dataset = train_data.map(tokenize_function, batched=True, remove_columns=[""text""])
+print(f""Tokens par exemple : {len(tokenized_dataset[0]['input_ids'])}"")
+print(f""Dataset tokenise : {len(tokenized_dataset)} exemples"")",,,,,,,,629b538887f154b3,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,f302a0b6,markdown,fr,2a140d6e7014c8c5,"Le dataset est maintenant tokenise avec un padding uniforme a 256 tokens, pret pour l'entrainement. Chaque exemple contient les `input_ids` et les `labels` (copies des input_ids pour le language modeling causal).
+
+Nous allons maintenant configurer le Trainer Hugging Face avec les arguments QLoRA : optimiseur 8-bit (`paged_adamw_8bit`), FP16, et un learning rate adapte a l'adaptateur LoRA.",,,,,,,,2a140d6e7014c8c5,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,fbe099a2,code,fr,667557059f20d847,"from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling
+
+# Arguments d'entrainement QLoRA
+training_args = TrainingArguments(
+    output_dir=""./temp_ft02_output"",
+    num_train_epochs=15,
+    per_device_train_batch_size=2,
+    learning_rate=2e-4,
+    weight_decay=0.01,
+    logging_steps=10,
+    save_strategy=""no"",
+    report_to=""none"",
+    fp16=torch.cuda.is_available(),
+    seed=42,
+    optim=""paged_adamw_8bit"",  # Optimiseur 8-bit pour economiser la VRAM
+)
+
+data_collator = DataCollatorForLanguageModeling(
+    tokenizer=tokenizer,
+    mlm=False,
+)
+
+trainer = Trainer(
+    model=model_qlora,
+    args=training_args,
+    train_dataset=tokenized_dataset,
+    data_collator=data_collator,
+)
+
+# Mesurer VRAM avant/apres
+if torch.cuda.is_available():
+    torch.cuda.reset_peak_memory_stats()
+    vram_start = torch.cuda.memory_allocated() / 1e9
+else:
+    vram_start = 0
+
+start_time = time.time()
+print(""Entrainement QLoRA en cours..."")
+train_result = trainer.train()
+elapsed = time.time() - start_time
+
+if torch.cuda.is_available():
+    vram_peak = torch.cuda.max_memory_allocated() / 1e9
+else:
+    vram_peak = 0
+
+print(f""\nPerte finale : {train_result.training_loss:.4f}"")
+print(f""Temps : {elapsed:.1f}s"")
+print(f""VRAM pic entrainement : {vram_peak:.2f} Go"")",,,,,,,,667557059f20d847,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,5b8b7716,markdown,fr,253fd529fb437f3a,"## 6. Generation avec le modele QLoRA
+
+Comparons la generation avant et apres fine-tuning.",,,,,,,,253fd529fb437f3a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,ca2a65b6,code,fr,9e41989ba3e5e6d1,"# Generer avec le modele fine-tune
+model_qlora.eval()
+
+def generate_qlora(prompt, max_new_tokens=100, temperature=0.8):
+    inputs = tokenizer(prompt, return_tensors=""pt"").to(model_qlora.device)
+    with torch.no_grad():
+        outputs = model_qlora.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            do_sample=True,
+            top_p=0.9,
+            pad_token_id=tokenizer.eos_token_id,
+        )
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+prompts = [
+    ""Dans les rues sombres de Paris,"",
+    ""Jean Valjean regardait la nuit"",
+    ""Cosette marchait dans le jardin"",
+]
+
+for p in prompts:
+    print(f""\n{'='*60}"")
+    print(f""Prompt : \""{p}\"""")
+    print(f""{'='*60}"")
+    output = generate_qlora(p)
+    print(output)",,,,,,,,9e41989ba3e5e6d1,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,acf6d40f,markdown,fr,b95db2e90033c063,"## 7. Comparaison LoRA vs QLoRA
+
+Chargeons le meme modele en FP16 (sans quantization) pour comparer l'empreinte memoire.",,,,,,,,b95db2e90033c063,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,30bb6cda,code,fr,31c5fe7b307bf67a,"# Charger le modele en FP16 pour comparaison
+model_fp16 = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME,
+    torch_dtype=torch.float16,
+    device_map=""auto"",
+)
+
+# Ajouter LoRA identique
+lora_config_fp16 = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    target_modules=[""q_proj"", ""v_proj""],
+    lora_dropout=0.05,
+    bias=""none"",
+    task_type=""CAUSAL_LM"",
+)
+model_lora_fp16 = get_peft_model(model_fp16, lora_config_fp16)
+
+# Mesures comparatives
+def measure_vram(model, label):
+    if torch.cuda.is_available():
+        alloc = torch.cuda.memory_allocated() / 1e9
+        reserved = torch.cuda.memory_reserved() / 1e9
+        print(f""{label} : alloue={alloc:.2f} Go, reserve={reserved:.2f} Go"")
+        return alloc
+    return 0
+
+print(f""\n{'='*50}"")
+print(f""Comparaison memoire — {MODEL_NAME}"")
+print(f""{'='*50}"")
+
+# Nettoyer pour mesure propre
+del model_fp16, model_lora_fp16
+gc.collect()
+if torch.cuda.is_available():
+    torch.cuda.empty_cache()
+
+# Recharger pour mesure propre
+torch.cuda.reset_peak_memory_stats()
+model_fp16 = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME, torch_dtype=torch.float16, device_map=""auto"",
+)
+vram_fp16 = torch.cuda.max_memory_allocated() / 1e9
+
+del model_fp16
+gc.collect()
+torch.cuda.empty_cache()
+torch.cuda.reset_peak_memory_stats()
+
+model_4b = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME, quantization_config=bnb_config, device_map=""auto"",
+)
+vram_4bit_load = torch.cuda.max_memory_allocated() / 1e9
+
+del model_4b
+gc.collect()
+if torch.cuda.is_available():
+    torch.cuda.empty_cache()
+
+print(f""\n{'Configuration':<25} {'VRAM':>10} {'Economie':>10}"")
+print(f""{'-'*25} {'-'*10} {'-'*10}"")
+print(f""{'FP16 (base)':<25} {vram_fp16:>9.2f} G {'ref':>10}"")
+print(f""{'4-bit NF4 (QLoRA base)':<25} {vram_4bit_load:>9.2f} G {(1-vram_4bit_load/vram_fp16)*100:>9.1f}%"")
+print(f""{'QLoRA (4-bit + LoRA r=16)':<25} {vram_peak:>9.2f} G {(1-vram_peak/vram_fp16)*100:>9.1f}%"")
+print(f""\nTheorie : FP16 = {total_params*2/1e9:.2f} Go vs 4-bit = {total_params*0.5/1e9:.2f} Go (ratio 4x)"")",,,,,,,,31c5fe7b307bf67a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,fee88c51,code,fr,2373ea481726cb41,"# Tableau recapitulatif complet
+print(""\n"" + ""="" * 70)
+print(""RESUME COMPARATIF : LoRA (FP16) vs QLoRA (4-bit)"")
+print(""="" * 70)
+print(f""\n{'Aspect':<30} {'LoRA (FP16)':<20} {'QLoRA (4-bit)':<20}"")
+print(f""{'-'*30} {'-'*20} {'-'*20}"")
+print(f""{'Precision poids':<30} {'FP16 (16 bits)':<20} {'NF4 (4 bits)':<20}"")
+print(f""{'Calculs forward':<30} {'FP16':<20} {'FP16 (dequant)':<20}"")
+print(f""{'Grad + optimizer':<30} {'FP16 (LoRA seul)':<20} {'FP16 (LoRA seul)':<20}"")
+print(f""{'VRAM modele ~1.3B':<30} {'~2.6 Go':<20} {'~0.7 Go':<20}"")
+print(f""{'Qualite vs full FT':<30} {'~98-99%':<20} {'~97-99%':<20}"")
+print(f""{'Vitesse entrainement':<30} {'1x (ref)':<20} {'~0.8x (dequant)':<20}"")
+print(f""\nRecommendation :\n""
+      ""  - Modele < 1B + VRAM suffisante -> LoRA (FP16) : plus simple, plus rapide\n""
+      ""  - Modele > 1B ou VRAM limitee -> QLoRA : Economie memoire 3-4x"")",,,,,,,,2373ea481726cb41,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,c0dcac7e,markdown,fr,5908d144660dd9fe,## 8. Nettoyage memoire GPU,,,,,,,,5908d144660dd9fe,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,5daaeefa,code,fr,150132583b58e543,"del model_qlora, trainer
+gc.collect()
+if torch.cuda.is_available():
+    torch.cuda.empty_cache()
+    print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} Go"")
+else:
+    print(""Nettoyage termine"")",,,,,,,,150132583b58e543,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,8108d79d,markdown,fr,e4ec48ca64d396e4,"## 9. Exercices
+
+Appliquez les concepts de ce notebook.",,,,,,,,e4ec48ca64d396e4,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,e8d55b99,code,fr,8053ee91bcb22b72,"# Exercice 1 : Impact de la precision
+# TODO etudiant : Comparez INT8 (load_in_8bit=True) vs NF4 vs FP16
+# sur le meme modele. Mesurez la VRAM et la qualite de generation.
+# Indice : creez 3 BitsAndBytesConfig differents et chargez le modele.
+
+print(""Exercice a completer : comparez INT8 vs NF4 vs FP16"")",,,,,,,,8053ee91bcb22b72,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,2b0dd6e8,code,fr,b2bbc269cb1b8919,"# Exercice 2 : LoRA rank et memoire
+# TODO etudiant : Testez r=4, r=16, r=64 avec QLoRA sur OPT-1.3B.
+# Pour chaque rang, notez : params entrainables, VRAM pic, perte finale.
+# Etape 1 : definissez les 3 LoraConfig
+# Etape 2 : lancez l'entrainement pour chaque
+# Etape 3 : comparez dans un tableau
+
+print(""Exercice a completer : comparez les rangs QLoRA r=4, 16, 64"")",,,,,,,,b2bbc269cb1b8919,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,0dd9c769,markdown,fr,82904e6f41eb9847,"### Exercice 3 : Double quantization
+
+La double quantization (`bnb_4bit_use_double_quant=True`) compresse les constantes de quantization elles-memes en FP8, economisant ~0.37 bits/param. Comparez avec et sans pour mesurer l'impact reel sur la VRAM et la qualite.",,,,,,,,82904e6f41eb9847,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,c1471986,code,fr,27a3c73edffe2c59,"# Exercice 3 : Double quantization on/off
+# TODO etudiant : Comparez bnb_4bit_use_double_quant=True vs False.
+# Mesurez la difference de VRAM. Est-ce que la qualite change ?
+# Indice : la double quantization economise ~0.37 bits/param.
+
+print(""Exercice a completer : comparez double quantization on/off"")",,,,,,,,27a3c73edffe2c59,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-02-QLoRA-Quantization.ipynb,3e1127c5,markdown,fr,04913002b87b6de9,"## Resume
+
+| Aspect | LoRA (FT-01) | QLoRA (FT-02) |
+|--------|-------------|---------------|
+| Poids du modele | FP16 (16 bits) | NF4 (4 bits) |
+| Adaptateurs | LoRA en FP16 | LoRA en FP16 |
+| Calculs forward | FP16 natif | Dequantize → FP16 → re-quantize |
+| Economie memoire | ~1.1x modele base | **~3-4x vs FP16** |
+| Qualite | ~98-99% du full FT | ~97-99% du full FT |
+| Modele recommande | < 1B params | **> 1B params** |
+
+**Points cles** :
+- **QLoRA = Quantization (NF4) + LoRA** : le meilleur des deux mondes
+- **NF4** est optimal pour les poids (distribution normale), pas un simple INT4
+- **Double quantization** compresse les scaling factors pour des gains supplementaires
+- **`paged_adamw_8bit`** : optimiseur en 8-bit pour economiser encore plus de VRAM
+- Un modele 7B en QLoRA tient sur un GPU 6 Go — democratise le fine-tuning
+
+**Reference** : Dettmers et al., ""QLoRA: Efficient Finetuning of Quantized LLMs"" (2023).
+
+**Prochaines etapes** (FT-03) : Fine-tuning multi-taches avec plusieurs adaptateurs LoRA.",,,,,,,,04913002b87b6de9,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,0e944cc3,markdown,fr,5c753bc2baab385a,"# FT-03 : Supervised Fine-Tuning (SFT) — Instruction Following
+
+**Objectif** : Apprendre le Supervised Fine-Tuning (SFT), la technique qui transforme un modele de base (base model) en un assistant capable de suivre des instructions (instruct model). Vous comprendrez le format instruction-réponse, la preparation des donnees d'entrainement, et l'evaluation de la qualite des reponses.
+
+**Prerequis** :
+- FT-01 (Introduction au Fine-Tuning, LoRA sur GPT-2)
+- FT-02 (QLoRA Quantization)
+- Notions de PyTorch et Transformers
+
+**Plan du notebook** :
+1. Base Model vs Instruct Model — la difference cruciale
+2. Le format instruction-réponse (chat templates)
+3. Preparation d'un dataset SFT
+4. SFT avec QLoRA sur OPT-1.3B
+5. Evaluation qualitative : avant vs apres
+6. Impact de la taille du dataset
+7. Exercices
+
+**Duree estimee** : 45-60 minutes",,,,,,,,5c753bc2baab385a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,879e8090,code,fr,a96d427262372dd8,"import torch
+import os
+import gc
+import json
+import time
+
+print(f""PyTorch {torch.__version__}"")
+print(f""CUDA : {torch.cuda.is_available()}"")
+if torch.cuda.is_available():
+    print(f""GPU : {torch.cuda.get_device_name(0)}"")
+    props = torch.cuda.get_device_properties(0)
+    print(f""VRAM : {props.total_memory / 1e9:.1f} Go"")
+
+# Mode batch pour execution automatisee
+BATCH_MODE = os.environ.get(""BATCH_MODE"", ""false"").lower() == ""true""
+print(f""Batch mode : {BATCH_MODE}"")",,,,,,,,a96d427262372dd8,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,ad342c4a,markdown,fr,21f3114bf4bf9d92,"## 1. Base Model vs Instruct Model
+
+Un **modele de base** (base model) est entraine uniquement a predire le token suivant dans un texte. Il ne comprend pas la notion d'""instruction"" — si vous lui dites ""Expliquez la photosynthese"", il pourrait continuer la phrase (""...en utilisant des termes simples"") au lieu de repondre.
+
+Un **modele instruct** (instruct model) a subi un Supervised Fine-Tuning sur des paires instruction-réponse. Il a appris a :
+- Comprendre qu'on lui pose une question ou donne une tache
+- Produire une reponse structuree et pertinente
+- Suivre des formats specifiques (explication, code, liste, etc.)
+
+La transition base → instruct est exactement ce que nous allons reproduire dans ce notebook avec un petit modele.",,,,,,,,21f3114bf4bf9d92,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,d7add7dd,markdown,fr,c9809a663f4b7007,"## 2. Le format instruction-réponse (chat templates)
+
+Les modeles instruct utilisent un **format de conversation** (chat template) pour delimiter les roles. Par exemple :
+
+```
+### Human: Expliquez la photosynthese en 2 phrases.
+### Assistant: La photosynthese est le processus par lequel les plantes convertissent la lumiere du soleil, le CO2 et l'eau en glucose et oxygene. Ce mecanisme se deroule dans les chloroplastes des cellules vegetales grace a la chlorophylle.
+```
+
+Le format exact depend du modele. Pour les modeles de la famille OPT, le format `### Human:` / `### Assistant:` est courant. D'autres modeles utilisent des tokens speciaux (`<|im_start|>user\n...<|im_end|>` pour les modeles ChatML).
+
+**Point cle** : le chat template est un contrat entre les donnees d'entrainement et l'inference. Si vous entrainez avec un format, vous devez utiliser le meme format a l'inference.",,,,,,,,c9809a663f4b7007,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,2ba5d60b,code,fr,7833f4582ae811f9,"# Charger le modele de base (OPT-1.3B, quantize 4-bit pour economiser la VRAM)
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+import torch
+
+MODEL_NAME = ""facebook/opt-1.3b""
+
+# Quantization 4-bit (QLoRA, comme dans FT-02)
+bnb_config = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type=""nf4"",
+    bnb_4bit_compute_dtype=torch.float16,
+    bnb_4bit_use_double_quant=True,
+)
+
+print(f""Chargement de {MODEL_NAME} en 4-bit..."")
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+tokenizer.pad_token = tokenizer.eos_token
+tokenizer.padding_side = ""right""
+
+model_base = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME,
+    quantization_config=bnb_config,
+    device_map=""auto"",
+)
+print(f""Modele charge. Parametres : {sum(p.numel() for p in model_base.parameters()):,}"")
+
+if torch.cuda.is_available():
+    vram_mb = torch.cuda.memory_allocated() / 1e6
+    print(f""VRAM utilisee : {vram_mb:.0f} Mo"")",,,,,,,,7833f4582ae811f9,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,87c08f80,markdown,fr,a860a9e4936ccaa0,"### 2a. Demonstration : le modele de base ne suit pas les instructions
+
+Testons le modele de base avec des instructions. Observez comment il ""continue"" le texte au lieu de repondre a la question.",,,,,,,,a860a9e4936ccaa0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,c5b7deff,code,fr,76f2fc7fced2ad81,"# Test du modele de base avec des instructions
+def generate(model, prompt, max_new_tokens=80, temperature=0.7):
+    inputs = tokenizer(prompt, return_tensors=""pt"").to(model.device)
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            do_sample=True,
+            top_p=0.9,
+            pad_token_id=tokenizer.eos_token_id,
+        )
+    response = tokenizer.decode(outputs[0][inputs[""input_ids""].shape[1]:], skip_special_tokens=True)
+    return response.strip()
+
+# Instructions de test
+test_prompts = [
+    ""### Human: Qu'est-ce que la gravite ?\n### Assistant:"",
+    ""### Human: Expliquez le concept d'intelligence artificielle en termes simples.\n### Assistant:"",
+    ""### Human: Donne-moi 3 conseils pour ameliorer ma productivite.\n### Assistant:"",
+]
+
+print(""=== REPONSES DU MODELE DE BASE (avant SFT) ===\n"")
+for prompt in test_prompts:
+    response = generate(model_base, prompt)
+    instruction = prompt.split(""### Human: "")[1].split(""\n"")[0]
+    print(f""Instruction : {instruction}"")
+    print(f""Reponse     : {response}"")
+    print(""-"" * 60)",,,,,,,,76f2fc7fced2ad81,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,da07c4a7,markdown,fr,6acd106968fa98e6,"**Observation** : Le modele de base produit du texte coherent mais ne repond pas vraiment aux instructions. Il peut ignorer la question, la reformuler, ou generer du contenu sans rapport. C'est normal : il a ete entraine uniquement a predire la suite du texte, pas a suivre des instructions.
+
+Nous allons maintenant lui apprendre a repondre correctement avec le SFT.",,,,,,,,6acd106968fa98e6,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,8d1a1b00,markdown,fr,795beb8153082597,"## 3. Preparation d'un dataset SFT
+
+Pour le SFT, nous avons besoin de paires **instruction → reponse attendue**. La qualite du dataset est le facteur le plus important pour la reussite du fine-tuning.
+
+Nous allons creer un petit dataset synthetique en francais couvrant plusieurs categories d'instructions :
+- **Questions factuelles** : ""Qu'est-ce que X ?""
+- **Explications** : ""Expliquez le concept de Y""
+- **Listes/conseils** : ""Donnez N conseils pour Z""
+- **Resumes** : ""Resumez le texte suivant""",,,,,,,,795beb8153082597,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,f850cac2,code,fr,eefe041aca1416d0,"# Dataset SFT synthetique — paires instruction/reponse en francais
+# Format: {""instruction"": ""..."", ""response"": ""...""}
+sft_data = [
+    # Questions factuelles
+    {""instruction"": ""Qu'est-ce que la gravite ?"", ""response"": ""La gravite est une force fondamentale qui attire deux corps massifs l'un vers l'autre. Sur Terre, elle nous maintient au sol et donne leur poids aux objets. Isaac Newton a formule la loi de la gravitation universelle, puis Albert Einstein l'a reformulee dans sa theorie de la relativite generale comme une deformation de l'espace-temps.""},
+    {""instruction"": ""Qu'est-ce que l'intelligence artificielle ?"", ""response"": ""L'intelligence artificielle (IA) est un domaine de l'informatique qui vise a creer des systemes capables de realiser des taches necessitant normalement l'intelligence humaine : reconnaissance d'images, comprehension du langage, prise de decision. L'apprentissage profond (deep learning) est la technique la plus performante actuellement.""},
+    {""instruction"": ""Qu'est-ce que le machine learning ?"", ""response"": ""Le machine learning (apprentissage automatique) est une branche de l'IA ou les systemes apprennent a partir de donnees sans etre explicitement programmes. Les trois types principaux sont : l'apprentissage supervise (avec labels), non supervise (sans labels) et par renforcement (par recompenses).""},
+    {""instruction"": ""Qu'est-ce qu'un neurone artificiel ?"", ""response"": ""Un neurone artificiel est l'unite de base d'un reseau de neurones. Il recoit des entrees numeriques, les multiplie par des poids, additionne les resultats, puis applique une fonction d'activation (comme ReLU ou sigmoid) pour produire une sortie. En combinant des millions de neurones, on obtient des modeles capables d'apprendre des patterns complexes.""},
+    {""instruction"": ""Qu'est-ce que Python ?"", ""response"": ""Python est un langage de programmation de haut niveau, cree par Guido van Rossum en 1991. Il est connu pour sa syntaxe lisible et sa polyvalence. Python est tres utilise en science des donnees, en intelligence artificielle, en developpement web et en automatisation.""},
+
+    # Explications
+    {""instruction"": ""Expliquez le concept de reseau de neurones en termes simples."", ""response"": ""Un reseau de neurones fonctionne comme une equipe de decision. Imaginez des centaines de personnes, chacune regardant une petite partie d'un probleme. Chaque personne donne son avis avec une certaine confiance (le poids). Un chef d'equipe rassemble tous les avis et prend une decision. En s'entrainant sur beaucoup d'exemples, l'equipe apprend a donner les bonnes reponses.""},
+    {""instruction"": ""Expliquez la difference entre CPU et GPU."", ""response"": ""Le CPU (processeur) est comme un chef tres intelligent qui traite les taches une par une rapidement. Le GPU (carte graphique) est comme une equipe de milliers de travailleurs moins rapides mais travaillant en parallele. Pour les calculs repetitifs comme l'entrainement des reseaux de neurones, le GPU est beaucoup plus efficace grace a son parallelisme massif.""},
+    {""instruction"": ""Expliquez ce qu'est une API."", ""response"": ""Une API (Application Programming Interface) est comme un menu de restaurant entre deux logiciels. Le menu liste ce que vous pouvez commander (les fonctions disponibles), comment passer commande (les parametres), et ce que vous recevez (la reponse). Vous n'avez pas besoin de savoir comment la cuisine fonctionne, il suffit de commander.""},
+
+    # Listes / Conseils
+    {""instruction"": ""Donnez 3 conseils pour ameliorer sa productivite au travail."", ""response"": ""Voici 3 conseils pour ameliorer votre productivite :\n1. **Technique Pomodoro** : Travaillez 25 minutes, puis faites 5 minutes de pause. Apres 4 cycles, prenez une pause de 15-30 minutes.\n2. **Priorisation** : Commencez par la tache la plus importante (la methode \""eat the frog\""). Les premieres heures sont souvent les plus productives.\n3. **Bloquer les distractions** : Desactivez les notifications, fermez les onglets inutiles et utilisez un casque pour signaler que vous etes concentre.""},
+    {""instruction"": ""Listez 4 avantages du langage Python pour la data science."", ""response"": ""Voici 4 avantages de Python pour la data science :\n1. **Ecosysteme riche** : NumPy, Pandas, Scikit-learn, TensorFlow, PyTorch couvrent tout le pipeline.\n2. **Syntaxe lisible** : Le code est facile a comprendre et a partager entre equipes.\n3. **Communaute active** : Des millions de developpeurs, des milliers de tutoriels et de packages.\n4. **Polyvalence** : Meme langage pour l'analyse, le ML, le web et l'automatisation.""},
+    {""instruction"": ""Quelles sont les 5 etapes d'un projet de machine learning ?"", ""response"": ""Les 5 etapes d'un projet de ML sont :\n1. **Definition du probleme** : Clarifier l'objectif et les metriques de succes.\n2. **Collecte de donnees** : Obtenir un dataset representative et de qualite.\n3. **Preparation** : Nettoyage, transformation, et split train/validation/test.\n4. **Entrainement** : Choisir un modele, l'entrainer et optimiser les hyperparametres.\n5. **Evaluation et deploiement** : Mesurer les performances et mettre en production.""},
+
+    # Resumes
+    {""instruction"": ""Resumez en une phrase : Le machine learning permet aux ordinateurs d'apprendre a partir de donnees sans etre explicitement programmes pour chaque tache."", ""response"": ""Le machine learning est une approche ou les systemes informatiques apprennent automatiquement des patterns a partir de donnees plutot que de suivre des regles predefinies.""},
+    {""instruction"": ""Resumez en une phrase : Les transformers sont une architecture de reseau de neurones qui utilise le mecanisme d'attention pour traiter des sequences de donnees en parallele, revolutionnant le NLP."", ""response"": ""Les transformers utilisent le mecanisme d'attention pour traiter des sequences en parallele, ce qui a transforme le traitement du langage naturel.""},
+    {""instruction"": ""Resumez en une phrase : Le fine-tuning consiste a ajuster les poids d'un modele pre-entraine sur un dataset specifique pour adapter ses performances a une tache particuliere."", ""response"": ""Le fine-tuning adapte un modele pre-entraine a une tache specifique en ajustant ses poids sur un dataset cible.""},
+
+    # Questions conceptuelles
+    {""instruction"": ""Pourquoi le deep learning a-t-il connu un essor recent ?"", ""response"": ""Le deep learning a connu un essor recent grace a trois facteurs : (1) la disponibilite de grandes quantites de donnees sur Internet, (2) l'augmentation de la puissance de calcul, notamment avec les GPU, et (3) les progres algorithmiques comme les architectures transformers et les techniques d'entrainement plus efficaces.""},
+    {""instruction"": ""Quelle est la difference entre apprentissage supervise et non supervise ?"", ""response"": ""En apprentissage supervise, le modele apprend a partir de donnees labellisees (exemples avec la reponse correcte), comme classifier des images avec leurs etiquettes. En apprentissage non supervise, le modele decouvre des structures dans les donnees sans labels, comme regrouper des clients similaires (clustering).""},
+    {""instruction"": ""Qu'est-ce que le surapprentissage (overfitting) ?"", ""response"": ""Le surapprentissage se produit quand un modele apprend par coeur les donnees d'entrainement au lieu de generaliser. Il obtient d'excellents resultats sur les donnees vues mais de mauvais sur les nouvelles donnees. On le combat avec la regularisation, le dropout, l'augmentation de donnees et un split train/validation.""},
+
+    # Code / Pratique
+    {""instruction"": ""Comment creer une liste vide en Python ?"", ""response"": ""Pour creer une liste vide en Python, vous pouvez utiliser soit les crochets `ma_liste = []` soit le constructeur `ma_liste = list()`. La premiere methode est plus courante et legerement plus rapide.""},
+    {""instruction"": ""Quelle est la difference entre une liste et un tuple en Python ?"", ""response"": ""Une liste (entre crochets `[]`) est mutable : on peut ajouter, supprimer ou modifier ses elements. Un tuple (entre parentheses `()`) est immutable : une fois cree, il ne peut pas etre modifie. Les tuples sont legerement plus rapides et servent souvent de cles de dictionnaire.""},
+    {""instruction"": ""Qu'est-ce qu'un dictionnaire en Python ?"", ""response"": ""Un dictionnaire est une structure de donnees qui stocke des paires cle-valeur. Par exemple : `etudiant = {\""nom\"": \""Alice\"", \""age\"": 22}`. On accede aux valeurs via les cles : `etudiant[\""nom\""]` retourne \""Alice\"". Les dictionnaires sont mutables et tres efficaces pour la recherche.""},
+]
+
+print(f""Dataset SFT cree : {len(sft_data)} paires instruction/reponse"")
+print(f""\nExemple :"")
+print(f""  Instruction : {sft_data[0]['instruction']}"")
+print(f""  Reponse     : {sft_data[0]['response'][:80]}..."")
+
+# Statistiques
+categories = {
+    ""Questions factuelles"": sum(1 for d in sft_data if d[""instruction""].startswith(""Qu'est-ce"")),
+    ""Explications"": sum(1 for d in sft_data if d[""instruction""].startswith(""Expliquez"")),
+    ""Listes/Conseils"": sum(1 for d in sft_data if any(k in d[""instruction""] for k in [""conseils"", ""Listez"", ""etapes"", ""avantages""])),
+    ""Resumes"": sum(1 for d in sft_data if d[""instruction""].startswith(""Resumez"")),
+    ""Concepts"": sum(1 for d in sft_data if d[""instruction""].startswith(""Pourquoi"") or d[""instruction""].startswith(""Quelle"")),
+    ""Code/Pratique"": sum(1 for d in sft_data if any(k in d[""instruction""] for k in [""Python"", ""Comment"", ""creer""])),
+}
+print(f""\nRepartition par categorie :"")
+for cat, count in categories.items():
+    print(f""  {cat} : {count}"")",,,,,,,,eefe041aca1416d0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,cc37460f,markdown,fr,ba5d1f8b34674e0e,"## 4. Formatage et tokenisation des donnees
+
+Avant l'entrainement, chaque paire instruction/reponse doit etre formatee selon le **chat template** du modele. Pour OPT, le format est :
+
+```
+### Human: {instruction}
+### Assistant: {response}
+```
+
+Nous tokenisons ensuite le texte formate pour obtenir les sequences d'entiers compréhensibles par le modele.",,,,,,,,ba5d1f8b34674e0e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,aeb5d3eb,code,fr,ae0448dd8dca0070,"# Formater les donnees SFT en utilisant le chat template
+def format_sft_example(example):
+    """"""Convertit une paire instruction/reponse en texte formate pour OPT.""""""
+    return f""### Human: {example['instruction']}\n### Assistant: {example['response']}""
+
+# Formater et tokeniser toutes les donnees
+formatted_data = []
+for item in sft_data:
+    text = format_sft_example(item)
+    formatted_data.append(text)
+
+print(f""Exemple formate :\n{'-' * 50}"")
+print(formatted_data[0][:200] + ""..."")
+print(f""\n{len(formatted_data)} exemples formates"")
+
+# Tokeniser avec le tokenizer du modele
+tokenized_data = []
+for text in formatted_data:
+    tokens = tokenizer(text, truncation=True, max_length=512, return_tensors=None)
+    tokenized_data.append({
+        ""input_ids"": tokens[""input_ids""],
+        ""attention_mask"": tokens[""attention_mask""],
+        ""text"": text,
+    })
+
+# Statistiques de longueur
+lengths = [len(t[""input_ids""]) for t in tokenized_data]
+print(f""\nStatistiques de tokenisation :"")
+print(f""  Longueur min  : {min(lengths)} tokens"")
+print(f""  Longueur max  : {max(lengths)} tokens"")
+print(f""  Longueur moy  : {sum(lengths) / len(lengths):.0f} tokens"")",,,,,,,,ae0448dd8dca0070,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,68fbcff5,markdown,fr,cebe5401fa1f8a1b,"### 4a. Configuration QLoRA pour le SFT
+
+Nous reprenons la configuration QLoRA du FT-02, en ajoutant les adapteurs LoRA sur le modele deja quantifie en 4-bit. Seuls les parametres LoRA seront entraines (quelques millions), pas le modele complet (~1.3 milliard).",,,,,,,,cebe5401fa1f8a1b,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,19ded383,code,fr,868f4bb26a11037a,"# Configurer QLoRA (LoRA sur modele quantifie)
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training, TaskType
+
+# Preparer le modele pour l'entrainement en 4-bit
+model_base = prepare_model_for_kbit_training(model_base)
+
+# Configuration LoRA
+lora_config = LoraConfig(
+    task_type=TaskType.CAUSAL_LM,
+    r=16,                    # Rang des matrices LoRA
+    lora_alpha=32,           # Facteur de mise a l'echelle
+    lora_dropout=0.05,       # Dropout pour regularisation
+    target_modules=[""q_proj"", ""v_proj""],  # Couches a adapter
+    bias=""none"",
+)
+
+# Appliquer LoRA au modele
+model_sft = get_peft_model(model_base, lora_config)
+model_sft.print_trainable_parameters()
+
+print(f""\nVRAM avant entrainement : {torch.cuda.memory_allocated() / 1e6:.0f} Mo"")",,,,,,,,868f4bb26a11037a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,dbb4632c,markdown,fr,bf5825e94ea83a14,"## 5. Entrainement SFT
+
+Nous utilisons le `Trainer` de HuggingFace pour orchestrer l'entrainement. Le dataset est petit (21 exemples), donc nous ferons plusieurs epoques pour que le modele apprenne bien le format instruction/reponse.
+
+**Hyperparametres cles** :
+- `num_train_epochs=5` : le dataset est petit, on compense avec plus de passages
+- `learning_rate=2e-4` : taux d'apprentissage standard pour LoRA
+- `per_device_train_batch_size=2` : petit batch pour la VRAM
+- `gradient_accumulation_steps=4` : simule un batch de 8",,,,,,,,bf5825e94ea83a14,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,6eb4f241,code,fr,cceb5aa30ebbedfb,"# Preparation du dataset pour le Trainer HuggingFace
+from datasets import Dataset
+from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling
+
+# Creer un Dataset HuggingFace a partir des donnees formatees
+train_texts = [t[""text""] for t in tokenized_data]
+train_dataset = Dataset.from_dict({""text"": train_texts})
+
+# Fonction de tokenisation pour le dataset
+def tokenize_function(examples):
+    return tokenizer(
+        examples[""text""],
+        truncation=True,
+        max_length=512,
+        padding=""max_length"",
+        return_tensors=None,
+    )
+
+tokenized_dataset = train_dataset.map(
+    tokenize_function,
+    batched=True,
+    remove_columns=[""text""],
+)
+
+# Data collator pour le language modeling causal
+data_collator = DataCollatorForLanguageModeling(
+    tokenizer=tokenizer,
+    mlm=False,
+)
+
+print(f""Dataset pret : {len(tokenized_dataset)} exemples"")
+print(f""Colonnes : {tokenized_dataset.column_names}"")",,,,,,,,cceb5aa30ebbedfb,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,2e7449a9,code,fr,bbd5c351edae0724,"# Entrainement SFT
+training_args = TrainingArguments(
+    output_dir=""./results_ft03"",
+    num_train_epochs=5,
+    per_device_train_batch_size=2,
+    gradient_accumulation_steps=4,
+    learning_rate=2e-4,
+    weight_decay=0.01,
+    warmup_ratio=0.1,
+    logging_steps=5,
+    save_strategy=""epoch"",
+    report_to=""none"",
+    fp16=True,
+    gradient_checkpointing=True,
+    remove_unused_columns=False,
+)
+
+trainer = Trainer(
+    model=model_sft,
+    args=training_args,
+    train_dataset=tokenized_dataset,
+    data_collator=data_collator,
+)
+
+print(""Debut de l'entrainement SFT..."")
+start_time = time.time()
+train_result = trainer.train()
+elapsed = time.time() - start_time
+
+print(f""\nEntrainement termine en {elapsed:.1f}s ({elapsed/60:.1f} min)"")
+print(f""Perte finale : {train_result.training_loss:.4f}"")
+print(f""VRAM apres entrainement : {torch.cuda.memory_allocated() / 1e6:.0f} Mo"")",,,,,,,,bbd5c351edae0724,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,a81a363c,markdown,fr,7ae0e41cead8d7ac,"## 6. Evaluation : avant vs apres SFT
+
+C'est le moment de verifier si le SFT a fonctionne. Nous testons le modele fine-tune avec les memes instructions que le modele de base. Un modele SFT reussi devrait :
+- Repondre directement a l'instruction (pas continuer le texte)
+- Produire une reponse coherente et pertinente
+- Respecter le format attendu (explication, liste, resume)",,,,,,,,7ae0e41cead8d7ac,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,e94be965,code,fr,523d879d90cda59e,"# Evaluation comparative : modele de base vs modele SFT
+model_sft.eval()
+
+# Instructions de test (memes que pour le modele de base, plus de nouvelles)
+eval_prompts = [
+    ""### Human: Qu'est-ce que la gravite ?\n### Assistant:"",
+    ""### Human: Expliquez le concept d'intelligence artificielle en termes simples.\n### Assistant:"",
+    ""### Human: Donne-moi 3 conseils pour ameliorer ma productivite.\n### Assistant:"",
+    ""### Human: Qu'est-ce qu'un reseau de neurones ?\n### Assistant:"",
+]
+
+print(""="" * 70)
+print(""COMPARAISON : MODELE DE BASE vs MODELE SFT"")
+print(""="" * 70)
+
+for prompt in eval_prompts:
+    instruction = prompt.split(""### Human: "")[1].split(""\n"")[0]
+
+    # Reponse du modele SFT
+    response_sft = generate(model_sft, prompt, max_new_tokens=100, temperature=0.7)
+
+    print(f""\nInstruction : {instruction}"")
+    print(f""  SFT : {response_sft[:200]}"")
+    print(""  "" + ""-"" * 60)",,,,,,,,523d879d90cda59e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,a047e5d6,markdown,fr,d26f5e7c6e619fe1,"**Observation** : Le modele SFT devrait maintenant repondre directement aux instructions au lieu de continuer le texte. La qualite des reponses depend de :
+1. **La taille du dataset** — 21 exemples est un minimum, les modeles de production utilisent 10K-100K+ exemples
+2. **La qualite des donnees** — des reponses mal formatees ou incorrectes seront apprises telles quelles
+3. **Le nombre d'epochs** — trop peu = sous-apprentissage, trop = surapprentissage",,,,,,,,d26f5e7c6e619fe1,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,dcc61c62,markdown,fr,bbe5ecffc498e921,"## 7. Impact de la taille du dataset
+
+Un SFT efficace depends fortement de la quantite de donnees. Testons avec differents sous-ensembles de notre dataset pour observer l'impact sur la qualite des reponses.",,,,,,,,bbe5ecffc498e921,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,160dc825,code,fr,c47a8ce407a807dd,"# Impact de la taille du dataset — entrainement avec seulement 5 exemples
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+import copy
+
+# Recharger un modele frais pour comparaison equitable
+model_small = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME,
+    quantization_config=bnb_config,
+    device_map=""auto"",
+)
+model_small = prepare_model_for_kbit_training(model_small)
+model_small = get_peft_model(model_small, lora_config)
+
+# Entrainer avec seulement 5 exemples
+small_texts = [format_sft_example(d) for d in sft_data[:5]]
+small_dataset = Dataset.from_dict({""text"": small_texts})
+small_tokenized = small_dataset.map(tokenize_function, batched=True, remove_columns=[""text""])
+
+small_trainer = Trainer(
+    model=model_small,
+    args=TrainingArguments(
+        output_dir=""./results_ft03_small"",
+        num_train_epochs=5,
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=2,
+        learning_rate=2e-4,
+        logging_steps=2,
+        report_to=""none"",
+        fp16=True,
+        gradient_checkpointing=True,
+        remove_unused_columns=False,
+    ),
+    train_dataset=small_tokenized,
+    data_collator=data_collator,
+)
+
+print(""Entrainement avec 5 exemples seulement..."")
+small_result = small_trainer.train()
+print(f""Perte finale (5 exemples) : {small_result.training_loss:.4f}"")
+
+# Tester
+test_prompt = ""### Human: Qu'est-ce que la gravite ?\n### Assistant:""
+response_small = generate(model_small, test_prompt, max_new_tokens=80)
+print(f""\nReponse (5 exemples) : {response_small[:200]}"")
+
+# Liberer la memoire
+del model_small, small_trainer
+gc.collect()
+torch.cuda.empty_cache()
+print(f""\nVRAM apres cleanup : {torch.cuda.memory_allocated() / 1e6:.0f} Mo"")",,,,,,,,c47a8ce407a807dd,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,8a64a856,markdown,fr,2c886c6a35a70940,"**Conclusion sur la taille du dataset** : Avec seulement 5 exemples, le modele apprend moins bien le format instruction/reponse. La difference est visible : les reponses sont moins structurees et le modele peut encore parfois \""oublier\"" qu'il doit repondre a une instruction.
+
+En production, les datasets SFT contiennent typiquement entre 10 000 et 1 million de paires instruction/reponse.",,,,,,,,2c886c6a35a70940,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,fc7a9214,code,fr,0d31b0b8cca1b1b3,"# Liberation de la memoire GPU
+del model_sft, model_base, trainer
+gc.collect()
+torch.cuda.empty_cache()
+print(""Memoire GPU liberee."")
+if torch.cuda.is_available():
+    print(f""VRAM residuelle : {torch.cuda.memory_allocated() / 1e6:.0f} Mo"")",,,,,,,,0d31b0b8cca1b1b3,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,e287ecdc,markdown,fr,65476f33de2ac5b3,"## 8. Exercices
+
+Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts precedents.",,,,,,,,65476f33de2ac5b3,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,d01fb06b,markdown,fr,861618f9b4b198a1,"### Exercice 1 : Creer un dataset SFT thematique
+
+Creez un dataset SFT de 10 paires instruction/reponse sur un **theme de votre choix** (cuisine, sport, musique, etc.). Formatez les donnees avec le chat template, puis entrainez un modele QLoRA et observez les resultats.
+
+**Etapes** :
+1. Choisissez un theme et creez 10 paires instruction/reponse coherentes
+2. Formatez avec le chat template `### Human:` / `### Assistant:`
+3. Entrainez le modele avec les memes hyperparametres
+4. Testez avec 3 instructions de votre theme",,,,,,,,861618f9b4b198a1,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,266ae5f2,code,fr,1e677a3ce33719f0,"# Exercice 1 : Creez votre dataset SFT thematique
+# TODO etudiant : remplacez les exemples ci-dessous par votre propre theme
+
+mon_dataset = [
+    {""instruction"": ""Donnez une recette simple de pates."", ""response"": ""Faites cuire 200g de pates dans l'eau bouillante salee pendant 8-10 minutes. Egouttez, ajoutez un filet d'huile d'olive, du parmesan rape et du poivre. C'est pret !""},
+    # TODO etudiant : ajoutez 9 autres paires sur votre theme
+]
+
+# TODO etudiant : formatez avec le chat template et entrainez le modele
+print(f""Dataset en cours : {len(mon_dataset)} paires (objectif : 10)"")",,,,,,,,1e677a3ce33719f0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,7e1c0804,markdown,fr,c6f71911f23fcc50,"### Exercice 2 : Comparer differents rangs LoRA
+
+Le rang `r` des matrices LoRA controle la capacite d'apprentissage. Testez avec `r=4` (faible) et `r=64` (eleve) et comparez les resultats. Observez le trade-off entre qualite des reponses et nombre de parametres entrainables.
+
+**Etapes** :
+1. Entrainez avec `r=4` et notez le nombre de parametres entrainables + la perte finale
+2. Entrainez avec `r=64` et notez les memes metriques
+3. Comparez les reponses sur 2 instructions test
+4. Quel rang donne les meilleurs resultats sur notre petit dataset ?",,,,,,,,c6f71911f23fcc50,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,ac8745ff,code,fr,2a9ac476dd9efc9b,"# Exercice 2 : Comparez differents rangs LoRA (r=4 vs r=64)
+# TODO etudiant : entrainez avec r=4 puis r=64 et comparez
+
+# Indice : modifiez LoraConfig(r=4, ...) et LoraConfig(r=64, ...)
+# Puis utilisez le meme Trainer qu'en section 5
+
+resultats_comparaison = {
+    ""r=4"": {""parametres"": None, ""perte"": None},   # TODO etudiant : remplir
+    ""r=16"": {""parametres"": None, ""perte"": None},   # reference (deja fait)
+    ""r=64"": {""parametres"": None, ""perte"": None},   # TODO etudiant : remplir
+}
+print(""Completez les entrainements puis remplissez resultats_comparaison"")",,,,,,,,2a9ac476dd9efc9b,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,1e5e92a0,markdown,fr,1cfa7b345afe12b0,"### Exercice 3 : Analyser les limites du SFT avec un petit dataset
+
+Produisez un petit rapport (en markdown dans une cellule) analysant les limites observees :
+1. Quels types d'instructions le modele SFT gere-t-il bien ? Mal ?
+2. Que se passe-t-il si vous donnez une instruction hors du dataset d'entrainement ?
+3. Combien d'exemples faudrait-il approximativement pour obtenir des resultats fiables ?
+
+**Indice** : Testez avec des instructions originales non presentes dans le dataset pour evaluer la generalisation.",,,,,,,,1cfa7b345afe12b0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,6c80266a,code,fr,b45f07d235dcd061,"# Exercice 3 : Test de generalisation
+# TODO etudiant : testez le modele SFT avec des instructions originales
+
+instructions_test = [
+    ""Quelle est la capitale de l'Australie ?"",
+    ""Expliquez pourquoi le ciel est bleu."",
+    ""Donnez 2 astuces pour apprendre une langue etrangere."",
+]
+
+# TODO etudiant : chargez le meilleur modele SFT, testez ces instructions
+# et analysez la qualite des reponses
+print(""Testez avec votre modele SFT et analysez les resultats"")",,,,,,,,b45f07d235dcd061,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-03-Supervised-FineTuning-SFT.ipynb,6f2647d5,markdown,fr,2f952da284e721d4,"## 9. Resume du FT-03
+
+| Concept | Detail |
+|---------|--------|
+| **SFT (Supervised Fine-Tuning)** | Entrainement sur des paires instruction/reponse pour transformer un modele de base en assistant |
+| **Chat template** | Format de conversation (`### Human:` / `### Assistant:`) — contrat entre entrainement et inference |
+| **Dataset SFT** | 21 paires en francais couvrant 6 categories de taches |
+| **QLoRA** | Quantization 4-bit NF4 + LoRA (r=16) = ~0.1% des parametres entraines |
+| **Resultat** | Le modele apprend a repondre aux instructions au lieu de continuer le texte |
+| **Limites** | Petit dataset = generalisation limitee, reponses parfois repetitives |
+
+**Prochaines etapes** : Le FT-04 explorera le RLHF (Reinforcement Learning from Human Feedback), qui affine les reponses du modele SFT en utilisant les preferences humaines comme signal de recompense.",,,,,,,,2f952da284e721d4,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,d2186f84,markdown,fr,61679d3ef8df9173,"# FT-04 : RLHF et Alignement — Preferences Humaines et DPO
+
+**Objectif** : Comprendre comment les preferences humaines permettent d'aligner un LLM, du Reward Model au DPO (Direct Preference Optimization).
+
+**Prerequis** : FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT)
+
+**Duree estimee** : ~30 min
+
+**Plan du notebook** :
+1. Pourquoi le SFT ne suffit pas
+2. Le pipeline RLHF (SFT -> Reward Model -> PPO)
+3. Donnees de preference (chosen vs rejected)
+4. Le Reward Model
+5. DPO : Optimisation Directe des Preferences
+6. Evaluation : SFT vs DPO
+7. Comparaison RLHF vs DPO
+
+**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**",,,,,,,,61679d3ef8df9173,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,cf552bd0,code,fr,c2261ec1b233c654,"import torch
+import os
+import gc
+import copy
+import json
+import torch.nn.functional as F
+
+BATCH_MODE = os.environ.get(""BATCH_MODE"", ""false"").lower() == ""true""
+
+print(f""PyTorch {torch.__version__}"")
+print(f""CUDA : {torch.cuda.is_available()}"")
+if torch.cuda.is_available():
+    props = torch.cuda.get_device_properties(0)
+    print(f""GPU : {props.name}, {props.total_memory / 1e9:.1f} GB VRAM"")
+    print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} GB"")",,,,,,,,c2261ec1b233c654,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,caab975c,markdown,fr,cd6114804e4633a2,"## 1. Pourquoi le SFT ne suffit pas
+
+Le FT-03 nous a montre comment transformer un modele de base en modele instruct via le SFT. Mais le SFT a des limites fondamentales :
+
+- **Pas de notion de qualite** : Le SFT apprend a reproduire les reponses du dataset, sans distinguer une bonne reponse d'une excellente.
+- **Pas d'alignement** : Un modele SFT peut generer des reponses techniquement correctes mais maladroites, trop longues, ou manquant de nuances.
+- **Pas de signal de preference** : Le SFT optimise la cross-entropy sur une seule reponse cible, pas une metrique de ""qualite percue par l'utilisateur"".
+
+**Le probleme central** : Comment faire pour que le modele produise des reponses que les humains *preferent* ?",,,,,,,,cd6114804e4633a2,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,2bbe17fa,code,fr,a33739e880577f34,"# Charger le modele de base pour demontrer les limites du SFT
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training, TaskType
+
+MODEL_NAME = ""facebook/opt-1.3b""
+
+bnb_config = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type=""nf4"",
+    bnb_4bit_compute_dtype=torch.float16,
+    bnb_4bit_use_double_quant=True,
+)
+
+model_base = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME, quantization_config=bnb_config, device_map=""auto""
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+tokenizer.pad_token = tokenizer.eos_token
+
+def generate(model, prompt, max_new_tokens=60, temperature=0.7):
+    inputs = tokenizer(prompt, return_tensors=""pt"").to(model.device)
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs, max_new_tokens=max_new_tokens,
+            temperature=temperature, do_sample=True, top_p=0.9,
+            pad_token_id=tokenizer.eos_token_id
+        )
+    response = tokenizer.decode(outputs[0][inputs[""input_ids""].shape[1]:], skip_special_tokens=True)
+    return response.strip()
+
+# Exemple : questions ou la ""meilleure"" reponse est subjective
+test_prompts = [
+    ""### Human: Quel est le meilleur framework Python pour le web ?\n### Assistant:"",
+    ""### Human: Comment reussir un projet de developpement ?\n### Assistant:"",
+]
+
+print(""Le modele de base ne distingue pas une reponse 'bonne' d'une 'preferee' :"")
+print()
+for p in test_prompts:
+    q = p.split(""Human: "")[1].split(""\\n"")[0]
+    resp = generate(model_base, p, max_new_tokens=40)
+    print(f""Q: {q}"")
+    print(f""  Reponse: {resp}"")
+    print()",,,,,,,,a33739e880577f34,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,95d9c377,markdown,fr,8bb67b06426ad6d9,"**Observation** : Le modele de base genere du texte coherent mais ne peut pas distinguer une reponse ""bonne"" d'une reponse ""preferee par l'utilisateur"". Le SFT resout partiellement ce probleme en apprenant des reponses cibles, mais il n'apprend pas a **ranger** les reponses par qualite.
+
+C'est la que le RLHF intervient : utiliser les **preferences humaines** comme signal d'apprentissage.",,,,,,,,8bb67b06426ad6d9,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,24941a98,markdown,fr,6759f7bf678e333f,"## 2. Le Pipeline RLHF
+
+Le RLHF (Reinforcement Learning from Human Feedback) resout ce probleme en 3 etapes :
+
+```
+  Etape 1           Etape 2              Etape 3
+  SFT               Reward Model         PPO ou DPO
+  (FT-03)           (ce notebook)        (optimisation)
+     |                   |                     |
+  Modele instruct    Score de qualite      Maximiser le score
+  de base           des reponses          des reponses
+```
+
+**Etape 1 -- SFT** (deja vu en FT-03) : Creer un modele de base qui suit les instructions.
+
+**Etape 2 -- Reward Model** : Entrainer un modele a scorer les reponses selon les preferences humaines. Pour chaque paire (question, reponse), le RM attribue un score.
+
+**Etape 3 -- PPO ou DPO** : Optimiser le modele pour maximiser le score du reward model (PPO) ou directement les preferences (DPO).
+
+Dans ce notebook, nous implementons les etapes 2 et 3.",,,,,,,,6759f7bf678e333f,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,fdc5b501,markdown,fr,d4611a691402a4a0,"## 3. Donnees de Preference
+
+Le RLHF repose sur un type de donnees specifique : les **paires de preference**. Pour chaque prompt, on collecte deux reponses aupres d'annotateurs humains :
+
+- **chosen** (y_w) : la reponse preferee par l'annotateur
+- **rejected** (y_l) : la reponse jugee moins bonne
+
+Le modele de recompense apprend a donner un score plus eleve a `chosen` qu'a `rejected`.",,,,,,,,d4611a691402a4a0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,45c88110,code,fr,93686a74c62ab619,"# Dataset de preferences synthetique
+preference_data = [
+    {
+        ""prompt"": ""### Human: Expliquez brievement ce qu'est une API REST.\n### Assistant:"",
+        ""chosen"": ""Une API REST est une interface de programmation qui utilise le protocole HTTP pour echanger des donnees. Elle repose sur les verbes HTTP (GET, POST, PUT, DELETE) et retourne generalement du JSON."",
+        ""rejected"": ""REST est un truc avec HTTP. Tu fais des requetes et ca repond. C'est utilise partout dans le web."",
+    },
+    {
+        ""prompt"": ""### Human: Donnez un conseil pour apprendre Python.\n### Assistant:"",
+        ""chosen"": ""Commencez par les bases : variables, boucles, fonctions. Pratiquez avec de petits projets comme une calculatrice. Utilisez la documentation officielle et des tutoriels interactifs."",
+        ""rejected"": ""Python est facile, juste regarde des videos YouTube et tu verras bien. Pas besoin de livres ou de cours."",
+    },
+    {
+        ""prompt"": ""### Human: Quelle est la difference entre SQL et NoSQL ?\n### Assistant:"",
+        ""chosen"": ""SQL utilise des tables structurees avec des schemas fixes et des relations (MySQL, PostgreSQL). NoSQL utilise des formats flexibles comme des documents (MongoDB) ou des cles-valeurs (Redis)."",
+        ""rejected"": ""SQL c'est mieux que NoSQL. Les bases SQL sont plus rapides et plus utilisees. NoSQL c'est pour les gens qui aiment pas les tables."",
+    },
+    {
+        ""prompt"": ""### Human: Comment fonctionne le machine learning ?\n### Assistant:"",
+        ""chosen"": ""Le ML permet a un algorithme d'apprendre des patterns dans des donnees sans etre explicitement programme. On l'entraine sur un dataset, il ajuste ses parametres pour minimiser une erreur, puis il peut predire sur de nouvelles donnees."",
+        ""rejected"": ""Le machine learning c'est de l'intelligence artificielle. Les ordinateurs pensent tout seuls. C'est magique et ca remplace les humains."",
+    },
+    {
+        ""prompt"": ""### Human: Qu'est-ce que Docker en une phrase ?\n### Assistant:"",
+        ""chosen"": ""Docker est un outil qui permet d'empaqueter une application et ses dependances dans un conteneur isole, assurant qu'elle fonctionne de maniere identique sur tout environnement."",
+        ""rejected"": ""Docker c'est comme une machine virtuelle mais en mieux. Tu mets ton code dedans et ca marche partout c'est tout."",
+    },
+    {
+        ""prompt"": ""### Human: Pourquoi utiliser Git ?\n### Assistant:"",
+        ""chosen"": ""Git est un systeme de controle de version qui permet de suivre chaque modification du code, de collaborer sans conflits via les branches, et de revenir a n'importe quelle version anterieure."",
+        ""rejected"": ""Git c'est pour faire des commits. Tu sauvegardes ton code et c'est bon. Pas besoin d'en savoir plus."",
+    },
+]
+
+print(f""Dataset de preferences : {len(preference_data)} paires"")
+print()
+print(""Exemple :"")
+ex = preference_data[0]
+print(f""  Prompt: {ex['prompt']}"")
+print(f""  Chosen:  {ex['chosen'][:80]}..."")
+print(f""  Rejected: {ex['rejected'][:80]}..."")",,,,,,,,93686a74c62ab619,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,4f01ec51,markdown,fr,c995032b93798a99,"**Analyse des donnees** : Les reponses ""chosen"" sont :
+- Plus precises et structurees
+- Plus nuancees (pas de generalisations abusives)
+- Plus utiles pour l'utilisateur
+
+Les reponses ""rejected"" sont :
+- Vagues ou imprecises
+- Trop subjectives ou biaisees
+- Manquent de details concrets
+
+Cette distinction est le coeur du RLHF : le modele doit apprendre a privilegier le style ""chosen"".",,,,,,,,c995032b93798a99,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,35f472ea,markdown,fr,9bd07251f0ed2b15,"## 4. Le Reward Model (Modele de Recompense)
+
+Le Reward Model est un modele qui attribue un **score de qualite** a chaque reponse. Il est entraine sur les paires de preference avec le modele de Bradley-Terry :
+
+$$P(y_w \succ y_l) = \sigma(r(x, y_w) - r(x, y_l))$$
+
+ou $r(x, y)$ est le score de recompense et $\sigma$ est la fonction sigmoid.
+
+En pratique, une mesure simple de ""qualite"" est la **log-probabilite** que le modele attribue a la reponse. Verifions si le modele de base distingue deja les bonnes des mauvaises reponses :",,,,,,,,9bd07251f0ed2b15,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,cc693e01,code,fr,942092f989ba82c4,"# Utiliser les log-probabilites comme signal de recompense
+def compute_logprob_reward(model, prompt, response):
+    # Calcule la log-probabilite moyenne de la reponse donnee le prompt
+    full_text = prompt + "" "" + response
+    inputs = tokenizer(full_text, return_tensors=""pt"", truncation=True, max_length=256).to(model.device)
+    prompt_len = len(tokenizer(prompt, return_tensors=""pt"")[""input_ids""][0])
+    with torch.no_grad():
+        outputs = model(**inputs)
+    logits = outputs.logits[:, prompt_len-1:-1, :]
+    labels = inputs[""input_ids""][:, prompt_len:]
+    log_probs = F.log_softmax(logits, dim=-1)
+    token_log_probs = log_probs.gather(2, labels.unsqueeze(-1)).squeeze(-1)
+    return token_log_probs.mean().item()
+
+# Evaluer le modele de base sur les preferences
+model_base.eval()
+print(""Log-probabilites du modele de base (recompense proxy) :"")
+print(""-"" * 65)
+correct = 0
+for i, ex in enumerate(preference_data):
+    chosen_r = compute_logprob_reward(model_base, ex[""prompt""], ex[""chosen""])
+    rejected_r = compute_logprob_reward(model_base, ex[""prompt""], ex[""rejected""])
+    diff = chosen_r - rejected_r
+    status = ""OK"" if diff > 0 else ""INV""
+    if diff > 0:
+        correct += 1
+    print(f""  Pair {i}: chosen={chosen_r:.3f}  rejected={rejected_r:.3f}  ""
+          f""diff={diff:+.3f}  [{status}]"")
+
+print(f""\nTaux de preference correct : {correct}/{len(preference_data)} ""
+      f""({100*correct/len(preference_data):.0f}%)"")
+print()
+print(""Le modele de base a une idee partielle de la qualite, mais il n'est pas fiable."")
+print(""Un Reward Model entraine ameliorerait ce signal, et le DPO le contourne completement."")",,,,,,,,942092f989ba82c4,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,7e0a8039,markdown,fr,be4606f5e95e0a5d,"**Observation** : Le modele de base a parfois des scores plus eleves pour les reponses ""chosen"" (plus naturelles), mais ce n'est pas fiable. Le signal de log-probabilite est un proxy imparfait de la ""qualite percue"".
+
+En pratique, les reward models utilises dans ChatGPT ou Claude sont :
+- Entraines sur des millions de paires de preference
+- Bases sur des modeles beaucoup plus grands (7B-70B parametres)
+- Evalues sur des benchmarks de calibration
+
+Le DPO (section suivante) contourne le besoin d'un reward model separe.",,,,,,,,be4606f5e95e0a5d,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,a8ef08bf,markdown,fr,c03e4dd3eb106b0c,"## 5. DPO : Optimisation Directe des Preferences
+
+Le DPO (Direct Preference Optimization, [Rafailov et al., 2023](https://arxiv.org/abs/2305.18290)) est une alternative elegante au pipeline PPO classique. Il elimine le besoin d'un reward model separe.
+
+### PPO classique vs DPO
+
+| Aspect | PPO | DPO |
+|--------|-----|-----|
+| Reward Model | Necessaire (entraine separement) | Pas necessaire |
+| Modeles en memoire | 4 (policy, ref, reward, value) | 2 (policy, reference) |
+| Stabilite | Difficile (hyperparametres sensibles) | Plus stable |
+| Etapes | RM training + PPO loop | Un seul passage d'entrainement |
+| Complexite code | Elevee | Simple |",,,,,,,,c03e4dd3eb106b0c,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,de4ef4d9,markdown,fr,33a3502914c4d6b4,"### 5a. La perte DPO
+
+La fonction de perte du DPO est derivee analytiquement a partir de l'objectif RLHF :
+
+$$\mathcal{L}_{DPO} = -\mathbb{E}\left[\log \sigma\left(\beta \left(\log \frac{\pi_\theta(y_w|x)}{\pi_{ref}(y_w|x)} - \log \frac{\pi_\theta(y_l|x)}{\pi_{ref}(y_l|x)}\right)\right)\right]$$
+
+Ou :
+- $\pi_\theta$ = modele en cours d'entrainement (policy)
+- $\pi_{ref}$ = modele de reference fige (SFT)
+- $y_w$ = reponse choisie (chosen / winner)
+- $y_l$ = reponse rejetee (rejected / loser)
+- $\beta$ = temperature (controle la force de l'alignement)
+
+**Intuition** : Le DPO pousse le modele a augmenter les log-probs des reponses ""chosen"" et a diminuer celles des ""rejected"", par rapport au modele de reference.",,,,,,,,33a3502914c4d6b4,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,c1a356a8,code,fr,2a2cb7da9c21b3ac,"# Etape 1 : Quick SFT pour avoir un modele instruct de depart
+from datasets import Dataset
+from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling
+
+# Petit dataset SFT (5 exemples pour un entrainement rapide)
+sft_examples = [
+    {""text"": ""### Human: Qu'est-ce que Python ?\n### Assistant: Python est un langage de programmation polyvalent, connu pour sa syntaxe claire et sa large bibliotheque standard.""},
+    {""text"": ""### Human: Expliquez Docker.\n### Assistant: Docker est un outil de conteneurisation qui empaquette une application et ses dependances dans un environnement isole.""},
+    {""text"": ""### Human: C'est quoi Git ?\n### Assistant: Git est un systeme de controle de version distribue qui permet de suivre les modifications du code source.""},
+    {""text"": ""### Human: Qu'est-ce que le machine learning ?\n### Assistant: Le machine learning est un domaine de l'IA ou les algorithmes apprennent des patterns dans les donnees pour faire des predictions.""},
+    {""text"": ""### Human: Expliquez les API REST.\n### Assistant: Une API REST est une interface utilisant HTTP pour echanger des donnees structurees, typiquement en JSON.""},
+]
+
+# Preparer le modele avec LoRA pour le SFT
+model_base.gradient_checkpointing_enable()
+model_base = prepare_model_for_kbit_training(model_base)
+
+lora_config = LoraConfig(
+    task_type=TaskType.CAUSAL_LM, r=16, lora_alpha=32,
+    lora_dropout=0.05, target_modules=[""q_proj"", ""v_proj""], bias=""none""
+)
+model_sft = get_peft_model(model_base, lora_config)
+model_sft.print_trainable_parameters()
+
+# Tokenizer le dataset SFT
+sft_dataset = Dataset.from_list(sft_examples)
+def tokenize_fn(examples):
+    return tokenizer(examples[""text""], truncation=True, max_length=128, padding=""max_length"")
+
+sft_dataset = sft_dataset.map(tokenize_fn, batched=True)
+sft_dataset.set_format(""torch"", columns=[""input_ids"", ""attention_mask""])
+
+# Quick SFT (2 epochs)
+training_args = TrainingArguments(
+    output_dir=""./results_ft04_sft"",
+    num_train_epochs=2, per_device_train_batch_size=1,
+    learning_rate=5e-4, logging_steps=5,
+    save_strategy=""no"", report_to=""none"",
+    fp16=True, gradient_accumulation_steps=2,
+)
+data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+trainer = Trainer(
+    model=model_sft, args=training_args,
+    train_dataset=sft_dataset, data_collator=data_collator,
+)
+print(""Quick SFT (2 epochs sur 5 exemples)..."")
+trainer.train()
+print(""SFT termine."")",,,,,,,,2a2cb7da9c21b3ac,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,d15cc7a1,markdown,fr,2eb016e33e906808,Le SFT rapide (2 epochs sur 5 exemples) est termine. Ce modele servira de **reference** $\pi_{ref}$ pour le DPO. La prochaine etape consiste a sauvegarder ses poids et a calculer les log-probabilites de reference pour chaque paire chosen/rejected du dataset de preferences.,,,,,,,,2eb016e33e906808,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,8c94c2a6,code,fr,1c585ba174afbf8f,"# Etape 2 : Sauvegarder les poids de reference (SFT) et calculer les log-probs de ref
+import copy
+
+# Sauvegarder l'etat LoRA comme reference
+ref_lora_state = copy.deepcopy(model_sft.state_dict())
+
+# Generer les reponses SFT de base (pour comparaison ulterieure)
+model_sft.eval()
+eval_prompts = [
+    ""### Human: Expliquez brievement ce qu'est une API REST.\n### Assistant:"",
+    ""### Human: Donnez un conseil pour apprendre Python.\n### Assistant:"",
+    ""### Human: Quelle est la difference entre SQL et NoSQL ?\n### Assistant:"",
+]
+
+sft_baseline = {}
+print(""Reponses SFT de reference :"")
+for p in eval_prompts:
+    q = p.split(""Human: "")[1].split(""\\n"")[0]
+    resp = generate(model_sft, p, max_new_tokens=50)
+    sft_baseline[q] = resp
+    print(f""  Q: {q}"")
+    print(f""  SFT: {resp}"")
+    print()
+
+# Calculer les log-probabilites de reference pour chaque paire (chosen, rejected)
+def get_logprobs(model, prompt, response):
+    # Calcule log P(response | prompt) avec gradients
+    full_text = prompt + "" "" + response
+    inputs = tokenizer(full_text, return_tensors=""pt"", truncation=True, max_length=256).to(model.device)
+    prompt_len = len(tokenizer(prompt, return_tensors=""pt"")[""input_ids""][0])
+    outputs = model(**inputs)
+    logits = outputs.logits
+    resp_logits = logits[:, prompt_len-1:-1, :]
+    resp_ids = inputs[""input_ids""][:, prompt_len:]
+    log_probs = F.log_softmax(resp_logits, dim=-1)
+    token_lps = log_probs.gather(2, resp_ids.unsqueeze(-1)).squeeze(-1)
+    return token_lps.sum()
+
+print(""Calcul des log-probabilites de reference..."")
+ref_logprobs = []
+with torch.no_grad():
+    for ex in preference_data:
+        lp_c = get_logprobs(model_sft, ex[""prompt""], ex[""chosen""]).item()
+        lp_r = get_logprobs(model_sft, ex[""prompt""], ex[""rejected""]).item()
+        ref_logprobs.append({""chosen"": lp_c, ""rejected"": lp_r})
+
+print(f""  Log-probs reference calculees pour {len(ref_logprobs)} paires"")
+for i, rlp in enumerate(ref_logprobs[:3]):
+    print(f""  Pair {i}: chosen={rlp['chosen']:.2f}, rejected={rlp['rejected']:.2f}"")",,,,,,,,1c585ba174afbf8f,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,c496029a,markdown,fr,4f617bce16a2c05d,"Le modele SFT de reference est pret. Ses poids LoRA sont sauvegardes (via `copy.deepcopy`), et les log-probabilites de reference ont ete calculees pour les 6 paires chosen/rejected. Ces valeurs serviront de point de comparaison dans la perte DPO : $\beta \cdot (\log \pi_\theta - \log \pi_{ref})$.
+
+Nous pouvons maintenant lancer l'optimisation DPO sur 3 epochs.",,,,,,,,4f617bce16a2c05d,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,b3a7520d,code,fr,c586c3b154fa98a2,"# Etape 3 : DPO Training
+beta = 0.1  # Temperature DPO (controle la force de l'alignement)
+
+model_sft.train()
+optimizer = torch.optim.AdamW(model_sft.parameters(), lr=1e-5)
+
+print(f""DPO Training (3 epochs, beta={beta})..."")
+print(""-"" * 50)
+for epoch in range(3):
+    total_loss = 0
+    n_correct = 0
+    for i, ex in enumerate(preference_data):
+        # Log-probs de la policy (modele courant, avec gradients)
+        policy_chosen_lp = get_logprobs(model_sft, ex[""prompt""], ex[""chosen""])
+        policy_rejected_lp = get_logprobs(model_sft, ex[""prompt""], ex[""rejected""])
+
+        # DPO loss : -log sigmoid(beta * (pi_chosen - ref_chosen - pi_rejected + ref_rejected))
+        chosen_reward = beta * (policy_chosen_lp - ref_logprobs[i][""chosen""])
+        rejected_reward = beta * (policy_rejected_lp - ref_logprobs[i][""rejected""])
+        loss = -F.logsigmoid(chosen_reward - rejected_reward)
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        total_loss += loss.item()
+        # Verifier si le modele prefere maintenant chosen a rejected
+        with torch.no_grad():
+            if chosen_reward.item() > rejected_reward.item():
+                n_correct += 1
+
+    avg_loss = total_loss / len(preference_data)
+    print(f""  Epoch {epoch+1}/3 | Loss: {avg_loss:.4f} | ""
+          f""Preferences correctes: {n_correct}/{len(preference_data)}"")
+
+print()
+print(""DPO termine."")",,,,,,,,c586c3b154fa98a2,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,5660cbd8,markdown,fr,af912238e7f8ec03,"## 6. Evaluation : SFT vs DPO
+
+Comparons les reponses du modele SFT (reference) et du modele DPO (aligne). Le DPO a du pousser le modele a privilegier le style ""chosen"" : reponses plus precises, structurees et utiles.",,,,,,,,af912238e7f8ec03,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,dfbc120b,code,fr,0ed09f7ee78d867e,"# Generer avec le modele DPO et comparer avec le SFT
+model_sft.eval()
+
+print(""="" * 70)
+print(""COMPARAISON : SFT (reference) vs DPO (aligne)"")
+print(""="" * 70)
+
+for p in eval_prompts:
+    q = p.split(""Human: "")[1].split(""\\n"")[0]
+    dpo_resp = generate(model_sft, p, max_new_tokens=50)
+    sft_resp = sft_baseline.get(q, ""N/A"")
+
+    print(f""\nQuestion: {q}"")
+    print(f""  SFT: {sft_resp}"")
+    print(f""  DPO: {dpo_resp}"")
+
+# Verifier les log-probs post-DPO
+print()
+print(""-"" * 50)
+print(""Log-probabilites post-DPO :"")
+correct = 0
+with torch.no_grad():
+    for i, ex in enumerate(preference_data):
+        policy_lp_c = get_logprobs(model_sft, ex[""prompt""], ex[""chosen""]).item()
+        policy_lp_r = get_logprobs(model_sft, ex[""prompt""], ex[""rejected""]).item()
+        # DPO implicit reward = beta * (policy_lp - ref_lp)
+        implicit_c = beta * (policy_lp_c - ref_logprobs[i][""chosen""])
+        implicit_r = beta * (policy_lp_r - ref_logprobs[i][""rejected""])
+        ok = ""OK"" if implicit_c > implicit_r else ""INV""
+        if implicit_c > implicit_r:
+            correct += 1
+        print(f""  Pair {i}: reward_chosen={implicit_c:+.4f}  ""
+              f""reward_rejected={implicit_r:+.4f}  [{ok}]"")
+
+print(f""\nTaux de preference correct (DPO) : {correct}/{len(preference_data)} ""
+      f""({100*correct/len(preference_data):.0f}%)"")",,,,,,,,0ed09f7ee78d867e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,567f932b,markdown,fr,adab29d053c907fe,"**Analyse** : Apres le DPO, le modele devrait :
+1. **Privilegier les reponses ""chosen""** : Les rewards implicites (marge entre chosen et rejected) devraient etre positifs.
+2. **Generer des reponses plus structurees** : Le style des reponses DPO devrait etre plus proche du style ""chosen"" du dataset de preferences.
+3. **Etre plus aligne** : Les reponses evitent les generalisations abusives et les formulations vagues.
+
+Avec seulement 6 paires et 3 epochs, l'effet est subtil. En production, le DPO utilise des milliers de paires et des modeles beaucoup plus grands.",,,,,,,,adab29d053c907fe,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,ca9bbcd5,markdown,fr,c3685ceda711f8e4,"## 7. RLHF vs DPO — Comparaison
+
+### Quand utiliser quoi ?
+
+| Critere | PPO (RLHF classique) | DPO |
+|---------|---------------------|-----|
+| **Simplicite** | Complexe (4 modeles) | Simple (2 modeles) |
+| **Donnees** | Preferences + Reward Model | Preferences uniquement |
+| **Stabilite** | Sensible aux hyperparametres | Stable |
+| **Cout compute** | Eleve (boucle RL) | Modere (un seul passage) |
+| **Qualite** | Tres bonne si bien regle | Comparable a PPO |
+| **Cas d'usage** | ChatGPT, Claude (production) | Fine-tuning rapide, recherches |
+
+### En pratique aujourd'hui
+- **OpenAI, Anthropic** : utilisent des variantes de RLHF avec PPO + Reward Model
+- **Meta (LLaMA), Mistral** : utilisent DPO pour l'alignement
+- **Communaute open-source** : DPO est le standard de facto (TRL, Axolotl)",,,,,,,,c3685ceda711f8e4,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,69f31ddb,code,fr,3aabcb1a11b9211a,"# Liberation de la memoire GPU
+del model_sft, model_base
+gc.collect()
+if torch.cuda.is_available():
+    torch.cuda.empty_cache()
+    vram = torch.cuda.mem_get_info()[0] / 1e9
+    print(f""VRAM libre apres cleanup : {vram:.1f} GB"")
+print(""Memoire GPU liberee."")",,,,,,,,3aabcb1a11b9211a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,33ad67b0,markdown,fr,65476f33de2ac5b3,"## 8. Exercices
+
+Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts precedents.",,,,,,,,65476f33de2ac5b3,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,4f9a2cb2,markdown,fr,d6ec9d8131f7e11e,"### Exercice 1 : Creer un dataset de preferences thematique
+
+Creez un dataset de 8 paires de preference sur un theme de votre choix (cuisine, voyage, musique, etc.). Chaque paire doit avoir une reponse ""chosen"" precise et une reponse ""rejected"" vague ou biaisee.
+
+**Indices** :
+- Inspirez-vous du dataset synthetique de la section 3
+- Les reponses ""chosen"" doivent etre factuelles et structurees
+- Les reponses ""rejected"" doivent etre plausibles mais de moindre qualite",,,,,,,,d6ec9d8131f7e11e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,5437126a,code,fr,fa327908a72b52d3,"# Exercice 1 : Creez votre dataset de preferences thematique
+# TODO etudiant : remplacez les exemples ci-dessous par votre propre theme
+mon_dataset_preferences = [
+    {
+        ""prompt"": ""### Human: [votre question ici]\n### Assistant:"",
+        ""chosen"": ""Votre reponse precise et structuree ici."",
+        ""rejected"": ""Votre reponse vague ou biaisee ici."",
+    },
+    # TODO etudiant : ajoutez 7 autres paires sur votre theme
+]
+print(f""Dataset en cours : {len(mon_dataset_preferences)} paires (objectif : 8)"")",,,,,,,,fa327908a72b52d3,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,c035350c,markdown,fr,eb7f808d348914b6,"### Exercice 2 : Analyser l'impact du parametre beta
+
+Le parametre `beta` dans DPO controle la force de l'alignement. Testez avec `beta = 0.01` (faible) et `beta = 1.0` (fort) et observez les differences.
+
+**Indice** : Un beta trop faible ne change rien ; un beta trop fort peut degrader la coherence du texte.",,,,,,,,eb7f808d348914b6,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,f7c6f904,code,fr,be4568bd39b1be83,"# Exercice 2 : Testez differents valeurs de beta
+# TODO etudiant : testez beta=0.01 et beta=1.0, comparez les loss et les reponses
+# Indice : reentrainez le modele SFT (cellule 14) entre chaque test de beta
+
+beta_test = 0.1  # TODO etudiant : remplacez par 0.01 ou 1.0
+print(f""Test avec beta={beta_test} (a completer par l'etudiant)"")
+print(""Etapes : 1) Re-SFT | 2) Calcul ref_logprobs | 3) DPO avec nouveau beta | 4) Evaluer"")",,,,,,,,be4568bd39b1be83,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,9561b518,markdown,fr,3ad57a80be157e47,"### Exercice 3 : RLHF vs SFT — Avantages et limites
+
+En vous basant sur les experiences de ce notebook et des notebooks precedents (FT-01 a FT-03), redigez une courte analyse (3-5 phrases en markdown) comparant :
+1. Ce que le SFT apporte par rapport au modele de base
+2. Ce que le DPO/RLHF apporte par rapport au SFT
+3. Les limites de notre implementation pedagogique",,,,,,,,3ad57a80be157e47,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,73872671,code,fr,ca57eabd18400ebf,"# Exercice 3 : Zone de reflexion
+# TODO etudiant : ecrivez votre analyse en markdown ci-dessous
+# Par exemple : convertissez cette cellule en markdown et redigez
+
+analyse = (
+    ""SFT vs Modele de base : [votre analyse ici]\n\n""
+    ""DPO vs SFT : [votre analyse ici]\n\n""
+    ""Limites de notre implementation : [votre analyse ici]""
+)
+print(""Exercice a completer en markdown."")
+print(""Conseil : convertissez cette cellule en cellule Markdown pour rediger votre analyse."")",,,,,,,,ca57eabd18400ebf,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb,56a9d5fb,markdown,fr,f7007bd00cfb11b0,"## 9. Resume du FT-04
+
+| Concept | Detail |
+|---------|--------|
+| **RLHF** | Pipeline en 3 etapes : SFT -> Reward Model -> PPO |
+| **Donnees de preference** | Paires (chosen, rejected) annotatees par des humains |
+| **Reward Model** | Modele entraine a scorer la qualite des reponses |
+| **DPO** | Optimisation directe des preferences, sans reward model separe |
+| **Perte DPO** | Maximise la marge entre log-probs chosen vs rejected par rapport a la reference |
+| **Beta** | Parametre de temperature controlant la force de l'alignement |
+| **Resultat** | Le modele DPO privilegie les reponses precises et structurees |
+
+**Prochaines etapes** : Le FT-05 explorera le merge de modeles et le routing, qui permettent de combiner plusieurs modeles specialises en un seul modele plus performant.
+
+---
+
+**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**",,,,,,,,f7007bd00cfb11b0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a1b2c3d0,markdown,fr,2eb8c88b04fcc8d0,"# FT-05 : Fusion et Routage de Modeles -- Combiner les Expertises
+
+**Objectif** : Comprendre comment fusionner plusieurs modeles fine-tunes en un seul modele plus performant, du merge de poids au routage dynamique.
+
+**Prerequis** : FT-01 (LoRA), FT-02 (QLoRA), FT-03 (SFT), FT-04 (DPO)
+
+**Duree estimee** : ~35 min
+
+**Plan du notebook** :
+1. Pourquoi fusionner des modeles ?
+2. Les Task Vectors
+3. Interpolation Lineaire (LERP)
+4. Interpolation Spherique (SLERP)
+5. TIES et DARE -- Techniques avancees
+6. Routing et Mixture of Experts
+7. Exercices
+
+**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**",,,,,,,,2eb8c88b04fcc8d0,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b2c3d4e1,code,fr,c486595d61399270,"import torch
+import os
+import gc
+import copy
+import numpy as np
+
+BATCH_MODE = os.environ.get(""BATCH_MODE"", ""false"").lower() == ""true""
+
+print(f""PyTorch {torch.__version__}"")
+print(f""CUDA : {torch.cuda.is_available()}"")
+if torch.cuda.is_available():
+    props = torch.cuda.get_device_properties(0)
+    print(f""GPU : {props.name}, {props.total_memory / 1e9:.1f} GB VRAM"")
+    print(f""VRAM libre : {torch.cuda.mem_get_info()[0] / 1e9:.1f} GB"")",,,,,,,,c486595d61399270,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c3d4e5f2,markdown,fr,630d03a8d8be0ffc,"## 1. Pourquoi fusionner des modeles ?
+
+Apres avoir fine-tune plusieurs adaptateurs LoRA pour differentes taches (FT-03, FT-04), une question naturelle se pose : **comment combiner ces expertises ?**
+
+### Le probleme du deploiement multi-modeles
+
+Imaginons que nous ayons :
+- Un modele specialise en QA technique
+- Un modele specialise en QA cuisine
+- Un modele specialise en QA voyage
+
+Servir 3 modeles separement coute **3x plus de VRAM** et **3x plus d'infrastructure**. Ne peut-on pas en faire un seul modele ?
+
+### Deux approches
+
+1. **Model Merging** : Combiner les poids des modeles en un seul ensemble de poids. Le resultat est un modele unique qui ""sait"" faire plusieurs taches.
+2. **Routing (MoE)** : Garder tous les modeles (experts) et utiliser un routeur qui selectionne le bon expert pour chaque requete.
+
+Dans ce notebook, nous allons explorer les deux approches en creant deux adaptateurs LoRA specialises, puis en les fusionnant.",,,,,,,,630d03a8d8be0ffc,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d4e5f6a3,code,fr,f85697b31d44d4dd,"# Charger le modele de base et creer 2 adaptateurs LoRA specialises
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training, TaskType
+from datasets import Dataset
+from transformers import TrainingArguments, Trainer, DataCollatorForLanguageModeling
+
+MODEL_NAME = ""facebook/opt-1.3b""
+
+bnb_config = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type=""nf4"",
+    bnb_4bit_compute_dtype=torch.float16,
+    bnb_4bit_use_double_quant=True,
+)
+
+# Charger le modele et le tokenizer
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+tokenizer.pad_token = tokenizer.eos_token
+
+model_base = AutoModelForCausalLM.from_pretrained(
+    MODEL_NAME, quantization_config=bnb_config, device_map=""auto""
+)
+model_base.gradient_checkpointing_enable()
+model_base = prepare_model_for_kbit_training(model_base)
+
+lora_config = LoraConfig(
+    task_type=TaskType.CAUSAL_LM, r=16, lora_alpha=32,
+    lora_dropout=0.05, target_modules=[""q_proj"", ""v_proj""], bias=""none""
+)
+
+# Fonction utilitaire de generation
+def generate(model, prompt, max_new_tokens=60, temperature=0.7):
+    inputs = tokenizer(prompt, return_tensors=""pt"").to(model.device)
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs, max_new_tokens=max_new_tokens,
+            temperature=temperature, do_sample=True, top_p=0.9,
+            pad_token_id=tokenizer.eos_token_id
+        )
+    response = tokenizer.decode(outputs[0][inputs[""input_ids""].shape[1]:], skip_special_tokens=True)
+    return response.strip()
+
+print(f""Modele de base charge : {MODEL_NAME}"")
+print(f""LoRA config : r={lora_config.r}, alpha={lora_config.lora_alpha}"")
+print(f""Target modules : {lora_config.target_modules}"")",,,,,,,,f85697b31d44d4dd,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c6264858,markdown,fr,c3cdf7c377977351,"Nous allons maintenant creer deux adaptateurs LoRA specialises. Chaque adaptateur sera fine-tune sur un domaine specifique via un SFT rapide (2 epochs, 5 exemples). Ce processus est le meme que celui vu en FT-03, mais execute deux fois pour deux domaines differents.",,,,,,,,c3cdf7c377977351,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e5f6a7b4,code,fr,bb7f0419e151aa4e,"# Creer et entrainer l'Adaptateur A : specialise en QA technique
+tech_examples = [
+    {""text"": ""### Human: Qu'est-ce que Python ?\n### Assistant: Python est un langage de programmation polyvalent connu pour sa syntaxe claire et sa bibliotheque standard etendue.""},
+    {""text"": ""### Human: Expliquez Docker.\n### Assistant: Docker est un outil de conteneurisation qui empaquette une application et ses dependances dans un environnement isole et portable.""},
+    {""text"": ""### Human: C'est quoi Git ?\n### Assistant: Git est un systeme de controle de version distribue qui permet de suivre les modifications du code source.""},
+    {""text"": ""### Human: Qu'est-ce qu'une API REST ?\n### Assistant: Une API REST est une interface utilisant le protocole HTTP pour echanger des donnees structurees, typiquement en JSON.""},
+    {""text"": ""### Human: Expliquez le machine learning.\n### Assistant: Le machine learning est un domaine de l'IA ou les algorithmes apprennent des patterns dans les donnees.""},
+]
+
+# Creer une copie du modele de base pour l'adaptateur A
+model_tech = get_peft_model(copy.deepcopy(model_base), lora_config)
+print(""Adaptateur A (Tech) - parametres entrainables :"")
+model_tech.print_trainable_parameters()
+
+# SFT rapide pour l'adaptateur A
+tech_dataset = Dataset.from_list(tech_examples)
+def tokenize_fn(examples):
+    return tokenizer(examples[""text""], truncation=True, max_length=128, padding=""max_length"")
+
+tech_dataset = tech_dataset.map(tokenize_fn, batched=True)
+tech_dataset.set_format(""torch"", columns=[""input_ids"", ""attention_mask""])
+
+training_args = TrainingArguments(
+    output_dir=""./results_ft05_tech"",
+    num_train_epochs=2, per_device_train_batch_size=1,
+    learning_rate=5e-4, logging_steps=5,
+    save_strategy=""no"", report_to=""none"",
+    fp16=True, gradient_accumulation_steps=2,
+)
+data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+trainer_tech = Trainer(
+    model=model_tech, args=training_args,
+    train_dataset=tech_dataset, data_collator=data_collator,
+)
+print(""SFT Adaptateur A (Tech) - 2 epochs sur 5 exemples..."")
+trainer_tech.train()
+
+# Extraire UNIQUEMENT les poids LoRA (pas les cles BitsAndBytes)
+adapter_a_state = {k: v.detach().clone() for k, v in model_tech.state_dict().items() if ""lora"" in k}
+lora_keys_a = list(adapter_a_state.keys())
+print(f""Adaptateur A : {len(lora_keys_a)} couches LoRA sauvegardees"")
+print(""SFT Adaptateur A termine."")",,,,,,,,bb7f0419e151aa4e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,7e384d22,markdown,fr,71b35104e6dea028,"Premier adaptateur : fine-tune sur 5 exemples de QA technique (Python, Docker, Git, API REST, Machine Learning).",,,,,,,,71b35104e6dea028,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f6a7b8c5,code,fr,1d2e92c5dfb2c288,"# Creer et entrainer l'Adaptateur B : specialise en QA cuisine
+cooking_examples = [
+    {""text"": ""### Human: Comment faire une bechamel ?\n### Assistant: Pour une bechamel, faites fondre 30g de beurre, ajoutez 30g de farine, puis versez 500ml de lait tout en remuant.""},
+    {""text"": ""### Human: Quelle temperature pour cuire un steak ?\n### Assistant: Pour un steak saignant, saisissez a feu vif 2 minutes par cote. La temperature interne doit atteindre 52 degres Celsius.""},
+    {""text"": ""### Human: Comment preparer une vinaigrette ?\n### Assistant: Melangez 3 cuilleres d'huile d'olive, 1 cuillere de vinaigre, du sel, du poivre et une cuillere de moutarde.""},
+    {""text"": ""### Human: Qu'est-ce que le beurre clarifie ?\n### Assistant: Le beurre clarifie est du beurre dont on a retire les proteines et le lactose, ne gardant que la matiere grasse pure.""},
+    {""text"": ""### Human: Comment reussir une pate brisee ?\n### Assistant: Melangez 250g de farine, 125g de beurre froid et une pincee de sel. Ajoutez de l'eau froide jusqu'a obtenir une boule.""},
+]
+
+# Creer une copie du modele de base pour l'adaptateur B
+model_cook = get_peft_model(copy.deepcopy(model_base), lora_config)
+print(""Adaptateur B (Cuisine) - parametres entrainables :"")
+model_cook.print_trainable_parameters()
+
+# SFT rapide pour l'adaptateur B
+cook_dataset = Dataset.from_list(cooking_examples)
+cook_dataset = cook_dataset.map(tokenize_fn, batched=True)
+cook_dataset.set_format(""torch"", columns=[""input_ids"", ""attention_mask""])
+
+trainer_cook = Trainer(
+    model=model_cook, args=TrainingArguments(
+        output_dir=""./results_ft05_cook"",
+        num_train_epochs=2, per_device_train_batch_size=1,
+        learning_rate=5e-4, logging_steps=5,
+        save_strategy=""no"", report_to=""none"",
+        fp16=True, gradient_accumulation_steps=2,
+    ),
+    train_dataset=cook_dataset, data_collator=data_collator,
+)
+print(""SFT Adaptateur B (Cuisine) - 2 epochs sur 5 exemples..."")
+trainer_cook.train()
+
+# Extraire UNIQUEMENT les poids LoRA (pas les cles BitsAndBytes)
+adapter_b_state = {k: v.detach().clone() for k, v in model_cook.state_dict().items() if ""lora"" in k}
+lora_keys_b = list(adapter_b_state.keys())
+print(f""Adaptateur B : {len(lora_keys_b)} couches LoRA sauvegardees"")
+print(""SFT Adaptateur B termine."")",,,,,,,,1d2e92c5dfb2c288,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,ec0e2218,markdown,fr,e8c5753b20fa61ba,"Deuxieme adaptateur : fine-tune sur 5 exemples de QA cuisine (sauces, cuisson, vinaigrette, beurre, pate brisee).",,,,,,,,e8c5753b20fa61ba,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a7b8c9d6,markdown,fr,754fee79d528cbf2,"### Interpretation : Deux adaptateurs specialises
+
+Nous avons maintenant deux adaptateurs LoRA :
+
+| Adaptateur | Domaine | Donnees d'entrainement |
+|-----------|---------|----------------------|
+| A (Tech) | Programmation, DevOps, APIs | 5 exemples QA technique |
+| B (Cuisine) | Recettes, techniques culinaires | 5 exemples QA cuisine |
+
+Chaque adaptateur a appris a specialiser le modele de base dans son domaine. Verifions cette specialisation en testant les deux adaptateurs sur des questions des deux domaines.",,,,,,,,754fee79d528cbf2,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b8c9d0e7,code,fr,f9971f0c5cda9e71,"# Tester chaque adaptateur sur des questions cross-domaine
+test_prompts = [
+    (""tech"", ""### Human: Qu'est-ce que Docker ?\n### Assistant:""),
+    (""tech"", ""### Human: Expliquez le controle de version.\n### Assistant:""),
+    (""cuisine"", ""### Human: Comment faire une bechamel ?\n### Assistant:""),
+    (""cuisine"", ""### Human: Quelle temperature pour cuire un poulet ?\n### Assistant:""),
+]
+
+model_tech.eval()
+model_cook.eval()
+
+print(""="" * 70)
+print(""TESTS CROSS-DOMAINE : Adaptateur A (Tech) vs Adaptateur B (Cuisine)"")
+print(""="" * 70)
+
+for domain, prompt in test_prompts:
+    q = prompt.split(""Human: "")[1].split(""\\n"")[0]
+    resp_tech = generate(model_tech, prompt, max_new_tokens=40)
+    resp_cook = generate(model_cook, prompt, max_new_tokens=40)
+    
+    print(f""\n[{domain.upper()}] Q: {q}"")
+    print(f""  Adaptateur A (Tech):    {resp_tech}"")
+    print(f""  Adaptateur B (Cuisine): {resp_cook}"")",,,,,,,,f9971f0c5cda9e71,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c9d0e1f8,markdown,fr,cfa42bb7ce2f3884,"**Observation** : Chaque adaptateur repond mieux dans son domaine de specialisation. L'adaptateur A (Tech) produit des reponses plus coherentes sur les sujets techniques, et l'adaptateur B (Cuisine) sur les sujets culinaires.
+
+Le probleme : si on deploie un chatbot generaliste, il faudrait servir les deux modeles. C'est ici que le **model merging** intervient.",,,,,,,,cfa42bb7ce2f3884,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d0e1f2a9,markdown,fr,5619eb189e465114,"## 2. Les Task Vectors
+
+Avant de fusionner, il faut comprendre ce que chaque adaptateur a appris. Le concept de **Task Vector** ([Ilharco et al., 2022](https://arxiv.org/abs/2212.04089)) formalise cela :
+
+$$\tau = \theta_{\text{fine-tune}} - \theta_{\text{base}}$$
+
+Le task vector $\tau$ est la **difference** entre les poids fine-tunes et les poids de base. Il capture la ""competence"" ajoutee par le fine-tuning.
+
+Avec LoRA, c'est encore plus simple : les poids LoRA **sont** deja le task vector, car ils s'ajoutent aux poids de base. Chaque matrice LoRA represente directement la modification apprise.",,,,,,,,5619eb189e465114,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e1f2a3b0,code,fr,f56b9361a05c4fa3,"# Extraire et analyser les task vectors (poids LoRA)
+# adapter_a_state et adapter_b_state contiennent deja uniquement les cles LoRA
+tv_a = {k: v.detach().cpu().float() for k, v in adapter_a_state.items()}
+tv_b = {k: v.detach().cpu().float() for k, v in adapter_b_state.items()}
+
+print(""Task Vectors (poids LoRA) extraits :"")
+print(""-"" * 55)
+print(f""{'Couche':<45} {'Norme A':>8} {'Norme B':>8}"")
+print(""-"" * 55)
+
+for key in tv_a:
+    norm_a = torch.norm(tv_a[key]).item()
+    norm_b = torch.norm(tv_b[key]).item()
+    short_key = key.split(""."")[-3] + ""."" + key.split(""."")[-2] + ""."" + key.split(""."")[-1]
+    print(f""  {short_key:<43} {norm_a:>8.3f} {norm_b:>8.3f}"")
+
+# Statistiques globales
+all_a = torch.cat([v.flatten() for v in tv_a.values()])
+all_b = torch.cat([v.flatten() for v in tv_b.values()])
+print(""-"" * 55)
+print(f""Norme L2 totale  A: {torch.norm(all_a):.2f}  |  B: {torch.norm(all_b):.2f}"")
+print(f""Moyenne          A: {all_a.mean():.6f}  |  B: {all_b.mean():.6f}"")
+print(f""Ecart-type       A: {all_a.std():.6f}  |  B: {all_b.std():.6f}"")
+
+# Correlation entre les deux task vectors
+cos_sim = torch.nn.functional.cosine_similarity(all_a.unsqueeze(0), all_b.unsqueeze(0)).item()
+print(f""\nCosine similarity entre TV_A et TV_B : {cos_sim:.4f}"")
+print(""Une correlation faible indique que les task vectors capturent des competences differentes."")",,,,,,,,f56b9361a05c4fa3,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f2a3b4c1,markdown,fr,e1e27e38d89435fc,"### Interpretation : Task Vectors
+
+**Sortie obtenue** : Les normes et statistiques des poids LoRA pour chaque adaptateur.
+
+| Aspect | Observation |
+|--------|-------------|
+| Normes L2 | Chaque task vector a une magnitude significative |
+| Cosine similarity | Si proche de 0, les vecteurs sont orthogonaux (competences independantes) |
+| Distribution | Les valeurs sont centrees autour de 0 avec un ecart-type faible |
+
+**Points cles** :
+1. Les task vectors sont des modifications **denses** -- chaque poids contribue un peu
+2. Si la cosine similarity est faible, les competences sont independantes et le merge sera plus efficace
+3. Si elle est elevee, il peut y avoir des conflits lors du merge
+
+C'est cette structure que nous allons maintenant combiner.",,,,,,,,e1e27e38d89435fc,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a3b4c5d2,markdown,fr,eff2cb7b3609a8e4,"## 3. Interpolation Lineaire (LERP)
+
+La methode la plus simple pour fusionner : la moyenne ponderee des poids.
+
+$$\theta_{\text{merge}} = \alpha \cdot \theta_A + (1 - \alpha) \cdot \theta_B$$
+
+En termes de task vectors :
+
+$$\tau_{\text{merge}} = \alpha \cdot \tau_A + (1 - \alpha) \cdot \tau_B$$
+
+Le parametre $\alpha \in [0, 1]$ controle la balance entre les deux expertises :
+- $\alpha = 1$ : seul l'adaptateur A (Tech)
+- $\alpha = 0$ : seul l'adaptateur B (Cuisine)
+- $\alpha = 0.5$ : melange egalitaire
+
+**Limite** : L'interpolation lineaire peut ""annuler"" des modifications si les task vectors pointent dans des directions opposees.",,,,,,,,eff2cb7b3609a8e4,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b4c5d6e3,code,fr,a89180379ff3155a,"# Implementer le merge LERP
+def lerp_merge(state_a, state_b, alpha=0.5):
+    """"""Interpolation lineaire entre deux state dicts LoRA.""""""
+    merged = {}
+    for key in state_a:
+        merged[key] = alpha * state_a[key] + (1 - alpha) * state_b[key]
+    return merged
+
+# Merger avec alpha = 0.5 (melange egalitaire)
+merged_state_lerp = lerp_merge(adapter_a_state, adapter_b_state, alpha=0.5)
+
+# Charger les poids merges dans un nouveau modele
+model_lerp = get_peft_model(copy.deepcopy(model_base), lora_config)
+model_lerp.load_state_dict(merged_state_lerp, strict=False)
+model_lerp.eval()
+
+print(""Modele LERP (alpha=0.5) charge."")
+print(""\nTest du modele fusionne LERP :"")
+print(""-"" * 50)
+for domain, prompt in test_prompts:
+    q = prompt.split(""Human: "")[1].split(""\\n"")[0]
+    resp = generate(model_lerp, prompt, max_new_tokens=40)
+    print(f""  [{domain}] {q}"")
+    print(f""    LERP: {resp}"")
+    print()",,,,,,,,a89180379ff3155a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c5d6e7f4,markdown,fr,f8082ef697574522,"### Interpretation : LERP
+
+**Sortie obtenue** : Reponses du modele fusionne avec interpolation lineaire.
+
+| Aspect | Observation |
+|--------|-------------|
+| alpha = 0.5 | Melange egalitaire des deux expertises |
+| Qualite tech | Peut etre degradee par rapport a l'adaptateur A seul |
+| Qualite cuisine | Peut etre degradee par rapport a l'adaptateur B seul |
+
+**Points cles** :
+1. Le LERP est simple mais peut degrader les deux expertises
+2. Dans un espace de grande dimension, la moyenne de deux vecteurs peut ""dilater"" l'espace et perdre des informations
+3. C'est pourquoi SLERP (section suivante) est souvent preferee",,,,,,,,f8082ef697574522,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d6e7f8a5,markdown,fr,ff4992770d21f689,"## 4. SLERP -- Interpolation Spherique Lineaire
+
+Le SLERP (Spherical Linear Interpolation) resout le probleme du LERP en interpolant le long d'un **grand cercle** sur la sphere unitaire, plutot que le long d'une ligne droite.
+
+$$\text{SLERP}(t, v_0, v_1) = \frac{\sin((1-t)\Omega)}{\sin(\Omega)} v_0 + \frac{\sin(t\Omega)}{\sin(\Omega)} v_1$$
+
+ou $\Omega = \arccos(v_0 \cdot v_1)$ est l'angle entre les deux vecteurs.
+
+**Avantages du SLERP** :
+- Preserve les **directions** des vecteurs (pas de dilation)
+- Vitesse angulaire constante le long de l'arc
+- Meilleure preservation des proprietes dans les espaces de grande dimension
+
+En pratique, si l'angle entre les vecteurs est tres petit (quasi-colineaires), on retombe sur le LERP.",,,,,,,,ff4992770d21f689,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e7f8a9b6,code,fr,4ed8862f440f863e,"# Implementer le merge SLERP
+def slerp(t, v0, v1, DOT_THRESHOLD=0.9995):
+    """"""
+    Interpolation spherique entre deux vecteurs.
+    Si les vecteurs sont quasi-colineaires, retombe sur LERP.
+    """"""
+    v0_flat = v0.flatten().float()
+    v1_flat = v1.flatten().float()
+    
+    # Normaliser
+    v0_norm = v0_flat / (torch.norm(v0_flat) + 1e-8)
+    v1_norm = v1_flat / (torch.norm(v1_flat) + 1e-8)
+    
+    # Produit scalaire (cosine similarity)
+    dot = torch.dot(v0_norm, v1_norm)
+    dot = torch.clamp(dot, -1.0, 1.0)
+    
+    # Si quasi-colineaires, utiliser LERP
+    if dot.item() > DOT_THRESHOLD:
+        return lerp_weighted(t, v0, v1)
+    
+    # Angle entre les vecteurs
+    theta_0 = torch.arccos(dot)
+    sin_theta_0 = torch.sin(theta_0)
+    
+    theta_t = theta_0 * t
+    sin_theta_t = torch.sin(theta_t)
+    
+    s0 = torch.sin(theta_0 - theta_t) / sin_theta_0
+    s1 = sin_theta_t / sin_theta_0
+    
+    return (s0 * v0 + s1 * v1).to(v0.dtype)
+
+def lerp_weighted(t, v0, v1):
+    """"""LERP simple, fallback du SLERP.""""""
+    return ((1 - t) * v0 + t * v1).to(v0.dtype)
+
+def slerp_merge(state_a, state_b, t=0.5):
+    """"""Merge SLERP entre deux state dicts LoRA.""""""
+    merged = {}
+    n_lerp = 0
+    n_slerp = 0
+    for key in state_a:
+        result = slerp(t, state_a[key], state_b[key])
+        merged[key] = result
+        # Compter combien de couches ont utilise LERP vs SLERP
+        v0_f = state_a[key].flatten().float()
+        v1_f = state_b[key].flatten().float()
+        v0_n = v0_f / (torch.norm(v0_f) + 1e-8)
+        v1_n = v1_f / (torch.norm(v1_f) + 1e-8)
+        d = torch.dot(v0_n, v1_n).item()
+        if d > 0.9995:
+            n_lerp += 1
+        else:
+            n_slerp += 1
+    print(f""  SLERP : {n_slerp} couches | LERP fallback : {n_lerp} couches"")
+    return merged
+
+# Merger avec SLERP (t=0.5)
+print(""Merge SLERP (t=0.5)..."")
+merged_state_slerp = slerp_merge(adapter_a_state, adapter_b_state, t=0.5)
+
+# Charger dans un nouveau modele
+model_slerp = get_peft_model(copy.deepcopy(model_base), lora_config)
+model_slerp.load_state_dict(merged_state_slerp, strict=False)
+model_slerp.eval()
+
+print(""\nModele SLERP charge."")
+print(""\nTest du modele fusionne SLERP :"")
+print(""-"" * 50)
+for domain, prompt in test_prompts:
+    q = prompt.split(""Human: "")[1].split(""\\n"")[0]
+    resp = generate(model_slerp, prompt, max_new_tokens=40)
+    print(f""  [{domain}] {q}"")
+    print(f""    SLERP: {resp}"")
+    print()",,,,,,,,4ed8862f440f863e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f8a9b0c7,markdown,fr,347fb365bc6da12f,"### Interpretation : SLERP
+
+**Sortie obtenue** : Reponses du modele fusionne avec interpolation spherique.
+
+| Aspect | LERP | SLERP |
+|--------|------|-------|
+| Preservation des directions | Non (dilation possible) | Oui (arc de grand cercle) |
+| Couches quasi-colineaires | N/A | Fallback automatique vers LERP |
+| Qualite du melange | Moyenne, risque de degradation | Meilleure preservation des expertises |
+
+**Points cles** :
+1. SLERP preserve les proprietes geometriques des deux task vectors
+2. Quand les vecteurs sont quasi-colineaires (meme direction), SLERP retombe sur LERP
+3. C'est la methode de merge la plus utilisee en pratique pour les modeles de grande taille
+
+> **Note technique** : En production, des outils comme Mergekit automatisent le merge SLERP sur des modeles complets (pas seulement LoRA).",,,,,,,,347fb365bc6da12f,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a9b0c1d8,markdown,fr,2f01497dde5f7618,"## 5. TIES et DARE -- Techniques avancees
+
+Le LERP et le SLERP font une moyenne de tous les poids. Mais tous les poids ne sont pas egalement utiles. Deux techniques recentes introduisent une **selection** des poids :
+
+### TIES (Trim, Elect Sign, Merge)
+
+[Yadav et al., 2023](https://arxiv.org/abs/2306.01708) : resout les conflits de signe entre task vectors.
+
+1. **Trim** : Ne garder que le top-k% des valeurs (en valeur absolue) de chaque task vector
+2. **Elect Sign** : Pour chaque position, choisir le signe majoritaire parmi les task vectors
+3. **Merge** : Combiner en gardant uniquement les valeurs dont le signe correspond au signe elu
+
+### DARE (Drop And Rescale)
+
+[Yu et al., 2023](https://arxiv.org/abs/2311.03099) : approche encore plus simple.
+
+1. **Drop** : Mettre a zero aleatoirement un pourcentage des poids du task vector
+2. **Rescale** : Multiplier les poids restants par $1/(1-p)$ pour preserver la magnitude attendue
+
+L'intuition : la plupart des modifications de poids sont redondantes. En n'en gardant qu'une fraction, on reduit les interferences entre taches.",,,,,,,,2f01497dde5f7618,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b0c1d2e9,code,fr,c15258b8cde4f3c1,"# Implementer le merge DARE
+def dare_merge(state_a, state_b, drop_rate=0.3, seed=42):
+    """"""
+    DARE merge : Drop And Rescale.
+    - Supprime aleatoirement drop_rate% des poids de chaque task vector
+    - Rescale pour preserver la magnitude attendue
+    """"""
+    torch.manual_seed(seed)  # Reproductibilite
+    merged = {}
+    total_dropped = 0
+    total_params = 0
+    
+    for key in state_a:
+        va = state_a[key].float()
+        vb = state_b[key].float()
+        
+        # Mask de dropout aleatoire
+        mask_a = (torch.rand_like(va) > drop_rate).float()
+        mask_b = (torch.rand_like(vb) > drop_rate).float()
+        
+        # Rescale pour preserver la magnitude
+        rescale = 1.0 / (1.0 - drop_rate)
+        va_dare = va * mask_a * rescale
+        vb_dare = vb * mask_b * rescale
+        
+        # Sommer les task vectors filtres
+        merged[key] = (va_dare + vb_dare).to(state_a[key].dtype)
+        
+        total_dropped += (mask_a == 0).sum().item() + (mask_b == 0).sum().item()
+        total_params += va.numel() + vb.numel()
+    
+    pct_dropped = 100 * total_dropped / total_params if total_params > 0 else 0
+    print(f""  DARE : {pct_dropped:.1f}% des poids supprimes (drop_rate={drop_rate})"")
+    return merged
+
+# Merger avec DARE (drop_rate=0.3)
+print(""Merge DARE (drop_rate=0.3)..."")
+merged_state_dare = dare_merge(adapter_a_state, adapter_b_state, drop_rate=0.3)
+
+# Charger dans un nouveau modele
+model_dare = get_peft_model(copy.deepcopy(model_base), lora_config)
+model_dare.load_state_dict(merged_state_dare, strict=False)
+model_dare.eval()
+
+print(""Modele DARE charge."")
+print(""\nTest du modele fusionne DARE :"")
+print(""-"" * 50)
+for domain, prompt in test_prompts:
+    q = prompt.split(""Human: "")[1].split(""\\n"")[0]
+    resp = generate(model_dare, prompt, max_new_tokens=40)
+    print(f""  [{domain}] {q}"")
+    print(f""    DARE: {resp}"")
+    print()",,,,,,,,c15258b8cde4f3c1,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c1d2e3fa,markdown,fr,a2eae6221c97023e,"### Interpretation : DARE
+
+**Sortie obtenue** : Reponses du modele fusionne avec DARE (30% de dropout).
+
+| Aspect | Observation |
+|--------|-------------|
+| Drop rate | 30% des poids de chaque task vector sont mis a zero |
+| Rescaling | Les poids restants sont multiplies par 1/(1-0.3) ~ 1.43 |
+| Interference | Reduite par la suppression aleatoire des poids redondants |
+
+**Points cles** :
+1. DARE est tres simple a implementer et ne necessite pas de calcul de signe
+2. Le rescaling preserve la magnitude attendue des modifications
+3. Un drop_rate plus eleve (0.5-0.7) reduit davantage les interferences mais peut perdre des informations utiles",,,,,,,,a2eae6221c97023e,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d2e3f4ab,markdown,fr,464479e2f029f79a,"## 6. Routing et Mixture of Experts
+
+Le model merging combine les poids en un seul modele. Le **routing** adopte une approche differente : garder tous les experts et **selectionner dynamiquement** le bon pour chaque requete.
+
+### Architecture MoE (Mixture of Experts)
+
+```
+  Entree (prompt)
+       |
+  [ Routeur / Classifieur ]
+       |
+       +---> Expert A (Tech)     (si domaine = technique)
+       |
+       +---> Expert B (Cuisine)  (si domaine = cuisine)
+```
+
+Le routeur est un petit classifieur qui apprend a detecter le domaine de la requete. En pratique :
+- Les MoE a grande echelle (Mixtral, Switch Transformer) utilisent des routeurs appris par backprop
+- Ici, nous utilisons un classifieur simple sur les embeddings du modele de base",,,,,,,,464479e2f029f79a,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,m0eft05r,markdown,fr,9707d9a758606d90,"Le diagramme ci-dessous rend cette architecture **Mixture of Experts** sous forme de
+graphe : un routeur dirige chaque requete vers l'expert specialise du bon domaine.
+
+```mermaid
+flowchart TD
+    IN([""Entree (prompt)""]) --> R{""Routeur / Classifieur""}
+    R -->|""domaine = technique""| EA[""Expert A<br/>(Tech)""]
+    R -->|""domaine = cuisine""| EB[""Expert B<br/>(Cuisine)""]
+    classDef route fill:#f8d7da,stroke:#842029,color:#58151c
+    classDef exp fill:#fff3cd,stroke:#b8860b,color:#5c4400
+    classDef in fill:#cfe2ff,stroke:#084298,color:#052c65
+    class R route
+    class EA,EB exp
+    class IN in
+```
+
+> **Lecture.** Contrairement au *model merging* (qui fond les poids en un seul modele),
+> le **routing** conserve tous les experts intacts et en **selectionne dynamiquement**
+> un par requete. Le **routeur** est un petit classifieur qui detecte le domaine ; ici
+> il opere sur les embeddings du modele de base, tandis que les MoE a grande echelle
+> (Mixtral, Switch Transformer) apprennent leur routeur par retropropagation. L'interet :
+> n'activer qu'une fraction des parametres a chaque appel (calcul *creux*).
+",,,,,,,,9707d9a758606d90,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e3f4a5bc,code,fr,9f3fa7594110c6be,"# Implementer un routeur simple base sur les embeddings du modele de base
+import torch.nn as nn
+
+class SimpleRouter(nn.Module):
+    """"""Routeur qui classifie les requetes par domaine.""""""
+    def __init__(self, input_dim, num_experts):
+        super().__init__()
+        self.classifier = nn.Linear(input_dim, num_experts)
+    
+    def forward(self, x):
+        return self.classifier(x)
+    
+    def predict(self, x):
+        logits = self.forward(x)
+        return torch.argmax(logits, dim=-1)
+
+# Extraire les embeddings du modele de base pour entrainer le routeur
+def get_prompt_embedding(model, prompt):
+    """"""Extrait le embedding moyen du dernier layer cache.""""""
+    inputs = tokenizer(prompt, return_tensors=""pt"", truncation=True, max_length=64).to(model.device)
+    with torch.no_grad():
+        outputs = model(**inputs, output_hidden_states=True)
+    # Moyenne du dernier hidden state (couche finale)
+    last_hidden = outputs.hidden_states[-1]
+    # Moyenne sur la dimension de sequence (ignorer le padding)
+    mask = inputs[""attention_mask""].unsqueeze(-1).float()
+    embedding = (last_hidden * mask).sum(dim=1) / mask.sum(dim=1)
+    return embedding.squeeze(0)
+
+# Donnees d'entrainement du routeur (plus de diversite que les adaptateurs)
+router_train_data = [
+    # Domaine Tech (label=0)
+    (""### Human: Qu'est-ce que Python ?\n### Assistant:"", 0),
+    (""### Human: Expliquez Docker.\n### Assistant:"", 0),
+    (""### Human: C'est quoi Git ?\n### Assistant:"", 0),
+    (""### Human: Qu'est-ce qu'une API REST ?\n### Assistant:"", 0),
+    (""### Human: Expliquez le machine learning.\n### Assistant:"", 0),
+    (""### Human: Comment marche Kubernetes ?\n### Assistant:"", 0),
+    (""### Human: Qu'est-ce que JavaScript ?\n### Assistant:"", 0),
+    # Domaine Cuisine (label=1)
+    (""### Human: Comment faire une bechamel ?\n### Assistant:"", 1),
+    (""### Human: Quelle temperature pour cuire un steak ?\n### Assistant:"", 1),
+    (""### Human: Comment preparer une vinaigrette ?\n### Assistant:"", 1),
+    (""### Human: Qu'est-ce que le beurre clarifie ?\n### Assistant:"", 1),
+    (""### Human: Comment reussir une pate brisee ?\n### Assistant:"", 1),
+    (""### Human: Comment faire un bouillon de volaille ?\n### Assistant:"", 1),
+    (""### Human: Quelle est la difference entre sauter et poeler ?\n### Assistant:"", 1),
+]
+
+# Extraire les embeddings pour l'entrainement du routeur
+print(""Extraction des embeddings pour le routeur..."")
+embeddings = []
+labels = []
+for prompt, label in router_train_data:
+    emb = get_prompt_embedding(model_base, prompt)
+    embeddings.append(emb)
+    labels.append(label)
+
+emb_tensor = torch.stack(embeddings).detach()  # Detach du graph
+label_tensor = torch.tensor(labels)
+print(f""Embeddings : {emb_tensor.shape}"")
+print(f""Labels : {len(labels)} ({labels.count(0)} tech, {labels.count(1)} cuisine)"")
+
+# Entrainer le routeur
+input_dim = emb_tensor.shape[1]
+router = SimpleRouter(input_dim, num_experts=2).to(model_base.device)
+optimizer_router = torch.optim.Adam(router.parameters(), lr=0.01)
+loss_fn = nn.CrossEntropyLoss()
+
+# Deplacer les donnees sur le device
+emb_tensor = emb_tensor.to(model_base.device)
+label_tensor = label_tensor.to(model_base.device)
+
+print(""\nEntrainement du routeur (50 epochs)..."")
+for epoch in range(50):
+    logits = router(emb_tensor)
+    loss = loss_fn(logits, label_tensor)
+    optimizer_router.zero_grad()
+    loss.backward()
+    optimizer_router.step()
+    
+    if (epoch + 1) % 10 == 0:
+        preds = torch.argmax(logits, dim=-1)
+        acc = (preds == label_tensor).float().mean().item()
+        print(f""  Epoch {epoch+1}/50 | Loss: {loss.item():.4f} | Accuracy: {acc:.1%}"")
+
+print(""\nRouteur entrainte."")",,,,,,,,9f3fa7594110c6be,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f4a5b6cd,markdown,fr,622240de07796e53,"### Interpretation : Routeur
+
+**Sortie obtenue** : Le routeur a appris a classifier les requetes entre domaine tech et cuisine.
+
+| Aspect | Valeur | Signification |
+|--------|--------|---------------|
+| Input dim | Dimension du dernier hidden state | Richesse du signal |
+| Accuracy | >90% typiquement | Le routeur distingue bien les domaines |
+| Entrainement | 50 epochs, <1s | Tres rapide car le classifieur est lineaire |
+
+**Points cles** :
+1. Le routeur utilise les **hidden states du modele de base** comme features (pas besoin d'embeddings separes)
+2. Un classifieur lineaire suffit car les domaines sont bien separes dans l'espace latent
+3. Le routeur est leger et ajoute un cout negligeable a l'inference",,,,,,,,622240de07796e53,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a5b6c7de,code,fr,62e785c72f0180c7,"# Pipeline complet de routing : classifieur -> selection d'expert -> generation
+expert_names = [""Tech"", ""Cuisine""]
+expert_models = [model_tech, model_cook]
+
+def route_and_generate(prompt, router, experts, max_new_tokens=40):
+    """"""Route la requete vers le bon expert et genere la reponse.""""""
+    # Etape 1 : Extraire l'embedding
+    emb = get_prompt_embedding(model_base, prompt)
+    
+    # Etape 2 : Router
+    expert_idx = router.predict(emb.unsqueeze(0)).item()
+    
+    # Etape 3 : Generer avec l'expert selectionne
+    response = generate(experts[expert_idx], prompt, max_new_tokens=max_new_tokens)
+    return expert_idx, response
+
+# Test du pipeline de routing
+routing_test_prompts = [
+    (""tech"", ""### Human: Qu'est-ce que Kubernetes ?\n### Assistant:""),
+    (""tech"", ""### Human: Expliquez le versionning.\n### Assistant:""),
+    (""cuisine"", ""### Human: Comment faire un bouillon de volaille ?\n### Assistant:""),
+    (""cuisine"", ""### Human: Quelle est la difference entre sauter et poeler ?\n### Assistant:""),
+]
+
+print(""="" * 70)
+print(""PIPELINE DE ROUTING : Routeur -> Expert -> Generation"")
+print(""="" * 70)
+
+routing_results = []
+for true_domain, prompt in routing_test_prompts:
+    q = prompt.split(""Human: "")[1].split(""\\n"")[0]
+    expert_idx, response = route_and_generate(prompt, router, expert_models)
+    selected = expert_names[expert_idx]
+    correct = (selected.lower() == true_domain)
+    status = ""OK"" if correct else ""FAUX""
+    
+    routing_results.append({
+        ""domain"": true_domain, ""question"": q,
+        ""routed_to"": selected, ""correct"": correct, ""response"": response
+    })
+    
+    print(f""\n  [{true_domain.upper()}] Q: {q}"")
+    print(f""    Route vers: Expert {selected} [{status}]"")
+    print(f""    Reponse: {response}"")
+
+n_correct = sum(1 for r in routing_results if r[""correct""])
+print(f""\nPrecision du routing : {n_correct}/{len(routing_results)} ""
+      f""({100*n_correct/len(routing_results):.0f}%)"")",,,,,,,,62e785c72f0180c7,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b6c7d8ef,markdown,fr,042b157778ee4090,"### Comparaison : Merging vs Routing
+
+Maintenant que nous avons implemente toutes les approches, comparons-les systematiquement.
+
+| Critere | LERP | SLERP | DARE | Routing (MoE) |
+|---------|------|-------|------|---------------|
+| **Simplicite** | Tres simple | Simple | Simple | Plus complexe |
+| **Qualite par domaine** | Degradee | Moins degradee | Variable | Optimale (expert dedie) |
+| **Cout d'inference** | 1 modele | 1 modele | 1 modele | N modeles + routeur |
+| **VRAM** | 1x | 1x | 1x | Nx (ou offloading) |
+| **Flexibilite** | Fixe au merge | Fixe au merge | Fixe au merge | Dynamique (ajout d'experts) |
+| **Outils** | Mergekit | Mergekit | Mergekit | Custom / vLLM |
+
+**Quand utiliser quoi ?**
+- **SLERP** : Meilleur compromis qualite/simplicite pour combiner 2-3 modeles
+- **DARE** : Quand on a beaucoup d'experts (>3) et des interferences entre taches
+- **Routing** : Quand les domaines sont tres differents et qu'on peut se permettre Nx VRAM",,,,,,,,042b157778ee4090,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c7d8e9fa,code,fr,8914473747b089de,"# Comparaison quantitative de toutes les approches
+comparison_prompts = [
+    (""tech"", ""### Human: Qu'est-ce que Docker ?\n### Assistant:""),
+    (""cuisine"", ""### Human: Comment faire une bechamel ?\n### Assistant:""),
+]
+
+# Approches a tester
+approaches = {
+    ""Adaptateur A (Tech)"": model_tech,
+    ""Adaptateur B (Cuisine)"": model_cook,
+    ""LERP (alpha=0.5)"": model_lerp,
+    ""SLERP (t=0.5)"": model_slerp,
+    ""DARE (drop=0.3)"": model_dare,
+}
+
+print(""="" * 80)
+print(""COMPARAISON QUANTITATIVE DE TOUTES LES APPROCHES"")
+print(""="" * 80)
+
+for domain, prompt in comparison_prompts:
+    q = prompt.split(""Human: "")[1].split(""\\n"")[0]
+    print(f""\n[{domain.upper()}] Q: {q}"")
+    print(""-"" * 80)
+    
+    for name, model in approaches.items():
+        resp = generate(model, prompt, max_new_tokens=40)
+        print(f""  {name:<25} : {resp[:70]}"")
+    
+    # Ajouter le routing
+    expert_idx, resp = route_and_generate(prompt, router, expert_models, max_new_tokens=40)
+    print(f""  {'Routing -> ' + expert_names[expert_idx]:<25} : {resp[:70]}"")
+
+print(""\n"" + ""="" * 80)
+print(""Note : Les reponses varient avec la temperature (do_sample=True)."")
+print(""Le routing selectionne le meilleur expert pour chaque domaine."")
+print(""Le merge (LERP/SLERP/DARE) tente de combiner les expertises en un seul modele."")",,,,,,,,8914473747b089de,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d8e9f0ab,markdown,fr,57b510a5982f3a95,"### Interpretation : Comparaison finale
+
+**Resultats attendus** :
+
+| Approche | Tech | Cuisine | Commentaire |
+|----------|------|---------|-------------|
+| Adaptateur A | Bon | Faible | Specialise tech |
+| Adaptateur B | Faible | Bon | Specialise cuisine |
+| LERP | Moyen | Moyen | Melange egalitaire, degradation des deux |
+| SLERP | Moyen+ | Moyen+ | Meilleur preservation que LERP |
+| DARE | Variable | Variable | Dependant du dropout aleatoire |
+| Routing | Bon | Bon | Selectionne le bon expert, meilleur resultat |
+
+**Points cles** :
+1. Le **routing** offre les meilleurs resultats par domaine mais coute plus cher en VRAM
+2. Le **SLERP** est le meilleur merge statique -- bon compromis entre les deux expertises
+3. Le **DARE** est efficace quand on a beaucoup d'experts, mais moins bon avec seulement 2
+4. En production, les approches peuvent etre combinees : merge SLERP pour les experts proches + routing pour les domaines tres differents",,,,,,,,57b510a5982f3a95,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e9f0a1bc,code,fr,e4bdd20549e3a3b9,"# Liberation de la memoire GPU avant les exercices
+del model_tech, model_cook, model_lerp, model_slerp, model_dare
+del model_base, router
+del adapter_a_state, adapter_b_state
+del merged_state_lerp, merged_state_slerp, merged_state_dare
+gc.collect()
+if torch.cuda.is_available():
+    torch.cuda.empty_cache()
+    vram = torch.cuda.mem_get_info()[0] / 1e9
+    print(f""VRAM libre apres cleanup : {vram:.1f} GB"")
+print(""Memoire GPU liberee."")",,,,,,,,e4bdd20549e3a3b9,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f0a1b2cd,markdown,fr,286d51177063b829,"## 7. Exercices
+
+Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts precedents.",,,,,,,,286d51177063b829,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a1b2c3d4,markdown,fr,afd13b38fcd9b8a6,"### Exercice 1 : Explorer differentes valeurs de alpha (LERP/SLERP)
+
+Testez differentes valeurs du parametre `alpha` (ou `t` pour SLERP) et observez comment la balance entre les deux domaines change.
+
+**Indices** :
+- Testez alpha = 0.2 (majorite cuisine), 0.5 (egalitaire), 0.8 (majorite tech)
+- Observez comment les reponses aux questions tech et cuisine evoluent
+- Comparez LERP et SLERP pour les memes valeurs de alpha
+- Un alpha proche de 0 ou 1 s'approche d'un seul adaptateur",,,,,,,,afd13b38fcd9b8a6,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,b2c3d4e5,code,fr,660f24426c4a3378,"# Exercice 1 : testez differents alpha pour LERP et SLERP
+# TODO etudiant : rechargez le modele de base et les adaptateurs (cellules 4-6)
+# puis testez differentes valeurs d'alpha
+
+alpha_values = [0.2, 0.5, 0.8]  # TODO etudiant : remplacez par vos tests
+print(""Exercice a completer : testez LERP/SLERP avec differents alpha"")
+print(f""Valeurs a tester : {alpha_values}"")
+print(""Etapes :"")
+print(""  1) Rechargez le modele de base et entrainez les 2 adaptateurs"")
+print(""  2) Pour chaque alpha, creez un modele LERP et SLERP"")
+print(""  3) Testez sur des questions tech ET cuisine"")
+print(""  4) Observez comment la balance change avec alpha"")",,,,,,,,660f24426c4a3378,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,c3d4e5f6,markdown,fr,e429363c91f2b6b7,"### Exercice 2 : Implementer le merge TIES
+
+Implementez l'algorithme TIES (Trim, Elect Sign, Merge) vu en section 5. TIES resout les conflits de signe entre task vectors en gardant uniquement les modifications les plus importantes.
+
+**Indices** :
+- Etape 1 (Trim) : pour chaque task vector, ne garder que le top `density`% des valeurs en valeur absolue, mettre le reste a 0
+- Etape 2 (Elect Sign) : pour chaque position, compter le signe majoritaire entre les deux task vectors
+- Etape 3 (Merge) : sommer les valeurs en gardant uniquement celles dont le signe correspond au signe elu",,,,,,,,e429363c91f2b6b7,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,d4e5f6a7,code,fr,a4eda4b78737c9f8,"def ties_merge(tv_a, tv_b, density=0.5):
+    # TODO etudiant : implementez TIES merge
+    # Etape 1 : Trim - garder uniquement le top density% des valeurs absolues
+    # Indice : utilisez torch.kthvalue ou un seuil sur les valeurs absolues
+    
+    # Etape 2 : Elect Sign - choisir le signe majoritaire par position
+    # Indice : le signe majoritaire est celui dont la somme des valeurs absolues est la plus grande
+    
+    # Etape 3 : Merge - combiner en gardant le signe elect
+    # Indice : ne garder que les valeurs dont le signe correspond au signe elu
+    pass  # TODO etudiant
+
+print(""Exercice a completer : implementez TIES merge"")
+print(""Parametres a tester : density=0.3, density=0.5, density=0.7"")",,,,,,,,a4eda4b78737c9f8,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,e5f6a7b8,markdown,fr,fac7e791a210e732,"### Exercice 3 : Ajouter un troisieme expert au systeme de routing
+
+Creez un troisieme adaptateur specialise dans un domaine de votre choix (sport, musique, histoire, etc.) et ajoutez-le au systeme de routing.
+
+**Indices** :
+- Etape 1 : Definissez un dataset SFT de 5 exemples pour votre domaine
+- Etape 2 : Entrainez le 3e adaptateur LoRA avec le meme lora_config
+- Etape 3 : Ajoutez des exemples d'entrainement au routeur (label=2)
+- Etape 4 : Reentrainez le routeur avec 3 classes
+- Etape 5 : Testez le routing sur des questions des 3 domaines",,,,,,,,fac7e791a210e732,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,f6a7b8c9,code,fr,de22ef0f1c026102,"# Exercice 3 : creez un 3e adapter et mettez a jour le router
+# TODO etudiant : definissez votre domaine et vos exemples SFT
+
+# Etape 1 : Definir le dataset SFT pour le 3e domaine
+mon_domaine = ""sport""  # TODO etudiant : choisissez votre domaine
+mes_exemples = [
+    # TODO etudiant : ajoutez 5 exemples QA pour votre domaine
+]
+
+# Etape 2 : Entrainer le 3e adapter
+# TODO etudiant : utilisez le meme pattern que les cellules 5-6
+
+# Etape 3 : Ajouter au router
+# TODO etudiant : ajoutez des exemples label=2 dans router_train_data
+
+# Etape 4 : Reentrainer le router avec 3 classes
+# TODO etudiant : reentrainez avec num_experts=3
+
+print(""Exercice a completer : ajoutez un 3e expert au systeme de routing"")",,,,,,,,de22ef0f1c026102,,,,,,,
+MyIA.AI.Notebooks/GenAI/FineTuning/FT-05-ModelMerging-Routing.ipynb,a7b8c9d0,markdown,fr,fba0ed6dc054d6c2,"## 8. Resume du FT-05
+
+| Concept | Detail |
+|---------|--------|
+| **Task Vectors** | Difference entre poids fine-tunes et poids de base, capture la competence ajoutee |
+| **LERP** | Interpolation lineaire : moyenne ponderee des poids, simple mais peut dilater l'espace |
+| **SLERP** | Interpolation spherique : preserve les directions, meilleur merge pour 2-3 modeles |
+| **DARE** | Drop And Rescale : supprime aleatoirement des poids pour reduire les interferences |
+| **TIES** | Trim + Elect Sign + Merge : resout les conflits de signe entre task vectors |
+| **Routing (MoE)** | Routeur qui selectionne dynamiquement l'expert adapte a chaque requete |
+| **Trade-off** | Merge = 1 modele (moins cher) vs Routing = N modeles (meilleure qualite) |
+| **Outils** | Mergekit (production), implementation manuelle PyTorch (ce notebook) |
+
+---
+
+**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | [FT-04](./FT-04-RLHF-DPO.ipynb) | **FT-05**",,,,,,,,fba0ed6dc054d6c2,,,,,,,


### PR DESCRIPTION
## Summary

T1 extraction (Phase 0.5 backfill, Epic #4957/#1650) of the **GenAI/FineTuning** series into `translations/genai-finetuning/genai-finetuning.csv`. Covers the LLM fine-tuning chain end-to-end: intro (FT-01), QLoRA 4-bit quantization (FT-02), supervised fine-tuning SFT (FT-03), RLHF/DPO alignment (FT-04), model merging & MoE routing (FT-05).

## Content
- **161 cells** (71 `code` + 90 `markdown`), **5 notebooks**, **21 columns**
- Pivot `src_lang = fr` for all 161 cells (FR-first, per [`readme-french-first`](../blob/main/.claude/rules/readme-french-first.md))
- Target T3 columns (`text_en`/`hash_en`/`text_pt`/`hash_pt`) remain empty — gated by #1650 Phase 1 (Argumentum datasetupdater run)

## Verification
- **Deterministic**: SHA256 `9ca37363f0…` — re-running the extractor produces the byte-identical CSV
- **T2 drift check**: `check_translation_sync.py` → **0 anomalies** (`src_hash == hash_fr` verified on all 161 rows)
- **Integrity**: 0 violations `src_hash == hash_fr`
- **Safe owner-lane**: derived CSV artifacts from upstream notebook cells — **no notebook code modified**, no re-execution involved
- Catalogue byte-identical to main

```bash
python scripts/translation/extract_cells_to_csv.py     MyIA.AI.Notebooks/GenAI/FineTuning/     -o translations/genai-finetuning/genai-finetuning.csv
# -> OK : 161 cellules extraites de 5 notebook(s)
```

See #4957, #1650 (partial — one more GenAI sub-family covered; GenAI/Image, Audio, Texte, Video, SemanticKernel remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)