### PR TITLE
fix(genai-audio,#5780): 6 figures Audio = vraies sorties notebook, corrige texte d'audit faux (c.481/c.490) + légende audio4

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -29,28 +29,7 @@ L'objectif fil rouge de cette série est de construire un podcast entièrement g
 
 Plutôt qu'une galerie séparée du propos, chaque niveau ci-dessous est illustré par une sortie réelle de notebook (EPIC #5654), placée au plus près du concept qu'elle démontre : la forme d'onde d'un signal brut, la reconnaissance vocale par Whisper, la séparation de sources par Demucs, ou l'espace de features d'un benchmark TTS. La provenance exacte de chaque figure (notebook source, cellule, poids) et l'audit G.1 firsthand figurent dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md).
 
-> **Note d'audit c.481 (2026-07-14, doctrine #5780).** L'audit 2026-07-10 cataloguait `audio2-spectrogram.png` et `audio5-multimodel.png` comme DÉCLASSÉs. Une re-vérification G.1 firsthand c.481 a montré que les **PNG eux-mêmes étaient inversés** entre les slots `audio3-stt-tts.png` et `audio5-multimodel.png` (le contenu de l'un matchait le titre de l'autre et vice-versa). **Swap correctif c.481** : `git mv audio3-stt-tts.png audio5-multimodel.png` + `git mv audio5-multimodel.png audio3-stt-tts.png`. État après swap :
->
-> - `audio2-spectrogram.png` : **VRAI** (3 heatmaps MFCC authentiques, c.481 corrige l'erreur 2026-07-10 qui l'avait à tort catalogué DÉCLASSÉ — le contenu décrit alors provenait en fait du PNG désormais sous `audio5-multimodel.png`).
-> - `audio3-stt-tts.png` : **DÉCLASSÉ** (4 courbes librosa « Caractéristiques audio extraites », le titre STT/TTS reste trompeur ; le notebook 03-1-Multi-Model-Audio-Comparison produit ce contenu après analyse spectrale STT préalable).
-> - `audio5-multimodel.png` : **VRAI TTS-only** (2 barplots kokoro vs openai/tts-1, scope TTS-côté-serveur uniquement, pas STT/TTS multi-voies comme le titre le suggère).
->
-> Toutes les figures sont conservées dans le MANIFEST à titre de traçabilité ; la `audio3-stt-tts.png` DÉCLASSÉE n'est plus promue dans la section Aperçu.
->
-> ⚠️ **Note corrective c.490 (2026-07-14)** : la description « audio2: VRAI (3 heatmaps MFCC) » ci-dessus est **infondée**. Le c.490 a montré que audio2 contient en fait **5 panneaux Demucs SOTA**, pas des MFCC. Le MANIFEST c.481 perpétuait l'erreur de l'audit 2026-07-10 (description échangée entre audio2 et audio5). Voir la note d'audit c.490 détaillée ci-dessous pour le constat complet.
->
-> **Note d'audit c.490 (2026-07-14, doctrine #5780) — vérification G.1 fondateur post-c.481.** Une relecture G.1 firsthand des 6 PNG 2026-07-14 (via l'outil `Read` après le swap c.481) révèle un **constat majeur** : le swap c.481 a effectivement corrigé audio3↔audio5 (les contenus ont bien été échangés au niveau des blobs disque), mais **5/6 attributions MANIFEST (audio2, audio3, audio4, audio5, audio6) restent invérifiables par `nbformat` Python** :
->
-> - `audio1-waveform.png` : **VRAI** confirmé (forme d'onde = cell[12] out[1] du 01-3-Basic-Audio-Operations, ratio taille 0,95).
-> - `audio2-spectrogram.png` : contient en fait **5 panneaux Demucs SOTA** (Mix + DRUMS + BASS + OTHER + VOCALS), pas un spectrogramme MFCC. Aucun `nbformat` match. Probablement généré par un script externe ou un notebook de test.
-> - `audio3-stt-tts.png` : contient une **grille 4 panneaux STT/TTS** (Latence STT 0,47 s + 2 panneaux « Pas de resultats TTS » + Radar), pas les « 4 courbes librosa » annoncées par le MANIFEST c.481. Mais l'**alt-text in-situ ligne 74 est cohérent** avec ce contenu (« Reconnaissance vocale validée par Whisper large-v3-turbo ; volet TTS non abouti ») — donc la figure inline est pédagogique, seul le MANIFEST est trompeur.
-> - `audio4-demucs.png` : contient la **même grille STT/TTS** qu'audio3 (à plus haute résolution), pas du Demucs. Probable double-export de la même source.
-> - `audio5-multimodel.png` : contient en fait **4 courbes librosa spectral/RMS/ZCR** (« Caractéristiques audio extraites »), pas les « 2 barplots kokoro vs openai/tts-1 » annoncées par le MANIFEST c.481. Source amont probable = cell[28] out[2] du 01-3 (taille ratio 1,03).
-> - `audio6-tts-benchmark.png` : contient en fait **2 barplots kokoro vs openai/tts-1** (Latence + Taille audio), pas les « 3 heatmaps MFCC » annoncées par le MANIFEST c.481. Source amont probable = cell[29] out[1] du 03-1 (taille ratio 1,43).
->
-> **Hypothèse haute confiance** : `audio5-multimodel.png` et `audio6-tts-benchmark.png` sont des **exports aux attributions mélangées** entre les notebooks 01-3 et 03-1 ; `audio2-spectrogram.png` et `audio4-demucs.png` sont deux exports du même notebook Demucs (02-4) à downscale différents ; `audio3-stt-tts.png` est une figure externe non traçable.
->
-> **Swap correctif NON TENTÉ** par prudence (sans moyen de vérifier la source d'origine par `nbformat`, un swap risquerait de casser l'inventaire). Les alt-texts in-situ sont **conservés tels quels** car ils décrivent le contenu pédagogique réel observé (audio3 line 74 caveat « volet TTS en attente » cohérent ; audio4 line 97 « Demucs isole voix » est trompeur et à corriger dans une PR ultérieure si audit fondateur peut être refait avec re-exécution effective des notebooks). **0 figure DROP** — les 6 fichiers restent sur disque pour préservation du matériel pédagogique. Voir [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md) section *Vérification G.1* pour le détail MD5/taille/structurel.
+> **Note d'audit c.529 (2026-07-16, #5780).** Les notes d'audit c.481 et c.490 (retirées ici) avaient interverti le contenu de `audio2` et `audio4` dans leur propre lecture, puis conclu à tort que 5/6 figures étaient « invérifiables / probablement externes ». Une relecture vision firsthand des 6 PNG, croisée avec l'historique git par-blob et un scan `nbformat` des notebooks sources, établit que **les 6 figures sont de vraies sorties de notebook** : l'écart de taille et de MD5 avec les cellules brutes vient de l'optimisation PIL de `extract_readme_figures.py` (downscale ≤ 1200 px + recompression, ratio 0,62–0,97), et non d'une source externe. L'attribution corrigée et le détail par-blob (cellule source, MD5, ratio) sont dans [`assets/readme/MANIFEST.md`](assets/readme/MANIFEST.md) ; les légendes inline ci-dessous sont désormais fidèles au contenu réel de chaque figure.
 
 ## Structure
 
@@ -109,8 +88,8 @@ Un podcast de qualité demande une voix naturelle et une identité sonore distin
 La séparation de sources en est l'exemple le plus visuel : plutôt que de régénérer, Demucs ([02-4](02-Advanced/02-4-Demucs-Source-Separation.ipynb)) décompose un mix stéréo en quatre stems (batterie, basse, autre, voix) et en mesure l'énergie RMS :
 
 <p align="center">
-  <a href="02-Advanced/02-4-Demucs-Source-Separation.ipynb"><img src="assets/readme/audio4-demucs.png" width="360" alt="Grille STT/TTS multi-modèles : latence Whisper large-v3-turbo (0,47 s) validée, volet TTS non abouti dans l'environnement de test (panneaux « Pas de resultats TTS »)."></a><br>
-  <em>Grille de benchmark STT vs TTS du notebook 03-1-Multi-Model-Audio-Comparison (et non 02-4-Demucs comme l'attribution initiale le suggérait ; voir note d'audit c.490 dans <a href="assets/readme/MANIFEST.md">MANIFEST</a>).</em>
+  <a href="02-Advanced/02-4-Demucs-Source-Separation.ipynb"><img src="assets/readme/audio4-demucs.png" width="360" alt="Séparation de sources Demucs : un mix stéréo décomposé en quatre stems (batterie, basse, autre, voix), chacun avec son énergie RMS annotée."></a><br>
+  <em>Sortie du notebook <a href="02-Advanced/02-4-Demucs-Source-Separation.ipynb">02-4</a> : 5 panneaux — le mix original puis les stems DRUMS, BASS, OTHER et VOCALS isolés, avec le RMS mesuré pour chacun (voix ≈ 0,012, basse ≈ 0,163).</em>
 </p>
 
 ### 03-Orchestration - Multi-modèles & Temps réel
@@ -147,7 +126,7 @@ Le notebook [03-1](03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb) com
 
 <p align="center">
   <a href="03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb"><img src="assets/readme/audio6-tts-benchmark.png" width="340" alt="Benchmark multi-modèles TTS : latence (ms) et taille audio (KB) de kokoro vs openai/tts-1 par type de texte (dialogue, monologue, narration)."></a><br>
-  <em>Sortie du notebook <a href="03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb">03-1</a> (et non 04-7 comme l'attribution initiale le suggérait ; voir note d'audit c.490 dans <a href="assets/readme/MANIFEST.md">MANIFEST</a>) : 2 barplots Latence/Taille audio kokoro vs openai/tts-1 — discrimination nette sur latence, taille cohérente openai &gt; kokoro.</em>
+  <em>Sortie du notebook <a href="03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb">03-1</a> (cellule 29 ; provenance détaillée dans <a href="assets/readme/MANIFEST.md">MANIFEST</a>) : 2 barplots Latence/Taille audio kokoro vs openai/tts-1 — discrimination nette sur latence, taille cohérente openai &gt; kokoro.</em>
 </p>
 
 ## Technologies

--- a/MyIA.AI.Notebooks/GenAI/Audio/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/assets/readme/MANIFEST.md
@@ -1,130 +1,85 @@
 # Manifeste des figures — GenAI/Audio
 
-Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'outputs de notebooks).
+Provenance des images de `assets/readme/` (EPIC #5654, source 1 = extraction d'outputs de notebooks via `extract_readme_figures.py`).
 
-**Audit G.1 c.490 (2026-07-14, doctrine #5780)** : audit fondateur de vérification post-c.481 swap. Constat majeur : **5/6 PNG n'ont pas d'attribution source vérifiable** par `nbformat` (MD5 cell output ≠ MD5 disque, taille différente systématique, contenu visuel G.1 ne correspond à aucune cellule des 4 notebooks référencés). Les PNG ont probablement été produits par un processus externe (script ad-hoc, notebook supprimé, environnement de test hors-repo) et leur traçabilité amont est **perdue**. État détaillé figure par figure dans la section *Contenu réel vérifié (G.1 firsthand 2026-07-14)*.
+**Résolution d'audit c.529 (2026-07-16, #5780) — vérification vision firsthand + traçage nbformat.** Les notes d'audit c.481 et c.490 concluaient à tort que 5/6 PNG étaient « invérifiables / probablement externes ». Cette conclusion reposait sur une **double erreur de méthode** :
 
-**Audit G.1 c.481 (2026-07-14, doctrine #5780)** : swap audio3↔audio5 corrige le mismatch de contenu (les PNG assignés à ces deux slots ne correspondaient pas à leurs alt-texts respectifs). Le PNG « comparaison multi-modèles » (2 barplots kokoro/openai-tts-1) est désormais sous `audio5-multimodel.png` ; le PNG « caractéristiques audio extraites » (4 courbes librosa) est désormais sous `audio3-stt-tts.png`.
+1. **Inversion de lecture audio2↔audio4** : le c.490 a lu le contenu de `audio2` (3 heatmaps MFCC) comme du « Demucs », et celui de `audio4` (5 panneaux Demucs) comme une « grille STT/TTS ». Les deux attributions de cellule source du MANIFEST c.481 étaient en fait **correctes** (audio2 ← MFCC, audio4 ← Demucs).
+2. **Fausse prémisse « MD5 ≠ donc externe »** : `extract_readme_figures.py` **optimise chaque figure au moment de l'extraction** (downscale à ≤ 1200 px de large + recompression PIL). Le MD5 et la taille du PNG disque **diffèrent donc nécessairement** de la sortie de cellule brute — ce n'est pas la signature d'une source externe, mais le comportement normal de l'outil. Le « ratio systématique 0,55–2,36 » invoqué par le c.490 provenait de comparaisons contre les **mauvaises cellules attendues** (le corps du c.490 identifiait pourtant les bonnes sources pour audio5/audio6, en contradiction avec sa propre table).
 
-**Audit G.1 2026-07-10** : vague-1 fondateur cataloguait à tort `audio2-spectrogram.png` et `audio5-multimodel.png` comme DÉCLASSÉs. L'audit c.481 a montré que les contenus alors décrits provenaient en fait de PNG permutés, et a corrigé par swap des blobs. La classification DÉCLASSÉ a été levée pour audio2/audio5 dans le MANIFEST post-c.481.
-
-**Constat c.490 (2026-07-14) — dette cumulative majeure non détectée par 5 PRs successives** : la relecture G.1 firsthand 2026-07-14 (post-c.481, post-c.437, post-#6009, post-#5701) révèle que **5/6 PNG audio (audio2, audio3, audio4, audio5, audio6) ont un contenu visuel qui ne correspond à AUCUNE cellule des 4 notebooks référencés** (`01-3-Basic-Audio-Operations`, `02-4-Demucs-Source-Separation`, `03-1-Multi-Model-Audio-Comparison`, `04-7-TTS-Voice-Benchmark`). Les attributions du MANIFEST c.481 sont donc **structurellement invérifiables** par `nbformat` Python. C'est une **erreur d'audit fondateur systémique** : aucun des 5 audits passés n'a vraisemblablement effectué de lecture G.1 firsthand des 6 PNG avant de rédiger les attributions.
-
-**État post-c.490 — figures conservées sur disque, traçabilité reconstruite par contenu visuel** : aucune figure n'est supprimée du dépôt (préservation du matériel pédagogique). Les alt-texts in-situ dans le README sont **alignés avec le contenu G.1 firsthand** (vérifié 2026-07-14 pour `audio1-waveform` ligne 59, `audio3-stt-tts` ligne 74, `audio4-demucs` ligne 97, `audio6-tts-benchmark` ligne 134 — voir `README.md`). Aucune correction d'alt-text in-situ n'est nécessaire au c.490.
+**Constat c.529 : les 6 figures sont de vraies sorties de notebook.** Cinq sont tracées à une cellule committée par contenu + ratio de taille cohérent avec l'optimisation PIL (ratio 0,62–0,97, toujours ≤ 1,0). La sixième (`audio3`) est une figure de benchmark STT/TTS réelle dont le volet TTS vide est **honnêtement signalé** dans l'alt-text in-situ (disclosure, cf doctrine C522) ; sa cellule source exacte n'est pas committée dans les 3 notebooks référencés. **Aucun swap de fichier n'est nécessaire** ; les légendes inline du README sont corrigées pour être fidèles au contenu réel.
 
 ## audio1-waveform.png
 
-- **Source** : notebook `01-Foundation/01-3-Basic-Audio-Operations.ipynb` (cellule 12, output 1)
+- **Source** : `01-Foundation/01-3-Basic-Audio-Operations.ipynb` cell[12] out[1] (`# Visualisation de la forme d'onde`).
+- **Contenu (vision firsthand c.529)** : courbe matplotlib unique « Forme d'onde », amplitude ±0,4, axe temps 0–12 s.
+- **Traçage** : cellule brute 39 273 B (md5 `3ace572f`) → disque 37 273 B (md5 `09e55bfb`), ratio **0,95**.
 - **Alt-text (FR)** : Forme d'onde : échantillonnage d'un signal audio continu et visualisation temporelle.
-- **Poids** : 36.4 KB (natif) → 37.3 KB (réexport actuel, taille 37273 B)
-- **SHA256** : `17bf37ed06a8fdb6...` (37 273 B)
-- **Contenu réel vérifié (G.1 firsthand 2026-07-14)** : courbe unique matplotlib « Forme d'onde - Echantillon de test », amplitude ±0,4, axe temps 0–12 s, signal parole alternant silences et phonèmes. **VRAI** — contenu correspond à l'alt-text. Cohérent avec la cellule 12 out[1] du notebook 01-3 (`librosa.load()` + `waveshow()`).
-- **Verdict G.1 2026-07-14** : VRAI — figure légitime, traçabilité amont confirmée par taille proche (cell 39 273 B vs disk 37 273 B, ratio 0,95).
-- **Note** : seul PNG audio dont la cellule source est **structurellement cohérente** avec le contenu visuel et la taille.
+- **Verdict** : **SOTA-OK** — vraie sortie de notebook, légende fidèle. Inliné (README §01-Foundation).
 
 ## audio2-spectrogram.png
 
-- **Source MANIFEST c.481** : notebook `01-Foundation/01-3-Basic-Audio-Operations.ipynb` (cellule 20, output 3) — **attribution invérifiable par nbformat** (MD5 cell `238e0bd6` ≠ MD5 disk `b9792e33`).
+- **Source** : `01-Foundation/01-3-Basic-Audio-Operations.ipynb` cell[20] out[3] (`# MFCC (Mel-Frequency Cepstral Coefficients)`).
+- **Contenu (vision firsthand c.529)** : **3 heatmaps MFCC** empilées (MFCC, delta, delta-delta), échelle de couleur, axe temps horizontal, coefficients en ordonnée. **Ce ne sont pas des panneaux Demucs** (erreur de lecture c.490).
+- **Traçage** : cellule brute 84 031 B (md5 `238e0bd6`) → disque 77 625 B (md5 `b9792e33`), ratio **0,92**.
 - **Alt-text (FR)** : Spectrogramme et MFCC : décomposition temps-fréquence du signal pour la reconnaissance vocale.
-- **Poids** : 75.8 KB (natif) → 77.6 KB (réexport actuel, taille 77625 B)
-- **SHA256** : `c39fe6aa74dca587...` (77 625 B)
-- **Contenu réel vérifié (G.1 firsthand 2026-07-14)** : **5 panneaux Demucs SOTA séparation de sources** — Mix original (gris, axe 0–9 s, amplitude ±0,75), DRUMS (rouge, RMS 0,0307), BASS (vert, RMS 0,1626), OTHER (bleu, RMS 0,1524), VOCALS (orange, RMS 0,0117). Axe temps 0–9 s, amplitude ±0,4. **NE CORRESPOND PAS à un spectrogramme / MFCC** comme le suggère l'alt-text et l'attribution cell[20] out[3] du 01-3 (qui produit des heatmaps MFCC couleur rouge/bleu).
-- **Verdict G.1 2026-07-14** : **DÉCLASSÉ** — contenu réel = Demucs SOTA, attendu = spectrogramme MFCC. Source d'origine non traçable par `nbformat` (MD5 cell[20] out[3] ≠ MD5 disk, et aucune autre cellule des notebooks référencés ne produit cette figure 5 panneaux Demucs). Probablement généré par un script externe ou un notebook de test hors-repo.
-- **Correspondance visuelle probable** : le contenu (5 panneaux Demucs avec RMS annotés) est structurellement identique à ce que produirait `demucs.apply()` + un subplot matplotlib 5 lignes. La cellule 23 out[2] du notebook 02-4-Demucs-Source-Separation (md5 `b5cc7ba0`, 284 044 B) produit effectivement un PNG Demucs 5 panneaux — taille 1,6× supérieure au disk (284044 / 175056), donc peut être le même contenu à DPI différent. **Hypothèse à vérifier** : audio2-spectrogram.png et audio4-demucs.png sont **deux exports du même notebook source** (02-4 cell[23] out[2]), à des paramètres de downscale différents.
-- **Note** : swap correctif NON TENTÉ — sans confirmation de la source amont, risque de casse de l'inventaire. Documentation honnête de l'état réel.
+- **Verdict** : **SOTA-OK** — vraie sortie MFCC du 01-3. Asset orphelin (non inliné dans le README ; disponible pour réutilisation).
 
 ## audio3-stt-tts.png
 
-- **Source MANIFEST c.481** : notebook `01-Foundation/01-3-Basic-Audio-Operations.ipynb` (cellule 28, output 2) — **attribution invérifiable par nbformat** (MD5 cell `890f2d8a` ≠ MD5 disk `b047ef65`).
-- **Alt-text MANIFEST c.481 (FR)** : Reconnaissance (STT) et synthèse (TTS) : transcription et génération vocale appliquées au même flux.
-- **Alt-text in-situ README ligne 74** : Reconnaissance vocale (STT) validée par Whisper large-v3-turbo ; volet TTS non abouti dans l'environnement de test (sous-figures vides). — **correspond au contenu G.1 firsthand** (le caption ligne 75 caveat « volet TTS en attente de re-exécution » est cohérent).
-- **Poids** : 163.8 KB (avant c.481) → 92.1 KB (avant c.481) → 94.3 KB (réexport actuel, taille 94346 B, post-c.481 swap)
-- **SHA256** : `bcfcf5250776c992...` (94 346 B)
-- **Contenu réel vérifié (G.1 firsthand 2026-07-14)** : **grille 4 panneaux STT/TTS** — (1) barplot « Latence STT par modele » (bleu ciel, large-v3-turbo = 0,47 s ± barre d'erreur), (2) panneau vide « Pas de resultats TTS » (échelle 0–1), (3) panneau « Analyse des couts (USD/heure) » avec annotation « Gratuit » (échelle −0,04 à +0,04), (4) radar plot « Pas de resultats TTS » (grille polaire 0°/45°/90°/.../315°). **NE CORRESPOND PAS** à « 4 courbes librosa Caractéristiques audio extraites » comme le prétend le MANIFEST c.481, NI à ce que produirait cell[28] out[2] du 01-3.
-- **Verdict G.1 2026-07-14** : **DÉCLASSÉ** par rapport au MANIFEST c.481 (lequel disait « 4 courbes librosa »), MAIS **VRAI** par rapport à l'**alt-text in-situ du README** ligne 74 qui décrit précisément « STT validé 0,47 s + volet TTS en attente de re-exécution ». **L'alt-text in-situ est plus fidèle au contenu réel que le MANIFEST** — c'est l'inverse de la situation classique.
-- **Source d'origine** : non traçable par `nbformat`. Aucune cellule des 4 notebooks référencés ne produit la string `"Pas de resultats TTS"`. Probablement généré par un script ad-hoc ou un notebook de test hors-repo.
-- **Note** : swap correctif NON TENTÉ — sans confirmation de la source amont, risque de casse de l'inventaire. Alt-text in-situ conservé tel quel (déjà fidèle au contenu).
+- **Source** : figure de benchmark STT/TTS réelle. **Cellule source non committée** dans les 3 notebooks 01-3 / 02-4 / 03-1 (aucun n'émet la chaîne « Pas de resultats TTS » en output committé). Candidat probable : une exécution de comparaison STT/TTS où les services TTS étaient indisponibles.
+- **Contenu (vision firsthand c.529)** : grille 4 panneaux — (1) barplot « Latence STT par modele » (large-v3-turbo = 0,47 s), (2) panneau vide « Pas de resultats TTS », (3) « Analyse des couts (USD/heure) » (Gratuit), (4) radar « Pas de resultats TTS ».
+- **Poids disque** : 94 346 B (md5 `b047ef65`).
+- **Alt-text in-situ (README ligne 89)** : Reconnaissance vocale (STT) validée par Whisper large-v3-turbo ; volet TTS non abouti dans l'environnement de test (sous-figures vides). — **fidèle au contenu**.
+- **Verdict** : **INTRINSIC (disclosure honnête, C522)** — le volet TTS vide est explicitement signalé dans l'alt-text et le caption ; c'est une divulgation honnête d'un état d'environnement de test, pas un placebo consacré. Inliné (README §01-Foundation). Provenance de cellule à confirmer si les notebooks STT/TTS sont un jour re-exécutés avec services TTS actifs.
 
 ## audio4-demucs.png
 
-- **Source MANIFEST c.481** : notebook `02-Advanced/02-4-Demucs-Source-Separation.ipynb` (cellule 23, output 2) — **attribution invérifiable par nbformat** (MD5 cell `b5cc7ba0` ≠ MD5 disk `ab63e644`).
-- **Alt-text (FR)** : Séparation de sources : Demucs isole voix, batterie, basse et autre à partir d'un mix stéréo.
-- **Poids** : 171.0 KB (natif) → 175.1 KB (réexport actuel, taille 175056 B)
-- **SHA256** : `faf73521b308d4fa...` (175 056 B)
-- **Contenu réel vérifié (G.1 firsthand 2026-07-14)** : **grille 4 panneaux STT/TTS** — (haut gauche) barplot « Latence STT par modele » large-v3-turbo (0,47 s), (haut droit) panneau « Pas de resultats TTS » (échelle 0–1), (bas gauche) « Analyse des couts (USD/heure) » (large-v3-turbo / Gratuit), (bas droit) radar plot « Pas de resultats TTS ». **NE CORRESPOND PAS à du Demucs SOTA** comme le suggère l'alt-text et l'attribution cell[23] out[2] du 02-4 (qui produit 5 panneaux Demucs).
-- **Verdict G.1 2026-07-14** : **DÉCLASSÉ** — contenu réel = grille STT/TTS (identique visuellement à audio3-stt-tts.png mais à plus haute résolution), attendu = Demucs SOTA. La cellule 23 out[2] du notebook 02-4 produit effectivement du Demucs 5 panneaux, mais ce n'est PAS ce que contient audio4 sur disque. Source d'origine non traçable.
-- **Hypothèse probable** : audio4-demucs.png et audio3-stt-tts.png sont **deux exports du même contenu source** (grille STT/TTS), à des paramètres de résolution différents (audio3 = 94 KB, audio4 = 175 KB).
-- **Note** : swap correctif NON TENTÉ. Le contenu visible est « honnête » au sens où il documente un état d'environnement de test (STT validé / TTS non abouti) — donc même si le slot est mal nommé, la figure reste pédagogique.
+- **Source** : `02-Advanced/02-4-Demucs-Source-Separation.ipynb` cell[23] out[2] (`# Visualisation et remixage des stems`).
+- **Contenu (vision firsthand c.529)** : **5 panneaux Demucs** — Mix original + DRUMS (RMS 0,0307) + BASS (RMS 0,1626) + OTHER (RMS 0,1524) + VOCALS (RMS 0,0117), axe temps 0–9 s. **C'est bien du Demucs** (erreur de lecture c.490 qui y voyait une grille STT/TTS).
+- **Traçage** : cellule brute 284 044 B (md5 `b5cc7ba0`) → disque 175 056 B (md5 `ab63e644`), ratio **0,62** (figure large 1398 px ramenée sous le plafond 1200 px).
+- **Alt-text (FR, corrigé c.529)** : Séparation de sources Demucs : un mix stéréo décomposé en quatre stems (batterie, basse, autre, voix), chacun avec son énergie RMS annotée.
+- **Verdict** : **SOTA-OK** — vraie sortie Demucs du 02-4, légende corrigée (l'ancienne, héritée du misread c.490, décrivait une grille STT/TTS). Inliné (README §02-Advanced).
 
 ## audio5-multimodel.png
 
-- **Source MANIFEST c.481** : notebook `03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb` (cellule 29, output 1) — **attribution invérifiable par nbformat** (MD5 cell `18fd4304` ≠ MD5 disk `03e86f25`).
-- **Alt-text (FR)** : Comparaison de modèles audio : plusieurs voies STT/TTS évaluées côte à côte dans un pipeline.
-- **Poids** : 163.8 KB (post-c.481 swap, 167.8 KB réexport actuel) — *avant c.481 : 92.1 KB*
-- **SHA256** : `994f7713dca9dc29...` (167 756 B)
-- **Contenu réel vérifié (G.1 firsthand 2026-07-14)** : **4 courbes librosa « Caractéristiques audio extraites »** superposées verticalement — (1) Spectral Centroid (bleu, Hz 0–8000), (2) Spectral Bandwidth (vert, Hz 1000–3500), (3) RMS Energy (rouge, Amplitude 0–0,15), (4) Zero-Crossing Rate (violet, Rate 0–0,6). Axe temps 0–12 s. **NE CORRESPOND PAS à des barplots kokoro vs openai/tts-1** comme le prétend le MANIFEST c.481 (qui disait « 2 barplots matplotlib Latence + Taille kokoro vs openai/tts-1 »).
-- **Verdict G.1 2026-07-14** : **DÉCLASSÉ** par rapport au MANIFEST c.481, MAIS le contenu correspond à ce que produirait `librosa.feature.spectral_centroid()` + `spectral_bandwidth()` + `rms()` + `zero_crossing_rate()`. C'est structurellement cohérent avec **la cellule 28 out[2] du 01-3-Basic-Audio-Operations** (md5 `890f2d8a`, 172 278 B, « EXTRACTION DE CARACTERISTIQUES » avec Spectral Centroid + Bandwidth + RMS + ZCR), qui est la **vraie source amont probable** (taille 1,03× supérieure au disk : 172278 / 167756).
-- **Hypothèse probable** : audio5-multimodel.png = export de la cellule 28 out[2] du 01-3 (Caractéristiques audio extraites), à un DPI légèrement inférieur. **C'est la même figure que cell[28] out[2] du 01-3, pas cell[29] out[1] du 03-1** comme le MANIFEST c.481 le prétend.
-- **Source d'origine** : cellule 28 out[2] du 01-3-Basic-Audio-Operations (hypothèse haute confiance par taille + contenu G.1 + structure du code source de la cellule `EXTRACTION DE CARACTERISTIQUES`).
-- **Note** : swap correctif NON TENTÉ — la « permutation audio3↔audio5 » c.481 était fondée sur une lecture G.1 erronée ; le c.490 confirme que le contenu d'audio5 vient bien de cell[28] du 01-3 (et pas de cell[29] du 03-1), mais ne tente pas le swap vers audio3 car audio3 contient déjà un autre PNG (grille STT/TTS) avec un alt-text in-situ cohérent.
+- **Source** : `01-Foundation/01-3-Basic-Audio-Operations.ipynb` cell[28] out[2] (`# Extraction de caracteristiques`).
+- **Contenu (vision firsthand c.529)** : **4 courbes de features librosa** empilées — Spectral Centroid, Spectral Bandwidth, RMS Energy, Zero-Crossing Rate, axe temps 0–12 s.
+- **Traçage** : cellule brute 172 278 B (md5 `890f2d8a`) → disque 167 756 B (md5 `03e86f25`), ratio **0,97**.
+- **Alt-text (FR)** : Comparaison de modèles audio : plusieurs voies STT/TTS évaluées côte à côte dans un pipeline. — *le nom de slot et l'alt-text historique évoquent une comparaison multi-modèles ; le contenu réel est un panneau de features librosa. Asset orphelin (non inliné), conservé pour traçabilité ; à renommer si un jour réutilisé.*
+- **Verdict** : **SOTA-OK** (contenu réel = features librosa du 01-3). Le c.490 avait correctement identifié la cellule source (cell[28]) tout en la classant à tort « déclassée ».
 
 ## audio6-tts-benchmark.png
 
-- **Source MANIFEST c.481** : notebook `04-Applications/04-7-TTS-Voice-Benchmark.ipynb` (cellule 31, output 0) — **attribution invérifiable par nbformat** (MD5 cell `781aa4a1` ≠ MD5 disk `25b1a862`).
-- **Alt-text (FR)** : Benchmark de voix TTS : qualité, naturel et latence comparés en vue d'un déploiement en production.
-- **Poids** : 48.8 KB (natif) → 49.9 KB (réexport actuel, taille 49946 B)
-- **SHA256** : `ac205a122d5b9104...` (49 946 B)
-- **Contenu réel vérifié (G.1 firsthand 2026-07-14)** : **2 barplots « Latence par modele et type de texte » + « Taille audio par modele et type de texte »** (côte à côte, axes log-latence ms 3·10³–4·10³ et taille KB 0–350), modèles kokoro vs openai/tts-1, légende Type dialogue/monologue/narration. **NE CORRESPOND PAS à « 3 heatmaps MFCC »** comme le prétend le MANIFEST c.481, NI à ce que produirait cell[31] out[0] du 04-7.
-- **Verdict G.1 2026-07-14** : **DÉCLASSÉ** par rapport au MANIFEST c.481, MAIS le contenu correspond à des barplots `pandas.DataFrame.plot.bar()` typiques d'une comparaison kokoro vs openai/tts-1. C'est structurellement cohérent avec **la cellule 29 out[1] du 03-1-Multi-Model-Audio-Comparison** (md5 `18fd4304`, 71 205 B, 2 barplots Latence + Taille kokoro vs openai/tts-1), qui est la **vraie source amont probable** (taille 1,43× supérieure au disk : 71205 / 49946).
-- **Hypothèse probable** : audio6-tts-benchmark.png = export de la cellule 29 out[1] du 03-1 (2 barplots kokoro vs openai/tts-1), à un DPI plus faible. **C'est la même figure que cell[29] out[1] du 03-1, pas cell[31] out[0] du 04-7** comme le MANIFEST c.481 le prétend.
-- **Source d'origine** : cellule 29 out[1] du 03-1-Multi-Model-Audio-Comparison (hypothèse haute confiance par taille + contenu G.1 + structure du code source de la cellule).
-- **Note** : swap correctif NON TENTÉ. Le contenu est « honnête » au sens où il documente une comparaison kokoro vs openai/tts-1, donc même si le slot est mal nommé, la figure reste pédagogique.
+- **Source** : `03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb` cell[29] out[1] (`# Visualisation des resultats`).
+- **Contenu (vision firsthand c.529)** : **2 barplots** « Latence par modele et type de texte » + « Taille audio par modele et type de texte », kokoro vs openai/tts-1, légende dialogue/monologue/narration.
+- **Traçage** : cellule brute 71 205 B (md5 `18fd4304`) → disque 49 946 B (md5 `25b1a862`), ratio **0,70**.
+- **Alt-text (FR)** : Benchmark multi-modèles TTS : latence (ms) et taille audio (KB) de kokoro vs openai/tts-1 par type de texte (dialogue, monologue, narration).
+- **Verdict** : **SOTA-OK** — vraie sortie du 03-1, légende fidèle. Inliné (README §03-Orchestration). Le c.490 avait correctement identifié la cellule source (03-1 cell[29]) tout en la classant à tort « déclassée ».
 
 ---
 
-## Vérification G.1 — provenance investigation 2026-07-14
+## Vérification — traçage nbformat c.529 (2026-07-16, worktree fresh origin/main)
 
-Investigation `nbformat` Python (script de référence `audit-genai-audio-c490.py` dans le scratchpad) sur les 6 PNG + 4 notebooks sources :
+Scan `nbformat` des outputs image committés des 3 notebooks sources, croisé avec le MD5/taille des PNG disque :
 
-| Fichier | MD5 cell attendu | MD5 disk | Ratio taille | Conclusion |
-|---|---|---|---|---|
-| `audio1-waveform.png` | `3ace572f` (39 273 B) | `09e55bfb` (37 273 B) | 0,95 | VRAI — cellule 12 out[1] du 01-3 cohérente |
-| `audio2-spectrogram.png` | `238e0bd6` (84 031 B) | `b9792e33` (77 625 B) | 0,92 | DÉCLASSÉ — contenu Demucs ≠ MFCC attendu |
-| `audio3-stt-tts.png` | `890f2d8a` (172 278 B) | `b047ef65` (94 346 B) | 0,55 | DÉCLASSÉ par MANIFEST c.481 mais VRAI par alt-text in-situ README |
-| `audio4-demucs.png` | `b5cc7ba0` (284 044 B) | `ab63e644` (175 056 B) | 0,62 | DÉCLASSÉ — contenu grille STT/TTS ≠ Demucs |
-| `audio5-multimodel.png` | `18fd4304` (71 205 B) | `03e86f25` (167 756 B) | 2,36 | DÉCLASSÉ — contenu librosa spectral ≠ barplots kokoro/openai |
-| `audio6-tts-benchmark.png` | `781aa4a1` (33 230 B) | `25b1a862` (49 946 B) | 1,50 | DÉCLASSÉ — contenu barplots kokoro/openai ≠ heatmaps MFCC |
+| Fichier | Cellule source | Brut (nbformat) | Disque | Ratio | Inliné | Verdict |
+|---|---|---|---|---|---|---|
+| `audio1-waveform.png` | 01-3 cell[12] out[1] | 39 273 B / `3ace572f` | 37 273 B / `09e55bfb` | 0,95 | oui | SOTA-OK |
+| `audio2-spectrogram.png` | 01-3 cell[20] out[3] | 84 031 B / `238e0bd6` | 77 625 B / `b9792e33` | 0,92 | non (orphelin) | SOTA-OK (MFCC) |
+| `audio3-stt-tts.png` | non committée (3 nb réf.) | — | 94 346 B / `b047ef65` | — | oui | INTRINSIC (TTS vide signalé) |
+| `audio4-demucs.png` | 02-4 cell[23] out[2] | 284 044 B / `b5cc7ba0` | 175 056 B / `ab63e644` | 0,62 | oui | SOTA-OK (Demucs) |
+| `audio5-multimodel.png` | 01-3 cell[28] out[2] | 172 278 B / `890f2d8a` | 167 756 B / `03e86f25` | 0,97 | non (orphelin) | SOTA-OK (features) |
+| `audio6-tts-benchmark.png` | 03-1 cell[29] out[1] | 71 205 B / `18fd4304` | 49 946 B / `25b1a862` | 0,70 | oui | SOTA-OK (barplots TTS) |
 
-**Constat G.1 2026-07-14 — dette cumulative majeure non détectée par 5 PRs successives (#5701, #6009, #6466, #6510, + PR vague-3 c.437) :** aucune des attributions MANIFEST c.481 n'est vérifiable par `nbformat`. Les tailles diffèrent systématiquement (ratio 0,55 à 2,36), les MD5 diffèrent aussi, et le contenu visuel G.1 firsthand ne correspond à la cellule référencée que pour **1/6 PNG** (audio1).
+**Lecture des ratios** : tous ≤ 1,0 — cohérent avec l'optimisation PIL de `extract_readme_figures.py` (recompression + downscale ≤ 1200 px, qui ne peut que réduire la taille). Le ratio 0,62 d'`audio4` correspond au downscale d'une figure large (1398 px) sous le plafond 1200 px. Aucun ratio n'exige une « source externe ».
 
-**Hypothèses haute confiance (par taille + contenu G.1)** :
-- audio5-multimodel.png ← **01-3 cell[28] out[2]** (Caractéristiques audio extraites librosa)
-- audio6-tts-benchmark.png ← **03-1 cell[29] out[1]** (2 barplots Latence + Taille kokoro vs openai/tts-1)
-- audio2-spectrogram.png + audio4-demucs.png ← **02-4 cell[23] out[2]** (Demucs 5 panneaux) — à deux paramètres de downscale différents
-- audio3-stt-tts.png ← **source externe non traçable** (grille STT/TTS générée par un script ad-hoc ou un notebook de test hors-repo)
+**Bilan c.529** : 5/6 tracés à une cellule committée (SOTA-OK), 1/6 (`audio3`) = benchmark STT/TTS réel à volet TTS honnêtement vide (INTRINSIC/C522). 0 figure DROP, 0 swap, 0 régénération nécessaire. La remédiation #5780 sur cette tranche = correction de **texte d'audit faux** (README + MANIFEST), pas de rendu de figure.
 
-**Swap correctif NON TENTÉ** : sans moyen de vérifier la source d'origine (les PNG disk diffèrent des PNG cell output par leur compression / downscale), un swap pourrait casser l'inventaire ou pire, déplacer du matériel pédagogique. La documentation honnête de l'état réel (MANIFEST + README note d'audit c.490) est préférée à un swap risqué.
+## Historique d'audit (superséré — conservé pour traçabilité)
 
----
+- **c.481 (2026-07-14)** : swap `audio3`↔`audio5` au niveau des blobs disque. Attributions de cellule d'audio2 (MFCC) et audio4 (Demucs) **correctes** ; celles d'audio5 (donné 03-1 au lieu de 01-3) et audio6 (donné 04-7 au lieu de 03-1) **erronées**.
+- **c.490 (2026-07-14)** : a **inversé la lecture visuelle d'audio2 et audio4** (MFCC lu « Demucs », Demucs lu « STT/TTS »), et conclu à tort « 5/6 externes » sur la fausse prémisse MD5≠brut (ignorant l'optimisation PIL). A néanmoins corrigé les sources d'audio5 (01-3 cell[28]) et audio6 (03-1 cell[29]).
+- **c.529 (2026-07-16)** : réconciliation firsthand (vision + git par-blob + nbformat) → les 6 figures sont de vraies sorties de notebook ; attributions ci-dessus définitives.
 
-## Bilan audit c.490 — 21ᵉ pilote rollout #5780
-
-| Fichier | Verdict G.1 firsthand 2026-07-14 | Action |
-|---|---|---|
-| `audio1-waveform.png` | **VRAI** | **CONSERVÉ** — seul PNG dont l'attribution MANIFEST est cohérente avec le contenu visuel |
-| `audio2-spectrogram.png` | **DÉCLASSÉ** (contenu Demucs ≠ spectrogramme MFCC) | **CONSERVÉ** sur disque, MANIFEST mis à jour avec disclosure, swap NON TENTÉ (source amont non traçable) |
-| `audio3-stt-tts.png` | **DÉCLASSÉ** par MANIFEST c.481 mais **VRAI** par alt-text in-situ | **CONSERVÉ** sur disque, alt-text in-situ déjà fidèle (ligne 74 README), pas de correction nécessaire |
-| `audio4-demucs.png` | **DÉCLASSÉ** (contenu grille STT/TTS ≠ Demucs) | **CONSERVÉ** sur disque, MANIFEST mis à jour avec disclosure, swap NON TENTÉ |
-| `audio5-multimodel.png` | **DÉCLASSÉ** (contenu librosa spectral ≠ barplots kokoro/openai) | **CONSERVÉ** sur disque, MANIFEST mis à jour avec disclosure, swap NON TENTÉ |
-| `audio6-tts-benchmark.png` | **DÉCLASSÉ** (contenu barplots kokoro/openai ≠ heatmaps MFCC) | **CONSERVÉ** sur disque, MANIFEST mis à jour avec disclosure, swap NON TENTÉ |
-
-**Bilan** : 1/6 VRAI confirmé (audio1) + 5/6 DÉCLASSÉ par MANIFEST c.481 (contenu réel vérifié ≠ intitulé du slot). 0 figure DROP, 0 swap correctif tenté, 0 modification d'alt-text in-situ (déjà fidèle pour audio3, et le caption existant ligne 75 caveat « volet TTS en attente de re-exécution » est cohérent avec le contenu G.1).
-
-**Conformité règles** :
-- §A single-subject : 1 sujet (audit G.1 fondateur vérification post-c.481), 1 sous-dossier, 2 fichiers (MANIFEST + README note d'audit c.490).
-- §E doctrine corrigée (issue #5780) : pas de section `## Galerie`, figures inline dans la prose avec alt-text décrivant le contenu réel vérifié par lecture directe.
-- R1 catalog-pr-hygiene : `git diff origin/main..HEAD -- "**/CATALOG-STATUS*" "**/COURSE_CATALOG*"` = vide. Section Audio n'utilise pas CATALOG-STATUS, R1 non-applicable.
-- L268 #4 LF-only : `git diff | tr -cd '\r' | wc -c` = 0. Pas de retour chariot dans le diff.
-- L143 secrets-hygiene : `grep -nE "sk-|ghp_|AIza|password=|secret="` sur le diff = 0 hit.
-
-**Voir aussi** : [c.481 GenAI/Audio swap audio3↔audio5 MANIFEST post-c.490](../../README.md#aperçu--la-génération-audio-en-images) — pattern frère (audit fondateur post-swap) ; [c.481 GenAI/Image racine MANIFEST](../../../Image/assets/readme/MANIFEST.md) — pattern frère (dette cumulative racine pré-doctrine) ; [c.487 GenAI/Video racine MANIFEST](../../../Video/assets/readme/MANIFEST.md) — pattern frère (audit fondateur G.1 sur MANIFEST vague-1 non migré) ; issue [#5780](../../../issues/5780) ; EPIC [#5654](../../../issues/5654).
+**Voir aussi** : issue [#5780](../../../issues/5780) ; EPIC [#5654](../../../issues/5654) ; [GenAI/Image MANIFEST](../../../Image/assets/readme/MANIFEST.md) et [GenAI/Video MANIFEST](../../../Video/assets/readme/MANIFEST.md) (patterns frères de traçabilité de figures).


### PR DESCRIPTION
## fix(genai-audio,#5780): les 6 figures Audio sont de vraies sorties de notebook — correction du texte d'audit faux (c.481/c.490) + légende audio4

**C529 PIVOT R6 hors-Translation** (post-c.526/c.527/c.528 = 3 cycles Translation, R5.4b LIMIT 3 honoré). Tranche **GenAI/Audio** de la remédiation figures #5780 (dispatch ai-01, double-vision : worker classe par le regard, ai-01 valide au merge-gate). Registre EPIC #5654 / #3801 (SOTA Prong-A).

### Constat — la remédiation est une correction de **texte d'audit faux**, pas un rendu de figure

Les notes d'audit c.481 et c.490 baked dans le README + MANIFEST concluaient que **5/6 PNG Audio étaient « invérifiables / probablement externes / DÉCLASSÉS »**. Vérification vision firsthand (session Opus, capacité vision) croisée avec l'historique git par-blob et un scan `nbformat` des notebooks sources : **les 6 figures sont de vraies sorties de notebook.** La conclusion c.490 reposait sur une **double erreur de méthode** :

1. **Inversion de lecture audio2↔audio4** : le c.490 a lu `audio2` (3 heatmaps MFCC) comme « Demucs », et `audio4` (5 panneaux Demucs) comme « grille STT/TTS ». Les attributions de cellule source du MANIFEST c.481 étaient en fait **correctes** (audio2←MFCC 01-3 cell[20], audio4←Demucs 02-4 cell[23]).
2. **Fausse prémisse « MD5≠brut ⇒ externe »** : `extract_readme_figures.py` **optimise chaque figure à l'extraction** (downscale ≤1200 px + recompression PIL). Le MD5/taille disque **diffèrent donc nécessairement** de la cellule brute — comportement normal de l'outil, pas une signature de source externe. Le « ratio 0,55–2,36 » du c.490 venait de comparaisons contre les **mauvaises cellules attendues**.

### Verdict SOTA par figure (doctrine sota-not-workaround / #5780)

| Slot | Contenu réel (vision firsthand) | Source cellule (nbformat, worktree) | Brut→disque | Inliné | Verdict |
|---|---|---|---|---|---|
| audio1-waveform | forme d'onde | 01-3 cell[12] out[1] | 39273→37273 (0,95) | oui | **SOTA-OK** |
| audio2-spectrogram | **3 heatmaps MFCC** | 01-3 cell[20] out[3] `# MFCC` | 84031→77625 (0,92) | non (orphelin) | **SOTA-OK** |
| audio3-stt-tts | grille STT/TTS, volet TTS vide signalé | non committée dans les 3 nb réf. | — | oui | **INTRINSIC / C522** (disclosure honnête) |
| audio4-demucs | **5 panneaux Demucs** (Mix+DRUMS/BASS/OTHER/VOCALS+RMS) | 02-4 cell[23] out[2] `# stems` | 284044→175056 (0,62) | oui | **SOTA-OK** |
| audio5-multimodel | **4 courbes features librosa** | 01-3 cell[28] out[2] `# caracteristiques` | 172278→167756 (0,97) | non (orphelin) | **SOTA-OK** |
| audio6-tts-benchmark | 2 barplots TTS kokoro vs openai/tts-1 | 03-1 cell[29] out[1] `# resultats` | 71205→49946 (0,70) | oui | **SOTA-OK** |

Tous les ratios ≤ 1,0 (l'optimisation PIL ne peut que réduire). Le 0,62 d'audio4 = downscale d'une figure large (1398 px) sous le plafond 1200 px. **Aucune figure ne requiert de régénération** : 5/6 tracées à une cellule committée, audio3 = benchmark STT/TTS réel à volet TTS honnêtement vide (C522, cf alt-text in-situ ligne 89).

### Changements (2 fichiers, docs-only, R3 atomique)

**`README.md`** (−25 net) :
- **Défaut actif corrigé** : l'alt-text + le caption d'`audio4` (lignes 111-113) avaient été vandalisés par le misread c.490 pour décrire une « grille STT/TTS 03-1 » alors que la figure EST du Demucs et que la prose juste au-dessus (ligne 109) décrit correctement « Demucs décompose un mix en 4 stems + RMS ». Restaurés en Demucs 5 panneaux, cohérents avec la prose.
- Les 3 notes d'audit contradictoires empilées (c.481 + corrective-c.490 + c.490, 22 lignes) fusionnées en **une note c.529 succincte et correcte** (harness-hygiene 3-tiers : le README pointe, le MANIFEST détaille).
- `audio6` caption : référence pendante « note d'audit c.490 » remplacée par pointeur MANIFEST (l'attribution 03-1 était déjà correcte).

**`assets/readme/MANIFEST.md`** (−66 net) : réécrit en provenance correcte et grounded (source cellule + contenu + ratio + verdict SOTA par figure + table nbformat firsthand). L'historique d'audit c.481/c.490 est **préservé en footnote** (Consolider ≠ Archiver) expliquant l'inversion audio2/audio4 et la fausse prémisse PIL, pour que la leçon de méthode survive.

### Doctrine appliquée

- **sota-not-workaround Prong A** : verdict SOTA écrit par figure ; 5×SOTA-OK + 1×INTRINSIC(C522). Aucun placeholder consacré ; la « remédiation » corrige du texte faux, elle ne fabrique rien.
- **C522 disclosure honnête** : audio3 volet TTS vide explicitement signalé (alt-text ligne 89) = divulgation acceptable, pas un placebo.
- **anti-regression (§D)** : deletions > insertions (120/54) = suppression de **prose d'audit fausse** (docs), PAS de code/preuve/notebook. §D exclut explicitement les docs ; la leçon durable est préservée en footnote MANIFEST.
- **harness-hygiene 3-tiers** : README succinct (pointe), MANIFEST durable (détaille), aucun log éphémère baké.
- **Stop & Repair (secrets-hygiene §6)** : aucune sortie de cellule hand-éditée — pur texte de doc README/MANIFEST.
- **R1 catalog-pr-hygiene** : `git diff origin/main...HEAD -- '**/CATALOG-STATUS*' '**/COURSE_CATALOG*'` = vide.
- **R2 rebase frais** : branche depuis `origin/main` `a6adc7f39`.
- **R3 atomique** : 2 fichiers, 1 sous-dossier, 1 sujet (correction audit figures Audio), 1 domaine (docs). Loin sous G.4.
- **L268 LF-only** : CR=0 sur les 2 fichiers. **C280-1 MD047** : trailing newline présent.
- **C403-L1** : PR body via `--body-file`.
- **C444-L1 pré-flight** : `gh issue view 5780` OPEN ✓ ; tranche GenAI/Audio (PyMC = claim po-2025, non touchée).

### Vérification double-vision

Worker (po-2023, Opus vision) a classé les 6 figures par le regard + tracé par nbformat firsthand dans le worktree. ai-01 valide au merge-gate en regardant effectivement audio4 (Demucs) vs son ancienne légende (STT/TTS) pour confirmer la correction.

### Refs

- See #5780 (remédiation figures README — légendes fidèles au contenu réel ; cette PR = tranche GenAI/Audio, partielle à l'EPIC)
- See #5654 (EPIC figures README GenAI)
- See #3801 (EPIC SOTA Prong-A — vrai outil, jamais placeholder consacré)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
