### PR TITLE
fix(gt-12,#6927): Plotly CDN-script -> SVG inline Overlay (KMRW cooperation curve)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames-Csharp.ipynb
@@ -862,15 +862,16 @@
     },
     {
      "data": {
-      "text/html": [
-       "<div id=\"plt5beaaa2196a349deaf0298141f7dec9b\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt5beaaa2196a349deaf0298141f7dec9b',[{\"x\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],\"y\":[100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,100,0.3,0.3,0.3],\"type\":\"scatter\",\"mode\":\"lines\\u002Bmarkers\",\"name\":\"Cooperation mutuelle (C,C)\",\"line\":{\"color\":\"#2a6dba\",\"width\":2}}],{\"title\":{\"text\":\"KMRW : taux de cooperation par tour (effet horizon fini)\"},\"xaxis\":{\"title\":{\"text\":\"Tour\"},\"dtick\":1},\"yaxis\":{\"title\":{\"text\":\"Cooperation mutuelle (%\"},\"range\":[0,100]},\"margin\":{\"l\":50,\"r\":30,\"b\":50}})</script>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='480' viewBox='0 0 820 480' font-family='sans-serif' font-size='12'><rect width='820' height='480' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>KMRW : taux de cooperation par tour (effet horizon fini)</text><line x1='52' y1='438' x2='804' y2='438' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='442' text-anchor='end' fill='#333333'>-5.682</text><line x1='52' y1='337' x2='804' y2='337' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='341' text-anchor='end' fill='#333333'>22.234</text><line x1='52' y1='236' x2='804' y2='236' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='240' text-anchor='end' fill='#333333'>50.15</text><line x1='52' y1='135' x2='804' y2='135' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='139' text-anchor='end' fill='#333333'>78.066</text><line x1='52' y1='34' x2='804' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>105.982</text><line x1='52' y1='34' x2='52' y2='438' stroke='#888888' stroke-width='1'/><line x1='52' y1='417.443' x2='804' y2='417.443' stroke='#888888' stroke-width='1'/><text x='52' y='454' text-anchor='middle' fill='#333333'>1</text><text x='240' y='454' text-anchor='middle' fill='#333333'>5.75</text><text x='428' y='454' text-anchor='middle' fill='#333333'>10.5</text><text x='616' y='454' text-anchor='middle' fill='#333333'>15.25</text><text x='804' y='454' text-anchor='middle' fill='#333333'>20</text><text x='428' y='474' text-anchor='middle' fill='#333333'>Tour</text><text x='14' y='236' text-anchor='middle' fill='#333333' transform='rotate(-90 14 236)'>Cooperation mutuelle (%)</text><polyline points='52,55.643 91.579,55.643 131.158,55.643 170.737,55.643 210.316,55.643 249.895,55.643 289.474,55.643 329.053,55.643 368.632,55.643 408.211,55.643 447.789,55.643 487.368,55.643 526.947,55.643 566.526,55.643 606.105,55.643 645.684,55.643 685.263,55.643 724.842,416.357 764.421,416.357 804,416.357' fill='none' stroke='#2a6dba' stroke-width='2'/><circle cx='52' cy='55.643' r='3' fill='#2a6dba'/><circle cx='91.579' cy='55.643' r='3' fill='#2a6dba'/><circle cx='131.158' cy='55.643' r='3' fill='#2a6dba'/><circle cx='170.737' cy='55.643' r='3' fill='#2a6dba'/><circle cx='210.316' cy='55.643' r='3' fill='#2a6dba'/><circle cx='249.895' cy='55.643' r='3' fill='#2a6dba'/><circle cx='289.474' cy='55.643' r='3' fill='#2a6dba'/><circle cx='329.053' cy='55.643' r='3' fill='#2a6dba'/><circle cx='368.632' cy='55.643' r='3' fill='#2a6dba'/><circle cx='408.211' cy='55.643' r='3' fill='#2a6dba'/><circle cx='447.789' cy='55.643' r='3' fill='#2a6dba'/><circle cx='487.368' cy='55.643' r='3' fill='#2a6dba'/><circle cx='526.947' cy='55.643' r='3' fill='#2a6dba'/><circle cx='566.526' cy='55.643' r='3' fill='#2a6dba'/><circle cx='606.105' cy='55.643' r='3' fill='#2a6dba'/><circle cx='645.684' cy='55.643' r='3' fill='#2a6dba'/><circle cx='685.263' cy='55.643' r='3' fill='#2a6dba'/><circle cx='724.842' cy='416.357' r='3' fill='#2a6dba'/><circle cx='764.421' cy='416.357' r='3' fill='#2a6dba'/><circle cx='804' cy='416.357' r='3' fill='#2a6dba'/><rect x='632' y='42' width='168' height='32' fill='white' stroke='#E5E5E5' stroke-width='1'/><line x1='642' y1='54' x2='666' y2='54' stroke='#2a6dba' stroke-width='2'/><text x='674' y='58' fill='#333333'>Cooperation mutuelle (C,C)</text></svg>"
      },
+     "execution_count": 6,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "#load \"SvgChartHelper.cs\"\n",
+    "\n",
     "#nullable enable\n",
     "using System;\n",
     "using System.Collections.Generic;\n",
@@ -983,24 +984,15 @@
     "// La courbe en hockey-stick -- cooperation elevee en debut, effondrement sur la fin --\n",
     "// est la signature de KMRW : avec un peu d'incertitude sur le type (TFT), les joueurs\n",
     "// cooperent jusqu'a l'approche de l'horizon fini ou la defection retro-propage.\n",
-    "{\n",
-    "    var xs = Enumerable.Range(1, T).Select(t => (object)t).ToArray();\n",
-    "    var ys = coopRate.Select(v => (object)Math.Round(v * 100.0, 1)).ToArray();\n",
-    "    var trace = System.Text.Json.JsonSerializer.Serialize(\n",
-    "        new Dictionary<string, object> { [\"x\"] = xs, [\"y\"] = ys, [\"type\"] = \"scatter\", [\"mode\"] = \"lines+markers\",\n",
-    "                                         [\"name\"] = \"Cooperation mutuelle (C,C)\",\n",
-    "                                         [\"line\"] = new Dictionary<string,object>{ [\"color\"] = \"#2a6dba\", [\"width\"] = 2 } });\n",
-    "    var layout = System.Text.Json.JsonSerializer.Serialize(\n",
-    "        new Dictionary<string, object> { [\"title\"] = new Dictionary<string,object>{ [\"text\"] = \"KMRW : taux de cooperation par tour (effet horizon fini)\" },\n",
-    "                                         [\"xaxis\"] = new Dictionary<string,object>{ [\"title\"] = new Dictionary<string,object>{ [\"text\"] = \"Tour\" }, [\"dtick\"] = 1 },\n",
-    "                                         [\"yaxis\"] = new Dictionary<string,object>{ [\"title\"] = new Dictionary<string,object>{ [\"text\"] = \"Cooperation mutuelle (%\" }, [\"range\"] = new object[] { 0, 100 } },\n",
-    "                                         [\"margin\"] = new Dictionary<string,object>{ [\"l\"] = 50, [\"r\"] = 30, [\"b\"] = 50 } });\n",
-    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
-    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
-    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + trace + \"],\" + layout + \")</script>\";\n",
-    "    display(new PlotlyHtml(markup));\n",
-    "}\n"
+    "SvgChartHelper.Overlay(\n",
+    "    \"KMRW : taux de cooperation par tour (effet horizon fini)\",\n",
+    "    \"Tour\", \"Cooperation mutuelle (%)\",\n",
+    "    new[] {\n",
+    "        new SvgSeries(\"Cooperation mutuelle (C,C)\",\n",
+    "            Enumerable.Range(1, T).Select(t => (double)t).ToArray(),\n",
+    "            coopRate.Select(v => Math.Round(v * 100.0, 1)).ToArray(),\n",
+    "            TraceStyle.LineMarkers, \"#2a6dba\"),\n",
+    "    })"
    ]
   },
   {


### PR DESCRIPTION
## What

`GameTheory-12-ReputationGames-Csharp.ipynb` **cell[11]**: replace blank-in-static Plotly chart with inline static SVG via **`SvgChartHelper.Overlay()`** (single series, #6942 + #6958 MERGED).

The chart is the **KMRW cooperation rate** — mutual cooperation % per round over a 20-round iterated Prisoner's Dilemma under type uncertainty (epsilon=0.05 of TFT type). The **hockey-stick** curve (high early cooperation, collapse near the finite horizon as defection back-propagates) is the signature of reputation-based cooperation. This convergence behavior is the pedagogical point — it must render on GitHub.

## Surgical block-swap (simulation preserved)

Only the **chart-build block** is replaced by a single `Overlay()` last-expression. The full simulation (`SimulatePdWithReputation`, TFT-vs-Normal heuristic, nSims) and the text-table `sb.ToString().Display()` are **preserved byte-for-byte**. No computation changed.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Real `.net-csharp` exec (H.4) | exec_count=6, 0 errors, SVG out_len=3419 |
| `detect_svg_decimal_commas.py` (#6959, merge-gate) | **0 defects** rc=0 (helper F()=InvariantCulture) |
| `check_plotly_static_risk.py` (#6931) | GT-12 **no longer risky** |
| `cdn.plot.ly` in output | **False** |
| probeAddresses banner (kernel-inherent) | **absent** |
| series label present | True |
| Simulation + Display preserved | `SimulatePdWithReputation` + `.Display()` both intact |
| C.3 scope | **only cell[11]** changed |
| Catalog byte-identity (R1) | 0 diff; README untouched |

## Verdict: **SOTA-OK** (#3801 Prong-A)

## Notes

- **Visual QA**: GLM lane not vision-capable; routes to MiniMax (CoursIA-2) / ai-01 at merge-gate. Deterministic gates green.
- **See #6927** (partial — sibling to #6972 GT-4c + #6974 GT-17; remaining partition: GT-8c/GT-15c).

🤖 po-2025 (GLM no-vision lane)
