### PR TITLE
feat(lean,#2874): figureEight_not_tricolorable via native_decide + layered Decidable instances

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -61,6 +61,7 @@
 
 import Knots.Basic
 import Knots.Reidemeister
+import Mathlib.Data.Fintype.Pi
 
 namespace Knots
 
@@ -83,6 +84,15 @@ inductive TriColor where
   | blue : TriColor
   | green : TriColor
   deriving BEq, DecidableEq, Repr
+
+/-- `TriColor` est un type à trois éléments, donc un `Fintype` : nécessaire pour
+décider par énumération finie (`native_decide`) l'existentiel
+`∃ coloring : Fin n → TriColor, …` dans `figureEight_not_tricolorable`. Sans cette
+instance, `Fintype (Fin n → TriColor)` (via `Pi.fintype`) ne se synthétise pas et
+`decide`/`native_decide` échouent en amont de toute réduction. -/
+instance : Fintype TriColor where
+  elems := {TriColor.red, TriColor.blue, TriColor.green}
+  complete := by intro x; cases x <;> decide
 
 /-- A tricoloring assigns a color to each edge in a knot diagram. -/
 def TriColoring (d : KnotDiagram) := Fin d.numEdges → TriColor
@@ -221,6 +231,47 @@ def IsTricolorable (d : KnotDiagram) : Prop :=
 /-- A knot is tricolorable if any of its diagrams is. -/
 def Knot.isTricolorable (k : Knot) : Prop :=
   IsTricolorable k.diagram
+
+/-! ### Décidabilité de la tricolorabilité (énumération finie)
+
+La tricolorabilité d'un diagramme fini est décidable : chaque couche prédicative
+reçoit une instance `Decidable` nommée, de sorte que la synthèse au point d'usage
+(`native_decide` dans `figureEight_not_tricolorable`) reste peu profonde. Sans cette
+décomposition, une seule synthèse monolithique doit enchaîner `List.decidableBAll`,
+plusieurs `And.decidable`, les `DecidableEq TriColor` des `dite` de coloriage, et
+l'énumération `Fintype (Fin n → TriColor)` — ce qui épuise le budget de synthèse
+d'instances alors même que chaque couche est individuellement décidable. -/
+
+/-- La condition de Fox par croisement (`triColorConditionAt`) est une conjonction
+de bornes entières, d'égalités et de disjonctions sur `TriColor` : décidable. -/
+instance triColorConditionAt.decidable (d : KnotDiagram)
+    (coloring : Fin d.numEdges → TriColor) (c : PDCrossing) :
+    Decidable (triColorConditionAt d coloring c) := by
+  unfold triColorConditionAt
+  infer_instance
+
+/-- Un coloriage valide (`IsTriColoring`) est décidable : le `∀ c ∈ crossings`
+s'appuie sur l'instance par croisement ci-dessus, et « ≥ 2 couleurs » sur la
+finitude de `Fin d.numEdges`. -/
+instance IsTriColoring.decidable (d : KnotDiagram) (coloring : TriColoring d) :
+    Decidable (IsTriColoring d coloring) := by
+  unfold IsTriColoring
+  infer_instance
+
+/-- L'espace des coloriages `TriColoring d = Fin d.numEdges → TriColor` est fini
+(`Pi.fintype` + `Fintype TriColor`). `TriColoring` étant un `def` non réductible,
+cette instance est nécessaire pour que la synthèse la trouve sous ce nom. -/
+instance TriColoring.fintype (d : KnotDiagram) : Fintype (TriColoring d) := by
+  unfold TriColoring
+  infer_instance
+
+/-- La tricolorabilité (`∃ coloring : Fin n → TriColor, IsTriColoring …`) est
+décidable par énumération finie de l'espace des coloriages (`Fintype (TriColoring
+d)`) combinée à la décidabilité de `IsTriColoring`. -/
+instance IsTricolorable.decidable (d : KnotDiagram) :
+    Decidable (IsTricolorable d) := by
+  unfold IsTricolorable
+  infer_instance
 
 /-! ### GF(3) linearity of the per-crossing Fox condition (cycle-3, #4022)
 
@@ -979,6 +1030,28 @@ theorem unknot_not_tricolorable : ¬ Knot.isTricolorable unknot := by
     rw [hi, hj]
   obtain ⟨i, j, hne⟩ := htwocolors
   exact hne (this i j)
+
+/-! ## 4b. La figure-eight n'est PAS tricolorable
+
+La figure-eight (4₁) possède 4 croisements et un déterminant égal à 5 ; elle
+n'est donc PAS 3-coloriable au sens de Fox. Sous **Path B** (conjonction
+d'arc-égalité `c₂ = c₄`), c'est le témoin de distinction canonique : le modèle
+permissif antérieur laissait passer une tricoloration parasite `(0,0,0,1,0,0,1,2)`
+(README §Path B), que la contrainte d'arc exclut désormais.
+
+Preuve par énumération finie (`native_decide`) : l'espace des coloriages
+`Fin 8 → TriColor` (3⁸ = 6561) est parcouru, et pour chacun la conjonction
+d'arc-égalité + Fox aux 4 croisements est réfutée — soit l'arc-continuité casse,
+soit Fox force le monochrome (contredisant « ≥ 2 couleurs »). On emploie
+`native_decide` (et non `decide`) : l'existentiel porte sur le type-fonction
+`Fin 8 → TriColor`, dont l'instance `Decidable` repose sur `Fintype.piFinset` ; le
+noyau ne réduit pas cette énumération (`decide` échoue avec « did not reduce to
+'isTrue' or 'isFalse' »), là où l'évaluateur natif la traite en quelques ms —
+même outil que les lemmes de calibration finie de `conway_lean/Angel.lean`.
+Témoin de non-régression Path B (#2874). -/
+theorem figureEight_not_tricolorable : ¬ Knot.isTricolorable figureEight := by
+  unfold Knot.isTricolorable
+  native_decide
 
 /-! ## 5. Corollary: the trefoil is not the unknot
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -16,6 +16,7 @@
 
 import Knots.Basic_en
 import Knots.Reidemeister_en
+import Mathlib.Data.Fintype.Pi
 
 /-
   English mirror of `Invariant.lean` (FR canonical). Convention EPIC #4980
@@ -46,6 +47,15 @@ inductive TriColor where
   | blue : TriColor
   | green : TriColor
   deriving BEq, DecidableEq, Repr
+
+/-- `TriColor` is a three-element type, hence a `Fintype`: needed to decide, by
+finite enumeration (`native_decide`), the existential
+`∃ coloring : Fin n → TriColor, …` in `figureEight_not_tricolorable`. Without this
+instance, `Fintype (Fin n → TriColor)` (via `Pi.fintype`) fails to synthesize and
+`decide`/`native_decide` fail before any reduction. -/
+instance : Fintype TriColor where
+  elems := {TriColor.red, TriColor.blue, TriColor.green}
+  complete := by intro x; cases x <;> decide
 
 /-- A tricoloring assigns a color to each edge in a knot diagram. -/
 def TriColoring (d : KnotDiagram) := Fin d.numEdges → TriColor
@@ -184,6 +194,47 @@ def IsTricolorable (d : KnotDiagram) : Prop :=
 /-- A knot is tricolorable if any of its diagrams is. -/
 def Knot.isTricolorable (k : Knot) : Prop :=
   IsTricolorable k.diagram
+
+/-! ### Decidability of tricolorability (finite enumeration)
+
+Tricolorability of a finite diagram is decidable: each predicate layer receives a
+named `Decidable` instance, so that synthesis at the use site (`native_decide` in
+`figureEight_not_tricolorable`) stays shallow. Without this decomposition, a single
+monolithic synthesis must chain `List.decidableBAll`, several `And.decidable`, the
+`DecidableEq TriColor` of the coloring `dite`s, and the `Fintype (Fin n →
+TriColor)` enumeration — exhausting the instance synthesis budget even though each
+layer is individually decidable. -/
+
+/-- The per-crossing Fox condition (`triColorConditionAt`) is a conjunction of
+integer bounds, equalities and disjunctions over `TriColor`: decidable. -/
+instance triColorConditionAt.decidable (d : KnotDiagram)
+    (coloring : Fin d.numEdges → TriColor) (c : PDCrossing) :
+    Decidable (triColorConditionAt d coloring c) := by
+  unfold triColorConditionAt
+  infer_instance
+
+/-- A valid coloring (`IsTriColoring`) is decidable: the `∀ c ∈ crossings` relies
+on the per-crossing instance above, and "≥ 2 colors" on the finiteness of
+`Fin d.numEdges`. -/
+instance IsTriColoring.decidable (d : KnotDiagram) (coloring : TriColoring d) :
+    Decidable (IsTriColoring d coloring) := by
+  unfold IsTriColoring
+  infer_instance
+
+/-- The coloring space `TriColoring d = Fin d.numEdges → TriColor` is finite
+(`Pi.fintype` + `Fintype TriColor`). Since `TriColoring` is a non-reducible `def`,
+this instance is needed for synthesis to find it under that name. -/
+instance TriColoring.fintype (d : KnotDiagram) : Fintype (TriColoring d) := by
+  unfold TriColoring
+  infer_instance
+
+/-- Tricolorability (`∃ coloring : Fin n → TriColor, IsTriColoring …`) is decidable
+by finite enumeration of the coloring space (`Fintype (TriColoring d)`) combined
+with the decidability of `IsTriColoring`. -/
+instance IsTricolorable.decidable (d : KnotDiagram) :
+    Decidable (IsTricolorable d) := by
+  unfold IsTricolorable
+  infer_instance
 
 /-! ### GF(3) linearity of the per-crossing Fox condition (cycle-3, #4022)
 
@@ -942,6 +993,28 @@ theorem unknot_not_tricolorable : ¬ Knot.isTricolorable unknot := by
     rw [hi, hj]
   obtain ⟨i, j, hne⟩ := htwocolors
   exact hne (this i j)
+
+/-! ## 4b. The figure-eight is NOT tricolorable
+
+The figure-eight (4_1) has 4 crossings and determinant 5, so it is NOT
+3-colorable in the Fox sense. Under **Path B** (the `c₂ = c₄` over-strand
+continuity conjunct), this is the canonical distinguishing witness: the earlier
+permissive model admitted a spurious tricoloring `(0,0,0,1,0,0,1,2)` (README
+§Path B), which the arc constraint now excludes.
+
+Proof by finite enumeration (`native_decide`): the coloring space
+`Fin 8 → TriColor` (3⁸ = 6561) is exhausted, and for each the arc-continuity +
+Fox conjunction at all 4 crossings is refuted — either arc-continuity breaks, or
+Fox forces monochrome (contradicting "≥ 2 colors"). We use `native_decide` (not
+`decide`): the existential ranges over the function type `Fin 8 → TriColor`, whose
+`Decidable` instance rests on `Fintype.piFinset`; the kernel does not reduce that
+enumeration (`decide` fails with "did not reduce to 'isTrue' or 'isFalse'"),
+whereas the native evaluator handles it in a few ms — the same tool used by the
+finite-calibration lemmas in `conway_lean/Angel.lean`. Path-B non-regression
+witness (#2874). -/
+theorem figureEight_not_tricolorable : ¬ Knot.isTricolorable figureEight := by
+  unfold Knot.isTricolorable
+  native_decide
 
 /-! ## 5. Corollary: the trefoil is not the unknot
 


### PR DESCRIPTION
## Summary

Adds theorem `figureEight_not_tricolorable` to both FR `Invariant.lean` and EN twin `Invariant_en.lean` (knot_lean), proving the figure-eight knot (4₁) is **NOT** Fox-tricolorable under the Path-B arc-respecting model. This is the **canonical distinguishing witness** for #3003 Path-B: figure-eight has determinant 5, and 3 ∤ 5, so no Fox 3-coloring exists. It mirrors `unknot_not_tricolorable` as a non-regression guard that the invariant genuinely distinguishes trefoil (tricolorable) from figure-eight (not) — not just from the unknot.

**Supersedes the coordinator-closed PR #6761.** That PR failed `Lean CI (knot_lean)`:
- the `decide` proof cannot kernel-reduce the `Fintype.piFinset` enumeration over `Fin 8 → TriColor` (3⁸ = 6561);
- a bare `native_decide` retry failed instance synthesis (`failed to synthesize Decidable`) — a single monolithic synthesis must chain `List.decidableBAll`, several `And.decidable`, the coloring `dite` `DecidableEq TriColor`, and the function-space `Fintype`, exhausting the synthesis budget **even though each layer is individually decidable** (confirmed by isolated probes).

## Fix — decompose decidability into named instances

Synthesis at the use site then stays shallow (`Not.decidable (IsTricolorable.decidable …)`), each layer pre-elaborated:

- `instance : Fintype TriColor`
- `triColorConditionAt.decidable` — per-crossing Fox condition
- `IsTriColoring.decidable` — valid coloring
- `TriColoring.fintype` — coloring space (`TriColoring` is a non-reducible `def`, so needs an explicit `Fintype` instance)
- `IsTricolorable.decidable` — finite existential

```lean
theorem figureEight_not_tricolorable : ¬ Knot.isTricolorable figureEight := by
  unfold Knot.isTricolorable
  native_decide
```

`native_decide` (precedent: `conway_lean/Angel.lean`) evaluates the 6561 colorings in ms.

## Validation

- **Build SUCCESS (local, both twins)**: `lake build Knots.Invariant Knots.Invariant_en` → `Build completed successfully (2951 jobs)`, exit 0. `native_decide` cannot close a false goal, so the successful build *is* the mathematical proof that no valid tricoloring exists.
- **i18n #4980**: FR/EN code skeletons **byte-identical** (770 code lines each after `_en` normalization); only docstrings differ.
- **Anti-regression §D**: **0 sorry added** — `Invariant.lean` stays at its 5 pre-existing real proof-sorries.
- Fresh base off current `origin/main` (no catalog/README churn; 2 files, +146 lines).

See #2874.