### PR TITLE
fix(translation,#4957): resync genai-video CSV (2 SRC_DRIFT -> 0)

### DIFF
--- a/translations/genai-video/genai-video.csv
+++ b/translations/genai-video/genai-video.csv
@@ -8014,7 +8014,7 @@ Ce notebook a permis d explorer les aspects essentiels de 02 3 wan video generat
 - Les resultats obtenus permettent de valider la comprehension
 
 **Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines.",,,,,,,,1f0abdae3dce9961,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-4-SVD-Image-to-Video.ipynb,cell-0,markdown,fr,2d290c4436df2ad8,"# SVD - Stable Video Diffusion (Image-to-Video)
+MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-4-SVD-Image-to-Video.ipynb,cell-0,markdown,fr,aa3581fc88fdcf6d,"# SVD - Stable Video Diffusion (Image-to-Video)
 
 **Module :** 02-Video-Advanced  
 **Niveau :** Intermediaire  
@@ -8038,7 +8038,7 @@ MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-4-SVD-Image-to-Video.ipynb,cell-0,m
 - Notebooks 02-1 a 02-3 completes pour comparaison
 - Packages : `diffusers>=0.30`, `transformers`, `torch`, `accelerate`, `imageio`, `imageio-ffmpeg`, `Pillow`
 
-**Navigation :** [<< 02-3](02-3-Wan-Video-Generation.ipynb) | [Index](../README.md) | [Suivant >>](../03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb)",,,,,,,,2d290c4436df2ad8,,,,,,,
+**Navigation :** [<< 02-3](02-3-Wan-Video-Generation.ipynb) | [Index](../README.md) | [02-5 LTX-2 >>](02-5-LTX2-Audiovisual.ipynb)",,,,,,,,aa3581fc88fdcf6d,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-4-SVD-Image-to-Video.ipynb,cell-1,code,fr,744bc8d40dd6ca41,"# Parametres Papermill - JAMAIS modifier ce commentaire
 
 # Configuration notebook
@@ -10116,7 +10116,7 @@ Une fois **un** des deux debloque, basculer `run_generation=True` (et choisir `r
 ---
 
 **Navigation :** [<< 02-4 SVD](02-4-SVD-Image-to-Video.ipynb) | [Index](../README.md) | [Comparaison multi-modeles >>](../03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb)",,,,,,,,d89d861e9e3c550e,,,,,,,
-MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb,cell-header,markdown,fr,89e3c740fc1e316b,"# Comparaison Multi-Modeles de Generation Video
+MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb,cell-header,markdown,fr,1e0998a4df5d31b3,"# Comparaison Multi-Modeles de Generation Video
 
 **Module :** 03-Video-Orchestration  
 **Niveau :** Avance  
@@ -10136,10 +10136,10 @@ MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison
 ## Prerequis
 
 - GPU avec 18+ GB VRAM (RTX 3090 / RTX 4090)
-- Module 02-Advanced complete (notebooks 02-1 a 02-4)
+- Module 02-Advanced complete (notebooks 02-1 a 02-5)
 - Packages : `diffusers>=0.32`, `transformers`, `torch`, `accelerate`, `bitsandbytes`, `imageio`, `imageio-ffmpeg`
 
-**Navigation :** [<< 02-4](../02-Advanced/02-4-SVD-Image-to-Video.ipynb) | [Index](../README.md) | [Suivant >>](03-2-Video-Workflow-Orchestration.ipynb)",,,,,,,,89e3c740fc1e316b,,,,,,,
+**Navigation :** [<< 02-5 LTX-2](../02-Advanced/02-5-LTX2-Audiovisual.ipynb) | [Index](../README.md) | [Suivant >>](03-2-Video-Workflow-Orchestration.ipynb)",,,,,,,,1e0998a4df5d31b3,,,,,,,
 MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb,cell-params,code,fr,60911a579ea44765,"# Parametres Papermill - JAMAIS modifier ce commentaire
 
 # Configuration notebook


### PR DESCRIPTION
## fix(translation,#4957): resync genai-video CSV (2 SRC_DRIFT -> 0)

Maintenance resync of `translations/genai-video/genai-video.csv` (Epic #4957 T2 drift fix). The GenAI/Video source notebooks drifted from their sync CSV after a navlink update; this refreshes the `src_hash` + `text_fr` to match current sources.

### Drift (2 SRC_DRIFT, real source change)

| Notebook | cell | Change |
|----------|------|--------|
| `02-Advanced/02-4-SVD-Image-to-Video.ipynb` | `cell-0` | navlink `[Suivant >>](03-1-Multi-Model-Video-Comparison)` -> `[02-5 LTX-2 >>](02-5-LTX2-Audiovisual)` (points to new 02-5-LTX2 notebook) |
| `03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb` | `cell-header` | header source hash refresh |

Both are **legitimate FR source changes** (navlink work + new 02-5-LTX2 notebook), not scanner artifacts.

### Method

```bash
python scripts/translation/extract_cells_to_csv.py MyIA.AI.Notebooks/GenAI/Video/ --update translations/genai-video/genai-video.csv
# OK (--update): 2 ligne(s) rafraichie(s), 484 deja in-sync, 0 ajoutee(s), 0 orpheline(s)
```

### Verification (fresh origin/main worktree, anti-phantom G.1)

```
pre:  DRIFT DETECTE (2 anomalie(s) sur 1 CSV): SRC_DRIFT=2
post: OK : 1 CSV verifie(s), 0 drift.
```

Diff: +5/-5, single file. Only the 2 changed cells refresh (src_hash + text_fr); 484 other rows preserved verbatim.

### Collision-guard + anti-phantom

- **Verified on fresh origin/main worktree** (NOT the dirty shared tree, which is stale and reports phantom drift — e.g. gametheory.csv shows 8 drift on the stale shared tree but **0 on origin/main**). G.1 firsthand.
- Single canonical CSV (seeded #6784, **no duplication sibling**). Note: GenAI/Texte has a structural duplicate-CSV issue (`genai/texte.csv` #6769 vs `genai-texte/genai-texte.csv` #6858, both 24 drift) flagged separately to ai-01 — out of scope here.
- No open PR touches genai-video (search-part1=#6943, z3-api/z3-linq2z3=#6939 are the open translation PRs; disjoint).

### Scope

1 file, +5/-5, atomique. No catalogue touched. Genre rotation (po-2025 just delivered C# engine work PR #6942; this is 1 translation item for 2026-07-17, within R6 cap).

See #4957 (EPIC, ongoing — not closed).
