### PR TITLE
docs(lean,#5780): audit vision fondateur 6 figures SymbolicAI/Lean — 4 corrections caption-vs-image

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -13,14 +13,14 @@ Cette série introduit **Lean 4**, un assistant de preuves et langage de program
 
 ## Aperçu — Lean en images
 
-Six visualisations extraites des notebooks illustrent l'arc de la série : de l'assistance aux preuves par LLM et la vérification formelle de réseaux de neurones jusqu'aux automates de Conway (Game of Life) et à la théorie des nœuds (définition, nœud de Conway, invariants). Provenance détaillée : [`MANIFEST.md`](assets/readme/MANIFEST.md).
+Six visualisations extraites des notebooks illustrent l'arc de la série : de l'assistance aux preuves par LLM et la vérification formelle de réseaux de neurones jusqu'aux automates de Conway (Game of Life) et à la théorie des nœuds (nœuds simples, couple de mutants Conway/Kinoshita-Terasaka, invariant d'Alexander). Provenance détaillée : [`MANIFEST.md`](assets/readme/MANIFEST.md).
 
 ### Assistance aux preuves et vérification formelle
 
-L'état de l'art de la série : un LLM interprète et visualise une solution de preuve ([Lean-7b](Lean-7b-Examples.ipynb)), puis TorchLean propage intervalles (IBP) et bornes (CROWN) pour certifier formellement la robustesse d'un réseau de neurones ([Lean-11a](Lean-11-TorchLean-Python.ipynb)).
+L'état de l'art de la série : un LLM génère des preuves Lean, dont on mesure la performance sur un banc de théorèmes ([Lean-7b](Lean-7b-Examples.ipynb)), puis TorchLean propage intervalles (IBP) et bornes (CROWN) pour certifier formellement la robustesse d'un réseau de neurones ([Lean-11a](Lean-11-TorchLean-Python.ipynb)).
 
 <p align="center">
-  <a href="Lean-7b-Examples.ipynb"><img src="assets/readme/lean-llm-examples.png" width="420" alt="Assistance LLM : interprétation visualisée d'une solution de preuve."></a>
+  <a href="Lean-7b-Examples.ipynb"><img src="assets/readme/lean-llm-examples.png" width="420" alt="Génération de preuves par LLM : taux de succès, itérations, temps d'exécution et tokens sur dix théorèmes Lean."></a>
 </p>
 
 <p align="center">
@@ -37,18 +37,18 @@ L'hommage à John Conway passe par le Game of Life comme modèle de calcul ([Lea
 
 ### Théorie des nœuds
 
