### PR TITLE
docs(sudoku,#2876): restore FR accents in Sudoku-9-GraphColoring-Python (82→0)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "403f4734",
    "metadata": {
     "papermill": {
-     "duration": 0.004474,
-     "end_time": "2026-06-02T17:32:58.634391+00:00",
+     "duration": 0.004451,
+     "end_time": "2026-07-17T05:24:55.186702",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.629917+00:00",
+     "start_time": "2026-07-17T05:24:55.182251",
      "status": "completed"
     },
     "tags": []
@@ -22,16 +22,16 @@
     "\n",
     "A la fin de ce notebook, vous saurez :\n",
     "\n",
-    "1. **Modeliser** un Sudoku comme un probleme de coloration de graphe\n",
-    "2. **Comprendre** la theorie des graphes sous-jacente (81 sommets, degre 20)\n",
+    "1. **Modeliser** un Sudoku comme un problème de coloration de graphe\n",
+    "2. **Comprendre** la théorie des graphes sous-jacente (81 sommets, degré 20)\n",
     "3. **Utiliser** NetworkX pour manipuler des graphes de contraintes\n",
-    "4. **Comparer** l'efficacite de differentes strategies de coloration\n",
+    "4. **Comparer** l'efficacite de différentes strategies de coloration\n",
     "\n",
     "**Duree estimee** : ~15 min | **Prerequis** : Sudoku-0 Environment\n",
     "\n",
     "---\n",
     "\n",
-    "Ce notebook implemente des solveurs de Sudoku utilisant la **coloration de graphe**, une approche classique de la theorie des graphes.\n"
+    "Ce notebook implemente des solveurs de Sudoku utilisant la **coloration de graphe**, une approche classique de la théorie des graphes.\n"
    ]
   },
   {
@@ -44,16 +44,16 @@
      "start_time": "2026-04-20T08:09:57.302191300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:58.642695Z",
-     "iopub.status.busy": "2026-06-02T17:32:58.642505Z",
-     "iopub.status.idle": "2026-06-02T17:32:58.933041Z",
-     "shell.execute_reply": "2026-06-02T17:32:58.932342Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.194625Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.194438Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.455937Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.455421Z"
     },
     "papermill": {
-     "duration": 0.295549,
-     "end_time": "2026-06-02T17:32:58.933706+00:00",
+     "duration": 0.26586,
+     "end_time": "2026-07-17T05:24:55.456841",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.638157+00:00",
+     "start_time": "2026-07-17T05:24:55.190981",
      "status": "completed"
     },
     "tags": []
@@ -83,31 +83,31 @@
    "id": "e3b99014",
    "metadata": {
     "papermill": {
-     "duration": 0.002905,
-     "end_time": "2026-06-02T17:32:58.939916+00:00",
+     "duration": 0.002617,
+     "end_time": "2026-07-17T05:24:55.462508",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.937011+00:00",
+     "start_time": "2026-07-17T05:24:55.459891",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## Introduction : Sudoku et Theorie des Graphes\n",
+    "## Introduction : Sudoku et Théorie des Graphes\n",
     "\n",
-    "Le Sudoku peut etre modelise comme un **probleme de coloration de graphe** :\n",
+    "Le Sudoku peut etre modelise comme un **problème de coloration de graphe** :\n",
     "\n",
     "### Modelisation\n",
     "\n",
     "- **Sommets** : 81 cellules de la grille (9x9)\n",
-    "- **Aretes** : deux cellules sont reliees si elles ne peuvent pas avoir la meme valeur\n",
+    "- **Aretes** : deux cellules sont reliees si elles ne peuvent pas avoir la même valeur\n",
     "- **Couleurs** : valeurs 1 a 9\n",
     "\n",
     "### Proprietes du graphe Sudoku\n",
     "\n",
     "- **Nombre de sommets** : 81\n",
-    "- **Degre de chaque sommet** : 20\n",
+    "- **Degré de chaque sommet** : 20\n",
     "- **Nombre d'aretes** : 810\n",
-    "- **Graphe regulier** : tous les sommets ont le meme degre\n"
+    "- **Graphe regulier** : tous les sommets ont le même degré\n"
    ]
   },
   {
@@ -120,16 +120,16 @@
      "start_time": "2026-04-20T08:11:59.150112600Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:58.947177Z",
-     "iopub.status.busy": "2026-06-02T17:32:58.946897Z",
-     "iopub.status.idle": "2026-06-02T17:32:58.951403Z",
-     "shell.execute_reply": "2026-06-02T17:32:58.950867Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.469006Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.468700Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.482068Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.481361Z"
     },
     "papermill": {
-     "duration": 0.008965,
-     "end_time": "2026-06-02T17:32:58.951949+00:00",
+     "duration": 0.01807,
+     "end_time": "2026-07-17T05:24:55.483161",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.942984+00:00",
+     "start_time": "2026-07-17T05:24:55.465091",
      "status": "completed"
     },
     "tags": []
@@ -170,10 +170,10 @@
    "id": "b6bb9148",
    "metadata": {
     "papermill": {
-     "duration": 0.002979,
-     "end_time": "2026-06-02T17:32:58.957919+00:00",
+     "duration": 0.002565,
+     "end_time": "2026-07-17T05:24:55.488757",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.954940+00:00",
+     "start_time": "2026-07-17T05:24:55.486192",
      "status": "completed"
     },
     "tags": []
@@ -194,16 +194,16 @@
      "start_time": "2026-04-20T08:12:07.647028300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:58.964806Z",
-     "iopub.status.busy": "2026-06-02T17:32:58.964638Z",
-     "iopub.status.idle": "2026-06-02T17:32:58.969657Z",
-     "shell.execute_reply": "2026-06-02T17:32:58.969030Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.494989Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.494592Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.500099Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.499653Z"
     },
     "papermill": {
-     "duration": 0.009408,
-     "end_time": "2026-06-02T17:32:58.970285+00:00",
+     "duration": 0.009565,
+     "end_time": "2026-07-17T05:24:55.500811",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.960877+00:00",
+     "start_time": "2026-07-17T05:24:55.491246",
      "status": "completed"
     },
     "tags": []
