### PR TITLE
docs(genai,#6912): complete GenAI/Texte navigation tail 12->20 (Classes A+B)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/12_Test_Time_Scaling.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "# 12 - Test-Time Scaling : le second axe de mise a l'echelle\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Precedent](11_Quantization.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](11_Quantization.ipynb) | [Suivant >>](13_Agentic_Orchestration.ipynb)\n",
     "\n",
     "Jusqu'ici nous avons mis a l'echelle les LLM en augmentant leur **taille** (parametres, donnees d'entrainement) : c'est le **size-scaling**. Snell et al. (2024), dans *Scaling LLM Test-Time Compute Optimally*, ont formalise un **second axe** : depenser davantage de **calcul a l'inference** (test-time compute). Au lieu d'un seul appel direct, on orchestre plusieurs appels : Best-of-N, Reflexion, Tree-of-Thoughts...\n",
     "\n",
@@ -1683,7 +1683,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Precedent](11_Quantization.ipynb)"
+    "**Navigation** : [Index](README.md) | [<< Precedent](11_Quantization.ipynb) | [Suivant >>](13_Agentic_Orchestration.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/13_Agentic_Orchestration.ipynb
@@ -16,6 +16,8 @@
    "source": [
     "# 13. Orchestration agentique du test-time scaling\n",
     "\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](12_Test_Time_Scaling.ipynb) | [Suivant >>](14_Persistent_Memory.ipynb)\n",
+    "\n",
     "**Pont entre NB-12 (les quatre moteurs) et NB-04 (Function Calling) / NB-09 (Production).**\n",
     "\n",
     "Le notebook **`12_Test_Time_Scaling.ipynb`** implemente from scratch, en Python pur, quatre\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/14_Persistent_Memory.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/14_Persistent_Memory.ipynb
@@ -16,6 +16,8 @@
    "source": [
     "# 14. Memoire persistante pour le test-time scaling\n",
     "\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](13_Agentic_Orchestration.ipynb) | [Suivant >>](15_Tree_of_Thoughts_Search.ipynb)\n",
+    "\n",
     "**Phase 2 de l'epic #2926** — pont entre **NB-12** (moteur Reflexion, memoire *in-memory*),\n",
     "**NB-13** (routeur agentique) et **NB-05** (RAG : embeddings + vector store).\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/15_Tree_of_Thoughts_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/15_Tree_of_Thoughts_Search.ipynb
@@ -16,6 +16,8 @@
    "source": [
     "# 15. Tree-of-Thoughts sur de vrais problemes de recherche\n",
     "\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](14_Persistent_Memory.ipynb) | [Suivant >>](16_Scaling_Test_Time_Compute.ipynb)\n",
+    "\n",
     "**Phase 3 de l'epic #2926** — pont entre **NB-12** (ToT demontre sur le 24-game), **NB-13/NB-14**\n",
     "(routeur + memoire agentiques) et les series **Search (CSP)** / **Sudoku**.\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/16_Scaling_Test_Time_Compute.ipynb
@@ -16,6 +16,8 @@
    "source": [
     "# 16. Scaling du test-time compute (Snell 2024)\n",
     "\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](15_Tree_of_Thoughts_Search.ipynb) | [Suivant >>](17_Native_Reasoning_vs_Scaling.ipynb)\n",
+    "\n",
     "**Phase 4 de l'epic #2926** — suite de **NB-12** (moteurs), **NB-13** (routeur), **NB-14**\n",
     "(memoire), **NB-15** (ToT sur CSP).\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/17_Native_Reasoning_vs_Scaling.ipynb
@@ -16,6 +16,8 @@
    "source": [
     "# 17. Modeles a raisonnement natif vs scaling du test-time compute\n",
     "\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](16_Scaling_Test_Time_Compute.ipynb) | [Suivant >>](18_Semantic_Kernel_Plugins.ipynb)\n",
+    "\n",
     "**Phase 5 de l'epic #2926** — suite de **NB-12** (moteurs), **NB-16** (scaling pass@k).\n",
     "\n",
     "## La question centrale de Snell (Phase 5)\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
@@ -16,6 +16,8 @@
    "source": [
     "# 18. Plugins Semantic Kernel pour le test-time scaling\n",
     "\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](17_Native_Reasoning_vs_Scaling.ipynb) | [Suivant >>](19_OWUI_Orchestration.ipynb)\n",
+    "\n",
     "**Phase 6 (finale) de l'epic #2926** — suite de **NB-12** (moteurs) a **NB-17** (raisonnement natif).\n",
     "Ce notebook **clot #2926** en exposant les moteurs de test-time scaling (BoN, Reflexion, routeur)\n",
     "comme des **plugins [Semantic Kernel](https://github.com/microsoft/semantic-kernel)** (SK), faisant\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/19_OWUI_Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/19_OWUI_Orchestration.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# 19. Orchestration et tâches planifiées avec Open WebUI v0.9.0\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Précédent](18_Semantic_Kernel_Plugins.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Précédent](18_Semantic_Kernel_Plugins.ipynb) | [Suivant >>](20_OWUI_Native_API.ipynb)\n",
     "\n",
     "Le notebook **`13_Agentic_Orchestration.ipynb`** montrait comment un **agent planificateur**\n",
     "choisit, en code, quel moteur de test-time scaling invoquer. Ce notebook **NB-19** ouvre une\n",
@@ -963,7 +963,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Précédent](18_Semantic_Kernel_Plugins.ipynb)\n"
+    "**Navigation** : [Index](README.md) | [<< Précédent](18_Semantic_Kernel_Plugins.ipynb) | [Suivant >>](20_OWUI_Native_API.ipynb)\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GenAI/Texte/20_OWUI_Native_API.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/20_OWUI_Native_API.ipynb
@@ -9,6 +9,8 @@
    "source": [
     "# 20. OWUI Native API v0.9.6 — introspection REST et surface authentifiee\n",
     "\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](19_OWUI_Orchestration.ipynb)\n",
+    "\n",
     "Le notebook [19_OWUI_Orchestration](19_OWUI_Orchestration.ipynb) orchestrait des LLM via l'**endpoint OpenAI-compatible** `POST /api/chat/completions` d'Open WebUI. Cet endpoint est pratique (un SDK `openai` standard suffit) mais il ne couvre qu'une fraction de ce qu'OWUI expose.\n",
     "\n",
     "Ce notebook compagnon explore la **vraie surface API native d'OWUI v0.9.6** : les routes REST qui decrivent et controlent le deploiement lui-meme. On y trouve deux couches distinctes :\n",


### PR DESCRIPTION
## Scope

Completes the `**Navigation**` chain for the **tail** of the GenAI/Texte series (notebooks **12 -> 20**), the Classes A+B follow-up of #6912. **Fully disjoint** from the open Class-C PRs (#6913 / #6915, po-2026), which touch only notebooks **1-11** (`[Index]` navlink normalization). Verified: my 9 files ∩ their 11 files = ∅.

## What changed (9 notebooks, markdown-only, +18 / -4)

- **Class B** — 7 notebooks that had **no navigation line** at all: `13, 14, 15, 16, 17, 18, 20` receive the full line
  `**Navigation** : [Index](README.md) | [<< Precedent](n-1) | [Suivant >>](n+1)`
  (`[Index](README.md)` was already correct on these; **#20** is the series endpoint -> no `Suivant >>`).
- **Class A tail** — `Suivant >>` was missing: `12` and `19` gain `[Suivant >>]` on **both** nav copies (top header + References footer). Their existing `[Index](README.md)` and `<< Precedent` are untouched — **nb19 keeps its accented "Precedent"** (only appended, no rewrite).

Result: the chain `11 <-> 12 <-> 13 <-> ... <-> 20` is now continuous.

## Compliance

- **C.2-safe**: edits are on the markdown header nav line only -> **no cell re-execution** required, no output churn.
- **No untouched-cell churn**: `json.dumps(indent=1, ensure_ascii=False)` round-trip verified byte-faithful before editing -> only the nav lines differ.
- **LF-only** (0 CR bytes across all 9), **catalogue byte-identical** (no `CATALOG-STATUS` marker, no `COURSE_CATALOG.generated.*` touched).

## Residual (deferred, out of scope)

Notebooks **9, 10, 11** still miss `Suivant >>` (Class A), but their nav line is being rewritten by #6913/#6915 for `[Index]` -> adding `Suivant >>` now would conflict on the same line. Deferred until the Class-C PR merges.

See #6912