### PR TITLE
feat(svg-helper,#6927): add GroupedBar() primitive + App-8 cell[18] Plotly-CDN -> SVG

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/SvgChartHelper.cs
+++ b/MyIA.AI.Notebooks/Probas/Infer/SvgChartHelper.cs
@@ -108,6 +108,20 @@ public static class SvgChartHelper
         string colorLow = "#F7FBFF", string colorHigh = "#08306B")
         => new SvgChart(BuildHeatmap(title, xLabels, yLabels, values, width, height, colorLow, colorHigh));
 
+    /// <summary>
+    /// Barres groupees : pour chaque categorie, plusieurs series tracees cote a cote (ex.
+    /// comparaison de N solveurs sur une meme famille de problemes, ou score multi-criteres par
+    /// methode). Une legende (haut-droite) identifie chaque serie par sa couleur. SVG inline statique.
+    /// </summary>
+    /// <param name="categories">Labels de l'axe X (une entree par groupe).</param>
+    /// <param name="seriesValues">Une sous-liste par serie ; chaque sous-liste a une valeur par categorie.</param>
+    /// <param name="seriesLabels">Nom de chaque serie (legende), une entree par serie.</param>
+    /// <param name="colors">Couleurs optionnelles par serie (defaut = palette SvgChartHelper).</param>
+    public static SvgChart GroupedBar(string title, string[] categories,
+        double[][] seriesValues, string[] seriesLabels,
+        int width = 640, int height = 360, string[] colors = null)
+        => new SvgChart(BuildGroupedBar(title, categories, seriesValues, seriesLabels, width, height, colors));
+
     // ---------------------------------------------------------------------------------------------
     // Generateurs
     // ---------------------------------------------------------------------------------------------
@@ -136,6 +150,67 @@ public static class SvgChartHelper
             sb.Append($"<rect x='{F(x)}' y='{F(y)}' width='{F(barW)}' height='{F(barH)}' fill='{c}'/>");
             sb.Append(CategoryLabel(layout, x + barW / 2.0, categories[i]));
         }
