### PR TITLE
fix(z3-06,#6927): Plotly CDN Pareto front -> SVG inline Overlay (SMT/Z3 family)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
@@ -743,56 +743,32 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div id=\"pltPareto\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltPareto',[{\"name\":\"Front de Pareto\",\"x\":[\"10\",\"9\",\"8\",\"7\",\"6\",\"5\",\"4\",\"3\",\"2\",\"1\"],\"y\":[20,19,17,14,12,10,9,7,5,2],\"type\":\"scatter\",\"mode\":\"lines+markers\",\"line\":{\"color\":\"#1f77b4\"},\"marker\":{\"size\":10,\"color\":\"#1f77b4\"}},{\"name\":\"cout_min = 2*qualite\",\"x\":[\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\",\"9\",\"10\"],\"y\":[0,2,4,6,8,10,12,14,16,18,20],\"type\":\"scatter\",\"mode\":\"lines\",\"line\":{\"color\":\"#d62728\"}}],{\"title\":{\"text\":\"Front de Pareto : qualite vs cout\"},\"xaxis\":{\"title\":{\"text\":\"qualite\"}},\"yaxis\":{\"title\":{\"text\":\"cout\"}},\"legend\":{\"x\":0.02,\"xanchor\":\"left\",\"y\":0.98}},{responsive:true})</script>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='820' height='480' viewBox='0 0 820 480' font-family='sans-serif' font-size='12'><rect width='820' height='480' fill='white'/><text x='410' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Front de Pareto : qualite vs cout</text><line x1='52' y1='438' x2='804' y2='438' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='442' text-anchor='end' fill='#333333'>-1.2</text><line x1='52' y1='337' x2='804' y2='337' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='341' text-anchor='end' fill='#333333'>4.4</text><line x1='52' y1='236' x2='804' y2='236' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='240' text-anchor='end' fill='#333333'>10</text><line x1='52' y1='135' x2='804' y2='135' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='139' text-anchor='end' fill='#333333'>15.6</text><line x1='52' y1='34' x2='804' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>21.2</text><line x1='52' y1='34' x2='52' y2='438' stroke='#888888' stroke-width='1'/><line x1='52' y1='416.357' x2='804' y2='416.357' stroke='#888888' stroke-width='1'/><text x='52' y='454' text-anchor='middle' fill='#333333'>0</text><text x='240' y='454' text-anchor='middle' fill='#333333'>2.5</text><text x='428' y='454' text-anchor='middle' fill='#333333'>5</text><text x='616' y='454' text-anchor='middle' fill='#333333'>7.5</text><text x='804' y='454' text-anchor='middle' fill='#333333'>10</text><text x='428' y='474' text-anchor='middle' fill='#333333'>qualite</text><text x='14' y='236' text-anchor='middle' fill='#333333' transform='rotate(-90 14 236)'>cout</text><polyline points='804,55.643 728.8,73.679 653.6,109.75 578.4,163.857 503.2,199.929 428,236 352.8,254.036 277.6,290.107 202.4,326.179 127.2,380.286' fill='none' stroke='#1f77b4' stroke-width='2'/><circle cx='804' cy='55.643' r='3' fill='#1f77b4'/><circle cx='728.8' cy='73.679' r='3' fill='#1f77b4'/><circle cx='653.6' cy='109.75' r='3' fill='#1f77b4'/><circle cx='578.4' cy='163.857' r='3' fill='#1f77b4'/><circle cx='503.2' cy='199.929' r='3' fill='#1f77b4'/><circle cx='428' cy='236' r='3' fill='#1f77b4'/><circle cx='352.8' cy='254.036' r='3' fill='#1f77b4'/><circle cx='277.6' cy='290.107' r='3' fill='#1f77b4'/><circle cx='202.4' cy='326.179' r='3' fill='#1f77b4'/><circle cx='127.2' cy='380.286' r='3' fill='#1f77b4'/><polyline points='52,416.357 127.2,380.286 202.4,344.214 277.6,308.143 352.8,272.071 428,236 503.2,199.929 578.4,163.857 653.6,127.786 728.8,91.714 804,55.643' fill='none' stroke='#d62728' stroke-width='2'/><rect x='632' y='42' width='168' height='50' fill='white' stroke='#E5E5E5' stroke-width='1'/><line x1='642' y1='54' x2='666' y2='54' stroke='#1f77b4' stroke-width='2'/><text x='674' y='58' fill='#333333'>Front de Pareto</text><line x1='642' y1='72' x2='666' y2='72' stroke='#d62728' stroke-width='2'/><text x='674' y='76' fill='#333333'>cout_min = 2*qualite</text></svg>"
      },
