### PR TITLE
feat(notebook-tools,#3436): own papermill path leak in a pre-commit hook + one-time sweep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,23 @@ repos:
         pass_filenames: true
         files: '\.ipynb$'
         stages: [pre-commit]
+
+      - id: scrub-papermill-paths
+        name: Scrub absolute papermill input/output paths from staged notebooks
+        description: |
+          Rewrites metadata.papermill.input_path / output_path from an absolute
+          machine-local path (C:\Users\<user>\..., /home/<user>/..., WSL/temp
+          dirs) down to the notebook basename. Papermill records the absolute
+          --output path it was handed into the notebook metadata at EVERY
+          execution, so this machine-path leak is re-injected on each
+          re-execution regardless of the launcher (batch_reexecute, wsl_papermill,
+          or a hand-typed `papermill --output /abs/path`). Hand-patching it per
+          notebook is a treadmill wiped by the next run; this metadata-only
+          pre-commit strip is the durable owner (mirrors the probeAddresses and
+          NuGet-cache strip hooks above). Byte-surgical text edit: source cells,
+          outputs and execution_count are untouched. See #3436.
+        entry: python scripts/notebook_tools/scrub_papermill_paths.py --apply
+        language: system
+        pass_filenames: true
+        files: '\.ipynb$'
+        stages: [pre-commit]

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames-Csharp.ipynb
@@ -1466,7 +1466,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks\\GameTheory\\GameTheory-11-BayesianGames-Csharp.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\gt11_csharp_exec.ipynb",
+   "output_path": "GameTheory-11-BayesianGames-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-06T08:27:25.526621",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
@@ -932,7 +932,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp/gt4c_out.ipynb",
+   "output_path": "GameTheory-4c-NashExistence-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-06T08:47:46.509497+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb
@@ -1482,7 +1482,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust-Csharp.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/gt6_exec.ipynb",
+   "output_path": "GameTheory-6-EvolutionTrust-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-06T19:57:47.082433",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction-Csharp.ipynb
@@ -1427,7 +1427,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "GameTheory-9-BackwardInduction-Csharp.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/gt9_csharp_exec.ipynb",
+   "output_path": "GameTheory-9-BackwardInduction-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-06T09:29:32.070332",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb
@@ -1952,8 +1952,8 @@
    "end_time": "2026-07-10T18:54:32.960828",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\wt-genai03-5867\\MyIA.AI.Notebooks\\GenAI\\Image\\03-Orchestration\\03-2-Workflow-Orchestration.ipynb",
-   "output_path": "D:\\Dev\\wt-genai03-5867\\MyIA.AI.Notebooks\\GenAI\\Image\\03-Orchestration\\03-2-Workflow-Orchestration_output.ipynb",
+   "input_path": "03-2-Workflow-Orchestration.ipynb",
+   "output_path": "03-2-Workflow-Orchestration.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-16-MDLTwoPartCode.ipynb
@@ -942,8 +942,8 @@
    "end_time": "2026-07-08T11:36:59.964084+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\IIT\\ICT-Series\\ICT-16-MDLTwoPartCode.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\IIT\\ICT-Series\\ICT-16-MDLTwoPartCode_output.ipynb",
+   "input_path": "ICT-16-MDLTwoPartCode.ipynb",
+   "output_path": "ICT-16-MDLTwoPartCode.ipynb",
    "parameters": {},
    "start_time": "2026-07-08T11:36:50.884552+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb
@@ -1889,7 +1889,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Search/Applications/CSP/App-5-Timetabling-CSharp.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/App-5-Timetabling-CSharp-test.ipynb",
+   "output_path": "App-5-Timetabling-CSharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-07T05:17:04.319352",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata-Csharp.ipynb
@@ -1766,8 +1766,8 @@
    "end_time": "2026-07-08T06:06:24.212095+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-10-SymbolicAutomata-Csharp.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-10-SymbolicAutomata-Csharp_output.ipynb",
+   "input_path": "Search-10-SymbolicAutomata-Csharp.ipynb",
+   "output_path": "Search-10-SymbolicAutomata-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-08T06:06:04.994988+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part3.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part3.ipynb
@@ -1115,7 +1115,7 @@
    "end_time": "2026-07-06T04:55:57.461089",
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part3.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/3cb4a5e4-afad-4632-af95-d13a321e6664/scratchpad/s11c_out.ipynb",
+   "output_path": "Search-11b-Metaheuristiques-Deep-Part3.ipynb",
    "start_time": "2026-07-06T04:55:52.217477"
   }
  },

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part4.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part4.ipynb
@@ -991,7 +991,7 @@
    "end_time": "2026-07-06T05:28:44.790357",
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11b-Metaheuristiques-Deep-Part4.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/3cb4a5e4-afad-4632-af95-d13a321e6664/scratchpad/s11d_out.ipynb",
+   "output_path": "Search-11b-Metaheuristiques-Deep-Part4.ipynb",
    "start_time": "2026-07-06T05:28:39.853932"
   }
  },

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -3536,8 +3536,8 @@
    "end_time": "2026-07-09T22:54:04.626758+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\wt-c394-search3-prongb\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-3-Informed.ipynb",