@@ -216,13 +216,13 @@
       "=== Statistiques du Graphe Sudoku ===\n",
       "Sommets: 81\n",
       "Aretes: 810\n",
-      "Degre min: 20, max: 20\n",
+      "Degré min: 20, max: 20\n",
       "Graphe regulier: True\n"
      ]
     }
    ],
    "source": [
-    "# Creer le graphe Sudoku avec NetworkX\n",
+    "# Créer le graphe Sudoku avec NetworkX\n",
     "G = nx.sudoku_graph()\n",
     "\n",
     "print(\"=== Statistiques du Graphe Sudoku ===\")\n",
@@ -231,7 +231,7 @@
     "\n",
     "# Verifier que c'est un graphe regulier\n",
     "degrees = [d for n, d in G.degree()]\n",
-    "print(f\"Degre min: {min(degrees)}, max: {max(degrees)}\")\n",
+    "print(f\"Degré min: {min(degrees)}, max: {max(degrees)}\")\n",
     "print(f\"Graphe regulier: {len(set(degrees)) == 1}\")\n"
    ]
   },
@@ -240,10 +240,10 @@
    "id": "50545bc9",
    "metadata": {
     "papermill": {
-     "duration": 0.003022,
-     "end_time": "2026-06-02T17:32:58.976229+00:00",
+     "duration": 0.002575,
+     "end_time": "2026-07-17T05:24:55.506079",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.973207+00:00",
+     "start_time": "2026-07-17T05:24:55.503504",
      "status": "completed"
     },
     "tags": []
@@ -255,7 +255,7 @@
     "\n",
     "- **81 sommets** (index 0-80)\n",
     "- **810 aretes** (sans doublons)\n",
-    "- **Graphe regulier de degre 20**\n",
+    "- **Graphe regulier de degré 20**\n",
     "\n",
     "Chaque sommet represente une cellule, et les aretes representent les contraintes d'exclusion.\n"
    ]
@@ -265,10 +265,10 @@
    "id": "ex-cell-constraints",
    "metadata": {
     "papermill": {
-     "duration": 0.003076,
-     "end_time": "2026-06-02T17:32:58.982513+00:00",
+     "duration": 0.002682,
+     "end_time": "2026-07-17T05:24:55.511386",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.979437+00:00",
+     "start_time": "2026-07-17T05:24:55.508704",
      "status": "completed"
     },
     "tags": []
@@ -284,9 +284,9 @@
     "\n",
     "### Indices\n",
     "\n",
-    "- Etape 1 : Identifiez les sommets non colories (`coloring[v] == 0`)\n",
-    "- Etape 2 : Pour chaque sommet non colorie, comptez ses voisins non colories\n",
-    "- Etape 3 : Retournez le dictionnaire trie par nombre de contraintes decroissant\n"
+    "- Étape 1 : Identifiez les sommets non colories (`coloring[v] == 0`)\n",
+    "- Étape 2 : Pour chaque sommet non colorie, comptez ses voisins non colories\n",
+    "- Étape 3 : Retournez le dictionnaire trie par nombre de contraintes decroissant\n"
    ]
   },
   {
@@ -295,16 +295,16 @@
    "id": "ex-cell-constraints-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:58.990267Z",
-     "iopub.status.busy": "2026-06-02T17:32:58.989904Z",
-     "iopub.status.idle": "2026-06-02T17:32:58.994832Z",
-     "shell.execute_reply": "2026-06-02T17:32:58.994193Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.518121Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.517887Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.522614Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.521534Z"
     },
     "papermill": {
-     "duration": 0.010097,
-     "end_time": "2026-06-02T17:32:58.995656+00:00",
+     "duration": 0.009379,
+     "end_time": "2026-07-17T05:24:55.523630",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.985559+00:00",
+     "start_time": "2026-07-17T05:24:55.514251",
      "status": "completed"
     },
     "tags": []
@@ -358,10 +358,10 @@
    "id": "b9920bf3",
    "metadata": {
     "papermill": {
-     "duration": 0.003133,
-     "end_time": "2026-06-02T17:32:59.001936+00:00",
+     "duration": 0.003516,
+     "end_time": "2026-07-17T05:24:55.530294",
      "exception": false,
-     "start_time": "2026-06-02T17:32:58.998803+00:00",
+     "start_time": "2026-07-17T05:24:55.526778",
      "status": "completed"
     },
     "tags": []
@@ -380,16 +380,16 @@
      "start_time": "2026-04-20T08:14:06.261561900Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:59.009598Z",
-     "iopub.status.busy": "2026-06-02T17:32:59.009412Z",
-     "iopub.status.idle": "2026-06-02T17:32:59.015386Z",
-     "shell.execute_reply": "2026-06-02T17:32:59.014862Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.538969Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.538581Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.546677Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.546063Z"
     },
     "papermill": {
-     "duration": 0.010646,
-     "end_time": "2026-06-02T17:32:59.015929+00:00",
+     "duration": 0.013411,
+     "end_time": "2026-07-17T05:24:55.547662",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.005283+00:00",
+     "start_time": "2026-07-17T05:24:55.534251",
      "status": "completed"
     },
     "tags": []
@@ -428,7 +428,7 @@
     "    def from_string(cls, s: str) -> \"SudokuGrid\":\n",
     "        s = s.replace(\".\", \"0\").replace(\" \", \"\").replace(\"\\n\", \"\")\n",
     "        if len(s) != 81:\n",
-    "            raise ValueError(\"La chaine doit avoir 81 caracteres\")\n",
+    "            raise ValueError(\"La chaîne doit avoir 81 caractères\")\n",
     "        grid = cls()\n",
     "        for i in range(81):\n",
     "            grid.cells[i // 9][i % 9] = int(s[i])\n",
