### PR TITLE
chore(translation,#4957): SMT CSV drift resync (z3-api + z3-linq2z3)

### DIFF
--- a/translations/smt/z3-api.csv
+++ b/translations/smt/z3-api.csv
@@ -3991,45 +3991,53 @@ for (int i = 0; i < front.Count; i++) {
 Console.WriteLine($""\n{front.Count} points Pareto-optimaux trouves (qualites distinctes)."");
 Console.WriteLine(""Chaque point est un compromis : pour baisser le cout, il faut"");
 Console.WriteLine(""sacrifier de la qualite (puisque cout_min = 2 * qualite)."");",,,,,,,,f4afe24f020f29bd,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,db8cd9f9,markdown,fr,c25462b8c2ea5960,"### Visualiser le front de Pareto
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,db8cd9f9,markdown,fr,fabd638e7d2a636f,"### Visualiser le front de Pareto
 
 Un tableau de nombres ne rend pas justice au concept de **compromis**. En projetant chaque point Pareto-optimal dans le plan (qualite, cout), le front devient une courbe descendante : chaque pas vers un cout plus bas coute de la qualite. La droite `cout_min = 2 * qualite` (la frontiere de faisabilite imposee par le modele) apparait en pointille : on voit immediatement que certains points Pareto-optimaux sont *strictement au-dessus* de cette borne minimale -- Z3 les a choisis parce qu'a qualite fixee, plusieurs couts sont Pareto-equivalents, et le solveur en echantillonne un. C'est precisement ce que le front de Pareto revele qu'un simple « minimiser le cout » cacherait.
 
-> Le twin Python trace cette courbe avec **matplotlib** (rendu PNG). Le twin C# utilise un rendu **ASCII** (matrice de caracteres) pour rester autonome, sans dependance graphique.",,,,,,,,c25462b8c2ea5960,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,e3af6499,code,fr,a16fbe033d7991a5,"// Visualisation ASCII du front de Pareto : qualite (x) vs cout (y).
-// 'O' = points Pareto-optimaux ; '.' = droite cout_min = 2*qualite.
-void AfficherFrontPareto(List<(long q, long c)> front) {
-    int W = 34, H = 16;            // largeur / hauteur (caracteres)
-    long qMax = 10, cMax = 20;
-    var grille = new char[H, W];
-    for (int y = 0; y < H; y++)
-        for (int x = 0; x < W; x++) grille[y, x] = ' ';
-    // Front de Pareto (O)
-    foreach (var (q, c) in front) {
-        int x = (int)(q * (W - 1) / qMax);
-        int y = (int)(c * (H - 1) / cMax);   // y=0 en haut = cout max
-        if (y >= 0 && y < H && x >= 0 && x < W) grille[y, x] = 'O';
-    }
-    // Borne cout_min = 2*qualite (.)
-    for (long q = 0; q <= qMax; q++) {
-        long c = 2 * q;
-        if (c < 0 || c > cMax) continue;
-        int x = (int)(q * (W - 1) / qMax);
-        int y = (int)(c * (H - 1) / cMax);
-        if (y >= 0 && y < H && x >= 0 && x < W && grille[y, x] == ' ') grille[y, x] = '.';
-    }
-    Console.WriteLine(""Front de Pareto (O) vs cout_min = 2*qualite (.)"");
-    Console.WriteLine($""cout {cMax,3} +"");
-    for (int y = 0; y < H; y++) {
-        Console.Write(""       |"");
-        for (int x = 0; x < W; x++) Console.Write(grille[y, x]);
-        Console.WriteLine();
-    }
-    Console.WriteLine($""cout {0,3} +{new string('-', W)}  qualite -> {qMax}"");
+> Le twin Python trace cette courbe avec **matplotlib** (rendu PNG). Le twin C# utilise **Plotly** (rendu HTML via le formatteur builtin du kernel .NET, sans dependance NuGet additionnelle) -- les deux twins offrent maintenant une vraie courbe, pas un tableau de nombres.",,,,,,,,fabd638e7d2a636f,,,,,,,
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,e3af6499,code,fr,dfbce36b7e1bff83,"// Visualisation Plotly du front de Pareto : qualite (x) vs cout (y).
+// Prong-A (#3801) : remplace la matrice ASCII (Console.WriteLine) par un vrai rendu Plotly.
+// C548-L2 zero-restore : Formatter.Register (builtin) + System.Text.Json, aucun #r nuget charting.
+using Microsoft.DotNet.Interactive.Formatting;
+using System.IO;
+record PlotlyHtml(string Markup);
+Formatter.Register(typeof(PlotlyHtml), (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), ""text/html"");
+
+// Donnees : front (points Pareto-optimaux) + droite cout_min = 2*qualite (frontiere de faisabilite)
+var opt = new System.Text.Json.JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
+string[] qualiteX = front.Select(p => p.qualite.ToString()).ToArray();
+double[] coutFront = front.Select(p => (double)p.cout).ToArray();
+
+// Droite cout_min = 2*qualite (de q=0 a q=10)
+int qMaxLine = 10;
+string[] qualiteLine = Enumerable.Range(0, qMaxLine + 1).Select(q => q.ToString()).ToArray();
+double[] coutMinLine = Enumerable.Range(0, qMaxLine + 1).Select(q => (double)(2 * q)).ToArray();
+
+string Trace(string name, string[] x, double[] y, string mode, string color, int? size=null) {
+    var d = new Dictionary<string, object> {
+        [""name""]=name, [""x""]=x, [""y""]=y.Select(v=>System.Math.Round(v,3)).ToArray(),
+        [""type""]=""scatter"", [""mode""]=mode, [""line""]=new Dictionary<string,object>{{""color"",color}}
+    };
+    if (size.HasValue) d[""marker""]=new Dictionary<string,object>{{""size"",size.Value},{""color"",color}};
+    return System.Text.Json.JsonSerializer.Serialize(d, opt);
 }
-AfficherFrontPareto(front);
-Console.WriteLine($""\nLe front comporte {front.Count} compromis Pareto-optimaux."");
-Console.WriteLine(""La pente descendante illustre le trade-off : baisser le cout degrade la qualite."");",,,,,,,,a16fbe033d7991a5,,,,,,,
+string trFront = Trace(""Front de Pareto"", qualiteX, coutFront, ""lines+markers"", ""#1f77b4"", 10);
+string trBound = Trace(""cout_min = 2*qualite"", qualiteLine, coutMinLine, ""lines"", ""#d62728"");
+
+string layout = ""{\""title\"":{\""text\"":\""Front de Pareto : qualite vs cout\""},"" +
+    ""\""xaxis\"":{\""title\"":{\""text\"":\""qualite\""}},"" +
+    ""\""yaxis\"":{\""title\"":{\""text\"":\""cout\""}},"" +
+    ""\""legend\"":{\""x\"":0.02,\""xanchor\"":\""left\"",\""y\"":0.98}}"";
+
+string divId = ""pltPareto"";
+string markup =
+    ""<div id=\""""+divId+""\""></div>"" +
+    ""<script src=\""https://cdn.plot.ly/plotly-2.35.2.min.js\""></script>"" +
+    ""<script>Plotly.newPlot('""+divId+""',[""+trFront+"",""+trBound+""],""+layout+"",{responsive:true})</script>"";
+display(new PlotlyHtml(markup));
+",,,,,,,,dfbce36b7e1bff83,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb,ce51dd89,markdown,fr,1f0b0c5a0b3dbe03,"### Interpretation : front de Pareto
 
 **Sortie obtenue** : une liste de points `(qualite, cout)` tries par cout decroissant. Chaque point est Pareto-optimal : on ne peut pas ameliorer un objectif sans degrader l'autre.

--- a/translations/smt/z3-linq2z3.csv
+++ b/translations/smt/z3-linq2z3.csv
@@ -459,15 +459,15 @@ MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,1ba631d6,code
 // using (var ctx = new Z3Context()) { ... }
 
 Console.WriteLine(""Exercice a completer : loups, chevres et choux avec Z3.Linq"");",,,,,,,,84e038c7d6d9b98e,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,af7cac81,markdown,fr,68d241d6a3e2fc3d,"## B9 - Environnements `record` positionnels (DSL `NewTheorem<PositionalRecord>`)
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,af7cac81,markdown,fr,f4872f8badf4f803,"## B9 - Environnements `record` positionnels (DSL `NewTheorem<PositionalRecord>`)
 
-L'environnement d'un théorème (le type `T` passe a `NewTheorem<T>`) peut etre un **record positionnel** C# -- par exemple `record Point(int X, int Y)` -- et non une `class` mutable. La reconstruction de la solution passe alors par une branche dediee du solveur ([`Theorem.cs:993-1099`](../../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993)) qui selectionne le *primary constructor* du record, evalue chaque parametre depuis le modele Z3, puis invoque `Activator.CreateInstance(t, args)` avec les valeurs positionnelles -- l'ancienne branche `Activator.CreateInstance(t)` throw sur un record sans constructeur sans parametre (un positional record n'expose que des `init`-only setters).
+L'environnement d'un théorème (le type `T` passe a `NewTheorem<T>`) peut etre un **record positionnel** C# -- par exemple `record Point(int X, int Y)` -- et non une `class` mutable. La reconstruction de la solution passe alors par une branche dediee du solveur ([`Theorem.cs:993-1099`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993)) qui selectionne le *primary constructor* du record, evalue chaque parametre depuis le modele Z3, puis invoque `Activator.CreateInstance(t, args)` avec les valeurs positionnelles -- l'ancienne branche `Activator.CreateInstance(t)` throw sur un record sans constructeur sans parametre (un positional record n'expose que des `init`-only setters).
 
 Le mini-probleme : sur un point `(X, Y)` dans le plan, trouver le point satisfaisant `X + Y = 12` **et** `X = 2·Y` (solution unique attendue : `X = 8, Y = 4`).
 
 > **Stack : A+B** -- le raw doit gerer manuellement la reconstruction via `Model.Eval` sur chaque `IntExpr`, tandis que le DSL `NewTheorem<Point>().Where(...)` invoque la branche `ConstructFromModel` automatiquement ; l'objet rendu (`Point { X = 8, Y = 4 }`) est type C#, pas une paire de `IntNum`.
 
-**Ancre fork** : `Theorem.cs:993-1099` (branche `ConstructFromModel`), tests `Z3.Linq.Tests/RecordEnvTheoryTests.cs:18-91` (4 cas : positional standard, scalaires mixtes int+bool, trois parametres, UNSAT). La feature etait listee dans le backlog `B9` d'[#4688](https://github.com/jsboige/CoursIA/issues/4688) avec une ancre « a confirmer » -- le grep la trouve dans la branche reconstruction, **pas** dans la declaration de type (qui est du C# standard).",,,,,,,,68d241d6a3e2fc3d,,,,,,,
+**Ancre fork** : `Theorem.cs:993-1099` (branche `ConstructFromModel`), tests `Z3.Linq.Tests/RecordEnvTheoryTests.cs:18-91` (4 cas : positional standard, scalaires mixtes int+bool, trois parametres, UNSAT). La feature etait listee dans le backlog `B9` d'[#4688](https://github.com/jsboige/CoursIA/issues/4688) avec une ancre « a confirmer » -- le grep la trouve dans la branche reconstruction, **pas** dans la declaration de type (qui est du C# standard).",,,,,,,,f4872f8badf4f803,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,999c4775,code,fr,1642dddcb8763e73,"// B9 - Record positionnel ""deux stacks"" sur le meme probleme (X+Y=12, X=2Y).
 //   Un point (X, Y) dans le plan, soumis a 2 contraintes lineaires.
 //   Solution unique attendue : X=8, Y=4.
@@ -528,7 +528,7 @@ public record PointRecord(int X, int Y) { }
     sUn.Assert(z3.MkLt(x, z3.MkInt(0)));
     Console.WriteLine($""[RAW]   X>=0 et X<0 : {sUn.Check()}   (aucune affectation)"");
 }",,,,,,,,1642dddcb8763e73,,,,,,,
-MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,4ab72a78,markdown,fr,ee1fd8be466e3760,"### Lecture B9 - deux ecritures d'un meme record, un meme resultat
+MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,4ab72a78,markdown,fr,62aaa153f8fada23,"### Lecture B9 - deux ecritures d'un meme record, un meme resultat
 
 Les deux ecritures resolvent **le meme systeme** (`X + Y = 12`, `X = 2·Y`) et produisent **le meme temoin** (`X = 8, Y = 4`), mais leur cout d'ecriture est asymetrique :
 
@@ -541,7 +541,7 @@ Les deux ecritures resolvent **le meme systeme** (`X + Y = 12`, `X = 2·Y`) et p
 | Surface code | ~10 lignes significatives + risque d'erreur de typage des `IntNum` | 3 lignes de contraintes |
 | Constructeur sans parametre | non requis (le raw n'instancie jamais d'objet C#) | **necessaire dans le cas d'une `class` mutable**, **interdit dans le cas d'un record** (l'ancienne branche `Activator.CreateInstance(t)` throw) |
 
-> **Ligne de contraste** : la valeur ajoutee du DSL ici n'est pas une fecondation d'expression (comme `Sum` qui replie N termes en un seul `MkAdd`), mais le **routage de reconstruction** -- la detection du type d'environnement (`class` mutable avec setter vs `record` positionnel vs type anonyme) et l'invocation de la bonne branche de [`Theorem.cs:993-1099`](../../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993). Cote raw, c'est au chercheur de coder la reconstruction -- cote DSL, elle est *incluse par defaut* dans `NewTheorem<T>()`. Les tests unitaires `RecordEnvTheoryTests` (4 cas) verifient que la branche positionnelle couvre records a 2-3 params, scalaires mixtes (int + bool), et le retour `null` sur UNSAT.",,,,,,,,ee1fd8be466e3760,,,,,,,
+> **Ligne de contraste** : la valeur ajoutee du DSL ici n'est pas une fecondation d'expression (comme `Sum` qui replie N termes en un seul `MkAdd`), mais le **routage de reconstruction** -- la detection du type d'environnement (`class` mutable avec setter vs `record` positionnel vs type anonyme) et l'invocation de la bonne branche de [`Theorem.cs:993-1099`](../Z3.Linq/solutions/Z3.Linq/Theorem.cs#L993). Cote raw, c'est au chercheur de coder la reconstruction -- cote DSL, elle est *incluse par defaut* dans `NewTheorem<T>()`. Les tests unitaires `RecordEnvTheoryTests` (4 cas) verifient que la branche positionnelle couvre records a 2-3 params, scalaires mixtes (int + bool), et le retour `null` sur UNSAT.",,,,,,,,62aaa153f8fada23,,,,,,,
 MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/01_Linq2Z3_Intro.ipynb,68738069,markdown,fr,f49117462f86284b,"### Exercice 4 : record positionnel a 3 parametres (stability of constructor order)
 
 Reproduisez la demarche ci-dessus avec un record a **trois** parametres -- par exemple `record Triple(int A, int B, int C)` -- et trois contraintes scalaires (par exemple `A == 1, B == 2, C == 3`). Le solveur doit rendre un `Triple { A = 1, B = 2, C = 3 }`.


### PR DESCRIPTION
## Summary

T1 baseline translation CSVs in `translations/smt/` had fallen out of sync with their source notebooks (detected by `scripts/translation/check_translation_sync.py` — 4 SRC_DRIFT). This PR refreshes the source columns to match the current notebooks.

## What drifted (and why)

| CSV | Notebook | Cells | Cause |
|-----|----------|-------|-------|
| `smt/z3-api.csv` | `Z3-Python-06-Advanced-Optimization-Csharp.ipynb` | `db8cd9f9`, `e3af6499` | Prong-A #3801 SOTA upgrade: ASCII Pareto matrix → real Plotly HTML render (C548-L2 zero-restore `Formatter.Register` technique) |
| `smt/z3-linq2z3.csv` | `01_Linq2Z3_Intro.ipynb` | `af7cac81`, `4ab72a78` | Markdown link path fix (`../../Z3.Linq` → `../Z3.Linq`) |

Both are legitimate source evolutions; the CSV baseline was simply stale.

## How — deterministic resync, source-only

```
python scripts/translation/extract_cells_to_csv.py <notebook> --update translations/smt/<csv>
```

- **z3-api.csv**: 2 rows refreshed, 25 already in-sync, 514 other-notebook rows preserved, 0 orphan.
- **z3-linq2z3.csv**: 2 rows refreshed, 30 already in-sync, 493 rows preserved, 0 orphan.
- Translation columns (`text_en` … `text_pt`) remain empty (T1 baseline; filled later by the Argumentum T3 engine, gated #1650 Phase 1). **No translation data touched.**
- Post-resync `check_translation_sync.py translations/smt/` → **0 anomalies**.

## Verification

- [x] Drift checker re-run firsthand: SMT 4 → **0 anomalies**.
- [x] Diff is source-only (text_fr + hash columns); translation columns unchanged.
- [x] Catalogue byte-identical to main (no CATALOG-STATUS churn).
- [x] No notebook edited — CSV-only, deterministic re-extraction.

## Scope note

Repo-wide drift is 57 anomalies across 7 CSVs. The largest cluster is the **`genai/texte.csv` ↔ `genai-texte/genai-texte.csv` duplicate pair** (24 + 24) — these are byte-identical-duplicate conventions (the c.549/#6862 collision trap) and need canonical disambiguation **before** resync, so they are deliberately left out of this PR. This PR takes only the clean, unambiguous, partition-owned SMT slice (4 cells).

See #4957 (T1 baseline maintenance). Partial contribution — does not close the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)