+     "execution_count": 5,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
+    "#load \"SvgChartHelper.cs\"\n",
     "// Visualisation Plotly du front de Pareto : qualite (x) vs cout (y).\n",
     "// Prong-A (#3801) : remplace la matrice ASCII (Console.WriteLine) par un vrai rendu Plotly.\n",
     "// C548-L2 zero-restore : Formatter.Register (builtin) + System.Text.Json, aucun #r nuget charting.\n",
-    "using Microsoft.DotNet.Interactive.Formatting;\n",
-    "using System.IO;\n",
-    "record PlotlyHtml(string Markup);\n",
-    "Formatter.Register(typeof(PlotlyHtml), (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
-    "\n",
     "// Donnees : front (points Pareto-optimaux) + droite cout_min = 2*qualite (frontiere de faisabilite)\n",
-    "var opt = new System.Text.Json.JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping };\n",
-    "\n",
-    "string[] qualiteX = front.Select(p => p.qualite.ToString()).ToArray();\n",
-    "double[] coutFront = front.Select(p => (double)p.cout).ToArray();\n",
-    "\n",
-    "// Droite cout_min = 2*qualite (de q=0 a q=10)\n",
-    "int qMaxLine = 10;\n",
-    "string[] qualiteLine = Enumerable.Range(0, qMaxLine + 1).Select(q => q.ToString()).ToArray();\n",
-    "double[] coutMinLine = Enumerable.Range(0, qMaxLine + 1).Select(q => (double)(2 * q)).ToArray();\n",
-    "\n",
-    "string Trace(string name, string[] x, double[] y, string mode, string color, int? size=null) {\n",
-    "    var d = new Dictionary<string, object> {\n",
-    "        [\"name\"]=name, [\"x\"]=x, [\"y\"]=y.Select(v=>System.Math.Round(v,3)).ToArray(),\n",
-    "        [\"type\"]=\"scatter\", [\"mode\"]=mode, [\"line\"]=new Dictionary<string,object>{{\"color\",color}}\n",
-    "    };\n",
-    "    if (size.HasValue) d[\"marker\"]=new Dictionary<string,object>{{\"size\",size.Value},{\"color\",color}};\n",
-    "    return System.Text.Json.JsonSerializer.Serialize(d, opt);\n",
-    "}\n",
-    "string trFront = Trace(\"Front de Pareto\", qualiteX, coutFront, \"lines+markers\", \"#1f77b4\", 10);\n",
-    "string trBound = Trace(\"cout_min = 2*qualite\", qualiteLine, coutMinLine, \"lines\", \"#d62728\");\n",
-    "\n",
-    "string layout = \"{\\\"title\\\":{\\\"text\\\":\\\"Front de Pareto : qualite vs cout\\\"},\" +\n",
-    "    \"\\\"xaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"qualite\\\"}},\" +\n",
-    "    \"\\\"yaxis\\\":{\\\"title\\\":{\\\"text\\\":\\\"cout\\\"}},\" +\n",
-    "    \"\\\"legend\\\":{\\\"x\\\":0.02,\\\"xanchor\\\":\\\"left\\\",\\\"y\\\":0.98}}\";\n",
-    "\n",
-    "string divId = \"pltPareto\";\n",
-    "string markup =\n",
-    "    \"<div id=\\\"\"+divId+\"\\\"></div>\" +\n",
-    "    \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "    \"<script>Plotly.newPlot('\"+divId+\"',[\"+trFront+\",\"+trBound+\"],\"+layout+\",{responsive:true})</script>\";\n",
-    "display(new PlotlyHtml(markup));\n"
+    "SvgChartHelper.Overlay(\n",
+    "    \"Front de Pareto : qualite vs cout\",\n",
+    "    \"qualite\", \"cout\",\n",
+    "    new[] {\n",
+    "        new SvgSeries(\"Front de Pareto\",\n",
+    "            front.Select(p => (double)p.qualite).ToArray(),\n",
+    "            front.Select(p => (double)p.cout).ToArray(),\n",
+    "            TraceStyle.LineMarkers, \"#1f77b4\"),\n",
+    "        new SvgSeries(\"cout_min = 2*qualite\",\n",
+    "            Enumerable.Range(0, 11).Select(q => (double)q).ToArray(),\n",
+    "            Enumerable.Range(0, 11).Select(q => (double)(2 * q)).ToArray(),\n",
+    "            TraceStyle.Line, \"#d62728\"),\n",
+    "    })"
    ]
   },
   {


### PR DESCRIPTION
## What

`SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb` **cell[12]**: replace blank-in-static Plotly chart with inline static SVG via **`SvgChartHelper.Overlay()`** (#6942 + #6958 MERGED).

Z3 SMT multi-objective optimization: the **Pareto front** (qualité vs coût) from the Z3 solver — **2 series** sharing numeric X axis (qualité):
- **Front de Pareto** — the Pareto-optimal points (`front` from the upstream solver), LineMarkers blue — the solver's output
- **cout_min = 2·qualité** — the cost feasibility bound (cost = 2×quality, line), red — the analytical frontier

Showing the solver's discrete Pareto points above the analytical cost bound is the pedagogical point that must render on GitHub.

## Family rotation (R6)

SVG genre was saturated this cluster burst (GameTheory/Probas drained, 5+ workers on #6927, peers po-2024/po-2023 pivoted off SVG). All genuinely-rotated grains verified blocked/clean first-hand: §E READMEs in my partition (#3974) all reconcile disk↔prose (no real defect), QC quantbooks (#6891) need QC-Cloud research-kernel (no MCP flow), non-QC blank-figures are GenAI-dependent, ASCII workaround drained, Lean CI-only, vision out (GLM lane), accents = po-2023 turf. The #6927 residual was scoured for a **locally-executable, un-claimed, NEW-family** cell — **SMT/Z3** is a family I'd never touched, and Z3-06 is the only residual cell whose env is clean.

- MGS-17: **blocked** (MetaGeneticSharp submodule DLLs fail to load — `System.Runtime 9.0.0.0` FileNotFoundException — first-hand, not locally executable).
- Sudoku-18 / App-8: `#r "nuget: Google.OrTools"` (and Z3-06 `#r "nuget: Microsoft.Z3"`). Verified first-hand that `#r nuget` **resolves in 4s on this machine** (cache hit) — the cluster-wide hang claim is stale for cached packages. Z3-06 picked as the single-cell scatter (cleanest primitive match).

## `#load` resolves via CWD override

Helper is in `Probas/Infer/`, notebook in `SymbolicAI/SMT/Z3-API/` → cross-family. Bare `#load "SvgChartHelper.cs"` resolves with `ExecutePreprocessor` CWD override to `Probas/Infer/` (cf c.563 empirical #load truth). Z3-06 has **no local file deps** (verified: no File.ReadAllText/relative paths), so the CWD override is safe — `#r "nuget: Microsoft.Z3"` is path-independent.

## Surgical block-swap

Only cell[12] uses `PlotlyHtml` → formatter setup dropped. The data-prep + chart-build block (`var opt = …` through `display(new PlotlyHtml(markup));`) swaps to `Overlay()` as last-expression. The Pareto solver (Z3 `Optimize`, `frontBrut`/`front` upstream) is **untouched** — only the rendering cell changes.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| Real `.net-csharp` exec (H.4) | cell[12] exec_count=5, 0 errors (27-cell exec, Microsoft.Z3 nuget resolved 4s), SVG out_len=2966 |
| `detect_svg_decimal_commas.py` (#6959, merge-gate) | **0 defects** rc=0 (helper `F()`=InvariantCulture) |
| `detect_svg_empty_display.py` (#6971, no-vision blank-gate) | **0 defects** rc=0 (mechanically non-blank) |
| `check_plotly_static_risk.py` (#6931) | Z3-06 **no longer risky** (repo risky 12→11) |
| `cdn.plotly` in output | **False** |
| probeAddresses banner | absent |
| 2 series legend | True (Front de Pareto + cout_min = 2·qualité) |
| curve + markers | `<polyline>`/`<path>` + `<circle>` confirmed |
| C.3 scope | **only cell[12]** changed |
| Catalog byte-identity (R1) | 0 diff; README untouched |

## Verdict: **SOTA-OK** (#3801 Prong-A)

## Notes

- **Visual QA**: GLM lane not vision-capable; routes to MiniMax (CoursIA-2) / ai-01. Deterministic gates (#6959 + #6971) green.
- **See #6927** (partial — repo-wide Plotly-CDN→SVG; Z3-API family done, residual risky: Infer-11/12 claimed, DecInfer-6/8, Search-11b, Sudoku-18, App-8, ML-5 [#r-nuget], GT-8c cell[8] [per-color bar primitive absent]).

🤖 po-2025 (GLM no-vision lane)
