### PR TITLE
feat(smt,#6927): Z3-Python-06-Csharp Pareto chart Plotly-CDN -> SVG inline Overlay

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
@@ -725,7 +725,7 @@
     "\n",
     "Un tableau de nombres ne rend pas justice au concept de **compromis**. En projetant chaque point Pareto-optimal dans le plan (qualite, cout), le front devient une courbe descendante : chaque pas vers un cout plus bas coute de la qualite. La droite `cout_min = 2 * qualite` (la frontiere de faisabilite imposee par le modele) apparait en pointille : on voit immediatement que certains points Pareto-optimaux sont *strictement au-dessus* de cette borne minimale -- Z3 les a choisis parce qu'a qualite fixee, plusieurs couts sont Pareto-equivalents, et le solveur en echantillonne un. C'est precisement ce que le front de Pareto revele qu'un simple « minimiser le cout » cacherait.\n",
     "\n",
-    "> Le twin Python trace cette courbe avec **matplotlib** (rendu PNG). Le twin C# utilise **Plotly** (rendu HTML via le formatteur builtin du kernel .NET, sans dependance NuGet additionnelle) -- les deux twins offrent maintenant une vraie courbe, pas un tableau de nombres."
+    "> Le twin Python trace cette courbe avec **matplotlib** (rendu PNG). Le twin C# utilise **SVG inline** (rendu statique zero-dependance via le helper SvgChartHelper, visible sur GitHub/nbviewer/offline) -- les deux twins offrent maintenant une vraie courbe, pas un tableau de nombres."
    ]
   },
   {
@@ -744,7 +744,7 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"pltPareto\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltPareto',[{\"name\":\"Front de Pareto\",\"x\":[\"10\",\"9\",\"8\",\"7\",\"6\",\"5\",\"4\",\"3\",\"2\",\"1\"],\"y\":[20,19,17,14,12,10,9,7,5,2],\"type\":\"scatter\",\"mode\":\"lines+markers\",\"line\":{\"color\":\"#1f77b4\"},\"marker\":{\"size\":10,\"color\":\"#1f77b4\"}},{\"name\":\"cout_min = 2*qualite\",\"x\":[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\",\"9\",\"10\"],\"y\":[0,2,4,6,8,10,12,14,16,18,20],\"type\":\"scatter\",\"mode\":\"lines\",\"line\":{\"color\":\"#d62728\"}}],{\"title\":{\"text\":\"Front de Pareto : qualite vs cout\"},\"xaxis\":{\"title\":{\"text\":\"qualite\"}},\"yaxis\":{\"title\":{\"text\":\"cout\"}},\"legend\":{\"x\":0.02,\"xanchor\":\"left\",\"y\":0.98}},{responsive:true})</script>"
+       "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='480' viewBox='0 0 820 480' font-family='sans-serif' font-size='12'><rect width='820' height='480' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Front de Pareto : qualite vs cout</text><line x1='52' y1='438' x2='804' y2='438' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='442' text-anchor='end' fill='#333333'>-1.2</text><line x1='52' y1='337' x2='804' y2='337' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='341' text-anchor='end' fill='#333333'>4.4</text><line x1='52' y1='236' x2='804' y2='236' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='240' text-anchor='end' fill='#333333'>10</text><line x1='52' y1='135' x2='804' y2='135' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='139' text-anchor='end' fill='#333333'>15.6</text><line x1='52' y1='34' x2='804' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>21.2</text><line x1='52' y1='34' x2='52' y2='438' stroke='#888888' stroke-width='1'/><line x1='52' y1='416.357' x2='804' y2='416.357' stroke='#888888' stroke-width='1'/><text x='52' y='454' text-anchor='middle' fill='#333333'>0</text><text x='240' y='454' text-anchor='middle' fill='#333333'>2.5</text><text x='428' y='454' text-anchor='middle' fill='#333333'>5</text><text x='616' y='454' text-anchor='middle' fill='#333333'>7.5</text><text x='804' y='454' text-anchor='middle' fill='#333333'>10</text><text x='428' y='474' text-anchor='middle' fill='#333333'>qualite</text><text x='14' y='236' text-anchor='middle' fill='#333333' transform='rotate(-90 14 236)'>cout</text><polyline points='804,55.643 728.8,73.679 653.6,109.75 578.4,163.857 503.2,199.929 428,236 352.8,254.036 277.6,290.107 202.4,326.179 127.2,380.286' fill='none' stroke='#1f77b4' stroke-width='2'/><circle cx='804' cy='55.643' r='3' fill='#1f77b4'/><circle cx='728.8' cy='73.679' r='3' fill='#1f77b4'/><circle cx='653.6' cy='109.75' r='3' fill='#1f77b4'/><circle cx='578.4' cy='163.857' r='3' fill='#1f77b4'/><circle cx='503.2' cy='199.929' r='3' fill='#1f77b4'/><circle cx='428' cy='236' r='3' fill='#1f77b4'/><circle cx='352.8' cy='254.036' r='3' fill='#1f77b4'/><circle cx='277.6' cy='290.107' r='3' fill='#1f77b4'/><circle cx='202.4' cy='326.179' r='3' fill='#1f77b4'/><circle cx='127.2' cy='380.286' r='3' fill='#1f77b4'/><polyline points='52,416.357 127.2,380.286 202.4,344.214 277.6,308.143 352.8,272.071 428,236 503.2,199.929 578.4,163.857 653.6,127.786 728.8,91.714 804,55.643' fill='none' stroke='#d62728' stroke-width='2'/><rect x='632' y='42' width='168' height='50' fill='white' stroke='#E5E5E5' stroke-width='1'/><line x1='642' y1='54' x2='666' y2='54' stroke='#1f77b4' stroke-width='2'/><text x='674' y='58' fill='#333333'>Front de Pareto</text><line x1='642' y1='72' x2='666' y2='72' stroke='#d62728' stroke-width='2'/><text x='674' y='76' fill='#333333'>cout_min = 2*qualite</text></svg>"
       ]
      },
      "metadata": {},