@@ -474,10 +474,10 @@
    "id": "69b3809b",
    "metadata": {
     "papermill": {
-     "duration": 0.003134,
-     "end_time": "2026-06-02T17:32:59.022165+00:00",
+     "duration": 0.00341,
+     "end_time": "2026-07-17T05:24:55.555299",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.019031+00:00",
+     "start_time": "2026-07-17T05:24:55.551889",
      "status": "completed"
     },
     "tags": []
@@ -498,16 +498,16 @@
      "start_time": "2026-04-20T08:15:12.638358300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:59.029502Z",
-     "iopub.status.busy": "2026-06-02T17:32:59.029174Z",
-     "iopub.status.idle": "2026-06-02T17:32:59.037601Z",
-     "shell.execute_reply": "2026-06-02T17:32:59.036865Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.563578Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.563277Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.573019Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.572031Z"
     },
     "papermill": {
-     "duration": 0.013025,
-     "end_time": "2026-06-02T17:32:59.038174+00:00",
+     "duration": 0.01544,
+     "end_time": "2026-07-17T05:24:55.574194",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.025149+00:00",
+     "start_time": "2026-07-17T05:24:55.558754",
      "status": "completed"
     },
     "tags": []
@@ -530,7 +530,7 @@
       "7 . 5 | 2 . . | 3 . 4 \n",
       ". 8 . | . 4 1 | 9 5 . \n",
       "\n",
-      "Resolu: True en 1.88 ms\n",
+      "Resolu: True en 2.15 ms\n",
       "Noeuds explores: 37\n",
       "Backtracks: 0\n",
       "\n",
@@ -620,10 +620,10 @@
    "id": "4taoqji9bpb",
    "metadata": {
     "papermill": {
-     "duration": 0.003173,
-     "end_time": "2026-06-02T17:32:59.044997+00:00",
+     "duration": 0.005391,
+     "end_time": "2026-07-17T05:24:55.584154",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.041824+00:00",
+     "start_time": "2026-07-17T05:24:55.578763",
      "status": "completed"
     },
     "tags": []
@@ -635,14 +635,14 @@
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| **Temps** | 1.88 ms | Resolution tres rapide |\n",
+    "| **Temps** | 1.88 ms | Resolution très rapide |\n",
     "| **Noeuds explores** | 37 | MRV reduit l'espace de recherche |\n",
     "| **Backtracks** | 0 | Pas d'erreurs necessaires |\n",
     "\n",
     "**Points cles** :\n",
-    "1. **MRV fonctionne tres bien** : La heuristique choisit les cases les plus contraintes\n",
+    "1. **MRV fonctionne très bien** : La heuristique choisit les cases les plus contraintes\n",
     "2. **NetworkX simplifie le code** : Plus besoin de gerer manuellement les voisins\n",
-    "3. **Graphe regulier** : Tous les sommets ont degre 20, donc MRV se base sur les domaines\n",
+    "3. **Graphe regulier** : Tous les sommets ont degré 20, donc MRV se base sur les domaines\n",
     "\n",
     "> **Note technique** : L'heuristique MRV (Minimum Remaining Values) est particulierement efficace sur Sudoku car les contraintes locales (ligne, colonne, bloc) reduisent rapidement les domaines des cases voisines.\n"
    ]
@@ -652,29 +652,29 @@
    "id": "ex-degree-heuristic",
    "metadata": {
     "papermill": {
-     "duration": 0.002998,
-     "end_time": "2026-06-02T17:32:59.051092+00:00",
+     "duration": 0.003737,
+     "end_time": "2026-07-17T05:24:55.592421",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.048094+00:00",
+     "start_time": "2026-07-17T05:24:55.588684",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## Exercice : Heuristique de degre (Degree Heuristic)\n",
+    "## Exercice : Heuristique de degré (Degree Heuristic)\n",
     "\n",
     "### Enonce\n",
     "\n",
-    "L'heuristique MRV choisit le sommet avec le moins de couleurs disponibles. Mais quand plusieurs sommets ont le meme nombre de couleurs possibles (egalite MRV), l'**heuristique de degre** les departage en choisissant celui qui a le **plus de voisins non colories**. Ce sommet est le plus contraignant, donc le colorier en premier reduit l'arbre de recherche.\n",
+    "L'heuristique MRV choisit le sommet avec le moins de couleurs disponibles. Mais quand plusieurs sommets ont le même nombre de couleurs possibles (egalite MRV), l'**heuristique de degré** les departage en choisissant celui qui a le **plus de voisins non colories**. Ce sommet est le plus contraignant, donc le colorier en premier reduit l'arbre de recherche.\n",
     "\n",
-    "Implementez `select_unassigned_vertex(coloring, G)` qui combine MRV + degre.\n",
+    "Implementez `select_unassigned_vertex(coloring, G)` qui combine MRV + degré.\n",
     "\n",
     "### Indices\n",
     "\n",
-    "- Etape 1 : Collectez tous les sommets non colories (`coloring[v] == 0`)\n",
-    "- Etape 2 : Pour chacun, calculez le nombre de couleurs disponibles (couleurs 1-9 deja prises par les voisins)\n",
-    "- Etape 3 : Trouvez le minimum de couleurs disponibles (MRV)\n",
-    "- Etape 4 : En cas d'egalite, departagez avec le degre (nombre de voisins non colories)"
+    "- Étape 1 : Collectez tous les sommets non colories (`coloring[v] == 0`)\n",
+    "- Étape 2 : Pour chacun, calculez le nombre de couleurs disponibles (couleurs 1-9 déjà prises par les voisins)\n",
+    "- Étape 3 : Trouvez le minimum de couleurs disponibles (MRV)\n",
+    "- Étape 4 : En cas d'egalite, departagez avec le degré (nombre de voisins non colories)"
    ]
   },
   {
@@ -683,16 +683,16 @@
    "id": "ex-degree-heuristic-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:59.058626Z",
-     "iopub.status.busy": "2026-06-02T17:32:59.058416Z",
-     "iopub.status.idle": "2026-06-02T17:32:59.062783Z",
-     "shell.execute_reply": "2026-06-02T17:32:59.062002Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.603101Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.602543Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.607884Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.607219Z"
     },
     "papermill": {
-     "duration": 0.009228,
-     "end_time": "2026-06-02T17:32:59.063485+00:00",
+     "duration": 0.013347,
+     "end_time": "2026-07-17T05:24:55.609866",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.054257+00:00",
+     "start_time": "2026-07-17T05:24:55.596519",
      "status": "completed"
     },
     "tags": []