+        sb.Append(CloseSvg());
+        return sb.ToString();
+    }
+
+    private static string BuildGroupedBar(string title, string[] categories,
+        double[][] seriesValues, string[] seriesLabels, int w, int h, string[] colors)
+    {
+        int catCount = categories?.Length ?? 0;
+        int seriesCount = seriesValues?.Length ?? 0;
+        if (catCount == 0 || seriesCount == 0)
+            throw new ArgumentException("GroupedBar: categories et seriesValues ne doivent pas etre vides.");
+        if (seriesLabels == null || seriesLabels.Length != seriesCount)
+            throw new ArgumentException("GroupedBar: seriesLabels doit avoir une entree par serie.");
+        for (int j = 0; j < seriesCount; j++)
+            if (seriesValues[j] == null || seriesValues[j].Length != catCount)
+                throw new ArgumentException("GroupedBar: chaque serie doit avoir une valeur par categorie.");
+
+        // Bornes Y sur l'union de toutes les series (NiceBounds attend un double[] plat).
+        double[] all = new double[catCount * seriesCount];
+        int k = 0;
+        for (int j = 0; j < seriesCount; j++)
+            for (int i = 0; i < catCount; i++)
+                all[k++] = seriesValues[j][i];
+        var (yMin, yMax) = NiceBounds(all);
+        var layout = new PlotLayout(w, h, yMin, yMax, catCount);
+
+        string[] palette = { ColorPrimary, ColorAccent, "#DD8452", ColorNegative, "#8172B3", "#937860" };
+        string SeriesColor(int j) => colors != null && j < colors.Length ? colors[j] : palette[j % palette.Length];
+
+        var sb = new StringBuilder();
+        sb.Append(OpenSvg(w, h, title));
+        sb.Append(GridAndYAxis(layout));
+
+        // Groupe = 80% de la cellule categorie ; sous-barres cote a cote, centrees sur CatX(i).
+        double groupW = (layout.PlotW / (double)catCount) * 0.80;
+        double barW = groupW / seriesCount;
+        for (int i = 0; i < catCount; i++)
+        {
+            double gx = layout.CatX(i) - groupW / 2.0;
+            for (int j = 0; j < seriesCount; j++)
+            {
+                double v = seriesValues[j][i];
+                double barH = Math.Abs(v - 0) / layout.YRange * layout.PlotH;
+                // y = sommet (SVG) de la barre : Y(v) si v>=0, Y(0) si v<0 (geometrie = BuildBar).
+                double y = v >= 0 ? layout.Y(v) : layout.Y(0);
+                sb.Append($"<rect x='{F(gx + j * barW)}' y='{F(y)}' width='{F(barW)}' height='{F(barH)}' fill='{SeriesColor(j)}'/>");
+            }
+            sb.Append(CategoryLabel(layout, layout.CatX(i), categories[i]));
+        }
+
+        // Legende (haut-droite de la zone de plot), une entree par serie : carre couleur + label.
+        double lx = layout.PadL + layout.PlotW - 172, ly = layout.PadT + 8;
+        double lh = 14 + seriesCount * 18;
+        sb.Append($"<rect x='{F(lx)}' y='{F(ly)}' width='168' height='{F(lh)}' fill='white' stroke='{ColorGrid}' stroke-width='1'/>");
+        for (int j = 0; j < seriesCount; j++)
+        {
+            double ey = ly + 16 + j * 18;
+            sb.Append($"<rect x='{F(lx + 12)}' y='{F(ey - 9)}' width='12' height='8' fill='{SeriesColor(j)}'/>");
+            sb.Append($"<text x='{F(lx + 30)}' y='{F(ey)}' fill='{ColorText}'>{Esc(seriesLabels[j])}</text>");
+        }
+
         sb.Append(CloseSvg());
         return sb.ToString();
     }

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
@@ -1118,57 +1118,42 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<h4>Concision du modele</h4><div id=\"pltConcision\"></div><h4>Evaluation multi-criteres</h4><div id=\"pltScore\"></div><script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script><script>Plotly.newPlot('pltConcision',[{\"name\":\"Python pur\",\"x\":[\"N-Reines\",\"Emploi du temps\",\"Sudoku\"],\"y\":[20,60,50],\"type\":\"bar\"},{\"name\":\"CP-SAT\",\"x\":[\"N-Reines\",\"Emploi du temps\",\"Sudoku\"],\"y\":[12,45,35],\"type\":\"bar\"},{\"name\":\"MiniZinc\",\"x\":[\"N-Reines\",\"Emploi du temps\",\"Sudoku\"],\"y\":[5,25,20],\"type\":\"bar\"}],{\"title\":{\"text\":\"Concision du modele (lignes de code estimees)\"},\"barmode\":\"group\",\"yaxis\":{\"title\":\"Lignes de code\"}});Plotly.newPlot('pltScore',[{\"name\":\"Python pur\",\"x\":[\"Concision\",\"Lisibilite\",\"Portabilite\",\"Integr. .NET\",\"Performance\"],\"y\":[2,2,1,5,2],\"type\":\"bar\"},{\"name\":\"CP-SAT\",\"x\":[\"Concision\",\"Lisibilite\",\"Portabilite\",\"Integr. .NET\",\"Performance\"],\"y\":[3,3,2,5,5],\"type\":\"bar\"},{\"name\":\"MiniZinc\",\"x\":[\"Concision\",\"Lisibilite\",\"Portabilite\",\"Integr. .NET\",\"Performance\"],\"y\":[5,5,5,3,4],\"type\":\"bar\"}],{\"title\":{\"text\":\"Evaluation multi-criteres (score 1-5)\"},\"barmode\":\"group\",\"yaxis\":{\"title\":\"Score\",\"range\":[0,5]}});</script>"
-      ]
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='720' height='340' viewBox='0 0 720 340' font-family='sans-serif' font-size='12'><rect width='720' height='340' fill='white'/><text x='360' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Concision du modele (lignes de code estimees)</text><line x1='52' y1='298' x2='704' y2='298' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='302' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='232' x2='704' y2='232' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='236' text-anchor='end' fill='#333333'>16.2</text><line x1='52' y1='166' x2='704' y2='166' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='170' text-anchor='end' fill='#333333'>32.4</text><line x1='52' y1='100' x2='704' y2='100' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='104' text-anchor='end' fill='#333333'>48.6</text><line x1='52' y1='34' x2='704' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>64.8</text><line x1='52' y1='34' x2='52' y2='298' stroke='#888888' stroke-width='1'/><line x1='52' y1='298' x2='704' y2='298' stroke='#888888' stroke-width='1'/><rect x='73.733' y='216.519' width='57.956' height='81.481' fill='#4C72B0'/><rect x='131.689' y='249.111' width='57.956' height='48.889' fill='#55A868'/><rect x='189.644' y='277.63' width='57.956' height='20.37' fill='#DD8452'/><text x='160.667' y='314' text-anchor='middle' fill='#333333'>N-Reines</text><rect x='291.067' y='53.556' width='57.956' height='244.444' fill='#4C72B0'/><rect x='349.022' y='114.667' width='57.956' height='183.333' fill='#55A868'/><rect x='406.978' y='196.148' width='57.956' height='101.852' fill='#DD8452'/><text x='378' y='314' text-anchor='middle' fill='#333333'>Emploi du temps</text><rect x='508.4' y='94.296' width='57.956' height='203.704' fill='#4C72B0'/><rect x='566.356' y='155.407' width='57.956' height='142.593' fill='#55A868'/><rect x='624.311' y='216.519' width='57.956' height='81.481' fill='#DD8452'/><text x='595.333' y='314' text-anchor='middle' fill='#333333'>Sudoku</text><rect x='532' y='42' width='168' height='68' fill='white' stroke='#E5E5E5' stroke-width='1'/><rect x='544' y='49' width='12' height='8' fill='#4C72B0'/><text x='562' y='58' fill='#333333'>Python pur</text><rect x='544' y='67' width='12' height='8' fill='#55A868'/><text x='562' y='76' fill='#333333'>CP-SAT</text><rect x='544' y='85' width='12' height='8' fill='#DD8452'/><text x='562' y='94' fill='#333333'>MiniZinc</text></svg>"
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='720' height='340' viewBox='0 0 720 340' font-family='sans-serif' font-size='12'><rect width='720' height='340' fill='white'/><text x='360' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>Evaluation multi-criteres (score 1-5)</text><line x1='52' y1='298' x2='704' y2='298' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='302' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='232' x2='704' y2='232' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='236' text-anchor='end' fill='#333333'>1.35</text><line x1='52' y1='166' x2='704' y2='166' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='170' text-anchor='end' fill='#333333'>2.7</text><line x1='52' y1='100' x2='704' y2='100' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='104' text-anchor='end' fill='#333333'>4.05</text><line x1='52' y1='34' x2='704' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>5.4</text><line x1='52' y1='34' x2='52' y2='298' stroke='#888888' stroke-width='1'/><line x1='52' y1='298' x2='704' y2='298' stroke='#888888' stroke-width='1'/><rect x='65.04' y='200.222' width='34.773' height='97.778' fill='#4C72B0'/><rect x='99.813' y='151.333' width='34.773' height='146.667' fill='#55A868'/><rect x='134.587' y='53.556' width='34.773' height='244.444' fill='#DD8452'/><text x='117.2' y='314' text-anchor='middle' fill='#333333'>Concision</text><rect x='195.44' y='200.222' width='34.773' height='97.778' fill='#4C72B0'/><rect x='230.213' y='151.333' width='34.773' height='146.667' fill='#55A868'/><rect x='264.987' y='53.556' width='34.773' height='244.444' fill='#DD8452'/><text x='247.6' y='314' text-anchor='middle' fill='#333333'>Lisibilite</text><rect x='325.84' y='249.111' width='34.773' height='48.889' fill='#4C72B0'/><rect x='360.613' y='200.222' width='34.773' height='97.778' fill='#55A868'/><rect x='395.387' y='53.556' width='34.773' height='244.444' fill='#DD8452'/><text x='378' y='314' text-anchor='middle' fill='#333333'>Portabilite</text><rect x='456.24' y='53.556' width='34.773' height='244.444' fill='#4C72B0'/><rect x='491.013' y='53.556' width='34.773' height='244.444' fill='#55A868'/><rect x='525.787' y='151.333' width='34.773' height='146.667' fill='#DD8452'/><text x='508.4' y='314' text-anchor='middle' fill='#333333'>Integr. .NET</text><rect x='586.64' y='200.222' width='34.773' height='97.778' fill='#4C72B0'/><rect x='621.413' y='53.556' width='34.773' height='244.444' fill='#55A868'/><rect x='656.187' y='102.444' width='34.773' height='195.556' fill='#DD8452'/><text x='638.8' y='314' text-anchor='middle' fill='#333333'>Performance</text><rect x='532' y='42' width='168' height='68' fill='white' stroke='#E5E5E5' stroke-width='1'/><rect x='544' y='49' width='12' height='8' fill='#4C72B0'/><text x='562' y='58' fill='#333333'>Python pur</text><rect x='544' y='67' width='12' height='8' fill='#55A868'/><text x='562' y='76' fill='#333333'>CP-SAT</text><rect x='544' y='85' width='12' height='8' fill='#DD8452'/><text x='562' y='94' fill='#333333'>MiniZinc</text></svg>"
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "// Visualisation Plotly (remplace l'ASCII art -- EPIC #3801 Prong A) :\n",
-    "// concision du modele (lignes de code) + evaluation multi-criteres (score 1-5).\n",
-    "// Technique C548-L2 : Plotly.js via Formatter.Register (kernel builtin, aucun #r nuget).\n",
-    "using Microsoft.DotNet.Interactive.Formatting;\n",
-    "using System.IO;\n",
-    "using System.Text.Json;\n",
+    "#load \"../../../Probas/Infer/SvgChartHelper.cs\"\n",
+    "// Visualisation SVG statique (remplace Plotly-CDN qui rend BLANC en consultation statique --\n",
+    "// GitHub sandbox les <script>; EPIC #3801 Prong A + EPIC #6927). Technique #6942 : <svg> inline\n",
+    "// via SvgChartHelper (zero-dependance, rend sur GitHub/nbviewer/offline, aucun CDN ni <script>).\n",
     "\n",
