### PR TITLE
fix(translation,#4957,#3801): resync probas-infer CSV Infer-11 drift (1 SRC_DRIFT → 0)

### DIFF
--- a/translations/probas-infer/probas_infer.csv
+++ b/translations/probas-infer/probas_infer.csv
@@ -2474,7 +2474,12 @@ MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,1dc820f4,markdown,fr,
 Pour comprendre ce que chaque topic a ""appris"", nous visualisons la distribution $\phi_k$ des mots pour chaque topic. Les **mots les plus probables** definissent l'interpretation semantique du topic.
 
 En pratique, on affiche les **top-N mots** par topic pour faciliter l'interpretation humaine.",,,,,,,,2c0afe41102e39bc,,,,,,,
-MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,0e5bd4a3,code,fr,963a7023ddaaa7ba,"// Distribution phi (mots par topic) - simulee
+MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,0e5bd4a3,code,fr,4c5b0d65ed8b9485,"// Setup Plotly (technique C548-L2) — la clause using DOIT preceder tout autre element (CS1529).
+using Microsoft.DotNet.Interactive.Formatting;
+using System.IO;
+using System.Text.Json;
+
+// Distribution phi (mots par topic) - simulee
 
 double[,] phiSimule = {
     // Topic Sport
@@ -2493,19 +2498,57 @@ Console.WriteLine();
 for (int k = 0; k < numTopics; k++)
 {
     Console.WriteLine($""Topic {k+1} ({topicNames[k]}) :"");
-    
+
     // Top mots
     var topMots = Enumerable.Range(0, vocabSize)
         .Select(v => (mot: vocabulaire[v], prob: phiSimule[k, v]))
         .OrderByDescending(x => x.prob)
         .Take(3);
-    
+
     foreach (var (mot, prob) in topMots)
     {
         Console.WriteLine($""  {mot,-12} : {prob:F2}"");
     }
     Console.WriteLine();
-}",,,,,,,,963a7023ddaaa7ba,,,,,,,
+}
+
+// --- Visualisation Plotly (EPIC #3801 Prong-A) : heatmap complete de la matrice phi ---
+// Technique C548-L2 : Plotly.js via Formatter.Register (kernel builtin, aucun #r nuget).
+// Le top-3 ASCII ci-dessus masque la structure bloc-diagonale (chaque topic ""possede""
+// 3 mots a 0.30) ; la heatmap de la matrice COMPLETE 3x9 la rend immediatement visible.
+
+record PlotlyHtml(string Markup);
+Formatter.Register(typeof(PlotlyHtml),
+    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), ""text/html"");
+
+// z = phiSimule en listes de listes (Plotly attend un tableau 2D JSON)
+var z = new List<List<double>>();
+for (int k = 0; k < numTopics; k++) {
+    var row = new List<double>();
+    for (int v = 0; v < vocabSize; v++) row.Add(phiSimule[k, v]);
+    z.Add(row);
+}
+string trace = JsonSerializer.Serialize(new Dictionary<string, object> {
+    [""z""] = z,
+    [""x""] = vocabulaire,
+    [""y""] = topicNames,
+    [""type""] = ""heatmap"",
+    [""colorscale""] = ""Viridis"",
+    [""zmin""] = 0.0, [""zmax""] = 0.35,
+    [""text""] = z, [""texttemplate""] = ""%{text:.2f}"",
+    [""hovertemplate""] = ""P(%{x} | %{y}) = %{z:.2f}<extra></extra>"",
+});
+string layout = JsonSerializer.Serialize(new Dictionary<string, object> {
+    [""title""] = new Dictionary<string, string> { [""text""] = ""Matrice phi complete : P(mot | topic)"" },
+    [""xaxis""] = new Dictionary<string, object> { [""title""] = ""Vocabulaire"", [""side""] = ""bottom"" },
+    [""yaxis""] = new Dictionary<string, object> { [""title""] = ""Topic"", [""autorange""] = ""reversed"" },
+    [""margin""] = new Dictionary<string, int> { [""t""] = 60, [""r""] = 20, [""b""] = 60, [""l""] = 90 },
+    [""height""] = 320,
+});
+string markup = ""<div id=\""pltPhi\""></div>"" +
+    ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
+    $""<script>Plotly.newPlot('pltPhi',[{trace}],{layout});</script>"";
+new PlotlyHtml(markup)",,,,,,,,4c5b0d65ed8b9485,,,,,,,
 MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb,cc8aichxbkn,markdown,fr,5ccab0f76313cb75,"### Interpretation de la matrice phi
 
 **Structure de la distribution mots/topics** :


### PR DESCRIPTION
## Summary

**Translation CSV resync (EPIC #4957, #3801 cluster-wave collateral)** — `probas-infer.csv` cell `0e5bd4a3` (Infer-11-Topic-Models) drifted because the cell source changed in my own **#6840** (C548-L2 Plotly LDA heatmap, c.596). This PR refreshes the hash + source snapshot → **0 anomalies post-update**.

| File | Change |
|------|--------|
| `translations/probas-infer/probas_infer.csv` | `extract_cells_to_csv.py <notebook> --update` — refresh 1 row (cell `0e5bd4a3`), preserve 939 others. |

## Why this drifted (my own collateral)

`Infer-11-Topic-Models.ipynb` cell index 32 (`0e5bd4a3`) is the cell I upgraded in **#6840** — the ASCII top-3 word list became a full **Plotly heatmap of the 3×9 phi matrix** via the C548-L2 `Formatter.Register(typeof(PlotlyHtml)…)` technique. The source content changed → the CSV's source-hash for that cell went stale (SRC_DRIFT). Verified firsthand: the cell source contains `Formatter.Register` / `PlotlyHtml` / `heatmap` + my own comment "technique C548-L2 / CS1529".

## Scope — targeted single-notebook (L605-L1)

Per L605-L1, `--update` was run on **the drifted notebook alone** (`Infer-11-Topic-Models.ipynb`), NOT dir-wide. Dir-wide `--update` does not filter `_archives/` and force-adds git-tracked archived notebooks (learned c.605). Targeted = surgical.

## Verification (firsthand)

| Check | Result |
|-------|--------|
| Drift source | `check_translation_sync.py --check` → 1 anomaly (Infer-11 cell `0e5bd4a3`, SRC_DRIFT) ✓ firsthand |
| Post-update | `--update`: "1 ligne rafraîchie, 54 déjà in-sync, 0 ajoutée, 0 orpheline, 885 autres préservées" → **0 anomalies** ✓ |
| G.1 cell verify | cell `0e5bd4a3` = index 32, code cell, contains Plotly C548-L2 heatmap (my #6840) ✓ |
| Diff | hash refresh `963a7023ddaaa7ba`→`4c5b0d65ed8b9485` + source snapshot now mirrors notebook (Plotly code) ✓ |
| LF | 0 CRLF ✓ |
| Catalogue (R1) | byte-identical (no CATALOG-STATUS / generated touched) ✓ |
| CSV parse | 940 rows × 21 cols ✓ |
| Secrets | 0 inline ✓ |
| Collision | `gh pr list --search "infer csv resync"` = 0 OPEN → uncontested ✓ |

See #4957 (EPIC translation infra), #3801 (SOTA cluster-wave collateral drift). `.NET` partition, my own #6840 collateral.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
