### PR TITLE
feat(lean,#6842): factor p4_nw_shift_lemma — whnf-timeout fix infrastructure

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2825,6 +2825,47 @@ private theorem window_cone_in_domain (k : Nat) (p q : Int × Int)
   refine ⟨?_, ?_, ?_, ?_⟩
   all_goals linarith
 
+/-- **P4.4 NW-quadrant shift lemma (factorisé, c.488).** Caractérise l'appartenance
+    pointwise `p ∈ (hashlifeResultAux (k+1) q_nw).toGrid (2^k, 2^k)` du quadrant NW
+    (offset `(2^k, 2^k)` via `mem_toGrid_node`) en une conjonction `isAlive ... ∧
+    bounds`, où `q_nw = node r1 r2 r4 r5` est la super-cellule des quatre résultats
+    wave-1.
+
+    **Pourquoi factoriser hors `p4_succ_membership`** : ces étapes (construire
+    `centralCorrect q_nw (k-1)` via `p4_wave2_ih_step`, puis appliquer
+    `centralCorrect_mem_shift` pour réancrer l'offset `(2^k, 2^k)`) étaient inline
+    dans `p4_succ_membership` (snapshot #6724 run-4) et déclenchaient un whnf
+    timeout (200000 heartbeats) sur la tête de la déclaration monolithique. Le
+    budget heartbeats se réinitialise **par déclaration** : un lemme standalone au
+    corps court compile sans timeout, et `p4_succ_membership` n'a plus qu'à
+    l'appliquer (`have hnw_shift := p4_nw_shift_lemma ...`) sans ré-encourir le
+    coût d'élaboration inline. Pattern cohérent avec `p4_wave2_ih_step` (c.142).
+
+    **Corps** : `p4_wave2_ih_step` (ih sur la super-cellule opaque) →
+    `centralCorrect_mem_shift` (réancrage offset, G2 congruence). Sorry-free. -/
+private theorem p4_nw_shift_lemma
+    (k : Nat) (hk1 : 1 ≤ k)
+    (r1 r2 r4 r5 : MacroCell)
+    (hr1_l : r1.level = k) (hr2_l : r2.level = k)
+    (hr4_l : r4.level = k) (hr5_l : r5.level = k)
+    (hr1_w : r1.wf = true) (hr2_w : r2.wf = true)
+    (hr4_w : r4.wf = true) (hr5_w : r5.wf = true)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j)
+    (p : Int × Int) :
+    p ∈ (hashlifeResultAux ((k - 1) + 2) (node r1 r2 r4 r5)).toGrid
+          ((2^k : Int), (2^k : Int)) ↔
+      isAlive (evolve (2^(k - 1)) ((node r1 r2 r4 r5).toGrid (0, 0)))
+        (p.1 - (2^k : Int) + (2^(k - 1) : Int),
+         p.2 - (2^k : Int) + (2^(k - 1) : Int)) = true ∧
+      (2^k : Int) ≤ p.1 ∧ p.1 < (2^k : Int) + 2^((k - 1) + 1) ∧
+      (2^k : Int) ≤ p.2 ∧ p.2 < (2^k : Int) + 2^((k - 1) + 1) := by
+  have hcc : centralCorrect (node r1 r2 r4 r5) (k - 1) :=
+    p4_wave2_ih_step k hk1 r1 r2 r4 r5
+      hr1_l hr2_l hr4_l hr5_l hr1_w hr2_w hr4_w hr5_w ih
+  exact centralCorrect_mem_shift (node r1 r2 r4 r5) (k - 1)
+    (2^k) (2^k) p hcc
+
 /-- **P4 entry point**: the pointwise membership biconditional for the
     inductive step. Glues `p4_double_nine_shape` (P4.1), `p4_wave1_ih`
     (P4.2), and `p4_wave2_ih` (P4.3). The P4.4 half-step composition is


### PR DESCRIPTION
## Summary

Factor out the NW-quadrant **shift characterization** (`centralCorrect_mem_shift` G2 gate) from the monolithic `p4_succ_membership` declaration into a standalone, sorry-free lemma `p4_nw_shift_lemma`. Addresses the **whnf-timeout root cause** identified in #6724 forensic run-4 (steps 3-5 inline triggered a 200000-heartbeats whnf timeout on `p4_succ_membership`'s head). See #6842.

## What this PR does (and does NOT do) — honest scope

**Does (infrastructure, sorry-free):**
- Adds `p4_nw_shift_lemma` (+42 lines): consumes the 4 wave-1 results `(r1, r2, r4, r5)` + level/wf facts + `ih`, produces the pointwise membership iff at quadrant offset `(2^k, 2^k)`:
  `p ∈ (hRA (k+1) (node r1 r2 r4 r5)).toGrid (2^k, 2^k) ↔ isAlive (evolve 2^(k-1) q_nw_grid) (back-shifted p) = true ∧ bounds`
- Body: `p4_wave2_ih_step` (ih on opaque super-cell, c.142 pattern) → `centralCorrect_mem_shift` (offset re-anchoring, G2 congruence). **Sorry free.**
- Pattern-coherent with `p4_wave2_ih_step` (c.142), `centralCorrect_mem`/`centralCorrect_mem_shift` (c.153) — "sorry-stable infrastructure that unlocks the next attack".

**Does NOT (honestly deferred):**
- **Sorry count is STABLE** (not reduced): the NW call-site retains a sorry for the **G3 bridge** (`evolve_half_step` + `evolve_cone_agree` locality) connecting the shifted characterization to the global `evolve 2^k` RHS window. This PR is **factorization infrastructure**, not sorry elimination.
- Does not touch the ne/sw/se/mpr quadrants.

**Why this is progress despite stable sorry count:** the inline steps 3-5 were the **direct cause** of the whnf timeout blocking `p4_succ_membership` (#6724 run-4). Factoring them into a standalone declaration resets the per-declaration heartbeats budget — the short lemma body compiles without timeout, and `p4_succ_membership` no longer re-incurs the inline elaboration cost. The G3 bridge, now isolated from the shift characterization, is the next attackable sub-goal (the shift lemma is the gate it consumes).

## Build verification

- `lake build Conway.Life.HashlifeCorrectness` : **SUCCESS** (exit 0, 8498 jobs, ~6 min incremental with warm mathlib cache via recette c.473 `lake exe cache get`). No whnf timeout on the new lemma.
- `grep -c sorry HashlifeCorrectness.lean` : before = 59, after = **59 (stable)** — factorization only, no sorry eliminated.
- Lemma body sorry count: **0** (verified precise — the `have hcc := p4_wave2_ih_step ...` + `exact centralCorrect_mem_shift ...` chain is sorry-free).
- Cold-build recette c.473 validated on po-2026 (8119 mathlib oleans fetched, `lake exe cache get` = 230s, local `lake build` feasible on this lane — cf #6771 infra).

## Anti-regression

- +42/-0, 1 file, **pure additive** (no deletions, no proof/impl replaced).
- Call-site `p4_succ_membership` **unchanged** (the sorry at the NW quadrant stays verbatim — only a new lemma is added above it).
- Diff stat: `1 file changed, 41 insertions(+)` (lemma + docstring).

See #6842, See #6724, See #3846 (GOL S4), See #6771 (warm-cache infra).
