### PR TITLE
feat(notebook-tools,#3801): detect_svg_empty_display.py — catch white-figure regression (display(chart)→empty output)

### DIFF
--- a/scripts/notebook_tools/detect_svg_empty_display.py
+++ b/scripts/notebook_tools/detect_svg_empty_display.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+r"""Detecte les cellules .NET qui `display()` un chart SVG mais produisent un output VIDE (figure BLANCHE sur GitHub/nbviewer).
+
+Pourquoi cet outil existe
+-------------------------
+Le rollout SVG inline (#6927) remplace les graphiques Plotly.js-CDN par du SVG
+inline `text/html` qui rend partout. Le canon (ai-01, `svg-6927-canon.md`) pose
+deux regles mecaniques pour qu'un notebook converti rende REELLEMENT :
+
+  1. Le SVG doit etre la **derniere expression de cellule** (`execute_result`),
+     PAS `display(chart)` -> sous .NET Interactive headless, `display(chartObj)`
+     produit frequemment un **output vide** (`outputs: []`) alors meme que la
+     cellule s'execute sans erreur (`execution_count` set).
+  2. no-cdn + no-comma sont **necessaires PAS suffisantes** : un output vide
+     passe les deux detecteurs (`detect_svg_decimal_commas.py` #6959 n'a aucun
+     SVG a verifier ; `detect_blank_figures.py` #6918 cible les PNG degenerees,
+     pas les outputs text/html manquants). Resultat : **figure BLANCHE sur
+     GitHub** alors que CI est verte, code execute, valeurs correctes ->
+     invisible a la review de code et a la validation structurelle. Incident
+     fondateur : PR #6963 (DecInfer-6, po-2023) -- 4 cellules
+     `display(SvgChartHelper.Bar(...))` avec exec_count set mais `outputs: []`,
+     0 SVG dans tout le notebook ; base main avait 5 outputs Plotly-CDN, head a
+     0 chart = regression nette (Plotly-blanc -> rien du tout).
+
+Portee cluster : tous les workers po-* convergent les notebooks Plotly-CDN vers
+SvgChartHelper.cs (#6942) ou des builders inline. Une conversion qui utilise
+`display(chart)` au lieu d'une derniere expression peut silencieusement produire
+un output vide -> l'objectif explicite de la PR « render on GitHub/nbviewer »
+est non atteint. Les 21 PRs soeurs du rollout #6927 sont a risque.
+
+Ce que l'outil DETECTE (DETERMINISTE, zero faux-positif)
+-------------------------------------------------------
+Pour chaque cellule **code** d'un notebook, flagge si les 3 conditions sont
+vraies SIMULTANEMENT :
+
+  1. **`execution_count` est non-null** -- la cellule a reellement execute
+     (exclut les cellules non-run, `outputs: []` legitime).
+  2. **`outputs == []`** (vide, **pas** de sortie stream/error/display) -- la
+     cellule a produit STRICTEMENT rien. Une cellule en erreur aurait un output
+     `error` (probleme different, attrape par H.1) ; une cellule qui print a un
+     output `stream`. Ici on cible le cas precis ou l'execution reussit
+     (`execution_count` set) mais n'emet AUCUN output.
+  3. **La source contient un pattern de DISPLAY de chart** -- la cellule a
+     l'intention declaree de produire un graphique :
+       - `display(SvgChartHelper.`  (canon helper #6942)
+       - `display(HTML(`            (wrapper HTML inline, ex GT-3 #6961)
+       - `ScatterSvg` / `PlotSvg` / `BuildScatterSvg` (builders inline,
+         ex Infer-17 #6946, MGS-15 #6960)
+
+     La combinaison (display-intention + execution reussie + zero output) est la
+     **signature exacte** du blanc-sur-GitHub. **Zero faux-positif** : aucune
+     cellule legitime n'ecrit `display(SvgChartHelper.Bar(...))` (ou un builder
+     SVG) en attendant un output vide -- une cellule qui construit un chart
+     sans l'afficher ne contient pas ces patterns de display.
+
+Ce qu'il NE corrige PAS
+-----------------------
+Il DETECTE, il ne CORRIGE PAS. La correction = faire du chart la **derniere
+expression** de la cellule (retirer le `display(...)` et laisser l'objet chart
+comme valeur de finalisation -> `execute_result` porte le SVG), OU investiguer
+pourquoi le helper n'emet pas sous l'exec headless, puis **re-executer** le
+kernel .NET -> l'output committee porte le `<svg>`. Stop&Repair : on repare la
+cause et on re-execute, jamais scrubber la sortie a la main (regle
+secrets-hygiene 6).
+
+Known blind spots (hors scope par design)
+-----------------------------------------
+- **Cellule qui `display()` un chart et emet un output SANS svg** (ex un
+  stream-only ou un display_data d'un autre type) : non couvert ici (rare ;
+  l'echec canonique de #6927 est l'output totalement vide). Le cas "output
+  present mais sans svg" est un defeau de logique applicative, pas un blanc
+  de display.
+- **Notebooks non-.NET** : les patterns (`SvgChartHelper`, `display(HTML(`,
+  `ScatterSvg`) sont specifiques au rollout .NET/C# de #6927. Un notebook
+  Python matplotlib n'utilise pas ces constructs (ses charts sont des PNG en
+  `image/png`, couverts par `detect_blank_figures.py` #6918).
+- **Detection base-vs-head** : cet outil scanne un notebook tel-committe (pas
+  un diff). Une PR qui SUPPRIME intentionnellement une cellule chart n'est pas
+  flaggee (la cellule n'existe plus). Le cas #6963 est detecte car les cellules
+  existent toujours (videes de leur output, pas supprimees).
+
+Usage
+-----
+    python detect_svg_empty_display.py NB.ipynb                 # un notebook
+    python detect_svg_empty_display.py --family Probas          # une famille
+    python detect_svg_empty_display.py                          # tous les notebooks
+    python detect_svg_empty_display.py NB.ipynb --json          # sortie machine
+    python detect_svg_empty_display.py NB.ipynb --check         # exit 1 si defauts (CI-ready)
+
+Exit codes
+----------
+    0 -- aucun defaut (ou mode non --check)
+    1 -- un ou plusieurs defauts (--check seulement)
+    2 -- erreur (notebook illisible, famille introuvable)
+
+Voir aussi
+----------
+- `detect_svg_decimal_commas.py` (#6959) -- l'AUTRE defeau de rendu SVG (virgule
+  decimale fr-FR -> zigzag). Les deux detecteurs sont complementaires : celui-ci
+  attrape le "chart absent", #6959 attrape le "chart present mais casse".
+- `detect_blank_figures.py` (#3801/#6918) -- figures PNG degenerees (1x1, 70 o).
+- `.github/workflows/svg-decimal-comma-gate.yml` (#6965) -- gate CI per-PR pour
+  #6959 ; cet outil est destine a une gate soeur.
+- ai-01 canon `svg-6927-canon.md` (points 1 et 2) -- la regle que cet outil
+  encode mecaniquement.
+
+Part of #3801 (EPIC SOTA axe-2) + See #6927 (SVG inline rollout).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Pattern de DISPLAY de chart : la cellule a l'intention declaree de produire
+# un graphique SVG inline (canon helper #6942, wrapper HTML inline, ou builders
+# ScatterSvg/PlotSvg/BuildScatterSvg utilises par Infer-17/MGS-15). Zero-FP :
+# aucun code legitime n'ecrit ces constructs sans en attendre un output.
+_CHART_DISPLAY_RE = re.compile(
+    r"display\s*\(\s*SvgChartHelper\."  # canon: display(SvgChartHelper.Bar(...))
+    r"|display\s*\(\s*HTML\s*\("         # wrapper HTML inline (display(HTML(...)))
+    r"|ScatterSvg"                        # builder inline (Infer-17 #6946)
+    r"|PlotSvg"                           # builder inline (GT-3 #6961)
+    r"|BuildScatterSvg",                  # builder inline (MGS-15 #6960)
+    re.IGNORECASE,
+)
+
+# Un bloc <svg ...> dans un output (preuve qu'un chart a bien ete emis).
+_SVG_RE = re.compile(r"<svg\b", re.IGNORECASE)
+
+
+def _cell_source(cell: dict) -> str:
+    src = cell.get("source", "")
+    if isinstance(src, list):
+        return "".join(src)
+    return str(src)
+
+
+def _output_has_svg(outputs: list) -> bool:
+    """True si un des outputs porte un <svg> dans text/html ou image/svg+xml."""
+    for out in outputs:
+        if not isinstance(out, dict):
+            continue
+        data = out.get("data", {})
+        if not isinstance(data, dict):
+            continue
+        for payload in data.values():
+            txt = "".join(payload) if isinstance(payload, list) else str(payload)
+            if _SVG_RE.search(txt):
+                return True
+    return False
+
+
+def detect_cell(cell: dict) -> bool:
+    """True si la cellule code porte le signature blanc-sur-GitHub.
+
+    3 conditions co-necessaires (zero-FP) :
+      1. execution_count non-null (cellule rellement executee)
+      2. outputs == [] (strictement vide -- pas d'erreur, pas de stream)
+      3. source contient un pattern display(chart) (intention declaree)
+    """
+    if cell.get("cell_type") != "code":
+        return False
+    if cell.get("execution_count") is None:  # pas executee -> outputs=[] legit
+        return False
+    outputs = cell.get("outputs", [])
+    if outputs:  # a un output (erreur/stream/display) -> pas le blanc cible
+        return False
+    if _output_has_svg(outputs):  # defensive (vide -> toujours False)
+        return False
+    return bool(_CHART_DISPLAY_RE.search(_cell_source(cell)))
+
+
+def detect_cell_detail(cell: dict) -> dict | None:
+    """Return a detail dict if the cell is flagged, else None (for reporting)."""
+    if not detect_cell(cell):
+        return None
+    return {
+        "exec_count": cell.get("execution_count"),
+        "source_excerpt": _cell_source(cell)[:120].replace("\n", " "),
+        "matched_pattern": _matched_pattern(_cell_source(cell)),
+    }
+
+
+def _matched_pattern(src: str) -> str:
+    """Human-readable name of the first chart-display pattern matched."""
+    s = src
+    if re.search(r"display\s*\(\s*SvgChartHelper\.", s, re.IGNORECASE):
+        return "display(SvgChartHelper.<chart>)"
+    if re.search(r"display\s*\(\s*HTML\s*\(", s, re.IGNORECASE):
+        return "display(HTML(<svg>))"
+    if re.search(r"ScatterSvg", s, re.IGNORECASE):
+        return "ScatterSvg builder"
+    if re.search(r"PlotSvg", s, re.IGNORECASE):
+        return "PlotSvg builder"
+    if re.search(r"BuildScatterSvg", s, re.IGNORECASE):
+        return "BuildScatterSvg builder"
+    return "chart-display"
+
+
+def scan_notebook(path: Path) -> dict:
+    """Return a result dict for one notebook: path, kernel, hits[], error."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            nb = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"path": str(path), "error": str(exc), "hits": []}
+    hits = []
+    for ci, cell in enumerate(nb.get("cells", [])):
+        detail = detect_cell_detail(cell)
+        if detail:
+            hits.append({"cell_index": ci, **detail})
+    kernel = nb.get("metadata", {}).get("kernelspec", {}).get("name", "?")
+    return {"path": str(path), "kernel": kernel, "hits": hits, "error": None}
+
+
+# Dossiers a ignorer (alignes sur detect_svg_decimal_commas.py / detect_blank_figures.py).
+SKIP_DIRS = {
+    ".lake", ".git", "__pycache__", "_archives", "archive", "_archive",
+    ".ipynb_checkpoints", ".pytest_cache", "worktrees",
+    "foundry-lib",  # lib vendored tierce, pas a nous a fixer
+}
+_OUTPUT_SUFFIX = "_output.ipynb"
+
+
+def _should_skip(rel: Path) -> bool:
+    if any(part in SKIP_DIRS for part in rel.parts):
+        return True
+    return rel.name.endswith(_OUTPUT_SUFFIX)
+
+
+def _iter_notebooks(root: Path, family: str | None):
+    base = root / "MyIA.AI.Notebooks"
+    if family:
+        base = base / family
+    if not base.exists():
+        return
+    for nb in sorted(base.rglob("*.ipynb")):
+        if _should_skip(nb.relative_to(base)):
+            continue
+        yield nb
+
+
+def _human_report(results: list[dict]) -> str:
+    total_hits = sum(len(r["hits"]) for r in results)
+    affected = [r for r in results if r["hits"]]
+    errored = [r for r in results if r.get("error")]
+    lines = [
+        f"Notebooks scanned    : {len(results)}",
+        f"Empty-display defects : {total_hits}",
+        f"Affected notebooks   : {len(affected)}",
+        "",
+    ]
+    if not affected:
+        lines.append(
+            "No empty-display defects detected (display(chart) cell with empty output)."
+        )
+        if errored:
+            lines.append("")
+            lines.append(f"NOTE: {len(errored)} notebook(s) unreadable (see --json for details).")
+        return "\n".join(lines)
+    for r in affected:
+        short = r["path"].split("MyIA.AI.Notebooks")[-1].lstrip("\\/")
+        lines.append(f"## {short}  [{r['kernel']}]")
+        for h in r["hits"]:
+            lines.append(
+                f"  - cell [{h['cell_index']}] exec_count={h['exec_count']} "
+                f"outputs=[] {h['matched_pattern']} : {h['source_excerpt']!r}"
+            )
+        lines.append("")
+    lines.append(
+        "FIX: make the chart the LAST EXPRESSION of the cell (drop `display(chart)` -> "
+        "leave the chart object as the cell's final value -> `execute_result` carries "
+        "the <svg>), then re-execute the .NET kernel -- the committed output then carries "
+        "the SVG. See ai-01 canon `svg-6927-canon.md` (point 1). "
+        "Stop&Repair: fix cause + re-execute, never scrub the output by hand "
+        "(secrets-hygiene rule 6)."
+    )
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("notebook", nargs="?", help="Notebook to scan (default: all pedagogical)")
+    parser.add_argument("--family", help="Top-level family under MyIA.AI.Notebooks/ (e.g. Probas)")
+    parser.add_argument("--root", default=".", help="Repo root (default: cwd)")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--check", action="store_true", help="Exit 1 if any empty-display defect (CI-ready)")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.notebook:
+        paths = [Path(args.notebook)]
+        if not paths[0].is_absolute():
+            paths[0] = root / paths[0]
+        if not paths[0].exists():
+            print(f"error: notebook not found: {paths[0]}", file=sys.stderr)
+            return 2
+    else:
+        paths = list(_iter_notebooks(root, args.family))
+        if args.family and not paths:
+            print(f"error: family not found: {args.family}", file=sys.stderr)
+            return 2
+
+    results = [scan_notebook(p) for p in paths]
+    total_hits = sum(len(r["hits"]) for r in results)
+
+    if args.json:
+        payload = {"notebooks_scanned": len(results), "total_hits": total_hits, "results": results}
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(_human_report(results))
+
+    if args.check and total_hits > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_detect_svg_empty_display.py
+++ b/scripts/notebook_tools/tests/test_detect_svg_empty_display.py
@@ -1,0 +1,195 @@
+"""Tests for scripts/notebook_tools/detect_svg_empty_display.py — empty-display
+(chart `display()`-ed but output empty = white figure on GitHub) detector.
+
+Tests focus on pure functions: detect_cell, detect_cell_detail, scan_notebook,
+and the main() exit codes. Uses synthetic notebook dicts and tmp_path for
+filesystem isolation.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from detect_svg_empty_display import (  # noqa: E402
+    detect_cell,
+    detect_cell_detail,
+    main,
+    scan_notebook,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _code_cell(source: str, exec_count=1, outputs=None) -> dict:
+    """A code cell with given source, execution_count, and outputs (default empty)."""
+    return {
+        "cell_type": "code",
+        "execution_count": exec_count,
+        "source": [source] if isinstance(source, str) else source,
+        "outputs": outputs if outputs is not None else [],
+    }
+
+
+def _svg_output(svg: str = '<svg viewBox="0 0 10 10"><rect width="10" height="10"/></svg>') -> dict:
+    """A display_data output carrying an inline SVG (the happy-path chart output)."""
+    return {"data": {"text/html": svg}, "metadata": {}, "output_type": "display_data"}
+
+
+def _write_nb(path: Path, cells: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    nb = {
+        "cells": cells,
+        "metadata": {"kernelspec": {"name": ".net-csharp"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# detect_cell — the zero-FP 3-condition signature
+# ---------------------------------------------------------------------------
+
+class TestDetectCell:
+    def test_flags_display_svgcharthelper_empty_output(self):
+        # The #6963 signature: display(SvgChartHelper.Bar(...)) + ran + empty output.
+        cell = _code_cell('display(SvgChartHelper.Bar("title", labels, vals));')
+        assert detect_cell(cell) is True
+
+    def test_flags_display_html_empty_output(self):
+        # display(HTML("<svg ...>")) wrapper + ran + empty output.
+        cell = _code_cell('display(HTML("<svg><rect/></svg>"));')
+        assert detect_cell(cell) is True
+
+    def test_flags_scattersvg_builder_empty_output(self):
+        cell = _code_cell("var c = BuildScatterSvg(xs, ys); display(c);")
+        assert detect_cell(cell) is True
+
+    def test_passes_when_output_has_svg(self):
+        # Happy path: chart display AND the SVG is in the output (not a white figure).
+        cell = _code_cell(
+            'display(SvgChartHelper.Bar("t", l, v));',
+            outputs=[_svg_output()],
+        )
+        assert detect_cell(cell) is False
+
+    def test_passes_when_exec_count_null(self):
+        # Not executed -> outputs=[] is legitimate (not a white-figure regression).
+        cell = _code_cell('display(SvgChartHelper.Bar("t", l, v));', exec_count=None)
+        assert detect_cell(cell) is False
+
+    def test_passes_when_outputs_nonempty_stream(self):
+        # Has a stream output (Console.WriteLine) -> not the empty-display signature.
+        cell = _code_cell(
+            'Console.WriteLine("hi"); display(SvgChartHelper.Bar("t", l, v));',
+            outputs=[{"name": "stdout", "output_type": "stream", "text": ["hi"]}],
+        )
+        assert detect_cell(cell) is False
+
+    def test_passes_when_outputs_nonempty_error(self):
+        # Has an error output -> different problem (caught by H.1), not flagged here.
+        cell = _code_cell(
+            'display(SvgChartHelper.Bar("t", l, v));',
+            outputs=[{"output_type": "error", "ename": "Exception", "evalue": "boom"}],
+        )
+        assert detect_cell(cell) is False
+
+    def test_passes_when_no_chart_display_pattern(self):
+        # A legitimately silent cell (defines a function, no display(chart)) -> not flagged.
+        cell = _code_cell("double Mean(double[] xs) => xs.Average();")
+        assert detect_cell(cell) is False
+
+    def test_passes_markdown_cell(self):
+        assert detect_cell({"cell_type": "markdown", "source": ["# hi"], "outputs": []}) is False
+
+    def test_passes_case_insensitive_display(self):
+        # DISPLAY( vs display( — C# is case-insensitive; source may use either.
+        cell = _code_cell('DISPLAY(SvgChartHelper.Bar("t", l, v));')
+        assert detect_cell(cell) is True
+
+
+# ---------------------------------------------------------------------------
+# detect_cell_detail — reporting fields
+# ---------------------------------------------------------------------------
+
+class TestDetectCellDetail:
+    def test_detail_returns_exec_count_and_pattern(self):
+        cell = _code_cell('display(SvgChartHelper.Bar("t", l, v));', exec_count=7)
+        d = detect_cell_detail(cell)
+        assert d is not None
+        assert d["exec_count"] == 7
+        assert "SvgChartHelper" in d["matched_pattern"]
+
+    def test_detail_returns_none_for_clean(self):
+        cell = _code_cell("var x = 1;", outputs=[_svg_output()])
+        assert detect_cell_detail(cell) is None
+
+
+# ---------------------------------------------------------------------------
+# scan_notebook (filesystem)
+# ---------------------------------------------------------------------------
+
+class TestScanNotebook:
+    def test_broken_notebook_flagged(self, tmp_path):
+        # Mirror of #6963: 4 chart cells with empty output.
+        cells = [
+            _code_cell('display(SvgChartHelper.Bar("a", la, va));', exec_count=1),
+            _code_cell('Console.WriteLine("setup");', exec_count=2,
+                       outputs=[{"name": "stdout", "output_type": "stream", "text": ["setup"]}]),
+            _code_cell('display(SvgChartHelper.Bar("b", lb, vb));', exec_count=3),
+        ]
+        p = _write_nb(tmp_path / "broken.ipynb", cells)
+        result = scan_notebook(p)
+        assert result["error"] is None
+        assert len(result["hits"]) == 2
+        assert {h["cell_index"] for h in result["hits"]} == {0, 2}
+
+    def test_clean_notebook_no_hits(self, tmp_path):
+        # Happy path: chart cells carry their SVG in the output.
+        cells = [_code_cell('display(SvgChartHelper.Bar("t", l, v));', outputs=[_svg_output()])]
+        p = _write_nb(tmp_path / "clean.ipynb", cells)
+        result = scan_notebook(p)
+        assert result["error"] is None
+        assert result["hits"] == []
+
+    def test_unreadable_notebook_error(self, tmp_path):
+        p = tmp_path / "bad.ipynb"
+        p.write_text("{ not json", encoding="utf-8")
+        result = scan_notebook(p)
+        assert result["error"] is not None
+        assert result["hits"] == []
+
+
+# ---------------------------------------------------------------------------
+# main() exit codes
+# ---------------------------------------------------------------------------
+
+class TestMainExitCodes:
+    def test_check_clean_exit_0(self, tmp_path):
+        p = _write_nb(tmp_path / "clean.ipynb",
+                      [_code_cell('display(SvgChartHelper.Bar("t", l, v));', outputs=[_svg_output()])])
+        assert main([str(p), "--check"]) == 0
+
+    def test_check_broken_exit_1(self, tmp_path):
+        p = _write_nb(tmp_path / "broken.ipynb",
+                      [_code_cell('display(SvgChartHelper.Bar("t", l, v));')])
+        assert main([str(p), "--check"]) == 1
+
+    def test_missing_notebook_exit_2(self, tmp_path):
+        assert main([str(tmp_path / "nope.ipynb")]) == 2
+
+    def test_json_mode(self, tmp_path, capsys):
+        p = _write_nb(tmp_path / "broken.ipynb",
+                      [_code_cell('display(SvgChartHelper.Bar("t", l, v));', exec_count=5)])
+        rc = main([str(p), "--json"])
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["total_hits"] == 1
+        assert payload["results"][0]["hits"][0]["cell_index"] == 0
+        assert rc == 0  # without --check, exit 0 even with hits


### PR DESCRIPTION
## What

New read-only detector [`scripts/notebook_tools/detect_svg_empty_display.py`](scripts/notebook_tools/detect_svg_empty_display.py) (+ 19 tests) that catches the **second** SVG-render defect class of the #6927 rollout — the one the new ai-01 canon (`svg-6927-canon.md` points 1+2) warns about and that **passes both existing detectors**.

It is the **companion to `detect_svg_decimal_commas.py` (#6959)**: #6959 catches "chart present but broken" (decimal-comma zigzag); this one catches **"chart absent — `display(chart)` produced empty output = figure BLANCHE on GitHub"**.

## Why (the gap ai-01's canon exposed)

The canon established two mechanical rules for a #6927 conversion to actually render:

1. **The SVG must be the last expression (`execute_result`), NOT `display(chart)`** → under .NET Interactive headless, `display(chartObj)` frequently produces an **empty output** (`outputs: []`) even though the cell executes without error (`execution_count` set).
2. **no-cdn + no-comma are necessary NOT sufficient** → an empty output passes both `detect_svg_decimal_commas.py` #6959 (no SVG to check) AND `detect_blank_figures.py` #6918 (targets degenerate PNG, not missing text/html). Result: **white figure on GitHub** while CI is green, code executes, values correct → invisible to code review and structural validation.

**Incident fondateur: #6963 (DecInfer-6, po-2023)** — 4 cells `display(SvgChartHelper.Bar(...))` with `execution_count` set but `outputs: []`, **0 SVG in the entire notebook**. Base main had 5 Plotly-CDN outputs → head has 0 charts = **net regression** (Plotly-blank-on-GitHub → nothing at all). ai-01 CR'd it (03:49Z); I independently confirmed the same finding firsthand this cycle (base-vs-head delta).

## Detection (deterministic, zero-FP)

Flags a **code** cell when ALL THREE hold simultaneously:

1. `execution_count` is **not null** (cell actually ran — excludes the legitimate "not-run → outputs=[]" case)
2. `outputs == []` (**strictly** empty — no error, no stream; an errored cell has an `error` output = different problem caught by H.1)
3. source matches a **chart-DISPLAY pattern** (declared intent to produce a graph):
   - `display(SvgChartHelper.` — canon helper (#6942)
   - `display(HTML(` — inline HTML wrapper (GT-3 #6961)
   - `ScatterSvg` / `PlotSvg` / `BuildScatterSvg` — inline builders (Infer-17 #6946, MGS-15 #6960)

**Zero false-positives**: no legitimate cell writes `display(SvgChartHelper.Bar(...))` (or an SVG builder) and expects empty output. A cell that builds a chart without displaying it does not contain these patterns.

## Validation (firsthand)

| Check | Result |
|---|---|
| **TP**: #6963 DecInfer-6 head (the CR'd incident) | **4 hits** (cells 29/35/45/49), `display(SvgChartHelper.<chart>)`, exit 1 with `--check` |
| **TN**: #6964 MGS-10 (clean, SVG in output) | 0 hits |
| **TN**: #6946 Infer-17 merged (converted, has output) | 0 hits |
| **Baseline**: all 930 pedagogical notebooks on main | **0 defects** (zero-FP confirmed; converted notebooks all carry their charts) |
| Unit tests | **19 passed** (0.18s) — zero-FP contract + exit codes + scan_notebook + main |
| Catalogue byte-identity | untouched (scripts-only PR) |

## Fix guidance (emitted in the detector output)

Make the chart the **last expression** of the cell (drop `display(chart)` → leave the chart object as the cell's final value → `execute_result` carries the `<svg>`), then **re-execute** the .NET kernel. Stop&Repair: fix cause + re-execute, never scrub the output by hand.

## Scope

`See #3801` (EPIC SOTA axe-2 — prevention tooling). `See #6927` (SVG inline rollout — what this protects). `See #6959` (sibling comma detector). `See #6965` (comma CI gate — a sister gate wiring this detector is the natural follow-up). Not `Closes` — prevention infra for an open epic.

## Note

ai-01 independently CR'd #6963 for this exact defect (03:49Z). This detector mechanizes that judgment so the #6963 class is caught at CI time for the remaining sister #6927 PRs, not only by manual forensic review.