### PR TITLE
docs(curriculum,#5081): PyMC phase-1 renumbering analysis — verdict no renumber

### DIFF
--- a/docs/curriculum/pymc-renumbering-phase1.md
+++ b/docs/curriculum/pymc-renumbering-phase1.md
@@ -1,0 +1,73 @@
+# Probas/PyMC — phase 1 : analyse de cohérence narrative (#5081)
+
+Troisième série analysée pour l'EPIC #5081 (après [Probas/Infer](infer-renumbering-phase1.md)
+et [Search](search-renumbering-phase1.md)). **Verdict : aucune renumérotation nécessaire
+(no-defect-found)** — comme Probas/Infer.
+
+L'EPIC #5081 cite la galerie officielle pymc.io comme squelette canonique ; l'ordre actuel
+PyMC-1..19 est cohérent avec cette progression.
+
+## Méthode
+
+Comme pour Probas/Infer : extraction du navlink `[<< Précédent]` (prédécesseur narratif déclaré)
+depuis le bloc Navigation de chaque notebook, puis vérification **topologique** — chaque
+prereq déclaré doit pointer vers un numéro strictement inférieur. Couverture numérique et
+intégrité du DAG vérifiées mécaniquement (script `pymc_spine.py`, 19 notebooks).
+
+## Résultats (firsthand)
+
+| Métrique | Valeur |
+|----------|--------|
+| Notebooks | 19 (PyMC-1..19) |
+| Couverture numérique 1..19 | **complète, 0 absent** |
+| Arêtes broken-order (prereq #≥own) | **0** → l'ordre 1→19 est un tri topologique VALIDE du DAG |
+| Navlinks cassés (404) | 0 |
+
+> Note G.1 : un premier scan `grep -iv infer` avait faussement signalé PyMC-5 manquant —
+> le filtre excluant « infer » (insensible casse) rayait `PyMC-5-Causal-Inference.ipynb`.
+> PyMC-5 **existe** (verified firsthand). Artefact d'outil, corrigé.
+
+## Arc narratif (cohérent)
+
+| Bloc | Numéros | Thème |
+|------|---------|-------|
+| Fondations | 1→2→3→4→5 | Setup → Gaussian Mixtures → Factor Graphs → Bayesian Networks → Causal Inference |
+| Méthodologie | 6 | Debugging |
+| Psychométrie / skills | 7→8→9 | Skills IRT → TrueSkill → Classification |
+| Modélisation | 10→11→12 | Model Selection → Topic Models → Hiérarchiques |
+| Applications | 13→14→15 | Crowdsourcing → Sequences → Recommenders |
+| Avancé | 16→17→18→19 | Sparse GP → Kalman Filter → Change Point → Survival Analysis |
+
+L'arc monte progressivement des fondations (modélisation bayésienne) vers les applications
+avancées (séries temporelles, survie). Les ajouts récents (18 Change-Point, 19 Survival)
+tombent à la bonne place — l'anti-pattern « numérotation d'opportunité » **ne s'applique pas**.
+
+## Parallèle PyMC ↔ Infer.NET
+
+PyMC (Python) et Infer.NET (C#, [analyse phase-1](infer-renumbering-phase1.md)) couvrent les
+**mêmes concepts** (TrueSkill, Crowdsourcing, Change-Point, Sparse-GP, Kalman, Survival,
+Topic-Models, Recommenders, IRT). Les deux séries sont **propres** (tri topo valide, arc
+cohérent). La cohérence croisée confirme que la partition Probas est structurellement saine.
+
+## Verdict — pas de renumérotation
+
+Aucun défaut de numérotation. Les asymétries mineures de navlinks observées
+(some notebooks sans `<<` déclaré, ex. PyMC-6/12/14/15/17/18/19) sont des **sujets autonomes**
+sans prédécesseur linéaire direct — pas des défauts de numérotation. Un rename serait
+**contre-productif** : 0 bénéfice pédagogique, coût de sweep des liens entrants (leçon
+#4737→#4743).
+
+**Coût évité** : la série Probas/PyMC sort du backlog #5081 sans action.
+
+Récapitulatif #5081 (3 séries analysées) :
+- **Probas/Infer** : no-defect-found.
+- **Search** : 1 défaut de navlink (résidu périmé) réparé, 0 défaut de numérotation.
+- **Probas/PyMC** : no-defect-found.
+
+## Hors scope (transparence)
+
+- **3 arêtes prereq sémantiquement faibles** (héritées du parallèle Infer : TrueSkill→Topic,
+  HMM/Sequences→Recommenders, Debugging→Classification) = sujet de prose séparé, un rename ne
+  les corrigerait pas. Éligible comme à-côté plafonné (1 PR courte clarifiant les lignes prereq).
+
+See #5081.


### PR DESCRIPTION
Third #5081 series analyzed (after Probas/Infer #6879, Search #6883). **Verdict: no renumbering needed (no-defect-found)** — same as Probas/Infer.

## Method
Extract `[<< Precedent]` narrative navlink from each of 19 PyMC notebooks, verify topological validity (every declared prereq points to a strictly lower number).

## Results (firsthand)
- Coverage 1..19 **complete, 0 missing**
- **0 broken-order edges** → order 1→19 is a valid topological sort of the DAG
- 0 broken 404 navlinks

## Arc (coherent)
Foundations (1-5 Setup/Mixtures/FactorGraphs/BayesNets/Causal) → methodology (6 Debugging) → psychometry (7-9 IRT/TrueSkill/Classification) → modeling (10-12 Selection/Topics/Hierarchical) → applications (13-15 Crowdsourcing/Sequences/Recommenders) → advanced (16-19 SparseGP/Kalman/ChangePoint/Survival). Recent additions (18/19) land correctly.

## Cross-parallel PyMC ↔ Infer.NET
Same concepts (TrueSkill/Crowdsourcing/ChangePoint/SparseGP/Kalman/Survival/Topics/Recommenders/IRT), both series clean. Probas partition structurally sound.

## G.1 self-correction
An initial `grep -iv infer` falsely flagged PyMC-5 as missing (filter excluded `PyMC-5-Causal-Inference` by substring). PyMC-5 **exists** firsthand; tool artifact corrected and documented.

## Verification
| Check | Result |
|-------|--------|
| Topological DAG (prev < own) | **0 broken edges** |
| Coverage 1..19 | complete |
| CRLF / BOM | 0 / none |
| Catalogue (R1) | byte-identical |
| Diff scope | +73 doc-only (NEW) |

Out of scope: 3 semantically weak prereq edges (TrueSkill→Topic, Sequences→Recommenders, Debugging→Classification) = separate prose concern, eligible as capped aside.

See #5081 (partial: Probas/PyMC cleared).

Co-Authored-By: Claude-Code <noreply@anthropic.com>