### PR TITLE
fix(lean,#4362): pin mathlib @ v4.31.0-rc1 in 5 already-rc1 lakefiles

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/lakefile.lean
@@ -8,7 +8,7 @@ package «repeated_games» where
   ]
 
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.31.0-rc1"
 
 -- Convention i18n EPIC #4980 (ratifiee ai-01 2026-07-04, comment-4881909354) :
 -- chaque `Foo.lean` FR canonique a un sibling `Foo_en.lean` (miroir EN, namespace

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/lakefile.lean
@@ -8,7 +8,7 @@ package «calibration» where
   ]
 
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.31.0-rc1"
 
 @[default_target]
 lean_lib «Calibration» where

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lakefile.lean
@@ -8,7 +8,7 @@ package «grothendieck» where
   ]
 
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.31.0-rc1"
 
 -- Convention i18n EPIC #4980 (ratifiée user 04/07, finding 2 ai-01) :
 -- `globs` (et non `roots`) pour que `lake build` auto-découvre les siblings

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples/lakefile.lean
@@ -8,7 +8,7 @@ package «mathlib_examples» where
   ]
 
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.31.0-rc1"
 
 @[default_target]
 lean_lib «MathLibExamples» where

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean
@@ -8,7 +8,7 @@ package «sensitivity» where
   ]
 
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.31.0-rc1"
 
 @[default_target]
 lean_lib «Sensitivity» where


### PR DESCRIPTION
## Scope
Extends the **#6857** `conway_lean` pilot to the 5 own-lakes whose `lake-manifest.json` **already** resolves mathlib at `v4.31.0-rc1` (rev `d568c8c0`) but whose `lakefile.lean` `require mathlib from git` lacks the explicit `@ "v4.31.0-rc1"` pin.

Without the pin, `lake` resolves the require on `master` by default while the manifest is frozen at rc1 → **"manifest out of date"** warning on every `lake build`.

## Files (5 lakefiles, +5/−5)
| Lake | manifest rev (before) | pin added |
|------|----------------------|-----------|
| `GameTheory/repeated_games_lean` | d568c8c0 (=rc1) | `@ "v4.31.0-rc1"` |
| `SymbolicAI/Lean/calibration_lean` | d568c8c0 (=rc1) | `@ "v4.31.0-rc1"` |
| `SymbolicAI/Lean/grothendieck_lean` | d568c8c0 (=rc1) | `@ "v4.31.0-rc1"` |
| `SymbolicAI/Lean/mathlib_examples` | d568c8c0 (=rc1) | `@ "v4.31.0-rc1"` |
| `SymbolicAI/Lean/sensitivity_lean` | d568c8c0 (=rc1) | `@ "v4.31.0-rc1"` |

## Safety — behavioral no-op
For each file the pinned rev **==** the rev the manifest already resolves. No re-download, no rebuild, no API-change risk — same class as #6857 (full main tree SUCCESS, 8545 jobs). The diff is exactly one appended `@ "v4.31.0-rc1"` per file; no `.lean` proof touched, no catalogue/README touched (byte-identical to main).

## Verification
The **5 dedicated Lean CI cold-build workflows** (`lean-repeated-games`, `lean-calibration`, `lean-grothendieck`, `lean-mathlib-examples`, `lean-sensitivity`) fresh-checkout + build each lake — these are the merge-gate (lean-merge-discipline §1, genuine in-PR cold-build).

## Deliberately out of scope
- `GameTheory/social_choice_lean` — already-rc1 but **active hot-zone** (SocialChoice_en dup incident #6772/#6776) → excluded to avoid branch friction.
- `GameTheory/conway_cgt_lean` (manifest `acbd8f07` @ master) + `SymbolicAI/Lean/finiteness_lean` (no manifest) → real harmonization **marathon**, not a no-op pin.

See #4362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)