### PR TITLE
feat(GT-Lean): argmaxFin — finite argmax index mirror of maxFin (Max.lean)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Max.lean
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/Bayesian/Max.lean
@@ -96,3 +96,55 @@ theorem maxFin_if_distrib {n : Nat} (c : Prop) [Decidable c]
     (f : Fin (n + 1) → Int) :
     maxFin n (fun a => if c then f a else 0) = if c then maxFin n f else 0 := by
   by_cases h : c <;> simp [h]
+
+/-! ## Argmax fini — l'indice atteignant le maximum
+
+`maxFin` donne la *valeur* du maximum ; `argmaxFin` donne son *témoin* (un indice
+qui l'atteint). Ce témoin manquait jusqu'ici : le module de fictitious play
+(`FictitiousPlay.lean`, phase 7) calcule le paiement de la meilleure réponse via
+`maxFin` mais défère l'extraction de l'indice argmax. `argmaxFin` comble ce gap
+de manière *born-correct* : sur un domaine non vide `Fin (n + 1)`, il renvoie
+toujours un indice (jamais d'échec), avec une garantie d'optimalité. En cas
+d'égalité, le plus petit indice l'emporte.
+
+English:
+Finite argmax — the index achieving the maximum
+
+`maxFin` gives the *value* of the maximum; `argmaxFin` gives its *witness* (an
+index that attains it). This witness was missing until now: the fictitious play
+module (`FictitiousPlay.lean`, phase 7) computes the best-response payoff via
+`maxFin` but defers extracting the argmax index. `argmaxFin` fills this gap in a
+*born-correct* way: over a nonempty domain `Fin (n + 1)` it always returns an
+index (never fails), with an optimality guarantee. Ties break to the smaller
+index. -/
+
+/-- Indice atteignant le maximum de `f` sur `Fin (n + 1)` (domaine non vide),
+    miroir argmax de `maxFin`. En cas d'égalité, le plus petit indice l'emporte.
+    English: Index achieving the maximum of `f` over `Fin (n + 1)` (nonempty
+    domain), the argmax mirror of `maxFin`. Ties break to the smaller index. -/
+def argmaxFin : (n : Nat) → (Fin (n + 1) → Int) → Fin (n + 1)
+  | 0, _ => 0
+  | n + 1, f =>
+    if f 0 ≥ f (argmaxFin n (fun i => f i.succ)).succ
+    then 0
+    else (argmaxFin n (fun i => f i.succ)).succ
+
+/-- L'argmax atteint bien le maximum : `f (argmaxFin n f) = maxFin n f`.
+    English: The argmax does achieve the maximum: `f (argmaxFin n f) = maxFin n f`. -/
+theorem argmaxFin_spec : ∀ {n : Nat} (f : Fin (n + 1) → Int),
+    f (argmaxFin n f) = maxFin n f
+  | 0, _ => rfl
+  | n + 1, f => by
+    have ih : f (argmaxFin n (fun i => f i.succ)).succ
+        = maxFin n (fun i => f i.succ) := argmaxFin_spec (fun i => f i.succ)
+    simp only [argmaxFin, maxFin_succ]
+    split <;> rename_i h <;> omega
+
+/-- Garantie d'optimalité de l'argmax : aucune valeur ne dépasse celle de
+    l'indice choisi.
+    English: Optimality guarantee of the argmax: no value exceeds that of the
+    chosen index. -/
+theorem le_argmaxFin {n : Nat} (f : Fin (n + 1) → Int) (i : Fin (n + 1)) :
+    f i ≤ f (argmaxFin n f) := by
+  rw [argmaxFin_spec f]
+  exact le_maxFin f i


### PR DESCRIPTION
## Contexte

Extension additive de l'infrastructure `Bayesian.Max` (epic #2610). `maxFin` donne la *valeur* du maximum sur `Fin (n + 1)` ; **`argmaxFin` donne son *temoin* — l'indice qui l'atteint**. Ce temoin manquait et était explicitement différé par le module de fictitious play fusionné #6924 :

> « `maxFin` value is computed but `Fin.valFind` / `classical.choose` extraction is not formalized here. » (PR #6924, section "Out of scope")

Cette PR comble ce gap de façon *born-correct*.

## Livrable (additif pur, +52/0 sur `Max.lean`, 0 deletion)

| Objet | Role |
|-------|------|
| `argmaxFin` | `(n) → (Fin (n+1) → Int) → Fin (n+1)` — miroir argmax de `maxFin`. **Born-correct** : domaine non vide ⇒ renvoie toujours un indice (jamais d'échec). Égalité ⇒ plus petit indice. |
| `argmaxFin_spec` | `f (argmaxFin n f) = maxFin n f` — l'argmax atteint bien le max (preuve par récursion + `omega`). |
| `le_argmaxFin` | `f i ≤ f (argmaxFin n f)` — **garantie d'optimalité** : aucune valeur ne dépasse l'indice choisi (via `le_maxFin`). |

## Verification

- [x] `lake build` **SUCCESS** : `Build completed successfully (15 jobs)` (Lean-core no-Mathlib, WSL elan v4.31.0-rc1, `LAKE_JOBS=2`).
- [x] `FictitiousPlay.lean` fusionné (#6924) recompile OK contre le `Max.lean` étendu → **0 conflit** avec la substance mergée.
- [x] `grep -c sorry` = **0** maintenu dans `lean_game_defs_ext/` (0 real sorry — les occurrences « Tous prouvés 0 sorry » sont de la prose de docstring, pas des termes de preuve).
- [x] Catalogue **byte-identique** à main (0 marqueur `CATALOG-STATUS` touché).
- [x] Diff = `Max.lean` seul, +52/−0 (additif pur, **0 régression** du code existant). LF-only.

## Scope / anti-regression

- **Pure additif** : 1 fichier, +52 insertions, 0 suppression. Aucune preuve/impl remplacée, aucun `sorry`/stub introduit.
- **Worktree isolé** depuis `origin/main` HEAD `c155b64fb`. N'édite que `Max.lean` (infrastructure argmax naturelle — le docstring du fichier cadre déjà `maxFin` comme l'infrastructure des maxima finis).
- **Non-doublon** : étend le module fusionné, ne le remplace pas ; ne touche pas `FictitiousPlay.lean`.

## Transparence

Issue sœur : j'avais d'abord livré #6937 (un module FictitiousPlay complet) en doublon du #6924 fusionné — #6937 est **fermé (self-disposal)**. Le code `argmaxFin`/`argmaxFin_spec`/`le_argmaxFin` qui est ici était la partie *réellement additive* (le témoin argmax que #6924 déférait) ; récupérée honnêtement comme extension autonome de `Max.lean`. Voir le commentaire de fermeture de #6937 pour le détail.

See #6924 (merged FP qui flaggue le gap d'extraction argmax)
See #2610 (epic GT-Lean, infrastructure Bayesian.Max)
See #6922 (issue closee par #6924, contexte)

---
🤖 po-2024 lane · Lean/WSL elan · c.573→c.574
