### PR TITLE
docs(ml,#3974): corrige un decompte de cellules perime dans le README ML.Net (82 -> 86)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -67,7 +67,7 @@ Le notebook 2 plonge dans la préparation des données — l'étape la plus chro
 
 Le notebook 3 introduit l'entraînement proprement dit. Vous découvrirez SDCA (Stochastic Dual Coordinate Ascent) pour la régression linéaire, LightGBM pour les problèmes non linéaires, et surtout l'AutoML de ML.NET qui automatise la recherche d'hyperparamètres et la sélection d'algorithme. Vous verrez aussi les dangers du surapprentissage et comment l'arrêter précocement.
 
-Le notebook 4 est le plus dense (82 cellules) et le plus crucial : évaluation rigoureuse. Vous apprendrez à mesurer un modèle avec R², MAE, RMSE, à utiliser la validation croisée pour estimer la généralisation, et à expliquer les prédictions avec la Permutation Feature Importance (PFI) et le Feature Contribution Calculation (FCC). Ce notebook transforme un "modèle qui marche" en un modèle que vous comprenez et pouvez justifier.
+Le notebook 4 est le plus dense (86 cellules) et le plus crucial : évaluation rigoureuse. Vous apprendrez à mesurer un modèle avec R², MAE, RMSE, à utiliser la validation croisée pour estimer la généralisation, et à expliquer les prédictions avec la Permutation Feature Importance (PFI) et le Feature Contribution Calculation (FCC). Ce notebook transforme un "modèle qui marche" en un modèle que vous comprenez et pouvez justifier.
 
 ### Phase 2 : Fonctionnalités avancées (ML-5 à ML-9, ~2h30)
 


### PR DESCRIPTION
## docs(ml,#3974): corrige un décompte de cellules périmé dans le README ML.Net (82 → 86)

Passe **§E audit fichier-entier** (rollout README #3973/#3974) sur la feuille **ML.Net** et son parent **ML**, motivée par la plainte user 2026-07-04 (#5345 : intros corrigées mais listes/compteurs laissés périmés). Corrige la **seule** dérive trouvée, avec attestation de réconciliation complète pour le reste.

### La dérive corrigée (vérifiée firsthand)

`MyIA.AI.Notebooks/ML/ML.Net/README.md` L70 décrivait ML-4-Evaluation comme « le plus dense (**82 cellules**) ». Décompte réel (`json.load` firsthand) :

```
ML-4-Evaluation.ipynb : 86 cellules (40 code + 46 markdown)
```

La qualification « **le plus dense** » reste **exacte** — ML-4 (86) domine largement le reste de la série (ML-1 = 40, ML-5 = 40, ML-8/9 = 37, ML-7 = 36, ML-2/6 = 28, ML-3 = 20). Seul le **nombre** était périmé : le notebook a grandi de 82 → 86 cellules depuis la rédaction de la prose. `82 → 86`.

### Réconciliation §E fichier-entier (disque ↔ CATALOG-STATUS ↔ prose)

Audit des **deux** READMEs contre le disque — tout le reste s'aligne, donc **rien d'autre à corriger** (attestation, pas ligne-corrigée-en-aveugle) :

**`ML.Net/README.md`**
- `CATALOG-STATUS: pedagogical_count: 19` = 19 notebooks non-`_output` sur disque ✓ (ML-1…ML-9 dual-track = 18 + TP-prevision-ventes = 19).
- Les 19 liens de notebooks (tables « Notebooks » L36-55 + « Contenu détaillé » L141-227) résolvent tous sur disque ✓.
- Marqueur `CATALOG-STATUS` **inchangé** (auto-généré, propriété de l'automatisation — cf catalog-pr-hygiene R1).

**`ML/README.md`** (parent)
- `CATALOG-STATUS: pedagogical_count: 46 (DataScienceWithAgents=27, ML.Net=19)` = décompte disque ✓ (DSWA : 2 fondations + 8 socle 02-ML-Cours + 7 labs LangChain + 10 labs ADK = 27).
- Track A « 10 notebooks C# (9 ML-1→ML-9 + 1 TP) + 9 jumeaux Python » = 19 ML.Net ✓ ; les 9 jumeaux `*-Python.ipynb` existent tous sur disque ✓.
- Arbre de structure (L100-131), table ML.NET (L172-192), socle 02-ML-Cours 2.1→2.8 (L233-240), Labs 1→17 (L248-271) : liens et volumes réconciliés ✓.

Le décompte `86` n'est **pas** injecté dans le marqueur `CATALOG-STATUS` (qui n'agrège que les volumes par sous-série, pas les cellules par notebook) : la correction est purement prose, sans toucher au bloc généré.

### Doctrine appliquée

- **§E fichier-entier** : audit des deux READMEs (pas seulement la ligne corrigée) ; disque ↔ catalog ↔ prose réconciliés ; 1 seule dérive trouvée et corrigée.
- **R1 catalog-pr-hygiene** : `git diff | grep CATALOG` = vide → marqueur byte-identique à main.
- **R3 atomique** : 1 fichier, 1 ligne, 1 sujet (décompte périmé), 1 domaine (docs). Très loin sous G.4.
- **anti-regression (§D)** : docs-only, aucun code/preuve/notebook/output de cellule touché ; `+1/−1`, pas de suppression de contenu.
- **Stop & Repair (secrets-hygiene §6)** : aucune sortie de cellule hand-éditée — pure prose README.
- **L268 LF-only** : CR=0. **C280-1 MD047** : édition mi-fichier, newline final inchangé.
- **C403-L1** : PR body via `--body-file`.
- **C444-L1 pré-flight** : dernier commit du fichier = #5787 (figures, pas cette prose) ; aucune PR concurrente sur le README ML ; base `origin/main` `6fbd85d78` fraîche.

### Refs

- See #3974 (rollout README §E audit fichier-entier — feuille ML.Net, contribution partielle à l'EPIC)
- See #5345 (plainte user 2026-07-04 : compteurs périmés laissés dans les READMEs — classe de bug corrigée ici)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
