### PR TITLE
fix(prover): per-tree lockfile + EXIT postlude in BG launcher (See #6790)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -705,6 +705,8 @@ best_generation_*.png
 # Lean prover history & analysis
 **/.prover_history/
 **/PORT_ANALYSIS.md
+# Advisory per-tree lock of prover BG runs (See #6790)
+**/.prover.lock
 
 # GameTheory generated plots
 cfr_variants_comparison.png

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -23,6 +23,11 @@ from prover import DEMOS, PROVED_DEMOS, TraceLogger
 from prover.provers import MultiAgentSorryProver, AutonomousProver
 from prover.config import create_client
 from prover.lean_utils import count_real_sorries
+from prover.tree_lock import (
+    acquire_tree_lock,
+    find_lean_project_root,
+    release_tree_lock,
+)
 
 TRACES_DIR = Path(__file__).parent / "traces"
 TRACES_DIR.mkdir(exist_ok=True)
@@ -64,7 +69,8 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
                coordinator_provider: str = None,
                tactic_provider: str = None,
                use_diagnosis_agent: bool = False,
-               concurrent_search_count: int = 0):
+               concurrent_search_count: int = 0,
+               force_lock: bool = False):
     """Run the prover on a target."""
     if demo_num is not None:
         if demo_num not in DEMOS:
@@ -85,6 +91,32 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         print("Must specify --demo or --file/--line")
         sys.exit(1)
 
+    # One prover per tree (#6790): run-7 was launched through THIS launcher
+    # while run-6 held the same tree — run-7's cleanup reverted run-6's
+    # build-passing candidate. Refuse the second run instead.
+    tree_root = find_lean_project_root(filepath) or Path(filepath).resolve().parent
+    lock_path, lock_msg = acquire_tree_lock(
+        tree_root, demo_num if demo_num is not None else name, force=force_lock,
+    )
+    if lock_path is None:
+        print(f"[LOCKED] {lock_msg}")
+        return {"name": name, "result_kind": "locked", "reason": lock_msg}
+    print(f"[TREE_LOCK] {lock_path}")
+    try:
+        return _run_prover_locked(
+            demo, name, filepath, line, mode, iterations, provider,
+            local_provider, director_provider, coordinator_provider,
+            tactic_provider, use_diagnosis_agent, concurrent_search_count,
+        )
+    finally:
+        release_tree_lock(lock_path)
+
+
+def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
+                       local_provider, director_provider, coordinator_provider,
+                       tactic_provider, use_diagnosis_agent,
+                       concurrent_search_count):
+    """The original run body, executed while holding the tree lock."""
     original = Path(filepath).read_text(encoding="utf-8")
     original_sorry = count_real_sorries(original)
     print(f"Target: {name}")
@@ -260,9 +292,13 @@ if __name__ == "__main__":
                              "parallel (B.7). 0 = single search (default). "
                              "E.g. --concurrent-search 2 = 3 total search agents. "
                              "Only used in --mode multi.")
+    parser.add_argument("--force-lock", action="store_true",
+                        help="Break an existing .prover.lock even if its holder "
+                             "looks alive or is on a foreign host (WSL<->Windows). "
+                             "Operator decision — see #6790.")
     args = parser.parse_args()
 