@@ -707,16 +707,16 @@
     }
    ],
    "source": [
-    "# EXERCICE : Heuristique de degre (MRV + Degree)\n",
+    "# EXERCICE : Heuristique de degré (MRV + Degree)\n",
     "#\n",
     "# Indications :\n",
     "#   - Collectez les sommets non colories (coloring[v] == 0)\n",
-    "#   - Pour chacun, calculez les couleurs disponibles (couleurs des voisins deja prises)\n",
+    "#   - Pour chacun, calculez les couleurs disponibles (couleurs des voisins déjà prises)\n",
     "#   - Trouvez le minimum de couleurs (MRV)\n",
     "#   - En cas d egalite, choisissez le sommet avec le plus de voisins non colories\n",
     "\n",
     "def select_unassigned_vertex(coloring: list, G) -> int:\n",
-    "    \"\"\"Selectionne le prochain sommet a colorier avec MRV + degre.\n",
+    "    \"\"\"Selectionne le prochain sommet a colorier avec MRV + degré.\n",
     "\n",
     "    Args:\n",
     "        coloring: liste de 81 entiers (0=non colorie)\n",
@@ -742,10 +742,10 @@
    "id": "6f0fd4c0",
    "metadata": {
     "papermill": {
-     "duration": 0.003288,
-     "end_time": "2026-06-02T17:32:59.070079+00:00",
+     "duration": 0.003841,
+     "end_time": "2026-07-17T05:24:55.620276",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.066791+00:00",
+     "start_time": "2026-07-17T05:24:55.616435",
      "status": "completed"
     },
     "tags": []
@@ -764,16 +764,16 @@
      "start_time": "2026-04-20T08:16:19.956182900Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:59.077709Z",
-     "iopub.status.busy": "2026-06-02T17:32:59.077505Z",
-     "iopub.status.idle": "2026-06-02T17:32:59.187298Z",
-     "shell.execute_reply": "2026-06-02T17:32:59.186555Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.635491Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.635124Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.755608Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.755096Z"
     },
     "papermill": {
-     "duration": 0.114829,
-     "end_time": "2026-06-02T17:32:59.188073+00:00",
+     "duration": 0.130025,
+     "end_time": "2026-07-17T05:24:55.756586",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.073244+00:00",
+     "start_time": "2026-07-17T05:24:55.626561",
      "status": "completed"
     },
     "tags": []
@@ -786,7 +786,7 @@
       "\n",
       "Benchmark: Puzzles Faciles (3 puzzles)\n",
       "Succes: 3/3\n",
-      "Temps moyen: 2.47 ms\n",
+      "Temps moyen: 3.68 ms\n",
       "\n",
       "Benchmark: Puzzles Difficiles (2 puzzles)\n"
      ]
@@ -796,18 +796,18 @@
      "output_type": "stream",
      "text": [
       "Succes: 2/2\n",
-      "Temps moyen: 46.88 ms\n"
+      "Temps moyen: 45.95 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "[{'success': True,\n",
-       "  'time_ms': 8.841276168823242,\n",
+       "  'time_ms': 9.479761123657227,\n",
        "  'nodes': 164,\n",
        "  'backtracks': 104},\n",
        " {'success': True,\n",
-       "  'time_ms': 84.9144458770752,\n",
+       "  'time_ms': 82.42917060852051,\n",
        "  'nodes': 1496,\n",
        "  'backtracks': 1437}]"
       ]
@@ -848,10 +848,10 @@
    "id": "9mkm25kzhhd",
    "metadata": {
     "papermill": {
-     "duration": 0.003211,
-     "end_time": "2026-06-02T17:32:59.194940+00:00",
+     "duration": 0.003223,
+     "end_time": "2026-07-17T05:24:55.763376",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.191729+00:00",
+     "start_time": "2026-07-17T05:24:55.760153",
      "status": "completed"
     },
     "tags": []
@@ -859,7 +859,7 @@
    "source": [
     "### Interpretation : Benchmark Graph Coloring\n",
     "\n",
-    "Les resultats montrent que l'approche coloration de graphe est efficace mais moins optimale que les solveurs CSP dedies.\n",
+    "Les résultats montrent que l'approche coloration de graphe est efficace mais moins optimale que les solveurs CSP dedies.\n",
     "\n",
     "| Type | Temps moyen | Analyse |\n",
     "|------|-------------|---------|\n",
@@ -874,9 +874,9 @@
     "**Points cles** :\n",
     "1. **NetworkX n'a pas de solveur integre** : Nous devons implementer le backtracking\n",
     "2. **L'avantage est la flexibilite** : Facile d'experimentation avec d'autres algorithmes de coloration\n",
-    "3. **Graphe regulier** : Le degre constant (20) aide a comprendre la structure\n",
+    "3. **Graphe regulier** : Le degré constant (20) aide a comprendre la structure\n",
     "\n",
-    "> **Note technique** : La coloration de graphe est un probleme NP-complet. Le Sudoku est un cas particulier avec une structure tres reguliere, ce qui permet des optimisations specifiques que NetworkX n'exploite pas.\n"
+    "> **Note technique** : La coloration de graphe est un problème NP-complet. Le Sudoku est un cas particulier avec une structure très reguliere, ce qui permet des optimisations specifiques que NetworkX n'exploite pas.\n"
    ]
   },
   {
@@ -884,10 +884,10 @@
    "id": "ex-valid-coloring",
    "metadata": {
     "papermill": {
-     "duration": 0.003314,
-     "end_time": "2026-06-02T17:32:59.201354+00:00",
+     "duration": 0.003238,
+     "end_time": "2026-07-17T05:24:55.770866",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.198040+00:00",
+     "start_time": "2026-07-17T05:24:55.767628",
      "status": "completed"
     },
     "tags": []
@@ -897,16 +897,16 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Avant d'accepter une solution de Sudoku, il est essentiel de verifier que la coloration obtenue est une **coloration propre** du graphe de contraintes : deux sommets adjacents ne doivent pas partager la meme couleur.\n",
+    "Avant d'accepter une solution de Sudoku, il est essentiel de verifier que la coloration obtenue est une **coloration propre** du graphe de contraintes : deux sommets adjacents ne doivent pas partager la même couleur.\n",
     "\n",
     "Implementez la fonction `is_valid_coloring(coloring, G)` qui verifie cette propriete sur l'ensemble du graphe.\n",
     "\n",
     "### Indices\n",
     "\n",
-    "- Etape 1 : Parcourez toutes les aretes du graphe avec `G.edges()`\n",
-    "- Etape 2 : Pour chaque arete `(u, v)`, verifiez que `coloring[u] != coloring[v]`\n",
-    "- Etape 3 : Verifiez aussi qu'aucun sommet n'a la couleur 0 (non colorie)\n",
-    "- Etape 4 : Retournez `True` si la coloration est propre et complete, `False` sinon\n"
+    "- Étape 1 : Parcourez toutes les aretes du graphe avec `G.edges()`\n",
+    "- Étape 2 : Pour chaque arete `(u, v)`, verifiez que `coloring[u] != coloring[v]`\n",
+    "- Étape 3 : Verifiez aussi qu'aucun sommet n'a la couleur 0 (non colorie)\n",
+    "- Étape 4 : Retournez `True` si la coloration est propre et complete, `False` sinon\n"
    ]
   },
   {
@@ -915,16 +915,16 @@
    "id": "ex-valid-coloring-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:59.209500Z",
-     "iopub.status.busy": "2026-06-02T17:32:59.209203Z",
-     "iopub.status.idle": "2026-06-02T17:32:59.216900Z",
-     "shell.execute_reply": "2026-06-02T17:32:59.216358Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.779580Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.779100Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.786852Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.786323Z"
     },
     "papermill": {
-     "duration": 0.013047,
-     "end_time": "2026-06-02T17:32:59.217642+00:00",
+     "duration": 0.012755,
+     "end_time": "2026-07-17T05:24:55.787695",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.204595+00:00",
+     "start_time": "2026-07-17T05:24:55.774940",
      "status": "completed"
     },
     "tags": []
@@ -934,14 +934,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Coloration valide : False"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "Coloration valide : False\n"
      ]
     }
    ],
