### PR TITLE
fix(notebook-tools,#6927,#6981): gate FIX-prose leads with cause-racine helper-load (mirror #6978 canon)

### DIFF
--- a/.github/workflows/svg-empty-display-gate.yml
+++ b/.github/workflows/svg-empty-display-gate.yml
@@ -21,9 +21,11 @@ name: SVG empty-display gate
 # payload. The same code may render fine in a different setup (proven #6967
 # DecInfer-7 cell[32] by po-2025: `display()` returns SVG `<text/html>` 3563
 # chars when the helper is `#load`-ed from the right cwd). The defect class is
-# SYMPTOM (empty output) cause-agnostic — it catches all empty-display failures,
-# including the `display()`-vs-`return` pitfall, the `#load` path-failure, and
-# the kernel cwd path-resolution failure.
+# SYMPTOM (empty output) cause-agnostic — it catches all empty-display failures
+# rooted in the helper/Formatter-not-loaded pitfall (`#load` unresolved from
+# the kernel's real cwd at exec time, so `Formatter.Register` never runs and
+# `SvgChartHelper.<chart>` falls through to a no-op). See ai-01 canon
+# `svg-6927-canon.md` §4 (cause-racine helper-load).
 #
 # Why this is NOT a regression of `svg-decimal-comma-gate.yml`
 # -------------------------------------------------------------
@@ -59,13 +61,15 @@ name: SVG empty-display gate
 # notebook is a defect introduced or carried by the PR and must be fixed
 # before merge. A new notebook must commit real SVG output, not empty lists.
 #
-# Fix (mirror ai-01 `svg-6927-canon.md` point 1)
-# ------------------------------------------------
-# Make the chart the LAST EXPRESSION of the cell (drop `display(chart)`,
-# leave the chart object as the cell's final value -> `execute_result`
-# carries the `<svg>`), OR investigate why the helper does not emit under
-# the headless exec and re-execute the .NET kernel -> the committed output
-# then carries the SVG. Common root causes:
+# Fix (mirror ai-01 `svg-6927-canon.md` §4 — cause-racine helper-load)
+# --------------------------------------------------------------------
+# The empty `outputs` list means the helper's `Formatter.Register` did NOT
+# run during exec — `#load "SvgChartHelper.cs"` did not resolve from the
+# kernel's real cwd (the notebook dir at exec time). `display(chart)` AND
+# last-expression BOTH render once the helper is loaded (proof: MERGED
+# `#6967` DecInfer-7 cell[32] uses `display(SvgChartHelper...)` and captures
+# the `<svg>`). Discriminator = helper-load, NOT display-vs-expression.
+# Common root causes:
 #  (A) `.NET Interactive` / nbclient kernel cwd is wrong: helper
 #      `#load "SvgChartHelper.cs"` resolves only if the kernel's cwd is the
 #      directory containing the helper (or a path-relative one that
@@ -75,9 +79,6 @@ name: SVG empty-display gate
 #      fails (file not found), the helper types exist in source but
 #      `Formatter.Register` is never executed -> `display(...)` falls
 #      through to a no-op -> empty outputs.
-#  (C) `display(...)` captures `display_data` only for SOME object types
-#      under nbclient. Make the chart the LAST EXPRESSION of the cell
-#      instead -> `execute_result` always carries the SVG.
 # Stop&Repair (secrets-hygiene rule 6): fix the cause + re-execute, NEVER
 # scrub the output by hand. A hand-edited `outputs: [<svg>]` would falsify
 # the proof of execution and resurface on the next exec.
@@ -165,7 +166,7 @@ jobs:
 
           if [ "$fail" -ne 0 ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "FIX: make the chart the LAST EXPRESSION of the cell (drop \`display(chart)\` -> leave the chart object as the cell's final value -> \`execute_result\` carries the \`<svg>\`), OR re-execute the .NET kernel with the helper \`#load\`-ed from the correct cwd (verify \`Environment.CurrentDirectory\` matches the helper folder, e.g. \`Probas/Infer/\`). See ai-01 canon \`svg-6927-canon.md\` (point 1) and the detector docstring. Stop&Repair: fix the cause + re-execute, never scrub the output by hand (secrets-hygiene rule 6)." >> "$GITHUB_STEP_SUMMARY"
+            echo "FIX: the empty \`outputs\` list means the helper's \`Formatter.Register\` did NOT run in this exec — \`#load \"SvgChartHelper.cs\"\` did not resolve from the kernel's real cwd (the notebook dir at exec time). Make the \`#load\` resolve (helper in the notebook dir, OR relative \`#load \"../<family>/SvgChartHelper.cs\"\` that reaches it, OR re-execute via Papermill/ExecutePreprocessor with \`resources.metadata.path\` set to the helper dir), then re-execute the .NET kernel and confirm \`out_len>0\` (\`<svg>\` present in the cell \`outputs\`). \`display(chart)\` AND last-expression BOTH render once the helper is loaded (proof: MERGED \`#6967\` DecInfer-7 cell[32] uses \`display()\` and captures the \`<svg>\`); the discriminator is helper-load, NOT display-vs-expression. See ai-01 canon \`svg-6927-canon.md\` §4 (cause-racine helper-load) and the detector docstring. Stop&Repair: fix the cause + re-execute, never scrub the output by hand (secrets-hygiene rule 6)." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
           echo "::notice title=SVG empty-display gate::Checked $checked changed notebook(s); no empty-display SVG defect."

--- a/.github/workflows/svg-empty-display-gate.yml
+++ b/.github/workflows/svg-empty-display-gate.yml
@@ -1,0 +1,171 @@
+name: SVG empty-display gate
+
+# Purpose
+# -------
+# Per-PR gate for .NET Interactive cells that `display()` an SVG chart but
+# commit an EMPTY output list (`outputs: []`). Such cells render as a
+# BLANK/white figure on GitHub and nbviewer: the PR's literal goal "render on
+# GitHub/nbviewer" is unmet even though the XML would be well-formed, the code
+# executes successfully (`execution_count != null`), and CI passes. This is the
+# SYMPTOM-CLASS 2 of the SVG inline fleet-wide rollout #6927 (the SYMPTOM-CLASS
+# 1 = SVG emitted with French decimal commas that render as a zigzag, caught
+# by `svg-decimal-comma-gate.yml` / `#6959`).
+#
+# Root cause
+# ----------
+# .NET Interactive / nbclient headless kernels can capture `display_data` for
+# some object types but not others. Empirically (incident #6963 DecInfer-6,
+# po-2025 fr-FR), `display(SvgChartHelper.Bar(...))` in some execution contexts
+# succeeds (`execution_count` set, no exception raised) yet produces an EMPTY
+# `outputs` list because the kernel's display-capture path missed the SVG
+# payload. The same code may render fine in a different setup (proven #6967
+# DecInfer-7 cell[32] by po-2025: `display()` returns SVG `<text/html>` 3563
+# chars when the helper is `#load`-ed from the right cwd). The defect class is
+# SYMPTOM (empty output) cause-agnostic — it catches all empty-display failures,
+# including the `display()`-vs-`return` pitfall, the `#load` path-failure, and
+# the kernel cwd path-resolution failure.
+#
+# Why this is NOT a regression of `svg-decimal-comma-gate.yml`
+# -------------------------------------------------------------
+# `svg-decimal-comma-gate.yml` (`#6965`) inspects the OUTPUT PAYLOAD and parses
+# SVG coordinate attributes. It CANNOT detect an empty output list (there is no
+# SVG to parse). `check_plotly_static_risk.py` inspects the SOURCE for
+# `<script src="cdn.plot.ly">`; it ALSO cannot detect the empty-output defect.
+# Both gates passed on PR #6963 (4 cells), which then rendered BLANK on GitHub.
+# `detect_svg_empty_display.py` is the structural counterpart: 3-condition
+# zero-FP signature on the CELL (not the SVG payload) =
+# `execution_count != null` AND `outputs == []` AND source contains a chart
+# `display()` pattern (`display(SvgChartHelper.<chart>)`, `display(HTML(<svg>))`,
+# or builder patterns `ScatterSvg` / `PlotSvg` / `BuildScatterSvg`). The two
+# detectors are COMPLEMENTARY, not redundant: one inspects the SVG content,
+# the other inspects the cell rendering pipeline.
+#
+# This gate runs scripts/notebook_tools/detect_svg_empty_display.py (`#6971`)
+# in --check mode on every notebook changed by the PR and FAILs if any cell
+# commits an empty display. The detector is deterministic and zero-FP:
+#  - Cells with `execution_count: null` (not yet executed) are NOT flagged
+#    (legitimate un-run notebook, the empty output is expected).
+#  - Cells with non-empty outputs (stream, error, display_data with SVG,
+#    etc.) are NOT flagged (the empty-display defect requires STRICT zero
+#    outputs — a stream-only cell emitting `Console.WriteLine` is not a
+#    white figure on GitHub).
+#  - Cells whose source does NOT contain a chart-display pattern are NOT
+#    flagged (a legitimately silent cell defining a helper function, or
+#    computing a value without displaying, has no display intention).
+#
+# Absolute (not regression) semantics: baseline `main` carries 0 defects
+# (the detector was validated clean across 930 notebooks at #6971: 0 false
+# positives across the partition). Any empty-display cell in a changed
+# notebook is a defect introduced or carried by the PR and must be fixed
+# before merge. A new notebook must commit real SVG output, not empty lists.
+#
+# Fix (mirror ai-01 `svg-6927-canon.md` point 1)
+# ------------------------------------------------
+# Make the chart the LAST EXPRESSION of the cell (drop `display(chart)`,
+# leave the chart object as the cell's final value -> `execute_result`
+# carries the `<svg>`), OR investigate why the helper does not emit under
+# the headless exec and re-execute the .NET kernel -> the committed output
+# then carries the SVG. Common root causes:
+#  (A) `.NET Interactive` / nbclient kernel cwd is wrong: helper
+#      `#load "SvgChartHelper.cs"` resolves only if the kernel's cwd is the
+#      directory containing the helper (or a path-relative one that
+#      reaches it). Verify with `Environment.CurrentDirectory` first.
+#  (B) Helper never compiled: `Formatter.Register` is the linchpin that
+#      wires up `SvgChartHelper.Bar` rendering. If the `#load` silently
+#      fails (file not found), the helper types exist in source but
+#      `Formatter.Register` is never executed -> `display(...)` falls
+#      through to a no-op -> empty outputs.
+#  (C) `display(...)` captures `display_data` only for SOME object types
+#      under nbclient. Make the chart the LAST EXPRESSION of the cell
+#      instead -> `execute_result` always carries the SVG.
+# Stop&Repair (secrets-hygiene rule 6): fix the cause + re-execute, NEVER
+# scrub the output by hand. A hand-edited `outputs: [<svg>]` would falsify
+# the proof of execution and resurface on the next exec.
+#
+# Incident: PR #6963 (DecInfer-6, po-2025 fr-FR) committed 4 cells
+# (29/35/45/49) with `display(SvgChartHelper.Bar(...))` and ran
+# successfully (`execution_count` set, validator EXEC_PROVED), but
+# `outputs == []` for each — the kernel's display-capture missed the SVG
+# payload under the chosen setup. Baseline main was clean (0/930). The
+# `svg-decimal-comma-gate` (`#6965`) and `check_plotly_static_risk.py`
+# both passed. Result: 4 white figures on GitHub, invisible to code
+# review and structural validation. Detected by vision-QA only.
+# Followup: PR #6967 (DecInfer-7, po-2025) rendered correctly with the
+# same `display(...)` pattern under a different cwd setup (proving the
+# defect is cause-agnostic, not pattern-specific). See EPIC #3801,
+# rollout #6927 (SVG inline fleet-wide), canon ai-01 `svg-6927-canon.md`.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/notebook_tools/detect_svg_empty_display.py'
+      - '.github/workflows/svg-empty-display-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  svg-empty-display:
+    name: "No SVG empty-display defect in changed notebooks"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Gate changed notebooks
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::notice title=SVG empty-display gate::Manual dispatch — nothing to diff."
+            exit 0
+          fi
+
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'MyIA.AI.Notebooks/**/*.ipynb' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "::notice title=SVG empty-display gate::No notebooks changed — clean."
+            exit 0
+          fi
+
+          echo "## SVG empty-display gate" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          fail=0
+          checked=0
+          while IFS= read -r nb; do
+            [ -z "$nb" ] && continue
+            # Skip notebooks deleted by the PR.
+            [ -f "$nb" ] || continue
+            checked=$((checked + 1))
+            out=$(python scripts/notebook_tools/detect_svg_empty_display.py "$nb" --check 2>&1)
+            rc=$?
+            if [ "$rc" -eq 1 ]; then
+              echo "::error title=SVG empty-display defect::$nb commits a code cell with a chart-display pattern but EMPTY output list (renders BLANK on GitHub/nbviewer)."
+              echo "<details><summary><code>$nb</code></summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "$out" >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            elif [ "$rc" -eq 2 ]; then
+              echo "::warning title=SVG empty-display gate::$nb could not be read (rc=2); see detector log."
+            fi
+          done <<< "$CHANGED"
+
+          if [ "$fail" -ne 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "FIX: make the chart the LAST EXPRESSION of the cell (drop \`display(chart)\` -> leave the chart object as the cell's final value -> \`execute_result\` carries the \`<svg>\`), OR re-execute the .NET kernel with the helper \`#load\`-ed from the correct cwd (verify \`Environment.CurrentDirectory\` matches the helper folder, e.g. \`Probas/Infer/\`). See ai-01 canon \`svg-6927-canon.md\` (point 1) and the detector docstring. Stop&Repair: fix the cause + re-execute, never scrub the output by hand (secrets-hygiene rule 6)." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "::notice title=SVG empty-display gate::Checked $checked changed notebook(s); no empty-display SVG defect."


### PR DESCRIPTION
## Fix-prose correction for ai-01 CHANGES_REQUESTED on #6981

**This PR addresses the CHANGES_REQUESTED review (PRR_kwDOH2Odns8AAAABGVBAAg) on PR #6981.**

ai-01's review confirmed that the **mechanism** of the gate (3-condition detection: `execution_count != null` AND `outputs == []` AND chart-display pattern in source; per-PR-diff scope; mirror wiring of #6965) is **correct and validated firsthand**. The only defect is the **remediation prose** printed to workers on failure — it carried the **old, refuted** rule ("make the chart the LAST EXPRESSION, drop `display(chart)`"). Per ai-01 canon `svg-6927-canon.md` §4 (cause-racine helper-load), this rule was superseded by the proof that **MERGED #6967 DecInfer-7 cell[32] uses `display()` and captures the `<svg>`** (26 outputs, via `Console.WriteLine` legend AFTER). The discriminator is helper-load (`#load "SvgChartHelper.cs"` not resolving from the kernel's real cwd, so `Formatter.Register` never runs), NOT display-vs-expression.

This PR is the **mirror** of the correction ai-01 already merged for the detector itself in **#6978** (the detector docstring/FIX was updated to lead with helper-load). This PR applies the same correction to the **gate YAML** so the tool + the gate are coherent with the corrected canon.

## Changes (prose-only, 1 file +15/-14)

1. **L28** "display()-vs-return pitfall" → "helper/Formatter-not-loaded pitfall (`#load` unresolved from exec cwd, so `Formatter.Register` never runs)" + cross-ref §4.
2. **L62-80** "Fix (mirror `svg-6927-canon.md` point 1)" → "Fix (mirror `svg-6927-canon.md` §4 — cause-racine helper-load)".
   - Removed "Make the chart the LAST EXPRESSION of the cell (drop `display(chart)`)" as the fix prose.
   - Removed (C) "display(...) captures display_data only for SOME object types" (which implied display-vs-).
   - Kept (A) cwd-kernel and (B) `Formatter.Register` as the two real causes.
   - Added proof: "`display(chart)` AND last-expression BOTH render once the helper is loaded (proof: MERGED #6967 DecInfer-7 cell[32] uses `display()` and captures the `<svg>`)".
3. **L168** (`$GITHUB_STEP_SUMMARY` actually read by a worker on failure) — full FIX string rewritten to lead with cause-racine helper-load: "the empty `outputs` list means the helper's `Formatter.Register` did NOT run in this exec — `#load "SvgChartHelper.cs"` did not resolve from the kernel's real cwd". Cross-ref `svg-6927-canon.md` §4.

## Wiring unchanged

- 3 steps (checkout@v4 fetch-depth 0 / setup-python@v5 3.11 / gate inline)
- permissions contents:read
- paths scope (`MyIA.AI.Notebooks/**/*.ipynb` + detector + gate)
- branch logic: `[ "$rc" -eq 1 ]` fail ::error / `[ "$rc" -eq 2 ]` warn ::warning / else notice
- stdlib-only deps detector

## Verification (hand-operated, post-fix)

- `yaml.safe_load` OK; structure = jobs=1 `svg-empty-display`, steps=3, first step `actions/checkout@v4`, last step "Gate changed notebooks".
- `grep -n "LAST EXPRESSION" .github/workflows/svg-empty-display-gate.yml` → **0 hits** (forbidden phrase removed).
- `grep -n "svg-6927-canon\|Formatter.Register\|helper-load" .github/workflows/svg-empty-display-gate.yml` → 8 hits at L26, L28, L64, L66, L71, L77, L80, L169 (canon refs present).
- Diff = pure prose refactor; 0 logic change.

## Pre-flight collision scan L539-L1 ★★★

| Branch | Status | Target | Conflict? |
|--------|--------|--------|-----------|
| `origin/feature/c635-svg-empty-display-ci-gate` (#6981 base, `a76494ec9`) | OPEN | YAML workflow | **BASELINE** — this PR is based on this |
| `origin/feature/svg-empty-display-detector-3801` (#6971 MERGED `05e83fe7`) | MERGED | detector `.py` | NO (different file) |
| `origin/feature/svg-emptydisplay-fixguidance` (#3f204b6b8, docstring FIX on detector) | OPEN | detector `.py` docstring | NO (different file) |
| `origin/docs/svg-6927-mergegate-readme` (NEW tierce: README sequence docs) | NEW | `scripts/notebook_tools/*.md` | NO (different file) |
| `origin/main` (advanced `dbe6df1f8..365486c65` = #6982 Heatmap + #6983 Infer-19 + #6984 Sudoku accents + #6985 Infer-18) | moved | notebooks | NO (YAML-only diff) |

## Relationship to #6981

This PR is a **separate PR** because the original branch `feature/c635-svg-empty-display-ci-gate` is referenced by the ai-01 CR review, and changing the head of #6981 would orphan the review thread. To minimize noise:
- The fix commit `6e2825727` lives on `fix/c637-6981-fixprose` (this PR).
- When this PR is merged, #6981 can be **superseded** (close via "Superseded by #<this>" comment) OR the workflow file content can be cherry-picked into #6981's branch via a follow-up ai-01 PR.

ai-01 may prefer either: (a) merge this PR and supersede #6981, or (b) merge #6981 as-is then file a follow-up. I leave the call to ai-01.

## References

- See #6981 (PR this fix addresses — CHANGES_REQUESTED on its prose)
- See #6978 (MERGED detector docstring/FIX correction — the canonical mirror for this gate fix)
- See #6967 (DecInfer-7 proof that helper-load is the discriminator, not display-vs-expression)
- See #6971 (companion detector MERGED — what this gate wires)
- See #6965 (sister gate MERGED — pattern mirror)