### PR TITLE
fix(translation,#4957,#3801): resync symboliclearning CSV SL-8 drift (1 SRC_DRIFT -> 0)

### DIFF
--- a/translations/symboliclearning/symboliclearning.csv
+++ b/translations/symboliclearning/symboliclearning.csv
@@ -16665,14 +16665,14 @@ Console.WriteLine(""Sur ce KG, les regles sont non-recursives : 1 seule iteratio
 Console.WriteLine(""suffit. clingo ferait la meme chose (point fixe) MAIS saurait"");
 Console.WriteLine(""aussi resoudre ancestorOf recursif et le repair minimal —"");
 Console.WriteLine(""cas honnetement hors scope du twin C# (INTRINSIC sans clingo natif)."");",,,,,,,,6f492197d4aaed20,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP-Csharp.ipynb,7795167a,markdown,fr,c71c6fbfdb08d5af,"---
+MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP-Csharp.ipynb,7795167a,markdown,fr,279d3adf6421f84a,"---
 ## Exercices
 
-> **Convention** (cf [notebook-conventions.md](../../../../../.claude/rules/notebook-conventions.md) C.1) : les stubs d'exercice utilisent `pass`-equivalents C# (`// TODO etudiant`, commentaire sans erreur). Le notebook s'execute de bout en bout meme exercices non completes.
+> **Convention** (cf [notebook-conventions.md](../../../.claude/rules/notebook-conventions.md) C.1) : les stubs d'exercice utilisent `pass`-equivalents C# (`// TODO etudiant`, commentaire sans erreur). Le notebook s'execute de bout en bout meme exercices non completes.
 
 ### Exemple guide 1 : Ajouter `uncleOf` et rediscover sa regle
 
-> Solution demontree ci-dessous (See #2161). `uncleOf(X,Y) :- parentOf(Z,Y), siblingOf(Z,X)` (le frere d'un parent est l'oncle).",,,,,,,,c71c6fbfdb08d5af,,,,,,,
+> Solution demontree ci-dessous (See #2161). `uncleOf(X,Y) :- parentOf(Z,Y), siblingOf(Z,X)` (le frere d'un parent est l'oncle).",,,,,,,,279d3adf6421f84a,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP-Csharp.ipynb,d378262a,code,fr,2e449424114d7fd4,"// Exemple guide 1 : uncleOf(X,Y) :- parentOf(Z,Y) ^ siblingOf(Z,X)
 // Variante : on ajoute manuellement quelques uncleOf, puis on verifie
 // si le mineur retrouve la regle parentOf(B,Y) ^ siblingOf(A,B) => uncleOf(A,Y).


### PR DESCRIPTION
## Summary

`fix(translation,#4957,#3801): resync symboliclearning CSV SL-8 drift (1 SRC_DRIFT → 0)`

The drift monitor flagged **1 SRC_DRIFT** on `translations/symboliclearning/symboliclearning.csv`:

| Cell | Detail |
|------|--------|
| `SL-8-KnowledgeGraphs-ILP-Csharp.ipynb` `7795167a` | markdown source hash `c71c6fbf` → `279d3adf` (Exercices section) |

`.net-csharp` notebook — my .NET partition (SymbolicAI/SymbolicLearning C# twin).

## Recipe (C458-L2) — targeted single-notebook

```bash
extract_cells_to_csv.py MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP-Csharp.ipynb --update translations/symboliclearning/symboliclearning.csv
# OK (--update): 1 ligne rafraîchie, 706 préservées, 0 ajoutée(s), 0 orpheline(s)
```

## Scope discipline (important)

I deliberately did **NOT** run a dir-wide `--update` on `SymbolicAI/SymbolicLearning/`. That mode would have force-added **14 rows** for the archived notebook `_archives/2026-07-04-Neurosymbolic-EML-precurseur-SL12/EML-NAND-Compose.ipynb` — archived by #5304, never previously in the live translation CSV, and deprecated per the repo's archive-exclusion convention (cf QC Archive Carve-out decision). Archived content is not translation-maintenance scope. Targeting the single drifted notebook keeps the diff surgical (+3/−3) and avoids scope creep.

## Verification (firsthand)

| Check | Result |
|-------|--------|
| Pre-update anomalies | **1** |
| Post-update anomalies | **0** ✓ |
| Diff scope | symboliclearning.csv only (+3/−3, hash refresh) ✓ |
| Archive rows added | **0** (surgical) ✓ |
| CSV parses | pandas: 738 rows / 21 cols ✓ |
| Line endings | LF only (0 CRLF) ✓ |
| Secrets | 0 inline ✓ |
| Catalogue | byte-identical (R1) ✓ |

See #4957 (Phase 0.5 translation infra, partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
