### PR TITLE
docs(qc,#1027): revert #6881 phantom-claim — strategy trades (610 orders, bug #6196)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Coinbase-Hybrid/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Portfolio-IBKR-Coinbase-Hybrid/main.py
@@ -52,31 +52,31 @@ class PercentSlippageModel:
 # Alpha-framework attempt (CompositeAlphaModel + HybridPortfolioPCM) produced
 # 0 total orders across 6 backtest iterations (v1-v6) -- the Insight -> PCM
 # plumbing never emitted trades. The direct composite calls set_holdings()
-# explicitly each month, so it is INTENDED to trade by construction. NOTE
-# (diagnostic 2026-07-05, see #1027 c.11): this composite STILL emits 0 orders
-# in practice -- even a minimal `add_equity("SPY", DAILY) + schedule + single
-# set_holdings(spy, 0.5)` produces 0 orders on this project, so the root cause
-# is NOT the strategy structure but an upstream data/runtime condition (see
-# "Status" below).
+# explicitly each month, so it trades by construction. This is the live
+# equivalent of the MultiAlphaModel aggregation in the Phase 1 bridge table
+# (cell 2581bd22): each strategy contributes its within-strategy target weights,
+# blended by the fixed portfolio weights.
 #
 # Brokerage: the DEFAULT model (no set_brokerage_model), because IBKR margin
 # REJECTS Crypto ("Unsupported security type: Crypto"). The default authorizes
 # both equities and crypto; the explicit PercentFeeModel/PercentSlippageModel
 # (equities) + CoinbaseFeeModel (crypto) apply the README cost basis.
 #
-# Status -- 0 orders / phantom baseline (diagnostic 2026-07-05, see #1027 c.11
-# and c.12, 8 backtests QC Cloud firsthand): this algorithm produces 0 orders
-# across ALL variants tested since Phase 3 (14/06). The "leader 1.153 Sharpe /
-# 61.95% PSR" previously reported is a PHANTOM ARTIFACT, not real trading.
-# CORRECTION of the earlier (2026-06-28) note: set_account_currency("USDT")
-# does NOT "restore trades" -- with USDT the 100k starting cash is marked in
-# USDT and, with no USDTUSD pair subscribed, acts as a volatile-valuation proxy
-# that fabricates a non-flat equity curve (the phantom). set_account_currency
-# ("USD") reveals the truth: 0 orders, empty equity, all stats `-`. The root
-# cause is suspected to be an org-level data permission/subscription gap (or a
-# project flag / data-window coverage issue), NOT the account currency and NOT
-# the algorithm logic. Confirming requires QC runtime logs (qc-mcp-lite returns
-# statistics only, not AlgorithmLogs -- needs qc-mcp Docker or the QC web UI).
+# Status -- the composite DOES trade; metrics are real (re-read 2026-07-16).
+# A 2026-07-05 diagnostic claimed "0 orders / phantom baseline" for this
+# algorithm; that diagnosis was an artifact of the qc-mcp-lite totalOrders
+# bug (always 0, fixed in #6196 ~2026-07-14, AFTER the diagnostic). Re-reading
+# the same QC Cloud backtests (project 31717642) with the fixed wrapper:
+#   - post-mica-coinbase-2018-2025-5050: 610 orders, net ₮81,591, Sharpe 0.362
+#   - Phase3-OOS-2023-2025-5050: 289 orders, Sharpe 1.321, PSR 77.98%, net ₮107,955
+# The net profit corroborates the order count (the two fields are read from the
+# same real QC fields by #6196), so the strategy is NOT a phantom. The OOS
+# metrics still require the EPIC's multi-seed walk-forward + transaction-cost
+# discipline before any "BEATS" verdict (currently single-variant in-sample
+# OOS), but they are genuine trading results, not artifacts.
+# (The earlier "USDT restores trades" note was itself wrong in a different way
+# -- the USDT-cash-marking-as-phantom theory does not hold given real profit.)
+# See #1027 (self-correction comment 2026-07-16).
 #
 # MiCA migration (2026-06-28): crypto sleeve migrated Binance -> Coinbase.
 # Binance France services cease 2026-07-01 (no CASP MiCA licence); Coinbase


### PR DESCRIPTION
## Summary

**Self-correction of #6881 (my own merged PR).** #6881 rewrote the `Portfolio-IBKR-Coinbase-Hybrid/main.py` header toward "0 orders / phantom baseline / cause = data runtime". That diagnosis was an **artifact of the qc-mcp-lite `totalOrders`-always-0 bug**, fixed in **#6196** (~2026-07-14) — *after* the 07-05 diagnostic it was built on. This reverts the header to reflect that the strategy **does trade**.

## The bug behind the wrong diagnosis

`qc-mcp-lite` `read_backtest` returned `totalOrders: 0` for **every** backtest until #6196 fixed it (~2026-07-14). My 07-05 diagnostic (#1027 c.11/c.12) read "0 orders" with the **buggy** wrapper and concluded "phantom baseline". Re-reading the **same** backtests with the fixed wrapper:

| Backtest (id) | 07-05 read (buggy) | Now (fixed #6196) |
|---------------|-------------------|-------------------|
| `post-mica-coinbase-2018-2025-5050` (2796723a) | 0 orders, "phantom" | **610 orders**, net **₮81,591**, Sharpe 0.362 |
| `Phase3-OOS-2023-2025-5050` (63455524) | "leader 1.153 phantom" | **289 orders**, Sharpe 1.321, PSR **77.98%**, net **₮107,955** |

### Why this is real (2-field corroboration)

- **Net profit corroborates order count**: ₮81,591 (+81%) on 610 orders and ₮107,955 (+107%) on 289 orders cannot come from a flat cash position. #6196 reads `totalOrders` AND `netProfit` from the same "real QC fields".
- **Values now vary** (610 / 289 / 1 / 0 across backtests) instead of uniform 0 — the bug's signature was uniform 0 for everything.

## What the header now says

Reverted to: the composite **trades by construction** (direct `set_holdings` monthly), and the metrics are **genuine trading results** — but they still require the EPIC's **multi-seed walk-forward + transaction-cost discipline** before any "BEATS" verdict (currently single-variant in-sample OOS). The earlier "USDT-cash-marking phantom" theory is dropped (inconsistent with real profit).

## Validation

| Check | Result |
|-------|--------|
| `python -m py_compile main.py` | SYNTAX OK |
| Logic lines changed | **0** — every +/- line is a `#` comment |
| Diff | 1 file, +19/−19, header comment block |
| Catalogue byte-identique | ✓ |

## Open caveat (G.9 — not over-asserting)

I'm reversing my own prior diagnosis here. The 2-field corroboration (totalOrders + netProfit) is strong, but I've asked **@myia-ai-01** (who holds the live re-authed QC web session) to confirm the order count via the QC UI Orders tab before this is treated as final. If the UI disagrees, this PR will need adjustment. Full self-correction also posted on #1027 (issuecomment-4995422131).

See #1027

Co-Authored-By: Claude <noreply@anthropic.com>