### PR TITLE
chore(translation,#4957): search-part1 CSV drift resync (Search-8 DancingLinks)

### DIFF
--- a/translations/search-part1/search-part1.csv
+++ b/translations/search-part1/search-part1.csv
@@ -21223,9 +21223,9 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb,conclu
 - Browne, C.B., Powley, E., Whitehouse, D. et al. (2012). A Survey of Monte Carlo Tree Search Methods. IEEE Transactions on Computational Intelligence and AI in Games 4(1):1-43.
 
 ",,,,,,,,d12cb75fa9538af2,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb,l1i6cpxssef,markdown,fr,bd1ecd17b885fd1b,"# Search-8-DancingLinks : L'algorithme X et Dancing Links de Knuth
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb,l1i6cpxssef,markdown,fr,2e14f92af72873a0,"# Search-8-DancingLinks : L'algorithme X et Dancing Links de Knuth
 
-**Navigation** : [<< Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)
+**Navigation** : [<< MCTS](Search-7-MCTS-And-Beyond.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)
 
 ## L'algorithme X et Dancing Links (DLX)
 
@@ -21252,7 +21252,7 @@ A la fin de ce notebook, vous saurez :
 
 - **Original paper** : Knuth, D. E. (2000). *Dancing Links*. arXiv:cs/0011047
 - **Applications** : Sudoku, N-Queens, Pentominoes, Exact Cover
-- **Notebook connexe** : [Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)",,,,,,,,bd1ecd17b885fd1b,,,,,,,
+- **Notebook connexe** : [Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)",,,,,,,,2e14f92af72873a0,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb,ahuwgpl0co,code,fr,fbde0ee781bd1b85,"# Imports
 import sys
 import time
@@ -23026,13 +23026,13 @@ MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb,1w8yt0v6t
 - **Notebook Sudoku** : [Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb)
 - **Notebook suivant** : [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) - Programmation lineaire
 - **Applications** : [App-11-Picross](../Applications/CSP/App-11-Picross.ipynb) - DLX pour Picross",,,,,,,,4e9edc5e652158e9,,,,,,,
-MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb,ly6c9tsgai,markdown,fr,b2ce2024ab45e7a0,"---
+MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb,ly6c9tsgai,markdown,fr,a593fcd7ad476145,"---
 
-**Navigation** : [<< Metaheuristiques](Search-11-Metaheuristics.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)
+**Navigation** : [<< MCTS](Search-7-MCTS-And-Beyond.ipynb) | [Index](../README.md) | [Programmation lineaire >>](Search-9-LinearProgramming.ipynb)
 
 **Series connexes** : 
 - [Sudoku-2-DancingLinks-Python](../../Sudoku/Sudoku-2-DancingLinks-Python.ipynb) - Application complete pour Sudoku
-- [Search-App-11-Picross](../Applications/CSP/App-11-Picross.ipynb) - DLX pour Picross",,,,,,,,b2ce2024ab45e7a0,,,,,,,
+- [Search-App-11-Picross](../Applications/CSP/App-11-Picross.ipynb) - DLX pour Picross",,,,,,,,a593fcd7ad476145,,,,,,,
 MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb,d1a4b81e,markdown,fr,1f252590ddd1e9f9,"## Conclusion
 
 Ce notebook a presente l'**Algorithme X** de Knuth et les **Dancing Links (DLX)**, la structure de donnees qui le rend efficace pour les problemes de couverture exacte.


### PR DESCRIPTION
## Summary

T1 baseline translation CSV `translations/search-part1/search-part1.csv` had fallen out of sync with its source notebook (2 SRC_DRIFT detected by `scripts/translation/check_translation_sync.py`). This PR refreshes the source columns.

## What drifted (and why)

| CSV | Notebook | Cells | Cause |
|-----|----------|-------|-------|
| `search-part1/search-part1.csv` | `Search-8-DancingLinks.ipynb` | `l1i6cpxssef`, `ly6c9tsgai` | #6912 navlink-chain fix: `[<< Metaheuristiques](Search-11)` → `[<< MCTS](Search-7)` (Search-7 MCTS is the actual predecessor of Search-8, not Search-11) |

The navlink wave #6912/#6930 corrected the Search series navigation chain; the CSV baseline was simply stale.

## How — deterministic resync, source-only

```
python scripts/translation/extract_cells_to_csv.py Search-8-DancingLinks.ipynb --update translations/search-part1/search-part1.csv
```

- 2 rows refreshed, 56 already in-sync, 1112 other-notebook rows preserved, 0 orphan.
- Translation columns (`text_en` … `text_pt`) remain empty (T1 baseline; filled later by Argumentum T3, gated #1650 Phase 1). **No translation data touched.**
- Post-resync `check_translation_sync.py translations/search-part1/` → **0 anomalies**.

## Verification

- [x] Drift checker re-run firsthand: search-part1 2 → **0 anomalies**.
- [x] Diff is source-only (`text_fr` + hash columns); translation columns unchanged.
- [x] Catalogue byte-identical to main (no CATALOG-STATUS churn).
- [x] No notebook edited — CSV-only, deterministic re-extraction.

## Scope / R6

Famille-distinct from #6939 (SMT) — Search-.NET partition, rotation famille. Companion to the ongoing translation-drift-resync vein (#4957 T1 maintenance). The GenAI/Texte 48-drift pair (c.549 duplicate trap) is left for canonical disambiguation; this PR takes only the clean unambiguous slice.

See #4957. Partial contribution — does not close the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)