### PR TITLE
feat(tools,#6927,#3801): Plotly-CDN static-render risk detector + plan 22 nb / 31 cells

### DIFF
--- a/scripts/notebook_tools/check_plotly_static_risk.py
+++ b/scripts/notebook_tools/check_plotly_static_risk.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Detect Plotly-CDN cells in .ipynb notebooks = blanc en static rendering (cf #6927).
+
+Pourquoi cet outil existe
+-------------------------
+Le pattern `record PlotlyHtml + Formatter.Register` (canon C548-L2) emet du
+Plotly.js via un `<script src="https://cdn.plot.ly/...">` externe. Ce HTML
+rend correctement dans un kernel .NET Interactive live (VS Code / Jupyter Lab
+avec Internet), MAIS :
+- GitHub sandbox et n'execute pas les `<script>` → div vide.
+- Offline / nbviewer / CSP strict (artefacts CI) → CDN externe ne charge pas.
+
+Le pendant Python (matplotlib) emet du `image/png` persistant qui rend
+partout. Les jumeaux .NET Infer/DecInfer divergent sur ce point (cf #6927).
+
+Ce tool identifie les cellules a risque : celles qui contiennent
+`cdn.plot.ly`/`cdn.plotly` dans leur SORTIE (output) **et** n'emet aucune
+sortie `image/*` rasterisable → blanc en static rendering.
+
+Sortie : table par notebook avec comptage cells a risque + plan de remediation.
+
+Usage
+-----
+    python scripts/notebook_tools/check_plotly_static_risk.py [--json] [--root MyIA.AI.Notebooks]
+                                                           [--exit-risky-nb N]
+                                                           [--fix-plan-out FILE]
+
+Notes
+-----
+- Read-only : ne touche aucun notebook.
+- Couvre 5 familles (.NET C# heavy) : GameTheory, ML.Net, DecisionTheory/DecInfer,
+  Infer, Applications/CSP/Search, Sudoku, SMT/Z3, Part1-Foundations, Part4-Metaheuristics.
+- Le scope est strictement plus large que #6927 (8 nb Infer/DecInfer) : on trouve
+  en pratique 22+ notebooks repo-wide. Ce tool sert de barometre + plan source
+  pour les PRs de fix suivantes (1 PR par notebook, scope R3-atomique).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+# Patterns to detect
+CDN_PATTERN = re.compile(r"cdn\.plot\.?ly", re.IGNORECASE)
+IMAGE_MIMES = ("image/png", "image/jpeg", "image/svg+xml", "image/webp", "image/gif")
+
+# Skips
+SKIP_DIRS = {
+    ".git",
+    "_output",
+    "_archives",
+    ".ipynb_checkpoints",
+    ".lake",  # Lean vendored
+    ".claude",
+    "node_modules",
+}
+
+
+def iter_notebooks(root: Path):
+    """Yield all .ipynb paths under root, skipping vendored/archived dirs."""
+    for p in root.rglob("*.ipynb"):
+        # Skip vendored, archives, outputs
+        rel_parts = p.parts
+        if any(part in SKIP_DIRS for part in rel_parts):
+            continue
+        # Skip _output.ipynb duplicates (always have same outputs as primary)
+        if p.stem.endswith("_output"):
+            continue
+        yield p
+
+
+def cell_is_risky(cell: dict) -> bool:
+    """A cell is risky if it has a cdn.plot.ly output and NO image/* output.
+
+    Rationale: cdn.plot.ly HTML renders only in a kernel with internet + JS.
+    If the SAME cell also emits image/png or image/svg+xml, GitHub/nbviewer can
+    fall back to the static image. Risky = NO static fallback.
+    """
+    outputs = cell.get("outputs", [])
+    if not outputs:
+        # No outputs at all (un-executed cell) — can't be a static-render risk,
+        # but log for awareness
+        return False
+
+    # Quick pre-check: serialize once
+    try:
+        out_blob = json.dumps(outputs, ensure_ascii=False)
+    except (TypeError, ValueError):
+        # Some outputs may have non-serializable parts (rare); fall through
+        return False
+
+    has_cdn = bool(CDN_PATTERN.search(out_blob))
+    if not has_cdn:
+        return False
+
+    # Has cdn: check for image MIME fallback
+    for out in outputs:
+        if not isinstance(out, dict):
+            continue
+        data = out.get("data", {})
+        if not isinstance(data, dict):
+            continue
+        for mime in data.keys():
+            if mime in IMAGE_MIMES:
+                return False  # has static fallback → not risky
+    return True
+
+
+def scan_notebook(nb_path: Path) -> list[int]:
+    """Return list of cell indexes that are risky in this notebook."""
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"  [WARN] skip {nb_path.name}: {e}", file=sys.stderr)
+        return []
+    risky = []
+    for i, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        if cell_is_risky(cell):
+            risky.append(i)
+    return risky
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument(
+        "--root",
+        default="MyIA.AI.Notebooks",
+        type=Path,
+        help="Root directory to scan (default: MyIA.AI.Notebooks)",
+    )
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output instead of human-readable markdown table",
+    )
+    ap.add_argument(
+        "--exit-risky-nb",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Exit with code 1 if more than N risky notebooks are found (CI gate).",
+    )
+    ap.add_argument(
+        "--fix-plan-out",
+        type=Path,
+        default=None,
+        help="Write a Markdown fix-plan file (1 row per risky cell) to this path.",
+    )
+    args = ap.parse_args()
+
+    if not args.root.exists():
+        print(f"[ERROR] root not found: {args.root}", file=sys.stderr)
+        return 2
+
+    # Scan
+    risky_cells = []  # list of (notebook, cell_idx, family)
+    family_counts = defaultdict(lambda: {"notebooks": 0, "cells": 0})
+    total_nbs_scanned = 0
+    total_nbs_risky = 0
+
+    for nb_path in sorted(iter_notebooks(args.root)):
+        total_nbs_scanned += 1
+        risky = scan_notebook(nb_path)
+        if not risky:
+            continue
+        total_nbs_risky += 1
+        # Extract family (= top-level dir under root, e.g. "Infer" under "Probas/Infer")
+        rel = nb_path.relative_to(args.root)
+        family = "/".join(rel.parts[:-1])
+        family_counts[family]["notebooks"] += 1
+        family_counts[family]["cells"] += len(risky)
+        for cell_idx in risky:
+            risky_cells.append((nb_path, cell_idx, family))
+
+    # Emit results
+    if args.json:
+        out = {
+            "root": str(args.root),
+            "summary": {
+                "total_notebooks_scanned": total_nbs_scanned,
+                "risky_notebooks": total_nbs_risky,
+                "risky_cells_total": len(risky_cells),
+                "by_family": dict(family_counts),
+            },
+            "risky_cells": [
+                {"notebook": str(nb.relative_to(args.root)), "cell_idx": idx, "family": fam}
+                for nb, idx, fam in risky_cells
+            ],
+        }
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+    else:
+        print(f"# Plotly-CDN static-render risk scan")
+        print(f"Root: {args.root}")
+        print(f"Notebooks scanned: {total_nbs_scanned}")
+        print(f"Notebooks risky (>=1 cell): {total_nbs_risky}")
+        print(f"Cells risky total: {len(risky_cells)}")
+        print()
+        if not risky_cells:
+            print("**None.** All Plotly outputs have a static image fallback.")
+        else:
+            print("## By family")
+            for fam in sorted(family_counts):
+                fc = family_counts[fam]
+                print(f"- `{fam}/`: {fc['notebooks']} nb, {fc['cells']} cells")
+            print()
+            print("## Risky cells (notebook → cell)")
+            print("| Notebook | cell idx | Family |")
+            print("|----------|---------|--------|")
+            for nb, idx, fam in risky_cells:
+                rel = nb.relative_to(args.root)
+                print(f"| `{rel}` | {idx} | `{fam}` |")
+
+    # Fix plan file
+    if args.fix_plan_out:
+        lines = []
+        lines.append("# Fix plan — Plotly-CDN static-rendering risk (#6927)")
+        lines.append("")
+        lines.append("Generated by `scripts/notebook_tools/check_plotly_static_risk.py`.")
+        lines.append("")
+        lines.append("Each row = one cell to fix (replace CDN-script Plotly with a static PNG/SVG).")
+        lines.append("Recommended batch granularity: **1 notebook per PR** (R3 atomique — G.4).")
+        lines.append("")
+        lines.append("## Summary")
+        lines.append(f"- {total_nbs_scanned} notebooks scanned")
+        lines.append(f"- {total_nbs_risky} notebooks risky")
+        lines.append(f"- {len(risky_cells)} cells risky total")
+        lines.append("")
+        lines.append("## By family")
+        for fam in sorted(family_counts):
+            fc = family_counts[fam]
+            lines.append(f"- `{fam}/`: {fc['notebooks']} nb, {fc['cells']} cells")
+        lines.append("")
+        lines.append("## Risky cells")
+        lines.append("")
+        lines.append("| # | Notebook | cell idx | Family |")
+        lines.append("|---|----------|---------|--------|")
+        for i, (nb, idx, fam) in enumerate(risky_cells, 1):
+            rel = nb.relative_to(args.root)
+            lines.append(f"| {i} | `{rel}` | {idx} | `{fam}` |")
+        lines.append("")
+        lines.append("## Batch recommendation (R6 anti-monotonie)")
+        lines.append("")
+        lines.append("Pick ONE notebook per PR (R3 atomique); cover ONE family before pivoting.")
+        lines.append("Suggested priorities (descending pedagogical impact):")
+        lines.append("")
+        lines.append("1. **Probas/Infer** (canonical famille of #6927): Infer-12 first (already covered by c.450, see if PR helps here)")
+        lines.append("2. **GameTheory/GameTheory-*Csharp** (C548-L2 also used here, scope broader than #6927)")
+        lines.append("3. **Search/Applications/CSP** (App-7b App-8 — used by Search-series)")
+        lines.append("4. **ML.Net** (ML-5-TimeSeries)")
+        lines.append("5. **Sudoku**, **SymbolicAI/SMT/Z3** (lower priority)")
+        lines.append("")
+        lines.append("## Reference")
+        lines.append("")
+        lines.append("- Investigation: ai-01 2026-07-16 (see #6927 body)")
+        lines.append("- Canon C548-L2: `record PlotlyHtml + Formatter.Register` (cf MEMORY.md c.452)")
+        lines.append("- Issue: #6927 (scope restreint Infer/DecInfer — élargir repo-wide via ce plan)")
+        lines.append("")
+        args.fix_plan_out.write_text("\n".join(lines), encoding="utf-8")
+        print(f"\nFix plan written: {args.fix_plan_out} ({len(risky_cells)} cells)")
+
+    # CI gate
+    if args.exit_risky_nb is not None and total_nbs_risky > args.exit_risky_nb:
+        print(
+            f"\n[FAIL] {total_nbs_risky} risky notebooks > threshold {args.exit_risky_nb}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## feat(notebook-tools,#6927): détecteur Plotly-CDN blanc-en-statique + plan de remédiation 22 nb / 31 cells

Ajoute **`scripts/notebook_tools/check_plotly_static_risk.py`**, un détecteur read-only qui scan tous les `.ipynb` de `MyIA.AI.Notebooks/` et identifie les cellules dont la **sortie** contient `<script src="https://cdn.plot.ly/...">` (= Plotly.js CDN-script) **sans** émettre en parallèle une image rasterisable (`image/png`, `image/svg+xml`, `image/jpeg`, `image/webp`, `image/gif`). Ces cellules rendent correctement en kernel live avec Internet, mais sont **vides** (div blanche) sur GitHub/nbviewer/CSP-strict.

### Investigation repo-wide — l'ampleur du problème dépasse #6927

L'investigation ai-01 (#6927 body) avait scope les **8 notebooks Infer/DecInfer** comme suspects. Le détecteur **repo-wide** révèle un scope bien plus large : **22 notebooks / 31 cellules / 9 familles** portent ce pattern. #6927 sous-estime d'un facteur ~3 l'ampleur réelle.

| Famille | Notebooks | Cells risky |
|---------|-----------|-------------|
| `GameTheory/` (C548-L2 canon family) | 6 | 8 |
| `ML/ML.Net/` | 1 | 2 |
| `Probas/DecisionTheory/DecInfer/` | 3 | 6 |
| `Probas/Infer/` | 5 | 5 |
| `Search/Applications/CSP/` | 2 | 3 |
| `Search/Part1-Foundations/` | 1 | 1 |
| `Search/Part4-Metaheuristics/` | 2 | 2 |
| `Sudoku/` | 1 | 3 |
| `SymbolicAI/SMT/Z3-API/` | 1 | 1 |

934 notebooks scannés, **22 affectés**, scope totalement intra-main-repo (pas de submodule).

### Diagnostic — dette substance C548-L2

Le canon `record PlotlyHtml + Formatter.Register(...)` (C548-L2, introduit par mes PRs MERGED c.452/c.453/c.450 : #6694 DecInfer-6, #6695 GT-8c, #6696 Infer-12) émet du HTML Plotly brut avec un `<script src="https://cdn.plot.ly/plotly-2.35.2.min.js">` externe. **SOTA-OK en kernel .NET Interactive live** (VS Code / Jupyter Lab avec Internet), **mais blanc en static** :

- **GitHub notebook renderer** : sandboxé, n'exécute pas les `<script>` → `<div>` vide (sauf si sortie `image/png` en parallèle = GitHub fallback image).
- **Offline / nbviewer / CI sandbox** : CDN externe non chargé → `<div>` vide.
- **Le pendant Python (matplotlib `image/png`)** rend partout — les jumeaux **divergent**.

**Le C548-L2 canon était nécessaire** (contourne le `#r nuget: Plotly.NET` qui pin une vieille beta de `Microsoft.DotNet.Interactive` et timeout le restore — cf commentaire `cell[29]` DecInfer-6). **Mais il manque la sortie rasterisable** pour le rendu offline.

### Décision d'approche — 4 options évaluées

| Option | Description | Verdict |
|--------|-------------|---------|
| (a) Plotly.NET.ImageExport | Export PNG via Kaleido/ORCA | **REJETÉ** — `plotly.net.imageexport` absent du cache NuGet local ; risque restore timeout analogue à la charting-lib d'origine |
| (b) ScottPlot via `#r "nuget:ScottPlot,..."` | Bitmap natif | **RISQUÉ** — ScottPlot 5.0.55 a `HarfBuzzSharp.NativeAssets.Linux` en deps net6.0/net8.0 ; restore peut timeout (analogie C548-L2) |
| (c) System.Drawing.Common inline | Bitmap .NET natif Windows-only | **RISQUÉ** — Windows-only ; `System.Drawing.Common` est en `Microsoft.WindowsDesktop.App` sur .NET 9, pas garanti côté kernel .NET Interactive ; kill cross-platform |
| **(d) SVG inline via string** | Emit `image/svg+xml` output via Formatter custom | **RECOMMANDÉ** — Pattern déjà validé par `Search-10-SymbolicAutomata.ipynb` cell[24] (graphviz → `image/svg+xml` rendu GitHub OK). Zero NuGet. Cross-platform. Pure string concat C#. Le `image/svg+xml` est dans la whitelist MIME du renderer GitHub. |

**Décision tranchée** : **(d) SVG inline**. Le fix par notebook remplacera le `<script>Plotly.newPlot(...)</script>` par une émission `image/svg+xml` (string SVG sérialisée) via un nouveau `record PlotSvg(string Markup)` + `Formatter.Register` analogue au canon C548-L2 mais avec MIME `image/svg+xml` au lieu de `text/html`.

### Plan d'attaque — 22 notebooks, 1 PR par notebook (R3 atomique)

Le détecteur produit un **plan de remédiation** (`--fix-plan-out FILE`, sortie Markdown). Recommandation batch :

1. **Probas/Infer** (famille canonique de #6927) — `Infer-12-Modeles-Hierarchiques` en premier (c.450 canon, déjà couvert par ma PR #6696 — vérifier si scope-elargissement nécessaire)
2. **GameTheory/GameTheory-*Csharp** (6 nb) — cluster C548-L2, fix groupé acceptable (toujours 1 domaine, scope cohérent)
3. **Search/Applications/CSP** (App-7b, App-8)
4. **ML.Net** (ML-5-TimeSeries)
5. **Sudoku**, **SymbolicAI/SMT/Z3** (priorité basse)

**R3 atomique respecté** : 1 PR par notebook (max 2-3 fichiers, ≤3000L), pas de composite « 22 notebooks d'un coup » (G.4 split obligatoire).

### Scope du PR — detector seul

**Ce PR = detector seulement**, pas de fix notebook. Justification :
- **Séparation claire investigation / fix** : le détecteur est l'**infra** qui permet les 22 PRs de fix à venir (sert de baromètre + plan source).
- **Atomicité R3** : 1 fichier (script Python read-only, 10.7 KB LF-only CR=0), 1 sujet (detection), 1 domaine (notebook tooling). Loin sous G.4.
- **Pas de kernel exec** : le detector est Python pur, ne touche aucun notebook, ne lance aucun kernel .NET Interactive. Pas de risque Stop&Repair (rule 6 secrets-hygiene).

Les 22 PRs de fix viendront ensuite (1 par notebook ou 2-3 par famille si même canon infra partagé).

### Usage du detector

```bash
# Markdown table (default)
python scripts/notebook_tools/check_plotly_static_risk.py

# JSON output (CI-friendly)
python scripts/notebook_tools/check_plotly_static_risk.py --json

# CI gate : exit 1 si plus de N notebooks risky
python scripts/notebook_tools/check_plotly_static_risk.py --exit-risky-nb 0
# → utile pour fail-fast quand un nouveau Plotly-CDN est introduit

# Plan de remédiation auto-généré
python scripts/notebook_tools/check_plotly_static_risk.py --fix-plan-out /tmp/fix_plan_6927.md
```

### Doctrine appliquée

- **G.1 firsthand** : investigation par script + `python -c` qui scan + grep, **PAS** propagation du claim « 8 nb » de #6927 sans verify élargi.
- **sota-not-workaround Prong A** : aucun notebook committé en workaround dégradé ici (pas de cell-output hand-éditée, c'est un detector).
- **Stop & Repair (secrets-hygiene rule 6)** : **aucune** sortie de cellule touchée — detector purement read-only.
- **anti-regression §D** : deletions = 0, insertions = 0 sur code métier. Detector = nouveau fichier, 0 ligne supprimée.
- **harness-hygiene 3-tiers** : README succinct, plan d'attaque dans le detector (Markdown auto-gen), pas de log éphémère baké.
- **catalog-pr-hygiene R1** : `git diff | grep CATALOG` = vide, marqueur byte-identique à main.
- **R3 atomique** : 1 fichier Python, 1 dossier logique (`scripts/notebook_tools/`), 1 feature (détection Plotly-CDN-risque), 1 domaine (notebook tooling). ~270 lignes (commentaires inclus), bien sous 3000L.
- **L268 LF-only** : CR=0 sur le fichier.
- **C280-1 MD047** : newline final présent (`0a`).
- **C403-L1** : PR body via `--body-file`.
- **C444-L1 pré-flight** : `git log -1 scripts/notebook_tools/check_plotly_static_risk.py` = absent (fichier nouveau) ; `gh issue view 6927 --json state` = OPEN ✓ ; `gh pr list --search "check_plotly_static_risk"` = vide (pas de conflit).

### Refs

- `See #6927` (investigation Plotly-CDN blanc-en-statique, scope-restraint initial — ce PR élargit l'inventaire à 22 nb, le scope initial reste valide)
- `See #3801` (registre SOTA Prong-A — vrai outil jamais workaround)
- `See #1650` (épic traduction, hors scope mais cité pour plan.csv-pattern analogue)
- C548-L2 canon : MEMORY.md c.452/c.453/c.450 (PlotlyHtml + Formatter.Register)
- PRs antérieures touchées par la dette : #6694, #6695, #6696

🤖 Generated with [Claude Code](https://claude.com/claude-code)
