### PR TITLE
feat(security,#16): audit_exposed_services.py — tier API probe extension (14 compose + 5 ORPHELIN-DNS)

### DIFF
--- a/scripts/security/audit_exposed_services.py
+++ b/scripts/security/audit_exposed_services.py
@@ -16,12 +16,16 @@ Distinguishes three categories of debt (audit c.442, 2026-07-14):
                     ghost subdomain.
 
 Usage:
-    python audit_exposed_services.py                  # run full probe
+    python audit_exposed_services.py                  # run all tiers (webui + api)
+    python audit_exposed_services.py --tier api       # run only API tier
+    python audit_exposed_services.py --tier webui     # run only WebUI tier (legacy default)
     python audit_exposed_services.py --json out.json  # machine-readable output
     python audit_exposed_services.py --md report.md   # markdown report
 
 Sourced from issue #16 (sécurisation services IA exposés publiquement).
-First audit run by po-2023, cycle c.442, 2026-07-14T~14:00Z.
+First audit run by po-2023, cycle c.442, 2026-07-14T~14:00Z (tier WebUI).
+Tier API added by po-2026, cycle c.615, 2026-07-16 (12 services compose-driven
++ 5 ORPHELIN-DNS external — issue #16 §APIs nécessitant des tokens).
 Pattern mirror: scripts/notebook_tools/scan_md_hierarchy.py (render-agnostic,
 machine-readable summary line per finding, plus human report).
 """
@@ -35,13 +39,23 @@ import sys
 import time
 import urllib.request
 import urllib.error
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
-# Tier WebUI login natif — full set of exposed services to probe.
-# Each tier entry: (subdomain, compose_dir, auth_endpoint_probe)
-#   compose_dir: relative to docker-configurations/services/, or None if no compose.
-#   auth_endpoint_probe: URL to test for API auth, or None if not applicable.
-DEFAULT_TIER = [
+# A tier entry is a 3- or 4-tuple:
+#   (subdomain, compose_dir, api_endpoint[, local_port])
+#   compose_dir:    relative to docker-configurations/services/, or None if no
+#                  compose. When None, the service falls into ORPHELIN-DNS
+#                  (DNS resolves + reverse-proxy routes, but no compose file).
+#   api_endpoint:   URL path to test for API auth (localhost probe via
+#                  reverse-proxy bypass), or None if not applicable.
+#   local_port:     local backend port the API listens on (defaults to 1111
+#                  for backward compat with forge-turbo legacy default).
+TierEntry = Union[Tuple[str, Optional[str], Optional[str]],
+                  Tuple[str, Optional[str], Optional[str], int]]
+
+# Tier WebUI login natif (c.442 #6564) — full set of exposed services to probe.
+# Legacy 3-tuple shape; local_port defaults to DEFAULT_LOCAL_PORT (1111).
+DEFAULT_TIER: List[TierEntry] = [
     # (subdomain, expected_compose, api_endpoint_probe)
     ("stable-diffusion-webui-forge.myia.io", "forge-turbo", "/sdapi/v1/options"),
     ("sdnext.myia.io", "sdnext", None),
@@ -51,8 +65,72 @@ DEFAULT_TIER = [
     ("large.text-generation-webui.myia.io", None, None),
 ]
 
+# Alias for clarity (webui tier == legacy default tier). Added c.615 so that
+# future callers can reference WEBUI_TIER by name rather than DEFAULT_TIER.
+WEBUI_TIER: List[TierEntry] = DEFAULT_TIER
+
+# Tier API (c.615, this commit) — services listed in issue #16 §"APIs nécessitant
+# des tokens" + adjacent compose-driven services in docker-configurations/services/.
+# Local ports extracted from each service's docker-compose.yml header comment
+# (`# Port: NNNN`) verified firsthand 2026-07-16 (po-2026, c.615).
+#
+# Three sub-categories:
+#   (a) compose-driven (whisper-api, tts-api, etc.) — we can audit from here.
+#   (b) ORPHELIN-DNS external (mcp-tools, skagents, embeddings, qdrant, search)
+#       — DNS resolves + reverse-proxy routes, but no compose file in this
+#       repo. Flagged so that the runbook can route the audit to the
+#       appropriate machine tier.
+#
+# API endpoints probed via `localhost:<port><api_endpoint>` to bypass the
+# IIS reverse-proxy and hit the backend directly (same pattern as c.442).
+API_TIER: List[TierEntry] = [
+    # (subdomain, compose_dir, api_endpoint, local_port)
+    # (a) compose-driven API services — 12 entries
+    ("whisper-api.myia.io", "whisper-api", "/health", 8190),
+    ("whisper-api.myia.io", "whisper-api", "/v1/models", 8190),  # OpenAI-compat probe
+    ("tts-api.myia.io", "tts-api", "/health", 8191),
+    ("tts-api.myia.io", "tts-api", "/v1/voices", 8191),  # service-specific probe
+    ("musicgen-api.myia.io", "musicgen-api", "/health", 8192),
+    ("demucs-api.myia.io", "demucs-api", "/health", 8193),
+    ("funasr-api.myia.io", "funasr-api", "/health", 8194),
+    ("qwen-asr-api.myia.io", "qwen-asr-api", "/health", 8195),
+    ("tts-multi.myia.io", "tts-multi", "/health", 8196),
+    ("tts-fishaudio.myia.io", "tts-fishaudio", "/health", 8197),
+    ("vllm-zimage.myia.io", "vllm-zimage", "/v1/models", 8001),  # OpenAI-compat
+    ("comfyui-qwen.myia.io", "comfyui-qwen", "/system_stats", 8188),
+    ("comfyui-video.myia.io", "comfyui-video", "/system_stats", 8189),
+    ("orchestrator.myia.io", "orchestrator", "/health", 8090),
+    # (b) ORPHELIN-DNS external services — 5 entries, no compose in this repo
+    ("mcp-tools.myia.io", None, None, 0),
+    ("skagents.myia.io", None, None, 0),
+    ("embeddings.myia.io", None, None, 0),
+    ("qdrant.myia.io", None, None, 0),
+    ("search.myia.io", None, None, 0),
+]
+
 DEFAULT_TIMEOUT = 5.0
-DEFAULT_USER_AGENT = "CoursIA-AuditExposedServices/1.0 (po-2023, #16)"
+DEFAULT_USER_AGENT = "CoursIA-AuditExposedServices/1.0 (po-2026, #16)"
+DEFAULT_LOCAL_PORT = 1111  # forge-turbo legacy default (c.442)
+ALL_TIERS: Dict[str, List[TierEntry]] = {
+    "webui": WEBUI_TIER,
+    "api": API_TIER,
+}
+
+
+def normalize_entry(entry: TierEntry) -> Tuple[str, Optional[str], Optional[str], int]:
+    """Promote a 3-tuple entry to a 4-tuple with local_port defaulted.
+
+    Backward compatibility for tests/callers using the legacy 3-tuple shape
+    (c.442 #6564). New API_TIER entries use the 4-tuple shape explicitly.
+    """
+    if len(entry) == 4:
+        return entry
+    if len(entry) == 3:
+        subdomain, compose_dir, api_endpoint = entry
+        return (subdomain, compose_dir, api_endpoint, DEFAULT_LOCAL_PORT)
+    raise ValueError(
+        f"TierEntry must be 3- or 4-tuple, got {len(entry)}-tuple: {entry!r}"
+    )
 
 
 def dns_resolves(host: str) -> Tuple[bool, Optional[str]]:
@@ -100,12 +178,19 @@ def container_running(compose_dir: Optional[str]) -> bool:
         return False
 
 
-def probe_api_auth(api_endpoint: Optional[str], port: int = 1111, timeout: float = DEFAULT_TIMEOUT) -> str:
+def probe_api_auth(api_endpoint: Optional[str], port: int = DEFAULT_LOCAL_PORT,
+                   timeout: float = DEFAULT_TIMEOUT) -> str:
     """Test API auth on a known local port (proxy bypass).
 
-    Returns one of: 'OPEN' (no auth), 'PROTECTED' (401/403), 'N/A' (no probe configured).
+    Returns one of: 'OPEN' (no auth), 'PROTECTED' (401/403), 'N/A' (no probe
+    configured), 'ERR(<code>)' for other non-200/non-401/non-403 responses.
+
+    Accepts port=0 as 'skip' (used by ORPHELIN-DNS external services — see
+    issue #16 §APIs nécessitant des tokens). In that case returns 'N/A'
+    unconditionally, since we cannot reach a backend that has no compose
+    file in this repo.
     """
-    if not api_endpoint:
+    if not api_endpoint or port == 0:
         return "N/A"
     url = f"http://localhost:{port}{api_endpoint}"
     code, _ = http_probe(url, timeout=timeout)
@@ -117,7 +202,7 @@ def probe_api_auth(api_endpoint: Optional[str], port: int = 1111, timeout: float
 
 
 def classify_subdomain(subdomain: str, compose_dir: Optional[str], api_endpoint: Optional[str],
-                       local_port: int = 1111) -> Dict[str, object]:
+                       local_port: int = DEFAULT_LOCAL_PORT) -> Dict[str, object]:
     """Run all probes and return a single finding dict."""
     resolves, ip = dns_resolves(subdomain)
     http_code, headers = http_probe(f"https://{subdomain}", timeout=DEFAULT_TIMEOUT)
@@ -154,23 +239,44 @@ def classify_subdomain(subdomain: str, compose_dir: Optional[str], api_endpoint:
         "api_auth": api_auth,
         "redirect": headers.get("Location", ""),
         "server": headers.get("Server", ""),
+        "local_port": local_port,  # new c.615: which port was probed
+        "compose_dir": compose_dir,  # new c.615: aid triage of ORPHELIN-START/DNS
     }
 
 
-def run_audit(tier: List[Tuple[str, Optional[str], Optional[str]]] = None,
-              local_port: int = 1111) -> List[Dict[str, object]]:
-    """Run the full audit and return list of findings."""
+def run_audit(tier: Optional[List[TierEntry]] = None,
+              local_port: int = DEFAULT_LOCAL_PORT) -> List[Dict[str, object]]:
+    """Run the full audit and return list of findings.
+
+    When `tier` is None, defaults to WEBUI_TIER (== legacy DEFAULT_TIER) for
+    backward compatibility with c.442 callers and tests. New code should
+    pass an explicit tier (WEBUI_TIER, API_TIER, or pass the union of both).
+    Per-entry `local_port` from the tier tuple takes precedence over the
+    function-level `local_port` argument.
+    """
     if tier is None:
-        tier = DEFAULT_TIER
+        tier = WEBUI_TIER
     findings = []
-    for subdomain, compose_dir, api_endpoint in tier:
-        f = classify_subdomain(subdomain, compose_dir, api_endpoint, local_port=local_port)
+    for entry in tier:
+        subdomain, compose_dir, api_endpoint, entry_port = normalize_entry(entry)
+        # Per-entry port overrides function-level default — supports mixed-port
+        # tiers where each service listens on its own port.
+        effective_port = entry_port if entry_port != DEFAULT_LOCAL_PORT else local_port
+        f = classify_subdomain(
+            subdomain, compose_dir, api_endpoint,
+            local_port=effective_port,
+        )
         findings.append(f)
     return findings
 
 
 def render_markdown(findings: List[Dict[str, object]], tier_name: str = "tier WebUI login natif") -> str:
-    """Render a markdown audit report (mirror c.442 layout)."""
+    """Render a markdown audit report (mirror c.442 layout).
+
+    Header reflects tier_name (e.g. 'tier WebUI login natif', 'tier API',
+    'tous tiers (WebUI + API)'). Local port column added in c.615 so operators
+    can see which port was probed for each service.
+    """
     lines = [
         f"# Audit `*.myia.io` — {tier_name}",
         "",
@@ -179,8 +285,8 @@ def render_markdown(findings: List[Dict[str, object]], tier_name: str = "tier We
         "",
         "## Résultats",
         "",
-        "| Subdomain | DNS | HTTP ext. | Backend | Auth UI | Auth API | Catégorie |",
-        "|-----------|-----|-----------|---------|---------|----------|-----------|",
+        "| Subdomain | DNS | HTTP ext. | Backend | Auth UI | Auth API | Port | Catégorie |",
+        "|-----------|-----|-----------|---------|---------|----------|------|-----------|",
     ]
     for f in findings:
         dns = "OK" if f["dns_resolves"] else "FAIL"
@@ -192,9 +298,12 @@ def render_markdown(findings: List[Dict[str, object]], tier_name: str = "tier We
             "OK" if f["redirect"].endswith("/login")
             else ("n/a" if not f["container_running"] else "?")
         )
+        # Format the port column: 0 means "skipped" (ORPHELIN-DNS external).
+        port = f.get("local_port", DEFAULT_LOCAL_PORT)
+        port_str = str(port) if port else "—"
         lines.append(
             f"| `{f['subdomain']}` | {dns} | {f['http_external']} | {backend} | {auth_ui} | "
-            f"{f['api_auth']} | **{f['category']}** |"
+            f"{f['api_auth']} | {port_str} | **{f['category']}** |"
         )
     lines.extend([
         "",
@@ -208,27 +317,49 @@ def render_markdown(findings: List[Dict[str, object]], tier_name: str = "tier We
         "",
         "## Sourced from",
         "",
-        "Issue #16 — po-2023, cycle c.442, 2026-07-14T~14:00Z. Mirror de `scripts/notebook_tools/scan_md_hierarchy.py`.",
+        "Issue #16 — WebUI tier po-2023 c.442 2026-07-14 (#6564).",
+        "API tier extension po-2026 c.615 2026-07-16.",
+        "Mirror de `scripts/notebook_tools/scan_md_hierarchy.py`.",
     ])
     return "\n".join(lines) + "\n"
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description="Audit `*.myia.io` services for auth state.")
+    parser = argparse.ArgumentParser(
+        description="Audit `*.myia.io` services for auth state (tier WebUI + tier API).",
+    )
+    parser.add_argument("--tier", choices=("webui", "api", "all"), default="all",
+                        help="Which tier to audit: 'webui' (login natif, c.442), "
+                             "'api' (services API compose-driven, c.615), "
+                             "or 'all' (default).")
     parser.add_argument("--json", metavar="PATH", help="Write JSON findings to PATH")
     parser.add_argument("--md", metavar="PATH", help="Write markdown report to PATH")
-    parser.add_argument("--local-port", type=int, default=1111,
-                        help="Local backend port for API auth probe (default: 1111, forge-turbo)")
+    parser.add_argument("--local-port", type=int, default=DEFAULT_LOCAL_PORT,
+                        help="Fallback local backend port (default: 1111, forge-turbo). "
+                             "Per-entry ports in API_TIER override this.")
     parser.add_argument("--quiet", action="store_true", help="Suppress stdout output")
     args = parser.parse_args(argv)
 
-    findings = run_audit(local_port=args.local_port)
+    # Tier selection. 'all' concatenates WEBUI_TIER and API_TIER in that order,
+    # so the audit report reads WebUI first (c.442 baseline) then API.
+    if args.tier == "webui":
+        tier = WEBUI_TIER
+        tier_name = "tier WebUI login natif"
+    elif args.tier == "api":
+        tier = API_TIER
+        tier_name = "tier API (compose-driven + ORPHELIN-DNS)"
+    else:
+        tier = WEBUI_TIER + API_TIER
+        tier_name = "tous tiers (WebUI + API)"
+
+    findings = run_audit(tier=tier, local_port=args.local_port)
 
     if not args.quiet:
         # Compact stdout summary
         for f in findings:
-            print(f"  {f['subdomain']:50s} → {f['category']:15s} (HTTP={f['http_external']}, "
-                  f"container={f['container_running']}, api_auth={f['api_auth']})")
+            print(f"  {f['subdomain']:45s} → {f['category']:15s} "
+                  f"(HTTP={f['http_external']}, container={f['container_running']}, "
+                  f"api_auth={f['api_auth']}, port={f['local_port']})")
 
     if args.json:
         with open(args.json, "w", encoding="utf-8") as fp:
@@ -238,7 +369,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if args.md:
         with open(args.md, "w", encoding="utf-8") as fp:
-            fp.write(render_markdown(findings))
+            fp.write(render_markdown(findings, tier_name=tier_name))
         if not args.quiet:
             print(f"Markdown written to {args.md}")
 

--- a/scripts/tests/test_audit_exposed_services.py
+++ b/scripts/tests/test_audit_exposed_services.py
@@ -29,11 +29,15 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from security.audit_exposed_services import (  # noqa: E402
     DEFAULT_TIER,
+    WEBUI_TIER,
+    API_TIER,
+    DEFAULT_LOCAL_PORT,
     classify_subdomain,
     compose_exists,
     container_running,
     dns_resolves,
     http_probe,
+    normalize_entry,
     probe_api_auth,
     render_markdown,
     run_audit,
@@ -270,3 +274,145 @@ def test_default_tier_covers_forge_sdnext_and_text_gen():
     assert "sdnext.myia.io" in subdomains
     text_gen = [s for s in subdomains if "text-generation-webui.myia.io" in s]
     assert len(text_gen) == 4  # micro/mini/medium/large
+
+
+# --- API_TIER (c.615) — round-trip OUTPUT-content (L498) ---
+# Each test asserts on the dict/finding shape produced by the new code path,
+# not just detection booleans. Tests use mock fixtures so they don't depend
+# on whether whisper-api containers are actually running on the worker machine.
+
+def test_api_tier_covers_all_16_apis_from_issue_16():
+    """API_TIER must cover the 9 services in issue #16 §APIs nécessitant tokens
+    (whisper/tts/musicgen/demucs/mcp-tools/skagents/embeddings/qdrant/search)
+    plus adjacent compose-driven services (comfyui-qwen/comfyui-video/orchestrator).
+    """
+    subdomains = [entry[0] for entry in API_TIER]
+    # issue #16 §APIs (must-haves):
+    for required in ("whisper-api.myia.io", "tts-api.myia.io", "musicgen-api.myia.io",
+                     "demucs-api.myia.io", "mcp-tools.myia.io", "skagents.myia.io",
+                     "embeddings.myia.io", "qdrant.myia.io", "search.myia.io"):
+        assert required in subdomains, f"missing required service {required}"
+    # Adjacent compose-driven services:
+    for adjacent in ("comfyui-qwen.myia.io", "comfyui-video.myia.io",
+                     "orchestrator.myia.io"):
+        assert adjacent in subdomains, f"missing adjacent compose {adjacent}"
+
+
+def test_api_tier_each_entry_has_local_port_int():
+    """Every API_TIER entry must be a 4-tuple with explicit local_port (issue #16
+    category spans many different backend ports — Whisper=8190, TTS=8191, …)."""
+    for entry in API_TIER:
+        assert len(entry) == 4, f"entry not 4-tuple: {entry!r}"
+        subdomain, compose_dir, api_endpoint, port = entry
+        assert isinstance(port, int), f"port not int in {entry!r}"
+        # ORPHELIN-DNS external entries use port=0 as skip-sentinel
+        if compose_dir is None:
+            assert port == 0, f"ORPHELIN-DNS entry {entry!r} must use port=0"
+
+
+def test_orphelin_dns_external_services_have_no_compose():
+    """5 external services (mcp-tools/skagents/embeddings/qdrant/search) have
+    no compose_dir — they fall into ORPHELIN-DNS when DNS resolves but no
+    compose file exists in this repo. Round-trip on actual shape."""
+    externals = [entry for entry in API_TIER if entry[0]
+                 in ("mcp-tools.myia.io", "skagents.myia.io",
+                     "embeddings.myia.io", "qdrant.myia.io", "search.myia.io")]
+    assert len(externals) == 5
+    for entry in externals:
+        assert entry[1] is None, f"{entry[0]} must have compose_dir=None"
+        assert entry[2] is None, f"{entry[0]} must have api_endpoint=None"
+        assert entry[3] == 0, f"{entry[0]} must have local_port=0 (skip sentinel)"
+
+
+def test_normalize_entry_3_tuple_promotes_to_4_with_default_port():
+    """Backward compat: legacy 3-tuple entries (c.442) must still work — promote
+    to 4-tuple with DEFAULT_LOCAL_PORT (=1111, forge-turbo)."""
+    promoted = normalize_entry(("forge.myia.io", "forge-turbo", "/sdapi/v1/options"))
+    assert len(promoted) == 4
+    assert promoted[3] == DEFAULT_LOCAL_PORT
+
+
+def test_normalize_entry_4_tuple_passes_through():
+    """4-tuple entries must pass through unchanged."""
+    entry = ("whisper-api.myia.io", "whisper-api", "/health", 8190)
+    assert normalize_entry(entry) == entry
+
+
+def test_normalize_entry_rejects_invalid_arity():
+    """Anything other than 3- or 4-tuple must raise ValueError loudly."""
+    import pytest
+    with pytest.raises(ValueError, match="TierEntry must be 3- or 4-tuple"):
+        normalize_entry(("only", "two"))
+    with pytest.raises(ValueError, match="TierEntry must be 3- or 4-tuple"):
+        normalize_entry(("one",))
+
+
+def test_probe_api_auth_port_zero_returns_na():
+    """ORPHELIN-DNS external entries use port=0 as the skip-sentinel. The
+    probe must short-circuit to 'N/A' without contacting localhost."""
+    assert probe_api_auth(None, port=0) == "N/A"
+    assert probe_api_auth("/some/endpoint", port=0) == "N/A"
+
+
+def test_run_audit_api_tier_returns_findings_with_local_port_set():
+    """When run_audit is called with API_TIER, each finding must include
+    local_port field (round-trip on new c.615 output key). Mocks prevent
+    real network/probes."""
+    fake_finding_whisper = {
+        "subdomain": "whisper-api.myia.io", "category": "AUTH-OK",
+        "dns_resolves": True, "dns_ip": "82.66.89.184",
+        "http_external": 200, "compose_exists": True,
+        "container_running": True, "api_auth": "PROTECTED",
+        "redirect": "", "server": "Gradio", "local_port": 8190,
+        "compose_dir": "whisper-api",
+    }
+    fake_finding_external = {
+        "subdomain": "qdrant.myia.io", "category": "ORPHELIN-DNS",
+        "dns_resolves": True, "dns_ip": "82.66.89.184",
+        "http_external": 200, "compose_exists": False,
+        "container_running": False, "api_auth": "N/A",
+        "redirect": "", "server": "IIS", "local_port": 0,
+        "compose_dir": None,
+    }
+    with mock.patch(
+        "security.audit_exposed_services.classify_subdomain",
+        side_effect=[fake_finding_whisper, fake_finding_external],
+    ):
+        out = run_audit(tier=[("whisper-api.myia.io", "whisper-api", "/health", 8190),
+                              ("qdrant.myia.io", None, None, 0)])
+    assert len(out) == 2
+    assert out[0]["local_port"] == 8190  # normal service
+    assert out[0]["compose_dir"] == "whisper-api"
+    assert out[1]["local_port"] == 0     # ORPHELIN-DNS sentinel
+    assert out[1]["compose_dir"] is None
+
+
+def test_render_markdown_api_tier_includes_port_column():
+    """The c.615 markdown report must include the new 'Port' column and label
+    the API tier accordingly. Round-trip on output content (L498)."""
+    findings = [
+        {"subdomain": "whisper-api.myia.io", "category": "AUTH-OK",
+         "dns_resolves": True, "dns_ip": "82.66.89.184",
+         "http_external": 200, "compose_exists": True,
+         "container_running": True, "api_auth": "PROTECTED",
+         "redirect": "/login", "server": "Gradio",
+         "local_port": 8190, "compose_dir": "whisper-api"},
+        {"subdomain": "qdrant.myia.io", "category": "ORPHELIN-DNS",
+         "dns_resolves": True, "dns_ip": "82.66.89.184",
+         "http_external": 200, "compose_exists": False,
+         "container_running": False, "api_auth": "N/A",
+         "redirect": "", "server": "IIS",
+         "local_port": 0, "compose_dir": None},
+    ]
+    md = render_markdown(findings, tier_name="tier API (compose-driven + ORPHELIN-DNS)")
+    assert "# Audit `*.myia.io`" in md
+    assert "tier API" in md
+    assert "| Port |" in md  # new column header
+    assert "8190" in md     # concrete port
+    assert "—" in md        # ORPHELIN-DNS port placeholder
+
+
+def test_webui_tier_alias_matches_default_tier_identity():
+    """Rétro-compat: WEBUI_TIER must be the same object as DEFAULT_TIER (c.442
+    callers referencing either name see the same data)."""
+    assert WEBUI_TIER is DEFAULT_TIER


### PR DESCRIPTION
## Context

Issue #16 (sécurisation services IA exposés publiquement) §APIs nécessitant des tokens requires per-service auth-state auditing for 9 must-have APIs:
- whisper-api, tts-api, musicgen-api, demucs-api (compose-driven, ports 8190-8193)
- mcp-tools, skagents, embeddings, qdrant, search (no compose in this repo, DNS-only ghosts)

plus adjacent compose-driven services (comfyui-qwen, comfyui-video, orchestrator, tts-multi, tts-fishaudio, qwen-asr-api, funasr-api, vllm-zimage).

Existing c.442 (#6564 MERGED) tier WebUI login natif covers the *WebUI* surface (forge-turbo, sdnext, 4x text-gen). It uses a 3-tuple `(subdomain, compose_dir, api_endpoint)` and probes through `http://localhost:1111/...` (forge-turbo's legacy port). That shape doesn't fit the API tier — services listen on wildly different ports (8190-8197, 8001, 8188-8189, 8090) and 5 externals have no backend in this repo at all.

## What this PR does

Extends `audit_exposed_services.py` to support a second tier. The architecture is:
1. `TierEntry` promoted from 3-tuple to **3-or-4-tuple** (adds `local_port`). Backward-compat via `normalize_entry()` — legacy 3-tuple callers get `DEFAULT_LOCAL_PORT=1111` injected silently.
2. New `API_TIER` constant with 19 entries: **14 compose-driven** (explicit local ports extracted firsthand from each `docker-compose.yml` `# Port:` header) + **5 ORPHELIN-DNS externals** (port=0 sentinel = skip the localhost probe).
3. `probe_api_auth()` accepts `port=0` → short-circuits to `"N/A"` without contacting localhost (matters: we don't want audit probes to spuriously hit 404/401 on services whose backend lives elsewhere).
4. `classify_subdomain` finding dict gains `local_port` + `compose_dir` keys (L498 round-trip — operator can read which port was probed and which compose was matched).
5. `run_audit()` applies per-entry port override (mixed-port tier = each service listens on its own port; function-level `local_port` is fallback for legacy callers).
6. `render_markdown()` gains a "Port" column with `—` placeholder for ORPHELIN-DNS entries.
7. `main()` adds `--tier webui|api|all` flag (default: `all`) for retroactive full coverage.

## Verification (L498 round-trip OUTPUT-content)

- **31/31 pytest PASSED** (21 pre-existing tests preserved + 10 new tests for API_TIER).
- **Pre-flight L518b:** `gh pr list --search 'tier API' --state open` → 0 collisions (no concurrent PR).
- **G.1 firsthand:** DNS 19/19 resolve to `82.66.89.184` (IIS reverse-proxy); ports 8190-8197/8001/8188-8189/8090 extracted from each `docker-compose.yml` header comment; probe endpoints verified (`/health`, OpenAI-compat `/v1/models`, ComfyUI `/system_stats`).
- **End-to-end smoke** (this worker machine, where 12 API containers are not running):
  - 14 `ORPHELIN-START` (compose exists, containers off — 502 from reverse-proxy)
  - 5 `ORPHELIN-DNS` (api_auth=`N/A`, port=0 honored)
- **Retro-compat verified:** `WEBUI_TIER is DEFAULT_TIER` (identity check), legacy 3-tuple callers see same behavior via `normalize_entry`.

## Retro-compat

`DEFAULT_TIER` and `WEBUI_TIER` are now the **same object** (alias, not a copy). All 21 pre-existing tests pass unmodified. The c.442 `--tier webui` flow continues to work; `--tier api` is opt-in.

## Scope note (See #16 not Closes #16)

This PR delivers the **audit infrastructure** for the API tier — DNS/Compose/Container/Auth probes + classification + markdown report. It does NOT:
- Apply firewall rules to ORPHELIN-START services (operations task)
- Provision auth tokens (token ops task)
- Audit mcp-tools/skagents/embeddings/qdrant/search on the **machine that actually hosts them** (the runbook routes the audit to the appropriate machine tier)

So this is a `See #16` partial contribution, not a `Closes`. The issue stays open for the follow-up ops items.

## R6 variety

Lane pivot post-4 Lean/prover cycles (c.488/c.489/c.490/c.614) → genAI-infra security (c.615). Mixes audit infrastructure with the security lens (R6 genre rotation per `proactive-coordination.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>" 