### PR TITLE
ci(#6959,#6927): svg-comma-guard CI gate — block SVG decimal-comma render regressions

### DIFF
--- a/.github/workflows/svg-comma-guard.yml
+++ b/.github/workflows/svg-comma-guard.yml
@@ -1,0 +1,74 @@
+name: svg-comma-guard
+
+# Durable render-regression guard for the SVG decimal-comma defect in .NET
+# Interactive notebook outputs (code-style.md #6927 canon, secrets-hygiene.md
+# Stop & Repair). On a fr-FR (or any comma-decimal) machine, C# `:F1`/`:F3`/
+# `ToString()` are culture-sensitive and emit `cx="70,0"`. In an SVG coordinate a
+# comma is a TOKEN SEPARATOR, so `cx="70,0"` is parsed as two numbers by Chromium
+# (the GitHub / nbviewer render engine) and the figure renders zigzagged or blank.
+#
+# This defect is INVISIBLE to every existing check: notebook-validation only parses
+# structure, notebook-execution-required only proves the kernel ran, and there is no
+# visual-render gate -- so 20 green checks can sit on top of a broken figure. Only a
+# vision-QA pass (a human or a vision-capable model) or this mechanical detector
+# catches it. This workflow closes the gap by FAILING any PR that commits an SVG
+# output whose coordinates carry decimal commas.
+#
+# The fix is a Stop & Repair source fix, NOT a hand-edit of the committed output:
+# force InvariantCulture in the cell (or reuse the canon SvgChartHelper.cs #6942,
+# whose F() already formats with dots) and RE-EXECUTE the .NET kernel so the
+# committed output carries dot-decimals.
+#
+# Scope: main-repo notebooks only. `actions/checkout@v4` does not initialise
+# submodules, so the detector's rglob over MyIA.AI.Notebooks/ naturally sees no
+# submodule notebooks (their working trees are absent) -- same main-repo-only design
+# as banner-guard.yml. Sibling detector of detect_blank_figures.py (#6918); the
+# detector itself is #6959. Registre #3801 / rollout #6927.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.ipynb'
+      - 'scripts/notebook_tools/detect_svg_decimal_commas.py'
+      - '.github/workflows/svg-comma-guard.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - '**.ipynb'
+      - 'scripts/notebook_tools/detect_svg_decimal_commas.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: svg-comma-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  svg-comma-scan:
+    name: "SVG decimal-comma guard (main-repo notebooks)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # Default checkout does not initialise submodules -- the guard stays
+      # main-repo-only (submodules carry their own CI).
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: "Fail if any SVG output carries decimal-comma coordinates"
+        run: |
+          if ! python scripts/notebook_tools/detect_svg_decimal_commas.py --check; then
+            echo ""
+            echo "::error::An SVG output was committed with decimal-comma coordinates (e.g. cx=\"70,0\") -- the figure renders zigzagged or blank on GitHub / nbviewer (Chromium parses the comma as a coordinate separator)."
+            echo "Fix (Stop & Repair source fix, NOT a hand-edit of the output):"
+            echo "    force InvariantCulture in the cell (F(double)=v.ToString(\"0.###\", CultureInfo.InvariantCulture))"
+            echo "    or reuse the canon SvgChartHelper.cs (#6942) whose F() already formats with dots,"
+            echo "    then RE-EXECUTE the .NET kernel so the committed output carries dot-decimals."
+            exit 1
+          fi


### PR DESCRIPTION
## Quoi

Câble le détecteur `detect_svg_decimal_commas.py` (#6959) en **gate CI durable**, sur le modèle de `banner-guard.yml`.

## Pourquoi

Le bug de rendu fr-FR (`cx="70,0"` : la virgule décimale culture-sensitive de C# `:F1`/`:F3` devient un **séparateur de coordonnées** SVG → Chromium, moteur de rendu GitHub/nbviewer, casse la figure en zigzag/blanc) est **INVISIBLE à toute la CI existante** : `notebook-validation` ne parse que la structure, `notebook-execution-required` ne prouve que l'exécution du kernel, et aucun gate ne vérifie le **rendu visuel**. 20 checks verts peuvent donc reposer sur une figure cassée — seul un vision-QA (humain / modèle vision) ou ce détecteur mécanique l'attrape.

Ce guard protège tout le **rollout #6927** (SVG-inline, ~20 notebooks .NET Infer/DecInfer/GameTheory/Search restants) contre la ré-introduction du défaut par les lanes no-vision.

## Design (miroir banner-guard.yml)

- **Trigger** : PRs (+ push `main`) touchant `**.ipynb` ou le détecteur.
- **Scope main-repo only** : `actions/checkout@v4` n'initialise pas les submodules → le `rglob` du détecteur sur `MyIA.AI.Notebooks/` ne voit aucun notebook de submodule (working-trees absents). Même design que banner-guard.
- **Vert sur `main` courant** : 945 notebooks scannés, **0 défaut, exit 0** (vérifié firsthand ai-01).
- **Message d'échec = Stop & Repair** : fix à la SOURCE (InvariantCulture / helper canon `SvgChartHelper.cs` #6942 dont `F()` formate déjà en points) + **re-exécution** du kernel .NET — JAMAIS un hand-edit de la sortie (secrets-hygiene règle 6).

Sibling de `detect_blank_figures.py` (#6918). Registre axe-2 SOTA #3801.

See #6927
See #6959

🤖 Generated with [Claude Code](https://claude.com/claude-code)