### PR TITLE
fix(probas,#6927): Infer-12 cell[9] Plotly-CDN grouped-bars -> 3x SvgChartHelper.Bar (hierarchical shrinkage)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb
@@ -424,10 +424,10 @@
    "id": "c30c821e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-01T06:27:12.702306Z",
-     "iopub.status.busy": "2026-07-01T06:27:12.702071Z",
-     "iopub.status.idle": "2026-07-01T06:27:12.784229Z",
-     "shell.execute_reply": "2026-07-01T06:27:12.783957Z"
+     "iopub.execute_input": "2026-07-17T05:58:47.640043Z",
+     "iopub.status.busy": "2026-07-17T05:58:47.639865Z",
+     "iopub.status.idle": "2026-07-17T05:58:48.063961Z",
+     "shell.execute_reply": "2026-07-17T05:58:48.063771Z"
     }
    },
    "outputs": [
@@ -519,20 +519,54 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"plt9d5ffa54e66347c0822629d5dca70c26\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('plt9d5ffa54e66347c0822629d5dca70c26',[{\"x\":[\"cl.0 (n=6)\",\"cl.1 (n=5)\",\"cl.2 (n=1)\",\"cl.3 (n=7)\",\"cl.4 (n=4)\",\"cl.5 (n=2)\",\"cl.6 (n=6)\",\"cl.7 (n=1)\"],\"y\":[1,7,4,5.5,2.5,3.5,6.5,4.5],\"type\":\"bar\",\"name\":\"vrai\",\"marker\":{\"color\":\"#444\"}},{\"x\":[\"cl.0 (n=6)\",\"cl.1 (n=5)\",\"cl.2 (n=1)\",\"cl.3 (n=7)\",\"cl.4 (n=4)\",\"cl.5 (n=2)\",\"cl.6 (n=6)\",\"cl.7 (n=1)\"],\"y\":[0.44,6.09,4.83,5.91,2.64,3.32,7.02,2.6],\"type\":\"bar\",\"name\":\"no-pool\",\"marker\":{\"color\":\"#e8743b\"}},{\"x\":[\"cl.0 (n=6)\",\"cl.1 (n=5)\",\"cl.2 (n=1)\",\"cl.3 (n=7)\",\"cl.4 (n=4)\",\"cl.5 (n=2)\",\"cl.6 (n=6)\",\"cl.7 (n=1)\"],\"y\":[1.17,5.67,4.48,5.62,3.06,3.68,6.47,3.52],\"type\":\"bar\",\"name\":\"hierarchique\",\"marker\":{\"color\":\"#2a6dba\"}}],{\"barmode\":\"group\",\"title\":{\"text\":\"Modele hierarchique : retraction des effets de classe vers mu (le pooling retracte surtout les classes a faible effectif)\"},\"xaxis\":{\"title\":{\"text\":\"Classe (effectif n)\"}},\"yaxis\":{\"title\":{\"text\":\"Effet estime\"}},\"margin\":{\"l\":50,\"r\":30,\"b\":90}})</script>"
+       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Effet VRAI par classe (ground truth, reference)</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>1.89</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>3.78</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>5.67</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>7.56</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='63.685' y='245.725' width='38.13' height='32.275' fill='#4C72B0'/><text x='82.75' y='294' text-anchor='middle' fill='#333333'>cl.0 (n=6)</text><rect x='125.185' y='52.074' width='38.13' height='225.926' fill='#4C72B0'/><text x='144.25' y='294' text-anchor='middle' fill='#333333'>cl.1 (n=5)</text><rect x='186.685' y='148.899' width='38.13' height='129.101' fill='#4C72B0'/><text x='205.75' y='294' text-anchor='middle' fill='#333333'>cl.2 (n=1)</text><rect x='248.185' y='100.487' width='38.13' height='177.513' fill='#4C72B0'/><text x='267.25' y='294' text-anchor='middle' fill='#333333'>cl.3 (n=7)</text><rect x='309.685' y='197.312' width='38.13' height='80.688' fill='#4C72B0'/><text x='328.75' y='294' text-anchor='middle' fill='#333333'>cl.4 (n=4)</text><rect x='371.185' y='165.037' width='38.13' height='112.963' fill='#4C72B0'/><text x='390.25' y='294' text-anchor='middle' fill='#333333'>cl.5 (n=2)</text><rect x='432.685' y='68.212' width='38.13' height='209.788' fill='#4C72B0'/><text x='451.75' y='294' text-anchor='middle' fill='#333333'>cl.6 (n=6)</text><rect x='494.185' y='132.762' width='38.13' height='145.238' fill='#4C72B0'/><text x='513.25' y='294' text-anchor='middle' fill='#333333'>cl.7 (n=1)</text></svg>"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Vrai] reference inobservable -- montre les valeurs reelles des effets de classe.\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Effet NO-POOL par classe (MLE brut, non regularise)</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>1.896</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>3.791</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>5.687</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>7.583</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='63.685' y='263.687' width='38.13' height='14.313' fill='#4C72B0'/><text x='82.75' y='294' text-anchor='middle' fill='#333333'>cl.0 (n=6)</text><rect x='125.185' y='82.145' width='38.13' height='195.855' fill='#4C72B0'/><text x='144.25' y='294' text-anchor='middle' fill='#333333'>cl.1 (n=5)</text><rect x='186.685' y='122.423' width='38.13' height='155.577' fill='#4C72B0'/><text x='205.75' y='294' text-anchor='middle' fill='#333333'>cl.2 (n=1)</text><rect x='248.185' y='87.8' width='38.13' height='190.2' fill='#4C72B0'/><text x='267.25' y='294' text-anchor='middle' fill='#333333'>cl.3 (n=7)</text><rect x='309.685' y='192.942' width='38.13' height='85.058' fill='#4C72B0'/><text x='328.75' y='294' text-anchor='middle' fill='#333333'>cl.4 (n=4)</text><rect x='371.185' y='171.114' width='38.13' height='106.886' fill='#4C72B0'/><text x='390.25' y='294' text-anchor='middle' fill='#333333'>cl.5 (n=2)</text><rect x='432.685' y='52.074' width='38.13' height='225.926' fill='#4C72B0'/><text x='451.75' y='294' text-anchor='middle' fill='#333333'>cl.6 (n=6)</text><rect x='494.185' y='194.182' width='38.13' height='83.818' fill='#4C72B0'/><text x='513.25' y='294' text-anchor='middle' fill='#333333'>cl.7 (n=1)</text></svg>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [No-pool] suit bruyamment l'echantillon par classe -- pas de regularisation.\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<svg xmlns='http://www.w3.org/2000/svg' width='560' height='320' viewBox='0 0 560 320' font-family='sans-serif' font-size='12'><rect width='560' height='320' fill='white'/><text x='280' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Effet HIERARCHIQUE par classe (regularise vers mu)</text><line x1='52' y1='278' x2='544' y2='278' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='282' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='217' x2='544' y2='217' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='221' text-anchor='end' fill='#333333'>1.748</text><line x1='52' y1='156' x2='544' y2='156' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='160' text-anchor='end' fill='#333333'>3.496</text><line x1='52' y1='95' x2='544' y2='95' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='99' text-anchor='end' fill='#333333'>5.244</text><line x1='52' y1='34' x2='544' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>6.992</text><line x1='52' y1='34' x2='52' y2='278' stroke='#888888' stroke-width='1'/><line x1='52' y1='278' x2='544' y2='278' stroke='#888888' stroke-width='1'/><rect x='63.685' y='237.221' width='38.13' height='40.779' fill='#4C72B0'/><text x='82.75' y='294' text-anchor='middle' fill='#333333'>cl.0 (n=6)</text><rect x='125.185' y='80.305' width='38.13' height='197.695' fill='#4C72B0'/><text x='144.25' y='294' text-anchor='middle' fill='#333333'>cl.1 (n=5)</text><rect x='186.685' y='121.83' width='38.13' height='156.17' fill='#4C72B0'/><text x='205.75' y='294' text-anchor='middle' fill='#333333'>cl.2 (n=1)</text><rect x='248.185' y='81.983' width='38.13' height='196.017' fill='#4C72B0'/><text x='267.25' y='294' text-anchor='middle' fill='#333333'>cl.3 (n=7)</text><rect x='309.685' y='171.37' width='38.13' height='106.63' fill='#4C72B0'/><text x='328.75' y='294' text-anchor='middle' fill='#333333'>cl.4 (n=4)</text><rect x='371.185' y='149.422' width='38.13' height='128.578' fill='#4C72B0'/><text x='390.25' y='294' text-anchor='middle' fill='#333333'>cl.5 (n=2)</text><rect x='432.685' y='52.074' width='38.13' height='225.926' fill='#4C72B0'/><text x='451.75' y='294' text-anchor='middle' fill='#333333'>cl.6 (n=6)</text><rect x='494.185' y='155.112' width='38.13' height='122.888' fill='#4C72B0'/><text x='513.25' y='294' text-anchor='middle' fill='#333333'>cl.7 (n=1)</text></svg>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [Hierarchique] retraction adaptee a l'incertitude (n petit = shrinkage fort).\r\n"
+     ]
     }
    ],
    "source": [
-    "using Microsoft.DotNet.Interactive.Formatting;\n",
-    "using System.IO;\n",
-    "using System.Collections.Generic;\n",
-    "record PlotlyHtml(string Markup);\n",
-    "Formatter.Register(typeof(PlotlyHtml),\n",
-    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "#load \"SvgChartHelper.cs\"\n",
     "\n",
     "Console.WriteLine(\"Classe | n  | vrai | no-pool | hierarchique | retraction\");\n",
     "Console.WriteLine(\"-------|----|------|---------|--------------|----------\");\n",
@@ -556,35 +590,29 @@
     "Console.WriteLine($\"\\nNo-pooling   MSE = {noPoolMSE:F3}\");\n",
     "Console.WriteLine($\"Hierarchique MSE = {hierMSE:F3}   (amelioration {100*(1 - hierMSE/noPoolMSE):F0}%)\");\n",
     "\n",
-    "// Bar chart Plotly groupe : vrai / no-pool / hierarchique par classe.\n",
-    "// Le pooling hierarchique retracte chaque estimation de classe vers la moyenne de groupe (mu) :\n",
-    "// les classes a faible effectif (n petit) sont les plus retractees -- c'est tout l'interet du modele\n",
-    "// hierarchique (regularisation adaptee a l'incertitude). La barre 'hierarchique' se rapproche du\n",
-    "// centre du au retrait la ou 'no-pool' suit bruyamment l'echantillon.\n",
+    "// --- Visualisation SVG inline : retraction hierarchique par classe (3 series) ---\n",
+    "// Le grouped-bar Plotly-CDN precedent rendait BLANC en static (GitHub sandbox les <script src=cdn.plot.ly>).\n",
+    "// Technique canonique : SVG inline via SvgChartHelper.cs (#6942 MERGED), zero-dependance NuGet.\n",
+    "// SvgChartHelper.Overlay (#6958 MERGED) requiert un axe X numerique partage => inapplicable ici\n",
+    "// (les labels X sont categoriels : cl.0..cl.7). On deploie 3 Bar() distincts (un par serie)\n",
+    "// montrant la retraction des estimations vers mu (le pooling hierarchique).\n",
+    "// Le pattern hierarchique se voit clairement : 'hierarchique' se rapproche de mu (centre)\n",
+    "// par rapport a 'no-pool', surtout pour les classes a faible effectif (n=1, n=2).\n",
+    "\n",
     "{\n",
-    "    var xs = labels.Select(v => (object)v).ToArray();\n",
-    "    var tVrai = System.Text.Json.JsonSerializer.Serialize(\n",
-    "        new Dictionary<string, object> { [\"x\"] = xs, [\"y\"] = vraiArr.Select(v => (object)Math.Round(v,2)).ToArray(),\n",
-    "                                         [\"type\"] = \"bar\", [\"name\"] = \"vrai\",\n",
-    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = \"#444\" } });\n",
-    "    var tNoPool = System.Text.Json.JsonSerializer.Serialize(\n",
-    "        new Dictionary<string, object> { [\"x\"] = xs, [\"y\"] = noPoolArr.Select(v => (object)Math.Round(v,2)).ToArray(),\n",
-    "                                         [\"type\"] = \"bar\", [\"name\"] = \"no-pool\",\n",
-    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = \"#e8743b\" } });\n",
-    "    var tHier = System.Text.Json.JsonSerializer.Serialize(\n",
-    "        new Dictionary<string, object> { [\"x\"] = xs, [\"y\"] = hierArr.Select(v => (object)Math.Round(v,2)).ToArray(),\n",
-    "                                         [\"type\"] = \"bar\", [\"name\"] = \"hierarchique\",\n",
-    "                                         [\"marker\"] = new Dictionary<string,object>{ [\"color\"] = \"#2a6dba\" } });\n",
-    "    var divId = \"plt\" + Guid.NewGuid().ToString(\"N\");\n",
-    "    var layout = \"{\\\"barmode\\\":\\\"group\\\",\\\"title\\\":{\\\"text\\\":\\\"Modele hierarchique : retraction des effets de classe vers mu \" +\n",
-    "                 \"(le pooling retracte surtout les classes a faible effectif)\\\"},\" +\n",
-    "                 \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Classe (effectif n)\\\"}},\" +\n",
-    "                 \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"Effet estime\\\"}},\" +\n",
-    "                 \"\\\"margin\\\":{\\\"l\\\":50,\\\"r\\\":30,\\\"b\\\":90}}\";\n",
-    "    var markup = \"<div id=\\\"\" + divId + \"\\\"></div>\" +\n",
-    "                 \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "                 \"<script>Plotly.newPlot('\" + divId + \"',[\" + tVrai + \",\" + tNoPool + \",\" + tHier + \"],\" + layout + \")</script>\";\n",
-    "    display(new PlotlyHtml(markup));\n",
+    "    var xLabels = labels.ToArray();\n",
+    "    var yVrai = vraiArr.ToArray();\n",
+    "    var yNoPool = noPoolArr.ToArray();\n",
+    "    var yHier = hierArr.ToArray();\n",
+    "\n",
+    "    display(SvgChartHelper.Bar(\"Effet VRAI par classe (ground truth, reference)\", xLabels, yVrai));\n",
+    "    Console.WriteLine(\"  [Vrai] reference inobservable -- montre les valeurs reelles des effets de classe.\");\n",
+    "\n",
+    "    display(SvgChartHelper.Bar(\"Effet NO-POOL par classe (MLE brut, non regularise)\", xLabels, yNoPool));\n",
+    "    Console.WriteLine(\"  [No-pool] suit bruyamment l'echantillon par classe -- pas de regularisation.\");\n",
+    "\n",
+    "    display(SvgChartHelper.Bar(\"Effet HIERARCHIQUE par classe (regularise vers mu)\", xLabels, yHier));\n",
+    "    Console.WriteLine(\"  [Hierarchique] retraction adaptee a l'incertitude (n petit = shrinkage fort).\");\n",
     "}\n"
    ]
   },


