### PR TITLE
feat(notebook-tools,#3801): detect_blank_figures.py — degenerate PNG figure detector (#6891)

### DIFF
--- a/scripts/notebook_tools/detect_blank_figures.py
+++ b/scripts/notebook_tools/detect_blank_figures.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Detecte les figures degenerees committees comme si elles etaient de vrais graphiques (Prong-A, registre #3801).
+
+Pourquoi cet outil existe
+-------------------------
+Le sweep Prong-A (#3801) traque les sorties FABRIQUEES : une cellule code qui
+pretend produire une visualisation mais commit un placeholder. `detect_ascii_workaround.py`
+couvre le cas ASCII (un chart dessine en caracteres). Cet outil couvre l'AUTRE
+moitie : une cellule qui commit une image DEGENERECE en lieu et place d'un vrai
+graphique -- typiquement le PNG 1x1 de 70 octets que matplotlib emet quand la
+figure est vide, que le backend Agg n'a rien trace, ou que `QuantBook()` n'a
+jamais tourne. Incident fondateur #6891 : 8 quantbook.ipynb QuantConnect committes
+chacun avec un unique PNG 1x1 de 70 octets (+ des tableaux fabriques),
+execution_count peuple partout = "fabrication consacree" (une sortie vide
+maquillee en figure).
+
+Un vrai graphique matplotlib pedagogique fait des centaines de pixels et des
+dizaines de Ko (baseline mesuree sur `research.ipynb` QC : 690x590 a 1389x989,
+41-236 Ko). Un PNG 1x1 de 70 octets n'est jamais une figure legitime. La
+separation est nette et DETERMINISTE (dimensions IHDR + taille decodee), pas
+heuristique -- donc, contrairement au detecteur ASCII, pas de risque de faux
+positif sur les vrais plots.
+
+Il DETECTE, il ne CORRIGE PAS. La correction = re-executer la cellule dans le
+vrai environnement (QC Cloud research pour QuantBook, kernel local pour
+matplotlib) et committer la vraie figure -- Stop&Repair, JAMAIS scrubber ni
+supprimer pour cacher (regle secrets-hygiene 6 + sota-not-workaround Prong-A).
+L'outil guide le sweep en listant les fabrications ; le verdict (RECOVERABLE-*)
+et la re-exec restent un travail de substance par notebook.
+
+Ce qui est flagge (DETERMINISTE)
+--------------------------------
+Une sortie `image/png` (ou `image/jpeg`) d'une cellule code est DEGENERECE si :
+  - ses dimensions sont minuscules : width <= MIN_DIM ou height <= MIN_DIM
+    (defaut 8 px -- un 1x1 est le cas canonique #6891) ; OU
+  - sa taille decodee est infime : < MIN_BYTES (defaut 1024 o -- le PNG 1x1
+    fait 70 o ; un vrai plot fait des dizaines de Ko).
+Les deux signaux concordent sur le cas #6891 ; chacun est rapporte separement
+pour que l'humain juge (une image JPEG dont on ne parse pas les dimensions n'est
+retenue que sur la taille).
+
+Known blind spots (hors scope par design)
+-----------------------------------------
+- FIGURE PLEINE MAIS VIDE : un PNG full-size (ex 690x590) entierement blanc /
+  transparent (un plot qui a trace des axes vides). Detecter ca demande une
+  analyse pixel (variance de couleur) -- plus lourd et bruite. Hors scope : cet
+  outil cible la degenerescence de dimension/taille (le cas #6891 verifie), pas
+  le contenu semantique de l'image.
+- IMAGE LEGITIMEMENT PETITE : une icone / un sprite / un QR code volontairement
+  petit. Rare en notebook pedagogique (les sorties image sont des figures). Si
+  rencontre, l'exclure au cas par cas -- l'outil est read-only.
+
+Usage
+-----
+    python detect_blank_figures.py NB.ipynb                 # un notebook
+    python detect_blank_figures.py --family QuantConnect    # une famille
+    python detect_blank_figures.py                          # tous les notebooks
+    python detect_blank_figures.py NB.ipynb --json          # sortie machine
+    python detect_blank_figures.py NB.ipynb --check         # exit 1 si figures degenerees (CI-ready)
+    python detect_blank_figures.py NB.ipynb --min-dim 8 --min-bytes 1024   # seuils explicites
+
+Exit codes
+----------
+    0 -- aucune figure degenerece (ou mode non --check)
+    1 -- une ou plusieurs figures degenerees (--check seulement)
+    2 -- erreur (notebook illisible, famille introuvable)
+
+Voir aussi
+----------
+- `detect_ascii_workaround.py` (#3801) -- moitie ASCII du sweep Prong-A
+- `.claude/rules/sota-not-workaround.md` -- Prong-A : vrai outil, pas workaround/fabrication
+- `.claude/rules/secrets-hygiene.md` regle 6 -- Stop&Repair : re-executer, jamais scrubber
+- #6891 -- incident fondateur (8 quantbook.ipynb QC blank-PNG)
+
+Part of #3801 (EPIC SOTA axe-2).
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import sys
+from pathlib import Path
+
+# Seuils de degenerescence. Calibres sur la baseline QC #6891 :
+#   degenere  : 70 octets, 1x1  (le PNG vide de matplotlib)
+#   legitime  : 41-236 Ko, 690x590 a 1389x989  (vrais plots research.ipynb)
+# La separation est de plusieurs ordres de grandeur -> aucun chevauchement.
+MIN_DIM = 8         # px : une figure < 8px de cote n'est pas une viz reelle
+MIN_BYTES = 1024    # o  : un PNG decode < 1 Ko ne porte pas de vraie figure
+
+_IMAGE_MIMES = ("image/png", "image/jpeg")
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def _cell_outputs(cell: dict) -> list[dict]:
+    return cell.get("outputs", []) or []
+
+
+def _decode_image(b64: object) -> bytes | None:
+    """Decode a notebook image payload (str or list[str]) into raw bytes."""
+    if isinstance(b64, list):
+        b64 = "".join(b64)
+    if not isinstance(b64, str):
+        return None
+    try:
+        return base64.b64decode(b64, validate=False)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def _png_dimensions(raw: bytes) -> tuple[int, int] | None:
+    """Return (width, height) from a PNG IHDR, or None if not a parseable PNG.
+
+    PNG layout: 8-byte signature, then the IHDR chunk whose data begins at
+    offset 16 with big-endian 4-byte width then 4-byte height.
+    """
+    if len(raw) < 24 or raw[:8] != _PNG_SIGNATURE:
+        return None
+    if raw[12:16] != b"IHDR":
+        return None
+    width = int.from_bytes(raw[16:20], "big")
+    height = int.from_bytes(raw[20:24], "big")
+    return (width, height)
+
+
+def _classify_image(mime: str, raw: bytes, min_dim: int, min_bytes: int) -> dict | None:
+    """Return a finding dict if the image is degenerate, else None."""
+    reasons = []
+    size = len(raw)
+    dims = _png_dimensions(raw) if mime == "image/png" else None
+
+    if dims is not None:
+        w, h = dims
+        if w <= min_dim or h <= min_dim:
+            reasons.append(f"degenerate_dimensions({w}x{h})")
+
+    if size < min_bytes:
+        reasons.append(f"tiny_payload({size}B)")
+
+    if not reasons:
+        return None
+    return {
+        "mime": mime,
+        "bytes": size,
+        "dimensions": list(dims) if dims else None,
+        "reasons": reasons,
+    }
+
+
+def detect_cell(cell: dict, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) -> list[dict]:
+    """Return findings (one per degenerate image output) for a code cell."""
+    findings = []
+    for oi, out in enumerate(_cell_outputs(cell)):
+        data = out.get("data", {}) if isinstance(out, dict) else {}
+        for mime in _IMAGE_MIMES:
+            if mime not in data:
+                continue
+            raw = _decode_image(data[mime])
+            if raw is None:
+                continue
+            finding = _classify_image(mime, raw, min_dim, min_bytes)
+            if finding:
+                findings.append({"output_index": oi, **finding})
+    return findings
+
+
+def scan_notebook(path: Path, min_dim: int = MIN_DIM, min_bytes: int = MIN_BYTES) -> dict:
+    """Return a result dict for one notebook: path, hits[], error."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            nb = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"path": str(path), "error": str(exc), "hits": []}
+
+    hits = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        for finding in detect_cell(cell, min_dim, min_bytes):
+            hits.append({"cell_index": ci, **finding})
+    return {"path": str(path), "kernel": _kernel(nb), "hits": hits, "error": None}
+
+
+def _kernel(nb: dict) -> str:
+    return nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
+
+
+# Dossiers a ignorer (alignes sur detect_ascii_workaround.py:SKIP_DIRS).
+SKIP_DIRS = {
+    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
+    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
+    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
+}
+
+# Artefacts papermill (*_output.ipynb) : la source canonique est le livrable, le
+# _output re-genere peut porter une figure stale -- on scanne la source.
+_OUTPUT_SUFFIX = "_output.ipynb"
+
+
+def _should_skip(rel: Path) -> bool:
+    if any(part in SKIP_DIRS for part in rel.parts):
+        return True
+    return rel.name.endswith(_OUTPUT_SUFFIX)
+
+
+def _iter_notebooks(root: Path, family: str | None):
+    base = root / "MyIA.AI.Notebooks"
+    if family:
+        base = base / family
+    if not base.exists():
+        return
+    for nb in sorted(base.rglob("*.ipynb")):
+        if _should_skip(nb.relative_to(base)):
+            continue
+        yield nb
+
+
+def _human_report(results: list[dict]) -> str:
+    total_hits = sum(len(r["hits"]) for r in results)
+    affected = [r for r in results if r["hits"]]
+    errored = [r for r in results if r.get("error")]
+    lines = [
+        f"Notebooks scanned  : {len(results)}",
+        f"Degenerate figures : {total_hits}",
+        f"Affected notebooks : {len(affected)}",
+        "",
+    ]
+    if not affected:
+        lines.append("No degenerate figures detected (deterministic dimension/size check).")
+        if errored:
+            lines.append("")
+            lines.append(f"NOTE: {len(errored)} notebook(s) unreadable (see --json for details).")
+        return "\n".join(lines)
+    for r in affected:
+        short = r["path"].split("MyIA.AI.Notebooks")[-1].lstrip("\\/")
+        lines.append(f"## {short}  [{r['kernel']}]")
+        for h in r["hits"]:
+            reasons = ", ".join(h["reasons"])
+            lines.append(f"  - cell [{h['cell_index']}] output[{h['output_index']}] {h['mime']}: {reasons}")
+        lines.append("")
+    lines.append(
+        "FIX: re-execute the cell in the real environment (QC Cloud research for "
+        "QuantBook, local kernel for matplotlib) and commit the real figure -- "
+        "Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6)."
+    )
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("notebook", nargs="?", help="Notebook to scan (default: all pedagogical)")
+    parser.add_argument("--family", help="Top-level family under MyIA.AI.Notebooks/ (e.g. QuantConnect)")
+    parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if any degenerate figure (CI-ready)")
+    parser.add_argument("--min-dim", type=int, default=MIN_DIM, help=f"Min figure side px (default {MIN_DIM})")
+    parser.add_argument("--min-bytes", type=int, default=MIN_BYTES, help=f"Min decoded bytes (default {MIN_BYTES})")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.notebook:
+        paths = [Path(args.notebook)]
+        if not paths[0].is_absolute():
+            paths[0] = root / paths[0]
+        if not paths[0].exists():
+            print(f"error: notebook not found: {paths[0]}", file=sys.stderr)
+            return 2
+    else:
+        paths = list(_iter_notebooks(root, args.family))
+        if args.family and not paths:
+            print(f"error: family not found: {args.family}", file=sys.stderr)
+            return 2
+
+    results = [scan_notebook(p, args.min_dim, args.min_bytes) for p in paths]
+    total_hits = sum(len(r["hits"]) for r in results)
+
+    if args.json:
+        payload = {"notebooks_scanned": len(results), "total_hits": total_hits, "results": results}
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(_human_report(results))
+
+    if args.check and total_hits > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_detect_blank_figures.py
+++ b/scripts/tests/test_detect_blank_figures.py
@@ -1,0 +1,237 @@
+"""Tests for scripts/notebook_tools/detect_blank_figures.py — Prong-A blank-figure detector.
+
+Validates the deterministic dimension/size degeneracy check against the #6891
+baseline (70-byte 1x1 PNG = fabrication) vs real matplotlib figures (KB-sized,
+hundreds of px). Because detection is deterministic (parse PNG IHDR + byte size),
+there is no heuristic false-positive risk on real plots — the tests lock the
+clean separation in.
+"""
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Convention siblings (test_detect_ascii_workaround.py) : inserer
+# scripts/notebook_tools/ et importer le module directement (evite d'enregistrer
+# le repertoire comme namespace package masquant notebook_tools.py).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "notebook_tools"))
+
+from detect_blank_figures import (  # noqa: E402
+    MIN_BYTES,
+    MIN_DIM,
+    SKIP_DIRS,
+    _classify_image,
+    _decode_image,
+    _png_dimensions,
+    _should_skip,
+    detect_cell,
+    main,
+    scan_notebook,
+)
+
+_PNG_SIG = b"\x89PNG\r\n\x1a\n"
+
+
+def make_png(width: int, height: int, total_bytes: int) -> bytes:
+    """Construct a minimal PNG whose IHDR carries `width`x`height`, padded to `total_bytes`."""
+    ihdr = (
+        _PNG_SIG
+        + b"\x00\x00\x00\x0d"          # IHDR length = 13
+        + b"IHDR"
+        + width.to_bytes(4, "big")
+        + height.to_bytes(4, "big")
+        + b"\x08\x02\x00\x00\x00"      # bit depth / color type / compression / filter / interlace
+    )
+    pad = b"\x00" * max(0, total_bytes - len(ihdr))
+    return ihdr + pad
+
+
+def b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+def code_cell_with_png(raw: bytes, execution_count: int = 1) -> dict:
+    return {
+        "cell_type": "code",
+        "execution_count": execution_count,
+        "source": ["import matplotlib.pyplot as plt\n", "plt.plot([1,2,3])\n", "plt.show()\n"],
+        "outputs": [
+            {"output_type": "display_data", "data": {"image/png": b64(raw)}, "metadata": {}}
+        ],
+    }
+
+
+# The canonical #6891 fabrication: the exact 70-byte 1x1 PNG matplotlib emits for
+# an empty figure. Reconstructed to match (real bytes = 70).
+BLANK_1x1 = make_png(1, 1, 70)
+REAL_PLOT = make_png(690, 590, 41223)   # research.ipynb AllWeather cell — real matplotlib figure
+
+
+class TestPngDimensions:
+    def test_parses_real_dimensions(self):
+        assert _png_dimensions(make_png(690, 590, 41223)) == (690, 590)
+
+    def test_parses_1x1(self):
+        assert _png_dimensions(BLANK_1x1) == (1, 1)
+
+    def test_none_on_non_png(self):
+        assert _png_dimensions(b"not a png at all, just bytes here padding") is None
+
+    def test_none_on_too_short(self):
+        assert _png_dimensions(_PNG_SIG + b"\x00\x00") is None
+
+
+class TestClassifyImage:
+    def test_1x1_flagged_both_reasons(self):
+        """70-byte 1x1 = the #6891 case: BOTH degenerate dimensions AND tiny payload."""
+        f = _classify_image("image/png", BLANK_1x1, MIN_DIM, MIN_BYTES)
+        assert f is not None
+        reasons = " ".join(f["reasons"])
+        assert "degenerate_dimensions(1x1)" in reasons
+        assert "tiny_payload(70B)" in reasons
+        assert f["dimensions"] == [1, 1]
+        assert f["bytes"] == 70
+
+    def test_real_plot_not_flagged(self):
+        """690x590 @ 41KB = a real figure: neither degenerate nor tiny -> None."""
+        assert _classify_image("image/png", REAL_PLOT, MIN_DIM, MIN_BYTES) is None
+
+    def test_small_dimension_full_bytes_flagged_on_dims_only(self):
+        """A 4px-tall but heavy image is flagged on dimensions, not on size."""
+        img = make_png(600, 4, 5000)
+        f = _classify_image("image/png", img, MIN_DIM, MIN_BYTES)
+        assert f is not None
+        assert any("degenerate_dimensions" in r for r in f["reasons"])
+        assert not any("tiny_payload" in r for r in f["reasons"])
+
+    def test_full_dimension_tiny_bytes_flagged_on_size_only(self):
+        """A full-size-declared PNG that is nonetheless < MIN_BYTES is flagged on size."""
+        img = make_png(690, 590, 200)  # dims fine, but only 200 bytes
+        f = _classify_image("image/png", img, MIN_DIM, MIN_BYTES)
+        assert f is not None
+        assert any("tiny_payload" in r for r in f["reasons"])
+        assert not any("degenerate_dimensions" in r for r in f["reasons"])
+
+    def test_jpeg_flagged_on_size_only(self):
+        """JPEG dimensions are not parsed (PNG-only); a tiny JPEG is caught on size."""
+        f = _classify_image("image/jpeg", b"\xff\xd8\xff" + b"\x00" * 50, MIN_DIM, MIN_BYTES)
+        assert f is not None
+        assert f["dimensions"] is None
+        assert any("tiny_payload" in r for r in f["reasons"])
+
+
+class TestDetectCell:
+    def test_blank_cell_one_finding(self):
+        findings = detect_cell(code_cell_with_png(BLANK_1x1))
+        assert len(findings) == 1
+        assert findings[0]["output_index"] == 0
+
+    def test_real_cell_no_finding(self):
+        assert detect_cell(code_cell_with_png(REAL_PLOT)) == []
+
+    def test_cell_without_image_output_no_finding(self):
+        cell = {
+            "cell_type": "code",
+            "execution_count": 1,
+            "source": ["print('hello')\n"],
+            "outputs": [{"output_type": "stream", "name": "stdout", "text": ["hello\n"]}],
+        }
+        assert detect_cell(cell) == []
+
+    def test_malformed_payload_does_not_crash(self):
+        cell = {
+            "cell_type": "code",
+            "outputs": [{"output_type": "display_data", "data": {"image/png": 12345}, "metadata": {}}],
+        }
+        # non-str payload decodes to None -> skipped, no exception
+        assert detect_cell(cell) == []
+
+
+class TestDecodeImage:
+    def test_list_payload_joined(self):
+        raw = _decode_image([b64(BLANK_1x1)[:10], b64(BLANK_1x1)[10:]])
+        assert raw == BLANK_1x1
+
+    def test_non_str_returns_none(self):
+        assert _decode_image(999) is None
+
+
+class TestScanNotebook:
+    def _write_nb(self, tmp_path: Path, cells: list[dict]) -> Path:
+        nb = {"cells": cells, "metadata": {"kernelspec": {"name": "python3"}}, "nbformat": 4}
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        return p
+
+    def test_flags_only_degenerate(self, tmp_path):
+        p = self._write_nb(tmp_path, [
+            code_cell_with_png(BLANK_1x1, 1),   # fabrication
+            code_cell_with_png(REAL_PLOT, 2),   # real
+            {"cell_type": "markdown", "source": ["# title"]},
+        ])
+        res = scan_notebook(p)
+        assert res["error"] is None
+        assert len(res["hits"]) == 1
+        assert res["hits"][0]["cell_index"] == 0
+        assert res["kernel"] == "python3"
+
+    def test_clean_notebook_no_hits(self, tmp_path):
+        p = self._write_nb(tmp_path, [code_cell_with_png(REAL_PLOT, 1)])
+        assert scan_notebook(p)["hits"] == []
+
+    def test_unreadable_notebook_reports_error(self, tmp_path):
+        p = tmp_path / "broken.ipynb"
+        p.write_text("{not json", encoding="utf-8")
+        res = scan_notebook(p)
+        assert res["error"] is not None
+        assert res["hits"] == []
+
+
+class TestSkipDirs:
+    def test_should_skip_output_suffix(self):
+        assert _should_skip(Path("QuantConnect/projects/AllWeather/quantbook_output.ipynb")) is True
+
+    def test_should_not_skip_canonical(self):
+        assert _should_skip(Path("QuantConnect/projects/AllWeather/quantbook.ipynb")) is False
+
+    def test_should_skip_lake_dir(self):
+        assert _should_skip(Path("SomeFam/.lake/build/nb.ipynb")) is True
+
+    def test_skip_dirs_has_expected_entries(self):
+        assert ".lake" in SKIP_DIRS and "worktrees" in SKIP_DIRS
+
+
+class TestMainCli:
+    def _write_nb(self, tmp_path: Path, cells: list[dict], name="nb.ipynb") -> Path:
+        nb = {"cells": cells, "metadata": {"kernelspec": {"name": "python3"}}, "nbformat": 4}
+        p = tmp_path / name
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        return p
+
+    def test_check_returns_1_on_degenerate(self, tmp_path, capsys):
+        p = self._write_nb(tmp_path, [code_cell_with_png(BLANK_1x1)])
+        rc = main([str(p), "--check"])
+        assert rc == 1
+
+    def test_check_returns_0_on_clean(self, tmp_path):
+        p = self._write_nb(tmp_path, [code_cell_with_png(REAL_PLOT)])
+        assert main([str(p), "--check"]) == 0
+
+    def test_missing_file_returns_2(self, tmp_path):
+        assert main([str(tmp_path / "nope.ipynb"), "--check"]) == 2
+
+    def test_json_output_shape(self, tmp_path, capsys):
+        p = self._write_nb(tmp_path, [code_cell_with_png(BLANK_1x1)])
+        main([str(p), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["total_hits"] == 1
+        assert payload["notebooks_scanned"] == 1
+
+    def test_min_dim_threshold_honored(self, tmp_path):
+        """A 690x10 image passes at default min-dim=8 but fails at min-dim=16."""
+        p = self._write_nb(tmp_path, [code_cell_with_png(make_png(690, 10, 5000))])
+        assert main([str(p), "--check"]) == 0                       # 10 > 8 default
+        assert main([str(p), "--check", "--min-dim", "16"]) == 1    # 10 <= 16


### PR DESCRIPTION
## Summary

New deterministic detector `scripts/notebook_tools/detect_blank_figures.py` for the Prong-A **fabricated-figure** class (#3801 axe-2 SOTA), covering the half that `detect_ascii_workaround.py` does not: a code cell that commits a **degenerate image** in place of a real plot — the 70-byte 1×1 PNG matplotlib emits for an empty figure, or a `QuantBook()` cell that never ran.

**Founding incident #6891**: 8 QuantConnect `quantbook.ipynb` each committed with a single 70-byte 1×1 PNG (`execution_count` populated = *consecrated fabrication*). A real matplotlib figure is hundreds of px and tens of KB (baseline on `research.ipynb`: 690×590→1389×989, 41–236 KB). The separation is several orders of magnitude, so detection is **deterministic** (parse PNG IHDR dimensions + decoded byte size), **not heuristic** — no false-positive risk on real plots.

## What it flags

An `image/png`/`image/jpeg` code-cell output is degenerate when:
- `width ≤ --min-dim` **or** `height ≤ --min-dim` (default 8 px); **or**
- decoded size `< --min-bytes` (default 1024 B).

Both signals are reported separately so a human judges (JPEG kept on size only, dimensions not parsed).

## Repo-wide baseline (945 notebooks scanned)

| Result | Notebooks |
|--------|-----------|
| **8 #6891 quantbooks** — both signals (`degenerate_dimensions(1x1)` + `tiny_payload(70B)`) | AllWeather, DualMomentum, EMA-Cross-Alpha, FuturesTrend, MomentumStrategy, RiskParity, SectorMomentum, TurnOfMonth |
| **2 tiny-payload figures** (166B/148B, size-only — the documented *legitimately-small-image* blind spot, surfaced for judgment not asserted as fabrication) | `GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb` cells 12, 17 |
| **1 unreadable notebook** reported as error, no crash | `QuantConnect/ESGF-2026/.../BTC-ML-Researcher/research.ipynb` |

## Scope / conventions

- Same CLI family as `detect_ascii_workaround.py`: `notebook` positional, `--family`, `--root`, `--json`, `--check` (exit 0/1/2), `SKIP_DIRS`, `*_output.ipynb` filter.
- Tests `scripts/tests/test_detect_blank_figures.py` (27 tests, all green) run automatically in `scripts-tests.yml` (`scripts/**` trigger + `pytest scripts/tests`). No workflow edit — atomic PR.
- **It DETECTS, it does not CORRECT.** The #6891 re-exec itself (RECOVERABLE-MACHINE, QC Cloud research → real `QuantBook()` figures) is separate substance work — Stop&Repair, never scrub/delete to hide (secrets-hygiene rule 6, sota-not-workaround Prong-A).

## Test plan

- `pytest scripts/tests/test_detect_blank_figures.py -q` → **27 passed**
- `python scripts/notebook_tools/detect_blank_figures.py --family QuantConnect` → 8 quantbooks flagged
- `python scripts/notebook_tools/detect_blank_figures.py --json` (repo-wide) → 945 scanned, 10 hits as tabled above

See #6891
See #3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)