@@ -983,10 +976,10 @@
    "id": "ytp2bllgm1n",
    "metadata": {
     "papermill": {
-     "duration": 0.0036,
-     "end_time": "2026-06-02T17:32:59.224581+00:00",
+     "duration": 0.003288,
+     "end_time": "2026-07-17T05:24:55.794178",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.220981+00:00",
+     "start_time": "2026-07-17T05:24:55.790890",
      "status": "completed"
     },
     "tags": []
@@ -996,7 +989,7 @@
     "\n",
     "### Concept\n",
     "\n",
-    "L'heuristique **LCV (Least Constraining Value)** complete MRV en optimisant l'ordre des couleurs : a chaque etape, choisir la couleur qui reduit le moins les domaines des sommets voisins.\n",
+    "L'heuristique **LCV (Least Constraining Value)** complete MRV en optimisant l'ordre des couleurs : a chaque étape, choisir la couleur qui reduit le moins les domaines des sommets voisins.\n",
     "\n",
     "### Strategie LCV\n",
     "\n",
@@ -1024,16 +1017,16 @@
      "start_time": "2026-04-20T08:45:26.966039400Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:59.232977Z",
-     "iopub.status.busy": "2026-06-02T17:32:59.232766Z",
-     "iopub.status.idle": "2026-06-02T17:32:59.264665Z",
-     "shell.execute_reply": "2026-06-02T17:32:59.263914Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.802381Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.802114Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.828309Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.827702Z"
     },
     "papermill": {
-     "duration": 0.037605,
-     "end_time": "2026-06-02T17:32:59.265713+00:00",
+     "duration": 0.03146,
+     "end_time": "2026-07-17T05:24:55.829171",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.228108+00:00",
+     "start_time": "2026-07-17T05:24:55.797711",
      "status": "completed"
     },
     "tags": []
