### PR TITLE
docs(gametheory,#3978): document minimax_lean EN siblings (Pattern A i18n) in series README

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/minimax_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/minimax_lean/README.md
@@ -47,6 +47,14 @@ Ce premier livrable établit le **cœur formel** documenté de la preuve — la
 - **Build** : `lake build Minimax` (dépend de Mathlib4)
 - **CI** : `.github/workflows/lean-minimax.yml` (`sorry-filter-mode: standalone-tactic`,
   baseline `0`)
+- **Couverture i18n (EPIC #4980)** : **bilingue complet — Pattern A**. Les 3 modules
+  `Minimax/ZeroSum.lean`, `Minimax/Concavity.lean`, `Minimax/SionApplication.lean`
+  ont chacun un miroir `_en.lean` (`ZeroSum_en`, `Concavity_en`, `SionApplication_en`),
+  plus les deux agrégateurs `Minimax.lean` (FR canonique) et `Minimax_en.lean` (miroir
+  EN, namespace `MinimaxLean_en` anti-collision). Convention ratifiée par ai-01
+  (2026-07-04, #4980) : contenu non-docstring byte-identique entre siblings FR↔EN
+  (dérive détectable par CI), docstrings/commentaires traduits manuellement ; les deux
+  compilent dans le même lake. Posés par PR #5363.
 
 ## Stratégie de formalisation
 
@@ -90,6 +98,9 @@ flowchart TD
 
 ## Ce qui est formalisé (`Minimax/ZeroSum.lean`, 0 sorry)
 
+> **Miroir EN** : `Minimax/ZeroSum_en.lean` (Pattern A #4980, contenu non-docstring
+> byte-identique, docstrings traduits).
+
 - **Matrice de gains** `PayoffMatrix m n = Matrix m n ℝ` : `A i j` = gain du
   joueur-ligne quand `i` joue la ligne `i` et `j` la colonne `j` (somme nulle : le
   joueur-colonne reçoit `-A i j`).
@@ -108,6 +119,9 @@ flowchart TD
   `fun_prop`).
 
 ## Ce qui est formalisé (`Minimax/Concavity.lean`, 0 sorry) — glue Sion (itérations 1 & 2)
+
+> **Miroir EN** : `Minimax/Concavity_en.lean` (Pattern A #4980, byte-identique hors
+> docstrings).
 
 Les **4 hyps analytiques** de `Sion.exists_isSaddlePointOn'`, dérivées de la
 bilinéarité ci-dessus :
@@ -142,6 +156,9 @@ toutes prouvées 0 sorry.**
   multiplie à droite ⟹ `mul_add`.
 
 ## Ce qui est formalisé (`Minimax/SionApplication.lean`, 0 sorry) — itération 3 du glue Sion
+
+> **Miroir EN** : `Minimax/SionApplication_en.lean` (Pattern A #4980, byte-identique hors
+> docstrings).
 
 Le **théorème de von Neumann (forme point-selle)** — le milestone final de #4054,
 démontré en une application de `Sion.exists_isSaddlePointOn` :


### PR DESCRIPTION
## Summary — document minimax_lean EN siblings (Pattern A i18n #4980) in series README

The `minimax_lean` series README documented only the 3 FR-canonical modules (`Minimax/ZeroSum.lean`, `Concavity.lean`, `SionApplication.lean`) plus the FR aggregator. **PR #5363 (2026-07-04) added the full bilingual layer per EPIC #4980** (Option A sibling-pair convention): 3 `_en.lean` mirrors + `Minimax_en.lean` aggregator (namespace `MinimaxLean_en`), but the series README never reflected this coverage — a **2-week §E drift**.

## §E whole-file audit (firsthand disk-truth)

| Check | Result |
|-------|--------|
| `.lean` files on disk | **6** (3 FR + 3 `_en` siblings) + 2 aggregators (`Minimax.lean`, `Minimax_en.lean`) |
| README mentioned (pre-fix) | 3 FR + external `Nash.lean` (lean_game_defs) + Mathlib `Sion.lean` = **0 `_en`** |
| grep `_en` in README (pre-fix) | **0 hits** (drift confirmed) |
| `sorry` count (firsthand, all 6 .lean) | **0** (consistent with README "0-sorry" claim — no regression) |
| README last commit | 2026-06-26 (3 weeks stale vs #5363 2026-07-04) |
| Collision (`gh pr list --search minimax_lean README`) | **0 OPEN** (5 historical MERGED: #5233/#5008/#5414/#6101/#5367) |

## Change (atomic doc-only, +17/0, 1 file)

1. **Status section** — added an "i18n coverage (EPIC #4980)" bullet describing the complete bilingual layer: Pattern A (FR canonical `Foo.lean` + EN mirror `Foo_en.lean`), non-docstring content byte-identical FR↔EN (CI drift-detectable), docstrings/comments manually translated, namespace `MinimaxLean_en` anti-collision, both compile in the same lake, posés par PR #5363.
2. **3 formalisation section headers** (`ZeroSum` / `Concavity` / `SionApplication`) — added an EN-mirror blockquote pointing to the `_en.lean` sibling.

Convention matched to existing siblings: `grothendieck_lean/README.md` (i18n bullet + `_en` column) and `game_theory_lean/README.md` (sibling mentions + Lake `lean_lib` globs).

## Gates

- **CATALOG-STATUS**: untouched (no marker in this file).
- **Catalogue**: byte-identical (no `COURSE_CATALOG.generated.*` touched).
- **FR-first** (readme-french-first rule): preserved — README already FR, no EN-flip, no `.en.md` needed.
- **Anti-régression**: 0 sorry claims unchanged, 0 Lean source touched (doc-only).
- **Atomic** (catalog-pr-hygiene R3): 1 subject (document the #5363 bilingual layer), 1 file.

Grain steered by ai-01 (DM msg-20260717T100105, "Lean READMEs plays to your Lean familiarity", text-only GLM lane). `See #3973` (parent EPIC ascendant README resync — partial contribution, issue stays open).

See #3973, See #4980

🤖 po-2023 · cron-driven
