### PR TITLE
ci(prover,#6790): wire tree-lock offline tests into scripts-tests.yml

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -25,6 +25,12 @@ on:
       - 'tests/**'
       - 'pytest.ini'
       - '.github/workflows/scripts-tests.yml'
+      # #6790 prover tree-lock: the offline lock-lifecycle tests + the two
+      # source files they guard (see the pytest step for why only this one
+      # agent_tests file is included, not the whole dir).
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tree_lock.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py'
   pull_request:
     branches: [main]
     paths:
@@ -32,6 +38,9 @@ on:
       - 'tests/**'
       - 'pytest.ini'
       - '.github/workflows/scripts-tests.yml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tree_lock.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py'
   workflow_dispatch:
 
 jobs:
@@ -99,6 +108,16 @@ jobs:
         # is empty under POSIX. Both are fixed; papermill/nbformat are now
         # installed above. The 7 suites run here green (354 tests, validated
         # under WSL ubuntu + CI deps). genai -> po-2023, wsl -> po-2025.
+        #
+        # #6790 tree-lock guard: only test_bg_tree_lock.py is included from
+        # agent_tests/tests/, NOT the whole dir. That file loads tree_lock.py by
+        # file path (stdlib-only) and importorskips the LLM stack for its 3
+        # launcher-wiring tests, so on a bare runner it is hermetic: 14 pass,
+        # 3 skip. Its sibling test_prover_guards.py imports prover.state/.tools,
+        # which pull prover/__init__.py -> agent_framework at collection time and
+        # would abort the whole pytest session with a collection error (masking
+        # every other result) — the exact failure mode this workflow exists to
+        # prevent. agent_tests owner: po-2026 (Lean lane).
         run: |
           pytest \
             scripts/tests \
@@ -106,4 +125,5 @@ jobs:
             scripts/lean/tests \
             MyIA.AI.Notebooks/GameTheory/tests \
             MyIA.AI.Notebooks/QuantConnect/scripts/tests \
+            MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py \
             --tb=short -q

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py
@@ -19,20 +19,41 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+# The launcher-wiring tests below exercise prover/run_prover_bg.py, whose import
+# chain pulls the prover LLM stack (agent_framework / agent_framework_openai).
+# That stack is present on the worker/coordinator machines but NOT on a bare CI
+# runner, so those three tests importorskip on it (skip cleanly off-stack) while
+# the 14 tree_lock.py tests are stdlib-only and run everywhere.
+_LLM_STACK = "agent_framework"
+
 # Make `prover/` importable regardless of how pytest was invoked.
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
 sys.path.insert(0, str(ROOT))
 
-from prover.tree_lock import (  # noqa: E402
-    LOCK_BASENAME,
-    acquire_tree_lock,
-    find_lean_project_root,
-    host_id,
-    pid_alive,
-    read_lock,
-    release_tree_lock,
+# Load tree_lock.py DIRECTLY by file path, bypassing prover/__init__.py — that
+# package-init eagerly imports the LLM stack (prover.provers -> agent_framework,
+# prover.config -> agent_framework_openai), which is absent on a bare CI runner.
+# tree_lock.py is stdlib-only and self-contained, so the 14 lock-lifecycle tests
+# below run everywhere; only the 3 launcher-wiring tests (which import
+# prover.run_prover_bg) need the full stack and importorskip on it.
+import importlib.util  # noqa: E402
+
+_tl_spec = importlib.util.spec_from_file_location(
+    "prover_tree_lock", ROOT / "prover" / "tree_lock.py"
 )
+_tree_lock = importlib.util.module_from_spec(_tl_spec)
+_tl_spec.loader.exec_module(_tree_lock)
+
+LOCK_BASENAME = _tree_lock.LOCK_BASENAME
+acquire_tree_lock = _tree_lock.acquire_tree_lock
+find_lean_project_root = _tree_lock.find_lean_project_root
+host_id = _tree_lock.host_id
+pid_alive = _tree_lock.pid_alive
+read_lock = _tree_lock.read_lock
+release_tree_lock = _tree_lock.release_tree_lock
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -214,6 +235,7 @@ def test_release_none_is_noop():
 def test_inner_launcher_refuses_locked_tree(tmp_path):
     """prover/run_prover_bg.run_prover must refuse a tree whose lock is held
     (returns result_kind='locked' BEFORE touching the file or any LLM)."""
+    pytest.importorskip(_LLM_STACK, reason="prover LLM stack absent (bare CI)")
     from prover.run_prover_bg import run_prover
 
     (tmp_path / "lakefile.lean").write_text("-- lake", encoding="utf-8")
@@ -233,6 +255,7 @@ def test_inner_launcher_refuses_locked_tree(tmp_path):
 
 
 def test_inner_launcher_signature_has_force_lock():
+    pytest.importorskip(_LLM_STACK, reason="prover LLM stack absent (bare CI)")
     import inspect
     from prover.run_prover_bg import run_prover
 
@@ -244,6 +267,7 @@ def test_inner_launcher_signature_has_force_lock():
 def test_launcher_exposes_force_lock_flag():
     """The launcher must accept --force-lock (operator override, exit 3
     contract documented in the module docstring)."""
+    pytest.importorskip(_LLM_STACK, reason="prover LLM stack absent (bare CI)")
     import importlib
 
     mod = importlib.import_module("run_prover_bg")


### PR DESCRIPTION
## Summary

The #6790 per-tree lockfile (`prover/tree_lock.py`) is the safety mechanism that stops two prover runs from sharing one working tree — the run-6/run-7 clobber incident (DEMO-62), where run-7's cleanup reverted run-6's build-passing candidate. It ships with 17 offline tests (`agent_tests/tests/test_bg_tree_lock.py`) but **zero CI regression guard** — nothing re-ran them on push/PR.

This wires that suite into the existing light-dep `scripts-tests.yml` job, making it bare-CI-runnable first.

## What changed

**`test_bg_tree_lock.py` — make it hermetic on a bare runner:**
- Load `tree_lock.py` by file path (`importlib.util`) instead of `from prover.tree_lock import …`. The package import would trigger `prover/__init__.py` → `prover.provers` → `agent_framework` (the LLM stack, absent on a bare runner). `tree_lock.py` is stdlib-only (ctypes/json/os/platform/time/pathlib), so the 14 lock-lifecycle tests are now genuinely hermetic.
- `importorskip` the LLM stack in the 3 launcher-wiring tests (they import `prover.run_prover_bg`, which needs `agent_framework`).

**`scripts-tests.yml`:**
- Add `test_bg_tree_lock.py` to the pytest invocation — **only that file**, not the whole `agent_tests/tests/` dir: its sibling `test_prover_guards.py` imports `prover.state`/`prover.tools` (→ `__init__` → `agent_framework`) and would abort collection, masking every result (the exact failure mode this workflow exists to prevent).
- Add path triggers for the test + the two source files it guards (`tree_lock.py`, `run_prover_bg.py`).

## Validation (both paths, real)

| Environment | Result |
|---|---|
| ai-01 (stack present) | `17 passed` |
| Simulated bare CI (`agent_framework` blocked at import) | `14 passed, 3 skipped` |

Bare-CI simulated by inserting a `MetaPathFinder` that raises `ModuleNotFoundError` for `agent_framework*`, then running pytest in-process. The 3 skips are the launcher-wiring tests; the 14 lock-lifecycle tests (find_project_root, pid_alive, acquire/release, stale/foreign/corrupt/force-break) run and pass.

## Scope

- No production code touched — only the test's import mechanism + the CI workflow.
- Pure test-coverage addition (+52/−8, 2 files). No regression.
- `agent_tests/` owner: po-2026 (Lean lane).

See #6790.