### PR TITLE
fix(decinfer,#6309): strip probeAddresses banner from DecInfer-8 (unblock banner-guard CI)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
@@ -114,7 +114,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -124,10 +124,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -142,7 +142,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -154,8 +154,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://10.177.155.85:2051/\", \"http://172.21.208.1:2051/\", \"http://172.28.176.1:2051/\", \"http://127.0.0.1:2051/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -204,13 +204,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",


### PR DESCRIPTION
## Summary — cluster-critical CI unblock

Strips the **probeAddresses kernel banner** (9 lines) from `DecInfer-8-Sequential.ipynb` cell[2] out[0]. This is the **sole defect** keeping the `probeAddresses banner guard` check RED on `main` since **06:46Z (~2h)**, blocking the **entire merge queue** (15+ PRs, including #6996).

## Root cause

PR **#6977** (po-2025, DecInfer-8 cell[49] Plotly→3×SvgChartHelper.Bar) was merged to main after committing the **full re-executed notebook** without running `strip_probe_banner.py --apply` post-re-exec. The dotnet-interactive kernel injects its `probeAddresses` banner (host network interfaces) on startup, captured in the cell[2] setup output (`#r "nuget: Microsoft.ML.Probabilistic"`). This leaks the contributor's host network interfaces into the committed notebook.

Timeline (firsthand): #6991 merged 06:41:36Z (banner-guard green at merge) → #6977 merged right after → banner-guard RED 06:41:39Z on the resulting main commit (run 29561004815).

## Fix — canon Stop & Repair-compliant (#6312)

```
python scripts/notebook_tools/strip_probe_banner.py --apply <path>
```

This is the **prescribed** fix (the CI check's own failure message says exactly this). The banner is **kernel-injected** (not produced by notebook code), so stripping it is **NOT** a hand-edit of an execution proof — it is the documented canonical exception (memory: probeAddresses kernel-injected rule-6 exception, hook #6312). Re-executing would re-inject the same banner; strip is the correct durable action.

## C.3 surgical verification (firsthand)

| Check | Result |
|-------|--------|
| source changed cells | **[]** (no source touched) |
| execution_count changed cells | **[]** (preserved) |
| outputs changed cells | **[2]** only |
| cell[2] out[0] html | 3698 → 3202 chars (−496 = banner removed) |
| `probeAddresses` in cell[2] out[0] | **True → False** |
| post-strip scan | **0 banner / 0 defect** |
| other cells | **byte-identical** to origin/main |

## Impact

Unblocks the entire merge queue (every open .NET-touching PR inherits this RED check). Not po-2023's partition, but rule 5 (`/continue`): "rien n'est le turf d'un autre" + this directly unblocks my own #6996. 0 collision (`gh pr list --search DecInfer-8` = 0 open fix PR).

See #6309

🤖 po-2023 · cron-driven