-   "output_path": "D:\\dev\\wt-c394-search3-prongb\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-3-Informed_output.ipynb",
+   "input_path": "Search-3-Informed.ipynb",
+   "output_path": "Search-3-Informed.ipynb",
    "parameters": {},
    "start_time": "2026-07-09T22:53:50.724404+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
@@ -2655,7 +2655,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/c--dev-CoursIA-2/53aa98be-10aa-4031-be11-ff64ec023244/scratchpad/s9_execed2.ipynb",
+   "output_path": "Search-9-LinearProgramming.ipynb",
    "parameters": {},
    "start_time": "2026-07-12T14:13:11.610053+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -3168,8 +3168,8 @@
    "end_time": "2026-07-11T14:28:47.886916+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-c431\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-1-Fundamentals.ipynb",
-   "output_path": "D:\\dev\\CoursIA-c431\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-1-Fundamentals_output.ipynb",
+   "input_path": "CSP-1-Fundamentals.ipynb",
+   "output_path": "CSP-1-Fundamentals.ipynb",
    "parameters": {},
    "start_time": "2026-07-11T14:28:36.770292+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb
@@ -1149,7 +1149,7 @@
    "end_time": "2026-07-06T06:23:06.061749",
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction-Csharp.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/claude/d--Dev-CoursIA/3cb4a5e4-afad-4632-af95-d13a321e6664/scratchpad/planners1_out.ipynb",
+   "output_path": "Planners-1-Introduction-Csharp.ipynb",
    "start_time": "2026-07-06T06:23:01.260135"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics-Csharp.ipynb
@@ -1187,7 +1187,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks\\SymbolicAI\\Planners\\02-Classical\\Planners-5-Heuristics-Csharp.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\planners5_csharp_exec.ipynb",
+   "output_path": "Planners-5-Heuristics-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-06T08:51:57.219449",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb
@@ -2401,8 +2401,8 @@
    "end_time": "2026-07-07T00:50:48.898290",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-8-CSharp-SHACL.ipynb",
-   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-8-CSharp-SHACL_output.ipynb",
+   "input_path": "SW-8-CSharp-SHACL.ipynb",
+   "output_path": "SW-8-CSharp-SHACL.ipynb",
    "parameters": {},
    "start_time": "2026-07-07T00:50:44.270454",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
@@ -1359,8 +1359,8 @@
    "end_time": "2026-07-08T06:34:03.552156+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-1-LogicalLearning-Csharp.ipynb",
-   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-1-LogicalLearning-Csharp_output.ipynb",
+   "input_path": "SL-1-LogicalLearning-Csharp.ipynb",
+   "output_path": "SL-1-LogicalLearning-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-08T06:33:48.592745+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
@@ -1068,7 +1068,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp/sl2_out.ipynb",
+   "output_path": "SL-2-KnowledgeBasedLearning-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-06T06:23:07.140506+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb
@@ -1964,7 +1964,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sl4_exec.ipynb",
+   "output_path": "SL-4-InductiveLogicProgramming-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-06T20:22:29.174326",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
@@ -1056,7 +1056,7 @@
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp/sl5_out.ipynb",
+   "output_path": "SL-5-InverseResolution-Csharp.ipynb",
    "parameters": {},
    "start_time": "2026-07-06T07:56:51.628105+00:00",
    "version": "2.7.0"

--- a/scripts/notebook_tools/scrub_papermill_paths.py
+++ b/scripts/notebook_tools/scrub_papermill_paths.py
@@ -380,7 +380,10 @@ def main():
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--scan", metavar="PATH", help="dry-run scan a file or dir")
     group.add_argument("--scan-all", action="store_true", help="dry-run scan repo-wide")