-    run_prover(
+    summary = run_prover(
         demo_num=args.demo,
         filepath=args.file,
         line=args.line,
@@ -276,4 +312,7 @@ if __name__ == "__main__":
         tactic_provider=args.tactic_provider,
         use_diagnosis_agent=args.use_diagnosis_agent,
         concurrent_search_count=args.concurrent_search,
+        force_lock=args.force_lock,
     )
+    if isinstance(summary, dict) and summary.get("result_kind") == "locked":
+        sys.exit(3)  # same contract as the outer launcher (#6790)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tree_lock.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tree_lock.py
@@ -1,0 +1,173 @@
+"""Per-Lean-project-tree lockfile for prover BG runs (See #6790).
+
+Incident 2026-07-16 (DEMO 62, HashlifeCorrectness.lean): two prover runs
+(run-6 and run-7) executed concurrently on the SAME working tree. Run-6
+materialized a build-passing +28-line candidate; run-7, launched by another
+session on the same tree, suffered sorry-line drift from run-6's in-place
+edit, made zero attempts, and its end-of-run cleanup reverted the tree —
+destroying run-6's validated work. Two `lake` processes also shared one
+`.lake` directory (spurious-verify contention). Lesson: UN SEUL acteur
+prover par arbre.
+
+This module provides an advisory lockfile at `<lake_root>/.prover.lock`
+(gitignored). Acquisition is atomic (O_CREAT | O_EXCL). The lock records
+holder pid / host / demo_id / start time so a second launcher can print an
+actionable refusal instead of corrupting the tree.
+
+Staleness: a lock whose holder pid is dead is broken automatically — but
+ONLY when the recorded host matches ours. PIDs are meaningless across the
+Windows/WSL boundary (separate pid namespaces), so a foreign-host lock is
+never auto-broken; the operator decides via --force-lock.
+
+WARNING (Windows): never probe pid liveness with ``os.kill(pid, 0)`` — on
+Windows CPython that call TERMINATES the target process (TerminateProcess
+with exit code 0). ``pid_alive`` below uses OpenProcess/GetExitCodeProcess
+via ctypes instead.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import platform
+import time
+from pathlib import Path
+
+LOCK_BASENAME = ".prover.lock"
+
+_LAKEFILE_NAMES = ("lakefile.lean", "lakefile.toml")
+
+# GetExitCodeProcess reports this while the process is still running.
+_STILL_ACTIVE = 259
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+
+def host_id() -> str:
+    """Stable-enough identity of this pid namespace (node + os family)."""
+    return f"{platform.node()}/{os.name}"
+
+
+def pid_alive(pid: int) -> bool:
+    """True if ``pid`` is a live process on THIS host. Never signals it."""
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+        )
+        if not handle:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            ok = kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code))
+            return bool(ok) and exit_code.value == _STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)  # POSIX: signal 0 = existence probe, sends nothing
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by someone else
+    return True
+
+
+def find_lean_project_root(filepath: str | Path) -> Path | None:
+    """Walk up from ``filepath`` to the enclosing lake root (lakefile.*)."""
+    p = Path(filepath).resolve()
+    if p.is_file() or not p.exists():
+        p = p.parent
+    for candidate in (p, *p.parents):
+        if any((candidate / name).exists() for name in _LAKEFILE_NAMES):
+            return candidate
+    return None
+
+
+def read_lock(lock_path: Path) -> dict:
+    """Best-effort parse of an existing lock. Corrupt lock -> {} (treated
+    as unreadable-foreign: refused unless --force-lock)."""
+    try:
+        return json.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def acquire_tree_lock(
+    root: Path,
+    demo_id: int | str,
+    force: bool = False,
+) -> tuple[Path | None, str]:
+    """Try to take the advisory lock for ``root``.
+
+    Returns ``(lock_path, message)`` on success, ``(None, reason)`` on
+    refusal. Auto-breaks a same-host lock whose holder pid is dead;
+    ``force=True`` breaks anything (operator decision).
+    """
+    lock_path = root / LOCK_BASENAME
+    payload = json.dumps(
+        {
+            "pid": os.getpid(),
+            "host": host_id(),
+            "demo_id": demo_id,
+            "started_utc": time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+            ),
+            "started_epoch": time.time(),
+        },
+        indent=2,
+    )
+
+    for _ in range(2):  # second pass after breaking a stale/forced lock
+        try:
+            fd = os.open(
+                str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY
+            )
+        except FileExistsError:
+            holder = read_lock(lock_path)
+            h_pid = int(holder.get("pid") or -1)
+            h_host = holder.get("host", "<unreadable>")
+            h_age = time.time() - float(
+                holder.get("started_epoch") or time.time()
+            )
+            desc = (
+                f"holder pid={h_pid} host={h_host} "
+                f"demo={holder.get('demo_id')} age={h_age:.0f}s"
+            )
+            same_host = h_host == host_id()
+            if force or (same_host and not pid_alive(h_pid)):
+                why = "forced" if force else "stale (holder pid dead)"
+                try:
+                    lock_path.unlink()
+                except OSError as exc:
+                    return None, f"REFUSED cannot break lock ({exc}): {desc}"
+                # Loop back and race for a fresh O_EXCL create — if another
+                # launcher wins that race, the retry hits FileExistsError
+                # with a live holder and is refused (no double-break).
+                print(
+                    f"[BG] TREE_LOCK_BROKEN reason={why} {desc}", flush=True
+                )
+                continue
+            hint = (
+                "another prover is active on this tree (UN SEUL acteur "
+                "prover par arbre, #6790); wait for it or re-run with "
+                "--force-lock if you are certain it is gone"
+            )
+            return None, f"REFUSED {desc} — {hint}"
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        return lock_path, f"acquired {lock_path}"
+    return None, "REFUSED could not acquire after breaking existing lock"
+
+
+def release_tree_lock(lock_path: Path | None) -> None:
+    """Remove the lock IF it is still ours (pid match). Never raises."""
+    if lock_path is None:
+        return
+    try:
+        holder = read_lock(Path(lock_path))
+        if int(holder.get("pid") or -1) == os.getpid():
+            Path(lock_path).unlink()
+    except OSError:
+        pass  # best-effort: a stale lock is auto-broken by the next run

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
@@ -13,16 +13,34 @@ Output format (parseable by harvest scripts):
     [BG] FINAL ok=<bool> sorry=<final> elapsed=<s>
     [BG] OTEL_PATH=<absolute path>
     [BG] TRACE_PATH=<absolute path>
+    [BG] TREE_LOCK <path>          (advisory lock taken, See #6790)
+    [BG] LOCKED <reason>           (another prover holds the tree -> exit 3)
+    [BG] EXIT code=<rc>            (always printed, even on exception path)
+
+Launch WITHOUT piping through `tail`/`head`: `... | tee log | tail -30`
+makes the task exit code tail's (0) and loses python's real one (run-6
+forensic, #6790). Use `set -o pipefail` + `tee` alone, or redirect to a
+file and Read it.
+
+Concurrency: at most ONE prover run per Lean project tree. A second launch
+on the same tree is refused (exit 3) while the first holds
+`<lake_root>/.prover.lock` — run-7's cleanup destroyed run-6's
+build-passing candidate when both ran on the same tree (#6790).
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import faulthandler
 import os
 import sys
 import time
 from pathlib import Path
+
+# Dump native tracebacks on fatal signals (SIGSEGV/SIGABRT...) so a future
+# run-6-style silent death leaves a signature in the log (#6790).
+faulthandler.enable()
 
 PROVER_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(PROVER_DIR))
@@ -36,6 +54,11 @@ os.environ.setdefault("LEAN_PROJECT", str(DEFAULT_LEAN_PROJECT))
 from prover.config import DEMOS  # noqa: E402
 from prover.provers import MultiAgentSorryProver  # noqa: E402
 from prover.trace import TraceLogger  # noqa: E402
+from prover.tree_lock import (  # noqa: E402
+    acquire_tree_lock,
+    find_lean_project_root,
+    release_tree_lock,
+)
 
 
 def _bg(line: str) -> None:
@@ -68,6 +91,29 @@ async def main(args: argparse.Namespace) -> int:
         f"max_iter={args.max_iter} workflow_timeout={args.workflow_timeout}s"
     )
 
+    # One prover per tree (#6790): lock the lake root the run will mutate.
+    tree_root = None
+    if demo.get("file"):
+        tree_root = find_lean_project_root(demo["file"])
+    if tree_root is None:
+        tree_root = Path(os.environ["LEAN_PROJECT"])
+    lock_path, lock_msg = acquire_tree_lock(
+        tree_root, args.demo_id, force=args.force_lock
+    )
+    if lock_path is None:
+        _bg(f"LOCKED {lock_msg}")
+        return 3
+    _bg(f"TREE_LOCK {lock_path}")
+    try:
+        return await _run_locked(args, demo, file_target)
+    finally:
+        release_tree_lock(lock_path)
+
+
+async def _run_locked(
+    args: argparse.Namespace, demo: dict, file_target: str
+) -> int:
+    """The original run body, executed while holding the tree lock."""
     pre_sorry = _peek_sorry_count(file_target) if demo.get("file") else None
     if pre_sorry is not None:
         _bg(f"PRE_FILE_SORRY_COUNT {pre_sorry}")
@@ -144,8 +190,22 @@ def parse_args() -> argparse.Namespace:
                    help="Provider for TacticAgent (default: openrouter). "
                         "#1289: GLM-5.1 (zai) times out at 1680s on tactic generation; "
                         "GPT-5.5 via openrouter expected ~60-120s.")
+    p.add_argument("--force-lock", action="store_true",
+                   help="Break an existing .prover.lock even if its holder "
+                        "looks alive or is on a foreign host (WSL<->Windows). "
+                        "Operator decision — see #6790.")
     return p.parse_args()
 
 
 if __name__ == "__main__":
-    sys.exit(asyncio.run(main(parse_args())))
+    # 130 is the sentinel for "died before returning" — the postlude below
+    # prints it on the exception path so a log NEVER ends without an EXIT
+    # marker on a python-level failure (run-6 silent-death forensic, #6790;
+    # a SIGKILL still can't be caught — that's what the lock staleness +
+    # faulthandler cover).
+    _rc = 130
+    try:
+        _rc = asyncio.run(main(parse_args()))
+    finally:
+        _bg(f"EXIT code={_rc}")
+    sys.exit(_rc)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py
@@ -206,8 +206,39 @@ def test_release_none_is_noop():
 
 
 # ──────────────────────────────────────────────────────────────────────────
-# run_prover_bg CLI wiring
+# run_prover_bg CLI wiring — BOTH launchers (the run-7 result JSON came from
+# the INNER prover/run_prover_bg.py, so that one is the actual incident path)
 # ──────────────────────────────────────────────────────────────────────────
+
+
+def test_inner_launcher_refuses_locked_tree(tmp_path):
+    """prover/run_prover_bg.run_prover must refuse a tree whose lock is held
+    (returns result_kind='locked' BEFORE touching the file or any LLM)."""
+    from prover.run_prover_bg import run_prover
+
+    (tmp_path / "lakefile.lean").write_text("-- lake", encoding="utf-8")
+    target = tmp_path / "Foo.lean"
+    target.write_text("theorem t : True := by sorry", encoding="utf-8")
+
+    # Simulate run-6 already active on this tree (live pid = our own).
+    lock_path, _ = acquire_tree_lock(tmp_path, demo_id="run-6")
+    try:
+        summary = run_prover(filepath=str(target), line=1)
+        assert summary["result_kind"] == "locked"
+        assert "REFUSED" in summary["reason"]
+        # The first holder's lock is untouched.
+        assert read_lock(lock_path)["demo_id"] == "run-6"
+    finally:
+        release_tree_lock(lock_path)
+
+
+def test_inner_launcher_signature_has_force_lock():
+    import inspect
+    from prover.run_prover_bg import run_prover
+
+    sig = inspect.signature(run_prover)
+    assert "force_lock" in sig.parameters
+    assert sig.parameters["force_lock"].default is False
 
 
 def test_launcher_exposes_force_lock_flag():

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py
@@ -1,0 +1,229 @@
+"""Unit tests for the per-tree prover lockfile (prover/tree_lock.py, #6790).
+
+Incident 2026-07-16 (DEMO 62): two prover runs shared one working tree;
+run-7's end-of-run cleanup reverted run-6's build-passing candidate. The
+advisory lock makes the second launch refuse instead (exit 3 in
+run_prover_bg.py).
+
+All tests are offline — no lake, no Lean, tmp_path only.
+
+Run from `agent_tests/`:
+    python -m pytest tests/test_bg_tree_lock.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Make `prover/` importable regardless of how pytest was invoked.
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover.tree_lock import (  # noqa: E402
+    LOCK_BASENAME,
+    acquire_tree_lock,
+    find_lean_project_root,
+    host_id,
+    pid_alive,
+    read_lock,
+    release_tree_lock,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# find_lean_project_root — walks up to the enclosing lakefile
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_project_root_found_from_nested_file(tmp_path):
+    (tmp_path / "lakefile.lean").write_text("-- lake", encoding="utf-8")
+    nested = tmp_path / "Conway" / "Life"
+    nested.mkdir(parents=True)
+    target = nested / "HashlifeCorrectness.lean"
+    target.write_text("theorem t : True := by sorry", encoding="utf-8")
+
+    assert find_lean_project_root(target) == tmp_path
+
+
+def test_project_root_prefers_nearest_lakefile(tmp_path):
+    """A vendored sub-lake (e.g. .lake/packages/mathlib) must lock ITS root,
+    not the outer one — nearest lakefile wins."""
+    (tmp_path / "lakefile.lean").write_text("-- outer", encoding="utf-8")
+    inner = tmp_path / "vendored"
+    inner.mkdir()
+    (inner / "lakefile.toml").write_text("# inner", encoding="utf-8")
+    target = inner / "Foo.lean"
+    target.write_text("-- x", encoding="utf-8")
+
+    assert find_lean_project_root(target) == inner
+
+
+def test_project_root_none_without_lakefile(tmp_path):
+    target = tmp_path / "Loose.lean"
+    target.write_text("-- x", encoding="utf-8")
+    assert find_lean_project_root(target) is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# pid_alive — must never signal/kill (Windows os.kill(pid, 0) TERMINATES)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_pid_alive_self():
+    assert pid_alive(os.getpid()) is True
+
+
+def test_pid_alive_dead_child():
+    """A spawned-then-exited child is reliably dead on this host."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "pass"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    proc.wait()
+    assert pid_alive(proc.pid) is False
+
+
+def test_pid_alive_rejects_nonpositive():
+    assert pid_alive(0) is False
+    assert pid_alive(-1) is False
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# acquire / release lifecycle
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_acquire_creates_lock_and_release_removes(tmp_path):
+    lock_path, msg = acquire_tree_lock(tmp_path, demo_id=62)
+    assert lock_path == tmp_path / LOCK_BASENAME
+    assert lock_path.exists()
+    holder = read_lock(lock_path)
+    assert holder["pid"] == os.getpid()
+    assert holder["host"] == host_id()
+    assert holder["demo_id"] == 62
+
+    release_tree_lock(lock_path)
+    assert not lock_path.exists()
+
+
+def test_second_acquire_refused_while_holder_alive(tmp_path):
+    """The #6790 scenario: a second launcher on the same tree must be
+    refused while the first (here: our own live pid) holds the lock."""
+    lock_path, _ = acquire_tree_lock(tmp_path, demo_id=62)
+    assert lock_path is not None
+
+    second, reason = acquire_tree_lock(tmp_path, demo_id=63)
+    assert second is None
+    assert "REFUSED" in reason
+    assert "--force-lock" in reason  # actionable refusal
+    # The original lock is untouched.
+    assert read_lock(lock_path)["demo_id"] == 62
+    release_tree_lock(lock_path)
+
+
+def test_stale_same_host_lock_is_auto_broken(tmp_path):
+    """Holder pid dead + same host -> the lock is stale (e.g. run-6's
+    silent death would have left one) and a new run takes over."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "pass"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    proc.wait()
+    stale = tmp_path / LOCK_BASENAME
+    stale.write_text(json.dumps({
+        "pid": proc.pid, "host": host_id(), "demo_id": 9,
+        "started_epoch": 0,
+    }), encoding="utf-8")
+
+    lock_path, _ = acquire_tree_lock(tmp_path, demo_id=62)
+    assert lock_path is not None
+    assert read_lock(lock_path)["pid"] == os.getpid()
+    release_tree_lock(lock_path)
+
+
+def test_foreign_host_lock_never_auto_broken(tmp_path):
+    """PIDs are meaningless across the WSL/Windows boundary: a foreign-host
+    lock must be refused even if that pid happens to be dead HERE."""
+    foreign = tmp_path / LOCK_BASENAME
+    foreign.write_text(json.dumps({
+        "pid": 1, "host": "other-machine/posix", "demo_id": 9,
+        "started_epoch": 0,
+    }), encoding="utf-8")
+
+    lock_path, reason = acquire_tree_lock(tmp_path, demo_id=62)
+    assert lock_path is None
+    assert "REFUSED" in reason
+    assert foreign.exists()  # untouched
+
+
+def test_force_lock_breaks_anything(tmp_path):
+    foreign = tmp_path / LOCK_BASENAME
+    foreign.write_text(json.dumps({
+        "pid": os.getpid(), "host": "other-machine/posix", "demo_id": 9,
+        "started_epoch": 0,
+    }), encoding="utf-8")
+
+    lock_path, _ = acquire_tree_lock(tmp_path, demo_id=62, force=True)
+    assert lock_path is not None
+    assert read_lock(lock_path)["pid"] == os.getpid()
+    release_tree_lock(lock_path)
+
+
+def test_corrupt_lock_refused_without_force(tmp_path):
+    """An unreadable lock is treated as foreign (operator decides), never
+    silently clobbered."""
+    (tmp_path / LOCK_BASENAME).write_text("not json{", encoding="utf-8")
+
+    lock_path, reason = acquire_tree_lock(tmp_path, demo_id=62)
+    assert lock_path is None
+    assert "REFUSED" in reason
+
+    forced, _ = acquire_tree_lock(tmp_path, demo_id=62, force=True)
+    assert forced is not None
+    release_tree_lock(forced)
+
+
+def test_release_only_removes_own_lock(tmp_path):
+    """release_tree_lock must not remove a lock taken over by another pid
+    (e.g. after a force-break race)."""
+    other = tmp_path / LOCK_BASENAME
+    other.write_text(json.dumps({
+        "pid": os.getpid() + 424242, "host": host_id(),
+        "started_epoch": 0,
+    }), encoding="utf-8")
+
+    release_tree_lock(other)
+    assert other.exists()  # not ours -> untouched
+
+
+def test_release_none_is_noop():
+    release_tree_lock(None)  # must not raise
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# run_prover_bg CLI wiring
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_launcher_exposes_force_lock_flag():
+    """The launcher must accept --force-lock (operator override, exit 3
+    contract documented in the module docstring)."""
+    import importlib
+
+    mod = importlib.import_module("run_prover_bg")
+    # parse_args reads sys.argv — probe the parser via a controlled argv.
+    old_argv = sys.argv
+    try:
+        sys.argv = ["run_prover_bg.py", "62", "--force-lock"]
+        args = mod.parse_args()
+        assert args.force_lock is True
+        sys.argv = ["run_prover_bg.py", "62"]
+        args = mod.parse_args()
+        assert args.force_lock is False
+    finally:
+        sys.argv = old_argv


### PR DESCRIPTION
## Summary

Launcher-side hardening from the run-6/run-7 forensic (2026-07-16, DEMO 62 — see #6790 comments): two prover runs executed concurrently on the same working tree; run-7's end-of-run cleanup **reverted run-6's build-passing +28-line candidate**, and two `lake` processes shared one `.lake` (spurious-verify contention).

- **`prover/tree_lock.py`** (new): advisory `<lake_root>/.prover.lock`, atomic `O_CREAT|O_EXCL`, records holder pid/host/demo_id/start. Same-host locks with a dead holder pid are auto-broken (covers run-6-style silent deaths); foreign-host locks (WSL↔Windows pid namespaces) are never auto-broken — `--force-lock` is the operator override. `pid_alive` uses `OpenProcess`/`GetExitCodeProcess` on Windows because `os.kill(pid, 0)` **terminates** the target there.
- **`run_prover_bg.py`**: lock acquired after demo resolution → second launch on the same tree prints `[BG] LOCKED <actionable reason>` and exits 3; release in `finally`. `faulthandler.enable()` + a `[BG] EXIT code=<rc>` postlude printed on every path so a log never ends without a signature (run-6 died silently at ~+430s with no trace). Docstring documents the `| tail` exit-code-masking trap.
- **`.gitignore`**: `**/.prover.lock`.

## Scope / deconfliction

Launcher-side only (`run_prover_bg.py` + new module + tests). po-2026's #6790 residuals — (c) success-semantics, (3) freeze-loop — live in `provers.py`/`workflow.py`: zero file overlap. `[CLAIMED]` posted on workspace-CoursIA dashboard before work.

## Validation

```
python -m pytest tests/test_bg_tree_lock.py -q  → 15 passed in 1.96s
python -m pytest tests/ -q                      → 180 passed, 2 failed
```

The 2 failures (`test_path_constants_resolve_to_active_workspace`, `test_legacy_fallback_still_works_when_no_workspace_root`) are **pre-existing and unrelated**: verified failing on a clean stashed tree too (env-dependent path-constant resolution to `C:/dev/CoursIA` on this machine). Flagged separately, not touched here.

See #6790 (partial — po-2026 owns the in-harness residuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)