-    "record PlotlyHtml(string Markup);\n",
-    "Formatter.Register(typeof(PlotlyHtml),\n",
-    "    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), \"text/html\");\n",
-    "\n",
-    "static string Trace(string name, string[] x, double[] y) =>\n",
-    "    JsonSerializer.Serialize(new Dictionary<string, object> { [\"name\"]=name, [\"x\"]=x, [\"y\"]=y, [\"type\"]=\"bar\" });\n",
-    "\n",
-    "// --- (1) Concision du modele : lignes de code estimees (grouped bars) ---\n",
+    "// (1) Concision du modele : lignes de code estimees, 3 solveurs groupes par famille de probleme.\n",
     "var problems = new[] { \"N-Reines\", \"Emploi du temps\", \"Sudoku\" };\n",
-    "string tConcPy = Trace(\"Python pur\", problems, new double[]{20,60,50});\n",
-    "string tConcCp = Trace(\"CP-SAT\", problems, new double[]{12,45,35});\n",
-    "string tConcMz = Trace(\"MiniZinc\", problems, new double[]{5,25,20});\n",
-    "string layoutConc = JsonSerializer.Serialize(new Dictionary<string,object>{\n",
-    "    [\"title\"]=new Dictionary<string,string>{[\"text\"]=\"Concision du modele (lignes de code estimees)\"},\n",
-    "    [\"barmode\"]=\"group\", [\"yaxis\"]=new Dictionary<string,string>{[\"title\"]=\"Lignes de code\"}});\n",
+    "display(SvgChartHelper.GroupedBar(\n",
+    "    \"Concision du modele (lignes de code estimees)\",\n",
+    "    problems,\n",
+    "    new double[][] { new double[]{20,60,50}, new double[]{12,45,35}, new double[]{5,25,20} },\n",
+    "    new[] { \"Python pur\", \"CP-SAT\", \"MiniZinc\" },\n",
+    "    width: 720, height: 340));\n",
     "\n",