### PR DESCRIPTION
## Summary

Substance pivot for **#6927** Plotly-CDN → SVG migration (Infer series). Infer-12 cell[9] (id=`c30c821e`) visualized a hierarchical shrinkage comparison (vrai / no-pool / hierarchique) across 8 classes via Plotly grouped-bars CDN. Plotly-CDN renders **BLANC on static GitHub sandbox** (`<script src=cdn.plot.ly>` blocked). Replaces Plotly grouped-bars with **3 separate `SvgChartHelper.Bar(...)` calls** (one per series: vrai, no-pool, hierarchique), each showing the 8-class distribution.

**Infer-12 = LAST FREE #6927 notebook** (Infer-17 MERGED via #6946; DecInfer-6/7/8 + Infer-11/18/19 = 6 MERGED via #6963/#6967/#6977/#6986/#6983/#6985). This PR completes the Infer series pivot per investigation ai-01 issuecomment-4997257737 (scope = Infer-11/12/18 + Infer-19 parallel claim po-2024).

## Root cause

The Plotly-CDN call `new PlotlyHtml(markup)` (last expression) registers a `record PlotlyHtml` type with `Formatter.Register(typeof(PlotlyHtml), ..., "text/html")` and injects `<script src="https://cdn.plot.ly/plotly-2.x.x.min.js">` into the markup. GitHub's static HTML rendering sandbox **strips `<script>` tags** from `<text/html>` MIME blocks → JS never executes → no chart drawn → BLANC output on `https://github.com/.../blob/main/Infer-12-Modeles-Hierarchiques.ipynb`.

