### PR TITLE
fix(infer-11,#6927): Plotly CDN-script -> 3x SvgChartHelper.Bar (topic distributions)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
@@ -3245,10 +3245,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-16T10:07:58.026892Z",
-     "iopub.status.busy": "2026-07-16T10:07:58.026611Z",
-     "iopub.status.idle": "2026-07-16T10:07:58.183879Z",
-     "shell.execute_reply": "2026-07-16T10:07:58.183733Z"
+     "iopub.execute_input": "2026-07-17T05:32:09.075369Z",
+     "iopub.status.busy": "2026-07-17T05:32:09.075219Z",
+     "iopub.status.idle": "2026-07-17T05:32:09.272532Z",
+     "shell.execute_reply": "2026-07-17T05:32:09.272179Z"
     },
     "papermill": {
      "duration": 0.167186,
@@ -3388,19 +3388,54 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"pltPhi\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltPhi',[{\"z\":[[0.3,0.3,0.3,0.02,0.02,0.02,0.02,0.01,0.01],[0.02,0.02,0.02,0.3,0.3,0.3,0.02,0.01,0.01],[0.02,0.01,0.01,0.02,0.02,0.02,0.3,0.3,0.3]],\"x\":[\"sport\",\"equipe\",\"match\",\"politique\",\"election\",\"vote\",\"musique\",\"concert\",\"artiste\"],\"y\":[\"Sport\",\"Politique\",\"Musique\"],\"type\":\"heatmap\",\"colorscale\":\"Viridis\",\"zmin\":0,\"zmax\":0.35,\"text\":[[0.3,0.3,0.3,0.02,0.02,0.02,0.02,0.01,0.01],[0.02,0.02,0.02,0.3,0.3,0.3,0.02,0.01,0.01],[0.02,0.01,0.01,0.02,0.02,0.02,0.3,0.3,0.3]],\"texttemplate\":\"%{text:.2f}\",\"hovertemplate\":\"P(%{x} | %{y}) = %{z:.2f}\\u003Cextra\\u003E\\u003C/extra\\u003E\"}],{\"title\":{\"text\":\"Matrice phi complete : P(mot | topic)\"},\"xaxis\":{\"title\":\"Vocabulaire\",\"side\":\"bottom\"},\"yaxis\":{\"title\":\"Topic\",\"autorange\":\"reversed\"},\"margin\":{\"t\":60,\"r\":20,\"b\":60,\"l\":90},\"height\":320});</script>"
+       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Sport) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
       ]
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Sport] pic sur les 3 premiers mots (0.30) puis plateau quasi-nul (0.01-0.02).\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Politique) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Politique] bloc-diagonal decale : mots 4-6 (indices 3-5) a 0.30.\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>P(mot | Topic=Musique) - 3 mots dominants a 0.30</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>0.081</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>0.162</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>0.243</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>0.324</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='62.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='79.333' y='294' text-anchor='middle' fill='#333333'>sport</text><rect x='117.053' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='134' y='294' text-anchor='middle' fill='#333333'>equipe</text><rect x='171.72' y='270.469' width='33.893' height='7.531' fill='#4C72B0'/><text x='188.667' y='294' text-anchor='middle' fill='#333333'>match</text><rect x='226.387' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='243.333' y='294' text-anchor='middle' fill='#333333'>politique</text><rect x='281.053' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='298' y='294' text-anchor='middle' fill='#333333'>election</text><rect x='335.72' y='262.938' width='33.893' height='15.062' fill='#4C72B0'/><text x='352.667' y='294' text-anchor='middle' fill='#333333'>vote</text><rect x='390.387' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='407.333' y='294' text-anchor='middle' fill='#333333'>musique</text><rect x='445.053' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='462' y='294' text-anchor='middle' fill='#333333'>concert</text><rect x='499.72' y='52.074' width='33.893' height='225.926' fill='#4C72B0'/><text x='516.667' y='294' text-anchor='middle' fill='#333333'>artiste</text></svg>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Musique] bloc-diagonal en queue : mots 7-9 (indices 6-8) a 0.30.\r\n"
+     ]
     }
    ],
    "source": [
-    "// Setup Plotly (technique C548-L2) — la clause using DOIT preceder tout autre element (CS1529).\n",
-    "using Microsoft.DotNet.Interactive.Formatting;\n",
-    "using System.IO;\n",
-    "using System.Text.Json;\n",
+    "#load \"SvgChartHelper.cs\"\n",
     "\n",
     "// Distribution phi (mots par topic) - simulee\n",
     "\n",
@@ -3435,43 +3470,33 @@
     "    Console.WriteLine();\n",
     "}\n",
     "\n",
-    "// --- Visualisation Plotly (EPIC #3801 Prong-A) : heatmap complete de la matrice phi ---\n",
-    "// Technique C548-L2 : Plotly.js via Formatter.Register (kernel builtin, aucun #r nuget).\n",
-    "// Le top-3 ASCII ci-dessus masque la structure bloc-diagonale (chaque topic \"possede\"\n",
-    "// 3 mots a 0.30) ; la heatmap de la matrice COMPLETE 3x9 la rend immediatement visible.\n",
+    "// --- Visualisation SVG inline : distributions mots par topic (matrice phi 3x9) ---\n",
+    "// La heatmap Plotly-CDN precedente rendait BLANC en static (GitHub sandbox les <script src=cdn.plot.ly>).\n",
+    "// Technique canonique : SVG inline via SvgChartHelper.cs (#6942 MERGED), zero-dependance NuGet.\n",
+    "// On deploie 3 Bar() distincts (un par topic) montrant la distribution P(mot | topic) sur le vocabulaire.\n",
+    "// Le pattern bloc-diagonal (3 mots a 0.30 par topic) devient visible : chaque Bar() met en evidence\n",
+    "// le top-3 mots du topic via une legende textuelle ci-dessous.\n",
     "\n",
-    "record PlotlyHtml(string Markup);\n",
-    "Formatter.Register(typeof(PlotlyHtml),\n",
-    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "var vocab = vocabulaire;\n",
+    "{\n",
+    "    // Topic Sport (index 0)\n",
+    "    var ySport = new double[vocabSize];\n",
+    "    for (int v = 0; v < vocabSize; v++) ySport[v] = phiSimule[0, v];\n",
+    "    display(SvgChartHelper.Bar(\"P(mot | Topic=Sport) - 3 mots dominants a 0.30\", vocab, ySport));\n",
+    "    Console.WriteLine(\"  [Sport] pic sur les 3 premiers mots (0.30) puis plateau quasi-nul (0.01-0.02).\");\n",
     "\n",
-    "// z = phiSimule en listes de listes (Plotly attend un tableau 2D JSON)\n",
-    "var z = new List<List<double>>();\n",
-    "for (int k = 0; k < numTopics; k++) {\n",
-    "    var row = new List<double>();\n",
-    "    for (int v = 0; v < vocabSize; v++) row.Add(phiSimule[k, v]);\n",
-    "    z.Add(row);\n",
-    "}\n",
-    "string trace = JsonSerializer.Serialize(new Dictionary<string, object> {\n",
-    "    [\"z\"] = z,\n",
-    "    [\"x\"] = vocabulaire,\n",
-    "    [\"y\"] = topicNames,\n",
-    "    [\"type\"] = \"heatmap\",\n",
-    "    [\"colorscale\"] = \"Viridis\",\n",
-    "    [\"zmin\"] = 0.0, [\"zmax\"] = 0.35,\n",
-    "    [\"text\"] = z, [\"texttemplate\"] = \"%{text:.2f}\",\n",
-    "    [\"hovertemplate\"] = \"P(%{x} | %{y}) = %{z:.2f}<extra></extra>\",\n",
-    "});\n",
-    "string layout = JsonSerializer.Serialize(new Dictionary<string, object> {\n",
-    "    [\"title\"] = new Dictionary<string, string> { [\"text\"] = \"Matrice phi complete : P(mot | topic)\" },\n",
-    "    [\"xaxis\"] = new Dictionary<string, object> { [\"title\"] = \"Vocabulaire\", [\"side\"] = \"bottom\" },\n",
-    "    [\"yaxis\"] = new Dictionary<string, object> { [\"title\"] = \"Topic\", [\"autorange\"] = \"reversed\" },\n",
-    "    [\"margin\"] = new Dictionary<string, int> { [\"t\"] = 60, [\"r\"] = 20, [\"b\"] = 60, [\"l\"] = 90 },\n",
-    "    [\"height\"] = 320,\n",
-    "});\n",
-    "string markup = \"<div id=\\\"pltPhi\\\"></div>\" +\n",
-    "    \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "    $\"<script>Plotly.newPlot('pltPhi',[{trace}],{layout});</script>\";\n",
-    "new PlotlyHtml(markup)"
+    "    // Topic Politique (index 1)\n",
+    "    var yPolitique = new double[vocabSize];\n",
+    "    for (int v = 0; v < vocabSize; v++) yPolitique[v] = phiSimule[1, v];\n",
+    "    display(SvgChartHelper.Bar(\"P(mot | Topic=Politique) - 3 mots dominants a 0.30\", vocab, yPolitique));\n",
+    "    Console.WriteLine(\"  [Politique] bloc-diagonal decale : mots 4-6 (indices 3-5) a 0.30.\");\n",
+    "\n",
+    "    // Topic Musique (index 2)\n",
+    "    var yMusique = new double[vocabSize];\n",
+    "    for (int v = 0; v < vocabSize; v++) yMusique[v] = phiSimule[2, v];\n",
+    "    display(SvgChartHelper.Bar(\"P(mot | Topic=Musique) - 3 mots dominants a 0.30\", vocab, yMusique));\n",
+    "    Console.WriteLine(\"  [Musique] bloc-diagonal en queue : mots 7-9 (indices 6-8) a 0.30.\");\n",
+    "}\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Substance pivot for **#6927** Plotly-CDN → SVG migration (Infer series). Infer-11 cell[32] (id=`0e5bd4a3`) visualized a 3-topic × 9-word distribution matrix (phiSimule) using Plotly-CDN heatmap. Plotly-CDN renders **BLANC on static GitHub sandbox** (`<script src=cdn.plot.ly>` blocked). Replaces Plotly heatmap with 3 inline `SvgChartHelper.Bar(...)` calls (canon C548-L2, helper #6942 MERGED, Overlay API #6958 MERGED but reserved for numeric shared X).

Per investigation ai-01 issuecomment-4997257737, scope correct = **Infer-11/12/18** (Infer-17 MERGED via #6946, Infer-19 OPEN via #6983 po-2024). c.546 = Infer-11 atomic sequentiel strict per R6 anti-monotonie L540-L1 ★.

## Root cause

The Plotly-CDN call `new PlotlyHtml(markup)` (last expression) registers a `record PlotlyHtml` type with `Formatter.Register(typeof(PlotlyHtml), ..., "text/html")` and injects `<script src="https://cdn.plot.ly/plotly-2.x.x.min.js">` into the markup. GitHub's static HTML rendering sandbox **strips `<script>` tags** from `<text/html>` MIME blocks → JS never executes → no heatmap drawn → BLANC output on `https://github.com/.../blob/main/Infer-11-Topic-Models.ipynb`.

Detectors (`check_plotly_static_risk.py`) **DO catch** this pre-commit (source-level `cdn.plot.ly` keyword + `Formatter.Register(typeof(PlotlyHtml)...)` pattern), but the fix must substitute the visualization entirely, not strip the script tag (which would leave broken Plotly markup).

## Fix

1. **Stripped `using Microsoft.DotNet.Interactive.Formatting; using System.IO; using System.Text.Json; record PlotlyHtml(...); Formatter.Register(typeof(PlotlyHtml)...);` block** — SvgChartHelper registers its own Formatter type registration via static ctor, so the PlotlyHtml machinery is no longer needed.
2. **Prepended bare `#load "SvgChartHelper.cs"`** at top of cell (canon L542b-L1 ★ + L543-L1 ★ for kernel-cwd siblings in Infer notebooks — same pattern as DecInfer-7 cell 2's `FactorGraphHelper.cs`).
3. **Replaced the entire Plotly heatmap block** (z list construction + trace/layout JSON-serialization + markup assembly + last expression `new PlotlyHtml(markup)`) with **3 separate `SvgChartHelper.Bar(...)` calls**, one per topic (Sport, Politique, Musique). Each chart shows the distribution P(mot | topic) across the 9 vocabulary words, with the 3 dominant words at 0.30 visible as the highest bars.
4. **Preserved the LDA model logic INTACT** (phiSimule matrix definition, topicNames, top-3 Console.WriteLine loop). The pedagogical message (block-diagonal structure of phi, 3 topics each owning 3 words) is preserved by the 3 separate charts + Console.WriteLine legends.

**Why 3× Bar() and not Overlay()** : SvgChartHelper.Overlay requires a **shared numeric X axis**. The categorical/temporal X (9 vocabulary words as string labels) is best visualized as N separate Bar() charts with legends explaining each topic's distribution. This avoids misusing Overlay() with a categorical X axis that doesn't fit its contract.

## Verification (3 SVG charts in 1 target cell)

| Item | Value |
|------|-------|
| Cell | 32 (id=`0e5bd4a3`) |
| `execution_count` | 11 |
| `n_out` | 23 |
| SVG output 1 (Sport) | `text/html`, 2525 chars, contains `<svg xmlns='http://www.w3.org/2000/svg' ...` |
| SVG output 2 (Politique) | `text/html`, 2529 chars, contains `<svg xmlns='http://www.w3.org/2000/svg' ...` |
| SVG output 3 (Musique) | `text/html`, 2527 chars, contains `<svg xmlns='http://www.w3.org/2000/svg' ...` |
| stdout legends | 3× "  [Topic] ... " explanations |
| Code cells executed | 17/17 |
| Errors | 0 |
| `validate_pr_notebooks.py` | 17/17 PASS |
| `detect_svg_decimal_commas.py` | 0 defects |
| `detect_svg_empty_display.py` | 0 defects |
| `check_plotly_static_risk.py` | Infer-11 clean (exit la liste 15 risky notebooks) |

**Plotly references remaining: 1** in cell[32] — historical comment documenting the migration rationale (NOT active code): "// La heatmap Plotly-CDN precedente rendait BLANC en static (GitHub sandbox les <script src=cdn.plot.ly>)."

## Files changed

- `MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb` — +73/-48 lines (cell[32] rewritten multi-line, SvgChartHelper.Bar substituted for Plotly heatmap block)

## See also

- **#6927** — EPIC Plotly-CDN → SVG pivot
- **#6942** — `SvgChartHelper.cs` (MERGED, canon for axis-categorical SVG charts)
- **#6958** — `SvgChartHelper.Overlay` (MERGED, for multi-series on numeric shared X)
- **#6946** — Infer-17 precedent (MERGED, cell[8], same fix pattern)
- **#6963** — DecInfer-6 precedent (OPEN MERGEABLE, 5 SVG charts across 4 cells)
- **#6967** — DecInfer-7 precedent (MERGED, cell[32], 2× SvgChartHelper.Bar)
- **#6977** — DecInfer-8 precedent (OPEN MERGEABLE, 3× SvgChartHelper.Bar)
- **#6983** — Infer-19 parallel pivot (OPEN, po-2024, claimed Infer-19 same morning)
- **L542b-L1 ★** — bare `#load` canon for kernel-cwd siblings
- **L543-L1 ★** — bare path reuse pattern
- **L544-L1 ★★★** — single-line source = silent failure for .NET Interactive kernel
- C548-L2 — SVG inline zero-dependance NuGet canon