@@ -1155,10 +1148,10 @@
    "id": "e33c5566",
    "metadata": {
     "papermill": {
-     "duration": 0.004084,
-     "end_time": "2026-06-02T17:32:59.274179+00:00",
+     "duration": 0.003104,
+     "end_time": "2026-07-17T05:24:55.835699",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.270095+00:00",
+     "start_time": "2026-07-17T05:24:55.832595",
      "status": "completed"
     },
     "tags": []
@@ -1166,9 +1159,9 @@
    "source": [
     "### Interpretation : LCV vs MRV pur\n",
     "\n",
-    "Les resultats montrent un comportement contre-intuitif de LCV sur ce puzzle difficile.\n",
+    "Les résultats montrent un comportement contre-intuitif de LCV sur ce puzzle difficile.\n",
     "\n",
-    "| Methode | Noeuds explores | Backtracks | Analyse |\n",
+    "| Méthode | Noeuds explores | Backtracks | Analyse |\n",
     "|---------|----------------|------------|----------|\n",
     "| **LCV** | 182 | 122 | Plus de backtracks |\n",
     "| **MRV pur** | 164 | 104 | Plus efficace |\n",
@@ -1176,10 +1169,10 @@
     "**Points cles** :\n",
     "\n",
     "1. **LCV n'est pas toujours benefique** : Le calcul couteux de `count_remaining_options` pour chaque couleur peut ralentir la recherche plus qu'il n'aide a reduire les backtracks\n",
-    "2. **Le degre eleve du graphe Sudoku** : Avec 20 voisins par sommet, LCV doit calculer les domaines pour beaucoup de voisins\n",
-    "3. **Graphe regulier** : Tous les sommets ayant le meme degre, l'avantage de LCV est moins marque que sur des graphes heterogenes\n",
+    "2. **Le degré eleve du graphe Sudoku** : Avec 20 voisins par sommet, LCV doit calculer les domaines pour beaucoup de voisins\n",
+    "3. **Graphe regulier** : Tous les sommets ayant le même degré, l'avantage de LCV est moins marque que sur des graphes heterogenes\n",
     "\n",
-    "> **Note technique** : LCV est plus utile sur des graphes avec des degres heterogenes (certains sommets beaucoup plus contraints que d'autres). Sur le graphe Sudoku regulier (deg. 20 partout), le gain est limite par le cout de calcul.\n"
+    "> **Note technique** : LCV est plus utile sur des graphes avec des degrés heterogenes (certains sommets beaucoup plus contraints que d'autres). Sur le graphe Sudoku regulier (deg. 20 partout), le gain est limite par le cout de calcul.\n"
    ]
   },
   {
@@ -1187,10 +1180,10 @@
    "id": "5b18e409",
    "metadata": {
     "papermill": {
-     "duration": 0.004237,
-     "end_time": "2026-06-02T17:32:59.282542+00:00",
+     "duration": 0.003113,
+     "end_time": "2026-07-17T05:24:55.842014",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.278305+00:00",
+     "start_time": "2026-07-17T05:24:55.838901",
      "status": "completed"
     },
     "tags": []
@@ -1200,22 +1193,22 @@
     "\n",
     "### Enonce\n",
     "\n",
-    "Implementez un solveur de Sudoku par coloration de graphe avec l'heuristique **Welsh-Powell**, une approche gloutonne qui ordonne les sommets par degre decroissant avant coloration.\n",
+    "Implementez un solveur de Sudoku par coloration de graphe avec l'heuristique **Welsh-Powell**, une approche gloutonne qui ordonne les sommets par degré decroissant avant coloration.\n",
     "\n",
     "### Strategie Welsh-Powell\n",
     "\n",
     "L'heuristique Welsh-Powell est une approche gloutonne classique pour la coloration de graphes :\n",
     "\n",
-    "1. **Trier les sommets** par degre decroissant (sur le graphe des contraintes non colorees)\n",
+    "1. **Trier les sommets** par degré decroissant (sur le graphe des contraintes non colorees)\n",
     "2. **Colorier gloutonnement** : Pour chaque sommet dans cet ordre, lui assigner la plus petite couleur disponible\n",
-    "3. **Backtracking** : Si une impasse est rencontree, revenir a la derniere decision\n",
+    "3. **Backtracking** : Si une impasse est rencontree, revenir a la dernière decision\n",
     "\n",
     "### Implementation demandee\n",
     "\n",
-    "1. `sort_vertices_by_degree(coloring)` : retourne la liste des sommets non colories tries par degre decroissant (en ne comptant que les aretes vers les sommets non colories)\n",
+    "1. `sort_vertices_by_degree(coloring)` : retourne la liste des sommets non colories tries par degré decroissant (en ne comptant que les aretes vers les sommets non colories)\n",
     "\n",
     "2. `solve_with_welsh_powell(grid)` : solveur complet utilisant Welsh-Powell pour le choix du sommet. Le solveur doit :\n",
-    "   - Selectionner le sommet avec le plus grand degre actuel (parmi les non colories)\n",
+    "   - Sélectionner le sommet avec le plus grand degré actuel (parmi les non colories)\n",
     "   - Lui assigner la plus petite couleur disponible (1 a 9)\n",
     "   - Utiliser le backtracking si necessaire\n",
     "\n",
@@ -1223,9 +1216,9 @@
     "\n",
     "**Indice :**\n",
     "\n",
-    "Le degre actuel d'un sommet non colorie est le nombre de ses voisins qui sont egalement non colories. Plus ce degre est eleve, plus le sommet est contraint et doit etre colorie prioritairement.\n",
+    "Le degré actuel d'un sommet non colorie est le nombre de ses voisins qui sont egalement non colories. Plus ce degré est eleve, plus le sommet est contraint et doit etre colorie prioritairement.\n",
     "\n",
-    "Welsh-Powell est une heuristique gloutonne classique qui performe bien sur les graphes de coloration generaux, mais peut etre moins efficace que MRV sur Sudoku ou la structure est tres reguliere.\n"
+    "Welsh-Powell est une heuristique gloutonne classique qui performe bien sur les graphes de coloration généraux, mais peut etre moins efficace que MRV sur Sudoku ou la structure est très reguliere.\n"
    ]
   },
   {
@@ -1234,16 +1227,16 @@
    "id": "39831a5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T17:32:59.291406Z",
-     "iopub.status.busy": "2026-06-02T17:32:59.291192Z",
-     "iopub.status.idle": "2026-06-02T17:32:59.322955Z",
-     "shell.execute_reply": "2026-06-02T17:32:59.322300Z"
+     "iopub.execute_input": "2026-07-17T05:24:55.849504Z",
+     "iopub.status.busy": "2026-07-17T05:24:55.849249Z",
+     "iopub.status.idle": "2026-07-17T05:24:55.880968Z",
+     "shell.execute_reply": "2026-07-17T05:24:55.880216Z"
     },
     "papermill": {
-     "duration": 0.037281,
-     "end_time": "2026-06-02T17:32:59.323587+00:00",
+     "duration": 0.036692,
+     "end_time": "2026-07-17T05:24:55.881863",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.286306+00:00",
+     "start_time": "2026-07-17T05:24:55.845171",
      "status": "completed"
     },
     "tags": []
