### PR TITLE
fix(infer-18,#6927): Plotly CDN bar+marker -> SVG inline Bar (cp posterior)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
@@ -84,7 +84,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -94,10 +93,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -112,7 +108,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -124,8 +119,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -174,13 +167,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -405,7 +396,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Postérieur sur cp (masses > 0.1%, normalisees au pic) :\r\n"
+      "Posterieur sur cp (masses > 0.1%, normalisees au pic) :\r\n"
      ]
     },
     {
@@ -423,57 +414,46 @@
      ]
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Mode (MAP, vrai point de rupture estime) : t=50 (masse 0,9978)\r\n"
+     ]
+    },
+    {
      "data": {
-      "text/html": [
-       "<div id=\"pltfddf6ab86c9b4e3ab962da63ed7bca83\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltfddf6ab86c9b4e3ab962da63ed7bca83',[{\"name\":\"P(cp = t)\",\"x\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99],\"y\":{\"Dimension\":100,\"Sparsity\":{\"Storage\":0,\"IsDense\":true,\"IsSparse\":false,\"IsPiecewise\":false,\"IsApproximate\":false,\"IsExact\":true,\"Tolerance\":0,\"CountTolerance\":0},\"Point\":50,\"IsPointMass\":false},\"type\":\"bar\",\"marker\":{\"color\":\"#4C72B0\"}},{\"name\":\"vrai point de rupture\",\"x\":[50],\"y\":[0.9977545113649098],\"type\":\"scatter\",\"mode\":\"markers\",\"marker\":{\"color\":\"#C44E52\",\"size\":12,\"symbol\":\"triangle-up\"}}],{\"title\":{\"text\":\"Postérieur sur la localisation de la rupture cp\"},\"xaxis\":{\"title\":{\"text\":\"t (indice de rupture)\"}},\"yaxis\":{\"title\":{\"text\":\"P(cp = t)\"}},\"showlegend\":true,\"bargap\":0.05})</script>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='900' height='320' viewBox='0 0 900 320' font-family='sans-serif' font-size='12'><rect width='900' height='320' fill='white'/><text x='450' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Posterieur sur la localisation de la rupture cp (pic = mode/MAP)</text><line x1='52' y1='278' x2='884' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='884' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.269</text><line x1='52' y1='156' x2='884' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.539</text><line x1='52' y1='95' x2='884' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.808</text><line x1='52' y1='34' x2='884' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>1.078</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='884' y2='278' stroke='#888888' stroke-width='1'/><rect x='53.581' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='56.16' y='294' text-anchor='middle' fill='#333333'>0</text><rect x='61.901' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='64.48' y='294' text-anchor='middle' fill='#333333'>1</text><rect x='70.221' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='72.8' y='294' text-anchor='middle' fill='#333333'>2</text><rect x='78.541' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='81.12' y='294' text-anchor='middle' fill='#333333'>3</text><rect x='86.861' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='89.44' y='294' text-anchor='middle' fill='#333333'>4</text><rect x='95.181' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='97.76' y='294' text-anchor='middle' fill='#333333'>5</text><rect x='103.501' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='106.08' y='294' text-anchor='middle' fill='#333333'>6</text><rect x='111.821' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='114.4' y='294' text-anchor='middle' fill='#333333'>7</text><rect x='120.141' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='122.72' y='294' text-anchor='middle' fill='#333333'>8</text><rect x='128.461' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='131.04' y='294' text-anchor='middle' fill='#333333'>9</text><rect x='136.781' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='139.36' y='294' text-anchor='middle' fill='#333333'>10</text><rect x='145.101' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='147.68' y='294' text-anchor='middle' fill='#333333'>11</text><rect x='153.421' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='156' y='294' text-anchor='middle' fill='#333333'>12</text><rect x='161.741' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='164.32' y='294' text-anchor='middle' fill='#333333'>13</text><rect x='170.061' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='172.64' y='294' text-anchor='middle' fill='#333333'>14</text><rect x='178.381' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='180.96' y='294' text-anchor='middle' fill='#333333'>15</text><rect x='186.701' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='189.28' y='294' text-anchor='middle' fill='#333333'>16</text><rect x='195.021' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='197.6' y='294' text-anchor='middle' fill='#333333'>17</text><rect x='203.341' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='205.92' y='294' text-anchor='middle' fill='#333333'>18</text><rect x='211.661' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='214.24' y='294' text-anchor='middle' fill='#333333'>19</text><rect x='219.981' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='222.56' y='294' text-anchor='middle' fill='#333333'>20</text><rect x='228.301' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='230.88' y='294' text-anchor='middle' fill='#333333'>21</text><rect x='236.621' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='239.2' y='294' text-anchor='middle' fill='#333333'>22</text><rect x='244.941' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='247.52' y='294' text-anchor='middle' fill='#333333'>23</text><rect x='253.261' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='255.84' y='294' text-anchor='middle' fill='#333333'>24</text><rect x='261.581' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='264.16' y='294' text-anchor='middle' fill='#333333'>25</text><rect x='269.901' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='272.48' y='294' text-anchor='middle' fill='#333333'>26</text><rect x='278.221' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='280.8' y='294' text-anchor='middle' fill='#333333'>27</text><rect x='286.541' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='289.12' y='294' text-anchor='middle' fill='#333333'>28</text><rect x='294.861' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='297.44' y='294' text-anchor='middle' fill='#333333'>29</text><rect x='303.181' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='305.76' y='294' text-anchor='middle' fill='#333333'>30</text><rect x='311.501' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='314.08' y='294' text-anchor='middle' fill='#333333'>31</text><rect x='319.821' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='322.4' y='294' text-anchor='middle' fill='#333333'>32</text><rect x='328.141' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='330.72' y='294' text-anchor='middle' fill='#333333'>33</text><rect x='336.461' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='339.04' y='294' text-anchor='middle' fill='#333333'>34</text><rect x='344.781' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='347.36' y='294' text-anchor='middle' fill='#333333'>35</text><rect x='353.101' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='355.68' y='294' text-anchor='middle' fill='#333333'>36</text><rect x='361.421' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='364' y='294' text-anchor='middle' fill='#333333'>37</text><rect x='369.741' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='372.32' y='294' text-anchor='middle' fill='#333333'>38</text><rect x='378.061' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='380.64' y='294' text-anchor='middle' fill='#333333'>39</text><rect x='386.381' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='388.96' y='294' text-anchor='middle' fill='#333333'>40</text><rect x='394.701' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='397.28' y='294' text-anchor='middle' fill='#333333'>41</text><rect x='403.021' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='405.6' y='294' text-anchor='middle' fill='#333333'>42</text><rect x='411.341' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='413.92' y='294' text-anchor='middle' fill='#333333'>43</text><rect x='419.661' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='422.24' y='294' text-anchor='middle' fill='#333333'>44</text><rect x='427.981' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='430.56' y='294' text-anchor='middle' fill='#333333'>45</text><rect x='436.301' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='438.88' y='294' text-anchor='middle' fill='#333333'>46</text><rect x='444.621' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='447.2' y='294' text-anchor='middle' fill='#333333'>47</text><rect x='452.941' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='455.52' y='294' text-anchor='middle' fill='#333333'>48</text><rect x='461.261' y='277.998' width='5.158' height='0.002' fill='#4C72B0'/><text x='463.84' y='294' text-anchor='middle' fill='#333333'>49</text><rect x='469.581' y='52.074' width='5.158' height='225.926' fill='#4C72B0'/><text x='472.16' y='294' text-anchor='middle' fill='#333333'>50</text><rect x='477.901' y='277.494' width='5.158' height='0.506' fill='#4C72B0'/><text x='480.48' y='294' text-anchor='middle' fill='#333333'>51</text><rect x='486.221' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='488.8' y='294' text-anchor='middle' fill='#333333'>52</text><rect x='494.541' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='497.12' y='294' text-anchor='middle' fill='#333333'>53</text><rect x='502.861' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='505.44' y='294' text-anchor='middle' fill='#333333'>54</text><rect x='511.181' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='513.76' y='294' text-anchor='middle' fill='#333333'>55</text><rect x='519.501' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='522.08' y='294' text-anchor='middle' fill='#333333'>56</text><rect x='527.821' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='530.4' y='294' text-anchor='middle' fill='#333333'>57</text><rect x='536.141' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='538.72' y='294' text-anchor='middle' fill='#333333'>58</text><rect x='544.461' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='547.04' y='294' text-anchor='middle' fill='#333333'>59</text><rect x='552.781' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='555.36' y='294' text-anchor='middle' fill='#333333'>60</text><rect x='561.101' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='563.68' y='294' text-anchor='middle' fill='#333333'>61</text><rect x='569.421' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='572' y='294' text-anchor='middle' fill='#333333'>62</text><rect x='577.741' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='580.32' y='294' text-anchor='middle' fill='#333333'>63</text><rect x='586.061' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='588.64' y='294' text-anchor='middle' fill='#333333'>64</text><rect x='594.381' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='596.96' y='294' text-anchor='middle' fill='#333333'>65</text><rect x='602.701' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='605.28' y='294' text-anchor='middle' fill='#333333'>66</text><rect x='611.021' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='613.6' y='294' text-anchor='middle' fill='#333333'>67</text><rect x='619.341' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='621.92' y='294' text-anchor='middle' fill='#333333'>68</text><rect x='627.661' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='630.24' y='294' text-anchor='middle' fill='#333333'>69</text><rect x='635.981' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='638.56' y='294' text-anchor='middle' fill='#333333'>70</text><rect x='644.301' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='646.88' y='294' text-anchor='middle' fill='#333333'>71</text><rect x='652.621' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='655.2' y='294' text-anchor='middle' fill='#333333'>72</text><rect x='660.941' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='663.52' y='294' text-anchor='middle' fill='#333333'>73</text><rect x='669.261' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='671.84' y='294' text-anchor='middle' fill='#333333'>74</text><rect x='677.581' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='680.16' y='294' text-anchor='middle' fill='#333333'>75</text><rect x='685.901' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='688.48' y='294' text-anchor='middle' fill='#333333'>76</text><rect x='694.221' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='696.8' y='294' text-anchor='middle' fill='#333333'>77</text><rect x='702.541' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='705.12' y='294' text-anchor='middle' fill='#333333'>78</text><rect x='710.861' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='713.44' y='294' text-anchor='middle' fill='#333333'>79</text><rect x='719.181' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='721.76' y='294' text-anchor='middle' fill='#333333'>80</text><rect x='727.501' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='730.08' y='294' text-anchor='middle' fill='#333333'>81</text><rect x='735.821' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='738.4' y='294' text-anchor='middle' fill='#333333'>82</text><rect x='744.141' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='746.72' y='294' text-anchor='middle' fill='#333333'>83</text><rect x='752.461' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='755.04' y='294' text-anchor='middle' fill='#333333'>84</text><rect x='760.781' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='763.36' y='294' text-anchor='middle' fill='#333333'>85</text><rect x='769.101' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='771.68' y='294' text-anchor='middle' fill='#333333'>86</text><rect x='777.421' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='780' y='294' text-anchor='middle' fill='#333333'>87</text><rect x='785.741' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='788.32' y='294' text-anchor='middle' fill='#333333'>88</text><rect x='794.061' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='796.64' y='294' text-anchor='middle' fill='#333333'>89</text><rect x='802.381' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='804.96' y='294' text-anchor='middle' fill='#333333'>90</text><rect x='810.701' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='813.28' y='294' text-anchor='middle' fill='#333333'>91</text><rect x='819.021' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='821.6' y='294' text-anchor='middle' fill='#333333'>92</text><rect x='827.341' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='829.92' y='294' text-anchor='middle' fill='#333333'>93</text><rect x='835.661' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='838.24' y='294' text-anchor='middle' fill='#333333'>94</text><rect x='843.981' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='846.56' y='294' text-anchor='middle' fill='#333333'>95</text><rect x='852.301' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='854.88' y='294' text-anchor='middle' fill='#333333'>96</text><rect x='860.621' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='863.2' y='294' text-anchor='middle' fill='#333333'>97</text><rect x='868.941' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='871.52' y='294' text-anchor='middle' fill='#333333'>98</text><rect x='877.261' y='278' width='5.158' height='0' fill='#4C72B0'/><text x='879.84' y='294' text-anchor='middle' fill='#333333'>99</text></svg>"
      },
+     "execution_count": 4,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "// Outil de visualisation : rendu Plotly.js via le formatter HTML integre du kernel.\n",
-    "// (Zero `#r \"nuget:\"` sur une charting-lib : les charting libs pinent une vieille beta\n",
-    "//  de Microsoft.DotNet.Interactive et font timeout le restore, cluster-wide. Le formatter\n",
-    "//  ci-dessous emet du HTML Plotly brut, sans dependence. Cf #6599 / C548-L2.)\n",
-    "using Microsoft.DotNet.Interactive.Formatting;\n",
-    "using System.IO;\n",
-    "record PlotlyHtml(string Markup);\n",
-    "Formatter.Register(typeof(PlotlyHtml),\n",
-    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
-    "\n",
-    "// --- Visualisation : postérieur discret sur la localisation de la rupture ---\n",
+    "#load \"SvgChartHelper.cs\"\n",
+    "// --- Visualisation : posterieur discret sur la localisation de la rupture ---\n",
     "double pmax = 0.0;\n",
     "for (int i = 0; i < N; i++) pmax = Math.Max(pmax, cpPost[i]);\n",
     "\n",
     "// Masses > 0.1% (la masse utile), en valeurs relatives au pic.\n",
-    "Console.WriteLine(\"Postérieur sur cp (masses > 0.1%, normalisees au pic) :\");\n",
+    "Console.WriteLine(\"Posterieur sur cp (masses > 0.1%, normalisees au pic) :\");\n",
     "for (int i = 0; i < N; i++) {\n",
     "    if (cpPost[i] < 0.001) continue;\n",
     "    Console.WriteLine($\"  t={i,3}  {cpPost[i] / pmax,5:F2}  (masse {cpPost[i],7:F4})\");\n",
     "}\n",
     "\n",
-    "// Histogramme Plotly : le postérieur complet sur cp, avec le mode (argmax) marque.\n",
+    "// Mode (MAP) = argmax du posterieur = le \"vrai point de rupture\" estime ; c'est aussi le pic de l'histogramme.\n",
     "int mode = 0; double modeMass = 0.0;\n",
     "for (int i = 0; i < N; i++) if (cpPost[i] > modeMass) { modeMass = cpPost[i]; mode = i; }\n",
-    "var cpAxis = Enumerable.Range(0, N).Select(i => (double)i).ToArray();\n",
-    "var barTrace = System.Text.Json.JsonSerializer.Serialize(\n",
-    "    new Dictionary<string, object> { [\"name\"] = \"P(cp = t)\", [\"x\"] = cpAxis, [\"y\"] = cpPost,\n",
-    "                                     [\"type\"] = \"bar\", [\"marker\"] = new { color = \"#4C72B0\" } });\n",
-    "var vlineTrace = System.Text.Json.JsonSerializer.Serialize(\n",
-    "    new Dictionary<string, object> { [\"name\"] = \"vrai point de rupture\", [\"x\"] = new[] { (double)mode },\n",
-    "                                     [\"y\"] = new[] { modeMass }, [\"type\"] = \"scatter\", [\"mode\"] = \"markers\",\n",
-    "                                     [\"marker\"] = new { color = \"#C44E52\", size = 12, symbol = \"triangle-up\" } });\n",
-    "var layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Postérieur sur la localisation de la rupture cp\\\"},\" +\n",
-    "             \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"t (indice de rupture)\\\"}},\" +\n",
-    "             \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"P(cp = t)\\\"}},\" +\n",
-    "             \"\\\"showlegend\\\":true,\\\"bargap\\\":0.05}\";\n",
-    "var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
-    "var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
-    "             \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "             \"<script>Plotly.newPlot('\" + divId + \"',[\" + barTrace + \",\" + vlineTrace + \"],\" + layout + \")</script>\";\n",
-    "display(new PlotlyHtml(markup));\n"
+    "Console.WriteLine($\"\\nMode (MAP, vrai point de rupture estime) : t={mode} (masse {modeMass:F4})\");\n",
+    "\n",
+    "// Histogramme inline-SVG : posterieur complet sur cp (0..N-1). Le pic = mode (MAP).\n",
+    "SvgChartHelper.Bar(\n",
+    "    \"Posterieur sur la localisation de la rupture cp (pic = mode/MAP)\",\n",
+    "    Enumerable.Range(0, N).Select(i => i.ToString()).ToArray(),\n",
+    "    Enumerable.Range(0, N).Select(i => cpPost[i]).ToArray(),\n",
+    "    900, 320, \"#4C72B0\")"
    ]
   },
   {


### PR DESCRIPTION
## What

`Probas/Infer/Infer-18-Change-Point.ipynb` **cell[8]**: replace blank-in-static Plotly chart with inline static SVG via **`SvgChartHelper.Bar()`** (#6942 + #6958 MERGED).

Discrete posterior P(cp=t) over the change-point location t=0..99 (Infer.NET `Discrete cpPost`, N=100) — **100-bar histogram**. The mode (MAP = argmax of the posterior, the estimated true change-point) is the **peak bar**, and is also printed explicitly via `Console.WriteLine`.

## Why Bar() (not Overlay)

The original Plotly was a **bar histogram + 1 red triangle marker** at the mode. The helper `Bar()` covers the histogram; the mode is naturally the **tallest bar** (visually self-evident), and the explicit `Console.WriteLine($"Mode (MAP, vrai point de rupture estime) : t={mode} ...")` preserves the "vrai point de rupture" pedagogy the red triangle conveyed. No new primitive needed; the marker-on-bar combo collapses cleanly into Bar() + Console.

The distribution shape (posterior concentrated near the true cp) + the peak = mode is the pedagogical point that must render on GitHub.

## Family rotation (R6)

Continuing the **Probas/Infer** rotation (home turf, .NET). Same EPIC (#6927), same family as Infer-19 (#6983) — helper co-located → bare `#load` resolves natively.

## `#load` resolves natively here

Bare `#load "SvgChartHelper.cs"` resolves **without** an `ExecutePreprocessor` path override — the helper is **co-located** in `Probas/Infer/` (same folder as the notebook), so kernel CWD = notebook dir = helper dir (cf c.563 empirical `#load` truth: resolves relative to notebook dir).

## Surgical full-cell replace

cell[8] held the `record PlotlyHtml` + `Formatter.Register` setup block **and** the chart (only cell using `PlotlyHtml` — verified: 9 code cells, only cell[8] references it). So the entire cell source is replaced: setup dropped, computation **preserved byte-for-byte** (`pmax`, masses-table `Console.WriteLine`, `mode`/`modeMass` argmax), chart swaps to `Bar()`.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Real `.net-csharp` exec (H.4) | cell[8] exec_count=4, 0 errors (23-cell exec), SVG out_len=14865 |
| `detect_svg_decimal_commas.py` (#6959, merge-gate) | **0 defects** rc=0 (helper `F()`=InvariantCulture) |
| `detect_svg_empty_display.py` (#6971, no-vision blank-gate) | **0 defects** rc=0 (mechanically non-blank) |
| `check_plotly_static_risk.py` (#6931) | Infer-18 **no longer risky** |
| `cdn.plotly` in output | **False** |
| probeAddresses banner | absent |
| bar count | 101 `<rect>` (100 bars + axis/legend) |
| C.3 scope | **only cell[8]** changed |
| Catalog byte-identity (R1) | 0 diff; README untouched |

## Verdict: **SOTA-OK** (#3801 Prong-A)

## Notes

- **Visual QA**: GLM lane not vision-capable; routes to MiniMax (CoursIA-2) / ai-01. Deterministic gates (#6959 + #6971) green.
- **See #6927** (partial — repo-wide Plotly-CDN→SVG; GameTheory partition + Infer-18/19 now, residual risky: Infer-11[heatmap], Infer-12[grouped-bar], DecInfer-6/8, Search-11b, MGS-17, App-8, Sudoku-18, Z3-Python-06, ML-5[#r-nuget-hang]).

🤖 po-2025 (GLM no-vision lane)
