### PR TITLE
docs(genai,#6912): complete Suivant>> chain on GenAI/Texte notebooks 9/10/11

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](README.md) | [<< Precedent](9_Production_Patterns.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](9_Production_Patterns.ipynb) | [Suivant >>](11_Quantization.ipynb)\n",
     "\n",
     "# 10. Hébergement Local de Modèles Génératifs\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "# 11. Quantization des LLMs\n",
     "\n",
-    "**Navigation** : [<< 10. Hebergement Local](10_LocalLlama.ipynb) | [Index](README.md)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](10_LocalLlama.ipynb) | [Suivant >>](12_Test_Time_Scaling.ipynb)\n",
     "\n",
     "**Duree estimee** : 60 minutes\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "# Patterns de Production : APIs Avancées OpenAI\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Precedent](8_Reasoning_Models.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](8_Reasoning_Models.ipynb) | [Suivant >>](10_LocalLlama.ipynb)\n",
     "\n",
     "\n",
     "Ce notebook couvre les fonctionnalités avancées nécessaires pour des applications en production :\n",


### PR DESCRIPTION
## Objet

Dernier résidu de **Classe A** de #6912 : la chaîne de navigation « Suivant >> » de la série `GenAI/Texte/` était rompue **après le notebook 8**. Les PR sœurs déjà mergées ont couvert le reste :

- **#6916** (MERGED) — tail 12→20 (Classes A+B)
- **#6913** (MERGED) — Classe C ([Index] path stale sur 11 notebooks)

Restaient **9, 10, 11** sans lien « Suivant >> » (le trou `9→10→11→12`), vérifié firsthand sur `origin/main`.

## Correction (gabarit-maison unique, markdown-cell seule)

`**Navigation** : [Index](README.md) | [<< Precedent](PREV) | [Suivant >>](NEXT)`

| Notebook | Avant | Après |
|----------|-------|-------|
| `9_Production_Patterns` | `… \| [<< Precedent](8…)` | `+ \| [Suivant >>](10_LocalLlama.ipynb)` |
| `10_LocalLlama` | `… \| [<< Precedent](9…)` | `+ \| [Suivant >>](11_Quantization.ipynb)` |
| `11_Quantization` | `[<< 10. Hebergement Local](10…) \| [Index]` (ordre inversé, label non standard) | `[Index] \| [<< Precedent](10…) \| [Suivant >>](12_Test_Time_Scaling.ipynb)` |

## Vérification

- **Chaîne complète 1→20** vérifiée firsthand après ce fix (1 = Index+Suivant ; 2..19 = Index+Precedent+Suivant ; 20 = Index+Precedent) — verdict `ALL COMPLETE`.
- Édition **markdown-cell seule** → C.2 : aucune cellule code re-exécutée, outputs préservés.
- Remplacement **byte-exact** (pas de round-trip JSON) → 0 churn sur cellules/outputs/encodage ; 3 fichiers, 3 insertions / 3 deletions.
- Catalogue **byte-identique** à main.

Avec #6913 + #6916 (déjà mergées) + cette PR, les Classes A/B/C de #6912 sont **toutes résolues**.

Closes #6912