@@ -1261,8 +1254,8 @@
    "source": [
     "def sort_vertices_by_degree(coloring: List[int], G) -> List[int]:\n",
     "    \"\"\"\n",
-    "    Retourne la liste des sommets non colories tries par degre decroissant.\n",
-    "    Le degre compte les voisins non colories seulement.\n",
+    "    Retourne la liste des sommets non colories tries par degré decroissant.\n",
+    "    Le degré compte les voisins non colories seulement.\n",
     "    \"\"\"\n",
     "    uncolored = [v for v in range(81) if coloring[v] == 0]\n",
     "    def get_degree(v):\n",
@@ -1272,7 +1265,7 @@
     "def solve_with_welsh_powell(grid: SudokuGrid) -> tuple:\n",
     "    \"\"\"\n",
     "    Resout le Sudoku avec backtracking + heuristique Welsh-Powell.\n",
-    "    Welsh-Powell: choisir le sommet non colorie avec le plus grand degre actuel.\n",
+    "    Welsh-Powell: choisir le sommet non colorie avec le plus grand degré actuel.\n",
     "    Retourne (success, nodes_explored, backtracks).\n",
     "    \"\"\"\n",
     "    G = nx.sudoku_graph()\n",
@@ -1310,8 +1303,8 @@
     "    return success, nodes_explored, backtracks\n",
     "\n",
     "# Test comparatif Welsh-Powell vs MRV sur un puzzle facile.\n",
-    "# Note: Welsh-Powell selectionne le sommet de plus haut degre non colorie. Sur un graphe\n",
-    "# Sudoku regulier (tous degre 20), cette heuristique n'apporte pas de guide efficace\n",
+    "# Note: Welsh-Powell selectionne le sommet de plus haut degré non colorie. Sur un graphe\n",
+    "# Sudoku regulier (tous degré 20), cette heuristique n'apporte pas de guide efficace\n",
     "# et tombe vite dans de longues branches de backtracking sur les puzzles difficiles.\n",
     "# Les puzzles difficiles peuvent necessiter sys.setrecursionlimit() eleve et un stack Python\n",
     "# agrandi pour terminer ; on utilise ici un puzzle easy pour un benchmark reproductible.\n",
@@ -1329,10 +1322,10 @@
    "id": "10f7be5f",
    "metadata": {
     "papermill": {
-     "duration": 0.003417,
-     "end_time": "2026-06-02T17:32:59.330567+00:00",
+     "duration": 0.003377,
+     "end_time": "2026-07-17T05:24:55.888914",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.327150+00:00",
+     "start_time": "2026-07-17T05:24:55.885537",
      "status": "completed"
     },
     "tags": []
@@ -1340,21 +1333,21 @@
    "source": [
     "### Interpretation : Welsh-Powell vs MRV sur Sudoku\n",
     "\n",
-    "Les resultats sur le meme puzzle `easy_puzzles[0]` illustrent clairement les limites de Welsh-Powell dans ce contexte.\n",
+    "Les résultats sur le même puzzle `easy_puzzles[0]` illustrent clairement les limites de Welsh-Powell dans ce contexte.\n",
     "\n",
-    "| Methode | Noeuds explores | Backtracks | Analyse |\n",
+    "| Méthode | Noeuds explores | Backtracks | Analyse |\n",
     "|---------|-----------------|------------|---------|\n",
     "| **Welsh-Powell** | 992 | 955 | Beaucoup de retours en arriere |\n",
     "| **MRV pur** | 37 | 0 | Resolution sans erreur |\n",
     "\n",
     "**Points cles** :\n",
     "\n",
-    "1. **Welsh-Powell est correct mais sous-optimal** : L'algorithme produit une coloration valide (solution Sudoku complete), mais au prix d'un nombre de backtracks tres eleve.\n",
-    "2. **Graphe regulier = heuristique inoperante** : Sur le graphe Sudoku, tous les sommets non colories ont un degre similaire (proche de 20). Le tri par degre decroissant n'apporte donc pas de guide discriminant, et le choix du premier sommet devient quasi-arbitraire.\n",
-    "3. **MRV exploite la propagation des contraintes** : Choisir le sommet avec le **moins** de couleurs disponibles contraint mecaniquement la recherche : les sommets \"faciles\" sont resolus tot, les difficiles apparaissent quand le contexte est deja mieux contraint.\n",
-    "4. **Generalisation** : Welsh-Powell reste pertinent sur des graphes a degres heterogenes (graphes de registres pour l'allocation, graphes sociaux, etc.). Pour le Sudoku et les problemes reguliers fortement contraints, MRV et ses variantes (MRV + LCV, dom/deg) sont plus adaptees.\n",
+    "1. **Welsh-Powell est correct mais sous-optimal** : L'algorithme produit une coloration valide (solution Sudoku complete), mais au prix d'un nombre de backtracks très eleve.\n",
+    "2. **Graphe regulier = heuristique inoperante** : Sur le graphe Sudoku, tous les sommets non colories ont un degré similaire (proche de 20). Le tri par degré decroissant n'apporte donc pas de guide discriminant, et le choix du premier sommet devient quasi-arbitraire.\n",
+    "3. **MRV exploite la propagation des contraintes** : Choisir le sommet avec le **moins** de couleurs disponibles contraint mecaniquement la recherche : les sommets \"faciles\" sont resolus tot, les difficiles apparaissent quand le contexte est déjà mieux contraint.\n",
+    "4. **Generalisation** : Welsh-Powell reste pertinent sur des graphes a degrés heterogenes (graphes de registres pour l'allocation, graphes sociaux, etc.). Pour le Sudoku et les problemes reguliers fortement contraints, MRV et ses variantes (MRV + LCV, dom/deg) sont plus adaptees.\n",
     "\n",
-    "> **Note technique** : Sur les puzzles plus difficiles (`Sudoku_hardest.txt`, `Sudoku_top95.txt`), Welsh-Powell peut partir en branches de recherche tres profondes. Un `sys.setrecursionlimit(50000)` est alors necessaire pour eviter un `RecursionError`, et sur Windows la taille de stack Python par defaut (1 MB) peut encore limiter ; les benchmarks sur puzzles difficiles sont donc laisses de cote dans ce notebook pour rester reproductible.\n"
+    "> **Note technique** : Sur les puzzles plus difficiles (`Sudoku_hardest.txt`, `Sudoku_top95.txt`), Welsh-Powell peut partir en branches de recherche très profondes. Un `sys.setrecursionlimit(50000)` est alors necessaire pour eviter un `RecursionError`, et sur Windows la taille de stack Python par defaut (1 MB) peut encore limiter ; les benchmarks sur puzzles difficiles sont donc laisses de cote dans ce notebook pour rester reproductible.\n"
    ]
   },
   {
@@ -1362,10 +1355,10 @@
    "id": "94f0165b",
    "metadata": {
     "papermill": {
-     "duration": 0.003552,
-     "end_time": "2026-06-02T17:32:59.337485+00:00",
+     "duration": 0.003534,
+     "end_time": "2026-07-17T05:24:55.895985",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.333933+00:00",
+     "start_time": "2026-07-17T05:24:55.892451",
      "status": "completed"
     },
     "tags": []
@@ -1373,9 +1366,9 @@
    "source": [
     "## Resume et perspectives\n",
     "\n",
-    "Ce notebook a montre comment modeliser le Sudoku comme un **probleme de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degre 20 par sommet). L'implementation a couvert trois strategies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degre decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degre identique.\n",
+    "Ce notebook a montre comment modeliser le Sudoku comme un **problème de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degré 20 par sommet). L'implementation a couvert trois strategies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degré decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degré identique.\n",
     "\n",
-    "Les benchmarks comparatifs ont permis de quantifier ces differences : MRV resout un puzzle facile en 37 noeuds et 0 backtrack, tandis que Welsh-Powell necessite 992 noeuds et 955 backtracks sur la meme instance. Cette experience illustre un principe fondamental de la resolution de problemes combinatoires : l'efficacite d'une heuristique depend fortement de la structure du graphe sous-jacent. Les heuristiques conques pour des graphes heterogenes (cartes geographiques, allocation de registres) perdent leur avantage sur les graphes reguliers comme celui du Sudoku.\n",
+    "Les benchmarks comparatifs ont permis de quantifier ces différences : MRV resout un puzzle facile en 37 noeuds et 0 backtrack, tandis que Welsh-Powell necessite 992 noeuds et 955 backtracks sur la même instance. Cette expérience illustre un principe fondamental de la resolution de problemes combinatoires : l'efficacite d'une heuristique depend fortement de la structure du graphe sous-jacent. Les heuristiques conques pour des graphes heterogenes (cartes geographiques, allocation de registres) perdent leur avantage sur les graphes reguliers comme celui du Sudoku.\n",
     "\n",
     "Le prochain notebook, **Sudoku-10-ORTools-Python**, passe a une approche industrielle de la programmation par contraintes avec OR-Tools CP-SAT, un solveur qui combine propagation de contraintes, recherche locale et programmation lineaire pour atteindre des performances nettement superieures sur les instances difficiles."
    ]
@@ -1385,10 +1378,10 @@
    "id": "022b15c7",
    "metadata": {
     "papermill": {
-     "duration": 0.003568,
-     "end_time": "2026-06-02T17:32:59.344956+00:00",
+     "duration": 0.003444,
+     "end_time": "2026-07-17T05:24:55.902930",
      "exception": false,
-     "start_time": "2026-06-02T17:32:59.341388+00:00",
+     "start_time": "2026-07-17T05:24:55.899486",
      "status": "completed"
     },
     "tags": []
@@ -1434,18 +1427,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.512842,
-   "end_time": "2026-06-02T17:32:59.803361+00:00",
+   "duration": 3.052864,
+   "end_time": "2026-07-17T05:24:56.155181",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Sudoku-9-GraphColoring-Python.ipynb",
-   "output_path": "Sudoku-9-GraphColoring-Python_exec.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/accents_reexec_43693/out.ipynb",
    "parameters": {},
-   "start_time": "2026-06-02T17:32:56.290519+00:00",
+   "start_time": "2026-07-17T05:24:53.102317",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Restores French accents in `Sudoku-9-GraphColoring-Python.ipynb` (my partition). The accent-stripping residual (#2876) is large repo-wide (46K hits / 876 notebooks); this is 1 notebook, R6-compliant (1 accent PR/lane/day).

Detector: `detect_accent_stripping.py` (canon, #6806) reported **82 hits → 0** on this notebook.

## What changed (1 notebook, 209 ins / 216 del)

82 accent restorations: `probleme`→`problème`, `theorie`→`théorie`, `degre`→`degré`, `methode`→`méthode`, `resultats`→`résultats`, `experience`→`expérience`, `etape`→`étape`, `chaine`→`chaîne`, `caracteres`→`caractères`, `deja`→`déjà`, `meme`→`même`, `tres`→`très`, etc. (22 unique dictionary pairs, all multi-syllable, **no short false-friend words**).

## Safety (no code broken)

- **No Python identifier touched.** Verified firsthand: none of the 22 flagged words are `def`/`class`/assignment/call targets in this notebook (the variable is English `degrees`). The restore uses Python `tokenize` and confines replacement to **COMMENT + STRING + FSTRING_MIDDLE** tokens — never `NAME` (identifiers/keywords).
- **Case-preserving**: `Creer`→`Créer` (not `créer`), `Degre`→`Degré`.
- **Markdown safety**: fenced code blocks (` ``` `) and inline code (`` ` ``) are protected from replacement.
- **ast.parse** OK on all code cells post-restore.
- **No C.1 violation**, no exercise stub removed (TODO/EXERCICE markers intact, 24 `def` intact, `welsh_powell`/`mrva` logic intact).

## C.2 / H.3 compliance

The restore touched string literals that produce outputs (e.g. `print(f"Degré min")`), so the notebook was **re-executed via papermill** (python3 kernel, 11/11 code cells, **0 errors**) so outputs match the accented source. LF line endings (CRLF from Windows papermill normalized).

## Validation (firsthand, G.1)

- `detect_accent_stripping.py` residual **82 → 0**.
- Papermill: 29 cells, 11/11 code executed, 0 errors, "Degré min" regenerated in outputs.
- Secret scan: 0. C.1: 0 NotImplementedError. H.3: all code cells have `execution_count`.

## Scope

`See #2876` (partial — 1 notebook of a large residual). C.3: only this notebook touched. Catalogue byte-identical.

🤖 po-2023 · c.566