### PR TITLE
docs(genai-video,#5081): Video phase-1 — reintegrate 02-5-LTX2 into narrative spine (skip-defect fix)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-4-SVD-Image-to-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-4-SVD-Image-to-Video.ipynb
@@ -38,7 +38,7 @@
     "- Notebooks 02-1 a 02-3 completes pour comparaison\n",
     "- Packages : `diffusers>=0.30`, `transformers`, `torch`, `accelerate`, `imageio`, `imageio-ffmpeg`, `Pillow`\n",
     "\n",
-    "**Navigation :** [<< 02-3](02-3-Wan-Video-Generation.ipynb) | [Index](../README.md) | [Suivant >>](../03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb)"
+    "**Navigation :** [<< 02-3](02-3-Wan-Video-Generation.ipynb) | [Index](../README.md) | [02-5 LTX-2 >>](02-5-LTX2-Audiovisual.ipynb)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb
@@ -34,10 +34,10 @@
     "## Prerequis\n",
     "\n",
     "- GPU avec 18+ GB VRAM (RTX 3090 / RTX 4090)\n",
-    "- Module 02-Advanced complete (notebooks 02-1 a 02-4)\n",
+    "- Module 02-Advanced complete (notebooks 02-1 a 02-5)\n",
     "- Packages : `diffusers>=0.32`, `transformers`, `torch`, `accelerate`, `bitsandbytes`, `imageio`, `imageio-ffmpeg`\n",
     "\n",
-    "**Navigation :** [<< 02-4](../02-Advanced/02-4-SVD-Image-to-Video.ipynb) | [Index](../README.md) | [Suivant >>](03-2-Video-Workflow-Orchestration.ipynb)"
+    "**Navigation :** [<< 02-5 LTX-2](../02-Advanced/02-5-LTX2-Audiovisual.ipynb) | [Index](../README.md) | [Suivant >>](03-2-Video-Workflow-Orchestration.ipynb)"
    ]
   },
   {

--- a/docs/curriculum/video-renumbering-phase1.md
+++ b/docs/curriculum/video-renumbering-phase1.md
@@ -1,0 +1,66 @@
+# GenAI/Video — analyse renumérotation (EPIC #5081, phase-1)
+
+**Série** : `MyIA.AI.Notebooks/GenAI/Video/` — arborescence hiérarchique à 4 étages (`01-Foundation` → `04-Applications`), 17 notebooks.
+**Phase** : 1 (docs-only pour l'analyse ; 1 correctif navlink markdown appliqué — pas de ré-exécution, cf C.2).
+**Verdict** : **NO-RENUMBER** sur la structure (numérotation à 2 niveaux `étage-index` déjà cohérente) **+ 1 défaut de spine « skip » corrigé** (02-5-LTX2-Audiovisual court-circuité par le pont d'inter-étage 02-4↔03-1).
+
+L'objectif de #5081 est un *arc pédagogique cohérent*, pas une numérotation d'opportunité. La méthode phase-1 vérifie que la numérotation actuelle **est** déjà un tri topologique valide et que la réorganisation n'a pas laissé de références narratives cassées : lien `<<`/`>>` obsolète-mais-résolvable (stale-RESOLVES), ou notebook **sauté** par le fil narratif (skip).
+
+## Inventaire
+
+17 notebooks `.ipynb` (hors `_output`), répartis en 4 étages contigus.
+
+| Sous-dossier | Plage | Notebooks |
+|--------------|-------|-----------|
+| `01-Foundation` | 1-1 → 1-5 | Video-Operations-Basics, GPT-5-Video-Understanding, Qwen-VL-Video-Analysis, Video-Enhancement-ESRGAN, AnimateDiff-Introduction |
+| `02-Advanced` | 2-1 → 2-5 | HunyuanVideo, LTX-Video-Lightweight, Wan-Video, **SVD-Image-to-Video**, **LTX2-Audiovisual** |
+| `03-Orchestration` | 3-1 → 3-3 | Multi-Model-Video-Comparison, Video-Workflow-Orchestration, ComfyUI-Video-Workflows |
+| `04-Applications` | 4-1 → 4-4 | Educational-Video-Generation, Creative-Video-Workflows, Sora-API-Cloud-Video, Production-Video-Pipeline |
+
+**Chaque plage de numéros correspond exactement à son étage** : le rangement est cohérent avec l'ordre pédagogique. Aucune unité mal classée, aucun trou, aucun doublon → **pas de renumérotation nécessaire**.
+
+## 1. Vérification topologique (DAG des prérequis)
+
+Extraction des navlinks narratifs `[<< …]` (prev) et `[… >>]` (next) de **toutes les cellules markdown** de chaque notebook (L615-L1 : header ET footer), puis contrôle que la clé d'ordre `(étage, index)` du prédécesseur est strictement inférieure à celle du notebook courant.
+
+- Couverture `(1,1)..(4,4)` : **complète et contiguë** par étage.
+- **Arêtes en ordre inversé (stale-RESOLVES, `prev# ≥ own#` intra-étage) : 0.**
+
+## 2. Défaut « skip » détecté et corrigé (02-5-LTX2-Audiovisual)
+
+**Classe de défaut distincte du stale-RESOLVES** (L613-L1). Dans un stale-RESOLVES, une cible *renommée* résout mais pointe un voisin de numéro supérieur. Ici, les voisins sont correctement ordonnés mais **sautent par-dessus un notebook intermédiaire existant** :
+
+- `02-5-LTX2-Audiovisual` (capstone de l'étage 02, seul modèle vidéo **+** audio conjoints, LTX-2 22B) déclarait pourtant correctement sa place dans **deux** cellules (cell1 + cell23) : `[<< 02-4 SVD]` / `[Comparaison >>](03-1)`.
+- Mais le **pont d'inter-étage** liait 02-4 et 03-1 **directement**, court-circuitant 02-5 : `02-4` `[Suivant >>]` → `03-1`, et `03-1` `[<< 02-4]` → `02-4`. Vestige d'un navlink antérieur à l'insertion de 02-5 dans l'étage (cf PR #3110 qui documentait 02-5 dans le README **après** coup).
+
+Le lien passait le checker 404 (02-4 et 03-1 existent bien), mais le fil de lecture *sautait* le capstone.
+
+### Source narrative autoritaire : le README
+
+Le README de la série place déjà 02-5 **dans** le spine : parcours recommandé `… 02-4 → 02-5 → 03-Orchestration`, table de l'étage 02 listant 02-5 entre 02-4 et 03-1, et mermaid `B4 (02-5 LTX-2) → C1 (03-1)`. Le correctif **réaligne les navlinks des notebooks sur l'ordre déjà canonique du README**, il ne l'invente pas.
+
+### Correctif appliqué (3 lignes markdown, C.2-safe)
+
+| Fichier | Avant | Après |
+|---------|-------|-------|
+| `02-4-SVD` cell0 `>>` | `[Suivant >>](../03-Orchestration/03-1-…)` | `[02-5 LTX-2 >>](02-5-LTX2-Audiovisual.ipynb)` |
+| `03-1-Comparison` cell0 `<<` | `[<< 02-4](../02-Advanced/02-4-SVD-…)` | `[<< 02-5 LTX-2](../02-Advanced/02-5-LTX2-Audiovisual.ipynb)` |
+| `03-1-Comparison` prérequis | `notebooks 02-1 a 02-4` | `notebooks 02-1 a 02-5` (le capstone 02-5 fait partie de l'étage) |
+
+Spine réparé : **02-3 → 02-4 → 02-5 → 03-1 → 03-2**, chaîne avant+arrière symétrique.
+
+## 3. Faux positif écarté (non un défaut)
+
+`04-4-Production-Video-Pipeline` `[Audio 01-1 >>]` → `../../Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb` : **pont cross-module Video→Audio intentionnel**, explicitement labellisé, en fin de série. Laissé tel quel.
+
+## 4. Contrôle final
+
+Scan all-cells post-correctif sur les 17 notebooks : chaîne **contiguë de bout en bout** (`01-1 → … → 02-4 → 02-5 → 03-1 → … → 04-4 → pont Audio`), backward = forward pour chaque arête, **0 anomalie** (stale-RESOLVES + skip). `check_notebook_navlinks --check` : 0 nouveau lien cassé vs baseline.
+
+## Verdict
+
+**Structure NO-RENUMBER** (4 étages contigus, cohérents) + **1 défaut de spine « skip » corrigé** : 02-5-LTX2-Audiovisual ré-inséré dans la chaîne narrative avant+arrière. La classe « skip » (voisins bien ordonnés qui sautent un notebook intermédiaire existant) complète la classe « stale-RESOLVES » (cible renommée pointant un voisin de numéro supérieur) du catalogue de défauts phase-1.
+
+**Séries #5081 phase-1 traitées** : Infer (#6879), Search (#6883), PyMC (#6885), Planners (#6898), Video (ce document).
+
+*Analyse : po-2024:CoursIA-2. See #5081.*


### PR DESCRIPTION
## Résumé

Analyse renumérotation phase-1 (EPIC #5081) de **GenAI/Video** (17 notebooks, 4 étages hiérarchiques). Verdict : **NO-RENUMBER** (structure d'étages saine) **+ 1 défaut de spine « skip » corrigé**.

`docs/curriculum/video-renumbering-phase1.md` porte l'analyse DAG complète.

## Défaut « skip » (classe distincte du stale-RESOLVES)

`02-5-LTX2-Audiovisual` (capstone de l'étage 02 — seul modèle vidéo **+** audio conjoints, LTX-2 22B) était **court-circuité** par un pont d'inter-étage héritant du navlink antérieur à son insertion : `02-4 [Suivant >>] → 03-1` et `03-1 [<< 02-4] → 02-4`, sautant 02-5. Pourtant 02-5 déclarait correctement sa place dans **deux** cellules (cell1 + cell23). Le README place déjà 02-5 dans le spine (parcours recommandé, table d'étage, mermaid `B4→C1`) — ce correctif **réaligne les navlinks sur l'ordre canonique du README**.

- **Skip-defect** = voisins bien ordonnés qui sautent un notebook intermédiaire existant. Distinct du **stale-RESOLVES** (L613, cible renommée pointant un voisin de numéro supérieur).

## Correctif (3 lignes markdown, C.2-safe — pas de ré-exécution)

| Fichier | Avant | Après |
|---------|-------|-------|
| `02-4-SVD` cell0 `>>` | `→ 03-1` (skip) | `→ 02-5-LTX2-Audiovisual` |
| `03-1-Comparison` cell0 `<<` | `→ 02-4` (skip) | `→ 02-5 LTX-2` |
| `03-1-Comparison` prérequis | `02-1 a 02-4` | `02-1 a 02-5` |

Spine réparé : **02-3 → 02-4 → 02-5 → 03-1 → 03-2**.

## Vérifications

- Scan all-cells post-fix (17 notebooks) : chaîne **contiguë de bout en bout**, backward = forward, **0 anomalie** (stale-RESOLVES + skip).
- `check_notebook_navlinks --check` : 0 nouveau lien cassé vs baseline. `check_docs_links --check` : exit 0.
- Diff = **markdown seul** (navlinks + prérequis), aucune cellule code / output / `execution_count` touché → C.2-safe.
- Catalogue **byte-identique** à `main` (catalog-pr-hygiene R1).
- FP écarté : `04-4 [Audio 01-1 >>]` = pont cross-module Video→Audio intentionnel, laissé tel quel.

## Séries #5081 phase-1

Infer (#6879), Search (#6883), PyMC (#6885), Planners (#6898), **Video (cette PR)**.

See #5081.