-    "// --- (2) Evaluation multi-criteres (score 1-5, grouped bars) ---\n",
+    "// (2) Evaluation multi-criteres (score 1-5) : 3 solveurs groupes par critere.\n",
     "var criteria = new[] { \"Concision\", \"Lisibilite\", \"Portabilite\", \"Integr. .NET\", \"Performance\" };\n",
-    "string tScPy = Trace(\"Python pur\", criteria, new double[]{2,2,1,5,2});\n",
-    "string tScCp = Trace(\"CP-SAT\", criteria, new double[]{3,3,2,5,5});\n",
-    "string tScMz = Trace(\"MiniZinc\", criteria, new double[]{5,5,5,3,4});\n",
-    "string layoutScore = JsonSerializer.Serialize(new Dictionary<string,object>{\n",
-    "    [\"title\"]=new Dictionary<string,string>{[\"text\"]=\"Evaluation multi-criteres (score 1-5)\"},\n",
-    "    [\"barmode\"]=\"group\", [\"yaxis\"]=new Dictionary<string,object>{[\"title\"]=\"Score\",[\"range\"]=new double[]{0,5}}});\n",
-    "\n",
-    "string markup = \"<h4>Concision du modele</h4>\" +\n",
-    "    \"<div id=\\\"pltConcision\\\"></div>\" +\n",
-    "    \"<h4>Evaluation multi-criteres</h4>\" +\n",
-    "    \"<div id=\\\"pltScore\\\"></div>\" +\n",
-    "    \"<script src=\\\"https://cdn.plot.ly/plotly-2.35.2.min.js\\\"></script>\" +\n",
-    "    $\"<script>Plotly.newPlot('pltConcision',[{tConcPy},{tConcCp},{tConcMz}],{layoutConc});\" +\n",
-    "    $\"Plotly.newPlot('pltScore',[{tScPy},{tScCp},{tScMz}],{layoutScore});</script>\";\n",
-    "\n",
-    "new PlotlyHtml(markup)"
+    "display(SvgChartHelper.GroupedBar(\n",
+    "    \"Evaluation multi-criteres (score 1-5)\",\n",
+    "    criteria,\n",
+    "    new double[][] { new double[]{2,2,1,5,2}, new double[]{3,3,2,5,5}, new double[]{5,5,5,3,4} },\n",
+    "    new[] { \"Python pur\", \"CP-SAT\", \"MiniZinc\" },\n",
+    "    width: 720, height: 340))"
    ]
   },
   {


### PR DESCRIPTION
## What

Adds the **`SvgChartHelper.GroupedBar()`** primitive (+75 lines, purely additive, non-breaking) and demonstrates it by converting **`Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb` cell[18]** — the notebook's only Plotly-CDN cell — from a blank-in-static Plotly chart to **2 inline static SVGs** (#6927, #3801 Prong-A).

App-8 compares CSP solvers (Python pur / CP-SAT / MiniZinc) across two grouped-bar views:
- **Concision du modèle** — estimated lines of code, 3 solvers × 3 problem families (N-Reines / Emploi du temps / Sudoku)
- **Évaluation multi-critères** — score 1-5, 3 solvers × 5 criteria (Concision / Lisibilité / Portabilité / Intégr .NET / Performance)

`GroupedBar` was the primitive explicitly flagged as **missing** (po-2024 c.591 proposal, routed to po-2025) and blocking App-8. One PR, same pattern as **#6982** (Heatmap primitive + GT-8c demo).

## GroupedBar API

```csharp
SvgChartHelper.GroupedBar(string title, string[] categories,
    double[][] seriesValues, string[] seriesLabels,
    int width = 640, int height = 360, string[] colors = null)
```

- One sub-bar per series, side-by-side within each category group (80% of the category cell).
- Y-bounds computed via `NiceBounds` over the union of all series; geometry mirrors `BuildBar` exactly (`y = v>=0 ? Y(v) : Y(0)`, positive bar grows up from 0, negative down).
- Legend (top-right): one rect swatch (12×8) + label per series. Reuses `NiceBounds` / `PlotLayout` / `CategoryLabel` / `F()` (InvariantCulture) / `Esc()`.

## Compile proof (deterministic console, canon c.555)

`.NET Interactive` kernel exec is the ground truth for notebooks, but for the primitive itself I used the deterministic console fallback (MCP kernel was contaminated by a kaleido zombie in earlier cycles):

`dotnet build+run` net9.0 + `Microsoft.DotNet.Interactive` 1.0.0-beta.26120.1, linking `SvgChartHelper.cs` directly → **0 errors / 0 warnings**. Run output: valid `<svg>…</svg>` (len 2503), 14 `<rect>` (9 bars + 3 legend swatches + 1 legend box + 1 background), 3 swatches = seriesCount, **0 decimal-comma defects**, no `cdn.plot.ly`, no `probeAddresses`.

## Real .NET kernel exec (App-8 cell[18], H.4)

`ExecutePreprocessor` `.net-csharp` kernel, CWD = notebook dir (so the cross-family relative `#load "../../../Probas/Infer/SvgChartHelper.cs"` resolves per canon c.563), 24-cell full exec, Google.OrTools (cell[1]) restored ~cache-hit. cell[18] `exec_count=11`, **2 SVG outputs**, 0 errors end-to-end.

## Gates verified firsthand

| Gate | Result |
|------|--------|
| `detect_svg_decimal_commas.py` (#6959, merge-gate) | **0 defects** rc=0 |
| `detect_svg_empty_display.py` (#6971, no-vision blank-gate) | **0 defects** rc=0 |
| `check_plotly_static_risk.py` (#6931) | App-8 **no longer risky** (repo 11→8) |
| `strip_probe_banner.py --scan` | **0 banner lines** (stripped post-re-exec) |
| `cdn.plotly` in output | **False** |
| `probeAddresses` banner | absent |
| C.3 scope | source changed `[18]`, outputs/ec changed `[18]` — **only cell[18]** |
| Catalog byte-identity (R1) | 0 diff (`git diff --stat origin/main -- COURSE_CATALOG.*` empty) |
| Helper diff | **+75 / −0** (purely additive, non-breaking) |

## Verdict: **SOTA-OK** (#3801 Prong-A)

## Notes

- **Visual QA**: GLM lane is not vision-capable; routes to ai-01 / MiniMax (CoursIA-2) for visual confirmation. Deterministic gates (#6959 + #6971) green.
- **Cluster queue**: this PR queues behind **#6997** (po-2023, PRIORITY MERGE) — the `probeAddresses banner guard` check is RED on main since 06:46Z (my #6977 missed `strip_probe_banner.py --apply`). #6997 unblocks the whole queue; this PR merges after.
- **See #6927** (partial — fleet-wide Plotly-CDN→SVG; App-8 done. Residual helper-gated: Search-11b needs log-Y Overlay, GT-8c cell[8] needs per-color Bar).

🤖 po-2025 (GLM no-vision lane)
