### PR TITLE
fix(genai-texte,#6912): repair stale [Index] navlinks (11 notebooks -> series README)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](9_Production_Patterns.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](9_Production_Patterns.ipynb)\n",
     "\n",
     "# 10. Hébergement Local de Modèles Génératifs\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "# 11. Quantization des LLMs\n",
     "\n",
-    "**Navigation** : [<< 10. Hebergement Local](10_LocalLlama.ipynb) | [Index](../../README.md)\n",
+    "**Navigation** : [<< 10. Hebergement Local](10_LocalLlama.ipynb) | [Index](README.md)\n",
     "\n",
     "**Duree estimee** : 60 minutes\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "# 1. Introduction a l'IA generative avec l'API OpenAI\n",
     "\n",
-    "**Navigation** : [Index](../../README.md) | [Suivant >>](2_PromptEngineering.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [Suivant >>](2_PromptEngineering.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
@@ -15,7 +15,7 @@
    },
    "source": [
     "# 2. Prompt Engineering : Techniques Avancées\n",
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](1_OpenAI_Intro.ipynb) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](1_OpenAI_Intro.ipynb) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
     "\n",
     "## Prompt Engineering : Advanced Prompting avec OpenAI\n",
     "\n",
@@ -43,7 +43,7 @@
    },
    "source": [
     "\n",
-    "**Navigation** : [<< Precedent](1_OpenAI_Intro.ipynb) | [Index](../../README.md) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
+    "**Navigation** : [<< Precedent](1_OpenAI_Intro.ipynb) | [Index](README.md) | [Suivant >>](3_Structured_Outputs.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
@@ -15,7 +15,7 @@
    },
    "source": [
     "# 3. Structured Outputs : Sorties JSON Garanties\n",
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](2_PromptEngineering.ipynb) | [Suivant >>](4_Function_Calling.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](2_PromptEngineering.ipynb) | [Suivant >>](4_Function_Calling.ipynb)\n",
     "\n",
     "## Structured Outputs : Sorties JSON Garanties avec OpenAI\n",
     "\n",
@@ -47,7 +47,7 @@
    },
    "source": [
     "\n",
-    "**Navigation** : [<< Precedent](2_PromptEngineering.ipynb) | [Index](../../README.md) | [Suivant >>](4_Function_Calling.ipynb)\n",
+    "**Navigation** : [<< Precedent](2_PromptEngineering.ipynb) | [Index](README.md) | [Suivant >>](4_Function_Calling.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](../../README.md) | [<< Precedent](3_Structured_Outputs.ipynb) | [Suivant >>](5_RAG_Modern.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](3_Structured_Outputs.ipynb) | [Suivant >>](5_RAG_Modern.ipynb)\n",
     "\n",
     "# Function Calling : Connecter les LLMs au Monde Réel\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# 5. RAG Modern - Retrieval Augmented Generation\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](4_Function_Calling.ipynb) | [Suivant >>](6_PDF_Web_Search.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](4_Function_Calling.ipynb) | [Suivant >>](6_PDF_Web_Search.ipynb)\n",
     "\n",
     "\n",
     "**Durée estimée** : 65 minutes\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# PDF et Web Search : Sources Documentaires avec OpenAI\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](5_RAG_Modern.ipynb) | [Suivant >>](7_Code_Interpreter.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](5_RAG_Modern.ipynb) | [Suivant >>](7_Code_Interpreter.ipynb)\n",
     "\n",
     "\n",
     "Ce notebook explore deux fonctionnalités puissantes de l'API OpenAI :\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Code Interpreter : Exécution de Code avec OpenAI\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](6_PDF_Web_Search.ipynb) | [Suivant >>](8_Reasoning_Models.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](6_PDF_Web_Search.ipynb) | [Suivant >>](8_Reasoning_Models.ipynb)\n",
     "\n",
     "\n",
     "Le **Code Interpreter** est un outil intégré qui permet au modèle d'exécuter du code Python dans un environnement sandbox sécurisé. Il est particulièrement utile pour l'analyse de données, les calculs complexes, et la génération de visualisations.\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "# Modèles de Raisonnement : gpt-5-mini\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](7_Code_Interpreter.ipynb) | [Suivant >>](9_Production_Patterns.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](7_Code_Interpreter.ipynb) | [Suivant >>](9_Production_Patterns.ipynb)\n",
     "\n",
     "\n",
     "Les **modèles de raisonnement** représentent une évolution majeure des LLMs. Ils s'appuient sur le **chain-of-thought** (Wei et al., 2022) -- démontrer le raisonnement étape par étape améliore la précision -- et sur l'idée que l'on peut **échanger du temps de calcul contre de la qualité** (Snell et al., 2024). La sortie des modèles de type **o1** (OpenAI, 2024, *Learning to Reason with LLMs*) a institutionnalisé ce paradigme : le modèle produit un raisonnement interne (caché) avant de répondre. Contrairement aux modèles de chat classiques, ils prennent le temps de \"réfléchir\" avant de répondre, ce qui améliore significativement leurs performances sur les tâches complexes.\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "# Patterns de Production : APIs Avancées OpenAI\n",
     "\n",
-    "**Navigation** : [Index](../README.md) | [<< Precedent](8_Reasoning_Models.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](8_Reasoning_Models.ipynb)\n",
     "\n",
     "\n",
     "Ce notebook couvre les fonctionnalités avancées nécessaires pour des applications en production :\n",


### PR DESCRIPTION
## Objet — Class C de #6912 (navigation *correctness*)

Les 11 premiers notebooks de `GenAI/Texte/` avaient leur lien `[Index]` de navigation pointant vers un README **parent** au lieu de l'index de série :

| Cible erronée | Résolvait vers | Notebooks |
|---------------|----------------|-----------|
| `../../README.md` | racine `MyIA.AI.Notebooks/` | 1, 2, 3, 4, 10, 11 |
| `../README.md` | hub `GenAI/` | 5, 6, 7, 8, 9 |

Ces liens **résolvaient vers un fichier existant** (le checker 404 passait) mais vers la **mauvaise cible** — signature d'un chemin figé avant l'aplatissement de l'arborescence de la série. Corrigés vers `README.md` (→ `GenAI/Texte/README.md`, l'index de série). Seuls 12 & 19 étaient déjà corrects.

## Portée & sécurité

- **Éditions markdown-only** (ligne `**Navigation**` des cellules header/footer) → **C.2-safe** : aucune ré-exécution, `execution_count`/`outputs` inchangés (diff = 13 lignes, uniquement le token `[Index]`).
- Notebooks 2 & 3 portent une nav **header + footer** — les deux liens `[Index]` réparés.
- Catalogue **byte-identique** (aucun fichier catalogue touché), `nbformat.validate` OK.

## Reste de #6912 (PR séparée)

- Class A : chaîne `Suivant >>` interrompue (9,10,11,12,19).
- Class B : 7 notebooks sans navigation (13,14,15,16,17,18,20).

See #6912

🤖 Generated with [Claude Code](https://claude.com/claude-code)