### PR TITLE
docs(smartcontracts): §E full-file README audit — reconcile prose to disk

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -306,7 +306,7 @@ SmartContracts/
 | **xrpl-py** | Client Ripple | Connexion XRP Ledger | `pip install xrpl-py` |
 | **vyper** | Compilateur Vyper | Smart contracts Python-like | `pip install vyper` |
 | **python-bitcoinlib** | Bibliothèque Bitcoin | Manipulation UTXO/Script | `pip install python-bitcoinlib` |
-| **TenSEAL** | Homomorphic encryption | CKKS (multiplicatif) sur tensors | `pip install tensile` |
+| **TenSEAL** | Homomorphic encryption | CKKS (multiplicatif) sur tensors | `pip install tenseal` |
 
 ## Prérequis
 
@@ -520,7 +520,7 @@ anvil --port 8546
 
 ### 5. Erreurs d'import des bibliothèques cryptographiques
 
-**Symptôme** : `ImportError` pour `Crypto`, `phe`, `tensile` ou `xrpl`.
+**Symptôme** : `ImportError` pour `Crypto`, `phe`, `tenseal` ou `xrpl`.
 
 **Cause** : Dépendances non installées ou conflit de nom de package.
 
@@ -628,12 +628,12 @@ maturity: PRODUCTION=27
 
 | Notebook SmartContracts | Série parente | Pont conceptuel |
 |------------------------|---------------|-----------------|
-| `SC-12 Attack Patterns` | [Lean](../Lean/) (types dépendants, Curry-Howard) | Vérification formelle = même ambition (prouver la correction), deux faces : SMT automatique (SMTChecker) vs interactif expressif (Lean 4) |
+| `SC-12 Foundry Testing` | [Lean](../Lean/) (types dépendants, Curry-Howard) | Vérification formelle = même ambition (prouver la correction), deux faces : SMT automatique (SMTChecker) vs interactif expressif (Lean 4) |
 | `SC-14 Formal Verification` | [Lean](../Lean/) + [GameTheory](../../GameTheory/) (`social_choice_lean/`) | Pont vérification : Certora/SMTChecker prouvent les invariants Solidity ; Lean 4 prouve les théorèmes économiques (Arrow, Voting). Même méthodologie, deux domaines |
 | `SC-15 ZKP / SC-16 HE / SC-17 E2E Voting` | [Lean](../Lean/) + [Tweety](../Tweety/) (cryptographic protocols argumentation) | Cryptographie avancée : ZKP = preuve sans divulgation ; HE = calcul sur chiffré ; vote E2E = anonymat + vérifiabilité. Tweety argumente formellement ces protocoles |
 | `SC-11 LLM-Assisted Contracts` | [Argument_Analysis](../Argument_Analysis/) (Semantic Kernel) | LLM generates Solidity contracts via SK : prompting structuré → code Solidity → validation Foundry |
 | `SC-9 DAO Governance / SC-17 E2E Voting` | [GameTheory](../../GameTheory/) (Arrow.lean, Voting.lean) | Vote on-chain = instance concrète du théorème d'Arrow (impossibilité) ; vote E2E = instance des Banks sets + monotonie STV |
-| `SC-2 ZK-SNARKs / SC-22 Cross-Chain Bridges` | [SemanticWeb](../SemanticWeb/) (ontologies de domaine) | Modèle Solidity ↔ ontologie OWL : un smart contract peut être annoté sémantiquement (propriétés vérifiables par raisonneur) ; cross-chain bridges = ontologies inter-chaînes |
+| `SC-15 ZK-SNARKs / SC-23 Cross-Chain Bridges` | [SemanticWeb](../SemanticWeb/) (ontologies de domaine) | Modèle Solidity ↔ ontologie OWL : un smart contract peut être annoté sémantiquement (propriétés vérifiables par raisonneur) ; cross-chain bridges = ontologies inter-chaînes |
 
 **Paragraphe « effet de composition — SmartContracts = carrefour trust/privacy »** :
 


### PR DESCRIPTION
## Summary

Full-file §E ([pr-review-discipline](.claude/rules/pr-review-discipline.md) §E) audit of `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md`, reconciling **disk reality ↔ CATALOG-STATUS ↔ prose**. Accuracy audit, not a translation pass. README-only (+4/-4).

## Fixes (prose → disk)

- `pip install tensile` → `pip install tenseal` (l.309) — `requirements.txt` pins `tenseal>=0.3`; FAQ l.535 already noted the correct name.
- FAQ symptom list `tensile` → `tenseal` (l.523) — same evidence.
- Cross-lane table `SC-12 Attack Patterns` → `SC-12 Foundry Testing` (l.631) — disk: `SC-12-Foundry-Testing.ipynb`, no Attack-Patterns notebook.
- Cross-lane table `SC-2 ZK-SNARKs / SC-22 Cross-Chain Bridges` → `SC-15 ZK-SNARKs / SC-23 Cross-Chain Bridges` (l.636) — disk: SC-2=Setup-Web3py, SC-22=Solana-Anchor, ZK=SC-15, Cross-Chain=SC-23.

## Firsthand verification (ai-01)

All spot-checked against `git ls-files`:
- 27 notebooks SC-0..SC-26 ✓
- SC-2=Setup-Web3py, SC-12=Foundry-Testing, SC-15=Zero-Knowledge-Proofs, SC-22=Solana-Anchor, SC-23=Cross-Chain ✓
- `tenseal>=0.3` in `requirements.txt` ✓
- **CATALOG-STATUS marker (l.5-10) byte-identical to `main`** ✓ — `pedagogical_count=27` matches disk, left untouched.
- No `COURSE_CATALOG.generated.*` touched.

Counts, notebook lists, structure tree, per-subseries breakdowns, links and anchors independently re-verified — no other structural defect. `erc20_lean` "0 sorry" claim (l.175) confirmed.

See §E README rollout (#3975).