-    group.add_argument("--apply", metavar="PATH", help="fix a file or dir in place")
+    group.add_argument("--apply", metavar="PATH", nargs="+",
+                       help="fix file(s) or dir(s) in place (accepts multiple "
+                            "paths, so it can be wired as a pre-commit hook that "
+                            "receives the staged notebooks as trailing arguments)")
     group.add_argument("--apply-all", action="store_true", help="fix repo-wide in place")
     parser.add_argument("--outputs", action="store_true",
                         help="scrub machine-local paths in OUTPUT text "
@@ -393,17 +396,30 @@ def main():
     nb_root = os.path.join(repo_root, "MyIA.AI.Notebooks")
 
     do_apply = args.apply is not None or args.apply_all
-    target = args.apply if args.apply else (args.scan if args.scan else nb_root)
 
     paths = []
     if args.scan_all or args.apply_all:
         paths = list(iter_notebooks(nb_root))
-    elif os.path.isdir(target):
-        paths = list(iter_notebooks(target))
-    elif os.path.isfile(target):
-        paths = [target]
     else:
-        parser.error("path not found: %s" % target)
+        # --apply is nargs="+" (a list; a pre-commit hook appends the staged
+        # notebooks here). --scan is a single path. Default to the notebook root.
+        targets = args.apply if args.apply else ([args.scan] if args.scan else [nb_root])
+        for target in targets:
+            if os.path.isdir(target):
+                paths.extend(iter_notebooks(target))
+            elif os.path.isfile(target):
+                paths.append(target)
+            else:
+                parser.error("path not found: %s" % target)
+        paths = list(dict.fromkeys(paths))  # de-dup while preserving order
+
+    def _display(pp):
+        # relpath raises ValueError across Windows drives (e.g. a file on C:
+        # while the repo is on D:). Display-only, so fall back to the abs path.
+        try:
+            return os.path.relpath(pp, repo_root)
+        except ValueError:
+            return pp
 
     total_defects = 0
     total_fixed = 0
@@ -418,7 +434,7 @@ def main():
             files_with_defect += 1
             total_defects += found
             total_fixed += fixed
-            rel = os.path.relpath(p, repo_root)
+            rel = _display(p)
             tag = "FIXED" if do_apply and fixed else ("DEFECT" if not do_apply else "PARTIAL")
             print("[%s] %s  (%d output leak(s)%s)" % (
                 tag, rel, found, ", %d fixed" % fixed if do_apply else ""))
@@ -429,7 +445,7 @@ def main():
             continue
         files_with_defect += 1
         total_defects += len(defects)
-        rel = os.path.relpath(p, repo_root)
+        rel = _display(p)
         if do_apply:
             unfixed = [d for d in defects if d not in fixed]
             total_fixed += len(fixed)

--- a/scripts/notebook_tools/tests/test_scrub_papermill_paths.py
+++ b/scripts/notebook_tools/tests/test_scrub_papermill_paths.py
@@ -498,3 +498,75 @@ def test_scrub_outputs_repo_regex_does_not_span_newlines(tmp_path):
     assert out_text.count("proj") == 2
     # source cell byte-identical
     assert json.loads(after)["cells"][0]["source"] == ["show()"]
+
+
+# ---------------------------------------------------------------------------
+# CLI contract: --apply accepts a LIST of paths (the pre-commit-hook wiring).
+# pre-commit runs `... scrub_papermill_paths.py --apply <file1> <file2> ...`
+# with pass_filenames: true, so the tool must fix every staged notebook in a
+# single invocation, not just the first. tmp_path is typically on a different
+# Windows drive than the repo, which also exercises the cross-drive relpath
+# guard (_display) in main().
+# ---------------------------------------------------------------------------
+
+import subprocess
+
+_SCRIPT = str(Path(__file__).resolve().parent.parent / "scrub_papermill_paths.py")
+
+
+def _write_leaked(path: Path, name: str) -> Path:
+    absp = "C:/Users/jsboi/CoursIA/%s.ipynb" % name
+    return _write_nb(path, pm={"input_path": absp, "output_path": absp})
+
+
+def _pm(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))["metadata"]["papermill"]
+
+
+def test_cli_apply_scrubs_multiple_files_in_one_invocation(tmp_path):
+    a = _write_leaked(tmp_path / "nbA.ipynb", "nbA")
+    b = _write_leaked(tmp_path / "nbB.ipynb", "nbB")
+    r = subprocess.run(
+        [sys.executable, _SCRIPT, "--apply", str(a), str(b)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    # BOTH files scrubbed to their basename, not just the first positional arg.
+    for p, name in ((a, "nbA.ipynb"), (b, "nbB.ipynb")):
+        pm = _pm(p)
+        assert pm["input_path"] == name
+        assert pm["output_path"] == name
+
+
+def test_cli_apply_leaves_clean_notebook_untouched(tmp_path):
+    leaked = _write_leaked(tmp_path / "leaked.ipynb", "leaked")
+    clean = _write_nb(tmp_path / "clean.ipynb", pm={"output_path": "clean.ipynb"})
+    clean_before = clean.read_bytes()
+    r = subprocess.run(
+        [sys.executable, _SCRIPT, "--apply", str(leaked), str(clean)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert _pm(leaked)["output_path"] == "leaked.ipynb"
+    # A notebook with no absolute papermill path is a byte-for-byte no-op.
+    assert clean.read_bytes() == clean_before
+
+
+def test_cli_apply_is_idempotent(tmp_path):
+    a = _write_leaked(tmp_path / "nbA.ipynb", "nbA")
+    for _ in range(2):
+        r = subprocess.run(
+            [sys.executable, _SCRIPT, "--apply", str(a)],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 0, r.stderr
+    assert _pm(a)["output_path"] == "nbA.ipynb"
+
+
+def test_cli_apply_requires_at_least_one_path(tmp_path):
+    r = subprocess.run(
+        [sys.executable, _SCRIPT, "--apply"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode != 0
+    assert "at least one argument" in r.stderr


### PR DESCRIPTION
## Problème (steer user 2026-07-17 sur #6928)

papermill inscrit le chemin `--output` **absolu** qu'on lui passe dans
`metadata.papermill.{input,output}_path` à **chaque exécution**. Ce chemin
machine-local est donc **ré-injecté à chaque ré-exécution**, quel que soit le
lanceur : `batch_reexecute.py`, `wsl_papermill.py`, ou un `papermill --output
/abs/path` tapé à la main. Le corriger notebook-par-notebook (ex. #6928) est un
tapis roulant : la fuite revient au prochain run. Le user l'a signalé :

> *le pb doit être résolu à la source dans les outils utilisés, plutôt que
> patché de façon ad-hoc … s'il faut passer par une PR de deleak à chaque
> nouvelle exécution, ça n'est plus vraiment du deleak.*

po-2025 (sur #6928) a **correctement diagnostiqué** *quoi* fuit ; cette PR
corrige *où* : au niveau de l'outil, une fois pour toutes.

## Fix durable — un 3e hook pre-commit

Le dépôt possède déjà **deux** hooks pre-commit qui strippent la même classe de
fuite « ré-injectée à chaque run » : `strip-probeaddresses-banner` (#2727/#6309)
et `strip-dotnet-nuget-ext` (#6529). Il manquait l'équivalent pour les chemins
papermill. Cette PR l'ajoute, en miroir exact :

- **`.pre-commit-config.yaml`** : hook local `scrub-papermill-paths`
  (`entry: python scripts/notebook_tools/scrub_papermill_paths.py --apply`,
  `pass_filenames: true`, `files: '\.ipynb$'`). Édition **métadonnée seule,
  byte-chirurgicale** : cellules source, `outputs`, `execution_count` intacts.
- **`scrub_papermill_paths.py`** : `--apply` prend désormais `nargs="+"` pour
  recevoir la liste des notebooks stagés qu'un hook `pass_filenames: true`
  ajoute en arguments. La forme mono-chemin (`--apply <file>|<dir>`) marche
  toujours. `main()` itère la liste, dé-duplique ; un `relpath` cross-drive
  Windows (fichier sur C: alors que le repo est sur D:) ne lève plus —
  `_display()` retombe sur le chemin absolu (affichage seul).
- **tests** : 4 tests de contrat CLI (multi-fichiers en une invocation, no-op
  sur fichier propre, idempotence, `--apply` exige ≥1 chemin). **29/29 vert**.

### Preuve end-to-end (pre-commit 4.5.1)

```
$ pre-commit run scrub-papermill-paths --files <notebook stagé fuité>
Scrub absolute papermill input/output paths from staged notebooks....Failed
- hook id: scrub-papermill-paths
- files were modified by this hook
[FIXED] ...  output_path: C:/Users/.../probe_out.ipynb -> <basename>.ipynb
             input_path:  C:/Users/.../probe_out.ipynb -> <basename>.ipynb
```

Le hook scrubbe, signale « files were modified » (exit 1 → le commit est bloqué
jusqu'à re-stage), `execution_count` + sortie de cellule préservés. Comme les
deux hooks frères, plus aucune PR de de-leak papermill n'est nécessaire, **quel
que soit le mode d'exécution** du notebook.

## Balayage unique (commit 2)

`scrub_papermill_paths.py --apply-all` une fois → 20 notebooks / 27 chemins
absolus existants nettoyés d'un coup (au lieu du goutte-à-goutte 3-par-3 de
#6928). Diff **métadonnée seule** : chaque ligne changée est `input_path`/
`output_path` uniquement ; 0 ligne `execution_count`/`outputs`/`source` ;
delta 1+/1− ou 2+/2− par fichier. **Catalogue byte-identique à main.**

## Gates
- [x] Byte-surgical : outputs + execution_count intacts (C.2 préservée, pas de ré-exécution → C.3 N/A, pas de hand-edit de sortie de cellule — `metadata.papermill` = bookkeeping niveau-notebook, la classe sanctionnée des hooks frères).
- [x] Catalogue non touché (byte-identique à main).
- [x] Tests 29/29 ; hook prouvé end-to-end sous pre-commit 4.5.1.
- [x] Pas de force push ; branche `feature/`.

Supersedes #6928 (de-leak ad-hoc 3 notebooks). See #3436 (fuite papermill,
fermée sur balayages ponctuels #3435/#3436 qui n'ont pas tenu — ré-injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
