### PR TITLE
fix(audiobook,#1028): verify_transcript WER normalize — long dashes as word separators

### DIFF
--- a/scripts/tests/test_verify_transcript.py
+++ b/scripts/tests/test_verify_transcript.py
@@ -1,0 +1,100 @@
+"""Tests for scripts/tts_verification/verify_transcript.py — stage-1 WER/CER gate.
+
+Locks the text normalization and the WER/CER math, which are pure logic (no audio,
+no Whisper call) and therefore CI-testable. The network-facing function
+``transcribe_audio`` is intentionally NOT exercised: it needs the local whisper-api
+service, covered by the manual run on the #1028 review material.
+
+Regression under test (hand-verified on audiobook #1028):
+* Long dashes (``--``, ``—``, ``–``) and hyphen-joined compounds must split into
+  separate tokens, not fuse. Previously ``-`` was kept in the allowed-character set,
+  so ``Défaite--les Citoyens`` became one token ``défaite--les`` while Whisper
+  transcribes ``défaite les`` -> the segment was counted as 17.24% WER despite a
+  32/32 word match (false failure on French dialog text).
+"""
+
+import sys
+from pathlib import Path
+
+# Same sibling convention as test_verify_prosody.py: insert the tool dir and import
+# the module directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tts_verification"))
+
+from verify_transcript import (  # noqa: E402
+    _normalize_text,
+    compute_cer,
+    compute_wer,
+)
+
+
+# --- _normalize_text: dash separation ----------------------------------------
+
+
+def test_normalize_keeps_french_diacritics():
+    assert _normalize_text("Héroïque garçon Noël") == "héroïque garçon noël"
+
+
+def test_normalize_double_hyphen_splits_tokens():
+    # The #1028 regression: "--" must separate, not fuse.
+    assert _normalize_text("Défaite--les Citoyens") == "défaite les citoyens"
+
+
+def test_normalize_em_dash_splits_tokens():
+    assert _normalize_text("Mort»—passaient") == "mort passaient"
+
+
+def test_normalize_en_dash_splits_tokens():
+    assert _normalize_text("Mort – passaient") == "mort passaient"
+
+
+def test_normalize_hyphen_compound_splits_tokens():
+    # Whisper transcribes "francs-tireurs" as "francs tireurs"; the reference must
+    # split the same way or the compound is counted as a substitution.
+    assert _normalize_text("francs-tireurs") == "francs tireurs"
+
+
+def test_normalize_strips_punctuation():
+    assert _normalize_text("«Vengeurs!»...") == "vengeurs"
+
+
+def test_normalize_collapses_whitespace():
+    assert _normalize_text("a   b\t\nc") == "a b c"
+
+
+# --- WER / CER math ----------------------------------------------------------
+
+
+def test_wer_identical_is_zero():
+    assert compute_wer("le chat dort", "le chat dort") == 0.0
+
+
+def test_wer_real_substitution_is_nonzero():
+    assert compute_wer("le chat dort", "le chien dort") > 0.0
+
+
+def test_cer_identical_is_zero():
+    assert compute_cer("le chat dort", "le chat dort") == 0.0
+
+
+def test_wer_empty_reference_no_hypothesis_is_zero():
+    assert compute_wer("", "") == 0.0
+
+
+def test_wer_empty_reference_with_hypothesis_is_one():
+    assert compute_wer("", "abc") == 1.0
+
+
+def test_regression_audiobook_narrateur_dash_dialog_zero_wer():
+    """#1028 narrateur segment: reference has long-dash dialog markup, Whisper drops
+    the dashes. After the normalize fix this must be 0% WER, not ~17%."""
+    reference = (
+        "Des légions de francs-tireurs aux appellations héroïques: «les Vengeurs "
+        "de la Défaite--les Citoyens de la Tombe--les Partageurs de la "
+        "Mort»--passaient à leur tour, avec des airs de bandits."
+    )
+    hypothesis = (
+        "des légions de francs-tireurs aux appellations héroïques les vengeurs de "
+        "la défaite les citoyens de la tombe les partageurs de la mort passaient à "
+        "leur tour avec des airs de bandits"
+    )
+    assert compute_wer(reference, hypothesis) == 0.0

--- a/scripts/tts_verification/verify_transcript.py
+++ b/scripts/tts_verification/verify_transcript.py
@@ -28,9 +28,21 @@ WHISPER_KEY = os.getenv("WHISPER_API_KEY", "")
 
 
 def _normalize_text(text: str) -> str:
-    """Normalize text for comparison: lowercase, strip punctuation, collapse whitespace."""
+    """Normalize text for comparison: lowercase, strip punctuation, collapse whitespace.
+
+    Em-dashes / long dashes are treated as WORD SEPARATORS, not kept as part of a
+    token. Keeping ``-`` in the allowed-character set (the previous behavior) fused
+    ``Défaite--les Citoyens`` into the single token ``défaite--les`` while Whisper
+    transcribes the same span as ``défaite les`` -> every dash-joined span was
+    counted as a substitution, inflating the WER on French dialog text and producing
+    false failures (observed firsthand on audiobook #1028: raw WER 17.24% on a
+    segment whose semantic word match was 32/32 identical).
+    """
     text = text.lower().strip()
-    text = re.sub(r"[^\w\sàâéèêëïîôùûüÿçœæ-]", " ", text)
+    # Turn dash runs (em-dash, en-dash, double hyphen, isolated hyphen between letters)
+    # into spaces BEFORE stripping punctuation, so they split tokens instead of fusing.
+    text = re.sub(r"[—–‒―]|--+", " ", text)
+    text = re.sub(r"[^\w\sàâéèêëïîôùûüÿçœæ]", " ", text)
     text = re.sub(r"\s+", " ", text)
     return text.strip()
 


### PR DESCRIPTION
## Summary

The stage-1 WER normalizer in `scripts/tts_verification/verify_transcript.py` kept the hyphen `-` in its allowed-character set, so a reference span like `Défaite--les Citoyens` fused into the single token `défaite--les` while Whisper transcribes the same span as `défaite les`. Every dash-joined dialog span was counted as a substitution → inflated WER on French dialog text → false failures.

## Bug — hand-verified on #1028

Running `verify_transcript.py` on the `narrateur` segment of the audiobook EPIC:
- **Raw WER (default normalize): 17.24%** → would FAIL the 15% threshold.
- **Semantic word match: 32/32 words identical** → the "errors" were 100% long-dash (`--`) tokenization artifacts (CER 3.24%).
- The segment should have been a clean PASS for the intelligibility floor.

This is exactly the false-failure class that wastes review time on #1028.

## Fix

Turn dash runs into word separators **before** stripping punctuation:
- em-dash `—`, en-dash `–`, figure-dash `‒`, horizontal-bar `―`
- `--` runs (the dialog markup style in Boule de Suif)
- isolated hyphens (so `francs-tireurs` → `francs tireurs`, matching how Whisper transcribes French compounds)

After the fix: **narrateur WER 17.24% → 0.00%** (CER 3.24% → 0.00%), matching the verified semantic word identity. Real substitutions are still caught (regression test).

## Verification

- [x] **Before/after on the real segment** (hand-verified): 17.24% → 0.00% WER, no word error.
- [x] **New test suite** `scripts/tests/test_verify_transcript.py` — 13 tests, all green:
  - dash-separation (double-hyphen, em-dash, en-dash, hyphen-compound)
  - French diacritics preserved
  - punctuation stripped, whitespace collapsed
  - WER/CER math (identical=0, real-sub>0, empty-ref edge cases)
  - **named regression test** `test_regression_audiobook_narrateur_dash_dialog_zero_wer`
- [x] **No regression**: `test_verify_prosody.py` still 18/18 green.
- [x] Pure-logic tests (no audio, no Whisper service) → run in plain CI.

## Scope

One-file fix to the normalizer + one new test file mirroring the sibling `test_verify_prosody.py` convention (`scripts/tests` is in `pytest.ini` testpaths). No notebook, no catalogue, no audio touched.

See #1028 (audiobook intelligibility gate). Partial contribution — does not close the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)