### PR TITLE
feat(translation,#6949): T3 engine fork — translate_csv.py starter (gated, dry-run)

### DIFF
--- a/scripts/tests/test_translate_csv.py
+++ b/scripts/tests/test_translate_csv.py
@@ -1,0 +1,231 @@
+"""Tests for scripts/translation/translate_csv.py (T3 fork Argumentum, #6949 PR #2).
+
+The T3 engine forks Argumentum ``tools/dnn_i18n/translate_game_rules.py`` (gpt-5.5,
+193 LOC) into the CoursIA 7-lang CSV schema. These tests lock the safety gates and
+the hash contract WITHOUT calling any live API (``call_chat`` is mocked):
+
+1. **Hash contract** -- ``normalize`` / ``cell_hash`` are byte-identical to T1
+   (extract_cells_to_csv.py) and T2 (check_translation_sync.py). T3 must write
+   ``hash_<lang> = cell_hash(text_<lang>)`` or T2 drift detection breaks.
+2. **Safety gates** -- ``ENABLED=False`` + ``--apply`` is a no-op (no API, no
+   mutation); default mode is dry-run (no mutation); missing env keys raise
+   ``ValueError`` (never a literal fallback -- secrets-hygiene.md).
+3. **Plan semantics** -- markdown cells with empty ``text_<lang>`` are queued;
+   code cells skipped by default (``--include-code`` opts in); pre-filled
+   ``text_<lang>`` are skipped (resume cache).
+4. **CSV coherence** -- write/load round-trip preserves column order + LF endings.
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "translation"))
+
+import translate_csv as tc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures helpers.
+# ---------------------------------------------------------------------------
+COLUMNS = tc.CSV_COLUMNS
+
+
+def _write_csv(path, rows):
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        w = csv.DictWriter(f, fieldnames=COLUMNS, lineterminator="\n")
+        w.writeheader()
+        for r in rows:
+            w.writerow({c: r.get(c, "") for c in COLUMNS})
+
+
+def _row(cell_id, cell_type, text_fr, **filled):
+    r = {c: "" for c in COLUMNS}
+    r["notebook"] = f"nb/{cell_id}.ipynb"
+    r["cell_id"] = cell_id
+    r["cell_type"] = cell_type
+    r["src_lang"] = "fr"
+    r["text_fr"] = text_fr
+    r["src_hash"] = tc.cell_hash(text_fr)
+    r["hash_fr"] = r["src_hash"]
+    r.update(filled)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# 1. Hash contract (byte-identical to T1/T2).
+# ---------------------------------------------------------------------------
+def test_normalize_rstrips_lines_and_trailing_newline():
+    # Trailing whitespace + final newline must NOT create faux drift.
+    assert tc.normalize("line   \nsecond\t\n") == "line\nsecond"
+    assert tc.normalize("single") == "single"
+    assert tc.normalize("") == ""
+
+
+def test_cell_hash_is_sha256_16_of_normalized():
+    # Pinned vector: sha256("Bonjour")[:16]. Computed once, locks the contract.
+    import hashlib
+    expected = hashlib.sha256("Bonjour".encode("utf-8")).hexdigest()[:16]
+    assert tc.cell_hash("Bonjour") == expected
+    assert len(tc.cell_hash("x")) == 16
+
+
+def test_cell_hash_trailing_whitespace_stable():
+    # Drift-detection invariant: cosmetic whitespace must not change the hash.
+    assert tc.cell_hash("text\n") == tc.cell_hash("text")
+    assert tc.cell_hash("a \n b") == tc.cell_hash("a\n b")
+
+
+# ---------------------------------------------------------------------------
+# 2. Plan semantics.
+# ---------------------------------------------------------------------------
+def test_plan_markdown_only_skips_code_by_default():
+    rows = [
+        _row("c1", "markdown", "Bonjour le monde"),
+        _row("c2", "code", "print('hi')"),
+        _row("c3", "markdown", "Autre prose"),
+    ]
+    plan = list(tc.translation_plan(rows, ["en", "es"]))
+    # c1 -> en, c1 -> es, c3 -> en, c3 -> es. Code c2 excluded.
+    idxs = sorted({i for i, _ in plan})
+    assert idxs == [0, 2]
+    assert (0, "en") in plan and (0, "es") in plan
+    assert (1, "en") not in plan  # code skipped
+
+
+def test_plan_include_code_opts_in():
+    rows = [_row("c1", "code", "x = 1  # comment")]
+    assert list(tc.translation_plan(rows, ["en"])) == []
+    assert list(tc.translation_plan(rows, ["en"], include_code=True)) == [(0, "en")]
+
+
+def test_plan_skips_prefilled_target_resume_cache():
+    rows = [_row("c1", "markdown", "Bonjour", text_en="Hello world")]
+    plan = list(tc.translation_plan(rows, ["en", "es"]))
+    # en already filled -> only es queued (resume cache semantics).
+    assert (0, "en") not in plan
+    assert (0, "es") in plan
+
+
+def test_plan_skips_empty_fr():
+    rows = [_row("c1", "markdown", "   ")]
+    assert list(tc.translation_plan(rows, ["en"])) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. CSV round-trip coherence.
+# ---------------------------------------------------------------------------
+def test_write_load_roundtrip_preserves_columns_and_lf(tmp_path):
+    p = tmp_path / "x.csv"
+    rows = [_row("c1", "markdown", "Bonjour", text_en="Hello")]
+    tc.write_csv(str(p), rows)
+    raw = p.read_bytes()
+    assert b"\r\n" not in raw  # LF endings, not CRLF
+    loaded = tc.load_csv(str(p))
+    assert len(loaded) == 1
+    assert loaded[0]["cell_id"] == "c1"
+    assert loaded[0]["text_en"] == "Hello"
+    # All canonical columns present.
+    assert set(loaded[0].keys()) >= set(COLUMNS)
+
+
+def test_load_csv_tolerates_utf8_bom(tmp_path):
+    p = tmp_path / "bom.csv"
+    rows = [_row("c1", "markdown", "Été café")]
+    _write_csv(str(p), rows)
+    # Inject a BOM.
+    p.write_bytes(b"\xef\xbb\xbf" + p.read_bytes())
+    loaded = tc.load_csv(str(p))
+    assert loaded[0]["text_fr"] == "Été café"
+    assert loaded[0]["cell_id"] == "c1"  # header not polluted by BOM
+
+
+# ---------------------------------------------------------------------------
+# 4. run_translations with mocked call_chat -- writes text_<lang> + hash_<lang>.
+# ---------------------------------------------------------------------------
+def test_run_translations_writes_text_and_hash(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_call(messages, model, key, base_url, max_tokens, reasoning_effort="low", timeout=240):
+        calls.append((model, base_url))
+        # Deterministic translation derived from the target lang (parsed from the
+        # user message "Translate ... into {LangName}.") -- no real LLM call.
+        um = next(m["content"] for m in messages if m["role"] == "user")
+        lang_name = um.split("into ")[1].split(".")[0]
+        return f"[{lang_name}] translated", 0.1, 5
+
+    monkeypatch.setattr(tc, "call_chat", fake_call)
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key-for-testing")
+
+    p = tmp_path / "x.csv"
+    rows = [_row("c1", "markdown", "Bonjour le monde")]
+    _write_csv(str(p), rows)
+
+    loaded = tc.load_csv(str(p))
+    done, fails = tc.run_translations(loaded, ["en"], include_code=False,
+                                      out_path=str(p), smoke=False)
+    assert done == 1 and fails == 0
+    result = tc.load_csv(str(p))
+    assert result[0]["text_en"] == "[English] translated"
+    # hash_en MUST equal cell_hash of the written text (T2 coherence).
+    assert result[0]["hash_en"] == tc.cell_hash("[English] translated")
+    assert calls  # provider actually invoked
+
+
+def test_run_translations_no_env_keys_raises(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    p = tmp_path / "x.csv"
+    _write_csv(str(p), [_row("c1", "markdown", "Bonjour")])
+    rows = tc.load_csv(str(p))
+    try:
+        tc.run_translations(rows, ["en"], False, str(p), False)
+    except ValueError as e:
+        assert "OPENAI_API_KEY" in str(e)
+    else:
+        raise AssertionError("ValueError attendue sans clé env (secrets-hygiene)")
+
+
+# ---------------------------------------------------------------------------
+# 5. Safety gates via main() CLI.
+# ---------------------------------------------------------------------------
+def test_main_apply_gated_when_disabled(monkeypatch, tmp_path, capsys):
+    # ENABLED=False (module default). --apply must be a no-op.
+    monkeypatch.setattr(tc, "ENABLED", False)
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key-for-testing")
+    p = tmp_path / "x.csv"
+    original = [_row("c1", "markdown", "Bonjour")]
+    _write_csv(str(p), original)
+    monkeypatch.setattr(sys, "argv", ["translate_csv.py", "--csv", str(p), "--apply"])
+    rc = tc.main()
+    assert rc == 0
+    # No mutation, no API: text_en still empty.
+    assert tc.load_csv(str(p))[0]["text_en"] == ""
+    err = capsys.readouterr().err
+    assert "GATED" in err and "ENABLED=False" in err
+
+
+def test_main_dry_run_default_no_mutation(monkeypatch, tmp_path, capsys):
+    p = tmp_path / "x.csv"
+    _write_csv(str(p), [_row("c1", "markdown", "Bonjour le monde")])
+    monkeypatch.setattr(sys, "argv", ["translate_csv.py", "--csv", str(p)])
+    rc = tc.main()
+    assert rc == 0
+    assert tc.load_csv(str(p))[0]["text_en"] == ""  # untouched
+    err = capsys.readouterr().err
+    assert "dry-run" in err or "dry_run" in err
+    assert "traductions nécessaires" in err  # plan reported
+
+
+def test_main_smoke_limits_to_one_cell(monkeypatch, tmp_path, capsys):
+    p = tmp_path / "x.csv"
+    _write_csv(str(p), [
+        _row("c1", "markdown", "Premier"),
+        _row("c2", "markdown", "Deuxième"),
+    ])
+    monkeypatch.setattr(sys, "argv", ["translate_csv.py", "--csv", str(p), "--smoke"])
+    tc.main()
+    # Smoke plan = 1 cell x 7 langs = 7 (not 14).
+    err = capsys.readouterr().err
+    # The plan line reports the count after smoke reduction.
+    assert "7 traductions nécessaires" in err or " 7 " in err

--- a/scripts/translation/translate_csv.py
+++ b/scripts/translation/translate_csv.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""T3 — Moteur de traduction des cellules de notebooks (FR source -> 7 langues cibles).
+
+FORK depuis Argumentum `tools/dnn_i18n/translate_game_rules.py` (gpt-5.5, 193 LOC,
+commit submodule 7e72f3e5d), adapte au schéma CSV CoursIA (Epic #4957 / #1650).
+Voir issue #6949 (PR #2/2) pour le mapping Argumentum -> CoursIA et la motivation
+(arrêt des resync CSV "dans le vide" : sans ce moteur, les PRs de drift T1/T2
+produisent 0 cellule traduite en 7 langues cibles).
+
+Couches : T1 (extract_cells_to_csv.py) + T2 (check_translation_sync.py) sont
+livrées ; ce script est la couche T3 (gated). Il lit un CSV `translations/<famille>/
+<série>.csv`, traduit les cellules `text_fr` vers les langues cibles dont la colonne
+`text_<lang>` est vide, et réécrit le CSV avec `text_<lang>` + `hash_<lang>` cohérent
+avec T2 (hash_<lang> = cell_hash(text_<lang>), même normalize que T1/T2).
+
+Sécurité (HARD) :
+  - `ENABLED = False` par défaut. Même avec `--apply`, le moteur refuse d'appeler
+    l'API tant que `ENABLED` n'est pas passé à `True` dans la source (GO user,
+    #6949 moyen terme). Triple gate : edit source + --apply + clé env.
+  - `--dry-run` est le mode défaut (no API, no mutation) : imprime le plan de
+    traduction (cellules markdown x langues = N appels).
+  - Les clés API viennent UNIQUEMENT de l'environnement (`OPENAI_API_KEY`,
+    `OPENROUTER_API_KEY` optionnel). Aucun littéral, aucun fichier `.keys/`,
+    aucun `os.getenv("KEY", "<défaut>")` (secrets-hygiene.md règle 1-3).
+
+gpt-5.5 specifics (verified Argumentum #499 pilot, 2026-06-16) :
+  - Pas de `temperature` (HTTP 400 sur reasoning models).
+  - `max_completion_tokens` (PAS `max_tokens`), floor 1500 / cap 8000, sized au
+    champ. `reasoning_effort=low`.
+  - OpenAI direct en primaire, OpenRouter en fallback 401/429.
+
+Usage :
+  python translate_csv.py --csv translations/iit/iit.csv                  # dry-run plan
+  python translate_csv.py --csv x.csv --smoke                              # dry-run 1 cell x 7 langs
+  python translate_csv.py --csv x.csv --lang en                            # dry-run 1 langue
+  python translate_csv.py --csv x.csv --apply                              # GATED (ENABLED=False) -> no-op
+  # (activation : éditer ENABLED=True + OPENAI_API_KEY env + --apply)
+"""
+import argparse
+import csv
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# ----------------------------------------------------------------------------
+# Gate de sécurité (HARD). `False` = le moteur est inactif même avec --apply.
+# Passer à `True` uniquement après GO user (#6949 moyen terme, #1650 Phase 1).
+# ----------------------------------------------------------------------------
+ENABLED = False
+
+TARGETS = ["en", "ru", "pt", "es", "ar", "fa", "zh"]
+LANG_NAMES = {
+    "en": "English",
+    "ru": "Russian",
+    "pt": "Portuguese",
+    "es": "Spanish",
+    "ar": "Arabic",
+    "fa": "Persian",
+    "zh": "Chinese (Simplified)",
+}
+
+# Modèle + endpoints par défaut (overridable via --model / --base-url / env).
+DEFAULT_MODEL = os.environ.get("TRANSLATE_MODEL", "gpt-5.5")
+DEFAULT_BASE_URL = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_MODEL = os.environ.get("TRANSLATE_MODEL_OPENROUTER", "openai/gpt-5.5")
+
+
+# ----------------------------------------------------------------------------
+# Hash contract — identique à T1 (extract_cells_to_csv.py) et T2
+# (check_translation_sync.py). Maintenir la cohérence : hash_<lang> posé par T3
+# doit matcher ce que T2 recompute. NE PAS diverger.
+# ----------------------------------------------------------------------------
+def normalize(text: str) -> str:
+    """Normalisation du drift-detection : rstrip chaque ligne + strip newline final.
+
+    Évite les faux-drift cosmétiques (trailing whitespace / CRLF vs LF) tout en
+    préservant le contenu sémantique. Byte-identique à T1/T2.
+    """
+    lines = [line.rstrip() for line in text.splitlines()]
+    return "\n".join(lines).strip("\n")
+
+
+def cell_hash(text: str) -> str:
+    """sha256 (16 hex) du texte normalisé — invariant drift-detection intradépôt."""
+    return hashlib.sha256(normalize(text).encode("utf-8")).hexdigest()[:16]
+
+
+# ----------------------------------------------------------------------------
+# I/O CSV — RFC 4180, utf-8 BOM toléré en lecture, LF en écriture.
+# ----------------------------------------------------------------------------
+CSV_COLUMNS = [
+    "notebook", "cell_id", "cell_type", "src_lang", "src_hash",
+    "text_fr", "text_en", "text_es", "text_ar", "text_fa", "text_zh", "text_ru", "text_pt",
+    "hash_fr", "hash_en", "hash_es", "hash_ar", "hash_fa", "hash_zh", "hash_ru", "hash_pt",
+]
+
+
+def load_csv(path: str) -> list[dict]:
+    with open(path, encoding="utf-8-sig", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def write_csv(path: str, rows: list[dict]) -> None:
+    """Réécrit le CSV en préservant l'ordre des colonnes canonique (LF endings)."""
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        w = csv.DictWriter(f, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        w.writeheader()
+        for row in rows:
+            # Garde-fou : ne perdre aucune colonne canonique, ignore les extras.
+            w.writerow({col: row.get(col, "") for col in CSV_COLUMNS})
+
+
+# ----------------------------------------------------------------------------
+# Appel LLM — fork de Argumentum call_chat. Clés env uniquement.
+# ----------------------------------------------------------------------------
+def _provider_keys() -> list[tuple[str, str, str]]:
+    """Construit la liste des providers (model, key, base_url) depuis l'environnement.
+
+    Primaire OpenAI (OPENAI_API_KEY). Fallback OpenRouter (OPENROUTER_API_KEY)
+    si présent. Aucune clé -> liste vide (l'appelant lèvera une erreur claire).
+    """
+    providers = []
+    k = os.getenv("OPENAI_API_KEY")
+    if k:
+        providers.append((DEFAULT_MODEL, k, DEFAULT_BASE_URL))
+    k2 = os.getenv("OPENROUTER_API_KEY")
+    if k2:
+        providers.append((OPENROUTER_MODEL, k2, OPENROUTER_BASE_URL))
+    return providers
+
+
+def call_chat(messages, model, key, base_url, max_tokens, reasoning_effort="low", timeout=240):
+    """Appel Chat Completions. Retourne (content, dt, reasoning_tokens).
+
+    gpt-5.5 : pas de `temperature`, `max_completion_tokens` (pas `max_tokens`),
+    `reasoning_effort=low`. Fork direct de Argumentum (verified #499 pilot).
+    """
+    body = {"model": model, "messages": messages, "max_completion_tokens": max_tokens}
+    if reasoning_effort:
+        body["reasoning_effort"] = reasoning_effort
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        base_url.rstrip("/") + "/chat/completions",
+        data=data,
+        headers={"Authorization": "Bearer " + key, "Content-Type": "application/json"},
+    )
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        resp = json.loads(r.read())
+    dt = time.time() - t0
+    content = resp["choices"][0]["message"]["content"]
+    rt = resp.get("usage", {}).get("completion_tokens_details", {}).get("reasoning_tokens", 0)
+    return content, dt, rt
+
+
+def translate_markdown(fr_text, target_lang, model, key, base_url,
+                       max_tokens_cap=8000, max_tokens_floor=1500):
+    """Traduit une cellule markdown FR vers une langue cible. Retourne (html, dt, rt).
+
+    Prompt adapté d'Argumentum (HTML prose) -> markdown pédagogique CoursIA :
+    préserve fences de code, inline code, math ($...$), structure markdown
+    (headings, listes, liens). Rendu natif dans la langue cible (Cyrillic / CJK /
+    arabe). Le code lui-même n'est PAS traduit (seul le prose markdown l'est).
+    """
+    approx_in = len(fr_text) / 4
+    max_tokens = max(max_tokens_floor, min(max_tokens_cap, int(approx_in * 1.6) + 800))
+    lang_name = LANG_NAMES[target_lang]
+    sys_msg = (
+        "You are a professional translator for CoursIA, a French educational repository "
+        "of AI notebooks (machine learning, symbolic AI, probabilistic programming). "
+        "You translate pedagogical Markdown content from French.")
+    user_msg = (
+        f"Translate the following French Markdown into {lang_name}.\n"
+        "STRICT RULES:\n"
+        "- Preserve ALL fenced code blocks (```...```), inline code (`...`), and math "
+        "($...$, $$...$$) EXACTLY as-is. Never translate code or formulas — only the "
+        "prose around them.\n"
+        "- Preserve Markdown structure (headings #, lists -/*, links [text](url), "
+        "blockquotes >, tables). Keep the same number and order of structural elements.\n"
+        "- Keep proper nouns, library/API names, and identifiers consistent.\n"
+        "- Write in the target language's native script (Cyrillic for Russian, CJK for "
+        "Chinese, Arabic script for Arabic/Persian).\n"
+        "- Return ONLY the translated Markdown. No explanation, no fences around the "
+        "whole output, no preamble.\n\n"
+        f"FRENCH MARKDOWN TO TRANSLATE:\n{fr_text}")
+    msgs = [{"role": "system", "content": sys_msg}, {"role": "user", "content": user_msg}]
+    return call_chat(msgs, model, key, base_url, max_tokens)
+
+
+# ----------------------------------------------------------------------------
+# Plan de traduction — cellules éligibles.
+# ----------------------------------------------------------------------------
+def translation_plan(rows, langs, include_code=False):
+    """Yield (row_index, lang) pour chaque cellule markdown éligible x langue cible vide.
+
+    Éligibilité : cell_type == 'markdown' (ou 'code' si include_code), text_fr non
+    vide, text_<lang> vide (non déjà traduit — sert aussi de cache/resume).
+    """
+    for i, row in enumerate(rows):
+        ctype = row.get("cell_type", "")
+        if ctype == "code" and not include_code:
+            continue
+        if ctype not in ("markdown", "code"):
+            continue
+        fr = row.get("text_fr", "")
+        if not fr.strip():
+            continue
+        for lang in langs:
+            if not row.get(f"text_{lang}", "").strip():
+                yield i, lang
+
+
+def run_translations(rows, langs, include_code, out_path, smoke):
+    """Exécute les traductions live (ENABLED doit être True). Mutate rows in place.
+
+    Écrit le CSV incrémentalement après chaque cellule (resume-safe : un run
+    interrompu reprend où il s'est arrêté grâce au cache text_<lang>).
+    """
+    providers = _provider_keys()
+    if not providers:
+        raise ValueError(
+            "Aucune clé API trouvée. Définir OPENAI_API_KEY (et optionnellement "
+            "OPENROUTER_API_KEY) dans l'environnement. Jamais de littéral inline "
+            "(secrets-hygiene.md).")
+
+    plan = list(translation_plan(rows, langs, include_code))
+    if smoke:
+        # 1 cellule x toutes les langues demandées (premier markdown trouvé).
+        first_idx = next((i for i, _ in plan), None)
+        plan = [(i, lang) for i, lang in plan if i == first_idx] if first_idx is not None else []
+    total = len(plan)
+    print(f"[plan] {total} traductions à produire ({len(langs)} langue(s))", file=sys.stderr)
+
+    done = fails = 0
+    for idx, lang in plan:
+        fr = rows[idx]["text_fr"]
+        ok = False
+        for attempt, (model, key, base) in enumerate(providers):
+            try:
+                out, dt, rt = translate_markdown(fr, lang, model, key, base)
+                rows[idx][f"text_{lang}"] = out.strip()
+                rows[idx][f"hash_{lang}"] = cell_hash(rows[idx][f"text_{lang}"])
+                ok = True
+                done += 1
+                nb = rows[idx]["notebook"].split("/")[-1]
+                cid = rows[idx]["cell_id"][:8]
+                print(f"  [{done}/{total}] {nb} {cid}->{lang} "
+                      f"({len(out)}c, {dt:.1f}s, rt={rt}) via {model}", file=sys.stderr)
+                break
+            except urllib.error.HTTPError as e:
+                body = e.read().decode("utf-8", "replace")[:200]
+                print(f"  [warn] {nb if 'nb' in dir() else idx} {lang} {model} "
+                      f"HTTP {e.code}: {body}", file=sys.stderr)
+                if e.code in (401, 429) and attempt < len(providers) - 1:
+                    print("  [fallback] switching provider", file=sys.stderr)
+                    continue
+                time.sleep(3)
+            except Exception as e:  # noqa: BLE001 - réseau, robustesse avant tout
+                print(f"  [warn] cell[{idx}] ->{lang} {model} ERR "
+                      f"{type(e).__name__}: {e}", file=sys.stderr)
+                time.sleep(3)
+        if not ok:
+            fails += 1
+            print(f"  [FAIL] cell[{idx}]->{lang} all providers exhausted", file=sys.stderr)
+        write_csv(out_path, rows)  # resume-safe : persiste après chaque cellule
+        time.sleep(0.5)
+
+    print(f"\n[done] {done} traduites, {fails} échecs -> {out_path}", file=sys.stderr)
+    return done, fails
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="T3 moteur traduction CSV (fork Argumentum, #6949)")
+    ap.add_argument("--csv", required=True, help="CSV translations à traduire")
+    ap.add_argument("--out", help="CSV de sortie (défaut = --csv, in-place)")
+    ap.add_argument("--lang", help="une seule langue cible (sinon les 7)")
+    ap.add_argument("--all", action="store_true", help="toutes les langues cibles")
+    ap.add_argument("--smoke", action="store_true", help="1 cellule x langues (POC)")
+    ap.add_argument("--apply", action="store_true",
+                    help="applique réellement (défaut = dry-run plan seul)")
+    ap.add_argument("--include-code", action="store_true",
+                    help="traduit aussi les cellules code (défaut = markdown seul ; "
+                         "la traduction des commentaires de code est un refinement T3)")
+    ap.add_argument("--model", default=DEFAULT_MODEL, help=f"modèle primaire (défaut {DEFAULT_MODEL})")
+    ap.add_argument("--base-url", default=DEFAULT_BASE_URL, help="endpoint primaire")
+    args = ap.parse_args()
+
+    out_path = args.out or args.csv
+    rows = load_csv(args.csv)
+    n_md = sum(1 for r in rows if r.get("cell_type") == "markdown")
+    n_code = sum(1 for r in rows if r.get("cell_type") == "code")
+    print(f"[load] {len(rows)} lignes ({n_md} markdown, {n_code} code)", file=sys.stderr)
+
+    if args.lang:
+        langs = [args.lang]
+    elif args.all or args.smoke:
+        langs = list(TARGETS)
+    else:
+        langs = list(TARGETS)  # dry-run default = plan complet sur les 7 langues
+
+    plan = list(translation_plan(rows, langs, args.include_code))
+    if args.smoke:
+        first_idx = next((i for i, _ in plan), None)
+        plan = [(i, lang) for i, lang in plan if i == first_idx] if first_idx is not None else []
+
+    print(f"[plan] {len(plan)} traductions nécessaires "
+          f"({len(langs)} langue(s), include_code={args.include_code})", file=sys.stderr)
+
+    if not args.apply:
+        print("[dry-run] aucune mutation, aucun appel API. Passe --apply pour exécuter "
+              "(gated par ENABLED).", file=sys.stderr)
+        # Détaille un échantillon du plan (5 premières cellules).
+        sample = plan[:5]
+        for i, lang in sample:
+            nb = rows[i]["notebook"].split("/")[-1]
+            print(f"  - {nb} cell[{rows[i]['cell_id'][:8]}] ->{lang} "
+                  f"({len(rows[i]['text_fr'])}c FR)", file=sys.stderr)
+        if len(plan) > 5:
+            print(f"  ... +{len(plan) - 5} autres", file=sys.stderr)
+        return 0
+
+    # --apply : gate de sécurité ENABLED.
+    if not ENABLED:
+        print("[GATED] ENABLED=False dans translate_csv.py. Le moteur T3 est inactif : "
+              "aucun appel API, aucune mutation. Pour activer (après GO user, #6949 "
+              "moyen terme / #1650 Phase 1) : éditer ENABLED=True + définir "
+              "OPENAI_API_KEY env + re-passer --apply.", file=sys.stderr)
+        return 0
+
+    return 0 if run_translations(rows, langs, args.include_code, out_path, args.smoke)[1] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Forks Argumentum `translate_game_rules.py` (gpt-5.5, 193 LOC, submodule pin `7e72f3e5d`) into the CoursIA 7-lang CSV schema (Epic #4957 / #1650). **PR #2/2 of #6949** (PR #1 = the Argumentum→CoursIA doc mapping, to follow).

**Problem solved.** The 5 recent "CSV resync" PRs (#6939 SMT, #6929 IIT, #6943 Search, #6945 genai-video, #6947 tweety) drain `SRC_DRIFT` rows without producing a single translated cell — T3 (the actual translation engine) was gated, so the resyncs were pure noise. This starter ships the missing 3rd layer of the pipeline (T1 extract + T2 drift-check are already on main), giving the empty resyncs a path to real 7-lang output.

## Changes (2 files, +570)

- `scripts/translation/translate_csv.py` (~290 LOC) — the forked T3 engine.
- `scripts/tests/test_translate_csv.py` (231 LOC) — 14 tests, mocked `call_chat` (no live API).

## Safety (HARD — no live API call is possible from this PR)

| Gate | Mechanism |
|------|-----------|
| `ENABLED = False` | Module-level constant. Even `--apply` is a no-op until flipped to `True` in source (GO user, #6949 medium-term). Triple gate: edit source **+** `--apply` **+** env key. |
| `--dry-run` default | No API, no mutation. Prints the plan. |
| Keys env-only | `OPENAI_API_KEY` / `OPENROUTER_API_KEY`, no default, `raise ValueError` on missing. Replaces Argumentum file-based `.keys/` (secrets-hygiene.md rule 1-3). No literal in diff. |

## Validation (firsthand)

- **Dry-run on real `translations/iit/iit.csv`** (776 rows = 459 markdown + 317 code): `3213 translations needed` (459 × 7 ✓), no API call, CSV **byte-identical** after (`git diff --stat` empty).
- **`--apply` with `ENABLED=False`**: prints `[GATED] ENABLED=False... aucun appel API, aucune mutation`, returns 0, no mutation.
- **14/14 tests pass** (0.6s): hash contract (byte-identical to T1/T2), plan semantics (markdown-only default, `--include-code` opt-in, resume cache, empty-fr skip), CSV round-trip (columns + LF + BOM tolerance), ENABLED gate no-op, dry-run no-mutation, smoke limit.
- **Secret scan**: 0 literal key, 0 `getenv("KEY", "<literal>")` (the 2 `fake-key-for-testing` strings are pytest `monkeypatch.setenv` mocks — call_chat is mocked, never sent).
- `py_compile` OK.

## Design decisions

- **markdown cells translated** (59% of cells): the prompt preserves fenced code blocks, inline code, math (`$...$`), Markdown structure (headings/lists/links). Code itself is never translated.
- **code cells skipped in the starter** (`--include-code` opts in): translating code comments is a refinement gated behind T3 activation; skipping avoids corrupting code in a gated engine. Documented in `--help`.
- **`hash_<lang> = cell_hash(text_<lang>)`** written for every translation, so T2 (`check_translation_sync.py`, which reads `hash_<lang>` at line 124) stays coherent.
- **Self-contained**: `normalize`/`cell_hash` replicated inline (4 lines) rather than imported, matching Argumentum zero-dependency philosophy and avoiding cross-module coupling.

## Scope

`See #6949` (partial — this is PR 2/2; PR #1 = the `docs/translation/argumentum-fork-mapping.md` doc + `scripts/translation/README.md` T3-status update). No notebook touched, no catalogue touched (catalogue byte-identical to main per catalog-pr-hygiene).

🤖 po-2023 · c.565