@@ -752,47 +752,26 @@
     }
    ],
    "source": [
-    "// Visualisation Plotly du front de Pareto : qualite (x) vs cout (y).\n",
-    "// Prong-A (#3801) : remplace la matrice ASCII (Console.WriteLine) par un vrai rendu Plotly.\n",
-    "// C548-L2 zero-restore : Formatter.Register (builtin) + System.Text.Json, aucun #r nuget charting.\n",
-    "using Microsoft.DotNet.Interactive.Formatting;\n",
-    "using System.IO;\n",
-    "record PlotlyHtml(string Markup);\n",
-    "Formatter.Register(typeof(PlotlyHtml), (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
+    "// Visualisation SVG inline du front de Pareto : qualite (x) vs cout (y).\n",
+    "// Prong-A (#3801, #6927) : rendu SVG statique zero-dependance (rend sur GitHub/nbviewer/offline).\n",
+    "// Remplace le chart Plotly-CDN (#6856) dont le script externe rendait BLANC en consultation statique.\n",
+    "// Helper canon SvgChartHelper.cs (#6942 MERGED) ; primitive Overlay multi-series (#6958 MERGED).\n",
+    "#load \"../../../Probas/Infer/SvgChartHelper.cs\"\n",
     "\n",
-    "// Donnees : front (points Pareto-optimaux) + droite cout_min = 2*qualite (frontiere de faisabilite)\n",
-    "var opt = new System.Text.Json.JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };\n",
-    "\n",
-    "string[] qualiteX = front.Select(p => p.qualite.ToString()).ToArray();\n",
-    "double[] coutFront = front.Select(p => (double)p.cout).ToArray();\n",
-    "\n",
-    "// Droite cout_min = 2*qualite (de q=0 a q=10)\n",
-    "int qMaxLine = 10;\n",
-    "string[] qualiteLine = Enumerable.Range(0, qMaxLine + 1).Select(q => q.ToString()).ToArray();\n",
-    "double[] coutMinLine = Enumerable.Range(0, qMaxLine + 1).Select(q => (double)(2 * q)).ToArray();\n",
-    "\n",
-    "string Trace(string name, string[] x, double[] y, string mode, string color, int? size=null) {\n",
-    "    var d = new Dictionary<string, object> {\n",
-    "        [\"name\"]=name, [\"x\"]=x, [\"y\"]=y.Select(v=>System.Math.Round(v,3)).ToArray(),\n",
-    "        [\"type\"]=\"scatter\", [\"mode\"]=mode, [\"line\"]=new Dictionary<string,object>{{\"color\",color}}\n",
-    "    };\n",
-    "    if (size.HasValue) d[\"marker\"]=new Dictionary<string,object>{{\"size\",size.Value},{\"color\",color}};\n",
-    "    return System.Text.Json.JsonSerializer.Serialize(d, opt);\n",
-    "}\n",
-    "string trFront = Trace(\"Front de Pareto\", qualiteX, coutFront, \"lines+markers\", \"#1f77b4\", 10);\n",
-    "string trBound = Trace(\"cout_min = 2*qualite\", qualiteLine, coutMinLine, \"lines\", \"#d62728\");\n",
-    "\n",
-    "string layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Front de Pareto : qualite vs cout\\\"},\" +\n",
-    "    \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"qualite\\\"}},\" +\n",
-    "    \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"cout\\\"}},\" +\n",
-    "    \"\\\"legend\\\":{\\\"x\\\":0.02,\\\"xanchor\\\":\\\"left\\\",\\\"y\\\":0.98}}\";\n",
-    "\n",
-    "string divId = \"pltPareto\";\n",
-    "string markup =\n",
-    "    \"<div id=\\\"\"+divId+\"\\\"></div>\" +\n",
-    "    \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "    \"<script>Plotly.newPlot('\"+divId+\"',[\"+trFront+\",\"+trBound+\"],\"+layout+\",{responsive:true})</script>\";\n",
-    "display(new PlotlyHtml(markup));\n"
+    "// Donnees : front (points Pareto-optimaux) + droite cout_min = 2*qualite (frontiere de faisabilite).\n",
+    "// 2 series sur axe X numerique partage (qualite) -> SvgChartHelper.Overlay (pattern canon #6927).\n",
+    "var series = new SvgSeries[]\n",
+    "{\n",
+    "    new SvgSeries(\"Front de Pareto\",\n",
+    "        front.Select(p => (double)p.qualite).ToArray(),\n",
+    "        front.Select(p => (double)p.cout).ToArray(),\n",
+    "        TraceStyle.LineMarkers, \"#1f77b4\"),\n",
+    "    new SvgSeries(\"cout_min = 2*qualite\",\n",
+    "        Enumerable.Range(0, 11).Select(q => (double)q).ToArray(),\n",
+    "        Enumerable.Range(0, 11).Select(q => (double)(2 * q)).ToArray(),\n",
+    "        TraceStyle.Line, \"#d62728\"),\n",
+    "};\n",
+    "display(SvgChartHelper.Overlay(\"Front de Pareto : qualite vs cout\", \"qualite\", \"cout\", series));\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Converts the **Z3-Python-06-Advanced-Optimization-Csharp** Pareto-front chart from **Plotly-CDN** (the external `<script>` tag renders blank in static mode — introduced by #6856) to **inline SVG** via the canon `SvgChartHelper.Overlay()` (#6942 helper + #6958 primitive). Part of EPIC **#6927** (fleet-wide Plotly-CDN → SVG).

**My partition** (Z3-Csharp / SMT). po-2025 is on GameTheory/Infer SVG conversions; this notebook was unclaimed (collision-checked: 0 open PR — #6856 = Python version, #5616 = C# twin creation, neither is the SVG conversion).

## Change (C.3 atomic scope — 1 file, 22+/43-)

- **cell[12] code**: `PlotlyHtml` record + `Formatter.Register` + external-script chart → `#load "../../../Probas/Infer/SvgChartHelper.cs"` + `SvgChartHelper.Overlay(...)` with 2 `SvgSeries` on shared numeric axis (qualite): Front de Pareto (LineMarkers, blue) + cout_min=2*qualite feasibility line (Line, red).
- **cell[11] markdown**: prose "utilise **Plotly**" → "utilise **SVG inline**" (coherence, pr-review-discipline E).
- Cross-family helper load via **relative** `#load` (portable — resolves from notebook-dir CWD = default nbconvert, robust to local re-exec; po-2025's "portable alternative" c.563).

## Real execution (C.2 / H.4)

`.net-csharp` kernel, Z3 `#r nuget: Microsoft.Z3` (known-good v4.12.2.0, NOT the cluster `#r nuget` hang). **exec_count=5, inline `<svg>` output len=2966, 0 errors end-to-end (10 code cells).** Output transplanted onto origin/main base (C.3: only cell[11] source + cell[12] source/output committed; 2 incidental output-churn cells restored to origin/main).

## Gates green (firsthand)

| Gate | Result |
|------|--------|
| `detect_svg_decimal_commas.py` (#6959) | **0 defects** |
| `detect_svg_empty_display.py` (#6971) | **0 defects** |
| `check_plotly_static_risk.py` (#6931) | **0 risky nb / 0 risky cells** (whole Z3-API dir now clean) |
| `cdn.plot.ly` / `Plotly.newPlot` remaining | **0** |
| C.1 (`raise NotImplementedError`/`assert False`/`1/0`) | **0** |
| `validate_pr_notebooks.py` (H.1/H.3) | **1/1 PASS** (10 cells) |
| Catalog (`COURSE_CATALOG.generated.*`) | **byte-identical** |

**Verdict: SOTA-OK** (#3801 Prong-A — real inline SVG zero-dependency, renders on GitHub / nbviewer / offline).

## Residual

- **Visual QA = vision-gated** (GLM no-vision lane): chart pedagogy sign-off routes to ai-01 / MiniMax (CoursIA-2), per cluster canon. Deterministic gates all green.
- **Sudoku-18-Comparison-Csharp** (7 Plotly-CDN hits, same partition) deliberately **left out**: blocked by the cluster-wide `#r nuget` hang → C.2 re-exec impossible. Separate issue.

See #6927

🤖 po-2023 · cron-driven
