### PR TITLE
docs(qc,#3976): synchronise QUICK_TOUR counts on canonical leafs (116/55)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
+++ b/MyIA.AI.Notebooks/QuantConnect/QUICK_TOUR.md
@@ -1,6 +1,6 @@
 # QuantConnect AI Trading - Quick Tour
 
-**95+ stratégies backtested | 51 notebooks Python | 20 patterns confirmés | Composite robuste (TrendWeather Sharpe aligné 0.95)**
+**116 stratégies backtestées (projects/) | 55 notebooks Python (Python/) | 20 patterns confirmés | Composite robuste (TrendWeather Sharpe aligné 0.948)**
 
 Cette section contient un parcours complet de trading algorithmique sur **QuantConnect LEAN**, du débutant au déploiement live. Tout est exécutable gratuitement sur le cloud QC.
 
@@ -10,11 +10,11 @@ Cette section contient un parcours complet de trading algorithmique sur **QuantC
 
 1. **[Meilleure stratégie](projects/Framework_Composite_TrendWeather/)** — Composite TrendStocks + AllWeather (Sharpe 1.156, CAGR 27.4%). Architecture Algorithm Framework modulaire : AlphaModel + PortfolioConstruction + Execution.
 
-2. **[Catalogue stratégies](docs/qc_strategies_catalog.md)** — 95+ projets organisés par catégorie (Alpha, Trend Following, ML/RL, Composites). Top performers vérifiés alignés (#1630) : Long-Short Harvest (Sharpe **1.64**, PSR 98.7%), TrendWeather Composite (**0.948**, PSR 56.6%), EMATrend (**0.611**).
+2. **[Catalogue stratégies](docs/qc_strategies_catalog.md)** — 116 projets organisés par catégorie (Alpha, Trend Following, ML/RL, Composites) — voir [`projects/README.md`](projects/README.md) pour la classification canonique par robustesse (Robuste / Historique / Exploratoire). Top performers vérifiés alignés (#1630) : Long-Short Harvest (Sharpe **1.64**, PSR 98.7%), TrendWeather Composite (**0.948**, PSR 56.6%), EMATrend (**0.611**).
 
 3. **[Patterns confirmés](../../docs/qc/quantconnect.md)** — 20 patterns valides sur 30+ iterations (risk-adjusted momentum, skip-month, stop-loss -8/-12%, monthly rebalancing, anti-overfitting) et 10 anti-patterns critiques (SPY Parking, backtests courts, yfinance != QC cloud).
 
-4. **[Notebooks pédagogiques](Python/)** — 51 notebooks en 8 phases progressives : fondations LEAN, universe/asset classes, risk management, Algorithm Framework, données alternatives, ML (RF/XGBoost), deep learning (LSTM/Transformers), RL et LLMs pour trading.
+4. **[Notebooks pédagogiques](Python/)** — 55 notebooks en 8 phases progressives (cf. classification 4-types par modalité d'exécution dans [`Python/README.md`](Python/README.md) — quantbook QC Cloud / research companion / standalone local / placeholder pédagogique) : fondations LEAN, universe/asset classes, risk management, Algorithm Framework, données alternatives, ML (RF/XGBoost), deep learning (LSTM/Transformers), RL et LLMs pour trading.
 
 5. **[Mapping livre Jared Broad](BOOK_MAPPING.md)** — 63 exemples du livre *Hands-On AI Trading* (2025) mappés à nos notebooks et projets. 22 stratégies ML du Chapitre 6 importées.
 


### PR DESCRIPTION
Closes nothing — See #3976 (rollout parent #3973/#3975 feuilles READMEs, partiel 1/N)

## Contexte (mandat user 2026-06-21 readme-french-first + §E pr-review-discipline)

QUICK_TOUR.md (hub QuantConnect, point d'entrée rapide) contenait trois counts stale non synchronisés avec les sources canoniques par sous-série. Découverte lors de l'audit §E fichier-entier obligatoire (mandat user 2026-07-04 post-plainte PR #5345 Probas) appliqué sur la famille QC partition-mienne.

Issue #3976 (owner po-2024 par greenlight ai-01) trace le rollout global des feuilles READMEs QC (#3973+#3975 par-série) ; cette PR contribue livrable 1/N = hub-level counts alignés sur les leafs.

## Triple incohérence identifiée (G.1 firsthand)

| # | Ligne | Stale (avant) | Canonical (après) | Source canonique |
|---|-------|---------------|-------------------|------------------|
| 1 | L3 | 95+ stratégies + Sharpe aligné 0.95 | 116 stratégies (projects/) + 0.948 | projects/README.md L3 + quote #1630 vérifié TrendWeather Sharpe 0.948 |
| 2 | L13 | 95+ projets | 116 projets | projects/README.md L3 = 116 projets |
| 3 | L17 | 51 notebooks | 55 notebooks | Python/README.md L17 = 55 .ipynb |

Pourquoi ne PAS aligner sur le hub README principal (MyIA.AI.Notebooks/QuantConnect/README.md) ? Le hub README dit pedagogical_count: 105 avec breakdown Python=53, projects=49 = sous-ensemble pédagogique filtré, distinct des leafs (Python total brut = 55, projects total brut = 116). Aligner QUICK_TOUR sur le hub créerait une 2e incohérence entre hub et leafs. Choix retenu : aligner sur les sources canoniques per sous-série (projects/README.md + Python/README.md), puis traiter la divergence hub↔leafs dans un suivi dédié si nécessaire (sub-issue fille #3976).

## Sources canoniques (cross-référencées dans le hub)

| Sous-série | Source canonique | Count canonique |
|------------|------------------|------------------|
| projects/ | MyIA.AI.Notebooks/QuantConnect/projects/README.md L3 | 116 projets |
| Python/ | MyIA.AI.Notebooks/QuantConnect/Python/README.md L17 | 55 .ipynb |
| research/ | MyIA.AI.Notebooks/QuantConnect/research/README.md | 20 notebooks standalone |

## Workflow per c.626 doc-OWN pattern

- Worktree : ../CoursIA-quick-tour-sync branch feature/quick-tour-sync-3976 (origin/main frais c0b8bd7b6, post-#6956 merge)
- Pre-flight collision scan (L539-L1 ★★★) : git fetch --all && git branch -r | grep = 0 hits ; gh pr list --search QUICK_TOUR dernière PR = #4069 (2026-06-23, jamais mergée) = 0 collision
- §E surgical single-file : 1 fichier / 6 lignes diff (3+/3-) / 1 feature (count sync) / 1 domaine (QC docs)
- Prose FR préservée verbatim (readme-french-first) : aucune réécriture, uniquement mise à jour des counts + 2 cross-refs naturelles
- Pas de CATALOG-STATUS touché (catalog-pr-hygiene R1) : seul le marqueur du hub README change au cron
- Pas de catalogue régénéré (COURSE_CATALOG.generated.{json,md} byte-identique à main)

## Hors-scope explicite

1. Réconciliation hub README ↔ leafs (pedagogical_count: 105 vs leafs 55+116 = ?) : divergence légitime (hub = sous-ensemble pédagogique filtré, leafs = total brut), sub-issue à créer post-merge.
2. Audit fichier-entier des autres READMEs QC (research/, ML-Training-Pipeline/, kelly_lean/) : sub-issues du rollout #3976 à scheduler.
3. Sharpe catalogue vs Sharpe aligné : ligne 7 du hub parle déjà de la dérive ; le count L3 affiche désormais le Sharpe aligné (0.948) qui est la valeur de référence (#1630).

## Auto-audit §E pr-review-discipline

| Check | Verdict | Source |
|-------|---------|--------|
| Scope atomique strict | OK : 1 fichier QUICK_TOUR.md, 6 lignes diff (3+/3-) | git show --stat |
| §E audit fichier-entier | OK : (a) ls count par sous-dossier cité, (b) réconciliation disque ↔ cross-réfs, (c) listes/arbres : N/A (5 points avec liens, pas de compte par-série) | lecture intégrale QUICK_TOUR.md 28 lignes + leafs |
| catalog-pr-hygiene R1 | OK : 0 catalogue touché | git diff --stat origin/main |
| readme-french-first | OK : prose FR préservée verbatim | diff verbatim |
| G.4 composite split | OK : 1 file / 6 lignes (sous seuil 3000/15/4/1) | git diff --stat |
| G.1 verify-before-claiming | OK : counts vérifiés firsthand (116 dans projects/README.md L3, 55 dans Python/README.md L17, Sharpe 0.948 cité verbatim #1630) | Read direct |
| R4 See #N partiel honnête | OK : See #3976 — livrable 1/N, pas Closes sur epic | body PR |
| No secrets leak | OK : 0 secret, 0 chemin, 0 IP, 0 token | diff verbatim |
| UTF-8 no-BOM + LF-only | OK : UTF-8, fin .md)\n | tail -c 5 \| xxd |
| Pre-flight collision scan L539-L1 ★★★ | OK : 0 branche distante concurrente, 0 PR ouverte | git fetch --all + gh pr list |

## Reproductibilité

```bash
ls MyIA.AI.Notebooks/QuantConnect/
grep -E '^\*\*[0-9]+' MyIA.AI.Notebooks/QuantConnect/projects/README.md | head -3
# → 116 projets (canon)
grep -E '^\*\*[0-9]+' MyIA.AI.Notebooks/QuantConnect/Python/README.md | head -3
# → 55 notebooks (canon, phases)
```

## Liens

- Issue : #3976 (rollout parent feuilles READMEs QC, owner po-2024)
- Worktree : ../CoursIA-quick-tour-sync branch feature/quick-tour-sync-3976
- Commit : 61b030ab7
- Sources canoniques : projects/README.md L3 + Python/README.md L17
- Mandat : readme-french-first + pr-review-discipline §E