### PR TITLE
docs(genai,#6912): normalize [Index] navlink to series README on 11 GenAI/Texte notebooks (Class C)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](9_Production_Patterns.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](9_Production_Patterns.ipynb)\n",
     "\n",
     "# 10. Hébergement Local de Modèles Génératifs\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "# 11. Quantization des LLMs\n",
     "\n",
-    "**Navigation** : [<< 10. Hebergement Local](10_LocalLlama.ipynb) | [Index](../../README.md)\n",
+    "**Navigation** : [<< 10. Hebergement Local](10_LocalLlama.ipynb) | [Index](README.md)\n",
     "\n",
     "**Duree estimee** : 60 minutes\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "# 1. Introduction a l'IA generative avec l'API OpenAI\n",
     "\n",
-    "**Navigation** : [Index](../../README.md) | [Suivant >>](2_PromptEngineering.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [Suivant >>](2_PromptEngineering.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
@@ -15,7 +15,7 @@
    },
    "source": [
     "# 2. Prompt Engineering : Techniques Avancées\n",
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](1_OpenAI_Intro.ipynb) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](1_OpenAI_Intro.ipynb) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
     "\n",
     "## Prompt Engineering : Advanced Prompting avec OpenAI\n",
     "\n",
@@ -43,7 +43,7 @@
    },
    "source": [
     "\n",
-    "**Navigation** : [<< Precedent](1_OpenAI_Intro.ipynb) | [Index](../../README.md) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
+    "**Navigation** : [<< Precedent](1_OpenAI_Intro.ipynb) | [Index](README.md) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
@@ -15,7 +15,7 @@
    },
    "source": [
     "# 3. Structured Outputs : Sorties JSON Garanties\n",
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](2_PromptEngineering.ipynb) | [Suivant >>](4_Function_Calling.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](2_PromptEngineering.ipynb) | [Suivant >>](4_Function_Calling.ipynb)\n",
     "\n",
     "## Structured Outputs : Sorties JSON Garanties avec OpenAI\n",
     "\n",
@@ -47,7 +47,7 @@
    },
    "source": [
     "\n",
-    "**Navigation** : [<< Precedent](2_PromptEngineering.ipynb) | [Index](../../README.md) | [Suivant >>](4_Function_Calling.ipynb)\n",
+    "**Navigation** : [<< Precedent](2_PromptEngineering.ipynb) | [Index](README.md) | [Suivant >>](4_Function_Calling.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](3_Structured_Outputs.ipynb) | [Suivant >>](5_RAG_Modern.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](3_Structured_Outputs.ipynb) | [Suivant >>](5_RAG_Modern.ipynb)\n",
     "\n",
     "# Function Calling : Connecter les LLMs au Monde Réel\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# 5. RAG Modern - Retrieval Augmented Generation\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](4_Function_Calling.ipynb) | [Suivant >>](6_PDF_Web_Search.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](4_Function_Calling.ipynb) | [Suivant >>](6_PDF_Web_Search.ipynb)\n",
     "\n",
     "\n",
     "**Durée estimée** : 65 minutes\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# PDF et Web Search : Sources Documentaires avec OpenAI\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](5_RAG_Modern.ipynb) | [Suivant >>](7_Code_Interpreter.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](5_RAG_Modern.ipynb) | [Suivant >>](7_Code_Interpreter.ipynb)\n",
     "\n",
     "\n",
     "Ce notebook explore deux fonctionnalités puissantes de l'API OpenAI :\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Code Interpreter : Exécution de Code avec OpenAI\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](6_PDF_Web_Search.ipynb) | [Suivant >>](8_Reasoning_Models.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](6_PDF_Web_Search.ipynb) | [Suivant >>](8_Reasoning_Models.ipynb)\n",
     "\n",
     "\n",
     "Le **Code Interpreter** est un outil intégré qui permet au modèle d'exécuter du code Python dans un environnement sandbox sécurisé. Il est particulièrement utile pour l'analyse de données, les calculs complexes, et la génération de visualisations.\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "# Modèles de Raisonnement : gpt-5-mini\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](7_Code_Interpreter.ipynb) | [Suivant >>](9_Production_Patterns.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](7_Code_Interpreter.ipynb) | [Suivant >>](9_Production_Patterns.ipynb)\n",
     "\n",
     "\n",
     "Les **modèles de raisonnement** représentent une évolution majeure des LLMs. Ils s'appuient sur le **chain-of-thought** (Wei et al., 2022) -- démontrer le raisonnement étape par étape améliore la précision -- et sur l'idée que l'on peut **échanger du temps de calcul contre de la qualité** (Snell et al., 2024). La sortie des modèles de type **o1** (OpenAI, 2024, *Learning to Reason with LLMs*) a institutionnalisé ce paradigme : le modèle produit un raisonnement interne (caché) avant de répondre. Contrairement aux modèles de chat classiques, ils prennent le temps de \"réfléchir\" avant de répondre, ce qui améliore significativement leurs performances sur les tâches complexes.\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "# Patterns de Production : APIs Avancées OpenAI\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](8_Reasoning_Models.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](8_Reasoning_Models.ipynb)\n",
     "\n",
     "\n",
     "Ce notebook couvre les fonctionnalités avancées nécessaires pour des applications en production :\n",


### PR DESCRIPTION
## Slice Class C de #6912

Le lien `[Index]` de la ligne **Navigation** pointait vers un README parent (`../../README.md` -> racine notebooks ; `../README.md` -> hub GenAI) au lieu du README de serie `Texte/README.md`. Chemin fige avant l'aplatissement de l'arborescence : resolvait-vers-existant (passe le checker 404) mais mauvaise cible.

**Fix** : `[Index](README.md)` sur les 11 notebooks concernes (1-11).

### Verifications
- Edition **markdown-only** (cellule markdown de navigation) -> **C.2-safe**, aucune re-execution.
- Remplacement **byte-level** : aucune reserialization JSON, aucun flip CRLF, sorties de cellules code **intactes**.
- Diff **13/13 symetrique**, uniquement des lignes `[Index]` (sanity grep code/execution_count/outputs = vide). Notebooks 2 & 3 ont la nav en en-tete ET pied (2 corrections chacun).
- `[Index](README.md)` resout vers `Texte/README.md` (existe, verifie).
- `_output.ipynb` = artefacts papermill locaux **non-suivis**, hors commit.
- Catalogue **byte-identique** (non touche).

### Scope
Class C uniquement. Classes A (chaine `Suivant >>` sur 9-12,19) et B (7 notebooks sans nav : 13-18,20) = **PR de suivi** (total >15 fichiers -> decoupage G.4 recommande par l'issue).

See #6912