### PR TITLE
fix(sudoku,#5081): repair Sudoku-4-Csharp stale prev-navlink (reorg residue)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Résolution de Sudoku par Recuit Simulé\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Sudoku-3-Genetic](Sudoku-3-Genetic-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -3121,7 +3121,7 @@
    "source": [
     "---\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Sudoku-7-Norvig](Sudoku-7-Norvig-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Sudoku-3-Genetic](Sudoku-3-Genetic-Csharp.ipynb) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Csharp.ipynb)\n",
     "\n",
     "**Voir aussi** :\n",
     "- [Search-4-LocalSearch](../Search/Part1-Foundations/Search-4-LocalSearch.ipynb) - Théorie du recuit simulé (Hill Climbing, SA, Tabu Search)\n",


### PR DESCRIPTION
Extending the L613 stale-RESOLVES navlink scan (first applied to Search in #6883) to the other .NET families. **1 defect found in Sudoku; GameTheory and ML are clean.**

## Defect (firsthand)
`Sudoku-4-SimulatedAnnealing-Csharp` declared `[<< Sudoku-7-Norvig]` as its narrative predecessor — **backward** (prev #7 > own #4), same stale-reorg-residue class as Search-8 (#6883).

The Sudoku C# spine is otherwise contiguous (0→1→2→3→4→7→8→...→18), and **Sudoku-3-Genetic-Csharp `>>` already points to Sudoku-4**, so the symmetric correct precedent is **Sudoku-3-Genetic**.

**Conceptual corroboration**: Simulated Annealing (metaheuristic/optimization) aligns after Genetic (#3, metaheuristic), not after Norvig (#7, constraint propagation). The fix restores both numeric spine symmetry and pedagogical coherence.

## Why the 404 checker missed it
Target `Sudoku-7-Norvig-Csharp.ipynb` EXISTS (resolves), so the broken-but-existing link survived the navlink checker (same as Search-8). Detection = backward-navlink scan (`<<` target same-series with number > own) = **L613-L1**.

## Fix
2 occurrences (cell 0 header + cell 44 footer), +2/−2 markdown-only (C.2-safe per #6722/#6796, no re-exec).

| Check | Result |
|-------|--------|
| `check_notebook_navlinks.py --family Sudoku` | **0 broken** (36 scanned) |
| backward-navlink scan Sudoku | **0** (Sudoku-4 gone) |
| `check_docs_links.py --check` | **0/3968** maintained |
| CRLF / BOM | 0 / none |
| Diff scope | +2/−2 notebook (markdown-only) |
| Catalogue (R1) | byte-identical |

## Scanner results — .NET families (this cycle)
| Family | Backward navlinks | Action |
|--------|-------------------|--------|
| Search | 1 | fixed (#6883) |
| **Sudoku** | **1** | **fixed (here)** |
| GameTheory | 0 | clean |
| ML | 0 | clean |

The .NET partition stale-RESOLVES sweep is now complete (2 defects total, both fixed).

See #5081 (partial: Sudoku navlink cleared).

Co-Authored-By: Claude-Code <noreply@anthropic.com>