### PR TITLE
fix(gt-15c,#6927): Plotly CDN-script -> SVG inline Bar (Shapley + Banzhaf power indices)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
@@ -616,15 +616,15 @@
     },
     {
      "data": {
-      "text/html": [
-       "<div id=\"plt25223da3cdda4176a851e0c95a304c5d\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt25223da3cdda4176a851e0c95a304c5d',[{\"x\":[\"L1 (gant gauche)\",\"L2 (gant gauche)\",\"R1 (gant droit)\"],\"y\":[0.1667,0.1667,0.6667],\"type\":\"bar\",\"marker\":{\"color\":\"#2a6dba\"}}],{\"title\":{\"text\":\"Valeurs de Shapley - jeu de gants\"},\"xaxis\":{\"title\":{\"text\":\"Joueur\"}},\"yaxis\":{\"title\":{\"text\":\"Valeur de Shapley\"},\"range\":[0,0.8]},\"shapes\":[{\"type\":\"line\",\"xref\":\"paper\",\"x0\":0,\"x1\":1,\"y0\":0.3333,\"y1\":0.3333,\"line\":{\"color\":\"#e8743b\",\"width\":2,\"dash\":\"dash\"}}],\"margin\":{\"l\":50,\"r\":30}})</script>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Valeurs de Shapley - jeu de gants</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.18</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.36</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.54</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.72</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='83.16' y='221.51' width='101.68' height='56.49' fill='#2a6dba'/><text x='134' y='294' text-anchor='middle' fill='#333333'>L1 (gant gauche)</text><rect x='247.16' y='221.51' width='101.68' height='56.49' fill='#2a6dba'/><text x='298' y='294' text-anchor='middle' fill='#333333'>L2 (gant gauche)</text><rect x='411.16' y='52.074' width='101.68' height='225.926' fill='#2a6dba'/><text x='462' y='294' text-anchor='middle' fill='#333333'>R1 (gant droit)</text></svg>"
      },
+     "execution_count": 5,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "#load \"SvgChartHelper.cs\"\n",
     "// Visualisation Plotly des valeurs de Shapley (jeu de gants) -- technique C548-L2\n",
     "// (formatter HTML integre au kernel, zero dependence NuGet cote charting, rendu Plotly.js brut).\n",
     "using Microsoft.DotNet.Interactive.Formatting;\n",
@@ -640,24 +640,11 @@
     "// Bar chart Plotly : le jeu de gants illustre un pouvoir asymetrique -- un seul joueur a un\n",
     "// gant droit (rare) -> sa valeur (0,667) domine celle des deux joueurs au gant gauche (0,167).\n",
     "// La ligne pointillee marque le partage egal (1/3), jamais atteint ici.\n",
-    "{\n",
-    "    var labs = gloveLabels.ToArray();\n",
-    "    var vals = shapleyGlove.Select(v => Math.Round(v, 4)).Select(v => (object)v).ToArray();\n",
-    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
-    "    var trace = System.Text.Json.JsonSerializer.Serialize(\n",
-    "        new Dictionary<string, object> { [\"x\"] = labs, [\"y\"] = vals, [\"type\"] = \"bar\",\n",
-    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"]=\"#2a6dba\" } });\n",
-    "    var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Valeurs de Shapley - jeu de gants\\\"},\" +\n",
-    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Joueur\\\"}},\" +\n",
-    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Valeur de Shapley\\\"},\\\"range\\\":[0,0.8]},\" +\n",
-    "                 \"\\\"shapes\\\":[{\\\"type\\\":\\\"line\\\",\\\"xref\\\":\\\"paper\\\",\\\"x0\\\":0,\\\"x1\\\":1,\" +\n",
-    "                 \"\\\"y0\\\":0.3333,\\\"y1\\\":0.3333,\\\"line\\\":{\\\"color\\\":\\\"#e8743b\\\",\\\"width\\\":2,\\\"dash\\\":\\\"dash\\\"}}],\" +\n",
-    "                 \"\\\"margin\\\":{\\\"l\\\":50,\\\"r\\\":30}}\";\n",
-    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
-    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + trace + \"],\" + layout + \")</script>\";\n",
-    "    display(new PlotlyHtml(markup));\n",
-    "}\n"
+    "SvgChartHelper.Bar(\n",
+    "    \"Valeurs de Shapley - jeu de gants\",\n",
+    "    gloveLabels.ToArray(),\n",
+    "    shapleyGlove.Select(v => Math.Round(v, 4)).ToArray(),\n",
+    "    color: \"#2a6dba\")"
    ]
   },
   {
@@ -1357,9 +1344,14 @@
     },
     {
      "data": {
-      "text/html": [
-       "<div id=\"plt8e068ca9686543a5bd723d33ce4fd5ea\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt8e068ca9686543a5bd723d33ce4fd5ea',[{\"x\":[\"P1\",\"P2\",\"N1\",\"N2\",\"N3\"],\"y\":[0.3,0.3,0.1333,0.1333,0.1333],\"type\":\"bar\",\"name\":\"Shapley\",\"marker\":{\"color\":\"#2a6dba\"}},{\"x\":[\"P1\",\"P2\",\"N1\",\"N2\",\"N3\"],\"y\":[0.2857,0.2857,0.1429,0.1429,0.1429],\"type\":\"bar\",\"name\":\"Banzhaf\",\"marker\":{\"color\":\"#e8743b\"}}],{\"barmode\":\"group\",\"title\":{\"text\":\"Mini-ONU : Shapley vs Banzhaf (2 indices de pouvoir)\"},\"xaxis\":{\"title\":{\"text\":\"Etat membre\"}},\"yaxis\":{\"title\":{\"text\":\"Indice de pouvoir\"}},\"margin\":{\"l\":50,\"r\":30}})</script>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Mini-ONU : indice de Shapley</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='70.696' y='52.074' width='61.008' height='225.926' fill='#2a6dba'/><text x='101.2' y='294' text-anchor='middle' fill='#333333'>P1</text><rect x='169.096' y='52.074' width='61.008' height='225.926' fill='#2a6dba'/><text x='199.6' y='294' text-anchor='middle' fill='#333333'>P2</text><rect x='267.496' y='177.614' width='61.008' height='100.386' fill='#2a6dba'/><text x='298' y='294' text-anchor='middle' fill='#333333'>N1</text><rect x='365.896' y='177.614' width='61.008' height='100.386' fill='#2a6dba'/><text x='396.4' y='294' text-anchor='middle' fill='#333333'>N2</text><rect x='464.296' y='177.614' width='61.008' height='100.386' fill='#2a6dba'/><text x='494.8' y='294' text-anchor='middle' fill='#333333'>N3</text></svg>"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Mini-ONU : indice de Banzhaf</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.077</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.154</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.231</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.309</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='70.696' y='52.074' width='61.008' height='225.926' fill='#e8743b'/><text x='101.2' y='294' text-anchor='middle' fill='#333333'>P1</text><rect x='169.096' y='52.074' width='61.008' height='225.926' fill='#e8743b'/><text x='199.6' y='294' text-anchor='middle' fill='#333333'>P2</text><rect x='267.496' y='164.997' width='61.008' height='113.003' fill='#e8743b'/><text x='298' y='294' text-anchor='middle' fill='#333333'>N1</text><rect x='365.896' y='164.997' width='61.008' height='113.003' fill='#e8743b'/><text x='396.4' y='294' text-anchor='middle' fill='#333333'>N2</text><rect x='464.296' y='164.997' width='61.008' height='113.003' fill='#e8743b'/><text x='494.8' y='294' text-anchor='middle' fill='#333333'>N3</text></svg>"
      },
      "metadata": {},
      "output_type": "display_data"
@@ -1374,33 +1366,24 @@
     }
    ],
    "source": [
+    "#load \"SvgChartHelper.cs\"\n",
     "// Comparaison Plotly Shapley vs Banzhaf (Mini-ONU) -- (PlotlyHtml defini en cell[9], technique C548-L2).\n",
     "// Deux indices de pouvoir : Shapley (valeur) et Banzhaf (pivots). Comparer les deux met en evidence\n",
     "// que le pouvoir reel differe du poids nominal, et que les deux indices divergent legerement.\n",
     "Console.WriteLine(\"Comparaison Shapley vs Banzhaf (Mini-ONU) :\");\n",
     "foreach (var (lab, sh, ba) in labelsUN.Zip(shapleyUN, banzhafUN))\n",
     "    Console.WriteLine($\"  {lab,-8} Shapley {sh:F4}  Banzhaf {ba:F4}\");\n",
-    "{\n",
-    "    var labs = labelsUN.ToArray();\n",
-    "    var sh = shapleyUN.Select(v => Math.Round(v, 4)).Select(v => (object)v).ToArray();\n",
-    "    var ba = banzhafUN.Select(v => Math.Round(v, 4)).Select(v => (object)v).ToArray();\n",
-    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
-    "    var tShapley = System.Text.Json.JsonSerializer.Serialize(\n",
-    "        new Dictionary<string, object> { [\"x\"] = labs, [\"y\"] = sh, [\"type\"] = \"bar\", [\"name\"] = \"Shapley\",\n",
-    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"]=\"#2a6dba\" } });\n",
-    "    var tBanzhaf = System.Text.Json.JsonSerializer.Serialize(\n",
-    "        new Dictionary<string, object> { [\"x\"] = labs, [\"y\"] = ba, [\"type\"] = \"bar\", [\"name\"] = \"Banzhaf\",\n",
-    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"]=\"#e8743b\" } });\n",
-    "    var layout = \"{\\\"barmode\\\":\\\"group\\\",\\\"title\\\":{\\\"text\\\":\\\"Mini-ONU : Shapley vs Banzhaf (2 indices de pouvoir)\\\"},\" +\n",
-    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Etat membre\\\"}},\" +\n",
-    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Indice de pouvoir\\\"}},\" +\n",
-    "                 \"\\\"margin\\\":{\\\"l\\\":50,\\\"r\\\":30}}\";\n",
-    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
-    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + tShapley + \",\" + tBanzhaf + \"],\" + layout + \")</script>\";\n",
-    "    display(new PlotlyHtml(markup));\n",
-    "}\n",
-    "Console.WriteLine(\"\\nNote : le pouvoir reel (Shapley/Banzhaf) peut differer du poids nominal.\");\n"
+    "display(SvgChartHelper.Bar(\n",
+    "    \"Mini-ONU : indice de Shapley\",\n",
+    "    labelsUN.ToArray(),\n",
+    "    shapleyUN.Select(v => Math.Round(v, 4)).ToArray(),\n",
+    "    color: \"#2a6dba\"));\n",
+    "display(SvgChartHelper.Bar(\n",
+    "    \"Mini-ONU : indice de Banzhaf\",\n",
+    "    labelsUN.ToArray(),\n",
+    "    banzhafUN.Select(v => Math.Round(v, 4)).ToArray(),\n",
+    "    color: \"#e8743b\"));\n",
+    "Console.WriteLine(\"\\nNote : le pouvoir reel (Shapley/Banzhaf) peut differer du poids nominal.\");"
    ]
   },
   {


### PR DESCRIPTION
## What

`GameTheory-15c-CooperativeGames-Csharp.ipynb` **cells[9, 23]**: replace blank-in-static Plotly charts with inline static SVG via **`SvgChartHelper.Bar()`** (#6942 MERGED).

- **cell[9]** — Shapley values (glove game): single `Bar()` last-expression. The bar asymmetry (0.667 vs 0.167/0.167) makes the asymmetric power visually obvious.
- **cell[23]** — Shapley vs Banzhaf (Mini-ONU): **2 `display(Bar())`** (pattern from #6967 DecInfer-7: distinct categorical axes → 2 `Bar()` not `Overlay`; `display()` renders per ai-01 `svg-6927-canon.md`). Compares the two power indices side by side.

Console.WriteLine comparison table + trailing Note preserved (block-swap, not full-cell rewrite).

## Gates verified firsthand (incl. new no-vision gate)

| Gate | Result |
|------|--------|
| Real `.net-csharp` exec (H.4) | cell[9] exec_count=5 (1 SVG), cell[23] exec_count=12 (2 SVGs), 0 errors |
| `detect_svg_decimal_commas.py` (#6959, merge-gate) | **0 defects** rc=0 |
| `detect_svg_empty_display.py` (#6971, no-vision blank-gate) | **0 defects** rc=0 (mechanically confirms non-blank render) |
| `check_plotly_static_risk.py` (#6931) | GT-15c **no longer risky** |
| `cdn.plot.ly` in output | **False** |
| probeAddresses banner | absent |
| C.3 scope | **only cells[9, 23]** changed |
| Catalog byte-identity (R1) | 0 diff; README untouched |

## Verdict: **SOTA-OK** (#3801 Prong-A)

## Notes

- The 1/3 egalitarian dashed reference line in the original cell[9] Plotly is not reproduced — the canon `Bar()` has no reference-line primitive, and the bar asymmetry conveys the message without it (values also printed via the preserved Console.WriteLine).
- **Visual QA**: GLM lane not vision-capable; routes to MiniMax (CoursIA-2) / ai-01 at merge-gate. The deterministic no-vision gates (#6959 + #6971 + #6931) are all green — #6971 in particular mechanically confirms the charts are non-blank.
- **See #6927** (partial — sibling to #6972 GT-4c, #6974 GT-17, #6975 GT-12; remaining partition: GT-8c heatmap = custom builder).

🤖 po-2025 (GLM no-vision lane)
