### PR TITLE
feat(lean,#6724): hashlife P4.4 shift lemmas (3 NE/SW/SE quadrants)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -2866,6 +2866,93 @@ private theorem p4_nw_shift_lemma
   exact centralCorrect_mem_shift (node r1 r2 r4 r5) (k - 1)
     (2^k) (2^k) p hcc
 
+/-- **P4.4 NE-quadrant shift lemma (factorisé, c.619).** Caractérise l'appartenance
+    pointwise `p ∈ (hashlifeResultAux (k+1) q_ne).toGrid (2^k, 2^k + 2^(k-1))`
+    du quadrant NE (offset `(2^k, 2^k + 2^(k-1))` via `mem_toGrid_node`) en une
+    conjonction `isAlive ... ∧ bounds`. La super-cellule opaque `q_ne` =
+    `hashlifeResultAux (k+1) (node ...)` (level `k`) passe par
+    `p4_wave2_ih_step` (ih sur la super-cellule) puis
+    `centralCorrect_mem_shift` pour réancrer l'offset `(2^k, 2^k + 2^(k-1))`.
+
+    Pattern cohérent avec `p4_nw_shift_lemma` (c.488) — seul l'offset
+    `(a, b)` change pour atteindre le quadrant NE. Sorry-free. -/
+private theorem p4_ne_shift_lemma
+    (k : Nat) (hk1 : 1 ≤ k)
+    (r1 r2 r4 r5 : MacroCell)
+    (hr1_l : r1.level = k) (hr2_l : r2.level = k)
+    (hr4_l : r4.level = k) (hr5_l : r5.level = k)
+    (hr1_w : r1.wf = true) (hr2_w : r2.wf = true)
+    (hr4_w : r4.wf = true) (hr5_w : r5.wf = true)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j)
+    (p : Int × Int) :
+    p ∈ (hashlifeResultAux ((k - 1) + 2) (node r1 r2 r4 r5)).toGrid
+          ((2^k : Int), (2^k + (2^(k - 1) : Int))) ↔
+      isAlive (evolve (2^(k - 1)) ((node r1 r2 r4 r5).toGrid (0, 0)))
+        (p.1 - (2^k : Int) + (2^(k - 1) : Int),
+         p.2 - ((2^k + (2^(k - 1) : Int))) + (2^(k - 1) : Int)) = true ∧
+      (2^k : Int) ≤ p.1 ∧ p.1 < (2^k : Int) + 2^((k - 1) + 1) ∧
+      ((2^k + (2^(k - 1) : Int))) ≤ p.2 ∧
+        p.2 < ((2^k + (2^(k - 1) : Int))) + 2^((k - 1) + 1) := by
+  have hcc : centralCorrect (node r1 r2 r4 r5) (k - 1) :=
+    p4_wave2_ih_step k hk1 r1 r2 r4 r5
+      hr1_l hr2_l hr4_l hr5_l hr1_w hr2_w hr4_w hr5_w ih
+  exact centralCorrect_mem_shift (node r1 r2 r4 r5) (k - 1)
+    (2^k) (2^k + (2^(k - 1) : Int)) p hcc
+
+/-- **P4.4 SW-quadrant shift lemma (factorisé, c.619).** Symétrique au
+    `p4_ne_shift_lemma` pour l'offset SW `(2^k + 2^(k-1), 2^k)`. Sorry-free. -/
+private theorem p4_sw_shift_lemma
+    (k : Nat) (hk1 : 1 ≤ k)
+    (r1 r2 r4 r5 : MacroCell)
+    (hr1_l : r1.level = k) (hr2_l : r2.level = k)
+    (hr4_l : r4.level = k) (hr5_l : r5.level = k)
+    (hr1_w : r1.wf = true) (hr2_w : r2.wf = true)
+    (hr4_w : r4.wf = true) (hr5_w : r5.wf = true)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j)
+    (p : Int × Int) :
+    p ∈ (hashlifeResultAux ((k - 1) + 2) (node r1 r2 r4 r5)).toGrid
+          ((2^k + (2^(k - 1) : Int), (2^k : Int))) ↔
+      isAlive (evolve (2^(k - 1)) ((node r1 r2 r4 r5).toGrid (0, 0)))
+        (p.1 - ((2^k + (2^(k - 1) : Int))) + (2^(k - 1) : Int),
+         p.2 - (2^k : Int) + (2^(k - 1) : Int)) = true ∧
+      ((2^k + (2^(k - 1) : Int))) ≤ p.1 ∧
+        p.1 < ((2^k + (2^(k - 1) : Int))) + 2^((k - 1) + 1) ∧
+      (2^k : Int) ≤ p.2 ∧ p.2 < (2^k : Int) + 2^((k - 1) + 1) := by
+  have hcc : centralCorrect (node r1 r2 r4 r5) (k - 1) :=
+    p4_wave2_ih_step k hk1 r1 r2 r4 r5
+      hr1_l hr2_l hr4_l hr5_l hr1_w hr2_w hr4_w hr5_w ih
+  exact centralCorrect_mem_shift (node r1 r2 r4 r5) (k - 1)
+    (2^k + (2^(k - 1) : Int)) (2^k) p hcc
+
+/-- **P4.4 SE-quadrant shift lemma (factorisé, c.619).** Symétrique au
+    `p4_ne_shift_lemma` pour l'offset SE `(2^k + 2^(k-1), 2^k + 2^(k-1))`. Sorry-free. -/
+private theorem p4_se_shift_lemma
+    (k : Nat) (hk1 : 1 ≤ k)
+    (r1 r2 r4 r5 : MacroCell)
+    (hr1_l : r1.level = k) (hr2_l : r2.level = k)
+    (hr4_l : r4.level = k) (hr5_l : r5.level = k)
+    (hr1_w : r1.wf = true) (hr2_w : r2.wf = true)
+    (hr4_w : r4.wf = true) (hr5_w : r5.wf = true)
+    (ih : ∀ (c' : MacroCell) (j : Nat), j < k → c'.wf = true → c'.level = j + 2 →
+      centralCorrect c' j)
+    (p : Int × Int) :
+    p ∈ (hashlifeResultAux ((k - 1) + 2) (node r1 r2 r4 r5)).toGrid
+          ((2^k + (2^(k - 1) : Int), 2^k + (2^(k - 1) : Int))) ↔
+      isAlive (evolve (2^(k - 1)) ((node r1 r2 r4 r5).toGrid (0, 0)))
+        (p.1 - ((2^k + (2^(k - 1) : Int))) + (2^(k - 1) : Int),
+         p.2 - ((2^k + (2^(k - 1) : Int))) + (2^(k - 1) : Int)) = true ∧
+      ((2^k + (2^(k - 1) : Int))) ≤ p.1 ∧
+        p.1 < ((2^k + (2^(k - 1) : Int))) + 2^((k - 1) + 1) ∧
+      ((2^k + (2^(k - 1) : Int))) ≤ p.2 ∧
+        p.2 < ((2^k + (2^(k - 1) : Int))) + 2^((k - 1) + 1) := by
+  have hcc : centralCorrect (node r1 r2 r4 r5) (k - 1) :=
+    p4_wave2_ih_step k hk1 r1 r2 r4 r5
+      hr1_l hr2_l hr4_l hr5_l hr1_w hr2_w hr4_w hr5_w ih
+  exact centralCorrect_mem_shift (node r1 r2 r4 r5) (k - 1)
+    (2^k + (2^(k - 1) : Int)) (2^k + (2^(k - 1) : Int)) p hcc
+
 /-- **P4 entry point**: the pointwise membership biconditional for the
     inductive step. Glues `p4_double_nine_shape` (P4.1), `p4_wave1_ih`
     (P4.2), and `p4_wave2_ih` (P4.3). The P4.4 half-step composition is


### PR DESCRIPTION
## feat(lean,#6724): hashlife P4.4 shift lemmas (3 NE/SW/SE quadrants)

**Source issue** : #6724 (GOL/Hashlife N3 — cœur résiduel P4 S4 assembleur)
**Scope** : factorize the offset-matching infrastructure for the 4-quadrant S4 assembly inside `p4_succ_membership`, following the c.488 `p4_nw_shift_lemma` template (sorry-free NW wrapper, already landed via #6869).
**Acceptance** : 4 shift lemmas wrapping `p4_wave2_ih_step` + `centralCorrect_mem_shift` at the 4 quadrant offsets. **3/4 delivered in this PR** (NE/SW/SE). The NW wrapper already exists at L2846-2867 from c.488.

### Changes (1 file, +87/-0)

`MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean` — three new sorry-free private theorems:

| Lemma | Lines | Offset `(a, b)` | RHS shape |
|-------|-------|------------------|-----------|
| `p4_nw_shift_lemma` (c.488) | 2846-2867 | `(2^k, 2^k)` | `isAlive ∧ [2^k, 3·2^k)²` |
| `p4_ne_shift_lemma` | 2879-2901 | `(2^k, 2^k + 2^(k-1))` | `isAlive ∧ [2^k, 3·2^k) × [2^k+2^(k-1), 3·2^k)` |
| `p4_sw_shift_lemma` | 2905-2927 | `(2^k + 2^(k-1), 2^k)` | symmetric to NE |
| `p4_se_shift_lemma` | 2931-2954 | `(2^k + 2^(k-1), 2^k + 2^(k-1))` | symmetric to NE |

Each new lemma is **~10 lines**, body = `p4_wave2_ih_step` (ih on `node r1 r2 r4 r5`) followed by `centralCorrect_mem_shift` at the chosen offset. No new infrastructure; just exposes the (a, b) parameter of `centralCorrect_mem_shift` as 4 named quadrants.

### Build evidence

```
$ cd /c/dev/CoursIA-c619-hashlife-p4s4/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
$ LAKE_JOBS=2 lake build Conway.Life.HashlifeCorrectness
Build completed successfully (8498 jobs).
```

Sorry count (line-bare `^[[:space:]]*sorry[[:space:]]*$`):

```
$ grep -cE "^[[:space:]]*sorry[[:space:]]*$" Conway/Life/HashlifeCorrectness.lean
8
```

Unchanged: 5 in `p4_succ_membership` (4 quadrant sub-sorries + mpr) + 3 downstream at L3395/L3547/L3576. **The 3 new lemmas are sorry-free**; the residual sorries in `p4_succ_membership` are unchanged pending the LHS→RHS bridge.

### Why `See #6724` partial (NOT `Closes`)

The 4 shift lemmas reduce the offset-matching half of the S4 assembly, but the proof is NOT complete. Each shift lemma returns a biconditional `p ∈ toGrid ↔ isAlive ∧ bounds` whose RHS is NOT yet equivalent to the goal `p ∈ restrictGridTo (evolve 2^k g) 2^k 2^(k+1)`. The missing bridge is one lemma:

```lean
-- Pseudo-spec (proof target for next cycle)
private theorem restrictGridTo_bridge
    (g : Grid) (k : Nat) (p : Int × Int)
    (hk : 1 ≤ k) :
    (isAlive (evolve 2^k g) p ∧ 2^k ≤ p.1 ∧ p.1 < 3·2^k ∧ 2^k ≤ p.2 ∧ p.2 < 3·2^k)
    ↔ p ∈ restrictGridTo (evolve 2^k g) (2^k : Int) (2^(k+1))
```

Once that bridge exists, each of the 4 sub-sorries becomes:

```lean
have hshift := p4_*_shift_lemma ... r1 r2 r4 r5 ... p
exact (hshift.mp h*).trans restrictGridTo_bridge
```

### Verification checklist (per [lean-merge-discipline.md](.claude/rules/lean-merge-discipline.md))

- [x] `lake build SUCCESS` local firsthand (po-2026, recipe c.473)
- [x] `grep -c sorry` unchanged at 8 line-sorries (no regression, no sorry inflation)
- [x] Diff is purely additive (+87/-0, 1 file)
- [x] Branch off origin/main (cb5114f32), 1 commit ahead
- [x] Co-Authored-By trailer present
- [ ] Lean CI — to run on PR open

### See also

- #6724 — Hashlife N3 core residual
- #6869 (c.488) — `p4_nw_shift_lemma` template
- #6771 (c.472-473) — local lake build recovery recipe (used here)
- [docs/lean/coordinator-workflow.md](docs/lean/coordinator-workflow.md)
- [catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md) R4 — `See #N` for partial