### PR TITLE
docs(search,#5780): fix Prérequis QuikGraph Search-13→Search-16 + vision-audit 6/6 légendes Part1

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -93,7 +93,7 @@ Les fondamentaux de cette partie (formalisation, backtracking, heuristiques) son
 | `mealpy` | Search-11 (Métaheuristiques) |
 | `z3-solver` | Search-10 (Symbolic Automata) |
 | OpenSpiel | Search-7 (MCTS) : requiert WSL ou Linux |
-| `QuikGraph 2.5.0` (NuGet) | Search-13 (parité C#) : nécessite .NET Interactive, installable via `dotnet tool install --global Microsoft.dotnet-interactive` |
+| `QuikGraph 2.5.0` (NuGet) | Search-16 (parité C#) : nécessite .NET Interactive, installable via `dotnet tool install --global Microsoft.dotnet-interactive` |
 
 Pour le setup complet, voir le [README de la série Search](../README.md).
 


### PR DESCRIPTION
## Contexte

Audit fidélité légende↔image (issue #5780) des figures README de la série Search,
volet **Part1-Foundations**. Même axe que #6925 (ICT-Series, c.571) et #6508 (ML) :
lecture directe de chaque PNG via vision Opus-4.8 (lane po-2024 CPU sans GPU, mais
vision-capable), puis vérification que la légende décrit fidèlement ce que montre l'image.

## Résultat vision-audit : 6/6 légendes fidèles

Les 6 figures de `Part1-Foundations/README.md` ont été lues firsthand ; **toutes les
légendes sont exactes**, aucune correction de légende n'est nécessaire :

| Figure | Légende | Verdict |
|--------|---------|---------|
| `search1-statespace` | 8 états en grille, transitions colorées par action | exacte |
| `search2-bfs-dfs` | deux arbres binaires, nœuds numérotés par ordre d'exploration | exacte |
| `search3-astar` | états successifs annotés g/h/f | exacte |
| `search15-networkx` | réseau routier 5×5, arêtes pondérées, plus court chemin Dijkstra en rouge | exacte |
| `search11-metaheuristics` | fitness (log) et temps, par algorithme et fonction | exacte |
| `search11-convergence` | impact de la taille de population PSO : fitness et temps | exacte |

Contraste avec ICT-Series (#6925) qui portait 2 erreurs de légende : ici la prose
figure était déjà juste — **0 regen GPU, 0 hand-edit de sortie**.

## Correction livrée : renvoi Prérequis QuikGraph (L96)

L'audit **fichier-entier §E** (obligatoire, pas seulement la ligne touchée) a révélé
une erreur factuelle de renvoi dans le tableau des prérequis :

```diff
-| `QuikGraph 2.5.0` (NuGet) | Search-13 (parité C#) : nécessite .NET Interactive, ... |
+| `QuikGraph 2.5.0` (NuGet) | Search-16 (parité C#) : nécessite .NET Interactive, ... |
```

QuikGraph est le notebook **Search-16** (parité C# de Search-15-NetworkX), pas Search-13
(= `LimitedDiscrepancySearch`, dans Part3-Advanced).

**Vérification disque §E** (`git ls-tree`) :
- `Search-16-QuikGraph.ipynb` est bien dans `Part1-Foundations/` ✓
- `Search-13-LimitedDiscrepancySearch*` sont dans `Part3-Advanced/` ✓
- Tableau notebooks (L60), prose (L102), note de numérotation (L108) : **toutes cohérentes
  avec Search-16** — L96 était le **seul** renvoi erroné ✓

## Scope

- **docs-only**, français, LF-only.
- 1 fichier, 1 insertion / 1 suppression.
- Catalogue **byte-identique à main** (0 marqueur `CATALOG-STATUS` touché).
- Warnings markdown-lint pré-existants (MD060/MD033/MD037) non touchés (hors scope, cosmétiques).

See #5780 (axe fidélité-légende + correctness renvoi Prérequis ; l'épic reste ouverte).

---
🤖 po-2024 lane · vision-audit Opus-4.8 · c.572
