### PR TITLE
docs(translation,#6949): Argumentum→CoursIA fork mapping + README T3 status

### DIFF
--- a/docs/translation/argumentum-fork-mapping.md
+++ b/docs/translation/argumentum-fork-mapping.md
@@ -1,0 +1,83 @@
+# Mapping de fork Argumentum → CoursIA (moteur T3)
+
+> **Statut** : référence pérenne pour la couche T3 (moteur de traduction).
+> Issue [#6949](https://github.com/jsboige/CoursIA/issues/6949) (PR #1/2 — doc).
+> Fork code : PR #6976 (`scripts/translation/translate_csv.py`).
+> Épics parents : [#4957](https://github.com/jsboige/CoursIA/issues/4957) (infra synchro), [#1650](https://github.com/jsboige/CoursIA/issues/1650) (traduction multilingue).
+
+## 1. Pourquoi forker Argumentum
+
+Le dépôt CoursIA consomme, depuis mi-2026, un flux de PR dites « resync CSV »
+(`extract_cells_to_csv.py --update` + `check_translation_sync.py`) qui drainent
+les `SRC_DRIFT` entre les notebooks source et le CSV pivot `fr`. **Ces PR ne
+produisent aucune cellule traduite** en 7 langues cibles : la couche T3 (le
+vrai moteur de traduction) était gated ([#1650](https://github.com/jsboige/CoursIA/issues/1650) Phase 1), donc les resyncs
+étaient du bruit de fond — 1-2 h d'agent + 1 merge de coordinator chacune pour
+zéro valeur linguistique.
+
+Le submodule `ArgumentumGames/Argumentum` (pin `7e72f3e5d`, v0.9.0) contient un
+**système de traduction multilingue mûr et fonctionnel** (29 outils Python +
+moteur .NET 9 `DatasetUpdater`). Plutôt que de réinventer un moteur, on **fork
+les patterns identifiés** côté CoursIA, en s'appuyant sur l'exploration du
+2026-07-17.
+
+## 2. Ce qu'on fork, ce qu'on laisse
+
+| Élément Argumentum | Statut CoursIA | Décision |
+|---|---|---|
+| `tools/dnn_i18n/translate_game_rules.py` (193 LOC, gpt-5.5) | Fork → `scripts/translation/translate_csv.py` (#6976) | **Forked** — script Python pur, zéro dépendance Argumentum-specific, déjà 80 % du travail T3 |
+| `multilingual-drift-audit.py` (453 LOC, 5 classes drift) | `check_translation_sync.py` (T2, 4 verdicts) | **Laissé** — T2 CoursIA est livré ; harmonisation des 5 classes = travail futur optionnel |
+| Moteur .NET `DatasetUpdater/*.cs` (gpt-5.4-mini, function calling) | — | **Laissé** — trop couplé au schéma 2sxc ; le fork Python `urllib` suffit et reste auditable |
+| `.keys/openai-key.txt` (clés sur disque) | `os.getenv("OPENAI_API_KEY")` | **Refusé** — violerait [secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md) règle 1-3 (clés env-only, jamais de littéral/fichier) |
+| Format entrée 2sxc JSON (`EntityID`/`StaticName`/`Value`) | CSV RFC 4180 (`notebook`/`cell_id`/`text_fr`) | **Adapté** — voir §3 |
+
+## 3. Mapping de schéma (Argumentum → CoursIA)
+
+| Aspect | Argumentum | CoursIA T1/T2 (livré) | CoursIA T3 (fork #6976) |
+|---|---|---|---|
+| Identifiant de cellule | `EntityID` + `StaticName` | `notebook` + `cell_id` (composite) | Idem |
+| Source FR | `Value` (2sxc) | `text_fr` (FR = source canonique) | Lit `text_fr` |
+| 7 langues cibles | `en, ru, pt, es, ar, fa, zh` | `text_<lang>` + `hash_<lang>` | **Identique** — mapping exhaustif confirmé |
+| Cache / resume | JSON output reuse | — | `text_<lang>` non-vide = déjà traduit (skip) |
+| Sortie | re-import JSON 2sxc | — | Réécrit le CSV (`text_<lang>` + `hash_<lang>`) |
+| Hash drift | — | `cell_hash = sha256(normalize)[:16]` | **Réutilisé tel quel** (cohérence T2) |
+
+## 4. Lessons apprises d'Argumentum (intégrées au fork)
+
+1. **gpt-5.5 specifics** (verified #499 pilot, 2026-06-16) : pas de `temperature`
+   (HTTP 400 sur reasoning models) ; `max_completion_tokens` (pas `max_tokens`),
+   floor 1500 / cap 8000, sized au champ ; `reasoning_effort=low`. Fork direct.
+2. **Préservation structurelle** : Argumentum préserve les entités HTML (`&amp;`
+   `&nbsp;`). CoursIA préserve **fences de code**, **inline code**, **math**
+   (`$...$`), **structure Markdown** (headings, listes, liens). Le code lui-même
+   n'est jamais traduit.
+3. **Script natif dans la langue cible** : Cyrillic (ru), CJK (zh), arabe (ar/fa).
+4. **Fallback provider** : OpenAI direct en primaire, OpenRouter en fallback
+   401/429. Conservé dans le fork.
+5. **Gating `Enabled=false`** jusqu'à GO user ([457-document-tier-translation-workflow.md](../../MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argumentum/docs/dnn-localization/457-document-tier-translation-workflow.md) §3) : le fork
+   ajoute un double gate `ENABLED=False` (module) + `--dry-run` (défaut CLI).
+
+## 5. Séquencement T0 → T3
+
+```
+T0  (manuel)      notebooks source FR = source canonique
+T1  extract       extract_cells_to_csv.py  →  CSV pivot (text_fr + hash_fr)         [livré]
+T2  drift-check   check_translation_sync.py → verdicts IN_SYNC / SRC_DRIFT / ...    [livré, CI non-bloquant]
+T3  translate     translate_csv.py (#6976)  →  text_<lang> + hash_<lang>            [starter livré, GATED]
+T4  re-import     patcher xxx_<lang>.ipynb depuis le CSV + Papermill re-exec         [à venir, #1650]
+```
+
+**Activation T3** (moyen terme, après GO user) :
+1. Éditer `ENABLED = True` dans `translate_csv.py`.
+2. Définir `OPENAI_API_KEY` (env, jamais de littéral).
+3. Premier run sur 1 CSV test : `python translate_csv.py --csv <x.csv> --smoke --apply`.
+4. Audit post-run : `check_translation_sync.py <x.csv>` → `TRAD_DRIFT` doit tomber à 0.
+
+## 6. Voir aussi
+
+- [Issue #6949](https://github.com/jsboige/CoursIA/issues/6949) — motivation, scope (PR #1 doc + PR #2 code), arrêt des resync vides.
+- [Issue #4957](https://github.com/jsboige/CoursIA/issues/4957) — design de l'infra (schéma CSV, sémantique drift).
+- [Epic #1650](https://github.com/jsboige/CoursIA/issues/1650) — traduction multilingue du dépôt.
+- PR #6976 — fork code (`scripts/translation/translate_csv.py` + 14 tests).
+- [`scripts/translation/README.md`](../../scripts/translation/README.md) — workflow T1→T2→T3.
+- Argumentum source (submodule pin `7e72f3e5d`) : `tools/dnn_i18n/translate_game_rules.py`.

--- a/docs/translation/argumentum-fork-mapping.md
+++ b/docs/translation/argumentum-fork-mapping.md
@@ -54,12 +54,12 @@ les patterns identifiés** côté CoursIA, en s'appuyant sur l'exploration du
 3. **Script natif dans la langue cible** : Cyrillic (ru), CJK (zh), arabe (ar/fa).
 4. **Fallback provider** : OpenAI direct en primaire, OpenRouter en fallback
    401/429. Conservé dans le fork.
-5. **Gating `Enabled=false`** jusqu'à GO user ([457-document-tier-translation-workflow.md](../../MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argumentum/docs/dnn-localization/457-document-tier-translation-workflow.md) §3) : le fork
+5. **Gating `Enabled=false`** jusqu'à GO user (Argumentum `docs/dnn-localization/457-document-tier-translation-workflow.md` §3, submodule `ArgumentumGames/Argumentum`) : le fork
    ajoute un double gate `ENABLED=False` (module) + `--dry-run` (défaut CLI).
 
 ## 5. Séquencement T0 → T3
 
-```
+```text
 T0  (manuel)      notebooks source FR = source canonique
 T1  extract       extract_cells_to_csv.py  →  CSV pivot (text_fr + hash_fr)         [livré]
 T2  drift-check   check_translation_sync.py → verdicts IN_SYNC / SRC_DRIFT / ...    [livré, CI non-bloquant]
@@ -68,6 +68,7 @@ T4  re-import     patcher xxx_<lang>.ipynb depuis le CSV + Papermill re-exec    
 ```
 
 **Activation T3** (moyen terme, après GO user) :
+
 1. Éditer `ENABLED = True` dans `translate_csv.py`.
 2. Définir `OPENAI_API_KEY` (env, jamais de littéral).
 3. Premier run sur 1 CSV test : `python translate_csv.py --csv <x.csv> --smoke --apply`.

--- a/scripts/translation/README.md
+++ b/scripts/translation/README.md
@@ -1,6 +1,6 @@
 # Scripts de synchro traduction (Epic #4957 / #1650)
 
-Infrastructure de synchronisation multilingue pour les notebooks pédagogiques. Le moteur de traduction (datasetupdater Argumentum, v0.9.0, 8 langues) n'est PAS réécrit ici — ces scripts en sont la couche d'**alignement** : ils maintiennent le CSV source de vérité et détectent le drift.
+Infrastructure de synchronisation multilingue pour les notebooks pédagogiques. Trois couches : **T1/T2** (alignement — maintiennent le CSV source de vérité `fr` et détectent le drift) + **T3** (`translate_csv.py`, fork Argumentum `translate_game_rules.py`, moteur de traduction gated). Mapping complet Argumentum → CoursIA : [`docs/translation/argumentum-fork-mapping.md`](../../docs/translation/argumentum-fork-mapping.md).
 
 ## Workflow en 3 couches (T1 → T2 → T3)
 
@@ -8,7 +8,7 @@ Infrastructure de synchronisation multilingue pour les notebooks pédagogiques. 
 |--------|--------|------|--------|
 | **T1** | `extract_cells_to_csv.py` | Extrait les cellules des notebooks vers le CSV (langue pivot `fr`) | Livré |
 | **T2** | `check_translation_sync.py` | Détecte le drift (source modifiée / trad éditée / cellule supprimée) | Livré (non-bloquant, CI) |
-| **T3** | moteur Argumentum | Resync des langues cibles sur les lignes flaggées | À venir (gated #1650 Phase 1) |
+| **T3** | `translate_csv.py` | Traduit les cellules `text_fr` vers les 7 langues cibles (`text_<lang>` + `hash_<lang>`) | Starter livré ([#6976](https://github.com/jsboige/CoursIA/pull/6976), gated `ENABLED=False` + `--dry-run` défaut — activation après GO user, [#6949](https://github.com/jsboige/CoursIA/issues/6949)) |
 
 ## Schéma CSV (ratified #4957 §1)
 


### PR DESCRIPTION
## Summary

**PR #1/2 of #6949** — the reference doc companion to the code fork (#6976). The issue body (user-authored from po-2023 Argumentum exploration) scoped the short-term deliverable as ~2 PRs: #1 doc-mapping + #2 fork-code. This is #1.

## Changes (2 files, +88/-2)

- `docs/translation/argumentum-fork-mapping.md` (NEW, ~115 lines, FR-first per readme-french-first.md) — locks the Argumentum → CoursIA mapping: §1 why fork (stop the "empty CSV resync" noise from #6939/#6929/#6943/#6945/#6947), §2 what is forked vs left, §3 schema mapping (EntityID→cell_id, 2sxc-JSON→CSV), §4 lessons (gpt-5.5 specifics, structure preservation, env-only keys rejecting Argumentum `.keys/`), §5 T0→T3 sequencing + activation steps, §6 see-also.
- `scripts/translation/README.md` — T3 row "À venir" → "Starter livré (#6976, gated)"; intro reflects the 3-layer pipeline + links the mapping doc.

## Validation

- **Markdown links**: 2 file-relative links (`secrets-hygiene.md`, `README.md`) verified resolving; submodule-internal link replaced with a plain citation (resolves broken when the Argumentum submodule is not initialized on a worktree).
- **Markdown lint**: MD040 (code-fence language `text`) + MD032 (blank line before list) fixed. MD060 table-style warnings left as-is — they match the existing repo table style (README.md, CLAUDE.md use the same compact pipes).
- Doc-only: no code, no notebook, no catalogue.

## Scope

`See #6949` (partial — PR 1/2; code fork is #6976). FR-first reference doc per readme-french-first.md HARD rule 1 (new doc content = français, never "match surrounding language").

🤖 po-2023 · c.565