### PR TITLE
fix(search,#5081): repair Search-8 stale prev-navlink + phase-1 verdict (no renumber)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Search-8-DancingLinks : L'algorithme X et Dancing Links de Knuth\n",
     "\n",
-    "**Navigation** : [<< Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)\n",
+    "**Navigation** : [<< MCTS](Search-7-MCTS-And-Beyond.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)\n",
     "\n",
     "## L'algorithme X et Dancing Links (DLX)\n",
     "\n",
@@ -3174,7 +3174,7 @@
    "source": [
     "---\n",
     "\n",
-    "**Navigation** : [<< Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)\n",
+    "**Navigation** : [<< MCTS](Search-7-MCTS-And-Beyond.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)\n",
     "\n",
     "**Series connexes** : \n",
     "- [Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb) - Application complete pour Sudoku\n",

--- a/docs/curriculum/search-renumbering-phase1.md
+++ b/docs/curriculum/search-renumbering-phase1.md
@@ -1,0 +1,92 @@
+# Search — phase 1 : analyse de cohérence narrative (#5081)
+
+Deuxième série analysée pour l'EPIC #5081 (après [Probas/Infer](infer-renumbering-phase1.md), verdict « no-defect-found »).
+Contrairement à Probas/Infer, **Search présente un défaut de navlink résiduel** — mais **pas de renumérotation** nécessaire.
+
+## Méthode
+
+Les notebooks Search portent un bloc **Navigation** en cellule 0 (et pied de page) :
+
+```
+**Navigation** : [<< Précédent](X.ipynb) | [Index](../README.md) | [Suivant >>](Y.ipynb)
+```
+
+Le lien `[<< Précédent]` encode le **prédécesseur narratif déclaré** (le vrai prereq de la
+colonne vertébrale), pas simplement un « see-also ». J'ai extrait ces `<<`/`>>` pour
+reconstruire la chaîne narrative déclarée, puis scanné les **navlinks arrières**
+(`<<` cible dans la même série avec un numéro `>=` au numéro courant) — signature d'un
+**résidu de réorganisation périmé** : la cible a été renommée pendant la reorg Part1-4,
+le lien conceptuel a cassé, le navlink n'a pas été mis à jour.
+
+## Résultat du scan (firsthand, 112 notebooks, 4 sous-dossiers)
+
+| Métrique | Valeur |
+|----------|--------|
+| Notebooks scannés | 112 (Part1-Foundations, Part2-CSP, Part3-Advanced, Applications) |
+| Navlinks cassés (404) | **0** (`check_notebook_navlinks.py --family Search`) — déjà réparés par la vague #6801/#6809/#6821/#6827/#6859 |
+| Navlinks arrières bruts | 9 |
+| — dont jumeaux C# (`b`) vers l'original Python | 5 (légitimes : le port C# précède son original Python) |
+| — dont sous-série Search-11b-Deep (Part2/3/4) | 3 (légitimes : parties séquentielles) |
+| — dont **vraie cible périmée** | **1** : `Search-8-DancingLinks << Search-11-Metaheuristics` |
+
+## Le défaut (confirmé firsthand)
+
+`Search-8-DancingLinks.ipynb` (cellule 0 + cellule 56) déclarait :
+
+```
+[<< Metaheuristiques](Search-11-Metaheuristics.ipynb)
+```
+
+**Pourquoi c'est un résidu périmé** : pendant la reorg Part1-4, `Search-11-SimulatedAnnealing`
+a été absorbé dans `Search-11-Metaheuristics` (SA plié dans le notebook métaheuristique plus
+large). Le `<<` pointait originellement vers SA (lien local-search ↔ exact-cover défensible) ;
+après rename, il pointe vers « Métaheuristiques » au sens large (PSO/ABC/SA…) — Dancing Links
+(algorithme X de Knuth, exact-cover) n'a **aucun lien conceptuel** avec les métaheuristiques.
+
+**Pourquoi le checker 404 ne l'a pas vu** : la cible `Search-11-Metaheuristics.ipynb`
+**existe** (elle résout) — le checker de la vague #6801 ne catche que les 404, pas les
+cibles « résout-vers-existant mais conceptuellement cassées ».
+
+## Correctif appliqué (cette PR)
+
+Restauration de la **symétrie de la colonne vertébrale** : `Search-7-MCTS-And-Beyond >>`
+pointe déjà vers `Search-8-DancingLinks`, donc `Search-8 <<` doit pointer vers
+`Search-7-MCTS-And-Beyond`. Remplacement des 2 occurrences (en-tête cellule 0 + pied de
+page cellule 56) :
+
+```
+[<< MCTS](Search-7-MCTS-And-Beyond.ipynb)
+```
+
+Diff +2/−2, markdown-only (C.2-safe, pas de re-exécution — #6722/#6796). Post-fix :
+`check_notebook_navlinks` = 0 cassé, `check_docs_links` = 0/3968 maintenu.
+
+## Verdict — pas de renumérotation
+
+Les autres « écarts structurels » observés sont **défendables par design**, pas des défauts :
+
+- `Search-11 << Search-4` (gap 4→11) : les métaheuristiques bâtissent sur la recherche locale
+  (Search-4), le saut sur la branche adversarielle/MCTS est intentionnel.
+- `Search-6 << Search-3` : la recherche adversarielle (minimax) nécessite les heuristiques
+  (Search-3 Informed), fourche légitime après les fondations.
+- `Search-12/13/14` dans Part3-Advanced : collection « techniques avancées » **intentionnellement
+  séparée** (cf blockquote intro Search-12 : « Partie 3 — Recherche avancée, au-delà des
+  fondations de la Partie 1 »). Pas sur la colonne vertébrale Part1 par design.
+- `Search-15 << Search-11`, `Search-10/16` sans `<<` : sujets autonomes (graphes, automates).
+
+**Conclusion** : la série Search ne souffre pas de « numérotation d'opportunité » — la structure
+Part1 (fondations) / Part2-CSP / Part3-Advanced (blockquotes explicites) / Applications est
+cohérente. Le seul défaut était un navlink périmé (résidu de reorg), désormais réparé.
+
+À comparer :
+- **Probas/Infer** : no-defect-found (ordre 1→19 déjà tri topo valide du DAG).
+- **Search** : 1 défaut de navlink (résidu périmé), 0 défaut de numérotation.
+
+## Hors scope (transparence)
+
+- **Applications/{CSP,Hybrid,Search}** : ensemble d'exercices capstone plat, pas une progression
+  narrative — la numérotation y est un index d'exercices, pas un ordre pédagogique.
+- **Jumeaux C# (`-Csharp` / suffixe `b`)** : ports miroirs des notebooks Python, même
+  numérotation par construction.
+
+See #5081.


### PR DESCRIPTION
## Summary

Search phase-1 narrative-coherence analysis for EPIC #5081 (2nd series analyzed, after Probas/Infer #6879). **Verdict: Search needs 1 navlink cleanup, NOT wholesale renumbering.**

Unlike Probas/Infer (no-defect-found), Search had exactly **1 stale-reorg-residue navlink** — now repaired. Plus a new phase-1 doc documenting the analysis method + verdict.

| File | Change |
|------|--------|
| `Search/Part1-Foundations/Search-8-DancingLinks.ipynb` | Fix `<<` prev-navlink: `Search-11-Metaheuristics` → `Search-7-MCTS-And-Beyond` (both occurrences: cell 0 header + cell 56 footer). +2/−2 markdown-only. |
| `docs/curriculum/search-renumbering-phase1.md` | NEW (92 lines, FR) — phase-1 analysis. |

## The defect (firsthand)

`Search-8-DancingLinks` declared `[<< Metaheuristiques](Search-11-Metaheuristics.ipynb)` as its narrative predecessor. **Why stale**: during the Part1-4 reorg, `Search-11-SimulatedAnnealing` was absorbed into `Search-11-Metaheuristics` (SA folded in). The `<<` originally pointed to SA (local-search ↔ exact-cover, defensible link); after rename it points to broad "Metaheuristics" (PSO/ABC/SA) — Dancing Links (Knuth's Algorithm X, exact-cover) has no conceptual link to metaheuristics.

**Why the #6801-#6859 wave missed it**: that wave's 404 checker only catches targets that don't resolve. `Search-11-Metaheuristics.ipynb` exists (resolves), so the broken-but-existing link survived.

## Method

Extracted the `[<< Precedent](X.ipynb)` navlink (declared spine predecessor, not see-also) from 112 Search notebooks, then scanned for **backward navlinks** (same-series target with number `>=` own number) = stale-reorg-residue signature.

Raw backward count = 9. Breakdown:
- 5 = C# twins (`b` suffix) pointing to their Python original (same number) — **legit**.
- 3 = Search-11b-Metaheuristiques-Deep Part2/3/4 sequential parts — **legit**.
- **1 = Search-8 ← Search-11** — the only true stale residue (now fixed).

## Fix: restore spine symmetry

`Search-7-MCTS-And-Beyond >>` already points to `Search-8-DancingLinks`, so `Search-8 <<` must point to `Search-7-MCTS` (restores the symmetric spine link; the asymmetry 7→8 forward but 8←11 backward was the bug).

## Verification (firsthand)

| Check | Result |
|-------|--------|
| `check_notebook_navlinks.py --family Search` | **0 broken** (112 scanned) |
| `check_docs_links.py --check` | **0/3968** (no new broken, baseline maintained) |
| backward-navlink residual | **8** (all legit C# twins + deep-parts; Search-8 gone) |
| Search-8 JSON | valid (json.loads OK) |
| CRLF / BOM | **0** / none |
| Diff scope | +2/−2 notebook (markdown-only) + NEW doc |
| Catalogue (R1) | byte-identical (0 CATALOG-STATUS touched) |
| C.2 | markdown-only, no re-exec (#6722/#6796) |

## Verdict — no renumbering

Other observed spine gaps are **defensible by design**, not defects:
- `Search-11 << Search-4` (gap): metaheuristics builds on local search, branch skip is intentional.
- `Search-6 << Search-3` (fork): adversarial search needs heuristics (Informed), legitimate fork.
- `Search-12/13/14` in Part3-Advanced: intentionally separate "advanced techniques" collection (explicit blockquote intros), not on the Part1 spine by design.

**Conclusion**: Search does not suffer "numérotation d'opportunité" — the Part1/Part2-CSP/Part3-Advanced/Applications structure is coherent. The only defect was a stale navlink (reorg residue), now repaired.

See #5081 (partial: Search series cleared).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