-La série dédiée (companion `knot_lean`, Epic #2874) développe trois vues complémentaires : la définition d'un nœud mathématique ([Lean-17a](Lean-17-Knots-a-Conway-and-Proofs.ipynb)), le nœud de Conway (11n34) dont Lisa Piccirillo prouva la non-sliceness, puis le polynôme d'Alexander qui caractérise cette sliceness ([Lean-17b](Lean-17-Knots-b-Invariants-Companion.ipynb)).
+La série dédiée (companion `knot_lean`, Epic #2874) développe trois vues complémentaires : les nœuds les plus simples classés par nombre de croisements ([Lean-17a](Lean-17-Knots-a-Conway-and-Proofs.ipynb)), le couple de mutants Conway (11n34) / Kinoshita-Terasaka (11n42) dont Lisa Piccirillo prouva que seul le second borne un disque lisse (slice), puis le polynôme d'Alexander — trivial (= 1) pour ce couple, et donc incapable à lui seul de distinguer leur sliceness ([Lean-17b](Lean-17-Knots-b-Invariants-Companion.ipynb)).
 
 <p align="center">
-  <a href="Lean-17-Knots-a-Conway-and-Proofs.ipynb"><img src="assets/readme/lean-knot-conway.png" width="420" alt="Théorie des nœuds : qu'est-ce qu'un nœud mathématique ?"></a>
+  <a href="Lean-17-Knots-a-Conway-and-Proofs.ipynb"><img src="assets/readme/lean-knot-conway.png" width="420" alt="Les trois premiers nœuds par nombre de croisements : nœud trivial (unknot), trèfle (3₁) et nœud de huit (4₁)."></a>
 </p>
 
 <p align="center">
-  <a href="Lean-17-Knots-a-Conway-and-Proofs.ipynb"><img src="assets/readme/lean-knot-piccirillo.png" width="420" alt="Le nœud de Conway (11n34) — schéma."></a>
+  <a href="Lean-17-Knots-a-Conway-and-Proofs.ipynb"><img src="assets/readme/lean-knot-piccirillo.png" width="420" alt="Nœuds mutants de Conway (11n34) et Kinoshita-Terasaka (11n42) : même polynôme d'Alexander (= 1), sliceness lisse différente."></a>
 </p>
 
 <p align="center">
-  <a href="Lean-17-Knots-b-Invariants-Companion.ipynb"><img src="assets/readme/lean-knot-invariants.png" width="420" alt="Polynôme d'Alexander et sliceness — le critère de Conway."></a>
+  <a href="Lean-17-Knots-b-Invariants-Companion.ipynb"><img src="assets/readme/lean-knot-invariants.png" width="420" alt="Polynômes d'Alexander Δ(t) du trèfle, du nœud de huit et du couple Conway/Kinoshita-Terasaka (Δ(t) = 1, trivial comme l'unknot)."></a>
 </p>
 
 ## Navigation

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/assets/readme/MANIFEST.md
@@ -4,11 +4,11 @@ Provenance de chaque figure (convention d'indexation **all-cells** du module `ex
 
 | Figure | Fichier | Dimensions | Poids | Source (notebook · cellule · output) | Sujet |
 |--------|---------|------------|-------|--------------------------------------|-------|
-| Assistance LLM | `lean-llm-examples.png` | 1389×985 | 99 Ko | `Lean-7b-Examples.ipynb` · cellule 24 · output 0 | Interprétation visualisée d'une solution de preuve (§7.5) |
+| Performance LLM | `lean-llm-examples.png` | 1389×985 | 99 Ko | `Lean-7b-Examples.ipynb` · cellule 24 · output 0 | Analyse de performance de la génération de preuves LLM : succès, itérations, temps, tokens sur 10 théorèmes (§7.5) |
 | TorchLean (IBP) | `lean-torchlean.png` | 1188×985 | 57 Ko | `Lean-11-TorchLean-Python.ipynb` · cellule 23 · output 1 | Propagation IBP pour la vérification de réseaux de neurones (§3.6) |
 | Conway Game of Life | `lean-conway-gol.png` | 884×499 | 20 Ko | `Lean-16b-Conway-Game-of-Life-Lean.ipynb` · cellule 24 · output 1 | Self-replicator Gemini (Andrew Wade, 2010) — Acte III |
-| Nœud mathématique | `lean-knot-conway.png` | 1604×515 | 62 Ko | `Lean-17-Knots-a-Conway-and-Proofs.ipynb` · cellule 2 · output 0 | Définition : qu'est-ce qu'un nœud mathématique ? (§1) |
-| Nœud de Conway | `lean-knot-piccirillo.png` | 1389×617 | 112 Ko | `Lean-17-Knots-a-Conway-and-Proofs.ipynb` · cellule 8 · output 0 | Schéma du nœud de Conway (11n34) (§2) |
-| Alexander & sliceness | `lean-knot-invariants.png` | 1590×425 | 48 Ko | `Lean-17-Knots-b-Invariants-Companion.ipynb` · cellule 11 · output 0 | Polynôme d'Alexander et sliceness — critère de Conway (§5) |
+| Trois premiers nœuds | `lean-knot-conway.png` | 1604×515 | 62 Ko | `Lean-17-Knots-a-Conway-and-Proofs.ipynb` · cellule 2 · output 0 | Les trois premiers nœuds par nombre de croisements : unknot, trèfle (3₁), nœud de huit (4₁) (§1) |
+| Conway ↔ K-T (mutants) | `lean-knot-piccirillo.png` | 1389×617 | 112 Ko | `Lean-17-Knots-a-Conway-and-Proofs.ipynb` · cellule 8 · output 0 | Mutants Conway (11n34) ↔ Kinoshita-Terasaka (11n42) : même Alexander (= 1), sliceness lisse différente (§2) |
+| Polynômes d'Alexander | `lean-knot-invariants.png` | 1590×425 | 48 Ko | `Lean-17-Knots-b-Invariants-Companion.ipynb` · cellule 11 · output 0 | Polynômes d'Alexander Δ(t) : trèfle, nœud de huit, et Conway/K-T trivial (= 1) (§5) |
 
-**Total** : 6 figures, 402 Ko. **Politique** (#5654) : ≤200 Ko/fichier, downscale ≤1200 px max. Diagrammes et line-art (nœuds, automates Cellulaire, réseaux de neurones) → **PNG lossless natif** (netteté ; tous sous le seuil sans downscale, max 112 Ko). Arc : assistance LLM → vérification formelle de réseaux de neurones → automate de Conway (Game of Life) → théorie des nœuds (définition, nœud de Conway 11n34, invariant d'Alexander/sliceness).
+**Total** : 6 figures, 402 Ko. **Politique** (#5654) : ≤200 Ko/fichier, downscale ≤1200 px max. Diagrammes et line-art (nœuds, automates Cellulaire, réseaux de neurones) → **PNG lossless natif** (netteté ; tous sous le seuil sans downscale, max 112 Ko). Arc : performance de la génération de preuves LLM → vérification formelle de réseaux de neurones → automate de Conway (Game of Life) → théorie des nœuds (trois premiers nœuds, mutants Conway 11n34 / Kinoshita-Terasaka 11n42, polynôme d'Alexander trivial).


### PR DESCRIPTION
## Contexte

`See #5780` (audit figures-README, étape *audit vision fondateur*). Complète le sweep #5780 : SymbolicAI/Lean avait reçu l'**étape 1** (dissolution de la mosaïque en narration, #6142) mais **jamais l'étape 2** — la vérification caption-vs-image que QC-projects (#6655/#6656/#6661/#6668/#6676/#6680), GameTheory (#6524), Planners (#6551), Sudoku (#6505/#6512) ont chacun reçue. C'est le **dernier README à figures encore non-audité en vision** de la vague.

## Attestation visuelle (critère d'acceptation #5780)

Les **6 PNG ont été ouverts au Read tool (vision)** avant toute réécriture de légende/alt-text/MANIFEST. Résultat : **2 ACCURATE, 4 corrections**.

| Figure | Image réelle (vue) | Verdict |
|--------|--------------------|---------|
| `lean-torchlean.png` | Propagation IBP (ε=0.05), boîtes d'intervalles couche par couche | **ACCURATE** |
| `lean-conway-gol.png` | Self-replicator Gemini : ruban oblique + zoom moteur (37245 cellules) | **ACCURATE** |
| `lean-llm-examples.png` | **Dashboard de performance** : succès 0/10, itérations, temps, tokens sur 10 théorèmes | **CORRIGÉ** — l'alt-text disait "interprétation visualisée d'une solution de preuve" |
| `lean-knot-conway.png` | **Les trois premiers nœuds** : unknot, trèfle (3₁), nœud de huit (4₁) | **CORRIGÉ** — vague "qu'est-ce qu'un nœud mathématique ?" |
| `lean-knot-piccirillo.png` | **Paire de mutants** Conway (11n34) ↔ Kinoshita-Terasaka (11n42), même Alexander (=1), sliceness différente | **CORRIGÉ** — disait "Conway seul, schéma" |
| `lean-knot-invariants.png` | **Polynômes d'Alexander** Δ(t) : trèfle, huit, Conway/K-T trivial (=1) | **CORRIGÉ** — vague "sliceness / critère de Conway" |

## Correction mathématique bonus

La narration affirmait *« le polynôme d'Alexander **qui caractérise** cette sliceness »* — or la figure `lean-knot-invariants` démontre l'**inverse** : Δ(t)=1 est **trivial** pour le couple Conway/K-T, donc **incapable à lui seul** de distinguer leur sliceness. C'est précisément ce qui motive le résultat de Piccirillo (invariants plus fins). Corrigé dans le README + MANIFEST.

## Vérifications

- Dimensions PNG vs MANIFEST : **6/6 OK** (aucun octet PNG modifié).
- Pas de bloc `CATALOG-STATUS` dans ce README → rien à préserver de ce côté.
- Diff : 2 fichiers, +12/−12 (pure réécriture de prose/légendes, aucun ajout de poids).
- Doc primaire FR (readme-french-first) : conservée FR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)