### PR TITLE
fix(infer-19,#6927): Plotly CDN-script -> SVG inline Overlay (survival function S(t))

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
@@ -75,7 +75,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -85,10 +84,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -103,7 +99,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -115,8 +110,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -165,13 +158,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -527,15 +518,15 @@
     },
     {
      "data": {
-      "text/html": [
-       "<div id=\"plt17fab564fdc943f098cb16a3590a06ab\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt17fab564fdc943f098cb16a3590a06ab',[{\"name\":\"Bayesienne (modele exponentiel)\",\"x\":[0,37.5,75,112.5,150,187.5,225,262.5,300,337.5,375,412.5,450,487.5,525,562.5,600,637.5,675,712.5,750,787.5,825,862.5,900,937.5,975,1012.5,1050,1087.5,1125,1162.5,1200,1237.5,1275,1312.5,1350,1387.5,1425,1462.5,1500,1537.5,1575,1612.5,1650,1687.5,1725,1762.5,1800,1837.5,1875,1912.5,1950,1987.5,2025,2062.5,2100,2137.5,2175,2212.5,2250,2287.5,2325,2362.5,2400,2437.5,2475,2512.5,2550,2587.5,2625,2662.5,2700,2737.5,2775,2812.5,2850,2887.5,2925,2962.5,3000],\"y\":[1,0.9707499014366825,0.9423692055293654,0.9148316601651196,0.8881118183208658,0.8621850129935085,0.8370273329225478,0.8126155990797352,0.7889273419011632,0.7659407792380303,0.7436347950030093,0.7219889184899899,0.7009833043456324,0.6805987131718751,0.6608164927392217,0.6416185597912983,0.622987382421802,0.6049059630055352,0.5873578216658814,0.5703269802615968,0.553797946876345,0.5377557007949973,0.5221856779511592,0.507073756830923,0.4924062448183519,0.47816986496865266,0.4643517431953826,0.4509393958586274,0.43792071774133895,0.4252839704015386,0.41301777088849556,0.4011110808112635,0.38955319574848063,0.3783337349885781,0.367442631589962,0.3568701227510018,0.346606740480077,0.33664330255614483,0.3269709037706838,0.3175809074421042,0.3084649371940359,0.29961486898913486,0.29102282341040664,0.28268115818217704,0.27458246092320104,0.26671954212459215,0.259085428345467,0.2516733556194912,0.24447676306567015,0.23748928669695826,0.23070475342050234,0.22411717522345134,0.21772074353855467,0.21150982378387928,0.20547895007118558,0.19962282007768775,0.1939362900760701,0.18841437011780418,0.1830522193649651,0.17784514156590972,0.17278858067030048,0.16787811657914176,0.16310946102558888,0.1584784535824533,0.15398105779246157,0.1496133574174116,0.1453715528025433,0.1412519573525194,0.13725099411553962,0.1333651924722244,0.12959118492600613,0.12592570399186642,0.12236557918036264,0.11890773407398472,0.115549183492972,0.11228703074780767,0.10911846497570565,0.106040758558482,0.10305126461928871,0.1001474145957624,0.09732671588721924],\"type\":\"scatter\",\"mode\":\"lines\"},{\"name\":\"Empirique (donnees)\",\"x\":[0,37.5,75,112.5,150,187.5,225,262.5,300,337.5,375,412.5,450,487.5,525,562.5,600,637.5,675,712.5,750,787.5,825,862.5,900,937.5,975,1012.5,1050,1087.5,1125,1162.5,1200,1237.5,1275,1312.5,1350,1387.5,1425,1462.5,1500,1537.5,1575,1612.5,1650,1687.5,1725,1762.5,1800,1837.5,1875,1912.5,1950,1987.5,2025,2062.5,2100,2137.5,2175,2212.5,2250,2287.5,2325,2362.5,2400,2437.5,2475,2512.5,2550,2587.5,2625,2662.5,2700,2737.5,2775,2812.5,2850,2887.5,2925,2962.5,3000],\"y\":[1,1,1,0.9833333333333333,0.9833333333333333,0.9833333333333333,0.9166666666666666,0.8833333333333333,0.85,0.8333333333333334,0.7666666666666667,0.75,0.7333333333333333,0.7,0.6833333333333333,0.65,0.65,0.6166666666666667,0.5333333333333333,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5,0.48333333333333334,0.45,0.45,0.45,0.45,0.45,0.43333333333333335,0.4166666666666667,0.4166666666666667,0.4,0.4,0.36666666666666664,0.3333333333333333,0.3333333333333333,0.31666666666666665,0.31666666666666665,0.31666666666666665,0.31666666666666665,0.31666666666666665,0.31666666666666665,0.3,0.3,0.2833333333333333,0.26666666666666666,0.26666666666666666,0.26666666666666666,0.21666666666666667,0.2,0.18333333333333332,0.18333333333333332,0.18333333333333332,0.16666666666666666,0.16666666666666666,0.15,0.15,0.15,0.15,0.15,0.15,0.15,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.13333333333333333,0.1],\"type\":\"scatter\",\"mode\":\"lines\"}],{\"title\":{\"text\":\"Fonction de survie S(t) : bayesienne vs empirique\"},\"xaxis\":{\"title\":{\"text\":\"t (heures)\"}},\"yaxis\":{\"title\":{\"text\":\"S(t)\"},\"range\":[0,1.05]}})</script>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='480' viewBox='0 0 820 480' font-family='sans-serif' font-size='12'><rect width='820' height='480' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Fonction de survie S(t) : bayesienne vs empirique</text><line x1='52' y1='438' x2='804' y2='438' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='442' text-anchor='end' fill='#333333'>0.043</text><line x1='52' y1='337' x2='804' y2='337' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='341' text-anchor='end' fill='#333333'>0.296</text><line x1='52' y1='236' x2='804' y2='236' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='240' text-anchor='end' fill='#333333'>0.549</text><line x1='52' y1='135' x2='804' y2='135' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='139' text-anchor='end' fill='#333333'>0.801</text><line x1='52' y1='34' x2='804' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>1.054</text><line x1='52' y1='34' x2='52' y2='438' stroke='#888888' stroke-width='1'/><line x1='52' y1='438' x2='804' y2='438' stroke='#888888' stroke-width='1'/><text x='52' y='454' text-anchor='middle' fill='#333333'>0</text><text x='240' y='454' text-anchor='middle' fill='#333333'>750</text><text x='428' y='454' text-anchor='middle' fill='#333333'>1500</text><text x='616' y='454' text-anchor='middle' fill='#333333'>2250</text><text x='804' y='454' text-anchor='middle' fill='#333333'>3000</text><text x='428' y='474' text-anchor='middle' fill='#333333'>t (heures)</text><text x='14' y='236' text-anchor='middle' fill='#333333' transform='rotate(-90 14 236)'>S(t)</text><polyline points='52,55.643 61.4,67.331 70.8,78.673 80.2,89.677 89.6,100.354 99,110.715 108.4,120.768 117.8,130.523 127.2,139.989 136.6,149.174 146,158.088 155.4,166.738 164.8,175.132 174.2,183.278 183.6,191.183 193,198.854 202.4,206.3 211.8,213.525 221.2,220.537 230.6,227.343 240,233.948 249.4,240.359 258.8,246.581 268.2,252.619 277.6,258.481 287,264.17 296.4,269.691 305.8,275.051 315.2,280.254 324.6,285.303 334,290.205 343.4,294.963 352.8,299.581 362.2,304.065 371.6,308.417 381,312.642 390.4,316.743 399.8,320.725 409.2,324.59 418.6,328.342 428,331.985 437.4,335.521 446.8,338.955 456.2,342.288 465.6,345.525 475,348.667 484.4,351.717 493.8,354.679 503.2,357.555 512.6,360.347 522,363.058 531.4,365.691 540.8,368.247 550.2,370.729 559.6,373.139 569,375.479 578.4,377.751 587.8,379.958 597.2,382.101 606.6,384.181 616,386.202 625.4,388.164 634.8,390.07 644.2,391.92 653.6,393.718 663,395.463 672.4,397.158 681.8,398.804 691.2,400.403 700.6,401.956 710,403.464 719.4,404.929 728.8,406.351 738.2,407.733 747.6,409.075 757,410.379 766.4,411.645 775.8,412.875 785.2,414.07 794.6,415.23 804,416.357' fill='none' stroke='#2a6dba' stroke-width='2'/><circle cx='52' cy='55.643' r='3' fill='#e8743b'/><circle cx='61.4' cy='55.643' r='3' fill='#e8743b'/><circle cx='70.8' cy='55.643' r='3' fill='#e8743b'/><circle cx='80.2' cy='62.303' r='3' fill='#e8743b'/><circle cx='89.6' cy='62.303' r='3' fill='#e8743b'/><circle cx='99' cy='62.303' r='3' fill='#e8743b'/><circle cx='108.4' cy='88.943' r='3' fill='#e8743b'/><circle cx='117.8' cy='102.264' r='3' fill='#e8743b'/><circle cx='127.2' cy='115.584' r='3' fill='#e8743b'/><circle cx='136.6' cy='122.244' r='3' fill='#e8743b'/><circle cx='146' cy='148.884' r='3' fill='#e8743b'/><circle cx='155.4' cy='155.545' r='3' fill='#e8743b'/><circle cx='164.8' cy='162.205' r='3' fill='#e8743b'/><circle cx='174.2' cy='175.525' r='3' fill='#e8743b'/><circle cx='183.6' cy='182.185' r='3' fill='#e8743b'/><circle cx='193' cy='195.505' r='3' fill='#e8743b'/><circle cx='202.4' cy='195.505' r='3' fill='#e8743b'/><circle cx='211.8' cy='208.825' r='3' fill='#e8743b'/><circle cx='221.2' cy='242.126' r='3' fill='#e8743b'/><circle cx='230.6' cy='248.786' r='3' fill='#e8743b'/><circle cx='240' cy='248.786' r='3' fill='#e8743b'/><circle cx='249.4' cy='248.786' r='3' fill='#e8743b'/><circle cx='258.8' cy='248.786' r='3' fill='#e8743b'/><circle cx='268.2' cy='248.786' r='3' fill='#e8743b'/><circle cx='277.6' cy='255.446' r='3' fill='#e8743b'/><circle cx='287' cy='262.106' r='3' fill='#e8743b'/><circle cx='296.4' cy='275.427' r='3' fill='#e8743b'/><circle cx='305.8' cy='275.427' r='3' fill='#e8743b'/><circle cx='315.2' cy='275.427' r='3' fill='#e8743b'/><circle cx='324.6' cy='275.427' r='3' fill='#e8743b'/><circle cx='334' cy='275.427' r='3' fill='#e8743b'/><circle cx='343.4' cy='282.087' r='3' fill='#e8743b'/><circle cx='352.8' cy='288.747' r='3' fill='#e8743b'/><circle cx='362.2' cy='288.747' r='3' fill='#e8743b'/><circle cx='371.6' cy='295.407' r='3' fill='#e8743b'/><circle cx='381' cy='295.407' r='3' fill='#e8743b'/><circle cx='390.4' cy='308.727' r='3' fill='#e8743b'/><circle cx='399.8' cy='322.047' r='3' fill='#e8743b'/><circle cx='409.2' cy='322.047' r='3' fill='#e8743b'/><circle cx='418.6' cy='328.707' r='3' fill='#e8743b'/><circle cx='428' cy='328.707' r='3' fill='#e8743b'/><circle cx='437.4' cy='328.707' r='3' fill='#e8743b'/><circle cx='446.8' cy='328.707' r='3' fill='#e8743b'/><circle cx='456.2' cy='328.707' r='3' fill='#e8743b'/><circle cx='465.6' cy='328.707' r='3' fill='#e8743b'/><circle cx='475' cy='335.368' r='3' fill='#e8743b'/><circle cx='484.4' cy='335.368' r='3' fill='#e8743b'/><circle cx='493.8' cy='342.028' r='3' fill='#e8743b'/><circle cx='503.2' cy='348.688' r='3' fill='#e8743b'/><circle cx='512.6' cy='348.688' r='3' fill='#e8743b'/><circle cx='522' cy='348.688' r='3' fill='#e8743b'/><circle cx='531.4' cy='368.668' r='3' fill='#e8743b'/><circle cx='540.8' cy='375.328' r='3' fill='#e8743b'/><circle cx='550.2' cy='381.988' r='3' fill='#e8743b'/><circle cx='559.6' cy='381.988' r='3' fill='#e8743b'/><circle cx='569' cy='381.988' r='3' fill='#e8743b'/><circle cx='578.4' cy='388.648' r='3' fill='#e8743b'/><circle cx='587.8' cy='388.648' r='3' fill='#e8743b'/><circle cx='597.2' cy='395.309' r='3' fill='#e8743b'/><circle cx='606.6' cy='395.309' r='3' fill='#e8743b'/><circle cx='616' cy='395.309' r='3' fill='#e8743b'/><circle cx='625.4' cy='395.309' r='3' fill='#e8743b'/><circle cx='634.8' cy='395.309' r='3' fill='#e8743b'/><circle cx='644.2' cy='395.309' r='3' fill='#e8743b'/><circle cx='653.6' cy='395.309' r='3' fill='#e8743b'/><circle cx='663' cy='401.969' r='3' fill='#e8743b'/><circle cx='672.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='681.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='691.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='700.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='710' cy='401.969' r='3' fill='#e8743b'/><circle cx='719.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='728.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='738.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='747.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='757' cy='401.969' r='3' fill='#e8743b'/><circle cx='766.4' cy='401.969' r='3' fill='#e8743b'/><circle cx='775.8' cy='401.969' r='3' fill='#e8743b'/><circle cx='785.2' cy='401.969' r='3' fill='#e8743b'/><circle cx='794.6' cy='401.969' r='3' fill='#e8743b'/><circle cx='804' cy='415.289' r='3' fill='#e8743b'/><rect x='632' y='42' width='168' height='50' fill='white' stroke='#E5E5E5' stroke-width='1'/><line x1='642' y1='54' x2='666' y2='54' stroke='#2a6dba' stroke-width='2'/><text x='674' y='58' fill='#333333'>Bayesienne (modele exponentiel)</text><circle cx='654' cy='72' r='3' fill='#e8743b'/><text x='674' y='76' fill='#333333'>Empirique (donnees)</text></svg>"
      },
+     "execution_count": 5,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "#load \"SvgChartHelper.cs\"\n",
     "// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.\n",
     "// On evite `#r \"nuget:\"` sur une charting-lib : XPlot.Plotly.Interactive / Plotly.NET\n",
     "// pinent une vieille beta de Microsoft.DotNet.Interactive et font timeout le restore\n",
@@ -560,20 +551,16 @@
     "// Courbe continue S(t) : trace Plotly comparant le modele bayesien aux donnees empiriques.\n",
     "int NP = 80;\n",
     "var tGrid = Enumerable.Range(0, NP + 1).Select(j => j * 3000.0 / NP).ToArray();\n",
-    "string BuildTrace(string name, double[] ys) => System.Text.Json.JsonSerializer.Serialize(\n",
-    "    new Dictionary<string, object> { [\"name\"] = name, [\"x\"] = tGrid, [\"y\"] = ys,\n",
-    "                                     [\"type\"] = \"scatter\", [\"mode\"] = \"lines\" });\n",
-    "var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
-    "var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Fonction de survie S(t) : bayesienne vs empirique\\\"},\" +\n",
-    "             \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"t (heures)\\\"}},\" +\n",
-    "             \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"S(t)\\\"},\\\"range\\\":[0,1.05]}}\";\n",
-    "var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
-    "             \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "             \"<script>Plotly.newPlot('\" + divId + \"',[\" +\n",
-    "             BuildTrace(\"Bayesienne (modele exponentiel)\", tGrid.Select(Sbayes).ToArray()) + \",\" +\n",
-    "             BuildTrace(\"Empirique (donnees)\", tGrid.Select(t => Semp(t, lifetimesExp)).ToArray()) +\n",
-    "             \"],\" + layout + \")</script>\";\n",
-    "display(new PlotlyHtml(markup));\n"
+    "SvgChartHelper.Overlay(\n",
+    "    \"Fonction de survie S(t) : bayesienne vs empirique\",\n",
+    "    \"t (heures)\", \"S(t)\",\n",
+    "    new[] {\n",
+    "        new SvgSeries(\"Bayesienne (modele exponentiel)\",\n",
+    "            tGrid, tGrid.Select(Sbayes).ToArray(), TraceStyle.Line, \"#2a6dba\"),\n",
+    "        new SvgSeries(\"Empirique (donnees)\",\n",
+    "            tGrid, tGrid.Select(t => Semp(t, lifetimesExp)).ToArray(),\n",
+    "            TraceStyle.Markers, \"#e8743b\"),\n",
+    "    })"
    ]
   },
   {


### PR DESCRIPTION
## What

`Probas/Infer/Infer-19-Survival-Analysis.ipynb` **cell[11]**: replace blank-in-static Plotly chart with inline static SVG via **`SvgChartHelper.Overlay()`** (#6942 + #6958 MERGED).

Survival function S(t) over t(heures) 0..3000 — **2 Line series** sharing numeric X axis:
- **Bayesienne** (closed-form exponential model from the Gamma posterior `lambdaPost`) — smooth curve
- **Empirique** (data step function via `Semp(t, lifetimesExp)`) — markers

The smooth model curve vs the noisy empirical points shows the **regularizing benefit** of the Bayesian posterior — the pedagogical point that must render on GitHub.

## Family rotation (R6)

GameTheory-Csharp partition nearly drained (5 PR this session) → rotating to **Probas/Infer** (my home turf, .NET). Same EPIC (#6927), different family.

## `#load` resolves natively here

Bare `#load "SvgChartHelper.cs"` resolves **without** an `ExecutePreprocessor` path override — the helper is **co-located** in `Probas/Infer/` (same folder as the notebook), so kernel CWD = notebook dir = helper dir. This is the easy case, unlike the cross-family GameTheory conversions (GT-4c/8c/15c) which needed `resources.metadata.path = Probas/Infer/`.

## Surgical block-swap

`Console.WriteLine` S(t) comparison table, `Sbayes`/`Semp` functions, and `tGrid` are **preserved byte-for-byte**; only the `BuildTrace` → `display(PlotlyHtml)` block swaps to `Overlay()`. No computation changed.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Real `.net-csharp` exec (H.4) | cell[11] exec_count=5, 0 errors (27-cell exec), SVG out_len=7522 |
| `detect_svg_decimal_commas.py` (#6959, merge-gate) | **0 defects** rc=0 (helper `F()`=InvariantCulture) |
| `detect_svg_empty_display.py` (#6971, no-vision blank-gate) | **0 defects** rc=0 (mechanically non-blank) |
| `check_plotly_static_risk.py` (#6931) | Infer-19 **no longer risky** |
| `cdn.plotly` in output | **False** |
| probeAddresses banner | absent |
| 2 series legend | True (Bayesienne + Empirique) |
| C.3 scope | **only cell[11]** changed |
| Catalog byte-identity (R1) | 0 diff; README untouched |

## Verdict: **SOTA-OK** (#3801 Prong-A)

## Notes

- **Visual QA**: GLM lane not vision-capable; routes to MiniMax (CoursIA-2) / ai-01. Deterministic gates (#6959 + #6971) green.
- **See #6927** (partial — repo-wide Plotly-CDN→SVG; GameTheory partition + Infer-19 now, 15 risky notebooks remain across families).

🤖 po-2025 (GLM no-vision lane)