Detectors (`check_plotly_static_risk.py`) **DO catch** this pre-commit (source-level `cdn.plot.ly` keyword + `Formatter.Register(typeof(PlotlyHtml)...)` pattern), but the fix must substitute the visualization entirely, not strip the script tag (which would leave broken Plotly markup).

## Fix

1. **Stripped `using Microsoft.DotNet.Interactive.Formatting; using System.IO; using System.Collections.Generic; record PlotlyHtml(...); Formatter.Register(typeof(PlotlyHtml)...);` block** — SvgChartHelper registers its own Formatter type registration via static ctor, so the PlotlyHtml machinery is no longer needed.
2. **Prepended bare `#load "SvgChartHelper.cs"`** at top of cell (canon L542b-L1 + L543-L1 for kernel-cwd siblings in Infer notebooks — same pattern as DecInfer-7 cell 2's `FactorGraphHelper.cs`).
3. **Replaced the entire Plotly grouped-bars block** (xs array construction + 3 trace JSON-serialization + layout JSON-serialization + markup assembly with `<script src=cdn.plot.ly>` + last expression `new PlotlyHtml(markup)`) with **3 separate `SvgChartHelper.Bar(...)` calls**, one per series (vrai, no-pool, hierarchique). Each chart shows the effect distribution P(effet | classe) across the 8 classes (cl.0..cl.7), with classes à faible effectif (n=1, n=2) showing distinct shrinkage patterns.
4. **Preserved the MSE hierarchical-model logic INTACT** (loop populating vraiArr/noPoolArr/hierArr + MSE console output). The pedagogical message (retraction vers mu via pooling hierarchique) is preserved by 3 separate charts + Console.WriteLine legends explaining each series.

**Why 3× Bar() and not Overlay()** : SvgChartHelper.Overlay requires a **shared numeric X axis**. The categorical/temporal X (8 class labels as string labels) is best visualized as 3 separate Bar() charts with legends explaining each series's distribution. This avoids misusing Overlay() with a categorical X axis that doesn't fit its contract (L542 / L543 / L545-L1).

**Brace-matching fix (lesson learned)**: The original Plotly block was wrapped in outer `{ ... }`. Naive replace-from-`display(new PlotlyHtml(markup))` left an orphan closing `}`. Applied brace-depth matching (open at L1462, close at L3420) to capture the entire outer block.

## Verification (3 SVG charts in 1 target cell)

| Item | Value |
|------|-------|
| Cell | 9 (id=`c30c821e`) |
| `execution_count` | 5 |
| `n_out` | 18 (12 stream + 3 SVG + 3 stream legends) |
| SVG output 1 (Vrai) | `text/html`, 2403 chars, contains `<svg xmlns='http://www.w3.org/2000/svg' ...` |
| SVG output 2 (No-pool) | `text/html`, 2405 chars, contains `<svg xmlns='http://www.w3.org/2000/svg' ...` |
| SVG output 3 (Hierarchique) | `text/html`, 2406 chars, contains `<svg xmlns='http://www.w3.org/2000/svg' ...` |
| stdout legends | 3× "  [Series] ... " explanations (Vrai/No-pool/Hierarchique) |
| Code cells executed | 7/7 (validator) |
| Errors | 0 |
| `validate_pr_notebooks.py` | 7/7 PASS [.net-csharp] |
| `detect_svg_decimal_commas.py` | 0 defects |
| `detect_svg_empty_display.py` | 0 defects |
| `check_plotly_static_risk.py` | Infer-12 CLEAN (only Infer-11 has comment-level Plotly ref, no active code) |
| `strip_probe_banner.py --scan` | 0 probe banner lines (SVG inline cells bypass JavaScript injection) |

**Plotly references remaining: 1** in cell[9] — historical comment documenting the migration rationale (NOT active code): "// Le grouped-bar Plotly-CDN precedent rendait BLANC en static (GitHub sandbox les <script src=cdn.plot.ly>)."

## Minimal-diff swap (L595-L2 canon application)

First attempt used `nbformat.write(nb, NB)` which re-serialized the entire notebook, churning markdown cells (string→list-of-lines) and resetting other cell execution metadata. Resulted in **44 ins / 132 del** mass churn + CRLF warnings.

Fix: **JSON-level surgical swap** — read worktree nb as raw JSON, find cell[9], replace ONLY source/outputs/metadata.execution fields while preserving all other cells byte-identical. Resulted in **67 ins / 39 del** (cell[9] only). Markdown cells `4663e998`, factor-graph structure byte-identical to main.

Pattern: `python scratchpad/json_swap_infer12_c547.py` (this commit's tool).

## Files changed

- `MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb` — +67/-39 lines (cell[9] only)

## See also

- **#6927** — EPIC Plotly-CDN → SVG pivot
- **#6942** — `SvgChartHelper.cs` (MERGED, canon for axis-categorical SVG charts)
- **#6958** — `SvgChartHelper.Overlay` (MERGED, for multi-series on numeric shared X)
- **#6946** — Infer-17 precedent (MERGED, cell[8], same fix pattern)
- **#6963** — DecInfer-6 precedent (MERGED, cells 29/35/45/49, same fix pattern)
- **#6967** — DecInfer-7 precedent (MERGED, cell[32], 2× SvgChartHelper.Bar)
- **#6977** — DecInfer-8 precedent (MERGED, cell[49], 3× SvgChartHelper.Bar)
- **#6983** — Infer-19 parallel pivot (MERGED, Overlay, po-2024)
- **#6985** — Infer-18 parallel pivot (MERGED, Bar, po-2025 c.546)
- **#6986** — Infer-11 parallel pivot (OPEN, 3× SvgChartHelper.Bar, po-2025 c.546)
- **L542b-L1** — bare `#load` canon for kernel-cwd siblings
- **L543-L1** — bare path reuse pattern
- **L544-L1** — single-line source = silent failure for .NET Interactive kernel
- **L595-L2** — minimal-diff swap canon (avoid nbformat.write churn)
- **L619-L2** — JSON trailing newline canon
- C548-L2 — SVG inline zero-dependance NuGet canon