### PR TITLE
fix(genai-texte,#6912): complete Suivant >> chain on notebooks 9, 10, 11

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](README.md) | [<< Precedent](9_Production_Patterns.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](9_Production_Patterns.ipynb) | [Suivant >>](11_Quantization.ipynb)\n",
     "\n",
     "# 10. Hébergement Local de Modèles Génératifs\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "# 11. Quantization des LLMs\n",
     "\n",
-    "**Navigation** : [<< 10. Hebergement Local](10_LocalLlama.ipynb) | [Index](README.md)\n",
+    "**Navigation** : [<< 10. Hebergement Local](10_LocalLlama.ipynb) | [Index](README.md) | [Suivant >>](12_Test_Time_Scaling.ipynb)\n",
     "\n",
     "**Duree estimee** : 60 minutes\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "# Patterns de Production : APIs Avancées OpenAI\n",
     "\n",
-    "**Navigation** : [Index](README.md) | [<< Precedent](8_Reasoning_Models.ipynb)\n",
+    "**Navigation** : [Index](README.md) | [<< Precedent](8_Reasoning_Models.ipynb) | [Suivant >>](10_LocalLlama.ipynb)\n",
     "\n",
     "\n",
     "Ce notebook couvre les fonctionnalités avancées nécessaires pour des applications en production :\n",


### PR DESCRIPTION
## Resume
Fix Class-A slice de #6912 : complete la chaîne `Suivant >>` manquante sur les notebooks 9, 10, 11 de GenAI/Texte.

## Contexte
#6912 decompense en 3 classes :
- **Class-C** (stale `[Index]` paths) → fixee par #6913 (MERGED)
- **Class-B** (notebooks 13-18, 20 sans navlinks) → fixee par #6916 (MERGED)
- **Class-A** (chain `Suivant >>` incomplete sur 9, 10, 11, 12, 19) → cette PR (tête 9-11)

Verifie firsthand via Python avant edit : 9, 10, 11 ont `<< Precedent` mais pas de `Suivant >>`. Notebooks 12 et 19 ont deja leur chain (deja fixes par commits anterieurs) — pas de scope creep.

## Diff
3 fichiers, +3 / -3, exact 1 ligne ajoutee par notebook (cellule markdown Navigation only, C.2-safe — pas de re-execution de cellule code).

| Notebook | Avant | Apres |
|----------|-------|-------|
| 9_Production_Patterns | `<< 8_Reasoning_Models` | `<< 8_Reasoning_Models \| Suivant >> 10_LocalLlama` |
| 10_LocalLlama | `<< 9_Production_Patterns` | `<< 9_Production_Patterns \| Suivant >> 11_Quantization` |
| 11_Quantization (format inverse `<< 10. Hebergement Local` + Index au milieu) | preserve | append `Suivant >> 12_Test_Time_Scaling` |

Format de chaque notebook preserve tel quel (notebook 11 garde son layout `<< ` | Index | `Suivant >>`, normalisation differee a un futur PR dedie pour eviter le scope creep).

## Validation
- `git diff --stat` : 3 files / 3 insertions / 3 deletions, **aucune marque `\ No newline at end of file`** (byte-identique sur la structure peripherique du .ipynb)
- Pre-commit H.3 verifie via Python : C.1 clean (no raise NotImplementedError / assert False / 1/0), toutes les cellules code ont execution_count+outputs coherents
- Pre-commit hygiene : CRLF absent, BOM absent (UTF-8 LF), trailing newline des notebooks preservee pour ceux qui en avaient une (10, 11), absente pour 9 (qui n'en avait pas sur origin/main)
- C.2-safe : cellules modifiees = markdown only (pas de re-execution requise)

## Scope discipline
Atomique, 1 sujet (chain `Suivant >>` manquante), 3 fichiers, sous le seuil G.4 (3000 lignes / 15 fichiers). Pas de regen catalogue (catalog-pr-hygiene R1) — diff limite au chain navlinks.

Closes #6912 (la totality des 3 classes est fixee par #6913 + #6916 + cette PR).